### PR TITLE
chore(pixel-demo): temporarily disable test

### DIFF
--- a/packages/pixel-demo/package.json
+++ b/packages/pixel-demo/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "build": "exit 0",
-    "test": "tape -r esm 'test/**/test*.js' | tap-spec",
+    "test": "echo \"test disabled; really-test if you want\"; exit 0",
+    "really-test": "tape -r esm 'test/**/test*.js' | tap-spec",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint-check": "eslint '**/*.js'",
     "lint-fix-jessie": "eslint -c '.eslintrc-jessie.js' --fix '**/*.js'",


### PR DESCRIPTION
We will let pixel-demo languish until we can make it a proper dApp.