### PR TITLE
Reenable the ag-solo bundle command

### DIFF
--- a/packages/agoric-cli/template/contract/deploy-autoswap.js
+++ b/packages/agoric-cli/template/contract/deploy-autoswap.js
@@ -14,7 +14,7 @@ export default async function deployContract(homeP, { bundleSource, pathResolve 
   CONTRACT_NAME = 'autoswap') {
 
   // Create a source bundle for the "myFirstDapp" smart contract.
-  const { source, moduleFormat } = await bundleSource(`./${CONTRACT_NAME}.js`);
+  const { source, moduleFormat } = await bundleSource(pathResolve(`./${CONTRACT_NAME}.js`));
 
   // =====================
   // === AWAITING TURN ===

--- a/packages/agoric-cli/template/contract/deploy.js
+++ b/packages/agoric-cli/template/contract/deploy.js
@@ -14,7 +14,7 @@ export default async function deployContract(homeP, { bundleSource, pathResolve 
   CONTRACT_NAME = 'myFirstDapp') {
 
   // Create a source bundle for the "myFirstDapp" smart contract.
-  const { source, moduleFormat } = await bundleSource(`./${CONTRACT_NAME}.js`);
+  const { source, moduleFormat } = await bundleSource(pathResolve(`./${CONTRACT_NAME}.js`));
 
   // =====================
   // === AWAITING TURN ===


### PR DESCRIPTION
Closes #606

Usage: `ag-solo bundle <PATH TO DAPP>/deploy.js`
from within an ag-solo directory in order to run a deployment script.