### PR TITLE
Support HandledPromise.unwrap(p)

### DIFF
--- a/packages/make-promise/package.json
+++ b/packages/make-promise/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "dependencies": {
+    "@agoric/eventual-send": "^0.5.0",
     "@agoric/harden": "^0.0.4"
   },
   "devDependencies": {

--- a/packages/make-promise/src/makePromise.js
+++ b/packages/make-promise/src/makePromise.js
@@ -1,9 +1,12 @@
 import harden from '@agoric/harden';
+import { HandledPromise } from '@agoric/eventual-send';
 
 export default function makePromise() {
   let res;
   let rej;
-  const p = new Promise((resolve, reject) => {
+  // We use a HandledPromise so that we can run HandledPromise.unwrap(p)
+  // even if p doesn't travel through a comms system (like SwingSet's).
+  const p = new HandledPromise((resolve, reject) => {
     res = resolve;
     rej = reject;
   });


### PR DESCRIPTION
Refs #615

When used locally, regular Promises don't support unwrap, since
they have not travelled through SwingSet's comms system (which
makes them all HandledPromises).

Using HandledPromise here enables unwrap(p) to be used even if
there is no intervening comms system.
