### PR TITLE
xs import tweaks

### DIFF
--- a/packages/SwingSet/src/index.js
+++ b/packages/SwingSet/src/index.js
@@ -1,19 +1,9 @@
-import { loadBasedir, buildVatController } from './controller';
-import { buildMailboxStateMap, buildMailbox } from './devices/mailbox';
-import { buildTimer } from './devices/timer';
+export { loadBasedir, buildVatController } from './controller';
+export { buildMailboxStateMap, buildMailbox } from './devices/mailbox';
+export { buildTimer } from './devices/timer';
 
-import { buildStorageInMemory } from './hostStorage';
-import buildCommand from './devices/command';
-
-export {
-  loadBasedir,
-  buildVatController,
-  buildMailboxStateMap,
-  buildMailbox,
-  buildTimer,
-  buildStorageInMemory,
-  buildCommand,
-};
+export { buildStorageInMemory } from './hostStorage';
+export { default as buildCommand } from './devices/command';
 
 export function getVatTPSourcePath() {
   return require.resolve('./vats/vat-tp');

--- a/packages/SwingSet/src/index.js
+++ b/packages/SwingSet/src/index.js
@@ -2,12 +2,17 @@ import { loadBasedir, buildVatController } from './controller';
 import { buildMailboxStateMap, buildMailbox } from './devices/mailbox';
 import { buildTimer } from './devices/timer';
 
+import { buildStorageInMemory } from './hostStorage';
+import buildCommand from './devices/command';
+
 export {
   loadBasedir,
   buildVatController,
   buildMailboxStateMap,
   buildMailbox,
   buildTimer,
+  buildStorageInMemory,
+  buildCommand,
 };
 
 export function getVatTPSourcePath() {

--- a/packages/cosmic-swingset/lib/ag-solo/start.js
+++ b/packages/cosmic-swingset/lib/ag-solo/start.js
@@ -19,8 +19,8 @@ import {
   getCommsSourcePath,
   getTimerWrapperSourcePath,
 } from '@agoric/swingset-vat';
-import { buildStorageInMemory } from '@agoric/swingset-vat/src/hostStorage';
-import buildCommand from '@agoric/swingset-vat/src/devices/command';
+import { buildStorageInMemory } from '@agoric/swingset-vat';
+import { buildCommand } from '@agoric/swingset-vat';
 
 import { deliver, addDeliveryTarget } from './outbound';
 import { makeHTTPListener } from './web';

--- a/packages/cosmic-swingset/lib/ag-solo/start.js
+++ b/packages/cosmic-swingset/lib/ag-solo/start.js
@@ -11,16 +11,16 @@ import readlines from 'n-readlines';
 
 import {
   loadBasedir,
+  buildCommand,
   buildVatController,
   buildMailboxStateMap,
   buildMailbox,
+  buildStorageInMemory,
   buildTimer,
   getVatTPSourcePath,
   getCommsSourcePath,
   getTimerWrapperSourcePath,
 } from '@agoric/swingset-vat';
-import { buildStorageInMemory } from '@agoric/swingset-vat';
-import { buildCommand } from '@agoric/swingset-vat';
 
 import { deliver, addDeliveryTarget } from './outbound';
 import { makeHTTPListener } from './web';

--- a/packages/cosmic-swingset/lib/ag-solo/web.js
+++ b/packages/cosmic-swingset/lib/ag-solo/web.js
@@ -1,10 +1,10 @@
 // Start a network service
-const path = require('path');
-const http = require('http');
-const express = require('express');
-const WebSocket = require('ws');
-const morgan = require('morgan');
-const fs = require('fs');
+import path from 'path';
+import http from 'http';
+import express from 'express';
+import WebSocket from 'ws';
+import morgan from 'morgan';
+import fs from 'fs';
 
 const points = new Map();
 const broadcasts = new Map();


### PR DESCRIPTION
 - export `buildStorageInMemory`, `buildCommand` from `@swingset-vat` to avoid `@agoric/swingset-vat/src/devices/command` style specifier;
 - ag-solo/web: require -> import (cjs -> esm)

@warner @michaelfig is there some protocol for routing PRs to reviewers?