### PR TITLE
chore: add 'import-bundle' package, the receiving end of bundle-source

### DIFF
--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -73,6 +73,8 @@ jobs:
       run: cd packages/evaluate && yarn test
     - name: yarn test (eventual-send)
       run: cd packages/eventual-send && yarn test
+    - name: yarn test (import-bundle)
+      run: cd packages/import-bundle && yarn test
     - name: yarn test (import-manager)
       run: cd packages/import-manager && yarn test
     - name: yarn test (make-promise)

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "packages/weak-store",
     "packages/acorn-eventual-send",
     "packages/bundle-source",
+    "packages/import-bundle",
     "packages/eventual-send",
     "packages/make-promise",
     "packages/transform-eventual-send",

--- a/packages/import-bundle/LICENSE
+++ b/packages/import-bundle/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/import-bundle/NEWS.md
+++ b/packages/import-bundle/NEWS.md
@@ -1,0 +1,5 @@
+User-visible changes in import-bundle:
+
+## Release ?? (date)
+
+* first release

--- a/packages/import-bundle/README.md
+++ b/packages/import-bundle/README.md
@@ -1,0 +1,48 @@
+# import-bundle
+
+`importBundle` is an async function that evaluates the bundles created by `bundle-source`, turning them back into callable functions:
+
+```js
+const bundle = await bundleSource('path/to/bundle.js');
+// 'bundle' is JSON-serializable
+const options = {}; // filePrefix, endowments, other compartment options
+const namespace = await importBundle(bundle);
+const { default, namedExport1, namedExport2 } = namespace;
+```
+
+When run in a SES environment, this will be secure: the bundle will be loaded into a new Compartment, which does not have access to platform globals like `document` or `Fetch` or `require`. This works by using `ses-adapter` to access the `Compartment` API. As a result, `importBundle` will work outside of SES as well, however it will not provide proper isolation properties without SES.
+
+Each call to `importBundle` creates a new `Compartment`. The globals of the new Compartment are frozen before any bundle code is evaluated, to enforce ocap rules.
+
+## Module Formats
+
+The source can be bundled in a variety of "formats". By default, `bundleSource` uses a format named `getExports`, in which the source tree is linearized into a single CommonJS-style string, and wrapped in a callable function that provides the `exports` and `module.exports` context to which the exports can be attached. `importBundle` recognizes this format, and invokes the function thus defined, to return the namespace object.
+
+A more sophisticated format is named `nestedEvaluate`. In this mode, the source tree is converted into a table of evaluable strings, one for each original module. This table is then encoded and wrapped as before. The evaluation process uses a separate evaluator call for each module, providing an opportunity to attach a distinct `sourceMap` to each one. This preserves relative filenames in subsequent debugging information and stack traces.
+
+To set a base prefix for these relative filenames, provide the `filePrefix` option.
+
+Note that the `nestedEvaluate` format requires an endowment named `require`, although it will only be called if the source tree imported one of the few modules on the `bundle-source` "external" list.
+
+## Options
+
+
+`importBundle()` takes an options bag:
+
+```js
+const namespace = await importBundle(bundle, options);
+```
+
+The most common option is `filePrefix`, which can be provided for `nestedEvaluate`-format bundles. This sets the source filename of the top-level module inside the bundle, as used in debugging messages (like the stack traces displayed in errors). The other modules will append a suffix to this filename, based upon their location within the original source tree.
+
+Another common option is `endowments`, which provides names that will be available everywhere in the evaluated sources. By default, the bundle will only get access to the standard JavaScript primordials (`Array`, `Object`, `Map`, etc). It will not get `document`, `window`, `Request`, `process`, `require`, or even `console` unless you provide them as endowments, giving you full control over what the loaded bundle can do.
+
+The `bundle-source` tool has a small number of module names marked as "external". These modules are not bundled into the source (copied from the filesystem where `bundleSource` was called). Instead, the bundler injects a call to `require()` for each external module that was imported from somewhere in original source graph. This let the final evaluation environment control what these imports get, rather than the original source tree.
+
+To support these "external" imports, you will need to provide a `require` endowment that can honor any such names. In addition, the `nestedEvaluate` format always needs a `require` endowment (although it will only be called if the original sources imported one of the "external" names).
+
+For debugging purposes, you should probably provide a `console` endowment. See `makeConsole.js` in the SwingSet source tree for inspiration.
+
+The rest of the `options` are passed through to the `Compartment` constructor, which currently only accepts `transforms`. For more information, see the `compartment-shim` docs in the SES repository. Note that `transforms` is defined to be an array of objects which each have a `rewrite` method.
+
+Note that `sloppyGlobalsMode` is only accepted by the Compartment's `evaluate` method, not the Compartment constructor itself, and thus cannot be supplied to `importBundle`. To use `sloppyGlobalsMode`, you will probably want to create a Compartment directly (and not freeze its globals).

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -1,0 +1,75 @@
+{
+  "name": "@agoric/import-bundle",
+  "version": "0.0.1",
+  "description": "load modules created by @agoric/bundle-source",
+  "main": "src/index.js",
+  "module": "src/index.js",
+  "engines": {
+    "node": ">=10.15.1"
+  },
+  "scripts": {
+    "test": "tap --no-coverage --reporter specy test/**/test*.js",
+    "build": "exit 0",
+    "lint-fix": "eslint --fix '**/*.js'",
+    "lint-check": "eslint '**/*.js'"
+  },
+  "dependencies": {
+    "ses-adapter": "^0.0.2"
+  },
+  "devDependencies": {
+    "@agoric/bundle-source": "^1.0.5",
+    "esm": "^3.2.5",
+    "ses": "^0.7.6",
+    "tap": "^14.10.5"
+  },
+  "files": [
+    "README.md",
+    "LICENSE",
+    "NEWS.md",
+    "src/**/*.js"
+  ],
+  "author": "Agoric",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/Agoric/agoric-sdk/issues"
+  },
+  "homepage": "https://github.com/Agoric/agoric-sdk/packages/import-bundle",
+  "eslintConfig": {
+    "extends": [
+      "airbnb-base",
+      "plugin:prettier/recommended"
+    ],
+    "env": {
+      "es6": true
+    },
+    "rules": {
+      "implicit-arrow-linebreak": "off",
+      "function-paren-newline": "off",
+      "arrow-parens": "off",
+      "strict": "off",
+      "no-console": "off",
+      "no-unused-vars": [
+        "error",
+        {
+          "argsIgnorePattern": "^_",
+          "varsIgnorePattern": "^_"
+        }
+      ],
+      "no-return-assign": "off",
+      "no-param-reassign": "off",
+      "no-restricted-syntax": [
+        "off",
+        "ForOfStatement"
+      ],
+      "no-unused-expressions": "off",
+      "no-loop-func": "off",
+      "no-inner-declarations": "off",
+      "import/extensions": "off",
+      "import/prefer-default-export": "off"
+    }
+  },
+  "prettier": {
+    "trailingComma": "all",
+    "singleQuote": true
+  }
+}

