### PR TITLE
[Zoe] Add Zoe README

### DIFF
--- a/packages/zoe/README.md
+++ b/packages/zoe/README.md
@@ -1,0 +1,20 @@
+# Zoe
+
+## What is Zoe?
+
+Zoe is a framework for building smart contracts like auctions, swaps,
+decentralized exchanges, and more. Zoe itself is a smart contract
+written in JavaScript and running on the Agoric platform. 
+
+_For users_: Zoe guarantees that as a user of a smart contract, you will
+either get what you wanted or get a full refund, even if the smart
+contract is buggy or malicious. (In fact, the smart contract never has
+access to your digital assets.)
+
+_For developers_: Zoe provides a safety net so you can focus on what
+your smart contract does best, without worrying about your users
+losing their assets due to a bug in the code that you wrote. Writing a
+smart contract on Zoe is easy: all of the Zoe smart contracts are
+written in the familiar language of JavaScript.
+
+To learn more, please see the [Zoe guide](https://agoric.com/documentation/zoe/guide/). 


### PR DESCRIPTION
Adds a README to `/packages/zoe` such that it shows up as information on the zoe page on npm. 