### PR TITLE
add check for mismatched dependencies, run from Github Actions CI

### DIFF
--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -35,6 +35,8 @@ jobs:
     # cross-package symlinks
     - name: yarn install
       run: yarn install
+    - name: check dependencies
+      run: yarn check-dependencies
     # 'yarn build' loops over all workspaces
     - name: yarn build
       run: yarn build

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "scripts": {
     "OFF-clean": "yarn workspaces run clean",
+    "check-dependencies": "node ./scripts/check-mismatched-dependencies.js",
     "prettier": "yarn workspaces run prettier",
     "link-cli": "node ./scripts/link-cli.js",
     "lint-fix": "yarn workspaces run lint-fix",

--- a/scripts/check-mismatched-dependencies.js
+++ b/scripts/check-mismatched-dependencies.js
@@ -1,0 +1,33 @@
+#! /usr/bin/env node
+
+const { spawnSync } = require('child_process');
+console.log(`running 'yarn workspaces info' to check for mismatched dependencies`);
+const s = spawnSync('yarn', ['workspaces', 'info', '--silent'], {
+  stdio: ['ignore', 'pipe', 'inherit']
+});
+if (s.status !== 0) {
+  console.log(`error running 'yarn workspaces info':`);
+  console.log(s.status);
+  console.log(s.signal);
+  console.log(s.error);
+  console.log(s.stdout);
+  console.log(s.stderr);
+  process.exit(1);
+}
+
+let good = true;
+const d = JSON.parse(s.stdout);
+for (const pkgname of Object.getOwnPropertyNames(d)) {
+  const md = d[pkgname].mismatchedWorkspaceDependencies;
+  if (md.length) {
+    console.log(`package '${pkgname}' has mismatched dependencies on: ${md}`);
+    good = false;
+  }
+}
+if (good) {
+  console.log('looks good');
+  process.exit(0);
+} else {
+  process.exit(1);
+}
+


### PR DESCRIPTION
This should catch cases where we bump the version of one package without bumping the dependency in the other packages to match.

@michaelfig @jfparadis does this enforce the right kind of invariant?

@katelynsills will this mess up any of the ERTP shuffling you're doing?
