### PR TITLE
[Zoe] Fix bug in which offer safety can be violated

### DIFF
--- a/packages/zoe/src/offerSafety.js
+++ b/packages/zoe/src/offerSafety.js
@@ -24,19 +24,11 @@ function isOfferSafeForOffer(
   proposal,
   newAmountKeywordRecord,
 ) {
-  const isGTEByKeyword = ([keyword, amount]) => {
-    if (!Object.keys(amountMathKeywordRecord).includes(keyword)) {
-      return false;
-    }
-    return amountMathKeywordRecord[keyword].isGTE(
+  const isGTEByKeyword = ([keyword, amount]) =>
+    amountMathKeywordRecord[keyword].isGTE(
       newAmountKeywordRecord[keyword],
       amount,
     );
-  };
-
-  const isUnchanged = ([keyword]) => {
-    return !newAmountKeywordRecord[keyword];
-  };
 
   // For this allocation to count as a full refund, the allocated
   // amount must be greater than or equal to what was originally
@@ -47,32 +39,7 @@ function isOfferSafeForOffer(
   // wanted, their allocated amount must be greater than or equal to
   // what the payoutRules said they wanted.
   const winningsOk = Object.entries(proposal.want).every(isGTEByKeyword);
-
-  // This reallocation is also offer safe if it only changes amounts that aren't
-  // mentioned in this offer's give and want.
-  const unchangedGive = Object.entries(proposal.give).every(isUnchanged);
-  const unchangedWant = Object.entries(proposal.want).every(isUnchanged);
-  return refundOk || winningsOk || (unchangedGive && unchangedWant);
+  return refundOk || winningsOk;
 }
 
-/**
- * @param  {object} amountMathKeywordRecord - a record with keywords
- * as keys and amountMath as values
- * @param  {proposal[]} proposals - an array of records which are the
- * proposal for a single player. Each proposal has keys `give`,
- * `want`, and `exit`.
- * @param  {newAmountKeywordRecord[]} newAllocations - an array of
- * records. Each of the records (amountKeywordRecord) has keywords for
- * keys and the values are the amount that a single user will get.
- */
-const isOfferSafeForAll = (
-  amountMathKeywordRecord,
-  proposals,
-  newAllocations,
-) =>
-  proposals.every((proposal, i) =>
-    isOfferSafeForOffer(amountMathKeywordRecord, proposal, newAllocations[i]),
-  );
-
-// `isOfferSafeForOffer` is only exported for testing
-export { isOfferSafeForOffer, isOfferSafeForAll };
+export { isOfferSafeForOffer };

--- a/packages/zoe/src/offerSafety.js
+++ b/packages/zoe/src/offerSafety.js
@@ -34,6 +34,10 @@ function isOfferSafeForOffer(
     );
   };
 
+  const isUnchanged = ([keyword]) => {
+    return !newAmountKeywordRecord[keyword];
+  };
+
   // For this allocation to count as a full refund, the allocated
   // amount must be greater than or equal to what was originally
   // offered.
@@ -43,7 +47,12 @@ function isOfferSafeForOffer(
   // wanted, their allocated amount must be greater than or equal to
   // what the payoutRules said they wanted.
   const winningsOk = Object.entries(proposal.want).every(isGTEByKeyword);
-  return refundOk || winningsOk;
+
+  // This reallocation is also offer safe if it only changes amounts that aren't
+  // mentioned in this offer's give and want.
+  const unchangedGive = Object.entries(proposal.give).every(isUnchanged);
+  const unchangedWant = Object.entries(proposal.want).every(isUnchanged);
+  return refundOk || winningsOk || (unchangedGive && unchangedWant);
 }
 
 /**

--- a/packages/zoe/src/state.js
+++ b/packages/zoe/src/state.js
@@ -76,19 +76,12 @@ const makeOfferTable = () => {
       },
       updateAmounts: (offerHandles, newAllocations) =>
         offerHandles.map((offerHandle, i) => {
-          // newAmountKeywordRecords may be based on sparse keywords,
-          // so we don't want to replace the allocation entirely
+          // newAllocation can replace the old allocation entirely
           const newAllocation = newAllocations[i];
-          const { updater, currentAllocation: pastAllocation } = table.get(
-            offerHandle,
-          );
-          const currentAllocation = {
-            ...pastAllocation,
-            ...newAllocation,
-          };
-          updater.updateState(currentAllocation);
+          const { updater } = table.get(offerHandle);
+          updater.updateState(newAllocation);
           return table.update(offerHandle, {
-            currentAllocation,
+            currentAllocation: newAllocation,
           });
         }),
     });

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -465,17 +465,7 @@ const makeZoe = (additionalEndowments = {}) => {
           sparseKeywords,
         );
 
-        // Filter proposal `want` and `give` by sparseKeywords
-        const filterProposalBySparseKeywords = proposal => {
-          return harden({
-            give: filterObjOkIfMissing(proposal.give, sparseKeywords),
-            want: filterObjOkIfMissing(proposal.want, sparseKeywords),
-          });
-        };
-
-        const proposals = offerRecords.map(offerRecord =>
-          filterProposalBySparseKeywords(offerRecord.proposal),
-        );
+        const proposals = offerRecords.map(offerRecord => offerRecord.proposal);
 
         const currentAmountMatrix = offerRecords.map(({ handle }) => {
           const filteredAmounts = contractFacet.getCurrentAllocation(

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -18,7 +18,6 @@ import {
   objToArray,
   objToArrayAssertFilled,
   filterObj,
-  filterObjOkIfMissing,
   filterFillAmounts,
   assertSubset,
 } from './objArrayConversion';

--- a/packages/zoe/test/unitTests/contracts/grifter.js
+++ b/packages/zoe/test/unitTests/contracts/grifter.js
@@ -1,0 +1,52 @@
+// @ts-check
+
+import harden from '@agoric/harden';
+
+// Eventually will be importable from '@agoric/zoe-contract-support'
+import { makeZoeHelpers } from '../../../src/contractSupport';
+
+/** @typedef {import('../zoe').ContractFacet} ContractFacet */
+
+// zcf is the Zoe Contract Facet, i.e. the contract-facing API of Zoe
+export const makeContract = harden(
+  /** @param {ContractFacet} zcf */ zcf => {
+    const { assertKeywords, checkHook } = makeZoeHelpers(zcf);
+    assertKeywords(harden(['Asset', 'Price']));
+
+    const makeAccompliceInvite = firstOfferHandle => {
+      const {
+        proposal: { want: wantProposal },
+      } = zcf.getOffer(firstOfferHandle);
+
+      return zcf.makeInvitation(
+        offerHandle => {
+          const firstHandleAlloc = zcf.getCurrentAllocation(firstOfferHandle);
+          // safe because it doesn't change give, so they can still get a refund
+          const vicProposal = { Price: firstHandleAlloc.Price };
+          const stepOne = [wantProposal, vicProposal];
+          // safe because it doesn't change want, so winningsOK looks true
+          const offerHandles = [firstOfferHandle, offerHandle];
+          zcf.reallocate(offerHandles, stepOne, ['Price']);
+          zcf.complete(harden(offerHandles));
+        },
+        'tantalizing offer',
+        harden({
+          customProperties: {
+            Price: wantProposal.Price,
+          },
+        }),
+      );
+    };
+
+    const firstOfferExpected = harden({
+      want: { Price: null },
+    });
+
+    return harden({
+      invite: zcf.makeInvitation(
+        checkHook(makeAccompliceInvite, firstOfferExpected),
+        'firstOffer',
+      ),
+    });
+  },
+);

--- a/packages/zoe/test/unitTests/contracts/test-grifter.js
+++ b/packages/zoe/test/unitTests/contracts/test-grifter.js
@@ -1,0 +1,69 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from 'tape-promise/tape';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import bundleSource from '@agoric/bundle-source';
+
+import harden from '@agoric/harden';
+
+import { makeZoe } from '../../..';
+// TODO: Remove setupBasicMints and rename setupBasicMints2
+import { setup } from '../setupBasicMints';
+
+const grifterRoot = `${__dirname}/grifter`;
+
+test('zoe - grifter', async t => {
+  t.plan(2);
+  // Setup zoe and mints
+  const { moola, moolaR, moolaMint, bucksR, bucks } = setup();
+  const zoe = makeZoe({ require });
+  // Pack the contract.
+  const { source, moduleFormat } = await bundleSource(grifterRoot);
+  const installationHandle = zoe.install(source, moduleFormat);
+
+  const issuerKeywordRecord = harden({
+    Asset: bucksR.issuer,
+    Price: moolaR.issuer,
+  });
+
+  const malloryInvite = zoe.makeInstance(
+    installationHandle,
+    issuerKeywordRecord,
+  );
+
+  // Mallory doesn't need any money
+  const malloryProposal = harden({
+    want: { Price: moola(37) },
+  });
+  const { payout: malloryPayoutP, outcome: vicInviteP } = await zoe.offer(
+    malloryInvite,
+    malloryProposal,
+    harden({}),
+  );
+
+  const vicMoolaPayment = moolaMint.mintPayment(moola(37));
+  const vicProposal = harden({
+    give: { Price: moola(37) },
+    want: { Asset: bucks(24) },
+    exit: { onDemand: null },
+  });
+  const vicPayments = { Price: vicMoolaPayment };
+  const { payout: vicPayoutP } = await zoe.offer(
+    vicInviteP,
+    vicProposal,
+    vicPayments,
+  );
+
+  const malloryPayout = await malloryPayoutP;
+  const malloryMoolaPayout = await malloryPayout.Price;
+  const malloryMoolaPurse = moolaR.issuer.makeEmptyPurse();
+
+  const vicPayout = await vicPayoutP;
+  const vicMoolaPayout = await vicPayout.Price;
+  const vicMoolaPurse = moolaR.issuer.makeEmptyPurse();
+
+  vicMoolaPurse.deposit(vicMoolaPayout);
+  malloryMoolaPurse.deposit(malloryMoolaPayout);
+
+  t.equals(malloryMoolaPurse.getCurrentAmount().extent, 37);
+  t.equals(vicMoolaPurse.getCurrentAmount().extent, 0);
+});

--- a/packages/zoe/test/unitTests/test-offerSafety.js
+++ b/packages/zoe/test/unitTests/test-offerSafety.js
@@ -2,7 +2,7 @@
 import { test } from 'tape-promise/tape';
 import harden from '@agoric/harden';
 
-import { isOfferSafeForOffer, isOfferSafeForAll } from '../../src/offerSafety';
+import { isOfferSafeForOffer } from '../../src/offerSafety';
 import { setup } from './setupBasicMints';
 
 // Potential outcomes:
@@ -233,68 +233,6 @@ test('isOfferSafeForOffer - empty proposal', t => {
     const amounts = harden({ A: moola(1), B: simoleans(6), C: bucks(7) });
 
     t.ok(isOfferSafeForOffer(amountMathKeywordRecord, proposal, amounts));
-  } catch (e) {
-    t.assert(false, e);
-  }
-});
-
-// All users get exactly what they wanted
-test('isOfferSafeForAll - All users get what they wanted', t => {
-  t.plan(1);
-  try {
-    const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
-    const amountMathKeywordRecord = harden({
-      A: moolaR.amountMath,
-      B: simoleanR.amountMath,
-      C: bucksR.amountMath,
-    });
-    const proposal = harden({
-      want: { B: simoleans(6) },
-      give: { A: moola(1), C: bucks(7) },
-    });
-    const proposals = [proposal, proposal, proposal];
-    const amounts = harden({ A: moola(0), B: simoleans(6), C: bucks(0) });
-    const amountKeywordRecords = [amounts, amounts, amounts];
-    t.ok(
-      isOfferSafeForAll(
-        amountMathKeywordRecord,
-        proposals,
-        amountKeywordRecords,
-      ),
-    );
-  } catch (e) {
-    t.assert(false, e);
-  }
-});
-
-test(`isOfferSafeForAll - One user doesn't get what they wanted`, t => {
-  t.plan(1);
-  try {
-    const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
-    const amountMathKeywordRecord = harden({
-      A: moolaR.amountMath,
-      B: simoleanR.amountMath,
-      C: bucksR.amountMath,
-    });
-    const proposal = harden({
-      want: { B: simoleans(6) },
-      give: { A: moola(1), C: bucks(7) },
-    });
-    const proposals = [proposal, proposal, proposal];
-    const amounts = harden({ A: moola(0), B: simoleans(6), C: bucks(0) });
-    const unsatisfiedAmounts = harden({
-      A: moola(0),
-      B: simoleans(4),
-      C: bucks(0),
-    });
-    const amountKeywordRecords = [amounts, amounts, unsatisfiedAmounts];
-    t.notOk(
-      isOfferSafeForAll(
-        amountMathKeywordRecord,
-        proposals,
-        amountKeywordRecords,
-      ),
-    );
   } catch (e) {
     t.assert(false, e);
   }


### PR DESCRIPTION
The bug was introduced in [filter proposal give and want by sparseKeywords](https://github.com/Agoric/agoric-sdk/pull/1076.)

It allows a grifter contract (demonstrated here) to slip assets away from a victim one keyword at a time. The victim is left with neither their give or their want.

The solution is to reinstate the insistance that offer safety be checked against all keywords. We provide the feature that #1076 was aiming for by allowing reallocations that don't impact keywords in an offer's proposal.
