### PR TITLE
fix: revamp multipoolAutoswap: liquidity bug, in vs. out prices

### DIFF
--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -96,7 +96,7 @@
  * @callback MakeZCFMint
  * @param {Keyword} keyword
  * @param {AmountMathKind=} amountMathKind
- * @returns {Promise<ZCFMint>}
+ * @returns {ZCFMint}
  */
 
 /**

--- a/packages/zoe/src/contractSupport/bondingCurves.js
+++ b/packages/zoe/src/contractSupport/bondingCurves.js
@@ -37,8 +37,7 @@ export const getInputPrice = ({
   const numerator = multiply(inputWithFee, outputReserve);
   const denominator = add(multiply(inputReserve, 10000), inputWithFee);
 
-  const outputValue = floorDivide(numerator, denominator);
-  return outputValue;
+  return floorDivide(numerator, denominator);
 };
 
 /**
@@ -127,12 +126,14 @@ export const calcSecondaryRequired = ({
     return secondaryIn;
   }
 
-  const exact =
-    multiply(centralIn, secondaryPool) === multiply(secondaryIn, centralPool);
   const scaledSecondary = floorDivide(
     multiply(centralIn, secondaryPool),
     centralPool,
   );
+  const exact =
+    multiply(centralIn, secondaryPool) ===
+    multiply(scaledSecondary, centralPool);
+
   // doesn't match the x-y-k.pdf paper, but more correct. When the ratios are
   // exactly equal, lPrime is exactly l * (1 + alpha) and adding one is wrong
   return exact ? scaledSecondary : 1 + scaledSecondary;

--- a/packages/zoe/src/contracts/exported.js
+++ b/packages/zoe/src/contracts/exported.js
@@ -54,6 +54,36 @@
  * @property {() => Record<string, Amount>} getPoolAllocation get an
  * AmountKeywordRecord showing the current balances in the pool.
  */
+
+/**
+ * @typedef {Object} MultipoolAutoswapPublicFacet
+ * @property {(issuer: Issuer, keyword: Keyword) => Pool} addPool
+ * add a new liquidity pool
+ * @property {() => Promise<Invitation>} makeSwapInvitation synonym for
+ * makeSwapInInvitation
+ * @property {() => Promise<Invitation>} makeSwapInInvitation make an invitation
+ * that allows one to do a swap in which the In amount is specified and the Out
+ * amount is calculated
+ * @property {() => Promise<Invitation>} makeSwapOutInvitation make an invitation
+ * that allows one to do a swap in which the Out amount is specified and the In
+ * amount is calculated
+ * @property {() => Promise<Invitation>} makeAddLiquidityInvitation make an
+ * invitation that allows one to add liquidity to the pool.
+ * @property {() => Promise<Invitation>} makeRemoveLiquidityInvitation make an
+ * invitation that allows one to remove liquidity from the pool.
+ * @property {() => Issuer} getLiquidityIssuer
+ * @property {() => number} getLiquiditySupply get the current value of
+ * liquidity held by investors.
+ * @property {(amountIn: Amount, brandOut: Brand) => Amount} getInputPrice
+ * calculate the amount of brandOut that will be returned if the amountIn is
+ * offered using makeSwapInInvitation at the current price.
+ * @property {(amountOut: Amount, brandIn: Brand) => Amount} getOutputPrice
+ * calculate the amount of brandIn that is required in order to get amountOut
+ * using makeSwapOutInvitation at the current price
+ * @property {() => Record<string, Amount>} getPoolAllocation get an
+ * AmountKeywordRecord showing the current balances in the pool.
+ */
+
 /**
  * @typedef {Object} AutomaticRefundPublicFacet
  * @property {() => number} getOffersCount

--- a/packages/zoe/src/contracts/exported.js
+++ b/packages/zoe/src/contracts/exported.js
@@ -56,8 +56,25 @@
  */
 
 /**
+ * @typedef {Object} Pool
+ * @property {(inputValue: Value) => Amount } getSecondaryToCentralInputPrice
+ * @property {(inputValue: Value) => Amount } getCentralToSecondaryInputPrice
+ * @property {(inputValue: Value) => Amount } getSecondaryToCentralOutputPrice
+ * @property {(inputValue: Value) => Amount } getCentralToSecondaryOutputPrice
+ * @property {() => number} getLiquiditySupply
+ * @property {(seat: ZCFSeat) => string} addLiquidity
+ * @property {(seat: ZCFSeat) => string} removeLiquidity
+ * @property {() => ZCFSeat} getPoolSeat
+ * @property {() => AmountMath} getAmountMath - get the amountMath for this
+ * pool's secondary brand
+ * @property {() => AmountMath} getCentralAmountMath
+ * @property {() => Amount} getSecondaryAmount
+ * @property {() => Amount} getCentralAmount
+ */
+
+/**
  * @typedef {Object} MultipoolAutoswapPublicFacet
- * @property {(issuer: Issuer, keyword: Keyword) => Pool} addPool
+ * @property {(issuer: Issuer, keyword: Keyword) => Promise<Issuer>} addPool
  * add a new liquidity pool
  * @property {() => Promise<Invitation>} makeSwapInvitation synonym for
  * makeSwapInInvitation

--- a/packages/zoe/src/contracts/multipoolAutoswap/getCurrentPrice.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/getCurrentPrice.js
@@ -1,47 +1,82 @@
+import '../../../exported';
+
 /**
+ * Build functions to calculate prices for multipoolAutoswap. Two methods are
+ * returned. In one the caller specifies the amount they will pay, and in the
+ * other they specify the amount they wish to receive.
  *
  * @param {(brand: Brand) => boolean} isSecondary
  * @param {(brand: Brand) => boolean} isCentral
  * @param {(brand: Brand) => Pool} getPool
  */
 
