### PR TITLE
Accomodate Zoe roles as is currently designed

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/vats/offer-compiler.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/offer-compiler.js
@@ -33,13 +33,12 @@ export default ({
       const issuer = purseToIssuer.get(purse);
       roleIssuerNames[role] = issuerToIssuerNames.get(issuer);
       const brand = issuerToBrand.get(issuer);
-      let amount;
+      const amountMath = brandToMath.get(brand);
       if (extent === undefined) {
-        amount = brandToMath.get(brand).getEmpty();
+        roles[role] = amountMath.getEmpty();
       } else {
-        amount = { brand, extent };
+        roles[role] = amountMath.make(extent);
       }
-      roles[role] = amount;
     };
 
     for (const dir of ['offer', 'want']) {


### PR DESCRIPTION
This second part of the wallet-revamp also resolves PR comments in #687 that I overlooked.

There should not need to be any more wallet changes once Zoe roles lands.  The new functionality is keyed off the presence of a `roles` field on the contract instance.
