### PR TITLE
fix: Clear vat table entries for promises when they are resolved

### DIFF
--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -342,6 +342,11 @@ function build(syscall, _state, makeRoot, forVatID) {
     }
     const val = m.unserialize(data);
     importedPromisesByPromiseID.get(promiseID).res(val);
+
+    importedPromisesByPromiseID.delete(promiseID);
+    const p = slotToVal.get(promiseID);
+    valToSlot.delete(p);
+    slotToVal.delete(promiseID);
   }
 
   function notifyFulfillToPresence(promiseID, slot) {


### PR DESCRIPTION
This takes care of the first part of #675, namely cleaning up the liveslots side of things.