### PR TITLE
add a GitHub Action script to update the hackathon branch

### DIFF
--- a/.github/workflows/update-hackathon-branch.yml
+++ b/.github/workflows/update-hackathon-branch.yml
@@ -1,0 +1,21 @@
+# when 'master' changes, update the 'hackathon' branch to match
+
+name: update-hackathon-branch
+
+# *only* run upon changes to 'master': ignore PRs and other branches
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  update-hackathon:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/github-script@0.9.0
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          let repo = { owner: 'Agoric', repo: 'agoric-sdk' };
+          let f = await github.git.getRef({ref: 'heads/master', ...repo});
+          let sha = f.data.object.sha;
+          await github.git.updateRef({ref:  'heads/hackathon-2020-04', sha, ...repo});


### PR DESCRIPTION
Once landed, this will trigger any time 'master' is changed, and will update
the hackathon-2020-04 branch to match.