### PR TITLE
[Zoe] Add new method: `zcf.initPublicAPI` and remove publicAPI from the return values of makeContract

### DIFF
--- a/packages/zoe/src/contracts/atomicSwap.js
+++ b/packages/zoe/src/contracts/atomicSwap.js
@@ -35,11 +35,9 @@ export const makeContract = harden(
       want: { Price: null },
     });
 
-    return harden({
-      invite: zcf.makeInvitation(
-        checkHook(makeMatchingInvite, firstOfferExpected),
-        'firstOffer',
-      ),
-    });
+    return zcf.makeInvitation(
+      checkHook(makeMatchingInvite, firstOfferExpected),
+      'firstOffer',
+    );
   },
 );

--- a/packages/zoe/src/contracts/automaticRefund.js
+++ b/packages/zoe/src/contracts/automaticRefund.js
@@ -25,12 +25,13 @@ export const makeContract = harden(
     const makeRefundInvite = () =>
       zcf.makeInvitation(refundOfferHook, 'getRefund');
 
-    return harden({
-      invite: makeRefundInvite(),
-      publicAPI: {
+    zcf.initPublicAPI(
+      harden({
         getOffersCount: () => offersCount,
         makeInvite: makeRefundInvite,
-      },
-    });
+      }),
+    );
+
+    return makeRefundInvite();
   },
 );

--- a/packages/zoe/src/contracts/autoswap.js
+++ b/packages/zoe/src/contracts/autoswap.js
@@ -256,9 +256,8 @@ export const makeContract = harden(
             'autoswap add liquidity',
           );
 
