### PR TITLE
Updates to bundle-source/README. (also lint cleanups)

### DIFF
--- a/packages/bundle-source/README.md
+++ b/packages/bundle-source/README.md
@@ -2,10 +2,26 @@
 
 This package creates source bundles from ES Modules, compatible with Agoric contracts and SwingSet vats.
 
-To bundle your sources:
+To bundle your sources, first do
 
 ```js
-import makeSourceBundle from '@agoric/bundle-source';
+import bundleSource from '@agoric/bundle-source';
 
-const { moduleFormat, source, sourceMap } = bundleSource(`${__dirname}/../path/to/toplevel`);
+const sourceBundleP = bundleSource(`${__dirname}/../path/to/toplevel`);
+```
+to get a promise for a source bundle, that resolves after reading the
+named sources and bindling them into a form that vats can load, as indicated
+by the `moduleFormat` below. Currently, the only supported module format
+is `getExport`. Note that this way of loading external modules is likely to
+change.
+
+To obtain the contents of the promised `sourceBundleP`, once it resolves, do:
+```js
+sourceBundleP.then(({moduleFormat, source, sourceMap}) => ...);
+```
+or inside an async function (and therefore outside of Jessie), do:
+
+```js
+const { moduleFormat, source, sourceMap } = await sourceBundleP;
+...
 ```


### PR DESCRIPTION
Made lint clean. eslint insisted that `@agoric/harden` be a dependency rather than a dev-dependency. This seems wrong to me but I don't know how to fix.

The new README explains more but is hardly a complete picture.  It also corrects an error in the original README.