--- a/packages/import-bundle/src/index.js
+++ b/packages/import-bundle/src/index.js
@@ -1,4 +1,5 @@
-import { harden, Compartment } from 'ses-adapter';
+/* global harden Compartment */
+// import { harden, Compartment } from 'ses-adapter';
 
 // importBundle takes the output of bundle-source, and returns a namespace
 // object (with .default, and maybe other properties for named exports)

--- a/packages/import-bundle/src/index.js
+++ b/packages/import-bundle/src/index.js
@@ -1,0 +1,45 @@
+import { harden, Compartment } from 'ses-adapter';
+
+// importBundle takes the output of bundle-source, and returns a namespace
+// object (with .default, and maybe other properties for named exports)
+
+export async function importBundle(bundle, options = {}) {
+  const {
+    filePrefix,
+    endowments: optEndowments = {},
+    ...compartmentOptions
+  } = options;
+  const endowments = { ...optEndowments };
+  const { source, sourceMap, moduleFormat } = bundle;
+  let c;
+  if (moduleFormat === 'getExport') {
+    // The 'getExport' format is a string which defines a wrapper function
+    // named `getExport()`. This function provides a `module` to the
+    // linearized source file, executes that source, then returns
+    // `module.exports`. To get the function object out of a program-mode
+    // evaluation, we must wrap the function definition in parentheses
+    // (making it an expression). We also want to append the `sourceMap`
+    // comment so `evaluate` can attach useful debug information. Finally, to
+    // extract the namespace object, we need to invoke this function.
+  } else if (moduleFormat === 'nestedEvaluate') {
+    // The 'nestedEvaluate' format is similar, except the wrapper function
+    // (now named `getExportWithNestedEvaluate`) wraps more than a single
+    // linearized string. Each source module is processed (converting
+    // `import` into `require`) and added to a table named `sourceBundle`.
+    // Each module will be evaluated separately (so they can get distinct
+    // sourceMap strings), using a mandatory endowment named
+    // `nestedEvaluate`. The wrapper function should be called with
+    // `filePrefix`, which will be used as the sourceMap for the top-level
+    // module. The sourceMap name for other modules will be derived from
+    // `filePrefix` and the relative import path of each module.
+    endowments.nestedEvaluate = src => c.evaluate(src);
+  } else {
+    throw Error(`unrecognized moduleFormat '${moduleFormat}'`);
+  }
+  c = new Compartment(endowments, {}, compartmentOptions);
+  harden(c.global);
+  const actualSource = `(${source})\n${sourceMap}`;
+  const namespace = c.evaluate(actualSource)(filePrefix);
+  // namespace.default has the default export
+  return namespace;
+}

