### PR TITLE
WIP Adds to purse a getCurrentAmountNotifier to notify of balance changes.

### DIFF
--- a/packages/ERTP/NEWS.md
+++ b/packages/ERTP/NEWS.md
@@ -1,11 +1,23 @@
 User-visible changes in ERTP:
 
+## Next Release
+
+* Purses now support `getCurrentAmountNotifier()` that notifies of balance
+  changes.
+* Purses now support `readOnlyView()` that supports the purse query methods
+  including `getCurrentAmountNotifier()`. (If this could be authenticated from
+  the brand or issuer, without the purse itself, it would enable a certain
+  degree of honest auditing. But note that notifiers are lossy, so it would not
+  notify on each balance change.)
+* The purse `makeDepositFacet` is renamed `getDepositFacet` since it now
+  returns the same deposit facet each time.
+
 ## Release v0.7.0 (21-July-2020)
 
 * Rename `extent` to `value`
 * Rename `produceIssuer` to `makeIssuerKit`
 
-## Release v0.6.0 (29-June-2020) 
+## Release v0.6.0 (29-June-2020)
 
 * `purse.deposit()` now returns the amount of the deposit, rather than
   the purse's new balance.
@@ -26,7 +38,7 @@ which only accepts payments.
   problem because where it was used to indicate the kind, like in
   `payment.getBalance()`, a user could grab an assay from the units,
   use it to claim their payment, and think they accomplished something
-  security-wise. 
+  security-wise.
 * Relatedly, most of the methods from payments have been removed. The
   only method on payments that remains is `getAllegedBrand`. To get
   the current amount of assets in a payment, use the issuer:
@@ -35,7 +47,7 @@ which only accepts payments.
   is most important and the mint is just the admin facet of the issuer.
 * ProduceIssuer returns an object with properties like issuer, mint,
   amountMath (formerly unitOps), and brand rather than the old version
-  that just returned a mint. 
+  that just returned a mint.
 * Most configuration has been removed from ERTP in favor of a few
   built-in configurations: digital assets can be fungible (the
   default), or non-fungible. If digital assets are non-fungible, there
@@ -43,7 +55,7 @@ which only accepts payments.
   math for extents that are sets of string IDS, and 'set' mathHelpers
   handle the math for extents that are sets of more complex objects
   (which might be opaque ids called handles or data). Zoe invites use
-  'set' mathHelpers. 
+  'set' mathHelpers.
 * CoreMintKeeper was rewritten to conserve currency and then inserted
   into issuer.js (formerly mint.js)
 * We removed the issuer and purse methods with suffix 'All' and
@@ -60,11 +72,11 @@ which only accepts payments.
 
 Update dependency on pixel-demo
 
-## Release v0.3.0 (3-Feb-2020) 
+## Release v0.3.0 (3-Feb-2020)
 
 * Move a number of files out of ERTP and into their own packages in
   this monorepo, including:
-  
+
   1. `@agoric/import-manager`
   2. `@agoric/make-promise`
   3. `@agoric/sparse-ints`
@@ -90,7 +102,7 @@ Update dependency on pixel-demo
   default, users can use the contract to trade one unit of one kind of
   digital assets for one unit of another kind of digital asset
   indefinitely as long as they alternate, but this behavior is meant
-  to be altered by the smart contract developer. 
+  to be altered by the smart contract developer.
 
 ## Release v0.1.11 (11/1/2019)
 
@@ -126,7 +138,7 @@ Update dependency on pixel-demo
   string to produce a value like `myName_4409`, if `myName` was the
   user-supplied string. Then, this full name can be used to `get` the
   object back from the registrar naming service. This can be used to
-  give public names to objects meant to be shared. 
+  give public names to objects meant to be shared.
 * The contracts that run on Zoe have been updated. There are now six
   contracts: `automaticRefund`, used for testing and tutorials, which
   just gives the user their digital assets back, `autoswap`, a Uniswap
@@ -134,12 +146,12 @@ Update dependency on pixel-demo
   offer that can act as an option, `publicAuction` which is a
   second-price auction, `publicSwap` which has the same swap logic
   as the `coveredCall` contract, but which doesn't use invites, and
