### PR TITLE
Change default dapp to dapp-encouragement

### DIFF
--- a/packages/agoric-cli/lib/main.js
+++ b/packages/agoric-cli/lib/main.js
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { Command } from 'commander';
 
-const DEFAULT_DAPP_TEMPLATE = 'dapp-simple-exchange';
+const DEFAULT_DAPP_TEMPLATE = 'dapp-encouragement';
 const DEFAULT_DAPP_URL_BASE = 'git://github.com/Agoric/';
 
 const STAMP = '_agstate';


### PR DESCRIPTION
This is needed to unbreak the integration test and allow steps in the [Getting Started](https://agoric.com/documentation/getting-started/#your-first-agoric-dapp) to work.
