### PR TITLE
fix: add shutdown() to atomicSwap, coveredCall, and sellItems.

### DIFF
--- a/packages/zoe/src/contractFacet/seat.js
+++ b/packages/zoe/src/contractFacet/seat.js
@@ -22,7 +22,8 @@ export const makeZcfSeatAdminKit = (
   let currentAllocation = harden(seatData.initialAllocation);
   let exited = false; // seat is "active"
 
-  const assertExitedFalse = () => assert(!exited, `seat has been exited`);
+  const assertExitedFalse = () =>
+    assert(!exited, details`seat has been exited`);
 
   /** @type {ZCFSeatAdmin} */
   const zcfSeatAdmin = harden({

--- a/packages/zoe/src/contracts/atomicSwap.js
+++ b/packages/zoe/src/contracts/atomicSwap.js
@@ -28,8 +28,11 @@ const start = zcf => {
     const { want, give } = firstSeat.getProposal();
 
     /** @type {OfferHandler} */
-    const matchingSeatOfferHandler = matchingSeat =>
-      swap(zcf, firstSeat, matchingSeat);
+    const matchingSeatOfferHandler = matchingSeat => {
+      const swapResult = swap(zcf, firstSeat, matchingSeat);
+      zcf.shutdown();
+      return swapResult;
+    };
 
     const matchingSeatInvitation = zcf.makeInvitation(
       matchingSeatOfferHandler,

--- a/packages/zoe/src/contracts/coveredCall.js
+++ b/packages/zoe/src/contracts/coveredCall.js
@@ -49,7 +49,9 @@ const start = zcf => {
     const rejectMsg = `The covered call option is expired.`;
 
     const exerciseOption = exerciserSeat => {
-      return swap(zcf, sellerSeat, exerciserSeat, rejectMsg);
+      const swapResult = swap(zcf, sellerSeat, exerciserSeat, rejectMsg);
+      zcf.shutdown();
+      return swapResult;
     };
 
     const exerciseOptionExpected = harden({

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -98,7 +98,7 @@ const start = zcf => {
     // The buyer's offer has been processed.
     buyerSeat.exit();
 
-    if (publicFacet.getAvailableItems().value.length === 0) {
+    if (itemsMath.isEmpty(publicFacet.getAvailableItems())) {
       zcf.shutdown();
     }
     return defaultAcceptanceMsg;

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -27,6 +27,11 @@ import '../../exported';
  * available to sell, and the money should be pricePerItem times the number of
  * items requested.
  *
+ * When all the items have been sold, the contract will terminate, triggering
+ * the creator's payout. If the creator has an onDemand exit clause, they can
+ * exit early to collect their winnings. The remaining items will still be
+ * available for sale, but the creator won't be able to collect later earnings.
+ *
  * @type {ContractStartFn}
  */
 const start = zcf => {
@@ -44,6 +49,15 @@ const start = zcf => {
   const sell = seat => {
     sellerSeat = seat;
     return defaultAcceptanceMsg;
+  };
+
+  /** @type {SellItemsPublicFacet} */
+  const publicFacet = {
+    getAvailableItems: () => {
+      assert(sellerSeat && !sellerSeat.hasExited(), `no items are for sale`);
+      return sellerSeat.getAmountAllocated('Items');
+    },
+    getItemsIssuer: () => issuers.Items,
   };
 
   const buy = buyerSeat => {
@@ -83,16 +97,11 @@ const start = zcf => {
 
     // The buyer's offer has been processed.
     buyerSeat.exit();
-    return defaultAcceptanceMsg;
-  };
 
-  /** @type {SellItemsPublicFacet} */
-  const publicFacet = {
-    getAvailableItems: () => {
-      assert(sellerSeat && !sellerSeat.hasExited(), `no items are for sale`);
-      return sellerSeat.getAmountAllocated('Items');
-    },
-    getItemsIssuer: () => issuers.Items,
+    if (publicFacet.getAvailableItems().value.length === 0) {
+      zcf.shutdown();
+    }
+    return defaultAcceptanceMsg;
   };
 
   /** @type {SellItemsCreatorFacet} */

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -291,7 +291,7 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
         },
         shutdown: () => {
           exitAllSeats();
-          adminNode.terminate();
+          E(adminNode).terminate();
         },
         makeZoeMint,
       };

--- a/packages/zoe/test/unitTests/contracts/test-sellTickets.js
+++ b/packages/zoe/test/unitTests/contracts/test-sellTickets.js
@@ -507,8 +507,6 @@ test(`mint and sell opera tickets`, async t => {
 
     const operaPurse = moolaIssuer.makeEmptyPurse();
 
-    await E(sellItemsCreatorSeat).tryExit();
-
     const moneyPayment = await E(sellItemsCreatorSeat).getPayout('Money');
     await E(operaPurse).deposit(moneyPayment);
     const currentPurseBalance = await E(operaPurse).getCurrentAmount();


### PR DESCRIPTION
atomicSwap already had obvious places to say they were finished. 

sellItems had to check that the items were all sold.

fixes #1606 