### PR TITLE
feat: make ERTP methods acccept promises or payments

### DIFF
--- a/packages/ERTP/src/issuer.chainmail
+++ b/packages/ERTP/src/issuer.chainmail
@@ -28,17 +28,28 @@ interface Issuer (Amount (Extent)) {
   makeEmptyPurse() -> (Purse);
 
   /**
+   * Return true if the payment continues to exist.
+   *
+   * If the payment is a promise, the operation will proceed upon resolution.
+   */
+  isLive(payment :Payment) -> (boolean);
+
+  /**
    * Get the amount of digital assets in the payment. Because the
-   * payment is not trusted, we cannot call a method on it directly, 
+   * payment is not trusted, we cannot call a method on it directly,
    * and must use the issuer instead.
-   */ 
+   *
+   * If the payment is a promise, the operation will proceed upon resolution.
+   */
   getAmountOf(payment :Payment) -> (Amount);
 
-  /** 
+  /**
    * Burn all of the digital assets in the payment. `optAmount` is optional.
    * If `optAmount` is present, the code will insist that the amount of
    * the digital assets in the payment is equal to `optAmount`, to 
    * prevent sending the wrong payment and other confusion.
+   *
+   * If the payment is a promise, the operation will proceed upon resolution.
    */
   burn(payment :Payment, optAmount :Amount) -> (Amount);
 
@@ -48,17 +59,26 @@ interface Issuer (Amount (Extent)) {
    * If `optAmount` is present, the code will insist that the amount of
    * digital assets in the payment is equal to `optAmount`, to prevent
    * sending the wrong  payment and other confusion.
+   *
+   * If the payment is a promise, the operation will proceed upon resolution.
    */
   claim(payment :Payment, optAmount :Amount)
     -> (Payment);
 
-  /** Combine multiple payments into one payment. */
+  /**
+   * Combine multiple payments into one payment.
+   *
+   * If any of the payments is a promise, the operation will proceed upon
+   * resolution.
+   */
   combine(paymentsArray :List(Payment))
     -> (Payment);
 
   /** 
    * Split a single payment into two payments, A and B, according to the
    * paymentAmountA passed in. 
+   *
+   * If the payment is a promise, the operation will proceed upon resolution.
    */
   split(payment :Payment, paymentAmountA :Amount)
     -> (List(Payment));
@@ -66,6 +86,8 @@ interface Issuer (Amount (Extent)) {
   /** 
    * Split a single payment into many payments, according to the
    * amounts passed in. 
+   *
+   * If the payment is a promise, the operation will proceed upon resolution.
    */
   splitMany(payment :Payment, amounts :List(Amount))
     -> (List(Payment));
@@ -147,14 +169,26 @@ interface Purse (Amount) {
   /**
    * Deposit all the contents of payment into this purse, returning the
    * amount. If the optional argument `optAmount` does not equal the
-   * amount of digital assets in the payment,
-   * throw an error.
+   * amount of digital assets in the payment, throw an error.
+   *
+   * If payment is an unresolved promise, throw an error.
    */
   deposit(payment :Payment, optAmount :Amount) -> (Amount);
 
+  /**
+   * Deposit all the contents of payment into this purse, returning the
+   * amount. If the optional argument `optAmount` does not equal the
+   * amount of digital assets in the payment, throw an error.
+   *
+   * Payment may be a promise, but the operation will only succeed if the
+   * promise came from the issuer's vat. When the operation succeeds, the
+   * deposit operation will be correctly ordered with respect to calls made in
+   * the same turn.
+   */
+  depositInOrder(payment :Payment, optAmount :Amount) -> (Amount);
+
   /** Withdraw amount from this purse into a new Payment. */
   withdraw(amount :Amount) -> (Payment);
-
 }
 
 /**

--- a/packages/ERTP/src/issuer.chainmail
+++ b/packages/ERTP/src/issuer.chainmail
@@ -175,18 +175,6 @@ interface Purse (Amount) {
    */
   deposit(payment :Payment, optAmount :Amount) -> (Amount);
 
-  /**
-   * Deposit all the contents of payment into this purse, returning the
-   * amount. If the optional argument `optAmount` does not equal the
-   * amount of digital assets in the payment, throw an error.
-   *
-   * Payment may be a promise, but the operation will only succeed if the
-   * promise came from the issuer's vat. When the operation succeeds, the
-   * deposit operation will be correctly ordered with respect to calls made in
-   * the same turn.
-   */
-  depositInOrder(payment :Payment, optAmount :Amount) -> (Amount);
-
   /** Withdraw amount from this purse into a new Payment. */
   withdraw(amount :Amount) -> (Payment);
 }

--- a/packages/ERTP/src/issuer.js
+++ b/packages/ERTP/src/issuer.js
@@ -39,14 +39,14 @@ function produceIssuer(allegedName, mathHelpersName = 'nat') {
 
   const makePurse = () => {
     const purse = harden({
-      deposit: (payment, optAmount = undefined) => {
-        // TODO(hibbert) use `if (isPromise(payment)) {` from makePromise.
-        if (Promise.resolve(payment) === payment) {
+      deposit: (srcPayment, optAmount = undefined) => {
+        // TODO(hibbert) use `if (isPromise(srcPayment)) {` from makePromise.
+        if (Promise.resolve(srcPayment) === srcPayment) {
           throw new TypeError(
             `deposit does not accept promises as first argument. Instead of passing the promise (deposit(paymentPromise)), consider unwrapping the promise first: paymentPromise.then(actualPayment => deposit(actualPayment))`,
           );
         }
-        const srcPaymentBalance = paymentLedger.get(payment);
+        const srcPaymentBalance = paymentLedger.get(srcPayment);
         // Note: this does not guarantee that optAmount itself is a valid stable amount
         assertAmountEqual(srcPaymentBalance, optAmount);
         const purseBalance = purse.getCurrentAmount();
@@ -55,7 +55,7 @@ function produceIssuer(allegedName, mathHelpersName = 'nat') {
         // eslint-disable-next-line no-use-before-define
         const payments = reallocate(
           harden({
-            payments: [payment],
+            payments: [srcPayment],
             purses: [purse],
             newPurseBalances: [newPurseBalance],
           }),

--- a/packages/ERTP/src/issuer.js
+++ b/packages/ERTP/src/issuer.js
@@ -42,8 +42,9 @@ function produceIssuer(allegedName, mathHelpersName = 'nat') {
       deposit: (paymentP, optAmount = undefined) => {
         // TODO(hibbert) use `if (isPromise(paymentP)) {` from makePromise.
         if (Promise.resolve(paymentP) === paymentP) {
-          throw new TypeError(`deposit does not accept promises as first argument. Instead of passing the promise (deposit(paymentPromise)), consider unwrapping the promise first:
-        paymentPromise.then(actualPayment => deposit(actualPayment))`);
+          throw new TypeError(
+            `deposit does not accept promises as first argument. Instead of passing the promise (deposit(paymentPromise)), consider unwrapping the promise first: paymentPromise.then(actualPayment => deposit(actualPayment))`,
+          );
         }
         const srcPaymentBalance = paymentLedger.get(paymentP);
         // Note: this does not guarantee that optAmount itself is a valid stable amount
@@ -61,28 +62,6 @@ function produceIssuer(allegedName, mathHelpersName = 'nat') {
         );
         assert(payments.length === 0, 'no payments should be returned');
         return newPurseBalance;
-      },
-      depositInOrder: (paymentP, optAmount = undefined) => {
-        return Promise.resolve(paymentP).then(srcPaymentBalance => {
-          // Note: this does not guarantee that optAmount itself is a valid stable amount
-          assertAmountEqual(srcPaymentBalance, optAmount);
-          const purseBalance = purse.getCurrentAmount();
-          const newPurseBalance = amountMath.add(
-            srcPaymentBalance,
-            purseBalance,
-          );
-          // Commit point
-          // eslint-disable-next-line no-use-before-define
-          const payments = reallocate(
-            harden({
-              payments: [paymentP],
-              purses: [purse],
-              newPurseBalances: [newPurseBalance],
-            }),
-          );
-          assert(payments.length === 0, 'no payments should be returned');
-          return newPurseBalance;
-        });
       },
       withdraw: amount => {
         amount = amountMath.coerce(amount);

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -318,6 +318,27 @@ test('issuer.combine good payments', t => {
   }
 });
 
+test('issuer.combine array of promises', t => {
+  try {
+    const { mint, issuer, amountMath } = produceIssuer('fungible');
+    const paymentsP = [];
+    for (let i = 0; i < 100; i += 1) {
+      const freshPayment = mint.mintPayment(amountMath.make(1));
+      const paymentP = issuer.claim(freshPayment);
+      paymentsP.push(paymentP);
+    }
+
+    E(issuer)
+      .combine(paymentsP)
+      .catch(e => t.assert(false, e))
+      .finally(_ => t.end());
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
 test('issuer.combine bad payments', t => {
   try {
     const { mint, issuer, amountMath } = produceIssuer('fungible');

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -107,6 +107,46 @@ test('issuer.makeEmptyPurse', t => {
   }
 });
 
+test('issuer.deposit', t => {
+  t.plan(2);
+  const { issuer, mint, amountMath } = produceIssuer('fungible');
+  const fungible25 = amountMath.make(25);
+
+  const purse = issuer.makeEmptyPurse('my new purse');
+  const payment = mint.mintPayment(fungible25);
+
+  const checkDeposit = newPurseBalance => {
+    t.ok(
+      amountMath.isEqual(newPurseBalance, fungible25),
+      `the balance returned is the purse balance`,
+    );
+    t.ok(
+      amountMath.isEqual(purse.getCurrentAmount(), fungible25),
+      `the new purse balance is the payment's old balance`,
+    );
+  };
+
+  E(purse)
+    .deposit(payment, fungible25)
+    .then(checkDeposit);
+});
+
+test('issuer.deposit promise', t => {
+  t.plan(1);
+  const { issuer, mint, amountMath } = produceIssuer('fungible');
+  const fungible25 = amountMath.make(25);
+
+  const purse = issuer.makeEmptyPurse('my new purse');
+  const payment = mint.mintPayment(fungible25);
+  const exclusivePaymentP = E(issuer).claim(payment);
+
+  t.rejects(
+    () => E(purse).deposit(exclusivePaymentP, fungible25),
+    /deposit does not accept promises/,
+    'failed to reject a promise for a payment',
+  );
+});
+
 test('issuer.burn', t => {
   try {
     const { issuer, mint, amountMath } = produceIssuer('fungible');

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -57,7 +57,7 @@ test('issuer.getMathHelpersName', t => {
 test('issuer.makeEmptyPurse', t => {
   try {
     const { issuer, mint, amountMath, brand } = produceIssuer('fungible');
-    const purse = issuer.makeEmptyPurse('my new purse');
+    const purse = issuer.makeEmptyPurse();
     const payment = mint.mintPayment(amountMath.make(837));
 
     t.ok(
@@ -112,7 +112,7 @@ test('issuer.deposit', t => {
   const { issuer, mint, amountMath } = produceIssuer('fungible');
   const fungible25 = amountMath.make(25);
 
-  const purse = issuer.makeEmptyPurse('my new purse');
+  const purse = issuer.makeEmptyPurse();
   const payment = mint.mintPayment(fungible25);
 
   const checkDeposit = newPurseBalance => {
@@ -136,7 +136,7 @@ test('issuer.deposit promise', t => {
   const { issuer, mint, amountMath } = produceIssuer('fungible');
   const fungible25 = amountMath.make(25);
 
-  const purse = issuer.makeEmptyPurse('my new purse');
+  const purse = issuer.makeEmptyPurse();
   const payment = mint.mintPayment(fungible25);
   const exclusivePaymentP = E(issuer).claim(payment);
 

--- a/packages/ERTP/test/unitTests/test-mintObj.js
+++ b/packages/ERTP/test/unitTests/test-mintObj.js
@@ -16,161 +16,145 @@ test('mint.getIssuer', t => {
 });
 
 test('mint.mintPayment default natMathHelper', t => {
-  try {
-    const { mint, issuer, amountMath } = produceIssuer('fungible');
-    const fungible1000 = amountMath.make(1000);
-    const payment1 = mint.mintPayment(fungible1000);
-    const paymentBalance1 = issuer.getAmountOf(payment1);
+  t.plan(2);
+  const { mint, issuer, amountMath } = produceIssuer('fungible');
+  const fungible1000 = amountMath.make(1000);
+  const payment1 = mint.mintPayment(fungible1000);
+  issuer.getAmountOf(payment1).then(paymentBalance1 => {
     t.ok(amountMath.isEqual(paymentBalance1, fungible1000));
+  });
 
-    const payment2 = mint.mintPayment(amountMath.make(1000));
-    const paymentBalance2 = issuer.getAmountOf(payment2);
+  const payment2 = mint.mintPayment(amountMath.make(1000));
+  issuer.getAmountOf(payment2).then(paymentBalance2 => {
     t.ok(amountMath.isEqual(paymentBalance2, fungible1000));
-  } catch (e) {
-    t.assert(false, e);
-  } finally {
-    t.end();
-  }
+  });
 });
 
 test('mint.mintPayment strSetMathHelpers', t => {
-  try {
-    const { mint, issuer, amountMath } = produceIssuer('items', 'strSet');
-    const items1and2and4 = amountMath.make(harden(['1', '2', '4']));
-    const payment1 = mint.mintPayment(items1and2and4);
-    const paymentBalance1 = issuer.getAmountOf(payment1);
+  t.plan(2);
+  const { mint, issuer, amountMath } = produceIssuer('items', 'strSet');
+  const items1and2and4 = amountMath.make(harden(['1', '2', '4']));
+  const payment1 = mint.mintPayment(items1and2and4);
+  issuer.getAmountOf(payment1).then(paymentBalance1 => {
     t.ok(amountMath.isEqual(paymentBalance1, items1and2and4));
+  });
 
-    const items5and6 = amountMath.make(harden(['5', '6']));
-    const payment2 = mint.mintPayment(items5and6);
-    const paymentBalance2 = issuer.getAmountOf(payment2);
+  const items5and6 = amountMath.make(harden(['5', '6']));
+  const payment2 = mint.mintPayment(items5and6);
+  issuer.getAmountOf(payment2).then(paymentBalance2 => {
     t.ok(amountMath.isEqual(paymentBalance2, items5and6));
-  } catch (e) {
-    t.assert(false, e);
-  } finally {
-    t.end();
-  }
+  });
 });
 
 test('mint.mintPayment setMathHelpers', t => {
-  try {
-    const { mint, issuer, amountMath } = produceIssuer('items', 'set');
-    const item1handle = {};
-    const item2handle = {};
-    const item3handle = {};
-    const items1and2 = amountMath.make(harden([item1handle, item2handle]));
-    const payment1 = mint.mintPayment(items1and2);
-    const paymentBalance1 = issuer.getAmountOf(payment1);
+  t.plan(3);
+  const { mint, issuer, amountMath } = produceIssuer('items', 'set');
+  const item1handle = {};
+  const item2handle = {};
+  const item3handle = {};
+  const items1and2 = amountMath.make(harden([item1handle, item2handle]));
+  const payment1 = mint.mintPayment(items1and2);
+  issuer.getAmountOf(payment1).then(paymentBalance1 => {
     t.ok(amountMath.isEqual(paymentBalance1, items1and2));
+  });
 
-    const item3 = amountMath.make(harden([item3handle]));
-    const payment2 = mint.mintPayment(item3);
-    const paymentBalance2 = issuer.getAmountOf(payment2);
+  const item3 = amountMath.make(harden([item3handle]));
+  const payment2 = mint.mintPayment(item3);
+  issuer.getAmountOf(payment2).then(paymentBalance2 => {
     t.ok(amountMath.isEqual(paymentBalance2, item3));
+  });
 
-    // TODO: prevent reminting the same non-fungible amounts
-    // https://github.com/Agoric/agoric-sdk/issues/552
-    const payment3 = mint.mintPayment(item3);
-    const paymentBalance3 = issuer.getAmountOf(payment3);
+  // TODO: prevent reminting the same non-fungible amounts
+  // https://github.com/Agoric/agoric-sdk/issues/552
+  const payment3 = mint.mintPayment(item3);
+  issuer.getAmountOf(payment3).then(paymentBalance3 => {
     t.ok(amountMath.isEqual(paymentBalance3, item3));
-  } catch (e) {
-    t.assert(false, e);
-  } finally {
-    t.end();
-  }
+  });
 });
 
 test('mint.mintPayment setMathHelpers with invites', t => {
-  try {
-    const { mint, issuer, amountMath } = produceIssuer('items', 'set');
-    const instanceHandle1 = {};
-    const invite1Extent = { handle: {}, instanceHandle: instanceHandle1 };
-    const invite2Extent = { handle: {}, instanceHandle: instanceHandle1 };
-    const invite3Extent = { handle: {}, instanceHandle: {} };
-    const invites1and2 = amountMath.make(
-      harden([invite1Extent, invite2Extent]),
-    );
-    const payment1 = mint.mintPayment(invites1and2);
-    const paymentBalance1 = issuer.getAmountOf(payment1);
+  t.plan(2);
+  const { mint, issuer, amountMath } = produceIssuer('items', 'set');
+  const instanceHandle1 = {};
+  const invite1Extent = { handle: {}, instanceHandle: instanceHandle1 };
+  const invite2Extent = { handle: {}, instanceHandle: instanceHandle1 };
+  const invite3Extent = { handle: {}, instanceHandle: {} };
+  const invites1and2 = amountMath.make(harden([invite1Extent, invite2Extent]));
+  const payment1 = mint.mintPayment(invites1and2);
+  issuer.getAmountOf(payment1).then(paymentBalance1 => {
     t.ok(amountMath.isEqual(paymentBalance1, invites1and2));
+  });
 
-    const invite3 = amountMath.make(harden([invite3Extent]));
-    const payment2 = mint.mintPayment(invite3);
-    const paymentBalance2 = issuer.getAmountOf(payment2);
+  const invite3 = amountMath.make(harden([invite3Extent]));
+  const payment2 = mint.mintPayment(invite3);
+  issuer.getAmountOf(payment2).then(paymentBalance2 => {
     t.ok(amountMath.isEqual(paymentBalance2, invite3));
-  } catch (e) {
-    t.assert(false, e);
-  } finally {
-    t.end();
-  }
+  });
 });
 
 // Tests related to non-fungible tokens
 // This test models ballet tickets
 test('non-fungible tokens example', t => {
-  try {
-    const {
-      mint: balletTicketMint,
-      issuer: balletTicketIssuer,
-      amountMath,
-    } = produceIssuer('Agoric Ballet Opera tickets', 'set');
+  t.plan(11);
+  const {
+    mint: balletTicketMint,
+    issuer: balletTicketIssuer,
+    amountMath,
+  } = produceIssuer('Agoric Ballet Opera tickets', 'set');
 
-    const startDateString = new Date(2020, 1, 17, 20, 30).toISOString();
+  const startDateString = new Date(2020, 1, 17, 20, 30).toISOString();
 
-    const ticketDescriptionObjects = Array(5)
-      .fill()
-      .map((_, i) => ({
-        seat: i + 1,
-        show: 'The Sofa',
-        start: startDateString,
-      }));
+  const ticketDescriptionObjects = Array(5)
+    .fill()
+    .map((_, i) => ({
+      seat: i + 1,
+      show: 'The Sofa',
+      start: startDateString,
+    }));
 
-    const balletTicketPayments = ticketDescriptionObjects.map(
-      ticketDescription => {
-        return balletTicketMint.mintPayment(
-          amountMath.make(harden([ticketDescription])),
-        );
-      },
-    );
+  const balletTicketPayments = ticketDescriptionObjects.map(
+    ticketDescription => {
+      return balletTicketMint.mintPayment(
+        amountMath.make(harden([ticketDescription])),
+      );
+    },
+  );
 
-    // Alice will buy ticket 1
-    const paymentForAlice = balletTicketPayments[0];
-    // Bob will buy tickets 3 and 4
-    const paymentForBob = balletTicketIssuer.combine([
-      balletTicketPayments[2],
-      balletTicketPayments[3],
-    ]);
+  // Alice will buy ticket 1
+  const paymentForAlice = balletTicketPayments[0];
+  // Bob will buy tickets 3 and 4
+  const paymentForBob = balletTicketIssuer.combine([
+    balletTicketPayments[2],
+    balletTicketPayments[3],
+  ]);
 
-    // ALICE SIDE
-    // Alice bought ticket 1 and has access to the balletTicketIssuer, because it's public
-    const myTicketPaymentAlice = balletTicketIssuer.claim(paymentForAlice);
-    // the call to claim hasn't thrown, so Alice knows myTicketPayment_Alice
+  // ALICE SIDE
+  // Alice bought ticket 1 and has access to the balletTicketIssuer, because it's public
+  balletTicketIssuer.claim(paymentForAlice).then(myTicketPaymentAlice => {
+    // the call to claim() hasn't thrown, so Alice knows myTicketPaymentAlice
     // is a genuine 'Agoric Ballet Opera tickets' payment and she has exclusive access
     // to its handle
-    const paymentAmountAlice = balletTicketIssuer.getAmountOf(
-      myTicketPaymentAlice,
-    );
+    balletTicketIssuer
+      .getAmountOf(myTicketPaymentAlice)
+      .then(paymentAmountAlice => {
+        t.equals(paymentAmountAlice.extent.length, 1);
+        t.equals(paymentAmountAlice.extent[0].seat, 1);
+        t.equals(paymentAmountAlice.extent[0].show, 'The Sofa');
+        t.equals(paymentAmountAlice.extent[0].start, startDateString);
+      });
+  });
 
-    t.equals(paymentAmountAlice.extent.length, 1);
-    t.equals(paymentAmountAlice.extent[0].seat, 1);
-    t.equals(paymentAmountAlice.extent[0].show, 'The Sofa');
-    t.equals(paymentAmountAlice.extent[0].start, startDateString);
-
-    // BOB SIDE
-    // Bob bought ticket 3 and 4 and has access to the balletTicketIssuer, because it's public
-    const myTicketPaymentBob = balletTicketIssuer.claim(paymentForBob);
-    const paymentAmountBob = balletTicketIssuer.getAmountOf(myTicketPaymentBob);
-
-    t.equals(paymentAmountBob.extent.length, 2);
-    t.equals(paymentAmountBob.extent[0].seat, 3);
-    t.equals(paymentAmountBob.extent[1].seat, 4);
-    t.equals(paymentAmountBob.extent[0].show, 'The Sofa');
-    t.equals(paymentAmountBob.extent[1].show, 'The Sofa');
-    t.equals(paymentAmountBob.extent[0].start, startDateString);
-    t.equals(paymentAmountBob.extent[1].start, startDateString);
-  } catch (e) {
-    t.assert(false, e);
-  } finally {
-    t.end();
-  }
+  // BOB SIDE
+  // Bob bought ticket 3 and 4 and has access to the balletTicketIssuer, because it's public
+  balletTicketIssuer.claim(paymentForBob).then(bobTicketPayment => {
+    balletTicketIssuer.getAmountOf(bobTicketPayment).then(paymentAmountBob => {
+      t.equals(paymentAmountBob.extent.length, 2);
+      t.equals(paymentAmountBob.extent[0].seat, 3);
+      t.equals(paymentAmountBob.extent[1].seat, 4);
+      t.equals(paymentAmountBob.extent[0].show, 'The Sofa');
+      t.equals(paymentAmountBob.extent[1].show, 'The Sofa');
+      t.equals(paymentAmountBob.extent[0].start, startDateString);
+      t.equals(paymentAmountBob.extent[1].start, startDateString);
+    });
+  });
 });

--- a/packages/spawner/src/contractHost.js
+++ b/packages/spawner/src/contractHost.js
@@ -38,12 +38,13 @@ function makeContractHost(E, evaluate, additionalEndowments = {}) {
   } = produceIssuer('contract host', 'set');
 
   function redeem(allegedInvitePayment) {
-    const inviteAmount = inviteIssuer.getAmountOf(allegedInvitePayment);
-    assert(!inviteAmountMath.isEmpty(inviteAmount), details`No invites left`);
-    const [{ seatIdentity }] = inviteAmountMath.getExtent(inviteAmount);
-    return Promise.resolve(
-      inviteIssuer.burn(allegedInvitePayment, inviteAmount),
-    ).then(_ => seats.get(seatIdentity));
+    return inviteIssuer.getAmountOf(allegedInvitePayment).then(inviteAmount => {
+      assert(!inviteAmountMath.isEmpty(inviteAmount), details`No invites left`);
+      const [{ seatIdentity }] = inviteAmountMath.getExtent(inviteAmount);
+      return Promise.resolve(
+        inviteIssuer.burn(allegedInvitePayment, inviteAmount),
+      ).then(_ => seats.get(seatIdentity));
+    });
   }
 
   const defaultEndowments = {

--- a/packages/spawner/test/swingsetTests/contractHost/bootstrap.js
+++ b/packages/spawner/test/swingsetTests/contractHost/bootstrap.js
@@ -65,14 +65,12 @@ function build(E, log) {
         const fooInviteP = E(installationP).spawn('foo terms');
 
         const inviteIssuerP = E(host).getInviteIssuer();
-
         return Promise.resolve(
           showPaymentBalance('foo', inviteIssuerP, fooInviteP),
         ).then(_ => {
           const eightP = E(host).redeem(fooInviteP);
 
           eightP.then(res => {
-            showPaymentBalance('foo', inviteIssuerP, fooInviteP);
             log('++ eightP resolved to ', res, ' (should be 8)');
             if (res !== 8) {
               throw new Error(`eightP resolved to ${res}, not 8`);

--- a/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
+++ b/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
@@ -11,477 +11,449 @@ import { setup } from '../setupBasicMints';
 const automaticRefundRoot = `${__dirname}/../../../src/contracts/automaticRefund`;
 
 test('zoe - simplest automaticRefund', async t => {
-  try {
-    // Setup zoe and mints
-    const { issuers, mints, moola } = setup();
-    const [moolaIssuer] = issuers;
-    const [moolaMint] = mints;
-    const zoe = makeZoe({ require });
-    // Pack the contract.
-    const { source, moduleFormat } = await bundleSource(automaticRefundRoot);
-    const installationHandle = zoe.install(source, moduleFormat);
+  t.plan(1);
 
-    // Setup Alice
-    const aliceMoolaPayment = moolaMint.mintPayment(moola(3));
+  // Setup zoe and mints
+  const { issuers, mints, moola } = setup();
+  const [moolaIssuer] = issuers;
+  const [moolaMint] = mints;
+  const zoe = makeZoe({ require });
+  // Pack the contract.
+  const { source, moduleFormat } = await bundleSource(automaticRefundRoot);
+  const installationHandle = zoe.install(source, moduleFormat);
 
-    // 1: Alice creates an automatic refund instance
-    const invite = await zoe.makeInstance(installationHandle, {
-      issuers: harden([moolaIssuer]),
-    });
+  // Setup Alice
+  const aliceMoolaPayment = moolaMint.mintPayment(moola(3));
 
-    const aliceOfferRules = harden({
-      payoutRules: [
-        {
-          kind: 'offerAtMost',
-          amount: moola(3),
-        },
-      ],
-      exitRule: {
-        kind: 'onDemand',
+  // 1: Alice creates an automatic refund instance
+  const invite = await zoe.makeInstance(installationHandle, {
+    issuers: harden([moolaIssuer]),
+  });
+
+  const aliceOfferRules = harden({
+    payoutRules: [
+      {
+        kind: 'offerAtMost',
+        amount: moola(3),
       },
-    });
-    const alicePayments = [aliceMoolaPayment];
+    ],
+    exitRule: {
+      kind: 'onDemand',
+    },
+  });
+  const alicePayments = [aliceMoolaPayment];
 
-    const { seat, payout: payoutP } = await zoe.redeem(
-      invite,
-      aliceOfferRules,
-      alicePayments,
-    );
+  const { seat, payout: payoutP } = await zoe.redeem(
+    invite,
+    aliceOfferRules,
+    alicePayments,
+  );
 
-    seat.makeOffer();
-    const alicePayout = await payoutP;
-    const aliceMoolaPayout = await alicePayout[0];
+  seat.makeOffer();
+  const alicePayout = await payoutP;
+  const aliceMoolaPayout = await alicePayout[0];
 
-    // Alice got back what she put in
-    t.deepEquals(
-      moolaIssuer.getAmountOf(aliceMoolaPayout),
-      aliceOfferRules.payoutRules[0].amount,
-    );
-  } catch (e) {
-    t.assert(false, e);
-    console.log(e);
-  } finally {
-    t.end();
-  }
+  // Alice got back what she put in
+  moolaIssuer.getAmountOf(aliceMoolaPayout).then(moolaAmount => {
+    t.deepEquals(moolaAmount, aliceOfferRules.payoutRules[0].amount);
+  });
 });
 
 test('zoe - automaticRefund same issuer', async t => {
-  try {
-    // Setup zoe and mints
-    const { issuers, moola } = setup();
-    const [moolaIssuer] = issuers;
-    const zoe = makeZoe({ require });
-    // Pack the contract.
-    const { source, moduleFormat } = await bundleSource(automaticRefundRoot);
-    const installationHandle = zoe.install(source, moduleFormat);
+  t.plan(1);
 
-    // 1: Alice creates an automatic refund instance
-    const invite = await zoe.makeInstance(installationHandle, {
-      issuers: harden([moolaIssuer, moolaIssuer]),
-    });
-    const aliceOfferRules = harden({
-      payoutRules: [
-        {
-          kind: 'wantAtLeast',
-          amount: moola(0),
-        },
-        {
-          kind: 'wantAtLeast',
-          amount: moola(0),
-        },
-      ],
-      exitRule: {
-        kind: 'onDemand',
+  // Setup zoe and mints
+  const { issuers, moola } = setup();
+  const [moolaIssuer] = issuers;
+  const zoe = makeZoe({ require });
+  // Pack the contract.
+  const { source, moduleFormat } = await bundleSource(automaticRefundRoot);
+  const installationHandle = zoe.install(source, moduleFormat);
+
+  // 1: Alice creates an automatic refund instance
+  const invite = await zoe.makeInstance(installationHandle, {
+    issuers: harden([moolaIssuer, moolaIssuer]),
+  });
+  const aliceOfferRules = harden({
+    payoutRules: [
+      {
+        kind: 'wantAtLeast',
+        amount: moola(0),
       },
-    });
-    const alicePayments = [undefined, undefined];
+      {
+        kind: 'wantAtLeast',
+        amount: moola(0),
+      },
+    ],
+    exitRule: {
+      kind: 'onDemand',
+    },
+  });
+  const alicePayments = [undefined, undefined];
 
-    const { seat, payout: payoutP } = await zoe.redeem(
-      invite,
-      aliceOfferRules,
-      alicePayments,
-    );
+  const { seat, payout: payoutP } = await zoe.redeem(
+    invite,
+    aliceOfferRules,
+    alicePayments,
+  );
 
-    seat.makeOffer();
-    const alicePayout = await payoutP;
-    const aliceMoolaPayout = await alicePayout[0];
+  seat.makeOffer();
+  const alicePayout = await payoutP;
+  const aliceMoolaPayout = await alicePayout[0];
 
-    // Alice got back what she put in
-    t.deepEquals(
-      moolaIssuer.getAmountOf(aliceMoolaPayout),
-      aliceOfferRules.payoutRules[0].amount,
-    );
-  } catch (e) {
-    t.assert(false, e);
-    console.log(e);
-  } finally {
-    t.end();
-  }
+  // Alice got back what she put in
+  moolaIssuer.getAmountOf(aliceMoolaPayout).then(moolaAmount => {
+    t.deepEquals(moolaAmount, aliceOfferRules.payoutRules[0].amount);
+  });
 });
 
 test('zoe with automaticRefund', async t => {
-  try {
-    // Setup zoe and mints
-    const {
-      issuers: defaultIssuers,
-      mints,
-      amountMaths,
-      moola,
-      simoleans,
-    } = setup();
-    const issuers = defaultIssuers.slice(0, 2);
-    const zoe = makeZoe({ require });
-    const inviteIssuer = zoe.getInviteIssuer();
+  t.plan(10);
 
-    // Setup Alice
-    const aliceMoolaPayment = mints[0].mintPayment(amountMaths[0].make(3));
-    const aliceMoolaPurse = issuers[0].makeEmptyPurse();
-    const aliceSimoleanPurse = issuers[1].makeEmptyPurse();
+  // Setup zoe and mints
+  const {
+    issuers: defaultIssuers,
+    mints,
+    amountMaths,
+    moola,
+    simoleans,
+  } = setup();
+  const issuers = defaultIssuers.slice(0, 2);
+  const zoe = makeZoe({ require });
+  const inviteIssuer = zoe.getInviteIssuer();
 
-    // Setup Bob
-    const bobMoolaPurse = issuers[0].makeEmptyPurse();
-    const bobSimoleanPurse = issuers[1].makeEmptyPurse();
-    const bobSimoleanPayment = mints[1].mintPayment(amountMaths[1].make(17));
+  // Setup Alice
+  const aliceMoolaPayment = mints[0].mintPayment(amountMaths[0].make(3));
+  const aliceMoolaPurse = issuers[0].makeEmptyPurse();
+  const aliceSimoleanPurse = issuers[1].makeEmptyPurse();
 
-    // Pack the contract.
-    const { source, moduleFormat } = await bundleSource(automaticRefundRoot);
+  // Setup Bob
+  const bobMoolaPurse = issuers[0].makeEmptyPurse();
+  const bobSimoleanPurse = issuers[1].makeEmptyPurse();
+  const bobSimoleanPayment = mints[1].mintPayment(amountMaths[1].make(17));
 
-    // 1: Alice creates an automatic refund instance
-    const installationHandle = zoe.install(source, moduleFormat);
-    const terms = harden({
-      issuers,
-    });
-    const aliceInvite = await zoe.makeInstance(installationHandle, terms);
-    const { publicAPI } = zoe.getInstance(
-      inviteIssuer.getAmountOf(aliceInvite).extent[0].instanceHandle,
-    );
+  // Pack the contract.
+  const { source, moduleFormat } = await bundleSource(automaticRefundRoot);
 
-    // 2: Alice escrows with zoe
-    const aliceOfferRules = harden({
-      payoutRules: [
-        {
-          kind: 'offerAtMost',
-          amount: moola(3),
-        },
-        {
-          kind: 'wantAtLeast',
-          amount: simoleans(7),
-        },
-      ],
-      exitRule: {
-        kind: 'onDemand',
+  // 1: Alice creates an automatic refund instance
+  const installationHandle = zoe.install(source, moduleFormat);
+  const terms = harden({
+    issuers,
+  });
+  const aliceInvite = await zoe.makeInstance(installationHandle, terms);
+  const aliceInviteAmount = await inviteIssuer.getAmountOf(aliceInvite);
+  const { publicAPI } = zoe.getInstance(
+    aliceInviteAmount.extent[0].instanceHandle,
+  );
+
+  // 2: Alice escrows with zoe
+  const aliceOfferRules = harden({
+    payoutRules: [
+      {
+        kind: 'offerAtMost',
+        amount: moola(3),
       },
-    });
-    const alicePayments = [aliceMoolaPayment, undefined];
-
-    // Alice gets two kinds of things back: a seat which she can use
-    // interact with the contract, and a payout promise
-    // that resolves to the array of promises for payments
-    const { seat: aliceSeat, payout: alicePayoutP } = await zoe.redeem(
-      aliceInvite,
-      aliceOfferRules,
-      alicePayments,
-    );
-
-    // In the 'automaticRefund' trivial contract, you just get your
-    // payoutRules back when you make an offer. The effect of calling
-    // makeOffer will vary widely depending on the smart  contract.
-    const aliceOutcome = aliceSeat.makeOffer();
-    const bobInvite = publicAPI.makeInvite();
-    const count = publicAPI.getOffersCount();
-    t.equals(count, 1);
-
-    // Imagine that Alice has shared the bobInvite with Bob. He
-    // will do a claim on the invite with the Zoe invite issuer and
-    // will check that the installationId and terms match what he
-    // expects
-    const exclusBobInvite = await inviteIssuer.claim(bobInvite);
-    const { instanceHandle } = inviteIssuer.getAmountOf(
-      exclusBobInvite,
-    ).extent[0];
-
-    const {
-      installationHandle: bobInstallationId,
-      terms: bobTerms,
-    } = zoe.getInstance(instanceHandle);
-    t.equals(bobInstallationId, installationHandle);
-    const bobIssuers = bobTerms.issuers;
-
-    // bob wants to know what issuers this contract is about and in
-    // what order. Is it what he expects?
-    t.deepEquals(bobIssuers, issuers);
-
-    // 6: Bob also wants to get an automaticRefund (why? we don't
-    // know) so he escrows his offer and his offer payments.
-
-    const bobOfferRules = harden({
-      payoutRules: [
-        {
-          kind: 'wantAtLeast',
-          amount: moola(15),
-        },
-        {
-          kind: 'offerAtMost',
-          amount: simoleans(17),
-        },
-      ],
-      exitRule: {
-        kind: 'onDemand',
+      {
+        kind: 'wantAtLeast',
+        amount: simoleans(7),
       },
-    });
-    const bobPayments = [undefined, bobSimoleanPayment];
+    ],
+    exitRule: {
+      kind: 'onDemand',
+    },
+  });
+  const alicePayments = [aliceMoolaPayment, undefined];
 
-    // Bob also gets two things back: a seat and a
-    // payout
-    const { seat: bobSeat, payout: bobPayoutP } = await zoe.redeem(
-      exclusBobInvite,
-      bobOfferRules,
-      bobPayments,
-    );
-    const bobOutcome = bobSeat.makeOffer();
+  // Alice gets two kinds of things back: a seat which she can use
+  // interact with the contract, and a payout promise
+  // that resolves to the array of promises for payments
+  const { seat: aliceSeat, payout: alicePayoutP } = await zoe.redeem(
+    aliceInvite,
+    aliceOfferRules,
+    alicePayments,
+  );
 
-    t.equals(aliceOutcome, 'The offer was accepted');
-    t.equals(bobOutcome, 'The offer was accepted');
+  // In the 'automaticRefund' trivial contract, you just get your
+  // payoutRules back when you make an offer. The effect of calling
+  // makeOffer will vary widely depending on the smart  contract.
+  const aliceOutcome = aliceSeat.makeOffer();
+  const bobInvite = publicAPI.makeInvite();
+  const count = publicAPI.getOffersCount();
+  t.equals(count, 1);
 
-    // These promise resolve when the offer completes, but it may
-    // still take longer for a remote issuer to actually make the
-    // payments, so we need to wait for those promises to resolve
-    // separately.
+  // Imagine that Alice has shared the bobInvite with Bob. He
+  // will do a claim on the invite with the Zoe invite issuer and
+  // will check that the installationId and terms match what he
+  // expects
+  const exclusBobInvite = await inviteIssuer.claim(bobInvite);
+  const bobInviteAmount = await inviteIssuer.getAmountOf(exclusBobInvite);
+  const { instanceHandle } = bobInviteAmount.extent[0];
 
-    // offer completes
-    const alicePayout = await alicePayoutP;
-    const bobPayout = await bobPayoutP;
-    const [aliceMoolaPayout, aliceSimoleanPayout] = await Promise.all(
-      alicePayout,
-    );
-    const [bobMoolaPayout, bobSimoleanPayout] = await Promise.all(bobPayout);
+  const {
+    installationHandle: bobInstallationId,
+    terms: bobTerms,
+  } = zoe.getInstance(instanceHandle);
+  t.equals(bobInstallationId, installationHandle);
+  const bobIssuers = bobTerms.issuers;
 
-    // Alice got back what she put in
-    t.deepEquals(
-      issuers[0].getAmountOf(aliceMoolaPayout),
-      aliceOfferRules.payoutRules[0].amount,
-    );
+  // bob wants to know what issuers this contract is about and in
+  // what order. Is it what he expects?
+  t.deepEquals(bobIssuers, issuers);
 
-    // Alice didn't get any of what she wanted
-    t.deepEquals(issuers[1].getAmountOf(aliceSimoleanPayout), simoleans(0));
+  // 6: Bob also wants to get an automaticRefund (why? we don't
+  // know) so he escrows his offer and his offer payments.
 
-    // 9: Alice deposits her refund to ensure she can
-    await aliceMoolaPurse.deposit(aliceMoolaPayout);
-    await aliceSimoleanPurse.deposit(aliceSimoleanPayout);
+  const bobOfferRules = harden({
+    payoutRules: [
+      {
+        kind: 'wantAtLeast',
+        amount: moola(15),
+      },
+      {
+        kind: 'offerAtMost',
+        amount: simoleans(17),
+      },
+    ],
+    exitRule: {
+      kind: 'onDemand',
+    },
+  });
+  const bobPayments = [undefined, bobSimoleanPayment];
 
-    // 10: Bob deposits his refund to ensure he can
-    await bobMoolaPurse.deposit(bobMoolaPayout);
-    await bobSimoleanPurse.deposit(bobSimoleanPayout);
+  // Bob also gets two things back: a seat and a
+  // payout
+  const { seat: bobSeat, payout: bobPayoutP } = await zoe.redeem(
+    exclusBobInvite,
+    bobOfferRules,
+    bobPayments,
+  );
+  const bobOutcome = bobSeat.makeOffer();
 
-    // Assert that the correct refund was achieved.
-    // Alice had 3 moola and 0 simoleans.
-    // Bob had 0 moola and 7 simoleans.
-    t.equals(aliceMoolaPurse.getCurrentAmount().extent, 3);
-    t.equals(aliceSimoleanPurse.getCurrentAmount().extent, 0);
-    t.equals(bobMoolaPurse.getCurrentAmount().extent, 0);
-    t.equals(bobSimoleanPurse.getCurrentAmount().extent, 17);
-  } catch (e) {
-    t.assert(false, e);
-    console.log(e);
-  } finally {
-    t.end();
-  }
+  t.equals(aliceOutcome, 'The offer was accepted');
+  t.equals(bobOutcome, 'The offer was accepted');
+
+  // These promise resolve when the offer completes, but it may
+  // still take longer for a remote issuer to actually make the
+  // payments, so we need to wait for those promises to resolve
+  // separately.
+
+  // offer completes
+  const alicePayout = await alicePayoutP;
+  const bobPayout = await bobPayoutP;
+  const [aliceMoolaPayout, aliceSimoleanPayout] = await Promise.all(
+    alicePayout,
+  );
+  const [bobMoolaPayout, bobSimoleanPayout] = await Promise.all(bobPayout);
+
+  // Alice got back what she put in
+  issuers[0].getAmountOf(aliceMoolaPayout).then(aliceMoolaAmount => {
+    t.deepEquals(aliceMoolaAmount, aliceOfferRules.payoutRules[0].amount);
+  });
+
+  // Alice didn't get any of what she wanted
+  issuers[1].getAmountOf(aliceSimoleanPayout).then(aliceSimoleanAmount => {
+    t.deepEquals(aliceSimoleanAmount, simoleans(0));
+  });
+
+  // 9: Alice deposits her refund to ensure she can
+  await aliceMoolaPurse.deposit(aliceMoolaPayout);
+  await aliceSimoleanPurse.deposit(aliceSimoleanPayout);
+
+  // 10: Bob deposits his refund to ensure he can
+  await bobMoolaPurse.deposit(bobMoolaPayout);
+  await bobSimoleanPurse.deposit(bobSimoleanPayout);
+
+  // Assert that the correct refund was achieved.
+  // Alice had 3 moola and 0 simoleans.
+  // Bob had 0 moola and 7 simoleans.
+  t.equals(aliceMoolaPurse.getCurrentAmount().extent, 3);
+  t.equals(aliceSimoleanPurse.getCurrentAmount().extent, 0);
+  t.equals(bobMoolaPurse.getCurrentAmount().extent, 0);
+  t.equals(bobSimoleanPurse.getCurrentAmount().extent, 17);
 });
 
 test('multiple instances of automaticRefund for the same Zoe', async t => {
-  try {
-    // Setup zoe and mints
-    const { issuers: originalIssuers, mints, moola, simoleans } = setup();
-    const issuers = originalIssuers.slice(0, 2);
-    const zoe = makeZoe({ require });
+  t.plan(6);
 
-    // Setup Alice
-    const aliceMoolaPayment = mints[0].mintPayment(moola(30));
-    const moola10 = moola(10);
-    const aliceMoolaPayments = issuers[0].splitMany(aliceMoolaPayment, [
-      moola10,
-      moola10,
-      moola10,
-    ]);
+  // Setup zoe and mints
+  const { issuers: originalIssuers, mints, moola, simoleans } = setup();
+  const issuers = originalIssuers.slice(0, 2);
+  const zoe = makeZoe({ require });
 
-    // 1: Alice creates 3 automatic refund instances
-    // Pack the contract.
-    const { source, moduleFormat } = await bundleSource(automaticRefundRoot);
+  // Setup Alice
+  const aliceMoolaPayment = mints[0].mintPayment(moola(30));
+  const moola10 = moola(10);
+  const aliceMoolaPayments = await issuers[0].splitMany(aliceMoolaPayment, [
+    moola10,
+    moola10,
+    moola10,
+  ]);
 
-    const installationHandle = zoe.install(source, moduleFormat);
-    const terms = harden({
-      issuers,
-    });
-    const inviteIssuer = zoe.getInviteIssuer();
-    const aliceInvite1 = await zoe.makeInstance(installationHandle, terms);
-    const { publicAPI: publicAPI1 } = zoe.getInstance(
-      inviteIssuer.getAmountOf(aliceInvite1).extent[0].instanceHandle,
+  // 1: Alice creates 3 automatic refund instances
+  // Pack the contract.
+  const { source, moduleFormat } = await bundleSource(automaticRefundRoot);
+
+  const installationHandle = zoe.install(source, moduleFormat);
+  const terms = harden({
+    issuers,
+  });
+  const inviteIssuer = zoe.getInviteIssuer();
+  const aliceInvite1 = await zoe.makeInstance(installationHandle, terms);
+  const { publicAPI: publicAPI1 } = await inviteIssuer
+    .getAmountOf(aliceInvite1)
+    .then(invite1Amount =>
+      zoe.getInstance(invite1Amount.extent[0].instanceHandle),
     );
 
-    const aliceInvite2 = await zoe.makeInstance(installationHandle, terms);
-    const { publicAPI: publicAPI2 } = zoe.getInstance(
-      inviteIssuer.getAmountOf(aliceInvite2).extent[0].instanceHandle,
+  const aliceInvite2 = await zoe.makeInstance(installationHandle, terms);
+  const { publicAPI: publicAPI2 } = await inviteIssuer
+    .getAmountOf(aliceInvite2)
+    .then(invite2Amount =>
+      zoe.getInstance(invite2Amount.extent[0].instanceHandle),
     );
 
-    const aliceInvite3 = await zoe.makeInstance(installationHandle, terms);
-    const { publicAPI: publicAPI3 } = zoe.getInstance(
-      inviteIssuer.getAmountOf(aliceInvite3).extent[0].instanceHandle,
+  const aliceInvite3 = await zoe.makeInstance(installationHandle, terms);
+  const { publicAPI: publicAPI3 } = await inviteIssuer
+    .getAmountOf(aliceInvite3)
+    .then(invite3Amount =>
+      zoe.getInstance(invite3Amount.extent[0].instanceHandle),
     );
 
-    // 2: Alice escrows with zoe
-    const aliceOfferRules = harden({
-      payoutRules: [
-        {
-          kind: 'offerAtMost',
-          amount: moola(10),
-        },
-        {
-          kind: 'wantAtLeast',
-          amount: simoleans(7),
-        },
-      ],
-      exitRule: {
-        kind: 'onDemand',
+  // 2: Alice escrows with zoe
+  const aliceOfferRules = harden({
+    payoutRules: [
+      {
+        kind: 'offerAtMost',
+        amount: moola(10),
       },
-    });
+      {
+        kind: 'wantAtLeast',
+        amount: simoleans(7),
+      },
+    ],
+    exitRule: {
+      kind: 'onDemand',
+    },
+  });
 
-    const {
-      seat: aliceSeat1,
-      payout: payoutP1,
-    } = await zoe.redeem(aliceInvite1, aliceOfferRules, [
-      aliceMoolaPayments[0],
-      undefined,
-    ]);
+  const { seat: aliceSeat1, payout: payoutP1 } = await zoe.redeem(
+    aliceInvite1,
+    aliceOfferRules,
+    [aliceMoolaPayments[0], undefined],
+  );
 
-    // 3: Alice escrows with zoe
-    const {
-      seat: aliceSeat2,
-      payout: payoutP2,
-    } = await zoe.redeem(aliceInvite2, aliceOfferRules, [
-      aliceMoolaPayments[1],
-      undefined,
-    ]);
+  // 3: Alice escrows with zoe
+  const { seat: aliceSeat2, payout: payoutP2 } = await zoe.redeem(
+    aliceInvite2,
+    aliceOfferRules,
+    [aliceMoolaPayments[1], undefined],
+  );
 
-    // 4: Alice escrows with zoe
-    const {
-      seat: aliceSeat3,
-      payout: payoutP3,
-    } = await zoe.redeem(aliceInvite3, aliceOfferRules, [
-      aliceMoolaPayments[2],
-      undefined,
-    ]);
+  // 4: Alice escrows with zoe
+  const { seat: aliceSeat3, payout: payoutP3 } = await zoe.redeem(
+    aliceInvite3,
+    aliceOfferRules,
+    [aliceMoolaPayments[2], undefined],
+  );
 
-    // 5: Alice makes an offer
-    aliceSeat1.makeOffer();
-    aliceSeat2.makeOffer();
-    aliceSeat3.makeOffer();
+  // 5: Alice makes an offer
+  aliceSeat1.makeOffer();
+  aliceSeat2.makeOffer();
+  aliceSeat3.makeOffer();
 
-    const [moolaPayout1P] = await payoutP1;
-    const [moolaPayout2P] = await payoutP2;
-    const [moolaPayout3P] = await payoutP3;
+  const [moolaPayout1P] = await payoutP1;
+  const [moolaPayout2P] = await payoutP2;
+  const [moolaPayout3P] = await payoutP3;
 
-    const moolaPayout1 = await moolaPayout1P;
-    const moolaPayout2 = await moolaPayout2P;
-    const moolaPayout3 = await moolaPayout3P;
+  const moolaPayout1 = await moolaPayout1P;
+  const moolaPayout2 = await moolaPayout2P;
+  const moolaPayout3 = await moolaPayout3P;
 
-    // Ensure that she got what she put in for each
-    t.deepEquals(
-      issuers[0].getAmountOf(moolaPayout1),
-      aliceOfferRules.payoutRules[0].amount,
-    );
-    t.deepEquals(
-      issuers[0].getAmountOf(moolaPayout2),
-      aliceOfferRules.payoutRules[0].amount,
-    );
-    t.deepEquals(
-      issuers[0].getAmountOf(moolaPayout3),
-      aliceOfferRules.payoutRules[0].amount,
-    );
+  // Ensure that she got what she put in for each
+  issuers[0].getAmountOf(moolaPayout1).then(payout1Amount => {
+    t.deepEquals(payout1Amount, aliceOfferRules.payoutRules[0].amount);
+  });
+  issuers[0].getAmountOf(moolaPayout2).then(payout2Amount => {
+    t.deepEquals(payout2Amount, aliceOfferRules.payoutRules[0].amount);
+  });
+  issuers[0].getAmountOf(moolaPayout3).then(payout3Amount => {
+    t.deepEquals(payout3Amount, aliceOfferRules.payoutRules[0].amount);
+  });
 
-    // Ensure that the number of offers received by each instance is one
-    t.equals(publicAPI1.getOffersCount(), 1);
-    t.equals(publicAPI2.getOffersCount(), 1);
-    t.equals(publicAPI3.getOffersCount(), 1);
-  } catch (e) {
-    t.assert(false, e);
-    console.log(e);
-  } finally {
-    t.end();
-  }
+  // Ensure that the number of offers received by each instance is one
+  t.equals(publicAPI1.getOffersCount(), 1);
+  t.equals(publicAPI2.getOffersCount(), 1);
+  t.equals(publicAPI3.getOffersCount(), 1);
 });
 
 test('zoe - alice cancels after completion', async t => {
-  try {
-    // Setup zoe and mints
-    const { issuers: defaultIssuers, mints, moola, simoleans } = setup();
-    const issuers = defaultIssuers.slice(0, 2);
-    const zoe = makeZoe({ require });
+  t.plan(4);
 
-    // Setup Alice
-    const aliceMoolaPayment = mints[0].mintPayment(moola(3));
-    const aliceMoolaPurse = issuers[0].makeEmptyPurse();
-    const aliceSimoleanPurse = issuers[1].makeEmptyPurse();
+  // Setup zoe and mints
+  const { issuers: defaultIssuers, mints, moola, simoleans } = setup();
+  const issuers = defaultIssuers.slice(0, 2);
+  const zoe = makeZoe({ require });
 
-    // 2: Alice escrows with zoe
-    const aliceOfferRules = harden({
-      payoutRules: [
-        {
-          kind: 'offerAtMost',
-          amount: moola(3),
-        },
-        {
-          kind: 'wantAtLeast',
-          amount: simoleans(7),
-        },
-      ],
-      exitRule: {
-        kind: 'onDemand',
+  // Setup Alice
+  const aliceMoolaPayment = mints[0].mintPayment(moola(3));
+  const aliceMoolaPurse = issuers[0].makeEmptyPurse();
+  const aliceSimoleanPurse = issuers[1].makeEmptyPurse();
+
+  // 2: Alice escrows with zoe
+  const aliceOfferRules = harden({
+    payoutRules: [
+      {
+        kind: 'offerAtMost',
+        amount: moola(3),
       },
-    });
-    const alicePayments = [aliceMoolaPayment, undefined];
+      {
+        kind: 'wantAtLeast',
+        amount: simoleans(7),
+      },
+    ],
+    exitRule: {
+      kind: 'onDemand',
+    },
+  });
+  const alicePayments = [aliceMoolaPayment, undefined];
 
-    // Pack the contract.
-    const { source, moduleFormat } = await bundleSource(automaticRefundRoot);
-    const installationHandle = zoe.install(source, moduleFormat);
-    const terms = harden({
-      issuers,
-    });
-    const invite = await zoe.makeInstance(installationHandle, terms);
+  // Pack the contract.
+  const { source, moduleFormat } = await bundleSource(automaticRefundRoot);
+  const installationHandle = zoe.install(source, moduleFormat);
+  const terms = harden({
+    issuers,
+  });
+  const invite = await zoe.makeInstance(installationHandle, terms);
 
-    const { seat, cancelObj, payout: payoutP } = await zoe.redeem(
-      invite,
-      aliceOfferRules,
-      alicePayments,
-    );
+  const { seat, cancelObj, payout: payoutP } = await zoe.redeem(
+    invite,
+    aliceOfferRules,
+    alicePayments,
+  );
 
-    await seat.makeOffer();
+  await seat.makeOffer();
 
-    t.throws(() => cancelObj.cancel(), /Error: offer has already completed/);
+  t.throws(() => cancelObj.cancel(), /Error: offer has already completed/);
 
-    const payout = await payoutP;
-    const [moolaPayout, simoleanPayout] = await Promise.all(payout);
+  const payout = await payoutP;
+  const [moolaPayout, simoleanPayout] = await Promise.all(payout);
 
-    // Alice got back what she put in
-    t.deepEquals(
-      issuers[0].getAmountOf(moolaPayout),
-      aliceOfferRules.payoutRules[0].amount,
-    );
+  // Alice got back what she put in
+  issuers[0].getAmountOf(moolaPayout).then(aliceMoolaAmount => {
+    t.deepEquals(aliceMoolaAmount, aliceOfferRules.payoutRules[0].amount);
+  });
 
-    // Alice didn't get any of what she wanted
-    t.deepEquals(issuers[1].getAmountOf(simoleanPayout), simoleans(0));
+  // Alice didn't get any of what she wanted
+  issuers[1].getAmountOf(simoleanPayout).then(aliceSimoleanAmount => {
+    t.deepEquals(aliceSimoleanAmount, simoleans(0));
+  });
 
-    // 9: Alice deposits her refund to ensure she can
-    await aliceMoolaPurse.deposit(moolaPayout);
-    await aliceSimoleanPurse.deposit(simoleanPayout);
+  // 9: Alice deposits her refund to ensure she can
+  await aliceMoolaPurse.deposit(moolaPayout);
+  await aliceSimoleanPurse.deposit(simoleanPayout);
 
-    // Assert that the correct refund was achieved.
-    // Alice had 3 moola and 0 simoleans.
-    t.equals(aliceMoolaPurse.getCurrentAmount().extent, 3);
-    t.equals(aliceSimoleanPurse.getCurrentAmount().extent, 0);
-  } catch (e) {
-    t.assert(false, e);
-    console.log(e);
-  } finally {
-    t.end();
-  }
+  // Assert that the correct refund was achieved.
+  // Alice had 3 moola and 0 simoleans.
+  t.equals(aliceMoolaPurse.getCurrentAmount().extent, 3);
+  t.equals(aliceSimoleanPurse.getCurrentAmount().extent, 0);
 });

--- a/packages/zoe/test/unitTests/contracts/test-autoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-autoswap.js
@@ -11,284 +11,298 @@ import { setup } from '../setupBasicMints';
 const autoswapRoot = `${__dirname}/../../../src/contracts/autoswap`;
 
 test('autoSwap with valid offers', async t => {
-  try {
-    const { mints, issuers: defaultIssuers, moola, simoleans } = setup();
-    const issuers = defaultIssuers.slice(0, 2);
-    const zoe = makeZoe({ require });
-    const inviteIssuer = zoe.getInviteIssuer();
-    const [moolaIssuer, simoleanIssuer] = issuers;
-    const [moolaMint, simoleanMint] = mints;
+  t.plan(19);
 
-    // Setup Alice
-    const aliceMoolaPayment = moolaMint.mintPayment(moola(10));
-    // Let's assume that simoleans are worth 2x as much as moola
-    const aliceSimoleanPayment = simoleanMint.mintPayment(simoleans(5));
+  const { mints, issuers: defaultIssuers, moola, simoleans } = setup();
+  const issuers = defaultIssuers.slice(0, 2);
+  const zoe = makeZoe({ require });
+  const inviteIssuer = zoe.getInviteIssuer();
+  const [moolaIssuer, simoleanIssuer] = issuers;
+  const [moolaMint, simoleanMint] = mints;
 
-    // Setup Bob
-    const bobMoolaPayment = moolaMint.mintPayment(moola(3));
-    const bobSimoleanPayment = simoleanMint.mintPayment(simoleans(3));
+  // Setup Alice
+  const aliceMoolaPayment = moolaMint.mintPayment(moola(10));
+  // Let's assume that simoleans are worth 2x as much as moola
+  const aliceSimoleanPayment = simoleanMint.mintPayment(simoleans(5));
 
-    // Alice creates an autoswap instance
+  // Setup Bob
+  const bobMoolaPayment = moolaMint.mintPayment(moola(3));
+  const bobSimoleanPayment = simoleanMint.mintPayment(simoleans(3));
 
-    // Pack the contract.
-    const { source, moduleFormat } = await bundleSource(autoswapRoot);
+  // Alice creates an autoswap instance
 
-    const installationHandle = zoe.install(source, moduleFormat);
-    const aliceInvite = await zoe.makeInstance(installationHandle, {
-      issuers,
-    });
-    const { instanceHandle } = inviteIssuer.getAmountOf(aliceInvite).extent[0];
-    const { publicAPI } = zoe.getInstance(instanceHandle);
-    const liquidityIssuer = publicAPI.getLiquidityIssuer();
-    const liquidity = liquidityIssuer.getAmountMath().make;
+  // Pack the contract.
+  const { source, moduleFormat } = await bundleSource(autoswapRoot);
 
-    // Alice adds liquidity
-    // 10 moola = 5 simoleans at the time of the liquidity adding
-    // aka 2 moola = 1 simolean
-    const aliceOfferRules = harden({
-      payoutRules: [
-        {
-          kind: 'offerAtMost',
-          amount: moola(10),
-        },
-        {
-          kind: 'offerAtMost',
-          amount: simoleans(5),
-        },
-        {
-          kind: 'wantAtLeast',
-          amount: liquidity(10),
-        },
-      ],
-      exitRule: {
-        kind: 'onDemand',
+  const installationHandle = zoe.install(source, moduleFormat);
+  const aliceInvite = await zoe.makeInstance(installationHandle, {
+    issuers,
+  });
+  const aliceInviteAmount = await inviteIssuer.getAmountOf(aliceInvite);
+  const { instanceHandle } = aliceInviteAmount.extent[0];
+  const { publicAPI } = zoe.getInstance(instanceHandle);
+  const liquidityIssuer = publicAPI.getLiquidityIssuer();
+  const liquidity = liquidityIssuer.getAmountMath().make;
+
+  // Alice adds liquidity
+  // 10 moola = 5 simoleans at the time of the liquidity adding
+  // aka 2 moola = 1 simolean
+  const aliceOfferRules = harden({
+    payoutRules: [
+      {
+        kind: 'offerAtMost',
+        amount: moola(10),
       },
-    });
-    const alicePayments = [aliceMoolaPayment, aliceSimoleanPayment, undefined];
-
-    const {
-      seat: aliceSeat,
-      payout: aliceAddLiquidityPayoutP,
-    } = await zoe.redeem(aliceInvite, aliceOfferRules, alicePayments);
-
-    const liquidityOk = await aliceSeat.addLiquidity();
-    t.equals(liquidityOk, 'Added liquidity.');
-
-    const liquidityPayments = await aliceAddLiquidityPayoutP;
-    const liquidityPayout = await liquidityPayments[2];
-
-    t.deepEquals(liquidityIssuer.getAmountOf(liquidityPayout), liquidity(10));
-    t.deepEquals(publicAPI.getPoolAmounts(), [
-      moola(10),
-      simoleans(5),
-      liquidity(0),
-    ]);
-
-    // Alice creates an invite for autoswap and sends it to Bob
-    const bobInvite = publicAPI.makeInvite();
-
-    // Bob claims it
-    const bobExclInvite = await inviteIssuer.claim(bobInvite);
-    const bobInviteExtent = inviteIssuer.getAmountOf(bobExclInvite).extent[0];
-    const {
-      publicAPI: bobAutoswap,
-      installationHandle: bobInstallationId,
-    } = zoe.getInstance(bobInviteExtent.instanceHandle);
-    t.equals(bobInstallationId, installationHandle);
-
-    // Bob looks up the price of 3 moola in simoleans
-    const simoleanAmounts = bobAutoswap.getPrice(moola(3));
-    t.deepEquals(simoleanAmounts, simoleans(1));
-
-    // Bob escrows
-
-    const bobMoolaForSimOfferRules = harden({
-      payoutRules: [
-        {
-          kind: 'offerAtMost',
-          amount: moola(3),
-        },
-        {
-          kind: 'wantAtLeast',
-          amount: simoleans(1),
-        },
-        {
-          kind: 'wantAtLeast',
-          amount: liquidity(0),
-        },
-      ],
-      exitRule: {
-        kind: 'onDemand',
+      {
+        kind: 'offerAtMost',
+        amount: simoleans(5),
       },
-    });
-    const bobMoolaForSimPayments = [bobMoolaPayment, undefined, undefined];
-
-    const { seat: bobSeat, payout: bobPayoutP } = await zoe.redeem(
-      bobExclInvite,
-      bobMoolaForSimOfferRules,
-      bobMoolaForSimPayments,
-    );
-
-    // Bob swaps
-    const offerOk = bobSeat.swap();
-    t.equal(offerOk, 'Swap successfully completed.');
-
-    const bobPayout = await bobPayoutP;
-
-    const [bobMoolaPayout1, bobSimoleanPayout1] = await Promise.all(bobPayout);
-
-    t.deepEqual(moolaIssuer.getAmountOf(bobMoolaPayout1), moola(0));
-    t.deepEqual(simoleanIssuer.getAmountOf(bobSimoleanPayout1), simoleans(1));
-    t.deepEquals(bobAutoswap.getPoolAmounts(), [
-      moola(13),
-      simoleans(4),
-      liquidity(0),
-    ]);
-
-    // Bob looks up the price of 3 simoleans
-    const moolaAmounts = bobAutoswap.getPrice(simoleans(3));
-    t.deepEquals(moolaAmounts, moola(5));
-
-    // Bob makes another offer and swaps
-    const bobSecondInvite = bobAutoswap.makeInvite();
-    const bobSimsForMoolaOfferRules = harden({
-      payoutRules: [
-        {
-          kind: 'wantAtLeast',
-          amount: moola(5),
-        },
-        {
-          kind: 'offerAtMost',
-          amount: simoleans(3),
-        },
-        {
-          kind: 'wantAtLeast',
-          amount: liquidity(0),
-        },
-      ],
-      exitRule: {
-        kind: 'onDemand',
+      {
+        kind: 'wantAtLeast',
+        amount: liquidity(10),
       },
-    });
-    const simsForMoolaPayments = [undefined, bobSimoleanPayment, undefined];
+    ],
+    exitRule: {
+      kind: 'onDemand',
+    },
+  });
+  const alicePayments = [aliceMoolaPayment, aliceSimoleanPayment, undefined];
 
-    const {
-      seat: bobSeatSimsForMoola,
-      payout: bobSimsForMoolaPayoutP,
-    } = await zoe.redeem(
-      bobSecondInvite,
-      bobSimsForMoolaOfferRules,
-      simsForMoolaPayments,
-    );
+  const {
+    seat: aliceSeat,
+    payout: aliceAddLiquidityPayoutP,
+  } = await zoe.redeem(aliceInvite, aliceOfferRules, alicePayments);
 
-    const simsForMoolaOk = bobSeatSimsForMoola.swap();
-    t.equal(simsForMoolaOk, 'Swap successfully completed.');
+  const liquidityOk = await aliceSeat.addLiquidity();
+  t.equals(liquidityOk, 'Added liquidity.');
 
-    const bobsNewMoolaPayment = await bobSimsForMoolaPayoutP;
-    const [bobMoolaPayout2, bobSimoleanPayout2] = await Promise.all(
-      bobsNewMoolaPayment,
-    );
+  const liquidityPayments = await aliceAddLiquidityPayoutP;
+  const liquidityPayout = await liquidityPayments[2];
 
-    t.deepEqual(moolaIssuer.getAmountOf(bobMoolaPayout2), moola(5));
-    t.deepEqual(simoleanIssuer.getAmountOf(bobSimoleanPayout2), simoleans(0));
-    t.deepEqual(bobAutoswap.getPoolAmounts(), [
-      moola(8),
-      simoleans(7),
-      liquidity(0),
-    ]);
+  const liquidityAmount = await liquidityIssuer.getAmountOf(liquidityPayout);
+  t.deepEquals(liquidityAmount, liquidity(10));
+  t.deepEquals(publicAPI.getPoolAmounts(), [
+    moola(10),
+    simoleans(5),
+    liquidity(0),
+  ]);
 
-    // Alice removes her liquidity
-    // She's not picky...
-    const aliceSecondInvite = publicAPI.makeInvite();
-    const aliceRemoveLiquidityOfferRules = harden({
-      payoutRules: [
-        {
-          kind: 'wantAtLeast',
-          amount: moola(0),
-        },
-        {
-          kind: 'wantAtLeast',
-          amount: simoleans(0),
-        },
-        {
-          kind: 'offerAtMost',
-          amount: liquidity(10),
-        },
-      ],
-      exitRule: {
-        kind: 'onDemand',
+  // Alice creates an invite for autoswap and sends it to Bob
+  const bobInvite = publicAPI.makeInvite();
+
+  // Bob claims it
+  const bobExclInvite = await inviteIssuer.claim(bobInvite);
+  const bobExclInviteAmount = await inviteIssuer.getAmountOf(bobExclInvite);
+  const bobInviteExtent = bobExclInviteAmount.extent[0];
+  const {
+    publicAPI: bobAutoswap,
+    installationHandle: bobInstallationId,
+  } = zoe.getInstance(bobInviteExtent.instanceHandle);
+  t.equals(bobInstallationId, installationHandle);
+
+  // Bob looks up the price of 3 moola in simoleans
+  const simoleanAmounts = bobAutoswap.getPrice(moola(3));
+  t.deepEquals(simoleanAmounts, simoleans(1));
+
+  // Bob escrows
+
+  const bobMoolaForSimOfferRules = harden({
+    payoutRules: [
+      {
+        kind: 'offerAtMost',
+        amount: moola(3),
       },
-    });
+      {
+        kind: 'wantAtLeast',
+        amount: simoleans(1),
+      },
+      {
+        kind: 'wantAtLeast',
+        amount: liquidity(0),
+      },
+    ],
+    exitRule: {
+      kind: 'onDemand',
+    },
+  });
+  const bobMoolaForSimPayments = [bobMoolaPayment, undefined, undefined];
 
-    const {
-      seat: aliceRemoveLiquiditySeat,
-      payout: aliceRemoveLiquidityPayoutP,
-    } = await zoe.redeem(
-      aliceSecondInvite,
-      aliceRemoveLiquidityOfferRules,
-      harden([undefined, undefined, liquidityPayout]),
-    );
+  const { seat: bobSeat, payout: bobPayoutP } = await zoe.redeem(
+    bobExclInvite,
+    bobMoolaForSimOfferRules,
+    bobMoolaForSimPayments,
+  );
 
-    const removeLiquidityResult = aliceRemoveLiquiditySeat.removeLiquidity();
-    t.equals(removeLiquidityResult, 'Liquidity successfully removed.');
+  // Bob swaps
+  const offerOk = bobSeat.swap();
+  t.equal(offerOk, 'Swap successfully completed.');
 
-    const alicePayoutPayments = await aliceRemoveLiquidityPayoutP;
-    const [
-      aliceMoolaPayout,
-      aliceSimoleanPayout,
-      aliceLiquidityPayout,
-    ] = await Promise.all(alicePayoutPayments);
+  const bobPayout = await bobPayoutP;
 
-    t.deepEquals(moolaIssuer.getAmountOf(aliceMoolaPayout), moola(8));
-    t.deepEquals(simoleanIssuer.getAmountOf(aliceSimoleanPayout), simoleans(7));
-    t.deepEquals(
-      liquidityIssuer.getAmountOf(aliceLiquidityPayout),
-      liquidity(0),
-    );
-    t.deepEquals(publicAPI.getPoolAmounts(), [
-      moola(0),
-      simoleans(0),
-      liquidity(10),
-    ]);
-  } catch (e) {
-    t.assert(false, e);
-    console.log(e);
-  } finally {
-    t.end();
-  }
+  const [bobMoolaPayout1, bobSimoleanPayout1] = await Promise.all(bobPayout);
+
+  moolaIssuer.getAmountOf(bobMoolaPayout1).then(bobMoolaAmount1 => {
+    t.deepEqual(bobMoolaAmount1, moola(0));
+  });
+
+  simoleanIssuer.getAmountOf(bobSimoleanPayout1).then(bobSimoleanAmount => {
+    t.deepEqual(bobSimoleanAmount, simoleans(1));
+  });
+
+  t.deepEquals(bobAutoswap.getPoolAmounts(), [
+    moola(13),
+    simoleans(4),
+    liquidity(0),
+  ]);
+
+  // Bob looks up the price of 3 simoleans
+  const moolaAmounts = bobAutoswap.getPrice(simoleans(3));
+  t.deepEquals(moolaAmounts, moola(5));
+
+  // Bob makes another offer and swaps
+  const bobSecondInvite = bobAutoswap.makeInvite();
+  const bobSimsForMoolaOfferRules = harden({
+    payoutRules: [
+      {
+        kind: 'wantAtLeast',
+        amount: moola(5),
+      },
+      {
+        kind: 'offerAtMost',
+        amount: simoleans(3),
+      },
+      {
+        kind: 'wantAtLeast',
+        amount: liquidity(0),
+      },
+    ],
+    exitRule: {
+      kind: 'onDemand',
+    },
+  });
+  const simsForMoolaPayments = [undefined, bobSimoleanPayment, undefined];
+
+  const {
+    seat: bobSeatSimsForMoola,
+    payout: bobSimsForMoolaPayoutP,
+  } = await zoe.redeem(
+    bobSecondInvite,
+    bobSimsForMoolaOfferRules,
+    simsForMoolaPayments,
+  );
+
+  const simsForMoolaOk = bobSeatSimsForMoola.swap();
+  t.equal(simsForMoolaOk, 'Swap successfully completed.');
+
+  const bobsNewMoolaPayment = await bobSimsForMoolaPayoutP;
+  const [bobMoolaPayout2, bobSimoleanPayout2] = await Promise.all(
+    bobsNewMoolaPayment,
+  );
+
+  moolaIssuer.getAmountOf(bobMoolaPayout2).then(bobMoolaAmount2 => {
+    t.deepEqual(bobMoolaAmount2, moola(5), 'bob moola should be 5');
+  });
+  simoleanIssuer.getAmountOf(bobSimoleanPayout2).then(bobSimoleanAmount2 => {
+    t.deepEqual(bobSimoleanAmount2, simoleans(0));
+  });
+
+  t.deepEqual(bobAutoswap.getPoolAmounts(), [
+    moola(8),
+    simoleans(7),
+    liquidity(0),
+  ]);
+
+  // Alice removes her liquidity
+  // She's not picky...
+  const aliceSecondInvite = publicAPI.makeInvite();
+  const aliceRemoveLiquidityOfferRules = harden({
+    payoutRules: [
+      {
+        kind: 'wantAtLeast',
+        amount: moola(0),
+      },
+      {
+        kind: 'wantAtLeast',
+        amount: simoleans(0),
+      },
+      {
+        kind: 'offerAtMost',
+        amount: liquidity(10),
+      },
+    ],
+    exitRule: {
+      kind: 'onDemand',
+    },
+  });
+
+  const {
+    seat: aliceRemoveLiquiditySeat,
+    payout: aliceRemoveLiquidityPayoutP,
+  } = await zoe.redeem(
+    aliceSecondInvite,
+    aliceRemoveLiquidityOfferRules,
+    harden([undefined, undefined, liquidityPayout]),
+  );
+
+  const removeLiquidityResult = aliceRemoveLiquiditySeat.removeLiquidity();
+  t.equals(removeLiquidityResult, 'Liquidity successfully removed.');
+
+  const alicePayoutPayments = await aliceRemoveLiquidityPayoutP;
+  const [
+    aliceMoolaPayout,
+    aliceSimoleanPayout,
+    aliceLiquidityPayout,
+  ] = await Promise.all(alicePayoutPayments);
+
+  moolaIssuer.getAmountOf(aliceMoolaPayout).then(aliceMoolaAmount => {
+    t.deepEquals(aliceMoolaAmount, moola(8));
+  });
+  simoleanIssuer.getAmountOf(aliceSimoleanPayout).then(aliceSimoleanAmount => {
+    t.deepEquals(aliceSimoleanAmount, simoleans(7));
+  });
+  liquidityIssuer.getAmountOf(aliceLiquidityPayout).then(aliceLiqAmount => {
+    t.deepEquals(aliceLiqAmount, liquidity(0));
+  });
+
+  t.deepEquals(publicAPI.getPoolAmounts(), [
+    moola(0),
+    simoleans(0),
+    liquidity(10),
+  ]);
 });
 
 test('autoSwap - test fee', async t => {
-  try {
-    const {
-      mints: defaultMints,
-      issuers: defaultIssuers,
-      moola,
-      simoleans,
-    } = setup();
-    const mints = defaultMints.slice(0, 2);
-    const issuers = defaultIssuers.slice(0, 2);
-    const zoe = makeZoe({ require });
-    const inviteIssuer = zoe.getInviteIssuer();
-    const [moolaIssuer, simoleanIssuer] = issuers;
+  t.plan(9);
+  const {
+    mints: defaultMints,
+    issuers: defaultIssuers,
+    moola,
+    simoleans,
+  } = setup();
+  const mints = defaultMints.slice(0, 2);
+  const issuers = defaultIssuers.slice(0, 2);
+  const zoe = makeZoe({ require });
+  const inviteIssuer = zoe.getInviteIssuer();
+  const [moolaIssuer, simoleanIssuer] = issuers;
 
-    // Setup Alice
-    const aliceMoolaPayment = mints[0].mintPayment(moola(10000));
-    const aliceSimoleanPayment = mints[1].mintPayment(simoleans(10000));
+  // Setup Alice
+  const aliceMoolaPayment = mints[0].mintPayment(moola(10000));
+  const aliceSimoleanPayment = mints[1].mintPayment(simoleans(10000));
 
-    // Setup Bob
-    const bobMoolaPayment = mints[0].mintPayment(moola(1000));
+  // Setup Bob
+  const bobMoolaPayment = mints[0].mintPayment(moola(1000));
 
-    // Alice creates an autoswap instance
+  // Alice creates an autoswap instance
 
-    // Pack the contract.
-    const { source, moduleFormat } = await bundleSource(autoswapRoot);
+  // Pack the contract.
+  const { source, moduleFormat } = await bundleSource(autoswapRoot);
 
-    const installationHandle = zoe.install(source, moduleFormat);
-    const aliceInvite = await zoe.makeInstance(installationHandle, {
-      issuers,
-    });
-    const { instanceHandle } = inviteIssuer.getAmountOf(aliceInvite).extent[0];
+  const installationHandle = zoe.install(source, moduleFormat);
+  const aliceInvite = await zoe.makeInstance(installationHandle, {
+    issuers,
+  });
+  inviteIssuer.getAmountOf(aliceInvite).then(async aliceInviteAmount => {
+    const { instanceHandle } = aliceInviteAmount.extent[0];
     const { publicAPI } = zoe.getInstance(instanceHandle);
     const liquidityIssuer = publicAPI.getLiquidityIssuer();
     const liquidity = liquidityIssuer.getAmountMath().make;
@@ -326,10 +340,10 @@ test('autoSwap - test fee', async t => {
     const liquidityPayments = await aliceAddLiquidityPayoutP;
     const liquidityPayout = await liquidityPayments[2];
 
-    t.deepEquals(
-      liquidityIssuer.getAmountOf(liquidityPayout),
-      liquidity(10000),
-    );
+    liquidityIssuer.getAmountOf(liquidityPayout).then(liquidityAmount => {
+      t.deepEquals(liquidityAmount, liquidity(10000));
+    });
+
     t.deepEquals(publicAPI.getPoolAmounts(), [
       moola(10000),
       simoleans(10000),
@@ -341,7 +355,8 @@ test('autoSwap - test fee', async t => {
 
     // Bob claims it
     const bobExclInvite = await inviteIssuer.claim(bobInvite);
-    const bobInviteExtent = inviteIssuer.getAmountOf(bobExclInvite).extent[0];
+    const bobExclAmount = await inviteIssuer.getAmountOf(bobExclInvite);
+    const bobInviteExtent = bobExclAmount.extent[0];
     const {
       publicAPI: bobAutoswap,
       installationHandle: bobInstallationId,
@@ -387,17 +402,17 @@ test('autoSwap - test fee', async t => {
     const bobPayout = await bobPayoutP;
     const [bobMoolaPayout, bobSimoleanPayout] = await Promise.all(bobPayout);
 
-    t.deepEqual(moolaIssuer.getAmountOf(bobMoolaPayout), moola(0));
-    t.deepEqual(simoleanIssuer.getAmountOf(bobSimoleanPayout), simoleans(906));
+    moolaIssuer.getAmountOf(bobMoolaPayout).then(bobMoolaAmount => {
+      t.deepEqual(bobMoolaAmount, moola(0));
+    });
+    simoleanIssuer.getAmountOf(bobSimoleanPayout).then(bobSimoleanAmount => {
+      t.deepEqual(bobSimoleanAmount, simoleans(906));
+    });
+
     t.deepEquals(bobAutoswap.getPoolAmounts(), [
       moola(11000),
       simoleans(9094),
       liquidity(0),
     ]);
-  } catch (e) {
-    t.assert(false, e);
-    console.log(e);
-  } finally {
-    t.end();
-  }
+  });
 });

--- a/packages/zoe/test/unitTests/contracts/test-publicAuction.js
+++ b/packages/zoe/test/unitTests/contracts/test-publicAuction.js
@@ -51,7 +51,8 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
       numBidsAllowed,
     });
 
-    const [{ instanceHandle }] = inviteIssuer.getAmountOf(aliceInvite).extent;
+    const aliceInviteAmount = await inviteIssuer.getAmountOf(aliceInvite);
+    const [{ instanceHandle }] = aliceInviteAmount.extent;
     const { publicAPI } = zoe.getInstance(instanceHandle);
 
     // Alice escrows with zoe
@@ -89,8 +90,8 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
     // Alice spreads the invites far and wide and Bob decides he
     // wants to participate in the auction.
     const bobExclusiveInvite = await inviteIssuer.claim(bobInvite);
-    const bobInviteExtent = inviteIssuer.getAmountOf(bobExclusiveInvite)
-      .extent[0];
+    const bobExclInvAmount = await inviteIssuer.getAmountOf(bobExclusiveInvite);
+    const bobInviteExtent = bobExclInvAmount.extent[0];
 
     const {
       installationHandle: bobInstallationId,
@@ -137,8 +138,8 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
     // Carol decides to bid for the one moola
 
     const carolExclusiveInvite = await inviteIssuer.claim(carolInvite);
-    const carolInviteExtent = inviteIssuer.getAmountOf(carolExclusiveInvite)
-      .extent[0];
+    const carolExclAmt = await inviteIssuer.getAmountOf(carolExclusiveInvite);
+    const carolInviteExtent = carolExclAmt.extent[0];
 
     const {
       installationHandle: carolInstallationId,
@@ -184,8 +185,8 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
 
     // Dave decides to bid for the one moola
     const daveExclusiveInvite = await inviteIssuer.claim(daveInvite);
-    const daveInviteExtent = inviteIssuer.getAmountOf(daveExclusiveInvite)
-      .extent[0];
+    const daveExclAmount = await inviteIssuer.getAmountOf(daveExclusiveInvite);
+    const daveInviteExtent = daveExclAmount.extent[0];
 
     const {
       installationHandle: daveInstallationId,
@@ -244,13 +245,12 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
     const [daveMoolaPayout, daveSimoleanPayout] = await Promise.all(daveResult);
 
     // Alice (the creator of the auction) gets back the second highest bid
-    t.deepEquals(
-      simoleanIssuer.getAmountOf(aliceSimoleanPayout),
-      carolOfferRules.payoutRules[1].amount,
-    );
+    const aliceSimAmt = await simoleanIssuer.getAmountOf(aliceSimoleanPayout);
+    t.deepEquals(aliceSimAmt, carolOfferRules.payoutRules[1].amount);
 
     // Alice didn't get any of what she put in
-    t.deepEquals(moolaIssuer.getAmountOf(aliceMoolaPayout), moola(0));
+    const aliceMoolaAmount = await moolaIssuer.getAmountOf(aliceMoolaPayout);
+    t.deepEquals(aliceMoolaAmount, moola(0));
 
     // Alice deposits her payout to ensure she can
     await aliceMoolaPurse.deposit(aliceMoolaPayout);
@@ -258,29 +258,28 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
 
     // Bob (the winner of the auction) gets the one moola and the
     // difference between his bid and the price back
-    t.deepEquals(moolaIssuer.getAmountOf(bobMoolaPayout), moola(1));
-    t.deepEquals(simoleanIssuer.getAmountOf(bobSimoleanPayout), simoleans(4));
+    const bobMoolaAmount = await moolaIssuer.getAmountOf(bobMoolaPayout);
+    t.deepEquals(bobMoolaAmount, moola(1));
+    const bobSimAmount = await simoleanIssuer.getAmountOf(bobSimoleanPayout);
+    t.deepEquals(bobSimAmount, simoleans(4));
 
     // Bob deposits his payout to ensure he can
     await bobMoolaPurse.deposit(bobMoolaPayout);
     await bobSimoleanPurse.deposit(bobSimoleanPayout);
 
     // Carol gets a full refund
-    t.deepEquals(moolaIssuer.getAmountOf(carolMoolaPayout), moola(0));
-    t.deepEquals(
-      simoleanIssuer.getAmountOf(carolSimoleanPayout),
-      carolOfferRules.payoutRules[1].amount,
-    );
+    const carolMoolaAmount = await moolaIssuer.getAmountOf(carolMoolaPayout);
+    t.deepEquals(carolMoolaAmount, moola(0));
+    const carolSimAmt = await simoleanIssuer.getAmountOf(carolSimoleanPayout);
+    t.deepEquals(carolSimAmt, carolOfferRules.payoutRules[1].amount);
 
     // Carol deposits her payout to ensure she can
     await carolMoolaPurse.deposit(carolMoolaPayout);
     await carolSimoleanPurse.deposit(carolSimoleanPayout);
 
     // Dave gets a full refund
-    t.deepEquals(
-      simoleanIssuer.getAmountOf(daveSimoleanPayout),
-      daveOfferRules.payoutRules[1].amount,
-    );
+    const daveSimAmount = await simoleanIssuer.getAmountOf(daveSimoleanPayout);
+    t.deepEquals(daveSimAmount, daveOfferRules.payoutRules[1].amount);
 
     // Dave deposits his payout to ensure he can
     await daveMoolaPurse.deposit(daveMoolaPayout);
@@ -343,7 +342,8 @@ test('zoe - secondPriceAuction w/ 3 bids - alice exits onDemand', async t => {
       issuers,
       numBidsAllowed,
     });
-    const { instanceHandle } = inviteIssuer.getAmountOf(aliceInvite).extent[0];
+    const aliceInviteAmount = await inviteIssuer.getAmountOf(aliceInvite);
+    const { instanceHandle } = aliceInviteAmount.extent[0];
     const { publicAPI } = zoe.getInstance(instanceHandle);
 
     // Alice escrows with zoe
@@ -423,24 +423,22 @@ test('zoe - secondPriceAuction w/ 3 bids - alice exits onDemand', async t => {
     const [bobMoolaPayout, bobSimoleanPayout] = await Promise.all(bobResult);
 
     // Alice (the creator of the auction) gets back what she put in
-    t.deepEquals(
-      moolaIssuer.getAmountOf(aliceMoolaPayout),
-      aliceOfferRules.payoutRules[0].amount,
-    );
+    const aliceMoolaAmount = await moolaIssuer.getAmountOf(aliceMoolaPayout);
+    t.deepEquals(aliceMoolaAmount, aliceOfferRules.payoutRules[0].amount);
 
     // Alice didn't get any of what she wanted
-    t.deepEquals(simoleanIssuer.getAmountOf(aliceSimoleanPayout), simoleans(0));
+    const aliceSimAmt = await simoleanIssuer.getAmountOf(aliceSimoleanPayout);
+    t.deepEquals(aliceSimAmt, simoleans(0));
 
     // Alice deposits her payout to ensure she can
     await aliceMoolaPurse.deposit(aliceMoolaPayout);
     await aliceSimoleanPurse.deposit(aliceSimoleanPayout);
 
     // Bob gets a refund
-    t.deepEquals(moolaIssuer.getAmountOf(bobMoolaPayout), moola(0));
-    t.deepEquals(
-      simoleanIssuer.getAmountOf(bobSimoleanPayout),
-      bobOfferRules.payoutRules[1].amount,
-    );
+    const bobMoolaAmount = await moolaIssuer.getAmountOf(bobMoolaPayout);
+    t.deepEquals(bobMoolaAmount, moola(0));
+    const bobSimAmount = await simoleanIssuer.getAmountOf(bobSimoleanPayout);
+    t.deepEquals(bobSimAmount, bobOfferRules.payoutRules[1].amount);
 
     // Bob deposits his payout to ensure he can
     await bobMoolaPurse.deposit(bobMoolaPayout);

--- a/packages/zoe/test/unitTests/contracts/test-publicSwap.js
+++ b/packages/zoe/test/unitTests/contracts/test-publicSwap.js
@@ -71,8 +71,8 @@ test('zoe - atomicSwap', async t => {
     // counter-party.
 
     const bobExclusiveInvite = await inviteIssuer.claim(bobInviteP);
-    const bobInviteExtent = inviteIssuer.getAmountOf(bobExclusiveInvite)
-      .extent[0];
+    const bobExclAmount = await inviteIssuer.getAmountOf(bobExclusiveInvite);
+    const bobInviteExtent = bobExclAmount.extent[0];
 
     const {
       installationHandle: bobInstallationId,
@@ -123,13 +123,12 @@ test('zoe - atomicSwap', async t => {
     );
 
     // Alice gets what Alice wanted
-    t.deepEquals(
-      simoleanIssuer.getAmountOf(aliceSimoleanPayout),
-      aliceOfferRules.payoutRules[1].amount,
-    );
+    const aliceSimAmt = await simoleanIssuer.getAmountOf(aliceSimoleanPayout);
+    t.deepEquals(aliceSimAmt, aliceOfferRules.payoutRules[1].amount);
 
     // Alice didn't get any of what Alice put in
-    t.deepEquals(moolaIssuer.getAmountOf(aliceMoolaPayout), moola(0));
+    const aliceMoolaAmount = await moolaIssuer.getAmountOf(aliceMoolaPayout);
+    t.deepEquals(aliceMoolaAmount, moola(0));
 
     // Alice deposits her payout to ensure she can
     await aliceMoolaPurse.deposit(aliceMoolaPayout);


### PR DESCRIPTION
All ERTP functions except deposit() replace E.unwrap()  with use of .then().
Added/documented depositInOrder
added isLive to chainmail
Fixed Spawner and zoe.
Fixed many tests

fixes https://github.com/Agoric/agoric-sdk/issues/711