### PR TITLE
fix: remove console.error in assert.js

### DIFF
--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -162,7 +162,7 @@ function details(template, ...args) {
         parts.push('\nSee console for error data.');
       }
       const err = new Error(parts.join(''));
-      console.error('LOGGED ERROR:', ...interleaved, err);
+      // console.error('LOGGED ERROR:', ...interleaved, err);
       // eslint-disable-next-line no-debugger
       debugger;
       return err;

--- a/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
@@ -436,7 +436,6 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
       `inboxStateChangeLog with names`,
     );
 
-    console.log('EXPECTED ERROR ->>> "petname" not found');
     t.throws(
       () => wallet.getInstallation('whatever'),
       /"petname" not found/,

--- a/packages/notifier/src/notifier.js
+++ b/packages/notifier/src/notifier.js
@@ -108,6 +108,8 @@ export const makeNotifierKit = (...args) => {
       assert(nextPromiseKit);
       currentUpdateCount = undefined;
       currentResponse = undefined;
+      // Don't trigger Node.js's UnhandledPromiseRejectionWarning
+      nextPromiseKit.promise.catch(_ => {});
       nextPromiseKit.reject(reason);
     },
   });

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "yarn build-zcfBundle",
-    "test": "yarn build && tap --no-coverage --jobs=1 --timeout 600 'test/**/test-*.js'",
+    "test": "ava",
     "build-zcfBundle": "node -r esm scripts/build-zcfBundle.js",
     "lint-fix": "yarn lint --fix",
     "lint-check": "yarn lint",
@@ -53,16 +53,21 @@
     "@agoric/install-metering-and-ses": "^0.1.1",
     "@agoric/install-ses": "^0.2.0",
     "@agoric/swingset-vat": "^0.6.0",
-    "esm": "^3.2.25",
-    "tap": "^14.10.5",
-    "tape": "^4.11.0",
-    "tape-promise": "^4.0.0"
+    "ava": "^3.11.1",
+    "esm": "^3.2.25"
   },
   "files": [
     "src/",
-    "*.js",
     "NEWS.md"
   ],
