### PR TITLE
Add completeObj with complete method in addition to deprecated cancelObj

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
@@ -33,7 +33,7 @@ export async function makeWallet(
 
   // Compiled offers (all ready to execute).
   const idToCompiledOfferP = new Map();
-  const idToCancel = new Map();
+  const idToComplete = new Map();
   const idToOfferHandle = new Map();
   const idToOutcome = new Map();
 
@@ -147,7 +147,7 @@ export async function makeWallet(
 
     const {
       payout: payoutObjP,
-      cancelObj,
+      completeObj,
       outcome: outcomeP,
       offerHandle: offerHandleP,
     } = await E(zoe).offer(invite, proposal, payment);
@@ -190,7 +190,7 @@ export async function makeWallet(
       );
     });
 
-    return { depositedP, cancelObj, outcome, offerHandle };
+    return { depositedP, completeObj, outcome, offerHandle };
   }
 
   // === API
@@ -301,12 +301,12 @@ export async function makeWallet(
   }
 
   async function cancelOffer(id) {
-    const cancel = idToCancel.get(id);
-    if (!cancel) {
+    const completeFn = idToComplete.get(id);
+    if (!completeFn) {
       return false;
     }
 
-    cancel()
+    completeFn()
       .then(_ => {
         const offer = idToOffer.get(id);
         const cancelledOffer = {
@@ -356,14 +356,14 @@ export async function makeWallet(
       const inviteP = invite || E(publicAPIHooks).getInvite(publicAPI);
       const {
         depositedP,
-        cancelObj,
+        completeObj,
         outcome,
         offerHandle,
       } = await executeOffer(compiledOffer, inviteP);
 
       idToCancel.set(id, () => {
         alreadyResolved = true;
-        return E(cancelObj).cancel();
+        return E(completeObj).complete();
       });
       idToOfferHandle.set(id, offerHandle);
       // The offer might have been postponed, or it might have been immediately

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -116,8 +116,8 @@ import { makeTables } from './state';
  * @property {Promise<OfferOutcome>} outcome Note that if the offerHook throws,
  * this outcome Promise will reject, but the rest of the OfferResultRecord is
  * still meaningful.
- * @property {(() => undefined)} [cancelObj]
- * cancelObj will only be present if exitKind was 'onDemand'
+ * @property {(() => undefined)} [completeObj]
+ * completeObj will only be present if exitKind was 'onDemand'
  *
  * @typedef {Object} Proposal
  * @property {AmountKeywordRecord} want
@@ -529,8 +529,8 @@ const makeZoe = (additionalEndowments = {}) => {
   // retrieves an instance from Zoe, and `offer` allows users to
   // securely escrow and get in return a record containing a promise for
   // payouts, a promise for the outcome of joining the contract,
-  // and, depending on the exit conditions, perhaps a cancelObj,
-  // an object with a cancel method for leaving the contract on demand.
+  // and, depending on the exit conditions, perhaps a completeObj,
+  // an object with a complete method for leaving the contract on demand.
 
   /** @type {ZoeService} */
   const zoeService = harden(
@@ -752,10 +752,19 @@ const makeZoe = (additionalEndowments = {}) => {
               // Add an object with a cancel method to offerResult in
               // order to cancel on demand.
             } else if (exitKind === 'onDemand') {
-              offerResult.cancelObj = {
+              const completeObj = {
+                complete: () =>
+                  completeOffers(instanceHandle, harden([offerHandle])),
+              };
+              offerResult.completeObj = completeObj;
+              // The property "cancelObj" and method "cancel" are
+              // deprecated and will be removed in a later version.
+              // https://github.com/Agoric/agoric-sdk/issues/835
+              const cancelObj = {
                 cancel: () =>
                   completeOffers(instanceHandle, harden([offerHandle])),
               };
+              offerResult.cancelObj = cancelObj;
             } else {
               assert(
                 exitKind === 'waived',

--- a/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
+++ b/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
@@ -396,7 +396,7 @@ test('zoe - alice cancels after completion', async t => {
     });
     const alicePayments = { ContributionA: aliceMoolaPayment };
 
-    const { cancelObj, payout: payoutP, outcome: outcomeP } = await zoe.offer(
+    const { completeObj, payout: payoutP, outcome: outcomeP } = await zoe.offer(
       invite,
       aliceProposal,
       alicePayments,
@@ -404,7 +404,10 @@ test('zoe - alice cancels after completion', async t => {
 
     await outcomeP;
 
-    t.throws(() => cancelObj.cancel(), /Error: offer has already completed/);
+    t.throws(
+      () => completeObj.complete(),
+      /Error: offer has already completed/,
+    );
 
     const payout = await payoutP;
     const moolaPayout = await payout.ContributionA;

--- a/packages/zoe/test/unitTests/contracts/test-operaConcertTicket.js
+++ b/packages/zoe/test/unitTests/contracts/test-operaConcertTicket.js
@@ -83,13 +83,12 @@ test(`Zoe opera ticket contract`, async t => {
                 // "i want n times moolas where n is the number of sold tickets"
                 zoe
                   .offer(auditoriumInvite, harden({}))
-                  // cancel will be renamed complete: https://github.com/Agoric/agoric-sdk/issues/835
-                  // cancelObj exists because of a current limitation in @agoric/marshal : https://github.com/Agoric/agoric-sdk/issues/818
+                  // completeObj exists because of a current limitation in @agoric/marshal : https://github.com/Agoric/agoric-sdk/issues/818
                   .then(
                     async ({
                       outcome: auditoriumOutcomeP,
                       payout,
-                      cancelObj: { cancel: complete },
+                      completeObj: { complete },
                       offerHandle,
                     }) => {
                       t.equal(

--- a/packages/zoe/test/unitTests/contracts/test-publicAuction.js
+++ b/packages/zoe/test/unitTests/contracts/test-publicAuction.js
@@ -366,7 +366,7 @@ test('zoe - secondPriceAuction w/ 3 bids - alice exits onDemand', async t => {
     // Alice initializes the auction
     const {
       payout: alicePayoutP,
-      cancelObj,
+      completeObj,
       outcome: aliceOutcomeP,
     } = await zoe.offer(aliceInvite, aliceProposal, alicePayments);
 
@@ -379,7 +379,7 @@ test('zoe - secondPriceAuction w/ 3 bids - alice exits onDemand', async t => {
 
     // Alice cancels her offer, making the auction stop accepting
     // offers
-    cancelObj.cancel();
+    completeObj.complete();
 
     // Alice gives Bob the invite
 


### PR DESCRIPTION
For backwards compatibility, `cancelObj` is left in. Before this is merged, we should create a new issue to remove `cancelObj` at a later date.

Closes #835 