### PR TITLE
fix: add tests & fix for ZCF handling of crashes in contract code

### DIFF
--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -34,7 +34,6 @@ export const makeZoeHelpers = (zcf) => {
   const zoeService = zcf.getZoeService();
 
   const rejectOffer = (offerHandle, msg = defaultRejectMsg) => {
-    zcf.complete(harden([offerHandle]));
     assert.fail(msg);
   };
 

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -632,10 +632,14 @@ function makeZoe(vatAdminSvc) {
 
         const makeOfferResult = completeObj => {
           const offerHandler = inviteHandleToHandler.get(inviteHandle);
+          const offerOutcome = offerHandler(offerHandle).catch(err => {
+            completeOffers(instanceHandle, [offerHandle]);
+            throw err;
+          });
           const offerResult = {
             offerHandle: HandledPromise.resolve(offerHandle),
             payout: payoutMap.get(offerHandle).promise,
-            outcome: offerHandler(offerHandle),
+            outcome: offerOutcome,
             completeObj,
           };
           return harden(offerResult);

--- a/packages/zoe/test/swingsetTests/brokenContracts/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/bootstrap.js
@@ -1,0 +1,64 @@
+import { E } from '@agoric/eventual-send';
+import makeIssuerKit from '@agoric/ertp';
+/* eslint-disable import/extensions, import/no-unresolved */
+import crashingAutoRefund from './bundle-crashingAutoRefund';
+/* eslint-enable import/extensions, import/no-unresolved */
+
+const setupBasicMints = () => {
+  const all = [
+    makeIssuerKit('moola'),
+    makeIssuerKit('simoleans'),
+    makeIssuerKit('bucks'),
+  ];
+  const mints = all.map(objs => objs.mint);
+  const issuers = all.map(objs => objs.issuer);
+  const amountMaths = all.map(objs => objs.amountMath);
+
+  return harden({
+    mints,
+    issuers,
+    amountMaths,
+  });
+};
+
+const makeVats = (log, vats, zoe, installations, startingValues) => {
+  const { mints, issuers, amountMaths } = setupBasicMints();
+  const makePayments = values =>
+    mints.map((mint, i) => {
+      return mint.mintPayment(amountMaths[i].make(values[i]));
+    });
+
+  // Setup Alice
+  const alicePayment = makePayments(startingValues);
+  // const alicePayment = mints[0].mintPayment(amountMaths[0].make(3));
+  const aliceP = E(vats.alice).build(zoe, issuers, alicePayment, installations);
+
+  log(`=> alice is set up`);
+  return harden(aliceP);
+};
+
+export function buildRootObject(vatPowers) {
+  const obj0 = {
+    async bootstrap(argv, vats, devices) {
+      const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
+        devices.vatAdmin,
+      );
+      const zoe = await E(vats.zoe).buildZoe(vatAdminSvc);
+      const installations = {
+        crashAutoRefund: await E(zoe).install(crashingAutoRefund.bundle),
+      };
+
+      const [testName, startingValues] = argv;
+
+      const aliceP = makeVats(
+        vatPowers.testLog,
+        vats,
+        zoe,
+        installations,
+        startingValues,
+      );
+      await E(aliceP).startTest(testName);
+    },
+  };
+  return harden(obj0);
+}

--- a/packages/zoe/test/swingsetTests/brokenContracts/crashingAutoRefund.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/crashingAutoRefund.js
@@ -1,0 +1,105 @@
+// @ts-check
+
+import { makeZoeHelpers } from '../../../src/contractSupport';
+
+/**
+ * This is an atomic swap contract to test Zoe handling contract failures.
+ *
+ * This contract exceeds metering limits or throws exceptions in various
+ * situations. We want to see that each is handled correctly.
+ *
+ * @typedef {import('../zoe').ContractFacet} ContractFacet
+ * @param {ContractFacet} zcf
+ */
+const makeContract = zcf => {
+  const { swap, assertKeywords, checkHook } = makeZoeHelpers(zcf);
+
+  let offersCount = 0;
+
+  assertKeywords(harden(['Asset', 'Price']));
+
+  const { terms } = zcf.getInstanceRecord();
+  if (terms.throw) {
+    throw new Error('blowup in makeContract');
+  } else if (terms.meter) {
+    return new Array(1e9);
+  }
+
+  const safeAutoRefundHook = offerHandle => {
+    offersCount += 1;
+    zcf.complete(harden([offerHandle]));
+    return `The offer was accepted`;
+  };
+  const makeSafeInvite = () =>
+    zcf.makeInvitation(safeAutoRefundHook, 'getRefund');
+
+  const meterExceededHook = () => {
+    offersCount += 1;
+    return new Array(1e9);
+  };
+  const makeExcessiveInvite = () =>
+    zcf.makeInvitation(meterExceededHook, 'getRefund');
+
+  const throwingHook = () => {
+    offersCount += 1;
+    throw new Error('someException');
+  };
+  const makeThrowingInvite = () =>
+    zcf.makeInvitation(throwingHook, 'getRefund');
+
+  const swapOfferExpected = harden({
+    give: { Asset: null },
+    want: { Price: null },
+  });
+
+  const makeMatchingInvite = firstOfferHandle => {
+    offersCount += 1;
+    const {
+      proposal: { want, give },
+    } = zcf.getOffer(firstOfferHandle);
+
+    return zcf.makeInvitation(
+      offerHandle => swap(firstOfferHandle, offerHandle),
+      'matchOffer',
+      harden({
+        customProperties: {
+          asset: give.Asset,
+          price: want.Price,
+        },
+      }),
+    );
+  };
+
+  const makeSwapInvite = () =>
+    zcf.makeInvitation(
+      checkHook(makeMatchingInvite, swapOfferExpected),
+      'firstOffer',
+    );
+
+  offersCount += 1;
+  zcf.initPublicAPI(
+    harden({
+      getOffersCount: () => {
+        offersCount += 1;
+        return offersCount;
+      },
+      makeSafeInvite,
+      makeSwapInvite,
+      makeExcessiveInvite,
+      makeThrowingInvite,
+      meterException: () => {
+        offersCount += 1;
+        return new Array(1e9);
+      },
+      throwSomething: () => {
+        offersCount += 1;
+        throw new Error('someException');
+      },
+    }),
+  );
+
+  return makeSafeInvite();
+};
+
+harden(makeContract);
+export { makeContract };

--- a/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
@@ -1,0 +1,199 @@
+import '@agoric/install-metering-and-ses';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from 'tape-promise/tape';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { loadBasedir, buildVatController } from '@agoric/swingset-vat';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import bundleSource from '@agoric/bundle-source';
+
+import fs from 'fs';
+
+const CONTRACT_FILES = ['crashingAutoRefund'];
+const generateBundlesP = Promise.all(
+  CONTRACT_FILES.map(async contract => {
+    const bundle = await bundleSource(`${__dirname}/${contract}`);
+    const obj = { bundle, contract };
+    fs.writeFileSync(
+      `${__dirname}/bundle-${contract}.js`,
+      `export default ${JSON.stringify(obj)};`,
+    );
+  }),
+);
+
+async function main(argv) {
+  const config = await loadBasedir(__dirname);
+  await generateBundlesP;
+  const controller = await buildVatController(config, argv);
+  await controller.run();
+  return controller.dump();
+}
+
+const meterExceededInOfferLog = [
+  '=> alice is set up',
+  '=> alice.doMeterExceptionInHook called',
+  'outcome correctly resolves to broken: RangeError: Allocate meter exceeded',
+  'aliceMoolaPurse: balance {"brand":{},"value":3}',
+  'aliceSimoleanPurse: balance {"brand":{},"value":0}',
+  'contract no longer responds: RangeError: Allocate meter exceeded',
+  'counter: 2',
+];
+
+test('ZCF metering crash on invite exercise', async t => {
+  t.plan(1);
+  try {
+    const dump = await main(['meterInOfferHook', [3, 0, 0]]);
+    t.deepEquals(dump.log, meterExceededInOfferLog);
+  } catch (e) {
+    t.isNot(e, e, 'unexpected metering exception in crashing contract test');
+  }
+});
+
+const meterExceededInSecondOfferLog = [
+  '=> alice is set up',
+  '=> alice.doMeterExceptionInHook called',
+  'Swap outcome resolves to an invite: [Presence o-74]',
+  'aliceMoolaPurse: balance {"brand":{},"value":0}',
+  'aliceSimoleanPurse: balance {"brand":{},"value":0}',
+  'outcome correctly resolves to broken: RangeError: Allocate meter exceeded',
+  'aliceMoolaPurse: balance {"brand":{},"value":5}',
+  'aliceSimoleanPurse: balance {"brand":{},"value":0}',
+  'swap value, 5',
+  'contract no longer responds: RangeError: Allocate meter exceeded',
+  'aliceMoolaPurse: balance {"brand":{},"value":8}',
+  'aliceSimoleanPurse: balance {"brand":{},"value":0}',
+  'refund value, 8',
+  'counter: 2',
+];
+
+test('ZCF metering crash on invite exercise', async t => {
+  t.plan(1);
+  try {
+    const dump = await main(['meterInSecondInvite', [8, 0, 0]]);
+    t.deepEquals(dump.log, meterExceededInSecondOfferLog);
+  } catch (e) {
+    t.isNot(e, e, 'unexpected metering exception in crashing contract test');
+  }
+});
+
+const throwInOfferLog = [
+  '=> alice is set up',
+  '=> alice.doThrowInHook called',
+  'counter: 2',
+  'outcome correctly resolves to broken: Error: someException',
+  'counter: 4',
+  'aliceMoolaPurse: balance {"brand":{},"value":3}',
+  'aliceSimoleanPurse: balance {"brand":{},"value":0}',
+  'counter: 5',
+  'newCounter: 2',
+  'Successful refund: The offer was accepted',
+  'new Purse: balance {"brand":{},"value":3}',
+  'aliceSimoleanPurse: balance {"brand":{},"value":0}',
+  'counter: 7',
+];
+
+test('ZCF throwing on invite exercise', async t => {
+  t.plan(1);
+  try {
+    const dump = await main(['throwInOfferHook', [3, 0, 0]]);
+    t.deepEquals(dump.log, throwInOfferLog);
+  } catch (e) {
+    t.isNot(e, e, 'unexpected throw in crashing contract test');
+  }
+});
+
+const throwInAPILog = [
+  '=> alice is set up',
+  '=> alice.doThrowInApiCall called',
+  'counter: 3',
+  'throwingAPI should throw Error: someException',
+  'counter: 5',
+  'counter: 6',
+  'Swap outcome is an invite (true).',
+  'newCounter: 2',
+  'outcome correctly resolves: "The offer has been accepted. Once the contract has been completed, please check your payout"',
+  'counter: 7',
+  'aliceMoolaPurse: balance {"brand":{},"value":3}',
+  'second moolaPurse: balance {"brand":{},"value":2}',
+  'aliceSimoleanPurse: balance {"brand":{},"value":8}',
+  'second simoleanPurse: balance {"brand":{},"value":4}',
+];
+
+test('ZCF throwing in API call', async t => {
+  t.plan(1);
+  try {
+    const dump = await main(['throwInApiCall', [5, 12, 0]]);
+    t.deepEquals(dump.log, throwInAPILog);
+  } catch (e) {
+    t.isNot(e, e, 'unexpected API throw in crashing contract test');
+  }
+});
+
+const meteringExceededInAPILog = [
+  '=> alice is set up',
+  '=> alice.doMeterInApiCall called',
+  'counter: 2',
+  'counter: 3',
+  'outcome correctly resolves to "The offer was accepted"',
+  'counter: 5',
+  'Vat correctly died for RangeError: Allocate meter exceeded',
+  'aliceMoolaPurse: balance {"brand":{},"value":3}',
+  'aliceSimoleanPurse: balance {"brand":{},"value":0}',
+  'contract no longer responds: RangeError: Allocate meter exceeded',
+  'newCounter: 2',
+];
+
+test('ZCF metering crash in API call', async t => {
+  t.plan(1);
+  try {
+    const dump = await main(['meterInApiCall', [3, 0, 0]]);
+    t.deepEquals(dump.log, meteringExceededInAPILog);
+  } catch (e) {
+    t.isNot(
+      e,
+      e,
+      'unexpected API metering exception in crashing contract test',
+    );
+  }
+});
+
+const meteringExceptionInMakeContractILog = [
+  '=> alice is set up',
+  '=> alice.doMeterExceptionInMakeContract called',
+  'contract creation failed: RangeError: Allocate meter exceeded',
+  'newCounter: 2',
+];
+
+test('ZCF metering crash in makeContract call', async t => {
+  t.plan(1);
+  try {
+    const dump = await main(['meterInMakeContract', [3, 0, 0]]);
+    t.deepEquals(dump.log, meteringExceptionInMakeContractILog);
+  } catch (e) {
+    t.isNot(
+      e,
+      e,
+      'unexpected API metering exception in crashing contract test',
+    );
+  }
+});
+
+const thrownExceptionInMakeContractILog = [
+  '=> alice is set up',
+  '=> alice.doThrowInMakeContract called',
+  'contract creation failed: Error: blowup in makeContract',
+  'newCounter: 2',
+];
+
+test('ZCF metering crash in makeContract call', async t => {
+  t.plan(1);
+  try {
+    const dump = await main(['throwInMakeContract', [3, 0, 0]]);
+    t.deepEquals(dump.log, thrownExceptionInMakeContractILog);
+  } catch (e) {
+    t.isNot(
+      e,
+      e,
+      'unexpected API metering exception in crashing contract test',
+    );
+  }
+});

--- a/packages/zoe/test/swingsetTests/brokenContracts/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/vat-alice.js
@@ -1,0 +1,491 @@
+import { E } from '@agoric/eventual-send';
+import { assert } from '@agoric/assert';
+import { showPurseBalance, setupIssuers } from '../helpers';
+
+async function logCounter(log, publicAPI) {
+  log(`counter: ${await E(publicAPI).getOffersCount()}`);
+}
+
+const build = async (log, zoe, issuers, payments, installations) => {
+  const [moolaPayment, simoleansPayment] = payments;
+  const [moolaIssuer, simoleanIssuer] = issuers;
+  const { moola, simoleans, purses } = await setupIssuers(zoe, issuers);
+  const [moolaPurseP, simoleanPurseP] = purses;
+
+  // A metering exception is thrown while processing the offer
+  const doMeterExceptionInHook = async () => {
+    log(`=> alice.doMeterExceptionInHook called`);
+    const installId = installations.crashAutoRefund;
+
+    const issuerKeywordRecord = harden({
+      Asset: moolaIssuer,
+      Price: simoleanIssuer,
+    });
+    // This invite throws a metering exception
+    const {
+      instanceRecord: { publicAPI },
+    } = await E(zoe).makeInstance(installId, issuerKeywordRecord);
+    const proposal = harden({
+      give: { Asset: moola(3) },
+      want: { Price: simoleans(7) },
+      exit: { onDemand: null },
+    });
+    const alicePayments = { Asset: moolaPayment };
+
+    const invite = await E(publicAPI).makeExcessiveInvite();
+    const { payout: payoutP, outcome } = await E(zoe).offer(
+      invite,
+      proposal,
+      alicePayments,
+    );
+
+    outcome.then(
+      () => assert(false, ' expected outcome to fail'),
+      e => log(`outcome correctly resolves to broken: ${e}`),
+    );
+
+    const payout = await payoutP;
+    const moolaPayout = await payout.Asset;
+    const simoleanPayout = await payout.Price;
+
+    await E(moolaPurseP).deposit(moolaPayout);
+    await E(simoleanPurseP).deposit(simoleanPayout);
+
+    await showPurseBalance(moolaPurseP, 'aliceMoolaPurse', log);
+    await showPurseBalance(simoleanPurseP, 'aliceSimoleanPurse', log);
+
+    E(publicAPI)
+      .getOffersCount()
+      .then(
+        () => assert(false, 'contract should be non-responsive '),
+        e => log(`contract no longer responds: ${e}`),
+      );
+
+    // zoe should still be able to make new vats.
+    const { instanceRecord } = await E(zoe).makeInstance(
+      installId,
+      issuerKeywordRecord,
+    );
+    logCounter(log, instanceRecord.publicAPI);
+  };
+
+  // A swap offer is accepted, then an exception is thrown on a second offer
+  const doMeterExceptionInSecondInvite = async () => {
+    log(`=> alice.doMeterExceptionInHook called`);
+    const installId = installations.crashAutoRefund;
+    const [refundPayment, swapPayment] = await E(moolaIssuer).split(
+      moolaPayment,
+      moola(3),
+    );
+
+    const issuerKeywordRecord = harden({
+      Asset: moolaIssuer,
+      Price: simoleanIssuer,
+    });
+
+    const {
+      instanceRecord: { publicAPI },
+    } = await E(zoe).makeInstance(installId, issuerKeywordRecord);
+
+    const swapProposal = harden({
+      give: { Asset: moola(5) },
+      want: { Price: simoleans(12) },
+      exit: { onDemand: null },
+    });
+    const aliceSwapPayments = { Asset: swapPayment };
+    const swapInvite = await E(publicAPI).makeSwapInvite();
+    const { payout: swapPayoutP, outcome: swapOutcome } = await E(zoe).offer(
+      swapInvite,
+      swapProposal,
+      aliceSwapPayments,
+    );
+    swapOutcome.then(
+      o => log(`Swap outcome resolves to an invite: ${o}`),
+      e => assert(false, `Expected swap outcome to succeed ${e}`),
+    );
+    // the refunds for swap won't happen till later
+    swapPayoutP.then(async swapPayout => {
+      const { Asset: swapMoolaPayout, Price: swapSimoleanPayout } = E.G(
+        swapPayout,
+      );
+      E(moolaPurseP).deposit(await swapMoolaPayout);
+      E(simoleanPurseP).deposit(await swapSimoleanPayout);
+
+      showPurseBalance(moolaPurseP, 'aliceMoolaPurse', log);
+      showPurseBalance(simoleanPurseP, 'aliceSimoleanPurse', log);
+      E(moolaPurseP)
+        .getCurrentAmount()
+        .then(amount => log(`swap value, ${amount.value}`));
+    });
+
+    // This invite throws a metering exception
+    const refundInvite = await E(publicAPI).makeExcessiveInvite();
+    const refundProposal = harden({
+      give: { Asset: moola(3) },
+      want: { Price: simoleans(7) },
+      exit: { onDemand: null },
+    });
+    const refundPayments = { Asset: refundPayment };
+
+    const { payout: payoutP, outcome: refundOutcome } = await E(zoe).offer(
+      refundInvite,
+      refundProposal,
+      refundPayments,
+    );
+
+    // The swap deposit should be refunded
+    await showPurseBalance(moolaPurseP, 'aliceMoolaPurse', log);
+    await showPurseBalance(simoleanPurseP, 'aliceSimoleanPurse', log);
+
+    refundOutcome.then(
+      () => assert(false, ' expected outcome to fail'),
+      e => log(`outcome correctly resolves to broken: ${e}`),
+    );
+
+    payoutP.then(async refundPayout => {
+      const { Asset: swapMoolaPayout, Price: swapSimoleanPayout } = E.G(
+        refundPayout,
+      );
+      E(moolaPurseP).deposit(await swapMoolaPayout);
+      E(simoleanPurseP).deposit(await swapSimoleanPayout);
+
+      showPurseBalance(moolaPurseP, 'aliceMoolaPurse', log);
+      showPurseBalance(simoleanPurseP, 'aliceSimoleanPurse', log);
+      E(moolaPurseP)
+        .getCurrentAmount()
+        .then(amount => log(`refund value, ${amount.value}`));
+    });
+
+    E(publicAPI)
+      .getOffersCount()
+      .then(
+        () => assert(false, 'contract should be non-responsive '),
+        e => log(`contract no longer responds: ${e}`),
+      );
+
+    // zoe should still be able to make new vats.
+    const { instanceRecord: newInstanceRecord } = await E(zoe).makeInstance(
+      installId,
+      issuerKeywordRecord,
+    );
+    logCounter(log, newInstanceRecord.publicAPI);
+  };
+
+  const doThrowInHook = async () => {
+    log(`=> alice.doThrowInHook called`);
+    const installId = installations.crashAutoRefund;
+
+    const issuerKeywordRecord = harden({
+      Asset: moolaIssuer,
+      Price: simoleanIssuer,
+    });
+    const { instanceRecord } = await E(zoe).makeInstance(
+      installId,
+      issuerKeywordRecord,
+    );
+    const proposal = harden({
+      give: { Asset: moola(3) },
+      want: { Price: simoleans(7) },
+      exit: { onDemand: null },
+    });
+    const alicePayments = { Asset: moolaPayment };
+
+    logCounter(log, instanceRecord.publicAPI);
+    const invite = await E(instanceRecord.publicAPI).makeThrowingInvite();
+    const { payout: payoutP, outcome } = await E(zoe).offer(
+      invite,
+      proposal,
+      alicePayments,
+    );
+
+    outcome.then(
+      () => assert(false, ' expected outcome to fail'),
+      e => log(`outcome correctly resolves to broken: ${e}`),
+    );
+    logCounter(log, instanceRecord.publicAPI);
+    const payout = await payoutP;
+    const moolaPayout = await payout.Asset;
+    const simoleanPayout = await payout.Price;
+
+    await E(moolaPurseP).deposit(moolaPayout);
+    await E(simoleanPurseP).deposit(simoleanPayout);
+    await showPurseBalance(moolaPurseP, 'aliceMoolaPurse', log);
+    await showPurseBalance(simoleanPurseP, 'aliceSimoleanPurse', log);
+    logCounter(log, instanceRecord.publicAPI);
+
+    // zoe should still be able to make new vats.
+    const { instanceRecord: newInstanceRecord } = await E(zoe).makeInstance(
+      installId,
+      issuerKeywordRecord,
+    );
+    log(`newCounter: ${await E(newInstanceRecord.publicAPI).getOffersCount()}`);
+
+    const newInvite = await E(instanceRecord.publicAPI).makeSafeInvite();
+    const newMoolaPayment = await E(moolaPurseP).withdraw(moola(3));
+    const newPayments = { Asset: newMoolaPayment };
+
+    const { payout: secondPayoutP, outcome: secondOutcome } = await E(
+      zoe,
+    ).offer(newInvite, proposal, newPayments);
+
+    secondOutcome.then(
+      o => log(`Successful refund: ${o}`),
+      e => assert(false, `Expected swap outcome to succeed ${e}`),
+    );
+    const newPurse = await E(moolaIssuer).makeEmptyPurse();
+    const {
+      Asset: swapMoolaPayoutP,
+      Price: swapSimoleanPayoutP,
+    } = await secondPayoutP;
+    E(newPurse).deposit(await swapMoolaPayoutP);
+    E(simoleanPurseP).deposit(await swapSimoleanPayoutP);
+
+    showPurseBalance(newPurse, 'new Purse', log);
+    showPurseBalance(simoleanPurseP, 'aliceSimoleanPurse', log);
+    logCounter(log, instanceRecord.publicAPI);
+  };
+
+  const doThrowInApiCall = async () => {
+    log(`=> alice.doThrowInApiCall called`);
+    const installId = installations.crashAutoRefund;
+
+    const issuerKeywordRecord = harden({
+      Asset: moolaIssuer,
+      Price: simoleanIssuer,
+    });
+    const { instanceRecord } = await E(zoe).makeInstance(
+      installId,
+      issuerKeywordRecord,
+    );
+
+    const swapProposal = harden({
+      give: { Asset: moola(5) },
+      want: { Price: simoleans(8) },
+      exit: { onDemand: null },
+    });
+    const aliceSwapPayments = { Asset: moolaPayment };
+    const swapInvite = await E(instanceRecord.publicAPI).makeSwapInvite();
+    const { payout: swapPayoutP, outcome: swapOutcome } = await E(zoe).offer(
+      swapInvite,
+      swapProposal,
+      aliceSwapPayments,
+    );
+
+    const inviteIssuer = await E(zoe).getInviteIssuer();
+    let swapInviteTwo;
+    swapOutcome.then(
+      o => {
+        E(inviteIssuer)
+          .isLive(o)
+          .then(val => {
+            swapInviteTwo = o;
+            return log(`Swap outcome is an invite (${val}).`);
+          });
+      },
+      e => assert(false, `expected outcome not to resolve yet ${e}`),
+    );
+    logCounter(log, instanceRecord.publicAPI);
+
+    E(instanceRecord.publicAPI)
+      .throwSomething()
+      .then(
+        () => assert(false, 'expecting this to throw'),
+        e => log(`throwingAPI should throw ${e}`),
+      );
+    logCounter(log, instanceRecord.publicAPI);
+
+    // These should not resolve at this point, the funds are still escrowed
+    swapPayoutP.then(async swapPayout => {
+      const moolaSwapPayout = await swapPayout.Asset;
+      const simoleanSwapPayout = await swapPayout.Price;
+
+      await E(moolaPurseP).deposit(moolaSwapPayout);
+      await E(simoleanPurseP).deposit(simoleanSwapPayout);
+      await showPurseBalance(moolaPurseP, 'aliceMoolaPurse', log);
+      await showPurseBalance(simoleanPurseP, 'aliceSimoleanPurse', log);
+    });
+
+    // show that the contract is still responsive.
+    logCounter(log, instanceRecord.publicAPI);
+
+    // zoe should still be able to make new vats.
+    const { instanceRecord: newInstanceRecord } = await E(zoe).makeInstance(
+      installId,
+      issuerKeywordRecord,
+    );
+    log(`newCounter: ${await E(newInstanceRecord.publicAPI).getOffersCount()}`);
+
+    const swapTwoProposal = harden({
+      give: { Price: simoleans(12) },
+      want: { Asset: moola(2) },
+      exit: { onDemand: null },
+    });
+    const aliceSwapTwoPayments = { Price: simoleansPayment };
+    const { payout: swapTwoPayoutP, outcome: swapTwoOutcome } = await E(
+      zoe,
+    ).offer(swapInviteTwo, swapTwoProposal, aliceSwapTwoPayments);
+    logCounter(log, instanceRecord.publicAPI);
+
+    swapTwoOutcome.then(
+      o => log(`outcome correctly resolves: "${o}"`),
+      e => assert(false, `expected outcome to succeed ${e}`),
+    );
+    const swapTwoPayout = await swapTwoPayoutP;
+    const moolaSwapTwoPayout = await swapTwoPayout.Asset;
+    const simoleanSwapTwoPayout = await swapTwoPayout.Price;
+
+    const moolaPurse2P = E(moolaIssuer).makeEmptyPurse();
+    const simoleanPurse2P = E(simoleanIssuer).makeEmptyPurse();
+    await E(moolaPurse2P).deposit(moolaSwapTwoPayout);
+    await E(simoleanPurse2P).deposit(simoleanSwapTwoPayout);
+    await showPurseBalance(moolaPurse2P, 'second moolaPurse', log);
+    await showPurseBalance(simoleanPurse2P, 'second simoleanPurse', log);
+  };
+
+  const doMeterExceptionInApiCall = async () => {
+    log(`=> alice.doMeterInApiCall called`);
+    const installId = installations.crashAutoRefund;
+
+    const issuerKeywordRecord = harden({
+      Asset: moolaIssuer,
+      Price: simoleanIssuer,
+    });
+    const { instanceRecord } = await E(zoe).makeInstance(
+      installId,
+      issuerKeywordRecord,
+    );
+    logCounter(log, instanceRecord.publicAPI);
+    const proposal = harden({
+      give: { Asset: moola(3) },
+      want: { Price: simoleans(7) },
+      exit: { onDemand: null },
+    });
+    const alicePayments = { Asset: moolaPayment };
+    const invite = await E(instanceRecord.publicAPI).makeSafeInvite();
+    logCounter(log, instanceRecord.publicAPI);
+
+    const { payout: payoutP, outcome } = await E(zoe).offer(
+      invite,
+      proposal,
+      alicePayments,
+    );
+
+    logCounter(log, instanceRecord.publicAPI);
+    E(instanceRecord.publicAPI)
+      .meterException()
+      .then(
+        () => assert(false, `meterException in an API call should kill vat`),
+        e => log(`Vat correctly died for ${e}`),
+      );
+    outcome.then(
+      o => log(`outcome correctly resolves to "${o}"`),
+      e => assert(false, `expected outcome to succeed: ${e}`),
+    );
+
+    const payout = await payoutP;
+    const moolaPayout = await payout.Asset;
+    const simoleanPayout = await payout.Price;
+
+    await E(moolaPurseP).deposit(moolaPayout);
+    await E(simoleanPurseP).deposit(simoleanPayout);
+    await showPurseBalance(moolaPurseP, 'aliceMoolaPurse', log);
+    await showPurseBalance(simoleanPurseP, 'aliceSimoleanPurse', log);
+
+    E(instanceRecord.publicAPI)
+      .getOffersCount()
+      .then(
+        () => assert(false, 'contract should be non-responsive '),
+        e => log(`contract no longer responds: ${e}`),
+      );
+
+    // We should still be able to create new vats.
+    const { instanceRecord: newInstanceRecord } = await E(zoe).makeInstance(
+      installId,
+      issuerKeywordRecord,
+    );
+    log(`newCounter: ${await E(newInstanceRecord.publicAPI).getOffersCount()}`);
+  };
+
+  const doMeterExceptionInMakeContract = async () => {
+    log(`=> alice.doMeterExceptionInMakeContract called`);
+    const installId = installations.crashAutoRefund;
+
+    const issuerKeywordRecord = harden({
+      Asset: moolaIssuer,
+      Price: simoleanIssuer,
+    });
+    E(zoe)
+      .makeInstance(installId, issuerKeywordRecord, { meter: true })
+      .then(
+        () => assert(false, 'contract should not finish creation'),
+        e => log(`contract creation failed: ${e}`),
+      );
+
+    // We should still be able to create new vats.
+    const { instanceRecord: newInstanceRecord } = await E(zoe).makeInstance(
+      installId,
+      issuerKeywordRecord,
+    );
+    log(`newCounter: ${await E(newInstanceRecord.publicAPI).getOffersCount()}`);
+  };
+
+  const doThrowInMakeContract = async () => {
+    log(`=> alice.doThrowInMakeContract called`);
+    const installId = installations.crashAutoRefund;
+
+    const issuerKeywordRecord = harden({
+      Asset: moolaIssuer,
+      Price: simoleanIssuer,
+    });
+    E(zoe)
+      .makeInstance(installId, issuerKeywordRecord, { throw: true })
+      .then(
+        () => assert(false, 'contract should not finish creation'),
+        e => log(`contract creation failed: ${e}`),
+      );
+
+    // We should still be able to create new vats.
+    const { instanceRecord: newInstanceRecord } = await E(zoe).makeInstance(
+      installId,
+      issuerKeywordRecord,
+    );
+    log(`newCounter: ${await E(newInstanceRecord.publicAPI).getOffersCount()}`);
+  };
+
+  return harden({
+    startTest: async testName => {
+      switch (testName) {
+        case 'meterInOfferHook': {
+          return doMeterExceptionInHook();
+        }
+        case 'meterInSecondInvite': {
+          return doMeterExceptionInSecondInvite();
+        }
+        case 'throwInOfferHook': {
+          return doThrowInHook();
+        }
+        case 'throwInApiCall': {
+          return doThrowInApiCall();
+        }
+        case 'meterInApiCall': {
+          return doMeterExceptionInApiCall();
+        }
+        case 'throwInMakeContract': {
+          return doThrowInMakeContract();
+        }
+        case 'meterInMakeContract': {
+          return doMeterExceptionInMakeContract();
+        }
+        default: {
+          throw new Error(`testName ${testName} not recognized`);
+        }
+      }
+    },
+  });
+};
+
+export function buildRootObject(vatPowers) {
+  return harden({
+    build: (...args) => build(vatPowers.testLog, ...args),
+  });
+}

--- a/packages/zoe/test/swingsetTests/brokenContracts/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/vat-zoe.js
@@ -1,0 +1,8 @@
+// noinspection ES6PreferShortImport
+import { makeZoe } from '../../../src/zoe';
+
+export function buildRootObject(_vatPowers) {
+  return harden({
+    buildZoe: vatAdminSvc => makeZoe(vatAdminSvc),
+  });
+}

--- a/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
@@ -193,8 +193,8 @@ test('ZoeHelpers rejectIfNotProposal', t => {
     );
     t.deepEquals(
       mockZCF.getCompletedHandles(),
-      [offerHandles[1], offerHandles[2], offerHandles[3]],
-      `offers 1, 2, 3, (zero-indexed) should be completed`,
+      [],
+      `offers 1, 2, 3, (zero-indexed) won't be completed before rejection`,
     );
 
     // Now vary the offer.
@@ -226,14 +226,8 @@ test('ZoeHelpers rejectIfNotProposal', t => {
     );
     t.deepEquals(
       mockZCF.getCompletedHandles(),
-      [
-        offerHandles[1],
-        offerHandles[2],
-        offerHandles[3],
-        offerHandles[4],
-        offerHandles[5],
-      ],
-      `offers 1, 2, 3, 4, and 5 (zero indexed) should be completed`,
+      [],
+      `offers won't be completed before rejection`,
     );
   } catch (e) {
     t.assert(false, e);
@@ -369,13 +363,17 @@ test('ZoeHelpers rejectOffer', t => {
       /Error: The offer was invalid. Please check your refund./,
       `rejectOffer intentionally throws`,
     );
-    t.deepEquals(completedOfferHandles, harden([offerHandles[0]]));
+    t.deepEquals(completedOfferHandles, harden([]), 'no completion');
     t.throws(
       () => rejectOffer(offerHandles[1], 'offer was wrong'),
       /Error: offer was wrong/,
       `rejectOffer throws with custom msg`,
     );
-    t.deepEquals(completedOfferHandles, harden(offerHandles));
+    t.deepEquals(
+      completedOfferHandles,
+      [],
+      'rejection does not include completions',
+    );
   } catch (e) {
     t.assert(false, e);
   }
@@ -497,8 +495,8 @@ test('ZoeHelpers swap keep inactive', t => {
     t.deepEquals(reallocatedAmountObjs, harden([]), `no amounts reallocated`);
     t.deepEquals(
       mockZCF.getCompletedHandles(),
-      harden([rightOfferHandle]),
-      `only tryHandle (right) was completed`,
+      harden([]),
+      `no offers were completed`,
     );
   } catch (e) {
     t.assert(false, e);
@@ -557,11 +555,7 @@ test(`ZoeHelpers swap - can't trade with`, t => {
     const reallocatedAmountObjs = mockZcf.getReallocatedAmountObjs();
     t.deepEquals(reallocatedAmountObjs, harden([]), `no amounts reallocated`);
     const completedHandles = mockZcf.getCompletedHandles();
-    t.deepEquals(
-      completedHandles,
-      harden([rightOfferHandle]),
-      `only tryHandle (right) was completed`,
-    );
+    t.deepEquals(completedHandles, harden([]), `no offers were completed`);
   } catch (e) {
     t.assert(false, e);
   }


### PR DESCRIPTION
When contracts exceed metering limits, or throw exceptions, the
contract may fail, but exit safety should kick in, and other contracts
and Zoe should continue to function.