### PR TITLE
fix(assert): slightly better assert logging

### DIFF
--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -136,8 +136,11 @@ function details(template, ...args) {
       if (args.length >= 1) {
         parts.push('\nSee console for error data.');
       }
-      console.error(...interleaved);
-      return new Error(parts.join(''));
+      const err = new Error(parts.join(''));
+      console.error('LOGGED ERROR:', ...interleaved, err);
+      // eslint-disable-next-line no-debugger
+      debugger;
+      return err;
     },
   };
   // });
@@ -155,9 +158,7 @@ harden(details);
  */
 function fail(optDetails = details`Assert failed`) {
   if (typeof optDetails === 'string') {
-    const detailString = `Assertion failed: ${optDetails}`;
-    console.error(detailString);
-    throw new Error(detailString);
+    optDetails = details`${openDetail(optDetails)}`;
   }
   throw optDetails.complain();
 }
@@ -186,7 +187,6 @@ function fail(optDetails = details`Assert failed`) {
  */
 function assert(flag, optDetails = details`check failed`) {
   if (!flag) {
-    console.log(`FAILED ASSERTION ${flag}`);
     fail(optDetails);
   }
 }

--- a/packages/assert/test/test-assert.js
+++ b/packages/assert/test/test-assert.js
@@ -47,39 +47,28 @@ test('assert', t => {
     assert(2 + 3 === 5);
     assert.equal(2 + 3, 5);
     throwsAndLogs(t, () => assert(false), /check failed/, [
-      ['log', 'FAILED ASSERTION false'],
-      ['error', 'check failed'],
+      ['error', 'LOGGED ERROR:', 'check failed'],
     ]);
     throwsAndLogs(
       t,
       () => assert.equal(5, 6),
       /Expected \(a number\) === \(a number\)/,
-      [
-        ['log', 'FAILED ASSERTION false'],
-        ['error', 'Expected', 5, '===', 6],
-      ],
+      [['error', 'LOGGED ERROR:', 'Expected', 5, '===', 6]],
     );
     throwsAndLogs(t, () => assert.equal(5, 6, 'foo'), /foo/, [
-      ['log', 'FAILED ASSERTION false'],
-      ['error', 'Assertion failed: foo'],
+      ['error', 'LOGGED ERROR:', 'foo'],
     ]);
     throwsAndLogs(
       t,
       () => assert.equal(5, 6, details`${5} !== ${6}`),
       /\(a number\) !== \(a number\)/,
-      [
-        ['log', 'FAILED ASSERTION false'],
-        ['error', 5, '!==', 6],
-      ],
+      [['error', 'LOGGED ERROR:', 5, '!==', 6]],
     );
     throwsAndLogs(
       t,
       () => assert.equal(5, 6, details`${5} !== ${openDetail(6)}`),
       /\(a number\) !== 6/,
-      [
-        ['log', 'FAILED ASSERTION false'],
-        ['error', 5, '!==', 6],
-      ],
+      [['error', 'LOGGED ERROR:', 5, '!==', 6]],
     );
   } catch (e) {
     console.log('unexpected exception', e);

--- a/packages/assert/test/throwsAndLogs.js
+++ b/packages/assert/test/throwsAndLogs.js
@@ -22,6 +22,9 @@ function makeFakeConsole(logArray) {
     'timeEnd',
   ];
 
+  // TODO(msm): Too heavy a hammer
+  const noErrorFilter = specimen => !(specimen instanceof Error);
+
   const fakeConsole = {};
 
   consoleWhitelist.forEach(name => {
@@ -31,7 +34,7 @@ function makeFakeConsole(logArray) {
     const f = (...args) => {
       // Note the curlies and lack of a `return`. All these should return
       // only undefined, i.e., not return anything.
-      logArray.push([name, ...args]);
+      logArray.push([name, ...args.filter(noErrorFilter)]);
     };
     defineProperty(f, 'name', { value: name });
     fakeConsole[name] = f;

--- a/packages/zoe/src/objArrayConversion.js
+++ b/packages/zoe/src/objArrayConversion.js
@@ -1,4 +1,4 @@
-import { assert, details } from '@agoric/assert';
+import { assert, details, openDetail } from '@agoric/assert';
 
 export const arrayToObj = (array, keywords) => {
   assert(
@@ -14,7 +14,9 @@ export const objToArray = (obj, keywords) => {
   const keys = Object.getOwnPropertyNames(obj);
   assert(
     keys.length === keywords.length,
-    `object keys (${keys}) and keywords (${keywords}) must be of equal length`,
+    details`object keys (${openDetail(keys)}) and keywords (${openDetail(
+      keywords,
+    )}) must be of equal length`,
   );
   return keywords.map(keyword => obj[keyword]);
 };
@@ -24,9 +26,9 @@ export const assertSubset = (whole, part) => {
     assert.typeof(key, 'string');
     assert(
       whole.includes(key),
-      details`key ${key} was not one of the expected keys (${whole.join(
-        ', ',
-      )})`,
+      details`key ${openDetail(
+        key,
+      )} was not one of the expected keys (${openDetail(whole.join(', '))})`,
     );
   });
 };
@@ -36,14 +38,16 @@ export const objToArrayAssertFilled = (obj, keywords) => {
   const keys = Object.getOwnPropertyNames(obj);
   assert(
     keys.length === keywords.length,
-    `object keys (${keys}) and keywords (${keywords}) must be of equal length`,
+    details`object keys (${openDetail(keys)}) and keywords (${openDetail(
+      keywords,
+    )}) must be of equal length`,
   );
   assertSubset(keywords, keys);
   // ensure all keywords are defined on obj
   return keywords.map(keyword => {
     assert(
       obj[keyword] !== undefined,
-      details`obj[keyword] must be defined for keyword ${keyword}`,
+      details`obj[keyword] must be defined for keyword ${openDetail(keyword)}`,
     );
     return obj[keyword];
   });
@@ -56,7 +60,7 @@ export const filterObj = (obj, subsetKeywords) => {
   subsetKeywords.forEach(keyword => {
     assert(
       obj[keyword] !== undefined,
-      details`obj[keyword] must be defined for keyword ${keyword}`,
+      details`obj[keyword] must be defined for keyword ${openDetail(keyword)}`,
     );
     newObj[keyword] = obj[keyword];
   });

--- a/packages/zoe/test/unitTests/test-objArrayConversion.js
+++ b/packages/zoe/test/unitTests/test-objArrayConversion.js
@@ -38,14 +38,14 @@ test('objToArray', t => {
     const keywords2 = ['X', 'Y', 'Z'];
     t.throws(
       () => objToArray(obj, keywords2),
-      /Error: Assertion failed: object keys \(X,Y\) and keywords \(X,Y,Z\) must be of equal length/,
+      /Error: object keys \(X,Y\) and keywords \(X,Y,Z\) must be of equal length/,
       `unequal length should throw`,
     );
 
     const obj2 = { X: 1, Y: 2, Z: 5 };
     t.throws(
       () => objToArray(obj2, keywords),
-      /Error: Assertion failed: object keys \(X,Y,Z\) and keywords \(X,Y\) must be of equal length/,
+      /Error: object keys \(X,Y,Z\) and keywords \(X,Y\) must be of equal length/,
       `unequal length should throw`,
     );
   } catch (e) {


### PR DESCRIPTION
Improves the `assert` package so that the information logged to console is less noisy and more useful.
   * Sends the error object itself to the console, to get a stack.
   * Added a 'LOGGED ERROR' prefix to make the log of these easily findable in a long log by searching and by eye.
   * Eliminates the `FAILED ASSERTION false` noise, now that the rest is more findable.
   * Use of a string rather than `details` tag now goes through the logging path.

Improved `objArrayConversion`s use of `assert`.