### PR TITLE
Properly abort all communication when CapTP is disconnected

### DIFF
--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -500,7 +500,7 @@ function build(syscall, _state, makeRoot, forVatID) {
   // here we finally invoke the vat code, and get back the root object
   // We need to pass in Remotable and getInterfaceOf so that they can
   // access our own @agoric/marshal, not a separate instance in a bundle.
-  const vatPowers = { Remotable, getInterfaceOf };
+  const vatPowers = { HandledPromise, Remotable, getInterfaceOf };
   const rootObject = makeRoot(E, D, vatPowers);
   mustPassByPresence(rootObject);
 

--- a/packages/captp/lib/index.js
+++ b/packages/captp/lib/index.js
@@ -1,0 +1,8 @@
+import harden from '@agoric/harden';
+import Nat from '@agoric/nat';
+
+export * from '@agoric/eventual-send';
+export * from '@agoric/marshal';
+
+export * from './captp';
+export { harden, Nat };

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -10,7 +10,7 @@
   "author": "Michael FIG <michael@fig.org>",
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "license": "Apache-2.0",
-  "main": "dist/captp.cjs.js",
+  "main": "dist/captp.cjs",
   "module": "lib/captp.js",
   "browser": "dist/captp.umd.js",
   "directories": {

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -29,7 +29,7 @@
     "build": "rollup -c",
     "test": "tape -r esm 'test/**/*.js'",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint-check": "eslint '**/*.js'",
+    "lint-check": "eslint 'lib/*.js'",
     "lint-fix-jessie": "eslint -c '.eslintrc-jessie.js' --fix '**/*.js'",
     "lint-check-jessie": "eslint -c '.eslintrc-jessie.js' '**/*.js'"
   },

--- a/packages/captp/rollup.config.js
+++ b/packages/captp/rollup.config.js
@@ -3,7 +3,7 @@ import commonjs from 'rollup-plugin-commonjs';
 
 export default [
   {
-    input: 'lib/captp.js',
+    input: 'lib/index.js',
     output: [
       {
         file: 'dist/captp.umd.js',
@@ -15,7 +15,7 @@ export default [
         format: 'esm',
       },
       {
-        file: 'dist/captp.cjs.js',
+        file: 'dist/captp.cjs',
         format: 'cjs',
       },
     ],

--- a/packages/captp/test/crosstalk.js
+++ b/packages/captp/test/crosstalk.js
@@ -1,5 +1,5 @@
 import { test } from 'tape-promise/tape';
-import { harden, makeCapTP, E } from '../lib/captp';
+import { harden, makeCapTP, E } from '../lib';
 
 test('prevent crosstalk', async t => {
   try {

--- a/packages/captp/test/disco.js
+++ b/packages/captp/test/disco.js
@@ -1,5 +1,5 @@
 import { test } from 'tape-promise/tape';
-import { harden, makeCapTP } from '../lib/captp';
+import { harden, makeCapTP } from '../lib';
 
 test('try disconnecting captp', async t => {
   try {

--- a/packages/captp/test/loopback.js
+++ b/packages/captp/test/loopback.js
@@ -1,5 +1,5 @@
 import { test } from 'tape-promise/tape';
-import { E, harden, makeCapTP } from '../lib/captp';
+import { E, harden, makeCapTP } from '../lib';
 
 test('try loopback captp', async t => {
   try {

--- a/packages/cosmic-swingset/lib/ag-solo/vats/captp.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/captp.js
@@ -3,7 +3,7 @@
 import { makeCapTP } from '@agoric/captp/lib/captp';
 import harden from '@agoric/harden';
 
-export const getCapTPHandler = (E, send, getBootstrapObject) => {
+export const getCapTPHandler = (send, getBootstrapObject, powers) => {
   const chans = new Map();
   const handler = harden({
     onOpen(_obj, meta) {
@@ -16,6 +16,7 @@ export const getCapTPHandler = (E, send, getBootstrapObject) => {
         origin,
         sendObj,
         getBootstrapObject,
+        { harden, ...powers },
       );
       chans.set(channelHandle, [dispatch, abort]);
     },

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-http.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-http.js
@@ -73,9 +73,11 @@ function build(E, D, vatPowers) {
 
         // Assign the captp handler.
         // TODO: Break this out into a separate vat.
-        const captpHandler = getCapTPHandler(E, send, () =>
+        const captpHandler = getCapTPHandler(
+          send,
           // Harden only our exported objects.
-          harden(exportedToCapTP),
+          () => harden(exportedToCapTP),
+          { E, harden, ...vatPowers },
         );
         registerURLHandler(captpHandler, '/private/captp');
       }


### PR DESCRIPTION
This rejects promises with Error('Disconnected') once the CapTP connection is aborted.

The rest of this allows callers to override the powers used by CapTP, which means that three-party-handoff within SwingSet is properly detected (but unhandled).  I can imagine a world in which the three-party-handoff devolves into just proxying via the originating vat.
