### PR TITLE
fix(cosmic-swingset): make REPL history numbers more robust

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/vats/captp.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/captp.js
@@ -9,10 +9,12 @@ export const getCapTPHandler = (
   fallback = undefined,
 ) => {
   const chans = new Map();
-  const doFallback = (method, ...args) =>
-    E(fallback)
-      [method](...args)
-      .catch(_ => {});
+  const doFallback = async (method, ...args) => {
+    if (!fallback) {
+      return {};
+    }
+    return E(fallback)[method](...args);
+  };
   const handler = harden({
     onOpen(obj, meta) {
       const { channelHandle, origin = 'unknown' } = meta || {};

--- a/packages/cosmic-swingset/lib/ag-solo/vats/repl.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/repl.js
@@ -3,6 +3,7 @@
 import { isPromise } from '@agoric/promise-kit';
 import { E } from '@agoric/eventual-send';
 
+import Nat from '@agoric/nat';
 import makeUIAgentMakers from './ui-agent';
 
 // A REPL-specific JSON stringify.
@@ -190,6 +191,7 @@ export function getReplHandler(replObjects, send, vatPowers) {
     doEval(obj, _meta) {
       const { number: histnum, body } = obj;
       console.debug(`doEval`, histnum, body);
+      Nat(histnum);
       if (histnum <= highestHistory) {
         throw new Error(
           `histnum ${histnum} is not larger than highestHistory ${highestHistory}`,
@@ -250,10 +252,10 @@ export function getReplHandler(replObjects, send, vatPowers) {
     },
 
     onMessage(obj, meta) {
-      if (handler[obj.type]) {
-        return handler[obj.type](obj, meta);
+      if (!handler[obj.type]) {
+        return false;
       }
-      return false;
+      return handler[obj.type](obj, meta);
     },
   });
 

--- a/packages/cosmic-swingset/lib/ag-solo/web.js
+++ b/packages/cosmic-swingset/lib/ag-solo/web.js
@@ -66,7 +66,7 @@ export async function makeHTTPListener(basedir, port, host, rawInboundCommand) {
         'from',
         JSON.stringify(obj, undefined, 2),
       );
-      throw (err && err.message) || JSON.stringify(err);
+      throw (err && err.message) || err;
     });
   };
 


### PR DESCRIPTION
Thanks to @sickcodes for pointing out this inconsistent handling of history numbers.

Also cleans up unnecessary JSON serialisation.
