### PR TITLE
docs: improve Zoe JSDoc; enable type-checking in all contracts

### DIFF
--- a/packages/zoe/src/contracts/atomicSwap.js
+++ b/packages/zoe/src/contracts/atomicSwap.js
@@ -1,43 +1,45 @@
+// @ts-check
+
 import harden from '@agoric/harden';
 
 // Eventually will be importable from '@agoric/zoe-contract-support'
 import { makeZoeHelpers } from '../contractSupport';
 
-/**
- * @typedef {import('../zoe').ContractFacet} ContractFacet
- */
+/** @typedef {import('../zoe').ContractFacet} ContractFacet */
 
 // zcf is the Zoe Contract Facet, i.e. the contract-facing API of Zoe
-export const makeContract = harden(zcf => {
-  const { swap, assertKeywords, checkHook } = makeZoeHelpers(zcf);
-  assertKeywords(harden(['Asset', 'Price']));
+export const makeContract = harden(
+  /** @param {ContractFacet} zcf */ zcf => {
+    const { swap, assertKeywords, checkHook } = makeZoeHelpers(zcf);
+    assertKeywords(harden(['Asset', 'Price']));
 
-  const makeMatchingInvite = firstOfferHandle => {
-    const {
-      proposal: { want, give },
-    } = zcf.getOffer(firstOfferHandle);
+    const makeMatchingInvite = firstOfferHandle => {
+      const {
+        proposal: { want, give },
+      } = zcf.getOffer(firstOfferHandle);
 
-    return zcf.makeInvitation(
-      offerHandle => swap(firstOfferHandle, offerHandle),
-      'matchOffer',
-      harden({
-        customProperties: {
-          asset: give.Asset,
-          price: want.Price,
-        },
-      }),
-    );
-  };
+      return zcf.makeInvitation(
+        offerHandle => swap(firstOfferHandle, offerHandle),
+        'matchOffer',
+        harden({
+          customProperties: {
+            asset: give.Asset,
+            price: want.Price,
+          },
+        }),
+      );
+    };
 
-  const firstOfferExpected = harden({
-    give: { Asset: null },
-    want: { Price: null },
-  });
+    const firstOfferExpected = harden({
+      give: { Asset: null },
+      want: { Price: null },
+    });
 
-  return harden({
-    invite: zcf.makeInvitation(
-      checkHook(makeMatchingInvite, firstOfferExpected),
-      'firstOffer',
-    ),
-  });
-});
+    return harden({
+      invite: zcf.makeInvitation(
+        checkHook(makeMatchingInvite, firstOfferExpected),
+        'firstOffer',
+      ),
+    });
+  },
+);

--- a/packages/zoe/src/contracts/automaticRefund.js
+++ b/packages/zoe/src/contracts/automaticRefund.js
@@ -1,6 +1,8 @@
 // @ts-check
 import harden from '@agoric/harden';
 
+/** @typedef {import('../zoe').ContractFacet} ContractFacet */
+
 /**
  * This is a very trivial contract to explain and test Zoe.
  * AutomaticRefund just gives you back what you put in.
@@ -11,22 +13,24 @@ import harden from '@agoric/harden';
  *
  * @type {import('@agoric/zoe').MakeContract}
  */
-export const makeContract = harden(zcf => {
-  let offersCount = 0;
+export const makeContract = harden(
+  /** @param {ContractFacet} zcf */ zcf => {
+    let offersCount = 0;
 
-  const refundOfferHook = offerHandle => {
-    offersCount += 1;
-    zcf.complete(harden([offerHandle]));
-    return `The offer was accepted`;
-  };
-  const makeRefundInvite = () =>
-    zcf.makeInvitation(refundOfferHook, 'getRefund');
+    const refundOfferHook = offerHandle => {
+      offersCount += 1;
+      zcf.complete(harden([offerHandle]));
+      return `The offer was accepted`;
+    };
+    const makeRefundInvite = () =>
+      zcf.makeInvitation(refundOfferHook, 'getRefund');
 
-  return harden({
-    invite: makeRefundInvite(),
-    publicAPI: {
-      getOffersCount: () => offersCount,
-      makeInvite: makeRefundInvite,
-    },
-  });
-});
+    return harden({
+      invite: makeRefundInvite(),
+      publicAPI: {
+        getOffersCount: () => offersCount,
+        makeInvite: makeRefundInvite,
+      },
+    });
+  },
+);

--- a/packages/zoe/src/contracts/autoswap.js
+++ b/packages/zoe/src/contracts/autoswap.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import harden from '@agoric/harden';
 import produceIssuer from '@agoric/ertp';
 import { assert, details } from '@agoric/assert';
