### PR TITLE
fix: minor wallet cleanup

### DIFF
--- a/packages/dapp-svelte-wallet/api/src/lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-wallet.js
@@ -604,7 +604,7 @@ export async function makeWallet({
     updatePursesState(purseMapping.valToPetname.get(purse), purse);
   };
 
-  function deposit(pursePetname, payment) {
+  async function deposit(pursePetname, payment) {
     const purse = purseMapping.petnameToVal.get(pursePetname);
     return purse.deposit(payment);
   }
@@ -974,12 +974,10 @@ export async function makeWallet({
   const addPayment = async (payment, depositTo = undefined) => {
     // We don't even create the record until we get an alleged brand.
     const brand = await E(payment).getAllegedBrand();
+    const depositedPK = makePromiseKit();
 
     /** @type {PaymentRecord} */
-    let paymentRecord;
-
-    const depositedPK = makePromiseKit();
-    paymentRecord = {
+    let paymentRecord = {
       payment,
       brand,
       issuer: undefined,

--- a/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
@@ -274,7 +274,7 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
     const {
       value: [{ handle: inviteHandle2 }],
     } = await E(inviteIssuer).getAmountOf(invite2);
-    wallet.deposit('Default Zoe invite purse', invite2);
+    await wallet.deposit('Default Zoe invite purse', invite2);
 
     const currentAmount = await E(zoeInvitePurse).getCurrentAmount();
     t.deepEquals(


### PR DESCRIPTION
Make `wallet.deposit` always async.  Avoidance of minor unnecessary TDZ.
