### PR TITLE
Fix quadratic performance degradation issue

### DIFF
--- a/packages/SwingSet/src/blockBuffer.js
+++ b/packages/SwingSet/src/blockBuffer.js
@@ -76,6 +76,8 @@ export function buildBlockBuffer(hostDB) {
       ops.push({ op: 'delete', key });
     }
     hostDB.applyBatch(ops);
+    additions.clear();
+    deletions.clear();
   }
 
   return harden({ blockBuffer, commitBlock });

--- a/packages/SwingSet/src/kernel/state/storageWrapper.js
+++ b/packages/SwingSet/src/kernel/state/storageWrapper.js
@@ -159,6 +159,8 @@ export function buildCrankBuffer(storage) {
     for (const key of deletions) {
       storage.delete(key);
     }
+    additions.clear();
+    deletions.clear();
   }
 
   /**


### PR DESCRIPTION
Reference bug #619 

Crank buffer wasn't clearing its addition/deletion tables on commit, so it was replaying the entire history of state changes at the end of every crank.