### PR TITLE
feat: Add a notifier facility for Zoe and contracts

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "packages/cosmic-swingset",
     "packages/generator-agoric-dapp",
     "packages/agoric-cli",
-    "packages/deployment"
+    "packages/deployment",
+    "packages/notifier"
   ],
   "devDependencies": {
     "eslint": "^6.8.0",

--- a/packages/notifier/.eslintrc-jessie.js
+++ b/packages/notifier/.eslintrc-jessie.js
@@ -1,0 +1,7 @@
+/* global module */
+module.exports = {
+  extends: "jessie",
+  env: {
+    es6: true, // supports new ES6 globals (e.g., new types such as Set)
+  },
+};

--- a/packages/notifier/CHANGELOG.md
+++ b/packages/notifier/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+
+
+
+## 0.0.1 (2020-04-15)
+
+Initial Version

--- a/packages/notifier/CONTRIBUTING.md
+++ b/packages/notifier/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing
+
+Thank you!
+
+## Contact
+
+We use github issues for all bug reports:
+https://github.com/Agoric/agoric-sdk/issues Please add a [notifier]
+prefix to the title and `notifier` tag to notifier-related issues.
+
+## Installing, Testing
+
+You'll need Node.js version 11 or higher. 
+
+* `git clone https://github.com/Agoric/agoric-sdk/`
+* `cd agoric-sdk`
+* `yarn install`
+* `yarn build` (This *must* be done at the top level to build all of
+  the packages)
+* `cd packages/notifier`
+* `yarn test`
+
+## Pull Requests
+
+Before submitting a pull request, please:
+
+* run `yarn test` within `packages/notifier` and make sure all the unit
+  tests pass (running `yarn test` at the top level will test all the
+  monorepo packages, which can be a good integration test.)
+* run `yarn run lint-fix` to reformat the code according to our `eslint`
+  profile, and fix any complaints that it can't automatically correct
+
+## Making a Release
+
+* edit NEWS.md enumerating any user-visible changes. (If there are
+  changelogs/ snippets, consolidate them to build the new NEWS
+  entries, and then delete all the snippets.)
+* make sure `yarn config set version-git-tag false` is the current
+  setting
+* `yarn version` (interactive) or `yarn version --major` or `yarn version --minor`
+  * that changes `package.json`
+  * and does NOT do a `git commit` and `git tag`
+* `git add .`
+* `git commit -m "bump version"`
+* `git tag -a notifier-v$VERSION -m "notifier-v$VERSION"`
+* `yarn publish --access public`
+* `git push`
+* `git push origin notifier-v$VERSION`

--- a/packages/notifier/NEWS.md
+++ b/packages/notifier/NEWS.md
@@ -1,0 +1,5 @@
+User-visible changes in @agoric/notifier:
+
+## Release 0.0.1 (15-April-2020)
+
+Created package `@agoric/notifier`

--- a/packages/notifier/README.md
+++ b/packages/notifier/README.md
@@ -1,0 +1,4 @@
+# Notifier
+
+Produces a notifier, which allows a service to notify clients of
+state changes using a stream of update promises.

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -1,0 +1,87 @@
+{
+  "name": "@agoric/notifier",
+  "version": "0.0.1",
+  "description": "Notifier allows services to update clients about state changes using a stream of promises",
+  "main": "src/notifier.js",
+  "engines": {
+    "node": ">=11.0"
+  },
+  "scripts": {
+    "build": "exit 0",
+    "test": "tape -r esm 'test/**/test*.js' | tap-spec",
+    "lint-fix": "eslint --fix '**/*.js'",
+    "lint-check": "eslint '**/*.js'",
+    "lint-fix-jessie": "eslint -c '.eslintrc-jessie.js' --fix '**/*.js'",
+    "lint-check-jessie": "eslint -c '.eslintrc-jessie.js' '**/*.js'"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Agoric/agoric-sdk.git"
+  },
+  "keywords": [
+    "notifier"
+  ],
+  "author": "Agoric",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/Agoric/agoric-sdk/issues"
+  },
+  "homepage": "https://github.com/Agoric/agoric-sdk#readme",
+  "dependencies": {
+    "@agoric/produce-promise": "^0.0.5",
+    "@agoric/harden": "^0.0.4"
+  },
+  "devDependencies": {
+    "esm": "^3.2.25",
+    "tap-spec": "^5.0.0",
+    "tape": "^4.11.0",
+    "tape-promise": "^4.0.0"
+  },
+  "files": [
+    "src/",
+    "NEWS.md"
+  ],
+  "eslintConfig": {
+    "extends": [
+      "airbnb-base",
+      "plugin:prettier/recommended"
+    ],
+    "env": {
+      "es6": true
+    },
+    "rules": {
+      "implicit-arrow-linebreak": "off",
+      "function-paren-newline": "off",
+      "arrow-parens": "off",
+      "strict": "off",
+      "no-console": "off",
+      "no-unused-vars": [
+        "error",
+        {
+          "argsIgnorePattern": "^_",
+          "varsIgnorePattern": "^_"
+        }
+      ],
+      "no-return-assign": "off",
+      "no-param-reassign": "off",
+      "no-restricted-syntax": [
+        "off",
+        "ForOfStatement"
+      ],
+      "no-unused-expressions": "off",
+      "no-loop-func": "off",
+      "no-inner-declarations": "off",
+      "import/prefer-default-export": "off"
+    }
+  },
+  "eslintIgnore": [
+    "bundle-*.js"
+  ],
+  "prettier": {
+    "trailingComma": "all",
+    "singleQuote": true
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/notifier/src/notifier.js
+++ b/packages/notifier/src/notifier.js
@@ -1,0 +1,69 @@
+import { producePromise } from '@agoric/produce-promise';
+import harden from '@agoric/harden';
+
+/**
+ * Produces a pair of objects, which allow a service to produce a stream of
+ * update promises. The notifier has a single method: getUpdatesSince, while the
+ * updater has two methods, updateState and resolve. getUpdateSince can be
+ * called repeatedly to get access to a sequence of update records.
+ * Each update is a record containing { value, updateHandle, done }.
+ *   value is whatever state the service wants to publish,
+ *   updateHandle is an opaque object that identifies the update.
+ *   done is a boolean that remains false until the stream reaches a final state
+ *
+ * getUpdateSince(handle) returns the record above, or a HandledPromise for it.
+ * If the handle argument is omitted or differs from the current handle, the
+ * current record is returned. If the handle corresponds to the current state,
+ * a promise is returned. After the next state change, The promise will resolve
+ * to the then-current value of the record.
+ *
+ * updateState(state) sets a new state and resolves the outstanding promise.
+ * resolve(finalState) sets the new state, sends a final update, and freezes the
+ * updater. The updater object should be closely held, as anyone with access to
+ * it can provide updates.
+ */
+export const produceNotifier = () => {
+  let currentPromiseRec = producePromise();
+  let currentResponse = harden({
+    value: undefined,
+    updateHandle: {},
+    done: false,
+  });
+
+  function getUpdateSince(updateHandle = undefined) {
+    if (updateHandle === currentResponse.updateHandle) {
+      return currentPromiseRec.promise;
+    }
+
+    return currentResponse;
+  }
+
+  function updateState(state) {
+    if (!currentResponse.updateHandle) {
+      throw new Error('Cannot update state after resolve.');
+    }
+
+    currentResponse = harden({ value: state, updateHandle: {}, done: false });
+    currentPromiseRec.resolve(currentResponse);
+    currentPromiseRec = producePromise();
+  }
+
+  function resolve(finalState) {
+    if (!currentResponse.updateHandle) {
+      throw new Error('Cannot resolve again.');
+    }
+
+    currentResponse = harden({
+      value: finalState,
+      updateHandle: undefined,
+      done: true,
+    });
+    currentPromiseRec.resolve(currentResponse);
+  }
+
+  // notifier facet is separate so it can be handed out loosely while updater is
+  // tightly held
+  const notifier = harden({ getUpdateSince });
+  const updater = harden({ updateState, resolve });
+  return harden({ notifier, updater });
+};

--- a/packages/notifier/test/test-notifier.js
+++ b/packages/notifier/test/test-notifier.js
@@ -1,0 +1,78 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from 'tape-promise/tape';
+import { produceNotifier } from '../src/notifier';
+
+test('notifier - initital state', t => {
+  const { notifier, updater } = produceNotifier();
+  updater.updateState(1);
+
+  const updateDeNovo = notifier.getUpdateSince();
+  const updateFromNonExistent = notifier.getUpdateSince({});
+
+  t.equals(updateDeNovo.value, 1, 'state is one');
+  t.deepEquals(updateDeNovo, updateFromNonExistent, 'no param same as unknown');
+  t.end();
+});
+
+test('notifier - single update', t => {
+  t.plan(3);
+  const { notifier, updater } = produceNotifier();
+  updater.updateState(1);
+
+  const updateDeNovo = notifier.getUpdateSince();
+
+  const updateInWaiting = notifier.getUpdateSince(updateDeNovo.updateHandle);
+  t.equals(updateDeNovo.value, 1, 'initial state is one');
+  Promise.all([updateInWaiting]).then(([update]) => {
+    t.equals(update.value, 3, 'updated state is eventually three');
+  });
+
+  t.equals(notifier.getUpdateSince({}).value, 1);
+  updater.updateState(3);
+});
+
+test('notifier - update after state change', t => {
+  t.plan(5);
+  const { notifier, updater } = produceNotifier();
+  updater.updateState(1);
+
+  const updateDeNovo = notifier.getUpdateSince();
+
+  const updateInWaiting = notifier.getUpdateSince(updateDeNovo.updateHandle);
+  t.equals(updateDeNovo.value, 1, 'first state check (1)');
+  Promise.all([updateInWaiting]).then(([update1]) => {
+    t.equals(update1.value, 3, '4th check (delayed) 3');
+    const thirdStatePromise = notifier.getUpdateSince(update1.updateHandle);
+    Promise.all([thirdStatePromise]).then(([update2]) => {
+      t.equals(update2.value, 5, '5th check (delayed) 5');
+    });
+  });
+
+  t.equals(notifier.getUpdateSince({}).value, 1, '2nd check (1)');
+  updater.updateState(3);
+
+  t.equals(notifier.getUpdateSince({}).value, 3, '3rd check (3)');
+  updater.updateState(5);
+});
+
+test('notifier - final state', t => {
+  t.plan(6);
+  const { notifier, updater } = produceNotifier();
+  updater.updateState(1);
+
+  const updateDeNovo = notifier.getUpdateSince();
+  const updateInWaiting = notifier.getUpdateSince(updateDeNovo.updateHandle);
+  t.equals(updateDeNovo.value, 1, 'initial state is one');
+  Promise.all([updateInWaiting]).then(([update]) => {
+    t.equals(update.value, 'final', 'state is "final"');
+    t.notOk(update.updateHandle, 'no handle after close');
+    const postFinalUpdate = notifier.getUpdateSince(update.updateHandle);
+    Promise.all([postFinalUpdate]).then(([after]) => {
+      t.equals(after.value, 'final', 'stable');
+      t.notOk(after.updateHandle, 'no handle after close');
+    });
+  });
+
+  t.equals(notifier.getUpdateSince({}).value, 1, 'still one');
+  updater.resolve('final');
+});


### PR DESCRIPTION
The Notifier has public methods `updateState()` and `getUpdatesSince()`. `updateState()` would be used within a service to record state changes. `getUpdatesSince()` would be made available to clients to allow them to be notified of state changes by waiting for promise resolution. 

Includes usage documentation and tests.

This follows the pattern proposed in  #253 and #841, though it uses handles to represent the successive states rather than sequence numbers.
