### PR TITLE
Pass all tests with metering installed

### DIFF
--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -38,6 +38,7 @@
     "@agoric/marshal": "^0.1.1",
     "@agoric/nat": "^2.0.1",
     "@agoric/swing-store-simple": "^0.1.0",
+    "@agoric/tame-metering": "^1.0.0",
     "rollup": "^1.23.1",
     "rollup-plugin-node-resolve": "^5.2.0",
     "semver": "^6.3.0",

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -1,3 +1,4 @@
+/* global replaceGlobalMeter */
 import harden from '@agoric/harden';
 import { makeMarshal, QCLASS } from '@agoric/marshal';
 import Nat from '@agoric/nat';
@@ -114,6 +115,10 @@ export default function buildKernel(kernelEndowments) {
       .then(f)
       .then(undefined, logerr);
     await queueEmptyP;
+    if (typeof replaceGlobalMeter !== 'undefined') {
+      // Turn off the global meter now that we've run the user code.
+      replaceGlobalMeter(null);
+    }
     whenDone();
   }
 


### PR DESCRIPTION
This should be all the infrastructure that's necessary for the static Zoe vat to be able to use a basic global meter implementation.

The test that can detect if metering control is provided to a vat is:

```js
if (typeof replaceGlobalMeter !== 'undefined') {
  // Do the metering...
}
```
