### PR TITLE
Supply returnedP argument to handler

### DIFF
--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -74,9 +74,9 @@ function build(syscall, _state, makeRoot, forVatID) {
   function makeQueued(slot) {
     /* eslint-disable no-use-before-define */
     const handler = {
-      applyMethod(_o, prop, args) {
+      applyMethod(_o, prop, args, returnedP) {
         // Support: o~.[prop](...args) remote method invocation
-        return queueMessage(slot, prop, args);
+        return queueMessage(slot, prop, args, returnedP);
       },
     };
     /* eslint-enable no-use-before-define */
@@ -232,7 +232,7 @@ function build(syscall, _state, makeRoot, forVatID) {
 
   const m = makeMarshal(convertValToSlot, convertSlotToVal);
 
-  function queueMessage(targetSlot, prop, args) {
+  function queueMessage(targetSlot, prop, args, returnedP) {
     const serArgs = m.serialize(harden(args));
     const result = allocatePromiseID();
     const done = makeQueued(result);
@@ -247,10 +247,10 @@ function build(syscall, _state, makeRoot, forVatID) {
     lsdebug(`ls[${forVatID}].queueMessage.importedPromiseThen ${result}`);
     importedPromiseThen(result);
 
-    // prepare the serializer to recognize it, if it's used as an argument or
-    // return value
-    valToSlot.set(done.p, result);
-    slotToVal.set(result, done.p);
+    // prepare the serializer to recognize the promise we will return,
+    // if it's used as an argument or return value
+    valToSlot.set(returnedP, result);
+    slotToVal.set(result, returnedP);
 
     return done.p;
   }

--- a/packages/SwingSet/test/test-vpid-liveslots.js
+++ b/packages/SwingSet/test/test-vpid-liveslots.js
@@ -151,10 +151,10 @@ async function doVatResolveCase1(t, mode) {
       async run(target1) {
         const p1 = pr.promise;
         E(target1).one(p1);
+        resolvePR(pr, mode);
         // TODO: this stall shouldn't be necessary, but if I omit it, the
         // fulfillToPresence happens *after* two() is sent
         await Promise.resolve();
-        resolvePR(pr, mode);
         E(target1).two(p1);
       },
     });

--- a/packages/eventual-send/src/index.js
+++ b/packages/eventual-send/src/index.js
@@ -439,6 +439,7 @@ export function makeHandledPromise(Promise) {
     p = shorten(p);
     const unfulfilledHandler = promiseToHandler.get(p);
     let executor;
+    let returnedP;
     if (
       unfulfilledHandler &&
       typeof unfulfilledHandler[operation] === 'function'
@@ -448,7 +449,7 @@ export function makeHandledPromise(Promise) {
         HandledPromise.resolve()
           .then(() =>
             // and resolve to the answer from the specific unfulfilled handler,
-            resolve(unfulfilledHandler[operation](p, ...args)),
+            resolve(unfulfilledHandler[operation](p, ...args, returnedP)),
           )
           .catch(reject);
       };
@@ -464,7 +465,7 @@ export function makeHandledPromise(Promise) {
               );
             }
             // and resolve to the forwardingHandler's operation.
-            resolve(forwardingHandler[operation](o, ...args));
+            resolve(forwardingHandler[operation](o, ...args, returnedP));
           })
           .catch(reject);
       };
@@ -473,7 +474,8 @@ export function makeHandledPromise(Promise) {
     // We return a handled promise with the default unfulfilled handler.
     // This prevents a race between the above Promise.resolves and
     // pipelining.
-    return new HandledPromise(executor);
+    returnedP = new HandledPromise(executor);
+    return returnedP;
   };
 
   promiseResolve = Promise.resolve.bind(Promise);

--- a/packages/eventual-send/test/test-hp.js
+++ b/packages/eventual-send/test/test-hp.js
@@ -7,9 +7,9 @@ test('chained properties', async t => {
     const data = {};
     const queue = [];
     const handler = {
-      applyMethod(_o, prop, args) {
+      applyMethod(_o, prop, args, target) {
         // Support: o~.[prop](...args) remote method invocation
-        queue.push([0, prop, args]);
+        queue.push([0, prop, args, target]);
         return data;
         // return queueMessage(slot, prop, args);
       },
@@ -33,8 +33,8 @@ test('chained properties', async t => {
     t.deepEqual(
       queue,
       [
-        [0, 'cont0', []],
-        [0, 'cont1', []],
+        [0, 'cont0', [], hp],
+        [0, 'cont1', [], hp],
       ],
       `first turn`,
     );


### PR DESCRIPTION
Closes #886

This PR adds `returnedP` (a reference to the HandledPromise that was created for this call) as the last argument to the handler methods (currently `applyMethod` or `get`), as explained in https://github.com/Agoric/agoric-sdk/issues/886#issuecomment-611090801
