### PR TITLE
refactor: add makeGetInstanceHandle() and makeGetOfferHandle()

### DIFF
--- a/packages/zoe/src/clientSupport/index.js
+++ b/packages/zoe/src/clientSupport/index.js
@@ -1,0 +1,1 @@
+export { makeGetOfferHandle, makeGetInstanceHandle } from './offerHandle';

--- a/packages/zoe/src/clientSupport/offerHandle.js
+++ b/packages/zoe/src/clientSupport/offerHandle.js
@@ -1,0 +1,15 @@
+import { E } from '@agoric/eventual-send';
+
+export const makeGetOfferHandle = inviteIssuerP => inviteP =>
+  E(inviteIssuerP)
+    .getAmountOf(inviteP)
+    .then(amount => {
+      return amount.extent[0].handle;
+    });
+
+export const makeGetInstanceHandle = inviteIssuerP => inviteP =>
+  E(inviteIssuerP)
+    .getAmountOf(inviteP)
+    .then(amount => {
+      return amount.extent[0].instanceHandle;
+    });

--- a/packages/zoe/test/swingsetTests/zoe/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-alice.js
@@ -1,5 +1,6 @@
 import harden from '@agoric/harden';
 import { showPurseBalance, setupIssuers, getLocalAmountMath } from '../helpers';
+import { makeGetInstanceHandle } from '../../../src/clientSupport';
 
 const build = async (E, log, zoe, issuers, payments, installations, timer) => {
   const { moola, simoleans, purses } = await setupIssuers(zoe, issuers);
@@ -7,6 +8,7 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
   const [moolaPayment, simoleanPayment] = payments;
   const [moolaIssuer, simoleanIssuer] = issuers;
   const inviteIssuer = await E(zoe).getInviteIssuer();
+  const getInstanceHandle = makeGetInstanceHandle(inviteIssuer);
 
   const doAutomaticRefund = async bobP => {
     log(`=> alice.doCreateAutomaticRefund called`);
@@ -16,10 +18,8 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
       Contribution2: simoleanIssuer,
     });
     const invite = await E(zoe).makeInstance(installId, issuerKeywordRecord);
-    const {
-      extent: [{ instanceHandle }],
-    } = await E(inviteIssuer).getAmountOf(invite);
 
