### PR TITLE
feat: Add PDF and stdout support to stat-logger graphing

### DIFF
--- a/packages/swingset-runner/src/graphMem.js
+++ b/packages/swingset-runner/src/graphMem.js
@@ -22,6 +22,7 @@ export async function main() {
 
   let outfile = null;
   const datafiles = [];
+  let type = 'png';
 
   while (argv[0]) {
     const arg = argv.shift();
@@ -30,6 +31,9 @@ export async function main() {
         case '--output':
         case '-o':
           outfile = argv.shift();
+          break;
+        case '--pdf':
+          type = 'pdf';
           break;
         default:
           throw new Error(`invalid flag ${arg}`);
@@ -40,13 +44,6 @@ export async function main() {
   }
   if (datafiles.length < 1) {
     throw new Error('you must specify some input');
-  }
-
-  if (!outfile) {
-    outfile = datafiles[0];
-  }
-  if (!outfile.endsWith('.png')) {
-    outfile += '.png';
   }
 
   const spec = initGraphSpec(
@@ -67,5 +64,5 @@ export async function main() {
     colorIdx += 4;
   }
 
-  await renderGraph(spec, outfile);
+  await renderGraph(spec, outfile, type);
 }

--- a/packages/swingset-runner/src/graphTime.js
+++ b/packages/swingset-runner/src/graphTime.js
@@ -21,6 +21,7 @@ export async function main() {
 
   let outfile = null;
   const datafiles = [];
+  let type = 'png';
 
   while (argv[0]) {
     const arg = argv.shift();
@@ -29,6 +30,9 @@ export async function main() {
         case '--output':
         case '-o':
           outfile = argv.shift();
+          break;
+        case '--pdf':
+          type = 'pdf';
           break;
         default:
           throw new Error(`invalid flag ${arg}`);
@@ -39,10 +43,6 @@ export async function main() {
   }
   if (datafiles.length < 1) {
     throw new Error('you must specify some input');
-  }
-
-  if (!outfile) {
-    outfile = datafiles[0];
   }
 
   const spec = initGraphSpec(
@@ -57,5 +57,5 @@ export async function main() {
     addGraphToGraphSpec(spec, datafiles[i], 'btime', colors[i % colors.length]);
   }
 
-  await renderGraph(spec, outfile);
+  await renderGraph(spec, outfile, type);
 }


### PR DESCRIPTION
Added support to `stat-logger` to allow graphs to be output in PDF format and to have output go to stdout if no output file is specified, and then updated the graphing utilities in `swingset-runner` to use these.
