### PR TITLE
fix: exit zcfSeats immediately on shutdown.

### DIFF
--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -10,6 +10,7 @@
 import { assert, details } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
 import makeWeakStore from '@agoric/weak-store';
+import makeStore from '@agoric/store';
 
 import { makeAmountMath, MathKind } from '@agoric/ertp';
 import { makeNotifierKit, updateFromNotifier } from '@agoric/notifier';
@@ -45,8 +46,8 @@ export function buildRootObject(_powers, _params, testJigSetter = undefined) {
 
     const invitationHandleToHandler = makeWeakStore('invitationHandle');
 
-    /** @type {WeakStore<ZCFSeat,ZCFSeatAdmin>} */
-    const zcfSeatToZCFSeatAdmin = makeWeakStore('zcfSeat');
+    /** @type {Store<ZCFSeat,ZCFSeatAdmin>} */
+    const zcfSeatToZCFSeatAdmin = makeStore('zcfSeat');
     /** @type {WeakStore<ZCFSeat,SeatHandle>} */
     const zcfSeatToSeatHandle = makeWeakStore('zcfSeat');
 
@@ -345,7 +346,12 @@ export function buildRootObject(_powers, _params, testJigSetter = undefined) {
         return invitationP;
       },
       // Shutdown the entire vat and give payouts
-      shutdown: () => E(zoeInstanceAdmin).shutdown(),
+      shutdown: () => {
+        E(zoeInstanceAdmin).shutdown();
+        zcfSeatToZCFSeatAdmin.values().forEach(zcfSeatAdmin => {
+          zcfSeatAdmin.updateHasExited();
+        });
+      },
       makeZCFMint,
       makeEmptySeatKit,
 

--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -348,8 +348,10 @@ export function buildRootObject(_powers, _params, testJigSetter = undefined) {
       // Shutdown the entire vat and give payouts
       shutdown: () => {
         E(zoeInstanceAdmin).shutdown();
-        zcfSeatToZCFSeatAdmin.values().forEach(zcfSeatAdmin => {
-          zcfSeatAdmin.updateHasExited();
+        zcfSeatToZCFSeatAdmin.entries().forEach(([zcfSeat, zcfSeatAdmin]) => {
+          if (!zcfSeat.hasExited()) {
+            zcfSeatAdmin.updateHasExited();
+          }
         });
       },
       makeZCFMint,

--- a/packages/zoe/test/unitTests/contracts/test-sellTickets.js
+++ b/packages/zoe/test/unitTests/contracts/test-sellTickets.js
@@ -488,18 +488,7 @@ test(`mint and sell opera tickets`, async t => {
   };
 
   // === Final Opera part ===
-  const ticketSellerClosesContract = async (
-    sellItemsCreatorSeat,
-    sellItemsCreatorFacet,
-  ) => {
-    const availableTickets = await E(sellItemsCreatorFacet).getAvailableItems();
-    const ticketIssuer = await E(sellItemsCreatorFacet).getItemsIssuer();
-    const ticketAmountMath = await makeLocalAmountMath(ticketIssuer);
-    t.truthy(
-      ticketAmountMath.isEmpty(availableTickets),
-      'All the tickets have been sold',
-    );
-
+  const ticketSellerClosesContract = async sellItemsCreatorSeat => {
     const operaPurse = moolaIssuer.makeEmptyPurse();
 
     const moneyPayment = await E(sellItemsCreatorSeat).getPayout('Money');
@@ -534,5 +523,5 @@ test(`mint and sell opera tickets`, async t => {
     ticketSalesInvitation4,
     moolaMint.mintPayment(moola(100)),
   );
-  await ticketSellerClosesContract(sellItemsCreatorSeat, sellItemsCreatorFacet);
+  await ticketSellerClosesContract(sellItemsCreatorSeat);
 });

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -1208,13 +1208,12 @@ test(`zcf.shutdown - userSeat exits`, async t => {
   t.truthy(await E(userSeat).hasExited());
 });
 
-// TODO: Currently the zcfSeat does not exit
-// https://github.com/Agoric/agoric-sdk/issues/1755
-test.failing(`zcf.shutdown - zcfSeat exits`, async t => {
+test(`zcf.shutdown - zcfSeat exits`, async t => {
   const { zoe, zcf } = await setupZCFTest({});
   const { zcfSeat, userSeat } = await makeOffer(zoe, zcf);
+  t.falsy(zcfSeat.hasExited());
+  t.falsy(await E(userSeat).hasExited());
   zcf.shutdown();
-  // @ts-ignore
   t.truthy(zcfSeat.hasExited());
   t.truthy(await E(userSeat).hasExited());
 });


### PR DESCRIPTION
Closes #1755

This exits the zcfSeats synchronously such that even if the actual shutdown of the vat is delayed, the seats are no longer active. UserSeats are exited already through the shutdown command.