### PR TITLE
feat!: add to zcf the ability to find out when/why a vat shut down

### DIFF
--- a/packages/SwingSet/src/kernel/vatAdmin/vatAdmin-src.js
+++ b/packages/SwingSet/src/kernel/vatAdmin/vatAdmin-src.js
@@ -36,7 +36,7 @@ export function buildRootDeviceNode({ endowments, serialize }) {
       const vatID = kernelVatCreationFn({ bundleName }, options);
       return vatID;
     },
-    terminate(vatID, reason) {
+    terminateWithFailure(vatID, reason) {
       kernelTerminateVatFn(vatID, serialize(reason));
     },
     // Call the registered kernel function to request vat stats. Clean up the

--- a/packages/SwingSet/src/kernel/vatAdmin/vatAdminWrapper.js
+++ b/packages/SwingSet/src/kernel/vatAdmin/vatAdminWrapper.js
@@ -26,8 +26,8 @@ export function buildRootObject(vatPowers) {
     doneP.catch(() => {}); // shut up false whine about unhandled rejection
 
     const adminNode = harden({
-      terminate(reason) {
-        D(vatAdminNode).terminate(vatID, reason);
+      terminateWithFailure(reason) {
+        D(vatAdminNode).terminateWithFailure(vatID, reason);
       },
       adminData() {
         return D(vatAdminNode).adminStats(vatID);

--- a/packages/SwingSet/test/vat-admin/terminate/bootstrap-die-cleanly.js
+++ b/packages/SwingSet/test/vat-admin/terminate/bootstrap-die-cleanly.js
@@ -15,7 +15,7 @@ export function buildRootObject() {
     },
     async phase2() {
       // terminate as a second phase, so we can capture the kernel state in between
-      E(dude.adminNode).terminate('phase 2');
+      E(dude.adminNode).terminateWithFailure('phase 2');
       await E(dude.adminNode).done();
     },
   });

--- a/packages/SwingSet/test/vat-admin/terminate/bootstrap-no-zombies.js
+++ b/packages/SwingSet/test/vat-admin/terminate/bootstrap-no-zombies.js
@@ -9,7 +9,7 @@ export function buildRootObject() {
       // sure everything is working
       const weatherwax = await E(vatMaker).createVatByName('weatherwax');
       await E(weatherwax.root).live();
-      E(weatherwax.adminNode).terminate('no zombies?');
+      E(weatherwax.adminNode).terminateWithFailure('no zombies?');
       try {
         await E(weatherwax.adminNode).done();
       } catch (e) {

--- a/packages/SwingSet/test/vat-admin/terminate/bootstrap-speak-to-dead.js
+++ b/packages/SwingSet/test/vat-admin/terminate/bootstrap-speak-to-dead.js
@@ -37,7 +37,7 @@ export function buildRootObject(vatPowers) {
         testLog(`b: speak failed: ${e}`);
       }
 
-      E(weatherwax.adminNode).terminateWithFailure('arbitrary reason');
+      E(weatherwax.adminNode).terminateWithFailure(Error('arbitrary reason'));
       try {
         await E(weatherwax.adminNode).done();
       } catch (e) {

--- a/packages/SwingSet/test/vat-admin/terminate/bootstrap-speak-to-dead.js
+++ b/packages/SwingSet/test/vat-admin/terminate/bootstrap-speak-to-dead.js
@@ -37,7 +37,7 @@ export function buildRootObject(vatPowers) {
         testLog(`b: speak failed: ${e}`);
       }
 
-      E(weatherwax.adminNode).terminate('arbitrary reason');
+      E(weatherwax.adminNode).terminateWithFailure('arbitrary reason');
       try {
         await E(weatherwax.adminNode).done();
       } catch (e) {

--- a/packages/SwingSet/test/vat-admin/terminate/bootstrap-terminate.js
+++ b/packages/SwingSet/test/vat-admin/terminate/bootstrap-terminate.js
@@ -51,7 +51,7 @@ export function buildRootObject(vatPowers, vatParameters) {
       // .. but it will be killed ..
       switch (mode) {
         case 'kill':
-          E(dude.adminNode).terminate(mode);
+          E(dude.adminNode).terminateWithFailure(mode);
           break;
         case 'happy':
           E(dude.root).dieHappy(mode);
@@ -86,7 +86,7 @@ export function buildRootObject(vatPowers, vatParameters) {
       );
       // then we try to kill the vat again, which should be idempotent
       if (mode === 'kill') {
-        E(dude.adminNode).terminate('because we said so');
+        E(dude.adminNode).terminateWithFailure('because we said so');
       }
 
       // the run-queue should now look like:

--- a/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
+++ b/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
@@ -131,7 +131,7 @@ test('dispatches to the dead do not harm kernel', async t => {
       `w: I ate'nt dead`,
       'b: p1b = I so resolve',
       'b: p2b fails Error: vat terminated',
-      'done: arbitrary reason',
+      'done: Error: arbitrary reason',
     ]);
   }
   const state1 = getAllState(storage1);
@@ -154,7 +154,7 @@ test('dispatches to the dead do not harm kernel', async t => {
     t.deepEqual(c2.dump().log, [
       'b: p1b = I so resolve',
       'b: p2b fails Error: vat terminated',
-      'done: arbitrary reason',
+      'done: Error: arbitrary reason',
       'm: live 2 failed: Error: vat terminated',
     ]);
   }

--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -364,8 +364,16 @@ export function buildRootObject(_powers, _params, testJigSetter = undefined) {
         return invitationP;
       },
       // Shutdown the entire vat and give payouts
-      shutdown: () => {
-        E(zoeInstanceAdmin).shutdown();
+      shutdown: msg => {
+        E(zoeInstanceAdmin).exitAllSeats(msg);
+        zcfSeatToZCFSeatAdmin.entries().forEach(([zcfSeat, zcfSeatAdmin]) => {
+          if (!zcfSeat.hasExited()) {
+            zcfSeatAdmin.updateHasExited();
+          }
+        });
+      },
+      shutdownWithError: error => {
+        E(zoeInstanceAdmin).kickOutAllSeats(error);
         zcfSeatToZCFSeatAdmin.entries().forEach(([zcfSeat, zcfSeatAdmin]) => {
           if (!zcfSeat.hasExited()) {
             zcfSeatAdmin.updateHasExited();

--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -365,7 +365,7 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
       },
       // Shutdown the entire vat and give payouts
       shutdown: completion => {
-        E(zoeInstanceAdmin).exitAllSeats();
+        E(zoeInstanceAdmin).exitAllSeats(completion);
         zcfSeatToZCFSeatAdmin.entries().forEach(([zcfSeat, zcfSeatAdmin]) => {
           if (!zcfSeat.hasExited()) {
             zcfSeatAdmin.updateHasExited();
@@ -374,7 +374,7 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
         powers.exitVat(completion);
       },
       shutdownWithFailure: reason => {
-        E(zoeInstanceAdmin).kickOutAllSeats(reason);
+        E(zoeInstanceAdmin).failAllSeats(reason);
         zcfSeatToZCFSeatAdmin.entries().forEach(([zcfSeat, zcfSeatAdmin]) => {
           if (!zcfSeat.hasExited()) {
             zcfSeatAdmin.updateHasExited();
@@ -433,7 +433,7 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
         const offerHandler = invitationHandleToHandler.get(invitationHandle);
         // @ts-ignore
         const offerResultP = E(offerHandler)(zcfSeat).catch(reason => {
-          throw zcfSeat.kickOut(reason);
+          throw zcfSeat.fail(reason);
         });
         const exitObj = makeExitObj(
           seatData.proposal,

--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -382,6 +382,7 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
         });
         powers.exitVatWithFailure(reason);
       },
+      stopAcceptingOffers: () => E(zoeInstanceAdmin).stopAcceptingOffers(),
       makeZCFMint,
       makeEmptySeatKit,
 

--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -31,7 +31,7 @@ import { makeHandle } from '../makeHandle';
 import '../../exported';
 import '../internal-types';
 
-export function buildRootObject(_powers, _params, testJigSetter = undefined) {
+export function buildRootObject(powers, _params, testJigSetter = undefined) {
   /** @type {ExecuteContract} */
   const executeContract = async (
     bundle,
@@ -365,20 +365,22 @@ export function buildRootObject(_powers, _params, testJigSetter = undefined) {
       },
       // Shutdown the entire vat and give payouts
       shutdown: msg => {
-        E(zoeInstanceAdmin).exitAllSeats(msg);
+        E(zoeInstanceAdmin).exitAllSeats();
         zcfSeatToZCFSeatAdmin.entries().forEach(([zcfSeat, zcfSeatAdmin]) => {
           if (!zcfSeat.hasExited()) {
             zcfSeatAdmin.updateHasExited();
           }
         });
+        powers.exitVat(msg);
       },
-      shutdownWithError: error => {
-        E(zoeInstanceAdmin).kickOutAllSeats(error);
+      shutdownWithError: reason => {
+        E(zoeInstanceAdmin).kickOutAllSeats(reason);
         zcfSeatToZCFSeatAdmin.entries().forEach(([zcfSeat, zcfSeatAdmin]) => {
           if (!zcfSeat.hasExited()) {
             zcfSeatAdmin.updateHasExited();
           }
         });
+        powers.exitVatWithFailure(reason);
       },
       makeZCFMint,
       makeEmptySeatKit,

--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -364,16 +364,16 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
         return invitationP;
       },
       // Shutdown the entire vat and give payouts
-      shutdown: msg => {
+      shutdown: completion => {
         E(zoeInstanceAdmin).exitAllSeats();
         zcfSeatToZCFSeatAdmin.entries().forEach(([zcfSeat, zcfSeatAdmin]) => {
           if (!zcfSeat.hasExited()) {
             zcfSeatAdmin.updateHasExited();
           }
         });
-        powers.exitVat(msg);
+        powers.exitVat(completion);
       },
-      shutdownWithError: reason => {
+      shutdownWithFailure: reason => {
         E(zoeInstanceAdmin).kickOutAllSeats(reason);
         zcfSeatToZCFSeatAdmin.entries().forEach(([zcfSeat, zcfSeatAdmin]) => {
           if (!zcfSeat.hasExited()) {

--- a/packages/zoe/src/contractFacet/exit.js
+++ b/packages/zoe/src/contractFacet/exit.js
@@ -39,7 +39,7 @@ export const makeExitObj = (proposal, zoeSeatAdmin, zcfSeatAdmin) => {
         );
         console.error(reason);
         zcfSeatAdmin.updateHasExited();
-        E(zoeSeatAdmin).kickOut(reason);
+        E(zoeSeatAdmin).fail(reason);
         throw reason;
       });
   } else if (exitKind === 'onDemand') {

--- a/packages/zoe/src/contractFacet/seat.js
+++ b/packages/zoe/src/contractFacet/seat.js
@@ -45,19 +45,19 @@ export const makeZcfSeatAdminKit = (
 
   /** @type {ZCFSeat} */
   const zcfSeat = harden({
-    exit: () => {
+    exit: completion => {
       assertExitedFalse();
       zcfSeatAdmin.updateHasExited();
-      E(zoeSeatAdmin).exit();
+      E(zoeSeatAdmin).exit(completion);
     },
-    kickOut: (
+    fail: (
       reason = new Error(
         'Kicked out of seat. Please check the log for more information.',
       ),
     ) => {
       if (!exited) {
         zcfSeatAdmin.updateHasExited();
-        E(zoeSeatAdmin).kickOut(harden(reason));
+        E(zoeSeatAdmin).fail(harden(reason));
       }
       return reason;
     },

--- a/packages/zoe/src/contractFacet/seat.js
+++ b/packages/zoe/src/contractFacet/seat.js
@@ -61,6 +61,9 @@ export const makeZcfSeatAdminKit = (
       }
       return reason;
     },
+    // TODO(1837) remove deprecated method before Beta release.
+    // deprecated as of 0.9.1-dev.3. Use fail() instead.
+    kickOut: reason => zcfSeat.fail(reason),
     getNotifier: () => {
       return notifier;
     },

--- a/packages/zoe/src/contractFacet/seat.js
+++ b/packages/zoe/src/contractFacet/seat.js
@@ -52,7 +52,7 @@ export const makeZcfSeatAdminKit = (
     },
     fail: (
       reason = new Error(
-        'Kicked out of seat. Please check the log for more information.',
+        'Seat exited with failure. Please check the log for more information.',
       ),
     ) => {
       if (!exited) {

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -148,7 +148,7 @@
 /**
  * @typedef {Object} ZCFSeat
  * @property {() => void} exit
- * @property {(reason: Error=) => Error} kickOut called with the reason this
+ * @property {(reason: Error=) => Error} fail called with the reason this
  * seat is being kicked out, where reason is normally an instanceof Error.
  * @property {() => Notifier<Allocation>} getNotifier
  * @property {() => boolean} hasExited

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -2,6 +2,15 @@
 /// <reference types="ses"/>
 
 /**
+ * @typedef {any} Completion
+ * Any passable non-thenable. Often an explanatory string.
+ *
+ * @typedef {Error|any} TerminationReason
+ * Something provided as an explanation to a termination request. Usually an
+ * Error but not required to be so.
+ */
+
+/**
  * @typedef {Object} ContractFacet
  *
  * The Zoe interface specific to a contract instance. The Zoe Contract
@@ -18,8 +27,8 @@
  * and get the amountMath and brand synchronously accessible after
  * saving
  * @property {MakeInvitation} makeInvitation
- * @property {(reason: string) => void} shutdown
- * @property {(error: string) => void} shutdownWithError
+ * @property {(completion: Completion) => void} shutdown
+ * @property {(reason: TerminationReason) => void} shutdownWithFailure
  * @property {() => ZoeService} getZoeService
  * @property {() => Issuer} getInvitationIssuer
  * @property {() => Terms} getTerms

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -18,7 +18,8 @@
  * and get the amountMath and brand synchronously accessible after
  * saving
  * @property {MakeInvitation} makeInvitation
- * @property {() => void} shutdown
+ * @property {(reason: string) => void} shutdown
+ * @property {(error: string) => void} shutdownWithError
  * @property {() => ZoeService} getZoeService
  * @property {() => Issuer} getInvitationIssuer
  * @property {() => Terms} getTerms

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -148,8 +148,8 @@
 /**
  * @typedef {Object} ZCFSeat
  * @property {() => void} exit
- * @property {(reason: Error=) => Error} fail called with the reason this
- * seat is being kicked out, where reason is normally an instanceof Error.
+ * @property {(reason: Error=) => Error} fail called with the reason for this
+ * failure, where reason is normally an instanceof Error.
  * @property {() => Notifier<Allocation>} getNotifier
  * @property {() => boolean} hasExited
  * @property {() => ProposalRecord} getProposal

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -38,6 +38,7 @@
  * @property {MakeZCFMint} makeZCFMint
  * @property {(exit: ExitRule=) => ZcfSeatKit} makeEmptySeatKit
  * @property {SetTestJig} setTestJig
+ * @property {() => void} stopAcceptingOffers
  */
 
 /**

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -150,6 +150,9 @@
  * @property {() => void} exit
  * @property {(reason: Error=) => Error} fail called with the reason for this
  * failure, where reason is normally an instanceof Error.
+ * @property {(reason: Error=) => Error} kickOut called with the reason for
+ * this failure, where reason is normally an instanceof Error. This method
+ * is deprecated as of 0.9.1-dev.3 in favor of fail().
  * @property {() => Notifier<Allocation>} getNotifier
  * @property {() => boolean} hasExited
  * @property {() => ProposalRecord} getProposal

--- a/packages/zoe/src/contractSupport/types.js
+++ b/packages/zoe/src/contractSupport/types.js
@@ -34,13 +34,13 @@
  * gives 5 moola and seat B only wants 3 moola, seat A retains 2
  * moola.
  *
- * If the leftSeat has exited already, both seats will be kicked out
+ * If leftSeat has exited already, both seats will fail
  * with an error message (provided by 'leftHasExitedMsg'). Similarly,
- * if the rightSeat has exited already, both seats will be kicked out
+ * if rightSeat has exited already, both seats fail
  * with an error message (provided by 'rightHasExitedMsg').
  *
- * If the swap fails, no assets are transferred, both seats are kicked
- * out, and the function throws.
+ * If the swap fails, no assets are transferred, both seats will fail,
+ * and the function throws.
  *
  * @param {ContractFacet} zcf
  * @param {ZCFSeat} leftSeat

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -217,8 +217,8 @@ export const swap = (
       rightHasExitedMsg,
     );
   } catch (err) {
-    leftSeat.kickOut(err);
-    rightSeat.kickOut(err);
+    leftSeat.fail(err);
+    rightSeat.fail(err);
     throw err;
   }
 
@@ -258,8 +258,8 @@ export const swapExact = (
       rightHasExitedMsg,
     );
   } catch (err) {
-    leftSeat.kickOut(err);
-    rightSeat.kickOut(err);
+    leftSeat.fail(err);
+    rightSeat.fail(err);
     throw err;
   }
 

--- a/packages/zoe/src/contracts/atomicSwap.js
+++ b/packages/zoe/src/contracts/atomicSwap.js
@@ -35,7 +35,7 @@ const start = zcf => {
     /** @type {OfferHandler} */
     const matchingSeatOfferHandler = matchingSeat => {
       const swapResult = swap(zcf, firstSeat, matchingSeat);
-      zcf.shutdown();
+      zcf.shutdown('Swap completed.');
       return swapResult;
     };
 

--- a/packages/zoe/src/contracts/auction/secondPriceLogic.js
+++ b/packages/zoe/src/contracts/auction/secondPriceLogic.js
@@ -55,4 +55,5 @@ export const calcWinnerAndClose = (zcf, sellSeat, bidSeats) => {
       bidSeat.exit();
     }
   });
+  zcf.shutdown('Auction closed.');
 };

--- a/packages/zoe/src/contracts/auction/secondPriceLogic.js
+++ b/packages/zoe/src/contracts/auction/secondPriceLogic.js
@@ -29,7 +29,7 @@ export const calcWinnerAndClose = (zcf, sellSeat, bidSeats) => {
   });
 
   if (activeBidsCount === 0) {
-    throw sellSeat.kickOut(
+    throw sellSeat.fail(
       new Error(`Could not close auction. No bids were active`),
     );
   }

--- a/packages/zoe/src/contracts/coveredCall.js
+++ b/packages/zoe/src/contracts/coveredCall.js
@@ -77,7 +77,7 @@ const start = zcf => {
         );
         throw err;
       }
-      zcf.shutdown();
+      zcf.shutdown('Swap completed.');
       return `The option was exercised. Please collect the assets in your payout.`;
     };
 

--- a/packages/zoe/src/contracts/multipoolAutoswap/swap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/swap.js
@@ -149,7 +149,7 @@ export const makeMakeSwapInvitation = (
 
       const brandInAmountMath = getPool(brandIn).getAmountMath();
       if (!brandInAmountMath.isGTE(offeredAmountIn, amountIn)) {
-        seat.kickOut();
+        seat.fail();
         return `insufficient funds offered`;
       }
 

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -103,7 +103,7 @@ const start = zcf => {
     buyerSeat.exit();
 
     if (itemsMath.isEmpty(publicFacet.getAvailableItems())) {
-      zcf.shutdown();
+      zcf.shutdown('All items sold.');
     }
     return defaultAcceptanceMsg;
   };

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -75,7 +75,7 @@ const start = zcf => {
     // Check that the wanted items are still for sale.
     if (!itemsMath.isGTE(currentItemsForSale, wantedItems)) {
       const rejectMsg = `Some of the wanted items were not available for sale`;
-      throw buyerSeat.kickOut(new Error(rejectMsg));
+      throw buyerSeat.fail(new Error(rejectMsg));
     }
 
     // All items are the same price.

--- a/packages/zoe/src/contracts/simpleExchange.js
+++ b/packages/zoe/src/contracts/simpleExchange.js
@@ -125,7 +125,7 @@ const start = zcf => {
       return sell(seat);
     }
     // Eject because the offer must be invalid
-    throw seat.kickOut(
+    throw seat.fail(
       new Error(`The proposal did not match either a buy or sell order.`),
     );
   };

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -43,9 +43,9 @@
  *
  * @typedef {Object} ZoeSeatAdmin
  * @property {(allocation: Allocation) => void} replaceAllocation
- * @property {() => void} exit
- * @property {(reason: any) => void} kickOut called with the reason this seat
- * is being kicked out, where reason is normally an instanceof Error.
+ * @property {(completion: Completion) => void} exit
+ * @property {(reason: TerminationReason) => void} fail called with the reason
+ * for calling fail on this seat, where reason is normally an instanceof Error.
  * @property {() => Allocation} getCurrentAllocation
  */
 
@@ -97,8 +97,8 @@
  * @property {() => BrandKeywordRecord} getBrands
  * @property {() => Object} getTerms
  * @property {() => boolean} acceptingOffers
- * @property {() => void} exitAllSeats
- * @property {(reason: TerminationReason) => void} kickOutAllSeats
+ * @property {(completion: Completion) => void} exitAllSeats
+ * @property {(reason: TerminationReason) => void} failAllSeats
  * @property {() => void} stopAcceptingOffers
  */
 
@@ -127,8 +127,8 @@
  * @property {MakeZoeMint} makeZoeMint
  * @property {MakeNoEscrowSeat} makeNoEscrowSeat
  * @property {ReplaceAllocations} replaceAllocations
- * @property {() => void} exitAllSeats
- * @property {(reason: TerminationReason) => void} kickOutAllSeats
+ * @property {(completion: Completion) => void} exitAllSeats
+ * @property {(reason: TerminationReason) => void} failAllSeats
  */
 
 /**
@@ -234,8 +234,7 @@
  * rejected with the reason. If the contract terminates successfully, the
  * promise will fulfill to the completion value.
  * @property {(reason: TerminationReason) => void} terminateWithFailure
- * Terminate the vat in which the contract is running as a failure. This
- * bypasses notification of Zoe.
+ * Terminate the vat in which the contract is running as a failure.
  * @property {() => Object} adminData
  * returns some statistics about the vat in which the contract is running.
  */

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -129,6 +129,7 @@
  * @property {ReplaceAllocations} replaceAllocations
  * @property {(completion: Completion) => void} exitAllSeats
  * @property {(reason: TerminationReason) => void} failAllSeats
+ * @property {() => void} stopAcceptingOffers
  */
 
 /**

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -98,7 +98,7 @@
  * @property {() => Object} getTerms
  * @property {() => boolean} acceptingOffers
  * @property {() => void} exitAllSeats
- * @property {(reason: string) => void} kickOutAllSeats
+ * @property {(reason: TerminationReason) => void} kickOutAllSeats
  * @property {() => void} stopAcceptingOffers
  */
 
@@ -128,7 +128,7 @@
  * @property {MakeNoEscrowSeat} makeNoEscrowSeat
  * @property {ReplaceAllocations} replaceAllocations
  * @property {() => void} exitAllSeats
- * @property {(reason: string) => void} kickOutAllSeats
+ * @property {(reason: TerminationReason) => void} kickOutAllSeats
  */
 
 /**
@@ -228,12 +228,12 @@
  * A powerful object that can be used to terminate the vat in which a contract
  * is running, to get statistics, or to be notified when it terminates.
  *
- * @property {() => Promise<void>} done
+ * @property {() => Promise<Completion>} done
  * returns a promise that will be fulfilled or rejected when the contract is
  * terminated. If the contract terminates with a failure, the promise will be
  * rejected with the reason. If the contract terminates successfully, the
  * promise will fulfill to the completion value.
- * @property {(completion: string) => void} terminate
+ * @property {(reason: TerminationReason) => void} terminateWithFailure
  * Terminate the vat in which the contract is running as a failure. This
  * bypasses notification of Zoe.
  * @property {() => Object} adminData

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -96,8 +96,9 @@
  * @property {() => IssuerKeywordRecord} getIssuers
  * @property {() => BrandKeywordRecord} getBrands
  * @property {() => Object} getTerms
- * @property {() => boolean} hasShutdown
- * @property {() => void} shutdown
+ * @property {() => boolean} acceptingOffers
+ * @property {() => void} terminate
+ * @property {(reason: string) => void} terminateOnFailure
  */
 
 /**
@@ -119,7 +120,8 @@
  *             description: string,
  *             customProperties: Record<string, any>=,
  *            ) => Payment} makeInvitation
- * @property {() => void} shutdown
+ * @property {(completion: string) => void} terminate
+ * @property {(reason: string) => void} terminateOnFailure
  * @property {(issuerP: ERef<Issuer>,
  *             keyword: Keyword
  *            ) => Promise<void>} saveIssuer
@@ -231,11 +233,16 @@
  * ability to call terminate(), Zoe makes this visible.
  *
  * @property {() => Promise<void>} done
- * provides a promise that will be fulfilled when the contract is terminated.
- * @property {() => void} terminate
- * kills the vat in which the contract is running
+ * returns a promise that will be fulfilled or rejected when the contract is
+ * terminated.
+ * @property {(completion: string) => void} terminate
+ * Terminate the vat in which the contract is running. This bypasses
+ * notification of Zoe.
+ * @property {(reason: string) => void} terminateOnFailure
+ * Terminate the vat in which the contract is running and indicate failure. This
+ * bypasses notification of Zoe.
  * @property {() => Object} adminData
- * provides some statistics about the vat in which the contract is running.
+ * returns some statistics about the vat in which the contract is running.
  */
 
 /**

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -97,8 +97,9 @@
  * @property {() => BrandKeywordRecord} getBrands
  * @property {() => Object} getTerms
  * @property {() => boolean} acceptingOffers
- * @property {() => void} terminate
- * @property {(reason: string) => void} terminateOnFailure
+ * @property {() => void} exitAllSeats
+ * @property {(reason: string) => void} kickOutAllSeats
+ * @property {() => void} stopAcceptingOffers
  */
 
 /**
@@ -120,14 +121,14 @@
  *             description: string,
  *             customProperties: Record<string, any>=,
  *            ) => Payment} makeInvitation
- * @property {(completion: string) => void} terminate
- * @property {(reason: string) => void} terminateOnFailure
  * @property {(issuerP: ERef<Issuer>,
  *             keyword: Keyword
  *            ) => Promise<void>} saveIssuer
  * @property {MakeZoeMint} makeZoeMint
  * @property {MakeNoEscrowSeat} makeNoEscrowSeat
  * @property {ReplaceAllocations} replaceAllocations
+ * @property {() => void} exitAllSeats
+ * @property {(reason: string) => void} kickOutAllSeats
  */
 
 /**
@@ -225,21 +226,15 @@
 /**
  * @typedef {Object} AdminNode
  * A powerful object that can be used to terminate the vat in which a contract
- * is running, to get statistics, or to be notified when it terminates. The
- * object is only available from within the contract so
- * that clients of the contract can tell (by getting the source code from Zoe
- * using the installation) what use the contract makes of it. If they want to
- * be assured of discretion, or want to know that the contract doesn't have the
- * ability to call terminate(), Zoe makes this visible.
+ * is running, to get statistics, or to be notified when it terminates.
  *
  * @property {() => Promise<void>} done
  * returns a promise that will be fulfilled or rejected when the contract is
- * terminated.
+ * terminated. If the contract terminates with a failure, the promise will be
+ * rejected with the reason. If the contract terminates successfully, the
+ * promise will fulfill to the completion value.
  * @property {(completion: string) => void} terminate
- * Terminate the vat in which the contract is running. This bypasses
- * notification of Zoe.
- * @property {(reason: string) => void} terminateOnFailure
- * Terminate the vat in which the contract is running and indicate failure. This
+ * Terminate the vat in which the contract is running as a failure. This
  * bypasses notification of Zoe.
  * @property {() => Object} adminData
  * returns some statistics about the vat in which the contract is running.

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -114,7 +114,7 @@
 
 /**
  * @typedef {Object} AdminFacet
- * @property {() => Promise<void>} getVatShutdownPromise
+ * @property {() => Promise<string|Error|any>} getVatShutdownPromise
  * @property {() => any} getVatStats
  */
 

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -113,11 +113,18 @@
  */
 
 /**
+ * @typedef {Object} AdminFacet
+ * @property {() => Promise<void>} getVatShutdownPromise
+ * @property {() => any} getVatStats
+ */
+
+/**
  * @typedef {Object} StartInstanceResult
  * @property {any} creatorFacet
  * @property {any} publicFacet
  * @property {Instance} instance
  * @property {Payment | undefined} creatorInvitation
+ * @property {AdminFacet} adminFacet
  */
 
 /**

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -114,7 +114,7 @@
 
 /**
  * @typedef {Object} AdminFacet
- * @property {() => Promise<string|Error|any>} getVatShutdownPromise
+ * @property {() => Promise<Completion>} getVatShutdownPromise
  * @property {() => any} getVatStats
  */
 

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -245,13 +245,15 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
           getBrands: () => instanceRecord.terms.brands,
           getInstance: () => instance,
           acceptingOffers: () => acceptingOffers,
-          exitAllSeats: () => {
+          exitAllSeats: completion => {
             acceptingOffers = false;
-            zoeSeatAdmins.forEach(zoeSeatAdmin => zoeSeatAdmin.exit());
+            zoeSeatAdmins.forEach(zoeSeatAdmin =>
+              zoeSeatAdmin.exit(completion),
+            );
           },
-          kickOutAllSeats: reason => {
+          failAllSeats: reason => {
             acceptingOffers = false;
-            zoeSeatAdmins.forEach(zoeSeatAdmin => zoeSeatAdmin.kickOut(reason));
+            zoeSeatAdmins.forEach(zoeSeatAdmin => zoeSeatAdmin.fail(reason));
           },
           // TODO(1834): plumb this through to ZCF
           stopAcceptingOffers: () => (acceptingOffers = false),
@@ -264,8 +266,8 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
       E(adminNode)
         .done()
         .then(
-          () => instanceAdmin.exitAllSeats(),
-          reason => instanceAdmin.kickOutAllSeats(reason),
+          completion => instanceAdmin.exitAllSeats(completion),
+          reason => instanceAdmin.failAllSeats(reason),
         );
 
       // Unpack the invitationKit.
@@ -319,8 +321,8 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
           seatHandleToZoeSeatAdmin.init(seatHandle, zoeSeatAdmin);
           return { userSeat, notifier, zoeSeatAdmin };
         },
-        exitAllSeats: () => instanceAdmin.exitAllSeats(),
-        kickOutAllSeats: reason => instanceAdmin.kickOutAllSeats(reason),
+        exitAllSeats: completion => instanceAdmin.exitAllSeats(completion),
+        failAllSeats: reason => instanceAdmin.failAllSeats(reason),
         makeZoeMint,
         replaceAllocations: seatHandleAllocations => {
           seatHandleAllocations.forEach(({ seatHandle, allocation }) => {

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -258,18 +258,9 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
       };
 
       const instanceAdmin = makeInstanceAdmin();
-
       instanceToInstanceAdmin.init(instance, instanceAdmin);
 
-      E(adminNode)
-        .done()
-        .then(
-          () => instanceAdmin.terminate(),
-          error => instanceAdmin.terminateOnFailure(error),
-        );
-
       // Unpack the invitationKit.
-
       const {
         issuer: invitationIssuer,
         mint: invitationMint,
@@ -320,7 +311,7 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
           seatHandleToZoeSeatAdmin.init(seatHandle, zoeSeatAdmin);
           return { userSeat, notifier, zoeSeatAdmin };
         },
-        exitAllSeats: completion => instanceAdmin.exitAllSeats(completion),
+        exitAllSeats: () => instanceAdmin.exitAllSeats(),
         kickOutAllSeats: reason => instanceAdmin.kickOutAllSeats(reason),
         makeZoeMint,
         replaceAllocations: seatHandleAllocations => {

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -255,7 +255,6 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
             acceptingOffers = false;
             zoeSeatAdmins.forEach(zoeSeatAdmin => zoeSeatAdmin.fail(reason));
           },
-          // TODO(1834): plumb this through to ZCF
           stopAcceptingOffers: () => (acceptingOffers = false),
         };
       };
@@ -330,6 +329,7 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
             zoeSeatAdmin.replaceAllocation(allocation);
           });
         },
+        stopAcceptingOffers: () => instanceAdmin.stopAcceptingOffers(),
       };
 
       // At this point, the contract will start executing. All must be ready

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -253,12 +253,20 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
             acceptingOffers = false;
             zoeSeatAdmins.forEach(zoeSeatAdmin => zoeSeatAdmin.kickOut(reason));
           },
+          // TODO(1834): plumb this through to ZCF
           stopAcceptingOffers: () => (acceptingOffers = false),
         };
       };
 
       const instanceAdmin = makeInstanceAdmin();
       instanceToInstanceAdmin.init(instance, instanceAdmin);
+
+      E(adminNode)
+        .done()
+        .then(
+          () => instanceAdmin.exitAllSeats(),
+          reason => instanceAdmin.kickOutAllSeats(reason),
+        );
 
       // Unpack the invitationKit.
       const {

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -73,7 +73,7 @@ export const makeZoeSeatAdminKit = (
     fail: reason => {
       assert(
         instanceAdmin.hasZoeSeatAdmin(zoeSeatAdmin),
-        `Cannot kick out of seat. Seat has already exited`,
+        `Cannot fail seat. Seat has already exited`,
       );
       updater.fail(reason);
       doExit(zoeSeatAdmin);

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -62,15 +62,15 @@ export const makeZoeSeatAdminKit = (
       updater.updateState(replacementAllocation);
       currentAllocation = replacementAllocation;
     },
-    exit: () => {
+    exit: reason => {
       assert(
         instanceAdmin.hasZoeSeatAdmin(zoeSeatAdmin),
         `Cannot exit seat. Seat has already exited`,
       );
-      updater.finish(undefined);
+      updater.finish(reason);
       doExit(zoeSeatAdmin);
     },
-    kickOut: reason => {
+    fail: reason => {
       assert(
         instanceAdmin.hasZoeSeatAdmin(zoeSeatAdmin),
         `Cannot kick out of seat. Seat has already exited`,

--- a/packages/zoe/test/swingsetTests/brokenContracts/crashingAutoRefund.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/crashingAutoRefund.js
@@ -69,6 +69,9 @@ const start = zcf => {
     );
   };
 
+  const terminateFail = msg => zcf.shutdownWithError(msg);
+  const terminateClean = msg => zcf.shutdown(msg);
+
   const makeSwapInvitation = () =>
     zcf.makeInvitation(makeMatchingInvitation, 'firstOffer');
 
@@ -82,6 +85,8 @@ const start = zcf => {
     makeSwapInvitation,
     makeExcessiveInvitation,
     makeThrowingInvitation,
+    terminateClean,
+    terminateFail,
     meterException: () => {
       offersCount += 1;
       return new Array(1e9);

--- a/packages/zoe/test/swingsetTests/brokenContracts/crashingAutoRefund.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/crashingAutoRefund.js
@@ -69,8 +69,8 @@ const start = zcf => {
     );
   };
 
-  const terminateFail = msg => zcf.shutdownWithError(msg);
-  const terminateClean = msg => zcf.shutdown(msg);
+  const zcfShutdown = completion => zcf.shutdown(completion);
+  const zcfShutdownWithFailure = reason => zcf.shutdownWithFailure(reason);
 
   const makeSwapInvitation = () =>
     zcf.makeInvitation(makeMatchingInvitation, 'firstOffer');
@@ -85,8 +85,8 @@ const start = zcf => {
     makeSwapInvitation,
     makeExcessiveInvitation,
     makeThrowingInvitation,
-    terminateClean,
-    terminateFail,
+    zcfShutdown,
+    zcfShutdownWithFailure,
     meterException: () => {
       offersCount += 1;
       return new Array(1e9);

--- a/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
@@ -150,3 +150,39 @@ test('throw in makeContract call', async t => {
   const dump = await main(['throwInMakeContract', [3, 0, 0]]);
   t.deepEqual(dump.log, thrownExceptionInMakeContractILog);
 });
+
+const happyTerminationLog = [
+  '=> alice is set up',
+  '=> alice.doHappyTermintion called',
+  'happy termination saw "Success"',
+];
+
+test('happy termination path', async t => {
+  const dump = await main(['happyTermination', [3, 0, 0]]);
+  t.deepEqual(dump.log, happyTerminationLog);
+});
+
+const happyTerminationWOffersLog = [
+  '=> alice is set up',
+  '=> alice.doHappyTerminationWOffers called',
+  'Swap outcome resolves to an invitation: [Alleged: presence o-72]',
+  'happy termination saw "Success"',
+  'second moolaPurse: balance {"brand":{},"value":5}',
+  'second simoleanPurse: balance {"brand":{},"value":0}',
+];
+
+test('happy termination with offers path', async t => {
+  const dump = await main(['happyTerminationWOffers', [5, 0, 0]]);
+  t.deepEqual(dump.log, happyTerminationWOffersLog);
+});
+
+const sadTerminationLog = [
+  '=> alice is set up',
+  '=> alice.doSadTermintion called',
+  'sad termination saw reject "Sadness"',
+];
+
+test('sad termination path', async t => {
+  const dump = await main(['sadTermination', [3, 0, 0]]);
+  t.deepEqual(dump.log, sadTerminationLog);
+});

--- a/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
@@ -185,7 +185,7 @@ const doHappyTerminationRefusesContactLog = [
   'can\'t make more invitations because "Error: vat terminated"',
 ];
 
-test.only('happy termination refuses contact path', async t => {
+test('happy termination refuses contact path', async t => {
   const dump = await main(['doHappyTerminationRefusesContact', [5, 0, 0]]);
   t.deepEqual(dump.log, doHappyTerminationRefusesContactLog);
 });

--- a/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
@@ -165,7 +165,8 @@ test('happy termination path', async t => {
 const happyTerminationWOffersLog = [
   '=> alice is set up',
   '=> alice.doHappyTerminationWOffers called',
-  'Swap outcome resolves to an invitation: [Alleged: presence o-72]',
+  'seat has been exited: [object Promise]',
+  'Swap outcome rejected before fulfillment: "Error: vat terminated"',
   'happy termination saw "Success"',
   'second moolaPurse: balance {"brand":{},"value":5}',
   'second simoleanPurse: balance {"brand":{},"value":0}',
@@ -174,6 +175,19 @@ const happyTerminationWOffersLog = [
 test('happy termination with offers path', async t => {
   const dump = await main(['happyTerminationWOffers', [5, 0, 0]]);
   t.deepEqual(dump.log, happyTerminationWOffersLog);
+});
+
+const doHappyTerminationRefusesContactLog = [
+  '=> alice is set up',
+  '=> alice.doHappyTerminationWOffers called',
+  'offer correctly refused: "Error: No further offers are accepted"',
+  'happy termination saw "Success"',
+  'can\'t make more invitations because "Error: vat terminated"',
+];
+
+test('happy termination refuses contact path', async t => {
+  const dump = await main(['doHappyTerminationRefusesContact', [5, 0, 0]]);
+  t.deepEqual(dump.log, doHappyTerminationRefusesContactLog);
 });
 
 const sadTerminationLog = [

--- a/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
@@ -153,7 +153,7 @@ test('throw in makeContract call', async t => {
 
 const happyTerminationLog = [
   '=> alice is set up',
-  '=> alice.doHappyTermintion called',
+  '=> alice.doHappyTermination called',
   'happy termination saw "Success"',
 ];
 
@@ -185,14 +185,14 @@ const doHappyTerminationRefusesContactLog = [
   'can\'t make more invitations because "Error: vat terminated"',
 ];
 
-test('happy termination refuses contact path', async t => {
+test.only('happy termination refuses contact path', async t => {
   const dump = await main(['doHappyTerminationRefusesContact', [5, 0, 0]]);
   t.deepEqual(dump.log, doHappyTerminationRefusesContactLog);
 });
 
 const sadTerminationLog = [
   '=> alice is set up',
-  '=> alice.doSadTermintion called',
+  '=> alice.doSadTermination called',
   'sad termination saw reject "Sadness"',
 ];
 

--- a/packages/zoe/test/swingsetTests/brokenContracts/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/vat-alice.js
@@ -466,7 +466,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
   };
 
   const doHappyTermination = async () => {
-    log(`=> alice.doHappyTermintion called`);
+    log(`=> alice.doHappyTermination called`);
     const installId = installations.crashAutoRefund;
 
     const issuerKeywordRecord = harden({
@@ -487,7 +487,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
         e => log(`happy termination saw reject "${e}"`),
       );
 
-    E(publicFacet).terminateClean('Success');
+    E(publicFacet).zcfShutdown('Success');
   };
 
   // contract attempts a clean shutdown, but there are outstanding seats
@@ -535,7 +535,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
       );
 
     // contract asks for clean termination
-    E(publicFacet).terminateClean('Success');
+    E(publicFacet).zcfShutdown('Success');
     log(`seat has been exited: ${E(seat).hasExited()}`);
 
     const moolaSwapRefund = await E(seat).getPayout('Asset');
@@ -582,7 +582,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
     const swapInvitation = await E(publicFacet).makeSwapInvitation();
 
     // contract asks for clean termination
-    await E(publicFacet).terminateClean('Success');
+    await E(publicFacet).zcfShutdown('Success');
 
     await E(zoe)
       .offer(swapInvitation, swapProposal, aliceSwapPayments)
@@ -596,7 +596,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
   };
 
   const doSadTermination = async () => {
-    log(`=> alice.doSadTermintion called`);
+    log(`=> alice.doSadTermination called`);
     const installId = installations.crashAutoRefund;
 
     const issuerKeywordRecord = harden({
@@ -617,7 +617,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
         e => log(`sad termination saw reject "${e}"`),
       );
 
-    E(publicFacet).terminateFail('Sadness');
+    E(publicFacet).zcfShutdownWithFailure('Sadness');
   };
 
   return harden({

--- a/packages/zoe/test/swingsetTests/zoe/test-zoe.js
+++ b/packages/zoe/test/swingsetTests/zoe/test-zoe.js
@@ -100,6 +100,7 @@ const expectedCoveredCallOkLog = [
   '=> alice.doCreateCoveredCall called',
   '@@ schedule task for:1, currently: 0 @@',
   'The option was exercised. Please collect the assets in your payout.',
+  'covered call was shut down due to "Swap completed."',
   'bobMoolaPurse: balance {"brand":{},"value":3}',
   'bobSimoleanPurse: balance {"brand":{},"value":0}',
   'aliceMoolaPurse: balance {"brand":{},"value":0}',

--- a/packages/zoe/test/swingsetTests/zoe/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-alice.js
@@ -52,9 +52,16 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       UnderlyingAsset: moolaIssuer,
       StrikePrice: simoleanIssuer,
     });
-    const { creatorInvitation: writeCallInvitation } = await E(
+    const { creatorInvitation: writeCallInvitation, adminFacet } = await E(
       zoe,
     ).startInstance(installation, issuerKeywordRecord);
+
+    E(adminFacet)
+      .getVatShutdownPromise()
+      .then(
+        completion => log(`covered call was shut down due to "${completion}"`),
+        reason => log(`covered call failed due to "${reason}"`),
+      );
 
     const proposal = harden({
       give: { UnderlyingAsset: moola(3) },

--- a/packages/zoe/test/unitTests/contractSupport/test-depositTo.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-depositTo.js
@@ -28,7 +28,7 @@ async function setupContract(moolaIssuer, bucksIssuer) {
   const setJig = jig => {
     testJig = jig;
   };
-  const zoe = makeZoe(makeFakeVatAdmin(setJig));
+  const zoe = makeZoe(makeFakeVatAdmin(setJig).admin);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
@@ -29,7 +29,7 @@ async function setupContract(moolaIssuer, bucksIssuer) {
   const setJig = jig => {
     testJig = jig;
   };
-  const zoe = makeZoe(makeFakeVatAdmin(setJig));
+  const zoe = makeZoe(makeFakeVatAdmin(setJig).admin);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/contracts/escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/escrowToVote.js
@@ -88,7 +88,7 @@ const start = zcf => {
           const escrowedAmount = seat.getAmountAllocated('Assets');
           const sumSoFar = tally.get(response);
           tally.set(response, amountMath.add(escrowedAmount, sumSoFar));
-          seat.exit();
+          seat.exit('Thank you for voting');
         }
       }
       electionOpen = false;

--- a/packages/zoe/test/unitTests/contracts/fakeVatAdmin.js
+++ b/packages/zoe/test/unitTests/contracts/fakeVatAdmin.js
@@ -25,6 +25,7 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
             return kit.promise;
           },
           terminate: () => {},
+          terminateOnFailure: () => {},
           adminData: () => {},
         },
       });

--- a/packages/zoe/test/unitTests/contracts/fakeVatAdmin.js
+++ b/packages/zoe/test/unitTests/contracts/fakeVatAdmin.js
@@ -7,14 +7,17 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
   // FakeVatPowers isn't intended to support testing of vat termination, it is
   // provided to allow unit testing of contracts that call zcf.shutdown()
   let exitMessage;
-  let exitWithFailure = false;
+  let hasExited = false;
+  let exitWithFailure;
   const fakeVatPowers = {
     exitVat: completion => {
       exitMessage = completion;
+      hasExited = true;
       exitWithFailure = false;
     },
     exitVatWithFailure: reason => {
       exitMessage = reason;
+      hasExited = true;
       exitWithFailure = true;
     },
   };
@@ -50,7 +53,8 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
   });
   const vatAdminState = {
     getExitMessage: () => exitMessage,
-    getHasExited: () => exitWithFailure,
+    getHasExited: () => hasExited,
+    getExitWithFailure: () => exitWithFailure,
   };
   return { admin, vatAdminState };
 }

--- a/packages/zoe/test/unitTests/contracts/fakeVatAdmin.js
+++ b/packages/zoe/test/unitTests/contracts/fakeVatAdmin.js
@@ -39,7 +39,7 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
             kit.promise.catch(_ => {});
             return kit.promise;
           },
-          terminate: () => {},
+          terminateWithFailure: () => {},
           adminData: () => {},
         },
       });

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -55,18 +55,18 @@ test(`zoe.startInstance no issuerKeywordRecord, no terms`, async t => {
   const { zoe, installation } = await setupZCFTest();
   const result = await E(zoe).startInstance(installation);
   // Note that deepEqual treats all empty objects (handles) as interchangeable.
-  t.deepEqual(Object.getOwnPropertyNames(result), [
+  t.deepEqual(Object.getOwnPropertyNames(result).sort(), [
+    'adminFacet',
     'creatorFacet',
     'creatorInvitation',
     'instance',
     'publicFacet',
-    'adminFacet',
   ]);
   t.deepEqual(result.creatorFacet, {});
   t.deepEqual(result.creatorInvitation, undefined);
   t.deepEqual(result.instance, result.instance);
   t.deepEqual(result.publicFacet, {});
-  t.deepEqual(Object.getOwnPropertyNames(result.adminFacet), [
+  t.deepEqual(Object.getOwnPropertyNames(result.adminFacet).sort(), [
     'getVatShutdownPromise',
     'getVatStats',
   ]);

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -66,6 +66,10 @@ test(`zoe.startInstance no issuerKeywordRecord, no terms`, async t => {
   t.deepEqual(result.creatorInvitation, undefined);
   t.deepEqual(result.instance, result.instance);
   t.deepEqual(result.publicFacet, {});
+  t.deepEqual(Object.getOwnPropertyNames(result.adminFacet), [
+    'getVatShutdownPromise',
+    'getVatStats',
+  ]);
 });
 
 test(`zoe.startInstance - terms, issuerKeywordRecord switched`, async t => {

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -55,12 +55,17 @@ test(`zoe.startInstance no issuerKeywordRecord, no terms`, async t => {
   const { zoe, installation } = await setupZCFTest();
   const result = await E(zoe).startInstance(installation);
   // Note that deepEqual treats all empty objects (handles) as interchangeable.
-  t.deepEqual(result, {
-    creatorFacet: {},
-    creatorInvitation: undefined,
-    instance: result.instance,
-    publicFacet: {},
-  });
+  t.deepEqual(Object.getOwnPropertyNames(result), [
+    'creatorFacet',
+    'creatorInvitation',
+    'instance',
+    'publicFacet',
+    'adminFacet',
+  ]);
+  t.deepEqual(result.creatorFacet, {});
+  t.deepEqual(result.creatorInvitation, undefined);
+  t.deepEqual(result.instance, result.instance);
+  t.deepEqual(result.publicFacet, {});
 });
 
 test(`zoe.startInstance - terms, issuerKeywordRecord switched`, async t => {

--- a/packages/zoe/test/unitTests/zcf/setupZcfTest.js
+++ b/packages/zoe/test/unitTests/zcf/setupZcfTest.js
@@ -14,7 +14,8 @@ export const setupZCFTest = async (issuerKeywordRecord, terms) => {
     zcf = jig.zcf;
   };
   // The contract provides the `zcf` via `setTestJig` upon `start`.
-  const zoe = makeZoe(makeFakeVatAdmin(setZCF).admin);
+  const fakeVatAdmin = makeFakeVatAdmin(setZCF);
+  const zoe = makeZoe(fakeVatAdmin.admin);
   const bundle = await bundleSource(contractRoot);
   const installation = await E(zoe).install(bundle);
   const { creatorFacet, instance } = await E(zoe).startInstance(
@@ -22,5 +23,6 @@ export const setupZCFTest = async (issuerKeywordRecord, terms) => {
     issuerKeywordRecord,
     terms,
   );
-  return { zoe, zcf, instance, installation, creatorFacet };
+  const { vatAdminState } = fakeVatAdmin;
+  return { zoe, zcf, instance, installation, creatorFacet, vatAdminState };
 };

--- a/packages/zoe/test/unitTests/zcf/setupZcfTest.js
+++ b/packages/zoe/test/unitTests/zcf/setupZcfTest.js
@@ -14,7 +14,7 @@ export const setupZCFTest = async (issuerKeywordRecord, terms) => {
     zcf = jig.zcf;
   };
   // The contract provides the `zcf` via `setTestJig` upon `start`.
-  const zoe = makeZoe(makeFakeVatAdmin(setZCF));
+  const zoe = makeZoe(makeFakeVatAdmin(setZCF).admin);
   const bundle = await bundleSource(contractRoot);
   const installation = await E(zoe).install(bundle);
   const { creatorFacet, instance } = await E(zoe).startInstance(

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -615,18 +615,18 @@ test(`zcfSeat from zcf.makeEmptySeatKit - only these properties exist`, async t 
   const expectedMethods = [
     'exit',
     'fail',
-    'getNotifier',
-    'hasExited',
-    'getProposal',
     'getAmountAllocated',
     'getCurrentAllocation',
+    'getNotifier',
+    'getProposal',
+    'hasExited',
     'isOfferSafe',
     'stage',
   ];
   const { zcf } = await setupZCFTest();
   const makeZCFSeat = () => zcf.makeEmptySeatKit().zcfSeat;
   const seat = makeZCFSeat();
-  t.deepEqual(Object.keys(seat), expectedMethods);
+  t.deepEqual(Object.getOwnPropertyNames(seat).sort(), expectedMethods);
 });
 
 test(`zcfSeat.getProposal from zcf.makeEmptySeatKit`, async t => {

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -1180,3 +1180,30 @@ test(`zcf.reallocate 3 seats, rights NOT conserved`, async t => {
   });
   t.deepEqual(zcfSeat3.getCurrentAllocation(), { Whatever: moola(0) });
 });
+
+test(`zcf.shutdown - userSeat exits`, async t => {
+  const { zoe, zcf } = await setupZCFTest({});
+  const { userSeat } = await makeOffer(zoe, zcf);
+  zcf.shutdown('so long');
+  t.deepEqual(await E(userSeat).getPayouts(), {});
+  t.truthy(await E(userSeat).hasExited());
+});
+
+test(`zcf.shutdown - zcfSeat exits`, async t => {
+  const { zoe, zcf } = await setupZCFTest({});
+  const { zcfSeat, userSeat } = await makeOffer(zoe, zcf);
+  t.falsy(zcfSeat.hasExited());
+  await t.falsy(await E(userSeat).hasExited());
+  zcf.shutdown('done');
+  t.truthy(zcfSeat.hasExited());
+  t.truthy(await E(userSeat).hasExited());
+});
+
+test(`zcf.shutdown - no further offers accepted`, async t => {
+  const { zoe, zcf } = await setupZCFTest({});
+  const invitation = await zcf.makeInvitation(() => {}, 'seat');
+  zcf.shutdown('sayonara');
+  await t.throwsAsync(() => E(zoe).offer(invitation), {
+    message: 'No further offers are accepted',
+  });
+});

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -621,6 +621,7 @@ test(`zcfSeat from zcf.makeEmptySeatKit - only these properties exist`, async t 
     'getProposal',
     'hasExited',
     'isOfferSafe',
+    'kickOut', // Deprecated. Remove when we drop kickOut().
     'stage',
   ];
   const { zcf } = await setupZCFTest();
@@ -658,6 +659,19 @@ test(`zcfSeat.hasExited, fail from zcf.makeEmptySeatKit`, async t => {
   t.falsy(zcfSeat.hasExited());
   const msg = `this is the error message`;
   const err = zcfSeat.fail(Error(msg));
+  t.is(err.message, msg);
+  t.truthy(zcfSeat.hasExited());
+  t.truthy(await E(userSeat).hasExited());
+  t.deepEqual(await E(userSeat).getPayouts(), {});
+});
+
+// TODO(1837): remove deprecated kickOut
+test(`zcfSeat.kickOut, fail from zcf.makeEmptySeatKit`, async t => {
+  const { zcf } = await setupZCFTest();
+  const { zcfSeat, userSeat } = zcf.makeEmptySeatKit();
+  t.falsy(zcfSeat.hasExited());
+  const msg = `this is the error message`;
+  const err = zcfSeat.kickOut(Error(msg));
   t.is(err.message, msg);
   t.truthy(zcfSeat.hasExited());
   t.truthy(await E(userSeat).hasExited());

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -1180,30 +1180,3 @@ test(`zcf.reallocate 3 seats, rights NOT conserved`, async t => {
   });
   t.deepEqual(zcfSeat3.getCurrentAllocation(), { Whatever: moola(0) });
 });
-
-test(`zcf.shutdown - userSeat exits`, async t => {
-  const { zoe, zcf } = await setupZCFTest({});
-  const { userSeat } = await makeOffer(zoe, zcf);
-  zcf.shutdown();
-  t.deepEqual(await E(userSeat).getPayouts(), {});
-  t.truthy(await E(userSeat).hasExited());
-});
-
-test(`zcf.shutdown - zcfSeat exits`, async t => {
-  const { zoe, zcf } = await setupZCFTest({});
-  const { zcfSeat, userSeat } = await makeOffer(zoe, zcf);
-  t.falsy(zcfSeat.hasExited());
-  t.falsy(await E(userSeat).hasExited());
-  zcf.shutdown();
-  t.truthy(zcfSeat.hasExited());
-  t.truthy(await E(userSeat).hasExited());
-});
-
-test(`zcf.shutdown - no further offers accepted`, async t => {
-  const { zoe, zcf } = await setupZCFTest({});
-  const invitation = await zcf.makeInvitation(() => {}, 'seat');
-  zcf.shutdown();
-  await t.throwsAsync(() => E(zoe).offer(invitation), {
-    message: 'No further offers are accepted',
-  });
-});

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
@@ -15,7 +15,7 @@ import '../../../exported';
 
 const contractRoot = `${__dirname}/zcfTesterContract`;
 
-test(`zoe - zcfSeat.kickOut() doesn't throw`, async t => {
+test(`zoe - zcfSeat.fail() doesn't throw`, async t => {
   const { moolaIssuer, simoleanIssuer } = setup();
   let testJig;
   const setJig = jig => {
@@ -53,13 +53,13 @@ test(`zoe - zcfSeat.kickOut() doesn't throw`, async t => {
     return 'ok';
   };
 
-  const kickOutSeat = secondSeat => {
-    firstSeat.kickOut(new Error('kicked out first'));
-    throw secondSeat.kickOut(new Error('kicked out second'));
+  const failSeat = secondSeat => {
+    firstSeat.fail(new Error('kicked out first'));
+    throw secondSeat.fail(new Error('kicked out second'));
   };
 
   const invitation1 = await zcf.makeInvitation(grabSeat, 'seat1');
-  const invitation2 = await zcf.makeInvitation(kickOutSeat, 'seat2');
+  const invitation2 = await zcf.makeInvitation(failSeat, 'seat2');
 
   const userSeat1 = await E(zoe).offer(invitation1);
   const userSeat2 = await E(zoe).offer(invitation2);

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
@@ -54,8 +54,8 @@ test(`zoe - zcfSeat.fail() doesn't throw`, async t => {
   };
 
   const failSeat = secondSeat => {
-    firstSeat.fail(new Error('kicked out first'));
-    throw secondSeat.fail(new Error('kicked out second'));
+    firstSeat.fail(new Error('first seat failed'));
+    throw secondSeat.fail(new Error('second seat failed'));
   };
 
   const invitation1 = await zcf.makeInvitation(grabSeat, 'seat1');
@@ -68,7 +68,9 @@ test(`zoe - zcfSeat.fail() doesn't throw`, async t => {
 
   t.deepEqual(await E(userSeat2).getPayouts(), {});
 
-  await t.throwsAsync(E(userSeat2).getOfferResult());
+  await t.throwsAsync(E(userSeat2).getOfferResult(), {
+    message: 'second seat failed',
+  });
   await t.throwsAsync(() => E(userSeat1).tryExit(), {
     message: 'seat has been exited',
   });

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
@@ -21,7 +21,8 @@ test(`zoe - zcfSeat.kickOut() doesn't throw`, async t => {
   const setJig = jig => {
     testJig = jig;
   };
-  const zoe = makeZoe(makeFakeVatAdmin(setJig));
+  const { admin: fakeVatAdminSvc, vatAdminState } = makeFakeVatAdmin(setJig);
+  const zoe = makeZoe(fakeVatAdminSvc);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);
@@ -71,4 +72,5 @@ test(`zoe - zcfSeat.kickOut() doesn't throw`, async t => {
   await t.throwsAsync(() => E(userSeat1).tryExit(), {
     message: 'seat has been exited',
   });
+  t.falsy(vatAdminState.getHasExited());
 });

--- a/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
@@ -400,7 +400,7 @@ test(`zoeHelper w/zcf - swapExact w/shortage`, async t => {
     message:
       'The reallocation failed to conserve rights. Please check the log for more information',
   });
-  t.truthy(zcfSeatA.hasExited(), 'kickout right');
+  t.truthy(zcfSeatA.hasExited(), 'fail right');
   assertPayoutAmount(t, moolaIssuer, await userSeatA.getPayout('A'), moola(0));
   assertPayoutAmount(
     t,
@@ -408,7 +408,7 @@ test(`zoeHelper w/zcf - swapExact w/shortage`, async t => {
     await userSeatA.getPayout('B'),
     simoleans(10),
   );
-  t.truthy(zcfSeatB.hasExited(), 'kickout right');
+  t.truthy(zcfSeatB.hasExited(), 'fail right');
   assertPayoutAmount(
     t,
     simoleanIssuer,
@@ -447,7 +447,7 @@ test(`zoeHelper w/zcf - swapExact w/excess`, async t => {
     message:
       'The reallocation failed to conserve rights. Please check the log for more information',
   });
-  t.truthy(zcfSeatA.hasExited(), 'kickout right');
+  t.truthy(zcfSeatA.hasExited(), 'fail right');
   assertPayoutAmount(t, moolaIssuer, await userSeatA.getPayout('A'), moola(0));
   assertPayoutAmount(
     t,
@@ -455,7 +455,7 @@ test(`zoeHelper w/zcf - swapExact w/excess`, async t => {
     await userSeatA.getPayout('B'),
     simoleans(10),
   );
-  t.truthy(zcfSeatB.hasExited(), 'kickout right');
+  t.truthy(zcfSeatB.hasExited(), 'fail right');
   assertPayoutAmount(
     t,
     simoleanIssuer,
@@ -494,14 +494,14 @@ test(`zoeHelper w/zcf - swapExact w/extra payments`, async t => {
     message:
       'The reallocation failed to conserve rights. Please check the log for more information',
   });
-  t.truthy(zcfSeatA.hasExited(), 'kickout right');
+  t.truthy(zcfSeatA.hasExited(), 'fail right');
   assertPayoutAmount(
     t,
     simoleanIssuer,
     await userSeatA.getPayout('B'),
     simoleans(10),
   );
-  t.truthy(zcfSeatB.hasExited(), 'kickout right');
+  t.truthy(zcfSeatB.hasExited(), 'fail right');
   assertPayoutAmount(
     t,
     simoleanIssuer,


### PR DESCRIPTION
add a message parameter for vat shutdown
wire it through so adminNode.done() fires on shutdown
return adminFacet (`getVatShutdownPromise()`, `getVatStats()`) from `startInstance()`.

fixes: #1454
closes: #1774
fixes: #1453 

 #dapp-encouragement-branch: vatTermination

**API Documentation updates**

 * `zcfSeat.kickOut(reason)` is **deprecated**
 * `zcfSeat.fail(reason)` replaces `zcfSeat.kickOut(reason)` and has the same parameters and explanation.
 * `zcfSeat.exit()` adds a parameter: `zcfSeat.exit(completion)`
    "Completion is usually a string, but is not required to be one"
* `zcf.shutdown() adds a parameter: `zcf.shutdown(completion)`
    "Completion is usually a string, but is not required to be one"
 * `zoe.startInstance()` adds a return value to the list: AdminFacet.    AdminFacet has two methods: `getVatShutdownPromise()` and `getVatStats()`. The first returns a promise that resolves (to reason or completion) when the instance terminates. The second returns statistics about the activity of the vat.

I'll be adding `zcf.stopAcceptingOfferrs()` shortly. see #1834.