### PR TITLE
Part of my review of #319 in the form of a PR on that PR

### DIFF
--- a/packages/zoe/contracts/helpers/offerRules.js
+++ b/packages/zoe/contracts/helpers/offerRules.js
@@ -62,13 +62,8 @@ const hasAssays = (assays, newPayoutRules) =>
 export const hasValidPayoutRules = (kinds, assays, newPayoutRules) =>
   hasKinds(kinds, newPayoutRules) && hasAssays(assays, newPayoutRules);
 
-export const getActivePayoutRules = (zoe, offerHandles) => {
-  const { active } = zoe.getStatusFor(offerHandles);
-  return harden({
-    offerHandles: active,
-    payoutRulesArray: zoe.getPayoutRulesFor(active),
-  });
-};
+export const getActiveOffers = (zoe, offerHandles) =>
+  zoe.getOffers(zoe.getStatusFor(offerHandles).active);
 
 /**
  * Make a units without access to the assay, which we don't want

--- a/packages/zoe/contracts/simpleExchange.js
+++ b/packages/zoe/contracts/simpleExchange.js
@@ -1,10 +1,7 @@
 import harden from '@agoric/harden';
 
 import { rejectOffer, defaultAcceptanceMsg } from './helpers/userFlow';
-import {
-  hasValidPayoutRules,
-  getActiveOffers,
-} from './helpers/offerRules';
+import { hasValidPayoutRules, getActiveOffers } from './helpers/offerRules';
 import {
   isMatchingLimitOrder,
   reallocateSurplusToSeller as reallocate,
@@ -41,8 +38,8 @@ export const makeContract = harden((zoe, terms) => {
         // Try to match
         const activeBuyOffers = getActiveOffers(zoe, buyOfferHandles);
         for (const buyOffer of activeBuyOffers) {
-          if (isMatchingLimitOrder(zoe, payoutRules, butOffer.payoutRules)) {
-            return reallocate(zoe, offerHandle, activeBuyOffer.handle);
+          if (isMatchingLimitOrder(zoe, payoutRules, buyOffer.payoutRules)) {
+            return reallocate(zoe, offerHandle, buyOffer.handle);
           }
         }
         return defaultAcceptanceMsg;

--- a/packages/zoe/contracts/simpleExchange.js
+++ b/packages/zoe/contracts/simpleExchange.js
@@ -3,7 +3,7 @@ import harden from '@agoric/harden';
 import { rejectOffer, defaultAcceptanceMsg } from './helpers/userFlow';
 import {
   hasValidPayoutRules,
-  getActivePayoutRules,
+  getActiveOffers,
 } from './helpers/offerRules';
 import {
   isMatchingLimitOrder,
@@ -39,13 +39,10 @@ export const makeContract = harden((zoe, terms) => {
         sellOfferHandles.push(offerHandle);
 
         // Try to match
-        const {
-          offerHandles: activeBuyHandles,
-          payoutRulesArray: activeBuyPayoutRules,
-        } = getActivePayoutRules(zoe, buyOfferHandles);
-        for (let i = 0; i < activeBuyHandles.length; i += 1) {
-          if (isMatchingLimitOrder(zoe, payoutRules, activeBuyPayoutRules[i])) {
-            return reallocate(zoe, offerHandle, activeBuyHandles[i]);
+        const activeBuyOffers = getActiveOffers(zoe, buyOfferHandles);
+        for (const buyOffer of activeBuyOffers) {
+          if (isMatchingLimitOrder(zoe, payoutRules, butOffer.payoutRules)) {
+            return reallocate(zoe, offerHandle, activeBuyOffer.handle);
           }
         }
         return defaultAcceptanceMsg;
@@ -58,15 +55,10 @@ export const makeContract = harden((zoe, terms) => {
         buyOfferHandles.push(offerHandle);
 
         // Try to match
-        const {
-          offerHandles: activeSellHandles,
-          payoutRulesArray: activeSellPayoutRules,
-        } = getActivePayoutRules(zoe, sellOfferHandles);
-        for (let i = 0; i < activeSellHandles.length; i += 1) {
-          if (
-            isMatchingLimitOrder(zoe, activeSellPayoutRules[i], payoutRules)
-          ) {
-            reallocate(zoe, activeSellHandles[i], offerHandle);
+        const activeSellOffers = getActiveOffers(zoe, sellOfferHandles);
+        for (const sellOffer of activeSellOffers) {
+          if (isMatchingLimitOrder(zoe, sellOffer.payoutRules, payoutRules)) {
+            reallocate(zoe, sellOffer.handle, offerHandle);
           }
         }
         return defaultAcceptanceMsg;

--- a/packages/zoe/state.js
+++ b/packages/zoe/state.js
@@ -26,10 +26,10 @@ const makeTable = (validateFn, makeCustomMethodsFn = () => {}) => {
     delete: handleToRecord.delete,
     update: (handle, partialRecord) => {
       const record = handleToRecord.get(handle);
-      const updatedRecord = {
+      const updatedRecord = harden({
         ...record,
         ...partialRecord,
-      };
+      });
       table.validate(updatedRecord);
       handleToRecord.set(handle, updatedRecord);
       return record;
@@ -164,8 +164,7 @@ const makeOfferTable = () => {
 
       // For backwards-compatibility. To be deprecated in future PRs
       recordUsedInInstance: (offerHandle, instanceHandle) => {
-        const offerRecord = table.get(offerHandle);
-        offerRecord.instanceHandle = instanceHandle;
+        table.update(offerHandle, { instanceHandle });
       },
 
       // For backwards-compatibility. To be deprecated in future PRs

--- a/packages/zoe/state.js
+++ b/packages/zoe/state.js
@@ -131,10 +131,6 @@ const makeOfferTable = () => {
   const makeCustomMethods = table => {
     const customMethods = harden({
       getOffers: offerHandles => offerHandles.map(table.get),
-      getPayoutRules: offerHandle => table.get(offerHandle).payoutRules,
-      getExitRule: offerHandle => table.get(offerHandle).exitRule,
-      getUnitMatrix: offerHandles =>
-        offerHandles.map(offerHandle => table.get(offerHandle).units),
       getOfferStatuses: offerHandles => {
         const active = [];
         const inactive = [];
@@ -171,10 +167,6 @@ const makeOfferTable = () => {
       updateExtents: (offerHandle, extents) => {
         table.update(offerHandle, { extents });
       },
-
-      // For backwards-compatibility. To be deprecated in future PRs
-      getExtentMatrix: offerHandles =>
-        offerHandles.map(offerHandle => table.get(offerHandle).extents),
 
       // For backwards-compatibility. To be deprecated in future PRs
       updateExtentMatrix: (offerHandles, newExtentMatrix) =>

--- a/packages/zoe/state.js
+++ b/packages/zoe/state.js
@@ -84,7 +84,7 @@ const makeInstanceTable = () => {
 
 // Offer Table
 // Columns: handle | instanceHandle | assays | payoutRules | exitRule
-// | payoutPromise | units | extents
+// | units | extents
 const makeOfferTable = () => {
   const insistValidPayoutRuleKinds = payoutRules => {
     const acceptedKinds = [
@@ -118,7 +118,6 @@ const makeOfferTable = () => {
         'assays',
         'payoutRules',
         'exitRule',
-        'payoutPromise',
         'units',
         'extents',
       ],
@@ -153,8 +152,6 @@ const makeOfferTable = () => {
         });
       },
       isOfferActive: offerHandle => table.has(offerHandle),
-      getPayoutPromises: offerHandles =>
-        offerHandles.map(offerHandle => table.get(offerHandle).payoutPromise),
       deleteOffers: offerHandles =>
         offerHandles.map(offerHandle => table.delete(offerHandle)),
       updateUnitMatrix: (offerHandles, newUnitMatrix) =>
@@ -191,6 +188,10 @@ const makeOfferTable = () => {
 
   return makeTable(validate, makeCustomMethods);
 };
+
+// Payout Map
+// PrivateName: offerHandle | payoutPromise
+const makePayoutMap = makePrivateName;
 
 // Assay Table
 // Columns: assay | purseP | unitOps | label
@@ -252,6 +253,7 @@ const makeTables = () =>
     installationTable: makeInstallationTable(),
     instanceTable: makeInstanceTable(),
     offerTable: makeOfferTable(),
+    payoutMap: makePayoutMap(),
     assayTable: makeAssayTable(),
   });
 

--- a/packages/zoe/state.js
+++ b/packages/zoe/state.js
@@ -131,8 +131,6 @@ const makeOfferTable = () => {
   const makeCustomMethods = table => {
     const customMethods = harden({
       getOffers: offerHandles => offerHandles.map(table.get),
-      getPayoutRuleMatrix: offerHandles =>
-        offerHandles.map(offerHandle => table.get(offerHandle).payoutRules),
       getPayoutRules: offerHandle => table.get(offerHandle).payoutRules,
       getExitRule: offerHandle => table.get(offerHandle).exitRule,
       getUnitMatrix: offerHandles =>

--- a/packages/zoe/state.js
+++ b/packages/zoe/state.js
@@ -50,7 +50,8 @@ const validateProperties = (expectedProperties, obj) => {
   const actualProperties = Object.getOwnPropertyNames(obj);
   insist(
     actualProperties.length === expectedProperties.length,
-  )`the actual properties (${actualProperties}) did not match the expected properties (${expectedProperties})`;
+  )`the actual properties (${actualProperties}) did not match the \
+  expected properties (${expectedProperties})`;
   for (const prop of actualProperties) {
     insist(
       expectedProperties.includes(prop),

--- a/packages/zoe/state.js
+++ b/packages/zoe/state.js
@@ -130,6 +130,7 @@ const makeOfferTable = () => {
 
   const makeCustomMethods = table => {
     const customMethods = harden({
+      getOffers: offerHandles => offerHandles.map(table.get),
       getPayoutRuleMatrix: offerHandles =>
         offerHandles.map(offerHandle => table.get(offerHandle).payoutRules),
       getPayoutRules: offerHandle => table.get(offerHandle).payoutRules,

--- a/packages/zoe/zoe.chainmail
+++ b/packages/zoe/zoe.chainmail
@@ -15,7 +15,7 @@ struct EscrowReceiptAndPayout ( ) {
  * `inviteAssay` and a single `escrowReceiptAssay` for the entirety of its
  * lifetime. By having a reference to Zoe, a user can get the `inviteAssay`
  * or `escrowReceiptAssay` and thus validate any `seat` or `escrowReceipt`
- * they receive from someone else. 
+ * they receive from someone else.
  */
 
 interface Zoe {
@@ -36,7 +36,7 @@ interface Zoe {
   getEscrowReceiptAssay() -> (Assay);
 
   /**
-   * Returns the array of assays for the particular instance. This is 
+   * Returns the array of assays for the particular instance. This is
    * helpful in the case that the user has forgotten the order.
    */
   getAssaysForInstance() -> (List(Assay));
@@ -47,31 +47,31 @@ interface Zoe {
    */
   install(code :String) -> Object
 
-  /** 
+  /**
    * Zoe is long-lived. We can use Zoe to create smart contract
-   * instances by specifying a particular contract installation to 
-   * use, as well as the `terms` of the contract. The contract terms 
+   * instances by specifying a particular contract installation to
+   * use, as well as the `terms` of the contract. The contract terms
    * are the arguments to the contract, and must include
    * the expected assays for the underlying rights. (Other than the
-   * `assays` property of `terms`, the `terms` properties are up to 
+   * `assays` property of `terms`, the `terms` properties are up to
    * the discretion of the smart contract.) We get back an instance, a
    * handle for that instance, the handle for the installation, and the
    * terms.
    */
   makeInstance(installationHandle :Object, terms :Object) -> (InstanceInformation);
-  
+
   /**
    * Credibly get the instance from the instanceHandle.
    */
   getInstance(instanceHandle :Object) -> (InstanceInformation);
 
-  /** 
+  /**
    * To escrow, the user must provide a list of payments as well as
-   * their rules for the offer. 
-   * 
-   * The rules for the offer are in two parts: `payoutRules` are used 
-   * by Zoe to enforce offer safety, and `exitRule` is used by Zoe 
-   * to enforce exit safety. `payoutRules` is a list of objects, each 
+   * their rules for the offer.
+   *
+   * The rules for the offer are in two parts: `payoutRules` are used
+   * by Zoe to enforce offer safety, and `exitRule` is used by Zoe
+   * to enforce exit safety. `payoutRules` is a list of objects, each
    * with a `kind` property (such as 'offerExactly') and a units
    * property. The objects in the `payoutRules` must be in the same order
    * as the assays associated with a smart contract. That is, the
@@ -93,7 +93,7 @@ struct OfferRules ( ) {
 
 /**
  * payoutRules are an array of PayoutRule. The possible
- * kinds are 'offerExactly', 'offerAtMost', 'wantExactly', and 
+ * kinds are 'offerExactly', 'offerAtMost', 'wantExactly', and
  * 'wantAtLeast'.
  */
 struct PayoutRule ( ) {
@@ -113,7 +113,7 @@ struct ExitRule ( ) {
 
 interface ZoeGoverningContractFacet () {
 
-  /** 
+  /**
    * Instruct Zoe to try reallocating for the given offerHandles.
    * Reallocation is a matrix (array of arrays) where the rows are the
    * extents to be paid to the player who made the offer at the same
@@ -122,7 +122,7 @@ interface ZoeGoverningContractFacet () {
    */
   reallocate (offerHandles :List(Object), reallocation :List(List(Extent)));
 
-  /** 
+  /**
    * Eject the offer, taking the current allocation for that offer and
    * creating payments to be returned to the user. No 'offer safety' checks are
    * done here because any previous reallocation performed those checks.
@@ -131,10 +131,10 @@ interface ZoeGoverningContractFacet () {
 
   /**
    * Create an empty offer for recordkeeping purposes (Autoswap uses
-   * this to create the liquidity pool). 
+   * this to create the liquidity pool).
    */
   escrowEmptyOffer ( ) -> (offerHandle);
-  
+
   /**
    * Escrow an offer created by the smart contract. Autoswap uses
    * this to mint liquidity tokens and add them to the rights managed
@@ -144,33 +144,26 @@ interface ZoeGoverningContractFacet () {
 
   /** Burn and validate an escrowReceipt received from the user. */
   burnEscrowReceipt (escrowReceipt :Payment) -> (Extent);
-  
+
   /** Create an invite using the Zoe inviteMint */
   makeInvite (offerToBeMade :List(PayoutRulesElem), useObj :Object) -> (Payment);
 
   ////// The methods below are pure and have no side-effects. ////////
 
   /**
-   * Create an array of empty extents per assay. Note that if the 
-   * mint is not a basic fungible mint, this may be something other than 0. 
+   * Create an array of empty extents per assay. Note that if the
+   * mint is not a basic fungible mint, this may be something other than 0.
    */
   makeEmptyExtents ( ) -> (List(Extent));
 
   /** Get the array of extentOps, the logic from the unitOps */
   getExtentOps ( ) -> (List(ExtentOps));
 
-  /** 
+  /**
    * Pass in an array of offerHandles and get a matrix (array of arrays)
    * containing the extents, in the same order as the offerHandles array.
    */
   getExtentsFor (offerHandles :List(Object)) -> (List(List(Extent)));
-
-  /** 
-   * Pass in an array of offerHandles and get a matrix (array of arrays)
-   * containing the offer descriptions for the offers, in the same 
-   * order as the offerHandles array.
-   */
-  getPayoutRulesFor (offerHandles :List(Object)) -> (List(PayoutRules));
 
   /** Get the Zoe inviteAssay */
   getInviteAssay ( ) -> (Assay);

--- a/packages/zoe/zoe.js
+++ b/packages/zoe/zoe.js
@@ -61,8 +61,6 @@ const makeZoe = (additionalEndowments = {}) => {
     // line can be deleted
     const assays = getAssaysFromPayoutRules(offers[0].payoutRules);
 
-    const unitMatrix = offers.map(offer => offer.units);
-
     // Remove the offers from the offerTable so that they are no
     // longer active.
     offerTable.deleteOffers(offerHandles);
@@ -72,9 +70,7 @@ const makeZoe = (additionalEndowments = {}) => {
     for (const offer of offers) {
       // This Promise.all will be taken out in a later PR.
       const payout = Promise.all(
-        offer.units.map((units, j) =>
-          E(pursePs[j]).withdraw(units, 'payout'),
-        ),
+        offer.units.map((units, j) => E(pursePs[j]).withdraw(units, 'payout')),
       );
       payoutMap.get(offer.handle).res(payout);
     }

--- a/packages/zoe/zoe.js
+++ b/packages/zoe/zoe.js
@@ -55,13 +55,15 @@ const makeZoe = (additionalEndowments = {}) => {
     if (inactive.length > 0) {
       throw new Error(`offer has already completed`);
     }
+    const offers = offerTable.getOffers(offerHandles);
 
-    // In the future, when `assays` is a parameter, these next two
-    // lines can be deleted
-    const payoutRules = offerTable.getPayoutRules(offerHandles[0]);
-    const assays = getAssaysFromPayoutRules(payoutRules);
+    // In the future, when `assays` is a parameter, these next
+    // line can be deleted
+    const assays = getAssaysFromPayoutRules(offers[0].payoutRules);
 
-    const unitMatrix = offerTable.getUnitMatrix(offerHandles, assays);
+    // Not sure this is correct, because original had an "extra" assays
+    // argument
+    const unitMatrix = offers.map(offer => offer.units);
 
     // Remove the offers from the offerTable so that they are no
     // longer active.
@@ -147,8 +149,10 @@ const makeZoe = (additionalEndowments = {}) => {
       reallocate: (offerHandles, newExtentMatrix) => {
         const { assays } = instanceTable.get(instanceHandle);
 
-        const payoutRuleMatrix = offerTable.getPayoutRuleMatrix(offerHandles);
-        const currentExtentMatrix = offerTable.getExtentMatrix(offerHandles);
+        const offers = offerTable.getOffers(offerHandles);
+
+        const payoutRuleMatrix = offers.map(offer => offer.payoutRules);
+        const currentExtentMatrix = offers.map(offer => offer.extents);
         const extentOpsArray = assayTable.getExtentOpsForAssays(assays);
 
         // 1) ensure that rights are conserved

--- a/packages/zoe/zoe.js
+++ b/packages/zoe/zoe.js
@@ -298,7 +298,6 @@ const makeZoe = (additionalEndowments = {}) => {
       getInviteAssay: () => inviteAssay,
 
       // To be used by contracts in the near future.
-      // getPayoutRuleMatrix: offerTable.getPayoutRuleMatrix,
       // getUnitOpsForAssays: assayTable.getUnitOpsForAssays,
       // getOfferStatuses: offerTable.getOfferStatuses,
       // getUnitMatrix: offerTable.getUnitMatrix,
@@ -308,13 +307,13 @@ const makeZoe = (additionalEndowments = {}) => {
 
       // This methods will be replaced by the above methods in the
       // near future.
+      getOffers: offerTable.getOffers,
       getStatusFor: offerTable.getOfferStatuses,
       getExtentsFor: offerTable.getExtentsFor,
       getExtentOpsArray: () => {
         const { assays } = instanceTable.get(instanceHandle);
         return assayTable.getExtentOpsForAssays(assays);
       },
-      getPayoutRulesFor: offerTable.getPayoutRuleMatrix,
       makeEmptyExtents: () => {
         const { assays } = instanceTable.get(instanceHandle);
         const extentOpsArray = assayTable.getExtentOpsForAssays(assays);

--- a/packages/zoe/zoe.js
+++ b/packages/zoe/zoe.js
@@ -300,9 +300,6 @@ const makeZoe = (additionalEndowments = {}) => {
       // To be used by contracts in the near future.
       // getUnitOpsForAssays: assayTable.getUnitOpsForAssays,
       // getOfferStatuses: offerTable.getOfferStatuses,
-      // getUnitMatrix: offerTable.getUnitMatrix,
-      // getPayoutRules: offerTable.getPayoutRules,
-      // getExitRule: offerTable.getExitRule,
       // isOfferActive: offerTable.isOfferActive,
 
       // This methods will be replaced by the above methods in the

--- a/packages/zoe/zoe.js
+++ b/packages/zoe/zoe.js
@@ -61,8 +61,6 @@ const makeZoe = (additionalEndowments = {}) => {
     // line can be deleted
     const assays = getAssaysFromPayoutRules(offers[0].payoutRules);
 
-    // Not sure this is correct, because original had an "extra" assays
-    // argument
     const unitMatrix = offers.map(offer => offer.units);
 
     // Remove the offers from the offerTable so that they are no

--- a/packages/zoe/zoe.js
+++ b/packages/zoe/zoe.js
@@ -57,7 +57,7 @@ const makeZoe = (additionalEndowments = {}) => {
     }
     const offers = offerTable.getOffers(offerHandles);
 
-    // In the future, when `assays` is a parameter, these next
+    // In the future, when `assays` is a parameter, the next
     // line can be deleted
     const assays = getAssaysFromPayoutRules(offers[0].payoutRules);
 
@@ -68,20 +68,16 @@ const makeZoe = (additionalEndowments = {}) => {
     offerTable.deleteOffers(offerHandles);
 
     // Resolve the payout promises with the payouts
-    const pursesP = assayTable.getPursesForAssays(assays);
-    Promise.all(pursesP).then(purses => {
-      for (let i = 0; i < offerHandles.length; i += 1) {
-        const offerHandle = offerHandles[i];
-        const unitsForOffer = unitMatrix[i];
-        // This Promise.all will be taken out in a later PR.
-        const payout = Promise.all(
-          unitsForOffer.map((units, j) =>
-            E(purses[j]).withdraw(units, 'payout'),
-          ),
-        );
-        payoutMap.get(offerHandle).res(payout);
-      }
-    });
+    const pursePs = assayTable.getPursesForAssays(assays);
+    for (const offer of offers) {
+      // This Promise.all will be taken out in a later PR.
+      const payout = Promise.all(
+        offer.units.map((units, j) =>
+          E(pursePs[j]).withdraw(units, 'payout'),
+        ),
+      );
+      payoutMap.get(offer.handle).res(payout);
+    }
   };
 
   // Create payoutRules in which nothing is offered and anything


### PR DESCRIPTION
The offer record was mostly informational, with only the payoutPromise carrying authority. By separating that into a separate `payoutMap` (please rename), the remaining offer records could be exposed directly. The remaining source of mutability was that the updated records didn't stay frozen, which looks like a mistake. 

After fixing both of those, we can expose the offer records from state.js to zoe.js, and from zoe.js to the contracts. As a result, I was able to do a lot more decolumnization. I think there's still a lot of decolmnization to do, but this should give a flavor of what I have in mind. Do you agree that it is always strictly simpler than the columnar form?