### PR TITLE
fix: reduce inconsistency among our linting rules

### DIFF
--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -75,6 +75,8 @@
       "function-paren-newline": "off",
       "arrow-parens": "off",
       "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
       "no-console": "off",
       "no-unused-vars": [
         "error",

--- a/packages/SwingSet/.eslintrc.js
+++ b/packages/SwingSet/.eslintrc.js
@@ -1,6 +1,5 @@
 /* global module */
 module.exports = {
-  // parser: "babel-eslint",
   extends: ['airbnb-base', 'plugin:prettier/recommended'],
   env: {
     es6: true, // supports new ES6 globals (e.g., new types such as Set)
@@ -13,12 +12,16 @@ module.exports = {
     'prefer-destructuring': 'off',
     'no-else-return': 'off',
     'no-console': 'off',
-    'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    'no-unused-vars': ['error', {
+      argsIgnorePattern: '^_',
+      varsIgnorePattern: '^_',
+    }],
     'no-return-assign': 'off',
     'no-param-reassign': 'off',
     'no-restricted-syntax': ['off', 'ForOfStatement'],
     'no-unused-expressions': 'off',
     'no-loop-func': 'off',
-    'import/prefer-default-export': 'off', // contrary to Agoric standard
+    'no-inner-declarations': 'off',
+    'import/prefer-default-export': 'off',
   },
 };

--- a/packages/acorn-eventual-send/.eslintrc.js
+++ b/packages/acorn-eventual-send/.eslintrc.js
@@ -9,13 +9,19 @@ module.exports = {
     'function-paren-newline': 'off',
     'arrow-parens': 'off',
     strict: 'off',
+    'prefer-destructuring': 'off',
+    'no-else-return': 'off',
     'no-console': 'off',
-    'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    'no-unused-vars': ['error', {
+      argsIgnorePattern: '^_',
+      varsIgnorePattern: '^_',
+    }],
     'no-return-assign': 'off',
     'no-param-reassign': 'off',
     'no-restricted-syntax': ['off', 'ForOfStatement'],
     'no-unused-expressions': 'off',
     'no-loop-func': 'off',
-    'import/prefer-default-export': 'off', // contrary to Agoric standard
+    'no-inner-declarations': 'off',
+    'import/prefer-default-export': 'off',
   },
 };

--- a/packages/agoric-cli/.eslintrc.js
+++ b/packages/agoric-cli/.eslintrc.js
@@ -9,10 +9,12 @@ module.exports = {
     'function-paren-newline': 'off',
     'arrow-parens': 'off',
     strict: 'off',
+    'prefer-destructuring': 'off',
+    'no-else-return': 'off',
     'no-console': 'off',
     'no-unused-vars': ['error', {
       argsIgnorePattern: '^_',
-      varsIgnorePattern: '^_'
+      varsIgnorePattern: '^_',
     }],
     'no-return-assign': 'off',
     'no-param-reassign': 'off',
@@ -20,6 +22,6 @@ module.exports = {
     'no-unused-expressions': 'off',
     'no-loop-func': 'off',
     'no-inner-declarations': 'off',
-    'import/prefer-default-export': 'off', // contrary to Agoric standard
+    'import/prefer-default-export': 'off',
   },
 };

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -59,6 +59,8 @@
       "function-paren-newline": "off",
       "arrow-parens": "off",
       "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
       "no-console": "off",
       "no-unused-vars": [
         "error",

--- a/packages/captp/.eslintrc.js
+++ b/packages/captp/.eslintrc.js
@@ -9,13 +9,19 @@ module.exports = {
     'function-paren-newline': 'off',
     'arrow-parens': 'off',
     strict: 'off',
+    'prefer-destructuring': 'off',
+    'no-else-return': 'off',
     'no-console': 'off',
-    'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    'no-unused-vars': ['error', {
+      argsIgnorePattern: '^_',
+      varsIgnorePattern: '^_',
+    }],
     'no-return-assign': 'off',
     'no-param-reassign': 'off',
     'no-restricted-syntax': ['off', 'ForOfStatement'],
     'no-unused-expressions': 'off',
     'no-loop-func': 'off',
