### PR TITLE
refactor: move issuerKeywordRecord and brandKeywordRecord to terms

### DIFF
--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -75,7 +75,7 @@ export function buildRootObject() {
       return issuerRecord;
     };
 
-    const registerIssuerRecordWKeyword = (keyword, issuerRecord) => {
+    const registerIssuerRecordWithKeyword = (keyword, issuerRecord) => {
       assertKeywordName(keyword);
       assert(
         !getKeywords(instanceRecord.terms.issuers).includes(keyword),
@@ -109,7 +109,7 @@ export function buildRootObject() {
         issuer: mintyIssuer,
         amountMath: mintyAmountMath,
       });
-      registerIssuerRecordWKeyword(keyword, mintyIssuerRecord);
+      registerIssuerRecordWithKeyword(keyword, mintyIssuerRecord);
       issuerTable.registerIssuerRecord(mintyIssuerRecord);
 
       /** @type ZCFMint */
@@ -255,7 +255,7 @@ export function buildRootObject() {
           .then(() => {
             return issuerTable
               .getPromiseForIssuerRecord(issuerP)
-              .then(record => registerIssuerRecordWKeyword(keyword, record));
+              .then(record => registerIssuerRecordWithKeyword(keyword, record));
           });
       },
       makeInvitation: (offerHandler, description, customProperties = {}) => {

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -101,8 +101,8 @@ const mergeAllocations = (currentAllocation, allocation) => {
 };
 
 export const assertIssuerKeywords = (zcf, expected) => {
-  const { issuerKeywordRecord } = zcf.getInstanceRecord();
-  const actual = getKeysSorted(issuerKeywordRecord);
+  const { issuers } = zcf.getTerms();
+  const actual = getKeysSorted(issuers);
   expected = [...expected]; // in case hardened
   expected.sort();
   assert(

--- a/packages/zoe/src/contracts/atomicSwap.js
+++ b/packages/zoe/src/contracts/atomicSwap.js
@@ -20,7 +20,7 @@ import '../../exported';
  *
  * @type {ContractStartFn}
  */
-const start = (zcf, _terms) => {
+const start = zcf => {
   assertIssuerKeywords(zcf, harden(['Asset', 'Price']));
 
   /** @type {OfferHandler} */

--- a/packages/zoe/src/contracts/automaticRefund.js
+++ b/packages/zoe/src/contracts/automaticRefund.js
@@ -16,7 +16,7 @@ import '../../exported';
  * @type {ContractStartFn}
  * @param {ContractFacet} zcf
  */
-const start = (zcf, _terms) => {
+const start = zcf => {
   let offersCount = 0;
 
   /** @type {OfferHandler} */

--- a/packages/zoe/src/contracts/barterExchange.js
+++ b/packages/zoe/src/contracts/barterExchange.js
@@ -19,7 +19,7 @@ import { trade, satisfies } from '../contractSupport';
  *
  * @type {ContractStartFn}
  */
-const start = (zcf, _terms) => {
+const start = zcf => {
   // bookOrders is a Map of Maps. The first key is the brand of the offer's
   // GIVE, and the second key is the brand of its WANT. For each offer, we
   // store its handle and the amounts for `give` and `want`.

--- a/packages/zoe/src/contracts/coveredCall.js
+++ b/packages/zoe/src/contracts/coveredCall.js
@@ -40,7 +40,7 @@ import '../../exported';
  *
  * @type {ContractStartFn}
  */
-const start = (zcf, _terms) => {
+const start = zcf => {
   assertIssuerKeywords(zcf, harden(['UnderlyingAsset', 'StrikePrice']));
 
   const makeCallOption = sellerSeat => {

--- a/packages/zoe/src/contracts/mintAndSellNFT.js
+++ b/packages/zoe/src/contracts/mintAndSellNFT.js
@@ -25,7 +25,8 @@ import '../../exported';
  *
  * @type {ContractStartFn}
  */
-const start = (zcf, { tokenName = 'token' }) => {
+const start = zcf => {
+  const { tokenName = 'token' } = zcf.getTerms();
   // Create the internal token mint
   const { issuer, mint, amountMath: tokenAmountMath } = makeIssuerKit(
     tokenName,

--- a/packages/zoe/src/contracts/mintPayments.js
+++ b/packages/zoe/src/contracts/mintPayments.js
@@ -18,7 +18,7 @@ import '../../exported';
  *
  * @type {ContractStartFn}
  */
-const start = async (zcf, _terms) => {
+const start = async zcf => {
   // Create the internal token mint for a fungible digital asset. Note
   // that 'Tokens' is both the keyword and the allegedName.
   const zcfMint = await zcf.makeZCFMint('Tokens');

--- a/packages/zoe/src/contracts/multipoolAutoswap/multipoolAutoswap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/multipoolAutoswap.js
@@ -28,7 +28,7 @@ import '../../../exported';
  * be shared as much as possible.
  *
  * When the contract is instantiated, the central token is specified in the
- * issuerKeywordRecord. The party that calls `E(zoe).startInstance` gets an invitation
+ * terms. The party that calls `E(zoe).startInstance` gets an invitation
  * that can be used to request an invitation to add liquidity. The same
  * invitation is available by calling `await E(publicAPI).getLiquidityIssuer(brand)`.
  * Separate invitations are available for adding and removing liquidity, and for
@@ -37,11 +37,13 @@ import '../../../exported';
  *
  * @type {ContractStartFn}
  */
-const start = (zcf, _terms) => {
+const start = zcf => {
   // This contract must have a "Central" keyword and issuer in the
   // IssuerKeywordRecord.
+  const {
+    brands: { Central: centralBrand },
+  } = zcf.getTerms();
   assertIssuerKeywords(zcf, ['Central']);
-  const centralBrand = zcf.getInstanceRecord().brandKeywordRecord.Central;
   assert(centralBrand !== undefined, details`centralBrand must be present`);
 
   const secondaryBrandToPool = makeWeakStore();

--- a/packages/zoe/src/contracts/multipoolAutoswap/pool.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/pool.js
@@ -144,7 +144,7 @@ export const makeAddPool = (zcf, isSecondary, initPool, centralBrand) => {
    * its keyword must not have been already used
    * @param {Issuer} secondaryIssuer
    * @param {Keyword} keyword - will be used in the
-   * issuerKeywordRecord for the contract, but not used otherwise
+   * terms.issuers for the contract, but not used otherwise
    */
   const addPool = async (secondaryIssuer, keyword) => {
     zcf.assertUniqueKeyword(keyword);

--- a/packages/zoe/src/contracts/publicAuction.js
+++ b/packages/zoe/src/contracts/publicAuction.js
@@ -33,7 +33,11 @@ import '../../exported';
  *
  * @type {ContractStartFn}
  */
-const start = (zcf, { numBidsAllowed = 3 }) => {
+const start = zcf => {
+  const {
+    maths: { Asset: assetMath, Ask: bidMath },
+  } = zcf.getTerms();
+  let { numBidsAllowed = 3 } = zcf.getTerms();
   numBidsAllowed = Nat(numBidsAllowed);
 
   let sellSeat;
@@ -56,11 +60,11 @@ const start = (zcf, { numBidsAllowed = 3 }) => {
     }
     const sellerSatisfied = satisfies(zcf, sellSeat, {
       Ask: bidSeat.getAmountAllocated('Bid', minimumBid.brand),
-      Asset: zcf.getAmountMath(auctionedAssets.brand).getEmpty(),
+      Asset: assetMath.getEmpty(),
     });
     const bidderSatisfied = satisfies(zcf, bidSeat, {
       Asset: sellSeat.getAmountAllocated('Asset', auctionedAssets.brand),
-      Bid: zcf.getAmountMath(minimumBid.brand).getEmpty(),
+      Bid: bidMath.getEmpty(),
     });
     if (!(sellerSatisfied && bidderSatisfied)) {
       const rejectMsg = `Bid was under minimum bid or for the wrong assets`;
@@ -119,5 +123,4 @@ const start = (zcf, { numBidsAllowed = 3 }) => {
   });
 };
 
-harden(start);
 export { start };

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -30,12 +30,14 @@ import '../../exported';
  * @type {ContractStartFn}
  */
 const start = zcf => {
-  const { pricePerItem, issuers, maths } = zcf.getTerms();
+  const {
+    pricePerItem,
+    issuers,
+    maths: { Money: moneyMath, Items: itemsMath },
+  } = zcf.getTerms();
   const allKeywords = ['Items', 'Money'];
   assertIssuerKeywords(zcf, harden(allKeywords));
   assertNatMathHelpers(zcf, pricePerItem.brand);
-
-  const { Money: moneyMath, Items: itemsMath } = maths;
 
   let sellerSeat;
 

--- a/packages/zoe/src/contracts/simpleExchange.js
+++ b/packages/zoe/src/contracts/simpleExchange.js
@@ -31,7 +31,7 @@ import {
  *
  * @type {ContractStartFn}
  */
-const start = (zcf, _terms) => {
+const start = zcf => {
   let sellOfferSeats = [];
   let buyOfferSeats = [];
   // eslint-disable-next-line no-use-before-define

--- a/packages/zoe/src/types.js
+++ b/packages/zoe/src/types.js
@@ -336,7 +336,7 @@
  */
 
 /**
- * @typedef {Object} NonCustomTerms
+ * @typedef {Object} StandardTerms
  * @property {IssuerKeywordRecord} terms.issuers - record with
  * keywords keys, issuer values
  * @property {BrandKeywordRecord} terms.brands - record with keywords
@@ -344,7 +344,7 @@
  * @property {AmountMathKeywordRecord} terms.maths - record with keywords
  * keys, amountMath values
  * 
- * @typedef {NonCustomTerms & Record<string, any>} Terms
+ * @typedef {StandardTerms & Record<string, any>} Terms
  *
  * @typedef {object} InstanceRecord
  * @property {Installation} installation

--- a/packages/zoe/src/types.js
+++ b/packages/zoe/src/types.js
@@ -125,17 +125,18 @@
  *
  * Zoe is long-lived. We can use Zoe to create smart contract
  * instances by specifying a particular contract installation to use,
- * as well as the `issuerKeywordRecord` and `terms` of the contract.
- * The `issuerKeywordRecord` is a record mapping string names
- * (keywords) to issuers, such as `{ Asset: simoleanIssuer}`. (Note
- * that the keywords must begin with a capital letter and must be
- * ASCII identifiers.) Parties to the contract will use the keywords
- * to index their proposal and their payments.
+ * as well as the `terms` of the contract. The `terms.issuers` is a
+ * record mapping string names (keywords) to issuers, such as `{
+ * Asset: simoleanIssuer}`. (Note that the keywords must begin with a
+ * capital letter and must be ASCII identifiers.) Parties to the
+ * contract will use the keywords to index their proposal and their
+ * payments.
  *
- * Terms are the arguments to the contract, such as the number of bids
- * an auction will wait for before closing. Terms are up to the
- * discretion of the smart contract. We get back the admin facet as
- * defined by the contract.
+ * The custom terms are the arguments to the contract, such as the
+ * number of bids an auction will wait for before closing. Custom
+ * terms are up to the discretion of the smart contract. We get back
+ * the creator facet, public facet, and creator invitation as defined
+ * by the contract.
  */
 
 /**
@@ -190,7 +191,7 @@
  * @property {Shutdown} shutdown
  * @property {() => ZoeService} getZoeService
  * @property {() => Issuer} getInvitationIssuer
- * @property {() => InstanceRecord } getInstanceRecord
+ * @property {() => Terms } getTerms
  * @property {(issuer: Issuer) => Brand} getBrandForIssuer
  * @property {GetAmountMath} getAmountMath
  * @property {MakeZCFMint} makeZCFMint
@@ -335,12 +336,20 @@
  */
 
 /**
+ * @typedef {Object} NonCustomTerms
+ * @property {IssuerKeywordRecord} terms.issuers - record with
+ * keywords keys, issuer values
+ * @property {BrandKeywordRecord} terms.brands - record with keywords
+ * keys, brand values
+ * @property {AmountMathKeywordRecord} terms.maths - record with keywords
+ * keys, amountMath values
+ * 
+ * @typedef {NonCustomTerms & Record<string, any>} Terms
  *
  * @typedef {object} InstanceRecord
- * @property {Object} terms - contract parameters
- * @property {IssuerKeywordRecord} issuerKeywordRecord - record with keywords keys, issuer values
- * @property {BrandKeywordRecord} brandKeywordRecord - record with
- * keywords keys, brand values
+ * @property {Installation} installation
+ * @property {Terms} terms - contract parameters
+
  *
  * @typedef {Object} IssuerRecord
  * @property {Brand} brand

--- a/packages/zoe/src/types.js
+++ b/packages/zoe/src/types.js
@@ -337,11 +337,11 @@
 
 /**
  * @typedef {Object} StandardTerms
- * @property {IssuerKeywordRecord} terms.issuers - record with
+ * @property {IssuerKeywordRecord} issuers - record with
  * keywords keys, issuer values
- * @property {BrandKeywordRecord} terms.brands - record with keywords
+ * @property {BrandKeywordRecord} brands - record with keywords
  * keys, brand values
- * @property {AmountMathKeywordRecord} terms.maths - record with keywords
+ * @property {AmountMathKeywordRecord} maths - record with keywords
  * keys, amountMath values
  * 
  * @typedef {StandardTerms & Record<string, any>} Terms

--- a/packages/zoe/test/swingsetTests/brokenContracts/crashingAutoRefund.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/crashingAutoRefund.js
@@ -16,7 +16,8 @@ import '../../../exported';
  *
  * @type {ContractStartFn}
  */
-const start = (zcf, terms) => {
+const start = zcf => {
+  const terms = zcf.getTerms();
   let offersCount = 0;
 
   assertIssuerKeywords(zcf, harden(['Asset', 'Price']));

--- a/packages/zoe/test/unitTests/contracts/escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/escrowToVote.js
@@ -23,12 +23,13 @@ import '../../../exported';
  *
  * @type {ContractStartFn}
  */
-const start = (zcf, { question }) => {
+const start = zcf => {
+  const {
+    question,
+    brands: { Assets: assetsBrand },
+  } = zcf.getTerms();
   let electionOpen = true;
   assertIssuerKeywords(zcf, harden(['Assets']));
-  const {
-    brandKeywordRecord: { Assets: assetsBrand },
-  } = zcf.getInstanceRecord();
   assert.typeof(question, 'string');
   assertNatMathHelpers(zcf, assetsBrand);
   const amountMath = zcf.getAmountMath(assetsBrand);

--- a/packages/zoe/test/unitTests/contracts/grifter.js
+++ b/packages/zoe/test/unitTests/contracts/grifter.js
@@ -9,7 +9,7 @@ import {
 /**
  * @type {ContractStartFn}
  */
-const start = (zcf, _terms) => {
+const start = zcf => {
   assertIssuerKeywords(zcf, harden(['Asset', 'Price']));
 
   const makeAccompliceInvite = malSeat => {

--- a/packages/zoe/test/unitTests/contracts/test-autoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-autoswap.js
@@ -42,7 +42,7 @@ test('autoSwap with valid offers', async t => {
       TokenA: moolaIssuer,
       TokenB: simoleanIssuer,
     });
-    const { creatorFacet: publicFacet } = await zoe.startInstance(
+    const { publicFacet } = await zoe.startInstance(
       installation,
       issuerKeywordRecord,
     );
@@ -234,7 +234,7 @@ test('autoSwap - test fee', async t => {
       TokenA: moolaIssuer,
       TokenB: simoleanIssuer,
     });
-    const { creatorFacet: publicFacet } = await zoe.startInstance(
+    const { publicFacet } = await zoe.startInstance(
       installation,
       issuerKeywordRecord,
     );

--- a/packages/zoe/test/unitTests/contracts/useObjExample.js
+++ b/packages/zoe/test/unitTests/contracts/useObjExample.js
@@ -11,10 +11,12 @@ import {
  * Give a use object when a payment is escrowed
  * @type {ContractStartFn}
  */
-const start = (zcf, _terms) => {
+const start = zcf => {
+  const {
+    brands: { Pixels: pixelBrand },
+  } = zcf.getTerms();
   assertIssuerKeywords(zcf, harden(['Pixels']));
-  const { brandKeywordRecord } = zcf.getInstanceRecord();
-  const amountMath = zcf.getAmountMath(brandKeywordRecord.Pixels);
+  const amountMath = zcf.getAmountMath(pixelBrand);
 
   const makeUseObj = seat => {
     const useObj = harden({
@@ -27,10 +29,7 @@ const start = (zcf, _terms) => {
         // Throw if the offer is no longer active, i.e. the user has
         // completed their offer and the assets are no longer escrowed.
         assert(!seat.hasExited(), `the escrowing offer is no longer active`);
-        const escrowedAmount = seat.getAmountAllocated(
-          'Pixels',
-          brandKeywordRecord.Pixels,
-        );
+        const escrowedAmount = seat.getAmountAllocated('Pixels', pixelBrand);
         // If no amountToColor is provided, color all the pixels
         // escrowed for this offer.
         if (amountToColor === undefined) {

--- a/packages/zoe/test/unitTests/contracts/zcfTesterContract.js
+++ b/packages/zoe/test/unitTests/contracts/zcfTesterContract.js
@@ -4,7 +4,7 @@
  * Tests ZCF
  * @type {ContractStartFn}
  */
-const start = (_zcf, _terms) => {
+const start = _zcf => {
   // TODO: import tap/tape and do t.equals
   // TODO: Test ZCF here
 


### PR DESCRIPTION
Move issuerKeywordRecord and brandKeywordRecord to terms and rename as issuers and brands, respectively

Closes #1455 