### PR TITLE
Always send non-empty acknowledgements

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/html/main.js
+++ b/packages/cosmic-swingset/lib/ag-solo/html/main.js
@@ -53,8 +53,7 @@ function run() {
             .replace('&', '&amp;') // quote ampersands
             .replace('<', '&lt;') // quote html
             .replace(/\t/g, '  ') // expand tabs
-            .replace(/ /g, '&nbsp;') // convert spaces
-            .replace(/&nbsp;&nbsp;/g, '&nbsp; '), // allow multispace to break
+            .replace(/ {2}/g, ' &nbsp;'), // try preserving whitespace
       )
       .join('<br />');
   }


### PR DESCRIPTION
Until cosmos-sdk and the relayer support empty acks, we need to send at least *something* so that signature verification succeeds.
