### PR TITLE
Honour provisioning requests, and save in an egress database

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
+++ b/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
@@ -42,6 +42,7 @@ export async function connectToFakeChain(basedir, GCI, role, delay, inbound) {
   const vatsdir = path.join(basedir, 'vats');
   const argv = [`--role=${role}`, bootAddress];
   const stateDBdir = path.join(basedir, `fake-chain-${GCI}-state`);
+  const egressesDB = path.join(basedir, `fake-chain-${GCI}-egresses`);
   function doOutboundBridge(dstID, obj) {
     console.error('received', dstID, obj);
     return 'IBC and bridge device not used on fake-chain';
@@ -53,6 +54,7 @@ export async function connectToFakeChain(basedir, GCI, role, delay, inbound) {
   }
   const s = await launch(
     stateDBdir,
+    egressesDB,
     mailboxStorage,
     doOutboundBridge,
     flushChainSends,

--- a/packages/cosmic-swingset/lib/ag-solo/init-basedir.js
+++ b/packages/cosmic-swingset/lib/ag-solo/init-basedir.js
@@ -12,6 +12,7 @@ export default function initBasedir(
   webhost,
   subdir,
   egresses,
+  recover,
 ) {
   const here = __dirname;
   try {
@@ -100,6 +101,9 @@ export default function initBasedir(
     const agchServerDir = path.join(basedir, 'ag-cosmos-helper-statedir');
     if (!fs.existsSync(agchServerDir)) {
       fs.mkdirSync(agchServerDir);
+      const recoverArgs = recover ? ['--recover'] : [];
+      const recoverInput = recover ? `${recover}\n` : '';
+
       // we assume 'ag-cosmos-helper' is on $PATH for now, see chain-cosmos-sdk.js
       const keyName = 'ag-solo';
       // we suppress stderr because it displays the mnemonic phrase, but
@@ -113,9 +117,10 @@ export default function initBasedir(
           keyName,
           '--home',
           agchServerDir,
+          ...recoverArgs,
         ],
         {
-          input: Buffer.from(''),
+          input: Buffer.from(recoverInput),
           stdio: ['pipe', 'ignore', 'ignore'],
         },
       );

--- a/packages/cosmic-swingset/lib/ag-solo/main.js
+++ b/packages/cosmic-swingset/lib/ag-solo/main.js
@@ -67,11 +67,18 @@ start
         },
       });
       const webport = Number(subOpts.webport);
-      const { webhost, egresses } = subOpts;
+      const { webhost, egresses, recover } = subOpts;
       const basedir = subArgs[0] || AG_SOLO_BASEDIR;
       const subdir = subArgs[1];
       assert(basedir !== undefined, 'you must provide a BASEDIR');
-      initBasedir(basedir, webport, webhost, subdir, egresses.split(','));
+      initBasedir(
+        basedir,
+        webport,
+        webhost,
+        subdir,
+        egresses.split(','),
+        recover,
+      );
       await resetState(basedir);
 
       // TODO: We may want to give some instructions.  This is probably not the

--- a/packages/cosmic-swingset/lib/block-manager.js
+++ b/packages/cosmic-swingset/lib/block-manager.js
@@ -7,6 +7,7 @@ const DELIVER_INBOUND = 'DELIVER_INBOUND';
 const END_BLOCK = 'END_BLOCK';
 const COMMIT_BLOCK = 'COMMIT_BLOCK';
 const IBC_EVENT = 'IBC_EVENT';
+const PLEASE_PROVISION = 'PLEASE_PROVISION';
 
 export default function makeBlockManager({
   deliverInbound,
@@ -48,6 +49,11 @@ export default function makeBlockManager({
 
       case IBC_EVENT: {
         p = doBridgeInbound('dibc', action);
+        break;
+      }
+
+      case PLEASE_PROVISION: {
+        p = doBridgeInbound('provision', action);
         break;
       }
 

--- a/packages/cosmic-swingset/lib/chain-main.js
+++ b/packages/cosmic-swingset/lib/chain-main.js
@@ -38,6 +38,7 @@ export default async function main(progname, args, { path, env, agcc }) {
   // is better than scribbling into the current directory.
   const cosmosHome = getFlagValue('home', `${env.HOME}/.ag-chain-cosmos`);
   const stateDBDir = `${cosmosHome}/data/ag-cosmos-chain-state`;
+  const egressesDB = `${cosmosHome}/config/egresses`;
 
   // console.log('Have AG_COSMOS', agcc);
 
@@ -186,6 +187,7 @@ export default async function main(progname, args, { path, env, agcc }) {
     }
     const s = await launch(
       stateDBDir,
+      egressesDB,
       mailboxStorage,
       doOutboundBridge,
       flushChainSends,


### PR DESCRIPTION
Requires #1084

This makes out-of-SwingSet provisioning possible and persists into a swing-store database for easy restoring of old egresses in a new chain.

Also, allow recovery of an `ag-solo` key.
