### PR TITLE
Prevent deadlock in the input queue for delivered commands

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
+++ b/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
@@ -59,7 +59,7 @@ export async function connectToFakeChain(basedir, GCI, role, delay, inbound) {
   const maximumDelay = (delay || PRETEND_BLOCK_DELAY) * 1000;
 
   const withBlockQueue = makeWithQueue();
-  const simulateBlock = withBlockQueue(async () => {
+  const simulateBlock = withBlockQueue(async function simulateBlock() {
     const actualStart = Date.now();
     // Gather up the new messages into the latest block.
     thisBlock.push(...intoChain);
@@ -97,10 +97,7 @@ export async function connectToFakeChain(basedir, GCI, role, delay, inbound) {
     // TODO: maybe add latency to the inbound messages.
     const mailboxJSON = mailboxStorage.get(`mailbox.${bootAddress}`);
     const mailbox = mailboxJSON && JSON.parse(mailboxJSON);
-    const { outbox, ack } = mailbox || {
-      outbox: [],
-      ack: 0,
-    };
+    const { outbox = [], ack = 0 } = mailbox || {};
     inbound(GCI, outbox, ack);
   });
 

--- a/packages/cosmic-swingset/lib/ag-solo/queue.js
+++ b/packages/cosmic-swingset/lib/ag-solo/queue.js
@@ -19,7 +19,9 @@ export const makeWithQueue = () => {
       // Rerun dequeue() after settling.
       .finally(() => {
         queue.shift();
-        dequeue();
+        if (queue.length) {
+          dequeue();
+        }
       });
   };
 

--- a/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
@@ -362,6 +362,7 @@ export async function makeWallet(
         })
         .catch(rejected);
     } catch (e) {
+      console.error('Have error', e);
       rejected(e);
       throw e;
     }

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-http.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-http.js
@@ -199,7 +199,8 @@ function build(E, D) {
         D(commandDevice).sendResponse(count, false, harden(true));
       } catch (rej) {
         console.debug(`Error ${dispatcher}:`, rej);
-        D(commandDevice).sendResponse(count, true, harden(rej));
+        const jsonable = (rej && rej.message) || rej;
+        D(commandDevice).sendResponse(count, true, harden(jsonable));
       }
     },
   };

--- a/packages/cosmic-swingset/lib/ag-solo/web.js
+++ b/packages/cosmic-swingset/lib/ag-solo/web.js
@@ -167,11 +167,7 @@ export function makeHTTPListener(basedir, port, host, rawInboundCommand) {
       ).finally(() => channels.delete(channelID));
     });
 
-    inboundCommand(
-      { type: 'ws/meta' },
-      { ...meta, dispatcher: 'onOpen' },
-      id,
-    );
+    inboundCommand({ type: 'ws/meta' }, { ...meta, dispatcher: 'onOpen' }, id);
 
     ws.on('message', async message => {
       let obj = {};


### PR DESCRIPTION
We want to free the queue after the kernel is run, not necessarily when the command's result promise has settled.