### PR TITLE
fix: need type decl for HandledPromise.reject

### DIFF
--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -8,8 +8,7 @@
     "test": "tape -r esm 'test/**/test*.js'",
     "build": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint-check": "eslint '**/*.js'",
-    "lint:types": "tsc -p jsconfig.json"
+    "lint-check": "eslint '**/*.js'"
   },
   "repository": {
     "type": "git",

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -8,7 +8,8 @@
     "test": "tape -r esm 'test/**/test*.js'",
     "build": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint-check": "eslint '**/*.js'"
+    "lint-check": "eslint '**/*.js'",
+    "lint:types": "tsc -p jsconfig.json"
   },
   "repository": {
     "type": "git",

--- a/packages/eventual-send/src/index.d.ts
+++ b/packages/eventual-send/src/index.d.ts
@@ -22,26 +22,34 @@ type HandledExecutor<R> = (
 ) => void;
 
 interface HandledPromiseConstructor extends PromiseConstructor {
-  new<R> (executor: HandledExecutor<R>, unfulfilledHandler?: EHandler<Promise<unknown>>);
+  new <R>(
+    executor: HandledExecutor<R>,
+    unfulfilledHandler?: EHandler<Promise<unknown>>
+  );
   prototype: Promise<unknown>;
   applyFunction(target: unknown, args: unknown[]): Promise<unknown>;
   applyFunctionSendOnly(target: unknown, args: unknown[]): void;
-  applyMethod(target: unknown, prop: Property, args: unknown[]): Promise<unknown>;
+  applyMethod(
+    target: unknown,
+    prop: Property,
+    args: unknown[]
+  ): Promise<unknown>;
   applyMethodSendOnly(target: unknown, prop: Property, args: unknown[]): void;
   get(target: unknown, prop: Property): Promise<unknown>;
   getSendOnly(target: unknown, prop: Property): void;
-  resolve(target: unknown): Promise<any>;
 }
 
 export const HandledPromise: HandledPromiseConstructor;
 
 /* Types for E proxy calls. */
 type ESingleMethod<T> = {
-  readonly [P in keyof T]: (...args: Parameters<T[P]>) => Promise<Unpromise<ReturnType<T[P]>>>;
+  readonly [P in keyof T]: (
+    ...args: Parameters<T[P]>
+  ) => Promise<Unpromise<ReturnType<T[P]>>>;
 }
 type ESingleCall<T> = T extends Function ?
-  ((...args: Parameters<T>) => Promise<Unpromise<ReturnType<T>>>) & ESingleMethod<Required<T>> :
-  ESingleMethod<Required<T>>;
+  ((...args: Parameters<T>) => Promise<Unpromise<ReturnType<T>>>) &
+    ESingleMethod<Required<T>> : ESingleMethod<Required<T>>;
 type ESingleGet<T> = {
   readonly [P in keyof T]: Promise<Unpromise<T[P]>>;
 }
@@ -76,8 +84,8 @@ interface EProxy {
   /**
    * E.G(x) returns a proxy on which you can get arbitrary properties.
    * Each of these properties returns a promise for the property.  The promise
-   * value will be the property fetched from whatever 'x' designates (or resolves to)
-   * in a future turn, not this one.
+   * value will be the property fetched from whatever 'x' designates (or
+   * resolves to) in a future turn, not this one.
    *
    * @param {*} x target for property get
    * @returns {ESingleGet} property get proxy
@@ -90,13 +98,14 @@ interface EProxy {
   readonly when<T>(x: T): Promise<Unpromise<T>>;
 
   /**
-   * E.when(x, res, rej) is equivalent to HandledPromise.resolve(x).then(res, rej)
+   * E.when(x, res, rej) is equivalent to
+   * HandledPromise.resolve(x).then(res, rej)
    */
-  readonly when<T>(
+  readonly when<T,U>(
     x: T,
-    onfulfilled: (value: Unpromise<T>) => ERef<any> | undefined,
-    onrejected?: (reason: any) => PromiseLike<never>,
-  ): Promise<any>;
+    onfulfilled?: (value: Unpromise<T>) => ERef<U>,
+    onrejected?: (reason: any) => ERef<U>,
+  ): Promise<U>;
 
   /**
    * E.sendOnly returns a proxy similar to E, but for which the results

--- a/packages/eventual-send/src/index.d.ts
+++ b/packages/eventual-send/src/index.d.ts
@@ -31,6 +31,7 @@ interface HandledPromiseConstructor {
   get(target: unknown, prop: Property): Promise<unknown>;
   getSendOnly(target: unknown, prop: Property): void;
   resolve(target: unknown): Promise<any>;
+  reject<T = never>(reason?: any): Promise<T>;
 }
 
 export const HandledPromise: HandledPromiseConstructor;

--- a/packages/eventual-send/src/index.d.ts
+++ b/packages/eventual-send/src/index.d.ts
@@ -21,7 +21,7 @@ type HandledExecutor<R> = (
   resolveWithPresence: (presenceHandler: EHandler<{}>) => object,
 ) => void;
 
-interface HandledPromiseConstructor {
+interface HandledPromiseConstructor extends PromiseConstructor {
   new<R> (executor: HandledExecutor<R>, unfulfilledHandler?: EHandler<Promise<unknown>>);
   prototype: Promise<unknown>;
   applyFunction(target: unknown, args: unknown[]): Promise<unknown>;
@@ -31,7 +31,6 @@ interface HandledPromiseConstructor {
   get(target: unknown, prop: Property): Promise<unknown>;
   getSendOnly(target: unknown, prop: Property): void;
   resolve(target: unknown): Promise<any>;
-  reject<T = never>(reason?: any): Promise<T>;
 }
 
 export const HandledPromise: HandledPromiseConstructor;

--- a/packages/eventual-send/src/index.js
+++ b/packages/eventual-send/src/index.js
@@ -74,7 +74,8 @@ export function makeHandledPromise(Promise) {
    * https://en.wikipedia.org/wiki/Disjoint-set_data_structure
    *
    * @param {*} target Any value.
-   * @returns {*} If the target was a HandledPromise, the most-resolved parent of it, otherwise the target.
+   * @returns {*} If the target was a HandledPromise, the most-resolved parent
+   * of it, otherwise the target.
    */
   function shorten(target) {
     let p = target;


### PR DESCRIPTION
Declared the `HandledPromise` constructor to extend from the `Promise` constructor, mirroring the implementation's inheritance arrangement. Thus, the `HandledPromise` now inherits the `reject` declaration. Also the `resolve` declaration, which this PR deletes.

Better typing of `E.when`, fixing the "when" component of #1362 . 