### PR TITLE
test-kernel, test-marshal: revert to script

### DIFF
--- a/packages/SwingSet/test/test-kernel.js
+++ b/packages/SwingSet/test/test-kernel.js
@@ -34,1055 +34,1049 @@ function makeEndowments() {
   return { setImmediate, hostStorage: buildStorageInMemory().storage };
 }
 
-export default function runTests() {
-  test('build kernel', async t => {
-    const kernel = buildKernel(makeEndowments());
-    await kernel.start(); // empty queue
-    const data = kernel.dump();
-    t.deepEqual(data.vatTables, []);
-    t.deepEqual(data.kernelTable, []);
-    t.end();
+test('build kernel', async t => {
+  const kernel = buildKernel(makeEndowments());
+  await kernel.start(); // empty queue
+  const data = kernel.dump();
+  t.deepEqual(data.vatTables, []);
+  t.deepEqual(data.kernelTable, []);
+  t.end();
+});
+
+test('simple call', async t => {
+  const kernel = buildKernel(makeEndowments());
+  const log = [];
+  function setup1(syscall, state, helpers) {
+    function deliver(facetID, method, args) {
+      log.push([facetID, method, args]);
+      helpers.log(JSON.stringify({ facetID, method, args }));
+    }
+    return { deliver };
+  }
+  kernel.addGenesisVat('vat1', setup1);
+  await kernel.start();
+  const vat1 = kernel.vatNameToID('vat1');
+  let data = kernel.dump();
+  t.deepEqual(data.vatTables, [{ vatID: vat1, state: { transcript: [] } }]);
+  t.deepEqual(data.kernelTable, []);
+  t.deepEqual(data.log, []);
+  t.deepEqual(log, []);
+
+  kernel.queueToExport(vat1, 'o+1', 'foo', capdata('args'));
+  t.deepEqual(kernel.dump().runQueue, [
+    {
+      type: 'send',
+      target: 'ko20',
+      msg: {
+        method: 'foo',
+        args: capdata('args'),
+        result: null,
+      },
+    },
+  ]);
+  t.deepEqual(log, []);
+  await kernel.run();
+  t.deepEqual(log, [['o+1', 'foo', capdata('args')]]);
+
+  data = kernel.dump();
+  t.equal(data.log.length, 1);
+  t.deepEqual(JSON.parse(data.log[0]), {
+    facetID: 'o+1',
+    method: 'foo',
+    args: capdata('args'),
   });
 
-  test('simple call', async t => {
-    const kernel = buildKernel(makeEndowments());
-    const log = [];
-    function setup1(syscall, state, helpers) {
-      function deliver(facetID, method, args) {
-        log.push([facetID, method, args]);
-        helpers.log(JSON.stringify({ facetID, method, args }));
-      }
-      return { deliver };
+  t.end();
+});
+
+test('map inbound', async t => {
+  const kernel = buildKernel(makeEndowments());
+  const log = [];
+  function setup1(_syscall) {
+    function deliver(facetID, method, args) {
+      log.push([facetID, method, args]);
     }
-    kernel.addGenesisVat('vat1', setup1);
-    await kernel.start();
-    const vat1 = kernel.vatNameToID('vat1');
-    let data = kernel.dump();
-    t.deepEqual(data.vatTables, [{ vatID: vat1, state: { transcript: [] } }]);
-    t.deepEqual(data.kernelTable, []);
-    t.deepEqual(data.log, []);
-    t.deepEqual(log, []);
+    return { deliver };
+  }
+  kernel.addGenesisVat('vat1', setup1);
+  kernel.addGenesisVat('vat2', setup1);
+  await kernel.start();
+  const vat1 = kernel.vatNameToID('vat1');
+  const vat2 = kernel.vatNameToID('vat2');
+  const data = kernel.dump();
+  t.deepEqual(data.vatTables, [
+    { vatID: vat1, state: { transcript: [] } },
+    { vatID: vat2, state: { transcript: [] } },
+  ]);
+  t.deepEqual(data.kernelTable, []);
+  t.deepEqual(log, []);
 
-    kernel.queueToExport(vat1, 'o+1', 'foo', capdata('args'));
-    t.deepEqual(kernel.dump().runQueue, [
-      {
-        type: 'send',
-        target: 'ko20',
-        msg: {
-          method: 'foo',
-          args: capdata('args'),
-          result: null,
-        },
+  const koFor5 = kernel.addExport(vat1, 'o+5');
+  const koFor6 = kernel.addExport(vat2, 'o+6');
+  kernel.queueToExport(vat1, 'o+1', 'foo', capdata('args', [koFor5, koFor6]));
+  t.deepEqual(kernel.dump().runQueue, [
+    {
+      type: 'send',
+      target: 'ko22',
+      msg: {
+        method: 'foo',
+        args: capdata('args', [koFor5, koFor6]),
+        result: null,
       },
-    ]);
-    t.deepEqual(log, []);
-    await kernel.run();
-    t.deepEqual(log, [['o+1', 'foo', capdata('args')]]);
+    },
+  ]);
+  t.deepEqual(log, []);
+  await kernel.run();
+  t.deepEqual(log, [['o+1', 'foo', capdata('args', ['o+5', 'o-50'])]]);
+  t.deepEqual(kernel.dump().kernelTable, [
+    [koFor5, vat1, 'o+5'],
+    [koFor6, vat1, 'o-50'],
+    [koFor6, vat2, 'o+6'],
+    ['ko22', vat1, 'o+1'],
+  ]);
 
-    data = kernel.dump();
-    t.equal(data.log.length, 1);
-    t.deepEqual(JSON.parse(data.log[0]), {
-      facetID: 'o+1',
-      method: 'foo',
-      args: capdata('args'),
-    });
+  t.end();
+});
 
-    t.end();
-  });
+test('addImport', async t => {
+  const kernel = buildKernel(makeEndowments());
+  function setup(_syscall) {
+    function deliver(_facetID, _method, _args) {}
+    return { deliver };
+  }
+  kernel.addGenesisVat('vat1', setup);
+  kernel.addGenesisVat('vat2', setup);
+  await kernel.start();
+  const vat1 = kernel.vatNameToID('vat1');
+  const vat2 = kernel.vatNameToID('vat2');
 
-  test('map inbound', async t => {
-    const kernel = buildKernel(makeEndowments());
-    const log = [];
-    function setup1(_syscall) {
-      function deliver(facetID, method, args) {
-        log.push([facetID, method, args]);
-      }
-      return { deliver };
+  const slot = kernel.addImport(vat1, kernel.addExport(vat2, 'o+5'));
+  t.deepEqual(slot, 'o-50'); // first import
+  t.deepEqual(kernel.dump().kernelTable, [
+    ['ko20', vat1, 'o-50'],
+    ['ko20', vat2, 'o+5'],
+  ]);
+  t.end();
+});
+
+test('outbound call', async t => {
+  const kernel = buildKernel(makeEndowments());
+  const log = [];
+  let v1tovat25;
+  const p7 = 'p+7';
+
+  function setup1(syscall) {
+    let nextPromiseIndex = 5;
+    function allocatePromise() {
+      const index = nextPromiseIndex;
+      nextPromiseIndex += 1;
+      return makeVatSlot('promise', true, index);
     }
-    kernel.addGenesisVat('vat1', setup1);
-    kernel.addGenesisVat('vat2', setup1);
-    await kernel.start();
-    const vat1 = kernel.vatNameToID('vat1');
-    const vat2 = kernel.vatNameToID('vat2');
-    const data = kernel.dump();
-    t.deepEqual(data.vatTables, [
-      { vatID: vat1, state: { transcript: [] } },
-      { vatID: vat2, state: { transcript: [] } },
-    ]);
-    t.deepEqual(data.kernelTable, []);
-    t.deepEqual(log, []);
-
-    const koFor5 = kernel.addExport(vat1, 'o+5');
-    const koFor6 = kernel.addExport(vat2, 'o+6');
-    kernel.queueToExport(vat1, 'o+1', 'foo', capdata('args', [koFor5, koFor6]));
-    t.deepEqual(kernel.dump().runQueue, [
-      {
-        type: 'send',
-        target: 'ko22',
-        msg: {
-          method: 'foo',
-          args: capdata('args', [koFor5, koFor6]),
-          result: null,
-        },
-      },
-    ]);
-    t.deepEqual(log, []);
-    await kernel.run();
-    t.deepEqual(log, [['o+1', 'foo', capdata('args', ['o+5', 'o-50'])]]);
-    t.deepEqual(kernel.dump().kernelTable, [
-      [koFor5, vat1, 'o+5'],
-      [koFor6, vat1, 'o-50'],
-      [koFor6, vat2, 'o+6'],
-      ['ko22', vat1, 'o+1'],
-    ]);
-
-    t.end();
-  });
-
-  test('addImport', async t => {
-    const kernel = buildKernel(makeEndowments());
-    function setup(_syscall) {
-      function deliver(_facetID, _method, _args) {}
-      return { deliver };
+    function deliver(facetID, method, args) {
+      // console.log(`d1/${facetID} called`);
+      log.push(['d1', facetID, method, args]);
+      const pid = allocatePromise();
+      syscall.send(
+        v1tovat25,
+        'bar',
+        capdata('bargs', [v1tovat25, 'o+7', p7]),
+        pid,
+      );
     }
-    kernel.addGenesisVat('vat1', setup);
-    kernel.addGenesisVat('vat2', setup);
-    await kernel.start();
-    const vat1 = kernel.vatNameToID('vat1');
-    const vat2 = kernel.vatNameToID('vat2');
+    return { deliver };
+  }
+  kernel.addGenesisVat('vat1', setup1);
 
-    const slot = kernel.addImport(vat1, kernel.addExport(vat2, 'o+5'));
-    t.deepEqual(slot, 'o-50'); // first import
-    t.deepEqual(kernel.dump().kernelTable, [
-      ['ko20', vat1, 'o-50'],
-      ['ko20', vat2, 'o+5'],
-    ]);
-    t.end();
-  });
-
-  test('outbound call', async t => {
-    const kernel = buildKernel(makeEndowments());
-    const log = [];
-    let v1tovat25;
-    const p7 = 'p+7';
-
-    function setup1(syscall) {
-      let nextPromiseIndex = 5;
-      function allocatePromise() {
-        const index = nextPromiseIndex;
-        nextPromiseIndex += 1;
-        return makeVatSlot('promise', true, index);
-      }
-      function deliver(facetID, method, args) {
-        // console.log(`d1/${facetID} called`);
-        log.push(['d1', facetID, method, args]);
-        const pid = allocatePromise();
-        syscall.send(
-          v1tovat25,
-          'bar',
-          capdata('bargs', [v1tovat25, 'o+7', p7]),
-          pid,
-        );
-      }
-      return { deliver };
+  function setup2(_syscall) {
+    function deliver(facetID, method, args) {
+      // console.log(`d2/${facetID} called`);
+      log.push(['d2', facetID, method, args]);
+      log.push(['d2 promises', kernel.dump().promises]);
     }
-    kernel.addGenesisVat('vat1', setup1);
+    return { deliver };
+  }
+  kernel.addGenesisVat('vat2', setup2);
+  await kernel.start();
+  const vat1 = kernel.vatNameToID('vat1');
+  const vat2 = kernel.vatNameToID('vat2');
 
-    function setup2(_syscall) {
-      function deliver(facetID, method, args) {
-        // console.log(`d2/${facetID} called`);
-        log.push(['d2', facetID, method, args]);
-        log.push(['d2 promises', kernel.dump().promises]);
-      }
-      return { deliver };
-    }
-    kernel.addGenesisVat('vat2', setup2);
-    await kernel.start();
-    const vat1 = kernel.vatNameToID('vat1');
-    const vat2 = kernel.vatNameToID('vat2');
+  const t1 = kernel.addExport(vat1, 'o+1');
+  const vat2Obj5 = kernel.addExport(vat2, 'o+5');
+  v1tovat25 = kernel.addImport(vat1, vat2Obj5);
+  t.deepEqual(v1tovat25, 'o-50'); // first allocation
 
-    const t1 = kernel.addExport(vat1, 'o+1');
-    const vat2Obj5 = kernel.addExport(vat2, 'o+5');
-    v1tovat25 = kernel.addImport(vat1, vat2Obj5);
-    t.deepEqual(v1tovat25, 'o-50'); // first allocation
+  const data = kernel.dump();
+  t.deepEqual(data.vatTables, [
+    { vatID: vat1, state: { transcript: [] } },
+    { vatID: vat2, state: { transcript: [] } },
+  ]);
 
-    const data = kernel.dump();
-    t.deepEqual(data.vatTables, [
-      { vatID: vat1, state: { transcript: [] } },
-      { vatID: vat2, state: { transcript: [] } },
-    ]);
+  const kt = [
+    [t1, vat1, 'o+1'],
+    ['ko21', vat1, v1tovat25],
+    ['ko21', vat2, 'o+5'],
+  ];
+  checkKT(t, kernel, kt);
+  t.deepEqual(log, []);
 
-    const kt = [
-      [t1, vat1, 'o+1'],
-      ['ko21', vat1, v1tovat25],
-      ['ko21', vat2, 'o+5'],
-    ];
-    checkKT(t, kernel, kt);
-    t.deepEqual(log, []);
-
-    // o1!foo(args)
-    kernel.queueToExport(vat1, 'o+1', 'foo', capdata('args'));
-    t.deepEqual(log, []);
-    t.deepEqual(kernel.dump().runQueue, [
-      {
-        type: 'send',
-        target: t1,
-        msg: {
-          method: 'foo',
-          args: capdata('args'),
-          result: null,
-        },
+  // o1!foo(args)
+  kernel.queueToExport(vat1, 'o+1', 'foo', capdata('args'));
+  t.deepEqual(log, []);
+  t.deepEqual(kernel.dump().runQueue, [
+    {
+      type: 'send',
+      target: t1,
+      msg: {
+        method: 'foo',
+        args: capdata('args'),
+        result: null,
       },
-    ]);
+    },
+  ]);
 
-    await kernel.step();
-    // that queues pid=o2!bar(o2, o7, p7)
+  await kernel.step();
+  // that queues pid=o2!bar(o2, o7, p7)
 
-    t.deepEqual(log.shift(), ['d1', 'o+1', 'foo', capdata('args')]);
-    t.deepEqual(log, []);
+  t.deepEqual(log.shift(), ['d1', 'o+1', 'foo', capdata('args')]);
+  t.deepEqual(log, []);
 
-    t.deepEqual(kernel.dump().runQueue, [
-      {
-        type: 'send',
-        target: vat2Obj5,
-        msg: {
-          method: 'bar',
-          args: capdata('bargs', [vat2Obj5, 'ko22', 'kp40']),
-          result: 'kp41',
-        },
+  t.deepEqual(kernel.dump().runQueue, [
+    {
+      type: 'send',
+      target: vat2Obj5,
+      msg: {
+        method: 'bar',
+        args: capdata('bargs', [vat2Obj5, 'ko22', 'kp40']),
+        result: 'kp41',
       },
-    ]);
-    t.deepEqual(kernel.dump().promises, [
-      {
-        id: 'kp40',
-        state: 'unresolved',
-        decider: vat1,
-        subscribers: [],
-        queue: [],
-      },
-      {
-        id: 'kp41',
-        state: 'unresolved',
-        decider: undefined,
-        subscribers: [],
-        queue: [],
-      },
-    ]);
-
-    kt.push(['ko22', vat1, 'o+7']);
-    kt.push(['kp40', vat1, p7]);
-    kt.push(['kp41', vat1, 'p+5']);
-    checkKT(t, kernel, kt);
-
-    await kernel.step();
-    t.deepEqual(log, [
-      // todo: check result
-      ['d2', 'o+5', 'bar', capdata('bargs', ['o+5', 'o-50', 'p-60'])],
-      [
-        'd2 promises',
-        [
-          {
-            id: 'kp40',
-            state: 'unresolved',
-            decider: vat1,
-            subscribers: [],
-            queue: [],
-          },
-          {
-            id: 'kp41',
-            state: 'unresolved',
-            decider: vat2,
-            subscribers: [],
-            queue: [],
-          },
-        ],
-      ],
-    ]);
-
-    kt.push(['ko22', vat2, 'o-50']);
-    kt.push(['kp41', vat2, 'p-61']);
-    kt.push(['kp40', vat2, 'p-60']);
-    checkKT(t, kernel, kt);
-
-    t.deepEqual(kernel.dump().promises, [
-      {
-        id: 'kp40',
-        state: 'unresolved',
-        decider: vat1,
-        // Sending a promise from vat1 to vat2 doesn't cause vat2 to be
-        // subscribed unless they want it. Liveslots will always subscribe,
-        // because we don't have enough hooks into Promises to detect a
-        // .then(), but non-liveslots vats don't have to.
-        subscribers: [],
-        queue: [],
-      },
-      {
-        id: 'kp41',
-        state: 'unresolved',
-        decider: vat2,
-        subscribers: [],
-        queue: [],
-      },
-    ]);
-
-    t.end();
-  });
-
-  test('three-party', async t => {
-    const kernel = buildKernel(makeEndowments());
-    const log = [];
-    let bobForA;
-    let carolForA;
-
-    function setupA(syscall) {
-      let nextPromiseIndex = 5;
-      function allocatePromise() {
-        const index = nextPromiseIndex;
-        nextPromiseIndex += 1;
-        return makeVatSlot('promise', true, index);
-      }
-      function deliver(facetID, method, args) {
-        console.log(`vatA/${facetID} called`);
-        log.push(['vatA', facetID, method, args]);
-        const pid = allocatePromise();
-        syscall.send(bobForA, 'intro', capdata('bargs', [carolForA]), pid);
-        log.push(['vatA', 'promiseID', pid]);
-      }
-      return { deliver };
-    }
-    kernel.addGenesisVat('vatA', setupA);
-
-    function setupB(_syscall) {
-      function deliver(facetID, method, args) {
-        console.log(`vatB/${facetID} called`);
-        log.push(['vatB', facetID, method, args]);
-      }
-      return { deliver };
-    }
-    kernel.addGenesisVat('vatB', setupB);
-
-    function setupC(_syscall) {
-      function deliver(facetID, method, args) {
-        log.push(['vatC', facetID, method, args]);
-      }
-      return { deliver };
-    }
-    kernel.addGenesisVat('vatC', setupC);
-
-    await kernel.start();
-    const vatA = kernel.vatNameToID('vatA');
-    const vatB = kernel.vatNameToID('vatB');
-    const vatC = kernel.vatNameToID('vatC');
-
-    const alice = kernel.addExport(vatA, 'o+4');
-    const bob = kernel.addExport(vatB, 'o+5');
-    const carol = kernel.addExport(vatC, 'o+6');
-
-    bobForA = kernel.addImport(vatA, bob);
-    carolForA = kernel.addImport(vatA, carol);
-
-    // do an extra allocation to make sure we aren't confusing the indices
-    const extraP = 'p+99';
-    const ap = kernel.addExport(vatA, extraP);
-
-    const data = kernel.dump();
-    t.deepEqual(data.vatTables, [
-      { vatID: vatA, state: { transcript: [] } },
-      { vatID: vatB, state: { transcript: [] } },
-      { vatID: vatC, state: { transcript: [] } },
-    ]);
-    const kt = [
-      [alice, vatA, 'o+4'],
-      [bob, vatA, bobForA],
-      [bob, vatB, 'o+5'],
-      [carol, vatA, carolForA],
-      [carol, vatC, 'o+6'],
-      [ap, vatA, extraP],
-    ];
-    checkKT(t, kernel, kt);
-    t.deepEqual(log, []);
-
-    kernel.queueToExport(vatA, 'o+4', 'foo', capdata('args'));
-    await kernel.step();
-
-    t.deepEqual(log.shift(), ['vatA', 'o+4', 'foo', capdata('args')]);
-    t.deepEqual(log.shift(), ['vatA', 'promiseID', 'p+5']);
-    t.deepEqual(log, []);
-
-    t.deepEqual(kernel.dump().runQueue, [
-      {
-        type: 'send',
-        target: bob,
-        msg: {
-          method: 'intro',
-          args: capdata('bargs', [carol]),
-          result: 'kp41',
-        },
-      },
-    ]);
-    t.deepEqual(kernel.dump().promises, [
-      {
-        id: ap,
-        state: 'unresolved',
-        decider: vatA,
-        subscribers: [],
-        queue: [],
-      },
-      {
-        id: 'kp41',
-        state: 'unresolved',
-        decider: undefined,
-        subscribers: [],
-        queue: [],
-      },
-    ]);
-    kt.push(['kp41', vatA, 'p+5']);
-    checkKT(t, kernel, kt);
-
-    await kernel.step();
-    t.deepEqual(log, [['vatB', 'o+5', 'intro', capdata('bargs', ['o-50'])]]);
-    kt.push([carol, vatB, 'o-50']);
-    kt.push(['kp41', vatB, 'p-60']);
-    checkKT(t, kernel, kt);
-
-    t.end();
-  });
-
-  test('transfer promise', async t => {
-    const kernel = buildKernel(makeEndowments());
-    let syscallA;
-    const logA = [];
-    function setupA(syscall) {
-      syscallA = syscall;
-      function deliver(facetID, method, args) {
-        logA.push([facetID, method, args]);
-      }
-      return { deliver };
-    }
-    kernel.addGenesisVat('vatA', setupA);
-
-    let syscallB;
-    const logB = [];
-    function setupB(syscall) {
-      syscallB = syscall;
-      function deliver(facetID, method, args) {
-        logB.push([facetID, method, args]);
-      }
-      return { deliver };
-    }
-    kernel.addGenesisVat('vatB', setupB);
-
-    await kernel.start();
-    const vatA = kernel.vatNameToID('vatA');
-    const vatB = kernel.vatNameToID('vatB');
-
-    const alice = kernel.addExport(vatA, 'o+6');
-    const bob = kernel.addExport(vatB, 'o+5');
-
-    const B = kernel.addImport(vatA, bob);
-    const A = kernel.addImport(vatB, alice);
-
-    // we send pr1
-    const pr1 = 'p+6';
-
-    const kt = [
-      ['ko20', vatA, 'o+6'],
-      ['ko20', vatB, 'o-50'],
-      ['ko21', vatA, 'o-50'],
-      ['ko21', vatB, 'o+5'],
-    ];
-    checkKT(t, kernel, kt);
-    const kp = [];
-    checkPromises(t, kernel, kp);
-
-    // sending a promise should arrive as a promise
-    syscallA.send(B, 'foo1', capdata('args', [pr1]));
-    t.deepEqual(kernel.dump().runQueue, [
-      {
-        type: 'send',
-        target: bob,
-        msg: {
-          method: 'foo1',
-          args: capdata('args', ['kp40']),
-          result: null,
-        },
-      },
-    ]);
-    kt.push(['kp40', vatA, pr1]);
-    checkKT(t, kernel, kt);
-    kp.push({
+    },
+  ]);
+  t.deepEqual(kernel.dump().promises, [
+    {
       id: 'kp40',
+      state: 'unresolved',
+      decider: vat1,
+      subscribers: [],
+      queue: [],
+    },
+    {
+      id: 'kp41',
+      state: 'unresolved',
+      decider: undefined,
+      subscribers: [],
+      queue: [],
+    },
+  ]);
+
+  kt.push(['ko22', vat1, 'o+7']);
+  kt.push(['kp40', vat1, p7]);
+  kt.push(['kp41', vat1, 'p+5']);
+  checkKT(t, kernel, kt);
+
+  await kernel.step();
+  t.deepEqual(log, [
+    // todo: check result
+    ['d2', 'o+5', 'bar', capdata('bargs', ['o+5', 'o-50', 'p-60'])],
+    [
+      'd2 promises',
+      [
+        {
+          id: 'kp40',
+          state: 'unresolved',
+          decider: vat1,
+          subscribers: [],
+          queue: [],
+        },
+        {
+          id: 'kp41',
+          state: 'unresolved',
+          decider: vat2,
+          subscribers: [],
+          queue: [],
+        },
+      ],
+    ],
+  ]);
+
+  kt.push(['ko22', vat2, 'o-50']);
+  kt.push(['kp41', vat2, 'p-61']);
+  kt.push(['kp40', vat2, 'p-60']);
+  checkKT(t, kernel, kt);
+
+  t.deepEqual(kernel.dump().promises, [
+    {
+      id: 'kp40',
+      state: 'unresolved',
+      decider: vat1,
+      // Sending a promise from vat1 to vat2 doesn't cause vat2 to be
+      // subscribed unless they want it. Liveslots will always subscribe,
+      // because we don't have enough hooks into Promises to detect a
+      // .then(), but non-liveslots vats don't have to.
+      subscribers: [],
+      queue: [],
+    },
+    {
+      id: 'kp41',
+      state: 'unresolved',
+      decider: vat2,
+      subscribers: [],
+      queue: [],
+    },
+  ]);
+
+  t.end();
+});
+
+test('three-party', async t => {
+  const kernel = buildKernel(makeEndowments());
+  const log = [];
+  let bobForA;
+  let carolForA;
+
+  function setupA(syscall) {
+    let nextPromiseIndex = 5;
+    function allocatePromise() {
+      const index = nextPromiseIndex;
+      nextPromiseIndex += 1;
+      return makeVatSlot('promise', true, index);
+    }
+    function deliver(facetID, method, args) {
+      console.log(`vatA/${facetID} called`);
+      log.push(['vatA', facetID, method, args]);
+      const pid = allocatePromise();
+      syscall.send(bobForA, 'intro', capdata('bargs', [carolForA]), pid);
+      log.push(['vatA', 'promiseID', pid]);
+    }
+    return { deliver };
+  }
+  kernel.addGenesisVat('vatA', setupA);
+
+  function setupB(_syscall) {
+    function deliver(facetID, method, args) {
+      console.log(`vatB/${facetID} called`);
+      log.push(['vatB', facetID, method, args]);
+    }
+    return { deliver };
+  }
+  kernel.addGenesisVat('vatB', setupB);
+
+  function setupC(_syscall) {
+    function deliver(facetID, method, args) {
+      log.push(['vatC', facetID, method, args]);
+    }
+    return { deliver };
+  }
+  kernel.addGenesisVat('vatC', setupC);
+
+  await kernel.start();
+  const vatA = kernel.vatNameToID('vatA');
+  const vatB = kernel.vatNameToID('vatB');
+  const vatC = kernel.vatNameToID('vatC');
+
+  const alice = kernel.addExport(vatA, 'o+4');
+  const bob = kernel.addExport(vatB, 'o+5');
+  const carol = kernel.addExport(vatC, 'o+6');
+
+  bobForA = kernel.addImport(vatA, bob);
+  carolForA = kernel.addImport(vatA, carol);
+
+  // do an extra allocation to make sure we aren't confusing the indices
+  const extraP = 'p+99';
+  const ap = kernel.addExport(vatA, extraP);
+
+  const data = kernel.dump();
+  t.deepEqual(data.vatTables, [
+    { vatID: vatA, state: { transcript: [] } },
+    { vatID: vatB, state: { transcript: [] } },
+    { vatID: vatC, state: { transcript: [] } },
+  ]);
+  const kt = [
+    [alice, vatA, 'o+4'],
+    [bob, vatA, bobForA],
+    [bob, vatB, 'o+5'],
+    [carol, vatA, carolForA],
+    [carol, vatC, 'o+6'],
+    [ap, vatA, extraP],
+  ];
+  checkKT(t, kernel, kt);
+  t.deepEqual(log, []);
+
+  kernel.queueToExport(vatA, 'o+4', 'foo', capdata('args'));
+  await kernel.step();
+
+  t.deepEqual(log.shift(), ['vatA', 'o+4', 'foo', capdata('args')]);
+  t.deepEqual(log.shift(), ['vatA', 'promiseID', 'p+5']);
+  t.deepEqual(log, []);
+
+  t.deepEqual(kernel.dump().runQueue, [
+    {
+      type: 'send',
+      target: bob,
+      msg: {
+        method: 'intro',
+        args: capdata('bargs', [carol]),
+        result: 'kp41',
+      },
+    },
+  ]);
+  t.deepEqual(kernel.dump().promises, [
+    {
+      id: ap,
       state: 'unresolved',
       decider: vatA,
       subscribers: [],
       queue: [],
-    });
-    checkPromises(t, kernel, kp);
-    await kernel.run();
-    t.deepEqual(logB.shift(), ['o+5', 'foo1', capdata('args', ['p-60'])]);
-    t.deepEqual(logB, []);
-    kt.push(['kp40', vatB, 'p-60']); // pr1 for B
-    checkKT(t, kernel, kt);
+    },
+    {
+      id: 'kp41',
+      state: 'unresolved',
+      decider: undefined,
+      subscribers: [],
+      queue: [],
+    },
+  ]);
+  kt.push(['kp41', vatA, 'p+5']);
+  checkKT(t, kernel, kt);
 
-    // sending it a second time should arrive as the same thing
-    syscallA.send(B, 'foo2', capdata('args', [pr1]));
-    await kernel.run();
-    t.deepEqual(logB.shift(), ['o+5', 'foo2', capdata('args', ['p-60'])]);
-    t.deepEqual(logB, []);
-    checkKT(t, kernel, kt);
-    checkPromises(t, kernel, kp);
+  await kernel.step();
+  t.deepEqual(log, [['vatB', 'o+5', 'intro', capdata('bargs', ['o-50'])]]);
+  kt.push([carol, vatB, 'o-50']);
+  kt.push(['kp41', vatB, 'p-60']);
+  checkKT(t, kernel, kt);
 
-    // sending it back should arrive with the sender's index
-    syscallB.send(A, 'foo3', capdata('args', ['p-60']));
-    await kernel.run();
-    t.deepEqual(logA.shift(), ['o+6', 'foo3', capdata('args', [pr1])]);
-    t.deepEqual(logA, []);
-    checkKT(t, kernel, kt);
-    checkPromises(t, kernel, kp);
+  t.end();
+});
 
-    // sending it back a second time should arrive as the same thing
-    syscallB.send(A, 'foo4', capdata('args', ['p-60']));
-    await kernel.run();
-    t.deepEqual(logA.shift(), ['o+6', 'foo4', capdata('args', [pr1])]);
-    t.deepEqual(logA, []);
-    checkPromises(t, kernel, kp);
-    checkKT(t, kernel, kt);
+test('transfer promise', async t => {
+  const kernel = buildKernel(makeEndowments());
+  let syscallA;
+  const logA = [];
+  function setupA(syscall) {
+    syscallA = syscall;
+    function deliver(facetID, method, args) {
+      logA.push([facetID, method, args]);
+    }
+    return { deliver };
+  }
+  kernel.addGenesisVat('vatA', setupA);
 
-    t.end();
+  let syscallB;
+  const logB = [];
+  function setupB(syscall) {
+    syscallB = syscall;
+    function deliver(facetID, method, args) {
+      logB.push([facetID, method, args]);
+    }
+    return { deliver };
+  }
+  kernel.addGenesisVat('vatB', setupB);
+
+  await kernel.start();
+  const vatA = kernel.vatNameToID('vatA');
+  const vatB = kernel.vatNameToID('vatB');
+
+  const alice = kernel.addExport(vatA, 'o+6');
+  const bob = kernel.addExport(vatB, 'o+5');
+
+  const B = kernel.addImport(vatA, bob);
+  const A = kernel.addImport(vatB, alice);
+
+  // we send pr1
+  const pr1 = 'p+6';
+
+  const kt = [
+    ['ko20', vatA, 'o+6'],
+    ['ko20', vatB, 'o-50'],
+    ['ko21', vatA, 'o-50'],
+    ['ko21', vatB, 'o+5'],
+  ];
+  checkKT(t, kernel, kt);
+  const kp = [];
+  checkPromises(t, kernel, kp);
+
+  // sending a promise should arrive as a promise
+  syscallA.send(B, 'foo1', capdata('args', [pr1]));
+  t.deepEqual(kernel.dump().runQueue, [
+    {
+      type: 'send',
+      target: bob,
+      msg: {
+        method: 'foo1',
+        args: capdata('args', ['kp40']),
+        result: null,
+      },
+    },
+  ]);
+  kt.push(['kp40', vatA, pr1]);
+  checkKT(t, kernel, kt);
+  kp.push({
+    id: 'kp40',
+    state: 'unresolved',
+    decider: vatA,
+    subscribers: [],
+    queue: [],
   });
+  checkPromises(t, kernel, kp);
+  await kernel.run();
+  t.deepEqual(logB.shift(), ['o+5', 'foo1', capdata('args', ['p-60'])]);
+  t.deepEqual(logB, []);
+  kt.push(['kp40', vatB, 'p-60']); // pr1 for B
+  checkKT(t, kernel, kt);
 
-  test('subscribe to promise', async t => {
-    const kernel = buildKernel(makeEndowments());
-    let syscall;
-    const log = [];
-    function setup(s) {
-      syscall = s;
-      function deliver(facetID, method, args) {
-        log.push(['deliver', facetID, method, args]);
+  // sending it a second time should arrive as the same thing
+  syscallA.send(B, 'foo2', capdata('args', [pr1]));
+  await kernel.run();
+  t.deepEqual(logB.shift(), ['o+5', 'foo2', capdata('args', ['p-60'])]);
+  t.deepEqual(logB, []);
+  checkKT(t, kernel, kt);
+  checkPromises(t, kernel, kp);
+
+  // sending it back should arrive with the sender's index
+  syscallB.send(A, 'foo3', capdata('args', ['p-60']));
+  await kernel.run();
+  t.deepEqual(logA.shift(), ['o+6', 'foo3', capdata('args', [pr1])]);
+  t.deepEqual(logA, []);
+  checkKT(t, kernel, kt);
+  checkPromises(t, kernel, kp);
+
+  // sending it back a second time should arrive as the same thing
+  syscallB.send(A, 'foo4', capdata('args', ['p-60']));
+  await kernel.run();
+  t.deepEqual(logA.shift(), ['o+6', 'foo4', capdata('args', [pr1])]);
+  t.deepEqual(logA, []);
+  checkPromises(t, kernel, kp);
+  checkKT(t, kernel, kt);
+
+  t.end();
+});
+
+test('subscribe to promise', async t => {
+  const kernel = buildKernel(makeEndowments());
+  let syscall;
+  const log = [];
+  function setup(s) {
+    syscall = s;
+    function deliver(facetID, method, args) {
+      log.push(['deliver', facetID, method, args]);
+    }
+    return { deliver };
+  }
+  kernel.addGenesisVat('vat1', setup);
+  kernel.addGenesisVat('vat2', emptySetup);
+
+  await kernel.start();
+  const vat1 = kernel.vatNameToID('vat1');
+  const vat2 = kernel.vatNameToID('vat2');
+
+  const kp = kernel.addExport(vat2, 'p+5');
+  const pr = kernel.addImport(vat1, kp);
+  t.deepEqual(pr, 'p-60');
+  t.deepEqual(kernel.dump().kernelTable, [
+    [kp, vat1, pr],
+    [kp, vat2, 'p+5'],
+  ]);
+
+  syscall.subscribe(pr);
+  t.deepEqual(kernel.dump().promises, [
+    {
+      id: kp,
+      state: 'unresolved',
+      decider: vat2,
+      subscribers: [vat1],
+      queue: [],
+    },
+  ]);
+  t.deepEqual(kernel.dump().runQueue, []);
+  t.deepEqual(log, []);
+
+  t.end();
+});
+
+test('promise resolveToData', async t => {
+  const kernel = buildKernel(makeEndowments());
+  const log = [];
+
+  let syscallA;
+  function setupA(s) {
+    syscallA = s;
+    function deliver() {}
+    function notifyFulfillToData(promiseID, data) {
+      log.push(['notify', promiseID, data]);
+    }
+    return { deliver, notifyFulfillToData };
+  }
+  kernel.addGenesisVat('vatA', setupA);
+
+  let syscallB;
+  function setupB(s) {
+    syscallB = s;
+    function deliver() {}
+    return { deliver };
+  }
+  kernel.addGenesisVat('vatB', setupB);
+  await kernel.start();
+  const vatA = kernel.vatNameToID('vatA');
+  const vatB = kernel.vatNameToID('vatB');
+
+  const aliceForA = 'o+6';
+  const pForB = 'p+5';
+  const pForKernel = kernel.addExport(vatB, pForB);
+  const pForA = kernel.addImport(vatA, pForKernel);
+  t.deepEqual(kernel.dump().kernelTable, [
+    [pForKernel, vatA, pForA],
+    [pForKernel, vatB, pForB],
+  ]);
+
+  syscallA.subscribe(pForA);
+  t.deepEqual(kernel.dump().promises, [
+    {
+      id: pForKernel,
+      state: 'unresolved',
+      decider: vatB,
+      subscribers: [vatA],
+      queue: [],
+    },
+  ]);
+
+  syscallB.fulfillToData(pForB, capdata('args', [aliceForA]));
+  // this causes a notifyFulfillToData message to be queued
+  t.deepEqual(log, []); // no other dispatch calls
+  t.deepEqual(kernel.dump().runQueue, [
+    {
+      type: 'notify',
+      vatID: vatA,
+      kpid: pForKernel,
+    },
+  ]);
+
+  await kernel.step();
+  // the kernelPromiseID gets mapped back to the vat PromiseID
+  t.deepEqual(log.shift(), ['notify', pForA, capdata('args', ['o-50'])]);
+  t.deepEqual(log, []); // no other dispatch calls
+  t.deepEqual(kernel.dump().promises, [
+    {
+      id: pForKernel,
+      state: 'fulfilledToData',
+      data: capdata('args', ['ko20']),
+    },
+  ]);
+  t.deepEqual(kernel.dump().runQueue, []);
+
+  t.end();
+});
+
+test('promise resolveToPresence', async t => {
+  const kernel = buildKernel(makeEndowments());
+  const log = [];
+
+  let syscallA;
+  function setupA(s) {
+    syscallA = s;
+    function deliver() {}
+    function notifyFulfillToPresence(promiseID, slot) {
+      log.push(['notify', promiseID, slot]);
+    }
+    return { deliver, notifyFulfillToPresence };
+  }
+  kernel.addGenesisVat('vatA', setupA);
+
+  let syscallB;
+  function setupB(s) {
+    syscallB = s;
+    function deliver() {}
+    return { deliver };
+  }
+  kernel.addGenesisVat('vatB', setupB);
+  await kernel.start();
+  const vatA = kernel.vatNameToID('vatA');
+  const vatB = kernel.vatNameToID('vatB');
+
+  const bobForB = 'o+6';
+  const bobForKernel = kernel.addExport(vatB, 'o+6');
+  const bobForA = kernel.addImport(vatA, bobForKernel);
+
+  const pForB = 'p+5';
+  const pForKernel = kernel.addExport(vatB, 'p+5');
+  const pForA = kernel.addImport(vatA, pForKernel);
+  const kt = [
+    [bobForKernel, vatB, bobForB],
+    [bobForKernel, vatA, bobForA],
+    [pForKernel, vatA, pForA],
+    [pForKernel, vatB, pForB],
+  ];
+  checkKT(t, kernel, kt);
+
+  syscallA.subscribe(pForA);
+  t.deepEqual(kernel.dump().promises, [
+    {
+      id: pForKernel,
+      state: 'unresolved',
+      decider: vatB,
+      subscribers: [vatA],
+      queue: [],
+    },
+  ]);
+
+  syscallB.fulfillToPresence(pForB, bobForB);
+  t.deepEqual(log, []); // no other dispatch calls
+  t.deepEqual(kernel.dump().runQueue, [
+    {
+      type: 'notify',
+      vatID: vatA,
+      kpid: pForKernel,
+    },
+  ]);
+
+  await kernel.step();
+  t.deepEqual(log.shift(), ['notify', pForA, bobForA]);
+  t.deepEqual(log, []); // no other dispatch calls
+  t.deepEqual(kernel.dump().promises, [
+    {
+      id: pForKernel,
+      state: 'fulfilledToPresence',
+      slot: bobForKernel,
+    },
+  ]);
+  t.deepEqual(kernel.dump().runQueue, []);
+  t.end();
+});
+
+test('promise reject', async t => {
+  const kernel = buildKernel(makeEndowments());
+  const log = [];
+
+  let syscallA;
+  function setupA(s) {
+    syscallA = s;
+    function deliver() {}
+    function notifyReject(promiseID, rejectData) {
+      log.push(['notify', promiseID, rejectData]);
+    }
+    return { deliver, notifyReject };
+  }
+  kernel.addGenesisVat('vatA', setupA);
+
+  let syscallB;
+  function setupB(s) {
+    syscallB = s;
+    function deliver() {}
+    return { deliver };
+  }
+  kernel.addGenesisVat('vatB', setupB);
+  await kernel.start();
+  const vatA = kernel.vatNameToID('vatA');
+  const vatB = kernel.vatNameToID('vatB');
+
+  const aliceForA = 'o+6';
+  const pForB = 'p+5';
+  const pForKernel = kernel.addExport(vatB, pForB);
+  const pForA = kernel.addImport(vatA, pForKernel);
+  t.deepEqual(kernel.dump().kernelTable, [
+    [pForKernel, vatA, pForA],
+    [pForKernel, vatB, pForB],
+  ]);
+
+  syscallA.subscribe(pForA);
+  t.deepEqual(kernel.dump().promises, [
+    {
+      id: pForKernel,
+      state: 'unresolved',
+      decider: vatB,
+      subscribers: [vatA],
+      queue: [],
+    },
+  ]);
+
+  syscallB.reject(pForB, capdata('args', [aliceForA]));
+  // this causes a notifyFulfillToData message to be queued
+  t.deepEqual(log, []); // no other dispatch calls
+  t.deepEqual(kernel.dump().runQueue, [
+    {
+      type: 'notify',
+      vatID: vatA,
+      kpid: pForKernel,
+    },
+  ]);
+
+  await kernel.step();
+  // the kernelPromiseID gets mapped back to the vat PromiseID
+  t.deepEqual(log.shift(), ['notify', pForA, capdata('args', ['o-50'])]);
+  t.deepEqual(log, []); // no other dispatch calls
+  t.deepEqual(kernel.dump().promises, [
+    {
+      id: pForKernel,
+      state: 'rejected',
+      data: capdata('args', ['ko20']),
+    },
+  ]);
+  t.deepEqual(kernel.dump().runQueue, []);
+
+  t.end();
+});
+
+test('transcript', async t => {
+  const aliceForAlice = 'o+1';
+  const kernel = buildKernel(makeEndowments());
+  function setup(syscall, _state) {
+    function deliver(facetID, _method, args) {
+      if (facetID === aliceForAlice) {
+        syscall.send(args.slots[1], 'foo', capdata('fooarg'), 'p+5');
       }
-      return { deliver };
     }
-    kernel.addGenesisVat('vat1', setup);
-    kernel.addGenesisVat('vat2', emptySetup);
+    return { deliver };
+  }
+  kernel.addGenesisVat('vatA', setup);
+  kernel.addGenesisVat('vatB', emptySetup);
+  await kernel.start();
+  const vatA = kernel.vatNameToID('vatA');
+  const vatB = kernel.vatNameToID('vatB');
 
-    await kernel.start();
-    const vat1 = kernel.vatNameToID('vat1');
-    const vat2 = kernel.vatNameToID('vat2');
+  const alice = kernel.addExport(vatA, aliceForAlice);
+  const bob = kernel.addExport(vatB, 'o+2');
+  const bobForAlice = kernel.addImport(vatA, bob);
 
-    const kp = kernel.addExport(vat2, 'p+5');
-    const pr = kernel.addImport(vat1, kp);
-    t.deepEqual(pr, 'p-60');
-    t.deepEqual(kernel.dump().kernelTable, [
-      [kp, vat1, pr],
-      [kp, vat2, 'p+5'],
-    ]);
+  kernel.queueToExport(
+    vatA,
+    aliceForAlice,
+    'store',
+    capdata('args string', [alice, bob]),
+  );
+  await kernel.step();
 
-    syscall.subscribe(pr);
-    t.deepEqual(kernel.dump().promises, [
-      {
-        id: kp,
-        state: 'unresolved',
-        decider: vat2,
-        subscribers: [vat1],
-        queue: [],
-      },
-    ]);
-    t.deepEqual(kernel.dump().runQueue, []);
-    t.deepEqual(log, []);
+  // the transcript records vat-specific import/export slots
 
-    t.end();
-  });
-
-  test('promise resolveToData', async t => {
-    const kernel = buildKernel(makeEndowments());
-    const log = [];
-
-    let syscallA;
-    function setupA(s) {
-      syscallA = s;
-      function deliver() {}
-      function notifyFulfillToData(promiseID, data) {
-        log.push(['notify', promiseID, data]);
-      }
-      return { deliver, notifyFulfillToData };
-    }
-    kernel.addGenesisVat('vatA', setupA);
-
-    let syscallB;
-    function setupB(s) {
-      syscallB = s;
-      function deliver() {}
-      return { deliver };
-    }
-    kernel.addGenesisVat('vatB', setupB);
-    await kernel.start();
-    const vatA = kernel.vatNameToID('vatA');
-    const vatB = kernel.vatNameToID('vatB');
-
-    const aliceForA = 'o+6';
-    const pForB = 'p+5';
-    const pForKernel = kernel.addExport(vatB, pForB);
-    const pForA = kernel.addImport(vatA, pForKernel);
-    t.deepEqual(kernel.dump().kernelTable, [
-      [pForKernel, vatA, pForA],
-      [pForKernel, vatB, pForB],
-    ]);
-
-    syscallA.subscribe(pForA);
-    t.deepEqual(kernel.dump().promises, [
-      {
-        id: pForKernel,
-        state: 'unresolved',
-        decider: vatB,
-        subscribers: [vatA],
-        queue: [],
-      },
-    ]);
-
-    syscallB.fulfillToData(pForB, capdata('args', [aliceForA]));
-    // this causes a notifyFulfillToData message to be queued
-    t.deepEqual(log, []); // no other dispatch calls
-    t.deepEqual(kernel.dump().runQueue, [
-      {
-        type: 'notify',
-        vatID: vatA,
-        kpid: pForKernel,
-      },
-    ]);
-
-    await kernel.step();
-    // the kernelPromiseID gets mapped back to the vat PromiseID
-    t.deepEqual(log.shift(), ['notify', pForA, capdata('args', ['o-50'])]);
-    t.deepEqual(log, []); // no other dispatch calls
-    t.deepEqual(kernel.dump().promises, [
-      {
-        id: pForKernel,
-        state: 'fulfilledToData',
-        data: capdata('args', ['ko20']),
-      },
-    ]);
-    t.deepEqual(kernel.dump().runQueue, []);
-
-    t.end();
-  });
-
-  test('promise resolveToPresence', async t => {
-    const kernel = buildKernel(makeEndowments());
-    const log = [];
-
-    let syscallA;
-    function setupA(s) {
-      syscallA = s;
-      function deliver() {}
-      function notifyFulfillToPresence(promiseID, slot) {
-        log.push(['notify', promiseID, slot]);
-      }
-      return { deliver, notifyFulfillToPresence };
-    }
-    kernel.addGenesisVat('vatA', setupA);
-
-    let syscallB;
-    function setupB(s) {
-      syscallB = s;
-      function deliver() {}
-      return { deliver };
-    }
-    kernel.addGenesisVat('vatB', setupB);
-    await kernel.start();
-    const vatA = kernel.vatNameToID('vatA');
-    const vatB = kernel.vatNameToID('vatB');
-
-    const bobForB = 'o+6';
-    const bobForKernel = kernel.addExport(vatB, 'o+6');
-    const bobForA = kernel.addImport(vatA, bobForKernel);
-
-    const pForB = 'p+5';
-    const pForKernel = kernel.addExport(vatB, 'p+5');
-    const pForA = kernel.addImport(vatA, pForKernel);
-    const kt = [
-      [bobForKernel, vatB, bobForB],
-      [bobForKernel, vatA, bobForA],
-      [pForKernel, vatA, pForA],
-      [pForKernel, vatB, pForB],
-    ];
-    checkKT(t, kernel, kt);
-
-    syscallA.subscribe(pForA);
-    t.deepEqual(kernel.dump().promises, [
-      {
-        id: pForKernel,
-        state: 'unresolved',
-        decider: vatB,
-        subscribers: [vatA],
-        queue: [],
-      },
-    ]);
-
-    syscallB.fulfillToPresence(pForB, bobForB);
-    t.deepEqual(log, []); // no other dispatch calls
-    t.deepEqual(kernel.dump().runQueue, [
-      {
-        type: 'notify',
-        vatID: vatA,
-        kpid: pForKernel,
-      },
-    ]);
-
-    await kernel.step();
-    t.deepEqual(log.shift(), ['notify', pForA, bobForA]);
-    t.deepEqual(log, []); // no other dispatch calls
-    t.deepEqual(kernel.dump().promises, [
-      {
-        id: pForKernel,
-        state: 'fulfilledToPresence',
-        slot: bobForKernel,
-      },
-    ]);
-    t.deepEqual(kernel.dump().runQueue, []);
-    t.end();
-  });
-
-  test('promise reject', async t => {
-    const kernel = buildKernel(makeEndowments());
-    const log = [];
-
-    let syscallA;
-    function setupA(s) {
-      syscallA = s;
-      function deliver() {}
-      function notifyReject(promiseID, rejectData) {
-        log.push(['notify', promiseID, rejectData]);
-      }
-      return { deliver, notifyReject };
-    }
-    kernel.addGenesisVat('vatA', setupA);
-
-    let syscallB;
-    function setupB(s) {
-      syscallB = s;
-      function deliver() {}
-      return { deliver };
-    }
-    kernel.addGenesisVat('vatB', setupB);
-    await kernel.start();
-    const vatA = kernel.vatNameToID('vatA');
-    const vatB = kernel.vatNameToID('vatB');
-
-    const aliceForA = 'o+6';
-    const pForB = 'p+5';
-    const pForKernel = kernel.addExport(vatB, pForB);
-    const pForA = kernel.addImport(vatA, pForKernel);
-    t.deepEqual(kernel.dump().kernelTable, [
-      [pForKernel, vatA, pForA],
-      [pForKernel, vatB, pForB],
-    ]);
-
-    syscallA.subscribe(pForA);
-    t.deepEqual(kernel.dump().promises, [
-      {
-        id: pForKernel,
-        state: 'unresolved',
-        decider: vatB,
-        subscribers: [vatA],
-        queue: [],
-      },
-    ]);
-
-    syscallB.reject(pForB, capdata('args', [aliceForA]));
-    // this causes a notifyFulfillToData message to be queued
-    t.deepEqual(log, []); // no other dispatch calls
-    t.deepEqual(kernel.dump().runQueue, [
-      {
-        type: 'notify',
-        vatID: vatA,
-        kpid: pForKernel,
-      },
-    ]);
-
-    await kernel.step();
-    // the kernelPromiseID gets mapped back to the vat PromiseID
-    t.deepEqual(log.shift(), ['notify', pForA, capdata('args', ['o-50'])]);
-    t.deepEqual(log, []); // no other dispatch calls
-    t.deepEqual(kernel.dump().promises, [
-      {
-        id: pForKernel,
-        state: 'rejected',
-        data: capdata('args', ['ko20']),
-      },
-    ]);
-    t.deepEqual(kernel.dump().runQueue, []);
-
-    t.end();
-  });
-
-  test('transcript', async t => {
-    const aliceForAlice = 'o+1';
-    const kernel = buildKernel(makeEndowments());
-    function setup(syscall, _state) {
-      function deliver(facetID, _method, args) {
-        if (facetID === aliceForAlice) {
-          syscall.send(args.slots[1], 'foo', capdata('fooarg'), 'p+5');
-        }
-      }
-      return { deliver };
-    }
-    kernel.addGenesisVat('vatA', setup);
-    kernel.addGenesisVat('vatB', emptySetup);
-    await kernel.start();
-    const vatA = kernel.vatNameToID('vatA');
-    const vatB = kernel.vatNameToID('vatB');
-
-    const alice = kernel.addExport(vatA, aliceForAlice);
-    const bob = kernel.addExport(vatB, 'o+2');
-    const bobForAlice = kernel.addImport(vatA, bob);
-
-    kernel.queueToExport(
-      vatA,
+  const tr = kernel.dump().vatTables[0].state.transcript;
+  t.equal(tr.length, 1);
+  t.deepEqual(tr[0], {
+    d: [
+      'deliver',
       aliceForAlice,
       'store',
-      capdata('args string', [alice, bob]),
-    );
-    await kernel.step();
+      capdata('args string', [aliceForAlice, bobForAlice]),
+      null,
+    ],
+    syscalls: [
+      {
+        d: ['send', bobForAlice, 'foo', capdata('fooarg'), 'p+5'],
+        response: null,
+      },
+    ],
+  });
 
-    // the transcript records vat-specific import/export slots
+  t.end();
+});
 
-    const tr = kernel.dump().vatTables[0].state.transcript;
-    t.equal(tr.length, 1);
-    t.deepEqual(tr[0], {
-      d: [
-        'deliver',
-        aliceForAlice,
-        'store',
-        capdata('args string', [aliceForAlice, bobForAlice]),
-        null,
-      ],
-      syscalls: [
+// p1=x!foo(); p2=p1!bar(); p3=p2!urgh(); no pipelining. p1 will have a
+// decider but p2 gets queued in p1 (not pipelined to vat-with-x) so p2 won't
+// have a decider. Make sure p3 gets queued in p2 rather than exploding.
+
+test('non-pipelined promise queueing', async t => {
+  const kernel = buildKernel(makeEndowments());
+  const log = [];
+
+  let syscall;
+  function setupA(s) {
+    syscall = s;
+    function deliver() {}
+    return { deliver };
+  }
+  kernel.addGenesisVat('vatA', setupA);
+
+  function setupB(_s) {
+    function deliver(target, method, args, result) {
+      log.push([target, method, args, result]);
+    }
+    return { deliver };
+  }
+  kernel.addGenesisVat('vatB', setupB);
+  await kernel.start();
+  const vatA = kernel.vatNameToID('vatA');
+  const vatB = kernel.vatNameToID('vatB');
+
+  const bobForB = 'o+6';
+  const bobForKernel = kernel.addExport(vatB, bobForB);
+  const bobForA = kernel.addImport(vatA, bobForKernel);
+
+  const p1ForA = 'p+1';
+  syscall.send(bobForA, 'foo', capdata('fooargs'), p1ForA);
+  const p1ForKernel = kernel.addExport(vatA, p1ForA);
+
+  const p2ForA = 'p+2';
+  syscall.send(p1ForA, 'bar', capdata('barargs'), p2ForA);
+  const p2ForKernel = kernel.addExport(vatA, p2ForA);
+
+  const p3ForA = 'p+3';
+  syscall.send(p2ForA, 'urgh', capdata('urghargs'), p3ForA);
+  const p3ForKernel = kernel.addExport(vatA, p3ForA);
+
+  t.deepEqual(kernel.dump().promises, [
+    {
+      id: p1ForKernel,
+      state: 'unresolved',
+      decider: undefined,
+      subscribers: [],
+      queue: [],
+    },
+    {
+      id: p2ForKernel,
+      state: 'unresolved',
+      decider: undefined,
+      subscribers: [],
+      queue: [],
+    },
+    {
+      id: p3ForKernel,
+      state: 'unresolved',
+      decider: undefined,
+      subscribers: [],
+      queue: [],
+    },
+  ]);
+
+  await kernel.run();
+
+  const p1ForB = kernel.addImport(vatB, p1ForKernel);
+  t.deepEqual(log.shift(), [bobForB, 'foo', capdata('fooargs'), p1ForB]);
+  t.deepEqual(log, []);
+
+  t.deepEqual(kernel.dump().promises, [
+    {
+      id: p1ForKernel,
+      state: 'unresolved',
+      decider: vatB,
+      subscribers: [],
+      queue: [
         {
-          d: ['send', bobForAlice, 'foo', capdata('fooarg'), 'p+5'],
-          response: null,
+          method: 'bar',
+          args: capdata('barargs'),
+          result: p2ForKernel,
         },
       ],
-    });
+    },
+    {
+      id: p2ForKernel,
+      state: 'unresolved',
+      decider: undefined,
+      subscribers: [],
+      queue: [
+        {
+          method: 'urgh',
+          args: capdata('urghargs'),
+          result: p3ForKernel,
+        },
+      ],
+    },
+    {
+      id: p3ForKernel,
+      state: 'unresolved',
+      decider: undefined,
+      subscribers: [],
+      queue: [],
+    },
+  ]);
 
-    t.end();
-  });
+  t.end();
+});
 
-  // p1=x!foo(); p2=p1!bar(); p3=p2!urgh(); no pipelining. p1 will have a
-  // decider but p2 gets queued in p1 (not pipelined to vat-with-x) so p2 won't
-  // have a decider. Make sure p3 gets queued in p2 rather than exploding.
+// p1=x!foo(); p2=p1!bar(); p3=p2!urgh(); with pipelining. All three should
+// get delivered to vat-with-x.
 
-  test('non-pipelined promise queueing', async t => {
-    const kernel = buildKernel(makeEndowments());
-    const log = [];
+test('pipelined promise queueing', async t => {
+  const kernel = buildKernel(makeEndowments());
+  const log = [];
 
-    let syscall;
-    function setupA(s) {
-      syscall = s;
-      function deliver() {}
-      return { deliver };
+  let syscall;
+  function setupA(s) {
+    syscall = s;
+    function deliver() {}
+    return { deliver };
+  }
+  kernel.addGenesisVat('vatA', setupA);
+
+  function setupB(_s) {
+    function deliver(target, method, args, result) {
+      log.push([target, method, args, result]);
     }
-    kernel.addGenesisVat('vatA', setupA);
+    return { deliver };
+  }
+  kernel.addGenesisVat('vatB', setupB, { enablePipelining: true });
+  await kernel.start();
+  const vatA = kernel.vatNameToID('vatA');
+  const vatB = kernel.vatNameToID('vatB');
 
-    function setupB(_s) {
-      function deliver(target, method, args, result) {
-        log.push([target, method, args, result]);
-      }
-      return { deliver };
-    }
-    kernel.addGenesisVat('vatB', setupB);
-    await kernel.start();
-    const vatA = kernel.vatNameToID('vatA');
-    const vatB = kernel.vatNameToID('vatB');
+  const bobForB = 'o+6';
+  const bobForKernel = kernel.addExport(vatB, bobForB);
+  const bobForA = kernel.addImport(vatA, bobForKernel);
 
-    const bobForB = 'o+6';
-    const bobForKernel = kernel.addExport(vatB, bobForB);
-    const bobForA = kernel.addImport(vatA, bobForKernel);
+  const p1ForA = 'p+1';
+  syscall.send(bobForA, 'foo', capdata('fooargs'), p1ForA);
+  const p1ForKernel = kernel.addExport(vatA, p1ForA);
 
-    const p1ForA = 'p+1';
-    syscall.send(bobForA, 'foo', capdata('fooargs'), p1ForA);
-    const p1ForKernel = kernel.addExport(vatA, p1ForA);
+  const p2ForA = 'p+2';
+  syscall.send(p1ForA, 'bar', capdata('barargs'), p2ForA);
+  const p2ForKernel = kernel.addExport(vatA, p2ForA);
 
-    const p2ForA = 'p+2';
-    syscall.send(p1ForA, 'bar', capdata('barargs'), p2ForA);
-    const p2ForKernel = kernel.addExport(vatA, p2ForA);
+  const p3ForA = 'p+3';
+  syscall.send(p2ForA, 'urgh', capdata('urghargs'), p3ForA);
+  const p3ForKernel = kernel.addExport(vatA, p3ForA);
 
-    const p3ForA = 'p+3';
-    syscall.send(p2ForA, 'urgh', capdata('urghargs'), p3ForA);
-    const p3ForKernel = kernel.addExport(vatA, p3ForA);
+  t.deepEqual(kernel.dump().promises, [
+    {
+      id: p1ForKernel,
+      state: 'unresolved',
+      decider: undefined,
+      subscribers: [],
+      queue: [],
+    },
+    {
+      id: p2ForKernel,
+      state: 'unresolved',
+      decider: undefined,
+      subscribers: [],
+      queue: [],
+    },
+    {
+      id: p3ForKernel,
+      state: 'unresolved',
+      decider: undefined,
+      subscribers: [],
+      queue: [],
+    },
+  ]);
 
-    t.deepEqual(kernel.dump().promises, [
-      {
-        id: p1ForKernel,
-        state: 'unresolved',
-        decider: undefined,
-        subscribers: [],
-        queue: [],
-      },
-      {
-        id: p2ForKernel,
-        state: 'unresolved',
-        decider: undefined,
-        subscribers: [],
-        queue: [],
-      },
-      {
-        id: p3ForKernel,
-        state: 'unresolved',
-        decider: undefined,
-        subscribers: [],
-        queue: [],
-      },
-    ]);
+  await kernel.run();
 
-    await kernel.run();
+  const p1ForB = kernel.addImport(vatB, p1ForKernel);
+  const p2ForB = kernel.addImport(vatB, p2ForKernel);
+  const p3ForB = kernel.addImport(vatB, p3ForKernel);
+  t.deepEqual(log.shift(), [bobForB, 'foo', capdata('fooargs'), p1ForB]);
+  t.deepEqual(log.shift(), [p1ForB, 'bar', capdata('barargs'), p2ForB]);
+  t.deepEqual(log.shift(), [p2ForB, 'urgh', capdata('urghargs'), p3ForB]);
+  t.deepEqual(log, []);
 
-    const p1ForB = kernel.addImport(vatB, p1ForKernel);
-    t.deepEqual(log.shift(), [bobForB, 'foo', capdata('fooargs'), p1ForB]);
-    t.deepEqual(log, []);
+  t.deepEqual(kernel.dump().promises, [
+    {
+      id: p1ForKernel,
+      state: 'unresolved',
+      decider: vatB,
+      subscribers: [],
+      queue: [],
+    },
+    {
+      id: p2ForKernel,
+      state: 'unresolved',
+      decider: vatB,
+      subscribers: [],
+      queue: [],
+    },
+    {
+      id: p3ForKernel,
+      state: 'unresolved',
+      decider: vatB,
+      subscribers: [],
+      queue: [],
+    },
+  ]);
 
-    t.deepEqual(kernel.dump().promises, [
-      {
-        id: p1ForKernel,
-        state: 'unresolved',
-        decider: vatB,
-        subscribers: [],
-        queue: [
-          {
-            method: 'bar',
-            args: capdata('barargs'),
-            result: p2ForKernel,
-          },
-        ],
-      },
-      {
-        id: p2ForKernel,
-        state: 'unresolved',
-        decider: undefined,
-        subscribers: [],
-        queue: [
-          {
-            method: 'urgh',
-            args: capdata('urghargs'),
-            result: p3ForKernel,
-          },
-        ],
-      },
-      {
-        id: p3ForKernel,
-        state: 'unresolved',
-        decider: undefined,
-        subscribers: [],
-        queue: [],
-      },
-    ]);
-
-    t.end();
-  });
-
-  // p1=x!foo(); p2=p1!bar(); p3=p2!urgh(); with pipelining. All three should
-  // get delivered to vat-with-x.
-
-  test('pipelined promise queueing', async t => {
-    const kernel = buildKernel(makeEndowments());
-    const log = [];
-
-    let syscall;
-    function setupA(s) {
-      syscall = s;
-      function deliver() {}
-      return { deliver };
-    }
-    kernel.addGenesisVat('vatA', setupA);
-
-    function setupB(_s) {
-      function deliver(target, method, args, result) {
-        log.push([target, method, args, result]);
-      }
-      return { deliver };
-    }
-    kernel.addGenesisVat('vatB', setupB, { enablePipelining: true });
-    await kernel.start();
-    const vatA = kernel.vatNameToID('vatA');
-    const vatB = kernel.vatNameToID('vatB');
-
-    const bobForB = 'o+6';
-    const bobForKernel = kernel.addExport(vatB, bobForB);
-    const bobForA = kernel.addImport(vatA, bobForKernel);
-
-    const p1ForA = 'p+1';
-    syscall.send(bobForA, 'foo', capdata('fooargs'), p1ForA);
-    const p1ForKernel = kernel.addExport(vatA, p1ForA);
-
-    const p2ForA = 'p+2';
-    syscall.send(p1ForA, 'bar', capdata('barargs'), p2ForA);
-    const p2ForKernel = kernel.addExport(vatA, p2ForA);
-
-    const p3ForA = 'p+3';
-    syscall.send(p2ForA, 'urgh', capdata('urghargs'), p3ForA);
-    const p3ForKernel = kernel.addExport(vatA, p3ForA);
-
-    t.deepEqual(kernel.dump().promises, [
-      {
-        id: p1ForKernel,
-        state: 'unresolved',
-        decider: undefined,
-        subscribers: [],
-        queue: [],
-      },
-      {
-        id: p2ForKernel,
-        state: 'unresolved',
-        decider: undefined,
-        subscribers: [],
-        queue: [],
-      },
-      {
-        id: p3ForKernel,
-        state: 'unresolved',
-        decider: undefined,
-        subscribers: [],
-        queue: [],
-      },
-    ]);
-
-    await kernel.run();
-
-    const p1ForB = kernel.addImport(vatB, p1ForKernel);
-    const p2ForB = kernel.addImport(vatB, p2ForKernel);
-    const p3ForB = kernel.addImport(vatB, p3ForKernel);
-    t.deepEqual(log.shift(), [bobForB, 'foo', capdata('fooargs'), p1ForB]);
-    t.deepEqual(log.shift(), [p1ForB, 'bar', capdata('barargs'), p2ForB]);
-    t.deepEqual(log.shift(), [p2ForB, 'urgh', capdata('urghargs'), p3ForB]);
-    t.deepEqual(log, []);
-
-    t.deepEqual(kernel.dump().promises, [
-      {
-        id: p1ForKernel,
-        state: 'unresolved',
-        decider: vatB,
-        subscribers: [],
-        queue: [],
-      },
-      {
-        id: p2ForKernel,
-        state: 'unresolved',
-        decider: vatB,
-        subscribers: [],
-        queue: [],
-      },
-      {
-        id: p3ForKernel,
-        state: 'unresolved',
-        decider: vatB,
-        subscribers: [],
-        queue: [],
-      },
-    ]);
-
-    t.end();
-  });
-}
-
-if (typeof require !== 'undefined' && typeof module !== 'undefined') {
-  runTests();
-}
+  t.end();
+});

--- a/packages/SwingSet/test/test-marshal.js
+++ b/packages/SwingSet/test/test-marshal.js
@@ -9,321 +9,315 @@ import makePromise from '../src/makePromise';
 
 import { buildVatController } from '../src/index';
 
-export default function runTests() {
-  async function prep() {
-    const config = {
-      vats: new Map(),
-      bootstrapIndexJS: undefined,
-    };
-    const controller = await buildVatController(config, false);
-    await controller.run();
+async function prep() {
+  const config = {
+    vats: new Map(),
+    bootstrapIndexJS: undefined,
+  };
+  const controller = await buildVatController(config, false);
+  await controller.run();
+}
+
+test('serialize static data', t => {
+  const m = makeMarshal();
+  const ser = val => m.serialize(val);
+  t.throws(() => ser([1, 2]), /cannot pass non-frozen objects like .*/);
+  t.deepEqual(ser(harden([1, 2])), { body: '[1,2]', slots: [] });
+  t.deepEqual(ser(harden({ foo: 1 })), {
+    body: '{"foo":1}',
+    slots: [],
+  });
+  t.deepEqual(ser(true), { body: 'true', slots: [] });
+  t.deepEqual(ser(1), { body: '1', slots: [] });
+  t.deepEqual(ser('abc'), { body: '"abc"', slots: [] });
+  t.deepEqual(ser(undefined), {
+    body: '{"@qclass":"undefined"}',
+    slots: [],
+  });
+  t.deepEqual(ser(-0), { body: '{"@qclass":"-0"}', slots: [] });
+  t.deepEqual(ser(NaN), { body: '{"@qclass":"NaN"}', slots: [] });
+  t.deepEqual(ser(Infinity), {
+    body: '{"@qclass":"Infinity"}',
+    slots: [],
+  });
+  t.deepEqual(ser(-Infinity), {
+    body: '{"@qclass":"-Infinity"}',
+    slots: [],
+  });
+  t.deepEqual(ser(Symbol.for('sym1')), {
+    body: '{"@qclass":"symbol","key":"sym1"}',
+    slots: [],
+  });
+  let bn;
+  try {
+    bn = BigInt(4);
+  } catch (e) {
+    if (!(e instanceof ReferenceError)) {
+      throw e;
+    }
+  }
+  if (bn) {
+    t.deepEqual(ser(bn), {
+      body: '{"@qclass":"bigint","digits":"4"}',
+      slots: [],
+    });
   }
 
-  test('serialize static data', t => {
-    const m = makeMarshal();
-    const ser = val => m.serialize(val);
-    t.throws(() => ser([1, 2]), /cannot pass non-frozen objects like .*/);
-    t.deepEqual(ser(harden([1, 2])), { body: '[1,2]', slots: [] });
-    t.deepEqual(ser(harden({ foo: 1 })), {
-      body: '{"foo":1}',
-      slots: [],
-    });
-    t.deepEqual(ser(true), { body: 'true', slots: [] });
-    t.deepEqual(ser(1), { body: '1', slots: [] });
-    t.deepEqual(ser('abc'), { body: '"abc"', slots: [] });
-    t.deepEqual(ser(undefined), {
-      body: '{"@qclass":"undefined"}',
-      slots: [],
-    });
-    t.deepEqual(ser(-0), { body: '{"@qclass":"-0"}', slots: [] });
-    t.deepEqual(ser(NaN), { body: '{"@qclass":"NaN"}', slots: [] });
-    t.deepEqual(ser(Infinity), {
-      body: '{"@qclass":"Infinity"}',
-      slots: [],
-    });
-    t.deepEqual(ser(-Infinity), {
-      body: '{"@qclass":"-Infinity"}',
-      slots: [],
-    });
-    t.deepEqual(ser(Symbol.for('sym1')), {
-      body: '{"@qclass":"symbol","key":"sym1"}',
-      slots: [],
-    });
-    let bn;
-    try {
-      bn = BigInt(4);
-    } catch (e) {
-      if (!(e instanceof ReferenceError)) {
-        throw e;
-      }
+  let em;
+  try {
+    throw new ReferenceError('msg');
+  } catch (e) {
+    em = harden(e);
+  }
+  t.deepEqual(ser(em), {
+    body: '{"@qclass":"error","name":"ReferenceError","message":"msg"}',
+    slots: [],
+  });
+
+  t.end();
+});
+
+test('unserialize static data', t => {
+  const m = makeMarshal();
+  const uns = body => m.unserialize({ body, slots: [] });
+  t.equal(uns('1'), 1);
+  t.equal(uns('"abc"'), 'abc');
+  t.equal(uns('false'), false);
+
+  // JS primitives that aren't natively representable by JSON
+  t.deepEqual(uns('{"@qclass":"undefined"}'), undefined);
+  t.ok(Object.is(uns('{"@qclass":"-0"}'), -0));
+  t.notOk(Object.is(uns('{"@qclass":"-0"}'), 0));
+  t.ok(Object.is(uns('{"@qclass":"NaN"}'), NaN));
+  t.deepEqual(uns('{"@qclass":"Infinity"}'), Infinity);
+  t.deepEqual(uns('{"@qclass":"-Infinity"}'), -Infinity);
+  t.deepEqual(uns('{"@qclass":"symbol", "key":"sym1"}'), Symbol.for('sym1'));
+
+  // Normal json reviver cannot make properties with undefined values
+  t.deepEqual(uns('[{"@qclass":"undefined"}]'), [undefined]);
+  t.deepEqual(uns('{"foo": {"@qclass":"undefined"}}'), { foo: undefined });
+  let bn;
+  try {
+    bn = BigInt(4);
+  } catch (e) {
+    if (!(e instanceof ReferenceError)) {
+      throw e;
     }
-    if (bn) {
-      t.deepEqual(ser(bn), {
-        body: '{"@qclass":"bigint","digits":"4"}',
-        slots: [],
-      });
-    }
+  }
+  if (bn) {
+    t.deepEqual(uns('{"@qclass":"bigint","digits":"1234"}'), BigInt(1234));
+  }
 
-    let em;
-    try {
-      throw new ReferenceError('msg');
-    } catch (e) {
-      em = harden(e);
-    }
-    t.deepEqual(ser(em), {
-      body: '{"@qclass":"error","name":"ReferenceError","message":"msg"}',
-      slots: [],
-    });
+  const em1 = uns(
+    '{"@qclass":"error","name":"ReferenceError","message":"msg"}',
+  );
+  t.ok(em1 instanceof ReferenceError);
+  t.equal(em1.message, 'msg');
+  t.ok(Object.isFrozen(em1));
 
-    t.end();
+  const em2 = uns('{"@qclass":"error","name":"TypeError","message":"msg2"}');
+  t.ok(em2 instanceof TypeError);
+  t.equal(em2.message, 'msg2');
+
+  const em3 = uns('{"@qclass":"error","name":"Unknown","message":"msg3"}');
+  t.ok(em3 instanceof Error);
+  t.equal(em3.message, 'msg3');
+
+  t.deepEqual(uns('[1,2]'), [1, 2]);
+  t.deepEqual(uns('{"a":1,"b":2}'), { a: 1, b: 2 });
+  t.deepEqual(uns('{"a":1,"b":{"c": 3}}'), { a: 1, b: { c: 3 } });
+
+  // should be frozen
+  const arr = uns('[1,2]');
+  t.ok(Object.isFrozen(arr));
+  const a = uns('{"b":{"c":{"d": []}}}');
+  t.ok(Object.isFrozen(a));
+  t.ok(Object.isFrozen(a.b));
+  t.ok(Object.isFrozen(a.b.c));
+  t.ok(Object.isFrozen(a.b.c.d));
+
+  t.end();
+});
+
+test('serialize ibid cycle', t => {
+  const m = makeMarshal();
+  const ser = val => m.serialize(val);
+  const cycle = ['a', 'x', 'c'];
+  cycle[1] = cycle;
+  harden(cycle);
+
+  t.deepEqual(ser(cycle), {
+    body: '["a",{"@qclass":"ibid","index":0},"c"]',
+    slots: [],
+  });
+  t.end();
+});
+
+test('forbid ibid cycle', t => {
+  const m = makeMarshal();
+  const uns = body => m.unserialize({ body, slots: [] });
+  t.throws(
+    () => uns('["a",{"@qclass":"ibid","index":0},"c"]'),
+    /Ibid cycle at 0/,
+  );
+  t.end();
+});
+
+test('unserialize ibid cycle', t => {
+  const m = makeMarshal();
+  const uns = body => m.unserialize({ body, slots: [] }, 'warnOfCycles');
+  const cycle = uns('["a",{"@qclass":"ibid","index":0},"c"]');
+  t.ok(Object.is(cycle[1], cycle));
+  t.end();
+});
+
+test('serialize exports', t => {
+  const { m } = makeMarshaller();
+  const ser = val => m.serialize(val);
+  const o1 = harden({});
+  const o2 = harden({
+    meth1() {
+      return 4;
+    },
+  });
+  t.deepEqual(ser(o1), {
+    body: '{"@qclass":"slot","index":0}',
+    slots: ['o+1'],
+  });
+  // m now remembers that o1 is exported as 1
+  t.deepEqual(ser(harden([o1, o1])), {
+    body: '[{"@qclass":"slot","index":0},{"@qclass":"ibid","index":1}]',
+    slots: ['o+1'],
+  });
+  t.deepEqual(ser(harden([o2, o1])), {
+    body: '[{"@qclass":"slot","index":0},{"@qclass":"slot","index":1}]',
+    slots: ['o+2', 'o+1'],
   });
 
-  test('unserialize static data', t => {
-    const m = makeMarshal();
-    const uns = body => m.unserialize({ body, slots: [] });
-    t.equal(uns('1'), 1);
-    t.equal(uns('"abc"'), 'abc');
-    t.equal(uns('false'), false);
+  t.end();
+});
 
-    // JS primitives that aren't natively representable by JSON
-    t.deepEqual(uns('{"@qclass":"undefined"}'), undefined);
-    t.ok(Object.is(uns('{"@qclass":"-0"}'), -0));
-    t.notOk(Object.is(uns('{"@qclass":"-0"}'), 0));
-    t.ok(Object.is(uns('{"@qclass":"NaN"}'), NaN));
-    t.deepEqual(uns('{"@qclass":"Infinity"}'), Infinity);
-    t.deepEqual(uns('{"@qclass":"-Infinity"}'), -Infinity);
-    t.deepEqual(uns('{"@qclass":"symbol", "key":"sym1"}'), Symbol.for('sym1'));
+test('deserialize imports', async t => {
+  await prep();
+  const { m } = makeMarshaller();
+  const a = m.unserialize({
+    body: '{"@qclass":"slot","index":0}',
+    slots: ['o-1'],
+  });
+  // a should be a proxy/presence. For now these are obvious.
+  t.equal(a.toString(), '[Presence o-1]');
+  t.ok(Object.isFrozen(a));
 
-    // Normal json reviver cannot make properties with undefined values
-    t.deepEqual(uns('[{"@qclass":"undefined"}]'), [undefined]);
-    t.deepEqual(uns('{"foo": {"@qclass":"undefined"}}'), { foo: undefined });
-    let bn;
-    try {
-      bn = BigInt(4);
-    } catch (e) {
-      if (!(e instanceof ReferenceError)) {
-        throw e;
-      }
-    }
-    if (bn) {
-      t.deepEqual(uns('{"@qclass":"bigint","digits":"1234"}'), BigInt(1234));
-    }
+  // m now remembers the proxy
+  const b = m.unserialize({
+    body: '{"@qclass":"slot","index":0}',
+    slots: ['o-1'],
+  });
+  t.is(a, b);
 
-    const em1 = uns(
-      '{"@qclass":"error","name":"ReferenceError","message":"msg"}',
-    );
-    t.ok(em1 instanceof ReferenceError);
-    t.equal(em1.message, 'msg');
-    t.ok(Object.isFrozen(em1));
+  // the slotid is what matters, not the index
+  const c = m.unserialize({
+    body: '{"@qclass":"slot","index":2}',
+    slots: ['x', 'x', 'o-1'],
+  });
+  t.is(a, c);
 
-    const em2 = uns('{"@qclass":"error","name":"TypeError","message":"msg2"}');
-    t.ok(em2 instanceof TypeError);
-    t.equal(em2.message, 'msg2');
+  t.end();
+});
 
-    const em3 = uns('{"@qclass":"error","name":"Unknown","message":"msg3"}');
-    t.ok(em3 instanceof Error);
-    t.equal(em3.message, 'msg3');
+test('deserialize exports', t => {
+  const { m } = makeMarshaller();
+  const o1 = harden({});
+  m.serialize(o1); // allocates slot=1
+  const a = m.unserialize({
+    body: '{"@qclass":"slot","index":0}',
+    slots: ['o+1'],
+  });
+  t.is(a, o1);
 
-    t.deepEqual(uns('[1,2]'), [1, 2]);
-    t.deepEqual(uns('{"a":1,"b":2}'), { a: 1, b: 2 });
-    t.deepEqual(uns('{"a":1,"b":{"c": 3}}'), { a: 1, b: { c: 3 } });
+  t.end();
+});
 
-    // should be frozen
-    const arr = uns('[1,2]');
-    t.ok(Object.isFrozen(arr));
-    const a = uns('{"b":{"c":{"d": []}}}');
-    t.ok(Object.isFrozen(a));
-    t.ok(Object.isFrozen(a.b));
-    t.ok(Object.isFrozen(a.b.c));
-    t.ok(Object.isFrozen(a.b.c.d));
-
-    t.end();
+test('serialize imports', async t => {
+  await prep();
+  const { m } = makeMarshaller();
+  const a = m.unserialize({
+    body: '{"@qclass":"slot","index":0}',
+    slots: ['o-1'],
+  });
+  t.deepEqual(m.serialize(a), {
+    body: '{"@qclass":"slot","index":0}',
+    slots: ['o-1'],
   });
 
-  test('serialize ibid cycle', t => {
-    const m = makeMarshal();
-    const ser = val => m.serialize(val);
-    const cycle = ['a', 'x', 'c'];
-    cycle[1] = cycle;
-    harden(cycle);
+  t.end();
+});
 
-    t.deepEqual(ser(cycle), {
-      body: '["a",{"@qclass":"ibid","index":0},"c"]',
-      slots: [],
-    });
-    t.end();
+test('serialize promise', async t => {
+  const log = [];
+  const syscall = {
+    fulfillToData(result, data) {
+      log.push({ result, data });
+    },
+  };
+
+  const { m } = makeMarshaller(syscall);
+  const { p, res } = makePromise();
+  t.deepEqual(m.serialize(p), {
+    body: '{"@qclass":"slot","index":0}',
+    slots: ['p+5'],
+  });
+  // serializer should remember the promise
+  t.deepEqual(m.serialize(harden(['other stuff', p])), {
+    body: '["other stuff",{"@qclass":"slot","index":0}]',
+    slots: ['p+5'],
   });
 
-  test('forbid ibid cycle', t => {
-    const m = makeMarshal();
-    const uns = body => m.unserialize({ body, slots: [] });
-    t.throws(
-      () => uns('["a",{"@qclass":"ibid","index":0},"c"]'),
-      /Ibid cycle at 0/,
-    );
-    t.end();
+  // inbound should recognize it and return the promise
+  t.deepEqual(
+    m.unserialize({ body: '{"@qclass":"slot","index":0}', slots: ['p+5'] }),
+    p,
+  );
+
+  res(5);
+  t.deepEqual(log, []);
+
+  const { p: pauseP, res: pauseRes } = makePromise();
+  setImmediate(() => pauseRes());
+  await pauseP;
+  t.deepEqual(log, [{ result: 'p+5', data: { body: '5', slots: [] } }]);
+
+  t.end();
+});
+
+test('unserialize promise', async t => {
+  await prep();
+  const log = [];
+  const syscall = {
+    subscribe(promiseID) {
+      log.push(`subscribe-${promiseID}`);
+    },
+  };
+
+  const { m } = makeMarshaller(syscall);
+  const p = m.unserialize({
+    body: '{"@qclass":"slot","index":0}',
+    slots: ['p-1'],
   });
+  t.deepEqual(log, ['subscribe-p-1']);
+  t.ok(p instanceof Promise);
 
-  test('unserialize ibid cycle', t => {
-    const m = makeMarshal();
-    const uns = body => m.unserialize({ body, slots: [] }, 'warnOfCycles');
-    const cycle = uns('["a",{"@qclass":"ibid","index":0},"c"]');
-    t.ok(Object.is(cycle[1], cycle));
-    t.end();
-  });
+  t.end();
+});
 
-  test('serialize exports', t => {
-    const { m } = makeMarshaller();
-    const ser = val => m.serialize(val);
-    const o1 = harden({});
-    const o2 = harden({
-      meth1() {
-        return 4;
-      },
-    });
-    t.deepEqual(ser(o1), {
-      body: '{"@qclass":"slot","index":0}',
-      slots: ['o+1'],
-    });
-    // m now remembers that o1 is exported as 1
-    t.deepEqual(ser(harden([o1, o1])), {
-      body: '[{"@qclass":"slot","index":0},{"@qclass":"ibid","index":1}]',
-      slots: ['o+1'],
-    });
-    t.deepEqual(ser(harden([o2, o1])), {
-      body: '[{"@qclass":"slot","index":0},{"@qclass":"slot","index":1}]',
-      slots: ['o+2', 'o+1'],
-    });
+test('null cannot be pass-by-presence', t => {
+  t.throws(() => mustPassByPresence(null), /null cannot be pass-by-presence/);
+  t.end();
+});
 
-    t.end();
-  });
-
-  test('deserialize imports', async t => {
-    await prep();
-    const { m } = makeMarshaller();
-    const a = m.unserialize({
-      body: '{"@qclass":"slot","index":0}',
-      slots: ['o-1'],
-    });
-    // a should be a proxy/presence. For now these are obvious.
-    t.equal(a.toString(), '[Presence o-1]');
-    t.ok(Object.isFrozen(a));
-
-    // m now remembers the proxy
-    const b = m.unserialize({
-      body: '{"@qclass":"slot","index":0}',
-      slots: ['o-1'],
-    });
-    t.is(a, b);
-
-    // the slotid is what matters, not the index
-    const c = m.unserialize({
-      body: '{"@qclass":"slot","index":2}',
-      slots: ['x', 'x', 'o-1'],
-    });
-    t.is(a, c);
-
-    t.end();
-  });
-
-  test('deserialize exports', t => {
-    const { m } = makeMarshaller();
-    const o1 = harden({});
-    m.serialize(o1); // allocates slot=1
-    const a = m.unserialize({
-      body: '{"@qclass":"slot","index":0}',
-      slots: ['o+1'],
-    });
-    t.is(a, o1);
-
-    t.end();
-  });
-
-  test('serialize imports', async t => {
-    await prep();
-    const { m } = makeMarshaller();
-    const a = m.unserialize({
-      body: '{"@qclass":"slot","index":0}',
-      slots: ['o-1'],
-    });
-    t.deepEqual(m.serialize(a), {
-      body: '{"@qclass":"slot","index":0}',
-      slots: ['o-1'],
-    });
-
-    t.end();
-  });
-
-  test('serialize promise', async t => {
-    const log = [];
-    const syscall = {
-      fulfillToData(result, data) {
-        log.push({ result, data });
-      },
-    };
-
-    const { m } = makeMarshaller(syscall);
-    const { p, res } = makePromise();
-    t.deepEqual(m.serialize(p), {
-      body: '{"@qclass":"slot","index":0}',
-      slots: ['p+5'],
-    });
-    // serializer should remember the promise
-    t.deepEqual(m.serialize(harden(['other stuff', p])), {
-      body: '["other stuff",{"@qclass":"slot","index":0}]',
-      slots: ['p+5'],
-    });
-
-    // inbound should recognize it and return the promise
-    t.deepEqual(
-      m.unserialize({ body: '{"@qclass":"slot","index":0}', slots: ['p+5'] }),
-      p,
-    );
-
-    res(5);
-    t.deepEqual(log, []);
-
-    const { p: pauseP, res: pauseRes } = makePromise();
-    setImmediate(() => pauseRes());
-    await pauseP;
-    t.deepEqual(log, [{ result: 'p+5', data: { body: '5', slots: [] } }]);
-
-    t.end();
-  });
-
-  test('unserialize promise', async t => {
-    await prep();
-    const log = [];
-    const syscall = {
-      subscribe(promiseID) {
-        log.push(`subscribe-${promiseID}`);
-      },
-    };
-
-    const { m } = makeMarshaller(syscall);
-    const p = m.unserialize({
-      body: '{"@qclass":"slot","index":0}',
-      slots: ['p-1'],
-    });
-    t.deepEqual(log, ['subscribe-p-1']);
-    t.ok(p instanceof Promise);
-
-    t.end();
-  });
-
-  test('null cannot be pass-by-presence', t => {
-    t.throws(() => mustPassByPresence(null), /null cannot be pass-by-presence/);
-    t.end();
-  });
-
-  test('mal-formed @qclass', t => {
-    const m = makeMarshal();
-    const uns = body => m.unserialize({ body, slots: [] });
-    t.throws(() => uns('{"@qclass": 0}'), /invalid qclass/);
-    t.end();
-  });
-}
-
-if (typeof require !== 'undefined' && typeof module !== 'undefined') {
-  runTests();
-}
+test('mal-formed @qclass', t => {
+  const m = makeMarshal();
+  const uns = body => m.unserialize({ body, slots: [] });
+  t.throws(() => uns('{"@qclass": 0}'), /invalid qclass/);
+  t.end();
+});


### PR DESCRIPTION
It turns out that updating all test scripts to be importable modules
is not necessary; we can run each script in its own Compartment.

closes #49

reverts:
7ba6947e (change some tests into importable modules, to test under XS, Mon Sep 9 15:06:49 2019 -0700)