### PR TITLE
chore: add name of keys to Store

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/vats/lib-board.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/lib-board.js
@@ -5,8 +5,8 @@ import { assert, details } from '@agoric/assert';
 import makeStore from '@agoric/store';
 
 function makeBoard(seed = 0) {
-  const idToVal = makeStore();
-  const valToId = makeStore();
+  const idToVal = makeStore('boardId');
+  const valToId = makeStore('value');
   const sparseInts = generateSparseInts(seed);
 
   const board = harden({

--- a/packages/cosmic-swingset/lib/ag-solo/vats/lib-dehydrate.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/lib-dehydrate.js
@@ -10,14 +10,14 @@ import { assert, details } from '@agoric/assert';
 export const makeDehydrator = (initialUnnamedCount = 0) => {
   let unnamedCount = initialUnnamedCount;
 
-  const petnameKindToMapping = makeStore();
+  const petnameKindToMapping = makeStore('petnameKind');
 
   const searchOrder = [];
 
   const makeMapping = kind => {
     assert.typeof(kind, 'string', details`kind ${kind} must be a string`);
-    const valToPetname = makeStore();
-    const petnameToVal = makeStore();
+    const valToPetname = makeStore('value');
+    const petnameToVal = makeStore('petname');
     const addPetname = (petname, val) => {
       assert(
         !petnameToVal.has(petname),

--- a/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
@@ -39,8 +39,8 @@ export async function makeWallet({
       harden(['brand', 'issuer', 'amountMath']),
     );
 
-    const issuersInProgress = makeStore();
-    const issuerToBrand = makeWeakStore();
+    const issuersInProgress = makeStore('issuer');
+    const issuerToBrand = makeWeakStore('issuer');
     const makeCustomProperties = table =>
       harden({
         addIssuer: issuerP => {
@@ -84,14 +84,14 @@ export async function makeWallet({
   };
 
   // issuerNames have properties like 'brandRegKey' and 'issuerPetname'.
-  const issuerToIssuerNames = makeWeakStore();
+  const issuerToIssuerNames = makeWeakStore('issuer');
   const brandTable = makeBrandTable();
-  const purseToBrand = makeWeakStore();
-  const brandToDepositFacetId = makeWeakStore();
+  const purseToBrand = makeWeakStore('purse');
+  const brandToDepositFacetId = makeWeakStore('brand');
 
   // Offers that the wallet knows about (the inbox).
-  const idToOffer = makeStore();
-  const idToNotifierP = makeStore();
+  const idToOffer = makeStore('offerId');
+  const idToNotifierP = makeStore('offerId');
 
   // Compiled offers (all ready to execute).
   const idToCompiledOfferP = new Map();

--- a/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
@@ -79,7 +79,11 @@ export async function makeWallet({
         },
         getBrandForIssuer: issuerToBrand.get,
       });
-    const brandTable = makeTable(validateSomewhat, makeCustomProperties);
+    const brandTable = makeTable(
+      validateSomewhat,
+      'brand',
+      makeCustomProperties,
+    );
     return brandTable;
   };
 

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-mints.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-mints.js
@@ -8,7 +8,7 @@ import makeStore from '@agoric/store';
 // simoleanMint.
 
 function build(_E, _log) {
-  const mintsAndMath = makeStore();
+  const mintsAndMath = makeStore('issuerName');
 
   const api = harden({
     getAllIssuerNames: () => mintsAndMath.keys(),

--- a/packages/zoe/src/contracts/multipoolAutoswap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap.js
@@ -90,6 +90,7 @@ const makeContract = zcf => {
         'liquidityTokenSupply',
       ]),
     ),
+    'tokenBrand',
   );
 
   // Allows users to add new liquidity pools. `newTokenIssuer` and

--- a/packages/zoe/src/state.js
+++ b/packages/zoe/src/state.js
@@ -17,7 +17,7 @@ const makeInstallationTable = () => {
   const validateSomewhat = makeValidateProperties(
     harden(['installation', 'bundle']),
   );
-  return makeTable(validateSomewhat);
+  return makeTable(validateSomewhat, 'installationHandle');
 };
 
 // Instance Table
@@ -36,7 +36,7 @@ const makeInstanceTable = () => {
     ]),
   );
 
-  return makeTable(validateSomewhat);
+  return makeTable(validateSomewhat, 'instanceHandle');
 };
 
 // Offer Table
@@ -101,7 +101,7 @@ const makeOfferTable = () => {
     return customMethods;
   };
 
-  return makeTable(validateSomewhat, makeCustomMethods);
+  return makeTable(validateSomewhat, 'offerHandle', makeCustomMethods);
 };
 
 // Payout Map
@@ -128,8 +128,8 @@ const makeIssuerTable = () => {
   );
 
   const makeCustomMethods = table => {
-    const issuersInProgress = makeStore();
-    const issuerToBrand = makeStore();
+    const issuersInProgress = makeStore('issuer');
+    const issuerToBrand = makeStore('issuer');
 
     // We can't be sure we can build the table entry soon enough that the first
     // caller will get the actual data, so we start by saving a promise in the
@@ -190,7 +190,7 @@ const makeIssuerTable = () => {
     return customMethods;
   };
 
-  return makeTable(validateSomewhat, makeCustomMethods);
+  return makeTable(validateSomewhat, 'brand', makeCustomMethods);
 };
 
 const makeTables = () =>

--- a/packages/zoe/src/table.js
+++ b/packages/zoe/src/table.js
@@ -5,10 +5,11 @@ import { assert, details } from '@agoric/assert';
 
 export const makeTable = (
   validateFn,
+  key = undefined,
   makeCustomMethodsFn = () => undefined,
 ) => {
   // The WeakMap that stores the records
-  const handleToRecord = makeStore();
+  const handleToRecord = makeStore(key);
 
   const table = harden({
     validate: validateFn,

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -339,7 +339,7 @@ import { makeTables } from './state';
  */
 function makeZoe(additionalEndowments = {}, vatPowers = {}) {
   // Zoe maps the inviteHandles to contract offerHook upcalls
-  const inviteHandleToOfferHook = makeStore();
+  const inviteHandleToOfferHook = makeStore('inviteHandle');
 
   const {
     mint: inviteMint,

--- a/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
@@ -30,10 +30,10 @@ test('ZoeHelpers messages', t => {
 });
 
 function makeMockZoeBuilder() {
-  const offers = makeStore();
-  const allocs = makeStore();
+  const offers = makeStore('offerHandle');
+  const allocs = makeStore('offerHandle');
   let instanceRecord;
-  const amountMathToBrand = makeStore();
+  const amountMathToBrand = makeStore('amountMath');
   const completedHandles = [];
   const reallocatedAmountObjs = [];
   const reallocatedHandles = [];


### PR DESCRIPTION
Add the name of keys to `makeStore` calls to improve the default error messages. 

Starts to address #1274 

Now the error reads slightly better:

<img width="917" alt="Screen Shot 2020-07-08 at 4 48 54 PM" src="https://user-images.githubusercontent.com/2441069/86981405-5dd9af80-c13b-11ea-9c8d-ee336abaecef.png">
