### PR TITLE
refactor(assert): clearer typing

### DIFF
--- a/packages/assert/jsconfig.json
+++ b/packages/assert/jsconfig.json
@@ -1,0 +1,11 @@
+// This file can contain .js-specific Typescript compiler config.
+{
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "downlevelIteration": true,
+    "strictNullChecks": true,
+  },
+  "include": ["src/*.js"],
+}

--- a/packages/assert/jsconfig.json
+++ b/packages/assert/jsconfig.json
@@ -1,11 +1,11 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "compilerOptions": {
-    "noEmit": false,
+    // "noEmit": false,
     "declaration": true,
-    "emitDeclarationOnly": true,
+    // "emitDeclarationOnly": true,
     "downlevelIteration": true,
     "strictNullChecks": true,
   },
-  "include": ["src/*.js"],
+  "include": ["src/**/*.js", "exported.js"],
 }

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -7,7 +7,7 @@
     "node": ">=11.0"
   },
   "scripts": {
-    "build": "exit 0",
+    "build": "tsc -p jsconfig.json",
     "test": "tape -r esm test/**/test*.js",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint-check": "eslint '**/*.js'",

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -49,6 +49,9 @@
     "env": {
       "es6": true
     },
+    "globals": {
+      "harden": "readonly"
+    },
     "rules": {
       "implicit-arrow-linebreak": "off",
       "function-paren-newline": "off",

--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -2,9 +2,6 @@
 
 // @ts-check
 
-// eslint-disable-next-line spaced-comment
-/// <reference types="ses"/>
-
 // This module assumes the de-facto standard `console` host object.
 // To the extent that this `console` is considered a resource,
 // this module must be considered a resource module.
@@ -217,63 +214,6 @@ function equal(
 ) {
   assert(Object.is(actual, expected), optDetails);
 }
-
-// Type all the overloads of the assertTypeof function.
-// There may eventually be a better way to do this, but
-// thems the breaks with Typescript 4.0.
-/**
- * @callback AssertTypeofBigint
- * @param {any} specimen
- * @param {'bigint'} typename
- * @param {Details} [optDetails]
- * @returns {asserts specimen is bigint}
- *
- * @callback AssertTypeofBoolean
- * @param {any} specimen
- * @param {'boolean'} typename
- * @param {Details} [optDetails]
- * @returns {asserts specimen is boolean}
- *
- * @callback AssertTypeofFunction
- * @param {any} specimen
- * @param {'function'} typename
- * @param {Details} [optDetails]
- * @returns {asserts specimen is Function}
- *
- * @callback AssertTypeofNumber
- * @param {any} specimen
- * @param {'number'} typename
- * @param {Details} [optDetails]
- * @returns {asserts specimen is number}
- *
- * @callback AssertTypeofObject
- * @param {any} specimen
- * @param {'object'} typename
- * @param {Details} [optDetails]
- * @returns {asserts specimen is object}
- *
- * @callback AssertTypeofString
- * @param {any} specimen
- * @param {'string'} typename
- * @param {Details} [optDetails]
- * @returns {asserts specimen is string}
- *
- * @callback AssertTypeofSymbol
- * @param {any} specimen
- * @param {'symbol'} typename
- * @param {Details} [optDetails]
- * @returns {asserts specimen is symbol}
- *
- * @callback AssertTypeofUndefined
- * @param {any} specimen
- * @param {'undefined'} typename
- * @param {Details} [optDetails]
- * @returns {asserts specimen is undefined}
- */
-
-/**
- * @typedef {AssertTypeofBigint & AssertTypeofBoolean & AssertTypeofFunction & AssertTypeofNumber & AssertTypeofObject & AssertTypeofString & AssertTypeofSymbol & AssertTypeofUndefined} AssertTypeof
- */
 
 /**
  * Assert an expected typeof result.

--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -269,7 +269,9 @@ function equal(
  * @param {'undefined'} typename
  * @param {Details} [optDetails]
  * @returns {asserts specimen is undefined}
- *
+ */
+
+/**
  * @typedef {AssertTypeofBigint & AssertTypeofBoolean & AssertTypeofFunction & AssertTypeofNumber & AssertTypeofObject & AssertTypeofString & AssertTypeofSymbol & AssertTypeofUndefined} AssertTypeof
  */
 

--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -1,8 +1,9 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
-/* global harden */
-
 // @ts-check
+
+// eslint-disable-next-line spaced-comment
+/// <reference types="ses"/>
 
 // This module assumes the de-facto standard `console` host object.
 // To the extent that this `console` is considered a resource,
@@ -123,7 +124,7 @@ harden(q);
  *
  * @typedef {string|Complainer} Details Either a plain string, or made by details``
  *
- * @param {TemplateStringsArray} template The template to format
+ * @param {TemplateStringsArray | string[]} template The template to format
  * @param {any[]} args Arguments to the template
  * @returns {Complainer} The complainer for these details
  */
@@ -145,7 +146,7 @@ function details(template, ...args) {
 
         // Remove the extra spaces (since console.error puts them
         // between each interleaved).
-        const priorWithoutSpace = interleaved.pop().replace(/ $/, '');
+        const priorWithoutSpace = (interleaved.pop() || '').replace(/ $/, '');
         if (priorWithoutSpace !== '') {
           interleaved.push(priorWithoutSpace);
         }
@@ -212,10 +213,11 @@ function fail(optDetails = details`Assert failed`) {
  * with the nodejs assertion library.
  * @param {*} flag The truthy/falsy value
  * @param {Details} [optDetails] The details to throw
+ * @returns {asserts flag}
  */
 function assert(flag, optDetails = details`Check failed`) {
   if (!flag) {
-    fail(optDetails);
+    throw fail(optDetails);
   }
 }
 
@@ -224,6 +226,7 @@ function assert(flag, optDetails = details`Check failed`) {
  * @param {*} actual The value we received
  * @param {*} expected What we wanted
  * @param {Details} [optDetails] The details to throw
+ * @returns {asserts actual is expected}
  */
 function equal(
   actual,

--- a/packages/assert/src/types.js
+++ b/packages/assert/src/types.js
@@ -1,0 +1,59 @@
+// eslint-disable-next-line spaced-comment
+/// <reference types="ses"/>
+
+// Type all the overloads of the assertTypeof function.
+// There may eventually be a better way to do this, but
+// thems the breaks with Typescript 4.0.
+/**
+ * @callback AssertTypeofBigint
+ * @param {any} specimen
+ * @param {'bigint'} typename
+ * @param {Details} [optDetails]
+ * @returns {asserts specimen is bigint}
+ *
+ * @callback AssertTypeofBoolean
+ * @param {any} specimen
+ * @param {'boolean'} typename
+ * @param {Details} [optDetails]
+ * @returns {asserts specimen is boolean}
+ *
+ * @callback AssertTypeofFunction
+ * @param {any} specimen
+ * @param {'function'} typename
+ * @param {Details} [optDetails]
+ * @returns {asserts specimen is Function}
+ *
+ * @callback AssertTypeofNumber
+ * @param {any} specimen
+ * @param {'number'} typename
+ * @param {Details} [optDetails]
+ * @returns {asserts specimen is number}
+ *
+ * @callback AssertTypeofObject
+ * @param {any} specimen
+ * @param {'object'} typename
+ * @param {Details} [optDetails]
+ * @returns {asserts specimen is object}
+ *
+ * @callback AssertTypeofString
+ * @param {any} specimen
+ * @param {'string'} typename
+ * @param {Details} [optDetails]
+ * @returns {asserts specimen is string}
+ *
+ * @callback AssertTypeofSymbol
+ * @param {any} specimen
+ * @param {'symbol'} typename
+ * @param {Details} [optDetails]
+ * @returns {asserts specimen is symbol}
+ *
+ * @callback AssertTypeofUndefined
+ * @param {any} specimen
+ * @param {'undefined'} typename
+ * @param {Details} [optDetails]
+ * @returns {asserts specimen is undefined}
+ */
+
+/**
+ * @typedef {AssertTypeofBigint & AssertTypeofBoolean & AssertTypeofFunction & AssertTypeofNumber & AssertTypeofObject & AssertTypeofString & AssertTypeofSymbol & AssertTypeofUndefined} AssertTypeof
+ */

--- a/packages/assert/test/throwsAndLogs.js
+++ b/packages/assert/test/throwsAndLogs.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 const { defineProperty } = Object;
 
 // Patterned after


### PR DESCRIPTION
Use Typescript 3.7 to provide the 'asserts XXX' type to the assert function.  This helps ensure that callers who assert don't get warned about a variable being falsy later in the control flow.

Also, add the `harden` global and SES typing of it, mainly as an example of how to do this elsewhere.