### PR TITLE
docs: add documentation to all Zoe contracts

### DIFF
--- a/packages/zoe/src/contracts/atomicSwap.js
+++ b/packages/zoe/src/contracts/atomicSwap.js
@@ -5,39 +5,49 @@ import harden from '@agoric/harden';
 // Eventually will be importable from '@agoric/zoe-contract-support'
 import { makeZoeHelpers } from '../contractSupport';
 
-/** @typedef {import('../zoe').ContractFacet} ContractFacet */
+/**
+ * Trade one item for another.
+ *
+ * The initial offer is { give: { Asset: A }, want: { Price: B } }.
+ * The outcome from the first offer is an invitation for the second party,
+ * who should offer { give: { Price: B }, want: { Asset: A } }, with a want
+ * amount no greater than the original's give, and a give amount at least as
+ * large as the original's want.
+ *
+ * @typedef {import('../zoe').ContractFacet} ContractFacet
+ * @param {ContractFacet} zcf
+ */
+const makeContract = zcf => {
+  const { swap, assertKeywords, checkHook } = makeZoeHelpers(zcf);
+  assertKeywords(harden(['Asset', 'Price']));
 
-// zcf is the Zoe Contract Facet, i.e. the contract-facing API of Zoe
-export const makeContract = harden(
-  /** @param {ContractFacet} zcf */ zcf => {
-    const { swap, assertKeywords, checkHook } = makeZoeHelpers(zcf);
-    assertKeywords(harden(['Asset', 'Price']));
-
-    const makeMatchingInvite = firstOfferHandle => {
-      const {
-        proposal: { want, give },
-      } = zcf.getOffer(firstOfferHandle);
-
-      return zcf.makeInvitation(
-        offerHandle => swap(firstOfferHandle, offerHandle),
-        'matchOffer',
-        harden({
-          customProperties: {
-            asset: give.Asset,
-            price: want.Price,
-          },
-        }),
-      );
-    };
-
-    const firstOfferExpected = harden({
-      give: { Asset: null },
-      want: { Price: null },
-    });
+  const makeMatchingInvite = firstOfferHandle => {
+    const {
+      proposal: { want, give },
+    } = zcf.getOffer(firstOfferHandle);
 
     return zcf.makeInvitation(
-      checkHook(makeMatchingInvite, firstOfferExpected),
-      'firstOffer',
+      offerHandle => swap(firstOfferHandle, offerHandle),
+      'matchOffer',
+      harden({
+        customProperties: {
+          asset: give.Asset,
+          price: want.Price,
+        },
+      }),
     );
-  },
-);
+  };
+
+  const firstOfferExpected = harden({
+    give: { Asset: null },
+    want: { Price: null },
+  });
+
+  return zcf.makeInvitation(
+    checkHook(makeMatchingInvite, firstOfferExpected),
+    'firstOffer',
+  );
+};
+
+harden(makeContract);
+export { makeContract };

--- a/packages/zoe/src/contracts/automaticRefund.js
+++ b/packages/zoe/src/contracts/automaticRefund.js
@@ -1,8 +1,6 @@
 // @ts-check
 import harden from '@agoric/harden';
 
-/** @typedef {import('../zoe').ContractFacet} ContractFacet */
-
 /**
  * This is a very trivial contract to explain and test Zoe.
  * AutomaticRefund just gives you back what you put in.
@@ -11,27 +9,33 @@ import harden from '@agoric/harden';
  * contracts will use these same steps, but they will have more
  * sophisticated logic and interfaces.
  *
- * @type {import('@agoric/zoe').MakeContract}
+ * Since the contract doesn't attempt any reallocation, the offer can contain
+ * anything in `give` and `want`. The amount in `give` will be returned, and
+ * `want` will be ignored.
+ *
+ * @typedef {import('../zoe').ContractFacet} ContractFacet
+ * @param {ContractFacet} zcf
  */
-export const makeContract = harden(
-  /** @param {ContractFacet} zcf */ zcf => {
-    let offersCount = 0;
+const makeContract = zcf => {
+  let offersCount = 0;
 
-    const refundOfferHook = offerHandle => {
-      offersCount += 1;
-      zcf.complete(harden([offerHandle]));
-      return `The offer was accepted`;
-    };
-    const makeRefundInvite = () =>
-      zcf.makeInvitation(refundOfferHook, 'getRefund');
+  const refundOfferHook = offerHandle => {
+    offersCount += 1;
+    zcf.complete(harden([offerHandle]));
+    return `The offer was accepted`;
+  };
+  const makeRefundInvite = () =>
+    zcf.makeInvitation(refundOfferHook, 'getRefund');
 
-    zcf.initPublicAPI(
-      harden({
-        getOffersCount: () => offersCount,
-        makeInvite: makeRefundInvite,
-      }),
-    );
+  zcf.initPublicAPI(
+    harden({
+      getOffersCount: () => offersCount,
+      makeInvite: makeRefundInvite,
+    }),
+  );
 
-    return makeRefundInvite();
-  },
-);
+  return makeRefundInvite();
+};
+
+harden(makeContract);
+export { makeContract };

--- a/packages/zoe/src/contracts/autoswap.js
+++ b/packages/zoe/src/contracts/autoswap.js
@@ -12,309 +12,314 @@ import {
   makeZoeHelpers,
 } from '../contractSupport';
 
-// Autoswap is a rewrite of Uniswap. Please see the documentation for
-// more https://agoric.com/documentation/zoe/guide/contracts/autoswap.html
-
 /**
+ * Autoswap is a rewrite of Uniswap. Please see the documentation for
+ * more https://agoric.com/documentation/zoe/guide/contracts/autoswap.html
+ *
+ * When the contract is instantiated, the two tokens are specified in the
+ * issuerKeywordRecord. The party that calls makeInstance gets an invitation
+ * to add liquidity. The same invitation is available by calling
+ * `publicAPI.makeAddLiquidityInvite()`. Separate invitations are available for
+ * adding and removing liquidity, and for doing a swap. Other API operations
+ * support monitoring the price and the size of the liquidity pool.
+ *
  * @typedef {import('../zoe').ContractFacet} ContractFacet
+ * @param {ContractFacet} zcf
  */
