### PR TITLE
add ses-adapter package

### DIFF
--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -83,6 +83,8 @@ jobs:
       run: cd packages/registrar && yarn test
     - name: yarn test (same-structure)
       run: cd packages/same-structure && yarn test
+    - name: yarn test (ses-adapter)
+      run: cd packages/ses-adapter && yarn test
     - name: yarn test (sharing-service)
       run: cd packages/sharing-service && yarn test
     - name: yarn test (sparse-ints)

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "useWorkspaces": true,
   "workspaces": [
     "packages/assert",
+    "packages/ses-adapter",
     "packages/import-manager",
     "packages/sparse-ints",
     "packages/registrar",

--- a/packages/ses-adapter/LICENSE
+++ b/packages/ses-adapter/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/ses-adapter/NEWS.md
+++ b/packages/ses-adapter/NEWS.md
@@ -1,0 +1,5 @@
+User-visible changes in ses-adapter:
+
+## Release xx (date)
+
+* first release

--- a/packages/ses-adapter/README.md
+++ b/packages/ses-adapter/README.md
@@ -1,0 +1,45 @@
+# SES-adapter
+
+```js
+import { harden, Compartment, HandledPromise } from 'ses-adapter';
+```
+
+This `ses-adapter` module provides a future-proof way to access three
+SES-related functions:
+
+* `harden`: recursively freeze the API surface of an object
+* `Compartment`: create a new Compartment, in which code can be evaluated
+* `HandledPromise`: augment Promises with eventual-send pipelining methods
+
+If the program is running in a SES environment when this module is first
+loaded, `ses-adapter` will return the SES versions of those functions. If
+not, it will provide an insecure simulation, which should be good enough for
+unit tests.
+
+The safe versions of these functions are provided as globals inside a SES
+environment. The easiest way to turn a Node.js or browser web-page context
+into a SES environment is to use the SES-shim package (published to NPM as
+`ses`) and call its `lockdown` function:
+
+```js
+import { lockdown } from 'ses';
+lockdown();
+```
+
+Applications should create a local module, perhaps named `install-SES.js`,
+which performs that `lockdown` step. The application should then import
+`./install-SES.js` before it imports anything else. This will ensure that the
+entire applications runs in a secure SES environment.
+
+Library code which wants to use harden/etc, and which does not want to impose
+a particular execution environment on the application which eventually uses
+it, should not import `ses` or call `lockdown` itself. Instead, it should
+merely import `ses-adapter` to access harden/etc.
+
+Library code that wants to run unit tests under SES, to verify it behaves
+correctly in a full SES environment, should create an `install-SES.js` and
+import it at the beginning of the unit test, before any of the
+code-under-test is imported. It should not import `install-SES.js` from the
+library code, but only from the unit test files (which are like applications,
+in that they are the first code run by Node).
+

--- a/packages/ses-adapter/package.json
+++ b/packages/ses-adapter/package.json
@@ -23,6 +23,12 @@
     "@agoric/harden": "^0.0.4",
     "@agoric/eventual-send": "^0.5.0"
   },
+  "files": [
+    "README.md",
+    "LICENSE",
+    "NEWS.md",
+    "src/**/*.js"
+  ],
   "author": "Agoric",
   "license": "Apache-2.0",
   "bugs": {

--- a/packages/ses-adapter/package.json
+++ b/packages/ses-adapter/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "ses-adapter",
+  "version": "0.0.1",
+  "description": "access harden/Compartment/HandledPromise inside or outside of SES",
+  "main": "src/index.js",
+  "module": "src/index.js",
+  "engines": {
+    "node": ">=10.15.1"
+  },
+  "scripts": {
+    "test": "tap --no-coverage --reporter specy test/**/test*.js",
+    "build": "exit 0",
+    "lint-fix": "eslint --fix '**/*.js'",
+    "lint-check": "eslint '**/*.js'"
+  },
+  "devDependencies": {
+    "tap": "^14.10.5",
+    "tape": "^4.10.0",
+    "tape-promise": "^4.0.0"
+  },
+  "dependencies": {
+    "ses": "^0.7.4",
+    "@agoric/harden": "^0.0.4",
+    "@agoric/eventual-send": "^0.5.0"
+  },
+  "author": "Agoric",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/Agoric/agoric-sdk/issues"
+  },
+  "homepage": "https://github.com/Agoric/agoric-sdk/packages/ses-adapter",
+  "eslintConfig": {
+    "extends": [
+      "airbnb-base",
+      "plugin:prettier/recommended"
+    ],
+    "env": {
+      "es6": true
+    },
+    "rules": {
+      "implicit-arrow-linebreak": "off",
+      "function-paren-newline": "off",
+      "arrow-parens": "off",
+      "strict": "off",
+      "no-console": "off",
+      "no-unused-vars": [
+        "error",
+        {
+          "argsIgnorePattern": "^_",
+          "varsIgnorePattern": "^_"
+        }
+      ],
+      "no-return-assign": "off",
+      "no-param-reassign": "off",
+      "no-restricted-syntax": [
+        "off",
+        "ForOfStatement"
+      ],
+      "no-unused-expressions": "off",
+      "no-loop-func": "off",
+      "no-inner-declarations": "off",
+      "import/extensions": "off",
+      "import/prefer-default-export": "off"
+    }
+  },
+  "prettier": {
+    "trailingComma": "all",
+    "singleQuote": true
+  }
+}

