### PR TITLE
Tame metering direct eval

### DIFF
--- a/packages/tame-metering/package.json
+++ b/packages/tame-metering/package.json
@@ -10,9 +10,9 @@
     "build": "exit 0"
   },
   "dependencies": {
-    "@agoric/harden": "^0.0.8",
-    "@agoric/nat": "^2.0.1",
-    "re2": "^1.10.5"
+    "esm": "^3.2.5",
+    "tape": "^4.9.2",
+    "tape-promise": "^4.0.0"
   },
   "keywords": [],
   "files": [

--- a/packages/tame-metering/src/ses1.js
+++ b/packages/tame-metering/src/ses1.js
@@ -5,7 +5,7 @@ const shim = `\
 (() => {
   const globalThis = this;
 
-  // Declare to the metering tamer that we're using SES 1.
+  // Declare to the metering tamer that we're using SES 1 (pre-0.8).
   const SES1ErrorConstructor = Error;
 
   // Provide imported references to the metering tamer.

--- a/packages/tame-metering/src/tame.js
+++ b/packages/tame-metering/src/tame.js
@@ -75,13 +75,22 @@ export function tameMetering() {
     let targetIsConstructor = false;
 
     // Without this ErrorConstructor hack, SES pre-0.8 fails with:
-    // TypeError: prototype function Error() { [native code] } of unknown.global.EvalError is not already in the fringeSet
-    // This is due to an ordering constraint between when SES-pre-0.8 captures the intrinsics versus when it runs the shims.
+    // TypeError: prototype function Error() { [native code] } of
+    //   unknown.global.EvalError is not already in the fringeSet
+    // This is due to an ordering constraint between when SES-pre-0.8
+    // captures the intrinsics versus when it runs the shims.
     //
-    // SES 0.8 and later do not have this constraint, since the vetted shims are installed before SES is even imported.
+    // SES 0.8 and later do not have this constraint, since the
+    // vetted shims are installed before SES is even imported.
     //
-    // Not wrapping the Error constructor doesn't cause much of an exposure, although it can be used to allocate large
-    // strings without counting towards the allocation meter.  That's not a problem we're trying to solve yet.
+    // Not wrapping the Error constructor doesn't cause much of an
+    // exposure, although it can be used to hold onto large
+    // strings without counting towards the allocation meter.
+    // That's not a problem we're trying to solve yet.
+    //
+    // Passing through globalEval's identity is alright, too, since
+    // only SES uses it directly, and wraps it with a rewriting
+    // version for user code.
     if (
       typeof target !== 'function' ||
       target === FunctionPrototype ||

--- a/packages/tame-metering/test/test-sanity.js
+++ b/packages/tame-metering/test/test-sanity.js
@@ -1,0 +1,17 @@
+import '../src/install-global-metering';
+import test from 'tape-promise/tape';
+
+test('symbol properties', t => {
+  t.assert(RegExp[Symbol.species], 'RegExp[Symbol.species] is kept');
+  t.end();
+});
+
+function foo(_bar) {
+  // eslint-disable-next-line no-eval
+  return eval('_bar');
+}
+
+test('direct eval', t => {
+  t.equals(foo(123), 123, 'direct eval succeeds');
+  t.end();
+});


### PR DESCRIPTION
Closes #1180, closes #1179

Ensure that we preserve the `eval` identity so that direct eval continues to work, even in the face of `-r esm`.
