### PR TITLE
Log and graph disk use

### DIFF
--- a/packages/swing-store-lmdb/lmdbSwingStore.js
+++ b/packages/swing-store-lmdb/lmdbSwingStore.js
@@ -39,6 +39,12 @@ function makeSwingStore(dirPath, forceReset = false) {
     }
   }
 
+  function diskUsage() {
+    const dataFilePath = `${dirPath}/data.mdb`;
+    const stat = fs.statSync(dataFilePath);
+    return stat.size;
+  }
+
   /**
    * Obtain the value stored for a given key.
    *
@@ -180,7 +186,7 @@ function makeSwingStore(dirPath, forceReset = false) {
     lmdbEnv = null;
   }
 
-  return { storage, commit, close };
+  return { storage, commit, close, diskUsage };
 }
 
 /**

--- a/packages/swingset-runner/bin/graphDisk
+++ b/packages/swingset-runner/bin/graphDisk
@@ -1,0 +1,1 @@
+../src/graphDisk.js

--- a/packages/swingset-runner/bin/graphMem
+++ b/packages/swingset-runner/bin/graphMem
@@ -1,8 +1,1 @@
-#!/usr/bin/env -S node -r esm
-
-/**
- * Simple boilerplate program providing linkage to launch an application written using modules within the
- * as yet not-entirely-ESM-supporting version of NodeJS.
- */
-import { main } from '../src/graphMem.js';
-main();
+../src/graphMem.js

--- a/packages/swingset-runner/bin/graphTime
+++ b/packages/swingset-runner/bin/graphTime
@@ -1,8 +1,1 @@
-#!/usr/bin/env -S node -r esm
-
-/**
- * Simple boilerplate program providing linkage to launch an application written using modules within the
- * as yet not-entirely-ESM-supporting version of NodeJS.
- */
-import { main } from '../src/graphTime.js';
-main();
+../src/graphTime.js

--- a/packages/swingset-runner/src/dataGraphApp.js
+++ b/packages/swingset-runner/src/dataGraphApp.js
@@ -1,0 +1,64 @@
+import process from 'process';
+
+import {
+  initGraphSpec,
+  addDataToGraphSpec,
+  addGraphToGraphSpec,
+  renderGraph,
+} from '@agoric/stat-logger';
+
+// prettier-ignore
+const colors = [
+  [ '#61d836', '#88fa4e', '#1db100', '#017100' ],
+  [ '#00a2ff', '#56c1ff', '#0076ba', '#004d7f' ],
+  [ '#fae232', '#fffc66', '#f8ba00', '#ff9300' ],
+  [ '#ff644e', '#ff968d', '#ee220c', '#b51700' ],
+  [ '#ef5fa7', '#ff8dc6', '#cb297b', '#991953' ],
+  [ '#16e7cf', '#73fdea', '#00a89d', '#2e578c' ],
+];
+
+export async function dataGraphApp(xField, xLabel, yField, yLabel, lineFields) {
+  const argv = process.argv.splice(2);
+
+  let outfile = null;
+  const datafiles = [];
+  let type = 'png';
+
+  while (argv[0]) {
+    const arg = argv.shift();
+    if (arg.startsWith('-')) {
+      switch (arg) {
+        case '--output':
+        case '-o':
+          outfile = argv.shift();
+          break;
+        case '--pdf':
+          type = 'pdf';
+          break;
+        default:
+          throw new Error(`invalid flag ${arg}`);
+      }
+    } else {
+      datafiles.push(arg);
+    }
+  }
+  if (datafiles.length < 1) {
+    throw new Error('you must specify some input');
+  }
+
+  const spec = initGraphSpec(datafiles[0], xField, xLabel, yField, yLabel);
+  for (let dataIdx = 0; dataIdx < datafiles.length; dataIdx += 1) {
+    addDataToGraphSpec(spec, datafiles[dataIdx]);
+    const groupColors = colors[dataIdx % colors.length];
+    for (let lineIdx = 0; lineIdx < lineFields.length; lineIdx += 1) {
+      addGraphToGraphSpec(
+        spec,
+        datafiles[dataIdx],
+        lineFields[lineIdx],
+        groupColors[lineIdx % groupColors.length],
+      );
+    }
+  }
+
+  await renderGraph(spec, outfile, type);
+}

--- a/packages/swingset-runner/src/graphDisk.js
+++ b/packages/swingset-runner/src/graphDisk.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env -S node -r esm
+
+import { dataGraphApp } from './dataGraphApp';
+
+export async function main() {
+  // prettier-ignore
+  await dataGraphApp(
+    'block',
+    'Block #',
+    'disk',
+    'Database size (bytes)',
+    ['disk'],
+  );
+}
+
+main();

--- a/packages/swingset-runner/src/graphMem.js
+++ b/packages/swingset-runner/src/graphMem.js
@@ -1,68 +1,16 @@
-import process from 'process';
+#!/usr/bin/env -S node -r esm
 
