### PR TITLE
feat(reset-state): add command to ag-solo to reset SwingSet

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/init-basedir.js
+++ b/packages/cosmic-swingset/lib/ag-solo/init-basedir.js
@@ -89,15 +89,6 @@ export default function initBasedir(
   }
   fs.symlinkSync(nm, path.join(basedir, 'node_modules'));
 
-  const mailboxStateFile = path.resolve(basedir, 'swingset-mailbox-state.json');
-  fs.writeFileSync(mailboxStateFile, `{}\n`);
-  const kernelStateFile = path.resolve(
-    basedir,
-    'swingset-kernel-state.jsonlines',
-  );
-  // this contains newline-terminated lines of JSON.stringify(['key', 'value'])
-  fs.writeFileSync(kernelStateFile, ``);
-
   // cosmos-sdk keypair
   if (egresses.includes('cosmos')) {
     const agchServerDir = path.join(basedir, 'ag-cosmos-helper-statedir');

--- a/packages/cosmic-swingset/lib/ag-solo/main.js
+++ b/packages/cosmic-swingset/lib/ag-solo/main.js
@@ -7,6 +7,7 @@ import { insist } from './insist';
 // Start a network service
 import bundle from './bundle';
 import initBasedir from './init-basedir';
+import resetState from './reset-state';
 import setGCIIngress from './set-gci-ingress';
 import setFakeChain from './set-fake-chain';
 import start from './start';
@@ -64,6 +65,7 @@ start
     const subdir = subArgs[1];
     insist(basedir !== undefined, 'you must provide a BASEDIR');
     initBasedir(basedir, webport, webhost, subdir, egresses.split(','));
+    await resetState(basedir);
     // console.error(
     //   `Run '(cd ${basedir} && ${progname} start)' to start the vat machine`,
     // );
@@ -83,6 +85,9 @@ start
     const basedir = insistIsBasedir();
     const withSES = true;
     await start(basedir, withSES, argv.slice(1));
+  } else if (argv[0] === 'reset-state') {
+    const basedir = insistIsBasedir();
+    await resetState(basedir);
   } else if (argv[0] === 'bundle') {
     await bundle(insistIsBasedir, argv.slice(1));
   } else if (argv[0] === 'upload-contract') {

--- a/packages/cosmic-swingset/lib/ag-solo/reset-state.js
+++ b/packages/cosmic-swingset/lib/ag-solo/reset-state.js
@@ -1,0 +1,13 @@
+import path from 'path';
+import fs from 'fs';
+
+export default async function resetState(basedir) {
+  const mailboxStateFile = path.resolve(basedir, 'swingset-mailbox-state.json');
+  fs.writeFileSync(mailboxStateFile, `{}\n`);
+  const kernelStateFile = path.resolve(
+    basedir,
+    'swingset-kernel-state.jsonlines',
+  );
+  // this contains newline-terminated lines of JSON.stringify(['key', 'value'])
+  fs.writeFileSync(kernelStateFile, ``);
+}


### PR DESCRIPTION
Note that the ag-cosmos-helper state is not reset.