### PR TITLE
fix: deprecate getMathHelpersName for getMathHelperName

### DIFF
--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -73,7 +73,9 @@ function makeAmountMath(brand, mathHelpersName) {
 
   const amountMath = harden({
     getBrand: () => brand,
+    /** @deprecated Use getMathHelperName */
     getMathHelpersName: () => mathHelpersName,
+    getMathHelperName: () => mathHelpersName,
 
     /**
      * Make an amount from a value by adding the brand.

--- a/packages/ERTP/src/issuer.js
+++ b/packages/ERTP/src/issuer.js
@@ -175,7 +175,9 @@ function makeIssuerKit(allegedName, mathHelpersName = 'nat') {
     getBrand: () => brand,
     getAllegedName: () => allegedName,
     getAmountMath: () => amountMath,
+    /** @deprecated Use getMathHelperName */
     getMathHelpersName: () => mathHelpersName,
+    getMathHelperName: () => mathHelpersName,
     makeEmptyPurse: () => {
       const purse = makePurse();
       purseLedger.init(purse, amountMath.getEmpty());

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -46,6 +46,8 @@
  *
  * @property {() => Brand} getBrand Return the brand.
  * @property {() => MathHelpersName} getMathHelpersName
+ * Deprecated. Use getMathHelperName
+ * @property {() => MathHelpersName} getMathHelperName
  * Get the name of the mathHelpers used. This can be used as an
  * argument to `makeAmountMath` to create local amountMath.
  *
@@ -127,7 +129,10 @@
  *
  * @property {() => string} getAllegedName Get the allegedName for this mint/issuer
  * @property {() => AmountMath} getAmountMath Get the AmountMath for this Issuer.
- * @property {() => MathHelpersName} getMathHelpersName Get the name of the MathHelpers for this Issuer.
+ * @property {() => MathHelpersName} getMathHelpersName
+ * Deprecated. Use getMathHelperName
+ * @property {() => MathHelpersName} getMathHelperName Get the name of the
+ * MathHelpers for this Issuer.
  * @property {() => Purse} makeEmptyPurse Make an empty purse of this brand.
  * @property {(payment: PaymentP) => Promise<boolean>} isLive
  * Return true if the payment continues to exist.

--- a/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
@@ -20,7 +20,7 @@ test('natMathHelpers', t => {
   try {
     const {
       getBrand,
-      getMathHelpersName,
+      getMathHelperName,
       make,
       coerce,
       getValue,
@@ -35,8 +35,8 @@ test('natMathHelpers', t => {
     // getBrand
     t.deepEquals(getBrand(), mockBrand, 'brand is brand');
 
-    // getMathHelpersName
-    t.deepEquals(getMathHelpersName(), 'nat', 'mathHelpersName is nat');
+    // getMathHelperName
+    t.deepEquals(getMathHelperName(), 'nat', 'mathHelpersName is nat');
 
     // make
     t.deepEquals(make(4), { brand: mockBrand, value: 4 });

--- a/packages/ERTP/test/unitTests/mathHelpers/test-setMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-setMathHelpers.js
@@ -23,7 +23,7 @@ const runSetMathHelpersTests = (t, [a, b, c], a2 = undefined) => {
 
   const {
     getBrand,
-    getMathHelpersName,
+    getMathHelperName,
     make,
     coerce,
     getValue,
@@ -38,8 +38,8 @@ const runSetMathHelpersTests = (t, [a, b, c], a2 = undefined) => {
   // getBrand
   t.deepEquals(getBrand(), mockBrand, 'brand is brand');
 
-  // getMathHelpersName
-  t.deepEquals(getMathHelpersName(), 'set', 'mathHelpersName is set');
+  // getMathHelperName
+  t.deepEquals(getMathHelperName(), 'set', 'mathHelpersName is set');
 
   // make
   t.deepEquals(

--- a/packages/ERTP/test/unitTests/mathHelpers/test-strSetMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-strSetMathHelpers.js
@@ -20,7 +20,7 @@ test('strSetMathHelpers', t => {
   try {
     const {
       getBrand,
-      getMathHelpersName,
+      getMathHelperName,
       make,
       coerce,
       getValue,
@@ -35,8 +35,8 @@ test('strSetMathHelpers', t => {
     // getBrand
     t.deepEquals(getBrand(), mockBrand, 'brand is brand');
 
-    // getMathHelpersName
-    t.deepEquals(getMathHelpersName(), 'strSet', 'mathHelpersName is strSet');
+    // getMathHelperName
+    t.deepEquals(getMathHelperName(), 'strSet', 'mathHelpersName is strSet');
 
     // make
     t.doesNotThrow(

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -44,10 +44,10 @@ test('issuer.getAmountMath', t => {
   }
 });
 
-test('issuer.getMathHelpersName', t => {
+test('issuer.getMathHelperName', t => {
   try {
     const { issuer } = makeIssuerKit('fungible');
-    t.equals(issuer.getMathHelpersName(), 'nat');
+    t.equals(issuer.getMathHelperName(), 'nat');
   } catch (e) {
     t.assert(false, e);
   } finally {

--- a/packages/dapp-svelte-wallet/api/src/lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-wallet.js
@@ -51,7 +51,7 @@ export async function makeWallet({
             }
 
             // remote calls which immediately return a promise
-            const mathHelpersNameP = E(issuer).getMathHelpersName();
+            const mathHelpersNameP = E(issuer).getMathHelperName();
             const brandP = E(issuer).getBrand();
             const issuerBoardIdP = E(board)
               .has(issuer)

--- a/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
@@ -792,7 +792,7 @@ test('lib-wallet addOffer for autoswap swap', async t => {
     const getLocalAmountMath = issuer =>
       Promise.all([
         E(issuer).getBrand(),
-        E(issuer).getMathHelpersName(),
+        E(issuer).getMathHelperName(),
       ]).then(([brand, mathHelpersName]) =>
         makeAmountMath(brand, mathHelpersName),
       );

--- a/packages/spawner/test/swingsetTests/contractHost/bootstrap.js
+++ b/packages/spawner/test/swingsetTests/contractHost/bootstrap.js
@@ -37,7 +37,7 @@ export function buildRootObject(vatPowers, vatParameters) {
   const getLocalAmountMath = issuer =>
     Promise.all([
       E(issuer).getBrand(),
-      E(issuer).getMathHelpersName(),
+      E(issuer).getMathHelperName(),
     ]).then(([brand, mathHelpersName]) =>
       makeAmountMath(brand, mathHelpersName),
     );

--- a/packages/spawner/test/swingsetTests/contractHost/vat-alice.js
+++ b/packages/spawner/test/swingsetTests/contractHost/vat-alice.js
@@ -25,7 +25,7 @@ function makeAliceMaker(host, log) {
   const getLocalAmountMath = issuer =>
     Promise.all([
       E(issuer).getBrand(),
-      E(issuer).getMathHelpersName(),
+      E(issuer).getMathHelperName(),
     ]).then(([brand, mathHelpersName]) =>
       makeAmountMath(brand, mathHelpersName),
     );

--- a/packages/spawner/test/swingsetTests/contractHost/vat-bob.js
+++ b/packages/spawner/test/swingsetTests/contractHost/vat-bob.js
@@ -13,7 +13,7 @@ function makeBobMaker(host, log) {
   const getLocalAmountMath = issuer =>
     Promise.all([
       E(issuer).getBrand(),
-      E(issuer).getMathHelpersName(),
+      E(issuer).getMathHelperName(),
     ]).then(([brand, mathHelpersName]) =>
       makeAmountMath(brand, mathHelpersName),
     );

--- a/packages/spawner/test/swingsetTests/contractHost/vat-fred.js
+++ b/packages/spawner/test/swingsetTests/contractHost/vat-fred.js
@@ -14,7 +14,7 @@ function makeFredMaker(host, log) {
   const getLocalAmountMath = issuer =>
     Promise.all([
       E(issuer).getBrand(),
-      E(issuer).getMathHelpersName(),
+      E(issuer).getMathHelperName(),
     ]).then(([brand, mathHelpersName]) =>
       makeAmountMath(brand, mathHelpersName),
     );

--- a/packages/swingset-runner/demo/exchangeBenchmark/helpers.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/helpers.js
@@ -15,7 +15,7 @@ export async function showPurseBalance(purseP, name, log) {
 export function getLocalAmountMath(issuer) {
   return Promise.all([
     E(issuer).getBrand(),
-    E(issuer).getMathHelpersName(),
+    E(issuer).getMathHelperName(),
   ]).then(([brand, mathHelpersName]) => makeAmountMath(brand, mathHelpersName));
 }
 

--- a/packages/swingset-runner/demo/zoeTests/helpers.js
+++ b/packages/swingset-runner/demo/zoeTests/helpers.js
@@ -15,7 +15,7 @@ export const showPurseBalance = async (purseP, name, log) => {
 export const getLocalAmountMath = issuer =>
   Promise.all([
     E(issuer).getBrand(),
-    E(issuer).getMathHelpersName(),
+    E(issuer).getMathHelperName(),
   ]).then(([brand, mathHelpersName]) => makeAmountMath(brand, mathHelpersName));
 
 export const setupIssuers = async (zoe, issuers) => {

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -431,7 +431,7 @@ export const makeZoeHelpers = zcf => {
     assertNatMathHelpers: brand => {
       const amountMath = zcf.getAmountMath(brand);
       assert(
-        amountMath.getMathHelpersName() === 'nat',
+        amountMath.getMathHelperName() === 'nat',
         details`issuer must have natMathHelpers`,
       );
     },

--- a/packages/zoe/src/state.js
+++ b/packages/zoe/src/state.js
@@ -204,7 +204,7 @@ const makeIssuerTable = (withPurses = true) => {
      */
     function buildTableEntryAndPlaceHolder(issuer) {
       // remote calls which immediately return a promise
-      const mathHelpersNameP = E(issuer).getMathHelpersName();
+      const mathHelpersNameP = E(issuer).getMathHelperName();
       const brandP = E(issuer).getBrand();
 
       /**

--- a/packages/zoe/test/swingsetTests/helpers.js
+++ b/packages/zoe/test/swingsetTests/helpers.js
@@ -13,7 +13,7 @@ export const showPurseBalance = async (purseP, name, log) => {
 export const getLocalAmountMath = issuer =>
   Promise.all([
     E(issuer).getBrand(),
-    E(issuer).getMathHelpersName(),
+    E(issuer).getMathHelperName(),
   ]).then(([brand, mathHelpersName]) => makeAmountMath(brand, mathHelpersName));
 
 export const setupIssuers = async (zoe, issuers) => {

--- a/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
@@ -52,7 +52,7 @@ test('multipoolAutoSwap with valid offers', async t => {
     const makeAmountMathFromIssuer = issuer =>
       Promise.all([
         E(issuer).getBrand(),
-        E(issuer).getMathHelpersName(),
+        E(issuer).getMathHelperName(),
       ]).then(([brand, mathName]) => makeAmountMath(brand, mathName));
     const inviteAmountMath = await makeAmountMathFromIssuer(inviteIssuer);
 


### PR DESCRIPTION
AFAICT, the only publicly exposed API using the plural "mathHelpers" are the `getMathHelpersName` methods. Since we're about to do a major release, it's worth deprecating them, introducing the singular instead, and changing all uses in this PR to use the singular form.

There are many other uses of the plural that will need to be changed as well, such as variables, types, comments and documentation. But non of these create painful cross version compat problems. In the interest of minimizing spurious merge conflicts before major merging, I omitted all these others.

So that I could test and see I didn't break anything, I did this as a delta on master rather than new-zoe-spike-2.