### PR TITLE
feat: further along the path of state export and migration

### DIFF
--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -81,7 +81,7 @@ scenario2-setup-nobuild:
 	mkdir t1/bootstrap
 	$(AGCH) --home=t1/bootstrap keys add bootstrap --keyring-backend=test
 	$(AGCH) --home=t1/bootstrap keys show -a bootstrap --keyring-backend=test > t1/bootstrap-address
-	$(AGC) --home=t1/n0 add-genesis-account `cat t1/bootstrap-address` 100000000uagstake
+	$(AGC) --home=t1/n0 add-genesis-account `cat t1/bootstrap-address` 100000000uagstake,100provisionpass,100sendpacketpass
 	# Create the (singleton) chain node.
 	$(AGC) --home=t1/n0 gentx --keyring-backend=test --home-client=t1/bootstrap --name=bootstrap --amount=1000000uagstake
 	$(AGC) --home=t1/n0 collect-gentxs
@@ -91,17 +91,19 @@ scenario2-setup-nobuild:
 	$(MAKE) set-local-gci-ingress
 
 scenario2-run-chain:
-	ROLE=two_chain BOOT_ADDRESS=`cat t1/bootstrap-address` $(NODE_DEBUG) \
+	ROLE=two_chain $(NODE_DEBUG) \
 	  `$(BREAK_CHAIN) && echo --inspect-brk` $(AGC) --home=t1/n0 start --pruning=nothing
 
 # Provision and start a client.
 scenario2-run-client: t1-provision-one t1-start-ag-solo
 
-# Provision the ag-solo from the bootstrap address (idempotent).
+# Provision the ag-solo from an provisionpass-holding address (idempotent).
 t1-provision-one:
-	$(AGCH) --home=t1/bootstrap tx swingset provision-one --keyring-backend=test --from=bootstrap \
-		--gas=auto --gas-adjustment=1.2 --broadcast-mode=block --yes --chain-id=$(CHAIN_ID) \
-		t1/$(BASE_PORT) `cat t1/$(BASE_PORT)/ag-cosmos-helper-address`
+	addr=$$(cat t1/$(BASE_PORT)/ag-cosmos-helper-address); \
+	  $(AGCH) --home=t1/bootstrap query swingset egress $$addr --chain-id=$(CHAIN_ID) || \
+	  $(AGCH) --home=t1/bootstrap tx swingset provision-one --keyring-backend=test --from=bootstrap \
+		  --gas=auto --gas-adjustment=1.3 --broadcast-mode=block --yes --chain-id=$(CHAIN_ID) \
+		  t1/$(BASE_PORT) $$addr | tee /dev/stderr | grep -q 'code: 0'
 
 # Actually start the ag-solo.
 t1-start-ag-solo:

--- a/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
@@ -159,11 +159,7 @@ export default function setup(syscall, state, helpers) {
         });
       }
 
-      async function registerNetworkProtocols(
-        vats,
-        bridgeMgr,
-        packetSendersWhitelist = [],
-      ) {
+      async function registerNetworkProtocols(vats, bridgeMgr) {
         const ps = [];
         // Every vat has a loopback device.
         ps.push(
@@ -183,10 +179,7 @@ export default function setup(syscall, state, helpers) {
               });
             },
           });
