### PR TITLE
add inescapable metering wrappers to dynamic vat Compartments

### DIFF
--- a/packages/SwingSet/src/kernel/dynamicVat.js
+++ b/packages/SwingSet/src/kernel/dynamicVat.js
@@ -81,12 +81,14 @@ export function makeDynamicVatCreator(stuff) {
         );
       }
       const getMeter = meterRecord.getMeter;
-      const transforms = [src => transformMetering(src, getMeter)];
+      const inescapableTransforms = [src => transformMetering(src, getMeter)];
+      const inescapableGlobalLexicals = { getMeter };
 
       const vatNS = await importBundle(vatSourceBundle, {
         filePrefix: vatID,
-        transforms,
-        endowments: { ...makeVatEndowments(vatID), getMeter },
+        endowments: makeVatEndowments(vatID),
+        inescapableTransforms,
+        inescapableGlobalLexicals,
       });
       if (typeof vatNS.buildRootObject !== 'function') {
         throw Error(

--- a/packages/SwingSet/test/metering/grandchild.js
+++ b/packages/SwingSet/test/metering/grandchild.js
@@ -1,0 +1,6 @@
+import { meterMe } from './metered-code';
+
+export function meterThem(explode) {
+  const log2 = [];
+  meterMe(log2, explode);
+}

--- a/packages/SwingSet/test/metering/metered-code.js
+++ b/packages/SwingSet/test/metering/metered-code.js
@@ -8,7 +8,7 @@ function delveForeverIntoTheRecursiveDepths() {
   return delveForeverIntoTheRecursiveDepths();
 }
 
-export default function meterMe(log2, explode = 'no') {
+export function meterMe(log2, explode = 'no') {
   log2.push('started');
   harden({});
   // console.log(`explode mode ${explode}`);

--- a/packages/SwingSet/test/metering/metered-dynamic-vat.js
+++ b/packages/SwingSet/test/metering/metered-dynamic-vat.js
@@ -1,6 +1,5 @@
 /* global harden */
-
-import meterMe from './metered-code';
+import { meterMe } from './metered-code';
 
 export function buildRootObject(_dynamicVatPowers) {
   return harden({

--- a/packages/SwingSet/test/metering/metered-dynamic-vat.js
+++ b/packages/SwingSet/test/metering/metered-dynamic-vat.js
@@ -1,7 +1,10 @@
 /* global harden */
+import { importBundle } from '@agoric/import-bundle';
 import { meterMe } from './metered-code';
 
 export function buildRootObject(_dynamicVatPowers) {
+  let grandchildNS;
+
   return harden({
     async run() {
       meterMe([], 'no');
@@ -11,6 +14,17 @@ export function buildRootObject(_dynamicVatPowers) {
     async explode(how) {
       meterMe([], how);
       return -1;
+    },
+
+    async load(bundle) {
+      const require = harden(() => 0);
+      grandchildNS = await importBundle(bundle, {
+        endowments: { console, require },
+      });
+    },
+
+    async meterThem(explode) {
+      grandchildNS.meterThem(explode);
     },
   });
 }

--- a/packages/SwingSet/test/metering/test-dynamic-vat-subcompartment.js
+++ b/packages/SwingSet/test/metering/test-dynamic-vat-subcompartment.js
@@ -1,0 +1,97 @@
+/* global harden */
+
+import '@agoric/install-metering-and-ses';
+import bundleSource from '@agoric/bundle-source';
+import tap from 'tap';
+import { buildVatController } from '../../src/index';
+import makeNextLog from '../make-nextlog';
+
+function capdata(body, slots = []) {
+  return harden({ body, slots });
+}
+
+function capargs(args, slots = []) {
+  return capdata(JSON.stringify(args), slots);
+}
+
+// This test checks that dynamic vats (which are metered) can import bundles,
+// and that those bundles are also metered.
+
+tap.test('metering dynamic vat which imports bundle', async t => {
+  // We first create a static vat with vat-load-dynamic.js
+  const config = {
+    vats: new Map(),
+    bootstrapIndexJS: require.resolve('./vat-load-dynamic.js'),
+  };
+  const c = await buildVatController(config, []);
+  const nextLog = makeNextLog(c);
+
+  // let the vatAdminService get wired up before we create any new vats
+  await c.run();
+
+  // now we tell the static vat to create a dynamic vat, from
+  // metered-dynamic-vat.js
+  const dynamicVatBundle = await bundleSource(
+    require.resolve('./metered-dynamic-vat.js'),
+  );
+
+  // 'createVat' will import the bundle
+  c.queueToVatExport(
+    '_bootstrap',
+    'o+0',
+    'createVat',
+    capargs([dynamicVatBundle]),
+  );
+  await c.run();
+  t.deepEqual(nextLog(), ['created'], 'first create');
+
+  // then we tell the dynamic vat to load the grandchild.js bundle
+  const grandchildBundle = await bundleSource(
+    require.resolve('./grandchild.js'),
+  );
+  const r = c.queueToVatExport(
+    '_bootstrap',
+    'o+0',
+    'load',
+    capargs([grandchildBundle]),
+  );
+  await c.run();
+  t.deepEqual(r.resolution(), capargs('ok'));
+
+  // First, send a message to the grandchild that runs normally
+  c.queueToVatExport('_bootstrap', 'o+0', 'bundleRun', capargs([]));
+  await c.run();
+
+  t.deepEqual(nextLog(), ['did run'], 'first run ok');
+
+  // Now tell the grandchild to exhaust the dynamic vat's meter. The message
+  // result promise should be rejected, and the control facet should report
+  // the vat's demise
+  c.queueToVatExport(
+    '_bootstrap',
+    'o+0',
+    'bundleExplode',
+    capargs(['allocate']),
+  );
+  await c.run();
+
+  t.deepEqual(
+    nextLog(),
+    [
+      'did explode: RangeError: Allocate meter exceeded',
+      'terminated: RangeError: Allocate meter exceeded',
+    ],
+    'grandchild go boom',
+  );
+
+  // the whole vat should be dead (we use 'run' instead of 'bundleRun')
+  c.queueToVatExport('_bootstrap', 'o+0', 'run', capargs([]));
+  await c.run();
+  t.deepEqual(
+    nextLog(),
+    ['run exploded: RangeError: Allocate meter exceeded'],
+    'whole dynamic vat is dead',
+  );
+
+  t.end();
+});

--- a/packages/SwingSet/test/metering/test-metering.js
+++ b/packages/SwingSet/test/metering/test-metering.js
@@ -109,7 +109,7 @@ tap.test('metering a single bundle', async function testSingleBundle(t) {
   } = await meteredImportBundle(bundle, endowments);
 
   const log2 = [];
-  const meterMe = ns.default;
+  const meterMe = ns.meterMe;
   // console.log(`running without explosion`);
   let ok = await runBundleThunkUnderMeter(() => meterMe(log2, 'no'));
   t.deepEqual(log2, ['started', 'done'], 'computation completed');

--- a/packages/SwingSet/test/metering/vat-load-dynamic.js
+++ b/packages/SwingSet/test/metering/vat-load-dynamic.js
@@ -40,6 +40,29 @@ function build(buildStuff) {
         log(`did explode: ${err}`);
       }
     },
+
+    async load(grandchildBundle) {
+      await E(control.root).load(grandchildBundle);
+      return 'ok';
+    },
+
+    async bundleRun() {
+      try {
+        await E(control.root).meterThem('no');
+        log('did run');
+      } catch (err) {
+        log(`run exploded: ${err}`);
+      }
+    },
+
+    async bundleExplode(how) {
+      try {
+        await E(control.root).meterThem(how);
+        log('failed to explode');
+      } catch (err) {
+        log(`did explode: ${err}`);
+      }
+    },
   });
 }
 

--- a/packages/SwingSet/test/metering/vat-within.js
+++ b/packages/SwingSet/test/metering/vat-within.js
@@ -42,7 +42,7 @@ function build(buildStuff) {
         transforms: [src => transformMetering(src, getMeter)],
       });
       // console.log('ns', ns);
-      meterMe = ns.default;
+      meterMe = ns.meterMe;
       log('imported');
     },
 

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -19,6 +19,9 @@
     "esm": "^3.2.5",
     "tap": "^14.10.5"
   },
+  "peerDependencies": {
+    "ses": "^0.9.1"
+  },
   "files": [
     "README.md",
     "LICENSE",

--- a/packages/import-bundle/src/compartment-wrapper.js
+++ b/packages/import-bundle/src/compartment-wrapper.js
@@ -1,0 +1,70 @@
+export function wrapInescapableCompartment(
+  OldCompartment,
+  inescapableTransforms,
+  inescapableGlobalLexicals,
+) {
+  // This is the new Compartment constructor. We name it `Compartment` so
+  // that it's .name property is correct, but we hold it in 'NewCompartment'
+  // so that lint doesn't think we're shadowing the original.
+  const NewCompartment = function Compartment(
+    endowments,
+    modules,
+    oldOptions = {},
+  ) {
+    const {
+      transforms: oldTransforms = [],
+      globalLexicals: oldGlobalLexicals = {},
+      ...otherOptions
+    } = oldOptions;
+    const newTransforms = [...oldTransforms, ...inescapableTransforms];
+    const newGlobalLexicals = {
+      ...oldGlobalLexicals,
+      ...inescapableGlobalLexicals,
+    };
+    const newOptions = {
+      ...otherOptions,
+      transforms: newTransforms,
+      globalLexicals: newGlobalLexicals,
+    };
+
+    // The real Compartment is defined as a class, so 'new Compartment()'
+    // works but not 'Compartment()'. We can behave the same way. It would be
+    // nice to delegate the 'throw' to the original constructor by knowing
+    // calling it the wrong way, but I don't know how to do that.
+    if (new.target === undefined) {
+      // `newCompartment` was called as a function
+      throw Error('Compartment must be called as a constructor');
+    }
+
+    // It, or a subclass, was called as a constructor
+
+    const c = Reflect.construct(
+      OldCompartment,
+      [endowments, modules, newOptions],
+      new.target,
+    );
+    // The confinement applies to all compartments too. This relies upon the
+    // child's normal Compartment behaving the same way as the parent's,
+    // which will cease to be the case soon (their module tables are
+    // different). TODO: update this when that happens, we need something
+    // like c.globalThis.Compartment = wrap(c.globalThis.Compartment), but
+    // there are details to work out.
+    c.globalThis.Compartment = NewCompartment;
+
+    return c;
+  };
+
+  // ensure `(c isinstance Compartment)` remains true
+  NewCompartment.prototype = OldCompartment.prototype;
+
+  // SECURITY NOTE: if this were used outside of SES, this might leave
+  // c.prototype.constructor pointing at the original (untamed) Compartment,
+  // which would allow a breach. Kris says this will be hard to fix until he
+  // rewrites the compartment shim, possibly as a plain function instead of a
+  // class. Under SES, OldCompartment.prototype.constructor is tamed
+
+  return NewCompartment;
+}
+
+// swingset would do this to each dynamic vat
+//  c.globalThis.Compartment = wrapCompartment(c.globalThis.Compartment, ..);

--- a/packages/import-bundle/src/compartment-wrapper.md
+++ b/packages/import-bundle/src/compartment-wrapper.md
@@ -1,0 +1,81 @@
+# Compartment Wrapper
+
+Impose inescapable options on a `Compartment`.
+
+[compartment][Compartments] provide a way to evaluate ECMAScript code against a specific global object, which can be used to limit that code's authority by simply removing access to host-provided IO properties like `Request`.
+
+Compartments can also apply a transform to all the code they evaluate, and provide additional global lexicals to its environment, which can futher control its behavior. For example, the transform might inject a "metering check" into the beginning of each block, which decrements a counter and throws an exception if it underflows. This can be used to prevent the confined code from consuming excessive CPU.
+
+The Compartment's configured transform will be applied to any code evaluated through external calls to `c.evaluate(code)` and `c.import(module)`. It will also be applied to internal evaluations via `eval(code)` and `new Function(code)`. However, the transforms and other options are not automatically propagated to new child Compartments.
+
+To prevent code from escaping a transform by evaluating its code in a new child `Compartment`, the creator of the confined compartment must replace its `Compartment` constructor with a wrapped version. The wrapper will modify the arguments to include the transforms (and other options). It must merge the provided options with the imposed ones in the right order, to ensure they cannot be overridden (i.e. the imposed transforms must appear at the *end* of the list). Finally, it must also propogate the wrapper itself to the new child Compartment, by modifying `c.thisGlobal.Compartment` on each newly created compartment.
+
+This module provides a function to create a `Compartment` constructor that enforces a set of "inescapable options".
+
+
+## Usage
+
+```js
+import { wrapInescapableCompartment } from '.../compartment-wrapper';
+
+// Allow oldSrc to increment the odometer, but not read it. SES offers much
+// easier ways to do this, of course.
+
+function milageTransform(oldSrc) {
+  if (oldSrc.indexOf('getOdometer') !== -1) {
+    throw Error(`forbidden access to 'getOdometer' in oldSrc`);
+  }
+  return oldSrc.replace(/addMilage\(\)/g, 'getOdometer().add(1)');
+}
+
+// add a lexical that the original code cannot reach
+function makeOdometer() {
+  let counter = 0;
+  function add(count) {
+    counter += count;
+  }
+  function read() {
+    return counter;
+  }
+  return { add, read };
+}
+const odometer = makeOdometer();
+function getOdometer() {
+  return odometer;
+}
+
+const inescapableTransforms = [milageTransform];
+const inescapableGlobalLexicals = { getOdometer };
+const WrappedCompartment = wrapInescapableCompartment(Compartment,
+                                                      inescapableTransforms,
+                                                      inescapableGlobalLexicals);
+const endowments = {};
+const modules = {};
+const options = {};
+const c = new WrappedCompartment(endowments, modules, options);
+c.evaluate(confinedCode);
+// c.import(confinedModule);
+```
+
+If `confinedCode` creates its own Compartment with something like:
+
+```js
+const c2 = new Compartment(endowments, modules, { transforms, globalLexicals });
+```
+
+then its Compartment constructor will actually be invoked like this:
+
+```js
+new Compartment(endowments, modules,
+                {
+                  transforms: [...transforms, milageTransform],
+                  globalLexicals: { ...globalLexicals, getOdometer },
+                });
+```
+
+except that it could not make such an invocation itself, because it won't have access to `milageTransform` (which doesn't appear in the globals or global lexicals), or `getOdometer` (which *does* appear in the global lexicals, but the transform ensures that it cannot be reached by the pre-transformed `confinedCode`).
+
+
+
+  [Compartments]: https://github.com/Agoric/SES-shim/blob/master/packages/ses/README.md#compartment
+  [SES]: https://github.com/Agoric/SES-shim/blob/master/packages/ses/README.md

--- a/packages/import-bundle/test/test-compartment-wrapper.js
+++ b/packages/import-bundle/test/test-compartment-wrapper.js
@@ -1,0 +1,150 @@
+/* global Compartment */
+import '@agoric/install-ses';
+import tap from 'tap';
+import { wrapInescapableCompartment } from '../src/compartment-wrapper.js';
+
+const { test } = tap;
+
+// We build a transform that allows oldSrc to increment the odometer, but not
+// read it. Note, of course, that SES provides a far easier way to accomplish
+// this (pass in a hardened `addMilage` endowment), but there are metering
+// use cases that don't involve voluntary participation by oldSrc.
+
+function milageTransform(oldSrc) {
+  if (oldSrc.indexOf('getOdometer') !== -1) {
+    throw Error(`forbidden access to 'getOdometer' in oldSrc`);
+  }
+  return oldSrc.replace(/addMilage\(\)/g, 'getOdometer().add(1)');
+}
+
+// add a lexical that the original code cannot reach
+function makeOdometer() {
+  let counter = 0;
+  function add(count) {
+    counter += count;
+  }
+  function reset() {
+    counter = 0; // forbidden
+  }
+  function read() {
+    return counter;
+  }
+  return { add, read, reset };
+}
+
+const createChild = `() => new Compartment({console})`;
+const doAdd = `addMilage()`;
+const doAddInChild = `(doAdd) => (new Compartment({console})).evaluate(doAdd)`;
+const attemptReset = `() => getOdometer().reset()`;
+const attemptResetInChild = `(attemptReset) => {
+  const c = new Compartment();
+  c.evaluate(attemptReset)();
+}`;
+
+// attempt to shadow 'getOdometer' (blocked by the inescapable lexical coming
+// last)
+const attemptResetByShadow = `(doAdd) => {
+  const taboo = 'get' + 'Odometer';
+  let fakeCalled = false;
+  function fakeGet() {
+    fakeCalled = true;
+    return {
+       add(_) {addMilage(); addMilage();},
+    };
+  }
+  const globalLexicals = { [taboo]: fakeGet };
+
+  const c = new Compartment({ console }, {}, { globalLexicals });
+  c.evaluate(doAdd);
+  return fakeCalled;
+}`;
+
+// attempt to undo the transform (blocked by the inescapable transform coming
+// last)
+const attemptResetByTransform = `() => {
+  const taboo = 'get' + 'Odometer';
+  function transform(oldSrc) {
+    return oldSrc.replace(/getTaboo/g, taboo);
+  }
+  const transforms = [ transform ];
+  const c = new Compartment({ console }, {}, { transforms });
+  c.evaluate('getTaboo().reset()');
+}`;
+
+function check(t, c, odometer, n) {
+  t.equal(odometer.read(), 0, `${n}.start`);
+  c.evaluate(doAdd);
+  t.equal(odometer.read(), 1, `${n}.doAdd`);
+  odometer.reset();
+
+  c.evaluate(doAddInChild)(doAdd);
+  t.equal(odometer.read(), 1, `${n}.doAddInChild`);
+  odometer.reset();
+
+  odometer.add(5);
+  t.throws(
+    () => c.evaluate(attemptReset)(),
+    /forbidden access/,
+    `${n}.attemptReset`,
+  );
+  t.equal(odometer.read(), 5, `${n}  not reset`);
+
+  t.throws(
+    () => c.evaluate(attemptResetInChild)(attemptReset),
+    /forbidden access/,
+    `${n}.attemptResetInChild`,
+  );
+  t.equal(odometer.read(), 5, `${n}  not reset`);
+  odometer.reset();
+
+  const fakeCalled = c.evaluate(attemptResetByShadow)(doAdd);
+  t.notOk(fakeCalled, `${n}.attemptResetByShadow`);
+  t.equal(odometer.read(), 1, `${n}  called anyway`);
+  odometer.reset();
+
+  odometer.add(5);
+  t.throws(
+    () => c.evaluate(attemptResetByTransform)(),
+    /forbidden access/,
+    `${n}.attemptResetByTransform`,
+  );
+  t.equal(odometer.read(), 5, `${n}  not reset`);
+  odometer.reset();
+
+  t.equal(
+    c.evaluate('Compartment.name'),
+    'Compartment',
+    `${n}.Compartment.name`,
+  );
+
+  t.ok(c instanceof Compartment, `${n} instanceof`);
+
+  const Con = Object.getPrototypeOf(c.globalThis.Compartment).constructor;
+  t.throws(() => new Con(), /Not available/, `${n} .constructor is tamed`);
+}
+
+test('wrap', t => {
+  const odometer = makeOdometer();
+  function getOdometer() {
+    return odometer;
+  }
+
+  const inescapableTransforms = [milageTransform];
+  const inescapableGlobalLexicals = { getOdometer };
+  const WrappedCompartment = wrapInescapableCompartment(
+    Compartment,
+    inescapableTransforms,
+    inescapableGlobalLexicals,
+  );
+  const endowments = { console };
+  const c1 = new WrappedCompartment(endowments);
+  check(t, c1, odometer, 'c1');
+
+  const c2 = c1.evaluate(createChild)();
+  check(t, c2, odometer, 'c2');
+
+  const c3 = c2.evaluate(createChild)();
+  check(t, c3, odometer, 'c3');
+
+  t.end();
+});

--- a/packages/import-bundle/test/test-import-bundle.js
+++ b/packages/import-bundle/test/test-import-bundle.js
@@ -97,3 +97,45 @@ tap.test('test missing sourceMap', async function testImport(t) {
   tap.equal(ns1.f1(1), 2, `missing sourceMap ns.f1 ok`);
   t.end();
 });
+
+tap.test('inescapable transforms', async function testInescapableTransforms(t) {
+  const b1 = await bundleSource(
+    require.resolve('./bundle1.js'),
+    'nestedEvaluate',
+  );
+  function req(what) {
+    console.log(`require(${what})`);
+  }
+  harden(Object.getPrototypeOf(console));
+  const endowments = { require: req, console };
+
+  const ns = await importBundle(b1, {
+    endowments,
+    inescapableTransforms: [transform1],
+  });
+  tap.equal(ns.f4('is ok'), 'substitution is ok', `iT ns.f4 ok`);
+  t.end();
+});
+
+tap.test(
+  'inescapable globalLexicals',
+  async function testInescapableGlobalLexicals(t) {
+    const b1 = await bundleSource(
+      require.resolve('./bundle1.js'),
+      'nestedEvaluate',
+    );
+    function req(what) {
+      console.log(`require(${what})`);
+    }
+    harden(Object.getPrototypeOf(console));
+    const endowments = { require: req, console };
+
+    const ns = await importBundle(b1, {
+      endowments,
+      inescapableGlobalLexicals: { endow1: 3 },
+    });
+    tap.equal(ns.f3(1), 4, `iGL ns.f3 ok`);
+
+    t.end();
+  },
+);


### PR DESCRIPTION
As described in #1296, we need any metered Compartment to impose metering upon any new child Compartments it creates. Otherwise the contract code can escape metering by just evaluating the infinite loop in a child compartment.

This is needed even earlier, to make sure the contract code is metered at all. The dynamic vat is created with the ZCF code (which *is* metered), and ZCF creates a new (hitherto unmetered) child Compartment to hold the contract.

I started out putting the compartment wrapper in the SES-shim repo, where it could be used more widely, but then I backpedalled about chosing a name to publish it with. We'll let it live here in agoric-sdk, as an unpublished internal module of the `@agoric/import-bundle` package, until we know enough about it's potential generality to publish it on its own.

Note that the wrapper depends upon the current behavior of SES (specifically that all compartments have equivalent `Compartment` constructors, which will change when https://github.com/Agoric/SES-shim/issues/366 is implemented. At that time we'll need to change the wrapper (to wrap each compartment's `c.globalThis.Compartment` separately).

closes #1296 
obsoletes refs https://github.com/Agoric/SES-shim/issues/377
obsoletes refs https://github.com/Agoric/SES-shim/pull/383
