### PR TITLE
meter dynamic vats

### DIFF
--- a/packages/SwingSet/docs/dynamic-vats.md
+++ b/packages/SwingSet/docs/dynamic-vats.md
@@ -1,0 +1,98 @@
+# Dynamic Vats
+
+A SwingSet machine has two sets of vats. The first are the *Static Vats*, which are defined in the configuration object, and created at startup time. The root objects of these vats are made available to the `bootstrap()` method, which can wire them together as it sees fit.
+
+The second set are the *Dynamic Vats*. These are created after startup, with source code bundles that were not known at boot time. Typically these bundles arrive over the network from external providers. In the Agoric system, contracts are installed as dynamic vats (each spawned instance goes into a separate vat).
+
+Dynamic vats are metered: each message delivered gets a limited amount of resources (CPU cycles, memory, stack frames). If it exceeds this budget, the vat is terminated. All outstanding messages will be rejected, any future messages will be rejected, and it will never get CPU time again.
+
+## Creating a Dynamic Vat
+
+Vats are created by sending a `createVat()` message to the *Vat Admin Service* object, containing the source bundle which defines your new vat. Dynamic vats can only be created by other vats on the same SwingSet, so ultimately one of the static vats must cooperate.
+
+The ability to create new vats is not ambient: it requires access to the Vat Admin Service object, which is initially only made available to the bootstrap call. The bootstrap call usually shares it with the vat that installs contracts.
+
+### Making the Source Bundle
+
+The first step is to create a source bundle. To do this, you'll want to point the `bundleSource` function at a local source file. This file should have a function named `buildRootObject` as its default export. Suppose your vat code is stored in `vat-counter.js`:
+
+```js
+/* global harden */
+export default function buildRootObject() {
+  let counter = 0;
+  const root = {
+    increment() {
+      return counter += 1;
+    },
+    read() {
+      return counter;
+    },
+  };
+  return harden(root);
+}
+```
+
+Then turn this into a bundle:
+
+```js
+import bundleSource from '@agoric/bundle-source';
+async function run() {
+  const bundle = await bundleSource('.../vat-counter.js');
+  // 'bundle' can be JSON serialized
+}
+```
+
+The next step is to somehow get this bundle into an existing vat. The bundle can be turned into a string with `s = JSON.stringify(bundle)`, and back into an object with `bundle = JSON.parse(s)`. In the Agoric system, the bundling and transfer is managed by the `agoric deploy` command.
+
+### Invoking createVat()
+
+Once the bundle object is present within a vat that has access to the Vat Admin Service, you create the vat with a `createVat` call:
+
+```js
+const control = await E(vatAdminService).createVat(bundle);
+```
+
+## Root Object and Admin Node
+
+The result of `createVat` gives you access to two things. One is a *Presence* through which you can send messages to the root object of the new vat (whatever the `buildRootObject()` function returned):
+
+
+```js
+const { root, adminNode } = await E(vatAdminService).createVat(bundle);
+await E(root).increment();
+let count = E(root).read();
+console.log(count); // 1
+await E(root).increment();
+count = E(root).read();
+console.log(count); // 2
+```
+
+The other is the `adminNode`. This gives the creator of the vat control over the vat itself. Through this, you can retrieve statistics about the vat's execution, find out whether it is still running or not (it might be terminated because it ran down its meter), and preemptively terminate the vat. More features will be added in the future.
+
+### Vat Stats
+
+The current stats include the number of objects, promises, and devices in the vat's *C-List*, which tracks what this vat can reach on other vats.
+
+It also contains the count of entries in the vat's *transcript*. When the SwingSet restarts and needs to restore the vat to its previously-stored state, the kernel will replay the transcript: it re-submits each entry to the vat, allowing the vat to perform the same actions it did the previous time around. Each message delivery goes into a separate transcript entry, as does each promise-resolution notification. The `transcriptCount` thus gives a rough measure of how many messages the vat has executed.
+
+```js
+const data = E(adminNode).adminData();
+const {
+  objectCount,
+  promiseCount,
+  deviceCount,
+  transcriptCount,
+} = data;
+```
+
+### Waiting for Vat Termination
+
+To find out when the vat is terminated (either explicitly or due to a metering fault), you can wait for the `done()` Promise to fire. It will be resolved normally if the vat was terminated explicitly, and it will be rejected if the vat halted for any other reason.
+
+```
+E(adminNode).done()
+  .then(() => console.log(`the vat was intentionally shut down`) )
+  .catch(error => console.log(`surprise halt: ${error}`) );
+```
+
+When the vat halted due to a metering fault, `error` will be a `RangeError` with a message of `Compute meter exceeded`, `Allocate meter exceeded`, or `Stack meter exceeded`.

