### PR TITLE
fix: have liveSlots reject Promise arguments in D() invocations

### DIFF
--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -299,6 +299,14 @@ function build(
     return p;
   }
 
+  function forbidPromises(serArgs) {
+    for (const slot of serArgs.slots) {
+      if (parseVatSlot(slot).type === 'promise') {
+        throw Error(`D() arguments cannot include a Promise`);
+      }
+    }
+  }
+
   function DeviceHandler(slot) {
     return {
       get(target, prop) {
@@ -307,6 +315,7 @@ function build(
         }
         return (...args) => {
           const serArgs = m.serialize(harden(args));
+          forbidPromises(serArgs);
           const ret = syscall.callNow(slot, prop, serArgs);
           insistCapData(ret);
           const retval = m.unserialize(ret);

--- a/packages/SwingSet/test/files-devices/bootstrap-2.js
+++ b/packages/SwingSet/test/files-devices/bootstrap-2.js
@@ -87,17 +87,19 @@ export function buildRootObject(vatPowers, vatParameters) {
         const p = Promise.resolve();
         log('sending Promise');
         try {
-          // this will be rejected immediately, killing the vat shortly
+          // this will be rejected by liveslots before the device is involved
           D(devices.d0).send({ p });
           // shouldn't get here
           log('oops: survived sending Promise');
         } catch (e) {
-          // we aren't currently killed until the end of the crank
           log('good: callNow failed');
         }
       } else {
         throw new Error(`unknown argv mode '${argv[0]}'`);
       }
+    },
+    ping() {
+      return true;
     },
   });
 }

--- a/packages/SwingSet/test/files-devices/bootstrap-4.js
+++ b/packages/SwingSet/test/files-devices/bootstrap-4.js
@@ -1,0 +1,48 @@
+import { assert } from '@agoric/assert';
+import { QCLASS } from '@agoric/marshal';
+import { insistVatType } from '../../src/parseVatSlots';
+
+// to exercise the error we get when syscall.callNow() is given a promise
+// identifier, we must bypass liveslots, which would otherwise protect us
+// against the vat-fatal mistake
+
+function capdata(body, slots = []) {
+  return harden({ body, slots });
+}
+
+function capargs(args, slots = []) {
+  return capdata(JSON.stringify(args), slots);
+}
+
+export default function setup(syscall, state, _helpers, vatPowers) {
+  const { callNow } = syscall;
+  const { testLog } = vatPowers;
+  const dispatch = harden({
+    deliver(facetid, method, args, _result) {
+      if (method === 'bootstrap') {
+        // find the device slot
+        const [_vats, devices] = JSON.parse(args.body);
+        const qnode = devices.d0;
+        assert.equal(qnode[QCLASS], 'slot');
+        const slot = args.slots[qnode.index];
+        insistVatType('device', slot);
+
+        const vpid = 'p+1'; // pretend we're exporting a promise
+        const pnode = { [QCLASS]: 'slot', index: 0 };
+        const callNowArgs = capargs([pnode], [vpid]);
+
+        testLog('sending Promise');
+        try {
+          // this will throw an exception, but is also (eventually) vat-fatal
+          callNow(slot, 'send', callNowArgs);
+          testLog('oops: survived sending Promise');
+        } catch (e) {
+          testLog('good: callNow failed');
+        }
+      } else if (method === 'ping') {
+        testLog('oops: still alive');
+      }
+    },
+  });
+  return dispatch;
+}

--- a/packages/SwingSet/test/test-devices.js
+++ b/packages/SwingSet/test/test-devices.js
@@ -521,9 +521,15 @@ test.serial('syscall.callNow(promise) is vat-fatal', async t => {
         creationOptions: { enableSetup: true },
       },
     },
-    devices: [['d0', require.resolve('./files-devices/device-0'), {}]],
+    devices: {
+      d0: {
+        sourceSpec: require.resolve('./files-devices/device-0'),
+      },
+    },
   };
-  const c = await buildVatController(config, [], t.context.data);
+  const storage = initSwingStore().storage;
+  await initializeSwingset(config, [], storage, t.context.data);
+  const c = await makeSwingsetController(storage, { d0: {} });
   await c.step();
   // if the kernel paniced, that c.step() will reject, and the await will throw
   t.deepEqual(c.dump().log, ['sending Promise', 'good: callNow failed']);

--- a/packages/SwingSet/test/test-devices.js
+++ b/packages/SwingSet/test/test-devices.js
@@ -29,12 +29,14 @@ test.before(async t => {
   const bootstrap1 = await bundleSource(dfile('bootstrap-1'));
   const bootstrap2 = await bundleSource(dfile('bootstrap-2'));
   const bootstrap3 = await bundleSource(dfile('bootstrap-3'));
+  const bootstrap4 = await bundleSource(dfile('bootstrap-4'));
   t.context.data = {
     kernelBundles,
     bootstrap0,
     bootstrap1,
     bootstrap2,
     bootstrap3,
+    bootstrap4,
   };
 });
 
@@ -475,7 +477,7 @@ test.serial('command deliver', async t => {
   t.deepEqual(rejection, { response: 'body' });
 });
 
-test('callNow refuses promises', async t => {
+test.serial('liveslots throws when D() gets promise', async t => {
   const config = {
     bootstrap: 'bootstrap',
     vats: {
@@ -494,6 +496,40 @@ test('callNow refuses promises', async t => {
   await initializeSwingset(config, ['promise1'], storage, t.context.data);
   const c = await makeSwingsetController(storage, { d0: {} });
   await c.step();
+  // When liveslots catches an attempt to send a promise into D(), it throws
+  // a regular error, which the vat can catch.
+  t.deepEqual(c.dump().log, ['sending Promise', 'good: callNow failed']);
+
+  // If that isn't working as expected, and the promise makes it to
+  // syscall.callNow, the translator will notice and kill the vat. We send a
+  // ping() to it to make sure it's still alive. If the vat were dead,
+  // queueToVatExport would throw because the vat was deleted.
+  c.queueToVatExport('bootstrap', 'o+0', 'ping', capargs([]), 'panic');
+  await c.run();
+
+  // If the translator doesn't catch the promise and it makes it to the device,
+  // the kernel will panic, and the c.step() above will reject, so the
+  // 'await c.step()' will throw.
+});
+
+test.serial('syscall.callNow(promise) is vat-fatal', async t => {
+  const config = {
+    bootstrap: 'bootstrap',
+    vats: {
+      bootstrap: {
+        bundle: t.context.data.bootstrap4, // uses setup() to bypass liveslots
+        creationOptions: { enableSetup: true },
+      },
+    },
+    devices: [['d0', require.resolve('./files-devices/device-0'), {}]],
+  };
+  const c = await buildVatController(config, [], t.context.data);
+  await c.step();
   // if the kernel paniced, that c.step() will reject, and the await will throw
   t.deepEqual(c.dump().log, ['sending Promise', 'good: callNow failed']);
+  // now check that the vat was terminated: this should throw an exception
+  // because the entire bootstrap vat was deleted
+  t.throws(() => c.queueToVatExport('bootstrap', 'o+0', 'ping', capargs([])), {
+    message: `vat name bootstrap must exist, but doesn't`,
+  });
 });


### PR DESCRIPTION
This is in addition to the kernel-side translator killing the vat if one gets
through. Using a promise in `syscall.callNow()` is vat-fatal. Using one in
`D()` merely throws an Error (thrown by liveslots before the syscall is
made).

closes #1358