-    'import/prefer-default-export': 'off', // contrary to Agoric standard
+    'no-inner-declarations': 'off',
+    'import/prefer-default-export': 'off',
   },
 };

--- a/packages/cosmic-swingset/.eslintrc.js
+++ b/packages/cosmic-swingset/.eslintrc.js
@@ -9,13 +9,19 @@ module.exports = {
     'function-paren-newline': 'off',
     'arrow-parens': 'off',
     strict: 'off',
+    'prefer-destructuring': 'off',
+    'no-else-return': 'off',
     'no-console': 'off',
-    'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    'no-unused-vars': ['error', {
+      argsIgnorePattern: '^_',
+      varsIgnorePattern: '^_',
+    }],
     'no-return-assign': 'off',
     'no-param-reassign': 'off',
     'no-restricted-syntax': ['off', 'ForOfStatement'],
     'no-unused-expressions': 'off',
     'no-loop-func': 'off',
-    'import/prefer-default-export': 'off', // contrary to Agoric standard
+    'no-inner-declarations': 'off',
+    'import/prefer-default-export': 'off',
   },
 };

--- a/packages/dapp-svelte-wallet/api/package.json
+++ b/packages/dapp-svelte-wallet/api/package.json
@@ -45,6 +45,8 @@
       "function-paren-newline": "off",
       "arrow-parens": "off",
       "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
       "no-console": "off",
       "no-unused-vars": [
         "error",

--- a/packages/deployment/.eslintrc.js
+++ b/packages/deployment/.eslintrc.js
@@ -9,13 +9,19 @@ module.exports = {
     'function-paren-newline': 'off',
     'arrow-parens': 'off',
     strict: 'off',
+    'prefer-destructuring': 'off',
+    'no-else-return': 'off',
     'no-console': 'off',
-    'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    'no-unused-vars': ['error', {
+      argsIgnorePattern: '^_',
+      varsIgnorePattern: '^_',
+    }],
     'no-return-assign': 'off',
     'no-param-reassign': 'off',
     'no-restricted-syntax': ['off', 'ForOfStatement'],
     'no-unused-expressions': 'off',
     'no-loop-func': 'off',
