### PR TITLE
feat(HandledPromise): add unwrap method to allow sync access to presences

### DIFF
--- a/.github/workflows/ag-solo-xs.yml
+++ b/.github/workflows/ag-solo-xs.yml
@@ -22,12 +22,12 @@ jobs:
       run: |
         cd $HOME
         curl -L https://github.com/dckc/moddable/releases/download/ag08/moddable-linux-sdk.tgz | tar xzf -
-    - name: install tape-xs
+    - name: install tape-xs ag03
       # ISSUE: merge into agoric-sdk?
       run: |
         cd $HOME
-        curl -L https://github.com/dckc/tape-xs/archive/ag01.tar.gz | tar xzf -
-        mv tape-xs-ag01 tape-xs
+        curl -L https://github.com/agoric-labs/tape-xs/archive/ag03.tar.gz | tar xzf -
+        mv tape-xs-ag03 tape-xs
         cd tape-xs
         yarn install
     - name: test eventual-send on xs

--- a/packages/eventual-send/src/E.js
+++ b/packages/eventual-send/src/E.js
@@ -68,6 +68,7 @@ export default function makeE(HandledPromise) {
 
   E.G = makeEGetterProxy;
   E.resolve = HandledPromise.resolve;
+  E.unwrap = HandledPromise.unwrap;
 
   return harden(E);
 }

--- a/packages/eventual-send/test/test-e.js
+++ b/packages/eventual-send/test/test-e.js
@@ -1,5 +1,16 @@
 import test from 'tape-promise/tape';
-import { E } from '../src/index';
+import { E, HandledPromise } from '../src/index';
+
+test('E reexports', async t => {
+  try {
+    t.equals(E.resolve, HandledPromise.resolve, 'E reexports resolve');
+    t.equals(E.unwrap, HandledPromise.unwrap, 'E reexports unwrap');
+  } catch (e) {
+    t.isNot(e, e, 'unexpected exception');
+  } finally {
+    t.end();
+  }
+});
 
 test('E method calls', async t => {
   try {

--- a/packages/eventual-send/test/test-hp.js
+++ b/packages/eventual-send/test/test-hp.js
@@ -45,3 +45,88 @@ test('chained properties', async t => {
     t.end();
   }
 });
+
+test('HandledPromise.unwrap', async t => {
+  try {
+    t.throws(
+      () => HandledPromise.unwrap({}),
+      TypeError,
+      `unwrapped non-presence throws`,
+    );
+    const p0 = new Promise(_ => {});
+    t.throws(
+      () => HandledPromise.unwrap(p0),
+      TypeError,
+      `unwrapped unfulfilled Promise throws`,
+    );
+    const p1 = new Promise(resolve => {
+      resolve({});
+    });
+    t.throws(
+      () => HandledPromise.unwrap(p1),
+      TypeError,
+      `unwrapped resolved Promise throws`,
+    );
+    const p2 = new Promise((_, reject) => {
+      reject(Error('p2'));
+    });
+    // Prevent unhandled promise rejection.
+    p2.catch(_ => {});
+    t.throws(
+      () => HandledPromise.unwrap(p2),
+      TypeError,
+      `unwrapped rejected Promise throws`,
+    );
+    const hp0 = new HandledPromise(_ => {});
+    t.throws(
+      () => HandledPromise.unwrap(hp0),
+      TypeError,
+      'unfulfilled HandledPromise throws',
+    );
+    const hp1 = new HandledPromise(resolve => {
+      resolve({});
+    });
+    t.throws(
+      () => HandledPromise.unwrap(hp1),
+      TypeError,
+      'resolved HandledPromise throws',
+    );
+    const hp2 = new HandledPromise((_, reject) => {
+      reject(Error('hp2'));
+    });
+    // Prevent unhandled promise rejection.
+    hp2.catch(_ => {});
+    t.throws(
+      () => HandledPromise.unwrap(hp2),
+      TypeError,
+      'rejected HandledPromise throws',
+    );
+    let presence;
+    const hp3 = new HandledPromise((_res, _rej, resolveWithPresence) => {
+      presence = resolveWithPresence({});
+    });
+    t.equals(typeof presence, 'object', `typeof presence is object`);
+    t.equals(
+      HandledPromise.unwrap(hp3),
+      presence,
+      `unwrapped HandledPromise is presence`,
+    );
+    t.equals(
+      HandledPromise.unwrap(presence),
+      presence,
+      `unwrapped presence is presence`,
+    );
+    const hp4 = new HandledPromise(resolve => {
+      resolve(hp3);
+    });
+    t.equals(
+      HandledPromise.unwrap(hp4),
+      presence,
+      `unwrapped forwarded HandledPromise is presence`,
+    );
+  } catch (e) {
+    t.isNot(e, e, 'unexpected exception');
+  } finally {
+    t.end();
+  }
+});


### PR DESCRIPTION
Closes #412

The new `HandledPromise.unwrap(p)` synchronously returns `p` if it is a presence, or the presence corresponding to the HandledPromise `p` that was fulfilled with `resolveWithPresence`.

If no synchronous presence can be found, `unwrap` throws a `TypeError`.
