### PR TITLE
update liveslots and HandledPromise to get correct ordering

### DIFF
--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -140,14 +140,14 @@ function build(syscall, _state, makeRoot, forVatID) {
     // prepare for the kernel to tell us about resolution
 
     function fulfillToLocalObject(newObject) {
-      console.log(`fulfillToLocalObject`);
+      // console.log(`fulfillToLocalObject`);
       // the old handler should never be called again
       currentSlotID = 'local';
       resolve(newObject);
     }
 
     function fulfillToRemoteObject(newSlot, newPresence) {
-      console.log(`fulfillToRemoteObject ${newSlot} ${newPresence}`);
+      // console.log(`fulfillToRemoteObject ${newSlot} ${newPresence}`);
       insistVatType('object', newSlot);
       // Now, to ensure any p~.foo() calls during the remainder of the
       // *current* turn also go to 'newSlot', we modify our old handler, by

--- a/packages/SwingSet/test/message-patterns.js
+++ b/packages/SwingSet/test/message-patterns.js
@@ -451,7 +451,8 @@ export function buildPatterns(E, log) {
       p1.resolve(x);
     };
   }
-  out.a71 = ['pipe1', 'pipe2', 'pipe3', 'p1.then', 'p2.then', 'p3.then'];
+  out.a71 = ['pipe1', 'p1.then', 'pipe2', 'p2.then', 'pipe3', 'p3.then'];
+  outPipelined.a71 = ['pipe1', 'pipe2', 'pipe3', 'p1.then', 'p2.then', 'p3.then'];
   test('a71');
 
   // px!pipe1()!pipe2()!pipe3(); px.resolve() but better

--- a/packages/eventual-send/src/index.js
+++ b/packages/eventual-send/src/index.js
@@ -473,7 +473,7 @@ export function makeHandledPromise(Promise) {
               // so we don't risk the user's args leaking into this expansion.
               // eslint-disable-next-line no-use-before-define
               resolve(forwardingHandler[operation](o, ...opArgs, returnedP));
-            });
+            }).catch(reject);
           }
         })
         .catch(reject);


### PR DESCRIPTION
This combines @michaelfig's branch (to update HandledPromise), my branch to change liveslots to use the new HP more correctly, and some new tests to check the order in which operations happen.

@michaelfig: the test (`cd packages/SwingSet; yarn build; node -r esm test/test-vpid-liveslots.js`) currently provokes an `UnhandledPromiseRejectionWarning`, which I think is coming from HandledPromise, in the `handle()` functon, in the `resolve(forwardingHandler[operation]..`) in this clause (around line 475):

```js
          } else {
            p.then(o => {
              // We now have the naked object,
              // so resolve to the forwardingHandler's operation.
              // opArgs are something like [prop] or [method, args],
              // so we don't risk the user's args leaking into this expansion.
              // eslint-disable-next-line no-use-before-define
              resolve(forwardingHandler[operation](o, ...opArgs, returnedP));
            });
```

In particular, if I resolve a HandledPromise to data (something without a callback `four()` method), and then do `E(p1).four()`, I get a warning from that line that says `TypeError: o["four"] is not a function`.

Is that something that can be fixed from within HandledPromise?

If you can figure that out, I think the rest of this can be aimed towards landing. I will clean up my tests and other changes (probably squash everything into a single commit, and remove a lot of the debugging messages). I'm guessing we'll need to land both your HP changes and my liveslots changes in the same PR, since my tests are kinda picky.

I haven't tried to fix any linting errors yet, I'll do that last.
