### PR TITLE
require Node.js v12.16.1 or higher: update docs and metadata

### DIFF
--- a/.github/workflows/ag-solo-xs.yml
+++ b/.github/workflows/ag-solo-xs.yml
@@ -16,6 +16,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.16.1'
     - name: cache node modules
       uses: actions/cache@v1
       with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,6 +24,9 @@ jobs:
     #    restore-keys: |
     #      ${{ runner.os }}-go-
 
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.16.1'
     # 'yarn install' must be done at the top level, to build all the
     # cross-package symlinks
     - run: yarn install

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -13,6 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.16.1'
 
     # FIXME: Reenable after 2020-04-01 when Github cache doesn't take forever.
     #- name: cache node modules

--- a/.github/workflows/test-all-packages.yml.use-cache
+++ b/.github/workflows/test-all-packages.yml.use-cache
@@ -13,6 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.16.1'
 
     - name: cache node modules
       uses: actions/cache@v1

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ But if you are improving the platform itself, this is the repository to use.
 ## Prerequisites
 
 * Git
-* Node.js (version 11 or higher)
+* Node.js (version 12.16.1 or higher)
 * Yarn (`npm install -g yarn`)
 
 You don't need Golang if you just want to test contracts and run the

--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
     "lerna": "^3.20.2",
     "prettier": "^1.18.2"
   },
+  "engines": {
+    "node": ">=12.16.1"
+  },
   "scripts": {
     "OFF-clean": "yarn workspaces run clean",
     "check-dependencies": "node ./scripts/check-mismatched-dependencies.js",

--- a/packages/SwingSet/test/test-node-version.js
+++ b/packages/SwingSet/test/test-node-version.js
@@ -3,10 +3,18 @@
 import semver from 'semver';
 import { test } from 'tape-promise/tape';
 
-test('Node version', t => {
+test('Node version for IO queue priority', t => {
   t.true(
     semver.satisfies(process.version, '>=11.0'),
     'we need Node 11 where the IO queue is higher priority than the Promise queue',
+  );
+  t.end();
+});
+
+test('Node version', t => {
+  t.true(
+    semver.satisfies(process.version, '>=12.16.1'),
+    'we only test against Node 12.16.1 (LTS)',
   );
   t.end();
 });


### PR DESCRIPTION
We acquired a dependency on at least 12.11 (see #837) that we don't
understand enough to relax, and we're only testing CI on 13.

So we're declaring that we require Node 13 or higher. This updates the
top-level package.json's `engines:` property, so that `yarn` will complain
immediately if you use an old Node.

It also updates a SwingSet unit test to check for the new version, as a
backup.

closes #937
refs #837 (makes it obsolete)
closes #35

@tyg: tagging you so you'll be aware, this updates the README but I expect there are other docs places that need to mention the new requirement