### PR TITLE
fix: re-enable mebrane proto walking (delta to PR #1716)

### DIFF
--- a/packages/captp/lib/membrane.js
+++ b/packages/captp/lib/membrane.js
@@ -19,10 +19,17 @@ export const makeMembrane = (rootBlue, opts = {}) => {
     finishBlue = IDENTITY,
     finishYellow = IDENTITY,
     eager = false,
+    initialBlueYellowPairs = [
+      [Object.prototype, Object.prototype],
+      [Function.prototype, Function.prototype],
+      [Array.prototype, Array.prototype],
+    ],
   } = opts;
 
-  const blueToYellow = new WeakMap();
-  const yellowToBlue = new WeakMap();
+  const initialYellowBluePairs = initialBlueYellowPairs.map(([b, y]) => [y, b]);
+  // TODO should verify that these are proper inverses
+  const blueToYellow = new WeakMap(initialBlueYellowPairs);
+  const yellowToBlue = new WeakMap(initialYellowBluePairs);
 
   /**
    * @param {WeakMap<NearRef, FarRef>} nearToFar
@@ -78,6 +85,8 @@ export const makeMembrane = (rootBlue, opts = {}) => {
         /** Typecasts necessary */
         const fnUnknown = /** @type {unknown} */ (fnFar);
         xFar = /** @type {FarRef} */ (fnUnknown);
+      } else if (Array.isArray(xNearRef)) {
+        xFar = /** @type {FarRef} */ ([]);
       } else {
         xFar = /** @type {FarRef} */ ({});
       }

--- a/packages/captp/lib/membrane.js
+++ b/packages/captp/lib/membrane.js
@@ -108,7 +108,7 @@ export const makeMembrane = (rootBlue, opts = {}) => {
               get: () => passNearToFar(vDescNear.value),
               enumerable: vDescNear.enumerable,
               configurable: vDescNear.configurable,
-            }
+            };
           }
           return [name, vDescFar];
         }

--- a/packages/captp/lib/membrane.js
+++ b/packages/captp/lib/membrane.js
@@ -1,8 +1,10 @@
 // @ts-check
 
 /**
- * @typedef {({} | Function) & 'Near'} NearRef Intersection to make compatible only with itself.
- * @typedef {({} | Function) & 'Far'} FarRef Intersection to make compatible only with itself.
+ * @typedef {({} | Function) & 'Near'} NearRef Intersection to make compatible
+ * only with itself.
+ * @typedef {({} | Function) & 'Far'} FarRef Intersection to make compatible
+ * only with itself.
  */
 
 /**
@@ -16,6 +18,7 @@ export const makeMembrane = (rootBlue, opts = {}) => {
     distortYellow = IDENTITY,
     finishBlue = IDENTITY,
     finishYellow = IDENTITY,
+    eager = false,
   } = opts;
 
   const blueToYellow = new WeakMap();
@@ -94,10 +97,19 @@ export const makeMembrane = (rootBlue, opts = {}) => {
        */
       const nearToFarMapper = ([name, vDescNear]) => {
         if ('value' in vDescNear) {
-          const vDescFar = {
-            ...vDescNear,
-            value: passNearToFar(vDescNear.value),
-          };
+          let vDescFar;
+          if (eager) {
+            vDescFar = {
+              ...vDescNear,
+              value: passNearToFar(vDescNear.value),
+            };
+          } else {
+            vDescFar = {
+              get: () => passNearToFar(vDescNear.value),
+              enumerable: vDescNear.enumerable,
+              configurable: vDescNear.configurable,
+            }
+          }
           return [name, vDescFar];
         }
         const vFarDesc = {

--- a/packages/captp/lib/membrane.js
+++ b/packages/captp/lib/membrane.js
@@ -86,12 +86,7 @@ export const makeMembrane = (rootBlue, opts = {}) => {
       const xProtoNear = Object.getPrototypeOf(xNearRef);
       const xProtoFar = passNearToFar(xProtoNear);
 
-      xProtoFar; // Silence unused warning.
-      /* Object.setPrototypeOf(xFar, xProtoFar); */
-      // FIXME: If above is uncommented, fails with:
-      // TypeError {
-      //   message: 'a prototype of something is not already in the fringeset (and .toString failed)',
-      // }
+      Object.setPrototypeOf(xFar, xProtoFar);
 
       /**
        * @param {[string, PropertyDescriptor]} param0

--- a/packages/captp/lib/membrane.js
+++ b/packages/captp/lib/membrane.js
@@ -114,14 +114,13 @@ export const makeMembrane = (rootBlue, opts = {}) => {
           try {
             Object.defineProperty(xFar, name, descFar);
           } catch (e) {
-            /*
-            console.log(xNear, xDescsNear);
+            console.log(
+              'Membrane failed to defineProperty',
+              xNear,
+              xDescsNear,
+              e,
+            );
             throw e;
-            */
-            // FIXME: If above is uncommented, fails with:
-            // TypeError {
-            //   message: 'Cannot redefine property: name',
-            // }
           }
         });
 


### PR DESCRIPTION
In order to try an experiment I uncommented the commented out `setPrototype` that was giving us trouble, and reran tests to start experimenting with the problem. To my surprise, all tests still pass. Did the problem fail to reproduce, or were we trying a case that is not in the automated tests?

Our previous failure of `defineProperty` to define a `name` property also failed to reproduce.

Added the actual experiment, which I think is a good idea anyway --- property proxying defaults to lazy using an accessor, but with an eager option. However, since I cannot reproduce the problems, I can't tell if this fixes them.