### PR TITLE
[Zoe] Add installationHandle to invite extent

### DIFF
--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -544,6 +544,7 @@ const makeZoe = (additionalEndowments = {}) => {
         );
         const { customProperties = harden({}) } = options;
         const inviteHandle = harden({});
+        const { installationHandle } = instanceTable.get(instanceHandle);
         const inviteAmount = inviteAmountMath.make(
           harden([
             {
@@ -551,6 +552,7 @@ const makeZoe = (additionalEndowments = {}) => {
               inviteDesc,
               handle: inviteHandle,
               instanceHandle,
+              installationHandle,
             },
           ]),
         );

--- a/packages/zoe/test/swingsetTests/zoe/vat-bob.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-bob.js
@@ -87,12 +87,8 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
       const { extent: optionExtent } = await E(inviteIssuer).getAmountOf(
         exclInvite,
       );
-
-      const instanceHandle = await getInstanceHandle(exclInvite);
-      const instanceInfo = await E(zoe).getInstanceRecord(instanceHandle);
-
       assert(
-        instanceInfo.installationHandle === installations.coveredCall,
+        optionExtent[0].installationHandle === installations.coveredCall,
         details`wrong installation`,
       );
       assert(
@@ -111,7 +107,9 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
       );
       assert(optionExtent[0].timerAuthority === timer, 'wrong timer');
 
-      const { UnderlyingAsset, StrikePrice } = instanceInfo.issuerKeywordRecord;
+      const {
+        issuerKeywordRecord: { UnderlyingAsset, StrikePrice },
+      } = await E(zoe).getInstanceRecord(optionExtent[0].instanceHandle);
 
       assert(
         UnderlyingAsset === moolaIssuer,
@@ -152,11 +150,8 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
       const optionAmounts = await E(inviteIssuer).getAmountOf(exclInvite);
       const optionExtent = optionAmounts.extent;
 
-      const instanceInfo = await E(zoe).getInstanceRecord(
-        optionExtent[0].instanceHandle,
-      );
       assert(
-        instanceInfo.installationHandle === installations.coveredCall,
+        optionExtent[0].installationHandle === installations.coveredCall,
         details`wrong installation`,
       );
       assert(
@@ -176,7 +171,9 @@ const build = async (E, log, zoe, issuers, payments, installations, timer) => {
         details`wrong expiration date`,
       );
       assert(optionExtent[0].timerAuthority === timer, details`wrong timer`);
-      const { UnderlyingAsset, StrikePrice } = instanceInfo.issuerKeywordRecord;
+      const {
+        issuerKeywordRecord: { UnderlyingAsset, StrikePrice },
+      } = await E(zoe).getInstanceRecord(optionExtent[0].instanceHandle);
       assert(
         UnderlyingAsset === moolaIssuer,
         details`The underlyingAsset issuer should be the moola issuer`,

--- a/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
@@ -64,6 +64,7 @@ test('multipoolAutoSwap with valid offers', async t => {
           {
             inviteDesc: 'multipool autoswap add liquidity',
             instanceHandle: aliceInviteAmount.extent[0].instanceHandle,
+            installationHandle,
             handle: aliceInviteAmount.extent[0].handle,
           },
         ]),


### PR DESCRIPTION
Closes #1065 

Add `installationHandle` to invite extent for ease of use. 

## How to test
`yarn test`

