### PR TITLE
Don't use the LMDB `useWritemap` option if we know we don't need it

### DIFF
--- a/packages/swing-store-lmdb/lmdbSwingStore.js
+++ b/packages/swing-store-lmdb/lmdbSwingStore.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 import lmdb from 'node-lmdb';
@@ -27,7 +28,12 @@ function makeSwingStore(dirPath, forceReset = false) {
   lmdbEnv.open({
     path: dirPath,
     mapSize: 2 * 1024 * 1024 * 1024, // XXX need to tune this
-    useWritemap: true,
+    // Turn off useWritemap on the Mac.  The userWritemap option is currently
+    // required for LMDB to function correctly on Linux running under WSL, but
+    // we don't yet have a convenient recipe to probe our environment at
+    // runtime to distinguish that species of Linux from the others.  For now
+    // we're running our benchmarks on Mac, so this will do for the time being.
+    useWritemap: os.platform() !== 'darwin',
   });
 
   let dbi = lmdbEnv.openDbi({


### PR DESCRIPTION
The LMDB `useWritemap` option, which was required for LMDB to work properly when running on WSL, unconditionally creates a ~2GB database file (even though it doesn't actually take up that much space on disk until you actually put that much data in).  This makes it hard to measure database space usage by looking at the file size, since now the file size is constant.  However, if we know we are running on an OS where we know LMDB works without the `useWritemap` option, we can do without it and return to a world where we can get useful measurements of database space usage.  MacOS is one such, so at a minimum we can exempt that, which is what this change does.  It's possible that we could cook up some more sophisticated way to test for WSL specifically, but this much simpler test is doable immediately.