### PR TITLE
add VatWorker for local threads (Node.js "Worker")

### DIFF
--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -23,7 +23,6 @@
   },
   "devDependencies": {
     "@agoric/install-metering-and-ses": "^0.1.1",
-    "@agoric/install-ses": "^0.2.0",
     "esm": "^3.2.5",
     "tap": "^14.10.5",
     "tape": "^4.13.2",
@@ -35,6 +34,7 @@
     "@agoric/bundle-source": "^1.1.6",
     "@agoric/eventual-send": "^0.9.3",
     "@agoric/import-bundle": "^0.0.8",
+    "@agoric/install-ses": "^0.2.0",
     "@agoric/marshal": "^0.2.3",
     "@agoric/nat": "^2.0.1",
     "@agoric/promise-kit": "^0.1.3",

--- a/packages/SwingSet/src/assertOptions.js
+++ b/packages/SwingSet/src/assertOptions.js
@@ -1,0 +1,10 @@
+import { assert } from '@agoric/assert';
+
+export function assertKnownOptions(options, knownNames) {
+  assert(knownNames instanceof Array);
+  for (const name of Object.keys(options)) {
+    if (knownNames.indexOf(name) === -1) {
+      throw Error(`unknown option ${name}`);
+    }
+  }
+}

--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -277,7 +277,7 @@ export async function buildVatController(
   const timerWrapperBundle = await bundleSource(timerWrapperSourcePath);
   kernel.addGenesisVat('timer', timerWrapperBundle);
 
-  async function addGenesisVat(
+  function addGenesisVat(
     name,
     bundleName,
     vatParameters = {},
@@ -387,19 +387,10 @@ export async function buildVatController(
   }
 
   if (config.vats) {
-    const vats = [];
     for (const name of Object.keys(config.vats)) {
-      const v = config.vats[name];
-      vats.push(
-        addGenesisVat(
-          name,
-          v.bundleName || name,
-          v.parameters || {},
-          v.creationOptions || {},
-        ),
-      );
+      const { bundleName, parameters, creationOptions } = config.vats[name];
+      addGenesisVat(name, bundleName || name, parameters, creationOptions);
     }
-    await Promise.all(vats);
   }
 
   // start() may queue bootstrap if state doesn't say we did it already. It

--- a/packages/SwingSet/src/kernel/dynamicVat.js
+++ b/packages/SwingSet/src/kernel/dynamicVat.js
@@ -77,14 +77,6 @@ export function makeDynamicVatCreator(stuff) {
       );
     }
 
-    const managerOptions = {
-      metered,
-      notifyTermination: metered ? notifyTermination : undefined,
-      vatPowerType: 'dynamic',
-      creationOptions,
-      vatParameters,
-    };
-
     async function build() {
       if (typeof vatSourceBundle !== 'object') {
         throw Error(
@@ -92,11 +84,16 @@ export function makeDynamicVatCreator(stuff) {
         );
       }
 
-      const manager = await vatManagerFactory.createFromBundle(
-        vatSourceBundle,
-        vatID,
-        managerOptions,
-      );
+      const mOpts = {
+        bundle: vatSourceBundle,
+        metered,
+        notifyTermination: metered ? notifyTermination : undefined,
+        enableInternalMetering: false,
+        enableSetup: false,
+        creationOptions,
+        vatParameters,
+      };
+      const manager = await vatManagerFactory(vatID, mOpts);
       const addOptions = {}; // enablePipelining:false
       addVatManager(vatID, manager, addOptions);
     }

--- a/packages/SwingSet/src/kernel/dynamicVat.js
+++ b/packages/SwingSet/src/kernel/dynamicVat.js
@@ -1,3 +1,4 @@
+import { assertKnownOptions } from '../assertOptions';
 import { makeVatSlot } from '../parseVatSlots';
 
 export function makeVatRootObjectSlot() {
@@ -35,17 +36,9 @@ export function makeDynamicVatCreator(stuff) {
    * citing this vatID
    */
 
-  function createVatDynamically(vatSourceBundle, options = {}) {
-    const {
-      metered = true,
-      creationOptions = {},
-      vatParameters = {},
-      ...unknownOptions
-    } = options;
-    if (Object.keys(unknownOptions).length) {
-      const msg = JSON.stringify(Object.keys(unknownOptions));
-      throw Error(`createVatDynamically got unknown options ${msg}`);
-    }
+  function createVatDynamically(vatSourceBundle, dynamicOptions = {}) {
+    assertKnownOptions(dynamicOptions, ['metered', 'vatParameters']);
+    const { metered = true, vatParameters = {} } = dynamicOptions;
 
     const vatID = allocateUnusedVatID();
     let terminated = false;
@@ -84,18 +77,16 @@ export function makeDynamicVatCreator(stuff) {
         );
       }
 
-      const mOpts = {
+      const managerOptions = {
         bundle: vatSourceBundle,
         metered,
-        notifyTermination: metered ? notifyTermination : undefined,
-        enableInternalMetering: false,
         enableSetup: false,
-        creationOptions,
+        enableInternalMetering: false,
+        notifyTermination: metered ? notifyTermination : undefined,
         vatParameters,
       };
-      const manager = await vatManagerFactory(vatID, mOpts);
-      const addOptions = {}; // enablePipelining:false
-      addVatManager(vatID, manager, addOptions);
+      const manager = await vatManagerFactory(vatID, managerOptions);
+      addVatManager(vatID, manager, managerOptions);
     }
 
     function makeSuccessResponse() {

--- a/packages/SwingSet/src/kernel/vatManager/deliver.js
+++ b/packages/SwingSet/src/kernel/vatManager/deliver.js
@@ -82,7 +82,7 @@ export function makeDeliver(tools, dispatch) {
   }
 
   async function deliverOneNotification(vpid, vp) {
-    const errmsg = `vat[${vatID}].promise[${vpid}] vp.state failed`;
+    const errmsg = `vat[${vatID}].promise[${vpid}] ${vp.state} failed`;
     switch (vp.state) {
       case 'fulfilledToPresence':
         return doProcess(['notifyFulfillToPresence', vpid, vp.slot], errmsg);

--- a/packages/SwingSet/src/kernel/vatManager/factory.js
+++ b/packages/SwingSet/src/kernel/vatManager/factory.js
@@ -1,0 +1,79 @@
+/* global harden */
+import { assert } from '@agoric/assert';
+import { makeLocalVatManagerFactory } from './localVatManager';
+import { makeNodeWorkerVatManagerFactory } from './nodeWorker';
+
+export function makeVatManagerFactory({
+  allVatPowers,
+  kernelKeeper,
+  makeVatEndowments,
+  meterManager,
+  transformMetering,
+  waitUntilQuiescent,
+  makeNodeWorker,
+}) {
+  const localFactory = makeLocalVatManagerFactory({
+    allVatPowers,
+    kernelKeeper,
+    makeVatEndowments,
+    meterManager,
+    transformMetering,
+    waitUntilQuiescent,
+  });
+
+  const nodeWorkerFactory = makeNodeWorkerVatManagerFactory({
+    makeNodeWorker,
+    kernelKeeper,
+  });
+
+  // returns promise for new vatManager
+  function vatManagerFactory(vatID, options) {
+    // options: setup|bundle, managerType, metered, notifyTermination,
+    // internalMetering
+    const {
+      managerType = 'local',
+      setup,
+      bundle,
+      metered = false,
+      enableSetup = false,
+      enableInternalMetering = false,
+      notifyTermination = undefined,
+    } = options || {};
+    assert(setup || bundle);
+    assert(
+      !bundle || typeof bundle === 'object',
+      `bundle must be object, not a plain string`,
+    );
+    assert(!(setup && !enableSetup), `setup() provided, but not enabled`); // todo maybe useless
+    assert(
+      !(notifyTermination && !metered),
+      `notifyTermination is useless without metered:true`,
+    );
+    const fOpts = {
+      metered,
+      enableSetup,
+      enableInternalMetering,
+      notifyTermination,
+    };
+
+    if (managerType === 'local') {
+      if (setup) {
+        return localFactory.createFromSetup(vatID, setup, fOpts);
+      }
+      return localFactory.createFromBundle(vatID, bundle, fOpts);
+    }
+
+    if (managerType === 'nodeWorker') {
+      // 'setup' based vats must be local. TODO: stop using 'setup' in vats,
+      // but tests and comms-vat still need it
+      assert(!setup, `setup()-based vats must use a local Manager`);
+      return nodeWorkerFactory.createFromBundle(vatID, bundle, fOpts);
+    }
+
+    throw Error(
+      `unknown manager type ${managerType}, not 'local' or 'nodeWorker'`,
+    );
+  }
+
+  return harden(vatManagerFactory);
+}

--- a/packages/SwingSet/src/kernel/vatManager/localVatManager.js
+++ b/packages/SwingSet/src/kernel/vatManager/localVatManager.js
@@ -1,0 +1,160 @@
+/* global harden */
+import { assert } from '@agoric/assert';
+import { importBundle } from '@agoric/import-bundle';
+import { makeLiveSlots } from '../liveSlots';
+import { createSyscall } from './syscall';
+import { makeDeliver } from './deliver';
+import { makeTranscriptManager } from './transcript';
+
+export function makeLocalVatManagerFactory(tools) {
+  const {
+    allVatPowers,
+    kernelKeeper,
+    makeVatEndowments,
+    meterManager,
+    transformMetering,
+    waitUntilQuiescent,
+  } = tools;
+
+  const { makeGetMeter, refillAllMeters, stopGlobalMeter } = meterManager;
+  const baseVP = {
+    Remotable: allVatPowers.Remotable,
+    getInterfaceOf: allVatPowers.getInterfaceOf,
+    transformTildot: allVatPowers.transformTildot,
+  };
+  const internalMeteringVP = {
+    makeGetMeter: allVatPowers.makeGetMeter,
+    transformMetering: allVatPowers.transformMetering,
+  };
+  // testLog is also a vatPower, only for unit tests
+
+  function prepare(vatID, options = {}) {
+    const { notifyTermination = undefined } = options;
+    const vatKeeper = kernelKeeper.allocateVatKeeperIfNeeded(vatID);
+    const transcriptManager = makeTranscriptManager(
+      kernelKeeper,
+      vatKeeper,
+      vatID,
+    );
+    const { syscall, setVatSyscallHandler } = createSyscall(transcriptManager);
+    function finish(dispatch, meterRecord) {
+      assert(
+        dispatch && dispatch.deliver,
+        `vat failed to return a 'dispatch' with .deliver: ${dispatch}`,
+      );
+      const { deliver, replayTranscript } = makeDeliver(
+        {
+          vatID,
+          stopGlobalMeter,
+          notifyTermination,
+          meterRecord,
+          refillAllMeters,
+          transcriptManager,
+          vatKeeper,
+          waitUntilQuiescent,
+        },
+        dispatch,
+      );
+
+      function shutdown() {
+        // local workers don't need anything special to shut down between turns
+      }
+
+      const manager = harden({
+        replayTranscript,
+        setVatSyscallHandler,
+        deliver,
+        shutdown,
+      });
+      return manager;
+    }
+    return { syscall, finish };
+  }
+
+  function createFromSetup(vatID, setup, options) {
+    assert(!options.metered, `unsupported`);
+    assert(!options.enableInternalMetering, `unsupported`);
+    assert(!options.notifyTermination, `unsupported`);
+    assert(setup instanceof Function, 'setup is not an in-realm function');
+    const { syscall, finish } = prepare(vatID, options);
+
+    const helpers = harden({}); // DEPRECATED, todo remove from setup()
+    const state = null; // TODO remove from setup()
+    const vatPowers = harden({ ...baseVP, testLog: allVatPowers.testLog });
+    const dispatch = setup(syscall, state, helpers, vatPowers);
+    const meterRecord = null;
+    return finish(dispatch, meterRecord);
+  }
+
+  async function createFromBundle(vatID, bundle, options) {
+    const {
+      metered,
+      notifyTermination,
+      enableSetup,
+      enableInternalMetering,
+    } = options;
+
+    let meterRecord = null;
+    if (metered) {
+      // fail-stop: we refill the meter after each crank (in vatManager
+      // doProcess()), but if the vat exhausts its meter within a single
+      // crank, it will never run again. We set refillEachCrank:false because
+      // we want doProcess to do the refilling itself, so it can count the
+      // usage
+      meterRecord = makeGetMeter({
+        refillEachCrank: false,
+        refillIfExhausted: false,
+      });
+    }
+
+    const inescapableTransforms = [];
+    const inescapableGlobalLexicals = {};
+    if (metered) {
+      const getMeter = meterRecord.getMeter;
+      inescapableTransforms.push(src => transformMetering(src, getMeter));
+      inescapableGlobalLexicals.getMeter = getMeter;
+    }
+
+    const vatNS = await importBundle(bundle, {
+      filePrefix: vatID,
+      endowments: makeVatEndowments(vatID),
+      inescapableTransforms,
+      inescapableGlobalLexicals,
+    });
+
+    const { syscall, finish } = prepare(vatID, { notifyTermination });
+    const imVP = enableInternalMetering ? internalMeteringVP : {};
+    const vatPowers = harden({
+      ...baseVP,
+      ...imVP,
+      testLog: allVatPowers.testLog,
+    });
+    const state = null; // TODO remove from makeLiveSlots()
+
+    let dispatch;
+    if (typeof vatNS.buildRootObject === 'function') {
+      const { buildRootObject } = vatNS;
+      dispatch = makeLiveSlots(
+        syscall,
+        state,
+        buildRootObject,
+        vatID,
+        vatPowers,
+      );
+    } else {
+      const setup = vatNS.default;
+      assert(setup, `vat source bundle lacks (default) setup() function`);
+      assert(setup instanceof Function, `setup is not a function`);
+      assert(enableSetup, `got setup(), but not options.enableSetup`);
+      const helpers = harden({}); // DEPRECATED, todo remove from setup()
+      dispatch = setup(syscall, state, helpers, vatPowers);
+    }
+    return finish(dispatch, meterRecord);
+  }
+
+  const localVatManagerFactory = harden({
+    createFromBundle,
+    createFromSetup,
+  });
+  return localVatManagerFactory;
+}

--- a/packages/SwingSet/src/kernel/vatManager/nodeWorker.js
+++ b/packages/SwingSet/src/kernel/vatManager/nodeWorker.js
@@ -27,7 +27,12 @@ function parentLog(first, ...args) {
 export function makeNodeWorkerVatManagerFactory(tools) {
   const { makeNodeWorker, kernelKeeper } = tools;
 
-  function createFromBundle(vatID, bundle, _options) {
+  function createFromBundle(vatID, bundle, managerOptions) {
+    const { vatParameters } = managerOptions;
+    assert(!managerOptions.metered, 'not supported yet');
+    assert(!managerOptions.notifyTermination, 'not supported yet');
+    assert(!managerOptions.enableSetup, 'not supported at all');
+    assert(!managerOptions.enableInternalMetering, 'eww ick');
     const vatKeeper = kernelKeeper.allocateVatKeeperIfNeeded(vatID);
     const transcriptManager = makeTranscriptManager(
       kernelKeeper,
@@ -101,7 +106,7 @@ export function makeNodeWorkerVatManagerFactory(tools) {
     gotWorker(worker);
 
     parentLog(`instructing worker to load bundle..`);
-    sendToWorker(['setBundle', bundle]);
+    sendToWorker(['setBundle', bundle, vatParameters]);
 
     function deliver(delivery) {
       parentLog(`sending delivery`, delivery);

--- a/packages/SwingSet/src/kernel/vatManager/nodeWorker.js
+++ b/packages/SwingSet/src/kernel/vatManager/nodeWorker.js
@@ -1,0 +1,137 @@
+/* global harden */
+
+// import { Worker } from 'worker_threads'; // not from a Compartment
+import { assert } from '@agoric/assert';
+import { makePromiseKit } from '@agoric/promise-kit';
+import { makeTranscriptManager } from './transcript';
+
+import { createSyscall } from './syscall';
+
+// start a "Worker" (Node's tool for starting new threads) and load a bundle
+// into it
+
+/*
+import { waitUntilQuiescent } from '../../waitUntilQuiescent';
+function wait10ms() {
+  const { promise: queueEmptyP, resolve } = makePromiseKit();
+  setTimeout(() => resolve(), 10);
+  return queueEmptyP;
+}
+*/
+
+// eslint-disable-next-line no-unused-vars
+function parentLog(first, ...args) {
+  // console.error(`--parent: ${first}`, ...args);
+}
+
+export function makeNodeWorkerVatManagerFactory(tools) {
+  const { makeNodeWorker, kernelKeeper } = tools;
+
+  function createFromBundle(vatID, bundle, _options) {
+    const vatKeeper = kernelKeeper.allocateVatKeeperIfNeeded(vatID);
+    const transcriptManager = makeTranscriptManager(
+      kernelKeeper,
+      vatKeeper,
+      vatID,
+    );
+
+    // prepare to accept syscalls from the worker
+
+    // TODO: make the worker responsible for checking themselves: we send
+    // both the delivery and the expected syscalls, and the supervisor
+    // compares what the bundle does with what it was told to expect.
+    // Modulo flow control, we just stream transcript entries at the
+    // worker and eventually get back an "ok" or an error. When we do
+    // that, doSyscall won't even see replayed syscalls from the worker.
+
+    const { doSyscall, setVatSyscallHandler } = createSyscall(
+      transcriptManager,
+    );
+    function handleSyscall(vatSyscallObject) {
+      const type = vatSyscallObject[0];
+      if (type === 'callNow') {
+        throw Error(`nodeWorker cannot block, cannot use syscall.callNow`);
+      }
+      doSyscall(vatSyscallObject);
+    }
+
+    // start the worker and establish a connection
+
+    const { promise: workerP, resolve: gotWorker } = makePromiseKit();
+
+    function sendToWorker(msg) {
+      assert(msg instanceof Array);
+      workerP.then(worker => worker.postMessage(msg));
+    }
+
+    const {
+      promise: dispatchReadyP,
+      resolve: dispatchIsReady,
+    } = makePromiseKit();
+    let waiting;
+
+    function handleUpstream([type, ...args]) {
+      parentLog(`received`, type);
+      if (type === 'setUplinkAck') {
+        parentLog(`upload ready`);
+      } else if (type === 'gotBundle') {
+        parentLog(`bundle loaded`);
+      } else if (type === 'dispatchReady') {
+        parentLog(`dispatch() ready`);
+        // wait10ms().then(dispatchIsReady); // stall to let logs get printed
+        dispatchIsReady();
+      } else if (type === 'syscall') {
+        parentLog(`syscall`, args);
+        const vatSyscallObject = args;
+        handleSyscall(vatSyscallObject);
+      } else if (type === 'deliverDone') {
+        parentLog(`deliverDone`);
+        if (waiting) {
+          const resolve = waiting;
+          waiting = null;
+          resolve();
+        }
+      } else {
+        parentLog(`unrecognized uplink message ${type}`);
+      }
+    }
+
+    const worker = makeNodeWorker();
+    worker.on('message', handleUpstream);
+    gotWorker(worker);
+
+    parentLog(`instructing worker to load bundle..`);
+    sendToWorker(['setBundle', bundle]);
+
+    function deliver(delivery) {
+      parentLog(`sending delivery`, delivery);
+      assert(!waiting, `already waiting for delivery`);
+      const pr = makePromiseKit();
+      waiting = pr.resolve;
+      sendToWorker(['deliver', ...delivery]);
+      return pr.promise;
+    }
+
+    function replayTranscript() {
+      throw Error(`replayTranscript not yet implemented`);
+    }
+
+    function shutdown() {
+      // this returns a Promise that fulfills with 1 if we used
+      // worker.terminate(), otherwise with the `exitCode` passed to
+      // `process.exit(exitCode)` within the worker.
+      return worker.terminate();
+    }
+
+    const manager = harden({
+      replayTranscript,
+      setVatSyscallHandler,
+      deliver,
+      shutdown,
+    });
+
+    return dispatchReadyP.then(() => manager);
+  }
+
+  return harden({ createFromBundle });
+}

--- a/packages/SwingSet/src/kernel/vatManager/nodeWorker.js
+++ b/packages/SwingSet/src/kernel/vatManager/nodeWorker.js
@@ -32,7 +32,12 @@ export function makeNodeWorkerVatManagerFactory(tools) {
     assert(!managerOptions.metered, 'not supported yet');
     assert(!managerOptions.notifyTermination, 'not supported yet');
     assert(!managerOptions.enableSetup, 'not supported at all');
-    assert(!managerOptions.enableInternalMetering, 'eww ick');
+    if (managerOptions.enableInternalMetering) {
+      // TODO: warn+ignore, rather than throw, because the kernel enables it
+      // for all vats, because the Spawner still needs it. When the kernel
+      // stops doing that, turn this into a regular assert
+      console.log(`node-worker does not support enableInternalMetering`);
+    }
     const vatKeeper = kernelKeeper.allocateVatKeeperIfNeeded(vatID);
     const transcriptManager = makeTranscriptManager(
       kernelKeeper,

--- a/packages/SwingSet/src/kernel/vatManager/nodeWorkerSupervisor.js
+++ b/packages/SwingSet/src/kernel/vatManager/nodeWorkerSupervisor.js
@@ -70,10 +70,11 @@ let syscallLog;
 parentPort.on('message', ([type, ...margs]) => {
   workerLog(`received`, type);
   if (type === 'start') {
+    // TODO: parent should send ['start', vatID]
     workerLog(`got start`);
     sendUplink(['gotStart']);
   } else if (type === 'setBundle') {
-    const [bundle] = margs;
+    const [bundle, vatParameters] = margs;
     const endowments = {
       console: makeConsole(`SwingSet:vatWorker`),
       HandledPromise,
@@ -110,6 +111,7 @@ parentPort.on('message', ([type, ...margs]) => {
         vatNS.buildRootObject,
         vatID,
         vatPowers,
+        vatParameters,
       );
       workerLog(`got dispatch:`, Object.keys(dispatch).join(','));
       sendUplink(['dispatchReady']);

--- a/packages/SwingSet/src/kernel/vatManager/nodeWorkerSupervisor.js
+++ b/packages/SwingSet/src/kernel/vatManager/nodeWorkerSupervisor.js
@@ -1,0 +1,140 @@
+/* global harden */
+// this file is loaded at the start of a new Worker, which makes it a new JS
+// environment (with it's own Realm), so we must install-ses too.
+import '@agoric/install-ses';
+import { parentPort } from 'worker_threads';
+import anylogger from 'anylogger';
+
+import { assert } from '@agoric/assert';
+import { importBundle } from '@agoric/import-bundle';
+import { Remotable, getInterfaceOf } from '@agoric/marshal';
+import { HandledPromise } from '@agoric/eventual-send';
+import { waitUntilQuiescent } from '../../waitUntilQuiescent';
+import { makeLiveSlots } from '../liveSlots';
+
+// eslint-disable-next-line no-unused-vars
+function workerLog(first, ...args) {
+  // console.error(`---worker: ${first}`, ...args);
+}
+
+workerLog(`supervisor started`);
+
+function makeConsole(tag) {
+  const log = anylogger(tag);
+  const cons = {};
+  for (const level of ['debug', 'log', 'info', 'warn', 'error']) {
+    cons[level] = log[level];
+  }
+  return harden(cons);
+}
+
+function runAndWait(f, errmsg) {
+  Promise.resolve()
+    .then(f)
+    .then(undefined, err => workerLog(`doProcess: ${errmsg}:`, err));
+  return waitUntilQuiescent();
+}
+
+function sendUplink(msg) {
+  assert(msg instanceof Array, `msg must be an Array`);
+  parentPort.postMessage(msg);
+}
+
+let dispatch;
+
+async function doProcess(dispatchRecord, errmsg) {
+  const dispatchOp = dispatchRecord[0];
+  const dispatchArgs = dispatchRecord.slice(1);
+  workerLog(`runAndWait`);
+  await runAndWait(() => dispatch[dispatchOp](...dispatchArgs), errmsg);
+  workerLog(`doProcess done`);
+}
+
+function doNotify(vpid, vp) {
+  const errmsg = `vat.promise[${vpid}] ${vp.state} failed`;
+  switch (vp.state) {
+    case 'fulfilledToPresence':
+      return doProcess(['notifyFulfillToPresence', vpid, vp.slot], errmsg);
+    case 'redirected':
+      throw new Error('not implemented yet');
+    case 'fulfilledToData':
+      return doProcess(['notifyFulfillToData', vpid, vp.data], errmsg);
+    case 'rejected':
+      return doProcess(['notifyReject', vpid, vp.data], errmsg);
+    default:
+      throw Error(`unknown promise state '${vp.state}'`);
+  }
+}
+
+let syscallLog;
+parentPort.on('message', ([type, ...margs]) => {
+  workerLog(`received`, type);
+  if (type === 'start') {
+    workerLog(`got start`);
+    sendUplink(['gotStart']);
+  } else if (type === 'setBundle') {
+    const [bundle] = margs;
+    const endowments = {
+      console: makeConsole(`SwingSet:vatWorker`),
+      HandledPromise,
+    };
+    importBundle(bundle, { endowments }).then(vatNS => {
+      workerLog(`got vatNS:`, Object.keys(vatNS).join(','));
+      sendUplink(['gotBundle']);
+
+      function doSyscall(vatSyscallObject) {
+        sendUplink(['syscall', ...vatSyscallObject]);
+      }
+      const syscall = harden({
+        send: (...args) => doSyscall(['send', ...args]),
+        callNow: (..._args) => {
+          throw Error(`nodeWorker cannot syscall.callNow`);
+        },
+        subscribe: (...args) => doSyscall(['subscribe', ...args]),
+        fulfillToData: (...args) => doSyscall(['fulfillToData', ...args]),
+        fulfillToPresence: (...args) =>
+          doSyscall(['fulfillToPresence', ...args]),
+        reject: (...args) => doSyscall(['reject', ...args]),
+      });
+
+      const state = null;
+      const vatID = 'demo-vatID';
+      // todo: maybe add transformTildot, makeGetMeter/transformMetering to
+      // vatPowers, but only if options tell us they're wanted. Maybe
+      // transformTildot should be async and outsourced to the kernel
+      // process/thread.
+      const vatPowers = { Remotable, getInterfaceOf };
+      dispatch = makeLiveSlots(
+        syscall,
+        state,
+        vatNS.buildRootObject,
+        vatID,
+        vatPowers,
+      );
+      workerLog(`got dispatch:`, Object.keys(dispatch).join(','));
+      sendUplink(['dispatchReady']);
+    });
+  } else if (type === 'deliver') {
+    if (!dispatch) {
+      workerLog(`error: deliver before dispatchReady`);
+      return;
+    }
+    const [dtype, ...dargs] = margs;
+    if (dtype === 'message') {
+      const [targetSlot, msg] = dargs;
+      const errmsg = `vat[${targetSlot}].${msg.method} dispatch failed`;
+      doProcess(
+        ['deliver', targetSlot, msg.method, msg.args, msg.result],
+        errmsg,
+      ).then(() => {
+        sendUplink(['deliverDone']);
+      });
+    } else if (dtype === 'notify') {
+      doNotify(...dargs).then(() => sendUplink(['deliverDone', syscallLog]));
+    } else {
+      throw Error(`bad delivery type ${dtype}`);
+    }
+  } else {
+    workerLog(`unrecognized downlink message ${type}`);
+  }
+});

--- a/packages/SwingSet/src/kernel/vatManager/syscall.js
+++ b/packages/SwingSet/src/kernel/vatManager/syscall.js
@@ -104,5 +104,5 @@ export function createSyscall(transcriptManager) {
     reject: (...args) => doSyscall(['reject', ...args]),
   });
 
-  return harden({ syscall, setVatSyscallHandler });
+  return harden({ syscall, doSyscall, setVatSyscallHandler });
 }

--- a/packages/SwingSet/test/metering/vat-load-dynamic.js
+++ b/packages/SwingSet/test/metering/vat-load-dynamic.js
@@ -12,8 +12,8 @@ export function buildRootObject(vatPowers) {
       service = await E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
     },
 
-    async createVat(bundle, options) {
-      control = await E(service).createVat(bundle, options);
+    async createVat(bundle, dynamicOptions) {
+      control = await E(service).createVat(bundle, dynamicOptions);
       E(control.adminNode)
         .done()
         .then(

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -33,7 +33,7 @@ async function simpleCall(t) {
     vats: {
       vat1: {
         sourcePath: require.resolve('./vat-controller-1'),
-        options: { enableSetup: true },
+        creationOptions: { enableSetup: true },
       },
     },
   };

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -33,6 +33,7 @@ async function simpleCall(t) {
     vats: {
       vat1: {
         sourcePath: require.resolve('./vat-controller-1'),
+        options: { enableSetup: true },
       },
     },
   };

--- a/packages/SwingSet/test/test-demos-comms.js
+++ b/packages/SwingSet/test/test-demos-comms.js
@@ -4,6 +4,12 @@ import { loadBasedir, buildVatController } from '../src/index';
 
 async function main(basedir, argv) {
   const config = await loadBasedir(basedir);
+  if (config.vats.botcomms) {
+    config.vats.botcomms.options.enableSetup = true;
+  }
+  if (config.vats.usercomms) {
+    config.vats.usercomms.options.enableSetup = true;
+  }
   const ldSrcPath = require.resolve('../src/devices/loopbox-src');
   config.devices = [['loopbox', ldSrcPath, {}]];
 

--- a/packages/SwingSet/test/test-demos-comms.js
+++ b/packages/SwingSet/test/test-demos-comms.js
@@ -4,11 +4,12 @@ import { loadBasedir, buildVatController } from '../src/index';
 
 async function main(basedir, argv) {
   const config = await loadBasedir(basedir);
+  const enableSetup = true;
   if (config.vats.botcomms) {
-    config.vats.botcomms.options.enableSetup = true;
+    config.vats.botcomms.creationOptions = { enableSetup };
   }
   if (config.vats.usercomms) {
-    config.vats.usercomms.options.enableSetup = true;
+    config.vats.usercomms.creationOptions = { enableSetup };
   }
   const ldSrcPath = require.resolve('../src/devices/loopbox-src');
   config.devices = [['loopbox', ldSrcPath, {}]];

--- a/packages/SwingSet/test/test-devices.js
+++ b/packages/SwingSet/test/test-devices.js
@@ -22,6 +22,7 @@ test('d0', async t => {
     vats: {
       bootstrap: {
         sourcePath: require.resolve('./files-devices/bootstrap-0'),
+        options: { enableSetup: true },
       },
     },
     devices: [['d0', require.resolve('./files-devices/device-0'), {}]],
@@ -62,6 +63,7 @@ test('d1', async t => {
     vats: {
       bootstrap: {
         sourcePath: require.resolve('./files-devices/bootstrap-1'),
+        options: { enableSetup: true },
       },
     },
     devices: [

--- a/packages/SwingSet/test/test-devices.js
+++ b/packages/SwingSet/test/test-devices.js
@@ -22,7 +22,7 @@ test('d0', async t => {
     vats: {
       bootstrap: {
         sourcePath: require.resolve('./files-devices/bootstrap-0'),
-        options: { enableSetup: true },
+        creationOptions: { enableSetup: true },
       },
     },
     devices: [['d0', require.resolve('./files-devices/device-0'), {}]],
@@ -63,7 +63,7 @@ test('d1', async t => {
     vats: {
       bootstrap: {
         sourcePath: require.resolve('./files-devices/bootstrap-1'),
-        options: { enableSetup: true },
+        creationOptions: { enableSetup: true },
       },
     },
     devices: [

--- a/packages/SwingSet/test/test-message-patterns.js
+++ b/packages/SwingSet/test/test-message-patterns.js
@@ -73,6 +73,7 @@ const vatTPSourcePath = require.resolve('../src/vats/vat-tp');
 
 export async function runVatsInComms(t, enablePipelining, name) {
   console.log(`------ testing pattern (comms) -- ${name}`);
+  const enableSetup = true;
   const bdir = path.resolve(__dirname, 'basedir-message-patterns');
   const config = await loadBasedir(bdir);
   config.bootstrap = 'bootstrap';
@@ -81,12 +82,14 @@ export async function runVatsInComms(t, enablePipelining, name) {
     sourcePath: commsSourcePath,
     creationOptions: {
       enablePipelining,
+      enableSetup,
     },
   };
   config.vats.rightcomms = {
     sourcePath: commsSourcePath,
     creationOptions: {
       enablePipelining,
+      enableSetup,
     },
   };
   config.vats.leftvattp = { sourcePath: vatTPSourcePath };

--- a/packages/SwingSet/test/workers/bootstrap.js
+++ b/packages/SwingSet/test/workers/bootstrap.js
@@ -14,7 +14,7 @@ export function buildRootObject() {
   const precE = makePromiseKit();
 
   return harden({
-    bootstrap(_argv, vats) {
+    bootstrap(vats) {
       const pA = E(vats.target).zero(callbackObj, precD.promise, precE.promise);
       const rp3 = E(vats.target).one();
       precD.resolve(callbackObj); // two

--- a/packages/SwingSet/test/workers/bootstrap.js
+++ b/packages/SwingSet/test/workers/bootstrap.js
@@ -1,0 +1,29 @@
+/* global harden */
+import { E } from '@agoric/eventual-send';
+import { makePromiseKit } from '@agoric/promise-kit';
+
+export function buildRootObject() {
+  const callbackObj = harden({
+    callback(arg1, arg2) {
+      console.log(`callback`, arg1, arg2);
+      return ['data', callbackObj]; // four, resolves pF
+    },
+  });
+
+  const precD = makePromiseKit();
+  const precE = makePromiseKit();
+
+  return harden({
+    bootstrap(_argv, vats) {
+      const pA = E(vats.target).zero(callbackObj, precD.promise, precE.promise);
+      const rp3 = E(vats.target).one();
+      precD.resolve(callbackObj); // two
+      precE.reject(Error('four')); // three
+      const done = Promise.all([
+        pA.then(([pB, pC, pF]) => Promise.all([pB, pC.catch(() => 0), pF])),
+        rp3,
+      ]);
+      return done;
+    },
+  });
+}

--- a/packages/SwingSet/test/workers/test-worker.js
+++ b/packages/SwingSet/test/workers/test-worker.js
@@ -1,16 +1,10 @@
 import '@agoric/install-ses';
 import tap from 'tap';
-import { buildVatController } from '../../src/index';
+import { loadBasedir, buildVatController } from '../../src/index';
 
 tap.test('nodeWorker vat manager', async t => {
-  const config = {
-    vats: new Map(),
-    bootstrapIndexJS: require.resolve('./bootstrap.js'),
-  };
-  config.vats.set('target', {
-    sourcepath: require.resolve('./vat-target.js'),
-    options: { managerType: 'nodeWorker' },
-  });
+  const config = await loadBasedir(__dirname);
+  config.vats.target.creationOptions = { managerType: 'nodeWorker' };
   const c = await buildVatController(config, []);
 
   await c.run();

--- a/packages/SwingSet/test/workers/test-worker.js
+++ b/packages/SwingSet/test/workers/test-worker.js
@@ -1,0 +1,21 @@
+import '@agoric/install-ses';
+import tap from 'tap';
+import { buildVatController } from '../../src/index';
+
+tap.test('nodeWorker vat manager', async t => {
+  const config = {
+    vats: new Map(),
+    bootstrapIndexJS: require.resolve('./bootstrap.js'),
+  };
+  config.vats.set('target', {
+    sourcepath: require.resolve('./vat-target.js'),
+    options: { managerType: 'nodeWorker' },
+  });
+  const c = await buildVatController(config, []);
+
+  await c.run();
+  t.equal(c.bootstrapResult.status(), 'fulfilled');
+
+  await c.shutdown();
+  t.end();
+});

--- a/packages/SwingSet/test/workers/vat-target.js
+++ b/packages/SwingSet/test/workers/vat-target.js
@@ -1,0 +1,57 @@
+/* global harden */
+import { E } from '@agoric/eventual-send';
+import { makePromiseKit } from '@agoric/promise-kit';
+
+function ignore(p) {
+  p.then(
+    () => 0,
+    () => 0,
+  );
+}
+
+// We arrange for this vat, 'vat-target', to receive a specific set of
+// inbound events ('dispatch'), which will provoke a set of outbound events
+// ('syscall'), that cover the full range of the dispatch/syscall interface
+
+export function buildRootObject() {
+  console.log(`vat does buildRootObject`); // make sure console works
+  const precB = makePromiseKit();
+  const precC = makePromiseKit();
+  let callbackObj;
+
+  // zero: dispatch.deliver(target, method="one", result=pA, args=[callbackObj, pD, pE])
+  //       syscall.subscribe(pD)
+  //       syscall.subscribe(pE)
+  //       syscall.send(callbackObj, method="callback", result=rp2, args=[11, 12]);
+  //       syscall.subscribe(rp2)
+  //       syscall.fulfillToData(pA, [pB, pC]);
+  function zero(obj, pD, pE) {
+    callbackObj = obj;
+    const pF = E(callbackObj).callback(11, 12); // syscall.send
+    ignore(pD);
+    ignore(pE);
+    return [precB.promise, precC.promise, pF]; // syscall.fulfillToData
+  }
+
+  // one: dispatch.deliver(target, method="two", result=rp3, args=[])
+  //      syscall.fulfillToPresence(pB, callbackObj)
+  //      syscall.reject(pC, Error('oops'))
+  //      syscall.fulfillToData(rp3, 1)
+  function one() {
+    precB.resolve(callbackObj); // syscall.fulfillToPresence
+    precC.reject(Error('oops')); // syscall.reject
+    return 1;
+  }
+
+  // two: dispatch.notifyFulfillToPresence(pD, callbackObj)
+  // three: dispatch.notifyReject(pE, Error('four'))
+
+  // four: dispatch.notifyFulfillToData(pF, ['data', callbackObj])
+
+  const target = harden({
+    zero,
+    one,
+  });
+
+  return target;
+}


### PR DESCRIPTION
This adds a per-vat option to run the vat code in a separate thread, sharing the process with the main (kernel) thread, sending VatDelivery and VatSyscall objects over the postMessage channel. This isn't particularly useful by itself, but it establishes the protocol for running vats in a separate *process*, possibly written in a different language or using a different JS engine (like XS).

This 'nodeWorker' managertype has several limitations. The shallow ones are:

* vatPowers is missing transformTildot, which shouldn't be hard to add
* vatPowers.testLog is missing, only used for unit tests so we can probably live without it
* vatPowers is missing makeGetMeter/transformMetering (and will probably never get them, since they're only used for within-vat metering and we're trying to get rid of that)
* metering is not implemented at all

Metering shouldn't be too hard to add, although we'll probably make it an option, to avoid paying the instrumented-globals penalty when we aren't using it. We also need to add proper control over vat termination (via meter exhaustion or manually).

The deeper limitation is that nodeWorkers cannot block to wait for a syscall (like `callNow`), so they cannot invoke devices

Remaining design issues:

* I'm not yet sure how the new manager should be organized, or where it should be located.
* the 'local' vatManager can probably be refactored to share more code with the new 'nodeWorker' type

The controller/kernel acquired a new `shutdown()` method, to use at the end of unit tests that create `nodeWorker` -style workers. Without `shutdown()`, the worker thread would keep the process from ever exiting.

refs #1299 

CC @dckc 
