### PR TITLE
[cosmic-swingset, agoric-cli] Update how users get initial payments

### DIFF
--- a/packages/agoric-cli/template/contract/deploy.js
+++ b/packages/agoric-cli/template/contract/deploy.js
@@ -22,8 +22,8 @@ export default async function deployContract(homeP, { bundleSource, pathResolve 
   // =====================
   
   // 1. Assays and payments
-  const purse0P = homeP~.wallet~.getPurse('moola purse');
-  const purse1P = homeP~.wallet~.getPurse('simolean purse');
+  const purse0P = homeP~.wallet~.getPurse('moola');
+  const purse1P = homeP~.wallet~.getPurse('simolean');
   const assay0P = purse0P~.getAssay();
   const assay1P = purse1P~.getAssay();
   const payment0P = purse0P~.withdraw(900);

--- a/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
@@ -72,16 +72,16 @@ export default function setup(syscall, state, helpers) {
         const dustAssay = await E(vats.pixel).startup(contractHost);
 
         // Make the other demo mints
-        const nonDustAssetNames = ['moola', 'simolean'];
-        const nonDustAssays = await Promise.all(
-          nonDustAssetNames.map(assetName =>
+        const otherAssetNames = ['moola', 'simolean'];
+        const otherAssays = await Promise.all(
+          otherAssetNames.map(assetName =>
             E(vats.mints).makeMintAndAssay(assetName),
           ),
         );
 
         // All the demo assays and assetNames
-        const assetNames = [...nonDustAssetNames, 'dust'];
-        const assays = [...nonDustAssays, dustAssay];
+        const assetNames = [...otherAssetNames, 'dust'];
+        const assays = [...otherAssays, dustAssay];
 
         // Register all of the starting assays. The assetName will
         // also serve as the assayName.
@@ -108,7 +108,7 @@ export default function setup(syscall, state, helpers) {
             });
 
             const payments = await E(vats.mints).mintInitialPayments(
-              nonDustAssetNames,
+              otherAssetNames,
               harden([1900, 1900]),
             );
 

--- a/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
@@ -3,6 +3,7 @@ import { allComparable } from '@agoric/ertp/util/sameStructure';
 // this will return { undefined } until `ag-solo set-gci-ingress`
 // has been run to update gci.js
 import { GCI } from './gci';
+import makeStore from './store';
 
 console.log(`loading bootstrap.js`);
 
@@ -58,15 +59,6 @@ export default function setup(syscall, state, helpers) {
 
       // Make services that are provided on the real or virtual chain side
       async function makeChainBundler(vats, timerDevice) {
-        // Remember the assayIds to pass to the wallet
-        const assayIdMap = new Map();
-
-        async function registerAssay(registrar, assayNameP, assayP) {
-          const [assayName, assay] = await Promise.all([assayNameP, assayP]);
-          const assayId = await E(registrar).register(assayName, assay);
-          assayIdMap.set(assayName, assayId);
-        }
-
         // Create singleton instances.
         const sharingService = await E(vats.sharing).getSharingService();
         const registrar = await E(vats.registrar).getSharedRegistrar();
@@ -76,20 +68,36 @@ export default function setup(syscall, state, helpers) {
         const zoe = await E(vats.zoe).getZoe();
         const contractHost = await E(vats.host).makeHost();
 
-        // dustAssay is built and registered in the pixel vat. Wallet needs it.
-        const dustAssay = E(vats.pixel).startup(contractHost);
-        await registerAssay(registrar, 'dust', dustAssay);
+        // dustAssay is built in the pixel vat. Wallet needs it.
+        const dustAssay = await E(vats.pixel).startup(contractHost);
 
-        const { moolaAssay, simoleanAssay } = await E(vats.mints).getAssays();
+        // Make the other demo mints
+        const nonDustAssetNames = ['moola', 'simolean'];
+        const nonDustAssays = await Promise.all(
+          nonDustAssetNames.map(assetName =>
+            E(vats.mints).makeMintAndAssay(assetName),
+          ),
+        );
 
-        // Two purses were created in vats.mint
-        await registerAssay(registrar, 'moola', moolaAssay);
-        await registerAssay(registrar, 'simolean', simoleanAssay);
+        // All the demo assays and assetNames
+        const assetNames = [...nonDustAssetNames, 'dust'];
+        const assays = [...nonDustAssays, dustAssay];
+
+        // Register all of the starting assays. The assetName will
+        // also serve as the assayName.
+        const assayInfo = await Promise.all(
+          assetNames.map(async (assetName, i) =>
+            harden({
+              assay: assays[i],
+              petname: assetName,
+              regKey: await E(registrar).register(assetName, assays[i]),
+            }),
+          ),
+        );
 
         return harden({
           async createUserBundle(nickname) {
-            const pBundle = await E(vats.pixel).createPixelBundle(nickname);
-            const { purse: dust, bundle: pixelBundle } = pBundle;
+            const pixelBundle = await E(vats.pixel).createPixelBundle(nickname);
             const bundle = harden({
               ...pixelBundle,
               chainTimerService,
@@ -99,35 +107,23 @@ export default function setup(syscall, state, helpers) {
               zoe,
             });
 
-            // assayNames mapped to [assayId, purse] for building wallet
-            const purses = {};
-            for (const assayName of ['moola', 'simolean']) {
-              const purseName = `${assayName} purse`;
-              const purse = E(vats.mints).getNewPurse(assayName, purseName);
-              purses[assayName] = [assayIdMap.get(assayName), purse];
-            }
+            const payments = await E(vats.mints).mintInitialPayments(
+              nonDustAssetNames,
+              harden([1900, 1900]),
+            );
 
-            purses.dust = [assayIdMap.get('dust'), dust];
-
-            // return purses separately so they can be added to local wallet
-            return harden({ purses, bundle });
+            // return payments and assayInfo separately from the
+            // bundle so that they can be used to initialize a wallet
+            // per user
+            return harden({ payments, assayInfo, bundle });
           },
         });
-      }
-
-      function addPursesToWallet(purses, walletVat) {
-        const wallet = E(walletVat).getWallet();
-        for (const assayName of Object.keys(purses)) {
-          const [assayId, purse] = purses[assayName];
-          E(wallet).addPurse(purse, assayId);
-        }
-        return wallet;
       }
 
       // objects that live in the client's solo vat. Some services should only
       // be in the DApp environment (or only in end-user), but we're not yet
       // making a distinction, so the user also gets them.
-      async function createLocalBundle(vats, userBundle, purses) {
+      async function createLocalBundle(vats, userBundle, payments, assayInfo) {
         const { contractHost, zoe, registrar } = userBundle;
         // This will eventually be a vat spawning service. Only needed by dev
         // environments.
@@ -137,8 +133,26 @@ export default function setup(syscall, state, helpers) {
         const uploads = E(vats.uploads).getUploads();
 
         // Wallet for both end-user client and dapp dev client
-        E(vats.wallet).startup(contractHost, zoe, registrar);
-        const wallet = addPursesToWallet(purses, vats.wallet);
+        E(vats.wallet).startup(zoe, registrar);
+        const wallet = E(vats.wallet).getWallet();
+        await Promise.all(
+          assayInfo.map(({ petname, regKey, assay }) =>
+            E(wallet).addAssay(petname, regKey, assay),
+          ),
+        );
+
+        // Make empty purses. Reuse assay petname for purse petname.
+        await Promise.all(
+          assayInfo.map(({ petname }) =>
+            E(wallet).makeEmptyPurse(petname, petname),
+          ),
+        );
+
+        // deposit payments
+        const [moolaPayment, simoleanPayment] = payments;
+
+        await E(wallet).deposit('moola', moolaPayment);
+        await E(wallet).deposit('simolean', simoleanPayment);
 
         // exchange is used for autoswap. Only needed for the dapp's Swingset
         await E(vats.exchange).startup(contractHost, zoe, registrar);
@@ -262,10 +276,12 @@ export default function setup(syscall, state, helpers) {
                 GCI,
                 PROVISIONER_INDEX,
               );
-              const { purses, bundle } = await E(demoProvider).getDemoBundle();
+              const { payments, bundle, assayInfo } = await E(
+                demoProvider,
+              ).getDemoBundle();
               await E(vats.http).setPresences(
                 { ...bundle, localTimerService },
-                await createLocalBundle(vats, bundle, purses),
+                await createLocalBundle(vats, bundle, payments, assayInfo),
               );
               await setupWalletVat(devices.command, vats.http, vats.wallet);
               break;
@@ -311,10 +327,10 @@ export default function setup(syscall, state, helpers) {
               );
               // Get the demo bundle from the chain-side provider
               const b = await E(demoProvider).getDemoBundle('client');
-              const { purses, bundle } = b;
+              const { payments, bundle, assayInfo } = b;
               await E(vats.http).setPresences(
                 { ...bundle, localTimerService },
-                await createLocalBundle(vats, bundle, purses),
+                await createLocalBundle(vats, bundle, payments, assayInfo),
               );
               await setupWalletVat(devices.command, vats.http, vats.wallet);
               break;
@@ -327,14 +343,14 @@ export default function setup(syscall, state, helpers) {
               await setupCommandDevice(vats.http, devices.command, {
                 client: true,
               });
-              const { purses, bundle } = await E(
+              const { payments, bundle, assayInfo } = await E(
                 makeChainBundler(vats, devices.timer),
               ).createUserBundle('localuser');
 
               // Setup of the Local part /////////////////////////////////////
               await E(vats.http).setPresences(
                 { ...bundle, localTimerService: bundle.chainTimerService },
-                await createLocalBundle(vats, bundle, purses),
+                await createLocalBundle(vats, bundle, payments, assayInfo),
               );
 
               setupWalletVat(devices.command, vats.http, vats.wallet);

--- a/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
@@ -7,16 +7,15 @@ import makeObservablePurse from './observable';
 import makeStore from './store';
 import makeWeakStore from './weakStore';
 
-function mockStateChangeHandler(_newState) {
-  // does nothing
-}
+// does nothing
+const noActionStateChangeHandler = _newState => {};
 
 export async function makeWallet(
   E,
   zoe,
   registrar,
-  pursesStateChangeHandler = mockStateChangeHandler,
-  inboxStateChangeHandler = mockStateChangeHandler,
+  pursesStateChangeHandler = noActionStateChangeHandler,
+  inboxStateChangeHandler = noActionStateChangeHandler,
 ) {
   const petnameToPurse = makeStore();
   const assayPetnameToAssay = makeStore();
@@ -254,10 +253,10 @@ export async function makeWallet(
 
     // IMPORTANT: once wrapped, the original purse should never
     // be used otherwise the UI state will be out of sync.
-    const _ = await E(assay).makeEmptyPurse(memo);
+    const doNotUse = await E(assay).makeEmptyPurse(memo);
 
-    const purse = makeObservablePurse(E, _, () =>
-      updatePursesState(pursePetname, _),
+    const purse = makeObservablePurse(E, doNotUse, () =>
+      updatePursesState(pursePetname, doNotUse),
     );
 
     petnameToPurse.init(pursePetname, purse);

--- a/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
@@ -1,22 +1,30 @@
 import harden from '@agoric/harden';
 import { insist } from '@agoric/ertp/util/insist';
 
+import { makeUnitOps } from '@agoric/ertp/core/unitOps';
+
+import makeObservablePurse from './observable';
+import makeStore from './store';
+import makeWeakStore from './weakStore';
+
 function mockStateChangeHandler(_newState) {
   // does nothing
 }
 
 export async function makeWallet(
   E,
-  log,
-  host,
   zoe,
   registrar,
   pursesStateChangeHandler = mockStateChangeHandler,
   inboxStateChangeHandler = mockStateChangeHandler,
 ) {
-  // Map of purses in the wallet by pet name. Assume immutable.
-  const nameToPurse = new Map();
-  const nameToAssayId = new Map();
+  const petnameToPurse = makeStore();
+  const petnameToAssay = makeStore();
+  const assayToPetname = makeWeakStore();
+
+  const petnameToUnitOps = makeStore();
+  const regKeyToAssayPetname = makeStore();
+  const assayPetnameToRegKey = makeStore();
 
   // Offers that the wallet knows about (the inbox).
   const dateToOfferRec = new Map();
@@ -33,14 +41,17 @@ export async function makeWallet(
     return JSON.stringify([...inboxState.values()]);
   }
 
-  async function updatePursesState(purseName, purse) {
-    const balance = await E(purse).getBalance();
-    const {
+  async function updatePursesState(pursePetname, purse) {
+    const { extent } = await E(purse).getBalance();
+    const assay = await E(purse).getAssay();
+    const assayPetname = assayToPetname.get(assay);
+    const assayRegKey = assayPetnameToRegKey.get(assayPetname);
+    pursesState.set(pursePetname, {
+      purseName: pursePetname,
+      assayId: assayRegKey,
+      allegedName: assayPetname,
       extent,
-      label: { allegedName },
-    } = balance;
-    const assayId = nameToAssayId.get(purseName);
-    pursesState.set(purseName, { purseName, assayId, allegedName, extent });
+    });
     pursesStateChangeHandler(getPursesState());
   }
 
@@ -48,52 +59,6 @@ export async function makeWallet(
     // Only sent the metadata to the client.
     inboxState.set(date, offerRec.meta);
     inboxStateChangeHandler(getInboxState());
-  }
-
-  function makeObservablePurse(purse, onFulfilled) {
-    return {
-      getName() {
-        return E(purse).getName();
-      },
-      getAssay() {
-        return E(purse).getAssay();
-      },
-      getBalance() {
-        return E(purse).getBalance();
-      },
-      depositExactly(...args) {
-        return E(purse)
-          .depositExactly(...args)
-          .then(result => {
-            onFulfilled();
-            return result;
-          });
-      },
-      depositAll(...args) {
-        return E(purse)
-          .depositAll(...args)
-          .then(result => {
-            onFulfilled();
-            return result;
-          });
-      },
-      withdraw(...args) {
-        return E(purse)
-          .withdraw(...args)
-          .then(result => {
-            onFulfilled();
-            return result;
-          });
-      },
-      withdrawAll(...args) {
-        return E(purse)
-          .withdrawAll(...args)
-          .then(result => {
-            onFulfilled();
-            return result;
-          });
-      },
-    };
   }
 
   function checkOrder(a0, a1, b0, b1) {
@@ -105,7 +70,7 @@ export async function makeWallet(
       return false;
     }
 
-    throw new TypeError('Canot resove assay ordering');
+    throw new TypeError('Cannot resolve assay ordering');
   }
 
   async function makeOffer(date) {
@@ -114,8 +79,8 @@ export async function makeWallet(
       offerRules,
     } = dateToOfferRec.get(date);
 
-    const purse0 = nameToPurse.get(purseName0);
-    const purse1 = nameToPurse.get(purseName1);
+    const purse0 = petnameToPurse.get(purseName0);
+    const purse1 = petnameToPurse.get(purseName1);
 
     const {
       payoutRules: [
@@ -261,48 +226,50 @@ export async function makeWallet(
     return offerOk;
   }
 
+  const getLocalUnitOps = assay =>
+    Promise.all([
+      E(assay).getLabel(),
+      E(assay).getExtentOps(),
+    ]).then(([label, { name, extentOpsArgs = [] }]) =>
+      makeUnitOps(label, name, extentOpsArgs),
+    );
+
   // === API
 
-  async function addPurse(purse, assayId) {
-    const purseNameP = E(purse).getName();
-    const assayP = E(purse).getAssay();
-    const labelP = E(assayP).getLabel();
+  async function addAssay(assayPetname, regKey, assay) {
+    petnameToAssay.init(assayPetname, assay);
+    assayToPetname.init(assay, assayPetname);
+    regKeyToAssayPetname.init(regKey, assayPetname);
+    assayPetnameToRegKey.init(assayPetname, regKey);
+    petnameToUnitOps.init(assayPetname, await getLocalUnitOps(assay));
+  }
 
-    const [purseName, assay, { allegedName }] = await Promise.all([
-      purseNameP,
-      assayP,
-      labelP,
-    ]);
 
-    // =====================
-    // === AWAITING TURN ===
-    // =====================
-
-    insist(!nameToPurse.has(purseName))`Purse name already used in wallet.`;
-
-    // =====================
-    // === AWAITING TURN ===
-    // =====================
+  async function makeEmptyPurse(assayPetname, pursePetname, memo = 'purse') {
+    insist(
+      !petnameToPurse.has(pursePetname),
+    )`Purse name already used in wallet.`;
+    const assay = petnameToAssay.get(assayPetname);
 
     // IMPORTANT: once wrapped, the original purse should never
     // be used otherwise the UI state will be out of sync.
+    const _ = await E(assay).makeEmptyPurse(memo);
 
-    const observablePurse = makeObservablePurse(purse, () =>
-      updatePursesState(purseName, purse),
+    const purse = makeObservablePurse(E, _, () =>
+      updatePursesState(pursePetname, _),
     );
 
-    nameToPurse.set(purseName, observablePurse);
-    nameToAssayId.set(purseName, assayId);
+    petnameToPurse.init(pursePetname, purse);
+    updatePursesState(pursePetname, purse);
+  }
 
-    updatePursesState(purseName, purse);
+  function deposit(pursePetName, payment) {
+    const purse = petnameToPurse.get(pursePetName);
+    purse.depositAll(payment);
   }
 
   function getPurses() {
-    return harden([...nameToPurse.values()]);
-  }
-
-  function getPurse(name) {
-    return nameToPurse.get(name);
+    return harden([...petnameToPurse.values()]);
   }
 
   async function addOffer(offerRec) {
@@ -338,16 +305,14 @@ export async function makeWallet(
   }
 
   const wallet = harden({
-    userFacet: {
-      addPurse,
-      getPurses,
-      getPurse,
-      addOffer,
-      declineOffer,
-      acceptOffer,
-    },
-    adminFacet: {},
-    readFacet: {},
+    addAssay,
+    makeEmptyPurse,
+    deposit,
+    getPurses,
+    getPurse: petnameToPurse.get,
+    addOffer,
+    declineOffer,
+    acceptOffer,
   });
 
   return wallet;

--- a/packages/cosmic-swingset/lib/ag-solo/vats/observable.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/observable.js
@@ -1,0 +1,45 @@
+export default function makeObservablePurse(E, purse, onFulfilled) {
+  return {
+    getName() {
+      return E(purse).getName();
+    },
+    getAssay() {
+      return E(purse).getAssay();
+    },
+    getBalance() {
+      return E(purse).getBalance();
+    },
+    depositExactly(...args) {
+      return E(purse)
+        .depositExactly(...args)
+        .then(result => {
+          onFulfilled();
+          return result;
+        });
+    },
+    depositAll(...args) {
+      return E(purse)
+        .depositAll(...args)
+        .then(result => {
+          onFulfilled();
+          return result;
+        });
+    },
+    withdraw(...args) {
+      return E(purse)
+        .withdraw(...args)
+        .then(result => {
+          onFulfilled();
+          return result;
+        });
+    },
+    withdrawAll(...args) {
+      return E(purse)
+        .withdrawAll(...args)
+        .then(result => {
+          onFulfilled();
+          return result;
+        });
+    },
+  };
+}

--- a/packages/cosmic-swingset/lib/ag-solo/vats/store.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/store.js
@@ -1,0 +1,42 @@
+// Copyright (C) 2019 Agoric, under Apache license 2.0
+
+import harden from '@agoric/harden';
+import { insist } from '@agoric/ertp/util/insist';
+/**
+ * Distinguishes between adding a new key (init) and updating or
+ * referencing a key (get, set, delete).
+ *
+ * `init` is only allowed if the key does not already exist. `Get`,
+ * `set` and `delete` are only allowed if the key does already exist.
+ * @param  {string} keyName - the column name for the key
+ */
+function makeStore(keyName = 'key') {
+  const store = new Map();
+  const insistKeyDoesNotExist = key =>
+    insist(!store.has(key))([`${keyName} already registered`]);
+  const insistKeyExists = key =>
+    insist(store.has(key))([`${keyName} not found: `, ''], key);
+  return harden({
+    has: key => store.has(key),
+    init: (key, value) => {
+      insistKeyDoesNotExist(key);
+      store.set(key, value);
+    },
+    get: key => {
+      insistKeyExists(key);
+      return store.get(key);
+    },
+    set: (key, value) => {
+      insistKeyExists(key);
+      store.set(key, value);
+    },
+    delete: key => {
+      insistKeyExists(key);
+      store.delete(key);
+    },
+    keys: () => Array.from(store.keys()),
+    values: () => Array.from(store.values()),
+  });
+}
+harden(makeStore);
+export default makeStore;

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-mints.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-mints.js
@@ -11,14 +11,17 @@ function build(_E, _log) {
 
   const api = harden({
     getAllAssetNames: () => mints.keys(),
-    getMint: mints.get,
-    getMints: assetNames => assetNames.map(api.getMint),
     getAssay: assetName => {
       const mint = mints.get(assetName);
       mint.getAssay();
     },
     getAssays: assetNames => assetNames.map(api.getAssay),
 
+    // NOTE: having a reference to a mint object gives the ability to mint
+    // new digital assets, a very powerful authority. This authority
+    // should be closely held.
+    getMint: mints.get,
+    getMints: assetNames => assetNames.map(api.getMint),
     // For example, assetNameSingular might be 'moola', or 'simolean'
     makeMintAndAssay: assetNameSingular => {
       const mint = makeMint(assetNameSingular);

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-mints.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-mints.js
@@ -1,37 +1,42 @@
 import harden from '@agoric/harden';
 import { makeMint } from '@agoric/ertp/core/mint';
+import makeStore from './store';
 
-// This vat contains the registrar for the demo.
+// This vat contains two starting mints for demos: moolaMint and
+// simoleanMint. A third mint, the dustMint, is made by the pixel
+// demo.
 
 function build(_E, _log) {
-  const moolaMint = makeMint('moola');
-  const simoleanMint = makeMint('simolean');
+  const mints = makeStore();
 
-  const moolaAssay = moolaMint.getAssay();
-  const simoleanAssay = simoleanMint.getAssay();
+  const api = harden({
+    getAllAssetNames: () => mints.keys(),
+    getMint: mints.get,
+    getMints: assetNames => assetNames.map(api.getMint),
+    getAssay: assetName => {
+      const mint = mints.get(assetName);
+      mint.getAssay();
+    },
+    getAssays: assetNames => assetNames.map(api.getAssay),
 
-  const mints = new Map([
-    ['moola', moolaMint],
-    ['simolean', simoleanMint],
-  ]);
-
-  function getNewPurse(desc, nickname) {
-    return mints.get(desc).mint(1000, nickname);
-  }
-
-  function getMint(desc) {
-    return harden(mints.get(desc));
-  }
-
-  return harden({
-    getMint,
-    getNewPurse,
-    getAssays: () =>
-      harden({
-        moolaAssay,
-        simoleanAssay,
-      }),
+    // For example, assetNameSingular might be 'moola', or 'simolean'
+    makeMintAndAssay: assetNameSingular => {
+      const mint = makeMint(assetNameSingular);
+      mints.init(assetNameSingular, mint);
+      return mint.getAssay();
+    },
+    mintInitialPayment: (assetName, extent) => {
+      const mint = mints.get(assetName);
+      const purse = mint.mint(extent);
+      return purse.withdrawAll();
+    },
+    mintInitialPayments: (assetNames, extents) =>
+      assetNames.map((assetName, i) =>
+        api.mintInitialPayment(assetName, extents[i]),
+      ),
   });
+
+  return api;
 }
 
 export default function setup(syscall, state, helpers) {

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-pixel.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-pixel.js
@@ -44,12 +44,11 @@ function build(E, log) {
 
   async function createPixelBundle(_nickname) {
     const gallery = sharedGalleryUserFacet;
-    const purse = await sharedDustAssay.makeEmptyPurse();
     const chainBundle = {
       gallery,
       canvasStatePublisher,
     };
-    return { purse, bundle: harden(chainBundle) };
+    return harden(chainBundle);
   }
 
   return harden({ startup, createPixelBundle });

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-wallet.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-wallet.js
@@ -2,8 +2,8 @@ import harden from '@agoric/harden';
 import { makeWallet } from './lib-wallet';
 import pubsub from './pubsub';
 
-function build(E, D, log) {
-  let userFacet;
+function build(E, D, _log) {
+  let wallet;
   let pursesState;
   let inboxState;
   let commandDevice;
@@ -11,21 +11,12 @@ function build(E, D, log) {
   const { publish: pursesPublish, subscribe: purseSubscribe } = pubsub(E);
   const { publish: inboxPublish, subscribe: inboxSubscribe } = pubsub(E);
 
-  async function startup(host, zoe, registrar) {
-    const wallet = await makeWallet(
-      E,
-      log,
-      host,
-      zoe,
-      registrar,
-      pursesPublish,
-      inboxPublish,
-    );
-    userFacet = wallet.userFacet;
+  async function startup(zoe, registrar) {
+    wallet = await makeWallet(E, zoe, registrar, pursesPublish, inboxPublish);
   }
 
   async function getWallet() {
-    return harden(userFacet);
+    return harden(wallet);
   }
 
   function setCommandDevice(d, _ROLES) {
@@ -57,7 +48,7 @@ function build(E, D, log) {
         }
 
         if (type === 'walletAddOffer') {
-          const result = userFacet.addOffer(data);
+          const result = wallet.addOffer(data);
           return {
             type: 'walletOfferAdded',
             data: result,
@@ -65,7 +56,7 @@ function build(E, D, log) {
         }
 
         if (type === 'walletDeclineOffer') {
-          const result = userFacet.declineOffer(data);
+          const result = wallet.declineOffer(data);
           return {
             type: 'walletOfferDeclineed',
             data: result,
@@ -73,7 +64,7 @@ function build(E, D, log) {
         }
 
         if (type === 'walletAcceptOffer') {
-          const result = await userFacet.acceptOffer(data);
+          const result = await wallet.acceptOffer(data);
           return {
             type: 'walletOfferAccepted',
             data: result,

--- a/packages/cosmic-swingset/lib/ag-solo/vats/weakStore.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/weakStore.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2019 Agoric, under Apache license 2.0
+
+import harden from '@agoric/harden';
+import { insist } from '@agoric/ertp/util/insist';
+/**
+ * Distinguishes between adding a new key (init) and updating or
+ * referencing a key (get, set, delete).
+ *
+ * `init` is only allowed if the key does not already exist. `Get`,
+ * `set` and `delete` are only allowed if the key does already exist.
+ * @param  {string} keyName - the column name for the key
+ */
+function makeStore(keyName = 'key') {
+  const wm = new WeakMap();
+  const insistKeyDoesNotExist = key =>
+    insist(!wm.has(key))([`${keyName} already registered`]);
+  const insistKeyExists = key =>
+    insist(wm.has(key))([`${keyName} not found: `, ''], key);
+  return harden({
+    has: key => wm.has(key),
+    init: (key, value) => {
+      insistKeyDoesNotExist(key);
+      wm.set(key, value);
+    },
+    get: key => {
+      insistKeyExists(key);
+      return wm.get(key);
+    },
+    set: (key, value) => {
+      insistKeyExists(key);
+      wm.set(key, value);
+    },
+    delete: key => {
+      insistKeyExists(key);
+      wm.delete(key);
+    },
+  });
+}
+harden(makeStore);
+export default makeStore;


### PR DESCRIPTION
This PR changes the wallet API and how initial payments are made in cosmic-swingset.

Instead of adding purses to the wallet (in ERTP, we want to discourage sending and receiving purses), we should move to an API that adds assays, creates empty purses, and deposits payments. The wallet should allow the user to create petnames for the assays and purses. The wallet should also know about the registrar and store the registrar keys as external common references for things like assays.

Now that we have a wallet, the pixel demo doesn't need to create an empty dust purse. The code for setting up the wallet should do that, once informed about the dustAssay.

I moved the observable purse code to a separate file.

Instead of using `new Map()`, I used the store/weakStore implementation previously known as makePrivateName. Unfortunately, this change isn't yet on master from ERTP, and we will be moving this file around drastically, so for now, for lack of a better alternative, it is copied here. I'll add a separate issue to fix these references once the store/weakStore implementations are in separate packages in this monorepo. 

I'll follow up this PR with another to clean up the autoswap/exchange library code and vats.

Closes #479 