### PR TITLE
[Zoe] Remove keywords from `areRightsConserved`

### DIFF
--- a/packages/store/src/store.js
+++ b/packages/store/src/store.js
@@ -8,15 +8,16 @@ const harden = /** @type {<T>(x: T) => T} */ (rawHarden);
 
 /**
  * @template K,V
- * @typedef {Object} Store A wrapper around a Map
- * @property {(key: K) => boolean} has Check if a key exists
- * @property {(key: K, value: V) => void} init Initialize the key only if it doesn't already exist
- * @property {(key: K) => V?} get Return a value fo the key, or undefined
- * @property {(key: K, value: V) => void} set Unconditionally set the key
- * @property {(key: K) => void} delete Remove the key
- * @property {() => K[]} keys Return an array of keys
- * @property {() => V[]} values Return an array of values
- * @property {() => [K, V][]} entries Return an array of entries
+ * @typedef {Object} Store - A wrapper around a Map
+ * @property {(key: K) => boolean} has - Check if a key exists
+ * @property {(key: K, value: V) => void} init - Initialize the key only if it doesn't already exist
+ * @property {(key: K) => V} get - Return a value for the key. Throws
+ * if not found.
+ * @property {(key: K, value: V) => void} set - Unconditionally set the key
+ * @property {(key: K) => void} delete - Remove the key
+ * @property {() => K[]} keys - Return an array of keys
+ * @property {() => V[]} values - Return an array of values
+ * @property {() => [K, V][]} entries - Return an array of entries
  */
 
 /**

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -42,6 +42,7 @@
     "@agoric/notifier": "^0.1.2",
     "@agoric/produce-promise": "^0.1.2",
     "@agoric/same-structure": "^0.0.7",
+    "@agoric/store": "^0.1.2",
     "@agoric/transform-metering": "^1.2.5",
     "@agoric/weak-store": "^0.0.7"
   },

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -265,7 +265,6 @@ export const makeZoeHelpers = (zcf) => {
           zcf.reallocate(
             harden([tempHandle, recipientHandle]),
             harden([tempAlloc, recipientAlloc]),
-            harden([keyword]),
           );
 
           // Complete the temporary offerHandle

--- a/packages/zoe/src/contracts/autoswap.js
+++ b/packages/zoe/src/contracts/autoswap.js
@@ -177,7 +177,6 @@ export const makeContract = harden(
             zcf.reallocate(
               harden([offerHandle, poolHandle]),
               harden([newUserAmounts, newPoolAmounts]),
-              harden(['TokenA', 'TokenB', 'Liquidity']),
             );
             zcf.complete(harden([offerHandle]));
             return 'Added liquidity.';

--- a/packages/zoe/src/contracts/multipoolAutoswap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap.js
@@ -312,7 +312,6 @@ export const makeContract = harden(
         zcf.reallocate(
           harden([offerHandle, poolHandle]),
           harden([newUserAmounts, newPoolAmounts]),
-          liquidityKeys,
         );
         zcf.complete(harden([offerHandle]));
         return 'Added liquidity.';
@@ -396,7 +395,6 @@ export const makeContract = harden(
       zcf.reallocate(
         harden([offerHandle, poolHandle]),
         harden([newUserAmounts, newPoolAmounts]),
-        liquidityKeys,
       );
       zcf.complete(harden([offerHandle]));
       return 'Liquidity successfully removed.';
@@ -449,7 +447,6 @@ export const makeContract = harden(
         zcf.reallocate(
           harden([offerHandle, poolHandle]),
           harden([newUserAmounts, newPoolAmounts]),
-          keywords,
         );
         zcf.complete(harden([offerHandle]));
         return `Swap successfully completed.`;
@@ -470,7 +467,6 @@ export const makeContract = harden(
         zcf.reallocate(
           harden([offerHandle, poolHandle]),
           harden([newUserAmounts, newPoolAmounts]),
-          keywords,
         );
         zcf.complete(harden([offerHandle]));
         return `Swap successfully completed.`;
@@ -523,7 +519,6 @@ export const makeContract = harden(
         zcf.reallocate(
           harden([poolHandleA, poolHandleB, offerHandle]),
           harden([finalPoolAmountsA, finalPoolAmountsB, finalUserAmounts]),
-          keywords,
         );
         zcf.complete(harden([offerHandle]));
         return `Swap successfully completed.`;

--- a/packages/zoe/src/rightsConservation.js
+++ b/packages/zoe/src/rightsConservation.js
@@ -1,63 +1,78 @@
-/**
- * Transpose an array of arrays
- * @param {matrix} matrix
- */
-// https://stackoverflow.com/questions/17428587/transposing-a-2d-array-in-javascript/41772644#41772644
-const transpose = matrix =>
-  matrix.reduce(
-    (acc, row) => row.map((_, i) => [...(acc[i] || []), row[i]]),
-    [],
-  );
+import makeStore from '@agoric/store';
+import { assert, details } from '@agoric/assert';
 
 /**
- * The columns in an `amount` matrix are per issuer, and the rows
- * are per offer. We want to transpose the matrix such that each
- * row is per issuer so we can do 'with' on the array to get a total
- * per issuer and make sure the rights are conserved.
- * @param  {amountMath[]} amountMathArray - an array of amountMath per issuer
- * @param  {amount[][]} amountMatrix - an array of arrays with a row per
- * offer indexed by issuer
+ * @typedef {import('@agoric/ertp').Amount} Amount
+ * @typedef {import('@agoric/ertp').Brand} Brand
+ * @typedef {import('@agoric/ertp').AmountMath} AmountMath
+ * @typedef {import('@agoric/store').Store<Brand, Amount>} Store
  */
