### PR TITLE
Quieter captp

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/vats/captp.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/captp.js
@@ -4,7 +4,7 @@
 // in its own makeHardener, etc.
 import { makeCapTP } from '@agoric/captp/lib/captp';
 
-export const getCapTPHandler = (send, getBootstrapObject, powers) => {
+export const getCapTPHandler = (send, getBootstrapObject) => {
   const chans = new Map();
   const handler = harden({
     onOpen(_obj, meta) {
@@ -17,7 +17,12 @@ export const getCapTPHandler = (send, getBootstrapObject, powers) => {
         origin,
         sendObj,
         getBootstrapObject,
-        { harden, ...powers },
+        {
+          onReject(err) {
+            // Be quieter for sanity's sake.
+            console.log('CapTP', origin, 'exception:', err);
+          },
+        },
       );
       chans.set(channelHandle, [dispatch, abort]);
     },

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-http.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-http.js
@@ -71,9 +71,8 @@ export function buildRootObject(vatPowers) {
       // TODO: Break this out into a separate vat.
       const captpHandler = getCapTPHandler(
         send,
-        // Harden only our exported objects.
+        // Harden only our exported objects, and fetch them afresh each time.
         () => harden(exportedToCapTP),
-        { E, harden, ...vatPowers },
       );
       registerURLHandler(captpHandler, '/private/captp');
     },


### PR DESCRIPTION
Make the default console less noisy when deploying to captp on `ag-solo` (or disconnecting).
