### PR TITLE
Support jigs for synchronous testing of `zcf` and contract internals

### DIFF
--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -233,8 +233,17 @@ export function buildRootObject(testContext) {
       return zcfMint;
     };
 
-    /** @type SetTestJig */
-    const setTestJig = testFn => {
+    /**
+     * Provide a callback whose return result will be made available
+     * to the test that started this contract. The supplied callback
+     * will only be called in a testing context, never in production.
+     * 
+     * Additionally, when the callback is invoked, the zcf will be 
+     * made available as well.
+     * 
+     * @type SetTestJig 
+     */
+    const setTestJig = (testFn = () => { }) => {
       if (testContext) {
         console.warn("TEST ONLY: capturing test data", testFn);
         testContext.zcf = zcf;

--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -30,7 +30,8 @@ import { makeHandle } from '../makeHandle';
 import '../../exported';
 import '../internal-types';
 
-export function buildRootObject() {
+// TODO the `testContext` might need to be a later argument
+export function buildRootObject(testContext) {
   /** @type ExecuteContract */
   const executeContract = async (
     bundle,
@@ -232,6 +233,15 @@ export function buildRootObject() {
       return zcfMint;
     };
 
+    /** @type TestOnly */
+    const testOnly = testFn => {
+      if (testContext) {
+        console.warn("TEST ONLY: capturing test data", testFn);
+        testContext.zcf = zcf;
+        testContext.data = testFn();
+      }
+    }
+
     /** @type ContractFacet */
     const zcf = {
       reallocate: (/** @type SeatStaging[] */ ...seatStagings) => {
@@ -350,6 +360,7 @@ export function buildRootObject() {
       getBrandForIssuer: issuer => issuerTable.getByIssuer(issuer).brand,
       getIssuerForBrand: brand => issuerTable.getByBrand(brand).issuer,
       getAmountMath,
+      testOnly,
     };
     harden(zcf);
 

--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -233,21 +233,25 @@ export function buildRootObject(_vatPowers, _vatParameters, testJigSetter = unde
     };
 
     /**
-     * Provide a callback whose return result will be made available
-     * to the test that started this contract. The supplied callback
-     * will only be called in a testing context, never in production.
+     * Provide a jig object for testing purposes only.
      * 
-     * The callback is only called if `testJigSetter` was supplied. 
-     * If this operation is called without a `testFn`, the `testJigSetter` 
-     * will be called with object with the `zcf` property set to the
-     * current ContractFacet.
+     * The contract code provides a callback whose return result will 
+     * be made available to the test that started this contract. The 
+     * supplied callback will only be called in a testing context, 
+     * never in production; i.e., it is only called if `testJigSetter`
+     * was supplied. 
+     * 
+     * If no, \testFn\ is supplied, then an empty jig will be used.
+     * An additional `zcf` property set to the current ContractFacet
+     * will be appended to the returned jig object (overriding any 
+     * provided by the `testFn`).
      * 
      * @type SetTestJig 
      */
-    const setTestJig = (testFn = undefined) => {
+    const setTestJig = (testFn = () => ({})) => {
       if (testJigSetter) {
-        console.warn('TEST ONLY: capturing test data', testFn || 'zcf');
-        testJigSetter(testFn ? testFn() : { zcf });
+        console.warn('TEST ONLY: capturing test data', testFn);
+        testJigSetter({ ...testFn(), zcf });
       }
     }
 

--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -30,7 +30,7 @@ import { makeHandle } from '../makeHandle';
 import '../../exported';
 import '../internal-types';
 
-export function buildRootObject(_vatPowers, _vatParameters, testJigSetter = undefined) {
+export function buildRootObject(_powers, _params, testJigSetter = undefined) {
   /** @type ExecuteContract */
   const executeContract = async (
     bundle,
@@ -232,29 +232,6 @@ export function buildRootObject(_vatPowers, _vatParameters, testJigSetter = unde
       return zcfMint;
     };
 
-    /**
-     * Provide a jig object for testing purposes only.
-     * 
-     * The contract code provides a callback whose return result will 
-     * be made available to the test that started this contract. The 
-     * supplied callback will only be called in a testing context, 
-     * never in production; i.e., it is only called if `testJigSetter`
-     * was supplied. 
-     * 
-     * If no, \testFn\ is supplied, then an empty jig will be used.
-     * An additional `zcf` property set to the current ContractFacet
-     * will be appended to the returned jig object (overriding any 
-     * provided by the `testFn`).
-     * 
-     * @type SetTestJig 
-     */
-    const setTestJig = (testFn = () => ({})) => {
-      if (testJigSetter) {
-        console.warn('TEST ONLY: capturing test data', testFn);
-        testJigSetter({ ...testFn(), zcf });
-      }
-    }
-
     /** @type ContractFacet */
     const zcf = {
       reallocate: (/** @type SeatStaging[] */ ...seatStagings) => {
@@ -329,10 +306,10 @@ export function buildRootObject(_vatPowers, _vatParameters, testJigSetter = unde
         /** @type {PromiseRecord<ZoeSeatAdmin>} */
         const zoeSeatAdminPromiseKit = makePromiseKit();
         // Don't trigger Node.js's UnhandledPromiseRejectionWarning
-        zoeSeatAdminPromiseKit.promise.catch(_ => { });
+        zoeSeatAdminPromiseKit.promise.catch(_ => {});
         const userSeatPromiseKit = makePromiseKit();
         // Don't trigger Node.js's UnhandledPromiseRejectionWarning
-        userSeatPromiseKit.promise.catch(_ => { });
+        userSeatPromiseKit.promise.catch(_ => {});
         const seatHandle = makeHandle('SeatHandle');
 
         const seatData = harden({
@@ -373,7 +350,28 @@ export function buildRootObject(_vatPowers, _vatParameters, testJigSetter = unde
       getBrandForIssuer: issuer => issuerTable.getByIssuer(issuer).brand,
       getIssuerForBrand: brand => issuerTable.getByBrand(brand).issuer,
       getAmountMath,
-      setTestJig,
+      /**
+       * Provide a jig object for testing purposes only.
+       *
+       * The contract code provides a callback whose return result will
+       * be made available to the test that started this contract. The
+       * supplied callback will only be called in a testing context,
+       * never in production; i.e., it is only called if `testJigSetter`
+       * was supplied.
+       *
+       * If no, \testFn\ is supplied, then an empty jig will be used.
+       * An additional `zcf` property set to the current ContractFacet
+       * will be appended to the returned jig object (overriding any
+       * provided by the `testFn`).
+       *
+       * @type SetTestJig
+       */
+      setTestJig: (testFn = () => ({})) => {
+        if (testJigSetter) {
+          console.warn('TEST ONLY: capturing test data', testFn);
+          testJigSetter({ ...testFn(), zcf });
+        }
+      },
     };
     harden(zcf);
 
@@ -409,7 +407,7 @@ export function buildRootObject(_vatPowers, _vatParameters, testJigSetter = unde
     // First, evaluate the contract code bundle.
     const contractCode = evalContractBundle(bundle);
     // Don't trigger Node.js's UnhandledPromiseRejectionWarning
-    contractCode.catch(() => { });
+    contractCode.catch(() => {});
 
     // Next, execute the contract code, passing in zcf
     /** @type {Promise<ExecuteContractResult>} */
@@ -423,7 +421,7 @@ export function buildRootObject(_vatPowers, _vatParameters, testJigSetter = unde
           addSeatObj,
         });
       });
-    result.catch(() => { }); // Don't trigger Node.js's UnhandledPromiseRejectionWarning
+    result.catch(() => {}); // Don't trigger Node.js's UnhandledPromiseRejectionWarning
     return result;
   };
 

--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -233,8 +233,8 @@ export function buildRootObject(testContext) {
       return zcfMint;
     };
 
-    /** @type TestOnly */
-    const testOnly = testFn => {
+    /** @type SetTestJig */
+    const setTestJig = testFn => {
       if (testContext) {
         console.warn("TEST ONLY: capturing test data", testFn);
         testContext.zcf = zcf;
@@ -360,7 +360,7 @@ export function buildRootObject(testContext) {
       getBrandForIssuer: issuer => issuerTable.getByIssuer(issuer).brand,
       getIssuerForBrand: brand => issuerTable.getByBrand(brand).issuer,
       getAmountMath,
-      testOnly,
+      setTestJig,
     };
     harden(zcf);
 

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -27,7 +27,7 @@
  * @property {GetAmountMath} getAmountMath
  * @property {MakeZCFMint} makeZCFMint
  * @property {<Deadline>(exit?: ExitRule<Deadline>) => ZcfSeatKit} makeEmptySeatKit
- * @property {TestOnly} testOnly
+ * @property {SetTestJig} setTestJig
  */
 
 /**
@@ -101,7 +101,7 @@
  */
 
 /**
- * @callback TestOnly
+ * @callback SetTestJig
  * @param {() => any} testFn
  * @returns {undefined}
  */

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -27,6 +27,7 @@
  * @property {GetAmountMath} getAmountMath
  * @property {MakeZCFMint} makeZCFMint
  * @property {<Deadline>(exit?: ExitRule<Deadline>) => ZcfSeatKit} makeEmptySeatKit
+ * @property {TestOnly} testOnly
  */
 
 /**
@@ -97,6 +98,12 @@
  * @param {Keyword} keyword
  * @param {AmountMathKind=} amountMathKind
  * @returns {Promise<ZCFMint>}
+ */
+
+/**
+ * @callback TestOnly
+ * @param {() => any} testFn
+ * @returns {undefined}
  */
 
 /**

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -102,7 +102,7 @@
 
 /**
  * @callback SetTestJig
- * @param {() => any} testFn
+ * @param {() => any=() => {}} testFn
  * @returns {void}
  */
 

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -103,7 +103,7 @@
 /**
  * @callback SetTestJig
  * @param {() => any} testFn
- * @returns {undefined}
+ * @returns {void}
  */
 
 /**

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -1,13 +1,13 @@
 // @ts-check
+import '../../exported';
 
 import { assert, details } from '@agoric/assert';
 import { sameStructure } from '@agoric/same-structure';
+import { E } from '@agoric/eventual-send';
 
 import { MathKind } from '@agoric/ertp';
 import { satisfiesWant } from '../contractFacet/offerSafety';
 import { objectMap } from '../objArrayConversion';
-
-import '../../exported';
 
 export const defaultAcceptanceMsg = `The offer has been accepted. Once the contract has been completed, please check your payout`;
 
@@ -255,3 +255,45 @@ export const assertUsesNatMath = (zcf, brand) => {
     details`issuer must use NAT amountMath`,
   );
 };
+
+/**
+ * Escrow payments with Zoe and reallocate the amount of the
+ * payment to a seat. The `amounts` and `payments` records 
+ * must have corresponding keywords.
+ * 
+ * @param {ContractFacet} zcf
+ * @param {ZCFSeat} recipientSeat
+ * @param {AmountKeywordRecord} amounts
+ * @param {PaymentKeywordRecord} payments
+ * @returns {Promise<undefined>}
+ */
+export async function escrowAllTo(zcf, recipientSeat, amounts, payments) {
+  assert(!recipientSeat.hasExited(), "An active seat is required");
+
+  // We will create a temporary offer to be able to escrow our payment
+  // with Zoe.
+  function onReceipt(seat) {
+    // When the assets arrive, move them onto the target seat and 
+    // exit. Note that this happens synchronously before the 
+    // the offerResult resolves.
+    trade(zcf,
+      { seat, gains: {} },
+      {
+        seat: recipientSeat,
+        gains: amounts,
+      },
+    );
+    seat.exit();
+  }
+  const invitation = zcf.makeInvitation(onReceipt, 'escrowAllTo landing place');
+  const proposal = harden({ give: amounts });
+  harden(payments);
+  // To escrow the payment, we must get the Zoe Service facet and
+  // make an offer
+  const zoe = zcf.getZoeService();
+  const tempSeat = E(zoe).offer(invitation, proposal, payments);
+  // We aren't expecting anything back, so just return the outcome
+  // so the caller can wait till this completes. It will only
+  // fulfill after the assets have been moved onto thte `recipientSeat`
+  return E(tempSeat).getOfferResult();
+}

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -1,13 +1,13 @@
 // @ts-check
-import '../../exported';
 
 import { assert, details } from '@agoric/assert';
 import { sameStructure } from '@agoric/same-structure';
-import { E } from '@agoric/eventual-send';
 
 import { MathKind } from '@agoric/ertp';
 import { satisfiesWant } from '../contractFacet/offerSafety';
 import { objectMap } from '../objArrayConversion';
+
+import '../../exported';
 
 export const defaultAcceptanceMsg = `The offer has been accepted. Once the contract has been completed, please check your payout`;
 
@@ -255,45 +255,3 @@ export const assertUsesNatMath = (zcf, brand) => {
     details`issuer must use NAT amountMath`,
   );
 };
-
-/**
- * Escrow payments with Zoe and reallocate the amount of the
- * payment to a seat. The `amounts` and `payments` records 
- * must have corresponding keywords.
- * 
- * @param {ContractFacet} zcf
- * @param {ZCFSeat} recipientSeat
- * @param {AmountKeywordRecord} amounts
- * @param {PaymentKeywordRecord} payments
- * @returns {Promise<undefined>}
- */
-export async function escrowAllTo(zcf, recipientSeat, amounts, payments) {
-  assert(!recipientSeat.hasExited(), "An active seat is required");
-
-  // We will create a temporary offer to be able to escrow our payment
-  // with Zoe.
-  function onReceipt(seat) {
-    // When the assets arrive, move them onto the target seat and 
-    // exit. Note that this happens synchronously before the 
-    // the offerResult resolves.
-    trade(zcf,
-      { seat, gains: {} },
-      {
-        seat: recipientSeat,
-        gains: amounts,
-      },
-    );
-    seat.exit();
-  }
-  const invitation = zcf.makeInvitation(onReceipt, 'escrowAllTo landing place');
-  const proposal = harden({ give: amounts });
-  harden(payments);
-  // To escrow the payment, we must get the Zoe Service facet and
-  // make an offer
-  const zoe = zcf.getZoeService();
-  const tempSeat = E(zoe).offer(invitation, proposal, payments);
-  // We aren't expecting anything back, so just return the outcome
-  // so the caller can wait till this completes. It will only
-  // fulfill after the assets have been moved onto thte `recipientSeat`
-  return E(tempSeat).getOfferResult();
-}

--- a/packages/zoe/test/unitTests/contracts/fakeVatAdmin.js
+++ b/packages/zoe/test/unitTests/contracts/fakeVatAdmin.js
@@ -3,9 +3,12 @@ import { makePromiseKit } from '@agoric/promise-kit';
 
 import { evalContractBundle } from '../../../src/contractFacet/evalContractCode';
 
-export const testContext = {};
+// This is explicitly intended to be mutable so that 
+// test-only state can be provided from contracts
+// to their tests.
+const testContext = {};
 
-export default harden({
+const fakeVatAdmin = harden({
   createVat: bundle => {
     return harden({
       root: E(evalContractBundle(bundle)).buildRootObject(testContext),
@@ -25,3 +28,6 @@ export default harden({
     throw Error(`createVatByName not supported in fake mode`);
   },
 });
+
+export default fakeVatAdmin;
+export { fakeVatAdmin, testContext };

--- a/packages/zoe/test/unitTests/contracts/fakeVatAdmin.js
+++ b/packages/zoe/test/unitTests/contracts/fakeVatAdmin.js
@@ -3,14 +3,15 @@ import { makePromiseKit } from '@agoric/promise-kit';
 
 import { evalContractBundle } from '../../../src/contractFacet/evalContractCode';
 
-function makeFakeVatAdmin(testContext = undefined, makeFar = x => x) {
+function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
   // This is explicitly intended to be mutable so that 
   // test-only state can be provided from contracts
   // to their tests.
   const admin = harden({
     createVat: bundle => {
       return harden({
-        root: makeFar(E(evalContractBundle(bundle)).buildRootObject(testContext)),
+        root: makeRemote(E(evalContractBundle(bundle))
+          .buildRootObject(undefined, undefined, testContextSetter)),
         adminNode: {
           done: () => {
             const kit = makePromiseKit();

--- a/packages/zoe/test/unitTests/contracts/fakeVatAdmin.js
+++ b/packages/zoe/test/unitTests/contracts/fakeVatAdmin.js
@@ -4,23 +4,28 @@ import { makePromiseKit } from '@agoric/promise-kit';
 import { evalContractBundle } from '../../../src/contractFacet/evalContractCode';
 
 function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
-  // This is explicitly intended to be mutable so that 
+  // This is explicitly intended to be mutable so that
   // test-only state can be provided from contracts
   // to their tests.
   const admin = harden({
     createVat: bundle => {
       return harden({
-        root: makeRemote(E(evalContractBundle(bundle))
-          .buildRootObject(undefined, undefined, testContextSetter)),
+        root: makeRemote(
+          E(evalContractBundle(bundle)).buildRootObject(
+            undefined,
+            undefined,
+            testContextSetter,
+          ),
+        ),
         adminNode: {
           done: () => {
             const kit = makePromiseKit();
             // Don't trigger Node.js's UnhandledPromiseRejectionWarning
-            kit.promise.catch(_ => { });
+            kit.promise.catch(_ => {});
             return kit.promise;
           },
-          terminate: () => { },
-          adminData: () => ({}),
+          terminate: () => {},
+          adminData: () => {},
         },
       });
     },

--- a/packages/zoe/test/unitTests/contracts/fakeVatAdmin.js
+++ b/packages/zoe/test/unitTests/contracts/fakeVatAdmin.js
@@ -3,31 +3,34 @@ import { makePromiseKit } from '@agoric/promise-kit';
 
 import { evalContractBundle } from '../../../src/contractFacet/evalContractCode';
 
-// This is explicitly intended to be mutable so that 
-// test-only state can be provided from contracts
-// to their tests.
-const testContext = {};
-
-const fakeVatAdmin = harden({
-  createVat: bundle => {
-    return harden({
-      root: E(evalContractBundle(bundle)).buildRootObject(testContext),
-      adminNode: {
-        done: () => {
-          const kit = makePromiseKit();
-          // Don't trigger Node.js's UnhandledPromiseRejectionWarning
-          kit.promise.catch(_ => {});
-          return kit.promise;
+function makeFakeVatAdmin(testContext = undefined, makeFar = x => x) {
+  // This is explicitly intended to be mutable so that 
+  // test-only state can be provided from contracts
+  // to their tests.
+  const admin = harden({
+    createVat: bundle => {
+      return harden({
+        root: makeFar(E(evalContractBundle(bundle)).buildRootObject(testContext)),
+        adminNode: {
+          done: () => {
+            const kit = makePromiseKit();
+            // Don't trigger Node.js's UnhandledPromiseRejectionWarning
+            kit.promise.catch(_ => { });
+            return kit.promise;
+          },
+          terminate: () => { },
+          adminData: () => ({}),
         },
-        terminate: () => {},
-        adminData: () => ({}),
-      },
-    });
-  },
-  createVatByName: _name => {
-    throw Error(`createVatByName not supported in fake mode`);
-  },
-});
+      });
+    },
+    createVatByName: _name => {
+      throw Error(`createVatByName not supported in fake mode`);
+    },
+  });
+  return admin;
+}
+
+const fakeVatAdmin = makeFakeVatAdmin();
 
 export default fakeVatAdmin;
-export { fakeVatAdmin, testContext };
+export { makeFakeVatAdmin };

--- a/packages/zoe/test/unitTests/contracts/fakeVatAdmin.js
+++ b/packages/zoe/test/unitTests/contracts/fakeVatAdmin.js
@@ -3,10 +3,12 @@ import { makePromiseKit } from '@agoric/promise-kit';
 
 import { evalContractBundle } from '../../../src/contractFacet/evalContractCode';
 
+export const testContext = {};
+
 export default harden({
   createVat: bundle => {
     return harden({
-      root: E(evalContractBundle(bundle)).buildRootObject(),
+      root: E(evalContractBundle(bundle)).buildRootObject(testContext),
       adminNode: {
         done: () => {
           const kit = makePromiseKit();

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -18,7 +18,9 @@ const contractRoot = `${__dirname}/zcfTesterContract`;
 const setupZCFTest = async (issuerKeywordRecord, terms) => {
   /** @type ContractFacet */
   let zcf;
-  const zoe = makeZoe(makeFakeVatAdmin(jig => zcf = jig.zcf));
+  const setZCF = jig => { zcf = jig.zcf; };
+  // The contract provides the `zcf` via `setTestJig` upon `start`.
+  const zoe = makeZoe(makeFakeVatAdmin(setZCF));
   const bundle = await bundleSource(contractRoot);
   const installation = await zoe.install(bundle);
   const { creatorFacet, instance } = await E(zoe).startInstance(
@@ -26,7 +28,6 @@ const setupZCFTest = async (issuerKeywordRecord, terms) => {
     issuerKeywordRecord,
     terms,
   );
-  // This contract gives ZCF as the contractFacet for testing purposes
   return { zoe, zcf, instance, installation, creatorFacet };
 };
 

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -18,7 +18,9 @@ const contractRoot = `${__dirname}/zcfTesterContract`;
 const setupZCFTest = async (issuerKeywordRecord, terms) => {
   /** @type ContractFacet */
   let zcf;
-  const setZCF = jig => { zcf = jig.zcf; };
+  const setZCF = jig => {
+    zcf = jig.zcf;
+  };
   // The contract provides the `zcf` via `setTestJig` upon `start`.
   const zoe = makeZoe(makeFakeVatAdmin(setZCF));
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -10,13 +10,15 @@ import bundleSource from '@agoric/bundle-source';
 // noinspection ES6PreferShortImport
 import { makeZoe } from '../../../src/zoeService/zoe';
 import { setup } from '../setupBasicMints';
-import fakeVatAdmin from '../contracts/fakeVatAdmin';
+import { makeFakeVatAdmin } from '../contracts/fakeVatAdmin';
 import buildManualTimer from '../../../tools/manualTimer';
 
 const contractRoot = `${__dirname}/zcfTesterContract`;
 
 const setupZCFTest = async (issuerKeywordRecord, terms) => {
-  const zoe = makeZoe(fakeVatAdmin);
+  /** @type ContractFacet */
+  let zcf;
+  const zoe = makeZoe(makeFakeVatAdmin(jig => zcf = jig.zcf));
   const bundle = await bundleSource(contractRoot);
   const installation = await zoe.install(bundle);
   const { creatorFacet, instance } = await E(zoe).startInstance(
@@ -25,9 +27,7 @@ const setupZCFTest = async (issuerKeywordRecord, terms) => {
     terms,
   );
   // This contract gives ZCF as the contractFacet for testing purposes
-  /** @type ContractFacet */
-  const zcf = creatorFacet;
-  return { zoe, zcf, instance, installation };
+  return { zoe, zcf, instance, installation, creatorFacet };
 };
 
 // TODO: Still to be tested:

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
@@ -16,7 +16,9 @@ const contractRoot = `${__dirname}/zcfTesterContract`;
 test(`zoe - zcfSeat.kickOut() doesn't throw`, async t => {
   const { moolaIssuer, simoleanIssuer } = setup();
   let testJig;
-  const setJig = jig => { testJig = jig; };
+  const setJig = jig => {
+    testJig = jig;
+  };
   const zoe = makeZoe(makeFakeVatAdmin(setJig));
 
   // pack the contract
@@ -30,6 +32,7 @@ test(`zoe - zcfSeat.kickOut() doesn't throw`, async t => {
     Money: simoleanIssuer,
   });
 
+  // eslint-disable-next-line no-unused-vars
   const { creatorFacet } = await E(zoe).startInstance(
     installation,
     issuerKeywordRecord,

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
@@ -9,13 +9,14 @@ import bundleSource from '@agoric/bundle-source';
 // noinspection ES6PreferShortImport
 import { makeZoe } from '../../../src/zoeService/zoe';
 import { setup } from '../setupBasicMints';
-import { fakeVatAdmin, testContext } from './fakeVatAdmin';
+import { makeFakeVatAdmin } from '../contracts/fakeVatAdmin';
 
 const contractRoot = `${__dirname}/zcfTesterContract`;
 
 test(`zoe - zcfSeat.kickOut() doesn't throw`, async t => {
   const { moolaIssuer, simoleanIssuer } = setup();
-  const zoe = makeZoe(fakeVatAdmin);
+  const testContext = {};
+  const zoe = makeZoe(makeFakeVatAdmin(testContext));
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
@@ -33,7 +33,8 @@ test(`zoe - zcfSeat.kickOut() doesn't throw`, async t => {
     issuerKeywordRecord,
   );
 
-  // This contract gives ZCF as the contractFacet for testing purposes
+  // The contract uses the tstJig so the contractFacet 
+  // is available here for testing purposes
   /** @type ContractFacet */
   const zcf = testContext.zcf;
 

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
@@ -15,8 +15,8 @@ const contractRoot = `${__dirname}/zcfTesterContract`;
 
 test(`zoe - zcfSeat.kickOut() doesn't throw`, async t => {
   const { moolaIssuer, simoleanIssuer } = setup();
-  const testContext = {};
-  const zoe = makeZoe(makeFakeVatAdmin(testContext));
+  let testJig;
+  const zoe = makeZoe(makeFakeVatAdmin(jig => testJig = jig));
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);
@@ -37,7 +37,7 @@ test(`zoe - zcfSeat.kickOut() doesn't throw`, async t => {
   // The contract uses the tstJig so the contractFacet 
   // is available here for testing purposes
   /** @type ContractFacet */
-  const zcf = testContext.zcf;
+  const zcf = testJig.zcf;
 
   let firstSeat;
 

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
@@ -16,7 +16,8 @@ const contractRoot = `${__dirname}/zcfTesterContract`;
 test(`zoe - zcfSeat.kickOut() doesn't throw`, async t => {
   const { moolaIssuer, simoleanIssuer } = setup();
   let testJig;
-  const zoe = makeZoe(makeFakeVatAdmin(jig => testJig = jig));
+  const setJig = jig => { testJig = jig; };
+  const zoe = makeZoe(makeFakeVatAdmin(setJig));
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);
@@ -34,7 +35,7 @@ test(`zoe - zcfSeat.kickOut() doesn't throw`, async t => {
     issuerKeywordRecord,
   );
 
-  // The contract uses the tstJig so the contractFacet 
+  // The contract uses the testJig so the contractFacet
   // is available here for testing purposes
   /** @type ContractFacet */
   const zcf = testJig.zcf;

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
@@ -9,7 +9,7 @@ import bundleSource from '@agoric/bundle-source';
 // noinspection ES6PreferShortImport
 import { makeZoe } from '../../../src/zoeService/zoe';
 import { setup } from '../setupBasicMints';
-import fakeVatAdmin from '../contracts/fakeVatAdmin';
+import { fakeVatAdmin, testContext } from './fakeVatAdmin';
 
 const contractRoot = `${__dirname}/zcfTesterContract`;
 
@@ -35,7 +35,7 @@ test(`zoe - zcfSeat.kickOut() doesn't throw`, async t => {
 
   // This contract gives ZCF as the contractFacet for testing purposes
   /** @type ContractFacet */
-  const zcf = creatorFacet;
+  const zcf = testContext.zcf;
 
   let firstSeat;
 

--- a/packages/zoe/test/unitTests/zcf/zcfTesterContract.js
+++ b/packages/zoe/test/unitTests/zcf/zcfTesterContract.js
@@ -7,7 +7,8 @@ import '../../../exported';
  * @type {ContractStartFn}
  */
 const start = zcf => {
-  zcf.setTestJig(() => ({ zcf }));
+  // make the `zcf` available to the tests
+  zcf.setTestJig(() => {});
   return { };
 };
 

--- a/packages/zoe/test/unitTests/zcf/zcfTesterContract.js
+++ b/packages/zoe/test/unitTests/zcf/zcfTesterContract.js
@@ -7,7 +7,8 @@ import '../../../exported';
  * @type {ContractStartFn}
  */
 const start = zcf => {
-  return { creatorFacet: zcf };
+  zcf.setTestJig(() => ({ zcf }));
+  return { };
 };
 
 harden(start);

--- a/packages/zoe/test/unitTests/zcf/zcfTesterContract.js
+++ b/packages/zoe/test/unitTests/zcf/zcfTesterContract.js
@@ -9,7 +9,7 @@ import '../../../exported';
 const start = zcf => {
   // make the `zcf` available to the tests
   zcf.setTestJig();
-  return { };
+  return {};
 };
 
 harden(start);

--- a/packages/zoe/test/unitTests/zcf/zcfTesterContract.js
+++ b/packages/zoe/test/unitTests/zcf/zcfTesterContract.js
@@ -8,7 +8,7 @@ import '../../../exported';
  */
 const start = zcf => {
   // make the `zcf` available to the tests
-  zcf.setTestJig(() => {});
+  zcf.setTestJig();
   return { };
 };
 


### PR DESCRIPTION
Close: #1727
Refs: #1668

Implement the "test jig" design that uses a function to pass the test jig from the contract to the tests. Add it to the ZCF and zoe helper tests.