### PR TITLE
fix: get Zoe cosmic-swingset tests to pass

### DIFF
--- a/packages/cosmic-swingset/test/test-home.js
+++ b/packages/cosmic-swingset/test/test-home.js
@@ -75,7 +75,9 @@ test('home.wallet - receive zoe invite', async t => {
     );
     const bundle = await bundleSource(contractRoot);
     const installationHandle = await E(zoe).install(bundle);
-    const { invite } = await E(zoe).makeInstance(installationHandle);
+    const { creatorInvitation: invite } = await E(zoe).makeInstance(
+      installationHandle,
+    );
 
     // Check that the wallet knows about the Zoe invite issuer and starts out
     // with a default Zoe invite issuer purse.

--- a/packages/dapp-svelte-wallet/api/src/lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-wallet.js
@@ -1070,13 +1070,9 @@ export async function makeWallet({
     },
   });
 
-  function getDepositFacetId(brandBoardId) {
-    return E(board)
-      .getValue(brandBoardId)
-      .then(brand => {
-        const depositFacetBoardId = brandToDepositFacetId.get(brand);
-        return depositFacetBoardId;
-      });
+  async function getDepositFacetId(_brandBoardId) {
+    // Always return the generic deposit facet.
+    return selfContact.depositBoardId;
   }
 
   async function disableAutoDeposit(pursePetname) {


### PR DESCRIPTION
Along the way, always return the public payment facet as the wallet's only deposit facet.
