### PR TITLE
Add support for getting return value from exogenous kernel messages

### DIFF
--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -398,7 +398,7 @@ export default function buildKernel(kernelEndowments) {
   let kernelPanic = null;
 
   function panic(problem) {
-    console.log(`##### KERNEL PANIC: ${problem} #####`);
+    console.error(`##### KERNEL PANIC: ${problem} #####`);
     kernelPanic = new Error(`kernel panic ${problem}`);
   }
 
@@ -426,16 +426,15 @@ export default function buildKernel(kernelEndowments) {
     }
     insistCapData(args);
     args.slots.forEach(s => parseKernelSlot(s)); // typecheck
-    // we use result=null because this will be json stringified
 
     const resultPromise = kernelKeeper.addKernelPromise();
-    const result = makeMessageResult(method, policy, panic);
-    pendingMessageResults.set(resultPromise, result);
+    const [resultRead, resultWrite] = makeMessageResult(method, policy, panic);
+    pendingMessageResults.set(resultPromise, resultWrite);
 
     const msg = harden({ method, args, result: resultPromise });
     const kernelSlot = addExport(vatID, vatSlot);
     send(kernelSlot, msg);
-    return result;
+    return resultRead;
   }
 
   async function deliverToVat(vatID, target, msg) {

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -402,7 +402,7 @@ export default function buildKernel(kernelEndowments) {
     kernelPanic = new Error(`kernel panic ${problem}`);
   }
 
-  function queueToExport(vatID, vatSlot, method, args, resultPolicy = 'ignore') {
+  function queueToExport(vatID, vatSlot, method, args, policy = 'ignore') {
     // queue a message on the end of the queue, with 'absolute' kernelSlots.
     // Use 'step' or 'run' to execute it
     vatID = `${vatID}`;
@@ -429,7 +429,7 @@ export default function buildKernel(kernelEndowments) {
     // we use result=null because this will be json stringified
 
     const resultPromise = kernelKeeper.addKernelPromise();
-    const result = makeMessageResult(method, resultPolicy, panic);
+    const result = makeMessageResult(method, policy, panic);
     pendingMessageResults.set(resultPromise, result);
 
     const msg = harden({ method, args, result: resultPromise });

--- a/packages/SwingSet/src/kernel/messageResult.js
+++ b/packages/SwingSet/src/kernel/messageResult.js
@@ -1,0 +1,68 @@
+/* global harden */
+
+import { assert, details } from '@agoric/assert';
+import { insistCapData } from '../capdata';
+
+export function makeMessageResult(message, resultPolicy, panic) {
+  let currentStatus = 'pending';
+  let eventualResolution;
+
+  assert(
+    resultPolicy === 'logAlways' ||
+      resultPolicy === 'logFailure' ||
+      resultPolicy === 'panic' ||
+      resultPolicy === 'ignore',
+    details`invalid result policy ${resultPolicy}`,
+  );
+  assert.typeof(panic, 'function');
+
+  function log() {
+    // prettier-ignore
+    console.log(
+      `kernel message ${message}: ${currentStatus} ${JSON.stringify(eventualResolution)}`,
+    );
+  }
+
+  return harden({
+    status() {
+      return currentStatus;
+    },
+    resolution() {
+      if (currentStatus === 'pending') {
+        throw new Error(`resolution of result is still pending`);
+      } else {
+        return eventualResolution;
+      }
+    },
+    noteResolution(newStatus, resolvedTo) {
+      assert(currentStatus === 'pending', 'already resolved');
+      assert(
+        newStatus === 'fulfilled' || newStatus === 'rejected',
+        details`invalid newStatus ${newStatus}`,
+      );
+      insistCapData(resolvedTo);
+      currentStatus = newStatus;
+      eventualResolution = resolvedTo;
+      switch (resultPolicy) {
+        case 'logAlways':
+          log();
+          break;
+        case 'logFailure':
+          if (newStatus === 'rejected') {
+            log();
+          }
+          break;
+        case 'panic':
+          if (newStatus === 'rejected') {
+            log();
+            panic(`${message} failure`);
+          }
+          break;
+        case 'ignore':
+          break;
+        default:
+          throw new Error("this can't happen");
+      }
+    },
+  });
+}

--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -40,7 +40,7 @@ export function initializeVatState(storage, vatID) {
  * @param vatID  The vat ID string of the vat in question
  * @param addKernelObject  Kernel function to add a new object to the kernel's
  *    mapping tables.
- * @param addKernelPromise  Kernel function to add a new promise to the
+ * @param addKernelPromiseForVat  Kernel function to add a new promise to the
  *    kernel's mapping tables.
  *
  * @return an object to hold and access the kernel's state for the given vat
@@ -49,7 +49,7 @@ export function makeVatKeeper(
   storage,
   vatID,
   addKernelObject,
-  addKernelPromise,
+  addKernelPromiseForVat,
   incrementRefCount,
   decrementRefCount,
   incStat,
@@ -81,7 +81,7 @@ export function makeVatKeeper(
         } else if (type === 'device') {
           throw new Error(`normal vats aren't allowed to export device nodes`);
         } else if (type === 'promise') {
-          kernelSlot = addKernelPromise(vatID);
+          kernelSlot = addKernelPromiseForVat(vatID);
         } else {
           throw new Error(`unknown type ${type}`);
         }

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -52,7 +52,7 @@ async function simpleCall(t, withSES) {
       msg: {
         method: 'foo',
         args: capdata('args'),
-        result: null,
+        result: 'kp40',
       },
       target: 'ko20',
       type: 'send',
@@ -137,7 +137,7 @@ async function bootstrapExport(t, withSES) {
   t.deepEqual(c.dump().runQueue, [
     {
       msg: {
-        result: null,
+        result: 'kp40',
         method: 'bootstrap',
         args: {
           body:
@@ -158,7 +158,7 @@ async function bootstrapExport(t, withSES) {
   // console.log('--- c.step() running bootstrap.obj0.bootstrap');
   await c.step();
   // kernel promise for result of the foo() that bootstrap sends to vat-left
-  const fooP = 'kp40';
+  const fooP = 'kp41';
   t.deepEqual(c.dump().log, [
     'left.setup called',
     'right.setup called',
@@ -187,7 +187,7 @@ async function bootstrapExport(t, withSES) {
   ]);
 
   await c.step();
-  const barP = 'kp41';
+  const barP = 'kp42';
   t.deepEqual(c.dump().log, [
     'left.setup called',
     'right.setup called',

--- a/packages/SwingSet/test/test-exomessages.js
+++ b/packages/SwingSet/test/test-exomessages.js
@@ -1,0 +1,121 @@
+import '@agoric/install-ses';
+import { test } from 'tape-promise/tape';
+import { buildVatController } from '../src/index';
+
+async function beginning(t, mode) {
+  const config = { bootstrapIndexJS: require.resolve(`./vat-exomessages.js`) };
+  const controller = await buildVatController(config, true, [mode]);
+  t.equal(controller.bootstrapResult.status(), 'pending');
+  return controller;
+}
+
+async function bootstrapSuccessfully(t, mode, body, slots) {
+  const controller = await beginning(t, mode);
+  await controller.run();
+  t.equal(controller.bootstrapResult.status(), 'fulfilled');
+  t.deepEqual(controller.bootstrapResult.resolution(), {
+    body,
+    slots,
+  });
+  t.end();
+}
+
+test('bootstrap returns data', async t => {
+  await bootstrapSuccessfully(
+    t,
+    'data',
+    '"a big hello to all intelligent lifeforms everywhere"',
+    [],
+  );
+});
+
+test('bootstrap returns presence', async t => {
+  // prettier-ignore
+  await bootstrapSuccessfully(
+    t,
+    'presence',
+    '{"@qclass":"slot",index:0}',
+    ['ko22'],
+  );
+});
+
+test('bootstrap returns void', async t => {
+  await bootstrapSuccessfully(t, 'void', '{"@qclass":"undefined"}', []);
+});
+
+async function testFailure(t) {
+  const controller = await beginning(t, 'reject');
+  let failureHappened = false;
+  try {
+    await controller.run();
+  } catch (e) {
+    failureHappened = true;
+    t.equal(e.message, 'kernel panic bootstrap failure');
+  }
+  t.ok(failureHappened);
+  t.equal(controller.bootstrapResult.status(), 'rejected');
+  t.deepEqual(controller.bootstrapResult.resolution(), {
+    body: '{"@qclass":"error","name":"Error","message":"gratuitous error"}',
+    slots: [],
+  });
+  t.end();
+}
+
+test('bootstrap failure', async t => {
+  await testFailure(t);
+});
+
+async function extraMessage(t, mode, status, body, slots) {
+  const controller = await beginning(t, 'data');
+  await controller.run();
+  const args = { body: `["${mode}"]`, slots: [] };
+  const extraResult = controller.queueToVatExport(
+    '_bootstrap',
+    'o+0',
+    'extra',
+    args,
+    'ignore',
+  );
+  await controller.run();
+  t.equal(extraResult.status(), status);
+  t.deepEqual(extraResult.resolution(), {
+    body,
+    slots,
+  });
+  t.end();
+}
+
+test('extra message returns data', async t => {
+  await extraMessage(
+    t,
+    'data',
+    'fulfilled',
+    '"a big hello to all intelligent lifeforms everywhere"',
+    [],
+  );
+});
+
+test('extra message returns presence', async t => {
+  // prettier-ignore
+  await extraMessage(
+    t,
+    'presence',
+    'fulfilled',
+    '{"@qclass":"slot",index:0}',
+    ['ko22'],
+  );
+});
+
+test('extra message returns void', async t => {
+  await extraMessage(t, 'void', 'fulfilled', '{"@qclass":"undefined"}', []);
+});
+
+test('extra message rejects', async t => {
+  await extraMessage(
+    t,
+    'reject',
+    'rejected',
+    '{"@qclass":"error","name":"Error","message":"gratuitous error"}',
+    [],
+  );
+});

--- a/packages/SwingSet/test/test-kernel.js
+++ b/packages/SwingSet/test/test-kernel.js
@@ -77,7 +77,7 @@ test('simple call', async t => {
       msg: {
         method: 'foo',
         args: capdata('args'),
-        result: null,
+        result: 'kp40',
       },
     },
   ]);
@@ -128,7 +128,7 @@ test('map inbound', async t => {
       msg: {
         method: 'foo',
         args: capdata('args', [koFor5, koFor6]),
-        result: null,
+        result: 'kp40',
       },
     },
   ]);
@@ -140,6 +140,7 @@ test('map inbound', async t => {
     [koFor6, vat1, 'o-50'],
     [koFor6, vat2, 'o+6'],
     ['ko22', vat1, 'o+1'],
+    ['kp40', vat1, 'p-60'],
   ]);
 
   t.end();
@@ -236,7 +237,7 @@ test('outbound call', async t => {
       msg: {
         method: 'foo',
         args: capdata('args'),
-        result: null,
+        result: 'kp40',
       },
     },
   ]);
@@ -253,8 +254,8 @@ test('outbound call', async t => {
       target: vat2Obj5,
       msg: {
         method: 'bar',
-        args: capdata('bargs', [vat2Obj5, 'ko22', 'kp40']),
-        result: 'kp41',
+        args: capdata('bargs', [vat2Obj5, 'ko22', 'kp41']),
+        result: 'kp42',
       },
     },
   ]);
@@ -262,13 +263,21 @@ test('outbound call', async t => {
     {
       id: 'kp40',
       state: 'unresolved',
-      refCount: 2,
+      refCount: 1,
       decider: vat1,
       subscribers: [],
       queue: [],
     },
     {
       id: 'kp41',
+      state: 'unresolved',
+      refCount: 2,
+      decider: vat1,
+      subscribers: [],
+      queue: [],
+    },
+    {
+      id: 'kp42',
       state: 'unresolved',
       refCount: 2,
       decider: undefined,
@@ -278,8 +287,9 @@ test('outbound call', async t => {
   ]);
 
   kt.push(['ko22', vat1, 'o+7']);
-  kt.push(['kp40', vat1, p7]);
-  kt.push(['kp41', vat1, 'p+5']);
+  kt.push(['kp40', vat1, 'p-60']);
+  kt.push(['kp41', vat1, p7]);
+  kt.push(['kp42', vat1, 'p+5']);
   checkKT(t, kernel, kt);
 
   await kernel.step();
@@ -292,13 +302,21 @@ test('outbound call', async t => {
         {
           id: 'kp40',
           state: 'unresolved',
-          refCount: 2,
+          refCount: 1,
           decider: vat1,
           subscribers: [],
           queue: [],
         },
         {
           id: 'kp41',
+          state: 'unresolved',
+          refCount: 2,
+          decider: vat1,
+          subscribers: [],
+          queue: [],
+        },
+        {
+          id: 'kp42',
           state: 'unresolved',
           refCount: 2,
           decider: vat2,
@@ -310,13 +328,21 @@ test('outbound call', async t => {
   ]);
 
   kt.push(['ko22', vat2, 'o-50']);
-  kt.push(['kp41', vat2, 'p-61']);
-  kt.push(['kp40', vat2, 'p-60']);
+  kt.push(['kp42', vat2, 'p-61']);
+  kt.push(['kp41', vat2, 'p-60']);
   checkKT(t, kernel, kt);
 
   t.deepEqual(kernel.dump().promises, [
     {
       id: 'kp40',
+      state: 'unresolved',
+      refCount: 1,
+      decider: vat1,
+      subscribers: [],
+      queue: [],
+    },
+    {
+      id: 'kp41',
       state: 'unresolved',
       refCount: 2,
       decider: vat1,
@@ -328,7 +354,7 @@ test('outbound call', async t => {
       queue: [],
     },
     {
-      id: 'kp41',
+      id: 'kp42',
       state: 'unresolved',
       refCount: 2,
       decider: vat2,
@@ -428,7 +454,7 @@ test('three-party', async t => {
       msg: {
         method: 'intro',
         args: capdata('bargs', [carol]),
-        result: 'kp41',
+        result: 'kp42',
       },
     },
   ]);
@@ -444,19 +470,28 @@ test('three-party', async t => {
     {
       id: 'kp41',
       state: 'unresolved',
+      refCount: 1,
+      decider: vatA,
+      subscribers: [],
+      queue: [],
+    },
+    {
+      id: 'kp42',
+      state: 'unresolved',
       refCount: 2,
       decider: undefined,
       subscribers: [],
       queue: [],
     },
   ]);
-  kt.push(['kp41', vatA, 'p+5']);
+  kt.push(['kp41', vatA, 'p-60']);
+  kt.push(['kp42', vatA, 'p+5']);
   checkKT(t, kernel, kt);
 
   await kernel.step();
   t.deepEqual(log, [['vatB', 'o+5', 'intro', capdata('bargs', ['o-50'])]]);
   kt.push([carol, vatB, 'o-50']);
-  kt.push(['kp41', vatB, 'p-60']);
+  kt.push(['kp42', vatB, 'p-60']);
   checkKT(t, kernel, kt);
 
   t.end();
@@ -882,7 +917,7 @@ test('transcript', async t => {
       aliceForAlice,
       'store',
       capdata('args string', [aliceForAlice, bobForAlice]),
-      null,
+      'p-60',
     ],
     syscalls: [
       {

--- a/packages/SwingSet/test/test-promises.js
+++ b/packages/SwingSet/test/test-promises.js
@@ -175,7 +175,16 @@ async function testCircularPromiseData(t, withSES) {
   await c.run();
   const expectedPromises = [
     {
-      id: 'kp40',
+      id: 'kp41',
+      state: 'fulfilledToData',
+      refCount: 3,
+      data: {
+        body: '[{"@qclass":"slot","index":0}]',
+        slots: ['kp42'],
+      },
+    },
+    {
+      id: 'kp42',
       state: 'fulfilledToData',
       refCount: 3,
       data: {
@@ -183,19 +192,10 @@ async function testCircularPromiseData(t, withSES) {
         slots: ['kp41'],
       },
     },
-    {
-      id: 'kp41',
-      state: 'fulfilledToData',
-      refCount: 3,
-      data: {
-        body: '[{"@qclass":"slot","index":0}]',
-        slots: ['kp40'],
-      },
-    },
   ];
   if (!RETIRE_KPIDS) {
     expectedPromises.push({
-      id: 'kp42',
+      id: 'kp43',
       state: 'fulfilledToData',
       refCount: 0,
       data: {

--- a/packages/SwingSet/test/test-state.js
+++ b/packages/SwingSet/test/test-state.js
@@ -393,7 +393,7 @@ test('kernelKeeper promises', async t => {
   const k = makeKernelKeeper(kstorage);
   k.createStartingKernelState();
 
-  const p1 = k.addKernelPromise('v4');
+  const p1 = k.addKernelPromiseForVat('v4');
   t.deepEqual(k.getKernelPromise(p1), {
     state: 'unresolved',
     refCount: 0,
@@ -497,7 +497,7 @@ test('kernelKeeper promise resolveToData', async t => {
   const k = makeKernelKeeper(kstorage);
   k.createStartingKernelState();
 
-  const p1 = k.addKernelPromise('v4');
+  const p1 = k.addKernelPromiseForVat('v4');
   const capdata = harden({ body: 'bodyjson', slots: ['ko22', 'kp24', 'kd25'] });
   k.fulfillKernelPromiseToData(p1, capdata);
   t.deepEqual(k.getKernelPromise(p1), {
@@ -516,7 +516,7 @@ test('kernelKeeper promise reject', async t => {
   const k = makeKernelKeeper(kstorage);
   k.createStartingKernelState();
 
-  const p1 = k.addKernelPromise('v4');
+  const p1 = k.addKernelPromiseForVat('v4');
   const capdata = harden({ body: 'bodyjson', slots: ['ko22', 'kp24', 'kd25'] });
   k.rejectKernelPromise(p1, capdata);
   t.deepEqual(k.getKernelPromise(p1), {

--- a/packages/SwingSet/test/vat-exomessages.js
+++ b/packages/SwingSet/test/vat-exomessages.js
@@ -1,0 +1,38 @@
+import harden from '@agoric/harden';
+
+function build(_E, _log) {
+  const other = harden({
+    something(arg) {
+      return arg;
+    },
+  });
+
+  function behave(mode) {
+    if (mode === 'data') {
+      return 'a big hello to all intelligent lifeforms everywhere';
+    } else if (mode === 'presence') {
+      return other;
+    } else if (mode === 'reject') {
+      throw new Error('gratuitous error');
+    }
+    return undefined;
+  }
+
+  return {
+    bootstrap(argv, _vats) {
+      return behave(argv[0]);
+    },
+    extra(mode) {
+      return behave(mode);
+    },
+  };
+}
+
+export default function setup(syscall, state, helpers) {
+  return helpers.makeLiveSlots(
+    syscall,
+    state,
+    E => harden(build(E, helpers.log)),
+    helpers.vatID,
+  );
+}

--- a/packages/swingset-runner/demo/exchangeBenchmark/bootstrap.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/bootstrap.js
@@ -96,6 +96,7 @@ function build(E, log) {
       await E(alice).initiateSimpleExchange(bob);
       await E(bob).initiateSimpleExchange(alice);
       log(`=> end of benchmark round ${round}`);
+      return `round ${round} complete`;
     },
   });
 }

--- a/packages/swingset-runner/src/main.js
+++ b/packages/swingset-runner/src/main.js
@@ -383,10 +383,10 @@ export async function main() {
       const [steps, deltaT] = await runBatch(0, false);
       const status = roundResult.status();
       if (status === 'pending') {
-        log(`benchmark round ${i+1} did not finish`);
+        log(`benchmark round ${i + 1} did not finish`);
       } else {
         const resolution = JSON.stringify(roundResult.resolution());
-        log(`benchmark round ${i+1} ${status}: ${resolution}`);
+        log(`benchmark round ${i + 1} ${status}: ${resolution}`);
       }
       totalSteps += steps;
       totalDeltaT += deltaT;

--- a/packages/swingset-runner/src/main.js
+++ b/packages/swingset-runner/src/main.js
@@ -246,6 +246,7 @@ export async function main() {
   }
 
   const controller = await buildVatController(config, true, bootstrapArgv);
+  let bootstrapResult = controller.bootstrapResult;
 
   let blockNumber = 0;
   let statLogger = null;
@@ -371,14 +372,22 @@ export async function main() {
     let totalSteps = 0;
     let totalDeltaT = BigInt(0);
     for (let i = 0; i < rounds; i += 1) {
-      controller.queueToVatExport(
+      const roundResult = controller.queueToVatExport(
         '_bootstrap',
         'o+0',
         'runBenchmarkRound',
         args,
+        'ignore',
       );
       // eslint-disable-next-line no-await-in-loop
       const [steps, deltaT] = await runBatch(0, false);
+      const status = roundResult.status();
+      if (status === 'pending') {
+        log(`benchmark round ${i+1} did not finish`);
+      } else {
+        const resolution = JSON.stringify(roundResult.resolution());
+        log(`benchmark round ${i+1} ${status}: ${resolution}`);
+      }
       totalSteps += steps;
       totalDeltaT += deltaT;
     }
@@ -483,6 +492,16 @@ export async function main() {
       deltaT += moreDeltaT;
     }
     store.close();
+    if (bootstrapResult) {
+      const status = bootstrapResult.status();
+      if (status === 'pending') {
+        log('bootstrap result still pending');
+      } else {
+        const resolution = JSON.stringify(bootstrapResult.resolution());
+        log(`bootstrap result ${status}: ${resolution}`);
+        bootstrapResult = null;
+      }
+    }
     if (logTimes) {
       if (totalSteps) {
         const per = deltaT / BigInt(totalSteps);


### PR DESCRIPTION
This includes detecting failure on `bootstrap` and inducing a kernel panic if that happens.

This implements the design laid out in #1206
