### PR TITLE
fix: push the @agoric/sdk tag separately to trigger Docker builds

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -35,7 +35,7 @@ REFERENCES TO YOUR TAGS.
 
 ```sh
 # Publish the released package tags.
-./scripts/get-released-tags | xargs git push origin
+./scripts/get-released-tags git push origin
 ```
 
 ## More subtlety

--- a/scripts/get-released-tags
+++ b/scripts/get-released-tags
@@ -1,2 +1,17 @@
 #! /bin/sh
-git tag -l | egrep -e '@[0-9]+\.[0-9]+\.[0-9]+$'
+cmd=${1+"$@"}
+sdkTags=
+otherTags=
+if test -z "$cmd"; then
+  cmd=echo
+fi
+for tag in $(git tag -l | egrep -e '@[0-9]+\.[0-9]+\.[0-9]+$'); do
+  case $tag in
+  @agoric/sdk@*) sdkTags="$sdkTags $tag" ;;
+  *) otherTags="$otherTags $tag" ;;
+  esac
+done
+
+# Push the SDK tag separately so that it can trigger CI.
+$cmd$otherTags && $cmd$sdkTags
+exit $?


### PR DESCRIPTION
This allows the `.github/workflows/docker.yml` to properly detect an `@agoric/sdk@*` tag push.
