### PR TITLE
fix: minor: rearrange asserts in Remotable

### DIFF
--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -83,7 +83,7 @@ function build(
       // remote === presence, actually
 
       // todo: mfig says to swap remote and presence (resolveWithPresence
-      // gives us a Presence, Remoteable gives us a Remote). I think that
+      // gives us a Presence, Remotable gives us a Remote). I think that
       // implies we have a lot of renaming to do, 'makeRemote' instead of
       // 'makeImportedPresence', etc. I'd like to defer that for a later
       // cleanup/renaming pass.

--- a/packages/marshal/marshal.js
+++ b/packages/marshal/marshal.js
@@ -722,25 +722,24 @@ export function makeMarshal(
  *
  * @param {InterfaceSpec} [iface='Remotable'] The interface specification for
  * the remotable. For now, a string iface must be "Remotable" or begin with
- * "Alleged: ". More general ifaces are not yet implemented.
+ * "Alleged: ", to serve as the alleged name. More general ifaces are not yet
+ * implemented. This is temporary.
  * @param {object} [props={}] Own-properties are copied to the remotable
  * @param {object} [remotable={}] The object used as the remotable
  * @returns {object} remotable, modified for debuggability
  */
 function Remotable(iface = 'Remotable', props = {}, remotable = {}) {
-  if (typeof iface === 'string') {
-    assert(
-      iface === 'Remotable' || iface.startsWith('Alleged: '),
-      details`For now, a string iface must be "Remotable" or begin with "Alleged: "`,
-    );
-  }
-  iface = pureCopy(harden(iface));
-  const ifaceType = typeof iface;
-
   // Find the alleged name.
-  if (ifaceType !== 'string') {
-    throw Error(`Interface must be a string, not ${ifaceType}; unimplemented`);
-  }
+  assert.typeof(
+    iface,
+    'string',
+    details`Interface ${iface} must be a string; unimplemented`,
+  );
+  assert(
+    iface === 'Remotable' || iface.startsWith('Alleged: '),
+    details`For now, iface ${iface} must be "Remotable" or begin with "Alleged: "; unimplemented`,
+  );
+  iface = pureCopy(harden(iface));
 
   // TODO: When iface is richer than just string, we need to get the allegedName
   // in a different way.


### PR DESCRIPTION
Minor PR rearranging asserts at the start of `Remotable` to reduce redundancy. Note that the `pureCopy` call now happens after both asserts.