### PR TITLE
refactor: makeInstance() return { invite, instanceRecord }

### DIFF
--- a/packages/cosmic-swingset/test/unitTests/test-lib-wallet.js
+++ b/packages/cosmic-swingset/test/unitTests/test-lib-wallet.js
@@ -33,7 +33,7 @@ const setupTest = async () => {
   const installationHandle = zoe.install(source, moduleFormat);
 
   const issuerKeywordRecord = harden({ Contribution: moolaBundle.issuer });
-  const invite = await zoe.makeInstance(
+  const { invite } = await zoe.makeInstance(
     installationHandle,
     issuerKeywordRecord,
   );

--- a/packages/zoe/src/contracts/mintAndSellNFT.js
+++ b/packages/zoe/src/contracts/mintAndSellNFT.js
@@ -3,7 +3,6 @@
 
 import harden from '@agoric/harden';
 import produceIssuer from '@agoric/ertp';
-import { makeGetInstanceHandle } from '../clientSupport';
 
 // This contract mints non-fungible tokens and creates an instance of
 // a selling contract to sell the tokens in exchange for some sort of money.
@@ -74,20 +73,15 @@ export const makeContract = harden(
           issuerKeywordRecord,
           sellItemsTerms,
         )
-        .then(invite => {
-          const getInstanceHandle = makeGetInstanceHandle(
-            zoeService.getInviteIssuer(),
-          );
-          return getInstanceHandle(invite).then(instanceHandle => {
-            return zoeService
-              .offer(invite, proposal, paymentKeywordRecord)
-              .then(offerResult => {
-                return harden({
-                  ...offerResult,
-                  sellItemsInstanceHandle: instanceHandle,
-                });
+        .then(({ invite, instanceRecord: { handle: instanceHandle } }) => {
+          return zoeService
+            .offer(invite, proposal, paymentKeywordRecord)
+            .then(offerResult => {
+              return harden({
+                ...offerResult,
+                sellItemsInstanceHandle: instanceHandle,
               });
-          });
+            });
         });
     };
 

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -731,11 +731,7 @@ const makeZoe = (additionalEndowments = {}) => {
                 );
                 return {
                   invite,
-                  instanceRecord: {
-                    ...instanceRecord,
-                    publicAPI,
-                    handle: instanceHandle,
-                  },
+                  instanceRecord: instanceTable.get(instanceHandle),
                 };
               });
             });

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -731,7 +731,11 @@ const makeZoe = (additionalEndowments = {}) => {
                 );
                 return {
                   invite,
-                  instanceRecord: { ...instanceRecord, publicAPI },
+                  instanceRecord: {
+                    ...instanceRecord,
+                    publicAPI,
+                    handle: instanceHandle,
+                  },
                 };
               });
             });

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -729,7 +729,10 @@ const makeZoe = (additionalEndowments = {}) => {
                   success,
                   details`invites must be issued by the inviteIssuer.`,
                 );
-                return invite;
+                return {
+                  invite,
+                  instanceRecord: { ...instanceRecord, publicAPI },
+                };
               });
             });
         };

--- a/packages/zoe/test/swingsetTests/zoe-metering/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/zoe-metering/bootstrap.js
@@ -42,11 +42,9 @@ function build(E, log) {
       log(`instantiating ${testName}`);
       const inviteIssuer = E(zoe).getInviteIssuer();
       const issuerKeywordRecord = harden({ Keyword1: inviteIssuer });
-      const invite = await E(zoe).makeInstance(installId, issuerKeywordRecord);
       const {
-        extent: [{ instanceHandle }],
-      } = await E(inviteIssuer).getAmountOf(invite);
-      const { publicAPI } = await E(zoe).getInstanceRecord(instanceHandle);
+        instanceRecord: { publicAPI },
+      } = await E(zoe).makeInstance(installId, issuerKeywordRecord);
       log(`invoking ${testName}.doTest()`);
       await E(publicAPI).doTest();
       log(`complete`);

--- a/packages/zoe/test/swingsetTests/zoe/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-alice.js
@@ -1,14 +1,11 @@
 import harden from '@agoric/harden';
 import { showPurseBalance, setupIssuers, getLocalAmountMath } from '../helpers';
-import { makeGetInstanceHandle } from '../../../src/clientSupport';
 
 const build = async (E, log, zoe, issuers, payments, installations, timer) => {
   const { moola, simoleans, purses } = await setupIssuers(zoe, issuers);
   const [moolaPurseP, simoleanPurseP] = purses;
   const [moolaPayment, simoleanPayment] = payments;
   const [moolaIssuer, simoleanIssuer] = issuers;
-  const inviteIssuer = await E(zoe).getInviteIssuer();
-  const getInstanceHandle = makeGetInstanceHandle(inviteIssuer);
 
   const doAutomaticRefund = async bobP => {
     log(`=> alice.doCreateAutomaticRefund called`);
@@ -316,12 +313,11 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
     });
     const {
       invite: addLiquidityInvite,
-      instanceRecord: { publicAPI },
+      instanceRecord: { publicAPI, handle: instanceHandle },
     } = await E(zoe).makeInstance(installations.autoswap, issuerKeywordRecord);
     const liquidityIssuer = await E(publicAPI).getLiquidityIssuer();
     const liquidityAmountMath = await getLocalAmountMath(liquidityIssuer);
     const liquidity = liquidityAmountMath.make;
