### PR TITLE
Remove returns of value from insistKind functions

### DIFF
--- a/packages/ERTP/core/config/extentOps/listExtentOps.js
+++ b/packages/ERTP/core/config/extentOps/listExtentOps.js
@@ -25,7 +25,6 @@ const makeListExtentOps = (
       for (const element of list) {
         insistElementKind(element);
       }
-      return harden(list);
     },
     empty: _ => harden([]),
     isEmpty: list => {

--- a/packages/ERTP/core/config/extentOps/uniExtentOps.js
+++ b/packages/ERTP/core/config/extentOps/uniExtentOps.js
@@ -23,10 +23,10 @@ const makeUniExtentOps = (customInsistKind = () => {}) => {
   const uniExtentOps = harden({
     insistKind: extent => {
       if (extent === null) {
-        return null;
+        return;
       }
       mustBeComparable(extent);
-      return customInsistKind(extent);
+      customInsistKind(extent);
     },
     empty: _ => null,
     isEmpty: uni => uni === null,


### PR DESCRIPTION
We decided that functions that have `insist` in the name should not return a value and should be used only to throw if invariants aren't met. Therefore, the `insistKind` function in various `extentOps` should not return a value.

Closes #89 