-    'import/prefer-default-export': 'off', // contrary to Agoric standard
+    'no-inner-declarations': 'off',
+    'import/prefer-default-export': 'off',
   },
 };

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -53,6 +53,8 @@
       "function-paren-newline": "off",
       "arrow-parens": "off",
       "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
       "no-console": "off",
       "no-unused-vars": [
         "error",
@@ -70,8 +72,8 @@
       "no-unused-expressions": "off",
       "no-loop-func": "off",
       "no-inner-declarations": "off",
-      "import/extensions": "off",
-      "import/prefer-default-export": "off"
+      "import/prefer-default-export": "off",
+      "import/extensions": "off"
     }
   },
   "prettier": {

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -47,6 +47,8 @@
       "function-paren-newline": "off",
       "arrow-parens": "off",
       "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
       "no-console": "off",
       "no-unused-vars": [
         "error",
@@ -64,8 +66,8 @@
       "no-unused-expressions": "off",
       "no-loop-func": "off",
       "no-inner-declarations": "off",
-      "import/extensions": "off",
-      "import/prefer-default-export": "off"
+      "import/prefer-default-export": "off",
+      "import/extensions": "off"
     }
   },
   "prettier": {

--- a/packages/import-manager/package.json
+++ b/packages/import-manager/package.json
@@ -53,6 +53,8 @@
       "function-paren-newline": "off",
       "arrow-parens": "off",
       "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
       "no-console": "off",
       "no-unused-vars": [
         "error",

--- a/packages/install-metering-and-ses/package.json
+++ b/packages/install-metering-and-ses/package.json
@@ -47,6 +47,8 @@
       "function-paren-newline": "off",
       "arrow-parens": "off",
       "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
       "no-console": "off",
       "no-unused-vars": [
         "error",

--- a/packages/install-ses/package.json
+++ b/packages/install-ses/package.json
@@ -44,6 +44,8 @@
       "function-paren-newline": "off",
       "arrow-parens": "off",
       "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
       "no-console": "off",
       "no-unused-vars": [
         "error",

--- a/packages/marshal/.eslintrc.js
+++ b/packages/marshal/.eslintrc.js
@@ -9,16 +9,19 @@ module.exports = {
     'function-paren-newline': 'off',
     'arrow-parens': 'off',
     strict: 'off',
+    'prefer-destructuring': 'off',
+    'no-else-return': 'off',
     'no-console': 'off',
     'no-unused-vars': ['error', {
       argsIgnorePattern: '^_',
-      "varsIgnorePattern": "^_",
+      varsIgnorePattern: '^_',
     }],
     'no-return-assign': 'off',
     'no-param-reassign': 'off',
     'no-restricted-syntax': ['off', 'ForOfStatement'],
     'no-unused-expressions': 'off',
     'no-loop-func': 'off',
-    'import/prefer-default-export': 'off', // contrary to Agoric standard
+    'no-inner-declarations': 'off',
+    'import/prefer-default-export': 'off',
   },
 };

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -61,6 +61,8 @@
       "function-paren-newline": "off",
       "arrow-parens": "off",
       "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
       "no-console": "off",
       "no-unused-vars": [
         "error",

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -55,6 +55,8 @@
       "function-paren-newline": "off",
       "arrow-parens": "off",
       "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
       "no-console": "off",
       "no-unused-vars": [
         "error",

--- a/packages/registrar/package.json
+++ b/packages/registrar/package.json
@@ -53,6 +53,8 @@
       "function-paren-newline": "off",
       "arrow-parens": "off",
       "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
       "no-console": "off",
       "no-unused-vars": [
         "error",

--- a/packages/same-structure/package.json
+++ b/packages/same-structure/package.json
@@ -55,6 +55,8 @@
       "function-paren-newline": "off",
       "arrow-parens": "off",
       "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
       "no-console": "off",
       "no-unused-vars": [
         "error",

--- a/packages/sharing-service/package.json
+++ b/packages/sharing-service/package.json
@@ -54,6 +54,8 @@
       "function-paren-newline": "off",
       "arrow-parens": "off",
       "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
       "no-console": "off",
       "no-unused-vars": [
         "error",

--- a/packages/sparse-ints/package.json
+++ b/packages/sparse-ints/package.json
@@ -50,6 +50,8 @@
       "function-paren-newline": "off",
       "arrow-parens": "off",
       "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
       "no-console": "off",
       "no-unused-vars": [
         "error",

--- a/packages/spawner/package.json
+++ b/packages/spawner/package.json
@@ -64,6 +64,8 @@
       "function-paren-newline": "off",
       "arrow-parens": "off",
       "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
       "no-console": "off",
       "no-unused-vars": [
         "error",

--- a/packages/stat-logger/.eslintrc.js
+++ b/packages/stat-logger/.eslintrc.js
@@ -1,6 +1,5 @@
 /* global module */
 module.exports = {
-  // parser: "babel-eslint",
   extends: ['airbnb-base', 'plugin:prettier/recommended'],
   env: {
     es6: true, // supports new ES6 globals (e.g., new types such as Set)
@@ -10,13 +9,19 @@ module.exports = {
     'function-paren-newline': 'off',
     'arrow-parens': 'off',
     strict: 'off',
+    'prefer-destructuring': 'off',
+    'no-else-return': 'off',
     'no-console': 'off',
-    'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    'no-unused-vars': ['error', {
+      argsIgnorePattern: '^_',
+      varsIgnorePattern: '^_',
+    }],
     'no-return-assign': 'off',
     'no-param-reassign': 'off',
     'no-restricted-syntax': ['off', 'ForOfStatement'],
     'no-unused-expressions': 'off',
     'no-loop-func': 'off',
-    'import/prefer-default-export': 'off', // contrary to Agoric standard
+    'no-inner-declarations': 'off',
+    'import/prefer-default-export': 'off',
   },
 };

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -55,6 +55,8 @@
       "function-paren-newline": "off",
       "arrow-parens": "off",
       "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
       "no-console": "off",
       "no-unused-vars": [
         "error",

--- a/packages/swing-store-lmdb/.eslintrc.js
+++ b/packages/swing-store-lmdb/.eslintrc.js
@@ -1,6 +1,5 @@
 /* global module */
 module.exports = {
-  // parser: "babel-eslint",
   extends: ['airbnb-base', 'plugin:prettier/recommended'],
   env: {
     es6: true, // supports new ES6 globals (e.g., new types such as Set)
@@ -10,13 +9,19 @@ module.exports = {
     'function-paren-newline': 'off',
     'arrow-parens': 'off',
     strict: 'off',
+    'prefer-destructuring': 'off',
+    'no-else-return': 'off',
     'no-console': 'off',
-    'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    'no-unused-vars': ['error', {
+      argsIgnorePattern: '^_',
+      varsIgnorePattern: '^_',
+    }],
     'no-return-assign': 'off',
     'no-param-reassign': 'off',
     'no-restricted-syntax': ['off', 'ForOfStatement'],
     'no-unused-expressions': 'off',
     'no-loop-func': 'off',
-    'import/prefer-default-export': 'off', // contrary to Agoric standard
+    'no-inner-declarations': 'off',
+    'import/prefer-default-export': 'off',
   },
 };

--- a/packages/swing-store-simple/.eslintrc.js
+++ b/packages/swing-store-simple/.eslintrc.js
@@ -1,6 +1,5 @@
 /* global module */
 module.exports = {
-  // parser: "babel-eslint",
   extends: ['airbnb-base', 'plugin:prettier/recommended'],
   env: {
     es6: true, // supports new ES6 globals (e.g., new types such as Set)
@@ -10,13 +9,19 @@ module.exports = {
     'function-paren-newline': 'off',
     'arrow-parens': 'off',
     strict: 'off',
+    'prefer-destructuring': 'off',
+    'no-else-return': 'off',
     'no-console': 'off',
-    'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    'no-unused-vars': ['error', {
+      argsIgnorePattern: '^_',
+      varsIgnorePattern: '^_',
+    }],
     'no-return-assign': 'off',
     'no-param-reassign': 'off',
     'no-restricted-syntax': ['off', 'ForOfStatement'],
     'no-unused-expressions': 'off',
     'no-loop-func': 'off',
-    'import/prefer-default-export': 'off', // contrary to Agoric standard
+    'no-inner-declarations': 'off',
+    'import/prefer-default-export': 'off',
   },
 };

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -40,7 +40,6 @@
       "function-paren-newline": "off",
       "arrow-parens": "off",
       "strict": "off",
-      "no-lonely-if": "off",
       "prefer-destructuring": "off",
       "no-else-return": "off",
       "no-console": "off",
@@ -60,14 +59,15 @@
       "no-unused-expressions": "off",
       "no-loop-func": "off",
       "no-inner-declarations": "off",
+      "import/prefer-default-export": "off",
+      "no-lonely-if": "off",
       "yoda": [
         "error",
         "never",
         {
           "exceptRange": true
         }
-      ],
-      "import/prefer-default-export": "off"
+      ]
     },
     "globals": {
       "harden": "readonly",

--- a/packages/tame-metering/.eslintrc.js
+++ b/packages/tame-metering/.eslintrc.js
@@ -9,13 +9,19 @@ module.exports = {
     'function-paren-newline': 'off',
     'arrow-parens': 'off',
     strict: 'off',
+    'prefer-destructuring': 'off',
+    'no-else-return': 'off',
     'no-console': 'off',
-    'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    'no-unused-vars': ['error', {
+      argsIgnorePattern: '^_',
+      varsIgnorePattern: '^_',
+    }],
     'no-return-assign': 'off',
     'no-param-reassign': 'off',
     'no-restricted-syntax': ['off', 'ForOfStatement'],
     'no-unused-expressions': 'off',
     'no-loop-func': 'off',
-    'import/prefer-default-export': 'off', // contrary to Agoric standard
+    'no-inner-declarations': 'off',
+    'import/prefer-default-export': 'off',
   },
 };

--- a/packages/transform-eventual-send/.eslintrc.js
+++ b/packages/transform-eventual-send/.eslintrc.js
@@ -9,13 +9,19 @@ module.exports = {
     'function-paren-newline': 'off',
     'arrow-parens': 'off',
     strict: 'off',
+    'prefer-destructuring': 'off',
+    'no-else-return': 'off',
     'no-console': 'off',
-    'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    'no-unused-vars': ['error', {
+      argsIgnorePattern: '^_',
+      varsIgnorePattern: '^_',
+    }],
     'no-return-assign': 'off',
     'no-param-reassign': 'off',
     'no-restricted-syntax': ['off', 'ForOfStatement'],
     'no-unused-expressions': 'off',
     'no-loop-func': 'off',
-    'import/prefer-default-export': 'off', // contrary to Agoric standard
+    'no-inner-declarations': 'off',
+    'import/prefer-default-export': 'off',
   },
 };

--- a/packages/transform-metering/.eslintrc.js
+++ b/packages/transform-metering/.eslintrc.js
@@ -9,13 +9,19 @@ module.exports = {
     'function-paren-newline': 'off',
     'arrow-parens': 'off',
     strict: 'off',
+    'prefer-destructuring': 'off',
+    'no-else-return': 'off',
     'no-console': 'off',
-    'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    'no-unused-vars': ['error', {
+      argsIgnorePattern: '^_',
+      varsIgnorePattern: '^_',
+    }],
     'no-return-assign': 'off',
     'no-param-reassign': 'off',
     'no-restricted-syntax': ['off', 'ForOfStatement'],
     'no-unused-expressions': 'off',
     'no-loop-func': 'off',
