### PR TITLE
fix: revive the ability of a zoe client to get access to the code.

### DIFF
--- a/packages/zoe/src/state.js
+++ b/packages/zoe/src/state.js
@@ -6,9 +6,11 @@ import makeAmountMath from '@agoric/ertp/src/amountMath';
 import { makeTable, makeValidateProperties } from './table';
 
 // Installation Table
-// Columns: handle | installation
+// Columns: handle | installation | code
 const makeInstallationTable = () => {
-  const validateSomewhat = makeValidateProperties(harden(['installation']));
+  const validateSomewhat = makeValidateProperties(
+    harden(['installation', 'code']),
+  );
   return makeTable(validateSomewhat);
 };
 

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -321,7 +321,7 @@ const makeZoe = (additionalEndowments = {}) => {
         }
       }
       const installationHandle = installationTable.create(
-        harden({ installation }),
+        harden({ installation, code }),
       );
       return installationHandle;
     },
@@ -500,6 +500,8 @@ const makeZoe = (additionalEndowments = {}) => {
     isOfferActive: offerTable.isOfferActive,
     getOffers: offerTable.getOffers,
     getOffer: offerTable.get,
+    getInstallation: installationHandle =>
+      installationTable.get(installationHandle).code,
   });
   return zoeService;
 };

--- a/packages/zoe/test/swingsetTests/zoe/vat-dave.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-dave.js
@@ -84,6 +84,17 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
       const { installationHandle, issuerKeywordRecord } = await E(
         zoe,
       ).getInstance(instanceHandle);
+      const installationCode = await E(zoe).getInstallation(installationHandle);
+      // pick some arbitrary code points as a signature.
+      assert(
+        installationCode.indexOf("['Asset', 'Price']") === 58060,
+        details`source code didn't match`,
+      );
+      assert(
+        installationCode.indexOf('makeMatchingInvite') === 58091,
+        installationCode.indexOf('makeFirstOfferInvite') === 58498,
+        details`source code didn't match`,
+      );
       assert(
         installationHandle === installations.atomicSwap,
         details`wrong installation`,


### PR DESCRIPTION
It's tested in an existing large test by checking for specific text in
the source code. We could check something less fragile (e.g. starts
with 'function getExport'), and still be pretty sure that if a string
is returned, it would continue to be the source of the contract.

fixes #877