### PR TITLE
fix: add "TODO unimplemented"s

### DIFF
--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -336,6 +336,7 @@ export default function buildKernel(kernelEndowments, kernelOptions = {}) {
         await deliverToTarget(kp.slot, msg);
       } else if (kp.state === 'redirected') {
         // await deliverToTarget(kp.redirectTarget, msg); // probably correct
+        // TODO unimplemented
         throw new Error('not implemented yet');
       } else if (kp.state === 'fulfilledToData') {
         if (msg.result) {

--- a/packages/SwingSet/src/kernel/vatManager/deliver.js
+++ b/packages/SwingSet/src/kernel/vatManager/deliver.js
@@ -87,6 +87,7 @@ export function makeDeliver(tools, dispatch) {
       case 'fulfilledToPresence':
         return doProcess(['notifyFulfillToPresence', vpid, vp.slot], errmsg);
       case 'redirected':
+        // TODO unimplemented
         throw new Error('not implemented yet');
       case 'fulfilledToData':
         return doProcess(['notifyFulfillToData', vpid, vp.data], errmsg);

--- a/packages/SwingSet/src/kernel/vatManager/nodeWorker.js
+++ b/packages/SwingSet/src/kernel/vatManager/nodeWorker.js
@@ -123,6 +123,7 @@ export function makeNodeWorkerVatManagerFactory(tools) {
     }
 
     function replayTranscript() {
+      // TODO unimplemented
       throw Error(`replayTranscript not yet implemented`);
     }
 

--- a/packages/SwingSet/src/kernel/vatManager/nodeWorkerSupervisor.js
+++ b/packages/SwingSet/src/kernel/vatManager/nodeWorkerSupervisor.js
@@ -55,6 +55,7 @@ function doNotify(vpid, vp) {
     case 'fulfilledToPresence':
       return doProcess(['notifyFulfillToPresence', vpid, vp.slot], errmsg);
     case 'redirected':
+      // TODO unimplemented
       throw new Error('not implemented yet');
     case 'fulfilledToData':
       return doProcess(['notifyFulfillToData', vpid, vp.data], errmsg);

--- a/packages/SwingSet/src/kernel/vatManager/subprocessSupervisor.js
+++ b/packages/SwingSet/src/kernel/vatManager/subprocessSupervisor.js
@@ -51,6 +51,7 @@ function doNotify(vpid, vp) {
     case 'fulfilledToPresence':
       return doProcess(['notifyFulfillToPresence', vpid, vp.slot], errmsg);
     case 'redirected':
+      // TODO unimplemented
       throw new Error('not implemented yet');
     case 'fulfilledToData':
       return doProcess(['notifyFulfillToData', vpid, vp.data], errmsg);

--- a/packages/SwingSet/src/kernel/vatManager/worker-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/worker-subprocess-node.js
@@ -124,6 +124,7 @@ export function makeNodeSubprocessFactory(tools) {
     }
 
     function replayTranscript() {
+      // TODO unimplemented
       throw Error(`replayTranscript not yet implemented`);
     }
 

--- a/packages/SwingSet/src/kernel/vatTranslator.js
+++ b/packages/SwingSet/src/kernel/vatTranslator.js
@@ -61,6 +61,7 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
       vp.slot = mapKernelSlotToVatSlot(kp.slot);
       vatKeeper.deleteCListEntry(kpid, vpid);
     } else if (kp.state === 'redirected') {
+      // TODO unimplemented
       throw new Error('not implemented yet');
     } else if (kp.state === 'fulfilledToData' || kp.state === 'rejected') {
       vp.data = {

--- a/packages/SwingSet/test/test-vpid-liveslots.js
+++ b/packages/SwingSet/test/test-vpid-liveslots.js
@@ -709,4 +709,5 @@ for (const mode of modes) {
   });
 }
 
+// TODO unimplemented
 // cases 5 and 6 are not implemented due to #886

--- a/packages/cosmic-swingset/lib/block-manager.js
+++ b/packages/cosmic-swingset/lib/block-manager.js
@@ -118,6 +118,7 @@ export default function makeBlockManager({
           if (restoreHeight !== computedHeight) {
             // Keep throwing forever.
             decohered = Error(
+              // TODO unimplemented
               `Unimplemented reset state from ${computedHeight} to ${restoreHeight}`,
             );
             throw decohered;

--- a/packages/marshal/marshal.js
+++ b/packages/marshal/marshal.js
@@ -730,12 +730,13 @@ export function makeMarshal(
  * @returns {object} remotable, modified for debuggability
  */
 function Remotable(iface = 'Remotable', props = {}, remotable = {}) {
-  // Find the alleged name.
+  // TODO unimplemented
   assert.typeof(
     iface,
     'string',
     details`Interface ${iface} must be a string; unimplemented`,
   );
+  // TODO unimplemented
   assert(
     iface === 'Remotable' || iface.startsWith('Alleged: '),
     details`For now, iface ${iface} must be "Remotable" or begin with "Alleged: "; unimplemented`,

--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -167,6 +167,7 @@ export function buildRootObject() {
           return mintyIssuerRecord;
         },
         mintGains: (gains, zcfSeat = undefined) => {
+          // TODO unimplemented
           assert(
             zcfSeat !== undefined,
             details`On demand seat creation not yet implemented`,

--- a/packages/zoe/src/types.js
+++ b/packages/zoe/src/types.js
@@ -232,7 +232,9 @@
  *
  * Mint that amount of assets into the pooled purse.
  * If a seat is provided, it is returned. Otherwise a new seat is
- * returned. TODO This creation-on-demand is not yet implemented.
+ * returned.
+ * TODO unimplemented
+ * This creation-on-demand is not yet implemented.
  *
  * @property {(losses: AmountKeywordRecord,
  *             zcfSeat: ZCFSeat,


### PR DESCRIPTION
Just grepped for "implemented" to find error messages, etc, that complain that something is not yet implemented, or words to that effect. Added a
```js
// TODO unimplemented
```
to make these easier to find, as a first step a towards a more principled treatment of these.

Please look at each individual case and advise if it needs a different approach immediately.