### PR TITLE
refactor: move ERTP interfaces to separate file and pair with assertions of interfaces

### DIFF
--- a/packages/ERTP/src/interfaces.js
+++ b/packages/ERTP/src/interfaces.js
@@ -1,0 +1,16 @@
+/** @type {ERTPKind} */
+export const ERTPKind = {
+  ISSUER: 'issuer',
+  BRAND: 'brand',
+  PURSE: 'purse',
+  PAYMENT: 'payment',
+  MINT: 'mint',
+  // TODO: improve implementation such that spaces can be used in
+  // ERTPKind. Currently we assume that the ERTPKind is the last
+  // element of the interface, after we split on spaces.
+  DEPOSIT_FACET: 'depositFacet',
+};
+
+/** @type {MakeInterface} */
+export const makeInterface = (allegedName, kind) =>
+  `Alleged: ${allegedName} ${kind}`;

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -7,6 +7,11 @@
  */
 
 /**
+ * @typedef {import('@agoric/marshal').InterfaceSpec} InterfaceSpec
+ * @typedef {import('@agoric/marshal').GetInterfaceOf} GetInterfaceOf
+ */
+
+/**
  * @typedef {Object} Amount
  * Amounts are descriptions of digital assets, answering the questions
  * "how much" and "of what kind". Amounts are values labeled with a brand.
@@ -308,4 +313,22 @@
  * @property {(left: Value, right: Value) => Value} doSubtract
  * Return what remains after removing the right from the left. If
  * something in the right was not in the left, we throw an error.
+ */
+
+/**
+ * @typedef {{ISSUER: 'issuer', BRAND: 'brand', PURSE: 'purse', PAYMENT:
+ * 'payment', MINT: 'mint', DEPOSIT_FACET: 'depositFacet' }} ERTPKind
+ */
+
+/**
+ * @callback MakeInterface
+ * Make the interface using the allegedName and kind. The particular
+ * structure may change in the future to be more sophisticated.
+ * Therefore, ERTP and Zoe should not depend on this particular
+ * implementation.
+ *
+ * @param {string} allegedName The allegedName, as passed to
+ *  `makeIssuerKit`
+ * @param {string} kind The ERTPKind
+ * @returns {InterfaceSpec}
  */

--- a/packages/ERTP/test/unitTests/test-interfaces.js
+++ b/packages/ERTP/test/unitTests/test-interfaces.js
@@ -1,0 +1,36 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import test from 'ava';
+import { getInterfaceOf } from '@agoric/marshal';
+import { makeIssuerKit } from '../../src';
+import { ERTPKind, makeInterface } from '../../src/interfaces';
+
+test('interfaces - abstracted implementation', t => {
+  const allegedName = 'bucks';
+  const { issuer, brand, mint, amountMath } = makeIssuerKit(allegedName);
+  t.is(getInterfaceOf(issuer), makeInterface(allegedName, ERTPKind.ISSUER));
+  t.is(getInterfaceOf(brand), makeInterface(allegedName, ERTPKind.BRAND));
+  t.is(getInterfaceOf(mint), makeInterface(allegedName, ERTPKind.MINT));
+  const purse = issuer.makeEmptyPurse();
+  t.is(getInterfaceOf(purse), makeInterface(allegedName, ERTPKind.PURSE));
+  const depositFacet = purse.getDepositFacet();
+  t.is(
+    getInterfaceOf(depositFacet),
+    makeInterface(allegedName, ERTPKind.DEPOSIT_FACET),
+  );
+  const payment = mint.mintPayment(amountMath.make(2));
+  t.is(getInterfaceOf(payment), makeInterface(allegedName, ERTPKind.PAYMENT));
+});
+
+test('interfaces - particular implementation', t => {
+  const allegedName = 'bucks';
+  const { issuer, brand, mint, amountMath } = makeIssuerKit(allegedName);
+  t.is(getInterfaceOf(issuer), 'Alleged: bucks issuer');
+  t.is(getInterfaceOf(brand), 'Alleged: bucks brand');
+  t.is(getInterfaceOf(mint), 'Alleged: bucks mint');
+  const purse = issuer.makeEmptyPurse();
+  t.is(getInterfaceOf(purse), 'Alleged: bucks purse');
+  const depositFacet = purse.getDepositFacet();
+  t.is(getInterfaceOf(depositFacet), 'Alleged: bucks depositFacet');
+  const payment = mint.mintPayment(amountMath.make(2));
+  t.is(getInterfaceOf(payment), 'Alleged: bucks payment');
+});

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { E } from '@agoric/eventual-send';
 import { MathKind, makeIssuerKit } from '../../src';

--- a/packages/marshal/marshal.js
+++ b/packages/marshal/marshal.js
@@ -29,11 +29,14 @@ const remotableToInterface = new WeakMap();
 
 /**
  * Simple semantics, just tell what interface (or undefined) a remotable has.
+ *
  * @callback GetInterfaceOf
  * @param {*} maybeRemotable the value to check
  * @returns {InterfaceSpec|undefined} the interface specification, or undefined
  * if not a Remotable
  */
+
+/** @type {GetInterfaceOf} */
 export function getInterfaceOf(maybeRemotable) {
   return remotableToInterface.get(maybeRemotable);
 }

--- a/packages/marshal/marshal.js
+++ b/packages/marshal/marshal.js
@@ -29,7 +29,7 @@ const remotableToInterface = new WeakMap();
 
 /**
  * Simple semantics, just tell what interface (or undefined) a remotable has.
- *
+ * @callback GetInterfaceOf
  * @param {*} maybeRemotable the value to check
  * @returns {InterfaceSpec|undefined} the interface specification, or undefined
  * if not a Remotable


### PR DESCRIPTION
Move all of the particulars of the ERTP interfaces to a separate file such that the current interface structure is abstracted away. 

This PR no longer adds assertions, since those assumed that `getInterfaceOf` would be passed in. I'll create an issue for a good way of obtaining `getInterfaceOf` (as an import?), and create a new PR that assumes it