### PR TITLE
fix(swingset): check promise resolution table during comms.inbound

### DIFF
--- a/packages/SwingSet/src/vats/comms/inbound.js
+++ b/packages/SwingSet/src/vats/comms/inbound.js
@@ -23,14 +23,14 @@ function getInboundFor(state, remoteID, remoteTarget) {
         return p.resolution.slot;
       }
       if (p.resolution.type === 'data') {
-        throw new Error(`todo: error for fulfilledToData`);
+        throw Error(`todo: error for fulfilledToData`);
       }
       if (p.resolution.type === 'reject') {
-        throw new Error(`todo: error for rejected`);
+        throw Error(`todo: error for rejected`);
       }
-      throw new Error(`unknown res type ${p.resolution.type}`);
+      throw Error(`unknown res type ${p.resolution.type}`);
     }
-    throw new Error(`unknown p.state ${p.state}`);
+    throw Error(`unknown p.state ${p.state}`);
   }
   return target;
 }

--- a/packages/SwingSet/src/vats/comms/inbound.js
+++ b/packages/SwingSet/src/vats/comms/inbound.js
@@ -9,6 +9,32 @@ import {
   markPromiseAsResolved,
 } from './state';
 
+function getInboundFor(state, remoteID, remoteTarget) {
+  const target = getInbound(state, remoteID, remoteTarget);
+  // That might point to o-NN or a promise. Check if the promise was resolved
+  // already.
+  if (state.promiseTable.has(target)) {
+    const p = state.promiseTable.get(target);
+    if (p.state === 'unresolved') {
+      return target;
+    }
+    if (p.state === 'resolved') {
+      if (p.resolution.type === 'object') {
+        return p.resolution.slot;
+      }
+      if (p.resolution.type === 'data') {
+        throw new Error(`todo: error for fulfilledToData`);
+      }
+      if (p.resolution.type === 'reject') {
+        throw new Error(`todo: error for rejected`);
+      }
+      throw new Error(`unknown res type ${p.resolution.type}`);
+    }
+    throw new Error(`unknown p.state ${p.state}`);
+  }
+  return target;
+}
+
 export function deliverFromRemote(syscall, state, remoteID, message) {
   const command = message.split(':', 1)[0];
 
@@ -21,7 +47,7 @@ export function deliverFromRemote(syscall, state, remoteID, message) {
       .split(':')
       .slice(1);
     // slots: [$target, $method, $result, $slots..]
-    const target = getInbound(state, remoteID, slots[0]);
+    const target = getInboundFor(state, remoteID, slots[0]);
     const method = slots[1];
     const result = slots[2]; // 'rp-NN' or empty string
     const msgSlots = slots.slice(3).map(s => mapInbound(state, remoteID, s));

--- a/packages/SwingSet/test/message-patterns.js
+++ b/packages/SwingSet/test/message-patterns.js
@@ -7,6 +7,7 @@
 
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
+import { ignore } from './util';
 
 // Exercise a set of increasingly complex object-capability message patterns,
 // for testing.
@@ -515,6 +516,27 @@ export function buildPatterns(log) {
     'p3.then',
   ];
   test('a72');
+
+  // Exercise bug #1400. We set up two messages:
+  //   pipe1 = bob~.one()
+  //   pipe1~.two()
+  // but their handling must meet two ordering constraints:
+  // 1: left-comms transmits two() before learning about pipe1 resolving
+  // 2: right-comms receives two() *after* learning about pipe1 resolving
+  // to achieve this, we changed loopbox() to deliver one message at a time
+  {
+    objA.a73 = async () => {
+      const pipe1 = E(b.bob).b73_one();
+      const p2 = E(pipe1).two();
+      ignore(p2);
+    };
+    objB.b73_one = () =>
+      harden({
+        two: () => log('two'),
+      });
+  }
+  out.a73 = ['two'];
+  test('a73');
 
   return harden({
     setA,

--- a/packages/SwingSet/test/test-message-patterns.js
+++ b/packages/SwingSet/test/test-message-patterns.js
@@ -96,7 +96,7 @@ export async function runVatsInComms(t, enablePipelining, name) {
   config.vats.leftvattp = { sourcePath: vatTPSourcePath };
   config.vats.rightvattp = { sourcePath: vatTPSourcePath };
   const { passOneMessage, loopboxSrcPath, loopboxEndowments } = buildLoopbox(
-    'immediate',
+    'queued',
   );
   config.devices = [['loopbox', loopboxSrcPath, loopboxEndowments]];
   const c = await buildVatController(config, [name]);

--- a/packages/SwingSet/test/util.js
+++ b/packages/SwingSet/test/util.js
@@ -69,3 +69,10 @@ export function buildDispatch(onDispatchCallback = undefined) {
 
   return { log, dispatch };
 }
+
+export function ignore(p) {
+  p.then(
+    () => 0,
+    () => 0,
+  );
+}


### PR DESCRIPTION
closes #1400

This fixes the case where a cross-machine message is pipelined to a result promise that gets resolved before that message arrives. Previously the receiving comms vat would mistakenly deliver it into the kernel to the old promise-ID, which the kernel has forgotten by that point. Now the comms vat references its internal promise table on the way in, so the message is delivered into the kernel to the new object-ID.
