### PR TITLE
WIP: Passable collections

### DIFF
--- a/packages/marshal/marshal.js
+++ b/packages/marshal/marshal.js
@@ -156,17 +156,6 @@ export function mustPassByPresence(val) {
   // ok!
 }
 
-// This is the equality comparison used by JavaScript's Map and Set
-// abstractions, where NaN is the same as NaN and -0 is the same as
-// 0. Marshal serializes -0 as zero, so the semantics of our distributed
-// object system does not distinguish 0 from -0.
-//
-// `sameValueZero` is the EcmaScript spec name for this equality comparison,
-// but TODO we need a better name for the API.
-export function sameValueZero(x, y) {
-  return x === y || Object.is(x, y);
-}
-
 // How would val be passed?  For primitive values, the answer is
 //   * 'null' for null
 //   * throwing an error for a symbol, whether registered or not.

--- a/packages/same-structure/src/sameStructure.js
+++ b/packages/same-structure/src/sameStructure.js
@@ -1,7 +1,7 @@
 import harden from '@agoric/harden';
 import { passStyleOf } from '@agoric/marshal';
 import { assert, details, openDetail } from '@agoric/assert';
-import makeStrongStore, { sameKey } from './store';
+import { sameKey } from '../../store/src/store';
 
 // Shim of Object.fromEntries from
 // https://github.com/tc39/proposal-object-from-entries/blob/master/polyfill.js

--- a/packages/same-structure/src/sameStructure.js
+++ b/packages/same-structure/src/sameStructure.js
@@ -1,7 +1,7 @@
 import harden from '@agoric/harden';
-import makeStrongStore, { sameKey } from './store';
 import { passStyleOf } from '@agoric/marshal';
 import { assert, details, openDetail } from '@agoric/assert';
+import makeStrongStore, { sameKey } from './store';
 
 // Shim of Object.fromEntries from
 // https://github.com/tc39/proposal-object-from-entries/blob/master/polyfill.js

--- a/packages/same-structure/src/sameStructure.js
+++ b/packages/same-structure/src/sameStructure.js
@@ -1,5 +1,6 @@
 import harden from '@agoric/harden';
-import { sameValueZero, passStyleOf } from '@agoric/marshal';
+import makeStrongStore, { sameKey } from './store';
+import { passStyleOf } from '@agoric/marshal';
 import { assert, details, openDetail } from '@agoric/assert';
 
 // Shim of Object.fromEntries from
