### PR TITLE
chore: add mailbox for Zoe invites

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
@@ -280,6 +280,9 @@ export default function setup(syscall, state, helpers) {
         await E(wallet).deposit(pursePetnames.moola, moolaPayment);
         await E(wallet).deposit(pursePetnames.simolean, simoleanPayment);
 
+        // Make mailbox for Default Zoe invite purse
+        await E(wallet).makeMailbox(pursePetnames['zoe invite']);
+
         // This will allow dApp developers to register in their api/deploy.js
         const httpRegCallback = {
           send(obj, connectionHandles) {

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-wallet.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-wallet.js
@@ -248,6 +248,15 @@ function build(E, _D, _log) {
                 };
               }
 
+              case 'walletGetMailboxIdByBrand': {
+                const { brandBoardId } = obj;
+                const result = await wallet.getMailboxIdByBrand(brandBoardId);
+                return {
+                  type: 'walletMailboxIdByBrandResponse',
+                  data: result,
+                };
+              }
+
               default:
                 return Promise.resolve(false);
             }

--- a/packages/cosmic-swingset/test/test-home.js
+++ b/packages/cosmic-swingset/test/test-home.js
@@ -133,7 +133,7 @@ test('home.wallet - receive zoe invite', async t => {
     );
     const invitePurse = await E(wallet).getPurse('Default Zoe invite purse');
     const zoeInviteBrand = await E(invitePurse).getAllegedBrand();
-    t.deepEquals(
+    t.equals(
       zoeInviteBrand,
       await E(zoeInviteIssuer).getBrand(),
       `invite purse is actually a zoe invite purse`,


### PR DESCRIPTION
Closes #1177 

This PR adds a mailbox for receiving Zoe invites to the user's wallet. There is still no UI for mailboxes, but anything sent through this mailbox will show up in the user's Zoe invite purse:

<img width="344" alt="Screen Shot 2020-06-12 at 6 47 18 PM" src="https://user-images.githubusercontent.com/2441069/84557154-88bc1980-acdd-11ea-811b-c29d0842f994.png">

(It's not pretty. That will be improved when everything is displayed in terms of petnames.)

Two methods are added to the walletAPI: `makeMailbox(pursePetname)` and `getMailboxIdByBrand(brandBoardId)`. `makeMailbox` is meant to be called on the user's behalf, but `getMailboxIdByBrand` is meant to be called on behalf of an external dapp. A new message type is created so that the external dapp can call `getMailboxIdByBrand`.

I've tested this out with dapp-encouragement, and this process works. Here's the WIP PR (https://github.com/Agoric/dapp-encouragement/pull/43/) so that you can see how it would be used.