### PR TITLE
Robust bundle source rewrite

### DIFF
--- a/packages/bundle-source/demo/circular/a.js
+++ b/packages/bundle-source/demo/circular/a.js
@@ -1,5 +1,8 @@
 // eslint-disable-next-line import/no-cycle
 import { bar } from './b';
 
+/**
+ * @type {import('./b').Bar}
+ */
 export const foo = 'Foo';
 export default bar;

--- a/packages/bundle-source/demo/circular/b.js
+++ b/packages/bundle-source/demo/circular/b.js
@@ -1,4 +1,9 @@
 // eslint-disable-next-line import/no-cycle
 import { foo } from './a';
 
+/*
+ * --------->
+ * <!-- foo as bar -->
+ */
+console.error('here am I');
 export { foo as bar };

--- a/packages/bundle-source/demo/circular/b.js
+++ b/packages/bundle-source/demo/circular/b.js
@@ -5,5 +5,4 @@ import { foo } from './a';
  * --------->
  * <!-- foo as bar -->
  */
-console.error('here am I');
 export { foo as bar };

--- a/packages/bundle-source/demo/dir1/index.js
+++ b/packages/bundle-source/demo/dir1/index.js
@@ -6,6 +6,7 @@ export default function makeEncourager() {
   return harden({
     encourage,
     makeError,
+    makeError2: msg => TypeError(msg),
     more,
   });
 }

--- a/packages/bundle-source/demo/trailing-comment.js
+++ b/packages/bundle-source/demo/trailing-comment.js
@@ -1,9 +1,13 @@
+/* global harden */
 export function buildRootObject() {
   const a = {
     a: 123,
     b: 456,
   };
-  return harden({ run() {
-    return a; } });
+  return harden({
+    run() {
+      return a;
+    },
+  });
 }
 // comment

--- a/packages/bundle-source/demo/trailing-comment.js
+++ b/packages/bundle-source/demo/trailing-comment.js
@@ -1,0 +1,9 @@
+export function buildRootObject() {
+  const a = {
+    a: 123,
+    b: 456,
+  };
+  return harden({ run() {
+    return a; } });
+}
+// comment

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -23,6 +23,7 @@
     "@agoric/harden": "^0.0.8",
     "@agoric/transform-eventual-send": "^1.3.1",
     "@babel/generator": "^7.6.4",
+    "@babel/traverse": "^7.8.3",
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",
     "acorn": "^7.1.0",

