### PR TITLE
test: add tests of zoe service

### DIFF
--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -54,6 +54,7 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
    */
   /** @type {Install} */
   const install = async bundle => {
+    assert(bundle, `a bundle must be provided`);
     /** @type {Installation} */
     const installation = { getBundle: () => bundle };
     harden(installation);


### PR DESCRIPTION
This PR adds tests of the Zoe Service. There is one change to Zoe that was a quick fix that asserts that a bundle exists before it is installed. I created TODO issues for other issues that arose.