### PR TITLE
test(cosmic-swingset): prevent flakey test-home

### DIFF
--- a/packages/agoric-cli/lib/open.js
+++ b/packages/agoric-cli/lib/open.js
@@ -5,15 +5,20 @@ import path from 'path';
 
 import { openSwingStore } from '@agoric/swing-store-simple';
 
-// From https://stackoverflow.com/a/43866992/14073862
+// Adapted from https://stackoverflow.com/a/43866992/14073862
 export function generateAccessToken({
-  stringBase = 'base64',
+  stringBase = 'base64url',
   byteLength = 48,
 } = {}) {
   return new Promise((resolve, reject) =>
     crypto.randomBytes(byteLength, (err, buffer) => {
       if (err) {
         reject(err);
+      } else if (stringBase === 'base64url') {
+        // Convert to url-safe base64.
+        const base64 = buffer.toString('base64');
+        const base64url = base64.replace(/\+/g, '-').replace(/\//g, '_');
+        resolve(base64url);
       } else {
         resolve(buffer.toString(stringBase));
       }

--- a/packages/cosmic-swingset/lib/ag-solo/access-token.js
+++ b/packages/cosmic-swingset/lib/ag-solo/access-token.js
@@ -4,15 +4,20 @@ import path from 'path';
 
 import { openSwingStore } from '@agoric/swing-store-simple';
 
-// From https://stackoverflow.com/a/43866992/14073862
+// Adapted from https://stackoverflow.com/a/43866992/14073862
 export function generateAccessToken({
-  stringBase = 'base64',
+  stringBase = 'base64url',
   byteLength = 48,
 } = {}) {
   return new Promise((resolve, reject) =>
     crypto.randomBytes(byteLength, (err, buffer) => {
       if (err) {
         reject(err);
+      } else if (stringBase === 'base64url') {
+        // Convert to url-safe base64.
+        const base64 = buffer.toString('base64');
+        const base64url = base64.replace(/\+/g, '-').replace(/\//g, '_');
+        resolve(base64url);
       } else {
         resolve(buffer.toString(stringBase));
       }

--- a/packages/cosmic-swingset/test/captp-fixture.js
+++ b/packages/cosmic-swingset/test/captp-fixture.js
@@ -9,7 +9,9 @@ const PORT = 7999;
 // Ensure we're all using the same HandledPromise.
 export { E };
 
-export function makeFixture() {
+export async function makeFixture() {
+  const accessToken = await getAccessToken(PORT);
+
   let expectedToExit = false;
   let buf = '';
   const cp = spawn(
@@ -38,8 +40,6 @@ export function makeFixture() {
     process.stdout.write('# connecting');
     async function tryConnect(resolve, reject) {
       process.stdout.write('.');
-
-      const accessToken = await getAccessToken(PORT);
 
       /** @type {() => void} */
       let abortCapTP;

--- a/packages/cosmic-swingset/test/test-home.js
+++ b/packages/cosmic-swingset/test/test-home.js
@@ -8,7 +8,7 @@ import { makeFixture, E } from './captp-fixture';
 let home;
 let teardown;
 test.before('setup', async t => {
-  const { homeP, kill } = makeFixture();
+  const { homeP, kill } = await makeFixture();
   teardown = kill;
   home = await homeP;
   t.truthy('ready');


### PR DESCRIPTION
Access tokens were being generated with `+` in them, which was URL-decoding to space (` `), and not matching.  I implemented [`base64url` encoding](https://tools.ietf.org/html/rfc4648#section-5), which changes `+` to `-` and `/` to `_`.
