### PR TITLE
Be lazy in choosing which handler to use

### DIFF
--- a/packages/eventual-send/src/index.js
+++ b/packages/eventual-send/src/index.js
@@ -462,7 +462,7 @@ export function makeHandledPromise(Promise) {
               // so we don't risk the user's args leaking into this expansion.
               // eslint-disable-next-line no-use-before-define
               resolve(forwardingHandler[operation](o, ...opArgs, returnedP));
-            });
+            }).catch(reject);
           }
         })
         .catch(reject);


### PR DESCRIPTION
This fixes a race between forwarding a promise and discarding its old handler.