### PR TITLE
chore: improve display of invites and amounts generally

### DIFF
--- a/packages/cosmic-swingset/test/unitTests/test-lib-wallet.js
+++ b/packages/cosmic-swingset/test/unitTests/test-lib-wallet.js
@@ -135,7 +135,7 @@ test('lib-wallet issuer and purse methods', async t => {
       `returns petname and brandRegKey`,
     );
     t.deepEquals(pursesStateChangeLog, [
-      '[{"issuerPetname":"moola","brandRegKey":"fakeRegKeyMoola","pursePetname":"fun money","extent":0}]',
+      '[{"issuerPetname":"moola","brandRegKey":"fakeRegKeyMoola","pursePetname":"fun money","extent":0,"currentAmountSlots":{"body":"{\\"brand\\":{\\"@qclass\\":\\"slot\\",\\"index\\":0},\\"extent\\":0}","slots":[{"kind":"brand","petname":"moola"}]},"currentAmount":{"brand":{"kind":"brand","petname":"moola"},"extent":0}}]',
     ]);
     t.deepEquals(inboxStateChangeLog, []);
   } catch (e) {
@@ -247,10 +247,10 @@ test('lib-wallet offer methods', async t => {
     t.deepEquals(
       pursesStateChangeLog,
       [
-        '[{"issuerPetname":"moola","brandRegKey":"moolabrand_2059","pursePetname":"Fun budget","extent":0}]',
-        '[{"issuerPetname":"moola","brandRegKey":"moolabrand_2059","pursePetname":"Fun budget","extent":100}]',
-        '[{"issuerPetname":"moola","brandRegKey":"moolabrand_2059","pursePetname":"Fun budget","extent":99}]',
-        '[{"issuerPetname":"moola","brandRegKey":"moolabrand_2059","pursePetname":"Fun budget","extent":100}]',
+        '[{"issuerPetname":"moola","brandRegKey":"moolabrand_2059","pursePetname":"Fun budget","extent":0,"currentAmountSlots":{"body":"{\\"brand\\":{\\"@qclass\\":\\"slot\\",\\"index\\":0},\\"extent\\":0}","slots":[{"kind":"brand","petname":"moola"}]},"currentAmount":{"brand":{"kind":"brand","petname":"moola"},"extent":0}}]',
+        '[{"issuerPetname":"moola","brandRegKey":"moolabrand_2059","pursePetname":"Fun budget","extent":100,"currentAmountSlots":{"body":"{\\"brand\\":{\\"@qclass\\":\\"slot\\",\\"index\\":0},\\"extent\\":100}","slots":[{"kind":"brand","petname":"moola"}]},"currentAmount":{"brand":{"kind":"brand","petname":"moola"},"extent":100}}]',
+        '[{"issuerPetname":"moola","brandRegKey":"moolabrand_2059","pursePetname":"Fun budget","extent":99,"currentAmountSlots":{"body":"{\\"brand\\":{\\"@qclass\\":\\"slot\\",\\"index\\":0},\\"extent\\":99}","slots":[{"kind":"brand","petname":"moola"}]},"currentAmount":{"brand":{"kind":"brand","petname":"moola"},"extent":99}}]',
+        '[{"issuerPetname":"moola","brandRegKey":"moolabrand_2059","pursePetname":"Fun budget","extent":100,"currentAmountSlots":{"body":"{\\"brand\\":{\\"@qclass\\":\\"slot\\",\\"index\\":0},\\"extent\\":100}","slots":[{"kind":"brand","petname":"moola"}]},"currentAmount":{"brand":{"kind":"brand","petname":"moola"},"extent":100}}]',
       ],
       `purses state change log`,
     );

--- a/packages/wallet-frontend/src/components/Amount.jsx
+++ b/packages/wallet-frontend/src/components/Amount.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+import {
+  List,
+  ListItem,
+  ListItemText,
+} from '@material-ui/core';
+
+const displayNonfungible = amount => {
+  const { brand, extent } = amount;
+
+  // TODO: base this on brandBoardId instead since petnames can change
+  if (brand.petname === 'zoe invite') {
+    if (extent.length === 0) {
+      return `"${brand.petname}" purse is empty.`;
+    }
+    const elems = extent.map(elem => {
+      return {
+        instance: elem.instanceHandle.petname,
+        inviteDesc: elem.inviteDesc,
+      };
+    });
+    return (
+      <div>
+        <b> 
+{' '}
+{brand.petname} (Non-fungible)</b>
+        <List>
+          {elems.map(({ instance, inviteDesc }) => (
+            <ListItem key={inviteDesc} value={inviteDesc} divider>
+              <ListItemText
+                primary={`instance: ${instance}`}
+                secondary={`inviteDesc: ${inviteDesc}`}
+              />
+            </ListItem>
+          ))}
+        </List>
+      </div>
+    );
+  }
+  return (
+    <div>
+      <b>
+{brand.petname} (Non-fungible)</b>
+      <List>
+        {extent.map(elem => (
+          <ListItem key={JSON.stringify(elem)} divider>
+            <ListItemText primary={JSON.stringify(elem)} />
+          </ListItem>
+        ))}
+      </List>
+    </div>
+  );
+};
+
+export default function Amount({ amount }) {
+  return (
+    <>
+      {Array.isArray(amount.extent) ? (
+        displayNonfungible(amount)
+      ) : (
+        <b>
+          {' '}
+          {amount.extent} 
+{' '}
+{amount.brand.petname}
+        </b>
+      )}
+    </>
+  );
+}

--- a/packages/wallet-frontend/src/components/Amount.jsx
+++ b/packages/wallet-frontend/src/components/Amount.jsx
@@ -12,7 +12,7 @@ const displayNonfungible = amount => {
   // TODO: base this on brandBoardId instead since petnames can change
   if (brand.petname === 'zoe invite') {
     if (extent.length === 0) {
-      return `"${brand.petname}" purse is empty.`;
+      return `${JSON.stringify(brand.petname)} purse is empty.`;
     }
     const elems = extent.map(elem => {
       return {

--- a/packages/wallet-frontend/src/components/Purses.jsx
+++ b/packages/wallet-frontend/src/components/Purses.jsx
@@ -37,11 +37,7 @@ export default function Purses() {
               </ListItemIcon>
               <ListItemText
                 primary={pursePetname}
-                secondary={
-                  <>
-                    <Amount amount={currentAmount} />
-                  </>
-                }
+                secondary={<Amount amount={currentAmount} />}
               />
             </ListItem>
           ))}

--- a/packages/wallet-frontend/src/components/Purses.jsx
+++ b/packages/wallet-frontend/src/components/Purses.jsx
@@ -11,6 +11,7 @@ import {
 import PurseIcon from '@material-ui/icons/BusinessCenter';
 
 import { useApplicationContext } from '../contexts/Application';
+import Amount from './Amount';
 
 const useStyles = makeStyles(theme => ({
   icon: {
@@ -29,26 +30,21 @@ export default function Purses() {
       <Typography variant="h6">Purses</Typography>
       {Array.isArray(purses) && purses.length > 0 ? (
         <List>
-          {purses.map(
-            ({ pursePetname, brandRegKey, issuerPetname, extent }) => (
-              <ListItem key={pursePetname} value={pursePetname} divider>
-                <ListItemIcon className={classes.icon}>
-                  <PurseIcon />
-                </ListItemIcon>
-                <ListItemText
-                  primary={pursePetname}
-                  secondary={
-                    <>
-                      <b>
-                        {JSON.stringify(extent)} {issuerPetname}
-                      </b>{' '}
-                      {brandRegKey ? <i>({brandRegKey})</i> : ''}
-                    </>
-                  }
-                />
-              </ListItem>
-            ),
-          )}
+          {purses.map(({ pursePetname, currentAmount }) => (
+            <ListItem key={pursePetname} value={pursePetname} divider>
+              <ListItemIcon className={classes.icon}>
+                <PurseIcon />
+              </ListItemIcon>
+              <ListItemText
+                primary={pursePetname}
+                secondary={
+                  <>
+                    <Amount amount={currentAmount} />
+                  </>
+                }
+              />
+            </ListItem>
+          ))}
         </List>
       ) : (
         <Typography color="inherit">No purses.</Typography>


### PR DESCRIPTION
This PR improves the display of amounts in the wallet, while maintaining backwards-compatibility.

Two new properties are added to `pursesState` elements: `currentAmountSlots`, which is the amount put through the `dehydrate` function, so it has `body` and `slot` properties, like:

```
{
          body: '{"handle":{"@qclass":"slot","index":0}}',
          slots: [{ kind: 'instanceHandle', petname: 'autoswap' }],
        }
```
and `currentAmount`, which takes the body and slots and fills the body with the slots to give something like `{ handle:{ kind: 'instanceHandle', petname: 'autoswap' }}`. This is useful for display purposes, but loses data because the special identifier `@qclass` is lost.

On the wallet side, a new Amount.jsx file is added with logic to handle nonfungible extents, and special logic to display the invite extent.

<img width="348" alt="Screen Shot 2020-06-17 at 10 55 23 AM" src="https://user-images.githubusercontent.com/2441069/84932398-15255e00-b089-11ea-983e-4309b155dabf.png">


Please let me know if I'm misusing React or if there are improvements. Thanks!