### PR TITLE
Refactor swing store API

### DIFF
--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -10,7 +10,7 @@ import { assert } from '@agoric/assert';
 
 import makeDefaultEvaluateOptions from '@agoric/default-evaluate-options';
 import bundleSource from '@agoric/bundle-source';
-import { makeSwingStore } from '@agoric/swing-store-simple';
+import { initSwingStore } from '@agoric/swing-store-simple';
 import {
   SES1ReplaceGlobalMeter,
   SES1TameMeteringShim,
@@ -239,7 +239,7 @@ export async function buildVatController(config, withSES = true, argv = []) {
     return setup;
   }
 
-  const hostStorage = config.hostStorage || makeSwingStore(null, true).storage;
+  const hostStorage = config.hostStorage || initSwingStore().storage;
   insistStorageAPI(hostStorage);
   const kernelEndowments = {
     setImmediate,

--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -10,11 +10,11 @@ import { assert } from '@agoric/assert';
 
 import makeDefaultEvaluateOptions from '@agoric/default-evaluate-options';
 import bundleSource from '@agoric/bundle-source';
+import { makeSwingStore } from '@agoric/swing-store-simple';
 import {
   SES1ReplaceGlobalMeter,
   SES1TameMeteringShim,
 } from '@agoric/tame-metering';
-import { makeSwingStore } from '@agoric/swing-store-simple';
 
 // eslint-disable-next-line import/extensions
 import kernelSourceFunc from './bundles/kernel';

--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -10,11 +10,11 @@ import { assert } from '@agoric/assert';
 
 import makeDefaultEvaluateOptions from '@agoric/default-evaluate-options';
 import bundleSource from '@agoric/bundle-source';
-import { makeMemorySwingStore } from '@agoric/swing-store-simple';
 import {
   SES1ReplaceGlobalMeter,
   SES1TameMeteringShim,
 } from '@agoric/tame-metering';
+import { makeSwingStore } from '@agoric/swing-store-simple';
 
 // eslint-disable-next-line import/extensions
 import kernelSourceFunc from './bundles/kernel';
@@ -239,7 +239,7 @@ export async function buildVatController(config, withSES = true, argv = []) {
     return setup;
   }
 
-  const hostStorage = config.hostStorage || makeMemorySwingStore().storage;
+  const hostStorage = config.hostStorage || makeSwingStore(null, true).storage;
   insistStorageAPI(hostStorage);
   const kernelEndowments = {
     setImmediate,

--- a/packages/SwingSet/src/hostStorage.js
+++ b/packages/SwingSet/src/hostStorage.js
@@ -1,5 +1,5 @@
 import harden from '@agoric/harden';
-import { makeSwingStore } from '@agoric/swing-store-simple';
+import { initSwingStore } from '@agoric/swing-store-simple';
 
 /*
 The "Storage API" is a set of functions { has, getKeys, get, set, delete } that
@@ -28,7 +28,7 @@ directly.
  */
 export function buildHostDBInMemory(storage) {
   if (!storage) {
-    storage = makeSwingStore(null, true).store;
+    storage = initSwingStore().store;
   }
 
   /**

--- a/packages/SwingSet/src/hostStorage.js
+++ b/packages/SwingSet/src/hostStorage.js
@@ -1,5 +1,5 @@
 import harden from '@agoric/harden';
-import { makeMemorySwingStore } from '@agoric/swing-store-simple';
+import { makeSwingStore } from '@agoric/swing-store-simple';
 
 /*
 The "Storage API" is a set of functions { has, getKeys, get, set, delete } that
@@ -28,7 +28,7 @@ directly.
  */
 export function buildHostDBInMemory(storage) {
   if (!storage) {
-    storage = makeMemorySwingStore().store;
+    storage = makeSwingStore(null, true).store;
   }
 
   /**

--- a/packages/SwingSet/test/test-devices.js
+++ b/packages/SwingSet/test/test-devices.js
@@ -1,6 +1,6 @@
 import { test } from 'tape-promise/tape';
 import harden from '@agoric/harden';
-import { makeSwingStore, getAllState } from '@agoric/swing-store-simple';
+import { initSwingStore, getAllState } from '@agoric/swing-store-simple';
 
 import { buildVatController } from '../src/index';
 import { buildMailboxStateMap, buildMailbox } from '../src/devices/mailbox';
@@ -185,7 +185,7 @@ test('d2.5 without SES', async t => {
 });
 
 async function testState(t, withSES) {
-  const { storage } = makeSwingStore(null, true);
+  const { storage } = initSwingStore();
   const config = {
     vats: new Map(),
     devices: [['d3', require.resolve('./files-devices/device-3'), {}]],

--- a/packages/SwingSet/test/test-devices.js
+++ b/packages/SwingSet/test/test-devices.js
@@ -1,6 +1,6 @@
 import { test } from 'tape-promise/tape';
 import harden from '@agoric/harden';
-import { makeMemorySwingStore, getAllState } from '@agoric/swing-store-simple';
+import { makeSwingStore, getAllState } from '@agoric/swing-store-simple';
 
 import { buildVatController } from '../src/index';
 import { buildMailboxStateMap, buildMailbox } from '../src/devices/mailbox';
@@ -185,7 +185,7 @@ test('d2.5 without SES', async t => {
 });
 
 async function testState(t, withSES) {
-  const { storage } = makeMemorySwingStore();
+  const { storage } = makeSwingStore(null, true);
   const config = {
     vats: new Map(),
     devices: [['d3', require.resolve('./files-devices/device-3'), {}]],

--- a/packages/SwingSet/test/test-kernel.js
+++ b/packages/SwingSet/test/test-kernel.js
@@ -2,7 +2,7 @@
 /* global setImmediate */
 import { test } from 'tape-promise/tape';
 import harden from '@agoric/harden';
-import { makeMemorySwingStore } from '@agoric/swing-store-simple';
+import { makeSwingStore } from '@agoric/swing-store-simple';
 
 import buildKernel from '../src/kernel/index';
 import { makeVatSlot } from '../src/parseVatSlots';
@@ -32,7 +32,7 @@ function emptySetup(_syscall) {
 }
 
 function makeEndowments() {
-  return { setImmediate, hostStorage: makeMemorySwingStore().storage };
+  return { setImmediate, hostStorage: makeSwingStore(null, true).storage };
 }
 
 test('build kernel', async t => {

--- a/packages/SwingSet/test/test-kernel.js
+++ b/packages/SwingSet/test/test-kernel.js
@@ -2,7 +2,7 @@
 /* global setImmediate */
 import { test } from 'tape-promise/tape';
 import harden from '@agoric/harden';
-import { makeSwingStore } from '@agoric/swing-store-simple';
+import { initSwingStore } from '@agoric/swing-store-simple';
 
 import buildKernel from '../src/kernel/index';
 import { makeVatSlot } from '../src/parseVatSlots';
@@ -32,7 +32,7 @@ function emptySetup(_syscall) {
 }
 
 function makeEndowments() {
-  return { setImmediate, hostStorage: makeSwingStore(null, true).storage };
+  return { setImmediate, hostStorage: initSwingStore().storage };
 }
 
 test('build kernel', async t => {

--- a/packages/SwingSet/test/test-liveslots.js
+++ b/packages/SwingSet/test/test-liveslots.js
@@ -2,7 +2,7 @@
 /* global setImmediate */
 import { test } from 'tape-promise/tape';
 import harden from '@agoric/harden';
-import { makeMemorySwingStore } from '@agoric/swing-store-simple';
+import { makeSwingStore } from '@agoric/swing-store-simple';
 
 import buildKernel from '../src/kernel/index';
 import { makeLiveSlots } from '../src/kernel/liveSlots';
@@ -16,7 +16,7 @@ function capargs(args, slots = []) {
 }
 
 function makeEndowments() {
-  return { setImmediate, hostStorage: makeMemorySwingStore().storage };
+  return { setImmediate, hostStorage: makeSwingStore(null, true).storage };
 }
 
 test('calls', async t => {

--- a/packages/SwingSet/test/test-liveslots.js
+++ b/packages/SwingSet/test/test-liveslots.js
@@ -2,7 +2,7 @@
 /* global setImmediate */
 import { test } from 'tape-promise/tape';
 import harden from '@agoric/harden';
-import { makeSwingStore } from '@agoric/swing-store-simple';
+import { initSwingStore } from '@agoric/swing-store-simple';
 
 import buildKernel from '../src/kernel/index';
 import { makeLiveSlots } from '../src/kernel/liveSlots';
@@ -16,7 +16,7 @@ function capargs(args, slots = []) {
 }
 
 function makeEndowments() {
-  return { setImmediate, hostStorage: makeSwingStore(null, true).storage };
+  return { setImmediate, hostStorage: initSwingStore().storage };
 }
 
 test('calls', async t => {

--- a/packages/SwingSet/test/test-state.js
+++ b/packages/SwingSet/test/test-state.js
@@ -1,7 +1,7 @@
 import harden from '@agoric/harden';
 import { test } from 'tape-promise/tape';
 import {
-  makeMemorySwingStore,
+  makeSwingStore,
   getAllState,
   setAllState,
 } from '@agoric/swing-store-simple';
@@ -65,13 +65,13 @@ function testStorage(t, s, getState, commit) {
 }
 
 test('storageInMemory', t => {
-  const { storage } = makeMemorySwingStore();
+  const { storage } = makeSwingStore(null, true);
   testStorage(t, storage, () => getAllState(storage), null);
   t.end();
 });
 
 function buildHostDBAndGetState() {
-  const { storage } = makeMemorySwingStore();
+  const { storage } = makeSwingStore(null, true);
   const hostDB = buildHostDBInMemory(storage);
   return { hostDB, getState: () => getAllState(storage) };
 }
@@ -119,14 +119,14 @@ test('blockBuffer fulfills storage API', t => {
 });
 
 test('guardStorage fulfills storage API', t => {
-  const { storage } = makeMemorySwingStore();
+  const { storage } = makeSwingStore(null, true);
   const guardedHostStorage = guardStorage(storage);
   testStorage(t, guardedHostStorage, () => getAllState(storage), null);
   t.end();
 });
 
 test('crankBuffer fulfills storage API', t => {
-  const { storage } = makeMemorySwingStore();
+  const { storage } = makeSwingStore(null, true);
   const { crankBuffer, commitCrank } = buildCrankBuffer(storage);
   testStorage(t, crankBuffer, () => getAllState(storage), commitCrank);
   t.end();
@@ -191,19 +191,19 @@ test('crankBuffer can abortCrank', t => {
 
 test('read cache fulfills storage API', t => {
   // cache everything
-  let { storage } = makeMemorySwingStore();
+  let { storage } = makeSwingStore(null, true);
   let cachedStorage = addReadCache(storage, _key => true);
   testStorage(t, cachedStorage, () => getAllState(storage), null);
 
   // test again, but don't cache anything
-  storage = makeMemorySwingStore().storage;
+  storage = makeSwingStore(null, true).storage;
   cachedStorage = addReadCache(storage, _key => false);
   testStorage(t, cachedStorage, () => getAllState(storage), null);
   t.end();
 });
 
 function buildTracedStorage() {
-  const s = makeMemorySwingStore().storage;
+  const s = makeSwingStore(null, true).storage;
 
   const ops = [];
   function has(key) {
@@ -333,7 +333,7 @@ test('read cache', t => {
 });
 
 test('storage helpers', t => {
-  const { storage } = makeMemorySwingStore();
+  const { storage } = makeSwingStore(null, true);
   const s = addHelpers(storage);
 
   s.set('foo.0', 'f0');
@@ -385,7 +385,7 @@ test('storage helpers', t => {
 });
 
 function buildKeeperStorageInMemory() {
-  const { storage } = makeMemorySwingStore();
+  const { storage } = makeSwingStore(null, true);
   const { enhancedCrankBuffer, commitCrank } = wrapStorage(storage);
   return {
     kstorage: enhancedCrankBuffer,
@@ -395,7 +395,7 @@ function buildKeeperStorageInMemory() {
 }
 
 function duplicateKeeper(getState) {
-  const { storage } = makeMemorySwingStore();
+  const { storage } = makeSwingStore(null, true);
   setAllState(storage, getState());
   const { enhancedCrankBuffer } = wrapStorage(storage);
   return makeKernelKeeper(enhancedCrankBuffer);

--- a/packages/SwingSet/test/test-state.js
+++ b/packages/SwingSet/test/test-state.js
@@ -1,7 +1,7 @@
 import harden from '@agoric/harden';
 import { test } from 'tape-promise/tape';
 import {
-  makeSwingStore,
+  initSwingStore,
   getAllState,
   setAllState,
 } from '@agoric/swing-store-simple';
@@ -65,13 +65,13 @@ function testStorage(t, s, getState, commit) {
 }
 
 test('storageInMemory', t => {
-  const { storage } = makeSwingStore(null, true);
+  const { storage } = initSwingStore();
   testStorage(t, storage, () => getAllState(storage), null);
   t.end();
 });
 
 function buildHostDBAndGetState() {
-  const { storage } = makeSwingStore(null, true);
+  const { storage } = initSwingStore();
   const hostDB = buildHostDBInMemory(storage);
   return { hostDB, getState: () => getAllState(storage) };
 }
@@ -119,14 +119,14 @@ test('blockBuffer fulfills storage API', t => {
 });
 
 test('guardStorage fulfills storage API', t => {
-  const { storage } = makeSwingStore(null, true);
+  const { storage } = initSwingStore();
   const guardedHostStorage = guardStorage(storage);
   testStorage(t, guardedHostStorage, () => getAllState(storage), null);
   t.end();
 });
 
 test('crankBuffer fulfills storage API', t => {
-  const { storage } = makeSwingStore(null, true);
+  const { storage } = initSwingStore();
   const { crankBuffer, commitCrank } = buildCrankBuffer(storage);
   testStorage(t, crankBuffer, () => getAllState(storage), commitCrank);
   t.end();
@@ -191,19 +191,19 @@ test('crankBuffer can abortCrank', t => {
 
 test('read cache fulfills storage API', t => {
   // cache everything
-  let { storage } = makeSwingStore(null, true);
+  let { storage } = initSwingStore();
   let cachedStorage = addReadCache(storage, _key => true);
   testStorage(t, cachedStorage, () => getAllState(storage), null);
 
   // test again, but don't cache anything
-  storage = makeSwingStore(null, true).storage;
+  storage = initSwingStore().storage;
   cachedStorage = addReadCache(storage, _key => false);
   testStorage(t, cachedStorage, () => getAllState(storage), null);
   t.end();
 });
 
 function buildTracedStorage() {
-  const s = makeSwingStore(null, true).storage;
+  const s = initSwingStore().storage;
 
   const ops = [];
   function has(key) {
@@ -333,7 +333,7 @@ test('read cache', t => {
 });
 
 test('storage helpers', t => {
-  const { storage } = makeSwingStore(null, true);
+  const { storage } = initSwingStore();
   const s = addHelpers(storage);
 
   s.set('foo.0', 'f0');
@@ -385,7 +385,7 @@ test('storage helpers', t => {
 });
 
 function buildKeeperStorageInMemory() {
-  const { storage } = makeSwingStore(null, true);
+  const { storage } = initSwingStore();
   const { enhancedCrankBuffer, commitCrank } = wrapStorage(storage);
   return {
     kstorage: enhancedCrankBuffer,
@@ -395,7 +395,7 @@ function buildKeeperStorageInMemory() {
 }
 
 function duplicateKeeper(getState) {
-  const { storage } = makeSwingStore(null, true);
+  const { storage } = initSwingStore();
   setAllState(storage, getState());
   const { enhancedCrankBuffer } = wrapStorage(storage);
   return makeKernelKeeper(enhancedCrankBuffer);

--- a/packages/SwingSet/test/test-transcript-light.js
+++ b/packages/SwingSet/test/test-transcript-light.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import { test } from 'tape-promise/tape';
 import {
-  makeSwingStore,
+  initSwingStore,
   getAllState,
   setAllState,
 } from '@agoric/swing-store-simple';
@@ -11,7 +11,7 @@ async function testLoadState(t, withSES) {
   const config = await loadBasedir(
     path.resolve(__dirname, 'basedir-transcript'),
   );
-  const { storage } = makeSwingStore(null, true);
+  const { storage } = initSwingStore();
   config.hostStorage = storage;
   const c = await buildVatController(config, withSES, ['one']);
   const state0 = getAllState(storage);
@@ -35,7 +35,7 @@ async function testLoadState(t, withSES) {
   // Step 0
 
   const cfg0 = await loadBasedir(path.resolve(__dirname, 'basedir-transcript'));
-  const storage0 = makeSwingStore(null, true).storage;
+  const storage0 = initSwingStore().storage;
   setAllState(storage0, state0);
   cfg0.hostStorage = storage0;
   const c0 = await buildVatController(cfg0, withSES, ['one']);
@@ -58,7 +58,7 @@ async function testLoadState(t, withSES) {
   // Step 1
 
   const cfg1 = await loadBasedir(path.resolve(__dirname, 'basedir-transcript'));
-  const storage1 = makeSwingStore(null, true).storage;
+  const storage1 = initSwingStore().storage;
   setAllState(storage1, state1);
   cfg1.hostStorage = storage1;
   const c1 = await buildVatController(cfg1, withSES, ['one']);
@@ -80,7 +80,7 @@ async function testLoadState(t, withSES) {
   // Step 2
 
   const cfg2 = await loadBasedir(path.resolve(__dirname, 'basedir-transcript'));
-  const storage2 = makeSwingStore(null, true).storage;
+  const storage2 = initSwingStore().storage;
   setAllState(storage2, state2);
   cfg2.hostStorage = storage2;
   const c2 = await buildVatController(cfg2, withSES, ['one']);

--- a/packages/SwingSet/test/test-transcript-light.js
+++ b/packages/SwingSet/test/test-transcript-light.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import { test } from 'tape-promise/tape';
 import {
-  makeMemorySwingStore,
+  makeSwingStore,
   getAllState,
   setAllState,
 } from '@agoric/swing-store-simple';
@@ -11,7 +11,7 @@ async function testLoadState(t, withSES) {
   const config = await loadBasedir(
     path.resolve(__dirname, 'basedir-transcript'),
   );
-  const { storage } = makeMemorySwingStore();
+  const { storage } = makeSwingStore(null, true);
   config.hostStorage = storage;
   const c = await buildVatController(config, withSES, ['one']);
   const state0 = getAllState(storage);
@@ -35,7 +35,7 @@ async function testLoadState(t, withSES) {
   // Step 0
 
   const cfg0 = await loadBasedir(path.resolve(__dirname, 'basedir-transcript'));
-  const storage0 = makeMemorySwingStore().storage;
+  const storage0 = makeSwingStore(null, true).storage;
   setAllState(storage0, state0);
   cfg0.hostStorage = storage0;
   const c0 = await buildVatController(cfg0, withSES, ['one']);
@@ -58,7 +58,7 @@ async function testLoadState(t, withSES) {
   // Step 1
 
   const cfg1 = await loadBasedir(path.resolve(__dirname, 'basedir-transcript'));
-  const storage1 = makeMemorySwingStore().storage;
+  const storage1 = makeSwingStore(null, true).storage;
   setAllState(storage1, state1);
   cfg1.hostStorage = storage1;
   const c1 = await buildVatController(cfg1, withSES, ['one']);
@@ -80,7 +80,7 @@ async function testLoadState(t, withSES) {
   // Step 2
 
   const cfg2 = await loadBasedir(path.resolve(__dirname, 'basedir-transcript'));
-  const storage2 = makeMemorySwingStore().storage;
+  const storage2 = makeSwingStore(null, true).storage;
   setAllState(storage2, state2);
   cfg2.hostStorage = storage2;
   const c2 = await buildVatController(cfg2, withSES, ['one']);

--- a/packages/SwingSet/test/test-transcript.js
+++ b/packages/SwingSet/test/test-transcript.js
@@ -2,7 +2,7 @@ import path from 'path';
 import { test } from 'tape-promise/tape';
 // import fs from 'fs';
 import {
-  makeMemorySwingStore,
+  makeSwingStore,
   getAllState,
   setAllState,
 } from '@agoric/swing-store-simple';
@@ -23,7 +23,7 @@ async function testSaveState(t, withSES) {
   const config = await loadBasedir(
     path.resolve(__dirname, 'basedir-transcript'),
   );
-  const { storage } = makeMemorySwingStore();
+  const { storage } = makeSwingStore(null, true);
   config.hostStorage = storage;
   const c1 = await buildVatController(config, withSES, ['one']);
   const states1 = await buildTrace(c1, storage);
@@ -32,7 +32,7 @@ async function testSaveState(t, withSES) {
     fs.writeFileSync(`kdata-${i}.json`, JSON.stringify(s))
   ); */
 
-  const storage2 = makeMemorySwingStore().storage;
+  const storage2 = makeSwingStore(null, true).storage;
   config.hostStorage = storage2;
   const c2 = await buildVatController(config, withSES, ['one']);
   const states2 = await buildTrace(c2, storage2);
@@ -55,7 +55,7 @@ async function testLoadState(t, withSES) {
   const config = await loadBasedir(
     path.resolve(__dirname, 'basedir-transcript'),
   );
-  const s0 = makeMemorySwingStore().storage;
+  const s0 = makeSwingStore(null, true).storage;
   config.hostStorage = s0;
   const c0 = await buildVatController(config, withSES, ['one']);
   const states = await buildTrace(c0, s0);
@@ -68,7 +68,7 @@ async function testLoadState(t, withSES) {
     const cfg = await loadBasedir(
       path.resolve(__dirname, 'basedir-transcript'),
     );
-    const s = makeMemorySwingStore().storage;
+    const s = makeSwingStore(null, true).storage;
     setAllState(s, states[i]);
     cfg.hostStorage = s;
     // eslint-disable-next-line no-await-in-loop

--- a/packages/SwingSet/test/test-transcript.js
+++ b/packages/SwingSet/test/test-transcript.js
@@ -2,7 +2,7 @@ import path from 'path';
 import { test } from 'tape-promise/tape';
 // import fs from 'fs';
 import {
-  makeSwingStore,
+  initSwingStore,
   getAllState,
   setAllState,
 } from '@agoric/swing-store-simple';
@@ -23,7 +23,7 @@ async function testSaveState(t, withSES) {
   const config = await loadBasedir(
     path.resolve(__dirname, 'basedir-transcript'),
   );
-  const { storage } = makeSwingStore(null, true);
+  const { storage } = initSwingStore();
   config.hostStorage = storage;
   const c1 = await buildVatController(config, withSES, ['one']);
   const states1 = await buildTrace(c1, storage);
@@ -32,7 +32,7 @@ async function testSaveState(t, withSES) {
     fs.writeFileSync(`kdata-${i}.json`, JSON.stringify(s))
   ); */
 
-  const storage2 = makeSwingStore(null, true).storage;
+  const storage2 = initSwingStore().storage;
   config.hostStorage = storage2;
   const c2 = await buildVatController(config, withSES, ['one']);
   const states2 = await buildTrace(c2, storage2);
@@ -55,7 +55,7 @@ async function testLoadState(t, withSES) {
   const config = await loadBasedir(
     path.resolve(__dirname, 'basedir-transcript'),
   );
-  const s0 = makeSwingStore(null, true).storage;
+  const s0 = initSwingStore().storage;
   config.hostStorage = s0;
   const c0 = await buildVatController(config, withSES, ['one']);
   const states = await buildTrace(c0, s0);
@@ -68,7 +68,7 @@ async function testLoadState(t, withSES) {
     const cfg = await loadBasedir(
       path.resolve(__dirname, 'basedir-transcript'),
     );
-    const s = makeSwingStore(null, true).storage;
+    const s = initSwingStore().storage;
     setAllState(s, states[i]);
     cfg.hostStorage = s;
     // eslint-disable-next-line no-await-in-loop

--- a/packages/SwingSet/test/vat-admin/test-innerVat.js
+++ b/packages/SwingSet/test/vat-admin/test-innerVat.js
@@ -1,6 +1,6 @@
 import { test } from 'tape';
 import path from 'path';
-import { makeMemorySwingStore } from '@agoric/swing-store-simple';
+import { makeSwingStore } from '@agoric/swing-store-simple';
 
 import { buildVatController, loadBasedir } from '../../src';
 
@@ -8,7 +8,7 @@ async function createConfig() {
   const dir = path.resolve('./test/vat-admin');
   const config = await loadBasedir(dir);
 
-  config.hostStorage = makeMemorySwingStore().storage;
+  config.hostStorage = makeSwingStore(null, true).storage;
   return config;
 }
 

--- a/packages/SwingSet/test/vat-admin/test-innerVat.js
+++ b/packages/SwingSet/test/vat-admin/test-innerVat.js
@@ -1,6 +1,6 @@
 import { test } from 'tape';
 import path from 'path';
-import { makeSwingStore } from '@agoric/swing-store-simple';
+import { initSwingStore } from '@agoric/swing-store-simple';
 
 import { buildVatController, loadBasedir } from '../../src';
 
@@ -8,7 +8,7 @@ async function createConfig() {
   const dir = path.resolve('./test/vat-admin');
   const config = await loadBasedir(dir);
 
-  config.hostStorage = makeSwingStore(null, true).storage;
+  config.hostStorage = initSwingStore().storage;
   return config;
 }
 

--- a/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
+++ b/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
@@ -34,7 +34,8 @@ export async function connectToFakeChain(basedir, GCI, role, delay, inbound) {
 
   const vatsdir = path.join(basedir, 'vats');
   const argv = [`--role=${role}`, bootAddress];
-  const s = await launch(basedir, mailboxStorage, `fake-chain-${GCI}-state`, vatsdir, argv);
+  const stateDBdir = path.join(basedir, `fake-chain-${GCI}-state`);
+  const s = await launch(stateDBdir, mailboxStorage, vatsdir, argv);
   const { deliverInbound, deliverStartBlock } = s;
 
   let pretendLast = Date.now();

--- a/packages/cosmic-swingset/lib/ag-solo/reset-state.js
+++ b/packages/cosmic-swingset/lib/ag-solo/reset-state.js
@@ -1,13 +1,13 @@
 import path from 'path';
 import fs from 'fs';
 
-import { makeSwingStore } from '@agoric/swing-store-simple';
+import { initSwingStore } from '@agoric/swing-store-simple';
 
 export default async function resetState(basedir) {
   const mailboxStateFile = path.resolve(basedir, 'swingset-kernel-mailbox.json');
   fs.writeFileSync(mailboxStateFile, `{}\n`);
   const kernelStateDBDir = path.join(basedir, 'swingset-kernel-state');
-  const { commit, close } = makeSwingStore(kernelStateDBDir, true);
+  const { commit, close } = initSwingStore(kernelStateDBDir);
   commit();
   close();
 }

--- a/packages/cosmic-swingset/lib/ag-solo/reset-state.js
+++ b/packages/cosmic-swingset/lib/ag-solo/reset-state.js
@@ -1,13 +1,13 @@
 import path from 'path';
 import fs from 'fs';
 
-import { makeSimpleSwingStore } from '@agoric/swing-store-simple';
+import { makeSwingStore } from '@agoric/swing-store-simple';
 
 export default async function resetState(basedir) {
   const mailboxStateFile = path.resolve(basedir, 'swingset-kernel-mailbox.json');
   fs.writeFileSync(mailboxStateFile, `{}\n`);
-
-  const { commit, close } = makeSimpleSwingStore(basedir, 'swingset-kernel-state', true);
+  const kernelStateDBDir = path.join(basedir, 'swingset-kernel-state');
+  const { commit, close } = makeSwingStore(kernelStateDBDir, true);
   commit();
   close();
 }

--- a/packages/cosmic-swingset/lib/ag-solo/start.js
+++ b/packages/cosmic-swingset/lib/ag-solo/start.js
@@ -9,7 +9,7 @@ import readlines from 'n-readlines';
 // import harden from '@agoric/harden';
 // import djson from 'deterministic-json';
 
-import { makeSimpleSwingStore } from '@agoric/swing-store-simple';
+import { makeSwingStore } from '@agoric/swing-store-simple';
 import {
   loadBasedir,
   buildCommand,
@@ -72,9 +72,8 @@ async function atomicReplaceFile(filename, contents) {
 }
 
 async function buildSwingset(
-  basedir,
+  kernelStateDBDir,
   mailboxStateFile,
-  kernelStateDBName,
   withSES,
   vatsDir,
   argv,
@@ -101,7 +100,7 @@ async function buildSwingset(
   });
   config.vats.set('timer', { sourcepath: getTimerWrapperSourcePath() });
 
-  const { storage, commit } = makeSimpleSwingStore(basedir, kernelStateDBName, false);
+  const { storage, commit } = makeSwingStore(kernelStateDBDir, false);
   config.hostStorage = storage;
 
   const controller = await buildVatController(config, withSES, argv);
@@ -239,10 +238,10 @@ export default async function start(basedir, withSES, argv) {
   );
 
   const vatsDir = path.join(basedir, 'vats');
+  const stateDBDir = path.join(basedir, 'swingset-kernel-state');
   const d = await buildSwingset(
-    basedir,
+    stateDBDir,
     mailboxStateFile,
-    'swingset-kernel-state',
     withSES,
     vatsDir,
     argv,

--- a/packages/cosmic-swingset/lib/ag-solo/start.js
+++ b/packages/cosmic-swingset/lib/ag-solo/start.js
@@ -9,7 +9,7 @@ import readlines from 'n-readlines';
 // import harden from '@agoric/harden';
 // import djson from 'deterministic-json';
 
-import { makeSwingStore } from '@agoric/swing-store-simple';
+import { openSwingStore } from '@agoric/swing-store-simple';
 import {
   loadBasedir,
   buildCommand,
@@ -100,7 +100,7 @@ async function buildSwingset(
   });
   config.vats.set('timer', { sourcepath: getTimerWrapperSourcePath() });
 
-  const { storage, commit } = makeSwingStore(kernelStateDBDir, false);
+  const { storage, commit } = openSwingStore(kernelStateDBDir);
   config.hostStorage = storage;
 
   const controller = await buildVatController(config, withSES, argv);

--- a/packages/cosmic-swingset/lib/launch-chain.js
+++ b/packages/cosmic-swingset/lib/launch-chain.js
@@ -11,7 +11,7 @@ import {
   getTimerWrapperSourcePath,
   getVatTPSourcePath,
 } from '@agoric/swingset-vat';
-import { makeSimpleSwingStore } from '@agoric/swing-store-simple';
+import { makeSwingStore } from '@agoric/swing-store-simple';
 
 async function buildSwingset(withSES, mailboxState, storage, vatsDir, argv) {
   const config = {};
@@ -47,7 +47,7 @@ async function buildSwingset(withSES, mailboxState, storage, vatsDir, argv) {
   return { controller, mb, mbs, timer };
 }
 
-export async function launch(basedir, mailboxStorage, stateDB, vatsDir, argv) {
+export async function launch(kernelStateDBDir, mailboxStorage, vatsDir, argv) {
   const withSES = true;
 
   console.log(
@@ -58,7 +58,7 @@ export async function launch(basedir, mailboxStorage, stateDB, vatsDir, argv) {
     ? JSON.parse(mailboxStorage.get('mailbox'))
     : {};
 
-  const { storage, commit } = makeSimpleSwingStore(basedir, stateDB, false);
+  const { storage, commit } = makeSwingStore(kernelStateDBDir, false);
 
   console.log(`buildSwingset`);
   const { controller, mb, mbs, timer } = await buildSwingset(

--- a/packages/cosmic-swingset/lib/launch-chain.js
+++ b/packages/cosmic-swingset/lib/launch-chain.js
@@ -11,7 +11,7 @@ import {
   getTimerWrapperSourcePath,
   getVatTPSourcePath,
 } from '@agoric/swingset-vat';
-import { makeSwingStore } from '@agoric/swing-store-simple';
+import { openSwingStore } from '@agoric/swing-store-simple';
 
 async function buildSwingset(withSES, mailboxState, storage, vatsDir, argv) {
   const config = {};
@@ -58,7 +58,7 @@ export async function launch(kernelStateDBDir, mailboxStorage, vatsDir, argv) {
     ? JSON.parse(mailboxStorage.get('mailbox'))
     : {};
 
-  const { storage, commit } = makeSwingStore(kernelStateDBDir, false);
+  const { storage, commit } = openSwingStore(kernelStateDBDir);
 
   console.log(`buildSwingset`);
   const { controller, mb, mbs, timer } = await buildSwingset(

--- a/packages/swing-store-lmdb/lmdbSwingStore.js
+++ b/packages/swing-store-lmdb/lmdbSwingStore.js
@@ -3,12 +3,9 @@ import fs from 'fs';
 import lmdb from 'node-lmdb';
 
 /**
- * Create a swingset store instance backed by an LMDB database.
+ * Do the work of `initSwingStore` and `openSwingStore`.
  *
  * @param dirPath  Path to a directory in which database files may be kept.
- *   This directory need not actually exist yet (if it doesn't it will be
- *   created) but it is reserved (by the caller) for the exclusive use of this
- *   swing store instance.
  * @param forceReset  If true, initialize the database to an empty state
  *
  * @return an object: {
@@ -17,7 +14,7 @@ import lmdb from 'node-lmdb';
  *   close    // a function to shutdown the store, abandoning any uncommitted changes
  * }
  */
-export function makeSwingStore(dirPath, forceReset = false) {
+function makeSwingStore(dirPath, forceReset = false) {
   let txn = null;
 
   if (forceReset) {
@@ -184,4 +181,50 @@ export function makeSwingStore(dirPath, forceReset = false) {
   }
 
   return { storage, commit, close };
+}
+
+/**
+ * Create a swingset store backed by an LMDB database.  If there is an existing
+ * store at the given `dirPath`, it will be reinitialized to an empty state.
+ *
+ * @param dirPath  Path to a directory in which database files may be kept.
+ *   This directory need not actually exist yet (if it doesn't it will be
+ *   created) but it is reserved (by the caller) for the exclusive use of this
+ *   swing store instance.
+ *
+ * @return an object: {
+ *   storage, // a storage API object to load and store data
+ *   commit,  // a function to commit changes made since the last commit
+ *   close    // a function to shutdown the store, abandoning any uncommitted
+ *            // changes
+ * }
+ */
+export function initSwingStore(dirPath) {
+  if (`${dirPath}` !== dirPath) {
+    throw new Error('dirPath must be a string');
+  }
+  return makeSwingStore(dirPath, true);
+}
+
+/**
+ * Open a swingset store backed by an LMDB database.  If there is no existing
+ * store at the given `dirPath`, a new, empty store will be created.
+ *
+ * @param dirPath  Path to a directory in which database files may be kept.
+ *   This directory need not actually exist yet (if it doesn't it will be
+ *   created) but it is reserved (by the caller) for the exclusive use of this
+ *   swing store instance.
+ *
+ * @return an object: {
+ *   storage, // a storage API object to load and store data
+ *   commit,  // a function to commit changes made since the last commit
+ *   close    // a function to shutdown the store, abandoning any uncommitted
+ *            // changes
+ * }
+ */
+export function openSwingStore(dirPath) {
+  if (`${dirPath}` !== dirPath) {
+    throw new Error('dirPath must be a string');
+  }
+  return makeSwingStore(dirPath, false);
 }

--- a/packages/swing-store-lmdb/lmdbSwingStore.js
+++ b/packages/swing-store-lmdb/lmdbSwingStore.js
@@ -1,23 +1,14 @@
 import fs from 'fs';
-import path from 'path';
 
 import lmdb from 'node-lmdb';
-
-function safeUnlink(filePath) {
-  try {
-    fs.unlinkSync(filePath);
-  } catch (e) {
-    if (e.code !== 'ENOENT') {
-      throw e;
-    }
-  }
-}
 
 /**
  * Create a swingset store instance backed by an LMDB database.
  *
- * @param basedir  Directory in which database files will be kept
- * @param dbName   Name for the database
+ * @param dirPath  Path to a directory in which database files may be kept.
+ *   This directory need not actually exist yet (if it doesn't it will be
+ *   created) but it is reserved (by the caller) for the exclusive use of this
+ *   swing store instance.
  * @param forceReset  If true, initialize the database to an empty state
  *
  * @return an object: {
@@ -26,22 +17,22 @@ function safeUnlink(filePath) {
  *   close    // a function to shutdown the store, abandoning any uncommitted changes
  * }
  */
-export function makeLMDBSwingStore(basedir, dbName, forceReset = false) {
+export function makeSwingStore(dirPath, forceReset = false) {
   let txn = null;
 
   if (forceReset) {
-    safeUnlink(path.resolve(basedir, 'data.mdb'));
-    safeUnlink(path.resolve(basedir, 'lock.mdb'));
+    fs.rmdirSync(dirPath, { recursive: true });
   }
+  fs.mkdirSync(dirPath, { recursive: true });
 
   let lmdbEnv = new lmdb.Env();
   lmdbEnv.open({
-    path: basedir,
+    path: dirPath,
     mapSize: 2 * 1024 * 1024 * 1024, // XXX need to tune this
   });
 
   let dbi = lmdbEnv.openDbi({
-    name: dbName,
+    name: 'swingset-kernel-state',
     create: true,
   });
 
@@ -174,8 +165,6 @@ export function makeLMDBSwingStore(basedir, dbName, forceReset = false) {
     if (txn) {
       txn.commit();
       txn = null;
-    } else {
-      throw new Error('commit called without open transaction');
     }
   }
 
@@ -186,6 +175,7 @@ export function makeLMDBSwingStore(basedir, dbName, forceReset = false) {
   function close() {
     if (txn) {
       txn.abort();
+      txn = null;
     }
     dbi.close();
     dbi = null;

--- a/packages/swing-store-lmdb/test/test-state.js
+++ b/packages/swing-store-lmdb/test/test-state.js
@@ -3,7 +3,7 @@ import fs from 'fs';
 import { test } from 'tape-promise/tape';
 import { getAllState } from '@agoric/swing-store-simple';
 
-import { makeSwingStore } from '../lmdbSwingStore';
+import { initSwingStore, openSwingStore } from '../lmdbSwingStore';
 
 function testStorage(t, storage) {
   t.notOk(storage.has('missing'));
@@ -37,13 +37,13 @@ function testStorage(t, storage) {
 }
 
 test('storageInLMDB', t => {
-  const { storage, commit, close } = makeSwingStore('testdb', true);
+  const { storage, commit, close } = initSwingStore('testdb');
   testStorage(t, storage);
   commit();
   const before = getAllState(storage);
   close();
 
-  const { storage: after } = makeSwingStore('testdb', false);
+  const { storage: after } = openSwingStore('testdb');
   t.deepEqual(getAllState(after), before, 'check state after reread');
   t.end();
 });

--- a/packages/swing-store-lmdb/test/test-state.js
+++ b/packages/swing-store-lmdb/test/test-state.js
@@ -3,7 +3,7 @@ import fs from 'fs';
 import { test } from 'tape-promise/tape';
 import { getAllState } from '@agoric/swing-store-simple';
 
-import { makeLMDBSwingStore } from '../lmdbSwingStore';
+import { makeSwingStore } from '../lmdbSwingStore';
 
 function testStorage(t, storage) {
   t.notOk(storage.has('missing'));
@@ -37,18 +37,15 @@ function testStorage(t, storage) {
 }
 
 test('storageInLMDB', t => {
-  const { storage, commit, close } = makeLMDBSwingStore('.', 'stuff', true);
+  const { storage, commit, close } = makeSwingStore('testdb', true);
   testStorage(t, storage);
   commit();
   const before = getAllState(storage);
   close();
 
-  const { storage: after } = makeLMDBSwingStore('.', 'stuff', false);
+  const { storage: after } = makeSwingStore('testdb', false);
   t.deepEqual(getAllState(after), before, 'check state after reread');
   t.end();
 });
 
-test.onFinish(() => {
-  fs.unlinkSync('data.mdb');
-  fs.unlinkSync('lock.mdb');
-});
+test.onFinish(() => fs.rmdirSync('testdb', { recursive: true }));

--- a/packages/swing-store-simple/simpleSwingStore.js
+++ b/packages/swing-store-simple/simpleSwingStore.js
@@ -138,31 +138,14 @@ function makeStorageInMemory() {
 }
 
 /**
- * Create a swingset store instance that exists strictly as an in-memory map
- * with no persistent backing.
+ * Create a swingset store instance that is an in-memory map, normally backed
+ * by JSON serialized to a text file.
  *
- * @return an object: {
- *   storage, // a storage API object to load and store data
- *   commit,  // a function to commit changes made since the last commit (a
- *            // no-op in this case)
- *   close    // a function to shutdown the store, abandoning any uncommitted
- *            // changes (also a no-op)
- * }
- */
-export function makeMemorySwingStore(_basedir, _dbName, _forceReset) {
-  return {
-    storage: makeStorageInMemory().storage,
-    commit: () => {},
-    close: () => {},
-  };
-}
-
-/**
- * Create a swingset store instance that is an in-memory map backed by JSON
- * serialized to a text file.
- *
- * @param basedir  Directory in which database files will be kept
- * @param dbName   Name for the database
+ * @param dirPath  Path to a directory in which database files may be kept.
+ *   This directory need not actually exist yet (if it doesn't it will be
+ *   created) but it is reserved (by the caller) for the exclusive use of this
+ *   swing store instance.  If this is null, the swing store created will have
+ *   no backing store and thus be non-persistent.
  * @param forceReset  If true, initialize the database to an empty state
  *
  * @return an object: {
@@ -172,29 +155,33 @@ export function makeMemorySwingStore(_basedir, _dbName, _forceReset) {
  *            // changes
  * }
  */
-export function makeSimpleSwingStore(basedir, dbName, forceReset = false) {
+export function makeSwingStore(dirPath, forceReset = false) {
   const { storage, state } = makeStorageInMemory();
 
-  const storeFile = path.resolve(basedir, `${dbName}.jsonlines`);
-  if (forceReset) {
-    safeUnlink(storeFile);
-  } else {
-    let lines;
-    try {
-      lines = new Readlines(storeFile);
-    } catch (e) {
-      // storeFile will be missing the first time we try to use it.  That's OK;
-      // commit will create it.
-      if (e.code !== 'ENOENT') {
-        throw e;
+  let storeFile;
+  if (dirPath) {
+    fs.mkdirSync(dirPath, { recursive: true });
+    storeFile = path.resolve(dirPath, 'swingset-kernel-state.jsonlines');
+    if (forceReset) {
+      safeUnlink(storeFile);
+    } else {
+      let lines;
+      try {
+        lines = new Readlines(storeFile);
+      } catch (e) {
+        // storeFile will be missing the first time we try to use it.  That's OK;
+        // commit will create it.
+        if (e.code !== 'ENOENT') {
+          throw e;
+        }
       }
-    }
-    if (lines) {
-      let line = lines.next();
-      while (line) {
-        const [key, value] = JSON.parse(line);
-        storage.set(key, value);
-        line = lines.next();
+      if (lines) {
+        let line = lines.next();
+        while (line) {
+          const [key, value] = JSON.parse(line);
+          storage.set(key, value);
+          line = lines.next();
+        }
       }
     }
   }
@@ -203,16 +190,18 @@ export function makeSimpleSwingStore(basedir, dbName, forceReset = false) {
    * Commit unsaved changes.
    */
   function commit() {
-    const tempFile = `${storeFile}.tmp`;
-    const fd = fs.openSync(tempFile, 'w');
+    if (dirPath) {
+      const tempFile = `${storeFile}.tmp`;
+      const fd = fs.openSync(tempFile, 'w');
 
-    for (const [key, value] of state.entries()) {
-      const line = JSON.stringify([key, value]);
-      fs.writeSync(fd, line);
-      fs.writeSync(fd, '\n');
+      for (const [key, value] of state.entries()) {
+        const line = JSON.stringify([key, value]);
+        fs.writeSync(fd, line);
+        fs.writeSync(fd, '\n');
+      }
+      fs.closeSync(fd);
+      fs.renameSync(tempFile, storeFile);
     }
-    fs.closeSync(fd);
-    fs.renameSync(tempFile, storeFile);
   }
 
   /**

--- a/packages/swing-store-simple/simpleSwingStore.js
+++ b/packages/swing-store-simple/simpleSwingStore.js
@@ -138,14 +138,10 @@ function makeStorageInMemory() {
 }
 
 /**
- * Create a swingset store instance that is an in-memory map, normally backed
- * by JSON serialized to a text file.
+ * Do the work of `initSwingStore` and `openSwingStore`.
  *
- * @param dirPath  Path to a directory in which database files may be kept.
- *   This directory need not actually exist yet (if it doesn't it will be
- *   created) but it is reserved (by the caller) for the exclusive use of this
- *   swing store instance.  If this is null, the swing store created will have
- *   no backing store and thus be non-persistent.
+ * @param dirPath  Path to a directory in which database files may be kept, or
+ *   null.
  * @param forceReset  If true, initialize the database to an empty state
  *
  * @return an object: {
@@ -155,7 +151,7 @@ function makeStorageInMemory() {
  *            // changes
  * }
  */
-export function makeSwingStore(dirPath, forceReset = false) {
+function makeSwingStore(dirPath, forceReset = false) {
   const { storage, state } = makeStorageInMemory();
 
   let storeFile;
@@ -213,6 +209,55 @@ export function makeSwingStore(dirPath, forceReset = false) {
   }
 
   return { storage, commit, close };
+}
+
+/**
+ * Create a swingset store that is an in-memory map, normally backed by JSON
+ * serialized to a text file.  If there is an existing store at the given
+ * `dirPath`, it will be reinitialized to an empty state.
+ *
+ * @param dirPath  Path to a directory in which database files may be kept.
+ *   This directory need not actually exist yet (if it doesn't it will be
+ *   created) but it is reserved (by the caller) for the exclusive use of this
+ *   swing store instance.  If this is nullish, the swing store created will
+ *   have no backing store and thus be non-persistent.
+ *
+ * @return an object: {
+ *   storage, // a storage API object to load and store data
+ *   commit,  // a function to commit changes made since the last commit
+ *   close    // a function to shutdown the store, abandoning any uncommitted
+ *            // changes
+ * }
+ */
+export function initSwingStore(dirPath) {
+  if (dirPath !== null && dirPath !== undefined && `${dirPath}` !== dirPath) {
+    throw new Error('dirPath must be a string or nullish');
+  }
+  return makeSwingStore(dirPath, true);
+}
+
+/**
+ * Open a swingset store that is an in-memory map, backed by JSON serialized to
+ * a text file.  If there is no existing store at the given `dirPath`, a new,
+ * empty store will be created.
+ *
+ * @param dirPath  Path to a directory in which database files may be kept.
+ *   This directory need not actually exist yet (if it doesn't it will be
+ *   created) but it is reserved (by the caller) for the exclusive use of this
+ *   swing store instance.
+ *
+ * @return an object: {
+ *   storage, // a storage API object to load and store data
+ *   commit,  // a function to commit changes made since the last commit
+ *   close    // a function to shutdown the store, abandoning any uncommitted
+ *            // changes
+ * }
+ */
+export function openSwingStore(dirPath) {
+  if (`${dirPath}` !== dirPath) {
+    throw new Error('dirPath must be a string');
+  }
+  return makeSwingStore(dirPath, false);
 }
 
 /**

--- a/packages/swing-store-simple/test/test-state.js
+++ b/packages/swing-store-simple/test/test-state.js
@@ -1,7 +1,11 @@
 import fs from 'fs';
 
 import { test } from 'tape-promise/tape';
-import { makeSwingStore, getAllState } from '../simpleSwingStore';
+import {
+  initSwingStore,
+  openSwingStore,
+  getAllState,
+} from '../simpleSwingStore';
 
 function testStorage(t, storage) {
   t.notOk(storage.has('missing'));
@@ -35,19 +39,19 @@ function testStorage(t, storage) {
 }
 
 test('storageInMemory', t => {
-  const { storage } = makeSwingStore(null, true);
+  const { storage } = initSwingStore();
   testStorage(t, storage);
   t.end();
 });
 
 test('storageInFile', t => {
-  const { storage, commit, close } = makeSwingStore('testdb', true);
+  const { storage, commit, close } = initSwingStore('testdb');
   testStorage(t, storage);
   commit();
   const before = getAllState(storage);
   close();
 
-  const { storage: after } = makeSwingStore('testdb', false);
+  const { storage: after } = openSwingStore('testdb');
   t.deepEqual(getAllState(after), before, 'check state after reread');
   t.end();
 });

--- a/packages/swing-store-simple/test/test-state.js
+++ b/packages/swing-store-simple/test/test-state.js
@@ -1,11 +1,7 @@
 import fs from 'fs';
 
 import { test } from 'tape-promise/tape';
-import {
-  makeMemorySwingStore,
-  makeSimpleSwingStore,
-  getAllState,
-} from '../simpleSwingStore';
+import { makeSwingStore, getAllState } from '../simpleSwingStore';
 
 function testStorage(t, storage) {
   t.notOk(storage.has('missing'));
@@ -39,21 +35,21 @@ function testStorage(t, storage) {
 }
 
 test('storageInMemory', t => {
-  const { storage } = makeMemorySwingStore();
+  const { storage } = makeSwingStore(null, true);
   testStorage(t, storage);
   t.end();
 });
 
 test('storageInFile', t => {
-  const { storage, commit, close } = makeSimpleSwingStore('.', 'stuff', true);
+  const { storage, commit, close } = makeSwingStore('testdb', true);
   testStorage(t, storage);
   commit();
   const before = getAllState(storage);
   close();
 
-  const { storage: after } = makeSimpleSwingStore('.', 'stuff', false);
+  const { storage: after } = makeSwingStore('testdb', false);
   t.deepEqual(getAllState(after), before, 'check state after reread');
   t.end();
 });
 
-test.onFinish(() => fs.unlinkSync('stuff.jsonlines'));
+test.onFinish(() => fs.rmdirSync('testdb', { recursive: true }));

--- a/packages/swingset-runner/src/main.js
+++ b/packages/swingset-runner/src/main.js
@@ -4,8 +4,14 @@ import repl from 'repl';
 import util from 'util';
 
 import { buildVatController, loadBasedir } from '@agoric/swingset-vat';
-import { makeSwingStore as makeSimpleSwingStore } from '@agoric/swing-store-simple';
-import { makeSwingStore as makeLMDBSwingStore } from '@agoric/swing-store-lmdb';
+import {
+  initSwingStore as initSimpleSwingStore,
+  openSwingStore as openSimpleSwingStore,
+} from '@agoric/swing-store-simple';
+import {
+  initSwingStore as initLMDBSwingStore,
+  openSwingStore as openLMDBSwingStore,
+} from '@agoric/swing-store-lmdb';
 
 function deepLog(item) {
   console.log(util.inspect(item, false, null, true));
@@ -76,13 +82,21 @@ export async function main() {
   const kernelStateDBDir = path.join(basedir, 'swingset-kernel-state');
   switch (dbMode) {
     case '--filedb':
-      store = makeSimpleSwingStore(kernelStateDBDir, forceReset);
+      if (forceReset) {
+        store = initSimpleSwingStore(kernelStateDBDir);
+      } else {
+        store = openSimpleSwingStore(kernelStateDBDir);
+      }
       break;
     case '--memdb':
-      store = makeSimpleSwingStore(null, forceReset);
+      store = initSimpleSwingStore();
       break;
     case '--lmdb':
-      store = makeLMDBSwingStore(kernelStateDBDir, forceReset);
+      if (forceReset) {
+        store = initLMDBSwingStore(kernelStateDBDir);
+      } else {
+        store = openLMDBSwingStore(kernelStateDBDir);
+      }
       break;
     default:
       throw new Error(`invalid database mode ${dbMode}`);


### PR DESCRIPTION
Refactoring of the swing store API, per a conversation with Brian yesterday.  Changes consist of:
-- Rename swing store creator to `makeSwingStore` universally, so that choice of swing store implementation can typically be switched simply by changing the package imported from without further code changes.
-- Configuration of a store limited to specifying the base directory it will use for persistence, to minimize the amount of external variation based on what kind of data store is actually underneath.
-- Merging the in-memory store with the simple file store into a single store (since they were already together and jointed intimately); to specify a volatile (i.e., non-persistent) store, pass `null` as the path to the storage directory.

All tests and consumers updated to match.
Also verified that you can run cosmic-swingset on top of LMDB!
