### PR TITLE
Add example of a contract that gives and revokes use objects based on escrowed assets

### DIFF
--- a/packages/zoe/src/contracts/useObj.js
+++ b/packages/zoe/src/contracts/useObj.js
@@ -1,0 +1,58 @@
+/* global harden */
+// @ts-check
+
+// Eventually will be importable from '@agoric/zoe-contract-support'
+import { assert, details } from '@agoric/assert';
+import { makeZoeHelpers } from '../contractSupport';
+
+/**
+ * Give a use object when a payment is escrowed
+ *
+ * @typedef {import('../zoe').ContractFacet} ContractFacet
+ * @param {ContractFacet} zcf
+ */
+const makeContract = zcf => {
+  const { assertKeywords, checkHook } = makeZoeHelpers(zcf);
+  assertKeywords(harden(['Pixels']));
+  const { brandKeywordRecord } = zcf.getInstanceRecord();
+  const amountMath = zcf.getAmountMath(brandKeywordRecord.Pixels);
+
+  const makeUseObjHook = offerHandle => {
+    return harden({
+      colorPixels: (color, amountToColor) => {
+        assert(
+          zcf.isOfferActive(offerHandle),
+          `the escrowing offer is no longer active`,
+        );
+        const { Pixels: escrowedAmount } = zcf.getCurrentAllocation(
+          offerHandle,
+          brandKeywordRecord,
+        );
+        if (amountToColor === undefined) {
+          amountToColor = escrowedAmount;
+        }
+        assert(
+          amountMath.isGTE(escrowedAmount, amountToColor),
+          details`The pixels to color were not all escrowed. Currently escrowed: ${escrowedAmount}, amount to color: ${amountToColor}`,
+        );
+        return `successfully colored ${amountToColor.extent} pixels ${color}`;
+      },
+    });
+  };
+
+  const expected = harden({
+    give: { Pixels: null },
+  });
+
+  const makeUseObjInvite = () =>
+    zcf.makeInvitation(checkHook(makeUseObjHook, expected), 'use object');
+
+  zcf.initPublicAPI({
+    makeInvite: makeUseObjInvite,
+  });
+
+  return makeUseObjInvite();
+};
+
+harden(makeContract);
+export { makeContract };

--- a/packages/zoe/test/unitTests/contracts/test-useObj.js
+++ b/packages/zoe/test/unitTests/contracts/test-useObj.js
@@ -39,7 +39,7 @@ test('zoe - useObj', async t => {
   });
   const alicePayments = { Pixels: aliceMoolaPayment };
 
-  // Alice makes the first offer in the swap.
+  // Alice makes an offer
   const {
     payout: alicePayoutP,
     outcome: useObjP,

--- a/packages/zoe/test/unitTests/contracts/test-useObj.js
+++ b/packages/zoe/test/unitTests/contracts/test-useObj.js
@@ -9,9 +9,9 @@ import bundleSource from '@agoric/bundle-source';
 import { makeZoe } from '../../../src/zoe';
 import { setup } from '../setupBasicMints';
 
-const contractRoot = `${__dirname}/../../../src/contracts/useObj`;
+const contractRoot = `${__dirname}/useObjExample`;
 
-test.only('zoe - useObj', async t => {
+test('zoe - useObj', async t => {
   t.plan(3);
   const { moolaIssuer, moolaMint, moola } = setup();
   const zoe = makeZoe();

--- a/packages/zoe/test/unitTests/contracts/test-useObj.js
+++ b/packages/zoe/test/unitTests/contracts/test-useObj.js
@@ -1,0 +1,75 @@
+/* global harden */
+
+import '@agoric/install-ses';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from 'tape-promise/tape';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import bundleSource from '@agoric/bundle-source';
+
+import { makeZoe } from '../../../src/zoe';
+import { setup } from '../setupBasicMints';
+
+const contractRoot = `${__dirname}/../../../src/contracts/useObj`;
+
+test.only('zoe - useObj', async t => {
+  t.plan(3);
+  const { moolaIssuer, moolaMint, moola } = setup();
+  const zoe = makeZoe();
+
+  // pack the contract
+  const bundle = await bundleSource(contractRoot);
+  // install the contract
+  const installationHandle = await zoe.install(bundle);
+
+  // Setup Alice
+  const aliceMoolaPayment = moolaMint.mintPayment(moola(3));
+
+  // Alice creates an instance
+  const issuerKeywordRecord = harden({
+    Pixels: moolaIssuer,
+  });
+  const { invite: aliceInvite } = await zoe.makeInstance(
+    installationHandle,
+    issuerKeywordRecord,
+  );
+
+  // Alice escrows with zoe
+  const aliceProposal = harden({
+    give: { Pixels: moola(3) },
+  });
+  const alicePayments = { Pixels: aliceMoolaPayment };
+
+  // Alice makes the first offer in the swap.
+  const {
+    payout: alicePayoutP,
+    outcome: useObjP,
+    completeObj,
+  } = await zoe.offer(aliceInvite, aliceProposal, alicePayments);
+
+  const useObj = await useObjP;
+
+  t.equals(
+    useObj.colorPixels('purple'),
+    `successfully colored 3 pixels purple`,
+    `use of use object works`,
+  );
+
+  completeObj.complete();
+
+  const alicePayout = await alicePayoutP;
+
+  const aliceMoolaPayoutPayment = await alicePayout.Pixels;
+
+  t.deepEquals(
+    await moolaIssuer.getAmountOf(aliceMoolaPayoutPayment),
+    moola(3),
+    `alice gets everything she escrowed back`,
+  );
+
+  console.log('EXPECTED ERROR ->>>');
+  t.throws(
+    () => useObj.colorPixels('purple'),
+    /the escrowing offer is no longer active/,
+    `use of use object fails once offer is withdrawn or amounts are reallocated`,
+  );
+});

--- a/packages/zoe/test/unitTests/contracts/useObjExample.js
+++ b/packages/zoe/test/unitTests/contracts/useObjExample.js
@@ -3,12 +3,12 @@
 
 // Eventually will be importable from '@agoric/zoe-contract-support'
 import { assert, details } from '@agoric/assert';
-import { makeZoeHelpers } from '../contractSupport';
+import { makeZoeHelpers } from '../../../src/contractSupport';
 
 /**
  * Give a use object when a payment is escrowed
  *
- * @typedef {import('../zoe').ContractFacet} ContractFacet
+ * @typedef {import('../../../src/zoe').ContractFacet} ContractFacet
  * @param {ContractFacet} zcf
  */
 const makeContract = zcf => {
@@ -19,7 +19,7 @@ const makeContract = zcf => {
 
   const makeUseObjHook = offerHandle => {
     return harden({
-      colorPixels: (color, amountToColor) => {
+      colorPixels: (color, amountToColor = undefined) => {
         assert(
           zcf.isOfferActive(offerHandle),
           `the escrowing offer is no longer active`,


### PR DESCRIPTION
This PR adds a use object example contract. The contract gives a use object for coloring pixels, given that the pixels have been escrowed. The user can get their escrowed assets back by calling `completeObj.complete()` but if they do so, the use object functions error with an understandable error message.

More work could be done in the future to make this generic and move the contract into zoe/src/contracts/.