### PR TITLE
chore(swingset): add slogging framework

### DIFF
--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -287,14 +287,12 @@ export async function buildVatController(
   // the same is true for the tildot transform
   const transformTildot = harden(makeTransform(babelParser, babelGenerate));
 
-  function makeVatEndowments(consoleTag) {
-    return harden({
-      console: makeConsole(`${debugPrefix}SwingSet:${consoleTag}`),
-      // re2 is a RegExp work-a-like that disables backtracking expressions for
-      // safer memory consumption
-      RegExp: re2,
-    });
-  }
+  // all vats get these in their global scope, plus a vat-specific 'console'
+  const vatEndowments = harden({
+    // re2 is a RegExp work-a-like that disables backtracking expressions for
+    // safer memory consumption
+    RegExp: re2,
+  });
 
   const hostStorage = runtimeOptions.hostStorage || initSwingStore().storage;
   insistStorageAPI(hostStorage);
@@ -320,15 +318,23 @@ export async function buildVatController(
     return new Worker(supercode);
   }
 
+  function writeSlogObject(_obj) {
+    // TODO sqlite
+    // console.log(`--slog ${JSON.stringify(obj)}`);
+  }
+
   const kernelEndowments = {
     waitUntilQuiescent,
     hostStorage,
-    makeVatEndowments,
+    debugPrefix,
+    vatEndowments,
+    makeConsole,
     replaceGlobalMeter,
     transformMetering,
     transformTildot,
     makeNodeWorker,
     startSubprocessWorker,
+    writeSlogObject,
   };
 
   const kernel = buildKernel(kernelEndowments);

--- a/packages/SwingSet/src/kernel/dynamicVat.js
+++ b/packages/SwingSet/src/kernel/dynamicVat.js
@@ -12,6 +12,8 @@ export function makeDynamicVatCreator(stuff) {
     allocateUnusedVatID,
     vatNameToID,
     vatManagerFactory,
+    kernelSlog,
+    makeVatConsole,
     addVatManager,
     addExport,
     queueToExport,
@@ -64,6 +66,11 @@ export function makeDynamicVatCreator(stuff) {
     if (!vatSourceBundle) {
       throw Error(`Bundle ${source.bundleName} not found`);
     }
+    // TODO: maybe hash the bundle object somehow for the description
+    const description = source.bundle
+      ? '(source bundle)'
+      : `from: ${source.bundleName}`;
+
     assertKnownOptions(dynamicOptions, ['metered', 'vatParameters']);
     const { metered = true, vatParameters = {} } = dynamicOptions;
     let terminated = false;
@@ -102,12 +109,14 @@ export function makeDynamicVatCreator(stuff) {
         );
       }
 
+      kernelSlog.addVat(vatID, true, description);
       const managerOptions = {
         bundle: vatSourceBundle,
         metered,
         enableSetup: false,
         enableInternalMetering: false,
         notifyTermination: metered ? notifyTermination : undefined,
+        vatConsole: makeVatConsole(vatID),
         vatParameters,
       };
       const manager = await vatManagerFactory(vatID, managerOptions);

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -39,7 +39,7 @@ function makeError(s) {
   return harden({ body: JSON.stringify(s), slots: [] });
 }
 
-export default function buildKernel(kernelEndowments, kernelOptions = {}) {
+export default function buildKernel(kernelEndowments) {
   const {
     waitUntilQuiescent,
     hostStorage,
@@ -53,13 +53,12 @@ export default function buildKernel(kernelEndowments, kernelOptions = {}) {
     startSubprocessWorker,
     writeSlogObject,
   } = kernelEndowments;
-  const { disableSlog = false } = kernelOptions;
   insistStorageAPI(hostStorage);
   const { enhancedCrankBuffer, commitCrank } = wrapStorage(hostStorage);
 
-  const kernelSlog = disableSlog
-    ? makeDummySlogger(makeConsole)
-    : makeSlogger(writeSlogObject);
+  const kernelSlog = writeSlogObject
+    ? makeSlogger(writeSlogObject)
+    : makeDummySlogger(makeConsole);
 
   const kernelKeeper = makeKernelKeeper(enhancedCrankBuffer);
 

--- a/packages/SwingSet/src/kernel/kernelSyscall.js
+++ b/packages/SwingSet/src/kernel/kernelSyscall.js
@@ -148,7 +148,7 @@ export function makeKernelSyscallHandler(tools) {
   }
 
   const kernelSyscallHandler = harden({
-    send,
+    send, // TODO remove these individual ones
     invoke,
     subscribe,
     fulfillToPresence,

--- a/packages/SwingSet/src/kernel/slogger.js
+++ b/packages/SwingSet/src/kernel/slogger.js
@@ -1,0 +1,111 @@
+/* global harden */
+import { assert } from '@agoric/assert';
+
+const IDLE = 'idle';
+const STARTUP = 'startup';
+const DELIVERY = 'delivery';
+
+export function makeDummySlogger(makeConsole) {
+  return harden({
+    addVat: () => 0,
+    vatConsole: () => makeConsole('disabled slogger'),
+    startup: () => () => 0, // returns nop finish() function
+    delivery: () => () => 0,
+    syscall: () => () => 0,
+  });
+}
+
+export function makeSlogger(writeObj) {
+  const write = writeObj ? e => writeObj(harden(e)) : () => 0;
+
+  const vatSlogs = new Map(); // vatID -> vatSlog
+
+  function makeVatSlog(vatID) {
+    let state = IDLE; // or STARTUP or DELIVERY
+    let crankNum;
+    let deliveryNum = 0;
+    let syscallNum;
+
+    function assertOldState(exp, msg) {
+      assert(state === exp, `vat ${vatID} in ${state}, not ${exp}: ${msg}`);
+    }
+
+    function vatConsole(origConsole) {
+      const vc = {};
+      for (const level of ['debug', 'log', 'info', 'warn', 'error']) {
+        vc[level] = (...args) => {
+          origConsole[level](...args);
+          const when = { state, crankNum, vatID, deliveryNum };
+          write({ type: 'console', ...when, level, args });
+        };
+      }
+      return harden(vc);
+    }
+
+    function startup() {
+      // provide a context for console calls during startup
+      assertOldState(IDLE, 'did startup get called twice?');
+      state = STARTUP;
+      function finish() {
+        assertOldState(STARTUP, 'startup-finish called twice?');
+        state = IDLE;
+      }
+      return harden(finish);
+    }
+
+    // kd: kernelDelivery, vd: vatDelivery
+    function delivery(newCrankNum, kd, vd) {
+      assertOldState(IDLE, 'reentrant delivery?');
+      state = DELIVERY;
+      crankNum = newCrankNum;
+      const when = { crankNum, vatID, deliveryNum };
+      write({ type: 'deliver', ...when, kd, vd });
+      deliveryNum += 1;
+      syscallNum = 0;
+
+      // dr: deliveryResult
+      function finish(dr) {
+        assertOldState(DELIVERY, 'delivery-finish called twice?');
+        write({ type: 'deliver-result', ...when, dr });
+        state = IDLE;
+      }
+      return harden(finish);
+    }
+
+    // ksc: kernelSyscallObject, vsc: vatSyscallObject
+    function syscall(ksc, vsc) {
+      assertOldState(DELIVERY, 'syscall invoked outside of delivery');
+      const when = { crankNum, vatID, deliveryNum, syscallNum };
+      write({ type: 'syscall', ...when, ksc, vsc });
+      syscallNum += 1;
+
+      // ksr: kernelSyscallResult, vsr: vatSyscallResult
+      function finish(ksr, vsr) {
+        assertOldState(DELIVERY, 'syscall finished after delivery?');
+        write({ type: 'syscall-result', ...when, ksr, vsr });
+      }
+      return harden(finish);
+    }
+    return harden({ vatConsole, startup, delivery, syscall });
+  }
+
+  function addVat(vatID, dynamic, description) {
+    assert(!vatSlogs.has(vatID), `already have slog for ${vatID}`);
+    const vatSlog = makeVatSlog(vatID);
+    vatSlogs.set(vatID, vatSlog);
+    write({ type: 'create-vat', vatID, dynamic, description });
+    return vatSlog;
+  }
+
+  // function annotateVat(vatID, data) {
+  //   write({ type: 'annotate-vat', vatID, data });
+  // }
+
+  return harden({
+    addVat,
+    vatConsole: (vatID, ...args) => vatSlogs.get(vatID).vatConsole(...args),
+    startup: (vatID, ...args) => vatSlogs.get(vatID).startup(...args),
+    delivery: (vatID, ...args) => vatSlogs.get(vatID).delivery(...args),
+    syscall: (vatID, ...args) => vatSlogs.get(vatID).syscall(...args),
+  });
+}

--- a/packages/SwingSet/src/kernel/vatManager/factory.js
+++ b/packages/SwingSet/src/kernel/vatManager/factory.js
@@ -8,7 +8,7 @@ import { makeNodeSubprocessFactory } from './worker-subprocess-node';
 export function makeVatManagerFactory({
   allVatPowers,
   kernelKeeper,
-  makeVatEndowments,
+  vatEndowments,
   meterManager,
   transformMetering,
   waitUntilQuiescent,
@@ -18,7 +18,7 @@ export function makeVatManagerFactory({
   const localFactory = makeLocalVatManagerFactory({
     allVatPowers,
     kernelKeeper,
-    makeVatEndowments,
+    vatEndowments,
     meterManager,
     transformMetering,
     waitUntilQuiescent,
@@ -45,6 +45,7 @@ export function makeVatManagerFactory({
       'enableInternalMetering',
       'notifyTermination',
       'vatParameters',
+      'vatConsole',
     ]);
     const {
       setup,

--- a/packages/SwingSet/test/test-kernel.js
+++ b/packages/SwingSet/test/test-kernel.js
@@ -2,6 +2,7 @@
 
 import '@agoric/install-ses';
 import { test } from 'tape-promise/tape';
+import anylogger from 'anylogger';
 import { initSwingStore } from '@agoric/swing-store-simple';
 import { waitUntilQuiescent } from '../src/waitUntilQuiescent';
 
@@ -34,16 +35,26 @@ function emptySetup(_syscall) {
   return { deliver };
 }
 
+function makeConsole(tag) {
+  const log = anylogger(tag);
+  const cons = {};
+  for (const level of ['debug', 'log', 'info', 'warn', 'error']) {
+    cons[level] = log[level];
+  }
+  return harden(cons);
+}
+
 function makeEndowments() {
   return {
     waitUntilQuiescent,
     hostStorage: initSwingStore().storage,
     runEndOfCrank: () => {},
+    makeConsole,
   };
 }
 
 test('build kernel', async t => {
-  const kernel = buildKernel(makeEndowments());
+  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
   await kernel.start(); // empty queue
   const data = kernel.dump();
   t.deepEqual(data.vatTables, []);
@@ -52,7 +63,7 @@ test('build kernel', async t => {
 });
 
 test('simple call', async t => {
-  const kernel = buildKernel(makeEndowments());
+  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
   const log = [];
   function setup1(syscall, state, _helpers, vatPowers) {
     function deliver(facetID, method, args) {
@@ -98,7 +109,7 @@ test('simple call', async t => {
 });
 
 test('map inbound', async t => {
-  const kernel = buildKernel(makeEndowments());
+  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
   const log = [];
   function setup1(_syscall) {
     function deliver(facetID, method, args) {
@@ -148,7 +159,7 @@ test('map inbound', async t => {
 });
 
 test('addImport', async t => {
-  const kernel = buildKernel(makeEndowments());
+  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
   function setup(_syscall) {
     function deliver(_facetID, _method, _args) {}
     return { deliver };
@@ -169,7 +180,7 @@ test('addImport', async t => {
 });
 
 test('outbound call', async t => {
-  const kernel = buildKernel(makeEndowments());
+  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
   const log = [];
   let v1tovat25;
   const p7 = 'p+7';
@@ -368,7 +379,7 @@ test('outbound call', async t => {
 });
 
 test('three-party', async t => {
-  const kernel = buildKernel(makeEndowments());
+  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
   const log = [];
   let bobForA;
   let carolForA;
@@ -499,7 +510,7 @@ test('three-party', async t => {
 });
 
 test('transfer promise', async t => {
-  const kernel = buildKernel(makeEndowments());
+  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
   let syscallA;
   const logA = [];
   function setupA(syscall) {
@@ -603,7 +614,7 @@ test('transfer promise', async t => {
 });
 
 test('subscribe to promise', async t => {
-  const kernel = buildKernel(makeEndowments());
+  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
   let syscall;
   const log = [];
   function setup(s) {
@@ -646,7 +657,7 @@ test('subscribe to promise', async t => {
 });
 
 test('promise resolveToData', async t => {
-  const kernel = buildKernel(makeEndowments());
+  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
   const log = [];
 
   let syscallA;
@@ -723,7 +734,7 @@ test('promise resolveToData', async t => {
 });
 
 test('promise resolveToPresence', async t => {
-  const kernel = buildKernel(makeEndowments());
+  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
   const log = [];
 
   let syscallA;
@@ -803,7 +814,7 @@ test('promise resolveToPresence', async t => {
 });
 
 test('promise reject', async t => {
-  const kernel = buildKernel(makeEndowments());
+  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
   const log = [];
 
   let syscallA;
@@ -881,7 +892,7 @@ test('promise reject', async t => {
 
 test('transcript', async t => {
   const aliceForAlice = 'o+1';
-  const kernel = buildKernel(makeEndowments());
+  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
   function setup(syscall, _state) {
     function deliver(facetID, _method, args) {
       if (facetID === aliceForAlice) {
@@ -937,7 +948,7 @@ test('transcript', async t => {
 // have a decider. Make sure p3 gets queued in p2 rather than exploding.
 
 test('non-pipelined promise queueing', async t => {
-  const kernel = buildKernel(makeEndowments());
+  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
   const log = [];
 
   let syscall;
@@ -1054,7 +1065,7 @@ test('non-pipelined promise queueing', async t => {
 // get delivered to vat-with-x.
 
 test('pipelined promise queueing', async t => {
-  const kernel = buildKernel(makeEndowments());
+  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
   const log = [];
 
   let syscall;

--- a/packages/SwingSet/test/test-kernel.js
+++ b/packages/SwingSet/test/test-kernel.js
@@ -54,7 +54,7 @@ function makeEndowments() {
 }
 
 test('build kernel', async t => {
-  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
+  const kernel = buildKernel(makeEndowments());
   await kernel.start(); // empty queue
   const data = kernel.dump();
   t.deepEqual(data.vatTables, []);
@@ -63,7 +63,7 @@ test('build kernel', async t => {
 });
 
 test('simple call', async t => {
-  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
+  const kernel = buildKernel(makeEndowments());
   const log = [];
   function setup1(syscall, state, _helpers, vatPowers) {
     function deliver(facetID, method, args) {
@@ -109,7 +109,7 @@ test('simple call', async t => {
 });
 
 test('map inbound', async t => {
-  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
+  const kernel = buildKernel(makeEndowments());
   const log = [];
   function setup1(_syscall) {
     function deliver(facetID, method, args) {
@@ -159,7 +159,7 @@ test('map inbound', async t => {
 });
 
 test('addImport', async t => {
-  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
+  const kernel = buildKernel(makeEndowments());
   function setup(_syscall) {
     function deliver(_facetID, _method, _args) {}
     return { deliver };
@@ -180,7 +180,7 @@ test('addImport', async t => {
 });
 
 test('outbound call', async t => {
-  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
+  const kernel = buildKernel(makeEndowments());
   const log = [];
   let v1tovat25;
   const p7 = 'p+7';
@@ -379,7 +379,7 @@ test('outbound call', async t => {
 });
 
 test('three-party', async t => {
-  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
+  const kernel = buildKernel(makeEndowments());
   const log = [];
   let bobForA;
   let carolForA;
@@ -510,7 +510,7 @@ test('three-party', async t => {
 });
 
 test('transfer promise', async t => {
-  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
+  const kernel = buildKernel(makeEndowments());
   let syscallA;
   const logA = [];
   function setupA(syscall) {
@@ -614,7 +614,7 @@ test('transfer promise', async t => {
 });
 
 test('subscribe to promise', async t => {
-  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
+  const kernel = buildKernel(makeEndowments());
   let syscall;
   const log = [];
   function setup(s) {
@@ -657,7 +657,7 @@ test('subscribe to promise', async t => {
 });
 
 test('promise resolveToData', async t => {
-  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
+  const kernel = buildKernel(makeEndowments());
   const log = [];
 
   let syscallA;
@@ -734,7 +734,7 @@ test('promise resolveToData', async t => {
 });
 
 test('promise resolveToPresence', async t => {
-  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
+  const kernel = buildKernel(makeEndowments());
   const log = [];
 
   let syscallA;
@@ -814,7 +814,7 @@ test('promise resolveToPresence', async t => {
 });
 
 test('promise reject', async t => {
-  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
+  const kernel = buildKernel(makeEndowments());
   const log = [];
 
   let syscallA;
@@ -892,7 +892,7 @@ test('promise reject', async t => {
 
 test('transcript', async t => {
   const aliceForAlice = 'o+1';
-  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
+  const kernel = buildKernel(makeEndowments());
   function setup(syscall, _state) {
     function deliver(facetID, _method, args) {
       if (facetID === aliceForAlice) {
@@ -948,7 +948,7 @@ test('transcript', async t => {
 // have a decider. Make sure p3 gets queued in p2 rather than exploding.
 
 test('non-pipelined promise queueing', async t => {
-  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
+  const kernel = buildKernel(makeEndowments());
   const log = [];
 
   let syscall;
@@ -1065,7 +1065,7 @@ test('non-pipelined promise queueing', async t => {
 // get delivered to vat-with-x.
 
 test('pipelined promise queueing', async t => {
-  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
+  const kernel = buildKernel(makeEndowments());
   const log = [];
 
   let syscall;

--- a/packages/SwingSet/test/test-vpid-kernel.js
+++ b/packages/SwingSet/test/test-vpid-kernel.js
@@ -3,6 +3,7 @@
 
 import '@agoric/install-ses';
 import { test } from 'tape-promise/tape';
+import anylogger from 'anylogger';
 import { initSwingStore } from '@agoric/swing-store-simple';
 import { waitUntilQuiescent } from '../src/waitUntilQuiescent';
 
@@ -20,11 +21,21 @@ function capargs(args, slots = []) {
   return capdata(JSON.stringify(args), slots);
 }
 
+function makeConsole(tag) {
+  const log = anylogger(tag);
+  const cons = {};
+  for (const level of ['debug', 'log', 'info', 'warn', 'error']) {
+    cons[level] = log[level];
+  }
+  return harden(cons);
+}
+
 function makeEndowments() {
   return {
     waitUntilQuiescent,
     hostStorage: initSwingStore().storage,
     runEndOfCrank: () => {},
+    makeConsole,
   };
 }
 
@@ -189,7 +200,7 @@ function inCList(kernel, vatID, kpid, vpid) {
 }
 
 async function doTest123(t, which, mode) {
-  const kernel = buildKernel(makeEndowments());
+  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
   // vatA is our primary actor
   const { log: logA, getSyscall: getSyscallA } = buildRawVat('vatA', kernel);
   // we use vatB when necessary to send messages to vatA
@@ -358,7 +369,7 @@ for (const caseNum of [1, 2, 3]) {
 }
 
 async function doTest4567(t, which, mode) {
-  const kernel = buildKernel(makeEndowments());
+  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
   // vatA is our primary actor
   let onDispatchCallback;
   function odc(d) {

--- a/packages/SwingSet/test/test-vpid-kernel.js
+++ b/packages/SwingSet/test/test-vpid-kernel.js
@@ -200,7 +200,7 @@ function inCList(kernel, vatID, kpid, vpid) {
 }
 
 async function doTest123(t, which, mode) {
-  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
+  const kernel = buildKernel(makeEndowments());
   // vatA is our primary actor
   const { log: logA, getSyscall: getSyscallA } = buildRawVat('vatA', kernel);
   // we use vatB when necessary to send messages to vatA
@@ -369,7 +369,7 @@ for (const caseNum of [1, 2, 3]) {
 }
 
 async function doTest4567(t, which, mode) {
-  const kernel = buildKernel(makeEndowments(), { disableSlog: true });
+  const kernel = buildKernel(makeEndowments());
   // vatA is our primary actor
   let onDispatchCallback;
   function odc(d) {


### PR DESCRIPTION
This adds a set of logging hooks which record swingset deliveries (the kernel
sending messages and resolution notifications into vats), syscalls (from the
vat into the kernel), and console messages. All these events can be
correlated by their crank number, vatID, delivery number, and syscall number.

The output function is not yet implemented; my notional plan is to log to
lines of JSON for now, and maybe move to a SQLite based store for later. I've
not written any analysis tools yet either.

I made a few refactorings to make things smoother:

* vats get their console object from `managerOptions.vatConsole`, rather than
  having the manager build it themselves, which makes it easier to provide
  one that writes to both the regular console and the slog
* as a result, all vats get the same basic `vatEndowments` (with the console
  added on later), rather than calling `makeVatEndowments(vatID)`
* in kernel.js, `deliverToVat` and `processNotify` had their common code
  factored out into `deliverAndLogToVat()`, which now writes to the slog
  in addition to actually performing the `manager.deliver`. The names aren't
  great and want to be changed at some point.
* `buildVatSyscallHandler` function was moved out of `addVatManager` to make
  things easier to read. The new function writes syscalls to the slog.
* console messages written by vats in top-level code, or during the execution
  of `buildRootObject`, are slogged in the "startup" phase. All other calls
  to `console.log` and friends are recorded in a "delivery" phase.

refs #1535