### PR TITLE
Add example "Escrow to Vote" contract

### DIFF
--- a/packages/zoe/test/unitTests/contracts/escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/escrowToVote.js
@@ -1,0 +1,107 @@
+/* global harden */
+// @ts-check
+
+// Eventually will be importable from '@agoric/zoe-contract-support'
+import { assert, details } from '@agoric/assert';
+import makeStore from '@agoric/store';
+import { makeZoeHelpers } from '../../../src/contractSupport';
+
+/**
+ * Implement coin voting. Give a voting capability when a payment is
+ * escrowed.
+ *
+ * @typedef {import('../../../src/zoe').ContractFacet} ContractFacet
+ * @typedef {import('@agoric/ERTP').Amount} Amount
+ * @param {ContractFacet} zcf
+ */
+const makeContract = zcf => {
+  const { assertKeywords, checkHook } = makeZoeHelpers(zcf);
+  assertKeywords(harden(['Assets']));
+  const {
+    brandKeywordRecord,
+    terms: { question },
+  } = zcf.getInstanceRecord();
+  // We assume the only valid responses are 'YES' and 'NO'
+  const amountMath = zcf.getAmountMath(brandKeywordRecord.Assets);
+
+  const offerHandleToResponse = makeStore('offerHandle');
+
+  // TODO: Validate that the response is of the format: { [question]: 'YES'|'NO'}
+  const validateResponse = (_offerHandle, _response) => {
+    // Complete the offer if the response is not valid and then throw.
+  };
+
+  const voterHook = voterOfferHandle => {
+    const voter = harden({
+      /**
+       * Vote on a particular issue
+       * @param {object} response: { [question]: answer }
+       */
+      vote: response => {
+        // Throw if the offer is no longer active, i.e. the user has
+        // completed their offer and the assets are no longer escrowed.
+        assert(
+          zcf.isOfferActive(voterOfferHandle),
+          `the escrowing offer is no longer active`,
+        );
+
+        validateResponse(response);
+
+        // Record the response
+        if (offerHandleToResponse.has(voterOfferHandle)) {
+          offerHandleToResponse.set(voterOfferHandle, response);
+        } else {
+          offerHandleToResponse.init(voterOfferHandle, response);
+        }
+        return `Successfully voted ${response}`;
+      },
+    });
+    return voter;
+  };
+
+  const expectedVoterProposal = harden({
+    give: { Assets: null },
+  });
+
+  const makeVoterInvite = () =>
+    zcf.makeInvitation(checkHook(voterHook, expectedVoterProposal), 'voter');
+
+  const expectedSecretaryProposal = harden({});
+
+  const secretaryHook = secretaryOfferHandle => {
+    const secretary = harden({
+      // TODO: complete function
+      closeElection: () => {
+        // YES | NO to Nat
+        const tally = new Map();
+        // Iterate through offerHandleToResponse
+
+        // Get the amount currently escrowed for each offerHandle
+        // const escrowedAmount = zcf.getCurrentAllocation(offerHandle).Assets;
+
+        // Add to the running tally weighting by the extent escrowed.
+        // tally.set(response[question], escrowedAmount.extent)
+
+        // Complete all the voting offers
+        // zcf.complete(offerHandleToResponse.keys())
+
+        // Complete the secretary offer?
+
+        return harden(tally);
+      },
+      // TODO: prevent this from working if election is closed?
+      makeVoterInvite,
+    });
+    return secretary;
+  };
+
+  // Return the secretary invite so that the entity that created the
+  // contract instance can hand out scarce votes and close the election.
+  return zcf.makeInvitation(
+    checkHook(secretaryHook, expectedSecretaryProposal),
+    'secretary',
+  );
+};
+
+harden(makeContract);
+export { makeContract };

