### PR TITLE
Improve metering PR

### DIFF
--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -185,16 +185,28 @@ function makeSESEvaluator(registerEndOfCrank) {
     '@agoric/nat': Nat,
   });
 
+  const realmRegisterEndOfCrank = s.evaluate(
+    `\
+function realmRegisterEndOfCrank(fn) {
+  try {
+    registerEndOfCrank(fn);
+  } catch (e) {
+    // do nothing.
+  }
+}`,
+    { registerEndOfCrank },
+  );
+
   return src => {
     // FIXME: Note that this replaceGlobalMeter endowment is not any
     // worse than before metering existed.  However, it probably is
     // only necessary to be added to the kernel, rather than all
     // static vats once we add metering support to the dynamic vat
     // implementation.
-    // Same for registerEndOfCrank.
+    // FIXME: Same for registerEndOfCrank.
     return s.evaluate(src, {
       require: r,
-      registerEndOfCrank,
+      registerEndOfCrank: realmRegisterEndOfCrank,
       replaceGlobalMeter,
     })().default;
   };

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -31,6 +31,7 @@ export default function buildKernel(kernelEndowments) {
   const {
     setImmediate,
     hostStorage,
+    runEndOfCrank,
     vatAdminVatSetup,
     vatAdminDevSetup,
   } = kernelEndowments;
@@ -115,11 +116,15 @@ export default function buildKernel(kernelEndowments) {
       .then(f)
       .then(undefined, logerr);
     await queueEmptyP;
+
     if (typeof replaceGlobalMeter !== 'undefined') {
-      // Turn off the global meter now that we've run the user code.
-      // Also indicate that we should run the refillers.
-      replaceGlobalMeter(null, true);
+      // Turn off the global meter.
+      replaceGlobalMeter(null);
     }
+
+    // Finish everything at the end of the crank.
+    runEndOfCrank();
+
     whenDone();
   }
 

--- a/packages/SwingSet/test/test-kernel.js
+++ b/packages/SwingSet/test/test-kernel.js
@@ -32,7 +32,11 @@ function emptySetup(_syscall) {
 }
 
 function makeEndowments() {
-  return { setImmediate, hostStorage: initSwingStore().storage };
+  return {
+    setImmediate,
+    hostStorage: initSwingStore().storage,
+    runEndOfCrank: () => {},
+  };
 }
 
 test('build kernel', async t => {

--- a/packages/SwingSet/test/test-liveslots.js
+++ b/packages/SwingSet/test/test-liveslots.js
@@ -16,7 +16,11 @@ function capargs(args, slots = []) {
 }
 
 function makeEndowments() {
-  return { setImmediate, hostStorage: initSwingStore().storage };
+  return {
+    setImmediate,
+    hostStorage: initSwingStore().storage,
+    runEndOfCrank: () => {},
+  };
 }
 
 test('calls', async t => {

--- a/packages/spawner/src/contractHost.js
+++ b/packages/spawner/src/contractHost.js
@@ -1,4 +1,4 @@
-/* global replaceGlobalMeter */
+/* global replaceGlobalMeter, registerEndOfCrank */
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
 import Nat from '@agoric/nat';
@@ -79,17 +79,21 @@ function makeContractHost(E, evaluate, additionalEndowments = {}) {
     };
 
     // Make an endowment to get our meter.
-    const getGlobalMeter = m => {
+    const getMeter = m => {
       if (m !== true && typeof replaceGlobalMeter !== 'undefined') {
         // Replace the global meter and register our refiller.
-        replaceGlobalMeter(meter, doRefill);
+        replaceGlobalMeter(meter);
+      }
+      if (typeof registerEndOfCrank !== 'undefined') {
+        // Register our refiller.
+        registerEndOfCrank(doRefill);
       }
       return meter;
     };
 
     const fn = evaluate(functionSrcString, {
       ...fullEndowments,
-      getGlobalMeter,
+      getMeter,
     });
     assert(
       typeof fn === 'function',

--- a/packages/transform-metering/src/constants.js
+++ b/packages/transform-metering/src/constants.js
@@ -3,7 +3,6 @@ export * from '@agoric/tame-metering/src/constants';
 export const METER_COMBINED = '*';
 
 export const DEFAULT_METER_ID = '$h\u200d_meter';
-export const DEFAULT_GET_METER_ID = '$h\u200d_meter_get';
 export const DEFAULT_SET_METER_ID = '$h\u200d_meter_set';
 export const DEFAULT_REGEXP_ID_PREFIX = '$h\u200d_re_';
 

--- a/packages/transform-metering/src/evaluator.js
+++ b/packages/transform-metering/src/evaluator.js
@@ -43,7 +43,7 @@ export function makeMeteredEvaluator({
 
       if (typeof srcOrThunk === 'string') {
         // Transform the source on our own budget, then evaluate against the meter.
-        endowments.getGlobalMeter = m => {
+        endowments.getMeter = m => {
           if (refillMeterInNewTurn && !metersSeenThisTurn.has(meter)) {
             metersSeenThisTurn.add(meter);
             refillMeterInNewTurn(meter);

--- a/packages/transform-metering/test/test-transform.js
+++ b/packages/transform-metering/test/test-transform.js
@@ -8,20 +8,20 @@ import * as c from '../src/constants';
 
 test('meter transform', async t => {
   try {
-    let getGlobalMeter;
+    let getMeter;
     const meteringTransform = makeMeteringTransformer(babelCore, {
       overrideMeterId: '$m',
       overrideRegExpIdPrefix: '$re_',
     });
     const rewrite = (source, testName) => {
       let cMeter;
-      getGlobalMeter = () => ({
+      getMeter = () => ({
         [c.METER_COMPUTE]: units => (cMeter = units),
       });
 
       const ss = meteringTransform.rewrite({
         src: source,
-        endowments: { getGlobalMeter },
+        endowments: { getMeter },
         sourceType: 'script',
       });
 

--- a/packages/transform-metering/testdata/arrow-function-block/rewrite.js
+++ b/packages/transform-metering/testdata/arrow-function-block/rewrite.js
@@ -1,3 +1,3 @@
-const $h‍_meter_get=getGlobalMeter;const $m=$h‍_meter_get();$m&&$m.e();try{() => {const $m = $h‍_meter_get();$m && $m.e();try {
+const $m=getMeter();$m&&$m.e();try{() => {const $m = getMeter();$m && $m.e();try {
     f();} finally {$m && $m.l();}};
 }finally{$m && $m.l();}

--- a/packages/transform-metering/testdata/arrow-function-expression/rewrite.js
+++ b/packages/transform-metering/testdata/arrow-function-expression/rewrite.js
@@ -1,3 +1,3 @@
-const $h‍_meter_get=getGlobalMeter;const $m=$h‍_meter_get();$m&&$m.e();try{() => {const $m = $h‍_meter_get();$m && $m.e();try {return (
+const $m=getMeter();$m&&$m.e();try{() => {const $m = getMeter();$m && $m.e();try {return (
       f());} finally {$m && $m.l();}};
 }finally{$m && $m.l();}

--- a/packages/transform-metering/testdata/classes/rewrite.js
+++ b/packages/transform-metering/testdata/classes/rewrite.js
@@ -1,5 +1,5 @@
-const $h‍_meter_get=getGlobalMeter;const $m=$h‍_meter_get();$m&&$m.e();try{class Abc {
-  f() {const $m = $h‍_meter_get();$m && $m.e();try {
+const $m=getMeter();$m&&$m.e();try{class Abc {
+  f() {const $m = getMeter();$m && $m.e();try {
       return doit();
     } finally {$m && $m.l();}}}
 }finally{$m && $m.l();}

--- a/packages/transform-metering/testdata/concise-method/rewrite.js
+++ b/packages/transform-metering/testdata/concise-method/rewrite.js
@@ -1,5 +1,5 @@
-const $h‍_meter_get=getGlobalMeter;const $m=$h‍_meter_get();$m&&$m.e();try{a = {
-  f() {const $m = $h‍_meter_get();$m && $m.e();try {
+const $m=getMeter();$m&&$m.e();try{a = {
+  f() {const $m = getMeter();$m && $m.e();try {
       doit();
     } finally {$m && $m.l();}} };
 }finally{$m && $m.l();}

--- a/packages/transform-metering/testdata/for-loops/rewrite.js
+++ b/packages/transform-metering/testdata/for-loops/rewrite.js
@@ -1,4 +1,4 @@
-const $h‍_meter_get=getGlobalMeter;const $m=$h‍_meter_get();$m&&$m.e();try{for (const f of b) {$m && $m.c();
+const $m=getMeter();$m&&$m.e();try{for (const f of b) {$m && $m.c();
   doit(f);}
 
 for (const p in bar) {$m && $m.c();

--- a/packages/transform-metering/testdata/function-expression/rewrite.js
+++ b/packages/transform-metering/testdata/function-expression/rewrite.js
@@ -1,4 +1,4 @@
-const $h‍_meter_get=getGlobalMeter;const $m=$h‍_meter_get();$m&&$m.e();try{(function () {const $m = $h‍_meter_get();$m && $m.e();try {
+const $m=getMeter();$m&&$m.e();try{(function () {const $m = getMeter();$m && $m.e();try {
     f();
   } finally {$m && $m.l();}});
 }finally{$m && $m.l();}

--- a/packages/transform-metering/testdata/regexp-literal/rewrite.js
+++ b/packages/transform-metering/testdata/regexp-literal/rewrite.js
@@ -1,4 +1,4 @@
-const $h‍_meter_get=getGlobalMeter;const $m=$h‍_meter_get();$m&&$m.e();try{const $re_0=RegExp("^my-favourite-regexp","");if ($re_0.test('myf')) {
+const $m=getMeter();$m&&$m.e();try{const $re_0=RegExp("^my-favourite-regexp","");if ($re_0.test('myf')) {
   doit();
 }
 }finally{$m && $m.l();}

--- a/packages/transform-metering/testdata/while-loops/rewrite.js
+++ b/packages/transform-metering/testdata/while-loops/rewrite.js
@@ -1,4 +1,4 @@
-const $h‍_meter_get=getGlobalMeter;const $m=$h‍_meter_get();$m&&$m.e();try{while (a) {$m && $m.c();}
+const $m=getMeter();$m&&$m.e();try{while (a) {$m && $m.c();}
 
 while (a) {$m && $m.c();doit();}
 


### PR DESCRIPTION
Rename `getGlobalMeter` to `getMeter`.  Simplify `transform-metering` to use it directly.

Separate `refillingReplaceGlobalMeter` into just `replaceGlobalMeter` and `registerEndOfCrank`.
