### PR TITLE
chore(swingset): enhance loopbox, change API

### DIFF
--- a/packages/SwingSet/bin/vat
+++ b/packages/SwingSet/bin/vat
@@ -28,8 +28,9 @@ async function main() {
   const vatArgv = argv[0] === '--' ? argv.slice(1) : argv;
 
   const config = await loadBasedir(basedir);
-  const ldSrcPath = require.resolve('../src/devices/loopbox-src');
-  config.devices = [['loopbox', ldSrcPath, {}]];
+  const { buildLoopbox } = require('../src/devices/loopbox');
+  const { loopboxSrcPath, loopboxEndowments } = buildLoopbox('immediate');
+  config.devices = [['loopbox', loopboxSrcPath, loopboxEndowments]];
 
   const controller = await buildVatController(config, withSES, vatArgv);
   if (command === 'run') {

--- a/packages/SwingSet/src/devices/loopbox.js
+++ b/packages/SwingSet/src/devices/loopbox.js
@@ -1,0 +1,38 @@
+/* global harden */
+
+/*
+ * The "loopbox" is a special device used for unit tests, which glues one
+ * comms+vattp pair to another, within the same swingset machine. It looks
+ * like a regular mailbox, but everything added to it is delivered into the
+ * other vattp, rather than being serialized and sent out onto a network
+ * somehow.
+ *
+ * deliverMode='immediate' means each message sent by e.g. left-vattp will be
+ * immediately enqueued for delivery to right-vattp.
+ *
+ * deliverMode='queued' will stall the message until the host invokes our
+ * `passOneMessage()` message function. We need this to exercise bugs like
+ * #1400 which are sensitive to cross-machine message delivery order.
+ *
+ */
+
+export function buildLoopbox(deliverMode) {
+  if (deliverMode !== 'immediate' && deliverMode !== 'queued') {
+    throw Error(`deliverMode=${deliverMode}, must be 'immediate' or 'queued'`);
+  }
+  const loopboxSrcPath = require.resolve('./loopbox-src');
+
+  let loopboxPassOneMessage;
+  function registerPassOneMessage(lpom) {
+    loopboxPassOneMessage = lpom;
+  }
+  function passOneMessage() {
+    return loopboxPassOneMessage();
+  }
+
+  const loopboxEndowments = {
+    registerPassOneMessage,
+    deliverMode,
+  };
+  return harden({ passOneMessage, loopboxSrcPath, loopboxEndowments });
+}

--- a/packages/SwingSet/test/test-demos-comms.js
+++ b/packages/SwingSet/test/test-demos-comms.js
@@ -1,5 +1,6 @@
 import '@agoric/install-ses';
 import { test } from 'tape-promise/tape';
+import { buildLoopbox } from '../src/devices/loopbox';
 import { loadBasedir, buildVatController } from '../src/index';
 
 async function main(basedir, argv) {
@@ -11,8 +12,8 @@ async function main(basedir, argv) {
   if (config.vats.usercomms) {
     config.vats.usercomms.creationOptions = { enableSetup };
   }
-  const ldSrcPath = require.resolve('../src/devices/loopbox-src');
-  config.devices = [['loopbox', ldSrcPath, {}]];
+  const { loopboxSrcPath, loopboxEndowments } = buildLoopbox('immediate');
+  config.devices = [['loopbox', loopboxSrcPath, loopboxEndowments]];
 
   const controller = await buildVatController(config, argv);
   await controller.run();

--- a/packages/SwingSet/test/test-demos.js
+++ b/packages/SwingSet/test/test-demos.js
@@ -1,11 +1,12 @@
 import '@agoric/install-ses';
 import { test } from 'tape-promise/tape';
+import { buildLoopbox } from '../src/devices/loopbox';
 import { loadBasedir, buildVatController } from '../src/index';
 
 async function main(basedir, argv) {
   const config = await loadBasedir(basedir);
-  const ldSrcPath = require.resolve('../src/devices/loopbox-src');
-  config.devices = [['loopbox', ldSrcPath, {}]];
+  const { loopboxSrcPath, loopboxEndowments } = buildLoopbox('immediate');
+  config.devices = [['loopbox', loopboxSrcPath, loopboxEndowments]];
 
   const controller = await buildVatController(config, argv);
   await controller.run();


### PR DESCRIPTION
This adds a 'queued' mode, which delivers each message into a separate
swingset block/cycle. This matches the way cosmic-swingset's "fake chain"
mode works, so we can replicate a bug triggered only under that mode.

We'll need this to exercise the bug found in #1400 
