### PR TITLE
worker fixes

### DIFF
--- a/packages/SwingSet/src/kernel/vatManager/factory.js
+++ b/packages/SwingSet/src/kernel/vatManager/factory.js
@@ -27,16 +27,19 @@ export function makeVatManagerFactory({
   const nodeWorkerFactory = makeNodeWorkerVatManagerFactory({
     makeNodeWorker,
     kernelKeeper,
+    testLog: allVatPowers.testLog,
   });
 
   const nodeSubprocessFactory = makeNodeSubprocessFactory({
     startSubprocessWorker: startSubprocessWorkerNode,
     kernelKeeper,
+    testLog: allVatPowers.testLog,
   });
 
   const xsWorkerFactory = makeNodeSubprocessFactory({
     startSubprocessWorker: startSubprocessWorkerXS,
     kernelKeeper,
+    testLog: allVatPowers.testLog,
   });
 
   function validateManagerOptions(managerOptions) {

--- a/packages/SwingSet/src/kernel/vatManager/nodeWorker.js
+++ b/packages/SwingSet/src/kernel/vatManager/nodeWorker.js
@@ -23,7 +23,7 @@ function parentLog(first, ...args) {
 }
 
 export function makeNodeWorkerVatManagerFactory(tools) {
-  const { makeNodeWorker, kernelKeeper } = tools;
+  const { makeNodeWorker, kernelKeeper, testLog } = tools;
 
   function createFromBundle(vatID, bundle, managerOptions) {
     const { vatParameters } = managerOptions;
@@ -97,6 +97,8 @@ export function makeNodeWorkerVatManagerFactory(tools) {
         parentLog(`syscall`, args);
         const vatSyscallObject = args;
         handleSyscall(vatSyscallObject);
+      } else if (type === 'testLog') {
+        testLog(...args);
       } else if (type === 'deliverDone') {
         parentLog(`deliverDone`);
         if (waiting) {

--- a/packages/SwingSet/src/kernel/vatManager/nodeWorkerSupervisor.js
+++ b/packages/SwingSet/src/kernel/vatManager/nodeWorkerSupervisor.js
@@ -105,13 +105,22 @@ parentPort.on('message', ([type, ...margs]) => {
         reject: (...args) => doSyscall(['reject', ...args]),
       });
 
+      function testLog(...args) {
+        sendUplink(['testLog', ...args]);
+      }
+
       const state = null;
       const vatID = 'demo-vatID';
       // todo: maybe add transformTildot, makeGetMeter/transformMetering to
       // vatPowers, but only if options tell us they're wanted. Maybe
       // transformTildot should be async and outsourced to the kernel
       // process/thread.
-      const vatPowers = { Remotable, getInterfaceOf, makeMarshal };
+      const vatPowers = {
+        Remotable,
+        getInterfaceOf,
+        makeMarshal,
+        testLog,
+      };
       dispatch = makeLiveSlots(
         syscall,
         state,

--- a/packages/SwingSet/src/kernel/vatManager/subprocessSupervisor.js
+++ b/packages/SwingSet/src/kernel/vatManager/subprocessSupervisor.js
@@ -120,13 +120,22 @@ fromParent.on('data', data => {
         reject: (...args) => doSyscall(['reject', ...args]),
       });
 
+      function testLog(...args) {
+        sendUplink(['testLog', ...args]);
+      }
+
       const state = null;
       const vatID = 'demo-vatID';
       // todo: maybe add transformTildot, makeGetMeter/transformMetering to
       // vatPowers, but only if options tell us they're wanted. Maybe
       // transformTildot should be async and outsourced to the kernel
       // process/thread.
-      const vatPowers = { Remotable, getInterfaceOf, makeMarshal };
+      const vatPowers = {
+        Remotable,
+        getInterfaceOf,
+        makeMarshal,
+        testLog,
+      };
       dispatch = makeLiveSlots(
         syscall,
         state,

--- a/packages/SwingSet/src/kernel/vatManager/worker-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/worker-subprocess-node.js
@@ -56,10 +56,18 @@ export function makeNodeSubprocessFactory(tools) {
       transcriptManager,
     );
     function handleSyscall(vatSyscallObject) {
+      // We are currently invoked by an async piped from the worker thread,
+      // whose vat code has moved on (it really wants a synchronous/immediate
+      // syscall). TODO: unlike threads, subprocesses could be made to wait
+      // by doing a blocking read from the pipe, so we could fix this, and
+      // re-enable syscall.callNow
       const type = vatSyscallObject[0];
       if (type === 'callNow') {
         throw Error(`nodeWorker cannot block, cannot use syscall.callNow`);
       }
+      // This might throw an Error if the syscall was faulty, in which case
+      // the vat will be terminated soon. It returns a vatSyscallResults,
+      // which we discard because there is currently nobody to send it to.
       doSyscall(vatSyscallObject);
     }
 
@@ -96,7 +104,8 @@ export function makeNodeSubprocessFactory(tools) {
         if (waiting) {
           const resolve = waiting;
           waiting = null;
-          resolve();
+          const deliveryResult = args;
+          resolve(deliveryResult);
         }
       } else {
         parentLog(`unrecognized uplink message ${type}`);

--- a/packages/SwingSet/src/kernel/vatManager/worker-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/worker-subprocess-node.js
@@ -24,7 +24,7 @@ function parentLog(first, ...args) {
 }
 
 export function makeNodeSubprocessFactory(tools) {
-  const { startSubprocessWorker, kernelKeeper } = tools;
+  const { startSubprocessWorker, kernelKeeper, testLog } = tools;
 
   function createFromBundle(vatID, bundle, managerOptions) {
     const { vatParameters } = managerOptions;
@@ -99,6 +99,8 @@ export function makeNodeSubprocessFactory(tools) {
         parentLog(`syscall`, args);
         const vatSyscallObject = args;
         handleSyscall(vatSyscallObject);
+      } else if (type === 'testLog') {
+        testLog(...args);
       } else if (type === 'deliverDone') {
         parentLog(`deliverDone`);
         if (waiting) {

--- a/packages/SwingSet/src/spawnSubprocessWorker.js
+++ b/packages/SwingSet/src/spawnSubprocessWorker.js
@@ -1,5 +1,4 @@
 // this file is loaded by the controller, in the start compartment
-import process from 'process';
 import { spawn } from 'child_process';
 import Netstring from 'netstring-stream';
 
@@ -10,19 +9,14 @@ function parentLog(first, ...args) {
   // console.error(`--parent: ${first}`, ...args);
 }
 
-const supercode = require.resolve(
-  './kernel/vatManager/subprocessSupervisor.js',
-);
 // we send on fd3, and receive on fd4. We pass fd1/2 (stdout/err) through, so
 // console log/err from the child shows up normally. We don't use Node's
 // built-in serialization feature ('ipc') because the child process won't
 // always be Node.
 const stdio = harden(['inherit', 'inherit', 'inherit', 'pipe', 'pipe']);
 
-export function startSubprocessWorker(options) {
-  const execPath = options.execPath || process.execPath;
-  const args = options.args || ['-r', 'esm', supercode];
-  const proc = spawn(execPath, args, { stdio });
+export function startSubprocessWorker(execPath, procArgs = []) {
+  const proc = spawn(execPath, procArgs, { stdio });
 
   const toChild = Netstring.writeStream();
   toChild.pipe(proc.stdio[3]);

--- a/packages/SwingSet/test/workers/test-worker.js
+++ b/packages/SwingSet/test/workers/test-worker.js
@@ -15,6 +15,7 @@ maybeTestXS('xs vat manager', async t => {
 
   await c.run();
   t.is(c.bootstrapResult.status(), 'fulfilled');
+  t.deepEqual(c.dump().log, ['testLog works']);
 
   await c.shutdown();
 });
@@ -28,6 +29,7 @@ test.skip('nodeWorker vat manager', async t => {
 
   await c.run();
   t.is(c.bootstrapResult.status(), 'fulfilled');
+  t.deepEqual(c.dump().log, ['testLog works']);
 
   await c.shutdown();
 });
@@ -40,6 +42,7 @@ test('node-subprocess vat manager', async t => {
 
   await c.run();
   t.is(c.bootstrapResult.status(), 'fulfilled');
+  t.deepEqual(c.dump().log, ['testLog works']);
 
   await c.shutdown();
 });

--- a/packages/SwingSet/test/workers/vat-target.js
+++ b/packages/SwingSet/test/workers/vat-target.js
@@ -12,8 +12,11 @@ function ignore(p) {
 // inbound events ('dispatch'), which will provoke a set of outbound events
 // ('syscall'), that cover the full range of the dispatch/syscall interface
 
-export function buildRootObject() {
+export function buildRootObject(vatPowers) {
   console.log(`vat does buildRootObject`); // make sure console works
+  // note: XS doesn't appear to print console.log unless an exception happens
+  vatPowers.testLog('testLog works');
+
   const precB = makePromiseKit();
   const precC = makePromiseKit();
   let callbackObj;

--- a/packages/xs-vat-worker/src/vatWorker.js
+++ b/packages/xs-vat-worker/src/vatWorker.js
@@ -1,6 +1,6 @@
 /* global HandledPromise */
 import { importBundle } from '@agoric/import-bundle';
-import { Remotable, getInterfaceOf } from '@agoric/marshal';
+import { Remotable, getInterfaceOf, makeMarshal } from '@agoric/marshal';
 // TODO? import anylogger from 'anylogger';
 import { makeLiveSlots } from '@agoric/swingset-vat/src/kernel/liveSlots';
 
@@ -133,7 +133,11 @@ function makeWorker(io, setImmediate) {
         // vatPowers, but only if options tell us they're wanted. Maybe
         // transformTildot should be async and outsourced to the kernel
         // process/thread.
-        const vatPowers = { Remotable, getInterfaceOf };
+        const vatPowers = {
+          Remotable,
+          getInterfaceOf,
+          makeMarshal,
+        };
         dispatch = makeLiveSlots(
           syscall,
           state,

--- a/packages/xs-vat-worker/src/vatWorker.js
+++ b/packages/xs-vat-worker/src/vatWorker.js
@@ -127,6 +127,9 @@ function makeWorker(io, setImmediate) {
           reject: (...args) => doSyscall(['reject', ...args]),
         });
 
+        function testLog(...args) {
+          sendUplink(['testLog', ...args]);
+        }
         const state = null;
         const vatID = 'demo-vatID';
         // todo: maybe add transformTildot, makeGetMeter/transformMetering to
@@ -137,6 +140,7 @@ function makeWorker(io, setImmediate) {
           Remotable,
           getInterfaceOf,
           makeMarshal,
+          testLog,
         };
         dispatch = makeLiveSlots(
           syscall,


### PR DESCRIPTION
Address a bunch of small issues with our different vatWorker types, to align their feature sets more closely. They aren't quite identical yet, but this is enough to allow more tests to pass, and should unblock the addition of CI for the xs-vat-worker type (#1299)
