### PR TITLE
Update swingset-runner tests for new Zoe

### DIFF
--- a/packages/swingset-runner/demo/encouragementBot/bootstrap.js
+++ b/packages/swingset-runner/demo/encouragementBot/bootstrap.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 const log = console.log;

--- a/packages/swingset-runner/demo/encouragementBot/vat-bot.js
+++ b/packages/swingset-runner/demo/encouragementBot/vat-bot.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 export function buildRootObject(_vatPowers) {
   return harden({
     encourageMe(name) {

--- a/packages/swingset-runner/demo/encouragementBot/vat-user.js
+++ b/packages/swingset-runner/demo/encouragementBot/vat-user.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 const log = console.log;

--- a/packages/swingset-runner/demo/exchangeBenchmark/bootstrap.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/bootstrap.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { makeIssuerKit } from '@agoric/ertp';
 import { E } from '@agoric/eventual-send';
 import { makePrintLog } from './printLog';

--- a/packages/swingset-runner/demo/exchangeBenchmark/exchanger.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/exchanger.js
@@ -1,4 +1,3 @@
-/* global harden */
 // @ts-check
 
 import { E } from '@agoric/eventual-send';

--- a/packages/swingset-runner/demo/exchangeBenchmark/exchanger.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/exchanger.js
@@ -5,8 +5,17 @@ import { E } from '@agoric/eventual-send';
 import { showPurseBalance, setupPurses } from './helpers';
 import { makePrintLog } from './printLog';
 
+import '@agoric/zoe/exported';
+
 const log = makePrintLog();
 
+/**
+ * @param {string} name
+ * @param {ZoeService} zoe
+ * @param {Issuer[]} issuers
+ * @param {Payment[]} payments
+ * @param {Record<string,Installation>} installations
+ */
 async function build(name, zoe, issuers, payments, installations) {
   const { moola, simoleans, purses } = await setupPurses(
     zoe,
@@ -44,10 +53,13 @@ async function build(name, zoe, issuers, payments, installations) {
   async function initiateSimpleExchange(otherP) {
     await preReport();
 
-    const {
-      invite: addOrderInvite,
-      instanceRecord: { publicAPI },
-    } = await E(zoe).startInstance(simpleExchange, issuerKeywordRecord);
+    const { publicFacet } = await E(zoe).startInstance(
+      simpleExchange,
+      issuerKeywordRecord,
+    );
+    const publicAPI = /** @type {{ makeInvitation: () => Invitation }} */ (publicFacet);
+
+    const addOrderInvite = await E(publicAPI).makeInvitation();
 
     const mySellOrderProposal = harden({
       give: { Asset: moola(1) },
@@ -57,13 +69,15 @@ async function build(name, zoe, issuers, payments, installations) {
     const paymentKeywordRecord = {
       Asset: await E(moolaPurseP).withdraw(moola(1)),
     };
-    const { payout: payoutP } = await E(zoe).offer(
+    console.error('offering', addOrderInvite);
+    const seat = await E(zoe).offer(
       addOrderInvite,
       mySellOrderProposal,
       paymentKeywordRecord,
     );
+    const payoutP = E(seat).getPayouts();
 
-    const inviteP = E(publicAPI).makeInvite();
+    const inviteP = E(publicAPI).makeInvitation();
     await E(otherP).respondToSimpleExchange(inviteP);
 
     await receivePayout(payoutP);
@@ -85,11 +99,12 @@ async function build(name, zoe, issuers, payments, installations) {
       Price: await E(simoleanPurseP).withdraw(simoleans(1)),
     };
 
-    const { payout: payoutP } = await E(zoe).offer(
+    const seatP = await E(zoe).offer(
       exclInvite,
       myBuyOrderProposal,
       paymentKeywordRecord,
     );
+    const payoutP = E(seatP).getPayouts();
 
     await receivePayout(payoutP);
     await postReport();
@@ -103,6 +118,7 @@ async function build(name, zoe, issuers, payments, installations) {
 
 export function buildRootObjectCommon(name, _vatPowers) {
   return harden({
-    build: (...args) => build(name, ...args),
+    build: (zoe, issuers, payments, installations) =>
+      build(name, zoe, issuers, payments, installations),
   });
 }

--- a/packages/swingset-runner/demo/exchangeBenchmark/helpers.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/helpers.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 import { makeLocalAmountMath } from '@agoric/ertp';
 

--- a/packages/swingset-runner/demo/exchangeBenchmark/helpers.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/helpers.js
@@ -3,6 +3,8 @@
 import { E } from '@agoric/eventual-send';
 import { makeLocalAmountMath } from '@agoric/ertp';
 
+import '@agoric/zoe/exported';
+
 export async function showPurseBalance(purseP, name, log) {
   try {
     const amount = await E(purseP).getCurrentAmount();
@@ -12,6 +14,11 @@ export async function showPurseBalance(purseP, name, log) {
   }
 }
 
+/**
+ * @param {ZoeService} zoe
+ * @param {Issuer[]} issuers
+ * @param {Payment[]} payments
+ */
 export async function setupPurses(zoe, issuers, payments) {
   const purses = issuers.map(issuer => E(issuer).makeEmptyPurse());
   const [moolaIssuer, simoleanIssuer] = issuers;

--- a/packages/swingset-runner/demo/exchangeBenchmark/prepareContracts.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/prepareContracts.js
@@ -6,9 +6,10 @@ const CONTRACT_FILES = ['simpleExchange'];
 
 const generateBundlesP = Promise.all(
   CONTRACT_FILES.map(async contract => {
-    const bundle = await bundleSource(
-      `${__dirname}/../../../zoe/src/contracts/${contract}`,
+    const contractPath = require.resolve(
+      `@agoric/zoe/src/contracts/${contract}`,
     );
+    const bundle = await bundleSource(contractPath);
     const obj = { bundle, contract };
     fs.writeFileSync(
       `${__dirname}/bundle-${contract}.js`,

--- a/packages/swingset-runner/demo/exchangeBenchmark/vat-zoe.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/vat-zoe.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { makeZoe } from '@agoric/zoe';
 
 export function buildRootObject(_vatPowers, vatParameters) {

--- a/packages/swingset-runner/demo/justReply/bootstrap.js
+++ b/packages/swingset-runner/demo/justReply/bootstrap.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 const log = console.log;

--- a/packages/swingset-runner/demo/justReply/vat-alice.js
+++ b/packages/swingset-runner/demo/justReply/vat-alice.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 const log = console.log;

--- a/packages/swingset-runner/demo/justReply/vat-bob.js
+++ b/packages/swingset-runner/demo/justReply/vat-bob.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 export function buildRootObject(_vatPowers) {
   return harden({
     hello() {

--- a/packages/swingset-runner/demo/megaPong/bootstrap.js
+++ b/packages/swingset-runner/demo/megaPong/bootstrap.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 const log = console.log;

--- a/packages/swingset-runner/demo/megaPong/vat-alice.js
+++ b/packages/swingset-runner/demo/megaPong/vat-alice.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 const log = console.log;

--- a/packages/swingset-runner/demo/megaPong/vat-bob.js
+++ b/packages/swingset-runner/demo/megaPong/vat-bob.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 const log = console.log;

--- a/packages/swingset-runner/demo/pingPongBenchmark/bootstrap.js
+++ b/packages/swingset-runner/demo/pingPongBenchmark/bootstrap.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 const log = console.log;

--- a/packages/swingset-runner/demo/pingPongBenchmark/vat-alice.js
+++ b/packages/swingset-runner/demo/pingPongBenchmark/vat-alice.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 const log = console.log;

--- a/packages/swingset-runner/demo/pingPongBenchmark/vat-bob.js
+++ b/packages/swingset-runner/demo/pingPongBenchmark/vat-bob.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 const log = console.log;

--- a/packages/swingset-runner/demo/promiseChainBenchmark/bootstrap.js
+++ b/packages/swingset-runner/demo/promiseChainBenchmark/bootstrap.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 const log = console.log;

--- a/packages/swingset-runner/demo/promiseChainBenchmark/vat-bob.js
+++ b/packages/swingset-runner/demo/promiseChainBenchmark/vat-bob.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 function makePR() {
   let r;
   const p = new Promise((resolve, _reject) => {

--- a/packages/swingset-runner/demo/resolveCase1/bootstrap.js
+++ b/packages/swingset-runner/demo/resolveCase1/bootstrap.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 const log = console.log;

--- a/packages/swingset-runner/demo/resolveCase1/vat-bob.js
+++ b/packages/swingset-runner/demo/resolveCase1/vat-bob.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 const log = console.log;
 
 export function buildRootObject(_vatPowers) {

--- a/packages/swingset-runner/demo/resolveCase2/bootstrap.js
+++ b/packages/swingset-runner/demo/resolveCase2/bootstrap.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 const log = console.log;

--- a/packages/swingset-runner/demo/resolveCase2/vat-bob.js
+++ b/packages/swingset-runner/demo/resolveCase2/vat-bob.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 const log = console.log;
 
 export function buildRootObject(_vatPowers) {

--- a/packages/swingset-runner/demo/resolveCase3/bootstrap.js
+++ b/packages/swingset-runner/demo/resolveCase3/bootstrap.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 const log = console.log;

--- a/packages/swingset-runner/demo/resolveCase3/vat-bob.js
+++ b/packages/swingset-runner/demo/resolveCase3/vat-bob.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 const log = console.log;
 
 export function buildRootObject(_vatPowers) {

--- a/packages/swingset-runner/demo/resolveChain/bootstrap.js
+++ b/packages/swingset-runner/demo/resolveChain/bootstrap.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 const log = console.log;

--- a/packages/swingset-runner/demo/resolveChain/vat-bob.js
+++ b/packages/swingset-runner/demo/resolveChain/vat-bob.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 function makePR() {
   let r;
   const p = new Promise((resolve, _reject) => {

--- a/packages/swingset-runner/demo/resolveCircular/bootstrap.js
+++ b/packages/swingset-runner/demo/resolveCircular/bootstrap.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 console.log(`=> loading bootstrap.js`);

--- a/packages/swingset-runner/demo/resolveCircular/vat-bob.js
+++ b/packages/swingset-runner/demo/resolveCircular/vat-bob.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 function makePR() {
   let r;
   const p = new Promise((resolve, _reject) => {

--- a/packages/swingset-runner/demo/resolveDelayedPipeline/bootstrap.js
+++ b/packages/swingset-runner/demo/resolveDelayedPipeline/bootstrap.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 const log = console.log;

--- a/packages/swingset-runner/demo/resolveDelayedPipeline/vat-bob.js
+++ b/packages/swingset-runner/demo/resolveDelayedPipeline/vat-bob.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 const log = console.log;
 
 export function buildRootObject(_vatPowers) {

--- a/packages/swingset-runner/demo/resolveInArrayCase1/bootstrap.js
+++ b/packages/swingset-runner/demo/resolveInArrayCase1/bootstrap.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 const log = console.log;

--- a/packages/swingset-runner/demo/resolveInArrayCase1/vat-bob.js
+++ b/packages/swingset-runner/demo/resolveInArrayCase1/vat-bob.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 const log = console.log;
 
 export function buildRootObject(_vatPowers) {

--- a/packages/swingset-runner/demo/resolveIndirect/bootstrap.js
+++ b/packages/swingset-runner/demo/resolveIndirect/bootstrap.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 console.log(`=> loading bootstrap.js`);

--- a/packages/swingset-runner/demo/resolveIndirect/vat-bob.js
+++ b/packages/swingset-runner/demo/resolveIndirect/vat-bob.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 function makePR() {
   let r;
   const p = new Promise((resolve, _reject) => {

--- a/packages/swingset-runner/demo/resolvePassResult/bootstrap.js
+++ b/packages/swingset-runner/demo/resolvePassResult/bootstrap.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 const log = console.log;

--- a/packages/swingset-runner/demo/resolvePassResult/vat-bob.js
+++ b/packages/swingset-runner/demo/resolvePassResult/vat-bob.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 const log = console.log;
 
 export function buildRootObject(_vatPowers) {

--- a/packages/swingset-runner/demo/resolvePassResultPromise/bootstrap.js
+++ b/packages/swingset-runner/demo/resolvePassResultPromise/bootstrap.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 const log = console.log;

--- a/packages/swingset-runner/demo/resolvePassResultPromise/vat-bob.js
+++ b/packages/swingset-runner/demo/resolvePassResultPromise/vat-bob.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 const log = console.log;
 
 export function buildRootObject(_vatPowers) {

--- a/packages/swingset-runner/demo/resolvePipelined/bootstrap.js
+++ b/packages/swingset-runner/demo/resolvePipelined/bootstrap.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 const log = console.log;

--- a/packages/swingset-runner/demo/resolvePipelined/vat-bob.js
+++ b/packages/swingset-runner/demo/resolvePipelined/vat-bob.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 const log = console.log;
 
 export function buildRootObject(_vatPowers) {

--- a/packages/swingset-runner/demo/resolvePromiseComplicated/bootstrap.js
+++ b/packages/swingset-runner/demo/resolvePromiseComplicated/bootstrap.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 const log = console.log;

--- a/packages/swingset-runner/demo/resolvePromiseComplicated/vat-bob.js
+++ b/packages/swingset-runner/demo/resolvePromiseComplicated/vat-bob.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 const log = console.log;

--- a/packages/swingset-runner/demo/resolvePromiseComplicated/vat-carol.js
+++ b/packages/swingset-runner/demo/resolvePromiseComplicated/vat-carol.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 const log = console.log;
 
 export function buildRootObject(_vatPowers) {

--- a/packages/swingset-runner/demo/resolveSimpleCicular/bootstrap.js
+++ b/packages/swingset-runner/demo/resolveSimpleCicular/bootstrap.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 console.log(`=> loading bootstrap.js`);

--- a/packages/swingset-runner/demo/resolveSimpleCicular/vat-bob.js
+++ b/packages/swingset-runner/demo/resolveSimpleCicular/vat-bob.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 function makePR() {
   let r;
   const p = new Promise((resolve, _reject) => {

--- a/packages/swingset-runner/demo/resolveWithEmbeddedPromise/bootstrap.js
+++ b/packages/swingset-runner/demo/resolveWithEmbeddedPromise/bootstrap.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 const log = console.log;

--- a/packages/swingset-runner/demo/resolveWithEmbeddedPromise/vat-bob.js
+++ b/packages/swingset-runner/demo/resolveWithEmbeddedPromise/vat-bob.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 const log = console.log;
 
 function makePR() {

--- a/packages/swingset-runner/demo/simplePromisePass/bootstrap.js
+++ b/packages/swingset-runner/demo/simplePromisePass/bootstrap.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 const log = console.log;

--- a/packages/swingset-runner/demo/simplePromisePass/vat-alice.js
+++ b/packages/swingset-runner/demo/simplePromisePass/vat-alice.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 const log = console.log;

--- a/packages/swingset-runner/demo/simplePromisePass/vat-bob.js
+++ b/packages/swingset-runner/demo/simplePromisePass/vat-bob.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 const log = console.log;
 
 export function buildRootObject(_vatPowers) {

--- a/packages/swingset-runner/demo/vatResolveTest/bootstrap.js
+++ b/packages/swingset-runner/demo/vatResolveTest/bootstrap.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 const log = console.log;

--- a/packages/swingset-runner/demo/vatResolveTest/vat-bob.js
+++ b/packages/swingset-runner/demo/vatResolveTest/vat-bob.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 const log = console.log;

--- a/packages/swingset-runner/demo/vatResolveTestSimple/bootstrap.js
+++ b/packages/swingset-runner/demo/vatResolveTestSimple/bootstrap.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 const log = console.log;

--- a/packages/swingset-runner/demo/vatResolveTestSimple/vat-bob.js
+++ b/packages/swingset-runner/demo/vatResolveTestSimple/vat-bob.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 const log = console.log;

--- a/packages/swingset-runner/demo/zoeTests/bootstrap.js
+++ b/packages/swingset-runner/demo/zoeTests/bootstrap.js
@@ -2,6 +2,8 @@ import { E } from '@agoric/eventual-send';
 import { makeIssuerKit } from '@agoric/ertp';
 import buildManualTimer from './manualTimer';
 
+import { makePrintLog } from './printLog';
+
 /* eslint-disable import/no-unresolved, import/extensions */
 import automaticRefundBundle from './bundle-automaticRefund';
 import coveredCallBundle from './bundle-coveredCall';
@@ -86,7 +88,7 @@ const makeVats = (log, vats, zoe, installations, startingValues) => {
   return harden(result);
 };
 
-export function buildRootObject(vatPowers, vatParameters) {
+export function buildRootObject(_vatPowers, vatParameters) {
   const obj0 = {
     async bootstrap(vats, devices) {
       const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
@@ -118,12 +120,12 @@ export function buildRootObject(vatPowers, vatParameters) {
         throw Error(
           `Cannot find startingValues for ${testName} in ${JSON.stringify(
             vatParameters,
-          )} or ${JSON.stringify(vatPowers)}`,
+          )} or ${JSON.stringify(_vatPowers)}`,
         );
       }
 
       const { aliceP, bobP, carolP, daveP } = makeVats(
-        vatPowers.testLog,
+        makePrintLog(),
         vats,
         zoe,
         installations,

--- a/packages/swingset-runner/demo/zoeTests/bootstrap.js
+++ b/packages/swingset-runner/demo/zoeTests/bootstrap.js
@@ -1,6 +1,6 @@
 import { E } from '@agoric/eventual-send';
 import { makeIssuerKit } from '@agoric/ertp';
-import buildManualTimer from '../../../tools/manualTimer';
+import buildManualTimer from './manualTimer';
 
 /* eslint-disable import/no-unresolved, import/extensions */
 import automaticRefundBundle from './bundle-automaticRefund';

--- a/packages/swingset-runner/demo/zoeTests/bootstrap.js
+++ b/packages/swingset-runner/demo/zoeTests/bootstrap.js
@@ -104,7 +104,23 @@ export function buildRootObject(vatPowers, vatParameters) {
         mintAndSellNFT: await E(zoe).install(mintAndSellNFTBundle.bundle),
       };
 
-      const [testName, startingValues] = vatParameters.argv;
+      const testName = vatParameters.argv[0] || 'simpleExchangeOk';
+      const startingValuesStr = vatParameters.argv[1];
+      let startingValues;
+      if (startingValuesStr) {
+        startingValues = JSON.parse(startingValuesStr);
+      } else if (
+        vatParameters.startingValues &&
+        vatParameters.startingValues[testName]
+      ) {
+        startingValues = vatParameters.startingValues[testName];
+      } else {
+        throw Error(
+          `Cannot find startingValues for ${testName} in ${JSON.stringify(
+            vatParameters,
+          )} or ${JSON.stringify(vatPowers)}`,
+        );
+      }
 
       const { aliceP, bobP, carolP, daveP } = makeVats(
         vatPowers.testLog,

--- a/packages/swingset-runner/demo/zoeTests/bootstrap.js
+++ b/packages/swingset-runner/demo/zoeTests/bootstrap.js
@@ -120,7 +120,7 @@ export function buildRootObject(_vatPowers, vatParameters) {
         throw Error(
           `Cannot find startingValues for ${testName} in ${JSON.stringify(
             vatParameters,
-          )} or ${JSON.stringify(_vatPowers)}`,
+          )}`,
         );
       }
 

--- a/packages/swingset-runner/demo/zoeTests/helpers.js
+++ b/packages/swingset-runner/demo/zoeTests/helpers.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 import { makeLocalAmountMath } from '@agoric/ertp';
 

--- a/packages/swingset-runner/demo/zoeTests/manualTimer.js
+++ b/packages/swingset-runner/demo/zoeTests/manualTimer.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 // A fake clock that also logs progress in tests.
 export default function buildManualTimer(log, startValue = 0) {
   let ticks = startValue;

--- a/packages/swingset-runner/demo/zoeTests/prepareContracts.js
+++ b/packages/swingset-runner/demo/zoeTests/prepareContracts.js
@@ -15,9 +15,10 @@ const CONTRACT_FILES = [
 
 const generateBundlesP = Promise.all(
   CONTRACT_FILES.map(async contract => {
-    const bundle = await bundleSource(
-      `${__dirname}/../../../zoe/src/contracts/${contract}`,
+    const contractPath = require.resolve(
+      `@agoric/zoe/src/contracts/${contract}`,
     );
+    const bundle = await bundleSource(contractPath);
     const obj = { bundle, contract };
     fs.writeFileSync(
       `${__dirname}/bundle-${contract}.js`,

--- a/packages/swingset-runner/demo/zoeTests/swingset.json
+++ b/packages/swingset-runner/demo/zoeTests/swingset.json
@@ -2,7 +2,7 @@
   "bootstrap": "bootstrap",
   "bundles": {
     "zcf": {
-      "sourceSpec": "../../../zoe/src/contractFacet.js"
+      "sourceSpec": "@agoric/zoe/contractFacet"
     }
   },
   "vats": {

--- a/packages/swingset-runner/demo/zoeTests/vat-alice.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-alice.js
@@ -1,13 +1,8 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 import { makeLocalAmountMath } from '@agoric/ertp';
-import { showPurseBalance, setupIssuers } from './helpers';
-import { makePrintLog } from './printLog';
+import { showPurseBalance, setupIssuers } from '../helpers';
 
-const log = makePrintLog();
-
-const build = async (zoe, issuers, payments, installations, timer) => {
+const build = async (log, zoe, issuers, payments, installations, timer) => {
   const { moola, simoleans, purses } = await setupIssuers(zoe, issuers);
   const [moolaPurseP, simoleanPurseP] = purses;
   const [moolaPayment, simoleanPayment] = payments;
@@ -20,12 +15,10 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       Contribution1: moolaIssuer,
       Contribution2: simoleanIssuer,
     });
-    const { invite: refundInvite, instanceRecord } = await E(zoe).startInstance(
-      installId,
-      issuerKeywordRecord,
-    );
+    const { publicFacet, creatorInvitation: refundInvitation } = await E(
+      zoe,
+    ).startInstance(installId, issuerKeywordRecord);
 
-    const { publicAPI } = instanceRecord;
     const proposal = harden({
       give: { Contribution1: moola(3) },
       want: { Contribution2: simoleans(7) },
@@ -33,18 +26,17 @@ const build = async (zoe, issuers, payments, installations, timer) => {
     });
 
     const paymentKeywordRecord = { Contribution1: moolaPayment };
-    const { payout: payoutP, outcome: outcomeP } = await E(zoe).offer(
-      refundInvite,
+    const refundSeatP = await E(zoe).offer(
+      refundInvitation,
       proposal,
       paymentKeywordRecord,
     );
-    log(await outcomeP);
+    log(await E(refundSeatP).getOfferResult());
 
-    const bobInvite = E(publicAPI).makeInvite();
-    await E(bobP).doAutomaticRefund(bobInvite);
-    const payout = await payoutP;
-    const moolaPayout = await payout.Contribution1;
-    const simoleanPayout = await payout.Contribution2;
+    const bobInvitation = E(publicFacet).makeInvitation();
+    await E(bobP).doAutomaticRefund(bobInvitation);
+    const moolaPayout = await E(refundSeatP).getPayout('Contribution1');
+    const simoleanPayout = await E(refundSeatP).getPayout('Contribution2');
 
     await E(moolaPurseP).deposit(moolaPayout);
     await E(simoleanPurseP).deposit(simoleanPayout);
@@ -55,15 +47,14 @@ const build = async (zoe, issuers, payments, installations, timer) => {
 
   const doCoveredCall = async bobP => {
     log(`=> alice.doCreateCoveredCall called`);
-    const installId = installations.coveredCall;
+    const installation = installations.coveredCall;
     const issuerKeywordRecord = harden({
       UnderlyingAsset: moolaIssuer,
       StrikePrice: simoleanIssuer,
     });
-    const { invite: writeCallInvite } = await E(zoe).startInstance(
-      installId,
-      issuerKeywordRecord,
-    );
+    const { creatorInvitation: writeCallInvitation } = await E(
+      zoe,
+    ).startInstance(installation, issuerKeywordRecord);
 
     const proposal = harden({
       give: { UnderlyingAsset: moola(3) },
@@ -72,17 +63,16 @@ const build = async (zoe, issuers, payments, installations, timer) => {
     });
 
     const paymentKeywordRecord = { UnderlyingAsset: moolaPayment };
-    const { payout: payoutP, outcome: optionP } = await E(zoe).offer(
-      writeCallInvite,
+    const seatP = await E(zoe).offer(
+      writeCallInvitation,
       proposal,
       paymentKeywordRecord,
     );
 
+    const optionP = E(seatP).getOfferResult();
     await E(bobP).doCoveredCall(optionP);
-    const payout = await payoutP;
-    const moolaPayout = await payout.UnderlyingAsset;
-    const simoleanPayout = await payout.StrikePrice;
-
+    const moolaPayout = await E(seatP).getPayout('UnderlyingAsset');
+    const simoleanPayout = await E(seatP).getPayout('StrikePrice');
     await E(moolaPurseP).deposit(moolaPayout);
     await E(simoleanPurseP).deposit(simoleanPayout);
 
@@ -96,10 +86,9 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       UnderlyingAsset: moolaIssuer,
       StrikePrice: simoleanIssuer,
     });
-    const { invite: writeCallInvite } = await E(zoe).startInstance(
-      installations.coveredCall,
-      issuerKeywordRecord,
-    );
+    const { creatorInvitation: writeCallInvitation } = await E(
+      zoe,
+    ).startInstance(installations.coveredCall, issuerKeywordRecord);
 
     const proposal = harden({
       give: { UnderlyingAsset: moola(3) },
@@ -113,17 +102,17 @@ const build = async (zoe, issuers, payments, installations, timer) => {
     });
 
     const paymentKeywordRecord = harden({ UnderlyingAsset: moolaPayment });
-    const { payout: payoutP, outcome: optionP } = await E(zoe).offer(
-      writeCallInvite,
+    const seatP = await E(zoe).offer(
+      writeCallInvitation,
       proposal,
       paymentKeywordRecord,
     );
 
     log('call option made');
-    await E(bobP).doSwapForOption(optionP, daveP);
-    const payout = await payoutP;
-    const moolaPayout = await payout.UnderlyingAsset;
-    const simoleanPayout = await payout.StrikePrice;
+    const invitationForBob = E(seatP).getOfferResult();
+    await E(bobP).doSwapForOption(invitationForBob, daveP);
+    const moolaPayout = await E(seatP).getPayout('UnderlyingAsset');
+    const simoleanPayout = await E(seatP).getPayout('StrikePrice');
 
     await E(moolaPurseP).deposit(moolaPayout);
     await E(simoleanPurseP).deposit(simoleanPayout);
@@ -139,14 +128,9 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       Ask: simoleanIssuer,
     });
     const terms = harden({ numBidsAllowed });
-    const {
-      invite: sellAssetsInvite,
-      instanceRecord: { publicAPI },
-    } = await E(zoe).startInstance(
-      installations.publicAuction,
-      issuerKeywordRecord,
-      terms,
-    );
+    const { creatorInvitation: sellAssetsInvitation } = await E(
+      zoe,
+    ).startInstance(installations.publicAuction, issuerKeywordRecord, terms);
 
     const proposal = harden({
       give: { Asset: moola(1) },
@@ -154,27 +138,25 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       exit: { onDemand: null },
     });
     const paymentKeywordRecord = { Asset: moolaPayment };
-    const { payout: payoutP, outcome: outcomeP } = await E(zoe).offer(
-      sellAssetsInvite,
+    const aliceSeatP = await E(zoe).offer(
+      sellAssetsInvitation,
       proposal,
       paymentKeywordRecord,
     );
 
-    const [bobInvite, carolInvite, daveInvite] = await E(publicAPI).makeInvites(
-      3,
-    );
+    const makeBidInvitationObj = await E(aliceSeatP).getOfferResult();
+    const bobInvitation = E(makeBidInvitationObj).makeBidInvitation();
+    const carolInvitation = E(makeBidInvitationObj).makeBidInvitation();
+    const daveInvitation = E(makeBidInvitationObj).makeBidInvitation();
 
-    log(await outcomeP);
-
-    const bobDoneP = E(bobP).doPublicAuction(bobInvite);
-    const carolDoneP = E(carolP).doPublicAuction(carolInvite);
-    const daveDoneP = E(daveP).doPublicAuction(daveInvite);
+    const bobDoneP = E(bobP).doPublicAuction(bobInvitation);
+    const carolDoneP = E(carolP).doPublicAuction(carolInvitation);
+    const daveDoneP = E(daveP).doPublicAuction(daveInvitation);
 
     await Promise.all([bobDoneP, carolDoneP, daveDoneP]);
 
-    const payout = await payoutP;
-    const moolaPayout = await payout.Asset;
-    const simoleanPayout = await payout.Ask;
+    const moolaPayout = await E(aliceSeatP).getPayout('Asset');
+    const simoleanPayout = await E(aliceSeatP).getPayout('Ask');
 
     await E(moolaPurseP).deposit(moolaPayout);
     await E(simoleanPurseP).deposit(simoleanPayout);
@@ -188,10 +170,9 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       Asset: moolaIssuer,
       Price: simoleanIssuer,
     });
-    const { invite: firstOfferInvite } = await E(zoe).startInstance(
-      installations.atomicSwap,
-      issuerKeywordRecord,
-    );
+    const { creatorInvitation: firstOfferInvitation } = await E(
+      zoe,
+    ).startInstance(installations.atomicSwap, issuerKeywordRecord);
 
     const proposal = harden({
       give: { Asset: moola(3) },
@@ -199,17 +180,16 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       exit: { onDemand: null },
     });
     const paymentKeywordRecord = { Asset: moolaPayment };
-    const { payout: payoutP, outcome: bobInviteP } = await E(zoe).offer(
-      firstOfferInvite,
+    const seatP = await E(zoe).offer(
+      firstOfferInvitation,
       proposal,
       paymentKeywordRecord,
     );
 
-    E(bobP).doAtomicSwap(bobInviteP);
+    E(bobP).doAtomicSwap(E(seatP).getOfferResult());
 
-    const payout = await payoutP;
-    const moolaPayout = await payout.Asset;
-    const simoleanPayout = await payout.Price;
+    const moolaPayout = await E(seatP).getPayout('Asset');
+    const simoleanPayout = await E(seatP).getPayout('Price');
 
     await E(moolaPurseP).deposit(moolaPayout);
     await E(simoleanPurseP).deposit(simoleanPayout);
@@ -224,34 +204,33 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       Asset: moolaIssuer,
     });
     const { simpleExchange } = installations;
-    const {
-      invite: addOrderInvite,
-      instanceRecord: { publicAPI },
-    } = await E(zoe).startInstance(simpleExchange, issuerKeywordRecord);
+    const { publicFacet } = await E(zoe).startInstance(
+      simpleExchange,
+      issuerKeywordRecord,
+    );
 
+    const addOrderInvitation = await E(publicFacet).makeInvitation();
     const aliceSellOrderProposal = harden({
       give: { Asset: moola(3) },
       want: { Price: simoleans(4) },
       exit: { onDemand: null },
     });
     const paymentKeywordRecord = { Asset: moolaPayment };
-    const { payout: payoutP, outcome: outcomeP } = await E(zoe).offer(
-      addOrderInvite,
+    const addOrderSeatP = await E(zoe).offer(
+      addOrderInvitation,
       aliceSellOrderProposal,
       paymentKeywordRecord,
     );
 
-    log(await outcomeP);
+    log(await E(addOrderSeatP).getOfferResult());
 
-    const bobInviteP = E(publicAPI).makeInvite();
-    await E(bobP).doSimpleExchange(bobInviteP);
+    const bobInvitationP = E(publicFacet).makeInvitation();
+    await E(bobP).doSimpleExchange(bobInvitationP);
+    const moolaPayout = await E(addOrderSeatP).getPayout('Asset');
+    const simoleanPayout = await E(addOrderSeatP).getPayout('Price');
 
-    const payout = await payoutP;
-    const moolaPayout = await payout.Asset;
-    const simoleanPayout = await payout.Price;
-
-    await E(moolaPurseP).deposit(moolaPayout);
-    await E(simoleanPurseP).deposit(simoleanPayout);
+    await E(moolaPurseP).deposit(await moolaPayout);
+    await E(simoleanPurseP).deposit(await simoleanPayout);
 
     await showPurseBalance(moolaPurseP, 'aliceMoolaPurse', log);
     await showPurseBalance(simoleanPurseP, 'aliceSimoleanPurse', log);
@@ -271,12 +250,12 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       Asset: moolaIssuer,
     });
     const { simpleExchange } = installations;
-    const {
-      invite: addOrderInvite,
-      instanceRecord: { publicAPI },
-    } = await E(zoe).startInstance(simpleExchange, issuerKeywordRecord);
+    const { publicFacet } = await E(zoe).startInstance(
+      simpleExchange,
+      issuerKeywordRecord,
+    );
 
-    logStateOnChanges(await E(publicAPI).getNotifier());
+    logStateOnChanges(await E(publicFacet).getNotifier());
 
     const aliceSellOrderProposal = harden({
       give: { Asset: moola(3) },
@@ -284,30 +263,29 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       exit: { onDemand: null },
     });
     const paymentKeywordRecord = { Asset: moolaPayment };
-    const { payout: payoutP, outcome: outcomeP } = await E(zoe).offer(
-      addOrderInvite,
+    const addOrderInvitation = await E(publicFacet).makeInvitation();
+    const addOrderSeatP = await E(zoe).offer(
+      addOrderInvitation,
       aliceSellOrderProposal,
       paymentKeywordRecord,
     );
 
-    log(await outcomeP);
+    log(await E(addOrderSeatP).getOfferResult());
 
-    const bobInvite1P = E(publicAPI).makeInvite();
-    await E(bobP).doSimpleExchangeUpdates(bobInvite1P, 3, 7);
-    const bobInvite2P = E(publicAPI).makeInvite();
-    await E(bobP).doSimpleExchangeUpdates(bobInvite2P, 8, 2);
+    const bobInvitation1P = E(publicFacet).makeInvitation();
+    await E(bobP).doSimpleExchangeUpdates(bobInvitation1P, 3, 7);
+    const bobInvitation2P = E(publicFacet).makeInvitation();
+    await E(bobP).doSimpleExchangeUpdates(bobInvitation2P, 8, 2);
 
-    const payout = await payoutP;
+    const moolaPayout = await E(addOrderSeatP).getPayout('Asset');
+    const simoleanPayout = await E(addOrderSeatP).getPayout('Price');
 
-    const moolaPayout = await payout.Asset;
-    const simoleanPayout = await payout.Price;
     await E(moolaPurseP).deposit(moolaPayout);
     await E(simoleanPurseP).deposit(simoleanPayout);
-    const bobInvite3P = E(publicAPI).makeInvite();
-    await E(bobP).doSimpleExchangeUpdates(bobInvite3P, 20, 13);
-    const bobInvite4P = E(publicAPI).makeInvite();
-    await E(bobP).doSimpleExchangeUpdates(bobInvite4P, 5, 2);
-
+    const bobInvitation3P = E(publicFacet).makeInvitation();
+    await E(bobP).doSimpleExchangeUpdates(bobInvitation3P, 20, 13);
+    const bobInvitation4P = E(publicFacet).makeInvitation();
+    await E(bobP).doSimpleExchangeUpdates(bobInvitation4P, 5, 2);
     await showPurseBalance(moolaPurseP, 'aliceMoolaPurse', log);
     await showPurseBalance(simoleanPurseP, 'aliceSimoleanPurse', log);
   };
@@ -317,11 +295,11 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       TokenA: moolaIssuer,
       TokenB: simoleanIssuer,
     });
-    const {
-      invite: addLiquidityInvite,
-      instanceRecord: { publicAPI, handle: instanceHandle },
-    } = await E(zoe).startInstance(installations.autoswap, issuerKeywordRecord);
-    const liquidityIssuer = await E(publicAPI).getLiquidityIssuer();
+    const { publicFacet, instance } = await E(zoe).startInstance(
+      installations.autoswap,
+      issuerKeywordRecord,
+    );
+    const liquidityIssuer = await E(publicFacet).getLiquidityIssuer();
     const liquidityAmountMath = await makeLocalAmountMath(liquidityIssuer);
     const liquidity = liquidityAmountMath.make;
 
@@ -336,19 +314,21 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       TokenA: moolaPayment,
       TokenB: simoleanPayment,
     });
-    const { payout: payoutP, outcome: addLiquidityOutcomeP } = await E(
-      zoe,
-    ).offer(addLiquidityInvite, addLiquidityProposal, paymentKeywordRecord);
+    const addLiquidityInvitation = E(publicFacet).makeAddLiquidityInvitation();
+    const addLiqSeatP = await E(zoe).offer(
+      addLiquidityInvitation,
+      addLiquidityProposal,
+      paymentKeywordRecord,
+    );
 
-    log(await addLiquidityOutcomeP);
+    log(await E(addLiqSeatP).getOfferResult());
 
-    const addLiquidityPayments = await payoutP;
-    const liquidityPayout = await addLiquidityPayments.Liquidity;
+    const liquidityPayout = await E(addLiqSeatP).getPayout('Liquidity');
 
     const liquidityTokenPurseP = E(liquidityIssuer).makeEmptyPurse();
     await E(liquidityTokenPurseP).deposit(liquidityPayout);
 
-    await E(bobP).doAutoswap(instanceHandle);
+    await E(bobP).doAutoswap(instance);
 
     // remove the liquidity
     const aliceRemoveLiquidityProposal = harden({
@@ -359,27 +339,25 @@ const build = async (zoe, issuers, payments, installations, timer) => {
     const liquidityTokenPayment = await E(liquidityTokenPurseP).withdraw(
       liquidity(10),
     );
-    const removeLiquidityInvite = E(publicAPI).makeRemoveLiquidityInvite();
+    const removeLiquidityInvitation = E(
+      publicFacet,
+    ).makeRemoveLiquidityInvitation();
 
-    const {
-      payout: aliceRemoveLiquidityPayoutP,
-      outcome: removeLiquidityOutcomeP,
-    } = await E(zoe).offer(
-      removeLiquidityInvite,
+    const removeLiquiditySeatP = await E(zoe).offer(
+      removeLiquidityInvitation,
       aliceRemoveLiquidityProposal,
       harden({ Liquidity: liquidityTokenPayment }),
     );
 
-    log(await removeLiquidityOutcomeP);
+    log(await E(removeLiquiditySeatP).getOfferResult());
 
-    const payout = await aliceRemoveLiquidityPayoutP;
-    const moolaPayout = await payout.TokenA;
-    const simoleanPayout = await payout.TokenB;
+    const moolaPayout = await E(removeLiquiditySeatP).getPayout('TokenA');
+    const simoleanPayout = await E(removeLiquiditySeatP).getPayout('TokenB');
 
     await E(moolaPurseP).deposit(moolaPayout);
     await E(simoleanPurseP).deposit(simoleanPayout);
 
-    const poolAmounts = await E(publicAPI).getPoolAllocation();
+    const poolAmounts = await E(publicFacet).getPoolAllocation();
 
     log(`poolAmounts`, poolAmounts);
 
@@ -394,40 +372,34 @@ const build = async (zoe, issuers, payments, installations, timer) => {
 
   const doSellTickets = async bobP => {
     const { mintAndSellNFT } = installations;
-    const { invite } = await E(zoe).startInstance(mintAndSellNFT);
-
-    const { outcome } = await E(zoe).offer(invite);
-    const ticketSeller = await outcome;
+    const { creatorFacet } = await E(zoe).startInstance(mintAndSellNFT);
 
     // completeObj exists because of a current limitation in @agoric/marshal : https://github.com/Agoric/agoric-sdk/issues/818
     const {
-      sellItemsInstanceHandle: ticketSalesInstanceHandle,
-      payout: payoutP,
-      completeObj,
-    } = await E(ticketSeller).sellTokens({
+      sellItemsInstance: ticketSalesInstance,
+      sellItemsCreatorSeat,
+      sellItemsPublicFacet,
+      sellItemsCreatorFacet,
+    } = await E(creatorFacet).sellTokens({
       customValueProperties: {
         show: 'Steven Universe, the Opera',
         start: 'Wed, March 25th 2020 at 8pm',
       },
       count: 3,
       moneyIssuer: moolaIssuer,
-      sellItemsInstallationHandle: installations.sellItems,
+      sellItemsInstallation: installations.sellItems,
       pricePerItem: moola(22),
     });
+    const buyerInvitation = E(sellItemsCreatorFacet).makeBuyerInvitation();
+    await E(bobP).doBuyTickets(ticketSalesInstance, buyerInvitation);
 
-    await E(bobP).doBuyTickets(ticketSalesInstanceHandle);
-
-    const { publicAPI: ticketSalesPublicAPI } = await E(zoe).getInstanceRecord(
-      ticketSalesInstanceHandle,
-    );
-    const availableTickets = await E(ticketSalesPublicAPI).getAvailableItems();
+    const availableTickets = await E(sellItemsPublicFacet).getAvailableItems();
 
     log('after ticket1 purchased: ', availableTickets);
 
-    await E(completeObj).complete();
+    await E(sellItemsCreatorSeat).exit();
 
-    const payout = await payoutP;
-    const moneyPayment = await payout.Money;
+    const moneyPayment = await E(sellItemsCreatorSeat).getPayout('Money');
     await E(moolaPurseP).deposit(moneyPayment);
     const currentPurseBalance = await E(moolaPurseP).getCurrentAmount();
 
@@ -472,6 +444,8 @@ const build = async (zoe, issuers, payments, installations, timer) => {
   });
 };
 
-export function buildRootObject(_vatPowers) {
-  return harden({ build });
+export function buildRootObject(vatPowers) {
+  return harden({
+    build: (...args) => build(vatPowers.testLog, ...args),
+  });
 }

--- a/packages/swingset-runner/demo/zoeTests/vat-alice.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-alice.js
@@ -2,6 +2,8 @@ import { E } from '@agoric/eventual-send';
 import { makeLocalAmountMath } from '@agoric/ertp';
 import { showPurseBalance, setupIssuers } from './helpers';
 
+import { makePrintLog } from './printLog';
+
 const build = async (log, zoe, issuers, payments, installations, timer) => {
   const { moola, simoleans, purses } = await setupIssuers(zoe, issuers);
   const [moolaPurseP, simoleanPurseP] = purses;
@@ -444,8 +446,8 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
   });
 };
 
-export function buildRootObject(vatPowers) {
+export function buildRootObject(_vatPowers) {
   return harden({
-    build: (...args) => build(vatPowers.testLog, ...args),
+    build: (...args) => build(makePrintLog(), ...args),
   });
 }

--- a/packages/swingset-runner/demo/zoeTests/vat-alice.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-alice.js
@@ -1,6 +1,6 @@
 import { E } from '@agoric/eventual-send';
 import { makeLocalAmountMath } from '@agoric/ertp';
-import { showPurseBalance, setupIssuers } from '../helpers';
+import { showPurseBalance, setupIssuers } from './helpers';
 
 const build = async (log, zoe, issuers, payments, installations, timer) => {
   const { moola, simoleans, purses } = await setupIssuers(zoe, issuers);

--- a/packages/swingset-runner/demo/zoeTests/vat-bob.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-bob.js
@@ -4,6 +4,8 @@ import { sameStructure } from '@agoric/same-structure';
 import { makeLocalAmountMath } from '@agoric/ertp';
 import { showPurseBalance, setupIssuers } from './helpers';
 
+import { makePrintLog } from './printLog';
+
 const build = async (log, zoe, issuers, payments, installations, timer) => {
   const {
     moola,
@@ -532,8 +534,8 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
   });
 };
 
-export function buildRootObject(vatPowers) {
+export function buildRootObject(_vatPowers) {
   return harden({
-    build: (...args) => build(vatPowers.testLog, ...args),
+    build: (...args) => build(makePrintLog(), ...args),
   });
 }

--- a/packages/swingset-runner/demo/zoeTests/vat-bob.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-bob.js
@@ -1,15 +1,10 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 import { assert, details } from '@agoric/assert';
 import { sameStructure } from '@agoric/same-structure';
 import { makeLocalAmountMath } from '@agoric/ertp';
-import { showPurseBalance, setupIssuers } from './helpers';
-import { makePrintLog } from './printLog';
+import { showPurseBalance, setupIssuers } from '../helpers';
 
-const log = makePrintLog();
-
-const build = async (zoe, issuers, payments, installations, timer) => {
+const build = async (log, zoe, issuers, payments, installations, timer) => {
   const {
     moola,
     simoleans,
@@ -21,26 +16,19 @@ const build = async (zoe, issuers, payments, installations, timer) => {
   const [moolaPurseP, simoleanPurseP, bucksPurseP] = purses;
   const [moolaPayment, simoleanPayment] = payments;
   const [moolaIssuer, simoleanIssuer, bucksIssuer] = issuers;
-  const inviteIssuer = await E(zoe).getInvitationIssuer();
+  const invitationIssuer = await E(zoe).getInvitationIssuer();
 
   return harden({
-    doAutomaticRefund: async inviteP => {
-      const invite = await inviteP;
-      const exclInvite = await E(inviteIssuer).claim(invite);
-      const getInstanceHandle = iP =>
-        E(inviteIssuer)
-          .getAmountOf(iP)
-          .then(amount => amount.value[0].instanceHandle);
+    doAutomaticRefund: async invitation => {
+      const instance = await E(zoe).getInstance(invitation);
+      const installation = await E(zoe).getInstallation(invitation);
+      const exclInvitation = await E(invitationIssuer).claim(invitation);
 
-      const instanceHandle = await getInstanceHandle(exclInvite);
-
-      const { installationHandle, issuerKeywordRecord } = await E(
-        zoe,
-      ).getInstanceRecord(instanceHandle);
+      const issuerKeywordRecord = await E(zoe).getIssuers(instance);
 
       // Bob ensures it's the contract he expects
       assert(
-        installations.automaticRefund === installationHandle,
+        installations.automaticRefund === installation,
         details`should be the expected automaticRefund`,
       );
 
@@ -63,16 +51,15 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       const bobPayments = { Contribution2: simoleanPayment };
 
       // 2. Bob makes an offer
-      const { payout: payoutP, outcome: outcomeP } = await E(zoe).offer(
-        exclInvite,
+      const bobSeatP = await E(zoe).offer(
+        exclInvitation,
         bobProposal,
         bobPayments,
       );
-      log(await outcomeP);
+      log(await E(bobSeatP).getOfferResult());
 
-      const bobResult = await payoutP;
-      const moolaPayout = await bobResult.Contribution1;
-      const simoleanPayout = await bobResult.Contribution2;
+      const moolaPayout = await E(bobSeatP).getPayout('Contribution1');
+      const simoleanPayout = await E(bobSeatP).getPayout('Contribution2');
 
       // 5: Bob deposits his winnings
       await E(moolaPurseP).deposit(moolaPayout);
@@ -82,28 +69,29 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       await showPurseBalance(simoleanPurseP, 'bobSimoleanPurse', log);
     },
 
-    doCoveredCall: async inviteP => {
-      // Bob claims all with the Zoe inviteIssuer
-      const invite = await inviteP;
-      const exclInvite = await E(inviteIssuer).claim(invite);
+    doCoveredCall: async invitation => {
+      // Bob claims all with the Zoe invitationIssuer
+      const instance = await E(zoe).getInstance(invitation);
+      const installation = await E(zoe).getInstallation(invitation);
+      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const issuerKeywordRecord = await E(zoe).getIssuers(instance);
 
       const bobIntendedProposal = harden({
         want: { UnderlyingAsset: moola(3) },
         give: { StrikePrice: simoleans(7) },
       });
 
-      // Bob checks that the invite is for the right covered call
-      const { value: optionValue } = await E(inviteIssuer).getAmountOf(
-        exclInvite,
+      // Bob checks that the invitation is for the right covered call
+      const { value: optionValue } = await E(invitationIssuer).getAmountOf(
+        exclInvitation,
       );
-
       assert(
-        optionValue[0].installationHandle === installations.coveredCall,
+        installation === installations.coveredCall,
         details`wrong installation`,
       );
       assert(
         optionValue[0].description === 'exerciseOption',
-        details`wrong invite`,
+        details`wrong invitation`,
       );
       assert(moolaAmountMath.isEqual(optionValue[0].underlyingAsset, moola(3)));
       assert(
@@ -114,10 +102,7 @@ const build = async (zoe, issuers, payments, installations, timer) => {
         details`wrong expirationDate`,
       );
       assert(optionValue[0].timerAuthority === timer, 'wrong timer');
-
-      const {
-        issuerKeywordRecord: { UnderlyingAsset, StrikePrice },
-      } = await E(zoe).getInstanceRecord(optionValue[0].instanceHandle);
+      const { UnderlyingAsset, StrikePrice } = issuerKeywordRecord;
 
       assert(
         UnderlyingAsset === moolaIssuer,
@@ -129,19 +114,17 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       );
 
       const bobPayments = { StrikePrice: simoleanPayment };
-
       // Bob escrows
-      const { payout: payoutP, outcome: bobOutcomeP } = await E(zoe).offer(
-        exclInvite,
+      const seatP = await E(zoe).offer(
+        exclInvitation,
         bobIntendedProposal,
         bobPayments,
       );
 
-      log(await bobOutcomeP);
+      log(await E(seatP).getOfferResult());
 
-      const bobResult = await payoutP;
-      const moolaPayout = await bobResult.UnderlyingAsset;
-      const simoleanPayout = await bobResult.StrikePrice;
+      const moolaPayout = await E(seatP).getPayout('UnderlyingAsset');
+      const simoleanPayout = await E(seatP).getPayout('StrikePrice');
 
       await E(moolaPurseP).deposit(moolaPayout);
       await E(simoleanPurseP).deposit(simoleanPayout);
@@ -149,22 +132,30 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       await showPurseBalance(moolaPurseP, 'bobMoolaPurse', log);
       await showPurseBalance(simoleanPurseP, 'bobSimoleanPurse', log);
     },
-    doSwapForOption: async (inviteP, daveP) => {
-      // Bob claims all with the Zoe inviteIssuer
-      const invite = await inviteP;
-      const exclInvite = await E(inviteIssuer).claim(invite);
 
-      // Bob checks that the invite is for the right covered call
-      const optionAmounts = await E(inviteIssuer).getAmountOf(exclInvite);
+    doSwapForOption: async (invitation, daveP) => {
+      // Bob claims all with the Zoe invitationIssuer
+      const instance = await E(zoe).getInstance(invitation);
+      const installation = await E(zoe).getInstallation(invitation);
+      const exclInvitation = await E(invitationIssuer).claim(invitation);
+
+      const { UnderlyingAsset, StrikePrice } = await E(zoe).getIssuers(
+        instance,
+      );
+
+      // Bob checks that the invitation is for the right covered call
+      const optionAmounts = await E(invitationIssuer).getAmountOf(
+        exclInvitation,
+      );
       const optionValue = optionAmounts.value;
 
       assert(
-        optionValue[0].installationHandle === installations.coveredCall,
+        installation === installations.coveredCall,
         details`wrong installation`,
       );
       assert(
         optionValue[0].description === 'exerciseOption',
-        details`wrong invite`,
+        details`wrong invitation`,
       );
       assert(
         moolaAmountMath.isEqual(optionValue[0].underlyingAsset, moola(3)),
@@ -179,9 +170,6 @@ const build = async (zoe, issuers, payments, installations, timer) => {
         details`wrong expiration date`,
       );
       assert(optionValue[0].timerAuthority === timer, details`wrong timer`);
-      const {
-        issuerKeywordRecord: { UnderlyingAsset, StrikePrice },
-      } = await E(zoe).getInstanceRecord(optionValue[0].instanceHandle);
       assert(
         UnderlyingAsset === moolaIssuer,
         details`The underlyingAsset issuer should be the moola issuer`,
@@ -192,39 +180,37 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       );
 
       // Let's imagine that Bob wants to create a swap to trade this
-      // invite for bucks. He wants to invite Dave as the
+      // invitation for bucks. He wants to invitation Dave as the
       // counter-party.
-      const issuerKeywordRecord = harden({
-        Asset: inviteIssuer,
+      const offerIssuerKeywordRecord = harden({
+        Asset: invitationIssuer,
         Price: bucksIssuer,
       });
-      const { invite: bobSwapInvite } = await E(zoe).startInstance(
-        installations.atomicSwap,
-        issuerKeywordRecord,
-      );
+      const { creatorInvitation: bobSwapInvitation } = await E(
+        zoe,
+      ).startInstance(installations.atomicSwap, offerIssuerKeywordRecord);
 
-      // Bob wants to swap an invite with the same amount as his
-      // current invite from Alice. He wants 1 buck in return.
+      // Bob wants to swap an invitation with the same amount as his
+      // current invitation from Alice. He wants 1 buck in return.
       const bobProposalSwap = harden({
         give: { Asset: optionAmounts },
         want: { Price: bucks(1) },
       });
 
-      const bobSwapPayments = harden({ Asset: exclInvite });
+      const bobSwapPayments = harden({ Asset: exclInvitation });
 
       // Bob escrows his option in the swap
-      const { payout: payoutP, outcome: daveSwapInviteP } = await E(zoe).offer(
-        bobSwapInvite,
+      const bobSeatP = await E(zoe).offer(
+        bobSwapInvitation,
         bobProposalSwap,
         bobSwapPayments,
       );
-
+      const daveSwapInvitationP = E(bobSeatP).getOfferResult();
       // Bob makes an offer to the swap with his "higher order"
-      log('swap invite made');
-      await E(daveP).doSwapForOption(daveSwapInviteP, optionAmounts);
+      log('swap invitation made');
+      await E(daveP).doSwapForOption(daveSwapInvitationP, optionAmounts);
 
-      const bobResult = await payoutP;
-      const bucksPayout = await bobResult.Price;
+      const bucksPayout = await E(bobSeatP).getPayout('Price');
 
       // Bob deposits his winnings
       await E(bucksPurseP).deposit(bucksPayout);
@@ -233,18 +219,18 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       await showPurseBalance(simoleanPurseP, 'bobSimoleanPurse', log);
       await showPurseBalance(bucksPurseP, 'bobBucksPurse;', log);
     },
-    doPublicAuction: async inviteP => {
-      const invite = await inviteP;
-      const exclInvite = await E(inviteIssuer).claim(invite);
-      const { value: inviteValue } = await E(inviteIssuer).getAmountOf(
-        exclInvite,
+    doPublicAuction: async invitation => {
+      const instance = await E(zoe).getInstance(invitation);
+      const installation = await E(zoe).getInstallation(invitation);
+      const terms = await E(zoe).getTerms(instance);
+      const issuerKeywordRecord = await E(zoe).getIssuers(instance);
+      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const { value: invitationValue } = await E(invitationIssuer).getAmountOf(
+        exclInvitation,
       );
 
-      const { installationHandle, issuerKeywordRecord, terms } = await E(
-        zoe,
-      ).getInstanceRecord(inviteValue[0].instanceHandle);
       assert(
-        installationHandle === installations.publicAuction,
+        installation === installations.publicAuction,
         details`wrong installation`,
       );
       assert(
@@ -255,8 +241,8 @@ const build = async (zoe, issuers, payments, installations, timer) => {
         details`issuerKeywordRecord was not as expected`,
       );
       assert(terms.numBidsAllowed === 3, details`terms not as expected`);
-      assert(sameStructure(inviteValue[0].minimumBid, simoleans(3)));
-      assert(sameStructure(inviteValue[0].auctionedAssets, moola(1)));
+      assert(sameStructure(invitationValue[0].minimumBid, simoleans(3)));
+      assert(sameStructure(invitationValue[0].auctionedAssets, moola(1)));
 
       const proposal = harden({
         want: { Asset: moola(1) },
@@ -264,17 +250,16 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       });
       const paymentKeywordRecord = { Bid: simoleanPayment };
 
-      const { payout: payoutP, outcome: outcomeP } = await E(zoe).offer(
-        exclInvite,
+      const seatP = await E(zoe).offer(
+        exclInvitation,
         proposal,
         paymentKeywordRecord,
       );
 
-      log(await outcomeP);
+      log(`Bob: ${await E(seatP).getOfferResult()}`);
 
-      const bobResult = await payoutP;
-      const moolaPayout = await bobResult.Asset;
-      const simoleanPayout = await bobResult.Bid;
+      const moolaPayout = await E(seatP).getPayout('Asset');
+      const simoleanPayout = await E(seatP).getPayout('Bid');
 
       await E(moolaPurseP).deposit(moolaPayout);
       await E(simoleanPurseP).deposit(simoleanPayout);
@@ -282,18 +267,17 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       await showPurseBalance(moolaPurseP, 'bobMoolaPurse', log);
       await showPurseBalance(simoleanPurseP, 'bobSimoleanPurse', log);
     },
-    doAtomicSwap: async inviteP => {
-      const invite = await inviteP;
-      const exclInvite = await E(inviteIssuer).claim(invite);
-      const { value: inviteValue } = await E(inviteIssuer).getAmountOf(
-        exclInvite,
+    doAtomicSwap: async invitation => {
+      const instance = await E(zoe).getInstance(invitation);
+      const installation = await E(zoe).getInstallation(invitation);
+      const issuerKeywordRecord = await E(zoe).getIssuers(instance);
+      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const { value: invitationValue } = await E(invitationIssuer).getAmountOf(
+        exclInvitation,
       );
 
-      const { installationHandle, issuerKeywordRecord } = await E(
-        zoe,
-      ).getInstanceRecord(inviteValue[0].instanceHandle);
       assert(
-        installationHandle === installations.atomicSwap,
+        installation === installations.atomicSwap,
         details`wrong installation`,
       );
       assert(
@@ -305,11 +289,11 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       );
 
       assert(
-        sameStructure(inviteValue[0].asset, moola(3)),
+        sameStructure(invitationValue[0].asset, moola(3)),
         details`Alice made a different offer than expected`,
       );
       assert(
-        sameStructure(inviteValue[0].price, simoleans(7)),
+        sameStructure(invitationValue[0].price, simoleans(7)),
         details`Alice made a different offer than expected`,
       );
 
@@ -319,17 +303,16 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       });
       const paymentKeywordRecord = { Price: simoleanPayment };
 
-      const { payout: payoutP, outcome: outcomeP } = await E(zoe).offer(
-        exclInvite,
+      const seatP = await E(zoe).offer(
+        exclInvitation,
         proposal,
         paymentKeywordRecord,
       );
 
-      log(await outcomeP);
+      log(await E(seatP).getOfferResult());
 
-      const bobResult = await payoutP;
-      const moolaPayout = await bobResult.Asset;
-      const simoleanPayout = await bobResult.Price;
+      const moolaPayout = await E(seatP).getPayout('Asset');
+      const simoleanPayout = await E(seatP).getPayout('Price');
 
       await E(moolaPurseP).deposit(moolaPayout);
       await E(simoleanPurseP).deposit(simoleanPayout);
@@ -337,18 +320,15 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       await showPurseBalance(moolaPurseP, 'bobMoolaPurse', log);
       await showPurseBalance(simoleanPurseP, 'bobSimoleanPurse', log);
     },
-    doSimpleExchange: async inviteP => {
-      const invite = await inviteP;
-      const exclInvite = await E(inviteIssuer).claim(invite);
-      const { value: inviteValue } = await E(inviteIssuer).getAmountOf(
-        exclInvite,
-      );
 
-      const { installationHandle, issuerKeywordRecord } = await E(
-        zoe,
-      ).getInstanceRecord(inviteValue[0].instanceHandle);
+    doSimpleExchange: async invitation => {
+      const instance = await E(zoe).getInstance(invitation);
+      const installation = await E(zoe).getInstallation(invitation);
+      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const issuerKeywordRecord = await E(zoe).getIssuers(instance);
+
       assert(
-        installationHandle === installations.simpleExchange,
+        installation === installations.simpleExchange,
         details`wrong installation`,
       );
       assert(
@@ -367,17 +347,16 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       });
       const paymentKeywordRecord = { Price: simoleanPayment };
 
-      const { payout: payoutP, outcome: outcomeP } = await E(zoe).offer(
-        exclInvite,
+      const seatP = await E(zoe).offer(
+        exclInvitation,
         bobBuyOrderProposal,
         paymentKeywordRecord,
       );
 
-      log(await outcomeP);
+      log(await E(seatP).getOfferResult());
 
-      const bobResult = await payoutP;
-      const moolaPayout = await bobResult.Asset;
-      const simoleanPayout = await bobResult.Price;
+      const moolaPayout = await E(seatP).getPayout('Asset');
+      const simoleanPayout = await E(seatP).getPayout('Price');
 
       await E(moolaPurseP).deposit(moolaPayout);
       await E(simoleanPurseP).deposit(simoleanPayout);
@@ -385,14 +364,14 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       await showPurseBalance(moolaPurseP, 'bobMoolaPurse', log);
       await showPurseBalance(simoleanPurseP, 'bobSimoleanPurse', log);
     },
-    doSimpleExchangeUpdates: async (inviteP, m, s) => {
-      const invite = await E(inviteIssuer).claim(inviteP);
-      const { value: inviteValue } = await E(inviteIssuer).getAmountOf(invite);
-      const { installationHandle, issuerKeywordRecord } = await E(
-        zoe,
-      ).getInstanceRecord(inviteValue[0].instanceHandle);
+    doSimpleExchangeUpdates: async (invitationP, m, s) => {
+      const invitation = await E(invitationIssuer).claim(invitationP);
+      const instance = await E(zoe).getInstance(invitation);
+      const installation = await E(zoe).getInstallation(invitation);
+      const issuerKeywordRecord = await E(zoe).getIssuers(instance);
+
       assert(
-        installationHandle === installations.simpleExchange,
+        installation === installations.simpleExchange,
         details`wrong installation`,
       );
       assert(
@@ -413,31 +392,38 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       }
       const simoleanPayment2 = await E(simoleanPurseP).withdraw(simoleans(s));
       const paymentKeywordRecord = { Price: simoleanPayment2 };
-      const { payout: payoutP, outcome: outcomeP } = await E(zoe).offer(
-        invite,
+      const seatP = await E(zoe).offer(
+        invitation,
         bobBuyOrderProposal,
         paymentKeywordRecord,
       );
 
-      log(await outcomeP);
+      log(await E(seatP).getOfferResult());
 
-      payoutP.then(async bobResult => {
-        E(moolaPurseP).deposit(await bobResult.Asset);
-        E(simoleanPurseP).deposit(await bobResult.Price);
-      });
-
+      E(seatP)
+        .getPayout('Asset')
+        .then(moolaPayout => {
+          E(moolaPurseP).deposit(moolaPayout);
+        });
+      E(seatP)
+        .getPayout('Price')
+        .then(simoleanPayout => {
+          E(simoleanPurseP).deposit(simoleanPayout);
+        });
       await showPurseBalance(moolaPurseP, 'bobMoolaPurse', log);
       await showPurseBalance(simoleanPurseP, 'bobSimoleanPurse', log);
     },
-    doAutoswap: async instanceHandle => {
-      const { installationHandle, issuerKeywordRecord, publicAPI } = await E(
-        zoe,
-      ).getInstanceRecord(instanceHandle);
+
+    doAutoswap: async instance => {
+      const publicFacet = await E(zoe).getPublicFacet(instance);
+      const buyBInvitation = await E(publicFacet).makeSwapInvitation();
+      const installation = await E(zoe).getInstallation(buyBInvitation);
+      const issuerKeywordRecord = await E(zoe).getIssuers(instance);
       assert(
-        installationHandle === installations.autoswap,
+        installation === installations.autoswap,
         details`wrong installation`,
       );
-      const liquidityIssuer = await E(publicAPI).getLiquidityIssuer();
+      const liquidityIssuer = await E(publicFacet).getLiquidityIssuer();
       assert(
         sameStructure(
           harden({
@@ -451,13 +437,11 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       );
 
       // bob checks the price of 3 moola. The price is 1 simolean
-      const simoleanAmounts = await E(publicAPI).getCurrentPrice(
+      const simoleanAmounts = await E(publicFacet).getCurrentPrice(
         moola(3),
         simoleans(0).brand,
       );
       log(`simoleanAmounts `, simoleanAmounts);
-
-      const buyBInvite = E(publicAPI).makeSwapInvite();
 
       const moolaForSimProposal = harden({
         give: { In: moola(3) },
@@ -465,20 +449,22 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       });
 
       const moolaForSimPayments = harden({ In: moolaPayment });
-      const { payout: moolaForSimPayoutP, outcome: outcomeP } = await E(
-        zoe,
-      ).offer(buyBInvite, moolaForSimProposal, moolaForSimPayments);
+      const buySeatP = await E(zoe).offer(
+        buyBInvitation,
+        moolaForSimProposal,
+        moolaForSimPayments,
+      );
 
-      log(await outcomeP);
-      const moolaForSimPayout = await moolaForSimPayoutP;
-      const moolaPayout1 = await moolaForSimPayout.In;
-      const simoleanPayout1 = await moolaForSimPayout.Out;
+      log(await E(buySeatP).getOfferResult());
 
-      await E(moolaPurseP).deposit(moolaPayout1);
-      await E(simoleanPurseP).deposit(simoleanPayout1);
+      const moolaPayout1 = await E(buySeatP).getPayout('In');
+      const simoleanPayout1 = await E(buySeatP).getPayout('Out');
+
+      await E(moolaPurseP).deposit(await moolaPayout1);
+      await E(simoleanPurseP).deposit(await simoleanPayout1);
 
       // Bob looks up the price of 3 simoleans. It's 5 moola
-      const moolaAmounts = await E(publicAPI).getCurrentPrice(
+      const moolaAmounts = await E(publicFacet).getCurrentPrice(
         simoleans(3),
         moola(0).brand,
       );
@@ -492,22 +478,18 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       await E(simoleanPurseP).deposit(simoleanPayment);
       const bobSimoleanPayment = await E(simoleanPurseP).withdraw(simoleans(3));
       const simsForMoolaPayments = harden({ In: bobSimoleanPayment });
-      const invite2 = E(publicAPI).makeSwapInvite();
+      const invitation2 = E(publicFacet).makeSwapInvitation();
 
-      const {
-        payout: bobSimsForMoolaPayoutP,
-        outcome: simsForMoolaOutcomeP,
-      } = await E(zoe).offer(
-        invite2,
+      const swapSeat2 = await E(zoe).offer(
+        invitation2,
         bobSimsForMoolaProposal,
         simsForMoolaPayments,
       );
 
-      log(await simsForMoolaOutcomeP);
+      log(await E(swapSeat2).getOfferResult());
 
-      const simsForMoolaPayout = await bobSimsForMoolaPayoutP;
-      const moolaPayout2 = await simsForMoolaPayout.Out;
-      const simoleanPayout2 = await simsForMoolaPayout.In;
+      const moolaPayout2 = await E(swapSeat2).getPayout('Out');
+      const simoleanPayout2 = await E(swapSeat2).getPayout('In');
 
       await E(moolaPurseP).deposit(moolaPayout2);
       await E(simoleanPurseP).deposit(simoleanPayout2);
@@ -515,30 +497,21 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       await showPurseBalance(moolaPurseP, 'bobMoolaPurse', log);
       await showPurseBalance(simoleanPurseP, 'bobSimoleanPurse', log);
     },
-    doBuyTickets: async ticketSalesInstanceHandle => {
-      const { publicAPI: ticketSalesPublicAPI, terms } = await E(
-        zoe,
-      ).getInstanceRecord(ticketSalesInstanceHandle);
-      const ticketIssuer = await E(ticketSalesPublicAPI).getItemsIssuer();
+
+    doBuyTickets: async (instance, invitation) => {
+      const publicFacet = await E(zoe).getPublicFacet(instance);
+      const terms = await E(zoe).getTerms(instance);
+      const ticketIssuer = await E(publicFacet).getItemsIssuer();
       const ticketAmountMath = await makeLocalAmountMath(ticketIssuer);
 
-      // Bob makes an invite
-      const invite = await E(ticketSalesPublicAPI).makeBuyerInvitation();
-
-      const availableTickets = await E(
-        ticketSalesPublicAPI,
-      ).getAvailableItems();
+      const availableTickets = await E(publicFacet).getAvailableItems();
       log('availableTickets: ', availableTickets);
-
       // find the value corresponding to ticket #1
       const ticket1Value = availableTickets.value.find(
         ticket => ticket.number === 1,
       );
       // make the corresponding amount
-      const ticket1Amount = await E(ticketAmountMath).make(
-        harden([ticket1Value]),
-      );
-
+      const ticket1Amount = ticketAmountMath.make(harden([ticket1Value]));
       const proposal = harden({
         give: { Money: terms.pricePerItem },
         want: { Items: ticket1Amount },
@@ -546,20 +519,21 @@ const build = async (zoe, issuers, payments, installations, timer) => {
 
       const paymentKeywordRecord = harden({ Money: moolaPayment });
 
-      const { payout: payoutP } = await E(zoe).offer(
-        invite,
+      const seat = await E(zoe).offer(
+        invitation,
         proposal,
         paymentKeywordRecord,
       );
-      const payout = await payoutP;
       const boughtTicketAmount = await E(ticketIssuer).getAmountOf(
-        payout.Items,
+        E(seat).getPayout('Items'),
       );
       log('boughtTicketAmount: ', boughtTicketAmount);
     },
   });
 };
 
-export function buildRootObject(_vatPowers) {
-  return harden({ build });
+export function buildRootObject(vatPowers) {
+  return harden({
+    build: (...args) => build(vatPowers.testLog, ...args),
+  });
 }

--- a/packages/swingset-runner/demo/zoeTests/vat-bob.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-bob.js
@@ -2,7 +2,7 @@ import { E } from '@agoric/eventual-send';
 import { assert, details } from '@agoric/assert';
 import { sameStructure } from '@agoric/same-structure';
 import { makeLocalAmountMath } from '@agoric/ertp';
-import { showPurseBalance, setupIssuers } from '../helpers';
+import { showPurseBalance, setupIssuers } from './helpers';
 
 const build = async (log, zoe, issuers, payments, installations, timer) => {
   const {

--- a/packages/swingset-runner/demo/zoeTests/vat-carol.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-carol.js
@@ -1,7 +1,7 @@
 import { E } from '@agoric/eventual-send';
 import { assert, details } from '@agoric/assert';
 import { sameStructure } from '@agoric/same-structure';
-import { showPurseBalance, setupIssuers } from '../helpers';
+import { showPurseBalance, setupIssuers } from './helpers';
 
 const build = async (log, zoe, issuers, payments, installations) => {
   const { moola, simoleans, purses } = await setupIssuers(zoe, issuers);

--- a/packages/swingset-runner/demo/zoeTests/vat-carol.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-carol.js
@@ -1,30 +1,28 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 import { assert, details } from '@agoric/assert';
 import { sameStructure } from '@agoric/same-structure';
-import { showPurseBalance, setupIssuers } from './helpers';
-import { makePrintLog } from './printLog';
+import { showPurseBalance, setupIssuers } from '../helpers';
 
-const log = makePrintLog();
-
-const build = async (zoe, issuers, payments, installations) => {
+const build = async (log, zoe, issuers, payments, installations) => {
   const { moola, simoleans, purses } = await setupIssuers(zoe, issuers);
   const [moolaPurseP, simoleanPurseP] = purses;
   const [_moolaPayment, simoleanPayment] = payments;
   const [moolaIssuer, simoleanIssuer] = issuers;
-  const inviteIssuer = await E(zoe).getInvitationIssuer();
+  const invitationIssuer = await E(zoe).getInvitationIssuer();
 
   return harden({
-    doPublicAuction: async inviteP => {
-      const invite = await E(inviteIssuer).claim(inviteP);
-      const { value: inviteValue } = await E(inviteIssuer).getAmountOf(invite);
+    doPublicAuction: async invitationP => {
+      const invitation = await E(invitationIssuer).claim(invitationP);
+      const instance = await E(zoe).getInstance(invitation);
+      const installation = await E(zoe).getInstallation(invitation);
+      const terms = await E(zoe).getTerms(instance);
+      const issuerKeywordRecord = await E(zoe).getIssuers(instance);
+      const { value: invitationValue } = await E(invitationIssuer).getAmountOf(
+        invitation,
+      );
 
-      const { installationHandle, terms, issuerKeywordRecord } = await E(
-        zoe,
-      ).getInstanceRecord(inviteValue[0].instanceHandle);
       assert(
-        installationHandle === installations.publicAuction,
+        installation === installations.publicAuction,
         details`wrong installation`,
       );
       assert(
@@ -35,8 +33,8 @@ const build = async (zoe, issuers, payments, installations) => {
         details`issuerKeywordRecord were not as expected`,
       );
       assert(terms.numBidsAllowed === 3, details`terms not as expected`);
-      assert(sameStructure(inviteValue[0].minimumBid, simoleans(3)));
-      assert(sameStructure(inviteValue[0].auctionedAssets, moola(1)));
+      assert(sameStructure(invitationValue[0].minimumBid, simoleans(3)));
+      assert(sameStructure(invitationValue[0].auctionedAssets, moola(1)));
 
       const proposal = harden({
         want: { Asset: moola(1) },
@@ -45,17 +43,16 @@ const build = async (zoe, issuers, payments, installations) => {
       });
       const paymentKeywordRecord = { Bid: simoleanPayment };
 
-      const { payout: payoutP, outcome: outcomeP } = await E(zoe).offer(
-        invite,
+      const seatP = await E(zoe).offer(
+        invitation,
         proposal,
         paymentKeywordRecord,
       );
 
-      log(await outcomeP);
+      log(`Carol: ${await E(seatP).getOfferResult()}`);
 
-      const carolResult = await payoutP;
-      const moolaPayout = await carolResult.Asset;
-      const simoleanPayout = await carolResult.Bid;
+      const moolaPayout = await E(seatP).getPayout('Asset');
+      const simoleanPayout = await E(seatP).getPayout('Bid');
 
       await E(moolaPurseP).deposit(moolaPayout);
       await E(simoleanPurseP).deposit(simoleanPayout);
@@ -66,6 +63,8 @@ const build = async (zoe, issuers, payments, installations) => {
   });
 };
 
-export function buildRootObject(_vatPowers) {
-  return harden({ build });
+export function buildRootObject(vatPowers) {
+  return harden({
+    build: (...args) => build(vatPowers.testLog, ...args),
+  });
 }

--- a/packages/swingset-runner/demo/zoeTests/vat-carol.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-carol.js
@@ -3,6 +3,8 @@ import { assert, details } from '@agoric/assert';
 import { sameStructure } from '@agoric/same-structure';
 import { showPurseBalance, setupIssuers } from './helpers';
 
+import { makePrintLog } from './printLog';
+
 const build = async (log, zoe, issuers, payments, installations) => {
   const { moola, simoleans, purses } = await setupIssuers(zoe, issuers);
   const [moolaPurseP, simoleanPurseP] = purses;
@@ -63,8 +65,8 @@ const build = async (log, zoe, issuers, payments, installations) => {
   });
 };
 
-export function buildRootObject(vatPowers) {
+export function buildRootObject(_vatPowers) {
   return harden({
-    build: (...args) => build(vatPowers.testLog, ...args),
+    build: (...args) => build(makePrintLog(), ...args),
   });
 }

--- a/packages/swingset-runner/demo/zoeTests/vat-dave.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-dave.js
@@ -3,6 +3,8 @@ import { assert, details } from '@agoric/assert';
 import { sameStructure } from '@agoric/same-structure';
 import { showPurseBalance, setupIssuers } from './helpers';
 
+import { makePrintLog } from './printLog';
+
 const build = async (log, zoe, issuers, payments, installations, timer) => {
   const {
     moola,
@@ -180,8 +182,8 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
   });
 };
 
-export function buildRootObject(vatPowers) {
+export function buildRootObject(_vatPowers) {
   return harden({
-    build: (...args) => build(vatPowers.testLog, ...args),
+    build: (...args) => build(makePrintLog(), ...args),
   });
 }

--- a/packages/swingset-runner/demo/zoeTests/vat-dave.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-dave.js
@@ -1,14 +1,9 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 import { assert, details } from '@agoric/assert';
 import { sameStructure } from '@agoric/same-structure';
-import { showPurseBalance, setupIssuers } from './helpers';
-import { makePrintLog } from './printLog';
+import { showPurseBalance, setupIssuers } from '../helpers';
 
-const log = makePrintLog();
-
-const build = async (zoe, issuers, payments, installations, timer) => {
+const build = async (log, zoe, issuers, payments, installations, timer) => {
   const {
     moola,
     simoleans,
@@ -20,21 +15,20 @@ const build = async (zoe, issuers, payments, installations, timer) => {
   const [moolaPurseP, simoleanPurseP, bucksPurseP] = purses;
   const [_moolaPayment, simoleanPayment, bucksPayment] = payments;
   const [moolaIssuer, simoleanIssuer, bucksIssuer] = issuers;
-  const inviteIssuer = await E(zoe).getInvitationIssuer();
+  const invitationIssuer = await E(zoe).getInvitationIssuer();
 
   return harden({
-    doPublicAuction: async inviteP => {
-      const invite = await inviteP;
-      const exclInvite = await E(inviteIssuer).claim(invite);
-      const { value: inviteValue } = await E(inviteIssuer).getAmountOf(
-        exclInvite,
+    doPublicAuction: async invitation => {
+      const instance = await E(zoe).getInstance(invitation);
+      const installation = await E(zoe).getInstallation(invitation);
+      const issuerKeywordRecord = await E(zoe).getIssuers(instance);
+      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const { value: invitationValue } = await E(invitationIssuer).getAmountOf(
+        exclInvitation,
       );
 
-      const { installationHandle, terms, issuerKeywordRecord } = await E(
-        zoe,
-      ).getInstanceRecord(inviteValue[0].instanceHandle);
       assert(
-        installationHandle === installations.publicAuction,
+        installation === installations.publicAuction,
         details`wrong installation`,
       );
       assert(
@@ -44,9 +38,10 @@ const build = async (zoe, issuers, payments, installations, timer) => {
         ),
         details`issuerKeywordRecord were not as expected`,
       );
+      const terms = await E(zoe).getTerms(instance);
       assert(terms.numBidsAllowed === 3, details`terms not as expected`);
-      assert(sameStructure(inviteValue[0].minimumBid, simoleans(3)));
-      assert(sameStructure(inviteValue[0].auctionedAssets, moola(1)));
+      assert(sameStructure(invitationValue[0].minimumBid, simoleans(3)));
+      assert(sameStructure(invitationValue[0].auctionedAssets, moola(1)));
 
       const proposal = harden({
         want: { Asset: moola(1) },
@@ -55,17 +50,16 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       });
       const paymentKeywordRecord = { Bid: simoleanPayment };
 
-      const { payout: payoutP, outcome: outcomeP } = await E(zoe).offer(
-        exclInvite,
+      const seatP = await E(zoe).offer(
+        exclInvitation,
         proposal,
         paymentKeywordRecord,
       );
 
-      log(await outcomeP);
+      log(`Dave: ${await E(seatP).getOfferResult()}`);
 
-      const daveResult = await payoutP;
-      const moolaPayout = await daveResult.Asset;
-      const simoleanPayout = await daveResult.Bid;
+      const moolaPayout = await E(seatP).getPayout('Asset');
+      const simoleanPayout = await E(seatP).getPayout('Bid');
 
       await E(moolaPurseP).deposit(moolaPayout);
       await E(simoleanPurseP).deposit(simoleanPayout);
@@ -73,45 +67,38 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       await showPurseBalance(moolaPurseP, 'daveMoolaPurse', log);
       await showPurseBalance(simoleanPurseP, 'daveSimoleanPurse', log);
     },
-    doSwapForOption: async (inviteP, optionAmounts) => {
+
+    doSwapForOption: async (invitation, optionAmounts) => {
       // Dave is looking to buy the option to trade his 7 simoleans for
       // 3 moola, and is willing to pay 1 buck for the option.
-      const invite = await inviteP;
-      const exclInvite = await E(inviteIssuer).claim(invite);
-      const { value: inviteValue } = await E(inviteIssuer).getAmountOf(
-        exclInvite,
+      const instance = await E(zoe).getInstance(invitation);
+      const installation = await E(zoe).getInstallation(invitation);
+      const issuerKeywordRecord = await E(zoe).getIssuers(instance);
+      const exclInvitation = await E(invitationIssuer).claim(invitation);
+      const { value: invitationValue } = await E(invitationIssuer).getAmountOf(
+        exclInvitation,
       );
-      const getInstanceHandle = iP =>
-        E(inviteIssuer)
-          .getAmountOf(iP)
-          .then(amount => amount.value[0].instanceHandle);
-      const instanceHandle = await getInstanceHandle(exclInvite);
-      const { installationHandle, issuerKeywordRecord } = await E(
-        zoe,
-      ).getInstanceRecord(instanceHandle);
-      const installationBundle = await E(zoe).getInstallation(
-        installationHandle,
-      );
+      const { source } = await E(installation).getBundle();
       // pick some arbitrary code points as a signature.
       assert(
-        installationBundle.source.includes('asset: give.Asset,'),
+        source.includes('asset: give.Asset,'),
         details`source bundle didn't match at "asset: give.Asset,"`,
       );
       assert(
-        installationBundle.source.includes('firstOfferExpected'),
-        details`source bundle didn't match at "firstOfferExpected"`,
+        source.includes('firstProposalExpected'),
+        details`source bundle didn't match at "firstProposalExpected"`,
       );
       assert(
-        installationBundle.source.includes('makeMatchingInvite'),
-        details`source bundle didn't match at "makeMatchingInvite"`,
+        source.includes('makeMatchingInvitation'),
+        details`source bundle didn't match at "makeMatchingInvitation"`,
       );
       assert(
-        installationHandle === installations.atomicSwap,
+        installation === installations.atomicSwap,
         details`wrong installation`,
       );
       assert(
         sameStructure(
-          harden({ Asset: inviteIssuer, Price: bucksIssuer }),
+          harden({ Asset: invitationIssuer, Price: bucksIssuer }),
           issuerKeywordRecord,
         ),
         details`issuerKeywordRecord were not as expected`,
@@ -120,17 +107,17 @@ const build = async (zoe, issuers, payments, installations, timer) => {
       // Dave expects that Bob has already made an offer in the swap
       // with the following rules:
       assert(
-        sameStructure(inviteValue[0].asset, optionAmounts),
+        sameStructure(invitationValue[0].asset, optionAmounts),
         details`asset is the option`,
       );
       assert(
-        sameStructure(inviteValue[0].price, bucks(1)),
+        sameStructure(invitationValue[0].price, bucks(1)),
         details`price is 1 buck`,
       );
       const optionValue = optionAmounts.value;
       assert(
         optionValue[0].description === 'exerciseOption',
-        details`wrong invite`,
+        details`wrong invitation`,
       );
       assert(
         moolaAmountMath.isEqual(optionValue[0].underlyingAsset, moola(3)),
@@ -152,15 +139,16 @@ const build = async (zoe, issuers, payments, installations, timer) => {
         give: { Price: bucks(1) },
       });
       const daveSwapPayments = harden({ Price: bucksPayment });
-      const { payout: daveSwapPayoutP, outcome: daveSwapOutcomeP } = await E(
-        zoe,
-      ).offer(exclInvite, daveSwapProposal, daveSwapPayments);
+      const seatP = await E(zoe).offer(
+        exclInvitation,
+        daveSwapProposal,
+        daveSwapPayments,
+      );
 
-      log(await daveSwapOutcomeP);
+      log(await E(seatP).getOfferResult());
 
-      const daveSwapPayout = await daveSwapPayoutP;
-      const daveOption = await daveSwapPayout.Asset;
-      const daveBucksPayout = await daveSwapPayout.Price;
+      const daveOption = await E(seatP).getPayout('Asset');
+      const daveBucksPayout = await E(seatP).getPayout('Price');
 
       // Dave exercises his option by making an offer to the covered
       // call. First, he escrows with Zoe.
@@ -170,20 +158,16 @@ const build = async (zoe, issuers, payments, installations, timer) => {
         give: { StrikePrice: simoleans(7) },
       });
       const daveCoveredCallPayments = harden({ StrikePrice: simoleanPayment });
-      const {
-        payout: daveCoveredCallPayoutP,
-        outcome: daveCoveredCallOutcomeP,
-      } = await E(zoe).offer(
+      const optionSeatP = await E(zoe).offer(
         daveOption,
         daveCoveredCallProposal,
         daveCoveredCallPayments,
       );
 
-      log(await daveCoveredCallOutcomeP);
+      log(await E(optionSeatP).getOfferResult());
 
-      const daveCoveredCallResult = await daveCoveredCallPayoutP;
-      const moolaPayout = await daveCoveredCallResult.UnderlyingAsset;
-      const simoleanPayout = await daveCoveredCallResult.StrikePrice;
+      const moolaPayout = await E(optionSeatP).getPayout('UnderlyingAsset');
+      const simoleanPayout = await E(optionSeatP).getPayout('StrikePrice');
 
       await E(bucksPurseP).deposit(daveBucksPayout);
       await E(moolaPurseP).deposit(moolaPayout);
@@ -196,6 +180,8 @@ const build = async (zoe, issuers, payments, installations, timer) => {
   });
 };
 
-export function buildRootObject(_vatPowers) {
-  return harden({ build });
+export function buildRootObject(vatPowers) {
+  return harden({
+    build: (...args) => build(vatPowers.testLog, ...args),
+  });
 }

--- a/packages/swingset-runner/demo/zoeTests/vat-dave.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-dave.js
@@ -1,7 +1,7 @@
 import { E } from '@agoric/eventual-send';
 import { assert, details } from '@agoric/assert';
 import { sameStructure } from '@agoric/same-structure';
-import { showPurseBalance, setupIssuers } from '../helpers';
+import { showPurseBalance, setupIssuers } from './helpers';
 
 const build = async (log, zoe, issuers, payments, installations, timer) => {
   const {

--- a/packages/swingset-runner/demo/zoeTests/vat-zoe.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-zoe.js
@@ -1,9 +1,8 @@
-/* global harden */
+// noinspection ES6PreferShortImport
+import { makeZoe } from '../../../src/zoeService/zoe';
 
-import { makeZoe } from '@agoric/zoe';
-
-export function buildRootObject(_vatPowers, vatParameters) {
+export function buildRootObject(_vatPowers) {
   return harden({
-    buildZoe: vatAdminSvc => makeZoe(vatAdminSvc, vatParameters.zcfBundleName),
+    buildZoe: vatAdminSvc => makeZoe(vatAdminSvc),
   });
 }

--- a/packages/swingset-runner/demo/zoeTests/vat-zoe.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-zoe.js
@@ -1,5 +1,5 @@
 // noinspection ES6PreferShortImport
-import { makeZoe } from '../../../src/zoeService/zoe';
+import { makeZoe } from '@agoric/zoe';
 
 export function buildRootObject(_vatPowers) {
   return harden({

--- a/packages/swingset-runner/demo/zoeTests/vat-zoe.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-zoe.js
@@ -1,7 +1,7 @@
 // noinspection ES6PreferShortImport
 import { makeZoe } from '@agoric/zoe';
 
-export function buildRootObject(__vatPowers) {
+export function buildRootObject(_vatPowers) {
   return harden({
     buildZoe: vatAdminSvc => makeZoe(vatAdminSvc),
   });

--- a/packages/swingset-runner/demo/zoeTests/vat-zoe.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-zoe.js
@@ -1,7 +1,7 @@
 // noinspection ES6PreferShortImport
 import { makeZoe } from '@agoric/zoe';
 
-export function buildRootObject(_vatPowers) {
+export function buildRootObject(__vatPowers) {
   return harden({
     buildZoe: vatAdminSvc => makeZoe(vatAdminSvc),
   });

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -70,6 +70,7 @@
       "import/prefer-default-export": "off"
     },
     "globals": {
+      "harden": "readonly",
       "BigInt": "readonly"
     }
   },

--- a/packages/swingset-runner/src/vat-launcher.js
+++ b/packages/swingset-runner/src/vat-launcher.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { E } from '@agoric/eventual-send';
 
 /**

--- a/packages/zoe/test/swingsetTests/zoe-metering/infiniteTestLoop.js
+++ b/packages/zoe/test/swingsetTests/zoe-metering/infiniteTestLoop.js
@@ -1,4 +1,4 @@
-export const start = zcf => {
+export const start = _zcf => {
   const publicFacet = harden({
     doTest: () => {
       for (;;) {

--- a/packages/zoe/test/swingsetTests/zoe/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/zoe/bootstrap.js
@@ -104,23 +104,7 @@ export function buildRootObject(vatPowers, vatParameters) {
         mintAndSellNFT: await E(zoe).install(mintAndSellNFTBundle.bundle),
       };
 
-      const testName = vatParameters.argv[0] || 'simpleExchangeOk';
-      const startingValuesStr = vatParameters.argv[1];
-      let startingValues;
-      if (startingValuesStr) {
-        startingValues = JSON.parse(startingValuesStr);
-      } else if (
-        vatParameters.startingValues &&
-        vatParameters.startingValues[testName]
-      ) {
-        startingValues = vatParameters.startingValues[testName];
-      } else {
-        throw Error(
-          `Cannot find startingValues for ${testName} in ${JSON.stringify(
-            vatParameters,
-          )} or ${JSON.stringify(vatPowers)}`,
-        );
-      }
+      const [testName, startingValues] = vatParameters.argv;
 
       const { aliceP, bobP, carolP, daveP } = makeVats(
         vatPowers.testLog,

--- a/packages/zoe/test/swingsetTests/zoe/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/zoe/bootstrap.js
@@ -104,7 +104,23 @@ export function buildRootObject(vatPowers, vatParameters) {
         mintAndSellNFT: await E(zoe).install(mintAndSellNFTBundle.bundle),
       };
 
-      const [testName, startingValues] = vatParameters.argv;
+      const testName = vatParameters.argv[0] || 'simpleExchangeOk';
+      const startingValuesStr = vatParameters.argv[1];
+      let startingValues;
+      if (startingValuesStr) {
+        startingValues = JSON.parse(startingValuesStr);
+      } else if (
+        vatParameters.startingValues &&
+        vatParameters.startingValues[testName]
+      ) {
+        startingValues = vatParameters.startingValues[testName];
+      } else {
+        throw Error(
+          `Cannot find startingValues for ${testName} in ${JSON.stringify(
+            vatParameters,
+          )} or ${JSON.stringify(vatPowers)}`,
+        );
+      }
 
       const { aliceP, bobP, carolP, daveP } = makeVats(
         vatPowers.testLog,


### PR DESCRIPTION
This takes a fresh copy of `swingset-runner`s Zoe tests from `zoe-release-candidate`, and applies the changes described in https://github.com/Agoric/agoric-sdk/issues/1194

Please see
https://github.com/Agoric/agoric-sdk/pull/1487/files/c5885700..93be4a9b
to review those changes in isolation.

Many of the Zoe typing changes were moved to #1488.

#dapp-encouragement-branch: new-zoe