--- a/packages/SwingSet/src/kernel/dynamicVat.js
+++ b/packages/SwingSet/src/kernel/dynamicVat.js
@@ -11,6 +11,8 @@ export function makeDynamicVatCreator(stuff) {
     vatNameToID,
     vatEndowments,
     dynamicVatPowers,
+    transformMetering,
+    makeGetMeter,
     addVatManager,
     addExport,
     queueToExport,
@@ -33,6 +35,9 @@ export function makeDynamicVatCreator(stuff) {
 
   function createVatDynamically(vatSourceBundle) {
     const vatID = allocateUnusedVatID();
+
+    const meterRecord = null;
+    const notifyTermination = null;
 
     async function makeBuildRootObject() {
       if (typeof vatSourceBundle !== 'object') {
@@ -60,7 +65,14 @@ export function makeDynamicVatCreator(stuff) {
           dynamicVatPowers,
         );
       }
-      addVatManager(vatID, `dynamicVat${vatID}`, setup);
+      addVatManager(
+        vatID,
+        `dynamicVat${vatID}`,
+        setup,
+        {},
+        meterRecord,
+        notifyTermination,
+      );
     }
 
     function makeSuccessResponse() {

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -713,7 +713,14 @@ export default function buildKernel(kernelEndowments) {
     );
   }
 
-  function addVatManager(vatID, name, setup, options = {}) {
+  function addVatManager(
+    vatID,
+    name,
+    setup,
+    options,
+    meterRecord,
+    notifyTermination,
+  ) {
     const { enablePipelining = false } = options;
     validateVatSetupFn(setup);
     const helpers = harden({
@@ -740,6 +747,8 @@ export default function buildKernel(kernelEndowments) {
       kernelKeeper,
       kernelKeeper.allocateVatKeeperIfNeeded(vatID),
       vatPowers,
+      meterRecord,
+      notifyTermination,
     );
     ephemeral.vats.set(
       vatID,
@@ -755,6 +764,8 @@ export default function buildKernel(kernelEndowments) {
     vatNameToID,
     vatEndowments,
     dynamicVatPowers,
+    transformMetering,
+    makeGetMeter,
     addVatManager,
     addExport,
     queueToExport,
@@ -811,7 +822,16 @@ export default function buildKernel(kernelEndowments) {
       const { setup, options } = genesisVats.get(name);
       const vatID = kernelKeeper.allocateVatIDForNameIfNeeded(name);
       console.debug(`Assigned VatID ${vatID} for genesis vat ${name}`);
-      addVatManager(vatID, name, setup, options);
+      const meterRecord = null; // static vats are not metered
+      const notifyTermination = null; // nobody watches static
+      addVatManager(
+        vatID,
+        name,
+        setup,
+        options,
+        meterRecord,
+        notifyTermination,
+      );
     }
 
     if (vatAdminDevSetup) {

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -123,15 +123,19 @@ export default function buildKernel(kernelEndowments) {
   }
   harden(makeGetMeter);
 
-  function endOfCrankMeterTask() {
+  function stopGlobalMeter() {
     if (replaceGlobalMeter) {
       replaceGlobalMeter(null);
     }
+  }
+  harden(stopGlobalMeter);
+
+  function refillAllMeters() {
     for (const refiller of allRefillers) {
       refiller();
     }
   }
-  harden(endOfCrankMeterTask);
+  harden(refillAllMeters);
 
   function runWithoutGlobalMeter(f, ...args) {
     if (!replaceGlobalMeter) {
@@ -362,7 +366,8 @@ export default function buildKernel(kernelEndowments) {
     fulfillToData,
     reject,
     waitUntilQuiescent,
-    endOfCrankMeterTask,
+    stopGlobalMeter,
+    refillAllMeters,
   });
 
   function vatNameToID(name) {

--- a/packages/SwingSet/src/kernel/vatManager.js
+++ b/packages/SwingSet/src/kernel/vatManager.js
@@ -15,6 +15,8 @@ export default function makeVatManager(
   kernelKeeper,
   vatKeeper,
   vatPowers,
+  meterRecord,
+  notifyTermination,
 ) {
   const {
     waitUntilQuiescent,

--- a/packages/SwingSet/src/kernel/vatManager.js
+++ b/packages/SwingSet/src/kernel/vatManager.js
@@ -16,7 +16,11 @@ export default function makeVatManager(
   vatKeeper,
   vatPowers,
 ) {
-  const { waitUntilQuiescent, endOfCrankMeterTask } = syscallManager;
+  const {
+    waitUntilQuiescent,
+    stopGlobalMeter,
+    refillAllMeters,
+  } = syscallManager;
 
   // We use vat-centric terminology here, so "inbound" means "into a vat",
   // generally from the kernel. We also have "comms vats" which use special
@@ -344,7 +348,10 @@ export default function makeVatManager(
     // TODO: if the vat is metered, and requested death-before-confusion,
     // then find the relevant meter, check whether it's exhausted, and react
     // somehow
-    endOfCrankMeterTask();
+    stopGlobalMeter();
+
+    // refill all within-vat -created meters
+    refillAllMeters();
 
     // TODO: if the dispatch failed, and we choose to destroy the vat, change
     // what we do with the transcript here.

--- a/packages/SwingSet/src/kernel/vatManager.js
+++ b/packages/SwingSet/src/kernel/vatManager.js
@@ -342,15 +342,32 @@ export default function makeVatManager(
     return waitUntilQuiescent();
   }
 
+  function updateStats(_used) {
+    // TODO: accumulate used.allocate and used.compute into vatStats
+  }
+
   async function doProcess(dispatchRecord, errmsg) {
     const dispatchOp = dispatchRecord[0];
     const dispatchArgs = dispatchRecord.slice(1);
     transcriptStartDispatch(dispatchRecord);
     await runAndWait(() => dispatch[dispatchOp](...dispatchArgs), errmsg);
-    // TODO: if the vat is metered, and requested death-before-confusion,
-    // then find the relevant meter, check whether it's exhausted, and react
-    // somehow
     stopGlobalMeter();
+
+    // refill this vat's meter, if any, accumulating its usage for stats
+    if (meterRecord) {
+      // note that refill() won't actually refill an exhausted meter
+      const used = meterRecord.refill();
+      const exhaustionError = meterRecord.isExhausted();
+      if (exhaustionError) {
+        // TODO: if the vat requested death-before-confusion, unwind this
+        // crank and pretend all its syscalls never happened
+        if (notifyTermination) {
+          notifyTermination(exhaustionError);
+        }
+      } else {
+        updateStats(used);
+      }
+    }
 
     // refill all within-vat -created meters
     refillAllMeters();

--- a/packages/SwingSet/test/metering/metered-dynamic-vat.js
+++ b/packages/SwingSet/test/metering/metered-dynamic-vat.js
@@ -1,0 +1,16 @@
+import harden from '@agoric/harden';
+import meterMe from './metered-code';
+
+export default function buildRoot(_dynamicVatPowers) {
+  return harden({
+    async run() {
+      meterMe([], 'no');
+      return 42;
+    },
+
+    async explode(how) {
+      meterMe([], how);
+      return -1;
+    },
+  });
+}

--- a/packages/SwingSet/test/metering/test-dynamic-vat.js
+++ b/packages/SwingSet/test/metering/test-dynamic-vat.js
@@ -1,0 +1,73 @@
+/* global harden */
+import '@agoric/install-metering-and-ses';
+import bundleSource from '@agoric/bundle-source';
+import tap from 'tap';
+import { buildVatController } from '../../src/index';
+import makeNextLog from '../make-nextlog';
+
+function capdata(body, slots = []) {
+  return harden({ body, slots });
+}
+
+function capargs(args, slots = []) {
+  return capdata(JSON.stringify(args), slots);
+}
+
+tap.test('metering dynamic vats', async t => {
+  // we'll give this bundle to the loader vat, which will use it to create a
+  // new (metered) dynamic vat
+  const dynamicVatBundle = await bundleSource(
+    require.resolve('./metered-dynamic-vat.js'),
+  );
+  const config = {
+    vats: new Map(),
+    bootstrapIndexJS: require.resolve('./vat-load-dynamic.js'),
+  };
+  const c = await buildVatController(config, true, []);
+  const nextLog = makeNextLog(c);
+
+  // let the vatAdminService get wired up before we create any new vats
+  await c.run();
+
+  // 'createVat' will import the bundle
+  c.queueToVatExport(
+    '_bootstrap',
+    'o+0',
+    'createVat',
+    capargs([dynamicVatBundle]),
+  );
+  await c.run();
+  t.deepEqual(nextLog(), ['created'], 'first create');
+
+  // First, send a message to the dynamic vat that runs normally
+  c.queueToVatExport('_bootstrap', 'o+0', 'run', capargs([]));
+  await c.run();
+
+  t.deepEqual(nextLog(), ['did run'], 'first run ok');
+
+  // Now send a message that makes the dynamic vat exhaust its meter. The
+  // message result promise should be rejected, and the control facet should
+  // report the vat's demise
+  c.queueToVatExport('_bootstrap', 'o+0', 'explode', capargs(['allocate']));
+  await c.run();
+
+  t.deepEqual(
+    nextLog(),
+    [
+      'did explode: RangeError: Allocate meter exceeded',
+      'terminated: RangeError: Allocate meter exceeded',
+    ],
+    'first boom',
+  );
+
+  // the dead vat should stay dead
+  c.queueToVatExport('_bootstrap', 'o+0', 'run', capargs([]));
+  await c.run();
+  t.deepEqual(
+    nextLog(),
+    ['run exploded: RangeError: Allocate meter exceeded'],
+    'stay dead',
+  );
+
+  t.end();
+});

--- a/packages/SwingSet/test/metering/vat-load-dynamic.js
+++ b/packages/SwingSet/test/metering/vat-load-dynamic.js
@@ -1,0 +1,54 @@
+import harden from '@agoric/harden';
+import { E } from '@agoric/eventual-send';
+
+function build(buildStuff) {
+  const { log } = buildStuff;
+  let service;
+  let control;
+
+  return harden({
+    async bootstrap(argv, vats, devices) {
+      service = await E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
+    },
+
+    async createVat(bundle) {
+      control = await E(service).createVat(bundle);
+      E(control.adminNode)
+        .done()
+        .then(
+          () => log('finished'),
+          err => log(`terminated: ${err}`),
+        );
+      log(`created`);
+    },
+
+    async run() {
+      try {
+        await E(control.root).run();
+        log('did run');
+      } catch (err) {
+        log(`run exploded: ${err}`);
+      }
+    },
+
+    async explode(how) {
+      try {
+        await E(control.root).explode(how);
+        log('failed to explode');
+      } catch (err) {
+        log(`did explode: ${err}`);
+      }
+    },
+  });
+}
+
+export default function setup(syscall, state, helpers, vatPowers0) {
+  const { log, makeLiveSlots } = helpers;
+  return makeLiveSlots(
+    syscall,
+    state,
+    (_E, _D, _vatPowers) => build({ log }),
+    helpers.vatID,
+    vatPowers0,
+  );
+}

--- a/packages/SwingSet/test/metering/vat-within.js
+++ b/packages/SwingSet/test/metering/vat-within.js
@@ -15,8 +15,6 @@ function build(buildStuff) {
   const {
     getMeter,
     isExhausted,
-    resetMeterUsed,
-    // getMeterUsed,
     refillFacet,
     // resetGlobalMeter,
   } = makeGetMeter({ refillEachCrank: false });
@@ -50,7 +48,6 @@ function build(buildStuff) {
     run(mode) {
       log(`run ${mode}`);
       log2.splice(0);
-      resetMeterUsed();
       try {
         meterMe(log2, mode);
       } catch (e) {

--- a/packages/SwingSet/test/vat-admin/test-innerVat.js
+++ b/packages/SwingSet/test/vat-admin/test-innerVat.js
@@ -1,4 +1,4 @@
-import '@agoric/install-ses';
+import '@agoric/install-metering-and-ses';
 import path from 'path';
 import { test } from 'tape';
 import { initSwingStore } from '@agoric/swing-store-simple';


### PR DESCRIPTION
This PR enables metering for dynamic vats. The first five commits are refactorings, preparation, and docs. The real action takes place in the final commit. Consider reviewing each commit separately. This builds on top of #1218, and thus initially targets `1208-refactor-dynamic-vats` rather than trunk. I believe that once #1218 lands, github will retarget this PR to point at trunk instead.

closes #1208 , achieving the "bonus" but not the "double bonus" goals.

vatManager now does a check, just after the vat finishes with a crank, to see
if a meter was active for that vat (`meterRecord`). If so, it checks the
meter for exhaustion and uses `notifyTermination` to tell the admin facet
about it. Otherwise it refills the meter. Vats get unlimited cranks, but each
crank has a limited meter budget.

The dynamic-vat creation code makes a new meterRecord, applies the
metering-transform (and endowment to let the transformed code do `getMeter`),
and prepares a `notifyTermination` callback which will queue a message to the
vatAdminWrapper with the details.

The vatAdminWrapper now manages an additional `done` promise for each dynamic
vat it manages. When it gets the `notifyTermination` message, it resolves
this promise. Whichever vat object holds the `adminNode` can retrieve this
promise and get notified when the vat dies.

The unit test exercises a vat overrunning the "allocate" meter (which is easy
to trigger without a long slow loop), and makes sure the vat doesn't respond
to future messages after it's been exhausted. The existing dynamic-vat
test (vat-admin/test-innerVat.js) was updated to install global metering,
because now all dynamic vats are metered, whether the test is exercising
metering or not, and swingset emits a warning unless global metering is
installed.

We don't currently attempt to clean up the vat in any way. We rely upon the
vat's one meter remaining exhausted and never being refilled. As long as that
remains the case, all vat code will throw (the same exception) immediately
upon any message delivery, so while the vat's liveslots code gets to run (and
result promises are rejected appropriately), the vat code itself will never
get control again.

We also don't yet have a way to preemptively terminate a vat. We could add
this pretty easily by changing `doProcess` to check a new "null or Error"
flag just before dispatching into the vat.

One missing feature is that any Promises the late vat was controlling will
remain forever unresolved. Ideally all those promises should be rejected as
soon as the vat is known to be terminated. This is the highest-priority
followup task.

A further-out task is to delete the vat from memory, decref its c-list
entries, and somehow propagate disconnect messages back to holders of
now-dangling object references.

Another remaining task is to handle state cleanup and "rewind the
transaction" better. In the present code, when a vat dies mid-way through a
crank, any syscalls it made before the meter exhausted will still get
through. External observers will see a prefix of the messages the vat would
have sent if it hadn't run out of metering budget. Ideally the entire crank
would atomically happen or not happen, which will require us to buffer those
syscalls until the crank finishes with time still on the clock. This is
visible now, but isn't too serious yet. It will become more important when we
consider allowing vats to re-start the message that killed them (using a
bigger meter).
