### PR TITLE
fix!: combine peer and submitter for `tx swingset deliver`

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/chain-cosmos-sdk.js
+++ b/packages/cosmic-swingset/lib/ag-solo/chain-cosmos-sdk.js
@@ -326,7 +326,7 @@ export async function connectToChain(
     try {
       log(`delivering to chain`, GCI, newMessages, acknum);
 
-      // TODO: combine peer and submitter in the message format (i.e. remove
+      // Peer and submitter are combined in the message format (i.e. we removed
       // the extra 'myAddr' after 'tx swingset deliver'). All messages from
       // solo vats are "from" the signer, and messages relayed from another
       // chain will have other data to demonstrate which chain it comes from
@@ -369,7 +369,6 @@ export async function connectToChain(
         'swingset',
         'deliver',
         '--keyring-backend=test',
-        myAddr,
         `@${tmpInfo.path}`, // Deliver message over file, as it could be big.
         '--gas=auto',
         '--gas-adjustment=1.05',

--- a/packages/cosmic-swingset/x/swingset/client/cli/tx.go
+++ b/packages/cosmic-swingset/x/swingset/client/cli/tx.go
@@ -38,9 +38,9 @@ func GetTxCmd(storeKey string, cdc *codec.Codec) *cobra.Command {
 // GetCmdDeliver is the CLI command for sending a DeliverInbound transaction
 func GetCmdDeliver(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:   "deliver [sender] [json string]",
+		Use:   "deliver [json string]",
 		Short: "deliver inbound messages",
-		Args:  cobra.ExactArgs(2),
+		Args:  cobra.ExactArgs(1),
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			inBuf := bufio.NewReader(cmd.InOrStdin())
@@ -48,9 +48,9 @@ func GetCmdDeliver(cdc *codec.Codec) *cobra.Command {
 
 			txBldr := auth.NewTxBuilderFromCLI(inBuf).WithTxEncoder(authclient.GetTxEncoder(cdc))
 
-			jsonIn := args[1]
+			jsonIn := args[0]
 			if jsonIn[0] == '@' {
-				fname := args[1][1:]
+				fname := args[0][1:]
 				if fname == "-" {
 					// Reading from stdin.
 					if _, err := fmt.Scanln(&jsonIn); err != nil {
@@ -69,7 +69,7 @@ func GetCmdDeliver(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			msg := types.NewMsgDeliverInbound(args[0], msgs, cliCtx.GetFromAddress())
+			msg := types.NewMsgDeliverInbound(msgs, cliCtx.GetFromAddress())
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}

--- a/packages/cosmic-swingset/x/swingset/client/rest/tx.go
+++ b/packages/cosmic-swingset/x/swingset/client/rest/tx.go
@@ -3,13 +3,12 @@ package rest
 import (
 	"net/http"
 
-	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/Agoric/agoric-sdk/packages/cosmic-swingset/x/swingset/internal/types"
+	"github.com/cosmos/cosmos-sdk/client/context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/rest"
 	authclient "github.com/cosmos/cosmos-sdk/x/auth/client"
-
 	// "github.com/gorilla/mux"
 )
 
@@ -47,7 +46,7 @@ func deliverMailboxHandler(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		msg := types.NewMsgDeliverInbound(req.Peer, deliver, addr)
+		msg := types.NewMsgDeliverInbound(deliver, addr)
 		err = msg.ValidateBasic()
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())

--- a/packages/cosmic-swingset/x/swingset/handler.go
+++ b/packages/cosmic-swingset/x/swingset/handler.go
@@ -69,7 +69,7 @@ func handleMsgDeliverInbound(ctx sdk.Context, keeper Keeper, msg MsgDeliverInbou
 
 	action := &deliverInboundAction{
 		Type:        "DELIVER_INBOUND",
-		Peer:        msg.Peer,
+		Peer:        msg.Submitter.String(),
 		Messages:    messages,
 		Ack:         msg.Ack,
 		StoragePort: GetPort("controller"),

--- a/packages/cosmic-swingset/x/swingset/internal/types/msgs.go
+++ b/packages/cosmic-swingset/x/swingset/internal/types/msgs.go
@@ -11,7 +11,6 @@ const RouterKey = ModuleName // this was defined in your key.go file
 
 // MsgDeliverInbound defines a DeliverInbound message
 type MsgDeliverInbound struct {
-	Peer      string
 	Messages  []string
 	Nums      []int
 	Ack       int
@@ -20,9 +19,8 @@ type MsgDeliverInbound struct {
 
 var _ sdk.Msg = &MsgDeliverInbound{}
 
-func NewMsgDeliverInbound(peer string, msgs *Messages, submitter sdk.AccAddress) MsgDeliverInbound {
+func NewMsgDeliverInbound(msgs *Messages, submitter sdk.AccAddress) MsgDeliverInbound {
 	return MsgDeliverInbound{
-		Peer:      peer,
 		Messages:  msgs.Messages,
 		Nums:      msgs.Nums,
 		Ack:       msgs.Ack,
@@ -34,15 +32,12 @@ func NewMsgDeliverInbound(peer string, msgs *Messages, submitter sdk.AccAddress)
 func (msg MsgDeliverInbound) Route() string { return RouterKey }
 
 // Type should return the action
-func (msg MsgDeliverInbound) Type() string { return "deliver" }
+func (msg MsgDeliverInbound) Type() string { return "eventualSend" }
 
 // ValidateBasic runs stateless checks on the message
 func (msg MsgDeliverInbound) ValidateBasic() error {
 	if msg.Submitter.Empty() {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, msg.Submitter.String())
-	}
-	if len(msg.Peer) == 0 {
-		return sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, "Peer cannot be empty")
 	}
 	if len(msg.Messages) != len(msg.Nums) {
 		return sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, "Messages and Nums must be the same length")
@@ -154,9 +149,6 @@ func (msg MsgProvision) ValidateBasic() error {
 	}
 	if len(msg.Nickname) == 0 {
 		return sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, "Nickname cannot be empty")
-	}
-	if msg.Address.Empty() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, msg.Address.String())
 	}
 	return nil
 }


### PR DESCRIPTION
The separation of these is not only ill-thought-out, it doesn't
properly verify that the submitter actually has the peer's
authority.

Dropping the separate Peer field, and just using the Submitter's
address is a better design.  Any need for forwarding these packets
from a separate Submitter will happen at a lower layer (e.g. IBC).