### PR TITLE
fix kernel-worker protocol

### DIFF
--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -47,7 +47,6 @@
     "@babel/generator": "^7.6.4",
     "anylogger": "^0.21.0",
     "esm": "^3.2.5",
-    "netstring-stream": "^1.0.1",
     "re2": "^1.10.5",
     "rollup": "^1.23.1",
     "rollup-plugin-node-resolve": "^5.2.0",

--- a/packages/SwingSet/src/kernel/loadVat.js
+++ b/packages/SwingSet/src/kernel/loadVat.js
@@ -68,6 +68,7 @@ export function makeVatLoader(stuff) {
 
   const allowedDynamicOptions = [
     'metered',
+    'managerType',
     'vatParameters',
     'enableSetup',
     'enablePipelining',
@@ -75,6 +76,7 @@ export function makeVatLoader(stuff) {
 
   const allowedStaticOptions = [
     'vatParameters',
+    'managerType',
     'enableSetup',
     'enablePipelining',
   ];

--- a/packages/SwingSet/src/kernel/vatManager/worker-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/worker-subprocess-node.js
@@ -75,8 +75,8 @@ export function makeNodeSubprocessFactory(tools) {
     const { fromChild, toChild, terminate, done } = startSubprocessWorker();
 
     function sendToWorker(msg) {
-      assert(msg instanceof Array);
-      toChild.write(JSON.stringify(msg));
+      assert(Array.isArray(msg));
+      toChild.write(msg);
     }
 
     const {
@@ -114,10 +114,7 @@ export function makeNodeSubprocessFactory(tools) {
       }
     }
 
-    fromChild.on('data', data => {
-      const msg = JSON.parse(data);
-      handleUpstream(msg);
-    });
+    fromChild.on('data', handleUpstream);
 
     parentLog(`instructing worker to load bundle..`);
     sendToWorker(['setBundle', bundle, vatParameters]);

--- a/packages/SwingSet/src/netstring.js
+++ b/packages/SwingSet/src/netstring.js
@@ -12,7 +12,7 @@ export function encode(data) {
 }
 
 // input is a sequence of strings, output is a byte pipe
-export function encoderStream() {
+export function netstringEncoderStream() {
   function transform(chunk, encoding, callback) {
     if (!Buffer.isBuffer(chunk)) {
       throw Error('stream requires Buffers');
@@ -25,6 +25,8 @@ export function encoderStream() {
     }
     callback(err);
   }
+  // (maybe empty) Buffer in, Buffer out. We use writableObjectMode to
+  // indicate that empty input buffers are important
   return new Transform({ transform, writableObjectMode: true });
 }
 
@@ -64,7 +66,7 @@ export function decode(data) {
 }
 
 // input is a byte pipe, output is a sequence of Buffers
-export function decoderStream() {
+export function netstringDecoderStream() {
   let buffered = Buffer.from('');
 
   function transform(chunk, encoding, callback) {
@@ -88,5 +90,8 @@ export function decoderStream() {
     callback(err);
   }
 
+  // Buffer in, Buffer out, except that each output Buffer is precious, even
+  // empty ones, and without readableObjectMode the Stream will discard empty
+  // buffers
   return new Transform({ transform, readableObjectMode: true });
 }

--- a/packages/SwingSet/src/spawnSubprocessWorker.js
+++ b/packages/SwingSet/src/spawnSubprocessWorker.js
@@ -1,8 +1,13 @@
 // this file is loaded by the controller, in the start compartment
 import { spawn } from 'child_process';
-import Netstring from 'netstring-stream';
-
 import { makePromiseKit } from '@agoric/promise-kit';
+import { arrayEncoderStream, arrayDecoderStream } from './worker-protocol';
+import { netstringEncoderStream, netstringDecoderStream } from './netstring';
+
+// Start a subprocess from a given executable, and arrange a bidirectional
+// message channel with a "supervisor" within that process. Return a {
+// toChild, fromChild } pair of Streams which accept/emit hardened Arrays of
+// JSON-serializable data.
 
 // eslint-disable-next-line no-unused-vars
 function parentLog(first, ...args) {
@@ -18,11 +23,12 @@ const stdio = harden(['inherit', 'inherit', 'inherit', 'pipe', 'pipe']);
 export function startSubprocessWorker(execPath, procArgs = []) {
   const proc = spawn(execPath, procArgs, { stdio });
 
-  const toChild = Netstring.writeStream();
-  toChild.pipe(proc.stdio[3]);
+  const toChild = arrayEncoderStream();
+  toChild.pipe(netstringEncoderStream()).pipe(proc.stdio[3]);
   // proc.stdio[4].setEncoding('utf-8');
-  const fromChild = proc.stdio[4].pipe(Netstring.readStream());
-  fromChild.setEncoding('utf-8');
+  const fromChild = proc.stdio[4]
+    .pipe(netstringDecoderStream())
+    .pipe(arrayDecoderStream());
 
   // fromChild.addListener('data', data => parentLog(`fd4 data`, data));
   // toChild.write('hello child');
@@ -43,13 +49,13 @@ export function startSubprocessWorker(execPath, procArgs = []) {
     proc.kill();
   }
 
-  // the Netstring objects don't like being hardened, so we wrap the methods
+  // the Transform objects don't like being hardened, so we wrap the methods
   // that get used
   const wrappedFromChild = {
-    on: (evName, f) => fromChild.on(evName, f),
+    on: (...args) => fromChild.on(...args),
   };
   const wrappedToChild = {
-    write: data => toChild.write(data),
+    write: (...args) => toChild.write(...args),
   };
 
   return harden({

--- a/packages/SwingSet/src/worker-protocol.js
+++ b/packages/SwingSet/src/worker-protocol.js
@@ -1,0 +1,41 @@
+import { Transform } from 'stream';
+
+// Transform objects which convert from hardened Arrays of JSON-serializable
+// data into Buffers suitable for netstring conversion.
+
+export function arrayEncoderStream() {
+  function transform(object, encoding, callback) {
+    if (!Array.isArray(object)) {
+      throw Error('stream requires Arrays');
+    }
+    let err;
+    try {
+      this.push(Buffer.from(JSON.stringify(object)));
+    } catch (e) {
+      err = e;
+    }
+    callback(err);
+  }
+  // Array in, Buffer out, hence writableObjectMode
+  return new Transform({ transform, writableObjectMode: true });
+}
+
+export function arrayDecoderStream() {
+  function transform(buf, encoding, callback) {
+    let err;
+    try {
+      if (!Buffer.isBuffer(buf)) {
+        throw Error('stream expects Buffers');
+      }
+      this.push(JSON.parse(buf));
+    } catch (e) {
+      err = e;
+    }
+    // this Transform is a one-to-one conversion of Buffer into Array, so we
+    // always consume the input each time we're called
+    callback(err);
+  }
+
+  // Buffer in, Array out, hence readableObjectMode
+  return new Transform({ transform, readableObjectMode: true });
+}

--- a/packages/SwingSet/test/test-netstring.js
+++ b/packages/SwingSet/test/test-netstring.js
@@ -1,7 +1,12 @@
 import '@agoric/install-ses'; // adds 'harden' to global
 
 import test from 'ava';
-import { encode, encoderStream, decode, decoderStream } from '../src/netstring';
+import {
+  encode,
+  decode,
+  netstringEncoderStream,
+  netstringDecoderStream,
+} from '../src/netstring';
 
 const umlaut = 'ümlaut';
 const umlautBuffer = Buffer.from(umlaut, 'utf-8');
@@ -51,7 +56,7 @@ test('encode', t => {
 });
 
 test('encode stream', async t => {
-  const e = encoderStream();
+  const e = netstringEncoderStream();
   const chunks = [];
   e.on('data', data => chunks.push(data));
   e.write(Buffer.from(''));
@@ -106,7 +111,7 @@ test('decode', t => {
 });
 
 test('decode stream', async t => {
-  const d = decoderStream();
+  const d = netstringDecoderStream();
   function write(s) {
     d.write(Buffer.from(s));
   }

--- a/packages/SwingSet/test/test-worker-protocol.js
+++ b/packages/SwingSet/test/test-worker-protocol.js
@@ -1,0 +1,76 @@
+import '@agoric/install-ses'; // adds 'harden' to global
+
+import test from 'ava';
+import { arrayEncoderStream, arrayDecoderStream } from '../src/worker-protocol';
+import {
+  encode,
+  netstringEncoderStream,
+  netstringDecoderStream,
+} from '../src/netstring';
+
+test('arrayEncoderStream', async t => {
+  const e = arrayEncoderStream();
+  const chunks = [];
+  e.on('data', data => chunks.push(data));
+  e.write([]);
+
+  function eq(expected) {
+    t.deepEqual(
+      chunks.map(buf => buf.toString()),
+      expected,
+    );
+  }
+  eq([`[]`]);
+
+  e.write(['command', { foo: 1 }]);
+  eq([`[]`, `["command",{"foo":1}]`]);
+});
+
+test('encode stream', async t => {
+  const aStream = arrayEncoderStream();
+  const nsStream = netstringEncoderStream();
+  aStream.pipe(nsStream);
+  const chunks = [];
+  nsStream.on('data', data => chunks.push(data));
+  function eq(expected) {
+    t.deepEqual(
+      chunks.map(buf => buf.toString()),
+      expected,
+    );
+  }
+
+  aStream.write([1]);
+  eq(['3:[1],']);
+
+  aStream.write(['command', { foo: 4 }]);
+  eq(['3:[1],', '21:["command",{"foo":4}],']);
+});
+
+test('decode stream', async t => {
+  const nsStream = netstringDecoderStream();
+  const aStream = arrayDecoderStream();
+  nsStream.pipe(aStream);
+  function write(s) {
+    nsStream.write(Buffer.from(s));
+  }
+
+  const msgs = [];
+  aStream.on('data', msg => msgs.push(msg));
+
+  function eq(expected) {
+    t.deepEqual(msgs, expected);
+  }
+
+  let buf = encode(Buffer.from(JSON.stringify([1])));
+  write(buf.slice(0, 1));
+  eq([]);
+  write(buf.slice(1));
+  eq([[1]]);
+  msgs.pop();
+
+  buf = encode(Buffer.from(JSON.stringify(['command', { foo: 2 }])));
+  write(buf.slice(0, 4));
+  eq([]);
+  write(buf.slice(4));
+  eq([['command', { foo: 2 }]]);
+});

--- a/packages/SwingSet/test/workers/test-worker.js
+++ b/packages/SwingSet/test/workers/test-worker.js
@@ -12,38 +12,31 @@ maybeTestXS('xs vat manager', async t => {
   const config = await loadBasedir(__dirname);
   config.vats.target.creationOptions = { managerType: 'xs-worker' };
   const c = await buildVatController(config, []);
+  t.teardown(c.shutdown);
 
   await c.run();
   t.is(c.kpStatus(c.bootstrapResult), 'fulfilled');
   t.deepEqual(c.dump().log, ['testLog works']);
-
-  await c.shutdown();
 });
 
-// XXX Test temporarily disabled on account of breakage due to some kind of
-// mysterious node worker mysteriousity.
-test.skip('nodeWorker vat manager', async t => {
+test('nodeWorker vat manager', async t => {
   const config = await loadBasedir(__dirname);
   config.vats.target.creationOptions = { managerType: 'nodeWorker' };
   const c = await buildVatController(config, []);
+  t.teardown(c.shutdown);
 
   await c.run();
   t.is(c.kpStatus(c.bootstrapResult), 'fulfilled');
   t.deepEqual(c.dump().log, ['testLog works']);
-
-  await c.shutdown();
 });
 
-/* // disabling for now due to possible buffering issue on MacOS
 test('node-subprocess vat manager', async t => {
   const config = await loadBasedir(__dirname);
   config.vats.target.creationOptions = { managerType: 'node-subprocess' };
   const c = await buildVatController(config, []);
+  t.teardown(c.shutdown);
 
   await c.run();
   t.is(c.kpStatus(c.bootstrapResult), 'fulfilled');
   t.deepEqual(c.dump().log, ['testLog works']);
-
-  await c.shutdown();
 });
-*/

--- a/yarn.lock
+++ b/yarn.lock
@@ -7012,13 +7012,6 @@ neo-async@^2.6.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
-netstring-stream@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/netstring-stream/-/netstring-stream-1.0.1.tgz#d1babecbc4715428154d2956201bc8be3a526729"
-  integrity sha512-/lXoL4KEi8Cty/AsjPkDF7S/cPaHSDMU8PU4NbJNDbW7EhMIb8o6JJA9BD4LJPqPBchpEEoKAluI+BxuqJkR9g==
-  dependencies:
-    through2 "^2.0.3"
-
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
@@ -10174,7 +10167,7 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
-through2@^2.0.0, through2@^2.0.2, through2@^2.0.3:
+through2@^2.0.0, through2@^2.0.2:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
   integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==


### PR DESCRIPTION
The NPM `netstring-stream` package is broken: the decoder corrupts large netstring frames which span multiple inbound chunks (basically anything bigger than 8kB, depending on the OS and other factors beyond our control). This uses our new local implementation, which should tolerate this properly.

It also moves the "command-array to JSON to Buffer" translation into another `Transform` stream object, which looks tidier.

Finally it reenables the pipe-using worker tests, since I believe the netstring problem was the reason they were failing on macOS, and they ought to pass on all platforms now.

@kriskowal please review my usage of Stream and Transform. My intention was to use the local idioms, but I'm not from around here so I don't know if `Transform` is in fact the local idiom, nor if I'm using it right. If there's a relatively simple way to write a non-Stream-based layer that can be composed similarly, let me know and I'll do that instead. If we stick with this implementation, I'm mainly worried about:

* the use of `objectMode: true` in the right places to say we expect an Array instead of a byte pipe and Bufers
* the way I'm `.pipe()`ing the streams together: I was expecting things to compose more easily than they did (I named the file `worker-protocol.js` because I expected it to import+hide `netstring` and export a single `Transform` that does both the Array serialization and the netstring wrapping, but I found that the caller really wanted to do `.pipe` on one end and `.on('data')` on the other, so returning a single object would have required a bunch of delicate wrapping, and the `multipipe` package didn't seem to do the complete job).
* I had to remove a `.setEncoding('utf-8')` call on the FD streams, as it seemed to interfere with the `objectMode: true` that I needed. I *think* that's right, but to be honest I don't really know what that `.setEncoding` was affecting.

@dckc please look at the kernel side of the kernel-worker protocol (`worker-subprocess-node.js`, `subprocessSupervisor.js`) to see if I did anything that might not match what the xs-worker is expecting. The tests pass.

@FUDCo general review of all things swingset, and keeping you up-to-date on the worker interface
