### PR TITLE
feat(captp): better rejection handling

### DIFF
--- a/packages/captp/lib/captp.js
+++ b/packages/captp/lib/captp.js
@@ -8,13 +8,32 @@ import { isPromise } from '@agoric/promise-kit';
 
 export { E, HandledPromise };
 
-export function makeCapTP(ourId, rawSend, bootstrapObj = undefined) {
+export function makeCapTP(ourId, rawSend, bootstrapObj = undefined, opts = {}) {
+  const {
+    onReject = err => console.error('CapTP', ourId, 'exception:', err),
+  } = opts;
+
   let unplug = false;
-  function send(...args) {
-    if (unplug !== false) {
-      throw unplug;
+  async function quietReject(reason = undefined, returnIt = true) {
+    if (onReject && (unplug === false || reason !== unplug)) {
+      onReject(reason);
     }
-    return rawSend(...args);
+    if (!returnIt) {
+      return Promise.resolve();
+    }
+
+    // Silence the unhandled rejection warning, but don't affect
+    // the user's handlers.
+    const p = Promise.reject(reason);
+    p.catch(_ => {});
+    return p;
+  }
+
+  function send(...args) {
+    // Don't throw here if unplugged, just don't send.
+    if (unplug === false) {
+      rawSend(...args);
+    }
   }
 
   // convertValToSlot and convertSlotToVal both perform side effects,
@@ -114,7 +133,7 @@ export function makeCapTP(ourId, rawSend, bootstrapObj = undefined) {
     const handler = {
       get(_o, prop) {
         if (unplug !== false) {
-          throw unplug;
+          return quietReject(unplug);
         }
         const [questionID, pr] = makeQuestion();
         send({
@@ -127,7 +146,7 @@ export function makeCapTP(ourId, rawSend, bootstrapObj = undefined) {
       },
       applyMethod(_o, prop, args) {
         if (unplug !== false) {
-          throw unplug;
+          return quietReject(unplug);
         }
         // Support: o~.[prop](...args) remote method invocation
         const [questionID, pr] = makeQuestion();
@@ -147,6 +166,11 @@ export function makeCapTP(ourId, rawSend, bootstrapObj = undefined) {
       pr.resPres = () => resolveWithPresence(handler);
       pr.res = res;
     }, handler);
+
+    // Silence the unhandled rejection warning, but don't affect
+    // the user's handlers.
+    pr.p.catch(e => quietReject(e, false));
+
     return harden(pr);
   }
 
@@ -183,20 +207,20 @@ export function makeCapTP(ourId, rawSend, bootstrapObj = undefined) {
   // Message handler used for CapTP dispatcher
   const handler = {
     // Remote is asking for bootstrap object
-    CTP_BOOTSTRAP(obj) {
+    async CTP_BOOTSTRAP(obj) {
       const { questionID } = obj;
       const bootstrap =
         typeof bootstrapObj === 'function' ? bootstrapObj() : bootstrapObj;
       // console.log('sending bootstrap', bootstrap);
       answers.set(questionID, bootstrap);
-      send({
+      return send({
         type: 'CTP_RETURN',
         answerID: questionID,
         result: serialize(bootstrap),
       });
     },
     // Remote is invoking a method or retrieving a property.
-    CTP_CALL(obj) {
+    async CTP_CALL(obj) {
       // questionId: Remote promise (for promise pipelining) this call is
       //   to fulfill
       // target: Slot id of the target to be invoked.  Checks against
@@ -224,22 +248,24 @@ export function makeCapTP(ourId, rawSend, bootstrapObj = undefined) {
       answers.set(questionID, hp);
       // Set up promise resolver for this handled promise to send
       // message to other vat when fulfilled/broken.
-      hp.then(res =>
-        send({
-          type: 'CTP_RETURN',
-          answerID: questionID,
-          result: serialize(harden(res)),
-        }),
-      ).catch(rej =>
-        send({
-          type: 'CTP_RETURN',
-          answerID: questionID,
-          exception: serialize(harden(rej)),
-        }),
-      );
+      return hp
+        .then(res =>
+          send({
+            type: 'CTP_RETURN',
+            answerID: questionID,
+            result: serialize(harden(res)),
+          }),
+        )
+        .catch(rej =>
+          send({
+            type: 'CTP_RETURN',
+            answerID: questionID,
+            exception: serialize(harden(rej)),
+          }),
+        );
     },
     // Answer to one of our questions.
-    CTP_RETURN(obj) {
+    async CTP_RETURN(obj) {
       const { result, exception, answerID } = obj;
       const pr = questions.get(answerID);
       if ('exception' in obj) {
@@ -250,7 +276,7 @@ export function makeCapTP(ourId, rawSend, bootstrapObj = undefined) {
       questions.delete(answerID);
     },
     // Resolution to an imported promise
-    CTP_RESOLVE(obj) {
+    async CTP_RESOLVE(obj) {
       const { promiseID, res, rej } = obj;
       const pr = imports.get(promiseID);
       if ('rej' in obj) {
@@ -262,23 +288,26 @@ export function makeCapTP(ourId, rawSend, bootstrapObj = undefined) {
     },
     // The other side has signaled something has gone wrong.
     // Pull the plug!
-    CTP_ABORT(obj) {
+    async CTP_ABORT(obj) {
       const { exception } = obj;
+      send(obj);
+      if (unplug === false) {
+        quietReject(exception, false);
+        unplug = exception;
+      }
       for (const pr of questions.values()) {
         pr.rej(exception);
       }
       for (const pr of imports.values()) {
         pr.rej(exception);
       }
-      send(obj);
-      unplug = exception;
     },
   };
 
   // Get a reference to the other side's bootstrap object.
   const getBootstrap = async () => {
     if (unplug !== false) {
-      throw unplug;
+      return quietReject(unplug);
     }
     const [questionID, pr] = makeQuestion();
     send({
@@ -291,15 +320,20 @@ export function makeCapTP(ourId, rawSend, bootstrapObj = undefined) {
 
   // Return a dispatch function.
   const dispatch = obj => {
-    if (unplug !== false) {
+    try {
+      if (unplug !== false) {
+        return false;
+      }
+      const fn = handler[obj.type];
+      if (fn) {
+        fn(obj).catch(e => quietReject(e, false));
+        return true;
+      }
+      return false;
+    } catch (e) {
+      quietReject(e, false);
       return false;
     }
-    const fn = handler[obj.type];
-    if (fn) {
-      fn(obj);
-      return true;
-    }
-    return false;
   };
 
   // Abort a connection.

--- a/packages/captp/test/disco.js
+++ b/packages/captp/test/disco.js
@@ -7,6 +7,7 @@ import { E, makeCapTP } from '../lib/captp';
 test('try disconnecting captp', async t => {
   try {
     const objs = [];
+    const rejected = [];
     const { getBootstrap, abort } = makeCapTP(
       'us',
       obj => objs.push(obj),
@@ -16,6 +17,11 @@ test('try disconnecting captp', async t => {
             return 'hello';
           },
         }),
+      {
+        onReject(e) {
+          rejected.push(e);
+        },
+      },
     );
     t.deepEqual(objs, [], 'expected no messages');
     const bs = getBootstrap();
@@ -39,6 +45,7 @@ test('try disconnecting captp', async t => {
       'expected disconnect messages',
     );
     await ps;
+    t.deepEqual(rejected, [abortMsg.exception], 'exactly one disconnect error');
   } catch (e) {
     t.isNot(e, e, 'unexpected exception');
   } finally {


### PR DESCRIPTION
In using this module for the new Agoric wallet, we cleaned up its error handling a bit better so that there weren't as many UnhandledPromiseRejectionWarnings.

We still reject the user's promises, but if they don't install a handler, the disconnect error only complains once.  This makes the complaints much more manageable.  If the user sets an `onReject` handler, they can get full control over that single complaint.
