### PR TITLE
fix: filter proposal give and want by sparseKeywords in zcf.reallocate

### DIFF
--- a/packages/zoe/src/objArrayConversion.js
+++ b/packages/zoe/src/objArrayConversion.js
@@ -71,7 +71,7 @@ export const filterObj = /** @type {function<T>(T, string[]): T} */ (
 };
 
 // return a new object with only the keys in subsetKeywords. `obj`
-// may *not* have all the `subsetKeywords`.
+// is allowed to not include keywords in subsetKeywords.
 export const filterObjOkIfMissing = /** @type {function<T>(T, string[]): T} */ (
   obj,
   subsetKeywords,

--- a/packages/zoe/src/objArrayConversion.js
+++ b/packages/zoe/src/objArrayConversion.js
@@ -70,6 +70,21 @@ export const filterObj = /** @type {function<T>(T, string[]): T} */ (
   return newObj;
 };
 
+// return a new object with only the keys in subsetKeywords. `obj`
+// may *not* have all the `subsetKeywords`.
+export const filterObjOkIfMissing = /** @type {function<T>(T, string[]): T} */ (
+  obj,
+  subsetKeywords,
+) => {
+  const newObj = {};
+  subsetKeywords.forEach(keyword => {
+    if (obj[keyword] !== undefined) {
+      newObj[keyword] = obj[keyword];
+    }
+  });
+  return newObj;
+};
+
 /**
  * @typedef {import('./zoe').Allocation} Allocation
  * @typedef {import('@agoric/ertp/src/amountMath').AmountMath} AmountMath

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -18,6 +18,7 @@ import {
   objToArray,
   objToArrayAssertFilled,
   filterObj,
+  filterObjOkIfMissing,
   filterFillAmounts,
   assertSubset,
 } from './objArrayConversion';
@@ -460,7 +461,22 @@ const makeZoe = (additionalEndowments = {}) => {
 
         const offerRecords = offerTable.getOffers(offerHandles);
 
-        const proposals = offerRecords.map(offerRecord => offerRecord.proposal);
+        const amountMathKeywordRecord = contractFacet.getAmountMaths(
+          sparseKeywords,
+        );
+
+        // Filter proposal `want` and `give` by sparseKeywords
+        const filterProposalBySparseKeywords = proposal => {
+          return harden({
+            give: filterObjOkIfMissing(proposal.give, sparseKeywords),
+            want: filterObjOkIfMissing(proposal.want, sparseKeywords),
+          });
+        };
+
+        const proposals = offerRecords.map(offerRecord =>
+          filterProposalBySparseKeywords(offerRecord.proposal),
+        );
+
         const currentAmountMatrix = offerRecords.map(({ handle }) => {
           const filteredAmounts = contractFacet.getCurrentAllocation(
             handle,
@@ -468,9 +484,7 @@ const makeZoe = (additionalEndowments = {}) => {
           );
           return objToArray(filteredAmounts, sparseKeywords);
         });
-        const amountMathKeywordRecord = contractFacet.getAmountMaths(
-          sparseKeywords,
-        );
+
         const amountMathsArray = objToArray(
           amountMathKeywordRecord,
           sparseKeywords,

--- a/packages/zoe/test/unitTests/contracts/test-mintPayments.js
+++ b/packages/zoe/test/unitTests/contracts/test-mintPayments.js
@@ -4,6 +4,8 @@ import { test } from 'tape-promise/tape';
 import bundleSource from '@agoric/bundle-source';
 
 import { E } from '@agoric/eventual-send';
+import harden from '@agoric/harden';
+import produceIssuer from '@agoric/ertp';
 
 import { makeGetInstanceHandle } from '../../../src/clientSupport';
 import { makeZoe } from '../../../src/zoe';
@@ -45,6 +47,75 @@ test('zoe - mint payments', async t => {
 
     // Bob got 1000 tokens
     t.deepEquals(tokenPayoutAmount, tokens1000);
+  } catch (e) {
+    t.assert(false, e);
+    console.log(e);
+  }
+});
+
+test('zoe - mint payments with unrelated give and want', async t => {
+  t.plan(3);
+  try {
+    const zoe = makeZoe({ require });
+    // Pack the contract.
+    const { source, moduleFormat } = await bundleSource(mintPaymentsRoot);
+    const installationHandle = await E(zoe).install(source, moduleFormat);
+    const inviteIssuer = await E(zoe).getInviteIssuer();
+    const getInstanceHandle = makeGetInstanceHandle(inviteIssuer);
+
+    const moolaBundle = produceIssuer('moola');
+    const simoleanBundle = produceIssuer('simolean');
+
+    // Alice creates a contract instance
+    const issuerKeywordRecord = harden({
+      Asset: moolaBundle.issuer,
+      Price: simoleanBundle.issuer,
+    });
+    const adminInvite = await E(zoe).makeInstance(
+      installationHandle,
+      issuerKeywordRecord,
+    );
+    const instanceHandle = await getInstanceHandle(adminInvite);
+
+    // Bob wants to get 1000 tokens so he gets an invite and makes an
+    // offer
+    const { publicAPI } = await E(zoe).getInstanceRecord(instanceHandle);
+    const invite = await E(publicAPI).makeInvite();
+    t.ok(await E(inviteIssuer).isLive(invite), `valid invite`);
+    const proposal = harden({
+      give: { Asset: moolaBundle.amountMath.make(10) },
+      want: { Price: simoleanBundle.amountMath.make(100) },
+    });
+    const paymentKeywordRecord = harden({
+      Asset: moolaBundle.mint.mintPayment(moolaBundle.amountMath.make(10)),
+    });
+    const { payout: payoutP } = await E(zoe).offer(
+      invite,
+      proposal,
+      paymentKeywordRecord,
+    );
+
+    // Bob's payout promise resolves
+    const bobPayout = await payoutP;
+    const bobTokenPayout = await bobPayout.Token;
+    const bobMoolaPayout = await bobPayout.Asset;
+
+    // Let's get the tokenIssuer from the contract so we can evaluate
+    // what we get as our payout
+    const tokenIssuer = await E(publicAPI).getTokenIssuer();
+    const tokenAmountMath = await E(tokenIssuer).getAmountMath();
+
+    const tokens1000 = await E(tokenAmountMath).make(1000);
+    const tokenPayoutAmount = await E(tokenIssuer).getAmountOf(bobTokenPayout);
+
+    const moola10 = moolaBundle.amountMath.make(10);
+    const moolaPayoutAmount = await moolaBundle.issuer.getAmountOf(
+      bobMoolaPayout,
+    );
+
+    // Bob got 1000 tokens
+    t.deepEquals(tokenPayoutAmount, tokens1000, `bobTokenPayout`);
+    t.deepEquals(moolaPayoutAmount, moola10, `bobMoolaPayout`);
   } catch (e) {
     t.assert(false, e);
     console.log(e);

--- a/packages/zoe/test/unitTests/test-offerSafety.js
+++ b/packages/zoe/test/unitTests/test-offerSafety.js
@@ -220,6 +220,24 @@ test('isOfferSafeForOffer - equal to want, equal to give', t => {
   }
 });
 
+test('isOfferSafeForOffer - empty proposal', t => {
+  t.plan(1);
+  try {
+    const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
+    const amountMathKeywordRecord = harden({
+      A: moolaR.amountMath,
+      B: simoleanR.amountMath,
+      C: bucksR.amountMath,
+    });
+    const proposal = harden({ give: {}, want: {} });
+    const amounts = harden({ A: moola(1), B: simoleans(6), C: bucks(7) });
+
+    t.ok(isOfferSafeForOffer(amountMathKeywordRecord, proposal, amounts));
+  } catch (e) {
+    t.assert(false, e);
+  }
+});
+
 // All users get exactly what they wanted
 test('isOfferSafeForAll - All users get what they wanted', t => {
   t.plan(1);


### PR DESCRIPTION
This PR fixes a bug (#1075) in `zcf.reallocate` in which we were filtering and filling the current allocation by `sparseKeywords` and asserting that the `newAllocation` is filled for `sparseKeywords` but we were not filtering the `proposal.want` or `proposal.give`, leading to valid partial reallocations being rejected for not meeting offer safety. See issue for more details. 

Adds two tests. One test ensures that an allocation of something that is not specified in the proposal is offer safe. Another test ensures that the `mintPayments.js` contract works even if the user has `proposal.want` and `proposal.give` using different keywords. The user gets a refund and the newly minted assets.

Edit (5/8/2020, 4:55pm): Updated information about how we handle sparse keywords for the current allocation and the `newAllocation`. We do not fill the `newAllocation`, we only assert that all the sparseKeywords exist. 

Closes #1075 