### PR TITLE
Accomodate relayers that start channels themselves

### DIFF
--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -26,14 +26,21 @@ NAME := $(shell sed -ne 's/.*"name": "\([^"]*\)".*/\1/p' package.json)
 VERSION := $(shell sed -ne 's/.*"version": "\([^"]*\)".*/\1/p' package.json)
 COMMIT := $(shell git log -1 --format='%H' || cat lib/git-revision.txt)
 
-ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=$(NAME) \
+ldflags = \
+	-X github.com/cosmos/cosmos-sdk/version.Name=$(NAME) \
 	-X github.com/cosmos/cosmos-sdk/version.ServerName=ag-chain-cosmos \
 	-X github.com/cosmos/cosmos-sdk/version.ClientName=ag-cosmos-helper \
 	-X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
 	-X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
 	-X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags)"
+gcflags =
 
-BUILD_FLAGS := -tags "$(build_tags)" -ldflags '$(ldflags)'
+ifneq ($(GO_DEBUG),)
+ldflags += -compressdwarf=false
+gcflags += -N -l
+endif
+
+BUILD_FLAGS := -tags "$(build_tags)" -gcflags '$(gcflags)' -ldflags '$(ldflags)'
 
 include Makefile.ledger
 all: build-cosmos install
@@ -149,7 +156,7 @@ node-compile-gyp:
 # Only run from the package.json build:gyp script.
 compile-gyp:
 	cp binding.gyp.in binding.gyp
-	node-gyp configure build || { status=$$?; rm -f binding.gyp; exit $$status; }
+	node-gyp configure build $(GYP_DEBUG) || { status=$$?; rm -f binding.gyp; exit $$status; }
 	rm -f binding.gyp
 
 install: go.sum

--- a/packages/cosmic-swingset/app/app.go
+++ b/packages/cosmic-swingset/app/app.go
@@ -329,7 +329,7 @@ func NewAgoricApp(
 		distr.NewAppModule(appCodec, app.distrKeeper, app.accountKeeper, app.bankKeeper, app.stakingKeeper),
 		staking.NewAppModule(appCodec, app.stakingKeeper, app.accountKeeper, app.bankKeeper),
 		upgrade.NewAppModule(app.upgradeKeeper),
-		evidence.NewAppModule(app.evidenceKeeper),
+		evidence.NewAppModule(appCodec, app.evidenceKeeper),
 		ibc.NewAppModule(app.ibcKeeper),
 		params.NewAppModule(app.paramsKeeper),
 		transferModule,

--- a/packages/cosmic-swingset/app/app.go
+++ b/packages/cosmic-swingset/app/app.go
@@ -186,7 +186,7 @@ func NewAgoricApp(
 		auth.StoreKey, bank.StoreKey, staking.StoreKey,
 		mint.StoreKey, distr.StoreKey, slashing.StoreKey,
 		gov.StoreKey, params.StoreKey, ibc.StoreKey, upgrade.StoreKey,
-		evidence.StoreKey, transfer.StoreKey, capability.StoreKey, swingset.StoreKey,
+		evidence.StoreKey, transfer.StoreKey, swingset.StoreKey, capability.StoreKey,
 	)
 	tKeys := sdk.NewTransientStoreKeys(params.TStoreKey)
 	memKeys := sdk.NewMemoryStoreKeys(capability.MemStoreKey)
@@ -291,7 +291,7 @@ func NewAgoricApp(
 	// This function is tricky to get right, so we inject it ourselves.
 	app.swingSetKeeper.CallToController = func(ctx sdk.Context, str string) (string, error) {
 		defer swingset.SetControllerContext(ctx)()
-		defer swingset.SetControllerKeeper(app.swingSetKeeper)()
+		defer swingset.SetControllerKeeper(&app.swingSetKeeper)()
 		return sendToController(true, str)
 	}
 
@@ -332,8 +332,8 @@ func NewAgoricApp(
 		evidence.NewAppModule(appCodec, app.evidenceKeeper),
 		ibc.NewAppModule(app.ibcKeeper),
 		params.NewAppModule(app.paramsKeeper),
-		transferModule,
 		swingsetModule,
+		transferModule,
 	)
 
 	// During begin block slashing happens after distr.BeginBlocker so that
@@ -353,8 +353,7 @@ func NewAgoricApp(
 	app.mm.SetOrderInitGenesis(
 		capability.ModuleName, auth.ModuleName, distr.ModuleName, staking.ModuleName, bank.ModuleName,
 		slashing.ModuleName, gov.ModuleName, mint.ModuleName, crisis.ModuleName,
-		ibc.ModuleName, genutil.ModuleName, evidence.ModuleName, transfer.ModuleName,
-		swingset.ModuleName,
+		ibc.ModuleName, genutil.ModuleName, evidence.ModuleName, swingset.ModuleName, transfer.ModuleName,
 	)
 
 	app.mm.RegisterInvariants(&app.crisisKeeper)

--- a/packages/cosmic-swingset/bin/ag-nchainz
+++ b/packages/cosmic-swingset/bin/ag-nchainz
@@ -11,6 +11,8 @@
 set -e
 progname=$(basename -- "$0")
 
+trap 'kill $(jobs -p) 2>/dev/null' EXIT 
+
 BASE_PORT=8000
 NUM_SOLOS=1
 
@@ -59,9 +61,10 @@ testnet)
       ag-solo 1000uag
 	done
 	# $thisdir/../../deployment/set-json.js $n0d/config/genesis.json --agoric-genesis-overrides
-  for node in `ls -d $chainid/n[1-9]* 2>/dev/null`; do
+  for node in `ls -d $chainid/n[1-9]* 2>/dev/null || :`; do
     cp $n0d/config/genesis.json $node/$DAEMON/config/genesis.json
   done
+  exit 0
   ;;
 start-daemon)
   BASEDIR=$1
@@ -73,6 +76,7 @@ start-daemon)
   done
   echo "Starting BOOT_ADDRESS=$ba $DAEMON ${1+"$@"}"
   DEBUG=agoric ROLE=two_chain BOOT_ADDRESS=$ba $DAEMON ${1+"$@"}
