### PR TITLE
Better detection of already-listening ports

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/start.js
+++ b/packages/cosmic-swingset/lib/ag-solo/start.js
@@ -292,7 +292,7 @@ export default async function start(basedir, withSES, argv) {
           if (broadcastJSON) {
             throw new Error(`duplicate type=http in connections.json`);
           }
-          broadcastJSON = makeHTTPListener(
+          broadcastJSON = await makeHTTPListener(
             basedir,
             c.port,
             c.host,


### PR DESCRIPTION
Closes #872

Try connecting to the local port before we listen on it.

This improves the user experience when there's a listening port
already, rather than just relying on crashing during the listen
(which doesn't happen under Windows at least).