### PR TITLE
docs: improve Zoe jsDoc annotations to support contract devs

### DIFF
--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -8,7 +8,7 @@ import { HandledPromise } from '@agoric/eventual-send';
  * @typedef {import('../zoe').Invite} Invite
  * @typedef {import('../zoe').OfferHook} OfferHook
  * @typedef {import('../zoe').CustomProperties} CustomProperties
- * @typedef {any} TODO Needs to be typed
+ * @typedef {import('../zoe').ContractFacet} ContractFacet
  */
 
 export const defaultRejectMsg = `The offer was invalid. Please check your refund.`;
@@ -17,8 +17,14 @@ export const defaultAcceptanceMsg = `The offer has been accepted. Once the contr
 const getKeys = obj => harden(Object.getOwnPropertyNames(obj || {}));
 const getKeysSorted = obj =>
   harden(Object.getOwnPropertyNames(obj || {}).sort());
-
-export const makeZoeHelpers = zcf => {
+/**
+ * @function makeZoeHelpers - makes an object with helper functions useful to zoe contracts.
+ *
+ * @param {ContractFacet} zcf
+ */
+// zcf only picks up the type if the param is in parens, which eslint dislikes
+// eslint-disable-next-line
+export const makeZoeHelpers = (zcf) => {
   const zoeService = zcf.getZoeService();
 
   const rejectOffer = (offerHandle, msg = defaultRejectMsg) => {

--- a/packages/zoe/src/contracts/atomicSwap.js
+++ b/packages/zoe/src/contracts/atomicSwap.js
@@ -3,6 +3,10 @@ import harden from '@agoric/harden';
 // Eventually will be importable from '@agoric/zoe-contract-support'
 import { makeZoeHelpers } from '../contractSupport';
 
+/**
+ * @typedef {import('../zoe').ContractFacet} ContractFacet
+ */
+
 // zcf is the Zoe Contract Facet, i.e. the contract-facing API of Zoe
 export const makeContract = harden(zcf => {
   const { swap, assertKeywords, inviteAnOffer } = makeZoeHelpers(zcf);

--- a/packages/zoe/src/contracts/multipoolAutoswap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /* eslint-disable no-use-before-define */
 import harden from '@agoric/harden';
 import produceIssuer from '@agoric/ertp';
@@ -12,6 +14,11 @@ import {
   calcExtentToRemove,
 } from '../contractSupport';
 
+/**
+ * @typedef {import('../zoe').ContractFacet} ContractFacet
+ * @typedef {import('@agoric/ertp/src/issuer').Amount} Amount
+ */
+
 // Autoswap is a rewrite of Uniswap. Please see the documentation for more
 // https://agoric.com/documentation/zoe/guide/contracts/autoswap.html
 
@@ -23,611 +30,624 @@ import {
 // would first use the pool (X, C) then the pool (Y, C). There are no
 // liquidity pools between two secondary tokens.
 
-export const makeContract = harden(zcf => {
-  // This contract must have a "central token" issuer in the terms.
-  const CENTRAL_TOKEN = 'CentralToken';
+export const makeContract = harden(
+  /** @param {ContractFacet} zcf */ zcf => {
+    // This contract must have a "central token" issuer in the terms.
+    const CENTRAL_TOKEN = 'CentralToken';
 
-  const getCentralTokenBrand = () => {
-    const {
-      terms: { CentralToken: centralTokenIssuer },
-    } = zcf.getInstanceRecord();
-    const { brand: centralTokenBrand } = zcf.getIssuerRecord(
-      centralTokenIssuer,
-    );
-    assert(
-      centralTokenBrand !== undefined,
-      details`centralTokenBrand must be present`,
-    );
-    return centralTokenBrand;
-  };
-  const centralTokenBrand = getCentralTokenBrand();
-
-  const {
-    rejectOffer,
-    makeEmptyOffer,
-    rejectIfNotProposal,
-    assertKeywords,
-    getKeys,
-  } = makeZoeHelpers(zcf);
-
-  // There must be one keyword at the start, which is equal to the
-  // value of CENTRAL_TOKEN
-  assertKeywords([CENTRAL_TOKEN]);
-
-  // We need to be able to retrieve information about the liquidity
-  // pools by tokenBrand. Key: tokenBrand Columns: poolHandle,
-  // tokenIssuer, liquidityMint, liquidityIssuer, tokenKeyword,
-  // liquidityKeyword, liquidityTokenSupply
-  const liquidityTable = makeTable(
-    makeValidateProperties(
-      harden([
-        'poolHandle',
-        'tokenIssuer',
-        'liquidityMint',
-        'liquidityIssuer',
-        'tokenKeyword',
-        'liquidityKeyword',
-        'liquidityTokenSupply',
-      ]),
-    ),
-  );
-
-  // Allows users to add new liquidity pools. `newTokenIssuer` and
-  // `newTokenKeyword` must not have been already used
-  const addPool = (newTokenIssuer, newTokenKeyword) => {
-    assertCapASCII(newTokenKeyword);
-    const { issuerKeywordRecord } = zcf.getInstanceRecord();
-    const keywords = Object.keys(issuerKeywordRecord);
-    const issuers = Object.values(issuerKeywordRecord);
-    assert(
-      !keywords.includes(newTokenKeyword),
-      details`newTokenKeyword must be unique`,
-    );
-    // TODO: handle newTokenIssuer as a potential promise
-    assert(
-      !issuers.includes(newTokenIssuer),
-      details`newTokenIssuer must not be already present`,
-    );
-    const newLiquidityKeyword = `${newTokenKeyword}Liquidity`;
-    assert(
-      !keywords.includes(newLiquidityKeyword),
-      details`newLiquidityKeyword must be unique`,
-    );
-    const { mint: liquidityMint, issuer: liquidityIssuer } = produceIssuer(
-      newLiquidityKeyword,
-    );
-    return Promise.all([
-      zcf.addNewIssuer(newTokenIssuer, newTokenKeyword),
-      makeEmptyOffer(),
-      zcf.addNewIssuer(liquidityIssuer, newLiquidityKeyword),
-    ]).then(([newTokenIssuerRecord, poolHandle]) => {
-      // The third element of the above array is intentionally
-      // ignored, since we already have the liquidityIssuer and mint.
-      const amountMaths = zcf.getAmountMaths(harden([newTokenKeyword]));
+    const getCentralTokenBrand = () => {
+      const {
+        terms: { CentralToken: centralTokenIssuer },
+      } = zcf.getInstanceRecord();
+      const { brand: centralTokenBrand } = zcf.getIssuerRecord(
+        centralTokenIssuer,
+      );
       assert(
-        amountMaths[newTokenKeyword].getMathHelpersName() === 'nat',
-        details`tokenIssuer must have natMathHelpers`,
+        centralTokenBrand !== undefined,
+        details`centralTokenBrand must be present`,
       );
-      liquidityTable.create(
-        harden({
-          poolHandle,
-          tokenIssuer: newTokenIssuer,
-          liquidityMint,
-          liquidityIssuer,
-          tokenKeyword: newTokenKeyword,
-          liquidityKeyword: newLiquidityKeyword,
-          liquidityTokenSupply: 0,
-        }),
-        newTokenIssuerRecord.brand,
+      return centralTokenBrand;
+    };
+    const centralTokenBrand = getCentralTokenBrand();
+
+    const {
+      rejectOffer,
+      makeEmptyOffer,
+      rejectIfNotProposal,
+      assertKeywords,
+      getKeys,
+    } = makeZoeHelpers(zcf);
+
+    // There must be one keyword at the start, which is equal to the
+    // value of CENTRAL_TOKEN
+    assertKeywords([CENTRAL_TOKEN]);
+
+    // We need to be able to retrieve information about the liquidity
+    // pools by tokenBrand. Key: tokenBrand Columns: poolHandle,
+    // tokenIssuer, liquidityMint, liquidityIssuer, tokenKeyword,
+    // liquidityKeyword, liquidityTokenSupply
+    const liquidityTable = makeTable(
+      makeValidateProperties(
+        harden([
+          'poolHandle',
+          'tokenIssuer',
+          'liquidityMint',
+          'liquidityIssuer',
+          'tokenKeyword',
+          'liquidityKeyword',
+          'liquidityTokenSupply',
+        ]),
+      ),
+    );
+
+    // Allows users to add new liquidity pools. `newTokenIssuer` and
+    // `newTokenKeyword` must not have been already used
+    const addPool = (newTokenIssuer, newTokenKeyword) => {
+      assertCapASCII(newTokenKeyword);
+      const { issuerKeywordRecord } = zcf.getInstanceRecord();
+      const keywords = Object.keys(issuerKeywordRecord);
+      const issuers = Object.values(issuerKeywordRecord);
+      assert(
+        !keywords.includes(newTokenKeyword),
+        details`newTokenKeyword must be unique`,
       );
-      return `liquidity pool for ${newTokenKeyword} added`;
-    });
-  };
-
-  // The secondary token brand is used as the key of liquidityTable
-  // rows, and we use it to look up the pool allocation. We only
-  // return the keywords for the secondary token, the central token,
-  // and the associated liquidity token.
-  const getPoolAllocation = tokenBrand => {
-    const { poolHandle, tokenKeyword, liquidityKeyword } = liquidityTable.get(
-      tokenBrand,
-    );
-    return zcf.getCurrentAllocation(
-      poolHandle,
-      harden([tokenKeyword, CENTRAL_TOKEN, liquidityKeyword]),
-    );
-  };
-
-  const doGetCurrentPrice = ({
-    amountIn,
-    keywordIn,
-    keywordOut,
-    secondaryBrand,
-  }) => {
-    const poolAmounts = getPoolAllocation(secondaryBrand);
-    const { outputExtent } = getCurrentPrice(
-      harden({
-        inputExtent: amountIn.extent,
-        inputReserve: poolAmounts[keywordIn].extent,
-        outputReserve: poolAmounts[keywordOut].extent,
-      }),
-    );
-    const amountMaths = zcf.getAmountMaths(harden([keywordOut]));
-    return amountMaths[keywordOut].make(outputExtent);
-  };
-
-  const doSwap = ({
-    userAllocation,
-    keywordIn,
-    keywordOut,
-    secondaryBrand,
-  }) => {
-    const { poolHandle } = liquidityTable.get(secondaryBrand);
-    const poolAllocation = getPoolAllocation(secondaryBrand);
-    const { outputExtent, newInputReserve, newOutputReserve } = getCurrentPrice(
-      harden({
-        inputExtent: userAllocation[keywordIn].extent,
-        inputReserve: poolAllocation[keywordIn].extent,
-        outputReserve: poolAllocation[keywordOut].extent,
-      }),
-    );
-    const amountMaths = zcf.getAmountMaths([keywordIn, keywordOut]);
-    const amountOut = amountMaths[keywordOut].make(outputExtent);
-
-    const newUserAmounts = harden({
-      [keywordIn]: amountMaths[keywordIn].getEmpty(),
-      [keywordOut]: amountOut,
-    });
-
-    const newPoolAmounts = harden({
-      [keywordIn]: amountMaths[keywordIn].make(newInputReserve),
-      [keywordOut]: amountMaths[keywordOut].make(newOutputReserve),
-    });
-
-    return harden({ poolHandle, newUserAmounts, newPoolAmounts });
-  };
-
-  const getSecondaryBrand = ({ offerHandle, isAddLiquidity }) => {
-    const { proposal } = zcf.getOffer(offerHandle);
-    const key = isAddLiquidity ? 'give' : 'want';
-    const {
-      // eslint-disable-next-line no-unused-vars
-      [key]: { [CENTRAL_TOKEN]: centralAmount, ...tokenAmountKeywordRecord },
-    } = proposal;
-    const values = Object.values(tokenAmountKeywordRecord);
-    if (values.length !== 1) {
-      rejectOffer(offerHandle, `only one secondary brand should be present`);
-    }
-    return values[0].brand;
-  };
-
-  const makeAdd = amountMaths => (key, obj1, obj2) =>
-    amountMaths[key].add(obj1[key], obj2[key]);
-
-  const makeSubtract = amountMaths => (key, obj1, obj2) =>
-    amountMaths[key].subtract(obj1[key], obj2[key]);
-
-  const makeGetAllEmpty = amountMaths => keywords => {
-    const newObj = {};
-    keywords.forEach(
-      keyword => (newObj[keyword] = amountMaths[keyword].getEmpty()),
-    );
-    // intentionally not hardened
-    return newObj;
-  };
-
-  const rejectIfNotTokenBrand = (inviteHandle, brand) => {
-    if (!liquidityTable.has(brand)) {
-      rejectOffer(inviteHandle, `brand ${brand} was not recognized`);
-    }
-  };
-
-  const addLiquidityHook = offerHandle => {
-    // Get the brand of the secondary token so we can identify the liquidity pool.
-    const secondaryTokenBrand = getSecondaryBrand(
-      harden({
-        offerHandle,
-        isAddLiquidity: true,
-      }),
-    );
-
-    const {
-      tokenKeyword,
-      liquidityKeyword,
-      liquidityTokenSupply,
-      liquidityMint,
-      poolHandle,
-    } = liquidityTable.get(secondaryTokenBrand);
-
-    // These are the keywords that will be used several times within this method
-    const liquidityKeys = harden([
-      CENTRAL_TOKEN,
-      tokenKeyword,
-      liquidityKeyword,
-    ]);
-
-    const expected = harden({
-      give: {
-        [CENTRAL_TOKEN]: null,
-        [tokenKeyword]: null,
-      },
-      want: { [liquidityKeyword]: null },
-    });
-    rejectIfNotProposal(offerHandle, expected);
-
-    const userAmounts = zcf.getCurrentAllocation(offerHandle, liquidityKeys);
-    const poolAmounts = getPoolAllocation(secondaryTokenBrand);
-
-    // Calculate how many liquidity tokens we should be minting.
-    const liquidityExtentOut = calcLiqExtentToMint(
-      harden({
-        liqTokenSupply: liquidityTokenSupply,
-        inputExtent: userAmounts[CENTRAL_TOKEN].extent,
-        inputReserve: poolAmounts[CENTRAL_TOKEN].extent,
-      }),
-    );
-    const amountMaths = zcf.getAmountMaths(liquidityKeys);
-
-    const liquidityAmountOut = amountMaths[liquidityKeyword].make(
-      liquidityExtentOut,
-    );
-
-    const liquidityPaymentP = liquidityMint.mintPayment(liquidityAmountOut);
-
-    // The contract needs to escrow the liquidity payment with Zoe
-    // to eventually pay as a payout to the user
-    const tempProposal = harden({
-      give: { [liquidityKeyword]: liquidityAmountOut },
-    });
-
-    let tempLiqHandle;
-
-    const tempLiqOfferHook = tmpHandle => (tempLiqHandle = tmpHandle);
-    const tempLiqInvite = zcf.makeInvitation(tempLiqOfferHook);
-    const zoeService = zcf.getZoeService();
-    // We update the liquidityTokenSupply before the next turn
-    liquidityTable.update(secondaryTokenBrand, {
-      liquidityTokenSupply: liquidityTokenSupply + liquidityExtentOut,
-    });
-    return zoeService
-      .offer(
-        tempLiqInvite,
-        tempProposal,
-        harden({ [liquidityKeyword]: liquidityPaymentP }),
-      )
-      .then(() => {
-        const add = makeAdd(amountMaths);
-        const getAllEmpty = makeGetAllEmpty(amountMaths);
-        const newPoolAmounts = harden({
-          [CENTRAL_TOKEN]: add(CENTRAL_TOKEN, userAmounts, poolAmounts),
-          [tokenKeyword]: add(tokenKeyword, userAmounts, poolAmounts),
-          [liquidityKeyword]: poolAmounts[liquidityKeyword],
-        });
-
-        const newUserAmounts = getAllEmpty(liquidityKeys);
-        newUserAmounts[liquidityKeyword] = liquidityAmountOut;
-
-        const newTempLiqAmounts = getAllEmpty(liquidityKeys);
-
-        zcf.reallocate(
-          harden([offerHandle, poolHandle, tempLiqHandle]),
-          harden([newUserAmounts, newPoolAmounts, newTempLiqAmounts]),
-          liquidityKeys,
+      // TODO: handle newTokenIssuer as a potential promise
+      assert(
+        !issuers.includes(newTokenIssuer),
+        details`newTokenIssuer must not be already present`,
+      );
+      const newLiquidityKeyword = `${newTokenKeyword}Liquidity`;
+      assert(
+        !keywords.includes(newLiquidityKeyword),
+        details`newLiquidityKeyword must be unique`,
+      );
+      const { mint: liquidityMint, issuer: liquidityIssuer } = produceIssuer(
+        newLiquidityKeyword,
+      );
+      return Promise.all([
+        zcf.addNewIssuer(newTokenIssuer, newTokenKeyword),
+        makeEmptyOffer(),
+        zcf.addNewIssuer(liquidityIssuer, newLiquidityKeyword),
+      ]).then(([newTokenIssuerRecord, poolHandle]) => {
+        // The third element of the above array is intentionally
+        // ignored, since we already have the liquidityIssuer and mint.
+        const amountMaths = zcf.getAmountMaths(harden([newTokenKeyword]));
+        assert(
+          amountMaths[newTokenKeyword].getMathHelpersName() === 'nat',
+          details`tokenIssuer must have natMathHelpers`,
         );
-        zcf.complete(harden([offerHandle, tempLiqHandle]));
-        return 'Added liquidity.';
-      });
-  };
-
-  const removeLiquidityHook = offerHandle => {
-    const secondaryTokenBrand = getSecondaryBrand(
-      harden({ offerHandle, isAddLiquidity: false }),
-    );
-
-    const {
-      tokenKeyword,
-      liquidityKeyword,
-      liquidityTokenSupply,
-      poolHandle,
-    } = liquidityTable.get(secondaryTokenBrand);
-
-    const expected = harden({
-      want: { [CENTRAL_TOKEN]: null, [tokenKeyword]: null },
-      give: { [liquidityKeyword]: null },
-    });
-    rejectIfNotProposal(offerHandle, expected);
-
-    const liquidityKeys = harden([
-      CENTRAL_TOKEN,
-      tokenKeyword,
-      liquidityKeyword,
-    ]);
-
-    const userAllocation = zcf.getCurrentAllocation(offerHandle, liquidityKeys);
-    const poolAllocation = getPoolAllocation(secondaryTokenBrand);
-    const liquidityExtentIn = userAllocation[liquidityKeyword].extent;
-
-    const amountMaths = zcf.getAmountMaths(liquidityKeys);
-
-    const subtract = makeSubtract(amountMaths);
-
-    const newUserAmounts = harden({
-      [CENTRAL_TOKEN]: amountMaths[CENTRAL_TOKEN].make(
-        calcExtentToRemove(
+        liquidityTable.create(
           harden({
-            liqTokenSupply: liquidityTokenSupply,
-            poolExtent: poolAllocation[CENTRAL_TOKEN].extent,
-            liquidityExtentIn,
+            poolHandle,
+            tokenIssuer: newTokenIssuer,
+            liquidityMint,
+            liquidityIssuer,
+            tokenKeyword: newTokenKeyword,
+            liquidityKeyword: newLiquidityKeyword,
+            liquidityTokenSupply: 0,
           }),
-        ),
-      ),
-      [tokenKeyword]: amountMaths[tokenKeyword].make(
-        calcExtentToRemove(
-          harden({
-            liqTokenSupply: liquidityTokenSupply,
-            poolExtent: poolAllocation[tokenKeyword].extent,
-            liquidityExtentIn,
-          }),
-        ),
-      ),
-      [liquidityKeyword]: amountMaths[liquidityKeyword].getEmpty(),
-    });
-
-    const newPoolAmounts = harden({
-      [CENTRAL_TOKEN]: subtract(CENTRAL_TOKEN, poolAllocation, newUserAmounts),
-      [tokenKeyword]: subtract(tokenKeyword, poolAllocation, newUserAmounts),
-      [liquidityKeyword]: amountMaths[liquidityKeyword].add(
-        poolAllocation[liquidityKeyword],
-        amountMaths[liquidityKeyword].make(liquidityExtentIn),
-      ),
-    });
-
-    liquidityTable.update(secondaryTokenBrand, {
-      liquidityTokenSupply: liquidityTokenSupply - liquidityExtentIn,
-    });
-
-    zcf.reallocate(
-      harden([offerHandle, poolHandle]),
-      harden([newUserAmounts, newPoolAmounts]),
-      liquidityKeys,
-    );
-    zcf.complete(harden([offerHandle]));
-    return 'Liquidity successfully removed.';
-  };
-
-  const swapHook = offerHandle => {
-    const { proposal } = zcf.getOffer(offerHandle);
-    const getKeywordAndBrand = amountKeywordRecord => {
-      const keywords = getKeys(amountKeywordRecord);
-      if (keywords.length !== 1) {
-        rejectOffer(
-          offerHandle,
-          `A swap requires giving one type of token for another, ${keywords.length} tokens were provided.`,
+          newTokenIssuerRecord.brand,
         );
-      }
-      return harden({
-        keyword: keywords[0],
-        brand: Object.values(amountKeywordRecord)[0].brand,
+        return `liquidity pool for ${newTokenKeyword} added`;
       });
     };
 
-    const { keyword: keywordIn, brand: brandIn } = getKeywordAndBrand(
-      proposal.give,
-    );
-    const { keyword: keywordOut, brand: brandOut } = getKeywordAndBrand(
-      proposal.want,
-    );
+    // The secondary token brand is used as the key of liquidityTable
+    // rows, and we use it to look up the pool allocation. We only
+    // return the keywords for the secondary token, the central token,
+    // and the associated liquidity token.
+    const getPoolAllocation = tokenBrand => {
+      const { poolHandle, tokenKeyword, liquidityKeyword } = liquidityTable.get(
+        tokenBrand,
+      );
+      return zcf.getCurrentAllocation(
+        poolHandle,
+        harden([tokenKeyword, CENTRAL_TOKEN, liquidityKeyword]),
+      );
+    };
 
-    const expected = harden({
-      give: { [keywordIn]: null },
-      want: { [keywordOut]: null },
-    });
-    rejectIfNotProposal(offerHandle, expected);
-
-    // we could be swapping (1) central to secondary, (2) secondary to central, or (3) secondary to secondary.
-
-    // 1) central to secondary
-    if (brandIn === centralTokenBrand) {
-      rejectIfNotTokenBrand(offerHandle, brandOut);
-
-      const keywords = harden([keywordIn, keywordOut]);
-      const { poolHandle, newUserAmounts, newPoolAmounts } = doSwap(
+    const doGetCurrentPrice = ({
+      amountIn,
+      keywordIn,
+      keywordOut,
+      secondaryBrand,
+    }) => {
+      const poolAmounts = getPoolAllocation(secondaryBrand);
+      const { outputExtent } = getCurrentPrice(
         harden({
-          userAllocation: zcf.getCurrentAllocation(offerHandle, keywords),
-          keywordIn,
-          keywordOut,
-          secondaryBrand: brandOut,
+          inputExtent: amountIn.extent,
+          inputReserve: poolAmounts[keywordIn].extent,
+          outputReserve: poolAmounts[keywordOut].extent,
         }),
       );
-      zcf.reallocate(
-        harden([offerHandle, poolHandle]),
-        harden([newUserAmounts, newPoolAmounts]),
-        keywords,
-      );
-      zcf.complete(harden([offerHandle]));
-      return `Swap successfully completed.`;
+      const amountMaths = zcf.getAmountMaths(harden([keywordOut]));
+      return amountMaths[keywordOut].make(outputExtent);
+    };
 
-      // eslint-disable-next-line no-else-return
-    } else if (brandOut === centralTokenBrand) {
-      // 2) secondary to central
-      rejectIfNotTokenBrand(offerHandle, brandIn);
-      const keywords = harden([keywordIn, keywordOut]);
-      const { poolHandle, newUserAmounts, newPoolAmounts } = doSwap(
-        harden({
-          userAllocation: zcf.getCurrentAllocation(offerHandle, keywords),
-          keywordIn,
-          keywordOut,
-          secondaryBrand: brandIn,
-        }),
-      );
-      zcf.reallocate(
-        harden([offerHandle, poolHandle]),
-        harden([newUserAmounts, newPoolAmounts]),
-        keywords,
-      );
-      zcf.complete(harden([offerHandle]));
-      return `Swap successfully completed.`;
-    } else {
-      // 3) secondary to secondary
-      rejectIfNotTokenBrand(offerHandle, brandIn);
-      rejectIfNotTokenBrand(offerHandle, brandOut);
-
+    const doSwap = ({
+      userAllocation,
+      keywordIn,
+      keywordOut,
+      secondaryBrand,
+    }) => {
+      const { poolHandle } = liquidityTable.get(secondaryBrand);
+      const poolAllocation = getPoolAllocation(secondaryBrand);
       const {
-        poolHandle: poolHandleA,
-        newUserAmounts: newUserAmountsA,
-        newPoolAmounts: newPoolAmountsA,
-      } = doSwap(
+        outputExtent,
+        newInputReserve,
+        newOutputReserve,
+      } = getCurrentPrice(
         harden({
-          userAllocation: zcf.getCurrentAllocation(
-            offerHandle,
-            harden([keywordIn, CENTRAL_TOKEN]),
-          ),
-          keywordIn,
-          keywordOut: CENTRAL_TOKEN,
-          secondaryBrand: brandIn,
+          inputExtent: userAllocation[keywordIn].extent,
+          inputReserve: poolAllocation[keywordIn].extent,
+          outputReserve: poolAllocation[keywordOut].extent,
         }),
       );
-      const {
-        poolHandle: poolHandleB,
-        newUserAmounts,
-        newPoolAmounts: newPoolAmountsB,
-      } = doSwap(
-        harden({
-          userAllocation: newUserAmountsA,
-          keywordIn: CENTRAL_TOKEN,
-          keywordOut,
-          secondaryBrand: brandOut,
-        }),
-      );
-      const keywords = harden([keywordIn, keywordOut, CENTRAL_TOKEN]);
-      const amountMaths = zcf.getAmountMaths(keywords);
-      const finalPoolAmountsA = {
-        ...newPoolAmountsA,
-        [keywordOut]: amountMaths[keywordOut].getEmpty(),
-      };
-      const finalPoolAmountsB = {
-        ...newPoolAmountsB,
+      const amountMaths = zcf.getAmountMaths([keywordIn, keywordOut]);
+      const amountOut = amountMaths[keywordOut].make(outputExtent);
+
+      const newUserAmounts = harden({
         [keywordIn]: amountMaths[keywordIn].getEmpty(),
-      };
-      const finalUserAmounts = {
-        ...newUserAmounts,
-        [keywordIn]: newUserAmountsA[keywordIn],
-      };
+        [keywordOut]: amountOut,
+      });
+
+      const newPoolAmounts = harden({
+        [keywordIn]: amountMaths[keywordIn].make(newInputReserve),
+        [keywordOut]: amountMaths[keywordOut].make(newOutputReserve),
+      });
+
+      return harden({ poolHandle, newUserAmounts, newPoolAmounts });
+    };
+
+    const getSecondaryBrand = ({ offerHandle, isAddLiquidity }) => {
+      const { proposal } = zcf.getOffer(offerHandle);
+      const key = isAddLiquidity ? 'give' : 'want';
+      const {
+        // eslint-disable-next-line no-unused-vars
+        [key]: { [CENTRAL_TOKEN]: centralAmount, ...tokenAmountKeywordRecord },
+      } = proposal;
+      const values = Object.values(tokenAmountKeywordRecord);
+      if (values.length !== 1) {
+        rejectOffer(offerHandle, `only one secondary brand should be present`);
+      }
+      return values[0].brand;
+    };
+
+    const makeAdd = amountMaths => (key, obj1, obj2) =>
+      amountMaths[key].add(obj1[key], obj2[key]);
+
+    const makeSubtract = amountMaths => (key, obj1, obj2) =>
+      amountMaths[key].subtract(obj1[key], obj2[key]);
+
+    const makeGetAllEmpty = amountMaths => keywords => {
+      const newObj = {};
+      keywords.forEach(
+        keyword => (newObj[keyword] = amountMaths[keyword].getEmpty()),
+      );
+      // intentionally not hardened
+      return newObj;
+    };
+
+    const rejectIfNotTokenBrand = (inviteHandle, brand) => {
+      if (!liquidityTable.has(brand)) {
+        rejectOffer(inviteHandle, `brand ${brand} was not recognized`);
+      }
+    };
+
+    const addLiquidityHook = offerHandle => {
+      // Get the brand of the secondary token so we can identify the liquidity pool.
+      const secondaryTokenBrand = getSecondaryBrand(
+        harden({
+          offerHandle,
+          isAddLiquidity: true,
+        }),
+      );
+
+      const {
+        tokenKeyword,
+        liquidityKeyword,
+        liquidityTokenSupply,
+        liquidityMint,
+        poolHandle,
+      } = liquidityTable.get(secondaryTokenBrand);
+
+      // These are the keywords that will be used several times within this method
+      const liquidityKeys = harden([
+        CENTRAL_TOKEN,
+        tokenKeyword,
+        liquidityKeyword,
+      ]);
+
+      const expected = harden({
+        give: {
+          [CENTRAL_TOKEN]: null,
+          [tokenKeyword]: null,
+        },
+        want: { [liquidityKeyword]: null },
+      });
+      rejectIfNotProposal(offerHandle, expected);
+
+      const userAmounts = zcf.getCurrentAllocation(offerHandle, liquidityKeys);
+      const poolAmounts = getPoolAllocation(secondaryTokenBrand);
+
+      // Calculate how many liquidity tokens we should be minting.
+      const liquidityExtentOut = calcLiqExtentToMint(
+        harden({
+          liqTokenSupply: liquidityTokenSupply,
+          inputExtent: userAmounts[CENTRAL_TOKEN].extent,
+          inputReserve: poolAmounts[CENTRAL_TOKEN].extent,
+        }),
+      );
+      const amountMaths = zcf.getAmountMaths(liquidityKeys);
+
+      const liquidityAmountOut = amountMaths[liquidityKeyword].make(
+        liquidityExtentOut,
+      );
+
+      const liquidityPaymentP = liquidityMint.mintPayment(liquidityAmountOut);
+
+      // The contract needs to escrow the liquidity payment with Zoe
+      // to eventually pay as a payout to the user
+      const tempProposal = harden({
+        give: { [liquidityKeyword]: liquidityAmountOut },
+      });
+
+      let tempLiqHandle;
+
+      const tempLiqOfferHook = tmpHandle => (tempLiqHandle = tmpHandle);
+      const tempLiqInvite = zcf.makeInvitation(tempLiqOfferHook);
+      const zoeService = zcf.getZoeService();
+      // We update the liquidityTokenSupply before the next turn
+      liquidityTable.update(secondaryTokenBrand, {
+        liquidityTokenSupply: liquidityTokenSupply + liquidityExtentOut,
+      });
+      return zoeService
+        .offer(
+          tempLiqInvite,
+          tempProposal,
+          harden({ [liquidityKeyword]: liquidityPaymentP }),
+        )
+        .then(() => {
+          const add = makeAdd(amountMaths);
+          const getAllEmpty = makeGetAllEmpty(amountMaths);
+          const newPoolAmounts = harden({
+            [CENTRAL_TOKEN]: add(CENTRAL_TOKEN, userAmounts, poolAmounts),
+            [tokenKeyword]: add(tokenKeyword, userAmounts, poolAmounts),
+            [liquidityKeyword]: poolAmounts[liquidityKeyword],
+          });
+
+          const newUserAmounts = getAllEmpty(liquidityKeys);
+          newUserAmounts[liquidityKeyword] = liquidityAmountOut;
+
+          const newTempLiqAmounts = getAllEmpty(liquidityKeys);
+
+          zcf.reallocate(
+            harden([offerHandle, poolHandle, tempLiqHandle]),
+            harden([newUserAmounts, newPoolAmounts, newTempLiqAmounts]),
+            liquidityKeys,
+          );
+          zcf.complete(harden([offerHandle, tempLiqHandle]));
+          return 'Added liquidity.';
+        });
+    };
+
+    const removeLiquidityHook = offerHandle => {
+      const secondaryTokenBrand = getSecondaryBrand(
+        harden({ offerHandle, isAddLiquidity: false }),
+      );
+
+      const {
+        tokenKeyword,
+        liquidityKeyword,
+        liquidityTokenSupply,
+        poolHandle,
+      } = liquidityTable.get(secondaryTokenBrand);
+
+      const expected = harden({
+        want: { [CENTRAL_TOKEN]: null, [tokenKeyword]: null },
+        give: { [liquidityKeyword]: null },
+      });
+      rejectIfNotProposal(offerHandle, expected);
+
+      const liquidityKeys = harden([
+        CENTRAL_TOKEN,
+        tokenKeyword,
+        liquidityKeyword,
+      ]);
+
+      const userAllocation = zcf.getCurrentAllocation(
+        offerHandle,
+        liquidityKeys,
+      );
+      const poolAllocation = getPoolAllocation(secondaryTokenBrand);
+      const liquidityExtentIn = userAllocation[liquidityKeyword].extent;
+
+      const amountMaths = zcf.getAmountMaths(liquidityKeys);
+
+      const subtract = makeSubtract(amountMaths);
+
+      const newUserAmounts = harden({
+        [CENTRAL_TOKEN]: amountMaths[CENTRAL_TOKEN].make(
+          calcExtentToRemove(
+            harden({
+              liqTokenSupply: liquidityTokenSupply,
+              poolExtent: poolAllocation[CENTRAL_TOKEN].extent,
+              liquidityExtentIn,
+            }),
+          ),
+        ),
+        [tokenKeyword]: amountMaths[tokenKeyword].make(
+          calcExtentToRemove(
+            harden({
+              liqTokenSupply: liquidityTokenSupply,
+              poolExtent: poolAllocation[tokenKeyword].extent,
+              liquidityExtentIn,
+            }),
+          ),
+        ),
+        [liquidityKeyword]: amountMaths[liquidityKeyword].getEmpty(),
+      });
+
+      const newPoolAmounts = harden({
+        [CENTRAL_TOKEN]: subtract(
+          CENTRAL_TOKEN,
+          poolAllocation,
+          newUserAmounts,
+        ),
+        [tokenKeyword]: subtract(tokenKeyword, poolAllocation, newUserAmounts),
+        [liquidityKeyword]: amountMaths[liquidityKeyword].add(
+          poolAllocation[liquidityKeyword],
+          amountMaths[liquidityKeyword].make(liquidityExtentIn),
+        ),
+      });
+
+      liquidityTable.update(secondaryTokenBrand, {
+        liquidityTokenSupply: liquidityTokenSupply - liquidityExtentIn,
+      });
+
       zcf.reallocate(
-        harden([poolHandleA, poolHandleB, offerHandle]),
-        harden([finalPoolAmountsA, finalPoolAmountsB, finalUserAmounts]),
-        keywords,
+        harden([offerHandle, poolHandle]),
+        harden([newUserAmounts, newPoolAmounts]),
+        liquidityKeys,
       );
       zcf.complete(harden([offerHandle]));
-      return `Swap successfully completed.`;
-    }
-  };
+      return 'Liquidity successfully removed.';
+    };
 
-  const makeAddLiquidityInvite = () =>
-    zcf.makeInvitation(addLiquidityHook, {
-      inviteDesc: 'multipool autoswap add liquidity',
-    });
-
-  return harden({
-    invite: makeAddLiquidityInvite(),
-    publicAPI: {
-      getBrandKeywordRecord: () => {
-        const { issuerKeywordRecord } = zcf.getInstanceRecord();
-        const brandKeywordRecord = {};
-        Object.entries(issuerKeywordRecord).forEach(([keyword, issuer]) => {
-          const { brand } = zcf.getIssuerRecord(issuer);
-          brandKeywordRecord[keyword] = brand;
-        });
-        return harden(brandKeywordRecord);
-      },
-      getKeywordForBrand: brand => {
-        assert(
-          liquidityTable.has(brand),
-          details`There is no pool for this brand. To create a pool, call 'addPool'`,
-        );
-        return liquidityTable.get(brand).tokenKeyword;
-      },
-      addPool,
-      getPoolAllocation,
-      getLiquidityIssuer: tokenBrand =>
-        liquidityTable.get(tokenBrand).liquidityIssuer,
-      /**
-       * `getCurrentPrice` calculates the result of a trade, given a certain
-       * amount of digital assets in.
-       * @param {object} amountIn - the amount of digital assets to be
-       * sent in
-       */
-      getCurrentPrice: (amountIn, brandOut) => {
-        const brandIn = amountIn.brand;
-        // brandIn could either be the central token brand, or one of
-        // the secondary token brands
-
-        // CentralToken to SecondaryToken
-        if (brandIn === centralTokenBrand) {
-          assert(
-            liquidityTable.has(brandOut),
-            details`brandOut ${brandOut} was not recognized`,
-          );
-          return doGetCurrentPrice(
-            harden({
-              amountIn,
-              keywordIn: CENTRAL_TOKEN,
-              keywordOut: liquidityTable.get(brandOut).tokenKeyword,
-              secondaryBrand: brandOut,
-            }),
-          );
-          // eslint-disable-next-line no-else-return
-        } else if (brandOut === centralTokenBrand) {
-          // SecondaryToken to CentralToken
-          assert(
-            liquidityTable.has(brandIn),
-            details`amountIn brand ${amountIn} was not recognized`,
-          );
-          return doGetCurrentPrice(
-            harden({
-              amountIn,
-              keywordIn: liquidityTable.get(brandIn).tokenKeyword,
-              keywordOut: CENTRAL_TOKEN,
-              secondaryBrand: brandIn,
-            }),
-          );
-        } else {
-          // SecondaryToken to SecondaryToken
-          assert(
-            liquidityTable.has(brandIn) && liquidityTable.has(brandOut),
-            details`amountIn brand ${brandIn} or brandOut ${brandOut} was not recognized`,
-          );
-
-          // We must do two consecutive `doGetCurrentPrice` calls: from
-          // the brandIn to the central token, then from the central
-          // token to the brandOut
-          const centralTokenAmount = doGetCurrentPrice(
-            harden({
-              amountIn,
-              keywordIn: liquidityTable.get(brandIn).tokenKeyword,
-              keywordOut: CENTRAL_TOKEN,
-              secondaryBrand: brandIn,
-            }),
-          );
-          return doGetCurrentPrice(
-            harden({
-              amountIn: centralTokenAmount,
-              keywordIn: CENTRAL_TOKEN,
-              keywordOut: liquidityTable.get(brandOut).tokenKeyword,
-              secondaryBrand: brandOut,
-            }),
+    const swapHook = offerHandle => {
+      const { proposal } = zcf.getOffer(offerHandle);
+      const getKeywordAndBrand = amountKeywordRecord => {
+        const keywords = getKeys(amountKeywordRecord);
+        if (keywords.length !== 1) {
+          rejectOffer(
+            offerHandle,
+            `A swap requires giving one type of token for another, ${keywords.length} tokens were provided.`,
           );
         }
+        return harden({
+          keyword: keywords[0],
+          brand: Object.values(amountKeywordRecord)[0].brand,
+        });
+      };
+
+      const { keyword: keywordIn, brand: brandIn } = getKeywordAndBrand(
+        proposal.give,
+      );
+      const { keyword: keywordOut, brand: brandOut } = getKeywordAndBrand(
+        proposal.want,
+      );
+
+      const expected = harden({
+        give: { [keywordIn]: null },
+        want: { [keywordOut]: null },
+      });
+      rejectIfNotProposal(offerHandle, expected);
+
+      // we could be swapping (1) central to secondary, (2) secondary to central, or (3) secondary to secondary.
+
+      // 1) central to secondary
+      if (brandIn === centralTokenBrand) {
+        rejectIfNotTokenBrand(offerHandle, brandOut);
+
+        const keywords = harden([keywordIn, keywordOut]);
+        const { poolHandle, newUserAmounts, newPoolAmounts } = doSwap(
+          harden({
+            userAllocation: zcf.getCurrentAllocation(offerHandle, keywords),
+            keywordIn,
+            keywordOut,
+            secondaryBrand: brandOut,
+          }),
+        );
+        zcf.reallocate(
+          harden([offerHandle, poolHandle]),
+          harden([newUserAmounts, newPoolAmounts]),
+          keywords,
+        );
+        zcf.complete(harden([offerHandle]));
+        return `Swap successfully completed.`;
+
+        // eslint-disable-next-line no-else-return
+      } else if (brandOut === centralTokenBrand) {
+        // 2) secondary to central
+        rejectIfNotTokenBrand(offerHandle, brandIn);
+        const keywords = harden([keywordIn, keywordOut]);
+        const { poolHandle, newUserAmounts, newPoolAmounts } = doSwap(
+          harden({
+            userAllocation: zcf.getCurrentAllocation(offerHandle, keywords),
+            keywordIn,
+            keywordOut,
+            secondaryBrand: brandIn,
+          }),
+        );
+        zcf.reallocate(
+          harden([offerHandle, poolHandle]),
+          harden([newUserAmounts, newPoolAmounts]),
+          keywords,
+        );
+        zcf.complete(harden([offerHandle]));
+        return `Swap successfully completed.`;
+      } else {
+        // 3) secondary to secondary
+        rejectIfNotTokenBrand(offerHandle, brandIn);
+        rejectIfNotTokenBrand(offerHandle, brandOut);
+
+        const {
+          poolHandle: poolHandleA,
+          newUserAmounts: newUserAmountsA,
+          newPoolAmounts: newPoolAmountsA,
+        } = doSwap(
+          harden({
+            userAllocation: zcf.getCurrentAllocation(
+              offerHandle,
+              harden([keywordIn, CENTRAL_TOKEN]),
+            ),
+            keywordIn,
+            keywordOut: CENTRAL_TOKEN,
+            secondaryBrand: brandIn,
+          }),
+        );
+        const {
+          poolHandle: poolHandleB,
+          newUserAmounts,
+          newPoolAmounts: newPoolAmountsB,
+        } = doSwap(
+          harden({
+            userAllocation: newUserAmountsA,
+            keywordIn: CENTRAL_TOKEN,
+            keywordOut,
+            secondaryBrand: brandOut,
+          }),
+        );
+        const keywords = harden([keywordIn, keywordOut, CENTRAL_TOKEN]);
+        const amountMaths = zcf.getAmountMaths(keywords);
+        const finalPoolAmountsA = {
+          ...newPoolAmountsA,
+          [keywordOut]: amountMaths[keywordOut].getEmpty(),
+        };
+        const finalPoolAmountsB = {
+          ...newPoolAmountsB,
+          [keywordIn]: amountMaths[keywordIn].getEmpty(),
+        };
+        const finalUserAmounts = {
+          ...newUserAmounts,
+          [keywordIn]: newUserAmountsA[keywordIn],
+        };
+        zcf.reallocate(
+          harden([poolHandleA, poolHandleB, offerHandle]),
+          harden([finalPoolAmountsA, finalPoolAmountsB, finalUserAmounts]),
+          keywords,
+        );
+        zcf.complete(harden([offerHandle]));
+        return `Swap successfully completed.`;
+      }
+    };
+
+    const makeAddLiquidityInvite = () =>
+      zcf.makeInvitation(addLiquidityHook, {
+        inviteDesc: 'multipool autoswap add liquidity',
+      });
+
+    return harden({
+      invite: makeAddLiquidityInvite(),
+      publicAPI: {
+        getBrandKeywordRecord: () => {
+          const { issuerKeywordRecord } = zcf.getInstanceRecord();
+          const brandKeywordRecord = {};
+          Object.entries(issuerKeywordRecord).forEach(([keyword, issuer]) => {
+            const { brand } = zcf.getIssuerRecord(issuer);
+            brandKeywordRecord[keyword] = brand;
+          });
+          return harden(brandKeywordRecord);
+        },
+        getKeywordForBrand: brand => {
+          assert(
+            liquidityTable.has(brand),
+            details`There is no pool for this brand. To create a pool, call 'addPool'`,
+          );
+          return liquidityTable.get(brand).tokenKeyword;
+        },
+        addPool,
+        getPoolAllocation,
+        getLiquidityIssuer: tokenBrand =>
+          liquidityTable.get(tokenBrand).liquidityIssuer,
+        /**
+         * `getCurrentPrice` calculates the result of a trade, given a certain
+         * amount of digital assets in.
+         * @param {object} amountIn - the amount of digital assets to be
+         * sent in
+         */
+        getCurrentPrice: (amountIn, brandOut) => {
+          const brandIn = amountIn.brand;
+          // brandIn could either be the central token brand, or one of
+          // the secondary token brands
+
+          // CentralToken to SecondaryToken
+          if (brandIn === centralTokenBrand) {
+            assert(
+              liquidityTable.has(brandOut),
+              details`brandOut ${brandOut} was not recognized`,
+            );
+            return doGetCurrentPrice(
+              harden({
+                amountIn,
+                keywordIn: CENTRAL_TOKEN,
+                keywordOut: liquidityTable.get(brandOut).tokenKeyword,
+                secondaryBrand: brandOut,
+              }),
+            );
+            // eslint-disable-next-line no-else-return
+          } else if (brandOut === centralTokenBrand) {
+            // SecondaryToken to CentralToken
+            assert(
+              liquidityTable.has(brandIn),
+              details`amountIn brand ${amountIn} was not recognized`,
+            );
+            return doGetCurrentPrice(
+              harden({
+                amountIn,
+                keywordIn: liquidityTable.get(brandIn).tokenKeyword,
+                keywordOut: CENTRAL_TOKEN,
+                secondaryBrand: brandIn,
+              }),
+            );
+          } else {
+            // SecondaryToken to SecondaryToken
+            assert(
+              liquidityTable.has(brandIn) && liquidityTable.has(brandOut),
+              details`amountIn brand ${brandIn} or brandOut ${brandOut} was not recognized`,
+            );
+
+            // We must do two consecutive `doGetCurrentPrice` calls: from
+            // the brandIn to the central token, then from the central
+            // token to the brandOut
+            const centralTokenAmount = doGetCurrentPrice(
+              harden({
+                amountIn,
+                keywordIn: liquidityTable.get(brandIn).tokenKeyword,
+                keywordOut: CENTRAL_TOKEN,
+                secondaryBrand: brandIn,
+              }),
+            );
+            return doGetCurrentPrice(
+              harden({
+                amountIn: centralTokenAmount,
+                keywordIn: CENTRAL_TOKEN,
+                keywordOut: liquidityTable.get(brandOut).tokenKeyword,
+                secondaryBrand: brandOut,
+              }),
+            );
+          }
+        },
+        makeSwapInvite: () =>
+          zcf.makeInvitation(swapHook, {
+            inviteDesc: 'autoswap swap',
+          }),
+        makeAddLiquidityInvite,
+        makeRemoveLiquidityInvite: () =>
+          zcf.makeInvitation(removeLiquidityHook, {
+            inviteDesc: 'autoswap remove liquidity',
+          }),
       },
-      makeSwapInvite: () =>
-        zcf.makeInvitation(swapHook, {
-          inviteDesc: 'autoswap swap',
-        }),
-      makeAddLiquidityInvite,
-      makeRemoveLiquidityInvite: () =>
-        zcf.makeInvitation(removeLiquidityHook, {
-          inviteDesc: 'autoswap remove liquidity',
-        }),
-    },
-  });
-});
+    });
+  },
+);

--- a/packages/zoe/src/contracts/simpleExchange.js
+++ b/packages/zoe/src/contracts/simpleExchange.js
@@ -1,6 +1,12 @@
+// @ts-check
+
 import harden from '@agoric/harden';
 import { produceNotifier } from '@agoric/notifier';
 import { makeZoeHelpers, defaultAcceptanceMsg } from '../contractSupport';
+
+/**
+ * @typedef {import('../zoe').ContractFacet} ContractFacet
+ */
 
 /**
  * The SimpleExchange uses Asset and Price as its keywords. In usage,
@@ -14,134 +20,135 @@ import { makeZoeHelpers, defaultAcceptanceMsg } from '../contractSupport';
  * Price is a limit that may be improved on. This simple exchange does
  * not partially fill orders.
  */
-// zcf is the Zoe Contract Facet, i.e. the contract-facing API of Zoe
-export const makeContract = harden(zcf => {
-  let sellOfferHandles = [];
-  let buyOfferHandles = [];
-  const { notifier, updater } = produceNotifier();
+export const makeContract = harden(
+  /** @param {ContractFacet} zcf */ zcf => {
+    let sellOfferHandles = [];
+    let buyOfferHandles = [];
+    const { notifier, updater } = produceNotifier();
 
-  const {
-    rejectOffer,
-    checkIfProposal,
-    swap,
-    canTradeWith,
-    getActiveOffers,
-    assertKeywords,
-    inviteAnOffer,
-  } = makeZoeHelpers(zcf);
+    const {
+      rejectOffer,
+      checkIfProposal,
+      swap,
+      canTradeWith,
+      getActiveOffers,
+      assertKeywords,
+      inviteAnOffer,
+    } = makeZoeHelpers(zcf);
 
-  assertKeywords(harden(['Asset', 'Price']));
+    assertKeywords(harden(['Asset', 'Price']));
 
-  function flattenOffer(o) {
-    return {
-      want: o.proposal.want,
-      give: o.proposal.give,
-    };
-  }
+    function flattenOffer(o) {
+      return {
+        want: o.proposal.want,
+        give: o.proposal.give,
+      };
+    }
 
-  function flattenOrders(offerHandles) {
-    const result = zcf
-      .getOffers(zcf.getOfferStatuses(offerHandles).active)
-      .map(offerRecord => flattenOffer(offerRecord));
-    return result;
-  }
+    function flattenOrders(offerHandles) {
+      const result = zcf
+        .getOffers(zcf.getOfferStatuses(offerHandles).active)
+        .map(offerRecord => flattenOffer(offerRecord));
+      return result;
+    }
 
-  function getBookOrders() {
-    return {
-      buys: flattenOrders(buyOfferHandles),
-      sells: flattenOrders(sellOfferHandles),
-    };
-  }
+    function getBookOrders() {
+      return {
+        buys: flattenOrders(buyOfferHandles),
+        sells: flattenOrders(sellOfferHandles),
+      };
+    }
 
-  function getOffer(offerHandle) {
-    for (const handle of [...sellOfferHandles, ...buyOfferHandles]) {
-      if (offerHandle === handle) {
-        return flattenOffer(getActiveOffers([offerHandle])[0]);
+    function getOffer(offerHandle) {
+      for (const handle of [...sellOfferHandles, ...buyOfferHandles]) {
+        if (offerHandle === handle) {
+          return flattenOffer(getActiveOffers([offerHandle])[0]);
+        }
       }
+      return 'not an active offer';
     }
-    return 'not an active offer';
-  }
 
-  // Tell the notifier that there has been a change to the book orders
-  function bookOrdersChanged() {
-    updater.updateState(getBookOrders());
-  }
+    // Tell the notifier that there has been a change to the book orders
+    function bookOrdersChanged() {
+      updater.updateState(getBookOrders());
+    }
 
-  // If there's an existing offer that this offer is a match for, make the trade
-  // and return the handle for the matched offer. If not, return undefined, so
-  // the caller can know to add the new offer to the book.
-  function swapIfCanTrade(offerHandles, offerHandle) {
-    for (const iHandle of offerHandles) {
-      if (canTradeWith(offerHandle, iHandle)) {
-        swap(offerHandle, iHandle);
-        // return handle to remove
-        return iHandle;
+    // If there's an existing offer that this offer is a match for, make the trade
+    // and return the handle for the matched offer. If not, return undefined, so
+    // the caller can know to add the new offer to the book.
+    function swapIfCanTrade(offerHandles, offerHandle) {
+      for (const iHandle of offerHandles) {
+        if (canTradeWith(offerHandle, iHandle)) {
+          swap(offerHandle, iHandle);
+          // return handle to remove
+          return iHandle;
+        }
       }
-    }
-    return undefined;
-  }
-
-  // try to swap offerHandle with one of the counterOffers. If it works, remove
-  // the matching offer and return the remaining counterOffers. If there's no
-  // matching offer, add the offerHandle to the coOffers, and return the
-  // unmodified counterOfffers
-  function swapIfCanTradeAndUpdateBook(counterOffers, coOffers, offerHandle) {
-    const handle = swapIfCanTrade(counterOffers, offerHandle);
-    if (handle) {
-      // remove the matched offer.
-      counterOffers = counterOffers.filter(value => value !== handle);
-    } else {
-      // Save the order in the book
-      coOffers.push(offerHandle);
+      return undefined;
     }
 
-    return counterOffers;
-  }
+    // try to swap offerHandle with one of the counterOffers. If it works, remove
+    // the matching offer and return the remaining counterOffers. If there's no
+    // matching offer, add the offerHandle to the coOffers, and return the
+    // unmodified counterOfffers
+    function swapIfCanTradeAndUpdateBook(counterOffers, coOffers, offerHandle) {
+      const handle = swapIfCanTrade(counterOffers, offerHandle);
+      if (handle) {
+        // remove the matched offer.
+        counterOffers = counterOffers.filter(value => value !== handle);
+      } else {
+        // Save the order in the book
+        coOffers.push(offerHandle);
+      }
 
-  const exchangeOfferHook = offerHandle => {
-    const buyAssetForPrice = harden({
-      give: { Price: null },
-      want: { Asset: null },
-    });
-    const sellAssetForPrice = harden({
-      give: { Asset: null },
-      want: { Price: null },
-    });
-    if (checkIfProposal(offerHandle, sellAssetForPrice)) {
-      buyOfferHandles = swapIfCanTradeAndUpdateBook(
-        buyOfferHandles,
-        sellOfferHandles,
-        offerHandle,
-      );
-      /* eslint-disable no-else-return */
-    } else if (checkIfProposal(offerHandle, buyAssetForPrice)) {
-      sellOfferHandles = swapIfCanTradeAndUpdateBook(
-        sellOfferHandles,
-        buyOfferHandles,
-        offerHandle,
-      );
-    } else {
-      // Eject because the offer must be invalid
-      return rejectOffer(offerHandle);
+      return counterOffers;
     }
-    bookOrdersChanged();
-    return defaultAcceptanceMsg;
-  };
 
-  const makeExchangeInvite = () =>
-    inviteAnOffer({
-      offerHook: exchangeOfferHook,
-      customProperties: {
-        inviteDesc: 'exchange',
+    const exchangeOfferHook = offerHandle => {
+      const buyAssetForPrice = harden({
+        give: { Price: null },
+        want: { Asset: null },
+      });
+      const sellAssetForPrice = harden({
+        give: { Asset: null },
+        want: { Price: null },
+      });
+      if (checkIfProposal(offerHandle, sellAssetForPrice)) {
+        buyOfferHandles = swapIfCanTradeAndUpdateBook(
+          buyOfferHandles,
+          sellOfferHandles,
+          offerHandle,
+        );
+        /* eslint-disable no-else-return */
+      } else if (checkIfProposal(offerHandle, buyAssetForPrice)) {
+        sellOfferHandles = swapIfCanTradeAndUpdateBook(
+          sellOfferHandles,
+          buyOfferHandles,
+          offerHandle,
+        );
+      } else {
+        // Eject because the offer must be invalid
+        return rejectOffer(offerHandle);
+      }
+      bookOrdersChanged();
+      return defaultAcceptanceMsg;
+    };
+
+    const makeExchangeInvite = () =>
+      inviteAnOffer({
+        offerHook: exchangeOfferHook,
+        customProperties: {
+          inviteDesc: 'exchange',
+        },
+      });
+
+    return harden({
+      invite: makeExchangeInvite(),
+      publicAPI: {
+        makeInvite: makeExchangeInvite,
+        getOffer,
+        getNotifier: () => notifier,
       },
     });
-
-  return harden({
-    invite: makeExchangeInvite(),
-    publicAPI: {
-      makeInvite: makeExchangeInvite,
-      getOffer,
-      getNotifier: () => notifier,
-    },
-  });
-});
+  },
+);

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -29,8 +29,11 @@ import { makeTables } from './state';
 // TODO Update types and documentatuon to describe the new API
 /**
  * Zoe uses ERTP, the Electronic Rights Transfer Protocol
- *
+ */
+
+/**
  * @typedef {import('@agoric/ertp/src/issuer').Amount} Amount
+ * @typedef {import('@agoric/ertp/src/issuer').Brand} Brand
  * @typedef {import('@agoric/ertp/src/amountMath').AmountMath} AmountMath
  * @typedef {import('@agoric/ertp/src/issuer').Payment} Payment
  * @typedef {import('@agoric/ertp/src/issuer').Issuer} Issuer
@@ -38,13 +41,24 @@ import { makeTables } from './state';
  *
  * @typedef {any} TODO Needs to be typed
  * @typedef {string} Keyword
- * @typedef {Object} InstallationHandle
+ * @typedef {{}} InstallationHandle
  * @typedef {Object.<Keyword,Issuer>} IssuerKeywordRecord
+ */
+
+/**
+ * There doesn't seem to be any way in JSDoc to specify a record consisting of
+ * an arbitrary number of key-value pairs of specified type.
  * @typedef {Object.<Keyword,Payment>} PaymentKeywordRecord
  */
 
 /**
  * @typedef {Object} ZoeService
+ * Zoe provides a framework for deploying and working with smart contracts. It
+ * is accessed as a long-lived and well-trusted service that enforces offer
+ * safety for the contracts that use it. Zoe has a single `inviteIssuer` for
+ * the entirety of its lifetime. By having a reference to Zoe, a user can get
+ * the `inviteIssuer` and thus validate any `invite` they receive from someone
+ * else.
  * @property {() => Issuer} getInviteIssuer
  * Zoe has a single `inviteIssuer` for the entirety of its lifetime.
  * By having a reference to Zoe, a user can get the `inviteIssuer`
@@ -97,13 +111,14 @@ import { makeTables } from './state';
  * is expected for every rule under `give`.
  *
  * @property {(offerHandle: OfferHandle) => boolean} isOfferActive
- * @property {(offerHandles: OfferHandle[]) => Offer[]} getOffers
- * @property {(offerHandle: OfferHandle) => Offer} getOffer
- * @property {(installationHandle: InstallationHandle) => InstallationRecord} getInstallation
+ * @property {(offerHandles: OfferHandle[]) => OfferRecord[]} getOffers
+ * @property {(offerHandle: OfferHandle) => OfferRecord} getOffer
+ * @property {(installationHandle: InstallationHandle) => string} getInstallation
+ * Get the source code for the installed contract. Throws an error if the
+ * installationHandle is not found.
  *
  * @typedef {any} OfferOutcome
  * A contract-specific value that is returned by the OfferHook.
- *
  *
  * @typedef {Object} OfferResultRecord This is returned by a call to `offer` on Zoe.
  * @property {OfferHandle} offerHandle
@@ -119,12 +134,10 @@ import { makeTables } from './state';
  * @property {(() => undefined)} [cancelObj]
  * cancelObj will only be present if exitKind was 'onDemand'
  *
- * @typedef {Object} Proposal
- * @property {AmountKeywordRecord} want
- * @property {AmountKeywordRecord} give
- * @property {ExitRule} exit
+ * @typedef {{give?:AmountKeywordRecord,want?:AmountKeywordRecord,exit?:ExitRule}} Proposal
  *
  * @typedef {Object.<Keyword,Amount>} AmountKeywordRecord
+ *
  * The keys are keywords, and the values are amounts. For example:
  * { Asset: amountMath.make(5), Price: amountMath.make(9) }
  *
@@ -140,6 +153,14 @@ import { makeTables } from './state';
  */
 
 /**
+ * @typedef {Object} Invite
+ * An invitation to participate in a Zoe contract.
+ * Invites are Payments, so they can be transferred, stored in Purses, and
+ * verified. Only Zoe can create new Invites.
+ * @property {() => Brand} getAllegedBrand
+ */
+
+/**
  * @callback MakeContract The type exported from a Zoe contract
  * @param {ContractFacet} zcf The Zoe Contract Facet
  * @returns {ContractInstance} The instantiated contract
@@ -147,36 +168,59 @@ import { makeTables } from './state';
  * @typedef {Object} ContractInstance
  * @property {Invite} invite The closely-held administrative invite
  * @property {Object.<string,function>} publicAPI Public functions that can be called on the instance
- *
- * @typedef {Object} InstanceHandle
- * @typedef {Object} OfferHandle
- * @typedef {Object} InviteHandle
- *
- * @typedef {TODO} Invite
+ */
+
+/**
+ * @typedef {{}} InstanceHandle - an opaque handle for a contract instance
+ * @typedef {{}} OfferHandle - an opaque handle for an offer
+ * @typedef {{}} InviteHandle - an opaque handle for an invite
  * @typedef {Object} CustomProperties
- * @typedef {TODO} Offer
- * @typedef {TODO} InstanceRecord
+ *
+ * @typedef {object} OfferRecord
+ * @property {OfferHandle} handle - opaque identifier for the offer, used as the key
+ * @property {InstanceHandle} instanceHandle - opaque identifier for the instance
+ * @property {Proposal} proposal - the offer proposal (including want, give, exit)
+ * @property {AmountKeywordRecord} amounts - the amountKeywordRecord that will be turned into payouts
+ *
+ * @typedef {object} InstanceRecord
+ * @property {InstanceHandle} handle - opaque identifier for the instance, used as the table key
+ * @property {InstallationHandle} installationHandle - opaque identifier for the installation
+ * @property {Object.<string,function>} publicAPI - the invite-free publicly accessible API for the contract
+ * @property {Object} terms - contract parameters
+ * @property {IssuerKeywordRecord} issuerKeywordRecord - record with keywords keys, issuer values
+ *
  * @typedef {TODO} IssuerRecord
- * @typedef {TODO} InstallationRecord
+ *
+ * @typedef {Object} InstallationRecord
+ * @property {{}} handle - opaque identifier, used as the table key
+ * @property {string} installation - contract code
+ *
  * @typedef {Object} OfferStatus
  * @property {OfferHandle[]} active
  * @property {OfferHandle[]} inactive
  *
  * @typedef {Keyword[]} SparseKeywords
- * @typedef {Object.<Keyword,Amount>} Allocation
- *
- * @typedef {Object} ContractFacet The Zoe interface specific to a contract instance
+ * @typedef {{[Keyword:string]:Amount}} Allocation
+ */
+
+/**
+ * @typedef {Object} ContractFacet
+ * The Zoe interface specific to a contract instance.
+ * The Zoe Contract Facet is an API object used by running contract instances to
+ * access the Zoe state for that instance. The Zoe Contract Facet is accessed
+ * synchronously from within the contract, and usually is referred to in code as
+ * zcf.
  * @property {Reallocate} reallocate Propose a reallocation of extents per offer
  * @property {Complete} complete Complete an offer
  * @property {MakeInvitation} makeInvitation
  * @property {AddNewIssuer} addNewIssuer
  * @property {() => ZoeService} getZoeService
  * @property {() => Issuer} getInviteIssuer
- * @property {(sparseKeywords: SparseKeywords) => Object.<Keyword,AmountMath>} getAmountMaths
+ * @property {(sparseKeywords: SparseKeywords) => {[Keyword:string]:AmountMath}} getAmountMaths
  * @property {(offerHandles: OfferHandle[]) => { active: OfferStatus[], inactive: OfferStatus[] }} getOfferStatuses
  * @property {(offerHandle: OfferHandle) => boolean} isOfferActive
- * @property {(offerHandles: OfferHandle[]) => Offer[]} getOffers
- * @property {(offerHandle: OfferHandle) => Offer} getOffer
+ * @property {(offerHandles: OfferHandle[]) => OfferRecord[]} getOffers
+ * @property {(offerHandle: OfferHandle) => OfferRecord} getOffer
  * @property {(offerHandle: OfferHandle, sparseKeywords: SparseKeywords) => Allocation} getCurrentAllocation
  * @property {(offerHandles: OfferHandle[], sparseKeywords: SparseKeywords) => Allocation[]} getCurrentAllocations
  * @property {() => InstanceRecord} getInstanceRecord
@@ -199,8 +243,8 @@ import { makeTables } from './state';
  * any newAmountKeywordRecords have keywords that are not in
  * sparseKeywords.
  *
- * @param  {object[]} offerHandles An array of offerHandles
- * @param  {AmountKeywordRecord[]} newAmountKeywordRecords An
+ * @param  {OfferHandle[]} offerHandles An array of offerHandles
+ * @param  {AmountKeywordRecord} newAmountKeywordRecords An
  * array of amountKeywordRecords  - objects with keyword keys
  * and amount values, with one keywordRecord per offerHandle.
  * @param  {Keyword[]} sparseKeywords An array of string
@@ -214,8 +258,8 @@ import { makeTables } from './state';
  * reallocations that conserve rights and are 'offer-safe', we
  * don't need to do those checks at this step and can assume
  * that the invariants hold.
- * @param  {object[]} offerHandles - an array of offerHandles
- * @returns {TODO}
+ * @param  {OfferHandle[]} offerHandles - an array of offerHandles
+ * @returns {undefined}
  *
  * @callback MakeInvitation
  * Make a credible Zoe invite for a particular smart contract
@@ -230,7 +274,7 @@ import { makeTables } from './state';
  * @param  {OfferHook} offerHook - a function that will be handed the
  * offerHandle at the right time, and returns a contract-specific
  * OfferOutcome which will be put in the OfferResultRecord.
- * @param  {CustomProperties} customProperties - an object of
+ * @param  {CustomProperties} [customProperties] - an object of
  * information to include in the extent, as defined by the smart
  * contract
  * @returns {Invite}
@@ -380,9 +424,6 @@ const makeZoe = (additionalEndowments = {}) => {
       return inviteMint.mintPayment(inviteAmount);
     };
 
-    /**
-     * @type {ContractFacet}
-     */
     const contractFacet = harden({
       reallocate: (offerHandles, newAmountKeywordRecords, sparseKeywords) => {
         assertOffersHaveInstanceHandle(offerHandles, instanceHandle);
@@ -647,7 +688,7 @@ const makeZoe = (additionalEndowments = {}) => {
       /**
        * Redeem the invite to receive a payout promise and an
        * outcome promise.
-       * @param {Payment} invite - an invite (ERTP payment) to join a
+       * @param {Invite} invite - an invite (ERTP payment) to join a
        * Zoe smart contract instance
        * @param  {object?} proposal - the proposal, a record
        * with properties `want`, `give`, and `exit`. The keys of

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -42,13 +42,13 @@ import { makeTables } from './state';
  * @typedef {any} TODO Needs to be typed
  * @typedef {string} Keyword
  * @typedef {{}} InstallationHandle
- * @typedef {Object.<Keyword,Issuer>} IssuerKeywordRecord
+ * @typedef {Object.<string,Issuer>} IssuerKeywordRecord
  */
 
 /**
  * There doesn't seem to be any way in JSDoc to specify a record consisting of
  * an arbitrary number of key-value pairs of specified type.
- * @typedef {Object.<Keyword,Payment>} PaymentKeywordRecord
+ * @typedef {Object.<string,Payment>} PaymentKeywordRecord
  */
 
 /**
@@ -136,7 +136,7 @@ import { makeTables } from './state';
  *
  * @typedef {{give?:AmountKeywordRecord,want?:AmountKeywordRecord,exit?:ExitRule}} Proposal
  *
- * @typedef {Object.<Keyword,Amount>} AmountKeywordRecord
+ * @typedef {Object.<string,Amount>} AmountKeywordRecord
  *
  * The keys are keywords, and the values are amounts. For example:
  * { Asset: amountMath.make(5), Price: amountMath.make(9) }
@@ -353,7 +353,7 @@ const makeZoe = (additionalEndowments = {}) => {
   };
 
   const getAmountMaths = (instanceHandle, sparseKeywords) => {
-    const amountMathKeywordRecord = /** @type {Object.<Keyword,AmountMath>} */ ({});
+    const amountMathKeywordRecord = /** @type {Object.<string,AmountMath>} */ ({});
     const { issuerKeywordRecord } = instanceTable.get(instanceHandle);
     sparseKeywords.forEach(keyword => {
       const issuer = issuerKeywordRecord[keyword];


### PR DESCRIPTION
Improve jsDoc annotations in Zoe and ZoeHelpers to support contract devs.

import more types
declare zcf's type in the contracts
use OfferRecord (vs. Offer) where warranted
typedef for Invite that works.
typedef for opaque handles is {}. Typedefs are apparently aliases, so they're not distinct. typedef to Object with no properties is identical to `any`, which is less helpful.

JSDoc/Typedef doesn't seem to have a way of saying a record with an arbitrary number of typed Key-Value pairs
I describe one pair and append "|any".

If Invite is typedef Payment, then VSCode shows it as Payment everywhere. We typedef it as an Object with a getAllegedBrand, so it's a distinct type.

**This is a reprise of #1019, which was intended to be merged to master, but was instead merged into a closed parent branch.**  #1019 was approved and everything.