### PR TITLE
refactor: Split Zoe contract facet to a separate vat per contract

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
@@ -75,7 +75,7 @@ export function buildRootObject(vatPowers) {
   }
 
   // Make services that are provided on the real or virtual chain side
-  async function makeChainBundler(vats, timerDevice) {
+  async function makeChainBundler(vats, timerDevice, vatAdminSvc) {
     // Create singleton instances.
     const sharingService = await E(vats.sharing).getSharingService();
     const registry = await E(vats.registrar).getSharedRegistrar();
@@ -84,7 +84,7 @@ export function buildRootObject(vatPowers) {
       timerDevice,
     );
 
-    const zoe = await E(vats.zoe).getZoe();
+    const zoe = E(vats.zoe).buildZoe(vatAdminSvc);
     const contractHost = await E(vats.host).makeHost();
 
     // Make the other demo mints
@@ -297,6 +297,10 @@ export function buildRootObject(vatPowers) {
         );
       }
 
+      const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
+        devices.vatAdmin,
+      );
+
       console.debug(`${ROLE} bootstrap starting`);
       // scenario #1: Cloud has: multi-node chain, controller solo node,
       // provisioning server (python). New clients run provisioning
@@ -308,7 +312,7 @@ export function buildRootObject(vatPowers) {
           // provisioning vat can ask the demo server for bundles, and can
           // register client pubkeys with comms
           await E(vats.provisioning).register(
-            await makeChainBundler(vats, devices.timer),
+            await makeChainBundler(vats, devices.timer, vatAdminSvc),
             vats.comms,
             vats.vattp,
           );
@@ -406,7 +410,11 @@ export function buildRootObject(vatPowers) {
           // localhost, HTML frontend on localhost. Single-player mode.
 
           // bootAddress holds the pubkey of localclient
-          const chainBundler = await makeChainBundler(vats, devices.timer);
+          const chainBundler = await makeChainBundler(
+            vats,
+            devices.timer,
+            vatAdminSvc,
+          );
 
           // Allow manual provisioning requests via `agoric cosmos`.
           await E(vats.provisioning).register(
@@ -466,7 +474,11 @@ export function buildRootObject(vatPowers) {
           // frontend. Limited subset of demo runs inside the solo node.
 
           // We pretend we're on-chain.
-          const chainBundler = makeChainBundler(vats, devices.timer);
+          const chainBundler = makeChainBundler(
+            vats,
+            devices.timer,
+            vatAdminSvc,
+          );
           await registerNetworkProtocols(vats, bridgeManager);
 
           // Shared Setup (virtual chain side) ///////////////////////////

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-zoe.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-zoe.js
@@ -2,9 +2,8 @@
 
 import { makeZoe } from '@agoric/zoe';
 
-export function buildRootObject(vatPowers) {
-  const zoe = makeZoe({}, vatPowers);
+export function buildRootObject(_vatPowers) {
   return harden({
-    getZoe: () => zoe,
+    buildZoe: adminVat => makeZoe(adminVat),
   });
 }

--- a/packages/cosmic-swingset/test/unitTests/test-lib-wallet.js
+++ b/packages/cosmic-swingset/test/unitTests/test-lib-wallet.js
@@ -8,6 +8,7 @@ import makeAmountMath from '@agoric/ertp/src/amountMath';
 
 import makeIssuerKit from '@agoric/ertp';
 import { makeZoe } from '@agoric/zoe';
+import fakeVatAdmin from '@agoric/zoe/test/unitTests/contracts/fakeVatAdmin';
 import { makeRegistrar } from '@agoric/registrar';
 
 import { E } from '@agoric/eventual-send';
@@ -27,7 +28,7 @@ const setupTest = async () => {
   const moolaBundle = makeIssuerKit('moola');
   const simoleanBundle = makeIssuerKit('simolean');
   const rpgBundle = makeIssuerKit('rpg', 'strSet');
-  const zoe = makeZoe();
+  const zoe = makeZoe(fakeVatAdmin);
   const registry = makeRegistrar();
   const board = makeBoard();
 

--- a/packages/swingset-runner/demo/exchangeBenchmark/bootstrap.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/bootstrap.js
@@ -2,6 +2,7 @@
 
 import makeIssuerKit from '@agoric/ertp';
 import { E } from '@agoric/eventual-send';
+import fakeVatAdmin from '@agoric/zoe/test/unitTests/contracts/fakeVatAdmin';
 import { makePrintLog } from './printLog';
 
 /* eslint-disable-next-line import/no-unresolved, import/extensions */
@@ -65,7 +66,7 @@ export function buildRootObject(_vatPowers) {
   let round = 0;
   return harden({
     async bootstrap(argv, vats) {
-      const zoe = await E(vats.zoe).getZoe();
+      const zoe = await E(vats.zoe).buildZoe(fakeVatAdmin);
 
       const installations = {
         simpleExchange: await E(zoe).install(simpleExchangeBundle),

--- a/packages/swingset-runner/demo/zoeTests/bootstrap.js
+++ b/packages/swingset-runner/demo/zoeTests/bootstrap.js
@@ -2,6 +2,7 @@
 
 import { E } from '@agoric/eventual-send';
 import makeIssuerKit from '@agoric/ertp';
+import fakeVatAdmin from '@agoric/zoe/test/unitTests/contracts/fakeVatAdmin';
 import buildManualTimer from './manualTimer';
 import { makePrintLog } from './printLog';
 
@@ -94,7 +95,7 @@ const makeVats = (vats, zoe, installations, startingValues) => {
 export function buildRootObject(_vatPowers) {
   const obj0 = {
     async bootstrap(argv, vats) {
-      const zoe = await E(vats.zoe).getZoe();
+      const zoe = await E(vats.zoe).buildZoe(fakeVatAdmin);
 
       const installations = {
         automaticRefund: await E(zoe).install(automaticRefundBundle),

--- a/packages/zoe/docs/zoe-zcf.puml
+++ b/packages/zoe/docs/zoe-zcf.puml
@@ -1,0 +1,54 @@
+
+@startuml Zoe communication with Zcf
+scale 8
+
+participant SwingSet
+actor Alice
+participant Zoe
+box new vat per contract
+collections Zcf
+database contract
+end box
+
+SwingSet -> Zoe : create
+Alice -> Zoe : install bundle
+Alice //-- Zoe : <font color=gray><size:12> installHandle
+Alice -> Zoe : makeInstance(handle, ...)
+Zoe -> Zoe : createVat()
+Zoe -> Zoe : makeZoeForZcf
+Zoe -> Zcf : startContract(zoeForZcf)
+Zcf -> Zcf : evalContractBundle()
+Zcf -> Zcf : makeZcfForContract
+Zcf -> contract : makeContract(zcfForContract)
+contract --\\ Zcf : <font color=gray><size:12> invite
+Zcf --\\ Zoe : <font color=gray><size:12> {invite, zcfForZoe}
+Alice //-- Zoe : <font color=gray><size:12> { invite, instanceRecord }
+
+====
+contract -> Zcf : makeInvitation(...)
+Zcf -> Zoe : makeInvitation(...)
+note right
+build invokable object around hook
+call Zoe.makeInvitation(callbackObj)
+end note
+note left
+create inviteHandle
+save callBackObj keyed by InviteHandle
+create InviteAmount
+mint invitePayment
+end note
+
+Zoe --\\ Zcf : <font color=gray><size:12> invite
+Zcf -> Bob :  <font color=slategray><size:12>//<out of band>// <font color=gray><size:12> invite
+Bob -> Zoe : offer(invite)
+note left
+record Deposit
+create payout
+end note
+Zoe -> Zcf : addOffer
+Zcf -> Zcf : setup completion actions
+Zcf --\\ Zoe : <font color=gray><size:12> completeObj
+Zoe -> Zcf : seatCallBack.invoke()
+Zoe --\\ Bob : <font color=gray><size:12> offerResult
+
+@enduml

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -7,8 +7,9 @@
     "node": ">=11.0"
   },
   "scripts": {
-    "build": "exit 0",
-    "test": "tap --no-coverage --jobs=1 --timeout 600 'test/**/test*.js'",
+    "build": "yarn build-zcfBundle",
+    "test": "tap --no-coverage --jobs=1 --timeout 600 'test/**/test-*.js'",
+    "build-zcfBundle": "node -r esm scripts/build-zcfBundle.js",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint-check": "eslint '**/*.js'",
     "lint-fix-jessie": "eslint -c '.eslintrc-jessie.js' --fix '**/*.js'",
@@ -43,10 +44,10 @@
     "@agoric/same-structure": "^0.0.8",
     "@agoric/store": "^0.2.0",
     "@agoric/transform-metering": "^1.3.0",
-    "@agoric/weak-store": "^0.0.8"
+    "@agoric/weak-store": "^0.0.8",
+    "@agoric/bundle-source": "^1.1.6"
   },
   "devDependencies": {
-    "@agoric/bundle-source": "^1.1.6",
     "@agoric/install-metering-and-ses": "^0.1.1",
     "@agoric/install-ses": "^0.2.0",
     "@agoric/swingset-vat": "^0.6.0",

--- a/packages/zoe/scripts/build-zcfBundle.js
+++ b/packages/zoe/scripts/build-zcfBundle.js
@@ -1,0 +1,27 @@
+import fs from 'fs';
+import process from 'process';
+import bundleSource from '@agoric/bundle-source';
+
+async function writeSourceBundle(contractFilename, outputPath) {
+  await bundleSource(contractFilename).then(bundle => {
+    fs.mkdirSync(`${__dirname}/../bundles`, { recursive: true }, err => {
+      if (err) throw err;
+    });
+    fs.writeFileSync(outputPath, `export default ${JSON.stringify(bundle)};`);
+  });
+}
+
+async function main() {
+  const contractFilename = `${__dirname}/../src/contractFacet.js`;
+  const outputPath = `${__dirname}/../bundles/bundle-contractFacet.js`;
+  await writeSourceBundle(contractFilename, outputPath);
+}
+
+main().then(
+  _ => process.exit(0),
+  err => {
+    console.log('error creating zcf bundle:');
+    console.log(err);
+    process.exit(1);
+  },
+);

--- a/packages/zoe/src/contractFacet.js
+++ b/packages/zoe/src/contractFacet.js
@@ -1,0 +1,467 @@
+// This is the Zoe contract facet. Each time we make a new instance of a
+// contract we will start by creating a new vat and running this code in it. In
+// order to install this code in a vat, Zoe needs to import a bundle containing
+// this code. We will eventually have an automated process, but for now, every
+// time this file is edited, the bundle must be manually rebuilt with
+// `yarn build-zcfBundle`.
+
+/* global harden */
+// @ts-check
+
+import { assert, details, q } from '@agoric/assert';
+import { E } from '@agoric/eventual-send';
+import { isOfferSafe } from './offerSafety';
+import { areRightsConserved } from './rightsConservation';
+import { assertKeywordName, getKeywords } from './cleanProposal';
+import { makeContractTables } from './state';
+import { filterObj, filterFillAmounts } from './objArrayConversion';
+import { evalContractBundle } from './evalContractCode';
+
+/**
+ * @typedef {Object} ContractFacet
+ * The Zoe interface specific to a contract instance.
+ * The Zoe Contract Facet is an API object used by running contract instances to
+ * access the Zoe state for that instance. The Zoe Contract Facet is accessed
+ * synchronously from within the contract, and usually is referred to in code as
+ * zcf.
+ * @property {Reallocate} reallocate Propose a reallocation of amounts per offer
+ * @property {Complete} complete Complete an offer
+ * @property {MakeInvitation} makeInvitation
+ * @property {AddNewIssuer} addNewIssuer
+ * @property {InitPublicAPI} initPublicAPI
+ * @property {() => ZoeService} getZoeService
+ * @property {() => Issuer} getInviteIssuer
+ * @property {(offerHandles: OfferHandle[]) => { active: OfferStatus[], inactive: OfferStatus[] }} getOfferStatuses
+ * @property {(offerHandle: OfferHandle) => boolean} isOfferActive
+ * @property {(offerHandles: OfferHandle[]) => OfferRecord[]} getOffers
+ * @property {(offerHandle: OfferHandle) => OfferRecord} getOffer
+ * @property {(offerHandle: OfferHandle, brandKeywordRecord?: BrandKeywordRecord) => Allocation} getCurrentAllocation
+ * @property {(offerHandles: OfferHandle[], brandKeywordRecords?: BrandKeywordRecord[]) => Allocation[]} getCurrentAllocations
+ * @property {() => InstanceRecord} getInstanceRecord
+ * @property {(issuer: Issuer) => Brand} getBrandForIssuer
+ * @property {(brand: Brand) => AmountMath} getAmountMath
+ * @property {() => Promise<Notifier>} getOfferNotifier
+ * @property {() => VatAdmin} getVatAdmin
+` *
+ * @callback Reallocate
+ * The contract can propose a reallocation of amounts across offers
+ * by providing two parallel arrays: offerHandles and newAllocations.
+ * Each element of newAllocations is an AmountKeywordRecord whose
+ * amount should replace the old amount for that keyword for the
+ * corresponding offer.
+ *
+ * The reallocation will only succeed if the reallocation 1) conserves
+ * rights (the amounts specified have the same total value as the
+ * current total amount), and 2) is 'offer-safe' for all parties involved.
+ *
+ * The reallocation is partial, meaning that it applies only to the
+ * amount associated with the offerHandles that are passed in. By
+ * induction, if rights conservation and offer safety hold before,
+ * they will hold after a safe reallocation, even though we only
+ * re-validate for the offers whose allocations will change. Since
+ * rights are conserved for the change, overall rights will be unchanged,
+ * and a reallocation can only effect offer safety for offers whose
+ * allocations change.
+ *
+ * zcf.reallocate will throw an error if any of the
+ * newAllocations do not have a value for all the
+ * keywords in sparseKeywords. An error will also be thrown if
+ * any newAllocations have keywords that are not in
+ * sparseKeywords.
+ *
+ * @param  {OfferHandle[]} offerHandles An array of offerHandles
+ * @param  {AmountKeywordRecord[]} newAllocations An
+ * array of amountKeywordRecords  - objects with keyword keys
+ * and amount values, with one keywordRecord per offerHandle.
+ * @returns {undefined}
+ *
+ * @callback Complete
+ * The contract can "complete" an offer to remove it from the
+ * ongoing contract and resolve the player's payouts (either
+ * winnings or refunds). Because Zoe only allows for
+ * reallocations that conserve rights and are 'offer-safe', we
+ * don't need to do those checks at this step and can assume
+ * that the invariants hold.
+ * @param  {OfferHandle[]} offerHandles - an array of offerHandles
+ * @returns {void}
+ *
+ * @callback MakeInvitation
+ * Make a credible Zoe invite for a particular smart contract
+ * indicated by the unique `instanceHandle`. The other
+ * information in the value of this invite is decided by the
+ * governing contract and should include whatever information is
+ * necessary for a potential buyer of the invite to know what
+ * they are getting. Note: if information can be derived in
+ * queries based on other information, we choose to omit it. For
+ * instance, `installationHandle` can be derived from
+ * `instanceHandle` and is omitted even though it is useful.
+ * @param {OfferHook} offerHook - a function that will be handed the
+ * offerHandle at the right time, and returns a contract-specific
+ * OfferOutcome which will be put in the OfferResultRecord.
+ * @param {string} inviteDesc
+ * @param {MakeInvitationOptions} [options]
+ * @returns {Invite}
+ *
+ * @typedef MakeInvitationOptions
+ * @property {CustomProperties} [customProperties] - an object containing
+ * information to include in the invitation's value, as defined by the smart
+ * contract
+ *
+ * @callback OfferHook
+ * This function will be called with the OfferHandle when the offer
+ * is prepared. It should return a contract-specific "OfferOutcome"
+ * value that will be put in the OfferResultRecord.
+ * @param {OfferHandle} offerHandle
+ * @returns {OfferOutcome}
+ *
+ * @callback AddNewIssuer
+ * Informs Zoe about an issuer and returns a promise for acknowledging
+ * when the issuer is added and ready.
+ * @param {Promise<Issuer>|Issuer} issuerP Promise for issuer
+ * @param {Keyword} keyword Keyword for added issuer
+ * @returns {Promise<IssuerRecord>} Issuer is added and ready
+ *
+ * @callback InitPublicAPI
+ * Initialize the publicAPI for the contract instance, as stored by Zoe in
+ * the instanceRecord.
+ * @param {Object} publicAPI - an object whose methods are the API
+ * available to anyone who knows the instanceHandle
+ * @returns {void}
+ */
+
+/**
+ * @typedef {Object} VatAdmin
+ * A powerful object that can be used to terminate the vat in which a contract
+ * is running, to get statistics, or to be notified when it terminates. The
+ * VatAdmin object is only available to the contract from within the contract so
+ * that clients of the contract can tell (by getting the source code from Zoe
+ * using the instanceHandle) what use the contract makes of it. If they want to
+ * be assured of discretion, or want to know that the contract doesn't have the
+ * ability to call terminate(), Zoe makes this visible.
+ *
+ * @property {() => Object} done
+ * provides a promise that will be fullfilled when the contract is terminated.
+ * @property {() => undefined} terminate
+ * kills the vat in which the contract is running
+ * @property {() => Object} adminData
+ * provides some statistics about the vat in which the contract is running.
+ */
+
+/**
+ * Create the contract facet.
+ *
+ * @returns {ContractFacet} The returned facet
+ */
+export function buildRootObject(_vatPowers) {
+  const visibleInstanceRecordFields = [
+    'instanceHandle',
+    'installationHandle',
+    'publicAPI',
+    'terms',
+    'issuerKeywordRecord',
+    'brandKeywordRecord',
+  ];
+  const visibleInstanceRecord = instanceRecord =>
+    filterObj(instanceRecord, visibleInstanceRecordFields);
+
+  const { offerTable, issuerTable } = makeContractTables();
+
+  const getAmountMathForBrand = brand => issuerTable.get(brand).amountMath;
+
+  const assertOffersAreActive = candidateOfferHandles =>
+    candidateOfferHandles.forEach(offerHandle =>
+      assert(offerTable.has(offerHandle), details`Offer is not active`),
+    );
+
+  const removeAmountsAndNotifier = offerRecord =>
+    filterObj(offerRecord, ['handle', 'instanceHandle', 'proposal']);
+  const removePurse = issuerRecord =>
+    filterObj(issuerRecord, ['issuer', 'brand', 'amountMath']);
+
+  const doGetCurrentAllocation = (offerHandle, brandKeywordRecord) => {
+    const { currentAllocation } = offerTable.get(offerHandle);
+    if (brandKeywordRecord === undefined) {
+      return currentAllocation;
+    }
+    const amountMathKeywordRecord = {};
+    Object.getOwnPropertyNames(brandKeywordRecord).forEach(keyword => {
+      const brand = brandKeywordRecord[keyword];
+      amountMathKeywordRecord[keyword] = issuerTable.get(brand).amountMath;
+    });
+    return filterFillAmounts(currentAllocation, amountMathKeywordRecord);
+  };
+
+  const doGetCurrentAllocations = (offerHandles, brandKeywordRecords) => {
+    if (brandKeywordRecords === undefined) {
+      return offerHandles.map(offerHandle =>
+        doGetCurrentAllocation(offerHandle),
+      );
+    }
+    return offerHandles.map((offerHandle, i) =>
+      doGetCurrentAllocation(offerHandle, brandKeywordRecords[i]),
+    );
+  };
+
+  const reallocate = (offerHandles, newAllocations, zoeForZcf) => {
+    assertOffersAreActive(offerHandles);
+    // We may want to handle this with static checking instead.
+    // Discussion at: https://github.com/Agoric/agoric-sdk/issues/1017
+    assert(
+      offerHandles.length >= 2,
+      details`reallocating must be done over two or more offers`,
+    );
+    assert(
+      offerHandles.length === newAllocations.length,
+      details`There must be as many offerHandles as entries in newAllocations`,
+    );
+
+    // 1) Ensure 'offer safety' for each offer separately.
+    const makeOfferSafeReallocation = (offerHandle, newAllocation) => {
+      const { proposal, currentAllocation } = offerTable.get(offerHandle);
+      const reallocation = harden({
+        ...currentAllocation,
+        ...newAllocation,
+      });
+
+      assert(
+        isOfferSafe(getAmountMathForBrand, proposal, reallocation),
+        details`The reallocation was not offer safe`,
+      );
+      return reallocation;
+    };
+
+    // Make the reallocation and test for offer safety by comparing the
+    // reallocation to the original proposal.
+    const reallocations = offerHandles.map((offerHandle, i) =>
+      makeOfferSafeReallocation(offerHandle, newAllocations[i]),
+    );
+
+    // 2. Ensure that rights are conserved overall.
+    const flattened = arr => [].concat(...arr);
+    const flattenAllocations = allocations =>
+      flattened(allocations.map(allocation => Object.values(allocation)));
+
+    const currentAllocations = offerTable
+      .getOffers(offerHandles)
+      .map(({ currentAllocation }) => currentAllocation);
+    const previousAmounts = flattenAllocations(currentAllocations);
+    const newAmounts = flattenAllocations(reallocations);
+
+    assert(
+      areRightsConserved(getAmountMathForBrand, previousAmounts, newAmounts),
+      details`Rights are not conserved in the proposed reallocation`,
+    );
+
+    // 3. Save the reallocations.
+    offerTable.updateAmounts(offerHandles, reallocations);
+    E(zoeForZcf).updateAmounts(offerHandles, reallocations);
+  };
+
+  const addNewIssuer = (issuerP, keyword, instanceRecord, zoeForZcf) =>
+    issuerTable.getPromiseForIssuerRecord(issuerP).then(issuerRecord => {
+      E(zoeForZcf).addNewIssuer(issuerP, keyword);
+      assertKeywordName(keyword);
+      assert(
+        !getKeywords(instanceRecord.issuerKeywordRecord).includes(keyword),
+        details`keyword ${keyword} must be unique`,
+      );
+      const newIssuerKeywordRecord = {
+        ...instanceRecord.issuerKeywordRecord,
+        [keyword]: issuerRecord.issuer,
+      };
+      const newBrandKeywordRecord = {
+        ...instanceRecord.brandKeywordRecord,
+        [keyword]: issuerRecord.brand,
+      };
+      instanceRecord.brandKeywordRecord = newBrandKeywordRecord;
+      instanceRecord.issuerKeywordRecord = newIssuerKeywordRecord;
+
+      return removePurse(issuerRecord);
+    });
+
+  function completeOffers(offerHandlesToDrop, zoeForZcf) {
+    assertOffersAreActive(offerHandlesToDrop);
+    offerTable.deleteOffers(offerHandlesToDrop);
+    return E(zoeForZcf).completeOffers(offerHandlesToDrop);
+  }
+
+  /** @type {ContractFacet} */
+  const makeContractFacet = (
+    zoeService,
+    instanceRecord,
+    inviteIssuer,
+    zoeForZcf,
+  ) => {
+    let publicApiInitialized = false;
+
+    return harden({
+      reallocate: (offerHandles, newAllocations) =>
+        reallocate(offerHandles, newAllocations, zoeForZcf),
+      addNewIssuer: (issuerP, keyword) =>
+        addNewIssuer(issuerP, keyword, instanceRecord, zoeForZcf),
+      complete: offerHandlesToDrop =>
+        completeOffers(offerHandlesToDrop, zoeForZcf),
+      makeInvitation: (offerHandler, inviteDesc, options = harden({})) => {
+        const inviteHandler = harden({ invoke: offerHandler });
+        return E(zoeForZcf).makeInvitation(inviteHandler, inviteDesc, options);
+      },
+      initPublicAPI: newPublicAPI => {
+        assert(
+          !publicApiInitialized,
+          details`the publicAPI has already been initialized`,
+        );
+        publicApiInitialized = true;
+        E(zoeForZcf).updatePublicAPI(newPublicAPI);
+      },
+
+      // The methods below are pure and have no side-effects //
+      getZoeService: () => zoeService,
+
+      getInviteIssuer: () => inviteIssuer,
+
+      getOfferNotifier: E(zoeService).getOfferNotifier,
+
+      getOfferStatuses: offerHandles => {
+        const { active, inactive } = offerTable.getOfferStatuses(offerHandles);
+        return harden({ active, inactive });
+      },
+      isOfferActive: offerHandle => {
+        const isActive = offerTable.isOfferActive(offerHandle);
+        // if offer isn't present, we do not want to throw.
+        return isActive;
+      },
+      getOffers: offerHandles => {
+        assertOffersAreActive(offerHandles);
+        return offerTable.getOffers(offerHandles).map(removeAmountsAndNotifier);
+      },
+      getOffer: offerHandle => {
+        assertOffersAreActive(harden([offerHandle]));
+        return removeAmountsAndNotifier(offerTable.get(offerHandle));
+      },
+      getCurrentAllocation: (offerHandle, brandKeywordRecord) => {
+        assertOffersAreActive(harden([offerHandle]));
+        return doGetCurrentAllocation(offerHandle, brandKeywordRecord);
+      },
+      getCurrentAllocations: (offerHandles, brandKeywordRecords) => {
+        assertOffersAreActive(offerHandles);
+        return doGetCurrentAllocations(offerHandles, brandKeywordRecords);
+      },
+      getInstanceRecord: () => visibleInstanceRecord(instanceRecord),
+      getIssuerForBrand: brand => issuerTable.get(brand).issuer,
+      getBrandForIssuer: issuer => issuerTable.brandFromIssuer(issuer),
+      getAmountMath: getAmountMathForBrand,
+      getVatAdmin: instanceRecord.adminNode,
+    });
+  };
+
+  /**
+   * @typedef {import('@agoric/zoe').CompleteObj} CompleteObj
+   *
+   * @typedef {Object} ZcfForZoe
+   * The facet ZCF presents to Zoe.
+   *
+   * @property {(OfferHandle, Proposal, Allocation) => CompleteObj} addOffer
+   * Add a single offer to this contract instance.
+   *
+   * @return CompleteObj
+   */
+  const makeZcfForZoe = (instanceHandle, zoeForZcf) =>
+    harden({
+      addOffer: (offerHandle, proposal, allocation) => {
+        const ignoringUpdater = harden({
+          updateState: () => {},
+          resolve: () => {},
+        });
+        const offerRecord = {
+          instanceHandle,
+          proposal,
+          currentAllocation: allocation,
+          notifier: undefined,
+          updater: ignoringUpdater,
+        };
+
+        const { exit } = proposal;
+        const [exitKind] = Object.getOwnPropertyNames(exit);
+
+        let completeObj;
+        const completeOffer = () => {
+          return completeOffers(harden([offerHandle]), zoeForZcf);
+        };
+
+        if (exitKind === 'afterDeadline') {
+          // Automatically complete offer after deadline.
+          E(exit.afterDeadline.timer).setWakeup(
+            exit.afterDeadline.deadline,
+            harden({
+              wake: () => completeOffer(),
+            }),
+          );
+        } else if (exitKind === 'onDemand') {
+          // Add to offerResult an object with a complete() method to support
+          // complete offer on demand. Note: we cannot add the `completeOffer`
+          // function directly to the offerResult because our marshalling layer
+          // only allows two kinds of objects: records (no methods and only
+          // data) and presences (local proxies for objects that may have
+          // methods).
+          completeObj = {
+            complete: () => completeOffer(),
+          };
+        } else {
+          // if exitRule.kind is 'waived' the user has no ability to complete
+          // on demand
+          assert(
+            exitKind === 'waived',
+            details`exit kind was not recognized: ${q(exitKind)}`,
+          );
+        }
+        offerTable.create(offerRecord, offerHandle);
+        return completeObj;
+      },
+    });
+
+  /**
+   * Makes a contract instance from an installation and returns a
+   * unique handle for the instance that can be shared, as well as
+   * other information, such as the terms used in the instance.
+   * @param params - a record containing { zoeService, bundle, instanceData,
+   *    zoeForZcf, inviteIssuer }
+   * @returns { Promise<Invite>, ZcfForZoe }
+   */
+  const startContract = params => {
+    const contractCode = evalContractBundle(params.bundle);
+
+    const { issuerKeywordRecord } = params.instanceData;
+    const issuersP = Object.getOwnPropertyNames(issuerKeywordRecord).map(
+      keyword => issuerKeywordRecord[keyword],
+    );
+
+    // invoke contract and return inner facet to Zoe.
+    const invokeContract = () => {
+      const contractFacet = makeContractFacet(
+        params.zoeService,
+        // copy so we can update brands and keywords
+        { ...params.instanceData },
+        params.inviteIssuer,
+        params.zoeForZcf,
+      );
+      const inviteP = E(contractCode).makeContract(contractFacet);
+      return {
+        inviteP,
+        zcfForZoe: makeZcfForZoe(
+          params.instanceData.instanceHandle,
+          params.zoeForZcf,
+        ),
+      };
+    };
+
+    // The issuers may not have been seen before, so we must wait for
+    // the issuer records to be available synchronously
+    return issuerTable
+      .getPromiseForIssuerRecords(issuersP)
+      .then(invokeContract);
+  };
+
+  return harden({ startContract });
+}
+
+harden(buildRootObject);

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -2,7 +2,7 @@
 
 import { assert, details } from '@agoric/assert';
 import { sameStructure } from '@agoric/same-structure';
-import { HandledPromise } from '@agoric/eventual-send';
+import { E, HandledPromise } from '@agoric/eventual-send';
 import { satisfiesWant, isOfferSafe } from '../offerSafety';
 
 /**
@@ -380,7 +380,7 @@ export const makeZoeHelpers = (zcf) => {
           offerHandle => resolve(offerHandle),
           'empty offer',
         );
-        zoeService.offer(invite);
+        E(zoeService).offer(invite);
       }),
 
     /**
@@ -410,8 +410,7 @@ export const makeZoeHelpers = (zcf) => {
       const proposal = harden({ give: { Temp: amount } });
       const payments = harden({ Temp: payment });
 
-      return zcf
-        .getZoeService()
+      return E(zcf.getZoeService())
         .offer(contractSelfInvite, proposal, payments)
         .then(() => {
           // At this point, the temporary offer has the amount from the

--- a/packages/zoe/src/contracts/autoswap.js
+++ b/packages/zoe/src/contracts/autoswap.js
@@ -18,7 +18,7 @@ import {
  * When the contract is instantiated, the two tokens are specified in the
  * issuerKeywordRecord. The party that calls makeInstance gets an invitation
  * to add liquidity. The same invitation is available by calling
- * `publicAPI.makeAddLiquidityInvite()`. Separate invitations are available for
+ * `await E(publicAPI).makeAddLiquidityInvite()`. Separate invitations are available for
  * adding and removing liquidity, and for doing a swap. Other API operations
  * support monitoring the price and the size of the liquidity pool.
  *

--- a/packages/zoe/src/contracts/mintAndSellNFT.js
+++ b/packages/zoe/src/contracts/mintAndSellNFT.js
@@ -2,6 +2,7 @@
 // @ts-check
 
 import makeIssuerKit from '@agoric/ertp';
+import { E } from '@agoric/eventual-send';
 
 /**
  * This contract mints non-fungible tokens and creates a selling contract
@@ -79,14 +80,14 @@ const makeContract = zcf => {
     const sellItemsTerms = harden({
       pricePerItem,
     });
-    return zoeService
+    return E(zoeService)
       .makeInstance(
         sellItemsInstallationHandle,
         issuerKeywordRecord,
         sellItemsTerms,
       )
       .then(({ invite, instanceRecord: { handle: instanceHandle } }) => {
-        return zoeService
+        return E(zoeService)
           .offer(invite, proposal, paymentKeywordRecord)
           .then(offerResult => {
             return harden({

--- a/packages/zoe/src/contracts/mintPayments.js
+++ b/packages/zoe/src/contracts/mintPayments.js
@@ -16,7 +16,7 @@ import { makeZoeHelpers } from '../contractSupport';
  * internally rather than sharing that ability widely as this one does.
  *
  * makeInstance returns an invitation that, when exercised, provides 1000 of the
- * new tokens. publicAPI.makeInvite() returns an invitation that accepts an
+ * new tokens. await E(publicAPI).makeInvite() returns an invitation that accepts an
  * empty offer and provides 1000 tokens.
  *
  * @typedef {import('../zoe').ContractFacet} ContractFacet

--- a/packages/zoe/src/contracts/multipoolAutoswap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap.js
@@ -33,7 +33,7 @@ import { filterObj } from '../objArrayConversion';
  * When the contract is instantiated, the central token is specified in the
  * issuerKeywordRecord. The party that calls makeInstance gets an invitation
  * that can be used to request an invitation to add liquidity. The same
- * invitation is available by calling `publicAPI.getLiquidityIssuer(brand)`.
+ * invitation is available by calling `await E(publicAPI).getLiquidityIssuer(brand)`.
  * Separate invitations are available for adding and removing liquidity, and for
  * making trades. Other API operations support monitoring prices and the sizes
  * of pools.

--- a/packages/zoe/src/contracts/publicAuction.js
+++ b/packages/zoe/src/contracts/publicAuction.js
@@ -24,7 +24,7 @@ import {
  * { give: { Asset: asset }, want: { Ask: minimumBidAmount } }
  * The asset can be non-fungible, but the Ask amount should be of a fungible
  * brand.
- * The bidder invitations are available from publicAPI.makeInvites(n). Each
+ * The bidder invitations are available from await E(publicAPI).makeInvites(n). Each
  * bidder can submit an offer: { give: { Bid: null } want: { Asset: null } }.
  *
  * publicAPI also has methods to find out what's being auctioned

--- a/packages/zoe/src/contracts/simpleExchange.js
+++ b/packages/zoe/src/contracts/simpleExchange.js
@@ -21,7 +21,7 @@ import { makeZoeHelpers, defaultAcceptanceMsg } from '../contractSupport';
  * not partially fill orders.
  *
  * The invitation returned on installation of the contract is the same as what
- * is returned by calling `publicAPI.makeInvite().
+ * is returned by calling `await E(publicAPI).makeInvite().
  *
  * @typedef {import('../zoe').ContractFacet} ContractFacet
  * @param {ContractFacet} zcf

--- a/packages/zoe/src/evalContractCode.js
+++ b/packages/zoe/src/evalContractCode.js
@@ -9,7 +9,7 @@ import { sameStructure } from '@agoric/same-structure';
 import { importBundle } from '@agoric/import-bundle';
 import { HandledPromise } from '@agoric/eventual-send';
 
-const evalContractBundle = (bundle, additionalEndowments, vatPowers) => {
+const evalContractBundle = (bundle, additionalEndowments = {}) => {
   // Make the console more verbose.
   const louderConsole = {
     ...console,
@@ -35,26 +35,9 @@ const evalContractBundle = (bundle, additionalEndowments, vatPowers) => {
     HandledPromise,
   };
 
-  const transforms = [];
-  const meteringEndowments = {};
-  if (vatPowers && vatPowers.transformMetering && vatPowers.makeGetMeter) {
-    const { makeGetMeter, transformMetering } = vatPowers;
-    // This implements fail-stop, since a contract that exhausts the meter
-    // will not run again.
-    const { getMeter } = makeGetMeter({ refillIfExhausted: false });
-    transforms.push(src => transformMetering(src, getMeter));
-    meteringEndowments.getMeter = getMeter;
-  }
-  // Note: Old dapps used `makeZoe({ require })`, not `makeZoe()` or
-  // `makeZoe({}, vatPowers)`. The first argument of makeZoe appears to
-  // evalContractBundle as 'additionalEndowments'. To remain compatible with
-  // them (for a brief while), we apply 'require' last, to ignore the one
-  // that appears in additionalEndowments.
-
   const fullEndowments = Object.create(null, {
     ...Object.getOwnPropertyDescriptors(defaultEndowments),
     ...Object.getOwnPropertyDescriptors(additionalEndowments),
-    ...Object.getOwnPropertyDescriptors(meteringEndowments),
     ...Object.getOwnPropertyDescriptors({ require: myRequire }),
   });
 
@@ -63,7 +46,6 @@ const evalContractBundle = (bundle, additionalEndowments, vatPowers) => {
 
   const installation = importBundle(bundle, {
     endowments: fullEndowments,
-    transforms,
   });
   return installation;
 };

--- a/packages/zoe/src/state.js
+++ b/packages/zoe/src/state.js
@@ -11,21 +11,25 @@ import { makeTable, makeValidateProperties } from './table';
  * @typedef {import('@agoric/ertp').Payment} Payment
  */
 
-// Installation Table
-// Columns: handle | installation | bundle
+// Installation Table key: installationHandle
+// Columns: bundle
 const makeInstallationTable = () => {
-  const validateSomewhat = makeValidateProperties(
-    harden(['installation', 'bundle']),
-  );
+  const validateSomewhat = makeValidateProperties(harden(['bundle']));
   return makeTable(validateSomewhat, 'installationHandle');
 };
 
-// Instance Table
-// Columns: handle | installationHandle | publicAPI | terms |
-// issuerKeywordRecord | brandKeywordRecord
+// Instance Table key: instanceHandle
+// Columns: installationHandle | publicAPI | terms | issuerKeywordRecord
+//  | brandKeywordRecord | zcfForZoe | offerHandles
+// Zoe uses this table to track contract instances. The issuerKeywordRecord and
+// brandKeyword are slightly redundant, but are each convenient at this point.
+// zcfForZoe provides a direct channel to the ZCF running in a vat. zcfForZoe
+// is initially set to a promise, since it can't be created until a reply is
+// received from the newly created vat. Zoe needs to know the offerHandles in
+// order to fulfill its responsibility for exit safety.
 const makeInstanceTable = () => {
   // TODO: make sure this validate function protects against malicious
-  // misshapen objects rather than just a general check.
+  //  misshapen objects rather than just a general check.
   const validateSomewhat = makeValidateProperties(
     harden([
       'installationHandle',
@@ -33,18 +37,43 @@ const makeInstanceTable = () => {
       'terms',
       'issuerKeywordRecord',
       'brandKeywordRecord',
+      'zcfForZoe',
+      'offerHandles',
     ]),
   );
 
-  return makeTable(validateSomewhat, 'instanceHandle');
+  const makeCustomMethods = table => {
+    const customMethods = harden({
+      addOffer: (instanceHandle, newOfferHandle) => {
+        const { offerHandles } = table.get(instanceHandle);
+        offerHandles.add(newOfferHandle);
+        return instanceHandle;
+      },
+      removeCompletedOffers: (instanceHandle, handlesToDrop) => {
+        const { offerHandles } = table.get(instanceHandle);
+        for (const h of handlesToDrop) {
+          offerHandles.delete(h);
+        }
+        return instanceHandle;
+      },
+    });
+    return customMethods;
+  };
+
+  return makeTable(validateSomewhat, 'instanceHandle', makeCustomMethods);
 };
 
-// Offer Table
-// Columns:
-//   handle | instanceHandle | proposal | currentAllocation, notifier, updater
+// Offer Table key: offerHandle
+// Columns: instanceHandle | proposal | currentAllocation | notifier | updater
+// The two versions of this table are slightly different. Zoe's
+// currentAllocation is kept up-to-date with ZCF and will be used for closing.
+// Zcf effectively has a local cache of the allocations. Zoe's allocations are
+// definitive (in comparison to the ones in zcf), so Zoe's notifier is
+// authoritative. Zcf doesn't store a notifier, but does store a no-action
+// updater, so updateAmounts can work polymorphically.
 const makeOfferTable = () => {
   // TODO: make sure this validate function protects against malicious
-  // misshapen objects rather than just a general check.
+  //  misshapen objects rather than just a general check.
   const validateProperties = makeValidateProperties(
     harden([
       'instanceHandle',
@@ -104,7 +133,8 @@ const makeOfferTable = () => {
   return makeTable(validateSomewhat, 'offerHandle', makeCustomMethods);
 };
 
-// Payout Map
+// Payout Map key: offerHandle
+// Columns: payout
 /**
  * Create payoutMap
  * @returns {import('@agoric/store').Store<OfferHandle,
@@ -112,19 +142,24 @@ const makeOfferTable = () => {
  */
 const makePayoutMap = () => makeStore('offerHandle');
 
-// Issuer Table
-// Columns: brand | issuer | purse | amountMath
+// Issuer Table key: brand
+// Columns: issuer | purse | amountMath
 //
 // The IssuerTable is keyed by brand, but the Issuer is required in order for
 // getPromiseForIssuerRecord() to initialize the records. When
 // getPromiseForIssuerRecord is called and the record doesn't exist, it stores a
 // promise for the record in issuersInProgress, and then builds the record. It
 // updates the tables when done.
-const makeIssuerTable = () => {
+//
+// Zoe main has an issuerTable that stores the purses with deposited assets.
+// Zoe contract facet has everything but the purses.
+const makeIssuerTable = (withPurses = true) => {
   // TODO: make sure this validate function protects against malicious
   //  misshapen objects rather than just a general check.
   const validateSomewhat = makeValidateProperties(
-    harden(['brand', 'issuer', 'purse', 'amountMath']),
+    withPurses
+      ? harden(['brand', 'issuer', 'purse', 'amountMath'])
+      : harden(['brand', 'issuer', 'amountMath']),
   );
 
   const makeCustomMethods = table => {
@@ -139,26 +174,29 @@ const makeIssuerTable = () => {
       // remote calls which immediately return a promise
       const mathHelpersNameP = E(issuer).getMathHelpersName();
       const brandP = E(issuer).getBrand();
-      const purseP = E(issuer).makeEmptyPurse();
 
       // a promise for a synchronously accessible record
-      const synchronousRecordP = Promise.all([
-        brandP,
-        mathHelpersNameP,
-        purseP,
-      ]).then(([brand, mathHelpersName, purse]) => {
-        const amountMath = makeAmountMath(brand, mathHelpersName);
-        const issuerRecord = {
-          brand,
-          issuer,
-          purse,
-          amountMath,
-        };
-        table.create(issuerRecord, brand);
-        issuerToBrand.init(issuer, brand);
-        issuersInProgress.delete(issuer);
-        return table.get(brand);
-      });
+      const promiseRecord = [brandP, mathHelpersNameP];
+      if (withPurses) {
+        promiseRecord.push(E(issuer).makeEmptyPurse());
+      }
+      const synchronousRecordP = Promise.all(promiseRecord).then(
+        ([brand, mathHelpersName, purse]) => {
+          const amountMath = makeAmountMath(brand, mathHelpersName);
+          const issuerRecord = {
+            brand,
+            issuer,
+            amountMath,
+          };
+          if (withPurses) {
+            issuerRecord.purse = purse;
+          }
+          table.create(issuerRecord, brand);
+          issuerToBrand.init(issuer, brand);
+          issuersInProgress.delete(issuer);
+          return table.get(brand);
+        },
+      );
       issuersInProgress.init(issuer, synchronousRecordP);
       return synchronousRecordP;
     }
@@ -193,7 +231,7 @@ const makeIssuerTable = () => {
   return makeTable(validateSomewhat, 'brand', makeCustomMethods);
 };
 
-const makeTables = () =>
+const makeZoeTables = () =>
   harden({
     installationTable: makeInstallationTable(),
     instanceTable: makeInstanceTable(),
@@ -202,4 +240,10 @@ const makeTables = () =>
     issuerTable: makeIssuerTable(),
   });
 
-export { makeTables };
+const makeContractTables = () =>
+  harden({
+    offerTable: makeOfferTable(),
+    issuerTable: makeIssuerTable(false),
+  });
+
+export { makeZoeTables, makeContractTables };

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -4,23 +4,21 @@
 import { E, HandledPromise } from '@agoric/eventual-send';
 import makeStore from '@agoric/weak-store';
 import makeIssuerKit from '@agoric/ertp';
-import { assert, details, q } from '@agoric/assert';
+import { assert, details } from '@agoric/assert';
 import { produceNotifier } from '@agoric/notifier';
 import { producePromise } from '@agoric/produce-promise';
 
-import {
-  cleanProposal,
-  assertKeywordName,
-  getKeywords,
-  cleanKeywords,
-} from './cleanProposal';
+import { cleanProposal, cleanKeywords } from './cleanProposal';
 import { arrayToObj, filterFillAmounts, filterObj } from './objArrayConversion';
-import { isOfferSafe } from './offerSafety';
-import { areRightsConserved } from './rightsConservation';
-import { evalContractBundle } from './evalContractCode';
-import { makeTables } from './state';
+import { makeZoeTables } from './state';
 
-// TODO Update types and documentation to describe the new API
+// This is the Zoe contract facet from contractFacet.js, packaged as a bundle
+// that can be used to create a new vat. Every time it is edited, it must be
+// manually rebuilt with `yarn build-zcfBundle`.
+
+/* eslint-disable-next-line import/no-unresolved, import/extensions */
+import zcfContractBundle from '../bundles/bundle-contractFacet';
+
 /**
  * Zoe uses ERTP, the Electronic Rights Transfer Protocol
  */
@@ -37,6 +35,7 @@ import { makeTables } from './state';
  * @typedef {string} Keyword
  * @typedef {{}} InstallationHandle
  * @typedef {Object.<string,Issuer>} IssuerKeywordRecord
+ * @typedef {Object.<string,Brand>} BrandKeywordRecord
  * @typedef {Object} Bundle
  * @property {string} source
  * @property {string} sourceMap
@@ -58,6 +57,15 @@ import { makeTables } from './state';
  * the entirety of its lifetime. By having a reference to Zoe, a user can get
  * the `inviteIssuer` and thus validate any `invite` they receive from someone
  * else.
+ *
+ * Zoe has two different facets: the public Zoe service and the contract facet
+ * (ZCF). Each contract instance has a copy of ZCF within its vat. The contract
+ * and ZCF never have direct access to the users' payments or the Zoe purses.
+ * The contract can only do a few things through ZCF. It can propose a
+ * reallocation of amount or complete an offer. It can also speak directly to Zoe
+ * outside of its vat, and create a new offer for record-keeping and other
+ * purposes.
+ *
  * @property {() => Issuer} getInviteIssuer
  * Zoe has a single `inviteIssuer` for the entirety of its lifetime.
  * By having a reference to Zoe, a user can get the `inviteIssuer`
@@ -118,6 +126,8 @@ import { makeTables } from './state';
  * Get the source code for the installed contract. Throws an error if the
  * installationHandle is not found.
  *
+ * @typedef {() => undefined} CompleteObj
+ *
  * @typedef {any} OfferOutcome
  * A contract-specific value that is returned by the OfferHook.
  *
@@ -132,7 +142,8 @@ import { makeTables } from './state';
  * @property {Promise<OfferOutcome>} outcome Note that if the offerHook throws,
  * this outcome Promise will reject, but the rest of the OfferResultRecord is
  * still meaningful.
- * @property {(() => undefined)} [completeObj]
+ *
+ * @property {CompleteObj=} completeObj
  * completeObj will only be present if exitKind was 'onDemand'
  *
  * @typedef {{give?:AmountKeywordRecord,want?:AmountKeywordRecord,exit?:ExitRule}} Proposal
@@ -143,6 +154,10 @@ import { makeTables } from './state';
  * { Asset: amountMath.make(5), Price: amountMath.make(9) }
  *
  * @typedef {AmountKeywordRecord[]} AmountKeywordRecords
+ *
+ * @typedef {Object} MakeInstanceResult
+ * @property {Invite} invite
+ * @property {InstanceRecord} instanceRecord
  */
 
 /**
@@ -211,135 +226,18 @@ import { makeTables } from './state';
  * @typedef {Keyword[]} SparseKeywords
  * @typedef {{[Keyword:string]:Amount}} Allocation
  * @typedef {{[Keyword:string]:AmountMath}} AmountMathKeywordRecord
- * @typedef {{[Keyword:string]:Brand}}
- * BrandKeywordRecord
- */
-
-/**
- * @typedef {Object} ContractFacet
- * The Zoe interface specific to a contract instance.
- * The Zoe Contract Facet is an API object used by running contract instances to
- * access the Zoe state for that instance. The Zoe Contract Facet is accessed
- * synchronously from within the contract, and usually is referred to in code as
- * zcf.
- * @property {Reallocate} reallocate Propose a reallocation of values per offer
- * @property {Complete} complete Complete an offer
- * @property {MakeInvitation} makeInvitation
- * @property {AddNewIssuer} addNewIssuer
- * @property {InitPublicAPI} initPublicAPI
- * @property {() => ZoeService} getZoeService
- * @property {() => Issuer} getInviteIssuer
- * @property {(offerHandles: OfferHandle[]) => { active: OfferStatus[], inactive: OfferStatus[] }} getOfferStatuses
- * @property {(offerHandle: OfferHandle) => boolean} isOfferActive
- * @property {(offerHandles: OfferHandle[]) => OfferRecord[]} getOffers
- * @property {(offerHandle: OfferHandle) => OfferRecord} getOffer
- * @property {(offerHandle: OfferHandle, brandKeywordRecord?: BrandKeywordRecord) => Allocation} getCurrentAllocation
- * @property {(offerHandles: OfferHandle[], brandKeywordRecords?: BrandKeywordRecord[]) => Allocation[]} getCurrentAllocations
- * @property {() => InstanceRecord} getInstanceRecord
- * @property {(issuer: Issuer) => Brand} getBrandForIssuer
- * @property {(brand: Brand) => Issuer} getIssuerForBrand
- * @property {(brand: Brand) => AmountMath} getAmountMath
- *
- * @callback Reallocate
- * The contract can propose a reallocation of values across offers
- * by providing two parallel arrays: offerHandles and newAllocations.
- * Each element of newAllocations is an AmountKeywordRecord whose
- * amount should replace the old amount for that keyword for the
- * corresponding offer.
- *
- * The reallocation will only succeed if the reallocation 1) conserves
- * rights (the amounts specified have the same total value as the
- * current total amount), and 2) is 'offer-safe' for all parties involved.
- *
- * The reallocation is partial, meaning that it applies only to the
- * amount associated with the offerHandles that are passed in. By
- * induction, if rights conservation and offer safety hold before,
- * they will hold after a safe reallocation, even though we only
- * re-validate for the offers whose allocations will change. Since
- * rights are conserved for the change, overall rights will be unchanged,
- * and a reallocation can only effect offer safety for offers whose
- * allocations change.
- *
- * zcf.reallocate will throw an error if any of the
- * newAllocations do not have a value for all the
- * keywords in sparseKeywords. An error will also be thrown if
- * any newAllocations have keywords that are not in
- * sparseKeywords.
- *
- * @param  {OfferHandle[]} offerHandles An array of offerHandles
- * @param  {AmountKeywordRecord[]} newAllocations An
- * array of amountKeywordRecords  - objects with keyword keys
- * and amount values, with one keywordRecord per offerHandle.
- * @returns {undefined}
- *
- * @callback Complete
- * The contract can "complete" an offer to remove it from the
- * ongoing contract and resolve the player's payouts (either
- * winnings or refunds). Because Zoe only allows for
- * reallocations that conserve rights and are 'offer-safe', we
- * don't need to do those checks at this step and can assume
- * that the invariants hold.
- * @param  {OfferHandle[]} offerHandles - an array of offerHandles
- * @returns {void}
- *
- * @callback MakeInvitation
- * Make a credible Zoe invite for a particular smart contract
- * indicated by the unique `instanceHandle`. The other
- * information in the value of this invite is decided by the
- * governing contract and should include whatever information is
- * necessary for a potential buyer of the invite to know what
- * they are getting. Note: if information can be derived in
- * queries based on other information, we choose to omit it. For
- * instance, `installationHandle` can be derived from
- * `instanceHandle` and is omitted even though it is useful.
- * @param {OfferHook} offerHook - a function that will be handed the
- * offerHandle at the right time, and returns a contract-specific
- * OfferOutcome which will be put in the OfferResultRecord.
- * @param {string} inviteDesc
- * @param {MakeInvitationOptions} [options]
- * @returns {Invite}
- *
- * @typedef MakeInvitationOptions
- * @property {CustomProperties} [customProperties] - an object of
- * information to include in the value, as defined by the smart
- * contract
- *
- * @callback OfferHook
- * This function will be called with the OfferHandle when the offer
- * is prepared. It should return a contract-specific "OfferOutcome"
- * value that will be put in the OfferResultRecord.
- * @param {OfferHandle} offerHandle
- * @returns {OfferOutcome}
- *
- *
- * @callback AddNewIssuer
- * Informs Zoe about an issuer and returns a promise for acknowledging
- * when the issuer is added and ready.
- * @param {Promise<Issuer>|Issuer} issuerP Promise for issuer
- * @param {Keyword} keyword Keyword for added issuer
- * @returns {Promise<IssuerRecord>} Issuer is added and ready
- *
- * @callback InitPublicAPI
- * Initialize the publicAPI for the contract instance, as stored by Zoe in
- * the instanceRecord.
- * @param {Object} publicAPI - an object whose methods are the API
- * available to anyone who knows the instanceHandle
- * @returns {void}
  */
 
 /**
  * Create an instance of Zoe.
  *
- * @param {Object.<string,any>} [additionalEndowments] pure or pure-ish
- * endowments to add to evaluator
- * @param {Object.<string,any>} [vatPowers] provide 'setMeter' and
- * 'transformMetering' (from the vat's buildRoot invocation) to enable
- * within-vat metering of contract code
+ * @param {Object} vatAdminSvc - The vatAdmin Service, which carries the power
+ * to create a new vat.
  * @returns {ZoeService} The created Zoe service.
  */
-function makeZoe(additionalEndowments = {}, vatPowers = {}) {
-  // Zoe maps the inviteHandles to contract offerHook upcalls
-  const inviteHandleToOfferHook = makeStore('inviteHandle');
+function makeZoe(vatAdminSvc) {
+  // A weakMap from the inviteHandles to contract offerHook upcalls
+  const inviteHandleToHandler = makeStore('inviteHandle');
 
   const {
     mint: inviteMint,
@@ -354,7 +252,7 @@ function makeZoe(additionalEndowments = {}, vatPowers = {}) {
     offerTable,
     payoutMap,
     issuerTable,
-  } = makeTables();
+  } = makeZoeTables();
 
   const getAmountMathForBrand = brand => issuerTable.get(brand).amountMath;
 
@@ -369,8 +267,7 @@ function makeZoe(additionalEndowments = {}, vatPowers = {}) {
     }
     const offerRecords = offerTable.getOffers(offerHandles);
 
-    // Remove the offers from the offerTable so that they are no
-    // longer active.
+    // Remove the offers from the offerTable so that they are no longer active.
     offerTable.deleteOffers(offerHandles);
 
     // Resolve the payout promises with promises for the payouts
@@ -384,25 +281,13 @@ function makeZoe(additionalEndowments = {}, vatPowers = {}) {
       harden(payout);
       payoutMap.get(offerRecord.handle).resolve(payout);
     }
-  };
 
-  const removePurse = issuerRecord =>
-    filterObj(issuerRecord, ['issuer', 'brand', 'amountMath']);
+    // Remove the offers from the instanceTable now that they've been completed.
+    instanceTable.removeCompletedOffers(instanceHandle, offerHandles);
+  };
 
   const removeAmountsAndNotifier = offerRecord =>
     filterObj(offerRecord, ['handle', 'instanceHandle', 'proposal']);
-
-  const assertOffersHaveInstanceHandle = (
-    offerHandles,
-    expectedInstanceHandle,
-  ) => {
-    offerHandles.forEach(offerHandle => {
-      assert(
-        offerTable.get(offerHandle).instanceHandle === expectedInstanceHandle,
-        details`contract instances can only access their own associated offers`,
-      );
-    });
-  };
 
   const doGetCurrentAllocation = (offerHandle, brandKeywordRecord) => {
     const { currentAllocation } = offerTable.get(offerHandle);
@@ -428,133 +313,64 @@ function makeZoe(additionalEndowments = {}, vatPowers = {}) {
     );
   };
 
-  // Zoe has two different facets: the public Zoe service and the
-  // contract facet. The contract facet is what is accessible to the
-  // smart contract instance and is remade for each instance. The
-  // contract at no time has access to the users' payments or the Zoe
-  // purses. The contract can only do a few things through the Zoe
-  // contract facet. It can propose a reallocation of amount,
-  // complete an offer, and can create a new offer itself for
-  // record-keeping and other various purposes.
+  // Make a Zoe invite payment with an value that is a mix of credible
+  // information from Zoe (the `handle` and `instanceHandle`) and
+  // other information defined by the smart contract (the mandatory
+  // `inviteDesc` and the optional `options.customProperties`).
+  // Note that the smart contract cannot override or change the values
+  // of `handle` and `instanceHandle`.
+  const makeInvitation = (
+    instanceHandle,
+    inviteHandler,
+    inviteDesc,
+    options = harden({}),
+  ) => {
+    assert.typeof(
+      inviteDesc,
+      'string',
+      details`expected an inviteDesc string: ${inviteDesc}`,
+    );
 
-  /**
-   * Create the contract facet.
-   *
-   * @param {InstanceHandle} instanceHandle The instance for which to create the facet
-   * @returns {ContractFacet} The returned facet
-   */
-  const makeContractFacet = instanceHandle => {
-    /**
-     * @type {ContractFacet}
-     */
-    const contractFacet = harden({
-      reallocate: (offerHandles, newAllocations) => {
-        assertOffersHaveInstanceHandle(offerHandles, instanceHandle);
-        // We may want to handle this with static checking instead.
-        // Discussion at: https://github.com/Agoric/agoric-sdk/issues/1017
-        assert(
-          offerHandles.length >= 2,
-          details`reallocating must be done over two or more offers`,
-        );
-        assert(
-          offerHandles.length === newAllocations.length,
-          details`There must be as many offerHandles as entries in newAllocations`,
-        );
-
-        // 1) Ensure 'offer safety' for each offer separately.
-        const makeOfferSafeReallocation = (offerHandle, newAllocation) => {
-          const { proposal, currentAllocation } = offerTable.get(offerHandle);
-          const reallocation = harden({
-            ...currentAllocation,
-            ...newAllocation,
-          });
-
-          assert(
-            isOfferSafe(getAmountMathForBrand, proposal, reallocation),
-            details`The reallocation was not offer safe`,
-          );
-          return reallocation;
-        };
-
-        // Make the reallocation and test for offer safety by comparing the
-        // reallocation to the original proposal.
-        const reallocations = offerHandles.map((offerHandle, i) =>
-          makeOfferSafeReallocation(offerHandle, newAllocations[i]),
-        );
-
-        // 2. Ensure that rights are conserved overall.
-        const flattened = arr => [].concat(...arr);
-        const flattenAllocations = allocations =>
-          flattened(allocations.map(allocation => Object.values(allocation)));
-
-        const currentAllocations = offerTable
-          .getOffers(offerHandles)
-          .map(({ currentAllocation }) => currentAllocation);
-        const previousAmounts = flattenAllocations(currentAllocations);
-        const newAmounts = flattenAllocations(reallocations);
-
-        assert(
-          areRightsConserved(
-            getAmountMathForBrand,
-            previousAmounts,
-            newAmounts,
-          ),
-          details`Rights are not conserved in the proposed reallocation`,
-        );
-
-        // 3. Save the reallocations.
-        offerTable.updateAmounts(offerHandles, reallocations);
-      },
-
-      complete: offerHandles => {
-        assert(
-          Array.isArray(offerHandles),
-          details`zcf.complete(offerHandles) must be Array, not ${offerHandles}`,
-        );
-        assertOffersHaveInstanceHandle(offerHandles, instanceHandle);
-        return completeOffers(instanceHandle, offerHandles);
-      },
-
-      // Make a Zoe invite payment with a value that is a mix of credible
-      // information from Zoe (the `handle` and `instanceHandle`) and
-      // other information defined by the smart contract (the mandatory
-      // `inviteDesc` and the optional`options.customProperties`).
-      // Note that the smart contract cannot override or change the values
-      // of `handle` and `instanceHandle`.
-      makeInvitation: (offerHook, inviteDesc, options = harden({})) => {
-        assert.typeof(
+    const { customProperties = harden({}) } = options;
+    const inviteHandle = harden({});
+    const { installationHandle } = instanceTable.get(instanceHandle);
+    const inviteAmount = inviteAmountMath.make(
+      harden([
+        {
+          ...customProperties,
           inviteDesc,
-          'string',
-          details`expected an inviteDesc string: ${inviteDesc}`,
-        );
+          handle: inviteHandle,
+          instanceHandle,
+          installationHandle,
+        },
+      ]),
+    );
+    const handler = offerHandle => E(inviteHandler).invoke(offerHandle);
+    inviteHandleToHandler.init(inviteHandle, handler);
+    return inviteMint.mintPayment(inviteAmount);
+  };
 
-        const { customProperties = harden({}) } = options;
-        const inviteHandle = harden({});
-        const { installationHandle } = instanceTable.get(instanceHandle);
-        const inviteAmount = inviteAmountMath.make(
-          harden([
-            {
-              ...customProperties,
-              inviteDesc,
-              handle: inviteHandle,
-              instanceHandle,
-              installationHandle,
-            },
-          ]),
-        );
-        inviteHandleToOfferHook.init(inviteHandle, offerHook);
-        return inviteMint.mintPayment(inviteAmount);
-      },
+  // drop zcfForZoe, offerHandles, adminNode.
+  const filterInstanceRecord = record =>
+    filterObj(record, [
+      'handle',
+      'installationHandle',
+      'publicAPI',
+      'terms',
+      'issuerKeywordRecord',
+      'brandKeywordRecord',
+    ]);
 
+  const makeZoeForZcf = (instanceHandle, publicApiP) => {
+    return harden({
+      makeInvitation: (...params) => makeInvitation(instanceHandle, ...params),
+      updateAmounts: (offerHandles, reallocations) =>
+        offerTable.updateAmounts(offerHandles, reallocations),
+      updatePublicAPI: publicAPI => publicApiP.resolve(publicAPI),
       addNewIssuer: (issuerP, keyword) =>
         issuerTable.getPromiseForIssuerRecord(issuerP).then(issuerRecord => {
-          assertKeywordName(keyword);
           const { issuerKeywordRecord, brandKeywordRecord } = instanceTable.get(
             instanceHandle,
-          );
-          assert(
-            !getKeywords(issuerKeywordRecord).includes(keyword),
-            details`keyword ${keyword} must be unique`,
           );
           const newIssuerKeywordRecord = {
             ...issuerKeywordRecord,
@@ -568,60 +384,10 @@ function makeZoe(additionalEndowments = {}, vatPowers = {}) {
             issuerKeywordRecord: newIssuerKeywordRecord,
             brandKeywordRecord: newBrandKeywordRecord,
           });
-          return removePurse(issuerRecord);
         }),
-
-      initPublicAPI: publicAPI => {
-        const { publicAPI: oldPublicAPI } = instanceTable.get(instanceHandle);
-        assert(
-          oldPublicAPI === undefined,
-          details`the publicAPI has already been initialized`,
-        );
-        instanceTable.update(instanceHandle, { publicAPI });
-      },
-
-      // eslint-disable-next-line no-use-before-define
-      getZoeService: () => zoeService,
-
-      // The methods below are pure and have no side-effects //
-      getInviteIssuer: () => inviteIssuer,
-
-      getOfferNotifier: offerHandle => offerTable.get(offerHandle).notifier,
-      getOfferStatuses: offerHandles => {
-        const { active, inactive } = offerTable.getOfferStatuses(offerHandles);
-        assertOffersHaveInstanceHandle(active, instanceHandle);
-        return harden({ active, inactive });
-      },
-      isOfferActive: offerHandle => {
-        const isActive = offerTable.isOfferActive(offerHandle);
-        // if offer isn't present, we do not want to throw.
-        if (isActive) {
-          assertOffersHaveInstanceHandle(harden([offerHandle]), instanceHandle);
-        }
-        return isActive;
-      },
-      getOffers: offerHandles => {
-        assertOffersHaveInstanceHandle(offerHandles, instanceHandle);
-        return offerTable.getOffers(offerHandles).map(removeAmountsAndNotifier);
-      },
-      getOffer: offerHandle => {
-        assertOffersHaveInstanceHandle(harden([offerHandle]), instanceHandle);
-        return removeAmountsAndNotifier(offerTable.get(offerHandle));
-      },
-      getCurrentAllocation: (offerHandle, brandKeywordRecord) => {
-        assertOffersHaveInstanceHandle(harden([offerHandle]), instanceHandle);
-        return doGetCurrentAllocation(offerHandle, brandKeywordRecord);
-      },
-      getCurrentAllocations: (offerHandles, brandKeywordRecords) => {
-        assertOffersHaveInstanceHandle(offerHandles, instanceHandle);
-        return doGetCurrentAllocations(offerHandles, brandKeywordRecords);
-      },
-      getInstanceRecord: () => instanceTable.get(instanceHandle),
-      getBrandForIssuer: issuer => issuerTable.brandFromIssuer(issuer),
-      getIssuerForBrand: brand => issuerTable.get(brand).issuer,
-      getAmountMath: getAmountMathForBrand,
+      completeOffers: offerHandles =>
+        completeOffers(instanceHandle, offerHandles),
     });
-    return contractFacet;
   };
 
   // The public Zoe service has four main methods: `install` takes
@@ -635,261 +401,264 @@ function makeZoe(additionalEndowments = {}, vatPowers = {}) {
   // an object with a complete method for leaving the contract on demand.
 
   /** @type {ZoeService} */
-  const zoeService = harden(
+  const zoeService = harden({
+    getInviteIssuer: () => inviteIssuer,
+
     /**
-     * @param {any} code
+     * Create an installation by permanently storing the bundle. It will be
+     * evaluated each time it is used to make a new instance of a contract.
      */
-    {
-      getInviteIssuer: () => inviteIssuer,
+    install: bundle => installationTable.create(harden({ bundle })),
 
-      /**
-       * Create an installation by safely evaluating the code and
-       * registering it with Zoe. We have a moduleFormat to allow for
-       * different future formats without silent failures.
-       */
-      install: async bundle => {
-        const installation = await evalContractBundle(
-          bundle,
-          additionalEndowments,
-          vatPowers,
-        );
-        const installationHandle = installationTable.create(
-          harden({ installation, bundle }),
-        );
-        return installationHandle;
-      },
+    /**
+     * Makes a contract instance from an installation and returns the
+     * invitation and InstanceRecord.
+     *
+     * @param  {object} installationHandle - the unique handle for the
+     * installation
+     * @param {Object.<string,Issuer>} issuerKeywordRecord - a record mapping
+     * keyword keys to issuer values
+     * @param  {object} terms - optional, arguments to the contract. These
+     * arguments depend on the contract.
+     * @returns {MakeInstanceResult}
+     */
+    makeInstance: (
+      installationHandle,
+      issuerKeywordRecord = harden({}),
+      terms = harden({}),
+    ) => {
+      assert(
+        installationTable.has(installationHandle),
+        details`${installationHandle} was not a valid installationHandle`,
+      );
+      const publicApiP = producePromise();
+      return E(vatAdminSvc)
+        .createVat(zcfContractBundle)
+        .then(({ root: zcfRoot, adminNode }) => {
+          const instanceHandle = harden({});
+          const zoeForZcf = makeZoeForZcf(instanceHandle, publicApiP);
 
-      /**
-       * Makes a contract instance from an installation and returns a
-       * unique handle for the instance that can be shared, as well as
-       * other information, such as the terms used in the instance.
-       * @param  {object} installationHandle - the unique handle for the
-       * installation
-       * @param {Object.<string,Issuer>} issuerKeywordRecord - a record mapping
-       * keyword keys to issuer values
-       * @param  {object} terms - optional, arguments to the contract. These
-       * arguments depend on the contract.
-       */
-      makeInstance: (
-        installationHandle,
-        issuerKeywordRecord = harden({}),
-        terms = harden({}),
-      ) => {
-        assert(
-          installationTable.has(installationHandle),
-          details`${installationHandle} was not a valid installationHandle`,
-        );
-        const { installation } = installationTable.get(installationHandle);
-        const instanceHandle = harden({});
-        const contractFacet = makeContractFacet(instanceHandle);
-
-        const cleanedKeywords = cleanKeywords(issuerKeywordRecord);
-        const issuersP = cleanedKeywords.map(
-          keyword => issuerKeywordRecord[keyword],
-        );
-
-        const makeInstanceRecord = issuerRecords => {
-          const issuers = issuerRecords.map(record => record.issuer);
-          const brands = issuerRecords.map(record => record.brand);
-          const cleanedIssuerKeywordRecord = arrayToObj(
-            issuers,
-            cleanedKeywords,
+          const cleanedKeywords = cleanKeywords(issuerKeywordRecord);
+          const issuersP = cleanedKeywords.map(
+            keyword => issuerKeywordRecord[keyword],
           );
-          const brandKeywordRecord = arrayToObj(brands, cleanedKeywords);
-          const instanceRecord = harden({
+          const makeCleanup = _marker => {
+            return () => {
+              // console.log(`ZOE makeInstance  enter CLEANUP: ${marker} `);
+              const { offerHandles } = instanceTable.get(instanceHandle);
+              // This cleanup can't rely on ZCF to complete the offers since
+              // it's invoked when ZCF is no longer accessible.
+              completeOffers(instanceHandle, Array.from(offerHandles));
+            };
+          };
+
+          // Build an entry for the instanceTable. It will contain zcfForZoe
+          // which isn't available until ZCF starts. When ZCF starts up, it
+          // will invoke the contract, which might make calls back to the Zoe
+          // facet we provide, so InstanceRecord needs to be present by then.
+          // We'll store an initial version of InstanceRecord before invoking
+          // ZCF and fill in the zcfForZoe when we get it.
+          const zcfForZoePromise = producePromise();
+          const instanceRecord = {
             installationHandle,
-            publicAPI: undefined,
+            publicAPI: publicApiP.promise,
             terms,
-            issuerKeywordRecord: cleanedIssuerKeywordRecord,
-            brandKeywordRecord,
-          });
+            zcfForZoe: zcfForZoePromise.promise,
+            offerHandles: new Set(),
+          };
+          const addIssuersToInstanceRecord = issuerRecords => {
+            const issuers = issuerRecords.map(record => record.issuer);
+            const cleanedIssuerKeywordRecord = arrayToObj(
+              issuers,
+              cleanedKeywords,
+            );
+            instanceRecord.issuerKeywordRecord = cleanedIssuerKeywordRecord;
+            const brands = issuerRecords.map(record => record.brand);
+            const brandKeywordRecord = arrayToObj(brands, cleanedKeywords);
+            instanceRecord.brandKeywordRecord = brandKeywordRecord;
+            instanceTable.create(instanceRecord, instanceHandle);
+            E(adminNode)
+              .done()
+              .then(makeCleanup('doneSuccess'), makeCleanup('done reject'));
+          };
 
-          instanceTable.create(instanceRecord, instanceHandle);
+          const callStartContract = () => {
+            const instanceData = harden({
+              instanceHandle,
+              installationHandle,
+              publicAPI: instanceRecord.publicAPI,
+              terms,
+              adminNode,
+              issuerKeywordRecord: instanceRecord.issuerKeywordRecord,
+              brandKeywordRecord: instanceRecord.brandKeywordRecord,
+            });
+            const contractParams = harden({
+              zoeService,
+              bundle: installationTable.get(installationHandle).bundle,
+              instanceData,
+              zoeForZcf,
+              inviteIssuer,
+            });
+            return E(zcfRoot).startContract(contractParams);
+          };
 
-          return Promise.resolve()
-            .then(_ => installation.makeContract(contractFacet))
-            .then(invite => {
-              return inviteIssuer.isLive(invite).then(success => {
-                assert(
-                  success,
-                  details`invites must be issued by the inviteIssuer.`,
-                );
+          const finishContractInstall = ({ inviteP, zcfForZoe }) => {
+            zcfForZoePromise.resolve(zcfForZoe);
+            return inviteIssuer.isLive(inviteP).then(success => {
+              assert(
+                success,
+                details`invites must be issued by the inviteIssuer.`,
+              );
+
+              function buildRecord(invite) {
                 return {
                   invite,
-                  instanceRecord: instanceTable.get(instanceHandle),
+                  instanceRecord: filterInstanceRecord(
+                    instanceTable.get(instanceHandle),
+                  ),
                 };
-              });
+              }
+
+              return inviteP.then(buildRecord, makeCleanup('invite failure'));
             });
+          };
+
+          // The issuers may not have been seen before, so we must wait for the
+          // issuer records to be available synchronously
+          return issuerTable
+            .getPromiseForIssuerRecords(issuersP)
+            .then(addIssuersToInstanceRecord)
+            .then(callStartContract)
+            .then(finishContractInstall);
+        });
+    },
+
+    /**
+     * Credibly retrieves an instance record given an instanceHandle.
+     * @param {object} instanceHandle - the unique, unforgeable
+     * identifier (empty object) for the instance
+     */
+    getInstanceRecord: instanceHandle =>
+      filterInstanceRecord(instanceTable.get(instanceHandle)),
+
+    /** Get a notifier (see @agoric/notify) for the offer. */
+    getOfferNotifier: offerHandle => offerTable.get(offerHandle).notifier,
+
+    /**
+     * Redeem the invite to receive a payout promise and an
+     * outcome promise.
+     * @param {Invite} invite - an invite (ERTP payment) to join a
+     * Zoe smart contract instance
+     * @param  {Proposal?} proposal - the proposal, a record
+     * with properties `want`, `give`, and `exit`. The keys of
+     * `want` and `give` are keywords and the values are amounts.
+     * @param  {Object.<string,Payment>?} paymentKeywordRecord - a record with
+     * keyword keys and values which are payments that will be escrowed by
+     * Zoe.
+     * @returns OfferResultRecord
+     *
+     * The default arguments allow remote invocations to specify empty
+     * objects. Otherwise, explicitly-provided empty objects would be
+     * marshaled as presences.
+     */
+    offer: (
+      invite,
+      proposal = harden({}),
+      paymentKeywordRecord = harden({}),
+    ) => {
+      return inviteIssuer.burn(invite).then(inviteAmount => {
+        assert(
+          inviteAmount.value.length === 1,
+          'only one invite should be redeemed',
+        );
+        const giveKeywords = proposal.give
+          ? Object.getOwnPropertyNames(proposal.give)
+          : [];
+        const wantKeywords = proposal.want
+          ? Object.getOwnPropertyNames(proposal.want)
+          : [];
+        const userKeywords = harden([...giveKeywords, ...wantKeywords]);
+
+        const cleanedProposal = cleanProposal(getAmountMathForBrand, proposal);
+
+        const paymentDepositedPs = userKeywords.map(keyword => {
+          if (giveKeywords.includes(keyword)) {
+            // We cannot trust the amount in the proposal, so we use our
+            // cleaned proposal's amount that should be the same.
+            const giveAmount = cleanedProposal.give[keyword];
+            const { purse } = issuerTable.get(giveAmount.brand);
+            return E(purse).deposit(paymentKeywordRecord[keyword], giveAmount);
+            // eslint-disable-next-line no-else-return
+          } else {
+            // payments outside the give: clause are ignored.
+            return getAmountMathForBrand(
+              cleanedProposal.want[keyword].brand,
+            ).getEmpty();
+          }
+        });
+
+        const {
+          value: [{ instanceHandle, handle: inviteHandle }],
+        } = inviteAmount;
+        const offerHandle = harden({});
+
+        // recordOffer() creates and stores a record in the offerTable. The
+        // allocations are according to the keywords in the offer's proposal,
+        // which are not required to match anything in the issuerKeywordRecord
+        // that was used to instantiate the contract. recordOffer() is called
+        // on amountsArray, which includes amounts for all the keywords in the
+        // proposal. Keywords in the give clause are mapped to the amount
+        // deposited. Keywords in the want clause are mapped to the empty
+        // amount for that keyword's Issuer.
+        const recordOffer = amountsArray => {
+          const notifierRec = produceNotifier();
+          const offerRecord = {
+            instanceHandle,
+            proposal: cleanedProposal,
+            currentAllocation: arrayToObj(amountsArray, userKeywords),
+            notifier: notifierRec.notifier,
+            updater: notifierRec.updater,
+          };
+          const { zcfForZoe } = instanceTable.get(instanceHandle);
+          payoutMap.init(offerHandle, producePromise());
+          offerTable.create(offerRecord, offerHandle);
+          instanceTable.addOffer(instanceHandle, offerHandle);
+          return E(zcfForZoe).addOffer(
+            offerHandle,
+            cleanedProposal,
+            offerRecord.currentAllocation,
+          );
         };
 
-        // The issuers may not have been seen before, so we must wait for
-        // the issuer records to be available synchronously
-        return issuerTable
-          .getPromiseForIssuerRecords(issuersP)
-          .then(makeInstanceRecord);
-      },
-      /**
-       * Credibly retrieves an instance record given an instanceHandle.
-       * @param {object} instanceHandle - the unique, unforgeable
-       * identifier (empty object) for the instance
-       */
-      getInstanceRecord: instanceTable.get,
-
-      /** Get a notifier (see @agoric/notify) for the offer. */
-      getOfferNotifier: offerHandle => offerTable.get(offerHandle).notifier,
-
-      /**
-       * Redeem the invite to receive a payout promise and an
-       * outcome promise.
-       * @param {Invite} invite - an invite (ERTP payment) to join a
-       * Zoe smart contract instance
-       * @param  {Proposal?} proposal - the proposal, a record
-       * with properties `want`, `give`, and `exit`. The keys of
-       * `want` and `give` are keywords and the values are amounts.
-       * @param  {Object.<string,Payment>?} paymentKeywordRecord - a record with
-       * keyword keys and values which are payments that will be escrowed by
-       * Zoe.
-       *
-       * The default arguments allow remote invocations to specify empty
-       * objects. Otherwise, explicitly-provided empty objects would be
-       * marshaled as presences.
-       */
-      offer: (
-        invite,
-        proposal = harden({}),
-        paymentKeywordRecord = harden({}),
-      ) => {
-        return inviteIssuer.burn(invite).then(inviteAmount => {
-          assert(
-            inviteAmount.value.length === 1,
-            'only one invite should be redeemed',
-          );
-          const giveKeywords = proposal.give
-            ? Object.getOwnPropertyNames(proposal.give)
-            : [];
-          const wantKeywords = proposal.want
-            ? Object.getOwnPropertyNames(proposal.want)
-            : [];
-          const userKeywords = harden([...giveKeywords, ...wantKeywords]);
-
-          const cleanedProposal = cleanProposal(
-            getAmountMathForBrand,
-            proposal,
-          );
-
-          const paymentDepositedPs = userKeywords.map(keyword => {
-            if (giveKeywords.includes(keyword)) {
-              // We cannot trust the amount in the proposal, so we use our
-              // cleaned proposal's amount that should be the same.
-              const giveAmount = cleanedProposal.give[keyword];
-              const { purse } = issuerTable.get(giveAmount.brand);
-              return E(purse).deposit(
-                paymentKeywordRecord[keyword],
-                giveAmount,
-              );
-              // eslint-disable-next-line no-else-return
-            } else {
-              // payments outside the give: clause are ignored.
-              return getAmountMathForBrand(
-                cleanedProposal.want[keyword].brand,
-              ).getEmpty();
-            }
-          });
-
-          const {
-            value: [{ instanceHandle, handle: inviteHandle }],
-          } = inviteAmount;
-          const offerHandle = harden({});
-
-          // recordOffer() creates and stores a record in the offerTable. The
-          // allocations are according to the keywords in the offer's proposal,
-          // which are not required to match anything in the issuerKeywordRecord
-          // that was used to instantiate the contract. recordOffer() is called
-          // on amountsArray, which includes amounts for all the keywords in the
-          // proposal. Keywords in the give clause are mapped to the amount
-          // deposited. Keywords in the want clause are mapped to the empty
-          // amount for that keyword's Issuer.
-          const recordOffer = amountsArray => {
-            const notifierRec = produceNotifier();
-            const offerRecord = {
-              instanceHandle,
-              proposal: cleanedProposal,
-              currentAllocation: arrayToObj(amountsArray, userKeywords),
-              notifier: notifierRec.notifier,
-              updater: notifierRec.updater,
-            };
-            offerTable.create(offerRecord, offerHandle);
-            payoutMap.init(offerHandle, producePromise());
+        const makeOfferResult = completeObj => {
+          const offerHandler = inviteHandleToHandler.get(inviteHandle);
+          const offerResult = {
+            offerHandle: HandledPromise.resolve(offerHandle),
+            payout: payoutMap.get(offerHandle).promise,
+            outcome: offerHandler(offerHandle),
+            completeObj,
           };
-
-          // Create result to be returned. Depends on `exit`
-          const makeOfferResult = _ => {
-            const offerHook = inviteHandleToOfferHook.get(inviteHandle);
-            // For now, the "remote" function call only works because
-            // the function is local. It cannot yet be remote
-            // in our system because functions are not yet passable.
-            const outcomeP = E(offerHook)(offerHandle);
-            const offerResult = {
-              offerHandle: HandledPromise.resolve(offerHandle),
-              payout: payoutMap.get(offerHandle).promise,
-              outcome: outcomeP,
-            };
-            const { exit } = cleanedProposal;
-            const [exitKind] = Object.getOwnPropertyNames(exit);
-            // Automatically complete offer after deadline.
-            if (exitKind === 'afterDeadline') {
-              E(exit.afterDeadline.timer).setWakeup(
-                exit.afterDeadline.deadline,
-                harden({
-                  wake: () =>
-                    completeOffers(instanceHandle, harden([offerHandle])),
-                }),
-              );
-              // Add an object with a complete method to offerResult
-              // in order to complete offer on demand. Note: we cannot
-              // add the `complete` function to the offerResult
-              // directly because our marshalling layer only allows
-              // two kinds of objects: records (no methods and only
-              // data) and presences (local proxies for objects that
-              // may have methods). Having a method makes an object
-              // automatically a presence, but we want the offerResult
-              // to be a record.
-            } else if (exitKind === 'onDemand') {
-              const completeObj = {
-                complete: () =>
-                  completeOffers(instanceHandle, harden([offerHandle])),
-              };
-              offerResult.completeObj = completeObj;
-            } else {
-              assert(
-                exitKind === 'waived',
-                details`exit kind was not recognized: ${q(exitKind)}`,
-              );
-            }
-
-            // if the exitRule.kind is 'waived' the user has no
-            // possibility of completing an offer on demand
-            return harden(offerResult);
-          };
-          return Promise.all(paymentDepositedPs)
-            .then(recordOffer)
-            .then(makeOfferResult);
-        });
-      },
-
-      isOfferActive: offerTable.isOfferActive,
-      getOffers: offerHandles =>
-        offerTable.getOffers(offerHandles).map(removeAmountsAndNotifier),
-      getOffer: offerHandle =>
-        removeAmountsAndNotifier(offerTable.get(offerHandle)),
-      getCurrentAllocation: (offerHandle, brandKeywordRecord) =>
-        doGetCurrentAllocation(offerHandle, brandKeywordRecord),
-      getCurrentAllocations: (offerHandles, brandKeywordRecords) =>
-        doGetCurrentAllocations(offerHandles, brandKeywordRecords),
-      getInstallation: installationHandle =>
-        installationTable.get(installationHandle).bundle,
+          return harden(offerResult);
+        };
+        return Promise.all(paymentDepositedPs)
+          .then(recordOffer)
+          .then(makeOfferResult);
+      });
     },
-  );
+
+    isOfferActive: offerTable.isOfferActive,
+    getOffers: offerHandles =>
+      offerTable.getOffers(offerHandles).map(removeAmountsAndNotifier),
+    getOffer: offerHandle =>
+      removeAmountsAndNotifier(offerTable.get(offerHandle)),
+    getCurrentAllocation: (offerHandle, brandKeywordRecord) =>
+      doGetCurrentAllocation(offerHandle, brandKeywordRecord),
+    getCurrentAllocations: (offerHandles, brandKeywordRecords) =>
+      doGetCurrentAllocations(offerHandles, brandKeywordRecords),
+    getInstallation: installationHandle =>
+      installationTable.get(installationHandle).bundle,
+  });
+
   return zoeService;
 }
 

--- a/packages/zoe/test/swingsetTests/zoe-metering/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/zoe-metering/bootstrap.js
@@ -10,9 +10,11 @@ import testBuiltinsBundle from './bundle-testBuiltins';
 
 function build(log) {
   const obj0 = {
-    async bootstrap(argv, vats) {
-      const zoe = await E(vats.zoe).getZoe();
-
+    async bootstrap(argv, vats, devices) {
+      const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
+        devices.vatAdmin,
+      );
+      const zoe = await E(vats.zoe).buildZoe(vatAdminSvc);
       const installations = {
         infiniteInstallLoop: () =>
           E(zoe).install(infiniteInstallLoopBundle.bundle),

--- a/packages/zoe/test/swingsetTests/zoe-metering/test-zoe-metering.js
+++ b/packages/zoe/test/swingsetTests/zoe-metering/test-zoe-metering.js
@@ -34,6 +34,7 @@ async function main(argv) {
 
 const infiniteInstallLoopLog = [
   'installing infiniteInstallLoop',
+  'instantiating infiniteInstallLoop',
   'error: RangeError: Compute meter exceeded',
 ];
 test('zoe - metering - infinite loop in installation', async t => {

--- a/packages/zoe/test/swingsetTests/zoe-metering/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/zoe-metering/vat-zoe.js
@@ -1,10 +1,10 @@
 /* global harden */
 
+// noinspection ES6PreferShortImport
 import { makeZoe } from '../../../src/zoe';
 
-export function buildRootObject(vatPowers) {
-  const zoe = makeZoe({}, vatPowers);
+export function buildRootObject(_vatPowers) {
   return harden({
-    getZoe: () => zoe,
+    buildZoe: vatAdminSvc => makeZoe(vatAdminSvc),
   });
 }

--- a/packages/zoe/test/swingsetTests/zoe/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/zoe/bootstrap.js
@@ -90,9 +90,11 @@ const makeVats = (log, vats, zoe, installations, startingValues) => {
 
 function build(log) {
   const obj0 = {
-    async bootstrap(argv, vats) {
-      const zoe = await E(vats.zoe).getZoe();
-
+    async bootstrap(argv, vats, devices) {
+      const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
+        devices.vatAdmin,
+      );
+      const zoe = await E(vats.zoe).buildZoe(vatAdminSvc);
       const installations = {
         automaticRefund: await E(zoe).install(automaticRefundBundle.bundle),
         coveredCall: await E(zoe).install(coveredCallBundle.bundle),

--- a/packages/zoe/test/swingsetTests/zoe/test-zoe.js
+++ b/packages/zoe/test/swingsetTests/zoe/test-zoe.js
@@ -1,4 +1,4 @@
-import '@agoric/install-ses';
+import '@agoric/install-metering-and-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from 'tape-promise/tape';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/swingsetTests/zoe/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-zoe.js
@@ -1,10 +1,10 @@
 /* global harden */
 
+// noinspection ES6PreferShortImport
 import { makeZoe } from '../../../src/zoe';
 
 export function buildRootObject(_vatPowers) {
-  const zoe = makeZoe();
   return harden({
-    getZoe: () => zoe,
+    buildZoe: vatAdminSvc => makeZoe(vatAdminSvc),
   });
 }

--- a/packages/zoe/test/unitTests/contracts/fakeVatAdmin.js
+++ b/packages/zoe/test/unitTests/contracts/fakeVatAdmin.js
@@ -1,0 +1,12 @@
+/* global harden */
+
+import { E } from '@agoric/eventual-send';
+import { evalContractBundle } from '../../../src/evalContractCode';
+
+export default harden({
+  createVat: bundle => {
+    return harden({
+      root: E(evalContractBundle(bundle)).buildRootObject(),
+    });
+  },
+});

--- a/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
+++ b/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
@@ -6,9 +6,11 @@ import { test } from 'tape-promise/tape';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import bundleSource from '@agoric/bundle-source';
 
+// noinspection ES6PreferShortImport
 import { makeZoe } from '../../../src/zoe';
 import { setup } from '../setupBasicMints';
 import { setupNonFungible } from '../setupNonFungibleMints';
+import fakeVatAdmin from './fakeVatAdmin';
 
 const atomicSwapRoot = `${__dirname}/../../../src/contracts/atomicSwap`;
 
@@ -22,7 +24,7 @@ test('zoe - atomicSwap', async t => {
     moola,
     simoleans,
   } = setup();
-  const zoe = makeZoe();
+  const zoe = makeZoe(fakeVatAdmin);
   const inviteIssuer = zoe.getInviteIssuer();
 
   // pack the contract
@@ -149,7 +151,7 @@ test('zoe - non-fungible atomicSwap', async t => {
     createRpgItem,
   } = setupNonFungible();
 
-  const zoe = makeZoe();
+  const zoe = makeZoe(fakeVatAdmin);
   const inviteIssuer = zoe.getInviteIssuer();
 
   // pack the contract
@@ -274,7 +276,7 @@ test('zoe - non-fungible atomicSwap', async t => {
 test('zoe - atomicSwap like-for-like', async t => {
   t.plan(13);
   const { moolaIssuer, moolaMint, moola } = setup();
-  const zoe = makeZoe();
+  const zoe = makeZoe(fakeVatAdmin);
   const inviteIssuer = zoe.getInviteIssuer();
 
   // pack the contract

--- a/packages/zoe/test/unitTests/contracts/test-barter.js
+++ b/packages/zoe/test/unitTests/contracts/test-barter.js
@@ -6,10 +6,13 @@ import '@agoric/install-ses';
 import { test } from 'tape-promise/tape';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import bundleSource from '@agoric/bundle-source';
+import { E } from '@agoric/eventual-send';
 
+// noinspection ES6PreferShortImport
 import { makeZoe } from '../../../src/zoe';
 import { setup } from '../setupBasicMints';
 import { makeGetInstanceHandle } from '../../../src/clientSupport';
+import fakeVatAdmin from './fakeVatAdmin';
 
 const barter = `${__dirname}/../../../src/contracts/barterExchange`;
 
@@ -24,7 +27,7 @@ test('barter with valid offers', async t => {
     moola,
     simoleans,
   } = setup();
-  const zoe = makeZoe();
+  const zoe = makeZoe(fakeVatAdmin);
   const inviteIssuer = zoe.getInviteIssuer();
   const getInstanceHandle = makeGetInstanceHandle(inviteIssuer);
 
@@ -52,7 +55,7 @@ test('barter with valid offers', async t => {
   const instanceHandle = await getInstanceHandle(simonInvite);
   const { publicAPI } = zoe.getInstanceRecord(instanceHandle);
 
-  const aliceInvite = publicAPI.makeInvite();
+  const aliceInvite = await E(publicAPI).makeInvite();
 
   // 2: Alice escrows with zoe to create a sell order. She wants to
   // sell 3 moola and wants to receive at least 4 simoleans in
@@ -70,7 +73,7 @@ test('barter with valid offers', async t => {
     alicePayments,
   );
 
-  const bobInvite = publicAPI.makeInvite();
+  const bobInvite = await E(publicAPI).makeInvite();
 
   // 5: Bob decides to join.
   const bobExclusiveInvite = await inviteIssuer.claim(bobInvite);

--- a/packages/zoe/test/unitTests/contracts/test-brokenContract.js
+++ b/packages/zoe/test/unitTests/contracts/test-brokenContract.js
@@ -6,8 +6,10 @@ import { test } from 'tape-promise/tape';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import bundleSource from '@agoric/bundle-source';
 
+// noinspection ES6PreferShortImport
 import { makeZoe } from '../../../src/zoe';
 import { setup } from '../setupBasicMints';
+import fakeVatAdmin from './fakeVatAdmin';
 
 const automaticRefundRoot = `${__dirname}/brokenAutoRefund`;
 
@@ -15,7 +17,7 @@ test('zoe - brokenAutomaticRefund', async t => {
   t.plan(1);
   // Setup zoe and mints
   const { moolaR } = setup();
-  const zoe = makeZoe();
+  const zoe = makeZoe(fakeVatAdmin);
   // Pack the contract.
   const bundle = await bundleSource(automaticRefundRoot);
   const installationHandle = await zoe.install(bundle);

--- a/packages/zoe/test/unitTests/contracts/test-coveredCall.js
+++ b/packages/zoe/test/unitTests/contracts/test-coveredCall.js
@@ -9,9 +9,11 @@ import bundleSource from '@agoric/bundle-source';
 import { sameStructure } from '@agoric/same-structure';
 
 import buildManualTimer from '../../../tools/manualTimer';
+// noinspection ES6PreferShortImport
 import { makeZoe } from '../../../src/zoe';
 import { setup } from '../setupBasicMints';
 import { setupNonFungible } from '../setupNonFungibleMints';
+import fakeVatAdmin from './fakeVatAdmin';
 
 const coveredCallRoot = `${__dirname}/../../../src/contracts/coveredCall`;
 const atomicSwapRoot = `${__dirname}/../../../src/contracts/atomicSwap`;
@@ -20,7 +22,7 @@ test('zoe - coveredCall', async t => {
   t.plan(13);
   try {
     const { moolaR, simoleanR, moola, simoleans } = setup();
-    const zoe = makeZoe();
+    const zoe = makeZoe(fakeVatAdmin);
     // Pack the contract.
     const bundle = await bundleSource(coveredCallRoot);
     const coveredCallInstallationHandle = await zoe.install(bundle);
@@ -145,7 +147,7 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
   t.plan(13);
   try {
     const { moolaR, simoleanR, moola, simoleans } = setup();
-    const zoe = makeZoe();
+    const zoe = makeZoe(fakeVatAdmin);
     // Pack the contract.
     const bundle = await bundleSource(coveredCallRoot);
     const coveredCallInstallationHandle = await zoe.install(bundle);
@@ -280,7 +282,7 @@ test('zoe - coveredCall with swap for invite', async t => {
     // Setup the environment
     const timer = buildManualTimer(console.log);
     const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
-    const zoe = makeZoe();
+    const zoe = makeZoe(fakeVatAdmin);
     // Pack the contract.
     const coveredCallBundle = await bundleSource(coveredCallRoot);
 
@@ -543,7 +545,7 @@ test('zoe - coveredCall with coveredCall for invite', async t => {
     // Setup the environment
     const timer = buildManualTimer(console.log);
     const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
-    const zoe = makeZoe();
+    const zoe = makeZoe(fakeVatAdmin);
     // Pack the contract.
     const bundle = await bundleSource(coveredCallRoot);
 
@@ -825,7 +827,7 @@ test('zoe - coveredCall non-fungible', async t => {
     createRpgItem,
   } = setupNonFungible();
 
-  const zoe = makeZoe();
+  const zoe = makeZoe(fakeVatAdmin);
   // install the contract.
   const bundle = await bundleSource(coveredCallRoot);
   const coveredCallInstallationHandle = await zoe.install(bundle);

--- a/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
@@ -9,13 +9,14 @@ import { E } from '@agoric/eventual-send';
 
 import { makeZoe } from '../../../src/zoe';
 import { setup } from '../setupBasicMints';
+import fakeVatAdmin from './fakeVatAdmin';
 
 const contractRoot = `${__dirname}/escrowToVote`;
 
 test('zoe - escrowToVote', async t => {
   t.plan(14);
   const { moolaIssuer, moolaMint, moola } = setup();
-  const zoe = makeZoe();
+  const zoe = makeZoe(fakeVatAdmin);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/contracts/test-grifter.js
+++ b/packages/zoe/test/unitTests/contracts/test-grifter.js
@@ -6,8 +6,10 @@ import { test } from 'tape-promise/tape';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import bundleSource from '@agoric/bundle-source';
 
-import { makeZoe } from '../../..';
+// noinspection ES6PreferShortImport
+import { makeZoe } from '../../../src/zoe';
 import { setup } from '../setupBasicMints';
+import fakeVatAdmin from './fakeVatAdmin';
 
 const grifterRoot = `${__dirname}/grifter`;
 
@@ -15,7 +17,7 @@ test('zoe - grifter tries to steal; prevented by offer safety', async t => {
   t.plan(1);
   // Setup zoe and mints
   const { moola, moolaR, moolaMint, bucksR, bucks } = setup();
-  const zoe = makeZoe();
+  const zoe = makeZoe(fakeVatAdmin);
   // Pack the contract.
   const bundle = await bundleSource(grifterRoot);
   const installationHandle = await zoe.install(bundle);

--- a/packages/zoe/test/unitTests/contracts/test-mintPayments.js
+++ b/packages/zoe/test/unitTests/contracts/test-mintPayments.js
@@ -8,7 +8,9 @@ import bundleSource from '@agoric/bundle-source';
 
 import { E } from '@agoric/eventual-send';
 import makeIssuerKit from '@agoric/ertp';
+import fakeVatAdmin from './fakeVatAdmin';
 
+// noinspection ES6PreferShortImport
 import { makeZoe } from '../../../src/zoe';
 
 const mintPaymentsRoot = `${__dirname}/../../../src/contracts/mintPayments`;
@@ -16,7 +18,7 @@ const mintPaymentsRoot = `${__dirname}/../../../src/contracts/mintPayments`;
 test('zoe - mint payments', async t => {
   t.plan(2);
   try {
-    const zoe = makeZoe();
+    const zoe = makeZoe(fakeVatAdmin);
     // Pack the contract.
     const bundle = await bundleSource(mintPaymentsRoot);
     const installationHandle = await E(zoe).install(bundle);
@@ -56,7 +58,7 @@ test('zoe - mint payments', async t => {
 test('zoe - mint payments with unrelated give and want', async t => {
   t.plan(3);
   try {
-    const zoe = makeZoe();
+    const zoe = makeZoe(fakeVatAdmin);
     // Pack the contract.
     const bundle = await bundleSource(mintPaymentsRoot);
     const installationHandle = await E(zoe).install(bundle);

--- a/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
@@ -9,7 +9,9 @@ import bundleSource from '@agoric/bundle-source';
 import makeAmountMath from '@agoric/ertp/src/amountMath';
 import makeIssuerKit from '@agoric/ertp';
 import { E } from '@agoric/eventual-send';
+import fakeVatAdmin from './fakeVatAdmin';
 
+// noinspection ES6PreferShortImport
 import { makeZoe } from '../../../src/zoe';
 import { setup } from '../setupBasicMints';
 
@@ -19,7 +21,7 @@ test('multipoolAutoSwap with valid offers', async t => {
   t.plan(35);
   try {
     const { moolaR, simoleanR, moola, simoleans } = setup();
-    const zoe = makeZoe();
+    const zoe = makeZoe(fakeVatAdmin);
     const inviteIssuer = zoe.getInviteIssuer();
 
     // Set up central token
@@ -198,7 +200,7 @@ test('multipoolAutoSwap with valid offers', async t => {
     );
 
     // Bob looks up the price of 17 moola in central tokens
-    const priceInCentralTokens = bobPublicAPI.getCurrentPrice(
+    const priceInCentralTokens = await E(bobPublicAPI).getCurrentPrice(
       moola(17),
       centralR.brand,
     );
@@ -239,7 +241,7 @@ test('multipoolAutoSwap with valid offers', async t => {
       `bob gets the same price as when he called the getCurrentPrice method`,
     );
     t.deepEquals(
-      bobPublicAPI.getPoolAllocation(moolaR.brand),
+      await E(bobPublicAPI).getPoolAllocation(moolaR.brand),
       {
         Moola: moola(117),
         CentralToken: centralTokens(43),
@@ -252,7 +254,7 @@ test('multipoolAutoSwap with valid offers', async t => {
     await E(bobCentralTokenPurse).deposit(bobCentralTokenPayout1);
 
     // Bob looks up the price of 7 central tokens in moola
-    const moolaAmounts = bobPublicAPI.getCurrentPrice(
+    const moolaAmounts = await E(bobPublicAPI).getCurrentPrice(
       centralTokens(7),
       moolaR.brand,
     );
@@ -263,7 +265,7 @@ test('multipoolAutoSwap with valid offers', async t => {
     );
 
     // Bob makes another offer and swaps
-    const bobSwapInvite2 = bobPublicAPI.makeSwapInvite();
+    const bobSwapInvite2 = await E(bobPublicAPI).makeSwapInvite();
     const bobCentralForMoolaProposal = harden({
       want: { Out: moola(16) },
       give: { In: centralTokens(7) },
@@ -302,7 +304,7 @@ test('multipoolAutoSwap with valid offers', async t => {
       `bob gets no central tokens back`,
     );
     t.deepEqual(
-      bobPublicAPI.getPoolAllocation(moolaR.brand),
+      await E(bobPublicAPI).getPoolAllocation(moolaR.brand),
       {
         Moola: moola(101),
         CentralToken: centralTokens(50),
@@ -315,7 +317,9 @@ test('multipoolAutoSwap with valid offers', async t => {
     // liquidity pool. 398 simoleans = 43 central tokens at the time of
     // the liquidity adding
     //
-    const aliceSimCentralLiquidityInvite = publicAPI.makeAddLiquidityInvite();
+    const aliceSimCentralLiquidityInvite = await E(
+      publicAPI,
+    ).makeAddLiquidityInvite();
     const aliceSimCentralProposal = harden({
       want: { Liquidity: simoleanLiquidity(43) },
       give: { SecondaryToken: simoleans(398), CentralToken: centralTokens(43) },
@@ -430,7 +434,7 @@ test('multipoolAutoSwap with valid offers', async t => {
     );
 
     t.deepEqual(
-      bobPublicAPI.getPoolAllocation(simoleanR.brand),
+      await E(bobPublicAPI).getPoolAllocation(simoleanR.brand),
       harden({
         // 398 + 74
         Simoleans: simoleans(472),
@@ -441,7 +445,7 @@ test('multipoolAutoSwap with valid offers', async t => {
       `the simolean liquidity pool gains simoleans and loses central tokens`,
     );
     t.deepEqual(
-      bobPublicAPI.getPoolAllocation(moolaR.brand),
+      await E(bobPublicAPI).getPoolAllocation(moolaR.brand),
       harden({
         // 101 - 10
         Moola: moola(91),
@@ -454,7 +458,9 @@ test('multipoolAutoSwap with valid offers', async t => {
 
     // Alice removes her liquidity
     // She's not picky...
-    const aliceRemoveLiquidityInvite = publicAPI.makeRemoveLiquidityInvite();
+    const aliceRemoveLiquidityInvite = await E(
+      publicAPI,
+    ).makeRemoveLiquidityInvite();
     const aliceRemoveLiquidityProposal = harden({
       give: { Liquidity: moolaLiquidity(50) },
       want: { SecondaryToken: moola(91), CentralToken: centralTokens(56) },
@@ -492,7 +498,7 @@ test('multipoolAutoSwap with valid offers', async t => {
       `alice gets no liquidity tokens`,
     );
     t.deepEqual(
-      bobPublicAPI.getPoolAllocation(moolaR.brand),
+      await E(bobPublicAPI).getPoolAllocation(moolaR.brand),
       harden({
         Moola: moola(0),
         CentralToken: centralTokens(0),

--- a/packages/zoe/test/unitTests/contracts/test-publicAuction.js
+++ b/packages/zoe/test/unitTests/contracts/test-publicAuction.js
@@ -5,10 +5,13 @@ import '@agoric/install-ses';
 import { test } from 'tape-promise/tape';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import bundleSource from '@agoric/bundle-source';
+import { E } from '@agoric/eventual-send';
 
+// noinspection ES6PreferShortImport
 import { makeZoe } from '../../../src/zoe';
 import { setup } from '../setupBasicMints';
 import { setupMixed } from '../setupMixedMints';
+import fakeVatAdmin from './fakeVatAdmin';
 
 const publicAuctionRoot = `${__dirname}/../../../src/contracts/publicAuction`;
 
@@ -16,7 +19,7 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
   t.plan(34);
   try {
     const { moolaR, simoleanR, moola, simoleans } = setup();
-    const zoe = makeZoe();
+    const zoe = makeZoe(fakeVatAdmin);
     const inviteIssuer = zoe.getInviteIssuer();
 
     // Setup Alice
@@ -69,7 +72,9 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
       alicePayments,
     );
 
-    const [bobInvite, carolInvite, daveInvite] = await publicAPI.makeInvites(3);
+    const [bobInvite, carolInvite, daveInvite] = await E(publicAPI).makeInvites(
+      3,
+    );
 
     t.equals(
       await aliceOutcomeP,
@@ -317,7 +322,7 @@ test('zoe - secondPriceAuction w/ 3 bids - alice exits onDemand', async t => {
   t.plan(10);
   try {
     const { moolaR, simoleanR, moola, simoleans } = setup();
-    const zoe = makeZoe();
+    const zoe = makeZoe(fakeVatAdmin);
 
     // Setup Alice
     const aliceMoolaPayment = moolaR.mint.mintPayment(moola(1));
@@ -359,7 +364,7 @@ test('zoe - secondPriceAuction w/ 3 bids - alice exits onDemand', async t => {
       outcome: aliceOutcomeP,
     } = await zoe.offer(aliceInvite, aliceProposal, alicePayments);
 
-    const [bobInvite] = publicAPI.makeInvites(1);
+    const [bobInvite] = await E(publicAPI).makeInvites(1);
 
     t.equals(
       await aliceOutcomeP,
@@ -455,7 +460,7 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
     cryptoCats,
     moola,
   } = setupMixed();
-  const zoe = makeZoe();
+  const zoe = makeZoe(fakeVatAdmin);
   const inviteIssuer = zoe.getInviteIssuer();
 
   // Setup Alice
@@ -508,7 +513,9 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
     alicePayments,
   );
 
-  const [bobInvite, carolInvite, daveInvite] = await publicAPI.makeInvites(3);
+  const [bobInvite, carolInvite, daveInvite] = await E(publicAPI).makeInvites(
+    3,
+  );
 
   t.equals(
     await aliceOutcomeP,

--- a/packages/zoe/test/unitTests/contracts/test-sellTickets.js
+++ b/packages/zoe/test/unitTests/contracts/test-sellTickets.js
@@ -5,10 +5,13 @@ import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from 'tape-promise/tape';
 // eslint-disable-next-line import/no-extraneous-dependencies
+
 import bundleSource from '@agoric/bundle-source';
 import makeIssuerKit from '@agoric/ertp';
 import { E } from '@agoric/eventual-send';
+import fakeVatAdmin from './fakeVatAdmin';
 
+// noinspection ES6PreferShortImport
 import { makeZoe } from '../../../src/zoe';
 import { defaultAcceptanceMsg } from '../../../src/contractSupport';
 
@@ -17,7 +20,7 @@ const sellItemsRoot = `${__dirname}/../../../src/contracts/sellItems`;
 
 test(`mint and sell tickets for multiple shows`, async t => {
   // Setup initial conditions
-  const zoe = makeZoe();
+  const zoe = makeZoe(fakeVatAdmin);
 
   const mintAndSellNFTBundle = await bundleSource(mintAndSellNFTRoot);
   const mintAndSellNFTInstallationHandle = await E(zoe).install(
@@ -151,7 +154,7 @@ test(`mint and sell opera tickets`, async t => {
     amountMath: { make: moola },
   } = makeIssuerKit('moola');
 
-  const zoe = makeZoe();
+  const zoe = makeZoe(fakeVatAdmin);
 
   const mintAndSellNFTBundle = await bundleSource(mintAndSellNFTRoot);
   const mintAndSellNFTInstallationHandle = await E(zoe).install(

--- a/packages/zoe/test/unitTests/contracts/test-useObj.js
+++ b/packages/zoe/test/unitTests/contracts/test-useObj.js
@@ -6,15 +6,17 @@ import { test } from 'tape-promise/tape';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import bundleSource from '@agoric/bundle-source';
 
+// noinspection ES6PreferShortImport
 import { makeZoe } from '../../../src/zoe';
 import { setup } from '../setupBasicMints';
+import fakeVatAdmin from './fakeVatAdmin';
 
 const contractRoot = `${__dirname}/useObjExample`;
 
 test('zoe - useObj', async t => {
   t.plan(3);
   const { moolaIssuer, moolaMint, moola } = setup();
-  const zoe = makeZoe();
+  const zoe = makeZoe(fakeVatAdmin);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/contracts/test-zcf.js
+++ b/packages/zoe/test/unitTests/contracts/test-zcf.js
@@ -6,15 +6,17 @@ import { test } from 'tape-promise/tape';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import bundleSource from '@agoric/bundle-source';
 
+// noinspection ES6PreferShortImport
 import { makeZoe } from '../../../src/zoe';
 import { setup } from '../setupBasicMints';
+import fakeVatAdmin from './fakeVatAdmin';
 
 const contractRoot = `${__dirname}/zcfTesterContract`;
 
 test('zoe - test zcf', async t => {
   t.plan(1);
   const { moolaIssuer, simoleanIssuer } = setup();
-  const zoe = makeZoe();
+  const zoe = makeZoe(fakeVatAdmin);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);


### PR DESCRIPTION
This is ready to be reviewed. The main change is pulling the Zoe contract facet out into a separate file, and calling makeInstance in a new vat. `state.js` was modified to support tables for both Zoe and ZCF.

Each of Zoe and ZCF now has an inner facet that is exposed to the other. 

The code isn't ready to be submitted because we haven't yet written the functionality to force an `eval` within a vat to enforce metering. That's being worked on separately, and isn't expected to require any changes to this PR.

@erights and @katelynsills:
  you'll want to look at `zoe.js` and `contractFacet.js` first. This will be easiest if you look just at the second commit. The first commit just moves some things around within `zoe.js`, and across to `contractFacet.js`, so the diffs will be informative.

@warner, 
it would be helpful if you would look at the way makeInstance is called. I also wonder about the way the tests needed to be changed to provide their bundles. Look both at `bootstrap.js` and the `test-foo.js` files. They had to take the previous `bundle`, and wrap it in a `{ bundle }` object. AIUI, that's because `build-zcf-bundle.js` creates a bundle file which contains an object containing a `bundle`, which in turn contains the `source`.

Closes: #553 

# User-Visible changes

* Addition of `getVatAdmin()` to zcf API. 
* the error from `reallocate()`, `getOffers()`, `getOffer()`, `getCurrentAllocations()`, `getCurrentAllocation()`, `isOfferActive()`, `getOfferStatuses()`, `reallocate()`, and `completeOffers()` when an offer is no longer active has changed from "offer has already completed" to "Offer is not active".
 * publicAPI is now always a Promise/Presence, so it has to be called using `E()`

#  Security Claims

Zoe will now create a separate vat for each instance of a contract. Zoe provides an internal facet (zoeForZcf) that Zcf can use, but doesn't make accessible to contracts or anyone else. The zoeForZcf facet has the instanceHandle curried in, so Zoe can tell which contract each is for. Zcf makes an interface (zcfForZoe) accessible to Zoe that Zoe doesn't share with anyone.

Zoe deposits and commingles all the funds that are offered by contracts and their clients. Zcf is informed of the amounts, and can rearrange them using reallocate, but has no accees to the funds, other than funds it deposits directly.


When a contract vat terminates, Zoe will detect that, and will call completeOffer() on all remaining offers.

When an offer is made to Zoe, Zoe will escrow the funds and notify the appropriate zcf. That zcf will create a closeObject if the exit condition calls for it, and pass it back (via Zoe) to the client. If Zcf is still functioning when that closeObject is invoked, the position will be closed out. If Zcf is non-responsive, Zoe will eventually be notified so it can clean up.


Zoe keeps a shared table of issuers. Each Zcf has a cached table containing just the issuers relevant for that contract instance.


Zoe enforces rights conservation and offer safety on every reallocation, so no zcf instance can get access to funds beyond what it properly manages.

Zoe validates requests from Zcfs to verify that they only access their own offers and their own instance data.

Zoe and Zcf maintain parallel copies of the offer table, so they both know the amounts allocated to each offer. Inital offers are created through Zoe and communicated to the relevant Zcf. Requests to change the allocation originate at the Zcf, and are forwarded to Zoe, so it can keep up-to-date in order to handle completion correctly if the Zcf stops communicating.


#dapp-encouragement-branch: ZoeSplit
