### PR TITLE
refactor: Make it possible for keywords to be relative to an offer

### DIFF
--- a/packages/zoe/src/cleanProposal.js
+++ b/packages/zoe/src/cleanProposal.js
@@ -81,7 +81,7 @@ export const cleanKeywords = keywordRecord => {
 // `{ waived: null }` `{ onDemand: null }` `{ afterDeadline: { timer
 // :Timer, deadline :Number } }
 export const cleanProposal = (
-  issuerKeywordRecord,
+  allKeywords,
   amountMathKeywordRecord,
   proposal,
 ) => {
@@ -93,7 +93,6 @@ export const cleanProposal = (
   let { want = harden({}), give = harden({}) } = proposal;
   const { exit = harden({ onDemand: null }) } = proposal;
 
-  const allKeywords = getKeywords(issuerKeywordRecord);
   want = coerceAmountKeywordRecord(amountMathKeywordRecord, allKeywords, want);
   give = coerceAmountKeywordRecord(amountMathKeywordRecord, allKeywords, give);
 

--- a/packages/zoe/test/unitTests/test-cleanProposal.js
+++ b/packages/zoe/test/unitTests/test-cleanProposal.js
@@ -3,7 +3,7 @@ import { test } from 'tape-promise/tape';
 
 import harden from '@agoric/harden';
 
-import { cleanProposal } from '../../src/cleanProposal';
+import { cleanProposal, getKeywords } from '../../src/cleanProposal';
 import { setup } from './setupBasicMints';
 import buildManualTimer from '../../tools/manualTimer';
 
@@ -44,7 +44,7 @@ test('cleanProposal test', t => {
     });
 
     const actual = cleanProposal(
-      issuerKeywordRecord,
+      getKeywords(issuerKeywordRecord),
       amountMathKeywordRecord,
       proposal,
     );
@@ -84,8 +84,9 @@ test('cleanProposal - all empty', t => {
     });
 
     // cleanProposal no longer fills in empty keywords
+    const allKeywords = getKeywords(issuerKeywordRecord);
     t.deepEquals(
-      cleanProposal(issuerKeywordRecord, amountMathKeywordRecord, proposal),
+      cleanProposal(allKeywords, amountMathKeywordRecord, proposal),
       expected,
     );
   } catch (e) {
@@ -137,7 +138,8 @@ test('cleanProposal - repeated brands', t => {
       exit: { afterDeadline: { timer, deadline: 100 } },
     });
     // cleanProposal no longer fills in empty keywords
-    const actual = cleanProposal(issuerKeywordRecord, amountMathsObj, proposal);
+    const keywords = getKeywords(issuerKeywordRecord);
+    const actual = cleanProposal(keywords, amountMathsObj, proposal);
     t.deepEquals(actual.want, expected.want);
     t.deepEquals(actual.give, expected.give);
     t.deepEquals(actual.exit, expected.exit);


### PR DESCRIPTION
reduce reliance on instanceKeywordRecord in offer().
use a brandToIssuer table to find Issuers


This is the first step of facet parameters (#718). It passes tests and doesn't change any external behavior, so it could be checked in, but my plan is to use it as the base for a branch containing the work toward Facet parameters.