### PR TITLE
build: check against latest 12.x and 14.x

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,6 +18,13 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: '12.x'
+    - name: cache node modules
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/yarn
+        key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
 
     # 'yarn install' must be done at the top level, to build all the
     # cross-package symlinks

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,18 +15,10 @@ jobs:
 
 # Prerequisites
 
-    # FIXME: Reenable after 2020-04-01 when Github cache doesn't take forever.
-    #- name: cache Go modules
-    #  uses: actions/cache@v1
-    #  with:
-    #    path: ~/go/pkg/mod
-    #    key: ${{ runner.os }}-go-${{ hashFiles('packages/cosmic-swingset/go.sum') }}
-    #    restore-keys: |
-    #      ${{ runner.os }}-go-
-
     - uses: actions/setup-node@v1
       with:
-        node-version: '12.16.1'
+        node-version: '12.x'
+
     # 'yarn install' must be done at the top level, to build all the
     # cross-package symlinks
     - run: yarn install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
       with:
-        node-version: '12.16.1'
+        node-version: '12.x'
 
     # FIXME: Reenable after 2020-04-01 when Github cache doesn't take forever.
     #- name: cache node modules

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,18 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+
     - uses: actions/setup-node@v1
       with:
         node-version: '12.x'
-
-    # FIXME: Reenable after 2020-04-01 when Github cache doesn't take forever.
-    #- name: cache node modules
-    #  uses: actions/cache@v1
-    #  with:
-    #    path: ~/.cache/yarn
-    #    key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
-    #    restore-keys: |
-    #      ${{ runner.os }}-yarn-
+    - name: cache node modules
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/yarn
+        key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
 
     # 'yarn install' must be done at the top level, to build all the
     # cross-package symlinks

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   test-all:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['12.16.1', '12.x']
     steps:
     - uses: actions/checkout@v1
 

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+
     - uses: actions/setup-node@v1
       with:
         node-version: '12.x'
-
     - name: cache node modules
       uses: actions/cache@v1
       with:

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -9,36 +9,21 @@ on:
  pull_request:
 
 jobs:
-  build:
+  test-all:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
       with:
-        node-version: '12.16.1'
+        node-version: '12.x'
 
-    # FIXME: Reenable after 2020-04-01 when Github cache doesn't take forever.
-    #- name: cache node modules
-    #  uses: actions/cache@v1
-    #  with:
-    #    path: ~/.cache/yarn
-    #    key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
-    #    restore-keys: |
-    #      ${{ runner.os }}-yarn-
-
-    - name: Set up Go 1.14
-      uses: actions/setup-go@v1
+    - name: cache node modules
+      uses: actions/cache@v1
       with:
-        go-version: 1.14
-
-    # FIXME: Reenable after 2020-04-01 when Github cache doesn't take forever.
-    #- name: cache Go modules
-    #  uses: actions/cache@v1
-    #  with:
-    #    path: ~/go/pkg/mod
-    #    key: ${{ runner.os }}-go-${{ hashFiles('packages/cosmic-swingset/go.sum') }}
-    #    restore-keys: |
-    #      ${{ runner.os }}-go-
+        path: ~/.cache/yarn
+        key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
 
     # 'yarn install' must be done at the top level, to build all the
     # cross-package symlinks

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -25,6 +25,18 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-yarn-
 
+    - name: Set up Go 1.14
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.14
+    - name: cache Go modules
+      uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('packages/cosmic-swingset/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
     # 'yarn install' must be done at the top level, to build all the
     # cross-package symlinks
     - name: yarn install

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['12.16.1', '12.x']
+        node-version: ['12.16.1', '12.x', '14.x']
     steps:
     - uses: actions/checkout@v1
 

--- a/.github/workflows/test-dapp-encouragement.yml
+++ b/.github/workflows/test-dapp-encouragement.yml
@@ -19,7 +19,6 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-        check-latest: true
     - name: Checkout agoric-sdk
       uses: actions/checkout@v2
 

--- a/.github/workflows/test-dapp-encouragement.yml
+++ b/.github/workflows/test-dapp-encouragement.yml
@@ -15,12 +15,21 @@ jobs:
       matrix:
         node-version: ['12.x', '14.x']
     steps:
+
+    - name: Checkout agoric-sdk
+      uses: actions/checkout@v2
+
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: Checkout agoric-sdk
-      uses: actions/checkout@v2
+    - name: cache node modules
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/yarn
+        key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
 
     # Select a branch on dapp-encouragement to test against by adding text to the body of the
     # pull request. For example: #dapp-encouragement-branch: zoe-release-0.7.0

--- a/.github/workflows/test-dapp-encouragement.yml
+++ b/.github/workflows/test-dapp-encouragement.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['12.x', '14.x']
+        node-version: ['12.16.1', '12.x', '14.x']
     steps:
 
     - name: Checkout agoric-sdk

--- a/.github/workflows/test-dapp-encouragement.yml
+++ b/.github/workflows/test-dapp-encouragement.yml
@@ -22,10 +22,6 @@ jobs:
         check-latest: true
     - name: Checkout agoric-sdk
       uses: actions/checkout@v2
-    - name: Set up Go 1.13
-      uses: actions/setup-go@v1
-      with:
-        go-version: 1.13
 
     # Select a branch on dapp-encouragement to test against by adding text to the body of the
     # pull request. For example: #dapp-encouragement-branch: zoe-release-0.7.0

--- a/.github/workflows/test-dapp-encouragement.yml
+++ b/.github/workflows/test-dapp-encouragement.yml
@@ -9,16 +9,17 @@ on:
  pull_request:
 
 jobs:
-  build:
+  dapp-encouragement:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.18.0, 14.4.0]
+        node-version: ['12.x', '14.x']
     steps:
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+        check-latest: true
     - name: Checkout agoric-sdk
       uses: actions/checkout@v2
     - name: Set up Go 1.13


### PR DESCRIPTION
This change has dapp-encouragement tested against the latest Node.js in the 12.x and 14.x lineage.

Also, reenable Yarn and Go caches.
