### PR TITLE
fix: demonstrate and fix a bug with mis-spelled liquidityTokenSupply

### DIFF
--- a/packages/zoe/src/contractSupport/bondingCurves.js
+++ b/packages/zoe/src/contractSupport/bondingCurves.js
@@ -1,5 +1,6 @@
 import harden from '@agoric/harden';
 
+import { assert, details } from '@agoric/assert';
 import { natSafeMath } from './safeMath';
 
 const { add, subtract, multiply, floorDivide } = natSafeMath;
@@ -39,6 +40,10 @@ export const getCurrentPrice = ({
   return harden({ outputExtent, newInputReserve, newOutputReserve });
 };
 
+function assertDefined(label, value) {
+  assert(value !== undefined, details`${label} value required`);
+}
+
 // Calculate how many liquidity tokens we should be minting to send back to the
 // user when adding liquidity. Calculations are based on the comparing the
 // inputExtent to the inputReserve. If the current supply is zero, just return
@@ -47,10 +52,14 @@ export const calcLiqExtentToMint = ({
   liqTokenSupply,
   inputExtent,
   inputReserve,
-}) =>
-  liqTokenSupply > 0
+}) => {
+  assertDefined('liqTokenSupply', liqTokenSupply);
+  assertDefined('inputExtent', inputExtent);
+  assertDefined('inputReserve', inputReserve);
+  return liqTokenSupply > 0
     ? floorDivide(multiply(inputExtent, liqTokenSupply), inputReserve)
     : inputExtent;
+};
 
 // Calculate how many underlying tokens (in the form of an extent) should be
 // returned when removing liquidity.
@@ -58,4 +67,10 @@ export const calcExtentToRemove = ({
   liqTokenSupply,
   poolExtent,
   liquidityExtentIn,
-}) => floorDivide(multiply(liquidityExtentIn, poolExtent), liqTokenSupply);
+}) => {
+  assertDefined('liqTokenSupply', liqTokenSupply);
+  assertDefined('liquidityExtentIn', liquidityExtentIn);
+  assertDefined('poolExtent', poolExtent);
+
+  return floorDivide(multiply(liquidityExtentIn, poolExtent), liqTokenSupply);
+};

--- a/packages/zoe/src/contracts/multipoolAutoswap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap.js
@@ -261,7 +261,7 @@ export const makeContract = harden(zcf => {
     // Calculate how many liquidity tokens we should be minting.
     const liquidityExtentOut = calcLiqExtentToMint(
       harden({
-        liquidityTokenSupply,
+        liqTokenSupply: liquidityTokenSupply,
         inputExtent: userAmounts[CENTRAL_TOKEN].extent,
         inputReserve: poolAmounts[CENTRAL_TOKEN].extent,
       }),

--- a/packages/zoe/test/unitTests/contractSupport/test-bondingCurves.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-bondingCurves.js
@@ -1,7 +1,10 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from 'tape-promise/tape';
 
-import { getCurrentPrice } from '../../../src/contractSupport';
+import {
+  getCurrentPrice,
+  calcLiqExtentToMint,
+} from '../../../src/contractSupport';
 
 const testGetPrice = (t, input, expectedOutput) => {
   const output = getCurrentPrice(input);
@@ -143,4 +146,44 @@ test('getCurrentPrice ok 6', t => {
   } catch (e) {
     t.assert(false, e);
   }
+});
+
+test('calculate extent to mint - positive supply', t => {
+  const res = calcLiqExtentToMint({
+    liqTokenSupply: 20,
+    inputExtent: 30,
+    inputReserve: 5,
+  });
+  t.equals(res, (20 * 30) / 5, 'When supply is present, floor(x*y/z)');
+  t.end();
+});
+
+test('calculate extent to mint - mispelled key', t => {
+  const res = calcLiqExtentToMint({
+    liquidityTokenSupply: 20,
+    inputExtent: 30,
+    inputReserve: 5,
+  });
+  t.equals(res, 30, 'When keyword is misspelled, inputExtent');
+  t.end();
+});
+
+test('calculate extent to mint - positive supply', t => {
+  const res = calcLiqExtentToMint({
+    liqTokenSupply: 5,
+    inputExtent: 8,
+    inputReserve: 7,
+  });
+  t.equals(res, 5, 'When supply is present, floor(x*y/z)');
+  t.end();
+});
+
+test('calculate extent to mint - no supply', t => {
+  const res = calcLiqExtentToMint({
+    liqTokenSupply: 0,
+    inputExtent: 30,
+    inputReserve: 5,
+  });
+  t.equals(res, 30, 'When the supply is empty, return inputExtent');
+  t.end();
 });

--- a/packages/zoe/test/unitTests/contractSupport/test-bondingCurves.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-bondingCurves.js
@@ -159,12 +159,15 @@ test('calculate extent to mint - positive supply', t => {
 });
 
 test('calculate extent to mint - mispelled key', t => {
-  const res = calcLiqExtentToMint({
-    liquidityTokenSupply: 20,
-    inputExtent: 30,
-    inputReserve: 5,
-  });
-  t.equals(res, 30, 'When keyword is misspelled, inputExtent');
+  t.throws(
+    () =>
+      calcLiqExtentToMint({
+        liquidityTokenSupply: 20,
+        inputExtent: 30,
+        inputReserve: 5,
+      }),
+    `calcLiqExtentToMint should throw if a key is misspelled`,
+  );
   t.end();
 });
 


### PR DESCRIPTION
In bondingCurves.js, `calcLiqExtentToMint()` and `calcLiqExtentToRemove()` destructure with `liqTokenSupply`, so `liquidityTokenSupply` doesn't work. Added tests and fixed code.

VSCode exposed the error once the typescript declarations were made more useful (PR for that coming shortly.)