### PR TITLE
Properly kill off child processes on SIGINT

### DIFF
--- a/packages/agoric-cli/bin/agoric
+++ b/packages/agoric-cli/bin/agoric
@@ -19,8 +19,6 @@ const progname = path.basename(process.argv[1]);
 const stdout = str => process.stdout.write(str);
 const makeWebSocket = (...args) => new WebSocket(...args);
 
-process.on('SIGINT', () => process.exit(-1));
-
 const rawArgs = process.argv.splice(2);
 main(progname, rawArgs, {
   anylogger,

--- a/packages/agoric-cli/lib/start.js
+++ b/packages/agoric-cli/lib/start.js
@@ -97,7 +97,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
     const ps = pspawn(agSolo, ['start', '--role=two_client'], {
       cwd: agServer,
     });
-    process.on('SIGHUP', () => ps.cp.kill('SIGHUP'));
+    process.on('SIGINT', () => ps.cp.kill('SIGINT'));
     return ps;
   }
 

--- a/packages/agoric-cli/test/test-workflow.js
+++ b/packages/agoric-cli/test/test-workflow.js
@@ -21,7 +21,7 @@ test('workflow', async t => {
       ? ['--sdk']
       : [];
     const myMain = args => {
-      console.error('running agoric-cli', ...extraArgs, ...args);
+      // console.error('running agoric-cli', ...extraArgs, ...args);
       return pspawn(`${__dirname}/../bin/agoric`, [...extraArgs, ...args], {
         stdio: ['ignore', 'pipe', 'inherit'],
       });
@@ -39,22 +39,30 @@ test('workflow', async t => {
       process.chdir('dapp-foo');
       t.equals(await myMain(['install']), 0, 'install works');
 
-      const startP = myMain(['start', '--reset']);
-      const to = setTimeout(() => startP.cp.kill('SIGHUP'), 10000);
+      t.equals(
+        await myMain(['start', '--no-restart']),
+        0,
+        'initial start works',
+      );
+
+      // Prevent the connections from interfering with the test.
+      fs.writeFileSync('_agstate/agoric-servers/dev/connections.json', '[]\n');
+      const startP = myMain(['start', '--delay=-1']);
+
       let stdoutStr = '';
       let successfulStart = false;
-      startP.cp.stdout.on('data', chunk => {
-        // console.log('stdout:', chunk.toString());
-        stdoutStr += chunk.toString();
-        if (stdoutStr.includes('HTTP/WebSocket will listen on')) {
-          successfulStart = true;
-          startP.cp.kill('SIGHUP');
-          clearTimeout(to);
-        }
-      });
+      if (startP.cp.stdout) {
+        startP.cp.stdout.on('data', chunk => {
+          // console.log('stdout:', chunk.toString());
+          stdoutStr += chunk.toString();
+          if (stdoutStr.match(/^swingset running$/m)) {
+            successfulStart = true;
+            startP.cp.kill('SIGHUP');
+          }
+        });
+      }
 
       await startP;
-      clearTimeout(to);
       t.assert(successfulStart, 'start works');
     } finally {
       process.chdir(olddir);

--- a/packages/agoric-cli/test/test-workflow.js
+++ b/packages/agoric-cli/test/test-workflow.js
@@ -57,7 +57,7 @@ test('workflow', async t => {
           stdoutStr += chunk.toString();
           if (stdoutStr.match(/^swingset running$/m)) {
             successfulStart = true;
-            startP.cp.kill('SIGHUP');
+            startP.cp.kill('SIGINT');
           }
         });
       }

--- a/packages/cosmic-swingset/bin/ag-solo
+++ b/packages/cosmic-swingset/bin/ag-solo
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 
 const process = require('process');
-require = require('esm')(module);
-const solo = require('../lib/ag-solo/main.js').default;
+const esmRequire = require('esm')(module);
+
+const solo = esmRequire('../lib/ag-solo/main.js').default;
 
 solo(process.argv[1], process.argv.splice(2)).then(
   _res => 0,


### PR DESCRIPTION
This also improves the `test-workflow` to exercise vat creation (but no connections).
