### PR TITLE
Update CONTRIBUTING.md for ERTP with latest instructions

### DIFF
--- a/packages/ERTP/CONTRIBUTING.md
+++ b/packages/ERTP/CONTRIBUTING.md
@@ -40,6 +40,6 @@ Before submitting a pull request, please:
   * and does NOT do a `git commit` and `git tag`
 * `git commit -m "bump version`
 * `git tag -a ERTP-v$VERSION -m "ERTP-v$VERSION"
-* `npm publish --access public`
+* `yarn publish --access public`
 * `git push`
 * `git push --tags`

--- a/packages/ERTP/CONTRIBUTING.md
+++ b/packages/ERTP/CONTRIBUTING.md
@@ -12,34 +12,40 @@ prefix to the title and ERTP tag to ERTP-related issues.
 
 You'll need Node.js version 11 or higher. 
 
-* git clone https://github.com/Agoric/agoric-sdk/
-* cd packages/ERTP
-* yarn install
-* yarn test
+* `git clone https://github.com/Agoric/agoric-sdk/`
+* `cd agoric-sdk`
+* `yarn install`
+* `yarn build` (This *must* be done at the top level to build all of
+  the packages)
+* `cd packages/ERTP`
+* `yarn test`
 
 ## Pull Requests
 
 Before submitting a pull request, please:
 
-* run `yarn test` and make sure all the unit tests pass
+* run `yarn test` within `packages/ERTP` and make sure all the unit
+  tests pass (running `yarn test` at the top level will test all the
+  monorepo packages, which can be a good integration test.)
 * run `yarn run lint-fix` to reformat the code according to our
   `eslint` profile, and fix any complaints that it can't automatically
   correct
-* Add a file to the `changelogs` directory named $ISSUENUMBER.txt , and
+* make sure your PR includes a new file in the `changelogs` directory named $ISSUENUMBER.txt , and
   describe any downstream-visible changes in it (one per line). See
   [README-changelogs.md](/packages/ERTP/changelogs/README-changelogs.md) for more information.
 
 ## Making a Release
 
-* edit NEWS.md enumerating any user-visible changes (this will be done
-  automatically in the future?)
+* edit NEWS.md enumerating any user-visible changes. (If there are
+  changelogs/ snippets, consolidate them to build the new NEWS
+  entries, and then delete all the snippets.)
 * make sure `yarn config set version-git-tag false` is the current
   setting
 * `yarn version` (interactive) or `yarn version --major` or `yarn version --minor`
   * that changes `package.json`
   * and does NOT do a `git commit` and `git tag`
-* `git commit -m "bump version`
-* `git tag -a ERTP-v$VERSION -m "ERTP-v$VERSION"
+* `git commit -m "bump version"`
+* `git tag -a ERTP-v$VERSION -m "ERTP-v$VERSION"`
 * `yarn publish --access public`
 * `git push`
 * `git push --tags`

--- a/packages/ERTP/CONTRIBUTING.md
+++ b/packages/ERTP/CONTRIBUTING.md
@@ -33,11 +33,13 @@ Before submitting a pull request, please:
 
 * edit NEWS.md enumerating any user-visible changes (this will be done
   automatically in the future?)
+* make sure `yarn config set version-git-tag false` is the current
+  setting
 * `yarn version` (interactive) or `yarn version --major` or `yarn version --minor`
   * that changes `package.json`
-  * and does a `git commit` and `git tag` by default
-  * to do `git commit` and `git tag` manually, use `yarn config set version-git-tag false`
-  * to get signed tags, start with `yarn config set version-sign-git-tag true`
+  * and does NOT do a `git commit` and `git tag`
+* `git commit -m "bump version`
+* `git tag -a ERTP-v$VERSION -m "ERTP-v$VERSION"
 * `npm publish --access public`
 * `git push`
 * `git push --tags`

--- a/packages/ERTP/CONTRIBUTING.md
+++ b/packages/ERTP/CONTRIBUTING.md
@@ -4,44 +4,40 @@ Thank you!
 
 ## Contact
 
-We use github issues for all bug reports: https://github.com/Agoric/ERTP/issues
+We use github issues for all bug reports:
+https://github.com/Agoric/agoric-sdk/issues Please add an [ERTP]
+prefix to the title and ERTP tag to ERTP-related issues.
 
 ## Installing, Testing
 
 You'll need Node.js version 11 or higher. 
 
-* git clone https://github.com/Agoric/ERTP/
-* npm install
-* npm test
+* git clone https://github.com/Agoric/agoric-sdk/
+* cd packages/ERTP
+* yarn install
+* yarn test
 
 ## Pull Requests
 
 Before submitting a pull request, please:
 
-* run `npm test` and make sure all the unit tests pass
-* run `npm run lint-fix` to reformat the code according to our
+* run `yarn test` and make sure all the unit tests pass
+* run `yarn run lint-fix` to reformat the code according to our
   `eslint` profile, and fix any complaints that it can't automatically
   correct
+* Add a file to the `changelogs` directory named $ISSUENUMBER.txt , and
+  describe any downstream-visible changes in it (one per line). See
+  [README-changelogs.md](/packages/ERTP/changelogs/README-changelogs.md) for more information.
 
 ## Making a Release
 
-* edit NEWS.md enumerating any user-visible changes
-* `npm version patch` (or `major` or `minor`)
-  * that changes `package.json` and `package-lock.json`
+* edit NEWS.md enumerating any user-visible changes (this will be done
+  automatically in the future?)
+* `yarn version` (interactive) or `yarn version --major` or `yarn version --minor`
+  * that changes `package.json`
   * and does a `git commit` and `git tag` by default
-  * to do `git commit` and `git tag` manually, use `--no-git-tag-version`
-  * to get signed tags, start with `npm config set sign-git-tag true`
+  * to do `git commit` and `git tag` manually, use `yarn config set version-git-tag false`
+  * to get signed tags, start with `yarn config set version-sign-git-tag true`
 * `npm publish --access public`
-* `npm version prerelease --preid=dev`
+* `git push`
 * `git push --tags`
-
-## Versioning
-
-While between releases, we use a version of "X.Y.Z-dev", where "X.Y.(Z-1)"
-was the previous release tag. This helps avoid confusion if/when people work
-from a git checkout, so bug reports to not make it look like they were using
-the previous tagged release.
-
-To achieve this, after doing a release, we run `npm version prerelease
---preid=dev` to modify the `package.json` and `package-lock.json` with
-the new in-between version string.


### PR DESCRIPTION
This PR updates CONTRIBUTING.md for ERTP with latest instructions. This should be the agreed-upon best practices that I can refer to in the future, so if anything isn't up to snuff, let's fix it in this PR. Thanks!

Questions:

* How and when do we bump the dependencies for this package in the other packages in our monorepo?