### PR TITLE
fix(Makefile): better convention for installing ag-chain-cosmos

### DIFF
--- a/packages/cosmic-swingset/Dockerfile
+++ b/packages/cosmic-swingset/Dockerfile
@@ -12,4 +12,4 @@ COPY cmd/ cmd/
 COPY lib/*.go lib/
 COPY lib/daemon/ lib/daemon/
 COPY lib/helper/ lib/helper/
-RUN make compile-go install
+RUN make

--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -129,7 +129,6 @@ docker-install: docker-pull
 compile-go: go.sum
 	go build -v $(MOD_READONLY) $(BUILD_FLAGS) -buildmode=c-shared -o lib/libagcosmosdaemon.so lib/agcosmosdaemon.go
 	test "`uname -s 2>/dev/null`" != Darwin || install_name_tool -id `pwd`/lib/libagcosmosdaemon.so lib/libagcosmosdaemon.so
-	-eval `go env` && ln -sf $$PWD/lib/ag-chain-cosmos $$GOPATH/bin/ag-chain-cosmos
 
 build-cosmos: compile-go node-compile-gyp
 
@@ -149,6 +148,7 @@ compile-gyp:
 
 install: go.sum
 	go install -v $(MOD_READONLY) $(BUILD_FLAGS) ./cmd/ag-cosmos-helper
+	bindir="$${GOBIN-$${GOPATH-$$HOME/go}/bin}"; ln -sf "$$PWD/lib/ag-chain-cosmos" "$$bindir/ag-chain-cosmos"
 
 go.sum: go.mod
 	@echo "--> Ensure dependencies have not been modified"

--- a/packages/cosmic-swingset/test/test-make.js
+++ b/packages/cosmic-swingset/test/test-make.js
@@ -1,10 +1,10 @@
 import { test } from 'tape-promise/tape';
 import { spawn } from 'child_process';
 
-test('make build-cosmos', async t => {
+test('make', async t => {
   try {
     await new Promise(resolve =>
-      spawn('make', ['build-cosmos'], {
+      spawn('make', {
         cwd: `${__dirname}/..`,
         stdio: ['ignore', 'ignore', 'inherit'],
       }).addListener('exit', code => {


### PR DESCRIPTION
We run the symlink command in the `install` rule after the
`go install` for `ag-cosmos-helper` succeeded.

Notably, we use the binary directory corresponding to the
description of `go help install`:

1. use `$GOBIN` if GOBIN is defined
2. use `$GOPATH/bin` if GOPATH is defined
3. use `$HOME/go/bin` otherwise