### PR TITLE
Further improvements to swingset-runner

### DIFF
--- a/packages/swingset-runner/bin/runner
+++ b/packages/swingset-runner/bin/runner
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node -r esm
+#!/usr/bin/env -S node --expose-gc -r esm
 
 /**
  * Simple boilerplate program providing linkage to launch an application written using modules within the


### PR DESCRIPTION
Further improvements to swingset-runner in preparation for working on pruning resolved promises.  The main new feature is a `--forcegc` flag that causes a garbage collection after running each block (but before collecting memory stats).  But that prompted a cleanup of error handling and console output, which lead to a `help` command (since it was getting complicated anyway and checking the source every time was getting ridiculous).