### PR TITLE
More typing

### DIFF
--- a/packages/ERTP/src/issuer.js
+++ b/packages/ERTP/src/issuer.js
@@ -214,6 +214,7 @@ import makeAmountMath from './amountMath';
  *
  * @param {string} allegedName
  * @param {string} mathHelpersName
+ * @returns {IssuerResults}
  */
 function produceIssuer(allegedName, mathHelpersName = 'nat') {
   assert.typeof(allegedName, 'string');

--- a/packages/SwingSet/src/vats/network/network.js
+++ b/packages/SwingSet/src/vats/network/network.js
@@ -56,6 +56,7 @@ export const ENDPOINT_SEPARATOR = '/';
  * @property {(port: Port, l: ListenHandler) => Promise<void>} [onListen] The listener has been registered
  * @property {(port: Port, listenAddr: Endpoint, remoteAddr: Endpoint, l: ListenHandler) => Promise<Endpoint>} [onInbound] Return metadata for inbound connection attempt
  * @property {(port: Port, localAddr: Endpoint, remoteAddr: Endpoint, l: ListenHandler) => Promise<ConnectionHandler>} onAccept A new connection is incoming
+ * @property {(port: Port, localAddr: Endpoint, remoteAddr: Endpoint, l: ListenHandler) => Promise<void>} onReject The connection was rejected
  * @property {(port: Port, rej: any, l: ListenHandler) => Promise<void>} [onError] There was an error while listening
  * @property {(port: Port, l: ListenHandler) => Promise<void>} [onRemove] The listener has been removed
  */
@@ -324,7 +325,10 @@ export function makeNetworkProtocol(protocolHandler, E = defaultE) {
     if (localAddr.endsWith(ENDPOINT_SEPARATOR)) {
       for (;;) {
         // eslint-disable-next-line no-await-in-loop
-        const portID = await E(protocolHandler).generatePortID(localAddr);
+        const portID = await E(protocolHandler).generatePortID(
+          localAddr,
+          protocolHandler,
+        );
         const newAddr = `${localAddr}${portID}`;
         if (!boundPorts.has(newAddr)) {
           localAddr = newAddr;

--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -180,6 +180,7 @@ harden(details);
  * The optional `optDetails` can be a string for backwards compatibility
  * with the nodejs assertion library.
  * @param {Details} [optDetails] The details of what was asserted
+ * @returns {never}
  */
 function fail(optDetails = details`Assert failed`) {
   if (typeof optDetails === 'string') {

--- a/packages/cosmic-swingset/lib/ag-solo/vats/bridge.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bridge.js
@@ -28,7 +28,7 @@ import makeStore from '@agoric/store';
 /**
  * Create a handler that demuxes/muxes the bridge device by its first argument.
  *
- * @param {<T>(target: T) => T} E The eventual sender
+ * @param {import('@agoric/eventual-send').EProxy} E The eventual sender
  * @param {<T>(target: Device<T>) => T} D The device sender
  * @param {Device<BridgeDevice>} bridgeDevice The bridge to manage
  * @returns {BridgeManager} admin facet for this handler

--- a/packages/cosmic-swingset/lib/ag-solo/vats/ibc.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/ibc.js
@@ -227,7 +227,7 @@ export function makeIBCProtocolHandler(E, callIBCDevice) {
           localAddr,
           remoteAddr,
         );
-        const connP = /** @type {Promise<Connection, any>} */ (E.when(conn));
+        const connP = E.when(conn);
         channelKeyToConnP.init(channelKey, connP);
       },
       onReceive,
@@ -515,14 +515,10 @@ EOF
           const remoteAddr = `${ibcHops}/ibc-port/${rPortID}/${order.toLowerCase()}/${rVersion}`;
 
           // See if we allow an inbound attempt for this address pair (without rejecting).
-          const attemptP =
-            /** @type {Promise<InboundAttempt>} */
-            (E(protocolImpl).inbound(localAddr, remoteAddr));
+          const attemptP = E(protocolImpl).inbound(localAddr, remoteAddr);
 
           // Tell what version string we negotiated.
-          const attemptedLocal =
-            /** @type {string} */
-            (await E(attemptP).getLocalAddress());
+          const attemptedLocal = await E(attemptP).getLocalAddress();
           const match = attemptedLocal.match(
             // Match:  ... /ORDER/VERSION ...
             new RegExp('^(/[^/]+/[^/]+)*/(ordered|unordered)/([^/]+)(/|$)'),
@@ -643,7 +639,6 @@ EOF
           E(connP)
             .send(data)
             .then(ack => {
-              /** @type {Data} */
               const realAck = ack || DEFAULT_ACKNOWLEDGEMENT;
               const ack64 = dataToBase64(realAck);
               return callIBCDevice('packetExecuted', { packet, ack: ack64 });

--- a/packages/eventual-send/src/index.d.ts
+++ b/packages/eventual-send/src/index.d.ts
@@ -37,13 +37,13 @@ export const HandledPromise: HandledPromiseConstructor;
 
 /* Types for E proxy calls. */
 type ESingleMethod<T> = {
-  readonly [P in keyof T]: (...args: Parameters<T[P]>) => Promise<ReturnType<T[P]>>;
+  readonly [P in keyof T]: (...args: Parameters<T[P]>) => Promise<Unpromise<ReturnType<T[P]>>>;
 }
 type ESingleCall<T> = T extends Function ?
-  ((...args: Parameters<T>) => Promise<ReturnType<T>>) & ESingleMethod<T> :
+  ((...args: Parameters<T>) => Promise<Unpromise<ReturnType<T>>>) & ESingleMethod<T> :
   ESingleMethod<T>;
 type ESingleGet<T> = {
-  readonly [P in keyof T]: Promise<T[P]>;
+  readonly [P in keyof T]: Promise<Unpromise<T[P]>>;
 }
   
 /* Same types for send-only. */
@@ -85,11 +85,16 @@ interface EProxy {
   readonly G<T>(x: T): ESingleGet<Unpromise<T>>;
 
   /**
+   * E.when(x) converts x to a promise.
+   */
+  readonly when<T>(x: T): Promise<Unpromise<T>>;
+
+  /**
    * E.when(x, res, rej) is equivalent to HandledPromise.resolve(x).then(res, rej)
    */
   readonly when<T>(
     x: T,
-    onfulfilled?: (value: Unpromise<T>) => any | PromiseLike<any>,
+    onfulfilled: (value: Unpromise<T>) => any | PromiseLike<any> | undefined,
     onrejected?: (reason: any) => PromiseLike<never>,
   ): Promise<any>;
 

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -319,7 +319,7 @@ import { makeTables } from './state';
  * @param {Keyword} keyword Keyword for added issuer
  * @returns {Promise<IssuerRecord>} Issuer is added and ready
  *
- *  * @callback InitPublicAPI
+ * @callback InitPublicAPI
  * Initialize the publicAPI for the contract instance, as stored by Zoe in
  * the instanceRecord.
  * @param {Object} publicAPI - an object whose methods are the API
@@ -337,7 +337,7 @@ import { makeTables } from './state';
  * within-vat metering of contract code
  * @returns {ZoeService} The created Zoe service.
  */
-const makeZoe = (additionalEndowments = {}, vatPowers = {}) => {
+function makeZoe(additionalEndowments = {}, vatPowers = {}) {
   // Zoe maps the inviteHandles to contract offerHook upcalls
   const inviteHandleToOfferHook = makeStore();
 
@@ -886,6 +886,6 @@ const makeZoe = (additionalEndowments = {}, vatPowers = {}) => {
     },
   );
   return zoeService;
-};
+}
 
 export { makeZoe };


### PR DESCRIPTION
This updates the Typescript/JSDoc typings.

Notably, now `E(x)` and `E.G(x)` are properly typed, so you can use Intellisense to complete eventual method and property gets.
