### PR TITLE
[ERTP] Delete payment in burnAll and burnExactly

### DIFF
--- a/packages/ERTP/core/mint.js
+++ b/packages/ERTP/core/mint.js
@@ -220,13 +220,20 @@ allegedName must be truthy: ${allegedName}`;
     },
 
     burnExactly(units, srcPaymentP) {
-      const sinkPurse = coreAssay.makeEmptyPurse('sink purse');
-      return sinkPurse.depositExactly(units, srcPaymentP);
+      return Promise.resolve(srcPaymentP).then(srcPayment => {
+        insistUnitsEqualsPaymentBalance(units, srcPayment);
+        const paymentUnits = paymentKeeper.getUnits(srcPayment);
+        paymentKeeper.remove(srcPayment);
+        return paymentUnits;
+      });
     },
 
     burnAll(srcPaymentP) {
-      const sinkPurse = coreAssay.makeEmptyPurse('sink purse');
-      return sinkPurse.depositAll(srcPaymentP);
+      return Promise.resolve(srcPaymentP).then(srcPayment => {
+        const paymentUnits = paymentKeeper.getUnits(srcPayment);
+        paymentKeeper.remove(srcPayment);
+        return paymentUnits;
+      });
     },
   });
 


### PR DESCRIPTION
This PR uses the `paymentKeeper` to simply remove the payment from the WeakMap of payments to balances, rather than create an empty purse, deposit the payment, and drop the purse. 

Removing the payment would happen anyways when the payment is deposited into the purse, but this is more direct.

Closes #103 