-        return harden({
-          invite: makeAddLiquidityInvite(),
-          publicAPI: {
+        zcf.initPublicAPI(
+          harden({
             /**
              * `getCurrentPrice` calculates the result of a trade, given a certain amount
              * of digital assets in.
@@ -306,8 +305,10 @@ export const makeContract = harden(
                 checkHook(removeLiquidityHook, removeLiquidityExpected),
                 'autoswap remove liquidity',
               ),
-          },
-        });
+          }),
+        );
+
+        return makeAddLiquidityInvite();
       });
     });
   },

--- a/packages/zoe/src/contracts/coveredCall.js
+++ b/packages/zoe/src/contracts/coveredCall.js
@@ -62,11 +62,9 @@ export const makeContract = harden(
       exit: { afterDeadline: null },
     });
 
-    return harden({
-      invite: zcf.makeInvitation(
-        checkHook(makeCallOptionInvite, writeOptionExpected),
-        'makeCallOption',
-      ),
-    });
+    return zcf.makeInvitation(
+      checkHook(makeCallOptionInvite, writeOptionExpected),
+      'makeCallOption',
+    );
   },
 );

--- a/packages/zoe/src/contracts/mintAndSellNFT.js
+++ b/packages/zoe/src/contracts/mintAndSellNFT.js
@@ -96,11 +96,12 @@ export const makeContract = harden(
       return harden({ sellTokens });
     };
 
-    return harden({
-      invite: zcf.makeInvitation(mintTokensHook, 'mint tokens'),
-      publicAPI: {
+    zcf.initPublicAPI(
+      harden({
         getTokenIssuer: () => issuer,
-      },
-    });
+      }),
+    );
+
+    return zcf.makeInvitation(mintTokensHook, 'mint tokens');
   },
 );

--- a/packages/zoe/src/contracts/mintPayments.js
+++ b/packages/zoe/src/contracts/mintPayments.js
@@ -53,19 +53,20 @@ export const makeContract = harden(
       // A function for making invites to this contract
       const makeInvite = () => zcf.makeInvitation(offerHook, 'mint a payment');
 
-      return harden({
-        // return an invite to the creator of the contract instance
-        // through Zoe
-        invite: makeInvite(),
-        publicAPI: {
+      zcf.initPublicAPI(
+        harden({
           // provide a way for anyone who knows the instanceHandle of
           // the contract to make their own invite.
           makeInvite,
           // make the token issuer public. Note that only the mint can
           // make new digital assets. The issuer is ok to make public.
           getTokenIssuer: () => issuer,
-        },
-      });
+        }),
+      );
+
+      // return an invite to the creator of the contract instance
+      // through Zoe
+      return makeInvite();
     });
   },
 );

--- a/packages/zoe/src/contracts/multipoolAutoswap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap.js
@@ -533,9 +533,8 @@ export const makeContract = harden(
     const makeAddLiquidityInvite = () =>
       zcf.makeInvitation(addLiquidityHook, 'multipool autoswap add liquidity');
 
-    return harden({
-      invite: makeAddLiquidityInvite(),
-      publicAPI: {
+    zcf.initPublicAPI(
+      harden({
         getBrandKeywordRecord: () => {
           const { issuerKeywordRecord } = zcf.getInstanceRecord();
           const brandKeywordRecord = {};
@@ -628,7 +627,9 @@ export const makeContract = harden(
         makeAddLiquidityInvite,
         makeRemoveLiquidityInvite: () =>
           zcf.makeInvitation(removeLiquidityHook, 'autoswap remove liquidity'),
-      },
-    });
+      }),
+    );
+
+    return makeAddLiquidityInvite();
   },
 );

--- a/packages/zoe/src/contracts/publicAuction.js
+++ b/packages/zoe/src/contracts/publicAuction.js
@@ -101,9 +101,8 @@ export const makeContract = harden(
         'sellAssets',
       );
 
-    return harden({
-      invite: makeSellerInvite(),
-      publicAPI: {
+    zcf.initPublicAPI(
+      harden({
         makeInvites: numInvites => {
           if (auctionedAssets === undefined) {
             throw new Error(`No assets are up for auction.`);
@@ -116,7 +115,9 @@ export const makeContract = harden(
         },
         getAuctionedAssetsAmounts: () => auctionedAssets,
         getMinimumBid: () => minimumBid,
-      },
-    });
+      }),
+    );
+
+    return makeSellerInvite();
   },
 );

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -93,9 +93,8 @@ export const makeContract = harden(
       give: { Money: null },
     });
 
-    return harden({
-      invite: zcf.makeInvitation(sellerOfferHook, 'seller'),
-      publicAPI: {
+    zcf.initPublicAPI(
+      harden({
         makeBuyerInvite: () => {
           assert(
             sellerOfferHandle &&
@@ -116,7 +115,9 @@ export const makeContract = harden(
           return zcf.getCurrentAllocation(sellerOfferHandle).Items;
         },
         getItemsIssuer: () => zcf.getInstanceRecord().issuerKeywordRecord.Items,
-      },
-    });
+      }),
+    );
+
+    return zcf.makeInvitation(sellerOfferHook, 'seller');
   },
 );

--- a/packages/zoe/src/contracts/simpleExchange.js
+++ b/packages/zoe/src/contracts/simpleExchange.js
@@ -136,13 +136,14 @@ export const makeContract = harden(
     const makeExchangeInvite = () =>
       zcf.makeInvitation(exchangeOfferHook, 'exchange');
 
-    return harden({
-      invite: makeExchangeInvite(),
-      publicAPI: {
+    zcf.initPublicAPI(
+      harden({
         makeInvite: makeExchangeInvite,
         getOffer,
         getNotifier: () => notifier,
-      },
-    });
+      }),
+    );
+
+    return makeExchangeInvite();
   },
 );

--- a/packages/zoe/test/swingsetTests/zoe-metering/infiniteTestLoop.js
+++ b/packages/zoe/test/swingsetTests/zoe-metering/infiniteTestLoop.js
@@ -1,15 +1,15 @@
 import harden from '@agoric/harden';
 
-export const makeContract = zoe => {
-  const invite = zoe.makeInvitation(() => {}, 'tester');
-  return harden({
-    invite,
-    publicAPI: {
+export const makeContract = zcf => {
+  const invite = zcf.makeInvitation(() => {}, 'tester');
+  zcf.initPublicAPI(
+    harden({
       doTest: () => {
         for (;;) {
           // Nothing
         }
       },
-    },
-  });
+    }),
+  );
+  return invite;
 };

--- a/packages/zoe/test/swingsetTests/zoe-metering/testBuiltins.js
+++ b/packages/zoe/test/swingsetTests/zoe-metering/testBuiltins.js
@@ -1,13 +1,13 @@
 import harden from '@agoric/harden';
 
-export const makeContract = zoe => {
-  const invite = zoe.makeInvitation(() => {}, 'tester');
-  return harden({
-    invite,
-    publicAPI: {
+export const makeContract = zcf => {
+  const invite = zcf.makeInvitation(() => {}, 'tester');
+  zcf.initPublicAPI(
+    harden({
       doTest: () => {
         new Array(1e7).map(Object.create);
       },
-    },
-  });
+    }),
+  );
+  return invite;
 };

--- a/packages/zoe/test/unitTests/contracts/brokenAutoRefund.js
+++ b/packages/zoe/test/unitTests/contracts/brokenAutoRefund.js
@@ -15,10 +15,6 @@ export const makeContract = harden(zcf => {
   };
   const makeRefundInvite = () =>
     zcf.makeInvitation(refundOfferHook, 'getRefund');
-
-  return harden({
-    // should be makeRefundInvite(). Intentionally wrong to provoke an error.
-    invite: makeRefundInvite,
-    publicAPI: {},
-  });
+  // should be makeRefundInvite(). Intentionally wrong to provoke an error.
+  return makeRefundInvite;
 });

--- a/packages/zoe/test/unitTests/contracts/grifter.js
+++ b/packages/zoe/test/unitTests/contracts/grifter.js
@@ -42,11 +42,9 @@ export const makeContract = harden(
       want: { Price: null },
     });
 
-    return harden({
-      invite: zcf.makeInvitation(
-        checkHook(makeAccompliceInvite, firstOfferExpected),
-        'firstOffer',
-      ),
-    });
+    return zcf.makeInvitation(
+      checkHook(makeAccompliceInvite, firstOfferExpected),
+      'firstOffer',
+    );
   },
 );


### PR DESCRIPTION
Add new method: `zcf.initPublicAPI` and remove publicAPI from the return values of makeContract

Closes #999 