-import {
-  initGraphSpec,
-  addDataToGraphSpec,
-  addGraphToGraphSpec,
-  renderGraph,
-} from '@agoric/stat-logger';
-
-// prettier-ignore
-const colors = [
-  '#00a2ff', '#56c1ff', '#0076ba', '#004d7f',
-  '#61d836', '#88fa4e', '#1db100', '#017100',
-  '#fae232', '#fffc66', '#f8ba00', '#ff9300',
-  '#ff644e', '#ff968d', '#ee220c', '#b51700',
-  '#ef5fa7', '#ff8dc6', '#cb297b', '#991953',
-  '#16e7cf', '#73fdea', '#00a89d', '#2e578c',
-];
+import { dataGraphApp } from './dataGraphApp';
 
 export async function main() {
-  const argv = process.argv.splice(2);
-
-  let outfile = null;
-  const datafiles = [];
-  let type = 'png';
-
-  while (argv[0]) {
-    const arg = argv.shift();
-    if (arg.startsWith('-')) {
-      switch (arg) {
-        case '--output':
-        case '-o':
-          outfile = argv.shift();
-          break;
-        case '--pdf':
-          type = 'pdf';
-          break;
-        default:
-          throw new Error(`invalid flag ${arg}`);
-      }
-    } else {
-      datafiles.push(arg);
-    }
-  }
-  if (datafiles.length < 1) {
-    throw new Error('you must specify some input');
-  }
-
-  const spec = initGraphSpec(
-    datafiles[0],
+  // prettier-ignore
+  await dataGraphApp(
     'block',
     'Block #',
     'rss',
     'Memory usage',
+    ['rss', 'heapTotal', 'heapUsed', 'external'],
   );
-  let colorIdx = 0;
-  for (let i = 0; i < datafiles.length; i += 1) {
-    colorIdx %= colors.length;
-    addDataToGraphSpec(spec, datafiles[i]);
-    addGraphToGraphSpec(spec, datafiles[i], 'rss', colors[colorIdx]);
-    addGraphToGraphSpec(spec, datafiles[i], 'heapTotal', colors[colorIdx + 1]);
-    addGraphToGraphSpec(spec, datafiles[i], 'heapUsed', colors[colorIdx + 2]);
-    addGraphToGraphSpec(spec, datafiles[i], 'external', colors[colorIdx + 3]);
-    colorIdx += 4;
-  }
-
-  await renderGraph(spec, outfile, type);
 }
+
+main();

--- a/packages/swingset-runner/src/graphTime.js
+++ b/packages/swingset-runner/src/graphTime.js
@@ -1,61 +1,16 @@
-import process from 'process';
+#!/usr/bin/env -S node -r esm
 
-import {
-  initGraphSpec,
-  addDataToGraphSpec,
-  addGraphToGraphSpec,
-  renderGraph,
-} from '@agoric/stat-logger';
-
-const colors = [
-  '#61d836',
-  '#00a2ff',
-  '#fae232',
-  '#ff644e',
-  '#ef5fa7',
-  '#16e7cf',
-];
+import { dataGraphApp } from './dataGraphApp';
 
 export async function main() {
-  const argv = process.argv.splice(2);
-
-  let outfile = null;
-  const datafiles = [];
-  let type = 'png';
-
-  while (argv[0]) {
-    const arg = argv.shift();
-    if (arg.startsWith('-')) {
-      switch (arg) {
-        case '--output':
-        case '-o':
-          outfile = argv.shift();
-          break;
-        case '--pdf':
-          type = 'pdf';
-          break;
-        default:
-          throw new Error(`invalid flag ${arg}`);
-      }
-    } else {
-      datafiles.push(arg);
-    }
-  }
-  if (datafiles.length < 1) {
-    throw new Error('you must specify some input');
-  }
-
-  const spec = initGraphSpec(
-    datafiles[0],
+  // prettier-ignore
+  await dataGraphApp(
     'block',
     'Block #',
     'btime',
     'Block time (ns)',
+    ['btime'],
   );
-  for (let i = 0; i < datafiles.length; i += 1) {
-    addDataToGraphSpec(spec, datafiles[i]);
-    addGraphToGraphSpec(spec, datafiles[i], 'btime', colors[i % colors.length]);
-  }
-
-  await renderGraph(spec, outfile, type);
 }
+
+main();


### PR DESCRIPTION
Extend swingset-runner to log database disk usage, and add graphing utilities to match.  Also refactored the graphing utilities themselves to unify a bunch of redundant code (since the disk logging added a third graphing utility, 2x redundant boilerplate became 3x redundant boilerplate, and I can anticipate more graphing thingies in the future as we think of new things to measure; better to squeeze out the redundancy now rather than signing up for N-way maintenance for increasing values of N).