### PR TITLE
Silence the builtin modules warning in agoric-cli deploy

### DIFF
--- a/packages/agoric-cli/lib/deploy.js
+++ b/packages/agoric-cli/lib/deploy.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-await-in-loop */
+import builtinModules from 'builtin-modules';
 import parseArgs from 'minimist';
 import { evaluateProgram } from '@agoric/evaluate';
 import { E, HandledPromise, makeCapTP } from '@agoric/captp';
@@ -55,7 +56,7 @@ export default async function deployMain(progname, rawArgs, powers) {
 
       // Wait for the chain to become ready.
       let bootP = getBootstrap();
-      log.error('Chain loaded:', await E.G(bootP).LOADING);
+      log.info('Chain loaded:', await E.G(bootP).LOADING);
       // Take a new copy, since the chain objects have been added to bootstrap.
       bootP = getBootstrap();
 
@@ -64,7 +65,11 @@ export default async function deployMain(progname, rawArgs, powers) {
         const pathResolve = (...resArgs) =>
           path.resolve(path.dirname(moduleFile), ...resArgs);
         log('running', moduleFile);
-        const { source, sourceMap } = await bundleSource(moduleFile);
+        const { source, sourceMap } = await bundleSource(
+          moduleFile,
+          undefined,
+          { externals: builtinModules },
+        );
 
         const actualSource = `(${source}\n)\n${sourceMap}`;
         const mainNS = evaluateProgram(actualSource, {
@@ -84,7 +89,7 @@ export default async function deployMain(progname, rawArgs, powers) {
         }
       }
 
-      log('Done!');
+      log.info('Done!');
       ws.close();
       exit.res(0);
     } catch (e) {

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -33,6 +33,7 @@
     "@agoric/eventual-send": "^0.5.0",
     "@agoric/make-promise": "^0.0.1",
     "anylogger": "^0.21.0",
+    "builtin-modules": "^3.1.0",
     "chalk": "^2.4.2",
     "esm": "^3.2.25",
     "minimist": "^1.2.0",

--- a/packages/bundle-source/src/index.js
+++ b/packages/bundle-source/src/index.js
@@ -12,23 +12,24 @@ const SUPPORTED_FORMATS = ['getExport', 'nestedEvaluate'];
 export default async function bundleSource(
   startFilename,
   moduleFormat = DEFAULT_MODULE_FORMAT,
-  access = undefined,
+  powers = undefined,
 ) {
   if (!SUPPORTED_FORMATS.includes(moduleFormat)) {
     throw Error(`moduleFormat ${moduleFormat} is not implemented`);
   }
-  const { commonjsPlugin, rollup, resolvePlugin, pathResolve } = access || {
-    rollup: rollup0,
-    resolvePlugin: resolve0,
-    commonjsPlugin: commonjs0,
-    pathResolve: path.resolve,
-  };
+  const {
+    commonjsPlugin = commonjs0,
+    rollup = rollup0,
+    resolvePlugin = resolve0,
+    pathResolve = path.resolve,
+    externals = [],
+  } = powers || {};
   const resolvedPath = pathResolve(startFilename);
   const bundle = await rollup({
     input: resolvedPath,
     treeshake: false,
     preserveModules: moduleFormat === 'nestedEvaluate',
-    external: ['@agoric/evaluate', '@agoric/harden'],
+    external: ['@agoric/evaluate', '@agoric/harden', ...externals],
     plugins: [resolvePlugin({ preferBuiltins: true }), commonjsPlugin()],
     acornInjectPlugins: [eventualSend(acorn)],
   });

--- a/packages/bundle-source/src/index.js
+++ b/packages/bundle-source/src/index.js
@@ -119,8 +119,8 @@ return module.exports;
     const nestedEvaluate = _src => {
       throw Error('need to override nestedEvaluate');
     };
-    function computeExports(filename, powers) {
-      const { require: systemRequire, _log } = powers;
+    function computeExports(filename, exportPowers) {
+      const { require: systemRequire, _log } = exportPowers;
       // This captures the endowed require.
       const match = filename.match(/^(.*)\/[^/]+$/);
       const thisdir = match ? match[1] : '.';
@@ -162,7 +162,7 @@ return module.exports;
         // log('requiring', modPath);
         if (!(modPath in nsBundle)) {
           // log('evaluating', modPath);
-          nsBundle[modPath] = computeExports(modPath, powers);
+          nsBundle[modPath] = computeExports(modPath, exportPowers);
         }
 
         // log('returning', nsBundle[modPath]);


### PR DESCRIPTION
This fixes a confusing warning, since `agoric deploy` scripts are allowed to access the full Node.js built-ins.  Note that, by default, the builtins are not supplied (so that contracts are warned if they use them).