--- a/packages/ses-adapter/src/index.js
+++ b/packages/ses-adapter/src/index.js
@@ -1,0 +1,78 @@
+/* global globalThis harden Compartment HandledPromise */
+
+// @agoric/harden-0.0.4 can only be imported under SES if noTameRegExp is
+// enabled
+import maybeHarden from '@agoric/harden';
+
+// ses-0.7.3 doesn't export Compartment, and when I patched it to do so
+// (https://github.com/Agoric/SES-shim/pull/225), `new Compartment` throws a
+// safety-check error
+// import { Compartment as maybeCompartment } from 'ses'; // 'compartment-shim';
+
+// @agoric/eventual-send-0.5.0 imports harden-0.0.4, requires noTameRegExp
+import { HandledPromise as maybeHandledPromise } from '@agoric/eventual-send';
+
+// Use some magic to obtain 'globalThis'. Remember, under SES, we cannot
+// modify globalThis.
+const gt =
+  typeof globalThis === 'undefined'
+    ? new Function('return this')() // eslint-disable-line no-new-func
+    : globalThis;
+
+// eslint-disable-next-line no-underscore-dangle
+const installed = gt.__SESAdapterInstalled || {};
+
+let newHarden;
+if (installed.harden) {
+  newHarden = installed.harden;
+} else if (typeof harden !== 'undefined') {
+  newHarden = harden;
+  installed.harden = harden;
+} else {
+  newHarden = maybeHarden;
+  installed.harden = newHarden;
+}
+
+let newCompartment;
+if (installed.Compartment) {
+  newCompartment = installed.Compartment;
+} else if (typeof Compartment !== 'undefined') {
+  newCompartment = Compartment;
+  installed.Compartment = Compartment;
+} else {
+  const maybeCompartment = () => {
+    throw Error('non-SES Compartment still broken');
+  }; // TODO
+  newCompartment = maybeCompartment;
+  installed.Compartment = newCompartment;
+}
+
+let newHandledPromise;
+if (installed.HandledPromise) {
+  newHandledPromise = installed.HandledPromise;
+} else if (typeof HandledPromise !== 'undefined') {
+  newHandledPromise = HandledPromise;
+  installed.HandledPromise = HandledPromise;
+} else {
+  newHandledPromise = maybeHandledPromise;
+  installed.HandledPromise = newHandledPromise;
+}
+
+try {
+  // outside of SES, notify any separately-bundled copies of SES-adapter of
+  // our choices, by adding a specially-named property to the global
+
+  // eslint-disable-next-line no-underscore-dangle
+  gt.__SESAdapterInstalled = installed;
+} catch (e) {
+  // inside SES, we ignore the failed attempt to modify the global
+}
+
+const exportHarden = newHarden;
+const exportCompartment = newCompartment;
+const exportHandledPromise = newHandledPromise;
+export {
+  exportHarden as harden,
+  exportCompartment as Compartment,
+  exportHandledPromise as HandledPromise,
+};

--- a/packages/ses-adapter/test/do-compartment.js
+++ b/packages/ses-adapter/test/do-compartment.js
@@ -1,0 +1,15 @@
+import tap from 'tap';
+import { Compartment } from '../src/index.js';
+
+export function testCompartment() {
+  tap.equal(typeof Compartment, 'function', 'Compartment is a function');
+
+  const c = new Compartment();
+  tap.equal(c.evaluate('1+2'), 3, 'basic c.evaluate works');
+  const endowments = { a: 1 };
+  tap.equal(
+    c.evaluate('a+2', { endowments }),
+    3,
+    'c.evaluate takes endowments',
+  );
+}

