### PR TITLE
Leave patch-package as an option

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,9 +67,12 @@
     "lint-check": "yarn workspaces run lint-check",
     "lint": "yarn workspaces run lint-check",
     "test": "yarn workspaces run test",
-    "build": "yarn workspaces run build"
+    "build": "yarn workspaces run build",
+    "postinstall": "patch-package"
   },
   "dependencies": {
-    "@agoric/store": "^0.2.0"
+    "@agoric/store": "^0.2.0",
+    "patch-package": "^6.2.2",
+    "postinstall-postinstall": "^2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -68,11 +68,10 @@
     "lint": "yarn workspaces run lint-check",
     "test": "yarn workspaces run test",
     "build": "yarn workspaces run build",
-    "postinstall": "patch-package"
+    "patch-package": "patch-package"
   },
   "dependencies": {
     "@agoric/store": "^0.2.0",
-    "patch-package": "^6.2.2",
-    "postinstall-postinstall": "^2.1.0"
+    "patch-package": "^6.2.2"
   }
 }

--- a/patches/depd+1.1.2.patch
+++ b/patches/depd+1.1.2.patch
@@ -1,0 +1,529 @@
+diff --git a/node_modules/depd/index.js b/node_modules/depd/index.js
+index d758d3c..dbff6c9 100644
+--- a/node_modules/depd/index.js
++++ b/node_modules/depd/index.js
+@@ -1,522 +1 @@
+-/*!
+- * depd
+- * Copyright(c) 2014-2017 Douglas Christopher Wilson
+- * MIT Licensed
+- */
+-
+-/**
+- * Module dependencies.
+- */
+-
+-var callSiteToString = require('./lib/compat').callSiteToString
+-var eventListenerCount = require('./lib/compat').eventListenerCount
+-var relative = require('path').relative
+-
+-/**
+- * Module exports.
+- */
+-
+-module.exports = depd
+-
+-/**
+- * Get the path to base files on.
+- */
+-
+-var basePath = process.cwd()
+-
+-/**
+- * Determine if namespace is contained in the string.
+- */
+-
+-function containsNamespace (str, namespace) {
+-  var vals = str.split(/[ ,]+/)
+-  var ns = String(namespace).toLowerCase()
+-
+-  for (var i = 0; i < vals.length; i++) {
+-    var val = vals[i]
+-
+-    // namespace contained
+-    if (val && (val === '*' || val.toLowerCase() === ns)) {
+-      return true
+-    }
+-  }
+-
+-  return false
+-}
+-
+-/**
+- * Convert a data descriptor to accessor descriptor.
+- */
+-
+-function convertDataDescriptorToAccessor (obj, prop, message) {
+-  var descriptor = Object.getOwnPropertyDescriptor(obj, prop)
+-  var value = descriptor.value
+-
+-  descriptor.get = function getter () { return value }
+-
+-  if (descriptor.writable) {
+-    descriptor.set = function setter (val) { return (value = val) }
+-  }
+-
+-  delete descriptor.value
+-  delete descriptor.writable
+-
+-  Object.defineProperty(obj, prop, descriptor)
+-
+-  return descriptor
+-}
+-
+-/**
+- * Create arguments string to keep arity.
+- */
+-
+-function createArgumentsString (arity) {
+-  var str = ''
+-
+-  for (var i = 0; i < arity; i++) {
+-    str += ', arg' + i
+-  }
+-
+-  return str.substr(2)
+-}
+-
+-/**
+- * Create stack string from stack.
+- */
+-
+-function createStackString (stack) {
+-  var str = this.name + ': ' + this.namespace
+-
+-  if (this.message) {
+-    str += ' deprecated ' + this.message
+-  }
+-
+-  for (var i = 0; i < stack.length; i++) {
+-    str += '\n    at ' + callSiteToString(stack[i])
+-  }
+-
+-  return str
+-}
+-
+-/**
+- * Create deprecate for namespace in caller.
+- */
+-
+-function depd (namespace) {
+-  if (!namespace) {
+-    throw new TypeError('argument namespace is required')
+-  }
+-
+-  var stack = getStack()
+-  var site = callSiteLocation(stack[1])
+-  var file = site[0]
+-
+-  function deprecate (message) {
+-    // call to self as log
+-    log.call(deprecate, message)
+-  }
+-
+-  deprecate._file = file
+-  deprecate._ignored = isignored(namespace)
+-  deprecate._namespace = namespace
+-  deprecate._traced = istraced(namespace)
+-  deprecate._warned = Object.create(null)
+-
+-  deprecate.function = wrapfunction
+-  deprecate.property = wrapproperty
+-
+-  return deprecate
+-}
+-
+-/**
+- * Determine if namespace is ignored.
+- */
+-
+-function isignored (namespace) {
+-  /* istanbul ignore next: tested in a child processs */
+-  if (process.noDeprecation) {
+-    // --no-deprecation support
+-    return true
+-  }
+-
+-  var str = process.env.NO_DEPRECATION || ''
+-
+-  // namespace ignored
+-  return containsNamespace(str, namespace)
+-}
+-
+-/**
+- * Determine if namespace is traced.
+- */
+-
+-function istraced (namespace) {
+-  /* istanbul ignore next: tested in a child processs */
+-  if (process.traceDeprecation) {
+-    // --trace-deprecation support
+-    return true
+-  }
+-
+-  var str = process.env.TRACE_DEPRECATION || ''
+-
+-  // namespace traced
+-  return containsNamespace(str, namespace)
+-}
+-
+-/**
+- * Display deprecation message.
+- */
+-
+-function log (message, site) {
+-  var haslisteners = eventListenerCount(process, 'deprecation') !== 0
+-
+-  // abort early if no destination
+-  if (!haslisteners && this._ignored) {
+-    return
+-  }
+-
+-  var caller
+-  var callFile
+-  var callSite
+-  var depSite
+-  var i = 0
+-  var seen = false
+-  var stack = getStack()
+-  var file = this._file
+-
+-  if (site) {
+-    // provided site
+-    depSite = site
+-    callSite = callSiteLocation(stack[1])
+-    callSite.name = depSite.name
+-    file = callSite[0]
+-  } else {
+-    // get call site
+-    i = 2
+-    depSite = callSiteLocation(stack[i])
+-    callSite = depSite
+-  }
+-
+-  // get caller of deprecated thing in relation to file
+-  for (; i < stack.length; i++) {
+-    caller = callSiteLocation(stack[i])
+-    callFile = caller[0]
+-
+-    if (callFile === file) {
+-      seen = true
+-    } else if (callFile === this._file) {
+-      file = this._file
+-    } else if (seen) {
+-      break
+-    }
+-  }
+-
+-  var key = caller
+-    ? depSite.join(':') + '__' + caller.join(':')
+-    : undefined
+-
+-  if (key !== undefined && key in this._warned) {
+-    // already warned
+-    return
+-  }
+-
+-  this._warned[key] = true
+-
+-  // generate automatic message from call site
+-  var msg = message
+-  if (!msg) {
+-    msg = callSite === depSite || !callSite.name
+-      ? defaultMessage(depSite)
+-      : defaultMessage(callSite)
+-  }
+-
+-  // emit deprecation if listeners exist
+-  if (haslisteners) {
+-    var err = DeprecationError(this._namespace, msg, stack.slice(i))
+-    process.emit('deprecation', err)
+-    return
+-  }
+-
+-  // format and write message
+-  var format = process.stderr.isTTY
+-    ? formatColor
+-    : formatPlain
+-  var output = format.call(this, msg, caller, stack.slice(i))
+-  process.stderr.write(output + '\n', 'utf8')
+-}
+-
+-/**
+- * Get call site location as array.
+- */
+-
+-function callSiteLocation (callSite) {
+-  var file = callSite.getFileName() || '<anonymous>'
+-  var line = callSite.getLineNumber()
+-  var colm = callSite.getColumnNumber()
+-
+-  if (callSite.isEval()) {
+-    file = callSite.getEvalOrigin() + ', ' + file
+-  }
+-
+-  var site = [file, line, colm]
+-
+-  site.callSite = callSite
+-  site.name = callSite.getFunctionName()
+-
+-  return site
+-}
+-
+-/**
+- * Generate a default message from the site.
+- */
+-
+-function defaultMessage (site) {
+-  var callSite = site.callSite
+-  var funcName = site.name
+-
+-  // make useful anonymous name
+-  if (!funcName) {
+-    funcName = '<anonymous@' + formatLocation(site) + '>'
+-  }
+-
+-  var context = callSite.getThis()
+-  var typeName = context && callSite.getTypeName()
+-
+-  // ignore useless type name
+-  if (typeName === 'Object') {
+-    typeName = undefined
+-  }
+-
+-  // make useful type name
+-  if (typeName === 'Function') {
+-    typeName = context.name || typeName
+-  }
+-
+-  return typeName && callSite.getMethodName()
+-    ? typeName + '.' + funcName
+-    : funcName
+-}
+-
+-/**
+- * Format deprecation message without color.
+- */
+-
+-function formatPlain (msg, caller, stack) {
+-  var timestamp = new Date().toUTCString()
+-
+-  var formatted = timestamp +
+-    ' ' + this._namespace +
+-    ' deprecated ' + msg
+-
+-  // add stack trace
+-  if (this._traced) {
+-    for (var i = 0; i < stack.length; i++) {
+-      formatted += '\n    at ' + callSiteToString(stack[i])
+-    }
+-
+-    return formatted
+-  }
+-
+-  if (caller) {
+-    formatted += ' at ' + formatLocation(caller)
+-  }
+-
+-  return formatted
+-}
+-
+-/**
+- * Format deprecation message with color.
+- */
+-
+-function formatColor (msg, caller, stack) {
+-  var formatted = '\x1b[36;1m' + this._namespace + '\x1b[22;39m' + // bold cyan
+-    ' \x1b[33;1mdeprecated\x1b[22;39m' + // bold yellow
+-    ' \x1b[0m' + msg + '\x1b[39m' // reset
+-
+-  // add stack trace
+-  if (this._traced) {
+-    for (var i = 0; i < stack.length; i++) {
+-      formatted += '\n    \x1b[36mat ' + callSiteToString(stack[i]) + '\x1b[39m' // cyan
+-    }
+-
+-    return formatted
+-  }
+-
+-  if (caller) {
+-    formatted += ' \x1b[36m' + formatLocation(caller) + '\x1b[39m' // cyan
+-  }
+-
+-  return formatted
+-}
+-
+-/**
+- * Format call site location.
+- */
+-
+-function formatLocation (callSite) {
+-  return relative(basePath, callSite[0]) +
+-    ':' + callSite[1] +
+-    ':' + callSite[2]
+-}
+-
+-/**
+- * Get the stack as array of call sites.
+- */
+-
+-function getStack () {
+-  var limit = Error.stackTraceLimit
+-  var obj = {}
+-  var prep = Error.prepareStackTrace
+-
+-  Error.prepareStackTrace = prepareObjectStackTrace
+-  Error.stackTraceLimit = Math.max(10, limit)
+-
+-  // capture the stack
+-  Error.captureStackTrace(obj)
+-
+-  // slice this function off the top
+-  var stack = obj.stack.slice(1)
+-
+-  Error.prepareStackTrace = prep
+-  Error.stackTraceLimit = limit
+-
+-  return stack
+-}
+-
+-/**
+- * Capture call site stack from v8.
+- */
+-
+-function prepareObjectStackTrace (obj, stack) {
+-  return stack
+-}
+-
+-/**
+- * Return a wrapped function in a deprecation message.
+- */
+-
+-function wrapfunction (fn, message) {
+-  if (typeof fn !== 'function') {
+-    throw new TypeError('argument fn must be a function')
+-  }
+-
+-  var args = createArgumentsString(fn.length)
+-  var deprecate = this // eslint-disable-line no-unused-vars
+-  var stack = getStack()
+-  var site = callSiteLocation(stack[1])
+-
+-  site.name = fn.name
+-
+-   // eslint-disable-next-line no-eval
+-  var deprecatedfn = eval('(function (' + args + ') {\n' +
+-    '"use strict"\n' +
+-    'log.call(deprecate, message, site)\n' +
+-    'return fn.apply(this, arguments)\n' +
+-    '})')
+-
+-  return deprecatedfn
+-}
+-
+-/**
+- * Wrap property in a deprecation message.
+- */
+-
+-function wrapproperty (obj, prop, message) {
+-  if (!obj || (typeof obj !== 'object' && typeof obj !== 'function')) {
+-    throw new TypeError('argument obj must be object')
+-  }
+-
+-  var descriptor = Object.getOwnPropertyDescriptor(obj, prop)
+-
+-  if (!descriptor) {
+-    throw new TypeError('must call property on owner object')
+-  }
+-
+-  if (!descriptor.configurable) {
+-    throw new TypeError('property must be configurable')
+-  }
+-
+-  var deprecate = this
+-  var stack = getStack()
+-  var site = callSiteLocation(stack[1])
+-
+-  // set site name
+-  site.name = prop
+-
+-  // convert data descriptor
+-  if ('value' in descriptor) {
+-    descriptor = convertDataDescriptorToAccessor(obj, prop, message)
+-  }
+-
+-  var get = descriptor.get
+-  var set = descriptor.set
+-
+-  // wrap getter
+-  if (typeof get === 'function') {
+-    descriptor.get = function getter () {
+-      log.call(deprecate, message, site)
+-      return get.apply(this, arguments)
+-    }
+-  }
+-
+-  // wrap setter
+-  if (typeof set === 'function') {
+-    descriptor.set = function setter () {
+-      log.call(deprecate, message, site)
+-      return set.apply(this, arguments)
+-    }
+-  }
+-
+-  Object.defineProperty(obj, prop, descriptor)
+-}
+-
+-/**
+- * Create DeprecationError for deprecation
+- */
+-
+-function DeprecationError (namespace, message, stack) {
+-  var error = new Error()
+-  var stackString
+-
+-  Object.defineProperty(error, 'constructor', {
+-    value: DeprecationError
+-  })
+-
+-  Object.defineProperty(error, 'message', {
+-    configurable: true,
+-    enumerable: false,
+-    value: message,
+-    writable: true
+-  })
+-
+-  Object.defineProperty(error, 'name', {
+-    enumerable: false,
+-    configurable: true,
+-    value: 'DeprecationError',
+-    writable: true
+-  })
+-
+-  Object.defineProperty(error, 'namespace', {
+-    configurable: true,
+-    enumerable: false,
+-    value: namespace,
+-    writable: true
+-  })
+-
+-  Object.defineProperty(error, 'stack', {
+-    configurable: true,
+-    enumerable: false,
+-    get: function () {
+-      if (stackString !== undefined) {
+-        return stackString
+-      }
+-
+-      // prepare stack trace
+-      return (stackString = createStackString.call(this, stack))
+-    },
+-    set: function setter (val) {
+-      stackString = val
+-    }
+-  })
+-
+-  return error
+-}
++module.exports = require('./lib/browser/index.js')
+\ No newline at end of file

