### PR TITLE
explicit access to filesystem, network, subprocesses

### DIFF
--- a/packages/agoric-cli/bin/agoric
+++ b/packages/agoric-cli/bin/agoric
@@ -10,11 +10,12 @@ const progname = path.basename(process.argv[1]);
 const error = (...args) => {
   console.error(`${progname}: ${chalk.red('ERROR')}:`, ...args);
 };
+const stat = require('fs').promises.stat;
 
 process.on('SIGINT', () => process.exit(-1));
 
 const rawArgs = process.argv.splice(2);
-main(progname, rawArgs, { console, error }).then(
+main(progname, rawArgs, { console, error, stat }).then(
   res => res === undefined || process.exit(res),
   rej => {
     error(rej);

--- a/packages/agoric-cli/bin/agoric
+++ b/packages/agoric-cli/bin/agoric
@@ -5,6 +5,7 @@ const path = esmRequire('path');
 const chalk = esmRequire('chalk').default;
 const WebSocket = esmRequire('ws');
 const { spawn } = esmRequire('child_process');
+const fs = esmRequire('fs').promises;
 
 const main = esmRequire('../lib/main.js').default;
 const progname = path.basename(process.argv[1]);
@@ -12,7 +13,6 @@ const progname = path.basename(process.argv[1]);
 const error = (...args) => {
   console.error(`${progname}: ${chalk.red('ERROR')}:`, ...args);
 };
-const fs = require('fs').promises;
 const makeWebSocket = (...args) => new WebSocket(...args);
 
 process.on('SIGINT', () => process.exit(-1));

--- a/packages/agoric-cli/bin/agoric
+++ b/packages/agoric-cli/bin/agoric
@@ -12,7 +12,7 @@ const progname = path.basename(process.argv[1]);
 const error = (...args) => {
   console.error(`${progname}: ${chalk.red('ERROR')}:`, ...args);
 };
-const stat = require('fs').promises.stat;
+const fs = require('fs').promises;
 const makeWebSocket = (...args) => new WebSocket(...args);
 
 process.on('SIGINT', () => process.exit(-1));

--- a/packages/agoric-cli/bin/agoric
+++ b/packages/agoric-cli/bin/agoric
@@ -4,6 +4,7 @@ esmRequire = require('esm')(module);
 const path = esmRequire('path');
 const chalk = esmRequire('chalk').default;
 const WebSocket = esmRequire('ws');
+const { spawn } = esmRequire('child_process');
 
 const main = esmRequire('../lib/main.js').default;
 const progname = path.basename(process.argv[1]);
@@ -17,7 +18,7 @@ const makeWebSocket = (...args) => new WebSocket(...args);
 process.on('SIGINT', () => process.exit(-1));
 
 const rawArgs = process.argv.splice(2);
-main(progname, rawArgs, { console, error, stat, makeWebSocket }).then(
+main(progname, rawArgs, { console, error, makeWebSocket, fs, spawn }).then(
   res => res === undefined || process.exit(res),
   rej => {
     error(rej);

--- a/packages/agoric-cli/bin/agoric
+++ b/packages/agoric-cli/bin/agoric
@@ -3,6 +3,7 @@
 esmRequire = require('esm')(module);
 const path = esmRequire('path');
 const chalk = esmRequire('chalk').default;
+const WebSocket = esmRequire('ws');
 
 const main = esmRequire('../lib/main.js').default;
 const progname = path.basename(process.argv[1]);
@@ -11,11 +12,12 @@ const error = (...args) => {
   console.error(`${progname}: ${chalk.red('ERROR')}:`, ...args);
 };
 const stat = require('fs').promises.stat;
+const makeWebSocket = (...args) => new WebSocket(...args);
 
 process.on('SIGINT', () => process.exit(-1));
 
 const rawArgs = process.argv.splice(2);
-main(progname, rawArgs, { console, error, stat }).then(
+main(progname, rawArgs, { console, error, stat, makeWebSocket }).then(
   res => res === undefined || process.exit(res),
   rej => {
     error(rej);

--- a/packages/agoric-cli/lib/deploy.js
+++ b/packages/agoric-cli/lib/deploy.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-await-in-loop */
 import parseArgs from 'minimist';
-import WebSocket from 'ws';
 import { evaluateProgram } from '@agoric/evaluate';
 import { E, makeCapTP } from '@agoric/captp';
 
@@ -26,7 +25,7 @@ const sendJSON = (ws, obj) => {
 };
 
 export default async function deployMain(progname, rawArgs, priv) {
-  const { console, error } = priv;
+  const { console, error, makeWebSocket } = priv;
   const { _: args, hostport } = parseArgs(rawArgs, {
     default: {
       hostport: '127.0.0.1:8000',
@@ -39,7 +38,7 @@ export default async function deployMain(progname, rawArgs, priv) {
   }
 
   const wsurl = `ws://${hostport}/captp`;
-  const ws = new WebSocket(wsurl, { origin: 'http://127.0.0.1' });
+  const ws = makeWebSocket(wsurl, { origin: 'http://127.0.0.1' });
 
   const exit = makePromise();
   ws.on('open', async () => {

--- a/packages/agoric-cli/lib/init.js
+++ b/packages/agoric-cli/lib/init.js
@@ -1,9 +1,8 @@
 import parseArgs from 'minimist';
-import fs from 'fs';
 import chalk from 'chalk';
 
 export default async function initMain(progname, rawArgs, priv) {
-  const { console, error } = priv;
+  const { console, error, fs } = priv;
   const {
     _: args,
     force,
@@ -22,7 +21,7 @@ export default async function initMain(progname, rawArgs, priv) {
     readdir,
     readFile,
     writeFile,
-  } = fs.promises;
+  } = fs;
 
   console.log(`initializing ${DIR}`);
   try {
@@ -60,7 +59,7 @@ export default async function initMain(progname, rawArgs, priv) {
           console.log(`mkdir ${DIR}${stem}`);
           await mkdir(`${DIR}${stem}`);
         }
-        await recursiveTemplate(templateDir, `${stem}`)
+        await recursiveTemplate(templateDir, `${stem}`);
       } else {
         console.log(`write ${DIR}${stem}`);
         await writeTemplate(stem);

--- a/packages/agoric-cli/lib/install.js
+++ b/packages/agoric-cli/lib/install.js
@@ -1,9 +1,8 @@
 import parseArgs from 'minimist';
 import chalk from 'chalk';
-import { spawn } from 'child_process';
 
 export default async function installMain(progname, rawArgs, priv) {
-  const { console, error } = priv;
+  const { console, error, spawn } = priv;
   const {
     _: args,
   } = parseArgs(rawArgs);

--- a/packages/agoric-cli/lib/install.js
+++ b/packages/agoric-cli/lib/install.js
@@ -1,7 +1,6 @@
 import parseArgs from 'minimist';
 import chalk from 'chalk';
 import { spawn } from 'child_process';
-import { promises as fs } from 'fs';
 
 export default async function installMain(progname, rawArgs, priv) {
   const { console, error } = priv;

--- a/packages/agoric-cli/lib/main.js
+++ b/packages/agoric-cli/lib/main.js
@@ -5,7 +5,7 @@ const VERSION = 'Agoric <some version>';
 const STAMP = '.agservers';
 
 const main = async (progname, rawArgs, privs) => {
-  const { console, error, stat } = privs;
+  const { console, error, fs } = privs;
   const { _: args, ...opts } = parseArgs(rawArgs, {
     boolean: ['version', 'help'],
     stopEarly: true,
@@ -13,7 +13,7 @@ const main = async (progname, rawArgs, privs) => {
 
   const isNotBasedir = async () => {
     try {
-      await stat('.agservers');
+      await fs.stat('.agservers');
       return false;
     } catch (e) {
       error(`current directory wasn't created by '${progname} init'`);

--- a/packages/agoric-cli/lib/main.js
+++ b/packages/agoric-cli/lib/main.js
@@ -1,12 +1,11 @@
 import chalk from 'chalk';
 import parseArgs from 'minimist';
-import fs from 'fs';
 
 const VERSION = 'Agoric <some version>';
 const STAMP = '.agservers';
 
 const main = async (progname, rawArgs, privs) => {
-  const { console, error } = privs;
+  const { console, error, stat } = privs;
   const { _: args, ...opts } = parseArgs(rawArgs, {
     boolean: ['version', 'help'],
     stopEarly: true,
@@ -14,7 +13,7 @@ const main = async (progname, rawArgs, privs) => {
 
   const isNotBasedir = async () => {
     try {
-      await fs.promises.stat('.agservers');
+      await stat('.agservers');
       return false;
     } catch (e) {
       error(`current directory wasn't created by '${progname} init'`);

--- a/packages/agoric-cli/lib/start.js
+++ b/packages/agoric-cli/lib/start.js
@@ -1,10 +1,8 @@
 import parseArgs from 'minimist';
 import chalk from 'chalk';
-import { spawn } from 'child_process';
-import { promises as fs } from 'fs';
 
 export default async function startMain(progname, rawArgs, priv) {
-  const { console, error } = priv;
+  const { console, error, fs, spawn } = priv;
   const {
     reset,
     _: args,


### PR DESCRIPTION
the `privs` argument was already a start at explicit access to
powerful objects; let's continue to apply ocap discipline.

I didn't address `__dirname`.

I suppose `import()` is powerful, but I'm not sure. The use of `import()` here could easily be reduced to static `import` in any case.

POLA suggests limiting use of `makeWebSocket` to urls provided as cli args, but I didn't do that either.

`npm test` passes but I haven't otherwise tested the code. Note that unit tests can now cover more functionality by passing in mock `privs`.

