### PR TITLE
refactor: remove string-based bootstrap argv in favour of data object

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
+++ b/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
@@ -45,11 +45,11 @@ export async function connectToFakeChain(basedir, GCI, delay, inbound) {
   const mailboxStorage = await makeMapStorage(mailboxFile);
 
   const vatsdir = path.join(basedir, 'vats');
-  const argv = [
-    `--role=sim-chain`,
-    `--give-me-all-the-agoric-powers`,
-    bootAddress,
-  ];
+  const argv = {
+    ROLE: 'sim-chain',
+    giveMeAllTheAgoricPowers: true,
+    hardcodedClientAddresses: [bootAddress],
+  };
   const stateDBdir = path.join(basedir, `fake-chain-${GCI}-state`);
   function doOutboundBridge(dstID, _obj) {
     // console.error('received', dstID, obj);

--- a/packages/cosmic-swingset/lib/ag-solo/main.js
+++ b/packages/cosmic-swingset/lib/ag-solo/main.js
@@ -129,7 +129,7 @@ start
     }
     case 'start': {
       const basedir = insistIsBasedir();
-      await start(basedir, argv.slice(1));
+      await start(basedir, { ROLE: 'client' });
       break;
     }
     case 'reset-state': {

--- a/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
@@ -16,35 +16,6 @@ const NUM_IBC_PORTS = 3;
 
 console.debug(`loading bootstrap.js`);
 
-function parseArgs(argv) {
-  let ROLE;
-  let gotRoles = false;
-  const hardcodedClientAddresses = [];
-  let giveMeAllTheAgoricPowers = false;
-  argv.forEach(arg => {
-    const match = arg.match(/^--role=(.*)$/);
-    if (match) {
-      if (gotRoles) {
-        throw new Error(`must assign only one role, saw ${ROLE}, ${match[1]}`);
-      }
-      [, ROLE] = match;
-      gotRoles = true;
-    } else if (arg === `--give-me-all-the-agoric-powers`) {
-      console.warn(`Giving all the Agoric powers to the client!`);
-      giveMeAllTheAgoricPowers = true;
-    } else if (arg.match(/^-/)) {
-      throw Error(`Unrecognized option ${arg}`);
-    } else {
-      hardcodedClientAddresses.push(arg);
-    }
-  });
-  if (!gotRoles) {
-    ROLE = 'client';
-  }
-
-  return { ROLE, giveMeAllTheAgoricPowers, hardcodedClientAddresses };
-}
-
 // Used for coordinating on an index in comms for the provisioning service
 const PROVISIONER_INDEX = 1;
 
@@ -288,7 +259,7 @@ export function buildRootObject(vatPowers, vatParameters) {
         ROLE,
         giveMeAllTheAgoricPowers,
         hardcodedClientAddresses,
-      } = parseArgs(vatParameters.argv);
+      } = vatParameters.argv;
 
       async function addRemote(addr) {
         const { transmitter, setReceiver } = await E(vats.vattp).addRemote(

--- a/packages/cosmic-swingset/lib/chain-main.js
+++ b/packages/cosmic-swingset/lib/chain-main.js
@@ -204,7 +204,7 @@ export default async function main(progname, args, { path, env, agcc }) {
     }
 
     const vatsdir = path.resolve(__dirname, '../lib/ag-solo/vats');
-    const argv = [`--role=chain`];
+    const argv = { ROLE: 'chain' };
     const s = await launch(
       stateDBDir,
       mailboxStorage,


### PR DESCRIPTION
A tiny PR to clean up unnecessary string parsing in the bootstrap vat.
