### PR TITLE
Introduce anylogger to SwingSet and cosmic-swingset

### DIFF
--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -42,6 +42,7 @@
     "@agoric/tame-metering": "^1.0.0",
     "@agoric/transform-metering": "^1.1.0",
     "@babel/core": "^7.5.0",
+    "anylogger": "^0.21.0",
     "rollup": "^1.23.1",
     "rollup-plugin-node-resolve": "^5.2.0",
     "semver": "^6.3.0",

--- a/packages/SwingSet/src/devices/command-src.js
+++ b/packages/SwingSet/src/devices/command-src.js
@@ -21,7 +21,7 @@ export default function setup(syscall, state, helpers, endowments) {
         const body = JSON.parse(`${bodyString}`);
         SO(inboundHandler).inbound(Nat(count), body);
       } catch (e) {
-        console.log(`error during inboundCallback: ${e}`);
+        console.error(`error during inboundCallback:`, e);
         throw new Error(`error during inboundCallback: ${e}`);
       }
     });
@@ -36,7 +36,7 @@ export default function setup(syscall, state, helpers, endowments) {
         try {
           deliverResponse(count, isReject, JSON.stringify(obj));
         } catch (e) {
-          console.log(`error during sendResponse: ${e}`);
+          console.error(`error during sendResponse:`, e);
         }
       },
 
@@ -44,7 +44,7 @@ export default function setup(syscall, state, helpers, endowments) {
         try {
           sendBroadcast(JSON.stringify(obj));
         } catch (e) {
-          console.log(`error during sendBroadcast: ${e}`);
+          console.error(`error during sendBroadcast:`, e);
         }
       },
     });

--- a/packages/SwingSet/src/devices/command.js
+++ b/packages/SwingSet/src/devices/command.js
@@ -24,7 +24,7 @@ export default function buildCommand(broadcastCallback) {
     try {
       inboundCallback(count, JSON.stringify(obj));
     } catch (e) {
-      console.log(`error running inboundCallback: ${e}`);
+      console.error(`error running inboundCallback:`, e);
     }
     return p;
   }

--- a/packages/SwingSet/src/devices/inbound-src.js
+++ b/packages/SwingSet/src/devices/inbound-src.js
@@ -18,7 +18,7 @@ export default function setup(syscall, state, helpers, endowments) {
         try {
           SO(inboundHandler).inbound(`${sender}`, `${message}`);
         } catch (e) {
-          console.log(`error during inboundCallback: ${e}`);
+          console.error(`error during inboundCallback:`, e);
         }
       };
       return harden({

--- a/packages/SwingSet/src/devices/mailbox-src.js
+++ b/packages/SwingSet/src/devices/mailbox-src.js
@@ -62,7 +62,7 @@ export default function setup(syscall, state, helpers, endowments) {
       try {
         SO(inboundHandler).deliverInboundMessages(peer, newMessages);
       } catch (e) {
-        console.log(`error during deliverInboundMessages: ${e}`);
+        console.error(`error during deliverInboundMessages: ${e}`, e);
       }
     };
 
@@ -73,7 +73,7 @@ export default function setup(syscall, state, helpers, endowments) {
       try {
         SO(inboundHandler).deliverInboundAck(peer, ack);
       } catch (e) {
-        console.log(`error during deliverInboundAck: ${e}`);
+        console.error(`error during deliverInboundAck:`, e);
       }
     };
 

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -281,7 +281,7 @@ export default function buildKernel(kernelEndowments) {
       await vat.manager.deliverOneMessage(target, msg);
     } catch (e) {
       // log so we get a stack trace
-      console.log(`error in kernel.deliver:`, e);
+      console.error(`error in kernel.deliver:`, e);
       throw e;
     }
   }
@@ -359,7 +359,7 @@ export default function buildKernel(kernelEndowments) {
       await vat.manager.deliverOneNotification(kpid, p);
     } catch (e) {
       // log so we get a stack trace
-      console.log(`error in kernel.processNotify:`, e);
+      console.error(`error in kernel.processNotify:`, e);
       throw e;
     }
   }
