### PR TITLE
feat(cosmic-swingset): add board, use board in mailboxAdmin

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
@@ -74,13 +74,14 @@ export default function setup(syscall, state, helpers) {
         // Create singleton instances.
         const sharingService = await E(vats.sharing).getSharingService();
         const registry = await E(vats.registrar).getSharedRegistrar();
+        const board = await E(vats.board).getBoard();
         const chainTimerService = await E(vats.timer).createTimerService(
           timerDevice,
         );
 
         const zoe = await E(vats.zoe).getZoe();
         const contractHost = await E(vats.host).makeHost();
-        const mailboxAdmin = await E(vats.mailbox).getMailboxAdmin();
+        const mailboxAdmin = await E(vats.mailbox).startup(board);
 
         // Make the other demo mints
         const issuerNames = ['moola', 'simolean'];
@@ -119,6 +120,7 @@ export default function setup(syscall, state, helpers) {
               ibcport,
               registrar: registry,
               registry,
+              board,
               zoe,
               mailboxAdmin,
             });

--- a/packages/cosmic-swingset/lib/ag-solo/vats/lib-board.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/lib-board.js
@@ -1,0 +1,38 @@
+import harden from '@agoric/harden';
+import { generateSparseInts } from '@agoric/sparse-ints';
+import { assert, details } from '@agoric/assert';
+import makeStore from '@agoric/store';
+
+function makeBoard(seed = 0) {
+  const idToVal = makeStore();
+  const valToId = makeStore();
+  const sparseInts = generateSparseInts(seed);
+
+  const board = harden({
+    // Add if not already present
+    getId: value => {
+      if (!valToId.has(value)) {
+        // Retry until we have a unique id.
+        let id;
+        do {
+          id = sparseInts.next().value.toString();
+        } while (idToVal.has(id));
+
+        valToId.init(value, id);
+        idToVal.init(id, value);
+      }
+      return valToId.get(value);
+    },
+    getValue: id => {
+      assert.equal(typeof id, 'string', details`id must be string ${id}`);
+      assert(idToVal.has(id), details`board does not have id: ${id}`);
+      return idToVal.get(id);
+    },
+    has: valToId.has,
+    ids: () => harden([...idToVal.keys()]),
+  });
+
+  return board;
+}
+
+export { makeBoard };

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-board.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-board.js
@@ -1,0 +1,16 @@
+import harden from '@agoric/harden';
+import { makeBoard } from './lib-board';
+
+function build(_E, _log) {
+  const board = makeBoard();
+  return harden({ getBoard: () => board });
+}
+
+export default function setup(syscall, state, helpers) {
+  return helpers.makeLiveSlots(
+    syscall,
+    state,
+    E => build(E, helpers.log),
+    helpers.vatID,
+  );
+}

