### PR TITLE
chore: prefer assert.typedef over assert.equal when appropriate

### DIFF
--- a/packages/SwingSet/src/capdata.js
+++ b/packages/SwingSet/src/capdata.js
@@ -13,13 +13,13 @@ import { assert, details } from '@agoric/assert';
  * @return nothing
  */
 export function insistCapData(capdata) {
-  assert.equal(
+  assert.typeof(
     capdata.body,
-    `${capdata.body}`,
+    'string',
     details`capdata has non-string .body ${capdata.body}`,
   );
   assert(
-    capdata.slots instanceof Array,
+    Array.isArray(capdata.slots),
     details`capdata has non-Array slots ${capdata.slots}`,
   );
   // TODO check that the .slots array elements are actually strings

--- a/packages/SwingSet/src/kernel/deviceManager.js
+++ b/packages/SwingSet/src/kernel/deviceManager.js
@@ -38,11 +38,7 @@ export default function makeDeviceManager(
    *    or is otherwise invalid.
    */
   function mapDeviceSlotToKernelSlot(devSlot) {
-    assert.equal(
-      devSlot,
-      `${devSlot}`,
-      details`non-string devSlot: ${devSlot}`,
-    );
+    assert.typeof(devSlot, 'string', details`non-string devSlot: ${devSlot}`);
     // kdebug(`mapOutbound ${devSlot}`);
     return deviceKeeper.mapDeviceSlotToKernelSlot(devSlot);
   }

--- a/packages/SwingSet/src/message.js
+++ b/packages/SwingSet/src/message.js
@@ -15,16 +15,16 @@ import { insistCapData } from './capdata';
  * @return nothing
  */
 export function insistMessage(message) {
-  assert.equal(
+  assert.typeof(
     message.method,
-    `${message.method}`,
+    'string',
     details`message has non-string .method ${message.method}`,
   );
   insistCapData(message.args);
   if (message.result) {
-    assert.equal(
+    assert.typeof(
       message.result,
-      `${message.result}`,
+      'string',
       details`message has non-string non-null .result ${message.result}`,
     );
   }

--- a/packages/SwingSet/test/test-vpid-liveslots.js
+++ b/packages/SwingSet/test/test-vpid-liveslots.js
@@ -541,7 +541,7 @@ async function doVatResolveCase23(t, which, mode, stalls) {
   } else if (mode === 'data') {
     t.equal(resolutionOfP1, 4);
   } else if (mode === 'promise-data') {
-    t.equal(resolutionOfP1 instanceof Array, true);
+    t.equal(Array.isArray(resolutionOfP1), true);
     t.equal(resolutionOfP1.length, 1);
     t.is(resolutionOfP1[0], Promise.resolve(resolutionOfP1[0]));
     t.is(resolutionOfP1[0], stashP1);

--- a/packages/cosmic-swingset/lib/ag-solo/start.js
+++ b/packages/cosmic-swingset/lib/ag-solo/start.js
@@ -134,7 +134,7 @@ async function buildSwingset(
   // other inbound messages.
   const queuedDeliverInboundToMbx = withInputQueue(
     async function deliverInboundToMbx(sender, messages, ack) {
-      if (!(messages instanceof Array)) {
+      if (!Array.isArray(messages)) {
         throw new Error(`inbound given non-Array: ${messages}`);
       }
       // console.debug(`deliverInboundToMbx`, messages, ack);

--- a/packages/cosmic-swingset/lib/launch-chain.js
+++ b/packages/cosmic-swingset/lib/launch-chain.js
@@ -123,7 +123,7 @@ export async function launch(
   }
 
   async function deliverInbound(sender, messages, ack) {
-    if (!(messages instanceof Array)) {
+    if (!Array.isArray(messages)) {
       throw new Error(`inbound given non-Array: ${messages}`);
     }
     if (!mb.deliverInbound(sender, messages, ack)) {

--- a/packages/marshal/marshal.js
+++ b/packages/marshal/marshal.js
@@ -666,7 +666,7 @@ export function makeMarshal(
         `unserialize() given non-capdata (.body is ${data.body}, not string)`,
       );
     }
-    if (!(data.slots instanceof Array)) {
+    if (!Array.isArray(data.slots)) {
       throw new Error(`unserialize() given non-capdata (.slots are not Array)`);
     }
     const rawTree = harden(JSON.parse(data.body));

--- a/packages/registrar/src/registrar.js
+++ b/packages/registrar/src/registrar.js
@@ -45,7 +45,7 @@ function makeRegistrar(systemVersion, seed = 0) {
       return key;
     },
     get(key, version = null) {
-      assert.equal(typeof key, 'string', details`Key must be string ${key}`);
+      assert.typeof(key, 'string', details`Key must be string ${key}`);
       assert(keyFormat.test(key), details`Key must end with _<digits> ${key}`);
       if (version) {
         assert.equal(


### PR DESCRIPTION
Two minor low-priority improvements.

Some calls to `assert.equal` were really only checking the typeof something, and should have used `assert.typeof`. Note that `assert.typeof`'s default error message may be adequate, but I didn't remove any of the provided error messages.

Replaced all array tests of the form `foo instanceof Array` with `Array.isArray(foo)`.
   * `instanceof` does not recognize arrays from other realms.
   * `instanceof` does recognize non-arrays that inherit from `Array.prototype`.
   * `Array.isArray` is correct, with none of these problems.