### PR TITLE
fix: missed a change in refactoring "cancel" to "complete"

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
@@ -361,7 +361,7 @@ export async function makeWallet(
         offerHandle,
       } = await executeOffer(compiledOffer, inviteP);
 
-      idToCancel.set(id, () => {
+      isToComplete.set(id, () => {
         alreadyResolved = true;
         return E(completeObj).complete();
       });


### PR DESCRIPTION
Fixes [hackathon#7](https://github.com/Agoric/cross-chain-hackathon/issues/7).

## Description

One usage of `idToCancel` did not get renamed `idToComplete`.

## Testing

Manually tested in Kevin McCabe's environment

