### PR TITLE
refactor: break the cycle between notifier and adaptor

### DIFF
--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -2,7 +2,7 @@
   "name": "@agoric/notifier",
   "version": "0.1.3",
   "description": "Notifier allows services to update clients about state changes using a stream of promises",
-  "main": "src/notifier.js",
+  "main": "src/index.js",
   "engines": {
     "node": ">=11.0"
   },

--- a/packages/notifier/src/asyncIterableAdaptor.js
+++ b/packages/notifier/src/asyncIterableAdaptor.js
@@ -3,8 +3,6 @@
 /// <reference types="ses"/>
 
 import { E } from '@agoric/eventual-send';
-// eslint-disable-next-line import/no-cycle
-import { makeNotifierKit } from './notifier';
 
 import './types';
 
@@ -127,19 +125,6 @@ export const updateFromIterable = (updater, asyncIterable) => {
     };
     recur();
   });
-};
-
-/**
- * Adaptor from async iterable to notifier.
- *
- * @template T
- * @param {AsyncIterable<T>} asyncIterable
- * @returns {Notifier<T>}
- */
-export const makeNotifierFromAsyncIterable = asyncIterable => {
-  const { notifier, updater } = makeNotifierKit();
-  updateFromIterable(updater, asyncIterable);
-  return notifier;
 };
 
 /**

--- a/packages/notifier/src/index.js
+++ b/packages/notifier/src/index.js
@@ -1,0 +1,2 @@
+export * from './notifier';
+export * from './asyncIterableAdaptor';

--- a/packages/notifier/src/notifier.js
+++ b/packages/notifier/src/notifier.js
@@ -4,8 +4,10 @@
 
 import { producePromise } from '@agoric/produce-promise';
 import { assert } from '@agoric/assert';
-// eslint-disable-next-line import/no-cycle
-import { makeAsyncIterableFromNotifier } from './asyncIterableAdaptor';
+import {
+  makeAsyncIterableFromNotifier,
+  updateFromIterable,
+} from './asyncIterableAdaptor';
 
 import './types';
 
@@ -117,4 +119,17 @@ export const makeNotifierKit = (...args) => {
   // notifier facet is separate so it can be handed out while updater
   // is tightly held
   return harden({ notifier, updater });
+};
+
+/**
+ * Adaptor from async iterable to notifier.
+ *
+ * @template T
+ * @param {AsyncIterable<T>} asyncIterable
+ * @returns {Notifier<T>}
+ */
+export const makeNotifierFromAsyncIterable = asyncIterable => {
+  const { notifier, updater } = makeNotifierKit();
+  updateFromIterable(updater, asyncIterable);
+  return notifier;
 };

--- a/packages/notifier/test/test-notifier-adaptor.js
+++ b/packages/notifier/test/test-notifier-adaptor.js
@@ -6,7 +6,7 @@ import {
   makeNotifierFromAsyncIterable,
   updateFromIterable,
   updateFromNotifier,
-} from '../src/asyncIterableAdaptor';
+} from '../src/index';
 
 const obj = harden({});
 const unresP = new Promise(_ => {});

--- a/packages/notifier/test/test-notifier.js
+++ b/packages/notifier/test/test-notifier.js
@@ -2,7 +2,7 @@
 import '@agoric/install-ses';
 
 import test from 'tape-promise/tape';
-import { makeNotifierKit } from '../src/notifier';
+import { makeNotifierKit } from '../src/index';
 
 import '../src/types';
 


### PR DESCRIPTION
We'd prefer not to have circular dependencies (they make bundlers very unhappy), so this PR organizes the notifier into an index file that includes acyclical exports.
