### PR TITLE
chore: remove spurious top-level dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "patch-package": "patch-package"
   },
   "dependencies": {
-    "@agoric/store": "^0.2.0",
     "patch-package": "^6.2.2"
   }
 }


### PR DESCRIPTION
I think this got added by accident in #1169