### PR TITLE
Wait for payments at opportune moments

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
@@ -154,7 +154,7 @@ export default function setup(syscall, state, helpers) {
         );
 
         // deposit payments
-        const [moolaPayment, simoleanPayment] = payments;
+        const [moolaPayment, simoleanPayment] = await Promise.all(payments);
 
         await E(wallet).deposit(pursePetnames.moola, moolaPayment);
         await E(wallet).deposit(pursePetnames.simolean, simoleanPayment);

--- a/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
@@ -145,10 +145,11 @@ export async function makeWallet(
         }),
       ).then(payoutArray =>
         Promise.all(
-          payoutArray.map((payout, payoutIndex) => {
+          payoutArray.map(async (payoutP, payoutIndex) => {
             const keyword = payoutIndexToKeyword[payoutIndex];
             const purse = purses[keyword];
-            if (purse && payout) {
+            if (purse && payoutP) {
+              const payout = await payoutP;
               return E(purse).deposit(payout);
             }
             return undefined;

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -394,8 +394,10 @@ const makeZoe = (additionalEndowments = {}) => {
             if (giveKeywords.includes(keyword)) {
               // We cannot trust these amounts since they come directly
               // from the remote issuer and so we must coerce them.
-              return E(purse)
-                .deposit(paymentKeywordRecord[keyword], proposal.give[keyword])
+              return Promise.resolve(paymentKeywordRecord[keyword])
+                .then(payment =>
+                  E(purse).deposit(payment, proposal.give[keyword]),
+                )
                 .then(_ => amountMath.coerce(proposal.give[keyword]));
             }
             // If any other payments are included, they are ignored.


### PR DESCRIPTION
Zoe and cosmic-swingset need to be defensive against payments that may be promises.  By the changes in ERTP 0.4.2, promises are not allowed as an argument to `deposit`.