### PR TITLE
Clear up presences vs. remotables

### DIFF
--- a/packages/agoric-cli/bin/agoric
+++ b/packages/agoric-cli/bin/agoric
@@ -2,12 +2,15 @@
 
 /* global globalThis */
 
-// Suppress the "'@agoric/harden' is ineffective without SES" warning. This
-// only affects uses inside the 'agoric' tool, not child processes. See #971
+const esmRequire = require('esm')(module);
+
+// Do a dance to suppress the "'@agoric/harden' is ineffective without SES" warning.
+// This only affects uses inside the 'agoric' tool, not child processes. See #971
 // for details.
 globalThis.harden = null;
+// Now redefine to cache the instance.
+globalThis.harden = esmRequire('@agoric/harden');
 
-const esmRequire = require('esm')(module);
 const path = require('path');
 const WebSocket = require('ws');
 const { spawn } = require('child_process');

--- a/packages/captp/lib/captp.js
+++ b/packages/captp/lib/captp.js
@@ -1,6 +1,6 @@
 // This logic was mostly lifted from @agoric/swingset-vat liveSlots.js
 // Defects in it are mfig's fault.
-import { makeMarshal, QCLASS } from '@agoric/marshal';
+import { Remotable, makeMarshal, QCLASS } from '@agoric/marshal';
 import harden from '@agoric/harden';
 import Nat from '@agoric/nat';
 import { HandledPromise, E } from '@agoric/eventual-send';