--- a/packages/zoe/test/unitTests/contracts/escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/escrowToVote.js
@@ -28,7 +28,8 @@ const makeContract = zcf => {
 
   // TODO: Validate that the response is of the format: { [question]: 'YES'|'NO'}
   const validateResponse = (_offerHandle, _response) => {
-    // Complete the offer if the response is not valid and then throw.
+    // Throw an error if the response is not valid, but do not
+    // complete the offer. We should allow the voter to recast their vote.
   };
 
   const voterHook = voterOfferHandle => {
@@ -69,12 +70,15 @@ const makeContract = zcf => {
   const expectedSecretaryProposal = harden({});
 
   const secretaryHook = secretaryOfferHandle => {
+    // TODO: what if the secretary offer is no longer active?
     const secretary = harden({
       // TODO: complete function
       closeElection: () => {
         // YES | NO to Nat
         const tally = new Map();
         // Iterate through offerHandleToResponse
+
+        // Check if the offer is still active.
 
         // Get the amount currently escrowed for each offerHandle
         // const escrowedAmount = zcf.getCurrentAllocation(offerHandle).Assets;
@@ -87,7 +91,10 @@ const makeContract = zcf => {
 
         // Complete the secretary offer?
 
-        return harden(tally);
+        return harden({
+          YES: tally.get('YES'),
+          NO: tally.get('NO'),
+        });
       },
       // TODO: prevent this from working if election is closed?
       makeVoterInvite,

--- a/packages/zoe/test/unitTests/contracts/escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/escrowToVote.js
@@ -7,8 +7,14 @@ import makeStore from '@agoric/store';
 import { makeZoeHelpers } from '../../../src/contractSupport';
 
 /**
- * Implement coin voting. Give a voting capability when a payment is
- * escrowed.
+ * This contract implements coin voting. There are two roles: the
+ * Secretary, who can determine the question (a string), make voting
+ * invites, and close the election; and the Voters, who can vote YES or
+ * NO on the question. The voters can only get the capability to vote
+ * by making an offer using a voter invite and escrowing assets. The
+ * brand of assets is determined on contract instantiation through an
+ * issuerKeywordRecord. The instantiator gets the only Secretary
+ * invite.
  *
  * @typedef {import('../../../src/zoe').ContractFacet} ContractFacet
  * @typedef {import('@agoric/ERTP').Amount} Amount

--- a/packages/zoe/test/unitTests/contracts/escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/escrowToVote.js
@@ -21,7 +21,9 @@ import { makeZoeHelpers } from '../../../src/contractSupport';
  * @param {ContractFacet} zcf
  */
 const makeContract = zcf => {
-  const { assertKeywords, assertNatMathHelpers, checkHook } = makeZoeHelpers(zcf);
+  const { assertKeywords, assertNatMathHelpers, checkHook } = makeZoeHelpers(
+    zcf,
+  );
   assertKeywords(harden(['Assets']));
   const {
     terms: { question },

--- a/packages/zoe/test/unitTests/contracts/escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/escrowToVote.js
@@ -18,26 +18,25 @@ const makeContract = zcf => {
   const { assertKeywords, checkHook } = makeZoeHelpers(zcf);
   assertKeywords(harden(['Assets']));
   const {
-    brandKeywordRecord,
     terms: { question },
   } = zcf.getInstanceRecord();
-  // We assume the only valid responses are 'YES' and 'NO'
-  const amountMath = zcf.getAmountMath(brandKeywordRecord.Assets);
 
   const offerHandleToResponse = makeStore('offerHandle');
 
+  // `question` is a string defined in the terms.
+  // We assume the only valid answers are 'YES' and 'NO'
   const validateResponse = response => {
     assert(
       Object.keys(response).length === 1 &&
         Object.keys(response)[0] === question,
-      `The question ${
+      `The question '${
         Object.keys(response)[0]
-      } did not match the question ${question}`,
+      }' did not match the question '${question}'`,
     );
 
     assert(
       response[question] === 'NO' || response[question] === 'YES',
-      `the answer ${response[question]} was not 'YES' or 'NO'`,
+      `the answer '${response[question]}' was not 'YES' or 'NO'`,
     );
     // Throw an error if the response is not valid, but do not
     // complete the offer. We should allow the voter to recast their vote.

--- a/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
@@ -1,0 +1,220 @@
+/* global harden */
+
+import '@agoric/install-ses';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from 'tape-promise/tape';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import bundleSource from '@agoric/bundle-source';
+import { E } from '@agoric/eventual-send';
+
+import { makeZoe } from '../../../src/zoe';
+import { setup } from '../setupBasicMints';
+
+const contractRoot = `${__dirname}/escrowToVote`;
+
+test('zoe - escrowToVote', async t => {
+  t.plan(13);
+  const { moolaIssuer, moolaMint, moola } = setup();
+  const zoe = makeZoe();
+
+  // pack the contract
+  const bundle = await bundleSource(contractRoot);
+  // install the contract
+  const installationHandle = await zoe.install(bundle);
+
+  // Alice creates an instance and acts as the Secretary
+  const issuerKeywordRecord = harden({
+    Assets: moolaIssuer,
+  });
+
+  // She sets the question to be voted on, in the terms of the contract.
+  const QUESTION = 'Should we upgrade?';
+  const terms = { question: QUESTION };
+
+  // She makes a running contract instance using the installation, and
+  // receives a special, secretary invite back which has the special
+  // authority to close elections.
+  const { invite: secretaryInvite } = await E(zoe).makeInstance(
+    installationHandle,
+    issuerKeywordRecord,
+    terms,
+  );
+
+  // Alice makes an offer to use the secretary invite and get a
+  // secretary use object back.
+  const { outcome: secretaryUseObjP, completeObj } = await E(zoe).offer(
+    secretaryInvite,
+  );
+
+  const secretary = await secretaryUseObjP;
+
+  // The secretary has the unique power to make voter invites.
+  const voterInvite1 = E(secretary).makeVoterInvite();
+  const voterInvite2 = E(secretary).makeVoterInvite();
+  const voterInvite3 = E(secretary).makeVoterInvite();
+
+  // Let's imagine that we send the voterInvites to various parties
+  // who use them to make an offer with Zoe in which they escrow moola.
+
+  // Voter 1 votes YES. Vote will be weighted by 3 (3 moola escrowed).
+  const voter1Votes = async invite => {
+    const proposal = harden({
+      give: { Assets: moola(3) },
+    });
+    const payments = harden({
+      Assets: moolaMint.mintPayment(moola(3)),
+    });
+    const { payout: payoutP, outcome: voterP } = await E(zoe).offer(
+      invite,
+      proposal,
+      payments,
+    );
+
+    const voter = await voterP;
+    const result = await E(voter).vote({ [QUESTION]: 'YES' });
+
+    t.equals(
+      result,
+      `Successfully voted ${{ [QUESTION]: 'YES' }}`,
+      `voter1 votes YES`,
+    );
+
+    payoutP.then(async payout => {
+      const moolaPayment = await payout.Assets;
+
+      t.deepEquals(
+        await moolaIssuer.getAmountOf(moolaPayment),
+        moola(3),
+        `voter1 gets everything she escrowed back`,
+      );
+
+      console.log('EXPECTED ERROR ->>>');
+      t.throws(
+        () => voter.vote({ [QUESTION]: 'NO' }),
+        /the escrowing offer is no longer active/,
+        `voter1 voting fails once offer is withdrawn or amounts are reallocated`,
+      );
+    });
+  };
+
+  await voter1Votes(voterInvite1);
+
+  // Voter 2 makes badly formed votes, then votes YES, then changes
+  // vote to NO. Vote will be weighted by 5 (5 moola escrowed).
+  const voter2Votes = async invite => {
+    const proposal = harden({
+      give: { Assets: moola(5) },
+    });
+    const payments = harden({
+      Assets: moolaMint.mintPayment(moola(5)),
+    });
+    const { payout: payoutP, outcome: voterP } = await E(zoe).offer(
+      invite,
+      proposal,
+      payments,
+    );
+
+    const voter = await voterP;
+    t.throws(
+      () => E(voter).vote({ 'not a question': 'NO' }),
+      /The question 'not a question' did not match the question 'Should we upgrade\?'/,
+      `A vote for the wrong question throws`,
+    );
+    t.throws(
+      () => E(voter).vote({ [QUESTION]: 'NOT A VALID ANSWER' }),
+      /the answer 'NOT A VALID ANSWER' was not 'YES' or 'NO'/,
+      `A vote with an invalid answer throws`,
+    );
+
+    const result1 = await E(voter).vote({ [QUESTION]: 'YES' });
+    t.equals(
+      result1,
+      `Successfully voted ${{ [QUESTION]: 'YES' }}`,
+      `voter2 votes YES`,
+    );
+
+    // Votes can be recast at any time
+    const result2 = await E(voter).vote({ [QUESTION]: 'NO' });
+    t.equals(
+      result2,
+      `Successfully voted ${{ [QUESTION]: 'NO' }}`,
+      `voter 2 recast vote for NO`,
+    );
+
+    payoutP.then(async payout => {
+      const moolaPayment = await payout.Assets;
+
+      t.deepEquals(
+        await moolaIssuer.getAmountOf(moolaPayment),
+        moola(5),
+        `voter2 gets everything she escrowed back`,
+      );
+
+      console.log('EXPECTED ERROR ->>>');
+      t.throws(
+        () => voter.vote({ [QUESTION]: 'NO' }),
+        /the escrowing offer is no longer active/,
+        `voter2 voting fails once offer is withdrawn or amounts are reallocated`,
+      );
+    });
+  };
+
+  await voter2Votes(voterInvite2);
+
+  // Voter 3 votes NO and then completes their offer, meaning that
+  // their vote should not be counted. They get their full moola (1
+  // moola) back as a payout.
+  const voter3Votes = async invite => {
+    const proposal = harden({
+      give: { Assets: moola(1) },
+    });
+    const payments = harden({
+      Assets: moolaMint.mintPayment(moola(1)),
+    });
+    const { payout: payoutP, outcome: voterP, completeObj } = await E(
+      zoe,
+    ).offer(invite, proposal, payments);
+
+    const voter = await voterP;
+    const result = await E(voter).vote({ [QUESTION]: 'NO' });
+    t.equals(
+      result,
+      `Successfully voted ${{ [QUESTION]: 'NO' }}`,
+      `voter3 votes NOT`,
+    );
+
+    // Voter3 completes their offer and exits before the election is
+    // closed. Voter3's vote will not be counted.
+    completeObj.complete();
+
+    const payout = await payoutP;
+
+    const moolaPayment = await payout.Assets;
+
+    t.deepEquals(
+      await moolaIssuer.getAmountOf(moolaPayment),
+      moola(1),
+      `voter3 gets everything she escrowed back`,
+    );
+
+    console.log('EXPECTED ERROR ->>>');
+    t.throws(
+      () => voter.vote({ [QUESTION]: 'NO' }),
+      /the escrowing offer is no longer active/,
+      `voter3 voting fails once offer is withdrawn or amounts are reallocated`,
+    );
+  };
+
+  await voter3Votes(voterInvite3);
+
+  // Secretary closes election and tallies the votes.
+  const electionResults = await E(secretary).closeElection();
+  t.deepEquals(electionResults, [
+    ['YES', 3],
+    ['NO', 5],
+  ]);
+
+  // Once the election is closed, the voters get their escrowed funds
+  // back and can no longer vote. See the voter functions for the
+  // resolution of the payout promises for each voter.
+});

--- a/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
@@ -40,11 +40,9 @@ test('zoe - escrowToVote', async t => {
     terms,
   );
 
-  // Alice makes an offer to use the secretary invite and get a
+  // Alice makes an offer to use the secretary invite and gets a
   // secretary use object back.
-  const { outcome: secretaryUseObjP, completeObj } = await E(zoe).offer(
-    secretaryInvite,
-  );
+  const { outcome: secretaryUseObjP } = await E(zoe).offer(secretaryInvite);
 
   const secretary = await secretaryUseObjP;
 
@@ -115,11 +113,13 @@ test('zoe - escrowToVote', async t => {
     );
 
     const voter = await voterP;
+    console.log('EXPECTED ERROR ->>>');
     t.rejects(
       () => E(voter).vote({ 'not a question': 'NO' }),
       /The question 'not a question' did not match the question 'Should we upgrade\?'/,
       `A vote for the wrong question throws`,
     );
+    console.log('EXPECTED ERROR ->>>');
     t.rejects(
       () => E(voter).vote({ [QUESTION]: 'NOT A VALID ANSWER' }),
       /the answer 'NOT A VALID ANSWER' was not 'YES' or 'NO'/,
@@ -209,10 +209,7 @@ test('zoe - escrowToVote', async t => {
 
   // Secretary closes election and tallies the votes.
   const electionResults = await E(secretary).closeElection();
-  t.deepEquals(electionResults, [
-    ['YES', 3],
-    ['NO', 5],
-  ]);
+  t.deepEquals(electionResults, { YES: 3, NO: 5 });
 
   // Once the election is closed, the voters get their escrowed funds
   // back and can no longer vote. See the voter functions for the

--- a/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
@@ -115,12 +115,12 @@ test('zoe - escrowToVote', async t => {
     );
 
     const voter = await voterP;
-    t.throws(
+    t.rejects(
       () => E(voter).vote({ 'not a question': 'NO' }),
       /The question 'not a question' did not match the question 'Should we upgrade\?'/,
       `A vote for the wrong question throws`,
     );
-    t.throws(
+    t.rejects(
       () => E(voter).vote({ [QUESTION]: 'NOT A VALID ANSWER' }),
       /the answer 'NOT A VALID ANSWER' was not 'YES' or 'NO'/,
       `A vote with an invalid answer throws`,


### PR DESCRIPTION
This PR adds the "escrow to vote" contract from the internal hackathon to the contract examples, with a test file executing the functionality.