### PR TITLE
Avoid database reentrancy issue during parallel testing

### DIFF
--- a/packages/swingset-runner/src/main.js
+++ b/packages/swingset-runner/src/main.js
@@ -42,6 +42,7 @@ FLAGS may be:
   --lmdb           - runs using LMDB as the data store (default)
   --filedb         - runs using the simple file-based data store
   --memdb          - runs using the non-persistent in-memory data store
+  --dbdir DIR      - specify where the data store should go (default BASEDIR)
   --blockmode      - run in block mode (checkpoint every BLOCKSIZE blocks)
   --blocksize N    - set BLOCKSIZE to N cranks (default 200)
   --logtimes       - log block execution time stats while running
@@ -166,6 +167,7 @@ export async function main() {
   let launchIndirectly = false;
   let benchmarkRounds = 0;
   let configPath = null;
+  let dbDir = null;
 
   while (argv[0] && argv[0].startsWith('-')) {
     const flag = argv.shift();
@@ -222,6 +224,9 @@ export async function main() {
       case '--dumptag':
         dumpTag = argv.shift();
         doDumps = true;
+        break;
+      case '--dbdir':
+        dbDir = argv.shift();
         break;
       case '--raw':
         rawMode = true;
@@ -306,9 +311,12 @@ export async function main() {
   if (launchIndirectly) {
     config = generateIndirectConfig(config);
   }
+  if (!dbDir) {
+    dbDir = basedir;
+  }
 
   let store;
-  const kernelStateDBDir = path.join(basedir, 'swingset-kernel-state');
+  const kernelStateDBDir = path.join(dbDir, 'swingset-kernel-state');
   switch (dbMode) {
     case '--filedb':
       if (forceReset) {

--- a/packages/swingset-runner/test/test-demo.js
+++ b/packages/swingset-runner/test/test-demo.js
@@ -1,10 +1,16 @@
 import test from 'ava';
 import { spawn } from 'child_process';
+import fs from 'fs';
 
-async function innerTest(t, extraFlags) {
+async function innerTest(t, extraFlags, dbdir) {
   await new Promise(resolve => {
+    const appDir = 'demo/encouragementBot';
+    if (dbdir) {
+      dbdir = `${appDir}/${dbdir}`;
+      extraFlags += ` --dbdir ${dbdir}`;
+    }
     const proc = spawn(
-      `node -r esm bin/runner --init ${extraFlags} run demo/encouragementBot`,
+      `node -r esm bin/runner --init ${extraFlags} run ${appDir}`,
       {
         cwd: `${__dirname}/..`,
         shell: true,
@@ -22,6 +28,9 @@ async function innerTest(t, extraFlags) {
       const bMsg = 'bot vat is happy';
       t.not(output.indexOf(`\n${bMsg}\n`), -1, bMsg);
       resolve();
+      if (dbdir) {
+        fs.rmdirSync(dbdir, { recursive: true });
+      }
     });
   });
 }
@@ -31,17 +40,17 @@ test('run encouragmentBot demo with memdb', async t => {
 });
 
 test('run encouragmentBot demo with filedb', async t => {
-  await innerTest(t, '--filedb');
+  await innerTest(t, '--filedb', 'filetest');
 });
 
 test('run encouragmentBot demo with lmdb', async t => {
-  await innerTest(t, '--lmdb');
+  await innerTest(t, '--lmdb', 'lmdbtest');
 });
 
 test('run encouragmentBot demo with default', async t => {
-  await innerTest(t, '');
+  await innerTest(t, '', 'defaulttest');
 });
 
 test('run encouragmentBot demo with indirectly loaded vats', async t => {
-  await innerTest(t, '--indirect');
+  await innerTest(t, '--indirect', 'indirecttest');
 });


### PR DESCRIPTION
Ava's parallel test execution was causing some of the swingset-runner tests to intermittently step on each other's database state, resulting in test flakiness.  Tests now run with each using its own temporary database file.

To achieve this swingset-runner has acquired a command line option to let you put the database someplace other than the default location for the swingset, which might be useful in other circumstances too.
