### PR TITLE
Default to nested evaluate

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "packages/sharing-service",
     "packages/zoe",
     "packages/cosmic-swingset",
+    "packages/generator-agoric-dapp",
     "packages/agoric-cli",
     "packages/deployment",
     "packages/notifier"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "packages/sharing-service",
     "packages/zoe",
     "packages/cosmic-swingset",
-    "packages/generator-agoric-dapp",
     "packages/agoric-cli",
     "packages/deployment",
     "packages/notifier"

--- a/packages/agoric-cli/lib/deploy.js
+++ b/packages/agoric-cli/lib/deploy.js
@@ -75,11 +75,11 @@ export default async function deployMain(progname, rawArgs, powers, opts) {
             { externals: builtinModules },
           );
 
+          const nestedEvaluate = src =>
+            evaluateProgram(src, { require, HandledPromise, nestedEvaluate });
+
           const actualSource = `(${source}\n)\n${sourceMap}`;
-          const mainNS = evaluateProgram(actualSource, {
-            require,
-            HandledPromise,
-          })();
+          const mainNS = nestedEvaluate(actualSource)();
           const main = mainNS.default;
           if (typeof main !== 'function') {
             log.error(

--- a/packages/bundle-source/src/index.js
+++ b/packages/bundle-source/src/index.js
@@ -5,7 +5,7 @@ import commonjs0 from '@rollup/plugin-commonjs';
 import eventualSend from '@agoric/acorn-eventual-send';
 import * as acorn from 'acorn';
 
-const DEFAULT_MODULE_FORMAT = 'getExport';
+const DEFAULT_MODULE_FORMAT = 'nestedEvaluate';
 const DEFAULT_FILE_PREFIX = '/bundled-source';
 const SUPPORTED_FORMATS = ['getExport', 'nestedEvaluate'];
 
@@ -97,7 +97,7 @@ ${sourceBundle[entrypoint]}
 
 return module.exports;
 }
-`;
+${sourceMap}`;
   } else if (moduleFormat === 'nestedEvaluate') {
     sourceMap = `//# sourceURL=${DEFAULT_FILE_PREFIX}-preamble.js\n`;
 
@@ -213,7 +213,8 @@ function getExportWithNestedEvaluate(filePrefix) {
 
   // Evaluate the entrypoint recursively.
   return computeExports(entrypoint, { require, log(...args) { return console.log(...args); } });
-}`;
+}
+${sourceMap}`;
   }
 
   // console.log(sourceMap);

--- a/packages/bundle-source/test/sanity.js
+++ b/packages/bundle-source/test/sanity.js
@@ -89,12 +89,16 @@ test('getExport', async t => {
       source: src2,
       sourceMap: map2,
     } = await bundleSource(`${__dirname}/../demo/dir1/encourage.js`);
-    t.equal(mf2, 'getExport', 'module format 2 is getExport');
+    t.equal(mf2, 'nestedEvaluate', 'module format 2 is nestedEvaluate');
 
     const srcMap2 = `(${src2})\n${map2}`;
 
+    const nestedEvaluate = src => {
+      // console.log('========== evaluating', src);
+      return evaluate(src, { require, nestedEvaluate });
+    };
     // eslint-disable-next-line no-eval
-    const ex2 = eval(srcMap2)();
+    const ex2 = nestedEvaluate(srcMap2)();
     t.equal(ex2.message, `You're great!`, 'exported message matches');
     t.equal(
       ex2.encourage('Nick'),

--- a/packages/transform-eventual-send/src/index.js
+++ b/packages/transform-eventual-send/src/index.js
@@ -27,13 +27,23 @@ function makeEventualSendTransformer(parser, generate) {
             if (!HandledPromise) {
               // Get a HandledPromise endowment for the evaluator.
               // It will be hardened in the evaluator's context.
-              const { source: evSendSrc, moduleFormat } = eventualSendBundle;
-              if (moduleFormat === 'getExport') {
+              const nestedEvaluate = src =>
+                (evaluateProgram || ss.evaluateProgram)(src, {
+                  require: myRequire || require,
+                  nestedEvaluate,
+                });
+              const {
+                source: evSendSrc,
+                moduleFormat,
+                sourceMap,
+              } = eventualSendBundle;
+              if (
+                moduleFormat === 'getExport' ||
+                moduleFormat === 'nestedEvaluate'
+              ) {
                 recursive = true;
                 try {
-                  const ns = (
-                    evaluateProgram || ss.evaluateProgram
-                  )(`(${evSendSrc})()`, { require: myRequire || require });
+                  const ns = nestedEvaluate(`(${evSendSrc}\n${sourceMap})`)();
                   HandledPromise = ns.HandledPromise;
                 } finally {
                   recursive = false;


### PR DESCRIPTION
This change finishes the migration from `getExport` to `nestedEvaluate` to improve stack traces wherever possible.
