### PR TITLE
Fix regression in `agoric start --reset`

### DIFF
--- a/packages/agoric-cli/lib/start.js
+++ b/packages/agoric-cli/lib/start.js
@@ -13,7 +13,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
   const { anylogger, fs, spawn, os, process } = powers;
   const log = anylogger('agoric:start');
 
-  const pspawn = (cmd, cargs, { stdio = 'inherit', ...rest }) => {
+  const pspawn = (cmd, cargs, { stdio = 'inherit', ...rest } = {}) => {
     log.info(chalk.blueBright(cmd, ...cargs));
     return new Promise((resolve, _reject) => {
       const cp = spawn(cmd, cargs, { stdio, ...rest });


### PR DESCRIPTION
`agoric start --reset` was failing with:
```
running agoric-cli --sdk start --reset
agoric: TypeError: Cannot read property 'stdio' of undefined
    at pspawn (/Users/michael/agoric/agoric-sdk/packages/agoric-cli/lib/start.js:16:33)
    at startMain (/Users/michael/agoric/agoric-sdk/packages/agoric-cli/lib/start.js:214:11)
    at subMain (/Users/michael/agoric/agoric-sdk/packages/agoric-cli/lib/main.js:26:12)
    at main (/Users/michael/agoric/agoric-sdk/packages/agoric-cli/lib/main.js:69:38)
```

Also add integration test for actual start.
