### PR TITLE
fix: handle circular module references in nestedEvaluate

### DIFF
--- a/packages/bundle-source/demo/circular/a.js
+++ b/packages/bundle-source/demo/circular/a.js
@@ -1,0 +1,4 @@
+import { bar } from './b.js';
+
+export const foo = 'Foo';
+export default bar;

--- a/packages/bundle-source/demo/circular/a.js
+++ b/packages/bundle-source/demo/circular/a.js
@@ -1,4 +1,5 @@
-import { bar } from './b.js';
+// eslint-disable-next-line import/no-cycle
+import { bar } from './b';
 
 export const foo = 'Foo';
 export default bar;

--- a/packages/bundle-source/demo/circular/b.js
+++ b/packages/bundle-source/demo/circular/b.js
@@ -1,3 +1,4 @@
-import { foo } from './a.js';
+// eslint-disable-next-line import/no-cycle
+import { foo } from './a';
 
 export { foo as bar };

--- a/packages/bundle-source/demo/circular/b.js
+++ b/packages/bundle-source/demo/circular/b.js
@@ -1,0 +1,3 @@
+import { foo } from './a.js';
+
+export { foo as bar };

--- a/packages/bundle-source/test/circular.js
+++ b/packages/bundle-source/test/circular.js
@@ -1,0 +1,29 @@
+import { test } from 'tape-promise/tape';
+import { evaluateProgram as evaluate } from '@agoric/evaluate';
+import bundleSource from '..';
+
+test('circular export', async t => {
+  try {
+    const { source: src1 } = await bundleSource(
+      `${__dirname}/../demo/circular/a.js`,
+      'nestedEvaluate',
+    );
+
+    // Fake out `require('@agoric/harden')`.
+    const require = _ => o => o;
+    const nestedEvaluate = src => {
+      // console.log('========== evaluating', src);
+      return evaluate(src, { require, nestedEvaluate });
+    };
+    // console.log(src1);
+    const srcMap1 = `(${src1})`;
+    const ex1 = nestedEvaluate(srcMap1)();
+
+    // console.log(err.stack);
+    t.equals(ex1.default, 'Foo', `circular export is Foo`);
+  } catch (e) {
+    t.isNot(e, e, 'unexpected exception');
+  } finally {
+    t.end();
+  }
+});


### PR DESCRIPTION
This improves the `require('x')` behaviour to create and cache `x`'s "exports" object before evaluating `x`'s code to update the cache.  Doing this allows `x` to be part of an import cycle.