### PR TITLE
Discard dapp template history

### DIFF
--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agoric",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Manage the Agoric Javascript smart contract platform",
   "main": "lib/main.js",
   "bin": "bin/agoric",


### PR DESCRIPTION
This PR addresses a comment made by @dtribble: `agoric init` should not produce a git repository with history, just a single initial commit and no configured remotes or branches.
