### PR TITLE
734 getting started tests

### DIFF
--- a/.github/workflows/getting-started.yml
+++ b/.github/workflows/getting-started.yml
@@ -1,0 +1,36 @@
+name: Getting Started steps
+
+# This workflow is meant to emulate what developers working with the Agoric platform will experience
+# It should be kept in sync with https://agoric.com/documentation/getting-started/
+
+on:
+ push:
+   branches: [master]
+ pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+# Prerequisites
+
+    # FIXME: Reenable after 2020-04-01 when Github cache doesn't take forever.
+    #- name: cache Go modules
+    #  uses: actions/cache@v1
+    #  with:
+    #    path: ~/go/pkg/mod
+    #    key: ${{ runner.os }}-go-${{ hashFiles('packages/cosmic-swingset/go.sum') }}
+    #    restore-keys: |
+    #      ${{ runner.os }}-go-
+
+    # 'yarn install' must be done at the top level, to build all the
+    # cross-package symlinks
+    - run: yarn install
+    - run: yarn build
+    - run: yarn link-cli ~/bin/agoric
+
+    - run: node test/gettingStarted.js
+
+

--- a/test/agoric-deploy-ui.js
+++ b/test/agoric-deploy-ui.js
@@ -1,0 +1,35 @@
+const {execSync} = require('child_process')
+
+// To keep in sync with https://agoric.com/documentation/getting-started/
+
+function runCommand(cmd){
+    try{
+        execSync(cmd, {stdio: 'inherit'})
+    }
+    catch(err){
+        console.error(`${cmd} error`, err)
+        process.exit(1)
+    }
+}
+
+console.log('cwd', process.cwd())
+
+process.chdir('/tmp/demo')
+console.log('cwd', process.cwd())
+
+runCommand('agoric deploy ./contract/deploy.js ./api/deploy.js')
+
+process.chdir('ui')
+console.log('cwd', process.cwd())
+
+runCommand('yarn install')
+runCommand('yarn start')
+
+/*
+cd demo
+agoric deploy ./contract/deploy.js ./api/deploy.js
+cd ui
+yarn install
+yarn start
+
+*/

--- a/test/agoric-deploy-ui.js
+++ b/test/agoric-deploy-ui.js
@@ -1,10 +1,10 @@
-const {execSync} = require('child_process')
+const {exec, execSync} = require('child_process')
 
 // To keep in sync with https://agoric.com/documentation/getting-started/
 