--- a/yarn.lock
+++ b/yarn.lock
@@ -1580,6 +1580,11 @@
   dependencies:
     "@types/node" "*"
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 "@zkochan/cmd-shim@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@zkochan/cmd-shim/-/cmd-shim-3.1.0.tgz#2ab8ed81f5bb5452a85f25758eb9b8681982fd2e"
@@ -4255,6 +4260,14 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
+find-yarn-workspace-root@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-1.2.1.tgz#40eb8e6e7c2502ddfaa2577c176f221422f860db"
+  integrity sha512-dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==
+  dependencies:
+    fs-extra "^4.0.3"
+    micromatch "^3.1.4"
+
 findit@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/findit/-/findit-2.0.0.tgz#6509f0126af4c178551cfa99394e032e13a4d56e"
@@ -4388,6 +4401,24 @@ fs-exists-cached@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-exists-cached/-/fs-exists-cached-1.0.0.tgz#cf25554ca050dc49ae6656b41de42258989dcbce"
   integrity sha1-zyVVTKBQ3EmuZla0HeQiWJidy84=
+
+fs-extra@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
+  integrity sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
 
 fs-extra@^8.0.0, fs-extra@^8.1.0:
   version "8.1.0"
@@ -5655,6 +5686,13 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+
 kleur@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
