### PR TITLE
Remove redundant ${e} ${e.message}

### DIFF
--- a/packages/SwingSet/src/devices/command-src.js
+++ b/packages/SwingSet/src/devices/command-src.js
@@ -21,8 +21,8 @@ export default function setup(syscall, state, helpers, endowments) {
         const body = JSON.parse(`${bodyString}`);
         SO(inboundHandler).inbound(Nat(count), body);
       } catch (e) {
-        console.log(`error during inboundCallback: ${e} ${e.message}`);
-        throw new Error(`error during inboundCallback: ${e} ${e.message}`);
+        console.log(`error during inboundCallback: ${e}`);
+        throw new Error(`error during inboundCallback: ${e}`);
       }
     });
 
@@ -36,7 +36,7 @@ export default function setup(syscall, state, helpers, endowments) {
         try {
           deliverResponse(count, isReject, JSON.stringify(obj));
         } catch (e) {
-          console.log(`error during sendResponse: ${e} ${e.message}`);
+          console.log(`error during sendResponse: ${e}`);
         }
       },
 
@@ -44,7 +44,7 @@ export default function setup(syscall, state, helpers, endowments) {
         try {
           sendBroadcast(JSON.stringify(obj));
         } catch (e) {
-          console.log(`error during sendBroadcast: ${e} ${e.message}`);
+          console.log(`error during sendBroadcast: ${e}`);
         }
       },
     });

--- a/packages/SwingSet/src/devices/command.js
+++ b/packages/SwingSet/src/devices/command.js
@@ -24,7 +24,7 @@ export default function buildCommand(broadcastCallback) {
     try {
       inboundCallback(count, JSON.stringify(obj));
     } catch (e) {
-      console.log(`error running inboundCallback: ${e} ${e.message}`);
+      console.log(`error running inboundCallback: ${e}`);
     }
     return p;
   }

--- a/packages/SwingSet/src/devices/inbound-src.js
+++ b/packages/SwingSet/src/devices/inbound-src.js
@@ -18,7 +18,7 @@ export default function setup(syscall, state, helpers, endowments) {
         try {
           SO(inboundHandler).inbound(`${sender}`, `${message}`);
         } catch (e) {
-          console.log(`error during inboundCallback: ${e} ${e.message}`);
+          console.log(`error during inboundCallback: ${e}`);
         }
       };
       return harden({

--- a/packages/SwingSet/src/devices/mailbox-src.js
+++ b/packages/SwingSet/src/devices/mailbox-src.js
@@ -62,7 +62,7 @@ export default function setup(syscall, state, helpers, endowments) {
       try {
         SO(inboundHandler).deliverInboundMessages(peer, newMessages);
       } catch (e) {
-        console.log(`error during deliverInboundMessages: ${e} ${e.message}`);
+        console.log(`error during deliverInboundMessages: ${e}`);
       }
     };
 
@@ -73,7 +73,7 @@ export default function setup(syscall, state, helpers, endowments) {
       try {
         SO(inboundHandler).deliverInboundAck(peer, ack);
       } catch (e) {
-        console.log(`error during deliverInboundAck: ${e} ${e.message}`);
+        console.log(`error during deliverInboundAck: ${e}`);
       }
     };
 
@@ -91,7 +91,7 @@ export default function setup(syscall, state, helpers, endowments) {
         try {
           endowments.add(`${peer}`, Nat(msgnum), `${body}`);
         } catch (e) {
-          throw new Error(`error in add: ${e} ${e.message}`);
+          throw new Error(`error in add: ${e}`);
         }
       },
 
@@ -99,7 +99,7 @@ export default function setup(syscall, state, helpers, endowments) {
         try {
           endowments.remove(`${peer}`, Nat(msgnum));
         } catch (e) {
-          throw new Error(`error in remove: ${e} ${e.message}`);
+          throw new Error(`error in remove: ${e}`);
         }
       },
 
@@ -107,7 +107,7 @@ export default function setup(syscall, state, helpers, endowments) {
         try {
           endowments.setAcknum(`${peer}`, Nat(msgnum));
         } catch (e) {
-          throw new Error(`error in ackInbound: ${e} ${e.message}`);
+          throw new Error(`error in ackInbound: ${e}`);
         }
       },
     });

--- a/packages/SwingSet/src/devices/mailbox.js
+++ b/packages/SwingSet/src/devices/mailbox.js
@@ -160,7 +160,7 @@ export function buildMailbox(state) {
     try {
       return Boolean(inboundCallback(peer, messages, ack));
     } catch (e) {
-      throw new Error(`error in inboundCallback: ${e} ${e.message}`);
+      throw new Error(`error in inboundCallback: ${e}`);
     }
   }
 

--- a/packages/SwingSet/src/devices/timer.js
+++ b/packages/SwingSet/src/devices/timer.js
@@ -23,7 +23,7 @@ export function buildTimer() {
     try {
       return Boolean(devicePollFunction(Nat(time)));
     } catch (e) {
-      throw new Error(`error in devicePollFunction: ${e} ${e.message}`);
+      throw new Error(`error in devicePollFunction: ${e}`);
     }
   }
 

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -273,7 +273,7 @@ export default function buildKernel(kernelEndowments) {
       await vat.manager.deliverOneMessage(target, msg);
     } catch (e) {
       // log so we get a stack trace
-      console.log(`error in kernel.deliver: ${e} ${e.message}`, e);
+      console.log(`error in kernel.deliver:`, e);
       throw e;
     }
   }
@@ -351,7 +351,7 @@ export default function buildKernel(kernelEndowments) {
       await vat.manager.deliverOneNotification(kpid, p);
     } catch (e) {
       // log so we get a stack trace
-      console.log(`error in kernel.processNotify: ${e} ${e.message}`, e);
+      console.log(`error in kernel.processNotify:`, e);
       throw e;
     }
   }


### PR DESCRIPTION
The only reason these both were used is because of an old bug
in SES that prevented `${e}` from displaying e.message.  This
is fixed, so remove the redundant redundant messages.