### PR TITLE
fix: cosmic-swingset: fall back to SimpleStore if LMDB doesn't work

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/reset-state.js
+++ b/packages/cosmic-swingset/lib/ag-solo/reset-state.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 
-import { initSwingStore } from '@agoric/swing-store-lmdb';
+import { getBestSwingStore } from '../check-lmdb';
 
 export default async function resetState(basedir) {
   const mailboxStateFile = path.resolve(
@@ -10,6 +10,8 @@ export default async function resetState(basedir) {
   );
   fs.writeFileSync(mailboxStateFile, `{}\n`);
   const kernelStateDBDir = path.join(basedir, 'swingset-kernel-state');
+  const tempdir = path.resolve(basedir, 'check-lmdb-tempdir');
+  const { initSwingStore } = getBestSwingStore(tempdir);
   const { commit, close } = initSwingStore(kernelStateDBDir);
   commit();
   close();

--- a/packages/cosmic-swingset/lib/ag-solo/start.js
+++ b/packages/cosmic-swingset/lib/ag-solo/start.js
@@ -10,7 +10,6 @@ import anylogger from 'anylogger';
 // import harden from '@agoric/harden';
 // import djson from 'deterministic-json';
 
-import { openSwingStore } from '@agoric/swing-store-lmdb';
 import {
   loadBasedir,
   buildCommand,
@@ -22,6 +21,7 @@ import {
   getCommsSourcePath,
   getTimerWrapperSourcePath,
 } from '@agoric/swingset-vat';
+import { getBestSwingStore } from '../check-lmdb';
 
 import { deliver, addDeliveryTarget } from './outbound';
 import { makeHTTPListener } from './web';
@@ -103,6 +103,8 @@ async function buildSwingset(
   });
   config.vats.set('timer', { sourcepath: getTimerWrapperSourcePath() });
 
+  const tempdir = path.resolve(kernelStateDBDir, 'check-lmdb-tempdir');
+  const { openSwingStore } = getBestSwingStore(tempdir);
   const { storage, commit } = openSwingStore(kernelStateDBDir);
   config.hostStorage = storage;
 

--- a/packages/cosmic-swingset/lib/check-lmdb.js
+++ b/packages/cosmic-swingset/lib/check-lmdb.js
@@ -1,0 +1,59 @@
+import fs from 'fs';
+import {
+  openSwingStore as openSwingStoreLMDB,
+  initSwingStore as initSwingStoreLMDB,
+} from '@agoric/swing-store-lmdb';
+import {
+  openSwingStore as openSwingStoreSimple,
+  initSwingStore as initSwingStoreSimple,
+} from '@agoric/swing-store-simple';
+
+/*
+ * Return an 'openSwingStore' function for the best kind of DB that works on
+ * this platform. This will be LMDB if possible, else Simple.
+ *
+ * This function will (briefly) create a new directory in 'tempdir' (which
+ * must not previously exist) to test LMDB.
+ *
+ */
+
+export function getBestSwingStore(tempdir) {
+  // if tempdir already exists, bail immediately so we don't accidentally
+  // clobber it later
+  if (fs.existsSync(tempdir)) {
+    throw Error(
+      `getBestSwingStore must be given a non-existing tempdir, not ${tempdir}`,
+    );
+  }
+
+  const tdb1 = openSwingStoreLMDB(tempdir);
+  tdb1.storage.set('test key', 'test value');
+  tdb1.commit();
+  tdb1.close();
+
+  try {
+    const tdb2 = openSwingStoreLMDB(tempdir);
+    if (!tdb2.storage.has('test key')) {
+      throw Error(`LMDB test disavows test key`);
+    }
+    const val = tdb2.storage.get('test key');
+    if (val !== 'test value') {
+      throw Error(`LMDB test returned '${val}', not 'test value'`);
+    }
+    tdb2.close();
+    // if we made it this far, LMDB works
+    return {
+      openSwingStore: openSwingStoreLMDB,
+      initSwingStore: initSwingStoreLMDB,
+    };
+  } catch (e) {
+    console.log(`LMDB does not work, falling back to Simple DB`);
+    // see https://github.com/Agoric/agoric-sdk/issues/950 for details
+    return {
+      openSwingStore: openSwingStoreSimple,
+      initSwingStore: initSwingStoreSimple,
+    };
+  } finally {
+    fs.rmdirSync(tempdir, { recursive: true });
+  }
+}

--- a/packages/cosmic-swingset/lib/check-lmdb.js
+++ b/packages/cosmic-swingset/lib/check-lmdb.js
@@ -26,12 +26,12 @@ export function getBestSwingStore(tempdir) {
     );
   }
 
-  const tdb1 = openSwingStoreLMDB(tempdir);
-  tdb1.storage.set('test key', 'test value');
-  tdb1.commit();
-  tdb1.close();
-
   try {
+    const tdb1 = openSwingStoreLMDB(tempdir);
+    tdb1.storage.set('test key', 'test value');
+    tdb1.commit();
+    tdb1.close();
+
     const tdb2 = openSwingStoreLMDB(tempdir);
     if (!tdb2.storage.has('test key')) {
       throw Error(`LMDB test disavows test key`);

--- a/packages/cosmic-swingset/lib/launch-chain.js
+++ b/packages/cosmic-swingset/lib/launch-chain.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 import anylogger from 'anylogger';
 
 import djson from 'deterministic-json';
@@ -12,7 +13,7 @@ import {
   getTimerWrapperSourcePath,
   getVatTPSourcePath,
 } from '@agoric/swingset-vat';
-import { openSwingStore } from '@agoric/swing-store-lmdb';
+import { getBestSwingStore } from './check-lmdb';
 
 const log = anylogger('launch-chain');
 
@@ -64,6 +65,8 @@ export async function launch(kernelStateDBDir, mailboxStorage, vatsDir, argv) {
     ? JSON.parse(mailboxStorage.get('mailbox'))
     : {};
 
+  const tempdir = path.resolve(kernelStateDBDir, 'check-lmdb-tempdir');
+  const { openSwingStore } = getBestSwingStore(tempdir);
   const { storage, commit } = openSwingStore(kernelStateDBDir);
 
   function bridgeOutbound(argx) {

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -33,6 +33,7 @@
     "@agoric/spawner": "^0.1.2",
     "@agoric/store": "^0.0.4",
     "@agoric/swing-store-lmdb": "^0.2.2",
+    "@agoric/swing-store-simple": "^0.1.2",
     "@agoric/swingset-vat": "^0.4.2",
     "@agoric/tendermint": "^4.1.3",
     "@agoric/weak-store": "^0.0.4",


### PR DESCRIPTION
This is a temporary workaround for #950, and should be reverted (i.e. use
LMDB unconditionally) when the LMDB crash on "Windows Subsystem for Linux" is
fixed.

@michaelfig please tell me if I caught all the places we're building a swingstore, and if my choice of `tempdir` is safe
@dtribble please tell me if this works on your WSL system. You should see messages like "LMDB does not work, falling back to Simple DB"
