### PR TITLE
Use dehydrator for petnames

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
@@ -225,7 +225,7 @@ export default function setup(syscall, state, helpers) {
       // be in the DApp environment (or only in end-user), but we're not yet
       // making a distinction, so the user also gets them.
       async function createLocalBundle(vats, userBundle, payments, issuerInfo) {
-        const { zoe, registry } = userBundle;
+        const { zoe, registry, board, mailboxAdmin } = userBundle;
         // This will eventually be a vat spawning service. Only needed by dev
         // environments.
         const spawner = E(vats.host).makeHost();
@@ -234,7 +234,7 @@ export default function setup(syscall, state, helpers) {
         const uploads = E(vats.uploads).getUploads();
 
         // Wallet for both end-user client and dapp dev client
-        await E(vats.wallet).startup(zoe, registry);
+        await E(vats.wallet).startup({ zoe, registry, board, mailboxAdmin });
         const wallet = E(vats.wallet).getWallet();
         await Promise.all(
           issuerInfo.map(({ petname, issuer, brandRegKey }) =>

--- a/packages/cosmic-swingset/lib/ag-solo/vats/lib-mailbox.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/lib-mailbox.js
@@ -1,0 +1,30 @@
+import harden from '@agoric/harden';
+import { E } from '@agoric/eventual-send';
+import { assert } from '@agoric/assert';
+
+export const makeMailboxAdmin = board => {
+  const mailboxAdmin = harden({
+    makeMailbox: (purse, action = 'deposit') => {
+      assert.typeof(action, 'string');
+      const mailbox = harden({
+        receivePayment: payment => {
+          switch (action) {
+            case 'deposit': {
+              return E(purse).deposit(payment);
+            }
+            default: {
+              throw new Error(`action ${action} is not implemented`);
+            }
+          }
+        },
+      });
+      return E(board).getId(mailbox);
+    },
+    sendPayment: async (mailboxId, payment) => {
+      return E(board)
+        .getValue(mailboxId)
+        .then(mailbox => mailbox.receivePayment(payment));
+    },
+  });
+  return mailboxAdmin;
+};

--- a/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
@@ -3,31 +3,87 @@ import { assert, details } from '@agoric/assert';
 import makeStore from '@agoric/store';
 import makeWeakStore from '@agoric/weak-store';
 import makeAmountMath from '@agoric/ertp/src/amountMath';
+import { makeTable, makeValidateProperties } from '@agoric/zoe/src/table';
 import { E } from '@agoric/eventual-send';
 
 import makeObservablePurse from './observable';
 import makeOfferCompiler from './offer-compiler';
+import { makeDehydrator } from './lib-dehydrate';
 
 // does nothing
 const noActionStateChangeHandler = _newState => {};
 
 export async function makeWallet({
   zoe,
+  // eslint-disable-next-line no-unused-vars
   mailboxAdmin,
+  // eslint-disable-next-line no-unused-vars
   board,
   registry,
   pursesStateChangeHandler = noActionStateChangeHandler,
   inboxStateChangeHandler = noActionStateChangeHandler,
 }) {
-  const petnameToPurse = makeStore();
-  const purseToIssuer = makeWeakStore();
-  const issuerPetnameToIssuer = makeStore();
+  // Create the petname maps so we can dehydrate information sent to
+  // the frontend.
+  const { makeMapping } = makeDehydrator();
+  const purseMapping = makeMapping('purse');
+  const brandMapping = makeMapping('brand');
+
+  // Brand Table
+  // Columns: key:brand | brand | issuer | amountMath
+  const makeBrandTable = () => {
+    const validateSomewhat = makeValidateProperties(
+      harden(['brand', 'issuer', 'amountMath']),
+    );
+
+    const issuersInProgress = makeStore();
+    const issuerToBrand = makeWeakStore();
+    const makeCustomProperties = table =>
+      harden({
+        addIssuer: issuerP => {
+          return Promise.resolve(issuerP).then(issuer => {
+            assert(
+              !table.has(issuer),
+              details`issuer ${issuer} is already in wallet`,
+            );
+            if (issuersInProgress.has(issuer)) {
+              // a promise which resolves to the issuer record
+              return issuersInProgress.get(issuer);
+            }
+            // remote calls which immediately return a promise
+            const mathHelpersNameP = E(issuer).getMathHelpersName();
+            const brandP = E(issuer).getBrand();
+
+            // a promise for a synchronously accessible record
+            const synchronousRecordP = Promise.all([
+              brandP,
+              mathHelpersNameP,
+            ]).then(([brand, mathHelpersName]) => {
+              const amountMath = makeAmountMath(brand, mathHelpersName);
+              const issuerRecord = {
+                issuer,
+                brand,
+                amountMath,
+              };
+              table.create(issuerRecord, brand);
+              issuerToBrand.init(issuer, brand);
+              issuersInProgress.delete(issuer);
+              return table.get(brand);
+            });
+            issuersInProgress.init(issuer, synchronousRecordP);
+            return synchronousRecordP;
+          });
+        },
+        getBrandForIssuer: issuerToBrand.get,
+      });
+    const brandTable = makeTable(validateSomewhat, makeCustomProperties);
+    return brandTable;
+  };
 
   // issuerNames have properties like 'brandRegKey' and 'issuerPetname'.
   const issuerToIssuerNames = makeWeakStore();
-  const issuerToBrand = makeWeakStore();
-  const brandToIssuer = makeStore();
-  const brandToMath = makeStore();
+  const brandTable = makeBrandTable();
+  const purseToBrand = makeWeakStore();
 
   // Offers that the wallet knows about (the inbox).
   const idToOffer = makeStore();
@@ -66,7 +122,8 @@ export async function makeWallet({
       E(purse).getCurrentAmount(),
       E(purse).getAllegedBrand(),
     ]);
-    const issuerNames = issuerToIssuerNames.get(brandToIssuer.get(brand));
+    const { issuer } = brandTable.get(brand);
+    const issuerNames = issuerToIssuerNames.get(issuer);
     pursesState.set(pursePetname, {
       ...issuerNames,
       pursePetname,
@@ -197,47 +254,66 @@ export async function makeWallet({
 
   // === API
 
-  async function addIssuer(issuerPetname, issuer, brandRegKey = undefined) {
-    issuerPetnameToIssuer.init(issuerPetname, issuer);
-    issuerToIssuerNames.init(issuer, { issuerPetname, brandRegKey });
-    const [brand, mathName] = await Promise.all([
-      E(issuer).getBrand(),
-      E(issuer).getMathHelpersName(),
-    ]);
-    brandToIssuer.init(brand, issuer);
-    issuerToBrand.init(issuer, brand);
+  // TODO: remove brandRegKey
+  const addIssuer = async (
+    petnameForBrand,
+    issuer,
+    brandRegKey = undefined,
+  ) => {
+    const issuerSavedP = brandTable.addIssuer(issuer);
+    const addBrandPetname = ({ brand }) => {
+      brandMapping.addPetname(petnameForBrand, brand);
 
-    const math = makeAmountMath(brand, mathName);
-    brandToMath.init(brand, math);
-  }
+      // TODO: remove issuerToIssuerNames
+      issuerToIssuerNames.init(issuer, {
+        issuerPetname: petnameForBrand,
+        brandRegKey,
+      });
+    };
+    return issuerSavedP.then(addBrandPetname).then(() => {
+      return `issuer ${petnameForBrand} successfully added to wallet`;
+    });
+  };
 
-  async function makeEmptyPurse(issuerPetname, pursePetname, memo = 'purse') {
+  const makeEmptyPurse = async (brandPetname, petnameForPurse) => {
     assert(
-      !petnameToPurse.has(pursePetname),
-      details`Purse name already used in wallet.`,
+      !purseMapping.petnameToVal.has(petnameForPurse),
+      details`Purse petname already used in wallet.`,
     );
-    const issuer = issuerPetnameToIssuer.get(issuerPetname);
+    const brand = brandMapping.petnameToVal.get(brandPetname);
+    const { issuer } = brandTable.get(brand);
 
     // IMPORTANT: once wrapped, the original purse should never
     // be used otherwise the UI state will be out of sync.
-    const doNotUse = await E(issuer).makeEmptyPurse(memo);
+    const doNotUse = await E(issuer).makeEmptyPurse();
 
     const purse = makeObservablePurse(E, doNotUse, () =>
-      updatePursesState(pursePetname, doNotUse),
+      updatePursesState(petnameForPurse, doNotUse),
     );
 
-    petnameToPurse.init(pursePetname, purse);
-    purseToIssuer.init(purse, issuer);
-    updatePursesState(pursePetname, purse);
-  }
+    purseToBrand.init(purse, brand);
+    purseMapping.addPetname(petnameForPurse, purse);
+    updatePursesState(petnameForPurse, purse);
+  };
 
-  function deposit(pursePetName, payment) {
-    const purse = petnameToPurse.get(pursePetName);
+  function deposit(pursePetname, payment) {
+    const purse = purseMapping.petnameToVal.get(pursePetname);
     return purse.deposit(payment);
   }
 
   function getPurses() {
-    return petnameToPurse.entries();
+    return purseMapping.petnameToVal.entries();
+  }
+
+  function getPurse(pursePetname) {
+    return purseMapping.petnameToVal.get(pursePetname);
+  }
+
+  function getPurseIssuer(pursePetname) {
+    const purse = purseMapping.petnameToVal.get(pursePetname);
+    const brand = purseToBrand.get(purse);
+    const { issuer } = brandTable.get(brand);
+    return issuer;
   }
 
   function getOffers({ origin = null } = {}) {
@@ -260,11 +336,10 @@ export async function makeWallet({
 
     collections: {
       idToOffer,
-      brandToMath,
+      brandTable,
+      purseToBrand,
       issuerToIssuerNames,
-      issuerToBrand,
-      purseToIssuer,
-      petnameToPurse,
+      purseMapping,
     },
   });
   async function addOffer(
@@ -411,7 +486,10 @@ export async function makeWallet({
   }
 
   function getIssuers() {
-    return issuerPetnameToIssuer.entries();
+    return brandMapping.petnameToVal.entries().map(([petname, brand]) => {
+      const { issuer } = brandTable.get(brand);
+      return [petname, issuer];
+    });
   }
 
   const hydrateHook = ([hookMethod, ...hookArgs] = []) => object => {
@@ -459,8 +537,9 @@ export async function makeWallet({
     deposit,
     getIssuers,
     getPurses,
-    getPurse: petnameToPurse.get,
-    getPurseIssuer: petname => purseToIssuer.get(petnameToPurse.get(petname)),
+    getPurse,
+    getPurseIssuer,
+    // TODO: remove when removing brandRegKey
     getIssuerNames: issuerToIssuerNames.get,
     hydrateHooks,
     addOffer,

--- a/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
@@ -3,6 +3,8 @@ import { assert, details } from '@agoric/assert';
 import makeStore from '@agoric/store';
 import makeWeakStore from '@agoric/weak-store';
 import makeAmountMath from '@agoric/ertp/src/amountMath';
+
+// TODO: move the Table abstraction out of Zoe
 import { makeTable, makeValidateProperties } from '@agoric/zoe/src/table';
 import { E } from '@agoric/eventual-send';
 
@@ -30,7 +32,7 @@ export async function makeWallet({
   const brandMapping = makeMapping('brand');
 
   // Brand Table
-  // Columns: key:brand | brand | issuer | amountMath
+  // Columns: key:brand | issuer | amountMath
   const makeBrandTable = () => {
     const validateSomewhat = makeValidateProperties(
       harden(['brand', 'issuer', 'amountMath']),

--- a/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
@@ -3,6 +3,7 @@ import { assert, details } from '@agoric/assert';
 import makeStore from '@agoric/store';
 import makeWeakStore from '@agoric/weak-store';
 import makeAmountMath from '@agoric/ertp/src/amountMath';
+import { E } from '@agoric/eventual-send';
 
 import makeObservablePurse from './observable';
 import makeOfferCompiler from './offer-compiler';
@@ -10,13 +11,14 @@ import makeOfferCompiler from './offer-compiler';
 // does nothing
 const noActionStateChangeHandler = _newState => {};
 
-export async function makeWallet(
-  E,
+export async function makeWallet({
   zoe,
+  mailboxAdmin,
+  board,
   registry,
   pursesStateChangeHandler = noActionStateChangeHandler,
   inboxStateChangeHandler = noActionStateChangeHandler,
-) {
+}) {
   const petnameToPurse = makeStore();
   const purseToIssuer = makeWeakStore();
   const issuerPetnameToIssuer = makeStore();

--- a/packages/cosmic-swingset/lib/ag-solo/vats/offer-compiler.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/offer-compiler.js
@@ -11,11 +11,10 @@ export default ({
 
   collections: {
     idToOffer,
-    brandToMath,
+    brandTable,
+    purseToBrand,
     issuerToIssuerNames,
-    issuerToBrand,
-    purseToIssuer,
-    petnameToPurse,
+    purseMapping,
   },
 }) => async (id, offer, hooks = {}) => {
   const { instanceRegKey, proposalTemplate } = offer;
@@ -35,10 +34,9 @@ export default ({
       purse,
       extent = undefined,
     ) => {
-      const issuer = purseToIssuer.get(purse);
+      const brand = purseToBrand.get(purse);
+      const { issuer, amountMath } = brandTable.get(brand);
       issuerNames[keyword] = issuerToIssuerNames.get(issuer);
-      const brand = issuerToBrand.get(issuer);
-      const amountMath = brandToMath.get(brand);
       if (extent === undefined) {
         keywords[keyword] = amountMath.getEmpty();
       } else {
@@ -58,7 +56,7 @@ export default ({
           amount.pursePetname,
           `Keyword ${dir} ${keyword} has no pursePetname`,
         );
-        const purse = petnameToPurse.get(amount.pursePetname);
+        const purse = purseMapping.petnameToVal.get(amount.pursePetname);
         assert(
           purse,
           `Keyword ${dir} ${keyword} pursePetname ${amount.pursePetname} is not a purse`,

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-mailbox.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-mailbox.js
@@ -1,34 +1,12 @@
 import harden from '@agoric/harden';
-import { E } from '@agoric/eventual-send';
-import { assert } from '@agoric/assert';
+
+import { makeMailboxAdmin } from './lib-mailbox';
 
 function build(_log) {
   let mailboxAdmin;
 
   const startup = board => {
-    mailboxAdmin = harden({
-      makeMailbox: (purse, action = 'deposit') => {
-        assert.typeof(action, 'string');
-        const mailbox = harden({
-          receivePayment: payment => {
-            switch (action) {
-              case 'deposit': {
-                return E(purse).deposit(payment);
-              }
-              default: {
-                throw new Error(`action ${action} is not implemented`);
-              }
-            }
-          },
-        });
-        return E(board).getId(mailbox);
-      },
-      sendPayment: async (mailboxId, payment) => {
-        return E(board)
-          .getValue(mailboxId)
-          .then(mailbox => mailbox.receivePayment(payment));
-      },
-    });
+    mailboxAdmin = makeMailboxAdmin(board);
     return mailboxAdmin;
   };
 

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-wallet.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-wallet.js
@@ -58,7 +58,6 @@ function build(E, _D, _log) {
     });
   }
 
-
   async function getWallet() {
     return harden(wallet);
   }

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-wallet.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-wallet.js
@@ -47,9 +47,17 @@ function build(E, _D, _log) {
   const { publish: pursesPublish, subscribe: purseSubscribe } = pubsub(E);
   const { publish: inboxPublish, subscribe: inboxSubscribe } = pubsub(E);
 
-  async function startup(zoe, registry) {
-    wallet = await makeWallet(E, zoe, registry, pursesPublish, inboxPublish);
+  async function startup({ zoe, registry, board, mailboxAdmin }) {
+    wallet = await makeWallet({
+      zoe,
+      mailboxAdmin,
+      board,
+      registry,
+      pursesStateChangeHandler: pursesPublish,
+      inboxStateChangeHandler: inboxPublish,
+    });
   }
+
 
   async function getWallet() {
     return harden(wallet);

--- a/packages/cosmic-swingset/test/unitTests/test-lib-wallet.js
+++ b/packages/cosmic-swingset/test/unitTests/test-lib-wallet.js
@@ -2,7 +2,6 @@
 import { test } from 'tape-promise/tape';
 import bundleSource from '@agoric/bundle-source';
 
-import { E } from '@agoric/eventual-send';
 import produceIssuer from '@agoric/ertp';
 import { makeZoe } from '@agoric/zoe';
 import { makeRegistrar } from '@agoric/registrar';

--- a/packages/cosmic-swingset/test/unitTests/test-lib-wallet.js
+++ b/packages/cosmic-swingset/test/unitTests/test-lib-wallet.js
@@ -10,6 +10,8 @@ import harden from '@agoric/harden';
 import { makeGetInstanceHandle } from '@agoric/zoe/src/clientSupport';
 
 import { makeWallet } from '../../lib/ag-solo/vats/lib-wallet';
+import { makeBoard } from '../../lib/ag-solo/vats/lib-board';
+import { makeMailboxAdmin } from '../../lib/ag-solo/vats/lib-mailbox';
 
 const setupTest = async () => {
   const contractRoot = require.resolve(
@@ -29,6 +31,8 @@ const setupTest = async () => {
   const rpgBundle = produceIssuer('rpg', 'strSet');
   const zoe = makeZoe({ require });
   const registry = makeRegistrar();
+  const board = makeBoard();
+  const mailboxAdmin = makeMailboxAdmin(board);
 
   const installationHandle = zoe.install(source, moduleFormat);
 
@@ -45,18 +49,21 @@ const setupTest = async () => {
     instanceHandle,
   );
 
-  const wallet = await makeWallet(
-    E,
+  const wallet = await makeWallet({
     zoe,
     registry,
+    board,
+    mailboxAdmin,
     pursesStateChangeHandler,
     inboxStateChangeHandler,
-  );
+  });
   return {
     moolaBundle,
     rpgBundle,
     zoe,
     registry,
+    mailboxAdmin,
+    board,
     wallet,
     invite,
     installationHandle,


### PR DESCRIPTION
This is an incremental PR that keeps the current wallet functionality but does some internal refactoring. Instead of using ad-hoc maps for keeping track of petnames, we start using the dehydrator's mappings. This PR does not capitalize on the dehydrator's ability to serialize and deserialize arbitrary data, but that will come in a future PR. 

It also moves the mailbox code into a separate file `lib-mailbox.js` for easier testing.