### PR TITLE
toward types for vatWorker protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "eslint-plugin-prettier": "^3.1.2",
     "lerna": "^3.20.2",
     "nyc": "^15.1.0",
-    "prettier": "^1.18.2"
+    "prettier": "^1.18.2",
+    "typescript": "^4.1.2"
   },
   "engines": {
     "node": ">=12.14.1"

--- a/packages/SwingSet/exported.js
+++ b/packages/SwingSet/exported.js
@@ -1,0 +1,1 @@
+import './src/types';

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -60,6 +60,7 @@
   },
   "files": [
     "bin/vat",
+    "exported.js",
     "src/**/*.js"
   ],
   "repository": {

--- a/packages/SwingSet/src/capdata.js
+++ b/packages/SwingSet/src/capdata.js
@@ -1,25 +1,32 @@
+// @ts-check
 import { assert, details } from '@agoric/assert';
 
-/* eslint-disable jsdoc/valid-types,jsdoc/require-returns-check */
+/**
+ * @param {unknown} capdata  The object to be tested
+ * @throws {Error} if, upon inspection, the parameter does not satisfy the above
+ *   criteria.
+ * @returns {CapData}
+ */
+function asCapData(capdata) {
+  assert(capdata !== undefined);
+  assert.typeof(capdata, 'object');
+  const { body, slots } = capdata;
+  assert.typeof(body, 'string', details`capdata has non-string .body ${body}`);
+  assert(Array.isArray(slots), details`capdata has non-Array slots ${slots}`);
+  // TODO check that the .slots array elements are actually strings
+  return capdata;
+}
+
 /**
  * Assert function to ensure that something expected to be a capdata object
  * actually is.  A capdata object should have a .body property that's a string
  * and a .slots property that's an array of strings.
  *
- * @param {any} capdata  The object to be tested
+ * @param {unknown} capdata  The object to be tested
  * @throws {Error} if, upon inspection, the parameter does not satisfy the above
  *   criteria.
- * @returns {asserts capdata is CapData}
+ * @returns {void}
  */
 export function insistCapData(capdata) {
-  assert.typeof(
-    capdata.body,
-    'string',
-    details`capdata has non-string .body ${capdata.body}`,
-  );
-  assert(
-    Array.isArray(capdata.slots),
-    details`capdata has non-Array slots ${capdata.slots}`,
-  );
-  // TODO check that the .slots array elements are actually strings
+  asCapData(capdata);
 }

--- a/packages/SwingSet/src/capdata.js
+++ b/packages/SwingSet/src/capdata.js
@@ -25,8 +25,9 @@ function asCapData(capdata) {
  * @param {unknown} capdata  The object to be tested
  * @throws {Error} if, upon inspection, the parameter does not satisfy the above
  *   criteria.
- * @returns {void}
+ * @returns {asserts capdata is CapData}
  */
 export function insistCapData(capdata) {
   asCapData(capdata);
+  return undefined;
 }

--- a/packages/SwingSet/src/capdata.js
+++ b/packages/SwingSet/src/capdata.js
@@ -5,7 +5,7 @@ import { assert, details } from '@agoric/assert';
  * @param {unknown} capdata  The object to be tested
  * @throws {Error} if, upon inspection, the parameter does not satisfy the above
  *   criteria.
- * @returns {CapData}
+ * @returns {CapData<string>}
  */
 function asCapData(capdata) {
   assert(capdata !== undefined);

--- a/packages/SwingSet/src/index.js
+++ b/packages/SwingSet/src/index.js
@@ -12,3 +12,5 @@ export { buildTimer } from './devices/timer';
 export { buildBridge } from './devices/bridge';
 export { default as buildCommand } from './devices/command';
 export { buildPlugin } from './devices/plugin';
+
+export { asMessage } from './message';

--- a/packages/SwingSet/src/kernel/vatManager/worker-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/worker-subprocess-node.js
@@ -36,6 +36,7 @@ function parentLog(first, ...args) {
  *     getVatKeeper: (id: string) => unknown,
  *   },
  *   testLog: (...args: unknown[]) => void,
+ *   decref: (vatID: unknown, vref: unknown, count: number) => void,
  * }} tools
  * @returns {{
  *   createFromBundle: (id: string, b: Bundle, o: ManagerOptions) => Promise<VatManager>

--- a/packages/SwingSet/src/kernel/vatManager/worker-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/worker-subprocess-node.js
@@ -119,6 +119,11 @@ export function makeNodeSubprocessFactory(tools) {
       toChild.write(msg);
     }
 
+    /**
+     * @typedef { import('@agoric/promise-kit').PromiseRecord<T>} PromiseRecord<T>
+     * @template T
+     */
+
     /** @type { PromiseRecord<void>} */
     const {
       promise: dispatchReadyP,

--- a/packages/SwingSet/src/kernel/vatManager/worker-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/worker-subprocess-node.js
@@ -113,7 +113,7 @@ export function makeNodeSubprocessFactory(tools) {
     // start the worker and establish a connection
     const { fromChild, toChild, terminate, done } = startSubprocessWorker();
 
-    /** @type {(msg: Serializable[]) => void} */
+    /** @type {(msg: unknown[]) => void} */
     function sendToWorker(msg) {
       assert(Array.isArray(msg));
       toChild.write(msg);
@@ -124,7 +124,7 @@ export function makeNodeSubprocessFactory(tools) {
       promise: dispatchReadyP,
       resolve: dispatchIsReady,
     } = makePromiseKit();
-    /** @type {null | ((r: Serializable[]) => void) } */
+    /** @type {null | ((r: unknown[]) => void) } */
     let waiting = null;
 
     /** @type {(data: unknown) => void} */
@@ -169,8 +169,8 @@ export function makeNodeSubprocessFactory(tools) {
     sendToWorker(['setBundle', bundle, vatParameters, virtualObjectCacheSize]);
 
     /**
-     * @param {Serializable[]} delivery
-     * @returns {Promise<Serializable[]>}
+     * @param {unknown[]} delivery
+     * @returns {Promise<unknown[]>}
      */
     function deliver(delivery) {
       parentLog(`sending delivery`, delivery);

--- a/packages/SwingSet/src/message.js
+++ b/packages/SwingSet/src/message.js
@@ -1,5 +1,31 @@
+// @ts-check
 import { assert, details } from '@agoric/assert';
 import { insistCapData } from './capdata';
+
+/**
+ * @param {unknown} message
+ * @returns { Message }
+ */
+export function asMessage(message) {
+  assert(message !== undefined);
+  assert.typeof(message, 'object');
+
+  const { method, args, result } = message;
+  assert.typeof(
+    method,
+    'string',
+    details`message has non-string .method ${method}`,
+  );
+  insistCapData(args);
+  if (result) {
+    assert.typeof(
+      result,
+      'string',
+      details`message has non-string non-null .result ${result}`,
+    );
+  }
+  return message;
+}
 
 /**
  * Assert function to ensure that something expected to be a message object
@@ -7,7 +33,7 @@ import { insistCapData } from './capdata';
  * string, a .args property that's a capdata object, and optionally a .result
  * property that, if present, must be a string.
  *
- * @param {any} message  The object to be tested
+ * @param {unknown} message  The object to be tested
  *
  * @throws {Error} if, upon inspection, the parameter does not satisfy the above
  *   criteria.
@@ -15,17 +41,5 @@ import { insistCapData } from './capdata';
  * @returns {void}
  */
 export function insistMessage(message) {
-  assert.typeof(
-    message.method,
-    'string',
-    details`message has non-string .method ${message.method}`,
-  );
-  insistCapData(message.args);
-  if (message.result) {
-    assert.typeof(
-      message.result,
-      'string',
-      details`message has non-string non-null .result ${message.result}`,
-    );
-  }
+  asMessage(message);
 }

--- a/packages/SwingSet/src/message.js
+++ b/packages/SwingSet/src/message.js
@@ -38,7 +38,7 @@ export function asMessage(message) {
  * @throws {Error} if, upon inspection, the parameter does not satisfy the above
  *   criteria.
  *
- * @returns {void}
+ * @returns {asserts message is Message}
  */
 export function insistMessage(message) {
   asMessage(message);

--- a/packages/SwingSet/src/message.js
+++ b/packages/SwingSet/src/message.js
@@ -42,4 +42,5 @@ export function asMessage(message) {
  */
 export function insistMessage(message) {
   asMessage(message);
+  return undefined;
 }

--- a/packages/SwingSet/src/types.js
+++ b/packages/SwingSet/src/types.js
@@ -35,3 +35,38 @@
  * @typedef {{ state: 'fulfilledToData', data: CapData }} ToData
  * @typedef {{ state: 'rejected', data: CapData }} Rejected
  */
+
+/**
+ * @typedef { import('@agoric/bundle-source').Bundle } Bundle
+ */
+
+/**
+ * @typedef {{
+ *   bundle: Bundle,
+ *   enableSetup: false,
+ * }} HasBundle
+ * @typedef {{
+ *   setup: unknown,
+ *   enableSetup: true,
+ * }} HasSetup
+ *
+ * TODO: metered...
+ * @typedef {{
+ *   managerType: 'local' | 'nodeWorker' | 'node-subprocess' | 'xs-worker',
+ *   metered?: boolean,
+ *   enableInternalMetering?: boolean,
+ *   vatParameters: Serializable,
+ * } & (HasBundle | HasSetup)} ManagerOptions
+ */
+
+/** @typedef { Scalar | Scalar[] | Record<string, Scalar> } Serializable */
+/** @typedef { null | boolean | number | string } Scalar */
+
+/**
+ * @typedef {{
+ *   replayTranscript: () => void,
+ *   setVatSyscallHandler: (h: any) => void,
+ *   deliver: (d: [Serializable, ...Serializable[]]) => Promise<Serializable[]>,
+ *   shutdown: () => Promise<void>,
+ * }} VatManager
+ */

--- a/packages/SwingSet/src/types.js
+++ b/packages/SwingSet/src/types.js
@@ -1,5 +1,37 @@
 /**
+ * see also docs/vat-worker.md
+ */
+
+/**
  * @typedef {Object} CapData
  * @property {string} body
  * @property {Array<string>} slots
+ */
+
+/**
+ * @typedef {{
+ *   method: string,
+ *   args: CapData,
+ *   result: string | null,
+ * }} Message
+ */
+
+/**
+ * @typedef { DeliveryMessage | DeliveryNotify } Delivery
+ * @typedef { ['message', Reference, Message] } DeliveryMessage
+ * @typedef { ['notify', PromiseReference, Resolution] } DeliveryNotify
+ * vp is the current (final) promise data, rendered in vat form
+ */
+
+/**
+ * @typedef { string } ObjectReference e.g. `o+13`
+ * @typedef { string } PromiseReference e.g. `p-24`
+ * @typedef { ObjectReference | PromiseReference } Reference
+ */
+
+/**
+ * @typedef { ToPresence | ToData | Rejected } Resolution
+ * @typedef {{ state: 'fulfilledToPresence', slot: ObjectReference }} ToPresence
+ * @typedef {{ state: 'fulfilledToData', data: CapData }} ToData
+ * @typedef {{ state: 'rejected', data: CapData }} Rejected
  */

--- a/packages/SwingSet/src/types.js
+++ b/packages/SwingSet/src/types.js
@@ -59,14 +59,11 @@
  * } & (HasBundle | HasSetup)} ManagerOptions
  */
 
-/** @typedef { Scalar | Scalar[] | Record<string, Scalar> } Serializable */
-/** @typedef { null | boolean | number | string } Scalar */
-
 /**
  * @typedef {{
  *   replayTranscript: () => void,
  *   setVatSyscallHandler: (h: any) => void,
- *   deliver: (d: [Serializable, ...Serializable[]]) => Promise<Serializable[]>,
+ *   deliver: (d: [unknown, ...unknown[]]) => Promise<unknown[]>,
  *   shutdown: () => Promise<void>,
  * }} VatManager
  */

--- a/packages/SwingSet/src/types.js
+++ b/packages/SwingSet/src/types.js
@@ -12,7 +12,7 @@
  * @typedef {{
  *   method: string,
  *   args: CapData,
- *   result: string | null,
+ *   result?: string,
  * }} Message
  */
 
@@ -56,6 +56,7 @@
  *   metered?: boolean,
  *   enableInternalMetering?: boolean,
  *   vatParameters: Serializable,
+ *   virtualObjectCacheSize: number,
  * } & (HasBundle | HasSetup)} ManagerOptions
  */
 

--- a/packages/notifier/src/asyncIterableAdaptor.js
+++ b/packages/notifier/src/asyncIterableAdaptor.js
@@ -96,7 +96,7 @@ export const makeAsyncIterableFromNotifier = notifierP => {
  * @template T
  * @param {ERef<AsyncIterator<T>>} asyncIteratorP
  * @param {Partial<IterationObserver<T>>} iterationObserver
- * @returns {Promise<undefined>}
+ * @returns {Promise<void>}
  */
 export const observeIterator = (asyncIteratorP, iterationObserver) => {
   return new Promise(ack => {
@@ -132,7 +132,7 @@ export const observeIterator = (asyncIteratorP, iterationObserver) => {
  * @template T
  * @param {ERef<AsyncIterable<T>>} asyncIterableP
  * @param {Partial<IterationObserver<T>>} iterationObserver
- * @returns {Promise<undefined>}
+ * @returns {Promise<void>}
  */
 export const observeIteration = (asyncIterableP, iterationObserver) => {
   const iteratorP = E(asyncIterableP)[Symbol.asyncIterator]();
@@ -144,7 +144,7 @@ export const observeIteration = (asyncIterableP, iterationObserver) => {
  * @template T
  * @param {Partial<IterationObserver<T>>} iterationObserver
  * @param {ERef<AsyncIterable<T>>} asyncIterableP
- * @returns {Promise<undefined>}
+ * @returns {Promise<void>}
  */
 export const updateFromIterable = (iterationObserver, asyncIterableP) =>
   observeIteration(asyncIterableP, iterationObserver);
@@ -158,7 +158,7 @@ export const updateFromIterable = (iterationObserver, asyncIterableP) =>
  * @template T
  * @param {Partial<IterationObserver<T>>} iterationObserver
  * @param {ERef<Notifier<T>>} notifierP
- * @returns {Promise<undefined>}
+ * @returns {Promise<void>}
  */
 export const updateFromNotifier = (iterationObserver, notifierP) =>
   observeIteration(makeAsyncIterableFromNotifier(notifierP), iterationObserver);

--- a/packages/xs-vat-worker/jsconfig.json
+++ b/packages/xs-vat-worker/jsconfig.json
@@ -1,0 +1,18 @@
+// This file can contain .js-specific Typescript compiler config.
+{
+  "compilerOptions": {
+    "target": "es2020",
+
+    "noEmit": true,
+/*
+    // The following flags are for creating .d.ts files:
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+*/
+    "downlevelIteration": true,
+    "strictNullChecks": true,
+    "moduleResolution": "node",
+  },
+  "include": ["src/**/*.js", "exports.js"],
+}

--- a/packages/xs-vat-worker/jsconfig.json
+++ b/packages/xs-vat-worker/jsconfig.json
@@ -10,9 +10,9 @@
     "declaration": true,
     "emitDeclarationOnly": true,
 */
-    "downlevelIteration": true,
     "strictNullChecks": true,
+    "noImplicitAny": true,
     "moduleResolution": "node",
   },
-  "include": ["src/**/*.js", "exports.js"],
+  "include": ["src/**/*.js", "src/**/*.ts", "exports.js"],
 }

--- a/packages/xs-vat-worker/jsconfig.json
+++ b/packages/xs-vat-worker/jsconfig.json
@@ -11,7 +11,6 @@
     "emitDeclarationOnly": true,
 */
     "strictNullChecks": true,
-    "noImplicitAny": true,
     "moduleResolution": "node",
   },
   "include": ["src/**/*.js", "src/**/*.ts", "exports.js"],

--- a/packages/xs-vat-worker/package.json
+++ b/packages/xs-vat-worker/package.json
@@ -12,10 +12,10 @@
     "build:xs-lin": "make",
     "test": "ava",
     "build": "exit 0",
-    "lint-fix": "eslint --fix '**/*.{js,jsx}'",
-    "lint-check": "eslint '**/*.{js,jsx}'",
-    "lint-fix-jessie": "eslint -c '.eslintrc-jessie.js' --fix '**/*.{js,jsx}'",
-    "lint-check-jessie": "eslint -c '.eslintrc-jessie.js' '**/*.{js,jsx}'"
+    "lint-fix": "yarn lint --fix",
+    "lint-check": "yarn lint",
+    "lint": "yarn lint:types && eslint '**/*.js'",
+    "lint:types": "tsc -p jsconfig.json"
   },
   "ava": {
     "files": [

--- a/packages/xs-vat-worker/src/compartment.d.ts
+++ b/packages/xs-vat-worker/src/compartment.d.ts
@@ -21,32 +21,32 @@ type CompartmentConstructorOptions = {
   //   nowHook(): number; // Use for both Date.now() and new Date(),
   // Supplied during Module instance creation instead of option
   //   hasSourceTextAvailableHook(scriptOrModule): bool; // Used for censorship
-  resolveHook(name: string, referrer: FullSpecifier): FullSpecifier
+  resolveHook?: (name: string, referrer: FullSpecifier) => FullSpecifier
 
   // timing
   // importHook delegates to importNowHook FIRST,
   // they share a memo cache
   // order to ensures importNow never allows async value of import
   // to be accessed prior to any attached promise
-  importHook(fullSpec: FullSpecifier): Promise<StaticModuleRecord>;
-  importNowHook(fullSpec: FullSpecifier): StaticModuleRecord?;
+  importHook?: (fullSpec: FullSpecifier) => Promise<StaticModuleRecord>;
+  importNowHook?: (fullSpec: FullSpecifier) => StaticModuleRecord?;
 
   // copy own props after return
-  importMetaHook(fullSpec: FullSpecifier): object
+  importMetaHook?: (fullSpec: FullSpecifier) => object
 
   // e.g.: 'fr-FR' - Affects appropriate ECMA-402 APIs within Compartment
-  localeHook(): string;
+  localeHook?: () => string;
   // This is important to be able to override for deterministic testing and such
-  localTZAHook(): string;
+  localTZAHook?: () => string;
 
   // determines if the fn is acting as an "eval" function
-  isDirectEvalHook(evalFunctionRef: any): boolean;
+  isDirectEvalHook?: (evalFunctionRef: any) => boolean;
 
   // prep for trusted types non-string
-  canCompileHook(source: any, {
+  canCompileHook?: (source: any, /*@@not sure how to do this in ts: {
     evaluator: functionRef, // can be a value from isDirectEvalHook
-    isDirect?: boolean
-  }): boolean; // need to allow mimicing CSP including nonces
+    isDirect?: boolean,
+  }*/) => boolean; // need to allow mimicing CSP including nonces
 };
 // Exposed on global object
 // new Constructor per Compartment
@@ -54,7 +54,7 @@ type CompartmentConstructorOptions = {
 // CreateRealm needs to be refactored to take params
 //  - intrinsics: an intrinsics record from
 //                6.1.7.4 Well-Known Intrinsic Objects
-interface Compartment {
+class Compartment {
   constructor(
     // extra bindings added to the global
     endowments?: {
@@ -90,4 +90,5 @@ interface Compartment {
   // the `moduleMap` Compartment constructor argument, without importing (and
   // consequently executing) the module.
   module(specifier: string): ModuleNamespace;
-  }
+}
+

--- a/packages/xs-vat-worker/src/compartment.d.ts
+++ b/packages/xs-vat-worker/src/compartment.d.ts
@@ -1,0 +1,93 @@
+// https://github.com/tc39/proposal-compartments b420786 on Jul 6
+
+// Shared space by Realm
+type FullSpecifier = string;
+type ModuleNamespace = object;
+// Used to create a Reusable Instance factory for Module Records
+// exotic
+interface StaticModuleRecord {
+  // intend to add reflection of import/export bindings
+
+  // needs to allow duplicates
+  staticImports(): {specifier: string, exportNames}[];
+}
+interface SourceTextStaticModuleRecord extends StaticModuleRecord {
+  // no coerce
+  constructor(source: string);
+}
+type CompartmentConstructorOptions = {
+  // JF has a better way for:
+  //   randomHook(): number; // Use for Math.random()
+  //   nowHook(): number; // Use for both Date.now() and new Date(),
+  // Supplied during Module instance creation instead of option
+  //   hasSourceTextAvailableHook(scriptOrModule): bool; // Used for censorship
+  resolveHook(name: string, referrer: FullSpecifier): FullSpecifier
+
+  // timing
+  // importHook delegates to importNowHook FIRST,
+  // they share a memo cache
+  // order to ensures importNow never allows async value of import
+  // to be accessed prior to any attached promise
+  importHook(fullSpec: FullSpecifier): Promise<StaticModuleRecord>;
+  importNowHook(fullSpec: FullSpecifier): StaticModuleRecord?;
+
+  // copy own props after return
+  importMetaHook(fullSpec: FullSpecifier): object
+
+  // e.g.: 'fr-FR' - Affects appropriate ECMA-402 APIs within Compartment
+  localeHook(): string;
+  // This is important to be able to override for deterministic testing and such
+  localTZAHook(): string;
+
+  // determines if the fn is acting as an "eval" function
+  isDirectEvalHook(evalFunctionRef: any): boolean;
+
+  // prep for trusted types non-string
+  canCompileHook(source: any, {
+    evaluator: functionRef, // can be a value from isDirectEvalHook
+    isDirect?: boolean
+  }): boolean; // need to allow mimicing CSP including nonces
+};
+// Exposed on global object
+// new Constructor per Compartment
+//
+// CreateRealm needs to be refactored to take params
+//  - intrinsics: an intrinsics record from
+//                6.1.7.4 Well-Known Intrinsic Objects
+interface Compartment {
+  constructor(
+    // extra bindings added to the global
+    endowments?: {
+      [globalPropertyName: string]: any
+    },
+    // need to figure out module attributes as it progresses
+    // maps child specifier to parent specifier
+    moduleMap?: {[key: FullSpecifier]: FullSpecifier | ModuleNamespace},
+    // including hooks like isDirectEvalHook
+    options?: CompartmentConstructorOptions
+  ): Compartment // an exotic compartment object
+
+  // access this compartment's global object, getter
+  globalThis: object;
+
+  // do an eval in this compartment
+  // default is strict indirect eval
+  evaluate(
+    // trusted types prep means use of `any`
+    src: any,
+    // FUTURE:
+    //   for other eval goals like Module, need to discuss import()/eval() to
+    //   get other Goals vs an option
+    // options?: object
+  ): any;
+
+  // Return signature differs to allow avoiding then() exports
+  // Used to ensure ability to be compatible with static import
+  async import(specifier: string): Promise<{namespace: ModuleNamespace}>;
+  // Desired by TC53
+  importNow(specifier: string): ModuleNamespace;
+  // Necessary to thread a module exports namespace from this compartment into
+  // the `moduleMap` Compartment constructor argument, without importing (and
+  // consequently executing) the module.
+  module(specifier: string): ModuleNamespace;
+  }

--- a/packages/xs-vat-worker/src/console.js
+++ b/packages/xs-vat-worker/src/console.js
@@ -1,20 +1,29 @@
 /** console for xs platform */
-const harden = x => Object.freeze(x, true);
+// @ts-check
+const { freeze } = Object;
 
-const text = it => (typeof it === 'object' ? JSON.stringify(it) : `${it}`);
+/** @type { (it: unknown) => string } */
+const text = it => ((typeof it === 'object' ? JSON.stringify(it) : `${it}`));
+/** @type { (...things: unknown[]) => string } */
 const combine = (...things) => `${things.map(text).join(' ')}\n`;
 
+/**
+ * @param {(txt: string) => void} write_
+ */
 export function makeConsole(write_) {
   const write = write_;
-  return harden({
+  return freeze({
+    /** @type { (...things: unknown[]) => void } */
     log(...things) {
       write(combine(...things));
     },
     // node.js docs say this is just an alias for error
+    /** @type { (...things: unknown[]) => void } */
     warn(...things) {
       write(combine('WARNING: ', ...things));
     },
     // node docs say this goes to stderr
+    /** @type { (...things: unknown[]) => void } */
     error(...things) {
       write(combine('ERROR: ', ...things));
     },

--- a/packages/xs-vat-worker/src/endo-load.js
+++ b/packages/xs-vat-worker/src/endo-load.js
@@ -1,39 +1,67 @@
 /* global Compartment */
+// @ts-check
 
+/** @param { unknown[] } _args  */
 function debug(..._args) {
   // console.log(...args);
 }
 
+/**
+ *
+ * @param { endo.CompartmentMap } compartmap
+ * @param { unknown } HandledPromise
+ */
 export function loadMain(compartmap, HandledPromise) {
-  // ISSUE: doesn't seem to work: const { entries, fromEntries, keys } = Object;
+  // ISSUE: doesn't seem to work:
+  const { entries, fromEntries, keys } = Object;
+  // const entries = o => Object.entries(o);
+  // const fromEntries = pvs => Object.fromEntries(pvs);
+  // const keys = o => Object.keys(o);
   // debug('entries, ...', { entries: typeof entries, fromEntries: typeof fromEntries, keys: typeof keys });
-  const entries = o => Object.entries(o);
-  const fromEntries = pvs => Object.fromEntries(pvs);
-  const keys = o => Object.keys(o);
 
-  function SESCompartment(endowments, map, options) {
-    debug('SESCompartment', { endowments, map, options });
-    const sesGlobals = {
-      harden,
-      console,
-      HandledPromise,
-      Compartment: SESCompartment,
-    };
-    return new Compartment({ ...sesGlobals, ...endowments }, map, options);
+  /**
+   *
+   * @param {{ [globalPropertyName: string]: any }} endowments
+   * @param {{[key: string]: FullSpecifier | ModuleNamespace}} map
+   * @param { CompartmentConstructorOptions } options
+   */
+  class SESCompartment extends Compartment {
+    constructor(endowments = {}, map = {}, options = {}) {
+      debug('SESCompartment', { endowments, map, options });
+      const sesGlobals = {
+        harden,
+        console,
+        HandledPromise,
+        Compartment: SESCompartment,
+      };
+      super({ ...sesGlobals, ...endowments }, map, options);
+    }
   }
 
+  /**
+   * @template T
+   * @param { (k: string) => T } f
+   * @return {(k: string) => T}
+   */
   const memoize = f => {
+    /** @type { {[k: string]: T} } */
     const cache = {};
     return k => cache[k] || (cache[k] = f(k));
   };
+  /** @type {(spec: string) => string} */
   const unjs = spec => spec.replace(/\.js$/, '');
+  /** @type {(spec: string) => string} */
   const unrel = spec => spec.replace(/^\.\//, '/');
+  /** @type {(base: string, ref: string) => string} */
   const join = (base, ref) => `${base}${unjs(ref.slice(2))}`;
+  /** @type {(loc: string) => Compartment} */
   const pkgCompartment = memoize(loc => {
+    /** @type {(ref: string) => [string, string]} */
     const intraPkg = ref => {
       debug('intraPkg', { loc, ref });
       return [unjs(unrel(ref).slice(1)), join(loc, ref)];
     };
+    /** @type {(entry: [string, { compartment: string, module: string }]) => [string, ModuleNamespace]} */
     function interPkg([specifier, { compartment, module }]) {
       const pc = pkgCompartment(compartment);
       const fullSpecifier = unjs(module.slice(2));
@@ -48,6 +76,7 @@ export function loadMain(compartmap, HandledPromise) {
       return [specifier, pc.importNow(fullSpecifier)];
     }
     const { contents, modules } = compartmap.compartments[loc];
+    /** @type { {[key: string]: FullSpecifier | ModuleNamespace} } */
     const cmap = fromEntries([
       ...contents.map(intraPkg),
       ...entries(modules).map(interPkg),

--- a/packages/xs-vat-worker/src/endo-load.js
+++ b/packages/xs-vat-worker/src/endo-load.js
@@ -75,6 +75,7 @@ export function loadMain(compartmap, HandledPromise) {
       });
       return [specifier, pc.importNow(fullSpecifier)];
     }
+    // @ts-ignore TODO: reconcile endo types (extra contents)
     const { contents, modules } = compartmap.compartments[loc];
     /** @type { {[key: string]: FullSpecifier | ModuleNamespace} } */
     const cmap = fromEntries([

--- a/packages/xs-vat-worker/src/endo-types.d.ts
+++ b/packages/xs-vat-worker/src/endo-types.d.ts
@@ -1,4 +1,7 @@
 // https://github.com/Agoric/SES-shim/blob/kris/endo-stack/packages/endo/DESIGN.md#compartment-maps
+
+namespace endo {
+
 // CompartmentMap describes how to prepare compartments
 // to run an application.
 type CompartmentMap = {
@@ -164,3 +167,5 @@ type RealmName = string;
 // The string value is the name of the module to be provided
 // in the application's given module map.
 type ModuleParameter = string;
+
+}

--- a/packages/xs-vat-worker/src/endo-types.d.ts
+++ b/packages/xs-vat-worker/src/endo-types.d.ts
@@ -38,7 +38,7 @@ type Compartment = {
 
 // Location is the URL relative to the compartmap.json's
 // containing location to the compartment's files.
-type Location string;
+type Location = string;
 
 // ModuleMap describes modules available in the compartment
 // that do not correspond to source files in the same compartment.

--- a/packages/xs-vat-worker/src/endo-types.d.ts
+++ b/packages/xs-vat-worker/src/endo-types.d.ts
@@ -1,0 +1,166 @@
+// https://github.com/Agoric/SES-shim/blob/kris/endo-stack/packages/endo/DESIGN.md#compartment-maps
+// CompartmentMap describes how to prepare compartments
+// to run an application.
+type CompartmentMap = {
+  tags: Tags,
+  main: CompartmentName,
+  compartments: Object<CompartmentName, Compartment>,
+  realms: Object<RealmName, Realm>, // TODO
+};
+
+// Tags are the build tags for the compartment.
+// These may include terms like "browser", meaning
+// each compartment uses the implementation of each
+// module suitable for use in a browser environment.
+type Tags = Array<Tag>;
+type Tag = string;
+
+// CompartmentName is an arbitrary string to name
+// a compartment for purposes of inter-compartment linkage.
+type CompartmentName = string;
+
+// Compartment describes where to find the modules
+// for a compartment and how to link the compartment
+// to modules in other compartments, or to built-in modules.
+type Compartment = {
+  location: Location,
+  modules: ModuleMap,
+  parsers: ParserMap,
+  types: ModuleParserMap,
+  scopes: ScopeMap,
+  // The name of the realm to run the compartment within.
+  // The default is a single frozen realm that has no name.
+  realm: RealmName? // TODO
+};
+
+// Location is the URL relative to the compartmap.json's
+// containing location to the compartment's files.
+type Location string;
+
+// ModuleMap describes modules available in the compartment
+// that do not correspond to source files in the same compartment.
+type ModuleMap = Object<InternalModuleSpecifier, Module>;
+
+// Module describes a module in a compartment.
+type Module = CompartmentModule | FileModule | ExitModule;
+
+// CompartmentModule describes a module that isn't in the same
+// compartment and how to introduce it to the compartment's
+// module namespace.
+type CompartmentModule = {
+  // The name of the foreign compartment:
+  // TODO an absent compartment name may imply either
+  // that the module is an internal alias of the
+  // same compartment, or given by the user.
+  compartment: CompartmentName?,
+  // The name of the module in the foreign compartment's
+  // module namespace:
+  module: ExternalModuleSpecifier?,
+};
+
+// FileLocation is a URL for a module's file relative to the location of the
+// containing compartment.
+type FileLocation = string
+
+// FileModule is a module from a file.
+// When loading modules off a file system (src/import.js), the assembler
+// does not need any explicit FileModules, and instead relies on the
+// compartment to declare a ParserMap and optionally ModuleParserMap and
+// ScopeMap.
+// Endo provides a Compartment importHook and moduleMapHook that will
+// search the filesystem for candidate module files and infer the type from the
+// extension when necessary.
+type FileModule = {
+   location: FileLocation,
+   parser: Parser,
+};
+
+// ExitName is the name of a built-in module, to be threaded in from the
+// modules passed to the module executor.
+type ExitName = string;
+
+// ExitModule refers to a module that comes from outside the compartment map.
+type ExitModule = {
+  exit: ExitName
+};
+
+// InternalModuleSpecifier is the module specifier
+// in the namespace of the native compartment.
+type InternalModuleSpecifier = string;
+
+// ExternalModuleSpecifier is the module specifier
+// in the namespace of the foreign compartment.
+type ExternalModuleSpecifier = string;
+
+// ParserMap indicates which parser to use to construct static module records
+// from sources, for each supported file extension.
+// For parity with Node.js, a package with `"type": "module"` in its
+// `package.json` would have a parser map of `{"js": "mjs", "cjs": "cjs",
+// "mjs": "mjs"}`.
+// If `"module"` is not defined in package.json, the legacy parser map // is
+// `{"js": "cjs", "cjs": "cjs", "mjs": "mjs"}`.
+// Endo adds `{"json": "json"}` for good measure in both cases, although
+// Node.js (as of version 0.14.5) does not support importing JSON modules from
+// ESM.
+type ParserMap = Object<Extension, Parser>;
+
+// Extension is a file extension such as "js" for "main.js" or "" for "README".
+type Extension = string;
+
+// Parser is a union of built-in parsers for static module records.
+// "mjs" corresponds to ECMAScript modules.
+// "cjs" corresponds to CommonJS modules.
+// "json" corresponds to JSON.
+type Parser = "mjs" | "cjs" | "json";
+
+// ModuleParserMap is a table of internal module specifiers
+// to the parser that should be used, regardless of that module's
+// extension.
+// Node.js allows the "module" property in package.json to denote
+// a file that is an ECMAScript module, regardless of its extension.
+// This is the mechanism that allows Endo to respect that behavior.
+type ModuleParserMap = Object<InternalModuleSpecifier, Parser>;
+
+// ScopeMap is a map from internal module specifier prefixes
+// like "dependency" or "@organization/dependency" to another
+// compartment.
+// Endo uses this to build a moduleMapHook that can dynamically
+// generate entries for a compartment's moduleMap into
+// Node.js packages that do not explicitly state their "exports".
+// For these modules, any specifier under that prefix corresponds
+// to a link into some internal module of the foreign compartment.
+// When Endo creates an archive, it captures all of the Modules
+// explicitly and erases the scopes entry.
+type ScopeMap = Object<InternalModuleSpecifier, Scope>;
+
+// Scope describes the compartment to use for all ad-hoc
+// entries in the compartment's module map.
+type Scope = {
+  compartment: CompartmentName
+};
+
+
+// TODO everything hereafter...
+
+// Realm describes another realm to contain one or more
+// compartments.
+// The default realm is frozen by lockdown with no
+// powerful references.
+type Realm = {
+  // TODO lockdown options
+};
+
+// RealmName is an arbitrary identifier for realms
+// for reference from any Compartment description.
+// No names are reserved; the default realm has no name.
+type RealmName = string;
+
+// ModuleParameter indicates that the module does not come from
+// another compartment but must be passed expressly into the
+// application by the user.
+// For example, the Node.js `fs` built-in module provides
+// powers that must be expressly granted to an application
+// and may be attenuated or limited by Endo on behalf of the user.
+// The string value is the name of the module to be provided
+// in the application's given module map.
+type ModuleParameter = string;

--- a/packages/xs-vat-worker/src/endo-types.d.ts
+++ b/packages/xs-vat-worker/src/endo-types.d.ts
@@ -7,8 +7,8 @@ namespace endo {
 type CompartmentMap = {
   tags: Tags,
   main: CompartmentName,
-  compartments: Object<CompartmentName, Compartment>,
-  realms: Object<RealmName, Realm>, // TODO
+  compartments: { [compartmentName: string]: Compartment },
+  realms: { [realmName: string]: Realm}, // TODO
 };
 
 // Tags are the build tags for the compartment.
@@ -42,7 +42,7 @@ type Location = string;
 
 // ModuleMap describes modules available in the compartment
 // that do not correspond to source files in the same compartment.
-type ModuleMap = Object<InternalModuleSpecifier, Module>;
+type ModuleMap = { [internalModuleSpecifier: string]: Module };
 
 // Module describes a module in a compartment.
 type Module = CompartmentModule | FileModule | ExitModule;
@@ -105,7 +105,7 @@ type ExternalModuleSpecifier = string;
 // Endo adds `{"json": "json"}` for good measure in both cases, although
 // Node.js (as of version 0.14.5) does not support importing JSON modules from
 // ESM.
-type ParserMap = Object<Extension, Parser>;
+type ParserMap = { [extension: string]: Parser };
 
 // Extension is a file extension such as "js" for "main.js" or "" for "README".
 type Extension = string;
@@ -122,7 +122,7 @@ type Parser = "mjs" | "cjs" | "json";
 // Node.js allows the "module" property in package.json to denote
 // a file that is an ECMAScript module, regardless of its extension.
 // This is the mechanism that allows Endo to respect that behavior.
-type ModuleParserMap = Object<InternalModuleSpecifier, Parser>;
+type ModuleParserMap = { [internalModuleSpecifier: string]: Parser };
 
 // ScopeMap is a map from internal module specifier prefixes
 // like "dependency" or "@organization/dependency" to another
@@ -134,7 +134,7 @@ type ModuleParserMap = Object<InternalModuleSpecifier, Parser>;
 // to a link into some internal module of the foreign compartment.
 // When Endo creates an archive, it captures all of the Modules
 // explicitly and erases the scopes entry.
-type ScopeMap = Object<InternalModuleSpecifier, Scope>;
+type ScopeMap = { [internalModuleSpecifier: string]: Scope };
 
 // Scope describes the compartment to use for all ad-hoc
 // entries in the compartment's module map.

--- a/packages/xs-vat-worker/src/harden.js
+++ b/packages/xs-vat-worker/src/harden.js
@@ -1,7 +1,7 @@
+// @ts-check
+
 // ISSUE: harden compat? https://github.com/Agoric/SES-shim/issues/104
-export function harden(x) {
-  return Object.freeze(x);
-}
+const { freeze: harden } = Object;
 
 harden(harden);
 globalThis.harden = harden;

--- a/packages/xs-vat-worker/src/harden.js
+++ b/packages/xs-vat-worker/src/harden.js
@@ -1,7 +1,14 @@
 // @ts-check
 
-// ISSUE: harden compat? https://github.com/Agoric/SES-shim/issues/104
-const { freeze: harden } = Object;
+/**
+ * ISSUE: harden compat? https://github.com/Agoric/SES-shim/issues/104
+ * @param {T} x
+ * @template T
+ * @returns {T}
+ */
+function harden(x) {
+  return Object.freeze(x);
+}
 
-harden(harden);
-globalThis.harden = harden;
+// @ts-ignore
+globalThis.harden = harden(harden);

--- a/packages/xs-vat-worker/src/vatWorker.js
+++ b/packages/xs-vat-worker/src/vatWorker.js
@@ -223,14 +223,15 @@ function makeWorker(io, setImmediate) {
           makeMarshal,
           testLog,
         };
-        dispatch = makeLiveSlots(
+        const ls = makeLiveSlots(
           syscall,
-          vatNS.buildRootObject,
           vatID,
           vatPowers,
           vatParameters,
           virtualObjectCacheSize,
         );
+        dispatch = ls.dispatch;
+        ls.setBuildRootObject(vatNS.buildRootObject);
         workerLog(`got dispatch:`, Object.keys(dispatch).join(','));
         sendUplink(['dispatchReady']);
         return type;

--- a/packages/xs-vat-worker/src/vatWorker.js
+++ b/packages/xs-vat-worker/src/vatWorker.js
@@ -142,7 +142,7 @@ function makeWorker(io, setImmediate) {
    * TODO: move VatSyscall where other stuff from vat-worker.md are defined
    * @typedef {Readonly<
    *   ['send', Reference, Message] |
-   *   ['callNow', Reference, string, CapData] |
+   *   ['callNow', Reference, string, CapData<string>] |
    *   ['subscribe', PromiseReference] |
    *   ['fulfillToPresence', PromiseReference, Reference] |
    *   ['fulfillToData', PromiseReference, unknown] |

--- a/packages/xs-vat-worker/src/vatWorker.js
+++ b/packages/xs-vat-worker/src/vatWorker.js
@@ -171,7 +171,7 @@ function makeWorker(io, setImmediate) {
       workerLog(`got start`);
       sendUplink(['gotStart']);
     } else if (type === 'setBundle') {
-      const [bundle, vatParameters, virtualObjectCacheSize] = margs;
+      const [bundle, vatParameters] = margs;
       const endowments = {
         console: makeConsole(`SwingSet:vatWorker`),
         assert,

--- a/packages/xs-vat-worker/src/vatWorker.js
+++ b/packages/xs-vat-worker/src/vatWorker.js
@@ -212,8 +212,6 @@ function makeWorker(io, setImmediate) {
         function testLog(/** @type {unknown[]} */ ...args) {
           sendUplink(['testLog', ...args]);
         }
-        /** @type { unknown } */
-        const state = null;
         const vatID = 'demo-vatID';
         // todo: maybe add transformTildot, makeGetMeter/transformMetering to
         // vatPowers, but only if options tell us they're wanted. Maybe
@@ -227,7 +225,6 @@ function makeWorker(io, setImmediate) {
         };
         dispatch = makeLiveSlots(
           syscall,
-          state,
           vatNS.buildRootObject,
           vatID,
           vatPowers,

--- a/packages/xs-vat-worker/src/vatWorker.js
+++ b/packages/xs-vat-worker/src/vatWorker.js
@@ -193,7 +193,7 @@ function makeWorker(io, setImmediate) {
         const syscall = harden({
           /** @type { (target: Reference, msg: Message) => void } */
           send: (target, smsg) => doSyscall(['send', target, smsg]),
-          /** @type { (target: Reference, method: string, args: CapData) => void } */
+          /** @type { (target: Reference, method: string, args: CapData<string>) => void } */
           callNow: (_target, _method, _args) => {
             throw Error(`nodeWorker cannot syscall.callNow`);
           },

--- a/packages/xs-vat-worker/src/vatWorker.js
+++ b/packages/xs-vat-worker/src/vatWorker.js
@@ -1,7 +1,7 @@
 /* global HandledPromise */
 // @ts-check
 import { importBundle } from '@agoric/import-bundle';
-import { asMessage } from '@agoric/swingset-vat';
+import { asMessage } from '@agoric/swingset-vat/src/message';
 import { Remotable, getInterfaceOf, makeMarshal } from '@agoric/marshal';
 // TODO? import anylogger from 'anylogger';
 import { makeLiveSlots } from '@agoric/swingset-vat/src/kernel/liveSlots';

--- a/packages/xs-vat-worker/src/vatWorker.js
+++ b/packages/xs-vat-worker/src/vatWorker.js
@@ -228,7 +228,7 @@ function makeWorker(io, setImmediate) {
           vatID,
           vatPowers,
           vatParameters,
-          virtualObjectCacheSize,
+          // TODO: virtualObjectCacheSize,
         );
         dispatch = ls.dispatch;
         ls.setBuildRootObject(vatNS.buildRootObject);

--- a/packages/xs-vat-worker/src/vatWorker.js
+++ b/packages/xs-vat-worker/src/vatWorker.js
@@ -42,7 +42,7 @@ function makeConsole(_tag) {
 /**
  *
  * @param {typeof setImmediate} setImmediate
- * @returns { Promise<unknown> }
+ * @returns { Promise<void> }
  */
 function waitUntilQuiescent(setImmediate) {
   return new Promise((resolve, _reject) => {

--- a/packages/zoe/tools/fakePriceAuthority.js
+++ b/packages/zoe/tools/fakePriceAuthority.js
@@ -59,6 +59,7 @@ export async function makeFakePriceAuthority(options) {
     if (tradeList) {
       return tradeList[currentPriceIndex % tradeList.length];
     }
+    assert(priceList); // static analysis limitation
     return [unitValueIn, priceList[currentPriceIndex % priceList.length]];
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1521,35 +1521,35 @@
     "@types/node" "*"
 
 "@typescript-eslint/parser@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.1.0.tgz#9b0409411725f14cd7faa81a664e5051225961db"
-  integrity sha512-hM/WNCQTzDHgS0Ke3cR9zPndL3OTKr9OoN9CL3UqulsAjYDrglSwIIgswSmHBcSbOzLmgaMARwrQEbIumIglvQ==
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.8.2.tgz#78dccbe5124de2b8dea2d4c363dee9f769151ca8"
+  integrity sha512-u0leyJqmclYr3KcXOqd2fmx6SDGBO0MUNHHAjr0JS4Crbb3C3d8dwAdlazy133PLCcPn+aOUFiHn72wcuc5wYw==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.1.0"
-    "@typescript-eslint/types" "4.1.0"
-    "@typescript-eslint/typescript-estree" "4.1.0"
+    "@typescript-eslint/scope-manager" "4.8.2"
+    "@typescript-eslint/types" "4.8.2"
+    "@typescript-eslint/typescript-estree" "4.8.2"
     debug "^4.1.1"
 
-"@typescript-eslint/scope-manager@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.1.0.tgz#9e389745ee9cfe12252ed1e9958808abd6b3a683"
-  integrity sha512-HD1/u8vFNnxwiHqlWKC/Pigdn0Mvxi84Y6GzbZ5f5sbLrFKu0al02573Er+D63Sw67IffVUXR0uR8rpdfdk+vA==
+"@typescript-eslint/scope-manager@4.8.2":
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.8.2.tgz#a18388c63ae9c17adde519384f539392f2c4f0d9"
+  integrity sha512-qHQ8ODi7mMin4Sq2eh/6eu03uVzsf5TX+J43xRmiq8ujng7ViQSHNPLOHGw/Wr5dFEoxq/ubKhzClIIdQy5q3g==
   dependencies:
-    "@typescript-eslint/types" "4.1.0"
-    "@typescript-eslint/visitor-keys" "4.1.0"
+    "@typescript-eslint/types" "4.8.2"
+    "@typescript-eslint/visitor-keys" "4.8.2"
 
-"@typescript-eslint/types@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.1.0.tgz#edbd3fec346f34e13ce7aa176b03b497a32c496a"
-  integrity sha512-rkBqWsO7m01XckP9R2YHVN8mySOKKY2cophGM8K5uDK89ArCgahItQYdbg/3n8xMxzu2elss+an1TphlUpDuJw==
+"@typescript-eslint/types@4.8.2":
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.8.2.tgz#c862dd0e569d9478eb82d6aee662ea53f5661a36"
+  integrity sha512-z1/AVcVF8ju5ObaHe2fOpZYEQrwHyZ7PTOlmjd3EoFeX9sv7UekQhfrCmgUO7PruLNfSHrJGQvrW3Q7xQ8EoAw==
 
-"@typescript-eslint/typescript-estree@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.1.0.tgz#394046ead25164494218c0e3d6b960695ea967f6"
-  integrity sha512-r6et57qqKAWU173nWyw31x7OfgmKfMEcjJl9vlJEzS+kf9uKNRr4AVTRXfTCwebr7bdiVEkfRY5xGnpPaNPe4Q==
+"@typescript-eslint/typescript-estree@4.8.2":
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.8.2.tgz#eeec34707d8577600fb21661b5287226cc8b3bed"
+  integrity sha512-HToGNwI6fekH0dOw3XEVESUm71Onfam0AKin6f26S2FtUmO7o3cLlWgrIaT1q3vjB3wCTdww3Dx2iGq5wtUOCg==
   dependencies:
-    "@typescript-eslint/types" "4.1.0"
-    "@typescript-eslint/visitor-keys" "4.1.0"
+    "@typescript-eslint/types" "4.8.2"
+    "@typescript-eslint/visitor-keys" "4.8.2"
     debug "^4.1.1"
     globby "^11.0.1"
     is-glob "^4.0.1"
@@ -1557,12 +1557,12 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/visitor-keys@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.1.0.tgz#b2d528c9484e7eda1aa4f86ccf0432fb16e4d545"
-  integrity sha512-+taO0IZGCtCEsuNTTF2Q/5o8+fHrlml8i9YsZt2AiDCdYEJzYlsmRY991l/6f3jNXFyAWepdQj7n8Na6URiDRQ==
+"@typescript-eslint/visitor-keys@4.8.2":
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.8.2.tgz#62cd3fbbbf65f8eccfbe6f159eb1b84a243a3f77"
+  integrity sha512-Vg+/SJTMZJEKKGHW7YC21QxgKJrSbxoYYd3MEUGtW7zuytHuEcksewq0DUmo4eh/CTNrVJGSdIY9AtRb6riWFw==
   dependencies:
-    "@typescript-eslint/types" "4.1.0"
+    "@typescript-eslint/types" "4.8.2"
     eslint-visitor-keys "^2.0.0"
 
 "@yarnpkg/lockfile@^1.1.0":
@@ -3376,12 +3376,19 @@ debug@^3.1.0, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@^4.0.1, debug@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.1.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
 
 debuglog@^1.0.1:
   version "1.0.1"
@@ -4410,9 +4417,9 @@ fastparse@^1.1.2:
   integrity sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==
 
 fastq@^1.6.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.8.0.tgz#550e1f9f59bbc65fe185cb6a9b4d95357107f481"
-  integrity sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.9.0.tgz#e16a72f338eaca48e91b5c23593bcc2ef66b7947"
+  integrity sha512-i7FVWL8HhVY+CTkwFxkN2mk3h+787ixS5S63eb78diVRc1MCssarHq3W5cj0av7YDSwmaV928RNag+U1etRQ7w==
   dependencies:
     reusify "^1.0.4"
 
@@ -6305,12 +6312,12 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.2.1:
+lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.2.1:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
-lodash@^4.17.19, lodash@^4.17.20:
+lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -6821,7 +6828,7 @@ ms@2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
-ms@^2.0.0, ms@^2.1.1, ms@^2.1.2:
+ms@2.1.2, ms@^2.0.0, ms@^2.1.1, ms@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -9032,9 +9039,9 @@ run-async@^2.2.0:
     is-promise "^2.1.0"
 
 run-parallel@^1.1.9:
-  version "1.1.9"
-  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
-  integrity sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.10.tgz#60a51b2ae836636c81377df16cb107351bcd13ef"
+  integrity sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==
 
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"
@@ -10194,9 +10201,9 @@ tsconfig-paths@^3.9.0:
     strip-bom "^3.0.0"
 
 tslib@^1.8.1:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
-  integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tslib@^1.9.0:
   version "1.10.0"
@@ -10273,6 +10280,11 @@ typescript@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
   integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
+
+typescript@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
+  integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
 
 uglify-js@^3.1.4:
   version "3.8.0"


### PR DESCRIPTION
This started as an experiment to figure out whether the compartmap used in xs-vat-worker has the same structure as the one used in endo. It does not. Reconciling the difference is still TODO.
https://github.com/Agoric/SES-shim/pull/458#issuecomment-694486578

I suppose `compartment-map-types.d.ts` should move to SES-shim, but I'm not sufficiently confident in my npm-fu to juggle work-in-progress in packages across monorepos.

Various bits should be squashed... maybe repackaged as different PRs...