### PR TITLE
WIP Support sub-contract components by virtualizing zcf

### DIFF
--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -182,7 +182,7 @@
  *
  * If the payment is a promise, the operation will proceed upon resolution.
  *
- * @property {(paymentsArray: PaymentP[]) => Promise<Payment>} combine
+ * @property {(paymentsArray: PaymentP[]) => PaymentP} combine
  * Combine multiple payments into one payment.
  *
  * If any of the payments is a promise, the operation will proceed upon

--- a/packages/zoe/docs/seats.md
+++ b/packages/zoe/docs/seats.md
@@ -15,7 +15,7 @@ __ZCF.reallocate() Flow__
 ![ZCF Reallocate Flow](./zcf-reallocate-flow.png)
 
 
-## UserSeat 
+## UserSeat
 
 The `UserSeat` is what is returned when a user calls
 `E(zoe).offer(invitation, proposal, payments)`. It has the following
@@ -27,7 +27,7 @@ type:
  * @property {() => Promise<Allocation>} getCurrentAllocation
  * @property {() => Promise<ProposalRecord>} getProposal
  * @property {() => Promise<PaymentPKeywordRecord>} getPayouts
- * @property {(keyword: Keyword) => Promise<Payment>} getPayout
+ * @property {(keyword: Keyword) => PaymentP} getPayout
  * @property {() => Promise<OfferResult>} getOfferResult
  * @property {() => void=} exit
  */
@@ -91,7 +91,7 @@ The type of the `ZoeSeatAdmin` is:
 
 ## ZCFSeatAdmin
 
-Internal to ZCF code only. 
+Internal to ZCF code only.
 
 The `ZCFSeatAdmin` is used by `reallocate` within ZCF to commit the
 allocation from a `seatStaging` to the corresponding `ZCFSeat`, and

--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -356,7 +356,7 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
 
         const invitationHandle = /** @type {InvitationHandle} */ (harden({}));
         invitationHandleToHandler.init(invitationHandle, offerHandler);
