### PR TITLE
remove controller solo

### DIFF
--- a/packages/cosmic-swingset/Dockerfile
+++ b/packages/cosmic-swingset/Dockerfile
@@ -1,6 +1,6 @@
 # The Golang build container.
 # TODO This should be split out into the cosmos-connector.
-FROM golang:1.13-stretch
+FROM golang:1.14-stretch
 
 WORKDIR /usr/src/app
 COPY go.mod go.sum ./

--- a/packages/deployment/ansible/roles/fetch-controller/tasks/main.yml
+++ b/packages/deployment/ansible/roles/fetch-controller/tasks/main.yml
@@ -2,4 +2,4 @@
   fetch:
     dest: "{{ data | default(service + '/data') }}/{{ inventory_hostname }}/boot-address.txt"
     flat: yes
-    src: "/home/{{ service }}/controller/ag-cosmos-helper-address"
+    src: "/home/{{ service }}/.{{ service }}/ag-cosmos-helper-address"

--- a/packages/deployment/ansible/roles/init-controller/tasks/main.yml
+++ b/packages/deployment/ansible/roles/init-controller/tasks/main.yml
@@ -8,19 +8,28 @@
 - name: "Create provisioning mnemonic"
   delegate_to: localhost
   shell:
-    cmd: "ag-cosmos-helper keys mnemonic | tee provisioning-mnemonic.txt"
+    cmd: "ag-cosmos-helper keys mnemonic 2>&1 | tee provisioning-mnemonic.txt"
+    chdir: "{{ SETUP_HOME }}"
   register: mnemonic
+
+- name: "Delete {{ service }} ag-solo key"
+  become: yes
+  become_user: "{{ service }}"
+  shell:
+    cmd: "ag-cosmos-helper --home=/home/{{ service }}/.ag-pserver/ag-cosmos-helper-statedir --keyring-backend=test keys delete ag-solo --yes"
+    removes: "/home/{{ service }}/.ag-pserver/ag-cosmos-helper-statedir"
+  ignore_errors: yes
 
 - name: "Create {{ service }} ag-solo key"
   become: yes
   become_user: "{{ service }}"
   shell:
-    cmd: "ag-cosmos-helper --home=.{{ service }}/ag-cosmos-helper-statedir --keyring-backend=test keys add ag-solo"
-    stdin: "{{ mnemonic.stdout_lines }}"
+    cmd: "ag-cosmos-helper --home=/home/{{ service }}/.ag-pserver/ag-cosmos-helper-statedir --keyring-backend=test keys add --recover ag-solo"
+    stdin: "{{ mnemonic.stdout }}"
 
 - name: "Create ag-cosmos-helper-address"
   become: yes
   become_user: "{{ service }}"
   shell:
-    cmd: "ag-cosmos-helper --home=.{{ service }}/ag-cosmos-helper-statedir \
-      --keyring-backend=test keys show -a ag-solo > .{{ service }}/ag-cosmos-helper-address"
+    cmd: "ag-cosmos-helper --home=/home/{{ service }}/.ag-pserver/ag-cosmos-helper-statedir \
+      --keyring-backend=test keys show -a ag-solo > /home/{{ service }}/.ag-pserver/ag-cosmos-helper-address"

--- a/packages/deployment/ansible/roles/init-controller/tasks/main.yml
+++ b/packages/deployment/ansible/roles/init-controller/tasks/main.yml
@@ -1,18 +1,3 @@
-- name: Synchronize vat directory
-  synchronize:
-    src: "{{ APPDIR }}/lib/ag-solo/vats/"
-    dest: /usr/src/ag-solo/lib/ag-solo/vats/
-    dirs: yes
-    delete: yes
-    mode: push
-
-- name: "Initialize {{ service }}"
-  become: yes
-  become_user: "{{ service }}"
-  shell:
-    cmd: "rm -rf controller && ag-solo init controller"
-    chdir: "/home/{{ service }}"
-
 - name: "Ensure /home/{{ service }}/.ag-pserver/wwwroot/{{ CHAIN_NAME }} exists"
   become: yes
   become_user: "{{ service }}"
@@ -20,10 +5,22 @@
     path: "/home/{{ service }}/.ag-pserver/wwwroot/{{ CHAIN_NAME }}"
     state: directory
 
