### PR TITLE
chore(swingset): test/vat-admin: update testBrokenVatCreation

### DIFF
--- a/packages/SwingSet/test/vat-admin/bootstrap.js
+++ b/packages/SwingSet/test/vat-admin/bootstrap.js
@@ -34,7 +34,8 @@ const serviceHolder = {
 
 const brokenServiceHolder = {
   build: () => {
-    return harden({});
+    // eslint-disable-next-line no-undef
+    return missing({});
   },
 };
 

--- a/packages/SwingSet/test/vat-admin/test-innerVat.js
+++ b/packages/SwingSet/test/vat-admin/test-innerVat.js
@@ -56,7 +56,7 @@ async function testBrokenVatCreation(t, withSES) {
   await c.run();
   t.deepEqual(c.dump().log, [
     'starting brokenVat test',
-    'yay, rejected: Error: Vat Creation Error: ReferenceError: harden is not defined',
+    'yay, rejected: Error: Vat Creation Error: ReferenceError: missing is not defined',
   ]);
   t.end();
 }


### PR DESCRIPTION
This test exercises the creation of a vat with errors, like missing names,
specifically `harden`. Under SES2, `harden` is a global, so it will no longer
be missing. This changes the test to rely upon `missing` being missing
instead.