### PR TITLE
fix: noticed bug in exit code (exit afterDeadline still needs to affect `hasExited` on ZCFSeat)

### DIFF
--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -314,7 +314,7 @@ export function buildRootObject() {
           }
           throw err;
         });
-        const exitObj = makeExitObj(seatData.proposal, zoeSeatAdmin);
+        const exitObj = makeExitObj(seatData.proposal, zoeSeatAdmin, zcfSeatAdmin);
         /** @type AddSeatResult */
         return harden({ offerResultP, exitObj });
       },

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -88,6 +88,7 @@
  * @typedef {{zcfSeatAdmin: ZCFSeatAdmin, zcfSeat: ZCFSeat}} ZcfSeatAdminKit
  * @typedef {Object} ZCFSeatAdmin
  * @property {(seatStaging: SeatStaging) => void} commit
+ * @property {() => void} updateHasExited - updates `exited` state to true
  */
 
 /**
@@ -196,6 +197,7 @@
  * @callback MakeExitObj
  * @param {ProposalRecord} proposal
  * @param {ZoeSeatAdmin} zoeSeatAdmin
+ * @param {ZCFSeatAdmin} zcfSeatAdmin
  */
 
 /**

--- a/packages/zoe/test/unitTests/contracts/test-coveredCall.js
+++ b/packages/zoe/test/unitTests/contracts/test-coveredCall.js
@@ -191,11 +191,10 @@ test('zoe - coveredCall', async t => {
 test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, async t => {
   t.plan(13);
   try {
-    const { moolaR, simoleanR, moola, simoleans } = setup();
-    const zoe = makeZoe(fakeVatAdmin);
+    const { moolaR, simoleanR, moola, simoleans, zoe } = setup();
     // Pack the contract.
     const bundle = await bundleSource(coveredCallRoot);
-    const coveredCallInstallationHandle = await zoe.install(bundle);
+    const coveredCallInstallation = await zoe.install(bundle);
     const timer = buildManualTimer(console.log);
 
     // Setup Alice
@@ -213,8 +212,8 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
       UnderlyingAsset: moolaR.issuer,
       StrikePrice: simoleanR.issuer,
     });
-    const { invite: aliceInvite } = await zoe.makeInstance(
-      coveredCallInstallationHandle,
+    const { creatorInvitation: aliceInvitation } = await zoe.makeInstance(
+      coveredCallInstallation,
       issuerKeywordRecord,
     );
 
@@ -231,29 +230,28 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
     });
     const alicePayments = { UnderlyingAsset: aliceMoolaPayment };
     // Alice makes an option
-    const { payout: alicePayoutP, outcome: optionP } = await zoe.offer(
-      aliceInvite,
+    const aliceSeat = await zoe.offer(
+      aliceInvitation,
       aliceProposal,
       alicePayments,
     );
     timer.tick();
 
+    const optionP = E(aliceSeat).getOfferResult();
+
     // Imagine that Alice sends the option to Bob for free (not done here
     // since this test doesn't actually have separate vats/parties)
 
-    // Bob inspects the option (an invite payment) and checks that it is the
+    // Bob inspects the option (an invitation payment) and checks that it is the
     // contract instance that he expects as well as that Alice has
     // already escrowed.
 
-    const inviteIssuer = zoe.getInvitationIssuer();
-    const bobExclOption = await inviteIssuer.claim(optionP);
+    const invitationIssuer = zoe.getInvitationIssuer();
+    const bobExclOption = await invitationIssuer.claim(optionP);
     const {
       value: [optionValue],
-    } = await inviteIssuer.getAmountOf(bobExclOption);
-    const { installationHandle } = zoe.getInstanceRecord(
-      optionValue.instanceHandle,
-    );
-    t.equal(installationHandle, coveredCallInstallationHandle);
+    } = await invitationIssuer.getAmountOf(bobExclOption);
+    t.equal(optionValue.installation, coveredCallInstallation);
     t.equal(optionValue.description, 'exerciseOption');
     t.ok(moolaR.amountMath.isEqual(optionValue.underlyingAsset, moola(3)));
     t.ok(simoleanR.amountMath.isEqual(optionValue.strikePrice, simoleans(7)));
@@ -268,25 +266,18 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
     });
 
     // Bob escrows
-    const { payout: bobPayoutP, outcome: bobOutcomeP } = await zoe.offer(
-      bobExclOption,
-      bobProposal,
-      bobPayments,
-    );
+    const bobSeat = await zoe.offer(bobExclOption, bobProposal, bobPayments);
 
     t.rejects(
-      () => bobOutcomeP,
-      new Error('The covered call option is expired'),
+      () => E(bobSeat).getOfferResult(),
+      /The covered call option is expired./,
       'The call option should be expired',
     );
 
-    const bobPayout = await bobPayoutP;
-    const alicePayout = await alicePayoutP;
-
-    const bobMoolaPayout = await bobPayout.UnderlyingAsset;
-    const bobSimoleanPayout = await bobPayout.StrikePrice;
-    const aliceMoolaPayout = await alicePayout.UnderlyingAsset;
-    const aliceSimoleanPayout = await alicePayout.StrikePrice;
+    const bobMoolaPayout = await E(bobSeat).getPayout('UnderlyingAsset');
+    const bobSimoleanPayout = await E(bobSeat).getPayout('StrikePrice');
+    const aliceMoolaPayout = await E(aliceSeat).getPayout('UnderlyingAsset');
+    const aliceSimoleanPayout = await E(aliceSeat).getPayout('StrikePrice');
 
     // Alice gets back what she put in
     t.deepEquals(await moolaR.issuer.getAmountOf(aliceMoolaPayout), moola(3));
@@ -317,21 +308,20 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
   }
 });
 
-// Alice makes a covered call and escrows. She shares the invite to
-// Bob. Bob tries to sell the invite to Dave through a swap. Can Bob
+// Alice makes a covered call and escrows. She shares the invitation to
+// Bob. Bob tries to sell the invitation to Dave through a swap. Can Bob
 // trick Dave? Can Dave describe what it is that he wants in the swap
 // offer description?
-test('zoe - coveredCall with swap for invite', async t => {
+test('zoe - coveredCall with swap for invitation', async t => {
   t.plan(24);
   try {
     // Setup the environment
     const timer = buildManualTimer(console.log);
-    const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
-    const zoe = makeZoe(fakeVatAdmin);
+    const { moolaR, simoleanR, bucksR, moola, simoleans, bucks, zoe } = setup();
     // Pack the contract.
     const coveredCallBundle = await bundleSource(coveredCallRoot);
 
-    const coveredCallInstallationHandle = await zoe.install(coveredCallBundle);
+    const coveredCallInstallation = await zoe.install(coveredCallBundle);
     const atomicSwapBundle = await bundleSource(atomicSwapRoot);
 
     const swapInstallationId = await zoe.install(atomicSwapBundle);
@@ -361,8 +351,8 @@ test('zoe - coveredCall with swap for invite', async t => {
       UnderlyingAsset: moolaR.issuer,
       StrikePrice: simoleanR.issuer,
     });
-    const { invite: aliceInvite } = await zoe.makeInstance(
-      coveredCallInstallationHandle,
+    const { creatorInvitation: aliceInvitation } = await zoe.makeInstance(
+      coveredCallInstallation,
       issuerKeywordRecord,
     );
 
@@ -385,29 +375,28 @@ test('zoe - coveredCall with swap for invite', async t => {
     });
     const alicePayments = { UnderlyingAsset: aliceMoolaPayment };
     // Alice makes an option.
-    const { payout: alicePayoutP, outcome: optionP } = await zoe.offer(
-      aliceInvite,
+    const aliceSeat = await zoe.offer(
+      aliceInvitation,
       aliceProposal,
       alicePayments,
     );
 
-    // Imagine that Alice sends the invite to Bob (not done here since
+    const optionP = E(aliceSeat).getOfferResult();
+
+    // Imagine that Alice sends the invitation to Bob (not done here since
     // this test doesn't actually have separate vats/parties)
 
-    // Bob inspects the invite payment and checks its information against the
+    // Bob inspects the invitation payment and checks its information against the
     // questions that he has about whether it is worth being a counter
     // party in the covered call: Did the covered call use the
     // expected covered call installation (code)? Does it use the issuers
     // that he expects (moola and simoleans)?
-    const inviteIssuer = zoe.getInvitationIssuer();
-    const inviteAmountMath = inviteIssuer.getAmountMath();
-    const bobExclOption = await inviteIssuer.claim(optionP);
-    const optionAmount = await inviteIssuer.getAmountOf(bobExclOption);
+    const invitationIssuer = zoe.getInvitationIssuer();
+    const invitationAmountMath = invitationIssuer.getAmountMath();
+    const bobExclOption = await invitationIssuer.claim(optionP);
+    const optionAmount = await invitationIssuer.getAmountOf(bobExclOption);
     const optionDesc = optionAmount.value[0];
-    const { installationHandle } = zoe.getInstanceRecord(
-      optionDesc.instanceHandle,
-    );
-    t.equal(installationHandle, coveredCallInstallationHandle);
+    t.equal(optionDesc.installation, coveredCallInstallation);
     t.equal(optionDesc.description, 'exerciseOption');
     t.ok(moolaR.amountMath.isEqual(optionDesc.underlyingAsset, moola(3)));
     t.ok(simoleanR.amountMath.isEqual(optionDesc.strikePrice, simoleans(7)));
@@ -415,44 +404,43 @@ test('zoe - coveredCall with swap for invite', async t => {
     t.deepEqual(optionDesc.timerAuthority, timer);
 
     // Let's imagine that Bob wants to create a swap to trade this
-    // invite for bucks.
+    // invitation for bucks.
     const swapIssuerKeywordRecord = harden({
-      Asset: inviteIssuer,
+      Asset: invitationIssuer,
       Price: bucksR.issuer,
     });
-    const { invite: bobSwapInvite } = await zoe.makeInstance(
+    const { creatorInvitation: bobSwapInvitation } = await zoe.makeInstance(
       swapInstallationId,
       swapIssuerKeywordRecord,
     );
 
-    // Bob wants to swap an invite with the same amount as his
-    // current invite from Alice. He wants 1 buck in return.
+    // Bob wants to swap an invitation with the same amount as his
+    // current invitation from Alice. He wants 1 buck in return.
     const bobProposalSwap = harden({
-      give: { Asset: await inviteIssuer.getAmountOf(bobExclOption) },
+      give: { Asset: await invitationIssuer.getAmountOf(bobExclOption) },
       want: { Price: bucks(1) },
     });
 
     const bobPayments = harden({ Asset: bobExclOption });
 
     // Bob escrows his option in the swap
-    // Bob makes an offer to the swap with his "higher order" invite
-    const { payout: bobPayoutP, outcome: daveSwapInviteP } = await zoe.offer(
-      bobSwapInvite,
+    // Bob makes an offer to the swap with his "higher order" invitation
+    const bobSwapSeat = await zoe.offer(
+      bobSwapInvitation,
       bobProposalSwap,
       bobPayments,
     );
 
-    // Bob passes the swap invite to Dave and tells him the
+    const daveSwapInvitationP = E(bobSwapSeat).getOfferResult();
+
+    // Bob passes the swap invitation to Dave and tells him the
     // optionAmounts (basically, the description of the option)
 
     const {
-      value: [{ instanceHandle: swapInstanceHandle }],
-    } = await inviteIssuer.getAmountOf(daveSwapInviteP);
+      value: [{ instance: swapInstance, installation: daveSwapInstallId }],
+    } = await invitationIssuer.getAmountOf(daveSwapInvitationP);
 
-    const {
-      installationHandle: daveSwapInstallId,
-      issuerKeywordRecord: daveSwapIssuers,
-    } = zoe.getInstanceRecord(swapInstanceHandle);
+    const daveSwapIssuers = zoe.getIssuers(swapInstance);
 
     // Dave is looking to buy the option to trade his 7 simoleans for
     // 3 moola, and is willing to pay 1 buck for the option. He
@@ -466,14 +454,14 @@ test('zoe - coveredCall with swap for invite', async t => {
       sameStructure(
         daveSwapIssuers,
         harden({
-          Asset: inviteIssuer,
+          Asset: invitationIssuer,
           Price: bucksR.issuer,
         }),
       ),
     );
 
-    // What's actually up to be bought? Is it the kind of invite that
-    // Dave wants? What's the price for that invite? Is it acceptable
+    // What's actually up to be bought? Is it the kind of invitation that
+    // Dave wants? What's the price for that invitation? Is it acceptable
     // to Dave? Bob can tell Dave this out of band, and if he lies,
     // Dave's offer will be rejected and he will get a refund. Dave
     // knows this to be true because he knows the swap.
@@ -485,19 +473,19 @@ test('zoe - coveredCall with swap for invite', async t => {
     });
 
     const daveSwapPayments = harden({ Price: daveBucksPayment });
-    const {
-      payout: daveSwapPayoutP,
-      outcome: daveSwapOutcomeP,
-    } = await zoe.offer(daveSwapInviteP, daveSwapProposal, daveSwapPayments);
+    const daveSwapSeat = await zoe.offer(
+      daveSwapInvitationP,
+      daveSwapProposal,
+      daveSwapPayments,
+    );
 
     t.equals(
-      await daveSwapOutcomeP,
+      await daveSwapSeat.getOfferResult(),
       'The offer has been accepted. Once the contract has been completed, please check your payout',
     );
 
-    const daveSwapPayout = await daveSwapPayoutP;
-    const daveOption = await daveSwapPayout.Asset;
-    const daveBucksPayout = await daveSwapPayout.Price;
+    const daveOption = await daveSwapSeat.getPayout('Asset');
+    const daveBucksPayout = await daveSwapSeat.getPayout('Price');
 
     // Dave exercises his option by making an offer to the covered
     // call. First, he escrows with Zoe.
@@ -509,31 +497,29 @@ test('zoe - coveredCall with swap for invite', async t => {
     const daveCoveredCallPayments = harden({
       StrikePrice: daveSimoleanPayment,
     });
-    const {
-      payout: daveCoveredCallPayoutP,
-      outcome: daveCoveredCallOutcomeP,
-    } = await zoe.offer(
+    const daveCoveredCallSeat = await zoe.offer(
       daveOption,
       daveCoveredCallProposal,
       daveCoveredCallPayments,
     );
 
     t.equals(
-      await daveCoveredCallOutcomeP,
+      await E(daveCoveredCallSeat).getOfferResult(),
       'The offer has been accepted. Once the contract has been completed, please check your payout',
     );
 
     // Dave should get 3 moola, Bob should get 1 buck, and Alice
     // get 7 simoleans
-    const daveCoveredCallResult = await daveCoveredCallPayoutP;
-    const daveMoolaPayout = await daveCoveredCallResult.UnderlyingAsset;
-    const daveSimoleanPayout = await daveCoveredCallResult.StrikePrice;
-    const aliceResult = await alicePayoutP;
-    const aliceMoolaPayout = await aliceResult.UnderlyingAsset;
-    const aliceSimoleanPayout = await aliceResult.StrikePrice;
-    const bobResult = await bobPayoutP;
-    const bobInvitePayout = await bobResult.Asset;
-    const bobBucksPayout = await bobResult.Price;
+    const daveMoolaPayout = await daveCoveredCallSeat.getPayout(
+      'UnderlyingAsset',
+    );
+    const daveSimoleanPayout = await daveCoveredCallSeat.getPayout(
+      'StrikePrice',
+    );
+    const aliceMoolaPayout = await aliceSeat.getPayout('UnderlyingAsset');
+    const aliceSimoleanPayout = await aliceSeat.getPayout('StrikePrice');
+    const bobInvitationPayout = await bobSwapSeat.getPayout('Asset');
+    const bobBucksPayout = await bobSwapSeat.getPayout('Price');
 
     t.deepEquals(await moolaR.issuer.getAmountOf(daveMoolaPayout), moola(3));
     t.deepEquals(
@@ -548,8 +534,8 @@ test('zoe - coveredCall with swap for invite', async t => {
     );
 
     t.deepEquals(
-      await inviteIssuer.getAmountOf(bobInvitePayout),
-      inviteAmountMath.getEmpty(),
+      await invitationIssuer.getAmountOf(bobInvitationPayout),
+      invitationAmountMath.getEmpty(),
     );
     t.deepEquals(await bucksR.issuer.getAmountOf(bobBucksPayout), bucks(1));
 
@@ -580,21 +566,21 @@ test('zoe - coveredCall with swap for invite', async t => {
   }
 });
 
-// Alice makes a covered call and escrows. She shares the invite to
-// Bob. Bob tries to sell the invite to Dave through another covered
+// Alice makes a covered call and escrows. She shares the invitation to
+// Bob. Bob tries to sell the invitation to Dave through another covered
 // call. Can Bob trick Dave? Can Dave describe what it is that he
 // wants in his offer description in the second covered call?
-test('zoe - coveredCall with coveredCall for invite', async t => {
+test('zoe - coveredCall with coveredCall for invitation', async t => {
   t.plan(31);
   try {
     // Setup the environment
     const timer = buildManualTimer(console.log);
-    const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
-    const zoe = makeZoe(fakeVatAdmin);
+    const { moolaR, simoleanR, bucksR, moola, simoleans, bucks, zoe } = setup();
+
     // Pack the contract.
     const bundle = await bundleSource(coveredCallRoot);
 
-    const coveredCallInstallationHandle = await zoe.install(bundle);
+    const coveredCallInstallation = await zoe.install(bundle);
 
     // Setup Alice
     // Alice starts with 3 moola
@@ -621,10 +607,9 @@ test('zoe - coveredCall with coveredCall for invite', async t => {
       UnderlyingAsset: moolaR.issuer,
       StrikePrice: simoleanR.issuer,
     });
-    const { invite: aliceCoveredCallInvite } = await zoe.makeInstance(
-      coveredCallInstallationHandle,
-      issuerKeywordRecord,
-    );
+    const {
+      creatorInvitation: aliceCoveredCallInvitation,
+    } = await zoe.makeInstance(coveredCallInstallation, issuerKeywordRecord);
 
     // Alice escrows with Zoe. She specifies her proposal,
     // which include what she wants and gives as well as the exit
@@ -644,33 +629,31 @@ test('zoe - coveredCall with coveredCall for invite', async t => {
       },
     });
     const alicePayments = { UnderlyingAsset: aliceMoolaPayment };
-    // Alice makes a call option, which is an invite to join the
+    // Alice makes a call option, which is an invitation to join the
     // covered call contract
-    const { payout: alicePayoutP, outcome: optionP } = await zoe.offer(
-      aliceCoveredCallInvite,
+    const aliceSeat = await zoe.offer(
+      aliceCoveredCallInvitation,
       aliceProposal,
       alicePayments,
     );
+    const optionP = await E(aliceSeat).getOfferResult();
 
-    // Imagine that Alice sends the invite to Bob as well as the
+    // Imagine that Alice sends the invitation to Bob as well as the
     // instanceHandle (not done here since this test doesn't actually have
     // separate vats/parties)
 
-    // Bob inspects the invite payment and checks its information against the
+    // Bob inspects the invitation payment and checks its information against the
     // questions that he has about whether it is worth being a counter
     // party in the covered call: Did the covered call use the
     // expected covered call installation (code)? Does it use the issuers
     // that he expects (moola and simoleans)?
-    const inviteIssuer = zoe.getInvitationIssuer();
-    const inviteAmountMath = inviteIssuer.getAmountMath();
-    const bobExclOption = await inviteIssuer.claim(optionP);
+    const invitationIssuer = zoe.getInvitationIssuer();
+    const invitationAmountMath = invitationIssuer.getAmountMath();
+    const bobExclOption = await invitationIssuer.claim(optionP);
     const {
       value: [optionValue],
-    } = await inviteIssuer.getAmountOf(bobExclOption);
-    const { installationHandle } = zoe.getInstanceRecord(
-      optionValue.instanceHandle,
-    );
-    t.equal(installationHandle, coveredCallInstallationHandle);
+    } = await invitationIssuer.getAmountOf(bobExclOption);
+    t.equal(optionValue.installation, coveredCallInstallation);
     t.equal(optionValue.description, 'exerciseOption');
     t.ok(moolaR.amountMath.isEqual(optionValue.underlyingAsset, moola(3)));
     t.ok(simoleanR.amountMath.isEqual(optionValue.strikePrice, simoleans(7)));
@@ -678,20 +661,21 @@ test('zoe - coveredCall with coveredCall for invite', async t => {
     t.deepEqual(optionValue.timerAuthority, timer);
 
     // Let's imagine that Bob wants to create another coveredCall, but
-    // this time to trade this invite for bucks.
+    // this time to trade this invitation for bucks.
     const issuerKeywordRecord2 = harden({
-      UnderlyingAsset: inviteIssuer,
+      UnderlyingAsset: invitationIssuer,
       StrikePrice: bucksR.issuer,
     });
-    const { invite: bobInviteForSecondCoveredCall } = await zoe.makeInstance(
-      coveredCallInstallationHandle,
-      issuerKeywordRecord2,
-    );
+    const {
+      creatorInvitation: bobInvitationForSecondCoveredCall,
+    } = await zoe.makeInstance(coveredCallInstallation, issuerKeywordRecord2);
 
-    // Bob wants to swap an invite with the same amount as his
-    // current invite from Alice. He wants 1 buck in return.
+    // Bob wants to swap an invitation with the same amount as his
+    // current invitation from Alice. He wants 1 buck in return.
     const bobProposalSecondCoveredCall = harden({
-      give: { UnderlyingAsset: await inviteIssuer.getAmountOf(bobExclOption) },
+      give: {
+        UnderlyingAsset: await invitationIssuer.getAmountOf(bobExclOption),
+      },
       want: { StrikePrice: bucks(1) },
       exit: {
         afterDeadline: {
@@ -703,28 +687,26 @@ test('zoe - coveredCall with coveredCall for invite', async t => {
 
     const bobPayments = { UnderlyingAsset: bobExclOption };
 
-    // Bob escrows his invite
+    // Bob escrows his invitation
     // Bob makes an offer to the swap with his "higher order" option
-    const { payout: bobPayoutP, outcome: inviteForDaveP } = await zoe.offer(
-      bobInviteForSecondCoveredCall,
+    const bobSeat = await zoe.offer(
+      bobInvitationForSecondCoveredCall,
       bobProposalSecondCoveredCall,
       bobPayments,
     );
+    const invitationForDaveP = E(bobSeat).getOfferResult();
 
-    // Bob passes the higher order invite and
+    // Bob passes the higher order invitation and
     // optionAmounts to Dave
 
     // Dave is looking to buy the option to trade his 7 simoleans for
     // 3 moola, and is willing to pay 1 buck for the option. He
-    // checks that this invite matches what he wants
-    const daveExclOption = await inviteIssuer.claim(inviteForDaveP);
+    // checks that this invitation matches what he wants
+    const daveExclOption = await invitationIssuer.claim(invitationForDaveP);
     const {
       value: [daveOptionValue],
-    } = await inviteIssuer.getAmountOf(daveExclOption);
-    const {
-      installationHandle: daveOptionInstallationHandle,
-    } = zoe.getInstanceRecord(daveOptionValue.instanceHandle);
-    t.equal(daveOptionInstallationHandle, coveredCallInstallationHandle);
+    } = await invitationIssuer.getAmountOf(daveExclOption);
+    t.equal(daveOptionValue.installation, coveredCallInstallation);
     t.equal(daveOptionValue.description, 'exerciseOption');
     t.ok(bucksR.amountMath.isEqual(daveOptionValue.strikePrice, bucks(1)));
     t.equal(daveOptionValue.expirationDate, 100);
@@ -753,24 +735,23 @@ test('zoe - coveredCall with coveredCall for invite', async t => {
     // Dave escrows his 1 buck with Zoe and forms his proposal
 
     const daveSecondCoveredCallPayments = { StrikePrice: daveBucksPayment };
-    const {
-      payout: daveSecondCoveredCallPayoutP,
-      outcome: daveSecondCoveredCallOutcomeP,
-    } = await zoe.offer(
+    const daveSecondCoveredCallSeat = await zoe.offer(
       daveExclOption,
       daveProposalCoveredCall,
       daveSecondCoveredCallPayments,
     );
     t.equals(
-      await daveSecondCoveredCallOutcomeP,
+      await E(daveSecondCoveredCallSeat).getOfferResult(),
       'The offer has been accepted. Once the contract has been completed, please check your payout',
       `dave second offer accepted`,
     );
 
-    const daveSecondCoveredCallPayout = await daveSecondCoveredCallPayoutP;
-
-    const firstCoveredCallInvite = await daveSecondCoveredCallPayout.UnderlyingAsset;
-    const daveBucksPayout = await daveSecondCoveredCallPayout.StrikePrice;
+    const firstCoveredCallInvitation = await daveSecondCoveredCallSeat.getPayout(
+      'UnderlyingAsset',
+    );
+    const daveBucksPayout = await daveSecondCoveredCallSeat.getPayout(
+      'StrikePrice',
+    );
 
     // Dave exercises his option by making an offer to the covered
     // call. First, he escrows with Zoe.
@@ -782,35 +763,33 @@ test('zoe - coveredCall with coveredCall for invite', async t => {
     const daveFirstCoveredCallPayments = harden({
       StrikePrice: daveSimoleanPayment,
     });
-    const {
-      payout: daveFirstCoveredCallPayoutP,
-      outcome: daveFirstCoveredCallOutcomeP,
-    } = await zoe.offer(
-      firstCoveredCallInvite,
+    const daveFirstCoveredCallSeat = await zoe.offer(
+      firstCoveredCallInvitation,
       daveFirstCoveredCallProposal,
       daveFirstCoveredCallPayments,
     );
 
     t.equals(
-      await daveFirstCoveredCallOutcomeP,
+      await daveFirstCoveredCallSeat.getOfferResult(),
       'The offer has been accepted. Once the contract has been completed, please check your payout',
       `dave first offer accepted`,
     );
 
     // Dave should get 3 moola, Bob should get 1 buck, and Alice
     // get 7 simoleans
-    const daveFirstCoveredCallResult = await daveFirstCoveredCallPayoutP;
-    const aliceResult = await alicePayoutP;
-    const bobResult = await bobPayoutP;
 
-    const daveMoolaPayout = await daveFirstCoveredCallResult.UnderlyingAsset;
-    const daveSimoleanPayout = await daveFirstCoveredCallResult.StrikePrice;
+    const daveMoolaPayout = await daveFirstCoveredCallSeat.getPayout(
+      'UnderlyingAsset',
+    );
+    const daveSimoleanPayout = await daveFirstCoveredCallSeat.getPayout(
+      'StrikePrice',
+    );
 
-    const aliceMoolaPayout = await aliceResult.UnderlyingAsset;
-    const aliceSimoleanPayout = await aliceResult.StrikePrice;
+    const aliceMoolaPayout = await aliceSeat.getPayout('UnderlyingAsset');
+    const aliceSimoleanPayout = await aliceSeat.getPayout('StrikePrice');
 
-    const bobInvitePayout = await bobResult.UnderlyingAsset;
-    const bobBucksPayout = await bobResult.StrikePrice;
+    const bobInvitationPayout = await bobSeat.getPayout('UnderlyingAsset');
+    const bobBucksPayout = await bobSeat.getPayout('StrikePrice');
 
     t.deepEquals(await moolaR.issuer.getAmountOf(daveMoolaPayout), moola(3));
     t.deepEquals(
@@ -825,8 +804,8 @@ test('zoe - coveredCall with coveredCall for invite', async t => {
     );
 
     t.deepEquals(
-      await inviteIssuer.getAmountOf(bobInvitePayout),
-      inviteAmountMath.getEmpty(),
+      await invitationIssuer.getAmountOf(bobInvitationPayout),
+      invitationAmountMath.getEmpty(),
     );
     t.deepEquals(await bucksR.issuer.getAmountOf(bobBucksPayout), bucks(1));
 
@@ -870,12 +849,12 @@ test('zoe - coveredCall non-fungible', async t => {
     rpgItems,
     amountMaths,
     createRpgItem,
+    zoe,
   } = setupNonFungible();
 
-  const zoe = makeZoe(fakeVatAdmin);
   // install the contract.
   const bundle = await bundleSource(coveredCallRoot);
-  const coveredCallInstallationHandle = await zoe.install(bundle);
+  const coveredCallInstallation = await zoe.install(bundle);
   const timer = buildManualTimer(console.log);
 
   // Setup Alice
@@ -902,8 +881,8 @@ test('zoe - coveredCall non-fungible', async t => {
     StrikePrice: rpgIssuer,
   });
   // separate issuerKeywordRecord from contract-specific terms
-  const { invite: aliceInvite } = await zoe.makeInstance(
-    coveredCallInstallationHandle,
+  const { creatorInvitation: aliceInvitation } = await zoe.makeInstance(
+    coveredCallInstallation,
     issuerKeywordRecord,
   );
 
@@ -915,28 +894,26 @@ test('zoe - coveredCall non-fungible', async t => {
   });
   const alicePayments = { UnderlyingAsset: aliceCcPayment };
   // Alice creates a call option
-  const { payout: alicePayoutP, outcome: optionP } = await zoe.offer(
-    aliceInvite,
+  const aliceSeat = await zoe.offer(
+    aliceInvitation,
     aliceProposal,
     alicePayments,
   );
+  const optionP = E(aliceSeat).getOfferResult();
 
   // Imagine that Alice sends the option to Bob for free (not done here
   // since this test doesn't actually have separate vats/parties)
 
-  // Bob inspects the option (an invite payment) and checks that it is the
+  // Bob inspects the option (an invitation payment) and checks that it is the
   // contract instance that he expects as well as that Alice has
   // already escrowed.
 
-  const inviteIssuer = zoe.getInvitationIssuer();
-  const bobExclOption = await inviteIssuer.claim(optionP);
+  const invitationIssuer = zoe.getInvitationIssuer();
+  const bobExclOption = await invitationIssuer.claim(optionP);
   const {
     value: [optionValue],
-  } = await inviteIssuer.getAmountOf(bobExclOption);
-  const { installationHandle } = zoe.getInstanceRecord(
-    optionValue.instanceHandle,
-  );
-  t.equal(installationHandle, coveredCallInstallationHandle);
+  } = await invitationIssuer.getAmountOf(bobExclOption);
+  t.equal(optionValue.installation, coveredCallInstallation);
   t.equal(optionValue.description, 'exerciseOption');
   t.ok(
     amountMaths
@@ -959,26 +936,19 @@ test('zoe - coveredCall non-fungible', async t => {
     exit: { onDemand: null },
   });
 
-  // Bob redeems his invite and escrows with Zoe
+  // Bob redeems his invitation and escrows with Zoe
   // Bob exercises the option
-  const { payout: bobPayoutP, outcome: bobOutcomeP } = await zoe.offer(
-    bobExclOption,
-    bobProposal,
-    bobPayments,
-  );
+  const bobSeat = await zoe.offer(bobExclOption, bobProposal, bobPayments);
 
   t.equals(
-    await bobOutcomeP,
+    await E(bobSeat).getOfferResult(),
     'The offer has been accepted. Once the contract has been completed, please check your payout',
   );
 
-  const bobPayout = await bobPayoutP;
-  const alicePayout = await alicePayoutP;
-
-  const bobCcPayout = await bobPayout.UnderlyingAsset;
-  const bobRpgPayout = await bobPayout.StrikePrice;
-  const aliceCcPayout = await alicePayout.UnderlyingAsset;
-  const aliceRpgPayout = await alicePayout.StrikePrice;
+  const bobCcPayout = await E(bobSeat).getPayout('UnderlyingAsset');
+  const bobRpgPayout = await E(bobSeat).getPayout('StrikePrice');
+  const aliceCcPayout = await E(aliceSeat).getPayout('UnderlyingAsset');
+  const aliceRpgPayout = await E(aliceSeat).getPayout('StrikePrice');
 
   // Alice gets what Alice wanted
   t.deepEquals(


### PR DESCRIPTION
Bug fix: exit afterDeadline still needs to affect `hasExited` on ZCFSeat

Also, all coveredCall tests now pass.