### PR TITLE
Add ability to request stats for a Vat.

### DIFF
--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -620,7 +620,8 @@ export default function buildKernel(kernelEndowments) {
 
   function collectVatStats(vatID) {
     insistVatID(vatID);
-    return kernelKeeper.vatStats(vatID);
+    const vatManager = ephemeral.vats.get(vatID).manager;
+    return vatManager.vatStats();
   }
 
   async function start(bootstrapVatName, argvString) {
@@ -663,7 +664,7 @@ export default function buildKernel(kernelEndowments) {
         setup: vatAdminDevSetup,
         endowments: {
           create: createVatDynamically,
-          vatStats: collectVatStats,
+          stats: collectVatStats,
           /* terminate */
         },
       };

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -618,6 +618,11 @@ export default function buildKernel(kernelEndowments) {
     );
   }
 
+  function collectVatStats(vatID) {
+    insistVatID(vatID);
+    return kernelKeeper.vatStats(vatID);
+  }
+
   async function start(bootstrapVatName, argvString) {
     if (started) {
       throw new Error('kernel.start already called');
@@ -656,7 +661,11 @@ export default function buildKernel(kernelEndowments) {
     if (vatAdminDevSetup) {
       const params = {
         setup: vatAdminDevSetup,
-        endowments: { create: createVatDynamically /* vatStats, terminate */ },
+        endowments: {
+          create: createVatDynamically,
+          vatStats: collectVatStats,
+          /* terminate */
+        },
       };
       genesisDevices.set('vatAdmin', params);
     }

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -507,15 +507,6 @@ export default function makeKernelKeeper(storage) {
     });
   }
 
-  function vatStats(vatID) {
-    return harden({
-      nextObjectId: storage.get(`${vatID}.o.nextID`),
-      nextPromiseId: storage.get(`${vatID}.p.nextID`),
-      nextDeviceId: storage.get(`${vatID}.d.nextID`),
-      nextTranscriptId: storage.get(`${vatID}.t.nextID`),
-    });
-  }
-
   return harden({
     getInitialized,
     setInitialized,
@@ -545,8 +536,6 @@ export default function makeKernelKeeper(storage) {
     provideUnusedVatID,
     provideVatKeeper,
     getAllVatNames,
-
-    vatStats,
 
     getDeviceIDForName,
     provideDeviceIDForName,

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -507,6 +507,15 @@ export default function makeKernelKeeper(storage) {
     });
   }
 
+  function vatStats(vatID) {
+    return harden({
+      nextObjectId: storage.get(`${vatID}.o.nextID`),
+      nextPromiseId: storage.get(`${vatID}.p.nextID`),
+      nextDeviceId: storage.get(`${vatID}.d.nextID`),
+      nextTranscriptId: storage.get(`${vatID}.t.nextID`),
+    });
+  }
+
   return harden({
     getInitialized,
     setInitialized,
@@ -536,6 +545,8 @@ export default function makeKernelKeeper(storage) {
     provideUnusedVatID,
     provideVatKeeper,
     getAllVatNames,
+
+    vatStats,
 
     getDeviceIDForName,
     provideDeviceIDForName,

--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -7,11 +7,17 @@ import { insistVatID } from '../id';
 
 // makeVatKeeper is a pure function: all state is kept in the argument object
 
+// TODO: tests rely on these numbers and haven't been updated to use names.
+const FIRST_OBJECT_ID = 50;
+const FIRST_PROMISE_ID = 60;
+const FIRST_DEVICE_ID = 70;
+const FIRST_TRANSCRIPT_ID = 0;
+
 export function initializeVatState(storage, vatID) {
-  storage.set(`${vatID}.o.nextID`, '50');
-  storage.set(`${vatID}.p.nextID`, '60');
-  storage.set(`${vatID}.d.nextID`, '70');
-  storage.set(`${vatID}.t.nextID`, '0');
+  storage.set(`${vatID}.o.nextID`, `${FIRST_OBJECT_ID}`);
+  storage.set(`${vatID}.p.nextID`, `${FIRST_PROMISE_ID}`);
+  storage.set(`${vatID}.d.nextID`, `${FIRST_DEVICE_ID}`);
+  storage.set(`${vatID}.t.nextID`, `${FIRST_TRANSCRIPT_ID}`);
 }
 
 export function makeVatKeeper(
@@ -101,6 +107,20 @@ export function makeVatKeeper(
     storage.set(`${vatID}.t.${id}`, JSON.stringify(msg));
   }
 
+  function vatStats() {
+    const objectCount = storage.get(`${vatID}.o.nextID`) - FIRST_OBJECT_ID;
+    const promiseCount = storage.get(`${vatID}.p.nextID`) - FIRST_PROMISE_ID;
+    const deviceCount = storage.get(`${vatID}.d.nextID`) - FIRST_DEVICE_ID;
+    const transcriptCount =
+      storage.get(`${vatID}.t.nextID`) - FIRST_TRANSCRIPT_ID;
+    return harden({
+      objectCount: Nat(Number(objectCount)),
+      promiseCount: Nat(Number(promiseCount)),
+      deviceCount: Nat(Number(deviceCount)),
+      transcriptCount: Nat(Number(transcriptCount)),
+    });
+  }
+
   // pretty print for logging and testing
   function dumpState() {
     const res = [];
@@ -123,6 +143,7 @@ export function makeVatKeeper(
     mapKernelSlotToVatSlot,
     getTranscript,
     addToTranscript,
+    vatStats,
     dumpState,
   });
 }

--- a/packages/SwingSet/src/kernel/vatAdmin/vatAdmin-src.js
+++ b/packages/SwingSet/src/kernel/vatAdmin/vatAdmin-src.js
@@ -22,7 +22,7 @@ import harden from '@agoric/harden';
 export default function setup(syscall, state, helpers, endowments) {
   const {
     create: kernelVatCreationFn,
-    // stats: kernelVatStatsFn,
+    stats: kernelVatStatsFn,
     // terminate: kernelTerminateFn,
   } = endowments;
 
@@ -30,6 +30,18 @@ export default function setup(syscall, state, helpers, endowments) {
   // vatId in return. Clean up the outgoing and incoming arguments.
   function callKernelVatCreation(src) {
     return kernelVatCreationFn(`${src}`);
+  }
+
+  // Call the registered kernel function to request vat stats. Clean up the
+  // outgoing and incoming arguments.
+  function callKernelVatStats(vatId) {
+    if (!kernelVatStatsFn || typeof kernelVatStatsFn !== 'function') {
+      throw new Error(
+        `Attempted to request stats before registering kernel function`,
+      );
+    }
+    const cleanVatId = `${vatId}`;
+    return kernelVatStatsFn(cleanVatId);
   }
 
   // makeRootDevice is called with { _SO, _getDeviceState, _setDeviceState } as
@@ -46,8 +58,8 @@ export default function setup(syscall, state, helpers, endowments) {
       terminate(_vatID) {
         // TODO(hibbert)
       },
-      adminStats(_vatID) {
-        // TODO(hibbert)
+      adminStats(vatID) {
+        return callKernelVatStats(vatID);
       },
     });
   }

--- a/packages/SwingSet/src/kernel/vatManager.js
+++ b/packages/SwingSet/src/kernel/vatManager.js
@@ -288,6 +288,10 @@ export default function makeVatManager(
     );
   }
 
+  function vatStats() {
+    return vatKeeper.vatStats();
+  }
+
   async function deliverOneMessage(target, msg) {
     insistMessage(msg);
     const targetSlot = mapKernelSlotToVatSlot(target);
@@ -385,6 +389,7 @@ export default function makeVatManager(
     deliverOneMessage,
     deliverOneNotification,
     replayTranscript,
+    vatStats,
   };
   return manager;
 }

--- a/packages/SwingSet/test/vat-admin/bootstrap.js
+++ b/packages/SwingSet/test/vat-admin/bootstrap.js
@@ -88,8 +88,7 @@ export default function setup(syscall, state, helpers) {
                 devices.vatAdmin,
               );
               const { adminNode } = await E(vatAdminSvc).createVat(src);
-              const stats = await E(adminNode).adminData();
-              log(stats);
+              log(await E(adminNode).adminData());
               return;
             }
             default:

--- a/packages/SwingSet/test/vat-admin/bootstrap.js
+++ b/packages/SwingSet/test/vat-admin/bootstrap.js
@@ -81,6 +81,17 @@ export default function setup(syscall, state, helpers) {
               log(await E(vatAdminSvc).createVat(src));
               return;
             }
+            case 'vatStats': {
+              log(`starting stats test`);
+              const src = `${serviceHolder.build}`;
+              const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
+                devices.vatAdmin,
+              );
+              const { adminNode } = await E(vatAdminSvc).createVat(src);
+              const stats = await E(adminNode).adminData();
+              log(stats);
+              return;
+            }
             default:
               throw new Error(`unknown argv mode '${argv[0]}'`);
           }

--- a/packages/SwingSet/test/vat-admin/test-innerVat.js
+++ b/packages/SwingSet/test/vat-admin/test-innerVat.js
@@ -68,3 +68,22 @@ test('VatAdmin broken vat creation', async t => {
 test('VatAdmin broken vat creation non-SES', async t => {
   await testBrokenVatCreation(t, false);
 });
+
+async function testGetVatStats(t, withSES) {
+  const config = await createConfig();
+  const c = await buildVatController(config, withSES, ['vatStats']);
+  await c.run();
+  t.deepEqual(c.dump().log, [
+    'starting stats test',
+    '{"objectCount":0,"promiseCount":0,"deviceCount":0,"transcriptCount":0}',
+  ]);
+  t.end();
+}
+
+test('VatAdmin get vat stats', async t => {
+  await testGetVatStats(t, true);
+});
+
+test('VatAdmin get vat stats non-SES', async t => {
+  await testGetVatStats(t, false);
+});


### PR DESCRIPTION
Adds collectVatStats and registers it with the device. Returns some basic stats about a vat.

The base change for the vatAdmin changes is [here](https://github.com/Agoric/agoric-sdk/pull/407).  See [this discussion](https://github.com/Agoric/agoric-sdk/issues/24) for context.