### PR TITLE
Let smart-relay policies use the timer device

### DIFF
--- a/packages/smart-relay/Makefile
+++ b/packages/smart-relay/Makefile
@@ -36,7 +36,7 @@ help:
 	@echo 'poke-bridge-ack           send an ack'
 	@echo 'poke-bridge-unknown       send an unknown'
 	@echo 'install-halfdrop-handler  install a handler that drops half'
-	@echo 'install-delay-handler     install a handler that delays messages'
+	@echo 'install-delay-handler     install a handler that delays'
 
 install-halfdrop-handler:
 	curl --data-binary @./halfdrop-handler.js -H "content-type: text/plain" http://localhost:8008/install

--- a/packages/smart-relay/Makefile
+++ b/packages/smart-relay/Makefile
@@ -13,20 +13,20 @@ relay:
 	./bin/rly start zero -d
 
 poke-http:
-	curl http://localhost:8000/hello
+	curl http://localhost:8008/hello
 	@echo
 
 poke-bridge-handshake:
-	curl http://localhost:8000/sendIntoBridge/is-handshake
+	curl http://localhost:8008/sendIntoBridge/is-handshake
 	@echo
 poke-bridge-packet:
-	curl http://localhost:8000/sendIntoBridge/is-packet
+	curl http://localhost:8008/sendIntoBridge/is-packet
 	@echo
 poke-bridge-ack:
-	curl http://localhost:8000/sendIntoBridge/is-ack
+	curl http://localhost:8008/sendIntoBridge/is-ack
 	@echo
 poke-bridge-unknown:
-	curl http://localhost:8000/sendIntoBridge/unknown
+	curl http://localhost:8008/sendIntoBridge/unknown
 	@echo
 
 help:
@@ -36,7 +36,12 @@ help:
 	@echo 'poke-bridge-ack           send an ack'
 	@echo 'poke-bridge-unknown       send an unknown'
 	@echo 'install-halfdrop-handler  install a handler that drops half'
+	@echo 'install-delay-handler     install a handler that delays messages'
 
 install-halfdrop-handler:
-	curl --data-binary @./halfdrop-handler.js -H "content-type: text/plain" http://localhost:8000/install
+	curl --data-binary @./halfdrop-handler.js -H "content-type: text/plain" http://localhost:8008/install
+	@echo
+
+install-delay-handler:
+	curl --data-binary @./delay-handler.js -H "content-type: text/plain" http://localhost:8008/install
 	@echo

--- a/packages/smart-relay/delay-handler.js
+++ b/packages/smart-relay/delay-handler.js
@@ -1,0 +1,46 @@
+// eslint-disable-next-line no-unused-vars
+function makePolicy(endowments) {
+  const { E, harden, console, timerManager } = endowments;
+
+  // this delivers every message, but one second late
+
+  function wait(duration) {
+    let r;
+    const p = new Promise(r0 => (r = r0));
+    const handler = harden({
+      wake(_intendedTime) {
+        r();
+      },
+    });
+    E(timerManager).setWakeup(duration, handler);
+    return p;
+  }
+
+  function makeDelayHandler(_oldState) {
+    return harden({
+      onPacket(target, packet) {
+        console.log(`delaying packet by 2s`);
+        wait(2.0).then(() => E(target).deliver(packet));
+      },
+      onAck(target, ackPacket) {
+        console.log(`delaying ack by 2s`);
+        wait(2.0).then(() => E(target).deliver(ackPacket));
+      },
+      onHandshake(target, metaPacket) {
+        console.log(`delaying handshake by 5s`);
+        wait(5.0).then(() => E(target).deliver(metaPacket));
+      },
+      retire() {
+        return harden({});
+      },
+    });
+  }
+
+  const delayPolicy = harden({
+    open(src, dest, oldState = undefined) {
+      return makeDelayHandler(oldState);
+    },
+  });
+
+  return delayPolicy;
+}

