### PR TITLE
dIBC inbound

### DIFF
--- a/packages/SwingSet/docs/networking.md
+++ b/packages/SwingSet/docs/networking.md
@@ -15,11 +15,9 @@ Solo machines may be able to talk to chains and vice versa using specialized pro
 
 == The agoric-sdk User Local Port ==
 
-Each user of the Agoric testnet gets their own personal IBC listening port. You can access this `Port` object in `home.ibcport`, and you can learn its local address by calling `home.ibcport~.getLocalAddress()`, which will give you something like `/ibc-port/port8312`.
+Each user of the Agoric testnet gets a few personal IBC listening ports. You can access these `Port` objects in the `home.ibcport` array, and you can learn their local address by calling something like `home.ibcport[0]~.getLocalAddress()`, which will give you a local address like `/ibc-port/portbvmnfb`.
 
 This is currently the only way for user code to get an IBC `Port`, though non-IBC ports can be allocated using the local `home.network` object.  This is an advanced use case, to be documented later.
-
-`home.ibcport~.connect()`
 
 == Connecting to a Remote Port ==
 
@@ -30,7 +28,7 @@ You must also prepare a `ConnectionHandler` object to manage the connection you'
 Then you will call the `connect()` method on your local `Port`. This will return a `Promise` that will fire with a new `Connection` object, on which you can send data. Your `ConnectionHandler` will be notified about the new channel, and will receive inbound data from the other side.
 
 ```js
-home.ibcport~.connect(endpoint, connectionHandler)
+home.ibcport[0]~.connect(endpoint, connectionHandler)
   .then(conn => doSomethingWithConnection(conn));
 ```
 
