### PR TITLE
Offer result exceptions

### DIFF
--- a/packages/dapp-svelte-wallet/api/src/lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-wallet.js
@@ -928,6 +928,9 @@ export async function makeWallet({
         .catch(rejected);
     } catch (e) {
       console.error('Have error', e);
+      if (offer.actions) {
+        E(offer.actions).error(offer, e);
+      }
       rejected(e);
       throw e;
     }

--- a/packages/dapp-svelte-wallet/api/src/wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/wallet.js
@@ -117,6 +117,19 @@ export function buildRootObject(_vatPowers) {
               [meta.channelHandle],
             );
           },
+          error(offer, reason) {
+            httpSend(
+              {
+                type: 'walletOfferResult',
+                data: {
+                  id: offer.id,
+                  dappContext: offer.dappContext,
+                  error: `${(reason && reason.stack) || reason}`,
+                },
+              },
+              [meta.channelHandle],
+            );
+          },
           handled(offer) {
             if (handled) {
               return;


### PR DESCRIPTION
This minor change ensures that the Websocket wallet client is called with any rejections caused by the offer handler.

Needed to propagate errors to the dapp.
