### PR TITLE
test: finish testing zcf

### DIFF
--- a/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
@@ -44,7 +44,7 @@ async function setupContract(moolaIssuer, bucksIssuer) {
 
   await E(zoe).startInstance(installation, issuerKeywordRecord);
 
-  /** @type ContractFacet */
+  /** @type {ContractFacet} */
   const zcf = testJig.zcf;
   return { zoe, zcf };
 }

--- a/packages/zoe/test/unitTests/zcf/setupZcfTest.js
+++ b/packages/zoe/test/unitTests/zcf/setupZcfTest.js
@@ -8,7 +8,7 @@ import { makeFakeVatAdmin } from '../contracts/fakeVatAdmin';
 const contractRoot = `${__dirname}/zcfTesterContract`;
 
 export const setupZCFTest = async (issuerKeywordRecord, terms) => {
-  /** @type ContractFacet */
+  /** @type {ContractFacet} */
   let zcf;
   const setZCF = jig => {
     zcf = jig.zcf;


### PR DESCRIPTION
With this PR in, we should have pretty good coverage of all of the ZCF methods, including `zcfSeat` and `userSeat` made with `zcf.makeEmptySeatKit`. 

Closes #1668 