### PR TITLE
Link to Getting Started Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 This repository contains most of the packages that make up the Agoric
 platform. If you want to build on top of this platform, you don't need this
-repository: instead you should `npm install -g agoric` and run `agoric init`,
-following the instructions (TODO: write those instructions).
+repository: instead you should [follow our instructions for getting started](https://agoric.com/documentation/getting-started/) with the Agoric SDK.
 
 But if you are improving the platform itself, this is the repository to use.
 


### PR DESCRIPTION
Let me know if I'm missing something, but it seems like we can link to our "Getting Started" documentation at the top of this README.md. That way we don't have to rewrite the instructions. If we need to make any changes, I think we should make changes to that documentation rather than reproducing it here.