### PR TITLE
Make devices and presences lack property names

### DIFF
--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -15,7 +15,7 @@ function setSwingSetIdentity(presence, description) {
   // Don't add an iterable property, but allow identification.
   const presencePrototype = harden({
     toString() {
-      return `[${this[Symbol.toStringTag]}]`;
+      return `[${description}]`;
     },
     [swingSetSymbol]: true,
     [Symbol.toStringTag]: description,

--- a/packages/SwingSet/test/files-devices/vat-left.js
+++ b/packages/SwingSet/test/files-devices/vat-left.js
@@ -9,6 +9,7 @@ export default function setup(syscall, state, helpers) {
       harden({
         left5(d2) {
           log(`left5`);
+          log(`left5 device d2 has ${Object.keys(d2).length} properties`);
           const ret = D(d2).method5('hello');
           log(`left5 did d2.method5, got ${ret}`);
           return 'done';

--- a/packages/SwingSet/test/files-vattp/bootstrap-test-vattp.js
+++ b/packages/SwingSet/test/files-vattp/bootstrap-test-vattp.js
@@ -10,6 +10,7 @@ function build(E, D, log) {
   return harden({
     async bootstrap(argv, vats, devices) {
       D(devices.mailbox).registerInboundHandler(vats.vattp);
+      log(`vats.vattp has ${Object.keys(vats.vattp).length} properties`);
       await E(vats.vattp).registerMailboxDevice(devices.mailbox);
       const name = 'remote1';
       const { transmitter, setReceiver } = await E(vats.vattp).addRemote(name);

--- a/packages/SwingSet/test/test-devices.js
+++ b/packages/SwingSet/test/test-devices.js
@@ -120,6 +120,7 @@ async function test2(t, mode, withSES) {
       'calling v2.method5',
       'called',
       'left5',
+      'left5 device d2 has 0 properties',
       'method5 hello',
       'left5 did d2.method5, got ok',
     ]);
@@ -128,6 +129,7 @@ async function test2(t, mode, withSES) {
       'calling v2.method5',
       'called',
       'left5',
+      'left5 device d2 has 0 properties',
       'method5 hello',
       'left5 did d2.method5, got ok',
       'ret done',

--- a/packages/SwingSet/test/test-vattp.js
+++ b/packages/SwingSet/test/test-vattp.js
@@ -29,6 +29,7 @@ async function testVatTP(t, withSES) {
   );
   await c.run();
   t.deepEqual(c.dump().log, [
+    'vats.vattp has 0 properties',
     'not sending anything',
     'ch.receive msg1',
     'ch.receive msg2',
@@ -74,12 +75,12 @@ async function testVatTP2(t, withSES) {
 
   t.equal(mb.deliverInbound('remote1', [], 1), true);
   await c.run();
-  t.deepEqual(c.dump().log, []);
+  t.deepEqual(c.dump().log, ['vats.vattp has 0 properties']);
   t.deepEqual(s.exportToData(), { remote1: { outbox: [], inboundAck: 0 } });
 
   t.equal(mb.deliverInbound('remote1', [[1, 'msg1']], 1), true);
   await c.run();
-  t.deepEqual(c.dump().log, ['ch.receive msg1']);
+  t.deepEqual(c.dump().log, ['vats.vattp has 0 properties', 'ch.receive msg1']);
   t.deepEqual(s.exportToData(), { remote1: { outbox: [], inboundAck: 1 } });
 
   t.equal(mb.deliverInbound('remote1', [[1, 'msg1']], 1), false);
@@ -96,7 +97,11 @@ async function testVatTP2(t, withSES) {
     true,
   );
   await c.run();
-  t.deepEqual(c.dump().log, ['ch.receive msg1', 'ch.receive msg2']);
+  t.deepEqual(c.dump().log, [
+    'vats.vattp has 0 properties',
+    'ch.receive msg1',
+    'ch.receive msg2',
+  ]);
   t.deepEqual(s.exportToData(), { remote1: { outbox: [], inboundAck: 2 } });
 
   t.end();

--- a/packages/captp/lib/captp.js
+++ b/packages/captp/lib/captp.js
@@ -12,7 +12,7 @@ function setSwingSetIdentity(presence, description) {
   // Don't add an iterable property, but allow identification.
   const presencePrototype = harden({
     toString() {
-      return `[${this[Symbol.toStringTag]}]`;
+      return `[${description}]`;
     },
     [swingSetSymbol]: true,
     [Symbol.toStringTag]: description,

--- a/packages/cosmic-swingset/lib/ag-solo/vats/offer-compiler.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/offer-compiler.js
@@ -58,7 +58,10 @@ export default ({
       keywordPurses[dir] = {};
       keywordIssuerNames[dir] = {};
       Object.entries(proposalTemplate[dir]).forEach(([keyword, amount]) => {
-        assert(amount.pursePetname, `Keyword ${dir} ${keyword} has no pursePetname`);
+        assert(
+          amount.pursePetname,
+          `Keyword ${dir} ${keyword} has no pursePetname`,
+        );
         const purse = petnameToPurse.get(amount.pursePetname);
         assert(
           purse,
@@ -150,10 +153,7 @@ export default ({
 
         // Find the only keyword with this prefix and brand.
         const multiword = keyword;
-        const multiwordPrefix = multiword.substr(
-          0,
-          multiword.length - 1,
-        );
+        const multiwordPrefix = multiword.substr(0, multiword.length - 1);
 
         // Now we actually need the brands (if we haven't already gotten them).
         await getKeywordBrandsP();
@@ -203,7 +203,12 @@ export default ({
     await Promise.all([
       Promise.all(
         Object.keys(proposal.want || {}).map(keyword =>
-          replaceMultiwords(proposal.want, directedPurses.want, keyword, 'Want'),
+          replaceMultiwords(
+            proposal.want,
+            directedPurses.want,
+            keyword,
+            'Want',
+          ),
         ),
       ),
       Promise.all(

--- a/packages/cosmic-swingset/lib/ag-solo/vats/repl.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/repl.js
@@ -1,6 +1,8 @@
 import { makeEvaluators } from '@agoric/evaluate';
 import harden from '@agoric/harden';
 
+const swingSetSymbol = Symbol.for('SwingSet');
+
 // A REPL-specific JSON stringify.
 export function stringify(value, spaces, already = new WeakSet()) {
   if (Object(value) !== value) {
@@ -37,9 +39,6 @@ export function stringify(value, spaces, already = new WeakSet()) {
   let ret = '{';
   let sep = '';
   for (const key of Object.keys(value)) {
-    if (key === 'toString' && typeof value[key] === 'function') {
-      return value[key]();
-    }
     ret += `${sep}${JSON.stringify(key, undefined, spaces)}:${stringify(
       value[key],
       spaces,
@@ -47,6 +46,15 @@ export function stringify(value, spaces, already = new WeakSet()) {
     )}`;
     sep = ',';
   }
+
+  // Empty object?
+  if (sep === '') {
+    // Distinguish SwingSet-created Presences and Devices if we get one.
+    if (value[swingSetSymbol] === true) {
+      return String(value);
+    };
+  }
+
   ret += '}';
   return ret;
 }

--- a/packages/cosmic-swingset/lib/ag-solo/vats/repl.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/repl.js
@@ -52,7 +52,7 @@ export function stringify(value, spaces, already = new WeakSet()) {
     // Distinguish SwingSet-created Presences and Devices if we get one.
     if (value[swingSetSymbol] === true) {
       return String(value);
-    };
+    }
   }
 
   ret += '}';


### PR DESCRIPTION
Closes #792 

This PR improves the debuggability and predictability of device nodes and presences created by SwingSet and CapTP.  Adding a `Symbol.for('SwingSet')` property (which doesn't show up with `Object.getOwnPropertyNames`), and setting a prototype that defines `toString()` (which allows the presence to be stringified as before) means that empty objects are marshalled compatibly as empty presences.

The REPL is improved to sniff specifically for this mechanism to distinguish presences from empty objects.