### PR TITLE
fix: stop accepting offers if zcf.shutdown is called

### DIFF
--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -96,6 +96,8 @@
  * @property {() => IssuerKeywordRecord} getIssuers
  * @property {() => BrandKeywordRecord} getBrands
  * @property {() => Object} getTerms
+ * @property {() => boolean} hasShutdown
+ * @property {() => void} shutdown
  */
 
 /**

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -1218,9 +1218,7 @@ test(`zcf.shutdown - zcfSeat exits`, async t => {
   t.truthy(await E(userSeat).hasExited());
 });
 
-// TODO: Any new offers should throw after zcf.shutdown() is called
-// https://github.com/Agoric/agoric-sdk/issues/1756
-test.failing(`zcf.shutdown - no further offers accepted`, async t => {
+test(`zcf.shutdown - no further offers accepted`, async t => {
   const { zoe, zcf } = await setupZCFTest({});
   const invitation = await zcf.makeInvitation(() => {}, 'seat');
   zcf.shutdown();


### PR DESCRIPTION
Closes #1756 

This PR makes it such that Zoe no longer accepts offers for instances that have been shutdown