### PR TITLE
Run "yarn install" in the ui directory

### DIFF
--- a/packages/agoric-cli/lib/install.js
+++ b/packages/agoric-cli/lib/install.js
@@ -61,6 +61,13 @@ export default async function installMain(progname, rawArgs, powers, opts) {
       log.error('Cannot copy _agstate/agoric-wallet');
     }
   }
+
+  if (await pspawn('yarn', ['install'], { stdio: 'inherit', cwd: 'ui' })) {
+    // Try to install via Yarn.
+    log.warn('Cannot yarn install in ui directory');
+    return 1;
+  }
+
   log.info(chalk.bold.green('Done installing'));
   return 0;
 }

--- a/packages/agoric-cli/test/test-workflow.js
+++ b/packages/agoric-cli/test/test-workflow.js
@@ -4,6 +4,8 @@ import tmp from 'tmp';
 
 import { spawn } from 'child_process';
 
+const SIMPLEST_TEMPLATE = 'dapp-encouragement';
+
 test('workflow', async t => {
   try {
     const pspawn = (...args) => {
@@ -35,7 +37,15 @@ test('workflow', async t => {
     try {
       process.chdir(name);
 
-      t.equals(await myMain(['init', 'dapp-foo']), 0, 'init dapp-foo works');
+      t.equals(
+        await myMain([
+          'init',
+          'dapp-foo',
+          `--dapp-template=${SIMPLEST_TEMPLATE}`,
+        ]),
+        0,
+        'init dapp-foo works',
+      );
       process.chdir('dapp-foo');
       t.equals(await myMain(['install']), 0, 'install works');
 


### PR DESCRIPTION
Minor usability improvement.  This way the instructions are more straightforward for running with a ui directory that has a package.json with a "start" entry (but needs to be installed before start).
