### PR TITLE
Enable Zoe to use kernel bundle table

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/start.js
+++ b/packages/cosmic-swingset/lib/ag-solo/start.js
@@ -12,6 +12,7 @@ import anylogger from 'anylogger';
 
 import {
   loadBasedir,
+  loadSwingsetConfigFile,
   buildCommand,
   buildVatController,
   buildMailboxStateMap,
@@ -87,7 +88,10 @@ async function buildSwingset(
   const cm = buildCommand(broadcast);
   const timer = buildTimer();
 
-  const config = await loadBasedir(vatsDir);
+  let config = loadSwingsetConfigFile(`${vatsDir}/solo-config.json`);
+  if (config === null) {
+    config = loadBasedir(vatsDir);
+  }
   config.devices = [
     ['mailbox', mb.srcPath, mb.endowments],
     ['command', cm.srcPath, cm.endowments],

--- a/packages/cosmic-swingset/lib/ag-solo/vats/chain-config.json
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/chain-config.json
@@ -1,0 +1,49 @@
+{
+  "bootstrap": "bootstrap",
+  "bundles": {
+    "zcf": {
+      "sourcePath": "../../../../zoe/src/contractFacet.js"
+    }
+  },
+  "vats": {
+    "board": {
+      "sourcePath": "vat-board.js"
+    },
+    "host": {
+      "sourcePath": "vat-host.js"
+    },
+    "http": {
+      "sourcePath": "vat-http.js"
+    },
+    "ibc": {
+      "sourcePath": "vat-ibc.js"
+    },
+    "mints": {
+      "sourcePath": "vat-mints.js"
+    },
+    "network": {
+      "sourcePath": "vat-network.js"
+    },
+    "provisioning": {
+      "sourcePath": "vat-provisioning.js"
+    },
+    "registrar": {
+      "sourcePath": "vat-registrar.js"
+    },
+    "sharing": {
+      "sourcePath": "vat-sharing.js"
+    },
+    "uploads": {
+      "sourcePath": "vat-uploads.js"
+    },
+    "zoe": {
+      "sourcePath": "vat-zoe.js",
+      "parameters": {
+        "zcfBundleName": "zcf"
+      }
+    },
+    "bootstrap": {
+      "sourcePath": "bootstrap.js"
+    }
+  }
+}

--- a/packages/cosmic-swingset/lib/ag-solo/vats/solo-config.json
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/solo-config.json
@@ -1,0 +1,49 @@
+{
+  "bootstrap": "bootstrap",
+  "bundles": {
+    "zcf": {
+      "sourcePath": "../../../../zoe/src/contractFacet.js"
+    }
+  },
+  "vats": {
+    "board": {
+      "sourcePath": "vat-board.js"
+    },
+    "host": {
+      "sourcePath": "vat-host.js"
+    },
+    "http": {
+      "sourcePath": "vat-http.js"
+    },
+    "ibc": {
+      "sourcePath": "vat-ibc.js"
+    },
+    "mints": {
+      "sourcePath": "vat-mints.js"
+    },
+    "network": {
+      "sourcePath": "vat-network.js"
+    },
+    "provisioning": {
+      "sourcePath": "vat-provisioning.js"
+    },
+    "registrar": {
+      "sourcePath": "vat-registrar.js"
+    },
+    "sharing": {
+      "sourcePath": "vat-sharing.js"
+    },
+    "uploads": {
+      "sourcePath": "vat-uploads.js"
+    },
+    "zoe": {
+      "sourcePath": "vat-zoe.js",
+      "parameters": {
+        "zcfBundleName": "zcf"
+      }
+    },
+    "bootstrap": {
+      "sourcePath": "bootstrap.js"
+    }
+  }
+}

--- a/packages/zoe/src/zoe.js
+++ b/packages/zoe/src/zoe.js
@@ -33,6 +33,8 @@ import zcfContractBundle from '../bundles/bundle-contractFacet';
  *
  * @param {Object} vatAdminSvc - The vatAdmin Service, which carries the power
  * to create a new vat.
+ * @param {string} [zcfBundleName] - Optional name of the kernel bundle for zcf
+ *
  * @returns {ZoeService} The created Zoe service.
  */
 function makeZoe(vatAdminSvc, zcfBundleName) {
@@ -241,6 +243,17 @@ function makeZoe(vatAdminSvc, zcfBundleName) {
       );
       const publicApiP = makePromiseKit();
 
+      // If `makeZoe` was passed a bundle name for zcf, the named kernel bundle
+      // will be used to generate the zcf vat; otherwise the imported zcf bundle
+      // file will be used directly.  Using a named bundle avoids transmitting
+      // the bundle itself across the network as an extremely long (300K+)
+      // string, as well as avoiding having this same large string appear
+      // several times in the kernel transcript.  However, the named bundle
+      // option is only available if (a) the Zoe vat was configured to have it
+      // (it is not required) and (b) Zoe is running in a context where the
+      // kernel bundle table is actually available for such a lookup (for
+      // example, many unit tests lack this since they don't have a SwingSet
+      // kernel present at all).
       const vatP = zcfBundleName
         ? E(vatAdminSvc).createVatByName(zcfBundleName)
         : E(vatAdminSvc).createVat(zcfContractBundle);

--- a/packages/zoe/test/unitTests/contracts/fakeVatAdmin.js
+++ b/packages/zoe/test/unitTests/contracts/fakeVatAdmin.js
@@ -7,7 +7,7 @@ export default harden({
       root: E(evalContractBundle(bundle)).buildRootObject(),
     });
   },
-  createVatByName: name => {
+  createVatByName: _name => {
     throw Error(`createVatByName not supported in fake mode`);
   },
 });

--- a/packages/zoe/test/unitTests/contracts/fakeVatAdmin.js
+++ b/packages/zoe/test/unitTests/contracts/fakeVatAdmin.js
@@ -7,4 +7,7 @@ export default harden({
       root: E(evalContractBundle(bundle)).buildRootObject(),
     });
   },
+  createVatByName: name => {
+    throw Error(`createVatByName not supported in fake mode`);
+  },
 });


### PR DESCRIPTION
(Diffs best viewed with the 'ignore whitespace' flag set)

Currently this has two independent config files, one for ag-solo and the other for on chain.  Right now they are identical, but they are configured separately in anticipation that the appropriate sets of vats for the two contexts are likely to diverge (and likely already would have had the code not previously been indiscriminately hoovering up everything the ag-solo/vats directory -- also, I expect we will eventually end up wanting to move some or all of those vat definitions to other places now that we can, but that's for another day).