### PR TITLE
feat: reintroduce anylogger as the console endowment

### DIFF
--- a/packages/SwingSet/src/kernel/dynamicVat.js
+++ b/packages/SwingSet/src/kernel/dynamicVat.js
@@ -9,7 +9,7 @@ export function makeDynamicVatCreator(stuff) {
   const {
     allocateUnusedVatID,
     vatNameToID,
-    vatEndowments,
+    makeVatEndowments,
     dynamicVatPowers,
     transformMetering,
     makeGetMeter,
@@ -86,7 +86,7 @@ export function makeDynamicVatCreator(stuff) {
       const vatNS = await importBundle(vatSourceBundle, {
         filePrefix: vatID,
         transforms,
-        endowments: { ...vatEndowments, getMeter },
+        endowments: { ...makeVatEndowments(vatID), getMeter },
       });
       if (typeof vatNS.buildRootObject !== 'function') {
         throw Error(

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -31,7 +31,7 @@ export default function buildKernel(kernelEndowments) {
   const {
     waitUntilQuiescent,
     hostStorage,
-    vatEndowments,
+    makeVatEndowments,
     vatAdminVatSetup,
     vatAdminDevSetup,
     replaceGlobalMeter,
@@ -769,7 +769,7 @@ export default function buildKernel(kernelEndowments) {
   const createVatDynamically = makeDynamicVatCreator({
     allocateUnusedVatID: kernelKeeper.allocateUnusedVatID,
     vatNameToID,
-    vatEndowments,
+    makeVatEndowments,
     dynamicVatPowers,
     transformMetering,
     makeGetMeter,

--- a/packages/cosmic-swingset/lib/ag-solo/vats/ibc.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/ibc.js
@@ -220,7 +220,7 @@ export function makeIBCProtocolHandler(E, callIBCDevice) {
 
     return harden({
       async onOpen(conn, localAddr, remoteAddr, _handler) {
-        console.info(
+        console.debug(
           'onOpen Remote IBC Connection',
           channelID,
           portID,
@@ -304,7 +304,7 @@ export function makeIBCProtocolHandler(E, callIBCDevice) {
    */
   const protocol = harden({
     async onCreate(impl, _protocolHandler) {
-      console.info('IBC onCreate');
+      console.debug('IBC onCreate');
       protocolImpl = impl;
     },
     async generatePortID(_localAddr, _protocolHandler) {
@@ -324,7 +324,7 @@ export function makeIBCProtocolHandler(E, callIBCDevice) {
       return callIBCDevice('bindPort', { packet });
     },
     async onConnect(port, localAddr, remoteAddr, chandler, _protocolHandler) {
-      console.warn('IBC onConnect', localAddr, remoteAddr);
+      console.debug('IBC onConnect', localAddr, remoteAddr);
       const portID = localAddrToPortID(localAddr);
       const pendingConns = portToPendingConns.get(port);
 
@@ -423,14 +423,14 @@ EOF
         .catch(rethrowUnlessMissing);
       return onConnectP.promise;
     },
-    async onListen(_port, _localAddr, _listenHandler) {
-      // console.warn('IBC onListen', localAddr);
+    async onListen(_port, localAddr, _listenHandler) {
+      console.debug('IBC onListen', localAddr);
     },
     async onListenRemove(_port, localAddr, _listenHandler) {
-      console.warn('IBC onListenRemove', localAddr);
+      console.debug('IBC onListenRemove', localAddr);
     },
     async onRevoke(port, localAddr, _protocolHandler) {
-      console.warn('IBC onRevoke', localAddr);
+      console.debug('IBC onRevoke', localAddr);
       const pendingConns = portToPendingConns.get(port);
       portToPendingConns.delete(port);
       portToCircuits.delete(port);
@@ -444,7 +444,7 @@ EOF
   return harden({
     ...protocol,
     async fromBridge(srcID, obj) {
-      console.warn('IBC fromBridge', srcID, obj);
+      console.debug('IBC fromBridge', srcID, obj);
       switch (obj.event) {
         case 'channelOpenInit': {
           // This event is sent by a naive relayer that wants to initiate
@@ -512,7 +512,7 @@ EOF
           const versionSuffix = version ? `/${version}` : '';
           const localAddr = `/ibc-port/${portID}/${order.toLowerCase()}${versionSuffix}`;
           const ibcHops = hops.map(hop => `/ibc-hop/${hop}`).join('/');
-          const remoteAddr = `${ibcHops}/ibc-port/${rPortID}/${order.toLowerCase()}/${rVersion}`;
+          const remoteAddr = `${ibcHops}/ibc-port/${rPortID}/${order.toLowerCase()}/${rVersion}/ibc-channel/${rChannelID}`;
 
           // See if we allow an inbound attempt for this address pair (without rejecting).
           const attemptP = E(protocolImpl).inbound(localAddr, remoteAddr);

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-wallet.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-wallet.js
@@ -178,11 +178,11 @@ function build(E, _D, _log) {
   function getCommandHandler() {
     return harden({
       onOpen(_obj, meta) {
-        console.error('Adding adminHandle', meta);
+        console.debug('Adding adminHandle', meta);
         adminHandles.add(meta.channelHandle);
       },
       onClose(_obj, meta) {
-        console.error('Removing adminHandle', meta);
+        console.debug('Removing adminHandle', meta);
         adminHandles.delete(meta.channelHandle);
       },
       onMessage: adminOnMessage,


### PR DESCRIPTION
The `agoric start` console output regressed and is currently very noisy.  This PR makes things nice and tidy again.

Looks like the anylogger-scoped console baby got thrown out with the SES1 bathwater. 😉 

BTW, If you ever want to crank up the debug level (to see the `console.debug` messages), use:

```sh
# for running ag-solo directly:
DEBUG=agoric ag-solo start ...
# for running under CLI:
agoric -vvv start
```
