### PR TITLE
fix: minor fixes for bootstrap and web server

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
@@ -230,6 +230,9 @@ export function buildRootObject(vatPowers, vatParameters) {
       send(obj, connectionHandles) {
         return E(vats.http).send(obj, connectionHandles);
       },
+      registerURLHandler(handler, path) {
+        return E(vats.http).registerURLHandler(handler, path);
+      },
       registerAPIHandler(handler) {
         return E(vats.http).registerURLHandler(handler, '/api');
       },
@@ -248,6 +251,9 @@ export function buildRootObject(vatPowers, vatParameters) {
     return allComparable(
       harden({
         ...(plugin ? { plugin } : {}),
+        // TODO: Our preferred name is "scratch", but there are many Dapps
+        // that use "uploads".
+        scratch: uploads,
         uploads,
         spawner,
         network: vats.network,

--- a/packages/cosmic-swingset/lib/ag-solo/web.js
+++ b/packages/cosmic-swingset/lib/ag-solo/web.js
@@ -40,8 +40,8 @@ export async function makeHTTPListener(basedir, port, host, rawInboundCommand) {
     // Strip away the query params, as the inbound command device can't handle
     // it and the accessToken is there.
     const parsedURL = new URL(url, 'http://some-host');
-    const query = {};
-    for (const [key, val] of parsedURL.searchParams) {
+    const query = { isQuery: true };
+    for (const [key, val] of parsedURL.searchParams.entries()) {
       if (key !== 'accessToken') {
         query[key] = val;
       }


### PR DESCRIPTION
* expose `E(local.http).registerURLHandler` so that deploy scripts can register handlers for different URLs than just `/api`
* expose `local.uploads` as `local.scratch`, which is the preferred name.  When we make a breaking change to the Dapps, we can remove the `local.uploads` name
* correctly propagate the web query parameters via `meta.query`.  Add `isQuery: true` to ensure there is at least one element and `meta.query` won't be marshalled as a device node.
