### PR TITLE
refactor: do reallocate's replaceAllocations atomically in one call

### DIFF
--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -125,7 +125,8 @@ export function buildRootObject() {
       // updates from zcf to zoe, its effects must occur immediately in zoe
       // on reception, and must not fail.
       //
-      // Commit the staged allocations and inform Zoe of the
+      // Commit the staged allocations (currentAllocation is replaced
+      // for each of the seats) and inform Zoe of the
       // newAllocation.
 
       seatStagings.forEach(seatStaging =>
@@ -188,9 +189,9 @@ export function buildRootObject() {
           // verifies offer safety
           const seatStaging = zcfSeat.stage(newAllocation);
           // No effects above. COMMIT POINT. The following two steps
-          // *should* be committed atomically.
-          // If we minted only, no one would ever get those
-          // invisibly-minted assets.
+          // *should* be committed atomically, but it is not a
+          // disaster if they are not. If we minted only, no one would
+          // ever get those invisibly-minted assets.
           E(zoeMintP).mintAndEscrow(totalToMint);
           reallocateInternal([seatStaging]);
           return zcfSeat;
@@ -217,9 +218,9 @@ export function buildRootObject() {
           // verifies offer safety
           const seatStaging = zcfSeat.stage(newAllocation);
           // No effects above. Commit point. The following two steps
-          // *should* be committed atomically.
-          // If we only commit the staging, no one would ever get the
-          // unburned assets.
+          // *should* be committed atomically, but it is not a
+          // disaster if they are not. If we only commit the staging,
+          // no one would ever get the unburned assets.
           reallocateInternal([seatStaging]);
           E(zoeMintP).withdrawAndBurn(totalToBurn);
         },

--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -145,8 +145,6 @@ export function buildRootObject() {
           const seatStaging = zcfSeat.stage(newAllocation);
           // No effects above. Commit point. The following two steps
           // *should* be committed atomically.
-          // But unlike https://github.com/Agoric/agoric-sdk/issues/1391
-          // it is not a disater if they are not.
           // If we minted only, no one would ever get those
           // invisibly-minted assets.
           E(zoeMintP).mintAndEscrow(totalToMint);
@@ -181,8 +179,6 @@ export function buildRootObject() {
           const seatStaging = zcfSeat.stage(newAllocation);
           // No effects above. Commit point. The following two steps
           // *should* be committed atomically.
-          // But unlike https://github.com/Agoric/agoric-sdk/issues/1391
-          // it is not a disater if they are not.
           // If we only commit the staging, no one would ever get the
           // unburned assets.
           zcfSeatAdmin.commit(seatStaging);
@@ -242,8 +238,6 @@ export function buildRootObject() {
         // COMMIT POINT
         // Commit the staged allocations and inform Zoe of the
         // newAllocation.
-        // Note that there is an atomicity issue:
-        // https://github.com/Agoric/agoric-sdk/issues/1391
         seatStagings.forEach(seatStaging =>
           zcfSeatToZCFSeatAdmin.get(seatStaging.getSeat()).commit(seatStaging),
         );

--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -94,6 +94,51 @@ export function buildRootObject() {
 
     const allSeatStagings = new WeakSet();
 
+    /**
+     * Unlike the zcf.reallocate method, this one does not check conservation,
+     * and so can be used internally for reallocations that violate
+     * conservation.
+     */
+    const reallocateInternal = seatStagings => {
+      // Keep track of seats used so far in this call, to prevent aliasing.
+      const seatsSoFar = new WeakSet();
+
+      seatStagings.forEach(seatStaging => {
+        assert(
+          allSeatStagings.has(seatStaging),
+          details`The seatStaging ${seatStaging} was not recognized`,
+        );
+        const seat = seatStaging.getSeat();
+        assert(
+          !seatsSoFar.has(seat),
+          details`Seat (${seat}) was already an argument to reallocate`,
+        );
+        seatsSoFar.add(seat);
+      });
+
+      // No side effects above. All conditions checked which could have
+      // caused us to reject this reallocation.
+      // COMMIT POINT
+      // All the effects below must succeed "atomically". Scare quotes because
+      // the eventual send at the bottom is part of this "atomicity" even
+      // though its effects happen later. The send occurs in the order of
+      // updates from zcf to zoe, its effects must occur immediately in zoe
+      // on reception, and must not fail.
+      //
+      // Commit the staged allocations and inform Zoe of the
+      // newAllocation.
+
+      seatStagings.forEach(seatStaging =>
+        zcfSeatToZCFSeatAdmin.get(seatStaging.getSeat()).commit(seatStaging),
+      );
+      const seatHandleAllocations = seatStagings.map(seatStaging => {
+        const zcfSeat = seatStaging.getSeat();
+        const seatHandle = zcfSeatToSeatHandle.get(zcfSeat);
+        return { seatHandle, allocation: zcfSeat.getCurrentAllocation() };
+      });
+      E(zoeInstanceAdmin).replaceAllocations(seatHandleAllocations);
+    };
+
     /** @type MakeZCFMint */
     const makeZCFMint = async (keyword, amountMathKind = MathKind.NAT) => {
       assert(
@@ -140,19 +185,14 @@ export function buildRootObject() {
             ...oldAllocation,
             ...updates,
           });
-          const zcfSeatAdmin = zcfSeatToZCFSeatAdmin.get(zcfSeat);
           // verifies offer safety
           const seatStaging = zcfSeat.stage(newAllocation);
-          // No effects above. Commit point. The following two steps
+          // No effects above. COMMIT POINT. The following two steps
           // *should* be committed atomically.
           // If we minted only, no one would ever get those
           // invisibly-minted assets.
           E(zoeMintP).mintAndEscrow(totalToMint);
-          zcfSeatAdmin.commit(seatStaging);
-          const seatHandle = zcfSeatToSeatHandle.get(zcfSeat);
-          E(zoeInstanceAdmin).replaceAllocations([
-            { seatHandle, allocation: zcfSeat.getCurrentAllocation() },
-          ]);
+          reallocateInternal([seatStaging]);
           return zcfSeat;
         },
         burnLosses: (losses, zcfSeat) => {
@@ -174,18 +214,13 @@ export function buildRootObject() {
             ...oldAllocation,
             ...updates,
           });
-          const zcfSeatAdmin = zcfSeatToZCFSeatAdmin.get(zcfSeat);
           // verifies offer safety
           const seatStaging = zcfSeat.stage(newAllocation);
           // No effects above. Commit point. The following two steps
           // *should* be committed atomically.
           // If we only commit the staging, no one would ever get the
           // unburned assets.
-          zcfSeatAdmin.commit(seatStaging);
-          const seatHandle = zcfSeatToSeatHandle.get(zcfSeat);
-          E(zoeInstanceAdmin).replaceAllocations([
-            { seatHandle, allocation: zcfSeat.getCurrentAllocation() },
-          ]);
+          reallocateInternal([seatStaging]);
           E(zoeMintP).withdrawAndBurn(totalToBurn);
         },
       });
@@ -201,22 +236,6 @@ export function buildRootObject() {
           seatStagings.length >= 2,
           details`reallocating must be done over two or more seats`,
         );
-
-        // Keep track of seats used so far in this call, to prevent aliasing.
-        const seatsSoFar = new WeakSet();
-
-        seatStagings.forEach(seatStaging => {
-          assert(
-            allSeatStagings.has(seatStaging),
-            details`The seatStaging ${seatStaging} was not recognized`,
-          );
-          const seat = seatStaging.getSeat();
-          assert(
-            !seatsSoFar.has(seat),
-            details`Seat (${seat}) was already an argument to reallocate`,
-          );
-          seatsSoFar.add(seat);
-        });
 
         // Ensure that rights are conserved overall. Offer safety was
         // already checked when an allocation was staged for an individual seat.
@@ -235,18 +254,7 @@ export function buildRootObject() {
 
         assertRightsConserved(getAmountMath, previousAmounts, newAmounts);
 
-        // COMMIT POINT
-        // Commit the staged allocations and inform Zoe of the
-        // newAllocation.
-        seatStagings.forEach(seatStaging =>
-          zcfSeatToZCFSeatAdmin.get(seatStaging.getSeat()).commit(seatStaging),
-        );
-        const seatHandleAllocations = seatStagings.map(seatStaging => {
-          const zcfSeat = seatStaging.getSeat();
-          const seatHandle = zcfSeatToSeatHandle.get(zcfSeat);
-          return { seatHandle, allocation: zcfSeat.getCurrentAllocation() };
-        });
-        E(zoeInstanceAdmin).replaceAllocations(seatHandleAllocations);
+        reallocateInternal(seatStagings);
       },
       assertUniqueKeyword: keyword => {
         assertKeywordName(keyword);

--- a/packages/zoe/src/contractFacet/seat.js
+++ b/packages/zoe/src/contractFacet/seat.js
@@ -34,7 +34,6 @@ export const makeZcfSeatAdminKit = (
         details`The seatStaging ${seatStaging} was not recognized`,
       );
       currentAllocation = seatStaging.getStagedAllocation();
-      E(zoeSeatAdmin).replaceAllocation(currentAllocation);
     },
     updateHasExited: () => {
       assertExitedFalse();

--- a/packages/zoe/src/contractFacet/seat.js
+++ b/packages/zoe/src/contractFacet/seat.js
@@ -27,6 +27,8 @@ export const makeZcfSeatAdminKit = (
 
   /** @type {ZCFSeatAdmin} */
   const zcfSeatAdmin = harden({
+    // Updates the currentAllocation of the seat, using the allocation
+    // from seatStaging.
     commit: seatStaging => {
       assertExitedFalse();
       assert(

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -37,7 +37,8 @@
  * @param {InstanceAdmin} instanceAdmin
  * @param {ProposalRecord} proposal
  * @param {WeakStore<Brand, ERef<Purse>>} brandToPurse
- * @param {{ offerResult?: ERef<OfferResult>, exitObj?: ERef<ExitObj>}} [options={}]
+ * @param {ERef<OfferResult>=} offerResult
+ * @param {ERef<ExitObj>=} exitObj
  * @returns {ZoeSeatAdminKit}
  *
  * @typedef {Object} ZoeSeatAdmin
@@ -81,6 +82,7 @@
  * @property {(invitationHandle: InvitationHandle,
  *             zoeSeatAdmin: ZoeSeatAdmin,
  *             seatData: SeatData,
+ *             seatHandle: SeatHandle,
  *            ) => Promise<AddSeatResult>} addZoeSeatAdmin
  * @property {(zoeSeatAdmin: ZoeSeatAdmin) => boolean} hasZoeSeatAdmin
  * @property {(zoeSeatAdmin: ZoeSeatAdmin) => void} removeZoeSeatAdmin
@@ -96,6 +98,7 @@
  * @property {(invitationHandle: InvitationHandle,
  *             zoeSeatAdmin: ZoeSeatAdmin,
  *             seatData: SeatData,
+ *             seatHandle: SeatHandle,
  *            ) => AddSeatResult} addSeat
  */
 
@@ -111,6 +114,7 @@
  *            ) => Promise<void>} saveIssuer
  * @property {MakeZoeMint} makeZoeMint
  * @property {MakeOfferlessSeat} makeOfferlessSeat
+ * @property {ReplaceAllocations} replaceAllocations
  */
 
 /**
@@ -123,8 +127,20 @@
 /**
  * @callback MakeOfferlessSeat
  * @param {Allocation} initialAllocation
- * @param {Proposal} proposal
+ * @param {ProposalRecord} proposal
+ * @param {SeatHandle} seatHandle
  * @returns {ZoeSeatAdminKit}
+ */
+
+/**
+ * @callback ReplaceAllocations
+ * @param {SeatHandleAllocation[]} seatHandleAllocations
+ */
+
+/**
+ * @typedef {Object} SeatHandleAllocation
+ * @property {SeatHandle} seatHandle
+ * @property {Allocation} allocation
  */
 
 /**
@@ -179,4 +195,8 @@
  * @property {(issuer: Issuer) => IssuerRecord} getByIssuer
  * @property {(issuerP: ERef<Issuer>) => Promise<IssuerRecord>} initIssuer
  * @property {(issuerRecord: IssuerRecord) => void } initIssuerByRecord
+ */
+
+/**
+ * @typedef {Handle<'SeatHandle'>} SeatHandle
  */

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -83,11 +83,12 @@
  * request by the contract for an "empty" seat.
  *
  * @typedef {Object} InstanceAdmin
+ * @property {(zoeSeatAdmin: ZoeSeatAdmin) => Set<ZoeSeatAdmin>} addZoeSeatAdmin
  * @property {(invitationHandle: InvitationHandle,
  *             zoeSeatAdmin: ZoeSeatAdmin,
  *             seatData: SeatData,
  *             seatHandle: SeatHandle,
- *            ) => Promise<AddSeatResult>} addZoeSeatAdmin
+ *            ) => Promise<AddSeatResult>} tellZCFToMakeSeat
  * @property {(zoeSeatAdmin: ZoeSeatAdmin) => boolean} hasZoeSeatAdmin
  * @property {(zoeSeatAdmin: ZoeSeatAdmin) => void} removeZoeSeatAdmin
  * @property {() => Instance} getInstance

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -78,6 +78,10 @@
  */
 
 /**
+ * The seatHandle may be created in either the Zoe or ZCF vat,
+ * depending on whether the seat comes from a normal offer or a
+ * request by the contract for an "empty" seat.
+ *
  * @typedef {Object} InstanceAdmin
  * @property {(invitationHandle: InvitationHandle,
  *             zoeSeatAdmin: ZoeSeatAdmin,
@@ -94,6 +98,10 @@
  */
 
 /**
+ * The seatHandle may be created in either the Zoe or ZCF vat,
+ * depending on whether the seat comes from a normal offer or a
+ * request by the contract for an "empty" seat.
+ *
  * @typedef {Object} AddSeatObj
  * @property {(invitationHandle: InvitationHandle,
  *             zoeSeatAdmin: ZoeSeatAdmin,

--- a/packages/zoe/src/makeHandle.js
+++ b/packages/zoe/src/makeHandle.js
@@ -1,0 +1,15 @@
+import { assert } from '@agoric/assert';
+
+/**
+ * Create an opaque handle object.
+ *
+ * @template {string} H
+ * @param {H} handleType the string literal type of the handle
+ * @returns {Handle<H>}
+ */
+export const makeHandle = handleType => {
+  // This assert ensures that handleType is referenced.
+  assert.typeof(handleType, 'string', 'handleType must be a string');
+  // Return the intersection type (really just an empty object).
+  return /** @type {Handle<H>} */ (harden({}));
+};

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -18,6 +18,7 @@ import { makeZoeSeatAdminKit } from './zoeSeat';
 import zcfContractBundle from '../../bundles/bundle-contractFacet';
 import { arrayToObj } from '../objArrayConversion';
 import { cleanKeywords, cleanProposal } from '../cleanProposal';
+import { makeHandle } from '../makeHandle';
 
 /**
  * Create an instance of Zoe.
@@ -44,19 +45,11 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
   /** @type {WeakStore<Brand, ERef<Purse>>} */
   const brandToPurse = makeWeakStore('brand');
 
-  /**
-   * Create an opaque handle object.
-   *
-   * @template {string} H
-   * @param {H} handleType the string literal type of the handle
-   * @returns {Handle<H>}
-   */
-  const makeHandle = handleType => {
-    // This assert ensures that handleType is referenced.
-    assert.typeof(handleType, 'string', 'handleType must be a string');
-    // Return the intersection type (really just an empty object).
-    return /** @type {Handle<H>} */ (harden({}));
-  };
+  /** @type {WeakStore<SeatHandle, ZoeSeatAdmin>} */
+  const seatHandleToZoeSeatAdmin = makeWeakStore('seatHandle');
+
+  /** @type {Set<ZoeSeatAdmin>} */
+  const zoeSeatAdmins = new Set();
 
   /**
    * Create an installation by permanently storing the bundle. It will be
@@ -105,7 +98,6 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
         details`${installation} was not a valid installation`,
       );
 
-      const zoeSeatAdmins = new Set();
       const instance = makeHandle('InstanceHandle');
 
       const keywords = cleanKeywords(uncleanIssuerKeywordRecord);
@@ -227,11 +219,16 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
 
       /** @type {InstanceAdmin} */
       const instanceAdmin = {
-        addZoeSeatAdmin: async (invitationHandle, zoeSeatAdmin, seatData) => {
+        addZoeSeatAdmin: async (
+          invitationHandle,
+          zoeSeatAdmin,
+          seatData,
+          seatHandle,
+        ) => {
           zoeSeatAdmins.add(zoeSeatAdmin);
           return E(
-            /** @type Promise<addSeatObj> */ (addSeatObjPromiseKit.promise),
-          ).addSeat(invitationHandle, zoeSeatAdmin, seatData);
+            /** @type Promise<AddSeatObj> */ (addSeatObjPromiseKit.promise),
+          ).addSeat(invitationHandle, zoeSeatAdmin, seatData, seatHandle);
         },
         hasZoeSeatAdmin: zoeSeatAdmin => zoeSeatAdmins.has(zoeSeatAdmin),
         removeZoeSeatAdmin: zoeSeatAdmin => zoeSeatAdmins.delete(zoeSeatAdmin),
@@ -279,14 +276,15 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
             return undefined;
           })),
         // A Seat requested by the contract without an offer
-        makeOfferlessSeat: (initialAllocation, proposal) => {
+        makeOfferlessSeat: (initialAllocation, proposal, seatHandle) => {
           const { userSeat, notifier, zoeSeatAdmin } = makeZoeSeatAdminKit(
             initialAllocation,
             instanceAdmin,
-            cleanProposal(getAmountMath, proposal),
+            proposal,
             brandToPurse,
           );
           zoeSeatAdmins.add(zoeSeatAdmin);
+          seatHandleToZoeSeatAdmin.init(seatHandle, zoeSeatAdmin);
           return { userSeat, notifier, zoeSeatAdmin };
         },
         shutdown: () => {
@@ -294,6 +292,12 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
           E(adminNode).terminate();
         },
         makeZoeMint,
+        replaceAllocations: seatHandleAllocations => {
+          seatHandleAllocations.forEach(({ seatHandle, allocation }) => {
+            const zoeSeatAdmin = seatHandleToZoeSeatAdmin.get(seatHandle);
+            zoeSeatAdmin.replaceAllocation(allocation);
+          });
+        },
       };
 
       // At this point, the contract will start executing. All must be ready
@@ -379,22 +383,28 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
           const offerResultPromiseKit = makePromiseKit();
           const exitObjPromiseKit = makePromiseKit();
           const instanceAdmin = instanceToInstanceAdmin.get(instance);
+          const seatHandle = makeHandle('SeatHandle');
 
           const { userSeat, notifier, zoeSeatAdmin } = makeZoeSeatAdminKit(
             initialAllocation,
             instanceAdmin,
             proposal,
             brandToPurse,
-            {
-              offerResult: offerResultPromiseKit.promise,
-              exitObj: exitObjPromiseKit.promise,
-            },
+            offerResultPromiseKit.promise,
+            exitObjPromiseKit.promise,
           );
+
+          seatHandleToZoeSeatAdmin.init(seatHandle, zoeSeatAdmin);
 
           const seatData = harden({ proposal, initialAllocation, notifier });
 
           instanceAdmin
-            .addZoeSeatAdmin(invitationHandle, zoeSeatAdmin, seatData)
+            .addZoeSeatAdmin(
+              invitationHandle,
+              zoeSeatAdmin,
+              seatData,
+              seatHandle,
+            )
             .then(({ offerResultP, exitObj }) => {
               offerResultPromiseKit.resolve(offerResultP);
               exitObjPromiseKit.resolve(exitObj);

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -35,7 +35,8 @@ export const makeZoeSeatAdminKit = (
   instanceAdmin,
   proposal,
   brandToPurse,
-  { offerResult = undefined, exitObj = defaultExitObj } = {},
+  offerResult = undefined,
+  exitObj = defaultExitObj,
 ) => {
   const payoutPromiseKit = makePromiseKit();
   const { notifier, updater } = makeNotifierKit();


### PR DESCRIPTION
Do reallocate's replaceAllocations atomically in one call from zcf to zoe.

This code is less pretty because we must move to the instance level rather than staying at the seat level. Note that in contractFacet, the code in `makeEmptySeatKit` got moved around a little so that ZoeSeatAdmin isn't stored as a promise.

Closes #1391 