+  "ava": {
+    "files": [
+      "test/**/test-*.js"
+    ],
+    "require": [
+      "esm"
+    ]
+  },
   "eslintConfig": {
     "extends": [
       "airbnb-base",

--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -282,7 +282,11 @@ export function buildRootObject() {
         const proposal = cleanProposal(getAmountMath, harden({}));
         const { notifier, updater } = makeNotifierKit();
         const zoeSeatAdminPromiseKit = makePromiseKit();
+        // Don't trigger Node.js's UnhandledPromiseRejectionWarning
+        zoeSeatAdminPromiseKit.promise.catch(_ => {});
         const userSeatPromiseKit = makePromiseKit();
+        // Don't trigger Node.js's UnhandledPromiseRejectionWarning
+        userSeatPromiseKit.promise.catch(_ => {});
 
         E(zoeInstanceAdmin)
           .makeOfferlessSeat(initialAllocation, proposal)
@@ -332,7 +336,6 @@ export function buildRootObject() {
         const offerHandler = invitationHandleToHandler.get(invitationHandle);
         // @ts-ignore
         const offerResultP = E(offerHandler)(zcfSeat).catch(reason => {
-          console.error(reason);
           if (!zcfSeat.hasExited()) {
             throw zcfSeat.kickOut(reason);
           } else {

--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -355,10 +355,12 @@ export function buildRootObject() {
 
     // First, evaluate the contract code bundle.
     const contractCode = evalContractBundle(bundle);
+    // Don't trigger Node.js's UnhandledPromiseRejectionWarning
+    contractCode.catch(() => {});
 
     // Next, execute the contract code, passing in zcf
-    /** @type {Promise<Invitation>} */
-    return E(contractCode)
+    /** @type {Promise<ExecuteContractResult>} */
+    const result = E(contractCode)
       .start(zcf)
       .then(({ creatorFacet, publicFacet, creatorInvitation }) => {
         return harden({
@@ -368,6 +370,8 @@ export function buildRootObject() {
           addSeatObj,
         });
       });
+    result.catch(() => {}); // Don't trigger Node.js's UnhandledPromiseRejectionWarning
+    return result;
   };
 
   return harden({ executeContract });

--- a/packages/zoe/src/contractFacet/evalContractCode.js
+++ b/packages/zoe/src/contractFacet/evalContractCode.js
@@ -23,7 +23,7 @@ const evalContractBundle = (bundle, additionalEndowments = {}) => {
 
   const installation = importBundle(bundle, {
     endowments: fullEndowments,
-  });
+  }).catch(() => {}); // Don't trigger Node.js's UnhandledPromiseRejectionWarning
   return installation;
 };
 

--- a/packages/zoe/src/contractFacet/seat.js
+++ b/packages/zoe/src/contractFacet/seat.js
@@ -56,7 +56,6 @@ export const makeZcfSeatAdminKit = (
       assertExitedFalse();
       zcfSeatAdmin.updateHasExited();
       E(zoeSeatAdmin).kickOut(harden(reason));
-      console.error(reason);
       throw reason;
     },
     getNotifier: () => {

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -59,7 +59,7 @@
  * @typedef {Object} ZoeSeatAdmin
  * @property {(allocation: Allocation) => void} replaceAllocation
  * @property {() => void} exit
- * @property {(reason: any) => never} kickOut called with the reason this seat
+ * @property {(reason: any) => void} kickOut called with the reason this seat
  * is being kicked out, where reason is normally an instanceof Error.
  * @property {() => Allocation} getCurrentAllocation
  */
@@ -173,7 +173,7 @@
  * @param {Issuer} invitationIssuer
  * @param {ZoeInstanceAdmin} zoeInstanceAdmin
  * @param {InstanceRecord} instanceRecord
- * @returns {ExecuteContractResult}
+ * @returns {Promise<ExecuteContractResult>}
  *
  */
 

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -223,7 +223,11 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
 
       const bundle = installation.getBundle();
       const addSeatObjPromiseKit = makePromiseKit();
+      // Don't trigger Node.js's UnhandledPromiseRejectionWarning
+      addSeatObjPromiseKit.promise.catch(_ => {});
       const publicFacetPromiseKit = makePromiseKit();
+      // Don't trigger Node.js's UnhandledPromiseRejectionWarning
+      publicFacetPromiseKit.promise.catch(_ => {});
 
       /** @type {InstanceAdmin} */
       const instanceAdmin = {
@@ -377,7 +381,11 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
           const initialAllocation = arrayToObj(amountsArray, proposalKeywords);
 
           const offerResultPromiseKit = makePromiseKit();
+          // Don't trigger Node.js's UnhandledPromiseRejectionWarning
+          offerResultPromiseKit.promise.catch(_ => {});
           const exitObjPromiseKit = makePromiseKit();
+          // Don't trigger Node.js's UnhandledPromiseRejectionWarning
+          exitObjPromiseKit.promise.catch(_ => {});
           const instanceAdmin = instanceToInstanceAdmin.get(instance);
 
           const { userSeat, notifier, zoeSeatAdmin } = makeZoeSeatAdminKit(
@@ -398,6 +406,10 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
             .then(({ offerResultP, exitObj }) => {
               offerResultPromiseKit.resolve(offerResultP);
               exitObjPromiseKit.resolve(exitObj);
+            })
+            .catch(err => {
+              console.log(err);
+              console.log('right here');
             });
 
           return userSeat;

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -38,6 +38,8 @@ export const makeZoeSeatAdminKit = (
   { offerResult = undefined, exitObj = defaultExitObj } = {},
 ) => {
   const payoutPromiseKit = makePromiseKit();
+  // Don't trigger Node.js's UnhandledPromiseRejectionWarning
+  payoutPromiseKit.promise.catch(_ => {});
   const { notifier, updater } = makeNotifierKit();
 
   let currentAllocation = initialAllocation;
@@ -82,8 +84,6 @@ export const makeZoeSeatAdminKit = (
       );
       updater.fail(reason);
       doExit(zoeSeatAdmin);
-      console.log(reason);
-      throw reason;
     },
     getCurrentAllocation: () => currentAllocation,
   });

--- a/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
@@ -1,6 +1,6 @@
 import '@agoric/install-metering-and-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from 'tape-promise/tape';
+import test from 'ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { loadBasedir, buildVatController } from '@agoric/swingset-vat';
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -39,13 +39,8 @@ const meterExceededInOfferLog = [
 ];
 
 test('ZCF metering crash on invitation exercise', async t => {
-  t.plan(1);
-  try {
-    const dump = await main(['meterInOfferHook', [3, 0, 0]]);
-    t.deepEquals(dump.log, meterExceededInOfferLog);
-  } catch (e) {
-    t.isNot(e, e, 'unexpected metering exception in crashing contract test');
-  }
+  const dump = await main(['meterInOfferHook', [3, 0, 0]]);
+  t.deepEqual(dump.log, meterExceededInOfferLog);
 });
 
 const meterExceededInSecondOfferLog = [
@@ -66,13 +61,8 @@ const meterExceededInSecondOfferLog = [
 ];
 
 test('ZCF metering crash on invitation exercise', async t => {
-  t.plan(1);
-  try {
-    const dump = await main(['meterInSecondInvitation', [8, 0, 0]]);
-    t.deepEquals(dump.log, meterExceededInSecondOfferLog);
-  } catch (e) {
-    t.isNot(e, e, 'unexpected metering exception in crashing contract test');
-  }
+  const dump = await main(['meterInSecondInvitation', [8, 0, 0]]);
+  t.deepEqual(dump.log, meterExceededInSecondOfferLog);
 });
 
 const throwInOfferLog = [
@@ -92,13 +82,8 @@ const throwInOfferLog = [
 ];
 
 test('ZCF throwing on invitation exercise', async t => {
-  t.plan(1);
-  try {
-    const dump = await main(['throwInOfferHook', [3, 0, 0]]);
-    t.deepEquals(dump.log, throwInOfferLog);
-  } catch (e) {
-    t.isNot(e, e, 'unexpected throw in crashing contract test');
-  }
+  const dump = await main(['throwInOfferHook', [3, 0, 0]]);
+  t.deepEqual(dump.log, throwInOfferLog);
 });
 
 const throwInAPILog = [
@@ -119,13 +104,8 @@ const throwInAPILog = [
 ];
 
 test('ZCF throwing in API call', async t => {
-  t.plan(1);
-  try {
-    const dump = await main(['throwInApiCall', [5, 12, 0]]);
-    t.deepEquals(dump.log, throwInAPILog);
-  } catch (e) {
-    t.isNot(e, e, 'unexpected API throw in crashing contract test');
-  }
+  const dump = await main(['throwInApiCall', [5, 12, 0]]);
+  t.deepEqual(dump.log, throwInAPILog);
 });
 
 const meteringExceededInAPILog = [
@@ -143,17 +123,8 @@ const meteringExceededInAPILog = [
 ];
 
 test('ZCF metering crash in API call', async t => {
-  t.plan(1);
-  try {
-    const dump = await main(['meterInApiCall', [3, 0, 0]]);
-    t.deepEquals(dump.log, meteringExceededInAPILog);
-  } catch (e) {
-    t.isNot(
-      e,
-      e,
-      'unexpected API metering exception in crashing contract test',
-    );
-  }
+  const dump = await main(['meterInApiCall', [3, 0, 0]]);
+  t.deepEqual(dump.log, meteringExceededInAPILog);
 });
 
 const meteringExceptionInMakeContractILog = [
@@ -164,17 +135,8 @@ const meteringExceptionInMakeContractILog = [
 ];
 
 test('ZCF metering crash in makeContract call', async t => {
-  t.plan(1);
-  try {
-    const dump = await main(['meterInMakeContract', [3, 0, 0]]);
-    t.deepEquals(dump.log, meteringExceptionInMakeContractILog);
-  } catch (e) {
-    t.isNot(
-      e,
-      e,
-      'unexpected API metering exception in crashing contract test',
-    );
-  }
+  const dump = await main(['meterInMakeContract', [3, 0, 0]]);
+  t.deepEqual(dump.log, meteringExceptionInMakeContractILog);
 });
 
 const thrownExceptionInMakeContractILog = [
@@ -185,15 +147,6 @@ const thrownExceptionInMakeContractILog = [
 ];
 
 test('ZCF metering crash in makeContract call', async t => {
-  t.plan(1);
-  try {
-    const dump = await main(['throwInMakeContract', [3, 0, 0]]);
-    t.deepEquals(dump.log, thrownExceptionInMakeContractILog);
-  } catch (e) {
-    t.isNot(
-      e,
-      e,
-      'unexpected API metering exception in crashing contract test',
-    );
-  }
+  const dump = await main(['throwInMakeContract', [3, 0, 0]]);
+  t.deepEqual(dump.log, thrownExceptionInMakeContractILog);
 });

--- a/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
@@ -60,7 +60,7 @@ const meterExceededInSecondOfferLog = [
   'counter: 2',
 ];
 
-test('ZCF metering crash on invitation exercise', async t => {
+test('ZCF metering crash on second invitation', async t => {
   const dump = await main(['meterInSecondInvitation', [8, 0, 0]]);
   t.deepEqual(dump.log, meterExceededInSecondOfferLog);
 });
@@ -146,7 +146,7 @@ const thrownExceptionInMakeContractILog = [
   'newCounter: 2',
 ];
 
-test('ZCF metering crash in makeContract call', async t => {
+test('throw in makeContract call', async t => {
   const dump = await main(['throwInMakeContract', [3, 0, 0]]);
   t.deepEqual(dump.log, thrownExceptionInMakeContractILog);
 });

--- a/packages/zoe/test/swingsetTests/zoe-metering/test-zoe-metering.js
+++ b/packages/zoe/test/swingsetTests/zoe-metering/test-zoe-metering.js
@@ -1,5 +1,5 @@
 import '@agoric/install-metering-and-ses';
-import { test } from 'tape-promise/tape';
+import test from 'ava';
 import { loadBasedir, buildVatController } from '@agoric/swingset-vat';
 import fs from 'fs';
 import bundleSource from '../../bundle-source';
@@ -38,13 +38,8 @@ const infiniteInstallLoopLog = [
   'error: RangeError: Compute meter exceeded',
 ];
 test('zoe - metering - infinite loop in installation', async t => {
-  t.plan(1);
-  try {
-    const dump = await main(['infiniteInstallLoop']);
-    t.deepEquals(dump.log, infiniteInstallLoopLog, 'log is correct');
-  } catch (e) {
-    t.isNot(e, e, 'unexpected exception');
-  }
+  const dump = await main(['infiniteInstallLoop']);
+  t.deepEqual(dump.log, infiniteInstallLoopLog, 'log is correct');
 });
 
 const infiniteInstanceLoopLog = [
@@ -53,13 +48,8 @@ const infiniteInstanceLoopLog = [
   'error: RangeError: Compute meter exceeded',
 ];
 test('zoe - metering - infinite loop in instantiation', async t => {
-  t.plan(1);
-  try {
-    const dump = await main(['infiniteInstanceLoop']);
-    t.deepEquals(dump.log, infiniteInstanceLoopLog, 'log is correct');
-  } catch (e) {
-    t.isNot(e, e, 'unexpected exception');
-  }
+  const dump = await main(['infiniteInstanceLoop']);
+  t.deepEqual(dump.log, infiniteInstanceLoopLog, 'log is correct');
 });
 
 const infiniteTestLoopLog = [
@@ -69,13 +59,8 @@ const infiniteTestLoopLog = [
   'error: RangeError: Compute meter exceeded',
 ];
 test('zoe - metering - infinite loop in contract method', async t => {
-  t.plan(1);
-  try {
-    const dump = await main(['infiniteTestLoop']);
-    t.deepEquals(dump.log, infiniteTestLoopLog, 'log is correct');
-  } catch (e) {
-    t.isNot(e, e, 'unexpected exception');
-  }
+  const dump = await main(['infiniteTestLoop']);
+  t.deepEqual(dump.log, infiniteTestLoopLog, 'log is correct');
 });
 
 const testBuiltinsLog = [
@@ -85,11 +70,6 @@ const testBuiltinsLog = [
   'error: RangeError: Allocate meter exceeded',
 ];
 test('zoe - metering - expensive builtins in contract method', async t => {
-  t.plan(1);
-  try {
-    const dump = await main(['testBuiltins']);
-    t.deepEquals(dump.log, testBuiltinsLog, 'log is correct');
-  } catch (e) {
-    t.isNot(e, e, 'unexpected exception');
-  }
+  const dump = await main(['testBuiltins']);
+  t.deepEqual(dump.log, testBuiltinsLog, 'log is correct');
 });

--- a/packages/zoe/test/swingsetTests/zoe/test-zoe.js
+++ b/packages/zoe/test/swingsetTests/zoe/test-zoe.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-metering-and-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'tape-promise/tape';
+import test from 'ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { loadBasedir, buildVatController } from '@agoric/swingset-vat';
 import bundleSource from '@agoric/bundle-source';
@@ -62,17 +62,12 @@ const expectedAutomaticRefundOkLog = [
 ];
 
 test('zoe - automaticRefund - valid inputs', async t => {
-  t.plan(1);
-  try {
-    const startingValues = [
-      [3, 0, 0],
-      [0, 17, 0],
-    ];
-    const dump = await main(['automaticRefundOk', startingValues]);
-    t.deepEquals(dump.log, expectedAutomaticRefundOkLog);
-  } catch (e) {
-    t.isNot(e, e, 'unexpected exception');
-  }
+  const startingValues = [
+    [3, 0, 0],
+    [0, 17, 0],
+  ];
+  const dump = await main(['automaticRefundOk', startingValues]);
+  t.deepEqual(dump.log, expectedAutomaticRefundOkLog);
 });
 
 const expectedCoveredCallOkLog = [
@@ -87,17 +82,12 @@ const expectedCoveredCallOkLog = [
 ];
 
 test('zoe - coveredCall - valid inputs', async t => {
-  t.plan(1);
-  try {
-    const startingValues = [
-      [3, 0, 0],
-      [0, 7, 0],
-    ];
-    const dump = await main(['coveredCallOk', startingValues]);
-    t.deepEquals(dump.log, expectedCoveredCallOkLog);
-  } catch (e) {
-    t.isNot(e, e, 'unexpected exception');
-  }
+  const startingValues = [
+    [3, 0, 0],
+    [0, 7, 0],
+  ];
+  const dump = await main(['coveredCallOk', startingValues]);
+  t.deepEqual(dump.log, expectedCoveredCallOkLog);
 });
 
 const expectedSwapForOptionOkLog = [
@@ -119,19 +109,14 @@ const expectedSwapForOptionOkLog = [
 ];
 
 test('zoe - swapForOption - valid inputs', async t => {
-  t.plan(1);
-  try {
-    const startingValues = [
-      [3, 0, 0], // Alice starts with 3 moola
-      [0, 0, 0], // Bob starts with nothing
-      [0, 0, 0], // Carol starts with nothing
-      [0, 7, 1], // Dave starts with 7 simoleans and 1 buck
-    ];
-    const dump = await main(['swapForOptionOk', startingValues]);
-    t.deepEquals(dump.log, expectedSwapForOptionOkLog);
-  } catch (e) {
-    t.isNot(e, e, 'unexpected exception');
-  }
+  const startingValues = [
+    [3, 0, 0], // Alice starts with 3 moola
+    [0, 0, 0], // Bob starts with nothing
+    [0, 0, 0], // Carol starts with nothing
+    [0, 7, 1], // Dave starts with 7 simoleans and 1 buck
+  ];
+  const dump = await main(['swapForOptionOk', startingValues]);
+  t.deepEqual(dump.log, expectedSwapForOptionOkLog);
 });
 
 const expectedSecondPriceAuctionOkLog = [
@@ -152,19 +137,14 @@ const expectedSecondPriceAuctionOkLog = [
   'aliceSimoleanPurse: balance {"brand":{},"value":7}',
 ];
 test('zoe - secondPriceAuction - valid inputs', async t => {
-  t.plan(1);
-  try {
-    const startingValues = [
-      [1, 0, 0],
-      [0, 11, 0],
-      [0, 7, 0],
-      [0, 5, 0],
-    ];
-    const dump = await main(['secondPriceAuctionOk', startingValues]);
-    t.deepEquals(dump.log, expectedSecondPriceAuctionOkLog);
-  } catch (e) {
-    t.isNot(e, e, 'unexpected exception');
-  }
+  const startingValues = [
+    [1, 0, 0],
+    [0, 11, 0],
+    [0, 7, 0],
+    [0, 5, 0],
+  ];
+  const dump = await main(['secondPriceAuctionOk', startingValues]);
+  t.deepEqual(dump.log, expectedSecondPriceAuctionOkLog);
 });
 
 const expectedAtomicSwapOkLog = [
@@ -176,17 +156,12 @@ const expectedAtomicSwapOkLog = [
   'bobSimoleanPurse: balance {"brand":{},"value":0}',
 ];
 test('zoe - atomicSwap - valid inputs', async t => {
-  t.plan(1);
-  try {
-    const startingValues = [
-      [3, 0, 0],
-      [0, 7, 0],
-    ];
-    const dump = await main(['atomicSwapOk', startingValues]);
-    t.deepEquals(dump.log, expectedAtomicSwapOkLog);
-  } catch (e) {
-    t.isNot(e, e, 'unexpected exception');
-  }
+  const startingValues = [
+    [3, 0, 0],
+    [0, 7, 0],
+  ];
+  const dump = await main(['atomicSwapOk', startingValues]);
+  t.deepEqual(dump.log, expectedAtomicSwapOkLog);
 });
 
 const expectedSimpleExchangeOkLog = [
@@ -200,17 +175,12 @@ const expectedSimpleExchangeOkLog = [
 ];
 
 test('zoe - simpleExchange - valid inputs', async t => {
-  t.plan(1);
-  try {
-    const startingValues = [
-      [3, 0, 0],
-      [0, 7, 0],
-    ];
-    const dump = await main(['simpleExchangeOk', startingValues]);
-    t.deepEquals(dump.log, expectedSimpleExchangeOkLog);
-  } catch (e) {
-    t.isNot(e, e, 'unexpected exception');
-  }
+  const startingValues = [
+    [3, 0, 0],
+    [0, 7, 0],
+  ];
+  const dump = await main(['simpleExchangeOk', startingValues]);
+  t.deepEqual(dump.log, expectedSimpleExchangeOkLog);
 });
 
 const expectedSimpleExchangeNotificationLog = [
@@ -245,7 +215,7 @@ test('zoe - simpleExchange - state Update', async t => {
     [0, 24, 0],
   ];
   const dump = await main(['simpleExchangeNotifier', startingValues]);
-  t.deepEquals(dump.log, expectedSimpleExchangeNotificationLog);
+  t.deepEqual(dump.log, expectedSimpleExchangeNotificationLog);
 });
 
 const expectedAutoswapOkLog = [
@@ -270,7 +240,7 @@ test('zoe - autoswap - valid inputs', async t => {
     [3, 7, 0],
   ];
   const dump = await main(['autoswapOk', startingValues]);
-  t.deepEquals(dump.log, expectedAutoswapOkLog);
+  t.deepEqual(dump.log, expectedAutoswapOkLog);
 });
 
 const expectedSellTicketsOkLog = [
@@ -287,7 +257,7 @@ test('zoe - sellTickets - valid inputs', async t => {
     [22, 0, 0],
   ];
   const dump = await main(['sellTicketsOk', startingValues]);
-  t.deepEquals(dump.log, expectedSellTicketsOkLog);
+  t.deepEqual(dump.log, expectedSellTicketsOkLog);
 });
 
 const expectedBadTimerLog = [
@@ -304,5 +274,5 @@ test('zoe - bad timer', async t => {
     [0, 0, 0],
   ];
   const dump = await main(['badTimer', startingValues]);
-  t.deepEquals(dump.log, expectedBadTimerLog);
+  t.deepEqual(dump.log, expectedBadTimerLog);
 });

--- a/packages/zoe/test/unitTests/contractSupport/test-bondingCurves.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-bondingCurves.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
-import { test } from 'tape-promise/tape';
+import test from 'ava';
 
 import {
   getInputPrice,
@@ -9,116 +9,81 @@ import {
 
 const testGetPrice = (t, input, expectedOutput) => {
   const output = getInputPrice(input);
-  t.deepEquals(output, expectedOutput);
+  t.deepEqual(output, expectedOutput);
 };
 
 // If these tests of `getInputPrice` fail, it would indicate that we have
 // diverged from the calculation in the Uniswap paper.
 test('getInputPrice ok 1', t => {
-  t.plan(1);
-  try {
-    const input = {
-      inputReserve: 0,
-      outputReserve: 0,
-      inputValue: 1,
-    };
-    const expectedOutput = 0;
-    testGetPrice(t, input, expectedOutput);
-  } catch (e) {
-    t.assert(false, e);
-  }
+  const input = {
+    inputReserve: 0,
+    outputReserve: 0,
+    inputValue: 1,
+  };
+  const expectedOutput = 0;
+  testGetPrice(t, input, expectedOutput);
 });
 
 test('getInputPrice ok 2', t => {
-  t.plan(1);
-  try {
-    const input = {
-      inputReserve: 5984,
-      outputReserve: 3028,
-      inputValue: 1398,
-    };
-    const expectedOutput = 572;
-    testGetPrice(t, input, expectedOutput);
-  } catch (e) {
-    t.assert(false, e);
-  }
+  const input = {
+    inputReserve: 5984,
+    outputReserve: 3028,
+    inputValue: 1398,
+  };
+  const expectedOutput = 572;
+  testGetPrice(t, input, expectedOutput);
 });
 
 test('getInputPrice ok 3', t => {
-  t.plan(1);
-  try {
-    const input = {
-      inputReserve: 8160,
-      outputReserve: 7743,
-      inputValue: 6635,
-    };
-    const expectedOutput = 3466;
-    testGetPrice(t, input, expectedOutput);
-  } catch (e) {
-    t.assert(false, e);
-  }
+  const input = {
+    inputReserve: 8160,
+    outputReserve: 7743,
+    inputValue: 6635,
+  };
+  const expectedOutput = 3466;
+  testGetPrice(t, input, expectedOutput);
 });
 
 test('getInputPrice reverse x and y amounts', t => {
-  t.plan(1);
-  try {
-    // Note: this is now the same test as the one above because we are
-    // only using values
-    const input = {
-      inputReserve: 8160,
-      outputReserve: 7743,
-      inputValue: 6635,
-    };
-    const expectedOutput = 3466;
-    testGetPrice(t, input, expectedOutput);
-  } catch (e) {
-    t.assert(false, e);
-  }
+  // Note: this is now the same test as the one above because we are
+  // only using values
+  const input = {
+    inputReserve: 8160,
+    outputReserve: 7743,
+    inputValue: 6635,
+  };
+  const expectedOutput = 3466;
+  testGetPrice(t, input, expectedOutput);
 });
 
 test('getInputPrice ok 4', t => {
-  t.plan(1);
-  try {
-    const input = {
-      inputReserve: 10,
-      outputReserve: 10,
-      inputValue: 1000,
-    };
-    const expectedOutput = 9;
-    testGetPrice(t, input, expectedOutput);
-  } catch (e) {
-    t.assert(false, e);
-  }
+  const input = {
+    inputReserve: 10,
+    outputReserve: 10,
+    inputValue: 1000,
+  };
+  const expectedOutput = 9;
+  testGetPrice(t, input, expectedOutput);
 });
 
 test('getInputPrice ok 5', t => {
-  t.plan(1);
-  try {
-    const input = {
-      inputReserve: 100,
-      outputReserve: 50,
-      inputValue: 17,
-    };
-    const expectedOutput = 7;
-    testGetPrice(t, input, expectedOutput);
-  } catch (e) {
-    t.assert(false, e);
-  }
+  const input = {
+    inputReserve: 100,
+    outputReserve: 50,
+    inputValue: 17,
+  };
+  const expectedOutput = 7;
+  testGetPrice(t, input, expectedOutput);
 });
 
 test('getInputPrice ok 6', t => {
-  t.plan(1);
-  try {
-    const input = {
-      outputReserve: 117,
-      inputReserve: 43,
-      inputValue: 7,
-    };
-    const expectedOutput = 16;
-    testGetPrice(t, input, expectedOutput);
-  } catch (e) {
-    t.assert(false, e);
-  }
+  const input = {
+    outputReserve: 117,
+    inputReserve: 43,
+    inputValue: 7,
+  };
+  const expectedOutput = 16;
+  testGetPrice(t, input, expectedOutput);
 });
 
 test('calculate value to mint - positive supply', t => {
@@ -127,8 +92,7 @@ test('calculate value to mint - positive supply', t => {
     inputValue: 30,
     inputReserve: 5,
   });
-  t.equals(res, (20 * 30) / 5, 'When supply is present, floor(x*y/z)');
-  t.end();
+  t.is(res, (20 * 30) / 5, 'When supply is present, floor(x*y/z)');
 });
 
 test('calculate value to mint - mispelled key', t => {
@@ -141,7 +105,6 @@ test('calculate value to mint - mispelled key', t => {
       }),
     `calcLiqValueToMint should throw if a key is misspelled`,
   );
-  t.end();
 });
 
 test('calculate value to mint - positive supply', t => {
@@ -150,8 +113,7 @@ test('calculate value to mint - positive supply', t => {
     inputValue: 8,
     inputReserve: 7,
   });
-  t.equals(res, 5, 'When supply is present, floor(x*y/z)');
-  t.end();
+  t.is(res, 5, 'When supply is present, floor(x*y/z)');
 });
 
 test('calculate value to mint - no supply', t => {
@@ -160,6 +122,5 @@ test('calculate value to mint - no supply', t => {
     inputValue: 30,
     inputReserve: 5,
   });
-  t.equals(res, 30, 'When the supply is empty, return inputValue');
-  t.end();
+  t.is(res, 30, 'When the supply is empty, return inputValue');
 });

--- a/packages/zoe/test/unitTests/contractSupport/test-bondingCurves.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-bondingCurves.js
@@ -86,7 +86,7 @@ test('getInputPrice ok 6', t => {
   testGetPrice(t, input, expectedOutput);
 });
 
-test('calculate value to mint - positive supply', t => {
+test('calculate value to mint - positive supply 1', t => {
   const res = calcLiqValueToMint({
     liqTokenSupply: 20,
     inputValue: 30,
@@ -103,11 +103,14 @@ test('calculate value to mint - mispelled key', t => {
         inputValue: 30,
         inputReserve: 5,
       }),
+    {
+      message: /value required/,
+    },
     `calcLiqValueToMint should throw if a key is misspelled`,
   );
 });
 
-test('calculate value to mint - positive supply', t => {
+test('calculate value to mint - positive supply 2', t => {
   const res = calcLiqValueToMint({
     liqTokenSupply: 5,
     inputValue: 8,

--- a/packages/zoe/test/unitTests/contractSupport/test-stateMachine.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-stateMachine.js
@@ -1,28 +1,24 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
-import { test } from 'tape-promise/tape';
+import test from 'ava';
 
 import { makeStateMachine } from '../../../src/contractSupport';
 
 test('stateMachine', t => {
   t.plan(4);
-  try {
-    const startState = 'empty';
-    const allowedTransitions = [
-      ['empty', ['open']],
-      ['open', ['rellocating', 'cancelled']],
-      ['reallocating', ['dispersing']],
-      ['dispersing', ['closed']],
-      ['cancelled', []],
-      ['closed', []],
-    ];
-    const stateMachine = makeStateMachine(startState, allowedTransitions);
-    t.equal(stateMachine.getStatus(), 'empty');
-    t.ok(stateMachine.canTransitionTo('open'));
-    t.notOk(stateMachine.canTransitionTo('closed'));
-    stateMachine.transitionTo('open');
-    t.equal(stateMachine.getStatus(), 'open');
-  } catch (e) {
-    t.assert(false, e);
-  }
+  const startState = 'empty';
+  const allowedTransitions = [
+    ['empty', ['open']],
+    ['open', ['rellocating', 'cancelled']],
+    ['reallocating', ['dispersing']],
+    ['dispersing', ['closed']],
+    ['cancelled', []],
+    ['closed', []],
+  ];
+  const stateMachine = makeStateMachine(startState, allowedTransitions);
+  t.is(stateMachine.getStatus(), 'empty');
+  t.truthy(stateMachine.canTransitionTo('open'));
+  t.falsy(stateMachine.canTransitionTo('closed'));
+  stateMachine.transitionTo('open');
+  t.is(stateMachine.getStatus(), 'open');
 });

--- a/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from 'tape-promise/tape';
+import test from 'ava';
 
 import makeStore from '@agoric/store';
 import { setup } from '../setupBasicMints';
@@ -12,15 +12,10 @@ import {
 } from '../../../src/contractSupport';
 
 test('ZoeHelpers messages', t => {
-  t.plan(1);
-  try {
-    t.equals(
+    t.is(
       defaultAcceptanceMsg,
       `The offer has been accepted. Once the contract has been completed, please check your payout`,
     );
-  } catch (e) {
-    t.assert(false, e);
-  }
 });
 
 function makeMockZoeBuilder() {
@@ -64,7 +59,6 @@ function makeMockZoeBuilder() {
 test.skip('ZoeHelpers assertKeywords', t => {
   t.plan(5);
   const { moolaR, simoleanR } = setup();
-  try {
     const mockZCFBuilder = makeMockZoeBuilder();
     mockZCFBuilder.setInstanceRecord({
       issuerKeywordRecord: {
@@ -98,16 +92,12 @@ test.skip('ZoeHelpers assertKeywords', t => {
       /were not as expected/,
       `a missing keyword will throw`,
     );
-  } catch (e) {
-    t.assert(false, e);
-  }
 });
 
 test.skip('ZoeHelpers rejectIfNotProposal', t => {
   t.plan(8);
   const { moola, simoleans } = setup();
   const offerHandles = harden([{}, {}, {}, {}, {}, {}, {}]);
-  try {
     const mockZCFBuilder = makeMockZoeBuilder();
     mockZCFBuilder.addOffer(offerHandles[4], {
       proposal: {
@@ -185,7 +175,7 @@ test.skip('ZoeHelpers rejectIfNotProposal', t => {
       /The offer was invalid. Please check your refund./,
       `had the wrong exit rule`,
     );
-    t.deepEquals(
+    t.deepEqual(
       mockZCF.getCompletedHandles(),
       [],
       `offers 1, 2, 3, (zero-indexed) won't be completed before rejection`,
@@ -218,19 +208,14 @@ test.skip('ZoeHelpers rejectIfNotProposal', t => {
       /The offer was invalid. Please check your refund./,
       `had the wrong want`,
     );
-    t.deepEquals(
+    t.deepEqual(
       mockZCF.getCompletedHandles(),
       [],
       `offers won't be completed before rejection`,
     );
-  } catch (e) {
-    t.assert(false, e);
-  }
 });
 
 test.skip('ZoeHelpers getActiveOffers', t => {
-  t.plan(1);
-  try {
     // uses its own mock because all it needs is a variant getOffers.
     const mockZCF = harden({
       getZoeService: () => {},
@@ -246,20 +231,16 @@ test.skip('ZoeHelpers getActiveOffers', t => {
     });
     const { getActiveOffers } = makeZoeHelpers(mockZCF);
     const offerHandles = harden([{}, {}]);
-    t.deepEquals(
+    t.deepEqual(
       getActiveOffers(offerHandles),
       harden([{ handle: offerHandles[0], id: 0 }]),
       `active offers gotten`,
     );
-  } catch (e) {
-    t.assert(false, e);
-  }
 });
 
 test.skip('ZoeHelpers rejectOffer', t => {
   t.plan(4);
   const completedOfferHandles = [];
-  try {
     const mockZCF = harden({
       getZoeService: () => {},
       complete: handles => completedOfferHandles.push(...handles),
@@ -271,20 +252,17 @@ test.skip('ZoeHelpers rejectOffer', t => {
       /Error: The offer was invalid. Please check your refund./,
       `rejectOffer intentionally throws`,
     );
-    t.deepEquals(completedOfferHandles, harden([]), 'no completion');
+    t.deepEqual(completedOfferHandles, harden([]), 'no completion');
     t.throws(
       () => rejectOffer(offerHandles[1], 'offer was wrong'),
       /Error: offer was wrong/,
       `rejectOffer throws with custom msg`,
     );
-    t.deepEquals(
+    t.deepEqual(
       completedOfferHandles,
       [],
       'rejection does not include completions',
     );
-  } catch (e) {
-    t.assert(false, e);
-  }
 });
 
 test.skip('ZoeHelpers swap ok', t => {
@@ -293,7 +271,6 @@ test.skip('ZoeHelpers swap ok', t => {
   const leftOfferHandle = harden({});
   const rightOfferHandle = harden({});
   const cantTradeRightOfferHandle = harden({});
-  try {
     const mockZCFBuilder = makeMockZoeBuilder();
     mockZCFBuilder.addBrand(moolaR);
     mockZCFBuilder.addBrand(simoleanR);
@@ -325,19 +302,19 @@ test.skip('ZoeHelpers swap ok', t => {
     });
     const mockZCF = mockZCFBuilder.build();
     const { swap } = makeZoeHelpers(mockZCF);
-    t.ok(
+    t.truthy(
       swap(
         leftOfferHandle,
         rightOfferHandle,
         'prior offer no longer available',
       ),
     );
-    t.deepEquals(
+    t.deepEqual(
       mockZCF.getReallocatedHandles(),
       harden([leftOfferHandle, rightOfferHandle]),
       `both handles reallocated`,
     );
-    t.deepEquals(
+    t.deepEqual(
       mockZCF.getReallocatedAmountObjs(),
       [
         { Asset: moola(3), Price: simoleans(4) },
@@ -345,14 +322,11 @@ test.skip('ZoeHelpers swap ok', t => {
       ],
       `amounts reallocated passed to reallocate were as expected`,
     );
-    t.deepEquals(
+    t.deepEqual(
       mockZCF.getCompletedHandles(),
       harden([leftOfferHandle, rightOfferHandle]),
       `both handles were completed`,
     );
-  } catch (e) {
-    t.assert(false, e);
-  }
 });
 
 test.skip('ZoeHelpers swap keep inactive', t => {
@@ -361,7 +335,6 @@ test.skip('ZoeHelpers swap keep inactive', t => {
   const leftOfferHandle = harden({});
   const rightOfferHandle = harden({});
   const cantTradeRightOfferHandle = harden({});
-  try {
     const mockZCFBuilder = makeMockZoeBuilder();
     mockZCFBuilder.addOffer(leftOfferHandle, {
       proposal: {
@@ -398,17 +371,14 @@ test.skip('ZoeHelpers swap keep inactive', t => {
       `throws if keepHandle offer is not active`,
     );
     const reallocatedHandles = mockZCF.getReallocatedHandles();
-    t.deepEquals(reallocatedHandles, harden([]), `nothing reallocated`);
+    t.deepEqual(reallocatedHandles, harden([]), `nothing reallocated`);
     const reallocatedAmountObjs = mockZCF.getReallocatedAmountObjs();
-    t.deepEquals(reallocatedAmountObjs, harden([]), `no amounts reallocated`);
-    t.deepEquals(
+    t.deepEqual(reallocatedAmountObjs, harden([]), `no amounts reallocated`);
+    t.deepEqual(
       mockZCF.getCompletedHandles(),
       harden([]),
       `no offers were completed`,
     );
-  } catch (e) {
-    t.assert(false, e);
-  }
 });
 
 test.skip(`ZoeHelpers swap - can't trade with`, t => {
@@ -418,7 +388,6 @@ test.skip(`ZoeHelpers swap - can't trade with`, t => {
   const rightOfferHandle = harden({});
   const cantTradeHandle = harden({});
 
-  try {
     const mockZCFBuilder = makeMockZoeBuilder();
     mockZCFBuilder.addBrand(moolaR);
     mockZCFBuilder.addBrand(simoleanR);
@@ -459,14 +428,11 @@ test.skip(`ZoeHelpers swap - can't trade with`, t => {
       `throws if can't trade with left and right`,
     );
     const reallocatedHandles = mockZcf.getReallocatedHandles();
-    t.deepEquals(reallocatedHandles, harden([]), `nothing reallocated`);
+    t.deepEqual(reallocatedHandles, harden([]), `nothing reallocated`);
     const reallocatedAmountObjs = mockZcf.getReallocatedAmountObjs();
-    t.deepEquals(reallocatedAmountObjs, harden([]), `no amounts reallocated`);
+    t.deepEqual(reallocatedAmountObjs, harden([]), `no amounts reallocated`);
     const completedHandles = mockZcf.getCompletedHandles();
-    t.deepEquals(completedHandles, harden([]), `no offers were completed`);
-  } catch (e) {
-    t.assert(false, e);
-  }
+    t.deepEqual(completedHandles, harden([]), `no offers were completed`);
 });
 
 test.skip('ZoeHelpers isOfferSafe', t => {
@@ -478,7 +444,6 @@ test.skip('ZoeHelpers isOfferSafe', t => {
   const reallocatedHandles = [];
   const reallocatedAmountObjs = [];
   const completedHandles = [];
-  try {
     const mockZCFBuilder = makeMockZoeBuilder();
     mockZCFBuilder.addBrand(moolaR);
     mockZCFBuilder.addBrand(simoleanR);
@@ -496,26 +461,23 @@ test.skip('ZoeHelpers isOfferSafe', t => {
     });
     const mockZCF = mockZCFBuilder.build();
     const { isOfferSafe } = makeZoeHelpers(mockZCF);
-    t.ok(
+    t.truthy(
       isOfferSafe(leftOfferHandle, {
         Asset: moola(0),
         Price: simoleans(4),
       }),
       `giving someone exactly what they want is offer safe`,
     );
-    t.notOk(
+    t.falsy(
       isOfferSafe(leftOfferHandle, {
         Asset: moola(0),
         Price: simoleans(3),
       }),
       `giving someone less than what they want and not what they gave is not offer safe`,
     );
-    t.deepEquals(reallocatedHandles, harden([]), `nothing reallocated`);
-    t.deepEquals(reallocatedAmountObjs, harden([]), `no amounts reallocated`);
-    t.deepEquals(completedHandles, harden([]), `no offers completed`);
-  } catch (e) {
-    t.assert(false, e);
-  }
+    t.deepEqual(reallocatedHandles, harden([]), `nothing reallocated`);
+    t.deepEqual(reallocatedAmountObjs, harden([]), `no amounts reallocated`);
+    t.deepEqual(completedHandles, harden([]), `no offers completed`);
 });
 
 test.skip('ZoeHelpers satisfies', t => {
@@ -527,7 +489,6 @@ test.skip('ZoeHelpers satisfies', t => {
   const reallocatedHandles = [];
   const reallocatedAmountObjs = [];
   const completedHandles = [];
-  try {
     const mockZCFBuilder = makeMockZoeBuilder();
     mockZCFBuilder.addBrand(moolaR);
     mockZCFBuilder.addBrand(simoleanR);
@@ -545,33 +506,30 @@ test.skip('ZoeHelpers satisfies', t => {
     });
     const mockZCF = mockZCFBuilder.build();
     const { satisfies } = makeZoeHelpers(mockZCF);
-    t.ok(
+    t.truthy(
       satisfies(leftOfferHandle, {
         Asset: moola(0),
         Price: simoleans(4),
       }),
       `giving someone exactly what they want satisifies wants`,
     );
-    t.notOk(
+    t.falsy(
       satisfies(leftOfferHandle, {
         Asset: moola(10),
         Price: simoleans(3),
       }),
       `giving someone less than what they want even with a refund doesn't satisfy wants`,
     );
-    t.notOk(
+    t.falsy(
       satisfies(leftOfferHandle, {
         Asset: moola(0),
         Price: simoleans(3),
       }),
       `giving someone less than what they want even with a refund doesn't satisfy wants`,
     );
-    t.deepEquals(reallocatedHandles, harden([]), `nothing reallocated`);
-    t.deepEquals(reallocatedAmountObjs, harden([]), `no amounts reallocated`);
-    t.deepEquals(completedHandles, harden([]), `no offers completed`);
-  } catch (e) {
-    t.assert(false, e);
-  }
+    t.deepEqual(reallocatedHandles, harden([]), `nothing reallocated`);
+    t.deepEqual(reallocatedAmountObjs, harden([]), `no amounts reallocated`);
+    t.deepEqual(completedHandles, harden([]), `no offers completed`);
 });
 
 test.skip('ZoeHelpers trade ok', t => {
@@ -579,7 +537,6 @@ test.skip('ZoeHelpers trade ok', t => {
   const { moolaR, simoleanR, moola, simoleans } = setup();
   const leftOfferHandle = harden({});
   const rightOfferHandle = harden({});
-  try {
     const mockZCFBuilder = makeMockZoeBuilder();
     mockZCFBuilder.addBrand(moolaR);
     mockZCFBuilder.addBrand(simoleanR);
@@ -615,12 +572,12 @@ test.skip('ZoeHelpers trade ok', t => {
         },
       ),
     );
-    t.deepEquals(
+    t.deepEqual(
       mockZCF.getReallocatedHandles(),
       harden([leftOfferHandle, rightOfferHandle]),
       `both handles reallocated`,
     );
-    t.deepEquals(
+    t.deepEqual(
       mockZCF.getReallocatedAmountObjs(),
       [
         { Asset: moola(3), Bid: simoleans(4) },
@@ -628,14 +585,11 @@ test.skip('ZoeHelpers trade ok', t => {
       ],
       `amounts reallocated passed to reallocate were as expected`,
     );
-    t.deepEquals(
+    t.deepEqual(
       mockZCF.getCompletedHandles(),
       harden([]),
       `no handles were completed`,
     );
-  } catch (e) {
-    t.assert(false, e);
-  }
 });
 
 test.skip('ZoeHelpers trade sameHandle', t => {
@@ -643,7 +597,6 @@ test.skip('ZoeHelpers trade sameHandle', t => {
   const { moolaR, simoleanR, moola, simoleans } = setup();
   const leftOfferHandle = harden({});
   const rightOfferHandle = harden({});
-  try {
     const mockZCFBuilder = makeMockZoeBuilder();
     mockZCFBuilder.addBrand(moolaR);
     mockZCFBuilder.addBrand(simoleanR);
@@ -682,22 +635,19 @@ test.skip('ZoeHelpers trade sameHandle', t => {
       /an offer cannot trade with itself/,
       `safe offer trading with itself fails with nice error message`,
     );
-    t.deepEquals(
+    t.deepEqual(
       mockZCF.getReallocatedHandles(),
       harden([]),
       `no handles reallocated`,
     );
-    t.deepEquals(
+    t.deepEqual(
       mockZCF.getReallocatedAmountObjs(),
       [],
       `no amounts reallocated`,
     );
-    t.deepEquals(
+    t.deepEqual(
       mockZCF.getCompletedHandles(),
       harden([]),
       `no handles were completed`,
     );
-  } catch (e) {
-    t.assert(false, e);
-  }
 });

--- a/packages/zoe/test/unitTests/contracts/fakeVatAdmin.js
+++ b/packages/zoe/test/unitTests/contracts/fakeVatAdmin.js
@@ -9,7 +9,10 @@ export default harden({
       root: E(evalContractBundle(bundle)).buildRootObject(),
       adminNode: {
         done: () => {
-          return makePromiseKit().promise;
+          const kit = makePromiseKit();
+          // Don't trigger Node.js's UnhandledPromiseRejectionWarning
+          kit.promise.catch(_ => {});
+          return kit.promise;
         },
         terminate: () => {},
         adminData: () => ({}),

--- a/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
+++ b/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'tape-promise/tape';
+import test from 'ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import bundleSource from '@agoric/bundle-source';
 import { E } from '@agoric/eventual-send';
@@ -48,18 +48,19 @@ test('zoe - atomicSwap', async t => {
           .getPayout('Asset')
           .then(moolaPurse.deposit)
           .then(amountDeposited =>
-            t.deepEquals(
+            t.deepEqual(
               amountDeposited,
               moola(0),
               `Alice didn't get any of what she put in`,
             ),
           );
 
+        // TODO async result should not be dropped on the floor
         E(seat)
           .getPayout('Price')
           .then(simoleanPurse.deposit)
           .then(amountDeposited =>
-            t.deepEquals(
+            t.deepEqual(
               amountDeposited,
               proposal.want.Price,
               `Alice got exactly what she wanted`,
@@ -86,18 +87,17 @@ test('zoe - atomicSwap', async t => {
         // an
         const invitation = await invitationIssuer.claim(untrustedInvitation);
         const invitationValue = await E(zoe).getInvitationDetails(invitation);
-
-        t.equals(
+        t.is(
           invitationValue.installation,
           installation,
           'installation is atomicSwap',
         );
-        t.deepEquals(
+        t.deepEqual(
           invitationValue.asset,
           moola(3),
           `asset to be traded is 3 moola`,
         );
-        t.deepEquals(
+        t.deepEqual(
           invitationValue.price,
           simoleans(7),
           `price is 7 simoleans, so bob must give that`,
@@ -112,38 +112,39 @@ test('zoe - atomicSwap', async t => {
 
         const seat = await zoe.offer(invitation, proposal, payments);
 
-        t.equals(
+        t.is(
           await E(seat).getOfferResult(),
           'The offer has been accepted. Once the contract has been completed, please check your payout',
         );
 
-        E(seat)
+        const r1 = E(seat)
           .getPayout('Asset')
           .then(moolaPurse.deposit)
           .then(amountDeposited =>
-            t.deepEquals(
+            t.deepEqual(
               amountDeposited,
               proposal.want.Asset,
               `Bob got what he wanted`,
             ),
           );
 
-        E(seat)
+        const r2 = E(seat)
           .getPayout('Price')
           .then(simoleanPurse.deposit)
           .then(amountDeposited =>
-            t.deepEquals(
+            t.deepEqual(
               amountDeposited,
               simoleans(0),
               `Bob didn't get anything back`,
             ),
           );
+        await r1;
+        await r2;
       },
     });
   };
 
   const alice = await makeAlice(await E(moolaKit.mint).mintPayment(moola(3)));
-
   // Alice makes an instance and makes her offer.
   const installation = await alice.installCode();
 
@@ -151,6 +152,7 @@ test('zoe - atomicSwap', async t => {
     installation,
     await E(simoleanKit.mint).mintPayment(simoleans(7)),
   );
+
   const { creatorInvitation } = await alice.startInstance(installation);
   const invitation = await alice.offer(creatorInvitation);
 
@@ -207,7 +209,7 @@ test('zoe - non-fungible atomicSwap', async t => {
           .getPayout('Asset')
           .then(ccPurse.deposit)
           .then(amountDeposited =>
-            t.deepEquals(
+            t.deepEqual(
               amountDeposited,
               cryptoCats(harden([])),
               `Alice didn't get any of what she put in`,
@@ -218,7 +220,7 @@ test('zoe - non-fungible atomicSwap', async t => {
           .getPayout('Price')
           .then(rpgPurse.deposit)
           .then(amountDeposited =>
-            t.deepEquals(
+            t.deepEqual(
               amountDeposited,
               proposal.want.Price,
               `Alice got exactly what she wanted`,
@@ -247,17 +249,17 @@ test('zoe - non-fungible atomicSwap', async t => {
         const invitation = await invitationIssuer.claim(untrustedInvitation);
         const invitationValue = await E(zoe).getInvitationDetails(invitation);
 
-        t.equals(
+        t.is(
           invitationValue.installation,
           installation,
           'installation is atomicSwap',
         );
-        t.deepEquals(
+        t.deepEqual(
           invitationValue.asset,
           calico37Amount,
           `asset to be traded is a particular crypto cat`,
         );
-        t.deepEquals(
+        t.deepEqual(
           invitationValue.price,
           vorpalAmount,
           `price is vorpalAmount, so bob must give that`,
@@ -272,27 +274,27 @@ test('zoe - non-fungible atomicSwap', async t => {
 
         const seat = await zoe.offer(invitation, proposal, payments);
 
-        t.equals(
+        t.is(
           await E(seat).getOfferResult(),
           'The offer has been accepted. Once the contract has been completed, please check your payout',
         );
 
-        seat
+        await seat
           .getPayout('Asset')
           .then(ccPurse.deposit)
           .then(amountDeposited =>
-            t.deepEquals(
+            t.deepEqual(
               amountDeposited,
               proposal.want.Asset,
               `Bob got what he wanted`,
             ),
           );
 
-        seat
+        await seat
           .getPayout('Price')
           .then(rpgPurse.deposit)
           .then(amountDeposited =>
-            t.deepEquals(
+            t.deepEqual(
               amountDeposited,
               rpgItems(harden([])),
               `Bob didn't get anything back`,
@@ -383,10 +385,10 @@ test('zoe - atomicSwap like-for-like', async t => {
 
   const bobIssuers = zoe.getIssuers(bobInvitationValue.instance);
 
-  t.equals(bobInvitationValue.installation, installation, 'bobInstallationId');
-  t.deepEquals(bobIssuers, { Asset: moolaIssuer, Price: moolaIssuer });
-  t.deepEquals(bobInvitationValue.asset, moola(3));
-  t.deepEquals(bobInvitationValue.price, moola(7));
+  t.is(bobInvitationValue.installation, installation, 'bobInstallationId');
+  t.deepEqual(bobIssuers, { Asset: moolaIssuer, Price: moolaIssuer });
+  t.deepEqual(bobInvitationValue.asset, moola(3));
+  t.deepEqual(bobInvitationValue.price, moola(7));
 
   const bobProposal = harden({
     give: { Price: moola(7) },
@@ -402,7 +404,7 @@ test('zoe - atomicSwap like-for-like', async t => {
     bobPayments,
   );
 
-  t.equals(
+  t.is(
     await E(bobSeat).getOfferResult(),
     'The offer has been accepted. Once the contract has been completed, please check your payout',
   );
@@ -414,29 +416,29 @@ test('zoe - atomicSwap like-for-like', async t => {
   const alicePricePayout = await aliceSeat.getPayout('Price');
 
   // Alice gets what Alice wanted
-  t.deepEquals(
+  t.deepEqual(
     await moolaIssuer.getAmountOf(alicePricePayout),
     aliceProposal.want.Price,
   );
 
   // Alice didn't get any of what Alice put in
-  t.deepEquals(await moolaIssuer.getAmountOf(aliceAssetPayout), moola(0));
+  t.deepEqual(await moolaIssuer.getAmountOf(aliceAssetPayout), moola(0));
 
   // Alice deposits her payout to ensure she can
   const aliceAssetAmount = await aliceMoolaPurse.deposit(aliceAssetPayout);
-  t.equals(aliceAssetAmount.value, 0);
+  t.is(aliceAssetAmount.value, 0);
   const alicePriceAmount = await aliceMoolaPurse.deposit(alicePricePayout);
-  t.equals(alicePriceAmount.value, 7);
+  t.is(alicePriceAmount.value, 7);
 
   // Bob deposits his original payments to ensure he can
   const bobAssetAmount = await bobMoolaPurse.deposit(bobAssetPayout);
-  t.equals(bobAssetAmount.value, 3);
+  t.is(bobAssetAmount.value, 3);
   const bobPriceAmount = await bobMoolaPurse.deposit(bobPricePayout);
-  t.equals(bobPriceAmount.value, 0);
+  t.is(bobPriceAmount.value, 0);
 
   // Assert that the correct payouts were received.
   // Alice had 3 moola from Asset and 0 from Price.
   // Bob had 0 moola from Asset and 7 from Price.
-  t.equals(aliceMoolaPurse.getCurrentAmount().value, 7);
-  t.equals(bobMoolaPurse.getCurrentAmount().value, 3);
+  t.is(aliceMoolaPurse.getCurrentAmount().value, 7);
+  t.is(bobMoolaPurse.getCurrentAmount().value, 3);
 });

--- a/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
+++ b/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'tape-promise/tape';
+import test from 'ava';
 import bundleSource from '@agoric/bundle-source';
 import { E } from '@agoric/eventual-send';
 
@@ -11,390 +11,359 @@ import { setupNonFungible } from '../setupNonFungibleMints';
 const automaticRefundRoot = `${__dirname}/../../../src/contracts/automaticRefund`;
 
 test('zoe - simplest automaticRefund', async t => {
-  t.plan(1);
-  try {
-    // Setup zoe and mints
-    const { moolaR, moola, zoe } = setup();
-    // Pack the contract.
-    const bundle = await bundleSource(automaticRefundRoot);
-    const installation = await zoe.install(bundle);
+  // Setup zoe and mints
+  const { moolaR, moola, zoe } = setup();
+  // Pack the contract.
+  const bundle = await bundleSource(automaticRefundRoot);
+  const installation = await zoe.install(bundle);
 
-    // Setup Alice
-    const aliceMoolaPayment = moolaR.mint.mintPayment(moola(3));
+  // Setup Alice
+  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(3));
 
-    // 1: Alice creates an automatic refund instance
-    const issuerKeywordRecord = harden({ Contribution: moolaR.issuer });
-    const { creatorInvitation } = await zoe.startInstance(
-      installation,
-      issuerKeywordRecord,
-    );
+  // 1: Alice creates an automatic refund instance
+  const issuerKeywordRecord = harden({ Contribution: moolaR.issuer });
+  const { creatorInvitation } = await zoe.startInstance(
+    installation,
+    issuerKeywordRecord,
+  );
 
-    const aliceProposal = harden({
-      give: { Contribution: moola(3) },
-      exit: { onDemand: null },
-    });
-    const alicePayments = { Contribution: aliceMoolaPayment };
+  const aliceProposal = harden({
+    give: { Contribution: moola(3) },
+    exit: { onDemand: null },
+  });
+  const alicePayments = { Contribution: aliceMoolaPayment };
 
-    const seat = await zoe.offer(
-      creatorInvitation,
-      aliceProposal,
-      alicePayments,
-    );
+  const seat = await zoe.offer(creatorInvitation, aliceProposal, alicePayments);
 
-    const aliceMoolaPayout = await seat.getPayout('Contribution');
+  const aliceMoolaPayout = await seat.getPayout('Contribution');
 
-    // Alice got back what she put in
-    t.deepEquals(
-      await moolaR.issuer.getAmountOf(aliceMoolaPayout),
-      aliceProposal.give.Contribution,
-      `Alice's payout matches what she put in`,
-    );
-  } catch (e) {
-    t.assert(false, e);
-    console.log(e);
-  }
+  // Alice got back what she put in
+  t.deepEqual(
+    await moolaR.issuer.getAmountOf(aliceMoolaPayout),
+    aliceProposal.give.Contribution,
+    `Alice's payout matches what she put in`,
+  );
 });
 
 test('zoe - automaticRefund same issuer', async t => {
-  t.plan(1);
-  try {
-    // Setup zoe and mints
-    const { moolaR, moola, zoe } = setup();
-    // Pack the contract.
-    const bundle = await bundleSource(automaticRefundRoot);
-    const installation = await E(zoe).install(bundle);
+  // Setup zoe and mints
+  const { moolaR, moola, zoe } = setup();
+  // Pack the contract.
+  const bundle = await bundleSource(automaticRefundRoot);
+  const installation = await E(zoe).install(bundle);
 
-    // Setup Alice
-    const aliceMoolaPayment = moolaR.mint.mintPayment(moola(9));
+  // Setup Alice
+  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(9));
 
-    // 1: Alice creates an automatic refund instance
-    const issuerKeywordRecord = harden({
-      Contribution1: moolaR.issuer,
-      Contribution2: moolaR.issuer,
-    });
-    const { creatorInvitation } = await E(zoe).startInstance(
-      installation,
-      issuerKeywordRecord,
-    );
+  // 1: Alice creates an automatic refund instance
+  const issuerKeywordRecord = harden({
+    Contribution1: moolaR.issuer,
+    Contribution2: moolaR.issuer,
+  });
+  const { creatorInvitation } = await E(zoe).startInstance(
+    installation,
+    issuerKeywordRecord,
+  );
 
-    const aliceProposal = harden({
-      give: { Contribution2: moola(9) },
-      exit: { onDemand: null },
-    });
-    const alicePayments = harden({ Contribution2: aliceMoolaPayment });
+  const aliceProposal = harden({
+    give: { Contribution2: moola(9) },
+    exit: { onDemand: null },
+  });
+  const alicePayments = harden({ Contribution2: aliceMoolaPayment });
 
-    const seat = await E(zoe).offer(
-      creatorInvitation,
-      aliceProposal,
-      alicePayments,
-    );
+  const seat = await E(zoe).offer(
+    creatorInvitation,
+    aliceProposal,
+    alicePayments,
+  );
 
-    const aliceMoolaPayout = await E(seat).getPayout('Contribution2');
+  const aliceMoolaPayout = await E(seat).getPayout('Contribution2');
 
-    // Alice got back what she put in
-    t.deepEquals(
-      await moolaR.issuer.getAmountOf(aliceMoolaPayout),
-      aliceProposal.give.Contribution2,
-    );
-  } catch (e) {
-    t.assert(false, e);
-    console.log(e);
-  }
+  // Alice got back what she put in
+  t.deepEqual(
+    await moolaR.issuer.getAmountOf(aliceMoolaPayout),
+    aliceProposal.give.Contribution2,
+  );
 });
 
 test('zoe with automaticRefund', async t => {
   t.plan(11);
-  try {
-    // Setup zoe and mints
-    const { moolaR, simoleanR, moola, simoleans, zoe } = setup();
-    const invitationIssuer = zoe.getInvitationIssuer();
+  // Setup zoe and mints
+  const { moolaR, simoleanR, moola, simoleans, zoe } = setup();
+  const invitationIssuer = zoe.getInvitationIssuer();
 
-    // Setup Alice
-    const aliceMoolaPayment = moolaR.mint.mintPayment(moola(3));
-    const aliceMoolaPurse = moolaR.issuer.makeEmptyPurse();
-    const aliceSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
+  // Setup Alice
+  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(3));
+  const aliceMoolaPurse = moolaR.issuer.makeEmptyPurse();
+  const aliceSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
 
-    // Setup Bob
-    const bobMoolaPurse = moolaR.issuer.makeEmptyPurse();
-    const bobSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
-    const bobSimoleanPayment = simoleanR.mint.mintPayment(simoleans(17));
+  // Setup Bob
+  const bobMoolaPurse = moolaR.issuer.makeEmptyPurse();
+  const bobSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
+  const bobSimoleanPayment = simoleanR.mint.mintPayment(simoleans(17));
 
-    // Pack the contract.
-    const bundle = await bundleSource(automaticRefundRoot);
+  // Pack the contract.
+  const bundle = await bundleSource(automaticRefundRoot);
 
-    // 1: Alice creates an automatic refund instance
-    const installation = await zoe.install(bundle);
-    const issuerKeywordRecord = harden({
-      Contribution1: moolaR.issuer,
-      Contribution2: simoleanR.issuer,
-    });
-    const {
-      creatorInvitation: aliceInvitation,
-      publicFacet,
-    } = await zoe.startInstance(installation, issuerKeywordRecord);
+  // 1: Alice creates an automatic refund instance
+  const installation = await zoe.install(bundle);
+  const issuerKeywordRecord = harden({
+    Contribution1: moolaR.issuer,
+    Contribution2: simoleanR.issuer,
+  });
+  const {
+    creatorInvitation: aliceInvitation,
+    publicFacet,
+  } = await zoe.startInstance(installation, issuerKeywordRecord);
 
-    // 2: Alice escrows with zoe
-    const aliceProposal = harden({
-      give: { Contribution1: moola(3) },
-      want: { Contribution2: simoleans(7) },
-      exit: { onDemand: null },
-    });
-    const alicePayments = { Contribution1: aliceMoolaPayment };
+  // 2: Alice escrows with zoe
+  const aliceProposal = harden({
+    give: { Contribution1: moola(3) },
+    want: { Contribution2: simoleans(7) },
+    exit: { onDemand: null },
+  });
+  const alicePayments = { Contribution1: aliceMoolaPayment };
 
-    // Alice gets a seat back.
-    //
-    // In the 'automaticRefund' trivial contract, you just get your
-    // payments back when you make an offer. The offerResult is simply
-    // the string 'The offer was accepted'
-    const aliceSeat = await zoe.offer(
-      aliceInvitation,
-      aliceProposal,
-      alicePayments,
-    );
+  // Alice gets a seat back.
+  //
+  // In the 'automaticRefund' trivial contract, you just get your
+  // payments back when you make an offer. The offerResult is simply
+  // the string 'The offer was accepted'
+  const aliceSeat = await zoe.offer(
+    aliceInvitation,
+    aliceProposal,
+    alicePayments,
+  );
 
-    const bobInvitation = await E(publicFacet).makeInvitation();
-    const count = await E(publicFacet).getOffersCount();
-    t.equals(count, 1);
+  const bobInvitation = await E(publicFacet).makeInvitation();
+  const count = await E(publicFacet).getOffersCount();
+  t.is(count, 1);
 
-    // Imagine that Alice has shared the bobInvitation with Bob. He
-    // will do a claim on the invitation with the Zoe invitation issuer and
-    // will check that the installation and terms match what he
-    // expects
-    const exclusBobInvitation = await invitationIssuer.claim(bobInvitation);
+  // Imagine that Alice has shared the bobInvitation with Bob. He
+  // will do a claim on the invitation with the Zoe invitation issuer and
+  // will check that the installation and terms match what he
+  // expects
+  const exclusBobInvitation = await invitationIssuer.claim(bobInvitation);
 
-    const {
-      value: [bobInvitationValue],
-    } = await E(invitationIssuer).getAmountOf(exclusBobInvitation);
-    t.equals(bobInvitationValue.installation, installation);
+  const {
+    value: [bobInvitationValue],
+  } = await E(invitationIssuer).getAmountOf(exclusBobInvitation);
+  t.is(bobInvitationValue.installation, installation);
 
-    // bob wants to know what issuers this contract is about and in
-    // what order. Is it what he expects?
-    const bobIssuers = await E(zoe).getIssuers(bobInvitationValue.instance);
-    t.deepEquals(bobIssuers, {
-      Contribution1: moolaR.issuer,
-      Contribution2: simoleanR.issuer,
-    });
+  // bob wants to know what issuers this contract is about and in
+  // what order. Is it what he expects?
+  const bobIssuers = await E(zoe).getIssuers(bobInvitationValue.instance);
+  t.deepEqual(bobIssuers, {
+    Contribution1: moolaR.issuer,
+    Contribution2: simoleanR.issuer,
+  });
 
-    // 6: Bob also wants to get an automaticRefund (why? we don't
-    // know) so he escrows his offer payments and makes a proposal.
-    const bobProposal = harden({
-      give: { Contribution2: simoleans(17) },
-      want: { Contribution1: moola(15) },
-      exit: { onDemand: null },
-    });
-    const bobPayments = { Contribution2: bobSimoleanPayment };
+  // 6: Bob also wants to get an automaticRefund (why? we don't
+  // know) so he escrows his offer payments and makes a proposal.
+  const bobProposal = harden({
+    give: { Contribution2: simoleans(17) },
+    want: { Contribution1: moola(15) },
+    exit: { onDemand: null },
+  });
+  const bobPayments = { Contribution2: bobSimoleanPayment };
 
-    // Bob also gets a seat back
-    const bobSeat = await zoe.offer(
-      exclusBobInvitation,
-      bobProposal,
-      bobPayments,
-    );
+  // Bob also gets a seat back
+  const bobSeat = await zoe.offer(
+    exclusBobInvitation,
+    bobProposal,
+    bobPayments,
+  );
 
-    t.equals(await E(aliceSeat).getOfferResult(), 'The offer was accepted');
-    t.equals(await E(bobSeat).getOfferResult(), 'The offer was accepted');
+  t.is(await E(aliceSeat).getOfferResult(), 'The offer was accepted');
+  t.is(await E(bobSeat).getOfferResult(), 'The offer was accepted');
 
-    // These promise resolve when the offer completes, but it may
-    // still take longer for a remote issuer to actually make the
-    // payments, so we need to wait for those promises to resolve
-    // separately.
+  // These promise resolve when the offer completes, but it may
+  // still take longer for a remote issuer to actually make the
+  // payments, so we need to wait for those promises to resolve
+  // separately.
 
-    // offer completes
-    const aliceMoolaPayout = await aliceSeat.getPayout('Contribution1');
-    const aliceSimoleanPayout = await aliceSeat.getPayout('Contribution2');
+  // offer completes
+  const aliceMoolaPayout = await aliceSeat.getPayout('Contribution1');
+  const aliceSimoleanPayout = await aliceSeat.getPayout('Contribution2');
 
-    const bobMoolaPayout = await bobSeat.getPayout('Contribution1');
-    const bobSimoleanPayout = await bobSeat.getPayout('Contribution2');
+  const bobMoolaPayout = await bobSeat.getPayout('Contribution1');
+  const bobSimoleanPayout = await bobSeat.getPayout('Contribution2');
 
-    // Alice got back what she put in
-    t.deepEquals(
-      await moolaR.issuer.getAmountOf(aliceMoolaPayout),
-      aliceProposal.give.Contribution1,
-    );
+  // Alice got back what she put in
+  t.deepEqual(
+    await moolaR.issuer.getAmountOf(aliceMoolaPayout),
+    aliceProposal.give.Contribution1,
+  );
 
-    // Alice didn't get any of what she wanted
-    t.deepEquals(
-      await simoleanR.issuer.getAmountOf(aliceSimoleanPayout),
-      simoleans(0),
-    );
+  // Alice didn't get any of what she wanted
+  t.deepEqual(
+    await simoleanR.issuer.getAmountOf(aliceSimoleanPayout),
+    simoleans(0),
+  );
 
-    // 9: Alice deposits her refund to ensure she can
-    await aliceMoolaPurse.deposit(aliceMoolaPayout);
-    await aliceSimoleanPurse.deposit(aliceSimoleanPayout);
+  // 9: Alice deposits her refund to ensure she can
+  await aliceMoolaPurse.deposit(aliceMoolaPayout);
+  await aliceSimoleanPurse.deposit(aliceSimoleanPayout);
 
-    // 10: Bob deposits his refund to ensure he can
-    await bobMoolaPurse.deposit(bobMoolaPayout);
-    await bobSimoleanPurse.deposit(bobSimoleanPayout);
+  // 10: Bob deposits his refund to ensure he can
+  await bobMoolaPurse.deposit(bobMoolaPayout);
+  await bobSimoleanPurse.deposit(bobSimoleanPayout);
 
-    // Assert that the correct refund was achieved.
-    // Alice had 3 moola and 0 simoleans.
-    // Bob had 0 moola and 7 simoleans.
-    t.equals(aliceMoolaPurse.getCurrentAmount().value, 3);
-    t.equals(aliceSimoleanPurse.getCurrentAmount().value, 0);
-    t.equals(bobMoolaPurse.getCurrentAmount().value, 0);
-    t.equals(bobSimoleanPurse.getCurrentAmount().value, 17);
-  } catch (e) {
-    t.assert(false, e);
-    console.log(e);
-  }
+  // Assert that the correct refund was achieved.
+  // Alice had 3 moola and 0 simoleans.
+  // Bob had 0 moola and 7 simoleans.
+  t.is(aliceMoolaPurse.getCurrentAmount().value, 3);
+  t.is(aliceSimoleanPurse.getCurrentAmount().value, 0);
+  t.is(bobMoolaPurse.getCurrentAmount().value, 0);
+  t.is(bobSimoleanPurse.getCurrentAmount().value, 17);
 });
 
 test('multiple instances of automaticRefund for the same Zoe', async t => {
   t.plan(6);
-  try {
-    // Setup zoe and mints
-    const { moolaR, simoleanR, moola, simoleans, zoe } = setup();
+  // Setup zoe and mints
+  const { moolaR, simoleanR, moola, simoleans, zoe } = setup();
 
-    // Setup Alice
-    const aliceMoolaPayment = moolaR.mint.mintPayment(moola(30));
-    const moola10 = moola(10);
-    const aliceMoolaPayments = await moolaR.issuer.splitMany(
-      aliceMoolaPayment,
-      [moola10, moola10, moola10],
-    );
+  // Setup Alice
+  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(30));
+  const moola10 = moola(10);
+  const aliceMoolaPayments = await moolaR.issuer.splitMany(aliceMoolaPayment, [
+    moola10,
+    moola10,
+    moola10,
+  ]);
 
-    // Alice creates 3 automatic refund instances
-    // Pack the contract.
-    const bundle = await bundleSource(automaticRefundRoot);
+  // Alice creates 3 automatic refund instances
+  // Pack the contract.
+  const bundle = await bundleSource(automaticRefundRoot);
 
-    const installation = await zoe.install(bundle);
-    const issuerKeywordRecord = harden({
-      ContributionA: moolaR.issuer,
-      ContributionB: simoleanR.issuer,
-    });
-    const {
-      creatorInvitation: aliceInvitation1,
-      publicFacet: publicFacet1,
-    } = await zoe.startInstance(installation, issuerKeywordRecord);
+  const installation = await zoe.install(bundle);
+  const issuerKeywordRecord = harden({
+    ContributionA: moolaR.issuer,
+    ContributionB: simoleanR.issuer,
+  });
+  const {
+    creatorInvitation: aliceInvitation1,
+    publicFacet: publicFacet1,
+  } = await zoe.startInstance(installation, issuerKeywordRecord);
 
-    const {
-      creatorInvitation: aliceInvitation2,
-      publicFacet: publicFacet2,
-    } = await zoe.startInstance(installation, issuerKeywordRecord);
+  const {
+    creatorInvitation: aliceInvitation2,
+    publicFacet: publicFacet2,
+  } = await zoe.startInstance(installation, issuerKeywordRecord);
 
-    const {
-      creatorInvitation: aliceInvitation3,
-      publicFacet: publicFacet3,
-    } = await zoe.startInstance(installation, issuerKeywordRecord);
+  const {
+    creatorInvitation: aliceInvitation3,
+    publicFacet: publicFacet3,
+  } = await zoe.startInstance(installation, issuerKeywordRecord);
 
-    const aliceProposal = harden({
-      give: { ContributionA: moola(10) },
-      want: { ContributionB: simoleans(7) },
-    });
+  const aliceProposal = harden({
+    give: { ContributionA: moola(10) },
+    want: { ContributionB: simoleans(7) },
+  });
 
-    const seat1 = await zoe.offer(
-      aliceInvitation1,
-      aliceProposal,
-      harden({ ContributionA: aliceMoolaPayments[0] }),
-    );
+  const seat1 = await zoe.offer(
+    aliceInvitation1,
+    aliceProposal,
+    harden({ ContributionA: aliceMoolaPayments[0] }),
+  );
 
-    const seat2 = await zoe.offer(
-      aliceInvitation2,
-      aliceProposal,
-      harden({ ContributionA: aliceMoolaPayments[1] }),
-    );
+  const seat2 = await zoe.offer(
+    aliceInvitation2,
+    aliceProposal,
+    harden({ ContributionA: aliceMoolaPayments[1] }),
+  );
 
-    const seat3 = await zoe.offer(
-      aliceInvitation3,
-      aliceProposal,
-      harden({ ContributionA: aliceMoolaPayments[2] }),
-    );
+  const seat3 = await zoe.offer(
+    aliceInvitation3,
+    aliceProposal,
+    harden({ ContributionA: aliceMoolaPayments[2] }),
+  );
 
-    const moolaPayout1 = await seat1.getPayout('ContributionA');
-    const moolaPayout2 = await seat2.getPayout('ContributionA');
-    const moolaPayout3 = await seat3.getPayout('ContributionA');
+  const moolaPayout1 = await seat1.getPayout('ContributionA');
+  const moolaPayout2 = await seat2.getPayout('ContributionA');
+  const moolaPayout3 = await seat3.getPayout('ContributionA');
 
-    // Ensure that she got what she put in for each
-    t.deepEquals(
-      await moolaR.issuer.getAmountOf(moolaPayout1),
-      aliceProposal.give.ContributionA,
-    );
-    t.deepEquals(
-      await moolaR.issuer.getAmountOf(moolaPayout2),
-      aliceProposal.give.ContributionA,
-    );
-    t.deepEquals(
-      await moolaR.issuer.getAmountOf(moolaPayout3),
-      aliceProposal.give.ContributionA,
-    );
+  // Ensure that she got what she put in for each
+  t.deepEqual(
+    await moolaR.issuer.getAmountOf(moolaPayout1),
+    aliceProposal.give.ContributionA,
+  );
+  t.deepEqual(
+    await moolaR.issuer.getAmountOf(moolaPayout2),
+    aliceProposal.give.ContributionA,
+  );
+  t.deepEqual(
+    await moolaR.issuer.getAmountOf(moolaPayout3),
+    aliceProposal.give.ContributionA,
+  );
 
-    // Ensure that the number of offers received by each instance is one
-    t.equals(await E(publicFacet1).getOffersCount(), 1);
-    t.equals(await E(publicFacet2).getOffersCount(), 1);
-    t.equals(await E(publicFacet3).getOffersCount(), 1);
-  } catch (e) {
-    t.assert(false, e);
-    console.log(e);
-  }
+  // Ensure that the number of offers received by each instance is one
+  t.is(await E(publicFacet1).getOffersCount(), 1);
+  t.is(await E(publicFacet2).getOffersCount(), 1);
+  t.is(await E(publicFacet3).getOffersCount(), 1);
 });
 
 test('zoe - alice tries to complete after completion has already occurred', async t => {
   t.plan(5);
-  try {
-    // Setup zoe and mints
-    const { moolaR, simoleanR, moola, simoleans, zoe } = setup();
+  // Setup zoe and mints
+  const { moolaR, simoleanR, moola, simoleans, zoe } = setup();
 
-    // Setup Alice
-    const aliceMoolaPayment = moolaR.mint.mintPayment(moola(3));
-    const aliceMoolaPurse = moolaR.issuer.makeEmptyPurse();
-    const aliceSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
+  // Setup Alice
+  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(3));
+  const aliceMoolaPurse = moolaR.issuer.makeEmptyPurse();
+  const aliceSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
 
-    // Pack the contract.
-    const bundle = await bundleSource(automaticRefundRoot);
-    const installation = await zoe.install(bundle);
-    const issuerKeywordRecord = harden({
-      ContributionA: moolaR.issuer,
-      ContributionB: simoleanR.issuer,
-    });
-    const { creatorInvitation } = await zoe.startInstance(
-      installation,
-      issuerKeywordRecord,
-    );
+  // Pack the contract.
+  const bundle = await bundleSource(automaticRefundRoot);
+  const installation = await zoe.install(bundle);
+  const issuerKeywordRecord = harden({
+    ContributionA: moolaR.issuer,
+    ContributionB: simoleanR.issuer,
+  });
+  const { creatorInvitation } = await zoe.startInstance(
+    installation,
+    issuerKeywordRecord,
+  );
 
-    const aliceProposal = harden({
-      give: { ContributionA: moola(3) },
-      want: { ContributionB: simoleans(7) },
-    });
-    const alicePayments = { ContributionA: aliceMoolaPayment };
+  const aliceProposal = harden({
+    give: { ContributionA: moola(3) },
+    want: { ContributionB: simoleans(7) },
+  });
+  const alicePayments = { ContributionA: aliceMoolaPayment };
 
-    const aliceSeat = await zoe.offer(
-      creatorInvitation,
-      aliceProposal,
-      alicePayments,
-    );
+  const aliceSeat = await zoe.offer(
+    creatorInvitation,
+    aliceProposal,
+    alicePayments,
+  );
 
-    await E(aliceSeat).getOfferResult();
+  await E(aliceSeat).getOfferResult();
 
-    console.log('EXPECTED ERROR: seat has been exited >>>');
-    t.rejects(() => E(aliceSeat).tryExit(), /Error: seat has been exited/);
+  console.log('EXPECTED ERROR: seat has been exited >>>');
+  await t.throwsAsync(() => E(aliceSeat).tryExit(), {
+    message: /seat has been exited/,
+  });
 
-    const moolaPayout = await aliceSeat.getPayout('ContributionA');
-    const simoleanPayout = await aliceSeat.getPayout('ContributionB');
+  const moolaPayout = await aliceSeat.getPayout('ContributionA');
+  const simoleanPayout = await aliceSeat.getPayout('ContributionB');
 
-    // Alice got back what she put in
-    t.deepEquals(
-      await moolaR.issuer.getAmountOf(moolaPayout),
-      aliceProposal.give.ContributionA,
-    );
+  // Alice got back what she put in
+  t.deepEqual(
+    await moolaR.issuer.getAmountOf(moolaPayout),
+    aliceProposal.give.ContributionA,
+  );
 
-    // Alice didn't get any of what she wanted
-    t.deepEquals(
-      await simoleanR.issuer.getAmountOf(simoleanPayout),
-      simoleans(0),
-    );
+  // Alice didn't get any of what she wanted
+  t.deepEqual(await simoleanR.issuer.getAmountOf(simoleanPayout), simoleans(0));
 
-    // 9: Alice deposits her refund to ensure she can
-    await aliceMoolaPurse.deposit(moolaPayout);
-    await aliceSimoleanPurse.deposit(simoleanPayout);
+  // 9: Alice deposits her refund to ensure she can
+  await aliceMoolaPurse.deposit(moolaPayout);
+  await aliceSimoleanPurse.deposit(simoleanPayout);
 
-    // Assert that the correct refund was achieved.
-    // Alice had 3 moola and 0 simoleans.
-    t.equals(aliceMoolaPurse.getCurrentAmount().value, 3);
-    t.equals(aliceSimoleanPurse.getCurrentAmount().value, 0);
-  } catch (e) {
-    t.assert(false, e);
-    console.log(e);
-  }
+  // Assert that the correct refund was achieved.
+  // Alice had 3 moola and 0 simoleans.
+  t.is(aliceMoolaPurse.getCurrentAmount().value, 3);
+  t.is(aliceSimoleanPurse.getCurrentAmount().value, 0);
 });
 
 test('zoe - automaticRefund non-fungible', async t => {
@@ -427,7 +396,7 @@ test('zoe - automaticRefund non-fungible', async t => {
   const aliceCcPayout = await seat.getPayout('Contribution');
 
   // Alice got back what she put in
-  t.deepEquals(
+  t.deepEqual(
     await ccIssuer.getAmountOf(aliceCcPayout),
     aliceProposal.give.Contribution,
   );

--- a/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
+++ b/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
@@ -339,7 +339,6 @@ test('zoe - alice tries to complete after completion has already occurred', asyn
 
   await E(aliceSeat).getOfferResult();
 
-  console.log('EXPECTED ERROR: seat has been exited >>>');
   await t.throwsAsync(() => E(aliceSeat).tryExit(), {
     message: /seat has been exited/,
   });

--- a/packages/zoe/test/unitTests/contracts/test-autoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-autoswap.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'tape-promise/tape';
+import test from 'ava';
 import { E } from '@agoric/eventual-send';
 import { makeLocalAmountMath } from '@agoric/ertp';
 
@@ -15,320 +15,310 @@ const autoswap = `${__dirname}/../../../src/contracts/autoswap`;
 
 test('autoSwap with valid offers', async t => {
   t.plan(19);
-  try {
-    const {
-      moolaIssuer,
-      simoleanIssuer,
-      moolaMint,
-      simoleanMint,
-      moola,
-      simoleans,
-      zoe,
-    } = setup();
-    const invitationIssuer = zoe.getInvitationIssuer();
-    const installation = await installationPFromSource(zoe, autoswap);
+  const {
+    moolaIssuer,
+    simoleanIssuer,
+    moolaMint,
+    simoleanMint,
+    moola,
+    simoleans,
+    zoe,
+  } = setup();
+  const invitationIssuer = zoe.getInvitationIssuer();
+  const installation = await installationPFromSource(zoe, autoswap);
 
-    // Setup Alice
-    const aliceMoolaPayment = moolaMint.mintPayment(moola(10));
-    // Let's assume that simoleans are worth 2x as much as moola
-    const aliceSimoleanPayment = simoleanMint.mintPayment(simoleans(5));
+  // Setup Alice
+  const aliceMoolaPayment = moolaMint.mintPayment(moola(10));
+  // Let's assume that simoleans are worth 2x as much as moola
+  const aliceSimoleanPayment = simoleanMint.mintPayment(simoleans(5));
 
-    // Setup Bob
-    const bobMoolaPayment = moolaMint.mintPayment(moola(3));
-    const bobSimoleanPayment = simoleanMint.mintPayment(simoleans(3));
+  // Setup Bob
+  const bobMoolaPayment = moolaMint.mintPayment(moola(3));
+  const bobSimoleanPayment = simoleanMint.mintPayment(simoleans(3));
 
-    // Alice creates an autoswap instance
-    const issuerKeywordRecord = harden({
-      TokenA: moolaIssuer,
-      TokenB: simoleanIssuer,
-    });
-    const { publicFacet } = await zoe.startInstance(
-      installation,
-      issuerKeywordRecord,
-    );
-    const liquidityIssuerP = await E(publicFacet).getLiquidityIssuer();
-    const liquidityAmountMath = await makeLocalAmountMath(liquidityIssuerP);
-    const liquidity = liquidityAmountMath.make;
+  // Alice creates an autoswap instance
+  const issuerKeywordRecord = harden({
+    TokenA: moolaIssuer,
+    TokenB: simoleanIssuer,
+  });
+  const { publicFacet } = await zoe.startInstance(
+    installation,
+    issuerKeywordRecord,
+  );
+  const liquidityIssuerP = await E(publicFacet).getLiquidityIssuer();
+  const liquidityAmountMath = await makeLocalAmountMath(liquidityIssuerP);
+  const liquidity = liquidityAmountMath.make;
 
-    // Alice adds liquidity
-    // 10 moola = 5 simoleans at the time of the liquidity adding
-    // aka 2 moola = 1 simolean
-    const aliceProposal = harden({
-      want: { Liquidity: liquidity(10) },
-      give: { TokenA: moola(10), TokenB: simoleans(5) },
-    });
-    const alicePayments = {
-      TokenA: aliceMoolaPayment,
-      TokenB: aliceSimoleanPayment,
-    };
-    const aliceInvitation = await publicFacet.makeAddLiquidityInvitation();
-    const aliceSeat = await zoe.offer(
-      aliceInvitation,
-      aliceProposal,
-      alicePayments,
-    );
+  // Alice adds liquidity
+  // 10 moola = 5 simoleans at the time of the liquidity adding
+  // aka 2 moola = 1 simolean
+  const aliceProposal = harden({
+    want: { Liquidity: liquidity(10) },
+    give: { TokenA: moola(10), TokenB: simoleans(5) },
+  });
+  const alicePayments = {
+    TokenA: aliceMoolaPayment,
+    TokenB: aliceSimoleanPayment,
+  };
+  const aliceInvitation = await publicFacet.makeAddLiquidityInvitation();
+  const aliceSeat = await zoe.offer(
+    aliceInvitation,
+    aliceProposal,
+    alicePayments,
+  );
 
-    assertOfferResult(t, aliceSeat, 'Added liquidity.');
-    const liquidityPayout = await aliceSeat.getPayout('Liquidity');
-    assertPayoutAmount(t, liquidityIssuerP, liquidityPayout, liquidity(10));
-    t.deepEquals(
-      await E(publicFacet).getPoolAllocation(),
-      {
-        TokenA: moola(10),
-        TokenB: simoleans(5),
-        Liquidity: liquidity(0),
-      },
-      `pool allocation`,
-    );
+  assertOfferResult(t, aliceSeat, 'Added liquidity.');
+  const liquidityPayout = await aliceSeat.getPayout('Liquidity');
+  assertPayoutAmount(t, liquidityIssuerP, liquidityPayout, liquidity(10));
+  t.deepEqual(
+    await E(publicFacet).getPoolAllocation(),
+    {
+      TokenA: moola(10),
+      TokenB: simoleans(5),
+      Liquidity: liquidity(0),
+    },
+    `pool allocation`,
+  );
 
-    // Alice creates an invitation for autoswap and sends it to Bob
-    const bobInvitation = await E(publicFacet).makeSwapInvitation();
+  // Alice creates an invitation for autoswap and sends it to Bob
+  const bobInvitation = await E(publicFacet).makeSwapInvitation();
 
-    // Bob claims it
-    const bobExclInvitation = await invitationIssuer.claim(bobInvitation);
-    const bobInstance = await E(zoe).getInstance(bobExclInvitation);
-    const bobInstallation = await E(zoe).getInstallation(bobExclInvitation);
-    t.equals(bobInstallation, installation, `installation`);
-    const bobAutoswap = E(zoe).getPublicFacet(bobInstance);
+  // Bob claims it
+  const bobExclInvitation = await invitationIssuer.claim(bobInvitation);
+  const bobInstance = await E(zoe).getInstance(bobExclInvitation);
+  const bobInstallation = await E(zoe).getInstallation(bobExclInvitation);
+  t.is(bobInstallation, installation, `installation`);
+  const bobAutoswap = E(zoe).getPublicFacet(bobInstance);
 
-    // Bob looks up the price of 3 moola in simoleans
-    const simoleanAmounts = await E(bobAutoswap).getCurrentPrice(
-      moola(3),
-      simoleans(0).brand,
-    );
-    t.deepEquals(simoleanAmounts, simoleans(1), `currentPrice`);
+  // Bob looks up the price of 3 moola in simoleans
+  const simoleanAmounts = await E(bobAutoswap).getCurrentPrice(
+    moola(3),
+    simoleans(0).brand,
+  );
+  t.deepEqual(simoleanAmounts, simoleans(1), `currentPrice`);
 
-    // Bob escrows
-    const bobMoolaForSimProposal = harden({
-      want: { Out: simoleans(1) },
-      give: { In: moola(3) },
-    });
-    const bobMoolaForSimPayments = harden({ In: bobMoolaPayment });
+  // Bob escrows
+  const bobMoolaForSimProposal = harden({
+    want: { Out: simoleans(1) },
+    give: { In: moola(3) },
+  });
+  const bobMoolaForSimPayments = harden({ In: bobMoolaPayment });
 
-    const bobSeat = await zoe.offer(
-      bobExclInvitation,
-      bobMoolaForSimProposal,
-      bobMoolaForSimPayments,
-    );
+  const bobSeat = await zoe.offer(
+    bobExclInvitation,
+    bobMoolaForSimProposal,
+    bobMoolaForSimPayments,
+  );
 
-    // Bob swaps
-    assertOfferResult(t, bobSeat, 'Swap successfully completed.');
+  // Bob swaps
+  assertOfferResult(t, bobSeat, 'Swap successfully completed.');
 
-    const {
-      In: bobMoolaPayout1,
-      Out: bobSimoleanPayout1,
-    } = await bobSeat.getPayouts();
+  const {
+    In: bobMoolaPayout1,
+    Out: bobSimoleanPayout1,
+  } = await bobSeat.getPayouts();
 
-    assertPayoutAmount(t, moolaIssuer, bobMoolaPayout1, moola(0));
-    assertPayoutAmount(t, simoleanIssuer, bobSimoleanPayout1, simoleans(1));
-    t.deepEquals(
-      await E(bobAutoswap).getPoolAllocation(),
-      {
-        TokenA: moola(13),
-        TokenB: simoleans(4),
-        Liquidity: liquidity(0),
-      },
-      `pool allocation after first swap`,
-    );
+  assertPayoutAmount(t, moolaIssuer, bobMoolaPayout1, moola(0));
+  assertPayoutAmount(t, simoleanIssuer, bobSimoleanPayout1, simoleans(1));
+  t.deepEqual(
+    await E(bobAutoswap).getPoolAllocation(),
+    {
+      TokenA: moola(13),
+      TokenB: simoleans(4),
+      Liquidity: liquidity(0),
+    },
+    `pool allocation after first swap`,
+  );
 
-    // Bob looks up the price of 3 simoleans
-    const moolaAmounts = await E(bobAutoswap).getCurrentPrice(
-      simoleans(3),
-      moola(0).brand,
-    );
-    t.deepEquals(moolaAmounts, moola(5), `price 2`);
+  // Bob looks up the price of 3 simoleans
+  const moolaAmounts = await E(bobAutoswap).getCurrentPrice(
+    simoleans(3),
+    moola(0).brand,
+  );
+  t.deepEqual(moolaAmounts, moola(5), `price 2`);
 
-    // Bob makes another offer and swaps
-    const bobSecondInvitation = E(bobAutoswap).makeSwapInvitation();
-    const bobSimsForMoolaProposal = harden({
-      want: { Out: moola(5) },
-      give: { In: simoleans(3) },
-    });
-    const simsForMoolaPayments = harden({ In: bobSimoleanPayment });
+  // Bob makes another offer and swaps
+  const bobSecondInvitation = E(bobAutoswap).makeSwapInvitation();
+  const bobSimsForMoolaProposal = harden({
+    want: { Out: moola(5) },
+    give: { In: simoleans(3) },
+  });
+  const simsForMoolaPayments = harden({ In: bobSimoleanPayment });
 
-    const bobSecondSeat = await zoe.offer(
-      bobSecondInvitation,
-      bobSimsForMoolaProposal,
-      simsForMoolaPayments,
-    );
+  const bobSecondSeat = await zoe.offer(
+    bobSecondInvitation,
+    bobSimsForMoolaProposal,
+    simsForMoolaPayments,
+  );
 
-    assertOfferResult(t, bobSeat, 'Swap successfully completed.');
+  assertOfferResult(t, bobSeat, 'Swap successfully completed.');
 
-    const {
-      Out: bobMoolaPayout2,
-      In: bobSimoleanPayout2,
-    } = await bobSecondSeat.getPayouts();
-    assertPayoutAmount(t, moolaIssuer, bobMoolaPayout2, moola(5));
-    assertPayoutAmount(t, simoleanIssuer, bobSimoleanPayout2, simoleans(0));
+  const {
+    Out: bobMoolaPayout2,
+    In: bobSimoleanPayout2,
+  } = await bobSecondSeat.getPayouts();
+  assertPayoutAmount(t, moolaIssuer, bobMoolaPayout2, moola(5));
+  assertPayoutAmount(t, simoleanIssuer, bobSimoleanPayout2, simoleans(0));
 
-    t.deepEqual(
-      await E(bobAutoswap).getPoolAllocation(),
-      {
-        TokenA: moola(8),
-        TokenB: simoleans(7),
-        Liquidity: liquidity(0),
-      },
-      `pool allocation after swap`,
-    );
+  t.deepEqual(
+    await E(bobAutoswap).getPoolAllocation(),
+    {
+      TokenA: moola(8),
+      TokenB: simoleans(7),
+      Liquidity: liquidity(0),
+    },
+    `pool allocation after swap`,
+  );
 
-    // Alice removes her liquidity
-    const aliceSecondInvitation = await E(
-      publicFacet,
-    ).makeRemoveLiquidityInvitation();
-    // She's not picky...
-    const aliceRemoveLiquidityProposal = harden({
-      give: { Liquidity: liquidity(10) },
-      want: { TokenA: moola(0), TokenB: simoleans(0) },
-    });
+  // Alice removes her liquidity
+  const aliceSecondInvitation = await E(
+    publicFacet,
+  ).makeRemoveLiquidityInvitation();
+  // She's not picky...
+  const aliceRemoveLiquidityProposal = harden({
+    give: { Liquidity: liquidity(10) },
+    want: { TokenA: moola(0), TokenB: simoleans(0) },
+  });
 
-    const aliceRmLiqSeat = await zoe.offer(
-      aliceSecondInvitation,
-      aliceRemoveLiquidityProposal,
-      harden({ Liquidity: liquidityPayout }),
-    );
+  const aliceRmLiqSeat = await zoe.offer(
+    aliceSecondInvitation,
+    aliceRemoveLiquidityProposal,
+    harden({ Liquidity: liquidityPayout }),
+  );
 
-    assertOfferResult(t, aliceRmLiqSeat, 'Liquidity successfully removed.');
-    const {
-      TokenA: aliceMoolaPayout,
-      TokenB: aliceSimoleanPayout,
-      Liquidity: aliceLiquidityPayout,
-    } = await aliceRmLiqSeat.getPayouts();
-    assertPayoutAmount(t, moolaIssuer, aliceMoolaPayout, moola(8));
-    assertPayoutAmount(t, simoleanIssuer, aliceSimoleanPayout, simoleans(7));
-    assertPayoutAmount(t, liquidityIssuerP, aliceLiquidityPayout, liquidity(0));
+  assertOfferResult(t, aliceRmLiqSeat, 'Liquidity successfully removed.');
+  const {
+    TokenA: aliceMoolaPayout,
+    TokenB: aliceSimoleanPayout,
+    Liquidity: aliceLiquidityPayout,
+  } = await aliceRmLiqSeat.getPayouts();
+  assertPayoutAmount(t, moolaIssuer, aliceMoolaPayout, moola(8));
+  assertPayoutAmount(t, simoleanIssuer, aliceSimoleanPayout, simoleans(7));
+  assertPayoutAmount(t, liquidityIssuerP, aliceLiquidityPayout, liquidity(0));
 
-    t.deepEquals(await E(publicFacet).getPoolAllocation(), {
-      TokenA: moola(0),
-      TokenB: simoleans(0),
-      Liquidity: liquidity(10),
-    });
-  } catch (e) {
-    t.assert(false, e);
-    console.log(e);
-  }
+  t.deepEqual(await E(publicFacet).getPoolAllocation(), {
+    TokenA: moola(0),
+    TokenB: simoleans(0),
+    Liquidity: liquidity(10),
+  });
 });
 
 test('autoSwap - test fee', async t => {
   t.plan(9);
-  try {
-    const {
-      moolaIssuer,
-      simoleanIssuer,
-      moolaMint,
-      simoleanMint,
-      moola,
-      simoleans,
-      zoe,
-    } = setup();
-    const invitationIssuer = zoe.getInvitationIssuer();
-    const installation = await installationPFromSource(zoe, autoswap);
+  const {
+    moolaIssuer,
+    simoleanIssuer,
+    moolaMint,
+    simoleanMint,
+    moola,
+    simoleans,
+    zoe,
+  } = setup();
+  const invitationIssuer = zoe.getInvitationIssuer();
+  const installation = await installationPFromSource(zoe, autoswap);
 
-    // Setup Alice
-    const aliceMoolaPayment = moolaMint.mintPayment(moola(10000));
-    const aliceSimoleanPayment = simoleanMint.mintPayment(simoleans(10000));
+  // Setup Alice
+  const aliceMoolaPayment = moolaMint.mintPayment(moola(10000));
+  const aliceSimoleanPayment = simoleanMint.mintPayment(simoleans(10000));
 
-    // Setup Bob
-    const bobMoolaPayment = moolaMint.mintPayment(moola(1000));
+  // Setup Bob
+  const bobMoolaPayment = moolaMint.mintPayment(moola(1000));
 
-    // Alice creates an autoswap instance
-    const issuerKeywordRecord = harden({
-      TokenA: moolaIssuer,
-      TokenB: simoleanIssuer,
-    });
-    const { publicFacet } = await zoe.startInstance(
-      installation,
-      issuerKeywordRecord,
-    );
-    const liquidityIssuer = await E(publicFacet).getLiquidityIssuer();
-    const liquidity = (await makeLocalAmountMath(liquidityIssuer)).make;
+  // Alice creates an autoswap instance
+  const issuerKeywordRecord = harden({
+    TokenA: moolaIssuer,
+    TokenB: simoleanIssuer,
+  });
+  const { publicFacet } = await zoe.startInstance(
+    installation,
+    issuerKeywordRecord,
+  );
+  const liquidityIssuer = await E(publicFacet).getLiquidityIssuer();
+  const liquidity = (await makeLocalAmountMath(liquidityIssuer)).make;
 
-    // Alice adds liquidity
-    const aliceProposal = harden({
-      give: {
-        TokenA: moola(10000),
-        TokenB: simoleans(10000),
-      },
-      want: { Liquidity: liquidity(0) },
-    });
-    const alicePayments = harden({
-      TokenA: aliceMoolaPayment,
-      TokenB: aliceSimoleanPayment,
-    });
+  // Alice adds liquidity
+  const aliceProposal = harden({
+    give: {
+      TokenA: moola(10000),
+      TokenB: simoleans(10000),
+    },
+    want: { Liquidity: liquidity(0) },
+  });
+  const alicePayments = harden({
+    TokenA: aliceMoolaPayment,
+    TokenB: aliceSimoleanPayment,
+  });
 
-    const aliceAddLiquidityInvitation = await publicFacet.makeAddLiquidityInvitation();
-    const aliceSeat = await zoe.offer(
-      aliceAddLiquidityInvitation,
-      aliceProposal,
-      alicePayments,
-    );
+  const aliceAddLiquidityInvitation = await publicFacet.makeAddLiquidityInvitation();
+  const aliceSeat = await zoe.offer(
+    aliceAddLiquidityInvitation,
+    aliceProposal,
+    alicePayments,
+  );
 
-    assertOfferResult(t, aliceSeat, 'Added liquidity.');
+  assertOfferResult(t, aliceSeat, 'Added liquidity.');
 
-    const liquidityPayout = await aliceSeat.getPayout('Liquidity');
+  const liquidityPayout = await aliceSeat.getPayout('Liquidity');
 
-    assertPayoutAmount(t, liquidityIssuer, liquidityPayout, liquidity(10000));
+  assertPayoutAmount(t, liquidityIssuer, liquidityPayout, liquidity(10000));
 
-    t.deepEquals(
-      await E(publicFacet).getPoolAllocation(),
-      {
-        TokenA: moola(10000),
-        TokenB: simoleans(10000),
-        Liquidity: liquidity(0),
-      },
-      `pool allocation`,
-    );
+  t.deepEqual(
+    await E(publicFacet).getPoolAllocation(),
+    {
+      TokenA: moola(10000),
+      TokenB: simoleans(10000),
+      Liquidity: liquidity(0),
+    },
+    `pool allocation`,
+  );
 
-    // Alice creates an invitation for autoswap and sends it to Bob
-    const bobInvitation = await E(publicFacet).makeSwapInvitation();
+  // Alice creates an invitation for autoswap and sends it to Bob
+  const bobInvitation = await E(publicFacet).makeSwapInvitation();
 
-    // Bob claims it
-    const bobExclInvitation = await invitationIssuer.claim(bobInvitation);
-    const bobInstance = await E(zoe).getInstance(bobExclInvitation);
-    const bobInstallation = await E(zoe).getInstallation(bobExclInvitation);
-    t.equals(bobInstallation, bobInstallation);
+  // Bob claims it
+  const bobExclInvitation = await invitationIssuer.claim(bobInvitation);
+  const bobInstance = await E(zoe).getInstance(bobExclInvitation);
+  const bobInstallation = await E(zoe).getInstallation(bobExclInvitation);
+  t.is(bobInstallation, bobInstallation);
 
-    const bobAutoswap = E(zoe).getPublicFacet(bobInstance);
-    // Bob looks up the price of 1000 moola in simoleans
-    const simoleanAmounts = await E(bobAutoswap).getCurrentPrice(
-      moola(1000),
-      simoleans(0).brand,
-    );
-    t.deepEquals(simoleanAmounts, simoleans(906), `simoleans out`);
+  const bobAutoswap = E(zoe).getPublicFacet(bobInstance);
+  // Bob looks up the price of 1000 moola in simoleans
+  const simoleanAmounts = await E(bobAutoswap).getCurrentPrice(
+    moola(1000),
+    simoleans(0).brand,
+  );
+  t.deepEqual(simoleanAmounts, simoleans(906), `simoleans out`);
 
-    // Bob escrows
-    const bobMoolaForSimProposal = harden({
-      give: { In: moola(1000) },
-      want: { Out: simoleans(0) },
-    });
-    const bobMoolaForSimPayments = harden({ In: bobMoolaPayment });
+  // Bob escrows
+  const bobMoolaForSimProposal = harden({
+    give: { In: moola(1000) },
+    want: { Out: simoleans(0) },
+  });
+  const bobMoolaForSimPayments = harden({ In: bobMoolaPayment });
 
-    // Bob swaps
-    const bobSeat = await zoe.offer(
-      bobExclInvitation,
-      bobMoolaForSimProposal,
-      bobMoolaForSimPayments,
-    );
+  // Bob swaps
+  const bobSeat = await zoe.offer(
+    bobExclInvitation,
+    bobMoolaForSimProposal,
+    bobMoolaForSimPayments,
+  );
 
-    assertOfferResult(t, bobSeat, 'Swap successfully completed.');
+  assertOfferResult(t, bobSeat, 'Swap successfully completed.');
 
-    const {
-      In: bobMoolaPayout,
-      Out: bobSimoleanPayout,
-    } = await bobSeat.getPayouts();
+  const {
+    In: bobMoolaPayout,
+    Out: bobSimoleanPayout,
+  } = await bobSeat.getPayouts();
 
-    assertPayoutAmount(t, moolaIssuer, bobMoolaPayout, moola(0));
-    assertPayoutAmount(t, simoleanIssuer, bobSimoleanPayout, simoleans(906));
-    t.deepEquals(
-      await E(bobAutoswap).getPoolAllocation(),
-      {
-        TokenA: moola(11000),
-        TokenB: simoleans(9094),
-        Liquidity: liquidity(0),
-      },
-      `pool allocation after first swap`,
-    );
-  } catch (e) {
-    t.assert(false, e);
-    console.log(e);
-  }
+  assertPayoutAmount(t, moolaIssuer, bobMoolaPayout, moola(0));
+  assertPayoutAmount(t, simoleanIssuer, bobSimoleanPayout, simoleans(906));
+  t.deepEqual(
+    await E(bobAutoswap).getPoolAllocation(),
+    {
+      TokenA: moola(11000),
+      TokenB: simoleans(9094),
+      Liquidity: liquidity(0),
+    },
+    `pool allocation after first swap`,
+  );
 });

--- a/packages/zoe/test/unitTests/contracts/test-barter.js
+++ b/packages/zoe/test/unitTests/contracts/test-barter.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'tape-promise/tape';
+import test from 'ava';
 import { E } from '@agoric/eventual-send';
 
 import { setup } from '../setupBasicMints';
@@ -69,8 +69,8 @@ test('barter with valid offers', async t => {
   // 4: Bob decides to join.
   const bobExclusiveInvitation = await invitationIssuer.claim(bobInvitation);
 
-  t.equals(bobInstallation, installation);
-  t.equals(bobInstance, instance);
+  t.is(bobInstallation, installation);
+  t.is(bobInstance, instance);
 
   // Bob creates a buy order, saying that he wants exactly 3 moola,
   // and is willing to pay up to 7 simoleans.
@@ -101,7 +101,7 @@ test('barter with valid offers', async t => {
   } = await aliceSeat.getPayouts();
 
   // Alice gets paid at least what she wanted
-  t.ok(
+  t.truthy(
     amountMaths
       .get('simoleans')
       .isGTE(
@@ -111,7 +111,7 @@ test('barter with valid offers', async t => {
   );
 
   // Alice sold all of her moola
-  t.deepEquals(await moolaIssuer.getAmountOf(aliceMoolaPayout), moola(0));
+  t.deepEqual(await moolaIssuer.getAmountOf(aliceMoolaPayout), moola(0));
 
   // Alice had 0 moola and 4 simoleans.
   assertPayoutAmount(t, moolaIssuer, aliceMoolaPayout, moola(0));

--- a/packages/zoe/test/unitTests/contracts/test-brokenContract.js
+++ b/packages/zoe/test/unitTests/contracts/test-brokenContract.js
@@ -1,6 +1,6 @@
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from 'tape-promise/tape';
+import test from 'ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import bundleSource from '@agoric/bundle-source';
 
@@ -27,9 +27,9 @@ test('zoe - brokenAutomaticRefund', async t => {
   console.log(
     'EXPECTED ERROR: The contract did not correctly return a creatorInvitation',
   );
-  t.rejects(
+  await t.throwsAsync(
     () => zoe.startInstance(installation, issuerKeywordRecord),
-    new Error('The contract did not correctly return a creatorInvitation'),
+    { message: 'The contract did not correctly return a creatorInvitation' },
     'startInstance should have thrown',
   );
 });

--- a/packages/zoe/test/unitTests/contracts/test-brokenContract.js
+++ b/packages/zoe/test/unitTests/contracts/test-brokenContract.js
@@ -24,9 +24,6 @@ test('zoe - brokenAutomaticRefund', async t => {
 
   // Alice tries to create an instance, but the contract is badly
   // written.
-  console.log(
-    'EXPECTED ERROR: The contract did not correctly return a creatorInvitation',
-  );
   await t.throwsAsync(
     () => zoe.startInstance(installation, issuerKeywordRecord),
     { message: 'The contract did not correctly return a creatorInvitation' },

--- a/packages/zoe/test/unitTests/contracts/test-coveredCall.js
+++ b/packages/zoe/test/unitTests/contracts/test-coveredCall.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'tape-promise/tape';
+import test from 'ava';
 import bundleSource from '@agoric/bundle-source';
 import { E } from '@agoric/eventual-send';
 
@@ -17,289 +17,280 @@ const atomicSwapRoot = `${__dirname}/../../../src/contracts/atomicSwap`;
 
 test('zoe - coveredCall', async t => {
   t.plan(11);
-  try {
-    const { moolaKit, simoleanKit, moola, simoleans, zoe } = setup();
+  const { moolaKit, simoleanKit, moola, simoleans, zoe } = setup();
 
-    const makeAlice = async (timer, moolaPayment) => {
-      const moolaPurse = await E(moolaKit.issuer).makeEmptyPurse();
-      const simoleanPurse = await E(simoleanKit.issuer).makeEmptyPurse();
-      return {
-        installCode: async () => {
-          // pack the contract
-          const bundle = await bundleSource(coveredCallRoot);
-          // install the contract
-          const installationP = E(zoe).install(bundle);
-          return installationP;
-        },
-        startInstance: async installation => {
-          const issuerKeywordRecord = harden({
-            UnderlyingAsset: moolaKit.issuer,
-            StrikePrice: simoleanKit.issuer,
-          });
-          const adminP = zoe.startInstance(installation, issuerKeywordRecord);
-          return adminP;
-        },
-        offer: async createCallOptionInvitation => {
-          const proposal = harden({
-            give: { UnderlyingAsset: moola(3) },
-            want: { StrikePrice: simoleans(7) },
-            exit: { afterDeadline: { deadline: 1, timer } },
-          });
-          const payments = { UnderlyingAsset: moolaPayment };
+  const makeAlice = async (timer, moolaPayment) => {
+    const moolaPurse = await E(moolaKit.issuer).makeEmptyPurse();
+    const simoleanPurse = await E(simoleanKit.issuer).makeEmptyPurse();
+    return {
+      installCode: async () => {
+        // pack the contract
+        const bundle = await bundleSource(coveredCallRoot);
+        // install the contract
+        const installationP = E(zoe).install(bundle);
+        return installationP;
+      },
+      startInstance: async installation => {
+        const issuerKeywordRecord = harden({
+          UnderlyingAsset: moolaKit.issuer,
+          StrikePrice: simoleanKit.issuer,
+        });
+        const adminP = zoe.startInstance(installation, issuerKeywordRecord);
+        return adminP;
+      },
+      offer: async createCallOptionInvitation => {
+        const proposal = harden({
+          give: { UnderlyingAsset: moola(3) },
+          want: { StrikePrice: simoleans(7) },
+          exit: { afterDeadline: { deadline: 1, timer } },
+        });
+        const payments = { UnderlyingAsset: moolaPayment };
 
-          const seat = await E(zoe).offer(
-            createCallOptionInvitation,
-            proposal,
-            payments,
+        const seat = await E(zoe).offer(
+          createCallOptionInvitation,
+          proposal,
+          payments,
+        );
+
+        E(seat)
+          .getPayout('UnderlyingAsset')
+          .then(moolaPurse.deposit)
+          .then(amountDeposited =>
+            t.deepEqual(
+              amountDeposited,
+              moola(0),
+              `Alice didn't get any of what she put in`,
+            ),
           );
 
-          E(seat)
-            .getPayout('UnderlyingAsset')
-            .then(moolaPurse.deposit)
-            .then(amountDeposited =>
-              t.deepEquals(
-                amountDeposited,
-                moola(0),
-                `Alice didn't get any of what she put in`,
-              ),
-            );
+        E(seat)
+          .getPayout('StrikePrice')
+          .then(simoleanPurse.deposit)
+          .then(amountDeposited =>
+            t.deepEqual(
+              amountDeposited,
+              proposal.want.StrikePrice,
+              `Alice got exactly what she wanted`,
+            ),
+          );
 
-          E(seat)
-            .getPayout('StrikePrice')
-            .then(simoleanPurse.deposit)
-            .then(amountDeposited =>
-              t.deepEquals(
-                amountDeposited,
-                proposal.want.StrikePrice,
-                `Alice got exactly what she wanted`,
-              ),
-            );
-
-          // The result of making the first offer is the call option
-          // digital asset. It is simultaneously actually an invitation to
-          // exercise the option.
-          const invitationP = E(seat).getOfferResult();
-          return invitationP;
-        },
-      };
+        // The result of making the first offer is the call option
+        // digital asset. It is simultaneously actually an invitation to
+        // exercise the option.
+        const invitationP = E(seat).getOfferResult();
+        return invitationP;
+      },
     };
+  };
 
-    const makeBob = (timer, installation, simoleanPayment) => {
-      const moolaPurse = moolaKit.issuer.makeEmptyPurse();
-      const simoleanPurse = simoleanKit.issuer.makeEmptyPurse();
-      return harden({
-        offer: async untrustedInvitation => {
-          const invitationIssuer = await E(zoe).getInvitationIssuer();
+  const makeBob = (timer, installation, simoleanPayment) => {
+    const moolaPurse = moolaKit.issuer.makeEmptyPurse();
+    const simoleanPurse = simoleanKit.issuer.makeEmptyPurse();
+    return harden({
+      offer: async untrustedInvitation => {
+        const invitationIssuer = await E(zoe).getInvitationIssuer();
 
-          // Bob is able to use the trusted invitationIssuer from Zoe to
-          // transform an untrusted invitation that Alice also has access to
-          const invitation = await E(invitationIssuer).claim(
-            untrustedInvitation,
+        // Bob is able to use the trusted invitationIssuer from Zoe to
+        // transform an untrusted invitation that Alice also has access to
+        const invitation = await E(invitationIssuer).claim(untrustedInvitation);
+
+        const invitationValue = await E(zoe).getInvitationDetails(invitation);
+
+        t.is(
+          invitationValue.installation,
+          installation,
+          'installation is atomicSwap',
+        );
+        t.is(invitationValue.description, 'exerciseOption');
+
+        t.deepEqual(
+          invitationValue.underlyingAsset,
+          moola(3),
+          `underlying asset is 3 moola`,
+        );
+        t.deepEqual(
+          invitationValue.strikePrice,
+          simoleans(7),
+          `strike price is 7 simoleans, so bob must give that`,
+        );
+
+        t.is(invitationValue.expirationDate, 1);
+        t.deepEqual(invitationValue.timerAuthority, timer);
+
+        const proposal = harden({
+          give: { StrikePrice: simoleans(7) },
+          want: { UnderlyingAsset: moola(3) },
+          exit: { onDemand: null },
+        });
+        const payments = { StrikePrice: simoleanPayment };
+
+        const seat = await E(zoe).offer(invitation, proposal, payments);
+
+        t.is(
+          await E(seat).getOfferResult(),
+          'The offer has been accepted. Once the contract has been completed, please check your payout',
+        );
+
+        E(seat)
+          .getPayout('UnderlyingAsset')
+          .then(moolaPurse.deposit)
+          .then(amountDeposited =>
+            t.deepEqual(
+              amountDeposited,
+              proposal.want.UnderlyingAsset,
+              `Bob got what he wanted`,
+            ),
           );
 
-          const invitationValue = await E(zoe).getInvitationDetails(invitation);
-
-          t.equals(
-            invitationValue.installation,
-            installation,
-            'installation is atomicSwap',
+        E(seat)
+          .getPayout('StrikePrice')
+          .then(simoleanPurse.deposit)
+          .then(amountDeposited =>
+            t.deepEqual(
+              amountDeposited,
+              simoleans(0),
+              `Bob didn't get anything back`,
+            ),
           );
-          t.equal(invitationValue.description, 'exerciseOption');
+      },
+    });
+  };
 
-          t.deepEquals(
-            invitationValue.underlyingAsset,
-            moola(3),
-            `underlying asset is 3 moola`,
-          );
-          t.deepEquals(
-            invitationValue.strikePrice,
-            simoleans(7),
-            `strike price is 7 simoleans, so bob must give that`,
-          );
+  const timer = buildManualTimer(console.log);
 
-          t.equal(invitationValue.expirationDate, 1);
-          t.deepEqual(invitationValue.timerAuthority, timer);
+  // Setup Alice
+  const aliceMoolaPayment = moolaKit.mint.mintPayment(moola(3));
+  const alice = await makeAlice(timer, aliceMoolaPayment);
 
-          const proposal = harden({
-            give: { StrikePrice: simoleans(7) },
-            want: { UnderlyingAsset: moola(3) },
-            exit: { onDemand: null },
-          });
-          const payments = { StrikePrice: simoleanPayment };
+  // Alice makes an instance and makes her offer.
+  const installation = await alice.installCode();
 
-          const seat = await E(zoe).offer(invitation, proposal, payments);
+  // Setup Bob
+  const bobSimoleanPayment = simoleanKit.mint.mintPayment(simoleans(7));
+  const bob = makeBob(timer, installation, bobSimoleanPayment);
 
-          t.equals(
-            await E(seat).getOfferResult(),
-            'The offer has been accepted. Once the contract has been completed, please check your payout',
-          );
+  const { creatorInvitation } = await alice.startInstance(installation);
+  const invitation = await alice.offer(creatorInvitation);
 
-          E(seat)
-            .getPayout('UnderlyingAsset')
-            .then(moolaPurse.deposit)
-            .then(amountDeposited =>
-              t.deepEquals(
-                amountDeposited,
-                proposal.want.UnderlyingAsset,
-                `Bob got what he wanted`,
-              ),
-            );
-
-          E(seat)
-            .getPayout('StrikePrice')
-            .then(simoleanPurse.deposit)
-            .then(amountDeposited =>
-              t.deepEquals(
-                amountDeposited,
-                simoleans(0),
-                `Bob didn't get anything back`,
-              ),
-            );
-        },
-      });
-    };
-
-    const timer = buildManualTimer(console.log);
-
-    // Setup Alice
-    const aliceMoolaPayment = moolaKit.mint.mintPayment(moola(3));
-    const alice = await makeAlice(timer, aliceMoolaPayment);
-
-    // Alice makes an instance and makes her offer.
-    const installation = await alice.installCode();
-
-    // Setup Bob
-    const bobSimoleanPayment = simoleanKit.mint.mintPayment(simoleans(7));
-    const bob = makeBob(timer, installation, bobSimoleanPayment);
-
-    const { creatorInvitation } = await alice.startInstance(installation);
-    const invitation = await alice.offer(creatorInvitation);
-
-    // Alice spreads the invitation far and wide with instructions
-    // on how to use it and Bob decides he wants to be the
-    // counter-party, without needing to trust Alice at all.
-    await bob.offer(invitation);
-  } catch (e) {
-    t.isNot(e, e, 'unexpected exception');
-  }
+  // Alice spreads the invitation far and wide with instructions
+  // on how to use it and Bob decides he wants to be the
+  // counter-party, without needing to trust Alice at all.
+  await bob.offer(invitation);
 });
 
 test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, async t => {
   t.plan(13);
-  try {
-    const { moolaR, simoleanR, moola, simoleans, zoe } = setup();
-    // Pack the contract.
-    const bundle = await bundleSource(coveredCallRoot);
-    const coveredCallInstallation = await zoe.install(bundle);
-    const timer = buildManualTimer(console.log);
+  const { moolaR, simoleanR, moola, simoleans, zoe } = setup();
+  // Pack the contract.
+  const bundle = await bundleSource(coveredCallRoot);
+  const coveredCallInstallation = await zoe.install(bundle);
+  const timer = buildManualTimer(console.log);
 
-    // Setup Alice
-    const aliceMoolaPayment = moolaR.mint.mintPayment(moola(3));
-    const aliceMoolaPurse = moolaR.issuer.makeEmptyPurse();
-    const aliceSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
+  // Setup Alice
+  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(3));
+  const aliceMoolaPurse = moolaR.issuer.makeEmptyPurse();
+  const aliceSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
 
-    // Setup Bob
-    const bobSimoleanPayment = simoleanR.mint.mintPayment(simoleans(7));
-    const bobMoolaPurse = moolaR.issuer.makeEmptyPurse();
-    const bobSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
+  // Setup Bob
+  const bobSimoleanPayment = simoleanR.mint.mintPayment(simoleans(7));
+  const bobMoolaPurse = moolaR.issuer.makeEmptyPurse();
+  const bobSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
 
-    // Alice creates a coveredCall instance
-    const issuerKeywordRecord = harden({
-      UnderlyingAsset: moolaR.issuer,
-      StrikePrice: simoleanR.issuer,
-    });
-    const { creatorInvitation: aliceInvitation } = await zoe.startInstance(
-      coveredCallInstallation,
-      issuerKeywordRecord,
-    );
+  // Alice creates a coveredCall instance
+  const issuerKeywordRecord = harden({
+    UnderlyingAsset: moolaR.issuer,
+    StrikePrice: simoleanR.issuer,
+  });
+  const { creatorInvitation: aliceInvitation } = await zoe.startInstance(
+    coveredCallInstallation,
+    issuerKeywordRecord,
+  );
 
-    // Alice escrows with Zoe
-    const aliceProposal = harden({
-      give: { UnderlyingAsset: moola(3) },
-      want: { StrikePrice: simoleans(7) },
-      exit: {
-        afterDeadline: {
-          deadline: 1,
-          timer,
-        },
+  // Alice escrows with Zoe
+  const aliceProposal = harden({
+    give: { UnderlyingAsset: moola(3) },
+    want: { StrikePrice: simoleans(7) },
+    exit: {
+      afterDeadline: {
+        deadline: 1,
+        timer,
       },
-    });
-    const alicePayments = { UnderlyingAsset: aliceMoolaPayment };
-    // Alice makes an option
-    const aliceSeat = await zoe.offer(
-      aliceInvitation,
-      aliceProposal,
-      alicePayments,
-    );
-    timer.tick();
+    },
+  });
+  const alicePayments = { UnderlyingAsset: aliceMoolaPayment };
+  // Alice makes an option
+  const aliceSeat = await zoe.offer(
+    aliceInvitation,
+    aliceProposal,
+    alicePayments,
+  );
+  timer.tick();
 
-    const optionP = E(aliceSeat).getOfferResult();
+  const optionP = E(aliceSeat).getOfferResult();
 
-    // Imagine that Alice sends the option to Bob for free (not done here
-    // since this test doesn't actually have separate vats/parties)
+  // Imagine that Alice sends the option to Bob for free (not done here
+  // since this test doesn't actually have separate vats/parties)
 
-    // Bob inspects the option (an invitation payment) and checks that it is the
-    // contract instance that he expects as well as that Alice has
-    // already escrowed.
+  // Bob inspects the option (an invitation payment) and checks that it is the
+  // contract instance that he expects as well as that Alice has
+  // already escrowed.
 
-    const invitationIssuer = zoe.getInvitationIssuer();
-    const bobExclOption = await invitationIssuer.claim(optionP);
-    const optionValue = await E(zoe).getInvitationDetails(bobExclOption);
-    t.equal(optionValue.installation, coveredCallInstallation);
-    t.equal(optionValue.description, 'exerciseOption');
-    t.ok(moolaR.amountMath.isEqual(optionValue.underlyingAsset, moola(3)));
-    t.ok(simoleanR.amountMath.isEqual(optionValue.strikePrice, simoleans(7)));
-    t.equal(optionValue.expirationDate, 1);
-    t.deepEqual(optionValue.timerAuthority, timer);
+  const invitationIssuer = zoe.getInvitationIssuer();
+  const bobExclOption = await invitationIssuer.claim(optionP);
+  const optionValue = await E(zoe).getInvitationDetails(bobExclOption);
+  t.is(optionValue.installation, coveredCallInstallation);
+  t.is(optionValue.description, 'exerciseOption');
+  t.truthy(moolaR.amountMath.isEqual(optionValue.underlyingAsset, moola(3)));
+  t.truthy(simoleanR.amountMath.isEqual(optionValue.strikePrice, simoleans(7)));
+  t.is(optionValue.expirationDate, 1);
+  t.deepEqual(optionValue.timerAuthority, timer);
 
-    const bobPayments = { StrikePrice: bobSimoleanPayment };
+  const bobPayments = { StrikePrice: bobSimoleanPayment };
 
-    const bobProposal = harden({
-      want: { UnderlyingAsset: optionValue.underlyingAsset },
-      give: { StrikePrice: optionValue.strikePrice },
-    });
+  const bobProposal = harden({
+    want: { UnderlyingAsset: optionValue.underlyingAsset },
+    give: { StrikePrice: optionValue.strikePrice },
+  });
 
-    // Bob escrows
-    const bobSeat = await zoe.offer(bobExclOption, bobProposal, bobPayments);
+  // Bob escrows
+  const bobSeat = await zoe.offer(bobExclOption, bobProposal, bobPayments);
 
-    t.rejects(
-      () => E(bobSeat).getOfferResult(),
-      /The covered call option is expired./,
-      'The call option should be expired',
-    );
+  // TODO is this await safe?
+  await t.throwsAsync(
+    () => E(bobSeat).getOfferResult(),
+    { message: /The covered call option is expired./ },
+    'The call option should be expired',
+  );
 
-    const bobMoolaPayout = await E(bobSeat).getPayout('UnderlyingAsset');
-    const bobSimoleanPayout = await E(bobSeat).getPayout('StrikePrice');
-    const aliceMoolaPayout = await E(aliceSeat).getPayout('UnderlyingAsset');
-    const aliceSimoleanPayout = await E(aliceSeat).getPayout('StrikePrice');
+  const bobMoolaPayout = await E(bobSeat).getPayout('UnderlyingAsset');
+  const bobSimoleanPayout = await E(bobSeat).getPayout('StrikePrice');
+  const aliceMoolaPayout = await E(aliceSeat).getPayout('UnderlyingAsset');
+  const aliceSimoleanPayout = await E(aliceSeat).getPayout('StrikePrice');
 
-    // Alice gets back what she put in
-    t.deepEquals(await moolaR.issuer.getAmountOf(aliceMoolaPayout), moola(3));
+  // Alice gets back what she put in
+  t.deepEqual(await moolaR.issuer.getAmountOf(aliceMoolaPayout), moola(3));
 
-    // Alice doesn't get what she wanted
-    t.deepEquals(
-      await simoleanR.issuer.getAmountOf(aliceSimoleanPayout),
-      simoleans(0),
-    );
+  // Alice doesn't get what she wanted
+  t.deepEqual(
+    await simoleanR.issuer.getAmountOf(aliceSimoleanPayout),
+    simoleans(0),
+  );
 
-    // Alice deposits her winnings to ensure she can
-    await aliceMoolaPurse.deposit(aliceMoolaPayout);
-    await aliceSimoleanPurse.deposit(aliceSimoleanPayout);
+  // Alice deposits her winnings to ensure she can
+  await aliceMoolaPurse.deposit(aliceMoolaPayout);
+  await aliceSimoleanPurse.deposit(aliceSimoleanPayout);
 
-    // Bob deposits his winnings to ensure he can
-    await bobMoolaPurse.deposit(bobMoolaPayout);
-    await bobSimoleanPurse.deposit(bobSimoleanPayout);
+  // Bob deposits his winnings to ensure he can
+  await bobMoolaPurse.deposit(bobMoolaPayout);
+  await bobSimoleanPurse.deposit(bobSimoleanPayout);
 
-    // Assert that the correct outcome was achieved.
-    // Alice had 3 moola and 0 simoleans.
-    // Bob had 0 moola and 7 simoleans.
-    t.deepEquals(aliceMoolaPurse.getCurrentAmount(), moola(3));
-    t.deepEquals(aliceSimoleanPurse.getCurrentAmount(), simoleans(0));
-    t.deepEquals(bobMoolaPurse.getCurrentAmount(), moola(0));
-    t.deepEquals(bobSimoleanPurse.getCurrentAmount(), simoleans(7));
-  } catch (e) {
-    t.isNot(e, e, 'unexpected exception');
-  }
+  // Assert that the correct outcome was achieved.
+  // Alice had 3 moola and 0 simoleans.
+  // Bob had 0 moola and 7 simoleans.
+  t.deepEqual(aliceMoolaPurse.getCurrentAmount(), moola(3));
+  t.deepEqual(aliceSimoleanPurse.getCurrentAmount(), simoleans(0));
+  t.deepEqual(bobMoolaPurse.getCurrentAmount(), moola(0));
+  t.deepEqual(bobSimoleanPurse.getCurrentAmount(), simoleans(7));
 });
 
 // Alice makes a covered call and escrows. She shares the invitation to
@@ -308,256 +299,250 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
 // offer description?
 test('zoe - coveredCall with swap for invitation', async t => {
   t.plan(24);
-  try {
-    // Setup the environment
-    const timer = buildManualTimer(console.log);
-    const { moolaR, simoleanR, bucksR, moola, simoleans, bucks, zoe } = setup();
-    // Pack the contract.
-    const coveredCallBundle = await bundleSource(coveredCallRoot);
+  // Setup the environment
+  const timer = buildManualTimer(console.log);
+  const { moolaR, simoleanR, bucksR, moola, simoleans, bucks, zoe } = setup();
+  // Pack the contract.
+  const coveredCallBundle = await bundleSource(coveredCallRoot);
 
-    const coveredCallInstallation = await zoe.install(coveredCallBundle);
-    const atomicSwapBundle = await bundleSource(atomicSwapRoot);
+  const coveredCallInstallation = await zoe.install(coveredCallBundle);
+  const atomicSwapBundle = await bundleSource(atomicSwapRoot);
 
-    const swapInstallationId = await zoe.install(atomicSwapBundle);
+  const swapInstallationId = await zoe.install(atomicSwapBundle);
 
-    // Setup Alice
-    // Alice starts with 3 moola
-    const aliceMoolaPayment = moolaR.mint.mintPayment(moola(3));
-    const aliceMoolaPurse = moolaR.issuer.makeEmptyPurse();
-    const aliceSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
+  // Setup Alice
+  // Alice starts with 3 moola
+  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(3));
+  const aliceMoolaPurse = moolaR.issuer.makeEmptyPurse();
+  const aliceSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
 
-    // Setup Bob
-    // Bob starts with nothing
-    const bobMoolaPurse = moolaR.issuer.makeEmptyPurse();
-    const bobSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
-    const bobBucksPurse = bucksR.issuer.makeEmptyPurse();
+  // Setup Bob
+  // Bob starts with nothing
+  const bobMoolaPurse = moolaR.issuer.makeEmptyPurse();
+  const bobSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
+  const bobBucksPurse = bucksR.issuer.makeEmptyPurse();
 
-    // Setup Dave
-    // Dave starts with 1 buck
-    const daveSimoleanPayment = simoleanR.mint.mintPayment(simoleans(7));
-    const daveBucksPayment = bucksR.mint.mintPayment(bucks(1));
-    const daveMoolaPurse = moolaR.issuer.makeEmptyPurse();
-    const daveSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
-    const daveBucksPurse = bucksR.issuer.makeEmptyPurse();
+  // Setup Dave
+  // Dave starts with 1 buck
+  const daveSimoleanPayment = simoleanR.mint.mintPayment(simoleans(7));
+  const daveBucksPayment = bucksR.mint.mintPayment(bucks(1));
+  const daveMoolaPurse = moolaR.issuer.makeEmptyPurse();
+  const daveSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
+  const daveBucksPurse = bucksR.issuer.makeEmptyPurse();
 
-    // Alice creates a coveredCall instance of moola for simoleans
-    const issuerKeywordRecord = harden({
-      UnderlyingAsset: moolaR.issuer,
-      StrikePrice: simoleanR.issuer,
-    });
-    const { creatorInvitation: aliceInvitation } = await zoe.startInstance(
-      coveredCallInstallation,
-      issuerKeywordRecord,
-    );
+  // Alice creates a coveredCall instance of moola for simoleans
+  const issuerKeywordRecord = harden({
+    UnderlyingAsset: moolaR.issuer,
+    StrikePrice: simoleanR.issuer,
+  });
+  const { creatorInvitation: aliceInvitation } = await zoe.startInstance(
+    coveredCallInstallation,
+    issuerKeywordRecord,
+  );
 
-    // Alice escrows with Zoe. She specifies her proposal,
-    // which includes the amounts she gives and wants as well as the exit
-    // conditions. In this case, she choses an exit condition of after
-    // the deadline of "100" according to a particular timer. This is
-    // meant to be something far in the future, and will not be
-    // reached in this test.
+  // Alice escrows with Zoe. She specifies her proposal,
+  // which includes the amounts she gives and wants as well as the exit
+  // conditions. In this case, she choses an exit condition of after
+  // the deadline of "100" according to a particular timer. This is
+  // meant to be something far in the future, and will not be
+  // reached in this test.
 
-    const aliceProposal = harden({
-      give: { UnderlyingAsset: moola(3) },
-      want: { StrikePrice: simoleans(7) },
-      exit: {
-        afterDeadline: {
-          deadline: 100, // we will not reach this
-          timer,
-        },
+  const aliceProposal = harden({
+    give: { UnderlyingAsset: moola(3) },
+    want: { StrikePrice: simoleans(7) },
+    exit: {
+      afterDeadline: {
+        deadline: 100, // we will not reach this
+        timer,
       },
-    });
-    const alicePayments = { UnderlyingAsset: aliceMoolaPayment };
-    // Alice makes an option.
-    const aliceSeat = await zoe.offer(
-      aliceInvitation,
-      aliceProposal,
-      alicePayments,
-    );
+    },
+  });
+  const alicePayments = { UnderlyingAsset: aliceMoolaPayment };
+  // Alice makes an option.
+  const aliceSeat = await zoe.offer(
+    aliceInvitation,
+    aliceProposal,
+    alicePayments,
+  );
 
-    const optionP = E(aliceSeat).getOfferResult();
+  const optionP = E(aliceSeat).getOfferResult();
 
-    // Imagine that Alice sends the invitation to Bob (not done here since
-    // this test doesn't actually have separate vats/parties)
+  // Imagine that Alice sends the invitation to Bob (not done here since
+  // this test doesn't actually have separate vats/parties)
 
-    // Bob inspects the invitation payment and checks its information against the
-    // questions that he has about whether it is worth being a counter
-    // party in the covered call: Did the covered call use the
-    // expected covered call installation (code)? Does it use the issuers
-    // that he expects (moola and simoleans)?
-    const invitationIssuer = zoe.getInvitationIssuer();
-    const invitationAmountMath = await makeLocalAmountMath(invitationIssuer);
-    const bobExclOption = await invitationIssuer.claim(optionP);
-    const optionAmount = await invitationIssuer.getAmountOf(bobExclOption);
-    const optionDesc = optionAmount.value[0];
-    t.equal(optionDesc.installation, coveredCallInstallation);
-    t.equal(optionDesc.description, 'exerciseOption');
-    t.ok(moolaR.amountMath.isEqual(optionDesc.underlyingAsset, moola(3)));
-    t.ok(simoleanR.amountMath.isEqual(optionDesc.strikePrice, simoleans(7)));
-    t.equal(optionDesc.expirationDate, 100);
-    t.deepEqual(optionDesc.timerAuthority, timer);
+  // Bob inspects the invitation payment and checks its information against the
+  // questions that he has about whether it is worth being a counter
+  // party in the covered call: Did the covered call use the
+  // expected covered call installation (code)? Does it use the issuers
+  // that he expects (moola and simoleans)?
+  const invitationIssuer = zoe.getInvitationIssuer();
+  const invitationAmountMath = await makeLocalAmountMath(invitationIssuer);
+  const bobExclOption = await invitationIssuer.claim(optionP);
+  const optionAmount = await invitationIssuer.getAmountOf(bobExclOption);
+  const optionDesc = optionAmount.value[0];
+  t.is(optionDesc.installation, coveredCallInstallation);
+  t.is(optionDesc.description, 'exerciseOption');
+  t.truthy(moolaR.amountMath.isEqual(optionDesc.underlyingAsset, moola(3)));
+  t.truthy(simoleanR.amountMath.isEqual(optionDesc.strikePrice, simoleans(7)));
+  t.is(optionDesc.expirationDate, 100);
+  t.deepEqual(optionDesc.timerAuthority, timer);
 
-    // Let's imagine that Bob wants to create a swap to trade this
-    // invitation for bucks.
-    const swapIssuerKeywordRecord = harden({
-      Asset: invitationIssuer,
-      Price: bucksR.issuer,
-    });
-    const { creatorInvitation: bobSwapInvitation } = await zoe.startInstance(
-      swapInstallationId,
-      swapIssuerKeywordRecord,
-    );
+  // Let's imagine that Bob wants to create a swap to trade this
+  // invitation for bucks.
+  const swapIssuerKeywordRecord = harden({
+    Asset: invitationIssuer,
+    Price: bucksR.issuer,
+  });
+  const { creatorInvitation: bobSwapInvitation } = await zoe.startInstance(
+    swapInstallationId,
+    swapIssuerKeywordRecord,
+  );
 
-    // Bob wants to swap an invitation with the same amount as his
-    // current invitation from Alice. He wants 1 buck in return.
-    const bobProposalSwap = harden({
-      give: { Asset: await invitationIssuer.getAmountOf(bobExclOption) },
-      want: { Price: bucks(1) },
-    });
+  // Bob wants to swap an invitation with the same amount as his
+  // current invitation from Alice. He wants 1 buck in return.
+  const bobProposalSwap = harden({
+    give: { Asset: await invitationIssuer.getAmountOf(bobExclOption) },
+    want: { Price: bucks(1) },
+  });
 
-    const bobPayments = harden({ Asset: bobExclOption });
+  const bobPayments = harden({ Asset: bobExclOption });
 
-    // Bob escrows his option in the swap
-    // Bob makes an offer to the swap with his "higher order" invitation
-    const bobSwapSeat = await zoe.offer(
-      bobSwapInvitation,
-      bobProposalSwap,
-      bobPayments,
-    );
+  // Bob escrows his option in the swap
+  // Bob makes an offer to the swap with his "higher order" invitation
+  const bobSwapSeat = await zoe.offer(
+    bobSwapInvitation,
+    bobProposalSwap,
+    bobPayments,
+  );
 
-    const daveSwapInvitationP = E(bobSwapSeat).getOfferResult();
+  const daveSwapInvitationP = E(bobSwapSeat).getOfferResult();
 
-    // Bob passes the swap invitation to Dave and tells him the
-    // optionAmounts (basically, the description of the option)
+  // Bob passes the swap invitation to Dave and tells him the
+  // optionAmounts (basically, the description of the option)
 
-    const {
-      value: [{ instance: swapInstance, installation: daveSwapInstallId }],
-    } = await invitationIssuer.getAmountOf(daveSwapInvitationP);
+  const {
+    value: [{ instance: swapInstance, installation: daveSwapInstallId }],
+  } = await invitationIssuer.getAmountOf(daveSwapInvitationP);
 
-    const daveSwapIssuers = zoe.getIssuers(swapInstance);
+  const daveSwapIssuers = zoe.getIssuers(swapInstance);
 
-    // Dave is looking to buy the option to trade his 7 simoleans for
-    // 3 moola, and is willing to pay 1 buck for the option. He
-    // checks that this instance matches what he wants
+  // Dave is looking to buy the option to trade his 7 simoleans for
+  // 3 moola, and is willing to pay 1 buck for the option. He
+  // checks that this instance matches what he wants
 
-    // Did this swap use the correct swap installation? Yes
-    t.equal(daveSwapInstallId, swapInstallationId);
+  // Did this swap use the correct swap installation? Yes
+  t.is(daveSwapInstallId, swapInstallationId);
 
-    // Is this swap for the correct issuers and has no other terms? Yes
-    t.ok(
-      sameStructure(
-        daveSwapIssuers,
-        harden({
-          Asset: invitationIssuer,
-          Price: bucksR.issuer,
-        }),
-      ),
-    );
+  // Is this swap for the correct issuers and has no other terms? Yes
+  t.truthy(
+    sameStructure(
+      daveSwapIssuers,
+      harden({
+        Asset: invitationIssuer,
+        Price: bucksR.issuer,
+      }),
+    ),
+  );
 
-    // What's actually up to be bought? Is it the kind of invitation that
-    // Dave wants? What's the price for that invitation? Is it acceptable
-    // to Dave? Bob can tell Dave this out of band, and if he lies,
-    // Dave's offer will be rejected and he will get a refund. Dave
-    // knows this to be true because he knows the swap.
+  // What's actually up to be bought? Is it the kind of invitation that
+  // Dave wants? What's the price for that invitation? Is it acceptable
+  // to Dave? Bob can tell Dave this out of band, and if he lies,
+  // Dave's offer will be rejected and he will get a refund. Dave
+  // knows this to be true because he knows the swap.
 
-    // Dave escrows his 1 buck with Zoe and forms his proposal
-    const daveSwapProposal = harden({
-      want: { Asset: optionAmount },
-      give: { Price: bucks(1) },
-    });
+  // Dave escrows his 1 buck with Zoe and forms his proposal
+  const daveSwapProposal = harden({
+    want: { Asset: optionAmount },
+    give: { Price: bucks(1) },
+  });
 
-    const daveSwapPayments = harden({ Price: daveBucksPayment });
-    const daveSwapSeat = await zoe.offer(
-      daveSwapInvitationP,
-      daveSwapProposal,
-      daveSwapPayments,
-    );
+  const daveSwapPayments = harden({ Price: daveBucksPayment });
+  const daveSwapSeat = await zoe.offer(
+    daveSwapInvitationP,
+    daveSwapProposal,
+    daveSwapPayments,
+  );
 
-    t.equals(
-      await daveSwapSeat.getOfferResult(),
-      'The offer has been accepted. Once the contract has been completed, please check your payout',
-    );
+  t.is(
+    await daveSwapSeat.getOfferResult(),
+    'The offer has been accepted. Once the contract has been completed, please check your payout',
+  );
 
-    const daveOption = await daveSwapSeat.getPayout('Asset');
-    const daveBucksPayout = await daveSwapSeat.getPayout('Price');
+  const daveOption = await daveSwapSeat.getPayout('Asset');
+  const daveBucksPayout = await daveSwapSeat.getPayout('Price');
 
-    // Dave exercises his option by making an offer to the covered
-    // call. First, he escrows with Zoe.
+  // Dave exercises his option by making an offer to the covered
+  // call. First, he escrows with Zoe.
 
-    const daveCoveredCallProposal = harden({
-      want: { UnderlyingAsset: moola(3) },
-      give: { StrikePrice: simoleans(7) },
-    });
-    const daveCoveredCallPayments = harden({
-      StrikePrice: daveSimoleanPayment,
-    });
-    const daveCoveredCallSeat = await zoe.offer(
-      daveOption,
-      daveCoveredCallProposal,
-      daveCoveredCallPayments,
-    );
+  const daveCoveredCallProposal = harden({
+    want: { UnderlyingAsset: moola(3) },
+    give: { StrikePrice: simoleans(7) },
+  });
+  const daveCoveredCallPayments = harden({
+    StrikePrice: daveSimoleanPayment,
+  });
+  const daveCoveredCallSeat = await zoe.offer(
+    daveOption,
+    daveCoveredCallProposal,
+    daveCoveredCallPayments,
+  );
 
-    t.equals(
-      await E(daveCoveredCallSeat).getOfferResult(),
-      'The offer has been accepted. Once the contract has been completed, please check your payout',
-    );
+  t.is(
+    await E(daveCoveredCallSeat).getOfferResult(),
+    'The offer has been accepted. Once the contract has been completed, please check your payout',
+  );
 
-    // Dave should get 3 moola, Bob should get 1 buck, and Alice
-    // get 7 simoleans
-    const daveMoolaPayout = await daveCoveredCallSeat.getPayout(
-      'UnderlyingAsset',
-    );
-    const daveSimoleanPayout = await daveCoveredCallSeat.getPayout(
-      'StrikePrice',
-    );
-    const aliceMoolaPayout = await aliceSeat.getPayout('UnderlyingAsset');
-    const aliceSimoleanPayout = await aliceSeat.getPayout('StrikePrice');
-    const bobInvitationPayout = await bobSwapSeat.getPayout('Asset');
-    const bobBucksPayout = await bobSwapSeat.getPayout('Price');
+  // Dave should get 3 moola, Bob should get 1 buck, and Alice
+  // get 7 simoleans
+  const daveMoolaPayout = await daveCoveredCallSeat.getPayout(
+    'UnderlyingAsset',
+  );
+  const daveSimoleanPayout = await daveCoveredCallSeat.getPayout('StrikePrice');
+  const aliceMoolaPayout = await aliceSeat.getPayout('UnderlyingAsset');
+  const aliceSimoleanPayout = await aliceSeat.getPayout('StrikePrice');
+  const bobInvitationPayout = await bobSwapSeat.getPayout('Asset');
+  const bobBucksPayout = await bobSwapSeat.getPayout('Price');
 
-    t.deepEquals(await moolaR.issuer.getAmountOf(daveMoolaPayout), moola(3));
-    t.deepEquals(
-      await simoleanR.issuer.getAmountOf(daveSimoleanPayout),
-      simoleans(0),
-    );
+  t.deepEqual(await moolaR.issuer.getAmountOf(daveMoolaPayout), moola(3));
+  t.deepEqual(
+    await simoleanR.issuer.getAmountOf(daveSimoleanPayout),
+    simoleans(0),
+  );
 
-    t.deepEquals(await moolaR.issuer.getAmountOf(aliceMoolaPayout), moola(0));
-    t.deepEquals(
-      await simoleanR.issuer.getAmountOf(aliceSimoleanPayout),
-      simoleans(7),
-    );
+  t.deepEqual(await moolaR.issuer.getAmountOf(aliceMoolaPayout), moola(0));
+  t.deepEqual(
+    await simoleanR.issuer.getAmountOf(aliceSimoleanPayout),
+    simoleans(7),
+  );
 
-    t.deepEquals(
-      await invitationIssuer.getAmountOf(bobInvitationPayout),
-      invitationAmountMath.getEmpty(),
-    );
-    t.deepEquals(await bucksR.issuer.getAmountOf(bobBucksPayout), bucks(1));
+  t.deepEqual(
+    await invitationIssuer.getAmountOf(bobInvitationPayout),
+    invitationAmountMath.getEmpty(),
+  );
+  t.deepEqual(await bucksR.issuer.getAmountOf(bobBucksPayout), bucks(1));
 
-    // Alice deposits her payouts
-    await aliceMoolaPurse.deposit(aliceMoolaPayout);
-    await aliceSimoleanPurse.deposit(aliceSimoleanPayout);
+  // Alice deposits her payouts
+  await aliceMoolaPurse.deposit(aliceMoolaPayout);
+  await aliceSimoleanPurse.deposit(aliceSimoleanPayout);
 
-    // Bob deposits his payouts
-    await bobBucksPurse.deposit(bobBucksPayout);
+  // Bob deposits his payouts
+  await bobBucksPurse.deposit(bobBucksPayout);
 
-    // Dave deposits his payouts
-    await daveMoolaPurse.deposit(daveMoolaPayout);
-    await daveSimoleanPurse.deposit(daveSimoleanPayout);
-    await daveBucksPurse.deposit(daveBucksPayout);
+  // Dave deposits his payouts
+  await daveMoolaPurse.deposit(daveMoolaPayout);
+  await daveSimoleanPurse.deposit(daveSimoleanPayout);
+  await daveBucksPurse.deposit(daveBucksPayout);
 
-    t.equals(aliceMoolaPurse.getCurrentAmount().value, 0);
-    t.equals(aliceSimoleanPurse.getCurrentAmount().value, 7);
+  t.is(aliceMoolaPurse.getCurrentAmount().value, 0);
+  t.is(aliceSimoleanPurse.getCurrentAmount().value, 7);
 
-    t.equals(bobMoolaPurse.getCurrentAmount().value, 0);
-    t.equals(bobSimoleanPurse.getCurrentAmount().value, 0);
-    t.equals(bobBucksPurse.getCurrentAmount().value, 1);
+  t.is(bobMoolaPurse.getCurrentAmount().value, 0);
+  t.is(bobSimoleanPurse.getCurrentAmount().value, 0);
+  t.is(bobBucksPurse.getCurrentAmount().value, 1);
 
-    t.equals(daveMoolaPurse.getCurrentAmount().value, 3);
-    t.equals(daveSimoleanPurse.getCurrentAmount().value, 0);
-    t.equals(daveBucksPurse.getCurrentAmount().value, 0);
-  } catch (e) {
-    t.isNot(e, e, 'unexpected exception');
-  }
+  t.is(daveMoolaPurse.getCurrentAmount().value, 3);
+  t.is(daveSimoleanPurse.getCurrentAmount().value, 0);
+  t.is(daveBucksPurse.getCurrentAmount().value, 0);
 });
 
 // Alice makes a covered call and escrows. She shares the invitation to
@@ -566,264 +551,257 @@ test('zoe - coveredCall with swap for invitation', async t => {
 // wants in his offer description in the second covered call?
 test('zoe - coveredCall with coveredCall for invitation', async t => {
   t.plan(31);
-  try {
-    // Setup the environment
-    const timer = buildManualTimer(console.log);
-    const { moolaR, simoleanR, bucksR, moola, simoleans, bucks, zoe } = setup();
+  // Setup the environment
+  const timer = buildManualTimer(console.log);
+  const { moolaR, simoleanR, bucksR, moola, simoleans, bucks, zoe } = setup();
 
-    // Pack the contract.
-    const bundle = await bundleSource(coveredCallRoot);
+  // Pack the contract.
+  const bundle = await bundleSource(coveredCallRoot);
 
-    const coveredCallInstallation = await zoe.install(bundle);
+  const coveredCallInstallation = await zoe.install(bundle);
 
-    // Setup Alice
-    // Alice starts with 3 moola
-    const aliceMoolaPayment = moolaR.mint.mintPayment(moola(3));
-    const aliceMoolaPurse = moolaR.issuer.makeEmptyPurse();
-    const aliceSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
+  // Setup Alice
+  // Alice starts with 3 moola
+  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(3));
+  const aliceMoolaPurse = moolaR.issuer.makeEmptyPurse();
+  const aliceSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
 
-    // Setup Bob
-    // Bob starts with nothing
-    const bobMoolaPurse = moolaR.issuer.makeEmptyPurse();
-    const bobSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
-    const bobBucksPurse = bucksR.issuer.makeEmptyPurse();
+  // Setup Bob
+  // Bob starts with nothing
+  const bobMoolaPurse = moolaR.issuer.makeEmptyPurse();
+  const bobSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
+  const bobBucksPurse = bucksR.issuer.makeEmptyPurse();
 
-    // Setup Dave
-    // Dave starts with 1 buck and 7 simoleans
-    const daveSimoleanPayment = simoleanR.mint.mintPayment(simoleans(7));
-    const daveBucksPayment = bucksR.mint.mintPayment(bucks(1));
-    const daveMoolaPurse = moolaR.issuer.makeEmptyPurse();
-    const daveSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
-    const daveBucksPurse = bucksR.issuer.makeEmptyPurse();
+  // Setup Dave
+  // Dave starts with 1 buck and 7 simoleans
+  const daveSimoleanPayment = simoleanR.mint.mintPayment(simoleans(7));
+  const daveBucksPayment = bucksR.mint.mintPayment(bucks(1));
+  const daveMoolaPurse = moolaR.issuer.makeEmptyPurse();
+  const daveSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
+  const daveBucksPurse = bucksR.issuer.makeEmptyPurse();
 
-    // Alice creates a coveredCall instance of moola for simoleans
-    const issuerKeywordRecord = harden({
-      UnderlyingAsset: moolaR.issuer,
-      StrikePrice: simoleanR.issuer,
-    });
-    const {
-      creatorInvitation: aliceCoveredCallInvitation,
-    } = await zoe.startInstance(coveredCallInstallation, issuerKeywordRecord);
+  // Alice creates a coveredCall instance of moola for simoleans
+  const issuerKeywordRecord = harden({
+    UnderlyingAsset: moolaR.issuer,
+    StrikePrice: simoleanR.issuer,
+  });
+  const {
+    creatorInvitation: aliceCoveredCallInvitation,
+  } = await zoe.startInstance(coveredCallInstallation, issuerKeywordRecord);
 
-    // Alice escrows with Zoe. She specifies her proposal,
-    // which include what she wants and gives as well as the exit
-    // condition. In this case, she choses an exit condition of after
-    // the deadline of "100" according to a particular timer. This is
-    // meant to be something far in the future, and will not be
-    // reached in this test.
+  // Alice escrows with Zoe. She specifies her proposal,
+  // which include what she wants and gives as well as the exit
+  // condition. In this case, she choses an exit condition of after
+  // the deadline of "100" according to a particular timer. This is
+  // meant to be something far in the future, and will not be
+  // reached in this test.
 
-    const aliceProposal = harden({
-      give: { UnderlyingAsset: moola(3) },
-      want: { StrikePrice: simoleans(7) },
-      exit: {
-        afterDeadline: {
-          deadline: 100, // we will not reach this
-          timer,
-        },
+  const aliceProposal = harden({
+    give: { UnderlyingAsset: moola(3) },
+    want: { StrikePrice: simoleans(7) },
+    exit: {
+      afterDeadline: {
+        deadline: 100, // we will not reach this
+        timer,
       },
-    });
-    const alicePayments = { UnderlyingAsset: aliceMoolaPayment };
-    // Alice makes a call option, which is an invitation to join the
-    // covered call contract
-    const aliceSeat = await zoe.offer(
-      aliceCoveredCallInvitation,
-      aliceProposal,
-      alicePayments,
-    );
-    const optionP = await E(aliceSeat).getOfferResult();
+    },
+  });
+  const alicePayments = { UnderlyingAsset: aliceMoolaPayment };
+  // Alice makes a call option, which is an invitation to join the
+  // covered call contract
+  const aliceSeat = await zoe.offer(
+    aliceCoveredCallInvitation,
+    aliceProposal,
+    alicePayments,
+  );
+  const optionP = await E(aliceSeat).getOfferResult();
 
-    // Imagine that Alice sends the invitation to Bob as well as the
-    // instanceHandle (not done here since this test doesn't actually have
-    // separate vats/parties)
+  // Imagine that Alice sends the invitation to Bob as well as the
+  // instanceHandle (not done here since this test doesn't actually have
+  // separate vats/parties)
 
-    // Bob inspects the invitation payment and checks its information against the
-    // questions that he has about whether it is worth being a counter
-    // party in the covered call: Did the covered call use the
-    // expected covered call installation (code)? Does it use the issuers
-    // that he expects (moola and simoleans)?
-    const invitationIssuer = zoe.getInvitationIssuer();
-    const invitationAmountMath = await makeLocalAmountMath(invitationIssuer);
-    const bobExclOption = await invitationIssuer.claim(optionP);
-    const optionValue = await E(zoe).getInvitationDetails(bobExclOption);
-    t.equal(optionValue.installation, coveredCallInstallation);
-    t.equal(optionValue.description, 'exerciseOption');
-    t.ok(moolaR.amountMath.isEqual(optionValue.underlyingAsset, moola(3)));
-    t.ok(simoleanR.amountMath.isEqual(optionValue.strikePrice, simoleans(7)));
-    t.equal(optionValue.expirationDate, 100);
-    t.deepEqual(optionValue.timerAuthority, timer);
+  // Bob inspects the invitation payment and checks its information against the
+  // questions that he has about whether it is worth being a counter
+  // party in the covered call: Did the covered call use the
+  // expected covered call installation (code)? Does it use the issuers
+  // that he expects (moola and simoleans)?
+  const invitationIssuer = zoe.getInvitationIssuer();
+  const invitationAmountMath = await makeLocalAmountMath(invitationIssuer);
+  const bobExclOption = await invitationIssuer.claim(optionP);
+  const optionValue = await E(zoe).getInvitationDetails(bobExclOption);
+  t.is(optionValue.installation, coveredCallInstallation);
+  t.is(optionValue.description, 'exerciseOption');
+  t.truthy(moolaR.amountMath.isEqual(optionValue.underlyingAsset, moola(3)));
+  t.truthy(simoleanR.amountMath.isEqual(optionValue.strikePrice, simoleans(7)));
+  t.is(optionValue.expirationDate, 100);
+  t.deepEqual(optionValue.timerAuthority, timer);
 
-    // Let's imagine that Bob wants to create another coveredCall, but
-    // this time to trade this invitation for bucks.
-    const issuerKeywordRecord2 = harden({
-      UnderlyingAsset: invitationIssuer,
-      StrikePrice: bucksR.issuer,
-    });
-    const {
-      creatorInvitation: bobInvitationForSecondCoveredCall,
-    } = await zoe.startInstance(coveredCallInstallation, issuerKeywordRecord2);
+  // Let's imagine that Bob wants to create another coveredCall, but
+  // this time to trade this invitation for bucks.
+  const issuerKeywordRecord2 = harden({
+    UnderlyingAsset: invitationIssuer,
+    StrikePrice: bucksR.issuer,
+  });
+  const {
+    creatorInvitation: bobInvitationForSecondCoveredCall,
+  } = await zoe.startInstance(coveredCallInstallation, issuerKeywordRecord2);
 
-    // Bob wants to swap an invitation with the same amount as his
-    // current invitation from Alice. He wants 1 buck in return.
-    const bobProposalSecondCoveredCall = harden({
-      give: {
-        UnderlyingAsset: await invitationIssuer.getAmountOf(bobExclOption),
+  // Bob wants to swap an invitation with the same amount as his
+  // current invitation from Alice. He wants 1 buck in return.
+  const bobProposalSecondCoveredCall = harden({
+    give: {
+      UnderlyingAsset: await invitationIssuer.getAmountOf(bobExclOption),
+    },
+    want: { StrikePrice: bucks(1) },
+    exit: {
+      afterDeadline: {
+        deadline: 100, // we will not reach this
+        timer,
       },
-      want: { StrikePrice: bucks(1) },
-      exit: {
-        afterDeadline: {
-          deadline: 100, // we will not reach this
-          timer,
-        },
-      },
-    });
+    },
+  });
 
-    const bobPayments = { UnderlyingAsset: bobExclOption };
+  const bobPayments = { UnderlyingAsset: bobExclOption };
 
-    // Bob escrows his invitation
-    // Bob makes an offer to the swap with his "higher order" option
-    const bobSeat = await zoe.offer(
-      bobInvitationForSecondCoveredCall,
-      bobProposalSecondCoveredCall,
-      bobPayments,
-    );
-    const invitationForDaveP = E(bobSeat).getOfferResult();
+  // Bob escrows his invitation
+  // Bob makes an offer to the swap with his "higher order" option
+  const bobSeat = await zoe.offer(
+    bobInvitationForSecondCoveredCall,
+    bobProposalSecondCoveredCall,
+    bobPayments,
+  );
+  const invitationForDaveP = E(bobSeat).getOfferResult();
 
-    // Bob passes the higher order invitation and
-    // optionAmounts to Dave
+  // Bob passes the higher order invitation and
+  // optionAmounts to Dave
 
-    // Dave is looking to buy the option to trade his 7 simoleans for
-    // 3 moola, and is willing to pay 1 buck for the option. He
-    // checks that this invitation matches what he wants
-    const daveExclOption = await invitationIssuer.claim(invitationForDaveP);
-    const daveOptionValue = await E(zoe).getInvitationDetails(daveExclOption);
-    t.equal(daveOptionValue.installation, coveredCallInstallation);
-    t.equal(daveOptionValue.description, 'exerciseOption');
-    t.ok(bucksR.amountMath.isEqual(daveOptionValue.strikePrice, bucks(1)));
-    t.equal(daveOptionValue.expirationDate, 100);
-    t.deepEqual(daveOptionValue.timerAuthority, timer);
+  // Dave is looking to buy the option to trade his 7 simoleans for
+  // 3 moola, and is willing to pay 1 buck for the option. He
+  // checks that this invitation matches what he wants
+  const daveExclOption = await invitationIssuer.claim(invitationForDaveP);
+  const daveOptionValue = await E(zoe).getInvitationDetails(daveExclOption);
+  t.is(daveOptionValue.installation, coveredCallInstallation);
+  t.is(daveOptionValue.description, 'exerciseOption');
+  t.truthy(bucksR.amountMath.isEqual(daveOptionValue.strikePrice, bucks(1)));
+  t.is(daveOptionValue.expirationDate, 100);
+  t.deepEqual(daveOptionValue.timerAuthority, timer);
 
-    // What about the underlying asset (the other option)?
-    t.equal(
-      daveOptionValue.underlyingAsset.value[0].description,
-      'exerciseOption',
-    );
-    t.equal(daveOptionValue.underlyingAsset.value[0].expirationDate, 100);
-    t.ok(
-      simoleanR.amountMath.isEqual(
-        daveOptionValue.underlyingAsset.value[0].strikePrice,
-        simoleans(7),
-      ),
-    );
-    t.deepEqual(daveOptionValue.underlyingAsset.value[0].timerAuthority, timer);
-
-    // Dave's planned proposal
-    const daveProposalCoveredCall = harden({
-      want: { UnderlyingAsset: daveOptionValue.underlyingAsset },
-      give: { StrikePrice: bucks(1) },
-    });
-
-    // Dave escrows his 1 buck with Zoe and forms his proposal
-
-    const daveSecondCoveredCallPayments = { StrikePrice: daveBucksPayment };
-    const daveSecondCoveredCallSeat = await zoe.offer(
-      daveExclOption,
-      daveProposalCoveredCall,
-      daveSecondCoveredCallPayments,
-    );
-    t.equals(
-      await E(daveSecondCoveredCallSeat).getOfferResult(),
-      'The offer has been accepted. Once the contract has been completed, please check your payout',
-      `dave second offer accepted`,
-    );
-
-    const firstCoveredCallInvitation = await daveSecondCoveredCallSeat.getPayout(
-      'UnderlyingAsset',
-    );
-    const daveBucksPayout = await daveSecondCoveredCallSeat.getPayout(
-      'StrikePrice',
-    );
-
-    // Dave exercises his option by making an offer to the covered
-    // call. First, he escrows with Zoe.
-
-    const daveFirstCoveredCallProposal = harden({
-      want: { UnderlyingAsset: moola(3) },
-      give: { StrikePrice: simoleans(7) },
-    });
-    const daveFirstCoveredCallPayments = harden({
-      StrikePrice: daveSimoleanPayment,
-    });
-    const daveFirstCoveredCallSeat = await zoe.offer(
-      firstCoveredCallInvitation,
-      daveFirstCoveredCallProposal,
-      daveFirstCoveredCallPayments,
-    );
-
-    t.equals(
-      await daveFirstCoveredCallSeat.getOfferResult(),
-      'The offer has been accepted. Once the contract has been completed, please check your payout',
-      `dave first offer accepted`,
-    );
-
-    // Dave should get 3 moola, Bob should get 1 buck, and Alice
-    // get 7 simoleans
-
-    const daveMoolaPayout = await daveFirstCoveredCallSeat.getPayout(
-      'UnderlyingAsset',
-    );
-    const daveSimoleanPayout = await daveFirstCoveredCallSeat.getPayout(
-      'StrikePrice',
-    );
-
-    const aliceMoolaPayout = await aliceSeat.getPayout('UnderlyingAsset');
-    const aliceSimoleanPayout = await aliceSeat.getPayout('StrikePrice');
-
-    const bobInvitationPayout = await bobSeat.getPayout('UnderlyingAsset');
-    const bobBucksPayout = await bobSeat.getPayout('StrikePrice');
-
-    t.deepEquals(await moolaR.issuer.getAmountOf(daveMoolaPayout), moola(3));
-    t.deepEquals(
-      await simoleanR.issuer.getAmountOf(daveSimoleanPayout),
-      simoleans(0),
-    );
-
-    t.deepEquals(await moolaR.issuer.getAmountOf(aliceMoolaPayout), moola(0));
-    t.deepEquals(
-      await simoleanR.issuer.getAmountOf(aliceSimoleanPayout),
+  // What about the underlying asset (the other option)?
+  t.is(daveOptionValue.underlyingAsset.value[0].description, 'exerciseOption');
+  t.is(daveOptionValue.underlyingAsset.value[0].expirationDate, 100);
+  t.truthy(
+    simoleanR.amountMath.isEqual(
+      daveOptionValue.underlyingAsset.value[0].strikePrice,
       simoleans(7),
-    );
+    ),
+  );
+  t.deepEqual(daveOptionValue.underlyingAsset.value[0].timerAuthority, timer);
 
-    t.deepEquals(
-      await invitationIssuer.getAmountOf(bobInvitationPayout),
-      invitationAmountMath.getEmpty(),
-    );
-    t.deepEquals(await bucksR.issuer.getAmountOf(bobBucksPayout), bucks(1));
+  // Dave's planned proposal
+  const daveProposalCoveredCall = harden({
+    want: { UnderlyingAsset: daveOptionValue.underlyingAsset },
+    give: { StrikePrice: bucks(1) },
+  });
 
-    // Alice deposits her payouts
-    await aliceMoolaPurse.deposit(aliceMoolaPayout);
-    await aliceSimoleanPurse.deposit(aliceSimoleanPayout);
+  // Dave escrows his 1 buck with Zoe and forms his proposal
 
-    // Bob deposits his payouts
-    await bobBucksPurse.deposit(bobBucksPayout);
+  const daveSecondCoveredCallPayments = { StrikePrice: daveBucksPayment };
+  const daveSecondCoveredCallSeat = await zoe.offer(
+    daveExclOption,
+    daveProposalCoveredCall,
+    daveSecondCoveredCallPayments,
+  );
+  t.is(
+    await E(daveSecondCoveredCallSeat).getOfferResult(),
+    'The offer has been accepted. Once the contract has been completed, please check your payout',
+    `dave second offer accepted`,
+  );
 
-    // Dave deposits his payouts
-    await daveMoolaPurse.deposit(daveMoolaPayout);
-    await daveSimoleanPurse.deposit(daveSimoleanPayout);
-    await daveBucksPurse.deposit(daveBucksPayout);
+  const firstCoveredCallInvitation = await daveSecondCoveredCallSeat.getPayout(
+    'UnderlyingAsset',
+  );
+  const daveBucksPayout = await daveSecondCoveredCallSeat.getPayout(
+    'StrikePrice',
+  );
 
-    t.equals(aliceMoolaPurse.getCurrentAmount().value, 0);
-    t.equals(aliceSimoleanPurse.getCurrentAmount().value, 7);
+  // Dave exercises his option by making an offer to the covered
+  // call. First, he escrows with Zoe.
 
-    t.equals(bobMoolaPurse.getCurrentAmount().value, 0);
-    t.equals(bobSimoleanPurse.getCurrentAmount().value, 0);
-    t.equals(bobBucksPurse.getCurrentAmount().value, 1);
+  const daveFirstCoveredCallProposal = harden({
+    want: { UnderlyingAsset: moola(3) },
+    give: { StrikePrice: simoleans(7) },
+  });
+  const daveFirstCoveredCallPayments = harden({
+    StrikePrice: daveSimoleanPayment,
+  });
+  const daveFirstCoveredCallSeat = await zoe.offer(
+    firstCoveredCallInvitation,
+    daveFirstCoveredCallProposal,
+    daveFirstCoveredCallPayments,
+  );
 
-    t.equals(daveMoolaPurse.getCurrentAmount().value, 3);
-    t.equals(daveSimoleanPurse.getCurrentAmount().value, 0);
-    t.equals(daveBucksPurse.getCurrentAmount().value, 0);
-  } catch (e) {
-    t.isNot(e, e, 'unexpected exception');
-  }
+  t.is(
+    await daveFirstCoveredCallSeat.getOfferResult(),
+    'The offer has been accepted. Once the contract has been completed, please check your payout',
+    `dave first offer accepted`,
+  );
+
+  // Dave should get 3 moola, Bob should get 1 buck, and Alice
+  // get 7 simoleans
+
+  const daveMoolaPayout = await daveFirstCoveredCallSeat.getPayout(
+    'UnderlyingAsset',
+  );
+  const daveSimoleanPayout = await daveFirstCoveredCallSeat.getPayout(
+    'StrikePrice',
+  );
+
+  const aliceMoolaPayout = await aliceSeat.getPayout('UnderlyingAsset');
+  const aliceSimoleanPayout = await aliceSeat.getPayout('StrikePrice');
+
+  const bobInvitationPayout = await bobSeat.getPayout('UnderlyingAsset');
+  const bobBucksPayout = await bobSeat.getPayout('StrikePrice');
+
+  t.deepEqual(await moolaR.issuer.getAmountOf(daveMoolaPayout), moola(3));
+  t.deepEqual(
+    await simoleanR.issuer.getAmountOf(daveSimoleanPayout),
+    simoleans(0),
+  );
+
+  t.deepEqual(await moolaR.issuer.getAmountOf(aliceMoolaPayout), moola(0));
+  t.deepEqual(
+    await simoleanR.issuer.getAmountOf(aliceSimoleanPayout),
+    simoleans(7),
+  );
+
+  t.deepEqual(
+    await invitationIssuer.getAmountOf(bobInvitationPayout),
+    invitationAmountMath.getEmpty(),
+  );
+  t.deepEqual(await bucksR.issuer.getAmountOf(bobBucksPayout), bucks(1));
+
+  // Alice deposits her payouts
+  await aliceMoolaPurse.deposit(aliceMoolaPayout);
+  await aliceSimoleanPurse.deposit(aliceSimoleanPayout);
+
+  // Bob deposits his payouts
+  await bobBucksPurse.deposit(bobBucksPayout);
+
+  // Dave deposits his payouts
+  await daveMoolaPurse.deposit(daveMoolaPayout);
+  await daveSimoleanPurse.deposit(daveSimoleanPayout);
+  await daveBucksPurse.deposit(daveBucksPayout);
+
+  t.is(aliceMoolaPurse.getCurrentAmount().value, 0);
+  t.is(aliceSimoleanPurse.getCurrentAmount().value, 7);
+
+  t.is(bobMoolaPurse.getCurrentAmount().value, 0);
+  t.is(bobSimoleanPurse.getCurrentAmount().value, 0);
+  t.is(bobBucksPurse.getCurrentAmount().value, 1);
+
+  t.is(daveMoolaPurse.getCurrentAmount().value, 3);
+  t.is(daveSimoleanPurse.getCurrentAmount().value, 0);
+  t.is(daveBucksPurse.getCurrentAmount().value, 0);
 });
 
 // Alice uses a covered call to sell a cryptoCat to Bob for the
@@ -901,19 +879,19 @@ test('zoe - coveredCall non-fungible', async t => {
   const invitationIssuer = zoe.getInvitationIssuer();
   const bobExclOption = await invitationIssuer.claim(optionP);
   const optionValue = await E(zoe).getInvitationDetails(bobExclOption);
-  t.equal(optionValue.installation, coveredCallInstallation);
-  t.equal(optionValue.description, 'exerciseOption');
-  t.ok(
+  t.is(optionValue.installation, coveredCallInstallation);
+  t.is(optionValue.description, 'exerciseOption');
+  t.truthy(
     amountMaths
       .get('cc')
       .isEqual(optionValue.underlyingAsset, growlTigerAmount),
   );
-  t.ok(
+  t.truthy(
     amountMaths
       .get('rpg')
       .isEqual(optionValue.strikePrice, aGloriousShieldAmount),
   );
-  t.equal(optionValue.expirationDate, 1);
+  t.is(optionValue.expirationDate, 1);
   t.deepEqual(optionValue.timerAuthority, timer);
 
   const bobPayments = { StrikePrice: bobRpgPayment };
@@ -928,7 +906,7 @@ test('zoe - coveredCall non-fungible', async t => {
   // Bob exercises the option
   const bobSeat = await zoe.offer(bobExclOption, bobProposal, bobPayments);
 
-  t.equals(
+  t.is(
     await E(bobSeat).getOfferResult(),
     'The offer has been accepted. Once the contract has been completed, please check your payout',
   );
@@ -939,13 +917,13 @@ test('zoe - coveredCall non-fungible', async t => {
   const aliceRpgPayout = await E(aliceSeat).getPayout('StrikePrice');
 
   // Alice gets what Alice wanted
-  t.deepEquals(
+  t.deepEqual(
     await rpgIssuer.getAmountOf(aliceRpgPayout),
     aliceProposal.want.StrikePrice,
   );
 
   // Alice didn't get any of what Alice put in
-  t.deepEquals(
+  t.deepEqual(
     await ccIssuer.getAmountOf(aliceCcPayout),
     cryptoCats(harden([])),
   );
@@ -961,8 +939,8 @@ test('zoe - coveredCall non-fungible', async t => {
   // Assert that the correct payouts were received.
   // Alice had growlTiger and no RPG tokens.
   // Bob had an empty CryptoCat purse and the Glorious Shield.
-  t.deepEquals(aliceCcPurse.getCurrentAmount().value, []);
-  t.deepEquals(aliceRpgPurse.getCurrentAmount().value, aGloriousShield);
-  t.deepEquals(bobCcPurse.getCurrentAmount().value, ['GrowlTiger']);
-  t.deepEquals(bobRpgPurse.getCurrentAmount().value, []);
+  t.deepEqual(aliceCcPurse.getCurrentAmount().value, []);
+  t.deepEqual(aliceRpgPurse.getCurrentAmount().value, aGloriousShield);
+  t.deepEqual(bobCcPurse.getCurrentAmount().value, ['GrowlTiger']);
+  t.deepEqual(bobRpgPurse.getCurrentAmount().value, []);
 });

--- a/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
@@ -1,6 +1,6 @@
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from 'tape-promise/tape';
+import test from 'ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import bundleSource from '@agoric/bundle-source';
 import { E } from '@agoric/eventual-send';
@@ -61,10 +61,10 @@ test('zoe - escrowToVote', async t => {
     const voter = await E(seat).getOfferResult();
     const result = await E(voter).vote('YES');
 
-    t.equals(result, `Successfully voted 'YES'`, `voter1 votes YES`);
+    t.is(result, `Successfully voted 'YES'`, `voter1 votes YES`);
 
     seat.getPayout('Assets').then(async moolaPayment => {
-      t.deepEquals(
+      t.deepEqual(
         await moolaIssuer.getAmountOf(moolaPayment),
         moola(3),
         `voter1 gets everything she escrowed back`,
@@ -73,7 +73,7 @@ test('zoe - escrowToVote', async t => {
       console.log('EXPECTED ERROR ->>>');
       t.throws(
         () => voter.vote('NO'),
-        /the voter seat has exited/,
+        { message: /the voter seat has exited/ },
         `voter1 voting fails once offer is withdrawn or amounts are reallocated`,
       );
     });
@@ -94,21 +94,21 @@ test('zoe - escrowToVote', async t => {
 
     const voter = await E(seat).getOfferResult();
     console.log('EXPECTED ERROR ->>>');
-    t.rejects(
+    await t.throwsAsync(
       () => E(voter).vote('NOT A VALID ANSWER'),
-      /the answer "NOT A VALID ANSWER" was not 'YES' or 'NO'/,
+      { message: /the answer "NOT A VALID ANSWER" was not 'YES' or 'NO'/ },
       `A vote with an invalid answer throws`,
     );
 
     const result1 = await E(voter).vote('YES');
-    t.equals(result1, `Successfully voted 'YES'`, `voter2 votes YES`);
+    t.is(result1, `Successfully voted 'YES'`, `voter2 votes YES`);
 
     // Votes can be recast at any time
     const result2 = await E(voter).vote('NO');
-    t.equals(result2, `Successfully voted 'NO'`, `voter 2 recast vote for NO`);
+    t.is(result2, `Successfully voted 'NO'`, `voter 2 recast vote for NO`);
 
     seat.getPayout('Assets').then(async moolaPayment => {
-      t.deepEquals(
+      t.deepEqual(
         await moolaIssuer.getAmountOf(moolaPayment),
         moola(5),
         `voter2 gets everything she escrowed back`,
@@ -117,7 +117,7 @@ test('zoe - escrowToVote', async t => {
       console.log('EXPECTED ERROR ->>>');
       t.throws(
         () => voter.vote('NO'),
-        /the voter seat has exited/,
+        { message: /the voter seat has exited/ },
         `voter2 voting fails once offer is withdrawn or amounts are reallocated`,
       );
     });
@@ -139,7 +139,7 @@ test('zoe - escrowToVote', async t => {
 
     const voter = await E(seat).getOfferResult();
     const result = await E(voter).vote('NO');
-    t.equals(result, `Successfully voted 'NO'`, `voter3 votes NOT`);
+    t.is(result, `Successfully voted 'NO'`, `voter3 votes NOT`);
 
     // Voter3 exits before the election is closed. Voter3's vote will
     // not be counted.
@@ -147,7 +147,7 @@ test('zoe - escrowToVote', async t => {
 
     const moolaPayment = await seat.getPayout('Assets');
 
-    t.deepEquals(
+    t.deepEqual(
       await moolaIssuer.getAmountOf(moolaPayment),
       moola(1),
       `voter3 gets everything she escrowed back`,
@@ -156,7 +156,7 @@ test('zoe - escrowToVote', async t => {
     console.log('EXPECTED ERROR ->>>');
     t.throws(
       () => voter.vote('NO'),
-      /the voter seat has exited/,
+      { message: /the voter seat has exited/ },
       `voter3 voting fails once offer is withdrawn or amounts are reallocated`,
     );
   };
@@ -176,10 +176,10 @@ test('zoe - escrowToVote', async t => {
     const voter = await E(seat).getOfferResult();
     const result = await E(voter).vote('YES');
 
-    t.equals(result, `Successfully voted 'YES'`, `voter1 votes YES`);
+    t.is(result, `Successfully voted 'YES'`, `voter1 votes YES`);
 
     seat.getPayout('Assets').then(async moolaPayment => {
-      t.deepEquals(
+      t.deepEqual(
         await moolaIssuer.getAmountOf(moolaPayment),
         moola(4),
         `voter4 gets everything she escrowed back`,
@@ -191,7 +191,7 @@ test('zoe - escrowToVote', async t => {
 
   // Secretary closes election and tallies the votes.
   const electionResults = await E(secretary).closeElection();
-  t.deepEquals(electionResults, { YES: moola(7), NO: moola(5) });
+  t.deepEqual(electionResults, { YES: moola(7), NO: moola(5) });
 
   // Once the election is closed, the voters get their escrowed funds
   // back and can no longer vote. See the voter functions for the

--- a/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
@@ -73,7 +73,6 @@ test('zoe - escrowToVote', async t => {
       `voter1 gets everything she escrowed back`,
     );
 
-    console.log('EXPECTED ERROR ->>>');
     t.throws(
       () => voter.vote('NO'),
       { message: /the voter seat has exited/ },
@@ -96,7 +95,6 @@ test('zoe - escrowToVote', async t => {
     const seat = await E(zoe).offer(invitation, proposal, payments);
 
     const voter = await E(seat).getOfferResult();
-    console.log('EXPECTED ERROR ->>>');
     await t.throwsAsync(
       () => E(voter).vote('NOT A VALID ANSWER'),
       { message: /the answer "NOT A VALID ANSWER" was not 'YES' or 'NO'/ },
@@ -120,7 +118,6 @@ test('zoe - escrowToVote', async t => {
       `voter2 gets everything she escrowed back`,
     );
 
-    console.log('EXPECTED ERROR ->>>');
     t.throws(
       () => voter.vote('NO'),
       { message: /the voter seat has exited/ },
@@ -163,7 +160,6 @@ test('zoe - escrowToVote', async t => {
       `voter3 gets everything she escrowed back`,
     );
 
-    console.log('EXPECTED ERROR ->>>');
     t.throws(
       () => voter.vote('NO'),
       { message: /the voter seat has exited/ },

--- a/packages/zoe/test/unitTests/contracts/test-mintPayments.js
+++ b/packages/zoe/test/unitTests/contracts/test-mintPayments.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'tape-promise/tape';
+import test from 'ava';
 
 import bundleSource from '@agoric/bundle-source';
 
@@ -16,178 +16,168 @@ const mintPaymentsRoot = `${__dirname}/../../../src/contracts/mintPayments`;
 
 test('zoe - mint payments', async t => {
   t.plan(2);
-  try {
-    const zoe = makeZoe(fakeVatAdmin);
+  const zoe = makeZoe(fakeVatAdmin);
 
-    const makeAlice = () => {
-      return {
-        installCode: async () => {
-          // pack the contract
-          const bundle = await bundleSource(mintPaymentsRoot);
-          // install the contract
-          const installationP = E(zoe).install(bundle);
-          return installationP;
-        },
-        startInstance: async installation => {
-          const adminP = zoe.startInstance(installation);
-          return adminP;
-        },
-      };
+  const makeAlice = () => {
+    return {
+      installCode: async () => {
+        // pack the contract
+        const bundle = await bundleSource(mintPaymentsRoot);
+        // install the contract
+        const installationP = E(zoe).install(bundle);
+        return installationP;
+      },
+      startInstance: async installation => {
+        const adminP = zoe.startInstance(installation);
+        return adminP;
+      },
     };
+  };
 
-    const makeBob = installation => {
-      return {
-        offer: async untrustedInvitation => {
-          const invitationIssuer = E(zoe).getInvitationIssuer();
-          const invitation = E(invitationIssuer).claim(untrustedInvitation);
+  const makeBob = installation => {
+    return {
+      offer: async untrustedInvitation => {
+        const invitationIssuer = E(zoe).getInvitationIssuer();
+        const invitation = E(invitationIssuer).claim(untrustedInvitation);
 
-          const {
-            value: [invitationValue],
-          } = await E(invitationIssuer).getAmountOf(invitation);
+        const {
+          value: [invitationValue],
+        } = await E(invitationIssuer).getAmountOf(invitation);
 
-          t.equals(
-            invitationValue.installation,
-            installation,
-            'installation is mintPayment',
-          );
+        t.is(
+          invitationValue.installation,
+          installation,
+          'installation is mintPayment',
+        );
 
-          const { instance } = invitationValue;
+        const { instance } = invitationValue;
 
-          const seat = await E(zoe).offer(invitation);
+        const seat = await E(zoe).offer(invitation);
 
-          const paymentP = E(seat).getPayout('Token');
+        const paymentP = E(seat).getPayout('Token');
 
-          // Let's get the tokenIssuer from the contract so we can evaluate
-          // what we get as our payout
-          const publicFacet = await E(zoe).getPublicFacet(instance);
-          const tokenIssuer = await E(publicFacet).getTokenIssuer();
-          const amountMath = await makeLocalAmountMath(tokenIssuer);
+        // Let's get the tokenIssuer from the contract so we can evaluate
+        // what we get as our payout
+        const publicFacet = await E(zoe).getPublicFacet(instance);
+        const tokenIssuer = await E(publicFacet).getTokenIssuer();
+        const amountMath = await makeLocalAmountMath(tokenIssuer);
 
-          const tokens1000 = await E(amountMath).make(1000);
-          const tokenPayoutAmount = await E(tokenIssuer).getAmountOf(paymentP);
+        const tokens1000 = await E(amountMath).make(1000);
+        const tokenPayoutAmount = await E(tokenIssuer).getAmountOf(paymentP);
 
-          // Bob got 1000 tokens
-          t.deepEquals(tokenPayoutAmount, tokens1000);
-        },
-      };
+        // Bob got 1000 tokens
+        t.deepEqual(tokenPayoutAmount, tokens1000);
+      },
     };
+  };
 
-    // Setup Alice
-    const alice = await makeAlice();
-    const installation = await alice.installCode();
-    const { creatorFacet } = await E(alice).startInstance(installation);
-    const invitation = E(creatorFacet).makeInvitation(1000);
+  // Setup Alice
+  const alice = await makeAlice();
+  const installation = await alice.installCode();
+  const { creatorFacet } = await E(alice).startInstance(installation);
+  const invitation = E(creatorFacet).makeInvitation(1000);
 
-    // Setup Bob
-    const bob = makeBob(installation);
-    await bob.offer(invitation);
-  } catch (e) {
-    t.assert(false, e);
-    console.log(e);
-  }
+  // Setup Bob
+  const bob = makeBob(installation);
+  await bob.offer(invitation);
 });
 
 test('zoe - mint payments with unrelated give and want', async t => {
   t.plan(3);
-  try {
-    const zoe = makeZoe(fakeVatAdmin);
-    const moolaKit = makeIssuerKit('moola');
-    const simoleanKit = makeIssuerKit('simolean');
+  const zoe = makeZoe(fakeVatAdmin);
+  const moolaKit = makeIssuerKit('moola');
+  const simoleanKit = makeIssuerKit('simolean');
 
-    const makeAlice = () => {
-      return {
-        installCode: async () => {
-          // pack the contract
-          const bundle = await bundleSource(mintPaymentsRoot);
-          // install the contract
-          const installationP = E(zoe).install(bundle);
-          return installationP;
-        },
-        startInstance: async installation => {
-          const issuerKeywordRecord = harden({
-            Asset: moolaKit.issuer,
-            Price: simoleanKit.issuer,
-          });
-          const adminP = await E(zoe).startInstance(
-            installation,
-            issuerKeywordRecord,
-          );
-          return adminP;
-        },
-      };
+  const makeAlice = () => {
+    return {
+      installCode: async () => {
+        // pack the contract
+        const bundle = await bundleSource(mintPaymentsRoot);
+        // install the contract
+        const installationP = E(zoe).install(bundle);
+        return installationP;
+      },
+      startInstance: async installation => {
+        const issuerKeywordRecord = harden({
+          Asset: moolaKit.issuer,
+          Price: simoleanKit.issuer,
+        });
+        const adminP = await E(zoe).startInstance(
+          installation,
+          issuerKeywordRecord,
+        );
+        return adminP;
+      },
     };
+  };
 
-    const makeBob = (installation, moolaPayment) => {
-      return {
-        offer: async untrustedInvitation => {
-          const invitationIssuer = E(zoe).getInvitationIssuer();
-          const invitation = E(invitationIssuer).claim(untrustedInvitation);
+  const makeBob = (installation, moolaPayment) => {
+    return {
+      offer: async untrustedInvitation => {
+        const invitationIssuer = E(zoe).getInvitationIssuer();
+        const invitation = E(invitationIssuer).claim(untrustedInvitation);
 
-          const {
-            value: [invitationValue],
-          } = await E(invitationIssuer).getAmountOf(invitation);
+        const {
+          value: [invitationValue],
+        } = await E(invitationIssuer).getAmountOf(invitation);
 
-          t.equals(
-            invitationValue.installation,
-            installation,
-            'installation is mintPayment',
-          );
+        t.is(
+          invitationValue.installation,
+          installation,
+          'installation is mintPayment',
+        );
 
-          const { instance } = invitationValue;
+        const { instance } = invitationValue;
 
-          const proposal = harden({
-            give: { Asset: moolaKit.amountMath.make(10) },
-            want: { Price: simoleanKit.amountMath.make(100) },
-          });
-          const paymentKeywordRecord = harden({
-            Asset: moolaPayment,
-          });
-          const seat = await E(zoe).offer(
-            invitation,
-            proposal,
-            paymentKeywordRecord,
-          );
+        const proposal = harden({
+          give: { Asset: moolaKit.amountMath.make(10) },
+          want: { Price: simoleanKit.amountMath.make(100) },
+        });
+        const paymentKeywordRecord = harden({
+          Asset: moolaPayment,
+        });
+        const seat = await E(zoe).offer(
+          invitation,
+          proposal,
+          paymentKeywordRecord,
+        );
 
-          const tokenPaymentP = E(seat).getPayout('Token');
-          const moolaRefundP = E(seat).getPayout('Asset');
+        const tokenPaymentP = E(seat).getPayout('Token');
+        const moolaRefundP = E(seat).getPayout('Asset');
 
-          // Let's get the tokenIssuer from the contract so we can evaluate
-          // what we get as our payout
-          const publicFacet = await E(zoe).getPublicFacet(instance);
-          const tokenIssuer = await E(publicFacet).getTokenIssuer();
-          const amountMath = await makeLocalAmountMath(tokenIssuer);
+        // Let's get the tokenIssuer from the contract so we can evaluate
+        // what we get as our payout
+        const publicFacet = await E(zoe).getPublicFacet(instance);
+        const tokenIssuer = await E(publicFacet).getTokenIssuer();
+        const amountMath = await makeLocalAmountMath(tokenIssuer);
 
-          const tokens1000 = await E(amountMath).make(1000);
-          const tokenPayoutAmount = await E(tokenIssuer).getAmountOf(
-            tokenPaymentP,
-          );
+        const tokens1000 = await E(amountMath).make(1000);
+        const tokenPayoutAmount = await E(tokenIssuer).getAmountOf(
+          tokenPaymentP,
+        );
 
-          // Bob got 1000 tokens
-          t.deepEquals(tokenPayoutAmount, tokens1000);
+        // Bob got 1000 tokens
+        t.deepEqual(tokenPayoutAmount, tokens1000);
 
-          // Got refunded all the moola given
-          t.deepEquals(
-            await E(moolaKit.issuer).getAmountOf(moolaRefundP),
-            moolaKit.amountMath.make(10),
-          );
-        },
-      };
+        // Got refunded all the moola given
+        t.deepEqual(
+          await E(moolaKit.issuer).getAmountOf(moolaRefundP),
+          moolaKit.amountMath.make(10),
+        );
+      },
     };
+  };
 
-    // Setup Alice
-    const alice = await makeAlice();
-    const installation = await alice.installCode();
-    const { creatorFacet } = await E(alice).startInstance(installation);
-    const invitation = E(creatorFacet).makeInvitation(1000);
+  // Setup Alice
+  const alice = await makeAlice();
+  const installation = await alice.installCode();
+  const { creatorFacet } = await E(alice).startInstance(installation);
+  const invitation = E(creatorFacet).makeInvitation(1000);
 
-    // Setup Bob
-    const bob = makeBob(
-      installation,
-      moolaKit.mint.mintPayment(moolaKit.amountMath.make(10)),
-    );
-    await bob.offer(invitation);
-  } catch (e) {
-    t.assert(false, e);
-    console.log(e);
-  }
+  // Setup Bob
+  const bob = makeBob(
+    installation,
+    moolaKit.mint.mintPayment(moolaKit.amountMath.make(10)),
+  );
+  await bob.offer(invitation);
 });

--- a/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
@@ -1,6 +1,6 @@
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from 'tape-promise/tape';
+import test from 'ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import bundleSource from '@agoric/bundle-source';
 
@@ -16,449 +16,441 @@ const multipoolAutoswapRoot = `${__dirname}/../../../src/contracts/multipoolAuto
 
 test('multipoolAutoSwap with valid offers', async t => {
   t.plan(33);
-  try {
-    const { moolaR, simoleanR, moola, simoleans } = setup();
-    const zoe = makeZoe(fakeVatAdmin);
-    const invitationIssuer = zoe.getInvitationIssuer();
+  const { moolaR, simoleanR, moola, simoleans } = setup();
+  const zoe = makeZoe(fakeVatAdmin);
+  const invitationIssuer = zoe.getInvitationIssuer();
 
-    // Set up central token
-    const centralR = makeIssuerKit('central');
-    const centralTokens = centralR.amountMath.make;
+  // Set up central token
+  const centralR = makeIssuerKit('central');
+  const centralTokens = centralR.amountMath.make;
 
-    // Setup Alice
-    const aliceMoolaPayment = moolaR.mint.mintPayment(moola(100));
-    // Let's assume that central tokens are worth 2x as much as moola
-    const aliceCentralPayment = centralR.mint.mintPayment(centralTokens(50));
-    const aliceSimoleanPayment = simoleanR.mint.mintPayment(simoleans(398));
+  // Setup Alice
+  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(100));
+  // Let's assume that central tokens are worth 2x as much as moola
+  const aliceCentralPayment = centralR.mint.mintPayment(centralTokens(50));
+  const aliceSimoleanPayment = simoleanR.mint.mintPayment(simoleans(398));
 
-    // Setup Bob
-    const bobMoolaPayment = moolaR.mint.mintPayment(moola(17));
-    const bobSimoleanPayment = simoleanR.mint.mintPayment(simoleans(74));
+  // Setup Bob
+  const bobMoolaPayment = moolaR.mint.mintPayment(moola(17));
+  const bobSimoleanPayment = simoleanR.mint.mintPayment(simoleans(74));
 
-    // Alice creates an autoswap instance
+  // Alice creates an autoswap instance
 
-    // Pack the contract.
-    const bundle = await bundleSource(multipoolAutoswapRoot);
+  // Pack the contract.
+  const bundle = await bundleSource(multipoolAutoswapRoot);
 
-    const installation = await zoe.install(bundle);
-    const { instance, publicFacet } = await zoe.startInstance(
-      installation,
-      harden({ Central: centralR.issuer }),
-    );
-    const aliceAddLiquidityInvitation = E(
-      publicFacet,
-    ).makeAddLiquidityInvitation();
+  const installation = await zoe.install(bundle);
+  const { instance, publicFacet } = await zoe.startInstance(
+    installation,
+    harden({ Central: centralR.issuer }),
+  );
+  const aliceAddLiquidityInvitation = E(
+    publicFacet,
+  ).makeAddLiquidityInvitation();
 
-    const invitationAmountMath = await makeLocalAmountMath(invitationIssuer);
-    const aliceInvitationAmount = await invitationIssuer.getAmountOf(
-      aliceAddLiquidityInvitation,
-    );
-    t.deepEquals(
-      aliceInvitationAmount,
-      invitationAmountMath.make(
-        harden([
-          {
-            description: 'multipool autoswap add liquidity',
-            instance,
-            installation,
-            handle: aliceInvitationAmount.value[0].handle,
-          },
-        ]),
-      ),
-      `invitation value is as expected`,
-    );
+  const invitationAmountMath = await makeLocalAmountMath(invitationIssuer);
+  const aliceInvitationAmount = await invitationIssuer.getAmountOf(
+    aliceAddLiquidityInvitation,
+  );
+  t.deepEqual(
+    aliceInvitationAmount,
+    invitationAmountMath.make(
+      harden([
+        {
+          description: 'multipool autoswap add liquidity',
+          instance,
+          installation,
+          handle: aliceInvitationAmount.value[0].handle,
+        },
+      ]),
+    ),
+    `invitation value is as expected`,
+  );
 
-    const moolaLiquidityIssuer = await E(publicFacet).addPool(
-      moolaR.issuer,
-      'Moola',
-    );
-    const moolaLiquidityAmountMath = await makeLocalAmountMath(
-      moolaLiquidityIssuer,
-    );
-    const moolaLiquidity = moolaLiquidityAmountMath.make;
+  const moolaLiquidityIssuer = await E(publicFacet).addPool(
+    moolaR.issuer,
+    'Moola',
+  );
+  const moolaLiquidityAmountMath = await makeLocalAmountMath(
+    moolaLiquidityIssuer,
+  );
+  const moolaLiquidity = moolaLiquidityAmountMath.make;
 
-    const simoleanLiquidityIssuer = await E(publicFacet).addPool(
-      simoleanR.issuer,
-      'Simoleans',
-    );
-    const simoleanLiquidityAmountMath = await makeLocalAmountMath(
-      simoleanLiquidityIssuer,
-    );
-    const simoleanLiquidity = simoleanLiquidityAmountMath.make;
+  const simoleanLiquidityIssuer = await E(publicFacet).addPool(
+    simoleanR.issuer,
+    'Simoleans',
+  );
+  const simoleanLiquidityAmountMath = await makeLocalAmountMath(
+    simoleanLiquidityIssuer,
+  );
+  const simoleanLiquidity = simoleanLiquidityAmountMath.make;
 
-    const issuerKeywordRecord = zoe.getIssuers(instance);
-    t.deepEquals(
-      issuerKeywordRecord,
-      harden({
-        Central: centralR.issuer,
-        Moola: moolaR.issuer,
-        MoolaLiquidity: moolaLiquidityIssuer,
-        Simoleans: simoleanR.issuer,
-        SimoleansLiquidity: simoleanLiquidityIssuer,
-      }),
-      `There are keywords for central token and two additional tokens and liquidity`,
-    );
-    t.deepEquals(
-      await E(publicFacet).getPoolAllocation(moolaR.brand),
-      {},
-      `The poolAllocation object values for moola should be empty`,
-    );
-    t.deepEquals(
-      await E(publicFacet).getPoolAllocation(simoleanR.brand),
-      {},
-      `The poolAllocation object values for simoleans should be empty`,
-    );
+  const issuerKeywordRecord = zoe.getIssuers(instance);
+  t.deepEqual(
+    issuerKeywordRecord,
+    harden({
+      Central: centralR.issuer,
+      Moola: moolaR.issuer,
+      MoolaLiquidity: moolaLiquidityIssuer,
+      Simoleans: simoleanR.issuer,
+      SimoleansLiquidity: simoleanLiquidityIssuer,
+    }),
+    `There are keywords for central token and two additional tokens and liquidity`,
+  );
+  t.deepEqual(
+    await E(publicFacet).getPoolAllocation(moolaR.brand),
+    {},
+    `The poolAllocation object values for moola should be empty`,
+  );
+  t.deepEqual(
+    await E(publicFacet).getPoolAllocation(simoleanR.brand),
+    {},
+    `The poolAllocation object values for simoleans should be empty`,
+  );
 
-    // Alice adds liquidity
-    // 10 moola = 5 central tokens at the time of the liquidity adding
-    // aka 2 moola = 1 central token
-    const aliceProposal = harden({
-      want: { Liquidity: moolaLiquidity(50) },
-      give: { Secondary: moola(100), Central: centralTokens(50) },
-    });
-    const alicePayments = {
-      Secondary: aliceMoolaPayment,
-      Central: aliceCentralPayment,
-    };
+  // Alice adds liquidity
+  // 10 moola = 5 central tokens at the time of the liquidity adding
+  // aka 2 moola = 1 central token
+  const aliceProposal = harden({
+    want: { Liquidity: moolaLiquidity(50) },
+    give: { Secondary: moola(100), Central: centralTokens(50) },
+  });
+  const alicePayments = {
+    Secondary: aliceMoolaPayment,
+    Central: aliceCentralPayment,
+  };
 
-    const addLiquiditySeat = await zoe.offer(
-      aliceAddLiquidityInvitation,
-      aliceProposal,
-      alicePayments,
-    );
+  const addLiquiditySeat = await zoe.offer(
+    aliceAddLiquidityInvitation,
+    aliceProposal,
+    alicePayments,
+  );
 
-    t.equals(
-      await E(addLiquiditySeat).getOfferResult(),
-      'Added liquidity.',
-      `Alice added moola and central liquidity`,
-    );
+  t.is(
+    await E(addLiquiditySeat).getOfferResult(),
+    'Added liquidity.',
+    `Alice added moola and central liquidity`,
+  );
 
-    const liquidityPayout = await addLiquiditySeat.getPayout('Liquidity');
+  const liquidityPayout = await addLiquiditySeat.getPayout('Liquidity');
 
-    t.deepEquals(
-      await moolaLiquidityIssuer.getAmountOf(liquidityPayout),
-      moolaLiquidity(50),
-    );
-    t.deepEquals(
-      await E(publicFacet).getPoolAllocation(moolaR.brand),
-      harden({
-        Secondary: moola(100),
-        Central: centralTokens(50),
-        Liquidity: moolaLiquidity(0),
-      }),
-      `The poolAmounts record should contain the new liquidity`,
-    );
+  t.deepEqual(
+    await moolaLiquidityIssuer.getAmountOf(liquidityPayout),
+    moolaLiquidity(50),
+  );
+  t.deepEqual(
+    await E(publicFacet).getPoolAllocation(moolaR.brand),
+    harden({
+      Secondary: moola(100),
+      Central: centralTokens(50),
+      Liquidity: moolaLiquidity(0),
+    }),
+    `The poolAmounts record should contain the new liquidity`,
+  );
 
-    // Bob creates a swap invitation for himself
-    const bobSwapInvitation1 = await E(publicFacet).makeSwapInvitation();
+  // Bob creates a swap invitation for himself
+  const bobSwapInvitation1 = await E(publicFacet).makeSwapInvitation();
 
-    const {
-      value: [bobInvitationValue],
-    } = await invitationIssuer.getAmountOf(bobSwapInvitation1);
-    const bobPublicFacet = zoe.getPublicFacet(bobInvitationValue.instance);
-    t.equals(
-      bobInvitationValue.installation,
-      installation,
-      `installation is as expected`,
-    );
+  const {
+    value: [bobInvitationValue],
+  } = await invitationIssuer.getAmountOf(bobSwapInvitation1);
+  const bobPublicFacet = zoe.getPublicFacet(bobInvitationValue.instance);
+  t.is(
+    bobInvitationValue.installation,
+    installation,
+    `installation is as expected`,
+  );
 
-    // Bob looks up the price of 17 moola in central tokens
-    const priceInCentrals = await E(bobPublicFacet).getCurrentPrice(
-      moola(17),
-      centralR.brand,
-    );
-    t.deepEquals(
-      priceInCentrals,
-      centralTokens(7),
-      `price in central tokens of 17 moola is as expected`,
-    );
+  // Bob looks up the price of 17 moola in central tokens
+  const priceInCentrals = await E(bobPublicFacet).getCurrentPrice(
+    moola(17),
+    centralR.brand,
+  );
+  t.deepEqual(
+    priceInCentrals,
+    centralTokens(7),
+    `price in central tokens of 17 moola is as expected`,
+  );
 
-    const bobMoolaForCentralProposal = harden({
-      want: { Out: centralTokens(7) },
-      give: { In: moola(17) },
-    });
-    const bobMoolaForCentralPayments = harden({ In: bobMoolaPayment });
+  const bobMoolaForCentralProposal = harden({
+    want: { Out: centralTokens(7) },
+    give: { In: moola(17) },
+  });
+  const bobMoolaForCentralPayments = harden({ In: bobMoolaPayment });
 
-    // Bob swaps
-    const bobSeat = await zoe.offer(
-      bobSwapInvitation1,
-      bobMoolaForCentralProposal,
-      bobMoolaForCentralPayments,
-    );
+  // Bob swaps
+  const bobSeat = await zoe.offer(
+    bobSwapInvitation1,
+    bobMoolaForCentralProposal,
+    bobMoolaForCentralPayments,
+  );
 
-    t.equal(await E(bobSeat).getOfferResult(), 'Swap successfully completed.');
+  t.is(await E(bobSeat).getOfferResult(), 'Swap successfully completed.');
 
-    const bobMoolaPayout1 = await bobSeat.getPayout('In');
-    const bobCentralPayout1 = await bobSeat.getPayout('Out');
+  const bobMoolaPayout1 = await bobSeat.getPayout('In');
+  const bobCentralPayout1 = await bobSeat.getPayout('Out');
 
-    t.deepEqual(
-      await moolaR.issuer.getAmountOf(bobMoolaPayout1),
-      moola(0),
-      `bob gets no moola back`,
-    );
-    t.deepEqual(
-      await centralR.issuer.getAmountOf(bobCentralPayout1),
-      centralTokens(7),
-      `bob gets the same price as when he called the getCurrentPrice method`,
-    );
-    t.deepEquals(
-      await E(bobPublicFacet).getPoolAllocation(moolaR.brand),
-      {
-        Secondary: moola(117),
-        Central: centralTokens(43),
-        Liquidity: moolaLiquidity(0),
-      },
-      `pool allocation added the moola and subtracted the central tokens`,
-    );
+  t.deepEqual(
+    await moolaR.issuer.getAmountOf(bobMoolaPayout1),
+    moola(0),
+    `bob gets no moola back`,
+  );
+  t.deepEqual(
+    await centralR.issuer.getAmountOf(bobCentralPayout1),
+    centralTokens(7),
+    `bob gets the same price as when he called the getCurrentPrice method`,
+  );
+  t.deepEqual(
+    await E(bobPublicFacet).getPoolAllocation(moolaR.brand),
+    {
+      Secondary: moola(117),
+      Central: centralTokens(43),
+      Liquidity: moolaLiquidity(0),
+    },
+    `pool allocation added the moola and subtracted the central tokens`,
+  );
 
-    const bobCentralPurse = await E(centralR.issuer).makeEmptyPurse();
-    await E(bobCentralPurse).deposit(bobCentralPayout1);
+  const bobCentralPurse = await E(centralR.issuer).makeEmptyPurse();
+  await E(bobCentralPurse).deposit(bobCentralPayout1);
 
-    // Bob looks up the price of 7 central tokens in moola
-    const moolaAmounts = await E(bobPublicFacet).getCurrentPrice(
-      centralTokens(7),
-      moolaR.brand,
-    );
-    t.deepEquals(
-      moolaAmounts,
-      moola(16),
-      `the fee was one moola over the two trades`,
-    );
+  // Bob looks up the price of 7 central tokens in moola
+  const moolaAmounts = await E(bobPublicFacet).getCurrentPrice(
+    centralTokens(7),
+    moolaR.brand,
+  );
+  t.deepEqual(
+    moolaAmounts,
+    moola(16),
+    `the fee was one moola over the two trades`,
+  );
 
-    // Bob makes another offer and swaps
-    const bobSwapInvitation2 = await E(bobPublicFacet).makeSwapInvitation();
-    const bobCentralForMoolaProposal = harden({
-      want: { Out: moola(16) },
-      give: { In: centralTokens(7) },
-    });
-    const centralForMoolaPayments = harden({
-      In: await E(bobCentralPurse).withdraw(centralTokens(7)),
-    });
+  // Bob makes another offer and swaps
+  const bobSwapInvitation2 = await E(bobPublicFacet).makeSwapInvitation();
+  const bobCentralForMoolaProposal = harden({
+    want: { Out: moola(16) },
+    give: { In: centralTokens(7) },
+  });
+  const centralForMoolaPayments = harden({
+    In: await E(bobCentralPurse).withdraw(centralTokens(7)),
+  });
 
-    const bobSeat2 = await zoe.offer(
-      bobSwapInvitation2,
-      bobCentralForMoolaProposal,
-      centralForMoolaPayments,
-    );
+  const bobSeat2 = await zoe.offer(
+    bobSwapInvitation2,
+    bobCentralForMoolaProposal,
+    centralForMoolaPayments,
+  );
 
-    t.equal(
-      await bobSeat2.getOfferResult(),
-      'Swap successfully completed.',
-      `second swap successful`,
-    );
+  t.is(
+    await bobSeat2.getOfferResult(),
+    'Swap successfully completed.',
+    `second swap successful`,
+  );
 
-    const bobMoolaPayout2 = await bobSeat2.getPayout('Out');
-    const bobCentralPayout2 = await bobSeat2.getPayout('In');
+  const bobMoolaPayout2 = await bobSeat2.getPayout('Out');
+  const bobCentralPayout2 = await bobSeat2.getPayout('In');
 
-    t.deepEqual(
-      await moolaR.issuer.getAmountOf(bobMoolaPayout2),
-      moola(16),
-      `bob gets 16 moola back`,
-    );
-    t.deepEqual(
-      await centralR.issuer.getAmountOf(bobCentralPayout2),
-      centralTokens(0),
-      `bob gets no central tokens back`,
-    );
-    t.deepEqual(
-      await E(bobPublicFacet).getPoolAllocation(moolaR.brand),
-      {
-        Secondary: moola(101),
-        Central: centralTokens(50),
-        Liquidity: moolaLiquidity(0),
-      },
-      `fee added to liquidity pool`,
-    );
+  t.deepEqual(
+    await moolaR.issuer.getAmountOf(bobMoolaPayout2),
+    moola(16),
+    `bob gets 16 moola back`,
+  );
+  t.deepEqual(
+    await centralR.issuer.getAmountOf(bobCentralPayout2),
+    centralTokens(0),
+    `bob gets no central tokens back`,
+  );
+  t.deepEqual(
+    await E(bobPublicFacet).getPoolAllocation(moolaR.brand),
+    {
+      Secondary: moola(101),
+      Central: centralTokens(50),
+      Liquidity: moolaLiquidity(0),
+    },
+    `fee added to liquidity pool`,
+  );
 
-    // Alice adds simoleans and central tokens to the simolean
-    // liquidity pool. 398 simoleans = 43 central tokens at the time of
-    // the liquidity adding
-    //
-    const aliceSimCentralLiquidityInvitation = await E(
-      publicFacet,
-    ).makeAddLiquidityInvitation();
-    const aliceSimCentralProposal = harden({
-      want: { Liquidity: simoleanLiquidity(43) },
-      give: { Secondary: simoleans(398), Central: centralTokens(43) },
-    });
-    const aliceCentralPayment2 = await centralR.mint.mintPayment(
-      centralTokens(43),
-    );
-    const aliceSimCentralPayments = {
-      Secondary: aliceSimoleanPayment,
-      Central: aliceCentralPayment2,
-    };
+  // Alice adds simoleans and central tokens to the simolean
+  // liquidity pool. 398 simoleans = 43 central tokens at the time of
+  // the liquidity adding
+  //
+  const aliceSimCentralLiquidityInvitation = await E(
+    publicFacet,
+  ).makeAddLiquidityInvitation();
+  const aliceSimCentralProposal = harden({
+    want: { Liquidity: simoleanLiquidity(43) },
+    give: { Secondary: simoleans(398), Central: centralTokens(43) },
+  });
+  const aliceCentralPayment2 = await centralR.mint.mintPayment(
+    centralTokens(43),
+  );
+  const aliceSimCentralPayments = {
+    Secondary: aliceSimoleanPayment,
+    Central: aliceCentralPayment2,
+  };
 
-    const aliceSeat2 = await zoe.offer(
-      aliceSimCentralLiquidityInvitation,
-      aliceSimCentralProposal,
-      aliceSimCentralPayments,
-    );
+  const aliceSeat2 = await zoe.offer(
+    aliceSimCentralLiquidityInvitation,
+    aliceSimCentralProposal,
+    aliceSimCentralPayments,
+  );
 
-    t.equals(
-      await aliceSeat2.getOfferResult(),
-      'Added liquidity.',
-      `Alice added simoleans and central liquidity`,
-    );
+  t.is(
+    await aliceSeat2.getOfferResult(),
+    'Added liquidity.',
+    `Alice added simoleans and central liquidity`,
+  );
 
-    const simoleanLiquidityPayout = await aliceSeat2.getPayout('Liquidity');
+  const simoleanLiquidityPayout = await aliceSeat2.getPayout('Liquidity');
 
-    t.deepEquals(
-      await simoleanLiquidityIssuer.getAmountOf(simoleanLiquidityPayout),
-      simoleanLiquidity(43),
-      `simoleanLiquidity minted was equal to the amount of central tokens added to pool`,
-    );
-    t.deepEquals(
-      await E(publicFacet).getPoolAllocation(simoleanR.brand),
-      harden({
-        Secondary: simoleans(398),
-        Central: centralTokens(43),
-        Liquidity: simoleanLiquidity(0),
-      }),
-      `The poolAmounts record should contain the new liquidity`,
-    );
+  t.deepEqual(
+    await simoleanLiquidityIssuer.getAmountOf(simoleanLiquidityPayout),
+    simoleanLiquidity(43),
+    `simoleanLiquidity minted was equal to the amount of central tokens added to pool`,
+  );
+  t.deepEqual(
+    await E(publicFacet).getPoolAllocation(simoleanR.brand),
+    harden({
+      Secondary: simoleans(398),
+      Central: centralTokens(43),
+      Liquidity: simoleanLiquidity(0),
+    }),
+    `The poolAmounts record should contain the new liquidity`,
+  );
 
-    // Bob tries to swap simoleans for moola. This will go through the
-    // central token, meaning that two swaps will happen synchronously
-    // under the hood.
+  // Bob tries to swap simoleans for moola. This will go through the
+  // central token, meaning that two swaps will happen synchronously
+  // under the hood.
 
-    // Bob checks the price. Let's say he gives 74 simoleans, and he
-    // wants to know how many moola he would get back.
+  // Bob checks the price. Let's say he gives 74 simoleans, and he
+  // wants to know how many moola he would get back.
 
-    const priceInMoola = await E(bobPublicFacet).getCurrentPrice(
-      simoleans(74),
-      moolaR.brand,
-    );
-    t.deepEquals(
-      priceInMoola,
-      moola(10),
-      `price is as expected for secondary token to secondary token`,
-    );
+  const priceInMoola = await E(bobPublicFacet).getCurrentPrice(
+    simoleans(74),
+    moolaR.brand,
+  );
+  t.deepEqual(
+    priceInMoola,
+    moola(10),
+    `price is as expected for secondary token to secondary token`,
+  );
 
-    // This is the same as making two synchronous exchanges
-    const priceInCentral = await E(bobPublicFacet).getCurrentPrice(
-      simoleans(74),
-      centralR.brand,
-    );
-    t.deepEquals(
-      priceInCentral,
-      centralTokens(6),
-      `price is as expected for secondary token to central`,
-    );
+  // This is the same as making two synchronous exchanges
+  const priceInCentral = await E(bobPublicFacet).getCurrentPrice(
+    simoleans(74),
+    centralR.brand,
+  );
+  t.deepEqual(
+    priceInCentral,
+    centralTokens(6),
+    `price is as expected for secondary token to central`,
+  );
 
-    const centralPriceInMoola = await E(bobPublicFacet).getCurrentPrice(
-      centralTokens(6),
-      moolaR.brand,
-    );
-    t.deepEquals(
-      centralPriceInMoola,
-      moola(10),
-      `price is as expected for secondary token to secondary token`,
-    );
+  const centralPriceInMoola = await E(bobPublicFacet).getCurrentPrice(
+    centralTokens(6),
+    moolaR.brand,
+  );
+  t.deepEqual(
+    centralPriceInMoola,
+    moola(10),
+    `price is as expected for secondary token to secondary token`,
+  );
 
-    const bobThirdInvitation = await E(bobPublicFacet).makeSwapInvitation();
-    const bobSimsForMoolaProposal = harden({
-      want: { Out: moola(10) },
-      give: { In: simoleans(74) },
-    });
-    const simsForMoolaPayments = harden({
-      In: bobSimoleanPayment,
-    });
+  const bobThirdInvitation = await E(bobPublicFacet).makeSwapInvitation();
+  const bobSimsForMoolaProposal = harden({
+    want: { Out: moola(10) },
+    give: { In: simoleans(74) },
+  });
+  const simsForMoolaPayments = harden({
+    In: bobSimoleanPayment,
+  });
 
-    const bobSeat3 = await zoe.offer(
-      bobThirdInvitation,
-      bobSimsForMoolaProposal,
-      simsForMoolaPayments,
-    );
+  const bobSeat3 = await zoe.offer(
+    bobThirdInvitation,
+    bobSimsForMoolaProposal,
+    simsForMoolaPayments,
+  );
 
-    const bobSimsPayout3 = await bobSeat3.getPayout('In');
-    const bobMoolaPayout3 = await bobSeat3.getPayout('Out');
+  const bobSimsPayout3 = await bobSeat3.getPayout('In');
+  const bobMoolaPayout3 = await bobSeat3.getPayout('Out');
 
-    t.deepEqual(
-      await moolaR.issuer.getAmountOf(bobMoolaPayout3),
-      moola(10),
-      `bob gets 10 moola`,
-    );
-    t.deepEqual(
-      await simoleanR.issuer.getAmountOf(bobSimsPayout3),
-      simoleans(0),
-      `bob gets no simoleans back`,
-    );
+  t.deepEqual(
+    await moolaR.issuer.getAmountOf(bobMoolaPayout3),
+    moola(10),
+    `bob gets 10 moola`,
+  );
+  t.deepEqual(
+    await simoleanR.issuer.getAmountOf(bobSimsPayout3),
+    simoleans(0),
+    `bob gets no simoleans back`,
+  );
 
-    t.deepEqual(
-      await E(bobPublicFacet).getPoolAllocation(simoleanR.brand),
-      harden({
-        // 398 + 74
-        Secondary: simoleans(472),
-        // 43 - 6
-        Central: centralTokens(37),
-        Liquidity: simoleanLiquidity(0),
-      }),
-      `the simolean liquidity pool gains simoleans and loses central tokens`,
-    );
-    t.deepEqual(
-      await E(bobPublicFacet).getPoolAllocation(moolaR.brand),
-      harden({
-        // 101 - 10
-        Secondary: moola(91),
-        // 50 + 6
-        Central: centralTokens(56),
-        Liquidity: moolaLiquidity(0),
-      }),
-      `the moola liquidity pool loses moola and gains central tokens`,
-    );
+  t.deepEqual(
+    await E(bobPublicFacet).getPoolAllocation(simoleanR.brand),
+    harden({
+      // 398 + 74
+      Secondary: simoleans(472),
+      // 43 - 6
+      Central: centralTokens(37),
+      Liquidity: simoleanLiquidity(0),
+    }),
+    `the simolean liquidity pool gains simoleans and loses central tokens`,
+  );
+  t.deepEqual(
+    await E(bobPublicFacet).getPoolAllocation(moolaR.brand),
+    harden({
+      // 101 - 10
+      Secondary: moola(91),
+      // 50 + 6
+      Central: centralTokens(56),
+      Liquidity: moolaLiquidity(0),
+    }),
+    `the moola liquidity pool loses moola and gains central tokens`,
+  );
 
-    // Alice removes her liquidity
-    // She's not picky...
-    const aliceRemoveLiquidityInvitation = await E(
-      publicFacet,
-    ).makeRemoveLiquidityInvitation();
-    const aliceRemoveLiquidityProposal = harden({
-      give: { Liquidity: moolaLiquidity(50) },
-      want: { Secondary: moola(91), Central: centralTokens(56) },
-    });
+  // Alice removes her liquidity
+  // She's not picky...
+  const aliceRemoveLiquidityInvitation = await E(
+    publicFacet,
+  ).makeRemoveLiquidityInvitation();
+  const aliceRemoveLiquidityProposal = harden({
+    give: { Liquidity: moolaLiquidity(50) },
+    want: { Secondary: moola(91), Central: centralTokens(56) },
+  });
 
-    const aliceSeat3 = await zoe.offer(
-      aliceRemoveLiquidityInvitation,
-      aliceRemoveLiquidityProposal,
-      harden({ Liquidity: liquidityPayout }),
-    );
+  const aliceSeat3 = await zoe.offer(
+    aliceRemoveLiquidityInvitation,
+    aliceRemoveLiquidityProposal,
+    harden({ Liquidity: liquidityPayout }),
+  );
 
-    t.equals(
-      await aliceSeat3.getOfferResult(),
-      'Liquidity successfully removed.',
-    );
+  t.is(await aliceSeat3.getOfferResult(), 'Liquidity successfully removed.');
 
-    const aliceMoolaPayout = await aliceSeat3.getPayout('Secondary');
-    const aliceCentralPayout = await aliceSeat3.getPayout('Central');
-    const aliceLiquidityPayout = await aliceSeat3.getPayout('Liquidity');
+  const aliceMoolaPayout = await aliceSeat3.getPayout('Secondary');
+  const aliceCentralPayout = await aliceSeat3.getPayout('Central');
+  const aliceLiquidityPayout = await aliceSeat3.getPayout('Liquidity');
 
-    t.deepEquals(
-      await moolaR.issuer.getAmountOf(aliceMoolaPayout),
-      moola(91),
-      `alice gets all the moola in the pool`,
-    );
-    t.deepEquals(
-      await centralR.issuer.getAmountOf(aliceCentralPayout),
-      centralTokens(56),
-      `alice gets all the central tokens in the pool`,
-    );
-    t.deepEquals(
-      await moolaLiquidityIssuer.getAmountOf(aliceLiquidityPayout),
-      moolaLiquidity(0),
-      `alice gets no liquidity tokens`,
-    );
-    t.deepEqual(
-      await E(bobPublicFacet).getPoolAllocation(moolaR.brand),
-      harden({
-        Secondary: moola(0),
-        Central: centralTokens(0),
-        Liquidity: moolaLiquidity(50),
-      }),
-      `liquidity is empty`,
-    );
-  } catch (e) {
-    t.assert(false, e);
-    console.log(e);
-  }
+  t.deepEqual(
+    await moolaR.issuer.getAmountOf(aliceMoolaPayout),
+    moola(91),
+    `alice gets all the moola in the pool`,
+  );
+  t.deepEqual(
+    await centralR.issuer.getAmountOf(aliceCentralPayout),
+    centralTokens(56),
+    `alice gets all the central tokens in the pool`,
+  );
+  t.deepEqual(
+    await moolaLiquidityIssuer.getAmountOf(aliceLiquidityPayout),
+    moolaLiquidity(0),
+    `alice gets no liquidity tokens`,
+  );
+  t.deepEqual(
+    await E(bobPublicFacet).getPoolAllocation(moolaR.brand),
+    harden({
+      Secondary: moola(0),
+      Central: centralTokens(0),
+      Liquidity: moolaLiquidity(50),
+    }),
+    `liquidity is empty`,
+  );
 });

--- a/packages/zoe/test/unitTests/contracts/test-secondPriceAuction.js
+++ b/packages/zoe/test/unitTests/contracts/test-secondPriceAuction.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'tape-promise/tape';
+import test from 'ava';
 import bundleSource from '@agoric/bundle-source';
 import { E } from '@agoric/eventual-send';
 
@@ -16,373 +16,363 @@ const secondPriceAuctionRoot = `${__dirname}/../../../src/contracts/auction/seco
 
 test('zoe - secondPriceAuction w/ 3 bids', async t => {
   t.plan(15);
-  try {
-    const { moolaKit, simoleanKit, moola, simoleans, zoe } = setup();
+  const { moolaKit, simoleanKit, moola, simoleans, zoe } = setup();
 
-    const makeAlice = async (timer, moolaPayment) => {
-      const moolaPurse = await E(moolaKit.issuer).makeEmptyPurse();
-      const simoleanPurse = await E(simoleanKit.issuer).makeEmptyPurse();
-      return {
-        installCode: async () => {
-          // pack the contract
-          const bundle = await bundleSource(secondPriceAuctionRoot);
-          // install the contract
-          const installationP = E(zoe).install(bundle);
-          return installationP;
-        },
-        startInstance: async installation => {
-          const issuerKeywordRecord = harden({
-            Asset: moolaKit.issuer,
-            Ask: simoleanKit.issuer,
-          });
-          const terms = { timerAuthority: timer, closesAfter: 1 };
-          const adminP = zoe.startInstance(
-            installation,
-            issuerKeywordRecord,
-            terms,
+  const makeAlice = async (timer, moolaPayment) => {
+    const moolaPurse = await E(moolaKit.issuer).makeEmptyPurse();
+    const simoleanPurse = await E(simoleanKit.issuer).makeEmptyPurse();
+    return {
+      installCode: async () => {
+        // pack the contract
+        const bundle = await bundleSource(secondPriceAuctionRoot);
+        // install the contract
+        const installationP = E(zoe).install(bundle);
+        return installationP;
+      },
+      startInstance: async installation => {
+        const issuerKeywordRecord = harden({
+          Asset: moolaKit.issuer,
+          Ask: simoleanKit.issuer,
+        });
+        const terms = { timerAuthority: timer, closesAfter: 1 };
+        const adminP = zoe.startInstance(
+          installation,
+          issuerKeywordRecord,
+          terms,
+        );
+        return adminP;
+      },
+      offer: async sellInvitation => {
+        const proposal = harden({
+          give: { Asset: moola(1) },
+          want: { Ask: simoleans(3) },
+          exit: { waived: null },
+        });
+
+        const payments = { Asset: moolaPayment };
+
+        const seat = await E(zoe).offer(sellInvitation, proposal, payments);
+
+        E(seat)
+          .getPayout('Asset')
+          .then(moolaPurse.deposit)
+          .then(amountDeposited =>
+            t.deepEqual(
+              amountDeposited,
+              moola(0),
+              `Alice didn't get any of what she put in`,
+            ),
           );
-          return adminP;
-        },
-        offer: async sellInvitation => {
-          const proposal = harden({
-            give: { Asset: moola(1) },
-            want: { Ask: simoleans(3) },
-            exit: { waived: null },
-          });
 
-          const payments = { Asset: moolaPayment };
+        E(seat)
+          .getPayout('Ask')
+          .then(simoleanPurse.deposit)
+          .then(amountDeposited =>
+            t.deepEqual(
+              amountDeposited,
+              simoleans(7),
+              `Alice got the second price bid, Carol's bid, even though Bob won`,
+            ),
+          );
 
-          const seat = await E(zoe).offer(sellInvitation, proposal, payments);
-
-          E(seat)
-            .getPayout('Asset')
-            .then(moolaPurse.deposit)
-            .then(amountDeposited =>
-              t.deepEquals(
-                amountDeposited,
-                moola(0),
-                `Alice didn't get any of what she put in`,
-              ),
-            );
-
-          E(seat)
-            .getPayout('Ask')
-            .then(simoleanPurse.deposit)
-            .then(amountDeposited =>
-              t.deepEquals(
-                amountDeposited,
-                simoleans(7),
-                `Alice got the second price bid, Carol's bid, even though Bob won`,
-              ),
-            );
-
-          const makeBidInvitationObj = await E(seat).getOfferResult();
-          return makeBidInvitationObj;
-        },
-      };
+        const makeBidInvitationObj = await E(seat).getOfferResult();
+        return makeBidInvitationObj;
+      },
     };
+  };
 
-    const makeBob = (installation, simoleanPayment) => {
-      const moolaPurse = moolaKit.issuer.makeEmptyPurse();
-      const simoleanPurse = simoleanKit.issuer.makeEmptyPurse();
-      return harden({
-        offer: async untrustedInvitation => {
-          const invitationIssuer = await E(zoe).getInvitationIssuer();
+  const makeBob = (installation, simoleanPayment) => {
+    const moolaPurse = moolaKit.issuer.makeEmptyPurse();
+    const simoleanPurse = simoleanKit.issuer.makeEmptyPurse();
+    return harden({
+      offer: async untrustedInvitation => {
+        const invitationIssuer = await E(zoe).getInvitationIssuer();
 
-          // Bob is able to use the trusted invitationIssuer from Zoe to
-          // transform an untrusted invitation that Alice also has access to, to
-          // an
-          const invitation = await invitationIssuer.claim(untrustedInvitation);
+        // Bob is able to use the trusted invitationIssuer from Zoe to
+        // transform an untrusted invitation that Alice also has access to, to
+        // an
+        const invitation = await invitationIssuer.claim(untrustedInvitation);
 
-          const invitationValue = await E(zoe).getInvitationDetails(invitation);
+        const invitationValue = await E(zoe).getInvitationDetails(invitation);
 
-          t.equals(
-            invitationValue.installation,
-            installation,
-            'installation is secondPriceAuction',
-          );
-          t.deepEquals(
-            invitationValue.auctionedAssets,
-            moola(1),
-            `asset to be auctioned is 1 moola`,
-          );
-          t.deepEquals(
-            invitationValue.minimumBid,
-            simoleans(3),
-            `minimum bid is 3 simoleans`,
-          );
+        t.is(
+          invitationValue.installation,
+          installation,
+          'installation is secondPriceAuction',
+        );
+        t.deepEqual(
+          invitationValue.auctionedAssets,
+          moola(1),
+          `asset to be auctioned is 1 moola`,
+        );
+        t.deepEqual(
+          invitationValue.minimumBid,
+          simoleans(3),
+          `minimum bid is 3 simoleans`,
+        );
 
-          t.deepEquals(
-            invitationValue.closesAfter,
-            1,
-            `auction will be closed after 1 tick according to the timerAuthority`,
-          );
+        t.deepEqual(
+          invitationValue.closesAfter,
+          1,
+          `auction will be closed after 1 tick according to the timerAuthority`,
+        );
 
-          const proposal = harden({
-            give: { Bid: simoleans(11) },
-            want: { Asset: moola(1) },
-          });
-          const payments = { Bid: simoleanPayment };
+        const proposal = harden({
+          give: { Bid: simoleans(11) },
+          want: { Asset: moola(1) },
+        });
+        const payments = { Bid: simoleanPayment };
 
-          const seat = await zoe.offer(invitation, proposal, payments);
+        const seat = await zoe.offer(invitation, proposal, payments);
 
-          t.equals(
-            await E(seat).getOfferResult(),
-            'The offer has been accepted. Once the contract has been completed, please check your payout',
-          );
+        t.is(
+          await E(seat).getOfferResult(),
+          'The offer has been accepted. Once the contract has been completed, please check your payout',
+        );
 
-          E(seat)
-            .getPayout('Asset')
-            .then(moolaPurse.deposit)
-            .then(amountDeposited =>
-              t.deepEquals(
-                amountDeposited,
-                proposal.want.Asset,
-                `Bob wins the auction`,
-              ),
-            );
-
-          E(seat)
-            .getPayout('Bid')
-            .then(simoleanPurse.deposit)
-            .then(amountDeposited =>
-              t.deepEquals(
-                amountDeposited,
-                simoleans(4),
-                `Bob gets the difference between the second-price bid (Carol's 7 simoleans) and his bid back`,
-              ),
-            );
-        },
-      });
-    };
-
-    const makeLosingBidder = (bidAmount, simoleanPayment) => {
-      const moolaPurse = moolaKit.issuer.makeEmptyPurse();
-      const simoleanPurse = simoleanKit.issuer.makeEmptyPurse();
-      return harden({
-        offer: async untrustedInvitation => {
-          const invitationIssuer = await E(zoe).getInvitationIssuer();
-          const invitation = await invitationIssuer.claim(untrustedInvitation);
-
-          const proposal = harden({
-            give: { Bid: bidAmount },
-            want: { Asset: moola(1) },
-          });
-          const payments = { Bid: simoleanPayment };
-
-          const seat = await zoe.offer(invitation, proposal, payments);
-
-          t.equals(
-            await E(seat).getOfferResult(),
-            'The offer has been accepted. Once the contract has been completed, please check your payout',
+        E(seat)
+          .getPayout('Asset')
+          .then(moolaPurse.deposit)
+          .then(amountDeposited =>
+            t.deepEqual(
+              amountDeposited,
+              proposal.want.Asset,
+              `Bob wins the auction`,
+            ),
           );
 
-          E(seat)
-            .getPayout('Asset')
-            .then(moolaPurse.deposit)
-            .then(amountDeposited =>
-              t.deepEquals(amountDeposited, moola(0), `didn't win the auction`),
-            );
+        E(seat)
+          .getPayout('Bid')
+          .then(simoleanPurse.deposit)
+          .then(amountDeposited =>
+            t.deepEqual(
+              amountDeposited,
+              simoleans(4),
+              `Bob gets the difference between the second-price bid (Carol's 7 simoleans) and his bid back`,
+            ),
+          );
+      },
+    });
+  };
 
-          E(seat)
-            .getPayout('Bid')
-            .then(simoleanPurse.deposit)
-            .then(amountDeposited =>
-              t.deepEquals(amountDeposited, bidAmount, `full refund`),
-            );
-        },
-      });
-    };
+  const makeLosingBidder = (bidAmount, simoleanPayment) => {
+    const moolaPurse = moolaKit.issuer.makeEmptyPurse();
+    const simoleanPurse = simoleanKit.issuer.makeEmptyPurse();
+    return harden({
+      offer: async untrustedInvitation => {
+        const invitationIssuer = await E(zoe).getInvitationIssuer();
+        const invitation = await invitationIssuer.claim(untrustedInvitation);
 
-    // Setup Alice
-    const timer = buildManualTimer(console.log);
-    const alice = await makeAlice(timer, moolaKit.mint.mintPayment(moola(1)));
-    const installation = await alice.installCode();
+        const proposal = harden({
+          give: { Bid: bidAmount },
+          want: { Asset: moola(1) },
+        });
+        const payments = { Bid: simoleanPayment };
 
-    // Setup Bob, Carol, Dave
-    const bob = makeBob(
-      installation,
-      await simoleanKit.mint.mintPayment(simoleans(11)),
-    );
-    const carol = makeLosingBidder(
-      simoleans(7),
-      await simoleanKit.mint.mintPayment(simoleans(7)),
-    );
-    const dave = makeLosingBidder(
-      simoleans(5),
-      await simoleanKit.mint.mintPayment(simoleans(5)),
-    );
+        const seat = await zoe.offer(invitation, proposal, payments);
 
-    const { creatorInvitation } = await alice.startInstance(installation);
+        t.is(
+          await E(seat).getOfferResult(),
+          'The offer has been accepted. Once the contract has been completed, please check your payout',
+        );
 
-    const makeInvitationsObj = await alice.offer(creatorInvitation);
+        E(seat)
+          .getPayout('Asset')
+          .then(moolaPurse.deposit)
+          .then(amountDeposited =>
+            t.deepEqual(amountDeposited, moola(0), `didn't win the auction`),
+          );
 
-    const bidInvitation1 = E(makeInvitationsObj).makeBidInvitation();
-    const bidInvitation2 = E(makeInvitationsObj).makeBidInvitation();
-    const bidInvitation3 = E(makeInvitationsObj).makeBidInvitation();
+        E(seat)
+          .getPayout('Bid')
+          .then(simoleanPurse.deposit)
+          .then(amountDeposited =>
+            t.deepEqual(amountDeposited, bidAmount, `full refund`),
+          );
+      },
+    });
+  };
 
-    await bob.offer(bidInvitation1);
-    await carol.offer(bidInvitation2);
-    await dave.offer(bidInvitation3);
-    timer.tick();
-  } catch (e) {
-    t.assert(false, e);
-    console.log(e);
-  }
+  // Setup Alice
+  const timer = buildManualTimer(console.log);
+  const alice = await makeAlice(timer, moolaKit.mint.mintPayment(moola(1)));
+  const installation = await alice.installCode();
+
+  // Setup Bob, Carol, Dave
+  const bob = makeBob(
+    installation,
+    await simoleanKit.mint.mintPayment(simoleans(11)),
+  );
+  const carol = makeLosingBidder(
+    simoleans(7),
+    await simoleanKit.mint.mintPayment(simoleans(7)),
+  );
+  const dave = makeLosingBidder(
+    simoleans(5),
+    await simoleanKit.mint.mintPayment(simoleans(5)),
+  );
+
+  const { creatorInvitation } = await alice.startInstance(installation);
+
+  const makeInvitationsObj = await alice.offer(creatorInvitation);
+
+  const bidInvitation1 = E(makeInvitationsObj).makeBidInvitation();
+  const bidInvitation2 = E(makeInvitationsObj).makeBidInvitation();
+  const bidInvitation3 = E(makeInvitationsObj).makeBidInvitation();
+
+  await bob.offer(bidInvitation1);
+  await carol.offer(bidInvitation2);
+  await dave.offer(bidInvitation3);
+  timer.tick();
 });
 
 test('zoe - secondPriceAuction - alice tries to exit', async t => {
   t.plan(12);
-  try {
-    const { moolaR, simoleanR, moola, simoleans } = setup();
-    const zoe = makeZoe(fakeVatAdmin);
+  const { moolaR, simoleanR, moola, simoleans } = setup();
+  const zoe = makeZoe(fakeVatAdmin);
 
-    // Setup Alice
-    const aliceMoolaPayment = moolaR.mint.mintPayment(moola(1));
-    const aliceMoolaPurse = moolaR.issuer.makeEmptyPurse();
-    const aliceSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
+  // Setup Alice
+  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(1));
+  const aliceMoolaPurse = moolaR.issuer.makeEmptyPurse();
+  const aliceSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
 
-    // Setup Bob
-    const bobSimoleanPayment = simoleanR.mint.mintPayment(simoleans(11));
-    const bobMoolaPurse = moolaR.issuer.makeEmptyPurse();
-    const bobSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
+  // Setup Bob
+  const bobSimoleanPayment = simoleanR.mint.mintPayment(simoleans(11));
+  const bobMoolaPurse = moolaR.issuer.makeEmptyPurse();
+  const bobSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
 
-    // Setup Carol
-    const carolSimoleanPayment = simoleanR.mint.mintPayment(simoleans(8));
+  // Setup Carol
+  const carolSimoleanPayment = simoleanR.mint.mintPayment(simoleans(8));
 
-    // Alice creates a secondPriceAuction instance
+  // Alice creates a secondPriceAuction instance
 
-    // Pack the contract.
-    const bundle = await bundleSource(secondPriceAuctionRoot);
+  // Pack the contract.
+  const bundle = await bundleSource(secondPriceAuctionRoot);
 
-    const installation = await zoe.install(bundle);
-    const issuerKeywordRecord = harden({
-      Asset: moolaR.issuer,
-      Ask: simoleanR.issuer,
-    });
-    const timer = buildManualTimer(console.log);
-    const terms = harden({ timerAuthority: timer, closesAfter: 1 });
-    const { creatorInvitation: aliceInvitation } = await zoe.startInstance(
-      installation,
-      issuerKeywordRecord,
-      terms,
-    );
+  const installation = await zoe.install(bundle);
+  const issuerKeywordRecord = harden({
+    Asset: moolaR.issuer,
+    Ask: simoleanR.issuer,
+  });
+  const timer = buildManualTimer(console.log);
+  const terms = harden({ timerAuthority: timer, closesAfter: 1 });
+  const { creatorInvitation: aliceInvitation } = await zoe.startInstance(
+    installation,
+    issuerKeywordRecord,
+    terms,
+  );
 
-    // Alice escrows with zoe
-    const aliceProposal = harden({
-      give: { Asset: moola(1) },
-      want: { Ask: simoleans(3) },
-      exit: { waived: null },
-    });
-    const alicePayments = harden({ Asset: aliceMoolaPayment });
-    // Alice initializes the auction
-    const aliceSeat = await zoe.offer(
-      aliceInvitation,
-      aliceProposal,
-      alicePayments,
-    );
-    const makeInvitationObj = await E(aliceSeat).getOfferResult();
+  // Alice escrows with zoe
+  const aliceProposal = harden({
+    give: { Asset: moola(1) },
+    want: { Ask: simoleans(3) },
+    exit: { waived: null },
+  });
+  const alicePayments = harden({ Asset: aliceMoolaPayment });
+  // Alice initializes the auction
+  const aliceSeat = await zoe.offer(
+    aliceInvitation,
+    aliceProposal,
+    alicePayments,
+  );
+  const makeInvitationObj = await E(aliceSeat).getOfferResult();
 
-    const bobInvitation = await E(makeInvitationObj).makeBidInvitation();
+  const bobInvitation = await E(makeInvitationObj).makeBidInvitation();
 
-    // Alice tries to exit, but cannot
-    t.rejects(
-      () => E(aliceSeat).tryExit(),
-      /Only seats with the exitKind "onDemand" can exit at will/,
-      `alice can't exit`,
-    );
+  // Alice tries to exit, but cannot
+  await t.throwsAsync(
+    () => E(aliceSeat).tryExit(),
+    { message: /Only seats with the exitKind "onDemand" can exit at will/ },
+    `alice can't exit`,
+  );
 
-    // Alice gives Bob the invitation
+  // Alice gives Bob the invitation
 
-    const bobProposal = harden({
-      want: { Asset: moola(1) },
-      give: { Bid: simoleans(11) },
-    });
-    const bobPayments = harden({ Bid: bobSimoleanPayment });
+  const bobProposal = harden({
+    want: { Asset: moola(1) },
+    give: { Bid: simoleans(11) },
+  });
+  const bobPayments = harden({ Bid: bobSimoleanPayment });
 
-    // Bob escrows with zoe
-    // Bob bids
-    const bobSeat = await zoe.offer(bobInvitation, bobProposal, bobPayments);
+  // Bob escrows with zoe
+  // Bob bids
+  const bobSeat = await zoe.offer(bobInvitation, bobProposal, bobPayments);
 
-    t.equals(
-      await E(bobSeat).getOfferResult(),
-      'The offer has been accepted. Once the contract has been completed, please check your payout',
-    );
+  t.is(
+    await E(bobSeat).getOfferResult(),
+    'The offer has been accepted. Once the contract has been completed, please check your payout',
+  );
 
-    // Bob exits early, but this does not stop the auction.
-    await E(bobSeat).tryExit();
-    const bobMoolaPayout = await bobSeat.getPayout('Asset');
-    const bobSimoleanPayout = await bobSeat.getPayout('Bid');
+  // Bob exits early, but this does not stop the auction.
+  await E(bobSeat).tryExit();
+  const bobMoolaPayout = await bobSeat.getPayout('Asset');
+  const bobSimoleanPayout = await bobSeat.getPayout('Bid');
 
-    const carolInvitation = await E(makeInvitationObj).makeBidInvitation();
+  const carolInvitation = await E(makeInvitationObj).makeBidInvitation();
 
-    const carolProposal = harden({
-      want: { Asset: moola(1) },
-      give: { Bid: simoleans(8) },
-    });
-    const carolPayments = harden({ Bid: carolSimoleanPayment });
+  const carolProposal = harden({
+    want: { Asset: moola(1) },
+    give: { Bid: simoleans(8) },
+  });
+  const carolPayments = harden({ Bid: carolSimoleanPayment });
 
-    // Carol bids
-    const carolSeat = await zoe.offer(
-      carolInvitation,
-      carolProposal,
-      carolPayments,
-    );
+  // Carol bids
+  const carolSeat = await zoe.offer(
+    carolInvitation,
+    carolProposal,
+    carolPayments,
+  );
 
-    timer.tick();
+  timer.tick();
 
-    const aliceMoolaPayout = await aliceSeat.getPayout('Asset');
-    const aliceSimoleanPayout = await aliceSeat.getPayout('Ask');
+  const aliceMoolaPayout = await aliceSeat.getPayout('Asset');
+  const aliceSimoleanPayout = await aliceSeat.getPayout('Ask');
 
-    const carolMoolaPayout = await carolSeat.getPayout('Asset');
-    const carolSimoleanPayout = await carolSeat.getPayout('Bid');
+  const carolMoolaPayout = await carolSeat.getPayout('Asset');
+  const carolSimoleanPayout = await carolSeat.getPayout('Bid');
 
-    // Alice (the creator of the auction) gets Carol's simoleans and
-    // carol gets the assets.
-    t.deepEquals(
-      await moolaR.issuer.getAmountOf(aliceMoolaPayout),
-      moola(0),
-      `alice has no moola`,
-    );
+  // Alice (the creator of the auction) gets Carol's simoleans and
+  // carol gets the assets.
+  t.deepEqual(
+    await moolaR.issuer.getAmountOf(aliceMoolaPayout),
+    moola(0),
+    `alice has no moola`,
+  );
 
-    // Alice got Carol's simoleans
-    t.deepEquals(
-      await simoleanR.issuer.getAmountOf(aliceSimoleanPayout),
-      simoleans(8),
-    );
+  // Alice got Carol's simoleans
+  t.deepEqual(
+    await simoleanR.issuer.getAmountOf(aliceSimoleanPayout),
+    simoleans(8),
+  );
 
-    // Alice deposits her payout to ensure she can
-    await aliceMoolaPurse.deposit(aliceMoolaPayout);
-    await aliceSimoleanPurse.deposit(aliceSimoleanPayout);
+  // Alice deposits her payout to ensure she can
+  await aliceMoolaPurse.deposit(aliceMoolaPayout);
+  await aliceSimoleanPurse.deposit(aliceSimoleanPayout);
 
-    // Bob gets a refund
-    t.deepEquals(await moolaR.issuer.getAmountOf(bobMoolaPayout), moola(0));
-    t.deepEquals(
-      await simoleanR.issuer.getAmountOf(bobSimoleanPayout),
-      bobProposal.give.Bid,
-    );
+  // Bob gets a refund
+  t.deepEqual(await moolaR.issuer.getAmountOf(bobMoolaPayout), moola(0));
+  t.deepEqual(
+    await simoleanR.issuer.getAmountOf(bobSimoleanPayout),
+    bobProposal.give.Bid,
+  );
 
-    // Bob deposits his payout to ensure he can
-    await bobMoolaPurse.deposit(bobMoolaPayout);
-    await bobSimoleanPurse.deposit(bobSimoleanPayout);
+  // Bob deposits his payout to ensure he can
+  await bobMoolaPurse.deposit(bobMoolaPayout);
+  await bobSimoleanPurse.deposit(bobSimoleanPayout);
 
-    // Carol gets the assets and all her simoleans are taken to pay
-    // Alice
-    t.deepEquals(await moolaR.issuer.getAmountOf(carolMoolaPayout), moola(1));
-    t.deepEquals(
-      await simoleanR.issuer.getAmountOf(carolSimoleanPayout),
-      simoleans(0),
-    );
+  // Carol gets the assets and all her simoleans are taken to pay
+  // Alice
+  t.deepEqual(await moolaR.issuer.getAmountOf(carolMoolaPayout), moola(1));
+  t.deepEqual(
+    await simoleanR.issuer.getAmountOf(carolSimoleanPayout),
+    simoleans(0),
+  );
 
-    // Assert that the correct refunds were received.
-    t.equals(aliceMoolaPurse.getCurrentAmount().value, 0);
-    t.equals(aliceSimoleanPurse.getCurrentAmount().value, 8);
-    t.equals(bobMoolaPurse.getCurrentAmount().value, 0);
-    t.equals(bobSimoleanPurse.getCurrentAmount().value, 11);
-  } catch (e) {
-    t.assert(false, e);
-    console.log(e);
-  }
+  // Assert that the correct refunds were received.
+  t.is(aliceMoolaPurse.getCurrentAmount().value, 0);
+  t.is(aliceSimoleanPurse.getCurrentAmount().value, 8);
+  t.is(bobMoolaPurse.getCurrentAmount().value, 0);
+  t.is(bobSimoleanPurse.getCurrentAmount().value, 11);
 });
 
 // Three bidders with (fungible) moola bid for a CryptoCat
@@ -464,10 +454,10 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
 
   const bobIssuers = zoe.getIssuers(bobInvitationValue.instance);
 
-  t.equals(bobInvitationValue.installation, installation, 'bobInstallationId');
-  t.deepEquals(bobIssuers, { Asset: ccIssuer, Ask: moolaIssuer }, 'bobIssuers');
-  t.deepEquals(bobInvitationValue.minimumBid, moola(3), 'minimumBid');
-  t.deepEquals(
+  t.is(bobInvitationValue.installation, installation, 'bobInstallationId');
+  t.deepEqual(bobIssuers, { Asset: ccIssuer, Ask: moolaIssuer }, 'bobIssuers');
+  t.deepEqual(bobInvitationValue.minimumBid, moola(3), 'minimumBid');
+  t.deepEqual(
     bobInvitationValue.auctionedAssets,
     cryptoCats(harden(['Felix'])),
     'assets',
@@ -487,7 +477,7 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
     bobPayments,
   );
 
-  t.equals(
+  t.is(
     await E(bobSeat).getOfferResult(),
     'The offer has been accepted. Once the contract has been completed, please check your payout',
     'bobOutcome',
@@ -504,18 +494,14 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
 
   const carolIssuers = zoe.getIssuers(carolInvitationValue.instance);
 
-  t.equals(
-    carolInvitationValue.installation,
-    installation,
-    'carolInstallationId',
-  );
-  t.deepEquals(
+  t.is(carolInvitationValue.installation, installation, 'carolInstallationId');
+  t.deepEqual(
     carolIssuers,
     { Asset: ccIssuer, Ask: moolaIssuer },
     'carolIssuers',
   );
-  t.deepEquals(carolInvitationValue.minimumBid, moola(3), 'carolMinimumBid');
-  t.deepEquals(
+  t.deepEqual(carolInvitationValue.minimumBid, moola(3), 'carolMinimumBid');
+  t.deepEqual(
     carolInvitationValue.auctionedAssets,
     cryptoCats(harden(['Felix'])),
     'carolAuctionedAssets',
@@ -535,7 +521,7 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
     carolPayments,
   );
 
-  t.equals(
+  t.is(
     await E(carolSeat).getOfferResult(),
     'The offer has been accepted. Once the contract has been completed, please check your payout',
     'carolOutcome',
@@ -549,14 +535,14 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
 
   const daveIssuers = zoe.getIssuers(daveInvitationValue.instance);
 
-  t.equals(daveInvitationValue.installation, installation, 'daveInstallation');
-  t.deepEquals(
+  t.is(daveInvitationValue.installation, installation, 'daveInstallation');
+  t.deepEqual(
     daveIssuers,
     { Asset: ccIssuer, Ask: moolaIssuer },
     'daveIssuers',
   );
-  t.deepEquals(daveInvitationValue.minimumBid, moola(3), 'daveMinimumBid');
-  t.deepEquals(
+  t.deepEqual(daveInvitationValue.minimumBid, moola(3), 'daveMinimumBid');
+  t.deepEqual(
     daveInvitationValue.auctionedAssets,
     cryptoCats(harden(['Felix'])),
     'daveAssets',
@@ -576,7 +562,7 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
     davePayments,
   );
 
-  t.equals(
+  t.is(
     await E(daveSeat).getOfferResult(),
     'The offer has been accepted. Once the contract has been completed, please check your payout',
     'daveOutcome',
@@ -597,14 +583,14 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
   const daveMoolaPayout = await daveSeat.getPayout('Bid');
 
   // Alice (the creator of the auction) gets back the second highest bid
-  t.deepEquals(
+  t.deepEqual(
     await moolaIssuer.getAmountOf(aliceMoolaPayout),
     carolProposal.give.Bid,
     `alice gets carol's bid`,
   );
 
   // Alice didn't get any of what she put in
-  t.deepEquals(
+  t.deepEqual(
     await ccIssuer.getAmountOf(aliceCcPayout),
     cryptoCats(harden([])),
     `alice gets nothing of what she put in`,
@@ -616,12 +602,12 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
 
   // Bob (the winner of the auction) gets the one moola and the
   // difference between his bid and the price back
-  t.deepEquals(
+  t.deepEqual(
     await ccIssuer.getAmountOf(bobCcPayout),
     cryptoCats(harden(['Felix'])),
     `bob is the winner`,
   );
-  t.deepEquals(
+  t.deepEqual(
     await moolaIssuer.getAmountOf(bobMoolaPayout),
     moola(4),
     `bob gets difference back`,
@@ -632,12 +618,12 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
   await bobMoolaPurse.deposit(bobMoolaPayout);
 
   // Carol gets a full refund
-  t.deepEquals(
+  t.deepEqual(
     await ccIssuer.getAmountOf(carolCcPayout),
     cryptoCats(harden([])),
     `carol doesn't win`,
   );
-  t.deepEquals(
+  t.deepEqual(
     await moolaIssuer.getAmountOf(carolMoolaPayout),
     carolProposal.give.Bid,
     `carol gets a refund`,
@@ -648,7 +634,7 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
   await carolMoolaPurse.deposit(carolMoolaPayout);
 
   // Dave gets a full refund
-  t.deepEquals(
+  t.deepEqual(
     await moolaIssuer.getAmountOf(daveMoolaPayout),
     daveProposal.give.Bid,
     `dave gets a refund`,
@@ -669,12 +655,12 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
   // Bob: the CryptoCat and 4 moola
   // Carol: an empty CryptoCat purse and 7 moola
   // Dave: an empty CryptoCat purse and 5 moola
-  t.deepEquals(aliceCcPurse.getCurrentAmount().value, []);
-  t.equals(aliceMoolaPurse.getCurrentAmount().value, 7);
-  t.deepEquals(bobCcPurse.getCurrentAmount().value, ['Felix']);
-  t.equals(bobMoolaPurse.getCurrentAmount().value, 4);
-  t.deepEquals(carolCcPurse.getCurrentAmount().value, []);
-  t.equals(carolMoolaPurse.getCurrentAmount().value, 7);
-  t.deepEquals(daveCcPurse.getCurrentAmount().value, []);
-  t.equals(daveMoolaPurse.getCurrentAmount().value, 5);
+  t.deepEqual(aliceCcPurse.getCurrentAmount().value, []);
+  t.is(aliceMoolaPurse.getCurrentAmount().value, 7);
+  t.deepEqual(bobCcPurse.getCurrentAmount().value, ['Felix']);
+  t.is(bobMoolaPurse.getCurrentAmount().value, 4);
+  t.deepEqual(carolCcPurse.getCurrentAmount().value, []);
+  t.is(carolMoolaPurse.getCurrentAmount().value, 7);
+  t.deepEqual(daveCcPurse.getCurrentAmount().value, []);
+  t.is(daveMoolaPurse.getCurrentAmount().value, 5);
 });

--- a/packages/zoe/test/unitTests/contracts/test-sellTickets.js
+++ b/packages/zoe/test/unitTests/contracts/test-sellTickets.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'tape-promise/tape';
+import test from 'ava';
 
 import bundleSource from '@agoric/bundle-source';
 import { makeIssuerKit, makeLocalAmountMath } from '@agoric/ertp';
@@ -44,7 +44,7 @@ test(`mint and sell tickets for multiple shows`, async t => {
     sellItemsInstallation,
     pricePerItem: moolaAmountMath.make(20),
   });
-  t.equals(
+  t.is(
     await sellItemsCreatorSeat.getOfferResult(),
     defaultAcceptanceMsg,
     `escrowTicketsOutcome is default acceptance message`,
@@ -54,7 +54,7 @@ test(`mint and sell tickets for multiple shows`, async t => {
   const ticketBrand = await E(ticketIssuerP).getBrand();
   const ticketSalesPublicFacet = await E(zoe).getPublicFacet(sellItemsInstance);
   const ticketsForSale = await E(ticketSalesPublicFacet).getAvailableItems();
-  t.deepEquals(
+  t.deepEqual(
     ticketsForSale,
     {
       brand: ticketBrand,
@@ -93,7 +93,7 @@ test(`mint and sell tickets for multiple shows`, async t => {
   });
   const sellItemsPublicFacet2 = await E(zoe).getPublicFacet(sellItemsInstance2);
   const ticketsForSale2 = await E(sellItemsPublicFacet2).getAvailableItems();
-  t.deepEquals(
+  t.deepEqual(
     ticketsForSale2,
     {
       brand: ticketBrand,
@@ -112,7 +112,6 @@ test(`mint and sell tickets for multiple shows`, async t => {
     },
     `we can reuse the mint to make more tickets and sell them in a different instance`,
   );
-  t.end();
 });
 
 // __Test Scenario__
@@ -175,7 +174,7 @@ test(`mint and sell opera tickets`, async t => {
 
     const ticketsForSale = await E(sellItemsPublicFacet).getAvailableItems();
 
-    t.equal(ticketsForSale.value.length, 3, `3 tickets for sale`);
+    t.is(ticketsForSale.value.length, 3, `3 tickets for sale`);
 
     return harden({
       sellItemsCreatorSeat,
@@ -199,26 +198,26 @@ test(`mint and sell opera tickets`, async t => {
     const alicePurse = await E(moolaIssuer).makeEmptyPurse();
     await E(alicePurse).deposit(moola100Payment);
 
-    t.deepEquals(terms.pricePerItem, moola(22), `pricePerItem is 22 moola`);
+    t.deepEqual(terms.pricePerItem, moola(22), `pricePerItem is 22 moola`);
 
     const availableTickets = await E(
       ticketSalesPublicFacet,
     ).getAvailableItems();
 
-    t.equal(
+    t.is(
       availableTickets.value.length,
       3,
       'Alice should see 3 available tickets',
     );
-    t.ok(
+    t.truthy(
       availableTickets.value.find(ticket => ticket.number === 1),
       `availableTickets contains ticket number 1`,
     );
-    t.ok(
+    t.truthy(
       availableTickets.value.find(ticket => ticket.number === 2),
       `availableTickets contains ticket number 2`,
     );
-    t.ok(
+    t.truthy(
       availableTickets.value.find(ticket => ticket.number === 3),
       `availableTickets contains ticket number 3`,
     );
@@ -249,12 +248,12 @@ test(`mint and sell opera tickets`, async t => {
       aliceTickets,
     );
 
-    t.equal(
+    t.is(
       aliceBoughtTicketAmount.value[0].show,
       'Steven Universe, the Opera',
       'Alice should have received the ticket for the correct show',
     );
-    t.equal(
+    t.is(
       aliceBoughtTicketAmount.value[0].number,
       1,
       'Alice should have received the ticket for the correct number',
@@ -311,9 +310,9 @@ test(`mint and sell opera tickets`, async t => {
     console.log(
       'EXPECTED ERROR: Some of the wanted items were not available for sale >>>',
     );
-    t.rejects(
+    await t.throwsAsync(
       seat.getOfferResult(),
-      /Some of the wanted items were not available for sale/,
+      { message: /Some of the wanted items were not available for sale/ },
       'ticket 1 is no longer available',
     );
 
@@ -324,11 +323,11 @@ test(`mint and sell opera tickets`, async t => {
       seat.getPayout('Money'),
     );
 
-    t.ok(
+    t.truthy(
       ticketAmountMath.isEmpty(jokerTicketPayoutAmount),
       'Joker should not receive ticket #1',
     );
-    t.deepEquals(
+    t.deepEqual(
       jokerMoneyPayoutAmount,
       moola(22),
       'Joker should get a refund after trying to get ticket #1',
@@ -385,9 +384,9 @@ test(`mint and sell opera tickets`, async t => {
     console.log(
       'EXPECTED ERROR: More money is required to buy these items >>> ',
     );
-    t.rejects(
+    await t.throwsAsync(
       seat.getOfferResult(),
-      /More money.*is required to buy these items/,
+      { message: /More money.*is required to buy these items/ },
       'outcome from Joker should throw when trying to buy a ticket for 1 moola',
     );
 
@@ -398,11 +397,11 @@ test(`mint and sell opera tickets`, async t => {
       seat.getPayout('Money'),
     );
 
-    t.ok(
+    t.truthy(
       ticketAmountMath.isEmpty(jokerTicketPayoutAmount),
       'Joker should not receive ticket #2',
     );
-    t.deepEquals(
+    t.deepEqual(
       jokerMoneyPayoutAmount,
       insufficientAmount,
       'Joker should get a refund after trying to get ticket #2 for 1 moola',
@@ -431,20 +430,20 @@ test(`mint and sell opera tickets`, async t => {
     ).getAvailableItems();
 
     // Bob sees the currently available tickets
-    t.equal(
+    t.is(
       availableTickets.value.length,
       2,
       'Bob should see 2 available tickets',
     );
-    t.ok(
+    t.truthy(
       !availableTickets.value.find(ticket => ticket.number === 1),
       `availableTickets should NOT contain ticket number 1`,
     );
-    t.ok(
+    t.truthy(
       availableTickets.value.find(ticket => ticket.number === 2),
       `availableTickets should still contain ticket number 2`,
     );
-    t.ok(
+    t.truthy(
       availableTickets.value.find(ticket => ticket.number === 3),
       `availableTickets should still contain ticket number 3`,
     );
@@ -477,16 +476,12 @@ test(`mint and sell opera tickets`, async t => {
     const bobTicketAmount = await E(ticketIssuer).getAmountOf(
       seat.getPayout('Items'),
     );
-    t.equal(
-      bobTicketAmount.value.length,
-      2,
-      'Bob should have received 2 tickets',
-    );
-    t.ok(
+    t.is(bobTicketAmount.value.length, 2, 'Bob should have received 2 tickets');
+    t.truthy(
       bobTicketAmount.value.find(ticket => ticket.number === 2),
       'Bob should have received tickets #2',
     );
-    t.ok(
+    t.truthy(
       bobTicketAmount.value.find(ticket => ticket.number === 3),
       'Bob should have received tickets #3',
     );
@@ -500,7 +495,7 @@ test(`mint and sell opera tickets`, async t => {
     const availableTickets = await E(sellItemsCreatorFacet).getAvailableItems();
     const ticketIssuer = await E(sellItemsCreatorFacet).getItemsIssuer();
     const ticketAmountMath = await makeLocalAmountMath(ticketIssuer);
-    t.ok(
+    t.truthy(
       ticketAmountMath.isEmpty(availableTickets),
       'All the tickets have been sold',
     );
@@ -513,7 +508,7 @@ test(`mint and sell opera tickets`, async t => {
     await E(operaPurse).deposit(moneyPayment);
     const currentPurseBalance = await E(operaPurse).getCurrentAmount();
 
-    t.equal(
+    t.is(
       currentPurseBalance.value,
       3 * 22,
       `The Opera should get ${3 * 22} moolas from ticket sales`,
@@ -542,5 +537,4 @@ test(`mint and sell opera tickets`, async t => {
     moolaMint.mintPayment(moola(100)),
   );
   await ticketSellerClosesContract(sellItemsCreatorSeat, sellItemsCreatorFacet);
-  t.end();
 });

--- a/packages/zoe/test/unitTests/contracts/test-sellTickets.js
+++ b/packages/zoe/test/unitTests/contracts/test-sellTickets.js
@@ -307,9 +307,6 @@ test(`mint and sell opera tickets`, async t => {
       }),
     );
 
-    console.log(
-      'EXPECTED ERROR: Some of the wanted items were not available for sale >>>',
-    );
     await t.throwsAsync(
       seat.getOfferResult(),
       { message: /Some of the wanted items were not available for sale/ },
@@ -381,9 +378,6 @@ test(`mint and sell opera tickets`, async t => {
       }),
     );
 
-    console.log(
-      'EXPECTED ERROR: More money is required to buy these items >>> ',
-    );
     await t.throwsAsync(
       seat.getOfferResult(),
       { message: /More money.*is required to buy these items/ },

--- a/packages/zoe/test/unitTests/contracts/test-useObj.js
+++ b/packages/zoe/test/unitTests/contracts/test-useObj.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'tape-promise/tape';
+import test from 'ava';
 
 import bundleSource from '@agoric/bundle-source';
 
@@ -48,7 +48,7 @@ test('zoe - useObj', async t => {
 
   const useObj = await E(aliceSeat).getOfferResult();
 
-  t.equals(
+  t.is(
     useObj.colorPixels('purple'),
     `successfully colored 3 pixels purple`,
     `use of use object works`,
@@ -58,7 +58,7 @@ test('zoe - useObj', async t => {
 
   const aliceMoolaPayoutPayment = await E(aliceSeat).getPayout('Pixels');
 
-  t.deepEquals(
+  t.deepEqual(
     await moolaIssuer.getAmountOf(aliceMoolaPayoutPayment),
     moola(3),
     `alice gets everything she escrowed back`,
@@ -67,7 +67,7 @@ test('zoe - useObj', async t => {
   console.log('EXPECTED ERROR ->>>');
   t.throws(
     () => useObj.colorPixels('purple'),
-    /the escrowing offer is no longer active/,
+    { message: /the escrowing offer is no longer active/ },
     `use of use object fails once offer is withdrawn or amounts are reallocated`,
   );
 });

--- a/packages/zoe/test/unitTests/contracts/test-useObj.js
+++ b/packages/zoe/test/unitTests/contracts/test-useObj.js
@@ -64,7 +64,6 @@ test('zoe - useObj', async t => {
     `alice gets everything she escrowed back`,
   );
 
-  console.log('EXPECTED ERROR ->>>');
   t.throws(
     () => useObj.colorPixels('purple'),
     { message: /the escrowing offer is no longer active/ },

--- a/packages/zoe/test/unitTests/contracts/test-zcf.js
+++ b/packages/zoe/test/unitTests/contracts/test-zcf.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'tape-promise/tape';
+import test from 'ava';
 
 import bundleSource from '@agoric/bundle-source';
 
@@ -27,5 +27,7 @@ test('zoe - test zcf', async t => {
     Pixels: moolaIssuer,
     Money: simoleanIssuer,
   });
-  t.doesNotReject(() => zoe.startInstance(installation, issuerKeywordRecord));
+  await t.notThrowsAsync(() =>
+    zoe.startInstance(installation, issuerKeywordRecord),
+  );
 });

--- a/packages/zoe/test/unitTests/contracts/zcfTesterContract.js
+++ b/packages/zoe/test/unitTests/contracts/zcfTesterContract.js
@@ -5,7 +5,7 @@
  * @type {ContractStartFn}
  */
 const start = _zcf => {
-  // TODO: import tap/tape and do t.equals
+  // TODO: import tap/tape and do t.is
   // TODO: Test ZCF here
 
   return harden({});

--- a/packages/zoe/test/unitTests/test-cleanProposal.js
+++ b/packages/zoe/test/unitTests/test-cleanProposal.js
@@ -1,106 +1,92 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'tape-promise/tape';
+import test from 'ava';
 import makeStore from '@agoric/weak-store';
 import { cleanProposal } from '../../src/cleanProposal';
 import { setup } from './setupBasicMints';
 import buildManualTimer from '../../tools/manualTimer';
 
 test('cleanProposal test', t => {
-  t.plan(1);
-  try {
-    const { simoleanR, moolaR, bucksR, moola, simoleans } = setup();
+  const { simoleanR, moolaR, bucksR, moola, simoleans } = setup();
 
-    const brandToAmountMath = makeStore('brand');
-    brandToAmountMath.init(moolaR.brand, moolaR.amountMath);
-    brandToAmountMath.init(simoleanR.brand, simoleanR.amountMath);
-    brandToAmountMath.init(bucksR.brand, bucksR.amountMath);
+  const brandToAmountMath = makeStore('brand');
+  brandToAmountMath.init(moolaR.brand, moolaR.amountMath);
+  brandToAmountMath.init(simoleanR.brand, simoleanR.amountMath);
+  brandToAmountMath.init(bucksR.brand, bucksR.amountMath);
 
-    const getAmountMathForBrand = brandToAmountMath.get;
+  const getAmountMathForBrand = brandToAmountMath.get;
 
-    const proposal = harden({
-      give: { Asset: simoleans(1) },
-      want: { Price: moola(3) },
-    });
+  const proposal = harden({
+    give: { Asset: simoleans(1) },
+    want: { Price: moola(3) },
+  });
 
-    const expected = harden({
-      give: { Asset: simoleans(1) },
-      want: { Price: moola(3) },
-      exit: { onDemand: null },
-    });
+  const expected = harden({
+    give: { Asset: simoleans(1) },
+    want: { Price: moola(3) },
+    exit: { onDemand: null },
+  });
 
-    const actual = cleanProposal(getAmountMathForBrand, proposal);
+  const actual = cleanProposal(getAmountMathForBrand, proposal);
 
-    t.deepEquals(actual, expected);
-  } catch (e) {
-    t.assert(false, e);
-  }
+  t.deepEqual(actual, expected);
 });
 
 test('cleanProposal - all empty', t => {
-  t.plan(1);
-  try {
-    const { simoleanR, moolaR, bucksR } = setup();
+  const { simoleanR, moolaR, bucksR } = setup();
 
-    const brandToAmountMath = makeStore('brand');
-    brandToAmountMath.init(moolaR.brand, moolaR.amountMath);
-    brandToAmountMath.init(simoleanR.brand, simoleanR.amountMath);
-    brandToAmountMath.init(bucksR.brand, bucksR.amountMath);
+  const brandToAmountMath = makeStore('brand');
+  brandToAmountMath.init(moolaR.brand, moolaR.amountMath);
+  brandToAmountMath.init(simoleanR.brand, simoleanR.amountMath);
+  brandToAmountMath.init(bucksR.brand, bucksR.amountMath);
 
-    const getAmountMathForBrand = brandToAmountMath.get;
+  const getAmountMathForBrand = brandToAmountMath.get;
 
-    const proposal = harden({
-      give: {},
-      want: {},
-      exit: { waived: null },
-    });
+  const proposal = harden({
+    give: {},
+    want: {},
+    exit: { waived: null },
+  });
 
-    const expected = harden({
-      give: {},
-      want: {},
-      exit: { waived: null },
-    });
+  const expected = harden({
+    give: {},
+    want: {},
+    exit: { waived: null },
+  });
 
-    // cleanProposal no longer fills in empty keywords
-    t.deepEquals(cleanProposal(getAmountMathForBrand, proposal), expected);
-  } catch (e) {
-    t.assert(false, e);
-  }
+  // cleanProposal no longer fills in empty keywords
+  t.deepEqual(cleanProposal(getAmountMathForBrand, proposal), expected);
 });
 
 test('cleanProposal - repeated brands', t => {
   t.plan(3);
-  try {
-    const { simoleanR, moolaR, bucksR, moola, simoleans } = setup();
+  const { simoleanR, moolaR, bucksR, moola, simoleans } = setup();
 
-    const brandToAmountMath = makeStore('brand');
-    brandToAmountMath.init(moolaR.brand, moolaR.amountMath);
-    brandToAmountMath.init(simoleanR.brand, simoleanR.amountMath);
-    brandToAmountMath.init(bucksR.brand, bucksR.amountMath);
+  const brandToAmountMath = makeStore('brand');
+  brandToAmountMath.init(moolaR.brand, moolaR.amountMath);
+  brandToAmountMath.init(simoleanR.brand, simoleanR.amountMath);
+  brandToAmountMath.init(bucksR.brand, bucksR.amountMath);
 
-    const getAmountMathForBrand = brandToAmountMath.get;
-    const timer = buildManualTimer(console.log);
+  const getAmountMathForBrand = brandToAmountMath.get;
+  const timer = buildManualTimer(console.log);
 
-    const proposal = harden({
-      want: { Asset2: simoleans(1) },
-      give: { Price2: moola(3) },
-      exit: { afterDeadline: { timer, deadline: 100 } },
-    });
+  const proposal = harden({
+    want: { Asset2: simoleans(1) },
+    give: { Price2: moola(3) },
+    exit: { afterDeadline: { timer, deadline: 100 } },
+  });
 
-    const expected = harden({
-      want: {
-        Asset2: simoleans(1),
-      },
-      give: { Price2: moola(3) },
-      exit: { afterDeadline: { timer, deadline: 100 } },
-    });
-    // cleanProposal no longer fills in empty keywords
-    const actual = cleanProposal(getAmountMathForBrand, proposal);
-    t.deepEquals(actual.want, expected.want);
-    t.deepEquals(actual.give, expected.give);
-    t.deepEquals(actual.exit, expected.exit);
-  } catch (e) {
-    t.assert(false, e);
-  }
+  const expected = harden({
+    want: {
+      Asset2: simoleans(1),
+    },
+    give: { Price2: moola(3) },
+    exit: { afterDeadline: { timer, deadline: 100 } },
+  });
+  // cleanProposal no longer fills in empty keywords
+  const actual = cleanProposal(getAmountMathForBrand, proposal);
+  t.deepEqual(actual.want, expected.want);
+  t.deepEqual(actual.give, expected.give);
+  t.deepEqual(actual.exit, expected.exit);
 });

--- a/packages/zoe/test/unitTests/test-objArrayConversion.js
+++ b/packages/zoe/test/unitTests/test-objArrayConversion.js
@@ -1,31 +1,27 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'tape-promise/tape';
+import test from 'ava';
 
 import { arrayToObj } from '../../src/objArrayConversion';
 
 test('arrayToObj', t => {
   t.plan(3);
-  try {
-    const keywords = ['X', 'Y'];
-    const array = [1, 2];
-    t.deepEquals(arrayToObj(array, keywords), { X: 1, Y: 2 });
+  const keywords = ['X', 'Y'];
+  const array = [1, 2];
+  t.deepEqual(arrayToObj(array, keywords), { X: 1, Y: 2 });
 
-    const keywords2 = ['X', 'Y', 'Z'];
-    t.throws(
-      () => arrayToObj(array, keywords2),
-      /Error: array and keys must be of equal length/,
-      `unequal length should throw`,
-    );
+  const keywords2 = ['X', 'Y', 'Z'];
+  t.throws(
+    () => arrayToObj(array, keywords2),
+    { message: 'array and keys must be of equal length' },
+    `unequal length should throw`,
+  );
 
-    const array2 = [4, 5, 2];
-    t.throws(
-      () => arrayToObj(array2, keywords),
-      /Error: array and keys must be of equal length/,
-      `unequal length should throw`,
-    );
-  } catch (e) {
-    t.assert(false, e);
-  }
+  const array2 = [4, 5, 2];
+  t.throws(
+    () => arrayToObj(array2, keywords),
+    { message: 'array and keys must be of equal length' },
+    `unequal length should throw`,
+  );
 });

--- a/packages/zoe/test/unitTests/test-offerSafety.js
+++ b/packages/zoe/test/unitTests/test-offerSafety.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 
 import '@agoric/install-ses';
-import { test } from 'tape-promise/tape';
+import test from 'ava';
 
 import { isOfferSafe } from '../../src/contractFacet/offerSafety';
 import { setup } from './setupBasicMints';
@@ -30,216 +30,166 @@ function makeGetAmountMath(mapping) {
 
 // more than want, more than give -> isOfferSafe() = true
 test('isOfferSafe - more than want, more than give', t => {
-  t.plan(1);
-  try {
-    const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
-    const getAmountMath = makeGetAmountMath([
-      [moolaR.brand, moolaR.amountMath],
-      [simoleanR.brand, simoleanR.amountMath],
-      [bucksR.brand, bucksR.amountMath],
-    ]);
-    const proposal = harden({
-      give: { A: moola(8) },
-      want: { B: simoleans(6), C: bucks(7) },
-    });
-    const amounts = harden({ A: moola(10), B: simoleans(7), C: bucks(8) });
+  const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
+  const getAmountMath = makeGetAmountMath([
+    [moolaR.brand, moolaR.amountMath],
+    [simoleanR.brand, simoleanR.amountMath],
+    [bucksR.brand, bucksR.amountMath],
+  ]);
+  const proposal = harden({
+    give: { A: moola(8) },
+    want: { B: simoleans(6), C: bucks(7) },
+  });
+  const amounts = harden({ A: moola(10), B: simoleans(7), C: bucks(8) });
 
-    t.ok(isOfferSafe(getAmountMath, proposal, amounts));
-  } catch (e) {
-    t.assert(false, e);
-  }
+  t.truthy(isOfferSafe(getAmountMath, proposal, amounts));
 });
 
 // more than want, less than give -> true
 test('isOfferSafe - more than want, less than give', t => {
-  t.plan(1);
-  try {
-    const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
-    const getAmountMath = makeGetAmountMath([
-      [moolaR.brand, moolaR.amountMath],
-      [simoleanR.brand, simoleanR.amountMath],
-      [bucksR.brand, bucksR.amountMath],
-    ]);
-    const proposal = harden({
-      give: { A: moola(8) },
-      want: { B: simoleans(6), C: bucks(7) },
-    });
-    const amounts = harden({ A: moola(1), B: simoleans(7), C: bucks(8) });
+  const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
+  const getAmountMath = makeGetAmountMath([
+    [moolaR.brand, moolaR.amountMath],
+    [simoleanR.brand, simoleanR.amountMath],
+    [bucksR.brand, bucksR.amountMath],
+  ]);
+  const proposal = harden({
+    give: { A: moola(8) },
+    want: { B: simoleans(6), C: bucks(7) },
+  });
+  const amounts = harden({ A: moola(1), B: simoleans(7), C: bucks(8) });
 
-    t.ok(isOfferSafe(getAmountMath, proposal, amounts));
-  } catch (e) {
-    t.assert(false, e);
-  }
+  t.truthy(isOfferSafe(getAmountMath, proposal, amounts));
 });
 
 // more than want, equal to give -> true
 test('isOfferSafe - more than want, equal to give', t => {
-  t.plan(1);
-  try {
-    const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
-    const getAmountMath = makeGetAmountMath([
-      [moolaR.brand, moolaR.amountMath],
-      [simoleanR.brand, simoleanR.amountMath],
-      [bucksR.brand, bucksR.amountMath],
-    ]);
-    const proposal = harden({
-      want: { A: moola(8) },
-      give: { B: simoleans(6), C: bucks(7) },
-    });
-    const amounts = harden({ A: moola(9), B: simoleans(6), C: bucks(7) });
+  const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
+  const getAmountMath = makeGetAmountMath([
+    [moolaR.brand, moolaR.amountMath],
+    [simoleanR.brand, simoleanR.amountMath],
+    [bucksR.brand, bucksR.amountMath],
+  ]);
+  const proposal = harden({
+    want: { A: moola(8) },
+    give: { B: simoleans(6), C: bucks(7) },
+  });
+  const amounts = harden({ A: moola(9), B: simoleans(6), C: bucks(7) });
 
-    t.ok(isOfferSafe(getAmountMath, proposal, amounts));
-  } catch (e) {
-    t.assert(false, e);
-  }
+  t.truthy(isOfferSafe(getAmountMath, proposal, amounts));
 });
 
 // less than want, more than give -> true
 test('isOfferSafe - less than want, more than give', t => {
-  t.plan(1);
-  try {
-    const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
-    const getAmountMath = makeGetAmountMath([
-      [moolaR.brand, moolaR.amountMath],
-      [simoleanR.brand, simoleanR.amountMath],
-      [bucksR.brand, bucksR.amountMath],
-    ]);
-    const proposal = harden({
-      want: { A: moola(8) },
-      give: { B: simoleans(6), C: bucks(7) },
-    });
-    const amounts = harden({ A: moola(7), B: simoleans(9), C: bucks(19) });
+  const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
+  const getAmountMath = makeGetAmountMath([
+    [moolaR.brand, moolaR.amountMath],
+    [simoleanR.brand, simoleanR.amountMath],
+    [bucksR.brand, bucksR.amountMath],
+  ]);
+  const proposal = harden({
+    want: { A: moola(8) },
+    give: { B: simoleans(6), C: bucks(7) },
+  });
+  const amounts = harden({ A: moola(7), B: simoleans(9), C: bucks(19) });
 
-    t.ok(isOfferSafe(getAmountMath, proposal, amounts));
-  } catch (e) {
-    t.assert(false, e);
-  }
+  t.truthy(isOfferSafe(getAmountMath, proposal, amounts));
 });
 
 // less than want, less than give -> false
 test('isOfferSafe - less than want, less than give', t => {
-  t.plan(1);
-  try {
-    const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
-    const getAmountMath = makeGetAmountMath([
-      [moolaR.brand, moolaR.amountMath],
-      [simoleanR.brand, simoleanR.amountMath],
-      [bucksR.brand, bucksR.amountMath],
-    ]);
-    const proposal = harden({
-      want: { A: moola(8) },
-      give: { B: simoleans(6), C: bucks(7) },
-    });
-    const amounts = harden({ A: moola(7), B: simoleans(5), C: bucks(6) });
+  const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
+  const getAmountMath = makeGetAmountMath([
+    [moolaR.brand, moolaR.amountMath],
+    [simoleanR.brand, simoleanR.amountMath],
+    [bucksR.brand, bucksR.amountMath],
+  ]);
+  const proposal = harden({
+    want: { A: moola(8) },
+    give: { B: simoleans(6), C: bucks(7) },
+  });
+  const amounts = harden({ A: moola(7), B: simoleans(5), C: bucks(6) });
 
-    t.notOk(isOfferSafe(getAmountMath, proposal, amounts));
-  } catch (e) {
-    t.assert(false, e);
-  }
+  t.falsy(isOfferSafe(getAmountMath, proposal, amounts));
 });
 
 // less than want, equal to give -> true
 test('isOfferSafe - less than want, equal to give', t => {
-  t.plan(1);
-  try {
-    const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
-    const getAmountMath = makeGetAmountMath([
-      [moolaR.brand, moolaR.amountMath],
-      [simoleanR.brand, simoleanR.amountMath],
-      [bucksR.brand, bucksR.amountMath],
-    ]);
-    const proposal = harden({
-      want: { B: simoleans(6) },
-      give: { A: moola(1), C: bucks(7) },
-    });
-    const amounts = harden({ A: moola(1), B: simoleans(5), C: bucks(7) });
+  const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
+  const getAmountMath = makeGetAmountMath([
+    [moolaR.brand, moolaR.amountMath],
+    [simoleanR.brand, simoleanR.amountMath],
+    [bucksR.brand, bucksR.amountMath],
+  ]);
+  const proposal = harden({
+    want: { B: simoleans(6) },
+    give: { A: moola(1), C: bucks(7) },
+  });
+  const amounts = harden({ A: moola(1), B: simoleans(5), C: bucks(7) });
 
-    t.ok(isOfferSafe(getAmountMath, proposal, amounts));
-  } catch (e) {
-    t.assert(false, e);
-  }
+  t.truthy(isOfferSafe(getAmountMath, proposal, amounts));
 });
 
 // equal to want, more than give -> true
 test('isOfferSafe - equal to want, more than give', t => {
-  t.plan(1);
-  try {
-    const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
-    const getAmountMath = makeGetAmountMath([
-      [moolaR.brand, moolaR.amountMath],
-      [simoleanR.brand, simoleanR.amountMath],
-      [bucksR.brand, bucksR.amountMath],
-    ]);
-    const proposal = harden({
-      want: { B: simoleans(6) },
-      give: { A: moola(1), C: bucks(7) },
-    });
-    const amounts = harden({ A: moola(2), B: simoleans(6), C: bucks(8) });
+  const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
+  const getAmountMath = makeGetAmountMath([
+    [moolaR.brand, moolaR.amountMath],
+    [simoleanR.brand, simoleanR.amountMath],
+    [bucksR.brand, bucksR.amountMath],
+  ]);
+  const proposal = harden({
+    want: { B: simoleans(6) },
+    give: { A: moola(1), C: bucks(7) },
+  });
+  const amounts = harden({ A: moola(2), B: simoleans(6), C: bucks(8) });
 
-    t.ok(isOfferSafe(getAmountMath, proposal, amounts));
-  } catch (e) {
-    t.assert(false, e);
-  }
+  t.truthy(isOfferSafe(getAmountMath, proposal, amounts));
 });
 
 // equal to want, less than give -> true
 test('isOfferSafe - equal to want, less than give', t => {
-  t.plan(1);
-  try {
-    const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
-    const getAmountMath = makeGetAmountMath([
-      [moolaR.brand, moolaR.amountMath],
-      [simoleanR.brand, simoleanR.amountMath],
-      [bucksR.brand, bucksR.amountMath],
-    ]);
-    const proposal = harden({
-      want: { B: simoleans(6) },
-      give: { A: moola(1), C: bucks(7) },
-    });
-    const amounts = harden({ A: moola(0), B: simoleans(6), C: bucks(0) });
+  const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
+  const getAmountMath = makeGetAmountMath([
+    [moolaR.brand, moolaR.amountMath],
+    [simoleanR.brand, simoleanR.amountMath],
+    [bucksR.brand, bucksR.amountMath],
+  ]);
+  const proposal = harden({
+    want: { B: simoleans(6) },
+    give: { A: moola(1), C: bucks(7) },
+  });
+  const amounts = harden({ A: moola(0), B: simoleans(6), C: bucks(0) });
 
-    t.ok(isOfferSafe(getAmountMath, proposal, amounts));
-  } catch (e) {
-    t.assert(false, e);
-  }
+  t.truthy(isOfferSafe(getAmountMath, proposal, amounts));
 });
 
 // equal to want, equal to give -> true
 test('isOfferSafe - equal to want, equal to give', t => {
-  t.plan(1);
-  try {
-    const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
-    const getAmountMath = makeGetAmountMath([
-      [moolaR.brand, moolaR.amountMath],
-      [simoleanR.brand, simoleanR.amountMath],
-      [bucksR.brand, bucksR.amountMath],
-    ]);
-    const proposal = harden({
-      want: { B: simoleans(6) },
-      give: { A: moola(1), C: bucks(7) },
-    });
-    const amounts = harden({ A: moola(1), B: simoleans(6), C: bucks(7) });
+  const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
+  const getAmountMath = makeGetAmountMath([
+    [moolaR.brand, moolaR.amountMath],
+    [simoleanR.brand, simoleanR.amountMath],
+    [bucksR.brand, bucksR.amountMath],
+  ]);
+  const proposal = harden({
+    want: { B: simoleans(6) },
+    give: { A: moola(1), C: bucks(7) },
+  });
+  const amounts = harden({ A: moola(1), B: simoleans(6), C: bucks(7) });
 
-    t.ok(isOfferSafe(getAmountMath, proposal, amounts));
-  } catch (e) {
-    t.assert(false, e);
-  }
+  t.truthy(isOfferSafe(getAmountMath, proposal, amounts));
 });
 
 test('isOfferSafe - empty proposal', t => {
-  t.plan(1);
-  try {
-    const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
-    const getAmountMath = makeGetAmountMath([
-      [moolaR.brand, moolaR.amountMath],
-      [simoleanR.brand, simoleanR.amountMath],
-      [bucksR.brand, bucksR.amountMath],
-    ]);
-    const proposal = harden({ give: {}, want: {} });
-    const amounts = harden({ A: moola(1), B: simoleans(6), C: bucks(7) });
+  const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
+  const getAmountMath = makeGetAmountMath([
+    [moolaR.brand, moolaR.amountMath],
+    [simoleanR.brand, simoleanR.amountMath],
+    [bucksR.brand, bucksR.amountMath],
+  ]);
+  const proposal = harden({ give: {}, want: {} });
+  const amounts = harden({ A: moola(1), B: simoleans(6), C: bucks(7) });
 
-    t.ok(isOfferSafe(getAmountMath, proposal, amounts));
-  } catch (e) {
-    t.assert(false, e);
-  }
+  t.truthy(isOfferSafe(getAmountMath, proposal, amounts));
 });

--- a/packages/zoe/test/unitTests/test-rightsConservation.js
+++ b/packages/zoe/test/unitTests/test-rightsConservation.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'tape-promise/tape';
+import test from 'ava';
 
 import makeStore from '@agoric/weak-store';
 import { makeIssuerKit } from '@agoric/ertp';
@@ -30,78 +30,62 @@ const makeAmountMatrix = (amountMathArray, valueMatrix) =>
 
 // rights are conserved for amount with Nat values
 test(`assertRightsConserved - true for amount with nat values`, t => {
-  t.plan(1);
-  try {
-    const { amountMathArray, getAmountMathForBrand } = setupAmountMaths();
-    const previousValues = [
-      [0, 1, 0],
-      [4, 1, 0],
-      [6, 3, 0],
-    ];
-    const newValues = [
-      [1, 2, 0],
-      [3, 1, 0],
-      [6, 2, 0],
-    ];
+  const { amountMathArray, getAmountMathForBrand } = setupAmountMaths();
+  const previousValues = [
+    [0, 1, 0],
+    [4, 1, 0],
+    [6, 3, 0],
+  ];
+  const newValues = [
+    [1, 2, 0],
+    [3, 1, 0],
+    [6, 2, 0],
+  ];
 
-    const previousAmounts = makeAmountMatrix(
-      amountMathArray,
-      previousValues,
-    ).flat();
-    const newAmounts = makeAmountMatrix(amountMathArray, newValues).flat();
+  const previousAmounts = makeAmountMatrix(
+    amountMathArray,
+    previousValues,
+  ).flat();
+  const newAmounts = makeAmountMatrix(amountMathArray, newValues).flat();
 
-    t.doesNotThrow(() =>
-      assertRightsConserved(getAmountMathForBrand, previousAmounts, newAmounts),
-    );
-  } catch (e) {
-    t.assert(false, e);
-  }
+  t.notThrows(() =>
+    assertRightsConserved(getAmountMathForBrand, previousAmounts, newAmounts),
+  );
 });
 
 // rights are *not* conserved for amount with Nat values
 test(`assertRightsConserved - false for amount with Nat values`, t => {
-  t.plan(1);
-  try {
-    const { amountMathArray, getAmountMathForBrand } = setupAmountMaths();
-    const oldValues = [
-      [0, 1, 4],
-      [4, 1, 0],
-      [6, 3, 0],
-    ];
-    const newValues = [
-      [1, 2, 0],
-      [3, 1, 0],
-      [6, 2, 0],
-    ];
+  const { amountMathArray, getAmountMathForBrand } = setupAmountMaths();
+  const oldValues = [
+    [0, 1, 4],
+    [4, 1, 0],
+    [6, 3, 0],
+  ];
+  const newValues = [
+    [1, 2, 0],
+    [3, 1, 0],
+    [6, 2, 0],
+  ];
 
-    const oldAmounts = makeAmountMatrix(amountMathArray, oldValues).flat();
-    const newAmounts = makeAmountMatrix(amountMathArray, newValues).flat();
+  const oldAmounts = makeAmountMatrix(amountMathArray, oldValues).flat();
+  const newAmounts = makeAmountMatrix(amountMathArray, newValues).flat();
 
-    console.log('ERROR EXPECTED: rights were not conserved for brand >>>');
-    t.throws(
-      () =>
-        assertRightsConserved(getAmountMathForBrand, oldAmounts, newAmounts),
-      /rights were not conserved for brand/,
-      `should throw if rights aren't conserved`,
-    );
-  } catch (e) {
-    t.assert(false, e);
-  }
+  console.log('ERROR EXPECTED: rights were not conserved for brand >>>');
+  t.throws(
+    () => assertRightsConserved(getAmountMathForBrand, oldAmounts, newAmounts),
+    { message: /rights were not conserved for brand/ },
+    `should throw if rights aren't conserved`,
+  );
 });
 
 test(`assertRightsConserved - empty arrays`, t => {
-  t.plan(1);
-  try {
-    const { getAmountMathForBrand } = setupAmountMaths();
-    const oldAmounts = [];
-    const newAmounts = [];
+  const { getAmountMathForBrand } = setupAmountMaths();
+  const oldAmounts = [];
+  const newAmounts = [];
 
-    t.doesNotThrow(() =>
-      assertRightsConserved(getAmountMathForBrand, oldAmounts, newAmounts),
-    );
-  } catch (e) {
-    t.assert(false, e);
-  }
+  t.notThrows(() =>
+    assertRightsConserved(getAmountMathForBrand, oldAmounts, newAmounts),
+  );
 });
 
 // TODO: add tests for non-Nat values

--- a/packages/zoe/test/unitTests/test-rightsConservation.js
+++ b/packages/zoe/test/unitTests/test-rightsConservation.js
@@ -70,7 +70,6 @@ test(`assertRightsConserved - false for amount with Nat values`, t => {
   const oldAmounts = makeAmountMatrix(amountMathArray, oldValues).flat();
   const newAmounts = makeAmountMatrix(amountMathArray, newValues).flat();
 
-  console.log('ERROR EXPECTED: rights were not conserved for brand >>>');
   t.throws(
     () => assertRightsConserved(getAmountMathForBrand, oldAmounts, newAmounts),
     { message: /rights were not conserved for brand/ },

--- a/packages/zoe/test/zoeTestHelpers.js
+++ b/packages/zoe/test/zoeTestHelpers.js
@@ -4,7 +4,7 @@ import '../exported';
 
 export const assertPayoutAmount = (t, issuer, payout, expectedAmount) => {
   issuer.getAmountOf(payout).then(amount => {
-    t.deepEquals(amount, expectedAmount, `payout was ${amount.value}`);
+    t.deepEqual(amount, expectedAmount, `payout was ${amount.value}`);
   });
 };
 
@@ -13,7 +13,7 @@ export const assertPayoutDeposit = (t, payout, purse, amount) => {
     E(purse)
       .deposit(payment)
       .then(payoutAmount => {
-        t.deepEquals(
+        t.deepEqual(
           payoutAmount,
           amount,
           `payout was ${payoutAmount.value}, expected ${amount}.value`,
@@ -26,7 +26,7 @@ export const assertOfferResult = (t, seat, expected, msg = expected) => {
   E(seat)
     .getOfferResult()
     .then(
-      result => t.equals(result, expected, msg),
+      result => t.is(result, expected, msg),
       e => t.fail(`expecting offer result to be ${expected}, ${e}`),
     );
 };
@@ -36,6 +36,4 @@ export const assertRejectedOfferResult = (
   seat,
   expected,
   msg = `offer result rejects as expected`,
-) => {
-  t.rejects(() => E(seat).getOfferResult(), expected, msg);
-};
+) => t.throwsAsync(() => E(seat).getOfferResult(), expected, msg);


### PR DESCRIPTION
I'd like to remove the console.error() logging from `@agoric/assert`. If we do that, we can remove a number of messages that are there to assure whoever is looking at the test output that the logged errors are intended. Is there a good reason to keep this in?