### PR TITLE
Improves the error messages if a Zoe invitation is required but not provided

### DIFF
--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -251,3 +251,13 @@
  * @param {IssuerRecord} issuerRecord
  * @returns {IssuerRecord}
  */
+
+/**
+ * @callback GetAmountOfInvitationThen
+ * Get the amount of an invitation and then call the `onFulfilled`
+ * function. If the invitation is not a Zoe invitation, the promise
+ * rejects with a helpful error message and `onFulfilled` is not called.
+ * @param {ERef<Invitation>} invitationP
+ * @param {(amount: Amount) => any} onFulfilled
+ * @returns {any} the result of `onFulfilled`
+ */

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -62,9 +62,7 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
     return installation;
   };
 
-  /**
-   * @type {GetAmountOfInvitationThen}
-   */
+  /** @type {GetAmountOfInvitationThen} */
   const getAmountOfInvitationThen = async (invitationP, onFulfilled) => {
     const onRejected = () =>
       assert.fail(details`A Zoe invitation is required, not ${invitationP}`);

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -62,6 +62,17 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
     return installation;
   };
 
+  /**
+   * @type {GetAmountOfInvitationThen}
+   */
+  const getAmountOfInvitationThen = async (invitationP, onFulfilled) => {
+    const onRejected = () =>
+      assert.fail(details`A Zoe invitation is required, not ${invitationP}`);
+    return E(invitationKit.issuer)
+      .getAmountOf(invitationP)
+      .then(onFulfilled, onRejected);
+  };
+
   /** @type {ZoeService} */
   const zoeService = {
     getInvitationIssuer: () => invitationKit.issuer,
@@ -71,18 +82,18 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
     getBrands: instance => instanceToInstanceAdmin.get(instance).getBrands(),
     getIssuers: instance => instanceToInstanceAdmin.get(instance).getIssuers(),
     getTerms: instance => instanceToInstanceAdmin.get(instance).getTerms(),
-    getInstance: invitation =>
-      E(invitationKit.issuer)
-        .getAmountOf(invitation)
-        .then(amount => amount.value[0].instance),
-    getInstallation: invitation =>
-      E(invitationKit.issuer)
-        .getAmountOf(invitation)
-        .then(amount => amount.value[0].installation),
-    getInvitationDetails: invitation =>
-      E(invitationKit.issuer)
-        .getAmountOf(invitation)
-        .then(amount => amount.value[0]),
+    getInstance: invitation => {
+      const onFulfilled = amount => amount.value[0].instance;
+      return getAmountOfInvitationThen(invitation, onFulfilled);
+    },
+    getInstallation: invitation => {
+      const onFulfilled = amount => amount.value[0].installation;
+      return getAmountOfInvitationThen(invitation, onFulfilled);
+    },
+    getInvitationDetails: invitation => {
+      const onFulfilled = amount => amount.value[0];
+      return getAmountOfInvitationThen(invitation, onFulfilled);
+    },
     startInstance: async (
       installation,
       uncleanIssuerKeywordRecord = harden({}),
@@ -367,82 +378,95 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
       uncleanProposal = harden({}),
       paymentKeywordRecord = harden({}),
     ) => {
-      return invitationKit.issuer.burn(invitation).then(invitationAmount => {
-        assert(
-          invitationAmount.value.length === 1,
-          'Only one invitation can be redeemed at a time',
-        );
-        const {
-          value: [{ instance, handle: invitationHandle }],
-        } = invitationAmount;
-        const instanceAdmin = instanceToInstanceAdmin.get(instance);
-        assert(!instanceAdmin.hasShutdown(), `No further offers are accepted`);
-
-        const proposal = cleanProposal(getAmountMath, uncleanProposal);
-        const { give, want } = proposal;
-        const giveKeywords = Object.keys(give);
-        const wantKeywords = Object.keys(want);
-        const proposalKeywords = harden([...giveKeywords, ...wantKeywords]);
-
-        const paymentDepositedPs = proposalKeywords.map(keyword => {
-          if (giveKeywords.includes(keyword)) {
-            // We cannot trust the amount in the proposal, so we use our
-            // cleaned proposal's amount that should be the same.
-            const giveAmount = proposal.give[keyword];
-            const purse = brandToPurse.get(giveAmount.brand);
-            return E.when(paymentKeywordRecord[keyword], payment =>
-              E(purse).deposit(payment, giveAmount),
-            );
-            // eslint-disable-next-line no-else-return
-          } else {
-            // payments outside the give: clause are ignored.
-            return getAmountMath(proposal.want[keyword].brand).getEmpty();
-          }
-        });
-
-        return Promise.all(paymentDepositedPs).then(amountsArray => {
-          const initialAllocation = arrayToObj(amountsArray, proposalKeywords);
-
-          const offerResultPromiseKit = makePromiseKit();
-          // Don't trigger Node.js's UnhandledPromiseRejectionWarning
-          offerResultPromiseKit.promise.catch(_ => {});
-          const exitObjPromiseKit = makePromiseKit();
-          // Don't trigger Node.js's UnhandledPromiseRejectionWarning
-          exitObjPromiseKit.promise.catch(_ => {});
-          const seatHandle = makeHandle('SeatHandle');
-
-          const { userSeat, notifier, zoeSeatAdmin } = makeZoeSeatAdminKit(
-            initialAllocation,
-            instanceAdmin,
-            proposal,
-            brandToPurse,
-            exitObjPromiseKit.promise,
-            offerResultPromiseKit.promise,
+      return invitationKit.issuer.burn(invitation).then(
+        invitationAmount => {
+          assert(
+            invitationAmount.value.length === 1,
+            'Only one invitation can be redeemed at a time',
+          );
+          const {
+            value: [{ instance, handle: invitationHandle }],
+          } = invitationAmount;
+          const instanceAdmin = instanceToInstanceAdmin.get(instance);
+          assert(
+            !instanceAdmin.hasShutdown(),
+            `No further offers are accepted`,
           );
 
-          seatHandleToZoeSeatAdmin.init(seatHandle, zoeSeatAdmin);
+          const proposal = cleanProposal(getAmountMath, uncleanProposal);
+          const { give, want } = proposal;
+          const giveKeywords = Object.keys(give);
+          const wantKeywords = Object.keys(want);
+          const proposalKeywords = harden([...giveKeywords, ...wantKeywords]);
 
-          const seatData = harden({ proposal, initialAllocation, notifier });
+          const paymentDepositedPs = proposalKeywords.map(keyword => {
+            if (giveKeywords.includes(keyword)) {
+              // We cannot trust the amount in the proposal, so we use our
+              // cleaned proposal's amount that should be the same.
+              const giveAmount = proposal.give[keyword];
+              const purse = brandToPurse.get(giveAmount.brand);
+              return E.when(paymentKeywordRecord[keyword], payment =>
+                E(purse).deposit(payment, giveAmount),
+              );
+              // eslint-disable-next-line no-else-return
+            } else {
+              // payments outside the give: clause are ignored.
+              return getAmountMath(proposal.want[keyword].brand).getEmpty();
+            }
+          });
 
-          instanceAdmin.addZoeSeatAdmin(zoeSeatAdmin);
-          instanceAdmin
-            .tellZCFToMakeSeat(
-              invitationHandle,
-              zoeSeatAdmin,
-              seatData,
-              seatHandle,
-            )
-            .then(({ offerResultP, exitObj }) => {
-              offerResultPromiseKit.resolve(offerResultP);
-              exitObjPromiseKit.resolve(exitObj);
-            })
-            .catch(err => {
-              console.log(err);
-            });
+          return Promise.all(paymentDepositedPs).then(amountsArray => {
+            const initialAllocation = arrayToObj(
+              amountsArray,
+              proposalKeywords,
+            );
 
-          return userSeat;
-        });
-      });
+            const offerResultPromiseKit = makePromiseKit();
+            // Don't trigger Node.js's UnhandledPromiseRejectionWarning
+            offerResultPromiseKit.promise.catch(_ => {});
+            const exitObjPromiseKit = makePromiseKit();
+            // Don't trigger Node.js's UnhandledPromiseRejectionWarning
+            exitObjPromiseKit.promise.catch(_ => {});
+            const seatHandle = makeHandle('SeatHandle');
+
+            const { userSeat, notifier, zoeSeatAdmin } = makeZoeSeatAdminKit(
+              initialAllocation,
+              instanceAdmin,
+              proposal,
+              brandToPurse,
+              exitObjPromiseKit.promise,
+              offerResultPromiseKit.promise,
+            );
+
+            seatHandleToZoeSeatAdmin.init(seatHandle, zoeSeatAdmin);
+
+            const seatData = harden({ proposal, initialAllocation, notifier });
+
+            instanceAdmin.addZoeSeatAdmin(zoeSeatAdmin);
+            instanceAdmin
+              .tellZCFToMakeSeat(
+                invitationHandle,
+                zoeSeatAdmin,
+                seatData,
+                seatHandle,
+              )
+              .then(({ offerResultP, exitObj }) => {
+                offerResultPromiseKit.resolve(offerResultP);
+                exitObjPromiseKit.resolve(exitObj);
+              })
+              .catch(err => {
+                console.log(err);
+              });
+
+            return userSeat;
+          });
+        },
+        () => {
+          throw assert.fail(
+            details`A Zoe invitation is required, not ${invitation}`,
+          );
+        },
+      );
     },
   };
   harden(zoeService);

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -89,11 +89,8 @@ test(`zoe.offer`, async t => {
 
 test(`zoe.offer - no invitation`, async t => {
   const { zoe } = await setupZCFTest();
-  // TODO: improve error message
-  // https://github.com/Agoric/agoric-sdk/issues/1767
-  // @ts-ignore
   await t.throwsAsync(() => E(zoe).offer(), {
-    message: 'payment not found for (a string)\nSee console for error data.',
+    message: `A Zoe invitation is required, not (an undefined)\nSee console for error data.`,
   });
 });
 
@@ -238,11 +235,8 @@ test(`zoe.getInstance`, async t => {
 
 test(`zoe.getInstance - no invitation`, async t => {
   const { zoe } = await setupZCFTest();
-  // TODO: improve error message
-  // https://github.com/Agoric/agoric-sdk/issues/1767
-  // @ts-ignore
   await t.throwsAsync(() => E(zoe).getInstance(), {
-    message: `payment not found for (a string)\nSee console for error data.`,
+    message: `A Zoe invitation is required, not (an undefined)\nSee console for error data.`,
   });
 });
 
@@ -255,11 +249,8 @@ test(`zoe.getInstallation`, async t => {
 
 test(`zoe.getInstallation - no invitation`, async t => {
   const { zoe } = await setupZCFTest();
-  // TODO: improve error message
-  // https://github.com/Agoric/agoric-sdk/issues/1767
-  // @ts-ignore
   await t.throwsAsync(() => E(zoe).getInstallation(), {
-    message: `payment not found for (a string)\nSee console for error data.`,
+    message: `A Zoe invitation is required, not (an undefined)\nSee console for error data.`,
   });
 });
 
@@ -277,10 +268,7 @@ test(`zoe.getInvitationDetails`, async t => {
 
 test(`zoe.getInvitationDetails - no invitation`, async t => {
   const { zoe } = await setupZCFTest();
-  // TODO: improve error message
-  // https://github.com/Agoric/agoric-sdk/issues/1767
-  // @ts-ignore
   await t.throwsAsync(() => E(zoe).getInvitationDetails(), {
-    message: `payment not found for (a string)\nSee console for error data.`,
+    message: `A Zoe invitation is required, not (an undefined)\nSee console for error data.`,
   });
 });


### PR DESCRIPTION
Closes #1767 

Improves the error messages if a Zoe invitation is required but is not provided. Does not use `getInterfaceOf`

This PR is a copy of https://github.com/Agoric/agoric-sdk/pull/1789 but this one will be merged into the right branch, master. 