### PR TITLE
Implement `agoric cosmos ...` and `agoric cosmos provision`

### DIFF
--- a/packages/agoric-cli/lib/cosmos.js
+++ b/packages/agoric-cli/lib/cosmos.js
@@ -1,0 +1,65 @@
+import chalk from 'chalk';
+
+export default async function cosmosMain(progname, rawArgs, powers, opts) {
+  const IMAGE = `agoric/agoric-sdk`;
+  const { anylogger, spawn, process } = powers;
+  const log = anylogger('agoric:cosmos');
+
+  const popts = opts;
+
+  const pspawnEnv = { ...process.env };
+  if (popts.verbose > 1) {
+    // Enable verbose logs.
+    pspawnEnv.DEBUG = 'agoric';
+  } else if (!popts.verbose) {
+    // Disable more logs.
+    pspawnEnv.DEBUG = '';
+  }
+
+  const pspawn = (
+    cmd,
+    cargs,
+    { stdio = 'inherit', env = pspawnEnv, ...rest } = {},
+  ) => {
+    log.debug(chalk.blueBright(cmd, ...cargs));
+    const cp = spawn(cmd, cargs, { stdio, env, ...rest });
+    const pr = new Promise((resolve, _reject) => {
+      cp.on('exit', resolve);
+      cp.on('error', () => resolve(-1));
+    });
+    pr.cp = cp;
+    return pr;
+  };
+
+  function helper(args, hopts = undefined) {
+    if (opts.sdk) {
+      return pspawn('ag-cosmos-helper', args, hopts);
+    }
+
+    // Don't allocate a TTY if we're not talking to one.
+    const ttyFlag = process.stdin.isTTY && process.stdout.isTTY ? '-it' : '-i';
+
+    return pspawn(
+      'docker',
+      [
+        'run',
+        `--volume=ag-cosmos-helper-state:/root/.ag-cosmos-helper`,
+        '--rm',
+        ttyFlag,
+        '--entrypoint=ag-cosmos-helper',
+        IMAGE,
+        ...args,
+      ],
+      hopts,
+    );
+  }
+
+  if (popts.pull) {
+    const status = await pspawn('docker', ['pull', IMAGE]);
+    if (status) {
+      return status;
+    }
+  }
+
+  return helper(rawArgs.slice(1));
+}

--- a/packages/agoric-cli/lib/main.js
+++ b/packages/agoric-cli/lib/main.js
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 
+import cosmosMain from './cosmos';
 import deployMain from './deploy';
 import initMain from './init';
 import installMain from './install';
@@ -51,9 +52,8 @@ const main = async (progname, rawArgs, powers) => {
     .command('cosmos <command...>')
     .description('client for an Agoric Cosmos chain')
     .action(async (command, cmd) => {
-      const opts = {...program.opts(), ...cmd.opts()};
-      const mod = await import('./cosmos');
-      return subMain(mod.default, ['cosmos', ...command], opts);
+      const opts = { ...program.opts(), ...cmd.opts() };
+      return subMain(cosmosMain, ['cosmos', ...command], opts);
     });
 
   program

--- a/packages/agoric-cli/lib/main.js
+++ b/packages/agoric-cli/lib/main.js
@@ -48,6 +48,15 @@ const main = async (progname, rawArgs, powers) => {
 
   // Add each of the commands.
   program
+    .command('cosmos <command...>')
+    .description('client for an Agoric Cosmos chain')
+    .action(async (command, cmd) => {
+      const opts = {...program.opts(), ...cmd.opts()};
+      const mod = await import('./cosmos');
+      return subMain(mod.default, ['cosmos', ...command], opts);
+    });
+
+  program
     .command('init <project>')
     .description('create a new Dapp directory named <project>')
     .option(
@@ -113,6 +122,12 @@ const main = async (progname, rawArgs, powers) => {
 
   // Throw an error instead of exiting directly.
   program.exitOverride();
+
+  // Hack: cosmos arguments are always unparsed.
+  const cosmosIndex = rawArgs.indexOf('cosmos');
+  if (cosmosIndex >= 0) {
+    rawArgs.splice(cosmosIndex + 1, 0, '--');
+  }
 
   try {
     await program.parseAsync(rawArgs, { from: 'user' });


### PR DESCRIPTION
Requires #1084, #1085

This provides `agoric cosmos ...` which is mostly a frontend for `ag-cosmos-helper`.  I know @warner, we had decided on `agc ...`, but I think this is the right place to put it.

The `agoric cosmos provision` subcommand is useful for a CLI way to provision a public address and nickname.
