### PR TITLE
Implement `agoric start testnet` and `agoric --sdk start testnet`

### DIFF
--- a/packages/agoric-cli/bin/agoric
+++ b/packages/agoric-cli/bin/agoric
@@ -6,6 +6,7 @@ const chalk = esmRequire('chalk').default;
 const WebSocket = esmRequire('ws');
 const { spawn } = esmRequire('child_process');
 const fs = esmRequire('fs').promises;
+const os = esmRequire('os');
 
 const main = esmRequire('../lib/main.js').default;
 const progname = path.basename(process.argv[1]);
@@ -23,6 +24,7 @@ main(progname, rawArgs, {
   error,
   makeWebSocket,
   fs,
+  os,
   process,
   spawn,
 }).then(

--- a/packages/agoric-cli/lib/start.js
+++ b/packages/agoric-cli/lib/start.js
@@ -1,21 +1,23 @@
- import parseArgs from 'minimist';
+import parseArgs from 'minimist';
+import path from 'path';
 import chalk from 'chalk';
+
+const FAKE_CHAIN_DELAY = 5;
 
 export default async function startMain(progname, rawArgs, priv, opts) {
   const { console, error, fs, spawn, process } = priv;
-  const {
-    reset,
-    _: args,
-  } = parseArgs(rawArgs, {
+  const { reset, _: args } = parseArgs(rawArgs, {
     boolean: ['reset'],
   });
 
-  const pspawn = (...args) =>
-    new Promise((resolve, reject) => {
-      const cp = spawn(...args);
+  const pspawn = (cmd, cargs, ...rest) => {
+    console.log(chalk.blueBright(cmd, ...cargs));
+    return new Promise((resolve, reject) => {
+      const cp = spawn(cmd, cargs, ...rest);
       cp.on('exit', resolve);
       cp.on('error', () => resolve(-1));
     });
+  };
 
   const exists = async file => {
     try {
@@ -26,41 +28,89 @@ export default async function startMain(progname, rawArgs, priv, opts) {
     }
   };
 
+  const linkHtml = async name => {
+    console.log(chalk.green('linking html directories'));
+    const dappHtml = `.agservers/${name}/dapp-html`;
+    const htmlWallet = `.agservers/${name}/html/wallet`;
+    // await Promise.all([fs.unlink(dappHtml).catch(() => {}), fs.unlink(htmlWallet).catch(() => {})]);
+    await Promise.all([
+      fs.symlink('../../ui/build', dappHtml).catch(() => {}),
+      fs.symlink('../../../.agwallet', htmlWallet).catch(() => {}),
+    ]);
+  };
+
   let agSolo;
+  let agServer;
   if (opts.sdk) {
-    agSolo = `${__dirname}/../../cosmic-swingset/bin/ag-solo`;
+    agSolo = path.resolve(__dirname, '../../cosmic-swingset/bin/ag-solo');
   } else {
-    if (!await exists('.agservers/node_modules')) {
+    if (!(await exists('.agservers/node_modules'))) {
       return error(`you must first run '${progname} install'`);
     }
     agSolo = `${process.cwd()}/node_modules/@agoric/cosmic-swingset/bin/ag-solo`;
   }
 
-  if (reset) {
-    console.log(chalk.green('removing .agservers/solo'));
-    await pspawn('rm', ['-rf', '.agservers/solo'], { stdio: 'inherit' });
-  }
+  async function startDev(profileName) {
+    const fakeGCI = 'myFakeGCI';
+    if (!(await exists(agServer))) {
+      console.log(chalk.yellow(`initializing ${profileName}`));
+      await pspawn(agSolo, ['init', profileName, '--egresses=fake'], {
+        stdio: 'inherit',
+        cwd: '.agservers',
+      });
+    }
 
-  // Run scenario3.
-  if (!await exists('.agservers/solo')) {
-    console.log(chalk.yellow('initializing solo'))
-    await pspawn(agSolo, ['init', 'solo', '--egresses=none'], {
+    console.log(
+      chalk.yellow(`setting fake chain with ${FAKE_CHAIN_DELAY} second delay`),
+    );
+    await pspawn(
+      agSolo,
+      [
+        'set-fake-chain',
+        '--role=two_chain',
+        `--delay=${FAKE_CHAIN_DELAY}`,
+        fakeGCI,
+      ],
+      {
+        stdio: 'inherit',
+        cwd: agServer,
+      },
+    );
+    await linkHtml(profileName);
+
+    await pspawn(agSolo, ['start', '--role=two_client'], {
       stdio: 'inherit',
-      cwd: '.agservers',
+      cwd: agServer,
     });
   }
 
-  console.log(chalk.green('linking html directories'));
-  const dappHtml = '.agservers/solo/dapp-html';
-  const htmlWallet = '.agservers/solo/html/wallet';
-  // await Promise.all([fs.unlink(dappHtml).catch(() => {}), fs.unlink(htmlWallet).catch(() => {})]);
-  await Promise.all([
-    fs.symlink('../../ui/build', dappHtml).catch(() => {}),
-    fs.symlink('../../../.agwallet', htmlWallet).catch(() => {}),
-  ]);
+  async function startTestnet(profileName) {
 
-  await pspawn(agSolo, ['start', '--role=three_client'], {
-    stdio: 'inherit',
-    cwd: '.agservers/solo',
-  });
+  }
+
+  const profiles = {
+    dev: startDev,
+    testnet: startTestnet,
+  };
+
+  const profileName = args[0] || 'dev';
+  const startFn = profiles[profileName];
+  if (!startFn) {
+    return error(
+      `unrecognized profile name ${profileName}; use one of: ${Object.keys(
+        profiles,
+      )
+        .sort()
+        .join(', ')}`,
+    );
+  }
+
+  agServer = `.agservers/${profileName}`;
+  if (reset) {
+    console.log(chalk.green(`removing ${agServer}`));
+    // FIXME: Use portable rimraf.
+    await pspawn('rm', ['-rf', agServer], { stdio: 'inherit' });
+  }
+
+  await startFn(profileName, agServer);
 }

--- a/packages/agoric-cli/template/.agservers/.gitignore
+++ b/packages/agoric-cli/template/.agservers/.gitignore
@@ -77,4 +77,6 @@ integration-test/transform-tests/output
 /docs/build/
 
 /solo
+/dev
+/testnet
 /chain

--- a/packages/agoric-cli/template/.agservers/.gitignore
+++ b/packages/agoric-cli/template/.agservers/.gitignore
@@ -80,3 +80,4 @@ integration-test/transform-tests/output
 /dev
 /testnet
 /chain
+/ve*

--- a/packages/cosmic-swingset/setup-solo/src/ag_setup_solo/main.py
+++ b/packages/cosmic-swingset/setup-solo/src/ag_setup_solo/main.py
@@ -38,6 +38,7 @@ class Options(usage.Options):
     ]
     optFlags = [
         ["destroy", None, "destroy all chain state"],
+        ["no-restart", None, "do not restart the solo vat"],
     ]
     def parseArgs(self, basedir=os.environ.get('AG_SOLO_BASEDIR', 'agoric')):
         self['basedir'] = os.environ['AG_SOLO_BASEDIR'] = basedir
@@ -46,7 +47,9 @@ class Options(usage.Options):
 def setIngress(sm):
     print('Setting chain parameters with ' + AG_SOLO)
     subprocess.run([AG_SOLO, 'set-gci-ingress', '--chainID=%s' % sm['chainName'], sm['gci'], *sm['rpcAddrs']], check=True)
-def restart():
+def restart(o):
+    if o['no-restart']:
+        return
     print('Restarting ' + AG_SOLO)
     os.execvp(AG_SOLO, [AG_SOLO, 'start', '--role=client'])
 
@@ -95,7 +98,7 @@ def run_client(reactor, o, pkeyFile):
     except:
         cleanup()
         raise
-    restart()
+    restart(o)
 
 def doInit(o):
     BASEDIR = o['basedir']
@@ -123,7 +126,7 @@ def resetNetconfig(o):
     for conn in conns:
       if 'GCI' in conn and conn['GCI'] == netconfig['gci']:
         print('Already have an entry for ' + conn['GCI'] + '; not replacing')
-        restart()
+        restart(o)
         sys.exit(1)
     
     return netconfig
@@ -169,5 +172,5 @@ def main():
     doInit(o)
 
     setIngress(netconfig)
-    restart()
+    restart(o)
     sys.exit(1)


### PR DESCRIPTION
Closes #501 

Use one of:

`agoric start testnet --pull`

or:

`agoric --sdk start testnet`

to run the solo-to-testnet-chain configuration, listening on http://localhost:8000
