### PR TITLE
chore(swingset): add test for vat termination

### DIFF
--- a/packages/SwingSet/test/vat-admin/terminate/bootstrap-terminate.js
+++ b/packages/SwingSet/test/vat-admin/terminate/bootstrap-terminate.js
@@ -1,0 +1,152 @@
+/* global harden */
+import { E } from '@agoric/eventual-send';
+
+export function buildRootObject(vatPowers) {
+  const { testLog } = vatPowers;
+
+  const self = harden({
+    async bootstrap(vats, devices) {
+      const vatMaker = E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
+
+      // create a dynamic vat, send it a message and let it respond, to make
+      // sure everything is working
+      const dude = await E(vatMaker).createVatByName('dude');
+      const count1 = await E(dude.root).foo(1);
+      // pushes 'FOO 1' to testLog
+      testLog(`count1 ${count1}`); // 'count1 FOO SAYS 1'
+
+      // get a promise that will never be resolved, at least not until the
+      // vat dies
+      const foreverP = E(dude.root).never();
+      foreverP.then(
+        answer => testLog(`foreverP.then ${answer}`),
+        err => testLog(`foreverP.catch ${err}`),
+      );
+
+      // and pipeline a message to it, which won't ever be delivered because
+      // we haven't configured the vat to enable pipelining. This message
+      // will sit in the kernel promise-table queue until the target
+      // resolves. When the vat is killed, this ought to be rejected too.
+      const afterForeverP = E(foreverP).something();
+      afterForeverP.then(
+        answer => testLog(`afterForeverP.then ${answer}`),
+        err => testLog(`afterForeverP.catch ${err}`),
+      );
+
+      // make it send an outgoing query, both to make sure that works, and
+      // also to make sure never() has been delivered before the vat is
+      // killed
+      const query2 = await E(dude.root).elsewhere(self, 2);
+      // pushes 'QUERY 2', 'GOT QUERY 2', 'ANSWER 2' to testLog
+      testLog(`query2 ${query2}`); // 'query2 2'
+
+      // now we queue up a batch of four messages:
+
+      // the first will trigger another outgoing query ..
+      const query3P = E(dude.root).elsewhere(self, 3);
+      query3P.then(
+        answer => testLog(`3P.then ${answer}`),
+        err => testLog(`3P.catch ${err}`),
+      );
+      // .. but it will be killed ..
+      E(dude.adminNode).terminate();
+      // .. before the third message can be delivered
+      const foo4P = E(dude.root).foo(4);
+      foo4P.then(
+        answer => testLog(`foo4P.then ${answer}`),
+        err => testLog(`foo4P.catch ${err}`),
+      );
+      // then we try to kill the vat again, which should be idempotent
+      // CHIP TODO PHASE1: uncomment, make controlFacet.terminate idempotent
+      // E(dude.adminNode).terminate();
+
+      // the run-queue should now look like:
+      // [dude.elsewhere(3), adminNode.terminate, dude.foo(4), adminNode.terminate]
+
+      // finally we wait for the kernel to tell us that the vat is dead
+      const doneP = E(dude.adminNode).done();
+
+      // first, dude.elsewhere(self, 3) is delivered, which pushes
+      // 'QUERY 3' to testLog, and sends query(). The run-queue should now look like:
+      // [adminNode.terminate, dude.foo(4), adminNode.terminate, self.query(3)]
+
+      // then terminate() is delivered, and the vat is killed. The kernel pushes a
+      // message to vatAdmin to let the done() promise resolve. (PHASE 2) The kernel also
+      // looks for the unresolved promises decided by the late vat, and rejects them,
+      // which pushes notify events on the queue
+      // (PHASE 1) run-queue is:
+      // [dude.foo(4), adminNode.terminate, self.query(3), vatAdmin.fireDone]
+      // (PHASE 2) run-queue is:
+      // [dude.foo(4), adminNode.terminate, self.query(3), vatAdmin.fireDone,
+      //  self.notify(foreverP), self.notify(afterForeverP)]
+
+      // now dude.foo(4) comes up for delivery, and deliverToVat notices the
+      // target is dead, so the kernel rejects the result, pushing another
+      // notify
+      // (PHASE 1) run-queue is:
+      // [adminNode.terminate, self.query(3), vatAdmin.fireDone, self.notify(foo4P)]
+      // (PHASE 2) run-queue is:
+      // [adminNode.terminate, self.query(3), vatAdmin.fireDone,
+      //  self.notify(foreverP), self.notify(afterForeverP), self.notify(foo4P)]
+
+      // now the duplicate terminate() comes up, and vatAdminVat should ignore it
+      // (PHASE 1) run-queue is:
+      // [self.query(3),
+      //  vatAdmin.fireDone, self.notify(foo4P)]
+      // (PHASE 2) run-queue is:
+      // [self.query(3), vatAdmin.fireDone,
+      //  self.notify(foreverP), self.notify(afterForeverP),
+      //  self.notify(foo4P)]
+
+      // now the self.query(3) gets delivered, which pushes 'GOT QUERY 3' onto testLog, and
+      // resolves the result promise. The dead vat is the only subscriber, so the kernel
+      // pushes a notify event to vat-dude for it (which will never be delivered)
+      // (PHASE 1) run-queue is:
+      // [vatAdmin.fireDone,
+      //  self.notify(foo4P), dude.notify(answerP)]
+      // (PHASE 2) run-queue is:
+      // [vatAdmin.fireDone,
+      //  self.notify(foreverP), self.notify(afterForeverP),
+      //  self.notify(foo4P), dude.notify(answerP)]
+
+      // now vatAdmin gets fireDone, which resolves the 'done' promise we've been awaiting for,
+      // which pushes a notify
+      // (PHASE 1) run-queue is:
+      // [self.notify(foo4P), dude.notify(answerP), self.notify(doneP)]
+      // (PHASE 2) run-queue is:
+      // [self.notify(foreverP), self.notify(afterForeverP),
+      //  self.notify(foo4P), dude.notify(answerP), self.notify(doneP)]
+
+      // PHASE 2: we receive the rejection of foreverP, pushing
+      // 'foreverP.catch (err)' to testLog
+      // PHASE 2: we receive the rejection of afterForeverP, pushing
+      // 'afterForeverP.catch (err)' to testLog
+
+      // run-queue is:
+      // [self.notify(foo4P), dude.notify(answerP), self.notify(doneP)]
+
+      // we receive the rejection of foo4P, pushing 'foo4P.catch (err)' to
+      // testLog. The run-queue is:
+      // [dude.notify(answerP), self.notify(doneP)]
+
+      // the dude.notify(answerP) comes to the top of the run-queue, and the
+      // kernel ignores it because the dude is dead. The run-queue is:
+      // [self.notify(doneP)]
+
+      // We finally hear about doneP resolving, allowing the bootstrap to
+      // proceed to the end of the test. We push the 'done' message to testLog
+      // CHIP TODO PHASE1: (or defer to phase1.5): uncomment, wire up
+      //                   queueToExport(vatAdminVat) to make it fire 'done'
+      // const doneMessage = await doneP;
+      // testLog(doneMessage);
+      doneP.then(() => 0); // hush eslint, delete after uncommenting await
+
+      return 'bootstrap done';
+    },
+    query(arg) {
+      testLog(`GOT QUERY ${arg}`);
+      return arg;
+    },
+  });
+  return self;
+}

