### PR TITLE
Add anylogger support

### DIFF
--- a/packages/agoric-cli/bin/agoric
+++ b/packages/agoric-cli/bin/agoric
@@ -1,27 +1,30 @@
 #!/usr/bin/env node
 
-esmRequire = require('esm')(module);
-const path = esmRequire('path');
-const chalk = esmRequire('chalk').default;
-const WebSocket = esmRequire('ws');
-const { spawn } = esmRequire('child_process');
-const fs = esmRequire('fs').promises;
-const os = esmRequire('os');
+const esmRequire = require('esm')(module);
+const path = require('path');
+const WebSocket = require('ws');
+const { spawn } = require('child_process');
+const fs = require('fs').promises;
+const os = require('os');
+
+// Configure logs.
+esmRequire('../lib/anylogger-agoric.js');
+const anylogger = require('anylogger');
 
 const main = esmRequire('../lib/main.js').default;
+
+const log = anylogger('agoric');
 const progname = path.basename(process.argv[1]);
 
-const error = (...args) => {
-  console.error(`${progname}: ${chalk.red('ERROR')}:`, ...args);
-};
+const stdout = str => process.stdout.write(str);
 const makeWebSocket = (...args) => new WebSocket(...args);
 
 process.on('SIGINT', () => process.exit(-1));
 
 const rawArgs = process.argv.splice(2);
 main(progname, rawArgs, {
-  console,
-  error,
+  anylogger,
+  stdout,
   makeWebSocket,
   fs,
   os,
@@ -30,7 +33,7 @@ main(progname, rawArgs, {
 }).then(
   res => res === undefined || process.exit(res),
   rej => {
-    error(rej);
+    log.error(rej);
     process.exit(2);
   },
 );

--- a/packages/agoric-cli/lib/anylogger-agoric.js
+++ b/packages/agoric-cli/lib/anylogger-agoric.js
@@ -1,0 +1,26 @@
+import anylogger from 'anylogger';
+import chalk from 'chalk';
+
+// Turn on debugging output with DEBUG=agoric
+
+const debugging = process.env.DEBUG && process.env.DEBUG.includes('agoric');
+const defaultLevel = debugging ? anylogger.levels.debug : anylogger.levels.info;
+
+const oldExt = anylogger.ext;
+anylogger.ext = (l, o) => {
+  l = oldExt(l, o);
+  l.enabledFor = lvl => defaultLevel >= anylogger.levels[lvl];
+
+  const prefix = l.name.replace(/:/g, ': ');
+  for (const [level, code] of Object.entries(anylogger.levels)) {
+    if (code > defaultLevel) {
+      // Disable printing.
+      l[level] = () => {};
+    } else {
+      // Enable the printing with a prefix.
+      const doLog = l[level] || (() => {});
+      l[level] = (...args) => doLog(chalk.bold.blue(`${prefix}:`), ...args);
+    }
+  }
+  return l;
+};

--- a/packages/agoric-cli/lib/init.js
+++ b/packages/agoric-cli/lib/init.js
@@ -15,7 +15,8 @@ const gitURL = (relativeOrAbsoluteURL, base) => {
 };
 
 export default async function initMain(_progname, rawArgs, priv, _opts) {
-  const { console, error, spawn } = priv;
+  const { anylogger, spawn } = priv;
+  const log = anylogger('agoric:init');
   const {
     _: args,
     'dapp-template': dappTemplate,
@@ -29,14 +30,14 @@ export default async function initMain(_progname, rawArgs, priv, _opts) {
   });
 
   if (args.length !== 1) {
-    return error(`you must specify exactly one DIR`);
+    return log.error(`you must specify exactly one DIR`);
   }
   const [DIR] = args;
 
   const dappURL = gitURL(dappTemplate, dappBase);
 
   // Run the Git commands.
-  console.log(`initializing ${DIR} from ${dappURL}`);
+  log.info(`initializing ${DIR} from ${dappURL}`);
 
   const pspawn = (...psargs) =>
     new Promise((resolve, _reject) => {
@@ -61,6 +62,6 @@ export default async function initMain(_progname, rawArgs, priv, _opts) {
     throw Error('cannot detach from upstream');
   }
 
-  console.log(chalk.bold.yellow(`Done initializing ${DIR}`));
+  log.info(chalk.bold.yellow(`Done initializing ${DIR}`));
   return 0;
 }

--- a/packages/agoric-cli/lib/install.js
+++ b/packages/agoric-cli/lib/install.js
@@ -2,8 +2,10 @@ import parseArgs from 'minimist';
 import path from 'path';
 import chalk from 'chalk';
 
-export default async function installMain(progname, rawArgs, priv, opts) {
-  const { console, error, fs, spawn } = priv;
+export default async function installMain(progname, rawArgs, powers, opts) {
+  const { anylogger, fs, spawn } = powers;
+  const log = anylogger('agoric:install');
+
   const { _: _args } = parseArgs(rawArgs);
 
   const pspawn = (...args) =>
@@ -18,7 +20,7 @@ export default async function installMain(progname, rawArgs, priv, opts) {
     await Promise.all(
       ['_agstate/agoric-servers', 'contract', 'api'].sort().map(subdir => {
         const nm = `${subdir}/node_modules`;
-        console.log(chalk.bold.green(`link SDK ${nm}`));
+        log(chalk.bold.green(`link SDK ${nm}`));
         return fs
           .unlink(nm)
           .catch(_ => {})
@@ -26,7 +28,7 @@ export default async function installMain(progname, rawArgs, priv, opts) {
       }),
     );
 
-    console.log(chalk.bold.green(`link SDK _agstate/agoric-wallet`));
+    log(chalk.bold.green(`link SDK _agstate/agoric-wallet`));
     await fs.unlink(`_agstate/agoric-wallet`).catch(_ => {});
     try {
       const agWallet = path.resolve(__dirname, '../../frontend-wallet/build');
@@ -38,15 +40,15 @@ export default async function installMain(progname, rawArgs, priv, opts) {
     }
   } else if (await pspawn('yarn', ['install'], { stdio: 'inherit' })) {
     // Try to install via Yarn.
-    error('Cannot yarn install');
+    log.error('Cannot yarn install');
     return 1;
   } else {
     // FIXME: Copy the agoric-wallet-build more portably
     const agWallet = path.resolve(__dirname, '../agoric-wallet-build');
     if (await pspawn('cp', ['-a', agWallet, '_agstate/agoric-wallet'])) {
-      error('Cannot copy _agstate/agoric-wallet');
+      log.error('Cannot copy _agstate/agoric-wallet');
     }
   }
-  console.log(chalk.bold.green('Done installing'));
+  log(chalk.bold.green('Done installing'));
   return 0;
 }

--- a/packages/agoric-cli/lib/start.js
+++ b/packages/agoric-cli/lib/start.js
@@ -9,13 +9,14 @@ const FAKE_CHAIN_DELAY =
 const PORT = process.env.PORT || 8000;
 const HOST_PORT = process.env.HOST_PORT || PORT;
 
-export default async function startMain(progname, rawArgs, priv, opts) {
-  const { console, error, fs, spawn, os, process } = priv;
+export default async function startMain(progname, rawArgs, powers, opts) {
+  const { anylogger, fs, spawn, os, process } = powers;
+  const log = anylogger('agoric:start');
 
-  const pspawn = (cmd, cargs, ...rest) => {
-    console.log(chalk.blueBright(cmd, ...cargs));
+  const pspawn = (cmd, cargs, { stdio = 'inherit', ...rest }) => {
+    log.info(chalk.blueBright(cmd, ...cargs));
     return new Promise((resolve, _reject) => {
-      const cp = spawn(cmd, cargs, ...rest);
+      const cp = spawn(cmd, cargs, { stdio, ...rest });
       cp.on('exit', resolve);
       cp.on('error', () => resolve(-1));
     });
@@ -31,7 +32,7 @@ export default async function startMain(progname, rawArgs, priv, opts) {
   };
 
   const linkHtml = async name => {
-    console.log(chalk.green('linking html directories'));
+    log(chalk.green('linking html directories'));
     // const dappHtml = `_agstate/agoric-servers/${name}/dapp-html`;
     const htmlWallet = `_agstate/agoric-servers/${name}/html/wallet`;
     // await Promise.all([fs.unlink(dappHtml).catch(() => {}), fs.unlink(htmlWallet).catch(() => {})]);
@@ -61,39 +62,35 @@ export default async function startMain(progname, rawArgs, priv, opts) {
       popts.delay === undefined ? FAKE_CHAIN_DELAY : Number(popts.delay);
     if (!opts.sdk) {
       if (!(await exists('_agstate/agoric-servers/node_modules'))) {
-        return error(`you must first run '${progname} install'`);
+        log.error(`you must first run '${progname} install'`);
+        return 1;
       }
     }
 
     const fakeGCI = 'myFakeGCI';
     if (!(await exists(agServer))) {
-      console.log(chalk.yellow(`initializing ${profileName}`));
+      log(chalk.yellow(`initializing ${profileName}`));
       await pspawn(agSolo, ['init', profileName, '--egresses=fake'], {
-        stdio: 'inherit',
         cwd: '_agstate/agoric-servers',
       });
     }
 
-    console.log(
-      chalk.yellow(`setting fake chain with ${fakeDelay} second delay`),
-    );
+    log(chalk.yellow(`setting fake chain with ${fakeDelay} second delay`));
     await pspawn(
       agSolo,
       ['set-fake-chain', '--role=two_chain', `--delay=${fakeDelay}`, fakeGCI],
       {
-        stdio: 'inherit',
         cwd: agServer,
       },
     );
     await linkHtml(profileName);
 
-    if (!popts['restart']) {
+    if (!popts.restart) {
       // Don't actually run the chain.
       return 0;
     }
 
     return pspawn(agSolo, ['start', '--role=two_client'], {
-      stdio: 'inherit',
       cwd: agServer,
     });
   }
@@ -102,34 +99,26 @@ export default async function startMain(progname, rawArgs, priv, opts) {
     const IMAGE = `agoric/cosmic-swingset-setup-solo`;
 
     if (popts.pull) {
-      const status = await pspawn('docker', ['pull', IMAGE], {
-        stdio: 'inherit',
-      });
+      const status = await pspawn('docker', ['pull', IMAGE]);
       if (status) {
         return status;
       }
     }
 
     const setupRun = (...bonusArgs) =>
-      pspawn(
-        'docker',
-        [
-          'run',
-          `-p127.0.0.1:${HOST_PORT}:${PORT}`,
-          `--volume=${process.cwd()}:/usr/src/dapp`,
-          `-eAG_SOLO_BASEDIR=/usr/src/dapp/_agstate/agoric-servers/${profileName}`,
-          `--rm`,
-          `-it`,
-          IMAGE,
-          `--webport=${PORT}`,
-          `--webhost=0.0.0.0`,
-          ...bonusArgs,
-          ...startArgs,
-        ],
-        {
-          stdio: 'inherit',
-        },
-      );
+      pspawn('docker', [
+        'run',
+        `-p127.0.0.1:${HOST_PORT}:${PORT}`,
+        `--volume=${process.cwd()}:/usr/src/dapp`,
+        `-eAG_SOLO_BASEDIR=/usr/src/dapp/_agstate/agoric-servers/${profileName}`,
+        `--rm`,
+        `-it`,
+        IMAGE,
+        `--webport=${PORT}`,
+        `--webhost=0.0.0.0`,
+        ...bonusArgs,
+        ...startArgs,
+      ]);
 
     if (!(await exists(agServer))) {
       const status =
@@ -148,7 +137,6 @@ export default async function startMain(progname, rawArgs, priv, opts) {
     );
     if (!(await exists(`${virtEnv}/bin/pip`))) {
       const status = await pspawn('python3', ['-mvenv', virtEnv], {
-        stdio: 'inherit',
         cwd: agSetupSolo,
       });
       if (status) {
@@ -158,7 +146,6 @@ export default async function startMain(progname, rawArgs, priv, opts) {
 
     const pipRun = (...bonusArgs) =>
       pspawn(`${virtEnv}/bin/pip`, bonusArgs, {
-        stdio: 'inherit',
         cwd: agSetupSolo,
       });
 
@@ -181,7 +168,6 @@ export default async function startMain(progname, rawArgs, priv, opts) {
         `${virtEnv}/bin/ag-setup-solo`,
         [`--webport=${PORT}`, ...bonusArgs, ...startArgs],
         {
-          stdio: 'inherit',
           env: { ...process.env, AG_SOLO_BASEDIR: agServer },
         },
       );
@@ -210,21 +196,22 @@ export default async function startMain(progname, rawArgs, priv, opts) {
   const profileName = args[0] || 'dev';
   const startFn = profiles[profileName];
   if (!startFn) {
-    return error(
+    log.error(
       `unrecognized profile name ${profileName}; use one of: ${Object.keys(
         profiles,
       )
         .sort()
         .join(', ')}`,
     );
+    return 1;
   }
 
   agServer = `_agstate/agoric-servers/${profileName}`;
 
   if (popts.reset) {
-    console.log(chalk.green(`removing ${agServer}`));
+    log(chalk.green(`removing ${agServer}`));
     // rm is available on all the unix-likes, so use it for speed.
-    await pspawn('rm', ['-rf', agServer], { stdio: 'inherit' });
+    await pspawn('rm', ['-rf', agServer]);
   }
 
   return startFn(profileName, args[0] ? args.slice(1) : args, popts);

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -23,11 +23,15 @@
     "tape-promise": "^4.0.0",
     "tmp": "^0.1.0"
   },
+  "peerDependencies": {
+    "anylogger": ">=0.21.0"
+  },
   "dependencies": {
     "@agoric/bundle-source": "^1.0.3",
     "@agoric/captp": "^1.2.0",
     "@agoric/evaluate": "^2.2.0",
     "@agoric/eventual-send": "^0.5.0",
+    "anylogger": "^0.21.0",
     "chalk": "^2.4.2",
     "esm": "^3.2.5",
     "minimist": "^1.2.0",

--- a/packages/agoric-cli/test/test-main.js
+++ b/packages/agoric-cli/test/test-main.js
@@ -1,14 +1,18 @@
 import { test } from 'tape-promise/tape';
+import anylogger from 'anylogger';
+
 import main from '../lib/main';
 
 test('sanity', async t => {
   try {
-    const myConsole = {
-      error(..._args) {},
-      log(..._args) {},
+    const stubAnylogger = () => {
+      const l = () => {};
+      for (const level of Object.keys(anylogger.levels)) {
+        l[level] = () => {};
+      }
+      return l;
     };
-    const myMain = args =>
-      main('foo', args, { console: myConsole, error: myConsole.error });
+    const myMain = args => main('foo', args, { anylogger: stubAnylogger, stdout: () => {} });
     t.equal(await myMain(['help']), 0, 'help exits zero');
     t.equal(await myMain(['--help']), 0, '--help exits zero');
     t.equal(await myMain(['--version']), 0, '--version exits zero');

--- a/packages/agoric-cli/test/test-workflow.js
+++ b/packages/agoric-cli/test/test-workflow.js
@@ -7,13 +7,6 @@ import main from '../lib/main';
 
 test('workflow', async t => {
   try {
-    const myConsole = {
-      error(...args) {
-        t.deepEquals(args, [], 'no error output');
-      },
-      log(..._args) {},
-    };
-
     const pspawn = (...args) =>
       new Promise((resolve, _reject) => {
         const cp = spawn(...args);

--- a/packages/cosmic-swingset/lib/ag-solo/main.js
+++ b/packages/cosmic-swingset/lib/ag-solo/main.js
@@ -34,7 +34,7 @@ function insistIsBasedir() {
 }
 
 export default async function solo(progname, rawArgv) {
-  console.error('solo', rawArgv);
+  // console.error('solo', rawArgv);
   const { _: argv, ...opts } = parseArgs(rawArgv, {
     stopEarly: true,
     boolean: ['help', 'version'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1450,6 +1450,11 @@ any-promise@^1.0.0:
   resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
   integrity sha1-q8av7tzqUugJzcA3au0845Y10X8=
 
+anylogger@^0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/anylogger/-/anylogger-0.21.0.tgz#b6cbea631cd5e1c884e5c0fa007d80bde1b22bd4"
+  integrity sha512-XJVplwflEff43l7aE48lW9gNoS0fpb1Ha4WttzjfTFlN3uJUIKALZ5oNWtwgRXPm/Q2dbp1EIddMbQ/AGHVX1A==
+
 anymatch@~3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.1.tgz#c55ecf02185e2469259399310c173ce31233b142"


### PR DESCRIPTION
Refs #571

This is a test of using the [anylogger](https://github.com/Download/anylogger) package that only affects `agoric-cli`.  Adopting it in other packages may be a good idea so that we can control how much logging we write and use anylogger's simple API for library files.

If you need debugging output, you can run with `export DEBUG=agoric`.
