### PR TITLE
docs: update typeof reallocate() param, and annotate contract

### DIFF
--- a/packages/zoe/src/contracts/multipoolAutoswap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap.js
@@ -17,6 +17,7 @@ import {
 /**
  * @typedef {import('../zoe').ContractFacet} ContractFacet
  * @typedef {import('@agoric/ertp/src/issuer').Amount} Amount
+ * @typedef {import('../zoe').AmountKeywordRecords} AmountKeywordRecords
  */
 
 // Autoswap is a rewrite of Uniswap. Please see the documentation for more
@@ -321,9 +322,12 @@ export const makeContract = harden(
 
           const newTempLiqAmounts = getAllEmpty(liquidityKeys);
 
+          const keywordAmountRecords = /** @type {AmountKeywordRecords} */ (harden(
+            [newUserAmounts, newPoolAmounts, newTempLiqAmounts],
+          ));
           zcf.reallocate(
             harden([offerHandle, poolHandle, tempLiqHandle]),
-            harden([newUserAmounts, newPoolAmounts, newTempLiqAmounts]),
+            keywordAmountRecords,
             liquidityKeys,
           );
           zcf.complete(harden([offerHandle, tempLiqHandle]));

--- a/packages/zoe/src/objArrayConversion.js
+++ b/packages/zoe/src/objArrayConversion.js
@@ -55,7 +55,10 @@ export const objToArrayAssertFilled = (obj, keywords) => {
 
 // return a new object with only the keys in subsetKeywords. `obj`
 // must have values for all the `subsetKeywords`.
-export const filterObj = (obj, subsetKeywords) => {
+export const filterObj = /** @type {function<T>(T, string[]): T} */ (
+  obj,
+  subsetKeywords,
+) => {
   const newObj = {};
   subsetKeywords.forEach(keyword => {
     assert(
@@ -67,9 +70,15 @@ export const filterObj = (obj, subsetKeywords) => {
   return newObj;
 };
 
+/**
+ * @typedef {import('./zoe').Allocation} Allocation
+ * @typedef {import('@agoric/ertp/src/amountMath').AmountMath} AmountMath
+ * @typedef {{[Keyword:string]:AmountMath}} KeywordAmountMathRecord
+ */
+
 // return a new object with only the keys in subsetKeywords, but fill
 // in empty amounts for any key that is undefined in the original obj
-export const filterFillAmounts = (
+export const filterFillAmounts = /** @type {function(Allocation, string[], KeywordAmountMathRecord):Allocation} */ (
   obj,
   subsetKeywords,
   amountMathKeywordRecord,

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -141,6 +141,8 @@ import { makeTables } from './state';
  * The keys are keywords, and the values are amounts. For example:
  * { Asset: amountMath.make(5), Price: amountMath.make(9) }
  *
+ * @typedef {AmountKeywordRecord[]} AmountKeywordRecords
+ *
  * @typedef {Object} ExitRule
  * The possible keys are 'waived', 'onDemand', and 'afterDeadline'.
  * `timer` and `deadline` only are used for the `afterDeadline` key.
@@ -244,7 +246,7 @@ import { makeTables } from './state';
  * sparseKeywords.
  *
  * @param  {OfferHandle[]} offerHandles An array of offerHandles
- * @param  {AmountKeywordRecord} newAmountKeywordRecords An
+ * @param  {AmountKeywordRecords} newAmountKeywordRecords An
  * array of amountKeywordRecords  - objects with keyword keys
  * and amount values, with one keywordRecord per offerHandle.
  * @param  {Keyword[]} sparseKeywords An array of string

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -261,7 +261,7 @@ import { makeTables } from './state';
  * don't need to do those checks at this step and can assume
  * that the invariants hold.
  * @param  {OfferHandle[]} offerHandles - an array of offerHandles
- * @returns {undefined}
+ * @returns {void}
  *
  * @callback MakeInvitation
  * Make a credible Zoe invite for a particular smart contract


### PR DESCRIPTION
reallocate's `newAmountKeywordRecords` is an array of
`AmountKeywordRecord`s. Corrected the JSDoc declaration.

VSCode wasn't happy with the call on reallocate in multipoolAutoswap,
so I added just enough declaration for it to pass.