### PR TITLE
fix: fix rather big bug in how exitAllSeats works

### DIFF
--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -83,11 +83,12 @@
  * request by the contract for an "empty" seat.
  *
  * @typedef {Object} InstanceAdmin
+ * @property {(zoeSeatAdmin: ZoeSeatAdmin) => Set<ZoeSeatAdmin>} addZoeSeatAdmin
  * @property {(invitationHandle: InvitationHandle,
  *             zoeSeatAdmin: ZoeSeatAdmin,
  *             seatData: SeatData,
  *             seatHandle: SeatHandle,
- *            ) => Promise<AddSeatResult>} addZoeSeatAdmin
+ *            ) => Promise<AddSeatResult>} tellZCFToMakeSeat
  * @property {(zoeSeatAdmin: ZoeSeatAdmin) => boolean} hasZoeSeatAdmin
  * @property {(zoeSeatAdmin: ZoeSeatAdmin) => void} removeZoeSeatAdmin
  * @property {() => Instance} getInstance


### PR DESCRIPTION
Zoe was exiting all seats on instance shutdown. Now only exits the seats for a particular instance.

#1472 depends on this fix to pass CI tests.