-  `simpleExchange` which is a naive decentralized exchange. 
+  `simpleExchange` which is a naive decentralized exchange.
 * Tests have been written for "higher order" contract uses. That is, a
   invite for one contract used as the underlying right in another
-  contract. 
+  contract.
 * Exit conditions were added to Zoe. This allows the user to specify
-  their exit conditions when they escrow an offer with Zoe. 
+  their exit conditions when they escrow an offer with Zoe.
 
 ## Release v0.1.7 (10/15/2019)
 
@@ -171,8 +183,8 @@ Update dependency on pixel-demo
        authority to create new assets. The `assay` is the
        public-facing facet that is often widely known and can be used
        to claim exclusive access to a payment or make an empty purse,
-       among other things. 
-* Added [support for uploading contracts](https://github.com/Agoric/cosmic-swingset/blob/master/lib/ag-solo/contracts/README-contract.md) at the start of the Agoric testnet. 
+       among other things.
+* Added [support for uploading contracts](https://github.com/Agoric/cosmic-swingset/blob/master/lib/ag-solo/contracts/README-contract.md) at the start of the Agoric testnet.
 * Added an [initial version of Zoe](https://github.com/Agoric/ERTP/commit/a32426aab307d31bd0fe1b6e1241d4a270964e31), our offer-safety enforcement layer.
   More on this to come.
 
@@ -229,7 +241,7 @@ Core ERTP:
   `depositExactly(amount, payment)`, which checks that the `amount` is
   equal to the `payment` balance, and `depositAll(payment)`. The
   methods for burning are now `burnExactly` and `burnAll`, and the
-  methods for claiming are now `claimExactly` and `claimAll`. 
+  methods for claiming are now `claimExactly` and `claimAll`.
 
 ## Release v0.1.1 (8/15/2019)
 
@@ -239,7 +251,7 @@ Core ERTP:
   that returns the custom purse or payment, the "trait-like" style
   combines the core methods of a purse or payment with the custom
   methods, overriding any custom methods with the core methods if
-  there is any overlap. 
+  there is any overlap.
 
 Pixel Demo:
 * Fixed a bug in which `tapFaucet` did not return newly minted
@@ -260,7 +272,7 @@ Pixel Demo:
 * Created a new representation of hierarchical rights for the pixel
   demo, which allows holders of higher-level rights to revoke rights
   held further down. This follows the pattern of owner, tenant, and
-  subtenant relationships in real property. 
+  subtenant relationships in real property.
 * Made the gallery in the pixel demo use a long-lived contract host
   rather than creating a new contract host for each contract
 

--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -43,8 +43,7 @@
     "@agoric/nat": "^2.0.1",
     "@agoric/promise-kit": "^0.1.3",
     "@agoric/same-structure": "^0.0.8",
-    "@agoric/store": "^0.2.0",
-    "@agoric/weak-store": "^0.0.8"
+    "@agoric/store": "^0.2.0"
   },
   "devDependencies": {
     "@agoric/bundle-source": "^1.1.6",
@@ -63,7 +62,7 @@
     ],
     "require": [
       "esm",
-      "@agoric/install-ses" 
+      "@agoric/install-ses"
     ]
   },
   "eslintConfig": {

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -247,7 +247,7 @@
  *
  * If payment is an unresolved promise, throw an error.
  *
- * @property {() => DepositFacet} makeDepositFacet
+ * @property {() => DepositFacet} getDepositFacet
  * Create an object whose `deposit` method deposits to the current Purse.
  *
  * @property {(amount: Amount) => Payment} withdraw

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -132,7 +132,7 @@ test('purse.deposit promise', t => {
   );
 });
 
-test('purse.makeDepositFacet', async t => {
+test('purse.getDepositFacet', async t => {
   t.plan(2);
   const { issuer, mint, amountMath } = makeIssuerKit('fungible');
   const fungible25 = amountMath.make(25);
@@ -152,7 +152,7 @@ test('purse.makeDepositFacet', async t => {
   };
 
   await E(purse)
-    .makeDepositFacet()
+    .getDepositFacet()
     .then(({ receive }) => receive(payment))
     .then(checkDeposit);
 });

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -44,7 +44,6 @@
     "@agoric/swingset-vat": "^0.6.0",
     "@agoric/tendermint": "^4.1.3",
     "@agoric/transform-eventual-send": "^1.3.1",
-    "@agoric/weak-store": "^0.0.8",
     "@agoric/zoe": "^0.7.0",
     "@babel/generator": "^7.6.4",
     "@iarna/toml": "^2.2.3",

--- a/packages/dapp-svelte-wallet/api/src/lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-wallet.js
@@ -1,8 +1,7 @@
 // @ts-check
 
 import { assert, details, q } from '@agoric/assert';
-import makeStore from '@agoric/store';
-import makeWeakStore from '@agoric/weak-store';
+import { makeStore, makeWeakStore } from '@agoric/store';
 import { makeIssuerTable } from '@agoric/zoe/src/issuerTable';
 
 import { E } from '@agoric/eventual-send';

--- a/packages/dapp-svelte-wallet/api/src/observable.js
+++ b/packages/dapp-svelte-wallet/api/src/observable.js
@@ -6,9 +6,12 @@
  */
 export default function makeObservablePurse(E, purse, onFulfilled) {
   return {
+    // TODO This `makeDepositFacet` does not seem to be used. Should it
+    // be renamed `getDepositFacet`? Do we need to leave behind a deprecated
+    // `makeDepositFacet` alias of this method, like we did in purse?
     makeDepositFacet() {
       return E(purse)
-        .makeDepositFacet()
+        .getDepositFacet()
         .then(depositOnlyFacet => {
           return {
             receive(...args) {

--- a/packages/spawner/package.json
+++ b/packages/spawner/package.json
@@ -35,8 +35,8 @@
     "@agoric/nat": "^2.0.1",
     "@agoric/promise-kit": "^0.1.3",
     "@agoric/same-structure": "^0.0.8",
-    "@agoric/transform-metering": "^1.3.0",
-    "@agoric/weak-store": "^0.0.8"
+    "@agoric/store": "^0.2.0",
+    "@agoric/transform-metering": "^1.3.0"
   },
   "devDependencies": {
     "@agoric/install-metering-and-ses": "^0.1.1",

--- a/packages/spawner/src/contractHost.js
+++ b/packages/spawner/src/contractHost.js
@@ -3,7 +3,7 @@
 /* global harden */
 
 import { importBundle } from '@agoric/import-bundle';
-import makeStore from '@agoric/weak-store';
+import { makeWeakStore } from '@agoric/store';
 import { assert, details } from '@agoric/assert';
 import { allComparable } from '@agoric/same-structure';
 import { makeIssuerKit } from '@agoric/ertp';
@@ -23,11 +23,11 @@ function makeContractHost(vatPowers, additionalEndowments = {}) {
   // buildRoot function.
 
   // Maps from seat identity to seats
-  const seats = makeStore('seatIdentity');
+  const seats = makeWeakStore('seatIdentity');
   // from seat identity to invite description.
-  const seatDescriptions = makeStore('seatIdentity');
+  const seatDescriptions = makeWeakStore('seatIdentity');
   // from installation to source code bundle
-  const installationSourceBundles = makeStore('installation');
+  const installationSourceBundles = makeWeakStore('installation');
 
   const {
     mint: inviteMint,

--- a/packages/store/NEWS.md
+++ b/packages/store/NEWS.md
@@ -1,5 +1,13 @@
 User-visible changes in @agoric/store:
 
+## Next Release
+
+* Moved `makeWeakStore` from `@agoric/weak-store` to here.
+* Added `makeLedger`, where a ledger is like a weakStore but
+  also supports a lazy `getNotifier`
+* Added a `readOnlyView()` to stores, weakStores, and ledgers.
+  It returns a ***shallow*** read-only facet of the stores.
+
 ## Release 0.0.1 (3-Feb-2020)
 
 Moved out of ERTP and created new package `@agoric/store`. Now depends

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -1,6 +1,6 @@
 # Store
 
-A wrapper around JavaScript Map. 
+A wrapper around JavaScript Map.
 
 Store adds some additional functionality on top of Map.
 
@@ -18,4 +18,22 @@ Store adds some additional functionality on top of Map.
    Map, because the Map methods are not tied to a particular
    Map instance.
 
-See @agoric/weak-store for the wrapper around JavaScript's WeakMap abstraction.
+# WeakStore
+
+Wrapper for JavaScript WeakMap
+
+WeakStore adds some additional functionality on top of WeakMap.
+
+1. WeakStore distinguishes between initializing (`init`) a (key,
+   value) pair and resetting the key to a different value (`set`),
+   whereas WeakMap doesn't. This means you can use the WeakStore
+   abstraction without having to check whether the key already exists.
+   This is because the method that you call (`init` or `set`) marks
+   your intention and does it for you.
+
+2. You can use the WeakStore methods in a functional programming
+   pattern, which you can't with WeakMap. For instance, you can create
+   a new function `const getPurse = weakStore.get` and you can do
+   `myArray.map(weakStore.get)`. You can't do either of these with
+   WeakMap, because the WeakMap methods are not tied to a particular
+   WeakMap instance.

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -2,7 +2,7 @@
   "name": "@agoric/store",
   "version": "0.2.0",
   "description": "Wrapper for JavaScript map",
-  "main": "src/store.js",
+  "main": "src/index.js",
   "engines": {
     "node": ">=11.0"
   },
@@ -30,7 +30,8 @@
   },
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "dependencies": {
-    "@agoric/assert": "^0.0.8"
+    "@agoric/assert": "^0.0.8",
+    "@agoric/notifier": "^0.1.3"
   },
   "devDependencies": {
     "ava": "^3.11.1",

--- a/packages/store/src/index.js
+++ b/packages/store/src/index.js
@@ -1,0 +1,6 @@
+export * from './store';
+export * from './ledger';
+export * from './weakStore';
+
+// @deprecated use named export
+export { makeStore as default } from './store';

--- a/packages/store/src/ledger.js
+++ b/packages/store/src/ledger.js
@@ -1,0 +1,111 @@
+// Copyright (C) 2019 Agoric, under Apache license 2.0
+
+/* global harden */
+
+import { assert, details, q } from '@agoric/assert';
+import { makeNotifierKit } from '@agoric/notifier';
+
+/**
+ * @template K,V
+ * @typedef {Object} WeakStore - A safety wrapper around a WeakMap
+ * @property {(key: any) => boolean} has - Check if a key exists
+ * @property {(key: K, value: V) => void} init - Initialize the key only if it
+ * doesn't already exist
+ * @property {(key: any) => V} get - Return a value for the key. Throws
+ * if not found.
+ * @property {(key: K, value: V) => void} set - Set the key. Throws if not
+ * found.
+ * @property {(key: K) => void} delete - Remove the key. Throws if not found.
+ */
+
+/**
+ * Distinguishes between adding a new key (init) and updating or
+ * referencing a key (get, set, delete).
+ *
+ * `init` is only allowed if the key does not already exist. `Get`,
+ * `set` and `delete` are only allowed if the key does already exist.
+ * @template K,V
+ * @param {string} [keyName='key'] - the column name for the key
+ * @returns {WeakStore<K,V>}
+ */
+export const makeLedger = harden((keyName = 'key') => {
+  const wm = new WeakMap();
+  // Made on demand. Keys always a subset of wm's keys.
+  const notifierKits = new WeakMap();
+
+  const assertKeyDoesNotExist = key =>
+    assert(!wm.has(key), details`${q(keyName)} already registered: ${key}`);
+  const assertKeyExists = key =>
+    assert(wm.has(key), details`${q(keyName)} not found: ${key}`);
+
+  // ********* Query methods ************
+
+  // eslint-disable-next-line no-use-before-define
+  const readOnlyView = () => ledgerReadOnlyFacet;
+  const has = key => wm.has(key);
+  const get = key => {
+    assertKeyExists(key);
+    return wm.get(key);
+  };
+  const getNotifier = key => {
+    if (wm.has(key)) {
+      if (!notifierKits.has(key)) {
+        const kit = makeNotifierKit(get(key));
+        notifierKits.init(key, kit);
+      }
+      return notifierKits.get(key).notifier;
+    } else {
+      // It is fine for a getNotifier request to come in after a key
+      // is deleted, in which case we just synthesize a notifier in
+      // the same finished state. However, to avoid extra bookkeeping,
+      // we can't tell the difference from a keyNotifier for a key that
+      // was never registered, so we do the same for it.
+      const kit = makeNotifierKit();
+      kit.updater.finish(undefined);
+      return kit.notifier;
+    }
+  };
+
+  // ********* Update methods ************
+
+  const init = (key, value) => {
+    assertKeyDoesNotExist(key);
+    wm.set(key, value);
+  };
+  const set = (key, value) => {
+    assertKeyExists(key);
+    wm.set(key, value);
+    if (notifierKits.has(key)) {
+      notifierKits.get(key).updater.updateState(value);
+    }
+  };
+  const deleteIt = key => {
+    assertKeyExists(key);
+    wm.delete(key);
+    if (notifierKits.has(key)) {
+      notifierKits.get(key).updater.finish(undefined);
+      notifierKits.delete(key);
+    }
+  };
+
+  // ********* Facets ************
+
+  const ledgerReadOnlyFacet = harden({
+    readOnlyView,
+    has,
+    get,
+    getNotifier,
+  });
+
+  const ledger = harden({
+    readOnlyView,
+    has,
+    get,
+    getNotifier,
+
+    init,
+    set,
+    delete: deleteIt,
+  });
+  return ledger;
+});

--- a/packages/store/src/weakStore.js
+++ b/packages/store/src/weakStore.js
@@ -8,10 +8,12 @@ import { assert, details, q } from '@agoric/assert';
  * @template K,V
  * @typedef {Object} WeakStore - A safety wrapper around a WeakMap
  * @property {(key: any) => boolean} has - Check if a key exists
- * @property {(key: K, value: V) => void} init - Initialize the key only if it doesn't already exist
+ * @property {(key: K, value: V) => void} init - Initialize the key only if it
+ * doesn't already exist
  * @property {(key: any) => V} get - Return a value for the key. Throws
  * if not found.
- * @property {(key: K, value: V) => void} set - Set the key. Throws if not found.
+ * @property {(key: K, value: V) => void} set - Set the key. Throws if not
+ * found.
  * @property {(key: K) => void} delete - Remove the key. Throws if not found.
  */
 
@@ -25,31 +27,55 @@ import { assert, details, q } from '@agoric/assert';
  * @param {string} [keyName='key'] - the column name for the key
  * @returns {WeakStore<K,V>}
  */
-function makeStore(keyName = 'key') {
+export const makeWeakStore = harden((keyName = 'key') => {
   const wm = new WeakMap();
   const assertKeyDoesNotExist = key =>
     assert(!wm.has(key), details`${q(keyName)} already registered: ${key}`);
   const assertKeyExists = key =>
     assert(wm.has(key), details`${q(keyName)} not found: ${key}`);
-  return harden({
-    has: key => wm.has(key),
-    init: (key, value) => {
-      assertKeyDoesNotExist(key);
-      wm.set(key, value);
-    },
-    get: key => {
-      assertKeyExists(key);
-      return wm.get(key);
-    },
-    set: (key, value) => {
-      assertKeyExists(key);
-      wm.set(key, value);
-    },
-    delete: key => {
-      assertKeyExists(key);
-      wm.delete(key);
-    },
+
+  // ********* Query methods ************
+
+  // eslint-disable-next-line no-use-before-define
+  const readOnlyView = () => storeReadOnlyFacet;
+
+  const has = key => wm.has(key);
+  const get = key => {
+    assertKeyExists(key);
+    return wm.get(key);
+  };
+
+  // ********* Update methods ************
+
+  const init = (key, value) => {
+    assertKeyDoesNotExist(key);
+    wm.set(key, value);
+  };
+  const set = (key, value) => {
+    assertKeyExists(key);
+    wm.set(key, value);
+  };
+  const deleteIt = key => {
+    assertKeyExists(key);
+    wm.delete(key);
+  };
+
+  // ********* Facets ************
+
+  const storeReadOnlyFacet = harden({
+    readOnlyView,
+    has,
+    get,
   });
-}
-harden(makeStore);
-export default makeStore;
+
+  const store = harden({
+    readOnlyView,
+    has,
+    get,
+
+    init,
+    set,
+    delete: deleteIt,
+  });
+  return store;
+});

--- a/packages/weak-store/NEWS.md
+++ b/packages/weak-store/NEWS.md
@@ -1,5 +1,10 @@
 User-visible changes in @agoric/weak-store:
 
+## Next release
+
+This package as a whole is deprecated. Use the explicitly named
+`makeWeakStore` export of `@agoric/store` instead.
+
 ## Release 0.0.1 (3-Feb-2020)
 
 Moved out of ERTP and created new npm package `@agoric/weak-store`.

--- a/packages/weak-store/README.md
+++ b/packages/weak-store/README.md
@@ -1,21 +1,2 @@
-# WeakStore
-
-Wrapper for JavaScript WeakMap
-
-WeakStore adds some additional functionality on top of WeakMap.
-
-1. WeakStore distinguishes between initializing (`init`) a (key,
-   value) pair and resetting the key to a different value (`set`),
-   whereas WeakMap doesn't. This means you can use the WeakStore
-   abstraction without having to check whether the key already exists.
-   This is because the method that you call (`init` or `set`) marks
-   your intention and does it for you.
-
-2. You can use the WeakStore methods in a functional programming
-   pattern, which you can't with WeakMap. For instance, you can create
-   a new function `const getPurse = weakStore.get` and you can do
-   `myArray.map(weakStore.get)`. You can't do either of these with
-   WeakMap, because the WeakMap methods are not tied to a particular
-   WeakMap instance.
-
-See @agoric/store for the wrapper around JavaScript's Map abstraction.
+This package as a whole is deprecated. Use the explicitly named
+`makeWeakStore` export of `@agoric/store` instead.

--- a/packages/weak-store/package.json
+++ b/packages/weak-store/package.json
@@ -2,7 +2,7 @@
   "name": "@agoric/weak-store",
   "version": "0.0.8",
   "description": "Wrapper for JavaScript WeakMap",
-  "main": "src/weakStore.js",
+  "main": "src/index.js",
   "engines": {
     "node": ">=11.0"
   },
@@ -26,7 +26,8 @@
   },
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "dependencies": {
-    "@agoric/assert": "^0.0.8"
+    "@agoric/assert": "^0.0.8",
+    "@agoric/store": "^0.2.0"
   },
   "devDependencies": {
     "ava": "^3.11.1",

--- a/packages/weak-store/src/index.js
+++ b/packages/weak-store/src/index.js
@@ -1,0 +1,2 @@
+// @deprecated Use named "weakStore" export of "@agoric/store"
+export { weakStore as default } from '@agoric/store';

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -46,7 +46,6 @@
     "@agoric/same-structure": "^0.0.8",
     "@agoric/store": "^0.2.0",
     "@agoric/transform-metering": "^1.3.0",
-    "@agoric/weak-store": "^0.0.8",
     "@agoric/bundle-source": "^1.1.6"
   },
   "devDependencies": {

--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -9,7 +9,7 @@
 
 import { assert, details } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
-import makeWeakStore from '@agoric/weak-store';
+import { makeWeakStore } from '@agoric/store';
 
 import { makeAmountMath, MathKind } from '@agoric/ertp';
 import { makeNotifierKit, updateFromNotifier } from '@agoric/notifier';

--- a/packages/zoe/src/contracts/multipoolAutoswap/multipoolAutoswap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/multipoolAutoswap.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { assert, details } from '@agoric/assert';
-import makeWeakStore from '@agoric/weak-store';
+import { makeWeakStore } from '@agoric/store';
 
 import { assertIssuerKeywords } from '../../contractSupport';
 import { makeAddPool } from './pool';

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -10,7 +10,7 @@
 
 /**
  * @template K,V
- * @typedef {import('@agoric/weak-store').WeakStore<K, V>} WeakStore
+ * @typedef {import('@agoric/store').WeakStore<K, V>} WeakStore
  */
 
 /**

--- a/packages/zoe/src/issuerTable.js
+++ b/packages/zoe/src/issuerTable.js
@@ -3,7 +3,7 @@
 import { assert } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
 
-import makeWeakStore from '@agoric/weak-store';
+import { makeWeakStore } from '@agoric/store';
 import { makeAmountMath } from '@agoric/ertp';
 
 import '../exported';

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -1,5 +1,5 @@
 // @ts-check
-import makeWeakStore from '@agoric/weak-store';
+import { makeWeakStore } from '@agoric/store';
 import { assert, details } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';

--- a/packages/zoe/test/unitTests/test-cleanProposal.js
+++ b/packages/zoe/test/unitTests/test-cleanProposal.js
@@ -2,7 +2,7 @@
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
-import makeStore from '@agoric/weak-store';
+import { makeWeakStore } from '@agoric/store';
 import { cleanProposal } from '../../src/cleanProposal';
 import { setup } from './setupBasicMints';
 import buildManualTimer from '../../tools/manualTimer';
@@ -10,7 +10,7 @@ import buildManualTimer from '../../tools/manualTimer';
 test('cleanProposal test', t => {
   const { simoleanR, moolaR, bucksR, moola, simoleans } = setup();
 
-  const brandToAmountMath = makeStore('brand');
+  const brandToAmountMath = makeWeakStore('brand');
   brandToAmountMath.init(moolaR.brand, moolaR.amountMath);
   brandToAmountMath.init(simoleanR.brand, simoleanR.amountMath);
   brandToAmountMath.init(bucksR.brand, bucksR.amountMath);
@@ -36,7 +36,7 @@ test('cleanProposal test', t => {
 test('cleanProposal - all empty', t => {
   const { simoleanR, moolaR, bucksR } = setup();
 
-  const brandToAmountMath = makeStore('brand');
+  const brandToAmountMath = makeWeakStore('brand');
   brandToAmountMath.init(moolaR.brand, moolaR.amountMath);
   brandToAmountMath.init(simoleanR.brand, simoleanR.amountMath);
   brandToAmountMath.init(bucksR.brand, bucksR.amountMath);
@@ -63,7 +63,7 @@ test('cleanProposal - repeated brands', t => {
   t.plan(3);
   const { simoleanR, moolaR, bucksR, moola, simoleans } = setup();
 
-  const brandToAmountMath = makeStore('brand');
+  const brandToAmountMath = makeWeakStore('brand');
   brandToAmountMath.init(moolaR.brand, moolaR.amountMath);
   brandToAmountMath.init(simoleanR.brand, simoleanR.amountMath);
   brandToAmountMath.init(bucksR.brand, bucksR.amountMath);

--- a/packages/zoe/test/unitTests/test-rightsConservation.js
+++ b/packages/zoe/test/unitTests/test-rightsConservation.js
@@ -3,7 +3,7 @@ import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 
-import makeStore from '@agoric/weak-store';
+import { makeWeakStore } from '@agoric/store';
 import { makeIssuerKit } from '@agoric/ertp';
 import { assertRightsConserved } from '../../src/contractFacet/rightsConservation';
 
@@ -14,7 +14,7 @@ const setupAmountMaths = () => {
 
   const all = [moolaIssuerResults, simoleanIssuerResults, bucksIssuerResults];
   const amountMathArray = all.map(objs => objs.amountMath);
-  const brandToAmountMath = makeStore('brand');
+  const brandToAmountMath = makeWeakStore('brand');
   all.forEach(bundle =>
     brandToAmountMath.init(bundle.brand, bundle.amountMath),
   );


### PR DESCRIPTION
issuer
* Purses now support `getCurrentAmountNotifier()` that notifies of balance
  changes.
* Purses now support `readOnlyView()` that supports the purse query methods
  including `getCurrentAmountNotifier()`. (If this could be authenticated from
  the brand or issuer, without the purse itself, it would enable a certain
  degree of honest auditing. But note that notifiers are lossy, so it would not
  notify on each balance change.)
* The purse `makeDepositFacet` is renamed `getDepositFacet` since it now
  returns the same deposit facet each time.

@agoric/store
* Moved `makeWeakStore` from `@agoric/weak-store` to here.
* Added `makeLedger`, where a ledger is like a weakStore but
  also supports a lazy `getNotifier`
* Added a `readOnlyView()` to stores, weakStores, and ledgers.
  It returns a ***shallow*** read-only facet of the stores.

LOW URGENCY. Everything here can wait till after alpha.

Fixes #1372 