### PR TITLE
test: add more zcf tests (Part 2)

### DIFF
--- a/packages/dapp-svelte-wallet/api/src/types.js
+++ b/packages/dapp-svelte-wallet/api/src/types.js
@@ -91,6 +91,7 @@
  * @property {PaymentActions} actions
  * @property {Amount=} lastAmount
  * @property {Amount=} depositedAmount
+ * @property {string=} issuerBoardId
  *
  * @typedef {Object} PaymentActions
  * @property {(purseOrPetname?: Purse | Petname) => Promise<Value>} deposit

--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -274,7 +274,9 @@ export function buildRootObject() {
         // affect those checks and see if one can be removed.
         zcf.assertUniqueKeyword(keyword);
         await E(zoeInstanceAdmin).saveIssuer(issuerP, keyword);
+        // AWAIT ///
         const record = await issuerTable.initIssuer(issuerP);
+        // AWAIT ///
         return registerIssuerRecordWithKeyword(keyword, record);
       },
       makeInvitation: (offerHandler, description, customProperties = {}) => {

--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -39,6 +39,7 @@ export function buildRootObject() {
     zoeInstanceAdmin,
     instanceRecord,
   ) => {
+    /** @type IssuerTable */
     const issuerTable = makeIssuerTable();
     const getAmountMath = brand => issuerTable.getByBrand(brand).amountMath;
 
@@ -55,6 +56,7 @@ export function buildRootObject() {
     const initIssuers = issuersP =>
       Promise.all(issuersP.map(issuerTable.initIssuer));
 
+    /** @type RegisterIssuerRecord */
     const registerIssuerRecord = (keyword, issuerRecord) => {
       instanceRecord = {
         ...instanceRecord,
@@ -78,6 +80,7 @@ export function buildRootObject() {
       return issuerRecord;
     };
 
+    /** @type RegisterIssuerRecordWithKeyword */
     const registerIssuerRecordWithKeyword = (keyword, issuerRecord) => {
       assertKeywordName(keyword);
       assert(
@@ -265,18 +268,14 @@ export function buildRootObject() {
           details`keyword ${keyword} must be unique`,
         );
       },
-      saveIssuer: (issuerP, keyword) => {
+      saveIssuer: async (issuerP, keyword) => {
         // TODO: The checks of the keyword for uniqueness are
         // duplicated. Assess how waiting on promises to resolve might
         // affect those checks and see if one can be removed.
         zcf.assertUniqueKeyword(keyword);
-        return E(zoeInstanceAdmin)
-          .saveIssuer(issuerP, keyword)
-          .then(() => {
-            return issuerTable
-              .initIssuer(issuerP)
-              .then(record => registerIssuerRecordWithKeyword(keyword, record));
-          });
+        await E(zoeInstanceAdmin).saveIssuer(issuerP, keyword);
+        const record = await issuerTable.initIssuer(issuerP);
+        return registerIssuerRecordWithKeyword(keyword, record);
       },
       makeInvitation: (offerHandler, description, customProperties = {}) => {
         assert.typeof(

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -200,7 +200,7 @@
 
 /**
  * @typedef {Object} IssuerTable
- * @propert {(brand: Brand) => boolean} hasByBrand
+ * @property {(brand: Brand) => boolean} hasByBrand
  * @property {(brand: Brand) => IssuerRecord} getByBrand
  * @property {(issuer: Issuer) => boolean} hasByIssuer
  * @property {(issuer: Issuer) => IssuerRecord} getByIssuer
@@ -234,4 +234,18 @@
  * kills the vat in which the contract is running
  * @property {() => Object} adminData
  * provides some statistics about the vat in which the contract is running.
+ */
+
+/**
+ * @callback RegisterIssuerRecord
+ * @param {Keyword} keyword
+ * @param {IssuerRecord} issuerRecord
+ * @returns {IssuerRecord}
+ */
+
+/**
+ * @callback RegisterIssuerRecordWithKeyword
+ * @param {Keyword} keyword
+ * @param {IssuerRecord} issuerRecord
+ * @returns {IssuerRecord}
  */

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -10,6 +10,7 @@ import bundleSource from '@agoric/bundle-source';
 import { makeZoe } from '../../../src/zoeService/zoe';
 import { setup } from '../setupBasicMints';
 import fakeVatAdmin from '../contracts/fakeVatAdmin';
+import buildManualTimer from '../../../tools/manualTimer';
 
 const contractRoot = `${__dirname}/zcfTesterContract`;
 
@@ -17,7 +18,7 @@ const setupZCFTest = async (issuerKeywordRecord, terms) => {
   const zoe = makeZoe(fakeVatAdmin);
   const bundle = await bundleSource(contractRoot);
   const installation = await zoe.install(bundle);
-  const { creatorFacet } = await E(zoe).startInstance(
+  const { creatorFacet, instance } = await E(zoe).startInstance(
     installation,
     issuerKeywordRecord,
     terms,
@@ -25,18 +26,11 @@ const setupZCFTest = async (issuerKeywordRecord, terms) => {
   // This contract gives ZCF as the contractFacet for testing purposes
   /** @type ContractFacet */
   const zcf = creatorFacet;
-  return { zoe, zcf };
+  return { zoe, zcf, instance, installation };
 };
 
 // TODO: Still to be tested:
-//  * @property {Reallocate} reallocate - reallocate amounts among seats
-//  * @property {(keyword: Keyword) => void} assertUniqueKeyword - check
-//  * whether a keyword is valid and unique and could be added in
-//  * `saveIssuer`
-//  * @property {SaveIssuer} saveIssuer - save an issuer to ZCF and Zoe
-//  * and get the amountMath and brand synchronously accessible after
-//  * saving
-//  * @property {MakeInvitation} makeInvitation
+//  * @property {Reallocate} reallocate
 //  * @property {() => void} shutdown
 //  * @property {MakeZCFMint} makeZCFMint
 //  * @property {<Deadline>(exit?: ExitRule<Deadline>) => ZcfSeatKit} makeEmptySeatKit
@@ -193,4 +187,203 @@ test(`zcf.getAmountMath - from issuerKeywordRecord & zcf.saveIssuer`, async t =>
   );
   await zcf.saveIssuer(bucksKit.issuer, 'C');
   compareAmountMath(t, zcf.getAmountMath(bucksKit.brand), bucksKit.amountMath);
+});
+
+test(`zcf.assertUniqueKeyword`, async t => {
+  const { moolaKit, simoleanKit } = setup();
+  const issuerKeywordRecord = { A: moolaKit.issuer, B: simoleanKit.issuer };
+  const { zcf } = await setupZCFTest(issuerKeywordRecord);
+  t.throws(() => zcf.assertUniqueKeyword('A'), {
+    message: 'keyword (a string) must be unique\nSee console for error data.',
+  });
+  t.throws(() => zcf.assertUniqueKeyword('B'), {
+    message: 'keyword (a string) must be unique\nSee console for error data.',
+  });
+  // Unique, but not a valid Keyword
+  t.throws(() => zcf.assertUniqueKeyword('a'), {
+    message:
+      'keyword "a" must be ascii and must start with a capital letter.\nSee console for error data.',
+  });
+  t.throws(() => zcf.assertUniqueKeyword('3'), {
+    message:
+      'keyword "3" must be ascii and must start with a capital letter.\nSee console for error data.',
+  });
+});
+
+test(`zcf.saveIssuer & zoe.getTerms`, async t => {
+  const { moolaKit, simoleanKit, bucksKit } = setup();
+  const expected = {
+    brands: { A: moolaKit.brand, B: simoleanKit.brand, C: bucksKit.brand },
+    issuers: { A: moolaKit.issuer, B: simoleanKit.issuer, C: bucksKit.issuer },
+    maths: {
+      A: moolaKit.amountMath,
+      B: simoleanKit.amountMath,
+      C: bucksKit.amountMath,
+    },
+    whatever: 'whatever',
+  };
+  const issuerKeywordRecord = { A: moolaKit.issuer, B: simoleanKit.issuer };
+  const customTerms = {
+    whatever: 'whatever',
+  };
+
+  const { zcf, instance, zoe } = await setupZCFTest(
+    issuerKeywordRecord,
+    customTerms,
+  );
+  await zcf.saveIssuer(bucksKit.issuer, 'C');
+
+  const zoeTerms = await E(zoe).getTerms(instance);
+  const zoeTermsMinusAmountMath = { ...zoeTerms, maths: {} };
+  const expectedMinusAmountMath = { ...expected, maths: {} };
+  t.deepEqual(zoeTermsMinusAmountMath, expectedMinusAmountMath);
+
+  compareAmountMaths(t, zoeTerms.maths, expected.maths);
+});
+
+test(`zcf.saveIssuer - bad issuer`, async t => {
+  const { moolaKit } = setup();
+  const { zcf } = await setupZCFTest();
+  // @ts-ignore
+  await t.throwsAsync(() => zcf.saveIssuer(moolaKit.brand, 'A'), {
+    // TODO: improve error message
+    // https://github.com/Agoric/agoric-sdk/issues/1701
+    message: 'o["getBrand"] is not a function',
+  });
+});
+
+test(`zcf.saveIssuer - bad keyword`, async t => {
+  const { moolaKit } = setup();
+  const { zcf } = await setupZCFTest();
+  // TODO: why does this not throwAsync?
+  t.throws(() => zcf.saveIssuer(moolaKit.issuer, 'bad keyword'), {
+    message: `keyword "bad keyword" must be ascii and must start with a capital letter.\nSee console for error data.`,
+  });
+});
+
+test(`zcf.saveIssuer - args reversed`, async t => {
+  const { moolaKit } = setup();
+  const { zcf } = await setupZCFTest();
+  // TODO: why does this not throwAsync?
+  // TODO: improve error message
+  // https://github.com/Agoric/agoric-sdk/issues/1702
+  // @ts-ignore
+  t.throws(() => zcf.saveIssuer('A', moolaKit.issuer), {
+    message: `(an object) must be a string\nSee console for error data.`,
+  });
+});
+
+test(`zcf.makeInvitation - no offerHandler`, async t => {
+  const { zcf, zoe } = await setupZCFTest();
+  const invitationP = zcf.makeInvitation(undefined, 'myInvitation');
+  const invitationIssuer = await E(zoe).getInvitationIssuer();
+  const isLive = await E(invitationIssuer).isLive(invitationP);
+  t.truthy(isLive);
+  const seat = E(zoe).offer(invitationP);
+
+  // TODO: this should not throw
+  // https://github.com/Agoric/agoric-sdk/issues/1703
+  // const offerResult = await E(seat).getOfferResult();
+  // t.is(offerResult, undefined);
+  await t.throwsAsync(() => E(seat).getOfferResult());
+});
+
+test(`zcf.makeInvitation - no-op offerHandler`, async t => {
+  const { zcf, zoe } = await setupZCFTest();
+  const invitationP = zcf.makeInvitation(() => {}, 'myInvitation');
+  const invitationIssuer = await E(zoe).getInvitationIssuer();
+  const isLive = await E(invitationIssuer).isLive(invitationP);
+  t.truthy(isLive);
+  const seat = E(zoe).offer(invitationP);
+  const offerResult = await E(seat).getOfferResult();
+  t.is(offerResult, undefined);
+});
+
+test(`zcf.makeInvitation - throwing offerHandler`, async t => {
+  const { zcf, zoe } = await setupZCFTest();
+  const handler = () => {
+    throw Error('my error message');
+  };
+  const invitationP = zcf.makeInvitation(handler, 'myInvitation');
+  const invitationIssuer = await E(zoe).getInvitationIssuer();
+  const isLive = await E(invitationIssuer).isLive(invitationP);
+  t.truthy(isLive);
+  const seat = E(zoe).offer(invitationP);
+  await t.throwsAsync(() => E(seat).getOfferResult(), {
+    message: 'my error message',
+  });
+});
+
+test(`zcf.makeInvitation - no description`, async t => {
+  const { zcf } = await setupZCFTest();
+  // @ts-ignore
+  t.throws(() => zcf.makeInvitation(() => {}), {
+    message: `invitations must have a description string: (an undefined)\nSee console for error data.`,
+  });
+});
+
+test(`zcf.makeInvitation - non-string description`, async t => {
+  const { zcf } = await setupZCFTest();
+  // TODO: improve error message
+  // https://github.com/Agoric/agoric-sdk/issues/1704
+  // @ts-ignore
+  t.throws(() => zcf.makeInvitation(() => {}, { something: 'a' }), {
+    message: `invitations must have a description string: (an object)\nSee console for error data.`,
+  });
+});
+
+test(`zcf.makeInvitation - no customProperties`, async t => {
+  const { zcf, zoe, instance, installation } = await setupZCFTest();
+  const invitationP = zcf.makeInvitation(() => {}, 'myInvitation');
+  // TODO: allow promises for payments
+  // https://github.com/Agoric/agoric-sdk/issues/1705
+  // @ts-ignore
+  const details = await E(zoe).getInvitationDetails(invitationP);
+  t.deepEqual(details, {
+    description: 'myInvitation',
+    handle: details.handle,
+    installation,
+    instance,
+  });
+});
+
+test(`zcf.makeInvitation - customProperties`, async t => {
+  const { zcf, zoe, instance, installation } = await setupZCFTest();
+  const timer = buildManualTimer(console.log);
+  const invitationP = zcf.makeInvitation(() => {}, 'myInvitation', {
+    whatever: 'whatever',
+    timer,
+  });
+  // TODO: allow promises for payments
+  // https://github.com/Agoric/agoric-sdk/issues/1705
+  // @ts-ignore
+  const details = await E(zoe).getInvitationDetails(invitationP);
+  t.deepEqual(details, {
+    description: 'myInvitation',
+    handle: details.handle,
+    installation,
+    instance,
+    timer,
+    whatever: 'whatever',
+  });
+});
+
+test(`zcf.makeInvitation - customProperties overwritten`, async t => {
+  const { zcf, zoe, instance, installation } = await setupZCFTest();
+  const invitationP = zcf.makeInvitation(() => {}, 'myInvitation', {
+    description: 'whatever',
+    installation: 'whatever',
+    instance: 'whatever',
+  });
+  // TODO: allow promises for payments
+  // https://github.com/Agoric/agoric-sdk/issues/1705
+  // @ts-ignore
+  const details = await E(zoe).getInvitationDetails(invitationP);
+  t.deepEqual(details, {
+    description: 'myInvitation',
+    handle: details.handle,
+    installation,
+    instance,
+  });
+  t.falsy(typeof details.handle === 'string');
 });

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -208,6 +208,7 @@ test(`zcf.assertUniqueKeyword`, async t => {
     message:
       'keyword "3" must be ascii and must start with a capital letter.\nSee console for error data.',
   });
+  zcf.assertUniqueKeyword('MyKeyword');
 });
 
 test(`zcf.saveIssuer & zoe.getTerms`, async t => {
@@ -255,8 +256,7 @@ test(`zcf.saveIssuer - bad issuer`, async t => {
 test(`zcf.saveIssuer - bad keyword`, async t => {
   const { moolaKit } = setup();
   const { zcf } = await setupZCFTest();
-  // TODO: why does this not throwAsync?
-  t.throws(() => zcf.saveIssuer(moolaKit.issuer, 'bad keyword'), {
+  await t.throwsAsync(() => zcf.saveIssuer(moolaKit.issuer, 'bad keyword'), {
     message: `keyword "bad keyword" must be ascii and must start with a capital letter.\nSee console for error data.`,
   });
 });
@@ -264,11 +264,10 @@ test(`zcf.saveIssuer - bad keyword`, async t => {
 test(`zcf.saveIssuer - args reversed`, async t => {
   const { moolaKit } = setup();
   const { zcf } = await setupZCFTest();
-  // TODO: why does this not throwAsync?
   // TODO: improve error message
   // https://github.com/Agoric/agoric-sdk/issues/1702
   // @ts-ignore
-  t.throws(() => zcf.saveIssuer('A', moolaKit.issuer), {
+  await t.throwsAsync(() => zcf.saveIssuer('A', moolaKit.issuer), {
     message: `(an object) must be a string\nSee console for error data.`,
   });
 });


### PR DESCRIPTION
This PR tests:

* zcf.assertUniqueKeyword
* zcf.saveIssuer
* zcf.makeInvitation

Still todo:

- [ ] reallocate
- [ ] shutdown
- [ ] makeZCFMint
- [ ] makeEmptySeatKit

Test ZCF objects like ZCFSeat.

Re: #1668 