### PR TITLE
Update exchange benchmark to re-use simpleExchange contract

### DIFF
--- a/packages/swingset-runner/demo/exchangeBenchmark/bootstrap.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/bootstrap.js
@@ -1,61 +1,8 @@
 import { makeIssuerKit } from '@agoric/ertp';
 import { E } from '@agoric/eventual-send';
-import { makePrintLog } from './printLog';
 
 /* eslint-disable-next-line import/no-unresolved, import/extensions */
-import simpleExchangeBundle from './bundle-simpleExchange';
-
-const log = makePrintLog();
-
-function setupBasicMints() {
-  // prettier-ignore
-  const all = [
-    makeIssuerKit('moola'),
-    makeIssuerKit('simoleans'),
-  ];
-  const mints = all.map(objs => objs.mint);
-  const issuers = all.map(objs => objs.issuer);
-  const amountMaths = all.map(objs => objs.amountMath);
-
-  return harden({
-    mints,
-    issuers,
-    amountMaths,
-  });
-}
-
-function makeVats(vats, zoe, installations, startingValues) {
-  const { mints, issuers, amountMaths } = setupBasicMints();
-  // prettier-ignore
-  function makePayments(values) {
-    return mints.map((mint, i) => mint.mintPayment(amountMaths[i].make(values[i])));
-  }
-  const [aliceValues, bobValues] = startingValues;
-
-  // Setup Alice
-  const alice = E(vats.alice).build(
-    zoe,
-    issuers,
-    makePayments(aliceValues),
-    installations,
-  );
-
-  // Setup Bob
-  const bob = E(vats.bob).build(
-    zoe,
-    issuers,
-    makePayments(bobValues),
-    installations,
-  );
-
-  const result = {
-    alice,
-    bob,
-  };
-
-  log(`=> alice and bob are set up`);
-  return harden(result);
-}
+import exchangeBundle from './bundle-simpleExchange';
 
 export function buildRootObject(_vatPowers, vatParameters) {
   let alice;
@@ -68,27 +15,50 @@ export function buildRootObject(_vatPowers, vatParameters) {
       );
       const zoe = await E(vats.zoe).buildZoe(vatAdminSvc);
 
-      const installations = {
-        simpleExchange: await E(zoe).install(simpleExchangeBundle.bundle),
-      };
+      const exchange = await E(zoe).install(exchangeBundle.bundle);
 
-      const startingValues = [
+      const grubStake = [
         [3, 0], // Alice: 3 moola, no simoleans
         [0, 3], // Bob:   no moola, 3 simoleans
       ];
 
-      ({ alice, bob } = makeVats(vats, zoe, installations, startingValues));
+      const all = [makeIssuerKit('moola'), makeIssuerKit('simoleans')];
+      const mints = all.map(objs => objs.mint);
+      const issuers = all.map(objs => objs.issuer);
+      const amountMaths = all.map(objs => objs.amountMath);
+
+      function makePayments(values) {
+        return mints.map((mint, i) =>
+          mint.mintPayment(amountMaths[i].make(values[i])),
+        );
+      }
+
+      const [alicePayments, bobPayments] = grubStake.map(v => makePayments(v));
+
+      const [moolaIssuer, simoleanIssuer] = issuers;
+      const issuerKeywordRecord = harden({
+        Price: simoleanIssuer,
+        Asset: moolaIssuer,
+      });
+      const { publicFacet } = await E(zoe).startInstance(
+        exchange,
+        issuerKeywordRecord,
+      );
+
+      alice = E(vats.alice).build(zoe, issuers, alicePayments, publicFacet);
+      bob = E(vats.bob).build(zoe, issuers, bobPayments, publicFacet);
+
       // Zoe appears to do some one-time setup the first time it's used, so this
-      // is a sacrifical benchmark round to prime the pump.
+      // is an optional, sacrifical benchmark round to prime the pump.
       if (vatParameters.argv[0] === '--prime') {
-        await E(alice).initiateSimpleExchange(bob);
-        await E(bob).initiateSimpleExchange(alice);
+        await E(alice).initiateTrade(bob);
+        await E(bob).initiateTrade(alice);
       }
     },
     async runBenchmarkRound() {
       round += 1;
-      await E(alice).initiateSimpleExchange(bob);
-      await E(bob).initiateSimpleExchange(alice);
+      await E(alice).initiateTrade(bob);
+      await E(bob).initiateTrade(alice);
       return `round ${round} complete`;
     },
   });