@@ -114,7 +115,7 @@ function sameStructure(left, right) {
     case 'symbol':
     case 'bigint':
     case 'presence': {
-      return sameValueZero(left, right);
+      return sameKey(left, right);
     }
     case 'copyRecord':
     case 'copyArray': {
@@ -193,7 +194,7 @@ function mustBeSameStructureInternal(left, right, message, path) {
     case 'symbol':
     case 'bigint':
     case 'presence': {
-      if (!sameValueZero(left, right)) {
+      if (!sameKey(left, right)) {
         complain('different');
       }
       break;

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "exit 0",
-    "test": "exit 0",
+    "test": "tape -r esm test/**/test*.js",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint-check": "eslint '**/*.js'",
     "lint-fix-jessie": "eslint -c '.eslintrc-jessie.js' --fix '**/*.js'",
@@ -29,7 +29,8 @@
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "dependencies": {
     "@agoric/harden": "^0.0.4",
-    "@agoric/assert": "^0.0.1"
+    "@agoric/assert": "^0.0.1",
+    "@agoric/weak-store": "^0.0.1"
   },
   "devDependencies": {
     "esm": "^3.2.25",

--- a/packages/store/src/store.js
+++ b/packages/store/src/store.js
@@ -3,18 +3,34 @@
 import harden from '@agoric/harden';
 import { assert, details, openDetail } from '@agoric/assert';
 
-// This is the equality used by JavaScript maps to compare their
-// keys. NaN is equal to NaN and -0 is equal to 0.
-// The simple store exported by this module uses the same
-// equality.
-export const mapKeyEqual = (a, b) => a === b || Object.is(a, b);
+// `sameKey` is the equality comparison used by JavaScript's Map and Set
+// abstractions to compare their keys. Its internal JavaScript spec name
+// is "SameValueZero". It forms a proper equivalence class that is less
+// precise than `Object.is`. Unlike `===`, `sameKey` is an equivalence
+// class because `sameKey(NaN, NaN)`. `sameKey` is more precise than
+// `Object.is` because `!sameKey(-0, 0)`.
+//
+// The simple `makeStore` exported by this module makes stores that
+// also use `sameKey` equality to compare their keys.
+//
+// Marshal serializes -0 as zero, so the semantics of our distributed
+// object system also does not distinguish 0 from -0.
+//
+// `sameValueZero` is the EcmaScript spec name for this equality comparison.
+// Unlike `===`, `sameKey` is an equivalence class, since
+export const sameKey = (a, b) => a === b || Object.is(a, b);
 
 /**
  * Distinguishes between adding a new key (init) and updating or
  * referencing a key (get, set, delete).
  *
- * `init` is only allowed if the key does not already exist. `Get`,
+ * `init` is only allowed if the key does not already exist. `get`,
  * `set` and `delete` are only allowed if the key does already exist.
+ * For any of these methods, an expression like `store.get`,
+ * extracting the `get` method from a store using dot (`.`), extracts
+ * a function that is effectively bound to that store, which can be
+ * passed and used elsewhere.
+ *
  * @param  {string} keyName - the column name for the key
  */
 function makeStore(keyName = 'key') {

--- a/packages/store/src/trieStore.js
+++ b/packages/store/src/trieStore.js
@@ -214,7 +214,7 @@ export const makeStrongTrieStore = makeTrieStoreMaker(makeStrongStore, true);
 function makeMixedStore(keyName = 'key') {
   const strongStore = makeStrongStore(keyName);
   const weakStore = makeWeakStore(keyName);
-  const storeFor = key => (Object(key) === key ? strongStore : weakStore);
+  const storeFor = key => (Object(key) === key ? weakStore : strongStore);
 
   return harden({
     has: key => storeFor(key).has(key),

--- a/packages/store/src/trieStore.js
+++ b/packages/store/src/trieStore.js
@@ -3,7 +3,7 @@
 import harden from '@agoric/harden';
 import { assert, details, openDetail } from '@agoric/assert';
 import makeWeakStore from '@agoric/weak-store';
-import makeStrongStore, { mapKeyEqual } from './store';
+import makeStrongStore, { sameKey } from './store';
 
 // The key equality used by the stores exported by this module
 // is to compare to arrays element by element using normal
@@ -12,7 +12,7 @@ import makeStrongStore, { mapKeyEqual } from './store';
 // trieKeyEqual([NaN, 0], [NaN, -0]);
 // ```
 export const trieKeyEqual = (a, b) =>
-  a.length === b.length && a.every((v, i) => mapKeyEqual(v, b[i]));
+  a.length === b.length && a.every((v, i) => sameKey(v, b[i]));
 
 // The Pumpkin must not escape. It must be distinct from any value that
 // could be passed into this module.

--- a/packages/store/src/trieStore.js
+++ b/packages/store/src/trieStore.js
@@ -1,0 +1,231 @@
+// Copyright (C) 2019 Agoric, under Apache license 2.0
+
+import harden from '@agoric/harden';
+import { assert, details, openDetail } from '@agoric/assert';
+import makeWeakStore from '@agoric/weak-store';
+import makeStrongStore, { mapKeyEqual } from './store';
+
+// The key equality used by the stores exported by this module
+// is to compare to arrays element by element using normal
+// JavaScript map equality.
+// ```js
+// trieKeyEqual([NaN, 0], [NaN, -0]);
+// ```
+export const trieKeyEqual = (a, b) =>
+  a.length === b.length && a.every((v, i) => mapKeyEqual(v, b[i]));
+
+// The Pumpkin must not escape. It must be distinct from any value that
+// could be passed into this module.
+const Pumpkin = harden({});
+
+// Not intended for export; just for internal use.
+// `enumerable` should only be true if the `makeStore` argument
+// makes enumerable stores.
+function makeTrieStoreMaker(makeStore, enumerable = false) {
+  /**
+   * A trieStore is a *store* (as defined in store.js) whose keys are arrays
+   * that are compared and looked up based on element-by-element equality.
+   * Internally it uses a trie made of a tree of stores.
+   *
+   * @param  {string} keyName - the column name for the key
+   */
+  function makeTrieStore(keyName = 'key') {
+    const root = makeStore(keyName);
+
+    // This caches lastStore keyed by the key *identity*.
+    // That way, once a given key is dropped, the cache entry gets collected.
+    // If the same key identity is reused, such as by a .has followed by a
+    // .get, it's fast. Should have no observable effect.
+    //
+    // Since the cache is *only* for speed, if it actually makes things slower
+    // because of WeakMap collection memory pressure, get rid of the cache.
+    const lastStoreCache = new WeakMap();
+
+    // If the key is already bound, return the last store in the trie which
+    // binds the Pumpkin to the key's current value. Otherwise, return
+    // undefined.
+    function finalStoreIfKeyBound(key) {
+      let cursor;
+      if (lastStoreCache.has(key) === key) {
+        cursor = lastStoreCache.get(key);
+      } else {
+        assert(Array.isArray(key), details`trie key must be an array: ${key}`);
+
+        cursor = root;
+        for (const element of key) {
+          // A "can never happen" that should abort rather than throw
+          assert(element !== Pumpkin, details`internal: Pumpkin leaked!`);
+          if (!cursor.has(element)) {
+            return undefined;
+          }
+          // cannot error because of .has test
+          cursor = cursor.get(element);
+        }
+        lastStoreCache.set(key, cursor);
+      }
+      if (!cursor.has(Pumpkin)) {
+        return undefined;
+      }
+      return cursor;
+    }
+
+    // Assert that the key is already bound, like assertKeyBound of store.js.
+    // Return the last store in the trie which binds the Pumpkin to the key's
+    // current value.
+    function finalStoreAssertKeyBound(key) {
+      const result = finalStoreIfKeyBound(key);
+      assert(
+        result !== undefined,
+        details`${openDetail(keyName)} not found: ${key}`,
+      );
+      return result;
+    }
+
+    // Assert that the key is not already bound, like assertKeyNotBound of
+    // store.js.
+    // Return the last store in the trie for this key, making it if
+    // necessary, in which there is not yet a binding from the Pumpkin to
+    // this key's value.
+    function finalStoreAssertKeyNotBound(key) {
+      let cursor;
+      if (lastStoreCache.has(key) === key) {
+        cursor = lastStoreCache.get(key);
+      } else {
+        assert(Array.isArray(key), details`trie key must be an array: ${key}`);
+
+        cursor = root;
+        for (const element of key) {
+          // A "can never happen" that should abort rather than throw
+          assert(element !== Pumpkin, details`internal: Pumpkin leaked!`);
+          if (cursor.has(element)) {
+            // cannot error because of .has test
+            cursor = cursor.get(element);
+          } else {
+            const nextCursor = makeStore(keyName);
+            // cannot error because of .has test
+            cursor.init(element, nextCursor);
+            cursor = nextCursor;
+          }
+        }
+        lastStoreCache.set(key, cursor);
+      }
+      assert(
+        !cursor.has(Pumpkin),
+        details`${openDetail(keyName)} already registered: ${key}`,
+      );
+      return cursor;
+    }
+
+    // /////// Methods /////////
+
+    const has = key => finalStoreIfKeyBound(key) !== undefined;
+    const init = (key, value) => {
+      const lastStore = finalStoreAssertKeyNotBound(key);
+      lastStore.init(Pumpkin, value);
+    };
+    const get = key => {
+      const lastStore = finalStoreAssertKeyBound(key);
+      return lastStore.get(Pumpkin);
+    };
+    const set = (key, value) => {
+      const lastStore = finalStoreAssertKeyBound(key);
+      lastStore.set(Pumpkin, value);
+    };
+    const deleteIt = key => {
+      const lastStore = finalStoreAssertKeyBound(key);
+      lastStore.delete(Pumpkin);
+    };
+
+    // eslint-disable-next-line no-use-before-define
+    const readOnly = () => readOnlyTrieStore;
+
+    let readOnlyEnumerators = {};
+    if (enumerable) {
+      const entries = () => {
+        const result = [];
+        const walk = (prefix, node) => {
+          for (const [k, v] of node) {
+            if (k === Pumpkin) {
+              result.push([prefix, v]);
+            } else {
+              walk([...prefix, k], v);
+            }
+          }
+        };
+        walk([], root);
+        return result;
+      };
+      const keys = () => entries.map(([k, _]) => k);
+      const values = () => entries.map(([_, v]) => v);
+
+      const diverge = () => {
+        const result = makeTrieStore(keyName);
+        for (const [k, v] of entries()) {
+          result.init(k, v);
+        }
+        return result;
+      };
+
+      const snapshot = () => {
+        const snapshotStore = harden({
+          ...diverge().readOnly(),
+          snapshot: () => snapshotStore,
+        });
+        return snapshotStore;
+      };
+
+      readOnlyEnumerators = {
+        diverge,
+        snapshot,
+        keys,
+        values,
+        entries,
+        [Symbol.iterator]: entries,
+      };
+    }
+
+    const readOnlyTrieStore = harden({
+      readOnly,
+      has,
+      get,
+      ...readOnlyEnumerators,
+    });
+
+    return harden({
+      readOnly,
+      has,
+      init,
+      get,
+      set,
+      delete: deleteIt,
+      ...readOnlyEnumerators,
+    });
+  }
+  harden(makeTrieStore);
+  return makeTrieStore;
+}
+
+export const makeStrongTrieStore = makeTrieStoreMaker(makeStrongStore, true);
+// Is this ever useful?
+// export const makeWeakTrieStore = makeTrieStoreMaker(makeWeakStore, false);
+
+// A simple store that holds objects weakly and everything else strongly.
+// Beware of memory leaks.
+function makeMixedStore(keyName = 'key') {
+  const strongStore = makeStrongStore(keyName);
+  const weakStore = makeWeakStore(keyName);
+  const storeFor = key => (Object(key) === key ? strongStore : weakStore);
+
+  return harden({
+    has: key => storeFor(key).has(key),
+    init: (key, value) => storeFor(key).init(key, value),
+    get: key => storeFor(key).get(key),
+    set: (key, value) => storeFor(key).set(key, value),
+    delete: key => storeFor(key).delete(key),
+  });
+}
+
+// A trieStore in which each element, if it is an object, is held weakly.
+// If the element disappears, so does the subtree rooted in that element.
+const makeTrieStore = makeTrieStoreMaker(makeMixedStore, false);
+export default makeTrieStore;

--- a/packages/store/src/trieStore.js
+++ b/packages/store/src/trieStore.js
@@ -9,9 +9,9 @@ import makeStrongStore, { sameKey } from './store';
 // is to compare to arrays element by element using normal
 // JavaScript map equality.
 // ```js
-// trieKeyEqual([NaN, 0], [NaN, -0]);
+// sameTrieKey([NaN, 0], [NaN, -0]);
 // ```
-export const trieKeyEqual = (a, b) =>
+export const sameTrieKey = (a, b) =>
   a.length === b.length && a.every((v, i) => sameKey(v, b[i]));
 
 // The Pumpkin must not escape. It must be distinct from any value that

--- a/packages/store/test/test-store.js
+++ b/packages/store/test/test-store.js
@@ -1,0 +1,43 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from 'tape-promise/tape';
+import makeStore from '../src/store';
+import { throwsAndLogs } from '../../assert/test/throwsAndLogs';
+
+export const testAStore = (t, makeAStore, key) => {
+  const store = makeAStore('fookey');
+  t.equal(store.has(key), false);
+  throwsAndLogs(t, () => store.get(key), /fookey not found: \(a.*\)/, [
+    ['log', 'FAILED ASSERTION false'],
+    ['error', '', 'fookey', ' not found: ', key, ''],
+  ]);
+  store.init(key, 8);
+  t.equal(store.has(key), true);
+  t.equal(store.get(key), 8);
+  store.set(key, 9);
+  t.equal(store.get(key), 9);
+  throwsAndLogs(
+    t,
+    () => store.init(key, 7),
+    /fookey already registered: \(a.*\)/,
+    [
+      ['log', 'FAILED ASSERTION false'],
+      ['error', '', 'fookey', ' already registered: ', key, ''],
+    ],
+  );
+  store.delete(key);
+  t.equal(store.has(key), false);
+  store.init(key, 5);
+  t.equal(store.has(key), true);
+  t.equal(store.get(key), 5);
+};
+
+test('store', t => {
+  try {
+    testAStore(t, makeStore, 'x');
+  } catch (e) {
+    console.log('unexpected exception', e);
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});

--- a/packages/store/test/test-trieStore.js
+++ b/packages/store/test/test-trieStore.js
@@ -1,0 +1,15 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from 'tape-promise/tape';
+import makeTrieStore from '../src/trieStore';
+import { testAStore } from './test-store';
+
+test('trieStore', t => {
+  try {
+    testAStore(t, makeTrieStore, [NaN, -0, {}]);
+  } catch (e) {
+    console.log('unexpected exception', e);
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});

--- a/packages/weak-store/package.json
+++ b/packages/weak-store/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "exit 0",
-    "test": "exit 0",
+    "test": "tape -r esm test/**/test*.js",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint-check": "eslint '**/*.js'",
     "lint-fix-jessie": "eslint -c '.eslintrc-jessie.js' --fix '**/*.js'",

--- a/packages/weak-store/test/test-weakStore.js
+++ b/packages/weak-store/test/test-weakStore.js
@@ -1,0 +1,15 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from 'tape-promise/tape';
+import makeWeakStore from '../src/weakStore';
+import { testAStore } from '../../store/test/test-store';
+
+test('weakStore', t => {
+  try {
+    testAStore(t, makeWeakStore, {});
+  } catch (e) {
+    console.log('unexpected exception', e);
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});


### PR DESCRIPTION
Fixes #16 

Working my way up to passable sets and maps indexed by sameStructure equivalence. This will let us express our setMathHelpers naturally and efficiently. Not there yet.

The draft proposed changes to our store apis, and the new trieStore, are here and interesting. The diverge/snapshot/readOnly methods are based on https://github.com/tc39/proposal-readonly-collections

NOT URGENT. Just a curiosity until we're past Zoe alpha.