### PR TITLE
tests: starting to update swingset tests. Breaks in myserious ways

### DIFF
--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -266,15 +266,11 @@ function makeZoe(vatAdminSvc) {
       addSeatObjPromiseKit.resolve(addSeatObj);
       publicFacetPromiseKit.resolve(publicFacet);
 
-      const creatorFacetWInstance = {
-        ...creatorFacet,
-        getInstance: () => instance,
-      };
-
       // Actually returned to the user.
       return {
-        creatorFacet: creatorFacetWInstance,
+        creatorFacet,
         creatorInvitation: await creatorInvitation,
+        instance,
       };
     },
     offer: async (

--- a/packages/zoe/test/swingsetTests/zoe/test-zoe.js
+++ b/packages/zoe/test/swingsetTests/zoe/test-zoe.js
@@ -245,12 +245,12 @@ const expectedAutoswapOkLog = [
   'bobMoolaPurse: balance {"brand":{},"value":5}',
   'bobSimoleanPurse: balance {"brand":{},"value":5}',
   'Liquidity successfully removed.',
-  'poolAmounts{"TokenA":{"brand":{},"value":0},"TokenB":{"brand":{},"value":0},"Liquidity":{"brand":{},"value":10}}',
+  'poolAmounts{"Liquidity":{"brand":{},"value":10},"TokenA":{"brand":{},"value":0},"TokenB":{"brand":{},"value":0}}',
   'aliceMoolaPurse: balance {"brand":{},"value":8}',
   'aliceSimoleanPurse: balance {"brand":{},"value":7}',
   'aliceLiquidityTokenPurse: balance {"brand":{},"value":0}',
 ];
-test('zoe - autoswap - valid inputs', async t => {
+test.only('zoe - autoswap - valid inputs', async t => {
   t.plan(1);
   const startingValues = [
     [10, 5, 0],

--- a/packages/zoe/test/unitTests/contracts/test-autoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-autoswap.js
@@ -4,8 +4,8 @@ import { test } from 'tape-promise/tape';
 import { E } from '@agoric/eventual-send';
 
 import { setup } from '../setupBasicMints';
+import { installationPFromSource } from '../installFromSource';
 import {
-  installationPFromSource,
   assertOfferResult,
   assertPayoutAmount,
   getInviteFields,

--- a/packages/zoe/test/unitTests/contracts/test-barter.js
+++ b/packages/zoe/test/unitTests/contracts/test-barter.js
@@ -5,8 +5,8 @@ import { test } from 'tape-promise/tape';
 import { E } from '@agoric/eventual-send';
 
 import { setup } from '../setupBasicMints';
+import { installationPFromSource } from '../installFromSource';
 import {
-  installationPFromSource,
   assertPayoutDeposit,
   assertOfferResult,
   getInviteFields,

--- a/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
@@ -42,11 +42,10 @@ test('multipoolAutoSwap with valid offers', async t => {
     const bundle = await bundleSource(multipoolAutoswapRoot);
 
     const installation = await zoe.install(bundle);
-    const { creatorFacet } = await zoe.makeInstance(
+    const { instance } = await zoe.makeInstance(
       installation,
       harden({ Central: centralR.issuer }),
     );
-    const instance = await E(creatorFacet).getInstance();
     const publicFacet = await E(zoe).getPublicFacet(instance);
     const aliceAddLiquidityInvitation = E(
       publicFacet,

--- a/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
+++ b/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
@@ -9,8 +9,8 @@ import { assert, details } from '@agoric/assert';
 // noinspection ES6PreferShortImport
 import { setup } from '../setupBasicMints';
 import { setupNonFungible } from '../setupNonFungibleMints';
+import { installationPFromSource } from '../installFromSource';
 import {
-  installationPFromSource,
   assertPayoutDeposit,
   assertOfferResult,
   getInviteFields,
@@ -48,13 +48,13 @@ test('simpleExchange with valid offers', async t => {
   const {
     creatorInvitation: aliceInvite,
     creatorFacet,
+    instance,
   } = await zoe.makeInstance(installation, {
     Asset: moolaIssuer,
     Price: simoleanIssuer,
   });
 
   const publicFacet = await creatorFacet.getPublicFacet();
-  const instance = creatorFacet.getInstance();
 
   const aliceNotifier = publicFacet.getNotifier();
   E(aliceNotifier)

--- a/packages/zoe/test/unitTests/installFromSource.js
+++ b/packages/zoe/test/unitTests/installFromSource.js
@@ -1,0 +1,4 @@
+import bundleSource from '@agoric/bundle-source';
+
+export const installationPFromSource = (zoe, source) =>
+  bundleSource(source).then(b => zoe.install(b));

--- a/packages/zoe/test/zoeTestHelpers.js
+++ b/packages/zoe/test/zoeTestHelpers.js
@@ -1,9 +1,19 @@
-import bundleSource from '@agoric/bundle-source';
 import { E } from '@agoric/eventual-send';
 
 export const assertPayoutAmount = (t, issuer, payout, expectedAmount) => {
   issuer.getAmountOf(payout).then(amount => {
     t.deepEquals(amount, expectedAmount, `payout was ${amount.value}`);
+  });
+};
+
+export const assertPayoutDeposit = (t, payout, purse, amount) => {
+  payout.then(payment => {
+    purse.deposit(payment);
+    t.deepEquals(
+      purse.getCurrentAmount(),
+      amount,
+      `payout was ${purse.getCurrentAmount().value}, expected ${amount}.value`,
+    );
   });
 };
 
@@ -20,9 +30,6 @@ export const assertRejectedOfferResult = (t, seat, expected) => {
     e => t.equals(e, expected, 'Expected offer to be rejected'),
   );
 };
-
-export const installationPFromSource = (zoe, source) =>
-  bundleSource(source).then(b => zoe.install(b));
 
 export const getInviteFields = (inviteIssuer, inviteP) =>
   E(inviteIssuer)


### PR DESCRIPTION
With logging to show that data returned from the contract makes it to ZCF, but doesn't reach Zoe or the contract creator.

```
/usr/local/bin/node -r esm /Users/chrishibbert/agoric-sdk/packages/zoe/test/swingsetTests/zoe/test-zoe.js
TAP version 13
# zoe - autoswap - valid inputs
= loading config from basedir /Users/chrishibbert/agoric-sdk/packages/zoe/test/swingsetTests/zoe
ignoring file bootstrap.js in /Users/chrishibbert/agoric-sdk/packages/zoe/test/swingsetTests/zoe
ignoring file bundle-atomicSwap.js in /Users/chrishibbert/agoric-sdk/packages/zoe/test/swingsetTests/zoe
ignoring file bundle-automaticRefund.js in /Users/chrishibbert/agoric-sdk/packages/zoe/test/swingsetTests/zoe
ignoring file bundle-autoswap.js in /Users/chrishibbert/agoric-sdk/packages/zoe/test/swingsetTests/zoe
ignoring file bundle-coveredCall.js in /Users/chrishibbert/agoric-sdk/packages/zoe/test/swingsetTests/zoe
ignoring file bundle-mintAndSellNFT.js in /Users/chrishibbert/agoric-sdk/packages/zoe/test/swingsetTests/zoe
ignoring file bundle-publicAuction.js in /Users/chrishibbert/agoric-sdk/packages/zoe/test/swingsetTests/zoe
ignoring file bundle-sellItems.js in /Users/chrishibbert/agoric-sdk/packages/zoe/test/swingsetTests/zoe
ignoring file bundle-simpleExchange.js in /Users/chrishibbert/agoric-sdk/packages/zoe/test/swingsetTests/zoe
ignoring file test-zoe.js in /Users/chrishibbert/agoric-sdk/packages/zoe/test/swingsetTests/zoe
SwingSet global metering is enabled
= adding vat 'alice' from bundle alice
= adding vat 'bob' from bundle bob
= adding vat 'carol' from bundle carol
= adding vat 'dave' from bundle dave
= adding vat 'zoe' from bundle zoe
= adding vat 'bootstrap' from bundle bootstrap
wasInitialized = false
Assigned VatID v1 for genesis vat vatAdmin
Assigned VatID v2 for genesis vat comms
Assigned VatID v3 for genesis vat vattp
Assigned VatID v4 for genesis vat timer
Assigned VatID v5 for genesis vat alice
Assigned VatID v6 for genesis vat bob
Assigned VatID v7 for genesis vat carol
Assigned VatID v8 for genesis vat dave
Assigned VatID v9 for genesis vat zoe
Assigned VatID v10 for genesis vat bootstrap
Assigned DeviceID d7 for genesis device vatAdmin
=> queueing bootstrap()
adding vref alice [v5]
adding vref bob [v6]
adding vref bootstrap [v10]
adding vref carol [v7]
adding vref comms [v2]
adding vref dave [v8]
adding vref timer [v4]
adding vref vatAdmin [v1]
adding vref vattp [v3]
adding vref zoe [v9]
adding dref vatAdmin [d7]
AUTO   pub: getCurrentPrice,getLiquidityIssuer,getPoolAllocation,makeSwapInvite,makeAddLiquidityInvite,makeRemoveLiquidityInvite
ZCF  getCurrentPrice,getLiquidityIssuer,getPoolAllocation,makeSwapInvite,makeAddLiquidityInvite,makeRemoveLiquidityInvite, getCurrentPrice,getLiquidityIssuer,getPoolAllocation,makeSwapInvite,makeAddLiquidityInvite,makeRemoveLiquidityInvite, undefined
 ZOE    foo creatorFacet,publicFacet,creatorInvitation,addSeatObj
ZOE  undefined [Presence o-63], 
ZOE   c:, w:getInstance
kernel message bootstrap: rejected {"body":"{\"@qclass\":\"error\",\"name\":\"TypeError\",\"message\":\"target[getLiquidityIssuer] does not exist, has getInstance\"}","slots":[]}
not ok 1 plan != count
  ---
    operator: fail
    expected: 1
    actual:   0
    at: Function.apply (/Users/chrishibbert/agoric-sdk/packages/tame-metering/src/tame.js:172:20)
    stack: |-
      Error: plan != count
        at Test.assert [as _assert] (/Users/chrishibbert/agoric-sdk/node_modules/tape/lib/test.js:225:54)
        at Function.apply (/Users/chrishibbert/agoric-sdk/packages/tame-metering/src/tame.js:172:20)
        at Test.bound [as _assert] (/Users/chrishibbert/agoric-sdk/node_modules/tape/lib/test.js:77:32)
        at Test.fail (/Users/chrishibbert/agoric-sdk/node_modules/tape/lib/test.js:318:10)
        at Function.apply (/Users/chrishibbert/agoric-sdk/packages/tame-metering/src/tame.js:172:20)
        at Test.bound [as fail] (/Users/chrishibbert/agoric-sdk/node_modules/tape/lib/test.js:77:32)
        at Test._exit (/Users/chrishibbert/agoric-sdk/node_modules/tape/lib/test.js:182:14)
        at Function.apply (/Users/chrishibbert/agoric-sdk/packages/tame-metering/src/tame.js:172:20)
        at Test.bound [as _exit] (/Users/chrishibbert/agoric-sdk/node_modules/tape/lib/test.js:77:32)
        at process.<anonymous> (/Users/chrishibbert/agoric-sdk/node_modules/tape/index.js:88:19)
  ...

1..1
# tests 1
# pass  0
# fail  1

##### KERNEL PANIC: bootstrap failure #####
UnhandledPromiseRejectionWarning: [Error <Object <[Object: null prototype] {}>>: kernel panic bootstrap failure
  at panic (kernel/packages/SwingSet/src/kernel/kernel.js:176:26)
  at Object.noteResolution (kernel/packages/SwingSet/src/kernel/messageResult.js:63:13)
  at notePendingMessageResolution (kernel/packages/SwingSet/src/kernel/kernelSyscall.js:86:12)
  at reject (kernel/packages/SwingSet/src/kernel/kernelSyscall.js:152:7)
  at Object.doKernelSyscall (kernel/packages/SwingSet/src/kernel/kernelSyscall.js:171:16)
  at vatSyscallHandler (kernel/packages/SwingSet/src/kernel/kernel.js:626:43)
  at doSyscall (kernel/packages/SwingSet/src/kernel/vatManager/syscall.js:80:18)
  at Object.reject (kernel/packages/SwingSet/src/kernel/vatManager/syscall.js:104:26)
  at eval (kernel/packages/SwingSet/src/kernel/liveSlots.js:461:15)]

Process finished with exit code 1
```