### PR TITLE
refactor: remove makeEmptyOffer from zoeHelpers, use zcf.makeEmptySeatKit instead

### DIFF
--- a/packages/zoe/src/contractSupport/index.js
+++ b/packages/zoe/src/contractSupport/index.js
@@ -20,5 +20,4 @@ export {
   satisfies,
   escrowAndAllocateTo,
   assertNatMathHelpers,
-  makeEmptyOffer,
 } from './zoeHelpers';

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -3,7 +3,6 @@
 import { assert, details } from '@agoric/assert';
 import { sameStructure } from '@agoric/same-structure';
 import { E } from '@agoric/eventual-send';
-import { makePromiseKit } from '@agoric/promise-kit';
 
 import { satisfiesWant } from '../contractFacet/offerSafety';
 
@@ -293,29 +292,6 @@ export const assertProposalKeywords = (offerHandler, expected) =>
     assertKeys(actual.exit, expected.exit);
     return offerHandler(seat);
   };
-/**
- * Return a record with a promise for the userSeat and a promise for
- * the zcfSeat
- *
- * This offer will have an empty 'give' and 'want', making it useful
- * for contracts to use for unrestricted internal asset reallocation.
- * One example is the Autoswap contract, which uses an empty offer
- * to manage internal escrowed assets.
- * @param {ContractFacet} zcf
- * @returns {{userSeat: Promise<UserSeat>, zcfSeat: Promise<ZCFSeat>}}
- */
-export const makeEmptyOffer = zcf => {
-  const ZCFSeatPromiseKit = makePromiseKit();
-  const invite = zcf.makeInvitation(
-    seat => ZCFSeatPromiseKit.resolve(seat),
-    'empty offer',
-  );
-  const zoeService = zcf.getZoeService();
-  return {
-    userSeat: E(zoeService).offer(invite),
-    zcfSeat: ZCFSeatPromiseKit.promise,
-  };
-};
 
 /**
  * Escrow payments with Zoe and reallocate the amount of each

--- a/packages/zoe/src/contracts/multipoolAutoswap/pool.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/pool.js
@@ -6,7 +6,6 @@ import {
   calcLiqValueToMint,
   calcValueToRemove,
   assertNatMathHelpers,
-  makeEmptyOffer,
   trade,
 } from '../../contractSupport';
 
@@ -165,7 +164,7 @@ export const makeAddPool = (zcf, isSecondary, initPool, centralBrand) => {
     await zcf.saveIssuer(secondaryIssuer, keyword);
     assertNatMathHelpers(zcf, secondaryBrand);
     const liquidityZCFMint = await zcf.makeZCFMint(liquidityKeyword);
-    const { zcfSeat: poolSeatP } = await makeEmptyOffer(zcf);
+    const { zcfSeat: poolSeatP } = zcf.makeEmptySeatKit(zcf);
     const poolSeat = await poolSeatP;
     const pool = makePool(liquidityZCFMint, poolSeat, secondaryBrand);
     initPool(secondaryBrand, pool);

--- a/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
@@ -560,41 +560,6 @@ test.skip(`ZoeHelpers swap - can't trade with`, t => {
   }
 });
 
-test.skip('ZoeHelpers makeEmptyOffer', async t => {
-  t.plan(2);
-  const { moolaR, simoleanR } = setup();
-  const redeemedInvites = [];
-  try {
-    const offerHandle = harden({});
-    const mockZCF = harden({
-      getInstanceRecord: () =>
-        harden({
-          issuerKeywordRecord: {
-            Asset: moolaR.issuer,
-            Price: simoleanR.issuer,
-          },
-        }),
-      getZoeService: () =>
-        harden({
-          offer: invite => {
-            redeemedInvites.push(invite);
-            return Promise.resolve();
-          },
-        }),
-      makeInvitation: offerHook => {
-        offerHook(offerHandle);
-        return 'anInvite';
-      },
-    });
-    const { makeEmptyOffer } = makeZoeHelpers(mockZCF);
-    const result = await makeEmptyOffer();
-    t.deepEquals(result, offerHandle, `offerHandle was returned`);
-    t.deepEquals(redeemedInvites, harden(['anInvite']), `invite was redeemed`);
-  } catch (e) {
-    t.assert(false, e);
-  }
-});
-
 test.skip('ZoeHelpers isOfferSafe', t => {
   t.plan(5);
   const { moolaR, simoleanR, moola, simoleans } = setup();


### PR DESCRIPTION
remove makeEmptyOffer from zoeHelpers, use zcf.makeEmptySeatKit instead

Closes #1442 