### PR TITLE
[ERTP] add regexp expected error message to any t.throws

### DIFF
--- a/packages/ERTP/test/unitTests/core/test-mint.js
+++ b/packages/ERTP/test/unitTests/core/test-mint.js
@@ -10,7 +10,10 @@ test('split bad units', t => {
     const payment = purse.withdrawAll();
 
     const badUnitsArray = Array(2).fill(assay.makeUnits(10));
-    t.throws(_ => assay.split(payment, badUnitsArray));
+    t.throws(
+      _ => assay.split(payment, badUnitsArray),
+      /Error: the units of the proposed new payments do not equal the units of the source payment/,
+    );
   } catch (e) {
     t.assert(false, e);
   } finally {
@@ -31,7 +34,8 @@ test('split good units', t => {
     for (const payment of splitPayments) {
       t.deepEqual(payment.getBalance(), assay.makeUnits(10));
     }
-    t.throws(() => oldPayment.getBalance());
+    // TODO: Improve error message for a deleted payment
+    t.throws(() => oldPayment.getBalance(), /Error: key not found/);
   } catch (e) {
     t.assert(false, e);
   } finally {
@@ -52,7 +56,7 @@ test('combine good payments', t => {
     const combinedPayment = assay.combine(payments);
     t.deepEqual(combinedPayment.getBalance(), assay.makeUnits(100));
     for (const payment of payments) {
-      t.throws(() => payment.getBalance());
+      t.throws(() => payment.getBalance(), /Error: key not found/);
     }
   } catch (e) {
     t.assert(false, e);
@@ -76,7 +80,7 @@ test('combine bad payments', t => {
     const otherPayment = otherPurse.withdrawAll();
     payments.push(otherPayment);
 
-    t.throws(() => assay.combine(payments));
+    t.throws(() => assay.combine(payments), /Error: key not found/);
   } catch (e) {
     t.assert(false, e);
   } finally {
@@ -116,7 +120,7 @@ test('depositExactly goodUnits', async t => {
     const payment = await purse.withdraw(7);
     await targetPurse.depositExactly(7, payment);
     t.deepEqual(targetPurse.getBalance(), assay.makeUnits(7));
-    t.throws(() => payment.getBalance());
+    t.throws(() => payment.getBalance(), /Error: key not found/);
   } catch (e) {
     t.assert(false, e);
   } finally {
@@ -133,7 +137,7 @@ test('depositAll goodUnits', async t => {
     const payment = await purse.withdraw(7);
     await targetPurse.depositAll(payment);
     t.deepEqual(targetPurse.getBalance(), assay.makeUnits(7));
-    t.throws(() => payment.getBalance());
+    t.throws(() => payment.getBalance(), /Error: key not found/);
   } catch (e) {
     t.assert(false, e);
   } finally {
@@ -170,7 +174,7 @@ test('burnExactly goodUnits', async t => {
     const purse = mint.mint(1000);
     const payment = await purse.withdraw(7);
     await assay.burnExactly(7, payment);
-    t.throws(() => payment.getBalance());
+    t.throws(() => payment.getBalance(), /Error: key not found/);
   } catch (e) {
     t.assert(false, e);
   } finally {
@@ -185,7 +189,7 @@ test('burnAll goodUnits', async t => {
     const purse = mint.mint(1000);
     const payment = await purse.withdraw(7);
     await assay.burnAll(payment);
-    t.throws(() => payment.getBalance());
+    t.throws(() => payment.getBalance(), /Error: key not found/);
   } catch (e) {
     t.assert(false, e);
   } finally {
@@ -222,7 +226,7 @@ test('claimExactly goodUnits', async t => {
     const purse = mint.mint(1000);
     const payment = await purse.withdraw(7);
     const newPayment = await assay.claimExactly(7, payment);
-    t.throws(() => payment.getBalance());
+    t.throws(() => payment.getBalance(), /Error: key not found/);
     t.deepEqual(newPayment.getBalance(), assay.makeUnits(7));
   } catch (e) {
     t.assert(false, e);
@@ -238,7 +242,7 @@ test('claimAll goodUnits', async t => {
     const purse = mint.mint(1000);
     const payment = await purse.withdraw(7);
     const newPayment = await assay.claimAll(payment);
-    t.throws(() => payment.getBalance());
+    t.throws(() => payment.getBalance(), /Error: key not found/);
     t.deepEqual(newPayment.getBalance(), assay.makeUnits(7));
   } catch (e) {
     t.assert(false, e);

--- a/packages/ERTP/test/unitTests/more/imports/test-importsA.js
+++ b/packages/ERTP/test/unitTests/more/imports/test-importsA.js
@@ -33,11 +33,11 @@ test('import listIsEmpty (true)', t => {
   t.end();
 });
 
-test('import not found', t => {
+test.skip('import not found', t => {
   const importer = makeGoodImportManager();
   t.throws(
     () => importer.lookupImport('emptyPixel'),
-    'There is no entry for "c".',
+    /There is no entry for "c"./,
   );
   t.end();
 });

--- a/packages/ERTP/test/unitTests/more/imports/test-importsA.js
+++ b/packages/ERTP/test/unitTests/more/imports/test-importsA.js
@@ -33,6 +33,8 @@ test('import listIsEmpty (true)', t => {
   t.end();
 });
 
+// TODO: This test throws because `lookupImport` does not exist. This
+// test needs to be fixed.
 test.skip('import not found', t => {
   const importer = makeGoodImportManager();
   t.throws(

--- a/packages/ERTP/test/unitTests/more/pixels/test-gallery.js
+++ b/packages/ERTP/test/unitTests/more/pixels/test-gallery.js
@@ -62,7 +62,10 @@ test('get all pixels and use them', async t => {
 
   t.deepEquals(bundles[0].getRawPixels(), []);
 
-  t.throws(() => bundles[0].changeColorAll('blue'));
+  t.throws(
+    () => bundles[0].changeColorAll('blue'),
+    /no use rights present in units/,
+  );
   t.doesNotThrow(() => bundles[1].changeColorAll('blue'));
   t.doesNotThrow(() => bundles[bundles.length - 1].changeColorAll('blue'));
   t.end();

--- a/packages/ERTP/test/unitTests/more/pixels/types/test-area.js
+++ b/packages/ERTP/test/unitTests/more/pixels/types/test-area.js
@@ -27,31 +27,37 @@ test('area insistArea', t => {
       5,
     ),
   );
-  t.throws(() =>
-    insistArea(
-      {
-        end: { x: 0, y: 0 },
-      },
-      5,
-    ),
+  t.throws(
+    () =>
+      insistArea(
+        {
+          end: { x: 0, y: 0 },
+        },
+        5,
+      ),
+    /areas must have start, end properties only/,
   );
-  t.throws(() =>
-    insistArea(
-      {
-        start: { x: 0, y: 0 },
-        end: { x: 3, y: 0 },
-      },
-      1,
-    ),
+  t.throws(
+    () =>
+      insistArea(
+        {
+          start: { x: 0, y: 0 },
+          end: { x: 3, y: 0 },
+        },
+        1,
+      ),
+    /pixel position must be within bounds/,
   );
-  t.throws(() =>
-    insistArea(
-      {
-        start: { x: 3, y: 0 },
-        end: { x: 0, y: 0 },
-      },
-      5,
-    ),
+  t.throws(
+    () =>
+      insistArea(
+        {
+          start: { x: 3, y: 0 },
+          end: { x: 0, y: 0 },
+        },
+        5,
+      ),
+    /the starting pixel must be "less than or equal" to the ending pixel/,
   );
   t.end();
 });

--- a/packages/ERTP/test/unitTests/more/pixels/types/test-pixel-list.js
+++ b/packages/ERTP/test/unitTests/more/pixels/types/test-pixel-list.js
@@ -214,7 +214,10 @@ test('pixelList without', t => {
   t.deepEqual(extentOps.without(harden([startPixel]), harden([])), [
     startPixel,
   ]);
-  t.throws(() => extentOps.without(harden([]), harden([startPixel])));
+  t.throws(
+    () => extentOps.without(harden([]), harden([startPixel])),
+    /part is not in whole/,
+  );
   t.deepEqual(
     extentOps.without(harden([startPixel]), harden([startPixel])),
     [],

--- a/packages/ERTP/test/unitTests/more/pixels/types/test-pixel.js
+++ b/packages/ERTP/test/unitTests/more/pixels/types/test-pixel.js
@@ -11,10 +11,16 @@ import {
 test('pixel insistWithinBounds', t => {
   t.doesNotThrow(() => insistWithinBounds(0, 1));
   t.doesNotThrow(() => insistWithinBounds(1, 2));
-  t.throws(() => insistWithinBounds(2, 2));
-  t.throws(() => insistWithinBounds('a', 2));
-  t.throws(() => insistWithinBounds(0, 0));
-  t.throws(() => insistWithinBounds(0, 'a'));
+  t.throws(
+    () => insistWithinBounds(2, 2),
+    /pixel position must be within bounds/,
+  );
+  t.throws(() => insistWithinBounds('a', 2), /not a safe integer/);
+  t.throws(
+    () => insistWithinBounds(0, 0),
+    /pixel position must be within bounds/,
+  );
+  t.throws(() => insistWithinBounds(0, 'a'), /not a safe integer/);
   t.end();
 });
 

--- a/packages/zoe/test/unitTests/contracts/test-publicAuction.js
+++ b/packages/zoe/test/unitTests/contracts/test-publicAuction.js
@@ -423,7 +423,7 @@ test('zoe - secondPriceAuction w/ 3 bids - alice exits onDemand', async t => {
     // 8: Bob makes an offer with his escrow receipt
     t.rejects(
       bobAuction.bid(bobEscrowReceipt),
-      `The item up for auction has been withdrawn`,
+      /The item up for auction has been withdrawn/,
     );
 
     // 9: Carol decides to bid for the one moola
@@ -463,7 +463,7 @@ test('zoe - secondPriceAuction w/ 3 bids - alice exits onDemand', async t => {
     // 11: Carol makes an offer with her escrow receipt
     t.rejects(
       carolAuction.bid(carolEscrowReceipt),
-      `The item up for auction has been withdrawn`,
+      /The item up for auction has been withdrawn/,
     );
 
     // 12: Dave decides to bid for the one moola
@@ -501,7 +501,7 @@ test('zoe - secondPriceAuction w/ 3 bids - alice exits onDemand', async t => {
     // 14: Dave makes an offer with his escrow receipt
     t.rejects(
       daveAuction.bid(daveEscrowReceipt),
-      `The item up for auction has been withdrawn`,
+      /The item up for auction has been withdrawn/,
     );
 
     const aliceResult = await alicePayoutP;

--- a/packages/zoe/test/unitTests/test-isOfferSafe.js
+++ b/packages/zoe/test/unitTests/test-isOfferSafe.js
@@ -12,7 +12,7 @@ test('isOfferSafeForOffer - empty payoutRules', t => {
 
     t.throws(
       _ => isOfferSafeForOffer(extentOps, payoutRules, extents),
-      'extentOps, payoutRules, and extents must be arrays of the same length',
+      /Error: extentOpsArray, the offer description, and extents must be arrays of the same length/,
     );
   } catch (e) {
     t.assert(false, e);
@@ -34,7 +34,7 @@ test('isOfferSafeForOffer - empty extents', t => {
 
     t.throws(
       _ => isOfferSafeForOffer(extentOps, payoutRules, extents),
-      'extentOps, payoutRules, and extents must be arrays of the same length',
+      /Error: extentOpsArray, the offer description, and extents must be arrays of the same length/,
     );
   } catch (e) {
     t.assert(false, e);
@@ -313,7 +313,7 @@ test('isOfferSafeForOffer - empty arrays', t => {
     const extents = [];
     t.throws(
       () => isOfferSafeForOffer(extentOps, payoutRules, extents),
-      /extentOpsArray, the offer description, and extents must be arrays of the same length/,
+      /Error: extentOpsArray, the offer description, and extents must be arrays of the same length/,
     );
   } catch (e) {
     t.assert(false, e);


### PR DESCRIPTION
Adds the expected error message to any `t.throws` in ERTP. If the expected error message was malformed or a string, that's corrected.

@Chris-Hibbert I skipped a test relating to the importManager - line 36 of `packages/ERTP/test/unitTests/more/imports/test-importsA.js`. It seems like that test is using a method that no longer exists. It throws, but not for the reasons specified.

Closes #83 