### PR TITLE
fix: A liberal sprinkling of type: module

### DIFF
--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -3,6 +3,7 @@
   "version": "0.6.0",
   "description": "Electronic Rights Transfer Protocol (ERTP). A smart contract framework for exchanging electronic rights",
   "main": "src/issuer.js",
+  "type": "module",
   "engines": {
     "node": ">=11.0"
   },

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.8",
   "description": "Assert expression support that protects sensitive data",
   "main": "src/assert.js",
+  "type": "module",
   "engines": {
     "node": ">=11.0"
   },

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -3,6 +3,7 @@
   "version": "0.9.3",
   "description": "Extend a Promise class to implement the eventual-send API",
   "main": "src/index.js",
+  "type": "module",
   "types": "src/index.d.ts",
   "scripts": {
     "test": "tape -r esm 'test/**/test*.js'",

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.8",
   "description": "load modules created by @agoric/bundle-source",
   "main": "src/index.js",
+  "type": "module",
   "module": "src/index.js",
   "engines": {
     "node": ">=10.15.1"

--- a/packages/import-manager/package.json
+++ b/packages/import-manager/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.7",
   "description": "Share code across vat boundaries",
   "main": "src/importManager.js",
+  "type": "module",
   "engines": {
     "node": ">=11.0"
   },

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.3",
   "description": "marshal",
   "main": "marshal.js",
+  "type": "module",
   "directories": {
     "test": "test"
   },

--- a/packages/produce-promise/package.json
+++ b/packages/produce-promise/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.3",
   "description": "Helper for making promises",
   "main": "src/producePromise.js",
+  "type": "module",
   "engines": {
     "node": ">=11.0"
   },

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.3",
   "description": "Helper for making promises",
   "main": "src/promiseKit.js",
+  "type": "module",
   "engines": {
     "node": ">=11.0"
   },

--- a/packages/same-structure/package.json
+++ b/packages/same-structure/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.8",
   "description": "Deep equals",
   "main": "src/sameStructure.js",
+  "type": "module",
   "engines": {
     "node": ">=11.0"
   },

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.0",
   "description": "Wrapper for JavaScript map",
   "main": "src/store.js",
+  "type": "module",
   "engines": {
     "node": ">=11.0"
   },

--- a/packages/weak-store/package.json
+++ b/packages/weak-store/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.8",
   "description": "Wrapper for JavaScript WeakMap",
   "main": "src/weakStore.js",
+  "type": "module",
   "engines": {
     "node": ">=11.0"
   },

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "Zoe: the Smart Contract Framework for Offer Enforcement",
   "main": "src/zoe.js",
+  "type": "module",
   "engines": {
     "node": ">=11.0"
   },


### PR DESCRIPTION
This change adds `"type": "module"` to various `package.json` files per the newish Node.js convention for declaring the intended format of `.js` files. Although `-r esm` does not appear to need this it is "proper" and will help Endo.