### PR TITLE
chore: add publicFacet and instance to MakeInstanceResult

### DIFF
--- a/packages/zoe/src/types.js
+++ b/packages/zoe/src/types.js
@@ -107,13 +107,10 @@
  */
 
 /**
- * @typedef {Object} CreatorFacetWInstance
- * @property {() => Instance} getInstance
- */
-
-/**
  * @typedef {Object} MakeInstanceResult
- * @property {CreatorFacetWInstance & Record<string, Function>} creatorFacet
+ * @property {Record<string, Function>} creatorFacet
+ * @property {{}} Instance
+ * @property {Record<string, Function>} publicFacet
  * @property {Payment} creatorInvitation
  */
 

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -266,15 +266,12 @@ function makeZoe(vatAdminSvc) {
       addSeatObjPromiseKit.resolve(addSeatObj);
       publicFacetPromiseKit.resolve(publicFacet);
 
-      const creatorFacetWInstance = {
-        ...creatorFacet,
-        getInstance: () => instance,
-      };
-
       // Actually returned to the user.
       return {
-        creatorFacet: creatorFacetWInstance,
+        creatorFacet,
         creatorInvitation: await creatorInvitation,
+        instance,
+        publicFacet,
       };
     },
     offer: async (


### PR DESCRIPTION
Add the `publicFacet` and `instance` to MakeInstanceResult.

Needed for dapp-encouragement work.