--- a/packages/bundle-source/src/index.js
+++ b/packages/bundle-source/src/index.js
@@ -88,20 +88,21 @@ export default async function bundleSource(
       // eslint-disable-next-line no-await-in-loop
       const consumer = await new SourceMapConsumer(chunk.map);
       const unmapped = new WeakSet();
-      let lastPos = ast.loc.start;
+      let lastPos = { ...ast.loc.start };
       unmapLoc = loc => {
         if (!loc || unmapped.has(loc)) {
           return;
         }
-        // Ensure we start in the right position... doesn't matter where we end.
-        loc.end = loc.start;
+        // Make sure things start at least at the right place.
+        loc.end = { ...loc.start };
         for (const pos of ['start', 'end']) {
           if (loc[pos]) {
             const newPos = consumer.originalPositionFor(loc[pos]);
             if (newPos.source !== null) {
-              lastPos = loc[pos];
-              lastPos.line = newPos.line;
-              lastPos.column = newPos.column;
+              lastPos = {
+                line: newPos.line,
+                column: newPos.column,
+              };
             }
             loc[pos] = lastPos;
           }

--- a/packages/bundle-source/src/index.js
+++ b/packages/bundle-source/src/index.js
@@ -76,6 +76,7 @@ export default async function bundleSource(
     }
 
     // Parse the rolled-up chunk with Babel.
+    // We are prepared for different module systems.
     const ast = (babelParser.parse || babelParser)(code);
 
     let unmapLoc;
@@ -113,10 +114,14 @@ export default async function bundleSource(
 
     const rewriteComment = node => {
       node.type = 'CommentBlock';
+      // Within comments...
       node.value = node.value
-        .replace(/^\s*/gm, '') // Strip extraneous comment whitespace.
+        // ...strip extraneous comment whitespace
+        .replace(/^\s+/gm, ' ')
+        // ...replace HTML comments with a defanged version to pass SES restrictions.
         .replace(HTML_COMMENT_START_RE, '<!X-')
         .replace(HTML_COMMENT_END_RE, '-X>')
+        // ...replace import expressions with a defanged version to pass SES restrictions.
         .replace(IMPORT_RE, 'X$1$2');
       if (unmapLoc) {
         unmapLoc(node.loc);

--- a/packages/bundle-source/test/circular.js
+++ b/packages/bundle-source/test/circular.js
@@ -10,7 +10,7 @@ function evaluate(src, endowments) {
 
 test('circular export', async t => {
   try {
-    const { source: src1 } = await bundleSource(
+    const { source: src1, sourceMap: map1 } = await bundleSource(
       `${__dirname}/../demo/circular/a.js`,
       'nestedEvaluate',
     );
@@ -22,7 +22,7 @@ test('circular export', async t => {
       return evaluate(src, { require, nestedEvaluate });
     };
     // console.log(src1);
-    const srcMap1 = `(${src1})`;
+    const srcMap1 = `(${src1})\n${map1}`;
     const ex1 = nestedEvaluate(srcMap1)();
 
     // console.log(err.stack);

--- a/packages/bundle-source/test/sanity.js
+++ b/packages/bundle-source/test/sanity.js
@@ -39,6 +39,12 @@ test('nestedEvaluate', async t => {
       'bundled source is in stack trace with correct line number',
     );
 
+    const err2 = bundle.makeError2('bar');
+    t.assert(
+      err2.stack.indexOf('(/bundled-source/index.js:9:') >= 0,
+      'bundled source is in second stack trace with correct line number',
+    );
+
     const {
       moduleFormat: mf2,
       source: src2,

--- a/packages/bundle-source/test/test-trailing-comment.js
+++ b/packages/bundle-source/test/test-trailing-comment.js
@@ -1,0 +1,39 @@
+/* global Compartment */
+import '@agoric/install-ses';
+import { test } from 'tape-promise/tape';
+import bundleSource from '..';
+
+function evaluate(src, endowments) {
+  const c = new Compartment(endowments, {}, {});
+  return c.evaluate(src);
+}
+
+test('trailing comment', async t => {
+  try {
+    const { source: src1 } = await bundleSource(
+      `${__dirname}/../demo/trailing-comment.js`,
+      'nestedEvaluate',
+    );
+
+    // Fake out `require('@agoric/harden')`.
+    const require = _ => o => o;
+    const nestedEvaluate = src => {
+      // console.log('========== evaluating', src);
+      return evaluate(src, { require, nestedEvaluate });
+    };
+    // console.log(src1);
+    const srcMap1 = `(${src1})`;
+    const ex1 = nestedEvaluate(srcMap1)();
+
+    // console.log(err.stack);
+    t.equals(
+      typeof ex1.buildRootObject,
+      'function',
+      `buildRootObject is exported`,
+    );
+  } catch (e) {
+    t.isNot(e, e, 'unexpected exception');
+  } finally {
+    t.end();
+  }
+});


### PR DESCRIPTION
Fixes #1249

This PR reimplements the following bundle-source features in a more robust way:

- Prevent many false positives (SES failing because of import expression detected, or HTML comment) by rewriting JS comments in the bundled source.
- Unmap the bundled source chunks so that expressions are present on the line numbers corresponding to the original sources.  We use only the start position of each AST node to decide the line number on which they should appear.

We do this by using the Babel parser and generator we already require for the tildot plugin.
