### PR TITLE
Let the caller handle dispatch rejections

### DIFF
--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -276,8 +276,16 @@ function build(syscall, _state, makeRoot, forVatID) {
     if (result) {
       lsdebug(` ls.deliver attaching then ->${result}`);
       insistVatType('promise', result);
+
+      // We return the results of the resolve/reject, rather
+      // than rejecting the dispatch with whatever the method
+      // did.
+      // It is up to the caller to handle or fail to handle the
+      // rejection.  Failing to handle should trigger a platform
+      // log, rather than via our parent doProcess call.
+
       // eslint-disable-next-line no-use-before-define
-      p.then(thenResolve(result), thenReject(result));
+      return p.then(thenResolve(result), thenReject(result));
     }
     return p;
   }


### PR DESCRIPTION
Discussion at #726

In this PR, we don't crash the doProcess call because technically, it has
succeeded (just resulted in a rejection), so reserve a rejection
for when the liveSlots mechanism actually fails.