### PR TITLE
Rename newAmountKeywordRecord parameter to allocation

### DIFF
--- a/packages/zoe/src/offerSafety.js
+++ b/packages/zoe/src/offerSafety.js
@@ -47,21 +47,17 @@ function isOfferSafeForOffer(
  * @param  {proposal[]} proposals - an array of records which are the
  * proposal for a single player. Each proposal has keys `give`,
  * `want`, and `exit`.
- * @param  {newAmountKeywordRecord[]} newAmountKeywordRecords- an array of
+ * @param  {newAmountKeywordRecord[]} newAllocations - an array of
  * records. Each of the records (amountKeywordRecord) has keywords for
  * keys and the values are the amount that a single user will get.
  */
 const isOfferSafeForAll = (
   amountMathKeywordRecord,
   proposals,
-  newAmountKeywordRecords,
+  newAllocations,
 ) =>
   proposals.every((proposal, i) =>
-    isOfferSafeForOffer(
-      amountMathKeywordRecord,
-      proposal,
-      newAmountKeywordRecords[i],
-    ),
+    isOfferSafeForOffer(amountMathKeywordRecord, proposal, newAllocations[i]),
   );
 
 // `isOfferSafeForOffer` is only exported for testing

--- a/packages/zoe/src/state.js
+++ b/packages/zoe/src/state.js
@@ -74,9 +74,9 @@ const makeOfferTable = () => {
           return table.delete(offerHandle);
         });
       },
-      updateAmounts: (offerHandles, newAmountKeywordRecords) =>
+      updateAmounts: (offerHandles, newAllocations) =>
         offerHandles.map((offerHandle, i) => {
-          const newAmountKeywordRecord = newAmountKeywordRecords[i];
+          const newAmountKeywordRecord = newAllocations[i];
           const { updater } = table.get(offerHandle);
           updater.updateState(newAmountKeywordRecord);
           return table.update(offerHandle, {

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -194,13 +194,13 @@ import { makeTables } from './state';
  * invariants are true, they will remain true until changes are
  * made.
  * zcf.reallocate will throw an error if any of the
- * newAmountKeywordRecords do not have a value for all the
+ * newAllocations do not have a value for all the
  * keywords in sparseKeywords. An error will also be thrown if
- * any newAmountKeywordRecords have keywords that are not in
+ * any newAllocations have keywords that are not in
  * sparseKeywords.
  *
  * @param  {object[]} offerHandles An array of offerHandles
- * @param  {AmountKeywordRecord[]} newAmountKeywordRecords An
+ * @param  {AmountKeywordRecord[]} newAllocations An
  * array of amountKeywordRecords  - objects with keyword keys
  * and amount values, with one keywordRecord per offerHandle.
  * @param  {Keyword[]} sparseKeywords An array of string
@@ -384,7 +384,7 @@ const makeZoe = (additionalEndowments = {}) => {
      * @type {ContractFacet}
      */
     const contractFacet = harden({
-      reallocate: (offerHandles, newAmountKeywordRecords, sparseKeywords) => {
+      reallocate: (offerHandles, newAllocations, sparseKeywords) => {
         assertOffersHaveInstanceHandle(offerHandles, instanceHandle);
         const { issuerKeywordRecord } = instanceTable.get(instanceHandle);
         const allKeywords = getKeywords(issuerKeywordRecord);
@@ -392,7 +392,7 @@ const makeZoe = (additionalEndowments = {}) => {
           sparseKeywords = allKeywords;
         }
 
-        const newAmountMatrix = newAmountKeywordRecords.map(amountObj =>
+        const newAmountMatrix = newAllocations.map(amountObj =>
           objToArrayAssertFilled(amountObj, sparseKeywords),
         );
 
@@ -426,16 +426,12 @@ const makeZoe = (additionalEndowments = {}) => {
 
         // 2) ensure 'offer safety' for each player
         assert(
-          isOfferSafeForAll(
-            amountMathKeywordRecord,
-            proposals,
-            newAmountKeywordRecords,
-          ),
+          isOfferSafeForAll(amountMathKeywordRecord, proposals, newAllocations),
           details`The proposed reallocation was not offer safe`,
         );
 
         // 3) save the reallocation
-        offerTable.updateAmounts(offerHandles, harden(newAmountKeywordRecords));
+        offerTable.updateAmounts(offerHandles, harden(newAllocations));
       },
 
       complete: offerHandles => {


### PR DESCRIPTION
Closes #875 

I'm keeping the type AmountKeywordRecord - the point is not to remove that concept, but to introduce the concept of an `allocation`