### PR TITLE
fix(resolve): protect against reentrancy attack

### DIFF
--- a/packages/eventual-send/changelogs/9.txt
+++ b/packages/eventual-send/changelogs/9.txt
@@ -1,0 +1,5 @@
+* `HandledPromise.resolve(p)` (and therefore `E.resolve(p)`) now
+assimilate Promises that have been mutated to add a `.then` method.
+These are delayed to a future turn before calling their `.then` method.
+This protects against reentrancy attacks, but only when running
+under SES.

--- a/packages/eventual-send/src/E.js
+++ b/packages/eventual-send/src/E.js
@@ -62,7 +62,7 @@ export default function makeE(HandledPromise) {
         return true;
       },
       get(_target, prop) {
-        return HandledPromise.get(x, prop);
+        return harden(HandledPromise.get(x, prop));
       },
     });
 

--- a/packages/eventual-send/src/index.js
+++ b/packages/eventual-send/src/index.js
@@ -234,11 +234,7 @@ export function makeHandledPromise(Promise) {
   }
 
   HandledPromise.prototype = promiseProto;
-
-  // Uncomment this line if needed for conformance to the proposal.
-  // Currently the proposal does not specify this, but we might change
-  // our mind.
-  // Object.setPrototypeOf(HandledPromise, Promise);
+  Object.setPrototypeOf(HandledPromise, Promise);
 
   function isFrozenPromiseThen(p) {
     return (

--- a/packages/eventual-send/test/test-thenable.js
+++ b/packages/eventual-send/test/test-thenable.js
@@ -1,0 +1,32 @@
+import test from 'tape-promise/tape';
+import { E, HandledPromise } from '../src/index';
+
+test('E.resolve is always asynchronous', async t => {
+  try {
+    const p = new Promise(_ => {});
+    p.then = (res, _rej) => res('done');
+    let thened = false;
+    const p2 = E.resolve(p).then(ret => (thened = ret));
+    t.is(thened, false, `p2 is not yet resolved`);
+    t.equal(await p2, 'done', `p2 is resolved`);
+  } catch (e) {
+    t.isNot(e, e, 'unexpected exception');
+  } finally {
+    t.end();
+  }
+});
+
+test('HandledPromise.resolve is always asynchronous', async t => {
+  try {
+    const p = new Promise(_ => {});
+    p.then = (res, _rej) => res('done');
+    let thened = false;
+    const p2 = HandledPromise.resolve(p).then(ret => (thened = ret));
+    t.is(thened, false, `p2 is not yet resolved`);
+    t.equal(await p2, 'done', `p2 is resolved`);
+  } catch (e) {
+    t.isNot(e, e, 'unexpected exception');
+  } finally {
+    t.end();
+  }
+});

--- a/packages/eventual-send/test/test-thenable.js
+++ b/packages/eventual-send/test/test-thenable.js
@@ -4,7 +4,8 @@ import { E, HandledPromise } from '../src/index';
 test('E.resolve is always asynchronous', async t => {
   try {
     const p = new Promise(_ => {});
-    p.then = (res, _rej) => res('done');
+    // Work around the override mistake on SES.
+    Object.defineProperty(p, 'then', { value: (res, _rej) => res('done') });
     let thened = false;
     const p2 = E.resolve(p).then(ret => (thened = ret));
     t.is(thened, false, `p2 is not yet resolved`);
@@ -19,7 +20,8 @@ test('E.resolve is always asynchronous', async t => {
 test('HandledPromise.resolve is always asynchronous', async t => {
   try {
     const p = new Promise(_ => {});
-    p.then = (res, _rej) => res('done');
+    // Work around the override mistake on SES.
+    Object.defineProperty(p, 'then', { value: (res, _rej) => res('done') });
     let thened = false;
     const p2 = HandledPromise.resolve(p).then(ret => (thened = ret));
     t.is(thened, false, `p2 is not yet resolved`);


### PR DESCRIPTION
Closes #9

Note that the test for `isNormalPromiseThen` does not check that the `Promise.prototype` is frozen as this is always true under SES and too strict outside of SES (tries assimilating all Promises).  It also checks if `p` is frozen only when under SES, as it is too strict outside of SES (tries assimilating platform Promises).

Please review carefully.  There is no rush.