### PR TITLE
Add new example contract to mint fungible tokens

### DIFF
--- a/packages/zoe/src/contracts/mintPayments.js
+++ b/packages/zoe/src/contracts/mintPayments.js
@@ -1,0 +1,87 @@
+/* eslint-disable no-use-before-define */
+import harden from '@agoric/harden';
+import produceIssuer from '@agoric/ertp';
+
+/*
+This is the simplest contract to mint payments and send them to users
+who request them. No offer safety is being enforced here.
+*/
+
+// zcf is the Zoe Contract Facet, i.e. the contract-facing API of Zoe
+export const makeContract = harden(zcf => {
+  // Create the internal token mint for a fungible digital asset
+  const { issuer, mint, amountMath } = produceIssuer('tokens');
+
+  // We need to tell Zoe about this issuer and add a keyword for the
+  // issuer. Let's call this the 'Token' issuer.
+  return zcf.addNewIssuer(issuer, 'Token').then(() => {
+    // We need to wait for the promise to resolve (meaning that Zoe
+    // has done the work of adding a new issuer).
+    const offerHook = userOfferHandle => {
+      // We will send everyone who makes an offer 1000 tokens
+
+      // make the description of 1000 tokens
+      const tokenAmount = amountMath.make(1000);
+
+      // actually mint the new value of 1000 tokens
+      const tokenPayment = mint.mintPayment(tokenAmount);
+
+      // Now we must escrow the tokens with Zoe.
+      let tempContractHandle;
+
+      // We need to make an invite and store the offerHandle of that
+      // invite for future use.
+      const contractSelfInvite = zcf.makeInvitation(
+        offerHandle => (tempContractHandle = offerHandle),
+      );
+      // To escrow the tokens, we must get the Zoe Service facet and
+      // make an offer
+      zcf
+        .getZoeService()
+        .offer(
+          contractSelfInvite,
+          harden({ give: { Token: tokenAmount } }),
+          // escrow the actual tokens
+          harden({ Token: tokenPayment }),
+        )
+        .then(() => {
+          // Now that the tokens have been escrowed, the temporary
+          // contract offer is currently allocated the tokens. We
+          // should swap the allocations for the temporary contract
+          // offer and the user's offer, so that the user eventually gets a
+          // payout of the tokens
+          zcf.reallocate(
+            [tempContractHandle, userOfferHandle],
+            [
+              zcf.getCurrentAllocation(userOfferHandle),
+              zcf.getCurrentAllocation(tempContractHandle),
+            ],
+          );
+          // Let's complete both offers so the user gets a payout of
+          // the tokens through Zoe.
+          zcf.complete([tempContractHandle, userOfferHandle]);
+
+          // Since the user is getting the payout through Zoe, we can
+          // return anything here. Let's return some helpful instructions.
+          return 'Offer completed. You should receive a payment from Zoe';
+        });
+    };
+
+    // A function for making invites to this contract
+    const makeInvite = () => zcf.makeInvitation(offerHook);
+
+    return harden({
+      // return an invite to the creator of the contract instance
+      // through Zoe
+      invite: makeInvite(),
+      publicAPI: {
+        // provide a way for anyone who knows the instanceHandle of
+        // the contract to make their own invite.
+        makeInvite,
+        // make the token issuer public. Note that only the mint can
+        // make new digital assets. The issuer is ok to make public.
+        getTokenIssuer: () => issuer,
+      },
+    });
+  });
+});

--- a/packages/zoe/test/unitTests/contracts/test-mintPayments.js
+++ b/packages/zoe/test/unitTests/contracts/test-mintPayments.js
@@ -1,0 +1,52 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from 'tape-promise/tape';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import bundleSource from '@agoric/bundle-source';
+
+import { E } from '@agoric/eventual-send';
+
+import { makeGetInstanceHandle } from '../../../src/clientSupport';
+import { makeZoe } from '../../../src/zoe';
+
+const mintPaymentsRoot = `${__dirname}/../../../src/contracts/mintPayments`;
+
+test.only('zoe - mint payments', async t => {
+  t.plan(2);
+  try {
+    const zoe = makeZoe({ require });
+    // Pack the contract.
+    const { source, moduleFormat } = await bundleSource(mintPaymentsRoot);
+    const installationHandle = await E(zoe).install(source, moduleFormat);
+    const inviteIssuer = await E(zoe).getInviteIssuer();
+    const getInstanceHandle = makeGetInstanceHandle(inviteIssuer);
+
+    // Alice creates a contract instance
+    const adminInvite = await E(zoe).makeInstance(installationHandle);
+    const instanceHandle = await getInstanceHandle(adminInvite);
+
+    // Bob wants to get 1000 tokens so he gets an invite and makes an
+    // offer
+    const { publicAPI } = await E(zoe).getInstanceRecord(instanceHandle);
+    const invite = await E(publicAPI).makeInvite();
+    t.ok(await E(inviteIssuer).isLive(invite), `valid invite`);
+    const { payout: payoutP } = await E(zoe).offer(invite);
+
+    // Bob's payout promise resolves
+    const bobPayout = await payoutP;
+    const bobTokenPayout = await bobPayout.Token;
+
+    // Let's get the tokenIssuer from the contract so we can evaluate
+    // what we get as our payout
+    const tokenIssuer = await E(publicAPI).getTokenIssuer();
+    const amountMath = await E(tokenIssuer).getAmountMath();
+
+    const tokens1000 = await E(amountMath).make(1000);
+    const tokenPayoutAmount = await E(tokenIssuer).getAmountOf(bobTokenPayout);
+
+    // Bob got 1000 tokens
+    t.deepEquals(tokenPayoutAmount, tokens1000);
+  } catch (e) {
+    t.assert(false, e);
+    console.log(e);
+  }
+});


### PR DESCRIPTION
This is meant to be the simplest example of how to mint payments in a Zoe contract and send them out to users. No offer safety is enforced here.