### PR TITLE
fix: zcf is unused, so prepend an underscore

### DIFF
--- a/packages/zoe/test/swingsetTests/zoe-metering/infiniteTestLoop.js
+++ b/packages/zoe/test/swingsetTests/zoe-metering/infiniteTestLoop.js
@@ -1,4 +1,4 @@
-export const start = zcf => {
+export const start = _zcf => {
   const publicFacet = harden({
     doTest: () => {
       for (;;) {


### PR DESCRIPTION
lint fix