### PR TITLE
Rendezvous service

### DIFF
--- a/packages/agoric-cli/lib/start.js
+++ b/packages/agoric-cli/lib/start.js
@@ -12,6 +12,7 @@ import {
 const PROVISION_COINS = `100000000${STAKING_DENOM},100000000${MINT_DENOM},100provisionpass,100sendpacketpass`;
 const DELEGATE0_COINS = `50000000${STAKING_DENOM}`;
 const CHAIN_ID = 'agoric';
+const BACKOFF_MS = 3000;
 
 const FAKE_CHAIN_DELAY =
   process.env.FAKE_CHAIN_DELAY === undefined
@@ -119,10 +120,9 @@ export default async function startMain(progname, rawArgs, powers, opts) {
   }
 
   async function startFakeChain(profileName, _startArgs, popts) {
+    const agServer = `_agstate/agoric-servers/${profileName}`;
     const fakeDelay =
       popts.delay === undefined ? FAKE_CHAIN_DELAY : Number(popts.delay);
-
-    const agServer = `_agstate/agoric-servers/${profileName}`;
 
     if (popts.reset) {
       log(chalk.green(`removing ${agServer}`));
@@ -354,7 +354,6 @@ export default async function startMain(progname, rawArgs, powers, opts) {
       log.error(`Argument to local-solo must be a port number`);
       return 1;
     }
-
     const agServer = `_agstate/agoric-servers/${profileName}-${portNum}`;
 
     if (popts.pull) {
@@ -504,6 +503,9 @@ export default async function startMain(progname, rawArgs, powers, opts) {
           bestRpcAddr = rpcAddr;
           break;
         }
+
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise(resolve => setTimeout(resolve, BACKOFF_MS));
       }
     }
     if (exitStatus) {

--- a/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
@@ -11,7 +11,6 @@ import { E } from '@agoric/eventual-send';
 import { makePluginManager } from '@agoric/swingset-vat/src/vats/plugin-manager';
 import { GCI } from './gci';
 import { makeBridgeManager } from './bridge';
-import { makeRendezvousNamespace } from './rendezvous';
 
 const NUM_IBC_PORTS = 3;
 const CENTRAL_ISSUER_NAME = 'Testnet.$USD';
@@ -186,8 +185,6 @@ export function buildRootObject(vatPowers, vatParameters) {
       }),
     );
 
-    const makeRendezvous = makeRendezvousNamespace();
-
     return harden({
       async createUserBundle(_nickname, addr, powerFlags = []) {
         // Bind to some fresh ports (unspecified name) on the IBC implementation
@@ -228,7 +225,7 @@ export function buildRootObject(vatPowers, vatParameters) {
           },
         };
 
-        const rendezvous = makeRendezvous(addr);
+        const rendezvous = await E(vats.rendezvous).rendezvousServiceFor(addr);
         const bundle = harden({
           ...additionalPowers,
           chainTimerService,

--- a/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
@@ -11,7 +11,7 @@ import { E } from '@agoric/eventual-send';
 import { makePluginManager } from '@agoric/swingset-vat/src/vats/plugin-manager';
 import { GCI } from './gci';
 import { makeBridgeManager } from './bridge';
-import { makeRendezvousMaker } from './rendezvous';
+import { makeRendezvousNamespace } from './rendezvous';
 
 const NUM_IBC_PORTS = 3;
 const CENTRAL_ISSUER_NAME = 'Testnet.$USD';
@@ -186,7 +186,7 @@ export function buildRootObject(vatPowers, vatParameters) {
       }),
     );
 
-    const makeRendezvous = makeRendezvousMaker();
+    const makeRendezvous = makeRendezvousNamespace();
 
     return harden({
       async createUserBundle(_nickname, addr, powerFlags = []) {

--- a/packages/cosmic-swingset/lib/ag-solo/vats/chain-config.json
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/chain-config.json
@@ -30,6 +30,9 @@
     "registrar": {
       "sourceSpec": "vat-registrar.js"
     },
+    "rendezvous": {
+      "sourceSpec": "vat-rendezvous.js"
+    },
     "sharing": {
       "sourceSpec": "vat-sharing.js"
     },

--- a/packages/cosmic-swingset/lib/ag-solo/vats/rendezvous.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/rendezvous.js
@@ -1,0 +1,132 @@
+// @ts-check
+import makeStore from '@agoric/store';
+import { makeNotifierKit } from '@agoric/notifier';
+
+/**
+ * @typedef {Object} PeerRecord
+ * @property {(result: any) => void} found
+ * @property {any} result
+ */
+
+/**
+ * Create a factory for makeRendezvous to revolve around.
+ */
+export function makeRendezvousMaker() {
+  /**
+   * @type {Store<string, Store<string, PeerRecord>>}
+   */
+  const addrToPeerRecordsStores = makeStore('localAddress');
+
+  // Return a rendezvous maker.
+  return addr =>
+    harden({
+      getLocalAddress() {
+        // We let people know who they are.
+        return addr;
+      },
+      /**
+       * Start a rendezvous process.
+       *
+       * @param {Record<string, any>} remoteAddressToResult
+       */
+      initiateRendezvous(remoteAddressToResult) {
+        /**
+         * @type {Record<string, any>}
+         */
+        const foundState = {};
+        let remainingToFind = 0;
+
+        /**
+         * @type {NotifierRecord<Record<string, any>>}
+         */
+        const foundNotifier = makeNotifierKit();
+
+        /**
+         * @type {Array<() => void>}
+         */
+        const disposals = [];
+
+        const completer = {
+          complete() {
+            // We want to mark the rendezvous as complete.
+            foundNotifier.updater.finish(harden({ ...foundState }));
+            // Remove any stale references.
+            for (const disposal of disposals) {
+              disposal();
+            }
+          },
+        };
+
+        for (const [remoteAddr, result] of Object.entries(
+          remoteAddressToResult,
+        )) {
+          remainingToFind += 1;
+
+          /**
+           * @type {Store<string, PeerRecord>}
+           */
+          let addrToPeerRecord;
+          if (addrToPeerRecordsStores.has(remoteAddr)) {
+            addrToPeerRecord = addrToPeerRecordsStores.get(remoteAddr);
+          } else {
+            addrToPeerRecord = makeStore('localAddr');
+            addrToPeerRecordsStores.init(remoteAddr, addrToPeerRecord);
+          }
+
+          const found = obj => {
+            remainingToFind -= 1;
+            foundState[remoteAddr] = obj;
+            if (remainingToFind === 0) {
+              // We're done!
+              completer.complete();
+            } else {
+              // We need to keep going.
+              foundNotifier.updater.updateState(harden({ ...foundState }));
+            }
+          };
+          const peerRecord = harden({
+            found,
+            result,
+          });
+          if (addrToPeerRecord.has(addr)) {
+            addrToPeerRecord.set(addr, peerRecord);
+          } else {
+            addrToPeerRecord.init(addr, peerRecord);
+          }
+          disposals.push(() => {
+            if (
+              addrToPeerRecord.has(addr) &&
+              addrToPeerRecord.get(addr) === peerRecord
+            ) {
+              // Remove the record for us.
+              addrToPeerRecord.delete(addr);
+            }
+          });
+        }
+
+        return harden({ notifier: foundNotifier.notifier, completer });
+      },
+      /**
+       * Complete a rendezvous with multiple remote addresses.
+       *
+       * @param {Record<string, any>} remoteAddressToResult
+       * @returns {Record<string, Array<any>>}
+       */
+      rendezvousWith(remoteAddressToResult) {
+        /**
+         * @type {Record<string, Array<any>>}
+         */
+        const resultsByAddress = {};
+        // Look up all the records associated with us and the remote address.
+        const addrToPeerRecord = addrToPeerRecordsStores.get(addr);
+        for (const [remoteAddr, obj] of Object.entries(remoteAddressToResult)) {
+          if (addrToPeerRecord.has(remoteAddr)) {
+            const { found, result } = addrToPeerRecord.get(remoteAddr);
+            found(obj);
+            resultsByAddress[remoteAddr] = result;
+          }
+        }
+        return harden(resultsByAddress);
+      },
+    });
+}

--- a/packages/cosmic-swingset/lib/ag-solo/vats/rendezvous.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/rendezvous.js
@@ -59,12 +59,12 @@ const RENDEZVOUS_ALREADY = harden({
  */
 
 /**
- * @callback RendezvousPrivateServiceFactory Create a private rendezvous service
- * for a given peer address.
- * @param {PeerAddress} ourAddress a string that must somehow strongly identify
- * the peer that has access to the private service, such as a cryptographic
- * identifier.
- * @returns {RendezvousPrivateService}
+ * @typedef {Object} RendezvousNamespace
+ * @property {(ourAddress: PeerAddress) => RendezvousPrivateService}
+ * rendezvousServiceFor Create a private rendezvous service for a given peer
+ * address.  `ourAddress` is a string that must somehow strongly identify the
+ * peer that has access to the private service, such as an identifier that is
+ * unique for the rendezvous namespace.
  */
 
 /**
@@ -110,7 +110,7 @@ const getPeerAddresses = peerAddrs => {
  *
  * @param {string} [namespaceName='Agoric'] the name of this rendezvous
  * namespace (doesn't have to be unique)
- * @returns {RendezvousPrivateServiceFactory}
+ * @returns {RendezvousNamespace}
  */
 export function makeRendezvousNamespace(namespaceName = 'Agoric') {
   /**
@@ -118,131 +118,134 @@ export function makeRendezvousNamespace(namespaceName = 'Agoric') {
    */
   const addrToPeerRecordStores = makeStore('localAddress');
 
-  // Return a rendezvous maker.
-  return ourAddress => {
-    /** @type {RendezvousPrivateService} */
-    const service = {
-      getNamespaceName() {
-        return namespaceName;
-      },
-      getLocalAddress() {
-        return ourAddress;
-      },
-      startRendezvous(peerAddrs, sendToPeer = undefined) {
-        const peerAddresses = getPeerAddresses(peerAddrs);
+  /** @type {RendezvousNamespace} */
+  const rendezvousMaker = {
+    rendezvousServiceFor(ourAddress) {
+      /** @type {RendezvousPrivateService} */
+      const service = {
+        getNamespaceName() {
+          return namespaceName;
+        },
+        getLocalAddress() {
+          return ourAddress;
+        },
+        startRendezvous(peerAddrs, sendToPeer = undefined) {
+          const peerAddresses = getPeerAddresses(peerAddrs);
 
-        let remainingToFind = peerAddresses.length;
-        let already = false;
-        const resultPK = makePromiseKit();
-
-        /**
-         * @type {Array<() => void>}
-         */
-        const disposals = [];
-
-        const rendezvous = {
-          getResult() {
-            return resultPK.promise;
-          },
-          cancel() {
-            // We want to mark the rendezvous as failed if not already.
-            if (!already) {
-              resultPK.reject(
-                details`Rendezvous with ${peerAddresses} not completed`.complain(),
-              );
-            }
-            // Remove any stale references.
-            for (const disposal of disposals) {
-              disposal();
-            }
-          },
-        };
-
-        for (let i = 0; i < peerAddresses.length; i += 1) {
-          const theirAddress = peerAddresses[i];
+          let remainingToFind = peerAddresses.length;
+          let already = false;
+          const resultPK = makePromiseKit();
 
           /**
-           * @type {Store<PeerAddress, PeerRecord>}
+           * @type {Array<() => void>}
            */
-          let addrToPeerRecord;
-          if (addrToPeerRecordStores.has(theirAddress)) {
-            addrToPeerRecord = addrToPeerRecordStores.get(theirAddress);
-          } else {
-            addrToPeerRecord = makeStore('localAddress');
-            addrToPeerRecordStores.init(theirAddress, addrToPeerRecord);
-          }
+          const disposals = [];
 
-          const complete = obj => {
-            remainingToFind -= 1;
-            // Try resolving the result if we're the first match for this rendezvous.
-            if (obj !== RENDEZVOUS_ALREADY) {
-              already = true;
-              resultPK.resolve(obj);
-            }
-            if (remainingToFind === 0) {
-              // We're done!
-              rendezvous.cancel();
-            }
+          const rendezvous = {
+            getResult() {
+              return resultPK.promise;
+            },
+            cancel() {
+              // We want to mark the rendezvous as failed if not already.
+              if (!already) {
+                resultPK.reject(
+                  details`Rendezvous with ${peerAddresses} not completed`.complain(),
+                );
+              }
+              // Remove any stale references.
+              for (const disposal of disposals) {
+                disposal();
+              }
+            },
           };
-          const peerRecord = harden({
-            complete,
-            receivedFrom: sendToPeer,
-          });
-          if (addrToPeerRecord.has(ourAddress)) {
-            addrToPeerRecord.set(ourAddress, peerRecord);
-          } else {
-            addrToPeerRecord.init(ourAddress, peerRecord);
-          }
-          disposals.push(() => {
-            if (
-              addrToPeerRecord.has(ourAddress) &&
-              addrToPeerRecord.get(ourAddress) === peerRecord
-            ) {
-              // Remove the record for us.
-              addrToPeerRecord.delete(ourAddress);
-            }
-          });
-        }
 
-        return harden(rendezvous);
-      },
-      // eslint-disable-next-line consistent-return
-      completeRendezvous(peerAddrs, sendToPeer = undefined) {
-        const peerAddresses = getPeerAddresses(peerAddrs);
+          for (let i = 0; i < peerAddresses.length; i += 1) {
+            const theirAddress = peerAddresses[i];
 
-        let already = false;
-        let returned;
-
-        // Look up all the records shared between us and the remote address.
-        assert(
-          addrToPeerRecordStores.has(ourAddress),
-          details`Rendezvous with ${peerAddrs} not completed`,
-        );
-        const addrToPeerRecord = addrToPeerRecordStores.get(ourAddress);
-
-        // Try the addresses in preference order.
-        for (const theirAddress of peerAddresses) {
-          if (addrToPeerRecord.has(theirAddress)) {
-            const {
-              complete,
-              receivedFrom: receivedFromThem,
-            } = addrToPeerRecord.get(theirAddress);
-
-            if (already) {
-              // Tell them we already completed the rendezvous.
-              complete(RENDEZVOUS_ALREADY);
+            /**
+             * @type {Store<PeerAddress, PeerRecord>}
+             */
+            let addrToPeerRecord;
+            if (addrToPeerRecordStores.has(theirAddress)) {
+              addrToPeerRecord = addrToPeerRecordStores.get(theirAddress);
             } else {
-              // Send them our object.
-              already = true;
-              complete(sendToPeer);
-              returned = receivedFromThem;
+              addrToPeerRecord = makeStore('localAddress');
+              addrToPeerRecordStores.init(theirAddress, addrToPeerRecord);
+            }
+
+            const complete = obj => {
+              remainingToFind -= 1;
+              // Try resolving the result if we're the first match for this rendezvous.
+              if (obj !== RENDEZVOUS_ALREADY) {
+                already = true;
+                resultPK.resolve(obj);
+              }
+              if (remainingToFind === 0) {
+                // We're done!
+                rendezvous.cancel();
+              }
+            };
+            const peerRecord = harden({
+              complete,
+              receivedFrom: sendToPeer,
+            });
+            if (addrToPeerRecord.has(ourAddress)) {
+              addrToPeerRecord.set(ourAddress, peerRecord);
+            } else {
+              addrToPeerRecord.init(ourAddress, peerRecord);
+            }
+            disposals.push(() => {
+              if (
+                addrToPeerRecord.has(ourAddress) &&
+                addrToPeerRecord.get(ourAddress) === peerRecord
+              ) {
+                // Remove the record for us.
+                addrToPeerRecord.delete(ourAddress);
+              }
+            });
+          }
+
+          return harden(rendezvous);
+        },
+        completeRendezvous(peerAddrs, sendToPeer = undefined) {
+          const peerAddresses = getPeerAddresses(peerAddrs);
+
+          let already = false;
+          let returned;
+
+          // Look up all the records shared between us and the remote address.
+          assert(
+            addrToPeerRecordStores.has(ourAddress),
+            details`Rendezvous with ${peerAddrs} not completed`,
+          );
+          const addrToPeerRecord = addrToPeerRecordStores.get(ourAddress);
+
+          // Try the addresses in preference order.
+          for (const theirAddress of peerAddresses) {
+            if (addrToPeerRecord.has(theirAddress)) {
+              const {
+                complete,
+                receivedFrom: receivedFromThem,
+              } = addrToPeerRecord.get(theirAddress);
+
+              if (already) {
+                // Tell them we already completed the rendezvous.
+                complete(RENDEZVOUS_ALREADY);
+              } else {
+                // Send them our object.
+                already = true;
+                complete(sendToPeer);
+                returned = receivedFromThem;
+              }
             }
           }
-        }
-        assert(already, details`Rendezvous with ${peerAddrs} not completed`);
-        return returned;
-      },
-    };
-    return harden(service);
+          assert(already, details`Rendezvous with ${peerAddrs} not completed`);
+          return returned;
+        },
+      };
+      return harden(service);
+    },
   };
+
+  return harden(rendezvousMaker);
 }

--- a/packages/cosmic-swingset/lib/ag-solo/vats/rendezvous.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/rendezvous.js
@@ -27,6 +27,36 @@ const RENDEZVOUS_ALREADY = harden({
  * with a specific Agoric peer.  It allows you to exchange values (possibly
  * ocaps) with another peer, given a third-party that can exchange the other
  * side's address strings between you.
+ *
+ * Consider the Agoric chain, A, and two ag-solos attached to the chain: B and
+ * C.  Given a Dapp UI, D, that can speak pure data (not ocaps) to both B and C,
+ * you have the following architecture:
+ *
+ * ```
+ *             A Agoric chain
+ *           // \\
+ *  ag-solo B     C ag-solo
+ *           \   /
+ *             D Dapp UI
+ * ```
+ * where the double-slashes indicate the ocap connections and the single-slashes
+ * indicate the pure data connections.  If B and C are willing, D can get B's
+ * rendezvous address, then tell C to initiate a rendezvous to B's address.  C
+ * will return its own rendezvous address to D, who then tells B to complete the
+ * rendezvous to C's address.
+ *
+ * The on-chain rendezvous namespace matches the two addresses to each other,
+ * sending B's specified object to C and C's specified object to B.  That
+ * effectively creates a connection between B and C, exposing only the methods
+ * that they choose, and (if the rendezvous addresses are assigned by A and
+ * globally unique, such as public keys signing their connection to A),
+ * guaranteeing that only B and C have initial access to those objects and that
+ * they know D introduced them.
+ *
+ * A strength of the system is that the rendezvous will fail if B and C are
+ * *not* connected to the same chain.  This helps D ensure that B and C have the
+ * same specific on-chain services, such as a common Zoe.
+ *
  * @property {() => string} getNamespaceName get the name of the rendezvous
  * namespace.  This will typically be the chain identifier, like `testnet-4` for
  * the Agoric testnet, or `mySim` for the simulated chain.  It is not
@@ -37,10 +67,10 @@ const RENDEZVOUS_ALREADY = harden({
  * startRendezvous create a new rendezvous instance for this local address,
  * returning the value from the first matching peerAddress and send it
  * `sendToPeer`
- * @property {(peerAddrs: PeerAddresses, sendToPeer: any) =>
- * any} completeRendezvous receive a value from the first matching peerAddress and
- * send it `sendToPeer`, throwing an exception if no peer completed the
- * rendezvous
+ * @property {(peerAddrs: PeerAddresses, sendToPeer: any) => any}
+ * completeRendezvous returns the value sent by the first matching peerAddress
+ * and sends `sendToPeer` to that peer, throwing an exception if no peer
+ * completed the rendezvous
  */
 
 /**

--- a/packages/cosmic-swingset/lib/ag-solo/vats/rendezvous.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/rendezvous.js
@@ -2,48 +2,201 @@
 import makeStore from '@agoric/store';
 import { makeNotifierKit } from '@agoric/notifier';
 
+import '@agoric/notifier/exports';
+import { assert, details } from '@agoric/assert';
+import { E } from '@agoric/eventual-send';
+
+/**
+ * @typedef {string} PeerAddress the string representation of an Agoric peer's
+ * identity.  For Cosmos, this will be the Agoric account ID, like
+ * `agoric16vcjpzjr8uhvwwngyzkpcwe4x0qmnjdu63hc9u`.  For the simulated chain,
+ * this will be something like `mySimGCI-client`.
+ */
+
+/**
+ * @typedef {Record<PeerAddress, any>} RendezvousResults a record that maps a
+ * peer's address to the value it sent (possibly `undefined`).
+ */
+
+/**
+ * @typedef {Object} RendezvousPrivateService A closely-held service associated
+ * with a specific Agoric peer.  It allows you to exchange values (possibly
+ * ocaps) with another peer, given a third-party that can exchange the other
+ * side's address strings between you.
+ * @property {() => string} getNamespaceName get the name of the rendezvous
+ * namespace.  This will typically be the chain identifier, like `testnet-4` for
+ * the Agoric testnet, or `mySim` for the simulated chain.  It is not
+ * necessarily unique.
+ * @property {() => PeerAddress} getLocalAddress get the address string for this
+ * private service
+ * @property {(peerAddress: PeerAddress, sendToPeer: any) => Rendezvous}
+ * startRendezvous create a new rendezvous instance for this local address,
+ * sending `sendToPeer`
+ * @property {(peerAddresses: Array<PeerAddress>, sendToPeerArray: Array<any> |
+ * undefined) => RendezvousMany} startRendezvousMany create a new rendezvous
+ * instance for this local address, sending `sendToPeerArray[i]` to each matched
+ * `peerAddresses[i]`.  The default `sendToPeer` value causes `undefined` to be
+ * sent.
+ * @property {(peerAddress: PeerAddress, sendToPeer: any) => any} rendezvousWith
+ * receive an object from peerAddress, throwing an exception if the peer did not
+ * rendezvous correctly
+ * @property {(peerAddresses: Array<PeerAddress>, sendToPeerArray: Array<any> |
+ * undefined) => RendezvousResults} rendezvousWithMany synchronously check if
+ * any of the `peerAddresses` match an existing rendezvous with our local address.
+ * Return a record with keys of the matching `peerAddresses`, and values sent from
+ * those peers (possibly undefined).
+ */
+
+/**
+ * @typedef {Object} Rendezvous
+ * @property {() => Promise<any>} getResult return the value sent from our peer
+ * @property {() => void} cancel declare that this rendezvous is finished and
+ * resolve the result
+ */
+
+/**
+ * @typedef {Object} RendezvousMany a per-attempt controller held by the
+ * rendezvous initiator
+ * @property {() => Notifier<RendezvousResults>} getNotifier notify
+ * the current collection of peer addresses matched with values
+ * @property {() => void} cancel declare that this rendezvous is
+ * finished.  The notifier will be finished with the latest RendezvousResults.
+ */
+
 /**
  * @typedef {Object} PeerRecord
- * @property {(result: any) => void} found
- * @property {any} result
+ * @property {(theirResult: any) => void} sendTo callback when the peer has
+ * been matched with the other side
+ * @property {any} receivedFrom the value from this peer to be returned to the
+ * rendezvousWith call
  */
 
 /**
- * @typedef {Record<string, any>} AddressResults
+ * @callback RendezvousPrivateServiceFactory Create a private rendezvous service
+ * for a given peer address.
+ * @param {PeerAddress} ourAddress a string that must somehow strongly identify
+ * the peer that has access to the private service, such as a cryptographic
+ * identifier.
+ * @returns {RendezvousPrivateService}
  */
 
 /**
- * Create a factory for makeRendezvous to revolve around.
+ * @param {PeerAddress} peerAddress
  */
-export function makeRendezvousMaker() {
+const assertPeerAddress = peerAddress => {
+  assert.typeof(
+    peerAddress,
+    'string',
+    details`peerAddress ${peerAddress} must be a string`,
+  );
+};
+
+/**
+ * Ensure the arguments to startRendezvous and rendezvousWith are legitimate.
+ *
+ * @param {Array<string>} peerAddresses
+ * @param {Array<any>} sendToPeerArray
+ */
+const assertManyArgs = (peerAddresses, sendToPeerArray) => {
+  assert(
+    Array.isArray(peerAddresses),
+    details`peerAddresses ${peerAddresses} is not an array`,
+  );
+  peerAddresses.forEach(assertPeerAddress);
+  assert(
+    Array.isArray(sendToPeerArray),
+    details`sendToPeerArray ${sendToPeerArray} is not an array`,
+  );
+};
+
+/**
+ *
+ * @param {PeerAddress} peerAddress
+ * @param {RendezvousResults} results
+ */
+const getSingleResult = (peerAddress, results) => {
+  const entries = Object.entries(results);
+
+  assert(
+    entries.length !== 0,
+    details`Rendezvous with ${peerAddress} not completed`,
+  );
+  assert.equal(
+    entries.length,
+    1,
+    details`Must have only one result, not ${results}`,
+  );
+  const [theirAddress, receivedFromThem] = entries[0];
+  assert.equal(
+    theirAddress,
+    peerAddress,
+    details`Returned address ${theirAddress} does not match ${peerAddress}`,
+  );
+
+  return receivedFromThem;
+};
+
+/**
+ * Create a factory for private rendezvous services, all of which are eligible
+ * for rendezvous with one another.
+ *
+ * @param {string} [namespaceName='Agoric'] the name of this rendezvous
+ * namespace (doesn't have to be unique)
+ * @returns {RendezvousPrivateServiceFactory}
+ */
+export function makeRendezvousNamespace(namespaceName = 'Agoric') {
   /**
    * @type {Store<string, Store<string, PeerRecord>>}
    */
   const addrToPeerRecordStores = makeStore('localAddress');
 
   // Return a rendezvous maker.
-  return addr =>
-    harden({
-      getLocalAddress() {
-        // We let people know who they are.
-        return addr;
+  return ourAddress => {
+    /** @type {RendezvousPrivateService} */
+    const service = {
+      getNamespaceName() {
+        return namespaceName;
       },
-      /**
-       * Start a rendezvous notifier process.
-       *
-       * @param {AddressResults} remoteAddressToResult
-       * @returns {{ notifier: Notifier<AddressResults>, completer: { complete:
-       * () => void }}}
-       */
-      startRendezvous(remoteAddressToResult) {
-        /**
-         * @type {Record<string, any>}
-         */
-        const foundState = {};
-        let remainingToFind = 0;
+      getLocalAddress() {
+        return ourAddress;
+      },
+      startRendezvous(peerAddress, sendToPeer = undefined) {
+        assertPeerAddress(peerAddress);
+        const rendezvousMany = service.startRendezvousMany(
+          [peerAddress],
+          [sendToPeer],
+        );
+        const makeResult = async () => {
+          const { updateCount, value } = await E(
+            E(rendezvousMany).getNotifier(),
+          ).getUpdateSince();
+          assert.typeof(
+            updateCount,
+            'undefined',
+            details`Notifier did not finish when expected`,
+          );
+          return getSingleResult(peerAddress, value);
+        };
+        const resultP = makeResult();
+        const rendezvous = {
+          cancel: rendezvousMany.cancel,
+          getResult() {
+            return resultP;
+          },
+        };
+        return harden(rendezvous);
+      },
+      startRendezvousMany(peerAddresses, sendToPeerArray = []) {
+        assertManyArgs(peerAddresses, sendToPeerArray);
 
         /**
-         * @type {NotifierRecord<AddressResults>}
+         * @type {Record<PeerAddress, any>}
+         */
+        const matchedState = {};
+        let remainingToFind = peerAddresses.length;
+
+        /**
+         * @type {NotifierRecord<RendezvousResults>}
          */
         const { updater, notifier } = makeNotifierKit();
 
@@ -52,10 +205,13 @@ export function makeRendezvousMaker() {
          */
         const disposals = [];
 
-        const completer = {
-          complete() {
+        const rendezvousMany = {
+          getNotifier() {
+            return notifier;
+          },
+          cancel() {
             // We want to mark the rendezvous as complete.
-            updater.finish(harden({ ...foundState }));
+            updater.finish(harden({ ...matchedState }));
             // Remove any stale references.
             for (const disposal of disposals) {
               disposal();
@@ -63,76 +219,85 @@ export function makeRendezvousMaker() {
           },
         };
 
-        for (const [remoteAddr, result] of Object.entries(
-          remoteAddressToResult,
-        )) {
-          remainingToFind += 1;
+        for (let i = 0; i < peerAddresses.length; i += 1) {
+          const sentFromUs = sendToPeerArray[i];
+          const theirAddress = peerAddresses[i];
 
           /**
-           * @type {Store<string, PeerRecord>}
+           * @type {Store<PeerAddress, PeerRecord>}
            */
           let addrToPeerRecord;
-          if (addrToPeerRecordStores.has(remoteAddr)) {
-            addrToPeerRecord = addrToPeerRecordStores.get(remoteAddr);
+          if (addrToPeerRecordStores.has(theirAddress)) {
+            addrToPeerRecord = addrToPeerRecordStores.get(theirAddress);
           } else {
-            addrToPeerRecord = makeStore('localAddr');
-            addrToPeerRecordStores.init(remoteAddr, addrToPeerRecord);
+            addrToPeerRecord = makeStore('localAddress');
+            addrToPeerRecordStores.init(theirAddress, addrToPeerRecord);
           }
 
-          const found = obj => {
+          const sendToUs = obj => {
             remainingToFind -= 1;
-            foundState[remoteAddr] = obj;
+            matchedState[theirAddress] = obj;
             if (remainingToFind === 0) {
               // We're done!
-              completer.complete();
+              rendezvousMany.cancel();
             } else {
-              // We need to keep going.
-              updater.updateState(harden({ ...foundState }));
+              // We need to keep going, but report the address.
+              updater.updateState(harden({ ...matchedState }));
             }
           };
           const peerRecord = harden({
-            found,
-            result,
+            sendTo: sendToUs,
+            receivedFrom: sentFromUs,
           });
-          if (addrToPeerRecord.has(addr)) {
-            addrToPeerRecord.set(addr, peerRecord);
+          if (addrToPeerRecord.has(ourAddress)) {
+            addrToPeerRecord.set(ourAddress, peerRecord);
           } else {
-            addrToPeerRecord.init(addr, peerRecord);
+            addrToPeerRecord.init(ourAddress, peerRecord);
           }
           disposals.push(() => {
             if (
-              addrToPeerRecord.has(addr) &&
-              addrToPeerRecord.get(addr) === peerRecord
+              addrToPeerRecord.has(ourAddress) &&
+              addrToPeerRecord.get(ourAddress) === peerRecord
             ) {
               // Remove the record for us.
-              addrToPeerRecord.delete(addr);
+              addrToPeerRecord.delete(ourAddress);
             }
           });
         }
 
-        return harden({ notifier, completer });
+        return harden(rendezvousMany);
       },
-      /**
-       * Synchronously complete a rendezvous with any number of remote addresses.
-       *
-       * @param {AddressResults} remoteAddressToResult
-       * @returns {AddressResults}
-       */
-      rendezvousWith(remoteAddressToResult) {
+      rendezvousWith(peerAddress, sendToPeer = undefined) {
+        assertPeerAddress(peerAddress);
+        const results = service.rendezvousWithMany([peerAddress], [sendToPeer]);
+        return getSingleResult(peerAddress, results);
+      },
+      rendezvousWithMany(peerAddresses, sendToPeer = []) {
+        assertManyArgs(peerAddresses, sendToPeer);
+
         /**
-         * @type {AddressResults}
+         * @type {RendezvousResults}
          */
-        const addressResults = {};
-        // Look up all the records associated with us and the remote address.
-        const addrToPeerRecord = addrToPeerRecordStores.get(addr);
-        for (const [remoteAddr, obj] of Object.entries(remoteAddressToResult)) {
-          if (addrToPeerRecord.has(remoteAddr)) {
-            const { found, result } = addrToPeerRecord.get(remoteAddr);
-            found(obj);
-            addressResults[remoteAddr] = result;
+        const rendezvousResults = {};
+        // Look up all the records shared between us and the remote address.
+        const addrToPeerRecord = addrToPeerRecordStores.get(ourAddress);
+        for (let i = 0; i < peerAddresses.length; i += 1) {
+          const sentFromUs = sendToPeer[i];
+          const theirAddress = peerAddresses[i];
+          if (addrToPeerRecord.has(theirAddress)) {
+            const {
+              sendTo: sendToThem,
+              receivedFrom: receivedFromThem,
+            } = addrToPeerRecord.get(theirAddress);
+
+            // Exchange the values.
+            sendToThem(sentFromUs);
+            rendezvousResults[theirAddress] = receivedFromThem;
           }
         }
-        return harden(addressResults);
+        return harden(rendezvousResults);
       },
-    });
+    };
+    return harden(service);
+  };
 }

--- a/packages/cosmic-swingset/lib/ag-solo/vats/rendezvous.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/rendezvous.js
@@ -178,7 +178,7 @@ export function makeRendezvousNamespace(namespaceName = 'Agoric') {
             // We want to mark the rendezvous as failed if not already.
             if (!already) {
               resultPK.reject(
-                details`Rendezvous with ${peerAddresses} not completed`.complain(),
+                Error(`Rendezvous with ${peerAddresses} not completed`),
               );
             }
             // Remove any stale references.

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-provisioning.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-provisioning.js
@@ -1,4 +1,5 @@
 import { E } from '@agoric/eventual-send';
+import makeStore from '@agoric/store';
 
 // This vat contains the controller-side provisioning service. To enable local
 // testing, it is loaded by both the controller and other ag-solo vat machines.
@@ -14,24 +15,40 @@ export function buildRootObject(_vatPowers) {
     vattp = v;
   }
 
-  async function pleaseProvision(nickname, pubkey, powerFlags) {
-    let chainBundle;
-    const fetch = harden({
-      getDemoBundle() {
-        return chainBundle;
-      },
-    });
-
-    // Add a remote and egress for the pubkey.
-    const { transmitter, setReceiver } = await E(vattp).addRemote(pubkey);
-    await E(comms).addRemote(pubkey, transmitter, setReceiver);
-
+  /**
+   * @type {Store<any, Array<Promise<any>>>}
+   */
+  const addressToChainBundles = makeStore('address');
+  async function pleaseProvision(nickname, address, powerFlags) {
     const INDEX = 1;
-    await E(comms).addEgress(pubkey, INDEX, fetch);
+    let chainBundles;
+    if (addressToChainBundles.has(address)) {
+      chainBundles = addressToChainBundles.get(address);
+    } else {
+      // Add a remote and egress for the address.
+      const { transmitter, setReceiver } = await E(vattp).addRemote(address);
+      await E(comms).addRemote(address, transmitter, setReceiver);
+      chainBundles = [];
+      addressToChainBundles.init(address, chainBundles);
+
+      const fetch = harden({
+        getDemoBundle() {
+          if (!chainBundles.length) {
+            throw Error(`No provisioned bundles to pick up for ${address}`);
+          }
+          // Consume a bundle.
+          return chainBundles.shift();
+        },
+      });
+
+      await E(comms).addEgress(address, INDEX, fetch);
+    }
 
     // Do this here so that any side-effects don't happen unless
     // the egress has been successfully added.
-    chainBundle = E(bundler).createUserBundle(nickname, powerFlags || []);
+    chainBundles.push(
+      E(bundler).createUserBundle(nickname, address, powerFlags || []),
+    );
     return { ingressIndex: INDEX };
   }
 

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-rendezvous.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-rendezvous.js
@@ -1,0 +1,5 @@
+import { makeRendezvousNamespace } from './rendezvous';
+
+export function buildRootObject() {
+  return makeRendezvousNamespace();
+}

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-rendezvous.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-rendezvous.js
@@ -1,5 +1,7 @@
 import { makeRendezvousNamespace } from './rendezvous';
 
 export function buildRootObject() {
-  return makeRendezvousNamespace();
+  return harden({
+    rendezvousServiceFor: makeRendezvousNamespace(),
+  });
 }

--- a/packages/cosmic-swingset/test/unitTests/test-rendezvous.js
+++ b/packages/cosmic-swingset/test/unitTests/test-rendezvous.js
@@ -5,7 +5,7 @@ import { makeRendezvousMaker } from '../../lib/ag-solo/vats/rendezvous';
 test('rendezvous with self', async t => {
   const makeRendezvous = makeRendezvousMaker();
   const self = makeRendezvous('self');
-  const { notifier } = self.initiateRendezvous({
+  const { notifier } = self.startRendezvous({
     [self.getLocalAddress()]: 'initiator',
   });
   t.deepEqual(self.rendezvousWith({ other: 'foo' }), {});
@@ -24,7 +24,7 @@ test('rendezvous three way', async t => {
   const testnet = makeRendezvous('testnet');
   const mainnet = makeRendezvous('mainnet');
 
-  const { notifier, completer } = solo.initiateRendezvous({
+  const { notifier, completer } = solo.startRendezvous({
     testnet: 'toTestnetFromSolo',
     mainnet: 'toMainnetFromSolo',
   });

--- a/packages/cosmic-swingset/test/unitTests/test-rendezvous.js
+++ b/packages/cosmic-swingset/test/unitTests/test-rendezvous.js
@@ -1,0 +1,56 @@
+import '@agoric/install-ses';
+import test from 'ava';
+import { makeRendezvousMaker } from '../../lib/ag-solo/vats/rendezvous';
+
+test('rendezvous with self', async t => {
+  const makeRendezvous = makeRendezvousMaker();
+  const self = makeRendezvous('self');
+  const { notifier } = self.initiateRendezvous({
+    [self.getLocalAddress()]: 'initiator',
+  });
+  t.deepEqual(self.rendezvousWith({ other: 'foo' }), {});
+  t.deepEqual(self.rendezvousWith({ self: 'first' }), {
+    self: 'initiator',
+  });
+  t.deepEqual(self.rendezvousWith({ self: 'second' }), {});
+  const update0 = await notifier.getUpdateSince();
+  t.deepEqual(update0, { updateCount: undefined, value: { self: 'first' } });
+});
+
+test('rendezvous three way', async t => {
+  const makeRendezvous = makeRendezvousMaker();
+
+  const solo = makeRendezvous('solo');
+  const testnet = makeRendezvous('testnet');
+  const mainnet = makeRendezvous('mainnet');
+
+  const { notifier, completer } = solo.initiateRendezvous({
+    testnet: 'toTestnetFromSolo',
+    mainnet: 'toMainnetFromSolo',
+  });
+
+  t.deepEqual(testnet.rendezvousWith({ solo: 'toSoloFromTestnet' }), {
+    solo: 'toTestnetFromSolo',
+  });
+  const update0 = await notifier.getUpdateSince();
+  t.deepEqual(update0.value, { testnet: 'toSoloFromTestnet' });
+
+  t.deepEqual(mainnet.rendezvousWith({ solo: 'toSoloFromMainnet' }), {
+    solo: 'toMainnetFromSolo',
+  });
+  const update1 = await notifier.getUpdateSince(update0.updateCount);
+  t.deepEqual(update1.value, {
+    testnet: 'toSoloFromTestnet',
+    mainnet: 'toSoloFromMainnet',
+  });
+
+  t.throws(() => completer.complete(), {
+    message: 'Cannot finish after termination.',
+    instanceOf: Error,
+  });
+  const update2 = await notifier.getUpdateSince(update1.updateCount);
+  t.deepEqual(update2.value, {
+    testnet: 'toSoloFromTestnet',
+    mainnet: 'toSoloFromMainnet',
+  });
+});

--- a/packages/cosmic-swingset/test/unitTests/test-rendezvous.js
+++ b/packages/cosmic-swingset/test/unitTests/test-rendezvous.js
@@ -108,3 +108,60 @@ test('rendezvous race three way', async t => {
     rendezvousFailed,
   );
 });
+
+test('multiple pending rendezvous', async t => {
+  const makeRendezvous = makeRendezvousNamespace();
+
+  const solo = makeRendezvous('solo');
+  const testnet = makeRendezvous('testnet');
+  const mainnet = makeRendezvous('mainnet');
+
+  const rendezvous1 = solo.startRendezvous(
+    'testnet',
+    makeObj('fromSolo1'),
+    'rdv1',
+  );
+  const rendezvous2 = solo.startRendezvous(
+    'testnet',
+    makeObj('fromSolo2'),
+    'rdv2',
+  );
+
+  t.is(
+    testnet
+      .completeRendezvous('solo', makeObj('toSoloFromTestnet2'), 'rdv2')
+      .getName(),
+    'fromSolo2',
+  );
+
+  t.is(
+    testnet
+      .completeRendezvous('solo', makeObj('toSoloFromTestnet1'), 'rdv1')
+      .getName(),
+    'fromSolo1',
+  );
+
+  t.is(await E(rendezvous1.getResult()).getName(), 'toSoloFromTestnet1');
+  t.is(await E(rendezvous2.getResult()).getName(), 'toSoloFromTestnet2');
+
+  t.throws(
+    () =>
+      mainnet.completeRendezvous('solo', makeObj('toSoloFromMainnet'), 'rdv1'),
+    rendezvousFailed,
+  );
+  t.throws(
+    () =>
+      mainnet.completeRendezvous('solo', makeObj('toSoloFromMainnet'), 'rdv2'),
+    rendezvousFailed,
+  );
+  t.throws(
+    () =>
+      testnet.completeRendezvous('solo', makeObj('toSoloFromTestnet'), 'rdv1'),
+    rendezvousFailed,
+  );
+  t.throws(
+    () =>
+      testnet.completeRendezvous('solo', makeObj('toSoloFromTestnet'), 'rdv2'),
+    rendezvousFailed,
+  );
+});

--- a/packages/dapp-svelte-wallet/api/deploy.js
+++ b/packages/dapp-svelte-wallet/api/deploy.js
@@ -12,7 +12,7 @@ export default async function deployWallet(
   const home = await homePromise;
   // console.log('have home', home);
   const {
-    agoric: { board, faucet, zoe },
+    agoric: { board, faucet, rendezvous, zoe },
     local: { http, spawner, wallet: oldWallet },
   } = home;
 
@@ -27,6 +27,7 @@ export default async function deployWallet(
     zoe,
     board,
     faucet,
+    rendezvous,
     http,
   });
 
@@ -34,7 +35,10 @@ export default async function deployWallet(
     if (!wallet) {
       return [];
     }
-    const issuers = await E(wallet).getIssuers();
+    const [issuers, purses] = await Promise.all([
+      E(wallet).getIssuers(),
+      E(wallet).getPurses(),
+    ]);
     const brandToIssuer = new Map();
     await Promise.all([
       issuers.map(async ([issuerPetname, issuer]) => {
@@ -44,7 +48,6 @@ export default async function deployWallet(
         brandToIssuer.set(brand, { issuerPetname, issuer });
       }),
     ]);
-    const purses = await E(wallet).getPurses();
     return Promise.all(
       purses.map(async ([pursePetname, purse]) => {
         const brand = await E(purse).getAllegedBrand();

--- a/packages/dapp-svelte-wallet/api/src/lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-wallet.js
@@ -268,34 +268,42 @@ export async function makeWallet({
     return proposalForDisplay;
   };
 
+  /**
+   * Create a JSONable offer structure.
+   *
+   * @param {any} offer
+   */
+  function displayOffer(offer) {
+    const { id, instance, installation, proposalTemplate } = offer;
+    const displayedOffer = {
+      ...offer,
+      requestContext: { ...offer.requestContext },
+    };
+
+    if (instance) {
+      displayedOffer.instancePetname = display(instance).petname;
+    }
+    if (installation) {
+      displayedOffer.installationPetname = display(installation).petname;
+    }
+    const alreadyDisplayed =
+      inboxState.has(id) && inboxState.get(id).proposalForDisplay;
+    displayedOffer.proposalForDisplay = displayProposal(
+      alreadyDisplayed || proposalTemplate,
+    );
+
+    return displayedOffer;
+  }
+
   async function updateInboxState(id, offer, doPush = true) {
     // Only sent the uncompiled offer to the client.
-    const { proposalTemplate } = offer;
     const { instance, installation } = idToOffer.get(id);
     if (!instance || !installation) {
       // We haven't yet deciphered the invitation, so don't send
       // this offer.
       return;
     }
-    const instanceDisplay = display(instance);
-    const installationDisplay = display(installation);
-    const alreadyDisplayed =
-      inboxState.has(id) && inboxState.get(id).proposalForDisplay;
-
-    const offerForDisplay = {
-      ...offer,
-      // We cannot store the actions, installation, and instance in the
-      // displayed offer objects because they are presences are presences and we
-      // don't wish to send presences to the frontend.
-      actions: undefined,
-      installation: undefined,
-      instance: undefined,
-      proposalTemplate,
-      instancePetname: instanceDisplay.petname,
-      installationPetname: installationDisplay.petname,
-      proposalForDisplay: displayProposal(alreadyDisplayed || proposalTemplate),
-    };
-
+    const offerForDisplay = displayOffer({ ...offer, ...idToOffer.get(id) });
     inboxState.set(id, offerForDisplay);
     if (doPush) {
       // Only trigger a state change if this was a single update.
@@ -851,7 +859,7 @@ export async function makeWallet({
       await updateInboxState(id, idToOffer.get(id));
       return id;
     });
-    return { offer, invitedP };
+    return { offer: displayOffer(offer), invitedP };
   }
 
   function consummated(offer) {

--- a/packages/dapp-svelte-wallet/api/src/lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-wallet.js
@@ -86,6 +86,16 @@ export async function makeWallet({
   const pursesFullState = new Map();
   const inboxState = new Map();
 
+  const idToInvitationPK = makeStore('offerId');
+  const ensureInvitationPK = id => {
+    if (idToInvitationPK.has(id)) {
+      return idToInvitationPK.get(id);
+    }
+    const invitationPK = makePromiseKit();
+    idToInvitationPK.init(id, invitationPK);
+    return invitationPK;
+  };
+
   /**
    * The default Zoe invite purse is used to make an offer.
    *
@@ -642,37 +652,48 @@ export async function makeWallet({
       invitationHandleBoardId = inviteHandleBoardId,
     } = offer;
 
-    assert.typeof(
-      invitationHandleBoardId,
-      'string',
-      details`invitationHandleBoardId must be a string`,
-    );
     const { proposal, purseKeywordRecord } = compileProposal(
       offer.proposalTemplate,
     );
 
-    // Find invite in wallet and withdraw
-    const { value: inviteValueElems } = await E(
-      zoeInvitePurse,
-    ).getCurrentAmount();
-    const inviteHandle = await E(board).getValue(invitationHandleBoardId);
-    const matchInvite = element => element.handle === inviteHandle;
-    const inviteBrand = purseToBrand.get(zoeInvitePurse);
-    const { amountMath: inviteAmountMath } = brandTable.getByBrand(inviteBrand);
-    const matchingInvite = inviteValueElems.find(matchInvite);
-    assert(
-      matchingInvite,
-      details`Cannot find invite corresponding to ${q(
+    const invitationPK = ensureInvitationPK(offer.id);
+    const inviteP = invitationPK.promise;
+    if (invitationHandleBoardId) {
+      // Legacy: the offer does not contain the invitation.
+      assert.typeof(
         invitationHandleBoardId,
-      )}`,
-    );
-    const inviteAmount = inviteAmountMath.make(
-      harden([inviteValueElems.find(matchInvite)]),
-    );
-    const inviteP = E(zoeInvitePurse).withdraw(inviteAmount);
+        'string',
+        details`invitationHandleBoardId must be a string`,
+      );
+
+      // Find invite in wallet and withdraw
+      const { value: inviteValueElems } = await E(
+        zoeInvitePurse,
+      ).getCurrentAmount();
+      const inviteHandle = await E(board).getValue(invitationHandleBoardId);
+      const matchInvite = element => element.handle === inviteHandle;
+      const inviteBrand = purseToBrand.get(zoeInvitePurse);
+      const { amountMath: inviteAmountMath } = brandTable.getByBrand(
+        inviteBrand,
+      );
+      const matchingInvite = inviteValueElems.find(matchInvite);
+      assert(
+        matchingInvite,
+        details`Cannot find invite corresponding to ${q(
+          invitationHandleBoardId,
+        )}`,
+      );
+      const inviteAmount = inviteAmountMath.make(
+        harden([inviteValueElems.find(matchInvite)]),
+      );
+      invitationPK.resolve(E(zoeInvitePurse).withdraw(inviteAmount));
+    }
+
+    // Find the details for the invitation.
     const { installation, instance } = await E(zoe).getInvitationDetails(
       inviteP,
     );
+    idToInvitationPK.delete(offer.id);
 
     return {
       proposal,
@@ -780,6 +801,20 @@ export async function makeWallet({
     return dappOrigins.get(origin);
   }
 
+  async function addOfferInvitation(offer, inviteP, requestContext = {}) {
+    const dappOrigin = requestContext.dappOrigin || requestContext.origin;
+    const { id } = offer;
+    if (dappOrigin !== undefined) {
+      assert(
+        id.startsWith(`${dappOrigin}#`),
+        details`Offer id ${id} is not from ${dappOrigin}`,
+      );
+    }
+    const invitationPK = ensureInvitationPK(id);
+    invitationPK.resolve(inviteP);
+    await inviteP;
+  }
+
   async function addOffer(rawOffer, requestContext = {}) {
     const dappOrigin =
       requestContext.dappOrigin || requestContext.origin || 'unknown';
@@ -800,21 +835,23 @@ export async function makeWallet({
 
     // Our inbox state may have an enriched offer.
     await updateInboxState(id, idToOffer.get(id));
-    const { installation, instance } = await compiledOfferP;
-
-    if (!idToOffer.has(id)) {
+    const invitedP = compiledOfferP.then(async ({ installation, instance }) => {
+      if (!idToOffer.has(id)) {
+        return id;
+      }
+      idToOffer.set(
+        id,
+        harden({
+          ...idToOffer.get(id),
+          installation,
+          instance,
+        }),
+      );
+      // Update the inbox any time later.
+      await updateInboxState(id, idToOffer.get(id));
       return id;
-    }
-    idToOffer.set(
-      id,
-      harden({
-        ...idToOffer.get(id),
-        installation,
-        instance,
-      }),
-    );
-    await updateInboxState(id, idToOffer.get(id));
-    return id;
+    });
+    return { offer, invitedP };
   }
 
   function consummated(offer) {
@@ -1285,6 +1322,7 @@ export async function makeWallet({
     getPurse,
     getPurseIssuer,
     addOffer,
+    addOfferInvitation,
     declineOffer,
     cancelOffer,
     acceptOffer,

--- a/packages/dapp-svelte-wallet/api/src/wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/wallet.js
@@ -93,8 +93,8 @@ export function buildRootObject(_vatPowers) {
   }
 
   async function adminOnMessage(obj, meta = { origin: 'unknown' }) {
-    const { type, data, dappOrigin = meta.origin } = obj;
-    switch (type) {
+    const { data, dappOrigin = meta.origin } = obj;
+    switch (obj.type) {
       case 'walletGetPurses': {
         return {
           type: 'walletUpdatePurses',
@@ -304,10 +304,11 @@ export function buildRootObject(_vatPowers) {
       },
       async addOfferInvitation(offer, invitation) {
         await approve();
-        return wallet.addOfferInvitation(offer, invitation, {
+        const p = wallet.addOfferInvitation(offer, invitation, {
           ...meta,
           dappOrigin,
         });
+        return p;
       },
       async getOfferNotifier(status = null) {
         await approve();
@@ -365,7 +366,6 @@ export function buildRootObject(_vatPowers) {
 
           async onMessage(obj, meta) {
             const {
-              type,
               dappOrigin = meta.origin,
               suggestedDappPetname = (meta.query &&
                 meta.query.suggestedDappPetname) ||
@@ -404,7 +404,7 @@ export function buildRootObject(_vatPowers) {
               );
             }
 
-            switch (type) {
+            switch (obj.type) {
               case 'walletRendezvous': {
                 const { dappAddresses } = obj;
                 const addressToWalletPK = makeStore('address');

--- a/packages/dapp-svelte-wallet/api/src/wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/wallet.js
@@ -435,7 +435,8 @@ export function buildRootObject(_vatPowers) {
                     console.error('Cannot rendezvous with', dappAddresses, e),
                   );
 
-                // Tell them how to find us.
+                // Tell them how to find us, once the rendezvous is initiated.
+                await rendezvous;
                 return {
                   type: 'walletRendezvousResponse',
                   data: { walletAddresses },

--- a/packages/dapp-svelte-wallet/api/src/wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/wallet.js
@@ -408,7 +408,7 @@ export function buildRootObject(_vatPowers) {
 
             switch (obj.type) {
               case 'walletRendezvous': {
-                const { dappAddresses } = obj;
+                const { dappAddresses, selector } = obj;
 
                 // Create a rendezvous from one of the dapp addresses to the
                 // wallet bridge facet.
@@ -416,6 +416,7 @@ export function buildRootObject(_vatPowers) {
                 const rendezvous = E(chainRendezvous).startRendezvous(
                   dappAddresses,
                   walletBridgePK.promise,
+                  selector,
                 );
 
                 // If this connection closes, stop listening for addresses.

--- a/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
@@ -260,7 +260,8 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
   const rawId = '1588645041696';
   const offer = formulateBasicOffer(rawId, inviteHandleBoardId1);
 
-  await wallet.addOffer(offer);
+  const { invitedP } = await wallet.addOffer(offer);
+  await invitedP;
 
   // Deposit a zoe invite in the wallet so that we can see how the
   // invite purse balance is rendered with petnames. We should see
@@ -431,7 +432,9 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
       proposalTemplate: {},
       requestContext: { dappOrigin: 'unknown' },
       instancePetname: 'automaticRefund',
+      installation: {},
       installationPetname: 'automaticRefund',
+      instance: {},
       proposalForDisplay: { exit: { onDemand: null } },
     },
     `inboxStateChangeLog with names`,
@@ -528,7 +531,9 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
       inviteHandleBoardId: '727995140',
       proposalTemplate: {},
       requestContext: { dappOrigin: 'unknown' },
+      instance: {},
       instancePetname: 'automaticRefund',
+      installation: {},
       installationPetname: 'automaticRefund2',
       proposalForDisplay: { exit: { onDemand: null } },
     },
@@ -586,7 +591,8 @@ test('lib-wallet offer methods', async t => {
   const id = `unknown#${rawId}`;
   const offer = formulateBasicOffer(rawId, inviteHandleBoardId1);
 
-  await wallet.addOffer(offer);
+  const { invitedP } = await wallet.addOffer(offer);
+  await invitedP;
 
   t.deepEqual(
     wallet.getOffers(),
@@ -594,8 +600,8 @@ test('lib-wallet offer methods', async t => {
       {
         id: 'unknown#1588645041696',
         inviteHandleBoardId: '727995140',
-        instance,
         installation,
+        instance,
         proposalTemplate: {
           give: { Contribution: { pursePetname: 'Fun budget', value: 1 } },
           exit: { onDemand: null },
@@ -632,7 +638,8 @@ test('lib-wallet offer methods', async t => {
   const offer2 = formulateBasicOffer(rawId2, inviteHandleBoardId2);
   await wallet.deposit('Default Zoe invite purse', invite2);
   // `addOffer` withdraws the invite from the Zoe invite purse.
-  await wallet.addOffer(offer2);
+  const { invitedP: invited2P } = await wallet.addOffer(offer2);
+  await invited2P;
   await wallet.declineOffer(id2);
   // TODO: test cancelOffer with a contract that holds offers, like
   // simpleExchange
@@ -693,6 +700,8 @@ test('lib-wallet offer methods', async t => {
       {
         id: 'unknown#1588645041696',
         inviteHandleBoardId: '727995140',
+        installation: {},
+        instance,
         proposalTemplate: {
           give: { Contribution: { pursePetname: 'Fun budget', value: 1 } },
           exit: { onDemand: null },
@@ -724,6 +733,8 @@ test('lib-wallet offer methods', async t => {
       {
         id: 'unknown#1588645230204',
         inviteHandleBoardId: '371571443',
+        installation: {},
+        instance,
         proposalTemplate: {
           give: { Contribution: { pursePetname: 'Fun budget', value: 1 } },
           exit: { onDemand: null },
@@ -856,7 +867,8 @@ test('lib-wallet addOffer for autoswap swap', async t => {
     },
   };
 
-  await wallet.addOffer(offer);
+  const { invitedP } = await wallet.addOffer(offer);
+  await invitedP;
 
   const accepted = await wallet.acceptOffer(id);
   assert(accepted);

--- a/packages/eventual-send/src/index.js
+++ b/packages/eventual-send/src/index.js
@@ -367,7 +367,7 @@ export function makeHandledPromise() {
         }
         return t(...args);
       }
-      if (!t) {
+      if (t !== Object(t)) {
         const ftype = typeof t;
         throw TypeError(
           `Cannot deliver ${q(method)} to target; typeof target is "${ftype}"`,


### PR DESCRIPTION
This service allows two Agoric solos introduced to one another only by pure data to use the chain to exchange two object references.  For example, a Dapp API server can get a reference to their client's Dapp-specific wallet facet.  The rendezvous service ensures the two sides know they are talking to the same chain.

Consider the Agoric chain, A, and two ag-solos attached to the chain: B and
C.  Given a Dapp UI, D, that can speak pure data (not ocaps) to both B and C,
you have the following architecture:

```
            A Agoric chain
          // \\
 ag-solo B     C ag-solo
          \   /
            D Dapp UI
```
where the double-slashes indicate the ocap connections and the single-slashes
indicate the pure data connections.  If B and C are willing, D can get B's
rendezvous address, then tell C to initiate a rendezvous to B's address.  C
will return its own rendezvous address to D, who then tells B to complete the
rendezvous to C's address.

The on-chain rendezvous namespace matches the two addresses to each other,
sending B's specified object to C and C's specified object to B.  That
effectively creates a connection between B and C, exposing only the methods
that they choose, and (if the rendezvous addresses are assigned by A and
globally unique, such as public keys signing their connection to A),
guaranteeing that only B and C have initial access to those objects and that
they know D introduced them.

A strength of the system is that the rendezvous will fail if B and C are
*not* connected to the same chain.  This helps D ensure that B and C have the
same specific on-chain services, such as a common Zoe.

Other, semi-related fixes include:
* make the HTTP service more robust for JSON data
* clean up the agoric-cli

Not necessary for this PR, but Agoric/dapp-encouragement#70 can take advantage of the rendezvous once it works.
