### PR TITLE
fix: refactoring suggestion for review of 1472

### DIFF
--- a/packages/zoe/src/contractFacet/seat.js
+++ b/packages/zoe/src/contractFacet/seat.js
@@ -32,6 +32,11 @@ export const makeZcfSeatAdminKit = (
         details`The seatStaging ${seatStaging} was not recognized`,
       );
       currentAllocation = seatStaging.getStagedAllocation();
+      return harden({
+        // PLEASE REVIEW THIS LINE BEFORE ACCEPTING THIS SUGGESTION
+        zoeSeatAdmin,
+        allocation: currentAllocation,
+      });
     },
     updateHasExited: () => {
       assertExitedFalse();

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -87,7 +87,7 @@
 /**
  * @typedef {{zcfSeatAdmin: ZCFSeatAdmin, zcfSeat: ZCFSeat}} ZcfSeatAdminKit
  * @typedef {Object} ZCFSeatAdmin
- * @property {(seatStaging: SeatStaging) => void} commit
+ * @property {(seatStaging: SeatStaging) => ZoeSeatAdminAllocation} commit
  * @property {() => void} updateHasExited - updates `exited` state to true
  */
 


### PR DESCRIPTION
My refactoring suggestion was sufficiently involved that I tried it first, and encountered an issue, flagged by our type checker (YAY! attn @michaelfig ). The problem, marked in seat.js line 36, is that zoeSeatAdmin at that point is a promise, not a presence, and in general cannot yet be a presence. However, the zoe `replaceAllocations` needs only presences to be sent, so they'll all arrive as the actual objects.

If this problem with this PR cannot easily be fixed, feel free to ignore this suggestion for now and merge #1472 into #1414 as LGTMed.

Otherwise, if this can be fixed while still being an improvement, feel free to merge this PR into your #1472 before fixing and merging #1472 into #1414 .

Either way, you're no longer blocked on me before merging #1472 into #1414 . Thanks.