### PR TITLE
pre-bundle to speed up swingset unit tests

### DIFF
--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -34,10 +34,6 @@ function makeConsole(tag) {
   return harden(cons);
 }
 
-const ADMIN_DEVICE_PATH = require.resolve('./kernel/vatAdmin/vatAdmin-src');
-const ADMIN_VAT_PATH = require.resolve('./kernel/vatAdmin/vatAdminWrapper');
-const KERNEL_SOURCE_PATH = require.resolve('./kernel/kernel.js');
-
 function byName(a, b) {
   if (a.name < b.name) {
     return -1;
@@ -205,27 +201,57 @@ export function loadSwingsetConfigFile(configPath) {
   }
 }
 
+/**
+ * Build the kernel source bundles.
+ *
+ */
+export async function buildKernelBundles() {
+  // this takes 2.7s on my computer
+  const sources = {
+    kernel: require.resolve('./kernel/kernel.js'),
+    adminDevice: require.resolve('./kernel/vatAdmin/vatAdmin-src'),
+    adminVat: require.resolve('./kernel/vatAdmin/vatAdminWrapper'),
+    comms: require.resolve('./vats/comms'),
+    vattp: require.resolve('./vats/vat-tp'),
+    timer: require.resolve('./vats/vat-timerWrapper'),
+  };
+  const kernelBundles = {};
+  for (const name of Object.keys(sources)) {
+    // this was harder to read with Promise.all
+    // eslint-disable-next-line no-await-in-loop
+    kernelBundles[name] = await bundleSource(sources[name]);
+  }
+  return harden(kernelBundles);
+}
+
 export async function buildVatController(
   config,
   argv = [],
   runtimeOptions = {},
 ) {
-  const { debugPrefix = '', verbose = false } = runtimeOptions;
+  // build console early so we can add console.log to diagnose early problems
+  const { debugPrefix = '' } = runtimeOptions;
   if (typeof Compartment === 'undefined') {
     throw Error('SES must be installed before calling buildVatController');
   }
 
   // eslint-disable-next-line no-shadow
   const console = makeConsole(`${debugPrefix}SwingSet:controller`);
+  // We can harden this 'console' because it's new, but if we were using the
+  // original 'console' object (which has a unique prototype), we'd have to
+  // harden(Object.getPrototypeOf(console));
+  // see https://github.com/Agoric/SES-shim/issues/292 for details
+  harden(console);
+
+  const {
+    verbose = false,
+    kernelBundles = await buildKernelBundles(),
+  } = runtimeOptions;
 
   // FIXME: Put this somewhere better.
   process.on('unhandledRejection', e =>
     console.error('UnhandledPromiseRejectionWarning:', e),
   );
-
-  // https://github.com/Agoric/SES-shim/issues/292
-  harden(Object.getPrototypeOf(console));
-  harden(console);
 
   if (config.bootstrap && argv) {
     if (!config.vats[config.bootstrap].parameters) {
@@ -248,8 +274,7 @@ export async function buildVatController(
       throw Error(`kernelRequire unprepared to satisfy require(${what})`);
     }
   }
-  const kernelSource = await bundleSource(KERNEL_SOURCE_PATH);
-  const kernelNS = await importBundle(kernelSource, {
+  const kernelNS = await importBundle(kernelBundles.kernel, {
     filePrefix: 'kernel',
     endowments: {
       console: makeConsole(`${debugPrefix}SwingSet:kernel`),
@@ -351,19 +376,15 @@ export async function buildVatController(
   }
 
   // the vatAdminDevice is given endowments by the kernel itself
-  const vatAdminVatBundle = await bundleSource(ADMIN_VAT_PATH);
-  kernel.addGenesisVat('vatAdmin', vatAdminVatBundle);
-  const vatAdminDeviceBundle = await bundleSource(ADMIN_DEVICE_PATH);
-  kernel.addVatAdminDevice(vatAdminDeviceBundle);
+  kernel.addGenesisVat('vatAdmin', kernelBundles.adminVat);
+  kernel.addVatAdminDevice(kernelBundles.adminDevice);
 
   // comms vat is added automatically, but TODO: bootstraps must still
   // connect it to vat-tp. TODO: test-message-patterns builds two comms and
   // two vattps, must handle somehow.
-  const commsVatSourcePath = require.resolve('./vats/comms');
-  const commsVatBundle = await bundleSource(commsVatSourcePath);
   kernel.addGenesisVat(
     'comms',
-    commsVatBundle,
+    kernelBundles.comms,
     {},
     {
       enablePipelining: true,
@@ -373,15 +394,11 @@ export async function buildVatController(
 
   // vat-tp is added automatically, but TODO: bootstraps must still connect
   // it to comms
-  const vatTPSourcePath = require.resolve('./vats/vat-tp');
-  const vatTPBundle = await bundleSource(vatTPSourcePath);
-  kernel.addGenesisVat('vattp', vatTPBundle);
+  kernel.addGenesisVat('vattp', kernelBundles.vattp);
 
   // timer wrapper vat is added automatically, but TODO: bootstraps must
   // still provide a timer device, and connect it to the wrapper vat
-  const timerWrapperSourcePath = require.resolve('./vats/vat-timerWrapper');
-  const timerWrapperBundle = await bundleSource(timerWrapperSourcePath);
-  kernel.addGenesisVat('timer', timerWrapperBundle);
+  kernel.addGenesisVat('timer', kernelBundles.timer);
 
   function addGenesisVat(
     name,

--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -254,10 +254,13 @@ export async function buildVatController(
   );
 
   if (config.bootstrap && argv) {
-    if (!config.vats[config.bootstrap].parameters) {
-      config.vats[config.bootstrap].parameters = {};
-    }
-    config.vats[config.bootstrap].parameters.argv = argv;
+    // move 'argv' into parameters on the bootstrap vat, without changing the
+    // original config (which might be hardened or shared)
+    const bootstrapName = config.bootstrap;
+    const parameters = { ...config.vats[bootstrapName].parameters, argv };
+    const bootstrapVat = { ...config.vats[bootstrapName], parameters };
+    const vats = { ...config.vats, [bootstrapName]: bootstrapVat };
+    config = { ...config, vats };
   }
 
   function kernelRequire(what) {

--- a/packages/SwingSet/src/index.js
+++ b/packages/SwingSet/src/index.js
@@ -2,6 +2,7 @@ export {
   loadBasedir,
   loadSwingsetConfigFile,
   buildVatController,
+  buildKernelBundles,
 } from './controller';
 
 export { buildMailboxStateMap, buildMailbox } from './devices/mailbox';

--- a/packages/SwingSet/test/basedir-message-patterns/vat-a.js
+++ b/packages/SwingSet/test/basedir-message-patterns/vat-a.js
@@ -17,7 +17,6 @@ export function buildRootObject(vatPowers) {
     },
 
     async run(which) {
-      console.log(`running alice[${which}]`);
       await alice[which]();
     },
   });

--- a/packages/SwingSet/test/test-message-patterns.js
+++ b/packages/SwingSet/test/test-message-patterns.js
@@ -5,7 +5,8 @@
 import '@agoric/install-ses';
 import test from 'ava';
 import path from 'path';
-import { buildVatController, loadBasedir } from '../src/index';
+import bundleSource from '@agoric/bundle-source';
+import { buildVatController, buildKernelBundles } from '../src/index';
 import { buildLoopbox } from '../src/devices/loopbox';
 import { buildPatterns } from './message-patterns';
 
@@ -38,13 +39,52 @@ async function runWithTrace(c) {
   }
 }
 
-export async function runVatsLocally(t, name) {
-  console.log(`------ testing pattern (local) -- ${name}`);
+test.before(async t => {
+  const kernelBundles = await buildKernelBundles();
   const bdir = path.resolve(__dirname, 'basedir-message-patterns');
-  const config = await loadBasedir(bdir);
-  config.bootstrap = 'bootstrap';
-  config.vats.bootstrap = { sourceSpec: path.join(bdir, 'bootstrap-local.js') };
-  const c = await buildVatController(config, [name]);
+  const bundleA = await bundleSource(path.resolve(bdir, 'vat-a.js'));
+  const bundleB = await bundleSource(path.resolve(bdir, 'vat-b.js'));
+
+  const bootstrapLocal = path.resolve(bdir, 'bootstrap-local.js');
+  const bundleLocal = await bundleSource(bootstrapLocal);
+  const localConfig = {
+    bootstrap: 'bootstrap',
+    vats: {
+      bootstrap: { bundle: bundleLocal },
+      a: { bundle: bundleA },
+      b: { bundle: bundleB },
+    },
+  };
+
+  const bootstrapComms = path.resolve(bdir, 'bootstrap-comms.js');
+  const bundleComms = await bundleSource(bootstrapComms);
+  const moreComms = {
+    bundle: kernelBundles.comms,
+    creationOptions: {
+      enablePipelining: true,
+      enableSetup: true,
+    },
+  };
+  const moreVatTP = { bundle: kernelBundles.vattp };
+  const commsConfig = {
+    bootstrap: 'bootstrap',
+    vats: {
+      bootstrap: { bundle: bundleComms },
+      a: { bundle: bundleA },
+      b: { bundle: bundleB },
+      leftcomms: moreComms,
+      rightcomms: moreComms,
+      leftvattp: moreVatTP,
+      rightvattp: moreVatTP,
+    },
+  };
+
+  t.context.data = { localConfig, commsConfig, kernelBundles };
+});
+
+export async function runVatsLocally(t, name) {
+  const { localConfig: config, kernelBundles } = t.context.data;
+  const c = await buildVatController(config, [name], { kernelBundles });
   // await runWithTrace(c);
   await c.run();
   return c.dump().log;
@@ -65,51 +105,26 @@ for (const name of Array.from(bp.patterns.keys()).sort()) {
   test.serial('local patterns', testLocalPattern, name);
 }
 
-const commsSourcePath = require.resolve('../src/vats/comms');
-const vatTPSourcePath = require.resolve('../src/vats/vat-tp');
-
-export async function runVatsInComms(t, enablePipelining, name) {
-  console.log(`------ testing pattern (comms) -- ${name}`);
-  const enableSetup = true;
-  const bdir = path.resolve(__dirname, 'basedir-message-patterns');
-  const config = await loadBasedir(bdir);
-  config.bootstrap = 'bootstrap';
-  config.vats.bootstrap = { sourceSpec: path.join(bdir, 'bootstrap-comms.js') };
-  config.vats.leftcomms = {
-    sourceSpec: commsSourcePath,
-    creationOptions: {
-      enablePipelining,
-      enableSetup,
-    },
-  };
-  config.vats.rightcomms = {
-    sourceSpec: commsSourcePath,
-    creationOptions: {
-      enablePipelining,
-      enableSetup,
-    },
-  };
-  config.vats.leftvattp = { sourceSpec: vatTPSourcePath };
-  config.vats.rightvattp = { sourceSpec: vatTPSourcePath };
+export async function runVatsInComms(t, name) {
+  const { commsConfig, kernelBundles } = t.context.data;
   const { passOneMessage, loopboxSrcPath, loopboxEndowments } = buildLoopbox(
     'queued',
   );
-  config.devices = [['loopbox', loopboxSrcPath, loopboxEndowments]];
-  const c = await buildVatController(config, [name]);
+  const devices = [['loopbox', loopboxSrcPath, loopboxEndowments]];
+  const config = { ...commsConfig, devices };
+  const c = await buildVatController(config, [name], { kernelBundles });
   // await runWithTrace(c);
   await c.run();
   while (passOneMessage()) {
     await c.run();
   }
-  console.log(`bootstrapResult`, c.bootstrapResult.status());
   return c.dump().log;
 }
 
 async function testCommsPattern(t, name) {
-  const enablePipelining = true;
-  const logs = await runVatsInComms(t, enablePipelining, name);
+  const logs = await runVatsInComms(t, name);
   let expected;
-  if (enablePipelining && name in bp.expected_pipelined) {
+  if (name in bp.expected_pipelined) {
     expected = bp.expected_pipelined[name];
   } else {
     expected = bp.expected[name];


### PR DESCRIPTION
This adds a `kernelBundles` option to `buildVatController`, a `buildKernelBundles` function to populate it, and converts the four largest swingset unit tests to use it.

It reduces the `cd packages/SwingSet; yarn test` time from 307s to 78s on my machine, a 4x speedup.

@FUDCo you might want to review the first two commits separately.

refs #1643 
refs #1490 
