### PR TITLE
remove `nat` from specially-treated modules

### DIFF
--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -4,7 +4,6 @@ import fs from 'fs';
 import path from 'path';
 // import { rollup } from 'rollup';
 import harden from '@agoric/harden';
-import Nat from '@agoric/nat';
 import SES from 'ses';
 import { assert } from '@agoric/assert';
 
@@ -163,11 +162,11 @@ function makeSESEvaluator(registerEndOfCrank) {
 
   // TODO: if the 'require' we provide here supplies a non-pure module,
   // that could open a communication channel between otherwise isolated
-  // Vats. For now that's just harden and Nat, but others might get added
-  // in the future, so pay attention to what we allow in. We could build
-  // a new makeRequire for each Vat, but 1: performance and 2: the same
-  // comms problem exists between otherwise-isolated code within a single
-  // Vat so it doesn't really help anyways
+  // Vats. For now that's just harden, but others might get added in the
+  // future, so pay attention to what we allow in. We could build a new
+  // makeRequire for each Vat, but 1: performance and 2: the same comms
+  // problem exists between otherwise-isolated code within a single Vat
+  // so it doesn't really help anyways
   const r = s.makeRequire({
     '@agoric/evaluate': {
       attenuatorSource: `${makeEvaluate}`,
@@ -187,7 +186,6 @@ function makeSESEvaluator(registerEndOfCrank) {
       },
     },
     '@agoric/harden': true,
-    '@agoric/nat': Nat,
   });
 
   const realmRegisterEndOfCrank = s.evaluate(

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -1,7 +1,6 @@
 /* global replaceGlobalMeter */
 import harden from '@agoric/harden';
 import { makeMarshal } from '@agoric/marshal';
-import Nat from '@agoric/nat';
 import evaluateProgram from '@agoric/evaluate';
 import { assert, details } from '@agoric/assert';
 import makeVatManager from './vatManager';
@@ -535,8 +534,6 @@ export default function buildKernel(kernelEndowments) {
     switch (name) {
       case '@agoric/harden':
         return harden;
-      case '@agoric/nat':
-        return Nat;
       case '@agoric/evaluate':
         return evaluateProgram;
       default:

--- a/packages/SwingSet/test/test-vat-imports.js
+++ b/packages/SwingSet/test/test-vat-imports.js
@@ -1,23 +1,6 @@
 import { test } from 'tape-promise/tape';
 import { buildVatController } from '../src/index';
 
-async function requireNat(t, withSES) {
-  const config = { bootstrapIndexJS: require.resolve('./vat-imports-1.js') };
-  const c = await buildVatController(config, withSES, ['nat']);
-  await c.step();
-  t.deepEqual(c.dump().log, ['nat-1', '2']);
-}
-
-test('vat can require nat with SES', async t => {
-  await requireNat(t, true);
-  t.end();
-});
-
-test('vat can require nat without SES', async t => {
-  await requireNat(t, false);
-  t.end();
-});
-
 async function requireHarden(t, withSES) {
   const config = { bootstrapIndexJS: require.resolve('./vat-imports-1.js') };
   const c = await buildVatController(config, withSES, ['harden']);

--- a/packages/SwingSet/test/vat-imports-1.js
+++ b/packages/SwingSet/test/vat-imports-1.js
@@ -3,12 +3,7 @@ import harden from '@agoric/harden';
 function build(E, log) {
   const obj0 = {
     bootstrap(argv, _vats) {
-      if (argv[0] === 'nat') {
-        log('nat-1');
-        // eslint-disable-next-line global-require
-        const nat = require('@agoric/nat');
-        log(nat(2));
-      } else if (argv[0] === 'harden') {
+      if (argv[0] === 'harden') {
         log('harden-1');
         // eslint-disable-next-line global-require
         const harden2 = require('@agoric/harden');

--- a/packages/bundle-source/src/index.js
+++ b/packages/bundle-source/src/index.js
@@ -28,7 +28,7 @@ export default async function bundleSource(
     input: resolvedPath,
     treeshake: false,
     preserveModules: moduleFormat === 'nestedEvaluate',
-    external: ['@agoric/evaluate', '@agoric/nat', '@agoric/harden'],
+    external: ['@agoric/evaluate', '@agoric/harden'],
     plugins: [resolvePlugin({ preferBuiltins: true }), commonjsPlugin()],
     acornInjectPlugins: [eventualSend(acorn)],
   });


### PR DESCRIPTION
The SwingSet controller creates a `require()` function for use by kernel and Vat code (anything running inside the kernel Realm). This function used to allow three imports: Nat, harden, and `@agoric/evaluate`. The `bundle-source` package had three `external:` names to match.

This removes `@agoric/nat` from both lists. The kernel/vat source code that is fed into bundle-source will now get Nat by importing the module directly. Unlike `harden` and `evaluate`, there's nothing special about Nat that makes it important to get a controller-provided copy: it's fine to just incorporate the original source code into the generated bundle and then evaluate it inline. I added `Nat` to the list originally because we were previously providing it as a global, and because it was easy. It's better to remove it from special treatment and let bundle-source incorporate it just like any other normal module.
