### PR TITLE
chore: add hasExited, getNotifier to UserSeat

### DIFF
--- a/packages/zoe/src/types.js
+++ b/packages/zoe/src/types.js
@@ -74,12 +74,14 @@
 
 /**
  * @typedef {Object} UserSeat
- * @property {() => Allocation} getCurrentAllocation
+ * @property {() => Promise<Allocation>} getCurrentAllocation
  * @property {() => Promise<ProposalRecord>} getProposal
  * @property {() => Promise<PaymentPKeywordRecord>} getPayouts
  * @property {(keyword: Keyword) => Promise<Payment>} getPayout
  * @property {() => Promise<OfferResult>} getOfferResult
  * @property {() => void=} exit
+ * @property {() => Promise<boolean>} hasExited
+ * @property {() => Promise<Notifier>} getNotifier
  *
  * @typedef {any} OfferResult
  */

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -58,14 +58,16 @@ export const makeZoeSeatAdminKit = (
 
   /** @type {UserSeat} */
   const userSeat = harden({
-    getCurrentAllocation: () => zoeSeatAdmin.getCurrentAllocation(),
+    getCurrentAllocation: async () => zoeSeatAdmin.getCurrentAllocation(),
     getProposal: async () => proposal,
     getPayouts: async () => payoutPromiseKit.promise,
     getPayout: async keyword =>
       payoutPromiseKit.promise.then(payouts => payouts[keyword]),
     getOfferResult: async () => offerResultPromiseKit.promise,
+    hasExited: async () => instanceAdmin.hasZoeSeatAdmin(zoeSeatAdmin),
     exit: async () =>
       exitObjPromiseKit.promise.then(exitObj => E(exitObj).exit()),
+    getNotifier: async () => notifier,
   });
 
   return { userSeat, zoeSeatAdmin, notifier };


### PR DESCRIPTION
Adds `hasExited`, `getNotifier` to UserSeat. Makes all methods async for predictability to improve the user experience.