### PR TITLE
Testnet 1.16.9 fixes

### DIFF
--- a/packages/cosmic-swingset/Dockerfile
+++ b/packages/cosmic-swingset/Dockerfile
@@ -12,4 +12,4 @@ COPY cmd/ cmd/
 COPY lib/*.go lib/
 COPY lib/daemon/ lib/daemon/
 COPY lib/helper/ lib/helper/
-RUN make
+RUN make compile-go install

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/cosmic-swingset",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Agoric's Cosmos blockchain integration",
   "main": "lib/ag-solo/main.js",
   "repository": "https://github.com/Agoric/agoric-sdk",

--- a/packages/cosmic-swingset/provisioning-server/src/ag_pserver/main.py
+++ b/packages/cosmic-swingset/provisioning-server/src/ag_pserver/main.py
@@ -76,14 +76,13 @@ class SendInputAndWaitProtocol(protocol.ProcessProtocol):
 class StackedResource(resource.Resource):
     def __init__(self, stack):
         super().__init__()
-        self.stack = stack
+        self.stack = [super(), *stack]
 
     def getChildWithDefault(self, *args):
-        res = super().getChildWithDefault(*args)
-        i = 0
-        while isinstance(res, resource.NoResource) and i < len(self.stack):
-            res = self.stack[i].getChildWithDefault(*args)
-            i += 1
+        for s in self.stack:
+            res = s.getChildWithDefault(*args)
+            if not isinstance(res, resource.NoResource):
+                return res
         return res
 
 def wwwroot(home):

--- a/packages/cosmic-swingset/provisioning-server/src/ag_pserver/main.py
+++ b/packages/cosmic-swingset/provisioning-server/src/ag_pserver/main.py
@@ -76,20 +76,15 @@ class SendInputAndWaitProtocol(protocol.ProcessProtocol):
 class RootResource(resource.Resource):
     def __init__(self, home):
         super().__init__()
-        print('serve', wwwroot(home), htmldir)
         self.wwwroot = static.File(wwwroot(home))
         self.htmldir = static.File(htmldir)
 
     def getChildWithDefault(self, *args):
-        print('getChildWithDefault', *args)
         res = super().getChildWithDefault(*args)
         if isinstance(res, resource.NoResource):
-            print('missed first', res)
             res = self.wwwroot.getChildWithDefault(*args)
         if isinstance(res, resource.NoResource):
-            print('missed', res)
             res = self.htmldir.getChildWithDefault(*args)
-        print('finally', res)
         return res
 
 def wwwroot(home):

--- a/packages/deployment/ansible/prepare-controller.yml
+++ b/packages/deployment/ansible/prepare-controller.yml
@@ -10,11 +10,9 @@
     - data: "{{ SETUP_HOME }}/{{ service }}/data"
     - APPDIR: "{{lookup('pipe', 'pwd')}}/../.."
     - HELPER_BINARY: "{{lookup('env', 'GOPATH') or '/usr/local'}}/bin/ag-cosmos-helper"
-    - to_remove:
-      - "/home/{{ service }}/controller"
+    - CHAIN_NAME: "{{ lookup('file', SETUP_HOME + '/ag-chain-cosmos/chain-name.txt') }}"
   roles:
     - copy
     - init
-    - remove
     - init-controller
     - fetch-controller

--- a/packages/deployment/ansible/prepare-cosmos.yml
+++ b/packages/deployment/ansible/prepare-cosmos.yml
@@ -13,15 +13,10 @@
     - CHAIN_NAME: "{{ lookup('file', SETUP_HOME + '/' + service + '/chain-name.txt') }}"
     - STAKER: ag-staker
     - STAKER_AMOUNT: 2000000uagstake
-    - to_remove:
-      - "/home/{{ service }}/.{{ service }}"
-      - "/home/{{ service }}/.ag-cosmos-helper"
-      - "/home/{{ service }}/ag-cosmos-chain-state.json"
     - HELPER_BINARY: "{{lookup('env', 'GOPATH') or '/usr/local'}}/bin/ag-cosmos-helper"
     - APPDIR: "{{lookup('pipe', 'pwd')}}/../.."
   roles:
     - copy
     - init
-    - remove
     - init-cosmos
     - fetch-cosmos

--- a/packages/deployment/ansible/roles/cosmos-delegates/tasks/main.yml
+++ b/packages/deployment/ansible/roles/cosmos-delegates/tasks/main.yml
@@ -1,16 +1,11 @@
-- name: "Check if /home/{{ service }}/cosmos-stakers.txt exists"
-  stat:
-    path: "/home/{{ service }}/cosmos-stakers.txt"
-  register: stakers
-
 - name: "Get pubkeys and amounts from /home/{{ service }}/cosmos-stakers.txt"
   command: "\
     sed -e 's/^\\([^:]*\\):\\([^:]*\\).*$/\\1 \\2/' \
       /home/{{ service }}/cosmos-stakers.txt"
   args:
     warn: false
+  ignore_errors: true
   register: stakers_data
-  when: stakers.stat.exists
 
 - name: "Transfer stake to delegates"
   become_user: "{{ service }}"

--- a/packages/deployment/ansible/roles/init-controller/tasks/main.yml
+++ b/packages/deployment/ansible/roles/init-controller/tasks/main.yml
@@ -14,11 +14,18 @@
     creates: controller
     chdir: "/home/{{ service }}"
 
-- name: "Ensure /home/{{ service }}/.ag-pserver exists"
+- name: "Reset {{ service }}"
+  become: yes
+  become_user: "{{ service }}"
+  shell:
+    cmd: "ag-solo reset-state"
+    chdir: "/home/{{ service }}/controller"
+
+- name: "Ensure /home/{{ service }}/.ag-pserver/wwwroot/{{ CHAIN_NAME }} exists"
   become: yes
   become_user: "{{ service }}"
   file:
-    path: "/home/{{ service }}/.ag-pserver"
+    path: "/home/{{ service }}/.ag-pserver/wwwroot/{{ CHAIN_NAME }}"
     state: directory
 
 - name: "Clone ag-cosmos-helper-statedir to pserver"

--- a/packages/deployment/ansible/roles/init-cosmos/tasks/main.yml
+++ b/packages/deployment/ansible/roles/init-cosmos/tasks/main.yml
@@ -1,7 +1,24 @@
+- name: "Check for {{ service }} private key"
+  stat:
+    path: "/home/{{ service }}/.{{ service }}/config/priv_validator_key.json"
+  register: valkey
+
+- name: "Reset {{ service }}"
+  become: yes
+  become_user: "{{ service }}"
+  shell: "{{ service }} unsafe-reset-all"
+  when:
+    - valkey.stat.exists
+
+- name: "Remove gentxs (they are signed incorrectly)"
+  file:
+    path: "/home/{{ service }}/.{{ service }}/config/gentx"
+    state: absent
+
 - name: "Initialize {{ service }}"
   become: yes
   become_user: "{{ service }}"
-  shell: "{{ service }} init {{ inventory_hostname }} --chain-id={{ CHAIN_NAME }}"
+  shell: "{{ service }} init --overwrite {{ inventory_hostname }} --chain-id={{ CHAIN_NAME }}"
 
 #- name: "Add coins to {{ service }}"
 #  become: yes

--- a/packages/deployment/ansible/roles/install-controller/tasks/main.yml
+++ b/packages/deployment/ansible/roles/install-controller/tasks/main.yml
@@ -11,7 +11,7 @@
   become: true
   copy:
     src: "{{ data | default(service + '/data') }}/../../ag-chain-cosmos/data/genesis.json"
-    dest: "/home/{{ service }}/.{{ service }}/cosmos-genesis.json"
+    dest: "/home/{{ service }}/.{{ service }}/wwwroot/{{ CHAIN_NAME }}/genesis.json"
     owner: "{{ service }}"
     group: "{{ service }}"
     mode: 0644
@@ -21,10 +21,18 @@
   become: true
   copy:
     src: "{{ data | default(service + '/data') }}/cosmos-chain.json"
-    dest: "/home/{{ service }}/.{{ service }}/cosmos-chain.json"
+    dest: "/home/{{ service }}/.{{ service }}/wwwroot/{{ CHAIN_NAME }}/chain.json"
     owner: "{{ service }}"
     group: "{{ service }}"
     mode: 0644
+
+- name: "Set wwwroot/current to {{ CHAIN_NAME }}"
+  become_user: "{{ service }}"
+  become: true
+  file:
+    state: link
+    path: "/home/{{ service }}/.{{ service }}/wwwroot/current"
+    src: "{{ CHAIN_NAME }}"
 
 - name: "set-gci-ingress for controller"
   become_user: "{{ service }}"

--- a/packages/deployment/bigdipper/README.md
+++ b/packages/deployment/bigdipper/README.md
@@ -1,0 +1,7 @@
+TODO: Write better instructions
+
+```sh
+git clone https://github.com/agoric-labs/big_dipper
+cd big_dipper
+./build.sh
+```

--- a/packages/deployment/bigdipper/README.md
+++ b/packages/deployment/bigdipper/README.md
@@ -1,7 +1,25 @@
-TODO: Write better instructions
+# Agoric Big Dipper setup
 
 ```sh
+# On a new Debian-like machine
+apt update
+apt -y upgrade
+
+# Create a Big Dipper user
+adduser bigdipper
+
+# Become that user
+su bigdipper
+
+# Clone the forked Big Dipper repo
 git clone https://github.com/agoric-labs/big_dipper
 cd big_dipper
-./build.sh
+
+# Follow the instructions in the README
+
+# Copy the contents of this directory to the user.
+curl https://codeload.github.com/Agoric/agoric-sdk/tar.gz/master | \
+  tar -xz --strip=4 agoric-sdk-master/packages/deployment/bigdipper
+
+# TODO: Describe installing the files in the right places and starting services.
 ```

--- a/packages/deployment/bigdipper/ag-bigdipper.service
+++ b/packages/deployment/bigdipper/ag-bigdipper.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Big Dipper Agoric Explorer
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+Environment=BIND_IP=127.0.0.1
+Environment=PORT=5000
+Environment=ROOT_URL=https://explorer-testnet.agoric.com/
+WorkingDirectory=/home/bigdipper
+Restart=on-failure
+User=bigdipper
+Group=bigdipper
+PermissionsStartOnly=true
+ExecStart=/home/bigdipper/ag-bigdipper.sh
+ExecReload=/bin/kill -HUP $MAINPID
+KillSignal=SIGTERM
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/deployment/bigdipper/ag-bigdipper.sh
+++ b/packages/deployment/bigdipper/ag-bigdipper.sh
@@ -1,0 +1,20 @@
+#! /bin/bash
+# bigdipper.sh - Run Agoric Big Dipper Explorer
+set -e
+ncf=`curl -Ss https://testnet.agoric.com/network-config`
+l=`echo "$ncf" | jq '.rpcAddrs | length'`
+eval rp=`echo "$ncf" | jq ".rpcAddrs[$(( RANDOM % l ))]"`
+eval cn=`echo "$ncf" | jq '.chainName'`
+
+case $cn in
+testnet-1.16.8) db=meteor ;;
+*) db=`echo "$cn" | sed -e 's/\./-/g'` ;;
+esac
+
+export MONGO_URL=mongodb://localhost:27017/"$db"
+
+test -d "portal-$cn" && ln -sfT "portal-$cn" portal
+cd portal
+export METEOR_SETTINGS=`sed -e "s/@CHAIN_NAME@/$cn/; s/@RPC@/$rp/" settings.json`
+exec /usr/bin/node main.js
+exit $?

--- a/packages/deployment/bigdipper/ag-lcd.service
+++ b/packages/deployment/bigdipper/ag-lcd.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Agoric Light Client Daemon
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+WorkingDirectory=/home/bigdipper
+Restart=on-failure
+User=bigdipper
+Group=bigdipper
+PermissionsStartOnly=true
+ExecStart=/home/bigdipper/ag-lcd.sh
+ExecReload=/bin/kill -HUP $MAINPID
+KillSignal=SIGTERM
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/deployment/bigdipper/ag-lcd.sh
+++ b/packages/deployment/bigdipper/ag-lcd.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+# ag-lcd.sh - run an Agoric Light Client Daemon
+set -e
+PATH=$PATH:/usr/local/bin
+ncf=`curl -Ss https://testnet.agoric.com/network-config`
+l=`echo "$ncf" | jq '.rpcAddrs | length'`
+eval rp=`echo "$ncf" | jq ".rpcAddrs[$(( RANDOM % l ))]"`
+eval cn=`echo "$ncf" | jq '.chainName'`
+exec ag-cosmos-helper rest-server --node="tcp://$rp" --chain-id="$cn"
+exit $?

--- a/packages/deployment/bigdipper/bigdipper.nginx
+++ b/packages/deployment/bigdipper/bigdipper.nginx
@@ -1,0 +1,52 @@
+# this section is needed to proxy web-socket connections
+map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+}
+# HTTP
+server {
+  listen 80;
+  return 301 https://$host$request_uri;
+}
+server {
+#        listen 80 default_server;
+#        listen [::]:80 default_server ipv6only=on;
+	listen 443;
+        server_name _; # explorer.testnet.agoric.com;
+
+	ssl on;
+	ssl_certificate /etc/ssl/explorer.testnet.agoric.com.pem;
+	ssl_certificate_key /etc/ssl/explorer.testnet.agoric.com.key;
+    ssl_session_cache  builtin:1000  shared:SSL:10m;
+    ssl_protocols  TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
+    ssl_prefer_server_ciphers on;
+
+        
+        location = /favicon.ico {
+          root /home/bigdipper/portal/programs/web.browser/app;
+          access_log off;
+        }
+        
+        location ~* "^/[a-z0-9]{40}\.(css|js)$" {
+          #gzip_static on;
+          root /home/bigdipper/portal/programs/web.browser;
+          access_log off;
+        }
+        
+        location ~ "^/packages" {
+          root /home/bigdipper/portal/programs/web.browser;
+          access_log off;
+        }
+
+        # pass requests to Meteor
+        location / {
+            proxy_pass http://127.0.0.1:5000;
+            proxy_http_version 1.1;
+	    proxy_ssl_server_name on;
+            proxy_set_header Upgrade $http_upgrade; #for websockets
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header X-Forwarded-For $remote_addr;
+            proxy_set_header Host $host;
+        }
+}

--- a/packages/deployment/bigdipper/settings.json
+++ b/packages/deployment/bigdipper/settings.json
@@ -1,0 +1,43 @@
+{
+  "public":{
+      "chainName": "Agoric Testnet",
+      "chainId": "@CHAIN_NAME@",
+      "gtm": "{Add your Google Tag Manager ID here}",
+      "slashingWindow": 10000,
+      "uptimeWindow": 250,
+      "initialPageSize": 30,
+      "bech32PrefixAccAddr": "cosmos",
+      "bech32PrefixAccPub": "cosmospub",
+      "bech32PrefixValAddr": "cosmosvaloper",
+      "bech32PrefixValPub": "cosmosvaloperpub",
+      "bech32PrefixConsAddr": "cosmosvalcons",
+      "bech32PrefixConsPub": "cosmosvalconspub",
+      "stakingDenom": "stake",
+      "stakingDenomPlural": "stakes", 
+      "mintingDenom": null,
+      "stakingFraction": 1000000,
+      "powerReduction": 0,
+      "gasPrice": 0.00,
+      "coingeckoId": null
+  },
+  "genesisFile": "https://testnet.agoric.com/genesis.json",
+  "remote":{
+      "rpc":"http://@RPC@",
+      "lcd":"http://127.0.0.1:1317"
+  },
+  "debug": {
+      "startTimer": true,
+      "readGenesis": true
+  },
+  "params":{
+      "startHeight": 0,
+      "defaultBlockTime": 5000,
+      "blockInterval": 15000,
+      "consensusInterval": 1000,
+      "statusInterval":7500,
+      "signingInfoInterval": 1800000,
+      "proposalInterval": -1,
+      "missedBlocksInterval": 60000,
+      "delegationInterval": 900000
+  }
+}

--- a/packages/deployment/main.js
+++ b/packages/deployment/main.js
@@ -286,7 +286,7 @@ show-config      display the client connection parameters
         tag = subOpts.tag;
       } else if (subArgs[0] === undefined || String(subArgs[0]) === 'true') {
         // Default bump.
-        versionKind = 'revision';
+        versionKind = 'patch';
       }
 
       switch (versionKind) {
@@ -302,9 +302,11 @@ show-config      display the client connection parameters
           break;
 
         case 'revision':
+        case 'patch':
           revision = Number(revision) + 1;
           break;
 
+        case 'none':
         case undefined:
           break;
 
@@ -346,7 +348,7 @@ show-config      display the client connection parameters
         `${COSMOS_DIR}/chain-name.txt`,
       ).catch(e => undefined);
 
-      if (currentChainName !== chainName) {
+      if (subOpts.bump || currentChainName !== chainName) {
         // We don't have matching parameters, so restart the chain.
         // Stop all the services.
         await reMain(['play', 'stop', '-eservice=ag-pserver']);

--- a/packages/deployment/package.json
+++ b/packages/deployment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/deployment",
-  "version": "1.16.8",
+  "version": "1.16.9",
   "description": "Set up Agoric public chain nodes",
   "private": true,
   "main": "main.js",


### PR DESCRIPTION
This PR is to merge the fixes needed for the latest testnet deployment.

* Fix Dockerfile not to build node-gyp when all we need is Golang
* Allow overriding provisioning server's HTTP service with contents of `wwwroot` directory.
* Make deployment scripts more robust
* Avoid regenerating keypairs if possible
* Bump deployment version number

@warner, I don't need review for the changes to `packages/deployment` (feel free to peruse just to get a sense of what's going in).  However, your comments are solicited for the other changes.
