### PR TITLE
Revert overspill from PR #1577

### DIFF
--- a/packages/SwingSet/test/test-exomessages.js
+++ b/packages/SwingSet/test/test-exomessages.js
@@ -1,5 +1,4 @@
 import '@agoric/install-ses';
-import { 'presence' } from '@agoric/marshal';
 import test from 'ava';
 import { buildVatController } from '../src/index';
 

--- a/packages/SwingSet/test/test-exomessages.js
+++ b/packages/SwingSet/test/test-exomessages.js
@@ -1,5 +1,5 @@
 import '@agoric/install-ses';
-import { REMOTE_STYLE } from '@agoric/marshal';
+import { 'presence' } from '@agoric/marshal';
 import test from 'ava';
 import { buildVatController } from '../src/index';
 
@@ -40,7 +40,7 @@ test('bootstrap returns presence', async t => {
   // prettier-ignore
   await bootstrapSuccessfully(
     t,
-    REMOTE_STYLE,
+    'presence',
     '{"@qclass":"slot",index:0}',
     ['ko25'],
   );
@@ -104,7 +104,7 @@ test('extra message returns presence', async t => {
   // prettier-ignore
   await extraMessage(
     t,
-    REMOTE_STYLE,
+    'presence',
     'fulfilled',
     '{"@qclass":"slot",index:0}',
     ['ko25'],

--- a/packages/SwingSet/test/test-vpid-kernel.js
+++ b/packages/SwingSet/test/test-vpid-kernel.js
@@ -2,7 +2,7 @@
 /* global harden */
 
 import '@agoric/install-ses';
-import { REMOTE_STYLE } from '@agoric/marshal';
+import { 'presence' } from '@agoric/marshal';
 import test from 'ava';
 import anylogger from 'anylogger';
 import { initSwingStore } from '@agoric/swing-store-simple';
@@ -91,7 +91,7 @@ function buildRawVat(name, kernel, onDispatchCallback = undefined) {
 // ways:
 // prettier-ignore
 const modes = [
-  REMOTE_STYLE,     // resolveToPresence: messages can be sent to resolution
+  'presence',     // resolveToPresence: messages can be sent to resolution
   'local-object',   // resolve to a local object: messages to resolution don't create syscalls
   'data',           // resolveToData: messages are rejected as DataIsNotCallable
   'promise-data',   // resolveToData that contains a promise ID
@@ -103,7 +103,7 @@ const slot0arg = { '@qclass': 'slot', index: 0 };
 
 function doResolveSyscall(syscallA, vpid, mode, targets) {
   switch (mode) {
-    case REMOTE_STYLE:
+    case 'presence':
       syscallA.fulfillToPresence(vpid, targets.target2);
       break;
     case 'local-object':
@@ -128,7 +128,7 @@ function doResolveSyscall(syscallA, vpid, mode, targets) {
 
 function resolutionOf(vpid, mode, targets) {
   switch (mode) {
-    case REMOTE_STYLE:
+    case 'presence':
       return {
         type: 'notifyFulfillToPresence',
         promiseID: vpid,

--- a/packages/SwingSet/test/test-vpid-kernel.js
+++ b/packages/SwingSet/test/test-vpid-kernel.js
@@ -2,7 +2,6 @@
 /* global harden */
 
 import '@agoric/install-ses';
-import { 'presence' } from '@agoric/marshal';
 import test from 'ava';
 import anylogger from 'anylogger';
 import { initSwingStore } from '@agoric/swing-store-simple';

--- a/packages/SwingSet/test/test-vpid-liveslots.js
+++ b/packages/SwingSet/test/test-vpid-liveslots.js
@@ -6,7 +6,7 @@ import test from 'ava';
 
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
-import { REMOTE_STYLE } from '@agoric/marshal';
+import { 'presence' } from '@agoric/marshal';
 import { makeLiveSlots } from '../src/kernel/liveSlots';
 
 const RETIRE_VPIDS = true;
@@ -101,7 +101,7 @@ function hush(p) {
 // In addition, we want to exercise the promises being resolved in various
 // ways:
 const modes = [
-  REMOTE_STYLE, // resolveToPresence, messages can be sent to resolution
+  'presence', // resolveToPresence, messages can be sent to resolution
   'local-object', // resolve to a local object, messages can be sent but do
   //              // not create syscalls
   'data', // resolveToData, messages are rejected as DataIsNotCallable
@@ -112,7 +112,7 @@ const modes = [
 
 function resolvePR(pr, mode, targets) {
   switch (mode) {
-    case REMOTE_STYLE:
+    case 'presence':
       pr.resolve(targets.target2);
       break;
     case 'local-object':
@@ -149,7 +149,7 @@ const slot1arg = { '@qclass': 'slot', index: 1 };
 
 function resolutionOf(vpid, mode, targets) {
   switch (mode) {
-    case REMOTE_STYLE:
+    case 'presence':
       return {
         type: 'fulfillToPresence',
         promiseID: vpid,
@@ -516,7 +516,7 @@ async function doVatResolveCase23(t, which, mode, stalls) {
   // resolution target. If that target is a Presence, we'll see a syscall,
   // otherwise the vat handles it internally.
 
-  if (mode === REMOTE_STYLE) {
+  if (mode === 'presence') {
     t.deepEqual(log.shift(), {
       type: 'send',
       targetSlot: target2,
@@ -537,7 +537,7 @@ async function doVatResolveCase23(t, which, mode, stalls) {
   t.deepEqual(log, []);
 
   // assert that the vat saw the local promise being resolved too
-  if (mode === REMOTE_STYLE) {
+  if (mode === 'presence') {
     t.is(resolutionOfP1.toString(), `[Alleged: presence ${target2}]`);
   } else if (mode === 'data') {
     t.is(resolutionOfP1, 4);
@@ -553,7 +553,7 @@ async function doVatResolveCase23(t, which, mode, stalls) {
 
 // uncomment this when debugging specific problems
 // test.only(`XX`, async t => {
-//   await doVatResolveCase23(t, 2, REMOTE_STYLE, 0);
+//   await doVatResolveCase23(t, 2, 'presence', 0);
 // });
 
 for (const caseNum of [2, 3]) {
@@ -639,7 +639,7 @@ async function doVatResolveCase4(t, mode) {
   t.deepEqual(log.shift(), { type: 'subscribe', target: expectedP3 });
   t.deepEqual(log, []);
 
-  if (mode === REMOTE_STYLE) {
+  if (mode === 'presence') {
     dispatch.notifyFulfillToPresence(p1, target2);
   } else if (mode === 'local-object') {
     dispatch.notifyFulfillToPresence(p1, rootA);
@@ -683,7 +683,7 @@ async function doVatResolveCase4(t, mode) {
     target: expectedResultOfThree,
   });
 
-  if (mode === REMOTE_STYLE) {
+  if (mode === 'presence') {
     const expectedP6 = nextP();
     t.deepEqual(log.shift(), {
       type: 'send',

--- a/packages/SwingSet/test/test-vpid-liveslots.js
+++ b/packages/SwingSet/test/test-vpid-liveslots.js
@@ -6,7 +6,6 @@ import test from 'ava';
 
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
-import { 'presence' } from '@agoric/marshal';
 import { makeLiveSlots } from '../src/kernel/liveSlots';
 
 const RETIRE_VPIDS = true;

--- a/packages/SwingSet/test/vat-exomessages.js
+++ b/packages/SwingSet/test/vat-exomessages.js
@@ -1,7 +1,5 @@
 /* global harden */
 
-import { 'presence' } from '@agoric/marshal';
-
 export function buildRootObject(_vatPowers, vatParameters) {
   const other = harden({
     something(arg) {

--- a/packages/SwingSet/test/vat-exomessages.js
+++ b/packages/SwingSet/test/vat-exomessages.js
@@ -1,6 +1,6 @@
 /* global harden */
 
-import { REMOTE_STYLE } from '@agoric/marshal';
+import { 'presence' } from '@agoric/marshal';
 
 export function buildRootObject(_vatPowers, vatParameters) {
   const other = harden({
@@ -12,7 +12,7 @@ export function buildRootObject(_vatPowers, vatParameters) {
   function behave(mode) {
     if (mode === 'data') {
       return 'a big hello to all intelligent lifeforms everywhere';
-    } else if (mode === REMOTE_STYLE) {
+    } else if (mode === 'presence') {
       return other;
     } else if (mode === 'reject') {
       throw new Error('gratuitous error');


### PR DESCRIPTION
Revert overspill from PR #1577 . For these occurrences of `'presence'`, they should stay `'presence'` even when `passStyleOf` and marshal change from `'presence'` to `'remote'`.