@@ -13,298 +15,306 @@ import {
 // Autoswap is a rewrite of Uniswap. Please see the documentation for
 // more https://agoric.com/documentation/zoe/guide/contracts/autoswap.html
 
+/**
+ * @typedef {import('../zoe').ContractFacet} ContractFacet
+ */
+
 // zcf is the Zoe Contract Facet, i.e. the contract-facing API of Zoe
-export const makeContract = harden(zcf => {
-  // Create the liquidity mint and issuer.
-  const { mint: liquidityMint, issuer: liquidityIssuer } = produceIssuer(
-    'liquidity',
-  );
-
-  let liqTokenSupply = 0;
-
-  const {
-    checkIfProposal,
-    rejectOffer,
-    makeEmptyOffer,
-    checkHook,
-    escrowAndAllocateTo,
-  } = makeZoeHelpers(zcf);
-
-  return zcf.addNewIssuer(liquidityIssuer, 'Liquidity').then(() => {
-    const amountMaths = zcf.getAmountMaths(
-      harden(['TokenA', 'TokenB', 'Liquidity']),
-    );
-    Object.values(amountMaths).forEach(amountMath =>
-      assert(
-        amountMath.getMathHelpersName() === 'nat',
-        details`issuers must have natMathHelpers`,
-      ),
+export const makeContract = harden(
+  /** @param {ContractFacet} zcf */ zcf => {
+    // Create the liquidity mint and issuer.
+    const { mint: liquidityMint, issuer: liquidityIssuer } = produceIssuer(
+      'liquidity',
     );
 
-    return makeEmptyOffer().then(poolHandle => {
-      const getPoolAllocation = () => zcf.getCurrentAllocation(poolHandle);
+    let liqTokenSupply = 0;
 
-      const swap = (offerHandle, giveKeyword, wantKeyword) => {
-        const { proposal } = zcf.getOffer(offerHandle);
-        if (proposal.want.Liquidity !== undefined) {
-          rejectOffer(
-            offerHandle,
-            `A Liquidity amount should not be present in a swap`,
+    const {
+      checkIfProposal,
+      rejectOffer,
+      makeEmptyOffer,
+      checkHook,
+      escrowAndAllocateTo,
+    } = makeZoeHelpers(zcf);
+
+    return zcf.addNewIssuer(liquidityIssuer, 'Liquidity').then(() => {
+      const amountMaths = zcf.getAmountMaths(
+        harden(['TokenA', 'TokenB', 'Liquidity']),
+      );
+      Object.values(amountMaths).forEach(amountMath =>
+        assert(
+          amountMath.getMathHelpersName() === 'nat',
+          details`issuers must have natMathHelpers`,
+        ),
+      );
+
+      return makeEmptyOffer().then(poolHandle => {
+        const getPoolAllocation = () => zcf.getCurrentAllocation(poolHandle);
+
+        const swap = (offerHandle, giveKeyword, wantKeyword) => {
+          const { proposal } = zcf.getOffer(offerHandle);
+          if (proposal.want.Liquidity !== undefined) {
+            rejectOffer(
+              offerHandle,
+              `A Liquidity amount should not be present in a swap`,
+            );
+          }
+
+          const poolAllocation = getPoolAllocation();
+          const {
+            outputExtent,
+            newInputReserve,
+            newOutputReserve,
+          } = getCurrentPrice(
+            harden({
+              inputExtent: proposal.give[giveKeyword].extent,
+              inputReserve: poolAllocation[giveKeyword].extent,
+              outputReserve: poolAllocation[wantKeyword].extent,
+            }),
           );
-        }
+          const amountOut = amountMaths[wantKeyword].make(outputExtent);
+          const wantedAmount = proposal.want[wantKeyword];
+          const satisfiesWantedAmounts = () =>
+            amountMaths[wantKeyword].isGTE(amountOut, wantedAmount);
+          if (!satisfiesWantedAmounts()) {
+            throw rejectOffer(offerHandle);
+          }
 
-        const poolAllocation = getPoolAllocation();
-        const {
-          outputExtent,
-          newInputReserve,
-          newOutputReserve,
-        } = getCurrentPrice(
-          harden({
-            inputExtent: proposal.give[giveKeyword].extent,
-            inputReserve: poolAllocation[giveKeyword].extent,
-            outputReserve: poolAllocation[wantKeyword].extent,
-          }),
-        );
-        const amountOut = amountMaths[wantKeyword].make(outputExtent);
-        const wantedAmount = proposal.want[wantKeyword];
-        const satisfiesWantedAmounts = () =>
-          amountMaths[wantKeyword].isGTE(amountOut, wantedAmount);
-        if (!satisfiesWantedAmounts()) {
-          throw rejectOffer(offerHandle);
-        }
+          const newUserAmounts = {
+            Liquidity: amountMaths.Liquidity.getEmpty(),
+          };
+          newUserAmounts[giveKeyword] = amountMaths[giveKeyword].getEmpty();
+          newUserAmounts[wantKeyword] = amountOut;
 
-        const newUserAmounts = {
-          Liquidity: amountMaths.Liquidity.getEmpty(),
-        };
-        newUserAmounts[giveKeyword] = amountMaths[giveKeyword].getEmpty();
-        newUserAmounts[wantKeyword] = amountOut;
-
-        const newPoolAmounts = { Liquidity: poolAllocation.Liquidity };
-        newPoolAmounts[giveKeyword] = amountMaths[giveKeyword].make(
-          newInputReserve,
-        );
-        newPoolAmounts[wantKeyword] = amountMaths[wantKeyword].make(
-          newOutputReserve,
-        );
-
-        zcf.reallocate(
-          harden([offerHandle, poolHandle]),
-          harden([newUserAmounts, newPoolAmounts]),
-        );
-        zcf.complete(harden([offerHandle]));
-        return `Swap successfully completed.`;
-      };
-
-      const buyASellB = harden({
-        give: { TokenB: null },
-        want: { TokenA: null },
-      });
-
-      const buyBSellA = harden({
-        give: { TokenA: null },
-        want: { TokenB: null },
-      });
-
-      const swapHook = offerHandle => {
-        assert(
-          !checkIfProposal(offerHandle, { give: { Liquidity: null } }),
-          details`A Liquidity amount should not be present in a swap`,
-        );
-        assert(
-          !checkIfProposal(offerHandle, { want: { Liquidity: null } }),
-          details`A Liquidity amount should not be present in a swap`,
-        );
-        if (checkIfProposal(offerHandle, buyASellB)) {
-          return swap(offerHandle, 'TokenB', 'TokenA');
-          /* eslint-disable no-else-return */
-        } else if (checkIfProposal(offerHandle, buyBSellA)) {
-          return swap(offerHandle, 'TokenA', 'TokenB');
-        } else {
-          // Eject because the offer must be invalid
-          return rejectOffer(offerHandle);
-        }
-      };
-
-      const addLiquidityHook = offerHandle => {
-        const userAllocation = zcf.getCurrentAllocation(offerHandle);
-        const poolAllocation = getPoolAllocation();
-
-        // Calculate how many liquidity tokens we should be minting.
-        // Calculations are based on the extents represented by TokenA.
-        // If the current supply is zero, start off by just taking the
-        // extent at TokenA and using it as the extent for the
-        // liquidity token.
-        const liquidityExtentOut = calcLiqExtentToMint(
-          harden({
-            liqTokenSupply,
-            inputExtent: userAllocation.TokenA.extent,
-            inputReserve: poolAllocation.TokenA.extent,
-          }),
-        );
-
-        const liquidityAmountOut = amountMaths.Liquidity.make(
-          liquidityExtentOut,
-        );
-
-        const liquidityPaymentP = liquidityMint.mintPayment(liquidityAmountOut);
-
-        return escrowAndAllocateTo({
-          amount: liquidityAmountOut,
-          payment: liquidityPaymentP,
-          keyword: 'Liquidity',
-          recipientHandle: offerHandle,
-        }).then(() => {
-          liqTokenSupply += liquidityExtentOut;
-
-          const add = (key, obj1, obj2) =>
-            amountMaths[key].add(obj1[key], obj2[key]);
-
-          const newPoolAmounts = harden({
-            TokenA: add('TokenA', userAllocation, poolAllocation),
-            TokenB: add('TokenB', userAllocation, poolAllocation),
-            Liquidity: poolAllocation.Liquidity,
-          });
-
-          const newUserAmounts = harden({
-            TokenA: amountMaths.TokenA.getEmpty(),
-            TokenB: amountMaths.TokenB.getEmpty(),
-            Liquidity: liquidityAmountOut,
-          });
+          const newPoolAmounts = { Liquidity: poolAllocation.Liquidity };
+          newPoolAmounts[giveKeyword] = amountMaths[giveKeyword].make(
+            newInputReserve,
+          );
+          newPoolAmounts[wantKeyword] = amountMaths[wantKeyword].make(
+            newOutputReserve,
+          );
 
           zcf.reallocate(
             harden([offerHandle, poolHandle]),
             harden([newUserAmounts, newPoolAmounts]),
-            harden(['TokenA', 'TokenB', 'Liquidity']),
           );
           zcf.complete(harden([offerHandle]));
-          return 'Added liquidity.';
+          return `Swap successfully completed.`;
+        };
+
+        const buyASellB = harden({
+          give: { TokenB: null },
+          want: { TokenA: null },
         });
-      };
 
-      const addLiquidityExpected = harden({
-        give: { TokenA: null, TokenB: null },
-        want: { Liquidity: null },
-      });
+        const buyBSellA = harden({
+          give: { TokenA: null },
+          want: { TokenB: null },
+        });
 
-      const removeLiquidityHook = offerHandle => {
-        const userAllocation = zcf.getCurrentAllocation(offerHandle);
-        const liquidityExtentIn = userAllocation.Liquidity.extent;
+        const swapHook = offerHandle => {
+          assert(
+            !checkIfProposal(offerHandle, { give: { Liquidity: null } }),
+            details`A Liquidity amount should not be present in a swap`,
+          );
+          assert(
+            !checkIfProposal(offerHandle, { want: { Liquidity: null } }),
+            details`A Liquidity amount should not be present in a swap`,
+          );
+          if (checkIfProposal(offerHandle, buyASellB)) {
+            return swap(offerHandle, 'TokenB', 'TokenA');
+            /* eslint-disable no-else-return */
+          } else if (checkIfProposal(offerHandle, buyBSellA)) {
+            return swap(offerHandle, 'TokenA', 'TokenB');
+          } else {
+            // Eject because the offer must be invalid
+            return rejectOffer(offerHandle);
+          }
+        };
 
-        const poolAllocation = getPoolAllocation();
+        const addLiquidityHook = offerHandle => {
+          const userAllocation = zcf.getCurrentAllocation(offerHandle);
+          const poolAllocation = getPoolAllocation();
 
-        const newUserTokenAAmount = amountMaths.TokenA.make(
-          calcExtentToRemove(
+          // Calculate how many liquidity tokens we should be minting.
+          // Calculations are based on the extents represented by TokenA.
+          // If the current supply is zero, start off by just taking the
+          // extent at TokenA and using it as the extent for the
+          // liquidity token.
+          const liquidityExtentOut = calcLiqExtentToMint(
             harden({
               liqTokenSupply,
-              poolExtent: poolAllocation.TokenA.extent,
-              liquidityExtentIn,
+              inputExtent: userAllocation.TokenA.extent,
+              inputReserve: poolAllocation.TokenA.extent,
             }),
-          ),
-        );
-        const newUserTokenBAmount = amountMaths.TokenB.make(
-          calcExtentToRemove(
-            harden({
-              liqTokenSupply,
-              poolExtent: poolAllocation.TokenB.extent,
-              liquidityExtentIn,
-            }),
-          ),
-        );
+          );
 
-        const newUserAmounts = harden({
-          TokenA: newUserTokenAAmount,
-          TokenB: newUserTokenBAmount,
-          Liquidity: amountMaths.Liquidity.getEmpty(),
+          const liquidityAmountOut = amountMaths.Liquidity.make(
+            liquidityExtentOut,
+          );
+
+          const liquidityPaymentP = liquidityMint.mintPayment(
+            liquidityAmountOut,
+          );
+
+          return escrowAndAllocateTo({
+            amount: liquidityAmountOut,
+            payment: liquidityPaymentP,
+            keyword: 'Liquidity',
+            recipientHandle: offerHandle,
+          }).then(() => {
+            liqTokenSupply += liquidityExtentOut;
+
+            const add = (key, obj1, obj2) =>
+              amountMaths[key].add(obj1[key], obj2[key]);
+
+            const newPoolAmounts = harden({
+              TokenA: add('TokenA', userAllocation, poolAllocation),
+              TokenB: add('TokenB', userAllocation, poolAllocation),
+              Liquidity: poolAllocation.Liquidity,
+            });
+
+            const newUserAmounts = harden({
+              TokenA: amountMaths.TokenA.getEmpty(),
+              TokenB: amountMaths.TokenB.getEmpty(),
+              Liquidity: liquidityAmountOut,
+            });
+
+            zcf.reallocate(
+              harden([offerHandle, poolHandle]),
+              harden([newUserAmounts, newPoolAmounts]),
+              harden(['TokenA', 'TokenB', 'Liquidity']),
+            );
+            zcf.complete(harden([offerHandle]));
+            return 'Added liquidity.';
+          });
+        };
+
+        const addLiquidityExpected = harden({
+          give: { TokenA: null, TokenB: null },
+          want: { Liquidity: null },
         });
 
-        const newPoolAmounts = harden({
-          TokenA: amountMaths.TokenA.subtract(
-            poolAllocation.TokenA,
-            newUserAmounts.TokenA,
-          ),
-          TokenB: amountMaths.TokenB.subtract(
-            poolAllocation.TokenB,
-            newUserAmounts.TokenB,
-          ),
-          Liquidity: amountMaths.Liquidity.add(
-            poolAllocation.Liquidity,
-            amountMaths.Liquidity.make(liquidityExtentIn),
-          ),
-        });
+        const removeLiquidityHook = offerHandle => {
+          const userAllocation = zcf.getCurrentAllocation(offerHandle);
+          const liquidityExtentIn = userAllocation.Liquidity.extent;
 
-        liqTokenSupply -= liquidityExtentIn;
+          const poolAllocation = getPoolAllocation();
 
-        zcf.reallocate(
-          harden([offerHandle, poolHandle]),
-          harden([newUserAmounts, newPoolAmounts]),
-        );
-        zcf.complete(harden([offerHandle]));
-        return 'Liquidity successfully removed.';
-      };
-
-      const removeLiquidityExpected = harden({
-        want: { TokenA: null, TokenB: null },
-        give: { Liquidity: null },
-      });
-
-      const makeAddLiquidityInvite = () =>
-        zcf.makeInvitation(
-          checkHook(addLiquidityHook, addLiquidityExpected),
-          'autoswap add liquidity',
-        );
-
-      return harden({
-        invite: makeAddLiquidityInvite(),
-        publicAPI: {
-          /**
-           * `getCurrentPrice` calculates the result of a trade, given a certain amount
-           * of digital assets in.
-           * @param {object} amountInObj - the amount of digital
-           * assets to be sent in, keyed by keyword
-           */
-          getCurrentPrice: amountInObj => {
-            const inKeywords = Object.getOwnPropertyNames(amountInObj);
-            assert(
-              inKeywords.length === 1,
-              details`argument to 'getCurrentPrice' must have one keyword`,
-            );
-            const [inKeyword] = inKeywords;
-            assert(
-              ['TokenA', 'TokenB'].includes(inKeyword),
-              details`keyword ${inKeyword} was not valid`,
-            );
-            const inputExtent = amountMaths[inKeyword].getExtent(
-              amountInObj[inKeyword],
-            );
-            const poolAllocation = getPoolAllocation();
-            const inputReserve = poolAllocation[inKeyword].extent;
-            const outKeyword = inKeyword === 'TokenA' ? 'TokenB' : 'TokenA';
-            const outputReserve = poolAllocation[outKeyword].extent;
-            const { outputExtent } = getCurrentPrice(
+          const newUserTokenAAmount = amountMaths.TokenA.make(
+            calcExtentToRemove(
               harden({
-                inputExtent,
-                inputReserve,
-                outputReserve,
+                liqTokenSupply,
+                poolExtent: poolAllocation.TokenA.extent,
+                liquidityExtentIn,
               }),
-            );
-            return amountMaths[outKeyword].make(outputExtent);
-          },
-
-          getLiquidityIssuer: () => liquidityIssuer,
-
-          getPoolAllocation,
-
-          makeSwapInvite: () => zcf.makeInvitation(swapHook, 'autoswap swap'),
-
-          makeAddLiquidityInvite,
-
-          makeRemoveLiquidityInvite: () =>
-            zcf.makeInvitation(
-              checkHook(removeLiquidityHook, removeLiquidityExpected),
-              'autoswap remove liquidity',
             ),
-        },
+          );
+          const newUserTokenBAmount = amountMaths.TokenB.make(
+            calcExtentToRemove(
+              harden({
+                liqTokenSupply,
+                poolExtent: poolAllocation.TokenB.extent,
+                liquidityExtentIn,
+              }),
+            ),
+          );
+
+          const newUserAmounts = harden({
+            TokenA: newUserTokenAAmount,
+            TokenB: newUserTokenBAmount,
+            Liquidity: amountMaths.Liquidity.getEmpty(),
+          });
+
+          const newPoolAmounts = harden({
+            TokenA: amountMaths.TokenA.subtract(
+              poolAllocation.TokenA,
+              newUserAmounts.TokenA,
+            ),
+            TokenB: amountMaths.TokenB.subtract(
+              poolAllocation.TokenB,
+              newUserAmounts.TokenB,
+            ),
+            Liquidity: amountMaths.Liquidity.add(
+              poolAllocation.Liquidity,
+              amountMaths.Liquidity.make(liquidityExtentIn),
+            ),
+          });
+
+          liqTokenSupply -= liquidityExtentIn;
+
+          zcf.reallocate(
+            harden([offerHandle, poolHandle]),
+            harden([newUserAmounts, newPoolAmounts]),
+          );
+          zcf.complete(harden([offerHandle]));
+          return 'Liquidity successfully removed.';
+        };
+
+        const removeLiquidityExpected = harden({
+          want: { TokenA: null, TokenB: null },
+          give: { Liquidity: null },
+        });
+
+        const makeAddLiquidityInvite = () =>
+          zcf.makeInvitation(
+            checkHook(addLiquidityHook, addLiquidityExpected),
+            'autoswap add liquidity',
+          );
+
+        return harden({
+          invite: makeAddLiquidityInvite(),
+          publicAPI: {
+            /**
+             * `getCurrentPrice` calculates the result of a trade, given a certain amount
+             * of digital assets in.
+             * @param {object} amountInObj - the amount of digital
+             * assets to be sent in, keyed by keyword
+             */
+            getCurrentPrice: amountInObj => {
+              const inKeywords = Object.getOwnPropertyNames(amountInObj);
+              assert(
+                inKeywords.length === 1,
+                details`argument to 'getCurrentPrice' must have one keyword`,
+              );
+              const [inKeyword] = inKeywords;
+              assert(
+                ['TokenA', 'TokenB'].includes(inKeyword),
+                details`keyword ${inKeyword} was not valid`,
+              );
+              const inputExtent = amountMaths[inKeyword].getExtent(
+                amountInObj[inKeyword],
+              );
+              const poolAllocation = getPoolAllocation();
+              const inputReserve = poolAllocation[inKeyword].extent;
+              const outKeyword = inKeyword === 'TokenA' ? 'TokenB' : 'TokenA';
+              const outputReserve = poolAllocation[outKeyword].extent;
+              const { outputExtent } = getCurrentPrice(
+                harden({
+                  inputExtent,
+                  inputReserve,
+                  outputReserve,
+                }),
+              );
+              return amountMaths[outKeyword].make(outputExtent);
+            },
+
+            getLiquidityIssuer: () => liquidityIssuer,
+
+            getPoolAllocation,
+
+            makeSwapInvite: () => zcf.makeInvitation(swapHook, 'autoswap swap'),
+
+            makeAddLiquidityInvite,
+
+            makeRemoveLiquidityInvite: () =>
+              zcf.makeInvitation(
+                checkHook(removeLiquidityHook, removeLiquidityExpected),
+                'autoswap remove liquidity',
+              ),
+          },
+        });
       });
     });
-  });
-});
+  },
+);

--- a/packages/zoe/src/contracts/mintPayments.js
+++ b/packages/zoe/src/contracts/mintPayments.js
@@ -1,4 +1,6 @@
 /* eslint-disable no-use-before-define */
+// @ts-check
+
 import harden from '@agoric/harden';
 import produceIssuer from '@agoric/ertp';
 import { makeZoeHelpers } from '../contractSupport';
@@ -8,58 +10,62 @@ This is the simplest contract to mint payments and send them to users
 who request them. No offer safety is being enforced here.
 */
 
+/** @typedef {import('../zoe').ContractFacet} ContractFacet */
+
 // zcf is the Zoe Contract Facet, i.e. the contract-facing API of Zoe
-export const makeContract = harden(zcf => {
-  // Create the internal token mint for a fungible digital asset
-  const { issuer, mint, amountMath } = produceIssuer('tokens');
+export const makeContract = harden(
+  /** @param {ContractFacet} zcf */ zcf => {
+    // Create the internal token mint for a fungible digital asset
+    const { issuer, mint, amountMath } = produceIssuer('tokens');
 
-  const zoeHelpers = makeZoeHelpers(zcf);
+    const zoeHelpers = makeZoeHelpers(zcf);
 
-  // We need to tell Zoe about this issuer and add a keyword for the
-  // issuer. Let's call this the 'Token' issuer.
-  return zcf.addNewIssuer(issuer, 'Token').then(() => {
-    // We need to wait for the promise to resolve (meaning that Zoe
-    // has done the work of adding a new issuer).
-    const offerHook = offerHandle => {
-      // We will send everyone who makes an offer 1000 tokens
+    // We need to tell Zoe about this issuer and add a keyword for the
+    // issuer. Let's call this the 'Token' issuer.
+    return zcf.addNewIssuer(issuer, 'Token').then(() => {
+      // We need to wait for the promise to resolve (meaning that Zoe
+      // has done the work of adding a new issuer).
+      const offerHook = offerHandle => {
+        // We will send everyone who makes an offer 1000 tokens
 
-      const tokens1000 = amountMath.make(1000);
-      const payment = mint.mintPayment(tokens1000);
+        const tokens1000 = amountMath.make(1000);
+        const payment = mint.mintPayment(tokens1000);
 
-      // Let's use a helper function which escrows the payment with
-      // Zoe, and reallocates to the recipientHandle.
-      return zoeHelpers
-        .escrowAndAllocateTo({
-          amount: tokens1000,
-          payment,
-          keyword: 'Token',
-          recipientHandle: offerHandle,
-        })
-        .then(() => {
-          // Complete the user's offer so that the user gets a payout
-          zcf.complete(harden([offerHandle]));
+        // Let's use a helper function which escrows the payment with
+        // Zoe, and reallocates to the recipientHandle.
+        return zoeHelpers
+          .escrowAndAllocateTo({
+            amount: tokens1000,
+            payment,
+            keyword: 'Token',
+            recipientHandle: offerHandle,
+          })
+          .then(() => {
+            // Complete the user's offer so that the user gets a payout
+            zcf.complete(harden([offerHandle]));
 
-          // Since the user is getting the payout through Zoe, we can
-          // return anything here. Let's return some helpful instructions.
-          return 'Offer completed. You should receive a payment from Zoe';
-        });
-    };
+            // Since the user is getting the payout through Zoe, we can
+            // return anything here. Let's return some helpful instructions.
+            return 'Offer completed. You should receive a payment from Zoe';
+          });
+      };
 
-    // A function for making invites to this contract
-    const makeInvite = () => zcf.makeInvitation(offerHook, 'mint a payment');
+      // A function for making invites to this contract
+      const makeInvite = () => zcf.makeInvitation(offerHook, 'mint a payment');
 
-    return harden({
-      // return an invite to the creator of the contract instance
-      // through Zoe
-      invite: makeInvite(),
-      publicAPI: {
-        // provide a way for anyone who knows the instanceHandle of
-        // the contract to make their own invite.
-        makeInvite,
-        // make the token issuer public. Note that only the mint can
-        // make new digital assets. The issuer is ok to make public.
-        getTokenIssuer: () => issuer,
-      },
+      return harden({
+        // return an invite to the creator of the contract instance
+        // through Zoe
+        invite: makeInvite(),
+        publicAPI: {
+          // provide a way for anyone who knows the instanceHandle of
+          // the contract to make their own invite.
+          makeInvite,
+          // make the token issuer public. Note that only the mint can
+          // make new digital assets. The issuer is ok to make public.
+          getTokenIssuer: () => issuer,
+        },
+      });
     });
-  });
-});
+  },
+);

--- a/packages/zoe/src/contracts/publicAuction.js
+++ b/packages/zoe/src/contracts/publicAuction.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import harden from '@agoric/harden';
 import Nat from '@agoric/nat';
 
@@ -9,108 +11,112 @@ import {
   closeAuction,
 } from '../contractSupport';
 
+/** @typedef {import('../zoe').ContractFacet} ContractFacet */
+
 // zcf is the Zoe Contract Facet, i.e. the contract-facing API of Zoe
-export const makeContract = harden(zcf => {
-  const {
-    rejectOffer,
-    canTradeWith,
-    assertKeywords,
-    checkHook,
-  } = makeZoeHelpers(zcf);
+export const makeContract = harden(
+  /** @param {ContractFacet} zcf */ zcf => {
+    const {
+      rejectOffer,
+      canTradeWith,
+      assertKeywords,
+      checkHook,
+    } = makeZoeHelpers(zcf);
 
-  let {
-    terms: { numBidsAllowed },
-  } = zcf.getInstanceRecord();
-  numBidsAllowed = Nat(numBidsAllowed !== undefined ? numBidsAllowed : 3);
+    let {
+      terms: { numBidsAllowed },
+    } = zcf.getInstanceRecord();
+    numBidsAllowed = Nat(numBidsAllowed !== undefined ? numBidsAllowed : 3);
 
-  let sellerOfferHandle;
-  let minimumBid;
-  let auctionedAssets;
-  const allBidHandles = [];
+    let sellerOfferHandle;
+    let minimumBid;
+    let auctionedAssets;
+    const allBidHandles = [];
 
-  assertKeywords(harden(['Asset', 'Bid']));
+    assertKeywords(harden(['Asset', 'Bid']));
 
-  const bidderOfferHook = offerHandle => {
-    // Check that the item is still up for auction
-    if (!zcf.isOfferActive(sellerOfferHandle)) {
-      const rejectMsg = `The item up for auction is not available or the auction has completed`;
-      throw rejectOffer(offerHandle, rejectMsg);
-    }
-    if (allBidHandles.length >= numBidsAllowed) {
-      throw rejectOffer(offerHandle, `No further bids allowed.`);
-    }
-    if (!canTradeWith(sellerOfferHandle, offerHandle)) {
-      const rejectMsg = `Bid was under minimum bid or for the wrong assets`;
-      throw rejectOffer(offerHandle, rejectMsg);
-    }
+    const bidderOfferHook = offerHandle => {
+      // Check that the item is still up for auction
+      if (!zcf.isOfferActive(sellerOfferHandle)) {
+        const rejectMsg = `The item up for auction is not available or the auction has completed`;
+        throw rejectOffer(offerHandle, rejectMsg);
+      }
+      if (allBidHandles.length >= numBidsAllowed) {
+        throw rejectOffer(offerHandle, `No further bids allowed.`);
+      }
+      if (!canTradeWith(sellerOfferHandle, offerHandle)) {
+        const rejectMsg = `Bid was under minimum bid or for the wrong assets`;
+        throw rejectOffer(offerHandle, rejectMsg);
+      }
 
-    // Save valid bid and try to close.
-    allBidHandles.push(offerHandle);
-    if (allBidHandles.length >= numBidsAllowed) {
-      closeAuction(zcf, {
-        auctionLogicFn: secondPriceLogic,
-        sellerOfferHandle,
-        allBidHandles,
-      });
-    }
-    return defaultAcceptanceMsg;
-  };
+      // Save valid bid and try to close.
+      allBidHandles.push(offerHandle);
+      if (allBidHandles.length >= numBidsAllowed) {
+        closeAuction(zcf, {
+          auctionLogicFn: secondPriceLogic,
+          sellerOfferHandle,
+          allBidHandles,
+        });
+      }
+      return defaultAcceptanceMsg;
+    };
 
-  const bidderOfferExpected = harden({
-    give: { Bid: null },
-    want: { Asset: null },
-  });
+    const bidderOfferExpected = harden({
+      give: { Bid: null },
+      want: { Asset: null },
+    });
 
-  const makeBidderInvite = () =>
-    zcf.makeInvitation(
-      checkHook(bidderOfferHook, bidderOfferExpected),
-      'bid',
-      harden({
-        customProperties: {
-          auctionedAssets,
-          minimumBid,
+    const makeBidderInvite = () =>
+      zcf.makeInvitation(
+        checkHook(bidderOfferHook, bidderOfferExpected),
+        'bid',
+        harden({
+          customProperties: {
+            auctionedAssets,
+            minimumBid,
+          },
+        }),
+      );
+
+    const sellerOfferHook = offerHandle => {
+      if (auctionedAssets) {
+        throw rejectOffer(offerHandle, `assets already present`);
+      }
+      // Save the valid offer
+      sellerOfferHandle = offerHandle;
+      const { proposal } = zcf.getOffer(offerHandle);
+      auctionedAssets = proposal.give.Asset;
+      minimumBid = proposal.want.Bid;
+      return defaultAcceptanceMsg;
+    };
+
+    const sellerOfferExpected = harden({
+      give: { Asset: null },
+      want: { Bid: null },
+    });
+
+    const makeSellerInvite = () =>
+      zcf.makeInvitation(
+        checkHook(sellerOfferHook, sellerOfferExpected),
+        'sellAssets',
+      );
+
+    return harden({
+      invite: makeSellerInvite(),
+      publicAPI: {
+        makeInvites: numInvites => {
+          if (auctionedAssets === undefined) {
+            throw new Error(`No assets are up for auction.`);
+          }
+          const invites = [];
+          for (let i = 0; i < numInvites; i += 1) {
+            invites.push(makeBidderInvite());
+          }
+          return invites;
         },
-      }),
-    );
-
-  const sellerOfferHook = offerHandle => {
-    if (auctionedAssets) {
-      throw rejectOffer(offerHandle, `assets already present`);
-    }
-    // Save the valid offer
-    sellerOfferHandle = offerHandle;
-    const { proposal } = zcf.getOffer(offerHandle);
-    auctionedAssets = proposal.give.Asset;
-    minimumBid = proposal.want.Bid;
-    return defaultAcceptanceMsg;
-  };
-
-  const sellerOfferExpected = harden({
-    give: { Asset: null },
-    want: { Bid: null },
-  });
-
-  const makeSellerInvite = () =>
-    zcf.makeInvitation(
-      checkHook(sellerOfferHook, sellerOfferExpected),
-      'sellAssets',
-    );
-
-  return harden({
-    invite: makeSellerInvite(),
-    publicAPI: {
-      makeInvites: numInvites => {
-        if (auctionedAssets === undefined) {
-          throw new Error(`No assets are up for auction.`);
-        }
-        const invites = [];
-        for (let i = 0; i < numInvites; i += 1) {
-          invites.push(makeBidderInvite());
-        }
-        return invites;
+        getAuctionedAssetsAmounts: () => auctionedAssets,
+        getMinimumBid: () => minimumBid,
       },
-      getAuctionedAssetsAmounts: () => auctionedAssets,
-      getMinimumBid: () => minimumBid,
-    },
-  });
-});
+    });
+  },
+);

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -144,16 +144,24 @@ import { makeTables } from './state';
  * { Asset: amountMath.make(5), Price: amountMath.make(9) }
  *
  * @typedef {AmountKeywordRecord[]} AmountKeywordRecords
+ */
+
+/**
+ * @typedef {Object} Timer
+ * @typedef {number} Deadline
  *
- * @typedef {Object} ExitRule
+ * @typedef {{waived:null}} Waived
+ * @typedef {{onDemand:null}} OnDemand
+ *
+ * @typedef {{afterDeadline:{timer:Timer, deadline:Deadline}}} AfterDeadline
+ *
+ * @typedef {(Waived|OnDemand|AfterDeadline)} ExitRule
  * The possible keys are 'waived', 'onDemand', and 'afterDeadline'.
  * `timer` and `deadline` only are used for the `afterDeadline` key.
  * The possible records are:
  * `{ waived: null }`
  * `{ onDemand: null }`
  * `{ afterDeadline: { timer :Timer<Deadline>, deadline :Deadline } }
- * @property {Timer} [timer]
- * @property {Deadline} [deadline]
  */
 
 /**
@@ -225,8 +233,8 @@ import { makeTables } from './state';
  * @property {(offerHandle: OfferHandle) => boolean} isOfferActive
  * @property {(offerHandles: OfferHandle[]) => OfferRecord[]} getOffers
  * @property {(offerHandle: OfferHandle) => OfferRecord} getOffer
- * @property {(offerHandle: OfferHandle, sparseKeywords: SparseKeywords) => Allocation} getCurrentAllocation
- * @property {(offerHandles: OfferHandle[], sparseKeywords: SparseKeywords) => Allocation[]} getCurrentAllocations
+ * @property {(offerHandle: OfferHandle, sparseKeywords?: SparseKeywords) => Allocation} getCurrentAllocation
+ * @property {(offerHandles: OfferHandle[], sparseKeywords?: SparseKeywords) => Allocation[]} getCurrentAllocations
  * @property {() => InstanceRecord} getInstanceRecord
  * @property {(issuer: Issuer) => IssuerRecord} getIssuerRecord
  *
@@ -251,7 +259,7 @@ import { makeTables } from './state';
  * @param  {AmountKeywordRecord[]} newAllocations An
  * array of amountKeywordRecords  - objects with keyword keys
  * and amount values, with one keywordRecord per offerHandle.
- * @param  {Keyword[]} sparseKeywords An array of string
+ * @param  {Keyword[]=} sparseKeywords An array of string
  * keywords, which may be a subset of allKeywords
  * @returns {TODO}
  *


### PR DESCRIPTION
The contracts have three changes:
 * turn on typechecking
 * declare ContractFacet
 * declare zcf to be a ContractFacet (which requires a massive
	 indentatino)

Zoe got
 * improved description of ExitRule and
 * annotations that sparseKeywords are optional.