### PR TITLE
HandledPromise.unwrap: pass through non-Thenables before throwing

### DIFF
--- a/packages/eventual-send/test/test-hp.js
+++ b/packages/eventual-send/test/test-hp.js
@@ -48,10 +48,31 @@ test('chained properties', async t => {
 
 test('HandledPromise.unwrap', async t => {
   try {
+    for (const [val, desc] of [
+      [{}, 'object'],
+      [true, 'true'],
+      [false, 'false'],
+      [undefined, 'undefined'],
+      [null, 'null'],
+      [123, 'number'],
+      ['hello', 'string'],
+    ]) {
+      t.equal(HandledPromise.unwrap(val), val, `unwrapped ${desc} is equal`);
+    }
+    const t0 = {
+      then() {},
+    };
     t.throws(
-      () => HandledPromise.unwrap({}),
+      () => HandledPromise.unwrap(t0),
       TypeError,
-      `unwrapped non-presence throws`,
+      `unwrapped thenable object throws`,
+    );
+    const t1 = () => {};
+    t1.then = () => {};
+    t.throws(
+      () => HandledPromise.unwrap(t1),
+      TypeError,
+      `unwrapped thenable function throws`,
     );
     const p0 = new Promise(_ => {});
     t.throws(


### PR DESCRIPTION
Closes #518

This makes unwrap a lot more useful in the case when the
calling code may or may not be in a different vat than the supplied
argument.