### PR TITLE
Remove extra interleaved spaces from assert console.error

### DIFF
--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -89,7 +89,13 @@ function details(template, ...args) {
         } else {
           argStr = `(${an(typeof arg)})`;
         }
-        interleaved.push(arg, template[i + 1]);
+
+        // Remove the extra spaces (since console.error puts them
+        // between each interleaved).
+        const priorWithoutSpace = interleaved.pop().replace(/ $/, '');
+        const nextWithoutSpace = template[i + 1].replace(/^ /, '');
+        interleaved.push(priorWithoutSpace, arg, nextWithoutSpace);
+
         parts.push(argStr, template[i + 1]);
       }
       if (args.length >= 1) {

--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -93,10 +93,17 @@ function details(template, ...args) {
         // Remove the extra spaces (since console.error puts them
         // between each interleaved).
         const priorWithoutSpace = interleaved.pop().replace(/ $/, '');
+        if (priorWithoutSpace !== '') {
+          interleaved.push(priorWithoutSpace);
+        }
+
         const nextWithoutSpace = template[i + 1].replace(/^ /, '');
-        interleaved.push(priorWithoutSpace, arg, nextWithoutSpace);
+        interleaved.push(arg, nextWithoutSpace);
 
         parts.push(argStr, template[i + 1]);
+      }
+      if (interleaved[interleaved.length - 1] === '') {
+        interleaved.pop();
       }
       if (args.length >= 1) {
         parts.push('\nSee console for error data.');

--- a/packages/assert/test/test-assert.js
+++ b/packages/assert/test/test-assert.js
@@ -56,7 +56,7 @@ test('assert', t => {
       /Expected \(a number\) === \(a number\)/,
       [
         ['log', 'FAILED ASSERTION false'],
-        ['error', 'Expected ', 5, ' === ', 6, ''],
+        ['error', 'Expected', 5, '===', 6],
       ],
     );
     throwsAndLogs(t, () => assert.equal(5, 6, 'foo'), /foo/, [
@@ -69,7 +69,7 @@ test('assert', t => {
       /\(a number\) !== \(a number\)/,
       [
         ['log', 'FAILED ASSERTION false'],
-        ['error', '', 5, ' !== ', 6, ''],
+        ['error', 5, '!==', 6],
       ],
     );
     throwsAndLogs(
@@ -78,7 +78,7 @@ test('assert', t => {
       /\(a number\) !== 6/,
       [
         ['log', 'FAILED ASSERTION false'],
-        ['error', '', 5, ' !== ', 6, ''],
+        ['error', 5, '!==', 6],
       ],
     );
   } catch (e) {


### PR DESCRIPTION
This prevents the console.error() from outputting `"foo  something  else  other  end"` (inserting two spaces) when the template is
```js
`foo ${bar} else ${baz} end`
```
and `bar` is `"something"`, and `baz` is `"other"`.

Instead of
```js
console.error("foo ", "something", " else ", "other", " end");
```
it makes
```js
console.error("foo", "something", "else", "other", "end");
```