### PR TITLE
BUGFIX: deliverOneMessage() accidentally skipped insist() msgs.

### DIFF
--- a/packages/SwingSet/src/kernel/vatManager.js
+++ b/packages/SwingSet/src/kernel/vatManager.js
@@ -291,9 +291,10 @@ export default function makeVatManager(
   async function deliverOneMessage(target, msg) {
     insistMessage(msg);
     const targetSlot = mapKernelSlotToVatSlot(target);
-    if (targetSlot.type === 'object') {
+    const { type } = parseVatSlot(targetSlot);
+    if (type === 'object') {
       insist(parseVatSlot(targetSlot).allocatedByVat, `deliver() to wrong vat`);
-    } else if (targetSlot.type === 'promise') {
+    } else if (type === 'promise') {
       const p = kernelKeeper.getKernelPromise(target);
       insist(p.decider === vatID, `wrong decider`);
     }


### PR DESCRIPTION
I don't see how to write a test for this. Suggestions?

The base change for the vatAdmin changes is [here](https://github.com/Agoric/agoric-sdk/pull/407).  See [this discussion](https://github.com/Agoric/agoric-sdk/issues/24) for context.