### PR TITLE
chore: Add more debugging info for ERTP and objArrayConversions

### DIFF
--- a/packages/zoe/src/objArrayConversion.js
+++ b/packages/zoe/src/objArrayConversion.js
@@ -14,7 +14,7 @@ export const objToArray = (obj, keywords) => {
   const keys = Object.getOwnPropertyNames(obj);
   assert(
     keys.length === keywords.length,
-    `object keys and keywords must be of equal length`,
+    `object keys (${keys}) and keywords (${keywords}) must be of equal length`,
   );
   return keywords.map(keyword => obj[keyword]);
 };

--- a/packages/zoe/test/unitTests/test-objArrayConversion.js
+++ b/packages/zoe/test/unitTests/test-objArrayConversion.js
@@ -38,14 +38,14 @@ test('objToArray', t => {
     const keywords2 = ['X', 'Y', 'Z'];
     t.throws(
       () => objToArray(obj, keywords2),
-      /Error: Assertion failed: object keys and keywords must be of equal length/,
+      /Error: Assertion failed: object keys \(X,Y\) and keywords \(X,Y,Z\) must be of equal length/,
       `unequal length should throw`,
     );
 
     const obj2 = { X: 1, Y: 2, Z: 5 };
     t.throws(
       () => objToArray(obj2, keywords),
-      /Error: Assertion failed: object keys and keywords must be of equal length/,
+      /Error: Assertion failed: object keys \(X,Y,Z\) and keywords \(X,Y\) must be of equal length/,
       `unequal length should throw`,
     );
   } catch (e) {


### PR DESCRIPTION
When purses and payments aren't present, report the issuer's alleged name
When objToArray finds a mismatch, report more details