### PR TITLE
hush harden warning

### DIFF
--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -37,7 +37,7 @@
     "@agoric/assert": "^0.0.4",
     "@agoric/evaluate": "^2.2.3",
     "@agoric/eventual-send": "^0.8.0",
-    "@agoric/harden": "^0.0.7",
+    "@agoric/harden": "^0.0.8",
     "@agoric/import-manager": "^0.0.3",
     "@agoric/layer-cake": "^0.0.1",
     "@agoric/marshal": "^0.1.5",

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -34,7 +34,7 @@
     "@agoric/default-evaluate-options": "^0.3.3",
     "@agoric/evaluate": "^2.2.3",
     "@agoric/eventual-send": "^0.8.0",
-    "@agoric/harden": "^0.0.7",
+    "@agoric/harden": "^0.0.8",
     "@agoric/marshal": "^0.1.5",
     "@agoric/nat": "^2.0.1",
     "@agoric/produce-promise": "^0.0.5",

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "dependencies": {
-    "@agoric/harden": "^0.0.7"
+    "@agoric/harden": "^0.0.8"
   },
   "devDependencies": {
     "esm": "^3.2.25",

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@agoric/acorn-eventual-send": "^2.0.2",
     "@agoric/evaluate": "^2.2.3",
-    "@agoric/harden": "^0.0.7",
+    "@agoric/harden": "^0.0.8",
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",
     "acorn": "^7.1.0",

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@agoric/eventual-send": "^0.8.0",
-    "@agoric/harden": "^0.0.7",
+    "@agoric/harden": "^0.0.8",
     "@agoric/marshal": "^0.1.5",
     "@agoric/nat": "^2.0.1",
     "@agoric/produce-promise": "^0.0.5",

--- a/packages/cosmic-swingset/lib/ag-solo/entrypoint.js
+++ b/packages/cosmic-swingset/lib/ag-solo/entrypoint.js
@@ -1,5 +1,14 @@
 #! /usr/bin/env node
 
+/* global globalThis */
+
+// Suppress the "'@agoric/harden' is ineffective without SES" warning. This
+// only affects uses inside the parent ag-solo process. The actual SES
+// environment which SwingSet builds uses a separate globalThis, so the
+// warning is still enabled for SES-confined code (but not triggered, of
+// course, because it runs under SES). See #971 for details.
+globalThis.harden = null;
+
 const process = require('process');
 const esmRequire = require('esm')(module);
 

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -24,7 +24,7 @@
     "@agoric/ertp": "^0.5.2",
     "@agoric/evaluate": "^2.2.3",
     "@agoric/eventual-send": "^0.8.0",
-    "@agoric/harden": "^0.0.7",
+    "@agoric/harden": "^0.0.8",
     "@agoric/nat": "2.0.1",
     "@agoric/produce-promise": "^0.0.5",
     "@agoric/registrar": "^0.0.4",

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "dependencies": {
-    "@agoric/harden": "^0.0.7"
+    "@agoric/harden": "^0.0.8"
   },
   "devDependencies": {
     "esm": "^3.2.7",

--- a/packages/import-manager/package.json
+++ b/packages/import-manager/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "dependencies": {
-    "@agoric/harden": "^0.0.7"
+    "@agoric/harden": "^0.0.8"
   },
   "devDependencies": {
     "esm": "^3.2.25",

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "dependencies": {
     "@agoric/eventual-send": "^0.8.0",
-    "@agoric/harden": "^0.0.7",
+    "@agoric/harden": "^0.0.8",
     "@agoric/nat": "^2.0.1",
     "@agoric/produce-promise": "^0.0.5"
   },

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "dependencies": {
     "@agoric/produce-promise": "^0.0.5",
-    "@agoric/harden": "^0.0.4"
+    "@agoric/harden": "^0.0.8"
   },
   "devDependencies": {
     "esm": "^3.2.25",

--- a/packages/produce-promise/package.json
+++ b/packages/produce-promise/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "dependencies": {
     "@agoric/eventual-send": "^0.8.0",
-    "@agoric/harden": "^0.0.7"
+    "@agoric/harden": "^0.0.8"
   },
   "devDependencies": {
     "esm": "^3.2.25",

--- a/packages/registrar/package.json
+++ b/packages/registrar/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "dependencies": {
     "@agoric/assert": "^0.0.4",
-    "@agoric/harden": "^0.0.7",
+    "@agoric/harden": "^0.0.8",
     "@agoric/sparse-ints": "^0.0.3"
   },
   "devDependencies": {

--- a/packages/same-structure/package.json
+++ b/packages/same-structure/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "dependencies": {
     "@agoric/assert": "^0.0.4",
-    "@agoric/harden": "^0.0.7",
+    "@agoric/harden": "^0.0.8",
     "@agoric/marshal": "^0.1.5"
   },
   "devDependencies": {

--- a/packages/ses-adapter/package.json
+++ b/packages/ses-adapter/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@agoric/eventual-send": "^0.8.0",
-    "@agoric/harden": "^0.0.7"
+    "@agoric/harden": "^0.0.8"
   },
   "files": [
     "README.md",

--- a/packages/sharing-service/package.json
+++ b/packages/sharing-service/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "dependencies": {
     "@agoric/assert": "^0.0.4",
-    "@agoric/harden": "^0.0.7"
+    "@agoric/harden": "^0.0.8"
   },
   "devDependencies": {
     "@agoric/swingset-vat": "^0.4.2",

--- a/packages/sparse-ints/package.json
+++ b/packages/sparse-ints/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "dependencies": {
-    "@agoric/harden": "^0.0.7"
+    "@agoric/harden": "^0.0.8"
   },
   "devDependencies": {
     "esm": "^3.2.25",

--- a/packages/spawner/package.json
+++ b/packages/spawner/package.json
@@ -31,7 +31,7 @@
     "@agoric/assert": "^0.0.4",
     "@agoric/ertp": "^0.5.2",
     "@agoric/evaluate": "^2.2.3",
-    "@agoric/harden": "^0.0.7",
+    "@agoric/harden": "^0.0.8",
     "@agoric/nat": "^2.0.1",
     "@agoric/produce-promise": "^0.0.5",
     "@agoric/same-structure": "^0.0.4",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "dependencies": {
     "@agoric/assert": "^0.0.4",
-    "@agoric/harden": "^0.0.7"
+    "@agoric/harden": "^0.0.8"
   },
   "devDependencies": {
     "esm": "^3.2.25",

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -14,7 +14,7 @@
     "lint-check": "eslint '**/*.js'"
   },
   "dependencies": {
-    "@agoric/harden": "^0.0.7",
+    "@agoric/harden": "^0.0.8",
     "@agoric/stat-logger": "^0.2.2",
     "@agoric/swing-store-lmdb": "^0.2.2",
     "@agoric/swing-store-simple": "^0.1.2",

--- a/packages/tame-metering/package.json
+++ b/packages/tame-metering/package.json
@@ -10,7 +10,7 @@
     "build": "exit 0"
   },
   "dependencies": {
-    "@agoric/harden": "^0.0.7",
+    "@agoric/harden": "^0.0.8",
     "@agoric/nat": "^2.0.1",
     "re2": "^1.10.5"
   },

--- a/packages/transform-eventual-send/package.json
+++ b/packages/transform-eventual-send/package.json
@@ -16,7 +16,7 @@
     "@agoric/babel-parser": "^7.6.4",
     "@agoric/bundle-source": "^1.1.2",
     "@agoric/eventual-send": "^0.8.0",
-    "@agoric/harden": "^0.0.7",
+    "@agoric/harden": "^0.0.8",
     "@babel/generator": "^7.5.0",
     "astring": "^1.4.0",
     "esm": "^3.2.5",

--- a/packages/transform-metering/package.json
+++ b/packages/transform-metering/package.json
@@ -22,7 +22,7 @@
     "tape-promise": "^4.0.0"
   },
   "dependencies": {
-    "@agoric/harden": "^0.0.7",
+    "@agoric/harden": "^0.0.8",
     "@agoric/nat": "^2.0.1",
     "@agoric/tame-metering": "^1.1.2",
     "re2": "^1.10.5"

--- a/packages/weak-store/package.json
+++ b/packages/weak-store/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "dependencies": {
     "@agoric/assert": "^0.0.4",
-    "@agoric/harden": "^0.0.7"
+    "@agoric/harden": "^0.0.8"
   },
   "devDependencies": {
     "esm": "^3.2.25",

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -36,7 +36,7 @@
     "@agoric/ertp": "^0.5.2",
     "@agoric/evaluate": "^2.2.3",
     "@agoric/eventual-send": "^0.8.0",
-    "@agoric/harden": "^0.0.7",
+    "@agoric/harden": "^0.0.8",
     "@agoric/marshal": "^0.1.5",
     "@agoric/nat": "^2.0.1",
     "@agoric/notifier": "^0.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,10 +14,10 @@
   dependencies:
     "@agoric/make-hardener" "0.0.4"
 
-"@agoric/harden@^0.0.7":
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/@agoric/harden/-/harden-0.0.7.tgz#1e6ff3b76e0dd73264cd0df58bb3090a84b3733a"
-  integrity sha512-vVdJhwg0weup94ez9TLjPTTEx6TVzjWmrt+Mbq0VMPBcRdEg1RDsBcpgNoT+4h8ooZNvaTbCWwA77MyFAzDjIw==
+"@agoric/harden@^0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@agoric/harden/-/harden-0.0.8.tgz#1bb7d4b4b9bc884578cb0d87f140bdbe70f563ba"
+  integrity sha512-psxe8nC9wphyeaIhdSFs45CcZnncb4JdoeqBldPNcmcStao8Keuzda9n6t3lqW3WuGm/DNikUyMJ5pE/LeLutQ==
   dependencies:
     "@agoric/make-hardener" "0.0.8"
 


### PR DESCRIPTION
When `@agoric/harden` is imported outside a SES environment, it logs a
warning that `harden()` cannot provide the level of protection that it's
documented to provide. The specific problem is that `harden()` only freezes
out to the "fringe" (which is initially filled with all the primordials like
`Object.prototype`), and if we aren't running under SES, these primordials
are not already frozen. So `harden()` outside SES doesn't protect you against
prototype poisoning.

We use `harden()` is lots of code, because it's the right thing to do, and
some of that code (like `@agoric/assert`) gets used both inside and outside
of SES.

There's a special way to tell `@agoric/harden` that "yes, I know I'm not
using SES, but that's ok, please don't print your warning". It is only
appropriate to send this signal from the top-most file of an application (the
initial `main.js` executable). Libraries should never send this signal,
because they are not responsible for setting up a SES environment (nor are
they usually aware of running inside one).

This patch sends this signal (by adding a falsy `harden` property to
`globalThis`) in the top-most executable for `ag-solo`. This hushes the
warnings caused by using `@agoric/assert` and others in the non-kernel-Realm
code used by ag-solo.

The kernel-Realm SwingSet code uses a different `globalThis`, so the warning
is not disabled there. But the warning isn't triggered there anyways, because
it really does use SES.

refs #971

Issue #971 will be fixed properly when we move to new-SES and make the
top-most file responsible for calling `lockdown()` to establish a global SES
environment. At this point all primordials should be frozen, and `harden()`
should be equally safe everywhere.
