### PR TITLE
update tests of zoeHelpers

### DIFF
--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -95,6 +95,12 @@ export const assertIssuerKeywords = (zcf, expected) => {
 };
 
 /**
+ * @typedef {Object} ZcfSeatPartial
+ * @property {() => ProposalRecord} getProposal
+ * @property {() => Allocation} getCurrentAllocation
+ */
+
+/**
  * Check whether an update to currentAllocation satisfies
  * proposal.want. Note that this is half of the offer safety
  * check; whether the allocation constitutes a refund is not
@@ -103,7 +109,7 @@ export const assertIssuerKeywords = (zcf, expected) => {
  * to produce the newAllocation.
  *
  * @param {ContractFacet} zcf
- * @param {ZCFSeat} seat
+ * @param {ZcfSeatPartial} seat
  * @param {AmountKeywordRecord} update
  * @returns {boolean}
  */

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -88,7 +88,7 @@ export const makeZoeSeatAdminKit = (
     getPayouts: async () => payoutPromiseKit.promise,
     getPayout: async keyword => E.G(payoutPromiseKit.promise)[keyword],
     getOfferResult: async () => offerResult,
-    hasExited: async () => instanceAdmin.hasZoeSeatAdmin(zoeSeatAdmin),
+    hasExited: async () => !instanceAdmin.hasZoeSeatAdmin(zoeSeatAdmin),
     tryExit: async () => E(exitObj).exit(),
     getNotifier: async () => notifier,
   });

--- a/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
@@ -378,12 +378,16 @@ const makeMockZcfSeatAdmin = (proposal, initialAllocation, getAmountMath) => {
     { proposal, initialAllocation },
     getAmountMath,
   );
+  let hasExited = false;
   const mockSeat = harden({
     isOfferSafe: actual.isOfferSafe,
     getCurrentAllocation: actual.getCurrentAllocation,
     getProposal: () => proposal,
     stage: actual.stage,
-    hasExited: actual.hasExited,
+    hasExited: () => hasExited,
+    exit: () => {
+      hasExited = true;
+    },
   });
   return mockSeat;
 };
