### PR TITLE
fix(agoric-cli): correct missing installation of ui subdirectory

### DIFF
--- a/packages/agoric-cli/lib/install.js
+++ b/packages/agoric-cli/lib/install.js
@@ -17,7 +17,7 @@ export default async function installMain(progname, rawArgs, powers, opts) {
 
   const rimraf = file => pspawn('rm', ['-rf', file]);
   const existingSubdirs = await Promise.all(
-    ['.', '_agstate/agoric-servers', 'contract', 'api']
+    ['.', '_agstate/agoric-servers', 'contract', 'api', 'ui']
       .sort()
       .map(async subd => {
         const exists = await fs.stat(`${subd}/package.json`).catch(_ => false);
@@ -57,8 +57,8 @@ export default async function installMain(progname, rawArgs, powers, opts) {
         packages.set(pkg, pj.name);
         versions.set(pj.name, pj.version);
 
-        // eslint-disable-next-line no-constant-condition
-        if (false) {
+        const SUBOPTIMAL = false;
+        if (SUBOPTIMAL) {
           // This use of yarn is noisy and slow.
           return pspawn('yarn', [...linkFlags, 'link'], {
             stdio: 'inherit',

--- a/packages/cosmic-swingset/lib/ag-solo/html/wallet-bridge.html
+++ b/packages/cosmic-swingset/lib/ag-solo/html/wallet-bridge.html
@@ -44,7 +44,6 @@
       let pendingWalletRequests = 0;
 
       launchWallet.addEventListener('click', ev => {
-        ackWallet();
         alert(`\
 Use the:
 


### PR DESCRIPTION
This was an oversight when consolidating the `yarn link` logic.  Fixing this also allows the `ui` directory to directly reference packages provided by Agoric-sdk.

Closes Agoric/dapp-encouragement#63
Closes Agoric/documentation#297
Closes Agoric/documentation#346