+const makeContract = zcf => {
+  // Create the liquidity mint and issuer.
+  const { mint: liquidityMint, issuer: liquidityIssuer } = produceIssuer(
+    'liquidity',
+  );
 
-// zcf is the Zoe Contract Facet, i.e. the contract-facing API of Zoe
-export const makeContract = harden(
-  /** @param {ContractFacet} zcf */ zcf => {
-    // Create the liquidity mint and issuer.
-    const { mint: liquidityMint, issuer: liquidityIssuer } = produceIssuer(
-      'liquidity',
-    );
+  let liqTokenSupply = 0;
 
-    let liqTokenSupply = 0;
+  const {
+    checkIfProposal,
+    rejectOffer,
+    makeEmptyOffer,
+    checkHook,
+    escrowAndAllocateTo,
+    assertNatMathHelpers,
+  } = makeZoeHelpers(zcf);
 
-    const {
-      checkIfProposal,
-      rejectOffer,
-      makeEmptyOffer,
-      checkHook,
-      escrowAndAllocateTo,
-      assertNatMathHelpers,
-    } = makeZoeHelpers(zcf);
+  return zcf.addNewIssuer(liquidityIssuer, 'Liquidity').then(() => {
+    const { brandKeywordRecord } = zcf.getInstanceRecord();
+    const amountMaths = {};
+    harden(['TokenA', 'TokenB', 'Liquidity']).forEach(keyword => {
+      const brand = brandKeywordRecord[keyword];
+      assertNatMathHelpers(brand);
+      amountMaths[keyword] = zcf.getAmountMath(brand);
+    });
 
-    return zcf.addNewIssuer(liquidityIssuer, 'Liquidity').then(() => {
-      const { brandKeywordRecord } = zcf.getInstanceRecord();
-      const amountMaths = {};
-      harden(['TokenA', 'TokenB', 'Liquidity']).forEach(keyword => {
-        const brand = brandKeywordRecord[keyword];
-        assertNatMathHelpers(brand);
-        amountMaths[keyword] = zcf.getAmountMath(brand);
+    return makeEmptyOffer().then(poolHandle => {
+      const getPoolAllocation = () =>
+        zcf.getCurrentAllocation(poolHandle, brandKeywordRecord);
+
+      const swap = (offerHandle, giveKeyword, wantKeyword) => {
+        const { proposal } = zcf.getOffer(offerHandle);
+        if (proposal.want.Liquidity !== undefined) {
+          rejectOffer(
+            offerHandle,
+            `A Liquidity amount should not be present in a swap`,
+          );
+        }
+
+        const poolAllocation = getPoolAllocation();
+        const {
+          outputExtent,
+          newInputReserve,
+          newOutputReserve,
+        } = getCurrentPrice(
+          harden({
+            inputExtent: proposal.give[giveKeyword].extent,
+            inputReserve: poolAllocation[giveKeyword].extent,
+            outputReserve: poolAllocation[wantKeyword].extent,
+          }),
+        );
+        const amountOut = amountMaths[wantKeyword].make(outputExtent);
+        const wantedAmount = proposal.want[wantKeyword];
+        const satisfiesWantedAmounts = () =>
+          amountMaths[wantKeyword].isGTE(amountOut, wantedAmount);
+        if (!satisfiesWantedAmounts()) {
+          throw rejectOffer(offerHandle);
+        }
+
+        const newUserAmounts = {
+          Liquidity: amountMaths.Liquidity.getEmpty(),
+        };
+        newUserAmounts[giveKeyword] = amountMaths[giveKeyword].getEmpty();
+        newUserAmounts[wantKeyword] = amountOut;
+
+        const newPoolAmounts = { Liquidity: poolAllocation.Liquidity };
+        newPoolAmounts[giveKeyword] = amountMaths[giveKeyword].make(
+          newInputReserve,
+        );
+        newPoolAmounts[wantKeyword] = amountMaths[wantKeyword].make(
+          newOutputReserve,
+        );
+
+        zcf.reallocate(
+          harden([offerHandle, poolHandle]),
+          harden([newUserAmounts, newPoolAmounts]),
+        );
+        zcf.complete(harden([offerHandle]));
+        return `Swap successfully completed.`;
+      };
+
+      const buyASellB = harden({
+        give: { TokenB: null },
+        want: { TokenA: null },
       });
 
-      return makeEmptyOffer().then(poolHandle => {
-        const getPoolAllocation = () =>
-          zcf.getCurrentAllocation(poolHandle, brandKeywordRecord);
+      const buyBSellA = harden({
+        give: { TokenA: null },
+        want: { TokenB: null },
+      });
 
-        const swap = (offerHandle, giveKeyword, wantKeyword) => {
-          const { proposal } = zcf.getOffer(offerHandle);
-          if (proposal.want.Liquidity !== undefined) {
-            rejectOffer(
-              offerHandle,
-              `A Liquidity amount should not be present in a swap`,
-            );
-          }
+      const swapHook = offerHandle => {
+        assert(
+          !checkIfProposal(offerHandle, { give: { Liquidity: null } }),
+          details`A Liquidity amount should not be present in a swap`,
+        );
+        assert(
+          !checkIfProposal(offerHandle, { want: { Liquidity: null } }),
+          details`A Liquidity amount should not be present in a swap`,
+        );
+        if (checkIfProposal(offerHandle, buyASellB)) {
+          return swap(offerHandle, 'TokenB', 'TokenA');
+          /* eslint-disable no-else-return */
+        } else if (checkIfProposal(offerHandle, buyBSellA)) {
+          return swap(offerHandle, 'TokenA', 'TokenB');
+        } else {
+          // Eject because the offer must be invalid
+          return rejectOffer(offerHandle);
+        }
+      };
 
-          const poolAllocation = getPoolAllocation();
-          const {
-            outputExtent,
-            newInputReserve,
-            newOutputReserve,
-          } = getCurrentPrice(
-            harden({
-              inputExtent: proposal.give[giveKeyword].extent,
-              inputReserve: poolAllocation[giveKeyword].extent,
-              outputReserve: poolAllocation[wantKeyword].extent,
-            }),
-          );
-          const amountOut = amountMaths[wantKeyword].make(outputExtent);
-          const wantedAmount = proposal.want[wantKeyword];
-          const satisfiesWantedAmounts = () =>
-            amountMaths[wantKeyword].isGTE(amountOut, wantedAmount);
-          if (!satisfiesWantedAmounts()) {
-            throw rejectOffer(offerHandle);
-          }
+      const addLiquidityHook = offerHandle => {
+        const userAllocation = zcf.getCurrentAllocation(offerHandle);
+        const poolAllocation = getPoolAllocation();
 
-          const newUserAmounts = {
-            Liquidity: amountMaths.Liquidity.getEmpty(),
-          };
-          newUserAmounts[giveKeyword] = amountMaths[giveKeyword].getEmpty();
-          newUserAmounts[wantKeyword] = amountOut;
-
-          const newPoolAmounts = { Liquidity: poolAllocation.Liquidity };
-          newPoolAmounts[giveKeyword] = amountMaths[giveKeyword].make(
-            newInputReserve,
-          );
-          newPoolAmounts[wantKeyword] = amountMaths[wantKeyword].make(
-            newOutputReserve,
-          );
-
-          zcf.reallocate(
-            harden([offerHandle, poolHandle]),
-            harden([newUserAmounts, newPoolAmounts]),
-          );
-          zcf.complete(harden([offerHandle]));
-          return `Swap successfully completed.`;
-        };
-
-        const buyASellB = harden({
-          give: { TokenB: null },
-          want: { TokenA: null },
-        });
-
-        const buyBSellA = harden({
-          give: { TokenA: null },
-          want: { TokenB: null },
-        });
-
-        const swapHook = offerHandle => {
-          assert(
-            !checkIfProposal(offerHandle, { give: { Liquidity: null } }),
-            details`A Liquidity amount should not be present in a swap`,
-          );
-          assert(
-            !checkIfProposal(offerHandle, { want: { Liquidity: null } }),
-            details`A Liquidity amount should not be present in a swap`,
-          );
-          if (checkIfProposal(offerHandle, buyASellB)) {
-            return swap(offerHandle, 'TokenB', 'TokenA');
-            /* eslint-disable no-else-return */
-          } else if (checkIfProposal(offerHandle, buyBSellA)) {
-            return swap(offerHandle, 'TokenA', 'TokenB');
-          } else {
-            // Eject because the offer must be invalid
-            return rejectOffer(offerHandle);
-          }
-        };
-
-        const addLiquidityHook = offerHandle => {
-          const userAllocation = zcf.getCurrentAllocation(offerHandle);
-          const poolAllocation = getPoolAllocation();
-
-          // Calculate how many liquidity tokens we should be minting.
-          // Calculations are based on the extents represented by TokenA.
-          // If the current supply is zero, start off by just taking the
-          // extent at TokenA and using it as the extent for the
-          // liquidity token.
-          const liquidityExtentOut = calcLiqExtentToMint(
-            harden({
-              liqTokenSupply,
-              inputExtent: userAllocation.TokenA.extent,
-              inputReserve: poolAllocation.TokenA.extent,
-            }),
-          );
-
-          const liquidityAmountOut = amountMaths.Liquidity.make(
-            liquidityExtentOut,
-          );
-
-          const liquidityPaymentP = liquidityMint.mintPayment(
-            liquidityAmountOut,
-          );
-
-          return escrowAndAllocateTo({
-            amount: liquidityAmountOut,
-            payment: liquidityPaymentP,
-            keyword: 'Liquidity',
-            recipientHandle: offerHandle,
-          }).then(() => {
-            liqTokenSupply += liquidityExtentOut;
-
-            const add = (key, obj1, obj2) =>
-              amountMaths[key].add(obj1[key], obj2[key]);
-
-            const newPoolAmounts = harden({
-              TokenA: add('TokenA', userAllocation, poolAllocation),
-              TokenB: add('TokenB', userAllocation, poolAllocation),
-              Liquidity: poolAllocation.Liquidity,
-            });
-
-            const newUserAmounts = harden({
-              TokenA: amountMaths.TokenA.getEmpty(),
-              TokenB: amountMaths.TokenB.getEmpty(),
-              Liquidity: liquidityAmountOut,
-            });
-
-            zcf.reallocate(
-              harden([offerHandle, poolHandle]),
-              harden([newUserAmounts, newPoolAmounts]),
-            );
-            zcf.complete(harden([offerHandle]));
-            return 'Added liquidity.';
-          });
-        };
-
-        const addLiquidityExpected = harden({
-          give: { TokenA: null, TokenB: null },
-          want: { Liquidity: null },
-        });
-
-        const removeLiquidityHook = offerHandle => {
-          const userAllocation = zcf.getCurrentAllocation(offerHandle);
-          const liquidityExtentIn = userAllocation.Liquidity.extent;
-
-          const poolAllocation = getPoolAllocation();
-
-          const newUserTokenAAmount = amountMaths.TokenA.make(
-            calcExtentToRemove(
-              harden({
-                liqTokenSupply,
-                poolExtent: poolAllocation.TokenA.extent,
-                liquidityExtentIn,
-              }),
-            ),
-          );
-          const newUserTokenBAmount = amountMaths.TokenB.make(
-            calcExtentToRemove(
-              harden({
-                liqTokenSupply,
-                poolExtent: poolAllocation.TokenB.extent,
-                liquidityExtentIn,
-              }),
-            ),
-          );
-
-          const newUserAmounts = harden({
-            TokenA: newUserTokenAAmount,
-            TokenB: newUserTokenBAmount,
-            Liquidity: amountMaths.Liquidity.getEmpty(),
-          });
-
-          const newPoolAmounts = harden({
-            TokenA: amountMaths.TokenA.subtract(
-              poolAllocation.TokenA,
-              newUserAmounts.TokenA,
-            ),
-            TokenB: amountMaths.TokenB.subtract(
-              poolAllocation.TokenB,
-              newUserAmounts.TokenB,
-            ),
-            Liquidity: amountMaths.Liquidity.add(
-              poolAllocation.Liquidity,
-              amountMaths.Liquidity.make(liquidityExtentIn),
-            ),
-          });
-
-          liqTokenSupply -= liquidityExtentIn;
-
-          zcf.reallocate(
-            harden([offerHandle, poolHandle]),
-            harden([newUserAmounts, newPoolAmounts]),
-          );
-          zcf.complete(harden([offerHandle]));
-          return 'Liquidity successfully removed.';
-        };
-
-        const removeLiquidityExpected = harden({
-          want: { TokenA: null, TokenB: null },
-          give: { Liquidity: null },
-        });
-
-        const makeAddLiquidityInvite = () =>
-          zcf.makeInvitation(
-            checkHook(addLiquidityHook, addLiquidityExpected),
-            'autoswap add liquidity',
-          );
-
-        zcf.initPublicAPI(
+        // Calculate how many liquidity tokens we should be minting.
+        // Calculations are based on the extents represented by TokenA.
+        // If the current supply is zero, start off by just taking the
+        // extent at TokenA and using it as the extent for the
+        // liquidity token.
+        const liquidityExtentOut = calcLiqExtentToMint(
           harden({
-            /**
-             * `getCurrentPrice` calculates the result of a trade, given a certain amount
-             * of digital assets in.
-             * @param {object} amountInObj - the amount of digital
-             * assets to be sent in, keyed by keyword
-             */
-            getCurrentPrice: amountInObj => {
-              const inKeywords = Object.getOwnPropertyNames(amountInObj);
-              assert(
-                inKeywords.length === 1,
-                details`argument to 'getCurrentPrice' must have one keyword`,
-              );
-              const [inKeyword] = inKeywords;
-              assert(
-                ['TokenA', 'TokenB'].includes(inKeyword),
-                details`keyword ${inKeyword} was not valid`,
-              );
-              const inputExtent = amountMaths[inKeyword].getExtent(
-                amountInObj[inKeyword],
-              );
-              const poolAllocation = getPoolAllocation();
-              const inputReserve = poolAllocation[inKeyword].extent;
-              const outKeyword = inKeyword === 'TokenA' ? 'TokenB' : 'TokenA';
-              const outputReserve = poolAllocation[outKeyword].extent;
-              const { outputExtent } = getCurrentPrice(
-                harden({
-                  inputExtent,
-                  inputReserve,
-                  outputReserve,
-                }),
-              );
-              return amountMaths[outKeyword].make(outputExtent);
-            },
-
-            getLiquidityIssuer: () => liquidityIssuer,
-
-            getPoolAllocation,
-
-            makeSwapInvite: () => zcf.makeInvitation(swapHook, 'autoswap swap'),
-
-            makeAddLiquidityInvite,
-
-            makeRemoveLiquidityInvite: () =>
-              zcf.makeInvitation(
-                checkHook(removeLiquidityHook, removeLiquidityExpected),
-                'autoswap remove liquidity',
-              ),
+            liqTokenSupply,
+            inputExtent: userAllocation.TokenA.extent,
+            inputReserve: poolAllocation.TokenA.extent,
           }),
         );
 
-        return makeAddLiquidityInvite();
+        const liquidityAmountOut = amountMaths.Liquidity.make(
+          liquidityExtentOut,
+        );
+
+        const liquidityPaymentP = liquidityMint.mintPayment(liquidityAmountOut);
+
+        return escrowAndAllocateTo({
+          amount: liquidityAmountOut,
+          payment: liquidityPaymentP,
+          keyword: 'Liquidity',
+          recipientHandle: offerHandle,
+        }).then(() => {
+          liqTokenSupply += liquidityExtentOut;
+
+          const add = (key, obj1, obj2) =>
+            amountMaths[key].add(obj1[key], obj2[key]);
+
+          const newPoolAmounts = harden({
+            TokenA: add('TokenA', userAllocation, poolAllocation),
+            TokenB: add('TokenB', userAllocation, poolAllocation),
+            Liquidity: poolAllocation.Liquidity,
+          });
+
+          const newUserAmounts = harden({
+            TokenA: amountMaths.TokenA.getEmpty(),
+            TokenB: amountMaths.TokenB.getEmpty(),
+            Liquidity: liquidityAmountOut,
+          });
+
+          zcf.reallocate(
+            harden([offerHandle, poolHandle]),
+            harden([newUserAmounts, newPoolAmounts]),
+          );
+          zcf.complete(harden([offerHandle]));
+          return 'Added liquidity.';
+        });
+      };
+
+      const addLiquidityExpected = harden({
+        give: { TokenA: null, TokenB: null },
+        want: { Liquidity: null },
       });
+
+      const removeLiquidityHook = offerHandle => {
+        const userAllocation = zcf.getCurrentAllocation(offerHandle);
+        const liquidityExtentIn = userAllocation.Liquidity.extent;
+
+        const poolAllocation = getPoolAllocation();
+
+        const newUserTokenAAmount = amountMaths.TokenA.make(
+          calcExtentToRemove(
+            harden({
+              liqTokenSupply,
+              poolExtent: poolAllocation.TokenA.extent,
+              liquidityExtentIn,
+            }),
+          ),
+        );
+        const newUserTokenBAmount = amountMaths.TokenB.make(
+          calcExtentToRemove(
+            harden({
+              liqTokenSupply,
+              poolExtent: poolAllocation.TokenB.extent,
+              liquidityExtentIn,
+            }),
+          ),
+        );
+
+        const newUserAmounts = harden({
+          TokenA: newUserTokenAAmount,
+          TokenB: newUserTokenBAmount,
+          Liquidity: amountMaths.Liquidity.getEmpty(),
+        });
+
+        const newPoolAmounts = harden({
+          TokenA: amountMaths.TokenA.subtract(
+            poolAllocation.TokenA,
+            newUserAmounts.TokenA,
+          ),
+          TokenB: amountMaths.TokenB.subtract(
+            poolAllocation.TokenB,
+            newUserAmounts.TokenB,
+          ),
+          Liquidity: amountMaths.Liquidity.add(
+            poolAllocation.Liquidity,
+            amountMaths.Liquidity.make(liquidityExtentIn),
+          ),
+        });
+
+        liqTokenSupply -= liquidityExtentIn;
+
+        zcf.reallocate(
+          harden([offerHandle, poolHandle]),
+          harden([newUserAmounts, newPoolAmounts]),
+        );
+        zcf.complete(harden([offerHandle]));
+        return 'Liquidity successfully removed.';
+      };
+
+      const removeLiquidityExpected = harden({
+        want: { TokenA: null, TokenB: null },
+        give: { Liquidity: null },
+      });
+
+      const makeAddLiquidityInvite = () =>
+        zcf.makeInvitation(
+          checkHook(addLiquidityHook, addLiquidityExpected),
+          'autoswap add liquidity',
+        );
+
+      zcf.initPublicAPI(
+        harden({
+          /**
+           * `getCurrentPrice` calculates the result of a trade, given a certain amount
+           * of digital assets in.
+           * @param {object} amountInObj - the amount of digital
+           * assets to be sent in, keyed by keyword
+           */
+          getCurrentPrice: amountInObj => {
+            const inKeywords = Object.getOwnPropertyNames(amountInObj);
+            assert(
+              inKeywords.length === 1,
+              details`argument to 'getCurrentPrice' must have one keyword`,
+            );
+            const [inKeyword] = inKeywords;
+            assert(
+              ['TokenA', 'TokenB'].includes(inKeyword),
+              details`keyword ${inKeyword} was not valid`,
+            );
+            const inputExtent = amountMaths[inKeyword].getExtent(
+              amountInObj[inKeyword],
+            );
+            const poolAllocation = getPoolAllocation();
+            const inputReserve = poolAllocation[inKeyword].extent;
+            const outKeyword = inKeyword === 'TokenA' ? 'TokenB' : 'TokenA';
+            const outputReserve = poolAllocation[outKeyword].extent;
+            const { outputExtent } = getCurrentPrice(
+              harden({
+                inputExtent,
+                inputReserve,
+                outputReserve,
+              }),
+            );
+            return amountMaths[outKeyword].make(outputExtent);
+          },
+
+          getLiquidityIssuer: () => liquidityIssuer,
+
+          getPoolAllocation,
+
+          makeSwapInvite: () => zcf.makeInvitation(swapHook, 'autoswap swap'),
+
+          makeAddLiquidityInvite,
+
+          makeRemoveLiquidityInvite: () =>
+            zcf.makeInvitation(
+              checkHook(removeLiquidityHook, removeLiquidityExpected),
+              'autoswap remove liquidity',
+            ),
+        }),
+      );
+
+      return makeAddLiquidityInvite();
     });
-  },
-);
+  });
+};
+
+harden(makeContract);
+export { makeContract };

--- a/packages/zoe/src/contracts/barterExchange.js
+++ b/packages/zoe/src/contracts/barterExchange.js
@@ -1,136 +1,141 @@
 // @ts-check
 
 import harden from '@agoric/harden';
+import makeStore from '@agoric/store';
 import { makeZoeHelpers, defaultAcceptanceMsg } from '../contractSupport';
 
-/** @typedef {import('../zoe').ContractFacet} ContractFacet */
-
 /**
+ * This Barter Exchange accepts offers to trade arbitrary goods for other
+ * things. It doesn't require registration of Issuers. If two offers satisfy
+ * each other, it exchanges the specified amounts in each side's want clause.
+ *
  * The Barter Exchange only accepts offers that look like
  * { give: { In: amount }, want: { Out: amount} }
+ * The want amount will be matched, while the give amount is a maximum. Each
+ * successful trader gets their `want` and may trade with counter-parties who
+ * specify any amount up to their specified `give`.
  *
- * The want and give amounts are both treated as minimums. Each successful
- * trader gets their `want` and may trade with counter-parties who specify any
- * amount up to their specified `give`.
+ * @typedef {import('../zoe').ContractFacet} ContractFacet
+ * @param {ContractFacet} zcf
  */
-export const makeContract = harden(
-  /** @param {ContractFacet} zcf */ zcf => {
-    // bookOrders is a Map of Maps. The first key is the brand of the offer's
-    // GIVE, and the second key is the brand of their WANT. For each offer, we
-    // store the handle and the amounts for `give` and `want`.
-    const bookOrders = new Map();
+const makeContract = zcf => {
+  // bookOrders is a Map of Maps. The first key is the brand of the offer's
+  // GIVE, and the second key is the brand of its WANT. For each offer, we
+  // store its handle and the amounts for `give` and `want`.
+  const bookOrders = makeStore('bookOrders');
 
-    const { canTradeWithMapKeywords } = makeZoeHelpers(zcf);
+  const { canTradeWithMapKeywords } = makeZoeHelpers(zcf);
 
-    function lookupBookOrders(brandIn, brandOut) {
-      let ordersMap = bookOrders.get(brandIn);
-      if (!ordersMap) {
-        ordersMap = new Map();
-        bookOrders.set(brandIn, ordersMap);
-      }
-      let ordersArray = ordersMap.get(brandOut);
-      if (!ordersArray) {
-        ordersArray = [];
-        ordersMap.set(brandOut, ordersArray);
-      }
-      return ordersArray;
+  function lookupBookOrders(brandIn, brandOut) {
+    if (!bookOrders.has(brandIn)) {
+      bookOrders.init(brandIn, new Map());
     }
-
-    function findMatchingTrade(newDetails, orders) {
-      return orders.find(order => {
-        return canTradeWithMapKeywords(
-          newDetails.offerHandle,
-          order.offerHandle,
-          [
-            ['In', 'Out'],
-            ['Out', 'In'],
-          ],
-        );
-      });
+    const ordersMap = bookOrders.get(brandIn);
+    let ordersArray = ordersMap.get(brandOut);
+    if (!ordersArray) {
+      ordersArray = [];
+      ordersMap.set(brandOut, ordersArray);
     }
+    return ordersArray;
+  }
 
-    function crossMatchAmounts(leftDetails, rightDetails) {
-      const amountMathLeftIn = zcf.getAmountMath(leftDetails.amountIn.brand);
-      const amountMathLeftOut = zcf.getAmountMath(leftDetails.amountOut.brand);
-      const newLeftAmountsRecord = {
-        Out: leftDetails.amountOut,
-        In: amountMathLeftIn.subtract(
-          leftDetails.amountIn,
-          rightDetails.amountOut,
-        ),
-      };
-      const newRightAmountsRecord = {
-        Out: rightDetails.amountOut,
-        In: amountMathLeftOut.subtract(
-          rightDetails.amountIn,
-          leftDetails.amountOut,
-        ),
-      };
-      return [newLeftAmountsRecord, newRightAmountsRecord];
-    }
-
-    function removeFromOrders(offerDetails) {
-      const orders = lookupBookOrders(
-        offerDetails.amountIn.brand,
-        offerDetails.amountOut.brand,
+  function findMatchingTrade(newDetails, orders) {
+    return orders.find(order => {
+      return canTradeWithMapKeywords(
+        newDetails.offerHandle,
+        order.offerHandle,
+        [
+          ['In', 'Out'],
+          ['Out', 'In'],
+        ],
       );
-      orders.splice(orders.indexOf(offerDetails), 1);
-    }
+    });
+  }
 
-    function tradeWithMatchingOffer(offerDetails) {
-      const orders = lookupBookOrders(
-        offerDetails.amountOut.brand,
-        offerDetails.amountIn.brand,
-      );
-      const matchingTrade = findMatchingTrade(offerDetails, orders);
-      if (matchingTrade) {
-        // reallocate by switching the amounts
-        const amounts = crossMatchAmounts(offerDetails, matchingTrade);
-        const handles = [offerDetails.offerHandle, matchingTrade.offerHandle];
-        zcf.reallocate(handles, amounts);
-        removeFromOrders(matchingTrade);
-        zcf.complete(handles);
-
-        return true;
-      }
-      return false;
-    }
-
-    function addToBook(offerDetails) {
-      const orders = lookupBookOrders(
-        offerDetails.amountIn.brand,
-        offerDetails.amountOut.brand,
-      );
-      orders.push(offerDetails);
-    }
-
-    function extractOfferDetails(offerHandle) {
-      const {
-        give: { In: amountIn },
-        want: { Out: amountOut },
-      } = zcf.getOffer(offerHandle).proposal;
-
-      return {
-        offerHandle,
-        amountIn,
-        amountOut,
-      };
-    }
-    const exchangeOfferHook = offerHandle => {
-      const offerDetails = extractOfferDetails(offerHandle);
-
-      if (!tradeWithMatchingOffer(offerDetails)) {
-        addToBook(offerDetails);
-      }
-
-      return defaultAcceptanceMsg;
+  function crossMatchAmounts(leftDetails, rightDetails) {
+    const amountMathLeftIn = zcf.getAmountMath(leftDetails.amountIn.brand);
+    const amountMathLeftOut = zcf.getAmountMath(leftDetails.amountOut.brand);
+    const newLeftAmountsRecord = {
+      Out: leftDetails.amountOut,
+      In: amountMathLeftIn.subtract(
+        leftDetails.amountIn,
+        rightDetails.amountOut,
+      ),
     };
+    const newRightAmountsRecord = {
+      Out: rightDetails.amountOut,
+      In: amountMathLeftOut.subtract(
+        rightDetails.amountIn,
+        leftDetails.amountOut,
+      ),
+    };
+    return [newLeftAmountsRecord, newRightAmountsRecord];
+  }
 
-    const makeExchangeInvite = () =>
-      zcf.makeInvitation(exchangeOfferHook, 'exchange');
+  function removeFromOrders(offerDetails) {
+    const orders = lookupBookOrders(
+      offerDetails.amountIn.brand,
+      offerDetails.amountOut.brand,
+    );
+    orders.splice(orders.indexOf(offerDetails), 1);
+  }
 
-    zcf.initPublicAPI(harden({ makeInvite: makeExchangeInvite }));
+  function tradeWithMatchingOffer(offerDetails) {
+    const orders = lookupBookOrders(
+      offerDetails.amountOut.brand,
+      offerDetails.amountIn.brand,
+    );
+    const matchingTrade = findMatchingTrade(offerDetails, orders);
+    if (matchingTrade) {
+      // reallocate by switching the amounts
+      const amounts = crossMatchAmounts(offerDetails, matchingTrade);
+      const handles = [offerDetails.offerHandle, matchingTrade.offerHandle];
+      zcf.reallocate(handles, amounts);
+      removeFromOrders(matchingTrade);
+      zcf.complete(handles);
 
-    return makeExchangeInvite();
-  },
-);
+      return true;
+    }
+    return false;
+  }
+
+  function addToBook(offerDetails) {
+    const orders = lookupBookOrders(
+      offerDetails.amountIn.brand,
+      offerDetails.amountOut.brand,
+    );
+    orders.push(offerDetails);
+  }
+
+  function extractOfferDetails(offerHandle) {
+    const {
+      give: { In: amountIn },
+      want: { Out: amountOut },
+    } = zcf.getOffer(offerHandle).proposal;
+
+    return {
+      offerHandle,
+      amountIn,
+      amountOut,
+    };
+  }
+  const exchangeOfferHook = offerHandle => {
+    const offerDetails = extractOfferDetails(offerHandle);
+
+    if (!tradeWithMatchingOffer(offerDetails)) {
+      addToBook(offerDetails);
+    }
+
+    return defaultAcceptanceMsg;
+  };
+
+  const makeExchangeInvite = () =>
+    zcf.makeInvitation(exchangeOfferHook, 'exchange');
+
+  zcf.initPublicAPI(harden({ makeInvite: makeExchangeInvite }));
+
+  return makeExchangeInvite();
+};
+
+harden(makeContract);
+export { makeContract };

--- a/packages/zoe/src/contracts/coveredCall.js
+++ b/packages/zoe/src/contracts/coveredCall.js
@@ -7,64 +7,77 @@ import { makeZoeHelpers } from '../contractSupport';
 
 const rejectMsg = `The covered call option is expired.`;
 
-/** @typedef {import('../zoe').ContractFacet} ContractFacet */
+/**
+ * In a covered call, a digital asset's owner sells a call
+ * option. A call option is the right to buy the digital asset at a
+ * pre-determined price, called the strike price. The call option has an expiry
+ * date, when the contract will be cancelled.
+ *
+ * In this contract, the expiry date is the deadline when
+ * the offer escrowing the underlying assets is cancelled.
+ * Therefore, the proposal for the underlying assets must have an
+ * exit record with the key "afterDeadline".
+ *
+ * The invite received by the covered call creator is the call option. It has
+ * this additional information in the invite's extent:
+ * { expirationDate, timerAuthority, underlyingAsset, strikePrice }
+ *
+ * The initial proposal should be:
+ * {
+ *   give: { UnderlyingAsset: assetAmount },
+ *   want: { StrikePrice: priceAmount  },
+ *   exit: { afterDeadline: { deadline: time, timer: timer } },
+ * }
+ * The result of the initial offer is { payout, outcome }, where payout will
+ * eventually resolve to the strikePrice, and outcome is an assayable invitation
+ * to buy the underlying asset. Since the contract provides assurance that the
+ * underlying asset is available on the specified terms, the invite itself can
+ * be traded as a valuable good.
+ *
+ * @typedef {import('../zoe').ContractFacet} ContractFacet
+ * @param {ContractFacet} zcf
+ */
+const makeContract = zcf => {
+  const { swap, assertKeywords, checkHook } = makeZoeHelpers(zcf);
+  assertKeywords(harden(['UnderlyingAsset', 'StrikePrice']));
 
-// In a covered call, the owner of a digital asset sells a call
-// option. A call option is the right to buy the digital asset at a
-// certain price, called the strike price. The call option has an expiry
-// date, at which point the contract is cancelled.
+  const makeCallOptionInvite = sellerHandle => {
+    const {
+      proposal: { want, give, exit },
+    } = zcf.getOffer(sellerHandle);
 
-// In this contract, the expiry date is represented by the deadline at
-// which the offer escrowing the underlying assets is cancelled.
-// Therefore, the proposal for the underlying assets must have an
-// exit record with the key "afterDeadline".
-
-// The invite that the creator of the covered call receives is the
-// call option and has the following additional information in the
-// extent of the invite:
-// { expirationDate, timerAuthority, underlyingAsset, strikePrice }
-
-// zcf is the Zoe Contract Facet, i.e. the contract-facing API of Zoe
-export const makeContract = harden(
-  /** @param {ContractFacet} zcf */ zcf => {
-    const { swap, assertKeywords, checkHook } = makeZoeHelpers(zcf);
-    assertKeywords(harden(['UnderlyingAsset', 'StrikePrice']));
-
-    const makeCallOptionInvite = sellerHandle => {
-      const {
-        proposal: { want, give, exit },
-      } = zcf.getOffer(sellerHandle);
-
-      const exerciseOptionHook = offerHandle =>
-        swap(sellerHandle, offerHandle, rejectMsg);
-      const exerciseOptionExpected = harden({
-        give: { StrikePrice: null },
-        want: { UnderlyingAsset: null },
-      });
-
-      return zcf.makeInvitation(
-        checkHook(exerciseOptionHook, exerciseOptionExpected),
-        'exerciseOption',
-        harden({
-          customProperties: {
-            expirationDate: exit.afterDeadline.deadline,
-            timerAuthority: exit.afterDeadline.timer,
-            underlyingAsset: give.UnderlyingAsset,
-            strikePrice: want.StrikePrice,
-          },
-        }),
-      );
-    };
-
-    const writeOptionExpected = harden({
-      give: { UnderlyingAsset: null },
-      want: { StrikePrice: null },
-      exit: { afterDeadline: null },
+    const exerciseOptionHook = offerHandle =>
+      swap(sellerHandle, offerHandle, rejectMsg);
+    const exerciseOptionExpected = harden({
+      give: { StrikePrice: null },
+      want: { UnderlyingAsset: null },
     });
 
     return zcf.makeInvitation(
-      checkHook(makeCallOptionInvite, writeOptionExpected),
-      'makeCallOption',
+      checkHook(exerciseOptionHook, exerciseOptionExpected),
+      'exerciseOption',
+      harden({
+        customProperties: {
+          expirationDate: exit.afterDeadline.deadline,
+          timerAuthority: exit.afterDeadline.timer,
+          underlyingAsset: give.UnderlyingAsset,
+          strikePrice: want.StrikePrice,
+        },
+      }),
     );
-  },
-);
+  };
+
+  const writeOptionExpected = harden({
+    give: { UnderlyingAsset: null },
+    want: { StrikePrice: null },
+    exit: { afterDeadline: null },
+  });
+
+  return zcf.makeInvitation(
+    checkHook(makeCallOptionInvite, writeOptionExpected),
+    'makeCallOption',
+  );
+};
+
+harden(makeContract);
+export { makeContract };

--- a/packages/zoe/src/contracts/mintAndSellNFT.js
+++ b/packages/zoe/src/contracts/mintAndSellNFT.js
@@ -1,101 +1,115 @@
-/* eslint-disable no-use-before-define */
 // @ts-check
 
 import harden from '@agoric/harden';
 import produceIssuer from '@agoric/ertp';
 
-// This contract mints non-fungible tokens and creates an instance of
-// a selling contract to sell the tokens in exchange for some sort of money.
+/**
+ * This contract mints non-fungible tokens and creates a selling contract
+ * instance to sell the tokens in exchange for some sort of money.
+ *
+ * makeInstance() returns an invitation that, when exercised, returns a
+ * ticketMaker with a `.sellTokens()` method. `.sellTokens()` takes a
+ * specification of what is being sold, such as:
+ * {
+ *   customExtentProperties: { ...arbitrary },
+ *   count: 3,
+ *   moneyIssuer: moolaIssuer,
+ *   sellItemsInstallationHandle,
+ *   pricePerItem: moolaAmountMath.make(20),
+ * }
+ * The payouts are returned as an offerResult in the `outcome`, and an API that
+ * allows selling the tickets that were produced. You can reuse the ticket maker
+ * to mint more tickets (e.g. for a separate show.)
+ *
+ * @typedef {import('../zoe').ContractFacet} ContractFacet
+ * @param {ContractFacet} zcf
+ */
+const makeContract = zcf => {
+  const { terms } = zcf.getInstanceRecord();
+  const { tokenName = 'token' } = terms;
 
-/** @typedef {import('../zoe').ContractFacet} ContractFacet */
+  // Create the internal token mint
+  const { issuer, mint, amountMath: tokenAmountMath } = produceIssuer(
+    tokenName,
+    'set',
+  );
 
-// zcf is the Zoe Contract Facet, i.e. the contract-facing API of Zoe
-export const makeContract = harden(
-  /** @param {ContractFacet} zcf */ zcf => {
-    const { terms } = zcf.getInstanceRecord();
-    const { tokenName = 'token' } = terms;
+  const zoeService = zcf.getZoeService();
 
-    // Create the internal token mint
-    const { issuer, mint, amountMath: tokenAmountMath } = produceIssuer(
-      tokenName,
-      'set',
+  const sellTokens = ({
+    customExtentProperties,
+    count,
+    moneyIssuer,
+    sellItemsInstallationHandle,
+    pricePerItem,
+  }) => {
+    const tokenAmount = tokenAmountMath.make(
+      harden(
+        Array(count)
+          // @ts-ignore
+          .fill()
+          .map((_, i) => {
+            const tokenNumber = i + 1;
+            return {
+              ...customExtentProperties,
+              number: tokenNumber,
+            };
+          }),
+      ),
     );
+    const tokenPayment = mint.mintPayment(harden(tokenAmount));
+    // Note that the proposal `want` is empty
+    // This is due to a current limitation in proposal
+    // expressiveness:
+    // https://github.com/Agoric/agoric-sdk/issues/855
+    // It's impossible to know in advance how many tokens will be
+    // sold, so it's not possible to say `want: moola(3*22)`
+    // In a future version of Zoe, it will be possible to express:
+    // "I want n times moolas where n is the number of sold tokens"
+    const proposal = harden({
+      give: { Items: tokenAmount },
+    });
+    const paymentKeywordRecord = harden({ Items: tokenPayment });
 
-    const zoeService = zcf.getZoeService();
+    const issuerKeywordRecord = harden({
+      Items: issuer,
+      Money: moneyIssuer,
+    });
 
-    const sellTokens = ({
-      customExtentProperties,
-      count,
-      moneyIssuer,
-      sellItemsInstallationHandle,
+    const sellItemsTerms = harden({
       pricePerItem,
-    }) => {
-      const tokenAmount = tokenAmountMath.make(
-        harden(
-          Array(count)
-            // @ts-ignore
-            .fill()
-            .map((_, i) => {
-              const tokenNumber = i + 1;
-              return {
-                ...customExtentProperties,
-                number: tokenNumber,
-              };
-            }),
-        ),
-      );
-      const tokenPayment = mint.mintPayment(harden(tokenAmount));
-      // Note that the proposal `want` is empty
-      // This is due to a current limitation in proposal
-      // expressiveness:
-      // https://github.com/Agoric/agoric-sdk/issues/855
-      // It's impossible to know in advance how many token will be
-      // sold, so it's not possible
-      // to say `want: moola(3*22)`
-      // in a future version of Zoe, it will be possible to express:
-      // "i want n times moolas where n is the number of sold tokens"
-      const proposal = harden({
-        give: { Items: tokenAmount },
-      });
-      const paymentKeywordRecord = harden({ Items: tokenPayment });
-
-      const issuerKeywordRecord = harden({
-        Items: issuer,
-        Money: moneyIssuer,
-      });
-
-      const sellItemsTerms = harden({
-        pricePerItem,
-      });
-      return zoeService
-        .makeInstance(
-          sellItemsInstallationHandle,
-          issuerKeywordRecord,
-          sellItemsTerms,
-        )
-        .then(({ invite, instanceRecord: { handle: instanceHandle } }) => {
-          return zoeService
-            .offer(invite, proposal, paymentKeywordRecord)
-            .then(offerResult => {
-              return harden({
-                ...offerResult,
-                sellItemsInstanceHandle: instanceHandle,
-              });
+    });
+    return zoeService
+      .makeInstance(
+        sellItemsInstallationHandle,
+        issuerKeywordRecord,
+        sellItemsTerms,
+      )
+      .then(({ invite, instanceRecord: { handle: instanceHandle } }) => {
+        return zoeService
+          .offer(invite, proposal, paymentKeywordRecord)
+          .then(offerResult => {
+            return harden({
+              ...offerResult,
+              sellItemsInstanceHandle: instanceHandle,
             });
-        });
-    };
+          });
+      });
+  };
 
-    const mintTokensHook = _offerHandle => {
-      // outcome is an object with a sellTokens method
-      return harden({ sellTokens });
-    };
+  const mintTokensHook = _offerHandle => {
+    // outcome is an object with a sellTokens method
+    return harden({ sellTokens });
+  };
 
-    zcf.initPublicAPI(
-      harden({
-        getTokenIssuer: () => issuer,
-      }),
-    );
+  zcf.initPublicAPI(
+    harden({
+      getTokenIssuer: () => issuer,
+    }),
+  );
 
-    return zcf.makeInvitation(mintTokensHook, 'mint tokens');
-  },
-);
+  return zcf.makeInvitation(mintTokensHook, 'mint tokens');
+};
+
+harden(makeContract);
+export { makeContract };

--- a/packages/zoe/src/contracts/mintPayments.js
+++ b/packages/zoe/src/contracts/mintPayments.js
@@ -5,68 +5,77 @@ import harden from '@agoric/harden';
 import produceIssuer from '@agoric/ertp';
 import { makeZoeHelpers } from '../contractSupport';
 
-/*
-This is the simplest contract to mint payments and send them to users
-who request them. No offer safety is being enforced here.
-*/
+/**
+ * This is a very simple contract that creates a new issuer and mints payments
+ * from it, in order to give an example of how that can be done.  This contract
+ * sends new tokens to anyone who requests them.
+ *
+ * Offer safety is not enforced here: the expectation is that most contracts
+ * that want to do something similar would use the ability to mint new payments
+ * internally rather than sharing that ability widely as this one does.
+ *
+ * makeInstance returns an invitation that, when exercised, provides 1000 of the
+ * new tokens. publicAPI.makeInvite() returns an invitation that accepts an
+ * empty offer and provides 1000 tokens.
+ *
+ * @typedef {import('../zoe').ContractFacet} ContractFacet
+ * @param {ContractFacet} zcf
+ */
+const makeContract = zcf => {
+  // Create the internal token mint for a fungible digital asset
+  const { issuer, mint, amountMath } = produceIssuer('tokens');
 
-/** @typedef {import('../zoe').ContractFacet} ContractFacet */
+  const zoeHelpers = makeZoeHelpers(zcf);
 
-// zcf is the Zoe Contract Facet, i.e. the contract-facing API of Zoe
-export const makeContract = harden(
-  /** @param {ContractFacet} zcf */ zcf => {
-    // Create the internal token mint for a fungible digital asset
-    const { issuer, mint, amountMath } = produceIssuer('tokens');
+  // We need to tell Zoe about this issuer and add a keyword for the
+  // issuer. Let's call this the 'Token' issuer.
+  return zcf.addNewIssuer(issuer, 'Token').then(() => {
+    // We need to wait for the promise to resolve (meaning that Zoe
+    // has done the work of adding a new issuer).
+    const offerHook = offerHandle => {
+      // We will send everyone who makes an offer 1000 tokens
 
-    const zoeHelpers = makeZoeHelpers(zcf);
+      const tokens1000 = amountMath.make(1000);
+      const payment = mint.mintPayment(tokens1000);
 
-    // We need to tell Zoe about this issuer and add a keyword for the
-    // issuer. Let's call this the 'Token' issuer.
-    return zcf.addNewIssuer(issuer, 'Token').then(() => {
-      // We need to wait for the promise to resolve (meaning that Zoe
-      // has done the work of adding a new issuer).
-      const offerHook = offerHandle => {
-        // We will send everyone who makes an offer 1000 tokens
+      // Let's use a helper function which escrows the payment with
+      // Zoe, and reallocates to the recipientHandle.
+      return zoeHelpers
+        .escrowAndAllocateTo({
+          amount: tokens1000,
+          payment,
+          keyword: 'Token',
+          recipientHandle: offerHandle,
+        })
+        .then(() => {
+          // Complete the user's offer so that the user gets a payout
+          zcf.complete(harden([offerHandle]));
 
-        const tokens1000 = amountMath.make(1000);
-        const payment = mint.mintPayment(tokens1000);
+          // Since the user is getting the payout through Zoe, we can
+          // return anything here. Let's return some helpful instructions.
+          return 'Offer completed. You should receive a payment from Zoe';
+        });
+    };
 
-        // Let's use a helper function which escrows the payment with
-        // Zoe, and reallocates to the recipientHandle.
-        return zoeHelpers
-          .escrowAndAllocateTo({
-            amount: tokens1000,
-            payment,
-            keyword: 'Token',
-            recipientHandle: offerHandle,
-          })
-          .then(() => {
-            // Complete the user's offer so that the user gets a payout
-            zcf.complete(harden([offerHandle]));
+    // A function for making invites to this contract
+    const makeInvite = () => zcf.makeInvitation(offerHook, 'mint a payment');
 
-            // Since the user is getting the payout through Zoe, we can
-            // return anything here. Let's return some helpful instructions.
-            return 'Offer completed. You should receive a payment from Zoe';
-          });
-      };
+    zcf.initPublicAPI(
+      harden({
+        // provide a way for anyone who knows the instanceHandle of
+        // the contract to make their own invite.
+        makeInvite,
+        // make the token issuer public. Note that only the mint can
+        // make new digital assets. The issuer is ok to make public.
+        getTokenIssuer: () => issuer,
+      }),
+    );
 
-      // A function for making invites to this contract
-      const makeInvite = () => zcf.makeInvitation(offerHook, 'mint a payment');
+    // return an invite to the creator of the contract instance
+    // through Zoe
+    return makeInvite();
+  });
+};
 
-      zcf.initPublicAPI(
-        harden({
-          // provide a way for anyone who knows the instanceHandle of
-          // the contract to make their own invite.
-          makeInvite,
-          // make the token issuer public. Note that only the mint can
-          // make new digital assets. The issuer is ok to make public.
-          getTokenIssuer: () => issuer,
-        }),
-      );
-
-      // return an invite to the creator of the contract instance
-      // through Zoe
-      return makeInvite();
-    });
-  },
-);
+harden(makeContract);
+export { makeContract };

--- a/packages/zoe/src/contracts/multipoolAutoswap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap.js
@@ -16,613 +16,621 @@ import {
 import { filterObj } from '../objArrayConversion';
 
 /**
- * @typedef {import('../zoe').ContractFacet} ContractFacet
+ * Autoswap is a rewrite of Uniswap. Please see the documentation for more
+ * https://agoric.com/documentation/zoe/guide/contracts/autoswap.html
+ *
+ * We expect that this contract will have tens to hundreds of issuers.
+ * Each liquidity pool is between the central token and a secondary
+ * token. Secondary tokens can be exchanged with each other, but only
+ * through the central token. For example, if X and Y are two token
+ * types and C is the central token, a swap giving X and wanting Y
+ * would first use the pool (X, C) then the pool (Y, C). There are no
+ * liquidity pools between two secondary tokens.
+ *
+ * There should only need to be one instance of this contract, so liquidity can
+ * be shared as much as possible.
+ *
+ * When the contract is instantiated, the central token is specified in the
+ * issuerKeywordRecord. The party that calls makeInstance gets an invitation
+ * that can be used to request an invitation to add liquidity. The same
+ * invitation is available by calling `publicAPI.getLiquidityIssuer(brand)`.
+ * Separate invitations are available for adding and removing liquidity, and for
+ * making trades. Other API operations support monitoring prices and the sizes
+ * of pools.
+ *
  * @typedef {import('@agoric/ertp/src/issuer').Amount} Amount
  * @typedef {import('../zoe').AmountKeywordRecords} AmountKeywordRecords
+ * @typedef {import('../zoe').ContractFacet} ContractFacet
+ * @param {ContractFacet} zcf
  */
+const makeContract = zcf => {
+  // This contract must have a "central token" issuer in the terms.
+  const CENTRAL_TOKEN = 'CentralToken';
 
-// Autoswap is a rewrite of Uniswap. Please see the documentation for more
-// https://agoric.com/documentation/zoe/guide/contracts/autoswap.html
+  function buildAmountMathKeywordRecord(keywords) {
+    const { brandKeywordRecord } = zcf.getInstanceRecord();
+    const amountMathKeywordRecord = {};
+    keywords.forEach(keyword => {
+      const brand = brandKeywordRecord[keyword];
+      assertNatMathHelpers(brand);
+      amountMathKeywordRecord[keyword] = zcf.getAmountMath(brand);
+    });
+    return amountMathKeywordRecord;
+  }
 
-// We expect that this contract will have tens to hundreds of issuers.
-// Each liquidity pool is between the central token and a secondary
-// token. Secondary tokens can be exchanged with each other, but only
-// through the central token. For example, if X and Y are two token
-// types and C is the central token, a swap giving X and wanting Y
-// would first use the pool (X, C) then the pool (Y, C). There are no
-// liquidity pools between two secondary tokens.
+  const getCentralTokenBrand = () => {
+    const { brandKeywordRecord } = zcf.getInstanceRecord();
+    assert(
+      brandKeywordRecord.CentralToken !== undefined,
+      details`centralTokenBrand must be present`,
+    );
+    return brandKeywordRecord.CentralToken;
+  };
+  const centralTokenBrand = getCentralTokenBrand();
 
-export const makeContract = harden(
-  /** @param {ContractFacet} zcf */ zcf => {
-    // This contract must have a "central token" issuer in the terms.
-    const CENTRAL_TOKEN = 'CentralToken';
+  const {
+    rejectOffer,
+    makeEmptyOffer,
+    rejectIfNotProposal,
+    assertKeywords,
+    escrowAndAllocateTo,
+    assertNatMathHelpers,
+  } = makeZoeHelpers(zcf);
 
-    function buildAmountMathKeywordRecord(keywords) {
-      const { brandKeywordRecord } = zcf.getInstanceRecord();
-      const amountMathKeywordRecord = {};
-      keywords.forEach(keyword => {
-        const brand = brandKeywordRecord[keyword];
-        assertNatMathHelpers(brand);
-        amountMathKeywordRecord[keyword] = zcf.getAmountMath(brand);
-      });
-      return amountMathKeywordRecord;
-    }
+  // There must be one keyword at the start, which is equal to the
+  // value of CENTRAL_TOKEN
+  assertKeywords([CENTRAL_TOKEN]);
 
-    const getCentralTokenBrand = () => {
-      const { brandKeywordRecord } = zcf.getInstanceRecord();
-      assert(
-        brandKeywordRecord.CentralToken !== undefined,
-        details`centralTokenBrand must be present`,
+  // We need to be able to retrieve information about the liquidity
+  // pools by tokenBrand. Key: tokenBrand Columns: poolHandle,
+  // tokenIssuer, liquidityMint, liquidityIssuer, tokenKeyword,
+  // liquidityKeyword, liquidityTokenSupply
+  const liquidityTable = makeTable(
+    makeValidateProperties(
+      harden([
+        'poolHandle',
+        'tokenIssuer',
+        'liquidityMint',
+        'liquidityIssuer',
+        'tokenKeyword',
+        'liquidityKeyword',
+        'liquidityTokenSupply',
+      ]),
+    ),
+  );
+
+  // Allows users to add new liquidity pools. `newTokenIssuer` and
+  // `newTokenKeyword` must not have been already used
+  const addPool = (newTokenIssuer, newTokenKeyword) => {
+    assertKeywordName(newTokenKeyword);
+    const { brandKeywordRecord } = zcf.getInstanceRecord();
+    const keywords = Object.keys(brandKeywordRecord);
+    const brands = Object.values(brandKeywordRecord);
+    assert(
+      !keywords.includes(newTokenKeyword),
+      details`newTokenKeyword must be unique`,
+    );
+    // TODO: handle newTokenIssuer as a potential promise
+    assert(
+      !brands.includes(newTokenIssuer.brand),
+      details`newTokenIssuer must not be already present`,
+    );
+    const newLiquidityKeyword = `${newTokenKeyword}Liquidity`;
+    assert(
+      !keywords.includes(newLiquidityKeyword),
+      details`newLiquidityKeyword must be unique`,
+    );
+    const { mint: liquidityMint, issuer: liquidityIssuer } = produceIssuer(
+      newLiquidityKeyword,
+    );
+    return Promise.all([
+      zcf.addNewIssuer(newTokenIssuer, newTokenKeyword),
+      makeEmptyOffer(),
+      zcf.addNewIssuer(liquidityIssuer, newLiquidityKeyword),
+    ]).then(([newTokenIssuerRecord, poolHandle]) => {
+      // The final element of the above array is intentionally
+      // ignored, since we already have the liquidityIssuer and mint.
+      assertNatMathHelpers(newTokenIssuerRecord.brand);
+      liquidityTable.create(
+        harden({
+          poolHandle,
+          tokenIssuer: newTokenIssuer,
+          liquidityMint,
+          liquidityIssuer,
+          tokenKeyword: newTokenKeyword,
+          liquidityKeyword: newLiquidityKeyword,
+          liquidityTokenSupply: 0,
+        }),
+        newTokenIssuerRecord.brand,
       );
-      return brandKeywordRecord.CentralToken;
-    };
-    const centralTokenBrand = getCentralTokenBrand();
+      return `liquidity pool for ${newTokenKeyword} added`;
+    });
+  };
 
-    const {
-      rejectOffer,
-      makeEmptyOffer,
-      rejectIfNotProposal,
-      assertKeywords,
-      escrowAndAllocateTo,
-      assertNatMathHelpers,
-    } = makeZoeHelpers(zcf);
-
-    // There must be one keyword at the start, which is equal to the
-    // value of CENTRAL_TOKEN
-    assertKeywords([CENTRAL_TOKEN]);
-
-    // We need to be able to retrieve information about the liquidity
-    // pools by tokenBrand. Key: tokenBrand Columns: poolHandle,
-    // tokenIssuer, liquidityMint, liquidityIssuer, tokenKeyword,
-    // liquidityKeyword, liquidityTokenSupply
-    const liquidityTable = makeTable(
-      makeValidateProperties(
-        harden([
-          'poolHandle',
-          'tokenIssuer',
-          'liquidityMint',
-          'liquidityIssuer',
-          'tokenKeyword',
-          'liquidityKeyword',
-          'liquidityTokenSupply',
-        ]),
-      ),
+  // The secondary token brand is used as the key of liquidityTable
+  // rows, and we use it to look up the pool allocation. We only
+  // return the keywords for the secondary token, the central token,
+  // and the associated liquidity token.
+  const getPoolAllocation = tokenBrand => {
+    const { poolHandle, tokenKeyword, liquidityKeyword } = liquidityTable.get(
+      tokenBrand,
     );
 
-    // Allows users to add new liquidity pools. `newTokenIssuer` and
-    // `newTokenKeyword` must not have been already used
-    const addPool = (newTokenIssuer, newTokenKeyword) => {
-      assertKeywordName(newTokenKeyword);
-      const { brandKeywordRecord } = zcf.getInstanceRecord();
-      const keywords = Object.keys(brandKeywordRecord);
-      const brands = Object.values(brandKeywordRecord);
-      assert(
-        !keywords.includes(newTokenKeyword),
-        details`newTokenKeyword must be unique`,
-      );
-      // TODO: handle newTokenIssuer as a potential promise
-      assert(
-        !brands.includes(newTokenIssuer.brand),
-        details`newTokenIssuer must not be already present`,
-      );
-      const newLiquidityKeyword = `${newTokenKeyword}Liquidity`;
-      assert(
-        !keywords.includes(newLiquidityKeyword),
-        details`newLiquidityKeyword must be unique`,
-      );
-      const { mint: liquidityMint, issuer: liquidityIssuer } = produceIssuer(
-        newLiquidityKeyword,
-      );
-      return Promise.all([
-        zcf.addNewIssuer(newTokenIssuer, newTokenKeyword),
-        makeEmptyOffer(),
-        zcf.addNewIssuer(liquidityIssuer, newLiquidityKeyword),
-      ]).then(([newTokenIssuerRecord, poolHandle]) => {
-        // The final element of the above array is intentionally
-        // ignored, since we already have the liquidityIssuer and mint.
-        assertNatMathHelpers(newTokenIssuerRecord.brand);
-        liquidityTable.create(
-          harden({
-            poolHandle,
-            tokenIssuer: newTokenIssuer,
-            liquidityMint,
-            liquidityIssuer,
-            tokenKeyword: newTokenKeyword,
-            liquidityKeyword: newLiquidityKeyword,
-            liquidityTokenSupply: 0,
-          }),
-          newTokenIssuerRecord.brand,
-        );
-        return `liquidity pool for ${newTokenKeyword} added`;
-      });
+    const brandKeywordRecord = filterObj(
+      zcf.getInstanceRecord().brandKeywordRecord,
+      [tokenKeyword, CENTRAL_TOKEN, liquidityKeyword],
+    );
+
+    return zcf.getCurrentAllocation(poolHandle, brandKeywordRecord);
+  };
+
+  const doGetCurrentPrice = ({
+    amountIn,
+    keywordIn,
+    keywordOut,
+    secondaryBrand,
+  }) => {
+    const poolAllocation = getPoolAllocation(secondaryBrand);
+    const { outputExtent } = getCurrentPrice(
+      harden({
+        inputExtent: amountIn.extent,
+        inputReserve: poolAllocation[keywordIn].extent,
+        outputReserve: poolAllocation[keywordOut].extent,
+      }),
+    );
+    const amountMathOut = zcf.getAmountMath(poolAllocation[keywordOut].brand);
+    return amountMathOut.make(outputExtent);
+  };
+
+  const doSwap = ({
+    userAllocation,
+    keywordIn,
+    keywordOut,
+    secondaryBrand,
+  }) => {
+    const poolAllocation = getPoolAllocation(secondaryBrand);
+    const { outputExtent, newInputReserve, newOutputReserve } = getCurrentPrice(
+      harden({
+        inputExtent: userAllocation.In.extent,
+        inputReserve: poolAllocation[keywordIn].extent,
+        outputReserve: poolAllocation[keywordOut].extent,
+      }),
+    );
+    const amountMathOut = zcf.getAmountMath(poolAllocation[keywordOut].brand);
+    const amountMathIn = zcf.getAmountMath(poolAllocation[keywordIn].brand);
+    const amountOut = amountMathOut.make(outputExtent);
+
+    const newUserAmounts = harden({
+      In: amountMathIn.getEmpty(),
+      Out: amountOut,
+    });
+
+    const newPoolAmounts = harden({
+      [keywordIn]: amountMathIn.make(newInputReserve),
+      [keywordOut]: amountMathOut.make(newOutputReserve),
+    });
+
+    const { poolHandle } = liquidityTable.get(secondaryBrand);
+    return harden({ poolHandle, newUserAmounts, newPoolAmounts });
+  };
+
+  const getSecondaryBrand = ({ offerHandle, isAddLiquidity }) => {
+    const { proposal } = zcf.getOffer(offerHandle);
+    const key = isAddLiquidity ? 'give' : 'want';
+    const {
+      [key]: { [CENTRAL_TOKEN]: _, ...tokenAmountKeywordRecord },
+    } = proposal;
+    const tokenAmounts = Object.values(tokenAmountKeywordRecord);
+    if (tokenAmounts.length !== 1) {
+      rejectOffer(offerHandle, `only one secondary brand should be present`);
+    }
+    return tokenAmounts[0].brand;
+  };
+
+  const rejectIfNotTokenBrand = (inviteHandle, brand) => {
+    if (!liquidityTable.has(brand)) {
+      rejectOffer(inviteHandle, `brand ${brand} was not recognized`);
+    }
+  };
+
+  const addLiquidityHook = offerHandle => {
+    // Get the brand of the secondary token so we can identify the liquidity pool.
+    const secondaryTokenBrand = getSecondaryBrand(
+      harden({
+        offerHandle,
+        isAddLiquidity: true,
+      }),
+    );
+
+    const {
+      tokenKeyword,
+      liquidityKeyword,
+      liquidityTokenSupply,
+      liquidityMint,
+      poolHandle,
+    } = liquidityTable.get(secondaryTokenBrand);
+
+    // These are the keywords for the pool in this method
+    const poolLiquidityKeys = harden([
+      CENTRAL_TOKEN,
+      tokenKeyword,
+      liquidityKeyword,
+    ]);
+    const {
+      brandKeywordRecord: poolBrandKeywordRecord,
+    } = zcf.getInstanceRecord();
+    const poolAmountMaths = buildAmountMathKeywordRecord(poolLiquidityKeys);
+    const userAmountMaths = {
+      In: poolAmountMaths[tokenKeyword],
+      Out: poolAmountMaths[liquidityKeyword],
+      [CENTRAL_TOKEN]: poolAmountMaths[CENTRAL_TOKEN],
+    };
+    const userBrandKeywordRecord = {
+      In: poolBrandKeywordRecord[tokenKeyword],
+      Out: poolBrandKeywordRecord[liquidityKeyword],
+      [CENTRAL_TOKEN]: poolBrandKeywordRecord[CENTRAL_TOKEN],
     };
 
-    // The secondary token brand is used as the key of liquidityTable
-    // rows, and we use it to look up the pool allocation. We only
-    // return the keywords for the secondary token, the central token,
-    // and the associated liquidity token.
-    const getPoolAllocation = tokenBrand => {
-      const { poolHandle, tokenKeyword, liquidityKeyword } = liquidityTable.get(
-        tokenBrand,
+    const expected = harden({
+      give: {
+        [CENTRAL_TOKEN]: null,
+        In: null,
+      },
+      want: { Out: null },
+    });
+    rejectIfNotProposal(offerHandle, expected);
+
+    const userAllocation = zcf.getCurrentAllocation(
+      offerHandle,
+      userBrandKeywordRecord,
+    );
+    const poolAllocation = getPoolAllocation(secondaryTokenBrand);
+
+    // Calculate how many liquidity tokens we should be minting.
+    const liquidityExtentOut = calcLiqExtentToMint(
+      harden({
+        liqTokenSupply: liquidityTokenSupply,
+        inputExtent: userAllocation[CENTRAL_TOKEN].extent,
+        inputReserve: poolAllocation[CENTRAL_TOKEN].extent,
+      }),
+    );
+
+    const liquidityAmountOut = poolAmountMaths[liquidityKeyword].make(
+      liquidityExtentOut,
+    );
+
+    const liquidityPaymentP = liquidityMint.mintPayment(liquidityAmountOut);
+
+    // We update the liquidityTokenSupply before the next turn
+    liquidityTable.update(secondaryTokenBrand, {
+      liquidityTokenSupply: liquidityTokenSupply + liquidityExtentOut,
+    });
+
+    // The contract needs to escrow the liquidity payment with Zoe
+    // to eventually payout to the user
+    return escrowAndAllocateTo({
+      amount: liquidityAmountOut,
+      payment: liquidityPaymentP,
+      keyword: 'Out',
+      recipientHandle: offerHandle,
+    }).then(() => {
+      const addByKey = (key, obj1, obj2) =>
+        poolAmountMaths[key].add(obj1[key], obj2[key]);
+      const newPoolTokenAmount = poolAmountMaths[tokenKeyword].add(
+        userAllocation.In,
+        poolAllocation[tokenKeyword],
       );
-
-      const brandKeywordRecord = filterObj(
-        zcf.getInstanceRecord().brandKeywordRecord,
-        [tokenKeyword, CENTRAL_TOKEN, liquidityKeyword],
-      );
-
-      return zcf.getCurrentAllocation(poolHandle, brandKeywordRecord);
-    };
-
-    const doGetCurrentPrice = ({
-      amountIn,
-      keywordIn,
-      keywordOut,
-      secondaryBrand,
-    }) => {
-      const poolAllocation = getPoolAllocation(secondaryBrand);
-      const { outputExtent } = getCurrentPrice(
-        harden({
-          inputExtent: amountIn.extent,
-          inputReserve: poolAllocation[keywordIn].extent,
-          outputReserve: poolAllocation[keywordOut].extent,
-        }),
-      );
-      const amountMathOut = zcf.getAmountMath(poolAllocation[keywordOut].brand);
-      return amountMathOut.make(outputExtent);
-    };
-
-    const doSwap = ({
-      userAllocation,
-      keywordIn,
-      keywordOut,
-      secondaryBrand,
-    }) => {
-      const poolAllocation = getPoolAllocation(secondaryBrand);
-      const {
-        outputExtent,
-        newInputReserve,
-        newOutputReserve,
-      } = getCurrentPrice(
-        harden({
-          inputExtent: userAllocation.In.extent,
-          inputReserve: poolAllocation[keywordIn].extent,
-          outputReserve: poolAllocation[keywordOut].extent,
-        }),
-      );
-      const amountMathOut = zcf.getAmountMath(poolAllocation[keywordOut].brand);
-      const amountMathIn = zcf.getAmountMath(poolAllocation[keywordIn].brand);
-      const amountOut = amountMathOut.make(outputExtent);
-
-      const newUserAmounts = harden({
-        In: amountMathIn.getEmpty(),
-        Out: amountOut,
-      });
 
       const newPoolAmounts = harden({
-        [keywordIn]: amountMathIn.make(newInputReserve),
-        [keywordOut]: amountMathOut.make(newOutputReserve),
+        [CENTRAL_TOKEN]: addByKey(
+          CENTRAL_TOKEN,
+          userAllocation,
+          poolAllocation,
+        ),
+        [tokenKeyword]: newPoolTokenAmount,
+        [liquidityKeyword]: poolAllocation[liquidityKeyword],
       });
 
-      const { poolHandle } = liquidityTable.get(secondaryBrand);
-      return harden({ poolHandle, newUserAmounts, newPoolAmounts });
-    };
-
-    const getSecondaryBrand = ({ offerHandle, isAddLiquidity }) => {
-      const { proposal } = zcf.getOffer(offerHandle);
-      const key = isAddLiquidity ? 'give' : 'want';
-      const {
-        [key]: { [CENTRAL_TOKEN]: _, ...tokenAmountKeywordRecord },
-      } = proposal;
-      const tokenAmounts = Object.values(tokenAmountKeywordRecord);
-      if (tokenAmounts.length !== 1) {
-        rejectOffer(offerHandle, `only one secondary brand should be present`);
-      }
-      return tokenAmounts[0].brand;
-    };
-
-    const rejectIfNotTokenBrand = (inviteHandle, brand) => {
-      if (!liquidityTable.has(brand)) {
-        rejectOffer(inviteHandle, `brand ${brand} was not recognized`);
-      }
-    };
-
-    const addLiquidityHook = offerHandle => {
-      // Get the brand of the secondary token so we can identify the liquidity pool.
-      const secondaryTokenBrand = getSecondaryBrand(
-        harden({
-          offerHandle,
-          isAddLiquidity: true,
-        }),
-      );
-
-      const {
-        tokenKeyword,
-        liquidityKeyword,
-        liquidityTokenSupply,
-        liquidityMint,
-        poolHandle,
-      } = liquidityTable.get(secondaryTokenBrand);
-
-      // These are the keywords for the pool in this method
-      const poolLiquidityKeys = harden([
-        CENTRAL_TOKEN,
-        tokenKeyword,
-        liquidityKeyword,
-      ]);
-      const {
-        brandKeywordRecord: poolBrandKeywordRecord,
-      } = zcf.getInstanceRecord();
-      const poolAmountMaths = buildAmountMathKeywordRecord(poolLiquidityKeys);
-      const userAmountMaths = {
-        In: poolAmountMaths[tokenKeyword],
-        Out: poolAmountMaths[liquidityKeyword],
-        [CENTRAL_TOKEN]: poolAmountMaths[CENTRAL_TOKEN],
+      const newUserAmounts = {
+        [CENTRAL_TOKEN]: userAmountMaths[CENTRAL_TOKEN].getEmpty(),
+        In: userAmountMaths.In.getEmpty(),
+        Out: liquidityAmountOut,
       };
-      const userBrandKeywordRecord = {
-        In: poolBrandKeywordRecord[tokenKeyword],
-        Out: poolBrandKeywordRecord[liquidityKeyword],
-        [CENTRAL_TOKEN]: poolBrandKeywordRecord[CENTRAL_TOKEN],
-      };
-
-      const expected = harden({
-        give: {
-          [CENTRAL_TOKEN]: null,
-          In: null,
-        },
-        want: { Out: null },
-      });
-      rejectIfNotProposal(offerHandle, expected);
-
-      const userAllocation = zcf.getCurrentAllocation(
-        offerHandle,
-        userBrandKeywordRecord,
-      );
-      const poolAllocation = getPoolAllocation(secondaryTokenBrand);
-
-      // Calculate how many liquidity tokens we should be minting.
-      const liquidityExtentOut = calcLiqExtentToMint(
-        harden({
-          liqTokenSupply: liquidityTokenSupply,
-          inputExtent: userAllocation[CENTRAL_TOKEN].extent,
-          inputReserve: poolAllocation[CENTRAL_TOKEN].extent,
-        }),
-      );
-
-      const liquidityAmountOut = poolAmountMaths[liquidityKeyword].make(
-        liquidityExtentOut,
-      );
-
-      const liquidityPaymentP = liquidityMint.mintPayment(liquidityAmountOut);
-
-      // We update the liquidityTokenSupply before the next turn
-      liquidityTable.update(secondaryTokenBrand, {
-        liquidityTokenSupply: liquidityTokenSupply + liquidityExtentOut,
-      });
-
-      // The contract needs to escrow the liquidity payment with Zoe
-      // to eventually payout to the user
-      return escrowAndAllocateTo({
-        amount: liquidityAmountOut,
-        payment: liquidityPaymentP,
-        keyword: 'Out',
-        recipientHandle: offerHandle,
-      }).then(() => {
-        const addByKey = (key, obj1, obj2) =>
-          poolAmountMaths[key].add(obj1[key], obj2[key]);
-        const newPoolTokenAmount = poolAmountMaths[tokenKeyword].add(
-          userAllocation.In,
-          poolAllocation[tokenKeyword],
-        );
-
-        const newPoolAmounts = harden({
-          [CENTRAL_TOKEN]: addByKey(
-            CENTRAL_TOKEN,
-            userAllocation,
-            poolAllocation,
-          ),
-          [tokenKeyword]: newPoolTokenAmount,
-          [liquidityKeyword]: poolAllocation[liquidityKeyword],
-        });
-
-        const newUserAmounts = {
-          [CENTRAL_TOKEN]: userAmountMaths[CENTRAL_TOKEN].getEmpty(),
-          In: userAmountMaths.In.getEmpty(),
-          Out: liquidityAmountOut,
-        };
-
-        zcf.reallocate(
-          harden([offerHandle, poolHandle]),
-          harden([newUserAmounts, newPoolAmounts]),
-        );
-        zcf.complete(harden([offerHandle]));
-        return 'Added liquidity.';
-      });
-    };
-
-    const removeLiquidityHook = offerHandle => {
-      const secondaryTokenBrand = getSecondaryBrand(
-        harden({ offerHandle, isAddLiquidity: false }),
-      );
-
-      const {
-        tokenKeyword,
-        liquidityKeyword,
-        liquidityTokenSupply,
-        poolHandle,
-      } = liquidityTable.get(secondaryTokenBrand);
-
-      const expected = harden({
-        want: { [CENTRAL_TOKEN]: null, Out: null },
-        give: { In: null },
-      });
-      rejectIfNotProposal(offerHandle, expected);
-      const poolAmountMaths = buildAmountMathKeywordRecord([
-        CENTRAL_TOKEN,
-        tokenKeyword,
-        liquidityKeyword,
-      ]);
-
-      const {
-        brandKeywordRecord: poolBrandKeywordRecord,
-      } = zcf.getInstanceRecord();
-      const userBrandKeywordRecord = {
-        In: poolBrandKeywordRecord[tokenKeyword],
-        Out: poolBrandKeywordRecord[liquidityKeyword],
-        [CENTRAL_TOKEN]: poolBrandKeywordRecord[CENTRAL_TOKEN],
-      };
-      const userAllocation = zcf.getCurrentAllocation(
-        offerHandle,
-        userBrandKeywordRecord,
-      );
-      const poolAllocation = getPoolAllocation(secondaryTokenBrand);
-      const liquidityExtentIn = userAllocation.In.extent;
-
-      const newUserAmounts = harden({
-        [CENTRAL_TOKEN]: poolAmountMaths[CENTRAL_TOKEN].make(
-          calcExtentToRemove(
-            harden({
-              liqTokenSupply: liquidityTokenSupply,
-              poolExtent: poolAllocation[CENTRAL_TOKEN].extent,
-              liquidityExtentIn,
-            }),
-          ),
-        ),
-        Out: poolAmountMaths[tokenKeyword].make(
-          calcExtentToRemove(
-            harden({
-              liqTokenSupply: liquidityTokenSupply,
-              poolExtent: poolAllocation[tokenKeyword].extent,
-              liquidityExtentIn,
-            }),
-          ),
-        ),
-        In: poolAmountMaths[liquidityKeyword].getEmpty(),
-      });
-
-      const newPoolAmounts = harden({
-        [CENTRAL_TOKEN]: poolAmountMaths[CENTRAL_TOKEN].subtract(
-          poolAllocation[CENTRAL_TOKEN],
-          newUserAmounts[CENTRAL_TOKEN],
-        ),
-        [tokenKeyword]: poolAmountMaths[tokenKeyword].subtract(
-          poolAllocation[tokenKeyword],
-          newUserAmounts.Out,
-        ),
-        [liquidityKeyword]: poolAmountMaths[liquidityKeyword].add(
-          poolAllocation[liquidityKeyword],
-          poolAmountMaths[liquidityKeyword].make(liquidityExtentIn),
-        ),
-      });
-
-      liquidityTable.update(secondaryTokenBrand, {
-        liquidityTokenSupply: liquidityTokenSupply - liquidityExtentIn,
-      });
 
       zcf.reallocate(
         harden([offerHandle, poolHandle]),
         harden([newUserAmounts, newPoolAmounts]),
       );
       zcf.complete(harden([offerHandle]));
-      return 'Liquidity successfully removed.';
-    };
+      return 'Added liquidity.';
+    });
+  };
 
-    const swapHook = offerHandle => {
-      const {
-        give: {
-          In: { brand: brandIn },
-        },
-        want: {
-          Out: { brand: brandOut },
-        },
-      } = zcf.getOffer(offerHandle).proposal;
-
-      const expected = harden({
-        give: { In: null },
-        want: { Out: null },
-      });
-      rejectIfNotProposal(offerHandle, expected);
-
-      // we could be swapping (1) central to secondary, (2) secondary to
-      // central, or (3) secondary to secondary.
-
-      // 1) central to secondary
-      if (brandIn === centralTokenBrand) {
-        rejectIfNotTokenBrand(offerHandle, brandOut);
-
-        const { poolHandle, newUserAmounts, newPoolAmounts } = doSwap(
-          harden({
-            userAllocation: zcf.getCurrentAllocation(offerHandle),
-            keywordIn: 'CentralToken',
-            keywordOut: liquidityTable.get(brandOut).tokenKeyword,
-            secondaryBrand: brandOut,
-          }),
-        );
-        zcf.reallocate(
-          harden([offerHandle, poolHandle]),
-          harden([newUserAmounts, newPoolAmounts]),
-        );
-        zcf.complete(harden([offerHandle]));
-        return `Swap successfully completed.`;
-
-        // eslint-disable-next-line no-else-return
-      } else if (brandOut === centralTokenBrand) {
-        // 2) secondary to central
-        rejectIfNotTokenBrand(offerHandle, brandIn);
-        const { poolHandle, newUserAmounts, newPoolAmounts } = doSwap(
-          harden({
-            userAllocation: zcf.getCurrentAllocation(offerHandle),
-            keywordIn: liquidityTable.get(brandIn).tokenKeyword,
-            keywordOut: 'CentralToken',
-            secondaryBrand: brandIn,
-          }),
-        );
-        zcf.reallocate(
-          harden([offerHandle, poolHandle]),
-          harden([newUserAmounts, newPoolAmounts]),
-        );
-        zcf.complete(harden([offerHandle]));
-        return `Swap successfully completed.`;
-      } else {
-        // 3) secondary to secondary
-        rejectIfNotTokenBrand(offerHandle, brandIn);
-        rejectIfNotTokenBrand(offerHandle, brandOut);
-
-        const {
-          poolHandle: poolHandleA,
-          newUserAmounts: newUserAmountsA,
-          newPoolAmounts: newPoolAmountsA,
-        } = doSwap(
-          harden({
-            userAllocation: zcf.getCurrentAllocation(offerHandle),
-            keywordIn: liquidityTable.get(brandIn).tokenKeyword,
-            keywordOut: CENTRAL_TOKEN,
-            secondaryBrand: brandIn,
-          }),
-        );
-        const {
-          poolHandle: poolHandleB,
-          newUserAmounts,
-          newPoolAmounts: newPoolAmountsB,
-        } = doSwap(
-          harden({
-            userAllocation: { In: newUserAmountsA.Out },
-            keywordIn: CENTRAL_TOKEN,
-            keywordOut: liquidityTable.get(brandOut).tokenKeyword,
-            secondaryBrand: brandOut,
-          }),
-        );
-        const amountMathOut = zcf.getAmountMath(brandOut);
-        const amountMathIn = zcf.getAmountMath(brandIn);
-        const finalPoolAmountsA = {
-          ...newPoolAmountsA,
-          Out: amountMathOut.getEmpty(),
-        };
-        const finalPoolAmountsB = {
-          ...newPoolAmountsB,
-          In: amountMathIn.getEmpty(),
-        };
-        const finalUserAmounts = {
-          ...newUserAmounts,
-          In: newUserAmountsA.In,
-        };
-        zcf.reallocate(
-          harden([poolHandleA, poolHandleB, offerHandle]),
-          harden([finalPoolAmountsA, finalPoolAmountsB, finalUserAmounts]),
-        );
-        zcf.complete(harden([offerHandle]));
-        return `Swap successfully completed.`;
-      }
-    };
-
-    const makeAddLiquidityInvite = () =>
-      zcf.makeInvitation(addLiquidityHook, 'multipool autoswap add liquidity');
-
-    zcf.initPublicAPI(
-      harden({
-        getBrandKeywordRecord: () => {
-          return zcf.getInstanceRecord().brandKeywordRecord;
-        },
-        addPool,
-        getPoolAllocation,
-        getLiquidityIssuer: tokenBrand =>
-          liquidityTable.get(tokenBrand).liquidityIssuer,
-        /**
-         * `getCurrentPrice` calculates the result of a trade, given a certain
-         * amount of digital assets in.
-         * @param {Amount} amountIn - the amount of digital assets to be
-         * sent in
-         * @param {Brand} brandOut - the brand of the requested payment.
-         */
-        getCurrentPrice: (amountIn, brandOut) => {
-          const brandIn = amountIn.brand;
-          // brandIn could either be the central token brand, or one of
-          // the secondary token brands
-
-          // CentralToken to SecondaryToken
-          if (brandIn === centralTokenBrand) {
-            assert(
-              liquidityTable.has(brandOut),
-              details`brandOut ${brandOut} was not recognized`,
-            );
-            return doGetCurrentPrice(
-              harden({
-                amountIn,
-                keywordIn: CENTRAL_TOKEN,
-                keywordOut: liquidityTable.get(brandOut).tokenKeyword,
-                secondaryBrand: brandOut,
-              }),
-            );
-            // eslint-disable-next-line no-else-return
-          } else if (brandOut === centralTokenBrand) {
-            // SecondaryToken to CentralToken
-            assert(
-              liquidityTable.has(brandIn),
-              details`amountIn brand ${amountIn} was not recognized`,
-            );
-            return doGetCurrentPrice(
-              harden({
-                amountIn,
-                keywordIn: liquidityTable.get(brandIn).tokenKeyword,
-                keywordOut: CENTRAL_TOKEN,
-                secondaryBrand: brandIn,
-              }),
-            );
-          } else {
-            // SecondaryToken to SecondaryToken
-            assert(
-              liquidityTable.has(brandIn) && liquidityTable.has(brandOut),
-              details`amountIn brand ${brandIn} or brandOut ${brandOut} was not recognized`,
-            );
-
-            // We must do two consecutive `doGetCurrentPrice` calls: from
-            // the brandIn to the central token, then from the central
-            // token to the brandOut
-            const centralTokenAmount = doGetCurrentPrice(
-              harden({
-                amountIn,
-                keywordIn: liquidityTable.get(brandIn).tokenKeyword,
-                keywordOut: CENTRAL_TOKEN,
-                secondaryBrand: brandIn,
-              }),
-            );
-            return doGetCurrentPrice(
-              harden({
-                amountIn: centralTokenAmount,
-                keywordIn: CENTRAL_TOKEN,
-                keywordOut: liquidityTable.get(brandOut).tokenKeyword,
-                secondaryBrand: brandOut,
-              }),
-            );
-          }
-        },
-        makeSwapInvite: () => zcf.makeInvitation(swapHook, 'autoswap swap'),
-        makeAddLiquidityInvite,
-        makeRemoveLiquidityInvite: () =>
-          zcf.makeInvitation(removeLiquidityHook, 'autoswap remove liquidity'),
-      }),
+  const removeLiquidityHook = offerHandle => {
+    const secondaryTokenBrand = getSecondaryBrand(
+      harden({ offerHandle, isAddLiquidity: false }),
     );
 
-    return makeAddLiquidityInvite();
-  },
-);
+    const {
+      tokenKeyword,
+      liquidityKeyword,
+      liquidityTokenSupply,
+      poolHandle,
+    } = liquidityTable.get(secondaryTokenBrand);
+
+    const expected = harden({
+      want: { [CENTRAL_TOKEN]: null, Out: null },
+      give: { In: null },
+    });
+    rejectIfNotProposal(offerHandle, expected);
+    const poolAmountMaths = buildAmountMathKeywordRecord([
+      CENTRAL_TOKEN,
+      tokenKeyword,
+      liquidityKeyword,
+    ]);
+
+    const {
+      brandKeywordRecord: poolBrandKeywordRecord,
+    } = zcf.getInstanceRecord();
+    const userBrandKeywordRecord = {
+      In: poolBrandKeywordRecord[tokenKeyword],
+      Out: poolBrandKeywordRecord[liquidityKeyword],
+      [CENTRAL_TOKEN]: poolBrandKeywordRecord[CENTRAL_TOKEN],
+    };
+    const userAllocation = zcf.getCurrentAllocation(
+      offerHandle,
+      userBrandKeywordRecord,
+    );
+    const poolAllocation = getPoolAllocation(secondaryTokenBrand);
+    const liquidityExtentIn = userAllocation.In.extent;
+
+    const newUserAmounts = harden({
+      [CENTRAL_TOKEN]: poolAmountMaths[CENTRAL_TOKEN].make(
+        calcExtentToRemove(
+          harden({
+            liqTokenSupply: liquidityTokenSupply,
+            poolExtent: poolAllocation[CENTRAL_TOKEN].extent,
+            liquidityExtentIn,
+          }),
+        ),
+      ),
+      Out: poolAmountMaths[tokenKeyword].make(
+        calcExtentToRemove(
+          harden({
+            liqTokenSupply: liquidityTokenSupply,
+            poolExtent: poolAllocation[tokenKeyword].extent,
+            liquidityExtentIn,
+          }),
+        ),
+      ),
+      In: poolAmountMaths[liquidityKeyword].getEmpty(),
+    });
+
+    const newPoolAmounts = harden({
+      [CENTRAL_TOKEN]: poolAmountMaths[CENTRAL_TOKEN].subtract(
+        poolAllocation[CENTRAL_TOKEN],
+        newUserAmounts[CENTRAL_TOKEN],
+      ),
+      [tokenKeyword]: poolAmountMaths[tokenKeyword].subtract(
+        poolAllocation[tokenKeyword],
+        newUserAmounts.Out,
+      ),
+      [liquidityKeyword]: poolAmountMaths[liquidityKeyword].add(
+        poolAllocation[liquidityKeyword],
+        poolAmountMaths[liquidityKeyword].make(liquidityExtentIn),
+      ),
+    });
+
+    liquidityTable.update(secondaryTokenBrand, {
+      liquidityTokenSupply: liquidityTokenSupply - liquidityExtentIn,
+    });
+
+    zcf.reallocate(
+      harden([offerHandle, poolHandle]),
+      harden([newUserAmounts, newPoolAmounts]),
+    );
+    zcf.complete(harden([offerHandle]));
+    return 'Liquidity successfully removed.';
+  };
+
+  const swapHook = offerHandle => {
+    const {
+      give: {
+        In: { brand: brandIn },
+      },
+      want: {
+        Out: { brand: brandOut },
+      },
+    } = zcf.getOffer(offerHandle).proposal;
+
+    const expected = harden({
+      give: { In: null },
+      want: { Out: null },
+    });
+    rejectIfNotProposal(offerHandle, expected);
+
+    // we could be swapping (1) central to secondary, (2) secondary to
+    // central, or (3) secondary to secondary.
+
+    // 1) central to secondary
+    if (brandIn === centralTokenBrand) {
+      rejectIfNotTokenBrand(offerHandle, brandOut);
+
+      const { poolHandle, newUserAmounts, newPoolAmounts } = doSwap(
+        harden({
+          userAllocation: zcf.getCurrentAllocation(offerHandle),
+          keywordIn: 'CentralToken',
+          keywordOut: liquidityTable.get(brandOut).tokenKeyword,
+          secondaryBrand: brandOut,
+        }),
+      );
+      zcf.reallocate(
+        harden([offerHandle, poolHandle]),
+        harden([newUserAmounts, newPoolAmounts]),
+      );
+      zcf.complete(harden([offerHandle]));
+      return `Swap successfully completed.`;
+
+      // eslint-disable-next-line no-else-return
+    } else if (brandOut === centralTokenBrand) {
+      // 2) secondary to central
+      rejectIfNotTokenBrand(offerHandle, brandIn);
+      const { poolHandle, newUserAmounts, newPoolAmounts } = doSwap(
+        harden({
+          userAllocation: zcf.getCurrentAllocation(offerHandle),
+          keywordIn: liquidityTable.get(brandIn).tokenKeyword,
+          keywordOut: 'CentralToken',
+          secondaryBrand: brandIn,
+        }),
+      );
+      zcf.reallocate(
+        harden([offerHandle, poolHandle]),
+        harden([newUserAmounts, newPoolAmounts]),
+      );
+      zcf.complete(harden([offerHandle]));
+      return `Swap successfully completed.`;
+    } else {
+      // 3) secondary to secondary
+      rejectIfNotTokenBrand(offerHandle, brandIn);
+      rejectIfNotTokenBrand(offerHandle, brandOut);
+
+      const {
+        poolHandle: poolHandleA,
+        newUserAmounts: newUserAmountsA,
+        newPoolAmounts: newPoolAmountsA,
+      } = doSwap(
+        harden({
+          userAllocation: zcf.getCurrentAllocation(offerHandle),
+          keywordIn: liquidityTable.get(brandIn).tokenKeyword,
+          keywordOut: CENTRAL_TOKEN,
+          secondaryBrand: brandIn,
+        }),
+      );
+      const {
+        poolHandle: poolHandleB,
+        newUserAmounts,
+        newPoolAmounts: newPoolAmountsB,
+      } = doSwap(
+        harden({
+          userAllocation: { In: newUserAmountsA.Out },
+          keywordIn: CENTRAL_TOKEN,
+          keywordOut: liquidityTable.get(brandOut).tokenKeyword,
+          secondaryBrand: brandOut,
+        }),
+      );
+      const amountMathOut = zcf.getAmountMath(brandOut);
+      const amountMathIn = zcf.getAmountMath(brandIn);
+      const finalPoolAmountsA = {
+        ...newPoolAmountsA,
+        Out: amountMathOut.getEmpty(),
+      };
+      const finalPoolAmountsB = {
+        ...newPoolAmountsB,
+        In: amountMathIn.getEmpty(),
+      };
+      const finalUserAmounts = {
+        ...newUserAmounts,
+        In: newUserAmountsA.In,
+      };
+      zcf.reallocate(
+        harden([poolHandleA, poolHandleB, offerHandle]),
+        harden([finalPoolAmountsA, finalPoolAmountsB, finalUserAmounts]),
+      );
+      zcf.complete(harden([offerHandle]));
+      return `Swap successfully completed.`;
+    }
+  };
+
+  const makeAddLiquidityInvite = () =>
+    zcf.makeInvitation(addLiquidityHook, 'multipool autoswap add liquidity');
+
+  zcf.initPublicAPI(
+    harden({
+      getBrandKeywordRecord: () => {
+        return zcf.getInstanceRecord().brandKeywordRecord;
+      },
+      addPool,
+      getPoolAllocation,
+      getLiquidityIssuer: tokenBrand =>
+        liquidityTable.get(tokenBrand).liquidityIssuer,
+      /**
+       * `getCurrentPrice` calculates the result of a trade, given a certain
+       * amount of digital assets in.
+       * @param {Amount} amountIn - the amount of digital assets to be
+       * sent in
+       * @param {Brand} brandOut - the brand of the requested payment.
+       */
+      getCurrentPrice: (amountIn, brandOut) => {
+        const brandIn = amountIn.brand;
+        // brandIn could either be the central token brand, or one of
+        // the secondary token brands
+
+        // CentralToken to SecondaryToken
+        if (brandIn === centralTokenBrand) {
+          assert(
+            liquidityTable.has(brandOut),
+            details`brandOut ${brandOut} was not recognized`,
+          );
+          return doGetCurrentPrice(
+            harden({
+              amountIn,
+              keywordIn: CENTRAL_TOKEN,
+              keywordOut: liquidityTable.get(brandOut).tokenKeyword,
+              secondaryBrand: brandOut,
+            }),
+          );
+          // eslint-disable-next-line no-else-return
+        } else if (brandOut === centralTokenBrand) {
+          // SecondaryToken to CentralToken
+          assert(
+            liquidityTable.has(brandIn),
+            details`amountIn brand ${amountIn} was not recognized`,
+          );
+          return doGetCurrentPrice(
+            harden({
+              amountIn,
+              keywordIn: liquidityTable.get(brandIn).tokenKeyword,
+              keywordOut: CENTRAL_TOKEN,
+              secondaryBrand: brandIn,
+            }),
+          );
+        } else {
+          // SecondaryToken to SecondaryToken
+          assert(
+            liquidityTable.has(brandIn) && liquidityTable.has(brandOut),
+            details`amountIn brand ${brandIn} or brandOut ${brandOut} was not recognized`,
+          );
+
+          // We must do two consecutive `doGetCurrentPrice` calls: from
+          // the brandIn to the central token, then from the central
+          // token to the brandOut
+          const centralTokenAmount = doGetCurrentPrice(
+            harden({
+              amountIn,
+              keywordIn: liquidityTable.get(brandIn).tokenKeyword,
+              keywordOut: CENTRAL_TOKEN,
+              secondaryBrand: brandIn,
+            }),
+          );
+          return doGetCurrentPrice(
+            harden({
+              amountIn: centralTokenAmount,
+              keywordIn: CENTRAL_TOKEN,
+              keywordOut: liquidityTable.get(brandOut).tokenKeyword,
+              secondaryBrand: brandOut,
+            }),
+          );
+        }
+      },
+      makeSwapInvite: () => zcf.makeInvitation(swapHook, 'autoswap swap'),
+      makeAddLiquidityInvite,
+      makeRemoveLiquidityInvite: () =>
+        zcf.makeInvitation(removeLiquidityHook, 'autoswap remove liquidity'),
+    }),
+  );
+
+  return makeAddLiquidityInvite();
+};
+
+harden(makeContract);
+export { makeContract };

--- a/packages/zoe/src/contracts/publicAuction.js
+++ b/packages/zoe/src/contracts/publicAuction.js
@@ -11,119 +11,139 @@ import {
   closeAuction,
 } from '../contractSupport';
 
-/** @typedef {import('../zoe').ContractFacet} ContractFacet */
+/**
+ * An auction contract in which the seller offers an Asset for sale, and states
+ * a minimum price. A pre-announced number of bidders compete to offer the best
+ * price. When the appropriate number of bids have been received, the second
+ * price rule is followed, so the highest bidder pays the amount bid by the
+ * second highest bidder.
+ *
+ * makeInstance() specifies the issuers and terms ({ numBidsAllowed }) specify
+ * the number of bids required. An invitation for the seller is returned. The
+ * seller's offer should look like
+ * { give: { Asset: asset }, want: { Ask: minimumBidAmount } }
+ * The asset can be non-fungible, but the Ask amount should be of a fungible
+ * brand.
+ * The bidder invitations are available from publicAPI.makeInvites(n). Each
+ * bidder can submit an offer: { give: { Bid: null } want: { Asset: null } }.
+ *
+ * publicAPI also has methods to find out what's being auctioned
+ * (getAuctionedAssetsAmounts()), or the minimum bid (getMinimumBid()).
+ *
+ * @typedef {import('../zoe').ContractFacet} ContractFacet
+ * @param {ContractFacet} zcf
+ */
+const makeContract = zcf => {
+  const {
+    rejectOffer,
+    canTradeWithMapKeywords,
+    assertKeywords,
+    checkHook,
+  } = makeZoeHelpers(zcf);
 
-// zcf is the Zoe Contract Facet, i.e. the contract-facing API of Zoe
-export const makeContract = harden(
-  /** @param {ContractFacet} zcf */ zcf => {
-    const {
-      rejectOffer,
-      canTradeWithMapKeywords,
-      assertKeywords,
-      checkHook,
-    } = makeZoeHelpers(zcf);
+  let {
+    terms: { numBidsAllowed },
+  } = zcf.getInstanceRecord();
+  numBidsAllowed = Nat(numBidsAllowed !== undefined ? numBidsAllowed : 3);
 
-    let {
-      terms: { numBidsAllowed },
-    } = zcf.getInstanceRecord();
-    numBidsAllowed = Nat(numBidsAllowed !== undefined ? numBidsAllowed : 3);
+  let sellerOfferHandle;
+  let minimumBid;
+  let auctionedAssets;
+  const allBidHandles = [];
 
-    let sellerOfferHandle;
-    let minimumBid;
-    let auctionedAssets;
-    const allBidHandles = [];
+  // seller will use 'Asset' and 'Ask'. buyer will use 'Asset' and 'Bid'
+  assertKeywords(harden(['Asset', 'Ask']));
 
-    // seller will use 'Asset' and 'Ask'. buyer will use 'Asset' and 'Bid'
-    assertKeywords(harden(['Asset', 'Ask']));
+  const bidderOfferHook = offerHandle => {
+    // Check that the item is still up for auction
+    if (!zcf.isOfferActive(sellerOfferHandle)) {
+      const rejectMsg = `The item up for auction is not available or the auction has completed`;
+      throw rejectOffer(offerHandle, rejectMsg);
+    }
+    if (allBidHandles.length >= numBidsAllowed) {
+      throw rejectOffer(offerHandle, `No further bids allowed.`);
+    }
+    if (
+      !canTradeWithMapKeywords(sellerOfferHandle, offerHandle, [
+        ['Asset', 'Ask'],
+        ['Asset', 'Bid'],
+      ])
+    ) {
+      const rejectMsg = `Bid was under minimum bid or for the wrong assets`;
+      throw rejectOffer(offerHandle, rejectMsg);
+    }
 
-    const bidderOfferHook = offerHandle => {
-      // Check that the item is still up for auction
-      if (!zcf.isOfferActive(sellerOfferHandle)) {
-        const rejectMsg = `The item up for auction is not available or the auction has completed`;
-        throw rejectOffer(offerHandle, rejectMsg);
-      }
-      if (allBidHandles.length >= numBidsAllowed) {
-        throw rejectOffer(offerHandle, `No further bids allowed.`);
-      }
-      if (
-        !canTradeWithMapKeywords(sellerOfferHandle, offerHandle, [
-          ['Asset', 'Ask'],
-          ['Asset', 'Bid'],
-        ])
-      ) {
-        const rejectMsg = `Bid was under minimum bid or for the wrong assets`;
-        throw rejectOffer(offerHandle, rejectMsg);
-      }
+    // Save valid bid and try to close.
+    allBidHandles.push(offerHandle);
+    if (allBidHandles.length >= numBidsAllowed) {
+      closeAuction(zcf, {
+        auctionLogicFn: secondPriceLogic,
+        sellerOfferHandle,
+        allBidHandles,
+      });
+    }
+    return defaultAcceptanceMsg;
+  };
 
-      // Save valid bid and try to close.
-      allBidHandles.push(offerHandle);
-      if (allBidHandles.length >= numBidsAllowed) {
-        closeAuction(zcf, {
-          auctionLogicFn: secondPriceLogic,
-          sellerOfferHandle,
-          allBidHandles,
-        });
-      }
-      return defaultAcceptanceMsg;
-    };
+  const bidderOfferExpected = harden({
+    give: { Bid: null },
+    want: { Asset: null },
+  });
 
-    const bidderOfferExpected = harden({
-      give: { Bid: null },
-      want: { Asset: null },
-    });
-
-    const makeBidderInvite = () =>
-      zcf.makeInvitation(
-        checkHook(bidderOfferHook, bidderOfferExpected),
-        'bid',
-        harden({
-          customProperties: {
-            auctionedAssets,
-            minimumBid,
-          },
-        }),
-      );
-
-    const sellerOfferHook = offerHandle => {
-      if (auctionedAssets) {
-        throw rejectOffer(offerHandle, `assets already present`);
-      }
-      // Save the valid offer
-      sellerOfferHandle = offerHandle;
-      const { proposal } = zcf.getOffer(offerHandle);
-      auctionedAssets = proposal.give.Asset;
-      minimumBid = proposal.want.Ask;
-      return defaultAcceptanceMsg;
-    };
-
-    const sellerOfferExpected = harden({
-      give: { Asset: null },
-      want: { Ask: null },
-    });
-
-    const makeSellerInvite = () =>
-      zcf.makeInvitation(
-        checkHook(sellerOfferHook, sellerOfferExpected),
-        'sellAssets',
-      );
-
-    zcf.initPublicAPI(
+  const makeBidderInvite = () =>
+    zcf.makeInvitation(
+      checkHook(bidderOfferHook, bidderOfferExpected),
+      'bid',
       harden({
-        makeInvites: numInvites => {
-          if (auctionedAssets === undefined) {
-            throw new Error(`No assets are up for auction.`);
-          }
-          const invites = [];
-          for (let i = 0; i < numInvites; i += 1) {
-            invites.push(makeBidderInvite());
-          }
-          return invites;
+        customProperties: {
+          auctionedAssets,
+          minimumBid,
         },
-        getAuctionedAssetsAmounts: () => auctionedAssets,
-        getMinimumBid: () => minimumBid,
       }),
     );
 
-    return makeSellerInvite();
-  },
-);
+  const sellerOfferHook = offerHandle => {
+    if (auctionedAssets) {
+      throw rejectOffer(offerHandle, `assets already present`);
+    }
+    // Save the valid offer
+    sellerOfferHandle = offerHandle;
+    const { proposal } = zcf.getOffer(offerHandle);
+    auctionedAssets = proposal.give.Asset;
+    minimumBid = proposal.want.Ask;
+    return defaultAcceptanceMsg;
+  };
+
+  const sellerOfferExpected = harden({
+    give: { Asset: null },
+    want: { Ask: null },
+  });
+
+  const makeSellerInvite = () =>
+    zcf.makeInvitation(
+      checkHook(sellerOfferHook, sellerOfferExpected),
+      'sellAssets',
+    );
+
+  zcf.initPublicAPI(
+    harden({
+      makeInvites: numInvites => {
+        if (auctionedAssets === undefined) {
+          throw new Error(`No assets are up for auction.`);
+        }
+        const invites = [];
+        for (let i = 0; i < numInvites; i += 1) {
+          invites.push(makeBidderInvite());
+        }
+        return invites;
+      },
+      getAuctionedAssetsAmounts: () => auctionedAssets,
+      getMinimumBid: () => minimumBid,
+    }),
+  );
+
+  return makeSellerInvite();
+};
+
+harden(makeContract);
+export { makeContract };

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -14,111 +14,120 @@ import { makeZoeHelpers, defaultAcceptanceMsg } from '../contractSupport';
  *
  * The `pricePerItem` is to be set in the terms. It is expected that all items
  * are sold for the same uniform price.
+ *
+ * The initial offer should be { give: { Items: items } }, accompanied by
+ * terms as described above.
+ * Buyers use offers that match { want: { Items: items } give: { Money: m } }.
+ * The items provided should match particular items that the seller still has
+ * available to sell, and the money should be pricePerItem times the number of
+ * items requested.
+ *
+ * @typedef {import('../zoe').ContractFacet} ContractFacet
+ * @param {ContractFacet} zcf
  */
+const makeContract = zcf => {
+  const allKeywords = ['Items', 'Money'];
+  const {
+    assertKeywords,
+    rejectOffer,
+    checkHook,
+    assertNatMathHelpers,
+  } = makeZoeHelpers(zcf);
+  assertKeywords(harden(allKeywords));
 
-// zcf is the Zoe Contract Facet, i.e. the contract-facing API of Zoe
-export const makeContract = harden(
-  /** @param {ContractFacet} zcf */ zcf => {
-    const allKeywords = ['Items', 'Money'];
-    const {
-      assertKeywords,
-      rejectOffer,
-      checkHook,
-      assertNatMathHelpers,
-    } = makeZoeHelpers(zcf);
-    assertKeywords(harden(allKeywords));
+  const { pricePerItem } = zcf.getInstanceRecord().terms;
+  assertNatMathHelpers(pricePerItem.brand);
+  let sellerOfferHandle;
 
-    const { pricePerItem } = zcf.getInstanceRecord().terms;
-    assertNatMathHelpers(pricePerItem.brand);
-    let sellerOfferHandle;
+  const sellerOfferHook = offerHandle => {
+    sellerOfferHandle = offerHandle;
+    return defaultAcceptanceMsg;
+  };
 
-    const sellerOfferHook = offerHandle => {
-      sellerOfferHandle = offerHandle;
-      return defaultAcceptanceMsg;
-    };
-
-    const buyerOfferHook = buyerOfferHandle => {
-      const { brandKeywordRecord } = zcf.getInstanceRecord();
-      const [sellerAllocation, buyerAllocation] = zcf.getCurrentAllocations(
-        [sellerOfferHandle, buyerOfferHandle],
-        [brandKeywordRecord, brandKeywordRecord],
-      );
-      const currentItemsForSale = sellerAllocation.Items;
-      const providedMoney = buyerAllocation.Money;
-
-      const { proposal } = zcf.getOffer(buyerOfferHandle);
-      const wantedItems = proposal.want.Items;
-      const numItemsWanted = wantedItems.extent.length;
-      const totalCostExtent = pricePerItem.extent * numItemsWanted;
-      const moneyAmountMaths = zcf.getAmountMath(pricePerItem.brand);
-      const itemsAmountMath = zcf.getAmountMath(wantedItems.brand);
-
-      const totalCost = moneyAmountMaths.make(totalCostExtent);
-
-      // Check that the wanted items are still for sale.
-      if (!itemsAmountMath.isGTE(currentItemsForSale, wantedItems)) {
-        return rejectOffer(
-          buyerOfferHandle,
-          `Some of the wanted items were not available for sale`,
-        );
-      }
-
-      // Check that the money provided to pay for the items is greater than the totalCost.
-      if (!moneyAmountMaths.isGTE(providedMoney, totalCost)) {
-        return rejectOffer(
-          buyerOfferHandle,
-          `More money (${totalCost}) is required to buy these items`,
-        );
-      }
-
-      // Reallocate and complete the buyer offer.
-      const newSellerAllocation = {
-        Money: moneyAmountMaths.add(sellerAllocation.Money, providedMoney),
-        Items: itemsAmountMath.subtract(sellerAllocation.Items, wantedItems),
-      };
-
-      const newBuyerAllocation = {
-        Money: moneyAmountMaths.getEmpty(),
-        Items: itemsAmountMath.add(buyerAllocation.Items, wantedItems),
-      };
-
-      zcf.reallocate(
-        [sellerOfferHandle, buyerOfferHandle],
-        [newSellerAllocation, newBuyerAllocation],
-      );
-      zcf.complete([buyerOfferHandle]);
-      return defaultAcceptanceMsg;
-    };
-
-    const buyerExpected = harden({
-      want: { Items: null },
-      give: { Money: null },
-    });
-
-    zcf.initPublicAPI(
-      harden({
-        makeBuyerInvite: () => {
-          const itemsAmount = zcf.getCurrentAllocation(sellerOfferHandle).Items;
-          const itemsAmountMath = zcf.getAmountMath(itemsAmount.brand);
-          assert(
-            sellerOfferHandle && !itemsAmountMath.isEmpty(itemsAmount),
-            details`no items are for sale`,
-          );
-          return zcf.makeInvitation(
-            checkHook(buyerOfferHook, buyerExpected),
-            'buyer',
-          );
-        },
-        getAvailableItems: () => {
-          if (!sellerOfferHandle) {
-            throw new Error(`no items have been escrowed`);
-          }
-          return zcf.getCurrentAllocation(sellerOfferHandle).Items;
-        },
-        getItemsIssuer: () => zcf.getInstanceRecord().issuerKeywordRecord.Items,
-      }),
+  const buyerOfferHook = buyerOfferHandle => {
+    const { brandKeywordRecord } = zcf.getInstanceRecord();
+    const [sellerAllocation, buyerAllocation] = zcf.getCurrentAllocations(
+      [sellerOfferHandle, buyerOfferHandle],
+      [brandKeywordRecord, brandKeywordRecord],
     );
+    const currentItemsForSale = sellerAllocation.Items;
+    const providedMoney = buyerAllocation.Money;
 
-    return zcf.makeInvitation(sellerOfferHook, 'seller');
-  },
-);
+    const { proposal } = zcf.getOffer(buyerOfferHandle);
+    const wantedItems = proposal.want.Items;
+    const numItemsWanted = wantedItems.extent.length;
+    const totalCostExtent = pricePerItem.extent * numItemsWanted;
+    const moneyAmountMaths = zcf.getAmountMath(pricePerItem.brand);
+    const itemsAmountMath = zcf.getAmountMath(wantedItems.brand);
+
+    const totalCost = moneyAmountMaths.make(totalCostExtent);
+
+    // Check that the wanted items are still for sale.
+    if (!itemsAmountMath.isGTE(currentItemsForSale, wantedItems)) {
+      return rejectOffer(
+        buyerOfferHandle,
+        `Some of the wanted items were not available for sale`,
+      );
+    }
+
+    // Check that the money provided to pay for the items is greater than the totalCost.
+    if (!moneyAmountMaths.isGTE(providedMoney, totalCost)) {
+      return rejectOffer(
+        buyerOfferHandle,
+        `More money (${totalCost}) is required to buy these items`,
+      );
+    }
+
+    // Reallocate and complete the buyer offer.
+    const newSellerAllocation = {
+      Money: moneyAmountMaths.add(sellerAllocation.Money, providedMoney),
+      Items: itemsAmountMath.subtract(sellerAllocation.Items, wantedItems),
+    };
+
+    const newBuyerAllocation = {
+      Money: moneyAmountMaths.getEmpty(),
+      Items: itemsAmountMath.add(buyerAllocation.Items, wantedItems),
+    };
+
+    zcf.reallocate(
+      [sellerOfferHandle, buyerOfferHandle],
+      [newSellerAllocation, newBuyerAllocation],
+    );
+    zcf.complete([buyerOfferHandle]);
+    return defaultAcceptanceMsg;
+  };
+
+  const buyerExpected = harden({
+    want: { Items: null },
+    give: { Money: null },
+  });
+
+  zcf.initPublicAPI(
+    harden({
+      makeBuyerInvite: () => {
+        const itemsAmount = zcf.getCurrentAllocation(sellerOfferHandle).Items;
+        const itemsAmountMath = zcf.getAmountMath(itemsAmount.brand);
+        assert(
+          sellerOfferHandle && !itemsAmountMath.isEmpty(itemsAmount),
+          details`no items are for sale`,
+        );
+        return zcf.makeInvitation(
+          checkHook(buyerOfferHook, buyerExpected),
+          'buyer',
+        );
+      },
+      getAvailableItems: () => {
+        if (!sellerOfferHandle) {
+          throw new Error(`no items have been escrowed`);
+        }
+        return zcf.getCurrentAllocation(sellerOfferHandle).Items;
+      },
+      getItemsIssuer: () => zcf.getInstanceRecord().issuerKeywordRecord.Items,
+    }),
+  );
+
+  return zcf.makeInvitation(sellerOfferHook, 'seller');
+};
+
+harden(makeContract);
+export { makeContract };

--- a/packages/zoe/src/contracts/simpleExchange.js
+++ b/packages/zoe/src/contracts/simpleExchange.js
@@ -5,13 +5,13 @@ import { produceNotifier } from '@agoric/notifier';
 import { makeZoeHelpers, defaultAcceptanceMsg } from '../contractSupport';
 
 /**
- * @typedef {import('../zoe').ContractFacet} ContractFacet
- */
-
-/**
- * The SimpleExchange uses Asset and Price as its keywords. In usage,
- * they're somewhat symmetrical. Participants will be buying or
- * selling in both directions.
+ * SimpleExchange is an exchange with a simple matching algorithm, which allows
+ * an unlimited number of parties to create new orders or accept existing
+ * orders. The notifier allows callers to find the current list of orders.
+ *
+ * The SimpleExchange uses Asset and Price as its keywords. The contract treats
+ * the two keywords symmetrically. New offers can be created and existing offers
+ * can be accepted in either direction.
  *
  * { give: { 'Asset', simoleans(5) }, want: { 'Price', quatloos(3) } }
  * { give: { 'Price', quatloos(8) }, want: { 'Asset', simoleans(3) } }
@@ -19,131 +19,138 @@ import { makeZoeHelpers, defaultAcceptanceMsg } from '../contractSupport';
  * The Asset is treated as an exact amount to be exchanged, while the
  * Price is a limit that may be improved on. This simple exchange does
  * not partially fill orders.
+ *
+ * The invitation returned on installation of the contract is the same as what
+ * is returned by calling `publicAPI.makeInvite().
+ *
+ * @typedef {import('../zoe').ContractFacet} ContractFacet
+ * @param {ContractFacet} zcf
  */
-export const makeContract = harden(
-  /** @param {ContractFacet} zcf */ zcf => {
-    let sellOfferHandles = [];
-    let buyOfferHandles = [];
-    const { notifier, updater } = produceNotifier();
+const makeContract = zcf => {
+  let sellOfferHandles = [];
+  let buyOfferHandles = [];
+  const { notifier, updater } = produceNotifier();
 
-    const {
-      rejectOffer,
-      checkIfProposal,
-      swap,
-      canTradeWith,
-      getActiveOffers,
-      assertKeywords,
-    } = makeZoeHelpers(zcf);
+  const {
+    rejectOffer,
+    checkIfProposal,
+    swap,
+    canTradeWith,
+    getActiveOffers,
+    assertKeywords,
+  } = makeZoeHelpers(zcf);
 
-    assertKeywords(harden(['Asset', 'Price']));
+  assertKeywords(harden(['Asset', 'Price']));
 
-    function flattenOffer(o) {
-      return {
-        want: o.proposal.want,
-        give: o.proposal.give,
-      };
-    }
-
-    function flattenOrders(offerHandles) {
-      const result = zcf
-        .getOffers(zcf.getOfferStatuses(offerHandles).active)
-        .map(offerRecord => flattenOffer(offerRecord));
-      return result;
-    }
-
-    function getBookOrders() {
-      return {
-        buys: flattenOrders(buyOfferHandles),
-        sells: flattenOrders(sellOfferHandles),
-      };
-    }
-
-    function getOffer(offerHandle) {
-      for (const handle of [...sellOfferHandles, ...buyOfferHandles]) {
-        if (offerHandle === handle) {
-          return flattenOffer(getActiveOffers([offerHandle])[0]);
-        }
-      }
-      return 'not an active offer';
-    }
-
-    // Tell the notifier that there has been a change to the book orders
-    function bookOrdersChanged() {
-      updater.updateState(getBookOrders());
-    }
-
-    // If there's an existing offer that this offer is a match for, make the trade
-    // and return the handle for the matched offer. If not, return undefined, so
-    // the caller can know to add the new offer to the book.
-    function swapIfCanTrade(offerHandles, offerHandle) {
-      for (const iHandle of offerHandles) {
-        if (canTradeWith(offerHandle, iHandle)) {
-          swap(offerHandle, iHandle);
-          // return handle to remove
-          return iHandle;
-        }
-      }
-      return undefined;
-    }
-
-    // try to swap offerHandle with one of the counterOffers. If it works, remove
-    // the matching offer and return the remaining counterOffers. If there's no
-    // matching offer, add the offerHandle to the coOffers, and return the
-    // unmodified counterOfffers
-    function swapIfCanTradeAndUpdateBook(counterOffers, coOffers, offerHandle) {
-      const handle = swapIfCanTrade(counterOffers, offerHandle);
-      if (handle) {
-        // remove the matched offer.
-        counterOffers = counterOffers.filter(value => value !== handle);
-      } else {
-        // Save the order in the book
-        coOffers.push(offerHandle);
-      }
-
-      return counterOffers;
-    }
-
-    const exchangeOfferHook = offerHandle => {
-      const buyAssetForPrice = harden({
-        give: { Price: null },
-        want: { Asset: null },
-      });
-      const sellAssetForPrice = harden({
-        give: { Asset: null },
-        want: { Price: null },
-      });
-      if (checkIfProposal(offerHandle, sellAssetForPrice)) {
-        buyOfferHandles = swapIfCanTradeAndUpdateBook(
-          buyOfferHandles,
-          sellOfferHandles,
-          offerHandle,
-        );
-        /* eslint-disable no-else-return */
-      } else if (checkIfProposal(offerHandle, buyAssetForPrice)) {
-        sellOfferHandles = swapIfCanTradeAndUpdateBook(
-          sellOfferHandles,
-          buyOfferHandles,
-          offerHandle,
-        );
-      } else {
-        // Eject because the offer must be invalid
-        return rejectOffer(offerHandle);
-      }
-      bookOrdersChanged();
-      return defaultAcceptanceMsg;
+  function flattenOffer(o) {
+    return {
+      want: o.proposal.want,
+      give: o.proposal.give,
     };
+  }
 
-    const makeExchangeInvite = () =>
-      zcf.makeInvitation(exchangeOfferHook, 'exchange');
+  function flattenOrders(offerHandles) {
+    const result = zcf
+      .getOffers(zcf.getOfferStatuses(offerHandles).active)
+      .map(offerRecord => flattenOffer(offerRecord));
+    return result;
+  }
 
-    zcf.initPublicAPI(
-      harden({
-        makeInvite: makeExchangeInvite,
-        getOffer,
-        getNotifier: () => notifier,
-      }),
-    );
+  function getBookOrders() {
+    return {
+      buys: flattenOrders(buyOfferHandles),
+      sells: flattenOrders(sellOfferHandles),
+    };
+  }
 
-    return makeExchangeInvite();
-  },
-);
+  function getOffer(offerHandle) {
+    for (const handle of [...sellOfferHandles, ...buyOfferHandles]) {
+      if (offerHandle === handle) {
+        return flattenOffer(getActiveOffers([offerHandle])[0]);
+      }
+    }
+    return 'not an active offer';
+  }
+
+  // Tell the notifier that there has been a change to the book orders
+  function bookOrdersChanged() {
+    updater.updateState(getBookOrders());
+  }
+
+  // If there's an existing offer that this offer is a match for, make the trade
+  // and return the handle for the matched offer. If not, return undefined, so
+  // the caller can know to add the new offer to the book.
+  function swapIfCanTrade(offerHandles, offerHandle) {
+    for (const iHandle of offerHandles) {
+      if (canTradeWith(offerHandle, iHandle)) {
+        swap(offerHandle, iHandle);
+        // return handle to remove
+        return iHandle;
+      }
+    }
+    return undefined;
+  }
+
+  // try to swap offerHandle with one of the counterOffers. If it works, remove
+  // the matching offer and return the remaining counterOffers. If there's no
+  // matching offer, add the offerHandle to the coOffers, and return the
+  // unmodified counterOfffers
+  function swapIfCanTradeAndUpdateBook(counterOffers, coOffers, offerHandle) {
+    const handle = swapIfCanTrade(counterOffers, offerHandle);
+    if (handle) {
+      // remove the matched offer.
+      counterOffers = counterOffers.filter(value => value !== handle);
+    } else {
+      // Save the order in the book
+      coOffers.push(offerHandle);
+    }
+
+    return counterOffers;
+  }
+
+  const exchangeOfferHook = offerHandle => {
+    const buyAssetForPrice = harden({
+      give: { Price: null },
+      want: { Asset: null },
+    });
+    const sellAssetForPrice = harden({
+      give: { Asset: null },
+      want: { Price: null },
+    });
+    if (checkIfProposal(offerHandle, sellAssetForPrice)) {
+      buyOfferHandles = swapIfCanTradeAndUpdateBook(
+        buyOfferHandles,
+        sellOfferHandles,
+        offerHandle,
+      );
+      /* eslint-disable no-else-return */
+    } else if (checkIfProposal(offerHandle, buyAssetForPrice)) {
+      sellOfferHandles = swapIfCanTradeAndUpdateBook(
+        sellOfferHandles,
+        buyOfferHandles,
+        offerHandle,
+      );
+    } else {
+      // Eject because the offer must be invalid
+      return rejectOffer(offerHandle);
+    }
+    bookOrdersChanged();
+    return defaultAcceptanceMsg;
+  };
+
+  const makeExchangeInvite = () =>
+    zcf.makeInvitation(exchangeOfferHook, 'exchange');
+
+  zcf.initPublicAPI(
+    harden({
+      makeInvite: makeExchangeInvite,
+      getOffer,
+      getNotifier: () => notifier,
+    }),
+  );
+
+  return makeExchangeInvite();
+};
+
+harden(makeContract);
+export { makeContract };


### PR DESCRIPTION
I was going to touch every contract in order to change the way that
zcf is declared for typescript, so I fixed all the documentation as well.

I tried to make every contract's jsdoc say what's required from the terms and in the offer, as well as what the publicAPI allows.

I converted to makeStore in barterExchange.

Please let me know if you have a better idea than
```
const contractFn = zcf => {
 ...
}

export const makeContract = harden(contractFn);
```

It's sad that github can't recognize and display simple whitespace changes. Everything has been unindented by two spaces.  focus on the opening comments in every contract.

closes #1192