-    const instanceHandle = await getInstanceHandle(addLiquidityInvite);
 
     // Alice adds liquidity
     // 10 moola = 5 simoleans at the time of the liquidity adding
@@ -392,7 +388,7 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
 
   const doSellTickets = async bobP => {
     const { mintAndSellNFT } = installations;
-    const invite = await E(zoe).makeInstance(mintAndSellNFT);
+    const { invite } = await E(zoe).makeInstance(mintAndSellNFT);
 
     const { outcome } = await E(zoe).offer(invite);
     const ticketSeller = await outcome;

--- a/packages/zoe/test/swingsetTests/zoe/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-alice.js
@@ -17,13 +17,11 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
       Contribution1: moolaIssuer,
       Contribution2: simoleanIssuer,
     });
-    const refundInvite = await E(zoe).makeInstance(
+    const { invite: refundInvite, instanceRecord } = await E(zoe).makeInstance(
       installId,
       issuerKeywordRecord,
     );
 
-    const instanceHandle = await getInstanceHandle(refundInvite);
-    const instanceRecord = await E(zoe).getInstanceRecord(instanceHandle);
     const { publicAPI } = instanceRecord;
     const proposal = harden({
       give: { Contribution1: moola(3) },
@@ -59,7 +57,7 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
       UnderlyingAsset: moolaIssuer,
       StrikePrice: simoleanIssuer,
     });
-    const writeCallInvite = await E(zoe).makeInstance(
+    const { invite: writeCallInvite } = await E(zoe).makeInstance(
       installId,
       issuerKeywordRecord,
     );
@@ -95,7 +93,7 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
       UnderlyingAsset: moolaIssuer,
       StrikePrice: simoleanIssuer,
     });
-    const writeCallInvite = await E(zoe).makeInstance(
+    const { invite: writeCallInvite } = await E(zoe).makeInstance(
       installations.coveredCall,
       issuerKeywordRecord,
     );
@@ -138,13 +136,14 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
       Bid: simoleanIssuer,
     });
     const terms = harden({ numBidsAllowed });
-    const sellAssetsInvite = await E(zoe).makeInstance(
+    const {
+      invite: sellAssetsInvite,
+      instanceRecord: { publicAPI },
+    } = await E(zoe).makeInstance(
       installations.publicAuction,
       issuerKeywordRecord,
       terms,
     );
-    const instanceHandle = await getInstanceHandle(sellAssetsInvite);
-    const { publicAPI } = await E(zoe).getInstanceRecord(instanceHandle);
 
     const proposal = harden({
       give: { Asset: moola(1) },
@@ -186,7 +185,7 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
       Asset: moolaIssuer,
       Price: simoleanIssuer,
     });
-    const firstOfferInvite = await E(zoe).makeInstance(
+    const { invite: firstOfferInvite } = await E(zoe).makeInstance(
       installations.atomicSwap,
       issuerKeywordRecord,
     );
@@ -222,12 +221,10 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
       Asset: moolaIssuer,
     });
     const { simpleExchange } = installations;
-    const addOrderInvite = await E(zoe).makeInstance(
-      simpleExchange,
-      issuerKeywordRecord,
-    );
-    const instanceHandle = await getInstanceHandle(addOrderInvite);
-    const { publicAPI } = await E(zoe).getInstanceRecord(instanceHandle);
+    const {
+      invite: addOrderInvite,
+      instanceRecord: { publicAPI },
+    } = await E(zoe).makeInstance(simpleExchange, issuerKeywordRecord);
 
     const aliceSellOrderProposal = harden({
       give: { Asset: moola(3) },
@@ -271,12 +268,10 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
       Asset: moolaIssuer,
     });
     const { simpleExchange } = installations;
-    const addOrderInvite = await E(zoe).makeInstance(
-      simpleExchange,
-      issuerKeywordRecord,
-    );
-    const instanceHandle = await getInstanceHandle(addOrderInvite);
-    const { publicAPI } = await E(zoe).getInstanceRecord(instanceHandle);
+    const {
+      invite: addOrderInvite,
+      instanceRecord: { publicAPI },
+    } = await E(zoe).makeInstance(simpleExchange, issuerKeywordRecord);
 
     logStateOnChanges(await E(publicAPI).getNotifier());
 