--- a/packages/smart-relay/lib/smart-relay-main.js
+++ b/packages/smart-relay/lib/smart-relay-main.js
@@ -224,9 +224,9 @@ async function main(args) {
       // TODO: This is a hack for testing, remove when IBC is wired to the
       // bridge. Do 'curl http://localhost:8000/sendIntoBridge' to pretend that
       // the IBC/relayer golang code just received something.
-      if (request.path === '/sendIntoBridge') {
+      if (request.path.startsWith('/sendIntoBridge')) {
         console.log(`http said to send something into the bridge device`);
-        queueInboundBridge('input arg');
+        queueInboundBridge(request.path);
         return 'queued for input into bridge';
       }
       // this is the general HTTP input path. TODO: collect and pass the

--- a/packages/smart-relay/lib/smart-relay-main.js
+++ b/packages/smart-relay/lib/smart-relay-main.js
@@ -133,7 +133,7 @@ async function buildSwingset() {
       thunk(); // device invocation
       await controller.run();
       await saveState();
-      console.log(`deliverOutbound not yet implemented`);
+      // console.log(`deliverOutbound not yet implemented`);
       // todo: deliver new outbound mailbox messages
       // deliver(mbs);
     }
@@ -176,8 +176,8 @@ async function buildSwingset() {
   let intervalMillis;
   function queueTimerEvent() {
     const p = queueInbound(() => {
-      const now = Math.floor(Date.now() / intervalMillis);
-      timer.poll(now);
+      const now = Math.floor(Date.now() / 1000);
+      timer.poll(now); // timer device gets seconds
     });
     p.then(() => {
       setTimeout(queueTimerEvent, intervalMillis);
@@ -202,6 +202,8 @@ async function buildSwingset() {
   };
 }
 
+const SECOND = 1000;
+
 async function main(args) {
   initBasedir();
 
@@ -212,7 +214,7 @@ async function main(args) {
       queueInboundBridge,
       startTimer,
     } = await buildSwingset();
-    startTimer(5000);
+    startTimer(1.0 * SECOND);
     console.log(`swingset running`);
 
     function inboundHTTPRequest(request) {
@@ -236,7 +238,7 @@ async function main(args) {
         body: request.body.toString(),
       });
     }
-    startAPIServer(8000, inboundHTTPRequest);
+    startAPIServer(8008, inboundHTTPRequest);
   }
 
   await runWrappedProgram(initSwingSet, args);

--- a/packages/smart-relay/vats/bootstrap.js
+++ b/packages/smart-relay/vats/bootstrap.js
@@ -6,6 +6,10 @@ function buildRootObject(E, D) {
   // this receives HTTP requests, and can return JSONable objects in response
 
   function doBootstrap(argv, vats, devices) {
+    E(vats.relayer).setTimerManager(
+      E(vats.timer).createTimerService(devices.timer),
+    );
+
     async function handleCommand(req) {
       if (req.path === '/install') {
         return E(vats.relayer).install(req.body);

--- a/packages/smart-relay/vats/vat-relayer.js
+++ b/packages/smart-relay/vats/vat-relayer.js
@@ -5,6 +5,8 @@ console.debug(`loading vat-relayer.js`);
 // At any given moment, there is exactly one PacketHandler in place.
 
 function buildRootObject(E) {
+  let timerManager;
+
   // the default Policy+PacketHandler transparently forwards all packets
 
   function makeDefaultPacketHandler() {
@@ -128,7 +130,7 @@ function buildRootObject(E) {
       );
       return;
     }
-    const endowments = { harden, E, console };
+    const endowments = { harden, E, console, timerManager };
     const newPolicy = harden(makePolicy(endowments));
     if (!newPolicy.open) {
       console.log(
@@ -154,6 +156,9 @@ function buildRootObject(E) {
   }
 
   const root = {
+    setTimerManager(t) {
+      timerManager = t;
+    },
     handle(...args) {
       console.log(`handle() invoked`);
       try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,10 +29,10 @@
     "@agoric/harden" "^0.0.4"
     esm "^3.2.5"
 
-"@agoric/lib-cosmic-relayer@0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@agoric/lib-cosmic-relayer/-/lib-cosmic-relayer-0.1.2.tgz#274f2857cbd9a63d5d5b80e5063c05e09e9cc3c2"
-  integrity sha512-WzF7xe9lo+aJ9MPcqwN5RHpYLINw7Ca0oTaplR80JqK3CZhhj8FiIIbezqcrgy4lsusf8pVRHZySkBZftuq0Kg==
+"@agoric/lib-cosmic-relayer@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@agoric/lib-cosmic-relayer/-/lib-cosmic-relayer-0.1.3.tgz#9ce6621599fc1a82a349b860adcdb1c376fce21e"
+  integrity sha512-GCOpjFpD1bzC15nBUnj0Azu70I0PSfSbhbJVoScasTHixJqh6CmJU5jAr70wNycoh27Sv55+pcIKdD55pG/a6w==
   dependencies:
     bindings "^1.2.1"
 


### PR DESCRIPTION
Closes #1158 

Allow smart-relay policies to use timer devices.

Note especially https://github.com/Agoric/agoric-sdk/pull/1159/files#diff-4c6b493c3d62fc16bc525723fbd9c422R227 which fixes a bad merge.