### PR TITLE
chore: clean up TODOs and remove deprecated from Zoe

### DIFF
--- a/packages/zoe/test/unitTests/contracts/brokenAutoRefund.js
+++ b/packages/zoe/test/unitTests/contracts/brokenAutoRefund.js
@@ -1,14 +1,11 @@
 // @ts-check
-import rawHarden from '@agoric/harden';
-
-// TODO: Until we have a version of harden that exports its type.
-const harden = /** @type {<T>(x: T) => T} */ (rawHarden);
+import harden from '@agoric/harden';
 
 /**
  * This is a a broken contact to test zoe's error handling
  * @type {import('@agoric/zoe').MakeContract} zoe - the contract facet of zoe
  */
-export const makeContract = harden(zcf => {
+const makeContract = zcf => {
   const refundOfferHook = offerHandle => {
     zcf.complete(harden([offerHandle]));
     return `The offer was accepted`;
@@ -17,4 +14,7 @@ export const makeContract = harden(zcf => {
     zcf.makeInvitation(refundOfferHook, 'getRefund');
   // should be makeRefundInvite(). Intentionally wrong to provoke an error.
   return makeRefundInvite;
-});
+};
+
+harden(makeContract);
+export { makeContract };

--- a/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
+++ b/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
@@ -8,7 +8,6 @@ import bundleSource from '@agoric/bundle-source';
 import harden from '@agoric/harden';
 
 import { makeZoe } from '../../../src/zoe';
-// TODO: Remove setupBasicMints and rename setupBasicMints2
 import { setup } from '../setupBasicMints';
 import { makeGetInstanceHandle } from '../../../src/clientSupport';
 import { setupNonFungible } from '../setupNonFungibleMints';

--- a/packages/zoe/test/unitTests/contracts/test-brokenContract.js
+++ b/packages/zoe/test/unitTests/contracts/test-brokenContract.js
@@ -7,7 +7,6 @@ import bundleSource from '@agoric/bundle-source';
 import harden from '@agoric/harden';
 
 import { makeZoe } from '../../../src/zoe';
-// TODO: Remove setupBasicMints and rename setupBasicMints2
 import { setup } from '../setupBasicMints';
 
 const automaticRefundRoot = `${__dirname}/brokenAutoRefund`;

--- a/packages/zoe/test/unitTests/contracts/test-grifter.js
+++ b/packages/zoe/test/unitTests/contracts/test-grifter.js
@@ -7,7 +7,6 @@ import bundleSource from '@agoric/bundle-source';
 import harden from '@agoric/harden';
 
 import { makeZoe } from '../../..';
-// TODO: Remove setupBasicMints and rename setupBasicMints2
 import { setup } from '../setupBasicMints';
 
 const grifterRoot = `${__dirname}/grifter`;


### PR DESCRIPTION
Closes #1184 

Along with #1236 and what is already in zoe-release-0.7.0, this should remove all of the currently deprecated features and clean up the TODO comments.