@@ -6094,7 +6132,7 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
-micromatch@^3.1.10:
+micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   integrity sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==
@@ -7089,6 +7127,24 @@ pascalcase@^0.1.1:
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
 
+patch-package@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-6.2.2.tgz#71d170d650c65c26556f0d0fbbb48d92b6cc5f39"
+  integrity sha512-YqScVYkVcClUY0v8fF0kWOjDYopzIM8e3bj/RU1DPeEF14+dCGm6UeOYm4jvCyxqIEQ5/eJzmbWfDWnUleFNMg==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^2.4.2"
+    cross-spawn "^6.0.5"
+    find-yarn-workspace-root "^1.2.1"
+    fs-extra "^7.0.1"
+    is-ci "^2.0.0"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.0"
+    rimraf "^2.6.3"
+    semver "^5.6.0"
+    slash "^2.0.0"
+    tmp "^0.0.33"
+
 path-dirname@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
@@ -7658,6 +7714,11 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.2
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
+
+postinstall-postinstall@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz#4f7f77441ef539d1512c40bd04c71b06a4704ca3"
+  integrity sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==
 
 prebuild-install@^5.2.5:
   version "5.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7715,11 +7715,6 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.2
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-postinstall-postinstall@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz#4f7f77441ef539d1512c40bd04c71b06a4704ca3"
-  integrity sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==
-
 prebuild-install@^5.2.5:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-5.3.3.tgz#ef4052baac60d465f5ba6bf003c9c1de79b9da8e"


### PR DESCRIPTION
Sometimes depd causes problems with other Node engines (I'm looking at you, Electron), so I'd suggest leaving this `patch-package` option available to unblock people who might find this note from the future:

> If you see the following:
> ```
> /Users/michael/agoric/agoric-sdk/node_modules/depd/index.js:1
>TypeError: callSite.getFileName is not a function
>    at callSiteLocation (/Users/michael/agoric/agoric-sdk/node_modules/depd/index.js:252:23)
>    at depd (/Users/michael/agoric/agoric-sdk/node_modules/depd/index.js:111:14)
>   at Object.<anonymous> (/Users/michael/agoric/agoric-sdk/node_modules/body-parser/index.js:14:32)
>    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1004:10)
> ```
> then you need to run `yarn patch-package`