### PR TITLE
run workflows on: [push, pull_request]

### DIFF
--- a/.github/workflows/ag-solo-xs.yml
+++ b/.github/workflows/ag-solo-xs.yml
@@ -1,6 +1,6 @@
 name: ag-solo on xs
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -1,6 +1,6 @@
 name: Test all Packages
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
Changes the workflows to run `on: [push, pull_request]` rather than merely `push`. I believe this will run the workflow on PRs created by contributers from branches on their own forked repo. 

Closes #400 