### PR TITLE
remove 'require' from vat endowments, remove 'harden' from kernelRequire

### DIFF
--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -117,9 +117,7 @@ export async function buildVatController(config, argv = []) {
   harden(console);
 
   function kernelRequire(what) {
-    if (what === '@agoric/harden') {
-      return harden;
-    } else if (what === 're2') {
+    if (what === 're2') {
       // The kernel imports @agoric/transform-metering to get makeMeter(),
       // and transform-metering imports re2, to add it to the generated
       // endowments. TODO Our transformers no longer traffic in endowments,

--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -167,19 +167,8 @@ export async function buildVatController(config, argv = []) {
   // the same is true for the tildot transform
   const transformTildot = harden(makeTransform(babelParser, babelGenerate));
 
-  // Allow vats to import certain modules, by providing them the same values
-  // we imported here in the kernel, which came themselves from
-  // kernelRequire() defined in the controller. This will go away once
-  // 'harden' is used as a global everywhere, and vats no longer need to
-  // import anything outside their bundle.
-
-  function vatRequire(what) {
-    throw Error(`vatRequire unprepared to satisfy require(${what})`);
-  }
-
   function makeVatEndowments(consoleTag) {
     return harden({
-      require: vatRequire,
       console: makeConsole(`SwingSet:${consoleTag}`),
       HandledPromise,
       // re2 is a RegExp work-a-like that disables backtracking expressions for


### PR DESCRIPTION
Now that vats (and the kernel) get their `harden` from a global, they no longer need to be able to do `import harden from '@agoric/harden'`, nor the `require('@agoric/harden')` which rollup transforms that into. This PR removes harden from the list of things that `kernelRequire` honors.

Vats no longer use `require` at all, so we also remove `require` from the list of `vatEndowments` which all vats receive. All vats must be self-contained, with no "externals" or `require` left in the source bundle.

The kernel still imports code (`transform-metering`) which imports `re2`, so we can't remove `kernelRequire` or `kernelEndowments.require` yet.
