### PR TITLE
Improve endowment security under SES

### DIFF
--- a/packages/SwingSet/src/makeConsole.js
+++ b/packages/SwingSet/src/makeConsole.js
@@ -1,0 +1,28 @@
+import harden from '@agoric/harden';
+
+// We assume we're running in a SES environment.
+export function makeConsole(baseConsole) {
+  // We restrict `console` to the API that can be implemented
+  // by the anylogger API.
+  // It should be unobservable by the code using it, notably
+  // only send output via the base console, and don't return a value.
+  const console = {};
+  for (const level of ['debug', 'log', 'info', 'warn', 'error']) {
+    console[level] = (...args) => {
+      baseConsole[level](...args);
+      return undefined;
+    };
+  }
+  return harden(console);
+}
+
+// This function implements makeConsole with SES1 (pre-lockdown).
+export function SES1MakeConsole(SES1, baseConsole) {
+  // We evaluate within SES so that the resulting object does
+  // not give away access to the root realm.
+  const source = `(${makeConsole})`;
+  const myConsole = SES1.evaluate(source, {
+    harden: SES1.global.SES.harden,
+  })(baseConsole);
+  return myConsole;
+}

--- a/packages/SwingSet/src/makeNestedEvaluate.js
+++ b/packages/SwingSet/src/makeNestedEvaluate.js
@@ -1,0 +1,22 @@
+import harden from '@agoric/harden';
+
+// We assume we're running in a SES environment.
+export function makeNestedEvaluate(compartment, endowments = {}) {
+  // Create a simple wrapper for the evaluator.
+  const nestedEvaluate = source => compartment.evaluate(source, endowments);
+
+  // Feed back the endowment to itself.
+  endowments.nestedEvaluate = nestedEvaluate;
+  return harden(nestedEvaluate);
+}
+
+// This function implements makeNestedEvaluate with SES1 (pre-lockdown).
+export function SES1MakeNestedEvaluate(SES1, endowments = {}) {
+  // We evaluate within SES so that the resulting object does
+  // not give away access to the root realm.
+  const source = `(${makeNestedEvaluate})`;
+  const nestedEvaluate = SES1.evaluate(source, {
+    harden: SES1.global.SES.harden,
+  })(SES1, endowments);
+  return nestedEvaluate;
+}


### PR DESCRIPTION
This PR prevents the SES-evaluated code from using the `console` or `nestedEvaluate` endowments to escape to the primal realm.  It also restricts the API presented by the console endowment, to prevent any future side-channels as well as make it deterministic (at least from the perspective of the evaluated code).

The mechanisms, while specific to SES1, are factored so that they can be applied to the `lockdown()`-based SES as well.
