### PR TITLE
[Zoe] Add multipool autoswap

### DIFF
--- a/packages/zoe/src/contractSupport/bondingCurves.js
+++ b/packages/zoe/src/contractSupport/bondingCurves.js
@@ -4,79 +4,58 @@ import { natSafeMath } from './safeMath';
 
 const { add, subtract, multiply, floorDivide } = natSafeMath;
 
-export const makeConstProductBC = zoe => {
-  return harden({
-    /**
-     * Contains the logic for calculating how much should be given
-     * back to the user in exchange for what they sent in. It also
-     * calculates the new amount of the assets in the pool. Reused in
-     * several different places, including to check whether an offer
-     * is valid, getting the current price for an asset on user
-     * request, and to do the actual reallocation after an offer has
-     * been made.
-     * @param  {extent} inputExtent - the extent of the assets sent in
-     * to be swapped
-     * @param  {extent} inputReserve - the extent in the liquidity
-     * pool of the kind of asset sent in
-     * @param  {extent} outputReserve - the extent in the liquidity
-     * pool of the kind of asset to be sent out
-     * @param  {number} feeBasisPoints=30 - the fee taken in
-     * basis points. The default is 0.3% or 30 basis points. The fee is taken from
-     * inputExtent
-     */
-    getPrice: ({
-      inputExtent,
-      inputReserve,
-      outputReserve,
-      feeBasisPoints = 30,
-    }) => {
-      const oneMinusFeeInTenThousandths = subtract(10000, feeBasisPoints);
-      const inputWithFee = multiply(inputExtent, oneMinusFeeInTenThousandths);
-      const numerator = multiply(inputWithFee, outputReserve);
-      const denominator = add(multiply(inputReserve, 10000), inputWithFee);
+/**
+ * Contains the logic for calculating how much should be given
+ * back to the user in exchange for what they sent in. It also
+ * calculates the new amount of the assets in the pool. Reused in
+ * several different places, including to check whether an offer
+ * is valid, getting the current price for an asset on user
+ * request, and to do the actual reallocation after an offer has
+ * been made.
+ * @param  {extent} inputExtent - the extent of the assets sent in
+ * to be swapped
+ * @param  {extent} inputReserve - the extent in the liquidity
+ * pool of the kind of asset sent in
+ * @param  {extent} outputReserve - the extent in the liquidity
+ * pool of the kind of asset to be sent out
+ * @param  {number} feeBasisPoints=30 - the fee taken in
+ * basis points. The default is 0.3% or 30 basis points. The fee is taken from
+ * inputExtent
+ */
+export const getCurrentPrice = ({
+  inputExtent,
+  inputReserve,
+  outputReserve,
+  feeBasisPoints = 30,
+}) => {
+  const oneMinusFeeInTenThousandths = subtract(10000, feeBasisPoints);
+  const inputWithFee = multiply(inputExtent, oneMinusFeeInTenThousandths);
+  const numerator = multiply(inputWithFee, outputReserve);
+  const denominator = add(multiply(inputReserve, 10000), inputWithFee);
 
-      const outputExtent = floorDivide(numerator, denominator);
-      const newOutputReserve = subtract(outputReserve, outputExtent);
-      const newInputReserve = add(inputReserve, inputExtent);
-      return harden({ outputExtent, newInputReserve, newOutputReserve });
-    },
-
-    // Calculate how many liquidity tokens we should be minting to
-    // send back to the user when adding liquidity. Calculations are
-    // based on the extents represented by TokenA. If the current
-    // supply is zero, start off by just taking the extent at TokenA
-    // and using it as the extent for the liquidity token.
-    calcLiqExtentToMint: ({ liqTokenSupply, inputExtent, inputReserve }) =>
-      liqTokenSupply > 0
-        ? floorDivide(multiply(inputExtent, liqTokenSupply), inputReserve)
-        : inputExtent,
-
-    // Calculate how many underlying tokens (in the form of amount)
-    // should be returned when removing liquidity.
-    calcAmountsToRemove: ({
-      liqTokenSupply,
-      poolAllocation,
-      liquidityExtentIn,
-    }) => {
-      const amountMaths = zoe.getAmountMaths(
-        harden(['TokenA', 'TokenB', 'Liquidity']),
-      );
-      const newUserAmounts = harden({
-        TokenA: amountMaths.TokenA.make(
-          floorDivide(
-            multiply(liquidityExtentIn, poolAllocation.TokenA.extent),
-            liqTokenSupply,
-          ),
-        ),
-        TokenB: amountMaths.TokenB.make(
-          floorDivide(
-            multiply(liquidityExtentIn, poolAllocation.TokenB.extent),
-            liqTokenSupply,
-          ),
-        ),
-        Liquidity: amountMaths.Liquidity.getEmpty(),
-      });
-      return newUserAmounts;
-    },
-  });
+  const outputExtent = floorDivide(numerator, denominator);
+  const newOutputReserve = subtract(outputReserve, outputExtent);
+  const newInputReserve = add(inputReserve, inputExtent);
+  return harden({ outputExtent, newInputReserve, newOutputReserve });
 };
+
+// Calculate how many liquidity tokens we should be minting to send back to the
+// user when adding liquidity. Calculations are based on the comparing the
+// inputExtent to the inputReserve. If the current supply is zero, just return
+// the inputExtent.
+export const calcLiqExtentToMint = ({
+  liqTokenSupply,
+  inputExtent,
+  inputReserve,
+}) =>
+  liqTokenSupply > 0
+    ? floorDivide(multiply(inputExtent, liqTokenSupply), inputReserve)
+    : inputExtent;
+
+// Calculate how many underlying tokens (in the form of an extent) should be
+// returned when removing liquidity.
+export const calcExtentToRemove = ({
+  liqTokenSupply,
+  poolExtent,
+  liquidityExtentIn,
+}) => floorDivide(multiply(liquidityExtentIn, poolExtent), liqTokenSupply);

--- a/packages/zoe/src/contractSupport/index.js
+++ b/packages/zoe/src/contractSupport/index.js
@@ -1,6 +1,10 @@
 export { secondPriceLogic, closeAuction } from './auctions';
 
-export { makeConstProductBC } from './bondingCurves';
+export {
+  getCurrentPrice,
+  calcLiqExtentToMint,
+  calcExtentToRemove,
+} from './bondingCurves';
 
 export { natSafeMath } from './safeMath';
 

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -6,7 +6,7 @@ import { HandledPromise } from '@agoric/eventual-send';
 export const defaultRejectMsg = `The offer was invalid. Please check your refund.`;
 export const defaultAcceptanceMsg = `The offer has been accepted. Once the contract has been completed, please check your payout`;
 
-export const getKeys = obj => harden(Object.getOwnPropertyNames(obj || {}));
+const getKeys = obj => harden(Object.getOwnPropertyNames(obj || {}));
 const getKeysSorted = obj =>
   harden(Object.getOwnPropertyNames(obj || {}).sort());
 
@@ -43,6 +43,7 @@ export const makeZoeHelpers = zcf => {
   };
 
   const helpers = harden({
+    getKeys,
     assertKeywords: expected => {
       const { issuerKeywordRecord } = zcf.getInstanceRecord();
       const actual = getKeysSorted(issuerKeywordRecord);

--- a/packages/zoe/src/contracts/autoswap.js
+++ b/packages/zoe/src/contracts/autoswap.js
@@ -52,7 +52,11 @@ export const makeContract = harden(zcf => {
         }
 
         const poolAllocation = getPoolAllocation();
-        const { outputExtent, newInputReserve, newOutputReserve } = getPrice(
+        const {
+          outputExtent,
+          newInputReserve,
+          newOutputReserve,
+        } = getCurrentPrice(
           harden({
             inputExtent: proposal.give[giveKeyword].extent,
             inputReserve: poolAllocation[giveKeyword].extent,

--- a/packages/zoe/src/contracts/autoswap.js
+++ b/packages/zoe/src/contracts/autoswap.js
@@ -3,7 +3,12 @@ import produceIssuer from '@agoric/ertp';
 import { assert, details } from '@agoric/assert';
 
 // Eventually will be importable from '@agoric/zoe-contract-support'
-import { makeConstProductBC, makeZoeHelpers } from '../contractSupport';
+import {
+  getCurrentPrice,
+  calcLiqExtentToMint,
+  calcExtentToRemove,
+  makeZoeHelpers,
+} from '../contractSupport';
 
 // Autoswap is a rewrite of Uniswap. Please see the documentation for
 // more https://agoric.com/documentation/zoe/guide/contracts/autoswap.html
@@ -33,11 +38,6 @@ export const makeContract = harden(zcf => {
       makeEmptyOffer,
       inviteAnOffer,
     } = makeZoeHelpers(zcf);
-    const {
-      getPrice,
-      calcLiqExtentToMint,
-      calcAmountsToRemove,
-    } = makeConstProductBC(zcf);
 
     return makeEmptyOffer().then(poolHandle => {
       const getPoolAllocation = () => zcf.getCurrentAllocation(poolHandle);
@@ -203,13 +203,30 @@ export const makeContract = harden(zcf => {
 
         const poolAllocation = getPoolAllocation();
 
-        const newUserAmounts = calcAmountsToRemove(
-          harden({
-            liqTokenSupply,
-            poolAllocation,
-            liquidityExtentIn,
-          }),
+        const newUserTokenAAmount = amountMaths.TokenA.make(
+          calcExtentToRemove(
+            harden({
+              liqTokenSupply,
+              poolExtent: poolAllocation.TokenA.extent,
+              liquidityExtentIn,
+            }),
+          ),
         );
+        const newUserTokenBAmount = amountMaths.TokenB.make(
+          calcExtentToRemove(
+            harden({
+              liqTokenSupply,
+              poolExtent: poolAllocation.TokenB.extent,
+              liquidityExtentIn,
+            }),
+          ),
+        );
+
+        const newUserAmounts = harden({
+          TokenA: newUserTokenAAmount,
+          TokenB: newUserTokenBAmount,
+          Liquidity: amountMaths.Liquidity.getEmpty(),
+        });
 
         const newPoolAmounts = harden({
           TokenA: amountMaths.TokenA.subtract(
@@ -252,16 +269,16 @@ export const makeContract = harden(zcf => {
         invite: makeAddLiquidityInvite(),
         publicAPI: {
           /**
-           * `getPrice` calculates the result of a trade, given a certain amount
+           * `getCurrentPrice` calculates the result of a trade, given a certain amount
            * of digital assets in.
            * @param {object} amountInObj - the amount of digital
            * assets to be sent in, keyed by keyword
            */
-          getPrice: amountInObj => {
+          getCurrentPrice: amountInObj => {
             const inKeywords = Object.getOwnPropertyNames(amountInObj);
             assert(
               inKeywords.length === 1,
-              details`argument to 'getPrice' must have one keyword`,
+              details`argument to 'getCurrentPrice' must have one keyword`,
             );
             const [inKeyword] = inKeywords;
             assert(
@@ -275,7 +292,7 @@ export const makeContract = harden(zcf => {
             const inputReserve = poolAllocation[inKeyword].extent;
             const outKeyword = inKeyword === 'TokenA' ? 'TokenB' : 'TokenA';
             const outputReserve = poolAllocation[outKeyword].extent;
-            const { outputExtent } = getPrice(
+            const { outputExtent } = getCurrentPrice(
               harden({
                 inputExtent,
                 inputReserve,

--- a/packages/zoe/src/contracts/multipoolAutoswap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap.js
@@ -1,0 +1,629 @@
+/* eslint-disable no-use-before-define */
+import harden from '@agoric/harden';
+import produceIssuer from '@agoric/ertp';
+import { assert, details } from '@agoric/assert';
+
+import { makeTable, makeValidateProperties } from '../table';
+import { assertCapASCII } from '../cleanProposal';
+import {
+  makeZoeHelpers,
+  getCurrentPrice,
+  calcLiqExtentToMint,
+  calcExtentToRemove,
+} from '../contractSupport';
+
+// Autoswap is a rewrite of Uniswap. Please see the documentation for more
+// https://agoric.com/documentation/zoe/guide/contracts/autoswap.html
+
+// We expect that this contract will have tens to hundreds of issuers.
+// Each liquidity pool is between the central token and a secondary
+// token. Secondary tokens can be exchanged with each other, but only
+// through the central token. For example, if X and Y are two token
+// types and C is the central token, a swap giving X and wanting Y
+// would first use the pool (X, C) then the pool (Y, C). There are no
+// liquidity pools between two secondary tokens.
+
+export const makeContract = harden(zoe => {
+  // This contract must have a "central token" issuer in the terms.
+  const CENTRAL_TOKEN = 'CentralToken';
+
+  const getCentralTokenBrand = () => {
+    const {
+      terms: { CentralToken: centralTokenIssuer },
+    } = zoe.getInstanceRecord();
+    const { brand: centralTokenBrand } = zoe.getIssuerRecord(
+      centralTokenIssuer,
+    );
+    assert(
+      centralTokenBrand !== undefined,
+      details`centralTokenBrand must be present`,
+    );
+    return centralTokenBrand;
+  };
+  const centralTokenBrand = getCentralTokenBrand();
+
+  const {
+    rejectOffer,
+    makeEmptyOffer,
+    rejectIfNotProposal,
+    assertKeywords,
+    getKeys,
+  } = makeZoeHelpers(zoe);
+
+  // There must be one keyword at the start, which is equal to the
+  // value of CENTRAL_TOKEN
+  assertKeywords([CENTRAL_TOKEN]);
+
+  // We need to be able to retrieve information about the liquidity
+  // pools by tokenBrand. Key: tokenBrand Columns: poolHandle,
+  // tokenIssuer, liquidityMint, liquidityIssuer, tokenKeyword,
+  // liquidityKeyword, liquidityTokenSupply
+  const liquidityTable = makeTable(
+    makeValidateProperties(
+      harden([
+        'poolHandle',
+        'tokenIssuer',
+        'liquidityMint',
+        'liquidityIssuer',
+        'tokenKeyword',
+        'liquidityKeyword',
+        'liquidityTokenSupply',
+      ]),
+    ),
+  );
+
+  // Allows users to add new liquidity pools. `newTokenIssuer` and
+  // `newTokenKeyword` must not have been already used
+  const addPool = (newTokenIssuer, newTokenKeyword) => {
+    assertCapASCII(newTokenKeyword);
+    const { issuerKeywordRecord } = zoe.getInstanceRecord();
+    const keywords = Object.keys(issuerKeywordRecord);
+    const issuers = Object.values(issuerKeywordRecord);
+    assert(
+      !keywords.includes(newTokenKeyword),
+      details`newTokenKeyword must be unique`,
+    );
+    // TODO: handle newTokenIssuer as a potential promise
+    assert(
+      !issuers.includes(newTokenIssuer),
+      details`newTokenIssuer must not be already present`,
+    );
+    const newLiquidityKeyword = `${newTokenKeyword}Liquidity`;
+    assert(
+      !keywords.includes(newLiquidityKeyword),
+      details`newLiquidityKeyword must be unique`,
+    );
+    const { mint: liquidityMint, issuer: liquidityIssuer } = produceIssuer(
+      newLiquidityKeyword,
+    );
+    return Promise.all([
+      zoe.addNewIssuer(newTokenIssuer, newTokenKeyword),
+      makeEmptyOffer(),
+      zoe.addNewIssuer(liquidityIssuer, newLiquidityKeyword),
+    ]).then(([newTokenIssuerRecord, poolHandle]) => {
+      // The third element of the above array is intentionally
+      // ignored, since we already have the liquidityIssuer and mint.
+      const amountMaths = zoe.getAmountMaths(harden([newTokenKeyword]));
+      assert(
+        amountMaths[newTokenKeyword].getMathHelpersName() === 'nat',
+        details`tokenIssuer must have natMathHelpers`,
+      );
+      liquidityTable.create(
+        harden({
+          poolHandle,
+          tokenIssuer: newTokenIssuer,
+          liquidityMint,
+          liquidityIssuer,
+          tokenKeyword: newTokenKeyword,
+          liquidityKeyword: newLiquidityKeyword,
+          liquidityTokenSupply: 0,
+        }),
+        newTokenIssuerRecord.brand,
+      );
+      return `liquidity pool for ${newTokenKeyword} added`;
+    });
+  };
+
+  // The secondary token brand is used as the key of liquidityTable
+  // rows, and we use it to look up the pool allocation. We only
+  // return the keywords for the secondary token, the central token,
+  // and the associated liquidity token.
+  const getPoolAllocation = tokenBrand => {
+    const { poolHandle, tokenKeyword, liquidityKeyword } = liquidityTable.get(
+      tokenBrand,
+    );
+    return zoe.getCurrentAllocation(
+      poolHandle,
+      harden([tokenKeyword, CENTRAL_TOKEN, liquidityKeyword]),
+    );
+  };
+
+  const doGetCurrentPrice = ({
+    amountIn,
+    keywordIn,
+    keywordOut,
+    secondaryBrand,
+  }) => {
+    const poolAmounts = getPoolAllocation(secondaryBrand);
+    const { outputExtent } = getCurrentPrice(
+      harden({
+        inputExtent: amountIn.extent,
+        inputReserve: poolAmounts[keywordIn].extent,
+        outputReserve: poolAmounts[keywordOut].extent,
+      }),
+    );
+    const amountMaths = zoe.getAmountMaths(harden([keywordOut]));
+    return amountMaths[keywordOut].make(outputExtent);
+  };
+
+  const doSwap = ({
+    userAllocation,
+    keywordIn,
+    keywordOut,
+    secondaryBrand,
+  }) => {
+    const { poolHandle } = liquidityTable.get(secondaryBrand);
+    const poolAllocation = getPoolAllocation(secondaryBrand);
+    const { outputExtent, newInputReserve, newOutputReserve } = getCurrentPrice(
+      harden({
+        inputExtent: userAllocation[keywordIn].extent,
+        inputReserve: poolAllocation[keywordIn].extent,
+        outputReserve: poolAllocation[keywordOut].extent,
+      }),
+    );
+    const amountMaths = zoe.getAmountMaths([keywordIn, keywordOut]);
+    const amountOut = amountMaths[keywordOut].make(outputExtent);
+
+    const newUserAmounts = harden({
+      [keywordIn]: amountMaths[keywordIn].getEmpty(),
+      [keywordOut]: amountOut,
+    });
+
+    const newPoolAmounts = harden({
+      [keywordIn]: amountMaths[keywordIn].make(newInputReserve),
+      [keywordOut]: amountMaths[keywordOut].make(newOutputReserve),
+    });
+
+    return harden({ poolHandle, newUserAmounts, newPoolAmounts });
+  };
+
+  const getSecondaryBrand = ({ offerHandle, isAddLiquidity }) => {
+    const { proposal } = zoe.getOffer(offerHandle);
+    const key = isAddLiquidity ? 'give' : 'want';
+    const {
+      // eslint-disable-next-line no-unused-vars
+      [key]: { [CENTRAL_TOKEN]: centralAmount, ...tokenAmountKeywordRecord },
+    } = proposal;
+    const values = Object.values(tokenAmountKeywordRecord);
+    if (values.length !== 1) {
+      rejectOffer(offerHandle, `only one secondary brand should be present`);
+    }
+    return values[0].brand;
+  };
+
+  const makeAdd = amountMaths => (key, obj1, obj2) =>
+    amountMaths[key].add(obj1[key], obj2[key]);
+
+  const makeSubtract = amountMaths => (key, obj1, obj2) =>
+    amountMaths[key].subtract(obj1[key], obj2[key]);
+
+  const makeGetAllEmpty = amountMaths => keywords => {
+    const newObj = {};
+    keywords.forEach(
+      keyword => (newObj[keyword] = amountMaths[keyword].getEmpty()),
+    );
+    // intentionally not hardened
+    return newObj;
+  };
+
+  const rejectIfNotTokenBrand = (inviteHandle, brand) => {
+    if (!liquidityTable.has(brand)) {
+      rejectOffer(inviteHandle, `brand ${brand} was not recognized`);
+    }
+  };
+
+  const addLiquidity = offerHandle => {
+    // Get the brand of the secondary token so we can identify the liquidity pool.
+    const secondaryTokenBrand = getSecondaryBrand(
+      harden({
+        offerHandle,
+        isAddLiquidity: true,
+      }),
+    );
+
+    const {
+      tokenKeyword,
+      liquidityKeyword,
+      liquidityTokenSupply,
+      liquidityMint,
+      poolHandle,
+    } = liquidityTable.get(secondaryTokenBrand);
+
+    // These are the keywords that will be used several times within this method
+    const liquidityKeys = harden([
+      CENTRAL_TOKEN,
+      tokenKeyword,
+      liquidityKeyword,
+    ]);
+
+    const expected = harden({
+      give: {
+        [CENTRAL_TOKEN]: null,
+        [tokenKeyword]: null,
+      },
+      want: { [liquidityKeyword]: null },
+    });
+    rejectIfNotProposal(offerHandle, expected);
+
+    const userAmounts = zoe.getCurrentAllocation(offerHandle, liquidityKeys);
+    const poolAmounts = getPoolAllocation(secondaryTokenBrand);
+
+    // Calculate how many liquidity tokens we should be minting.
+    const liquidityExtentOut = calcLiqExtentToMint(
+      harden({
+        liquidityTokenSupply,
+        inputExtent: userAmounts[CENTRAL_TOKEN].extent,
+        inputReserve: poolAmounts[CENTRAL_TOKEN].extent,
+      }),
+    );
+    const amountMaths = zoe.getAmountMaths(liquidityKeys);
+
+    const liquidityAmountOut = amountMaths[liquidityKeyword].make(
+      liquidityExtentOut,
+    );
+
+    const liquidityPaymentP = liquidityMint.mintPayment(liquidityAmountOut);
+
+    // The contract needs to escrow the liquidity payment with Zoe
+    // to eventually pay as a payout to the user
+    const tempProposal = harden({
+      give: { [liquidityKeyword]: liquidityAmountOut },
+    });
+
+    const { inviteHandle: tempLiqHandle, invite } = zoe.makeInvite();
+    const zoeService = zoe.getZoeService();
+    // We update the liquidityTokenSupply before the next turn
+    liquidityTable.update(secondaryTokenBrand, {
+      liquidityTokenSupply: liquidityTokenSupply + liquidityExtentOut,
+    });
+    return zoeService
+      .redeem(
+        invite,
+        tempProposal,
+        harden({ [liquidityKeyword]: liquidityPaymentP }),
+      )
+      .then(() => {
+        const add = makeAdd(amountMaths);
+        const getAllEmpty = makeGetAllEmpty(amountMaths);
+        const newPoolAmounts = harden({
+          [CENTRAL_TOKEN]: add(CENTRAL_TOKEN, userAmounts, poolAmounts),
+          [tokenKeyword]: add(tokenKeyword, userAmounts, poolAmounts),
+          [liquidityKeyword]: poolAmounts[liquidityKeyword],
+        });
+
+        const newUserAmounts = getAllEmpty(liquidityKeys);
+        newUserAmounts[liquidityKeyword] = liquidityAmountOut;
+
+        const newTempLiqAmounts = getAllEmpty(liquidityKeys);
+
+        zoe.reallocate(
+          harden([offerHandle, poolHandle, tempLiqHandle]),
+          harden([newUserAmounts, newPoolAmounts, newTempLiqAmounts]),
+          liquidityKeys,
+        );
+        zoe.complete(harden([offerHandle, tempLiqHandle]));
+        return 'Added liquidity.';
+      });
+  };
+
+  const removeLiquidity = offerHandle => {
+    const secondaryTokenBrand = getSecondaryBrand(
+      harden({ offerHandle, isAddLiquidity: false }),
+    );
+
+    const {
+      tokenKeyword,
+      liquidityKeyword,
+      liquidityTokenSupply,
+      poolHandle,
+    } = liquidityTable.get(secondaryTokenBrand);
+
+    const expected = harden({
+      want: { [CENTRAL_TOKEN]: null, [tokenKeyword]: null },
+      give: { [liquidityKeyword]: null },
+    });
+    rejectIfNotProposal(offerHandle, expected);
+
+    const liquidityKeys = harden([
+      CENTRAL_TOKEN,
+      tokenKeyword,
+      liquidityKeyword,
+    ]);
+
+    const userAllocation = zoe.getCurrentAllocation(offerHandle, liquidityKeys);
+    const poolAllocation = getPoolAllocation(secondaryTokenBrand);
+    const liquidityExtentIn = userAllocation[liquidityKeyword].extent;
+
+    const amountMaths = zoe.getAmountMaths(liquidityKeys);
+
+    const subtract = makeSubtract(amountMaths);
+
+    const newUserAmounts = harden({
+      [CENTRAL_TOKEN]: amountMaths[CENTRAL_TOKEN].make(
+        calcExtentToRemove(
+          harden({
+            liqTokenSupply: liquidityTokenSupply,
+            poolExtent: poolAllocation[CENTRAL_TOKEN].extent,
+            liquidityExtentIn,
+          }),
+        ),
+      ),
+      [tokenKeyword]: amountMaths[tokenKeyword].make(
+        calcExtentToRemove(
+          harden({
+            liqTokenSupply: liquidityTokenSupply,
+            poolExtent: poolAllocation[tokenKeyword].extent,
+            liquidityExtentIn,
+          }),
+        ),
+      ),
+      [liquidityKeyword]: amountMaths[liquidityKeyword].getEmpty(),
+    });
+
+    const newPoolAmounts = harden({
+      [CENTRAL_TOKEN]: subtract(CENTRAL_TOKEN, poolAllocation, newUserAmounts),
+      [tokenKeyword]: subtract(tokenKeyword, poolAllocation, newUserAmounts),
+      [liquidityKeyword]: amountMaths[liquidityKeyword].add(
+        poolAllocation[liquidityKeyword],
+        amountMaths[liquidityKeyword].make(liquidityExtentIn),
+      ),
+    });
+
+    liquidityTable.update(secondaryTokenBrand, {
+      liquidityTokenSupply: liquidityTokenSupply - liquidityExtentIn,
+    });
+
+    zoe.reallocate(
+      harden([offerHandle, poolHandle]),
+      harden([newUserAmounts, newPoolAmounts]),
+      liquidityKeys,
+    );
+    zoe.complete(harden([offerHandle]));
+    return 'Liquidity successfully removed.';
+  };
+
+  const swap = offerHandle => {
+    const { proposal } = zoe.getOffer(offerHandle);
+    const getKeywordAndBrand = amountKeywordRecord => {
+      const keywords = getKeys(amountKeywordRecord);
+      if (keywords.length !== 1) {
+        rejectOffer(
+          offerHandle,
+          `A swap requires giving one type of token for another, ${keywords.length} tokens were provided.`,
+        );
+      }
+      return harden({
+        keyword: keywords[0],
+        brand: Object.values(amountKeywordRecord)[0].brand,
+      });
+    };
+
+    const { keyword: keywordIn, brand: brandIn } = getKeywordAndBrand(
+      proposal.give,
+    );
+    const { keyword: keywordOut, brand: brandOut } = getKeywordAndBrand(
+      proposal.want,
+    );
+
+    const expected = harden({
+      give: { [keywordIn]: null },
+      want: { [keywordOut]: null },
+    });
+    rejectIfNotProposal(offerHandle, expected);
+
+    // we could be swapping (1) central to secondary, (2) secondary to central, or (3) secondary to secondary.
+
+    // 1) central to secondary
+    if (brandIn === centralTokenBrand) {
+      rejectIfNotTokenBrand(offerHandle, brandOut);
+
+      const keywords = harden([keywordIn, keywordOut]);
+      const { poolHandle, newUserAmounts, newPoolAmounts } = doSwap(
+        harden({
+          userAllocation: zoe.getCurrentAllocation(offerHandle, keywords),
+          keywordIn,
+          keywordOut,
+          secondaryBrand: brandOut,
+        }),
+      );
+      zoe.reallocate(
+        harden([offerHandle, poolHandle]),
+        harden([newUserAmounts, newPoolAmounts]),
+        keywords,
+      );
+      zoe.complete(harden([offerHandle]));
+      return `Swap successfully completed.`;
+
+      // eslint-disable-next-line no-else-return
+    } else if (brandOut === centralTokenBrand) {
+      // 2) secondary to central
+      rejectIfNotTokenBrand(offerHandle, brandIn);
+      const keywords = harden([keywordIn, keywordOut]);
+      const { poolHandle, newUserAmounts, newPoolAmounts } = doSwap(
+        harden({
+          userAllocation: zoe.getCurrentAllocation(offerHandle, keywords),
+          keywordIn,
+          keywordOut,
+          secondaryBrand: brandIn,
+        }),
+      );
+      zoe.reallocate(
+        harden([offerHandle, poolHandle]),
+        harden([newUserAmounts, newPoolAmounts]),
+        keywords,
+      );
+      zoe.complete(harden([offerHandle]));
+      return `Swap successfully completed.`;
+    } else {
+      // 3) secondary to secondary
+      rejectIfNotTokenBrand(offerHandle, brandIn);
+      rejectIfNotTokenBrand(offerHandle, brandOut);
+
+      const {
+        poolHandle: poolHandleA,
+        newUserAmounts: newUserAmountsA,
+        newPoolAmounts: newPoolAmountsA,
+      } = doSwap(
+        harden({
+          userAllocation: zoe.getCurrentAllocation(
+            offerHandle,
+            harden([keywordIn, CENTRAL_TOKEN]),
+          ),
+          keywordIn,
+          keywordOut: CENTRAL_TOKEN,
+          secondaryBrand: brandIn,
+        }),
+      );
+      const {
+        poolHandle: poolHandleB,
+        newUserAmounts,
+        newPoolAmounts: newPoolAmountsB,
+      } = doSwap(
+        harden({
+          userAllocation: newUserAmountsA,
+          keywordIn: CENTRAL_TOKEN,
+          keywordOut,
+          secondaryBrand: brandOut,
+        }),
+      );
+      const keywords = harden([keywordIn, keywordOut, CENTRAL_TOKEN]);
+      const amountMaths = zoe.getAmountMaths(keywords);
+      const finalPoolAmountsA = {
+        ...newPoolAmountsA,
+        [keywordOut]: amountMaths[keywordOut].getEmpty(),
+      };
+      const finalPoolAmountsB = {
+        ...newPoolAmountsB,
+        [keywordIn]: amountMaths[keywordIn].getEmpty(),
+      };
+      const finalUserAmounts = {
+        ...newUserAmounts,
+        [keywordIn]: newUserAmountsA[keywordIn],
+      };
+      zoe.reallocate(
+        harden([poolHandleA, poolHandleB, offerHandle]),
+        harden([finalPoolAmountsA, finalPoolAmountsB, finalUserAmounts]),
+        keywords,
+      );
+      zoe.complete(harden([offerHandle]));
+      return `Swap successfully completed.`;
+    }
+  };
+
+  const makeInvite = () => {
+    const seat = harden({
+      addLiquidity: () => addLiquidity(inviteHandle),
+      removeLiquidity: () => removeLiquidity(inviteHandle),
+      swap: () => swap(inviteHandle),
+    });
+    const { invite, inviteHandle } = zoe.makeInvite(seat, {
+      seatDesc: 'autoswapSeat',
+    });
+    return invite;
+  };
+
+  return harden({
+    invite: makeInvite(),
+    publicAPI: {
+      getBrandKeywordRecord: () => {
+        const { issuerKeywordRecord } = zoe.getInstanceRecord();
+        const brandKeywordRecord = {};
+        Object.entries(issuerKeywordRecord).forEach(([keyword, issuer]) => {
+          const { brand } = zoe.getIssuerRecord(issuer);
+          brandKeywordRecord[keyword] = brand;
+        });
+        return harden(brandKeywordRecord);
+      },
+      getKeywordForBrand: brand => {
+        assert(
+          liquidityTable.has(brand),
+          details`There is no pool for this brand. To create a pool, call 'addPool'`,
+        );
+        return liquidityTable.get(brand).tokenKeyword;
+      },
+      addPool,
+      getPoolAllocation,
+      getLiquidityIssuer: tokenBrand =>
+        liquidityTable.get(tokenBrand).liquidityIssuer,
+      makeInvite,
+      /**
+       * `getCurrentPrice` calculates the result of a trade, given a certain
+       * amount of digital assets in.
+       * @param {object} amountIn - the amount of digital assets to be
+       * sent in
+       */
+      getCurrentPrice: (amountIn, brandOut) => {
+        const brandIn = amountIn.brand;
+        // brandIn could either be the central token brand, or one of
+        // the secondary token brands
+
+        // CentralToken to SecondaryToken
+        if (brandIn === centralTokenBrand) {
+          assert(
+            liquidityTable.has(brandOut),
+            details`brandOut ${brandOut} was not recognized`,
+          );
+          return doGetCurrentPrice(
+            harden({
+              amountIn,
+              keywordIn: CENTRAL_TOKEN,
+              keywordOut: liquidityTable.get(brandOut).tokenKeyword,
+              secondaryBrand: brandOut,
+            }),
+          );
+          // eslint-disable-next-line no-else-return
+        } else if (brandOut === centralTokenBrand) {
+          // SecondaryToken to CentralToken
+          assert(
+            liquidityTable.has(brandIn),
+            details`amountIn brand ${amountIn} was not recognized`,
+          );
+          return doGetCurrentPrice(
+            harden({
+              amountIn,
+              keywordIn: liquidityTable.get(brandIn).tokenKeyword,
+              keywordOut: CENTRAL_TOKEN,
+              secondaryBrand: brandIn,
+            }),
+          );
+        } else {
+          // SecondaryToken to SecondaryToken
+          assert(
+            liquidityTable.has(brandIn) && liquidityTable.has(brandOut),
+            details`amountIn brand ${brandIn} or brandOut ${brandOut} was not recognized`,
+          );
+
+          // We must do two consecutive `doGetCurrentPrice` calls: from
+          // the brandIn to the central token, then from the central
+          // token to the brandOut
+          const centralTokenAmount = doGetCurrentPrice(
+            harden({
+              amountIn,
+              keywordIn: liquidityTable.get(brandIn).tokenKeyword,
+              keywordOut: CENTRAL_TOKEN,
+              secondaryBrand: brandIn,
+            }),
+          );
+          return doGetCurrentPrice(
+            harden({
+              amountIn: centralTokenAmount,
+              keywordIn: CENTRAL_TOKEN,
+              keywordOut: liquidityTable.get(brandOut).tokenKeyword,
+              secondaryBrand: brandOut,
+            }),
+          );
+        }
+      },
+    },
+  });
+});

--- a/packages/zoe/test/swingsetTests/zoe/vat-bob.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-bob.js
@@ -448,7 +448,7 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
       );
 
       // bob checks the price of 3 moola. The price is 1 simolean
-      const simoleanAmounts = await E(publicAPI).getPrice(
+      const simoleanAmounts = await E(publicAPI).getCurrentPrice(
         harden({ TokenA: moola(3) }),
       );
       log(`simoleanAmounts `, simoleanAmounts);
@@ -474,7 +474,7 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
       await E(simoleanPurseP).deposit(simoleanPayout1);
 
       // Bob looks up the price of 3 simoleans. It's 5 moola
-      const moolaAmounts = await E(publicAPI).getPrice(
+      const moolaAmounts = await E(publicAPI).getCurrentPrice(
         harden({ TokenB: simoleans(3) }),
       );
       log(`moolaAmounts `, moolaAmounts);

--- a/packages/zoe/test/unitTests/contractSupport/test-bondingCurves.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-bondingCurves.js
@@ -1,18 +1,16 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from 'tape-promise/tape';
-import harden from '@agoric/harden';
 
-import { makeConstProductBC } from '../../../src/contractSupport';
+import { getCurrentPrice } from '../../../src/contractSupport';
 
 const testGetPrice = (t, input, expectedOutput) => {
-  const zoe = harden({});
-  const { getPrice } = makeConstProductBC(zoe);
-
-  const output = getPrice(input);
+  const output = getCurrentPrice(input);
   t.deepEquals(output, expectedOutput);
 };
 
-test('getPrice ok 1', t => {
+// If these tests of `getCurrentPrice` fail, it would indicate that we have
+// diverged from the calculation in the Uniswap paper.
+test('getCurrentPrice ok 1', t => {
   t.plan(1);
   try {
     const input = {
@@ -31,7 +29,7 @@ test('getPrice ok 1', t => {
   }
 });
 
-test('getPrice ok 2', t => {
+test('getCurrentPrice ok 2', t => {
   t.plan(1);
   try {
     const input = {
@@ -50,7 +48,7 @@ test('getPrice ok 2', t => {
   }
 });
 
-test('getPrice ok 3', t => {
+test('getCurrentPrice ok 3', t => {
   t.plan(1);
   try {
     const input = {
@@ -69,7 +67,7 @@ test('getPrice ok 3', t => {
   }
 });
 
-test('getPrice reverse x and y amounts', t => {
+test('getCurrentPrice reverse x and y amounts', t => {
   t.plan(1);
   try {
     // Note: this is now the same test as the one above because we are
@@ -90,7 +88,7 @@ test('getPrice reverse x and y amounts', t => {
   }
 });
 
-test('getPrice ok 4', t => {
+test('getCurrentPrice ok 4', t => {
   t.plan(1);
   try {
     const input = {
@@ -102,6 +100,44 @@ test('getPrice ok 4', t => {
       outputExtent: 9,
       newInputReserve: 1010,
       newOutputReserve: 1,
+    };
+    testGetPrice(t, input, expectedOutput);
+  } catch (e) {
+    t.assert(false, e);
+  }
+});
+
+test('getCurrentPrice ok 5', t => {
+  t.plan(1);
+  try {
+    const input = {
+      inputReserve: 100,
+      outputReserve: 50,
+      inputExtent: 17,
+    };
+    const expectedOutput = {
+      outputExtent: 7,
+      newInputReserve: 117,
+      newOutputReserve: 43,
+    };
+    testGetPrice(t, input, expectedOutput);
+  } catch (e) {
+    t.assert(false, e);
+  }
+});
+
+test('getCurrentPrice ok 6', t => {
+  t.plan(1);
+  try {
+    const input = {
+      outputReserve: 117,
+      inputReserve: 43,
+      inputExtent: 7,
+    };
+    const expectedOutput = {
+      outputExtent: 16,
+      newInputReserve: 50,
+      newOutputReserve: 101,
     };
     testGetPrice(t, input, expectedOutput);
   } catch (e) {

--- a/packages/zoe/test/unitTests/contracts/test-autoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-autoswap.js
@@ -99,7 +99,9 @@ test('autoSwap with valid offers', async t => {
     t.equals(bobInstallationId, installationHandle);
 
     // Bob looks up the price of 3 moola in simoleans
-    const simoleanAmounts = bobAutoswap.getPrice(harden({ TokenA: moola(3) }));
+    const simoleanAmounts = bobAutoswap.getCurrentPrice(
+      harden({ TokenA: moola(3) }),
+    );
     t.deepEquals(simoleanAmounts, simoleans(1));
 
     // Bob escrows
@@ -136,7 +138,9 @@ test('autoSwap with valid offers', async t => {
     });
 
     // Bob looks up the price of 3 simoleans
-    const moolaAmounts = bobAutoswap.getPrice(harden({ TokenB: simoleans(3) }));
+    const moolaAmounts = bobAutoswap.getCurrentPrice(
+      harden({ TokenB: simoleans(3) }),
+    );
     t.deepEquals(moolaAmounts, moola(5));
 
     // Bob makes another offer and swaps
@@ -304,7 +308,7 @@ test('autoSwap - test fee', async t => {
     t.equals(bobInstallationId, installationHandle);
 
     // Bob looks up the price of 1000 moola in simoleans
-    const simoleanAmounts = bobAutoswap.getPrice(
+    const simoleanAmounts = bobAutoswap.getCurrentPrice(
       harden({ TokenA: moola(1000) }),
     );
     t.deepEquals(simoleanAmounts, simoleans(906));

--- a/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
@@ -1,0 +1,539 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from 'tape-promise/tape';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import bundleSource from '@agoric/bundle-source';
+
+import harden from '@agoric/harden';
+import makeAmountMath from '@agoric/ertp/src/amountMath';
+import produceIssuer from '@agoric/ertp';
+import { E } from '@agoric/eventual-send';
+
+import { makeZoe } from '../../../src/zoe';
+import { setup } from '../setupBasicMints2';
+
+const multipoolAutoswapRoot = `${__dirname}/../../../src/contracts/multipoolAutoswap`;
+
+test('multipoolAutoSwap with valid offers', async t => {
+  t.plan(37);
+  try {
+    const { moolaR, simoleanR, moola, simoleans } = setup();
+    const zoe = makeZoe({ require });
+    const inviteIssuer = zoe.getInviteIssuer();
+
+    // Set up central token
+    const centralR = produceIssuer('central');
+    const centralTokens = centralR.amountMath.make;
+
+    // Setup Alice
+    const aliceMoolaPayment = moolaR.mint.mintPayment(moola(100));
+    // Let's assume that central tokens are worth 2x as much as moola
+    const aliceCentralTokenPayment = centralR.mint.mintPayment(
+      centralTokens(50),
+    );
+    const aliceSimoleanPayment = simoleanR.mint.mintPayment(simoleans(398));
+
+    // Setup Bob
+    const bobMoolaPayment = moolaR.mint.mintPayment(moola(17));
+    const bobSimoleanPayment = simoleanR.mint.mintPayment(simoleans(74));
+
+    // Alice creates an autoswap instance
+
+    // Pack the contract.
+    const { source, moduleFormat } = await bundleSource(multipoolAutoswapRoot);
+
+    const installationHandle = zoe.install(source, moduleFormat);
+    const aliceInvite = await zoe.makeInstance(
+      installationHandle,
+      harden({ CentralToken: centralR.issuer }),
+      harden({ CentralToken: centralR.issuer }),
+    );
+
+    const makeAmountMathFromIssuer = issuer =>
+      Promise.all([
+        E(issuer).getBrand(),
+        E(issuer).getMathHelpersName(),
+      ]).then(([brand, mathName]) => makeAmountMath(brand, mathName));
+
+    const inviteAmountMath = await makeAmountMathFromIssuer(inviteIssuer);
+
+    const aliceInviteAmount = await inviteIssuer.getAmountOf(aliceInvite);
+    t.deepEquals(
+      aliceInviteAmount,
+      inviteAmountMath.make(
+        harden([
+          {
+            seatDesc: 'autoswapSeat',
+            instanceHandle: aliceInviteAmount.extent[0].instanceHandle,
+            handle: aliceInviteAmount.extent[0].handle,
+          },
+        ]),
+      ),
+      `seat extent is as expected`,
+    );
+
+    const { publicAPI, handle: instanceHandle } = zoe.getInstance(
+      aliceInviteAmount.extent[0].instanceHandle,
+    );
+
+    const addMoolaPoolResult = await E(publicAPI).addPool(
+      moolaR.issuer,
+      'Moola',
+    );
+    t.equals(
+      addMoolaPoolResult,
+      `liquidity pool for Moola added`,
+      `adding pool for moola`,
+    );
+    const moolaLiquidityIssuer = await E(publicAPI).getLiquidityIssuer(
+      moolaR.brand,
+    );
+    const moolaLiquidityAmountMath = await makeAmountMathFromIssuer(
+      moolaLiquidityIssuer,
+    );
+    const moolaLiquidity = moolaLiquidityAmountMath.make;
+
+    const addSimoleansPoolResult = await E(publicAPI).addPool(
+      simoleanR.issuer,
+      'Simoleans',
+    );
+    t.equals(
+      addSimoleansPoolResult,
+      `liquidity pool for Simoleans added`,
+      `adding pool for simoleans`,
+    );
+    const simoleanLiquidityIssuer = await E(publicAPI).getLiquidityIssuer(
+      simoleanR.brand,
+    );
+    const simoleanLiquidityAmountMath = await makeAmountMathFromIssuer(
+      simoleanLiquidityIssuer,
+    );
+    const simoleanLiquidity = simoleanLiquidityAmountMath.make;
+
+    const { issuerKeywordRecord } = zoe.getInstance(instanceHandle);
+    t.deepEquals(
+      issuerKeywordRecord,
+      harden({
+        CentralToken: centralR.issuer,
+        Moola: moolaR.issuer,
+        MoolaLiquidity: moolaLiquidityIssuer,
+        Simoleans: simoleanR.issuer,
+        SimoleansLiquidity: simoleanLiquidityIssuer,
+      }),
+      `There are keywords for central token and two additional tokens and liquidity`,
+    );
+    t.deepEquals(
+      await E(publicAPI).getPoolAllocation(moolaR.brand),
+      harden({
+        Moola: moolaR.amountMath.getEmpty(),
+        CentralToken: centralR.amountMath.getEmpty(),
+        MoolaLiquidity: moolaLiquidityAmountMath.getEmpty(),
+      }),
+      `The poolAmounts object should only have keywords for Moola, CentralToken, and MoolaLiquidity. Values should be empty`,
+    );
+    t.deepEquals(
+      await E(publicAPI).getPoolAllocation(simoleanR.brand),
+      harden({
+        Simoleans: simoleanR.amountMath.getEmpty(),
+        CentralToken: centralR.amountMath.getEmpty(),
+        SimoleansLiquidity: simoleanLiquidityAmountMath.getEmpty(),
+      }),
+      `The poolAmounts object should only have keywords for Simoleans, CentralToken, and SimoleansLiquidity. Values should be empty`,
+    );
+
+    // Alice adds liquidity
+    // 10 moola = 5 central tokens at the time of the liquidity adding
+    // aka 2 moola = 1 central token
+    const aliceProposal = harden({
+      want: { MoolaLiquidity: moolaLiquidity(50) },
+      give: { Moola: moola(100), CentralToken: centralTokens(50) },
+    });
+    const alicePayments = {
+      Moola: aliceMoolaPayment,
+      CentralToken: aliceCentralTokenPayment,
+    };
+
+    const {
+      seat: aliceSeat,
+      payout: aliceAddLiquidityPayoutP,
+    } = await zoe.redeem(aliceInvite, aliceProposal, alicePayments);
+
+    const liquidityOk = await aliceSeat.addLiquidity();
+    t.equals(
+      liquidityOk,
+      'Added liquidity.',
+      `Alice added moola and central liquidity`,
+    );
+
+    const liquidityPayments = await aliceAddLiquidityPayoutP;
+    const liquidityPayout = await liquidityPayments.MoolaLiquidity;
+
+    t.deepEquals(
+      await moolaLiquidityIssuer.getAmountOf(liquidityPayout),
+      moolaLiquidity(50),
+    );
+    t.deepEquals(
+      await E(publicAPI).getPoolAllocation(moolaR.brand),
+      harden({
+        Moola: moola(100),
+        CentralToken: centralTokens(50),
+        MoolaLiquidity: moolaLiquidity(0),
+      }),
+      `The poolAmounts record should contain the new liquidity`,
+    );
+
+    // Alice creates an invite for autoswap and sends it to Bob
+    const bobInvite = await E(publicAPI).makeInvite();
+
+    // Bob claims it
+    const bobExclInvite = await inviteIssuer.claim(bobInvite);
+    const {
+      extent: [bobInviteExtent],
+    } = await inviteIssuer.getAmountOf(bobExclInvite);
+    const {
+      publicAPI: bobPublicAPI,
+      installationHandle: bobInstallationId,
+    } = zoe.getInstance(bobInviteExtent.instanceHandle);
+    t.equals(
+      bobInstallationId,
+      installationHandle,
+      `installationHandle is as expected`,
+    );
+
+    // Bob can learn the keywords for brands by calling the following
+    // two methods on the publicAPI: getBrandKeywordRecord and getKeywordForBrand
+
+    t.deepEquals(
+      await E(bobPublicAPI).getBrandKeywordRecord(),
+      harden({
+        Moola: moolaR.brand,
+        Simoleans: simoleanR.brand,
+        CentralToken: centralR.brand,
+        MoolaLiquidity: await E(moolaLiquidityIssuer).getBrand(),
+        SimoleansLiquidity: await E(simoleanLiquidityIssuer).getBrand(),
+      }),
+      `keywords have expected brands`,
+    );
+
+    t.equals(
+      await E(bobPublicAPI).getKeywordForBrand(moolaR.brand),
+      'Moola',
+      `moola keyword is Moola`,
+    );
+
+    // Bob looks up the price of 17 moola in central tokens
+    const priceInCentralTokens = bobPublicAPI.getCurrentPrice(
+      moola(17),
+      centralR.brand,
+    );
+    t.deepEquals(
+      priceInCentralTokens,
+      centralTokens(7),
+      `price in central tokens of 17 moola is as expected`,
+    );
+
+    const bobMoolaForCentralProposal = harden({
+      want: { CentralToken: centralTokens(7) },
+      give: { Moola: moola(17) },
+    });
+    const bobMoolaForCentralPayments = harden({ Moola: bobMoolaPayment });
+
+    const { seat: bobSeat, payout: bobPayoutP } = await zoe.redeem(
+      bobExclInvite,
+      bobMoolaForCentralProposal,
+      bobMoolaForCentralPayments,
+    );
+
+    // Bob swaps
+    const offerOk = bobSeat.swap();
+    t.equal(offerOk, 'Swap successfully completed.');
+
+    const bobPayout = await bobPayoutP;
+
+    const bobMoolaPayout1 = await bobPayout.Moola;
+    const bobCentralTokenPayout1 = await bobPayout.CentralToken;
+
+    t.deepEqual(
+      await moolaR.issuer.getAmountOf(bobMoolaPayout1),
+      moola(0),
+      `bob gets no moola back`,
+    );
+    t.deepEqual(
+      await centralR.issuer.getAmountOf(bobCentralTokenPayout1),
+      centralTokens(7),
+      `bob gets the same price as when he called the getCurrentPrice method`,
+    );
+    t.deepEquals(
+      bobPublicAPI.getPoolAllocation(moolaR.brand),
+      {
+        Moola: moola(117),
+        CentralToken: centralTokens(43),
+        MoolaLiquidity: moolaLiquidity(0),
+      },
+      `pool allocation added the moola and subtracted the central tokens`,
+    );
+
+    const bobCentralTokenPurse = await E(centralR.issuer).makeEmptyPurse();
+    await E(bobCentralTokenPurse).deposit(bobCentralTokenPayout1);
+
+    // Bob looks up the price of 7 central tokens in moola
+    const moolaAmounts = bobPublicAPI.getCurrentPrice(
+      centralTokens(7),
+      moolaR.brand,
+    );
+    t.deepEquals(
+      moolaAmounts,
+      moola(16),
+      `the fee was one moola over the two trades`,
+    );
+
+    // Bob makes another offer and swaps
+    const bobSecondInvite = bobPublicAPI.makeInvite();
+    const bobCentralForMoolaProposal = harden({
+      want: { Moola: moola(16) },
+      give: { CentralToken: centralTokens(7) },
+    });
+    const centralForMoolaPayments = harden({
+      CentralToken: await E(bobCentralTokenPurse).withdraw(centralTokens(7)),
+    });
+
+    const {
+      seat: bobSeatCentralForMoola,
+      payout: bobCentralForMoolaPayoutP,
+    } = await zoe.redeem(
+      bobSecondInvite,
+      bobCentralForMoolaProposal,
+      centralForMoolaPayments,
+    );
+
+    const centralForMoolaOk = bobSeatCentralForMoola.swap();
+    t.equal(
+      centralForMoolaOk,
+      'Swap successfully completed.',
+      `second swap successful`,
+    );
+
+    const bobCentralForMoolaPayout = await bobCentralForMoolaPayoutP;
+    const bobMoolaPayout2 = await bobCentralForMoolaPayout.Moola;
+    const bobCentralPayout2 = await bobCentralForMoolaPayout.CentralToken;
+
+    t.deepEqual(
+      await moolaR.issuer.getAmountOf(bobMoolaPayout2),
+      moola(16),
+      `bob gets 16 moola back`,
+    );
+    t.deepEqual(
+      await centralR.issuer.getAmountOf(bobCentralPayout2),
+      centralTokens(0),
+      `bob gets no central tokens back`,
+    );
+    t.deepEqual(
+      bobPublicAPI.getPoolAllocation(moolaR.brand),
+      {
+        Moola: moola(101),
+        CentralToken: centralTokens(50),
+        MoolaLiquidity: moolaLiquidity(0),
+      },
+      `fee added to liquidity pool`,
+    );
+
+    // Alice adds simoleans and central tokens to the simolean
+    // liquidity pool. 398 simoleans = 43 central tokens at the time of
+    // the liquidity adding
+    //
+    const aliceSimCentralLiquidityInvite = publicAPI.makeInvite();
+    const aliceSimCentralProposal = harden({
+      want: { SimoleansLiquidity: simoleanLiquidity(43) },
+      give: { Simoleans: simoleans(398), CentralToken: centralTokens(43) },
+    });
+    const aliceCentralTokenPayment2 = await centralR.mint.mintPayment(
+      centralTokens(43),
+    );
+    const aliceSimCentralPayments = {
+      Simoleans: aliceSimoleanPayment,
+      CentralToken: aliceCentralTokenPayment2,
+    };
+
+    const {
+      seat: aliceSimCentralSeat,
+      payout: aliceSimCentralPayoutP,
+    } = await zoe.redeem(
+      aliceSimCentralLiquidityInvite,
+      aliceSimCentralProposal,
+      aliceSimCentralPayments,
+    );
+
+    const simCentralLiquidityOk = await aliceSimCentralSeat.addLiquidity();
+    t.equals(
+      simCentralLiquidityOk,
+      'Added liquidity.',
+      `Alice added simoleans and central liquidity`,
+    );
+
+    const simCentralPayments = await aliceSimCentralPayoutP;
+    const simoleanLiquidityPayout = await simCentralPayments.SimoleansLiquidity;
+
+    t.deepEquals(
+      await simoleanLiquidityIssuer.getAmountOf(simoleanLiquidityPayout),
+      simoleanLiquidity(43),
+      `simoleanLiquidity minted was equal to the amount of central tokens added to pool`,
+    );
+    t.deepEquals(
+      await E(publicAPI).getPoolAllocation(simoleanR.brand),
+      harden({
+        Simoleans: simoleans(398),
+        CentralToken: centralTokens(43),
+        SimoleansLiquidity: simoleanLiquidity(0),
+      }),
+      `The poolAmounts record should contain the new liquidity`,
+    );
+
+    // Bob tries to swap simoleans for moola. This will go through the
+    // central token, meaning that two swaps will happen synchronously
+    // under the hood.
+
+    // Bob checks the price. Let's say he gives 74 simoleans, and he
+    // wants to know how many moola he would get back.
+
+    const priceInMoola = await E(bobPublicAPI).getCurrentPrice(
+      simoleans(74),
+      moolaR.brand,
+    );
+    t.deepEquals(
+      priceInMoola,
+      moola(10),
+      `price is as expected for secondary token to secondary token`,
+    );
+
+    // This is the same as making two synchronous exchanges
+    const priceInCentral = await E(bobPublicAPI).getCurrentPrice(
+      simoleans(74),
+      centralR.brand,
+    );
+    t.deepEquals(
+      priceInCentral,
+      centralTokens(6),
+      `price is as expected for secondary token to central`,
+    );
+
+    const centralPriceInMoola = await E(bobPublicAPI).getCurrentPrice(
+      centralTokens(6),
+      moolaR.brand,
+    );
+    t.deepEquals(
+      centralPriceInMoola,
+      moola(10),
+      `price is as expected for secondary token to secondary token`,
+    );
+
+    const bobThirdInvite = await E(bobPublicAPI).makeInvite();
+    const bobSimsForMoolaProposal = harden({
+      want: { Moola: moola(10) },
+      give: { Simoleans: simoleans(74) },
+    });
+    const simsForMoolaPayments = harden({
+      Simoleans: bobSimoleanPayment,
+    });
+
+    const {
+      seat: bobSeatSimsForMoola,
+      payout: bobSimsForMoolaPayoutP,
+    } = await zoe.redeem(
+      bobThirdInvite,
+      bobSimsForMoolaProposal,
+      simsForMoolaPayments,
+    );
+
+    bobSeatSimsForMoola.swap();
+
+    const bobSimsForMoolaPayout = await bobSimsForMoolaPayoutP;
+    const bobSimsPayout3 = await bobSimsForMoolaPayout.Simoleans;
+    const bobMoolaPayout3 = await bobSimsForMoolaPayout.Moola;
+
+    t.deepEqual(
+      await moolaR.issuer.getAmountOf(bobMoolaPayout3),
+      moola(10),
+      `bob gets 10 moola`,
+    );
+    t.deepEqual(
+      await simoleanR.issuer.getAmountOf(bobSimsPayout3),
+      simoleans(0),
+      `bob gets no simoleans back`,
+    );
+
+    t.deepEqual(
+      bobPublicAPI.getPoolAllocation(simoleanR.brand),
+      harden({
+        // 398 + 74
+        Simoleans: simoleans(472),
+        // 43 - 6
+        CentralToken: centralTokens(37),
+        SimoleansLiquidity: simoleanLiquidity(0),
+      }),
+      `the simolean liquidity pool gains simoleans and loses central tokens`,
+    );
+    t.deepEqual(
+      bobPublicAPI.getPoolAllocation(moolaR.brand),
+      harden({
+        // 101 - 10
+        Moola: moola(91),
+        // 50 + 6
+        CentralToken: centralTokens(56),
+        MoolaLiquidity: moolaLiquidity(0),
+      }),
+      `the moola liquidity pool loses moola and gains central tokens`,
+    );
+
+    // Alice removes her liquidity
+    // She's not picky...
+    const aliceSecondInvite = publicAPI.makeInvite();
+    const aliceRemoveLiquidityProposal = harden({
+      give: { MoolaLiquidity: moolaLiquidity(50) },
+      want: { Moola: moola(91), CentralToken: centralTokens(56) },
+    });
+
+    const {
+      seat: aliceRemoveLiquiditySeat,
+      payout: aliceRemoveLiquidityPayoutP,
+    } = await zoe.redeem(
+      aliceSecondInvite,
+      aliceRemoveLiquidityProposal,
+      harden({ MoolaLiquidity: liquidityPayout }),
+    );
+
+    const removeLiquidityResult = aliceRemoveLiquiditySeat.removeLiquidity();
+    t.equals(removeLiquidityResult, 'Liquidity successfully removed.');
+
+    const aliceRemoveLiquidityPayout = await aliceRemoveLiquidityPayoutP;
+    const aliceMoolaPayout = await aliceRemoveLiquidityPayout.Moola;
+    const aliceCentralTokenPayout = await aliceRemoveLiquidityPayout.CentralToken;
+    const aliceMoolaLiquidityPayout = await aliceRemoveLiquidityPayout.MoolaLiquidity;
+
+    t.deepEquals(
+      await moolaR.issuer.getAmountOf(aliceMoolaPayout),
+      moola(91),
+      `alice gets all the moola in the pool`,
+    );
+    t.deepEquals(
+      await centralR.issuer.getAmountOf(aliceCentralTokenPayout),
+      centralTokens(56),
+      `alice gets all the central tokens in the pool`,
+    );
+    t.deepEquals(
+      await moolaLiquidityIssuer.getAmountOf(aliceMoolaLiquidityPayout),
+      moolaLiquidity(0),
+      `alice gets no liquidity tokens`,
+    );
+    t.deepEqual(
+      bobPublicAPI.getPoolAllocation(moolaR.brand),
+      harden({
+        Moola: moola(0),
+        CentralToken: centralTokens(0),
+        MoolaLiquidity: moolaLiquidity(50),
+      }),
+      `liquidity is empty`,
+    );
+  } catch (e) {
+    t.assert(false, e);
+    console.log(e);
+  }
+});


### PR DESCRIPTION
To add a new token (and therefore a new liquidity pool with the new token and the central token), the user calls the public `addPool` method on the `publicAPI` with the new token issuer and a keyword. 

```js
    const addMoolaPoolResult = await E(publicAPI).addPool(
      moolaR.issuer,
      'Moola',
    );

    const addSimoleansPoolResult = await E(publicAPI).addPool(
      simoleanR.issuer,
      'Simoleans',
    );
```

The user can see the current liquidity pool allocations (how much liquidity is available) by querying by the secondary token brand:

```js
    t.deepEquals(
      await E(publicAPI).getPoolAllocation(moolaR.brand),
      harden({
        Moola: moolaR.amountMath.getEmpty(),
        CentralToken: centralR.amountMath.getEmpty(),
        MoolaLiquidity: moolaLiquidityAmountMath.getEmpty(),
      }),
      `The poolAmounts object should only have keywords for Moola, CentralToken, and MoolaLiquidity. Values should be empty`,
    );
```

The user can get the current price:

```js
    // Bob looks up the price of 3 moola in central tokens
    const priceInCentralTokens = bobAutoswap.getPrice(moola(3), centralR.brand);
    t.deepEquals(priceInCentralTokens, centralTokens(1));
```

The user can swap tokens:

```js
    const bobMoolaForCentralProposal = harden({
      want: { CentralToken: centralTokens(1) },
      give: { Moola: moola(3) },
    });
    const bobMoolaForCentralPayments = harden({ Moola: bobMoolaPayment });

    const { seat: bobSeat, payout: bobPayoutP } = await zoe.redeem(
      bobExclInvite,
      bobMoolaForCentralProposal,
      bobMoolaForCentralPayments,
    );

    // Bob swaps
    const offerOk = bobSeat.swap();
    t.equal(offerOk, 'Swap successfully completed.');
```

The user can also check the price between two secondary tokens and swap between secondary tokens in the same way as trades with the central token:

```js
    const priceInMoola = await E(bobPublicAPI).getPrice(
      simoleans(74),
      moolaR.brand,
    );
    const bobSimsForMoolaProposal = harden({
      want: { Moola: moola(10) },
      give: { Simoleans: simoleans(74) },
    });

    ... 
    bobSeatSimsForMoola.swap();
```

The two swaps that occur under the hood when trading one secondary token for another, occur synchronously, meaning that no slippage can occur while the swap is happening.

Users (or wallets) can learn what keywords to use by calling `getBrandKeywordRecord` or `getKeywordForBrand`:

```js
    t.deepEquals(
      await E(bobPublicAPI).getBrandKeywordRecord(),
      harden({
        Moola: moolaR.brand,
        Simoleans: simoleanR.brand,
        CentralToken: centralR.brand,
        MoolaLiquidity: await E(moolaLiquidityIssuer).getBrand(),
        SimoleansLiquidity: await E(simoleanLiquidityIssuer).getBrand(),
      }),
      `keywords have expected brands`,
    );

    t.equals(
      await E(bobPublicAPI).getKeywordForBrand(moolaR.brand),
      'Moola',
      `moola keyword is Moola`,
    );
```

TODO:

- [x]  Swapping between two secondary tokens should be synchronous
- [x]  Show how a wallet or users generally can get the mapping from brands to keywords to learn what the keywords are