-const sumByIssuer = (amountMathArray, amountMatrix) =>
-  transpose(amountMatrix).map((amountPerIssuer, i) =>
-    amountPerIssuer.reduce(
-      amountMathArray[i].add,
-      amountMathArray[i].getEmpty(),
-    ),
-  );
 
 /**
- * Does the left array of summed amount equal the right array of
- * summed amount?
- * @param  {amountMath[]} amountMathArray - an array of amountMath per issuer
- * @param  {amount[]} leftAmounts- an array of total amount per issuer
- * @param  {amount[]} rightAmounts - an array of total amount per issuer
+ * Iterate over the amounts and sum, storing the sums in a
+ * map by brand.
+ * @param  {(brand: Brand) => AmountMath} getAmountMath - a function
+ * to get amountMath given a brand.
+ * @param  {Amount[]} amounts - an array of amounts
+ * @returns {Store} sumsByBrand - a map of Brand keys and
+ * Amount values. The amounts are the sums.
+ */
+const sumByBrand = (getAmountMath, amounts) => {
+  const sumsByBrand = makeStore('brand');
+  amounts.forEach(amount => {
+    const { brand } = amount;
+    const amountMath = getAmountMath(brand);
+    if (!sumsByBrand.has(brand)) {
+      sumsByBrand.init(brand, amountMath.getEmpty());
+    }
+    const sumSoFar = sumsByBrand.get(brand);
+    sumsByBrand.set(brand, amountMath.add(sumSoFar, amount));
+  });
+  return sumsByBrand;
+};
+
+/**
+ * Do the left sums by brand equal the right sums by brand?
+ * @param  {(brand: Brand) => AmountMath} getAmountMath - a function
+ * to get amountMath given a brand.
+ * @param  {Store} leftSumsByBrand - a map of brands to sums
+ * @param  {Store} rightSumsByBrand - a map of brands to sums
  * indexed by issuer
  */
