### PR TITLE
marshal reform: simplify makeMarshal arguments

### DIFF
--- a/packages/captp/lib/captp.js
+++ b/packages/captp/lib/captp.js
@@ -11,9 +11,9 @@ export function makeCapTP(ourId, send, bootstrapObj = undefined) {
   let unplug = false;
   const { serialize, unserialize } = makeMarshal(
     // eslint-disable-next-line no-use-before-define
-    serializeSlot,
+    convertValToSlot,
     // eslint-disable-next-line no-use-before-define
-    unserializeSlot,
+    convertSlotToVal,
   );
 
   let lastPromiseID = 0;
@@ -26,49 +26,37 @@ export function makeCapTP(ourId, send, bootstrapObj = undefined) {
   const answers = new Map(); // chosen by our peer
   const imports = new Map(); // chosen by our peer
 
-  function serializeSlot(val, slots, slotMap) {
-    if (!slotMap.has(val)) {
+  function convertValToSlot(val) {
+    if (!valToSlot.has(val)) {
       let slot;
-      if (!valToSlot.has(val)) {
-        // new export
-        if (HandledPromise.resolve(val) === val) {
-          lastPromiseID += 1;
-          const promiseID = lastPromiseID;
-          slot = `p+${promiseID}`;
-          val.then(
-            res =>
-              send({
-                type: 'CTP_RESOLVE',
-                promiseID,
-                res: serialize(harden(res)),
-              }),
-            rej =>
-              send({
-                type: 'CTP_RESOLVE',
-                promiseID,
-                rej: serialize(harden(rej)),
-              }),
-          );
-        } else {
-          lastExportID += 1;
-          const exportID = lastExportID;
-          slot = `o+${exportID}`;
-        }
-        valToSlot.set(val, slot);
-        slotToVal.set(slot, val);
+      // new export
+      if (HandledPromise.resolve(val) === val) {
+        lastPromiseID += 1;
+        const promiseID = lastPromiseID;
+        slot = `p+${promiseID}`;
+        val.then(
+          res =>
+            send({
+              type: 'CTP_RESOLVE',
+              promiseID,
+              res: serialize(harden(res)),
+            }),
+          rej =>
+            send({
+              type: 'CTP_RESOLVE',
+              promiseID,
+              rej: serialize(harden(rej)),
+            }),
+        );
+      } else {
+        lastExportID += 1;
+        const exportID = lastExportID;
+        slot = `o+${exportID}`;
       }
-
-      slot = valToSlot.get(val);
-      const slotIndex = slots.length;
-      slots.push(slot);
-      slotMap.set(val, slotIndex);
+      valToSlot.set(val, slot);
+      slotToVal.set(slot, val);
     }
-
-    const slotIndex = slotMap.get(val);
-    return harden({
-      [QCLASS]: 'slot',
-      index: slotIndex,
-    });
+    return valToSlot.get(val);
   }
 
   function makeQuestion() {
@@ -114,8 +102,7 @@ export function makeCapTP(ourId, send, bootstrapObj = undefined) {
     return harden(pr);
   }
 
-  function unserializeSlot(data, slots) {
-    const theirSlot = slots[Nat(data.index)];
+  function convertSlotToVal(theirSlot) {
     let val;
     const otherDir = theirSlot[1] === '+' ? '-' : '+';
     const slot = `${theirSlot[0]}${otherDir}${theirSlot.slice(2)}`;

--- a/packages/marshal/marshal.js
+++ b/packages/marshal/marshal.js
@@ -307,10 +307,9 @@ export function makeMarshal(
     if (slotMap.has(val)) {
       slotIndex = slotMap.get(val);
     } else {
-      slotIndex = slots.length;
-
       const slot = convertValToSlot(val);
 
+      slotIndex = slots.length;
       slots.push(slot);
       slotMap.set(val, slotIndex);
     }


### PR DESCRIPTION
The `makeMarshal` callback arguments `serializeSlot` and `unserializeSlot` were duplicating too much logic. Refactored so clients only provide much simpler `convertValToSlot` and `convertSlotToVal` functions. `makeMarshal` itself now takes care of all the common bookkeeping around those conversions.