### PR TITLE
fix: use REMOTE_STYLE rather than 'presence' to prepare

### DIFF
--- a/packages/SwingSet/test/test-exomessages.js
+++ b/packages/SwingSet/test/test-exomessages.js
@@ -1,4 +1,5 @@
 import '@agoric/install-ses';
+import { REMOTE_STYLE } from '@agoric/marshal';
 import test from 'ava';
 import { buildVatController } from '../src/index';
 
@@ -39,7 +40,7 @@ test('bootstrap returns presence', async t => {
   // prettier-ignore
   await bootstrapSuccessfully(
     t,
-    'presence',
+    REMOTE_STYLE,
     '{"@qclass":"slot",index:0}',
     ['ko25'],
   );
@@ -103,7 +104,7 @@ test('extra message returns presence', async t => {
   // prettier-ignore
   await extraMessage(
     t,
-    'presence',
+    REMOTE_STYLE,
     'fulfilled',
     '{"@qclass":"slot",index:0}',
     ['ko25'],

--- a/packages/SwingSet/test/test-vpid-kernel.js
+++ b/packages/SwingSet/test/test-vpid-kernel.js
@@ -2,6 +2,7 @@
 /* global harden */
 
 import '@agoric/install-ses';
+import { REMOTE_STYLE } from '@agoric/marshal';
 import test from 'ava';
 import anylogger from 'anylogger';
 import { initSwingStore } from '@agoric/swing-store-simple';
@@ -90,7 +91,7 @@ function buildRawVat(name, kernel, onDispatchCallback = undefined) {
 // ways:
 // prettier-ignore
 const modes = [
-  'presence',       // resolveToPresence: messages can be sent to resolution
+  REMOTE_STYLE,     // resolveToPresence: messages can be sent to resolution
   'local-object',   // resolve to a local object: messages to resolution don't create syscalls
   'data',           // resolveToData: messages are rejected as DataIsNotCallable
   'promise-data',   // resolveToData that contains a promise ID
@@ -102,7 +103,7 @@ const slot0arg = { '@qclass': 'slot', index: 0 };
 
 function doResolveSyscall(syscallA, vpid, mode, targets) {
   switch (mode) {
-    case 'presence':
+    case REMOTE_STYLE:
       syscallA.fulfillToPresence(vpid, targets.target2);
       break;
     case 'local-object':
@@ -127,7 +128,7 @@ function doResolveSyscall(syscallA, vpid, mode, targets) {
 
 function resolutionOf(vpid, mode, targets) {
   switch (mode) {
-    case 'presence':
+    case REMOTE_STYLE:
       return {
         type: 'notifyFulfillToPresence',
         promiseID: vpid,

--- a/packages/SwingSet/test/test-vpid-liveslots.js
+++ b/packages/SwingSet/test/test-vpid-liveslots.js
@@ -6,6 +6,7 @@ import test from 'ava';
 
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
+import { REMOTE_STYLE } from '@agoric/marshal';
 import { makeLiveSlots } from '../src/kernel/liveSlots';
 
 const RETIRE_VPIDS = true;
@@ -100,7 +101,7 @@ function hush(p) {
 // In addition, we want to exercise the promises being resolved in various
 // ways:
 const modes = [
-  'presence', // resolveToPresence, messages can be sent to resolution
+  REMOTE_STYLE, // resolveToPresence, messages can be sent to resolution
   'local-object', // resolve to a local object, messages can be sent but do
   //              // not create syscalls
   'data', // resolveToData, messages are rejected as DataIsNotCallable
@@ -111,7 +112,7 @@ const modes = [
 
 function resolvePR(pr, mode, targets) {
   switch (mode) {
-    case 'presence':
+    case REMOTE_STYLE:
       pr.resolve(targets.target2);
       break;
     case 'local-object':
@@ -148,7 +149,7 @@ const slot1arg = { '@qclass': 'slot', index: 1 };
 
 function resolutionOf(vpid, mode, targets) {
   switch (mode) {
-    case 'presence':
+    case REMOTE_STYLE:
       return {
         type: 'fulfillToPresence',
         promiseID: vpid,
@@ -515,7 +516,7 @@ async function doVatResolveCase23(t, which, mode, stalls) {
   // resolution target. If that target is a Presence, we'll see a syscall,
   // otherwise the vat handles it internally.
 
-  if (mode === 'presence') {
+  if (mode === REMOTE_STYLE) {
     t.deepEqual(log.shift(), {
       type: 'send',
       targetSlot: target2,
@@ -536,7 +537,7 @@ async function doVatResolveCase23(t, which, mode, stalls) {
   t.deepEqual(log, []);
 
   // assert that the vat saw the local promise being resolved too
-  if (mode === 'presence') {
+  if (mode === REMOTE_STYLE) {
     t.is(resolutionOfP1.toString(), `[Alleged: presence ${target2}]`);
   } else if (mode === 'data') {
     t.is(resolutionOfP1, 4);
@@ -552,7 +553,7 @@ async function doVatResolveCase23(t, which, mode, stalls) {
 
 // uncomment this when debugging specific problems
 // test.only(`XX`, async t => {
-//   await doVatResolveCase23(t, 2, 'presence', 0);
+//   await doVatResolveCase23(t, 2, REMOTE_STYLE, 0);
 // });
 
 for (const caseNum of [2, 3]) {
@@ -638,7 +639,7 @@ async function doVatResolveCase4(t, mode) {
   t.deepEqual(log.shift(), { type: 'subscribe', target: expectedP3 });
   t.deepEqual(log, []);
 
-  if (mode === 'presence') {
+  if (mode === REMOTE_STYLE) {
     dispatch.notifyFulfillToPresence(p1, target2);
   } else if (mode === 'local-object') {
     dispatch.notifyFulfillToPresence(p1, rootA);
@@ -682,7 +683,7 @@ async function doVatResolveCase4(t, mode) {
     target: expectedResultOfThree,
   });
 
-  if (mode === 'presence') {
+  if (mode === REMOTE_STYLE) {
     const expectedP6 = nextP();
     t.deepEqual(log.shift(), {
       type: 'send',

--- a/packages/SwingSet/test/vat-exomessages.js
+++ b/packages/SwingSet/test/vat-exomessages.js
@@ -1,5 +1,7 @@
 /* global harden */
 
+import { REMOTE_STYLE } from '@agoric/marshal';
+
 export function buildRootObject(_vatPowers, vatParameters) {
   const other = harden({
     something(arg) {
@@ -10,7 +12,7 @@ export function buildRootObject(_vatPowers, vatParameters) {
   function behave(mode) {
     if (mode === 'data') {
       return 'a big hello to all intelligent lifeforms everywhere';
-    } else if (mode === 'presence') {
+    } else if (mode === REMOTE_STYLE) {
       return other;
     } else if (mode === 'reject') {
       throw new Error('gratuitous error');

--- a/packages/marshal/marshal.js
+++ b/packages/marshal/marshal.js
@@ -9,7 +9,7 @@ import { assert, details } from '@agoric/assert';
 import { isPromise } from '@agoric/promise-kit';
 
 // TODO: Use just 'remote' when we're willing to make a breaking change.
-const REMOTE_STYLE = 'presence';
+export const REMOTE_STYLE = 'presence';
 
 // TODO, remove the mustPassByPresence alias when we make a breaking change.
 // eslint-disable-next-line no-use-before-define
@@ -101,7 +101,7 @@ function pureCopy(val, already = new WeakMap()) {
 
     case REMOTE_STYLE: {
       throw TypeError(
-        `Input value ${passStyle} cannot be copied as must be passed by reference`,
+        `Input value ${passStyle} cannot be copied as it must be passed by reference`,
       );
     }
 
@@ -243,8 +243,9 @@ function isPassByCopyRecord(val) {
 }
 
 /**
- * Ensure that val could become a legitimate remotable.  This is used internally both
- * in the construction of a new remotable and mustPassByRemote.
+ * Ensure that val could become a legitimate remotable.  This is used
+ * internally both in the construction of a new remotable and
+ * mustPassByRemote.
  *
  * @param {*} val The remotable candidate to check
  */
@@ -580,7 +581,7 @@ export function makeMarshal(
     // ibid table is shared across recursive calls to fullRevive.
     const ibidTable = makeReviverIbidTable(cyclePolicy);
 
-    // We stay close to the algorith at
+    // We stay close to the algorithm at
     // https://tc39.github.io/ecma262/#sec-json.parse , where
     // fullRevive(JSON.parse(str)) is like JSON.parse(str, revive))
     // for a similar reviver. But with the following differences:

--- a/packages/same-structure/src/sameStructure.js
+++ b/packages/same-structure/src/sameStructure.js
@@ -1,6 +1,6 @@
 /* global harden */
 
-import { sameValueZero, passStyleOf } from '@agoric/marshal';
+import { sameValueZero, passStyleOf, REMOTE_STYLE } from '@agoric/marshal';
 import { assert, details, q } from '@agoric/assert';
 
 // Shim of Object.fromEntries from
@@ -58,7 +58,7 @@ function allComparable(passable) {
     case 'number':
     case 'symbol':
     case 'bigint':
-    case 'presence':
+    case REMOTE_STYLE:
     case 'copyError': {
       return passable;
     }
@@ -114,7 +114,7 @@ function sameStructure(left, right) {
     case 'number':
     case 'symbol':
     case 'bigint':
-    case 'presence': {
+    case REMOTE_STYLE: {
       return sameValueZero(left, right);
     }
     case 'copyRecord':
@@ -193,7 +193,7 @@ function mustBeSameStructureInternal(left, right, message, path) {
     case 'number':
     case 'symbol':
     case 'bigint':
-    case 'presence': {
+    case REMOTE_STYLE: {
       if (!sameValueZero(left, right)) {
         complain('different');
       }


### PR DESCRIPTION
Currently, the `passStyleOf(remotable)` is `'presence'`, which mixes abstraction levels. It should be `'remote'`. To prepare to make this change, @michaelfig introduced the `REMOTE_STYLE` global constant whose current value is `'presence'`. However, we still had the literal `'presence'` string scattered throughout our code. This replaces all those with the `REMOTE_STYLE` constant until we have made the transition.

I verified that, in the PR, if we set the constant to `'remote'` CI still passes. However, we do not intend to actually take this step at this time. This PR is just to prepare.