-import '../../../exported';
-
 export const makeGetCurrentPrice = (isSecondary, isCentral, getPool) => {
   /**
-   * `getCurrentPrice` calculates the result of a trade, given a certain
+   * `getOutputForGivenInput` calculates the result of a trade, given a certain
    * amount of digital assets in.
-   * @param {Amount} amountIn - the amount of digital assets to be
-   * sent in
-   * @param {Brand} brandOut - the brand of the requested payment.
+   * @param {Amount} amountIn - the amount of digital
+   * assets to be sent in
+   * @param {Brand} brandOut - The brand of asset desired
+   * @return {Amount} the amount that would be paid out at the current price.
    */
-  // eslint-disable-next-line consistent-return
-  const getCurrentPrice = (amountIn, brandOut) => {
-    // BrandIn could either be the central token brand, or one of
-    // the secondary token brands.
+  const getOutputForGivenInput = (amountIn, brandOut) => {
     const { brand: brandIn, value: inputValue } = amountIn;
 
     if (isCentral(brandIn) && isSecondary(brandOut)) {
-      return getPool(brandOut).getCurrentPrice(true, inputValue);
+      return getPool(brandOut).getCentralToSecondaryInputPrice(inputValue);
     }
 
     if (isSecondary(brandIn) && isCentral(brandOut)) {
-      return getPool(brandIn).getCurrentPrice(false, inputValue);
+      return getPool(brandIn).getSecondaryToCentralInputPrice(inputValue);
     }
 
     if (isSecondary(brandIn) && isSecondary(brandOut)) {
-      // We must do two consecutive `getCurrentPrice` calls: from
+      // We must do two consecutive calls to get the price: from
       // the brandIn to the central token, then from the central
       // token to the brandOut.
-      const centralTokenAmount = getPool(brandIn).getCurrentPrice(
-        false,
-        inputValue,
+      const centralTokenAmount = getPool(
+        brandIn,
+      ).getSecondaryToCentralInputPrice(inputValue);
+      return getPool(brandOut).getCentralToSecondaryInputPrice(
+        centralTokenAmount.value,
       );
-      return getPool(brandOut).getCurrentPrice(true, centralTokenAmount.value);
     }
 
     throw new Error(`brands were not recognized`);
   };
 
-  return getCurrentPrice;
+  /**
+   * `getInputForGivenOutput` calculates the amount of assets required to be
+   * provided in order to obtain a specified gain.
+   * @param {Amount} amountOut - the amount of digital assets desired
+   * @param {Brand} brandIn - The brand of asset desired
+   * @return {Amount} The amount required to be paid in order to gain amountOut
+   */
+  const getInputForGivenOutput = (amountOut, brandIn) => {
+    const { brand: brandOut, value: outputValue } = amountOut;
+
+    if (isCentral(brandIn) && isSecondary(brandOut)) {
+      return getPool(brandOut).getCentralToSecondaryOutputPrice(outputValue);
+    }
+
+    if (isSecondary(brandIn) && isCentral(brandOut)) {
+      return getPool(brandIn).getSecondaryToCentralOutputPrice(outputValue);
+    }
+
+    if (isSecondary(brandIn) && isSecondary(brandOut)) {
+      // We must do two consecutive calls to get the price: from
+      // the brandIn to the central token, then from the central
+      // token to the brandOut.
+      const centralTokenAmount = getPool(
+        brandIn,
+      ).getSecondaryToCentralOutputPrice(outputValue);
+      return getPool(brandOut).getCentralToSecondaryOutputPrice(
+        centralTokenAmount.value,
+      );
+    }
+
+    throw new Error(`brands were not recognized`);
+  };
+
+  return { getOutputForGivenInput, getInputForGivenOutput };
 };

--- a/packages/zoe/src/contracts/multipoolAutoswap/multipoolAutoswap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/multipoolAutoswap.js
@@ -38,9 +38,9 @@ import '../../../exported';
  * the input price (swapIn, getInputPrice) or the output price (swapOut,
  * getOutPutPrice) is fixed. For swaps, the required keywords are `In` for the
  * trader's `give` amount, and `Out` for the trader's `want` amount.
- * getInputPrice and getOutPrice each take an Amount for the direction that is
- * being specified, and just a brand for the desired value, which is returned as
- * the appropriate amount.
+ * getInputPrice and getOutputPrice each take an Amount for the direction that
+ * is being specified, and just a brand for the desired value, which is returned
+ * as the appropriate amount.
  *
  * When adding and removing liquidity, the keywords are Central, Secondary, and
  * Liquidity. adding liquidity has Central and Secondary in the `give` section,

--- a/packages/zoe/src/contracts/multipoolAutoswap/multipoolAutoswap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/multipoolAutoswap.js
@@ -13,9 +13,9 @@ import { makeMakeRemoveLiquidityInvitation } from './removeLiquidity';
 import '../../../exported';
 
 /**
- * Autoswap is a rewrite of Uniswap. Please see the documentation for
- * more
- * https://agoric.com/documentation/zoe/guide/contracts/autoswap.html
+ * Multipool Autoswap is a rewrite of Uniswap that supports multiple liquidity
+ * pools, and direct exchanges across pools. Please see the documentation for
+ * more:  https://agoric.com/documentation/zoe/guide/contracts/autoswap.html
  *
  * We expect that this contract will have tens to hundreds of issuers.
  * Each liquidity pool is between the central token and a secondary
@@ -30,9 +30,25 @@ import '../../../exported';
  *
  * When the contract is instantiated, the central token is specified
  * in the terms. Separate invitations are available by calling methods
- * on the publicFacet for adding and removing liquidity, and for
- * making trades. Other publicFacet operations support monitoring
- * prices and the sizes of pools.
+ * on the publicFacet for adding and removing liquidity and for
+ * making trades. Other publicFacet operations support querying
+ * prices and the sizes of pools. New Pools can be created with addPool().
+ *
+ * When making trades or requesting prices, the caller must specify that either
+ * the input price (swapIn, getInputPrice) or the output price (swapOut,
+ * getOutPutPrice) is fixed. For swaps, the required keywords are `In` for the
+ * trader's `give` amount, and `Out` for the trader's `want` amount.
+ * getInputPrice and getOutPrice each take an Amount for the direction that is
+ * being specified, and just a brand for the desired value, which is returned as
+ * the appropriate amount.
+ *
+ * When adding and removing liquidity, the keywords are Central, Secondary, and
+ * Liquidity. adding liquidity has Central and Secondary in the `give` section,
+ * while removing liquidity has `want` and `give` swapped.
+ *
+ * Transactions that don't require an invitation include addPool, and the
+ * queries: getInputPrice, getOutputPrice, getPoolAllocation,
+ * getLiquidityIssuer, and getLiquiditySupply.
  *
  * @type {ContractStartFn}
  */
@@ -51,6 +67,7 @@ const start = zcf => {
   const isSecondary = secondaryBrandToPool.has;
   const isCentral = brand => brand === centralBrand;
 
+  const getLiquiditySupply = brand => getPool(brand).getLiquiditySupply();
   const getLiquidityIssuer = brand => getPool(brand).getLiquidityIssuer();
   const addPool = makeAddPool(zcf, isSecondary, initPool, centralBrand);
   const getPoolAllocation = brand => {
@@ -58,13 +75,15 @@ const start = zcf => {
       .getPoolSeat()
       .getCurrentAllocation();
   };
-  const getCurrentPrice = makeGetCurrentPrice(isSecondary, isCentral, getPool);
-  const makeSwapInvitation = makeMakeSwapInvitation(
-    zcf,
-    isSecondary,
-    isCentral,
-    getPool,
-  );
+
+  const {
+    getOutputForGivenInput,
+    getInputForGivenOutput,
+  } = makeGetCurrentPrice(isSecondary, isCentral, getPool);
+  const {
+    makeSwapInInvitation,
+    makeSwapOutInvitation,
+  } = makeMakeSwapInvitation(zcf, isSecondary, isCentral, getPool);
   const makeAddLiquidityInvitation = makeMakeAddLiquidityInvitation(
     zcf,
     getPool,
@@ -75,12 +94,17 @@ const start = zcf => {
     getPool,
   );
 
+  /** @type {MultipoolAutoswapPublicFacet} */
   const publicFacet = {
     addPool,
     getPoolAllocation,
     getLiquidityIssuer,
-    getCurrentPrice,
-    makeSwapInvitation,
+    getLiquiditySupply,
+    getInputPrice: getOutputForGivenInput,
+    getOutputPrice: getInputForGivenOutput,
+    makeSwapInvitation: makeSwapInInvitation,
+    makeSwapInInvitation,
+    makeSwapOutInvitation,
     makeAddLiquidityInvitation,
     makeRemoveLiquidityInvitation,
   };

--- a/packages/zoe/src/contracts/multipoolAutoswap/pool.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/pool.js
@@ -201,10 +201,11 @@ export const makeAddPool = (zcf, isSecondary, initPool, centralBrand) => {
     const liquidityKeyword = `${keyword}Liquidity`;
     zcf.assertUniqueKeyword(liquidityKeyword);
 
-    const secondaryBrandP = E(secondaryIssuer).getBrand();
-    const secondaryMathKindP = E(secondaryIssuer).getAmountMathKind();
-    const promises = [secondaryMathKindP, secondaryBrandP];
-    const [secondaryMathKind, secondaryBrand] = await Promise.all(promises);
+    const [secondaryMathKind, secondaryBrand] = await Promise.all([
+      E(secondaryIssuer).getAmountMathKind(),
+      E(secondaryIssuer).getBrand(),
+    ]);
+
     assert(
       !isSecondary(secondaryBrand),
       details`issuer ${secondaryIssuer} already has a pool`,

--- a/packages/zoe/src/contracts/multipoolAutoswap/swap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/swap.js
@@ -3,7 +3,6 @@ import { assertProposalShape, trade } from '../../contractSupport';
 import '../../../exported';
 
 /**
- *
  * @param {ContractFacet} zcf
  * @param {(brand: Brand) => boolean} isSecondary
  * @param {(brand: Brand) => boolean} isCentral
@@ -15,7 +14,8 @@ export const makeMakeSwapInvitation = (
   isCentral,
   getPool,
 ) => {
-  const swap = seat => {
+  // trade with a stated amountIn.
+  const swapIn = seat => {
     assertProposalShape(seat, {
       give: { In: null },
       want: { Out: null },
@@ -32,7 +32,7 @@ export const makeMakeSwapInvitation = (
 
     if (isCentral(brandIn) && isSecondary(brandOut)) {
       const pool = getPool(brandOut);
-      const amountOut = pool.getCurrentPrice(true, inputValue);
+      const amountOut = pool.getCentralToSecondaryInputPrice(inputValue);
       trade(
         zcf,
         {
@@ -52,7 +52,7 @@ export const makeMakeSwapInvitation = (
 
     if (isSecondary(brandIn) && isCentral(brandOut)) {
       const pool = getPool(brandIn);
-      const amountOut = pool.getCurrentPrice(false, inputValue);
+      const amountOut = pool.getSecondaryToCentralInputPrice(inputValue);
       trade(
         zcf,
         {
@@ -78,10 +78,11 @@ export const makeMakeSwapInvitation = (
       const brandInPool = getPool(brandIn);
       const brandOutPool = getPool(brandOut);
 
-      const centralTokenAmount = brandInPool.getCurrentPrice(false, inputValue);
-      const amountOut = brandOutPool.getCurrentPrice(
-        true,
-        centralTokenAmount.value,
+      const centralAmount = brandInPool.getSecondaryToCentralInputPrice(
+        inputValue,
+      );
+      const amountOut = brandOutPool.getCentralToSecondaryInputPrice(
+        centralAmount.value,
       );
 
       const seatStaging = seat.stage(
@@ -102,14 +103,14 @@ export const makeMakeSwapInvitation = (
         ),
         Central: centralTokenAmountMath.subtract(
           brandInPool.getCentralAmount(),
-          centralTokenAmount,
+          centralAmount,
         ),
       });
 
       const poolBrandOutStaging = brandOutPool.getPoolSeat().stage({
         Central: centralTokenAmountMath.add(
           brandOutPool.getCentralAmount(),
-          centralTokenAmount,
+          centralAmount,
         ),
         Secondary: brandOutAmountMath.subtract(
           brandOutPool.getSecondaryAmount(),
@@ -125,7 +126,131 @@ export const makeMakeSwapInvitation = (
     throw new Error(`brands were not recognized`);
   };
 
-  const makeSwapInvitation = () => zcf.makeInvitation(swap, 'autoswap swap');
+  // trade with a stated amount out.
+  const swapOut = seat => {
+    assertProposalShape(seat, {
+      give: { In: null },
+      want: { Out: null },
+    });
+    // The offer's amountOut is exact; the offeredAmountIn is a max.
+    const {
+      give: { In: offeredAmountIn },
+      want: { Out: amountOut },
+    } = seat.getProposal();
+    const { brand: brandOut, value: outputValue } = amountOut;
+    const brandIn = offeredAmountIn.brand;
 
-  return makeSwapInvitation;
+    // we could be swapping (1) central to secondary, (2) secondary to
+    // central, or (3) secondary to secondary
+
+    if (isCentral(brandOut) && isSecondary(brandIn)) {
+      const pool = getPool(brandIn);
+      const amountIn = pool.getCentralToSecondaryOutputPrice(outputValue);
+
+      const brandInAmountMath = getPool(brandIn).getAmountMath();
+      if (!brandInAmountMath.isGTE(offeredAmountIn, amountIn)) {
+        seat.kickOut();
+        return `insufficient funds offered`;
+      }
+
+      trade(
+        zcf,
+        {
+          seat: pool.getPoolSeat(),
+          gains: { Secondary: amountIn },
+          losses: { Central: amountOut },
+        },
+        {
+          seat,
+          gains: { Out: amountOut },
+          losses: { In: amountIn },
+        },
+      );
+      seat.exit();
+      return `Swap successfully completed.`;
+    }
+
+    if (isSecondary(brandOut) && isCentral(brandIn)) {
+      const pool = getPool(brandOut);
+      const amountIn = pool.getSecondaryToCentralOutputPrice(outputValue);
+      trade(
+        zcf,
+        {
+          seat: pool.getPoolSeat(),
+          gains: { Central: amountIn },
+          losses: { Secondary: amountOut },
+        },
+        {
+          seat,
+          gains: { Out: amountOut },
+          losses: { In: amountIn },
+        },
+      );
+      seat.exit();
+      return `Swap successfully completed.`;
+    }
+
+    if (isSecondary(brandOut) && isSecondary(brandIn)) {
+      // We must do two consecutive `getCurrentPrice` calls: from
+      // the brandOut to the central token, then from the central
+      // token to the brandIn.
+
+      const brandInPool = getPool(brandOut);
+      const brandOutPool = getPool(brandIn);
+
+      const centralAmount = brandInPool.getSecondaryToCentralOutputPrice(
+        outputValue,
+      );
+      const amountIn = brandOutPool.getCentralToSecondaryOutputPrice(
+        centralAmount.value,
+      );
+
+      const seatStaging = seat.stage(
+        harden({
+          In: brandInPool.getAmountMath().getEmpty(),
+          Out: amountOut,
+        }),
+      );
+
+      const centralAmountMath = brandInPool.getCentralAmountMath();
+      const brandInAmountMath = brandInPool.getAmountMath();
+      const brandOutAmountMath = brandOutPool.getAmountMath();
+
+      const poolBrandInStaging = brandInPool.getPoolSeat().stage({
+        Secondary: brandInAmountMath.add(
+          brandInPool.getSecondaryAmount(),
+          amountIn,
+        ),
+        Central: centralAmountMath.subtract(
+          brandInPool.getCentralAmount(),
+          centralAmount,
+        ),
+      });
+
+      const poolBrandOutStaging = brandOutPool.getPoolSeat().stage({
+        Central: centralAmountMath.add(
+          brandOutPool.getCentralAmount(),
+          centralAmount,
+        ),
+        Secondary: brandOutAmountMath.subtract(
+          brandOutPool.getSecondaryAmount(),
+          amountOut,
+        ),
+      });
+
+      zcf.reallocate(poolBrandInStaging, poolBrandOutStaging, seatStaging);
+      seat.exit();
+      return `Swap successfully completed.`;
+    }
+
+    throw new Error(`brands were not recognized`);
+  };
+
+  const makeSwapInInvitation = () =>
+    zcf.makeInvitation(swapIn, 'autoswap swapIn');
+
+  const makeSwapOutInvitation = () =>
+    zcf.makeInvitation(swapOut, 'autoswap swapOut');
+
+  return { makeSwapInInvitation, makeSwapOutInvitation };
 };

--- a/packages/zoe/test/autoswapJig.js
+++ b/packages/zoe/test/autoswapJig.js
@@ -1,0 +1,323 @@
+import { E } from '@agoric/eventual-send';
+import { makeLocalAmountMath } from '@agoric/ertp';
+import { natSafeMath } from '../src/contractSupport';
+
+import { assertOfferResult, assertPayoutAmount } from './zoeTestHelpers';
+
+const { add, subtract, multiply, floorDivide } = natSafeMath;
+
+// A test Harness that simplifies tests of autoswap and multipoolAutoswap. The
+// main component is the Trader, which can be instructed to make various offers
+// to the contracts, and will validate pre- and post-conditions, instructed by
+// a description of the expected previous state, the details of the offer and
+// the expected results. This leaves the tests with the responsibility to
+// clearly specify what changes should be expected. Helper methods calculate the
+// changes expected with various successful requests, so the test code only
+// needs additional detail when the expected outcome varies from common cases.
+
+const makeScaleFn = (xPre, xPost) => value => {
+  const deltaX = xPost > xPre ? subtract(xPost, xPre) : subtract(xPre, xPost);
+  return floorDivide(multiply(deltaX, value), xPre);
+};
+
+// deltaY = alpha * gamma * yPre / ( 1 + alpha * gamma )
+// gamma is (10000 - fee) / 10000
+// alpha is deltaX / xPre
+// reducing to a single division:
+//    deltaY = deltaX * gammaNum * yPre / (xPre * gammaDen + deltaX * gammaNum)
+export const outputFromInputPrice = (xPre, yPre, deltaX, fee) => {
+  const gammaNumerator = 10000 - fee;
+  return floorDivide(
+    multiply(multiply(deltaX, yPre), gammaNumerator),
+    add(multiply(xPre, 10000), multiply(deltaX, gammaNumerator)),
+  );
+};
+
+// deltaX = beta * xPre / ( (1 - beta) * gamma )
+// gamma is (10000 - fee) / 10000
+// beta is deltaY / yPre
+// reducing to a single division:
+//    deltaX = deltaY * xPre * 10000 / (yPre - deltaY ) * gammaNum)
+export const priceFromTargetOutput = (deltaY, yPre, xPre, fee) => {
+  const gammaNumerator = 10000 - fee;
+  return floorDivide(
+    multiply(multiply(deltaY, xPre), 10000),
+    multiply(subtract(yPre, deltaY), gammaNumerator),
+  );
+};
+
+// calculation of next state for a successful addLiquidity offer. Doesn't apply
+// to initial liquidity.
+export const scaleForAddLiquidity = (poolState, deposits, exactRatio) => {
+  const { c: cDeposit, s: sDeposit } = deposits;
+
+  const poolCentralPost = add(poolState.c, cDeposit);
+  const scaleByAlpha = makeScaleFn(poolState.c, poolCentralPost);
+  // The test declares when it expects an exact ratio
+  const deltaS = exactRatio
+    ? scaleByAlpha(poolState.s)
+    : add(1, scaleByAlpha(poolState.s));
+  const poolSecondaryPost = add(poolState.s, deltaS);
+  const liquidityPost = add(poolState.l, scaleByAlpha(poolState.l));
+
+  return {
+    c: poolCentralPost,
+    s: poolSecondaryPost,
+    l: liquidityPost,
+    k: multiply(poolCentralPost, poolSecondaryPost),
+    payoutL: subtract(liquidityPost, poolState.l),
+    payoutC: 0,
+    payoutS: subtract(sDeposit, deltaS),
+  };
+};
+
+// The state of the pool at the start of a transaction. The values of central,
+// and secondary pools, the liquidity outstanding, and K (the product of c and
+// s). K may turn out to always be redundant, but it was helpful in clarifying
+// which operations change K.
+export const updatePoolState = (oldState, newState) => ({
+  ...oldState,
+  c: newState.c,
+  s: newState.s,
+  l: newState.l,
+  k: newState.k,
+});
+
+export const makeTrader = async (purses, zoe, publicFacet, centralIssuer) => {
+  const purseMap = new Map();
+  for (const p of purses) {
+    purseMap.set(p.getAllegedBrand(), p);
+  }
+
+  const withdrawPayment = amount => {
+    return purseMap.get(amount.brand).withdraw(amount);
+  };
+
+  // autoswap ignores issuer, multipoolAutoswap needs to know which pool
+  const getLiquidity = issuer =>
+    E(publicFacet).getLiquiditySupply(issuer.getBrand());
+  const getPoolAllocation = issuer =>
+    E(publicFacet).getPoolAllocation(issuer.getBrand());
+
+  const trader = harden({
+    offerAndTrade: async (outAmount, inAmount, swapIn) => {
+      const proposal = harden({
+        want: { Out: outAmount },
+        give: { In: inAmount },
+      });
+      const payment = harden({ In: withdrawPayment(inAmount) });
+      const invitation = swapIn
+        ? E(publicFacet).makeSwapInInvitation()
+        : E(publicFacet).makeSwapOutInvitation();
+      const seat = await zoe.offer(invitation, proposal, payment);
+      return seat;
+    },
+
+    tradeAndCheck: async (
+      t,
+      swapIn,
+      prePoolState,
+      tradeDetails,
+      expected,
+      { Secondary: secondaryIssuer },
+    ) => {
+      const { make: central } = await makeLocalAmountMath(centralIssuer);
+      const { make: secondary } = await makeLocalAmountMath(secondaryIssuer);
+      // just check that the trade went through, and the results are as stated.
+      // The test will declare fees, refunds, and figure out when the trade
+      // gets less than requested
+
+      // c: central, s: secondary, l: liquidity
+      const { c: cPoolPre, s: sPoolPre, l: lPre, k: kPre } = prePoolState;
+      const { inAmount, outAmount } = tradeDetails;
+      const {
+        c: cPost,
+        s: sPost,
+        l: lPost,
+        k: kPost,
+        in: inExpected,
+        out: outExpected,
+      } = expected;
+
+      const poolPre = await getPoolAllocation(secondaryIssuer);
+      t.deepEqual(central(cPoolPre), poolPre.Central, `central before swap`);
+      t.deepEqual(secondary(sPoolPre), poolPre.Secondary, `s before swap`);
+      t.is(
+        lPre,
+        await getLiquidity(secondaryIssuer),
+        'liquidity pool before trade',
+      );
+      t.is(kPre, sPoolPre * cPoolPre);
+
+      const seat = await trader.offerAndTrade(outAmount, inAmount, swapIn);
+      assertOfferResult(t, seat, 'Swap successfully completed.');
+      const [inIssuer, inMath, outIssuer, out] =
+        inAmount.brand === centralIssuer.getBrand()
+          ? [centralIssuer, central, secondaryIssuer, secondary]
+          : [secondaryIssuer, secondary, centralIssuer, central];
+      const { In: refund, Out: payout } = await seat.getPayouts();
+      assertPayoutAmount(t, outIssuer, payout, out(outExpected), 'trade out');
+      assertPayoutAmount(t, inIssuer, refund, inMath(inExpected), 'trade in');
+
+      const poolPost = await getPoolAllocation(secondaryIssuer);
+      t.deepEqual(central(cPost), poolPost.Central, `central after swap`);
+      t.deepEqual(secondary(sPost), poolPost.Secondary, `s after swap`);
+      t.is(kPost, sPost * cPost);
+
+      await seat.getOfferResult();
+      t.is(lPost, await getLiquidity(secondaryIssuer), 'liquidity after');
+    },
+
+    // This check only handles success. Failing calls should do something else.
+    addLiquidityAndCheck: async (
+      t,
+      priorPoolState,
+      details,
+      expected,
+      { Liquidity: liquidityIssuer, Secondary: secondaryIssuer },
+    ) => {
+      const { make: central } = await makeLocalAmountMath(centralIssuer);
+      const { make: secondary } = await makeLocalAmountMath(secondaryIssuer);
+      const { make: liquidity } = await makeLocalAmountMath(liquidityIssuer);
+      // just check that it went through, and the results are as stated.
+      // The test will declare fees, refunds, and figure out when the trade
+      // gets less than requested
+      const { c: cPre, s: sPre, l: lPre, k: kPre } = priorPoolState;
+      const { cAmount, sAmount, lAmount = liquidity(0) } = details;
+      const {
+        c: cPost,
+        s: sPost,
+        l: lPost,
+        k: kPost,
+        payoutL,
+        payoutC,
+        payoutS,
+      } = expected;
+      t.truthy(payoutC === 0 || payoutS === 0, 'only refund one side');
+      const scaleByAlpha = makeScaleFn(cPre, cPost);
+
+      const poolPre = await getPoolAllocation(secondaryIssuer);
+      t.deepEqual(central(cPre), poolPre.Central, `central before add liq`);
+      t.deepEqual(secondary(sPre), poolPre.Secondary, `s before add liq`);
+      t.is(
+        lPre,
+        await getLiquidity(secondaryIssuer),
+        'liquidity pool before add',
+      );
+      t.is(kPre, sPre * cPre);
+
+      const proposal = harden({
+        give: { Central: cAmount, Secondary: sAmount },
+        want: { Liquidity: lAmount },
+      });
+      const payment = harden({
+        Central: withdrawPayment(cAmount),
+        Secondary: withdrawPayment(sAmount),
+      });
+
+      const seat = await zoe.offer(
+        E(publicFacet).makeAddLiquidityInvitation(),
+        proposal,
+        payment,
+      );
+      assertOfferResult(t, seat, 'Added liquidity.');
+
+      const {
+        Central: cPayout,
+        Secondary: sPayout,
+        Liquidity: lPayout,
+      } = await seat.getPayouts();
+      assertPayoutAmount(t, centralIssuer, cPayout, central(payoutC), '+c');
+      assertPayoutAmount(t, secondaryIssuer, sPayout, secondary(payoutS), '+s');
+      assertPayoutAmount(t, liquidityIssuer, lPayout, liquidity(payoutL), '+l');
+
+      const poolPost = await getPoolAllocation(secondaryIssuer);
+      t.deepEqual(central(cPost), poolPost.Central, `central after add liq`);
+      t.deepEqual(secondary(sPost), poolPost.Secondary, `s after add liq`);
+      t.is(lPost, await getLiquidity(secondaryIssuer), 'liquidity pool after');
+      t.is(kPost, sPost * cPost, 'expected value of K after addLiquidity');
+      t.is(lPost, add(lPre, scaleByAlpha(lPre)), 'liquidity scales');
+      const productC = multiply(cPre, scaleByAlpha(sPre));
+
+      const productS = multiply(sPre, cAmount.value);
+      const exact = productC === productS;
+      if (exact) {
+        t.is(cPost, add(cPre, scaleByAlpha(cPre)), 'central post add');
+        t.is(sPost, add(sPre, scaleByAlpha(sPre)), 'secondary post add');
+      } else {
+        t.is(cPost, add(cPre, cAmount.value), 'central post add');
+        t.is(sPost, add(1, add(sPre, scaleByAlpha(sPre))), 's post add');
+      }
+    },
+
+    initLiquidityAndCheck: async (
+      t,
+      priorPoolState,
+      details,
+      expected,
+      { Liquidity: liquidityIssuer, Secondary: secondaryIssuer },
+    ) => {
+      const { make: central } = await makeLocalAmountMath(centralIssuer);
+      const { make: secondary } = await makeLocalAmountMath(secondaryIssuer);
+      const { make: liquidity } = await makeLocalAmountMath(liquidityIssuer);
+
+      // just check that it went through, and the results are as stated.
+      // The test will declare fees, refunds, and figure out when the trade
+      // gets less than requested
+      const { c: cPre, s: sPre, l: lPre, k: kPre } = priorPoolState;
+      const { cAmount, sAmount, lAmount = liquidity(0) } = details;
+      const {
+        c: cPost,
+        s: sPost,
+        l: lPost,
+        k: kPost,
+        payoutL,
+        payoutC,
+        payoutS,
+      } = expected;
+      t.truthy(payoutC === 0 || payoutS === 0, 'only refund one side');
+      const poolPre = await getPoolAllocation(secondaryIssuer);
+      t.deepEqual({}, poolPre, `central before liquidity`);
+      t.is(0, await getLiquidity(secondaryIssuer), 'liquidity pool pre init');
+      t.is(kPre, sPre * cPre);
+      t.is(lPre, await getLiquidity(secondaryIssuer), 'liquidity pre init');
+
+      const proposal = harden({
+        give: { Central: cAmount, Secondary: sAmount },
+        want: { Liquidity: lAmount },
+      });
+      const payment = harden({
+        Central: withdrawPayment(cAmount),
+        Secondary: withdrawPayment(sAmount),
+      });
+
+      const seat = await zoe.offer(
+        await E(publicFacet).makeAddLiquidityInvitation(),
+        proposal,
+        payment,
+      );
+      assertOfferResult(t, seat, 'Added liquidity.');
+      const {
+        Central: cPayout,
+        Secondary: sPayout,
+        Liquidity: lPayout,
+      } = await seat.getPayouts();
+      assertPayoutAmount(t, centralIssuer, cPayout, central(payoutC), 'init c');
+      const secondaryAmt = secondary(payoutS);
+      assertPayoutAmount(t, secondaryIssuer, sPayout, secondaryAmt, 'init s');
+      const liquidityAmt = liquidity(payoutL);
+      assertPayoutAmount(t, liquidityIssuer, lPayout, liquidityAmt, 'init l');
+
+      const poolPost = await getPoolAllocation(secondaryIssuer);
+      t.deepEqual(central(cPost), poolPost.Central, `central after init`);
+      t.deepEqual(secondary(sPost), poolPost.Secondary, `s after liquidity`);
+      t.is(lPost, await getLiquidity(secondaryIssuer), 'liq pool after init');
+      t.truthy(lPost >= lAmount.value, 'liquidity want was honored');
+      t.is(kPost, sPost * cPost, 'expected value of K after init');
+      t.is(lPost, lAmount.value, 'liquidity scales (init)');
+      t.is(cPost, cAmount.value);
+      t.is(sPost, sAmount.value);
+    },
+  });
+  return trader;
+};

--- a/packages/zoe/test/autoswapJig.js
+++ b/packages/zoe/test/autoswapJig.js
@@ -140,11 +140,11 @@ export const makeTrader = async (purses, zoe, publicFacet, centralIssuer) => {
       } = expected;
 
       const poolPre = await getPoolAllocation(secondaryIssuer);
-      t.deepEqual(central(cPoolPre), poolPre.Central, `central before swap`);
-      t.deepEqual(secondary(sPoolPre), poolPre.Secondary, `s before swap`);
+      t.deepEqual(poolPre.Central, central(cPoolPre), `central before swap`);
+      t.deepEqual(poolPre.Secondary, secondary(sPoolPre), `s before swap`);
       t.is(
-        lPre,
         await getLiquidity(secondaryIssuer),
+        lPre,
         'liquidity pool before trade',
       );
       t.is(kPre, sPoolPre * cPoolPre);
@@ -160,12 +160,12 @@ export const makeTrader = async (purses, zoe, publicFacet, centralIssuer) => {
       assertPayoutAmount(t, inIssuer, refund, inMath(inExpected), 'trade in');
 
       const poolPost = await getPoolAllocation(secondaryIssuer);
-      t.deepEqual(central(cPost), poolPost.Central, `central after swap`);
-      t.deepEqual(secondary(sPost), poolPost.Secondary, `s after swap`);
+      t.deepEqual(poolPost.Central, central(cPost), `central after swap`);
+      t.deepEqual(poolPost.Secondary, secondary(sPost), `s after swap`);
       t.is(kPost, sPost * cPost);
 
       await seat.getOfferResult();
-      t.is(lPost, await getLiquidity(secondaryIssuer), 'liquidity after');
+      t.is(await getLiquidity(secondaryIssuer), lPost, 'liquidity after');
     },
 
     // This check only handles success. Failing calls should do something else.
@@ -197,11 +197,11 @@ export const makeTrader = async (purses, zoe, publicFacet, centralIssuer) => {
       const scaleByAlpha = makeScaleFn(cPre, cPost);
 
       const poolPre = await getPoolAllocation(secondaryIssuer);
-      t.deepEqual(central(cPre), poolPre.Central, `central before add liq`);
-      t.deepEqual(secondary(sPre), poolPre.Secondary, `s before add liq`);
+      t.deepEqual(poolPre.Central, central(cPre), `central before add liq`);
+      t.deepEqual(poolPre.Secondary, secondary(sPre), `s before add liq`);
       t.is(
-        lPre,
         await getLiquidity(secondaryIssuer),
+        lPre,
         'liquidity pool before add',
       );
       t.is(kPre, sPre * cPre);
@@ -232,21 +232,21 @@ export const makeTrader = async (purses, zoe, publicFacet, centralIssuer) => {
       assertPayoutAmount(t, liquidityIssuer, lPayout, liquidity(payoutL), '+l');
 
       const poolPost = await getPoolAllocation(secondaryIssuer);
-      t.deepEqual(central(cPost), poolPost.Central, `central after add liq`);
-      t.deepEqual(secondary(sPost), poolPost.Secondary, `s after add liq`);
-      t.is(lPost, await getLiquidity(secondaryIssuer), 'liquidity pool after');
+      t.deepEqual(poolPost.Central, central(cPost), `central after add liq`);
+      t.deepEqual(poolPost.Secondary, secondary(sPost), `s after add liq`);
+      t.is(await getLiquidity(secondaryIssuer), lPost, 'liquidity pool after');
       t.is(kPost, sPost * cPost, 'expected value of K after addLiquidity');
-      t.is(lPost, add(lPre, scaleByAlpha(lPre)), 'liquidity scales');
+      t.is(add(lPre, scaleByAlpha(lPre)), lPost, 'liquidity scales');
       const productC = multiply(cPre, scaleByAlpha(sPre));
 
       const productS = multiply(sPre, cAmount.value);
       const exact = productC === productS;
       if (exact) {
-        t.is(cPost, add(cPre, scaleByAlpha(cPre)), 'central post add');
-        t.is(sPost, add(sPre, scaleByAlpha(sPre)), 'secondary post add');
+        t.is(add(cPre, scaleByAlpha(cPre)), cPost, 'central post add');
+        t.is(add(sPre, scaleByAlpha(sPre)), sPost, 'secondary post add');
       } else {
-        t.is(cPost, add(cPre, cAmount.value), 'central post add');
-        t.is(sPost, add(1, add(sPre, scaleByAlpha(sPre))), 's post add');
+        t.is(add(cPre, cAmount.value), cPost, 'central post add');
+        t.is(add(1, add(sPre, scaleByAlpha(sPre))), sPost, 's post add');
       }
     },
 
@@ -277,10 +277,10 @@ export const makeTrader = async (purses, zoe, publicFacet, centralIssuer) => {
       } = expected;
       t.truthy(payoutC === 0 || payoutS === 0, 'only refund one side');
       const poolPre = await getPoolAllocation(secondaryIssuer);
-      t.deepEqual({}, poolPre, `central before liquidity`);
-      t.is(0, await getLiquidity(secondaryIssuer), 'liquidity pool pre init');
+      t.deepEqual(poolPre, {}, `central before liquidity`);
+      t.is(await getLiquidity(secondaryIssuer), 0, 'liquidity pool pre init');
       t.is(kPre, sPre * cPre);
-      t.is(lPre, await getLiquidity(secondaryIssuer), 'liquidity pre init');
+      t.is(await getLiquidity(secondaryIssuer), lPre, 'liquidity pre init');
 
       const proposal = harden({
         give: { Central: cAmount, Secondary: sAmount },
@@ -309,14 +309,14 @@ export const makeTrader = async (purses, zoe, publicFacet, centralIssuer) => {
       assertPayoutAmount(t, liquidityIssuer, lPayout, liquidityAmt, 'init l');
 
       const poolPost = await getPoolAllocation(secondaryIssuer);
-      t.deepEqual(central(cPost), poolPost.Central, `central after init`);
-      t.deepEqual(secondary(sPost), poolPost.Secondary, `s after liquidity`);
-      t.is(lPost, await getLiquidity(secondaryIssuer), 'liq pool after init');
+      t.deepEqual(poolPost.Central, central(cPost), `central after init`);
+      t.deepEqual(poolPost.Secondary, secondary(sPost), `s after liquidity`);
+      t.is(await getLiquidity(secondaryIssuer), lPost, 'liq pool after init');
       t.truthy(lPost >= lAmount.value, 'liquidity want was honored');
-      t.is(kPost, sPost * cPost, 'expected value of K after init');
-      t.is(lPost, lAmount.value, 'liquidity scales (init)');
-      t.is(cPost, cAmount.value);
-      t.is(sPost, sAmount.value);
+      t.is(sPost * cPost, kPost, 'expected value of K after init');
+      t.is(lAmount.value, lPost, 'liquidity scales (init)');
+      t.is(cAmount.value, cPost);
+      t.is(sAmount.value, sPost);
     },
   });
   return trader;

--- a/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
@@ -586,7 +586,6 @@ test('multipoolAutoSwap jig - liquidity', async t => {
     payoutS: 0,
     payoutL: 10000,
   };
-  t.truthy(t, '..Alice init liquidity');
 
   await alice.initLiquidityAndCheck(
     t,
@@ -595,7 +594,6 @@ test('multipoolAutoSwap jig - liquidity', async t => {
     initLiquidityExpected,
     issuerKeywordRecord,
   );
-  t.truthy(t, '..Alice initialize liquidity');
   moolaPoolState = updatePoolState(moolaPoolState, initLiquidityExpected);
 
   // Alice adds liquidity
@@ -615,7 +613,6 @@ test('multipoolAutoSwap jig - liquidity', async t => {
     liqExpected1,
     issuerKeywordRecord,
   );
-  t.truthy(t, '..Alice added more liquidity');
   moolaPoolState = updatePoolState(moolaPoolState, liqExpected1);
 
   // Alice adds liquidity with an out-of-balance offer -- too much moola
@@ -635,7 +632,6 @@ test('multipoolAutoSwap jig - liquidity', async t => {
     liqExpected2,
     issuerKeywordRecord,
   );
-  t.truthy(t, '..Alice added more liquidity');
   moolaPoolState = updatePoolState(moolaPoolState, liqExpected2);
 
   // Alice tries to add liquidity with little moola -- the offer is rejected

--- a/packages/zoe/test/zoeTestHelpers.js
+++ b/packages/zoe/test/zoeTestHelpers.js
@@ -10,7 +10,7 @@ export const assertPayoutAmount = (
   label = '',
 ) => {
   issuer.getAmountOf(payout).then(amount => {
-    t.deepEqual(expectedAmount, amount, `${label} payout was ${amount.value}`);
+    t.deepEqual(amount, expectedAmount, `${label} payout was ${amount.value}`);
   });
 };
 
@@ -20,8 +20,8 @@ export const assertPayoutDeposit = (t, payout, purse, amount) => {
       .deposit(payment)
       .then(payoutAmount => {
         t.deepEqual(
-          amount,
           payoutAmount,
+          amount,
           `payout was ${payoutAmount.value}, expected ${amount}.value`,
         );
       });

--- a/packages/zoe/test/zoeTestHelpers.js
+++ b/packages/zoe/test/zoeTestHelpers.js
@@ -2,9 +2,15 @@ import { E } from '@agoric/eventual-send';
 
 import '../exported';
 
-export const assertPayoutAmount = (t, issuer, payout, expectedAmount) => {
+export const assertPayoutAmount = (
+  t,
+  issuer,
+  payout,
+  expectedAmount,
+  label = '',
+) => {
   issuer.getAmountOf(payout).then(amount => {
-    t.deepEqual(amount, expectedAmount, `payout was ${amount.value}`);
+    t.deepEqual(expectedAmount, amount, `${label} payout was ${amount.value}`);
   });
 };
 
@@ -14,8 +20,8 @@ export const assertPayoutDeposit = (t, payout, purse, amount) => {
       .deposit(payment)
       .then(payoutAmount => {
         t.deepEqual(
-          payoutAmount,
           amount,
+          payoutAmount,
           `payout was ${payoutAmount.value}, expected ${amount}.value`,
         );
       });


### PR DESCRIPTION
distinguish prices for stated input from prices for stated output.
provide swapIn/swapOut to distinguish stated In/Out prices
ensure proportionality is enforced when adding liquidity
re-use the test jig
match the autoswap API
Tests for all combinations of swapIn/Out to/from central pool and trading secondary currencies
Update documentation

Fixes: #1600 
closes: #428, #1539, #1632, #921, #1153, #1192
See also: #1586

remaining issues moved to #1673