### PR TITLE
Don't bypass the block queue when running simulateBlock

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
+++ b/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
@@ -75,7 +75,7 @@ export async function connectToFakeChain(basedir, GCI, role, delay, inbound) {
   const maximumDelay = (delay || PRETEND_BLOCK_DELAY) * 1000;
 
   const withBlockQueue = makeWithQueue();
-  const simulateBlock = withBlockQueue(async function simulateBlock() {
+  const simulateBlock = withBlockQueue(async function unqueuedSimulateBlock() {
     const actualStart = Date.now();
     // Gather up the new messages into the latest block.
     thisBlock.push(...intoChain);


### PR DESCRIPTION
Due to a mistaken shadowing of the queued `simulateBlock` function with the inner unqueued function, the `simulateBlock` was not always using the queue.  This caused subtle and unpredictable data races when running the simulated chain.

This PR renames the inner definition to `unqueuedSimulateBlock` so that the queued version is always used, notably within that function as an argument to `setTimeout`.