-    'import/prefer-default-export': 'off', // contrary to Agoric standard
+    'no-inner-declarations': 'off',
+    'import/prefer-default-export': 'off',
   },
 };

--- a/packages/weak-store/package.json
+++ b/packages/weak-store/package.json
@@ -51,6 +51,8 @@
       "function-paren-newline": "off",
       "arrow-parens": "off",
       "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
       "no-console": "off",
       "no-unused-vars": [
         "error",

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -79,6 +79,8 @@
       "function-paren-newline": "off",
       "arrow-parens": "off",
       "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
       "no-console": "off",
       "no-unused-vars": [
         "error",


### PR DESCRIPTION
This gives most packages the same linting rules, whether in a `.eslintrc.js` file or in rules within a `package.json`. These are mostly gathered by unioning the rules that many files had in common. However, there are a few packages that have linting rules that remain specific to that package because I have not investigated how widely applicable they should be. All these are at the end of their `package.json` rules section. The packages are:
   * eventual-send: `"import/extensions": "off"`
   * import-bundle: `"import/extensions": "off"`
   * notifier: `"import/no-extraneous-dependencies": "off"`
   * dapp-svelte-wallet/api: `"import/no-extraneous-dependencies": "off"`
   * swingset-runner: a whole lot of stuff. Look there.