@@ -444,6 +448,8 @@ test('ZoeHelpers trade ok', t => {
     { Items: moola(7), Money: simoleans(2) },
     'right gets what he wants',
   );
+  t.not(leftZcfSeat.hasExited(), 'Trade should not cause seats to exit');
+  t.not(rightZcfSeat.hasExited(), 'Trade should not cause seats to exit');
 });
 
 test('ZoeHelpers trade same seat', t => {
@@ -483,4 +489,5 @@ test('ZoeHelpers trade same seat', t => {
     { message: 'a seat cannot trade with itself' },
     'seats must be different',
   );
+  t.not(leftZcfSeat.hasExited(), 'Trade should not cause seats to exit');
 });

--- a/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -6,52 +5,40 @@ import test from 'ava';
 
 import makeStore from '@agoric/store';
 import { setup } from '../setupBasicMints';
+import { makeZcfSeatAdminKit } from '../../../src/contractFacet/seat';
 
 import {
   defaultAcceptanceMsg,
+  satisfies,
+  trade,
 } from '../../../src/contractSupport';
 
 test('ZoeHelpers messages', t => {
-    t.is(
-      defaultAcceptanceMsg,
-      `The offer has been accepted. Once the contract has been completed, please check your payout`,
-    );
+  t.is(
+    defaultAcceptanceMsg,
+    `The offer has been accepted. Once the contract has been completed, please check your payout`,
+  );
 });
 
-function makeMockZoeBuilder() {
+function makeMockTradingZcfBuilder() {
   const offers = makeStore('offerHandle');
   const allocs = makeStore('offerHandle');
-  let instanceRecord;
   const amountMathToBrand = makeStore('amountMath');
-  const completedHandles = [];
-  const reallocatedAmountObjs = [];
-  const reallocatedHandles = [];
-  let isOfferActive = true;
+  const reallocatedStagings = [];
 
   return harden({
     addOffer: (keyword, offer) => offers.init(keyword, offer),
     addAllocation: (keyword, alloc) => allocs.init(keyword, alloc),
-    setInstanceRecord: newRecord => (instanceRecord = newRecord),
     addBrand: issuerRecord =>
       amountMathToBrand.init(issuerRecord.brand, issuerRecord.amountMath),
-    setOffersInactive: () => (isOfferActive = false),
     build: () =>
       harden({
-        getInstanceRecord: () => instanceRecord,
         getAmountMath: amountMath => amountMathToBrand.get(amountMath),
         getZoeService: () => {},
-        isOfferActive: () => isOfferActive,
-        getOffer: handle => offers.get(handle),
-        getCurrentAllocation: handle => allocs.get(handle),
-        reallocate: (handles, amountObjs) => {
-          reallocatedHandles.push(...handles);
-          reallocatedAmountObjs.push(...amountObjs);
+        reallocate: (...seatStagings) => {
+          reallocatedStagings.push(...seatStagings);
         },
-        complete: handles =>
-          handles.map(handle => completedHandles.push(handle)),
-        getReallocatedAmountObjs: () => reallocatedAmountObjs,
-        getReallocatedHandles: () => reallocatedHandles,
-        getCompletedHandles: () => completedHandles,
+        getReallocatedStagings: () => reallocatedStagings,
       }),
   });
 }
@@ -59,210 +46,40 @@ function makeMockZoeBuilder() {
 test.skip('ZoeHelpers assertKeywords', t => {
   t.plan(5);
   const { moolaR, simoleanR } = setup();
-    const mockZCFBuilder = makeMockZoeBuilder();
-    mockZCFBuilder.setInstanceRecord({
-      issuerKeywordRecord: {
-        Asset: moolaR.issuer,
-        Price: simoleanR.issuer,
-      },
-    });
+  const mockZCFBuilder = makeMockTradingZcfBuilder();
+  mockZCFBuilder.setInstanceRecord({
+    issuerKeywordRecord: {
+      Asset: moolaR.issuer,
+      Price: simoleanR.issuer,
+    },
+  });
 
-    const mockZCF = mockZCFBuilder.build();
-    const { assertKeywords } = makeZoeHelpers(mockZCF);
-    t.doesNotThrow(
-      () => assertKeywords(['Asset', 'Price']),
-      `Asset and Price are the correct keywords`,
-    );
-    t.doesNotThrow(
-      () => assertKeywords(['Price', 'Asset']),
-      `Order doesn't matter`,
-    );
-    t.throws(
-      () => assertKeywords(['TokenA', 'TokenB']),
-      /were not as expected/,
-      `The wrong keywords will throw`,
-    );
-    t.throws(
-      () => assertKeywords(['Asset', 'Price', 'Price2']),
-      /were not as expected/,
-      `An extra keyword will throw`,
-    );
-    t.throws(
-      () => assertKeywords(['Asset']),
-      /were not as expected/,
-      `a missing keyword will throw`,
-    );
-});
-
-test.skip('ZoeHelpers rejectIfNotProposal', t => {
-  t.plan(8);
-  const { moola, simoleans } = setup();
-  const offerHandles = harden([{}, {}, {}, {}, {}, {}, {}]);
-    const mockZCFBuilder = makeMockZoeBuilder();
-    mockZCFBuilder.addOffer(offerHandles[4], {
-      proposal: {
-        want: { Asset: moola(4) },
-        give: { Price: simoleans(16) },
-        exit: { waived: null },
-      },
-    });
-    mockZCFBuilder.addOffer(offerHandles[5], {
-      proposal: {
-        want: { Asset2: moola(4) },
-        give: { Price: simoleans(16) },
-        exit: { waived: null },
-      },
-    });
-
-    const otherOffers = harden({
-      proposal: {
-        want: { Asset: moola(4) },
-        give: { Price: simoleans(16) },
-        exit: { onDemand: null },
-      },
-    });
-    // TODO: perhaps mockZCFBuilder could have a default Offer?
-    mockZCFBuilder.addOffer(offerHandles[0], otherOffers);
-    mockZCFBuilder.addOffer(offerHandles[1], otherOffers);
-    mockZCFBuilder.addOffer(offerHandles[2], otherOffers);
-    mockZCFBuilder.addOffer(offerHandles[3], otherOffers);
-    const mockZCF = mockZCFBuilder.build();
-    const { rejectIfNotProposal } = makeZoeHelpers(mockZCF);
-    // Vary expected.
-    t.doesNotThrow(() =>
-      rejectIfNotProposal(
-        offerHandles[0],
-        harden({
-          want: { Asset: null },
-          give: { Price: null },
-        }),
-      ),
-    );
-    t.throws(
-      () =>
-        rejectIfNotProposal(
-          offerHandles[1],
-          harden({
-            want: { Assets: null },
-            give: { Price: null },
-          }),
-        ),
-      /The offer was invalid. Please check your refund./,
-      `had the wrong wants`,
-    );
-    t.throws(
-      () =>
-        rejectIfNotProposal(
-          offerHandles[2],
-          harden({
-            want: { Asset: null },
-            give: { Price2: null },
-          }),
-        ),
-      /The offer was invalid. Please check your refund./,
-      `had the wrong offer`,
-    );
-    t.throws(
-      () =>
-        rejectIfNotProposal(
-          offerHandles[3],
-          harden({
-            want: { Asset: null },
-            give: { Price: null },
-            exit: { waived: null },
-          }),
-        ),
-      /The offer was invalid. Please check your refund./,
-      `had the wrong exit rule`,
-    );
-    t.deepEqual(
-      mockZCF.getCompletedHandles(),
-      [],
-      `offers 1, 2, 3, (zero-indexed) won't be completed before rejection`,
-    );
-
-    // Now vary the offer.
-    t.throws(
-      () =>
-        rejectIfNotProposal(
-          offerHandles[4],
-          harden({
-            want: { Asset: null },
-            give: { Price: null },
-            exit: { waived: null },
-          }),
-        ),
-      /The offer was invalid. Please check your refund./,
-      `had the wrong exit rule`,
-    );
-    t.throws(
-      () =>
-        rejectIfNotProposal(
-          offerHandles[5],
-          harden({
-            want: { Asset: null },
-            give: { Price: null },
-            exit: { waived: null },
-          }),
-        ),
-      /The offer was invalid. Please check your refund./,
-      `had the wrong want`,
-    );
-    t.deepEqual(
-      mockZCF.getCompletedHandles(),
-      [],
-      `offers won't be completed before rejection`,
-    );
-});
-
-test.skip('ZoeHelpers getActiveOffers', t => {
-    // uses its own mock because all it needs is a variant getOffers.
-    const mockZCF = harden({
-      getZoeService: () => {},
-      getOfferStatuses: handles => {
-        const [firstHandle, restHandles] = handles;
-        return harden({
-          active: [firstHandle],
-          inactive: restHandles,
-        });
-      },
-      getOffers: handles =>
-        handles.map((handle, i) => harden({ handle, id: i })),
-    });
-    const { getActiveOffers } = makeZoeHelpers(mockZCF);
-    const offerHandles = harden([{}, {}]);
-    t.deepEqual(
-      getActiveOffers(offerHandles),
-      harden([{ handle: offerHandles[0], id: 0 }]),
-      `active offers gotten`,
-    );
-});
-
-test.skip('ZoeHelpers rejectOffer', t => {
-  t.plan(4);
-  const completedOfferHandles = [];
-    const mockZCF = harden({
-      getZoeService: () => {},
-      complete: handles => completedOfferHandles.push(...handles),
-    });
-    const { rejectOffer } = makeZoeHelpers(mockZCF);
-    const offerHandles = harden([{}, {}]);
-    t.throws(
-      () => rejectOffer(offerHandles[0]),
-      /Error: The offer was invalid. Please check your refund./,
-      `rejectOffer intentionally throws`,
-    );
-    t.deepEqual(completedOfferHandles, harden([]), 'no completion');
-    t.throws(
-      () => rejectOffer(offerHandles[1], 'offer was wrong'),
-      /Error: offer was wrong/,
-      `rejectOffer throws with custom msg`,
-    );
-    t.deepEqual(
-      completedOfferHandles,
-      [],
-      'rejection does not include completions',
-    );
+  const mockZCF = mockZCFBuilder.build();
+  // eslint-disable-next-line no-undef
+  const { assertKeywords } = makeZoeHelpers(mockZCF);
+  t.doesNotThrow(
+    () => assertKeywords(['Asset', 'Price']),
+    `Asset and Price are the correct keywords`,
+  );
+  t.doesNotThrow(
+    () => assertKeywords(['Price', 'Asset']),
+    `Order doesn't matter`,
+  );
+  t.throws(
+    () => assertKeywords(['TokenA', 'TokenB']),
+    /were not as expected/,
+    `The wrong keywords will throw`,
+  );
+  t.throws(
+    () => assertKeywords(['Asset', 'Price', 'Price2']),
+    /were not as expected/,
+    `An extra keyword will throw`,
+  );
+  t.throws(
+    () => assertKeywords(['Asset']),
+    /were not as expected/,
+    `a missing keyword will throw`,
+  );
 });
 
 test.skip('ZoeHelpers swap ok', t => {
@@ -271,62 +88,59 @@ test.skip('ZoeHelpers swap ok', t => {
   const leftOfferHandle = harden({});
   const rightOfferHandle = harden({});
   const cantTradeRightOfferHandle = harden({});
-    const mockZCFBuilder = makeMockZoeBuilder();
-    mockZCFBuilder.addBrand(moolaR);
-    mockZCFBuilder.addBrand(simoleanR);
-    mockZCFBuilder.addAllocation(leftOfferHandle, { Asset: moola(10) });
-    mockZCFBuilder.addAllocation(rightOfferHandle, { Price: simoleans(6) });
-    mockZCFBuilder.addAllocation(cantTradeRightOfferHandle, {
-      Price: simoleans(6),
-    });
-    mockZCFBuilder.addOffer(leftOfferHandle, {
-      proposal: {
-        give: { Asset: moola(10) },
-        want: { Price: simoleans(4) },
-        exit: { onDemand: null },
-      },
-    });
-    mockZCFBuilder.addOffer(rightOfferHandle, {
-      proposal: {
-        give: { Price: simoleans(6) },
-        want: { Asset: moola(7) },
-        exit: { onDemand: null },
-      },
-    });
-    mockZCFBuilder.addOffer(cantTradeRightOfferHandle, {
-      proposal: {
-        give: { Price: simoleans(6) },
-        want: { Asset: moola(100) },
-        exit: { onDemand: null },
-      },
-    });
-    const mockZCF = mockZCFBuilder.build();
-    const { swap } = makeZoeHelpers(mockZCF);
-    t.truthy(
-      swap(
-        leftOfferHandle,
-        rightOfferHandle,
-        'prior offer no longer available',
-      ),
-    );
-    t.deepEqual(
-      mockZCF.getReallocatedHandles(),
-      harden([leftOfferHandle, rightOfferHandle]),
-      `both handles reallocated`,
-    );
-    t.deepEqual(
-      mockZCF.getReallocatedAmountObjs(),
-      [
-        { Asset: moola(3), Price: simoleans(4) },
-        { Price: simoleans(2), Asset: moola(7) },
-      ],
-      `amounts reallocated passed to reallocate were as expected`,
-    );
-    t.deepEqual(
-      mockZCF.getCompletedHandles(),
-      harden([leftOfferHandle, rightOfferHandle]),
-      `both handles were completed`,
-    );
+  const mockZCFBuilder = makeMockTradingZcfBuilder();
+  mockZCFBuilder.addBrand(moolaR);
+  mockZCFBuilder.addBrand(simoleanR);
+  mockZCFBuilder.addAllocation(leftOfferHandle, { Asset: moola(10) });
+  mockZCFBuilder.addAllocation(rightOfferHandle, { Price: simoleans(6) });
+  mockZCFBuilder.addAllocation(cantTradeRightOfferHandle, {
+    Price: simoleans(6),
+  });
+  mockZCFBuilder.addOffer(leftOfferHandle, {
+    proposal: {
+      give: { Asset: moola(10) },
+      want: { Price: simoleans(4) },
+      exit: { onDemand: null },
+    },
+  });
+  mockZCFBuilder.addOffer(rightOfferHandle, {
+    proposal: {
+      give: { Price: simoleans(6) },
+      want: { Asset: moola(7) },
+      exit: { onDemand: null },
+    },
+  });
+  mockZCFBuilder.addOffer(cantTradeRightOfferHandle, {
+    proposal: {
+      give: { Price: simoleans(6) },
+      want: { Asset: moola(100) },
+      exit: { onDemand: null },
+    },
+  });
+  const mockZCF = mockZCFBuilder.build();
+  // eslint-disable-next-line no-undef
+  const { swap } = makeZoeHelpers(mockZCF);
+  t.truthy(
+    swap(leftOfferHandle, rightOfferHandle, 'prior offer no longer available'),
+  );
+  t.deepEqual(
+    mockZCF.getReallocatedHandles(),
+    harden([leftOfferHandle, rightOfferHandle]),
+    `both handles reallocated`,
+  );
+  t.deepEqual(
+    mockZCF.getReallocatedAmountObjs(),
+    [
+      { Asset: moola(3), Price: simoleans(4) },
+      { Price: simoleans(2), Asset: moola(7) },
+    ],
+    `amounts reallocated passed to reallocate were as expected`,
+  );
+  t.deepEqual(
+    mockZCF.getCompletedHandles(),
+    harden([leftOfferHandle, rightOfferHandle]),
+    `both handles were completed`,
+  );
 });
 
 test.skip('ZoeHelpers swap keep inactive', t => {
@@ -335,50 +149,51 @@ test.skip('ZoeHelpers swap keep inactive', t => {
   const leftOfferHandle = harden({});
   const rightOfferHandle = harden({});
   const cantTradeRightOfferHandle = harden({});
-    const mockZCFBuilder = makeMockZoeBuilder();
-    mockZCFBuilder.addOffer(leftOfferHandle, {
-      proposal: {
-        give: { Asset: moola(10) },
-        want: { Price: simoleans(4) },
-        exit: { onDemand: null },
-      },
-    });
-    mockZCFBuilder.addOffer(rightOfferHandle, {
-      proposal: {
-        give: { Price: simoleans(6) },
-        want: { Asset: moola(7) },
-        exit: { onDemand: null },
-      },
-    });
-    mockZCFBuilder.addOffer(cantTradeRightOfferHandle, {
-      proposal: {
-        give: { Price: simoleans(6) },
-        want: { Asset: moola(100) },
-        exit: { onDemand: null },
-      },
-    });
-    mockZCFBuilder.setOffersInactive();
-    const mockZCF = mockZCFBuilder.build();
-    const { swap } = makeZoeHelpers(mockZCF);
-    t.throws(
-      () =>
-        swap(
-          leftOfferHandle,
-          rightOfferHandle,
-          'prior offer no longer available',
-        ),
-      /Error: prior offer no longer available/,
-      `throws if keepHandle offer is not active`,
-    );
-    const reallocatedHandles = mockZCF.getReallocatedHandles();
-    t.deepEqual(reallocatedHandles, harden([]), `nothing reallocated`);
-    const reallocatedAmountObjs = mockZCF.getReallocatedAmountObjs();
-    t.deepEqual(reallocatedAmountObjs, harden([]), `no amounts reallocated`);
-    t.deepEqual(
-      mockZCF.getCompletedHandles(),
-      harden([]),
-      `no offers were completed`,
-    );
+  const mockZCFBuilder = makeMockTradingZcfBuilder();
+  mockZCFBuilder.addOffer(leftOfferHandle, {
+    proposal: {
+      give: { Asset: moola(10) },
+      want: { Price: simoleans(4) },
+      exit: { onDemand: null },
+    },
+  });
+  mockZCFBuilder.addOffer(rightOfferHandle, {
+    proposal: {
+      give: { Price: simoleans(6) },
+      want: { Asset: moola(7) },
+      exit: { onDemand: null },
+    },
+  });
+  mockZCFBuilder.addOffer(cantTradeRightOfferHandle, {
+    proposal: {
+      give: { Price: simoleans(6) },
+      want: { Asset: moola(100) },
+      exit: { onDemand: null },
+    },
+  });
+  mockZCFBuilder.setOffersInactive();
+  const mockZCF = mockZCFBuilder.build();
+  // eslint-disable-next-line no-undef
+  const { swap } = makeZoeHelpers(mockZCF);
+  t.throws(
+    () =>
+      swap(
+        leftOfferHandle,
+        rightOfferHandle,
+        'prior offer no longer available',
+      ),
+    /Error: prior offer no longer available/,
+    `throws if keepHandle offer is not active`,
+  );
+  const reallocatedHandles = mockZCF.getReallocatedHandles();
+  t.deepEqual(reallocatedHandles, harden([]), `nothing reallocated`);
+  const reallocatedAmountObjs = mockZCF.getReallocatedAmountObjs();
+  t.deepEqual(reallocatedAmountObjs, harden([]), `no amounts reallocated`);
+  t.deepEqual(
+    mockZCF.getCompletedHandles(),
+    harden([]),
+    `no offers were completed`,
+  );
 });
 
 test.skip(`ZoeHelpers swap - can't trade with`, t => {
@@ -388,51 +203,48 @@ test.skip(`ZoeHelpers swap - can't trade with`, t => {
   const rightOfferHandle = harden({});
   const cantTradeHandle = harden({});
 
-    const mockZCFBuilder = makeMockZoeBuilder();
-    mockZCFBuilder.addBrand(moolaR);
-    mockZCFBuilder.addBrand(simoleanR);
-    mockZCFBuilder.addOffer(leftOfferHandle, {
-      proposal: {
-        give: { Asset: moola(10) },
-        want: { Price: simoleans(4) },
-        exit: { onDemand: null },
-      },
-    });
-    mockZCFBuilder.addOffer(rightOfferHandle, {
-      proposal: {
-        give: { Price: simoleans(6) },
-        want: { Asset: moola(7) },
-        exit: { onDemand: null },
-      },
-    });
-    mockZCFBuilder.addOffer(cantTradeHandle, {
-      proposal: {
-        give: { Price: simoleans(6) },
-        want: { Asset: moola(100) },
-        exit: { onDemand: null },
-      },
-    });
-    mockZCFBuilder.addAllocation(leftOfferHandle, { Asset: moola(10) });
-    mockZCFBuilder.addAllocation(rightOfferHandle, { Price: simoleans(6) });
-    mockZCFBuilder.addAllocation(cantTradeHandle, { Price: simoleans(6) });
-    const mockZcf = mockZCFBuilder.build();
-    const { swap } = makeZoeHelpers(mockZcf);
-    t.throws(
-      () =>
-        swap(
-          leftOfferHandle,
-          cantTradeHandle,
-          'prior offer no longer available',
-        ),
-      /Error: The offer was invalid. Please check your refund./,
-      `throws if can't trade with left and right`,
-    );
-    const reallocatedHandles = mockZcf.getReallocatedHandles();
-    t.deepEqual(reallocatedHandles, harden([]), `nothing reallocated`);
-    const reallocatedAmountObjs = mockZcf.getReallocatedAmountObjs();
-    t.deepEqual(reallocatedAmountObjs, harden([]), `no amounts reallocated`);
-    const completedHandles = mockZcf.getCompletedHandles();
-    t.deepEqual(completedHandles, harden([]), `no offers were completed`);
+  const mockZCFBuilder = makeMockTradingZcfBuilder();
+  mockZCFBuilder.addBrand(moolaR);
+  mockZCFBuilder.addBrand(simoleanR);
+  mockZCFBuilder.addOffer(leftOfferHandle, {
+    proposal: {
+      give: { Asset: moola(10) },
+      want: { Price: simoleans(4) },
+      exit: { onDemand: null },
+    },
+  });
+  mockZCFBuilder.addOffer(rightOfferHandle, {
+    proposal: {
+      give: { Price: simoleans(6) },
+      want: { Asset: moola(7) },
+      exit: { onDemand: null },
+    },
+  });
+  mockZCFBuilder.addOffer(cantTradeHandle, {
+    proposal: {
+      give: { Price: simoleans(6) },
+      want: { Asset: moola(100) },
+      exit: { onDemand: null },
+    },
+  });
+  mockZCFBuilder.addAllocation(leftOfferHandle, { Asset: moola(10) });
+  mockZCFBuilder.addAllocation(rightOfferHandle, { Price: simoleans(6) });
+  mockZCFBuilder.addAllocation(cantTradeHandle, { Price: simoleans(6) });
+  const mockZcf = mockZCFBuilder.build();
+  // eslint-disable-next-line no-undef
+  const { swap } = makeZoeHelpers(mockZcf);
+  t.throws(
+    () =>
+      swap(leftOfferHandle, cantTradeHandle, 'prior offer no longer available'),
+    /Error: The offer was invalid. Please check your refund./,
+    `throws if can't trade with left and right`,
+  );
+  const reallocatedHandles = mockZcf.getReallocatedHandles();
+  t.deepEqual(reallocatedHandles, harden([]), `nothing reallocated`);
+  const reallocatedAmountObjs = mockZcf.getReallocatedAmountObjs();
+  t.deepEqual(reallocatedAmountObjs, harden([]), `no amounts reallocated`);
+  const completedHandles = mockZcf.getCompletedHandles();
+  t.deepEqual(completedHandles, harden([]), `no offers were completed`);
 });
 
 test.skip('ZoeHelpers isOfferSafe', t => {
@@ -444,210 +256,231 @@ test.skip('ZoeHelpers isOfferSafe', t => {
   const reallocatedHandles = [];
   const reallocatedAmountObjs = [];
   const completedHandles = [];
-    const mockZCFBuilder = makeMockZoeBuilder();
-    mockZCFBuilder.addBrand(moolaR);
-    mockZCFBuilder.addBrand(simoleanR);
-    mockZCFBuilder.addAllocation(leftOfferHandle, { Asset: moola(10) });
-    mockZCFBuilder.addAllocation(rightOfferHandle, { Price: simoleans(6) });
-    mockZCFBuilder.addAllocation(cantTradeRightOfferHandle, {
-      Price: simoleans(6),
-    });
-    mockZCFBuilder.addOffer(leftOfferHandle, {
-      proposal: {
-        give: { Asset: moola(10) },
-        want: { Price: simoleans(4) },
-        exit: { onDemand: null },
-      },
-    });
-    const mockZCF = mockZCFBuilder.build();
-    const { isOfferSafe } = makeZoeHelpers(mockZCF);
-    t.truthy(
-      isOfferSafe(leftOfferHandle, {
-        Asset: moola(0),
-        Price: simoleans(4),
-      }),
-      `giving someone exactly what they want is offer safe`,
-    );
-    t.falsy(
-      isOfferSafe(leftOfferHandle, {
-        Asset: moola(0),
-        Price: simoleans(3),
-      }),
-      `giving someone less than what they want and not what they gave is not offer safe`,
-    );
-    t.deepEqual(reallocatedHandles, harden([]), `nothing reallocated`);
-    t.deepEqual(reallocatedAmountObjs, harden([]), `no amounts reallocated`);
-    t.deepEqual(completedHandles, harden([]), `no offers completed`);
+  const mockZCFBuilder = makeMockTradingZcfBuilder();
+  mockZCFBuilder.addBrand(moolaR);
+  mockZCFBuilder.addBrand(simoleanR);
+  mockZCFBuilder.addAllocation(leftOfferHandle, { Asset: moola(10) });
+  mockZCFBuilder.addAllocation(rightOfferHandle, { Price: simoleans(6) });
+  mockZCFBuilder.addAllocation(cantTradeRightOfferHandle, {
+    Price: simoleans(6),
+  });
+  mockZCFBuilder.addOffer(leftOfferHandle, {
+    proposal: {
+      give: { Asset: moola(10) },
+      want: { Price: simoleans(4) },
+      exit: { onDemand: null },
+    },
+  });
+  const mockZCF = mockZCFBuilder.build();
+  // eslint-disable-next-line no-undef
+  const { isOfferSafe } = makeZoeHelpers(mockZCF);
+  t.truthy(
+    isOfferSafe(leftOfferHandle, {
+      Asset: moola(0),
+      Price: simoleans(4),
+    }),
+    `giving someone exactly what they want is offer safe`,
+  );
+  t.falsy(
+    isOfferSafe(leftOfferHandle, {
+      Asset: moola(0),
+      Price: simoleans(3),
+    }),
+    `giving someone less than what they want and not what they gave is not offer safe`,
+  );
+  t.deepEqual(reallocatedHandles, harden([]), `nothing reallocated`);
+  t.deepEqual(reallocatedAmountObjs, harden([]), `no amounts reallocated`);
+  t.deepEqual(completedHandles, harden([]), `no offers completed`);
 });
 
-test.skip('ZoeHelpers satisfies', t => {
-  t.plan(6);
-  const { moolaR, simoleanR, moola, simoleans } = setup();
-  const leftOfferHandle = harden({});
-  const rightOfferHandle = harden({});
-  const cantTradeRightOfferHandle = harden({});
-  const reallocatedHandles = [];
-  const reallocatedAmountObjs = [];
-  const completedHandles = [];
-    const mockZCFBuilder = makeMockZoeBuilder();
-    mockZCFBuilder.addBrand(moolaR);
-    mockZCFBuilder.addBrand(simoleanR);
-    mockZCFBuilder.addAllocation(leftOfferHandle, { Asset: moola(10) });
-    mockZCFBuilder.addAllocation(rightOfferHandle, { Price: simoleans(6) });
-    mockZCFBuilder.addAllocation(cantTradeRightOfferHandle, {
-      Price: simoleans(6),
-    });
-    mockZCFBuilder.addOffer(leftOfferHandle, {
-      proposal: {
-        give: { Asset: moola(10) },
-        want: { Price: simoleans(4) },
-        exit: { onDemand: null },
-      },
-    });
-    const mockZCF = mockZCFBuilder.build();
-    const { satisfies } = makeZoeHelpers(mockZCF);
-    t.truthy(
-      satisfies(leftOfferHandle, {
-        Asset: moola(0),
-        Price: simoleans(4),
-      }),
-      `giving someone exactly what they want satisifies wants`,
-    );
-    t.falsy(
-      satisfies(leftOfferHandle, {
-        Asset: moola(10),
-        Price: simoleans(3),
-      }),
-      `giving someone less than what they want even with a refund doesn't satisfy wants`,
-    );
-    t.falsy(
-      satisfies(leftOfferHandle, {
-        Asset: moola(0),
-        Price: simoleans(3),
-      }),
-      `giving someone less than what they want even with a refund doesn't satisfy wants`,
-    );
-    t.deepEqual(reallocatedHandles, harden([]), `nothing reallocated`);
-    t.deepEqual(reallocatedAmountObjs, harden([]), `no amounts reallocated`);
-    t.deepEqual(completedHandles, harden([]), `no offers completed`);
+test('ZoeHelpers satisfies blank proposal', t => {
+  const { moolaR, moola } = setup();
+  const fakeZcfSeat = harden({
+    getCurrentAllocation: () => harden({ Asset: moola(10) }),
+    getProposal: () => harden({}),
+  });
+  const mockZCFBuilder = makeMockTradingZcfBuilder();
+  mockZCFBuilder.addBrand(moolaR);
+  const mockZCF = mockZCFBuilder.build();
+  t.truthy(
+    satisfies(mockZCF, fakeZcfSeat, { Gift: moola(3) }),
+    `giving anything to a blank proposal is satisifying`,
+  );
 });
 
-test.skip('ZoeHelpers trade ok', t => {
-  t.plan(4);
-  const { moolaR, simoleanR, moola, simoleans } = setup();
-  const leftOfferHandle = harden({});
-  const rightOfferHandle = harden({});
-    const mockZCFBuilder = makeMockZoeBuilder();
-    mockZCFBuilder.addBrand(moolaR);
-    mockZCFBuilder.addBrand(simoleanR);
-    mockZCFBuilder.addAllocation(leftOfferHandle, { Asset: moola(10) });
-    mockZCFBuilder.addAllocation(rightOfferHandle, { Money: simoleans(6) });
-    mockZCFBuilder.addOffer(leftOfferHandle, {
-      proposal: {
-        give: { Asset: moola(10) },
-        want: { Bid: simoleans(4) },
-        exit: { onDemand: null },
+test('ZoeHelpers satisfies simple proposal', t => {
+  const { moolaR, moola, simoleans } = setup();
+  const fakeZcfSeat = harden({
+    getCurrentAllocation: () => harden({ Asset: moola(10) }),
+    getProposal: () => harden({ want: { Desire: moola(30) } }),
+  });
+  const mockZCFBuilder = makeMockTradingZcfBuilder();
+  mockZCFBuilder.addBrand(moolaR);
+  const mockZCF = mockZCFBuilder.build();
+  t.falsy(
+    satisfies(mockZCF, fakeZcfSeat, { Desire: moola(3) }),
+    `giving less than specified to a proposal is not satisifying`,
+  );
+  t.falsy(
+    satisfies(mockZCF, fakeZcfSeat, { Gift: moola(3) }),
+    `giving other than what's specified to a proposal is not satisifying`,
+  );
+  t.truthy(
+    satisfies(mockZCF, fakeZcfSeat, { Desire: moola(30) }),
+    `giving exactly what's proposed is satisifying`,
+  );
+  t.truthy(
+    satisfies(mockZCF, fakeZcfSeat, { Desire: moola(30), Gift: simoleans(1) }),
+    `giving extras beyond what's proposed is satisifying`,
+  );
+  t.truthy(
+    satisfies(mockZCF, fakeZcfSeat, { Desire: moola(40) }),
+    `giving more than what's proposed is satisifying`,
+  );
+});
+
+test('ZoeHelpers satisfies() with give', t => {
+  const { moolaR, moola, bucks, bucksR, simoleanR } = setup();
+  const fakeZcfSeat = harden({
+    getCurrentAllocation: () => harden({ Charge: moola(30) }),
+    getProposal: () =>
+      harden({ give: { Charge: moola(30) }, want: { Desire: bucks(5) } }),
+  });
+  const mockZCFBuilder = makeMockTradingZcfBuilder();
+  mockZCFBuilder.addBrand(moolaR);
+  mockZCFBuilder.addBrand(bucksR);
+  mockZCFBuilder.addBrand(simoleanR);
+  const mockZCF = mockZCFBuilder.build();
+  t.falsy(
+    satisfies(mockZCF, fakeZcfSeat, { Charge: moola(0), Desire: bucks(1) }),
+    `providing neither give nor want is not satisfying`,
+  );
+  t.falsy(
+    satisfies(mockZCF, fakeZcfSeat, { Charge: moola(30) }),
+    `providing less than what's wanted is not satisfying`,
+  );
+  t.truthy(
+    satisfies(mockZCF, fakeZcfSeat, { Charge: moola(0), Desire: bucks(40) }),
+    `providing more than what's wanted is satisfying`,
+  );
+  t.truthy(
+    satisfies(mockZCF, fakeZcfSeat, { Desire: bucks(40), Charge: moola(3) }),
+    `providing what's wanted makes it possible to reduce give`,
+  );
+});
+
+const makeMockZcfSeatAdmin = (proposal, initialAllocation, getAmountMath) => {
+  const allSeatStagings = new WeakSet();
+  const mockZoeSeatAdmin = harden({});
+  const { zcfSeat: actual } = makeZcfSeatAdminKit(
+    allSeatStagings,
+    mockZoeSeatAdmin,
+    { proposal, initialAllocation },
+    getAmountMath,
+  );
+  const mockSeat = harden({
+    isOfferSafe: actual.isOfferSafe,
+    getCurrentAllocation: actual.getCurrentAllocation,
+    getProposal: () => proposal,
+    stage: actual.stage,
+    hasExited: actual.hasExited,
+  });
+  return mockSeat;
+};
+
+test('ZoeHelpers trade ok', t => {
+  const { moolaR, simoleanR, moola, simoleans, amountMaths } = setup();
+  const getAmountMath = brand => amountMaths.get(brand.getAllegedName());
+  const leftProposal = {
+    give: { Asset: moola(10) },
+    want: { Bid: simoleans(4) },
+    exit: { onDemand: null },
+  };
+  const leftAlloc = { Asset: moola(10) };
+  const leftZcfSeat = makeMockZcfSeatAdmin(
+    leftProposal,
+    leftAlloc,
+    getAmountMath,
+  );
+  const rightProposal = {
+    give: { Money: simoleans(6) },
+    want: { Items: moola(7) },
+    exit: { onDemand: null },
+  };
+
+  const rightAlloc = { Money: simoleans(6) };
+  const rightZcfSeat = makeMockZcfSeatAdmin(
+    rightProposal,
+    rightAlloc,
+    getAmountMath,
+  );
+  const mockZCFBuilder = makeMockTradingZcfBuilder();
+  mockZCFBuilder.addBrand(moolaR);
+  mockZCFBuilder.addBrand(simoleanR);
+  const mockZCF = mockZCFBuilder.build();
+  t.notThrows(() =>
+    trade(
+      mockZCF,
+      {
+        seat: leftZcfSeat,
+        gains: { Bid: simoleans(4) },
+        losses: { Asset: moola(7) },
       },
-    });
-    mockZCFBuilder.addOffer(rightOfferHandle, {
-      proposal: {
-        give: { Money: simoleans(6) },
-        want: { Items: moola(7) },
-        exit: { onDemand: null },
+      {
+        seat: rightZcfSeat,
+        gains: { Items: moola(7) },
+        losses: { Money: simoleans(4) },
       },
-    });
-    const mockZCF = mockZCFBuilder.build();
-    const { trade } = makeZoeHelpers(mockZCF);
-    t.doesNotThrow(() =>
+    ),
+  );
+  t.deepEqual(mockZCF.getReallocatedStagings().length, 2, `both reallocated`);
+  t.deepEqual(
+    mockZCF.getReallocatedStagings()[0].getStagedAllocation(),
+    { Asset: moola(3), Bid: simoleans(4) },
+    'left gets what she wants',
+  );
+  t.deepEqual(
+    mockZCF.getReallocatedStagings()[1].getStagedAllocation(),
+    { Items: moola(7), Money: simoleans(2) },
+    'right gets what he wants',
+  );
+});
+
+test('ZoeHelpers trade same seat', t => {
+  const { moolaR, simoleanR, moola, simoleans, amountMaths } = setup();
+  const getAmountMath = brand => amountMaths.get(brand.getAllegedName());
+  const leftProposal = {
+    give: { Asset: moola(10) },
+    want: { Bid: simoleans(4) },
+    exit: { onDemand: null },
+  };
+  const leftAlloc = { Asset: moola(10) };
+  const leftZcfSeat = makeMockZcfSeatAdmin(
+    leftProposal,
+    leftAlloc,
+    getAmountMath,
+  );
+
+  const mockZCFBuilder = makeMockTradingZcfBuilder();
+  mockZCFBuilder.addBrand(moolaR);
+  mockZCFBuilder.addBrand(simoleanR);
+  const mockZCF = mockZCFBuilder.build();
+  t.throws(
+    () =>
       trade(
+        mockZCF,
         {
-          offerHandle: leftOfferHandle,
+          seat: leftZcfSeat,
           gains: { Bid: simoleans(4) },
           losses: { Asset: moola(7) },
         },
         {
-          offerHandle: rightOfferHandle,
+          seat: leftZcfSeat,
           gains: { Items: moola(7) },
           losses: { Money: simoleans(4) },
         },
       ),
-    );
-    t.deepEqual(
-      mockZCF.getReallocatedHandles(),
-      harden([leftOfferHandle, rightOfferHandle]),
-      `both handles reallocated`,
-    );
-    t.deepEqual(
-      mockZCF.getReallocatedAmountObjs(),
-      [
-        { Asset: moola(3), Bid: simoleans(4) },
-        { Money: simoleans(2), Items: moola(7) },
-      ],
-      `amounts reallocated passed to reallocate were as expected`,
-    );
-    t.deepEqual(
-      mockZCF.getCompletedHandles(),
-      harden([]),
-      `no handles were completed`,
-    );
-});
-
-test.skip('ZoeHelpers trade sameHandle', t => {
-  t.plan(4);
-  const { moolaR, simoleanR, moola, simoleans } = setup();
-  const leftOfferHandle = harden({});
-  const rightOfferHandle = harden({});
-    const mockZCFBuilder = makeMockZoeBuilder();
-    mockZCFBuilder.addBrand(moolaR);
-    mockZCFBuilder.addBrand(simoleanR);
-    mockZCFBuilder.addAllocation(leftOfferHandle, { Asset: moola(10) });
-    mockZCFBuilder.addAllocation(rightOfferHandle, { Money: simoleans(6) });
-    mockZCFBuilder.addOffer(leftOfferHandle, {
-      proposal: {
-        give: { Asset: moola(10) },
-        want: { Bid: simoleans(4) },
-        exit: { onDemand: null },
-      },
-    });
-    mockZCFBuilder.addOffer(rightOfferHandle, {
-      proposal: {
-        give: { Money: simoleans(6) },
-        want: { Items: moola(7) },
-        exit: { onDemand: null },
-      },
-    });
-    const mockZCF = mockZCFBuilder.build();
-    const { trade } = makeZoeHelpers(mockZCF);
-    t.throws(
-      () =>
-        trade(
-          {
-            offerHandle: leftOfferHandle,
-            gains: { Bid: simoleans(4) },
-            losses: { Asset: moola(7) },
-          },
-          {
-            offerHandle: leftOfferHandle,
-            gains: { Items: moola(7) },
-            losses: { Money: simoleans(4) },
-          },
-        ),
-      /an offer cannot trade with itself/,
-      `safe offer trading with itself fails with nice error message`,
-    );
-    t.deepEqual(
-      mockZCF.getReallocatedHandles(),
-      harden([]),
-      `no handles reallocated`,
-    );
-    t.deepEqual(
-      mockZCF.getReallocatedAmountObjs(),
-      [],
-      `no amounts reallocated`,
-    );
-    t.deepEqual(
-      mockZCF.getCompletedHandles(),
-      harden([]),
-      `no handles were completed`,
-    );
+    { message: 'a seat cannot trade with itself' },
+    'seats must be different',
+  );
 });

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -670,32 +670,27 @@ test(`zcfSeat.getProposal from zcf.makeEmptySeatKit`, async t => {
   });
 });
 
-test.failing(`zcfSeat.hasExited, exit from zcf.makeEmptySeatKit`, async t => {
+test(`zcfSeat.hasExited, exit from zcf.makeEmptySeatKit`, async t => {
   const { zcf } = await setupZCFTest();
   const { zcfSeat, userSeat } = zcf.makeEmptySeatKit();
   t.falsy(zcfSeat.hasExited());
   zcfSeat.exit();
   t.truthy(zcfSeat.hasExited());
-  // TODO: remove `failing` after fixing https://github.com/Agoric/agoric-sdk/issues/1729
   t.truthy(await E(userSeat).hasExited());
   t.deepEqual(await E(userSeat).getPayouts(), {});
 });
 
-test.failing(
-  `zcfSeat.hasExited, kickOut from zcf.makeEmptySeatKit`,
-  async t => {
-    const { zcf } = await setupZCFTest();
-    const { zcfSeat, userSeat } = zcf.makeEmptySeatKit();
-    t.falsy(zcfSeat.hasExited());
-    const msg = `this is the error message`;
-    const err = zcfSeat.kickOut(Error(msg));
-    t.is(err.message, msg);
-    t.truthy(zcfSeat.hasExited());
-    // TODO: remove `failing` after fixing https://github.com/Agoric/agoric-sdk/issues/1729
-    t.truthy(await E(userSeat).hasExited());
-    t.deepEqual(await E(userSeat).getPayouts(), {});
-  },
-);
+test(`zcfSeat.hasExited, kickOut from zcf.makeEmptySeatKit`, async t => {
+  const { zcf } = await setupZCFTest();
+  const { zcfSeat, userSeat } = zcf.makeEmptySeatKit();
+  t.falsy(zcfSeat.hasExited());
+  const msg = `this is the error message`;
+  const err = zcfSeat.kickOut(Error(msg));
+  t.is(err.message, msg);
+  t.truthy(zcfSeat.hasExited());
+  t.truthy(await E(userSeat).hasExited());
+  t.deepEqual(await E(userSeat).getPayouts(), {});
+});
 
 test(`zcfSeat.isOfferSafe from zcf.makeEmptySeatKit`, async t => {
   const { zcf } = await setupZCFTest();


### PR DESCRIPTION
zoeHelper tests were skipped. This updates the tests for `trade()` and `satisfies()`, and drops some tests for dropped helpers.

Also fixes `hasExited()`, which had the wrong valence.

see: #1652
