### PR TITLE
Replace `getInstance` with `getInstanceRecord` [WIP]

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/vats/offer-compiler.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/offer-compiler.js
@@ -113,7 +113,7 @@ export default ({
     publicAPI,
     issuerKeywordRecord, // Only present with Zoe 0.3.0.
     terms: { issuers: contractIssuers },
-  } = await E(zoe).getInstance(instanceHandle);
+  } = await E(zoe).getInstanceRecord(instanceHandle);
 
   // If issuerKeywordRecord exists, use it.
   const keywordIssuers = { ...issuerKeywordRecord };

--- a/packages/transform-metering/test/test-transform.js
+++ b/packages/transform-metering/test/test-transform.js
@@ -44,6 +44,7 @@ test('meter transform', async t => {
       );
       const rewritten = await fs.promises
         .readFile(`${base}/${testDir}/rewrite.js`, 'utf8')
+        .then(s => s.replace(/(\r\n|\r)/g, '\n'))
         .catch(_ => undefined);
       const transformed = rewrite(src.trimRight(), testDir);
       if (rewritten === undefined) {

--- a/packages/transform-metering/test/test-transform.js
+++ b/packages/transform-metering/test/test-transform.js
@@ -44,6 +44,7 @@ test('meter transform', async t => {
       );
       const rewritten = await fs.promises
         .readFile(`${base}/${testDir}/rewrite.js`, 'utf8')
+        // Fix golden files in case they have DOS or MacOS line endings.
         .then(s => s.replace(/(\r\n|\r)/g, '\n'))
         .catch(_ => undefined);
       const transformed = rewrite(src.trimRight(), testDir);

--- a/packages/zoe/src/zoe.chainmail
+++ b/packages/zoe/src/zoe.chainmail
@@ -79,7 +79,7 @@ interface ZoeService {
    * Credibly get information about the instance (such as the installation
    * and terms used).
    */
-  getInstance(instanceHandle :Handle(Instance)) -> (InstanceRecord);
+  getInstanceRecord(instanceHandle :Handle(Instance)) -> (InstanceRecord);
 
   /** 
    * To redeem an invite, the user normally provides a proposal (their rules for the

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -507,7 +507,7 @@ const makeZoe = (additionalEndowments = {}) => {
   // The public Zoe service has four main methods: `install` takes
   // contract code and registers it with Zoe associated with an
   // `installationHandle` for identification, `makeInstance` creates
-  // an instance from an installation, `getInstance` credibly
+  // an instance from an installation, `getInstanceRecord` credibly
   // retrieves an instance from Zoe, and `offer` allows users to
   // securely escrow and get in return a record containing a promise for
   // payouts, a promise for the outcome of joining the contract,
@@ -609,6 +609,14 @@ const makeZoe = (additionalEndowments = {}) => {
           .then(makeInstanceRecord);
       },
       /**
+       * Credibly retrieves an instance record given an instanceHandle.
+       * @param {object} instanceHandle - the unique, unforgeable
+       * identifier (empty object) for the instance
+       */
+      getInstanceRecord: instanceTable.get,
+
+      /**
+       * @deprecated renamed to getInstanceRecord
        * Credibly retrieves an instance record given an instanceHandle.
        * @param {object} instanceHandle - the unique, unforgeable
        * identifier (empty object) for the instance

--- a/packages/zoe/test/swingsetTests/zoe-metering/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/zoe-metering/bootstrap.js
@@ -46,7 +46,7 @@ function build(E, log) {
       const {
         extent: [{ instanceHandle }],
       } = await E(inviteIssuer).getAmountOf(invite);
-      const { publicAPI } = await E(zoe).getInstance(instanceHandle);
+      const { publicAPI } = await E(zoe).getInstanceRecord(instanceHandle);
       log(`invoking ${testName}.doTest()`);
       await E(publicAPI).doTest();
       log(`complete`);

--- a/packages/zoe/test/swingsetTests/zoe/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-alice.js
@@ -23,7 +23,7 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
     );
 
     const instanceHandle = await getInstanceHandle(refundInvite);
-    const instanceRecord = await E(zoe).getInstance(instanceHandle);
+    const instanceRecord = await E(zoe).getInstanceRecord(instanceHandle);
     const { publicAPI } = instanceRecord;
     const proposal = harden({
       give: { Contribution1: moola(3) },
@@ -144,7 +144,7 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
       terms,
     );
     const instanceHandle = await getInstanceHandle(sellAssetsInvite);
-    const { publicAPI } = await E(zoe).getInstance(instanceHandle);
+    const { publicAPI } = await E(zoe).getInstanceRecord(instanceHandle);
 
     const proposal = harden({
       give: { Asset: moola(1) },
@@ -227,7 +227,7 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
       issuerKeywordRecord,
     );
     const instanceHandle = await getInstanceHandle(addOrderInvite);
-    const { publicAPI } = await E(zoe).getInstance(instanceHandle);
+    const { publicAPI } = await E(zoe).getInstanceRecord(instanceHandle);
 
     const aliceSellOrderProposal = harden({
       give: { Asset: moola(3) },
@@ -301,7 +301,7 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
       issuerKeywordRecord,
     );
     const instanceHandle = await getInstanceHandle(addOrderInvite);
-    const { publicAPI } = await E(zoe).getInstance(instanceHandle);
+    const { publicAPI } = await E(zoe).getInstanceRecord(instanceHandle);
 
     const petnames = ['simoleans', 'moola'];
     const brands = await Promise.all([
@@ -354,7 +354,7 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
       issuerKeywordRecord,
     );
     const instanceHandle = await getInstanceHandle(addLiquidityInvite);
-    const { publicAPI } = await E(zoe).getInstance(instanceHandle);
+    const { publicAPI } = await E(zoe).getInstanceRecord(instanceHandle);
     const liquidityIssuer = await E(publicAPI).getLiquidityIssuer();
     const liquidityAmountMath = await getLocalAmountMath(liquidityIssuer);
     const liquidity = liquidityAmountMath.make;

--- a/packages/zoe/test/swingsetTests/zoe/vat-bob.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-bob.js
@@ -27,7 +27,7 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
 
       const { installationHandle, issuerKeywordRecord } = await E(
         zoe,
-      ).getInstance(instanceHandle);
+      ).getInstanceRecord(instanceHandle);
 
       // Bob ensures it's the contract he expects
       assert(
@@ -89,7 +89,7 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
       );
 
       const instanceHandle = await getInstanceHandle(exclInvite);
-      const instanceInfo = await E(zoe).getInstance(instanceHandle);
+      const instanceInfo = await E(zoe).getInstanceRecord(instanceHandle);
 
       assert(
         instanceInfo.installationHandle === installations.coveredCall,
@@ -152,7 +152,7 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
       const optionAmounts = await E(inviteIssuer).getAmountOf(exclInvite);
       const optionExtent = optionAmounts.extent;
 
-      const instanceInfo = await E(zoe).getInstance(
+      const instanceInfo = await E(zoe).getInstanceRecord(
         optionExtent[0].instanceHandle,
       );
       assert(
@@ -237,7 +237,7 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
 
       const { installationHandle, issuerKeywordRecord, terms } = await E(
         zoe,
-      ).getInstance(inviteExtent[0].instanceHandle);
+      ).getInstanceRecord(inviteExtent[0].instanceHandle);
       assert(
         installationHandle === installations.publicAuction,
         details`wrong installation`,
@@ -286,7 +286,7 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
 
       const { installationHandle, issuerKeywordRecord } = await E(
         zoe,
-      ).getInstance(inviteExtent[0].instanceHandle);
+      ).getInstanceRecord(inviteExtent[0].instanceHandle);
       assert(
         installationHandle === installations.atomicSwap,
         details`wrong installation`,
@@ -341,7 +341,7 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
 
       const { installationHandle, issuerKeywordRecord } = await E(
         zoe,
-      ).getInstance(inviteExtent[0].instanceHandle);
+      ).getInstanceRecord(inviteExtent[0].instanceHandle);
       assert(
         installationHandle === installations.simpleExchange,
         details`wrong installation`,
@@ -387,7 +387,7 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
       );
       const { installationHandle, issuerKeywordRecord } = await E(
         zoe,
-      ).getInstance(inviteExtent[0].instanceHandle);
+      ).getInstanceRecord(inviteExtent[0].instanceHandle);
       assert(
         installationHandle === installations.simpleExchange,
         details`wrong installation`,
@@ -429,7 +429,7 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
     doAutoswap: async instanceHandle => {
       const { installationHandle, issuerKeywordRecord, publicAPI } = await E(
         zoe,
-      ).getInstance(instanceHandle);
+      ).getInstanceRecord(instanceHandle);
       assert(
         installationHandle === installations.autoswap,
         details`wrong installation`,

--- a/packages/zoe/test/swingsetTests/zoe/vat-carol.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-carol.js
@@ -19,7 +19,7 @@ const build = async (E, log, zoe, issuers, payments, installations) => {
 
       const { installationHandle, terms, issuerKeywordRecord } = await E(
         zoe,
-      ).getInstance(inviteExtent[0].instanceHandle);
+      ).getInstanceRecord(inviteExtent[0].instanceHandle);
       assert(
         installationHandle === installations.publicAuction,
         details`wrong installation`,

--- a/packages/zoe/test/swingsetTests/zoe/vat-dave.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-dave.js
@@ -29,7 +29,7 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
 
       const { installationHandle, terms, issuerKeywordRecord } = await E(
         zoe,
-      ).getInstance(inviteExtent[0].instanceHandle);
+      ).getInstanceRecord(inviteExtent[0].instanceHandle);
       assert(
         installationHandle === installations.publicAuction,
         details`wrong installation`,
@@ -81,7 +81,7 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
       const instanceHandle = await getInstanceHandle(exclInvite);
       const { installationHandle, issuerKeywordRecord } = await E(
         zoe,
-      ).getInstance(instanceHandle);
+      ).getInstanceRecord(instanceHandle);
       const installationCode = await E(zoe).getInstallation(installationHandle);
       // pick some arbitrary code points as a signature.
       assert(

--- a/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
+++ b/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
@@ -76,7 +76,7 @@ test('zoe - atomicSwap', async t => {
   const {
     installationHandle: bobInstallationId,
     issuerKeywordRecord: bobIssuers,
-  } = zoe.getInstance(bobInviteExtent.instanceHandle);
+  } = zoe.getInstanceRecord(bobInviteExtent.instanceHandle);
 
   t.equals(bobInstallationId, installationHandle, 'bobInstallationId');
   t.deepEquals(bobIssuers, { Asset: moolaIssuer, Price: simoleanIssuer });
@@ -206,7 +206,7 @@ test('zoe - non-fungible atomicSwap', async t => {
   const {
     installationHandle: bobInstallationId,
     issuerKeywordRecord: bobIssuers,
-  } = zoe.getInstance(bobInviteExtent.instanceHandle);
+  } = zoe.getInstanceRecord(bobInviteExtent.instanceHandle);
 
   t.equals(bobInstallationId, installationHandle, 'bobInstallationId');
   t.deepEquals(bobIssuers, { Asset: ccIssuer, Price: rpgIssuer });

--- a/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
+++ b/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
@@ -141,7 +141,7 @@ test('zoe with automaticRefund', async t => {
       issuerKeywordRecord,
     );
     const instanceHandle = await getInstanceHandle(aliceInvite);
-    const { publicAPI } = zoe.getInstance(instanceHandle);
+    const { publicAPI } = zoe.getInstanceRecord(instanceHandle);
 
     // 2: Alice escrows with zoe
     const aliceProposal = harden({
@@ -179,7 +179,7 @@ test('zoe with automaticRefund', async t => {
     const {
       installationHandle: bobInstallationId,
       issuerKeywordRecord: bobIssuers,
-    } = zoe.getInstance(bobInstanceHandle);
+    } = zoe.getInstanceRecord(bobInstanceHandle);
     t.equals(bobInstallationId, installationHandle);
 
     // bob wants to know what issuers this contract is about and in
@@ -287,7 +287,7 @@ test('multiple instances of automaticRefund for the same Zoe', async t => {
       issuerKeywordRecord,
     );
     const instanceHandle1 = await getInstanceHandle(aliceInvite1);
-    const { publicAPI: publicAPI1 } = zoe.getInstance(instanceHandle1);
+    const { publicAPI: publicAPI1 } = zoe.getInstanceRecord(instanceHandle1);
 
     const aliceInvite2 = await zoe.makeInstance(
       installationHandle,
@@ -296,14 +296,14 @@ test('multiple instances of automaticRefund for the same Zoe', async t => {
     const {
       extent: [{ instanceHandle: instanceHandle2 }],
     } = await inviteIssuer.getAmountOf(aliceInvite2);
-    const { publicAPI: publicAPI2 } = zoe.getInstance(instanceHandle2);
+    const { publicAPI: publicAPI2 } = zoe.getInstanceRecord(instanceHandle2);
 
     const aliceInvite3 = await zoe.makeInstance(
       installationHandle,
       issuerKeywordRecord,
     );
     const instanceHandle3 = await getInstanceHandle(aliceInvite3);
-    const { publicAPI: publicAPI3 } = zoe.getInstance(instanceHandle3);
+    const { publicAPI: publicAPI3 } = zoe.getInstanceRecord(instanceHandle3);
 
     // 2: Alice escrows with zoe
     const aliceProposal = harden({

--- a/packages/zoe/test/unitTests/contracts/test-autoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-autoswap.js
@@ -50,7 +50,7 @@ test('autoSwap with valid offers', async t => {
       issuerKeywordRecord,
     );
     const instanceHandle = await getInstanceHandle(aliceInvite);
-    const { publicAPI } = zoe.getInstance(instanceHandle);
+    const { publicAPI } = zoe.getInstanceRecord(instanceHandle);
     const liquidityIssuer = publicAPI.getLiquidityIssuer();
     const liquidity = liquidityIssuer.getAmountMath().make;
 
@@ -95,7 +95,7 @@ test('autoSwap with valid offers', async t => {
     const {
       publicAPI: bobAutoswap,
       installationHandle: bobInstallationId,
-    } = zoe.getInstance(bobInstanceHandle);
+    } = zoe.getInstanceRecord(bobInstanceHandle);
     t.equals(bobInstallationId, installationHandle);
 
     // Bob looks up the price of 3 moola in simoleans
@@ -254,7 +254,7 @@ test('autoSwap - test fee', async t => {
       issuerKeywordRecord,
     );
     const instanceHandle = await getInstanceHandle(aliceAddLiquidityInvite);
-    const { publicAPI } = zoe.getInstance(instanceHandle);
+    const { publicAPI } = zoe.getInstanceRecord(instanceHandle);
     const liquidityIssuer = publicAPI.getLiquidityIssuer();
     const liquidity = liquidityIssuer.getAmountMath().make;
 
@@ -300,7 +300,7 @@ test('autoSwap - test fee', async t => {
     const {
       publicAPI: bobAutoswap,
       installationHandle: bobInstallationId,
-    } = zoe.getInstance(bobInstanceHandle);
+    } = zoe.getInstanceRecord(bobInstanceHandle);
     t.equals(bobInstallationId, installationHandle);
 
     // Bob looks up the price of 1000 moola in simoleans

--- a/packages/zoe/test/unitTests/contracts/test-coveredCall.js
+++ b/packages/zoe/test/unitTests/contracts/test-coveredCall.js
@@ -71,7 +71,7 @@ test('zoe - coveredCall', async t => {
     const {
       extent: [optionExtent],
     } = await inviteIssuer.getAmountOf(bobExclOption);
-    const { installationHandle } = zoe.getInstance(optionExtent.instanceHandle);
+    const { installationHandle } = zoe.getInstanceRecord(optionExtent.instanceHandle);
     t.equal(installationHandle, coveredCallInstallationHandle);
     t.equal(optionExtent.inviteDesc, 'exerciseOption');
     t.ok(moolaR.amountMath.isEqual(optionExtent.underlyingAsset, moola(3)));
@@ -199,7 +199,7 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
     const {
       extent: [optionExtent],
     } = await inviteIssuer.getAmountOf(bobExclOption);
-    const { installationHandle } = zoe.getInstance(optionExtent.instanceHandle);
+    const { installationHandle } = zoe.getInstanceRecord(optionExtent.instanceHandle);
     t.equal(installationHandle, coveredCallInstallationHandle);
     t.equal(optionExtent.inviteDesc, 'exerciseOption');
     t.ok(moolaR.amountMath.isEqual(optionExtent.underlyingAsset, moola(3)));
@@ -354,7 +354,7 @@ test('zoe - coveredCall with swap for invite', async t => {
     const bobExclOption = await inviteIssuer.claim(optionP);
     const optionAmount = await inviteIssuer.getAmountOf(bobExclOption);
     const optionDesc = optionAmount.extent[0];
-    const { installationHandle } = zoe.getInstance(optionDesc.instanceHandle);
+    const { installationHandle } = zoe.getInstanceRecord(optionDesc.instanceHandle);
     t.equal(installationHandle, coveredCallInstallationHandle);
     t.equal(optionDesc.inviteDesc, 'exerciseOption');
     t.ok(moolaR.amountMath.isEqual(optionDesc.underlyingAsset, moola(3)));
@@ -400,7 +400,7 @@ test('zoe - coveredCall with swap for invite', async t => {
     const {
       installationHandle: daveSwapInstallId,
       issuerKeywordRecord: daveSwapIssuers,
-    } = zoe.getInstance(swapInstanceHandle);
+    } = zoe.getInstanceRecord(swapInstanceHandle);
 
     // Dave is looking to buy the option to trade his 7 simoleans for
     // 3 moola, and is willing to pay 1 buck for the option. He
@@ -615,7 +615,7 @@ test('zoe - coveredCall with coveredCall for invite', async t => {
     const {
       extent: [optionExtent],
     } = await inviteIssuer.getAmountOf(bobExclOption);
-    const { installationHandle } = zoe.getInstance(optionExtent.instanceHandle);
+    const { installationHandle } = zoe.getInstanceRecord(optionExtent.instanceHandle);
     t.equal(installationHandle, coveredCallInstallationHandle);
     t.equal(optionExtent.inviteDesc, 'exerciseOption');
     t.ok(moolaR.amountMath.isEqual(optionExtent.underlyingAsset, moola(3)));
@@ -669,7 +669,7 @@ test('zoe - coveredCall with coveredCall for invite', async t => {
     } = await inviteIssuer.getAmountOf(daveExclOption);
     const {
       installationHandle: daveOptionInstallationHandle,
-    } = zoe.getInstance(daveOptionExtent.instanceHandle);
+    } = zoe.getInstanceRecord(daveOptionExtent.instanceHandle);
     t.equal(daveOptionInstallationHandle, coveredCallInstallationHandle);
     t.equal(daveOptionExtent.inviteDesc, 'exerciseOption');
     t.ok(bucksR.amountMath.isEqual(daveOptionExtent.strikePrice, bucks(1)));
@@ -882,7 +882,7 @@ test('zoe - coveredCall non-fungible', async t => {
   const {
     extent: [optionExtent],
   } = await inviteIssuer.getAmountOf(bobExclOption);
-  const { installationHandle } = zoe.getInstance(optionExtent.instanceHandle);
+  const { installationHandle } = zoe.getInstanceRecord(optionExtent.instanceHandle);
   t.equal(installationHandle, coveredCallInstallationHandle);
   t.equal(optionExtent.inviteDesc, 'exerciseOption');
   t.ok(

--- a/packages/zoe/test/unitTests/contracts/test-coveredCall.js
+++ b/packages/zoe/test/unitTests/contracts/test-coveredCall.js
@@ -71,7 +71,9 @@ test('zoe - coveredCall', async t => {
     const {
       extent: [optionExtent],
     } = await inviteIssuer.getAmountOf(bobExclOption);
-    const { installationHandle } = zoe.getInstanceRecord(optionExtent.instanceHandle);
+    const { installationHandle } = zoe.getInstanceRecord(
+      optionExtent.instanceHandle,
+    );
     t.equal(installationHandle, coveredCallInstallationHandle);
     t.equal(optionExtent.inviteDesc, 'exerciseOption');
     t.ok(moolaR.amountMath.isEqual(optionExtent.underlyingAsset, moola(3)));
@@ -199,7 +201,9 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
     const {
       extent: [optionExtent],
     } = await inviteIssuer.getAmountOf(bobExclOption);
-    const { installationHandle } = zoe.getInstanceRecord(optionExtent.instanceHandle);
+    const { installationHandle } = zoe.getInstanceRecord(
+      optionExtent.instanceHandle,
+    );
     t.equal(installationHandle, coveredCallInstallationHandle);
     t.equal(optionExtent.inviteDesc, 'exerciseOption');
     t.ok(moolaR.amountMath.isEqual(optionExtent.underlyingAsset, moola(3)));
@@ -354,7 +358,9 @@ test('zoe - coveredCall with swap for invite', async t => {
     const bobExclOption = await inviteIssuer.claim(optionP);
     const optionAmount = await inviteIssuer.getAmountOf(bobExclOption);
     const optionDesc = optionAmount.extent[0];
-    const { installationHandle } = zoe.getInstanceRecord(optionDesc.instanceHandle);
+    const { installationHandle } = zoe.getInstanceRecord(
+      optionDesc.instanceHandle,
+    );
     t.equal(installationHandle, coveredCallInstallationHandle);
     t.equal(optionDesc.inviteDesc, 'exerciseOption');
     t.ok(moolaR.amountMath.isEqual(optionDesc.underlyingAsset, moola(3)));
@@ -615,7 +621,9 @@ test('zoe - coveredCall with coveredCall for invite', async t => {
     const {
       extent: [optionExtent],
     } = await inviteIssuer.getAmountOf(bobExclOption);
-    const { installationHandle } = zoe.getInstanceRecord(optionExtent.instanceHandle);
+    const { installationHandle } = zoe.getInstanceRecord(
+      optionExtent.instanceHandle,
+    );
     t.equal(installationHandle, coveredCallInstallationHandle);
     t.equal(optionExtent.inviteDesc, 'exerciseOption');
     t.ok(moolaR.amountMath.isEqual(optionExtent.underlyingAsset, moola(3)));
@@ -882,7 +890,9 @@ test('zoe - coveredCall non-fungible', async t => {
   const {
     extent: [optionExtent],
   } = await inviteIssuer.getAmountOf(bobExclOption);
-  const { installationHandle } = zoe.getInstanceRecord(optionExtent.instanceHandle);
+  const { installationHandle } = zoe.getInstanceRecord(
+    optionExtent.instanceHandle,
+  );
   t.equal(installationHandle, coveredCallInstallationHandle);
   t.equal(optionExtent.inviteDesc, 'exerciseOption');
   t.ok(

--- a/packages/zoe/test/unitTests/contracts/test-operaConcertTicket.js
+++ b/packages/zoe/test/unitTests/contracts/test-operaConcertTicket.js
@@ -50,80 +50,78 @@ The Opera is told about the show being sold out. It gets all the moolas from the
         .then(auditoriumInvite => {
           return inviteIssuer
             .getAmountOf(auditoriumInvite)
-            .then(
-              ({ extent: [{ instanceHandle: auditoriumInstanceHandle }] }) => {
-                const { publicAPI } = zoe.getInstanceRecord(auditoriumInstanceHandle);
+            .then(({ extent: [{ instanceHandle: auditoriumHandle }] }) => {
+              const { publicAPI } = zoe.getInstanceRecord(auditoriumHandle);
 
-                t.equal(
-                  typeof publicAPI.makeBuyerInvite,
-                  'function',
-                  'publicAPI.makeBuyerInvite should be a function',
-                );
-                t.equal(
-                  typeof publicAPI.getTicketIssuer,
-                  'function',
-                  'publicAPI.getTicketIssuer should be a function',
-                );
-                t.equal(
-                  typeof publicAPI.getAvailableTickets,
-                  'function',
-                  'publicAPI.getAvailableTickets should be a function',
-                );
+              t.equal(
+                typeof publicAPI.makeBuyerInvite,
+                'function',
+                'publicAPI.makeBuyerInvite should be a function',
+              );
+              t.equal(
+                typeof publicAPI.getTicketIssuer,
+                'function',
+                'publicAPI.getTicketIssuer should be a function',
+              );
+              t.equal(
+                typeof publicAPI.getAvailableTickets,
+                'function',
+                'publicAPI.getAvailableTickets should be a function',
+              );
 
-                // The auditorium redeems its invite.
-                return (
-                  // Note that the proposal here is empty
-                  // This is due to a current limitation in proposal expressivness: https://github.com/Agoric/agoric-sdk/issues/855
-                  // It's impossible to know in advance how many tickets will be sold, so it's not possible
-                  // to say `want: moola(3*22)`
-                  // in a future version of Zoe, it will be possible to express:
-                  // "i want n times moolas where n is the number of sold tickets"
-                  zoe
-                    .redeem(auditoriumInvite, harden({}))
-                    // cancel will be renamed complete: https://github.com/Agoric/agoric-sdk/issues/835
-                    // cancelObj exists because of a current limitation in @agoric/marshal : https://github.com/Agoric/agoric-sdk/issues/818
-                    .then(
-                      ({
-                        seat: { getCurrentAllocation, afterRedeem },
-                        payout,
-                        cancelObj: { cancel: complete },
-                      }) => {
-                        t.equal(
-                          typeof afterRedeem,
-                          'function',
-                          'seat.afterRedeem should be a function',
-                        );
-                        t.equal(
-                          typeof getCurrentAllocation,
-                          'function',
-                          'seat.getCurrentAllocation should be a function',
-                        );
-                        t.equal(
-                          typeof complete,
-                          'function',
-                          'complete should be a function',
-                        );
+              // The auditorium redeems its invite.
+              return (
+                // Note that the proposal here is empty
+                // This is due to a current limitation in proposal expressivness: https://github.com/Agoric/agoric-sdk/issues/855
+                // It's impossible to know in advance how many tickets will be sold, so it's not possible
+                // to say `want: moola(3*22)`
+                // in a future version of Zoe, it will be possible to express:
+                // "i want n times moolas where n is the number of sold tickets"
+                zoe
+                  .redeem(auditoriumInvite, harden({}))
+                  // cancel will be renamed complete: https://github.com/Agoric/agoric-sdk/issues/835
+                  // cancelObj exists because of a current limitation in @agoric/marshal : https://github.com/Agoric/agoric-sdk/issues/818
+                  .then(
+                    ({
+                      seat: { getCurrentAllocation, afterRedeem },
+                      payout,
+                      cancelObj: { cancel: complete },
+                    }) => {
+                      t.equal(
+                        typeof afterRedeem,
+                        'function',
+                        'seat.afterRedeem should be a function',
+                      );
+                      t.equal(
+                        typeof getCurrentAllocation,
+                        'function',
+                        'seat.getCurrentAllocation should be a function',
+                      );
+                      t.equal(
+                        typeof complete,
+                        'function',
+                        'complete should be a function',
+                      );
 
-                        afterRedeem();
+                      afterRedeem();
 
-                        const currentAllocation = getCurrentAllocation();
+                      const currentAllocation = getCurrentAllocation();
 
-                        t.equal(
-                          currentAllocation.Ticket.extent.length,
-                          3,
-                          `the auditorium offerHandle should be associated with the 3 tickets`,
-                        );
+                      t.equal(
+                        currentAllocation.Ticket.extent.length,
+                        3,
+                        `the auditorium offerHandle should be associated with the 3 tickets`,
+                      );
 
-                        return {
-                          publicAPI,
-                          operaPayout: payout,
-                          complete,
-                        };
-                      },
-                    )
-                );
-              },
-            );
+                      return {
+                        publicAPI,
+                        operaPayout: payout,
+                        complete,
+                      };
+                    },
+                  )
+              );
+            });
         });
     },
   );
@@ -141,8 +139,8 @@ The Opera is told about the show being sold out. It gets all the moolas from the
     const aliceInvite = inviteIssuer.claim(publicAPI.makeBuyerInvite());
     return inviteIssuer
       .getAmountOf(aliceInvite)
-      .then(({ extent: [{ instanceHandle: instanceHandleOfAlice }] }) => {
-        const { terms: termsOfAlice } = zoe.getInstanceRecord(instanceHandleOfAlice);
+      .then(({ extent: [{ instanceHandle: aliceHandle }] }) => {
+        const { terms: termsOfAlice } = zoe.getInstanceRecord(aliceHandle);
         // Alice checks terms
         t.equal(termsOfAlice.show, 'Steven Universe, the Opera');
         t.equal(termsOfAlice.start, 'Web, March 25th 2020 at 8pm');

--- a/packages/zoe/test/unitTests/contracts/test-operaConcertTicket.js
+++ b/packages/zoe/test/unitTests/contracts/test-operaConcertTicket.js
@@ -52,7 +52,7 @@ The Opera is told about the show being sold out. It gets all the moolas from the
             .getAmountOf(auditoriumInvite)
             .then(
               ({ extent: [{ instanceHandle: auditoriumInstanceHandle }] }) => {
-                const { publicAPI } = zoe.getInstance(auditoriumInstanceHandle);
+                const { publicAPI } = zoe.getInstanceRecord(auditoriumInstanceHandle);
 
                 t.equal(
                   typeof publicAPI.makeBuyerInvite,
@@ -142,7 +142,7 @@ The Opera is told about the show being sold out. It gets all the moolas from the
     return inviteIssuer
       .getAmountOf(aliceInvite)
       .then(({ extent: [{ instanceHandle: instanceHandleOfAlice }] }) => {
-        const { terms: termsOfAlice } = zoe.getInstance(instanceHandleOfAlice);
+        const { terms: termsOfAlice } = zoe.getInstanceRecord(instanceHandleOfAlice);
         // Alice checks terms
         t.equal(termsOfAlice.show, 'Steven Universe, the Opera');
         t.equal(termsOfAlice.start, 'Web, March 25th 2020 at 8pm');
@@ -235,7 +235,7 @@ The Opera is told about the show being sold out. It gets all the moolas from the
       return inviteIssuer
         .getAmountOf(jokerInvite)
         .then(({ extent: [{ instanceHandle: instanceHandleOfJoker }] }) => {
-          const { terms } = zoe.getInstance(instanceHandleOfJoker);
+          const { terms } = zoe.getInstanceRecord(instanceHandleOfJoker);
 
           const {
             expectedAmountPerTicket: expectedAmountPerTicketOfJoker,
@@ -298,7 +298,7 @@ The Opera is told about the show being sold out. It gets all the moolas from the
       return inviteIssuer
         .getAmountOf(jokerInvite)
         .then(({ extent: [{ instanceHandle: instanceHandleOfJoker }] }) => {
-          const { terms } = zoe.getInstance(instanceHandleOfJoker);
+          const { terms } = zoe.getInstanceRecord(instanceHandleOfJoker);
 
           const ticket2Amount = ticketAmountMath.make(
             harden([

--- a/packages/zoe/test/unitTests/contracts/test-publicAuction.js
+++ b/packages/zoe/test/unitTests/contracts/test-publicAuction.js
@@ -59,7 +59,7 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
     );
 
     const instanceHandle = await getInstanceHandle(aliceInvite);
-    const { publicAPI } = zoe.getInstance(instanceHandle);
+    const { publicAPI } = zoe.getInstanceRecord(instanceHandle);
 
     // Alice escrows with zoe
     const aliceProposal = harden({
@@ -93,7 +93,7 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
       installationHandle: bobInstallationId,
       terms: bobTerms,
       issuerKeywordRecord: bobIssuers,
-    } = zoe.getInstance(bobInviteExtent.instanceHandle);
+    } = zoe.getInstanceRecord(bobInviteExtent.instanceHandle);
 
     t.equals(bobInstallationId, installationHandle, 'bobInstallationId');
     t.deepEquals(
@@ -136,7 +136,7 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
       installationHandle: carolInstallationId,
       terms: carolTerms,
       issuerKeywordRecord: carolIssuers,
-    } = zoe.getInstance(carolInviteExtent.instanceHandle);
+    } = zoe.getInstanceRecord(carolInviteExtent.instanceHandle);
 
     t.equals(carolInstallationId, installationHandle, 'carolInstallationId');
     t.deepEquals(
@@ -182,7 +182,7 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
       installationHandle: daveInstallationId,
       terms: daveTerms,
       issuerKeywordRecord: daveIssuers,
-    } = zoe.getInstance(daveInviteExtent.instanceHandle);
+    } = zoe.getInstanceRecord(daveInviteExtent.instanceHandle);
 
     t.equals(daveInstallationId, installationHandle, 'daveInstallationHandle');
     t.deepEquals(
@@ -355,7 +355,7 @@ test('zoe - secondPriceAuction w/ 3 bids - alice exits onDemand', async t => {
     const {
       extent: [{ instanceHandle }],
     } = await inviteIssuer.getAmountOf(aliceInvite);
-    const { publicAPI } = zoe.getInstance(instanceHandle);
+    const { publicAPI } = zoe.getInstanceRecord(instanceHandle);
 
     // Alice escrows with zoe
     const aliceProposal = harden({
@@ -509,7 +509,7 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
   );
 
   const instanceHandle = await getInstanceHandle(aliceInvite);
-  const { publicAPI } = zoe.getInstance(instanceHandle);
+  const { publicAPI } = zoe.getInstanceRecord(instanceHandle);
 
   // Alice escrows with zoe
   const aliceProposal = harden({
@@ -543,7 +543,7 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
     installationHandle: bobInstallationId,
     terms: bobTerms,
     issuerKeywordRecord: bobIssuers,
-  } = zoe.getInstance(bobInviteExtent.instanceHandle);
+  } = zoe.getInstanceRecord(bobInviteExtent.instanceHandle);
 
   t.equals(bobInstallationId, installationHandle, 'bobInstallationId');
   t.deepEquals(bobIssuers, { Asset: ccIssuer, Bid: moolaIssuer }, 'bobIssuers');
@@ -586,7 +586,7 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
     installationHandle: carolInstallationId,
     terms: carolTerms,
     issuerKeywordRecord: carolIssuers,
-  } = zoe.getInstance(carolInviteExtent.instanceHandle);
+  } = zoe.getInstanceRecord(carolInviteExtent.instanceHandle);
 
   t.equals(carolInstallationId, installationHandle, 'carolInstallationId');
   t.deepEquals(
@@ -632,7 +632,7 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
     installationHandle: daveInstallationId,
     terms: daveTerms,
     issuerKeywordRecord: daveIssuers,
-  } = zoe.getInstance(daveInviteExtent.instanceHandle);
+  } = zoe.getInstanceRecord(daveInviteExtent.instanceHandle);
 
   t.equals(daveInstallationId, installationHandle, 'daveInstallationHandle');
   t.deepEquals(

--- a/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
+++ b/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
@@ -50,7 +50,7 @@ test('simpleExchange with valid offers', async t => {
     Price: simoleanIssuer,
   });
   const instanceHandle = await getInstanceHandle(simonInvite);
-  const { publicAPI } = zoe.getInstance(instanceHandle);
+  const { publicAPI } = zoe.getInstanceRecord(instanceHandle);
 
   const aliceInvite = publicAPI.makeInvite();
 
@@ -78,7 +78,7 @@ test('simpleExchange with valid offers', async t => {
   const {
     installationHandle: bobInstallationId,
     issuerKeywordRecord: bobIssuers,
-  } = zoe.getInstance(instanceHandle);
+  } = zoe.getInstanceRecord(instanceHandle);
 
   t.equals(bobInstallationId, installationHandle);
 
@@ -189,7 +189,7 @@ test('simpleExchange with multiple sell offers', async t => {
       Price: simoleanIssuer,
     });
     const instanceHandle = await getInstanceHandle(simonInvite);
-    const { publicAPI } = zoe.getInstance(instanceHandle);
+    const { publicAPI } = zoe.getInstanceRecord(instanceHandle);
 
     const aliceInvite1 = publicAPI.makeInvite();
 
@@ -274,7 +274,7 @@ test('simpleExchange showPayoutRules', async t => {
     Price: simoleanIssuer,
   });
   const instanceHandle = await getInstanceHandle(simonInvite);
-  const { publicAPI } = zoe.getInstance(instanceHandle);
+  const { publicAPI } = zoe.getInstanceRecord(instanceHandle);
 
   const aliceInvite = publicAPI.makeInvite();
 
@@ -341,7 +341,7 @@ test('simpleExchange with non-fungible assets', async t => {
     Price: ccIssuer,
   });
   const instanceHandle = await getInstanceHandle(simonInvite);
-  const { publicAPI } = zoe.getInstance(instanceHandle);
+  const { publicAPI } = zoe.getInstanceRecord(instanceHandle);
 
   const aliceInvite = publicAPI.makeInvite();
 
@@ -368,7 +368,7 @@ test('simpleExchange with non-fungible assets', async t => {
   const {
     installationHandle: bobInstallationId,
     issuerKeywordRecord: bobIssuers,
-  } = zoe.getInstance(instanceHandle);
+  } = zoe.getInstanceRecord(instanceHandle);
 
   t.equals(bobInstallationId, installationHandle);
 


### PR DESCRIPTION
fix: [#916](https://github.com/Agoric/agoric-sdk/issues/916) 

This is a fix because it adds `getInstanceRecord` but leaves `getInstance` available but deprecated.

Also fixes one test to be insensitive to line ends.

NOTE tests in zoe pass locally, but I cannot run all tests because the lmdb fails to run. 