### PR TITLE
refactor: remove assumption of objective keywords from cleanProposal

### DIFF
--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -784,11 +784,7 @@ const makeZoe = (additionalEndowments = {}) => {
             getKeywords(issuerKeywordRecord),
           );
 
-          proposal = cleanProposal(
-            issuerKeywordRecord,
-            amountMathKeywordRecord,
-            proposal,
-          );
+          proposal = cleanProposal(issuerTable.getAmountMathByBrand, proposal);
 
           // Promise flow:
           // issuer -> purse -> deposit payment -> offerHook -> payout


### PR DESCRIPTION
This PR removes the assumption of objective keywords from `cleanProposal`. Whatever keywords the user used are accepted as long as they meet the criteria for keywords. Amounts are coerced using an amountMath selected by brand.