-- name: "Clone ag-cosmos-helper-statedir to pserver"
+- name: "Create provisioning mnemonic"
+  delegate_to: localhost
+  shell:
+    cmd: "ag-cosmos-helper keys mnemonic | tee provisioning-mnemonic.txt"
+  register: mnemonic
+
+- name: "Create {{ service }} ag-solo key"
   become: yes
   become_user: "{{ service }}"
-  delegate_to: "{{ inventory_hostname }}"
-  synchronize:
-    src: "/home/{{ service }}/controller/ag-cosmos-helper-statedir/"
-    dest: "/home/{{ service }}/.ag-pserver/ag-cosmos-helper-statedir/"
+  shell:
+    cmd: "ag-cosmos-helper --home=.{{ service }}/ag-cosmos-helper-statedir --keyring-backend=test keys add ag-solo"
+    stdin: "{{ mnemonic.stdout_lines }}"
+
+- name: "Create ag-cosmos-helper-address"
+  become: yes
+  become_user: "{{ service }}"
+  shell:
+    cmd: "ag-cosmos-helper --home=.{{ service }}/ag-cosmos-helper-statedir \
+      --keyring-backend=test keys show -a ag-solo > .{{ service }}/ag-cosmos-helper-address"

--- a/packages/deployment/ansible/roles/init-cosmos/tasks/main.yml
+++ b/packages/deployment/ansible/roles/init-cosmos/tasks/main.yml
@@ -24,8 +24,3 @@
   become: yes
   become_user: "{{ service }}"
   shell: "{{ service }} init --overwrite {{ inventory_hostname }} --chain-id={{ CHAIN_NAME }}"
-
-#- name: "Add coins to {{ service }}"
-#  become: yes
-#  become_user: "{{ service }}"
-#  shell: "{{ service }} add-genesis-account {{ BOOTSTRAP_ADDRESS }} {{ BOOTSTRAP_TOKENS }}"

--- a/packages/deployment/ansible/roles/install-controller/tasks/main.yml
+++ b/packages/deployment/ansible/roles/install-controller/tasks/main.yml
@@ -34,13 +34,6 @@
     path: "/home/{{ service }}/.{{ service }}/wwwroot/current"
     src: "{{ CHAIN_NAME }}"
 
-- name: "set-gci-ingress for controller"
-  become_user: "{{ service }}"
-  become: true
-  shell:
-    cmd: "ag-solo set-gci-ingress --chainID={{ CHAIN_NAME }} {{ GCI }} {{ RPC_ADDRS }}"
-    chdir: "/home/{{ service }}/controller"
-
 - name: "Add {{ NETWORK_NAME }} keys"
   synchronize:
     src: "{{ SETUP_HOME }}/{{ NETWORK_NAME }}.{{ item }}"

--- a/packages/deployment/ansible/roles/start/tasks/main.yml
+++ b/packages/deployment/ansible/roles/start/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
 
 - name: start service
-  service: "name={{service}} state=started"
-
+  service: "name={{service}} state=started enabled=yes"

--- a/packages/deployment/ansible/roles/stop/tasks/main.yml
+++ b/packages/deployment/ansible/roles/stop/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
 
 - name: stop service
-  service: "name={{service}} state=stopped"
-
+  service: "name={{service}} state=stopped enabled=no"

--- a/packages/deployment/docker/ag-setup-cosmos
+++ b/packages/deployment/docker/ag-setup-cosmos
@@ -21,10 +21,6 @@ show-*)
   TTY=-i
   ;;
 esac
-if test -n "$CONTROLLER_VATS"; then
-  # Mount the specified controller vats directory.
-  FLAGS="$FLAGS --volume=`cd "$CONTROLLER_VATS" && pwd`:/usr/src/app/lib/ag-solo/vats"
-fi
 exec docker run --rm $TTY $FLAGS \
   --volume=ag-setup-cosmos-chains:/usr/src/app/chains \
   --volume=ag-cosmos-helper-state:/root/.ag-cosmos-helper \


### PR DESCRIPTION
Refs #1238 

Remove all deprecated setup and usage of the "controller" ag-solo--the cosmic-swingset instance that was replaced by the use of `tx swingset provision-one`.

This removal has been tested against the Docker-based local testtestnet.
