### PR TITLE
[cosmic-swingset] Add mailbox vat, allowing users to send and receive payments

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
@@ -80,6 +80,7 @@ export default function setup(syscall, state, helpers) {
 
         const zoe = await E(vats.zoe).getZoe();
         const contractHost = await E(vats.host).makeHost();
+        const mailboxAdmin = await E(vats.mailbox).getMailboxAdmin();
 
         // Make the other demo mints
         const issuerNames = ['moola', 'simolean'];
@@ -119,6 +120,7 @@ export default function setup(syscall, state, helpers) {
               registrar: registry,
               registry,
               zoe,
+              mailboxAdmin,
             });
 
             const payments = await E(vats.mints).mintInitialPayments(

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-mailbox.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-mailbox.js
@@ -1,0 +1,48 @@
+import harden from '@agoric/harden';
+import { makeRegistrar } from '@agoric/registrar';
+import { E } from '@agoric/eventual-send';
+import { assert } from '@agoric/assert';
+
+function build(_log) {
+  const mailboxRegistry = makeRegistrar();
+
+  const mailboxAdmin = harden({
+    makeMailbox: (mailboxPrefix, purse, action = 'deposit') => {
+      assert.typeof(action, 'string');
+      const mailbox = harden({
+        receivePayment: payment => {
+          switch (action) {
+            case 'deposit': {
+              return E(purse).deposit(payment);
+            }
+            default: {
+              throw new Error(`action ${action} is not implemented`);
+            }
+          }
+        },
+      });
+      const key = mailboxRegistry.register(mailboxPrefix, mailbox);
+      return key;
+    },
+    sendPayment: (mailboxKey, payment) => {
+      const mailbox = mailboxRegistry.get(mailboxKey);
+      return mailbox.receivePayment(payment);
+    },
+    // We deliberately do not expose the entire registry so that the
+    // only way someone can send a payment using a mailbox is if they
+    // have obtained the key from the creator of a mailbox.
+  });
+
+  return harden({
+    getMailboxAdmin: () => mailboxAdmin,
+  });
+}
+
+export default function setup(syscall, state, helpers) {
+  return helpers.makeLiveSlots(
+    syscall,
+    state,
+    _E => build(helpers.log),
+    helpers.vatID,
+  );
+}

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-mailbox.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-mailbox.js
@@ -30,7 +30,8 @@ function build(_log) {
     },
     // We deliberately do not expose the entire registry so that the
     // only way someone can send a payment using a mailbox is if they
-    // have obtained the key from the creator of a mailbox.
+    // have obtained the key. This is intended only to cut down on
+    // spam. The key should not be assumed to be unforgeable or unguessable.
   });
 
   return harden({


### PR DESCRIPTION
Closes #1059

This adds the mailbox vat, allowing users to send and receive payments. The mailboxAdmin is added to `home`.

The following was how I was testing, but I'm open to any and all improvement!

## How to test the functionality
1. From the REPL, call `E(home.mailboxAdmin).makeMailbox('myMoola', moolaPurse, 'deposit')` where moolaPurse was gotten from the wallet. 
2. You will get a string identifier for the mailbox `mailboxKey`
3. From the REPL, call `E(home.mailboxAdmin).sendPayment(mailboxKey, payment)` where payment was withdrawn from the wallet.
4. You should see the balance of the moola purse go back to the original amount. 

## How to ensure the usual functionality still works 
1. Run dapp-encouragement following the steps here: https://agoric.com/documentation/dapps/
2. Manually test dapp-encouragement