### PR TITLE
fix: implement getLiquidityIssuer() in multipoolAutoswap pools

### DIFF
--- a/packages/zoe/src/contracts/exported.js
+++ b/packages/zoe/src/contracts/exported.js
@@ -62,6 +62,7 @@
  * @property {(inputValue: Value) => Amount } getSecondaryToCentralOutputPrice
  * @property {(inputValue: Value) => Amount } getCentralToSecondaryOutputPrice
  * @property {() => number} getLiquiditySupply
+ * @property {() => Issuer} getLiquidityIssuer
  * @property {(seat: ZCFSeat) => string} addLiquidity
  * @property {(seat: ZCFSeat) => string} removeLiquidity
  * @property {() => ZCFSeat} getPoolSeat
@@ -88,8 +89,8 @@
  * invitation that allows one to add liquidity to the pool.
  * @property {() => Promise<Invitation>} makeRemoveLiquidityInvitation make an
  * invitation that allows one to remove liquidity from the pool.
- * @property {brand: Brand => Issuer} getLiquidityIssuer
- * @property {brand: Brand => number} getLiquiditySupply get the current value of
+ * @property {(brand: Brand) => Issuer} getLiquidityIssuer
+ * @property {(brand: Brand) => number} getLiquiditySupply get the current value of
  * liquidity in the pool for brand held by investors.
  * @property {(amountIn: Amount, brandOut: Brand) => Amount} getInputPrice
  * calculate the amount of brandOut that will be returned if the amountIn is
@@ -97,7 +98,7 @@
  * @property {(amountOut: Amount, brandIn: Brand) => Amount} getOutputPrice
  * calculate the amount of brandIn that is required in order to get amountOut
  * using makeSwapOutInvitation at the current price
- * @property {brand: Brand => Record<string, Amount>} getPoolAllocation get an
+ * @property {(brand: Brand) => Record<string, Amount>} getPoolAllocation get an
  * AmountKeywordRecord showing the current balances in the pool for brand.
  */
 

--- a/packages/zoe/src/contracts/exported.js
+++ b/packages/zoe/src/contracts/exported.js
@@ -88,17 +88,17 @@
  * invitation that allows one to add liquidity to the pool.
  * @property {() => Promise<Invitation>} makeRemoveLiquidityInvitation make an
  * invitation that allows one to remove liquidity from the pool.
- * @property {() => Issuer} getLiquidityIssuer
- * @property {() => number} getLiquiditySupply get the current value of
- * liquidity held by investors.
+ * @property {brand: Brand => Issuer} getLiquidityIssuer
+ * @property {brand: Brand => number} getLiquiditySupply get the current value of
+ * liquidity in the pool for brand held by investors.
  * @property {(amountIn: Amount, brandOut: Brand) => Amount} getInputPrice
  * calculate the amount of brandOut that will be returned if the amountIn is
  * offered using makeSwapInInvitation at the current price.
  * @property {(amountOut: Amount, brandIn: Brand) => Amount} getOutputPrice
  * calculate the amount of brandIn that is required in order to get amountOut
  * using makeSwapOutInvitation at the current price
- * @property {() => Record<string, Amount>} getPoolAllocation get an
- * AmountKeywordRecord showing the current balances in the pool.
+ * @property {brand: Brand => Record<string, Amount>} getPoolAllocation get an
+ * AmountKeywordRecord showing the current balances in the pool for brand.
  */
 
 /**

--- a/packages/zoe/src/contracts/multipoolAutoswap/multipoolAutoswap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/multipoolAutoswap.js
@@ -61,6 +61,7 @@ const start = zcf => {
   assertIssuerKeywords(zcf, ['Central']);
   assert(centralBrand !== undefined, details`centralBrand must be present`);
 
+  /** @type {WeakStore<Brand,Pool>} */
   const secondaryBrandToPool = makeWeakStore();
   const getPool = secondaryBrandToPool.get;
   const initPool = secondaryBrandToPool.init;

--- a/packages/zoe/src/contracts/multipoolAutoswap/pool.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/pool.js
@@ -27,6 +27,7 @@ export const makeAddPool = (zcf, isSecondary, initPool, centralBrand) => {
     const {
       brand: liquidityBrand,
       amountMath: liquidityAmountMath,
+      issuer: liquidityIssuer,
     } = liquidityZcfMint.getIssuerRecord();
 
     const addLiquidityActual = (pool, userSeat, secondaryAmount) => {
@@ -67,6 +68,7 @@ export const makeAddPool = (zcf, isSecondary, initPool, centralBrand) => {
     /** @type {Pool} */
     const pool = {
       getLiquiditySupply: () => liqTokenSupply,
+      getLiquidityIssuer: () => liquidityIssuer,
       getPoolSeat: () => poolSeat,
       getAmountMath: () => zcf.getAmountMath(secondaryBrand),
       getCentralAmountMath: () => zcf.getAmountMath(centralBrand),

--- a/packages/zoe/test/autoswapJig.js
+++ b/packages/zoe/test/autoswapJig.js
@@ -317,6 +317,7 @@ export const makeTrader = async (purses, zoe, publicFacet, centralIssuer) => {
       t.is(lAmount.value, lPost, 'liquidity scales (init)');
       t.is(cAmount.value, cPost);
       t.is(sAmount.value, sPost);
+      return { central: cPayout, secondary: sPayout, liquidity: lPayout };
     },
   });
   return trader;

--- a/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
@@ -651,6 +651,51 @@ test('multipoolAutoSwap jig - liquidity', async t => {
     { message: 'insufficient Secondary deposited' },
     `insufficient secondary is unsuccessful`,
   );
+
+  // alice checks the liquidity levels
+  const moolaAllocations = await E(publicFacet).getPoolAllocation(moolaR.brand);
+  t.is(moolaAllocations.Central.value, moolaPoolState.c);
+  t.is(moolaAllocations.Secondary.value, moolaPoolState.s);
+
+  // trade to move the balance of liquididty
+  // trade for moola specifying 300 output
+  const gainC = 300;
+  const mPriceC = priceFromTargetOutput(
+    gainC,
+    moolaPoolState.c,
+    moolaPoolState.s,
+    30,
+  );
+
+  const tradeDetailsC = {
+    inAmount: centralTokens(mPriceC),
+    outAmount: moola(gainC),
+  };
+
+  const expectedC = {
+    c: moolaPoolState.c + mPriceC,
+    s: moolaPoolState.s - gainC,
+    l: 10200,
+    k: (moolaPoolState.c + mPriceC) * (moolaPoolState.s - gainC),
+    out: gainC,
+    in: 0,
+  };
+  await alice.tradeAndCheck(
+    t,
+    false,
+    moolaPoolState,
+    tradeDetailsC,
+    expectedC,
+    { Secondary: moolaR.issuer },
+  );
+  moolaPoolState = updatePoolState(moolaPoolState, expectedC);
+
+  // alice checks the liquidity levels again
+  const newMoolaAllocations = await E(publicFacet).getPoolAllocation(
+    moolaR.brand,
+  );
+  t.is(newMoolaAllocations.Central.value, moolaPoolState.c);
+  t.is(newMoolaAllocations.Secondary.value, moolaPoolState.s);
 });
 
 test('multipoolAutoSwap jig - swapOut', async t => {


### PR DESCRIPTION
update declarations for multipoolAutoswap methods that take a brand
argument

Added some tests for multipoolAutoswap while writing contract docs.