### PR TITLE
package.json: remove missing 'generator-agoric-dapp' package

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "packages/zoe",
     "packages/wallet-frontend",
     "packages/cosmic-swingset",
-    "packages/generator-agoric-dapp",
     "packages/agoric-cli",
     "packages/deployment",
     "packages/notifier"


### PR DESCRIPTION
Maybe this was leftover from when we kept dapps in this repo?