### PR TITLE
Fix workflow blockers in agoric-cli

### DIFF
--- a/packages/agoric-cli/lib/init.js
+++ b/packages/agoric-cli/lib/init.js
@@ -71,7 +71,7 @@ export default async function initMain(progname, rawArgs, priv, opts) {
         if (st.isDirectory()) {
           if (!target) {
             console.log(`mkdir ${destDir}${stem}`);
-            await mkdir(`${destDir}${stem}`);
+            await mkdir(`${destDir}${stem}`, { recursive: true });
           }
           await recursiveTemplate(templateDir, destDir, `${stem}`);
         } else if (st.isSymbolicLink()) {
@@ -88,7 +88,7 @@ export default async function initMain(progname, rawArgs, priv, opts) {
     );
   };
   await recursiveTemplate(dappRoot);
-  await mkdir(`${DIR}/_agstate`);
+  await mkdir(`${DIR}/_agstate`, { recursive: true });
 
   const ps = ['', 'api/', 'contract/', 'ui/'].map(dir => {
     const path = `${DIR}/${dir}package.json`;

--- a/packages/agoric-cli/lib/init.js
+++ b/packages/agoric-cli/lib/init.js
@@ -88,7 +88,7 @@ export default async function initMain(progname, rawArgs, priv, opts) {
     );
   };
   await recursiveTemplate(dappRoot);
-  await mkdir(`${DIR}/_agstate`, { recursive: true });
+  await mkdir(`${DIR}/_agstate/agoric-servers`, { recursive: true });
 
   const ps = ['', 'api/', 'contract/', 'ui/'].map(dir => {
     const path = `${DIR}/${dir}package.json`;

--- a/packages/agoric-cli/lib/start.js
+++ b/packages/agoric-cli/lib/start.js
@@ -87,6 +87,11 @@ export default async function startMain(progname, rawArgs, priv, opts) {
     );
     await linkHtml(profileName);
 
+    if (!popts['restart']) {
+      // Don't actually run the chain.
+      return 0;
+    }
+
     return pspawn(agSolo, ['start', '--role=two_client'], {
       stdio: 'inherit',
       cwd: agServer,
@@ -198,7 +203,8 @@ export default async function startMain(progname, rawArgs, priv, opts) {
   };
 
   const { _: args, ...popts } = parseArgs(rawArgs, {
-    boolean: ['reset', 'pull'],
+    boolean: ['reset', 'restart', 'pull'],
+    default: { restart: true },
   });
 
   const profileName = args[0] || 'dev';

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -20,7 +20,8 @@
   "devDependencies": {
     "tap-spec": "^5.0.0",
     "tape": "^4.11.0",
-    "tape-promise": "^4.0.0"
+    "tape-promise": "^4.0.0",
+    "tmp": "^0.1.0"
   },
   "dependencies": {
     "@agoric/bundle-source": "^1.0.3",

--- a/packages/agoric-cli/test/test-workflow.js
+++ b/packages/agoric-cli/test/test-workflow.js
@@ -1,0 +1,61 @@
+import { test } from 'tape-promise/tape';
+import fs from 'fs';
+import tmp from 'tmp';
+
+import { spawn } from 'child_process';
+import main from '../lib/main';
+
+test('workflow', async t => {
+  try {
+    const myConsole = {
+      error(...args) {
+        t.deepEquals(args, [], 'no error output');
+      },
+      log(..._args) {},
+    };
+
+    const pspawn = (...args) =>
+      new Promise((resolve, _reject) => {
+        const cp = spawn(...args);
+        cp.on('exit', resolve);
+        cp.on('error', () => resolve(-1));
+      });
+
+    // Run all main programs with the '--sdk' flag if we are in agoric-sdk.
+    const extraArgs = fs.existsSync(`${__dirname}/../../cosmic-swingset`)
+      ? ['--sdk']
+      : [];
+    const myMain = args => {
+      console.error('running agoric-cli', ...extraArgs, ...args);
+      return pspawn(`${__dirname}/../bin/agoric`, [...extraArgs, ...args], {
+        // TODO: make stdio more sane.
+        // stdio: ['ignore', 'pipe', 'pipe'],
+        stdio: 'inherit',
+      });
+    };
+
+    const olddir = process.cwd();
+    const { name, removeCallback } = tmp.dirSync({
+      unsafeCleanup: true,
+      prefix: 'agoric-cli-test-',
+    });
+    try {
+      process.chdir(name);
+
+      t.equals(await myMain(['init', 'dapp-foo']), 0, 'init dapp-foo works');
+      process.chdir('dapp-foo');
+      //
+      t.equals(await myMain(['install']), 0, 'install works');
+      // It would be nice to test the 'dev' environment with a
+      // "terminate for upgrade" flag instead of just --no-restart.
+      t.equals(await myMain(['start', '--no-restart']), 0, 'start works');
+    } finally {
+      process.chdir(olddir);
+      removeCallback();
+    }
+  } catch (e) {
+    t.isNot(e, e, 'unexpected exception');
+  } finally {
+    t.end();
+  }
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -7548,6 +7548,13 @@ tmp@^0.0.33:
   dependencies:
     os-tmpdir "~1.0.2"
 
+tmp@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.1.0.tgz#ee434a4e22543082e294ba6201dcc6eafefa2877"
+  integrity sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==
+  dependencies:
+    rimraf "^2.6.3"
+
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"


### PR DESCRIPTION
Fixes #662 

This adds an integration test for the basic developer workflow.

`{ recursive: true }` makes things more tolerant of existing directories.  Missing `mkdir`s were added, as well.

A `--no-restart` flag to prevent the actual ag-solo from running was added, until our integration tests can get smarter.