### PR TITLE
fix: kickOut takes a `reason` error rather than a `message` string

### DIFF
--- a/packages/notifier/src/types.js
+++ b/packages/notifier/src/types.js
@@ -57,8 +57,9 @@
  * @property {(finalState: T) => void} finish sets the final state, sends a
  * final update, and freezes the
  * updater
- * @property {(reason: Error) => void} fail the stream becomes erroneously
- * terminated, allegedly for the stated reason.
+ * @property {(reason: any) => void} fail the stream becomes erroneously
+ * terminated, allegedly for the stated reason, which is normally an
+ * instanceof `Error`.
  */
 
 /**

--- a/packages/notifier/src/types.js
+++ b/packages/notifier/src/types.js
@@ -57,7 +57,7 @@
  * @property {(finalState: T) => void} finish sets the final state, sends a
  * final update, and freezes the
  * updater
- * @property {(reason: T) => void} fail the stream becomes erroneously
+ * @property {(reason: Error) => void} fail the stream becomes erroneously
  * terminated, allegedly for the stated reason.
  */
 

--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -331,12 +331,12 @@ export function buildRootObject() {
         seatToZCFSeatAdmin.init(zcfSeat, zcfSeatAdmin);
         const offerHandler = invitationHandleToHandler.get(invitationHandle);
         // @ts-ignore
-        const offerResultP = E(offerHandler)(zcfSeat).catch(err => {
-          console.error(err);
+        const offerResultP = E(offerHandler)(zcfSeat).catch(reason => {
+          console.error(reason);
           if (!zcfSeat.hasExited()) {
-            throw zcfSeat.kickOut(err.message);
+            throw zcfSeat.kickOut(reason);
           } else {
-            throw err;
+            throw reason;
           }
         });
         const exitObj = makeExitObj(

--- a/packages/zoe/src/contractFacet/seat.js
+++ b/packages/zoe/src/contractFacet/seat.js
@@ -49,12 +49,15 @@ export const makeZcfSeatAdminKit = (
       E(zoeSeatAdmin).exit();
     },
     kickOut: (
-      msg = 'Kicked out of seat. Please check the log for more information.',
+      reason = new Error(
+        'Kicked out of seat. Please check the log for more information.',
+      ),
     ) => {
       assertExitedFalse();
       zcfSeatAdmin.updateHasExited();
-      E(zoeSeatAdmin).kickOut(msg);
-      assert.fail(msg);
+      E(zoeSeatAdmin).kickOut(harden(reason));
+      console.error(reason);
+      throw reason;
     },
     getNotifier: () => {
       return notifier;

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -140,7 +140,9 @@ export const trade = (zcf, keepLeft, tryRight) => {
   } catch (err) {
     console.log(err);
     throw tryRight.seat.kickOut(
-      `The trade between left ${keepLeft} and right ${tryRight} failed. Please check the log for more information`,
+      new Error(
+        `The trade between left ${keepLeft} and right ${tryRight} failed. Please check the log for more information`,
+      ),
     );
   }
 
@@ -164,7 +166,9 @@ export const trade = (zcf, keepLeft, tryRight) => {
       console.log(`offer not safe for right`);
     }
     return tryRight.seat.kickOut(
-      `The trade between left ${keepLeft} and right ${tryRight} failed offer safety. Please check the log for more information`,
+      new Error(
+        `The trade between left ${keepLeft} and right ${tryRight} failed offer safety. Please check the log for more information`,
+      ),
     );
   }
 
@@ -202,7 +206,7 @@ export const swap = (
   keepHandleInactiveMsg = 'prior offer is unavailable',
 ) => {
   if (keepSeat.hasExited()) {
-    throw trySeat.kickOut(keepHandleInactiveMsg);
+    throw trySeat.kickOut(new Error(keepHandleInactiveMsg));
   }
 
   trade(

--- a/packages/zoe/src/contracts/publicAuction.js
+++ b/packages/zoe/src/contracts/publicAuction.js
@@ -53,10 +53,10 @@ const start = zcf => {
     // Check that the item is still up for auction
     if (sellSeat.hasExited()) {
       const rejectMsg = `The item up for auction is not available or the auction has completed`;
-      throw bidSeat.kickOut(rejectMsg);
+      throw bidSeat.kickOut(new Error(rejectMsg));
     }
     if (bidSeats.length >= numBidsAllowed) {
-      throw bidSeat.kickOut(`No further bids allowed.`);
+      throw bidSeat.kickOut(new Error(`No further bids allowed.`));
     }
     const sellerSatisfied = satisfies(zcf, sellSeat, {
       Ask: bidSeat.getAmountAllocated('Bid', minimumBid.brand),
@@ -68,7 +68,7 @@ const start = zcf => {
     });
     if (!(sellerSatisfied && bidderSatisfied)) {
       const rejectMsg = `Bid was under minimum bid or for the wrong assets`;
-      throw bidSeat.kickOut(rejectMsg);
+      throw bidSeat.kickOut(new Error(rejectMsg));
     }
 
     // Save valid bid and try to close.

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -57,7 +57,7 @@ const start = zcf => {
     // Check that the wanted items are still for sale.
     if (!itemsMath.isGTE(currentItemsForSale, wantedItems)) {
       const rejectMsg = `Some of the wanted items were not available for sale`;
-      throw buyerSeat.kickOut(rejectMsg);
+      throw buyerSeat.kickOut(new Error(rejectMsg));
     }
 
     const totalCost = moneyMath.make(
@@ -67,7 +67,7 @@ const start = zcf => {
     // Check that the money provided to pay for the items is greater than the totalCost.
     if (!moneyMath.isGTE(providedMoney, totalCost)) {
       const rejectMsg = `More money (${totalCost}) is required to buy these items`;
-      throw buyerSeat.kickOut(rejectMsg);
+      throw buyerSeat.kickOut(new Error(rejectMsg));
     }
 
     // Reallocate. We are able to trade by only defining the gains

--- a/packages/zoe/src/contracts/simpleExchange.js
+++ b/packages/zoe/src/contracts/simpleExchange.js
@@ -131,7 +131,7 @@ const start = zcf => {
     }
     // Eject because the offer must be invalid
     throw seat.kickOut(
-      `The proposal did not match either a buy or sell order.`,
+      new Error(`The proposal did not match either a buy or sell order.`),
     );
   };
 

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -60,7 +60,7 @@
  * @property {(allocation: Allocation) => void} replaceAllocation
  * @property {() => void} exit
  * @property {(reason: any) => never} kickOut called with the reason this seat
- * is being kicked our, where reason is normally an instanceof Error.
+ * is being kicked out, where reason is normally an instanceof Error.
  * @property {() => Allocation} getCurrentAllocation
  */
 

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -59,7 +59,7 @@
  * @typedef {Object} ZoeSeatAdmin
  * @property {(allocation: Allocation) => void} replaceAllocation
  * @property {() => void} exit
- * @property {(msg: String) => never} kickOut
+ * @property {(reason: Error) => never} kickOut
  * @property {() => Allocation} getCurrentAllocation
  */
 

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -59,7 +59,8 @@
  * @typedef {Object} ZoeSeatAdmin
  * @property {(allocation: Allocation) => void} replaceAllocation
  * @property {() => void} exit
- * @property {(reason: Error) => never} kickOut
+ * @property {(reason: any) => never} kickOut called with the reason this seat
+ * is being kicked our, where reason is normally an instanceof Error.
  * @property {() => Allocation} getCurrentAllocation
  */
 

--- a/packages/zoe/src/types.js
+++ b/packages/zoe/src/types.js
@@ -357,7 +357,7 @@
  * keys, brand values
  * @property {AmountMathKeywordRecord} maths - record with keywords
  * keys, amountMath values
- * 
+ *
  * @typedef {StandardTerms & Record<string, any>} Terms
  *
  * @typedef {object} InstanceRecord
@@ -377,7 +377,7 @@
 /**
  * @typedef {Object} ZCFSeat
  * @property {() => void} exit
- * @property {(msg?: string) => never} kickOut
+ * @property {(reason?: Error) => never} kickOut
  * @property {() => Notifier<Allocation>} getNotifier
  * @property {() => boolean} hasExited
  * @property {() => ProposalRecord} getProposal

--- a/packages/zoe/src/types.js
+++ b/packages/zoe/src/types.js
@@ -378,7 +378,7 @@
  * @typedef {Object} ZCFSeat
  * @property {() => void} exit
  * @property {(reason?: any) => never} kickOut alled with the reason this seat
- * is being kicked our, where reason is normally an instanceof Error.
+ * is being kicked out, where reason is normally an instanceof Error.
  * @property {() => Notifier<Allocation>} getNotifier
  * @property {() => boolean} hasExited
  * @property {() => ProposalRecord} getProposal

--- a/packages/zoe/src/types.js
+++ b/packages/zoe/src/types.js
@@ -377,7 +377,8 @@
 /**
  * @typedef {Object} ZCFSeat
  * @property {() => void} exit
- * @property {(reason?: Error) => never} kickOut
+ * @property {(reason?: any) => never} kickOut alled with the reason this seat
+ * is being kicked our, where reason is normally an instanceof Error.
  * @property {() => Notifier<Allocation>} getNotifier
  * @property {() => boolean} hasExited
  * @property {() => ProposalRecord} getProposal

--- a/packages/zoe/src/types.js
+++ b/packages/zoe/src/types.js
@@ -377,8 +377,8 @@
 /**
  * @typedef {Object} ZCFSeat
  * @property {() => void} exit
- * @property {(reason?: any) => never} kickOut alled with the reason this seat
- * is being kicked out, where reason is normally an instanceof Error.
+ * @property {(reason?: any) => never} kickOut called with the reason this
+ * seat is being kicked out, where reason is normally an instanceof Error.
  * @property {() => Notifier<Allocation>} getNotifier
  * @property {() => boolean} hasExited
  * @property {() => ProposalRecord} getProposal

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -75,14 +75,15 @@ export const makeZoeSeatAdminKit = (
       updater.finish(undefined);
       doExit(zoeSeatAdmin);
     },
-    kickOut: msg => {
+    kickOut: reason => {
       assert(
         instanceAdmin.hasZoeSeatAdmin(zoeSeatAdmin),
         `Cannot kick out of seat. Seat has already exited`,
       );
-      updater.fail(msg);
+      updater.fail(reason);
       doExit(zoeSeatAdmin);
-      assert.fail(msg);
+      console.log(reason);
+      throw reason;
     },
     getCurrentAllocation: () => currentAllocation,
   });


### PR DESCRIPTION
Prior to this PR we have the following line of code:
```js
throw zcfSeat.kickOut(err.message);
```
The problem with this pattern of code is that `err` had an associated stack trace, whereas `err.message` is just a string. Currently we're not doing anything to correlate stack traces of sent errors with received errors, but I'm hoping to change that. This PR is in anticipation of that change.

I adopt the naming convention associated with a promise's rejection reason, which is normally an error object, of calling it a `reason`. I change `kickOut` to accept such a `reason` error rather than a `message` string. I fix the types, including noticing and fixing a bug in the notifier's type of `updater.fail`. This was declared with the same `T` template variable as for the values being reported, which was always wrong. It is now specifically a `reason: Error`.

Where the zcfSeat does an eventual send of `kickOut` to the zoeSeat, it also hardens the reason. The marshal layer transmits simple hardened errors. The marshal layer currently does not to enable recovery of the stack, but that's where I'm going.

This came up when @michaelfig and I were working on upgrading pegasus to the new Zoe.