-const isEqualPerIssuer = (amountMathArray, leftAmounts, rightAmounts) =>
-  leftAmounts.every((leftAmount, i) =>
-    amountMathArray[i].isEqual(leftAmount, rightAmounts[i]),
+const isEqualPerBrand = (getAmountMath, leftSumsByBrand, rightSumsByBrand) => {
+  const leftKeys = leftSumsByBrand.keys();
+  const rightKeys = rightSumsByBrand.keys();
+  assert.equal(
+    leftKeys.length,
+    rightKeys.length,
+    details`${leftKeys.length} should be equal to ${rightKeys.length}`,
   );
+  return leftSumsByBrand
+    .keys()
+    .every(brand =>
+      getAmountMath(brand).isEqual(
+        leftSumsByBrand.get(brand),
+        rightSumsByBrand.get(brand),
+      ),
+    );
+};
 
 /**
- * `areRightsConserved` checks that the total amount per issuer stays
- * the same regardless of the reallocation.
- * @param  {amountMath[]} amountMathArray - an array of amountMath per issuer
- * @param  {amount[][]} previousAmountsMatrix - array of arrays where a row
- * is the array of amount for a particular offer, per
- * issuer
- * @param  {amount[][]} newAmountsMatrix - array of arrays where a row
- * is the array of reallocated amount for a particular offer, per
- * issuer
+ * `areRightsConserved` checks that the total amount per brand is
+ * equal to the total amount per brand in the proposed reallocation
+ * @param  {(brand: Brand) => AmountMath} getAmountMath - a function
+ * to get amountMath given a brand.
+ * @param  {Amount[]} previousAmounts - an array of the amounts before the
+ * proposed reallocation
+ * @param  {Amount[]} newAmounts - an array of the amounts in the
+ * proposed reallocation
+ *
+ * @returns {boolean} isEqualPerBrand
  */
-function areRightsConserved(
-  amountMathArray,
-  previousAmountsMatrix,
-  newAmountsMatrix,
-) {
-  const sumsPrevAmounts = sumByIssuer(amountMathArray, previousAmountsMatrix);
-  const sumsNewAmounts = sumByIssuer(amountMathArray, newAmountsMatrix);
-  return isEqualPerIssuer(amountMathArray, sumsPrevAmounts, sumsNewAmounts);
+function areRightsConserved(getAmountMath, previousAmounts, newAmounts) {
+  const sumsPrevAmounts = sumByBrand(getAmountMath, previousAmounts);
+  const sumsNewAmounts = sumByBrand(getAmountMath, newAmounts);
+  return isEqualPerBrand(getAmountMath, sumsPrevAmounts, sumsNewAmounts);
 }
 
-export { areRightsConserved, transpose };
+export { areRightsConserved };

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -455,14 +455,11 @@ const makeZoe = (additionalEndowments = {}) => {
 
         // Make the potential reallocation and test for offer safety
         // by comparing the potential reallocation to the proposal.
-        const makePotentialReallocation = (
-          offerHandle,
-          sparseKeywordsAllocation,
-        ) => {
+        const makePotentialReallocation = (offerHandle, newAllocation) => {
           const { proposal, currentAllocation } = offerTable.get(offerHandle);
           const potentialReallocation = harden({
             ...currentAllocation,
-            ...sparseKeywordsAllocation,
+            ...newAllocation,
           });
           const proposalKeywords = [
             ...getKeywords(proposal.want),

--- a/packages/zoe/test/unitTests/contracts/grifter.js
+++ b/packages/zoe/test/unitTests/contracts/grifter.js
@@ -26,7 +26,7 @@ export const makeContract = harden(
           const stepOne = [wantProposal, vicProposal];
           // safe because it doesn't change want, so winningsOK looks true
           const offerHandles = [firstOfferHandle, offerHandle];
-          zcf.reallocate(offerHandles, stepOne, ['Price']);
+          zcf.reallocate(offerHandles, stepOne);
           zcf.complete(harden(offerHandles));
         },
         'tantalizing offer',


### PR DESCRIPTION
Closes #1154 

Remove keywords from `areRightsConserved`, meaning that `spareKeywords` are no longer needed as a parameter to `reallocate`. 