### PR TITLE
fix: cosmic-swingset should use disk-backed storage

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/reset-state.js
+++ b/packages/cosmic-swingset/lib/ag-solo/reset-state.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 
-import { initSwingStore } from '@agoric/swing-store-simple';
+import { initSwingStore } from '@agoric/swing-store-lmdb';
 
 export default async function resetState(basedir) {
   const mailboxStateFile = path.resolve(

--- a/packages/cosmic-swingset/lib/ag-solo/start.js
+++ b/packages/cosmic-swingset/lib/ag-solo/start.js
@@ -10,7 +10,7 @@ import anylogger from 'anylogger';
 // import harden from '@agoric/harden';
 // import djson from 'deterministic-json';
 
-import { openSwingStore } from '@agoric/swing-store-simple';
+import { openSwingStore } from '@agoric/swing-store-lmdb';
 import {
   loadBasedir,
   buildCommand,

--- a/packages/cosmic-swingset/lib/launch-chain.js
+++ b/packages/cosmic-swingset/lib/launch-chain.js
@@ -11,7 +11,7 @@ import {
   getTimerWrapperSourcePath,
   getVatTPSourcePath,
 } from '@agoric/swingset-vat';
-import { openSwingStore } from '@agoric/swing-store-simple';
+import { openSwingStore } from '@agoric/swing-store-lmdb';
 
 const log = anylogger('launch-chain');
 

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -32,7 +32,7 @@
     "@agoric/sharing-service": "^0.0.3",
     "@agoric/spawner": "^0.1.1",
     "@agoric/store": "^0.0.3",
-    "@agoric/swing-store-simple": "^0.1.1",
+    "@agoric/swing-store-lmdb": "^0.2.1",
     "@agoric/swingset-vat": "^0.4.1",
     "@agoric/tendermint": "^4.1.3",
     "@agoric/weak-store": "^0.0.3",


### PR DESCRIPTION
We were still using swing-store-simple, which keeps the kernel state in
RAM. This is serialized to disk at the end of each block.

This switches it to our nice shiny swing-store-lmdb, which keeps the state on
disk at all times, only reading one key at a time into RAM.

closes #899