### PR TITLE
fix: declare amountMathKind parameter to makeissuerkit optional

### DIFF
--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -183,7 +183,7 @@
 /**
  * @callback MakeIssuerKit
  * @param {string} allegedName
- * @param {AmountMathKind} amountMathKind
+ * @param {AmountMathKind=} amountMathKind
  * @returns {IssuerKit}
  *
  * The allegedName becomes part of the brand in asset descriptions. The


### PR DESCRIPTION
The mathHelperName was changed to amountMathKind, and it's optional in
the code. This updates the type declaration to match.

fixes: #1373