### PR TITLE
[Zoe] Remove old zoe.redeem, zcf.makeInvite, and other vestigal elements. Update all contracts.

### DIFF
--- a/packages/ERTP/src/issuer.js
+++ b/packages/ERTP/src/issuer.js
@@ -386,12 +386,6 @@ function produceIssuer(allegedName, mathHelpersName = 'nat') {
       });
     },
 
-    // TODO(msm): remove once we no longer need to support old API
-    getAmountOfNow: payment => {
-      assertKnownPayment(payment);
-      return paymentLedger.get(payment);
-    },
-
     burn: (paymentP, optAmount = undefined) => {
       return Promise.resolve(paymentP).then(payment => {
         assertKnownPayment(payment);

--- a/packages/zoe/src/contracts/multipoolAutoswap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap.js
@@ -280,7 +280,10 @@ export const makeContract = harden(zcf => {
       give: { [liquidityKeyword]: liquidityAmountOut },
     });
 
-    const { inviteHandle: tempLiqHandle, invite } = zcf.makeInvite();
+    let tempLiqHandle;
+
+    const tempLiqOfferHook = tmpHandle => (tempLiqHandle = tmpHandle);
+    const tempLiqInvite = zcf.makeInvitation(tempLiqOfferHook);
     const zoeService = zcf.getZoeService();
     // We update the liquidityTokenSupply before the next turn
     liquidityTable.update(secondaryTokenBrand, {
@@ -288,7 +291,7 @@ export const makeContract = harden(zcf => {
     });
     return zoeService
       .offer(
-        invite,
+        tempLiqInvite,
         tempProposal,
         harden({ [liquidityKeyword]: liquidityPaymentP }),
       )

--- a/packages/zoe/src/contracts/operaConcertTicket.js
+++ b/packages/zoe/src/contracts/operaConcertTicket.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-use-before-define */
 import harden from '@agoric/harden';
 import produceIssuer from '@agoric/ertp';
-import { makeZoeHelpers } from '../contractSupport';
+import { makeZoeHelpers, defaultAcceptanceMsg } from '../contractSupport';
 
 /*
   Roles in the arrangement:
@@ -40,6 +40,8 @@ export const makeContract = harden(zcf => {
 
   const { amountMath: moneyAmountMath } = zcf.getIssuerRecord(moneyIssuer);
 
+  let auditoriumOfferHandle;
+
   return zcf.addNewIssuer(issuer, 'Ticket').then(() => {
     // create Zoe helpers after zcf.addNewIssuer because of https://github.com/Agoric/agoric-sdk/issues/802
     const { rejectOffer } = makeZoeHelpers(zcf);
@@ -68,116 +70,98 @@ export const makeContract = harden(zcf => {
     );
     const ticketsPayment = mint.mintPayment(ticketsAmount);
 
-    const {
-      invite: contractSelfInvite,
-      inviteHandle: contractOfferHandle,
-    } = zcf.makeInvite();
+    let tempContractOfferHandle;
+    const tempContractOfferHook = offerHandle =>
+      (tempContractOfferHandle = offerHandle);
+
+    const contractSelfInvite = zcf.makeInvitation(tempContractOfferHook);
     // the contract creates an offer {give: tickets, want: nothing} with the tickets
     return zcf
       .getZoeService()
-      .redeem(
+      .offer(
         contractSelfInvite,
         harden({ give: { Ticket: ticketsAmount } }),
         harden({ Ticket: ticketsPayment }),
       )
       .then(() => {
-        const auditoriumSeat = harden({
-          // this is meant to be called right after redeem
-          // eventually, it might be done automatically: https://github.com/Agoric/agoric-sdk/issues/717
-          afterRedeem() {
-            // the contract transfers tickets to the auditorium leveraging Zoe offer safety
-            zcf.reallocate(
-              [contractOfferHandle, auditoriumOfferHandle],
-              [
-                zcf.getCurrentAllocation(auditoriumOfferHandle),
-                zcf.getCurrentAllocation(contractOfferHandle),
-              ],
-            );
-            zcf.complete([contractOfferHandle]);
-            // if both calls succeeded (did not throw), the auditoriumOfferHandle is now
-            // associated with the tickets and the contract offer is gone from the contract
-          },
-          getCurrentAllocation() {
-            return zcf.getCurrentAllocation(auditoriumOfferHandle);
-          },
-        });
-        const {
-          invite: auditoriumInvite,
-          inviteHandle: auditoriumOfferHandle,
-        } = zcf.makeInvite(auditoriumSeat);
-
-        const makeBuyerInvite = () => {
-          const seat = harden({
-            performExchange: () => {
-              const buyerOffer = zcf.getOffer(buyerOfferHandle);
-
-              const currentAuditoriumAllocation = zcf.getCurrentAllocation(
-                auditoriumOfferHandle,
-              );
-              const currentBuyerAllocation = zcf.getCurrentAllocation(
-                buyerOfferHandle,
-              );
-
-              const wantedTicketsCount =
-                buyerOffer.proposal.want.Ticket.extent.length;
-              const wantedMoney =
-                expectedAmountPerTicket.extent * wantedTicketsCount;
-
-              try {
-                if (
-                  !moneyAmountMath.isGTE(
-                    currentBuyerAllocation.Money,
-                    moneyAmountMath.make(wantedMoney),
-                  )
-                ) {
-                  throw new Error(
-                    'The offer associated with this seat does not contain enough moolas',
-                  );
-                }
-
-                const wantedAuditoriumAllocation = {
-                  Money: moneyAmountMath.add(
-                    currentAuditoriumAllocation.Money,
-                    currentBuyerAllocation.Money,
-                  ),
-                  Ticket: ticketAmountMath.subtract(
-                    currentAuditoriumAllocation.Ticket,
-                    buyerOffer.proposal.want.Ticket,
-                  ),
-                };
-
-                const wantedBuyerAllocation = {
-                  Money: moneyAmountMath.getEmpty(),
-                  Ticket: ticketAmountMath.add(
-                    currentBuyerAllocation.Ticket,
-                    buyerOffer.proposal.want.Ticket,
-                  ),
-                };
-
-                zcf.reallocate(
-                  [auditoriumOfferHandle, buyerOfferHandle],
-                  [wantedAuditoriumAllocation, wantedBuyerAllocation],
-                );
-                zcf.complete([buyerOfferHandle]);
-              } catch (err) {
-                // amounts don't match or reallocate certainly failed
-                rejectOffer(buyerOfferHandle);
-              }
-            },
-          });
-          const { invite, inviteHandle: buyerOfferHandle } = zcf.makeInvite(
-            seat,
+        const auditoriumOfferHook = offerHandle => {
+          auditoriumOfferHandle = offerHandle;
+          // the contract transfers tickets to the auditorium leveraging Zoe offer safety
+          zcf.reallocate(
+            [tempContractOfferHandle, auditoriumOfferHandle],
+            [
+              zcf.getCurrentAllocation(auditoriumOfferHandle),
+              zcf.getCurrentAllocation(tempContractOfferHandle),
+            ],
           );
-          return invite;
+          zcf.complete([tempContractOfferHandle]);
+          // the auditoriumOfferHandle is now associated with the
+          // tickets and the contract offer is gone from the contract
+          return defaultAcceptanceMsg;
+        };
+
+        const buyTicketOfferHook = buyerOfferHandle => {
+          const buyerOffer = zcf.getOffer(buyerOfferHandle);
+
+          const currentAuditoriumAllocation = zcf.getCurrentAllocation(
+            auditoriumOfferHandle,
+          );
+          const currentBuyerAllocation = zcf.getCurrentAllocation(
+            buyerOfferHandle,
+          );
+
+          const wantedTicketsCount =
+            buyerOffer.proposal.want.Ticket.extent.length;
+          const wantedMoney =
+            expectedAmountPerTicket.extent * wantedTicketsCount;
+
+          try {
+            if (
+              !moneyAmountMath.isGTE(
+                currentBuyerAllocation.Money,
+                moneyAmountMath.make(wantedMoney),
+              )
+            ) {
+              throw new Error(
+                'The offer associated with this seat does not contain enough moolas',
+              );
+            }
+
+            const wantedAuditoriumAllocation = {
+              Money: moneyAmountMath.add(
+                currentAuditoriumAllocation.Money,
+                currentBuyerAllocation.Money,
+              ),
+              Ticket: ticketAmountMath.subtract(
+                currentAuditoriumAllocation.Ticket,
+                buyerOffer.proposal.want.Ticket,
+              ),
+            };
+
+            const wantedBuyerAllocation = {
+              Money: moneyAmountMath.getEmpty(),
+              Ticket: ticketAmountMath.add(
+                currentBuyerAllocation.Ticket,
+                buyerOffer.proposal.want.Ticket,
+              ),
+            };
+
+            zcf.reallocate(
+              [auditoriumOfferHandle, buyerOfferHandle],
+              [wantedAuditoriumAllocation, wantedBuyerAllocation],
+            );
+            zcf.complete([buyerOfferHandle]);
+          } catch (err) {
+            // amounts don't match or reallocate certainly failed
+            rejectOffer(buyerOfferHandle);
+          }
         };
 
         return harden({
-          invite: auditoriumInvite,
+          invite: zcf.makeInvitation(auditoriumOfferHook),
           publicAPI: {
-            makeBuyerInvite,
-            getTicketIssuer() {
-              return issuer;
-            },
+            makeBuyerInvite: () => zcf.makeInvitation(buyTicketOfferHook),
+            getTicketIssuer: () => issuer,
             getAvailableTickets() {
               // Because of a technical limitation in @agoric/marshal, an array of extents
               // is better than a Map https://github.com/Agoric/agoric-sdk/issues/838

--- a/packages/zoe/src/contracts/operaConcertTicket.js
+++ b/packages/zoe/src/contracts/operaConcertTicket.js
@@ -70,11 +70,13 @@ export const makeContract = harden(zcf => {
     );
     const ticketsPayment = mint.mintPayment(ticketsAmount);
 
-    let tempContractOfferHandle;
-    const tempContractOfferHook = offerHandle =>
-      (tempContractOfferHandle = offerHandle);
+    let internalTicketSupplyHandle;
+    const internalTicketSupplyOfferHook = offerHandle =>
+      (internalTicketSupplyHandle = offerHandle);
 
-    const contractSelfInvite = zcf.makeInvitation(tempContractOfferHook);
+    const contractSelfInvite = zcf.makeInvitation(
+      internalTicketSupplyOfferHook,
+    );
     // the contract creates an offer {give: tickets, want: nothing} with the tickets
     return zcf
       .getZoeService()
@@ -88,13 +90,13 @@ export const makeContract = harden(zcf => {
           auditoriumOfferHandle = offerHandle;
           // the contract transfers tickets to the auditorium leveraging Zoe offer safety
           zcf.reallocate(
-            [tempContractOfferHandle, auditoriumOfferHandle],
+            [internalTicketSupplyHandle, auditoriumOfferHandle],
             [
               zcf.getCurrentAllocation(auditoriumOfferHandle),
-              zcf.getCurrentAllocation(tempContractOfferHandle),
+              zcf.getCurrentAllocation(internalTicketSupplyHandle),
             ],
           );
-          zcf.complete([tempContractOfferHandle]);
+          zcf.complete([internalTicketSupplyHandle]);
           // the auditoriumOfferHandle is now associated with the
           // tickets and the contract offer is gone from the contract
           return defaultAcceptanceMsg;

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -351,15 +351,6 @@ const makeZoe = (additionalEndowments = {}) => {
       return inviteMint.mintPayment(inviteAmount);
     };
 
-    // TODO(msm): remove once we no longer need to support old API
-    const makeInvite = (seat, customProperties = harden({})) => {
-      const offerHook = _ => seat;
-      const invitePayment = makeInvitation(offerHook, customProperties);
-      const amount = inviteIssuer.getAmountOfNow(invitePayment);
-      const inviteHandle = amount.extent[0].handle;
-      return harden({ invite: invitePayment, inviteHandle });
-    };
-
     /**
      * @type {ContractFacet}
      */
@@ -424,9 +415,6 @@ const makeZoe = (additionalEndowments = {}) => {
       },
 
       makeInvitation,
-
-      // TODO(msm): remove once we no longer need to support old API
-      makeInvite,
 
       addNewIssuer: (issuerP, keyword) =>
         issuerTable.getPromiseForIssuerRecord(issuerP).then(issuerRecord => {
@@ -749,22 +737,6 @@ const makeZoe = (additionalEndowments = {}) => {
             .then(recordOffer)
             .then(makeOfferResult);
         });
-      },
-
-      // TODO(msm): remove once we no longer need to support old API
-      redeem: (
-        invite,
-        proposal = harden({}),
-        paymentKeywordRecord = harden({}),
-      ) => {
-        return zoeService
-          .offer(invite, proposal, paymentKeywordRecord)
-          .then(offerResult => {
-            const { outcome: outcomeP, ...rest } = offerResult;
-            // The extra wait on outcomeP would enable a denial of
-            // service, but it's only in the code about to disappear
-            return outcomeP.then(seat => harden({ seat, ...rest }));
-          });
       },
 
       isOfferActive: offerTable.isOfferActive,


### PR DESCRIPTION
Remove old zoe.redeem and old zcf.makeInvite. Update multipoolAutoswap, update operaConcertTicket.

Closes #936 
Closes #928
Closes #947 (subsumed)