### PR TITLE
add Appveyor CI

### DIFF
--- a/.appveyor/appveyor.yml
+++ b/.appveyor/appveyor.yml
@@ -1,0 +1,40 @@
+# build+test under WSL (Windows Subsystem for Linux)
+#
+# WSL uses a Linux-ish kernel (apparently with modifications to talk to the
+# real windows kernel underneath). The Appveyor installation, at least,
+# defaults to an Ubuntu 18.04 "Bionic" userspace image, with a handful of
+# tools installed (but not build-essential).
+
+# The $PATH includes a bunch of windows directories, with things like Node.js
+# (version 8), yarn, Python, ruby, etc. None of which we use; I don't think
+# they're part of the normal WSL user's experience.
+
+# Commands added here as " - ps:" are run under PowerShell. Commands which
+# are run as " - ps: wsl -- XYZ" get run in a bash environment by the wsl
+# tool. In this environment, the exit code of XYZ is ignored (so failing
+# programs don't stop the build), but the build will halt with a failure if
+# anything is printed to stderr. We use the "./no-stderr" script to make this
+# behave more normally. The docs
+# (https://www.appveyor.com/docs/build-configuration/#interpreters-and-scripts)
+# suggest that putting `$ErrorActionPreference = "Stop";` at "the top of your
+# script" (i.e. your PowerShell script) might influence this.
+
+image: Visual Studio 2019
+build: off
+
+# the worker clones the repo into the clone folder
+# (/mnt/c/projects/agoric-sdk), cds there, then runs each of the following
+# steps. Each step is run from /mnt/c/projects/agoric-sdk, even if it uses
+# 'cd' internally (i.e. each step is run in a separate shell).
+install:
+  - ps: wsl -- .appveyor/no-stderr .appveyor/install-go.sh
+  - ps: wsl -- .appveyor/no-stderr .appveyor/install-nvm.sh
+  - ps: wsl -- .appveyor/no-stderr .appveyor/install-node-13.sh
+  - ps: wsl -- .appveyor/no-stderr .appveyor/install-yarn.sh
+  - ps: wsl -- .appveyor/no-stderr .appveyor/install-build-tools.sh
+
+build_script:
+  - ps: wsl -- .appveyor/no-stderr .appveyor/build.sh
+
+test_script:
+  - ps: wsl -- .appveyor/no-stderr .appveyor/test.sh

--- a/.appveyor/build.sh
+++ b/.appveyor/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -ie
+
+export PATH="/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+echo "pwd is"
+pwd
+
+nvm use v13.11.0
+echo "running nvm current"
+nvm current
+
+yarn
+
+yarn build
+

--- a/.appveyor/install-build-tools.sh
+++ b/.appveyor/install-build-tools.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -ie
+
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+echo "pwd is"
+pwd
+
+cd ~
+
+sudo apt update
+sudo apt install --yes build-essential make

--- a/.appveyor/install-go.sh
+++ b/.appveyor/install-go.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -ie
+
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+echo "PWD was"
+pwd
+
+cd ~
+echo "downloading golang installer"
+wget -q https://dl.google.com/go/go1.14.2.linux-amd64.tar.gz
+
+echo "unpacking tarball"
+sudo tar -C /usr/local -xzf go1.14.2.linux-amd64.tar.gz
+
+echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.profile
+
+echo "golang unpacked, PATH updated"

--- a/.appveyor/install-node-13.sh
+++ b/.appveyor/install-node-13.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -ie
+
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+echo "pwd is"
+pwd
+
+cd ~
+
+echo "running nvm current"
+nvm current
+
+echo "running nvm use v13.11.0"
+nvm install v13.11.0
+
+nvm use v13.11.0
+
+echo "running nvm current"
+nvm current

--- a/.appveyor/install-nvm.sh
+++ b/.appveyor/install-nvm.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -ie
+
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+echo "pwd is"
+pwd
+
+cd ~
+
+echo "downloading NVM install.sh"
+wget -q https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh
+
+echo "running NVM install.sh"
+bash install.sh
+echo "NVM install.sh done" $?

--- a/.appveyor/install-yarn.sh
+++ b/.appveyor/install-yarn.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -ie
+
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+echo "pwd is"
+pwd
+
+cd ~
+
+nvm use v13.11.0
+echo "running nvm current"
+nvm current
+
+npm install -g yarn

--- a/.appveyor/no-stderr
+++ b/.appveyor/no-stderr
@@ -1,0 +1,7 @@
+#!/bin/bash -ie
+
+if "$@" 2>&1; then
+    echo "command succeeded"
+else
+    echo "command failed $?" >&2
+fi

--- a/.appveyor/test.sh
+++ b/.appveyor/test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -ie
+
+export PATH="/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+echo "pwd is"
+pwd
+
+nvm use v13.11.0
+echo "running nvm current"
+nvm current
+
+yarn test
+

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -15,7 +15,7 @@
     "build-kernel": "node -r esm scripts/build-kernel.js",
     "pack": "npm run-script build-kernel && npm pack",
     "publish": "npm run-script pack && npm publish --access public",
-    "test": "npm run-script build-kernel && tap --no-coverage test/test-node-version.js && tap --no-coverage --reporter specy --timeout 120 'test/**/test*.js'",
+    "test": "npm run-script build-kernel && tap --no-coverage test/test-node-version.js && tap --no-coverage --reporter specy --timeout 600 'test/**/test*.js'",
     "test-nosort": "npm run-script build-kernel && tape -r esm test/test-node-version.js && tape -r esm 'test/**/test*.js'",
     "pretty-fix": "prettier --write '**/*.js'",
     "pretty-check": "prettier --check '**/*.js'",


### PR DESCRIPTION
This configures a windows CI job on Appveyor.com, currently at https://ci.appveyor.com/project/warner/agoric-sdk

The goal is to exercise the WSL build, specifically to catch things like #950 

closes #974 