### PR TITLE
Refactor dynamic vat creation to support contract host

### DIFF
--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -580,7 +580,7 @@ export default function buildKernel(kernelEndowments) {
   function createVatDynamically(buildFnSrc) {
     const endowments = { require: kernelRequire, HandledPromise };
     const nameSpace = evaluateProgram(buildFnSrc.source, endowments)();
-    const buildFn = () => harden({ start: nameSpace.makeContract.start });
+    const buildFn = () => harden(nameSpace);
     try {
       const vatID = createVat(buildFn);
       console.log(`added dynamic vat [${vatID}]`);

--- a/packages/SwingSet/src/kernel/vatAdmin/vatAdmin-src.js
+++ b/packages/SwingSet/src/kernel/vatAdmin/vatAdmin-src.js
@@ -32,9 +32,17 @@ export default function setup(syscall, state, helpers, endowments) {
     return harden({
       // Called by the wrapper vat to create a new vat. Gets a new ID from the
       // kernel's vat creator fn. Remember that the root object will arrive
-      // separately. Clean up the outgoing and incoming arguments.
+      // separately. We clean up the outgoing and incoming arguments.
       create(code) {
-        return kernelVatCreationFn(code);
+        const bundle = harden({
+          source: code.source,
+          moduleFormat: code.moduleFormat,
+        });
+        const result = kernelVatCreationFn(bundle);
+        if (result.vatID) {
+          return harden({ vatID: `${result.vatID}` });
+        }
+        return harden({ error: `${result.error}` });
       },
       terminate(_vatID) {
         // TODO(hibbert)

--- a/packages/SwingSet/src/kernel/vatAdmin/vatAdmin-src.js
+++ b/packages/SwingSet/src/kernel/vatAdmin/vatAdmin-src.js
@@ -34,7 +34,7 @@ export default function setup(syscall, state, helpers, endowments) {
       // kernel's vat creator fn. Remember that the root object will arrive
       // separately. Clean up the outgoing and incoming arguments.
       create(code) {
-        return kernelVatCreationFn(`${code}`);
+        return kernelVatCreationFn(code);
       },
       terminate(_vatID) {
         // TODO(hibbert)

--- a/packages/SwingSet/test/vat-admin/bootstrap.js
+++ b/packages/SwingSet/test/vat-admin/bootstrap.js
@@ -4,17 +4,13 @@ function buildContractBundle(makeContractSrc, mainFnName) {
   const contractBundleSource = `
 function getExport() {
   'use strict';
-   let exports = {};
-   const module = { exports };
-   Object.defineProperty(exports, '__esModule', { value: true });
    function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
    var harden = _interopDefault(require('@agoric/harden'));
    var Nat = _interopDefault(require('@agoric/nat'));
 
   ${makeContractSrc}
 
-  exports.${mainFnName} = ${mainFnName};
-  return module.exports;
+  return ${mainFnName};
 }`;
 
   return harden({

--- a/packages/SwingSet/test/vat-admin/test-innerVat.js
+++ b/packages/SwingSet/test/vat-admin/test-innerVat.js
@@ -17,10 +17,7 @@ async function testVatCreationFromBuild(t, withSES) {
   const c = await buildVatController(config, withSES, ['newVat']);
   t.equal(c.vatNameToID('vatAdmin'), 'v2');
   t.equal(c.vatNameToID('_bootstrap'), 'v1');
-  for (let i = 0; i < 9; i += 1) {
-    // eslint-disable-next-line no-await-in-loop
-    await c.step();
-  }
+  await c.run();
   t.deepEqual(c.dump().log, ['starting newVat test', '13']);
   t.end();
 }
@@ -37,7 +34,6 @@ async function testVatCreationAndObjectHosting(t, withSES) {
   const config = await createConfig();
   const c = await buildVatController(config, withSES, ['counters']);
   await c.run();
-  await c.run();
   t.deepEqual(c.dump().log, ['starting counter test', '4', '9', '2']);
   t.end();
 }
@@ -50,13 +46,29 @@ test('VatAdmin inner vat creation non-SES', async t => {
   await testVatCreationAndObjectHosting(t, false);
 });
 
+async function testVatCreationFromBundle(t, withSES) {
+  const config = await createConfig();
+  const c = await buildVatController(config, withSES, ['vatFromBundle']);
+  await c.run();
+  t.deepEqual(c.dump().log, ['starting vat from Bundle test', '4', '9', '2']);
+  t.end();
+}
+
+test('VatAdmin vat creation from Bundle', async t => {
+  await testVatCreationFromBundle(t, true);
+});
+
+test('VatAdmin vat creation from Bundle non-SES', async t => {
+  await testVatCreationFromBundle(t, false);
+});
+
 async function testBrokenVatCreation(t, withSES) {
   const config = await createConfig();
   const c = await buildVatController(config, withSES, ['brokenVat']);
   await c.run();
   t.deepEqual(c.dump().log, [
     'starting brokenVat test',
-    'yay, rejected: Error: Vat Creation Error: ReferenceError: harden is not defined',
+    'yay, rejected: Error: Vat Creation Error: Error: cannot serialize objects with non-methods like the .start in [object Object]',
   ]);
   t.end();
 }

--- a/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
@@ -65,7 +65,7 @@ export default function setup(syscall, state, helpers) {
           timerDevice,
         );
         const zoe = await E(vats.zoe).getZoe();
-        const contractHost = await E(vats.host).makeHost();
+        const contractHost = await E(vats.host).makeHost(vats.adminVat);
 
 
         // Make the other demo mints

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-host.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-host.js
@@ -11,8 +11,8 @@ function setup(syscall, state, helpers) {
     state,
     E =>
       harden({
-        makeHost() {
-          return harden(makeContractHost(E, evaluate, { require }));
+        makeHost(adminVat) {
+          return harden(makeContractHost(E, evaluate, adminVat));
         },
       }),
     helpers.vatID,

--- a/packages/spawner/src/contractHost.chainmail
+++ b/packages/spawner/src/contractHost.chainmail
@@ -1,21 +1,27 @@
 /**
- * ContractHost provides a way to install and run verifiable contracts.
+ * ContractHost provides a way to install and run verifiable contracts as
+ * independent vats.
  *
- * Install(source) creates Installations. Installations represent particular
- * contract forms, which can be spawn()'d to create Contract instances
- * initialized with specific terms. These Contracts manage invitations for
- * multiple seats, each of which represents a "role" in an interaction.
+ * Install(source, format) creates Installations. Installations represent
+ * particular contract forms, which can be spawn()'d to create Contract
+ * instances initialized with specific terms. These Contracts manage invitations
+ * for multiple seats, each of which represents a "role" in an interaction. At
+ * present, the only module format supported is 'module', which corresponds to
+ * ES6 modules.
  *
  * Some seats provide the methods getWinnings() and getRefunds(), which return
  * promises for payments for the outputs of the interaction. We provide the
  * collect() method (described later) to simplify collection of winnings and
  * refunds into appropriate purses.
+ *
+ * Vats are the unit of reliance and synchrony. Computations running in
+ * separate vats must communicate via eventual sends.
  */
 interface ContractHost {
   /**
    * ContractSrc is the source code for a Contract. See Contract for details.
    */
-  install(contractSrc :String) -> (Installation);
+  install(contractSrc :String, moduleFormat :String) -> (Installation);
 
   /** Returns the actual source of the Installation. */
   getInstallationSourceCode(installation :Installation) -> (String);
@@ -40,12 +46,6 @@ interface ContractHost {
   * or different terms. Each spawned instance has distinct invites and distinct
   * seats representing a specific group of agents interacting according to the
   * same prescribed roles.
-  *
-  * The Installation can also have functions with names starting `check`, as
-  * defined by the contract. They can be used to validate that the expected
-  * terms are actually the same as the terms of this spawned contract. The
-  * Installation is inserted by the ContactHost as the first parameter to these
-  * functions. The naming restriction is likely to be lifted.
   */
 interface Installation {
   /**
@@ -54,19 +54,6 @@ interface Installation {
    * for the seats in the contract, but see coveredCall for an exception.
    */
   spawn(terms :Terms) -> (invites :Object);
-
- /**
-  * The writer of the contract can provide methods to help users of the contract
-  * verify that the terms of the contract match their expectation. These methods
-  * are defined with the installation as the first parameter, so the verifiers
-  * can validate that the caller's invitation was issued by the same one. The
-  * invocation by clients should omit this parameter, as they will be supplied
-  * with a copy of the function with that information already supplied.
-  *
-  * Users usually want to validate their invitation, the terms of the deal
-  * they're attempting to participate in, and which seat they are taking.
-  */
-  checkUnits(installation :Installation, inviteUnits :Units, terms :Terms);
 }
 
 /**
@@ -100,7 +87,6 @@ interface Installation {
   *
   * const escrowExchangeSrcs = {
   *   start: `${escrowExchange.start}`,
-  *   checkUnits: `${escrowExchange.checkUnits}`,
   * };
   */
 interface Contract {
@@ -126,8 +112,7 @@ interface Contract {
   * {installation, terms, seatIdentity, seatDesc}. These are intended to be
   * sufficient for the recipient to verify that the contract and terms are the
   * ones they were expecting, and that the invite corresponds to the expected
-  * role in the contract. The installation can provide methods like
-  * checkUnits() to simplify verification.
+  * role in the contract.
   */
 interface InviteMaker {
   make(seatDesc :String, seat :Object, name :String = 'an invite payment')
@@ -164,9 +149,9 @@ interface Collector {
   * Arbitrary terms defined by each contract.
   *
   * These are defined by the contract, passed to spawn(), and available to be
-  * validated in the check methods (or manually) by contract participants to
-  * ensure they are connected to a contract with matching expectations about
-  * what will be traded, and which seat they will occupy.
+  * validated manually by contract participants to ensure they are connected to
+  * a contract with matching expectations about what will be traded, and which
+  * seat they will occupy.
   */
 interface Terms {
 }

--- a/packages/spawner/src/contractHost.chainmail
+++ b/packages/spawner/src/contractHost.chainmail
@@ -4,7 +4,7 @@
  * Install(source) creates Installations. Installations represent particular
  * contract forms, which can be spawn()'d to create Contract instances
  * initialized with specific terms. These Contracts manage invitations for
- * multiple seats, each of which repesents a "role" in an interaction.
+ * multiple seats, each of which represents a "role" in an interaction.
  *
  * Some seats provide the methods getWinnings() and getRefunds(), which return
  * promises for payments for the outputs of the interaction. We provide the

--- a/packages/spawner/src/contractHost.js
+++ b/packages/spawner/src/contractHost.js
@@ -56,7 +56,10 @@ function makeContractHost(E, evaluate, adminVat) {
         // contract in seatDescriptions, and is known to and verifiable by
         // contractHost itself.
         spawn(termsP) {
-          insist(moduleFormat === 'module')`Module format is required in vats`;
+          assert(
+            moduleFormat === 'module',
+            details`Module format is required in vats`,
+          );
           const startFnP = E(adminVat).createVat(contractSrcs);
           return Promise.resolve(allComparable(termsP)).then(terms => {
             const inviteMaker = harden({

--- a/packages/spawner/src/contractHost.js
+++ b/packages/spawner/src/contractHost.js
@@ -51,13 +51,10 @@ function makeContractHost(E, evaluate, adminVat) {
     getInviteAssay() {
       return inviteAssay;
     },
-    // contractSrcs is a record containing source code for the functions
+    // contractSrcBundle is a bundle containing source code for the functions
     // comprising a contract. `spawn` evaluates the `start` function
     // (parameterized by `terms` and `inviteMaker`) to start the contract, and
-    // returns whatever the contract returns. The contract can also have any
-    // number of functions with names beginning 'check', each of which can be
-    // used by clients to help validate that they have terms that match the
-    // contract.
+    // returns whatever the contract returns.
     install(contractSrcBundle, moduleFormat = 'object') {
       const installation = harden({
         // spawn() spins up a new vat for each new contract instance. There is

--- a/packages/spawner/test/swingsetTests/contractHost/vat-fred.js
+++ b/packages/spawner/test/swingsetTests/contractHost/vat-fred.js
@@ -35,14 +35,8 @@ function makeFredMaker(E, host, log) {
           const verifiedSaleInvitePaymentP = E(allegedSaleInvitePaymentP)
             .getBalance()
             .then(allegedInviteUnits => {
-              const escrowCheckerP = E(host).redeem(
-                escrowCheckerInviteP,
-
-              );
-              const ccCheckerP = E(host).redeem(
-                coveredCallCheckerInviteP,
-
-              );
+              const escrowCheckerP = E(host).redeem(escrowCheckerInviteP);
+              const ccCheckerP = E(host).redeem(coveredCallCheckerInviteP);
               return Promise.all([
                 ccCheckerP,
                 escrowCheckerP,
@@ -98,7 +92,9 @@ function makeFredMaker(E, host, log) {
               );
               return Promise.resolve(gotOptionP).then(_ => {
                 // Fred bought the option. Now fred tries to exercise the option.
-                const optionInvitePaymentP = E(optionInvitePurseP).withdrawAll();
+                const optionInvitePaymentP = E(
+                  optionInvitePurseP,
+                ).withdrawAll();
                 return E(host)
                   .redeem(optionInvitePaymentP)
                   .then(optionSeatP =>

--- a/packages/spawner/test/swingsetTests/contractHost/vat-host.js
+++ b/packages/spawner/test/swingsetTests/contractHost/vat-host.js
@@ -11,8 +11,8 @@ function setup(syscall, state, helpers) {
     state,
     E =>
       harden({
-        makeHost() {
-          return harden(makeContractHost(E, evaluate));
+        makeHost(adminVat) {
+          return harden(makeContractHost(E, evaluate, adminVat));
         },
       }),
     helpers.vatID,

--- a/packages/spawner/test/swingsetTests/escrow/test-escrow.js
+++ b/packages/spawner/test/swingsetTests/escrow/test-escrow.js
@@ -1,8 +1,8 @@
 import { test } from 'tape-promise/tape';
 import { buildVatController, loadBasedir } from '@agoric/swingset-vat';
 import path from 'path';
-import bundleSource from "@agoric/bundle-source";
-import fs from "fs";
+import bundleSource from '@agoric/bundle-source';
+import fs from 'fs';
 
 const CONTRACT_FILES = ['escrow'];
 const generateBundlesP = Promise.all(

--- a/packages/spawner/test/swingsetTests/escrow/vat-host.js
+++ b/packages/spawner/test/swingsetTests/escrow/vat-host.js
@@ -11,8 +11,8 @@ function setup(syscall, state, helpers) {
     state,
     E =>
       harden({
-        makeHost() {
-          return harden(makeContractHost(E, evaluate));
+        makeHost(adminVat) {
+          return harden(makeContractHost(E, evaluate, adminVat));
         },
       }),
     helpers.vatID,


### PR DESCRIPTION
We now consistently use modules as the code format across dynamic vat

In the kernel, I added HandledPromises to the endowments, and
evaluated code based on expecting it to start as a bundle.

ContractHost (yet to be renamed to vatSpawner) now only supports module format.

Support for check functions in the contract host has been removed
because there's no reasonable way to associate the functions with the
installation. It's straightforward to include them in the contract
code, and issue an invitation for them, so the client can get
validation that they're from the real source.

Most of the changes in this PR are updates to tests to use bundles.