-          const ibcHandler = await E(vats.ibc).createInstance(
-            callbacks,
-            packetSendersWhitelist,
-          );
+          const ibcHandler = await E(vats.ibc).createInstance(callbacks);
           bridgeMgr.register('dibc', ibcHandler);
           ps.push(
             E(vats.network).registerProtocolHandler(
@@ -313,8 +306,6 @@ export default function setup(syscall, state, helpers) {
             devices.bridge && makeBridgeManager(E, D, devices.bridge);
           const [ROLE, bootAddress, additionalAddresses] = parseArgs(argv);
 
-          const pswl = [bootAddress, ...additionalAddresses];
-
           async function addRemote(addr) {
             const { transmitter, setReceiver } = await E(vats.vattp).addRemote(
               addr,
@@ -350,7 +341,7 @@ export default function setup(syscall, state, helpers) {
               );
 
               // Must occur after makeChainBundler.
-              await registerNetworkProtocols(vats, bridgeManager, pswl);
+              await registerNetworkProtocols(vats, bridgeManager);
 
               if (FIXME_DEPRECATED_BOOT_ADDRESS && bootAddress) {
                 // accept provisioning requests from the controller
@@ -379,7 +370,7 @@ export default function setup(syscall, state, helpers) {
                 throw new Error(`controller must be given GCI`);
               }
 
-              await registerNetworkProtocols(vats, bridgeManager, pswl);
+              await registerNetworkProtocols(vats, bridgeManager);
 
               // Wire up the http server.
               await setupCommandDevice(vats.http, devices.command, {
@@ -410,7 +401,7 @@ export default function setup(syscall, state, helpers) {
               const localTimerService = await E(vats.timer).createTimerService(
                 devices.timer,
               );
-              await registerNetworkProtocols(vats, bridgeManager, pswl);
+              await registerNetworkProtocols(vats, bridgeManager);
 
               await setupCommandDevice(vats.http, devices.command, {
                 client: true,
@@ -451,7 +442,7 @@ export default function setup(syscall, state, helpers) {
                 vats.vattp,
               );
 
-              await registerNetworkProtocols(vats, bridgeManager, pswl);
+              await registerNetworkProtocols(vats, bridgeManager);
               if (FIXME_DEPRECATED_BOOT_ADDRESS && bootAddress) {
                 const demoProvider = harden({
                   // build a chain-side bundle for a client.
@@ -481,7 +472,7 @@ export default function setup(syscall, state, helpers) {
               const localTimerService = await E(vats.timer).createTimerService(
                 devices.timer,
               );
-              await registerNetworkProtocols(vats, bridgeManager, pswl);
+              await registerNetworkProtocols(vats, bridgeManager);
               await addRemote(GCI);
               // addEgress(..., PROVISIONER_INDEX) is called in case two_chain
               const demoProvider = E(vats.comms).addIngress(
@@ -510,7 +501,7 @@ export default function setup(syscall, state, helpers) {
 
               // We pretend we're on-chain.
               const chainBundler = makeChainBundler(vats, devices.timer);
-              await registerNetworkProtocols(vats, bridgeManager, pswl);
+              await registerNetworkProtocols(vats, bridgeManager);
 
               // Shared Setup (virtual chain side) ///////////////////////////
               await setupCommandDevice(vats.http, devices.command, {

--- a/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
@@ -12,6 +12,12 @@ import { makeBridgeManager } from './bridge';
 
 const NUM_IBC_PORTS = 3;
 
+// The old way of provisioning used an environment variable that
+// was an account ACL.  The new way uses "provisionpass", a
+// "bearer token" that is checked in handler.go before a provision
+// transaction is even sent to the JS side.
+const FIXME_DEPRECATED_BOOT_ADDRESS = true;
+
 console.debug(`loading bootstrap.js`);
 
 function parseArgs(argv) {
@@ -214,9 +220,6 @@ export default function setup(syscall, state, helpers) {
             async fromBridge(_srcID, obj) {
               switch (obj.type) {
                 case 'PLEASE_PROVISION': {
-                  if (!packetSendersWhitelist.includes(obj.submitter)) {
-                    throw Error('Permission denied');
-                  }
                   const { nickname, address } = obj;
                   return E(vats.provisioning)
                     .pleaseProvision(nickname, address, PROVISIONER_INDEX)
@@ -321,7 +324,7 @@ export default function setup(syscall, state, helpers) {
 
           D(devices.mailbox).registerInboundHandler(vats.vattp);
           await E(vats.vattp).registerMailboxDevice(devices.mailbox);
-          if (bootAddress) {
+          if (FIXME_DEPRECATED_BOOT_ADDRESS && bootAddress) {
             // FIXME: The old way: register egresses for the addresses.
             await Promise.all(
               [bootAddress, ...additionalAddresses].map(addr =>
@@ -349,23 +352,25 @@ export default function setup(syscall, state, helpers) {
               // Must occur after makeChainBundler.
               await registerNetworkProtocols(vats, bridgeManager, pswl);
 
-              // accept provisioning requests from the controller
-              const provisioner = harden({
-                pleaseProvision(nickname, pubkey) {
-                  console.debug('Provisioning', nickname, pubkey);
-                  return E(vats.provisioning).pleaseProvision(
-                    nickname,
-                    pubkey,
-                    PROVISIONER_INDEX,
-                  );
-                },
-              });
-              // bootAddress holds the pubkey of controller
-              await E(vats.comms).addEgress(
-                bootAddress,
-                KEY_REG_INDEX,
-                provisioner,
-              );
+              if (FIXME_DEPRECATED_BOOT_ADDRESS && bootAddress) {
+                // accept provisioning requests from the controller
+                const provisioner = harden({
+                  pleaseProvision(nickname, pubkey) {
+                    console.debug('Provisioning', nickname, pubkey);
+                    return E(vats.provisioning).pleaseProvision(
+                      nickname,
+                      pubkey,
+                      PROVISIONER_INDEX,
+                    );
+                  },
+                });
+                // bootAddress holds the pubkey of controller
+                await E(vats.comms).addEgress(
+                  bootAddress,
+                  KEY_REG_INDEX,
+                  provisioner,
+                );
+              }
               break;
             }
             case 'controller':
@@ -447,22 +452,23 @@ export default function setup(syscall, state, helpers) {
               );
 
               await registerNetworkProtocols(vats, bridgeManager, pswl);
-
-              const demoProvider = harden({
-                // build a chain-side bundle for a client.
-                async getDemoBundle(nickname) {
-                  return chainBundler.createUserBundle(nickname);
-                },
-              });
-              await Promise.all(
-                [bootAddress, ...additionalAddresses].map(addr =>
-                  E(vats.comms).addEgress(
-                    addr,
-                    PROVISIONER_INDEX,
-                    demoProvider,
+              if (FIXME_DEPRECATED_BOOT_ADDRESS && bootAddress) {
+                const demoProvider = harden({
+                  // build a chain-side bundle for a client.
+                  async getDemoBundle(nickname) {
+                    return chainBundler.createUserBundle(nickname);
+                  },
+                });
+                await Promise.all(
+                  [bootAddress, ...additionalAddresses].map(addr =>
+                    E(vats.comms).addEgress(
+                      addr,
+                      PROVISIONER_INDEX,
+                      demoProvider,
+                    ),
                   ),
-                ),
-              );
+                );
+              }
               break;
             }
             case 'two_client': {

--- a/packages/cosmic-swingset/lib/ag-solo/vats/ibc.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/ibc.js
@@ -699,18 +699,7 @@ EOF
         }
 
         case 'sendPacket': {
-          const { packet, sender } = obj;
-          if (!packetSendersWhitelist.includes(sender)) {
-            console.error(
-              sender,
-              'does not appear in the sendPacket whitelist',
-              packetSendersWhitelist,
-            );
-            throw Error(
-              `${sender} does not appear in the sendPacket whitelist`,
-            );
-          }
-
+          const { packet } = obj;
           const { source_port: portID, source_channel: channelID } = packet;
           const channelKey = `${channelID}:${portID}`;
           const seqToAck = channelKeyToSeqAck.get(channelKey);

--- a/packages/cosmic-swingset/lib/ag-solo/vats/ibc.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/ibc.js
@@ -80,14 +80,9 @@ let seed = 0;
  *
  * @param {import('@agoric/eventual-send').EProxy} E
  * @param {(method: string, params: any) => Promise<any>} callIBCDevice
- * @param {string[]} [packetSendersWhitelist=[]]
  * @returns {ProtocolHandler & BridgeHandler} Protocol/Bridge handler
  */
-export function makeIBCProtocolHandler(
-  E,
-  callIBCDevice,
-  packetSendersWhitelist = [],
-) {
+export function makeIBCProtocolHandler(E, callIBCDevice) {
   /**
    * @type {Store<string, Promise<Connection>>}
    */

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-ibc.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-ibc.js
@@ -2,11 +2,10 @@ import harden from '@agoric/harden';
 import { makeIBCProtocolHandler } from './ibc';
 
 function build(E, _log) {
-  function createInstance(callbacks, packetSendersWhitelist = [], powers = {}) {
+  function createInstance(callbacks, powers = {}) {
     const ibcHandler = makeIBCProtocolHandler(
       E,
       (method, params) => E(callbacks).downcall(method, params),
-      packetSendersWhitelist,
       powers,
     );
     return harden(ibcHandler);

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-provisioning.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-provisioning.js
@@ -15,7 +15,7 @@ function build(E) {
   }
 
   async function pleaseProvision(nickname, pubkey) {
-    const chainBundle = E(bundler).createUserBundle(nickname);
+    let chainBundle;
     const fetch = harden({
       getDemoBundle() {
         return chainBundle;
@@ -28,6 +28,10 @@ function build(E) {
 
     const INDEX = 1;
     await E(comms).addEgress(pubkey, INDEX, fetch);
+
+    // Do this here so that any side-effects don't happen unless
+    // the egress has been successfully added.
+    chainBundle = E(bundler).createUserBundle(nickname);
     return { ingressIndex: INDEX };
   }
 

--- a/packages/cosmic-swingset/lib/chain-main.js
+++ b/packages/cosmic-swingset/lib/chain-main.js
@@ -201,25 +201,25 @@ export default async function main(progname, args, { path, env, agcc }) {
 
   let blockManager;
   async function toSwingSet(action, _replier) {
-    // console.log(`toSwingSet`, action, replier);
-    if (action.type === AG_COSMOS_INIT) {
-      // console.error('got AG_COSMOS_INIT', action);
-      if (!process.env.BOOT_ADDRESS) {
-        throw Error(`You must set $BOOT_ADDRESS to run a chain node`);
-      }
+    // console.log(`toSwingSet`, action);
+    if (action.ibcPort) {
       portNums.dibc = action.ibcPort;
-      return true;
     }
 
     if (action.storagePort) {
       // Initialize the storage for this particular transaction.
       // console.log(` setting portNums.storage to`, action.storagePort);
       portNums.storage = action.storagePort;
+    }
 
-      if (!blockManager) {
-        const fns = await launchAndInitializeSwingSet();
-        blockManager = makeBlockManager(fns);
-      }
+    if (!blockManager) {
+      const fns = await launchAndInitializeSwingSet();
+      blockManager = makeBlockManager(fns);
+    }
+
+    if (action.type === AG_COSMOS_INIT) {
+      // console.error('got AG_COSMOS_INIT', action);
+      return true;
     }
 
     return blockManager(action);

--- a/packages/cosmic-swingset/lib/daemon/main.go
+++ b/packages/cosmic-swingset/lib/daemon/main.go
@@ -105,7 +105,7 @@ func makeNewApp(sendToController Sender) func(logger log.Logger, db dbm.DB, trac
 		}
 
 		// fmt.Println("Starting daemon!")
-		abci := app.NewAgoricApp(
+		return app.NewAgoricApp(
 			sendToController, logger, db, traceStore, true, invCheckPeriod, skipUpgradeHeights,
 			viper.GetString(flags.FlagHome),
 			baseapp.SetPruning(store.NewPruningOptionsFromString(viper.GetString("pruning"))),
@@ -114,16 +114,6 @@ func makeNewApp(sendToController Sender) func(logger log.Logger, db dbm.DB, trac
 			baseapp.SetHaltTime(viper.GetUint64(server.FlagHaltTime)),
 			baseapp.SetInterBlockCache(cache),
 		)
-		msg := fmt.Sprintf(`{"type":"AG_COSMOS_INIT","ibcPort":%d}`, abci.IBCPort)
-
-		// fmt.Println("Sending to Node", msg)
-		_, err := sendToController(true, msg)
-		// fmt.Println("Received AG_COSMOS_INIT response", ret, err)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "Cannot initialize Controller", err)
-			os.Exit(1)
-		}
-		return abci
 	}
 }
 

--- a/packages/cosmic-swingset/lib/launch-chain.js
+++ b/packages/cosmic-swingset/lib/launch-chain.js
@@ -154,7 +154,7 @@ export async function launch(
   }
 
   const [savedHeight, savedActions] = JSON.parse(
-    storage.get(SWING_STORE_META_KEY) || '[0, []]',
+    storage.get(SWING_STORE_META_KEY) || '[-1, []]',
   );
   return {
     deliverInbound,

--- a/packages/cosmic-swingset/x/swingset/alias.go
+++ b/packages/cosmic-swingset/x/swingset/alias.go
@@ -26,6 +26,7 @@ var (
 
 type (
 	Keeper            = keeper.Keeper
+	Egress            = types.Egress
 	MsgDeliverInbound = types.MsgDeliverInbound
 	MsgProvision      = types.MsgProvision
 	MsgSendPacket     = types.MsgSendPacket

--- a/packages/cosmic-swingset/x/swingset/client/cli/query.go
+++ b/packages/cosmic-swingset/x/swingset/client/cli/query.go
@@ -21,12 +21,34 @@ func GetQueryCmd(storeKey string, cdc *codec.Codec) *cobra.Command {
 		RunE:                       client.ValidateCmd,
 	}
 	swingsetQueryCmd.AddCommand(flags.GetCommands(
+		GetCmdGetEgress(storeKey, cdc),
 		GetCmdGetStorage(storeKey, cdc),
 		GetCmdGetKeys(storeKey, cdc),
 		GetCmdMailbox(storeKey, cdc),
 	)...)
 
 	return swingsetQueryCmd
+}
+
+func GetCmdGetEgress(queryRoute string, cdc *codec.Codec) *cobra.Command {
+	return &cobra.Command{
+		Use:   "egress [account]",
+		Short: "get egress nickname for account",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+			bech32 := args[0]
+
+			res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/egress/%s", queryRoute, bech32), nil)
+			if err != nil {
+				return err
+			}
+
+			var out types.QueryResEgress
+			cdc.MustUnmarshalJSON(res, &out)
+			return cliCtx.PrintOutput(out)
+		},
+	}
 }
 
 // GetCmdGetStorage queries information about storage

--- a/packages/cosmic-swingset/x/swingset/client/rest/query.go
+++ b/packages/cosmic-swingset/x/swingset/client/rest/query.go
@@ -11,6 +11,21 @@ import (
 	"github.com/gorilla/mux"
 )
 
+func getEgressHandler(cliCtx context.CLIContext, storeName string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		paramType := vars[peerName]
+
+		res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/egress/%s", storeName, paramType), nil)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusNotFound, err.Error())
+			return
+		}
+
+		rest.PostProcessResponse(w, cliCtx, res)
+	}
+}
+
 func getStorageHandler(cliCtx context.CLIContext, storeName string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)

--- a/packages/cosmic-swingset/x/swingset/client/rest/rest.go
+++ b/packages/cosmic-swingset/x/swingset/client/rest/rest.go
@@ -9,16 +9,17 @@ import (
 )
 
 const (
-	pathName = "storage"
+	pathName = "path"
 	keysName = "keys"
 	peerName = "peer"
 )
 
 // RegisterRoutes - Central function to define routes that get registered by the main application
 func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, storeName string) {
+	r.HandleFunc(fmt.Sprintf("/%s/egress/{%s}", storeName, peerName), getEgressHandler(cliCtx, storeName)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/%s/mailbox/{%s}", storeName, peerName), getMailboxHandler(cliCtx, storeName)).Methods("GET")
 	r.HandleFunc(fmt.Sprintf("/%s/mailbox", storeName), deliverMailboxHandler(cliCtx)).Methods("POST")
 	r.HandleFunc(fmt.Sprintf("/%s/storage/{%s}", storeName, pathName), getStorageHandler(cliCtx, storeName)).Methods("GET")
-	r.HandleFunc(fmt.Sprintf("/%s/keys/{%s}", storeName, keysName), getKeysHandler(cliCtx, keysName)).Methods("GET")
-	r.HandleFunc(fmt.Sprintf("/%s/keys", storeName), getKeysHandler(cliCtx, keysName)).Methods("GET")
+	r.HandleFunc(fmt.Sprintf("/%s/keys/{%s}", storeName, keysName), getKeysHandler(cliCtx, storeName)).Methods("GET")
+	r.HandleFunc(fmt.Sprintf("/%s/keys", storeName), getKeysHandler(cliCtx, storeName)).Methods("GET")
 }

--- a/packages/cosmic-swingset/x/swingset/genesis.go
+++ b/packages/cosmic-swingset/x/swingset/genesis.go
@@ -3,38 +3,83 @@ package swingset
 import (
 	// "fmt"
 
+	"encoding/json"
+	"fmt"
+
+	"github.com/Agoric/agoric-sdk/packages/cosmic-swingset/x/swingset/internal/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	abci "github.com/tendermint/tendermint/abci/types"
 )
 
 type GenesisState struct {
 	// TODO: Provisioning records
-	PubKeys []string `json:"swingset_pubkeys"`
+	Egresses []types.Egress `json:"egresses"`
 }
 
 func NewGenesisState() GenesisState {
 	return GenesisState{
-		PubKeys: []string{},
+		Egresses: []types.Egress{},
 	}
 }
 
 func ValidateGenesis(data GenesisState) error {
+	for _, egress := range data.Egresses {
+		if egress.Peer.Empty() {
+			return fmt.Errorf("empty peer for egress nicknamed %s", egress.Nickname)
+		}
+	}
 	return nil
 }
 
 func DefaultGenesisState() GenesisState {
 	return GenesisState{
-		PubKeys: []string{},
+		Egresses: []types.Egress{},
 	}
 }
 
 func InitGenesis(ctx sdk.Context, keeper Keeper, data GenesisState) []abci.ValidatorUpdate {
-	return []abci.ValidatorUpdate{}
+	for _, egress := range data.Egresses {
+		msg := MsgProvision{
+			Address:  egress.Peer,
+			Nickname: egress.Nickname,
+		}
+		action := &provisionAction{
+			MsgProvision: msg,
+			Type:         "PLEASE_PROVISION",
+			BlockHeight:  ctx.BlockHeight(),
+			BlockTime:    ctx.BlockTime().Unix(),
+		}
+
+		// fmt.Fprintf(os.Stderr, "Context is %+v\n", ctx)
+		b, err := json.Marshal(action)
+		if err != nil {
+			continue
+		}
+
+		// Reproduce the egress in our state.
+		egress := types.NewEgress(msg.Nickname, msg.Address)
+		err = keeper.SetEgress(ctx, egress)
+		if err != nil {
+			panic(err)
+		}
+
+		_, err = keeper.CallToController(ctx, string(b))
+		// fmt.Fprintln(os.Stderr, "Returned from SwingSet", out, err)
+		if err != nil {
+			panic(err)
+		}
+	}
+	// Flush the genesis transactions.
+	valup, err := EndBlock(ctx, abci.RequestEndBlock{}, keeper)
+	if err != nil {
+		panic(err)
+	}
+	return valup
 }
 
 func ExportGenesis(ctx sdk.Context, k Keeper) GenesisState {
 	// TODO: Preserve the SwingSet transcript
-	return GenesisState{
-		PubKeys: []string{},
-	}
+	gs := NewGenesisState()
+	gs.Egresses = k.ExportEgresses(ctx)
+	return gs
 }

--- a/packages/cosmic-swingset/x/swingset/internal/keeper/querier.go
+++ b/packages/cosmic-swingset/x/swingset/internal/keeper/querier.go
@@ -1,19 +1,21 @@
 package keeper
 
 import (
+	"fmt"
 	"strings"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-  sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	"github.com/Agoric/agoric-sdk/packages/cosmic-swingset/x/swingset/internal/types"
 )
 
 // query endpoints supported by the swingset Querier
 const (
+	QueryEgress  = "egress"
 	QueryMailbox = "mailbox"
 	QueryStorage = "storage"
 	QueryKeys    = "keys"
@@ -23,6 +25,8 @@ const (
 func NewQuerier(keeper Keeper) sdk.Querier {
 	return func(ctx sdk.Context, path []string, req abci.RequestQuery) (res []byte, err error) {
 		switch path[0] {
+		case QueryEgress:
+			return queryEgress(ctx, path[1], req, keeper)
 		case QueryStorage:
 			return queryStorage(ctx, strings.Join(path[1:], "/"), req, keeper)
 		case QueryKeys:
@@ -33,6 +37,26 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 			return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, "unknown swingset query endpoint")
 		}
 	}
+}
+
+// nolint: unparam
+func queryEgress(ctx sdk.Context, bech32 string, req abci.RequestQuery, keeper Keeper) ([]byte, error) {
+	acc, err := sdk.AccAddressFromBech32(bech32)
+	if err != nil {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, err.Error())
+	}
+
+	egress := keeper.GetEgress(ctx, acc)
+	if egress.Peer.Empty() {
+		return []byte{}, fmt.Errorf("egress %s not found", bech32)
+	}
+
+	bz, err := codec.MarshalJSONIndent(keeper.cdc, types.QueryResEgress{egress.Nickname})
+	if err != nil {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+	}
+
+	return bz, nil
 }
 
 // nolint: unparam

--- a/packages/cosmic-swingset/x/swingset/internal/types/key.go
+++ b/packages/cosmic-swingset/x/swingset/internal/types/key.go
@@ -9,6 +9,7 @@ const (
 )
 
 var (
-	DataPrefix = []byte(StoreKey + "/data")
-	KeysPrefix = []byte(StoreKey + "/keys")
+	DataPrefix   = []byte(StoreKey + "/data")
+	KeysPrefix   = []byte(StoreKey + "/keys")
+	EgressPrefix = []byte(StoreKey + "/egress")
 )

--- a/packages/cosmic-swingset/x/swingset/internal/types/querier.go
+++ b/packages/cosmic-swingset/x/swingset/internal/types/querier.go
@@ -1,6 +1,16 @@
 package types
 
-import "encoding/json"
+import (
+	"encoding/json"
+)
+
+type QueryResEgress struct {
+	Nickname string `json:"nickname"`
+}
+
+func (r QueryResEgress) String() string {
+	return r.Nickname
+}
 
 // Query Result Payload for a storage query
 type QueryResStorage struct {

--- a/packages/cosmic-swingset/x/swingset/internal/types/types.go
+++ b/packages/cosmic-swingset/x/swingset/internal/types/types.go
@@ -3,9 +3,23 @@ package types
 import (
 	"encoding/json"
 	"errors"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 const EmptyMailboxValue = `"{\"outbox\":[], \"ack\":0}"`
+
+type Egress struct {
+	Nickname string         `json:"nickname"`
+	Peer     sdk.AccAddress `json:"peer"`
+}
+
+func NewEgress(nickname string, peer sdk.AccAddress) Egress {
+	return Egress{
+		Nickname: nickname,
+		Peer:     peer,
+	}
+}
 
 type Storage struct {
 	Value string `json:"value"`

--- a/packages/deployment/set-json.js
+++ b/packages/deployment/set-json.js
@@ -12,6 +12,7 @@ const assigns = sargs.reduce((prior, assign) => {
     prior.push(
       `app_state.auth.params.tx_size_cost_per_byte="1"`,
       `app_state.staking.params.bond_denom="uagstake"`,
+      `consensus_params.block.time_iota_ms="1000"`,
     );
   } else {
     prior.push(assign);


### PR DESCRIPTION
Refs #1183 

This is not a complete PR in-and-of-itself, but it is a step further to proper chain state export and migration to a new chainID (i.e. starting over from block 0 with state from a different chain).

Accomplished in this PR:
- Introduce `provisionpass` and `sendpacketpass` tokens, so that holding > 1 of them is a "bearer token" that enables you to send `tx swingset provision-one` and `tx swingset send-packet` transactions respectively.  Not really ocaps, but better than ACLs.
- Deprecate the old ACL for provisioning/sendPacket via BOOT_ADDRESS and additionalAddresses.  This will not be fully removed until it really is no longer used.
- Add a `query swingset egress` command to find the nickname associated with an egress (if any)
- Initialise the controller (i.e. Node.js SwingSet) on genesis init or first proposed block, whichever comes first.
- Accommodate running transactions in the genesis init
- Work around missing `consensus_state.block.time_iota_ms` from exported genesis.json