### PR TITLE
[Zoe] Revert changes to zoe.js in #772

### DIFF
--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -394,10 +394,8 @@ const makeZoe = (additionalEndowments = {}) => {
             if (giveKeywords.includes(keyword)) {
               // We cannot trust these amounts since they come directly
               // from the remote issuer and so we must coerce them.
-              return Promise.resolve(paymentKeywordRecord[keyword])
-                .then(payment =>
-                  E(purse).deposit(payment, proposal.give[keyword]),
-                )
+              return E(purse)
+                .deposit(paymentKeywordRecord[keyword], proposal.give[keyword])
                 .then(_ => amountMath.coerce(proposal.give[keyword]));
             }
             // If any other payments are included, they are ignored.


### PR DESCRIPTION
https://github.com/Agoric/agoric-sdk/pull/772/ allowed Zoe to accept promises for payments even if `deposit` in ERTP now only accepts payments, not promises. We should analyze this change further in a separate PR if we want to add it. Alternatively, any user of Zoe can wait for a promise for a payment to resolve. 