--- a/packages/import-bundle/test/bundle1.js
+++ b/packages/import-bundle/test/bundle1.js
@@ -1,0 +1,19 @@
+/* global endow1 added */
+
+import { bundle2 } from './bundle2.js';
+
+export function f1(a) {
+  return a + 1;
+}
+
+export function f2(a) {
+  return bundle2(a);
+}
+
+export function f3(a) {
+  return a + endow1;
+}
+
+export function f4(a) {
+  return `replaceme ${added} ${a}`;
+}

--- a/packages/import-bundle/test/bundle2.js
+++ b/packages/import-bundle/test/bundle2.js
@@ -1,0 +1,3 @@
+export function bundle2(a) {
+  return a + 2;
+}

--- a/packages/import-bundle/test/do-import.js
+++ b/packages/import-bundle/test/do-import.js
@@ -1,0 +1,50 @@
+import bundleSource from '@agoric/bundle-source';
+import tap from 'tap';
+import { importBundle } from '../src/index.js';
+
+const transform1 = {
+  rewrite(rewriterState) {
+    const { src, endowments } = rewriterState;
+    return {
+      src: src.replace('replaceme', 'substitution'),
+      endowments: { added: 'by transform', ...endowments },
+    };
+  },
+};
+
+async function testBundle1(b1, mode, ew) {
+  const ns1 = await importBundle(b1, { endowments: ew });
+  tap.equal(ns1.f1(1), 2, `ns1.f1 ${mode} ok`);
+  tap.equal(ns1.f2(1), 3, `ns1.f2 ${mode} ok`);
+
+  const endowments = { endow1: 3, ...ew };
+  const ns2 = await importBundle(b1, { endowments });
+  tap.equal(ns2.f1(1), 2, `ns2.f1 ${mode} ok`);
+  tap.equal(ns2.f2(1), 3, `ns2.f2 ${mode} ok`);
+  tap.equal(ns2.f3(1), 4, `ns2.f3 ${mode} ok`);
+
+  const ns3 = await importBundle(b1, { endowments, transforms: [transform1] });
+  tap.equal(ns3.f4('ok'), 'substitution by transform ok', `ns3.f4 ${mode} ok`);
+}
+
+tap.test('test import', async function testImport(t) {
+  // nestedEvaluate requires a 'require' endowment, but doesn't call it
+  function req(what) {
+    console.log(`require(${what})`);
+  }
+  const endowments = { require: req };
+
+  const b1getExport = await bundleSource(
+    require.resolve('./bundle1.js'),
+    'getExport',
+  );
+  await testBundle1(b1getExport, 'getExport', endowments);
+
+  const b1NestedEvaluate = await bundleSource(
+    require.resolve('./bundle1.js'),
+    'nestedEvaluate',
+  );
+  await testBundle1(b1NestedEvaluate, 'nestedEvaluate', endowments);
+
+  t.end();
+});

--- a/packages/import-bundle/test/install-ses.js
+++ b/packages/import-bundle/test/install-ses.js
@@ -1,0 +1,12 @@
+import { lockdown } from 'ses';
+
+lockdown({
+  // noTameError: true, // enable if needed, for better debugging
+  noTameMath: true, // bundle-source -> rollup uses Math.random
+});
+
+process.on('unhandledRejection', (error, _p) => {
+  console.log('unhandled rejection, boo');
+  console.log('error is', error.toString());
+  return true;
+});

--- a/packages/import-bundle/test/test-non-ses.js
+++ b/packages/import-bundle/test/test-non-ses.js
@@ -1,0 +1,2 @@
+// disabled because our non-SES 'Compartment' is still a non-functioning stub
+// import './do-import.js';

--- a/packages/import-bundle/test/test-ses.js
+++ b/packages/import-bundle/test/test-ses.js
@@ -1,0 +1,2 @@
+import './install-ses.js';
+import './do-import.js';


### PR DESCRIPTION
closes #739

Note, for unit tests, `install-ses.js` disables some SES security features,
one because of a bug in SES (Agoric/SES-shim#237), and another because
`rollup` uses Math.random for reasons that are not clear. We'll need to fix
or find workarounds for both: eventually this test should work without those
two patches.