+  exit 0
   ;;
 
 start-solos)
@@ -100,8 +104,9 @@ start-solos)
     ) >>nchainz/logs/$log 2>&1 &
   done
   sleep 2
-  echo "Waiting for all solos (Hit Control-C to exit)..."
+  echo "Waiting for all ${1+"$@ "}solos (Hit Control-C to exit)..."
   wait
+  exit 0
   ;;
 *)
   echo 1>&2 "$progname: unrecognized command \`$COMMAND'"

--- a/packages/cosmic-swingset/bin/ag-nchainz
+++ b/packages/cosmic-swingset/bin/ag-nchainz
@@ -67,6 +67,10 @@ testnet)
   exit 0
   ;;
 start-daemon)
+  if [[ $1 == '--debug' ]]; then
+    debug=yes
+    shift
+  fi
   BASEDIR=$1
   shift
   ba=$($CLI --home "$BASEDIR/n0/$CLI" keys show n0 --keyring-backend=test | jq -r .address)
@@ -75,7 +79,11 @@ start-daemon)
     ba="$ba $(cat $solo/ag-cosmos-helper-address)"
   done
   echo "Starting BOOT_ADDRESS=$ba $DAEMON ${1+"$@"}"
-  DEBUG=agoric ROLE=two_chain BOOT_ADDRESS=$ba $DAEMON ${1+"$@"}
+  if [[ $debug == yes ]]; then
+    DEBUG=agoric ROLE=two_chain BOOT_ADDRESS=$ba node --inspect-brk $(which $DAEMON) ${1+"$@"}
+  else
+    DEBUG=agoric ROLE=two_chain BOOT_ADDRESS=$ba $DAEMON ${1+"$@"}
+  fi
   exit 0
   ;;
 

--- a/packages/cosmic-swingset/bin/ag-nchainz
+++ b/packages/cosmic-swingset/bin/ag-nchainz
@@ -61,7 +61,7 @@ testnet)
       ag-solo 1000uag
 	done
 	# $thisdir/../../deployment/set-json.js $n0d/config/genesis.json --agoric-genesis-overrides
-  for node in `ls -d $chainid/n[1-9]* 2>/dev/null || :`; do
+  for node in `ls -d $chainid/n[1-9]* 2>/dev/null || true`; do
     cp $n0d/config/genesis.json $node/$DAEMON/config/genesis.json
   done
   exit 0

--- a/packages/cosmic-swingset/cmd/ag-cosmos-daemon/main.go
+++ b/packages/cosmic-swingset/cmd/ag-cosmos-daemon/main.go
@@ -1,5 +1,9 @@
 package main
 
