### PR TITLE
test: make independent of current working directory

### DIFF
--- a/packages/ERTP/test/swingsetTests/splitPayments/test-splitPayments.js
+++ b/packages/ERTP/test/swingsetTests/splitPayments/test-splitPayments.js
@@ -5,7 +5,7 @@ import { loadBasedir, buildVatController } from '@agoric/swingset-vat';
 import path from 'path';
 
 async function main(withSES, basedir, argv) {
-  const dir = path.resolve('test/swingsetTests', basedir);
+  const dir = path.resolve(`${__dirname}/..`, basedir);
   const config = await loadBasedir(dir);
   const ldSrcPath = require.resolve(
     '@agoric/swingset-vat/src/devices/loopbox-src',

--- a/packages/SwingSet/test/vat-admin/test-innerVat.js
+++ b/packages/SwingSet/test/vat-admin/test-innerVat.js
@@ -1,12 +1,10 @@
 import { test } from 'tape';
-import path from 'path';
 import { initSwingStore } from '@agoric/swing-store-simple';
 
 import { buildVatController, loadBasedir } from '../../src';
 
 async function createConfig() {
-  const dir = __dirname;
-  const config = await loadBasedir(dir);
+  const config = await loadBasedir(__dirname);
 
   config.hostStorage = initSwingStore().storage;
   return config;

--- a/packages/SwingSet/test/vat-admin/test-innerVat.js
+++ b/packages/SwingSet/test/vat-admin/test-innerVat.js
@@ -5,7 +5,7 @@ import { initSwingStore } from '@agoric/swing-store-simple';
 import { buildVatController, loadBasedir } from '../../src';
 
 async function createConfig() {
-  const dir = path.resolve('./test/vat-admin');
+  const dir = __dirname;
   const config = await loadBasedir(dir);
 
   config.hostStorage = initSwingStore().storage;

--- a/packages/sharing-service/test/swingsetTests/sharingService/test-sharing.js
+++ b/packages/sharing-service/test/swingsetTests/sharingService/test-sharing.js
@@ -3,7 +3,7 @@ import path from 'path';
 import { buildVatController, loadBasedir } from '@agoric/swingset-vat';
 
 async function main(withSES, basedir, argv) {
-  const dir = path.resolve('test/swingsetTests', basedir);
+  const dir = path.resolve(`${__dirname}/..`, basedir);
   const config = await loadBasedir(dir);
   const ldSrcPath = require.resolve(
     '@agoric/swingset-vat/src/devices/loopbox-src',

--- a/packages/spawner/test/swingsetTests/contractHost/test-contractHost.js
+++ b/packages/spawner/test/swingsetTests/contractHost/test-contractHost.js
@@ -3,7 +3,7 @@ import path from 'path';
 import { buildVatController, loadBasedir } from '@agoric/swingset-vat';
 
 async function main(withSES, basedir, argv) {
-  const dir = path.resolve('test/swingsetTests', basedir);
+  const dir = path.resolve(`${__dirname}/..`, basedir);
   const config = await loadBasedir(dir);
   const ldSrcPath = require.resolve(
     '@agoric/swingset-vat/src/devices/loopbox-src',

--- a/packages/spawner/test/swingsetTests/escrow/test-escrow.js
+++ b/packages/spawner/test/swingsetTests/escrow/test-escrow.js
@@ -3,7 +3,7 @@ import { buildVatController, loadBasedir } from '@agoric/swingset-vat';
 import path from 'path';
 
 async function main(withSES, basedir, argv) {
-  const dir = path.resolve('test/swingsetTests', basedir);
+  const dir = path.resolve(`${__dirname}/..`, basedir);
   const config = await loadBasedir(dir);
   const ldSrcPath = require.resolve(
     '@agoric/swingset-vat/src/devices/loopbox-src',


### PR DESCRIPTION
Several tests relied on being executed from a specific working directory.  They used `path.resolve('...')` to attempt to find a relative directory.  That's the right tool for the job, but failed when running outside the expected working directory.

On Node.js, `__dirname` gives you the parent directory to the current module, and that can be used to reliably find files relative to the module.
