### PR TITLE
Full types for Zoe service and contract facet

### DIFF
--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -1,8 +1,107 @@
+// @ts-check
 import harden from '@agoric/harden';
 import { assert, details } from '@agoric/assert';
 
 import { mustBeSameStructure, mustBeComparable } from '@agoric/same-structure';
 import mathHelpersLib from './mathHelpersLib';
+
+/**
+ * @typedef {Object} Amount
+ * Amounts are descriptions of digital assets, answering the questions
+ * "how much" and "of what kind". Amounts are extents labeled with a brand.
+ * AmountMath executes the logic of how amounts are changed when digital
+ * assets are merged, separated, or otherwise manipulated. For
+ * example, a deposit of 2 bucks into a purse that already has 3 bucks
+ * gives a new purse balance of 5 bucks. An empty purse has 0 bucks. AmountMath
+ * relies heavily on polymorphic MathHelpers, which manipulate the unbranded
+ * portion.
+ *
+ * @property {Brand} brand
+ * @property {Extent} extent
+ */
+
+/**
+ * @typedef {Object} Extent
+ * Extents describe the extent of something that can be owned or shared.
+ * Fungible extents are normally represented by natural numbers. Other
+ * extents may be represented as strings naming a particular right, or
+ * an arbitrary object that sensibly represents the rights at issue.
+ *
+ * Extent must be Comparable. (This IDL doesn't yet provide a way to specify
+ * subtype relationships for structs.)
+ */
+
+/**
+ * @typedef {Object} AmountMath
+ * Logic for manipulating amounts.
+ *
+ * Amounts are the canonical description of tradable goods. They are manipulated
+ * by issuers and mints, and represent the goods and currency carried by purses and
+ * payments. They can be used to represent things like currency, stock, and the
+ * abstract right to participate in a particular exchange.
+ *
+ * @property {() => Brand} getBrand Return the brand.
+ * @property {() => string} getMathHelpersName
+ * Get the name of the mathHelpers used. This can be used as an
+ * argument to `makeAmountMath` to create local amountMath.
+ *
+ * @property {(allegedExtent: Extent) => Amount} make
+ * Make an amount from an extent by adding the brand.
+ *
+ * @property {(allegedAmount: Amount) => Amount} coerce
+ * Make sure this amount is valid and return it if so.
+ *
+ * @property {(amount: Amount) => Extent} extent
+ * Extract and return the extent.
+ *
+ * @property {() => Amount} getEmpty
+ * Return the amount representing an empty amount. This is the
+ * identity element for MathHelpers.add and MatHelpers.subtract.
+ *
+ * @property {(amount: Amount) => boolean} isEmpty
+ * Return true if the Amount is empty. Otherwise false.
+ *
+ * @property {(leftAmount: Amount, rightAmount: Amount) => boolean} isGTE
+ * Returns true if the leftAmount is greater than or equal to the
+ * rightAmount. For non-scalars, "greater than or equal to" depends
+ * on the kind of amount, as defined by the MathHelpers. For example,
+ * whether rectangle A is greater than rectangle B depends on whether rectangle
+ * A includes rectangle B as defined by the logic in MathHelpers.
+ *
+ * @property {(leftAmount: Amount, rightAmount: Amount) => boolean} isEqual
+ * Returns true if the leftAmount equals the rightAmount. We assume
+ * that if isGTE is true in both directions, isEqual is also true
+ *
+ * @property {(leftAmount: Amount, rightAmount: Amount) => Amount} add
+ * Returns a new amount that is the union of both leftAmount and rightAmount.
+ *
+ * For fungible amount this means adding the extents. For other kinds of
+ * amount, it usually means including all of the elements from both
+ * left and right.
+ *
+ * @property {(leftAmount: Amount, rightAmount: Amount) => Amount} subtract
+ * Returns a new amount that is the leftAmount minus the rightAmount
+ * (i.e. everything in the leftAmount that is not in the
+ * rightAmount). If leftAmount doesn't include rightAmount
+ * (subtraction results in a negative), throw  an error. Because the
+ * left amount must include the right amount, this is NOT equivalent
+ * to set subtraction.
+ */
+
+/**
+ * @typedef {Object} Brand
+ * The brand identifies the kind of issuer, and has a function to get the
+ * alleged name for the kind of asset described. The alleged name (such
+ * as 'BTC' or 'moola') is provided by the maker of the issuer and should
+ * not be trusted as accurate.
+ *
+ * Every amount created by AmountMath will have the same brand, but recipients
+ * cannot use the brand by itself to verify that a purported amount is
+ * authentic, since the brand can be reused by a misbehaving issuer.
+ *
+ * @property {(issuer: Issuer) => boolean} isMyIssuer
+ * @property {() => string} getAllegedName
+ */
 
 // Amounts describe digital assets. From an amount, you can learn the
 // kind of digital asset as well as "how much" or "how many". Amounts

--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -51,7 +51,7 @@ import mathHelpersLib from './mathHelpersLib';
  * @property {(allegedAmount: Amount) => Amount} coerce
  * Make sure this amount is valid and return it if so.
  *
- * @property {(amount: Amount) => Extent} extent
+ * @property {(amount: Amount) => Extent} getExtent
  * Extract and return the extent.
  *
  * @property {() => Amount} getEmpty

--- a/packages/ERTP/src/issuer.js
+++ b/packages/ERTP/src/issuer.js
@@ -1,4 +1,5 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
+// @ts-check
 
 import harden from '@agoric/harden';
 import { assert, details } from '@agoric/assert';
@@ -7,6 +8,211 @@ import { isPromise } from '@agoric/produce-promise';
 
 import makeAmountMath from './amountMath';
 
