### PR TITLE
[WIP] add test to show bug where offerHook is called twice

### DIFF
--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -28,6 +28,7 @@ export const makeZoeHelpers = (zcf) => {
   const zoeService = zcf.getZoeService();
 
   const rejectOffer = (offerHandle, msg = defaultRejectMsg) => {
+    console.log('in reject offer');
     zcf.complete(harden([offerHandle]));
     assert.fail(msg);
   };

--- a/packages/zoe/src/contracts/atomicSwap.js
+++ b/packages/zoe/src/contracts/atomicSwap.js
@@ -13,13 +13,19 @@ export const makeContract = harden(
     const { swap, assertKeywords, checkHook } = makeZoeHelpers(zcf);
     assertKeywords(harden(['Asset', 'Price']));
 
+    let callCount = 0;
+
     const makeMatchingInvite = firstOfferHandle => {
       const {
         proposal: { want, give },
       } = zcf.getOffer(firstOfferHandle);
 
       return zcf.makeInvitation(
-        offerHandle => swap(firstOfferHandle, offerHandle),
+        offerHandle => {
+          callCount += 1;
+          console.log(`second offerHook called ${callCount} times`);
+          return swap(firstOfferHandle, offerHandle);
+        },
         'matchOffer',
         harden({
           customProperties: {


### PR DESCRIPTION
Bug: If an offer is rejected inside an offerHook, the offerHook is called again.

This PR shows this case with a test: in atomicSwap, Alice creates an initial offer but completes it before bob tries to make a counter offer. Bob's offer is rejected, but strangely, his offerHook is called twice.

<img width="919" alt="Screen Shot 2020-05-14 at 4 51 24 PM" src="https://user-images.githubusercontent.com/2441069/81996911-336bea00-9603-11ea-8873-173a90c29f0f.png">

Note that this would not show up as a failing test. Because Bob's offer is already supposed to throw an error, another thrown error doesn't fail any tests.