@@ -319,15 +314,14 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
       TokenA: moolaIssuer,
       TokenB: simoleanIssuer,
     });
-    const addLiquidityInvite = await E(zoe).makeInstance(
-      installations.autoswap,
-      issuerKeywordRecord,
-    );
-    const instanceHandle = await getInstanceHandle(addLiquidityInvite);
-    const { publicAPI } = await E(zoe).getInstanceRecord(instanceHandle);
+    const {
+      invite: addLiquidityInvite,
+      instanceRecord: { publicAPI },
+    } = await E(zoe).makeInstance(installations.autoswap, issuerKeywordRecord);
     const liquidityIssuer = await E(publicAPI).getLiquidityIssuer();
     const liquidityAmountMath = await getLocalAmountMath(liquidityIssuer);
     const liquidity = liquidityAmountMath.make;
+    const instanceHandle = await getInstanceHandle(addLiquidityInvite);
 
     // Alice adds liquidity
     // 10 moola = 5 simoleans at the time of the liquidity adding

--- a/packages/zoe/test/swingsetTests/zoe/vat-bob.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-bob.js
@@ -193,7 +193,7 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
         Asset: inviteIssuer,
         Price: bucksIssuer,
       });
-      const bobSwapInvite = await E(zoe).makeInstance(
+      const { invite: bobSwapInvite } = await E(zoe).makeInstance(
         installations.atomicSwap,
         issuerKeywordRecord,
       );

--- a/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
+++ b/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
@@ -44,7 +44,7 @@ test('zoe - atomicSwap', async t => {
     Asset: moolaIssuer,
     Price: simoleanIssuer,
   });
-  const aliceInvite = await zoe.makeInstance(
+  const { invite: aliceInvite } = await zoe.makeInstance(
     installationHandle,
     issuerKeywordRecord,
   );
@@ -174,7 +174,7 @@ test('zoe - non-fungible atomicSwap', async t => {
     Asset: ccIssuer,
     Price: rpgIssuer,
   });
-  const aliceInvite = await zoe.makeInstance(
+  const { invite: aliceInvite } = await zoe.makeInstance(
     installationHandle,
     issuerKeywordRecord,
   );

--- a/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
+++ b/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
@@ -136,12 +136,10 @@ test('zoe with automaticRefund', async t => {
       Contribution1: moolaR.issuer,
       Contribution2: simoleanR.issuer,
     });
-    const { invite: aliceInvite } = await zoe.makeInstance(
-      installationHandle,
-      issuerKeywordRecord,
-    );
-    const instanceHandle = await getInstanceHandle(aliceInvite);
-    const { publicAPI } = zoe.getInstanceRecord(instanceHandle);
+    const {
+      invite: aliceInvite,
+      instanceRecord: { publicAPI },
+    } = await zoe.makeInstance(installationHandle, issuerKeywordRecord);
 
     // 2: Alice escrows with zoe
     const aliceProposal = harden({

--- a/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
+++ b/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
@@ -28,7 +28,7 @@ test('zoe - simplest automaticRefund', async t => {
 
     // 1: Alice creates an automatic refund instance
     const issuerKeywordRecord = harden({ Contribution: moolaR.issuer });
-    const invite = await zoe.makeInstance(
+    const { invite } = await zoe.makeInstance(
       installationHandle,
       issuerKeywordRecord,
     );
@@ -77,7 +77,7 @@ test('zoe - automaticRefund same issuer', async t => {
       Contribution1: moolaR.issuer,
       Contribution2: moolaR.issuer,
     });
-    const invite = await zoe.makeInstance(
+    const { invite } = await zoe.makeInstance(
       installationHandle,
       issuerKeywordRecord,
     );
@@ -136,7 +136,7 @@ test('zoe with automaticRefund', async t => {
       Contribution1: moolaR.issuer,
       Contribution2: simoleanR.issuer,
     });
-    const aliceInvite = await zoe.makeInstance(
+    const { invite: aliceInvite } = await zoe.makeInstance(
       installationHandle,
       issuerKeywordRecord,
     );
@@ -282,14 +282,14 @@ test('multiple instances of automaticRefund for the same Zoe', async t => {
     });
     const inviteIssuer = zoe.getInviteIssuer();
     const getInstanceHandle = makeGetInstanceHandle(inviteIssuer);
-    const aliceInvite1 = await zoe.makeInstance(
+    const { invite: aliceInvite1 } = await zoe.makeInstance(
       installationHandle,
       issuerKeywordRecord,
     );
     const instanceHandle1 = await getInstanceHandle(aliceInvite1);
     const { publicAPI: publicAPI1 } = zoe.getInstanceRecord(instanceHandle1);
 
-    const aliceInvite2 = await zoe.makeInstance(
+    const { invite: aliceInvite2 } = await zoe.makeInstance(
       installationHandle,
       issuerKeywordRecord,
     );
@@ -298,7 +298,7 @@ test('multiple instances of automaticRefund for the same Zoe', async t => {
     } = await inviteIssuer.getAmountOf(aliceInvite2);
     const { publicAPI: publicAPI2 } = zoe.getInstanceRecord(instanceHandle2);
 
-    const aliceInvite3 = await zoe.makeInstance(
+    const { invite: aliceInvite3 } = await zoe.makeInstance(
       installationHandle,
       issuerKeywordRecord,
     );
@@ -385,7 +385,7 @@ test('zoe - alice cancels after completion', async t => {
       ContributionA: moolaR.issuer,
       ContributionB: simoleanR.issuer,
     });
-    const invite = await zoe.makeInstance(
+    const { invite } = await zoe.makeInstance(
       installationHandle,
       issuerKeywordRecord,
     );
@@ -454,7 +454,7 @@ test('zoe - automaticRefund non-fungible', async t => {
 
   // 1: Alice creates an automatic refund instance
   const issuerKeywordRecord = harden({ Contribution: ccIssuer });
-  const invite = await zoe.makeInstance(
+  const { invite } = await zoe.makeInstance(
     installationHandle,
     issuerKeywordRecord,
   );

--- a/packages/zoe/test/unitTests/contracts/test-autoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-autoswap.js
@@ -45,12 +45,10 @@ test('autoSwap with valid offers', async t => {
       TokenA: moolaIssuer,
       TokenB: simoleanIssuer,
     });
-    const { invite: aliceInvite } = await zoe.makeInstance(
-      installationHandle,
-      issuerKeywordRecord,
-    );
-    const instanceHandle = await getInstanceHandle(aliceInvite);
-    const { publicAPI } = zoe.getInstanceRecord(instanceHandle);
+    const {
+      invite: aliceInvite,
+      instanceRecord: { publicAPI },
+    } = await zoe.makeInstance(installationHandle, issuerKeywordRecord);
     const liquidityIssuer = publicAPI.getLiquidityIssuer();
     const liquidity = liquidityIssuer.getAmountMath().make;
 
@@ -253,12 +251,10 @@ test('autoSwap - test fee', async t => {
       TokenA: moolaIssuer,
       TokenB: simoleanIssuer,
     });
-    const { invite: aliceAddLiquidityInvite } = await zoe.makeInstance(
-      installationHandle,
-      issuerKeywordRecord,
-    );
-    const instanceHandle = await getInstanceHandle(aliceAddLiquidityInvite);
-    const { publicAPI } = zoe.getInstanceRecord(instanceHandle);
+    const {
+      invite: aliceAddLiquidityInvite,
+      instanceRecord: { publicAPI },
+    } = await zoe.makeInstance(installationHandle, issuerKeywordRecord);
     const liquidityIssuer = publicAPI.getLiquidityIssuer();
     const liquidity = liquidityIssuer.getAmountMath().make;
 

--- a/packages/zoe/test/unitTests/contracts/test-autoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-autoswap.js
@@ -45,7 +45,7 @@ test('autoSwap with valid offers', async t => {
       TokenA: moolaIssuer,
       TokenB: simoleanIssuer,
     });
-    const aliceInvite = await zoe.makeInstance(
+    const { invite: aliceInvite } = await zoe.makeInstance(
       installationHandle,
       issuerKeywordRecord,
     );
@@ -253,7 +253,7 @@ test('autoSwap - test fee', async t => {
       TokenA: moolaIssuer,
       TokenB: simoleanIssuer,
     });
-    const aliceAddLiquidityInvite = await zoe.makeInstance(
+    const { invite: aliceAddLiquidityInvite } = await zoe.makeInstance(
       installationHandle,
       issuerKeywordRecord,
     );

--- a/packages/zoe/test/unitTests/contracts/test-coveredCall.js
+++ b/packages/zoe/test/unitTests/contracts/test-coveredCall.js
@@ -40,7 +40,7 @@ test('zoe - coveredCall', async t => {
       StrikePrice: simoleanR.issuer,
     });
     // separate issuerKeywordRecord from contract-specific terms
-    const aliceInvite = await zoe.makeInstance(
+    const { invite: aliceInvite } = await zoe.makeInstance(
       coveredCallInstallationHandle,
       issuerKeywordRecord,
     );
@@ -164,7 +164,7 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
       UnderlyingAsset: moolaR.issuer,
       StrikePrice: simoleanR.issuer,
     });
-    const aliceInvite = await zoe.makeInstance(
+    const { invite: aliceInvite } = await zoe.makeInstance(
       coveredCallInstallationHandle,
       issuerKeywordRecord,
     );
@@ -315,7 +315,7 @@ test('zoe - coveredCall with swap for invite', async t => {
       UnderlyingAsset: moolaR.issuer,
       StrikePrice: simoleanR.issuer,
     });
-    const aliceInvite = await zoe.makeInstance(
+    const { invite: aliceInvite } = await zoe.makeInstance(
       coveredCallInstallationHandle,
       issuerKeywordRecord,
     );
@@ -374,7 +374,7 @@ test('zoe - coveredCall with swap for invite', async t => {
       Asset: inviteIssuer,
       Price: bucksR.issuer,
     });
-    const bobSwapInvite = await zoe.makeInstance(
+    const { invite: bobSwapInvite } = await zoe.makeInstance(
       swapInstallationId,
       swapIssuerKeywordRecord,
     );
@@ -575,7 +575,7 @@ test('zoe - coveredCall with coveredCall for invite', async t => {
       UnderlyingAsset: moolaR.issuer,
       StrikePrice: simoleanR.issuer,
     });
-    const aliceCoveredCallInvite = await zoe.makeInstance(
+    const { invite: aliceCoveredCallInvite } = await zoe.makeInstance(
       coveredCallInstallationHandle,
       issuerKeywordRecord,
     );
@@ -637,7 +637,7 @@ test('zoe - coveredCall with coveredCall for invite', async t => {
       UnderlyingAsset: inviteIssuer,
       StrikePrice: bucksR.issuer,
     });
-    const bobInviteForSecondCoveredCall = await zoe.makeInstance(
+    const { invite: bobInviteForSecondCoveredCall } = await zoe.makeInstance(
       coveredCallInstallationHandle,
       issuerKeywordRecord2,
     );
@@ -859,7 +859,7 @@ test('zoe - coveredCall non-fungible', async t => {
     StrikePrice: rpgIssuer,
   });
   // separate issuerKeywordRecord from contract-specific terms
-  const aliceInvite = await zoe.makeInstance(
+  const { invite: aliceInvite } = await zoe.makeInstance(
     coveredCallInstallationHandle,
     issuerKeywordRecord,
   );

--- a/packages/zoe/test/unitTests/contracts/test-grifter.js
+++ b/packages/zoe/test/unitTests/contracts/test-grifter.js
@@ -25,7 +25,7 @@ test('zoe - grifter tries to steal; prevented by offer safety', async t => {
     Price: moolaR.issuer,
   });
 
-  const malloryInvite = zoe.makeInstance(
+  const { invite: malloryInvite } = await zoe.makeInstance(
     installationHandle,
     issuerKeywordRecord,
   );

--- a/packages/zoe/test/unitTests/contracts/test-mintPayments.js
+++ b/packages/zoe/test/unitTests/contracts/test-mintPayments.js
@@ -7,7 +7,6 @@ import { E } from '@agoric/eventual-send';
 import harden from '@agoric/harden';
 import produceIssuer from '@agoric/ertp';
 
-import { makeGetInstanceHandle } from '../../../src/clientSupport';
 import { makeZoe } from '../../../src/zoe';
 
 const mintPaymentsRoot = `${__dirname}/../../../src/contracts/mintPayments`;
@@ -20,15 +19,14 @@ test('zoe - mint payments', async t => {
     const { source, moduleFormat } = await bundleSource(mintPaymentsRoot);
     const installationHandle = await E(zoe).install(source, moduleFormat);
     const inviteIssuer = await E(zoe).getInviteIssuer();
-    const getInstanceHandle = makeGetInstanceHandle(inviteIssuer);
 
     // Alice creates a contract instance
-    const adminInvite = await E(zoe).makeInstance(installationHandle);
-    const instanceHandle = await getInstanceHandle(adminInvite);
+    const {
+      instanceRecord: { publicAPI },
+    } = await E(zoe).makeInstance(installationHandle);
 
     // Bob wants to get 1000 tokens so he gets an invite and makes an
     // offer
-    const { publicAPI } = await E(zoe).getInstanceRecord(instanceHandle);
     const invite = await E(publicAPI).makeInvite();
     t.ok(await E(inviteIssuer).isLive(invite), `valid invite`);
     const { payout: payoutP } = await E(zoe).offer(invite);
@@ -61,7 +59,6 @@ test('zoe - mint payments with unrelated give and want', async t => {
     const { source, moduleFormat } = await bundleSource(mintPaymentsRoot);
     const installationHandle = await E(zoe).install(source, moduleFormat);
     const inviteIssuer = await E(zoe).getInviteIssuer();
-    const getInstanceHandle = makeGetInstanceHandle(inviteIssuer);
 
     const moolaBundle = produceIssuer('moola');
     const simoleanBundle = produceIssuer('simolean');
@@ -71,15 +68,12 @@ test('zoe - mint payments with unrelated give and want', async t => {
       Asset: moolaBundle.issuer,
       Price: simoleanBundle.issuer,
     });
-    const adminInvite = await E(zoe).makeInstance(
-      installationHandle,
-      issuerKeywordRecord,
-    );
-    const instanceHandle = await getInstanceHandle(adminInvite);
+    const {
+      instanceRecord: { publicAPI },
+    } = await E(zoe).makeInstance(installationHandle, issuerKeywordRecord);
 
     // Bob wants to get 1000 tokens so he gets an invite and makes an
     // offer
-    const { publicAPI } = await E(zoe).getInstanceRecord(instanceHandle);
     const invite = await E(publicAPI).makeInvite();
     t.ok(await E(inviteIssuer).isLive(invite), `valid invite`);
     const proposal = harden({

--- a/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
@@ -42,7 +42,7 @@ test('multipoolAutoSwap with valid offers', async t => {
     const { source, moduleFormat } = await bundleSource(multipoolAutoswapRoot);
 
     const installationHandle = zoe.install(source, moduleFormat);
-    const aliceInvite = await zoe.makeInstance(
+    const { invite: aliceInvite } = await zoe.makeInstance(
       installationHandle,
       harden({ CentralToken: centralR.issuer }),
       harden({ CentralToken: centralR.issuer }),

--- a/packages/zoe/test/unitTests/contracts/test-publicAuction.js
+++ b/packages/zoe/test/unitTests/contracts/test-publicAuction.js
@@ -8,7 +8,6 @@ import harden from '@agoric/harden';
 import { makeZoe } from '../../../src/zoe';
 import { setup } from '../setupBasicMints';
 import { setupMixed } from '../setupMixedMints';
-import { makeGetInstanceHandle } from '../../../src/clientSupport';
 
 const publicAuctionRoot = `${__dirname}/../../../src/contracts/publicAuction`;
 
@@ -18,7 +17,6 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
     const { moolaR, simoleanR, moola, simoleans } = setup();
     const zoe = makeZoe({ require });
     const inviteIssuer = zoe.getInviteIssuer();
-    const getInstanceHandle = makeGetInstanceHandle(inviteIssuer);
 
     // Setup Alice
     const aliceMoolaPayment = moolaR.mint.mintPayment(moola(1));
@@ -52,14 +50,10 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
       Bid: simoleanR.issuer,
     });
     const terms = harden({ numBidsAllowed });
-    const aliceInvite = await zoe.makeInstance(
-      installationHandle,
-      issuerKeywordRecord,
-      terms,
-    );
-
-    const instanceHandle = await getInstanceHandle(aliceInvite);
-    const { publicAPI } = zoe.getInstanceRecord(instanceHandle);
+    const {
+      invite: aliceInvite,
+      instanceRecord: { publicAPI },
+    } = await zoe.makeInstance(installationHandle, issuerKeywordRecord, terms);
 
     // Alice escrows with zoe
     const aliceProposal = harden({
@@ -323,7 +317,6 @@ test('zoe - secondPriceAuction w/ 3 bids - alice exits onDemand', async t => {
   try {
     const { moolaR, simoleanR, moola, simoleans } = setup();
     const zoe = makeZoe({ require });
-    const inviteIssuer = zoe.getInviteIssuer();
 
     // Setup Alice
     const aliceMoolaPayment = moolaR.mint.mintPayment(moola(1));
@@ -347,15 +340,10 @@ test('zoe - secondPriceAuction w/ 3 bids - alice exits onDemand', async t => {
       Bid: simoleanR.issuer,
     });
     const terms = harden({ numBidsAllowed });
-    const aliceInvite = await zoe.makeInstance(
-      installationHandle,
-      issuerKeywordRecord,
-      terms,
-    );
     const {
-      extent: [{ instanceHandle }],
-    } = await inviteIssuer.getAmountOf(aliceInvite);
-    const { publicAPI } = zoe.getInstanceRecord(instanceHandle);
+      invite: aliceInvite,
+      instanceRecord: { publicAPI },
+    } = await zoe.makeInstance(installationHandle, issuerKeywordRecord, terms);
 
     // Alice escrows with zoe
     const aliceProposal = harden({
@@ -468,7 +456,6 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
   } = setupMixed();
   const zoe = makeZoe({ require });
   const inviteIssuer = zoe.getInviteIssuer();
-  const getInstanceHandle = makeGetInstanceHandle(inviteIssuer);
 
   // Setup Alice
   const aliceCcPayment = ccMint.mintPayment(cryptoCats(harden(['Felix'])));
@@ -502,14 +489,10 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
     Bid: moolaIssuer,
   });
   const terms = harden({ numBidsAllowed });
-  const aliceInvite = await zoe.makeInstance(
-    installationHandle,
-    issuerKeywordRecord,
-    terms,
-  );
-
-  const instanceHandle = await getInstanceHandle(aliceInvite);
-  const { publicAPI } = zoe.getInstanceRecord(instanceHandle);
+  const {
+    invite: aliceInvite,
+    instanceRecord: { publicAPI },
+  } = await zoe.makeInstance(installationHandle, issuerKeywordRecord, terms);
 
   // Alice escrows with zoe
   const aliceProposal = harden({

--- a/packages/zoe/test/unitTests/contracts/test-sellTickets.js
+++ b/packages/zoe/test/unitTests/contracts/test-sellTickets.js
@@ -7,7 +7,6 @@ import produceIssuer from '@agoric/ertp';
 import { E } from '@agoric/eventual-send';
 
 import { makeZoe } from '../../../src/zoe';
-import { makeGetInstanceHandle } from '../../../src/clientSupport';
 import { defaultAcceptanceMsg } from '../../../src/contractSupport';
 
 const mintAndSellNFTRoot = `${__dirname}/../../../src/contracts/mintAndSellNFT`;
@@ -16,8 +15,6 @@ const sellItemsRoot = `${__dirname}/../../../src/contracts/sellItems`;
 test(`mint and sell tickets for multiple shows`, async t => {
   // Setup initial conditions
   const zoe = makeZoe({ require });
-  const inviteIssuer = E(zoe).getInviteIssuer();
-  const getInstanceHandle = makeGetInstanceHandle(inviteIssuer);
 
   const mintAndSellNFTBundle = await bundleSource(mintAndSellNFTRoot);
   const mintAndSellNFTInstallationHandle = await E(zoe).install(
@@ -35,9 +32,10 @@ test(`mint and sell tickets for multiple shows`, async t => {
     'moola',
   );
 
-  const invite = await E(zoe).makeInstance(mintAndSellNFTInstallationHandle);
-  const instanceHandle = await getInstanceHandle(invite);
-  const { publicAPI } = await E(zoe).getInstanceRecord(instanceHandle);
+  const {
+    invite,
+    instanceRecord: { publicAPI },
+  } = await E(zoe).makeInstance(mintAndSellNFTInstallationHandle);
 
   const { outcome } = await E(zoe).offer(invite);
   const ticketMaker = await outcome;
@@ -155,9 +153,6 @@ test(`mint and sell opera tickets`, async t => {
   } = produceIssuer('moola');
 
   const zoe = makeZoe({ require });
-  const inviteIssuer = await E(zoe).getInviteIssuer();
-
-  const getInstanceHandle = makeGetInstanceHandle(inviteIssuer);
 
   const mintAndSellNFTBundle = await bundleSource(mintAndSellNFTRoot);
   const mintAndSellNFTInstallationHandle = await E(zoe).install(
@@ -175,9 +170,10 @@ test(`mint and sell opera tickets`, async t => {
 
   // create an instance of the venue contract
   const mintTickets = async () => {
-    const invite = await E(zoe).makeInstance(mintAndSellNFTInstallationHandle);
-    const instanceHandle = await getInstanceHandle(invite);
-    const { publicAPI } = await E(zoe).getInstanceRecord(instanceHandle);
+    const {
+      invite,
+      instanceRecord: { publicAPI },
+    } = await E(zoe).makeInstance(mintAndSellNFTInstallationHandle);
 
     const ticketIssuer = await E(publicAPI).getTokenIssuer();
     const { outcome } = await E(zoe).offer(invite);

--- a/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
+++ b/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
@@ -26,7 +26,6 @@ test('simpleExchange with valid offers', async t => {
   } = setup();
   const zoe = makeZoe({ require });
   const inviteIssuer = zoe.getInviteIssuer();
-  const getInstanceHandle = makeGetInstanceHandle(inviteIssuer);
 
   // Pack the contract.
   const { source, moduleFormat } = await bundleSource(simpleExchange);
@@ -43,14 +42,14 @@ test('simpleExchange with valid offers', async t => {
   const bobMoolaPurse = moolaIssuer.makeEmptyPurse();
   const bobSimoleanPurse = simoleanIssuer.makeEmptyPurse();
 
-  // 1: Simon creates a simpleExchange instance and spreads the invite far and
-  // wide with instructions on how to use it.
-  const simonInvite = await zoe.makeInstance(installationHandle, {
+  // 1: Simon creates a simpleExchange instance and spreads the publicAPI far
+  // and wide with instructions on how to call makeInvite().
+  const {
+    instanceRecord: { publicAPI },
+  } = await zoe.makeInstance(installationHandle, {
     Asset: moolaIssuer,
     Price: simoleanIssuer,
   });
-  const instanceHandle = await getInstanceHandle(simonInvite);
-  const { publicAPI } = zoe.getInstanceRecord(instanceHandle);
 
   const aliceInvite = publicAPI.makeInvite();
 
@@ -87,11 +86,13 @@ test('simpleExchange with valid offers', async t => {
 
   // 5: Bob decides to join.
   const bobExclusiveInvite = await inviteIssuer.claim(bobInvite);
+  const getInstanceHandle = makeGetInstanceHandle(inviteIssuer);
+  const bobInstanceHandle = await getInstanceHandle(bobExclusiveInvite);
 
   const {
     installationHandle: bobInstallationId,
     issuerKeywordRecord: bobIssuers,
-  } = zoe.getInstanceRecord(instanceHandle);
+  } = zoe.getInstanceRecord(bobInstanceHandle);
 
   t.equals(bobInstallationId, installationHandle);
 
@@ -180,7 +181,6 @@ test('simpleExchange with multiple sell offers', async t => {
     } = setup();
     const zoe = makeZoe({ require });
     const inviteIssuer = zoe.getInviteIssuer();
-    const getInstanceHandle = makeGetInstanceHandle(inviteIssuer);
 
     // Pack the contract.
     const { source, moduleFormat } = await bundleSource(simpleExchange);
@@ -197,12 +197,12 @@ test('simpleExchange with multiple sell offers', async t => {
 
     // 1: Simon creates a simpleExchange instance and spreads the invite far and
     // wide with instructions on how to use it.
-    const simonInvite = await zoe.makeInstance(installationHandle, {
+    const {
+      instanceRecord: { publicAPI },
+    } = await zoe.makeInstance(installationHandle, {
       Asset: moolaIssuer,
       Price: simoleanIssuer,
     });
-    const instanceHandle = await getInstanceHandle(simonInvite);
-    const { publicAPI } = zoe.getInstanceRecord(instanceHandle);
 
     const aliceInvite1 = publicAPI.makeInvite();
 
@@ -272,8 +272,6 @@ test('simpleExchange showPayoutRules', async t => {
   t.plan(1);
   const { moolaIssuer, simoleanIssuer, moolaMint, moola, simoleans } = setup();
   const zoe = makeZoe({ require });
-  const inviteIssuer = zoe.getInviteIssuer();
-  const getInstanceHandle = makeGetInstanceHandle(inviteIssuer);
 
   // Pack the contract.
   const { source, moduleFormat } = await bundleSource(simpleExchange);
@@ -284,12 +282,12 @@ test('simpleExchange showPayoutRules', async t => {
   const aliceMoolaPayment = moolaMint.mintPayment(moola(3));
   // 1: Simon creates a simpleExchange instance and spreads the invite far and
   // wide with instructions on how to use it.
-  const simonInvite = await zoe.makeInstance(installationHandle, {
+  const {
+    instanceRecord: { publicAPI },
+  } = await zoe.makeInstance(installationHandle, {
     Asset: moolaIssuer,
     Price: simoleanIssuer,
   });
-  const instanceHandle = await getInstanceHandle(simonInvite);
-  const { publicAPI } = zoe.getInstanceRecord(instanceHandle);
 
   const aliceInvite = publicAPI.makeInvite();
 
@@ -331,7 +329,6 @@ test('simpleExchange with non-fungible assets', async t => {
 
   const zoe = makeZoe({ require });
   const inviteIssuer = zoe.getInviteIssuer();
-  const getInstanceHandle = makeGetInstanceHandle(inviteIssuer);
 
   // Pack the contract.
   const { source, moduleFormat } = await bundleSource(simpleExchange);
@@ -351,12 +348,12 @@ test('simpleExchange with non-fungible assets', async t => {
 
   // 1: Simon creates a simpleExchange instance and spreads the invite far and
   // wide with instructions on how to use it.
-  const simonInvite = await zoe.makeInstance(installationHandle, {
+  const {
+    instanceRecord: { publicAPI },
+  } = await zoe.makeInstance(installationHandle, {
     Asset: rpgIssuer,
     Price: ccIssuer,
   });
-  const instanceHandle = await getInstanceHandle(simonInvite);
-  const { publicAPI } = zoe.getInstanceRecord(instanceHandle);
 
   const aliceInvite = publicAPI.makeInvite();
 
@@ -379,11 +376,13 @@ test('simpleExchange with non-fungible assets', async t => {
 
   // 5: Bob decides to join.
   const bobExclusiveInvite = await inviteIssuer.claim(bobInvite);
+  const getInstanceHandle = makeGetInstanceHandle(inviteIssuer);
+  const bobInstanceHandle = await getInstanceHandle(bobExclusiveInvite);
 
   const {
     installationHandle: bobInstallationId,
     issuerKeywordRecord: bobIssuers,
-  } = zoe.getInstanceRecord(instanceHandle);
+  } = zoe.getInstanceRecord(bobInstanceHandle);
 
   t.equals(bobInstallationId, installationHandle);
 


### PR DESCRIPTION
zoe.makeInstance() add instanceRecord to the invite previously being
returned.

Many calls on getInstanceRecord() were able to be removed, and the
code simplified.