### PR TITLE
feat: cleanups and fixes to the wallet

### DIFF
--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -812,7 +812,9 @@ export default function buildKernel(
     }
 
     // replay any transcripts
-    console.info('Replaying SwingSet transcripts');
+    // This happens every time, now that initialisation is separated from
+    // execution.
+    console.log('Replaying SwingSet transcripts');
     const oldLength = kernelKeeper.getRunQueueLength();
     for (const vatID of ephemeral.vats.keys()) {
       logStartup(`Replaying transcript of vatID ${vatID}`);

--- a/packages/cosmic-swingset/lib/ag-solo/html/wallet-bridge.html
+++ b/packages/cosmic-swingset/lib/ag-solo/html/wallet-bridge.html
@@ -41,8 +41,16 @@
 
     <button id="launchWallet">Agoric Wallet</button>
     <script type="text/javascript">
-      launchWallet.addEventListener('click', ev => {
+      const popupWallet = () => {
+        launchWallet.classList.add('pulse');
+      };
+
+      const ackWallet = () => {
         launchWallet.classList.remove('pulse');
+      };
+
+      launchWallet.addEventListener('click', ev => {
+        ackWallet();
         alert(`\
 Use the:
 
@@ -50,10 +58,6 @@ Use the:
 
 command-line request to open the Agoric wallet.`);
       });
-
-      const popupWallet = () => {
-        launchWallet.classList.add('pulse');
-      };
 
       const walletPublicURL = new URL(
         `/private/wallet-bridge${location.search}`,
@@ -63,6 +67,7 @@ command-line request to open the Agoric wallet.`);
       const wsQueue = [];
       const dappQueue = [];
       let origin;
+      let popped = false;
       ws.addEventListener('message', ev => {
         let obj;
         try {
@@ -76,6 +81,14 @@ command-line request to open the Agoric wallet.`);
         if (obj.type === 'walletNeedDappApproval') {
           // Let them approve.
           popupWallet();
+          popped = true;
+        } else if (popped && obj.type === 'walletHaveDappApproval') {
+          ackWallet();
+          popped = false;
+        } else if (obj.type === 'walletOfferAdded') {
+          popupWallet();
+        } else if (obj.type === 'walletOfferHandled') {
+          ackWallet();
         }
         if (origin === undefined) {
           dappQueue.push(obj);
@@ -94,10 +107,6 @@ command-line request to open the Agoric wallet.`);
           // The queued messages are raw objects, so JSONify.
           const obj = wsQueue.shift();
           ws.send(JSON.stringify(obj));
-          if (obj.type === 'walletAddOffer') {
-            // Just pop up our corresponding UI.
-            popupWallet();
-          }
         }
       });
 
@@ -127,10 +136,6 @@ command-line request to open the Agoric wallet.`);
         } else {
           // console.log('sending', obj);
           ws.send(JSON.stringify(obj));
-          if (obj.type === 'walletAddOffer') {
-            // Just pop up our corresponding UI.
-            popupWallet();
-          }
         }
       });
     </script>

--- a/packages/cosmic-swingset/lib/ag-solo/html/wallet-bridge.html
+++ b/packages/cosmic-swingset/lib/ag-solo/html/wallet-bridge.html
@@ -41,13 +41,7 @@
 
     <button id="launchWallet">Agoric Wallet</button>
     <script type="text/javascript">
