### PR TITLE
build: enable dapp-svelte-wallet/api CI testing

### DIFF
--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -118,8 +118,8 @@ jobs:
       run: cd packages/bundle-source && yarn test
     - name: yarn test (captp)
       run: cd packages/captp && yarn test
-    - name: yarn test (dapp-svelte-wallet)
-      run: cd packages/dapp-svelte-wallet && yarn test
+    - name: yarn test (dapp-svelte-wallet/api)
+      run: cd packages/dapp-svelte-wallet/api && yarn test
     - name: yarn test (deployment)
       run: cd packages/deployment && yarn test
     - name: yarn test (ERTP)


### PR DESCRIPTION
Minor fix to get all CI tests to run.

`dapp-svelte-wallet` is a bit of an oddball because it's dapp-like, but at least Yarn 1 doesn't handle nested packages with workspaces like that one.  So, we need to run `cd packages/dapp-svelte-wallet/api && yarn test` manually.
