### PR TITLE
Add and fix some kdebug statements

### DIFF
--- a/packages/SwingSet/src/kernel/deviceManager.js
+++ b/packages/SwingSet/src/kernel/deviceManager.js
@@ -25,8 +25,11 @@ export default function makeDeviceManager(
   // is used when building the arguments for dispatch.invoke.
   function mapKernelSlotToDeviceSlot(kernelSlot) {
     insist(`${kernelSlot}` === kernelSlot, 'non-string kernelSlot');
-    kdebug(`mapInbound for device-${deviceName} of ${kernelSlot}`);
-    return deviceKeeper.mapKernelSlotToDeviceSlot(kernelSlot);
+    const deviceSlot = deviceKeeper.mapKernelSlotToDeviceSlot(kernelSlot);
+    kdebug(
+      `mapInbound for device-${deviceName} of ${kernelSlot} to ${deviceSlot}`,
+    );
+    return deviceSlot;
   }
 
   // syscall handlers: these are wrapped by the 'syscall' object and made

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -4,13 +4,9 @@ import { initializeVatState, makeVatKeeper } from './vatKeeper';
 import { initializeDeviceState, makeDeviceKeeper } from './deviceKeeper';
 import { insist } from '../../insist';
 import { insistEnhancedStorageAPI } from '../../storageAPI';
-import {
-  insistKernelType,
-  makeKernelSlot,
-  parseKernelSlot,
-} from '../parseKernelSlots';
+import { insistKernelType, makeKernelSlot, parseKernelSlot } from '../parseKernelSlots';
 import { insistCapData } from '../../capdata';
-import { insistVatID, insistDeviceID, makeDeviceID, makeVatID } from '../id';
+import { insistDeviceID, insistVatID, makeDeviceID, makeVatID } from '../id';
 
 // This holds all the kernel state, including that of each Vat and Device, in
 // a single JSON-serializable object. At any moment (well, really only
@@ -91,6 +87,13 @@ const FIRST_PROMISE_ID = 40;
 export default function makeKernelKeeper(storage) {
   insistEnhancedStorageAPI(storage);
 
+  const enableKDebug = false;
+  function kdebug(...args) {
+    if (enableKDebug) {
+      console.log(...args);
+    }
+  }
+
   function getRequired(key) {
     if (!storage.has(key)) {
       throw new Error(`storage lacks required key ${key}`);
@@ -125,6 +128,7 @@ export default function makeKernelKeeper(storage) {
   function addKernelObject(ownerID) {
     insistVatID(ownerID);
     const id = Nat(Number(getRequired('ko.nextID')));
+    kdebug(`Adding kernel object ${id} for ${ownerID}`);
     storage.set('ko.nextID', `${id + 1}`);
     const s = makeKernelSlot('object', id);
     storage.set(`${s}.owner`, ownerID);

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -4,7 +4,11 @@ import { initializeVatState, makeVatKeeper } from './vatKeeper';
 import { initializeDeviceState, makeDeviceKeeper } from './deviceKeeper';
 import { insist } from '../../insist';
 import { insistEnhancedStorageAPI } from '../../storageAPI';
-import { insistKernelType, makeKernelSlot, parseKernelSlot } from '../parseKernelSlots';
+import {
+  insistKernelType,
+  makeKernelSlot,
+  parseKernelSlot,
+} from '../parseKernelSlots';
 import { insistCapData } from '../../capdata';
 import { insistDeviceID, insistVatID, makeDeviceID, makeVatID } from '../id';
 

--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -22,6 +22,13 @@ export function makeVatKeeper(
 ) {
   insistVatID(vatID);
 
+  const enableKDebug = false;
+  function kdebug(...args) {
+    if (enableKDebug) {
+      console.log(...args);
+    }
+  }
+
   function mapVatSlotToKernelSlot(vatSlot) {
     insist(`${vatSlot}` === vatSlot, 'non-string vatSlot');
     const vatKey = `${vatID}.c.${vatSlot}`;
@@ -42,6 +49,7 @@ export function makeVatKeeper(
         const kernelKey = `${vatID}.c.${kernelSlot}`;
         storage.set(kernelKey, vatSlot);
         storage.set(vatKey, kernelSlot);
+        kdebug(`Mapping ${kernelKey}<=>${vatKey}`);
       } else {
         // the vat didn't allocate it, and the kernel didn't allocate it
         // (else it would have been in the c-list), so it must be bogus

--- a/packages/SwingSet/src/kernel/vatManager.js
+++ b/packages/SwingSet/src/kernel/vatManager.js
@@ -80,10 +80,13 @@ export default function makeVatManager(
   // mapInbound: e.g. arguments of dispatch.deliver()
   function mapKernelSlotToVatSlot(kernelSlot) {
     insist(`${kernelSlot}` === kernelSlot, 'non-string kernelSlot');
+    const vatSlot = vatKeeper.mapKernelSlotToVatSlot(kernelSlot);
     kdebug(
-      `mapKernelSlotToVatSlot for ${vatID} of ${JSON.stringify(kernelSlot)}`,
+      `mapKernelSlotToVatSlot for ${vatID} of ${JSON.stringify(
+        kernelSlot,
+      )} to ${vatSlot}`,
     );
-    return vatKeeper.mapKernelSlotToVatSlot(kernelSlot);
+    return vatSlot;
   }
 
   let inReplay = false;
@@ -160,8 +163,9 @@ export default function makeVatManager(
     const kpid = mapVatSlotToKernelSlot(promiseID);
     const targetSlot = mapVatSlotToKernelSlot(slot);
     kdebug(
-      `syscall[${vatID}].fulfillToPresence(${promiseID / kpid}) = ${slot /
-        targetSlot})`,
+      `syscall[${vatID}].fulfillToPresence(${promiseID} / ${kpid}) = ${
+        slot
+      } / ${targetSlot})`,
     );
     syscallManager.fulfillToPresence(vatID, kpid, targetSlot);
   }

--- a/packages/SwingSet/src/kernel/vatManager.js
+++ b/packages/SwingSet/src/kernel/vatManager.js
@@ -163,9 +163,7 @@ export default function makeVatManager(
     const kpid = mapVatSlotToKernelSlot(promiseID);
     const targetSlot = mapVatSlotToKernelSlot(slot);
     kdebug(
-      `syscall[${vatID}].fulfillToPresence(${promiseID} / ${kpid}) = ${
-        slot
-      } / ${targetSlot})`,
+      `syscall[${vatID}].fulfillToPresence(${promiseID} / ${kpid}) = ${slot} / ${targetSlot})`,
     );
     syscallManager.fulfillToPresence(vatID, kpid, targetSlot);
   }


### PR DESCRIPTION
The kdebug in doFulfillToPresence was broken.

Added detail in a few places.

These were useful for debugging, so I wanted to add them to the
codebase. They're all disabled now.

The base change is [here](https://github.com/Agoric/agoric-sdk/pull/407).  See [this discussion](https://github.com/Agoric/agoric-sdk/issues/24) for context.