### PR TITLE
rationalize naming of cosmic swingset persistence files

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
+++ b/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
@@ -27,7 +27,7 @@ async function writeMap(file, map) {
 }
 
 export async function connectToFakeChain(basedir, GCI, role, delay, inbound) {
-  const stateFile = path.join(basedir, `fake-chain-${GCI}-state.json`);
+  const stateFile = path.join(basedir, `fake-chain-${GCI}-state.jsonlines`);
   const mailboxFile = path.join(basedir, `fake-chain-${GCI}-mailbox.json`);
   const bootAddress = `${GCI}-client`;
 

--- a/packages/cosmic-swingset/lib/ag-solo/reset-state.js
+++ b/packages/cosmic-swingset/lib/ag-solo/reset-state.js
@@ -2,7 +2,7 @@ import path from 'path';
 import fs from 'fs';
 
 export default async function resetState(basedir) {
-  const mailboxStateFile = path.resolve(basedir, 'swingset-mailbox-state.json');
+  const mailboxStateFile = path.resolve(basedir, 'swingset-kernel-mailbox.json');
   fs.writeFileSync(mailboxStateFile, `{}\n`);
   const kernelStateFile = path.resolve(
     basedir,

--- a/packages/cosmic-swingset/lib/ag-solo/start.js
+++ b/packages/cosmic-swingset/lib/ag-solo/start.js
@@ -182,7 +182,7 @@ async function buildSwingset(
 }
 
 export default async function start(basedir, withSES, argv) {
-  const mailboxStateFile = path.resolve(basedir, 'swingset-mailbox-state.json');
+  const mailboxStateFile = path.resolve(basedir, 'swingset-kernel-mailbox.json');
   const kernelStateFile = path.resolve(
     basedir,
     'swingset-kernel-state.jsonlines',


### PR DESCRIPTION
In order to assuage my OCD, the files for persisting stuff into are now named consistently: `${thing}-state.jsonlines` for state and `${thing}-mailbox.json` for the mailbox, where `${thing}` names the swingset (in the case of scenario 3, `'swingset-kernel'` and `'fake-chain-myFakeGCI'`)