--- a/packages/cosmic-swingset/test/test-home.js
+++ b/packages/cosmic-swingset/test/test-home.js
@@ -92,7 +92,7 @@ test('home.mailboxAdmin', async t => {
     const payment = await E(sourcePurse).withdraw(moola50);
     const mailboxId = await E(mailboxAdmin).makeMailbox(externalPurse);
 
-    // Someone else can get the mailbox given the id
+    // Someone else can send a payment given the mailboxId
     const result = await E(mailboxAdmin).sendPayment(mailboxId, payment);
     t.deepEquals(result, moola50, `result is 50 moola`);
     t.deepEquals(

--- a/packages/cosmic-swingset/test/test-home.js
+++ b/packages/cosmic-swingset/test/test-home.js
@@ -19,7 +19,7 @@ test('setup', async t => {
 // Now come the tests that use `home`...
 // =========================================
 
-test('registry', async t => {
+test('home.registry', async t => {
   try {
     const { registry } = E.G(home);
     const regVal = await E(registry).get('foolobr_19191');
@@ -31,6 +31,75 @@ test('registry', async t => {
 
     const registered = await E(registry).get(myRegKey);
     t.equals(registered, target, 'registry registers target');
+  } catch (e) {
+    t.isNot(e, e, 'unexpected exception');
+  } finally {
+    t.end();
+  }
+});
+
+test('home.board', async t => {
+  try {
+    const { board } = E.G(home);
+    t.rejects(
+      () => E(board).getValue('0000000000'),
+      `getting a value for a fake id throws`,
+    );
+
+    const myValue = {};
+    const myId = await E(board).getId(myValue);
+    t.equals(typeof myId, 'string', `board key is string`);
+
+    const valueInBoard = await E(board).getValue(myId);
+    t.deepEquals(valueInBoard, myValue, `board contains myValue`);
+
+    const myId2 = await E(board).getId(myValue);
+    t.equals(myId2, myId, `board gives the same id for the same value`);
+  } catch (e) {
+    t.isNot(e, e, 'unexpected exception');
+  } finally {
+    t.end();
+  }
+});
+
+test('home.mailboxAdmin', async t => {
+  try {
+    const { mailboxAdmin, wallet } = E.G(home);
+    await E(wallet).makeEmptyPurse('moola', 'externalPurse');
+
+    const purses = await E(wallet).getPurses();
+    const purseMap = new Map(purses);
+    const sourcePurse = purseMap.get('Fun budget');
+    const externalPurse = purseMap.get('externalPurse');
+
+    const issuers = await E(wallet).getIssuers();
+    const issuersMap = new Map(issuers);
+    const moolaIssuer = issuersMap.get('moola');
+    const amountMath = await E(moolaIssuer).getAmountMath();
+
+    t.deepEquals(
+      await E(sourcePurse).getCurrentAmount(),
+      await E(amountMath).make(1900),
+      `balance starts at 1900`,
+    );
+    t.deepEquals(
+      await E(externalPurse).getCurrentAmount(),
+      await E(amountMath).make(0),
+      `balance for external purse starts at 0`,
+    );
+
+    const moola50 = await E(amountMath).make(50);
+    const payment = await E(sourcePurse).withdraw(moola50);
+    const mailboxId = await E(mailboxAdmin).makeMailbox(externalPurse);
+
+    // Someone else can get the mailbox given the id
+    const result = await E(mailboxAdmin).sendPayment(mailboxId, payment);
+    t.deepEquals(result, moola50, `result is 50 moola`);
+    t.deepEquals(
+      await E(externalPurse).getCurrentAmount(),
+      moola50,
+      `balance for external purse is 50 moola`,
+    );
   } catch (e) {
     t.isNot(e, e, 'unexpected exception');
   } finally {

--- a/packages/cosmic-swingset/test/unitTests/test-lib-board.js
+++ b/packages/cosmic-swingset/test/unitTests/test-lib-board.js
@@ -1,0 +1,32 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from 'tape-promise/tape';
+import harden from '@agoric/harden';
+
+import { makeBoard } from '../../lib/ag-solo/vats/lib-board';
+
+test('makeBoard', async t => {
+  try {
+    const board = makeBoard();
+
+    const obj1 = harden({});
+    const obj2 = harden({});
+
+    t.deepEquals(board.ids(), [], `board is empty to start`);
+
+    const idObj1 = board.getId(obj1);
+    t.deepEquals(board.ids(), [idObj1], `board has one id`);
+
+    const idObj2 = board.getId(obj2);
+    t.deepEquals(board.ids().length, 2, `board has two ids`);
+
+    t.deepEquals(board.getValue(idObj1), obj1, `id matches value obj1`);
+    t.deepEquals(board.getValue(idObj2), obj2, `id matches value obj2`);
+
+    t.deepEquals(board.getId(obj1), idObj1, `value matches id obj1`);
+    t.deepEquals(board.getId(obj2), idObj2, `value matches id obj2`);
+  } catch (e) {
+    t.isNot(e, e, 'unexpected exception');
+  } finally {
+    t.end();
+  }
+});


### PR DESCRIPTION
Closes #1166 

This PR adds the "board", a registry-like vat which allows users to add a value and get a key for that value. The key is a non-human-readable string and can be shared widely. Users can retrieve a value by giving the board the key. Keys and values are in a bidirectional one-to-one mapping. If a user attempts to add a value that has already been added, they get the old id. 

This PR changes the mailbox vat to use the board rather than the registry. 

Unit tests are added for the board, and tests of `home.board` and `home.mailboxAdmin` are also added.

With this PR, users can now send and receive payments, but they can't use the wallet UI to do so yet. They can use deploy scripts or the REPL.