### PR TITLE
feat: a disciplined upgrade mechanism for remote objects

### DIFF
--- a/packages/produce-promise/src/producePromise.js
+++ b/packages/produce-promise/src/producePromise.js
@@ -8,8 +8,13 @@ import { HandledPromise } from '@agoric/eventual-send';
 
 /**
  * @template T
+ * @typedef {PromiseLike<T> | T} PromiseOrNot
+ */
+
+/**
+ * @template T
  * @typedef {Object} PromiseRecord A reified Promise
- * @property {(value: T) => void} resolve
+ * @property {(value: PromiseOrNot<T>) => void} resolve
  * @property {(reason: any) => void} reject
  * @property {Promise<T>} promise
  */

--- a/packages/upgrader/.eslintrc-jessie.js
+++ b/packages/upgrader/.eslintrc-jessie.js
@@ -1,0 +1,7 @@
+/* global module */
+module.exports = {
+  extends: "jessie",
+  env: {
+    es6: true, // supports new ES6 globals (e.g., new types such as Set)
+  },
+};

--- a/packages/upgrader/CHANGELOG.md
+++ b/packages/upgrader/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.1.3](https://github.com/Agoric/agoric-sdk/compare/@agoric/notifier@0.1.2...@agoric/notifier@0.1.3) (2020-06-30)
+
+**Note:** Version bump only for package @agoric/notifier
+
+
+
+
+
+## [0.1.2](https://github.com/Agoric/agoric-sdk/compare/@agoric/notifier@0.1.1...@agoric/notifier@0.1.2) (2020-05-17)
+
+**Note:** Version bump only for package @agoric/notifier
+
+
+
+
+
+## [0.1.1](https://github.com/Agoric/agoric-sdk/compare/@agoric/notifier@0.1.0...@agoric/notifier@0.1.1) (2020-05-10)
+
+**Note:** Version bump only for package @agoric/notifier
+
+
+
+
+
+# 0.1.0 (2020-05-04)
+
+
+### Features
+
+* Add a notifier facility for Zoe and contracts ([7d6e2a6](https://github.com/Agoric/agoric-sdk/commit/7d6e2a6eae5793c2a4b451405a0f4337bfcaa448))
+
+
+
+
+
+
+
+
+## 0.0.1 (2020-04-15)
+
+Initial Version

--- a/packages/upgrader/CONTRIBUTING.md
+++ b/packages/upgrader/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing
+
+Thank you!
+
+## Contact
+
+We use github issues for all bug reports:
+https://github.com/Agoric/agoric-sdk/issues Please add a [notifier]
+prefix to the title and `notifier` tag to notifier-related issues.
+
+## Installing, Testing
+
+You'll need Node.js version 11 or higher. 
+
+* `git clone https://github.com/Agoric/agoric-sdk/`
+* `cd agoric-sdk`
+* `yarn install`
+* `yarn build` (This *must* be done at the top level to build all of
+  the packages)
+* `cd packages/notifier`
+* `yarn test`
+
+## Pull Requests
+
+Before submitting a pull request, please:
+
+* run `yarn test` within `packages/notifier` and make sure all the unit
+  tests pass (running `yarn test` at the top level will test all the
+  monorepo packages, which can be a good integration test.)
+* run `yarn run lint-fix` to reformat the code according to our `eslint`
+  profile, and fix any complaints that it can't automatically correct
+
+## Making a Release
+
+* edit NEWS.md enumerating any user-visible changes. (If there are
+  changelogs/ snippets, consolidate them to build the new NEWS
+  entries, and then delete all the snippets.)
+* make sure `yarn config set version-git-tag false` is the current
+  setting
+* `yarn version` (interactive) or `yarn version --major` or `yarn version --minor`
+  * that changes `package.json`
+  * and does NOT do a `git commit` and `git tag`
+* `git add .`
+* `git commit -m "bump version"`
+* `git tag -a notifier-v$VERSION -m "notifier-v$VERSION"`
+* `yarn publish --access public`
+* `git push`
+* `git push origin notifier-v$VERSION`

--- a/packages/upgrader/NEWS.md
+++ b/packages/upgrader/NEWS.md
@@ -1,0 +1,5 @@
+User-visible changes in @agoric/upgrader:
+
+## Release 0.1.0 (2020-08-02)
+
+Created package `@agoric/upgrader`

--- a/packages/upgrader/README.md
+++ b/packages/upgrader/README.md
@@ -1,0 +1,3 @@
+# Upgrader
+
+Produces a presence, which can provide services to clients, and have its implementation replaced, frozen, or revoked.

--- a/packages/upgrader/exports.js
+++ b/packages/upgrader/exports.js
@@ -1,0 +1,1 @@
+import './src/types';

--- a/packages/upgrader/jsconfig.json
+++ b/packages/upgrader/jsconfig.json
@@ -1,0 +1,18 @@
+// This file can contain .js-specific Typescript compiler config.
+{
+  "compilerOptions": {
+    "target": "es2019",
+
+    "noEmit": true,
+/*
+    // The following flags are for creating .d.ts files:
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+*/
+    "downlevelIteration": true,
+    "strictNullChecks": true,
+    "moduleResolution": "node",
+  },
+  "include": ["src/**/*.js", "exports.js"],
+}

--- a/packages/upgrader/package.json
+++ b/packages/upgrader/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@agoric/notifier",
-  "version": "0.1.3",
-  "description": "Notifier allows services to update clients about state changes using a stream of promises",
+  "name": "@agoric/upgrader",
+  "version": "0.1.0",
+  "description": "Upgrader allows remote objects to replace their implementation",
   "main": "src/index.js",
   "engines": {
     "node": ">=11.0"
@@ -21,7 +21,7 @@
     "url": "git+https://github.com/Agoric/agoric-sdk.git"
   },
   "keywords": [
-    "notifier"
+    "upgrader"
   ],
   "author": "Agoric",
   "license": "Apache-2.0",

--- a/packages/upgrader/src/index.js
+++ b/packages/upgrader/src/index.js
@@ -1,0 +1,1 @@
+export * from './upgrader';

--- a/packages/upgrader/src/types.js
+++ b/packages/upgrader/src/types.js
@@ -12,19 +12,32 @@
  * @template T
  * @typedef {Object} UpgraderKit
  * @property {Promise<T>} upgradableP
+ * A stable HandledPromise identity whose implementation can be changed
  * @property {Upgrader<T>} upgrader
+ * The upgrader facet, by which implementations are modified
  */
 
 /**
  * @template T
  * @typedef {Object} Upgrader
  * @property {(replacerP: PromiseOrNot<Replacer<T>>) => Promise<T>} upgrade
+ * Coordinate an upgrade of the upgradableP's implementation.
  * @property {(reason?: any) => void} revoke
+ * Permanently reject the upgraderP and clean up old state
  * @property {() => void} finish
+ * Permanently resolve the upgraderP, using the latest implementation forevermore
  */
 
 /**
  * @template T
  * @typedef {Object} Replacer
- * @property {(lastInstance?: T) => Promise<T>} upgradeFromLast
+ * @property {(priorP: Promise<T> | undefined) => Promise<T>} upgradeFrom
+ * Receive a promise for the prior implementation (undefined if there was none),
+ * so that we can export state from it.  Return a promise that resolves
+ * to the next implementation.
+ *
+ * Guarantees atomically that message forwarding to the old implementation
+ * is suspended during upgrade, and resumed once the new implementation is
+ * installed.  The old implementation is rolled back on failure to upgrade,
+ * then messages resume to it.
  */

--- a/packages/upgrader/src/types.js
+++ b/packages/upgrader/src/types.js
@@ -1,0 +1,28 @@
+/**
+ * @template T
+ * @typedef {T | PromiseLike<T>} PromiseOrNot
+ */
+
+/**
+ * @template T
+ * @typedef {import('@agoric/produce-promise').PromiseRecord<T>} PromiseRecord
+ */
+
+/**
+ * @template T
+ * @typedef {Object} UpgraderKit
+ * @property {Promise<T>} upgradableP
+ * @property {Upgrader<T>} upgrader
+ */
+
+/**
+ * @template T
+ * @typedef {Object} Upgrader
+ * @property {(replacer: PromiseOrNot<Replacer<T>>) => Promise<T>} upgrade
+ */
+
+/**
+ * @template T
+ * @typedef {Object} Replacer
+ * @property {(lastInstance?: T) => T} upgradeFromLast
+ */

--- a/packages/upgrader/src/types.js
+++ b/packages/upgrader/src/types.js
@@ -18,11 +18,13 @@
 /**
  * @template T
  * @typedef {Object} Upgrader
- * @property {(replacer: PromiseOrNot<Replacer<T>>) => Promise<T>} upgrade
+ * @property {(replacerP: PromiseOrNot<Replacer<T>>) => Promise<T>} upgrade
+ * @property {(reason?: any) => void} revoke
+ * @property {() => void} finish
  */
 
 /**
  * @template T
  * @typedef {Object} Replacer
- * @property {(lastInstance?: T) => T} upgradeFromLast
+ * @property {(lastInstance?: T) => Promise<T>} upgradeFromLast
  */

--- a/packages/upgrader/src/upgrader.js
+++ b/packages/upgrader/src/upgrader.js
@@ -1,40 +1,129 @@
 // @ts-check
-import { assert, details } from '@agoric/assert';
-import { E } from '@agoric/eventual-send';
+import { E, HandledPromise } from '@agoric/eventual-send';
 import { producePromise } from '@agoric/produce-promise';
 
 import './types';
 
 /**
- * @template T
+ * @enum {number} MutabilityState
+ */
+const MutabilityState = {
+  INIT: 0,
+  INSTALLED: 1,
+  FINISHED: 2,
+  REVOKED: 3,
+};
+
+/**
+ * @template {Object} T
  * @param {T} [initialInstance]
  * @returns {UpgraderKit<T>}
  */
 export function makeUpgraderKit(initialInstance = undefined) {
-  assert(
-    initialInstance === undefined,
-    details`initialInstance not implemented`,
-  );
+  let mutability = MutabilityState.INIT;
+
+  const assertMutable = () => {
+    switch (mutability) {
+      case MutabilityState.FINISHED:
+        throw Error(`Upgrader already finished`);
+      case MutabilityState.REVOKED:
+        throw Error(`Upgrader already revoked`);
+      default:
+        return true;
+    }
+  };
 
   /** @type {PromiseRecord<T>} */
-  const upgradablePK = producePromise();
+  let upgradablePK = producePromise();
+  /** @type {T | undefined} */
+  let lastInstance = initialInstance;
+
+  /** @type {(instance: PromiseOrNot<T>) => void} */
+  let resolveUpgradableP;
+
+  /** @type {(reason?: any) => void} */
+  let rejectUpgradableP;
+
+  const upgradableP = new HandledPromise(
+    (resolve, reject) => {
+      resolveUpgradableP = resolve;
+      rejectUpgradableP = reject;
+    },
+    {
+      applyMethod(_p, name, args) {
+        if (name === undefined) {
+          return /** @type {Function} */ (E(upgradablePK.promise))(...args);
+        }
+        return E(upgradablePK.promise)[name](...args);
+      },
+      get(_p, name) {
+        return E.G(upgradablePK.promise)[name];
+      },
+    },
+  );
 
   /** @type {Upgrader<T>} */
   const upgrader = {
-    async upgrade(replacerP) {
-      // We deliberately stall until the upgrade succeeds.
-      const newInstance = await E(replacerP).upgradeFromLast(undefined);
+    finish() {
+      assertMutable();
+      if (!lastInstance) {
+        const err = Error(`No instance was ever installed`);
+        upgrader.revoke(err);
+        throw err;
+      }
+      mutability = MutabilityState.FINISHED;
+      resolveUpgradableP(lastInstance);
+      upgradablePK.resolve(lastInstance);
+    },
+    revoke(reason = undefined) {
+      assertMutable();
+      rejectUpgradableP(reason);
+      upgradablePK.reject(reason);
 
-      // Only now is it safe to replace the upgradable.
+      // These steps are to ensure that we rejected
+      // the promise kit.
+      upgradablePK = producePromise();
+      upgradablePK.reject(reason);
+
+      mutability = MutabilityState.REVOKED;
+      lastInstance = undefined;
+    },
+    async upgrade(replacerP) {
+      assertMutable();
+      if (lastInstance) {
+        // We deliberately stall until the upgrade succeeds.
+        upgradablePK = producePromise();
+      }
+      const ourPK = upgradablePK;
+      const newInstanceP = E(replacerP).upgradeFromLast(undefined);
+      newInstanceP.catch(_ => {
+        // Reinstall the old version.
+        if (lastInstance) {
+          upgradablePK.resolve(lastInstance);
+        }
+      });
+
+      // If we throw, we'll hit the above catch block on our way.
+      const newInstance = /** @type {T} */ (await newInstanceP);
+      // AWAIT
+
+      if (upgradablePK !== ourPK) {
+        // We've moved on to another request.
+        throw Error(`Stale upgrade request`);
+      }
+
+      assertMutable();
+      mutability = MutabilityState.INSTALLED;
+      lastInstance = newInstance;
       upgradablePK.resolve(newInstance);
 
       // Give back what we got from the upgrade function.
-      return newInstance;
+      return upgradablePK.promise;
     },
   };
 
   return harden({
-    upgradableP: upgradablePK.promise,
+    upgradableP,
     upgrader,
   });
 }

--- a/packages/upgrader/src/upgrader.js
+++ b/packages/upgrader/src/upgrader.js
@@ -5,31 +5,80 @@ import { producePromise } from '@agoric/produce-promise';
 import './types';
 
 /**
- * @enum {number} MutabilityState
+ * @enum {number} Internal state of the upgradableP
  */
 const MutabilityState = {
-  INIT: 0,
+  /**
+   * The upgradableP is queuing messages before the first
+   * installation.
+   */
+  QUEUING: 0,
+  /**
+   * The upgradeableP has an active implementation.
+   */
   INSTALLED: 1,
+  /**
+   * The upgradableP has been permanently resolved.
+   */
   FINISHED: 2,
+  /**
+   * The upgradableP has been permanently rejected.
+   */
   REVOKED: 3,
 };
 
 /**
- * @template {Object} T
- * @param {T} [initialInstance]
- * @returns {UpgraderKit<T>}
+ * Create a HandledPromise handler to forward to the results
+ * of a thunk.
+ * @param {() => any} getTarget fetch the latest value of the target
+ */
+const makeForwardingHandler = getTarget => ({
+  applyMethod(_p, name, args) {
+    if (name === undefined) {
+      // @ts-ignore This expression is not callable.
+      return E(getTarget())(...args);
+    }
+    return E(getTarget())[name](...args);
+  },
+  get(_p, name) {
+    // @ts-ignore Symbol can't be an index type.
+    return E.G(getTarget())[name];
+  },
+});
+
+/**
+ * Create a HandledPromise that is stable even though it forwards
+ * to the latest "upgrade" of the underlying implementation.
+ *
+ * The `upgrader` has methods for managing the mapping of the
+ * upgradableP to its implementation.  Notably, upgrades only
+ * take effect if they can be successfully installed.
+ *
+ * We take advantage of promise pipelining so that
+ * the stable `upgradableP` forwards eventual calls (using tildot or E())
+ * but is not actually resolved or rejected unless the upgrader asks
+ * to permanently finish() or revoke() it.
+ *
+ * @template {Object} T The type of the HandledPromise must be an object
+ * so that it can be used with the `@agoric/marshal` system.
+ * @param {T} [initialInstance] If set, the initial implementation of
+ * the HandledPromise.
+ * @returns {UpgraderKit<T>} The upgradableP and upgrader facet.
  */
 export function makeUpgraderKit(initialInstance = undefined) {
-  let mutability = MutabilityState.INIT;
+  let mutability = MutabilityState.QUEUING;
 
   const assertMutable = () => {
     switch (mutability) {
-      case MutabilityState.FINISHED:
+      case MutabilityState.FINISHED: {
         throw Error(`Upgrader already finished`);
-      case MutabilityState.REVOKED:
+      }
+      case MutabilityState.REVOKED: {
         throw Error(`Upgrader already revoked`);
-      default:
+      }
+      default: {
         return true;
+      }
     }
   };
 
@@ -49,31 +98,23 @@ export function makeUpgraderKit(initialInstance = undefined) {
       resolveUpgradableP = resolve;
       rejectUpgradableP = reject;
     },
-    {
-      applyMethod(_p, name, args) {
-        if (name === undefined) {
-          return /** @type {Function} */ (E(upgradablePK.promise))(...args);
-        }
-        return E(upgradablePK.promise)[name](...args);
-      },
-      get(_p, name) {
-        return E.G(upgradablePK.promise)[name];
-      },
-    },
+    makeForwardingHandler(() => upgradablePK.promise),
   );
 
   /** @type {Upgrader<T>} */
   const upgrader = {
     finish() {
       assertMutable();
-      if (!lastInstance) {
+      if (mutability === MutabilityState.QUEUING) {
         const err = Error(`No instance was ever installed`);
         upgrader.revoke(err);
         throw err;
       }
+      const final = /** @type {T} */ (lastInstance);
+      lastInstance = undefined;
       mutability = MutabilityState.FINISHED;
-      resolveUpgradableP(lastInstance);
-      upgradablePK.resolve(lastInstance);
+      resolveUpgradableP(final);
+      upgradablePK.resolve(final);
     },
     revoke(reason = undefined) {
       assertMutable();
@@ -90,16 +131,24 @@ export function makeUpgraderKit(initialInstance = undefined) {
     },
     async upgrade(replacerP) {
       assertMutable();
-      if (lastInstance) {
+      /** @type {Promise<T> | undefined} */
+      let priorP;
+      const prior = /** @type {T} */ (lastInstance);
+      if (mutability !== MutabilityState.QUEUING) {
         // We deliberately stall until the upgrade succeeds.
+        priorP = new HandledPromise((_res, _rej, resolveWithPresence) => {
+          // Wrap the old implementation in a presence so that the
+          // user cannot reach into it.
+          resolveWithPresence(makeForwardingHandler(() => prior));
+        });
         upgradablePK = producePromise();
       }
       const ourPK = upgradablePK;
-      const newInstanceP = E(replacerP).upgradeFromLast(undefined);
+      const newInstanceP = E(replacerP).upgradeFrom(priorP);
       newInstanceP.catch(_ => {
         // Reinstall the old version.
-        if (lastInstance) {
-          upgradablePK.resolve(lastInstance);
+        if (priorP) {
+          upgradablePK.resolve(prior);
         }
       });
 
@@ -115,7 +164,7 @@ export function makeUpgraderKit(initialInstance = undefined) {
       assertMutable();
       mutability = MutabilityState.INSTALLED;
       lastInstance = newInstance;
-      upgradablePK.resolve(newInstance);
+      upgradablePK.resolve(lastInstance);
 
       // Give back what we got from the upgrade function.
       return upgradablePK.promise;

--- a/packages/upgrader/src/upgrader.js
+++ b/packages/upgrader/src/upgrader.js
@@ -1,0 +1,40 @@
+// @ts-check
+import { assert, details } from '@agoric/assert';
+import { E } from '@agoric/eventual-send';
+import { producePromise } from '@agoric/produce-promise';
+
+import './types';
+
+/**
+ * @template T
+ * @param {T} [initialInstance]
+ * @returns {UpgraderKit<T>}
+ */
+export function makeUpgraderKit(initialInstance = undefined) {
+  assert(
+    initialInstance === undefined,
+    details`initialInstance not implemented`,
+  );
+
+  /** @type {PromiseRecord<T>} */
+  const upgradablePK = producePromise();
+
+  /** @type {Upgrader<T>} */
+  const upgrader = {
+    async upgrade(replacerP) {
+      // We deliberately stall until the upgrade succeeds.
+      const newInstance = await E(replacerP).upgradeFromLast(undefined);
+
+      // Only now is it safe to replace the upgradable.
+      upgradablePK.resolve(newInstance);
+
+      // Give back what we got from the upgrade function.
+      return newInstance;
+    },
+  };
+
+  return harden({
+    upgradableP: upgradablePK.promise,
+    upgrader,
+  });
+}

--- a/packages/upgrader/test/test-upgrader.js
+++ b/packages/upgrader/test/test-upgrader.js
@@ -1,0 +1,38 @@
+// @ts-check
+import '@agoric/install-ses';
+import { E } from '@agoric/eventual-send';
+
+import test from 'tape-promise/tape';
+import { makeUpgraderKit } from '../src/index';
+
+import '../src/types';
+
+/**
+ * @typedef {Object} Hello
+ * @property {(name: string) => string} hello
+ */
+
+test('upgrader - wait until initialized', async t => {
+  t.plan(3);
+  /** @type {UpgraderKit<Hello>} */
+  const { upgradableP: helloObj, upgrader } = makeUpgraderKit();
+
+  const msgP = E(helloObj).hello('World');
+  upgrader.upgrade({
+    upgradeFromLast(lastInstance) {
+      t.equals(lastInstance, undefined, `initial instance has no lastInstance`);
+      return harden({
+        hello(name) {
+          return `Hello, ${name}!`;
+        },
+      });
+    },
+  });
+
+  const msg = await msgP;
+  t.equals(msg, `Hello, World!`, `delayed message is returned`);
+
+  const msg2 = await E(helloObj).hello('foo');
+  t.equals(msg2, `Hello, foo!`, `fresh message is forwarded`);
+  t.end();
+});

--- a/packages/upgrader/test/test-upgrader.js
+++ b/packages/upgrader/test/test-upgrader.js
@@ -18,8 +18,8 @@ test('upgrader - wait until initialized', async t => {
   const { upgradableP: helloObj, upgrader } = makeUpgraderKit();
 
   const msgP = E(helloObj).hello('World');
-  upgrader.upgrade({
-    upgradeFromLast(lastInstance) {
+  await upgrader.upgrade({
+    async upgradeFromLast(lastInstance) {
       t.equals(lastInstance, undefined, `initial instance has no lastInstance`);
       return harden({
         hello(name) {
@@ -34,5 +34,47 @@ test('upgrader - wait until initialized', async t => {
 
   const msg2 = await E(helloObj).hello('foo');
   t.equals(msg2, `Hello, foo!`, `fresh message is forwarded`);
+  t.end();
+});
+
+test('upgrader - upgrade twice', async t => {
+  t.plan(5);
+  /** @type {UpgraderKit<Hello>} */
+  const { upgradableP: helloObj, upgrader } = makeUpgraderKit();
+
+  const msgP = E(helloObj).hello('World');
+  await upgrader.upgrade({
+    async upgradeFromLast(lastInstance) {
+      t.equals(lastInstance, undefined, `initial instance has no lastInstance`);
+      return harden({
+        hello(name) {
+          return `Hello, ${name}!`;
+        },
+      });
+    },
+  });
+
+  const msg = await msgP;
+  t.equals(msg, `Hello, World!`, `delayed message is returned`);
+
+  const msg2 = await E(helloObj).hello('foo');
+  t.equals(msg2, `Hello, foo!`, `fresh message is forwarded`);
+
+  const upP = upgrader.upgrade({
+    async upgradeFromLast(lastInstance) {
+      t.equals(lastInstance, undefined, `initial instance has no lastInstance`);
+      return harden({
+        hello(name) {
+          return `Goodbye, ${name}!`;
+        },
+      });
+    },
+  });
+  const msg3P = E(helloObj).hello('cruel World');
+
+  await upP;
+  const msg3 = await msg3P;
+  t.equals(msg3, `Goodbye, cruel World!`, `upgraded message is returned`);
+
   t.end();
 });


### PR DESCRIPTION
This is intended to be used by services that expose a standard interface and want to leave the door open for future upgrades.

The "upgradable" is a HandledPromise with an unfulfilled handler whose guts can be replaced, revoked, or finished.  This module works atomically so that upgrades can fail without affecting current users of the presence (except for delaying their messages while the upgrade attempt is being made).  Also, revoking or finishing the upgrade is irreversible, and result in rejecting/resolving the HandledPromise.

See the typing, comments, and tests for how to use.