### PR TITLE
SwingSet demo - install ses at start

### DIFF
--- a/packages/SwingSet/bin/vat
+++ b/packages/SwingSet/bin/vat
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 
+require = require('esm')(module);
+require('@agoric/install-ses');
+
 const process = require('process');
 const repl = require('repl');
-require = require('esm')(module);
 const util = require('util');
 
 const { loadBasedir, buildVatController } = require('../src/index.js');


### PR DESCRIPTION
Fixes https://github.com/Agoric/agoric-sdk/issues/1258
>  SwingSet readme instructions error with "harden is not defined"

please see issue for more info

