### PR TITLE
feat!: introduce notifier.getCurrentUpdate() which is immediate

### DIFF
--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -49,6 +49,9 @@
     "env": {
       "es6": true
     },
+    "globals": {
+      "harden": "readonly"
+    },
     "rules": {
       "implicit-arrow-linebreak": "off",
       "function-paren-newline": "off",

--- a/packages/notifier/src/notifier.js
+++ b/packages/notifier/src/notifier.js
@@ -1,42 +1,78 @@
-/* global harden */
+// @ts-check
+// eslint-disable-next-line spaced-comment
+/// <reference types="ses"/>
 
 import { producePromise } from '@agoric/produce-promise';
 
 /**
- * Produces a pair of objects, which allow a service to produce a stream of
- * update promises. The notifier has a single method: getUpdatesSince, while the
- * updater has two methods, updateState and resolve. getUpdateSince can be
- * called repeatedly to get access to a sequence of update records.
- * Each update is a record containing { value, updateHandle, done }.
- *   value is whatever state the service wants to publish,
- *   updateHandle is an opaque object that identifies the update.
- *   done is a boolean that remains false until the stream reaches a final state
- *
- * getUpdateSince(handle) returns the record above, or a HandledPromise for it.
- * If the handle argument is omitted or differs from the current handle, the
- * current record is returned. If the handle corresponds to the current state,
- * a promise is returned. After the next state change, The promise will resolve
- * to the then-current value of the record.
- *
- * updateState(state) sets a new state and resolves the outstanding promise.
- * resolve(finalState) sets the new state, sends a final update, and freezes the
- * updater. The updater object should be closely held, as anyone with access to
- * it can provide updates.
+ * @typedef {Object} UpdateHandle a value used to mark the position in the update stream
  */
-export const produceNotifier = () => {
+
+/**
+ * @template T the type of the state value
+ * @typedef {Object} UpdateRecord<T>
+ * @property {T} value is whatever state the service wants to publish
+ * @property {UpdateHandle} updateHandle is a value that identifies the update
+ * @property {boolean} done false until the updater publishes a final state
+ */
+
+/**
+ * @template T the type of the notifier state
+ * @callback GetUpdateSince<T> Can be called repeatedly to get a sequence of update records
+ * @param {UpdateHandle} [updateHandle] return update record as of a handle
+ * If the handle argument is omitted or differs from the current handle, return the current record.
+ * Otherwise, after the next state change, the promise will resolve to the then-current value of the record.
+ * @returns {Promise<UpdateRecord<T>>} resolves to the corresponding update
+ */
+
+/**
+ * @template T the type of the notifier state
+ * @typedef {Object} Notifier<T> an object that can be used to get the current state or updates
+ * @property {GetUpdateSince<T>} getUpdateSince return update record as of a handle
+ * @property {() => UpdateRecord<T>} getCurrentUpdate return the current update record
+ */
+
+/**
+ * @template T the type of the notifier state
+ * @typedef {Object} Updater<T> an object that should be closely held, as anyone with access to
+ * it can provide updates
+ * @property {(state: T) => void} updateState sets the new state, and resolves the outstanding promise to send an update
+ * @property {(finalState: T) => void} resolve sets the final state, sends a final update, and freezes the
+ * updater
+ */
+
+/**
+ * @template T the type of the notifier state
+ * @typedef {Object} NotifierRecord<T> the produced notifier/updater pair
+ * @property {Notifier<T>} notifier the (widely-held) notifier consumer
+ * @property {Updater<T>} updater the (closely-held) notifier producer
+ */
+
+/**
+ * Produces a pair of objects, which allow a service to produce a stream of
+ * update promises.
+ *
+ * @template T the type of the notifier state
+ * @param {T} [initialState] the first state to be returned
+ * @returns {NotifierRecord<T>} the notifier and updater
+ */
+export const produceNotifier = (initialState = undefined) => {
   let currentPromiseRec = producePromise();
   let currentResponse = harden({
-    value: undefined,
+    value: initialState,
     updateHandle: {},
     done: false,
   });
+
+  function getCurrentUpdate() {
+    return currentResponse;
+  }
 
   function getUpdateSince(updateHandle = undefined) {
     if (updateHandle === currentResponse.updateHandle) {
       return currentPromiseRec.promise;
     }
-
-    return currentResponse;
+    return Promise.resolve(currentResponse);
   }
 
   function updateState(state) {
@@ -64,7 +100,7 @@ export const produceNotifier = () => {
 
   // notifier facet is separate so it can be handed out loosely while updater is
   // tightly held
-  const notifier = harden({ getUpdateSince });
+  const notifier = harden({ getUpdateSince, getCurrentUpdate });
   const updater = harden({ updateState, resolve });
   return harden({ notifier, updater });
 };

--- a/packages/notifier/test/test-notifier.js
+++ b/packages/notifier/test/test-notifier.js
@@ -1,47 +1,75 @@
+// @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 import { test } from 'tape-promise/tape';
 import { produceNotifier } from '../src/notifier';
 
-test('notifier - initital state', t => {
+/**
+ * @template T
+ * @typedef {import('../src/notifier').NotifierRecord<T>} NotifierRecord<T>
+ */
+
+test('notifier - initial state', async t => {
+  /** @type {NotifierRecord<1>} */
   const { notifier, updater } = produceNotifier();
   updater.updateState(1);
 
-  const updateDeNovo = notifier.getUpdateSince();
-  const updateFromNonExistent = notifier.getUpdateSince({});
+  const updateDeNovo = await notifier.getUpdateSince();
+  const updateFromNonExistent = await notifier.getUpdateSince({});
 
   t.equals(updateDeNovo.value, 1, 'state is one');
   t.deepEquals(updateDeNovo, updateFromNonExistent, 'no param same as unknown');
   t.end();
 });
 
-test('notifier - single update', t => {
+test('notifier - single update', async t => {
   t.plan(3);
+  /** @type {NotifierRecord<number>} */
   const { notifier, updater } = produceNotifier();
   updater.updateState(1);
 
-  const updateDeNovo = notifier.getUpdateSince();
+  const updateDeNovo = await notifier.getUpdateSince();
+  t.equals(updateDeNovo.value, 1, 'initial state is one');
 
   const updateInWaiting = notifier.getUpdateSince(updateDeNovo.updateHandle);
-  t.equals(updateDeNovo.value, 1, 'initial state is one');
-  Promise.all([updateInWaiting]).then(([update]) => {
+  const all = Promise.all([updateInWaiting]).then(([update]) => {
     t.equals(update.value, 3, 'updated state is eventually three');
   });
 
-  t.equals(notifier.getUpdateSince({}).value, 1);
+  const update2 = await notifier.getUpdateSince({});
+  t.equals(update2.value, 1);
   updater.updateState(3);
+  await all;
 });
 
-test('notifier - update after state change', t => {
-  t.plan(5);
-  const { notifier, updater } = produceNotifier();
-  updater.updateState(1);
+test('notifier - initial update', async t => {
+  t.plan(3);
+  /** @type {NotifierRecord<number>} */
+  const { notifier, updater } = produceNotifier(1);
 
-  const updateDeNovo = notifier.getUpdateSince();
+  const updateDeNovo = notifier.getCurrentUpdate();
+  t.equals(updateDeNovo.value, 1, 'initial state is one');
+
+  const updateInWaiting = notifier.getUpdateSince(updateDeNovo.updateHandle);
+  const all = Promise.all([updateInWaiting]).then(([update]) => {
+    t.equals(update.value, 3, 'updated state is eventually three');
+  });
+
+  const update2 = await notifier.getUpdateSince({});
+  t.equals(update2.value, 1);
+  updater.updateState(3);
+  await all;
+});
+
+test('notifier - update after state change', async t => {
+  t.plan(5);
+  const { notifier, updater } = produceNotifier(1);
+
+  const updateDeNovo = notifier.getCurrentUpdate();
 
   const updateInWaiting = notifier.getUpdateSince(updateDeNovo.updateHandle);
   t.equals(updateDeNovo.value, 1, 'first state check (1)');
-  Promise.all([updateInWaiting]).then(([update1]) => {
+  const all = Promise.all([updateInWaiting]).then(([update1]) => {
     t.equals(update1.value, 3, '4th check (delayed) 3');
     const thirdStatePromise = notifier.getUpdateSince(update1.updateHandle);
     Promise.all([thirdStatePromise]).then(([update2]) => {
@@ -49,22 +77,23 @@ test('notifier - update after state change', t => {
     });
   });
 
-  t.equals(notifier.getUpdateSince({}).value, 1, '2nd check (1)');
+  t.equals(notifier.getCurrentUpdate().value, 1, '2nd check (1)');
   updater.updateState(3);
 
-  t.equals(notifier.getUpdateSince({}).value, 3, '3rd check (3)');
+  t.equals(notifier.getCurrentUpdate().value, 3, '3rd check (3)');
   updater.updateState(5);
+  await all;
 });
 
-test('notifier - final state', t => {
+test('notifier - final state', async t => {
   t.plan(6);
-  const { notifier, updater } = produceNotifier();
-  updater.updateState(1);
+  /** @type {NotifierRecord<number|string>} */
+  const { notifier, updater } = produceNotifier(1);
 
-  const updateDeNovo = notifier.getUpdateSince();
+  const updateDeNovo = notifier.getCurrentUpdate();
   const updateInWaiting = notifier.getUpdateSince(updateDeNovo.updateHandle);
   t.equals(updateDeNovo.value, 1, 'initial state is one');
-  Promise.all([updateInWaiting]).then(([update]) => {
+  const all = Promise.all([updateInWaiting]).then(([update]) => {
     t.equals(update.value, 'final', 'state is "final"');
     t.notOk(update.updateHandle, 'no handle after close');
     const postFinalUpdate = notifier.getUpdateSince(update.updateHandle);
@@ -74,6 +103,8 @@ test('notifier - final state', t => {
     });
   });
 
-  t.equals(notifier.getUpdateSince({}).value, 1, 'still one');
+  const invalidHandle = await notifier.getUpdateSince({});
+  t.equals(invalidHandle.value, 1, 'still one');
   updater.resolve('final');
+  await all;
 });

--- a/packages/zoe/src/contracts/simpleExchange.js
+++ b/packages/zoe/src/contracts/simpleExchange.js
@@ -29,7 +29,8 @@ import { makeZoeHelpers, defaultAcceptanceMsg } from '../contractSupport';
 const makeContract = zcf => {
   let sellOfferHandles = [];
   let buyOfferHandles = [];
-  const { notifier, updater } = produceNotifier();
+  // eslint-disable-next-line no-use-before-define
+  const { notifier, updater } = produceNotifier(getBookOrders());
 
   const {
     rejectOffer,

--- a/packages/zoe/test/swingsetTests/zoe/test-zoe.js
+++ b/packages/zoe/test/swingsetTests/zoe/test-zoe.js
@@ -202,7 +202,7 @@ test('zoe - simpleExchange - valid inputs', async t => {
 
 const expectedSimpleExchangeNotificationLog = [
   '=> alice, bob, carol and dave are set up',
-  '',
+  '{"buys":[],"sells":[]}',
   '{"buys":[],"sells":[{"want":{"Price":{"brand":{},"extent":4}},"give":{"Asset":{"brand":{},"extent":3}}}]}',
   'The offer has been accepted. Once the contract has been completed, please check your payout',
   '{"buys":[],"sells":[]}',


### PR DESCRIPTION
#dapp-encouragement-branch: mfig/notifier-refinement

The breaking change is always to return promises from `getUpdateSince()`.  I discovered this inconsistency in the return type when attempting to introduce full JSDoc typing.  

Note that if you want your contract to be compatible both before and after this breaking change, make sure you add `await notifier.getUpdateSince()` to allow the current `.getUpdateSince()` to return a promise or not.

The new API includes `notifier.getCurrentUpdate()` to be immediate to satisfy one of the use cases for `getUpdateSince()`.

There's also a non-breaking enhancement to allow the specification of the initial state as the argument to produceNotifier.
