### PR TITLE
feat(agoric): make `agoric --sdk install` use `yarn link`

### DIFF
--- a/packages/agoric-cli/integration-tests/test-workflow.js
+++ b/packages/agoric-cli/integration-tests/test-workflow.js
@@ -137,7 +137,7 @@ test('workflow', async t => {
       ]);
       finalizers.push(() => pkill(deployP.cp, 'SIGINT'));
 
-      timeout = setTimeout(deployResult.resolve, 30000, 'timeout');
+      timeout = setTimeout(deployResult.resolve, 60000, 'timeout');
       const done = await Promise.race([deployResult.promise, deployP]);
       t.equals(done, 0, `deploy successful before timeout`);
       clearTimeout(timeout);

--- a/packages/agoric-cli/lib/install.js
+++ b/packages/agoric-cli/lib/install.js
@@ -23,13 +23,16 @@ export default async function installMain(progname, rawArgs, powers, opts) {
       const dir = `${sdkPackagesDir}/${pkg}`;
       let packageJSON;
       try {
+        // eslint-disable-next-line no-await-in-loop
         packageJSON = await fs.readFile(`${dir}/package.json`);
       } catch (e) {
+        // eslint-disable-next-line no-continue
         continue;
       }
       if (packageJSON) {
         const pj = JSON.parse(packageJSON);
         if (!pj.private) {
+          // eslint-disable-next-line no-await-in-loop
           if (await pspawn('yarn', ['link'], { stdio: 'inherit', cwd: dir })) {
             log.error('Cannot yarn link', dir);
             return 1;
@@ -47,7 +50,13 @@ export default async function installMain(progname, rawArgs, powers, opts) {
     );
     const sdkPackages = [...packages.values()].sort();
     for (const subdir of subdirs) {
-      if (await pspawn('yarn', ['link', ...sdkPackages], { stdio: 'inherit', cwd: subdir })) {
+      if (
+        // eslint-disable-next-line no-await-in-loop
+        await pspawn('yarn', ['link', ...sdkPackages], {
+          stdio: 'inherit',
+          cwd: subdir,
+        })
+      ) {
         log.error('Cannot yarn link', ...sdkPackages);
         return 1;
       }

--- a/packages/agoric-cli/lib/install.js
+++ b/packages/agoric-cli/lib/install.js
@@ -16,32 +16,57 @@ export default async function installMain(progname, rawArgs, powers, opts) {
   const subdirs = ['.', '_agstate/agoric-servers', 'contract', 'api'].sort();
 
   if (opts.sdk) {
-    const sdkNodeModules = path.resolve(__dirname, '../../../node_modules');
-    await Promise.all(
-      subdirs.map(subdir => {
-        const nm = `${subdir}/node_modules`;
-        log(chalk.bold.green(`removing ${nm}`));
-        return rimraf(nm).then(_ => {
-          log(chalk.bold.green(`link SDK ${nm}`));
-          return fs.symlink(sdkNodeModules, nm);
-        });
-      }),
-    );
-  } else {
-    // Delete any symlinks.
-    await Promise.all(
-      subdirs.map(subdir => {
-        const nm = `${subdir}/node_modules`;
-        log(chalk.bold.green(`removing ${nm}`));
-        return fs.unlink(nm).catch(_ => {});
-      }),
-    );
-
-    if (await pspawn('yarn', ['install'], { stdio: 'inherit' })) {
-      // Try to install via Yarn.
-      log.error('Cannot yarn install');
-      return 1;
+    const sdkPackagesDir = path.resolve(__dirname, '../../../packages');
+    const allPackages = await fs.readdir(sdkPackagesDir);
+    const packages = new Map();
+    for (const pkg of allPackages) {
+      const dir = `${sdkPackagesDir}/${pkg}`;
+      let packageJSON;
+      try {
+        packageJSON = await fs.readFile(`${dir}/package.json`);
+      } catch (e) {
+        continue;
+      }
+      if (packageJSON) {
+        const pj = JSON.parse(packageJSON);
+        if (!pj.private) {
+          if (await pspawn('yarn', ['link'], { stdio: 'inherit', cwd: dir })) {
+            log.error('Cannot yarn link', dir);
+            return 1;
+          }
+          packages.set(pkg, pj.name);
+        }
+      }
     }
+    await Promise.all(
+      subdirs.map(subdir => {
+        const nm = `${subdir}/node_modules`;
+        log(chalk.bold.green(`removing ${nm}`));
+        return rimraf(nm);
+      }),
+    );
+    const sdkPackages = [...packages.values()].sort();
+    for (const subdir of subdirs) {
+      if (await pspawn('yarn', ['link', ...sdkPackages], { stdio: 'inherit', cwd: subdir })) {
+        log.error('Cannot yarn link', ...sdkPackages);
+        return 1;
+      }
+    }
+  } else {
+    // Delete all old node_modules.
+    await Promise.all(
+      subdirs.map(subdir => {
+        const nm = `${subdir}/node_modules`;
+        log(chalk.bold.green(`removing ${nm}`));
+        return rimraf(nm);
+      }),
+    );
+  }
+
+  if (await pspawn('yarn', ['install'], { stdio: 'inherit' })) {
+    // Try to install via Yarn.
+    log.error('Cannot yarn install');
+    return 1;
   }
 
   if (await pspawn('yarn', ['install'], { stdio: 'inherit', cwd: 'ui' })) {


### PR DESCRIPTION
This makes it possible to have dapp package dependencies diverge
from agoric-sdk's.

The necessary diff for dapp-encouragement is: https://github.com/Agoric/dapp-encouragement/compare/daa362...34abf0