### PR TITLE
swingset: remove no-ses mode

### DIFF
--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -15,7 +15,7 @@
     "build-kernel": "node -r esm scripts/build-kernel.js",
     "pack": "npm run-script build-kernel && npm pack",
     "publish": "npm run-script pack && npm publish --access public",
-    "test": "npm run-script build-kernel && tap --no-coverage test/test-node-version.js && tap --no-coverage --reporter specy --timeout 60 'test/**/test*.js'",
+    "test": "npm run-script build-kernel && tap --no-coverage test/test-node-version.js && tap --no-coverage --reporter specy --timeout 120 'test/**/test*.js'",
     "test-nosort": "npm run-script build-kernel && tape -r esm test/test-node-version.js && tape -r esm 'test/**/test*.js'",
     "pretty-fix": "prettier --write '**/*.js'",
     "pretty-check": "prettier --check '**/*.js'",

--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -236,6 +236,9 @@ function buildNonSESKernel(endowments) {
 }
 
 export async function buildVatController(config, withSES = true, argv = []) {
+  if (!withSES) {
+    throw Error('SES is now mandatory');
+  }
   // todo: move argv into the config
 
   const endOfCrankHooks = new Set();

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -13,7 +13,7 @@ test('load empty', async t => {
     vats: new Map(),
     bootstrapIndexJS: undefined,
   };
-  const controller = await buildVatController(config);
+  const controller = await buildVatController(config, true);
   await controller.run();
   t.ok(true);
   t.end();
@@ -64,10 +64,6 @@ test('simple call with SES', async t => {
   await simpleCall(t, true);
 });
 
-test('simple call non-SES', async t => {
-  await simpleCall(t, false);
-});
-
 test('reject module-like sourceIndex', async t => {
   const vats = new Map();
   // the keys of 'vats' have a 'sourcepath' property which are vat source
@@ -79,7 +75,7 @@ test('reject module-like sourceIndex', async t => {
   // that.
   vats.set('vat1', { sourcepath: 'vatsource' });
   t.rejects(
-    async () => buildVatController({ vats }, false),
+    async () => buildVatController({ vats }, true),
     /sourceIndex must be relative/,
   );
   t.end();
@@ -99,10 +95,6 @@ async function bootstrap(t, withSES) {
 
 test('bootstrap with SES', async t => {
   await bootstrap(t, true);
-});
-
-test('bootstrap without SES', async t => {
-  await bootstrap(t, false);
 });
 
 async function bootstrapExport(t, withSES) {
@@ -267,8 +259,4 @@ async function bootstrapExport(t, withSES) {
 
 test('bootstrap export with SES', async t => {
   await bootstrapExport(t, true);
-});
-
-test('bootstrap export without SES', async t => {
-  await bootstrapExport(t, false);
 });

--- a/packages/SwingSet/test/test-demos-comms.js
+++ b/packages/SwingSet/test/test-demos-comms.js
@@ -25,12 +25,6 @@ test('run encouragementBotComms Demo with SES', async t => {
   t.end();
 });
 
-test('run encouragementBotComms Demo without SES', async t => {
-  const dump = await main(false, 'demo/encouragementBotComms');
-  t.deepEquals(dump.log, encouragementBotCommsGolden);
-  t.end();
-});
-
 test('run encouragementBotCommsWavyDot Demo with SES', async t => {
   const dump = await main(true, 'demo/encouragementBotCommsWavyDot', []);
   t.deepEquals(dump.log, encouragementBotCommsGolden);

--- a/packages/SwingSet/test/test-demos.js
+++ b/packages/SwingSet/test/test-demos.js
@@ -24,9 +24,3 @@ test('run encouragementBot Demo with SES', async t => {
   t.deepEquals(dump.log, encouragementBotGolden);
   t.end();
 });
-
-test('run encouragementBot Demo without SES', async t => {
-  const dump = await main(false, 'demo/encouragementBot', []);
-  t.deepEquals(dump.log, encouragementBotGolden);
-  t.end();
-});

--- a/packages/SwingSet/test/test-devices.js
+++ b/packages/SwingSet/test/test-devices.js
@@ -43,10 +43,6 @@ test('d0 with SES', async t => {
   await test0(t, true);
 });
 
-test('d0 without SES', async t => {
-  await test0(t, false);
-});
-
 async function test1(t, withSES) {
   const sharedArray = [];
   const config = {
@@ -78,10 +74,6 @@ async function test1(t, withSES) {
 
 test('d1 with SES', async t => {
   await test1(t, true);
-});
-
-test('d1 without SES', async t => {
-  await test1(t, false);
 });
 
 async function test2(t, mode, withSES) {
@@ -148,40 +140,20 @@ test('d2.1 with SES', async t => {
   await test2(t, '1', true);
 });
 
-test('d2.1 without SES', async t => {
-  await test2(t, '1', false);
-});
-
 test('d2.2 with SES', async t => {
   await test2(t, '2', true);
-});
-
-test('d2.2 without SES', async t => {
-  await test2(t, '2', false);
 });
 
 test('d2.3 with SES', async t => {
   await test2(t, '3', true);
 });
 
-test('d2.3 without SES', async t => {
-  await test2(t, '3', false);
-});
-
 test('d2.4 with SES', async t => {
   await test2(t, '4', true);
 });
 
-test('d2.4 without SES', async t => {
-  await test2(t, '4', false);
-});
-
 test('d2.5 with SES', async t => {
   await test2(t, '5', true);
-});
-
-test('d2.5 without SES', async t => {
-  await test2(t, '5', false);
 });
 
 async function testState(t, withSES) {
@@ -208,10 +180,6 @@ async function testState(t, withSES) {
 
 test('device state with SES', async t => {
   await testState(t, true);
-});
-
-test('device state without SES', async t => {
-  await testState(t, false);
 });
 
 async function testMailboxOutbound(t, withSES) {
@@ -249,10 +217,6 @@ async function testMailboxOutbound(t, withSES) {
 
   t.end();
 }
-
-test('mailbox outbound without SES', async t => {
-  await testMailboxOutbound(t, false);
-});
 
 test('mailbox outbound with SES', async t => {
   await testMailboxOutbound(t, true);
@@ -371,10 +335,6 @@ async function testMailboxInbound(t, withSES) {
   t.end();
 }
 
-test('mailbox inbound without SES', async t => {
-  await testMailboxInbound(t, false);
-});
-
 test('mailbox inbound with SES', async t => {
   await testMailboxInbound(t, true);
 });
@@ -394,10 +354,6 @@ async function testCommandBroadcast(t, withSES) {
 
   t.end();
 }
-
-test('command broadcast without SES', async t => {
-  await testCommandBroadcast(t, false);
-});
 
 test('command broadcast with SES', async t => {
   await testCommandBroadcast(t, true);
@@ -433,10 +389,6 @@ async function testCommandDeliver(t, withSES) {
 
   t.end();
 }
-
-test('command deliver without SES', async t => {
-  await testCommandDeliver(t, false);
-});
 
 test('command deliver with SES', async t => {
   await testCommandDeliver(t, true);

--- a/packages/SwingSet/test/test-marshal.js
+++ b/packages/SwingSet/test/test-marshal.js
@@ -11,7 +11,7 @@ async function prep() {
     vats: new Map(),
     bootstrapIndexJS: undefined,
   };
-  const controller = await buildVatController(config, false);
+  const controller = await buildVatController(config, true);
   await controller.run();
 }
 

--- a/packages/SwingSet/test/test-message-patterns.js
+++ b/packages/SwingSet/test/test-message-patterns.js
@@ -47,24 +47,23 @@ async function runWithTrace(c) {
   }
 }
 
-export async function runVatsLocally(t, withSES, name) {
+export async function runVatsLocally(t, name) {
   console.log(`------ testing pattern (local) -- ${name}`);
   const bdir = path.resolve(__dirname, 'basedir-message-patterns');
   const config = await loadBasedir(bdir);
   config.bootstrapIndexJS = path.join(bdir, 'bootstrap-local.js');
-  const c = await buildVatController(config, withSES, [name]);
+  const c = await buildVatController(config, true, [name]);
   // await runWithTrace(c);
   await c.run();
   return c.dump().log;
 }
 
 function testLocalPatterns() {
-  const withSES = false;
   const bp = buildPatterns();
   for (const name of Array.from(bp.patterns.keys()).sort()) {
     const mode = bp.patterns.get(name).local;
     modes[mode](`test pattern ${name} locally`, async t => {
-      const logs = await runVatsLocally(t, withSES, name);
+      const logs = await runVatsLocally(t, name);
       t.deepEqual(logs, bp.expected[name]);
       t.end();
     });
@@ -72,7 +71,7 @@ function testLocalPatterns() {
 }
 testLocalPatterns();
 
-export async function runVatsInComms(t, withSES, enablePipelining, name) {
+export async function runVatsInComms(t, enablePipelining, name) {
   console.log(`------ testing pattern (comms) -- ${name}`);
   const bdir = path.resolve(__dirname, 'basedir-message-patterns');
   const config = await loadBasedir(bdir);
@@ -85,20 +84,19 @@ export async function runVatsInComms(t, withSES, enablePipelining, name) {
   config.vats.set('rightvattp', { sourcepath: getVatTPSourcePath() });
   const ldSrcPath = require.resolve('../src/devices/loopbox-src');
   config.devices = [['loopbox', ldSrcPath, {}]];
-  const c = await buildVatController(config, withSES, [name]);
+  const c = await buildVatController(config, true, [name]);
   // await runWithTrace(c);
   await c.run();
   return c.dump().log;
 }
 
 function testCommsPatterns() {
-  const withSES = false;
   const enablePipelining = true;
   const bp = buildPatterns();
   for (const name of Array.from(bp.patterns.keys()).sort()) {
     const mode = bp.patterns.get(name).comms;
     modes[mode](`test pattern ${name} locally`, async t => {
-      const logs = await runVatsInComms(t, withSES, enablePipelining, name);
+      const logs = await runVatsInComms(t, enablePipelining, name);
       let expected = bp.expected[name];
       if (enablePipelining && name in bp.expected_pipelined) {
         expected = bp.expected_pipelined[name];

--- a/packages/SwingSet/test/test-promises.js
+++ b/packages/SwingSet/test/test-promises.js
@@ -15,10 +15,6 @@ test('flush with SES', async t => {
   await testFlush(t, true);
 });
 
-test('flush without SES', async t => {
-  await testFlush(t, false);
-});
-
 async function testEThen(t, withSES) {
   const config = await loadBasedir(path.resolve(__dirname, 'basedir-promises'));
   const c = await buildVatController(config, withSES, ['e-then']);
@@ -36,10 +32,6 @@ async function testEThen(t, withSES) {
 
 test('E() resolve with SES', async t => {
   await testEThen(t, true);
-});
-
-test('E() resolve without SES', async t => {
-  await testEThen(t, false);
 });
 
 async function testChain1(t, withSES) {
@@ -70,10 +62,6 @@ test('E(E(x).foo()).bar() with SES', async t => {
   await testChain1(t, true);
 });
 
-test('E(E(x).foo()).bar() without SES', async t => {
-  await testChain1(t, false);
-});
-
 async function testChain2(t, withSES) {
   const config = await loadBasedir(path.resolve(__dirname, 'basedir-promises'));
   const c = await buildVatController(config, withSES, ['chain2']);
@@ -93,10 +81,6 @@ test('E(Promise.resolve(presence)).foo() with SES', async t => {
   await testChain2(t, true);
 });
 
-test('E(Promise.resolve(presence)).foo() without SES', async t => {
-  await testChain2(t, false);
-});
-
 async function testLocal1(t, withSES) {
   const config = await loadBasedir(path.resolve(__dirname, 'basedir-promises'));
   const c = await buildVatController(config, withSES, ['local1']);
@@ -113,10 +97,6 @@ async function testLocal1(t, withSES) {
 
 test('E(local).foo() with SES', async t => {
   await testLocal1(t, true);
-});
-
-test('E(local).foo() without SES', async t => {
-  await testLocal1(t, false);
 });
 
 async function testLocal2(t, withSES) {
@@ -138,10 +118,6 @@ test('resolve-to-local with SES', async t => {
   await testLocal2(t, true);
 });
 
-test('resolve-to-local without SES', async t => {
-  await testLocal2(t, false);
-});
-
 async function testSendPromise1(t, withSES) {
   const config = await loadBasedir(path.resolve(__dirname, 'basedir-promises'));
   const c = await buildVatController(config, withSES, ['send-promise1']);
@@ -160,10 +136,6 @@ async function testSendPromise1(t, withSES) {
 
 test('send-promise-resolve-to-local with SES', async t => {
   await testSendPromise1(t, true);
-});
-
-test('send-promise-resolve-to-local without SES', async t => {
-  await testSendPromise1(t, false);
 });
 
 async function testHardenPromise1(t, withSES) {
@@ -191,10 +163,4 @@ async function testHardenPromise1(t, withSES) {
 
 test('send-harden-promise-1 with SES', async t => {
   await testHardenPromise1(t, true);
-});
-
-// TODO: if/when we re-enable the infix-bang x!foo(), this test will only run
-// under SES, so disable the non-SES version
-test('send-harden-promise-1 without SES', async t => {
-  await testHardenPromise1(t, false);
 });

--- a/packages/SwingSet/test/test-transcript-light.js
+++ b/packages/SwingSet/test/test-transcript-light.js
@@ -102,7 +102,3 @@ async function testLoadState(t, withSES) {
 test('transcript-light load with SES', async t => {
   await testLoadState(t, true);
 });
-
-test('transcript-light load without SES', async t => {
-  await testLoadState(t, false);
-});

--- a/packages/SwingSet/test/test-transcript.js
+++ b/packages/SwingSet/test/test-transcript.js
@@ -47,10 +47,6 @@ test('transcript-one save with SES', async t => {
   await testSaveState(t, true);
 });
 
-test('transcript-one save without SES', async t => {
-  await testSaveState(t, false);
-});
-
 async function testLoadState(t, withSES) {
   const config = await loadBasedir(
     path.resolve(__dirname, 'basedir-transcript'),
@@ -85,8 +81,4 @@ async function testLoadState(t, withSES) {
 
 test('transcript-one load with SES', async t => {
   await testLoadState(t, true);
-});
-
-test('transcript-one load without SES', async t => {
-  await testLoadState(t, false);
 });

--- a/packages/SwingSet/test/test-vat-imports.js
+++ b/packages/SwingSet/test/test-vat-imports.js
@@ -13,11 +13,6 @@ test('vat can require harden with SES', async t => {
   t.end();
 });
 
-test('vat can require harden without SES', async t => {
-  await requireHarden(t, false);
-  t.end();
-});
-
 async function requireEvaluate(t, withSES) {
   const config = { bootstrapIndexJS: require.resolve('./vat-imports-1.js') };
   const c = await buildVatController(config, withSES, ['evaluate']);
@@ -27,10 +22,5 @@ async function requireEvaluate(t, withSES) {
 
 test('vat can require evaluate with SES', async t => {
   await requireEvaluate(t, true);
-  t.end();
-});
-
-test('vat can require evaluate without SES', async t => {
-  await requireEvaluate(t, false);
   t.end();
 });

--- a/packages/SwingSet/test/test-vattp.js
+++ b/packages/SwingSet/test/test-vattp.js
@@ -52,10 +52,6 @@ async function testVatTP(t, withSES) {
   t.end();
 }
 
-test('vattp without SES', async t => {
-  await testVatTP(t, false);
-});
-
 test('vattp with SES', async t => {
   await testVatTP(t, true);
 });
@@ -105,10 +101,6 @@ async function testVatTP2(t, withSES) {
 
   t.end();
 }
-
-test('vattp 2 without SES', async t => {
-  await testVatTP2(t, false);
-});
 
 test('vattp 2 with SES', async t => {
   await testVatTP2(t, true);

--- a/packages/SwingSet/test/timer-device/test-device.js
+++ b/packages/SwingSet/test/timer-device/test-device.js
@@ -24,10 +24,6 @@ test('wake with SES', async t => {
   await testSimpleWake(t, true);
 });
 
-test('wake without SES', async t => {
-  await testSimpleWake(t, false);
-});
-
 async function testRepeater(t, withSES) {
   const timer = buildTimer();
   const config = {
@@ -49,10 +45,6 @@ async function testRepeater(t, withSES) {
 
 test('repeater with SES', async t => {
   await testRepeater(t, true);
-});
-
-test('repeater without SES', async t => {
-  await testRepeater(t, false);
 });
 
 async function testRepeater2(t, withSES) {
@@ -79,10 +71,6 @@ async function testRepeater2(t, withSES) {
 
 test('repeater2 with SES', async t => {
   await testRepeater2(t, true);
-});
-
-test('repeater2 without SES', async t => {
-  await testRepeater2(t, false);
 });
 
 async function testRepeaterZero(t, withSES) {
@@ -124,8 +112,4 @@ async function testRepeaterZero(t, withSES) {
 
 test('repeaterZero with SES', async t => {
   await testRepeaterZero(t, true);
-});
-
-test('repeaterZero without SES', async t => {
-  await testRepeaterZero(t, false);
 });

--- a/packages/SwingSet/test/vat-admin/test-innerVat.js
+++ b/packages/SwingSet/test/vat-admin/test-innerVat.js
@@ -29,10 +29,6 @@ test('VatAdmin inner vat creation', async t => {
   await testVatCreationFromBuild(t, true);
 });
 
-test('VatAdmin inner vat creation non-SES', async t => {
-  await testVatCreationFromBuild(t, false);
-});
-
 async function testVatCreationAndObjectHosting(t, withSES) {
   const config = await createConfig();
   const c = await buildVatController(config, withSES, ['counters']);
@@ -44,10 +40,6 @@ async function testVatCreationAndObjectHosting(t, withSES) {
 
 test('VatAdmin inner vat creation', async t => {
   await testVatCreationAndObjectHosting(t, true);
-});
-
-test('VatAdmin inner vat creation non-SES', async t => {
-  await testVatCreationAndObjectHosting(t, false);
 });
 
 async function testBrokenVatCreation(t, withSES) {
@@ -63,10 +55,6 @@ async function testBrokenVatCreation(t, withSES) {
 
 test('VatAdmin broken vat creation', async t => {
   await testBrokenVatCreation(t, true);
-});
-
-test('VatAdmin broken vat creation non-SES', async t => {
-  await testBrokenVatCreation(t, false);
 });
 
 async function testGetVatStats(t, withSES) {
@@ -85,8 +73,4 @@ async function testGetVatStats(t, withSES) {
 
 test('VatAdmin get vat stats', async t => {
   await testGetVatStats(t, true);
-});
-
-test('VatAdmin get vat stats non-SES', async t => {
-  await testGetVatStats(t, false);
 });


### PR DESCRIPTION
This disables SwingSet's "no-SES" mode: it removes all no-ses tests, enforces the `createVatController()` `withSES` flag to be `true`, and removes the now-unused support code.

closes #721 