### PR TITLE
fix: temporary fix to support displaying NFT extents which are arrays of objects

### DIFF
--- a/packages/wallet-frontend/src/components/Inbox.jsx
+++ b/packages/wallet-frontend/src/components/Inbox.jsx
@@ -174,7 +174,7 @@ export default function Inbox() {
                         <Typography key={`give${role}`} variant="body1">
                           {i === 0 ? 'Give' : <>and&nbsp;give</>}&nbsp;
                           <Box component="span" fontWeight={800}>
-                            {extent}
+                            {JSON.stringify(extent)}
                             &nbsp;
                             {pet(issuerPetname)}
                           </Box>
@@ -192,7 +192,7 @@ export default function Inbox() {
                             <>and&nbsp;receieve</>
                           }&nbsp;
                           <Box component="span" fontWeight={800}>
-                            {extent}
+                            {JSON.stringify(extent)}
                             &nbsp;
                             {pet(issuerPetname)}
                           </Box>

--- a/packages/wallet-frontend/src/components/Purses.jsx
+++ b/packages/wallet-frontend/src/components/Purses.jsx
@@ -29,17 +29,26 @@ export default function Purses() {
       <Typography variant="h6">Purses</Typography>
       {Array.isArray(purses) && purses.length > 0 ? (
         <List>
-          {purses.map(({ pursePetname, brandRegKey, issuerPetname, extent }) => (
-            <ListItem key={pursePetname} value={pursePetname} divider>
-              <ListItemIcon className={classes.icon}>
-                <PurseIcon />
-              </ListItemIcon>
-              <ListItemText
-                primary={pursePetname}
-                secondary={<><b>{extent} {issuerPetname}</b> {brandRegKey ? <i>({brandRegKey})</i> : ''}</>}
-              />
-            </ListItem>
-          ))}
+          {purses.map(
+            ({ pursePetname, brandRegKey, issuerPetname, extent }) => (
+              <ListItem key={pursePetname} value={pursePetname} divider>
+                <ListItemIcon className={classes.icon}>
+                  <PurseIcon />
+                </ListItemIcon>
+                <ListItemText
+                  primary={pursePetname}
+                  secondary={
+                    <>
+                      <b>
+                        {JSON.stringify(extent)} {issuerPetname}
+                      </b>{' '}
+                      {brandRegKey ? <i>({brandRegKey})</i> : ''}
+                    </>
+                  }
+                />
+              </ListItem>
+            ),
+          )}
         </List>
       ) : (
         <Typography color="inherit">No purses.</Typography>


### PR DESCRIPTION
This is meant to be a very temporary fix to display something (and not break) when the wallet is holding NFT which have arrays of objects as extents. In the very near future, we will need to change this to take the dehydrated extent which has slots for petnames and do something to display petnames in a special format. 

Closes #1088 