### PR TITLE
Propagate makeContract exceptions

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
@@ -186,7 +186,7 @@ export async function makeWallet(
 
   function deposit(pursePetName, payment) {
     const purse = petnameToPurse.get(pursePetName);
-    purse.deposit(payment);
+    return purse.deposit(payment);
   }
 
   function getPurses() {
@@ -330,6 +330,7 @@ export async function makeWallet(
         .catch(rejected);
     } catch (e) {
       rejected(e);
+      throw e;
     }
     return ret;
   }

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-mints.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-mints.js
@@ -13,7 +13,7 @@ function build(_E, _log) {
     getAllIssuerNames: () => mintsAndMath.keys(),
     getIssuer: issuerName => {
       const mint = mintsAndMath.get(issuerName);
-      mint.getIssuer();
+      return mint.getIssuer();
     },
     getIssuers: issuerNames => issuerNames.map(api.getIssuer),
 

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -257,15 +257,15 @@ const makeZoe = (additionalEndowments = {}) => {
         // that the contract can query Zoe for information about the
         // instance (get issuers, amountMaths, etc.)
         instanceTable.create(instanceRecord, instanceHandle);
-        return Promise.resolve(
-          installation.makeContract(contractFacet, terms),
-        ).then(value => {
-          // Once the contract is made, we add the publicAPI to the
-          // contractRecord
-          const { invite, publicAPI } = value;
-          instanceTable.update(instanceHandle, { publicAPI });
-          return invite;
-        });
+        return Promise.resolve()
+          .then(_ => installation.makeContract(contractFacet, terms))
+          .then(value => {
+            // Once the contract is made, we add the publicAPI to the
+            // contractRecord
+            const { invite, publicAPI } = value;
+            instanceTable.update(instanceHandle, { publicAPI });
+            return invite;
+          });
       };
 
       // The issuers may not have been seen before, so we must wait for


### PR DESCRIPTION
It is necessary to wrap the makeContract call within a .then callback
or else synchronous exceptions in it are not converted to a
rejected promise.
