### PR TITLE
[Zoe] BREAKING CHANGE: Reduce to two payout rule kinds: `offerAtMost` and `wantAtLeast`

### DIFF
--- a/packages/zoe/contracts/autoswap.js
+++ b/packages/zoe/contracts/autoswap.js
@@ -39,7 +39,7 @@ export const makeContract = harden((zoe, terms) => {
       poolOfferHandle = zoe.escrowEmptyOffer();
     }
 
-    const kinds = ['offerExactly', 'offerExactly', 'wantAtLeast'];
+    const kinds = ['offerAtMost', 'offerAtMost', 'wantAtLeast'];
     if (!hasValidPayoutRules(kinds, assays, payoutRules)) {
       return rejectOffer(
         zoe,
@@ -82,7 +82,7 @@ export const makeContract = harden((zoe, terms) => {
     const newPayment = newPurse.withdrawAll();
     liqTokenSupply += liquidityEOut;
 
-    const liquidityOfferKinds = ['wantAtLeast', 'wantAtLeast', 'offerExactly'];
+    const liquidityOfferKinds = ['wantAtLeast', 'wantAtLeast', 'offerAtMost'];
     const extents = [
       extentOpsArray[0].empty(),
       extentOpsArray[1].empty(),
@@ -120,7 +120,7 @@ export const makeContract = harden((zoe, terms) => {
     } = await zoe.burnEscrowReceipt(escrowReceipt);
     const extentOpsArray = zoe.getExtentOpsArray();
 
-    const kinds = ['wantAtLeast', 'wantAtLeast', 'offerExactly'];
+    const kinds = ['wantAtLeast', 'wantAtLeast', 'offerAtMost'];
     if (!hasValidPayoutRules(kinds, assays, payoutRules)) {
       return rejectOffer(
         zoe,
@@ -248,7 +248,7 @@ export const makeContract = harden((zoe, terms) => {
     const [tokenAPoolE, tokenBPoolE] = poolExtents;
 
     // offer token A, want token B
-    const kindsOfferFirst = ['offerExactly', 'wantAtLeast', 'wantAtLeast'];
+    const kindsOfferFirst = ['offerAtMost', 'wantAtLeast', 'wantAtLeast'];
     if (hasValidPayoutRules(kindsOfferFirst, assays, payoutRules)) {
       const [tokenInE, wantAtLeastE] = playerExtents;
       const { tokenOutE, newTokenInPoolE, newTokenOutPoolE } = calculateSwap(
@@ -276,7 +276,7 @@ export const makeContract = harden((zoe, terms) => {
     }
 
     // want token A, offer token B
-    const kindsWantFirst = ['wantAtLeast', 'offerExactly', 'wantAtLeast'];
+    const kindsWantFirst = ['wantAtLeast', 'offerAtMost', 'wantAtLeast'];
     if (hasValidPayoutRules(kindsWantFirst, assays, payoutRules)) {
       const [wantAtLeastE, tokenInE] = playerExtents;
       const { tokenOutE, newTokenInPoolE, newTokenOutPoolE } = calculateSwap(

--- a/packages/zoe/contracts/autoswap.js
+++ b/packages/zoe/contracts/autoswap.js
@@ -89,7 +89,7 @@ export const makeContract = harden((zoe, terms) => {
       liquidityEOut,
     ];
     const exitRule = {
-      kind: 'noExit',
+      kind: 'waived',
     };
     const liquidityOfferRules = makeOfferRules(
       zoe,

--- a/packages/zoe/contracts/coveredCall.js
+++ b/packages/zoe/contracts/coveredCall.js
@@ -45,7 +45,7 @@ export const makeContract = harden((zoe, terms) => {
       );
       const { payoutRules } = offerRules;
 
-      const ruleKinds = ['offerExactly', 'wantExactly'];
+      const ruleKinds = ['offerAtMost', 'wantAtLeast'];
       if (!hasValidPayoutRules(ruleKinds, terms.assays, payoutRules)) {
         return rejectOffer(zoe, offerHandle);
       }

--- a/packages/zoe/contracts/helpers/offerRules.js
+++ b/packages/zoe/contracts/helpers/offerRules.js
@@ -9,7 +9,7 @@ export const isExactlyMatchingPayoutRules = (
   // "exactly matching" means that units are the same, but that the
   // kinds have switched places in the array
   const extentOpsArray = zoe.getExtentOpsArray();
-  const exactlyKinds = ['wantExactly', 'offerExactly'];
+  const exactlyKinds = ['wantAtLeast', 'offerAtMost'];
   return (
     // Are the extents equal according to the extentOps?
     extentOpsArray[0].equals(

--- a/packages/zoe/contracts/myFirstDapp.js
+++ b/packages/zoe/contracts/myFirstDapp.js
@@ -36,8 +36,8 @@ export const makeContract = harden((zoe, terms) => {
   // Let's make sure the swap offer that we get has the correct
   // structure.
   const isValidSimpleSwapOffer = myPayoutRules => {
-    const kindsOfferFirst = ['offerExactly', 'wantAtLeast', 'wantAtLeast'];
-    const kindsWantFirst = ['wantAtLeast', 'offerExactly', 'wantAtLeast'];
+    const kindsOfferFirst = ['offerAtMost', 'wantAtLeast', 'wantAtLeast'];
+    const kindsWantFirst = ['wantAtLeast', 'offerAtMost', 'wantAtLeast'];
     return (
       hasValidPayoutRules(kindsOfferFirst, assays, myPayoutRules) ||
       hasValidPayoutRules(kindsWantFirst, assays, myPayoutRules)

--- a/packages/zoe/contracts/publicAuction.js
+++ b/packages/zoe/contracts/publicAuction.js
@@ -27,7 +27,7 @@ export const makeContract = harden((zoe, terms) => {
         offerRules: { payoutRules },
       } = await zoe.burnEscrowReceipt(escrowReceipt);
 
-      const ruleKinds = ['offerExactly', 'wantAtLeast'];
+      const ruleKinds = ['offerAtMost', 'wantAtLeast'];
       if (
         creatorOfferHandle ||
         !hasValidPayoutRules(ruleKinds, terms.assays, payoutRules)
@@ -63,7 +63,7 @@ export const makeContract = harden((zoe, terms) => {
         return rejectOffer(zoe, offerHandle, `No further bids allowed.`);
       }
 
-      const ruleKinds = ['wantExactly', 'offerAtMost'];
+      const ruleKinds = ['wantAtLeast', 'offerAtMost'];
       if (!hasValidPayoutRules(ruleKinds, terms.assays, payoutRules)) {
         return rejectOffer(zoe, offerHandle);
       }

--- a/packages/zoe/contracts/publicSwap.js
+++ b/packages/zoe/contracts/publicSwap.js
@@ -17,7 +17,7 @@ export const makeContract = harden((zoe, terms) => {
         offerRules: { payoutRules },
       } = await zoe.burnEscrowReceipt(escrowReceipt);
 
-      const ruleKinds = ['offerExactly', 'wantExactly'];
+      const ruleKinds = ['offerAtMost', 'wantAtLeast'];
       if (!hasValidPayoutRules(ruleKinds, terms.assays, payoutRules)) {
         return rejectOffer(zoe, offerHandle);
       }

--- a/packages/zoe/contracts/simpleExchange.js
+++ b/packages/zoe/contracts/simpleExchange.js
@@ -11,9 +11,9 @@ import {
 } from './helpers/exchanges';
 
 // This exchange only accepts limit orders. A limit order is defined
-// as either a sell order with payoutRules: [ { kind: 'offerExactly',
+// as either a sell order with payoutRules: [ { kind: 'offerAtMost',
 // units1 }, {kind: 'wantAtLeast', units2 }] or a buy order:
-// [ { kind: 'wantExactly', units1 }, { kind: 'offerAtMost',
+// [ { kind: 'wantAtLeast', units1 }, { kind: 'offerAtMost',
 // units2 }]. Note that the asset in the first slot of the
 // payoutRules will always be bought or sold in exact amounts, whereas
 // the amount of the second asset received in a sell order may be
@@ -33,7 +33,7 @@ export const makeContract = harden((zoe, terms) => {
       } = await zoe.burnEscrowReceipt(escrowReceipt);
 
       // Is it a valid sell offer?
-      const sellOfferKinds = ['offerExactly', 'wantAtLeast'];
+      const sellOfferKinds = ['offerAtMost', 'wantAtLeast'];
       if (hasValidPayoutRules(sellOfferKinds, terms.assays, payoutRules)) {
         // Save the valid offer
         sellOfferHandles.push(offerHandle);
@@ -52,7 +52,7 @@ export const makeContract = harden((zoe, terms) => {
       }
 
       // Is it a valid buy offer?
-      const buyOfferFormat = ['wantExactly', 'offerAtMost'];
+      const buyOfferFormat = ['wantAtLeast', 'offerAtMost'];
       if (hasValidPayoutRules(buyOfferFormat, terms.assays, payoutRules)) {
         // Save the valid offer
         buyOfferHandles.push(offerHandle);

--- a/packages/zoe/isOfferSafe.js
+++ b/packages/zoe/isOfferSafe.js
@@ -29,12 +29,7 @@ function isOfferSafeForOffer(unitOpsArray, payoutRules, units) {
       unitOpsArray.length === units.length,
   )`unitOpsArray, payoutRules, and units must be arrays of the same length`;
 
-  const allowedRules = [
-    'offerExactly',
-    'offerAtMost',
-    'wantExactly',
-    'wantAtLeast',
-  ];
+  const allowedRules = ['offerAtMost', 'wantAtLeast'];
 
   for (const payoutRule of payoutRules) {
     if (payoutRule === null || payoutRule === undefined) {
@@ -49,10 +44,7 @@ function isOfferSafeForOffer(unitOpsArray, payoutRules, units) {
   // units must be greater than or equal to what was originally
   // offered.
   const refundOk = payoutRules.every((payoutRule, i) => {
-    if (payoutRule.kind === 'offerExactly') {
-      return unitOpsArray[i].equals(units[i], payoutRule.units);
-    }
-    if (payoutRules.kind === 'offerAtMost') {
+    if (payoutRule.kind === 'offerAtMost') {
       return unitOpsArray[i].includes(units[i], payoutRule.units);
     }
     // If the kind is 'want', anything we give back is fine for a refund.
@@ -63,9 +55,6 @@ function isOfferSafeForOffer(unitOpsArray, payoutRules, units) {
   // wanted, their allocated units must be greater than or equal to
   // what the payoutRules said they wanted.
   const winningsOk = payoutRules.every((payoutRule, i) => {
-    if (payoutRule.kind === 'wantExactly') {
-      return unitOpsArray[i].equals(units[i], payoutRule.units);
-    }
     if (payoutRule.kind === 'wantAtLeast') {
       return unitOpsArray[i].includes(units[i], payoutRule.units);
     }

--- a/packages/zoe/state.js
+++ b/packages/zoe/state.js
@@ -97,7 +97,7 @@ const makeOfferTable = () => {
   };
   const insistValidExitRule = exitRule => {
     const acceptedExitRuleKinds = [
-      'noExit',
+      'waived',
       'onDemand',
       'afterDeadline',
       // 'onDemandAfterDeadline', // not yet supported

--- a/packages/zoe/state.js
+++ b/packages/zoe/state.js
@@ -88,12 +88,7 @@ const makeInstanceTable = () => {
 // | units | extents
 const makeOfferTable = () => {
   const insistValidPayoutRuleKinds = payoutRules => {
-    const acceptedKinds = [
-      'offerExactly',
-      'offerAtMost',
-      'wantExactly',
-      'wantAtLeast',
-    ];
+    const acceptedKinds = ['offerAtMost', 'wantAtLeast'];
     for (const payoutRule of payoutRules) {
       insist(
         acceptedKinds.includes(payoutRule.kind),

--- a/packages/zoe/test/swingsetTests/zoe/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-alice.js
@@ -25,11 +25,11 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
     const offerRules = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: await E(assays[0]).makeUnits(3),
         },
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: await E(assays[1]).makeUnits(7),
         },
       ],
@@ -71,11 +71,11 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
     const offerRules = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: await E(assays[0]).makeUnits(3),
         },
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: await E(assays[1]).makeUnits(7),
         },
       ],
@@ -118,7 +118,7 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
     const offerRules = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: await E(assays[0]).makeUnits(1),
         },
         {
@@ -169,11 +169,11 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
     const offerRules = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: await E(assays[0]).makeUnits(3),
         },
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: await E(assays[1]).makeUnits(7),
         },
       ],
@@ -214,7 +214,7 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
     const aliceSellOrderOfferRules = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: await E(assays[0]).makeUnits(3),
         },
         {
@@ -265,11 +265,11 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
     const addLiquidityOfferRules = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: await E(allAssays[0]).makeUnits(10),
         },
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: await E(allAssays[1]).makeUnits(5),
         },
         {
@@ -312,7 +312,7 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
           units: await E(allAssays[1]).makeUnits(0),
         },
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: await E(allAssays[2]).makeUnits(10),
         },
       ],

--- a/packages/zoe/test/swingsetTests/zoe/vat-bob.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-bob.js
@@ -41,11 +41,11 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
       const bobOfferRules = harden({
         payoutRules: [
           {
-            kind: 'wantExactly',
+            kind: 'wantAtLeast',
             units: await E(assays[0]).makeUnits(15),
           },
           {
-            kind: 'offerExactly',
+            kind: 'offerAtMost',
             units: await E(assays[1]).makeUnits(17),
           },
         ],
@@ -93,11 +93,11 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
       const bobIntendedOfferRules = harden({
         payoutRules: [
           {
-            kind: 'wantExactly',
+            kind: 'wantAtLeast',
             units: await E(assays[0]).makeUnits(3),
           },
           {
-            kind: 'offerExactly',
+            kind: 'offerAtMost',
             units: await E(assays[1]).makeUnits(7),
           },
         ],
@@ -169,7 +169,7 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
       const offerRules = harden({
         payoutRules: [
           {
-            kind: 'wantExactly',
+            kind: 'wantAtLeast',
             units: await E(assays[0]).makeUnits(1),
           },
           {
@@ -216,11 +216,11 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
       const firstPayoutRules = await E(swap).getFirstPayoutRules();
       const expectedFirstPayoutRules = harden([
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: await E(assays[0]).makeUnits(3),
         },
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: await E(assays[1]).makeUnits(7),
         },
       ]);
@@ -231,11 +231,11 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
       const offerRules = harden({
         payoutRules: [
           {
-            kind: 'wantExactly',
+            kind: 'wantAtLeast',
             units: await E(assays[0]).makeUnits(3),
           },
           {
-            kind: 'offerExactly',
+            kind: 'offerAtMost',
             units: await E(assays[1]).makeUnits(7),
           },
         ],
@@ -278,7 +278,7 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
       const bobBuyOrderOfferRules = harden({
         payoutRules: [
           {
-            kind: 'wantExactly',
+            kind: 'wantAtLeast',
             units: await E(assays[0]).makeUnits(3),
           },
           {
@@ -338,7 +338,7 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
       const moolaForSimOfferRules = harden({
         payoutRules: [
           {
-            kind: 'offerExactly',
+            kind: 'offerAtMost',
             units: await E(allAssays[0]).makeUnits(2),
           },
           {
@@ -384,7 +384,7 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
             units: await E(allAssays[0]).makeUnits(6),
           },
           {
-            kind: 'offerExactly',
+            kind: 'offerAtMost',
             units: await E(allAssays[1]).makeUnits(3),
           },
           {

--- a/packages/zoe/test/swingsetTests/zoe/vat-carol.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-carol.js
@@ -28,7 +28,7 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
       const offerRules = harden({
         payoutRules: [
           {
-            kind: 'wantExactly',
+            kind: 'wantAtLeast',
             units: await E(assays[0]).makeUnits(1),
           },
           {

--- a/packages/zoe/test/swingsetTests/zoe/vat-dave.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-dave.js
@@ -28,7 +28,7 @@ const build = async (E, log, zoe, moolaPurseP, simoleanPurseP, installId) => {
       const offerRules = harden({
         payoutRules: [
           {
-            kind: 'wantExactly',
+            kind: 'wantAtLeast',
             units: await E(assays[0]).makeUnits(1),
           },
           {

--- a/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
+++ b/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
@@ -32,7 +32,7 @@ test('zoe - simplest automaticRefund', async t => {
     const aliceOfferRules = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: moolaAssay.makeUnits(3),
         },
       ],
@@ -155,11 +155,11 @@ test('zoe with automaticRefund', async t => {
     const aliceOfferRules = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: assays[0].makeUnits(3),
         },
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: assays[1].makeUnits(7),
         },
       ],
@@ -215,11 +215,11 @@ test('zoe with automaticRefund', async t => {
     const bobOfferRules = harden({
       payoutRules: [
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: bobAssays[0].makeUnits(15),
         },
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: bobAssays[1].makeUnits(17),
         },
       ],
@@ -326,11 +326,11 @@ test('multiple instances of automaticRefund for the same Zoe', async t => {
     const aliceOfferRules = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: assays[0].makeUnits(10),
         },
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: assays[1].makeUnits(7),
         },
       ],
@@ -397,11 +397,11 @@ test('zoe - alice cancels before entering a contract', async t => {
     const aliceOfferRules = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: assays[0].makeUnits(3),
         },
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: assays[1].makeUnits(7),
         },
       ],
@@ -478,11 +478,11 @@ test('zoe - alice cancels after completion', async t => {
     const aliceOfferRules = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: assays[0].makeUnits(3),
         },
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: assays[1].makeUnits(7),
         },
       ],

--- a/packages/zoe/test/unitTests/contracts/test-autoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-autoswap.js
@@ -53,11 +53,11 @@ test('autoSwap with valid offers', async t => {
     const aliceOfferRules = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: allAssays[0].makeUnits(10),
         },
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: allAssays[1].makeUnits(5),
         },
         {
@@ -115,7 +115,7 @@ test('autoSwap with valid offers', async t => {
     const bobMoolaForSimOfferRules = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: allAssays[0].makeUnits(2),
         },
         {
@@ -167,7 +167,7 @@ test('autoSwap with valid offers', async t => {
           units: allAssays[0].makeUnits(6),
         },
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: allAssays[1].makeUnits(3),
         },
         {
@@ -210,7 +210,7 @@ test('autoSwap with valid offers', async t => {
           units: allAssays[1].makeUnits(0),
         },
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: allAssays[2].makeUnits(10),
         },
       ],
@@ -294,11 +294,11 @@ test('autoSwap - test fee', async t => {
     const aliceOfferRules = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: allAssays[0].makeUnits(10000),
         },
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: allAssays[1].makeUnits(10000),
         },
         {
@@ -352,7 +352,7 @@ test('autoSwap - test fee', async t => {
     const bobMoolaForSimOfferRules = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: allAssays[0].makeUnits(1000),
         },
         {

--- a/packages/zoe/test/unitTests/contracts/test-coveredCall.js
+++ b/packages/zoe/test/unitTests/contracts/test-coveredCall.js
@@ -49,11 +49,11 @@ test('zoe - coveredCall', async t => {
     const aliceOfferRules = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: assays[0].makeUnits(3),
         },
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: assays[1].makeUnits(7),
         },
       ],
@@ -90,11 +90,11 @@ test('zoe - coveredCall', async t => {
     );
     t.deepEquals(bobInvitePayment.getBalance().extent.offerToBeMade, [
       {
-        kind: 'wantExactly',
+        kind: 'wantAtLeast',
         units: assays[0].makeUnits(3),
       },
       {
-        kind: 'offerExactly',
+        kind: 'offerAtMost',
         units: assays[1].makeUnits(7),
       },
     ]);
@@ -109,11 +109,11 @@ test('zoe - coveredCall', async t => {
     const bobIntendedOfferRules = harden({
       payoutRules: [
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: assays[0].makeUnits(3),
         },
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: assays[1].makeUnits(7),
         },
       ],
@@ -241,11 +241,11 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
     const aliceOfferRules = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: assays[0].makeUnits(3),
         },
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: assays[1].makeUnits(7),
         },
       ],
@@ -284,11 +284,11 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
     );
     t.deepEquals(bobInvitePayment.getBalance().extent.offerToBeMade, [
       {
-        kind: 'wantExactly',
+        kind: 'wantAtLeast',
         units: assays[0].makeUnits(3),
       },
       {
-        kind: 'offerExactly',
+        kind: 'offerAtMost',
         units: assays[1].makeUnits(7),
       },
     ]);
@@ -305,11 +305,11 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
     const bobIntendedOfferRules = harden({
       payoutRules: [
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: assays[0].makeUnits(3),
         },
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: assays[1].makeUnits(7),
         },
       ],
@@ -452,11 +452,11 @@ test('zoe - coveredCall with swap for invite', async t => {
     const aliceOfferRules = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: assays[0].makeUnits(3),
         },
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: assays[1].makeUnits(7),
         },
       ],
@@ -527,11 +527,11 @@ test('zoe - coveredCall with swap for invite', async t => {
     const bobExpectationsOfAliceOfferRules = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: assays[0].makeUnits(3),
         },
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: assays[1].makeUnits(7),
         },
       ],
@@ -553,11 +553,11 @@ test('zoe - coveredCall with swap for invite', async t => {
     const bobOfferRulesCoveredCall = harden({
       payoutRules: [
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: assays[0].makeUnits(3),
         },
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: assays[1].makeUnits(7),
         },
       ],
@@ -592,11 +592,11 @@ test('zoe - coveredCall with swap for invite', async t => {
     const bobOfferRulesSwap = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: bobExclInvitePayment.getBalance(),
         },
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: bucksAssay.makeUnits(1),
         },
       ],
@@ -660,11 +660,11 @@ test('zoe - coveredCall with swap for invite', async t => {
     const daveSwapOfferRules = harden({
       payoutRules: [
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: bobOfferRulesSwap.payoutRules[0].units,
         },
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: bucksAssay.makeUnits(1),
         },
       ],
@@ -697,11 +697,11 @@ test('zoe - coveredCall with swap for invite', async t => {
     const daveCoveredCallOfferRules = harden({
       payoutRules: [
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: moolaAssay.makeUnits(3),
         },
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: simoleanAssay.makeUnits(7),
         },
       ],
@@ -829,11 +829,11 @@ test('zoe - coveredCall with coveredCall for invite', async t => {
     const aliceOfferRules = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: assays[0].makeUnits(3),
         },
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: assays[1].makeUnits(7),
         },
       ],
@@ -904,11 +904,11 @@ test('zoe - coveredCall with coveredCall for invite', async t => {
     const bobExpectationsOfAliceOfferRules = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: assays[0].makeUnits(3),
         },
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: assays[1].makeUnits(7),
         },
       ],
@@ -930,11 +930,11 @@ test('zoe - coveredCall with coveredCall for invite', async t => {
     const bobOfferRulesCoveredCall = harden({
       payoutRules: [
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: assays[0].makeUnits(3),
         },
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: assays[1].makeUnits(7),
         },
       ],
@@ -973,11 +973,11 @@ test('zoe - coveredCall with coveredCall for invite', async t => {
     const bobOfferRulesSecondCoveredCall = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: firstCoveredCallInviteAssetDec,
         },
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: bucksAssay.makeUnits(1),
         },
       ],
@@ -1041,11 +1041,11 @@ test('zoe - coveredCall with coveredCall for invite', async t => {
     const daveExpectationsOfBobOfferRules = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: firstCoveredCallInviteAssetDec,
         },
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: bucksAssay.makeUnits(1),
         },
       ],
@@ -1067,11 +1067,11 @@ test('zoe - coveredCall with coveredCall for invite', async t => {
     const daveOfferRulesCoveredCall = harden({
       payoutRules: [
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: firstCoveredCallInviteAssetDec,
         },
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: bucksAssay.makeUnits(1),
         },
       ],
@@ -1123,11 +1123,11 @@ test('zoe - coveredCall with coveredCall for invite', async t => {
     const daveFirstCoveredCallOfferRules = harden({
       payoutRules: [
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: moolaAssay.makeUnits(3),
         },
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: simoleanAssay.makeUnits(7),
         },
       ],

--- a/packages/zoe/test/unitTests/contracts/test-myFirstDapp.js
+++ b/packages/zoe/test/unitTests/contracts/test-myFirstDapp.js
@@ -39,11 +39,11 @@ test('myFirstDapp with valid offers', async t => {
     const aliceOfferRules = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: allAssays[0].makeUnits(1),
         },
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: allAssays[1].makeUnits(1),
         },
         {
@@ -84,7 +84,7 @@ test('myFirstDapp with valid offers', async t => {
     const bobMoolaForSimOfferRules = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: allAssays[0].makeUnits(1),
         },
         {
@@ -128,7 +128,7 @@ test('myFirstDapp with valid offers', async t => {
           units: assays[0].makeUnits(1),
         },
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: assays[1].makeUnits(1),
         },
         {

--- a/packages/zoe/test/unitTests/contracts/test-publicAuction.js
+++ b/packages/zoe/test/unitTests/contracts/test-publicAuction.js
@@ -50,7 +50,7 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
     const aliceOfferRules = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: assays[0].makeUnits(1),
         },
         {
@@ -105,7 +105,7 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
     const bobOfferRules = harden({
       payoutRules: [
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: assays[0].makeUnits(1),
         },
         {
@@ -153,7 +153,7 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
     const carolOfferRules = harden({
       payoutRules: [
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: assays[0].makeUnits(1),
         },
         {
@@ -193,7 +193,7 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
     const daveOfferRules = harden({
       payoutRules: [
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: assays[0].makeUnits(1),
         },
         {
@@ -340,7 +340,7 @@ test('zoe - secondPriceAuction w/ 3 bids - alice exits onDemand', async t => {
     const aliceOfferRules = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: assays[0].makeUnits(1),
         },
         {
@@ -394,7 +394,7 @@ test('zoe - secondPriceAuction w/ 3 bids - alice exits onDemand', async t => {
     const bobOfferRules = harden({
       payoutRules: [
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: assays[0].makeUnits(1),
         },
         {
@@ -440,7 +440,7 @@ test('zoe - secondPriceAuction w/ 3 bids - alice exits onDemand', async t => {
     const carolOfferRules = harden({
       payoutRules: [
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: assays[0].makeUnits(1),
         },
         {
@@ -478,7 +478,7 @@ test('zoe - secondPriceAuction w/ 3 bids - alice exits onDemand', async t => {
     const daveOfferRules = harden({
       payoutRules: [
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: assays[0].makeUnits(1),
         },
         {

--- a/packages/zoe/test/unitTests/contracts/test-publicSwap.js
+++ b/packages/zoe/test/unitTests/contracts/test-publicSwap.js
@@ -38,11 +38,11 @@ test('zoe - publicSwap', async t => {
     const aliceOfferRules = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: assays[0].makeUnits(3),
         },
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: assays[1].makeUnits(7),
         },
       ],
@@ -84,11 +84,11 @@ test('zoe - publicSwap', async t => {
     const bobOfferRules = harden({
       payoutRules: [
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: bobTerms.assays[0].makeUnits(3),
         },
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: bobTerms.assays[1].makeUnits(7),
         },
       ],

--- a/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
+++ b/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
@@ -40,7 +40,7 @@ test('zoe - simpleExchange', async t => {
     const aliceSellOrderOfferRules = harden({
       payoutRules: [
         {
-          kind: 'offerExactly',
+          kind: 'offerAtMost',
           units: assays[0].makeUnits(3),
         },
         {
@@ -85,7 +85,7 @@ test('zoe - simpleExchange', async t => {
     const bobBuyOrderOfferRules = harden({
       payoutRules: [
         {
-          kind: 'wantExactly',
+          kind: 'wantAtLeast',
           units: bobTerms.assays[0].makeUnits(3),
         },
         {

--- a/packages/zoe/test/unitTests/test-isOfferSafe.js
+++ b/packages/zoe/test/unitTests/test-isOfferSafe.js
@@ -26,9 +26,9 @@ test('isOfferSafeForOffer - empty units', t => {
   try {
     const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'wantExactly', units: moola(8) },
-      { kind: 'wantExactly', units: simoleans(6) },
-      { kind: 'wantExactly', units: bucks(7) },
+      { kind: 'wantAtLeast', units: moola(8) },
+      { kind: 'wantAtLeast', units: simoleans(6) },
+      { kind: 'wantAtLeast', units: bucks(7) },
     ];
     const units = [];
 
@@ -49,9 +49,9 @@ test('isOfferSafeForOffer - gets want exactly', t => {
   try {
     const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'offerExactly', units: moola(8) },
-      { kind: 'wantExactly', units: simoleans(6) },
-      { kind: 'wantExactly', units: bucks(7) },
+      { kind: 'offerAtMost', units: moola(8) },
+      { kind: 'wantAtLeast', units: simoleans(6) },
+      { kind: 'wantAtLeast', units: bucks(7) },
     ];
     const units = [moola(0), simoleans(6), bucks(7)];
 
@@ -64,13 +64,13 @@ test('isOfferSafeForOffer - gets want exactly', t => {
 });
 
 // The player gets exactly what they wanted, with no 'offer'
-test('isOfferSafeForOffer - gets wantExactly', t => {
+test('isOfferSafeForOffer - gets wantAtLeast', t => {
   try {
     const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'wantExactly', units: moola(8) },
-      { kind: 'wantExactly', units: simoleans(6) },
-      { kind: 'wantExactly', units: bucks(7) },
+      { kind: 'wantAtLeast', units: moola(8) },
+      { kind: 'wantAtLeast', units: simoleans(6) },
+      { kind: 'wantAtLeast', units: bucks(7) },
     ];
     const units = [moola(8), simoleans(6), bucks(7)];
 
@@ -86,13 +86,13 @@ test('isOfferSafeForOffer - gets wantExactly', t => {
 // kind. Note: This returns 'true' counterintuitively because no
 // 'offer' rule kind was specified and none were given back, so the
 // refund condition was fulfilled trivially.
-test('isOfferSafeForOffer - gets wantExactly', t => {
+test('isOfferSafeForOffer - gets wantAtLeast', t => {
   try {
     const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'wantExactly', units: moola(8) },
-      { kind: 'wantExactly', units: simoleans(6) },
-      { kind: 'wantExactly', units: bucks(7) },
+      { kind: 'wantAtLeast', units: moola(8) },
+      { kind: 'wantAtLeast', units: simoleans(6) },
+      { kind: 'wantAtLeast', units: bucks(7) },
     ];
     const units = [moola(9), simoleans(6), bucks(7)];
 
@@ -104,14 +104,14 @@ test('isOfferSafeForOffer - gets wantExactly', t => {
   }
 });
 
-// The user gets refunded exactly what they put in, with a 'wantExactly'
-test(`isOfferSafeForOffer - gets offerExactly, doesn't get wantExactly`, t => {
+// The user gets refunded exactly what they put in, with a 'wantAtLeast'
+test(`isOfferSafeForOffer - gets offerAtMost, doesn't get wantAtLeast`, t => {
   try {
     const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'offerExactly', units: moola(1) },
-      { kind: 'wantExactly', units: simoleans(2) },
-      { kind: 'offerExactly', units: bucks(3) },
+      { kind: 'offerAtMost', units: moola(1) },
+      { kind: 'wantAtLeast', units: simoleans(2) },
+      { kind: 'offerAtMost', units: bucks(3) },
     ];
     const units = [moola(1), simoleans(0), bucks(3)];
 
@@ -123,14 +123,14 @@ test(`isOfferSafeForOffer - gets offerExactly, doesn't get wantExactly`, t => {
   }
 });
 
-// The user gets refunded exactly what they put in, with no 'wantExactly'
-test('isOfferSafeForOffer - gets offerExactly, no wantExactly', t => {
+// The user gets refunded exactly what they put in, with no 'wantAtLeast'
+test('isOfferSafeForOffer - gets offerAtMost, no wantAtLeast', t => {
   try {
     const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'offerExactly', units: moola(1) },
-      { kind: 'offerExactly', units: simoleans(2) },
-      { kind: 'offerExactly', units: bucks(3) },
+      { kind: 'offerAtMost', units: moola(1) },
+      { kind: 'offerAtMost', units: simoleans(2) },
+      { kind: 'offerAtMost', units: bucks(3) },
     ];
     const units = [moola(1), simoleans(2), bucks(3)];
 
@@ -147,9 +147,9 @@ test('isOfferSafeForOffer - refund and winnings', t => {
   try {
     const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'offerExactly', units: moola(2) },
-      { kind: 'wantExactly', units: simoleans(3) },
-      { kind: 'wantExactly', units: bucks(3) },
+      { kind: 'offerAtMost', units: moola(2) },
+      { kind: 'wantAtLeast', units: simoleans(3) },
+      { kind: 'wantAtLeast', units: bucks(3) },
     ];
     const units = [moola(2), simoleans(3), bucks(3)];
     t.ok(isOfferSafeForOffer(unitOps, payoutRules, units));
@@ -161,16 +161,16 @@ test('isOfferSafeForOffer - refund and winnings', t => {
 });
 
 // The user gets more than they wanted
-test('isOfferSafeForOffer - more than wantExactly', t => {
+test('isOfferSafeForOffer - more than wantAtLeast', t => {
   try {
     const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'offerExactly', units: moola(2) },
-      { kind: 'wantExactly', units: simoleans(3) },
-      { kind: 'wantExactly', units: bucks(4) },
+      { kind: 'offerAtMost', units: moola(2) },
+      { kind: 'wantAtLeast', units: simoleans(3) },
+      { kind: 'wantAtLeast', units: bucks(4) },
     ];
     const units = [moola(0), simoleans(3), bucks(5)];
-    t.notOk(isOfferSafeForOffer(unitOps, payoutRules, units));
+    t.ok(isOfferSafeForOffer(unitOps, payoutRules, units));
   } catch (e) {
     t.assert(false, e);
   } finally {
@@ -179,7 +179,7 @@ test('isOfferSafeForOffer - more than wantExactly', t => {
 });
 
 // The user gets more than they wanted - wantAtLeast
-test('isOfferSafeForOffer - more than wantAtLeast', t => {
+test('isOfferSafeForOffer - more than wantAtLeast (no offerAtMost)', t => {
   try {
     const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
@@ -197,16 +197,16 @@ test('isOfferSafeForOffer - more than wantAtLeast', t => {
 });
 
 // The user gets refunded more than what they put in
-test('isOfferSafeForOffer - more than offerExactly', t => {
+test('isOfferSafeForOffer - more than offerAtMost', t => {
   try {
     const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'offerExactly', units: moola(2) },
-      { kind: 'offerExactly', units: simoleans(3) },
-      { kind: 'wantExactly', units: bucks(4) },
+      { kind: 'offerAtMost', units: moola(2) },
+      { kind: 'offerAtMost', units: simoleans(3) },
+      { kind: 'wantAtLeast', units: bucks(4) },
     ];
     const units = [moola(5), simoleans(6), bucks(8)];
-    t.notOk(isOfferSafeForOffer(unitOps, payoutRules, units));
+    t.ok(isOfferSafeForOffer(unitOps, payoutRules, units));
   } catch (e) {
     t.assert(false, e);
   } finally {
@@ -215,15 +215,15 @@ test('isOfferSafeForOffer - more than offerExactly', t => {
 });
 
 // The user gets refunded more than what they put in, with no
-// wantExactly. Note: This returns 'true' counterintuitively
+// wantAtLeast. Note: This returns 'true' counterintuitively
 // because no winnings were specified and none were given back.
-test('isOfferSafeForOffer - more than offerExactly, no wants', t => {
+test('isOfferSafeForOffer - more than offerAtMost, no wants', t => {
   try {
     const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'offerExactly', units: moola(2) },
-      { kind: 'offerExactly', units: simoleans(3) },
-      { kind: 'offerExactly', units: bucks(4) },
+      { kind: 'offerAtMost', units: moola(2) },
+      { kind: 'offerAtMost', units: simoleans(3) },
+      { kind: 'offerAtMost', units: bucks(4) },
     ];
     const units = [moola(5), simoleans(6), bucks(8)];
     t.ok(isOfferSafeForOffer(unitOps, payoutRules, units));
@@ -241,7 +241,7 @@ test('isOfferSafeForOffer - more than offer', t => {
     const payoutRules = [
       { kind: 'offerAtMost', units: moola(2) },
       { kind: 'offerAtMost', units: simoleans(3) },
-      { kind: 'wantExactly', units: bucks(4) },
+      { kind: 'wantAtLeast', units: bucks(4) },
     ];
     const units = [moola(5), simoleans(3), bucks(0)];
     t.ok(isOfferSafeForOffer(unitOps, payoutRules, units));
@@ -252,14 +252,14 @@ test('isOfferSafeForOffer - more than offer', t => {
   }
 });
 
-// The user gets less than what they wanted - wantExactly
-test('isOfferSafeForOffer - less than wantExactly', t => {
+// The user gets less than what they wanted - wantAtLeast
+test('isOfferSafeForOffer - less than wantAtLeast', t => {
   try {
     const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'offerExactly', units: moola(2) },
-      { kind: 'wantExactly', units: simoleans(3) },
-      { kind: 'wantExactly', units: bucks(5) },
+      { kind: 'offerAtMost', units: moola(2) },
+      { kind: 'wantAtLeast', units: simoleans(3) },
+      { kind: 'wantAtLeast', units: bucks(5) },
     ];
     const units = [moola(0), simoleans(2), bucks(1)];
     t.notOk(isOfferSafeForOffer(unitOps, payoutRules, units));
@@ -271,11 +271,11 @@ test('isOfferSafeForOffer - less than wantExactly', t => {
 });
 
 // The user gets less than what they wanted - wantAtLeast
-test('isOfferSafeForOffer - less than wantExactly', t => {
+test('isOfferSafeForOffer - less than wantAtLeast', t => {
   try {
     const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'offerExactly', units: moola(2) },
+      { kind: 'offerAtMost', units: moola(2) },
       { kind: 'wantAtLeast', units: simoleans(3) },
       { kind: 'wantAtLeast', units: bucks(9) },
     ];
@@ -289,11 +289,11 @@ test('isOfferSafeForOffer - less than wantExactly', t => {
 });
 
 // The user gets refunded less than they put in
-test('isOfferSafeForOffer - less than wantExactly', t => {
+test('isOfferSafeForOffer - less than wantAtLeast', t => {
   try {
     const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'offerExactly', units: moola(2) },
+      { kind: 'offerAtMost', units: moola(2) },
       { kind: 'wantAtLeast', units: simoleans(3) },
       { kind: 'wantAtLeast', units: bucks(3) },
     ];
@@ -326,9 +326,9 @@ test('isOfferSafeForOffer - null for some assays', t => {
   try {
     const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'offerExactly', units: moola(2) },
+      { kind: 'offerAtMost', units: moola(2) },
       null,
-      { kind: 'offerExactly', units: bucks(4) },
+      { kind: 'offerAtMost', units: bucks(4) },
     ];
     const units = [moola(5), simoleans(6), bucks(8)];
     t.throws(
@@ -347,9 +347,9 @@ test('isOfferSafeForAll - All users get what they wanted', t => {
   try {
     const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'offerExactly', units: moola(2) },
-      { kind: 'wantExactly', units: simoleans(3) },
-      { kind: 'wantExactly', units: bucks(3) },
+      { kind: 'offerAtMost', units: moola(2) },
+      { kind: 'wantAtLeast', units: simoleans(3) },
+      { kind: 'wantAtLeast', units: bucks(3) },
     ];
 
     const offerMatrix = [payoutRules, payoutRules, payoutRules];
@@ -367,9 +367,9 @@ test(`isOfferSafeForAll - One user doesn't get what they wanted`, t => {
   try {
     const { unitOps, moola, simoleans, bucks } = setup();
     const payoutRules = [
-      { kind: 'offerExactly', units: moola(2) },
-      { kind: 'wantExactly', units: simoleans(3) },
-      { kind: 'wantExactly', units: bucks(3) },
+      { kind: 'offerAtMost', units: moola(2) },
+      { kind: 'wantAtLeast', units: simoleans(3) },
+      { kind: 'wantAtLeast', units: bucks(3) },
     ];
 
     const offerMatrix = [payoutRules, payoutRules, payoutRules];

--- a/packages/zoe/test/unitTests/test-seat.js
+++ b/packages/zoe/test/unitTests/test-seat.js
@@ -39,8 +39,8 @@ test('seatMint', async t => {
       handle: harden({}),
       offerToBeMade: {
         payoutRules: [
-          { kind: 'offerExactly', units: assays[0].makeUnits(8) },
-          { kind: 'wantExactly', units: assays[1].makeUnits(6) },
+          { kind: 'offerAtMost', units: assays[0].makeUnits(8) },
+          { kind: 'wantAtLeast', units: assays[1].makeUnits(6) },
         ],
       },
     });
@@ -65,8 +65,8 @@ test('seatMint', async t => {
       handle: harden({}),
       offerMade: {
         payoutRules: [
-          { kind: 'offerExactly', units: assays[0].makeUnits(8) },
-          { kind: 'wantExactly', units: assays[1].makeUnits(6) },
+          { kind: 'offerAtMost', units: assays[0].makeUnits(8) },
+          { kind: 'wantAtLeast', units: assays[1].makeUnits(6) },
         ],
       },
     });

--- a/packages/zoe/zoe.chainmail
+++ b/packages/zoe/zoe.chainmail
@@ -72,15 +72,15 @@ interface Zoe {
    * The rules for the offer are in two parts: `payoutRules` are used 
    * by Zoe to enforce offer safety, and `exitRule` is used by Zoe 
    * to enforce exit safety. `payoutRules` is a list of objects, each 
-   * with a `kind` property (such as 'offerExactly') and a units
+   * with a `kind` property (such as 'offerAtMost') and a units
    * property. The objects in the `payoutRules` must be in the same order
    * as the assays associated with a smart contract. That is, the
    * units in index 0 of `payoutRules` should be a units for the assay
    * in index 0 of the assays array.`payments` is an array of the
    * actual payments to be escrowed, following the rules in the
-   * payoutRules. If the payoutRules kind is 'offerExactly' or 'offerAtMost',
+   * payoutRules. If the payoutRules kind is 'offerAtMost',
    * then a payment matching the units is expected. If the payoutRules
-   * kind is 'wantAtLeast' or 'wantExactly' then the payment will be
+   * kind is 'wantAtLeast' then the payment will be
    * ignored at escrow and should be `undefined`.
    */
   escrow (offerRules :OfferRules, payments :List(Payment)) -> (EscrowReceiptAndPayout);
@@ -93,8 +93,7 @@ struct OfferRules ( ) {
 
 /**
  * payoutRules are an array of PayoutRule. The possible
- * kinds are 'offerExactly', 'offerAtMost', 'wantExactly', and 
- * 'wantAtLeast'.
+ * kinds are 'offerAtMost' and 'wantAtLeast'.
  */
 struct PayoutRule ( ) {
   kind :PayoutRuleKind;

--- a/packages/zoe/zoe.chainmail
+++ b/packages/zoe/zoe.chainmail
@@ -101,7 +101,7 @@ struct PayoutRule ( ) {
 }
 
 /**
- * The possible kinds are 'noExit', 'onDemand', and 'afterDeadline'.
+ * The possible kinds are 'waived', 'onDemand', and 'afterDeadline'.
  * `timer` and `deadline` only are used for the `afterDeadline` kind.
  */
 struct ExitRule ( ) {

--- a/packages/zoe/zoe.js
+++ b/packages/zoe/zoe.js
@@ -62,10 +62,7 @@ const makeZoe = (additionalEndowments = {}) => {
       const offerPayment = offerPayments[i];
 
       return assayRecordP.then(({ purse, unitOps }) => {
-        if (
-          payoutRule.kind === 'offerExactly' ||
-          payoutRule.kind === 'offerAtMost'
-        ) {
+        if (payoutRule.kind === 'offerAtMost') {
           // We cannot trust these units since they come directly
           // from the remote assay and must coerce them.
           return E(purse)


### PR DESCRIPTION
BREAKING CHANGE: This PR reduces the `payoutRule` kinds to be only `offerAtMost` and `wantAtLeast`.

Closes #101 