### PR TITLE
fix(eventual-send): silence unhandled rejection for remote calls

### DIFF
--- a/packages/eventual-send/src/index.js
+++ b/packages/eventual-send/src/index.js
@@ -449,6 +449,10 @@ export function makeHandledPromise() {
         .catch(lose);
     });
 
+    // Workaround for Node.js: silence "Unhandled Rejection" by default when
+    // using the static methods.
+    returnedP.catch(_ => {});
+
     // We return a handled promise with the default unsettled handler.
     // This prevents a race between the above Promise.resolves and
     // pipelining.


### PR DESCRIPTION
This silencing of Node.js unhandled rejections is less onerous for uses of tildot, where `a~.b()~.c` would cause an unhandled rejection warning if `b` rejects unless every use of tildot is wrapped in `.catch`.  This is because the individual static methods each delay the result by a turn, which is too late to avoid the warning.

Note that `HandledPromise`s are not all silenced, only `HandledPromise.applyMethod`, `HandledPromise.get` and friends.