-      const popupWallet = () => {
-        launchWallet.classList.add('pulse');
-      };
-
-      const ackWallet = () => {
-        launchWallet.classList.remove('pulse');
-      };
+      let pendingWalletRequests = 0;
 
       launchWallet.addEventListener('click', ev => {
         ackWallet();
@@ -67,7 +61,6 @@ command-line request to open the Agoric wallet.`);
       const wsQueue = [];
       const dappQueue = [];
       let origin;
-      let popped = false;
       ws.addEventListener('message', ev => {
         let obj;
         try {
@@ -78,17 +71,28 @@ command-line request to open the Agoric wallet.`);
         if (!obj || typeof obj.type !== 'string') {
           return;
         }
-        if (obj.type === 'walletNeedDappApproval') {
-          // Let them approve.
-          popupWallet();
-          popped = true;
-        } else if (popped && obj.type === 'walletHaveDappApproval') {
-          ackWallet();
-          popped = false;
-        } else if (obj.type === 'walletOfferAdded') {
-          popupWallet();
-        } else if (obj.type === 'walletOfferHandled') {
-          ackWallet();
+        // Check if the wallet launcher needs activation.
+        switch (obj.type) {
+          case 'walletNeedDappApproval':
+          case 'walletOfferAdded': {
+            // Encourage them to approve the request.
+            launchWallet.classList.add('pulse');
+            if (pendingWalletRequests <= 0) {
+              pendingWalletRequests = 0;
+            }
+            pendingWalletRequests += 1;
+            break;
+          }
+          case 'walletHaveDappApproval':
+          case 'walletOfferHandled': {
+            // They've approved a request.
+            pendingWalletRequests -= 1;
+            if (pendingWalletRequests <= 0) {
+              pendingWalletRequests = 0;
+              launchWallet.classList.remove('pulse');
+            }
+            break;
+          }
         }
         if (origin === undefined) {
           dappQueue.push(obj);

--- a/packages/dapp-svelte-wallet/api/src/lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-wallet.js
@@ -76,7 +76,6 @@ export async function makeWallet({
   const idToCompiledOfferP = new Map();
   const idToComplete = new Map();
   const idToSeat = new Map();
-  const idToOutcome = new Map();
 
   // Client-side representation of the purses inbox;
   /** @type {Map<string, PursesJSONState>} */
@@ -182,7 +181,8 @@ export async function makeWallet({
               throw e;
             }
           },
-          receive(payment) {
+          async receive(paymentP) {
+            const payment = await paymentP;
             return E(purse).deposit(payment);
           },
           deposit(payment, amount = undefined) {
@@ -246,11 +246,11 @@ export async function makeWallet({
 
   async function updateInboxState(id, offer) {
     // Only sent the uncompiled offer to the client.
-    const {
-      instanceHandleBoardId,
-      installationHandleBoardId,
-      proposalTemplate,
-    } = offer;
+    const { instance, installation, proposalTemplate, ...rest } = offer;
+    if (!instance || !installation) {
+      return;
+    }
+    delete rest.actions;
     // We could get the instanceHandle and installationHandle from the
     // board and store them to prevent having to make this call each
     // time, but if we want the offers to be able to sent to the
@@ -258,19 +258,16 @@ export async function makeWallet({
     // installationHandle in these offer objects because the handles
     // are presences and we don't wish to send presences to the
     // frontend.
-    const instanceHandle = await E(board).getValue(instanceHandleBoardId);
-    const installationHandle = await E(board).getValue(
-      installationHandleBoardId,
-    );
-    const instance = display(instanceHandle);
-    const installation = display(installationHandle);
+    const instanceDisplay = display(instance);
+    const installationDisplay = display(installation);
     const alreadyDisplayed =
       inboxState.has(id) && inboxState.get(id).proposalForDisplay;
 
     const offerForDisplay = {
-      ...offer,
-      instancePetname: instance.petname,
-      installationPetname: installation.petname,
+      ...rest,
+      proposalTemplate,
+      instancePetname: instanceDisplay.petname,
+      installationPetname: installationDisplay.petname,
       proposalForDisplay: displayProposal(alreadyDisplayed || proposalTemplate),
     };
 
@@ -442,8 +439,10 @@ export async function makeWallet({
 
   const addIssuer = async (petnameForBrand, issuerP, makePurse = false) => {
     const { brand, issuer } = await brandTable.initIssuer(issuerP);
-    const issuerBoardId = await E(board).getId(issuer);
-    issuerToBoardId.init(issuer, issuerBoardId);
+    if (!issuerToBoardId.has(issuer)) {
+      const issuerBoardId = await E(board).getId(issuer);
+      issuerToBoardId.init(issuer, issuerBoardId);
+    }
     const addBrandPetname = () => {
       let p;
       const already = brandMapping.valToPetname.has(brand);
@@ -486,8 +485,8 @@ export async function makeWallet({
       depositFacet = actions;
     } else {
       depositFacet = harden({
-        receive(payment) {
-          return E(actions).receive(payment);
+        receive(paymentP) {
+          return E(actions).receive(paymentP);
         },
       });
     }
@@ -620,6 +619,12 @@ export async function makeWallet({
       inviteHandleBoardId, // Keep for backward-compatibility.
       invitationHandleBoardId = inviteHandleBoardId,
     } = offer;
+
+    assert.typeof(
+      invitationHandleBoardId,
+      'string',
+      details`invitationHandleBoardId must be a string`,
+    );
     const { proposal, purseKeywordRecord } = compileProposal(
       offer.proposalTemplate,
     );
@@ -643,8 +648,17 @@ export async function makeWallet({
       harden([inviteValueElems.find(matchInvite)]),
     );
     const inviteP = E(zoeInvitePurse).withdraw(inviteAmount);
+    const { installation, instance } = await E(zoe).getInvitationDetails(
+      inviteP,
+    );
 
-    return { proposal, inviteP, purseKeywordRecord };
+    return {
+      proposal,
+      inviteP,
+      purseKeywordRecord,
+      installation,
+      instance,
+    };
   };
 
   /** @type {Store<string, DappRecord>} */
@@ -747,20 +761,8 @@ export async function makeWallet({
   async function addOffer(rawOffer, requestContext = {}) {
     const dappOrigin =
       requestContext.dappOrigin || requestContext.origin || 'unknown';
-    const {
-      id: rawId,
-      instanceHandleBoardId,
-      installationHandleBoardId,
-    } = rawOffer;
+    const { id: rawId } = rawOffer;
     const id = `${dappOrigin}#${rawId}`;
-    assert(
-      typeof instanceHandleBoardId === 'string',
-      details`instanceHandleBoardId must be a string`,
-    );
-    assert(
-      typeof installationHandleBoardId === 'string',
-      details`installationHandleBoardId must be a string`,
-    );
     const offer = harden({
       ...rawOffer,
       id,
@@ -771,15 +773,35 @@ export async function makeWallet({
     updateInboxState(id, offer);
 
     // Compile the offer
-    idToCompiledOfferP.set(id, await compileOffer(offer));
+    const compiledOfferP = compileOffer(offer);
+    idToCompiledOfferP.set(id, compiledOfferP);
 
     // Our inbox state may have an enriched offer.
     updateInboxState(id, idToOffer.get(id));
+    const { installation, instance } = await compiledOfferP;
+
+    if (idToOffer.has(id)) {
+      idToOffer.set(
+        id,
+        harden({
+          ...idToOffer.get(id),
+          installation,
+          instance,
+        }),
+      );
+      updateInboxState(id, idToOffer.get(id));
+    }
     return id;
   }
 
   function consummated(offer) {
-    return offer.status !== undefined;
+    if (offer.status !== undefined) {
+      return true;
+    }
+    if (offer.actions) {
+      E(offer.actions).handled(offer);
+    }
+    return false;
   }
 
   function declineOffer(id) {
@@ -824,7 +846,7 @@ export async function makeWallet({
       return undefined;
     }
 
-    /** @type {{ outcome?: any, depositedP?: Promise<any[]> }} */
+    /** @type {{ outcome?: any, depositedP?: Promise<any[]>, outcomeDetails?: any }} */
     let ret = {};
     let alreadyResolved = false;
     const rejected = e => {
@@ -870,9 +892,15 @@ export async function makeWallet({
       // it could be an object. We don't do anything currently if it
       // is an object, but we will store it here for future use.
       const outcome = await E(seat).getOfferResult();
-      idToOutcome.set(id, outcome);
+      if (offer.actions) {
+        E(offer.actions).result(offer, outcome);
+      }
 
-      ret = { outcome, depositedP };
+      ret = {
+        outcome,
+        depositedP,
+        outcomeDetails: offer.outcomeDetails,
+      };
 
       // Update status, drop the proposal
       depositedP
@@ -922,11 +950,12 @@ export async function makeWallet({
   };
 
   /**
-   * @param {Payment} payment
+   * @param {ERef<Payment>} paymentP
    * @param {Purse | Petname=} depositTo
    */
-  const addPayment = async (payment, depositTo = undefined) => {
-    // We don't even create the record until we get an alleged brand.
+  const addPayment = async (paymentP, depositTo = undefined) => {
+    // We don't even create the record until we resolve the payment.
+    const payment = await paymentP;
     const brand = await E(payment).getAllegedBrand();
     const depositedPK = makePromiseKit();
 

--- a/packages/dapp-svelte-wallet/api/src/observable.js
+++ b/packages/dapp-svelte-wallet/api/src/observable.js
@@ -12,7 +12,7 @@ export default function makeObservablePurse(E, purse, onFulfilled) {
         .then(depositOnlyFacet => {
           return {
             receive(...args) {
-              E(depositOnlyFacet)
+              return E(depositOnlyFacet)
                 .receive(...args)
                 .then(result => {
                   onFulfilled();

--- a/packages/dapp-svelte-wallet/api/src/wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/wallet.js
@@ -13,6 +13,9 @@ export function buildRootObject(_vatPowers) {
   const bridgeHandles = new Set();
   const offerSubscriptions = new Map();
 
+  const httpSend = (obj, channelHandles) =>
+    E(http).send(JSON.parse(JSON.stringify(obj)), channelHandles);
+
   const pushOfferSubscriptions = (channelHandle, offersStr) => {
     const offers = JSON.parse(offersStr);
     const subs = offerSubscriptions.get(channelHandle);
@@ -26,7 +29,7 @@ export function buildRootObject(_vatPowers) {
             offer.requestContext.origin === origin,
         ),
       );
-      E(http).send(
+      httpSend(
         {
           type: 'walletOfferDescriptions',
           data: result,
@@ -102,13 +105,13 @@ export function buildRootObject(_vatPowers) {
         let handled = false;
         const actions = harden({
           result(offer, outcome) {
-            E(http).send(
+            httpSend(
               {
                 type: 'walletOfferResult',
                 data: {
                   id: offer.id,
-                  outcomeDetails: offer.outcomeDetails,
-                  outcome: `${outcome}`,
+                  dappContext: offer.dappContext,
+                  outcome,
                 },
               },
               [meta.channelHandle],
@@ -119,7 +122,7 @@ export function buildRootObject(_vatPowers) {
               return;
             }
             handled = true;
-            E(http).send(
+            httpSend(
               {
                 type: 'walletOfferHandled',
                 data: offer.id,
@@ -186,7 +189,7 @@ export function buildRootObject(_vatPowers) {
           pursesState = m;
           pursesJSONUpdater.updateState(pursesState);
           if (http) {
-            E(http).send(
+            httpSend(
               {
                 type: 'walletUpdatePurses',
                 data: pursesState,
@@ -206,7 +209,7 @@ export function buildRootObject(_vatPowers) {
           inboxState = m;
           inboxJSONUpdater.updateState(inboxState);
           if (http) {
-            E(http).send(
+            httpSend(
               {
                 type: 'walletUpdateInbox',
                 data: inboxState,
@@ -348,7 +351,7 @@ export function buildRootObject(_vatPowers) {
               dappOrigin,
               () => {
                 needApproval = true;
-                E(http).send(
+                httpSend(
                   {
                     type: 'walletNeedDappApproval',
                     data: {
@@ -361,7 +364,7 @@ export function buildRootObject(_vatPowers) {
               },
             );
             if (needApproval) {
-              E(http).send(
+              httpSend(
                 {
                   type: 'walletHaveDappApproval',
                   data: {

--- a/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
@@ -241,17 +241,12 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
   const inviteHandleBoardId1 = await E(board).getId(inviteHandle);
   await wallet.deposit('Default Zoe invite purse', invite);
 
-  const instanceHandleBoardId = await E(board).getId(instance);
-  const installationHandleBoardId = await E(board).getId(installation);
-
   const formulateBasicOffer = (id, inviteHandleBoardId) =>
     harden({
       // JSONable ID for this offer.  This is scoped to the origin.
       id,
 
       inviteHandleBoardId,
-      instanceHandleBoardId,
-      installationHandleBoardId,
 
       proposalTemplate: {},
     });
@@ -420,8 +415,6 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
     {
       id: 'unknown#1588645041696',
       inviteHandleBoardId: '727995140',
-      instanceHandleBoardId: '371571443',
-      installationHandleBoardId: '1456154132',
       proposalTemplate: {},
       requestContext: { dappOrigin: 'unknown' },
       instancePetname: 'automaticRefund',
@@ -518,8 +511,6 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
     {
       id: 'unknown#1588645041696',
       inviteHandleBoardId: '727995140',
-      instanceHandleBoardId: '371571443',
-      installationHandleBoardId: '1456154132',
       proposalTemplate: {},
       requestContext: { dappOrigin: 'unknown' },
       instancePetname: 'automaticRefund',
@@ -556,8 +547,6 @@ test('lib-wallet offer methods', async t => {
   } = await E(inviteIssuer).getAmountOf(invite);
   const inviteHandleBoardId1 = await E(board).getId(inviteHandle);
   await wallet.deposit('Default Zoe invite purse', invite);
-  const instanceHandleBoardId = await E(board).getId(instance);
-  const installationHandleBoardId = await E(board).getId(installation);
 
   const formulateBasicOffer = (id, inviteHandleBoardId) =>
     harden({
@@ -565,8 +554,6 @@ test('lib-wallet offer methods', async t => {
       id,
 
       inviteHandleBoardId,
-      instanceHandleBoardId,
-      installationHandleBoardId,
 
       proposalTemplate: {
         give: {
@@ -592,8 +579,8 @@ test('lib-wallet offer methods', async t => {
       {
         id: 'unknown#1588645041696',
         inviteHandleBoardId: '727995140',
-        instanceHandleBoardId: '371571443',
-        installationHandleBoardId: '1456154132',
+        instance,
+        installation,
         proposalTemplate: {
           give: { Contribution: { pursePetname: 'Fun budget', value: 1 } },
           exit: { onDemand: null },
@@ -685,8 +672,6 @@ test('lib-wallet offer methods', async t => {
       {
         id: 'unknown#1588645041696',
         inviteHandleBoardId: '727995140',
-        instanceHandleBoardId: '371571443',
-        installationHandleBoardId: '1456154132',
         proposalTemplate: {
           give: { Contribution: { pursePetname: 'Fun budget', value: 1 } },
           exit: { onDemand: null },
@@ -714,9 +699,7 @@ test('lib-wallet offer methods', async t => {
       },
       {
         id: 'unknown#1588645230204',
-        inviteHandleBoardId: '500716545',
-        instanceHandleBoardId: '371571443',
-        installationHandleBoardId: '1456154132',
+        inviteHandleBoardId: '371571443',
         proposalTemplate: {
           give: { Contribution: { pursePetname: 'Fun budget', value: 1 } },
           exit: { onDemand: null },
@@ -756,7 +739,6 @@ test('lib-wallet addOffer for autoswap swap', async t => {
     wallet,
     addLiquidityInvite,
     autoswapInstanceHandle,
-    autoswapInstallationHandle,
     board,
   } = await setupTest();
 
@@ -825,16 +807,9 @@ test('lib-wallet addOffer for autoswap swap', async t => {
   const rawId = '1593482020370';
   const id = `unknown#${rawId}`;
 
-  const instanceHandleBoardId = await E(board).getId(autoswapInstanceHandle);
-  const installationHandleBoardId = await E(board).getId(
-    autoswapInstallationHandle,
-  );
-
   const offer = {
     id: rawId,
     inviteHandleBoardId,
-    instanceHandleBoardId,
-    installationHandleBoardId,
     proposalTemplate: {
       give: {
         In: {

--- a/packages/dapp-svelte-wallet/ui/src/Amount.svelte
+++ b/packages/dapp-svelte-wallet/ui/src/Amount.svelte
@@ -27,9 +27,9 @@
         </b>
       </div>
       {#if brand.petname === 'zoe invite'}
-        {#each value as { instanceHandle: { petname }, inviteDesc }}
+        {#each value as { instance: { petname }, description }}
           <div>instance: <Petname color={false} name={petname} /></div>
-          <div>inviteDesc: {inviteDesc}</div>
+          <div>description: {description}</div>
         {/each}
       {:else}
         {value.map(v => JSON.stringify(v)).join(', ')}

--- a/packages/dapp-svelte-wallet/ui/src/Transaction.svelte
+++ b/packages/dapp-svelte-wallet/ui/src/Transaction.svelte
@@ -17,7 +17,11 @@
     if (!obj) {
       return;
     }
-    let { outcome } = obj;
+    let { outcomeDetails, outcome } = obj;
+    if (outcomeDetails) {
+      // They have opted-in to handling the outcome.
+      return;
+    }
     if (typeof outcome !== 'string') {
       outcome = 'Offer was accepted.';
     }

--- a/packages/dapp-svelte-wallet/ui/src/Transaction.svelte
+++ b/packages/dapp-svelte-wallet/ui/src/Transaction.svelte
@@ -17,8 +17,8 @@
     if (!obj) {
       return;
     }
-    let { outcomeDetails, outcome } = obj;
-    if (outcomeDetails) {
+    let { dappContext, outcome } = obj;
+    if (dappContext) {
       // They have opted-in to handling the outcome.
       return;
     }


### PR DESCRIPTION
* pulse "Agoric Wallet" button when wallet interaction is needed, stop pulsing when the interaction is done
* get an offer's `instance` and `installation` directly from the Zoe invitation, not by gossip from the Dapp
* be more precise with promise and await handling
* propagate `offer.outcomeDetails` via `E(offer.actions).result(offer, outcome)` callback to the Dapp
* if `offer.outcomeDetails` is supplied then the wallet UI does not alert the outcome
* render Zoe invitations correctly in the wallet UI (used to crash)
