### PR TITLE
Changes to make `agoric --sdk` basically work again

### DIFF
--- a/packages/agoric-cli/.gitignore
+++ b/packages/agoric-cli/.gitignore
@@ -79,3 +79,4 @@ integration-test/transform-tests/output
 # generated Sphinx/ReadTheDocs files 
 /docs/build/
 /demo
+t[0-9]*

--- a/packages/agoric-cli/README.md
+++ b/packages/agoric-cli/README.md
@@ -31,7 +31,7 @@ If you have cloned and installed the Agoric SDK as described by its [README](/Ag
 alias agoric="/PATH/TO/agoric-sdk/packages/agoric-cli/bin/agoric --sdk"
 ```
 
-If you want to modify the `template` directory used by Agoric SDK, you can `cd` to it and skip the `agoric init` stage below.  Then, create a PR from your changes.
+If you want to modify the `template` directory used by Agoric SDK, you can `cd template` and skip to the `agoric install` stage below.  Then, iterate on editing the template and, when you're finished, create a PR from your changes.
 </details>
 
 ## Your first Agoric dApp
@@ -46,9 +46,11 @@ agoric init demo
 cd demo
 # Install Javascript dependencies.
 agoric install
-# Run the local vat machine.
-agoric start
-# Install your smart contract and web api (can be done separately)
+# Run the local vat machine, resetting to factory defaults.
+# Leave off `--reset` if you want to resume where you left off.
+agoric start --reset
+# Now you can navigate to http://localhost:8000/
+
+# Install your smart contract and web api
 agoric deploy ./contract/deploy.js ./api/deploy.js
-# Navigate to http://localhost:8000/
 ```

--- a/packages/agoric-cli/lib/deploy.js
+++ b/packages/agoric-cli/lib/deploy.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-await-in-loop */
 import parseArgs from 'minimist';
 import { evaluateProgram } from '@agoric/evaluate';
-import { E, makeCapTP } from '@agoric/captp';
+import { E, HandledPromise, makeCapTP } from '@agoric/captp';
 
 import bundleSource from '@agoric/bundle-source';
 
@@ -74,7 +74,7 @@ export default async function deployMain(progname, rawArgs, priv) {
         const { source, sourceMap } = await bundleSource(moduleFile);
 
         const actualSource = `(${source}\n)\n${sourceMap}`;
-        const mainNS = evaluateProgram(actualSource, { require })();
+        const mainNS = evaluateProgram(actualSource, { require, HandledPromise })();
         const main = mainNS.default;
         if (typeof main !== 'function') {
           console.error(

--- a/packages/agoric-cli/lib/init.js
+++ b/packages/agoric-cli/lib/init.js
@@ -56,8 +56,12 @@ export default async function initMain(progname, rawArgs, priv) {
           console.log(`mkdir ${DIR}${stem}`);
           await mkdir(`${DIR}${stem}`);
         }
-      }),
-    );
+        await recursiveTemplate(templateDir, `${stem}`);
+      } else {
+        console.log(`write ${DIR}${stem}`);
+        await writeTemplate(stem);
+      }
+    }));
   };
   await recursiveTemplate(templateDir);
 

--- a/packages/agoric-cli/lib/install.js
+++ b/packages/agoric-cli/lib/install.js
@@ -1,7 +1,7 @@
 import parseArgs from 'minimist';
 import chalk from 'chalk';
 
-export default async function installMain(progname, rawArgs, priv) {
+export default async function installMain(progname, rawArgs, priv, opts) {
   const { console, error, spawn } = priv;
   const { _: args } = parseArgs(rawArgs);
 
@@ -13,8 +13,8 @@ export default async function installMain(progname, rawArgs, priv) {
     });
 
   // Install via Yarn.
-  if (await pspawn('yarn', ['install'], { stdio: 'inherit'})) {
-    error('Cannot install');
+  if (!opts.sdk && await pspawn('yarn', ['install'], { stdio: 'inherit'})) {
+    error('Cannot yarn install');
     return 1;
   };
   console.log(chalk.bold.green('Done installing'));

--- a/packages/agoric-cli/template/api/deploy.js
+++ b/packages/agoric-cli/template/api/deploy.js
@@ -1,6 +1,4 @@
 // Agoric Dapp api deployment script
-import fs from 'fs';
-import harden from '@agoric/harden';
 
 export default async function deployApi(homeP, { bundleSource, pathResolve }) {
   const { source, moduleFormat } = await bundleSource('./handler.js');

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/bundle-source",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Create source bundles from ES Modules",
   "main": "src/index.js",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4214,7 +4214,7 @@ eslint-plugin-react-hooks@^1.6.1:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz#6210b6d5a37205f0b92858f895a4e827020a7d04"
   integrity sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==
 
-eslint-plugin-react-hooks@^2.2.0, eslint-plugin-react-hooks@^2.3.0:
+eslint-plugin-react-hooks@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.3.0.tgz#53e073961f1f5ccf8dd19558036c1fac8c29d99a"
   integrity sha512-gLKCa52G4ee7uXzdLiorca7JIQZPPXRAQDXV83J4bUEeUuc5pIEyZYAZ45Xnxe5IuupxEqHS+hUhSLIimK1EMw==
@@ -4234,7 +4234,7 @@ eslint-plugin-react@7.16.0:
     prop-types "^15.7.2"
     resolve "^1.12.0"
 
-eslint-plugin-react@^7.15.1, eslint-plugin-react@^7.18.0:
+eslint-plugin-react@^7.15.1:
   version "7.18.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.18.0.tgz#2317831284d005b30aff8afb7c4e906f13fa8e7e"
   integrity sha512-p+PGoGeV4SaZRDsXqdj9OWcOrOpZn8gXoGPcIQTzo2IDMbAKhNDnME9myZWqO3Ic4R3YmwAZ1lDjWl2R2hMUVQ==


### PR DESCRIPTION
This fixes the bitrot that I introduced in modifying `@agoric/eventual-send` and `@agoric/captp`.

Now the `template/contract/deploy.js` script just needs modification.  See the README for instructions on how to set up an `agoric --sdk` alias.

```
soil:template michael$ agoric deploy contract/deploy.js 
Chain loaded: chain bundle loaded
running /Users/michael/agoric/agoric-sdk/packages/agoric-cli/template/contract/deploy.js
'fs' is imported by contract/deploy.js, but could not be resolved – treating it as an external dependency
agoric: ERROR: data is not callable, has no method getAssay
soil:template michael$ 
```
