### PR TITLE
[Zoe] - add zoeHelper `trade` which performs a trade given the gains of both sides

### DIFF
--- a/packages/zoe/src/contractSupport/bondingCurves.js
+++ b/packages/zoe/src/contractSupport/bondingCurves.js
@@ -1,5 +1,3 @@
-import harden from '@agoric/harden';
-
 import { assert, details } from '@agoric/assert';
 import { natSafeMath } from './safeMath';
 
@@ -13,17 +11,19 @@ const { add, subtract, multiply, floorDivide } = natSafeMath;
  * is valid, getting the current price for an asset on user
  * request, and to do the actual reallocation after an offer has
  * been made.
- * @param  {extent} inputExtent - the extent of the assets sent in
- * to be swapped
- * @param  {extent} inputReserve - the extent in the liquidity
+ * @param {Object} params
+ * @param  {number} params.inputExtent - the extent of the asset sent
+ * in to be swapped
+ * @param  {number} params.inputReserve - the extent in the liquidity
  * pool of the kind of asset sent in
- * @param  {extent} outputReserve - the extent in the liquidity
+ * @param  {number} params.outputReserve - the extent in the liquidity
  * pool of the kind of asset to be sent out
- * @param  {number} feeBasisPoints=30 - the fee taken in
+ * @param  {number} params.feeBasisPoints=30 - the fee taken in
  * basis points. The default is 0.3% or 30 basis points. The fee is taken from
  * inputExtent
+ * @returns {number} outputExtent - the current price, in extent form
  */