+// #cgo CPPFLAGS: -I/usr/local/include/node
+// #cgo LDFLAGS: -L/usr/local/lib
+import "C"
+
 import "github.com/Agoric/agoric-sdk/packages/cosmic-swingset/lib/daemon"
 
 func main() {

--- a/packages/cosmic-swingset/go.mod
+++ b/packages/cosmic-swingset/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/99designs/keyring v1.1.4 // indirect
 	github.com/Agoric/agoric-sdk v0.0.0-00010101000000-000000000000 // indirect
 	github.com/bartekn/go-bip39 v0.0.0-20171116152956-a05967ea095d // indirect
-  github.com/cosmos/cosmos-sdk v0.34.4-0.20200422222342-f6e9ee762358
-  github.com/gibson042/canonicaljson-go v1.0.3 // indirect
+	github.com/cosmos/cosmos-sdk v0.34.4-0.20200423194215-1cd1d088df05
+	github.com/gibson042/canonicaljson-go v1.0.3 // indirect
 	github.com/golang/mock v1.4.3 // indirect
 	github.com/gorilla/handlers v1.4.2 // indirect
 	github.com/gorilla/mux v1.7.4

--- a/packages/cosmic-swingset/go.sum
+++ b/packages/cosmic-swingset/go.sum
@@ -87,6 +87,8 @@ github.com/cosmos/cosmos-sdk v0.34.4-0.20200417201027-11528d39594c h1:Yd7DVqfImC
 github.com/cosmos/cosmos-sdk v0.34.4-0.20200417201027-11528d39594c/go.mod h1:jngw1LJfwEAU+xc/tZwUGIXBAJHapckYGtXycsq8D+U=
 github.com/cosmos/cosmos-sdk v0.34.4-0.20200422222342-f6e9ee762358 h1:ZsII2yECeLh2jWqFz3bK8JInzzlHPhgB0ob2c9XMyz4=
 github.com/cosmos/cosmos-sdk v0.34.4-0.20200422222342-f6e9ee762358/go.mod h1:Kcgs8c2WWtO2Q+KmDogvGRw+sdEqpvHYXFhj/QiAoOg=
+github.com/cosmos/cosmos-sdk v0.34.4-0.20200423194215-1cd1d088df05 h1:jaV9iTBaiYmNAMaDEhvWukIQWQ/NfBoHbgSqPgdKFmM=
+github.com/cosmos/cosmos-sdk v0.34.4-0.20200423194215-1cd1d088df05/go.mod h1:Kcgs8c2WWtO2Q+KmDogvGRw+sdEqpvHYXFhj/QiAoOg=
 github.com/cosmos/cosmos-sdk v0.38.3 h1:qIBTiw+2T9POaSUJ5rvbBbXeq8C8btBlJxnSegPBd3Y=
 github.com/cosmos/cosmos-sdk v0.38.3/go.mod h1:rzWOofbKfRt3wxiylmYWEFHnxxGj0coyqgWl2I9obAw=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d h1:49RLWk1j44Xu4fjHb6JFYmeUnDORVwHNkDxaQ0ctCVU=

--- a/packages/cosmic-swingset/go.sum
+++ b/packages/cosmic-swingset/go.sum
@@ -5,6 +5,8 @@ github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4/go.mod h1:hN
 github.com/99designs/keyring v1.1.3/go.mod h1:657DQuMrBZRtuL/voxVyiyb6zpMehlm5vLB9Qwrv904=
 github.com/99designs/keyring v1.1.4 h1:x0g0zQ9bQKgNsLo0XSXAy1H8Q1RG/td+5OXJt+Ci8b8=
 github.com/99designs/keyring v1.1.4/go.mod h1:657DQuMrBZRtuL/voxVyiyb6zpMehlm5vLB9Qwrv904=
+github.com/99designs/keyring v1.1.5 h1:wLv7QyzYpFIyMSwOADq1CLTF9KbjbBfcnfmOGJ64aO4=
+github.com/99designs/keyring v1.1.5/go.mod h1:7hsVvt2qXgtadGevGJ4ujg+u8m6SpJ5TpHqTozIPqf0=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200102211924-4bcbc698314f h1:4O1om+UVU+Hfcihr1timk8YNXHxzZWgCo7ofnrZRApw=
@@ -21,6 +23,9 @@ github.com/Workiva/go-datastructures v1.0.52 h1:PLSK6pwn8mYdaoaCZEMsXBpBotr4HHn9
 github.com/Workiva/go-datastructures v1.0.52/go.mod h1:Z+F2Rca0qCsVYDS8z7bAGm8f3UkzuWYS/oBZz5a7VVA=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
+github.com/agoric-labs/cosmos-sdk v0.34.4-0.20200428210309-3cf84258cc12 h1:xnDgoo7cqnbvMFXp7QYrNwYPpAe0wtBuVSkG40PHb1U=
+github.com/agoric-labs/cosmos-sdk v0.34.4-0.20200428210309-3cf84258cc12/go.mod h1:tvCen72hkJxkYT1/CsOaKHjZ4PouX4Isp4w9aRL2K4c=
+github.com/agoric-labs/cosmos-sdk v0.37.0 h1:y9OTnnORhLHPnfxLIaK4Pv/7Z7KcpnbTxpE5xxWlUUY=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -315,6 +320,8 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/mtibben/percent v0.2.1 h1:5gssi8Nqo8QU/r2pynCm+hBQHpkB/uNK7BJCFogWdzs=
+github.com/mtibben/percent v0.2.1/go.mod h1:KG9uO+SZkUp+VkRHsCdYQV3XSZrrSpR3O9ibNBTZrns=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nats-io/jwt v0.3.0/go.mod h1:fRYCDE99xlTsqUzISS1Bi75UBJ6ljOJQOAAu5VglpSg=
 github.com/nats-io/jwt v0.3.2/go.mod h1:/euKqTS1ZD+zzjYrY7pseZrTtWQSjujC7xjPc8wL6eU=

--- a/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
+++ b/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
@@ -46,7 +46,19 @@ export async function connectToFakeChain(basedir, GCI, role, delay, inbound) {
     console.error('received', dstID, obj);
     return 'IBC and bridge device not used on fake-chain';
   }
-  const s = await launch(stateDBdir, mailboxStorage, doOutboundBridge, vatsdir, argv);
+  function flushChainSends(replay) {
+    if (replay) {
+      throw Error(`Replay not implemented`);
+    }
+  }
+  const s = await launch(
+    stateDBdir,
+    mailboxStorage,
+    doOutboundBridge,
+    flushChainSends,
+    vatsdir,
+    argv,
+  );
 
   const blockManager = makeBlockManager(s);
   const { savedHeight, savedActions } = s;

--- a/packages/cosmic-swingset/lib/ag-solo/vats/bridge.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bridge.js
@@ -58,11 +58,14 @@ export function makeBridgeManager(E, D, bridgeDevice) {
     if (!bridgeDevice) {
       throw Error(`bridge device not yet connected`);
     }
-    const retval = D(bridgeDevice).callOutbound(dstID, obj);
+    const retobj = D(bridgeDevice).callOutbound(dstID, obj);
     // note: *we* get this return value synchronously, but any callers (in
     // separate vats) only get a Promise, and will receive the value in some
     // future turn
-    return retval;
+    if (retobj && retobj.error) {
+      throw Error(retobj.error);
+    }
+    return retobj;
   }
 
   // We now manage the device.

--- a/packages/cosmic-swingset/lib/ag-solo/vats/ibc.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/ibc.js
@@ -199,7 +199,11 @@ export function makeIBCProtocolHandler(
       },
       onReceive,
       async onClose(_conn, _reason, _handler) {
-        await callIBCDevice('channelCloseInit', { channelID, portID });
+        const packet = {
+          source_port: portID,
+          source_channel: channelID,
+        };
+        await callIBCDevice('channelCloseInit', { packet });
         usedChannels.delete(channelID);
         usedChannels.delete(rChannelID);
       },
@@ -251,7 +255,10 @@ export function makeIBCProtocolHandler(
     },
     async onBind(_port, localAddr, _protocolHandler) {
       const portID = localAddrToPortID(localAddr);
-      return callIBCDevice('bindPort', { portID });
+      const packet = {
+        source_port: portID,
+      };
+      return callIBCDevice('bindPort', { packet });
     },
     async onConnect(_port, localAddr, remoteAddr, _protocolHandler) {
       console.warn('IBC onConnect', localAddr, remoteAddr);

--- a/packages/cosmic-swingset/lib/ag-solo/vats/ibc.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/ibc.js
@@ -221,6 +221,12 @@ export function makeIBCProtocolHandler(
           source_channel: channelID,
         };
         await callIBCDevice('channelCloseInit', { packet });
+        // TODO: Let's look carefully at this
+        // There's a danger of the two sides disagreeing about whether
+        // the channel is closed or not, and reusing channelIDs could
+        // be a security hole.
+        //
+        // FIXME: Maybe check whether channelCloseConfirm is done.
         usedChannels.delete(channelID);
         usedChannels.delete(rChannelID);
       },

--- a/packages/cosmic-swingset/lib/agcosmosdaemon-node.cc
+++ b/packages/cosmic-swingset/lib/agcosmosdaemon-node.cc
@@ -89,15 +89,17 @@ int SendToNode(int port, int replyPort, Body str) {
                     NodeReplier::New(env, promise),
                 };
             });
