### PR TITLE
Clean up some deployment scripts

### DIFF
--- a/packages/deployment/bigdipper/ag-lcd.sh
+++ b/packages/deployment/bigdipper/ag-lcd.sh
@@ -3,9 +3,30 @@
 set -e
 PATH=$PATH:/usr/local/bin
 ncf=`curl -Ss https://testnet.agoric.com/network-config`
-l=`echo "$ncf" | jq '.rpcAddrs | length'`
-eval rp=`echo "$ncf" | jq ".rpcAddrs[$(( RANDOM % l ))]"`
-eval cn=`echo "$ncf" | jq '.chainName'`
+cn=`echo "$ncf" | jq -r '.chainName'`
+
+origRpcAddrs=( $(echo $ncf | jq -r '.rpcAddrs | join(" ")' ) )
+
+rpcAddrs=(${origRpcAddrs[@]})
+rp=
+while [[ ${#rpcAddrs[@]} -gt 0 ]]; do
+  r=$(( $RANDOM % ${#rpcAddrs[@]} ))
+  selected=${rpcAddrs[$r]}
+  rpcAddrs=( ${rpcAddrs[@]/$selected} )
+
+  if curl -s http://$selected/status > /dev/null; then
+    # Found an active node.
+    rp=$selected
+    break
+  fi
+done
+
+if test -z "$rp"; then
+  echo "Cannot find an active node; last tried $selected"
+  sleep 20
+  exit 1
+fi
+
 # FIXME: Once https://github.com/cosmos/cosmos-sdk/issues/5592 is resolved,
 # we can use:
 #exec ag-cosmos-helper rest-server --node="tcp://$rp" --chain-id="$cn"

--- a/packages/deployment/main.js
+++ b/packages/deployment/main.js
@@ -467,6 +467,7 @@ show-config      display the client connection parameters
       const cfg = await needBacktick(`${shellEscape(progname)} show-config`);
       process.stdout.write(`${chalk.yellow(cfg)}\n`);
 
+      await mkdir(`${DWEB_DIR}/data`, { recursive: true });
       await createFile(`${DWEB_DIR}/data/cosmos-chain.json`, cfg);
 
       const rpcAddrs = await needBacktick(


### PR DESCRIPTION
The bigdipper (i.e. testnet blockchain explorer) scripts used to rely on the `node*.testnet.agoric.com` DNS names, which was an unnecessary dependency.  Now the only DNS dependency is on `https://testnet.agoric.com`, which we are more likely to keep updated.

Also fix a little problem where a parent directory wasn't being made when running the `ag-setup-cosmos dweb` command.