@@ -111,11 +111,9 @@ export function makeCapTP(ourId, send, bootstrapObj = undefined) {
       // Make a new handled promise for the slot.
       const pr = makeRemote(slot);
       if (slot[0] === 'o') {
-        // A new presence
-        const presence = pr.resPres();
-        presence.toString = () => `[Presence ${ourId} ${slot}]`;
-        harden(presence);
-        val = presence;
+        // A new remote presence
+        const pres = pr.resPres();
+        val = Remotable(`Presence ${ourId} ${slot}`, undefined, pres);
       } else {
         // A new promise
         imports.set(Number(slot.slice(2)), pr);

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-http.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-http.js
@@ -4,7 +4,7 @@ import { getReplHandler } from './repl';
 import { getCapTPHandler } from './captp';
 
 // This vat contains the HTTP request handler.
-function build(E, D) {
+function build(E, D, vatPowers) {
   let commandDevice;
   let provisioner;
   const channelIdToHandle = new Map();
@@ -68,7 +68,7 @@ function build(E, D) {
       if (ROLES.client) {
         handler.readyForClient = () => readyForClient.p;
 
-        const replHandler = getReplHandler(E, homeObjects, send);
+        const replHandler = getReplHandler(E, homeObjects, send, vatPowers);
         registerURLHandler(replHandler, '/private/repl');
 
         // Assign the captp handler.
@@ -210,7 +210,9 @@ export default function setup(syscall, state, helpers) {
   return helpers.makeLiveSlots(
     syscall,
     state,
-    (E, D) => harden(build(E, D)),
+    (E, D, powers) => {
+      return harden(build(E, D, powers));
+    },
     helpers.vatID,
   );
 }

--- a/packages/marshal/test/test-marshal.js
+++ b/packages/marshal/test/test-marshal.js
@@ -2,7 +2,12 @@
 
 import { test } from 'tape-promise/tape';
 import harden from '@agoric/harden';
-import { makeMarshal, mustPassByPresence } from '../marshal';
+import {
+  Remotable,
+  getInterfaceOf,
+  makeMarshal,
+  mustPassByPresence,
+} from '../marshal';
 
 // this only includes the tests that do not use liveSlots
 
@@ -171,5 +176,52 @@ test('mal-formed @qclass', t => {
   const m = makeMarshal();
   const uns = body => m.unserialize({ body, slots: [] });
   t.throws(() => uns('{"@qclass": 0}'), /invalid qclass/);
+  t.end();
+});
+
+test('Remotable/getInterfaceOf', t => {
+  t.throws(
+    () => Remotable({ bar: 29 }),
+    /unimplemented/,
+    'object ifaces are not implemented',
+  );
+  t.throws(
+    () => Remotable('MyHandle', { foo: 123 }),
+    /cannot serialize/,
+    'non-function props are not implemented',
+  );
+  t.throws(
+    () => Remotable('MyHandle', {}, a => a + 1),
+    /cannot serialize/,
+    'function presences are not implemented',
+  );
+
+  t.equals(getInterfaceOf('foo'), undefined, 'string, no interface');
+  t.equals(getInterfaceOf(null), undefined, 'null, no interface');
+  t.equals(
+    getInterfaceOf(a => a + 1),
+    undefined,
+    'function, no interface',
+  );
+  t.equals(getInterfaceOf(123), undefined, 'number, no interface');
+
+  // Check that a handle can be created.
+  const p = Remotable('MyHandle');
+  harden(p);
+  // console.log(p);
+  t.equals(getInterfaceOf(p), 'MyHandle', `interface is MyHandle`);
+  t.equals(`${p}`, '[MyHandle]', 'stringify is [MyHandle]');
+
+  const p2 = Remotable('Thing', {
+    name() {
+      return 'cretin';
+    },
+    birthYear(now) {
+      return now - 64;
+    },
+  });
+  t.equals(getInterfaceOf(p2), 'Thing', `interface is Thing`);
+  t.equals(p2.name(), 'cretin', `name() method is presence`);
+  t.equals(p2.birthYear(2020), 1956, `birthYear() works`);
   t.end();
 });

--- a/packages/marshal/test/test-marshal.js
+++ b/packages/marshal/test/test-marshal.js
@@ -168,7 +168,7 @@ test('unserialize ibid cycle', t => {
 });
 
 test('null cannot be pass-by-presence', t => {
-  t.throws(() => mustPassByPresence(null), /null cannot be pass-by-presence/);
+  t.throws(() => mustPassByPresence(null), /null cannot be pass-by-remote/);
   t.end();
 });
 


### PR DESCRIPTION
This implements the first part of the #804 plan for explicitly creating remotables via the `@agoric/marshal` `Remotable()` function.

`Remotable` and `getInterfaceOf` should be shared across marshal systems within the vat that imports them.  I explicitly provide them to the liveSlots caller in order to expose to the vat code that uses it, rather than bundling a new copy of `@agoric/marshal` and getting a different instance of the WeakMap that keeps the interface information.

This is the smallest step forward that properly solves #792 without needing more far-reaching changes.

Here is some annotated REPL output:
```
// Show how presences print
command[0] home
history[0] {"chainTimerService":[Presence o-50]{},"sharingService":[Presence o-51]{},"contractHost":[Presence o-52]{},"registrar":[Presence o-53]{},"zoe":[Presence o-54]{},"localTimerService":[Presence o-55]{},"uploads":[Presence o-56]{},"spawner":[Presence o-57]{},"wallet":[Presence o-58]{},"http":[Presence o-59]{}}
// Try making a remotable from an array
command[2] a = []
history[2] []
command[3] Remotable('Foo', {abc: 1}, a)
history[3] exception: Error: Arrays cannot be pass-by-presence
// Note that there is no mutation.
command[4] a
history[4] []
// Try adding a property to an empty remotable.
command[5] Remotable('Foo', {abc: 1})
history[5] exception: Error: cannot serialize objects with non-methods like the .abc in [Foo]
// Add a method to an empty remotable.
command[6] Remotable('Foo', {abc() { return 'def' }})
history[6] [Foo]{"abc":[Function abc]}
// Call the method.
command[7] history[6].abc()
history[7] "def"
// Use tildot.
command[8] history[6]~.abc()
history[8] "def"
// Try making a function into a remotable.
command[9] Remotable('Foo', {abc() { return 'def' }}, a => a + 1)
history[9] exception: Error: cannot serialize non-objects like a => a + 1
// Demonstrate that getInterfaceOf shows the iface we attached.
command[11] getInterfaceOf(history[6])
history[11] "Foo"
```
