### PR TITLE
fix: rename produceNotifier to makeNotifierKit

### DIFF
--- a/packages/notifier/src/notifier.js
+++ b/packages/notifier/src/notifier.js
@@ -56,7 +56,7 @@ import { producePromise } from '@agoric/produce-promise';
  * @param {T} [initialState] the first state to be returned
  * @returns {NotifierRecord<T>} the notifier and updater
  */
-export const produceNotifier = (initialState = undefined) => {
+export const makeNotifierKit = (initialState = undefined) => {
   let currentPromiseRec = producePromise();
   let currentResponse = harden({
     value: initialState,
@@ -104,3 +104,7 @@ export const produceNotifier = (initialState = undefined) => {
   const updater = harden({ updateState, resolve });
   return harden({ notifier, updater });
 };
+
+// Deprecated. TODO remove
+
+export { makeNotifierKit as produceNotifier };

--- a/packages/notifier/test/test-notifier.js
+++ b/packages/notifier/test/test-notifier.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 import { test } from 'tape-promise/tape';
-import { produceNotifier } from '../src/notifier';
+import { makeNotifierKit } from '../src/notifier';
 
 /**
  * @template T
@@ -11,7 +11,7 @@ import { produceNotifier } from '../src/notifier';
 
 test('notifier - initial state', async t => {
   /** @type {NotifierRecord<1>} */
-  const { notifier, updater } = produceNotifier();
+  const { notifier, updater } = makeNotifierKit();
   updater.updateState(1);
 
   const updateDeNovo = await notifier.getUpdateSince();
@@ -25,7 +25,7 @@ test('notifier - initial state', async t => {
 test('notifier - single update', async t => {
   t.plan(3);
   /** @type {NotifierRecord<number>} */
-  const { notifier, updater } = produceNotifier();
+  const { notifier, updater } = makeNotifierKit();
   updater.updateState(1);
 
   const updateDeNovo = await notifier.getUpdateSince();
@@ -45,7 +45,7 @@ test('notifier - single update', async t => {
 test('notifier - initial update', async t => {
   t.plan(3);
   /** @type {NotifierRecord<number>} */
-  const { notifier, updater } = produceNotifier(1);
+  const { notifier, updater } = makeNotifierKit(1);
 
   const updateDeNovo = notifier.getCurrentUpdate();
   t.equals(updateDeNovo.value, 1, 'initial state is one');
@@ -63,7 +63,7 @@ test('notifier - initial update', async t => {
 
 test('notifier - update after state change', async t => {
   t.plan(5);
-  const { notifier, updater } = produceNotifier(1);
+  const { notifier, updater } = makeNotifierKit(1);
 
   const updateDeNovo = notifier.getCurrentUpdate();
 
@@ -88,7 +88,7 @@ test('notifier - update after state change', async t => {
 test('notifier - final state', async t => {
   t.plan(6);
   /** @type {NotifierRecord<number|string>} */
-  const { notifier, updater } = produceNotifier(1);
+  const { notifier, updater } = makeNotifierKit(1);
 
   const updateDeNovo = notifier.getCurrentUpdate();
   const updateInWaiting = notifier.getUpdateSince(updateDeNovo.updateHandle);

--- a/packages/zoe/src/contracts/simpleExchange.js
+++ b/packages/zoe/src/contracts/simpleExchange.js
@@ -1,7 +1,7 @@
 /* global harden */
 // @ts-check
 
-import { produceNotifier } from '@agoric/notifier';
+import { makeNotifierKit } from '@agoric/notifier';
 import { makeZoeHelpers, defaultAcceptanceMsg } from '../contractSupport';
 
 /**
@@ -30,7 +30,7 @@ const makeContract = zcf => {
   let sellOfferHandles = [];
   let buyOfferHandles = [];
   // eslint-disable-next-line no-use-before-define
-  const { notifier, updater } = produceNotifier(getBookOrders());
+  const { notifier, updater } = makeNotifierKit(getBookOrders());
 
   const {
     rejectOffer,

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -5,7 +5,7 @@ import { E, HandledPromise } from '@agoric/eventual-send';
 import makeStore from '@agoric/weak-store';
 import makeIssuerKit from '@agoric/ertp';
 import { assert, details } from '@agoric/assert';
-import { produceNotifier } from '@agoric/notifier';
+import { makeNotifierKit } from '@agoric/notifier';
 import { producePromise } from '@agoric/produce-promise';
 
 import { cleanProposal, cleanKeywords } from './cleanProposal';
@@ -611,7 +611,7 @@ function makeZoe(vatAdminSvc) {
         // deposited. Keywords in the want clause are mapped to the empty
         // amount for that keyword's Issuer.
         const recordOffer = amountsArray => {
-          const notifierRec = produceNotifier();
+          const notifierRec = makeNotifierKit();
           const offerRecord = {
             instanceHandle,
             proposal: cleanedProposal,


### PR DESCRIPTION
Rename `produceNotifier` to `makeNotifierKit`.

In this case, the package name `@agoric/notifier` remains the same, so there's still the issue of dependencies outside the monorepo. To I added a deprecated transitional

```js
export { makeNotifierKit as produceNotifier };
```
