### PR TITLE
chore: add error handling for bad timers and deadlines when making seats

### DIFF
--- a/packages/zoe/src/contractFacet/exit.js
+++ b/packages/zoe/src/contractFacet/exit.js
@@ -38,7 +38,8 @@ export const makeExitObj = (proposal, zoeSeatAdmin, zcfSeatAdmin) => {
           `The seat could not be made with the provided timer ${proposal.exit.afterDeadline.timer} and deadline ${proposal.exit.afterDeadline.deadline}`,
         );
         console.error(err);
-        exitFn();
+        zcfSeatAdmin.updateHasExited();
+        E(zoeSeatAdmin).kickOut(err);
         throw err;
       });
   } else if (exitKind === 'onDemand') {

--- a/packages/zoe/src/contractFacet/exit.js
+++ b/packages/zoe/src/contractFacet/exit.js
@@ -33,14 +33,14 @@ export const makeExitObj = (proposal, zoeSeatAdmin, zcfSeatAdmin) => {
           wake: exitFn,
         }),
       )
-      .catch(err => {
+      .catch(reason => {
         console.error(
           `The seat could not be made with the provided timer ${proposal.exit.afterDeadline.timer} and deadline ${proposal.exit.afterDeadline.deadline}`,
         );
-        console.error(err);
+        console.error(reason);
         zcfSeatAdmin.updateHasExited();
-        E(zoeSeatAdmin).kickOut(err);
-        throw err;
+        E(zoeSeatAdmin).kickOut(reason);
+        throw reason;
       });
   } else if (exitKind === 'onDemand') {
     // Allow the user to exit their seat on demand. Note: we must wrap

--- a/packages/zoe/src/contractFacet/exit.js
+++ b/packages/zoe/src/contractFacet/exit.js
@@ -26,19 +26,21 @@ export const makeExitObj = (proposal, zoeSeatAdmin, zcfSeatAdmin) => {
 
   if (exitKind === 'afterDeadline') {
     // Automatically exit the seat after deadline.
-    E(proposal.exit.afterDeadline.timer).setWakeup(
-      proposal.exit.afterDeadline.deadline,
-      harden({
-        wake: exitFn,
-      }).catch(err => {
+    E(proposal.exit.afterDeadline.timer)
+      .setWakeup(
+        proposal.exit.afterDeadline.deadline,
+        harden({
+          wake: exitFn,
+        }),
+      )
+      .catch(err => {
         console.error(
           `The seat could not be made with the provided timer ${proposal.exit.afterDeadline.timer} and deadline ${proposal.exit.afterDeadline.deadline}`,
         );
         console.error(err);
         exitFn();
         throw err;
-      }),
-    );
+      });
   } else if (exitKind === 'onDemand') {
     // Allow the user to exit their seat on demand. Note: we must wrap
     // it in an object to send it back to Zoe because our marshalling layer

--- a/packages/zoe/src/contractFacet/exit.js
+++ b/packages/zoe/src/contractFacet/exit.js
@@ -30,6 +30,13 @@ export const makeExitObj = (proposal, zoeSeatAdmin, zcfSeatAdmin) => {
       proposal.exit.afterDeadline.deadline,
       harden({
         wake: exitFn,
+      }).catch(err => {
+        console.error(
+          `The seat could not be made with the provided timer ${proposal.exit.afterDeadline.timer} and deadline ${proposal.exit.afterDeadline.deadline}`,
+        );
+        console.error(err);
+        exitFn();
+        throw err;
       }),
     );
   } else if (exitKind === 'onDemand') {

--- a/packages/zoe/test/swingsetTests/zoe/test-zoe.js
+++ b/packages/zoe/test/swingsetTests/zoe/test-zoe.js
@@ -289,3 +289,20 @@ test('zoe - sellTickets - valid inputs', async t => {
   const dump = await main(['sellTicketsOk', startingValues]);
   t.deepEquals(dump.log, expectedSellTicketsOkLog);
 });
+
+const expectedBadTimerLog = [
+  '=> alice, bob, carol and dave are set up',
+  '=> alice.doBadTimer called',
+  'is a zoe invitation: true',
+  'aliceMoolaPurse: balance {"brand":{},"value":3}',
+  'aliceSimoleanPurse: balance {"brand":{},"value":0}',
+];
+test('zoe - bad timer', async t => {
+  t.plan(1);
+  const startingValues = [
+    [3, 0, 0],
+    [0, 0, 0],
+  ];
+  const dump = await main(['badTimer', startingValues]);
+  t.deepEquals(dump.log, expectedBadTimerLog);
+});


### PR DESCRIPTION
Add error handling when `setWakeup` throws. Add a better error message than whatever caused the attempt to fail.

Closes #1538