-        if (replyPort) {
-            // std::cerr << "Waiting on future" << std::endl;
-            try {
-                NodeReply ret = promise->get_future().get();
-                // std::cerr << "Replying to Go with " << ret.value() << " " << ret.isRejection() << std::endl;
-                ReplyToGo(replyPort, ret.isRejection(), ret.value().c_str());
-            } catch (std::exception& e) {
-                // std::cerr << "Exceptioning " << e.what() << std::endl;
-                ReplyToGo(replyPort, true, e.what());
+        // std::cerr << "Waiting on future" << std::endl;
+        try {
+            NodeReply ret = promise->get_future().get();
+            // std::cerr << "Replying to Go with " << ret.value() << " " << ret.isRejection() << std::endl;
+            if (replyPort) {
+              ReplyToGo(replyPort, ret.isRejection(), ret.value().c_str());
+            }
+        } catch (std::exception& e) {
+            // std::cerr << "Exceptioning " << e.what() << std::endl;
+            if (replyPort) {
+              ReplyToGo(replyPort, true, e.what());
             }
         }
         // std::cerr << "Thread is finished" << std::endl;

--- a/packages/cosmic-swingset/lib/block-manager.js
+++ b/packages/cosmic-swingset/lib/block-manager.js
@@ -8,13 +8,6 @@ const END_BLOCK = 'END_BLOCK';
 const COMMIT_BLOCK = 'COMMIT_BLOCK';
 const IBC_EVENT = 'IBC_EVENT';
 
-// This works for both *intArray, string, and Buffer.
-const getBytesToBase64 = data => Buffer.from(data).toString('base64');
-
-// FIXME: use an immutable Uint8Array.
-const getBase64ToBytes = data64 =>
-  Uint8Array.from(Buffer.from(data64, 'base64'));
-
 export default function makeBlockManager(
   {
     deliverInbound,

--- a/packages/cosmic-swingset/lib/launch-chain.js
+++ b/packages/cosmic-swingset/lib/launch-chain.js
@@ -67,6 +67,7 @@ export async function launch(
   kernelStateDBDir,
   mailboxStorage,
   doOutboundBridge,
+  flushChainSends,
   vatsDir,
   argv,
 ) {
@@ -159,6 +160,7 @@ export async function launch(
     deliverInbound,
     doBridgeInbound,
     // bridgeOutbound,
+    flushChainSends,
     beginBlock,
     saveChainState,
     saveOutsideState,

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "exit 0",
     "build:gyp": "make compile-gyp",
+    "build:gyp-debug": "make compile-gyp GYP_DEBUG=--debug",
     "test": "tape -r esm 'test/**/test*.js' | tap-spec",
     "pretty-fix": "prettier --write '**/*.js'",
     "pretty-check": "prettier --check '**/*.js'",

--- a/packages/cosmic-swingset/x/swingset/controller.go
+++ b/packages/cosmic-swingset/x/swingset/controller.go
@@ -8,7 +8,7 @@ import (
 )
 
 type ControllerContext struct {
-	Keeper                Keeper
+	Keeper                *Keeper
 	Context               sdk.Context
 	StoragePort           int
 	IBCChannelHandlerPort int
@@ -32,10 +32,10 @@ func SetControllerContext(ctx sdk.Context) func() {
 	}
 }
 
-func SetControllerKeeper(keeper Keeper) func() {
+func SetControllerKeeper(keeper *Keeper) func() {
 	controllerContext.Keeper = keeper
 	return func() {
-		controllerContext.Keeper = Keeper{}
+		controllerContext.Keeper = nil
 	}
 }
 

--- a/packages/cosmic-swingset/x/swingset/handler.go
+++ b/packages/cosmic-swingset/x/swingset/handler.go
@@ -78,9 +78,9 @@ func handleMsgDeliverInbound(ctx sdk.Context, keeper Keeper, msg MsgDeliverInbou
 	if err != nil {
 		return nil, err
 	}
-	return &sdk.Result{
-		Events: ctx.EventManager().Events().ToABCIEvents(),
-	}, nil
+	return &sdk.Result{}, nil
+	/*		Events: ctx.EventManager().Events().ToABCIEvents(),
+	}, nil */
 }
 
 type sendPacketAction struct {

--- a/packages/cosmic-swingset/x/swingset/ibc.go
+++ b/packages/cosmic-swingset/x/swingset/ibc.go
@@ -102,7 +102,7 @@ func (ch channelHandler) Receive(ctx *ControllerContext, str string) (ret string
 		}
 
 	case "bindPort":
-		err = ctx.Keeper.BindPort(ctx.Context, msg.PortID, ch.ibcModule)
+		err = ctx.Keeper.BindPort(ctx.Context, msg.PortID)
 		if err == nil {
 			ret = "true"
 		}

--- a/packages/cosmic-swingset/x/swingset/ibc.go
+++ b/packages/cosmic-swingset/x/swingset/ibc.go
@@ -21,13 +21,16 @@ type channelHandler struct {
 }
 
 type channelMessage struct { // comes from swingset's IBC handler
-	Type            string              `json:"type"` // IBC_METHOD
-	Method          string              `json:"method"`
-	PortID          string              `json:"portID"`
-	ChannelID       string              `json:"channelID"`
-	Packet          channeltypes.Packet `json:"packet"`
-	RelativeTimeout uint64              `json:"relativeTimeout"`
-	Ack             []byte              `json:"ack"`
+	Type            string                `json:"type"` // IBC_METHOD
+	Method          string                `json:"method"`
+	PortID          string                `json:"portID"`
+	ChannelID       string                `json:"channelID"`
+	Packet          channeltypes.Packet   `json:"packet"`
+	RelativeTimeout uint64                `json:"relativeTimeout"`
+	Order           channelexported.Order `json:"order"`
+	Hops            []string              `json:"hops"`
+	Version         string                `json:"version"`
+	Ack             []byte                `json:"ack"`
 }
 
 // DefaultRouter is a temporary hack until cosmos-sdk implements its features FIXME.
@@ -91,6 +94,17 @@ func (ch channelHandler) Receive(ctx *ControllerContext, str string) (ret string
 
 	case "packetExecuted":
 		err = ctx.Keeper.PacketExecuted(ctx.Context, msg.Packet, msg.Ack)
+		if err == nil {
+			ret = "true"
+		}
+
+	case "channelOpenInit":
+		err = ctx.Keeper.ChanOpenInit(
+			ctx.Context, msg.Order, msg.Hops,
+			msg.Packet.SourcePort, msg.Packet.SourceChannel,
+			msg.Packet.DestinationPort, msg.Packet.DestinationChannel,
+			msg.Version,
+		)
 		if err == nil {
 			ret = "true"
 		}

--- a/packages/cosmic-swingset/x/swingset/ibc.go
+++ b/packages/cosmic-swingset/x/swingset/ibc.go
@@ -23,8 +23,6 @@ type channelHandler struct {
 type channelMessage struct { // comes from swingset's IBC handler
 	Type            string                `json:"type"` // IBC_METHOD
 	Method          string                `json:"method"`
-	PortID          string                `json:"portID"`
-	ChannelID       string                `json:"channelID"`
 	Packet          channeltypes.Packet   `json:"packet"`
 	RelativeTimeout uint64                `json:"relativeTimeout"`
 	Order           channelexported.Order `json:"order"`
@@ -110,13 +108,13 @@ func (ch channelHandler) Receive(ctx *ControllerContext, str string) (ret string
 		}
 
 	case "channelCloseInit":
-		err = ctx.Keeper.ChanCloseInit(ctx.Context, msg.PortID, msg.ChannelID)
+		err = ctx.Keeper.ChanCloseInit(ctx.Context, msg.Packet.SourcePort, msg.Packet.SourceChannel)
 		if err == nil {
 			ret = "true"
 		}
 
 	case "bindPort":
-		err = ctx.Keeper.BindPort(ctx.Context, msg.PortID)
+		err = ctx.Keeper.BindPort(ctx.Context, msg.Packet.SourcePort)
 		if err == nil {
 			ret = "true"
 		}

--- a/packages/cosmic-swingset/x/swingset/ibc.go
+++ b/packages/cosmic-swingset/x/swingset/ibc.go
@@ -179,12 +179,13 @@ func (am AppModule) OnChanOpenInit(
 	}
 
 	_, err = am.CallToController(ctx, string(bytes))
+	if err != nil {
+		return err
+	}
 
-	if err == nil {
-		// Claim channel capability passed back by IBC module
-		if err := am.keeper.ClaimCapability(ctx, channelCap, ibctypes.ChannelCapabilityPath(portID, channelID)); err != nil {
-			return sdkerrors.Wrap(channel.ErrChannelCapabilityNotFound, err.Error())
-		}
+	// Claim channel capability passed back by IBC module
+	if err = am.keeper.ClaimCapability(ctx, channelCap, ibctypes.ChannelCapabilityPath(portID, channelID)); err != nil {
+		return sdkerrors.Wrap(channel.ErrChannelCapabilityNotFound, err.Error())
 	}
 
 	return err
@@ -232,12 +233,13 @@ func (am AppModule) OnChanOpenTry(
 	}
 
 	_, err = am.CallToController(ctx, string(bytes))
+	if err != nil {
+		return err
+	}
 
-	if err == nil {
-		// Claim channel capability passed back by IBC module
-		if err := am.keeper.ClaimCapability(ctx, channelCap, ibctypes.ChannelCapabilityPath(portID, channelID)); err != nil {
-			return sdkerrors.Wrap(channel.ErrChannelCapabilityNotFound, err.Error())
-		}
+	// Claim channel capability passed back by IBC module
+	if err = am.keeper.ClaimCapability(ctx, channelCap, ibctypes.ChannelCapabilityPath(portID, channelID)); err != nil {
+		return sdkerrors.Wrap(channel.ErrChannelCapabilityNotFound, err.Error())
 	}
 
 	return err

--- a/packages/cosmic-swingset/x/swingset/internal/keeper/keeper.go
+++ b/packages/cosmic-swingset/x/swingset/internal/keeper/keeper.go
@@ -212,8 +212,7 @@ func (k Keeper) ChanCloseInit(ctx sdk.Context, portID, channelID string) error {
 
 // BindPort defines a wrapper function for the port Keeper's function in
 // order to expose it to the SwingSet IBC handler.
-// It also registers a route to the port.
-func (k Keeper) BindPort(ctx sdk.Context, portID string, mod porttypes.IBCModule) error {
+func (k Keeper) BindPort(ctx sdk.Context, portID string) error {
 	cap := k.portKeeper.BindPort(ctx, portID)
 	return k.ClaimCapability(ctx, cap, porttypes.PortPath(portID))
 }

--- a/packages/cosmic-swingset/x/swingset/internal/keeper/keeper.go
+++ b/packages/cosmic-swingset/x/swingset/internal/keeper/keeper.go
@@ -171,7 +171,8 @@ func (k Keeper) ChanOpenInit(ctx sdk.Context, order channelexported.Order, conne
 	portID, channelID, rPortID, rChannelID, version string,
 ) error {
 	capName := porttypes.PortPath(portID)
-	portCap, ok := k.scopedKeeper.GetCapability(ctx, capName)
+	fmt.Printf("FIGME: k.ChanOpenInit scopedKeeper %+v\n", k.scopedKeeper)
+	portCap, ok := k.GetCapability(ctx, capName)
 	if !ok {
 		return sdkerrors.Wrapf(porttypes.ErrInvalidPort, "could not retrieve port capability at: %s", capName)
 	}
@@ -193,7 +194,8 @@ func (k Keeper) SendPacket(ctx sdk.Context, packet channelexported.PacketI) erro
 	portID := packet.GetSourcePort()
 	channelID := packet.GetSourceChannel()
 	capName := ibctypes.ChannelCapabilityPath(portID, channelID)
-	chanCap, ok := k.scopedKeeper.GetCapability(ctx, capName)
+	fmt.Printf("FIGME: k.SendPacket scopedKeeper %+v\n", k.scopedKeeper)
+	chanCap, ok := k.GetCapability(ctx, capName)
 	if !ok {
 		return sdkerrors.Wrapf(channel.ErrChannelCapabilityNotFound, "could not retrieve channel capability at: %s", capName)
 	}
@@ -206,7 +208,8 @@ func (k Keeper) PacketExecuted(ctx sdk.Context, packet channelexported.PacketI, 
 	portID := packet.GetDestPort()
 	channelID := packet.GetDestChannel()
 	capName := ibctypes.ChannelCapabilityPath(portID, channelID)
-	chanCap, ok := k.scopedKeeper.GetCapability(ctx, capName)
+	fmt.Printf("FIGME: k.PacketExecuted scopedKeeper %+v\n", k.scopedKeeper)
+	chanCap, ok := k.GetCapability(ctx, capName)
 	if !ok {
 		return sdkerrors.Wrapf(channel.ErrChannelCapabilityNotFound, "could not retrieve channel capability at: %s", capName)
 	}
@@ -217,7 +220,8 @@ func (k Keeper) PacketExecuted(ctx sdk.Context, packet channelexported.PacketI, 
 // in order to expose it to the SwingSet IBC handler.
 func (k Keeper) ChanCloseInit(ctx sdk.Context, portID, channelID string) error {
 	capName := ibctypes.ChannelCapabilityPath(portID, channelID)
-	chanCap, ok := k.scopedKeeper.GetCapability(ctx, capName)
+	fmt.Printf("FIGME: k.ChanCloseInit scopedKeeper %+v\n", k.scopedKeeper)
+	chanCap, ok := k.GetCapability(ctx, capName)
 	if !ok {
 		return sdkerrors.Wrapf(channel.ErrChannelCapabilityNotFound, "could not retrieve channel capability at: %s", capName)
 	}
@@ -237,7 +241,7 @@ func (k Keeper) TimeoutExecuted(ctx sdk.Context, packet channelexported.PacketI)
 	portID := packet.GetSourcePort()
 	channelID := packet.GetSourceChannel()
 	capName := ibctypes.ChannelCapabilityPath(portID, channelID)
-	chanCap, ok := k.scopedKeeper.GetCapability(ctx, capName)
+	chanCap, ok := k.GetCapability(ctx, capName)
 	if !ok {
 		return sdkerrors.Wrapf(channel.ErrChannelCapabilityNotFound, "could not retrieve channel capability at: %s", capName)
 	}
@@ -247,5 +251,13 @@ func (k Keeper) TimeoutExecuted(ctx sdk.Context, packet channelexported.PacketI)
 // ClaimCapability allows the SwingSet module to claim a capability that IBC module
 // passes to it
 func (k Keeper) ClaimCapability(ctx sdk.Context, cap *capability.Capability, name string) error {
-	return k.scopedKeeper.ClaimCapability(ctx, cap, name)
+	fmt.Printf("FIGME: k.ClaimCapability %s scopedKeeper %+v\n", name, k.scopedKeeper)
+	err := k.scopedKeeper.ClaimCapability(ctx, cap, name)
+	fmt.Printf("FIGME: stored under %s\n", k.scopedKeeper.GetCapabilityName(ctx, cap))
+	return err
+}
+
+func (k Keeper) GetCapability(ctx sdk.Context, name string) (*capability.Capability, bool) {
+	fmt.Printf("FIGME: k.GetCapability %s scopedKeeper %+v\n", name, k.scopedKeeper)
+	return k.scopedKeeper.GetCapability(ctx, name)
 }

--- a/packages/eventual-send/src/index.d.ts
+++ b/packages/eventual-send/src/index.d.ts
@@ -3,19 +3,19 @@
 
 type Property = string | number | symbol;
 
-interface EHandler {
-  get(p: Promise<unknown>, name: Property): Promise<unknown>;
-  applyMethod(p: Promise<unknown>, name?: Property, args: unknown[]): Promise<unknown>;
+interface EHandler<T> {
+  get?: (p: T, name: Property) => any;
+  applyMethod?: (p: T, name?: Property, args: unknown[]) => any;
 }
 
 type HandledExecutor<R> = (
   resolveHandled: (value?: R) => void,
   rejectHandled: (reason?: unknown) => void,
-  resolveWithRemote: (remoteHandler: EHandler) => object,
+  resolveWithPresence: (presenceHandler: EHandler<{}>) => object,
 ) => void;
 
 interface HandledPromiseConstructor {
-  new<R> (executor: HandledExecutor<R>);
+  new<R> (executor: HandledExecutor<R>, unfulfilledHandler: EHandler<Promise<unknown>>);
   prototype: Promise<unknown>;
   applyFunction(target: unknown, args: unknown[]): Promise<unknown>;
   applyFunctionSendOnly(target: unknown, args: unknown[]): void;

--- a/packages/marshal/marshal.js
+++ b/packages/marshal/marshal.js
@@ -154,7 +154,7 @@ function isPassByCopyError(val) {
   }
 
   const {
-    message: { value: messageStr },
+    message: { value: messageStr } = { value: '' },
     // Allow but ignore only extraneous own `stack` property.
     // TODO: I began the variable below with "_". Why do I still need
     // to suppress the lint complaint?

--- a/packages/marshal/test/test-marshal.js
+++ b/packages/marshal/test/test-marshal.js
@@ -58,6 +58,17 @@ test('serialize static data', t => {
     });
   }
 
+  let emptyem;
+  try {
+    throw new Error();
+  } catch (e) {
+    emptyem = harden(e);
+  }
+  t.deepEqual(ser(emptyem), {
+    body: '{"@qclass":"error","name":"Error","message":""}',
+    slots: [],
+  });
+
   let em;
   try {
     throw new ReferenceError('msg');


### PR DESCRIPTION
Postpone outbound IBC channels, until they are activated by the relayer.  This allows the existing relayer implementation to "complete" the channels, as it currently cannot create circuits on demand.

We try to future-proof by sending our own `ChanOpenInit` when `.connect()` is called.  The implementation should be compatible with both "active/naive" and "passive" relayers.