+    const instanceHandle = await getInstanceHandle(invite);
     const instanceRecord = await E(zoe).getInstance(instanceHandle);
     const { publicAPI } = instanceRecord;
     const proposal = harden({
@@ -140,9 +140,7 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
       issuerKeywordRecord,
       terms,
     );
-    const {
-      extent: [{ instanceHandle }],
-    } = await E(inviteIssuer).getAmountOf(invite);
+    const instanceHandle = await getInstanceHandle(invite);
     const { publicAPI } = await E(zoe).getInstance(instanceHandle);
 
     const proposal = harden({
@@ -227,9 +225,7 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
       simpleExchange,
       issuerKeywordRecord,
     );
-    const {
-      extent: [{ instanceHandle }],
-    } = await E(inviteIssuer).getAmountOf(invite);
+    const instanceHandle = await getInstanceHandle(invite);
     const { publicAPI } = await E(zoe).getInstance(instanceHandle);
 
     const aliceSellOrderProposal = harden({
@@ -305,9 +301,7 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
       simpleExchange,
       issuerKeywordRecord,
     );
-    const {
-      extent: [{ instanceHandle }],
-    } = await E(inviteIssuer).getAmountOf(invite);
+    const instanceHandle = await getInstanceHandle(invite);
     const { publicAPI } = await E(zoe).getInstance(instanceHandle);
 
     const petnames = ['simoleans', 'moola'];
@@ -362,9 +356,7 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
       installations.autoswap,
       issuerKeywordRecord,
     );
-    const {
-      extent: [{ instanceHandle }],
-    } = await E(inviteIssuer).getAmountOf(invite);
+    const instanceHandle = await getInstanceHandle(invite);
     const { publicAPI } = await E(zoe).getInstance(instanceHandle);
     const liquidityIssuer = await E(publicAPI).getLiquidityIssuer();
     const liquidityAmountMath = await getLocalAmountMath(liquidityIssuer);

--- a/packages/zoe/test/swingsetTests/zoe/vat-bob.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-bob.js
@@ -2,6 +2,7 @@ import harden from '@agoric/harden';
 import { assert, details } from '@agoric/assert';
 import { sameStructure } from '@agoric/same-structure';
 import { showPurseBalance, setupIssuers } from '../helpers';
+import { makeGetInstanceHandle } from '../../../src/clientSupport';
 
 const build = async (E, log, zoe, issuers, payments, installations, timer) => {
   const {
@@ -16,14 +17,13 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
   const [moolaPayment, simoleanPayment] = payments;
   const [moolaIssuer, simoleanIssuer, bucksIssuer] = issuers;
   const inviteIssuer = await E(zoe).getInviteIssuer();
+  const getInstanceHandle = makeGetInstanceHandle(inviteIssuer);
 
   return harden({
     doAutomaticRefund: async inviteP => {
       const invite = await inviteP;
       const exclInvite = await E(inviteIssuer).claim(invite);
-      const {
-        extent: [{ instanceHandle }],
-      } = await E(inviteIssuer).getAmountOf(exclInvite);
+      const instanceHandle = await getInstanceHandle(exclInvite);
 
       const { installationHandle, issuerKeywordRecord } = await E(
         zoe,
@@ -91,9 +91,8 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
         exclInvite,
       );
 
-      const instanceInfo = await E(zoe).getInstance(
-        optionExtent[0].instanceHandle,
-      );
+      const instanceHandle = await getInstanceHandle(exclInvite);
+      const instanceInfo = await E(zoe).getInstance(instanceHandle);
 
       assert(
         instanceInfo.installationHandle === installations.coveredCall,

--- a/packages/zoe/test/swingsetTests/zoe/vat-dave.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-dave.js
@@ -2,6 +2,7 @@ import harden from '@agoric/harden';
 import { assert, details } from '@agoric/assert';
 import { sameStructure } from '@agoric/same-structure';
 import { showPurseBalance, setupIssuers } from '../helpers';
+import { makeGetInstanceHandle } from '../../../src/clientSupport';
 
 const build = async (E, log, zoe, issuers, payments, installations, timer) => {
   const {
@@ -16,6 +17,7 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
   const [_moolaPayment, simoleanPayment, bucksPayment] = payments;
   const [moolaIssuer, simoleanIssuer, bucksIssuer] = issuers;
   const inviteIssuer = await E(zoe).getInviteIssuer();
+  const getInstanceHandle = makeGetInstanceHandle(inviteIssuer);
 
   return harden({
     doPublicAuction: async inviteP => {
@@ -78,9 +80,10 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
       const { extent: inviteExtent } = await E(inviteIssuer).getAmountOf(
         exclInvite,
       );
+      const instanceHandle = await getInstanceHandle(exclInvite);
       const { installationHandle, issuerKeywordRecord } = await E(
         zoe,
-      ).getInstance(inviteExtent[0].instanceHandle);
+      ).getInstance(instanceHandle);
       assert(
         installationHandle === installations.atomicSwap,
         details`wrong installation`,

--- a/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
+++ b/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
@@ -8,6 +8,7 @@ import harden from '@agoric/harden';
 import { makeZoe } from '../../../src/zoe';
 // TODO: Remove setupBasicMints and rename setupBasicMints2
 import { setup } from '../setupBasicMints2';
+import { makeGetInstanceHandle } from '../../../src/clientSupport';
 
 const automaticRefundRoot = `${__dirname}/../../../src/contracts/automaticRefund`;
 
@@ -115,6 +116,7 @@ test('zoe with automaticRefund', async t => {
     const { moolaR, simoleanR, moola, simoleans } = setup();
     const zoe = makeZoe({ require });
     const inviteIssuer = zoe.getInviteIssuer();
+    const getInstanceHandle = makeGetInstanceHandle(inviteIssuer);
 
     // Setup Alice
     const aliceMoolaPayment = moolaR.mint.mintPayment(moola(3));
@@ -139,9 +141,7 @@ test('zoe with automaticRefund', async t => {
       installationHandle,
       issuerKeywordRecord,
     );
-    const {
-      extent: [{ instanceHandle }],
-    } = await inviteIssuer.getAmountOf(aliceInvite);
+    const instanceHandle = await getInstanceHandle(aliceInvite);
     const { publicAPI } = zoe.getInstance(instanceHandle);
 
     // 2: Alice escrows with zoe
@@ -174,9 +174,7 @@ test('zoe with automaticRefund', async t => {
     // will check that the installationId and terms match what he
     // expects
     const exclusBobInvite = await inviteIssuer.claim(bobInvite);
-    const {
-      extent: [{ instanceHandle: bobInstanceHandle }],
-    } = await inviteIssuer.getAmountOf(exclusBobInvite);
+    const bobInstanceHandle = await getInstanceHandle(exclusBobInvite);
 
     const {
       installationHandle: bobInstallationId,
@@ -284,13 +282,12 @@ test('multiple instances of automaticRefund for the same Zoe', async t => {
       ContributionB: simoleanR.issuer,
     });
     const inviteIssuer = zoe.getInviteIssuer();
+    const getInstanceHandle = makeGetInstanceHandle(inviteIssuer);
     const aliceInvite1 = await zoe.makeInstance(
       installationHandle,
       issuerKeywordRecord,
     );
-    const {
-      extent: [{ instanceHandle: instanceHandle1 }],
-    } = await inviteIssuer.getAmountOf(aliceInvite1);
+    const instanceHandle1 = await getInstanceHandle(aliceInvite1);
     const { publicAPI: publicAPI1 } = zoe.getInstance(instanceHandle1);
 
     const aliceInvite2 = await zoe.makeInstance(
@@ -306,9 +303,7 @@ test('multiple instances of automaticRefund for the same Zoe', async t => {
       installationHandle,
       issuerKeywordRecord,
     );
-    const {
-      extent: [{ instanceHandle: instanceHandle3 }],
-    } = await inviteIssuer.getAmountOf(aliceInvite3);
+    const instanceHandle3 = await getInstanceHandle(aliceInvite3);
     const { publicAPI: publicAPI3 } = zoe.getInstance(instanceHandle3);
 
     // 2: Alice escrows with zoe

--- a/packages/zoe/test/unitTests/contracts/test-autoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-autoswap.js
@@ -7,6 +7,7 @@ import harden from '@agoric/harden';
 
 import { makeZoe } from '../../../src/zoe';
 import { setup } from '../setupBasicMints2';
+import { makeGetInstanceHandle } from '../../../src/clientSupport';
 
 const autoswapRoot = `${__dirname}/../../../src/contracts/autoswap`;
 
@@ -16,6 +17,7 @@ test('autoSwap with valid offers', async t => {
     const { moolaR, simoleanR, moola, simoleans } = setup();
     const zoe = makeZoe({ require });
     const inviteIssuer = zoe.getInviteIssuer();
+    const getInstanceHandle = makeGetInstanceHandle(inviteIssuer);
 
     // Setup Alice
     const aliceMoolaPayment = moolaR.mint.mintPayment(moola(10));
@@ -40,9 +42,7 @@ test('autoSwap with valid offers', async t => {
       installationHandle,
       issuerKeywordRecord,
     );
-    const {
-      extent: [{ instanceHandle }],
-    } = await inviteIssuer.getAmountOf(aliceInvite);
+    const instanceHandle = await getInstanceHandle(aliceInvite);
     const { publicAPI } = zoe.getInstance(instanceHandle);
     const liquidityIssuer = publicAPI.getLiquidityIssuer();
     const liquidity = liquidityIssuer.getAmountMath().make;
@@ -85,13 +85,11 @@ test('autoSwap with valid offers', async t => {
 
     // Bob claims it
     const bobExclInvite = await inviteIssuer.claim(bobInvite);
-    const {
-      extent: [bobInviteExtent],
-    } = await inviteIssuer.getAmountOf(bobExclInvite);
+    const bobInstanceHandle = await getInstanceHandle(bobExclInvite);
     const {
       publicAPI: bobAutoswap,
       installationHandle: bobInstallationId,
-    } = zoe.getInstance(bobInviteExtent.instanceHandle);
+    } = zoe.getInstance(bobInstanceHandle);
     t.equals(bobInstallationId, installationHandle);
 
     // Bob looks up the price of 3 moola in simoleans
@@ -222,6 +220,7 @@ test('autoSwap - test fee', async t => {
     const { moolaR, simoleanR, moola, simoleans } = setup();
     const zoe = makeZoe({ require });
     const inviteIssuer = zoe.getInviteIssuer();
+    const getInstanceHandle = makeGetInstanceHandle(inviteIssuer);
 
     // Setup Alice
     const aliceMoolaPayment = moolaR.mint.mintPayment(moola(10000));
@@ -244,9 +243,7 @@ test('autoSwap - test fee', async t => {
       installationHandle,
       issuerKeywordRecord,
     );
-    const {
-      extent: [{ instanceHandle }],
-    } = await inviteIssuer.getAmountOf(aliceInvite);
+    const instanceHandle = await getInstanceHandle(aliceInvite);
     const { publicAPI } = zoe.getInstance(instanceHandle);
     const liquidityIssuer = publicAPI.getLiquidityIssuer();
     const liquidity = liquidityIssuer.getAmountMath().make;
@@ -290,13 +287,11 @@ test('autoSwap - test fee', async t => {
 
     // Bob claims it
     const bobExclInvite = await inviteIssuer.claim(bobInvite);
-    const {
-      extent: [bobInviteExtent],
-    } = await inviteIssuer.getAmountOf(bobExclInvite);
+    const bobInstanceHandle = await getInstanceHandle(bobExclInvite);
     const {
       publicAPI: bobAutoswap,
       installationHandle: bobInstallationId,
-    } = zoe.getInstance(bobInviteExtent.instanceHandle);
+    } = zoe.getInstance(bobInstanceHandle);
     t.equals(bobInstallationId, installationHandle);
 
     // Bob looks up the price of 1000 moola in simoleans

--- a/packages/zoe/test/unitTests/contracts/test-publicAuction.js
+++ b/packages/zoe/test/unitTests/contracts/test-publicAuction.js
@@ -7,6 +7,7 @@ import harden from '@agoric/harden';
 
 import { makeZoe } from '../../../src/zoe';
 import { setup } from '../setupBasicMints2';
+import { makeGetInstanceHandle } from '../../../src/clientSupport';
 
 const publicAuctionRoot = `${__dirname}/../../../src/contracts/publicAuction`;
 
@@ -16,6 +17,7 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
     const { moolaR, simoleanR, moola, simoleans } = setup();
     const zoe = makeZoe({ require });
     const inviteIssuer = zoe.getInviteIssuer();
+    const getInstanceHandle = makeGetInstanceHandle(inviteIssuer);
 
     // Setup Alice
     const aliceMoolaPayment = moolaR.mint.mintPayment(moola(1));
@@ -55,9 +57,7 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
       terms,
     );
 
-    const {
-      extent: [{ instanceHandle }],
-    } = await inviteIssuer.getAmountOf(aliceInvite);
+    const instanceHandle = await getInstanceHandle(aliceInvite);
     const { publicAPI } = zoe.getInstance(instanceHandle);
 
     // Alice escrows with zoe


### PR DESCRIPTION
These helper functions provide convenient accessors for getting the
offerHandle starting from an invite.

Update tests to use it when appropriate.

These helpers are available in '.../zoe/src/clientSupport'