### PR TITLE
fix(marshal): make toString and Symbol.toStringTag non-enumerable

### DIFF
--- a/packages/marshal/marshal.js
+++ b/packages/marshal/marshal.js
@@ -726,9 +726,11 @@ function Remotable(iface = 'Remotable', props = {}, remotable = {}) {
     Object.create(oldRemotableProto, {
       toString: {
         value: toString,
+        enumerable: false,
       },
       [Symbol.toStringTag]: {
         value: allegedName,
+        enumerable: false,
       },
     }),
   );


### PR DESCRIPTION
~~Make `Object.keys(remotable)` return `[]`.~~

~~This was an oversight when making `Object.getOwnPropertyDescriptors(remotable)` return `[]` by moving these properties to the remotable's prototype, but still making them enumerable.~~

Just a minor hygienic cleanup.  No need for panic.