-export const getCurrentPrice = ({
+export const getInputPrice = ({
   inputExtent,
   inputReserve,
   outputReserve,
@@ -35,9 +35,7 @@ export const getCurrentPrice = ({
   const denominator = add(multiply(inputReserve, 10000), inputWithFee);
 
   const outputExtent = floorDivide(numerator, denominator);
-  const newOutputReserve = subtract(outputReserve, outputExtent);
-  const newInputReserve = add(inputReserve, inputExtent);
-  return harden({ outputExtent, newInputReserve, newOutputReserve });
+  return outputExtent;
 };
 
 function assertDefined(label, value) {

--- a/packages/zoe/src/contractSupport/index.js
+++ b/packages/zoe/src/contractSupport/index.js
@@ -1,7 +1,7 @@
 export { secondPriceLogic, closeAuction } from './auctions';
 
 export {
-  getCurrentPrice,
+  getInputPrice,
   calcLiqExtentToMint,
   calcExtentToRemove,
 } from './bondingCurves';

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -62,17 +62,20 @@ export const makeZoeHelpers = (zcf) => {
   };
 
   /**
-   * Given an amountKeywordRecord of the gains of a
-   * transfer, calculate the new allocations. The gains are added to
-   * allocations.to and taken from allocations.from.
+   * Given toGains (an AmountKeywordRecord), and allocations (a pair,
+   * 'to' and 'from', of AmountKeywordRecords), all the entries in
+   * toGains will be added to 'to'. If fromLosses is defined, all the
+   * entries in fromLosses are subtracted from 'from'. (If fromLosses
+   * is not defined, toGains is subtracted from 'from'.)
    *
-   * @param {FromToAllocations} allocations - the 'to' and 'from' allocations
+   * @param {FromToAllocations} allocations - the 'to' and 'from'
+   * allocations
    * @param {AmountKeywordRecord} toGains - what should be gained in
    * the 'to' allocation
    * @param {AmountKeywordRecord} fromLosses - what should be lost in
    * the 'from' allocation. If not defined, fromLosses is equal to
-   * toGains. Note that the total amounts should always be equal, it
-   * the keywords that might be different.
+   * toGains. Note that the total amounts should always be equal; it
+   * is the keywords that might be different.
    * @returns {FromToAllocations} allocations - new allocations
    *
    * @typedef FromToAllocations
@@ -203,12 +206,15 @@ export const makeZoeHelpers = (zcf) => {
      * @property {AmountKeywordRecord} gains - what the offer will
      * gain as a result of this trade
      * @property {AmountKeywordRecord=} losses - what the offer will
-     * lose as a result of this trade
+     * give up as a result of this trade. Losses is optional, but can
+     * only be omitted if the keywords for both offers are the same.
+     * If losses is not defined, the gains of the other offer is
+     * subtracted.
      */
     trade: (keepLeft, tryRight) => {
       assert(
         keepLeft.offerHandle !== tryRight.offerHandle,
-        details`the same offer cannot trade with itself`,
+        details`an offer cannot trade with itself`,
       );
       let leftAllocation = zcf.getCurrentAllocation(keepLeft.offerHandle);
       let rightAllocation = zcf.getCurrentAllocation(tryRight.offerHandle);

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -191,11 +191,12 @@ export const makeZoeHelpers = (zcf) => {
     /**
      * Check whether an update to currentAllocation satisfies offer
      * safety. Note that this is the equivalent of `satisfiesWant` ||
-     * `satisfiesGive`. Allocation is merged with currentAllocation,
-     * overwriting if the keywords are the same to produce the
-     * newAllocation.
+     * `satisfiesGive`. Allocation is merged with currentAllocation
+     * (allocations' values prevailing if the keywords are the same)
+     * to produce the newAllocation.
+
      * @param {OfferHandle} offerHandle
-     * @param {allocation} amountKeywordRecord
+     * @param {AmountKeywordRecord} allocation
      * @returns {boolean}
      */
     isOfferSafe: (offerHandle, allocation) => {

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -172,10 +172,11 @@ export const makeZoeHelpers = (zcf) => {
 
     /**
      * Check whether an update to currentAllocation satisfies
-     * proposal.want. Note that this is half of the offer safety check
-     * - whether the allocation is a refund is not checked. Allocation
-     * is merged with currentAllocation, overwriting if the keywords
-     * are the same to produce the newAllocation.
+     * proposal.want. Note that this is half of the offer safety
+     * check; whether the allocation constitutes a refund is not
+     * checked. Allocation is merged with currentAllocation
+     * (allocations' values prevailing if the keywords are the same)
+     * to produce the newAllocation.
      * @param {OfferHandle} offerHandle
      * @param {allocation} amountKeywordRecord
      * @returns {boolean}

--- a/packages/zoe/src/contracts/autoswap.js
+++ b/packages/zoe/src/contracts/autoswap.js
@@ -2,11 +2,10 @@
 
 import harden from '@agoric/harden';
 import produceIssuer from '@agoric/ertp';
-import { assert, details } from '@agoric/assert';
 
 // Eventually will be importable from '@agoric/zoe-contract-support'
 import {
-  getCurrentPrice,
+  getInputPrice,
   calcLiqExtentToMint,
   calcExtentToRemove,
   makeZoeHelpers,
@@ -28,136 +27,99 @@ import {
  */
 const makeContract = zcf => {
   // Create the liquidity mint and issuer.
-  const { mint: liquidityMint, issuer: liquidityIssuer } = produceIssuer(
-    'liquidity',
-  );
+  const {
+    mint: liquidityMint,
+    issuer: liquidityIssuer,
+    amountMath: liquidityAmountMath,
+  } = produceIssuer('liquidity');
 
   let liqTokenSupply = 0;
 
   const {
-    checkIfProposal,
-    rejectOffer,
     makeEmptyOffer,
     checkHook,
     escrowAndAllocateTo,
     assertNatMathHelpers,
+    trade,
   } = makeZoeHelpers(zcf);
 
   return zcf.addNewIssuer(liquidityIssuer, 'Liquidity').then(() => {
     const { brandKeywordRecord } = zcf.getInstanceRecord();
-    const amountMaths = {};
-    harden(['TokenA', 'TokenB', 'Liquidity']).forEach(keyword => {
-      const brand = brandKeywordRecord[keyword];
-      assertNatMathHelpers(brand);
-      amountMaths[keyword] = zcf.getAmountMath(brand);
-    });
+    Object.values(brandKeywordRecord).forEach(brand =>
+      assertNatMathHelpers(brand),
+    );
+    const getPoolKeyword = brandToMatch => {
+      const entries = Object.entries(brandKeywordRecord);
+      for (const [keyword, brand] of entries) {
+        if (brand === brandToMatch) {
+          return keyword;
+        }
+      }
+      throw new Error('getPoolKeyword: brand not found');
+    };
 
     return makeEmptyOffer().then(poolHandle => {
-      const getPoolAllocation = () =>
-        zcf.getCurrentAllocation(poolHandle, brandKeywordRecord);
+      const getPoolAmount = brand => {
+        const keyword = getPoolKeyword(brand);
+        return zcf.getCurrentAllocation(poolHandle)[keyword];
+      };
 
-      const swap = (offerHandle, giveKeyword, wantKeyword) => {
-        const { proposal } = zcf.getOffer(offerHandle);
-        if (proposal.want.Liquidity !== undefined) {
-          rejectOffer(
-            offerHandle,
-            `A Liquidity amount should not be present in a swap`,
-          );
-        }
-
-        const poolAllocation = getPoolAllocation();
+      const swapHook = offerHandle => {
         const {
-          outputExtent,
-          newInputReserve,
-          newOutputReserve,
-        } = getCurrentPrice(
+          proposal: {
+            give: { In: amountIn },
+            want: { Out: wantedAmountOut },
+          },
+        } = zcf.getOffer(offerHandle);
+        const outputExtent = getInputPrice(
           harden({
-            inputExtent: proposal.give[giveKeyword].extent,
-            inputReserve: poolAllocation[giveKeyword].extent,
-            outputReserve: poolAllocation[wantKeyword].extent,
+            inputExtent: amountIn.extent,
+            inputReserve: getPoolAmount(amountIn.brand).extent,
+            outputReserve: getPoolAmount(wantedAmountOut.brand).extent,
           }),
         );
-        const amountOut = amountMaths[wantKeyword].make(outputExtent);
-        const wantedAmount = proposal.want[wantKeyword];
-        const satisfiesWantedAmounts = () =>
-          amountMaths[wantKeyword].isGTE(amountOut, wantedAmount);
-        if (!satisfiesWantedAmounts()) {
-          throw rejectOffer(offerHandle);
-        }
+        const amountOut = zcf
+          .getAmountMath(wantedAmountOut.brand)
+          .make(outputExtent);
 
-        const newUserAmounts = {
-          Liquidity: amountMaths.Liquidity.getEmpty(),
-        };
-        newUserAmounts[giveKeyword] = amountMaths[giveKeyword].getEmpty();
-        newUserAmounts[wantKeyword] = amountOut;
-
-        const newPoolAmounts = { Liquidity: poolAllocation.Liquidity };
-        newPoolAmounts[giveKeyword] = amountMaths[giveKeyword].make(
-          newInputReserve,
-        );
-        newPoolAmounts[wantKeyword] = amountMaths[wantKeyword].make(
-          newOutputReserve,
-        );
-
-        zcf.reallocate(
-          harden([offerHandle, poolHandle]),
-          harden([newUserAmounts, newPoolAmounts]),
+        trade(
+          {
+            offerHandle: poolHandle,
+            gains: {
+              [getPoolKeyword(amountIn.brand)]: amountIn,
+            },
+            losses: {
+              [getPoolKeyword(amountOut.brand)]: amountOut,
+            },
+          },
+          {
+            offerHandle,
+            gains: { Out: amountOut },
+            losses: { In: amountIn },
+          },
         );
         zcf.complete(harden([offerHandle]));
         return `Swap successfully completed.`;
       };
 
-      const buyASellB = harden({
-        give: { TokenB: null },
-        want: { TokenA: null },
-      });
-
-      const buyBSellA = harden({
-        give: { TokenA: null },
-        want: { TokenB: null },
-      });
-
-      const swapHook = offerHandle => {
-        assert(
-          !checkIfProposal(offerHandle, { give: { Liquidity: null } }),
-          details`A Liquidity amount should not be present in a swap`,
-        );
-        assert(
-          !checkIfProposal(offerHandle, { want: { Liquidity: null } }),
-          details`A Liquidity amount should not be present in a swap`,
-        );
-        if (checkIfProposal(offerHandle, buyASellB)) {
-          return swap(offerHandle, 'TokenB', 'TokenA');
-          /* eslint-disable no-else-return */
-        } else if (checkIfProposal(offerHandle, buyBSellA)) {
-          return swap(offerHandle, 'TokenA', 'TokenB');
-        } else {
-          // Eject because the offer must be invalid
-          return rejectOffer(offerHandle);
-        }
-      };
-
       const addLiquidityHook = offerHandle => {
         const userAllocation = zcf.getCurrentAllocation(offerHandle);
-        const poolAllocation = getPoolAllocation();
 
         // Calculate how many liquidity tokens we should be minting.
         // Calculations are based on the extents represented by TokenA.
         // If the current supply is zero, start off by just taking the
         // extent at TokenA and using it as the extent for the
         // liquidity token.
+        const tokenAPoolAmount = getPoolAmount(userAllocation.TokenA.brand);
+        const inputReserve = tokenAPoolAmount ? tokenAPoolAmount.extent : 0;
         const liquidityExtentOut = calcLiqExtentToMint(
           harden({
             liqTokenSupply,
             inputExtent: userAllocation.TokenA.extent,
-            inputReserve: poolAllocation.TokenA.extent,
+            inputReserve,
           }),
         );
-
-        const liquidityAmountOut = amountMaths.Liquidity.make(
-          liquidityExtentOut,
-        );
-
+        const liquidityAmountOut = liquidityAmountMath.make(liquidityExtentOut);
         const liquidityPaymentP = liquidityMint.mintPayment(liquidityAmountOut);
 
         return escrowAndAllocateTo({
@@ -168,28 +130,69 @@ const makeContract = zcf => {
         }).then(() => {
           liqTokenSupply += liquidityExtentOut;
 
-          const add = (key, obj1, obj2) =>
-            amountMaths[key].add(obj1[key], obj2[key]);
-
-          const newPoolAmounts = harden({
-            TokenA: add('TokenA', userAllocation, poolAllocation),
-            TokenB: add('TokenB', userAllocation, poolAllocation),
-            Liquidity: poolAllocation.Liquidity,
-          });
-
-          const newUserAmounts = harden({
-            TokenA: amountMaths.TokenA.getEmpty(),
-            TokenB: amountMaths.TokenB.getEmpty(),
-            Liquidity: liquidityAmountOut,
-          });
-
-          zcf.reallocate(
-            harden([offerHandle, poolHandle]),
-            harden([newUserAmounts, newPoolAmounts]),
+          trade(
+            {
+              offerHandle: poolHandle,
+              gains: {
+                TokenA: userAllocation.TokenA,
+                TokenB: userAllocation.TokenB,
+              },
+            },
+            // We've already given the user their liquidity using
+            // escrowAndAllocateTo
+            { offerHandle, gains: {} },
           );
+
           zcf.complete(harden([offerHandle]));
           return 'Added liquidity.';
         });
+      };
+
+      const removeLiquidityHook = offerHandle => {
+        const userAllocation = zcf.getCurrentAllocation(offerHandle);
+        const liquidityExtentIn = userAllocation.Liquidity.extent;
+
+        const newUserTokenAAmount = zcf
+          .getAmountMath(userAllocation.TokenA.brand)
+          .make(
+            calcExtentToRemove(
+              harden({
+                liqTokenSupply,
+                poolExtent: getPoolAmount(userAllocation.TokenA.brand).extent,
+                liquidityExtentIn,
+              }),
+            ),
+          );
+        const newUserTokenBAmount = zcf
+          .getAmountMath(userAllocation.TokenB.brand)
+          .make(
+            calcExtentToRemove(
+              harden({
+                liqTokenSupply,
+                poolExtent: getPoolAmount(userAllocation.TokenB.brand).extent,
+                liquidityExtentIn,
+              }),
+            ),
+          );
+
+        liqTokenSupply -= liquidityExtentIn;
+
+        trade(
+          {
+            offerHandle: poolHandle,
+            gains: { Liquidity: userAllocation.Liquidity },
+          },
+          {
+            offerHandle,
+            gains: {
+              TokenA: newUserTokenAAmount,
+              TokenB: newUserTokenBAmount,
+            },
+          },
+        );
+
+        zcf.complete(harden([offerHandle]));
+        return 'Liquidity successfully removed.';
       };
 
       const addLiquidityExpected = harden({
@@ -197,66 +200,15 @@ const makeContract = zcf => {
         want: { Liquidity: null },
       });
 
-      const removeLiquidityHook = offerHandle => {
-        const userAllocation = zcf.getCurrentAllocation(offerHandle);
-        const liquidityExtentIn = userAllocation.Liquidity.extent;
-
-        const poolAllocation = getPoolAllocation();
-
-        const newUserTokenAAmount = amountMaths.TokenA.make(
-          calcExtentToRemove(
-            harden({
-              liqTokenSupply,
-              poolExtent: poolAllocation.TokenA.extent,
-              liquidityExtentIn,
-            }),
-          ),
-        );
-        const newUserTokenBAmount = amountMaths.TokenB.make(
-          calcExtentToRemove(
-            harden({
-              liqTokenSupply,
-              poolExtent: poolAllocation.TokenB.extent,
-              liquidityExtentIn,
-            }),
-          ),
-        );
-
-        const newUserAmounts = harden({
-          TokenA: newUserTokenAAmount,
-          TokenB: newUserTokenBAmount,
-          Liquidity: amountMaths.Liquidity.getEmpty(),
-        });
-
-        const newPoolAmounts = harden({
-          TokenA: amountMaths.TokenA.subtract(
-            poolAllocation.TokenA,
-            newUserAmounts.TokenA,
-          ),
-          TokenB: amountMaths.TokenB.subtract(
-            poolAllocation.TokenB,
-            newUserAmounts.TokenB,
-          ),
-          Liquidity: amountMaths.Liquidity.add(
-            poolAllocation.Liquidity,
-            amountMaths.Liquidity.make(liquidityExtentIn),
-          ),
-        });
-
-        liqTokenSupply -= liquidityExtentIn;
-
-        zcf.reallocate(
-          harden([offerHandle, poolHandle]),
-          harden([newUserAmounts, newPoolAmounts]),
-        );
-        zcf.complete(harden([offerHandle]));
-        return 'Liquidity successfully removed.';
-      };
-
       const removeLiquidityExpected = harden({
         want: { TokenA: null, TokenB: null },
         give: { Liquidity: null },
       });
+
+      const swapExpected = {
+        want: { Out: null },
+        give: { In: null },
+      };
 
       const makeAddLiquidityInvite = () =>
         zcf.makeInvitation(
@@ -264,55 +216,46 @@ const makeContract = zcf => {
           'autoswap add liquidity',
         );
 
+      const makeRemoveLiquidityInvite = () =>
+        zcf.makeInvitation(
+          checkHook(removeLiquidityHook, removeLiquidityExpected),
+          'autoswap remove liquidity',
+        );
+
+      const makeSwapInvite = () =>
+        zcf.makeInvitation(checkHook(swapHook, swapExpected), 'autoswap swap');
+
+      /**
+       * `getCurrentPrice` calculates the result of a trade, given a certain amount
+       * of digital assets in.
+       * @typedef {import('../zoe').Amount} Amount
+       * @param {Amount} amountIn - the amount of digital
+       * assets to be sent in
+       */
+      const getCurrentPrice = (amountIn, brandOut) => {
+        const inputReserve = getPoolAmount(amountIn.brand).extent;
+        const outputReserve = getPoolAmount(brandOut).extent;
+        const outputExtent = getInputPrice(
+          harden({
+            inputExtent: amountIn.extent,
+            inputReserve,
+            outputReserve,
+          }),
+        );
+        return zcf.getAmountMath(brandOut).make(outputExtent);
+      };
+
+      const getPoolAllocation = () =>
+        zcf.getCurrentAllocation(poolHandle, brandKeywordRecord);
+
       zcf.initPublicAPI(
         harden({
-          /**
-           * `getCurrentPrice` calculates the result of a trade, given a certain amount
-           * of digital assets in.
-           * @param {object} amountInObj - the amount of digital
-           * assets to be sent in, keyed by keyword
-           */
-          getCurrentPrice: amountInObj => {
-            const inKeywords = Object.getOwnPropertyNames(amountInObj);
-            assert(
-              inKeywords.length === 1,
-              details`argument to 'getCurrentPrice' must have one keyword`,
-            );
-            const [inKeyword] = inKeywords;
-            assert(
-              ['TokenA', 'TokenB'].includes(inKeyword),
-              details`keyword ${inKeyword} was not valid`,
-            );
-            const inputExtent = amountMaths[inKeyword].getExtent(
-              amountInObj[inKeyword],
-            );
-            const poolAllocation = getPoolAllocation();
-            const inputReserve = poolAllocation[inKeyword].extent;
-            const outKeyword = inKeyword === 'TokenA' ? 'TokenB' : 'TokenA';
-            const outputReserve = poolAllocation[outKeyword].extent;
-            const { outputExtent } = getCurrentPrice(
-              harden({
-                inputExtent,
-                inputReserve,
-                outputReserve,
-              }),
-            );
-            return amountMaths[outKeyword].make(outputExtent);
-          },
-
+          getCurrentPrice,
           getLiquidityIssuer: () => liquidityIssuer,
-
           getPoolAllocation,
-
-          makeSwapInvite: () => zcf.makeInvitation(swapHook, 'autoswap swap'),
-
+          makeSwapInvite,
           makeAddLiquidityInvite,
-
-          makeRemoveLiquidityInvite: () =>
-            zcf.makeInvitation(
-              checkHook(removeLiquidityHook, removeLiquidityExpected),
-              'autoswap remove liquidity',
-            ),
+          makeRemoveLiquidityInvite,
         }),
       );
 

--- a/packages/zoe/src/contracts/barterExchange.js
+++ b/packages/zoe/src/contracts/barterExchange.js
@@ -42,12 +42,8 @@ const makeContract = zcf => {
   function findMatchingTrade(newDetails, orders) {
     return orders.find(order => {
       return (
-        satisfies(newDetails.offerHandle, {
-          Out: zcf.getCurrentAllocation(order.offerHandle).In,
-        }) &&
-        satisfies(order.offerHandle, {
-          Out: zcf.getCurrentAllocation(newDetails.offerHandle).In,
-        })
+        satisfies(newDetails.offerHandle, { Out: order.amountIn }) &&
+        satisfies(order.offerHandle, { Out: newDetails.amountIn })
       );
     });
   }

--- a/packages/zoe/src/contracts/barterExchange.js
+++ b/packages/zoe/src/contracts/barterExchange.js
@@ -24,7 +24,7 @@ const makeContract = zcf => {
   // store its handle and the amounts for `give` and `want`.
   const bookOrders = makeStore('bookOrders');
 
-  const { canTradeWithMapKeywords } = makeZoeHelpers(zcf);
+  const { satisfies, trade } = makeZoeHelpers(zcf);
 
   function lookupBookOrders(brandIn, brandOut) {
     if (!bookOrders.has(brandIn)) {
@@ -41,35 +41,15 @@ const makeContract = zcf => {
 
   function findMatchingTrade(newDetails, orders) {
     return orders.find(order => {
-      return canTradeWithMapKeywords(
-        newDetails.offerHandle,
-        order.offerHandle,
-        [
-          ['In', 'Out'],
-          ['Out', 'In'],
-        ],
+      return (
+        satisfies(newDetails.offerHandle, {
+          Out: zcf.getCurrentAllocation(order.offerHandle).In,
+        }) &&
+        satisfies(order.offerHandle, {
+          Out: zcf.getCurrentAllocation(newDetails.offerHandle).In,
+        })
       );
     });
-  }
-
-  function crossMatchAmounts(leftDetails, rightDetails) {
-    const amountMathLeftIn = zcf.getAmountMath(leftDetails.amountIn.brand);
-    const amountMathLeftOut = zcf.getAmountMath(leftDetails.amountOut.brand);
-    const newLeftAmountsRecord = {
-      Out: leftDetails.amountOut,
-      In: amountMathLeftIn.subtract(
-        leftDetails.amountIn,
-        rightDetails.amountOut,
-      ),
-    };
-    const newRightAmountsRecord = {
-      Out: rightDetails.amountOut,
-      In: amountMathLeftOut.subtract(
-        rightDetails.amountIn,
-        leftDetails.amountOut,
-      ),
-    };
-    return [newLeftAmountsRecord, newRightAmountsRecord];
   }
 
   function removeFromOrders(offerDetails) {
@@ -87,12 +67,29 @@ const makeContract = zcf => {
     );
     const matchingTrade = findMatchingTrade(offerDetails, orders);
     if (matchingTrade) {
-      // reallocate by switching the amounts
-      const amounts = crossMatchAmounts(offerDetails, matchingTrade);
-      const handles = [offerDetails.offerHandle, matchingTrade.offerHandle];
-      zcf.reallocate(handles, amounts);
+      // reallocate by giving each side what it wants
+      trade(
+        {
+          offerHandle: matchingTrade.offerHandle,
+          gains: {
+            Out: matchingTrade.amountOut,
+          },
+          losses: {
+            In: offerDetails.amountOut,
+          },
+        },
+        {
+          offerHandle: offerDetails.offerHandle,
+          gains: {
+            Out: offerDetails.amountOut,
+          },
+          losses: {
+            In: matchingTrade.amountOut,
+          },
+        },
+      );
       removeFromOrders(matchingTrade);
-      zcf.complete(handles);
+      zcf.complete([offerDetails.offerHandle, matchingTrade.offerHandle]);
 
       return true;
     }

--- a/packages/zoe/src/contracts/multipoolAutoswap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap.js
@@ -182,14 +182,14 @@ const makeContract = zcf => {
   };
 
   const getPoolKeyword = brandToMatch => {
-    const { brandKeywordRecord } = zcf.getInstanceRecord();
-    const entries = Object.entries(brandKeywordRecord);
-    for (const [keyword, brand] of entries) {
-      if (brand === brandToMatch) {
-        return keyword;
-      }
+    if (brandToMatch === centralTokenBrand) {
+      return CENTRAL_TOKEN;
     }
-    throw new Error('getPoolKeyword: brand not found');
+    if (!liquidityTable.has(brandToMatch)) {
+      throw new Error('getPoolKeyword: brand not found');
+    }
+    const { tokenKeyword } = liquidityTable.get(brandToMatch);
+    return tokenKeyword;
   };
 
   const getPoolAmount = (poolAllocation, desiredBrand) => {

--- a/packages/zoe/src/contracts/multipoolAutoswap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap.js
@@ -9,7 +9,7 @@ import { makeTable, makeValidateProperties } from '../table';
 import { assertKeywordName } from '../cleanProposal';
 import {
   makeZoeHelpers,
-  getCurrentPrice,
+  getInputPrice,
   calcLiqExtentToMint,
   calcExtentToRemove,
 } from '../contractSupport';
@@ -39,6 +39,7 @@ import { filterObj } from '../objArrayConversion';
  * of pools.
  *
  * @typedef {import('@agoric/ertp/src/issuer').Amount} Amount
+ * @typedef {import('@agoric/ertp/src/issuer').Brand} Brand
  * @typedef {import('../zoe').AmountKeywordRecords} AmountKeywordRecords
  * @typedef {import('../zoe').ContractFacet} ContractFacet
  * @param {ContractFacet} zcf
@@ -46,17 +47,6 @@ import { filterObj } from '../objArrayConversion';
 const makeContract = zcf => {
   // This contract must have a "central token" issuer in the terms.
   const CENTRAL_TOKEN = 'CentralToken';
-
-  function buildAmountMathKeywordRecord(keywords) {
-    const { brandKeywordRecord } = zcf.getInstanceRecord();
-    const amountMathKeywordRecord = {};
-    keywords.forEach(keyword => {
-      const brand = brandKeywordRecord[keyword];
-      assertNatMathHelpers(brand);
-      amountMathKeywordRecord[keyword] = zcf.getAmountMath(brand);
-    });
-    return amountMathKeywordRecord;
-  }
 
   const getCentralTokenBrand = () => {
     const { brandKeywordRecord } = zcf.getInstanceRecord();
@@ -69,9 +59,10 @@ const makeContract = zcf => {
   const centralTokenBrand = getCentralTokenBrand();
 
   const {
+    trade,
     rejectOffer,
     makeEmptyOffer,
-    rejectIfNotProposal,
+    checkHook,
     assertKeywords,
     escrowAndAllocateTo,
     assertNatMathHelpers,
@@ -90,8 +81,10 @@ const makeContract = zcf => {
       harden([
         'poolHandle',
         'tokenIssuer',
+        'tokenBrand',
         'liquidityMint',
         'liquidityIssuer',
+        'liquidityBrand',
         'tokenKeyword',
         'liquidityKeyword',
         'liquidityTokenSupply',
@@ -120,9 +113,11 @@ const makeContract = zcf => {
       !keywords.includes(newLiquidityKeyword),
       details`newLiquidityKeyword must be unique`,
     );
-    const { mint: liquidityMint, issuer: liquidityIssuer } = produceIssuer(
-      newLiquidityKeyword,
-    );
+    const {
+      mint: liquidityMint,
+      issuer: liquidityIssuer,
+      brand: liquidityBrand,
+    } = produceIssuer(newLiquidityKeyword);
     return Promise.all([
       zcf.addNewIssuer(newTokenIssuer, newTokenKeyword),
       makeEmptyOffer(),
@@ -135,8 +130,10 @@ const makeContract = zcf => {
         harden({
           poolHandle,
           tokenIssuer: newTokenIssuer,
+          tokenBrand: newTokenIssuerRecord.brand,
           liquidityMint,
           liquidityIssuer,
+          liquidityBrand,
           tokenKeyword: newTokenKeyword,
           liquidityKeyword: newLiquidityKeyword,
           liquidityTokenSupply: 0,
@@ -164,67 +161,55 @@ const makeContract = zcf => {
     return zcf.getCurrentAllocation(poolHandle, brandKeywordRecord);
   };
 
-  const doGetCurrentPrice = ({
-    amountIn,
-    keywordIn,
-    keywordOut,
-    secondaryBrand,
+  const findSecondaryTokenBrand = ({
+    brandIn,
+    brandOut,
+    offerHandleToReject,
   }) => {
-    const poolAllocation = getPoolAllocation(secondaryBrand);
-    const { outputExtent } = getCurrentPrice(
-      harden({
-        inputExtent: amountIn.extent,
-        inputReserve: poolAllocation[keywordIn].extent,
-        outputReserve: poolAllocation[keywordOut].extent,
-      }),
-    );
-    const amountMathOut = zcf.getAmountMath(poolAllocation[keywordOut].brand);
-    return amountMathOut.make(outputExtent);
-  };
-
-  const doSwap = ({
-    userAllocation,
-    keywordIn,
-    keywordOut,
-    secondaryBrand,
-  }) => {
-    const poolAllocation = getPoolAllocation(secondaryBrand);
-    const { outputExtent, newInputReserve, newOutputReserve } = getCurrentPrice(
-      harden({
-        inputExtent: userAllocation.In.extent,
-        inputReserve: poolAllocation[keywordIn].extent,
-        outputReserve: poolAllocation[keywordOut].extent,
-      }),
-    );
-    const amountMathOut = zcf.getAmountMath(poolAllocation[keywordOut].brand);
-    const amountMathIn = zcf.getAmountMath(poolAllocation[keywordIn].brand);
-    const amountOut = amountMathOut.make(outputExtent);
-
-    const newUserAmounts = harden({
-      In: amountMathIn.getEmpty(),
-      Out: amountOut,
-    });
-
-    const newPoolAmounts = harden({
-      [keywordIn]: amountMathIn.make(newInputReserve),
-      [keywordOut]: amountMathOut.make(newOutputReserve),
-    });
-
-    const { poolHandle } = liquidityTable.get(secondaryBrand);
-    return harden({ poolHandle, newUserAmounts, newPoolAmounts });
-  };
-
-  const getSecondaryBrand = ({ offerHandle, isAddLiquidity }) => {
-    const { proposal } = zcf.getOffer(offerHandle);
-    const key = isAddLiquidity ? 'give' : 'want';
-    const {
-      [key]: { [CENTRAL_TOKEN]: _, ...tokenAmountKeywordRecord },
-    } = proposal;
-    const tokenAmounts = Object.values(tokenAmountKeywordRecord);
-    if (tokenAmounts.length !== 1) {
-      rejectOffer(offerHandle, `only one secondary brand should be present`);
+    if (liquidityTable.has(brandIn)) {
+      return brandIn;
     }
-    return tokenAmounts[0].brand;
+    if (liquidityTable.has(brandOut)) {
+      return brandOut;
+    }
+    // We couldn't find either so throw. Reject the offer if
+    // offerHandleToReject is defined.
+    const msg = `No secondary token was found`;
+    if (offerHandleToReject !== undefined) {
+      rejectOffer(offerHandleToReject, msg);
+    }
+    throw new Error(msg);
+  };
+
+  const getPoolKeyword = brandToMatch => {
+    const { brandKeywordRecord } = zcf.getInstanceRecord();
+    const entries = Object.entries(brandKeywordRecord);
+    for (const [keyword, brand] of entries) {
+      if (brand === brandToMatch) {
+        return keyword;
+      }
+    }
+    throw new Error('getPoolKeyword: brand not found');
+  };
+
+  const getPoolAmount = (poolAllocation, desiredBrand) => {
+    const keyword = getPoolKeyword(desiredBrand);
+    return poolAllocation[keyword];
+  };
+
+  const doGetCurrentPrice = ({ amountIn, brandOut }) => {
+    const brandIn = amountIn.brand;
+    const secondaryTokenBrand = findSecondaryTokenBrand({
+      brandIn,
+      brandOut,
+    });
+    const poolAllocation = getPoolAllocation(secondaryTokenBrand);
+    const outputExtent = getInputPrice({
+      inputExtent: amountIn.extent,
+      inputReserve: getPoolAmount(poolAllocation, brandIn).extent,
+      outputReserve: getPoolAmount(poolAllocation, brandOut).extent,
+    });
+    return zcf.getAmountMath(brandOut).make(outputExtent);
   };
 
   const rejectIfNotTokenBrand = (inviteHandle, brand) => {
@@ -233,71 +218,47 @@ const makeContract = zcf => {
     }
   };
 
+  const addLiquidityExpected = harden({
+    give: {
+      CentralToken: null,
+      SecondaryToken: null,
+    },
+    want: { Liquidity: null },
+  });
+
   const addLiquidityHook = offerHandle => {
     // Get the brand of the secondary token so we can identify the liquidity pool.
-    const secondaryTokenBrand = getSecondaryBrand(
-      harden({
-        offerHandle,
-        isAddLiquidity: true,
-      }),
-    );
+    const {
+      proposal: {
+        give: {
+          SecondaryToken: { brand: secondaryTokenBrand },
+        },
+      },
+    } = zcf.getOffer(offerHandle);
 
     const {
       tokenKeyword,
-      liquidityKeyword,
+      liquidityBrand,
       liquidityTokenSupply,
       liquidityMint,
       poolHandle,
     } = liquidityTable.get(secondaryTokenBrand);
 
-    // These are the keywords for the pool in this method
-    const poolLiquidityKeys = harden([
-      CENTRAL_TOKEN,
-      tokenKeyword,
-      liquidityKeyword,
-    ]);
-    const {
-      brandKeywordRecord: poolBrandKeywordRecord,
-    } = zcf.getInstanceRecord();
-    const poolAmountMaths = buildAmountMathKeywordRecord(poolLiquidityKeys);
-    const userAmountMaths = {
-      In: poolAmountMaths[tokenKeyword],
-      Out: poolAmountMaths[liquidityKeyword],
-      [CENTRAL_TOKEN]: poolAmountMaths[CENTRAL_TOKEN],
-    };
-    const userBrandKeywordRecord = {
-      In: poolBrandKeywordRecord[tokenKeyword],
-      Out: poolBrandKeywordRecord[liquidityKeyword],
-      [CENTRAL_TOKEN]: poolBrandKeywordRecord[CENTRAL_TOKEN],
-    };
-
-    const expected = harden({
-      give: {
-        [CENTRAL_TOKEN]: null,
-        In: null,
-      },
-      want: { Out: null },
-    });
-    rejectIfNotProposal(offerHandle, expected);
-
-    const userAllocation = zcf.getCurrentAllocation(
-      offerHandle,
-      userBrandKeywordRecord,
-    );
+    const userAllocation = zcf.getCurrentAllocation(offerHandle);
     const poolAllocation = getPoolAllocation(secondaryTokenBrand);
 
     // Calculate how many liquidity tokens we should be minting.
     const liquidityExtentOut = calcLiqExtentToMint(
       harden({
         liqTokenSupply: liquidityTokenSupply,
-        inputExtent: userAllocation[CENTRAL_TOKEN].extent,
-        inputReserve: poolAllocation[CENTRAL_TOKEN].extent,
+        inputExtent: userAllocation.CentralToken.extent,
+        inputReserve: poolAllocation.CentralToken.extent,
       }),
     );
 
-    const liquidityAmountOut = poolAmountMaths[liquidityKeyword].make(
-      liquidityExtentOut,
-    );
+    const liquidityAmountOut = zcf
+      .getAmountMath(liquidityBrand)
+      .make(liquidityExtentOut);
 
     const liquidityPaymentP = liquidityMint.mintPayment(liquidityAmountOut);
 
@@ -311,45 +272,46 @@ const makeContract = zcf => {
     return escrowAndAllocateTo({
       amount: liquidityAmountOut,
       payment: liquidityPaymentP,
-      keyword: 'Out',
+      keyword: 'Liquidity',
       recipientHandle: offerHandle,
     }).then(() => {
-      const addByKey = (key, obj1, obj2) =>
-        poolAmountMaths[key].add(obj1[key], obj2[key]);
-      const newPoolTokenAmount = poolAmountMaths[tokenKeyword].add(
-        userAllocation.In,
-        poolAllocation[tokenKeyword],
+      trade(
+        {
+          offerHandle: poolHandle,
+          gains: {
+            CentralToken: userAllocation.CentralToken,
+            [tokenKeyword]: userAllocation.SecondaryToken,
+          },
+        },
+        // We reallocated liquidity in the call to
+        // escrowAndAllocateTo.
+        { offerHandle, gains: {}, losses: userAllocation },
       );
 
-      const newPoolAmounts = harden({
-        [CENTRAL_TOKEN]: addByKey(
-          CENTRAL_TOKEN,
-          userAllocation,
-          poolAllocation,
-        ),
-        [tokenKeyword]: newPoolTokenAmount,
-        [liquidityKeyword]: poolAllocation[liquidityKeyword],
-      });
-
-      const newUserAmounts = {
-        [CENTRAL_TOKEN]: userAmountMaths[CENTRAL_TOKEN].getEmpty(),
-        In: userAmountMaths.In.getEmpty(),
-        Out: liquidityAmountOut,
-      };
-
-      zcf.reallocate(
-        harden([offerHandle, poolHandle]),
-        harden([newUserAmounts, newPoolAmounts]),
-      );
       zcf.complete(harden([offerHandle]));
       return 'Added liquidity.';
     });
   };
 
+  const removeLiquidityExpected = harden({
+    want: {
+      CentralToken: null,
+      SecondaryToken: null,
+    },
+    give: {
+      Liquidity: null,
+    },
+  });
+
   const removeLiquidityHook = offerHandle => {
-    const secondaryTokenBrand = getSecondaryBrand(
-      harden({ offerHandle, isAddLiquidity: false }),
-    );
+    // Get the brand of the secondary token so we can identify the liquidity pool.
+    const {
+      proposal: {
+        want: {
+          SecondaryToken: { brand: secondaryTokenBrand },
+        },
+      },
+    } = zcf.getOffer(offerHandle);
 
     const {
       tokenKeyword,
@@ -358,180 +320,133 @@ const makeContract = zcf => {
       poolHandle,
     } = liquidityTable.get(secondaryTokenBrand);
 
-    const expected = harden({
-      want: { [CENTRAL_TOKEN]: null, Out: null },
-      give: { In: null },
-    });
-    rejectIfNotProposal(offerHandle, expected);
-    const poolAmountMaths = buildAmountMathKeywordRecord([
-      CENTRAL_TOKEN,
-      tokenKeyword,
-      liquidityKeyword,
-    ]);
-
-    const {
-      brandKeywordRecord: poolBrandKeywordRecord,
-    } = zcf.getInstanceRecord();
-    const userBrandKeywordRecord = {
-      In: poolBrandKeywordRecord[tokenKeyword],
-      Out: poolBrandKeywordRecord[liquidityKeyword],
-      [CENTRAL_TOKEN]: poolBrandKeywordRecord[CENTRAL_TOKEN],
-    };
-    const userAllocation = zcf.getCurrentAllocation(
-      offerHandle,
-      userBrandKeywordRecord,
-    );
+    const userAllocation = zcf.getCurrentAllocation(offerHandle);
     const poolAllocation = getPoolAllocation(secondaryTokenBrand);
-    const liquidityExtentIn = userAllocation.In.extent;
+    const liquidityExtentIn = userAllocation.Liquidity.extent;
 
-    const newUserAmounts = harden({
-      [CENTRAL_TOKEN]: poolAmountMaths[CENTRAL_TOKEN].make(
-        calcExtentToRemove(
-          harden({
-            liqTokenSupply: liquidityTokenSupply,
-            poolExtent: poolAllocation[CENTRAL_TOKEN].extent,
-            liquidityExtentIn,
-          }),
-        ),
+    const centralTokenAmountOut = zcf.getAmountMath(centralTokenBrand).make(
+      calcExtentToRemove(
+        harden({
+          liqTokenSupply: liquidityTokenSupply,
+          poolExtent: poolAllocation[CENTRAL_TOKEN].extent,
+          liquidityExtentIn,
+        }),
       ),
-      Out: poolAmountMaths[tokenKeyword].make(
-        calcExtentToRemove(
-          harden({
-            liqTokenSupply: liquidityTokenSupply,
-            poolExtent: poolAllocation[tokenKeyword].extent,
-            liquidityExtentIn,
-          }),
-        ),
-      ),
-      In: poolAmountMaths[liquidityKeyword].getEmpty(),
-    });
+    );
 
-    const newPoolAmounts = harden({
-      [CENTRAL_TOKEN]: poolAmountMaths[CENTRAL_TOKEN].subtract(
-        poolAllocation[CENTRAL_TOKEN],
-        newUserAmounts[CENTRAL_TOKEN],
+    const tokenKeywordAmountOut = zcf.getAmountMath(secondaryTokenBrand).make(
+      calcExtentToRemove(
+        harden({
+          liqTokenSupply: liquidityTokenSupply,
+          poolExtent: poolAllocation[tokenKeyword].extent,
+          liquidityExtentIn,
+        }),
       ),
-      [tokenKeyword]: poolAmountMaths[tokenKeyword].subtract(
-        poolAllocation[tokenKeyword],
-        newUserAmounts.Out,
-      ),
-      [liquidityKeyword]: poolAmountMaths[liquidityKeyword].add(
-        poolAllocation[liquidityKeyword],
-        poolAmountMaths[liquidityKeyword].make(liquidityExtentIn),
-      ),
-    });
+    );
 
     liquidityTable.update(secondaryTokenBrand, {
       liquidityTokenSupply: liquidityTokenSupply - liquidityExtentIn,
     });
 
-    zcf.reallocate(
-      harden([offerHandle, poolHandle]),
-      harden([newUserAmounts, newPoolAmounts]),
+    trade(
+      {
+        offerHandle: poolHandle,
+        gains: { [liquidityKeyword]: userAllocation.Liquidity },
+        losses: {
+          CentralToken: centralTokenAmountOut,
+          [tokenKeyword]: tokenKeywordAmountOut,
+        },
+      },
+      {
+        offerHandle,
+        gains: {
+          CentralToken: centralTokenAmountOut,
+          SecondaryToken: tokenKeywordAmountOut,
+        },
+        losses: {
+          Liquidity: userAllocation.Liquidity,
+        },
+      },
     );
+
     zcf.complete(harden([offerHandle]));
     return 'Liquidity successfully removed.';
   };
 
+  const swapExpected = harden({
+    give: {
+      In: null,
+    },
+    want: {
+      Out: null,
+    },
+  });
+
   const swapHook = offerHandle => {
     const {
-      give: {
-        In: { brand: brandIn },
-      },
-      want: {
-        Out: { brand: brandOut },
-      },
+      give: { In: amountIn },
+      want: { Out: wantedAmountOut },
     } = zcf.getOffer(offerHandle).proposal;
+    const brandIn = amountIn.brand;
+    const brandOut = wantedAmountOut.brand;
 
-    const expected = harden({
-      give: { In: null },
-      want: { Out: null },
-    });
-    rejectIfNotProposal(offerHandle, expected);
+    // we could be swapping (1) secondary to secondary, (2) central
+    // to secondary, or (3) secondary to central.
 
-    // we could be swapping (1) central to secondary, (2) secondary to
-    // central, or (3) secondary to secondary.
-
-    // 1) central to secondary
-    if (brandIn === centralTokenBrand) {
-      rejectIfNotTokenBrand(offerHandle, brandOut);
-
-      const { poolHandle, newUserAmounts, newPoolAmounts } = doSwap(
-        harden({
-          userAllocation: zcf.getCurrentAllocation(offerHandle),
-          keywordIn: 'CentralToken',
-          keywordOut: liquidityTable.get(brandOut).tokenKeyword,
-          secondaryBrand: brandOut,
-        }),
-      );
-      zcf.reallocate(
-        harden([offerHandle, poolHandle]),
-        harden([newUserAmounts, newPoolAmounts]),
-      );
-      zcf.complete(harden([offerHandle]));
-      return `Swap successfully completed.`;
-
-      // eslint-disable-next-line no-else-return
-    } else if (brandOut === centralTokenBrand) {
-      // 2) secondary to central
-      rejectIfNotTokenBrand(offerHandle, brandIn);
-      const { poolHandle, newUserAmounts, newPoolAmounts } = doSwap(
-        harden({
-          userAllocation: zcf.getCurrentAllocation(offerHandle),
-          keywordIn: liquidityTable.get(brandIn).tokenKeyword,
-          keywordOut: 'CentralToken',
-          secondaryBrand: brandIn,
-        }),
-      );
-      zcf.reallocate(
-        harden([offerHandle, poolHandle]),
-        harden([newUserAmounts, newPoolAmounts]),
-      );
-      zcf.complete(harden([offerHandle]));
-      return `Swap successfully completed.`;
-    } else {
-      // 3) secondary to secondary
+    // 1) secondary to secondary
+    if (liquidityTable.has(brandIn) && liquidityTable.has(brandOut)) {
       rejectIfNotTokenBrand(offerHandle, brandIn);
       rejectIfNotTokenBrand(offerHandle, brandOut);
 
-      const {
-        poolHandle: poolHandleA,
-        newUserAmounts: newUserAmountsA,
-        newPoolAmounts: newPoolAmountsA,
-      } = doSwap(
+      const centralTokenAmount = doGetCurrentPrice(
         harden({
-          userAllocation: zcf.getCurrentAllocation(offerHandle),
-          keywordIn: liquidityTable.get(brandIn).tokenKeyword,
-          keywordOut: CENTRAL_TOKEN,
-          secondaryBrand: brandIn,
+          amountIn,
+          brandOut: centralTokenBrand,
         }),
       );
-      const {
-        poolHandle: poolHandleB,
-        newUserAmounts,
-        newPoolAmounts: newPoolAmountsB,
-      } = doSwap(
+      const amountOut = doGetCurrentPrice(
         harden({
-          userAllocation: { In: newUserAmountsA.Out },
-          keywordIn: CENTRAL_TOKEN,
-          keywordOut: liquidityTable.get(brandOut).tokenKeyword,
-          secondaryBrand: brandOut,
+          amountIn: centralTokenAmount,
+          brandOut,
         }),
       );
-      const amountMathOut = zcf.getAmountMath(brandOut);
-      const amountMathIn = zcf.getAmountMath(brandIn);
+
+      const brandInAmountMath = zcf.getAmountMath(brandIn);
+      const finalUserAmounts = harden({
+        In: brandInAmountMath.getEmpty(),
+        Out: amountOut,
+      });
+
+      const { poolHandle: poolHandleA } = liquidityTable.get(brandIn);
+      const poolAllocationA = zcf.getCurrentAllocation(poolHandleA);
+      const poolKeywordBrandIn = getPoolKeyword(brandIn);
+      const centralTokenAmountMath = zcf.getAmountMath(centralTokenBrand);
       const finalPoolAmountsA = {
-        ...newPoolAmountsA,
-        Out: amountMathOut.getEmpty(),
+        [poolKeywordBrandIn]: brandInAmountMath.add(
+          poolAllocationA[poolKeywordBrandIn],
+          amountIn,
+        ),
+        CentralToken: centralTokenAmountMath.subtract(
+          poolAllocationA.CentralToken,
+          centralTokenAmount,
+        ),
       };
+
+      const { poolHandle: poolHandleB } = liquidityTable.get(brandOut);
+      const poolAllocationB = zcf.getCurrentAllocation(poolHandleB);
+      const poolKeywordBrandOut = getPoolKeyword(brandOut);
+      const brandOutAmountMath = zcf.getAmountMath(brandOut);
       const finalPoolAmountsB = {
-        ...newPoolAmountsB,
-        In: amountMathIn.getEmpty(),
+        CentralToken: centralTokenAmountMath.add(
+          poolAllocationB.CentralToken,
+          centralTokenAmount,
+        ),
+        [poolKeywordBrandOut]: brandOutAmountMath.subtract(
+          poolAllocationB[poolKeywordBrandOut],
+          amountOut,
+        ),
       };
-      const finalUserAmounts = {
-        ...newUserAmounts,
-        In: newUserAmountsA.In,
-      };
+
       zcf.reallocate(
         harden([poolHandleA, poolHandleB, offerHandle]),
         harden([finalPoolAmountsA, finalPoolAmountsB, finalUserAmounts]),
@@ -539,93 +454,112 @@ const makeContract = zcf => {
       zcf.complete(harden([offerHandle]));
       return `Swap successfully completed.`;
     }
+    // 2) central to secondary and 3) secondary to central
+    const secondaryTokenBrand = findSecondaryTokenBrand({
+      brandIn,
+      brandOut,
+      offerHandleToReject: offerHandle,
+    });
+    const { poolHandle } = liquidityTable.get(secondaryTokenBrand);
+
+    const amountOut = doGetCurrentPrice(
+      harden({
+        amountIn,
+        brandOut,
+      }),
+    );
+    trade(
+      {
+        offerHandle: poolHandle,
+        gains: {
+          [getPoolKeyword(brandIn)]: amountIn,
+        },
+        losses: {
+          [getPoolKeyword(brandOut)]: amountOut,
+        },
+      },
+      {
+        offerHandle,
+        gains: { Out: amountOut },
+        losses: { In: amountIn },
+      },
+    );
+    zcf.complete(harden([offerHandle]));
+    return `Swap successfully completed.`;
   };
 
+  /**
+   * `getCurrentPrice` calculates the result of a trade, given a certain
+   * amount of digital assets in.
+   * @param {Amount} amountIn - the amount of digital assets to be
+   * sent in
+   * @param {Brand} brandOut - the brand of the requested payment.
+   */
+  const getCurrentPrice = (amountIn, brandOut) => {
+    const brandIn = amountIn.brand;
+    // brandIn could either be the central token brand, or one of
+    // the secondary token brands
+
+    // SecondaryToken to SecondaryToken
+    if (brandIn !== centralTokenBrand && brandOut !== centralTokenBrand) {
+      assert(
+        liquidityTable.has(brandIn) && liquidityTable.has(brandOut),
+        details`amountIn brand ${brandIn} or brandOut ${brandOut} was not recognized`,
+      );
+
+      // We must do two consecutive `doGetCurrentPrice` calls: from
+      // the brandIn to the central token, then from the central
+      // token to the brandOut
+      const centralTokenAmount = doGetCurrentPrice(
+        harden({
+          amountIn,
+          brandOut: centralTokenBrand,
+        }),
+      );
+      return doGetCurrentPrice(
+        harden({
+          amountIn: centralTokenAmount,
+          brandOut,
+        }),
+      );
+    }
+
+    // All other cases: secondaryToken to CentralToken or vice versa.
+    return doGetCurrentPrice(
+      harden({
+        amountIn,
+        brandOut,
+      }),
+    );
+  };
+
+  const getLiquidityIssuer = tokenBrand =>
+    liquidityTable.get(tokenBrand).liquidityIssuer;
+
   const makeAddLiquidityInvite = () =>
-    zcf.makeInvitation(addLiquidityHook, 'multipool autoswap add liquidity');
+    zcf.makeInvitation(
+      checkHook(addLiquidityHook, addLiquidityExpected),
+      'multipool autoswap add liquidity',
+    );
+
+  const makeSwapInvite = () =>
+    zcf.makeInvitation(checkHook(swapHook, swapExpected), 'autoswap swap');
+
+  const makeRemoveLiquidityInvite = () =>
+    zcf.makeInvitation(
+      checkHook(removeLiquidityHook, removeLiquidityExpected),
+      'autoswap remove liquidity',
+    );
 
   zcf.initPublicAPI(
     harden({
-      getBrandKeywordRecord: () => {
-        return zcf.getInstanceRecord().brandKeywordRecord;
-      },
       addPool,
       getPoolAllocation,
-      getLiquidityIssuer: tokenBrand =>
-        liquidityTable.get(tokenBrand).liquidityIssuer,
-      /**
-       * `getCurrentPrice` calculates the result of a trade, given a certain
-       * amount of digital assets in.
-       * @param {Amount} amountIn - the amount of digital assets to be
-       * sent in
-       * @param {Brand} brandOut - the brand of the requested payment.
-       */
-      getCurrentPrice: (amountIn, brandOut) => {
-        const brandIn = amountIn.brand;
-        // brandIn could either be the central token brand, or one of
-        // the secondary token brands
-
-        // CentralToken to SecondaryToken
-        if (brandIn === centralTokenBrand) {
-          assert(
-            liquidityTable.has(brandOut),
-            details`brandOut ${brandOut} was not recognized`,
-          );
-          return doGetCurrentPrice(
-            harden({
-              amountIn,
-              keywordIn: CENTRAL_TOKEN,
-              keywordOut: liquidityTable.get(brandOut).tokenKeyword,
-              secondaryBrand: brandOut,
-            }),
-          );
-          // eslint-disable-next-line no-else-return
-        } else if (brandOut === centralTokenBrand) {
-          // SecondaryToken to CentralToken
-          assert(
-            liquidityTable.has(brandIn),
-            details`amountIn brand ${amountIn} was not recognized`,
-          );
-          return doGetCurrentPrice(
-            harden({
-              amountIn,
-              keywordIn: liquidityTable.get(brandIn).tokenKeyword,
-              keywordOut: CENTRAL_TOKEN,
-              secondaryBrand: brandIn,
-            }),
-          );
-        } else {
-          // SecondaryToken to SecondaryToken
-          assert(
-            liquidityTable.has(brandIn) && liquidityTable.has(brandOut),
-            details`amountIn brand ${brandIn} or brandOut ${brandOut} was not recognized`,
-          );
-
-          // We must do two consecutive `doGetCurrentPrice` calls: from
-          // the brandIn to the central token, then from the central
-          // token to the brandOut
-          const centralTokenAmount = doGetCurrentPrice(
-            harden({
-              amountIn,
-              keywordIn: liquidityTable.get(brandIn).tokenKeyword,
-              keywordOut: CENTRAL_TOKEN,
-              secondaryBrand: brandIn,
-            }),
-          );
-          return doGetCurrentPrice(
-            harden({
-              amountIn: centralTokenAmount,
-              keywordIn: CENTRAL_TOKEN,
-              keywordOut: liquidityTable.get(brandOut).tokenKeyword,
-              secondaryBrand: brandOut,
-            }),
-          );
-        }
-      },
-      makeSwapInvite: () => zcf.makeInvitation(swapHook, 'autoswap swap'),
+      getLiquidityIssuer,
+      getCurrentPrice,
+      makeSwapInvite,
       makeAddLiquidityInvite,
-      makeRemoveLiquidityInvite: () =>
-        zcf.makeInvitation(removeLiquidityHook, 'autoswap remove liquidity'),
+      makeRemoveLiquidityInvite,
     }),
   );
 

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -32,6 +32,7 @@ const makeContract = zcf => {
     rejectOffer,
     checkHook,
     assertNatMathHelpers,
+    trade,
   } = makeZoeHelpers(zcf);
   assertKeywords(harden(allKeywords));
 
@@ -78,21 +79,13 @@ const makeContract = zcf => {
       );
     }
 
-    // Reallocate and complete the buyer offer.
-    const newSellerAllocation = {
-      Money: moneyAmountMaths.add(sellerAllocation.Money, providedMoney),
-      Items: itemsAmountMath.subtract(sellerAllocation.Items, wantedItems),
-    };
-
-    const newBuyerAllocation = {
-      Money: moneyAmountMaths.getEmpty(),
-      Items: itemsAmountMath.add(buyerAllocation.Items, wantedItems),
-    };
-
-    zcf.reallocate(
-      [sellerOfferHandle, buyerOfferHandle],
-      [newSellerAllocation, newBuyerAllocation],
+    // Reallocate.
+    trade(
+      { offerHandle: sellerOfferHandle, gains: { Money: providedMoney } },
+      { offerHandle: buyerOfferHandle, gains: { Items: wantedItems } },
     );
+
+    // Complete the buyer offer.
     zcf.complete([buyerOfferHandle]);
     return defaultAcceptanceMsg;
   };

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -79,7 +79,10 @@ const makeContract = zcf => {
       );
     }
 
-    // Reallocate.
+    // Reallocate. We are able to trade by only defining the gains
+    // (omitting the losses) because the keywords for both offers are
+    // the same, so the gains for one offer are the losses for the
+    // other.
     trade(
       { offerHandle: sellerOfferHandle, gains: { Money: providedMoney } },
       { offerHandle: buyerOfferHandle, gains: { Items: wantedItems } },

--- a/packages/zoe/src/contracts/simpleExchange.js
+++ b/packages/zoe/src/contracts/simpleExchange.js
@@ -82,15 +82,12 @@ const makeContract = zcf => {
   // the caller can know to add the new offer to the book.
   function swapIfCanTrade(offerHandles, offerHandle) {
     for (const iHandle of offerHandles) {
-      const iHandleSatisfied = satisfies(
-        iHandle,
-        zcf.getCurrentAllocation(offerHandle),
-      );
-      const offerHandleSatisfied = satisfies(
-        offerHandle,
-        zcf.getCurrentAllocation(iHandle),
-      );
-      if (iHandleSatisfied && offerHandleSatisfied) {
+      const satisfiedBy = (xHandle, yHandle) =>
+        satisfies(xHandle, zcf.getCurrentAllocation(yHandle));
+      if (
+        satisfiedBy(iHandle, offerHandle) &&
+        satisfiedBy(offerHandle, iHandle)
+      ) {
         swap(offerHandle, iHandle);
         // return handle to remove
         return iHandle;

--- a/packages/zoe/src/contracts/simpleExchange.js
+++ b/packages/zoe/src/contracts/simpleExchange.js
@@ -35,7 +35,7 @@ const makeContract = zcf => {
     rejectOffer,
     checkIfProposal,
     swap,
-    canTradeWith,
+    satisfies,
     getActiveOffers,
     assertKeywords,
   } = makeZoeHelpers(zcf);
@@ -82,7 +82,15 @@ const makeContract = zcf => {
   // the caller can know to add the new offer to the book.
   function swapIfCanTrade(offerHandles, offerHandle) {
     for (const iHandle of offerHandles) {
-      if (canTradeWith(offerHandle, iHandle)) {
+      const iHandleSatisfied = satisfies(
+        iHandle,
+        zcf.getCurrentAllocation(offerHandle),
+      );
+      const offerHandleSatisfied = satisfies(
+        offerHandle,
+        zcf.getCurrentAllocation(iHandle),
+      );
+      if (iHandleSatisfied && offerHandleSatisfied) {
         swap(offerHandle, iHandle);
         // return handle to remove
         return iHandle;

--- a/packages/zoe/src/offerSafety.js
+++ b/packages/zoe/src/offerSafety.js
@@ -13,7 +13,7 @@
  * @param {Proposal["give"] | Proposal["want"]} giveOrWant
  * @param {AmountKeywordRecord} allocation
  */
-const satisfies = (getAmountMath, giveOrWant, allocation) => {
+const satisfiesInternal = (getAmountMath, giveOrWant, allocation) => {
   const isGTEByKeyword = ([keyword, requiredAmount]) => {
     // If there is no allocation for a keyword, we know the giveOrWant
     // is not satisfied without checking further.
@@ -31,7 +31,8 @@ const satisfies = (getAmountMath, giveOrWant, allocation) => {
  * For this allocation to satisfy what the user wanted, their
  * allocated amounts must be greater than or equal to proposal.want.
  * @param  {(Brand) => AmountMath} getAmountMath - a function that
- * takes a brand and returns the appropriate amountMath
+ * takes a brand and returns the appropriate amountMath. The function
+ * must have an amountMath for every brand in proposal.want.
  * @param  {Proposal} proposal - the rules that accompanied the escrow
  * of payments that dictate what the user expected to get back from
  * Zoe. A proposal is a record with keys `give`, `want`, and `exit`.
@@ -43,14 +44,15 @@ const satisfies = (getAmountMath, giveOrWant, allocation) => {
  * to be given to a user.
  */
 const satisfiesWant = (getAmountMath, proposal, allocation) =>
-  satisfies(getAmountMath, proposal.want, allocation);
+  satisfiesInternal(getAmountMath, proposal.want, allocation);
 
 /**
  * For this allocation to count as a full refund, the allocated
  * amounts must be greater than or equal to what was originally
  * offered (proposal.give).
  * @param  {(Brand) => AmountMath} getAmountMath - a function that
- * takes a brand and returns the appropriate amountMath
+ * takes a brand and returns the appropriate amountMath. The function
+ * must have an amountMath for every brand in proposal.give.
  * @param  {Proposal} proposal - the rules that accompanied the escrow
  * of payments that dictate what the user expected to get back from
  * Zoe. A proposal is a record with keys `give`, `want`, and `exit`.
@@ -62,7 +64,7 @@ const satisfiesWant = (getAmountMath, proposal, allocation) =>
  * to be given to a user.
  */
 const satisfiesGive = (getAmountMath, proposal, allocation) =>
-  satisfies(getAmountMath, proposal.give, allocation);
+  satisfiesInternal(getAmountMath, proposal.give, allocation);
 
 /**
  * `isOfferSafe` checks offer safety for a single offer.
@@ -72,7 +74,9 @@ const satisfiesGive = (getAmountMath, proposal, allocation) =>
  * `proposal.want`. Both can be fully satisfied.
  *
  * @param  {(Brand) => AmountMath} getAmountMath - a function that
- * takes a brand and returns the appropriate amountMath
+ * takes a brand and returns the appropriate amountMath. The function
+ * must have an amountMath for every brand in proposal.want and
+ * proposal.give.
  * @param  {Proposal} proposal - the rules that accompanied the escrow
  * of payments that dictate what the user expected to get back from
  * Zoe. A proposal is a record with keys `give`, `want`, and `exit`.

--- a/packages/zoe/src/offerSafety.js
+++ b/packages/zoe/src/offerSafety.js
@@ -1,38 +1,93 @@
 /**
- * `isOfferSafeForOffer` checks offer safety for a single offer.
- *
- * Note: This implementation checks whether we refund for all rules or
- * return winnings for all rules. It does not allow some refunds and
- * some winnings, which is what would happen if you checked the rules
- * independently. It *does* allow for returning a full refund plus
- * full winnings.
- *
- * @param  {function} getAmountMath - a function that takes a brand and returns
- * the appropriate amountMath
- * @param  {object} proposal - the rules that accompanied the
- * escrow of payments that dictate what the user expected to get back
- * from Zoe. A proposal is a record with keys `give`,
- * `want`, and `exit`. `give` and `want` are records with keywords
- * as keys and amounts as values. The proposal is a player's
- * understanding of the contract that they are entering when they make
- * an offer.
- * @param  {object} newAmountKeywordRecord - a record with keywords as keys and
- * amounts as values. These amounts are the reallocation to be given to a user.
+ * @typedef {import('@agoric/ertp/src/issuer').Brand} Brand
+ * @typedef {import('@agoric/ertp/src/issuer').AmountMath} AmountMath
+ * @typedef {import('./zoe').Proposal} Proposal
+ * @typedef {import('./zoe').AmountKeywordRecord} AmountKeywordRecord
  */
-function isOfferSafeForOffer(getAmountMath, proposal, newAmountKeywordRecord) {
-  const isGTEByKeyword = ([keyword, amount]) =>
-    getAmountMath(amount.brand).isGTE(newAmountKeywordRecord[keyword], amount);
 
-  // For this allocation to count as a full refund, the allocated
-  // amount must be greater than or equal to what was originally
-  // offered.
-  const refundOk = Object.entries(proposal.give).every(isGTEByKeyword);
+/**
+ * Helper to perform satisfiesWant and satisfiesGive. Is
+ * allocationAmount greater than or equal to requiredAmount for every
+ * keyword of giveOrWant?
+ * @param {(Brand) => AmountMath} getAmountMath
+ * @param {Proposal["give"] | Proposal["want"]} giveOrWant
+ * @param {AmountKeywordRecord} allocation
+ */
+const satisfies = (getAmountMath, giveOrWant, allocation) => {
+  const isGTEByKeyword = ([keyword, requiredAmount]) => {
+    // If there is no allocation for a keyword, we know the giveOrWant
+    // is not satisfied without checking further.
+    if (allocation[keyword] === undefined) {
+      return false;
+    }
+    const amountMath = getAmountMath(requiredAmount.brand);
+    const allocationAmount = allocation[keyword];
+    return amountMath.isGTE(allocationAmount, requiredAmount);
+  };
+  return Object.entries(giveOrWant).every(isGTEByKeyword);
+};
 
-  // For this allocation to count as a full payout of what the user
-  // wanted, their allocated amount must be greater than or equal to
-  // what the payoutRules said they wanted.
-  const winningsOk = Object.entries(proposal.want).every(isGTEByKeyword);
-  return refundOk || winningsOk;
+/**
+ * For this allocation to satisfy what the user wanted, their
+ * allocated amounts must be greater than or equal to proposal.want.
+ * @param  {(Brand) => AmountMath} getAmountMath - a function that
+ * takes a brand and returns the appropriate amountMath
+ * @param  {Proposal} proposal - the rules that accompanied the escrow
+ * of payments that dictate what the user expected to get back from
+ * Zoe. A proposal is a record with keys `give`, `want`, and `exit`.
+ * `give` and `want` are records with keywords as keys and amounts as
+ * values. The proposal is a user's understanding of the contract that
+ * they are entering when they make an offer.
+ * @param  {AmountKeywordRecord} allocation - a record with keywords
+ * as keys and amounts as values. These amounts are the reallocation
+ * to be given to a user.
+ */
+const satisfiesWant = (getAmountMath, proposal, allocation) =>
+  satisfies(getAmountMath, proposal.want, allocation);
+
+/**
+ * For this allocation to count as a full refund, the allocated
+ * amounts must be greater than or equal to what was originally
+ * offered (proposal.give).
+ * @param  {(Brand) => AmountMath} getAmountMath - a function that
+ * takes a brand and returns the appropriate amountMath
+ * @param  {Proposal} proposal - the rules that accompanied the escrow
+ * of payments that dictate what the user expected to get back from
+ * Zoe. A proposal is a record with keys `give`, `want`, and `exit`.
+ * `give` and `want` are records with keywords as keys and amounts as
+ * values. The proposal is a user's understanding of the contract that
+ * they are entering when they make an offer.
+ * @param  {AmountKeywordRecord} allocation - a record with keywords
+ * as keys and amounts as values. These amounts are the reallocation
+ * to be given to a user.
+ */
+const satisfiesGive = (getAmountMath, proposal, allocation) =>
+  satisfies(getAmountMath, proposal.give, allocation);
+
+/**
+ * `isOfferSafe` checks offer safety for a single offer.
+ *
+ * Note: This implementation checks whether we fully satisfy
+ * `proposal.give` (giving a refund) or whether we fully satisfy
+ * `proposal.want`. Both can be fully satisfied.
+ *
+ * @param  {(Brand) => AmountMath} getAmountMath - a function that
+ * takes a brand and returns the appropriate amountMath
+ * @param  {Proposal} proposal - the rules that accompanied the escrow
+ * of payments that dictate what the user expected to get back from
+ * Zoe. A proposal is a record with keys `give`, `want`, and `exit`.
+ * `give` and `want` are records with keywords as keys and amounts as
+ * values. The proposal is a user's understanding of the contract that
+ * they are entering when they make an offer.
+ * @param  {AmountKeywordRecord} allocation - a record with keywords
+ * as keys and amounts as values. These amounts are the reallocation
+ * to be given to a user.
+ */
+function isOfferSafe(getAmountMath, proposal, allocation) {
+  return (
+    satisfiesGive(getAmountMath, proposal, allocation) ||
+    satisfiesWant(getAmountMath, proposal, allocation)
+  );
 }
 
-export { isOfferSafeForOffer };
+export { isOfferSafe, satisfiesWant };

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -14,7 +14,7 @@ import {
   cleanKeywords,
 } from './cleanProposal';
 import { arrayToObj, filterFillAmounts, filterObj } from './objArrayConversion';
-import { isOfferSafeForOffer } from './offerSafety';
+import { isOfferSafe } from './offerSafety';
 import { areRightsConserved } from './rightsConservation';
 import { evalContractBundle } from './evalContractCode';
 import { makeTables } from './state';
@@ -73,7 +73,7 @@ import { makeTables } from './state';
  * @property {(installationHandle: InstallationHandle,
  *             issuerKeywordRecord: IssuerKeywordRecord,
  *             terms?: object)
- *            => Promise<Invite>} makeInstance
+ *            => Promise<InviteIssuerRecord>} makeInstance
  * Zoe is long-lived. We can use Zoe to create smart contract
  * instances by specifying a particular contract installation to
  * use, as well as the `issuerKeywordRecord` and `terms` of the contract. The
@@ -195,6 +195,8 @@ import { makeTables } from './state';
  * @property {Object.<string,function>} publicAPI - the invite-free publicly accessible API for the contract
  * @property {Object} terms - contract parameters
  * @property {IssuerKeywordRecord} issuerKeywordRecord - record with keywords keys, issuer values
+ * @property {BrandKeywordRecord} brandKeywordRecord - record with
+ * keywords keys, brand values
  *
  * @typedef {TODO} IssuerRecord
  *
@@ -467,7 +469,7 @@ const makeZoe = (additionalEndowments = {}, vatPowers = {}) => {
           });
 
           assert(
-            isOfferSafeForOffer(getAmountMathForBrand, proposal, reallocation),
+            isOfferSafe(getAmountMathForBrand, proposal, reallocation),
             details`The reallocation was not offer safe`,
           );
           return reallocation;

--- a/packages/zoe/test/swingsetTests/zoe/test-zoe.js
+++ b/packages/zoe/test/swingsetTests/zoe/test-zoe.js
@@ -181,9 +181,9 @@ const expectedSimpleExchangeOkLog = [
   'The offer has been accepted. Once the contract has been completed, please check your payout',
   'The offer has been accepted. Once the contract has been completed, please check your payout',
   'bobMoolaPurse: balance {"brand":{},"extent":3}',
-  'bobSimoleanPurse: balance {"brand":{},"extent":0}',
+  'bobSimoleanPurse: balance {"brand":{},"extent":3}',
   'aliceMoolaPurse: balance {"brand":{},"extent":0}',
-  'aliceSimoleanPurse: balance {"brand":{},"extent":7}',
+  'aliceSimoleanPurse: balance {"brand":{},"extent":4}',
 ];
 
 test('zoe - simpleExchange - valid inputs - with SES', async t => {
@@ -208,21 +208,21 @@ const expectedSimpleExchangeNotificationLog = [
   '{"buys":[],"sells":[]}',
   'The offer has been accepted. Once the contract has been completed, please check your payout',
   'bobMoolaPurse: balance {"brand":{},"extent":0}',
-  'bobSimoleanPurse: balance {"brand":{},"extent":17}',
+  'bobSimoleanPurse: balance {"brand":{},"extent":20}',
   '{"buys":[{"want":{"Asset":{"brand":{},"extent":8}},"give":{"Price":{"brand":{},"extent":2}}}],"sells":[]}',
   'The offer has been accepted. Once the contract has been completed, please check your payout',
   'bobMoolaPurse: balance {"brand":{},"extent":3}',
-  'bobSimoleanPurse: balance {"brand":{},"extent":15}',
+  'bobSimoleanPurse: balance {"brand":{},"extent":18}',
   '{"buys":[{"want":{"Asset":{"brand":{},"extent":8}},"give":{"Price":{"brand":{},"extent":2}}},{"want":{"Asset":{"brand":{},"extent":20}},"give":{"Price":{"brand":{},"extent":13}}}],"sells":[]}',
   'The offer has been accepted. Once the contract has been completed, please check your payout',
   'bobMoolaPurse: balance {"brand":{},"extent":3}',
-  'bobSimoleanPurse: balance {"brand":{},"extent":2}',
+  'bobSimoleanPurse: balance {"brand":{},"extent":5}',
   '{"buys":[{"want":{"Asset":{"brand":{},"extent":8}},"give":{"Price":{"brand":{},"extent":2}}},{"want":{"Asset":{"brand":{},"extent":20}},"give":{"Price":{"brand":{},"extent":13}}},{"want":{"Asset":{"brand":{},"extent":5}},"give":{"Price":{"brand":{},"extent":2}}}],"sells":[]}',
   'The offer has been accepted. Once the contract has been completed, please check your payout',
   'bobMoolaPurse: balance {"brand":{},"extent":3}',
-  'bobSimoleanPurse: balance {"brand":{},"extent":0}',
+  'bobSimoleanPurse: balance {"brand":{},"extent":3}',
   'aliceMoolaPurse: balance {"brand":{},"extent":0}',
-  'aliceSimoleanPurse: balance {"brand":{},"extent":7}',
+  'aliceSimoleanPurse: balance {"brand":{},"extent":4}',
 ];
 
 test('zoe - simpleExchange - state Update - with SES', async t => {

--- a/packages/zoe/test/swingsetTests/zoe/vat-bob.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-bob.js
@@ -446,44 +446,46 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
 
       // bob checks the price of 3 moola. The price is 1 simolean
       const simoleanAmounts = await E(publicAPI).getCurrentPrice(
-        harden({ TokenA: moola(3) }),
+        moola(3),
+        simoleans(0).brand,
       );
       log(`simoleanAmounts `, simoleanAmounts);
 
       const buyBInvite = E(publicAPI).makeSwapInvite();
 
       const moolaForSimProposal = harden({
-        give: { TokenA: moola(3) },
-        want: { TokenB: simoleans(1) },
+        give: { In: moola(3) },
+        want: { Out: simoleans(1) },
       });
 
-      const moolaForSimPayments = harden({ TokenA: moolaPayment });
+      const moolaForSimPayments = harden({ In: moolaPayment });
       const { payout: moolaForSimPayoutP, outcome: outcomeP } = await E(
         zoe,
       ).offer(buyBInvite, moolaForSimProposal, moolaForSimPayments);
 
       log(await outcomeP);
       const moolaForSimPayout = await moolaForSimPayoutP;
-      const moolaPayout1 = await moolaForSimPayout.TokenA;
-      const simoleanPayout1 = await moolaForSimPayout.TokenB;
+      const moolaPayout1 = await moolaForSimPayout.In;
+      const simoleanPayout1 = await moolaForSimPayout.Out;
 
       await E(moolaPurseP).deposit(moolaPayout1);
       await E(simoleanPurseP).deposit(simoleanPayout1);
 
       // Bob looks up the price of 3 simoleans. It's 5 moola
       const moolaAmounts = await E(publicAPI).getCurrentPrice(
-        harden({ TokenB: simoleans(3) }),
+        simoleans(3),
+        moola(0).brand,
       );
       log(`moolaAmounts `, moolaAmounts);
 
       // Bob makes another offer and swaps
       const bobSimsForMoolaProposal = harden({
-        want: { TokenA: moola(5) },
-        give: { TokenB: simoleans(3) },
+        want: { Out: moola(5) },
+        give: { In: simoleans(3) },
       });
       await E(simoleanPurseP).deposit(simoleanPayment);
       const bobSimoleanPayment = await E(simoleanPurseP).withdraw(simoleans(3));
-      const simsForMoolaPayments = harden({ TokenB: bobSimoleanPayment });
+      const simsForMoolaPayments = harden({ In: bobSimoleanPayment });
       const invite2 = E(publicAPI).makeSwapInvite();
 
       const {
@@ -498,8 +500,8 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
       log(await simsForMoolaOutcomeP);
 
       const simsForMoolaPayout = await bobSimsForMoolaPayoutP;
-      const moolaPayout2 = await simsForMoolaPayout.TokenA;
-      const simoleanPayout2 = await simsForMoolaPayout.TokenB;
+      const moolaPayout2 = await simsForMoolaPayout.Out;
+      const simoleanPayout2 = await simsForMoolaPayout.In;
 
       await E(moolaPurseP).deposit(moolaPayout2);
       await E(simoleanPurseP).deposit(simoleanPayout2);

--- a/packages/zoe/test/unitTests/contractSupport/test-bondingCurves.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-bondingCurves.js
@@ -2,18 +2,18 @@
 import { test } from 'tape-promise/tape';
 
 import {
-  getCurrentPrice,
+  getInputPrice,
   calcLiqExtentToMint,
 } from '../../../src/contractSupport';
 
 const testGetPrice = (t, input, expectedOutput) => {
-  const output = getCurrentPrice(input);
+  const output = getInputPrice(input);
   t.deepEquals(output, expectedOutput);
 };
 
-// If these tests of `getCurrentPrice` fail, it would indicate that we have
+// If these tests of `getInputPrice` fail, it would indicate that we have
 // diverged from the calculation in the Uniswap paper.
-test('getCurrentPrice ok 1', t => {
+test('getInputPrice ok 1', t => {
   t.plan(1);
   try {
     const input = {
@@ -21,18 +21,14 @@ test('getCurrentPrice ok 1', t => {
       outputReserve: 0,
       inputExtent: 1,
     };
-    const expectedOutput = {
-      outputExtent: 0,
-      newInputReserve: 1,
-      newOutputReserve: 0,
-    };
+    const expectedOutput = 0;
     testGetPrice(t, input, expectedOutput);
   } catch (e) {
     t.assert(false, e);
   }
 });
 
-test('getCurrentPrice ok 2', t => {
+test('getInputPrice ok 2', t => {
   t.plan(1);
   try {
     const input = {
@@ -40,18 +36,14 @@ test('getCurrentPrice ok 2', t => {
       outputReserve: 3028,
       inputExtent: 1398,
     };
-    const expectedOutput = {
-      outputExtent: 572,
-      newInputReserve: 7382,
-      newOutputReserve: 2456,
-    };
+    const expectedOutput = 572;
     testGetPrice(t, input, expectedOutput);
   } catch (e) {
     t.assert(false, e);
   }
 });
 
-test('getCurrentPrice ok 3', t => {
+test('getInputPrice ok 3', t => {
   t.plan(1);
   try {
     const input = {
@@ -59,18 +51,14 @@ test('getCurrentPrice ok 3', t => {
       outputReserve: 7743,
       inputExtent: 6635,
     };
-    const expectedOutput = {
-      outputExtent: 3466,
-      newInputReserve: 14795,
-      newOutputReserve: 4277,
-    };
+    const expectedOutput = 3466;
     testGetPrice(t, input, expectedOutput);
   } catch (e) {
     t.assert(false, e);
   }
 });
 
-test('getCurrentPrice reverse x and y amounts', t => {
+test('getInputPrice reverse x and y amounts', t => {
   t.plan(1);
   try {
     // Note: this is now the same test as the one above because we are
@@ -80,18 +68,14 @@ test('getCurrentPrice reverse x and y amounts', t => {
       outputReserve: 7743,
       inputExtent: 6635,
     };
-    const expectedOutput = {
-      outputExtent: 3466,
-      newInputReserve: 14795,
-      newOutputReserve: 4277,
-    };
+    const expectedOutput = 3466;
     testGetPrice(t, input, expectedOutput);
   } catch (e) {
     t.assert(false, e);
   }
 });
 
-test('getCurrentPrice ok 4', t => {
+test('getInputPrice ok 4', t => {
   t.plan(1);
   try {
     const input = {
@@ -99,18 +83,14 @@ test('getCurrentPrice ok 4', t => {
       outputReserve: 10,
       inputExtent: 1000,
     };
-    const expectedOutput = {
-      outputExtent: 9,
-      newInputReserve: 1010,
-      newOutputReserve: 1,
-    };
+    const expectedOutput = 9;
     testGetPrice(t, input, expectedOutput);
   } catch (e) {
     t.assert(false, e);
   }
 });
 
-test('getCurrentPrice ok 5', t => {
+test('getInputPrice ok 5', t => {
   t.plan(1);
   try {
     const input = {
@@ -118,18 +98,14 @@ test('getCurrentPrice ok 5', t => {
       outputReserve: 50,
       inputExtent: 17,
     };
-    const expectedOutput = {
-      outputExtent: 7,
-      newInputReserve: 117,
-      newOutputReserve: 43,
-    };
+    const expectedOutput = 7;
     testGetPrice(t, input, expectedOutput);
   } catch (e) {
     t.assert(false, e);
   }
 });
 
-test('getCurrentPrice ok 6', t => {
+test('getInputPrice ok 6', t => {
   t.plan(1);
   try {
     const input = {
@@ -137,11 +113,7 @@ test('getCurrentPrice ok 6', t => {
       inputReserve: 43,
       inputExtent: 7,
     };
-    const expectedOutput = {
-      outputExtent: 16,
-      newInputReserve: 50,
-      newOutputReserve: 101,
-    };
+    const expectedOutput = 16;
     testGetPrice(t, input, expectedOutput);
   } catch (e) {
     t.assert(false, e);

--- a/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
@@ -810,7 +810,7 @@ test('ZoeHelpers trade sameHandle', t => {
             losses: { Money: simoleans(4) },
           },
         ),
-      /the same offer cannot trade with itself/,
+      /an offer cannot trade with itself/,
       `safe offer trading with itself fails with nice error message`,
     );
     t.deepEquals(

--- a/packages/zoe/test/unitTests/contracts/test-autoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-autoswap.js
@@ -70,7 +70,7 @@ test('autoSwap with valid offers', async t => {
       outcome: liquidityOkP,
     } = await zoe.offer(aliceInvite, aliceProposal, alicePayments);
 
-    t.equals(await liquidityOkP, 'Added liquidity.');
+    t.equals(await liquidityOkP, 'Added liquidity.', `added liquidity message`);
 
     const liquidityPayments = await aliceAddLiquidityPayoutP;
     const liquidityPayout = await liquidityPayments.Liquidity;
@@ -78,12 +78,17 @@ test('autoSwap with valid offers', async t => {
     t.deepEquals(
       await liquidityIssuer.getAmountOf(liquidityPayout),
       liquidity(10),
+      `liquidity payout`,
     );
-    t.deepEquals(publicAPI.getPoolAllocation(), {
-      TokenA: moola(10),
-      TokenB: simoleans(5),
-      Liquidity: liquidity(0),
-    });
+    t.deepEquals(
+      publicAPI.getPoolAllocation(),
+      {
+        TokenA: moola(10),
+        TokenB: simoleans(5),
+        Liquidity: liquidity(0),
+      },
+      `pool allocation`,
+    );
 
     // Alice creates an invite for autoswap and sends it to Bob
     const bobInvite = publicAPI.makeSwapInvite();
@@ -95,21 +100,22 @@ test('autoSwap with valid offers', async t => {
       publicAPI: bobAutoswap,
       installationHandle: bobInstallationId,
     } = zoe.getInstanceRecord(bobInstanceHandle);
-    t.equals(bobInstallationId, installationHandle);
+    t.equals(bobInstallationId, installationHandle, `installationHandle`);
 
     // Bob looks up the price of 3 moola in simoleans
     const simoleanAmounts = bobAutoswap.getCurrentPrice(
-      harden({ TokenA: moola(3) }),
+      moola(3),
+      simoleans(0).brand,
     );
-    t.deepEquals(simoleanAmounts, simoleans(1));
+    t.deepEquals(simoleanAmounts, simoleans(1), `currentPrice`);
 
     // Bob escrows
 
     const bobMoolaForSimProposal = harden({
-      want: { TokenB: simoleans(1) },
-      give: { TokenA: moola(3) },
+      want: { Out: simoleans(1) },
+      give: { In: moola(3) },
     });
-    const bobMoolaForSimPayments = harden({ TokenA: bobMoolaPayment });
+    const bobMoolaForSimPayments = harden({ In: bobMoolaPayment });
 
     const { payout: bobPayoutP, outcome: offerOkP } = await zoe.offer(
       bobExclInvite,
@@ -118,37 +124,47 @@ test('autoSwap with valid offers', async t => {
     );
 
     // Bob swaps
-    t.equal(await offerOkP, 'Swap successfully completed.');
+    t.equal(await offerOkP, 'Swap successfully completed.', `swap message 1`);
 
     const bobPayout = await bobPayoutP;
 
-    const bobMoolaPayout1 = await bobPayout.TokenA;
-    const bobSimoleanPayout1 = await bobPayout.TokenB;
+    const bobMoolaPayout1 = await bobPayout.In;
+    const bobSimoleanPayout1 = await bobPayout.Out;
 
-    t.deepEqual(await moolaIssuer.getAmountOf(bobMoolaPayout1), moola(0));
+    t.deepEqual(
+      await moolaIssuer.getAmountOf(bobMoolaPayout1),
+      moola(0),
+      `bob moola`,
+    );
     t.deepEqual(
       await simoleanIssuer.getAmountOf(bobSimoleanPayout1),
       simoleans(1),
+      `bob simoleans`,
     );
-    t.deepEquals(bobAutoswap.getPoolAllocation(), {
-      TokenA: moola(13),
-      TokenB: simoleans(4),
-      Liquidity: liquidity(0),
-    });
+    t.deepEquals(
+      bobAutoswap.getPoolAllocation(),
+      {
+        TokenA: moola(13),
+        TokenB: simoleans(4),
+        Liquidity: liquidity(0),
+      },
+      `pool allocation`,
+    );
 
     // Bob looks up the price of 3 simoleans
     const moolaAmounts = bobAutoswap.getCurrentPrice(
-      harden({ TokenB: simoleans(3) }),
+      simoleans(3),
+      moola(0).brand,
     );
-    t.deepEquals(moolaAmounts, moola(5));
+    t.deepEquals(moolaAmounts, moola(5), `price 2`);
 
     // Bob makes another offer and swaps
     const bobSecondInvite = bobAutoswap.makeSwapInvite();
     const bobSimsForMoolaProposal = harden({
-      want: { TokenA: moola(5) },
-      give: { TokenB: simoleans(3) },
+      want: { Out: moola(5) },
+      give: { In: simoleans(3) },
     });
-    const simsForMoolaPayments = harden({ TokenB: bobSimoleanPayment });
+    const simsForMoolaPayments = harden({ In: bobSimoleanPayment });
 
     const {
       payout: bobSimsForMoolaPayoutP,
@@ -159,11 +175,15 @@ test('autoSwap with valid offers', async t => {
       simsForMoolaPayments,
     );
 
-    t.equal(await simsForMoolaOkP, 'Swap successfully completed.');
+    t.equal(
+      await simsForMoolaOkP,
+      'Swap successfully completed.',
+      `swap message 2`,
+    );
 
     const bobSimsForMoolaPayout = await bobSimsForMoolaPayoutP;
-    const bobMoolaPayout2 = await bobSimsForMoolaPayout.TokenA;
-    const bobSimoleanPayout2 = await bobSimsForMoolaPayout.TokenB;
+    const bobMoolaPayout2 = await bobSimsForMoolaPayout.Out;
+    const bobSimoleanPayout2 = await bobSimsForMoolaPayout.In;
 
     t.deepEqual(await moolaIssuer.getAmountOf(bobMoolaPayout2), moola(5));
     t.deepEqual(
@@ -306,16 +326,17 @@ test('autoSwap - test fee', async t => {
 
     // Bob looks up the price of 1000 moola in simoleans
     const simoleanAmounts = bobAutoswap.getCurrentPrice(
-      harden({ TokenA: moola(1000) }),
+      moola(1000),
+      simoleans(0).brand,
     );
-    t.deepEquals(simoleanAmounts, simoleans(906));
+    t.deepEquals(simoleanAmounts, simoleans(906), `simoleans out`);
 
     // Bob escrows
     const bobMoolaForSimProposal = harden({
-      give: { TokenA: moola(1000) },
-      want: { TokenB: simoleans(0) },
+      give: { In: moola(1000) },
+      want: { Out: simoleans(0) },
     });
-    const bobMoolaForSimPayments = harden({ TokenA: bobMoolaPayment });
+    const bobMoolaForSimPayments = harden({ In: bobMoolaPayment });
 
     // Bob swaps
     const { payout: bobPayoutP, outcome: offerOkP } = await zoe.offer(
@@ -327,8 +348,8 @@ test('autoSwap - test fee', async t => {
     t.equal(await offerOkP, 'Swap successfully completed.');
 
     const bobPayout = await bobPayoutP;
-    const bobMoolaPayout = await bobPayout.TokenA;
-    const bobSimoleanPayout = await bobPayout.TokenB;
+    const bobMoolaPayout = await bobPayout.In;
+    const bobSimoleanPayout = await bobPayout.Out;
 
     t.deepEqual(await moolaIssuer.getAmountOf(bobMoolaPayout), moola(0));
     t.deepEqual(

--- a/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
@@ -15,7 +15,7 @@ import { setup } from '../setupBasicMints';
 const multipoolAutoswapRoot = `${__dirname}/../../../src/contracts/multipoolAutoswap`;
 
 test('multipoolAutoSwap with valid offers', async t => {
-  t.plan(36);
+  t.plan(35);
   try {
     const { moolaR, simoleanR, moola, simoleans } = setup();
     const zoe = makeZoe();
@@ -71,7 +71,7 @@ test('multipoolAutoSwap with valid offers', async t => {
       `invite extent is as expected`,
     );
 
-    const { publicAPI, handle: instanceHandle } = zoe.getInstance(
+    const { publicAPI, handle: instanceHandle } = zoe.getInstanceRecord(
       aliceInviteAmount.extent[0].instanceHandle,
     );
 
@@ -109,7 +109,7 @@ test('multipoolAutoSwap with valid offers', async t => {
     );
     const simoleanLiquidity = simoleanLiquidityAmountMath.make;
 
-    const { issuerKeywordRecord } = zoe.getInstance(instanceHandle);
+    const { issuerKeywordRecord } = zoe.getInstanceRecord(instanceHandle);
     t.deepEquals(
       issuerKeywordRecord,
       harden({
@@ -144,11 +144,11 @@ test('multipoolAutoSwap with valid offers', async t => {
     // 10 moola = 5 central tokens at the time of the liquidity adding
     // aka 2 moola = 1 central token
     const aliceProposal = harden({
-      want: { Out: moolaLiquidity(50) },
-      give: { In: moola(100), CentralToken: centralTokens(50) },
+      want: { Liquidity: moolaLiquidity(50) },
+      give: { SecondaryToken: moola(100), CentralToken: centralTokens(50) },
     });
     const alicePayments = {
-      In: aliceMoolaPayment,
+      SecondaryToken: aliceMoolaPayment,
       CentralToken: aliceCentralTokenPayment,
     };
 
@@ -164,7 +164,7 @@ test('multipoolAutoSwap with valid offers', async t => {
     );
 
     const liquidityPayments = await aliceAddLiquidityPayoutP;
-    const liquidityPayout = await liquidityPayments.Out;
+    const liquidityPayout = await liquidityPayments.Liquidity;
 
     t.deepEquals(
       await moolaLiquidityIssuer.getAmountOf(liquidityPayout),
@@ -194,21 +194,6 @@ test('multipoolAutoSwap with valid offers', async t => {
       bobInstallationId,
       installationHandle,
       `installationHandle is as expected`,
-    );
-
-    // Bob can learn the keywords for brands by calling the following
-    // two methods on the publicAPI: getBrandKeywordRecord and getKeywordForBrand
-
-    t.deepEquals(
-      await E(bobPublicAPI).getBrandKeywordRecord(),
-      harden({
-        Moola: moolaR.brand,
-        Simoleans: simoleanR.brand,
-        CentralToken: centralR.brand,
-        MoolaLiquidity: await E(moolaLiquidityIssuer).getBrand(),
-        SimoleansLiquidity: await E(simoleanLiquidityIssuer).getBrand(),
-      }),
-      `keywords have expected brands`,
     );
 
     // Bob looks up the price of 17 moola in central tokens
@@ -331,14 +316,14 @@ test('multipoolAutoSwap with valid offers', async t => {
     //
     const aliceSimCentralLiquidityInvite = publicAPI.makeAddLiquidityInvite();
     const aliceSimCentralProposal = harden({
-      want: { Out: simoleanLiquidity(43) },
-      give: { In: simoleans(398), CentralToken: centralTokens(43) },
+      want: { Liquidity: simoleanLiquidity(43) },
+      give: { SecondaryToken: simoleans(398), CentralToken: centralTokens(43) },
     });
     const aliceCentralTokenPayment2 = await centralR.mint.mintPayment(
       centralTokens(43),
     );
     const aliceSimCentralPayments = {
-      In: aliceSimoleanPayment,
+      SecondaryToken: aliceSimoleanPayment,
       CentralToken: aliceCentralTokenPayment2,
     };
 
@@ -358,7 +343,7 @@ test('multipoolAutoSwap with valid offers', async t => {
     );
 
     const simCentralPayments = await aliceSimCentralPayoutP;
-    const simoleanLiquidityPayout = await simCentralPayments.Out;
+    const simoleanLiquidityPayout = await simCentralPayments.Liquidity;
 
     t.deepEquals(
       await simoleanLiquidityIssuer.getAmountOf(simoleanLiquidityPayout),
@@ -470,8 +455,8 @@ test('multipoolAutoSwap with valid offers', async t => {
     // She's not picky...
     const aliceRemoveLiquidityInvite = publicAPI.makeRemoveLiquidityInvite();
     const aliceRemoveLiquidityProposal = harden({
-      give: { In: moolaLiquidity(50) },
-      want: { Out: moola(91), CentralToken: centralTokens(56) },
+      give: { Liquidity: moolaLiquidity(50) },
+      want: { SecondaryToken: moola(91), CentralToken: centralTokens(56) },
     });
 
     const {
@@ -480,15 +465,15 @@ test('multipoolAutoSwap with valid offers', async t => {
     } = await zoe.offer(
       aliceRemoveLiquidityInvite,
       aliceRemoveLiquidityProposal,
-      harden({ In: liquidityPayout }),
+      harden({ Liquidity: liquidityPayout }),
     );
 
     t.equals(await removeLiquidityResultP, 'Liquidity successfully removed.');
 
     const aliceRemoveLiquidityPayout = await aliceRemoveLiquidityPayoutP;
-    const aliceMoolaPayout = await aliceRemoveLiquidityPayout.Out;
+    const aliceMoolaPayout = await aliceRemoveLiquidityPayout.SecondaryToken;
     const aliceCentralTokenPayout = await aliceRemoveLiquidityPayout.CentralToken;
-    const aliceMoolaLiquidityPayout = await aliceRemoveLiquidityPayout.In;
+    const aliceMoolaLiquidityPayout = await aliceRemoveLiquidityPayout.Liquidity;
 
     t.deepEquals(
       await moolaR.issuer.getAmountOf(aliceMoolaPayout),

--- a/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
+++ b/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
@@ -164,9 +164,9 @@ test('simpleExchange with valid offers', async t => {
   // Alice had 3 moola and 0 simoleans.
   // Bob had 0 moola and 7 simoleans.
   t.equals(aliceMoolaPurse.getCurrentAmount().extent, 0);
-  t.equals(aliceSimoleanPurse.getCurrentAmount().extent, 7);
+  t.equals(aliceSimoleanPurse.getCurrentAmount().extent, 4);
   t.equals(bobMoolaPurse.getCurrentAmount().extent, 3);
-  t.equals(bobSimoleanPurse.getCurrentAmount().extent, 0);
+  t.equals(bobSimoleanPurse.getCurrentAmount().extent, 3);
 });
 
 test('simpleExchange with multiple sell offers', async t => {
@@ -362,7 +362,7 @@ test('simpleExchange with non-fungible assets', async t => {
   // sell a Spell of Binding and wants to receive CryptoCats in return.
   const aliceSellOrderProposal = harden({
     give: { Asset: rpgItems(spell) },
-    want: { Price: cryptoCats(harden([])) },
+    want: { Price: cryptoCats(harden(['Cheshire Cat'])) },
     exit: { onDemand: null },
   });
   const alicePayments = { Asset: aliceRpgPayment };

--- a/packages/zoe/test/unitTests/test-offerSafety.js
+++ b/packages/zoe/test/unitTests/test-offerSafety.js
@@ -2,7 +2,7 @@
 import { test } from 'tape-promise/tape';
 import harden from '@agoric/harden';
 
-import { isOfferSafeForOffer } from '../../src/offerSafety';
+import { isOfferSafe } from '../../src/offerSafety';
 import { setup } from './setupBasicMints';
 
 function makeGetAmountMath(mapping) {
@@ -28,7 +28,7 @@ function makeGetAmountMath(mapping) {
 // equal to want, equal to give -> true
 
 // more than want, more than give -> isOfferSafe() = true
-test('isOfferSafeForOffer - more than want, more than give', t => {
+test('isOfferSafe - more than want, more than give', t => {
   t.plan(1);
   try {
     const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
@@ -43,14 +43,14 @@ test('isOfferSafeForOffer - more than want, more than give', t => {
     });
     const amounts = harden({ A: moola(10), B: simoleans(7), C: bucks(8) });
 
-    t.ok(isOfferSafeForOffer(getAmountMath, proposal, amounts));
+    t.ok(isOfferSafe(getAmountMath, proposal, amounts));
   } catch (e) {
     t.assert(false, e);
   }
 });
 
 // more than want, less than give -> true
-test('isOfferSafeForOffer - more than want, less than give', t => {
+test('isOfferSafe - more than want, less than give', t => {
   t.plan(1);
   try {
     const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
@@ -65,14 +65,14 @@ test('isOfferSafeForOffer - more than want, less than give', t => {
     });
     const amounts = harden({ A: moola(1), B: simoleans(7), C: bucks(8) });
 
-    t.ok(isOfferSafeForOffer(getAmountMath, proposal, amounts));
+    t.ok(isOfferSafe(getAmountMath, proposal, amounts));
   } catch (e) {
     t.assert(false, e);
   }
 });
 
 // more than want, equal to give -> true
-test('isOfferSafeForOffer - more than want, equal to give', t => {
+test('isOfferSafe - more than want, equal to give', t => {
   t.plan(1);
   try {
     const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
@@ -87,14 +87,14 @@ test('isOfferSafeForOffer - more than want, equal to give', t => {
     });
     const amounts = harden({ A: moola(9), B: simoleans(6), C: bucks(7) });
 
-    t.ok(isOfferSafeForOffer(getAmountMath, proposal, amounts));
+    t.ok(isOfferSafe(getAmountMath, proposal, amounts));
   } catch (e) {
     t.assert(false, e);
   }
 });
 
 // less than want, more than give -> true
-test('isOfferSafeForOffer - less than want, more than give', t => {
+test('isOfferSafe - less than want, more than give', t => {
   t.plan(1);
   try {
     const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
@@ -109,14 +109,14 @@ test('isOfferSafeForOffer - less than want, more than give', t => {
     });
     const amounts = harden({ A: moola(7), B: simoleans(9), C: bucks(19) });
 
-    t.ok(isOfferSafeForOffer(getAmountMath, proposal, amounts));
+    t.ok(isOfferSafe(getAmountMath, proposal, amounts));
   } catch (e) {
     t.assert(false, e);
   }
 });
 
 // less than want, less than give -> false
-test('isOfferSafeForOffer - less than want, less than give', t => {
+test('isOfferSafe - less than want, less than give', t => {
   t.plan(1);
   try {
     const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
@@ -131,14 +131,14 @@ test('isOfferSafeForOffer - less than want, less than give', t => {
     });
     const amounts = harden({ A: moola(7), B: simoleans(5), C: bucks(6) });
 
-    t.notOk(isOfferSafeForOffer(getAmountMath, proposal, amounts));
+    t.notOk(isOfferSafe(getAmountMath, proposal, amounts));
   } catch (e) {
     t.assert(false, e);
   }
 });
 
 // less than want, equal to give -> true
-test('isOfferSafeForOffer - less than want, equal to give', t => {
+test('isOfferSafe - less than want, equal to give', t => {
   t.plan(1);
   try {
     const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
@@ -153,14 +153,14 @@ test('isOfferSafeForOffer - less than want, equal to give', t => {
     });
     const amounts = harden({ A: moola(1), B: simoleans(5), C: bucks(7) });
 
-    t.ok(isOfferSafeForOffer(getAmountMath, proposal, amounts));
+    t.ok(isOfferSafe(getAmountMath, proposal, amounts));
   } catch (e) {
     t.assert(false, e);
   }
 });
 
 // equal to want, more than give -> true
-test('isOfferSafeForOffer - equal to want, more than give', t => {
+test('isOfferSafe - equal to want, more than give', t => {
   t.plan(1);
   try {
     const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
@@ -175,14 +175,14 @@ test('isOfferSafeForOffer - equal to want, more than give', t => {
     });
     const amounts = harden({ A: moola(2), B: simoleans(6), C: bucks(8) });
 
-    t.ok(isOfferSafeForOffer(getAmountMath, proposal, amounts));
+    t.ok(isOfferSafe(getAmountMath, proposal, amounts));
   } catch (e) {
     t.assert(false, e);
   }
 });
 
 // equal to want, less than give -> true
-test('isOfferSafeForOffer - equal to want, less than give', t => {
+test('isOfferSafe - equal to want, less than give', t => {
   t.plan(1);
   try {
     const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
@@ -197,14 +197,14 @@ test('isOfferSafeForOffer - equal to want, less than give', t => {
     });
     const amounts = harden({ A: moola(0), B: simoleans(6), C: bucks(0) });
 
-    t.ok(isOfferSafeForOffer(getAmountMath, proposal, amounts));
+    t.ok(isOfferSafe(getAmountMath, proposal, amounts));
   } catch (e) {
     t.assert(false, e);
   }
 });
 
 // equal to want, equal to give -> true
-test('isOfferSafeForOffer - equal to want, equal to give', t => {
+test('isOfferSafe - equal to want, equal to give', t => {
   t.plan(1);
   try {
     const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
@@ -219,13 +219,13 @@ test('isOfferSafeForOffer - equal to want, equal to give', t => {
     });
     const amounts = harden({ A: moola(1), B: simoleans(6), C: bucks(7) });
 
-    t.ok(isOfferSafeForOffer(getAmountMath, proposal, amounts));
+    t.ok(isOfferSafe(getAmountMath, proposal, amounts));
   } catch (e) {
     t.assert(false, e);
   }
 });
 
-test('isOfferSafeForOffer - empty proposal', t => {
+test('isOfferSafe - empty proposal', t => {
   t.plan(1);
   try {
     const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
@@ -237,7 +237,7 @@ test('isOfferSafeForOffer - empty proposal', t => {
     const proposal = harden({ give: {}, want: {} });
     const amounts = harden({ A: moola(1), B: simoleans(6), C: bucks(7) });
 
-    t.ok(isOfferSafeForOffer(getAmountMath, proposal, amounts));
+    t.ok(isOfferSafe(getAmountMath, proposal, amounts));
   } catch (e) {
     t.assert(false, e);
   }


### PR DESCRIPTION
Adds a zoeHelper called `trade` which performs a trade given the gains of both sides.

Closes #1144 

Still to do:

- [x] Rename add/subtract in Zoe helpers and don't mutate an amountKeywordRecord
- [x] Write tests for new Zoe helpers
- [x] Address Chris' PR comments