### PR TITLE
refactor: assertProposalShape no longer takes in and produces an offerHandler

### DIFF
--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -234,36 +234,32 @@ export const swap = (
  */
 
 /**
- * Make an offerHandler that wraps the provided `offerHandler`, to first
- * check the submitted offer against an `expected` record that says
+ * Check the seat's proposal against an `expected` record that says
  * what shape of proposal is acceptable.
  *
  * This ExpectedRecord is like a Proposal, but the amounts in 'want'
  * and 'give' should be null; the exit clause should specify a rule with
- * null contents. If the client submits an Offer which does not match
- * these expectations, that offer will be rejected (and refunded).
+ * null contents. If the client submits an offer which does not match
+ * these expectations, the seat will be exited (and payments refunded).
  *
- * @param {OfferHandler} offerHandler
+ * @param {ZCFSeat} seat
  * @param {ExpectedRecord} expected
  */
-export const assertProposalShape = (offerHandler, expected) =>
-  /** @param {ZCFSeat} seat */
-  seat => {
-    const actual = seat.getProposal();
-    // Does not check values
-    const assertKeys = (a, e) => {
-      if (e !== undefined) {
-        assert(
-          sameStructure(getKeysSorted(a), getKeysSorted(e)),
-          details`actual ${a} did not match expected ${e}`,
-        );
-      }
-    };
-    assertKeys(actual.give, expected.give);
-    assertKeys(actual.want, expected.want);
-    assertKeys(actual.exit, expected.exit);
-    return offerHandler(seat);
+export const assertProposalShape = (seat, expected) => {
+  const actual = seat.getProposal();
+  // Does not check values
+  const assertKeys = (a, e) => {
+    if (e !== undefined) {
+      assert(
+        sameStructure(getKeysSorted(a), getKeysSorted(e)),
+        details`actual ${a} did not match expected ${e}`,
+      );
+    }
   };
+  assertKeys(actual.give, expected.give);
+  assertKeys(actual.want, expected.want);
+  assertKeys(actual.exit, expected.exit);
+};
 
 /* Given a brand, assert that the issuer uses NAT amountMath. */
 export const assertUsesNatMath = (zcf, brand) => {

--- a/packages/zoe/src/contracts/atomicSwap.js
+++ b/packages/zoe/src/contracts/atomicSwap.js
@@ -25,6 +25,10 @@ const start = zcf => {
 
   /** @type {OfferHandler} */
   const makeMatchingInvitation = firstSeat => {
+    assertProposalShape(firstSeat, {
+      give: { Asset: null },
+      want: { Price: null },
+    });
     const { want, give } = firstSeat.getProposal();
 
     /** @type {OfferHandler} */
@@ -45,13 +49,8 @@ const start = zcf => {
     return matchingSeatInvitation;
   };
 
-  const firstProposalExpected = harden({
-    give: { Asset: null },
-    want: { Price: null },
-  });
-
   const creatorInvitation = zcf.makeInvitation(
-    assertProposalShape(makeMatchingInvitation, firstProposalExpected),
+    makeMatchingInvitation,
     'firstOffer',
   );
 

--- a/packages/zoe/src/contracts/auction/secondPriceAuction.js
+++ b/packages/zoe/src/contracts/auction/secondPriceAuction.js
@@ -59,15 +59,14 @@ const start = zcf => {
   const makeBidInvitation = () => {
     /** @type {OfferHandler} */
     const performBid = seat => {
+      assertProposalShape(seat, {
+        give: { Bid: null },
+        want: { Asset: null },
+      });
       assertBidSeat(zcf, sellSeat, seat);
       bidSeats.push(seat);
       return defaultAcceptanceMsg;
     };
-
-    const bidExpected = harden({
-      give: { Bid: null },
-      want: { Asset: null },
-    });
 
     const customProperties = harden({
       auctionedAssets: sellSeat.getProposal().give.Asset,
@@ -76,22 +75,17 @@ const start = zcf => {
       timerAuthority,
     });
 
-    return zcf.makeInvitation(
-      assertProposalShape(performBid, bidExpected),
-      'bid',
-      customProperties,
-    );
+    return zcf.makeInvitation(performBid, 'bid', customProperties);
   };
 
-  const sellExpected = harden({
-    give: { Asset: null },
-    want: { Ask: null },
-    // The auction is not over until the deadline according to the
-    // provided timer. The seller cannot exit beforehand.
-    exit: { waived: null },
-  });
-
   const sell = seat => {
+    assertProposalShape(seat, {
+      give: { Asset: null },
+      want: { Ask: null },
+      // The auction is not over until the deadline according to the
+      // provided timer. The seller cannot exit beforehand.
+      exit: { waived: null },
+    });
     // Save the seat for when the auction closes.
     sellSeat = seat;
 
@@ -100,10 +94,7 @@ const start = zcf => {
     return harden({ makeBidInvitation });
   };
 
-  const creatorInvitation = zcf.makeInvitation(
-    assertProposalShape(sell, sellExpected),
-    'sellAssets',
-  );
+  const creatorInvitation = zcf.makeInvitation(sell, 'sellAssets');
 
   return harden({ creatorInvitation });
 };

--- a/packages/zoe/src/contracts/autoswap.js
+++ b/packages/zoe/src/contracts/autoswap.js
@@ -113,6 +113,12 @@ const start = async zcf => {
     return `Swap successfully completed.`;
   }
 
+  const assertSwapProposal = seat =>
+    assertProposalShape(seat, {
+      want: { Out: null },
+      give: { In: null },
+    });
+
   /**
    * Swap one asset for another. In specifies the asset being provided and Out
    * specifies the wanted asset. The amount of Out returned is calculated based
@@ -122,6 +128,7 @@ const start = async zcf => {
    * @type {OfferHandler}
    */
   const swapInHandler = swapSeat => {
+    assertSwapProposal(swapSeat);
     assert(
       !centralMath.isEmpty(getPoolAmount(brands.Central)),
       `Pool not initialized`,
@@ -152,6 +159,7 @@ const start = async zcf => {
    * @type {OfferHandler}
    */
   const swapOutHandler = swapSeat => {
+    assertSwapProposal(swapSeat);
     assert(
       !centralMath.isEmpty(getPoolAmount(brands.Central)),
       'Pool not initialized',
@@ -223,6 +231,10 @@ const start = async zcf => {
    * @type {OfferHandler}
    */
   const addLiquidityHandler = liqSeat => {
+    assertProposalShape(liqSeat, {
+      give: { Central: null, Secondary: null },
+      want: { Liquidity: null },
+    });
     if (centralMath.isEmpty(getPoolAmount(brands.Central))) {
       return initiateLiquidity(liqSeat);
     }
@@ -252,6 +264,10 @@ const start = async zcf => {
 
   /** @type {OfferHandler} */
   const removeLiquidityHandler = removeLiqSeat => {
+    assertProposalShape(removeLiqSeat, {
+      want: { Central: null, Secondary: null },
+      give: { Liquidity: null },
+    });
     // TODO (hibbert) should we burn tokens?
     const userAllocation = removeLiqSeat.getCurrentAllocation();
     const liquidityValueIn = userAllocation.Liquidity.value;
@@ -296,44 +312,17 @@ const start = async zcf => {
     return 'Liquidity successfully removed.';
   };
 
-  const addLiquidityExpected = harden({
-    give: { Central: null, Secondary: null },
-    want: { Liquidity: null },
-  });
-
-  const removeLiquidityExpected = harden({
-    want: { Central: null, Secondary: null },
-    give: { Liquidity: null },
-  });
-
-  const swapExpected = {
-    want: { Out: null },
-    give: { In: null },
-  };
-
   const makeAddLiquidityInvitation = () =>
-    zcf.makeInvitation(
-      assertProposalShape(addLiquidityHandler, addLiquidityExpected),
-      'autoswap add liquidity',
-    );
+    zcf.makeInvitation(addLiquidityHandler, 'autoswap add liquidity');
 
   const makeRemoveLiquidityInvitation = () =>
-    zcf.makeInvitation(
-      assertProposalShape(removeLiquidityHandler, removeLiquidityExpected),
-      'autoswap remove liquidity',
-    );
+    zcf.makeInvitation(removeLiquidityHandler, 'autoswap remove liquidity');
 
   const makeSwapInInvitation = () =>
-    zcf.makeInvitation(
-      assertProposalShape(swapInHandler, swapExpected),
-      'autoswap swap',
-    );
+    zcf.makeInvitation(swapInHandler, 'autoswap swap');
 
   const makeSwapOutInvitation = () =>
-    zcf.makeInvitation(
-      assertProposalShape(swapOutHandler, swapExpected),
-      'autoswap swap',
-    );
+    zcf.makeInvitation(swapOutHandler, 'autoswap swap');
 
   /**
    * `getOutputForGivenInput` calculates the result of a trade, given a certain

--- a/packages/zoe/src/contracts/coveredCall.js
+++ b/packages/zoe/src/contracts/coveredCall.js
@@ -45,22 +45,26 @@ const start = zcf => {
   assertIssuerKeywords(zcf, harden(['UnderlyingAsset', 'StrikePrice']));
 
   const makeCallOption = sellerSeat => {
+    assertProposalShape(sellerSeat, {
+      give: { UnderlyingAsset: null },
+      want: { StrikePrice: null },
+      exit: { afterDeadline: null },
+    });
     const { want, give, exit } = sellerSeat.getProposal();
     const rejectMsg = `The covered call option is expired.`;
 
     const exerciseOption = exerciserSeat => {
+      assertProposalShape(exerciserSeat, {
+        give: { StrikePrice: null },
+        want: { UnderlyingAsset: null },
+      });
       const swapResult = swap(zcf, sellerSeat, exerciserSeat, rejectMsg);
       zcf.shutdown();
       return swapResult;
     };
 
-    const exerciseOptionExpected = harden({
-      give: { StrikePrice: null },
-      want: { UnderlyingAsset: null },
-    });
-
     return zcf.makeInvitation(
-      assertProposalShape(exerciseOption, exerciseOptionExpected),
+      exerciseOption,
       'exerciseOption',
       harden({
         expirationDate: exit.afterDeadline.deadline,
@@ -71,14 +75,8 @@ const start = zcf => {
     );
   };
 
-  const makeCallOptionExpected = harden({
-    give: { UnderlyingAsset: null },
-    want: { StrikePrice: null },
-    exit: { afterDeadline: null },
-  });
-
   const creatorInvitation = zcf.makeInvitation(
-    assertProposalShape(makeCallOption, makeCallOptionExpected),
+    makeCallOption,
     'makeCallOption',
   );
 

--- a/packages/zoe/src/contracts/multipoolAutoswap/addLiquidity.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/addLiquidity.js
@@ -7,15 +7,14 @@ import '../../../exported';
  * @param {(brand: Brand) => Pool} getPool
  */
 export const makeMakeAddLiquidityInvitation = (zcf, getPool) => {
-  const addLiquidityExpected = harden({
-    give: {
-      Central: null,
-      Secondary: null,
-    },
-    want: { Liquidity: null },
-  });
-
   const addLiquidity = seat => {
+    assertProposalShape(seat, {
+      give: {
+        Central: null,
+        Secondary: null,
+      },
+      want: { Liquidity: null },
+    });
     // Get the brand of the secondary token so we can identify the liquidity pool.
     const secondaryBrand = seat.getProposal().give.Secondary.brand;
     const pool = getPool(secondaryBrand);
@@ -23,10 +22,7 @@ export const makeMakeAddLiquidityInvitation = (zcf, getPool) => {
   };
 
   const makeAddLiquidityInvitation = () =>
-    zcf.makeInvitation(
-      assertProposalShape(addLiquidity, addLiquidityExpected),
-      'multipool autoswap add liquidity',
-    );
+    zcf.makeInvitation(addLiquidity, 'multipool autoswap add liquidity');
 
   return makeAddLiquidityInvitation;
 };

--- a/packages/zoe/src/contracts/multipoolAutoswap/removeLiquidity.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/removeLiquidity.js
@@ -7,17 +7,16 @@ import '../../../exported';
  * @param {(brand: Brand) => Pool} getPool
  */
 export const makeMakeRemoveLiquidityInvitation = (zcf, getPool) => {
-  const removeLiquidityExpected = harden({
-    want: {
-      Central: null,
-      Secondary: null,
-    },
-    give: {
-      Liquidity: null,
-    },
-  });
-
   const removeLiquidity = seat => {
+    assertProposalShape(seat, {
+      want: {
+        Central: null,
+        Secondary: null,
+      },
+      give: {
+        Liquidity: null,
+      },
+    });
     // Get the brand of the secondary token so we can identify the liquidity pool.
     const secondaryBrand = seat.getProposal().want.Secondary.brand;
     const pool = getPool(secondaryBrand);
@@ -25,9 +24,6 @@ export const makeMakeRemoveLiquidityInvitation = (zcf, getPool) => {
   };
 
   const makeRemoveLiquidityInvitation = () =>
-    zcf.makeInvitation(
-      assertProposalShape(removeLiquidity, removeLiquidityExpected),
-      'autoswap remove liquidity',
-    );
+    zcf.makeInvitation(removeLiquidity, 'autoswap remove liquidity');
   return makeRemoveLiquidityInvitation;
 };

--- a/packages/zoe/src/contracts/multipoolAutoswap/swap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/swap.js
@@ -15,12 +15,11 @@ export const makeMakeSwapInvitation = (
   isCentral,
   getPool,
 ) => {
-  const swapExpected = harden({
-    give: { In: null },
-    want: { Out: null },
-  });
-
   const swap = seat => {
+    assertProposalShape(seat, {
+      give: { In: null },
+      want: { Out: null },
+    });
     const {
       give: { In: amountIn },
       want: { Out: wantedAmountOut },
@@ -126,11 +125,7 @@ export const makeMakeSwapInvitation = (
     throw new Error(`brands were not recognized`);
   };
 
-  const makeSwapInvitation = () =>
-    zcf.makeInvitation(
-      assertProposalShape(swap, swapExpected),
-      'autoswap swap',
-    );
+  const makeSwapInvitation = () => zcf.makeInvitation(swap, 'autoswap swap');
 
   return makeSwapInvitation;
 };

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -61,6 +61,10 @@ const start = zcf => {
   };
 
   const buy = buyerSeat => {
+    assertProposalShape(buyerSeat, {
+      want: { Items: null },
+      give: { Money: null },
+    });
     const currentItemsForSale = sellerSeat.getAmountAllocated('Items');
     const providedMoney = buyerSeat.getAmountAllocated('Money');
 
@@ -112,14 +116,7 @@ const start = zcf => {
         sellerSeat && !itemsMath.isEmpty(itemsAmount),
         details`no items are for sale`,
       );
-      const buyerExpected = harden({
-        want: { Items: null },
-        give: { Money: null },
-      });
-      return zcf.makeInvitation(
-        assertProposalShape(buy, buyerExpected),
-        'buyer',
-      );
+      return zcf.makeInvitation(buy, 'buyer');
     },
     getAvailableItems: publicFacet.getAvailableItems,
     getItemsIssuer: publicFacet.getItemsIssuer,

--- a/packages/zoe/src/contracts/simpleExchange.js
+++ b/packages/zoe/src/contracts/simpleExchange.js
@@ -9,6 +9,7 @@ import {
   assertProposalShape,
   assertIssuerKeywords,
 } from '../contractSupport/zoeHelpers';
+import { assert } from '@agoric/assert';
 
 /**
  * SimpleExchange is an exchange with a simple matching algorithm, which allows
@@ -95,39 +96,33 @@ const start = zcf => {
     return counterOffers;
   }
 
-  const sellAssetForPrice = harden({
-    give: { Asset: null },
-    want: { Price: null },
-  });
-
   const sell = seat => {
+    assertProposalShape(seat, {
+      give: { Asset: null },
+      want: { Price: null },
+    });
     buySeats = swapIfCanTradeAndUpdateBook(buySeats, sellSeats, seat);
     return 'Order Added';
   };
 
-  const sellHandler = assertProposalShape(sell, sellAssetForPrice);
-
-  const buyAssetForPrice = harden({
-    give: { Price: null },
-    want: { Asset: null },
-  });
-
   const buy = seat => {
+    assertProposalShape(seat, {
+      give: { Price: null },
+      want: { Asset: null },
+    });
     sellSeats = swapIfCanTradeAndUpdateBook(sellSeats, buySeats, seat);
     return 'Order Added';
   };
-
-  const buyHandler = assertProposalShape(buy, buyAssetForPrice);
 
   /** @type {OfferHandler} */
   const exchangeOfferHandler = seat => {
     // Buy Order
     if (seat.getProposal().want.Asset) {
-      return buyHandler(seat);
+      return buy(seat);
     }
     // Sell Order
     if (seat.getProposal().give.Asset) {
-      return sellHandler(seat);
+      return sell(seat);
     }
     // Eject because the offer must be invalid
     throw seat.kickOut(

--- a/packages/zoe/src/contracts/simpleExchange.js
+++ b/packages/zoe/src/contracts/simpleExchange.js
@@ -9,7 +9,6 @@ import {
   assertProposalShape,
   assertIssuerKeywords,
 } from '../contractSupport/zoeHelpers';
-import { assert } from '@agoric/assert';
 
 /**
  * SimpleExchange is an exchange with a simple matching algorithm, which allows

--- a/packages/zoe/test/swingsetTests/brokenContracts/crashingAutoRefund.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/crashingAutoRefund.js
@@ -51,12 +51,11 @@ const start = zcf => {
   const makeThrowingInvitation = () =>
     zcf.makeInvitation(throwing, 'getRefund');
 
-  const swapOfferExpected = harden({
-    give: { Asset: null },
-    want: { Price: null },
-  });
-
   const makeMatchingInvitation = firstSeat => {
+    assertProposalShape(firstSeat, {
+      give: { Asset: null },
+      want: { Price: null },
+    });
     offersCount += 1;
     const { want, give } = firstSeat.getProposal();
 
@@ -71,10 +70,7 @@ const start = zcf => {
   };
 
   const makeSwapInvitation = () =>
-    zcf.makeInvitation(
-      assertProposalShape(makeMatchingInvitation, swapOfferExpected),
-      'firstOffer',
-    );
+    zcf.makeInvitation(makeMatchingInvitation, 'firstOffer');
 
   offersCount += 1;
   const publicFacet = harden({

--- a/packages/zoe/test/swingsetTests/zoe/vat-dave.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-dave.js
@@ -85,8 +85,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         details`source bundle didn't match at "asset: give.Asset,"`,
       );
       assert(
-        source.includes('firstProposalExpected'),
-        details`source bundle didn't match at "firstProposalExpected"`,
+        source.includes(
+          'const swapResult = swap(zcf, firstSeat, matchingSeat);',
+        ),
+        details`source bundle didn't match at "const swapResult = swap(zcf, firstSeat, matchingSeat);"`,
       );
       assert(
         source.includes('makeMatchingInvitation'),

--- a/packages/zoe/test/swingsetTests/zoe/vat-dave.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-dave.js
@@ -85,10 +85,8 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         details`source bundle didn't match at "asset: give.Asset,"`,
       );
       assert(
-        source.includes(
-          'const swapResult = swap(zcf, firstSeat, matchingSeat);',
-        ),
-        details`source bundle didn't match at "const swapResult = swap(zcf, firstSeat, matchingSeat);"`,
+        source.includes('swap(zcf, firstSeat, matchingSeat)'),
+        details`source bundle didn't match at "swap(zcf, firstSeat, matchingSeat)"`,
       );
       assert(
         source.includes('makeMatchingInvitation'),

--- a/packages/zoe/test/unitTests/contracts/escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/escrowToVote.js
@@ -47,6 +47,9 @@ const start = zcf => {
   };
 
   const voteHandler = voterSeat => {
+    assertProposalShape(voterSeat, {
+      give: { Assets: null },
+    });
     const voter = harden({
       /**
        * Vote on a particular issue
@@ -70,10 +73,6 @@ const start = zcf => {
     });
     return voter;
   };
-
-  const expectedVoterProposal = harden({
-    give: { Assets: null },
-  });
 
   const creatorFacet = harden({
     closeElection: () => {
@@ -100,10 +99,7 @@ const start = zcf => {
     },
     makeVoterInvitation: () => {
       assert(electionOpen, 'the election is closed');
-      return zcf.makeInvitation(
-        assertProposalShape(voteHandler, expectedVoterProposal),
-        'voter',
-      );
+      return zcf.makeInvitation(voteHandler, 'voter');
     },
   });
 

--- a/packages/zoe/test/unitTests/contracts/useObjExample.js
+++ b/packages/zoe/test/unitTests/contracts/useObjExample.js
@@ -19,6 +19,9 @@ const start = zcf => {
   const amountMath = zcf.getAmountMath(pixelBrand);
 
   const makeUseObj = seat => {
+    assertProposalShape(seat, {
+      give: { Pixels: null },
+    });
     const useObj = harden({
       /**
        * (Pretend to) color some pixels.
@@ -49,17 +52,9 @@ const start = zcf => {
     return useObj;
   };
 
-  const expected = harden({
-    give: { Pixels: null },
-  });
-
   const publicFacet = {
     // The only publicFacet method is to make an invitation.
-    makeInvitation: () =>
-      zcf.makeInvitation(
-        assertProposalShape(makeUseObj, expected),
-        'use object',
-      ),
+    makeInvitation: () => zcf.makeInvitation(makeUseObj, 'use object'),
   };
 
   return harden({ publicFacet });


### PR DESCRIPTION
We had wanted to rename `assertProposalShape` because the assertion aspect of the name wasn't congruent with the fact it was a combinator. Dean suggested (see #1565) changing the helper so that it is within the offerHandler and is no longer a combinator. In doing so, I realized that we shouldn't add a method to `seat` because we want these checkers to be very flexible. So, it turned out that the easiest thing to do was to simply keep the name and change `assertProposalShape` to take a `seat` parameter instead, and put in the offerHandler.

Closes #1565 
