### PR TITLE
refactor: bring autoswap up to date on the new Zoe spike branch

### DIFF
--- a/packages/zoe/test/unitTests/contracts/test-barter.js
+++ b/packages/zoe/test/unitTests/contracts/test-barter.js
@@ -7,7 +7,7 @@ import { E } from '@agoric/eventual-send';
 import { setup } from '../setupBasicMints';
 import {
   installationPFromSource,
-  assertPayout,
+  assertPayoutDeposit,
   assertOfferResult,
   getInviteFields,
 } from '../../zoeTestHelpers';
@@ -124,11 +124,11 @@ test('barter with valid offers', async t => {
 
   // 6: Alice deposits her payout to ensure she can
   // Alice had 0 moola and 4 simoleans.
-  assertPayout(t, aliceMoolaPayout, aliceMoolaPurse, 0);
-  assertPayout(t, aliceSimoleanPayout, aliceSimoleanPurse, 4);
+  assertPayoutDeposit(t, aliceMoolaPayout, aliceMoolaPurse, moola(0));
+  assertPayoutDeposit(t, aliceSimoleanPayout, aliceSimoleanPurse, simoleans(4));
 
   // 7: Bob deposits his original payments to ensure he can
   // Bob had 3 moola and 3 simoleans.
-  assertPayout(t, bobMoolaPayout, bobMoolaPurse, 3);
-  assertPayout(t, bobSimoleanPayout, bobSimoleanPurse, 3);
+  assertPayoutDeposit(t, bobMoolaPayout, bobMoolaPurse, moola(3));
+  assertPayoutDeposit(t, bobSimoleanPayout, bobSimoleanPurse, simoleans(3));
 });

--- a/packages/zoe/test/zoeTestHelpers.js
+++ b/packages/zoe/test/zoeTestHelpers.js
@@ -1,14 +1,9 @@
 import bundleSource from '@agoric/bundle-source';
 import { E } from '@agoric/eventual-send';
 
-export const assertPayout = (t, payout, purse, amount) => {
-  payout.then(payment => {
-    purse.deposit(payment);
-    t.deepEquals(
-      purse.getCurrentAmount().value,
-      amount,
-      `payout was ${amount}`,
-    );
+export const assertPayoutAmount = (t, issuer, payout, expectedAmount) => {
+  issuer.getAmountOf(payout).then(amount => {
+    t.deepEquals(amount, expectedAmount, `payout was ${amount.value}`);
   });
 };
 


### PR DESCRIPTION
This brings the autoswap contract up-to-date on the new-zoe-spike-2 branch, based on the synchronous seat work.

The unit tests for autoswap pass. I haven't yet done the swingset tests.