### PR TITLE
refactor: remove deprecated cancelObj.cancel()

### DIFF
--- a/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
+++ b/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
@@ -366,7 +366,7 @@ test('multiple instances of automaticRefund for the same Zoe', async t => {
   }
 });
 
-test('zoe - alice cancels after completion', async t => {
+test('zoe - alice tries to complete after completion has already occurred', async t => {
   t.plan(5);
   try {
     // Setup zoe and mints

--- a/packages/zoe/test/unitTests/contracts/test-publicAuction.js
+++ b/packages/zoe/test/unitTests/contracts/test-publicAuction.js
@@ -366,7 +366,7 @@ test('zoe - secondPriceAuction w/ 3 bids - alice exits onDemand', async t => {
       'The offer has been accepted. Once the contract has been completed, please check your payout',
     );
 
-    // Alice cancels her offer, making the auction stop accepting
+    // Alice completes her offer, making the auction stop accepting
     // offers
     completeObj.complete();
 


### PR DESCRIPTION
Closes #1008 

This builds on and updates the work done in #1038. Thanks so much for the contribution @developerfred!