### PR TITLE
fix: replace openDetail with quoting q

### DIFF
--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -337,7 +337,7 @@ test('issuer.combine bad payments', t => {
 
     t.rejects(
       () => E(issuer).combine(payments),
-      /payment not found/,
+      /"payment" not found/,
       'payment from other mint is not found',
     );
   } catch (e) {

--- a/packages/assert/test/test-assert.js
+++ b/packages/assert/test/test-assert.js
@@ -1,5 +1,5 @@
 import { test } from 'tape';
-import { an, assert, details, openDetail } from '../src/assert';
+import { an, assert, details, q } from '../src/assert';
 import { throwsAndLogs } from './throwsAndLogs';
 
 test('an', t => {
@@ -45,16 +45,31 @@ test('throwsAndLogs', t => {
 test('assert', t => {
   try {
     assert(2 + 3 === 5);
-    assert.equal(2 + 3, 5);
-    throwsAndLogs(t, () => assert(false), /check failed/, [
-      ['error', 'LOGGED ERROR:', 'check failed'],
+
+    throwsAndLogs(t, () => assert(false), /Check failed/, [
+      ['error', 'LOGGED ERROR:', 'Check failed'],
     ]);
-    throwsAndLogs(
-      t,
-      () => assert.equal(5, 6),
-      /Expected \(a number\) === \(a number\)/,
-      [['error', 'LOGGED ERROR:', 'Expected', 5, '===', 6]],
-    );
+    throwsAndLogs(t, () => assert(false, 'foo'), /foo/, [
+      ['error', 'LOGGED ERROR:', 'foo'],
+    ]);
+
+    throwsAndLogs(t, () => assert.fail(), /Assert failed/, [
+      ['error', 'LOGGED ERROR:', 'Assert failed'],
+    ]);
+    throwsAndLogs(t, () => assert.fail('foo'), /foo/, [
+      ['error', 'LOGGED ERROR:', 'foo'],
+    ]);
+  } catch (e) {
+    console.log('unexpected exception', e);
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+test('assert equals', t => {
+  try {
+    assert.equal(2 + 3, 5);
     throwsAndLogs(t, () => assert.equal(5, 6, 'foo'), /foo/, [
       ['error', 'LOGGED ERROR:', 'foo'],
     ]);
@@ -66,9 +81,83 @@ test('assert', t => {
     );
     throwsAndLogs(
       t,
-      () => assert.equal(5, 6, details`${5} !== ${openDetail(6)}`),
+      () => assert.equal(5, 6, details`${5} !== ${q(6)}`),
       /\(a number\) !== 6/,
       [['error', 'LOGGED ERROR:', 5, '!==', 6]],
+    );
+
+    assert.equal(NaN, NaN);
+    throwsAndLogs(
+      t,
+      () => assert.equal(-0, 0),
+      /Expected \(a number\) is same as \(a number\)/,
+      [['error', 'LOGGED ERROR:', 'Expected', -0, 'is same as', 0]],
+    );
+  } catch (e) {
+    console.log('unexpected exception', e);
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+test('assert typeof', t => {
+  try {
+    assert.typeof(2, 'number');
+    throwsAndLogs(
+      t,
+      () => assert.typeof(2, 'string'),
+      /\(a number\) must be a string/,
+      [['error', 'LOGGED ERROR:', 2, 'must be a string']],
+    );
+    throwsAndLogs(t, () => assert.typeof(2, 'string', 'foo'), /foo/, [
+      ['error', 'LOGGED ERROR:', 'foo'],
+    ]);
+  } catch (e) {
+    console.log('unexpected exception', e);
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});
+
+test('assert q', t => {
+  try {
+    throwsAndLogs(
+      t,
+      () => assert.fail(details`<${'bar'},${q('baz')}>`),
+      /<\(a string\),"baz">/,
+      [['error', 'LOGGED ERROR:', '<', 'bar', ',', 'baz', '>']],
+    );
+
+    const list = ['a', 'b', 'c'];
+    throwsAndLogs(
+      t,
+      () => assert.fail(details`${q(list)}`),
+      /\["a","b","c"\]/,
+      [['error', 'LOGGED ERROR:', ['a', 'b', 'c']]],
+    );
+    const repeat = { x: list, y: list };
+    throwsAndLogs(
+      t,
+      () => assert.fail(details`${q(repeat)}`),
+      /{"x":\["a","b","c"\],"y":"<\*\*seen\*\*>"}/,
+      [['error', 'LOGGED ERROR:', { x: ['a', 'b', 'c'], y: ['a', 'b', 'c'] }]],
+    );
+
+    // Make it into a cycle
+    list[1] = list;
+    throwsAndLogs(
+      t,
+      () => assert.fail(details`${q(list)}`),
+      /\["a","<\*\*seen\*\*>","c"\]/,
+      [['error', 'LOGGED ERROR:', ['a', list, 'c']]],
+    );
+    throwsAndLogs(
+      t,
+      () => assert.fail(details`${q(repeat)}`),
+      /{"x":\["a","<\*\*seen\*\*>","c"\],"y":"<\*\*seen\*\*>"}/,
+      [['error', 'LOGGED ERROR:', { x: list, y: ['a', list, 'c'] }]],
     );
   } catch (e) {
     console.log('unexpected exception', e);

--- a/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
@@ -1,5 +1,5 @@
 import harden from '@agoric/harden';
-import { assert, details, openDetail } from '@agoric/assert';
+import { assert, details, q } from '@agoric/assert';
 import makeStore from '@agoric/store';
 import makeWeakStore from '@agoric/weak-store';
 import makeAmountMath from '@agoric/ertp/src/amountMath';
@@ -291,9 +291,7 @@ export async function makeWallet({
   const makeEmptyPurse = async (brandPetname, petnameForPurse) => {
     assert(
       !purseMapping.petnameToVal.has(petnameForPurse),
-      details`Purse petname ${openDetail(
-        petnameForPurse,
-      )} already used in wallet.`,
+      details`Purse petname ${q(petnameForPurse)} already used in wallet.`,
     );
     const brand = brandMapping.petnameToVal.get(brandPetname);
     const { issuer } = brandTable.get(brand);

--- a/packages/same-structure/src/sameStructure.js
+++ b/packages/same-structure/src/sameStructure.js
@@ -1,6 +1,6 @@
 import harden from '@agoric/harden';
 import { sameValueZero, passStyleOf } from '@agoric/marshal';
-import { assert, details, openDetail } from '@agoric/assert';
+import { assert, details, q } from '@agoric/assert';
 
 // Shim of Object.fromEntries from
 // https://github.com/tc39/proposal-object-from-entries/blob/master/polyfill.js
@@ -166,7 +166,7 @@ function pathStr(path) {
 function mustBeSameStructureInternal(left, right, message, path) {
   function complain(problem) {
     assert.fail(
-      details`${openDetail(message)}: ${openDetail(problem)} at ${openDetail(
+      details`${q(message)}: ${q(problem)} at ${q(
         pathStr(path),
       )}: (${left}) vs (${right})`,
     );

--- a/packages/store/src/store.js
+++ b/packages/store/src/store.js
@@ -2,7 +2,7 @@
 // @ts-check
 
 import rawHarden from '@agoric/harden';
-import { assert, details, openDetail } from '@agoric/assert';
+import { assert, details, q } from '@agoric/assert';
 
 const harden = /** @type {<T>(x: T) => T} */ (rawHarden);
 
@@ -32,12 +32,9 @@ const harden = /** @type {<T>(x: T) => T} */ (rawHarden);
 function makeStore(keyName = 'key') {
   const store = new Map();
   const assertKeyDoesNotExist = key =>
-    assert(
-      !store.has(key),
-      details`${openDetail(keyName)} already registered: ${key}`,
-    );
+    assert(!store.has(key), details`${q(keyName)} already registered: ${key}`);
   const assertKeyExists = key =>
-    assert(store.has(key), details`${openDetail(keyName)} not found: ${key}`);
+    assert(store.has(key), details`${q(keyName)} not found: ${key}`);
   return harden({
     has: key => store.has(key),
     init: (key, value) => {

--- a/packages/wallet-frontend/src/utils/fetch-websocket.js
+++ b/packages/wallet-frontend/src/utils/fetch-websocket.js
@@ -12,7 +12,7 @@ export async function doFetch(req) {
   }
 
   const socket = websocket;
-  
+
   let resolve;
   const p = new Promise(res => {
     resolve = res;

--- a/packages/weak-store/src/weakStore.js
+++ b/packages/weak-store/src/weakStore.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2019 Agoric, under Apache license 2.0
 
 import harden from '@agoric/harden';
-import { assert, details, openDetail } from '@agoric/assert';
+import { assert, details, q } from '@agoric/assert';
 /**
  * Distinguishes between adding a new key (init) and updating or
  * referencing a key (get, set, delete).
@@ -13,12 +13,9 @@ import { assert, details, openDetail } from '@agoric/assert';
 function makeStore(keyName = 'key') {
   const wm = new WeakMap();
   const assertKeyDoesNotExist = key =>
-    assert(
-      !wm.has(key),
-      details`${openDetail(keyName)} already registered: ${key}`,
-    );
+    assert(!wm.has(key), details`${q(keyName)} already registered: ${key}`);
   const assertKeyExists = key =>
-    assert(wm.has(key), details`${openDetail(keyName)} not found: ${key}`);
+    assert(wm.has(key), details`${q(keyName)} not found: ${key}`);
   return harden({
     has: key => wm.has(key),
     init: (key, value) => {

--- a/packages/zoe/src/cleanProposal.js
+++ b/packages/zoe/src/cleanProposal.js
@@ -1,5 +1,5 @@
 import harden from '@agoric/harden';
-import { assert, details, openDetail } from '@agoric/assert';
+import { assert, details, q } from '@agoric/assert';
 import { mustBeComparable } from '@agoric/same-structure';
 
 import { arrayToObj, assertSubset } from './objArrayConversion';
@@ -18,13 +18,13 @@ export const assertKeywordName = keyword => {
   const firstCapASCII = /^[A-Z][a-zA-Z0-9_$]*$/;
   assert(
     firstCapASCII.test(keyword),
-    details`keyword ${openDetail(
+    details`keyword ${q(
       keyword,
     )} must be ascii and must start with a capital letter.`,
   );
   assert(
     keyword !== 'NaN' && keyword !== 'Infinity',
-    details`keyword ${openDetail(keyword)} must not be a number's name`,
+    details`keyword ${q(keyword)} must not be a number's name`,
   );
 };
 

--- a/packages/zoe/src/objArrayConversion.js
+++ b/packages/zoe/src/objArrayConversion.js
@@ -1,4 +1,4 @@
-import { assert, details, openDetail } from '@agoric/assert';
+import { assert, details, q } from '@agoric/assert';
 
 export const arrayToObj = (array, keywords) => {
   assert(
@@ -14,9 +14,9 @@ export const objToArray = (obj, keywords) => {
   const keys = Object.getOwnPropertyNames(obj);
   assert(
     keys.length === keywords.length,
-    details`object keys (${openDetail(keys)}) and keywords (${openDetail(
+    details`object keys ${q(keys)} and keywords ${q(
       keywords,
-    )}) must be of equal length`,
+    )} must be of equal length`,
   );
   return keywords.map(keyword => obj[keyword]);
 };
@@ -26,9 +26,7 @@ export const assertSubset = (whole, part) => {
     assert.typeof(key, 'string');
     assert(
       whole.includes(key),
-      details`key ${openDetail(
-        key,
-      )} was not one of the expected keys (${openDetail(whole.join(', '))})`,
+      details`key ${q(key)} was not one of the expected keys ${q(whole)}`,
     );
   });
 };
@@ -38,16 +36,16 @@ export const objToArrayAssertFilled = (obj, keywords) => {
   const keys = Object.getOwnPropertyNames(obj);
   assert(
     keys.length === keywords.length,
-    details`object keys (${openDetail(keys)}) and keywords (${openDetail(
+    details`object keys ${q(keys)} and keywords ${q(
       keywords,
-    )}) must be of equal length`,
+    )} must be of equal length`,
   );
   assertSubset(keywords, keys);
   // ensure all keywords are defined on obj
   return keywords.map(keyword => {
     assert(
       obj[keyword] !== undefined,
-      details`obj[keyword] must be defined for keyword ${openDetail(keyword)}`,
+      details`obj[keyword] must be defined for keyword ${q(keyword)}`,
     );
     return obj[keyword];
   });
@@ -63,7 +61,7 @@ export const filterObj = /** @type {function<T>(T, string[]): T} */ (
   subsetKeywords.forEach(keyword => {
     assert(
       obj[keyword] !== undefined,
-      details`obj[keyword] must be defined for keyword ${openDetail(keyword)}`,
+      details`obj[keyword] must be defined for keyword ${q(keyword)}`,
     );
     newObj[keyword] = obj[keyword];
   });

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -3,7 +3,7 @@ import harden from '@agoric/harden';
 import { E, HandledPromise } from '@agoric/eventual-send';
 import makeStore from '@agoric/weak-store';
 import produceIssuer from '@agoric/ertp';
-import { assert, details, openDetail } from '@agoric/assert';
+import { assert, details, q } from '@agoric/assert';
 import { produceNotifier } from '@agoric/notifier';
 import { producePromise } from '@agoric/produce-promise';
 
@@ -882,7 +882,7 @@ const makeZoe = (additionalEndowments = {}) => {
             } else {
               assert(
                 exitKind === 'waived',
-                details`exit kind was not recognized: ${openDetail(exitKind)}`,
+                details`exit kind was not recognized: ${q(exitKind)}`,
               );
             }
 

--- a/packages/zoe/test/unitTests/test-objArrayConversion.js
+++ b/packages/zoe/test/unitTests/test-objArrayConversion.js
@@ -38,14 +38,14 @@ test('objToArray', t => {
     const keywords2 = ['X', 'Y', 'Z'];
     t.throws(
       () => objToArray(obj, keywords2),
-      /Error: object keys \(X,Y\) and keywords \(X,Y,Z\) must be of equal length/,
+      /Error: object keys \["X","Y"\] and keywords \["X","Y","Z"\] must be of equal length/,
       `unequal length should throw`,
     );
 
     const obj2 = { X: 1, Y: 2, Z: 5 };
     t.throws(
       () => objToArray(obj2, keywords),
-      /Error: object keys \(X,Y,Z\) and keywords \(X,Y\) must be of equal length/,
+      /Error: object keys \["X","Y","Z"\] and keywords \["X","Y"\] must be of equal length/,
       `unequal length should throw`,
     );
   } catch (e) {


### PR DESCRIPTION
This combines the declassification of `openDetail` with the quoting of the `q` from @kriskowal's assertion style. It makes sense that if you're putting the quoted form of the stringified payload into the message, then you must declassify it anyway, so it is unsurprising.

Open question: @kriskowal just did a `JSON.stringify` directly, without doing a `toString` stringification first. This has pros and cons. Looking for feedback.