-        /** @type {Promise<Payment>} */
+        /** @type {PaymentP} */
         const invitationP = E(zoeInstanceAdmin).makeInvitation(
           invitationHandle,
           description,
@@ -386,6 +386,11 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
       stopAcceptingOffers: () => E(zoeInstanceAdmin).stopAcceptingOffers(),
       makeZCFMint,
       makeEmptySeatKit,
+
+      makeSeatKit: (_offerHandler, _proposal, _paymentStaging) => {
+        // TODO implement
+        assert.fail(details`makeSeatKit is not yet implemented`);
+      },
 
       // The methods below are pure and have no side-effects //
       getZoeService: () => zoeService,

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -42,6 +42,28 @@
  */
 
 /**
+ * @callback MakeSeatKit
+ *
+ * The zcf `makeSeatKit` method is a synchronous blend of functionality from
+ * the zcf `makeInvitation` and the zoe `offer`. Like the `offer`, it takes a
+ * `proposal` to be associated with the new seat. In place of the
+ * `paymentKeywordRecord` it takes a `paymentStaging`. It does a reallocate
+ * with the `paymentStaging` and a new seatStaging made from the new seat
+ * and the `proposal.give`, giving the new seat an initial allocation
+ * satisfying its `give`, just like a successful offer would.
+ *
+ * If this reallocate succeeds, eventually calls the `offerHandler` with the new
+ * zcfSeat and immediately returns the new seatKit. The eventual call of the
+ * `offerHandler` is the only asynchony. Everything else happens during the
+ * call to `makeSeatKit`.
+ *
+ * @param {OfferHandler} offerHandler
+ * @param {Proposal=} proposal
+ * @param {SeatStaging} paymentStaging
+ * @returns {UserSeat} seat
+ */
+
+/**
  * @callback Reallocate
  *
  * The contract can reallocate over seatStagings, which are
@@ -190,6 +212,6 @@
 /**
  * @typedef {Object} ContractStartFnResult
  * @property {Object=} creatorFacet
- * @property {Promise<Invitation>=} creatorInvitation
+ * @property {ERef<Invitation>=} creatorInvitation
  * @property {Object=} publicFacet
  */

--- a/packages/zoe/src/contractSupport/index.js
+++ b/packages/zoe/src/contractSupport/index.js
@@ -28,3 +28,5 @@ export {
   saveAllIssuers,
   offerTo,
 } from './zoeHelpers';
+
+export { subContract } from './sub-contract';

--- a/packages/zoe/src/contractSupport/sub-contract.js
+++ b/packages/zoe/src/contractSupport/sub-contract.js
@@ -1,0 +1,232 @@
+import { assert, details } from '@agoric/assert';
+import makeWeakStore from '@agoric/weak-store';
+import '../../exported';
+
+const { entries } = Object;
+
+/**
+ * @typedef {Object} SubContractResult
+ *
+ * Like a `StartInstanceResult` but with an `offerService` rather than an
+ * `instance` facet.
+ *
+ * @property {any} creatorFacet
+ * @property {ERef<Invitation>=} creatorInvitation
+ * @property {any} publicFacet
+ * @property {OfferService} offerService
+ */
+
+/**
+ * @typedef {Object} OfferService
+ *
+ * Like the `ZoeService`, has a method for making an offer. But we call it
+ * `offerNow` instead of `offer` to emphasize its synchronous nature.
+ *
+ * @property {OfferNow} offerNow
+ */
+
+/**
+ * @callback OfferNow
+ *
+ * Like `Offer` but takes a `paymentStaging` instead of a
+ * `paymentKeywordRecord`, does the reallocation and returns a new seatKit
+ * immediately, rather than a promise for a userSeat.
+ *
+ * @param {Invitation} invitation
+ * @param {Proposal=} proposal
+ * @param {SeatStaging} paymentStaging
+ * @returns {ZcfSeatKit} seatKit
+ */
+
+/**
+ * `subContract` is like `ZoeService.startInstance`, but instead of an
+ * installation, `subContract` takes a `startFn` and a `descriptionPrefix`.
+ * The `startFn` is exactly the form of `start` function exported by a contract
+ * module.
+ *
+ * `subContract` calls `startFn` with `subZCF`, a virtualization of the `zcf`
+ * passed in. `subZCF` is not intended  a perfect virtualization. It is not
+ * fully compatible with the `startFn` of any possible correct contract. Rather,
+ * `subContract` is written to support the (hopefully) typical simple contracts
+ * that work either standalone or as subContract components. To write such
+ * contracts, be aware of the differences documented below.
+ *
+ * Some of the differences are opportunities --- enabling the subContract
+ * component to collaborate with its parent, or with other local subContract
+ * components, in ways that separate contracts cannot interact with each other.
+ * For example, the virtualization mechanism is unaware of which seat came from
+ * which component. They are just all seats to the underlying zcf they all
+ * share. Thus, any component can do an atomic reallocate across any seats it
+ * has access to. But for any seat it does not create it only has access if it
+ * is explicitly granted access. The zcf API does not itself leak access to
+ * seats, so the subZCF API naturally does not as well. This difference in
+ * `reallocate` behavior is pure opportunity without virtualization flaw.
+ *
+ * @param {ContractFacet} zcf
+ * @param {ContractStartFn} startFn
+ * @param {string} prefix
+ * @param {IssuerKeywordRecord=} issuerKeywordRecord is merged into the
+ *   parent's contract-level keyword namespace with `prefix.` prepended to
+ *   each keyword. The full parent keyword namespace is exposed by subZCF to the
+ *   subContract. The prefixing is only to avoid accidental collisions, but
+ *   this should be fine for most contracts.
+ * @param {Object=} customTerms
+ * @returns {SubContractResult} immediately, rather than a
+ * `Promise<StartInstanceResult>`.
+ */
+const subContract = async (
+  zcf,
+  startFn,
+  prefix,
+  issuerKeywordRecord = undefined,
+  customTerms = undefined,
+) => {
+  const baseKeyword = keyword => `${prefix}.${keyword}`;
+  await Promise.all(
+    entries(issuerKeywordRecord).map(([keyword, issuerP]) =>
+      zcf.saveIssuer(issuerP, baseKeyword(keyword)),
+    ),
+  );
+
+  /**
+   * @callback Offerer
+   *
+   * Like `Offer` without the initial invitation, and with
+   * a `paymentStaging` instead of a `paymentKeywordRecord`.
+   * Like `MakeSeatKit` without the initial `offerHandler`.
+   *
+   * @param {Proposal=} proposal
+   * @param {SeatStaging} paymentStaging
+   * @returns {ZcfSeatKit} seatKit
+   */
+
+  /** @type {WeakMap<Invitation,Offerer>} */
+  const offerers = makeWeakStore('invitation');
+
+  /** @type {OfferService} */
+  const offerService = harden({
+    offerNow: (invitation, proposal, paymentStaging) => {
+      if (offerers.has(invitation)) {
+        return offerers.get(invitation)(proposal, paymentStaging);
+      }
+      throw assert.fail(details`offer already made`);
+    },
+  });
+
+  /** @type {MakeInvitation} */
+  const makeInvitation = (offerHandler, description, customProperties) => {
+    let currentOfferHandler = seat => {
+      // eslint-disable-next-line no-use-before-define
+      offerers.delete(invitation);
+      currentOfferHandler = _seat => {
+        assert.fail(details`offer already made`);
+      };
+      return offerHandler(seat);
+    };
+    const offerHandlerWrapper = seat => currentOfferHandler(seat);
+
+    const invitation = zcf.makeInvitation(
+      offerHandlerWrapper,
+      `${prefix}.${description}`,
+      customProperties,
+    );
+    /** @type {Offerer} */
+    const offerer = (proposal, paymentStaging) =>
+      zcf.makeSeatKit(offerHandlerWrapper, proposal, paymentStaging);
+    offerers.init(invitation, offerer);
+    return invitation;
+  };
+
+  /** @type {ContractFacet} */
+  const subZCF = harden({
+    /**
+     * Works on seatStagings independent of which component made them.
+     */
+    reallocate: zcf.reallocate,
+    /**
+     * The prefix is visibly prepended onto the keyword used.
+     */
+    saveIssuer: (issuerP, keyword) =>
+      zcf.saveIssuer(issuerP, baseKeyword(keyword)),
+    /**
+     * Returns an invitation whose `instance` and `installation` visibly
+     * describes only the contract as a whole. However, the actual invitation's
+     * `description` will be this description prepended with `prefix`, which
+     * should be adequate disambiguation for most uses.
+     *
+     * For seats that are only intended for purposeful local use only among
+     * co-located components, `makeSeatKit` is likely to be a better choice than
+     * `makeInvitation`. However, regular contract code used as a subContract
+     * component will still call `makeInvitation` and return an invitation. To
+     * accommodate such code, `subContract` returns an `offerService` instead of
+     * an `instance`, where the offerService has an `offerNow` method for
+     * immediately making an offer. This path is just a fancy wrapper around
+     * `makeSeatKit`.
+     */
+    makeInvitation,
+    /**
+     * Does a lot less than an actual `shutdown`. Only denies any further
+     * access to the parent `zcf`. But the state of the parent `zcf` is
+     * unaffected.
+     */
+    shutdown: () => {
+      zcf = null;
+    },
+    /**
+     * The prefix is visibly prepended onto the keyword used.
+     */
+    assertUniqueKeyword: keyword =>
+      zcf.assertUniqueKeyword(baseKeyword(keyword)),
+    /** same as parent */
+    getZoeService: zcf.getZoeService,
+    /** same as parent */
+    getInvitationIssuer: zcf.getInvitationIssuer,
+    // Abstraction leaks the merged contract-level keyword namespace
+    getTerms: () => {
+      const { issuers, brands, maths } = zcf.getTerms();
+      return harden({
+        ...customTerms,
+        issuers,
+        brands,
+        maths,
+      });
+    },
+    /**
+     * Works across entire contract, so it is another opportunity without
+     * virtualization flaw.
+     */
+    getBrandForIssuer: zcf.getBrandForIssuer,
+    /**
+     * Works across entire contract, so it is another opportunity without
+     * virtualization flaw.
+     */
+    getIssuerForBrand: zcf.getIssuerForBrand,
+    /**
+     * Works across entire contract, so it is another opportunity without
+     * virtualization flaw.
+     */
+    getAmountMath: zcf.getAmountMath,
+
+    /**
+     * The prefix is visibly prepended onto the keyword used. Otherwise same
+     * as parent. Can be used on any seat within this contract.
+     */
+    makeZCFMint: (keyword, amountMathKind) =>
+      zcf.makeZCFMint(baseKeyword(keyword), amountMathKind),
+    /** same as parent */
+    makeEmptySeatKit: zcf.makeEmptySeatKit,
+    /** same as parent */
+    makeSeatKit: zcf.makeSeatKit,
+    /** same as parent */
+    setTestJig: zcf.setTestJig,
+  });
+  const { creatorFacet, publicFacet, creatorInvitation } = startFn(subZCF);
+  return harden({
+    creatorFacet,
+    publicFacet,
+    creatorInvitation,
+    offerService,
+  });
+};
+harden(subContract);
+export { subContract };

--- a/packages/zoe/src/contracts/exported.js
+++ b/packages/zoe/src/contracts/exported.js
@@ -4,7 +4,7 @@
  * @property {() => Amount} getAvailableItems
  *
  * @typedef {Object} SellItemsCreatorOnly
- * @property {() => Promise<Invitation>} makeBuyerInvitation
+ * @property {() => ERef<Invitation>} makeBuyerInvitation
  *
  * @typedef {SellItemsPublicFacet & SellItemsCreatorOnly} SellItemsCreatorFacet
  */
@@ -30,17 +30,17 @@
 
 /**
  * @typedef {Object} AutoswapPublicFacet
- * @property {() => Promise<Invitation>} makeSwapInvitation synonym for
+ * @property {() => ERef<Invitation>} makeSwapInvitation synonym for
  * makeSwapInInvitation
- * @property {() => Promise<Invitation>} makeSwapInInvitation make an invitation
+ * @property {() => ERef<Invitation>} makeSwapInInvitation make an invitation
  * that allows one to do a swap in which the In amount is specified and the Out
  * amount is calculated
- * @property {() => Promise<Invitation>} makeSwapOutInvitation make an invitation
+ * @property {() => ERef<Invitation>} makeSwapOutInvitation make an invitation
  * that allows one to do a swap in which the Out amount is specified and the In
  * amount is calculated
- * @property {() => Promise<Invitation>} makeAddLiquidityInvitation make an
+ * @property {() => ERef<Invitation>} makeAddLiquidityInvitation make an
  * invitation that allows one to add liquidity to the pool.
- * @property {() => Promise<Invitation>} makeRemoveLiquidityInvitation make an
+ * @property {() => ERef<Invitation>} makeRemoveLiquidityInvitation make an
  * invitation that allows one to remove liquidity from the pool.
  * @property {() => Issuer} getLiquidityIssuer
  * @property {() => number} getLiquiditySupply get the current value of
@@ -77,17 +77,17 @@
  * @typedef {Object} MultipoolAutoswapPublicFacet
  * @property {(issuer: Issuer, keyword: Keyword) => Promise<Issuer>} addPool
  * add a new liquidity pool
- * @property {() => Promise<Invitation>} makeSwapInvitation synonym for
+ * @property {() => ERef<Invitation>} makeSwapInvitation synonym for
  * makeSwapInInvitation
- * @property {() => Promise<Invitation>} makeSwapInInvitation make an invitation
+ * @property {() => ERef<Invitation>} makeSwapInInvitation make an invitation
  * that allows one to do a swap in which the In amount is specified and the Out
  * amount is calculated
- * @property {() => Promise<Invitation>} makeSwapOutInvitation make an invitation
+ * @property {() => ERef<Invitation>} makeSwapOutInvitation make an invitation
  * that allows one to do a swap in which the Out amount is specified and the In
  * amount is calculated
- * @property {() => Promise<Invitation>} makeAddLiquidityInvitation make an
+ * @property {() => ERef<Invitation>} makeAddLiquidityInvitation make an
  * invitation that allows one to add liquidity to the pool.
- * @property {() => Promise<Invitation>} makeRemoveLiquidityInvitation make an
+ * @property {() => ERef<Invitation>} makeRemoveLiquidityInvitation make an
  * invitation that allows one to remove liquidity from the pool.
  * @property {(brand: Brand) => Issuer} getLiquidityIssuer
  * @property {(brand: Brand) => number} getLiquiditySupply get the current value of
@@ -105,11 +105,11 @@
 /**
  * @typedef {Object} AutomaticRefundPublicFacet
  * @property {() => number} getOffersCount
- * @property {() => Promise<Invitation>} makeInvitation
+ * @property {() => ERef<Invitation>} makeInvitation
  */
 /**
  * @typedef {Object} SimpleExchangePublicFacet
- * @property {() => Promise<Invitation>} makeInvitation
+ * @property {() => ERef<Invitation>} makeInvitation
  * @property {() => Notifier<any>} getNotifier
  */
 

--- a/packages/zoe/src/contracts/mintAndSellNFT.js
+++ b/packages/zoe/src/contracts/mintAndSellNFT.js
@@ -80,10 +80,10 @@ const start = zcf => {
     });
     /**
      * @type {Promise<{
-     *   creatorInvitation: Invitation | undefined,
      *   creatorFacet: SellItemsCreatorFacet,
-     *   instance: Instance,
+     *   creatorInvitation?: ERef<Invitation>,
      *   publicFacet: SellItemsPublicFacet,
+     *   instance: Instance,
      * }>}
      */
     const instanceRecordP = E(zoeService).startInstance(

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -166,7 +166,7 @@
  *
  * @typedef {Object} ExecuteContractResult
  * @property {Object} creatorFacet
- * @property {Promise<Invitation>} creatorInvitation
+ * @property {ERef<Invitation>} creatorInvitation
  * @property {Object} publicFacet
  * @property {AddSeatObj} addSeatObj
  *

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -101,7 +101,7 @@
  * @property {() => Promise<Allocation>} getCurrentAllocation
  * @property {() => Promise<ProposalRecord>} getProposal
  * @property {() => Promise<PaymentPKeywordRecord>} getPayouts
- * @property {(keyword: Keyword) => Promise<Payment>} getPayout
+ * @property {(keyword: Keyword) => PaymentP} getPayout
  * @property {() => Promise<OfferResult>} getOfferResult
  * @property {() => void=} tryExit
  * @property {() => Promise<boolean>} hasExited
@@ -121,6 +121,7 @@
 /**
  * @typedef {Object} StartInstanceResult
  * @property {any} creatorFacet
+ * @property {ERef<Invitation>=} creatorInvitation
  * @property {any} publicFacet
  * @property {Instance} instance
  * @property {Payment | undefined} creatorInvitation

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -378,6 +378,7 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
         });
 
         // Actually returned to the user.
+        /** @type {StartInstanceResult} */
         return {
           creatorFacet,
           creatorInvitation,


### PR DESCRIPTION
***Non-urgent*** spike to explore an idea. Simpler synchronous composition of sub-contract components. Virtualization is good enough that most simple contracts can already be used as sub-contracts as is. Explained by extensive comments in the code.

A test case: If we had this earlier, could we have written multi-pool uniswap as a synchronous composition of multiple instances of uniswap?

Original idea from @dtribble . Thanks!