### PR TITLE
remove unused loopbox from tests in non-swingset packages

### DIFF
--- a/packages/ERTP/test/swingsetTests/splitPayments/test-splitPayments.js
+++ b/packages/ERTP/test/swingsetTests/splitPayments/test-splitPayments.js
@@ -8,11 +8,6 @@ import path from 'path';
 async function main(basedir, argv) {
   const dir = path.resolve(`${__dirname}/..`, basedir);
   const config = await loadBasedir(dir);
-  const ldSrcPath = require.resolve(
-    '@agoric/swingset-vat/src/devices/loopbox-src',
-  );
-  config.devices = [['loopbox', ldSrcPath, {}]];
-
   const controller = await buildVatController(config, argv);
   await controller.run();
   return controller.dump();

--- a/packages/sharing-service/test/swingsetTests/sharingService/test-sharing.js
+++ b/packages/sharing-service/test/swingsetTests/sharingService/test-sharing.js
@@ -6,11 +6,6 @@ import { buildVatController, loadBasedir } from '@agoric/swingset-vat';
 async function main(basedir, argv) {
   const dir = path.resolve(`${__dirname}/..`, basedir);
   const config = await loadBasedir(dir);
-  const ldSrcPath = require.resolve(
-    '@agoric/swingset-vat/src/devices/loopbox-src',
-  );
-  config.devices = [['loopbox', ldSrcPath, {}]];
-
   const controller = await buildVatController(config, argv);
   await controller.run();
   return controller.dump();

--- a/packages/spawner/test/swingsetTests/contractHost/test-contractHost.js
+++ b/packages/spawner/test/swingsetTests/contractHost/test-contractHost.js
@@ -6,11 +6,6 @@ import { buildVatController, loadBasedir } from '@agoric/swingset-vat';
 async function main(basedir, argv) {
   const dir = path.resolve(`${__dirname}/..`, basedir);
   const config = await loadBasedir(dir);
-  const ldSrcPath = require.resolve(
-    '@agoric/swingset-vat/src/devices/loopbox-src',
-  );
-  config.devices = [['loopbox', ldSrcPath, {}]];
-
   const controller = await buildVatController(config, argv);
   await controller.run();
   return controller.dump();

--- a/packages/spawner/test/swingsetTests/escrow/test-escrow.js
+++ b/packages/spawner/test/swingsetTests/escrow/test-escrow.js
@@ -6,11 +6,6 @@ import path from 'path';
 async function main(basedir, argv) {
   const dir = path.resolve(`${__dirname}/..`, basedir);
   const config = await loadBasedir(dir);
-  const ldSrcPath = require.resolve(
-    '@agoric/swingset-vat/src/devices/loopbox-src',
-  );
-  config.devices = [['loopbox', ldSrcPath, {}]];
-
   const controller = await buildVatController(config, argv);
   await controller.run();
   return controller.dump();


### PR DESCRIPTION
I'm about to change the API of this device, and the non-swingset packages that are using it don't really need it, so removing it will reduce the amount of code churn.

refs #1400 