--- a/packages/swingset-runner/demo/exchangeBenchmark/exchanger.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/exchanger.js
@@ -13,22 +13,17 @@ const log = makePrintLog();
  * @param {ZoeService} zoe
  * @param {Issuer[]} issuers
  * @param {Payment[]} payments
- * @param {Record<string,Installation>} installations
+ * @param {{ makeInvitation: () => Invitation }} publicAPI
  */
-async function build(name, zoe, issuers, payments, installations) {
+async function build(name, zoe, issuers, payments, publicAPI) {
   const { moola, simoleans, purses } = await setupPurses(
     zoe,
     issuers,
     payments,
   );
   const [moolaPurseP, simoleanPurseP] = purses;
-  const [moolaIssuer, simoleanIssuer] = issuers;
-  const issuerKeywordRecord = harden({
-    Price: simoleanIssuer,
-    Asset: moolaIssuer,
-  });
-  const inviteIssuer = await E(zoe).getInvitationIssuer();
-  const { simpleExchange } = installations;
+
+  const invitationIssuer = await E(zoe).getInvitationIssuer();
 
   async function preReport() {
     await showPurseBalance(moolaPurseP, `${name} moola before`, log);
@@ -49,16 +44,10 @@ async function build(name, zoe, issuers, payments, installations) {
     await E(simoleanPurseP).deposit(simoleanPayout);
   }
 
-  async function initiateSimpleExchange(otherP) {
+  async function initiateTrade(otherP) {
     await preReport();
 
-    const { publicFacet } = await E(zoe).startInstance(
-      simpleExchange,
-      issuerKeywordRecord,
-    );
-    const publicAPI = /** @type {{ makeInvitation: () => Invitation }} */ (publicFacet);
-
-    const addOrderInvite = await E(publicAPI).makeInvitation();
+    const addOrderInvitation = await E(publicAPI).makeInvitation();
 
     const mySellOrderProposal = harden({
       give: { Asset: moola(1) },
@@ -69,24 +58,24 @@ async function build(name, zoe, issuers, payments, installations) {
       Asset: await E(moolaPurseP).withdraw(moola(1)),
     };
     const seat = await E(zoe).offer(
-      addOrderInvite,
+      addOrderInvitation,
       mySellOrderProposal,
       paymentKeywordRecord,
     );
     const payoutP = E(seat).getPayouts();
 
-    const inviteP = E(publicAPI).makeInvitation();
-    await E(otherP).respondToSimpleExchange(inviteP);
+    const invitationP = E(publicAPI).makeInvitation();
+    await E(otherP).respondToTrade(invitationP);
 
     await receivePayout(payoutP);
     await postReport();
   }
 
-  async function respondToSimpleExchange(inviteP) {
+  async function respondToTrade(invitationP) {
     await preReport();
 
-    const invite = await inviteP;
-    const exclInvite = await E(inviteIssuer).claim(invite);
+    const invitation = await invitationP;
+    const exclInvitation = await E(invitationIssuer).claim(invitation);
 
     const myBuyOrderProposal = harden({
       want: { Asset: moola(1) },
@@ -98,7 +87,7 @@ async function build(name, zoe, issuers, payments, installations) {
     };
 
     const seatP = await E(zoe).offer(
-      exclInvite,
+      exclInvitation,
       myBuyOrderProposal,
       paymentKeywordRecord,
     );
@@ -109,14 +98,14 @@ async function build(name, zoe, issuers, payments, installations) {
   }
 
   return harden({
-    initiateSimpleExchange,
-    respondToSimpleExchange,
+    initiateTrade,
+    respondToTrade,
   });
 }
 
-export function buildRootObjectCommon(name, _vatPowers) {
+export function buildRootObject(_vatPowers, vatParameters) {
   return harden({
-    build: (zoe, issuers, payments, installations) =>
-      build(name, zoe, issuers, payments, installations),
+    build: (zoe, issuers, payments, publicAPI) =>
+      build(vatParameters.name, zoe, issuers, payments, publicAPI),
   });
 }

--- a/packages/swingset-runner/demo/exchangeBenchmark/exchanger.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/exchanger.js
@@ -13,9 +13,9 @@ const log = makePrintLog();
  * @param {ZoeService} zoe
  * @param {Issuer[]} issuers
  * @param {Payment[]} payments
- * @param {{ makeInvitation: () => Invitation }} publicAPI
+ * @param {{ makeInvitation: () => Invitation }} publicFacet
  */
-async function build(name, zoe, issuers, payments, publicAPI) {
+async function build(name, zoe, issuers, payments, publicFacet) {
   const { moola, simoleans, purses } = await setupPurses(
     zoe,
     issuers,
@@ -47,7 +47,7 @@ async function build(name, zoe, issuers, payments, publicAPI) {
   async function initiateTrade(otherP) {
     await preReport();
 
-    const addOrderInvitation = await E(publicAPI).makeInvitation();
+    const addOrderInvitation = await E(publicFacet).makeInvitation();
 
     const mySellOrderProposal = harden({
       give: { Asset: moola(1) },
@@ -64,7 +64,7 @@ async function build(name, zoe, issuers, payments, publicAPI) {
     );
     const payoutP = E(seat).getPayouts();
 
-    const invitationP = E(publicAPI).makeInvitation();
+    const invitationP = E(publicFacet).makeInvitation();
     await E(otherP).respondToTrade(invitationP);
 
     await receivePayout(payoutP);
@@ -105,7 +105,7 @@ async function build(name, zoe, issuers, payments, publicAPI) {
 
 export function buildRootObject(_vatPowers, vatParameters) {
   return harden({
-    build: (zoe, issuers, payments, publicAPI) =>
-      build(vatParameters.name, zoe, issuers, payments, publicAPI),
+    build: (zoe, issuers, payments, publicFacet) =>
+      build(vatParameters.name, zoe, issuers, payments, publicFacet),
   });
 }

--- a/packages/swingset-runner/demo/exchangeBenchmark/helpers.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/helpers.js
@@ -33,11 +33,6 @@ export async function setupPurses(zoe, issuers, payments) {
   const simoleans = simoleanAmountMath.make;
 
   return harden({
-    issuers: harden([moolaIssuer, simoleanIssuer]),
-    moolaIssuer,
-    simoleanIssuer,
-    moolaAmountMath,
-    simoleanAmountMath,
     moola,
     simoleans,
     purses,

--- a/packages/swingset-runner/demo/exchangeBenchmark/swingset.json
+++ b/packages/swingset-runner/demo/exchangeBenchmark/swingset.json
@@ -7,10 +7,16 @@
   },
   "vats": {
     "alice": {
-      "sourceSpec": "vat-alice.js"
+      "sourceSpec": "exchanger.js",
+      "parameters": {
+        "name": "alice"
+      }
     },
     "bob": {
-      "sourceSpec": "vat-bob.js"
+      "sourceSpec": "exchanger.js",
+      "parameters": {
+        "name": "bob"
+      }
     },
     "zoe": {
       "sourceSpec": "vat-zoe.js",

--- a/packages/swingset-runner/demo/exchangeBenchmark/vat-alice.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/vat-alice.js
@@ -1,5 +1,0 @@
-import { buildRootObjectCommon } from './exchanger';
-
-export function buildRootObject(vatPowers) {
-  return buildRootObjectCommon('alice', vatPowers);
-}

--- a/packages/swingset-runner/demo/exchangeBenchmark/vat-bob.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/vat-bob.js
@@ -1,5 +1,0 @@
-import { buildRootObjectCommon } from './exchanger';
-
-export function buildRootObject(vatPowers) {
-  return buildRootObjectCommon('bob', vatPowers);
-}


### PR DESCRIPTION
The swingset-runner performance benchmark `exchangeBenchmark` had been generating a new instance of the `simpleExchange` contract for each act of exchange, which I've learned was Wrong.  It's been updated to create a single instance of `simpleExchange` as part of its setup and then keep using this one contract for the duration of the benchmark.  The code has also been considerably simplified (boiling it down from its ancestry which was much, much more generalized) as part of the exercise of figuring out how to alter it from one-contract-per-trade to one contract ever.