### PR TITLE
CI: Hash fewer files as cache keys

### DIFF
--- a/.github/workflows/ag-solo-xs.yml
+++ b/.github/workflows/ag-solo-xs.yml
@@ -10,7 +10,7 @@ on:
    branches: [master]
 
 jobs:
-  build:
+  xs-build:
 
     runs-on: ubuntu-latest
 
@@ -20,7 +20,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cache/yarn
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
         restore-keys: |
           ${{ runner.os }}-yarn-
     - name: yarn install

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cache/yarn
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
         restore-keys: |
           ${{ runner.os }}-yarn-
     - name: Set up Go 1.13
@@ -28,7 +28,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-${{ hashFiles('packages/cosmic-swingset/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
     # 'yarn install' must be done at the top level, to build all the


### PR DESCRIPTION
We only need `packages/cosmic-swingset/go.sum` for Golang and `yarn.lock` for Yarn.

Note that this is still expensive until actions/runner#268 is deployed to hosted Github Actions.

Refs #502