### PR TITLE
Robust block manager and more

### DIFF
--- a/packages/captp/lib/captp.js
+++ b/packages/captp/lib/captp.js
@@ -274,7 +274,6 @@ export function makeCapTP(ourId, rawSend, bootstrapObj = undefined, opts = {}) {
       } else {
         pr.res(unserialize(result));
       }
-      questions.delete(answerID);
     },
     // Resolution to an imported promise
     async CTP_RESOLVE(obj) {

--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -89,7 +89,7 @@ scenario2-setup-nobuild:
 	$(MAKE) set-local-gci-ingress
 
 scenario2-run-chain:
-	$(AGC) `$(BREAK_CHAIN) && echo --inspect-brk` --home=t1/n0 start --pruning=nothing
+	$(AGC) `$(BREAK_CHAIN) && echo --inspect-brk` --home=t1/n0 start
 
 # Provision and start a client.
 scenario2-run-client: t1-provision-one-with-powers t1-start-ag-solo

--- a/packages/cosmic-swingset/scripts/single-node.sh
+++ b/packages/cosmic-swingset/scripts/single-node.sh
@@ -56,4 +56,4 @@ sedi 's/timeout_propose = "3s"/timeout_propose = "1s"/g' ~/.$DAEMON/config/confi
 sedi 's/index_all_keys = false/index_all_keys = true/g' ~/.$DAEMON/config/config.toml
 
 # Start the chain
-$DAEMON start --pruning=nothing
+$DAEMON start


### PR DESCRIPTION
I acted all Chaos-Monkey, and terminated `ag-chain-cosmos` first immediately before and later immediately after the `saveOutsideState` call in `COMMIT_BLOCK`.  When I did that then restarted the process, I got the following error:

```
launch-chain: Launching SwingSet kernel
launch-chain: checking for saved mailbox state true
SwingSet: controller: SwingSet global metering is enabled
SwingSet: kernel: Replaying SwingSet transcripts
E[2020-08-24|09:18:21.076] CONSENSUS FAILURE!!!                         module=consensus err="Error: Unimplemented reset state from 269 to 270\n  at blockManager (/Users/michael/agoric/agoric-sdk/packages/cosmic-swingset/lib/block-manager.js:135:25)\n
```

This matches what some people have seen on the testnet.

Moving the `saveOutsideState` call into `END_BLOCK`, and repeating the experiment, was robust and recovered just fine.

So, this PR does that, as a minimally invasive change.

We also remove some unnecessary `--pruning=nothing` flags.  And a CapTP mistake that was originally described in #1259.