@@ -368,7 +368,7 @@ export default function buildKernel(kernelEndowments) {
   async function processQueueMessage(message) {
     kdebug(`processQ ${JSON.stringify(message)}`);
     if (processQueueRunning) {
-      console.log(`We're currently already running at`, processQueueRunning);
+      console.error(`We're currently already running at`, processQueueRunning);
       throw Error(`Kernel reentrancy is forbidden`);
     }
     try {
@@ -494,7 +494,7 @@ export default function buildKernel(kernelEndowments) {
       if (drefs.has(val)) {
         return drefs.get(val);
       }
-      console.log(`oops ${val}`, val);
+      console.error(`oops ${val}`, val);
       throw Error('bootstrap got unexpected pass-by-presence');
     }
 
@@ -692,6 +692,7 @@ export default function buildKernel(kernelEndowments) {
 
     // if it *was* initialized, replay the transcripts
     if (wasInitialized) {
+      console.info('Replaying SwingSet transcripts');
       const oldLength = kernelKeeper.getRunQueueLength();
       for (const vatID of ephemeral.vats.keys()) {
         console.log(`Replaying transcript of vatID ${vatID}`);

--- a/packages/SwingSet/src/kernel/state/storageWrapper.js
+++ b/packages/SwingSet/src/kernel/state/storageWrapper.js
@@ -39,7 +39,7 @@ export function guardStorage(hostStorage) {
     try {
       return hostStorage[method](...args);
     } catch (err) {
-      console.log(`error invoking hostStorage.${method}(${args})`, err);
+      console.error(`error invoking hostStorage.${method}(${args})`, err);
       throw new Error(`error invoking hostStorage.${method}(${args}): ${err}`);
     }
   }
@@ -57,7 +57,10 @@ export function guardStorage(hostStorage) {
         yield `${key}`;
       }
     } catch (err) {
-      console.log(`error invoking hostStorage.getKeys(${start}, ${end})`, err);
+      console.error(
+        `error invoking hostStorage.getKeys(${start}, ${end})`,
+        err,
+      );
       throw new Error(
         `error invoking hostStorage.getKeys(${start}, ${end}): ${err}`,
       );

--- a/packages/agoric-cli/test/test-workflow.js
+++ b/packages/agoric-cli/test/test-workflow.js
@@ -55,7 +55,7 @@ test('workflow', async t => {
         startP.cp.stdout.on('data', chunk => {
           // console.log('stdout:', chunk.toString());
           stdoutStr += chunk.toString();
-          if (stdoutStr.match(/^swingset running$/m)) {
+          if (stdoutStr.match(/(^|:\s+)swingset running$/m)) {
             successfulStart = true;
             startP.cp.kill('SIGINT');
           }

--- a/packages/cosmic-swingset/bin/ag-solo
+++ b/packages/cosmic-swingset/bin/ag-solo
@@ -3,6 +3,8 @@
 const process = require('process');
 const esmRequire = require('esm')(module);
 
+// Configure logs.
+esmRequire('../lib/anylogger-agoric.js');
 const solo = esmRequire('../lib/ag-solo/main.js').default;
 
 solo(process.argv[1], process.argv.splice(2)).then(

--- a/packages/cosmic-swingset/lib/ag-chain-cosmos
+++ b/packages/cosmic-swingset/lib/ag-chain-cosmos
@@ -4,8 +4,9 @@ const path = require('path');
 const agcc = require('bindings')('agcosmosdaemon.node');
 const esmRequire = require('esm')(module);
 
-esmRequire('./agoric-anylogger');
+esmRequire('./anylogger-agoric');
 const anylogger = require('anylogger');
+
 const log = anylogger('ag-chain-cosmos');
 
 const main = esmRequire('./chain-main.js').default;

--- a/packages/cosmic-swingset/lib/ag-chain-cosmos
+++ b/packages/cosmic-swingset/lib/ag-chain-cosmos
@@ -4,6 +4,10 @@ const path = require('path');
 const agcc = require('bindings')('agcosmosdaemon.node');
 const esmRequire = require('esm')(module);
 
+esmRequire('./agoric-anylogger');
+const anylogger = require('anylogger');
+const log = anylogger('ag-chain-cosmos');
+
 const main = esmRequire('./chain-main.js').default;
 
 main(process.argv[1], process.argv.splice(2), {
@@ -13,7 +17,7 @@ main(process.argv[1], process.argv.splice(2), {
 }).then(
   _res => 0,
   rej => {
-    console.log(`error running ag-chain-cosmos:`, rej);
+    log.error(`error running ag-chain-cosmos:`, rej);
     process.exit(1);
   },
 );

--- a/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
+++ b/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
@@ -2,8 +2,12 @@
 import path from 'path';
 import fs from 'fs';
 import stringify from '@agoric/swingset-vat/src/kernel/json-stable-stringify';
+import anylogger from 'anylogger';
+
 import { launch } from '../launch-chain';
 import makeBlockManager from '../block-manager';
+
+const log = anylogger('fake-chain');
 
 const PRETEND_BLOCK_DELAY = 5;
 
@@ -80,7 +84,7 @@ export async function connectToFakeChain(basedir, GCI, role, delay, inbound) {
       blockTime = blockTime + Date.now() - actualStart;
       blockHeight += 1;
     } catch (e) {
-      console.log(`error fake processing`, e);
+      log.error(`error fake processing`, e);
     }
 
     if (delay) {

--- a/packages/cosmic-swingset/lib/ag-solo/init-basedir.js
+++ b/packages/cosmic-swingset/lib/ag-solo/init-basedir.js
@@ -2,6 +2,10 @@ import fs from 'fs';
 import path from 'path';
 import { execFileSync } from 'child_process';
 
+import anylogger from 'anylogger';
+
+const log = anylogger('ag-solo:init');
+
 export default function initBasedir(
   basedir,
   webport,
@@ -14,7 +18,7 @@ export default function initBasedir(
     fs.mkdirSync(basedir);
   } catch (e) {
     if (!fs.existsSync(path.join(basedir, 'ag-cosmos-helper-address'))) {
-      console.log(
+      log.error(
         `unable to create basedir ${basedir}, it must not already exist`,
       );
       throw e;
@@ -119,7 +123,7 @@ export default function initBasedir(
           stdio: ['pipe', 'ignore', 'ignore'],
         },
       );
-      console.log('key generated, now extracting address');
+      log('key generated, now extracting address');
       const kout = execFileSync(
         'ag-cosmos-helper',
         [
@@ -149,6 +153,6 @@ export default function initBasedir(
     path.join(basedir, 'solo-README.md'),
   );
 
-  console.log(`ag-solo initialized in ${basedir}`);
-  console.log(`HTTP/WebSocket will listen on ${webhost}:${webport}`);
+  log(`ag-solo initialized in ${basedir}`);
+  log(`HTTP/WebSocket will listen on ${webhost}:${webport}`);
 }

--- a/packages/cosmic-swingset/lib/ag-solo/main.js
+++ b/packages/cosmic-swingset/lib/ag-solo/main.js
@@ -4,6 +4,8 @@ import parseArgs from 'minimist';
 import process from 'process';
 import { assert } from '@agoric/assert';
 
+import anylogger from 'anylogger';
+
 // Start a network service
 import bundle from './bundle';
 import initBasedir from './init-basedir';
@@ -11,6 +13,8 @@ import resetState from './reset-state';
 import setGCIIngress from './set-gci-ingress';
 import setFakeChain from './set-fake-chain';
 import start from './start';
+
+const log = anylogger('ag-solo');
 
 // As we add more egress types, put the default types in a comma-separated
 // string below.
@@ -34,7 +38,7 @@ function insistIsBasedir() {
 }
 
 export default async function solo(progname, rawArgv) {
-  // console.error('solo', rawArgv);
+  log.debug('solo', rawArgv);
   const { _: argv, ...opts } = parseArgs(rawArgv, {
     stopEarly: true,
     boolean: ['help', 'version'],
@@ -66,7 +70,7 @@ start
     assert(basedir !== undefined, 'you must provide a BASEDIR');
     initBasedir(basedir, webport, webhost, subdir, egresses.split(','));
     await resetState(basedir);
-    // console.error(
+    // log.error(
     //   `Run '(cd ${basedir} && ${progname} start)' to start the vat machine`,
     // );
   } else if (argv[0] === 'set-gci-ingress') {
@@ -95,7 +99,7 @@ start
   } else if (argv[0] === 'register-http') {
     await bundle(insistIsBasedir, [`--evaluate`, ...argv]);
   } else {
-    console.error(`unrecognized command ${argv[0]}`);
-    console.error(`try one of: init, set-gci-ingress, start`);
+    log.error(`unrecognized command ${argv[0]}`);
+    log.error(`try one of: init, set-gci-ingress, start`);
   }
 }

--- a/packages/cosmic-swingset/lib/ag-solo/main.js
+++ b/packages/cosmic-swingset/lib/ag-solo/main.js
@@ -70,6 +70,9 @@ start
     assert(basedir !== undefined, 'you must provide a BASEDIR');
     initBasedir(basedir, webport, webhost, subdir, egresses.split(','));
     await resetState(basedir);
+
+    // TODO: We may want to give some instructions.  This is probably not the
+    // right place to determine our context.
     // log.error(
     //   `Run '(cd ${basedir} && ${progname} start)' to start the vat machine`,
     // );

--- a/packages/cosmic-swingset/lib/ag-solo/outbound.js
+++ b/packages/cosmic-swingset/lib/ag-solo/outbound.js
@@ -1,20 +1,24 @@
+import anylogger from 'anylogger';
+
+const log = anylogger('outbound');
+
 const knownTargets = new Map(); // target => { deliverator, highestSent, highestAck }
 
 export function deliver(mbs) {
   const data = mbs.exportToData();
-  // console.log(`deliver`, data);
+  log.debug(`deliver`, data);
   for (const target of Object.getOwnPropertyNames(data)) {
     if (!knownTargets.has(target)) {
-      console.log(`eek, no delivery method for target ${target}`);
+      log.error(`eek, no delivery method for target`, target);
       // eslint-disable-next-line no-continue
       continue;
     }
     const t = knownTargets.get(target);
     const newMessages = [];
     data[target].outbox.forEach(m => {
-      const [msgnum] = m;
+      const [msgnum, body] = m;
       if (msgnum > t.highestSent) {
-        // console.log(`new outbound message ${msgnum} for ${target}: ${body}`);
+        log.debug(`new outbound message ${msgnum} for ${target}: ${body}`);
         newMessages.push(m);
       }
     });
@@ -22,8 +26,8 @@ export function deliver(mbs) {
     // console.log(` ${newMessages.length} new messages`);
     const acknum = data[target].inboundAck;
     if (newMessages.length || acknum !== t.highestAck) {
-      console.log(
-        ` invoking deliverator; ${newMessages.length} new messages for ${target}`,
+      log.info(
+        `invoking deliverator; ${newMessages.length} new messages for ${target}`,
       );
       t.deliverator(newMessages, acknum);
       if (newMessages.length) {

--- a/packages/cosmic-swingset/lib/ag-solo/start.js
+++ b/packages/cosmic-swingset/lib/ag-solo/start.js
@@ -4,6 +4,8 @@ import temp from 'temp';
 import { promisify } from 'util';
 // import { createHash } from 'crypto';
 
+import anylogger from 'anylogger';
+
 // import connect from 'lotion-connect';
 // import harden from '@agoric/harden';
 // import djson from 'deterministic-json';
@@ -30,6 +32,8 @@ import { connectToFakeChain } from './fake-chain';
 
 // import { makeChainFollower } from './follower';
 // import { makeDeliverator } from './deliver-with-ag-cosmos-helper';
+
+const log = anylogger('start');
 
 let swingSetRunning = false;
 
@@ -166,10 +170,10 @@ async function buildSwingset(
     try {
       if (timer.poll(now)) {
         await processKernel();
-        console.log(`timer-provoked kernel crank complete ${now}`);
+        log.debug(`timer-provoked kernel crank complete ${now}`);
       }
     } catch (err) {
-      console.log(`timer-provoked kernel crank failed at ${now}:`, err);
+      log.error(`timer-provoked kernel crank failed at ${now}:`, err);
     } finally {
       // We only rearm the timeout if moveTimeForward has completed, to
       // make sure we don't have two copies of controller.run() executing
@@ -206,7 +210,7 @@ export default async function start(basedir, withSES, argv) {
     if (broadcastJSON) {
       broadcastJSON(obj);
     } else {
-      console.log(`Called broadcast before HTTP listener connected.`);
+      log.error(`Called broadcast before HTTP listener connected.`);
     }
   }
 
@@ -233,7 +237,7 @@ export default async function start(basedir, withSES, argv) {
       switch (c.type) {
         case 'chain-cosmos-sdk':
           {
-            console.log(`adding follower/sender for GCI ${c.GCI}`);
+            log(`adding follower/sender for GCI ${c.GCI}`);
             // c.rpcAddresses are strings of host:port for the RPC ports of several
             // chain nodes
             const deliverator = await connectToChain(
@@ -248,7 +252,7 @@ export default async function start(basedir, withSES, argv) {
           }
           break;
         case 'fake-chain': {
-          console.log(
+          log(
             `adding follower/sender for fake chain ${c.role} ${c.GCI}`,
           );
           const deliverator = await connectToFakeChain(
@@ -262,7 +266,7 @@ export default async function start(basedir, withSES, argv) {
           break;
         }
         case 'http':
-          console.log(`adding HTTP/WS listener on ${c.host}:${c.port}`);
+          log(`adding HTTP/WS listener on ${c.host}:${c.port}`);
           if (broadcastJSON) {
             throw new Error(`duplicate type=http in connections.json`);
           }
@@ -282,7 +286,7 @@ export default async function start(basedir, withSES, argv) {
   // Start timer here!
   startTimer(1200);
 
-  console.log(`swingset running`);
+  log.info(`swingset running`);
   swingSetRunning = true;
   deliverOutbound();
 }

--- a/packages/cosmic-swingset/lib/anylogger-agoric.js
+++ b/packages/cosmic-swingset/lib/anylogger-agoric.js
@@ -3,7 +3,7 @@ import anylogger from 'anylogger';
 // Turn on debugging output with DEBUG=agoric
 
 const debugging = process.env.DEBUG && process.env.DEBUG.includes('agoric');
-const defaultLevel = debugging ? anylogger.levels.debug : anylogger.levels.info;
+const defaultLevel = debugging ? anylogger.levels.debug : anylogger.levels.log;
 
 const oldExt = anylogger.ext;
 anylogger.ext = (l, o) => {

--- a/packages/cosmic-swingset/lib/anylogger-agoric.js
+++ b/packages/cosmic-swingset/lib/anylogger-agoric.js
@@ -2,8 +2,18 @@ import anylogger from 'anylogger';
 
 // Turn on debugging output with DEBUG=agoric
 
-const debugging = process.env.DEBUG && process.env.DEBUG.includes('agoric');
-const defaultLevel = debugging ? anylogger.levels.debug : anylogger.levels.log;
+let debugging;
+if (process.env.DEBUG === undefined) {
+  // DEBUG not set, default to log level.
+  debugging = 'log';
+} else if (process.env.DEBUG.includes('agoric')) {
+  // DEBUG set and we're enabled; verbose.
+  debugging = 'debug';
+} else {
+  // DEBUG set but we're not enabled; quieter than normal.
+  debugging = 'info';
+}
+const defaultLevel = anylogger.levels[debugging];
 
 const oldExt = anylogger.ext;
 anylogger.ext = (l, o) => {

--- a/packages/cosmic-swingset/lib/anylogger-agoric.js
+++ b/packages/cosmic-swingset/lib/anylogger-agoric.js
@@ -1,0 +1,25 @@
+import anylogger from 'anylogger';
+
+// Turn on debugging output with DEBUG=agoric
+
+const debugging = process.env.DEBUG && process.env.DEBUG.includes('agoric');
+const defaultLevel = debugging ? anylogger.levels.debug : anylogger.levels.info;
+
+const oldExt = anylogger.ext;
+anylogger.ext = (l, o) => {
+  l = oldExt(l, o);
+  l.enabledFor = lvl => defaultLevel >= anylogger.levels[lvl];
+
+  const prefix = l.name.replace(/:/g, ': ');
+  for (const [level, code] of Object.entries(anylogger.levels)) {
+    if (code > defaultLevel) {
+      // Disable printing.
+      l[level] = () => {};
+    } else {
+      // Enable the printing with a prefix.
+      const doLog = l[level] || (() => {});
+      l[level] = (...args) => doLog(`${prefix}:`, ...args);
+    }
+  }
+  return l;
+};

--- a/packages/cosmic-swingset/lib/block-manager.js
+++ b/packages/cosmic-swingset/lib/block-manager.js
@@ -1,3 +1,7 @@
+import anylogger from 'anylogger';
+
+const log = anylogger('block-manager');
+
 const BEGIN_BLOCK = 'BEGIN_BLOCK';
 const DELIVER_INBOUND = 'DELIVER_INBOUND';
 const END_BLOCK = 'END_BLOCK';
@@ -126,7 +130,7 @@ export default function makeBlockManager({
     savedActions = currentActions;
     computedHeight = action.blockHeight;
 
-    console.log(
+    log(
       `wrote SwingSet checkpoint (mailbox=${mailboxSize}), [run=${runTime}ms, mb=${mbTime}ms, save=${saveTime}ms]`,
     );
   }

--- a/packages/cosmic-swingset/lib/launch-chain.js
+++ b/packages/cosmic-swingset/lib/launch-chain.js
@@ -53,6 +53,7 @@ async function buildSwingset(withSES, mailboxState, storage, vatsDir, argv) {
 
 export async function launch(kernelStateDBDir, mailboxStorage, vatsDir, argv) {
   const withSES = true;
+  log.info('Launching SwingSet kernel');
 
   log(`checking for saved mailbox state`, mailboxStorage.has('mailbox'));
   const mailboxState = mailboxStorage.has('mailbox')

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -37,6 +37,7 @@
     "@agoric/weak-store": "^0.0.1",
     "@agoric/zoe": "^0.2.1",
     "@iarna/toml": "^2.2.3",
+    "anylogger": "^0.21.0",
     "bindings": "^1.2.1",
     "chalk": "^2.4.2",
     "deterministic-json": "^1.0.5",


### PR DESCRIPTION
Closes #571

In a continued effort to reduce confusing information as part of agoric-cli and the ag-chain-cosmos logs, I've introduced [`anylogger`](https://github.com/Download/anylogger) to the SwingSet and cosmic-swingset libraries.  This is based on my positive experience with anylogger in agoric-cli.

Notably, I've tagged the SwingSet anylogger instances with the name of the vat, device, or kernel, and passed it in as the `console` endowment to the ses-evaluated things.

This doesn't change any existing functionality (by default, anylogger just uses console.log and friends unchanged) but makes it possible for host programs to redirect, enhance, or filter out the log messages.

The magic happens in `ag-solo` and `ag-chain-cosmos` where they import `anylogger-agoric.js` to modify anylogger.  That makes anylogger sensitive to `export DEBUG=agoric`, and if it is not set, to log only the `.info`, `.warn`, and `.error` levels.  If that environment variable is set, then you get the full dumps, prefixed (approximately) by the `TAG` supplied to the `const log =. anylogger(TAG)`.  I find this truly useful when debugging.

In the future, we can change this policy without having to rewrite any library code or other modules except for `cosmic-swingset/lib/anylogger-agoric.js`.
