### PR TITLE
fix: add a version check assertion to enforce Golang 1.14+

### DIFF
--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -26,10 +26,10 @@ jobs:
     #    restore-keys: |
     #      ${{ runner.os }}-yarn-
 
-    - name: Set up Go 1.13
+    - name: Set up Go 1.14
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.14
 
     # FIXME: Reenable after 2020-04-01 when Github cache doesn't take forever.
     #- name: cache Go modules

--- a/packages/cosmic-swingset/app/version_check.go
+++ b/packages/cosmic-swingset/app/version_check.go
@@ -1,0 +1,6 @@
+//+build !go1.14
+
+package app
+
+cosmic-swingset requires requires Golang version 1.14.
+See https://golang.org/dl/ for upgrade information.


### PR DESCRIPTION
This prevents the annoying #1253 behaviour when an older Golang is in use.