--- a/packages/ses-adapter/test/do-handled-promise.js
+++ b/packages/ses-adapter/test/do-handled-promise.js
@@ -1,0 +1,14 @@
+import tap from 'tap';
+import { HandledPromise } from '../src/index.js';
+
+export async function testHandledPromise() {
+  tap.equal(typeof HandledPromise, 'function', 'HandledPromise is a function');
+  let resolver2;
+  const hp1 = new Promise(resolve => (resolver2 = resolve));
+  resolver2('correct value');
+  // this fails, "Cannot add property prepareStackTrace, object is not
+  // extensible", maybe 'tap' is trying to modify a SES-frozen HandledPromise
+  // tap.resolveMatch(hp1, /correct value/, 'HandledPromise resolves normally');
+  const result = await hp1;
+  tap.equal(result, 'correct value', 'HandledPromise resolves normally');
+}

--- a/packages/ses-adapter/test/do-harden.js
+++ b/packages/ses-adapter/test/do-harden.js
@@ -1,0 +1,15 @@
+import tap from 'tap';
+import { harden } from '../src/index.js';
+
+export function testHarden() {
+  tap.equal(typeof harden, 'function', 'harden is a function');
+
+  const o = {};
+  o.a = 1;
+  o.b = { c: 2 };
+  const o2 = harden(o);
+  tap.ok(o === o2, 'harden returns argument');
+  tap.throws(() => {
+    o.d = 'forbidden';
+  }, 'object is hardened');
+}

--- a/packages/ses-adapter/test/install-ses.js
+++ b/packages/ses-adapter/test/install-ses.js
@@ -1,0 +1,6 @@
+import { lockdown } from 'ses';
+
+lockdown({
+  noTameError: true, // for debugging
+  noTameRegExp: true, // for #230
+});

--- a/packages/ses-adapter/test/test-non-ses.js
+++ b/packages/ses-adapter/test/test-non-ses.js
@@ -1,0 +1,9 @@
+import { testHarden } from './do-harden.js';
+// eslint-disable-next-line no-unused-vars
+import { testCompartment } from './do-compartment.js';
+import { testHandledPromise } from './do-handled-promise.js';
+
+testHarden();
+// disabled because our non-SES 'Compartment' is still a non-functioning stub
+// testCompartment();
+testHandledPromise();

--- a/packages/ses-adapter/test/test-ses.js
+++ b/packages/ses-adapter/test/test-ses.js
@@ -1,0 +1,8 @@
+import './install-ses.js';
+import { testHarden } from './do-harden.js';
+import { testCompartment } from './do-compartment.js';
+import { testHandledPromise } from './do-handled-promise.js';
+
+testHarden();
+testCompartment();
+testHandledPromise();

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,6 +27,11 @@
   resolved "https://registry.yarnpkg.com/@agoric/make-hardener/-/make-hardener-0.0.4.tgz#9b5d6692bc2fbbac2fff0a6682959ac5e69c582d"
   integrity sha512-0k/wGkIVQO3IY7p/H/5OS3BIXsRK9Qb7nHnqyvj6hzvSyumwgPp8e4rz5QaVWSen43TGJl+zQn4mW9ZZShT1aw==
 
+"@agoric/make-hardener@0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@agoric/make-hardener/-/make-hardener-0.0.8.tgz#7f9e9d6874600b2e1b0543ce9456fbf62463be2d"
+  integrity sha512-bd83IYEMQbzpprwyA10RjHIGWmWeUMdsd5EzaHwke+zLH0HyqP6UKxFLv5mqkmrMeQyOMhNgKN1hCagjRyjlxQ==
+
 "@agoric/make-hardener@^0.0.6":
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/@agoric/make-hardener/-/make-hardener-0.0.6.tgz#5903748a71381bc37e23d571390aaff9973c37b2"
@@ -6818,6 +6823,13 @@ ses@^0.6.5:
     "@agoric/make-hardener" "^0.0.6"
     esm "^3.2.25"
     realms-shim "^1.2.2"
+
+ses@^0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/ses/-/ses-0.7.4.tgz#cb43a0406736d7cbd6975d67bd3866502feba4d6"
+  integrity sha512-wn1hEuMcDG4lCsqfgAlAS2w1gVVUlkV3i3uZnacvtrVJMtvMgUCTbECaK685vSUQz+J4B92m2OT6QQeC0ogoSw==
+  dependencies:
+    "@agoric/make-hardener" "0.0.8"
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"


### PR DESCRIPTION
See https://github.com/Agoric/SES-shim/issues/216 for details. I'm adding this to `agoric-sdk` for now because it depends upon `eventual-send` (which lives here), and will be mostly used by `import-bundle` (which will live here) and eventually zoe/ertp (which already live here). But it might want to be in its own repo, or in the `SES-shim` monorepo.

@michaelfig could you take a look at `src/index.js`, at the `globalThis` setup section? We worked on this together, but the code I wound up with had a valid lint complaint: I wasn't using the `gt` that we extracted. Please check that I'm getting and setting this value correctly (both at line 23, and line 66).
