### PR TITLE
CI should test against dapp-encouragement branches that aren't master

### DIFF
--- a/.github/workflows/test-dapp-encouragement.yml
+++ b/.github/workflows/test-dapp-encouragement.yml
@@ -1,0 +1,77 @@
+name: Test Dapp Encouragement
+
+# run CI on pushes to master, and on all PRs (even the ones that target other
+# branches)
+
+on:
+ push:
+   branches: [master]
+ pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.18.0, 14.4.0]
+    steps:
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Checkout agoric-sdk
+      uses: actions/checkout@v2
+    - name: Set up Go 1.13
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+
+    # Select a branch on dapp-encouragement to test against by adding text to the body of the
+    # pull request. For example: #dapp-encouragement-branch: zoe-release-0.7.0
+    # The default is 'master'
+    - name: Get the appropriate dapp-encouragement branch
+      id: get-branch
+      uses: actions/github-script@0.9.0
+      with:
+        result-encoding: string
+        script: |
+          let branch = 'master';
+          const { body } = context.payload.pull_request;
+          const regex = /.*\#dapp-encouragement-branch:\s+(\S+)/;
+          const result = regex.exec(body);
+          if (result) {
+            branch = result[1];
+          }
+          console.log(branch);
+          return branch;
+
+    - name: yarn install
+      run: yarn install
+    - name: check dependencies
+      run: yarn check-dependencies
+    # 'yarn build' loops over all workspaces
+    - name: yarn build
+      run: yarn build
+    - name: yarn link
+      run: |
+        yarn link-cli ~/bin/agoric
+        echo "::add-path::/home/runner/bin"
+
+    - name: Check out dapp-encouragement
+      uses: actions/checkout@v2
+      with:
+        repository: Agoric/dapp-encouragement
+        path: dapp-encouragement
+        ref: ${{steps.get-branch.outputs.result}}
+
+    - name: Agoric install in dapp-encouragement
+      run: agoric install
+      working-directory: ./dapp-encouragement
+
+    - name: yarn build in dapp-encouragement
+      run: yarn build
+      working-directory: ./dapp-encouragement
+    
+    - name: yarn test in dapp-encouragement
+      run: yarn test
+      working-directory: ./dapp-encouragement


### PR DESCRIPTION
Closes #1163 

This PR allows creators of PRs to specify which branch of dapp-encouragement to test against. If nothing is specified, master is used. The branch is specified in the text of the PR like:

#dapp-encouragement-branch: zoe-release-0.7.0

The dapp-encouragement CI test is failing because it is successfully testing against the zoe-release-0.7.0 branch of dapp-encouragement.

Some review questions:

This workflow somewhat overlaps the current integration test, but is not identical to it. This workflow doesn't use `agoric init` but instead checks out `dapp-encouragement`. Are we ok having some overlap?

Do we want to test against multiple node versions or only one?