### PR TITLE
Split exchange benchmark rounds in two

### DIFF
--- a/packages/swingset-runner/demo/exchangeBenchmark/bootstrap.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/bootstrap.js
@@ -57,9 +57,13 @@ export function buildRootObject(_vatPowers, vatParameters) {
     },
     async runBenchmarkRound() {
       round += 1;
-      await E(alice).initiateTrade(bob);
-      await E(bob).initiateTrade(alice);
-      return `round ${round} complete`;
+      if (round % 2) {
+        await E(alice).initiateTrade(bob);
+        return `round ${round} (alice->bob) complete`;
+      } else {
+        await E(bob).initiateTrade(alice);
+        return `round ${round} (bob->alice) complete`;
+      }
     },
   });
 }


### PR DESCRIPTION
Small change to the swingset-runner "exchange" benchmark. Instead of each round having Alice trade simoleans for moola with Bob and then Bob trading them back again with Alice (so that each round ends each party in the same state they began), rounds alternate: Alice->Bob in odd numbered rounds, Bob->Alice in even numbered rounds.  This way only one transaction happens on each round, making it easier to analyze per-transaction overheads (object allocations, messages sent, promises generated, promises resolved, etc) since each critical operation only happens once.