### PR TITLE
change zoe guide link to agoric.com docs

### DIFF
--- a/packages/ERTP/README.md
+++ b/packages/ERTP/README.md
@@ -21,7 +21,7 @@ escrowing and payouts and checks invariants like offer-safety and
 conservation of supply, meaning that developers can just focus on the
 particular logic of their contract. 
 
-Learn more about how to write a smart contract on [Zoe](core/zoe/docs/zoe.md).
+Learn more about how to write a smart contract on [Zoe](https://agoric.com/documentation/zoe/guide/).
 
 ## A quick tutorial
 


### PR DESCRIPTION
In a recent PR you mention zoe will be added to NPM soon. Looks like agoric.com is currently the best place to find the docs. Maybe you want to point people to the github version, but this should work in the interim.