@@ -58,7 +56,7 @@ You can ask the `Port` object this returns for its local address, which is espec
 port~.getLocalAddress().then(localAddress => useIt(localAddress))
 ```
 
-`home.ibcport~.addListener()`
+`home.ibcport[0]~.addListener()`
 
 Once the port is bound, you must call `addListener` to mark it as ready for inbound connections. You must provide this with a `ListenHandler` object, which has methods to react to listening events. As with `ConnectionHandler`, these methods are all optional.
 
@@ -140,4 +138,4 @@ port.revoke();
 
 to completely deallocate the port, remove all listeners, close all pending connections, and release its address.
 
-**CAUTION:** Be aware that if you call `home.ibcport~.revoke()`, it will be useless for new `.connect` or `.addListener` attempts.  You will need to provision a new Agoric client via https://testnet.agoric.com/ to obtain a new setup with a functioning `home.ibcport`.
+**CAUTION:** Be aware that if you call `home.ibcport[0]~.revoke()`, it will be useless for new `.connect` or `.addListener` attempts.  You will need to provision a new Agoric client via https://testnet.agoric.com/ to obtain a new setup with a functioning `home.ibcport`.

--- a/packages/SwingSet/src/vats/network/network.js
+++ b/packages/SwingSet/src/vats/network/network.js
@@ -7,6 +7,10 @@ import { toBytes } from './bytes';
 
 const harden = /** @type {<T>(x: T) => T} */ (rawHarden);
 
+/**
+ * Compatibility note: this must match what our peers use,
+ * so don't change it casually.
+ */
 export const ENDPOINT_SEPARATOR = '/';
 
 /**

--- a/packages/SwingSet/src/vats/network/network.js
+++ b/packages/SwingSet/src/vats/network/network.js
@@ -387,6 +387,7 @@ export function makeNetworkProtocol(protocolHandler, E = defaultE) {
           throw TypeError(`listenHandler is not defined`);
         }
         if (listening.has(localAddr)) {
+          // Last one wins.
           const [lport, lhandler] = listening.get(localAddr);
           if (lhandler === listenHandler) {
             return;
@@ -398,6 +399,8 @@ export function makeNetworkProtocol(protocolHandler, E = defaultE) {
         } else {
           listening.init(localAddr, [port, listenHandler]);
         }
+
+        // TODO: Check that the listener defines onAccept.
 
         await E(protocolHandler).onListen(
           port,

--- a/packages/SwingSet/test/test-network.js
+++ b/packages/SwingSet/test/test-network.js
@@ -29,9 +29,14 @@ const makeProtocolHandler = t => {
    */
   let l;
   let lp;
+  let nonce = 0;
   return harden({
     async onCreate(_protocol, _impl) {
       log('created', _protocol, _impl);
+    },
+    async generatePortID() {
+      nonce += 1;
+      return `${nonce}`;
     },
     async onBind(port, localAddr) {
       t.assert(port, `port is supplied to onBind`);

--- a/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
@@ -69,13 +69,14 @@ export default function setup(syscall, state, helpers) {
         await E(walletVat).setPresences();
       }
 
-      let chainTimerService;
       // Make services that are provided on the real or virtual chain side
       async function makeChainBundler(vats, timerDevice) {
         // Create singleton instances.
         const sharingService = await E(vats.sharing).getSharingService();
         const registry = await E(vats.registrar).getSharedRegistrar();
-        chainTimerService = await E(vats.timer).createTimerService(timerDevice);
+        const chainTimerService = await E(vats.timer).createTimerService(
+          timerDevice,
+        );
 
         const zoe = await E(vats.zoe).getZoe();
         const contractHost = await E(vats.host).makeHost();
@@ -137,7 +138,6 @@ export default function setup(syscall, state, helpers) {
         vats,
         bridgeMgr,
         packetSendersWhitelist = [],
-        { timerService },
       ) {
         const ps = [];
         // Every vat has a loopback device.
@@ -161,7 +161,6 @@ export default function setup(syscall, state, helpers) {
           const ibcHandler = await E(vats.ibc).createInstance(
             callbacks,
             packetSendersWhitelist,
-            { timerService },
           );
           bridgeMgr.register('dibc', ibcHandler);
           ps.push(
@@ -297,9 +296,7 @@ export default function setup(syscall, state, helpers) {
               );
 
               // Must occur after makeChainBundler.
-              await registerNetworkProtocols(vats, bridgeManager, pswl, {
-                timerService: chainTimerService,
-              });
+              await registerNetworkProtocols(vats, bridgeManager, pswl);
 
               // accept provisioning requests from the controller
               const provisioner = harden({
@@ -326,12 +323,7 @@ export default function setup(syscall, state, helpers) {
                 throw new Error(`controller must be given GCI`);
               }
 
-              const localTimerService = await E(vats.timer).createTimerService(
-                devices.timer,
-              );
-              await registerNetworkProtocols(vats, bridgeManager, pswl, {
-                timerService: localTimerService,
-              });
+              await registerNetworkProtocols(vats, bridgeManager, pswl);
 
               // Wire up the http server.
               await setupCommandDevice(vats.http, devices.command, {
@@ -362,9 +354,7 @@ export default function setup(syscall, state, helpers) {
               const localTimerService = await E(vats.timer).createTimerService(
                 devices.timer,
               );
-              await registerNetworkProtocols(vats, bridgeManager, pswl, {
-                timerService: localTimerService,
-              });
+              await registerNetworkProtocols(vats, bridgeManager, pswl);
 
               await setupCommandDevice(vats.http, devices.command, {
                 client: true,
@@ -398,9 +388,7 @@ export default function setup(syscall, state, helpers) {
               // bootAddress holds the pubkey of localclient
               const chainBundler = await makeChainBundler(vats, devices.timer);
 
-              await registerNetworkProtocols(vats, bridgeManager, pswl, {
-                timerService: chainTimerService,
-              });
+              await registerNetworkProtocols(vats, bridgeManager, pswl);
 
               const demoProvider = harden({
                 // build a chain-side bundle for a client.
@@ -429,9 +417,7 @@ export default function setup(syscall, state, helpers) {
               const localTimerService = await E(vats.timer).createTimerService(
                 devices.timer,
               );
-              await registerNetworkProtocols(vats, bridgeManager, pswl, {
-                timerService: localTimerService,
-              });
+              await registerNetworkProtocols(vats, bridgeManager, pswl);
               await addRemote(GCI);
               // addEgress(..., PROVISIONER_INDEX) is called in case two_chain
               const demoProvider = E(vats.comms).addIngress(
@@ -460,9 +446,7 @@ export default function setup(syscall, state, helpers) {
 
               // We pretend we're on-chain.
               const chainBundler = makeChainBundler(vats, devices.timer);
-              await registerNetworkProtocols(vats, bridgeManager, pswl, {
-                timerService: chainTimerService,
-              });
+              await registerNetworkProtocols(vats, bridgeManager, pswl);
 
               // Shared Setup (virtual chain side) ///////////////////////////
               await setupCommandDevice(vats.http, devices.command, {

--- a/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
@@ -10,6 +10,8 @@ import {
 import { GCI } from './gci';
 import { makeBridgeManager } from './bridge';
 
+const NUM_IBC_PORTS = 3;
+
 console.debug(`loading bootstrap.js`);
 
 function parseArgs(argv) {
@@ -101,14 +103,18 @@ export default function setup(syscall, state, helpers) {
         );
         return harden({
           async createUserBundle(_nickname) {
-            // Bind to a fresh port (unspecified name) on the IBC implementation
-            // and provide it for the user to have.
-            const ibcport = await E(vats.network).bind('/ibc-port/');
+            // Bind to some fresh ports (unspecified name) on the IBC implementation
+            // and provide them for the user to have.
+            const ibcports = [];
+            for (let i = 0; i < NUM_IBC_PORTS; i += 1) {
+              // eslint-disable-next-line no-await-in-loop
+              ibcports.push(await E(vats.network).bind('/ibc-port/'));
+            }
             const bundle = harden({
               chainTimerService,
               sharingService,
               contractHost,
-              ibcport,
+              ibcports,
               registrar: registry,
               registry,
               zoe,

--- a/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
@@ -105,16 +105,16 @@ export default function setup(syscall, state, helpers) {
           async createUserBundle(_nickname) {
             // Bind to some fresh ports (unspecified name) on the IBC implementation
             // and provide them for the user to have.
-            const ibcports = [];
+            const ibcport = [];
             for (let i = 0; i < NUM_IBC_PORTS; i += 1) {
               // eslint-disable-next-line no-await-in-loop
-              ibcports.push(await E(vats.network).bind('/ibc-port/'));
+              ibcport.push(await E(vats.network).bind('/ibc-port/'));
             }
             const bundle = harden({
               chainTimerService,
               sharingService,
               contractHost,
-              ibcports,
+              ibcport,
               registrar: registry,
               registry,
               zoe,

--- a/packages/cosmic-swingset/lib/ag-solo/vats/ibc.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/ibc.js
@@ -23,10 +23,10 @@ const FIXME_ALLOW_NAIVE_RELAYS = true;
 // cannot be sent before the channel ack is complete
 // (no sendPacket within a channelOpenAck).
 //
-// FIXME: We might be fix within the relayer, which currently
-// fails with:
-// cannot update client with ID ibczeroclient: header blocktime
-// ≤ latest client state block time (X ≤ X): invalid block header
+// FIXME: We might be able to fix this within the relayer, which
+// currently fails with:
+//   cannot update client with ID ibczeroclient: header blocktime
+//   ≤ latest client state block time (X ≤ X): invalid block header
 const FIXME_SENDPACKET_DELAY_S = 1;
 
 /**

--- a/packages/cosmic-swingset/lib/ag-solo/vats/ibc.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/ibc.js
@@ -19,16 +19,15 @@ const DEFAULT_PACKET_TIMEOUT = 1000;
 // only way to create channels.
 const FIXME_ALLOW_NAIVE_RELAYS = true;
 
-// FIXME: We need to delay to a later block to work around
-// a relayer race condition (no sendPacket too soon after
-// a channelOpenAck).
+// We need to delay to a later block because packets
+// cannot be sent before the channel ack is complete
+// (no sendPacket within a channelOpenAck).
 //
-// I[2020-05-01|15:32:43.721] - listening to tx events from ibc0...
-// I[2020-05-01|15:32:43.721] - listening to block events from ibc0...
-// Error: no transactions returned with query
-// no transactions returned with query
-// [exits]
-const FIXME_SENDPACKET_DELAY_S = 10; // fail <=3, work >=4
+// FIXME: We might be fix within the relayer, which currently
+// fails with:
+// cannot update client with ID ibczeroclient: header blocktime
+// ≤ latest client state block time (X ≤ X): invalid block header
+const FIXME_SENDPACKET_DELAY_S = 1;
 
 /**
  * @typedef {import('@agoric/swingset-vat/src/vats/network').ProtocolHandler} ProtocolHandler

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-network.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-network.js
@@ -3,7 +3,7 @@ import harden from '@agoric/harden';
 import { makeRouterProtocol } from '@agoric/swingset-vat/src/vats/network/router';
 
 function build(E) {
-  return harden(makeRouterProtocol('/', E));
+  return harden(makeRouterProtocol(E));
 }
 
 export default function setup(syscall, state, helpers) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10135,22 +10135,6 @@ node-notifier@^5.4.2:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-pre-gyp@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz#db1f33215272f692cd38f03238e3e9b47c5dd054"
@@ -14131,7 +14115,7 @@ tar-stream@^2.0.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@^4, tar@^4.4.10, tar@^4.4.12, tar@^4.4.2, tar@^4.4.8:
+tar@^4, tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==


### PR DESCRIPTION
Fail harder if onAccept is not supplied to a listener.

Don't accept the endpoint separator as a parameter; it is a manifest constant.

Reject pending sends on close, and connects on revoke.