### PR TITLE
fix: remove support for legacy notifier API

### DIFF
--- a/packages/notifier/src/notifier.js
+++ b/packages/notifier/src/notifier.js
@@ -64,13 +64,6 @@ import { assert } from '@agoric/assert';
  */
 
 /**
- * Whether to enable deprecated legacy features to support legacy clients
- * during the transition. TODO once all clients are updated to the new API,
- * remove this flag and all code enabled by this flag.
- */
-const supportLegacy = true;
-
-/**
  * Produces a pair of objects, which allow a service to produce a stream of
  * update promises.
  *
@@ -98,20 +91,11 @@ export const makeNotifierKit = (...args) => {
 
   const final = () => currentUpdateCount === undefined;
 
-  const extraProperties = () =>
-    supportLegacy
-      ? {
-          updateHandle: currentUpdateCount,
-          done: final(),
-        }
-      : {};
-
   if (args.length >= 1) {
     // start as hasState() && !final()
     currentResponse = harden({
       value: args[0],
       updateCount: currentUpdateCount,
-      ...extraProperties(),
     });
   }
   // else start as !hasState() && !final()
@@ -143,7 +127,6 @@ export const makeNotifierKit = (...args) => {
     currentResponse = harden({
       value: state,
       updateCount: currentUpdateCount,
-      ...extraProperties(),
     });
     nextPromiseKit.resolve(currentResponse);
     nextPromiseKit = producePromise();
@@ -160,7 +143,6 @@ export const makeNotifierKit = (...args) => {
     currentResponse = harden({
       value: finalState,
       updateCount: currentUpdateCount,
-      ...extraProperties(),
     });
     nextPromiseKit.resolve(currentResponse);
     nextPromiseKit = undefined;
@@ -185,13 +167,6 @@ export const makeNotifierKit = (...args) => {
     updateState,
     finish,
     reject,
-    ...(supportLegacy ? { resolve: finish } : {}),
   });
   return harden({ notifier, updater });
 };
-
-// Deprecated. TODO remove once no clients need it.
-// Unlike makeNotifierKit, produceNotifier always produces
-// a notifier with an initial state, which defaults to undefined.
-export const produceNotifier = (initialState = undefined) =>
-  makeNotifierKit(initialState);

--- a/packages/zoe/src/contractFacet.js
+++ b/packages/zoe/src/contractFacet.js
@@ -256,12 +256,11 @@ export function buildRootObject(_vatPowers) {
     const zcfForZoe = {
       addOffer: (offerHandle, proposal, allocation) => {
         /** @type {Updater<Allocation>} */
-        const ignoringUpdater = {
+        const ignoringUpdater = harden({
           updateState: _ => {},
           finish: _ => {},
           reject: _ => {},
-        };
-        harden(ignoringUpdater);
+        });
 
         /** @type {Omit<OfferRecord & PrivateOfferRecord, 'handle'>} */
         const offerRecord = {


### PR DESCRIPTION
To be considered once no remaining clients rely on the old API.