### PR TITLE
chore: cleanup exit type

### DIFF
--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -26,7 +26,7 @@
  * @property {(brand: Brand) => Issuer} getIssuerForBrand
  * @property {GetAmountMath} getAmountMath
  * @property {MakeZCFMint} makeZCFMint
- * @property {<Deadline>(exit?: ExitRule<Deadline>) => ZcfSeatKit} makeEmptySeatKit
+ * @property {(exit?: ExitRule) => ZcfSeatKit} makeEmptySeatKit
  * @property {SetTestJig} setTestJig
  */
 

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -264,7 +264,7 @@ export const swapExact = (
  * @typedef ExpectedRecord
  * @property {Record<Keyword, null>} [want]
  * @property {Record<Keyword, null>} [give]
- * @property {Record<keyof ProposalRecord['exit'], null>} [exit]
+ * @property {Partial<Record<keyof ProposalRecord['exit'], null>>} [exit]
  */
 
 /**

--- a/packages/zoe/src/contracts/otcDesk.js
+++ b/packages/zoe/src/contracts/otcDesk.js
@@ -62,7 +62,7 @@ const start = zcf => {
    *
    * @param {AmountKeywordRecord} price
    * @param {AmountKeywordRecord} assets
-   * @param {Timer<any>} timeAuthority
+   * @param {Timer} timeAuthority
    * @param {any} deadline
    * @returns {Promise<Payment>}
    */

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -125,7 +125,7 @@
  *
  * @typedef {{give: AmountKeywordRecord,
  *            want: AmountKeywordRecord,
- *            exit: ExitRule<any>
+ *            exit: ExitRule
  *           }} ProposalRecord
  */
 
@@ -139,25 +139,23 @@
 /**
  * @typedef {Object} Waker
  * @property {() => void} wake
- *
- * @typedef {{waived:null}} Waived
- * @typedef {{onDemand:null}} OnDemand
  */
 
 /**
- * @template Deadline
+ * @typedef {number} Deadline
+ */
+
+/**
  * @typedef {Object} Timer
  * @property {(deadline: Deadline, wakerP: ERef<Waker>) => void} setWakeup
  */
 
 /**
- * @template Deadline
- * @typedef {{afterDeadline:{timer:Timer<Deadline>, deadline:Deadline}}} AfterDeadline
- */
-
-/**
- * @template Deadline
- * @typedef {Waived | OnDemand | AfterDeadline<Deadline>} ExitRule
+ * @typedef {Object} ExitRule
+ * @property {null} [onDemand]
+ * @property {null} [waived]
+ * @property {{timer:Timer, deadline:Deadline}} [afterDeadline]
+ *
  * The possible keys are 'waived', 'onDemand', and 'afterDeadline'.
  * `timer` and `deadline` only are used for the `afterDeadline` key.
  * The possible records are:

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -152,9 +152,9 @@
 
 /**
  * @typedef {Object} ExitRule
- * @property {null} [onDemand]
- * @property {null} [waived]
- * @property {{timer:Timer, deadline:Deadline}} [afterDeadline]
+ * @property {null=} onDemand
+ * @property {null=} waived
+ * @property {{timer:Timer, deadline:Deadline}=} afterDeadline
  *
  * The possible keys are 'waived', 'onDemand', and 'afterDeadline'.
  * `timer` and `deadline` only are used for the `afterDeadline` key.

--- a/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
@@ -103,7 +103,7 @@ test.skip('ZoeHelpers rejectIfNotProposal', t => {
       proposal: {
         want: { Asset: moola(4) },
         give: { Price: simoleans(16) },
-        exit: { Waived: null },
+        exit: { waived: null },
       },
     });
     mockZCFBuilder.addOffer(offerHandles[5], {
@@ -169,7 +169,7 @@ test.skip('ZoeHelpers rejectIfNotProposal', t => {
           harden({
             want: { Asset: null },
             give: { Price: null },
-            exit: { Waived: null },
+            exit: { waived: null },
           }),
         ),
       /The offer was invalid. Please check your refund./,


### PR DESCRIPTION
From @dtribble:
> This is the best I could do. It shows ExitRule as the type, but tab completion does the right thing.

@erights wanted to parameterize `Deadline`, but this is simpler and more effective for now.
