### PR TITLE
feat: use debugName to differentiate sim-chain instances

### DIFF
--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -35,11 +35,6 @@ function makeConsole(tag) {
 }
 const console = makeConsole('SwingSet:controller');
 
-// FIXME: Put this somewhere better.
-process.on('unhandledRejection', e =>
-  console.error('UnhandledPromiseRejectionWarning:', e),
-);
-
 const ADMIN_DEVICE_PATH = require.resolve('./kernel/vatAdmin/vatAdmin-src');
 const ADMIN_VAT_PATH = require.resolve('./kernel/vatAdmin/vatAdminWrapper');
 const KERNEL_SOURCE_PATH = require.resolve('./kernel/kernel.js');
@@ -135,9 +130,18 @@ export async function buildVatController(
   argv = [],
   runtimeOptions = {},
 ) {
+  const { debugPrefix = '' } = runtimeOptions;
   if (typeof Compartment === 'undefined') {
     throw Error('SES must be installed before calling buildVatController');
   }
+
+  // eslint-disable-next-line no-shadow
+  const console = makeConsole(`${debugPrefix}SwingSet:controller`);
+
+  // FIXME: Put this somewhere better.
+  process.on('unhandledRejection', e =>
+    console.error('UnhandledPromiseRejectionWarning:', e),
+  );
 
   // https://github.com/Agoric/SES-shim/issues/292
   harden(Object.getPrototypeOf(console));
@@ -168,7 +172,7 @@ export async function buildVatController(
   const kernelNS = await importBundle(kernelSource, {
     filePrefix: 'kernel',
     endowments: {
-      console: makeConsole('SwingSet:kernel'),
+      console: makeConsole(`${debugPrefix}SwingSet:kernel`),
       require: kernelRequire,
       HandledPromise,
     },
@@ -203,7 +207,7 @@ export async function buildVatController(
 
   function makeVatEndowments(consoleTag) {
     return harden({
-      console: makeConsole(`SwingSet:${consoleTag}`),
+      console: makeConsole(`${debugPrefix}SwingSet:${consoleTag}`),
       HandledPromise,
       // re2 is a RegExp work-a-like that disables backtracking expressions for
       // safer memory consumption

--- a/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
+++ b/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
@@ -62,6 +62,7 @@ export async function connectToFakeChain(basedir, GCI, role, delay, inbound) {
     flushChainSends,
     vatsdir,
     argv,
+    GCI, // debugName
   );
 
   const blockManager = makeBlockManager(s);

--- a/packages/cosmic-swingset/lib/launch-chain.js
+++ b/packages/cosmic-swingset/lib/launch-chain.js
@@ -22,7 +22,9 @@ async function buildSwingset(
   storage,
   vatsDir,
   argv,
+  debugName = undefined,
 ) {
+  const debugPrefix = debugName === undefined ? '' : `${debugName}:`;
   const config = {};
   const mbs = buildMailboxStateMap();
   mbs.populateFromData(mailboxState);
@@ -50,6 +52,7 @@ async function buildSwingset(
 
   const controller = await buildVatController(config, argv, {
     hostStorage: storage,
+    debugPrefix,
   });
   await controller.run();
 
@@ -64,6 +67,7 @@ export async function launch(
   flushChainSends,
   vatsDir,
   argv,
+  debugName = undefined,
 ) {
   log.info('Launching SwingSet kernel');
 
@@ -87,6 +91,7 @@ export async function launch(
     storage,
     vatsDir,
     argv,
+    debugName,
   );
 
   function saveChainState() {

--- a/packages/cosmic-swingset/x/swingset/blockers.go
+++ b/packages/cosmic-swingset/x/swingset/blockers.go
@@ -13,6 +13,7 @@ type beginBlockAction struct {
 	StoragePort int    `json:"storagePort"`
 	BlockHeight int64  `json:"blockHeight"`
 	BlockTime   int64  `json:"blockTime"`
+	ChainID     string `json:"chainID"`
 }
 
 type endBlockAction struct {
@@ -34,6 +35,7 @@ func BeginBlock(ctx sdk.Context, req abci.RequestBeginBlock, keeper Keeper) erro
 		StoragePort: GetPort("storage"),
 		BlockHeight: ctx.BlockHeight(),
 		BlockTime:   ctx.BlockTime().Unix(),
+		ChainID:     ctx.ChainID(),
 	}
 	b, err := json.Marshal(action)
 	if err != nil {


### PR DESCRIPTION
Just to help with diagnosing which swingset some messages are coming from.

We also plumb through the `chainID` to provide more useful context, in case we need it in the future.
