### PR TITLE
[Zoe] Use units not extents in invariant checks

### DIFF
--- a/packages/zoe/areRightsConserved.js
+++ b/packages/zoe/areRightsConserved.js
@@ -10,51 +10,47 @@ const transpose = matrix =>
   );
 
 /**
- * The columns in a `extents` matrix are per assay, and the rows
+ * The columns in a `units` matrix are per assay, and the rows
  * are per offer. We want to transpose the matrix such that each
  * row is per assay so we can do 'with' on the array to get a total
  * per assay and make sure the rights are conserved.
- * @param  {extentOps[]} extentOpsArray - an array of extentOps per assay
- * @param  {extent[][]} extentsMatrix - an array of arrays with a row per
+ * @param  {unitOps[]} unitOpsArray - an array of unitOps per assay
+ * @param  {units[][]} unitsMatrix - an array of arrays with a row per
  * offer indexed by assay
  */
-const sumByAssay = (extentOpsArray, extentsMatrix) =>
-  transpose(extentsMatrix).map((extentsPerAssay, i) =>
-    extentsPerAssay.reduce(extentOpsArray[i].with, extentOpsArray[i].empty()),
+const sumByAssay = (unitOpsArray, unitsMatrix) =>
+  transpose(unitsMatrix).map((unitsPerAssay, i) =>
+    unitsPerAssay.reduce(unitOpsArray[i].with, unitOpsArray[i].empty()),
   );
 
 /**
- * Does the left array of summed extents equal the right array of
- * summed extents?
- * @param  {extentOps[]} extentOpsArray - an array of extentOps per assay
- * @param  {extent[]} leftExtentsArray - an array of total extents per assay
- * @param  {extent[]} rightExtentsArray - an array of total extents per assay
+ * Does the left array of summed units equal the right array of
+ * summed units?
+ * @param  {unitOps[]} unitOpsArray - an array of unitOps per assay
+ * @param  {units[]} leftUnitsArray - an array of total units per assay
+ * @param  {units[]} rightUnitsArray - an array of total units per assay
  * indexed by assay
  */
-const isEqualPerAssay = (extentOpsArray, leftExtentsArray, rightExtentsArray) =>
-  leftExtentsArray.every((leftExtent, i) =>
-    extentOpsArray[i].equals(leftExtent, rightExtentsArray[i]),
+const isEqualPerAssay = (unitOpsArray, leftUnitsArray, rightUnitsArray) =>
+  leftUnitsArray.every((leftUnits, i) =>
+    unitOpsArray[i].equals(leftUnits, rightUnitsArray[i]),
   );
 
 /**
- * `areRightsConserved` checks that the total extent per assay stays
+ * `areRightsConserved` checks that the total units per assay stays
  * the same regardless of the reallocation.
- * @param  {extentOps[]} extentOpsArray - an array of extentOps per assay
- * @param  {extent[][]} previousExtentsMatrix - array of arrays where a row
- * is the array of extents for a particular offer, per
+ * @param  {unitOps[]} unitOpsArray - an array of unitOps per assay
+ * @param  {unit[][]} previousUnitsMatrix - array of arrays where a row
+ * is the array of units for a particular offer, per
  * assay
- * @param  {extent[][]} newExtentsMatrix - array of arrays where a row
- * is the array of reallocated extents for a particular offer, per
+ * @param  {unit[][]} newUnitsMatrix - array of arrays where a row
+ * is the array of reallocated units for a particular offer, per
  * assay
  */
-function areRightsConserved(
-  extentOpsArray,
-  previousExtentsMatrix,
-  newExtentsMatrix,
-) {
-  const sumsPrevExtents = sumByAssay(extentOpsArray, previousExtentsMatrix);
-  const sumsNewExtents = sumByAssay(extentOpsArray, newExtentsMatrix);
-  return isEqualPerAssay(extentOpsArray, sumsPrevExtents, sumsNewExtents);
+function areRightsConserved(unitOpsArray, previousUnitsMatrix, newUnitsMatrix) {
+  const sumsPrevUnits = sumByAssay(unitOpsArray, previousUnitsMatrix);
+  const sumsNewUnits = sumByAssay(unitOpsArray, newUnitsMatrix);
+  return isEqualPerAssay(unitOpsArray, sumsPrevUnits, sumsNewUnits);
 }
 
 export { areRightsConserved, transpose };

--- a/packages/zoe/isOfferSafe.js
+++ b/packages/zoe/isOfferSafe.js
@@ -9,25 +9,25 @@ import { insist } from '@agoric/ertp/util/insist';
  * independently. It *does* allow for returning a full refund plus
  * full winnings.
  *
- * @param  {extentOps[]} extentOpsArray - an array of extentOps
- * ordered in the same order as the corresponding assays
+ * @param  {unitOps[]} unitOpsArray - an array of unitOps ordered in
+ * the same order as the assays for the payoutRules
  * @param  {payoutRule[]} payoutRules - the rules that accompanied the
  * escrow of payments that dictate what the user expected to get back
  * from Zoe. The payoutRules are an array of objects that have a kind
  * and units, in the same order as the corresponding assays. The
  * offerRules, including the payoutRules, are a player's understanding
- * of the contract that they are entering when they make an offer.
- * A payoutRule is structured in the form `{ kind:
- * descriptionString, units}`
- * @param  {extent[]} extents - an array of extents ordered in the
- * same order as the corresponding assays. This array of extents is
- * the reallocation to be given to a player.
+ * of the contract that they are entering when they make an offer. A
+ * payoutRule is structured in the form `{ kind: descriptionString,
+ * units}`
+ * @param  {unit[]} units - an array of units ordered in the same
+ * order as the assays for the payoutRules. This array of units is the
+ * reallocation to be given to a player.
  */
-function isOfferSafeForOffer(extentOpsArray, payoutRules, extents) {
+function isOfferSafeForOffer(unitOpsArray, payoutRules, units) {
   insist(
-    extentOpsArray.length === payoutRules.length &&
-      extentOpsArray.length === extents.length,
-  )`extentOpsArray, the offer description, and extents must be arrays of the same length`;
+    unitOpsArray.length === payoutRules.length &&
+      unitOpsArray.length === units.length,
+  )`unitOpsArray, payoutRules, and units must be arrays of the same length`;
 
   const allowedRules = [
     'offerExactly',
@@ -36,68 +36,58 @@ function isOfferSafeForOffer(extentOpsArray, payoutRules, extents) {
     'wantAtLeast',
   ];
 
-  // For this allocation to count as a full refund, the allocated
-  // extents must be greater than or equal to what was originally
-  // offered.
-  const refundOk = payoutRules.every((payoutRule, i) => {
+  for (const payoutRule of payoutRules) {
     if (payoutRule === null || payoutRule === undefined) {
       throw new Error(`payoutRule must be specified`);
     }
     insist(
       allowedRules.includes(payoutRule.kind),
     )`The kind ${payoutRule.kind} was not recognized`;
-    // If the kind was 'offerExactly', we should make sure that the
-    // user gets it back exactly in a refund. If the kind is
-    // 'offerAtMost' we need to ensure that the user gets back the
-    // extent or greater.
+  }
+
+  // For this allocation to count as a full refund, the allocated
+  // units must be greater than or equal to what was originally
+  // offered.
+  const refundOk = payoutRules.every((payoutRule, i) => {
     if (payoutRule.kind === 'offerExactly') {
-      return extentOpsArray[i].equals(extents[i], payoutRule.units.extent);
+      return unitOpsArray[i].equals(units[i], payoutRule.units);
     }
     if (payoutRules.kind === 'offerAtMost') {
-      return extentOpsArray[i].includes(extents[i], payoutRule.units.extent);
+      return unitOpsArray[i].includes(units[i], payoutRule.units);
     }
-    // If the kind is something else, anything we give back is fine.
+    // If the kind is 'want', anything we give back is fine for a refund.
     return true;
   });
 
   // For this allocation to count as a full payout of what the user
-  // wanted, their allocated extents must be greater than or equal to
+  // wanted, their allocated units must be greater than or equal to
   // what the payoutRules said they wanted.
   const winningsOk = payoutRules.every((payoutRule, i) => {
-    if (payoutRule === null || payoutRule === undefined) {
-      throw new Error(`payoutRule must be specified`);
-    }
-    insist(
-      allowedRules.includes(payoutRule.kind),
-    )`The kind ${payoutRule.kind} was not recognized`;
-    // If the kind was 'wantExactly', we should make sure that the
-    // user gets exactly the extent specified in their winnings. If
-    // the kind is 'wantAtLeast', we need to ensure that the user
-    // gets back winnings that are equal or greater to the extent.
     if (payoutRule.kind === 'wantExactly') {
-      return extentOpsArray[i].equals(extents[i], payoutRule.units.extent);
+      return unitOpsArray[i].equals(units[i], payoutRule.units);
     }
     if (payoutRule.kind === 'wantAtLeast') {
-      return extentOpsArray[i].includes(extents[i], payoutRule.units.extent);
+      return unitOpsArray[i].includes(units[i], payoutRule.units);
     }
-    // If the kind is something else, anything we give back is fine.
+    // If the kind is 'offer anything we give back is fine for a payout.
     return true;
   });
   return refundOk || winningsOk;
 }
+
 /**
- * @param  {extentOps[]} extentOpsArray - an array of extentOps ordered in
- * the same order as the corresponding assays
+ * @param  {unitOps[]} unitOpsArray - an array of unitOps ordered in
+ * the same order as the assays for the payoutRules
  * @param  {payoutRules[][]} payoutRulesMatrix - an array of arrays. Each of the
- * element arrays is the offer description that a single player
- * made, in the same order as the corresponding assays.
- * @param  {extent[][]} extentMatrix - an array of arrays. Each of the
- * element arrays is the array of extents that a single player will
- * get, in the same order as the corresponding assays.
+ * element arrays is the payout rules that a single player
+ * made.
+ * @param  {unit[][]} unitMatrix - an array of arrays. Each of the
+ * element arrays is the array of units that a single player will
+ * get, in the same order as the assays for the payoutRules
  */
-const isOfferSafeForAll = (extentOpsArray, payoutRulesMatrix, extentsMatrix) =>
-  payoutRulesMatrix.every((payoutRules, i) =>
-    isOfferSafeForOffer(extentOpsArray, payoutRules, extentsMatrix[i]),
+const isOfferSafeForAll = (unitOpsArray, payoutRuleMatrix, unitMatrix) =>
+  payoutRuleMatrix.every((payoutRules, i) =>
+    isOfferSafeForOffer(unitOpsArray, payoutRules, unitMatrix[i]),
   );
 
 // `isOfferSafeForOffer` is only exported for testing

--- a/packages/zoe/test/unitTests/setupBasicMints.js
+++ b/packages/zoe/test/unitTests/setupBasicMints.js
@@ -23,6 +23,9 @@ const setup = () => {
     unitOps,
     extentOps,
     labels,
+    moola: unitOps[0].make,
+    simoleans: unitOps[1].make,
+    bucks: unitOps[2].make,
   });
 };
 harden(setup);

--- a/packages/zoe/test/unitTests/test-areRightsConserved.js
+++ b/packages/zoe/test/unitTests/test-areRightsConserved.js
@@ -3,6 +3,9 @@ import { test } from 'tape-promise/tape';
 import { areRightsConserved, transpose } from '../../areRightsConserved';
 import { setup } from './setupBasicMints';
 
+const makeUnitMatrix = (unitOps, extentMatrix) =>
+  extentMatrix.map(row => row.map((extent, i) => unitOps[i].make(extent)));
+
 test('transpose', t => {
   try {
     t.deepEquals(
@@ -23,10 +26,10 @@ test('transpose', t => {
   }
 });
 
-// rights are conserved for Nat extents
-test(`areRightsConserved - true for nat extents`, t => {
+// rights are conserved for units with Nat extents
+test(`areRightsConserved - true for units with nat extents`, t => {
   try {
-    const { extentOps } = setup();
+    const { unitOps } = setup();
     const oldExtents = [
       [0, 1, 0],
       [4, 1, 0],
@@ -38,7 +41,10 @@ test(`areRightsConserved - true for nat extents`, t => {
       [6, 2, 0],
     ];
 
-    t.ok(areRightsConserved(extentOps, oldExtents, newExtents));
+    const oldUnits = makeUnitMatrix(unitOps, oldExtents);
+    const newUnits = makeUnitMatrix(unitOps, newExtents);
+
+    t.ok(areRightsConserved(unitOps, oldUnits, newUnits));
   } catch (e) {
     t.assert(false, e);
   } finally {
@@ -46,10 +52,10 @@ test(`areRightsConserved - true for nat extents`, t => {
   }
 });
 
-// rights are *not* conserved for Nat extents
-test(`areRightsConserved - false for nat extents`, t => {
+// rights are *not* conserved for units with Nat extents
+test(`areRightsConserved - false for units with Nat extents`, t => {
   try {
-    const { extentOps } = setup();
+    const { unitOps } = setup();
     const oldExtents = [
       [0, 1, 4],
       [4, 1, 0],
@@ -61,7 +67,10 @@ test(`areRightsConserved - false for nat extents`, t => {
       [6, 2, 0],
     ];
 
-    t.notOk(areRightsConserved(extentOps, oldExtents, newExtents));
+    const oldUnits = makeUnitMatrix(unitOps, oldExtents);
+    const newUnits = makeUnitMatrix(unitOps, newExtents);
+
+    t.notOk(areRightsConserved(unitOps, oldUnits, newUnits));
   } catch (e) {
     t.assert(false, e);
   } finally {

--- a/packages/zoe/test/unitTests/test-isOfferSafe.js
+++ b/packages/zoe/test/unitTests/test-isOfferSafe.js
@@ -6,13 +6,13 @@ import { setup } from './setupBasicMints';
 // The player must have payoutRules for each assay
 test('isOfferSafeForOffer - empty payoutRules', t => {
   try {
-    const { extentOps } = setup();
+    const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [];
-    const extents = [8, 6, 7];
+    const units = [moola(8), simoleans(6), bucks(7)];
 
     t.throws(
-      _ => isOfferSafeForOffer(extentOps, payoutRules, extents),
-      /Error: extentOpsArray, the offer description, and extents must be arrays of the same length/,
+      _ => isOfferSafeForOffer(unitOps, payoutRules, units),
+      /unitOpsArray, payoutRules, and units must be arrays of the same length/,
     );
   } catch (e) {
     t.assert(false, e);
@@ -21,20 +21,20 @@ test('isOfferSafeForOffer - empty payoutRules', t => {
   }
 });
 
-// The extents array must have an item for each assay/rule
-test('isOfferSafeForOffer - empty extents', t => {
+// The units array must have an item for each assay/rule
+test('isOfferSafeForOffer - empty units', t => {
   try {
-    const { extentOps, unitOps } = setup();
+    const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'wantExactly', units: unitOps[0].make(8) },
-      { kind: 'wantExactly', units: unitOps[1].make(6) },
-      { kind: 'wantExactly', units: unitOps[2].make(7) },
+      { kind: 'wantExactly', units: moola(8) },
+      { kind: 'wantExactly', units: simoleans(6) },
+      { kind: 'wantExactly', units: bucks(7) },
     ];
-    const extents = [];
+    const units = [];
 
     t.throws(
-      _ => isOfferSafeForOffer(extentOps, payoutRules, extents),
-      /Error: extentOpsArray, the offer description, and extents must be arrays of the same length/,
+      _ => isOfferSafeForOffer(unitOps, payoutRules, units),
+      'unitOpsArray, payoutRules, and units must be arrays of the same length',
     );
   } catch (e) {
     t.assert(false, e);
@@ -45,17 +45,17 @@ test('isOfferSafeForOffer - empty extents', t => {
 
 // The player puts in something and gets exactly what they wanted,
 // with no refund
-test('isOfferSafeForOffer - gets wantExactly, with offerExactly', t => {
+test('isOfferSafeForOffer - gets want exactly', t => {
   try {
-    const { extentOps, unitOps } = setup();
+    const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'offerExactly', units: unitOps[0].make(8) },
-      { kind: 'wantExactly', units: unitOps[1].make(6) },
-      { kind: 'wantExactly', units: unitOps[2].make(7) },
+      { kind: 'offerExactly', units: moola(8) },
+      { kind: 'wantExactly', units: simoleans(6) },
+      { kind: 'wantExactly', units: bucks(7) },
     ];
-    const extents = [0, 6, 7];
+    const units = [moola(0), simoleans(6), bucks(7)];
 
-    t.ok(isOfferSafeForOffer(extentOps, payoutRules, extents));
+    t.ok(isOfferSafeForOffer(unitOps, payoutRules, units));
   } catch (e) {
     t.assert(false, e);
   } finally {
@@ -66,15 +66,15 @@ test('isOfferSafeForOffer - gets wantExactly, with offerExactly', t => {
 // The player gets exactly what they wanted, with no 'offer'
 test('isOfferSafeForOffer - gets wantExactly', t => {
   try {
-    const { extentOps, unitOps } = setup();
+    const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'wantExactly', units: unitOps[0].make(8) },
-      { kind: 'wantExactly', units: unitOps[1].make(6) },
-      { kind: 'wantExactly', units: unitOps[2].make(7) },
+      { kind: 'wantExactly', units: moola(8) },
+      { kind: 'wantExactly', units: simoleans(6) },
+      { kind: 'wantExactly', units: bucks(7) },
     ];
-    const extents = [8, 6, 7];
+    const units = [moola(8), simoleans(6), bucks(7)];
 
-    t.ok(isOfferSafeForOffer(extentOps, payoutRules, extents));
+    t.ok(isOfferSafeForOffer(unitOps, payoutRules, units));
   } catch (e) {
     t.assert(false, e);
   } finally {
@@ -88,15 +88,15 @@ test('isOfferSafeForOffer - gets wantExactly', t => {
 // refund condition was fulfilled trivially.
 test('isOfferSafeForOffer - gets wantExactly', t => {
   try {
-    const { extentOps, unitOps } = setup();
+    const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'wantExactly', units: unitOps[0].make(8) },
-      { kind: 'wantExactly', units: unitOps[1].make(6) },
-      { kind: 'wantExactly', units: unitOps[2].make(7) },
+      { kind: 'wantExactly', units: moola(8) },
+      { kind: 'wantExactly', units: simoleans(6) },
+      { kind: 'wantExactly', units: bucks(7) },
     ];
-    const extents = [9, 6, 7];
+    const units = [moola(9), simoleans(6), bucks(7)];
 
-    t.ok(isOfferSafeForOffer(extentOps, payoutRules, extents));
+    t.ok(isOfferSafeForOffer(unitOps, payoutRules, units));
   } catch (e) {
     t.assert(false, e);
   } finally {
@@ -107,15 +107,15 @@ test('isOfferSafeForOffer - gets wantExactly', t => {
 // The user gets refunded exactly what they put in, with a 'wantExactly'
 test(`isOfferSafeForOffer - gets offerExactly, doesn't get wantExactly`, t => {
   try {
-    const { extentOps, unitOps } = setup();
+    const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'offerExactly', units: unitOps[0].make(1) },
-      { kind: 'wantExactly', units: unitOps[1].make(2) },
-      { kind: 'offerExactly', units: unitOps[2].make(3) },
+      { kind: 'offerExactly', units: moola(1) },
+      { kind: 'wantExactly', units: simoleans(2) },
+      { kind: 'offerExactly', units: bucks(3) },
     ];
-    const extents = [1, 0, 3];
+    const units = [moola(1), simoleans(0), bucks(3)];
 
-    t.ok(isOfferSafeForOffer(extentOps, payoutRules, extents));
+    t.ok(isOfferSafeForOffer(unitOps, payoutRules, units));
   } catch (e) {
     t.assert(false, e);
   } finally {
@@ -126,15 +126,15 @@ test(`isOfferSafeForOffer - gets offerExactly, doesn't get wantExactly`, t => {
 // The user gets refunded exactly what they put in, with no 'wantExactly'
 test('isOfferSafeForOffer - gets offerExactly, no wantExactly', t => {
   try {
-    const { extentOps, unitOps } = setup();
+    const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'offerExactly', units: unitOps[0].make(1) },
-      { kind: 'offerExactly', units: unitOps[1].make(2) },
-      { kind: 'offerExactly', units: unitOps[2].make(3) },
+      { kind: 'offerExactly', units: moola(1) },
+      { kind: 'offerExactly', units: simoleans(2) },
+      { kind: 'offerExactly', units: bucks(3) },
     ];
-    const extents = [1, 2, 3];
+    const units = [moola(1), simoleans(2), bucks(3)];
 
-    t.ok(isOfferSafeForOffer(extentOps, payoutRules, extents));
+    t.ok(isOfferSafeForOffer(unitOps, payoutRules, units));
   } catch (e) {
     t.assert(false, e);
   } finally {
@@ -145,14 +145,14 @@ test('isOfferSafeForOffer - gets offerExactly, no wantExactly', t => {
 // The user gets a refund *and* winnings. This is 'offer safe'.
 test('isOfferSafeForOffer - refund and winnings', t => {
   try {
-    const { extentOps, unitOps } = setup();
+    const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'offerExactly', units: unitOps[0].make(2) },
-      { kind: 'wantExactly', units: unitOps[1].make(3) },
-      { kind: 'wantExactly', units: unitOps[2].make(3) },
+      { kind: 'offerExactly', units: moola(2) },
+      { kind: 'wantExactly', units: simoleans(3) },
+      { kind: 'wantExactly', units: bucks(3) },
     ];
-    const extents = [2, 3, 3];
-    t.ok(isOfferSafeForOffer(extentOps, payoutRules, extents));
+    const units = [moola(2), simoleans(3), bucks(3)];
+    t.ok(isOfferSafeForOffer(unitOps, payoutRules, units));
   } catch (e) {
     t.assert(false, e);
   } finally {
@@ -160,17 +160,17 @@ test('isOfferSafeForOffer - refund and winnings', t => {
   }
 });
 
-// The user gets more than they wanted - wantExactly
+// The user gets more than they wanted
 test('isOfferSafeForOffer - more than wantExactly', t => {
   try {
-    const { extentOps, unitOps } = setup();
+    const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'offerExactly', units: unitOps[0].make(2) },
-      { kind: 'wantExactly', units: unitOps[1].make(3) },
-      { kind: 'wantExactly', units: unitOps[2].make(4) },
+      { kind: 'offerExactly', units: moola(2) },
+      { kind: 'wantExactly', units: simoleans(3) },
+      { kind: 'wantExactly', units: bucks(4) },
     ];
-    const extents = [0, 3, 5];
-    t.notOk(isOfferSafeForOffer(extentOps, payoutRules, extents));
+    const units = [moola(0), simoleans(3), bucks(5)];
+    t.notOk(isOfferSafeForOffer(unitOps, payoutRules, units));
   } catch (e) {
     t.assert(false, e);
   } finally {
@@ -181,14 +181,14 @@ test('isOfferSafeForOffer - more than wantExactly', t => {
 // The user gets more than they wanted - wantAtLeast
 test('isOfferSafeForOffer - more than wantAtLeast', t => {
   try {
-    const { extentOps, unitOps } = setup();
+    const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'wantAtLeast', units: unitOps[0].make(2) },
-      { kind: 'wantAtLeast', units: unitOps[1].make(3) },
-      { kind: 'wantAtLeast', units: unitOps[2].make(4) },
+      { kind: 'wantAtLeast', units: moola(2) },
+      { kind: 'wantAtLeast', units: simoleans(3) },
+      { kind: 'wantAtLeast', units: bucks(4) },
     ];
-    const extents = [2, 6, 7];
-    t.ok(isOfferSafeForOffer(extentOps, payoutRules, extents));
+    const units = [moola(2), simoleans(6), bucks(7)];
+    t.ok(isOfferSafeForOffer(unitOps, payoutRules, units));
   } catch (e) {
     t.assert(false, e);
   } finally {
@@ -199,14 +199,14 @@ test('isOfferSafeForOffer - more than wantAtLeast', t => {
 // The user gets refunded more than what they put in
 test('isOfferSafeForOffer - more than offerExactly', t => {
   try {
-    const { extentOps, unitOps } = setup();
+    const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'offerExactly', units: unitOps[0].make(2) },
-      { kind: 'offerExactly', units: unitOps[1].make(3) },
-      { kind: 'wantExactly', units: unitOps[2].make(4) },
+      { kind: 'offerExactly', units: moola(2) },
+      { kind: 'offerExactly', units: simoleans(3) },
+      { kind: 'wantExactly', units: bucks(4) },
     ];
-    const extents = [5, 6, 8];
-    t.notOk(isOfferSafeForOffer(extentOps, payoutRules, extents));
+    const units = [moola(5), simoleans(6), bucks(8)];
+    t.notOk(isOfferSafeForOffer(unitOps, payoutRules, units));
   } catch (e) {
     t.assert(false, e);
   } finally {
@@ -219,14 +219,14 @@ test('isOfferSafeForOffer - more than offerExactly', t => {
 // because no winnings were specified and none were given back.
 test('isOfferSafeForOffer - more than offerExactly, no wants', t => {
   try {
-    const { extentOps, unitOps } = setup();
+    const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'offerExactly', units: unitOps[0].make(2) },
-      { kind: 'offerExactly', units: unitOps[1].make(3) },
-      { kind: 'offerExactly', units: unitOps[2].make(4) },
+      { kind: 'offerExactly', units: moola(2) },
+      { kind: 'offerExactly', units: simoleans(3) },
+      { kind: 'offerExactly', units: bucks(4) },
     ];
-    const extents = [5, 6, 8];
-    t.ok(isOfferSafeForOffer(extentOps, payoutRules, extents));
+    const units = [moola(5), simoleans(6), bucks(8)];
+    t.ok(isOfferSafeForOffer(unitOps, payoutRules, units));
   } catch (e) {
     t.assert(false, e);
   } finally {
@@ -234,17 +234,17 @@ test('isOfferSafeForOffer - more than offerExactly, no wants', t => {
   }
 });
 
-// The user gets refunded more than what they put in, with 'offerAtMost'
-test('isOfferSafeForOffer - more than offerAtMost', t => {
+// The user gets refunded more than what they put in, with 'offer'
+test('isOfferSafeForOffer - more than offer', t => {
   try {
-    const { extentOps, unitOps } = setup();
+    const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'offerAtMost', units: unitOps[0].make(2) },
-      { kind: 'offerAtMost', units: unitOps[1].make(3) },
-      { kind: 'wantExactly', units: unitOps[2].make(4) },
+      { kind: 'offerAtMost', units: moola(2) },
+      { kind: 'offerAtMost', units: simoleans(3) },
+      { kind: 'wantExactly', units: bucks(4) },
     ];
-    const extents = [5, 3, 0];
-    t.ok(isOfferSafeForOffer(extentOps, payoutRules, extents));
+    const units = [moola(5), simoleans(3), bucks(0)];
+    t.ok(isOfferSafeForOffer(unitOps, payoutRules, units));
   } catch (e) {
     t.assert(false, e);
   } finally {
@@ -255,14 +255,14 @@ test('isOfferSafeForOffer - more than offerAtMost', t => {
 // The user gets less than what they wanted - wantExactly
 test('isOfferSafeForOffer - less than wantExactly', t => {
   try {
-    const { extentOps, unitOps } = setup();
+    const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'offerExactly', units: unitOps[0].make(2) },
-      { kind: 'wantExactly', units: unitOps[1].make(3) },
-      { kind: 'wantExactly', units: unitOps[2].make(5) },
+      { kind: 'offerExactly', units: moola(2) },
+      { kind: 'wantExactly', units: simoleans(3) },
+      { kind: 'wantExactly', units: bucks(5) },
     ];
-    const extents = [0, 2, 1];
-    t.notOk(isOfferSafeForOffer(extentOps, payoutRules, extents));
+    const units = [moola(0), simoleans(2), bucks(1)];
+    t.notOk(isOfferSafeForOffer(unitOps, payoutRules, units));
   } catch (e) {
     t.assert(false, e);
   } finally {
@@ -273,14 +273,14 @@ test('isOfferSafeForOffer - less than wantExactly', t => {
 // The user gets less than what they wanted - wantAtLeast
 test('isOfferSafeForOffer - less than wantExactly', t => {
   try {
-    const { extentOps, unitOps } = setup();
+    const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'offerExactly', units: unitOps[0].make(2) },
-      { kind: 'wantAtLeast', units: unitOps[1].make(3) },
-      { kind: 'wantAtLeast', units: unitOps[2].make(9) },
+      { kind: 'offerExactly', units: moola(2) },
+      { kind: 'wantAtLeast', units: simoleans(3) },
+      { kind: 'wantAtLeast', units: bucks(9) },
     ];
-    const extents = [0, 2, 1];
-    t.notOk(isOfferSafeForOffer(extentOps, payoutRules, extents));
+    const units = [moola(0), simoleans(2), bucks(1)];
+    t.notOk(isOfferSafeForOffer(unitOps, payoutRules, units));
   } catch (e) {
     t.assert(false, e);
   } finally {
@@ -291,14 +291,14 @@ test('isOfferSafeForOffer - less than wantExactly', t => {
 // The user gets refunded less than they put in
 test('isOfferSafeForOffer - less than wantExactly', t => {
   try {
-    const { extentOps, unitOps } = setup();
+    const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'offerExactly', units: unitOps[0].make(2) },
-      { kind: 'wantAtLeast', units: unitOps[1].make(3) },
-      { kind: 'wantAtLeast', units: unitOps[2].make(3) },
+      { kind: 'offerExactly', units: moola(2) },
+      { kind: 'wantAtLeast', units: simoleans(3) },
+      { kind: 'wantAtLeast', units: bucks(3) },
     ];
-    const extents = [1, 0, 0];
-    t.notOk(isOfferSafeForOffer(extentOps, payoutRules, extents));
+    const units = [moola(1), simoleans(0), bucks(0)];
+    t.notOk(isOfferSafeForOffer(unitOps, payoutRules, units));
   } catch (e) {
     t.assert(false, e);
   } finally {
@@ -308,12 +308,12 @@ test('isOfferSafeForOffer - less than wantExactly', t => {
 
 test('isOfferSafeForOffer - empty arrays', t => {
   try {
-    const { extentOps } = setup();
+    const { unitOps } = setup();
     const payoutRules = [];
-    const extents = [];
+    const units = [];
     t.throws(
-      () => isOfferSafeForOffer(extentOps, payoutRules, extents),
-      /Error: extentOpsArray, the offer description, and extents must be arrays of the same length/,
+      () => isOfferSafeForOffer(unitOps, payoutRules, units),
+      /unitOpsArray, payoutRules, and units must be arrays of the same length/,
     );
   } catch (e) {
     t.assert(false, e);
@@ -324,15 +324,15 @@ test('isOfferSafeForOffer - empty arrays', t => {
 
 test('isOfferSafeForOffer - null for some assays', t => {
   try {
-    const { extentOps, unitOps } = setup();
+    const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'offerExactly', units: unitOps[0].make(2) },
+      { kind: 'offerExactly', units: moola(2) },
       null,
-      { kind: 'offerExactly', units: unitOps[2].make(4) },
+      { kind: 'offerExactly', units: bucks(4) },
     ];
-    const extents = [5, 6, 8];
+    const units = [moola(5), simoleans(6), bucks(8)];
     t.throws(
-      () => isOfferSafeForOffer(extentOps, payoutRules, extents),
+      () => isOfferSafeForOffer(unitOps, payoutRules, units),
       /payoutRule must be specified/,
     );
   } catch (e) {
@@ -343,19 +343,19 @@ test('isOfferSafeForOffer - null for some assays', t => {
 });
 
 // All users get exactly what they wanted
-test('isOfferSafeForAll - get wantExactly', t => {
+test('isOfferSafeForAll - All users get what they wanted', t => {
   try {
-    const { extentOps, unitOps } = setup();
+    const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'offerExactly', units: unitOps[0].make(2) },
-      { kind: 'wantExactly', units: unitOps[1].make(3) },
-      { kind: 'wantExactly', units: unitOps[2].make(3) },
+      { kind: 'offerExactly', units: moola(2) },
+      { kind: 'wantExactly', units: simoleans(3) },
+      { kind: 'wantExactly', units: bucks(3) },
     ];
 
     const offerMatrix = [payoutRules, payoutRules, payoutRules];
-    const extents = [0, 3, 3];
-    const extentsMatrix = [extents, extents, extents];
-    t.ok(isOfferSafeForAll(extentOps, offerMatrix, extentsMatrix));
+    const units = [moola(0), simoleans(3), bucks(3)];
+    const unitsMatrix = [units, units, units];
+    t.ok(isOfferSafeForAll(unitOps, offerMatrix, unitsMatrix));
   } catch (e) {
     t.assert(false, e);
   } finally {
@@ -363,25 +363,20 @@ test('isOfferSafeForAll - get wantExactly', t => {
   }
 });
 
-// One user doesn't get what they wanted
-test(`isOfferSafeForAll - get wantExactly - one doesn't`, t => {
+test(`isOfferSafeForAll - One user doesn't get what they wanted`, t => {
   try {
-    const { extentOps, unitOps } = setup();
+    const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'offerExactly', units: unitOps[0].make(2) },
-      { kind: 'wantExactly', units: unitOps[1].make(3) },
-      { kind: 'wantExactly', units: unitOps[2].make(3) },
+      { kind: 'offerExactly', units: moola(2) },
+      { kind: 'wantExactly', units: simoleans(3) },
+      { kind: 'wantExactly', units: bucks(3) },
     ];
 
     const offerMatrix = [payoutRules, payoutRules, payoutRules];
-    const extents = [0, 3, 3];
-    const unsatisfiedUserextents = [
-      unitOps[0].make(0),
-      unitOps[1].make(3),
-      unitOps[2].make(2),
-    ];
-    const extentsMatrix = [extents, extents, unsatisfiedUserextents];
-    t.notOk(isOfferSafeForAll(extentOps, offerMatrix, extentsMatrix));
+    const units = [moola(0), simoleans(3), bucks(3)];
+    const unsatisfiedUserUnits = [moola(0), simoleans(3), bucks(2)];
+    const unitsMatrix = [units, units, unsatisfiedUserUnits];
+    t.notOk(isOfferSafeForAll(unitOps, offerMatrix, unitsMatrix));
   } catch (e) {
     t.assert(false, e);
   } finally {


### PR DESCRIPTION
Change to using units, not extents, but only in `areRightsConserved` and `isOfferSafe`