--- a/packages/SwingSet/test/vat-admin/terminate/swingset-terminate.json
+++ b/packages/SwingSet/test/vat-admin/terminate/swingset-terminate.json
@@ -1,0 +1,13 @@
+{
+  "bootstrap": "bootstrap",
+  "bundles": {
+    "dude": {
+      "sourceSpec": "vat-dude-terminate.js"
+    }
+  },
+  "vats": {
+    "bootstrap": {
+      "sourceSpec": "bootstrap-terminate.js"
+    }
+  }
+}

--- a/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
+++ b/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
@@ -1,0 +1,43 @@
+/* global harden */
+import '@agoric/install-ses';
+import path from 'path';
+import { test } from 'tape-promise/tape';
+import { buildVatController, loadSwingsetConfigFile } from '../../../src/index';
+
+function capdata(body, slots = []) {
+  return harden({ body, slots });
+}
+
+function capargs(args, slots = []) {
+  return capdata(JSON.stringify(args), slots);
+}
+
+test('terminate', async t => {
+  const configPath = path.resolve(__dirname, 'swingset-terminate.json');
+  const config = loadSwingsetConfigFile(configPath);
+  const controller = await buildVatController(config);
+  t.equal(controller.bootstrapResult.status(), 'pending');
+  await controller.run();
+  t.equal(controller.bootstrapResult.status(), 'fulfilled');
+  t.deepEqual(
+    controller.bootstrapResult.resolution(),
+    capargs('bootstrap done'),
+  );
+  t.deepEqual(controller.dump().log, [
+    'FOO 1',
+    'count1 FOO SAYS 1',
+    'QUERY 2',
+    'GOT QUERY 2',
+    'ANSWER 2',
+    'query2 2',
+    'QUERY 3',
+    'GOT QUERY 3',
+    // these two will be added in phase 2
+    // 'foreverP.catch (err??)',
+    // 'afterForeverP.catch (err??)',
+    'foo4P.catch vat is dead',
+    // CHIP TODO phase 1.5, when done() is wired up
+    // '(vat termination message????)',
+  ]);
+  t.end();
+});

--- a/packages/SwingSet/test/vat-admin/terminate/vat-dude-terminate.js
+++ b/packages/SwingSet/test/vat-admin/terminate/vat-dude-terminate.js
@@ -1,0 +1,27 @@
+/* global harden */
+import { E } from '@agoric/eventual-send';
+import { makePromiseKit } from '@agoric/promise-kit';
+
+export function buildRootObject(vatPowers) {
+  // we use testLog to attempt to deliver messages even after we're supposed
+  // to be cut off
+  const { testLog } = vatPowers;
+
+  return harden({
+    foo(arg) {
+      testLog(`FOO ${arg}`);
+      return `FOO SAYS ${arg}`;
+    },
+
+    never() {
+      return makePromiseKit().promise; // never fires
+    },
+
+    async elsewhere(other, arg) {
+      testLog(`QUERY ${arg}`);
+      const answer = await E(other).query(arg);
+      testLog(`ANSWER ${answer}`);
+      return answer;
+    },
+  });
+}


### PR DESCRIPTION
This adds a more comprehensive test of vat termination, and brings up a few things that either need to be wired up in the `vat-termination-phase1` branch, or scheduled for a phase1.5:

* `controlFacet~.terminate()` should be idempotent, but currently causes a kernel panic
* `controlFacet~.done()` never fires, needs to be wired up

The test also lays most of the groundwork to exercise phase2, in which outstanding Promises left stranded by the dead vat are rejected by the kernel. When that lands, just uncomment the appropriate lines.

@FUDCo please review, merge into your `vat-termination-phase1` branch, and fix up at least the `terminate` idempotency (so we don't introduce a DoS vuln). And then either wire up `done()`, or schedule a PR to wire it up before we move on to phase2.

refs #1466
refs #1486
