### PR TITLE
fix: improve handling of orders that are consummated immediately

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
@@ -366,7 +366,15 @@ export async function makeWallet(
         return E(cancelObj).cancel();
       });
       idToOfferHandle.set(id, offerHandle);
-      subscribeToNotifier(id, offerHandle);
+      // The offer might have been postponed, or it might have been immediately
+      // consummated. Only subscribe if it was postponed.
+      E(zoe)
+        .isOfferActive(offerHandle)
+        .then(active => {
+          if (active) {
+            subscribeToNotifier(id, offerHandle);
+          }
+        });
 
       // The outcome is most often a string that can be returned, but
       // it could be an object. We don't do anything currently if it


### PR DESCRIPTION
in the wallet, only subscribe to notifications if the offer becomes active.
in the contract, don't save offers  to the book if they are immediately consummated

It used to always update the counter-offers by asking zoe for fresh
getOfferStatuses(). Now it knows which offer was consumed, so it
directly removes that offer.

A little refactoring to pull out common cases.

This fixes the second problem described in https://github.com/Agoric/dapp-simple-exchange/issues/13 that included a stack trace.