### PR TITLE
Fix dapp-encouragement workflow - check if pull request info is defined

### DIFF
--- a/.github/workflows/test-dapp-encouragement.yml
+++ b/.github/workflows/test-dapp-encouragement.yml
@@ -36,11 +36,13 @@ jobs:
         result-encoding: string
         script: |
           let branch = 'master';
-          const { body } = context.payload.pull_request;
-          const regex = /.*\#dapp-encouragement-branch:\s+(\S+)/;
-          const result = regex.exec(body);
-          if (result) {
-            branch = result[1];
+          if (context.payload.pull_request) {
+            const { body } = context.payload.pull_request;
+            const regex = /.*\#dapp-encouragement-branch:\s+(\S+)/;
+            const result = regex.exec(body);
+            if (result) {
+              branch = result[1];
+            }
           }
           console.log(branch);
           return branch;


### PR DESCRIPTION
The dapp-encouragement CI tests were breaking when commits are made to master. The quick fix is to check whether the pull-request information is available (it will only be available if the action that triggered the CI run was a pull-request) and only if it is available, check for a different branch of dapp-encouragement to run. 

I considered stopping the workflow from running on commits to master, but I think in those cases, we do want to still run this check, just always against dapp-encouragement master.