### PR TITLE
Match notifier semantics to async iterables

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/lib-wallet.js
@@ -230,8 +230,8 @@ export async function makeWallet({
   // handle the update, which has already resolved to a record. If the offer is
   // 'done', mark the offer 'complete', otherwise resubscribe to the notifier.
   function updateOrResubscribe(id, offerHandle, update) {
-    const { updateHandle, done } = update;
-    if (done) {
+    const { updateCount } = update;
+    if (updateCount === undefined) {
       // TODO do we still need these?
       idToOfferHandle.delete(id);
 
@@ -245,7 +245,7 @@ export async function makeWallet({
       idToNotifierP.delete(id);
     } else {
       E(idToNotifierP.get(id))
-        .getUpdateSince(updateHandle)
+        .getUpdateSince(updateCount)
         .then(nextUpdate => updateOrResubscribe(id, offerHandle, nextUpdate));
     }
   }

--- a/packages/notifier/test/test-notifier.js
+++ b/packages/notifier/test/test-notifier.js
@@ -31,12 +31,12 @@ test('notifier - single update', async t => {
   const updateDeNovo = await notifier.getUpdateSince();
   t.equals(updateDeNovo.value, 1, 'initial state is one');
 
-  const updateInWaiting = notifier.getUpdateSince(updateDeNovo.updateHandle);
+  const updateInWaiting = notifier.getUpdateSince(updateDeNovo.updateCount);
   const all = Promise.all([updateInWaiting]).then(([update]) => {
     t.equals(update.value, 3, 'updated state is eventually three');
   });
 
-  const update2 = await notifier.getUpdateSince({});
+  const update2 = await notifier.getUpdateSince();
   t.equals(update2.value, 1);
   updater.updateState(3);
   await all;
@@ -47,15 +47,15 @@ test('notifier - initial update', async t => {
   /** @type {NotifierRecord<number>} */
   const { notifier, updater } = makeNotifierKit(1);
 
-  const updateDeNovo = notifier.getCurrentUpdate();
+  const updateDeNovo = await notifier.getUpdateSince();
   t.equals(updateDeNovo.value, 1, 'initial state is one');
 
-  const updateInWaiting = notifier.getUpdateSince(updateDeNovo.updateHandle);
+  const updateInWaiting = notifier.getUpdateSince(updateDeNovo.updateCount);
   const all = Promise.all([updateInWaiting]).then(([update]) => {
     t.equals(update.value, 3, 'updated state is eventually three');
   });
 
-  const update2 = await notifier.getUpdateSince({});
+  const update2 = await notifier.getUpdateSince();
   t.equals(update2.value, 1);
   updater.updateState(3);
   await all;
@@ -65,22 +65,22 @@ test('notifier - update after state change', async t => {
   t.plan(5);
   const { notifier, updater } = makeNotifierKit(1);
 
-  const updateDeNovo = notifier.getCurrentUpdate();
+  const updateDeNovo = await notifier.getUpdateSince();
 
-  const updateInWaiting = notifier.getUpdateSince(updateDeNovo.updateHandle);
+  const updateInWaiting = notifier.getUpdateSince(updateDeNovo.updateCount);
   t.equals(updateDeNovo.value, 1, 'first state check (1)');
   const all = Promise.all([updateInWaiting]).then(([update1]) => {
     t.equals(update1.value, 3, '4th check (delayed) 3');
-    const thirdStatePromise = notifier.getUpdateSince(update1.updateHandle);
+    const thirdStatePromise = notifier.getUpdateSince(update1.updateCount);
     Promise.all([thirdStatePromise]).then(([update2]) => {
       t.equals(update2.value, 5, '5th check (delayed) 5');
     });
   });
 
-  t.equals(notifier.getCurrentUpdate().value, 1, '2nd check (1)');
+  t.equals((await notifier.getUpdateSince()).value, 1, '2nd check (1)');
   updater.updateState(3);
 
-  t.equals(notifier.getCurrentUpdate().value, 3, '3rd check (3)');
+  t.equals((await notifier.getUpdateSince()).value, 3, '3rd check (3)');
   updater.updateState(5);
   await all;
 });
@@ -90,21 +90,21 @@ test('notifier - final state', async t => {
   /** @type {NotifierRecord<number|string>} */
   const { notifier, updater } = makeNotifierKit(1);
 
-  const updateDeNovo = notifier.getCurrentUpdate();
-  const updateInWaiting = notifier.getUpdateSince(updateDeNovo.updateHandle);
+  const updateDeNovo = await notifier.getUpdateSince();
+  const updateInWaiting = notifier.getUpdateSince(updateDeNovo.updateCount);
   t.equals(updateDeNovo.value, 1, 'initial state is one');
   const all = Promise.all([updateInWaiting]).then(([update]) => {
     t.equals(update.value, 'final', 'state is "final"');
-    t.notOk(update.updateHandle, 'no handle after close');
-    const postFinalUpdate = notifier.getUpdateSince(update.updateHandle);
+    t.notOk(update.updateCount, 'no handle after close');
+    const postFinalUpdate = notifier.getUpdateSince(update.updateCount);
     Promise.all([postFinalUpdate]).then(([after]) => {
       t.equals(after.value, 'final', 'stable');
-      t.notOk(after.updateHandle, 'no handle after close');
+      t.notOk(after.updateCount, 'no handle after close');
     });
   });
 
-  const invalidHandle = await notifier.getUpdateSince({});
+  const invalidHandle = await notifier.getUpdateSince();
   t.equals(invalidHandle.value, 1, 'still one');
-  updater.resolve('final');
+  updater.finish('final');
   await all;
 });

--- a/packages/swingset-runner/demo/zoeTests/vat-alice.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-alice.js
@@ -256,11 +256,11 @@ const build = async (zoe, issuers, payments, installations, timer) => {
     await showPurseBalance(simoleanPurseP, 'aliceSimoleanPurse', log);
   };
 
-  function logStateOnChanges(notifier, lastHandle = undefined) {
-    const updateRecordP = E(notifier).getUpdateSince(lastHandle);
+  function logStateOnChanges(notifier, lastCount = undefined) {
+    const updateRecordP = E(notifier).getUpdateSince(lastCount);
     updateRecordP.then(updateRec => {
       log(updateRec.value);
-      logStateOnChanges(notifier, updateRec.updateHandle);
+      logStateOnChanges(notifier, updateRec.updateCount);
     });
   }
 

--- a/packages/zoe/src/contractFacet.js
+++ b/packages/zoe/src/contractFacet.js
@@ -370,7 +370,7 @@ export function buildRootObject(_vatPowers) {
       addOffer: (offerHandle, proposal, allocation) => {
         const ignoringUpdater = harden({
           updateState: () => {},
-          resolve: () => {},
+          finish: () => {},
         });
         const offerRecord = {
           instanceHandle,

--- a/packages/zoe/src/state.js
+++ b/packages/zoe/src/state.js
@@ -112,7 +112,7 @@ const makeOfferTable = () => {
       deleteOffers: offerHandles => {
         return offerHandles.map(offerHandle => {
           const { updater } = table.get(offerHandle);
-          updater.resolve(undefined);
+          updater.finish(undefined);
           return table.delete(offerHandle);
         });
       },

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -611,13 +611,13 @@ function makeZoe(vatAdminSvc) {
         // deposited. Keywords in the want clause are mapped to the empty
         // amount for that keyword's Issuer.
         const recordOffer = amountsArray => {
-          const notifierRec = makeNotifierKit();
+          const notifierKit = makeNotifierKit(undefined);
           const offerRecord = {
             instanceHandle,
             proposal: cleanedProposal,
             currentAllocation: arrayToObj(amountsArray, userKeywords),
-            notifier: notifierRec.notifier,
-            updater: notifierRec.updater,
+            notifier: notifierKit.notifier,
+            updater: notifierKit.updater,
           };
           const { zcfForZoe } = instanceTable.get(instanceHandle);
           payoutMap.init(offerHandle, producePromise());

--- a/packages/zoe/test/swingsetTests/zoe/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-alice.js
@@ -253,11 +253,11 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     await showPurseBalance(simoleanPurseP, 'aliceSimoleanPurse', log);
   };
 
-  function logStateOnChanges(notifier, lastHandle = undefined) {
-    const updateRecordP = E(notifier).getUpdateSince(lastHandle);
+  function logStateOnChanges(notifier, lastCount = undefined) {
+    const updateRecordP = E(notifier).getUpdateSince(lastCount);
     updateRecordP.then(updateRec => {
       log(updateRec.value);
-      logStateOnChanges(notifier, updateRec.updateHandle);
+      logStateOnChanges(notifier, updateRec.updateCount);
     });
   }
 

--- a/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
+++ b/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
@@ -58,7 +58,7 @@ test('simpleExchange with valid offers', async t => {
 
   const { value: initialOrders } = await E(
     E(publicAPI).getNotifier(),
-  ).getCurrentUpdate();
+  ).getUpdateSince();
   t.deepEquals(
     initialOrders,
     { buys: [], sells: [] },
@@ -85,7 +85,7 @@ test('simpleExchange with valid offers', async t => {
 
   const { value: afterAliceOrders } = await E(
     E(publicAPI).getNotifier(),
-  ).getCurrentUpdate();
+  ).getUpdateSince();
   t.deepEquals(
     afterAliceOrders,
     {
@@ -100,13 +100,16 @@ test('simpleExchange with valid offers', async t => {
     `order notifier is updated with Alices sell order`,
   );
 
-  aliceOfferHandle.then(handle => {
+  aliceOfferHandle.then(async handle => {
     const aliceNotifier = zoe.getOfferNotifier(handle);
-    const firstUpdate = aliceNotifier.getCurrentUpdate();
+    const firstUpdate = await aliceNotifier.getUpdateSince();
     t.notOk(firstUpdate.value, 'notifier start state is empty');
-    t.notOk(firstUpdate.done, 'notifier start state is not done');
-    t.ok(firstUpdate.updateHandle, 'notifier start state has handle');
-    const nextUpdateP = aliceNotifier.getUpdateSince(firstUpdate.updateHandle);
+    t.notOk(
+      firstUpdate.updateCount === undefined,
+      'notifier start state is not done',
+    );
+    t.ok(firstUpdate.updateCount, 'notifier start state has handle');
+    const nextUpdateP = aliceNotifier.getUpdateSince(firstUpdate.updateCount);
     Promise.all([nextUpdateP]).then(([nextRecord]) => {
       t.ok(nextRecord.value.Asset, 'following state has update');
       t.ok(nextRecord.value.Price, 'following state has Price');
@@ -155,7 +158,7 @@ test('simpleExchange with valid offers', async t => {
 
   const { value: afterBobOrders } = await E(
     E(publicAPI).getNotifier(),
-  ).getCurrentUpdate();
+  ).getUpdateSince();
   t.deepEquals(
     afterBobOrders,
     { buys: [], sells: [] },
@@ -305,7 +308,7 @@ test('simpleExchange with multiple sell offers', async t => {
           ],
         };
         t.deepEquals(
-          (await E(E(publicAPI).getNotifier()).getCurrentUpdate()).value,
+          (await E(E(publicAPI).getNotifier()).getUpdateSince()).value,
           expectedBook,
         );
       },


### PR DESCRIPTION
This new semantics and representation derive from conversations with @dtribble and @Chris-Hibbert . It is also influenced by @kriskowal 's GTOR -- General Theory of Reactivity. It should be a better basis for reconstructing https://github.com/Agoric/agoric-sdk/pull/962 soundly, and for eventually forming working remote presences of notifiers and async iterables.

There is a key difference on starting, and another key difference on terminating.

On starting, if no initialState argument is provided, then the notifier starts with no initial state. It's initial state will be set by the first update. I also removed the `getCurrentState` synchronous access, as that conflicts with a delayed initial state. No one could explain why it was added.

On ending, two kinds of termination are supported, successfully with a last state value, and erroneously with a rejection reason.

With both of these changes, we can adapt both ways between notifiers and async iterators, while losing only the fidelity that is the point of notifiers --- the dropping of less recent states.