### PR TITLE
feat: add a /dev/sda -> /home filesystem for Digital Ocean

### DIFF
--- a/packages/deployment/ansible/roles/prereq/tasks/main.yml
+++ b/packages/deployment/ansible/roles/prereq/tasks/main.yml
@@ -17,4 +17,25 @@
     - rsync
     - sudo
     - curl
+    - xfsprogs
     - "nodejs={{ NODEJS_VERSION }}.*"
+
+- name: Stat /dev/sda
+  stat:
+    path: /dev/sda
+  register: sda
+
+- name: Resize /dev/sda with XFS
+  filesystem:
+    fstype: xfs
+    dev: /dev/sda
+    resizefs: yes
+  when: sda.stat.exists
+
+- name: Mount /dev/sda
+  mount:
+    path: /home
+    src: /dev/sda
+    fstype: auto
+    state: mounted
+  when: sda.stat.exists

--- a/packages/deployment/terraform/digitalocean/cluster/main.tf
+++ b/packages/deployment/terraform/digitalocean/cluster/main.tf
@@ -24,5 +24,13 @@ resource "digitalocean_droplet" "cluster" {
     timeout = "30s"
   }
 
+  volume_ids = ["${digitalocean_volume.cluster.*.id[count.index]}"]
 }
 
+resource "digitalocean_volume" "cluster" {
+  name = "${var.name}-volume${var.offset + count.index}"
+  region = "${element(var.regions, count.index)}"
+  size = "${var.volume_size}"
+  count = "${var.servers}"
+  tags = ["${digitalocean_tag.cluster.id}"]
+}

--- a/packages/deployment/terraform/digitalocean/cluster/variables.tf
+++ b/packages/deployment/terraform/digitalocean/cluster/variables.tf
@@ -23,8 +23,12 @@ variable "instance_size" {
   default = "2gb"
 }
 
+variable "volume_size" {
+  description = "The size (in GB) of the volume to attach to each instance"
+  default = 150
+}
+
 variable "servers" {
   description = "Desired instance count"
   default     = 4
 }
-


### PR DESCRIPTION
This adds a default 150GB disk volume to the testnet Digital Ocean provisioning, in order to allow room to grow without the expense of changing the base droplet size.