+/**
+ * @typedef {import('./amountMath').Amount} Amount
+ * @typedef {import('./amountMath').Extent} Extent
+ * @typedef {import('./amountMath').AmountMath} AmountMath
+ */
+
+/**
+ * @typedef {Object} Issuer
+ * The issuer cannot mint a new amount, but it can create empty purses and
+ * payments. The issuer can also transform payments (splitting payments,
+ * combining payments, burning payments, and claiming payments
+ * exclusively). The issuer should be gotten from a trusted source and
+ * then relied upon as the decider of whether an untrusted payment is valid.
+ *
+ * @property {() => Brand} getBrand Get the Brand for this Issuer. The Brand indicates the kind of
+ * digital asset and is shared by the mint, the issuer, and any purses
+ * and payments of this particular kind. The brand is not closely
+ * held, so this function should not be trusted to identify an issuer
+ * alone. Fake digital assets and amount can use another issuer's brand.
+ *
+ * @property {() => string} getAllegedName Get the allegedName for this mint/issuer
+ * @property {() => AmountMath} getAmountMath Get the AmountMath for this Issuer.
+ * @property {() => string} getMathHelpersName Get the name of the MathHelpers for this Issuer.
+ * @property {() => Purse} makeEmptyPurse Make an empty purse of this brand.
+ * @property {(payment: Payment) => boolean} isLive
+ * Return true if the payment continues to exist.
+ *
+ * If the payment is a promise, the operation will proceed upon resolution.
+ *
+ * @property {(payment: Payment) => Amount} getAmountOf
+ * Get the amount of digital assets in the payment. Because the
+ * payment is not trusted, we cannot call a method on it directly,
+ * and must use the issuer instead.
+ *
+ * If the payment is a promise, the operation will proceed upon resolution.
+ *
+ * @property {(payment: Payment, optAmount?: Amount) => Amount} burn
+ * Burn all of the digital assets in the payment. `optAmount` is optional.
+ * If `optAmount` is present, the code will insist that the amount of
+ * the digital assets in the payment is equal to `optAmount`, to
+ * prevent sending the wrong payment and other confusion.
+ *
+ * If the payment is a promise, the operation will proceed upon resolution.
+ *
+ * @property {(payment: Payment, optAmount?: Amount) => Payment} claim
+ * Transfer all digital assets from the payment to a new payment and
+ * delete the original. `optAmount` is optional.
+ * If `optAmount` is present, the code will insist that the amount of
+ * digital assets in the payment is equal to `optAmount`, to prevent
+ * sending the wrong  payment and other confusion.
+ *
+ * If the payment is a promise, the operation will proceed upon resolution.
+ *
+ * @property {(paymentsArray: Payment[]) => Payment} combine
+ * Combine multiple payments into one payment.
+ *
+ * If any of the payments is a promise, the operation will proceed upon
+ * resolution.
+ *
+ * @property {(payment: Payment, paymentAmountA: Amount) => Payment[]} split
+ * Split a single payment into two payments, A and B, according to the
+ * paymentAmountA passed in.
+ *
+ * If the payment is a promise, the operation will proceed upon resolution.
+ *
+ * @property {(payment: Payment, amounts: Amount[]) => Payment[]} splitMany
+ * Split a single payment into many payments, according to the
+ * amounts passed in.
+ *
+ * If the payment is a promise, the operation will proceed upon resolution.
+ */
+
+/**
+ * @typedef {Object} Brand
+ * The Brand indicates the kind of digital asset and is shared by
+ * the mint, the issuer, and any purses and payments of this
+ * particular kind. Fake digital assets and amount can use another
+ * issuer's brand.
+ *
+ * @property {(allegedIssuer: any) => boolean} isMyIssuer Should be used with
+ * `issuer.getBrand` to ensure an issuer and brand match.
+ * @property {() => string} getAllegedName
+ */
+
+/**
+ * @typedef {Object} IssuerMaker
+ * Makes Issuers.
+ *
+ * @property {(allegedName: string, mathHelperName: string) => IssuerResults} produceIssuer
+ * The allegedName becomes part of the brand in asset descriptions. The
+ * allegedName doesn't have to be a string, but it will only be used for
+ * its value. The allegedName is useful for debugging and double-checking
+ * assumptions, but should not be trusted.
+ *
+ * The mathHelpersName will be used to import a specific mathHelpers
+ * from the mathHelpers library. For example, natMathHelpers, the
+ * default, is used for basic fungible tokens.
+ *
+ * @typedef {Object} IssuerResults
+ * The return value of produceIssuer
+ *
+ * @property {Mint} mint
+ * @property {Issuer} issuer
+ * @property {AmountMath} amountMath
+ * @property {Brand} brand
+ */
+
+/**
+ * @typedef {Object} Mint
+ * Holding a Mint carries the right to issue new digital assets. These
+ * assets all have the same kind, which is called a Brand.
+ *
+ * @property {() => Issuer} getIssuer Gets the Issuer for this mint.
+ * @property {(newAmount: Amount) => Payment} mintPayment
+ * Creates a new Payment containing newly minted amount.
+ */
+
+/**
+ * @typedef {Object} Purse
+ * Purses hold amount of digital assets of the same brand, but unlike Payments, they are
+ * not meant to be sent to others. To transfer digital assets, a
+ * Payment should be withdrawn from a Purse. The amount of digital
+ * assets in a purse can change through the action of deposit() and withdraw().
+ *
+ * The primary use for Purses and Payments is for currency-like and goods-like
+ * digital assets, but they can also be used to represent other kinds of rights, such
+ * as the right to participate in a particular contract.
+ *
+ * @property {() => Issuer} getIssuer Get the Issuer for this Purse
+ *
+ * @property {() => Amount} getCurrentAmount
+ * Get the amount contained in this purse, confirmed by the issuer.
+ *
+ * @property {(payment: Payment, optAmount?: Amount) => Amount}
+ * Deposit all the contents of payment into this purse, returning the
+ * amount. If the optional argument `optAmount` does not equal the
+ * amount of digital assets in the payment, throw an error.
+ *
+ * If payment is an unresolved promise, throw an error.
+ *
+ * @property {(amount: Amount) => Payment} withdraw
+ * Withdraw amount from this purse into a new Payment.
+ */
+
+/**
+ * @typedef {Object} Payment
+ * Payments hold amount of digital assets of the same brand in transit. Payments can
+ * be deposited in purses, split into multiple payments, combined, and
+ * claimed (getting an exclusive payment). Payments are linear, meaning
+ * that either a payment has the same amount of digital assets it
+ * started with, or it is used up entirely. It is impossible to partially use a payment.
+ *
+ * Payments are often received from other actors and therefore should
+ * not be trusted themselves. To get the amount of digital assets in a payment, use the
+ * trusted issuer: issuer.getAmountOf(payment),
+ *
+ * Payments can be converted to Purses by getting a trusted issuer and
+ * calling `issuer.makeEmptyPurse()` to create a purse, then `purse.deposit(payment)`.
+ *
+ * @property {() => Brand} getAllegedBrand
+ * Get the allegedBrand, indicating the kind of digital asset this
+ * payment purports to be, and which issuer to use. Because payments
+ * are not trusted, any method calls on payments should be treated
+ * with suspicion and verified elsewhere.
+ */
+
+/**
+ * @typedef {Object} MathHelpers
+ * All of the difference in how digital asset amount are manipulated can be reduced to
+ * the behavior of the math on extents. We extract this
+ * custom logic into mathHelpers. MathHelpers are about extent
+ * arithmetic, whereas AmountMath is about amounts, which are the
+ * extents labeled with a brand. AmountMath use mathHelpers to do their extent arithmetic,
+ * and then brand the results, making a new amount.
+ *
+ * @property {(allegedExtent: Extent) => Extent} doCoerce
+ * Check the kind of this extent and throw if it is not the
+ * expected kind.
+ *
+ * @property {() => Extent} doGetEmpty
+ * Get the representation for the identity element (often 0 or an
+ * empty array)
+ *
+ * @property {(extent: Extent) => boolean} doIsEmpty
+ * Is the extent the identity element?
+ *
+ * @property {(left: Extent, right: Extent) => boolean} doIsGTE
+ * Is the left greater than or equal to the right?
+ *
+ * @property {(left: Extent, right: Extent) => boolean} doIsEqual
+ * Does left equal right?
+ *
+ * @property {(left: Extent, right: Extent) => Extent} doAdd
+ * Return the left combined with the right.
+ *
+ * @property {(left: Extent, right: Extent) => Extent} doSubtract
+ * Return what remains after removing the right from the left. If
+ * something in the right was not in the left, we throw an error.
+ */
+
+/**
+ *
+ * @param {string} allegedName
+ * @param {string} mathHelpersName
+ */
 function produceIssuer(allegedName, mathHelpersName = 'nat') {
   assert.typeof(allegedName, 'string');
 

--- a/packages/ERTP/src/issuer.js
+++ b/packages/ERTP/src/issuer.js
@@ -12,6 +12,7 @@ import makeAmountMath from './amountMath';
  * @typedef {import('./amountMath').Amount} Amount
  * @typedef {import('./amountMath').Extent} Extent
  * @typedef {import('./amountMath').AmountMath} AmountMath
+ * @typedef {Payment|Promise<Payment>} PaymentP
  */
 
 /**
@@ -32,19 +33,19 @@ import makeAmountMath from './amountMath';
  * @property {() => AmountMath} getAmountMath Get the AmountMath for this Issuer.
  * @property {() => string} getMathHelpersName Get the name of the MathHelpers for this Issuer.
  * @property {() => Purse} makeEmptyPurse Make an empty purse of this brand.
- * @property {(payment: Payment) => boolean} isLive
+ * @property {(payment: PaymentP) => Promise<boolean>} isLive
  * Return true if the payment continues to exist.
  *
  * If the payment is a promise, the operation will proceed upon resolution.
  *
- * @property {(payment: Payment) => Amount} getAmountOf
+ * @property {(payment: PaymentP) => Promise<Amount>} getAmountOf
  * Get the amount of digital assets in the payment. Because the
  * payment is not trusted, we cannot call a method on it directly,
  * and must use the issuer instead.
  *
  * If the payment is a promise, the operation will proceed upon resolution.
  *
- * @property {(payment: Payment, optAmount?: Amount) => Amount} burn
+ * @property {(payment: PaymentP, optAmount?: Amount) => Promise<Amount>} burn
  * Burn all of the digital assets in the payment. `optAmount` is optional.
  * If `optAmount` is present, the code will insist that the amount of
  * the digital assets in the payment is equal to `optAmount`, to
@@ -52,7 +53,7 @@ import makeAmountMath from './amountMath';
  *
  * If the payment is a promise, the operation will proceed upon resolution.
  *
- * @property {(payment: Payment, optAmount?: Amount) => Payment} claim
+ * @property {(payment: PaymentP, optAmount?: Amount) => Promise<Payment>} claim
  * Transfer all digital assets from the payment to a new payment and
  * delete the original. `optAmount` is optional.
  * If `optAmount` is present, the code will insist that the amount of
@@ -61,19 +62,19 @@ import makeAmountMath from './amountMath';
  *
  * If the payment is a promise, the operation will proceed upon resolution.
  *
- * @property {(paymentsArray: Payment[]) => Payment} combine
+ * @property {(paymentsArray: PaymentP[]) => Promise<Payment>} combine
  * Combine multiple payments into one payment.
  *
  * If any of the payments is a promise, the operation will proceed upon
  * resolution.
  *
- * @property {(payment: Payment, paymentAmountA: Amount) => Payment[]} split
+ * @property {(payment: PaymentP, paymentAmountA: Amount) => Promise<Payment[]>} split
  * Split a single payment into two payments, A and B, according to the
  * paymentAmountA passed in.
  *
  * If the payment is a promise, the operation will proceed upon resolution.
  *
- * @property {(payment: Payment, amounts: Amount[]) => Payment[]} splitMany
+ * @property {(payment: PaymentP, amounts: Amount[]) => Promise<Payment[]>} splitMany
  * Split a single payment into many payments, according to the
  * amounts passed in.
  *
@@ -136,12 +137,12 @@ import makeAmountMath from './amountMath';
  * digital assets, but they can also be used to represent other kinds of rights, such
  * as the right to participate in a particular contract.
  *
- * @property {() => Issuer} getIssuer Get the Issuer for this Purse
+ * @property {() => Brand} getAllegedBrand Get the alleged Brand for this Purse
  *
  * @property {() => Amount} getCurrentAmount
  * Get the amount contained in this purse, confirmed by the issuer.
  *
- * @property {(payment: Payment, optAmount?: Amount) => Amount}
+ * @property {(payment: PaymentP, optAmount?: Amount) => Amount} deposit
  * Deposit all the contents of payment into this purse, returning the
  * amount. If the optional argument `optAmount` does not equal the
  * amount of digital assets in the payment, throw an error.

--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -1,13 +1,21 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
+// @ts-check
 
 // This module assumes the de-facto standard `console` host object.
 // To the extent that this `console` is considered a resource,
 // this module must be considered a resource module.
 
-import harden from '@agoric/harden';
+import rawHarden from '@agoric/harden';
 
-// Prepend the correct indefinite article onto a noun, typically a typeof result
-// e.g., "an Object" vs. "a Number"
+const harden = /** @type {<T>(x: T) => T} */ (rawHarden);
+
+/**
+ * Prepend the correct indefinite article onto a noun, typically a typeof result
+ * e.g., "an Object" vs. "a Number"
+ *
+ * @param {string} str The noun to prepend
+ * @returns {string} The noun prepended with a/an
+ */
 function an(str) {
   str = `${str}`;
   if (str.length >= 1 && 'aeiouAEIOU'.includes(str[0])) {
@@ -19,22 +27,31 @@ harden(an);
 
 const declassifiers = new WeakSet();
 
-// To "declassify" a substitution value used in a details`...` template literal,
-// enclose that substitution expression in a call to openDetail. This states
-// that the argument should appear, stringified, in the error message of the
-// thrown error.
-//
-// Starting from the example in the `details` comment, say instead that the
-// color the sky is supposed to be is also computed. Say that we still don't
-// want to reveal the sky's actual color, but we do want the thrown error's
-// message to reveal what color the sky was supposed to be:
-// ```js
-// assert.equal(
-//   sky.color,
-//   color,
-//   details`${sky.color} should be ${openDetail(color)}`,
-// );
-// ```
+/**
+ * To "declassify" a substitution value used in a details`...` template literal,
+ * enclose that substitution expression in a call to openDetail. This states
+ * that the argument should appear, stringified, in the error message of the
+ * thrown error.
+ *
+ * Starting from the example in the `details` comment, say instead that the
+ * color the sky is supposed to be is also computed. Say that we still don't
+ * want to reveal the sky's actual color, but we do want the thrown error's
+ * message to reveal what color the sky was supposed to be:
+ * ```js
+ * assert.equal(
+ *   sky.color,
+ *   color,
+ *   details`${sky.color} should be ${openDetail(color)}`,
+ * );
+ * ```
+ *
+ * @typedef {Object} StringablePayload
+ * @property {*} payload The original payload
+ * @property {() => string} toString How to print the payload
+ *
+ * @param {*} payload What to declassify
+ * @returns {StringablePayload} The declassified payload
+ */
 function openDetail(payload) {
   const result = harden({
     payload,
@@ -47,33 +64,44 @@ function openDetail(payload) {
 }
 harden(openDetail);
 
-// Use the `details` function as a template literal tag to create
-// informative error messages. The assertion functions take such messages
-// as optional arguments:
-// ```js
-// assert(sky.isBlue(), details`${sky.color} should be blue`);
-// ```
-// The details template tag returns an object that can print itself with the
-// formatted message in two ways. It will report the real details to the
-// console but include only the typeof information in the thrown error
-// to prevent revealing secrets up the exceptional path. In the example
-// above, the thrown error may reveal only that `sky.color` is a string,
-// whereas the same diagnostic printed to the console reveals that the
-// sky was green.
-//
-// WARNING: this function currently returns an unhardened result, as hardening
-// proved to cause significant performance degradation.  Consequently, callers
-// should take care to use it only in contexts where this lack of hardening
-// does not present a hazard.  In current usage, a `details` template literal
-// may only appear either as an argument to `assert`, where we know hardening
-// won't matter, or inside another hardened object graph, where hardening is
-// already ensured.  However, there is currently no means to enfoce these
-// constraints, so users are required to employ this function with caution.
-// Our intent is to eventually have a lint rule that will check for
-// inappropriate uses or find an alternative means of implementing `details`
-// that does not encounter the performance issue.  The final disposition of
-// this is being discussed and tracked in issue #679 in the agoric-sdk
-// repository.
+/**
+ * Use the `details` function as a template literal tag to create
+ * informative error messages. The assertion functions take such messages
+ * as optional arguments:
+ * ```js
+ * assert(sky.isBlue(), details`${sky.color} should be blue`);
+ * ```
+ * The details template tag returns an object that can print itself with the
+ * formatted message in two ways. It will report the real details to the
+ * console but include only the typeof information in the thrown error
+ * to prevent revealing secrets up the exceptional path. In the example
+ * above, the thrown error may reveal only that `sky.color` is a string,
+ * whereas the same diagnostic printed to the console reveals that the
+ * sky was green.
+ *
+ * WARNING: this function currently returns an unhardened result, as hardening
+ * proved to cause significant performance degradation.  Consequently, callers
+ * should take care to use it only in contexts where this lack of hardening
+ * does not present a hazard.  In current usage, a `details` template literal
+ * may only appear either as an argument to `assert`, where we know hardening
+ * won't matter, or inside another hardened object graph, where hardening is
+ * already ensured.  However, there is currently no means to enfoce these
+ * constraints, so users are required to employ this function with caution.
+ * Our intent is to eventually have a lint rule that will check for
+ * inappropriate uses or find an alternative means of implementing `details`
+ * that does not encounter the performance issue.  The final disposition of
+ * this is being discussed and tracked in issue #679 in the agoric-sdk
+ * repository.
+ *
+ * @typedef {Object} Complainer An object that has custom assert behaviour
+ * @property {() => Error} complain Return an Error to throw, and print details to console
+ *
+ * @typedef {string|Complainer} Details Either a plain string, or made by details``
+ *
+ * @param {TemplateStringsArray} template The template to format
+ * @param {any[]} args Arguments to the template
+ * @returns {Complainer} The complainer for these details
+ */
 function details(template, ...args) {
   // const complainer = harden({  // remove harden per above discussion
   const complainer = {
@@ -117,11 +145,14 @@ function details(template, ...args) {
 }
 harden(details);
 
-// Fail an assertion, recording details to the console and
-// raising an exception with just type information.
-//
-// The optional `optDetails` can be a string for backwards compatibility
-// with the nodejs assertion library.
+/**
+ * Fail an assertion, recording details to the console and
+ * raising an exception with just type information.
+ *
+ * The optional `optDetails` can be a string for backwards compatibility
+ * with the nodejs assertion library.
+ * @param {Details} [optDetails] The details of what was asserted
+ */
 function fail(optDetails = details`Assert failed`) {
   if (typeof optDetails === 'string') {
     const detailString = `Assertion failed: ${optDetails}`;
@@ -131,24 +162,28 @@ function fail(optDetails = details`Assert failed`) {
   throw optDetails.complain();
 }
 
-// assert that expr is truthy, with an optional details to describe
-// the assertion. It is a tagged template literal like
-// ```js
-// assert(expr, details`....`);`
-// ```
-// If expr is falsy, then the template contents are reported to the
-// console and also in a thrown error.
-//
-// The literal portions of the template are assumed non-sensitive, as
-// are the `typeof` types of the substitution values. These are
-// assembled into the thrown error message. The actual contents of the
-// substitution values are assumed sensitive, to be revealed to the
-// console only. We assume only the virtual platform's owner can read
-// what is written to the console, where the owner is in a privileged
-// position over computation running on that platform.
-//
-// The optional `optDetails` can be a string for backwards compatibility
-// with the nodejs assertion library.
+/**
+ * assert that expr is truthy, with an optional details to describe
+ * the assertion. It is a tagged template literal like
+ * ```js
+ * assert(expr, details`....`);`
+ * ```
+ * If expr is falsy, then the template contents are reported to the
+ * console and also in a thrown error.
+ *
+ * The literal portions of the template are assumed non-sensitive, as
+ * are the `typeof` types of the substitution values. These are
+ * assembled into the thrown error message. The actual contents of the
+ * substitution values are assumed sensitive, to be revealed to the
+ * console only. We assume only the virtual platform's owner can read
+ * what is written to the console, where the owner is in a privileged
+ * position over computation running on that platform.
+ *
+ * The optional `optDetails` can be a string for backwards compatibility
+ * with the nodejs assertion library.
+ * @param {*} flag The truthy/falsy value
+ * @param {Details} [optDetails] The details to throw
+ */
 function assert(flag, optDetails = details`check failed`) {
   if (!flag) {
     console.log(`FAILED ASSERTION ${flag}`);
@@ -156,7 +191,12 @@ function assert(flag, optDetails = details`check failed`) {
   }
 }
 
-// Assert that two values must be `===`.
+/**
+ * Assert that two values must be `===`.
+ * @param {*} actual The value we received
+ * @param {*} expected What we wanted
+ * @param {Details} [optDetails] The details to throw
+ */
 function equal(
   actual,
   expected,
@@ -165,6 +205,13 @@ function equal(
   assert(actual === expected, optDetails);
 }
 
+/**
+ * Assert an expected typeof result.
+ *
+ * @param {*} specimen The value to get the typeof
+ * @param {string} typename The expected name
+ * @param {Details} [optDetails] The details to throw
+ */
 function assertTypeof(
   specimen,
   typename,

--- a/packages/zoe/src/contracts/automaticRefund.js
+++ b/packages/zoe/src/contracts/automaticRefund.js
@@ -1,4 +1,9 @@
-import harden from '@agoric/harden';
+// @ts-check
+import rawHarden from '@agoric/harden';
+
+// TODO: Until we have a version of harden that exports its type.
+const harden = /** @type {<T>(x: T) => T} */ (rawHarden);
+
 /**
  * This is a very trivial contract to explain and test Zoe.
  * AutomaticRefund just gives you back what you put in. It has one
@@ -6,7 +11,7 @@ import harden from '@agoric/harden';
  * offer, which gives the user their payout through Zoe. Other
  * contracts will use these same steps, but they will have more
  * sophisticated logic and interfaces.
- * @param {contractFacet} zoe - the contract facet of zoe
+ * @type {import('@agoric/zoe').MakeContract} zoe - the contract facet of zoe
  */
 export const makeContract = harden(zoe => {
   let offersCount = 0;

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -34,6 +34,7 @@ const harden = /** @type {<T>(x: T) => T} */ (rawHarden);
  * @typedef {import('@agoric/ertp/src/amountMath').AmountMath} AmountMath
  * @typedef {import('@agoric/ertp/src/issuer').Payment} Payment
  * @typedef {import('@agoric/ertp/src/issuer').Issuer} Issuer
+ * @typedef {import('@agoric/ertp/src/issuer').Purse} Purse
  *
  * @typedef {any} TODO Needs to be typed
  * @typedef {Object} InstallationHandle
@@ -75,7 +76,7 @@ const harden = /** @type {<T>(x: T) => T} */ (rawHarden);
  * Credibly get information about the instance (such as the installation
  * and terms used).
  *
- * @property {(invite: Invite, proposal: Proposal, payments: PaymentKeywordRecord) => SeatAndPayout} redeem
+ * @property {(invite: Invite, proposal: Proposal, payments: PaymentKeywordRecord) => Promise<SeatAndPayout>} redeem
  * To redeem an invite, the user normally provides a proposal (their rules for the
  * offer) as well as payments to be escrowed by Zoe.  If either the proposal or payments
  * would be empty, indicate this by omitting that argument or passing undefined, rather
@@ -88,6 +89,8 @@ const harden = /** @type {<T>(x: T) => T} */ (rawHarden);
  * as values. `payments` is a record with keywords as keys,
  * and the values are the actual payments to be escrowed. A payment
  * is expected for every rule under `give`.
+ *
+ * @property {(installationHandle: InstallationHandle) => InstallationRecord} getInstallation
  *
  * @typedef {Object} SeatAndPayout This is returned by a call to `redeem` on Zoe.
  *
@@ -142,6 +145,7 @@ const harden = /** @type {<T>(x: T) => T} */ (rawHarden);
  * @typedef {TODO} Offer
  * @typedef {TODO} InstanceRecord
  * @typedef {TODO} IssuerRecord
+ * @typedef {TODO} InstallationRecord
  *
  * @typedef {string[]} SparseKeywords
  * @typedef {Object.<string,TODO>} Allocation
@@ -461,6 +465,7 @@ const makeZoe = (additionalEndowments = {}) => {
   // retrieves an instance from Zoe, and `redeem` allows users to
   // securely escrow and get a seat and payouts in return.
 
+  /** @type {ZoeService} */
   const zoeService = harden(
     /**
      * @param {any} code

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -1,4 +1,5 @@
-import harden from '@agoric/harden';
+// @ts-check
+import rawHarden from '@agoric/harden';
 import { E } from '@agoric/eventual-send';
 import makeStore from '@agoric/weak-store';
 import produceIssuer from '@agoric/ertp';
@@ -24,10 +25,211 @@ import { areRightsConserved } from './rightsConservation';
 import { evalContractCode } from './evalContractCode';
 import { makeTables } from './state';
 
+const harden = /** @type {<T>(x: T) => T} */ (rawHarden);
+
+/**
+ * Zoe uses ERTP, the Electronic Rights Transfer Protocol
+ *
+ * @typedef {import('@agoric/ertp/src/issuer').Amount} Amount
+ * @typedef {import('@agoric/ertp/src/amountMath').AmountMath} AmountMath
+ * @typedef {import('@agoric/ertp/src/issuer').Payment} Payment
+ * @typedef {import('@agoric/ertp/src/issuer').Issuer} Issuer
+ *
+ * @typedef {any} TODO Needs to be typed
+ * @typedef {Object} InstallationHandle
+ * @typedef {Object.<string,Issuer>} IssuerKeywordRecord
+ * @typedef {Object.<string,Payment>} PaymentKeywordRecord
+ */
+
+/**
+ * @typedef {Object} ZoeService
+ * @property {() => Issuer} getInviteIssuer
+ * Zoe has a single `inviteIssuer` for the entirety of its lifetime.
+ * By having a reference to Zoe, a user can get the `inviteIssuer`
+ * and thus validate any `invite` they receive from someone else. The
+ * mint associated with the inviteIssuer creates the ERTP payments
+ * that represent the right to interact with a smart contract in
+ * particular ways.
+ *
+ * @property {(code: string, moduleFormat: string) => InstallationHandle} install
+ * Create an installation by safely evaluating the code and
+ * registering it with Zoe. Returns an installationHandle.
+ *
+ * @property {(installationHandle: InstallationHandle, issuerKeywordRecord: IssuerKeywordRecord, terms: object) => Invite} makeInstance
+ * Zoe is long-lived. We can use Zoe to create smart contract
+ * instances by specifying a particular contract installation to
+ * use, as well as the `issuerKeywordRecord` and `terms` of the contract. The
+ * `issuerKeywordRecord` is a record mapping string names (keywords) to issuers,
+ * such as `{ Asset: simoleanIssuer}`. (Note that the keywords must
+ * begin with a capital letter and must be ASCII.) Parties to the
+ * contract will use the keywords to index their proposal and
+ * their payments.
+ *
+ * The payout users receive from Zoe will be in the form of an object
+ * with keywords as keys. Terms are the arguments to the contract,
+ * such as the number of bids an auction will wait for before closing.
+ * Terms are up to the discretion of the smart contract. We get back
+ * an invite (an ERTP payment) to participate in the contract.
+ *
+ * TODO: property {(instanceHandle: InstanceHandle) => InstanceRecord} getInstanceRecord
+ * Credibly get information about the instance (such as the installation
+ * and terms used).
+ *
+ * @property {(invite: Invite, proposal: Proposal, payments: PaymentKeywordRecord) => SeatAndPayout} redeem
+ * To redeem an invite, the user normally provides a proposal (their rules for the
+ * offer) as well as payments to be escrowed by Zoe.  If either the proposal or payments
+ * would be empty, indicate this by omitting that argument or passing undefined, rather
+ * than passing an empty record.
+ *
+ * The proposal has three parts: `want` and `give` are used
+ * by Zoe to enforce offer safety, and `exit` is used to specify
+ * the extent of payout liveness that Zoe can guarantee.
+ * `want` and `give` are objects with keywords as keys and amounts
+ * as values. `payments` is a record with keywords as keys,
+ * and the values are the actual payments to be escrowed. A payment
+ * is expected for every rule under `give`.
+ *
+ * @typedef {Object} SeatAndPayout This is returned by a call to `redeem` on Zoe.
+ *
+ * @property {Object} seat An arbitrary object whose methods allow the user to take
+ * certain actions in a contract. The payout is a promise that resolves
+ * to an object which has keywords as keys and promises for payments
+ * as values. Note that while the payout promise resolves when an offer
+ * is completed, the promise for each payment resolves after the remote
+ * issuer successfully withdraws the payment.
+ *
+ * @property {Payment[]} payout A promise that resolves
+ * to an object which has keywords as keys and promises for payments
+ * as values. Note that while the payout promise resolves when an offer
+ * is completed, the promise for each payment resolves after the remote
+ * issuer successfully withdraws the payment.
+ *
+ * @typedef {Object} Proposal
+ * @property {AmountKeywordRecord} want
+ * @property {AmountKeywordRecord} give
+ * @property {ExitRule} exit
+ *
+ * @typedef {Object.<string,Amount>} AmountKeywordRecord
+ * The keys are keywords, and the values are amounts. For example:
+ * { Asset: amountMath.make(5), Price: amountMath.make(9) }
+ *
+ * @typedef {Object} ExitRule
+ * The possible keys are 'waived', 'onDemand', and 'afterDeadline'.
+ * `timer` and `deadline` only are used for the `afterDeadline` key.
+ * The possible records are:
+ * `{ waived: null }`
+ * `{ onDemand: null }`
+ * `{ afterDeadline: { timer :Timer<Deadline>, deadline :Deadline } }
+ * @property {Timer} [timer]
+ * @property {Deadline} [deadline]
+ */
+
+/**
+ * @callback MakeContract The type exported from a Zoe contract
+ * @param {ContractFacet} zoe The Zoe Contract Facet (zcf)
+ * @returns {ContractInstance} The instantiated contract
+ *
+ * @typedef {Object} ContractInstance
+ * @property {Object.<string,function>} publicAPI Public functions that can be called on the instance
+ *
+ * @property {Invite} invite The closely-held administrative invite
+ *
+ * @typedef {Object} InstanceHandle
+ * @typedef {Object} OfferHandle
+ * @typedef {Object} InviteHandle
+ *
+ * @typedef {TODO} Invite
+ * @typedef {TODO} Offer
+ * @typedef {TODO} InstanceRecord
+ * @typedef {TODO} IssuerRecord
+ *
+ * @typedef {string[]} SparseKeywords
+ * @typedef {Object.<string,TODO>} Allocation
+ *
+ * @typedef {Object} ContractFacet The Zoe interface specific to a contract instance
+ * @property {Reallocate} reallocate Propose a reallocation of extents per offer
+ * @property {Complete} complete Complete an offer
+ * @property {MakeInvite} makeInvite
+ * @property {AddNewIssuer} addNewIssuer
+ * @property {() => ZoeService} getZoeService
+ * @property {() => Issuer} getInviteIssuer
+ * @property {(sparseKeywords: SparseKeywords) => Object.<string,AmountMath>} getAmountMaths
+ * @property {(offerHandles: OfferHandle[]) => { active: OfferStatus[], inactive: OfferStatus[] }} getOfferStatuses
+ * @property {(offerHandle: OfferHandle) => boolean} isOfferActive
+ * @property {(offerHandles: OfferHandle[]) => Offer[]} getOffers
+ * @property {(offerHandle: OfferHandle) => Offer} getOffer
+ * @property {(offerHandle: OfferHandle, sparseKeywords: SparseKeywords) => Allocation} getCurrentAllocation
+ * @property {(offerHandles: OfferHandle[], sparseKeywords: SparseKeywords) => Allocation[]} getCurrentAllocations
+ * @property {() => InstanceRecord} getInstanceRecord
+ * @property {(issuer: Issuer) => IssuerRecord} getIssuerRecord
+ *
+ * @callback Reallocate
+ * The contract can propose a reallocation of extents per offer,
+ * which will only succeed if the reallocation 1) conserves
+ * rights, and 2) is 'offer-safe' for all parties involved. This
+ * reallocation is partial, meaning that it applies only to the
+ * amount associated with the offerHandles that are passed in.
+ * We are able to ensure that with each reallocation, rights are
+ * conserved and offer safety is enforced for all offers, even
+ * though the reallocation is partial, because once these
+ * invariants are true, they will remain true until changes are
+ * made.
+ * zcf.reallocate will throw an error if any of the
+ * newAmountKeywordRecords do not have a value for all the
+ * keywords in sparseKeywords. An error will also be thrown if
+ * any newAmountKeywordRecords have keywords that are not in
+ * sparseKeywords.
+ *
+ * @param  {object[]} offerHandles An array of offerHandles
+ * @param  {AmountKeywordRecord[]} newAmountKeywordRecords An
+ * array of amountKeywordRecords  - objects with keyword keys
+ * and amount values, with one keywordRecord per offerHandle.
+ * @param  {string[]} sparseKeywords An array of string
+ * keywords, which may be a subset of allKeywords
+ * @returns {TODO}
+ *
+ * @callback Complete
+ * The contract can "complete" an offer to remove it from the
+ * ongoing contract and resolve the player's payouts (either
+ * winnings or refunds). Because Zoe only allows for
+ * reallocations that conserve rights and are 'offer-safe', we
+ * don't need to do those checks at this step and can assume
+ * that the invariants hold.
+ * @param  {object[]} offerHandles - an array of offerHandles
+ * @returns {TODO}
+ *
+ * @callback MakeInvite
+ * Make a credible Zoe invite for a particular smart contract
+ * indicated by the unique `instanceHandle`. The other
+ * information in the extent of this invite is decided by the
+ * governing contract and should include whatever information is
+ * necessary for a potential buyer of the invite to know what
+ * they are getting. Note: if information can be derived in
+ * queries based on other information, we choose to omit it. For
+ * instance, `installationHandle` can be derived from
+ * `instanceHandle` and is omitted even though it is useful.
+ * @param  {object} seat - an object defined by the smart
+ * contract that is the use right associated with the invite. In
+ * other words, buying the invite is buying the right to call
+ * methods on this object.
+ * @param  {object} customProperties - an object of
+ * information to include in the extent, as defined by the smart
+ * contract
+ * @returns {{ invite: Invite, inviteHandle: InviteHandle }}
+ *
+ * @callback AddNewIssuer
+ * Informs Zoe about an issuer and returns a promise for acknowledging
+ * when the issuer is added and ready.
+ * @param {Promise<Issuer>|Issuer} issuerP Promise for issuer
+ * @param {string} keyword Keyword for added issuer
+ * @returns {Promise<void>} Issuer is added and ready
+ */
+
 /**
  * Create an instance of Zoe.
  *
- * @param additionalEndowments pure or pure-ish endowments to add to evaluator
+ * @param {Object.<string,any>} [additionalEndowments] pure or pure-ish endowments to add to evaluator
+ * @returns {ZoeService} The created Zoe service.
  */
 const makeZoe = (additionalEndowments = {}) => {
   // Zoe maps the inviteHandles to contract seats
@@ -47,6 +249,10 @@ const makeZoe = (additionalEndowments = {}) => {
     issuerTable,
   } = makeTables();
 
+  /**
+   * @param {InstanceHandle} instanceHandle
+   * @param {OfferHandle[]} offerHandles
+   */
   const completeOffers = (instanceHandle, offerHandles) => {
     const { inactive } = offerTable.getOfferStatuses(offerHandles);
     if (inactive.length > 0) {
@@ -77,7 +283,7 @@ const makeZoe = (additionalEndowments = {}) => {
   };
 
   const getAmountMaths = (instanceHandle, sparseKeywords) => {
-    const amountMathKeywordRecord = {};
+    const amountMathKeywordRecord = /** @type {Object.<string,AmountMath>} */ ({});
     const { issuerKeywordRecord } = instanceTable.get(instanceHandle);
     sparseKeywords.forEach(keyword => {
       const issuer = issuerKeywordRecord[keyword];
@@ -122,31 +328,17 @@ const makeZoe = (additionalEndowments = {}) => {
   // complete an offer, and can create a new offer itself for
   // record-keeping and other various purposes.
 
+  /**
+   * Create the contract facet.
+   *
+   * @param {InstanceHandle} instanceHandle The instance for which to create the facet
+   * @returns {ContractFacet} The returned facet
+   */
   const makeContractFacet = instanceHandle => {
+    /**
+     * @type {ContractFacet}
+     */
     const contractFacet = harden({
-      /**
-       * The contract can propose a reallocation of extents per offer,
-       * which will only succeed if the reallocation 1) conserves
-       * rights, and 2) is 'offer-safe' for all parties involved. This
-       * reallocation is partial, meaning that it applies only to the
-       * amount associated with the offerHandles that are passed in.
-       * We are able to ensure that with each reallocation, rights are
-       * conserved and offer safety is enforced for all offers, even
-       * though the reallocation is partial, because once these
-       * invariants are true, they will remain true until changes are
-       * made.
-       * zcf.reallocate will throw an error if any of the
-       * newAmountKeywordRecords do not have a value for all the
-       * keywords in sparseKeywords. An error will also be thrown if
-       * any newAmountKeywordRecords have keywords that are not in
-       * sparseKeywords.
-       * @param  {object[]} offerHandles - an array of offerHandles
-       * @param  {amountKeywordRecord[]} newAmountKeywordRecords - an
-       * array of amountKeywordRecords  - objects with keyword keys
-       * and amount values, with one keywordRecord per offerHandle.
-       * @param  {string[]} sparseKeywords - an array of string
-       * keywords, which may be a subset of allKeywords
-       */
       reallocate: (offerHandles, newAmountKeywordRecords, sparseKeywords) => {
         const { issuerKeywordRecord } = instanceTable.get(instanceHandle);
         const allKeywords = getKeywords(issuerKeywordRecord);
@@ -200,40 +392,11 @@ const makeZoe = (additionalEndowments = {}) => {
         offerTable.updateAmounts(offerHandles, harden(newAmountKeywordRecords));
       },
 
-      /**
-       * The contract can "complete" an offer to remove it from the
-       * ongoing contract and resolve the player's payouts (either
-       * winnings or refunds). Because Zoe only allows for
-       * reallocations that conserve rights and are 'offer-safe', we
-       * don't need to do those checks at this step and can assume
-       * that the invariants hold.
-       * @param  {object[]} offerHandles - an array of offerHandles
-       */
       complete: offerHandles => completeOffers(instanceHandle, offerHandles),
 
-      /**
-       * Make a credible Zoe invite for a particular smart contract
-       * indicated by the unique `instanceHandle`. The other
-       * information in the extent of this invite is decided by the
-       * governing contract and should include whatever information is
-       * necessary for a potential buyer of the invite to know what
-       * they are getting. Note: if information can be derived in
-       * queries based on other information, we choose to omit it. For
-       * instance, `installationHandle` can be derived from
-       * `instanceHandle` and is omitted even though it is useful.
-       * @param  {object} seat - an object defined by the smart
-       * contract that is the use right associated with the invite. In
-       * other words, buying the invite is buying the right to call
-       * methods on this object.
-       * @param  {object} customProperties - an object of
-       * information to include in the extent, as defined by the smart
-       * contract
-       */
       makeInvite: (seat, customProperties) =>
         makeInvite(instanceHandle, seat, customProperties),
 
-      // Informs Zoe about an issuer and returns a promise for acknowledging
-      // when the issuer is added and ready.
       addNewIssuer: (issuerP, keyword) =>
         issuerTable.getPromiseForIssuerRecord(issuerP).then(issuerRecord => {
           assertCapASCII(keyword);
@@ -298,211 +461,225 @@ const makeZoe = (additionalEndowments = {}) => {
   // retrieves an instance from Zoe, and `redeem` allows users to
   // securely escrow and get a seat and payouts in return.
 
-  const zoeService = harden({
-    getInviteIssuer: () => inviteIssuer,
-
+  const zoeService = harden(
     /**
-     * Create an installation by safely evaluating the code and
-     * registering it with Zoe. We have a moduleFormat to allow for
-     * different future formats without silent failures.
+     * @param {any} code
      */
-    install: (code, moduleFormat = 'nestedEvaluate') => {
-      let installation;
-      switch (moduleFormat) {
-        case 'nestedEvaluate':
-        case 'getExport': {
-          installation = evalContractCode(code, additionalEndowments);
-          break;
-        }
-        default: {
-          assert.fail(
-            details`Unimplemented installation moduleFormat ${moduleFormat}`,
-          );
-        }
-      }
-      const installationHandle = installationTable.create(
-        harden({ installation, code }),
-      );
-      return installationHandle;
-    },
+    {
+      getInviteIssuer: () => inviteIssuer,
 
-    /**
-     * Makes a contract instance from an installation and returns a
-     * unique handle for the instance that can be shared, as well as
-     * other information, such as the terms used in the instance.
-     * @param  {object} installationHandle - the unique handle for the
-     * installation
-     * @param  {object} issuerKeywordRecord - optional, a record mapping keyword keys to
-     * issuer values
-     * @param  {object} terms - optional, arguments to the contract. These
-     * arguments depend on the contract.
-     */
-    makeInstance: (
-      installationHandle,
-      issuerKeywordRecord = harden({}),
-      terms = harden({}),
-    ) => {
-      const { installation } = installationTable.get(installationHandle);
-      const instanceHandle = harden({});
-      const contractFacet = makeContractFacet(instanceHandle);
-
-      const cleanedKeywords = cleanKeywords(issuerKeywordRecord);
-      const issuersP = cleanedKeywords.map(
-        keyword => issuerKeywordRecord[keyword],
-      );
-
-      const makeInstanceRecord = issuerRecords => {
-        const issuers = issuerRecords.map(record => record.issuer);
-        const cleanedIssuerKeywordRecord = arrayToObj(issuers, cleanedKeywords);
-        const instanceRecord = harden({
-          installationHandle,
-          publicAPI: undefined,
-          terms,
-          issuerKeywordRecord: cleanedIssuerKeywordRecord,
-        });
-
-        instanceTable.create(instanceRecord, instanceHandle);
-        return Promise.resolve()
-          .then(_ => installation.makeContract(contractFacet))
-          .then(({ invite, publicAPI }) => {
-            // Once the contract is made, we add the publicAPI to the
-            // contractRecord
-            instanceTable.update(instanceHandle, { publicAPI });
-            return invite;
-          });
-      };
-
-      // The issuers may not have been seen before, so we must wait for
-      // the issuer records to be available synchronously
-      return issuerTable
-        .getPromiseForIssuerRecords(issuersP)
-        .then(makeInstanceRecord);
-    },
-    /**
-     * Credibly retrieves an instance record given an instanceHandle.
-     * @param {object} instanceHandle - the unique, unforgeable
-     * identifier (empty object) for the instance
-     */
-    getInstance: instanceTable.get,
-
-    /**
-     * Redeem the invite to receive a seat and a payout
-     * promise.
-     * @param {payment} invite - an invite (ERTP payment) to join a
-     * Zoe smart contract instance
-     * @param  {object?} proposal - the proposal, a record
-     * with properties `want`, `give`, and `exit`. The keys of
-     * `want` and `give` are keywords and the values are amounts.
-     * @param  {object?} paymentKeywordRecord - a record with keyword
-     * keys and values which are payments that will be escrowed by Zoe.
-     *
-     * The default arguments are so that remote invocations don't
-     * have to specify empty objects (which get marshaled as presences).
-     */
-    redeem: (
-      invite,
-      proposal = harden({}),
-      paymentKeywordRecord = harden({}),
-    ) => {
-      return inviteIssuer.burn(invite).then(inviteAmount => {
-        assert(
-          inviteAmount.extent.length === 1,
-          'only one invite should be redeemed',
-        );
-
-        const {
-          extent: [{ instanceHandle, handle: offerHandle }],
-        } = inviteAmount;
-        const { issuerKeywordRecord } = instanceTable.get(instanceHandle);
-
-        const amountMathKeywordRecord = getAmountMaths(
-          instanceHandle,
-          getKeywords(issuerKeywordRecord),
-        );
-
-        proposal = cleanProposal(
-          issuerKeywordRecord,
-          amountMathKeywordRecord,
-          proposal,
-        );
-        // Promise flow = issuer -> purse -> deposit payment -> seat/payout
-        const giveKeywords = Object.getOwnPropertyNames(proposal.give);
-        const wantKeywords = Object.getOwnPropertyNames(proposal.want);
-        const userKeywords = harden([...giveKeywords, ...wantKeywords]);
-        const paymentDepositedPs = userKeywords.map(keyword => {
-          const issuer = issuerKeywordRecord[keyword];
-          const issuerRecordP = issuerTable.getPromiseForIssuerRecord(issuer);
-          return issuerRecordP.then(({ purse, amountMath }) => {
-            if (giveKeywords.includes(keyword)) {
-              // We cannot trust these amounts since they come directly
-              // from the remote issuer and so we must coerce them.
-              return E(purse)
-                .deposit(paymentKeywordRecord[keyword], proposal.give[keyword])
-                .then(_ => amountMath.coerce(proposal.give[keyword]));
-            }
-            // If any other payments are included, they are ignored.
-            return Promise.resolve(amountMathKeywordRecord[keyword].getEmpty());
-          });
-        });
-
-        const recordOffer = amountsArray => {
-          const offerImmutableRecord = {
-            instanceHandle,
-            proposal,
-            currentAllocation: arrayToObj(amountsArray, userKeywords),
-          };
-          // Since we have redeemed an invite, the inviteHandle is
-          // also the offerHandle.
-          offerTable.create(offerImmutableRecord, offerHandle);
-          payoutMap.init(offerHandle, producePromise());
-        };
-
-        // Create result to be returned. Depends on `exit`
-        const makeRedemptionResult = _ => {
-          const redemptionResult = {
-            seat: handleToSeat.get(offerHandle),
-            payout: payoutMap.get(offerHandle).promise,
-          };
-          const { exit } = proposal;
-          const [exitKind] = Object.getOwnPropertyNames(exit);
-          // Automatically cancel on deadline.
-          if (exitKind === 'afterDeadline') {
-            E(exit.afterDeadline.timer).setWakeup(
-              exit.afterDeadline.deadline,
-              harden({
-                wake: () =>
-                  completeOffers(instanceHandle, harden([offerHandle])),
-              }),
-            );
-            // Add an object with a cancel method to redemptionResult in
-            // order to cancel on demand.
-          } else if (exitKind === 'onDemand') {
-            redemptionResult.cancelObj = {
-              cancel: () =>
-                completeOffers(instanceHandle, harden([offerHandle])),
-            };
-          } else {
-            assert(
-              exitKind === 'waived',
-              details`exit kind was not recognized: ${exitKind}`,
+      /**
+       * Create an installation by safely evaluating the code and
+       * registering it with Zoe. We have a moduleFormat to allow for
+       * different future formats without silent failures.
+       */
+      install: (code, moduleFormat = 'nestedEvaluate') => {
+        let installation;
+        switch (moduleFormat) {
+          case 'nestedEvaluate':
+          case 'getExport': {
+            installation = evalContractCode(code, additionalEndowments);
+            break;
+          }
+          default: {
+            assert.fail(
+              details`Unimplemented installation moduleFormat ${moduleFormat}`,
             );
           }
+        }
+        const installationHandle = installationTable.create(
+          harden({ installation, code }),
+        );
+        return installationHandle;
+      },
 
-          // if the exitRule.kind is 'waived' the user has no
-          // possibility of cancelling
-          return harden(redemptionResult);
+      /**
+       * Makes a contract instance from an installation and returns a
+       * unique handle for the instance that can be shared, as well as
+       * other information, such as the terms used in the instance.
+       * @param  {object} installationHandle - the unique handle for the
+       * installation
+       * @param  {object} issuerKeywordRecord - optional, a record mapping keyword keys to
+       * issuer values
+       * @param  {object} terms - optional, arguments to the contract. These
+       * arguments depend on the contract.
+       */
+      makeInstance: (
+        installationHandle,
+        issuerKeywordRecord = harden({}),
+        terms = harden({}),
+      ) => {
+        const { installation } = installationTable.get(installationHandle);
+        const instanceHandle = harden({});
+        const contractFacet = makeContractFacet(instanceHandle);
+
+        const cleanedKeywords = cleanKeywords(issuerKeywordRecord);
+        const issuersP = cleanedKeywords.map(
+          keyword => issuerKeywordRecord[keyword],
+        );
+
+        const makeInstanceRecord = issuerRecords => {
+          const issuers = issuerRecords.map(record => record.issuer);
+          const cleanedIssuerKeywordRecord = arrayToObj(
+            issuers,
+            cleanedKeywords,
+          );
+          const instanceRecord = harden({
+            installationHandle,
+            publicAPI: undefined,
+            terms,
+            issuerKeywordRecord: cleanedIssuerKeywordRecord,
+          });
+
+          instanceTable.create(instanceRecord, instanceHandle);
+          return Promise.resolve()
+            .then(_ => installation.makeContract(contractFacet))
+            .then(({ invite, publicAPI }) => {
+              // Once the contract is made, we add the publicAPI to the
+              // contractRecord
+              instanceTable.update(instanceHandle, { publicAPI });
+              return invite;
+            });
         };
-        return Promise.all(paymentDepositedPs)
-          .then(recordOffer)
-          .then(makeRedemptionResult);
-      });
+
+        // The issuers may not have been seen before, so we must wait for
+        // the issuer records to be available synchronously
+        return issuerTable
+          .getPromiseForIssuerRecords(issuersP)
+          .then(makeInstanceRecord);
+      },
+      /**
+       * Credibly retrieves an instance record given an instanceHandle.
+       * @param {object} instanceHandle - the unique, unforgeable
+       * identifier (empty object) for the instance
+       */
+      getInstance: instanceTable.get,
+
+      /**
+       * Redeem the invite to receive a seat and a payout
+       * promise.
+       * @param {Payment} invite - an invite (ERTP payment) to join a
+       * Zoe smart contract instance
+       * @param  {object?} proposal - the proposal, a record
+       * with properties `want`, `give`, and `exit`. The keys of
+       * `want` and `give` are keywords and the values are amounts.
+       * @param  {object?} paymentKeywordRecord - a record with keyword
+       * keys and values which are payments that will be escrowed by Zoe.
+       *
+       * The default arguments are so that remote invocations don't
+       * have to specify empty objects (which get marshaled as presences).
+       */
+      redeem: (
+        invite,
+        proposal = harden({}),
+        paymentKeywordRecord = harden({}),
+      ) => {
+        return inviteIssuer.burn(invite).then(inviteAmount => {
+          assert(
+            inviteAmount.extent.length === 1,
+            'only one invite should be redeemed',
+          );
+
+          const {
+            extent: [{ instanceHandle, handle: offerHandle }],
+          } = inviteAmount;
+          const { issuerKeywordRecord } = instanceTable.get(instanceHandle);
+
+          const amountMathKeywordRecord = getAmountMaths(
+            instanceHandle,
+            getKeywords(issuerKeywordRecord),
+          );
+
+          proposal = cleanProposal(
+            issuerKeywordRecord,
+            amountMathKeywordRecord,
+            proposal,
+          );
+
+          // Promise flow = issuer -> purse -> deposit payment -> seat/payout
+          const giveKeywords = Object.getOwnPropertyNames(proposal.give);
+          const wantKeywords = Object.getOwnPropertyNames(proposal.want);
+          const userKeywords = harden([...giveKeywords, ...wantKeywords]);
+          const paymentDepositedPs = userKeywords.map(keyword => {
+            const issuer = issuerKeywordRecord[keyword];
+            const issuerRecordP = issuerTable.getPromiseForIssuerRecord(issuer);
+            return issuerRecordP.then(({ purse, amountMath }) => {
+              if (giveKeywords.includes(keyword)) {
+                // We cannot trust these amounts since they come directly
+                // from the remote issuer and so we must coerce them.
+                return E(purse)
+                  .deposit(
+                    paymentKeywordRecord[keyword],
+                    proposal.give[keyword],
+                  )
+                  .then(_ => amountMath.coerce(proposal.give[keyword]));
+              }
+              // If any other payments are included, they are ignored.
+              return Promise.resolve(
+                amountMathKeywordRecord[keyword].getEmpty(),
+              );
+            });
+          });
+
+          const recordOffer = amountsArray => {
+            const offerImmutableRecord = {
+              instanceHandle,
+              proposal,
+              currentAllocation: arrayToObj(amountsArray, userKeywords),
+            };
+            // Since we have redeemed an invite, the inviteHandle is
+            // also the offerHandle.
+            offerTable.create(offerImmutableRecord, offerHandle);
+            payoutMap.init(offerHandle, producePromise());
+          };
+
+          // Create result to be returned. Depends on `exit`
+          const makeRedemptionResult = _ => {
+            const redemptionResult = {
+              seat: handleToSeat.get(offerHandle),
+              payout: payoutMap.get(offerHandle).promise,
+            };
+            const { exit } = proposal;
+            const [exitKind] = Object.getOwnPropertyNames(exit);
+            // Automatically cancel on deadline.
+            if (exitKind === 'afterDeadline') {
+              E(exit.afterDeadline.timer).setWakeup(
+                exit.afterDeadline.deadline,
+                harden({
+                  wake: () =>
+                    completeOffers(instanceHandle, harden([offerHandle])),
+                }),
+              );
+              // Add an object with a cancel method to redemptionResult in
+              // order to cancel on demand.
+            } else if (exitKind === 'onDemand') {
+              redemptionResult.cancelObj = {
+                cancel: () =>
+                  completeOffers(instanceHandle, harden([offerHandle])),
+              };
+            } else {
+              assert(
+                exitKind === 'waived',
+                details`exit kind was not recognized: ${exitKind}`,
+              );
+            }
+
+            // if the exitRule.kind is 'waived' the user has no
+            // possibility of cancelling
+            return harden(redemptionResult);
+          };
+          return Promise.all(paymentDepositedPs)
+            .then(recordOffer)
+            .then(makeRedemptionResult);
+        });
+      },
+      isOfferActive: offerTable.isOfferActive,
+      getOffers: offerTable.getOffers,
+      getOffer: offerTable.get,
+      getInstallation: installationHandle =>
+        installationTable.get(installationHandle).code,
     },
-    isOfferActive: offerTable.isOfferActive,
-    getOffers: offerTable.getOffers,
-    getOffer: offerTable.get,
-    getInstallation: installationHandle =>
-      installationTable.get(installationHandle).code,
-  });
+  );
   return zoeService;
 };
 


### PR DESCRIPTION
Closes #617

I got a little free tonight and made pretty good progress.  The `automaticRefund.js` contract now shows Intellisense for the Zoe contract facet.  Once this is complete enough, we can remove the chainmail files.  When we need an IDL in the future, I plan on extracting `.d.ts` files using the Typescript compiler and working from there (with annotations for things like Cap'n'Proto if necessary).

Note that adding `// @ts-check` to the top of a file will have its JSDocs actually parsed and verified by the Typescript compiler (and TS language server for VSCode, WebStorm, etc).  You'll get red underlines when types are not correct.

Some of the types are still missing (see the TODO entries in zoe.js), but otherwise, I'd say it's a good step forward.  @Chris-Hibbert please take a look, `git checkout 617-zoe-types`, and improve and push from there.

Also, the same mechanics I used in `automaticRefund.js` should be extended to all other contracts.  

[The ugly thing was having to manually type `harden`.  That should be fixed by another tiny PR (https://github.com/Agoric/SES-shim/pull/258), but the manual typing should prevent us from having to wait on the new harden release.  Your choice as to whether you want to wait for that to land, or just fake it and don't use the `rawHarden` hack (just import harden directly and use it).]
