### PR TITLE
fix: fix double invoke bug

### DIFF
--- a/packages/eventual-send/src/index.js
+++ b/packages/eventual-send/src/index.js
@@ -440,8 +440,11 @@ export function makeHandledPromise(Promise) {
         if (typeof handler[operation] !== 'function') {
           throw TypeError(`${handlerName}.${operation} is not a function`);
         }
-        // If we throw, the race is not over.
-        resolve(handler[operation](o, ...opArgs, returnedP));
+        try {
+          resolve(handler[operation](o, ...opArgs, returnedP));
+        } catch (reason) {
+          reject(reason);
+        }
         raceIsOver = true;
       }
 


### PR DESCRIPTION
Hypothesis: The interleavings between the call to `win` on line 458 and the call to `lose` on line 459. During the gap between the two, `raceIsOver` isn't set yet, so the other contender slips into the gap.
