### PR TITLE
fix: shorten chain cadence to 2 seconds (instead of default 5)

### DIFF
--- a/packages/deployment/ansible/install-cosmos.yml
+++ b/packages/deployment/ansible/install-cosmos.yml
@@ -8,9 +8,10 @@
   vars:
     - service: ag-chain-cosmos
     - data: "{{ SETUP_HOME }}/{{ service }}/data"
-    - execline: "/usr/src/cosmic-swingset/lib/ag-chain-cosmos start --proxy_app=kvstore"
+    - execline: "/usr/src/cosmic-swingset/lib/ag-chain-cosmos start"
     - PERSISTENT_PEERS: "{{ lookup('file', SETUP_HOME + '/' + service + '/data/peers.txt') }}"
     - NUM_FILE_DESCRIPTORS: 2048
+    - BLOCK_CADENCE: 2s
   roles:
     - install-cosmos
 

--- a/packages/deployment/ansible/roles/install-cosmos/tasks/main.yml
+++ b/packages/deployment/ansible/roles/install-cosmos/tasks/main.yml
@@ -8,6 +8,20 @@
     group: "{{ service }}"
     mode: 0644
 
+- name: Set proxy_app
+  lineinfile:
+    path: "/home/{{ service }}/.{{ service }}/config/config.toml"
+    state: present
+    regexp: '^proxy_app *='
+    line: 'proxy_app = "kvstore"'
+
+- name: Set block commit cadence
+  lineinfile:
+    path: "/home/{{ service }}/.{{ service }}/config/config.toml"
+    state: present
+    regexp: '^timeout_commit *='
+    line: 'timeout_commit = "{{ BLOCK_CADENCE }}"'
+
 - name: Set persistent_peers
   lineinfile:
     path: "/home/{{ service }}/.{{ service }}/config/config.toml"


### PR DESCRIPTION
We tweak the chain's `config.toml` to use 2 seconds between blocks instead of 5 seconds.
