### PR TITLE
ag-nchainz start-relayer

### DIFF
--- a/packages/cosmic-swingset/bin/ag-nchainz
+++ b/packages/cosmic-swingset/bin/ag-nchainz
@@ -16,6 +16,11 @@ trap 'kill $(jobs -p) 2>/dev/null' EXIT
 BASE_PORT=8000
 NUM_SOLOS=1
 
+get_alphabetic() {
+  id="$1"
+  ida=$(echo "$1" | sed -e 's/0/zero/g; s/1/one/g; s/2/two/g; s/3/three/g; s/4/four/g; s/5/five/g; s/6/six/g; s/7/seven/g; s/8/eight/g; s/9/nine/g;')
+}
+
 real0=$(readlink "${BASH_SOURCE[0]}" || echo "${BASH_SOURCE[0]}")
 thisdir=$(cd "$(dirname -- "$real0")" && pwd -P)
 
@@ -115,6 +120,106 @@ start-solos)
   echo "Waiting for all ${1+"$@ "}solos (Hit Control-C to exit)..."
   wait
   exit 0
+  ;;
+start-relayer)
+  replace=no
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+    --replace)
+      replace=yes
+      shift
+      ;;
+    *)
+      template=$1
+      shift
+      break
+      ;;
+    esac
+  done
+  BASE_RE='([^/]*)\.json$'
+
+  echo "Reading path specification (Control-D to finish, Control-C to abort)..."
+  tmpfile=$(mktemp ${TMPDIR-/tmp}/relayer-start.XXXXXX)
+  trap "rm -f '$tmpfile'" EXIT
+  cat > "$tmpfile"
+
+  srccid=$(jq -r '.src["connection-id"]' "$tmpfile")
+  if [[ $srccid == null ]]; then
+    echo 1>&2 "You must specify .src[\"connection-id\"]"
+    exit 1
+  fi
+
+  jqexpr=
+  for fname in nchainz/config/*.json; do
+    [[ -z $template || $fname == "nchainz/config/$template.json" ]] || continue
+    [[ $fname =~ $BASE_RE ]] || continue
+    if grep -q '"generator": "ag-nchainz"' "$fname"; then :
+    else
+      oldsrccid=$(jq -r '.src["connection-id"]' "$fname")
+      olddstcid=$(jq -r '.dst["connection-id"]' "$fname")
+      case "$oldsrccid:$olddstcid" in
+      $srccid:*)
+        # Forward order.
+        jqexpr='.[0] * .[1]'
+        template=${BASH_REMATCH[1]}
+        break
+        ;;
+      *:$srccid)
+        # Swapped order.
+        jqexpr='{ src: .[0].dst, dst: .[0].src, strategy: .[0].strategy } * .[1]'
+        template=${BASH_REMATCH[1]}
+        break
+        ;;
+      esac
+    fi
+  done
+
+  if [[ -z $jqexpr ]]; then
+    if [[ -n $template ]]; then
+      echo 1>&2 "Connection ID \`$srccid' is not defined in nchainz/config/$template.json"
+    else
+      echo 1>&2 "Connection ID \`$srccid' is not defined in nchainz/config/*.json"
+    fi
+    exit 1
+  fi
+
+  if [[ $replace == yes ]]; then
+    # Overwrite existing path.
+    echo "Replacing path \`$path'"
+    path=$template
+    jq -s "$jqexpr" \
+      "nchainz/config/$template.json" "$tmpfile" > "nchainz/config/$path.json"
+  else
+    # Create a new path.
+    i=0
+    get_alphabetic $i
+    while [[ -e "nchainz/config/$ida.json" ]]; do
+      i=$(( $i + 1 ))
+      get_alphabetic $i
+    done
+    path=$ida
+
+    echo "Creating new path \`$path'"
+    jq -s "$jqexpr"' * { "generator": "ag-nchainz" }' \
+      "nchainz/config/$template.json" "$tmpfile" > "nchainz/config/$path.json"
+  fi
+
+  echo "$ rly config add-dir nchainz/config/"
+  rly config add-dir nchainz/config/
+
+  echo "$ rly start -d $path"
+  rly start -d "$path" &
+  try=0
+  while ! rly tx link $path --timeout=3s -d >> "nchainz/logs/$path.log" 2>&1; do
+    try=$(( $try + 1 ))
+    echo "$path tx link not yet ready (try=$try)"
+    sleep 1
+  done
+  try=$(( $try + 1 ))
+  echo "$path tx link initialized (try=$try)"
+
+  # Wait for the rly start command.
+  wait
   ;;
 *)
   echo 1>&2 "$progname: unrecognized command \`$COMMAND'"

--- a/packages/cosmic-swingset/lib/ag-solo/vats/ibc.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/ibc.js
@@ -433,28 +433,26 @@ export function makeIBCProtocolHandler(
       }
 
       // We explain to the user how to configure a naive relayer.
+      const q = JSON.stringify;
       E(chandler)
         .infoMessage(
           `\
 # Set up the relayer for this path:
-paths:
-  XXX-PATH-ID:
-    src:
-      chain-id: XXX-SRC-CHAIN
-      client-id: YYY-DST-CLIENT
-      connection-id: ${hops[0]}
-      channel-id: ${channelID}
-      port-id: ${portID}
-      order: ${order}
-    dst:
-      chain-id: YYY-DST-CHAIN
-      client-id: XXX-SRC-CLIENT
-      connection-id: XXX-SRC-CONNECTION
-      channel-id: ${rChannelID}
-      port-id: ${rPortID}
-      order: ${order}
-    strategy:
-      type: naive
+ag-nchainz start-relayer <<'EOF'
+{
+  "src": {
+    "connection-id": ${q(hops[0])},
+    "channel-id": ${q(channelID)},
+    "port-id": ${q(portID)},
+    "order": ${q(order)}
+  },
+  "dst": {
+    "channel-id": ${q(rChannelID)},
+    "port-id": ${q(rPortID)},
+    "order": ${q(order)}
+  }
+}
+EOF
 # then your connection will try to proceed.
 `,
         )


### PR DESCRIPTION
This change allows starting the IBC relayer directly from the command printed out by the `connect` call.
