### PR TITLE
Meter API cleanups

### DIFF
--- a/packages/transform-metering/README.md
+++ b/packages/transform-metering/README.md
@@ -88,16 +88,20 @@ const { meter } = makeMeter();
 
 // Then to evaluate some source with endowments:
 meteredEval(meter, 'abc + def', {abc: 123, def: 456}).then(
-  ([normalReturn, value]) => {
+  ([normalReturn, value, seenMeters]) => {
+    for (const m of seenMeters) {
+      const ex = m.isExhausted();
+      if (ex) {
+        console.log('meter', m, 'was exhausted with', ex);;
+      }
+    }
     if (normalReturn) {
       console.log('normal return', value);
     } else {
       console.log('exception', value);
     }
   }
-).catch(e => {
-  console.log('meter exhausted', e);
-});
+);
 ```
 
 

--- a/packages/transform-metering/src/evaluator.js
+++ b/packages/transform-metering/src/evaluator.js
@@ -2,7 +2,7 @@ import { makeMeteringTransformer } from './transform';
 
 export function makeMeteredEvaluator({
   replaceGlobalMeter,
-  refillMeterOncePerTurn,
+  refillMeterInNewTurn,
   makeEvaluator,
   babelCore,
   quiesceCallback = cb => cb(),
@@ -44,9 +44,9 @@ export function makeMeteredEvaluator({
       if (typeof srcOrThunk === 'string') {
         // Transform the source on our own budget, then evaluate against the meter.
         endowments.getGlobalMeter = m => {
-          if (refillMeterOncePerTurn && !metersSeenThisTurn.has(meter)) {
+          if (refillMeterInNewTurn && !metersSeenThisTurn.has(meter)) {
             metersSeenThisTurn.add(meter);
-            refillMeterOncePerTurn(meter);
+            refillMeterInNewTurn(meter);
           }
           if (m !== true) {
             replaceGlobalMeter(meter);
@@ -56,9 +56,9 @@ export function makeMeteredEvaluator({
         returned = ev.evaluate(srcOrThunk, endowments);
       } else {
         // Evaluate the thunk with the specified meter.
-        if (refillMeterOncePerTurn && !metersSeenThisTurn.has(meter)) {
+        if (refillMeterInNewTurn && !metersSeenThisTurn.has(meter)) {
           metersSeenThisTurn.add(meter);
-          refillMeterOncePerTurn(meter);
+          refillMeterInNewTurn(meter);
         }
         replaceGlobalMeter(meter);
         returned = srcOrThunk();

--- a/packages/transform-metering/src/meter.js
+++ b/packages/transform-metering/src/meter.js
@@ -196,7 +196,7 @@ export function makeMeter(budgets = {}) {
     return maybeAbort(undefined, false);
   };
 
-  const adminFacet = {
+  const refillFacet = {
     isExhausted,
     allocate: makeResetter(allocateCounter),
     stack: makeResetter(stackCounter),
@@ -215,6 +215,6 @@ export function makeMeter(budgets = {}) {
   Object.assign(meterAllocate, meter);
   return {
     meter: meterAllocate,
-    adminFacet,
+    refillFacet,
   };
 }

--- a/packages/transform-metering/test/test-tame.js
+++ b/packages/transform-metering/test/test-tame.js
@@ -8,7 +8,7 @@ import { makeMeter, makeWithMeter } from '../src/index';
 
 test('meter running', async t => {
   try {
-    const { meter, adminFacet } = makeMeter({ budgetCombined: 10 });
+    const { meter, refillFacet } = makeMeter({ budgetCombined: 10 });
     const { withMeter, withoutMeter } = makeWithMeter(
       replaceGlobalMeter,
       meter,
@@ -29,14 +29,14 @@ test('meter running', async t => {
       `withMeter works`,
     );
 
-    adminFacet.combined(1000);
+    refillFacet.combined(1000);
     t.throws(
       withMeterFn(() => new Array(10000)),
       RangeError,
       'new Array exhausted',
     );
 
-    adminFacet.combined(100);
+    refillFacet.combined(100);
     t.throws(
       withMeterFn(() => 'x'.repeat(10000)),
       RangeError,
@@ -44,7 +44,7 @@ test('meter running', async t => {
     );
 
     const a = new Array(10);
-    adminFacet.combined(10);
+    refillFacet.combined(10);
     t.throws(
       withMeterFn(() => a.map(Object.create)),
       RangeError,


### PR DESCRIPTION
* Always return `[isNormalReturn, value, seenMeters]` from both quiescing meters and synchronous meters.
* Rename `adminFacet` to be `refillFacet`, since that's what it currently is.
* Add `refillMeterInNewTurn` callback for the evaluator to call when a meter is used in a new turn (i.e. after quiescence).
