### PR TITLE
[Zoe] Allow `payoutRules` to be in any order & a subset of the contract's `assays` array

### DIFF
--- a/packages/zoe/src/contracts/atomicSwap.js
+++ b/packages/zoe/src/contracts/atomicSwap.js
@@ -37,6 +37,5 @@ export const makeContract = harden((zoe, terms) => {
 
   return harden({
     invite: makeFirstOfferInvite(),
-    terms,
   });
 });

--- a/packages/zoe/src/contracts/automaticRefund.js
+++ b/packages/zoe/src/contracts/automaticRefund.js
@@ -8,7 +8,7 @@ import harden from '@agoric/harden';
  * sophisticated logic and interfaces.
  * @param {contractFacet} zoe - the contract facet of zoe
  */
-export const makeContract = harden((zoe, terms) => {
+export const makeContract = harden((zoe, _terms) => {
   let offersCount = 0;
   const makeSeatInvite = () => {
     const seat = harden({
@@ -30,6 +30,5 @@ export const makeContract = harden((zoe, terms) => {
       getOffersCount: () => offersCount,
       makeInvite: makeSeatInvite,
     },
-    terms,
   });
 });

--- a/packages/zoe/src/contracts/autoswap.js
+++ b/packages/zoe/src/contracts/autoswap.js
@@ -26,7 +26,7 @@ export const makeContract = harden((zoe, terms) => {
 
   const { subtract } = natSafeMath;
 
-  return zoe.addAssays(assays).then(() => {
+  return zoe.addNewAssay(liquidityAssay).then(() => {
     const unitOpsArray = zoe.getUnitOpsForAssays(assays);
     unitOpsArray.forEach(
       unitOps =>
@@ -117,11 +117,7 @@ export const makeContract = harden((zoe, terms) => {
               .mint(liquidityUnitsOut)
               .withdrawAll();
             const offerRules = harden({
-              payoutRules: [
-                { kind: 'wantAtLeast', units: unitOpsArray[0].empty() },
-                { kind: 'wantAtLeast', units: unitOpsArray[1].empty() },
-                { kind: 'offerAtMost', units: liquidityUnitsOut },
-              ],
+              payoutRules: [{ kind: 'offerAtMost', units: liquidityUnitsOut }],
               exitRule: {
                 kind: 'waived',
               },
@@ -206,7 +202,6 @@ export const makeContract = harden((zoe, terms) => {
           getPoolUnits,
           makeInvite,
         },
-        terms: { assays },
       });
     });
   });

--- a/packages/zoe/src/contracts/coveredCall.js
+++ b/packages/zoe/src/contracts/coveredCall.js
@@ -63,6 +63,5 @@ export const makeContract = harden((zoe, terms) => {
 
   return harden({
     invite: makeCoveredCallInvite(),
-    terms,
   });
 });

--- a/packages/zoe/src/contracts/helpers/userFlow.js
+++ b/packages/zoe/src/contracts/helpers/userFlow.js
@@ -83,12 +83,7 @@ export const makeHelpers = (zoe, assays) => {
     makeEmptyOffer: () => {
       const { inviteHandle, invite } = zoe.makeInvite();
       const offerRules = harden({
-        payoutRules: unitOpsArray.map(unitOps => {
-          return {
-            kind: 'wantAtLeast',
-            units: unitOps.empty(),
-          };
-        }),
+        payoutRules: [],
         exitRule: {
           kind: 'waived',
         },

--- a/packages/zoe/src/contracts/myFirstDapp.js
+++ b/packages/zoe/src/contracts/myFirstDapp.js
@@ -29,7 +29,7 @@ export const makeContract = harden((zoe, terms) => {
   const liquidityAssay = liquidityMint.getAssay();
   const assays = [...startingAssays, liquidityAssay];
 
-  return zoe.addAssays(assays).then(() => {
+  return zoe.addNewAssay(liquidityAssay).then(() => {
     // This handle is used to store the assets in the liquidity pool.
     let poolHandle;
 
@@ -113,7 +113,6 @@ export const makeContract = harden((zoe, terms) => {
           getPoolUnits,
           makeInvite,
         },
-        terms: { assays },
       });
     });
   });

--- a/packages/zoe/src/contracts/publicAuction.js
+++ b/packages/zoe/src/contracts/publicAuction.js
@@ -110,6 +110,5 @@ export const makeContract = harden((zoe, terms) => {
       getAuctionedAssetsUnits: () => auctionedAssets,
       getMinimumBid: () => minimumBid,
     },
-    terms,
   });
 });

--- a/packages/zoe/src/contracts/simpleExchange.js
+++ b/packages/zoe/src/contracts/simpleExchange.js
@@ -72,6 +72,5 @@ export const makeContract = harden((zoe, terms) => {
   return harden({
     invite: makeInvite(),
     publicAPI: { makeInvite },
-    terms,
   });
 });

--- a/packages/zoe/src/sortPayoutRules.js
+++ b/packages/zoe/src/sortPayoutRules.js
@@ -1,0 +1,31 @@
+import harden from '@agoric/harden';
+import { insist } from '@agoric/ertp/util/insist';
+
+// O(n^2), probably better than that though. How expensive is splicing?
+export const sortPayoutRules = (assays, unitOpsArray, hardenedPayoutRules) => {
+  const payoutRules = [...hardenedPayoutRules];
+  insist(
+    payoutRules.length <= assays.length,
+  )`payoutRules cannot be longer than the contract's assays`;
+
+  const newPayoutRules = [];
+
+  for (let i = 0; i < assays.length; i += 1) {
+    let assayFound = false;
+    for (let j = 0; j < payoutRules.length; j += 1) {
+      const payoutRule = payoutRules[j];
+      if (payoutRule.units.label.assay === assays[i]) {
+        assayFound = true;
+        payoutRules.splice(j, 1);
+        newPayoutRules.push(payoutRule);
+      }
+    }
+    if (!assayFound) {
+      newPayoutRules.push({
+        kind: 'wantAtLeast',
+        units: unitOpsArray[i].empty(),
+      });
+    }
+  }
+  return harden(newPayoutRules);
+};

--- a/packages/zoe/test/swingsetTests/zoe/vat-bob.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-bob.js
@@ -414,10 +414,7 @@ const build = async (E, log, zoe, purses, installations, timer) => {
       const liquidityAssay = await E(publicAPI).getLiquidityAssay();
       const liquidityUnitOps = await getLocalUnitOps(liquidityAssay);
       const liquidity = liquidityUnitOps.make;
-      const allAssays = harden([...assays, liquidityAssay]);
-      insist(
-        sameStructure(allAssays, terms.assays),
-      )`assays were not as expected`;
+      insist(sameStructure(assays, terms.assays))`assays were not as expected`;
 
       // bob checks the price of 3 moola. The price is 1 simolean
       const simoleanUnits = await E(publicAPI).getPrice(moola(3));

--- a/packages/zoe/test/unitTests/contracts/test-autoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-autoswap.js
@@ -52,16 +52,16 @@ test('autoSwap with valid offers', async t => {
     const aliceOfferRules = harden({
       payoutRules: [
         {
+          kind: 'wantAtLeast',
+          units: liquidity(10),
+        },
+        {
           kind: 'offerAtMost',
           units: moola(10),
         },
         {
           kind: 'offerAtMost',
           units: simoleans(5),
-        },
-        {
-          kind: 'wantAtLeast',
-          units: liquidity(10),
         },
       ],
       exitRule: {
@@ -109,16 +109,12 @@ test('autoSwap with valid offers', async t => {
     const bobMoolaForSimOfferRules = harden({
       payoutRules: [
         {
-          kind: 'offerAtMost',
-          units: moola(3),
-        },
-        {
           kind: 'wantAtLeast',
           units: simoleans(1),
         },
         {
-          kind: 'wantAtLeast',
-          units: liquidityAssay.makeUnits(0),
+          kind: 'offerAtMost',
+          units: moola(3),
         },
       ],
       exitRule: {
@@ -163,10 +159,6 @@ test('autoSwap with valid offers', async t => {
           kind: 'offerAtMost',
           units: simoleans(3),
         },
-        {
-          kind: 'wantAtLeast',
-          units: liquidity(0),
-        },
       ],
       exitRule: {
         kind: 'onDemand',
@@ -201,14 +193,6 @@ test('autoSwap with valid offers', async t => {
     const aliceSecondInvite = publicAPI.makeInvite();
     const aliceRemoveLiquidityOfferRules = harden({
       payoutRules: [
-        {
-          kind: 'wantAtLeast',
-          units: moola(0),
-        },
-        {
-          kind: 'wantAtLeast',
-          units: simoleans(0),
-        },
         {
           kind: 'offerAtMost',
           units: liquidity(10),

--- a/packages/zoe/test/unitTests/test-sortPayoutRules.js
+++ b/packages/zoe/test/unitTests/test-sortPayoutRules.js
@@ -1,0 +1,85 @@
+import { test } from 'tape-promise/tape';
+
+import { sortPayoutRules } from '../../src/sortPayoutRules';
+import { setup } from './setupBasicMints';
+
+test('sortPayoutRules', t => {
+  try {
+    const { unitOps, assays, moola, simoleans, bucks } = setup();
+
+    const payoutRules = [
+      { kind: 'wantAtLeast', units: simoleans(1) },
+      { kind: 'offerAtMost', units: moola(3) },
+    ];
+
+    const expectedSortedAndFilledPayoutRules = [
+      { kind: 'offerAtMost', units: moola(3) },
+      { kind: 'wantAtLeast', units: simoleans(1) },
+      { kind: 'wantAtLeast', units: bucks(0) },
+    ];
+
+    t.deepEquals(
+      sortPayoutRules(assays, unitOps, payoutRules),
+      expectedSortedAndFilledPayoutRules,
+    );
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+test('sortPayoutRules - all empty', t => {
+  try {
+    const { unitOps, assays, moola, simoleans, bucks } = setup();
+
+    const payoutRules = [];
+
+    const expectedSortedAndFilledPayoutRules = [
+      { kind: 'wantAtLeast', units: moola(0) },
+      { kind: 'wantAtLeast', units: simoleans(0) },
+      { kind: 'wantAtLeast', units: bucks(0) },
+    ];
+
+    t.deepEquals(
+      sortPayoutRules(assays, unitOps, payoutRules),
+      expectedSortedAndFilledPayoutRules,
+    );
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+test('sortPayoutRules - repeated assays', t => {
+  try {
+    const { unitOps, assays, moola, simoleans, bucks } = setup();
+
+    const repeatedAssays = [...assays, ...assays];
+    const repeatedUnitOps = [...unitOps, ...unitOps];
+
+    const payoutRules = [
+      { kind: 'wantAtLeast', units: simoleans(1) },
+      { kind: 'offerAtMost', units: moola(3) },
+    ];
+
+    const expectedSortedAndFilledPayoutRules = [
+      { kind: 'offerAtMost', units: moola(3) },
+      { kind: 'wantAtLeast', units: simoleans(1) },
+      { kind: 'wantAtLeast', units: bucks(0) },
+      { kind: 'wantAtLeast', units: moola(0) },
+      { kind: 'wantAtLeast', units: simoleans(0) },
+      { kind: 'wantAtLeast', units: bucks(0) },
+    ];
+
+    t.deepEquals(
+      sortPayoutRules(repeatedAssays, repeatedUnitOps, payoutRules),
+      expectedSortedAndFilledPayoutRules,
+    );
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});


### PR DESCRIPTION
Adds a function for sorting and filling in the payoutRules according to an array of assays. 

Other changes that were required:

1. `addNewAssays` ->  `addNewAssay`. This method should add new assays to the end of the `assays` array, so the way we were previously using it (pass in all the assays, whether new or not) was wrong, since it would add duplicates. We don't want to try to de-duplicate because duplicate assays in the assay array may be desired. 

2. If we have `addNewAssay` then we don't need to have the contracts return a `terms` property. This simplifies `zoe.js`

Closes #97 
Closes #392 