### PR TITLE
use named buildRootObject export for dynamic vats, not default export

### DIFF
--- a/packages/SwingSet/docs/dynamic-vats.md
+++ b/packages/SwingSet/docs/dynamic-vats.md
@@ -14,11 +14,11 @@ The ability to create new vats is not ambient: it requires access to the Vat Adm
 
 ### Making the Source Bundle
 
-The first step is to create a source bundle. To do this, you'll want to point the `bundleSource` function at a local source file. This file should have a function named `buildRootObject` as its default export. Suppose your vat code is stored in `vat-counter.js`:
+The first step is to create a source bundle. To do this, you'll want to point the `bundleSource` function (from the `@agoric/bundle-source` package) at a local source file. This file should export a function named `buildRootObject` (it can export other things too, perhaps for unit tests, but only `buildRootObject` will be used by the dynamic vat loader). Suppose your vat code is stored in `vat-counter.js`:
 
 ```js
 /* global harden */
-export default function buildRootObject() {
+export function buildRootObject() {
   let counter = 0;
   const root = {
     increment() {
@@ -54,7 +54,7 @@ const control = await E(vatAdminService).createVat(bundle);
 
 ## Root Object and Admin Node
 
-The result of `createVat` gives you access to two things. One is a *Presence* through which you can send messages to the root object of the new vat (whatever the `buildRootObject()` function returned):
+The result of `createVat` gives you access to two things. One is a *Presence* through which you can send messages to the root object of the new vat (whatever `buildRootObject()` returned):
 
 
 ```js

--- a/packages/SwingSet/src/kernel/dynamicVat.js
+++ b/packages/SwingSet/src/kernel/dynamicVat.js
@@ -88,9 +88,12 @@ export function makeDynamicVatCreator(stuff) {
         transforms,
         endowments: { ...vatEndowments, getMeter },
       });
-      // TODO: use a named export, not default
-      const buildRootObject = vatNS.default;
-      return buildRootObject;
+      if (typeof vatNS.buildRootObject !== 'function') {
+        throw Error(
+          `vat source bundle does not export buildRootObject function`,
+        );
+      }
+      return vatNS.buildRootObject;
     }
 
     function makeVatManager(buildRootObject) {

--- a/packages/SwingSet/test/metering/metered-dynamic-vat.js
+++ b/packages/SwingSet/test/metering/metered-dynamic-vat.js
@@ -1,7 +1,7 @@
 import harden from '@agoric/harden';
 import meterMe from './metered-code';
 
-export default function buildRoot(_dynamicVatPowers) {
+export function buildRootObject(_dynamicVatPowers) {
   return harden({
     async run() {
       meterMe([], 'no');

--- a/packages/SwingSet/test/vat-admin/broken-vat.js
+++ b/packages/SwingSet/test/vat-admin/broken-vat.js
@@ -1,4 +1,4 @@
-export default function build(_E) {
+export function buildRootObject(_E) {
   // eslint-disable-next-line no-undef
   return missing({});
 }

--- a/packages/SwingSet/test/vat-admin/new-vat.js
+++ b/packages/SwingSet/test/vat-admin/new-vat.js
@@ -1,6 +1,6 @@
 const harden = require('@agoric/harden');
 
-export default function build(E) {
+export function buildRootObject(E) {
   function rcvrMaker(seed) {
     let count = 0;
     let sum = seed;


### PR DESCRIPTION
Previously we were defining dynamic vats to export a default function for use
in building the new root object. It seems more flexible to have it export a
named function, specifically `buildRootObject`. These vats can export other
names too, maybe for unit tests, or run-time configuration queries to support
compatibility tricks in the future.