### PR TITLE
chore(swingset): localVatManager: give vatParameters to setup()

### DIFF
--- a/packages/SwingSet/src/kernel/vatManager/localVatManager.js
+++ b/packages/SwingSet/src/kernel/vatManager/localVatManager.js
@@ -78,9 +78,11 @@ export function makeLocalVatManagerFactory(tools) {
     assert(setup instanceof Function, 'setup is not an in-realm function');
     const { syscall, finish } = prepare(vatID, managerOptions);
 
+    const { vatParameters } = managerOptions;
+    const { testLog } = allVatPowers;
     const helpers = harden({}); // DEPRECATED, todo remove from setup()
     const state = null; // TODO remove from setup()
-    const vatPowers = harden({ ...baseVP, testLog: allVatPowers.testLog });
+    const vatPowers = harden({ ...baseVP, vatParameters, testLog });
     const dispatch = setup(syscall, state, helpers, vatPowers);
     const meterRecord = null;
     return finish(dispatch, meterRecord);
@@ -128,6 +130,7 @@ export function makeLocalVatManagerFactory(tools) {
     const vatPowers = harden({
       ...baseVP,
       ...imVP,
+      vatParameters,
       testLog: allVatPowers.testLog,
     });
     const state = null; // TODO remove from makeLiveSlots()


### PR DESCRIPTION
This comes in two flavors. The first is for vats that are defined by a
directly-submitted setup() function. The only vats which use this are defined
in swingset unit tests, without a controller.

The second is for vats defined by a bundle file, which exports a default
function (rather than a named `buildRootObject()` export, which already gets
`vatParameters`). The comms vat does this, because it doesn't use liveslots,
but `setup` must be enabled with a special config variable. No code outside
swingset ought to use `setup`.

This lets us pass vatParameters to the comms vat, which could be used to
enable debug logging, with distinct prefixes message for left-comms and
right-comms in the message-patterns tests. Unfortunately, because
buildVatController creates the normal comms vat config internally, there's no
opportunity for a host to switch on comms debug from the outside. This might
be fixed in the future if we use a "builder" approach to the config, as
described in #1351 .