### PR TITLE
Remove loopbox device from Zoe tests

### DIFF
--- a/packages/zoe/test/swingsetTests/zoe-metering/test-zoe-metering.js
+++ b/packages/zoe/test/swingsetTests/zoe-metering/test-zoe-metering.js
@@ -29,10 +29,6 @@ const generateBundlesP = Promise.all(
 async function main(basedir, withSES, argv) {
   const dir = path.resolve('test/swingsetTests', basedir);
   const config = await loadBasedir(dir);
-  const ldSrcPath = require.resolve(
-    '@agoric/swingset-vat/src/devices/loopbox-src',
-  );
-  config.devices = [['loopbox', ldSrcPath, {}]];
   await generateBundlesP;
   const controller = await buildVatController(config, withSES, argv);
   await controller.run();

--- a/packages/zoe/test/swingsetTests/zoe/test-zoe.js
+++ b/packages/zoe/test/swingsetTests/zoe/test-zoe.js
@@ -32,10 +32,6 @@ const generateBundlesP = Promise.all(
 async function main(withSES, basedir, argv) {
   const dir = path.resolve('test/swingsetTests', basedir);
   const config = await loadBasedir(dir);
-  const ldSrcPath = require.resolve(
-    '@agoric/swingset-vat/src/devices/loopbox-src',
-  );
-  config.devices = [['loopbox', ldSrcPath, {}]];
   await generateBundlesP;
   const controller = await buildVatController(config, withSES, argv);
   await controller.run();


### PR DESCRIPTION
Removed the loopbox device from the Zoe tests, which neither use nor need it.  (Motivated by desire to use this code in swingset-runner which doesn't have a loopbox device.)