### PR TITLE
feat: add the ability for a contract to get a synchronous seat

### DIFF
--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -12,7 +12,7 @@ import { E } from '@agoric/eventual-send';
 import makeWeakStore from '@agoric/weak-store';
 
 import makeAmountMath from '@agoric/ertp/src/amountMath';
-import { makeNotifierKit } from '@agoric/notifier';
+import { makeNotifierKit, updateFromNotifier } from '@agoric/notifier';
 import { makePromiseKit } from '@agoric/promise-kit';
 import { areRightsConserved } from './rightsConservation';
 import { makeIssuerTable } from '../issuerTable';
@@ -166,20 +166,6 @@ export function buildRootObject() {
       return zcfMint;
     };
 
-    function updateNotiferFrom(updater, notifier, nextCount = undefined) {
-      notifier.getUpdateSince(nextCount).then(
-        ({ value, updateCount }) => {
-          if (updateCount) {
-            updater.updateState(value);
-            updateNotiferFrom(updater, notifier, updateCount);
-          } else {
-            updater.finish(value);
-          }
-        },
-        e => updater.fail(e),
-      );
-    }
-
     /** @type ContractFacet */
     const zcf = {
       reallocate: (/** @type SeatStaging[] */ ...seatStagings) => {
@@ -282,7 +268,7 @@ export function buildRootObject() {
         E(zoeInstanceAdmin)
           .makeEmptySeat(initialAllocation, proposal)
           .then(({ zoeSeatAdmin, notifier: zoeNotifier, userSeat }) => {
-            updateNotiferFrom(updater, zoeNotifier);
+            updateFromNotifier(updater, zoeNotifier);
             zoeSeatAdminPromiseKit.resolve(zoeSeatAdmin);
             userSeatPromiseKit.resolve(userSeat);
           });

--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -258,7 +258,7 @@ export function buildRootObject() {
         issuerTable.getIssuerRecordByIssuer(issuer).brand,
       getAmountMath,
       makeZCFMint,
-      addEmptySeat: () => {
+      makeEmptySeatKit: () => {
         const initialAllocation = harden({});
         const proposal = harden({ want: {} });
         const { notifier, updater } = makeNotifierKit();
@@ -266,7 +266,7 @@ export function buildRootObject() {
         const userSeatPromiseKit = makePromiseKit();
 
         E(zoeInstanceAdmin)
-          .makeEmptySeat(initialAllocation, proposal)
+          .makeOfferlessSeat(initialAllocation, proposal)
           .then(({ zoeSeatAdmin, notifier: zoeNotifier, userSeat }) => {
             updateFromNotifier(updater, zoeNotifier);
             zoeSeatAdminPromiseKit.resolve(zoeSeatAdmin);
@@ -285,7 +285,7 @@ export function buildRootObject() {
           getAmountMath,
         );
         seatToZCFSeatAdmin.init(zcfSeat, zcfSeatAdmin);
-        return { zcfSeat, zcfSeatAdmin, userSeat: userSeatPromiseKit.promise };
+        return { zcfSeat, userSeat: userSeatPromiseKit.promise };
       },
     };
     harden(zcf);

--- a/packages/zoe/src/contractFacet/exit.js
+++ b/packages/zoe/src/contractFacet/exit.js
@@ -1,6 +1,11 @@
 import { assert, details, q } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
 
+/**
+ * Makes the appropriate exitObj, which runs in ZCF and allows the seat's owner
+ * to request the position be exited.
+ */
+
 /** @type MakeExitObj */
 export const makeExitObj = (proposal, zoeSeatAdmin) => {
   const [exitKind] = Object.getOwnPropertyNames(proposal.exit);

--- a/packages/zoe/src/contractFacet/seat.js
+++ b/packages/zoe/src/contractFacet/seat.js
@@ -8,8 +8,8 @@ import { isOfferSafe } from './offerSafety';
 import '../../exported';
 import '../internal-types';
 
-/** @type MakeSeatAdmin */
-export const makeSeatAdmin = (
+/** @type MakeZcfSeatAdminKit */
+export const makeZcfSeatAdminKit = (
   allSeatStagings,
   zoeSeatAdmin,
   seatData,

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -64,7 +64,7 @@
 
 /**
  * Make the ZCF seat and seat admin
- * @callback MakeSeatAdmin
+ * @callback MakeZcfSeatAdmin
  * @param {WeakSet<SeatStaging>} allSeatStagings - a set of valid
  * seatStagings where allocations have been checked for offerSafety
  * @param {ZoeSeatAdmin} zoeSeatAdmin

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -51,11 +51,6 @@
  */
 
 /**
- * @typedef {Object} ZCFSeatAdmin
- * @property {(seatStaging: SeatStaging) => void} commit
- */
-
-/**
  * @typedef {Object} SeatData
  * @property {ProposalRecord} proposal
  * @property {Notifier<Allocation>} notifier
@@ -63,16 +58,40 @@
  */
 
 /**
+ * @typedef {{UserSeat, ZoeSeatAdmin, Notifier}} ZoeSeatAdminKit
+ *
+ * @typedef MakeZoeSeatAdminKit
+ * Make the Zoe seat admin, user seat and a notifier
+ * @param {InstanceAdmin} instanceAdmin - pass-by-copy data to use to make the seat
+ * @param {Allocation} initialAllocation
+ * @param {Proposal} proposal
+ * @param {Proposal} brandToPurse
+ * @param {{ offerResult: Promise<OfferResult>=, exitObj: Promise<ExitObj>=}=} promises
+ * @returns {ZoeSeatAdminKit}
+ *
+ * @typedef ZoeSeatAdmin
+ * @property {Allocation => void} replaceAllocation
+ * @property {() => void} exit
+ * @property {() => Allocation} getCurrentAllocation
+ */
+
+/**
+ * @typedef MakeZcfSeatAdminKit
  * Make the ZCF seat and seat admin
- * @callback MakeZcfSeatAdmin
  * @param {WeakSet<SeatStaging>} allSeatStagings - a set of valid
  * seatStagings where allocations have been checked for offerSafety
  * @param {ZoeSeatAdmin} zoeSeatAdmin
  * - a presence from Zoe such that ZCF can tell Zoe
  * about seat events
  * @param {SeatData} seatData - pass-by-copy data to use to make the seat
- * @param {(brand: Brand) => AmountMath} getAmountMath
- * @returns {{zcfSeatAdmin: ZCFSeatAdmin, zcfSeat: ZCFSeat}}
+ * @param {GetAmountMath} getAmountMath
+ * @returns {ZcfSeatAdminKit}
+ */
+
+/**
+ * @typedef {{zcfSeatAdmin: ZCFSeatAdmin, zcfSeat: ZCFSeat}} ZcfSeatAdminKit
+ * @typedef {Object} ZCFSeatAdmin
+ * @property {(seatStaging: SeatStaging) => void} commit
  */
 
 /**
@@ -112,8 +131,8 @@
  *            ) => Payment} makeInvitation
  * @property {() => void} shutdown
  * @property {(issuerP: ERef<Issuer>, keyword: Keyword) => void} saveIssuer
- *
  * @property {MakeZoeMint} makeZoeMint
+ * @property {MakeOfferlessSeat} makeOfferlessSeat
  */
 
 /**
@@ -121,6 +140,13 @@
  * @param {Keyword} keyword
  * @param {MathHelpersName=} mathHelperName
  * @returns {ZoeMint}
+ */
+
+/**
+ * @callback MakeOfferlessSeat
+ * @param {Allocation} initialAllocation
+ * @param {Proposal} proposal
+ * @returns {ZoeSeatAdminKit}
  */
 
 /**

--- a/packages/zoe/src/types.js
+++ b/packages/zoe/src/types.js
@@ -74,12 +74,14 @@
 
 /**
  * @typedef {Object} UserSeat
- * @property {() => Promise<Allocation>} getCurrentAllocation
+ * @property {() => Allocation} getCurrentAllocation
  * @property {() => Promise<ProposalRecord>} getProposal
  * @property {() => Promise<PaymentPKeywordRecord>} getPayouts
  * @property {(keyword: Keyword) => Promise<Payment>} getPayout
  * @property {() => Promise<OfferResult>} getOfferResult
  * @property {() => void=} exit
+ *
+ * @typedef {any} OfferResult
  */
 
 /**
@@ -193,6 +195,7 @@
  * @property {(issuer: Issuer) => Brand} getBrandForIssuer
  * @property {GetAmountMath} getAmountMath
  * @property {MakeZCFMint} makeZCFMint
+ * @property {ZcfSeatKit} makeEmptySeatKit
  */
 
 /**
@@ -368,6 +371,10 @@
  * @typedef {Object} SeatStaging
  * @property {() => ZCFSeat} getSeat
  * @property {() => Allocation} getStagedAllocation
+ */
+
+/**
+ * @typedef {{ zcfSeat: ZCFSeat, userSeat: UserSeat}} ZcfSeatKit
  */
 
 /**

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -230,7 +230,8 @@ function makeZoe(vatAdminSvc) {
                 brandToPurse.init(brand, E(issuer).makeEmptyPurse());
               }
             }),
-        makeEmptySeat: (initialAllocation, proposal) => {
+        // A Seat requested by the contract without an offer
+        makeOfferlessSeat: (initialAllocation, proposal) => {
           const { userSeat, notifier, zoeSeatAdmin } = makeZoeSeatAdminKit(
             initialAllocation,
             instanceAdmin,
@@ -317,7 +318,7 @@ function makeZoe(vatAdminSvc) {
           const exitObjPromiseKit = makePromiseKit();
           const instanceAdmin = instanceToInstanceAdmin.get(instance);
 
-          /** @type {ZoeSeatAdmin} */
+          /** @type {ZoeSeatAdminKit} */
           const { userSeat, notifier, zoeSeatAdmin } = makeZoeSeatAdminKit(
             initialAllocation,
             instanceAdmin,

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -3,7 +3,6 @@ import makeIssuerKit from '@agoric/ertp';
 import makeWeakStore from '@agoric/weak-store';
 import { assert, details } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
-import { makeNotifierKit } from '@agoric/notifier';
 import { makePromiseKit } from '@agoric/promise-kit';
 
 /**
@@ -15,6 +14,7 @@ import '../../exported';
 import '../internal-types';
 
 import { makeIssuerTable } from '../issuerTable';
+import { makeZoeSeatAdminKit } from './zoeSeat';
 import zcfContractBundle from '../../bundles/bundle-contractFacet';
 import { arrayToObj } from '../objArrayConversion';
 import { cleanKeywords, cleanProposal } from './cleanProposal';
@@ -181,6 +181,29 @@ function makeZoe(vatAdminSvc) {
         return zoeMint;
       };
 
+      const bundle = installation.getBundle();
+      const addSeatObjPromiseKit = makePromiseKit();
+      const publicFacetPromiseKit = makePromiseKit();
+
+      /** @type {InstanceAdmin} */
+      const instanceAdmin = {
+        addZoeSeatAdmin: async (invitationHandle, zoeSeatAdmin, seatData) => {
+          zoeSeatAdmins.add(zoeSeatAdmin);
+          return E(
+            /** @type Promise<addSeatObj> */ (addSeatObjPromiseKit.promise),
+          ).addSeat(invitationHandle, zoeSeatAdmin, seatData);
+        },
+        hasZoeSeatAdmin: zoeSeatAdmin => zoeSeatAdmins.has(zoeSeatAdmin),
+        removeZoeSeatAdmin: zoeSeatAdmin => zoeSeatAdmins.delete(zoeSeatAdmin),
+        getPublicFacet: () => publicFacetPromiseKit.promise,
+        getTerms: () => instanceRecord.terms,
+        getIssuers: () => instanceRecord.issuerKeywordRecord,
+        getBrands: () => instanceRecord.brandKeywordRecord,
+        getInstance: () => instance,
+      };
+
+      instanceToInstanceAdmin.init(instance, instanceAdmin);
+
       /** @type {ZoeInstanceAdmin} */
       const zoeInstanceAdminForZcf = {
         makeInvitation: (invitationHandle, description, customProperties) => {
@@ -207,33 +230,15 @@ function makeZoe(vatAdminSvc) {
                 brandToPurse.init(brand, E(issuer).makeEmptyPurse());
               }
             }),
-        makeEmptySeat: (keyword, initialAllocation) => {
-          let currentAllocation = initialAllocation;
-
-          const { notifier, updater } = makeNotifierKit();
-
-          const seatAdmin = {
-            replaceAllocation: replacementAllocation => {
-              harden(replacementAllocation);
-              updater.updateState(replacementAllocation);
-              currentAllocation = replacementAllocation;
-            },
-            exit: () => {
-              updater.finish(undefined);
-              const instanceAdmin = instanceToInstanceAdmin.get(instance);
-              instanceAdmin.removeZoeSeatAdmin(seatAdmin);
-
-              // burn the holdings to keep Zoe's book straight
-              Object.entries(currentAllocation).forEach(([_, payoutAmount]) => {
-                const purse = brandToPurse.get(payoutAmount.brand);
-                const { issuer } = issuerTable.get(payoutAmount.brand);
-                E(issuer).burn(E(purse).withdraw(payoutAmount));
-              });
-            },
-          };
-
-          harden(seatAdmin);
-          return { seatAdmin, notifier };
+        makeEmptySeat: (initialAllocation, proposal) => {
+          const { userSeat, notifier, zoeSeatAdmin } = makeZoeSeatAdminKit(
+            initialAllocation,
+            instanceAdmin,
+            proposal,
+            brandToPurse,
+          );
+          zoeSeatAdmins.add(zoeSeatAdmin);
+          return { userSeat, notifier, zoeSeatAdmin };
         },
         shutdown: () => {
           exitAllSeats();
@@ -241,29 +246,6 @@ function makeZoe(vatAdminSvc) {
         },
         makeZoeMint,
       };
-
-      const bundle = installation.getBundle();
-      const addSeatObjPromiseKit = makePromiseKit();
-      const publicFacetPromiseKit = makePromiseKit();
-
-      /** @type {InstanceAdmin} */
-      const instanceAdmin = {
-        addZoeSeatAdmin: async (invitationHandle, zoeSeatAdmin, seatData) => {
-          zoeSeatAdmins.add(zoeSeatAdmin);
-          return E(
-            /** @type Promise<addSeatObj> */ (addSeatObjPromiseKit.promise),
-          ).addSeat(invitationHandle, zoeSeatAdmin, seatData);
-        },
-        hasZoeSeatAdmin: zoeSeatAdmin => zoeSeatAdmins.has(zoeSeatAdmin),
-        removeZoeSeatAdmin: zoeSeatAdmin => zoeSeatAdmins.delete(zoeSeatAdmin),
-        getPublicFacet: () => publicFacetPromiseKit.promise,
-        getTerms: () => instanceRecord.terms,
-        getIssuers: () => instanceRecord.issuerKeywordRecord,
-        getBrands: () => instanceRecord.brandKeywordRecord,
-        getInstance: () => instance,
-      };
-
-      instanceToInstanceAdmin.init(instance, instanceAdmin);
 
       // At this point, the contract will start executing. All must be ready
 
@@ -331,60 +313,21 @@ function makeZoe(vatAdminSvc) {
         return Promise.all(paymentDepositedPs).then(amountsArray => {
           const initialAllocation = arrayToObj(amountsArray, proposalKeywords);
 
-          const payoutPromiseKit = makePromiseKit();
           const offerResultPromiseKit = makePromiseKit();
           const exitObjPromiseKit = makePromiseKit();
-          const { notifier, updater } = makeNotifierKit();
-          let currentAllocation = initialAllocation;
-
           const instanceAdmin = instanceToInstanceAdmin.get(instance);
 
           /** @type {ZoeSeatAdmin} */
-          const zoeSeatAdmin = {
-            replaceAllocation: replacementAllocation => {
-              assert(
-                instanceAdmin.hasZoeSeatAdmin(zoeSeatAdmin),
-                `Cannot replace allocation. Seat has already exited`,
-              );
-              harden(replacementAllocation);
-              // Merging happens in ZCF, so replacementAllocation can
-              // replace the old allocation entirely.
-              updater.updateState(replacementAllocation);
-              currentAllocation = replacementAllocation;
+          const { userSeat, notifier, zoeSeatAdmin } = makeZoeSeatAdminKit(
+            initialAllocation,
+            instanceAdmin,
+            proposal,
+            brandToPurse,
+            {
+              offerResult: offerResultPromiseKit,
+              exitObj: exitObjPromiseKit,
             },
-            exit: () => {
-              assert(
-                instanceAdmin.hasZoeSeatAdmin(zoeSeatAdmin),
-                `Cannot exit seat. Seat has already exited`,
-              );
-              updater.finish(undefined);
-              instanceAdmin.removeZoeSeatAdmin(zoeSeatAdmin);
-
-              /** @type {PaymentPKeywordRecord} */
-              const payout = {};
-              Object.entries(currentAllocation).forEach(
-                ([keyword, payoutAmount]) => {
-                  const purse = brandToPurse.get(payoutAmount.brand);
-                  payout[keyword] = E(purse).withdraw(payoutAmount);
-                },
-              );
-              harden(payout);
-              payoutPromiseKit.resolve(payout);
-            },
-          };
-          harden(zoeSeatAdmin);
-
-          /** @type {UserSeat} */
-          const userSeat = {
-            getCurrentAllocation: async () => currentAllocation,
-            getProposal: async () => proposal,
-            getPayouts: async () => payoutPromiseKit.promise,
-            getPayout: async keyword =>
-              payoutPromiseKit.promise.then(payouts => payouts[keyword]),
-            getOfferResult: async () => offerResultPromiseKit.promise,
-            exit: async () =>
-              exitObjPromiseKit.promise.then(exitObj => E(exitObj).exit()),
-          };
+          );
 
           const seatData = harden({ proposal, initialAllocation, notifier });
 

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -1,0 +1,63 @@
+import { makePromiseKit } from '@agoric/promise-kit';
+import { makeNotifierKit } from '@agoric/notifier';
+import { assert } from '@agoric/assert';
+import { E } from '@agoric/eventual-send';
+
+export const makeZoeSeatAdminKit = (
+  initialAllocation,
+  instanceAdmin,
+  proposal,
+  brandToPurse,
+  promises = {},
+) => {
+  const payoutPromiseKit = promises.payout || makePromiseKit();
+  const offerResultPromiseKit = promises.offerResult || makePromiseKit();
+  const exitObjPromiseKit = promises.exitObj || makePromiseKit();
+  const { notifier, updater } = makeNotifierKit();
+
+  let currentAllocation = initialAllocation;
+  const zoeSeatAdmin = harden({
+    replaceAllocation: replacementAllocation => {
+      assert(
+        instanceAdmin.hasZoeSeatAdmin(zoeSeatAdmin),
+        `Cannot replace allocation. Seat has already exited`,
+      );
+      harden(replacementAllocation);
+      // Merging happens in ZCF, so replacementAllocation can
+      // replace the old allocation entirely.
+      updater.updateState(replacementAllocation);
+      currentAllocation = replacementAllocation;
+    },
+    exit: () => {
+      assert(
+        instanceAdmin.hasZoeSeatAdmin(zoeSeatAdmin),
+        `Cannot exit seat. Seat has already exited`,
+      );
+      updater.finish(undefined);
+      instanceAdmin.removeZoeSeatAdmin(zoeSeatAdmin);
+
+      /** @type {PaymentPKeywordRecord} */
+      const payout = {};
+      Object.entries(currentAllocation).forEach(([keyword, payoutAmount]) => {
+        const purse = brandToPurse.get(payoutAmount.brand);
+        payout[keyword] = E(purse).withdraw(payoutAmount);
+      });
+      harden(payout);
+      payoutPromiseKit.resolve(payout);
+    },
+    getCurrentAllocation: () => currentAllocation,
+  });
+
+  const userSeat = harden({
+    getCurrentAllocation: async () => zoeSeatAdmin.getCurrentAllocation(),
+    getProposal: async () => proposal,
+    getPayouts: async () => payoutPromiseKit.promise,
+    getPayout: async keyword =>
+      payoutPromiseKit.promise.then(payouts => payouts[keyword]),
+    getOfferResult: async () => offerResultPromiseKit.promise,
+    exit: async () =>
+      exitObjPromiseKit.promise.then(exitObj => E(exitObj).exit()),
+  });
+
+  return { userSeat, zoeSeatAdmin, notifier };
+};

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -10,12 +10,14 @@ export const makeZoeSeatAdminKit = (
   brandToPurse,
   promises = {},
 ) => {
-  const payoutPromiseKit = promises.payout || makePromiseKit();
+  const payoutPromiseKit = makePromiseKit();
   const offerResultPromiseKit = promises.offerResult || makePromiseKit();
   const exitObjPromiseKit = promises.exitObj || makePromiseKit();
   const { notifier, updater } = makeNotifierKit();
 
   let currentAllocation = initialAllocation;
+
+  /** @type ZoeSeatAdmin */
   const zoeSeatAdmin = harden({
     replaceAllocation: replacementAllocation => {
       assert(
@@ -48,6 +50,7 @@ export const makeZoeSeatAdminKit = (
     getCurrentAllocation: () => currentAllocation,
   });
 
+  /** @type UserSeat */
   const userSeat = harden({
     getCurrentAllocation: async () => zoeSeatAdmin.getCurrentAllocation(),
     getProposal: async () => proposal,


### PR DESCRIPTION
zcf.addEmptySeat() would return a zcfSeat that the contract could use
to hold allocations.

untested