### PR TITLE
New tool: kernel state dump utility

### DIFF
--- a/packages/swingset-runner/bin/kerneldump
+++ b/packages/swingset-runner/bin/kerneldump
@@ -1,0 +1,8 @@
+#!/usr/bin/env -S node -r esm
+
+/**
+ * Simple boilerplate program providing linkage to launch an application written using modules within the
+ * as yet not-entirely-ESM-supporting version of NodeJS.
+ */
+import { main } from '../src/kerneldump.js';
+main();

--- a/packages/swingset-runner/src/dumpstore.js
+++ b/packages/swingset-runner/src/dumpstore.js
@@ -33,13 +33,16 @@ export function dumpStore(store, outfile, rawMode) {
 
   p('// device info');
   popt('device.nextID');
-  const devNames = JSON.parse(popt('device.names'));
   const devs = new Map();
-  for (const dn of devNames) {
-    const d = popt(`device.name.${dn}`);
-    devs.set(dn, d);
+  const devNamesRaw = popt('device.names');
+  if (devNamesRaw) {
+    const devNames = JSON.parse(devNamesRaw);
+    for (const dn of devNames) {
+      const d = popt(`device.name.${dn}`);
+      devs.set(dn, d);
+    }
+    gap();
   }
-  gap();
 
   p('// kernel devices');
   popt('kd.nextID');
@@ -58,13 +61,16 @@ export function dumpStore(store, outfile, rawMode) {
 
   p('// vat info');
   popt('vat.nextID');
-  const vatNames = JSON.parse(popt('vat.names'));
   const vats = new Map();
-  for (const vn of vatNames) {
-    const v = popt(`vat.name.${vn}`);
-    vats.set(vn, v);
+  const vatNamesRaw = popt('vat.names');
+  if (vatNamesRaw) {
+    const vatNames = JSON.parse(vatNamesRaw);
+    for (const vn of vatNames) {
+      const v = popt(`vat.name.${vn}`);
+      vats.set(vn, v);
+    }
+    gap();
   }
-  gap();
 
   p('// kernel objects');
   popt('ko.nextID');

--- a/packages/swingset-runner/src/dumpstore.js
+++ b/packages/swingset-runner/src/dumpstore.js
@@ -1,0 +1,155 @@
+import fs from 'fs';
+import process from 'process';
+
+/* eslint-disable no-use-before-define */
+export function dumpStore(store, outfile, rawMode) {
+  let out;
+  if (outfile) {
+    out = fs.createWriteStream(outfile);
+  } else {
+    out = process.stdout;
+  }
+
+  const state = new Map();
+  for (const key of store.getKeys('', '~')) {
+    const value = store.get(key);
+    if (rawMode) {
+      pkv(key, value);
+    } else {
+      state.set(key, value);
+    }
+  }
+  if (rawMode) {
+    process.exit(0);
+  }
+
+  const initialized = popt('initialized');
+  if (initialized) {
+    gap();
+  }
+
+  popt('runQueue');
+  gap();
+
+  p('// device info');
+  popt('device.nextID');
+  const devNames = JSON.parse(popt('device.names'));
+  const devs = new Map();
+  for (const dn of devNames) {
+    const d = popt(`device.name.${dn}`);
+    devs.set(dn, d);
+  }
+  gap();
+
+  p('// kernel devices');
+  popt('kd.nextID');
+  pgroup('kd');
+  gap();
+
+  for (const [dn, d] of devs.entries()) {
+    p(`// device ${d} (${dn})`);
+    popt(`${d}.o.nextID`);
+    for (const key of groupKeys(`${d}.c.kd`)) {
+      const val = popt(key);
+      popt(`${d}.c.${val}`);
+    }
+  }
+  gap();
+
+  p('// vat info');
+  popt('vat.nextID');
+  const vatNames = JSON.parse(popt('vat.names'));
+  const vats = new Map();
+  for (const vn of vatNames) {
+    const v = popt(`vat.name.${vn}`);
+    vats.set(vn, v);
+  }
+  gap();
+
+  p('// kernel objects');
+  popt('ko.nextID');
+  pgroup('ko');
+  gap();
+  p('// kernel promises');
+  popt('kp.nextID');
+  pgroup('kp');
+  gap();
+
+  let starting = true;
+  for (const [vn, v] of vats.entries()) {
+    if (starting) {
+      starting = false;
+    } else {
+      gap();
+    }
+    p(`// vat ${v} (${vn})`);
+    popt(`${v}.d.nextID`);
+    popt(`${v}.o.nextID`);
+    popt(`${v}.p.nextID`);
+    popt(`${v}.t.nextID`);
+    for (const key of groupKeys(`${v}.c.kd`)) {
+      const val = popt(key);
+      popt(`${v}.c.${val}`);
+    }
+    for (const key of groupKeys(`${v}.c.ko`)) {
+      const val = popt(key);
+      popt(`${v}.c.${val}`);
+    }
+    for (const key of groupKeys(`${v}.c.kp`)) {
+      const val = popt(key);
+      popt(`${v}.c.${val}`);
+    }
+    pgroup(`${v}.t.`);
+  }
+
+  starting = true;
+  for (const key of groupKeys('')) {
+    if (starting) {
+      gap();
+      p('// other state');
+      starting = false;
+    }
+    popt(key);
+  }
+
+  function p(str) {
+    out.write(str);
+    out.write('\n');
+  }
+
+  function pkv(key, value) {
+    p(`${key} :: ${value}`);
+  }
+
+  function gap() {
+    p('');
+  }
+
+  function* groupKeys(baseKey) {
+    const subkeys = Array.from(state.keys()).sort();
+    const end = `${baseKey}~`;
+    for (const key of subkeys) {
+      if (baseKey <= key && key < end) {
+        yield key;
+      }
+    }
+  }
+
+  function pgroup(baseKey) {
+    for (const key of groupKeys(baseKey)) {
+      pkv(key, state.get(key));
+      state.delete(key);
+    }
+  }
+
+  function popt(key) {
+    if (state.has(key)) {
+      const value = state.get(key);
+      pkv(key, value);
+      state.delete(key);
+      return value;
+    } else {
+      return undefined;
+    }
+  }
+}

--- a/packages/swingset-runner/src/kerneldump.js
+++ b/packages/swingset-runner/src/kerneldump.js
@@ -1,7 +1,10 @@
 import path from 'path';
 import process from 'process';
 
-import { openSwingStore } from '@agoric/swing-store-lmdb';
+import { openSwingStore as openLMDBSwingStore } from '@agoric/swing-store-lmdb';
+import { openSwingStore as openSimpleSwingStore } from '@agoric/swing-store-simple';
+
+import { dumpStore } from './dumpstore';
 
 function usage() {
   console.log(`
@@ -9,8 +12,11 @@ Command line:
   kerneldump [FLAGS...] [BASEDIR]
 
 FLAGS may be:
-  --raw  - just dump the kernel state database as key/value pairs alphabetically without annotation
-  --help - print this helpful usage information
+  --raw       - just dump the kernel state database as key/value pairs alphabetically without annotation
+  --lmdb      - read an LMDB state database (default)
+  --filedb    - read a simple file-based (aka .jsonlines) data store
+  --help      - print this helpful usage information
+  --out PATH  - output dump to PATH ("-" indicates stdout, the default)
 
 BASEDIR is the base directory where a swingset's vats live
   If BASEDIR is omitted it defaults to the current working directory.
@@ -25,22 +31,11 @@ function fail(message, printUsage) {
   process.exit(1);
 }
 
-function pkv(key, value) {
-  console.log(`${key} :: ${value}`);
-}
-
-function p(str) {
-  console.log(str);
-}
-
-function gap() {
-  p('');
-}
-
-/* eslint-disable no-use-before-define */
 export function main() {
   const argv = process.argv.splice(2);
   let rawMode = false;
+  let dbMode = '--lmdb';
+  let outfile;
   while (argv[0] && argv[0].startsWith('-')) {
     const flag = argv.shift();
     switch (flag) {
@@ -51,6 +46,17 @@ export function main() {
         usage();
         process.exit(0);
         break;
+      case '--filedb':
+      case '--lmdb':
+        dbMode = flag;
+        break;
+      case '-o':
+      case '--out':
+        outfile = argv.shift();
+        if (outfile === '-') {
+          outfile = undefined;
+        }
+        break;
       default:
         fail(`invalid flag ${flag}`, true);
         break;
@@ -59,135 +65,16 @@ export function main() {
 
   const basedir = argv.shift();
   const kernelStateDBDir = path.join(basedir, 'swingset-kernel-state');
-  const store = openSwingStore(kernelStateDBDir).storage;
-
-  const state = new Map();
-  for (const key of store.getKeys('', '~')) {
-    const value = store.get(key);
-    if (rawMode) {
-      pkv(key, value);
-    } else {
-      state.set(key, value);
-    }
+  let store;
+  switch (dbMode) {
+    case '--filedb':
+      store = openSimpleSwingStore(kernelStateDBDir);
+      break;
+    case '--lmdb':
+      store = openLMDBSwingStore(kernelStateDBDir);
+      break;
+    default:
+      fail(`invalid database mode ${dbMode}`, true);
   }
-  if (rawMode) {
-    process.exit(0);
-  }
-
-  const initialized = popt('initialized');
-  if (initialized) {
-    gap();
-  }
-
-  popt('runQueue');
-  gap();
-
-  p('// device info');
-  popt('device.nextID');
-  const devNames = JSON.parse(popt('device.names'));
-  const devs = new Map();
-  for (const dn of devNames) {
-    const d = popt(`device.name.${dn}`);
-    devs.set(dn, d);
-  }
-  gap();
-
-  p('// kernel devices');
-  popt('kd.nextID');
-  pgroup('kd');
-  gap();
-
-  for (const [dn, d] of devs.entries()) {
-    p(`// device ${d} (${dn})`);
-    popt(`${d}.o.nextID`);
-    for (const key of groupKeys(`${d}.c.kd`)) {
-      const val = popt(key);
-      popt(`${d}.c.${val}`);
-    }
-  }
-  gap();
-
-  p('// vat info');
-  popt('vat.nextID');
-  const vatNames = JSON.parse(popt('vat.names'));
-  const vats = new Map();
-  for (const vn of vatNames) {
-    const v = popt(`vat.name.${vn}`);
-    vats.set(vn, v);
-  }
-  gap();
-
-  p('// kernel objects');
-  popt('ko.nextID');
-  pgroup('ko');
-  gap();
-  p('// kernel promises');
-  popt('kp.nextID');
-  pgroup('kp');
-  gap();
-
-  let starting = true;
-  for (const [vn, v] of vats.entries()) {
-    if (starting) {
-      starting = false;
-    } else {
-      gap();
-    }
-    p(`// vat ${v} (${vn})`);
-    popt(`${v}.d.nextID`);
-    popt(`${v}.o.nextID`);
-    popt(`${v}.p.nextID`);
-    popt(`${v}.t.nextID`);
-    for (const key of groupKeys(`${v}.c.kd`)) {
-      const val = popt(key);
-      popt(`${v}.c.${val}`);
-    }
-    for (const key of groupKeys(`${v}.c.ko`)) {
-      const val = popt(key);
-      popt(`${v}.c.${val}`);
-    }
-    for (const key of groupKeys(`${v}.c.kp`)) {
-      const val = popt(key);
-      popt(`${v}.c.${val}`);
-    }
-    pgroup(`${v}.t.`);
-  }
-
-  starting = true;
-  for (const key of groupKeys('')) {
-    if (starting) {
-      gap();
-      p('// other state');
-      starting = false;
-    }
-    popt(key);
-  }
-
-  function* groupKeys(baseKey) {
-    const subkeys = Array.from(state.keys()).sort();
-    const end = `${baseKey}~`;
-    for (const key of subkeys) {
-      if (baseKey <= key && key < end) {
-        yield key;
-      }
-    }
-  }
-
-  function pgroup(baseKey) {
-    for (const key of groupKeys(baseKey)) {
-      pkv(key, state.get(key));
-      state.delete(key);
-    }
-  }
-
-  function popt(key) {
-    if (state.has(key)) {
-      const value = state.get(key);
-      pkv(key, value);
-      state.delete(key);
-      return value;
-    } else {
-      return undefined;
-    }
-  }
+  dumpStore(store.storage, outfile, rawMode);
 }

--- a/packages/swingset-runner/src/kerneldump.js
+++ b/packages/swingset-runner/src/kerneldump.js
@@ -1,0 +1,192 @@
+import path from 'path';
+import process from 'process';
+
+import { openSwingStore } from '@agoric/swing-store-lmdb';
+
+function usage() {
+  console.log(`
+Command line:
+  kerneldump [FLAGS...] [BASEDIR]
+
+FLAGS may be:
+  --raw  - just dump the kernel state database as key/value pairs alphabetically without annotation
+  --help - print this helpful usage information
+
+BASEDIR is the base directory where a swingset's vats live
+  If BASEDIR is omitted it defaults to the current working directory.
+`);
+}
+
+function fail(message, printUsage) {
+  console.log(message);
+  if (printUsage) {
+    usage();
+  }
+  process.exit(1);
+}
+
+function pkv(key, value) {
+  console.log(`${key} :: ${value}`);
+}
+
+function p(str) {
+  console.log(str);
+}
+
+function gap() {
+  p('');
+}
+
+export function main() {
+  const argv = process.argv.splice(2);
+  let rawMode = false;
+  while (argv[0] && argv[0].startsWith('-')) {
+    const flag = argv.shift();
+    switch (flag) {
+      case '--raw':
+        rawMode = true;
+        break;
+      case '--help':
+        usage();
+        process.exit(0);
+        break;
+      default:
+        fail(`invalid flag ${flag}`, true);
+        break;
+    }
+  }
+
+  const basedir = argv.shift();
+  const kernelStateDBDir = path.join(basedir, 'swingset-kernel-state');
+  const store = openSwingStore(kernelStateDBDir).storage;
+
+  const state = new Map();
+  for (const key of store.getKeys('', '~')) {
+    const value = store.get(key);
+    if (rawMode) {
+      pkv(key, value);
+    } else {
+      state.set(key, value);
+    }
+  }
+  if (rawMode) {
+    process.exit(0);
+  }
+
+  const initialized = popt('initialized');
+  if (initialized) {
+    gap();
+  }
+
+  popt('runQueue');
+  gap();
+
+  p('// device info');
+  popt('device.nextID');
+  const devNames = JSON.parse(popt('device.names'));
+  const devs = new Map();
+  for (const dn of devNames) {
+    const d = popt(`device.name.${dn}`);
+    devs.set(dn, d);
+  }
+  gap();
+
+  p('// kernel devices');
+  popt('kd.nextID');
+  pgroup('kd');
+  gap();
+
+  for (const [dn, d] of devs.entries()) {
+    p(`// device ${d} (${dn})`);
+    popt(`${d}.o.nextID`);
+    for (const key of groupKeys(`${d}.c.kd`)) {
+      const val = popt(key);
+      popt(`${d}.c.${val}`);
+    }
+  }
+  gap();
+
+  p('// vat info');
+  popt('vat.nextID');
+  const vatNames = JSON.parse(popt('vat.names'));
+  const vats = new Map();
+  for (const vn of vatNames) {
+    const v = popt(`vat.name.${vn}`);
+    vats.set(vn, v);
+  }
+  gap();
+
+  p('// kernel objects');
+  popt('ko.nextID');
+  pgroup('ko');
+  gap();
+  p('// kernel promises');
+  popt('kp.nextID');
+  pgroup('kp');
+  gap();
+
+  let starting = true;
+  for (const [vn, v] of vats.entries()) {
+    if (starting) {
+      starting = false;
+    } else {
+      gap();
+    }
+    p(`// vat ${v} (${vn})`);
+    popt(`${v}.d.nextID`);
+    popt(`${v}.o.nextID`);
+    popt(`${v}.p.nextID`);
+    popt(`${v}.t.nextID`);
+    for (const key of groupKeys(`${v}.c.kd`)) {
+      const val = popt(key);
+      popt(`${v}.c.${val}`);
+    }
+    for (const key of groupKeys(`${v}.c.ko`)) {
+      const val = popt(key);
+      popt(`${v}.c.${val}`);
+    }
+    for (const key of groupKeys(`${v}.c.kp`)) {
+      const val = popt(key);
+      popt(`${v}.c.${val}`);
+    }
+    pgroup(`${v}.t.`);
+  }
+
+  starting = true;
+  for (const key of groupKeys('')) {
+    if (starting) {
+      gap();
+      p('// other state');
+      starting = false;
+    }
+    popt(key);
+  }
+
+  function* groupKeys(baseKey) {
+    const subkeys = Array.from(state.keys()).sort();
+    const end = `${baseKey}~`;
+    for (const key of subkeys) {
+      if (baseKey <= key && key < end) {
+        yield(key);
+      }
+    }
+  }
+
+  function pgroup(baseKey) {
+    for (const key of groupKeys(baseKey)) {
+      pkv(key, state.get(key));
+      state.delete(key);
+    }
+  }
+
+  function popt(key) {
+    if (state.has(key)) {
+      const value = state.get(key);
+      pkv(key, value);
+      state.delete(key);
+      return value;
+    } else {
+      return undefined;
+    }
+  }
+}

--- a/packages/swingset-runner/src/kerneldump.js
+++ b/packages/swingset-runner/src/kerneldump.js
@@ -37,6 +37,7 @@ function gap() {
   p('');
 }
 
+/* eslint-disable no-use-before-define */
 export function main() {
   const argv = process.argv.splice(2);
   let rawMode = false;
@@ -167,7 +168,7 @@ export function main() {
     const end = `${baseKey}~`;
     for (const key of subkeys) {
       if (baseKey <= key && key < end) {
-        yield(key);
+        yield key;
       }
     }
   }


### PR DESCRIPTION
This adds a new tool to our Swiss army knife: a utility that will dump the contents of an LMDB kernel state database in a legible form to stdout.

Usage:
  `bin/kerneldump` [_FLAGS_...] [_BASEDIR_]

_FLAGS_ may be:
  `--raw`  - just dump the kernel state database as key/value pairs alphabetically without annotation or organization
  `--help` - print this helpful usage information

_BASEDIR_ is the base directory where a swingset's vats live
  If _BASEDIR_ is omitted it defaults to the current working directory.

You typically would run this from the same directory you'd run `bin/runner`