-function runCommand(cmd){
+function runCommand(cmd, options={}){
     try{
-        execSync(cmd, {stdio: 'inherit'})
+        return execSync(cmd, {stdio: 'inherit', ...options})
     }
     catch(err){
         console.error(`${cmd} error`, err)
@@ -17,13 +17,38 @@ console.log('cwd', process.cwd())
 process.chdir('/tmp/demo')
 console.log('cwd', process.cwd())
 
+
+
+/*
+With runCommand ({stdio: 'inherit'}), i can see the error in deploy
+> cannot create initial offers TypeError: Cannot read property 'exit' of undefined
+
+
+With exec below (stdout should be buffered and passed to the callback), but the string is empty. Same for stderr
+
+No idea why there is a difference
+
+*/
+
 runCommand('agoric deploy ./contract/deploy.js ./api/deploy.js')
 
-process.chdir('ui')
-console.log('cwd', process.cwd())
+/*
+exec('agoric deploy ./contract/deploy.js ./api/deploy.js', (err, stdout, stderr) => {
+    console.log('DEPLOY err', err)
+    console.log('DEPLOY stdout', typeof stdout)
+    console.log('DEPLOY stderr', typeof stderr)
 
-runCommand('yarn install')
-runCommand('yarn start')
+    process.exit()
+
+    process.chdir('ui')
+    console.log('cwd', process.cwd())
+
+    runCommand('yarn install')
+    runCommand('yarn start')
+})*/
+
+
+
 
 /*
 cd demo

--- a/test/agoric-init-start.js
+++ b/test/agoric-init-start.js
@@ -1,31 +1,67 @@
-const {execSync} = require('child_process')
+const { request } = require('http')
+const { spawn, execSync } = require('child_process')
 
-function runCommand(cmd){
-    try{
-        execSync(cmd, {stdio: 'inherit'})
-    }
-    catch(err){
-        console.error(`${cmd} error`, err)
-        process.exit(1)
-    }
+
+// To keep in sync with https://agoric.com/documentation/getting-started/
+
+function runCommand(cmd) {
+  console.log('RUNNING', cmd)
+  try {
+    execSync(cmd, { stdio: 'inherit' })
+  }
+  catch (err) {
+    console.error(`${cmd} error`, err)
+    process.exit(1)
+  }
 }
 
 console.log('cwd', process.cwd())
 
+// cd /tmp
 process.chdir('/tmp')
 console.log('cwd', process.cwd())
 
-/*
-agoric init demo
-cd demo
-agoric install
-agoric start --reset
-*/
-
 runCommand('agoric init demo')
 
+// cd demo
 process.chdir('demo')
 console.log('cwd', process.cwd())
 
 runCommand('agoric install')
-runCommand('agoric start --reset')
+
+console.log('RUNNING', 'agoric start --reset')
+const agoricStartProcess = spawn('agoric', ['start', '--reset'], { stdio: 'inherit' })
+// for some reason, if stdout is piped, 'agoric start' closes the stream early, making it impossible to 
+// inspect stdout for relevant messages
+// no other 'agoric x' command has this problem
+
+// anyway, trying port 8000 until it does not return an error
+
+const interval = setInterval(() => {
+  const sendReady = () => {
+    console.log('server on localhost:8000 is certainly ready')
+    if(process.send){
+      process.send({httpReady: true})
+    }
+    clearInterval(interval)
+  }
+
+  const noErrorTimeout = setTimeout(sendReady, 2000)
+
+  const req = request('http://localhost:8000/', res => {
+    console.log('something came back from localhost:8000')
+    sendReady()
+    clearTimeout(noErrorTimeout)
+  })
+
+  req.on('error', err => {
+    clearTimeout(noErrorTimeout)
+    if(err.code === 'ECONNREFUSED'){
+      console.error('agoric started server on localhost:8000 not ready yet')
+    }
+    else{
+      console.error('http 8000 error', err)
+    }
+  })
+
+}, 3000)

--- a/test/agoric-init-start.js
+++ b/test/agoric-init-start.js
@@ -1,0 +1,31 @@
+const {execSync} = require('child_process')
+
+function runCommand(cmd){
+    try{
+        execSync(cmd, {stdio: 'inherit'})
+    }
+    catch(err){
+        console.error(`${cmd} error`, err)
+        process.exit(1)
+    }
+}
+
+console.log('cwd', process.cwd())
+
+process.chdir('/tmp')
+console.log('cwd', process.cwd())
+
+/*
+agoric init demo
+cd demo
+agoric install
+agoric start --reset
+*/
+
+runCommand('agoric init demo')
+
+process.chdir('demo')
+console.log('cwd', process.cwd())
+
+runCommand('agoric install')
+runCommand('agoric start --reset')

--- a/test/gettingStarted.js
+++ b/test/gettingStarted.js
@@ -1,0 +1,41 @@
+const { fork } = require('child_process');
+
+const test = require('tape');
+
+//const exec = promisify(execCb)
+
+// to keep in sync with https://agoric.com/documentation/getting-started/
+
+
+const firstProcessExitListener = code => {
+  console.error(`agoric init + start process stopped while it shouldn't have`)
+  t.fail(code);
+  t.end()
+}
+
+test('getting stated instructions', async t => {
+  console.log('Running commands in a first shell to run agoric start')
+
+  const initStartProcess = fork('./test/agoric-init-start.js', {stdio: 'inherit'})
+  
+  initStartProcess.on('error', error => {
+    t.fail(error);
+    initStartProcess.kill()
+    t.end()
+  })
+  initStartProcess.on('exit', firstProcessExitListener)
+
+
+  setTimeout(() => {
+    t.pass('pass after 15secs')
+    t.end()
+    initStartProcess.off('exit', firstProcessExitListener)
+    initStartProcess.kill()
+    
+  }, 15000)
+  
+
+  //t.equal(mf1, 'getExport', 'module format is getExport');
+  //t.assert(src1.match(/require\('@agoric\/harden'\)/), 'harden is required');
+  //t.end();
+});

--- a/test/gettingStarted.js
+++ b/test/gettingStarted.js
@@ -16,8 +16,8 @@ test('getting stated instructions', async t => {
     t.end()
   }
   const deployUiProcessExitListener = code => {
-    console.error(`agoric init + start process stopped while it shouldn't have`)
-    t.fail(code);
+    console.log(`agoric deploy + ui stopped`)
+    process.exit()
     t.end()
   }
 

--- a/test/gettingStarted.js
+++ b/test/gettingStarted.js
@@ -7,32 +7,67 @@ const test = require('tape');
 // to keep in sync with https://agoric.com/documentation/getting-started/
 
 
-const firstProcessExitListener = code => {
-  console.error(`agoric init + start process stopped while it shouldn't have`)
-  t.fail(code);
-  t.end()
-}
-
 test('getting stated instructions', async t => {
-  console.log('Running commands in a first shell to run agoric start')
+  console.log('Running commands in a first shell for agoric init + start')
+
+  const initStartProcessExitListener = code => {
+    console.error(`agoric init + start process stopped while it shouldn't have`)
+    t.fail(code);
+    t.end()
+  }
+  const deployUiProcessExitListener = code => {
+    console.error(`agoric init + start process stopped while it shouldn't have`)
+    t.fail(code);
+    t.end()
+  }
 
   const initStartProcess = fork('./test/agoric-init-start.js', {stdio: 'inherit'})
-  
+
   initStartProcess.on('error', error => {
     t.fail(error);
     initStartProcess.kill()
     t.end()
   })
-  initStartProcess.on('exit', firstProcessExitListener)
+  initStartProcess.on('exit', initStartProcessExitListener)
+
+  const vatsReadyP = new Promise(resolve => {
+    initStartProcess.on('message', (message) => {
+      console.log('receieved message from initStartProcess', message)
+      if(message.httpReady){
+        console.log('message.httpReady', message.httpReady)
+        resolve()
+      }
+    })
+  })
 
 
-  setTimeout(() => {
-    t.pass('pass after 15secs')
-    t.end()
-    initStartProcess.off('exit', firstProcessExitListener)
-    initStartProcess.kill()
-    
-  }, 15000)
+  vatsReadyP
+  .then(() => {
+    console.log('In a second shell, run agoric deploy + ui + yarn install+start')
+
+    const deployUiProcess = fork('./test/agoric-deploy-ui.js', {stdio: 'inherit'})
+
+    deployUiProcess.on('error', error => {
+      t.fail(error);
+      
+      initStartProcess.on('exit', initStartProcessExitListener)
+      initStartProcess.kill()
+
+      deployUiProcess.on('exit', deployUiProcessExitListener)
+      deployUiProcess.kill()
+
+      t.end()
+    })
+    deployUiProcess.on('exit', deployUiProcessExitListener)
+  })
+
+
+  // finalize steps
+  //t.pass('pass after 15secs')
+  //t.end()
+  //initStartProcess.off('exit', firstProcessExitListener)
+  //initStartProcess.kill()
+  
   
 
   //t.equal(mf1, 'getExport', 'module format is getExport');


### PR DESCRIPTION
Closes #734 

I'm really not there yet

Command to run is 
`rm -Rf /tmp/demo ; fuser -k 8000/tcp ; node test/gettingStarted.js`

I'm having a problem with stdout/stderr handling
I can see messages in my console when i use `{stdio: 'inherit'}`, but i see nothing when i use `{stdio: 'pipe'}` (+listen to data events or wait for the callback in the `exec` cases)
