### PR TITLE
Add E.when(x, onfulfilled, onrejected) as a convenience

### DIFF
--- a/packages/eventual-send/src/E.js
+++ b/packages/eventual-send/src/E.js
@@ -70,5 +70,8 @@ export default function makeE(HandledPromise) {
   E.resolve = HandledPromise.resolve;
   E.unwrap = HandledPromise.unwrap;
 
+  E.when = (x, onfulfilled = undefined, onrejected = undefined) =>
+    HandledPromise.resolve(x).then(onfulfilled, onrejected);
+
   return harden(E);
 }

--- a/packages/eventual-send/src/index.d.ts
+++ b/packages/eventual-send/src/index.d.ts
@@ -11,7 +11,7 @@ interface EHandler {
 type HandledExecutor<R> = (
   resolveHandled: (value?: R) => void,
   rejectHandled: (reason?: unknown) => void,
-  resolveWithPresence: (presenceHandler: EHandler) => object,
+  resolveWithRemote: (remoteHandler: EHandler) => object,
 ) => void;
 
 interface HandledPromiseConstructor {
@@ -62,6 +62,15 @@ interface EProxy {
    * @returns {ESingleGet} property get proxy
    */
   readonly G(x: unknown): ESingleGet;
+
+  /**
+   * E.when(x, res, rej) is equivalent to HandledPromise.resolve(x).then(res, rej)
+   */
+  readonly when(
+    x: unknown,
+    onfulfilled?: (value: unknown) => unknown | PromiseLike<unknown>,
+    onrejected?: (reason: any) => PromiseLike<never>,
+  ): Promise<unknown>;
 
   /**
    * E.sendOnly returns a proxy similar to E, but for which the results

--- a/packages/eventual-send/test/test-e.js
+++ b/packages/eventual-send/test/test-e.js
@@ -12,6 +12,43 @@ test('E reexports', async t => {
   }
 });
 
+test('E.when', async t => {
+  try {
+    let stash;
+    await E.when(123, val => (stash = val));
+    t.equals(stash, 123, `onfulfilled handler fires`);
+    let raised;
+    // eslint-disable-next-line prefer-promise-reject-errors
+    await E.when(Promise.reject('foo'), undefined, val => (raised = val));
+    t.assert(raised, 'foo', 'onrejected handler fires');
+
+    let ret;
+    let exc;
+    await E.when(
+      Promise.resolve('foo'),
+      val => (ret = val),
+      val => (exc = val),
+    );
+    t.equals(ret, 'foo', 'onfulfilled option fires');
+    t.equals(exc, undefined, 'onrejected option does not fire');
+
+    let ret2;
+    let exc2;
+    await E.when(
+      // eslint-disable-next-line prefer-promise-reject-errors
+      Promise.reject('foo'),
+      val => (ret2 = val),
+      val => (exc2 = val),
+    );
+    t.equals(ret2, undefined, 'onfulfilled option does not fire');
+    t.equals(exc2, 'foo', 'onrejected option fires');
+  } catch (e) {
+    t.isNot(e, e, 'unexpected exception');
+  } finally {
+    t.end();
+  }
+});
+
 test('E method calls', async t => {
   try {
     const x = {


### PR DESCRIPTION
As discussed with @erights, this helper is exactly:

```js
  E.when = (x, onfulfilled = undefined, onrejected = undefined) =>
    HandledPromise.resolve(x).then(onfulfilled, onrejected);
```

which enables more concise writing of:

```js
  HandledPromise.resolve(x).then(val => doStuff(foo))
// as
  E.when(x, val => doStuff(foo))
```