### PR TITLE
Implement far object helper

### DIFF
--- a/packages/captp/.eslintrc.js
+++ b/packages/captp/.eslintrc.js
@@ -4,6 +4,9 @@ module.exports = {
   env: {
     es6: true, // supports new ES6 globals (e.g., new types such as Set)
   },
+  globals: {
+    harden: 'readonly',
+  },
   rules: {
     'implicit-arrow-linebreak': 'off',
     'function-paren-newline': 'off',

--- a/packages/captp/lib/captp.js
+++ b/packages/captp/lib/captp.js
@@ -1,14 +1,27 @@
-/* global harden HandledPromise */
+// @ts-check
+
 // Your app may need to `import '@agoric/eventual-send/shim'` to get HandledPromise
 
 // This logic was mostly lifted from @agoric/swingset-vat liveSlots.js
 // Defects in it are mfig's fault.
 import { Remotable, makeMarshal, QCLASS } from '@agoric/marshal';
-import { E } from '@agoric/eventual-send';
+import { E, HandledPromise } from '@agoric/eventual-send';
 import { isPromise } from '@agoric/promise-kit';
 
 export { E };
 
+/**
+ * @typedef {Object} CapTPOptions the options to makeCapTP
+ * @property {(err: any) => void} onReject
+ */
+/**
+ * Create a CapTP connection.
+ *
+ * @param {string} ourId our name for the current side
+ * @param {(obj: Record<string, any>) => void} rawSend send a JSONable packet
+ * @param {any} bootstrapObj the object to export to the other side
+ * @param {Partial<CapTPOptions>} opts options to the connection
+ */
 export function makeCapTP(ourId, rawSend, bootstrapObj = undefined, opts = {}) {
   const {
     onReject = err => console.error('CapTP', ourId, 'exception:', err),
@@ -30,10 +43,13 @@ export function makeCapTP(ourId, rawSend, bootstrapObj = undefined, opts = {}) {
     return p;
   }
 
-  function send(...args) {
+  /**
+   * @param {Record<string, any>} obj
+   */
+  function send(obj) {
     // Don't throw here if unplugged, just don't send.
     if (unplug === false) {
-      rawSend(...args);
+      rawSend(obj);
     }
   }
 
@@ -49,6 +65,9 @@ export function makeCapTP(ourId, rawSend, bootstrapObj = undefined, opts = {}) {
     convertSlotToVal,
   );
 
+  const valToSlot = new WeakMap(); // exports looked up by val
+  const slotToVal = new Map(); // reverse
+
   // Used to construct slot names for promises/non-promises.
   // In this verison of CapTP we use strings for export/import slot names.
   // prefixed with 'p' if promises and 'o' otherwise;
@@ -58,8 +77,6 @@ export function makeCapTP(ourId, rawSend, bootstrapObj = undefined, opts = {}) {
   // the question key
   let lastQuestionID = 0;
 
-  const valToSlot = new WeakMap(); // exports looked up by val
-  const slotToVal = new Map(); // exports looked up by slot
   const questions = new Map(); // chosen by us
   const answers = new Map(); // chosen by our peer
   const imports = new Map(); // chosen by our peer
@@ -113,10 +130,12 @@ export function makeCapTP(ourId, rawSend, bootstrapObj = undefined, opts = {}) {
     return valToSlot.get(val);
   }
 
-  // Generate a new question in the questions table and set up a new
-  // remote handled promise.
-  // Returns: [questionId, pr]
-  //   where `pr` is the HandledPromise for this question.
+  /**
+   * Generate a new question in the questions table and set up a new
+   * remote handled promise.
+   *
+   * @returns {[number, ReturnType<typeof makeRemoteKit>]}
+   */
   function makeQuestion() {
     lastQuestionID += 1;
     const questionID = lastQuestionID;
@@ -344,5 +363,49 @@ export function makeCapTP(ourId, rawSend, bootstrapObj = undefined, opts = {}) {
     exception = Error(`disconnected from ${JSON.stringify(ourId)}`),
   ) => dispatch({ type: 'CTP_ABORT', exception });
 
-  return harden({ abort, dispatch, getBootstrap });
+  return harden({ abort, dispatch, getBootstrap, serialize, unserialize });
+}
+
+/**
+ * Create an async-isolated channel to an object.
+ *
+ * @param {string} ourId
+ * @returns {{ makeFar<T>(x: T): ERef<T> }}
+ */
+export function makeLoopback(ourId) {
+  let nextNonce = 0;
+  const nonceToRef = new Map();
+
+  // Create the tunnel.
+  let remoteDispatch;
+  const { dispatch: localDispatch, getBootstrap } = makeCapTP(
+    `local-${ourId}`,
+    o => remoteDispatch(o),
+  );
+  const { dispatch } = makeCapTP(
+    `remote-${ourId}`,
+    localDispatch,
+    harden({
+      farGetter: {
+        getRef(nonce) {
+          // Find the local ref for the specified nonce.
+          const xNear = nonceToRef.get(nonce);
+          nonceToRef.delete(nonce);
+          return xNear;
+        },
+      },
+    }),
+  );
+  remoteDispatch = dispatch;
+
+  const farGetter = E.G(getBootstrap()).farGetter;
+
+  async function makeFar(xNear) {
+    const myNonce = nextNonce;
+    nextNonce += 1;
+    nonceToRef.set(myNonce, harden(xNear));
+    return E(farGetter).getRef(myNonce);
+  }
+
+  return { makeFar };
 }

--- a/packages/captp/test/test-crosstalk.js
+++ b/packages/captp/test/test-crosstalk.js
@@ -2,28 +2,11 @@
 
 import '@agoric/install-ses';
 import test from 'ava';
-import { makeCapTP, E } from '../lib/captp';
+import { makeLoopback, E } from '../lib/captp';
 
 test('prevent crosstalk', async t => {
-  const debug = false;
-  let rightDispatch;
-  const { dispatch: leftDispatch, getBootstrap: leftBootstrap } = makeCapTP(
-    'left',
-    obj => {
-      if (debug) {
-        console.log('toRight', obj);
-      }
-      rightDispatch(obj);
-    },
-  );
-  ({ dispatch: rightDispatch } = makeCapTP(
-    'right',
-    obj => {
-      if (debug) {
-        console.log('toLeft', obj);
-      }
-      leftDispatch(obj);
-    },
+  const { makeFar } = makeLoopback('alice');
+  const rightRef = makeFar(
     harden({
       isSide(objP, side) {
         return E(objP)
@@ -34,8 +17,7 @@ test('prevent crosstalk', async t => {
         return 'right';
       },
     }),
-  ));
-  const rightRef = leftBootstrap();
+  );
 
   await E(rightRef).isSide(rightRef, 'right');
   const leftRef = harden({

--- a/packages/captp/test/test-loopback.js
+++ b/packages/captp/test/test-loopback.js
@@ -2,59 +2,89 @@
 
 import '@agoric/install-ses';
 import test from 'ava';
-import { E, makeCapTP } from '../lib/captp';
+import { E, makeLoopback } from '../lib/captp';
 
 test('try loopback captp', async t => {
-  const debug = false;
-  let rightDispatch;
-  const { dispatch: leftDispatch, getBootstrap: leftBootstrap } = makeCapTP(
-    'left',
-    obj => {
-      if (debug) {
-        console.log('toRight', obj);
-      }
-      rightDispatch(obj);
-    },
-  );
   const pr = {};
   pr.p = new Promise((resolve, reject) => {
     pr.res = resolve;
     pr.rej = reject;
   });
-  ({ dispatch: rightDispatch } = makeCapTP(
-    'right',
-    obj => {
-      if (debug) {
-        console.log('toLeft', obj);
-      }
-      leftDispatch(obj);
+
+  const syncHandle = harden({});
+  const syncAccess = {
+    checkHandle(hnd) {
+      // console.log('check', hnd, oobHandle);
+      return hnd === syncHandle;
     },
-    harden({
-      promise: pr.p,
-      encourager: {
-        encourage(name) {
-          const bang = new Promise(resolve => {
-            setTimeout(
-              () =>
-                resolve({
-                  trigger() {
-                    return `${name} BANG!`;
-                  },
-                }),
-              200,
-            );
-          });
-          return { comment: `good work, ${name}`, bang };
-        },
+    getHandleP() {
+      return Promise.resolve(syncHandle);
+    },
+    getHandle() {
+      return syncHandle;
+    },
+  };
+
+  const { makeFar } = makeLoopback('dean');
+  const objNear = harden({
+    promise: pr.p,
+    syncAccess,
+    encourager: {
+      encourage(name) {
+        const bang = new Promise(resolve => {
+          setTimeout(
+            () =>
+              resolve({
+                trigger() {
+                  return `${name} BANG!`;
+                },
+              }),
+            200,
+          );
+        });
+        return { comment: `good work, ${name}`, bang };
       },
-    }),
-  ));
-  const rightRef = leftBootstrap();
-  const { comment, bang } = await E(E.G(rightRef).encourager).encourage(
-    'buddy',
-  );
+    },
+  });
+
+  // Mark obj as far.
+  const obj = makeFar(objNear);
+
+  const { comment, bang } = await E(E.G(obj).encourager).encourage('buddy');
   t.is(comment, 'good work, buddy', 'got encouragement');
   t.is(await E(bang).trigger(), 'buddy BANG!', 'called on promise');
   pr.res('resolution');
-  t.is(await E.G(rightRef).promise, 'resolution', 'get resolution');
+  t.is(await E.G(obj).promise, 'resolution', 'get resolution');
+
+  const asyncAccess = E.G(obj).syncAccess;
+  t.is(
+    await E(asyncAccess).checkHandle(syncHandle),
+    false,
+    'sync handle fails inband',
+  );
+
+  const sa = makeFar(syncAccess);
+
+  const asyncHandle = await E(asyncAccess).getHandle();
+  // console.log('handle', ibHandle);
+  t.is(
+    await E(asyncAccess).checkHandle(asyncHandle),
+    true,
+    'async handle succeeds inband',
+  );
+  t.is(
+    await E(sa).checkHandle(asyncHandle),
+    true,
+    'async handle succeeds out-of-band',
+  );
+
+  const oobHandleP = await E(sa).getHandleP();
+  t.assert(
+    await E(sa).checkHandle(oobHandleP),
+    'out-of-band handle promise succeeds out-of-band',
+  );
+  t.assert(
+    await E(asyncAccess).checkHandle(oobHandleP),
+    'out-of-band handle promise succeeds inband',
+  );
 });

--- a/packages/eventual-send/src/no-shim.js
+++ b/packages/eventual-send/src/no-shim.js
@@ -1,4 +1,6 @@
 /* global HandledPromise */
 import makeE from './E';
 
+const hp = HandledPromise;
 export const E = makeE(HandledPromise);
+export { hp as HandledPromise };


### PR DESCRIPTION
Use to impose an async boundary between the caller and `obj`:

```js
import { makeLoopback } from '@agoric/captp';
const makeFar = makeLoopback('away');
// objFar is a far reference, on the connection named 'away'
const objFar = makeFar(obj);
E(objFar).method(); // will call `obj.method()` asynchronously.
```

Then if you receive (out-of-band) a synchronous object `obj` that you wish to be able to use the same objects with, use `makeFar` to wrap it and use the wrapped version with `E()`:

```js
const otherObjFar = makeFar(otherObj);
const ret = await E(otherObjFar).doit('foo');
E(objFar).otherMethod(ret);
// `obj.otherMethod` will be called asynchronously but receive ret as near reference
```
