### PR TITLE
fix: add a default offerHandler

### DIFF
--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -281,7 +281,11 @@ export function buildRootObject(_powers, _params, testJigSetter = undefined) {
         // AWAIT ///
         return registerIssuerRecordWithKeyword(keyword, record);
       },
-      makeInvitation: (offerHandler, description, customProperties = {}) => {
+      makeInvitation: (
+        offerHandler = () => {},
+        description,
+        customProperties = {},
+      ) => {
         assert.typeof(
           description,
           'string',

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -80,7 +80,7 @@
  * getting in the `customProperties`. `customProperties` will be
  * placed in the extent of the invitation.
  *
- * @param {OfferHandler} offerHandler - a contract specific function
+ * @param {OfferHandler=} offerHandler - a contract specific function
  * that handles the offer, such as saving it or performing a trade
  * @param {string} description
  * @param {Object=} customProperties

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -248,12 +248,8 @@ test(`zcf.makeInvitation - no offerHandler`, async t => {
   const isLive = await E(invitationIssuer).isLive(invitationP);
   t.truthy(isLive);
   const seat = E(zoe).offer(invitationP);
-
-  // TODO: this should not throw
-  // https://github.com/Agoric/agoric-sdk/issues/1703
-  // const offerResult = await E(seat).getOfferResult();
-  // t.is(offerResult, undefined);
-  await t.throwsAsync(() => E(seat).getOfferResult());
+  const offerResult = await E(seat).getOfferResult();
+  t.is(offerResult, undefined);
 });
 
 test(`zcf.makeInvitation - no-op offerHandler`, async t => {


### PR DESCRIPTION
Add a default offerHandler to `zcf.makeInvitation` such that if one is not provided, an error is not thrown.

Closes #1703 