### PR TITLE
Allow optional arguments to redeem

### DIFF
--- a/packages/zoe/src/contracts/helpers/zoeHelpers.js
+++ b/packages/zoe/src/contracts/helpers/zoeHelpers.js
@@ -107,9 +107,7 @@ export const makeZoeHelpers = zoe => {
     },
     makeEmptyOffer: () => {
       const { inviteHandle, invite } = zoe.makeInvite();
-      return zoeService
-        .redeem(invite, harden({}), harden({}))
-        .then(() => inviteHandle);
+      return zoeService.redeem(invite).then(() => inviteHandle);
     },
   });
   return helpers;

--- a/packages/zoe/src/zoe.chainmail
+++ b/packages/zoe/src/zoe.chainmail
@@ -47,8 +47,9 @@ interface ZoeService {
   getInstance(instanceHandle :InstanceHandle) -> (InstanceRecord);
 
   /** 
-   * To redeem an invite, the user must provide a proposal (their rules for the
-   * offer) as well as payments to be escrowed by Zoe.
+   * To redeem an invite, the user normally provides a proposal (their rules for the
+   * offer) as well as payments to be escrowed by Zoe.  If the proposal or payments are
+   * undefined, the default is not to propose or pay (just to obtain the invite's seat).
    * 
    * The proposal has three parts: `want` and `give` are used 
    * by Zoe to enforce offer safety, and `exit` is used to specify

--- a/packages/zoe/src/zoe.chainmail
+++ b/packages/zoe/src/zoe.chainmail
@@ -48,8 +48,9 @@ interface ZoeService {
 
   /** 
    * To redeem an invite, the user normally provides a proposal (their rules for the
-   * offer) as well as payments to be escrowed by Zoe.  If the proposal or payments are
-   * undefined, the default is not to propose or pay (just to obtain the invite's seat).
+   * offer) as well as payments to be escrowed by Zoe.  If either the proposal or payments
+   * would be empty, indicate this by omitting that argument or passing undefined, rather
+   * than passing an empty record.
    * 
    * The proposal has three parts: `want` and `give` are used 
    * by Zoe to enforce offer safety, and `exit` is used to specify

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -360,13 +360,20 @@ const makeZoe = (additionalEndowments = {}) => {
      * promise.
      * @param {payment} invite - an invite (ERTP payment) to join a
      * Zoe smart contract instance
-     * @param  {object} proposal - the proposal, a record
+     * @param  {object?} proposal - the proposal, a record
      * with properties `want`, `give`, and `exit`. The keys of
      * `want` and `give` are keywords and the values are amounts.
-     * @param  {object} paymentKeywordRecord - a record with keyword
+     * @param  {object?} paymentKeywordRecord - a record with keyword
      * keys and values which are payments that will be escrowed by Zoe.
+     *
+     * The default arguments are so that remote invocations don't
+     * have to specify empty objects (which get marshaled as presences).
      */
-    redeem: (invite, proposal, paymentKeywordRecord) => {
+    redeem: (
+      invite,
+      proposal = harden({}),
+      paymentKeywordRecord = harden({}),
+    ) => {
       return inviteIssuer.burn(invite).then(inviteAmount => {
         assert(
           inviteAmount.extent.length === 1,


### PR DESCRIPTION
This is necessary because trying to supply empty objects in a
remote call gets marshalled as presences, which fails Zoe's checks
because they have property names.