### PR TITLE
IBC version negotiation

### DIFF
--- a/packages/SwingSet/src/devices/mailbox-src.js
+++ b/packages/SwingSet/src/devices/mailbox-src.js
@@ -10,7 +10,7 @@ export default function setup(syscall, state, helpers, endowments) {
 
   function inboundCallback(hPeer, hMessages, hAck) {
     const peer = `${hPeer}`;
-    if (!inboundCallback) {
+    if (!deliverInboundMessages) {
       throw new Error(
         `mailbox.inboundCallback(${peer}) called before handler was registered`,
       );

--- a/packages/SwingSet/src/vats/network/bytes.js
+++ b/packages/SwingSet/src/vats/network/bytes.js
@@ -13,7 +13,6 @@
 export function toBytes(data) {
   // TODO: We really need marshallable TypedArrays.
   if (typeof data === 'string') {
-    // eslint-disable-next-line no-bitwise
     data = data.split('').map(c => c.charCodeAt(0));
   }
 

--- a/packages/SwingSet/test/test-network.js
+++ b/packages/SwingSet/test/test-network.js
@@ -47,9 +47,11 @@ const makeProtocolHandler = t => {
       t.assert(localAddr, `local address is supplied to onConnect`);
       t.assert(remoteAddr, `remote address is supplied to onConnect`);
       if (lp) {
-        return l.onAccept(lp, localAddr, remoteAddr, l);
+        return l
+          .onAccept(lp, localAddr, remoteAddr, l)
+          .then(ch => [localAddr, ch]);
       }
-      return makeEchoConnectionHandler();
+      return [remoteAddr, makeEchoConnectionHandler()];
     },
     async onListen(port, localAddr, listenHandler) {
       t.assert(port, `port is tracked in onListen`);

--- a/packages/SwingSet/test/test-network.js
+++ b/packages/SwingSet/test/test-network.js
@@ -86,7 +86,7 @@ test('handled protocol', async t => {
     await port.connect(
       '/ibc/*/ordered/echo',
       harden({
-        async onOpen(connection) {
+        async onOpen(connection, _localAddr, _remoteAddr) {
           const ack = await connection.send('ping');
           // log(ack);
           t.equals(`${ack}`, 'ping', 'received pong');
@@ -138,7 +138,7 @@ test('protocol connection listen', async t => {
         );
         let handler;
         return harden({
-          async onOpen(connection, connectionHandler) {
+          async onOpen(connection, _localAddr, _remoteAddr, connectionHandler) {
             t.assert(
               connectionHandler,
               `connectionHandler is tracked in onOpen`,
@@ -198,9 +198,14 @@ test('protocol connection listen', async t => {
       '/net/ordered/ordered/some-portname',
       harden({
         ...connectionHandler,
-        async onOpen(connection, c) {
+        async onOpen(connection, localAddr, remoteAddr, c) {
           if (connectionHandler.onOpen) {
-            await connectionHandler.onOpen(connection, c);
+            await connectionHandler.onOpen(
+              connection,
+              localAddr,
+              remoteAddr,
+              c,
+            );
           }
           connection.send('ping');
         },
@@ -245,7 +250,7 @@ test('loopback protocol', async t => {
     await port2.connect(
       port.getLocalAddress(),
       harden({
-        async onOpen(c, _connectionHandler) {
+        async onOpen(c, _localAddr, _remoteAddr, _connectionHandler) {
           t.equals(`${await c.send('ping')}`, 'pingack', 'expected pingack');
           closed.resolve();
         },

--- a/packages/cosmic-swingset/lib/ag-solo/vats/ibc.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/ibc.js
@@ -223,8 +223,14 @@ export function makeIBCProtocolHandler(
     }
 
     return harden({
-      async onOpen(conn, _handler) {
-        console.info('onOpen Remote IBC Connection', channelID, portID);
+      async onOpen(conn, localAddr, remoteAddr, _handler) {
+        console.info(
+          'onOpen Remote IBC Connection',
+          channelID,
+          portID,
+          localAddr,
+          remoteAddr,
+        );
         const connP = /** @type {Promise<Connection, any>} */ (E.when(conn));
         channelKeyToConnP.init(channelKey, connP);
       },

--- a/packages/cosmic-swingset/lib/chain-main.js
+++ b/packages/cosmic-swingset/lib/chain-main.js
@@ -176,7 +176,11 @@ export default async function main(progname, args, { path, env, agcc }) {
         );
       }
       const retStr = chainSend(portNum, stringify(obj));
-      return JSON.parse(retStr);
+      try {
+        return JSON.parse(retStr);
+      } catch (e) {
+        throw Error(`cannot JSON.parse(${JSON.stringify(retStr)}): ${e}`);
+      }
     }
 
     const vatsdir = path.resolve(__dirname, '../lib/ag-solo/vats');

--- a/packages/cosmic-swingset/x/swingset/blockers.go
+++ b/packages/cosmic-swingset/x/swingset/blockers.go
@@ -83,6 +83,7 @@ func CommitBlock(keeper Keeper) error {
 		BlockHeight: endBlockHeight,
 		BlockTime:   endBlockTime,
 	}
+	committedHeight = endBlockHeight
 
 	b, err := json.Marshal(action)
 	if err != nil {

--- a/packages/cosmic-swingset/x/swingset/handler.go
+++ b/packages/cosmic-swingset/x/swingset/handler.go
@@ -12,6 +12,8 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
+var committedHeight int64 = 0
+
 type deliverInboundAction struct {
 	Type        string          `json:"type"`
 	Peer        string          `json:"peer"`
@@ -25,6 +27,11 @@ type deliverInboundAction struct {
 // NewHandler returns a handler for "swingset" type messages.
 func NewHandler(keeper Keeper) sdk.Handler {
 	return func(ctx sdk.Context, msg sdk.Msg) (*sdk.Result, error) {
+		if committedHeight == ctx.BlockHeight() {
+			// We don't support simulation.
+			return &sdk.Result{}, nil
+		}
+
 		switch msg := msg.(type) {
 		// Legacy deliver inbound.
 		// TODO: Sometime merge with IBC?

--- a/packages/cosmic-swingset/x/swingset/ibc.go
+++ b/packages/cosmic-swingset/x/swingset/ibc.go
@@ -196,6 +196,11 @@ func (am AppModule) OnChanOpenInit(
 	counterparty channeltypes.Counterparty,
 	version string,
 ) error {
+	if committedHeight == ctx.BlockHeight() {
+		// We don't support simulation.
+		return nil
+	}
+
 	event := channelOpenInitEvent{
 		Type:           "IBC_EVENT",
 		Event:          "channelOpenInit",
@@ -252,6 +257,10 @@ func (am AppModule) OnChanOpenTry(
 	version,
 	counterpartyVersion string,
 ) error {
+	if committedHeight == ctx.BlockHeight() {
+		// We don't support simulation.
+		return nil
+	}
 
 	event := channelOpenTryEvent{
 		Type:                "IBC_EVENT",
@@ -301,6 +310,10 @@ func (am AppModule) OnChanOpenAck(
 	channelID string,
 	counterpartyVersion string,
 ) error {
+	if committedHeight == ctx.BlockHeight() {
+		// We don't support simulation.
+		return nil
+	}
 
 	event := channelOpenAckEvent{
 		Type:                "IBC_EVENT",
@@ -335,6 +348,11 @@ func (am AppModule) OnChanOpenConfirm(
 	portID,
 	channelID string,
 ) error {
+	if committedHeight == ctx.BlockHeight() {
+		// We don't support simulation.
+		return nil
+	}
+
 	event := channelOpenConfirmEvent{
 		Type:        "IBC_EVENT",
 		Event:       "channelOpenConfirm",
@@ -368,6 +386,11 @@ func (am AppModule) OnChanCloseInit(
 	portID,
 	channelID string,
 ) error {
+	if committedHeight == ctx.BlockHeight() {
+		// We don't support simulation.
+		return nil
+	}
+
 	event := channelCloseInitEvent{
 		Type:        "IBC_EVENT",
 		Event:       "channelCloseInit",
@@ -400,6 +423,11 @@ func (am AppModule) OnChanCloseConfirm(
 	portID,
 	channelID string,
 ) error {
+	if committedHeight == ctx.BlockHeight() {
+		// We don't support simulation.
+		return nil
+	}
+
 	event := channelCloseConfirmEvent{
 		Type:        "IBC_EVENT",
 		Event:       "channelCloseConfirm",
@@ -430,6 +458,15 @@ func (am AppModule) OnRecvPacket(
 	ctx sdk.Context,
 	packet channeltypes.Packet,
 ) (*sdk.Result, error) {
+	if committedHeight == ctx.BlockHeight() {
+		// We don't support simulation.
+		return &sdk.Result{}, nil
+	}
+	if packet.GetTimeoutTimestamp() == 0 {
+		// FIXME: Don't know why, but for every relayed packet, we receive
+		// a second nearly-identical packet with a zero Timestamp.
+		return &sdk.Result{}, nil
+	}
 
 	event := receivePacketEvent{
 		Type:        "IBC_EVENT",
@@ -468,6 +505,10 @@ func (am AppModule) OnAcknowledgementPacket(
 	packet channeltypes.Packet,
 	acknowledgement []byte,
 ) (*sdk.Result, error) {
+	if committedHeight == ctx.BlockHeight() {
+		// We don't support simulation.
+		return &sdk.Result{}, nil
+	}
 
 	event := acknowledgementPacketEvent{
 		Type:            "IBC_EVENT",
@@ -505,6 +546,10 @@ func (am AppModule) OnTimeoutPacket(
 	ctx sdk.Context,
 	packet channeltypes.Packet,
 ) (*sdk.Result, error) {
+	if committedHeight == ctx.BlockHeight() {
+		// We don't support simulation.
+		return &sdk.Result{}, nil
+	}
 
 	event := timeoutPacketEvent{
 		Type:        "IBC_EVENT",

--- a/packages/cosmic-swingset/x/swingset/ibc.go
+++ b/packages/cosmic-swingset/x/swingset/ibc.go
@@ -181,6 +181,8 @@ type channelOpenInitEvent struct {
 	ChannelID      string                    `json:"channelID"`
 	Counterparty   channeltypes.Counterparty `json:"counterparty"`
 	Version        string                    `json:"version"`
+	BlockHeight    int64                     `json:"blockHeight"`
+	BlockTime      int64                     `json:"blockTime"`
 }
 
 // Implement IBCModule callbacks
@@ -203,6 +205,8 @@ func (am AppModule) OnChanOpenInit(
 		ChannelID:      channelID,
 		Counterparty:   counterparty,
 		Version:        version,
+		BlockHeight:    ctx.BlockHeight(),
+		BlockTime:      ctx.BlockTime().Unix(),
 	}
 
 	bytes, err := json.Marshal(&event)
@@ -233,6 +237,8 @@ type channelOpenTryEvent struct {
 	Counterparty        channeltypes.Counterparty `json:"counterparty"`
 	Version             string                    `json:"version"`
 	CounterpartyVersion string                    `json:"counterpartyVersion"`
+	BlockHeight         int64                     `json:"blockHeight"`
+	BlockTime           int64                     `json:"blockTime"`
 }
 
 func (am AppModule) OnChanOpenTry(
@@ -257,6 +263,8 @@ func (am AppModule) OnChanOpenTry(
 		Counterparty:        counterparty,
 		Version:             version,
 		CounterpartyVersion: counterpartyVersion,
+		BlockHeight:         ctx.BlockHeight(),
+		BlockTime:           ctx.BlockTime().Unix(),
 	}
 
 	bytes, err := json.Marshal(&event)
@@ -283,6 +291,8 @@ type channelOpenAckEvent struct {
 	PortID              string `json:"portID"`
 	ChannelID           string `json:"channelID"`
 	CounterpartyVersion string `json:"counterpartyVersion"`
+	BlockHeight         int64  `json:"blockHeight"`
+	BlockTime           int64  `json:"blockTime"`
 }
 
 func (am AppModule) OnChanOpenAck(
@@ -298,6 +308,8 @@ func (am AppModule) OnChanOpenAck(
 		PortID:              portID,
 		ChannelID:           channelID,
 		CounterpartyVersion: counterpartyVersion,
+		BlockHeight:         ctx.BlockHeight(),
+		BlockTime:           ctx.BlockTime().Unix(),
 	}
 
 	bytes, err := json.Marshal(&event)
@@ -310,10 +322,12 @@ func (am AppModule) OnChanOpenAck(
 }
 
 type channelOpenConfirmEvent struct {
-	Type      string `json:"type"`  // IBC
-	Event     string `json:"event"` // channelOpenConfirm
-	PortID    string `json:"portID"`
-	ChannelID string `json:"channelID"`
+	Type        string `json:"type"`  // IBC
+	Event       string `json:"event"` // channelOpenConfirm
+	PortID      string `json:"portID"`
+	ChannelID   string `json:"channelID"`
+	BlockHeight int64  `json:"blockHeight"`
+	BlockTime   int64  `json:"blockTime"`
 }
 
 func (am AppModule) OnChanOpenConfirm(
@@ -322,10 +336,12 @@ func (am AppModule) OnChanOpenConfirm(
 	channelID string,
 ) error {
 	event := channelOpenConfirmEvent{
-		Type:      "IBC_EVENT",
-		Event:     "channelOpenConfirm",
-		PortID:    portID,
-		ChannelID: channelID,
+		Type:        "IBC_EVENT",
+		Event:       "channelOpenConfirm",
+		PortID:      portID,
+		ChannelID:   channelID,
+		BlockHeight: ctx.BlockHeight(),
+		BlockTime:   ctx.BlockTime().Unix(),
 	}
 
 	bytes, err := json.Marshal(&event)
@@ -339,10 +355,12 @@ func (am AppModule) OnChanOpenConfirm(
 }
 
 type channelCloseInitEvent struct {
-	Type      string `json:"type"`  // IBC
-	Event     string `json:"event"` // channelCloseInit
-	PortID    string `json:"portID"`
-	ChannelID string `json:"channelID"`
+	Type        string `json:"type"`  // IBC
+	Event       string `json:"event"` // channelCloseInit
+	PortID      string `json:"portID"`
+	ChannelID   string `json:"channelID"`
+	BlockHeight int64  `json:"blockHeight"`
+	BlockTime   int64  `json:"blockTime"`
 }
 
 func (am AppModule) OnChanCloseInit(
@@ -351,10 +369,12 @@ func (am AppModule) OnChanCloseInit(
 	channelID string,
 ) error {
 	event := channelCloseInitEvent{
-		Type:      "IBC_EVENT",
-		Event:     "channelCloseInit",
-		PortID:    portID,
-		ChannelID: channelID,
+		Type:        "IBC_EVENT",
+		Event:       "channelCloseInit",
+		PortID:      portID,
+		ChannelID:   channelID,
+		BlockHeight: ctx.BlockHeight(),
+		BlockTime:   ctx.BlockTime().Unix(),
 	}
 
 	bytes, err := json.Marshal(&event)
@@ -367,10 +387,12 @@ func (am AppModule) OnChanCloseInit(
 }
 
 type channelCloseConfirmEvent struct {
-	Type      string `json:"type"`  // IBC
-	Event     string `json:"event"` // channelCloseConfirm
-	PortID    string `json:"portID"`
-	ChannelID string `json:"channelID"`
+	Type        string `json:"type"`  // IBC
+	Event       string `json:"event"` // channelCloseConfirm
+	PortID      string `json:"portID"`
+	ChannelID   string `json:"channelID"`
+	BlockHeight int64  `json:"blockHeight"`
+	BlockTime   int64  `json:"blockTime"`
 }
 
 func (am AppModule) OnChanCloseConfirm(
@@ -379,10 +401,12 @@ func (am AppModule) OnChanCloseConfirm(
 	channelID string,
 ) error {
 	event := channelCloseConfirmEvent{
-		Type:      "IBC_EVENT",
-		Event:     "channelCloseConfirm",
-		PortID:    portID,
-		ChannelID: channelID,
+		Type:        "IBC_EVENT",
+		Event:       "channelCloseConfirm",
+		PortID:      portID,
+		ChannelID:   channelID,
+		BlockHeight: ctx.BlockHeight(),
+		BlockTime:   ctx.BlockTime().Unix(),
 	}
 
 	bytes, err := json.Marshal(&event)
@@ -395,9 +419,11 @@ func (am AppModule) OnChanCloseConfirm(
 }
 
 type receivePacketEvent struct {
-	Type   string              `json:"type"`  // IBC
-	Event  string              `json:"event"` // receivePacket
-	Packet channeltypes.Packet `json:"packet"`
+	Type        string              `json:"type"`  // IBC
+	Event       string              `json:"event"` // receivePacket
+	Packet      channeltypes.Packet `json:"packet"`
+	BlockHeight int64               `json:"blockHeight"`
+	BlockTime   int64               `json:"blockTime"`
 }
 
 func (am AppModule) OnRecvPacket(
@@ -406,9 +432,11 @@ func (am AppModule) OnRecvPacket(
 ) (*sdk.Result, error) {
 
 	event := receivePacketEvent{
-		Type:   "IBC_EVENT",
-		Event:  "receivePacket",
-		Packet: packet,
+		Type:        "IBC_EVENT",
+		Event:       "receivePacket",
+		Packet:      packet,
+		BlockHeight: ctx.BlockHeight(),
+		BlockTime:   ctx.BlockTime().Unix(),
 	}
 
 	bytes, err := json.Marshal(&event)
@@ -431,6 +459,8 @@ type acknowledgementPacketEvent struct {
 	Event           string              `json:"event"` // acknowledgementPacket
 	Packet          channeltypes.Packet `json:"packet"`
 	Acknowledgement []byte              `json:"acknowledgement"`
+	BlockHeight     int64               `json:"blockHeight"`
+	BlockTime       int64               `json:"blockTime"`
 }
 
 func (am AppModule) OnAcknowledgementPacket(
@@ -444,6 +474,8 @@ func (am AppModule) OnAcknowledgementPacket(
 		Event:           "acknowledgementPacket",
 		Packet:          packet,
 		Acknowledgement: acknowledgement,
+		BlockHeight:     ctx.BlockHeight(),
+		BlockTime:       ctx.BlockTime().Unix(),
 	}
 
 	bytes, err := json.Marshal(&event)
@@ -462,9 +494,11 @@ func (am AppModule) OnAcknowledgementPacket(
 }
 
 type timeoutPacketEvent struct {
-	Type   string              `json:"type"`  // IBC
-	Event  string              `json:"event"` // timeoutPacket
-	Packet channeltypes.Packet `json:"packet"`
+	Type        string              `json:"type"`  // IBC
+	Event       string              `json:"event"` // timeoutPacket
+	Packet      channeltypes.Packet `json:"packet"`
+	BlockHeight int64               `json:"blockHeight"`
+	BlockTime   int64               `json:"blockTime"`
 }
 
 func (am AppModule) OnTimeoutPacket(
@@ -473,9 +507,11 @@ func (am AppModule) OnTimeoutPacket(
 ) (*sdk.Result, error) {
 
 	event := timeoutPacketEvent{
-		Type:   "IBC_EVENT",
-		Event:  "timeoutPacket",
-		Packet: packet,
+		Type:        "IBC_EVENT",
+		Event:       "timeoutPacket",
+		Packet:      packet,
+		BlockHeight: ctx.BlockHeight(),
+		BlockTime:   ctx.BlockTime().Unix(),
 	}
 
 	bytes, err := json.Marshal(&event)

--- a/packages/cosmic-swingset/x/swingset/ibc.go
+++ b/packages/cosmic-swingset/x/swingset/ibc.go
@@ -24,10 +24,32 @@ type channelMessage struct { // comes from swingset's IBC handler
 	Method          string              `json:"method"`
 	Packet          channeltypes.Packet `json:"packet"`
 	RelativeTimeout uint64              `json:"relativeTimeout"`
-	Order           ibctypes.Order      `json:"order"`
+	Order           string              `json:"order"`
 	Hops            []string            `json:"hops"`
 	Version         string              `json:"version"`
 	Ack             []byte              `json:"ack"`
+}
+
+func stringToOrder(order string) ibctypes.Order {
+	switch order {
+	case "ORDERED":
+		return ibctypes.ORDERED
+	case "UNORDERED":
+		return ibctypes.UNORDERED
+	default:
+		return ibctypes.NONE
+	}
+}
+
+func orderToString(order ibctypes.Order) string {
+	switch order {
+	case ibctypes.ORDERED:
+		return "ORDERED"
+	case ibctypes.UNORDERED:
+		return "UNORDERED"
+	default:
+		return "NONE"
+	}
 }
 
 // DefaultRouter is a temporary hack until cosmos-sdk implements its features FIXME.
@@ -97,7 +119,7 @@ func (ch channelHandler) Receive(ctx *ControllerContext, str string) (ret string
 
 	case "channelOpenInit":
 		err = ctx.Keeper.ChanOpenInit(
-			ctx.Context, msg.Order, msg.Hops,
+			ctx.Context, stringToOrder(msg.Order), msg.Hops,
 			msg.Packet.SourcePort, msg.Packet.SourceChannel,
 			msg.Packet.DestinationPort, msg.Packet.DestinationChannel,
 			msg.Version,
@@ -142,7 +164,7 @@ func (am AppModule) CallToController(ctx sdk.Context, send string) (string, erro
 type channelOpenInitEvent struct {
 	Type           string                    `json:"type"`  // IBC
 	Event          string                    `json:"event"` // channelOpenInit
-	Order          ibctypes.Order            `json:"order"`
+	Order          string                    `json:"order"`
 	ConnectionHops []string                  `json:"connectionHops"`
 	PortID         string                    `json:"portID"`
 	ChannelID      string                    `json:"channelID"`
@@ -164,7 +186,7 @@ func (am AppModule) OnChanOpenInit(
 	event := channelOpenInitEvent{
 		Type:           "IBC_EVENT",
 		Event:          "channelOpenInit",
-		Order:          order,
+		Order:          orderToString(order),
 		ConnectionHops: connectionHops,
 		PortID:         portID,
 		ChannelID:      channelID,
@@ -193,7 +215,7 @@ func (am AppModule) OnChanOpenInit(
 type channelOpenTryEvent struct {
 	Type                string                    `json:"type"`  // IBC
 	Event               string                    `json:"event"` // channelOpenTry
-	Order               ibctypes.Order            `json:"order"`
+	Order               string                    `json:"order"`
 	ConnectionHops      []string                  `json:"connectionHops"`
 	PortID              string                    `json:"portID"`
 	ChannelID           string                    `json:"channelID"`
@@ -217,7 +239,7 @@ func (am AppModule) OnChanOpenTry(
 	event := channelOpenTryEvent{
 		Type:                "IBC_EVENT",
 		Event:               "channelOpenTry",
-		Order:               order,
+		Order:               orderToString(order),
 		ConnectionHops:      connectionHops,
 		PortID:              portID,
 		ChannelID:           channelID,

--- a/packages/cosmic-swingset/x/swingset/ibc.go
+++ b/packages/cosmic-swingset/x/swingset/ibc.go
@@ -117,16 +117,27 @@ func (ch channelHandler) Receive(ctx *ControllerContext, str string) (ret string
 			ret = "true"
 		}
 
-	case "channelOpenInit":
+	case "startChannelOpenInit":
+		/* TODO: Find out what is necessary to wake up a passive relayer.
 		err = ctx.Keeper.ChanOpenInit(
 			ctx.Context, stringToOrder(msg.Order), msg.Hops,
 			msg.Packet.SourcePort, msg.Packet.SourceChannel,
 			msg.Packet.DestinationPort, msg.Packet.DestinationChannel,
 			msg.Version,
 		)
+		*/
 		if err == nil {
 			ret = "true"
 		}
+		break
+
+	case "continueChannelOpenTry":
+		/* TODO: Call ctx.Keeper.ChanOpenTry.
+		 */
+		if err == nil {
+			ret = "true"
+		}
+		break
 
 	case "channelCloseInit":
 		err = ctx.Keeper.ChanCloseInit(ctx.Context, msg.Packet.SourcePort, msg.Packet.SourceChannel)


### PR DESCRIPTION
Make the network protocol add negotiated metadata to the local (listening) or remote (requested) address when a connection is complete.  This makes it possible to learn, say, IBC version information from the connection before sending or receiving any packets.

Also, make the IBC connection states clearer.
