### PR TITLE
feat(zoe): export src/contractFacet/fakeVatAdmin for dapps

### DIFF
--- a/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
@@ -6,7 +6,7 @@ import bundleSource from '@agoric/bundle-source';
 import { makeIssuerKit, makeLocalAmountMath } from '@agoric/ertp';
 
 import { makeZoe } from '@agoric/zoe';
-import fakeVatAdmin from '@agoric/zoe/test/unitTests/contracts/fakeVatAdmin';
+import fakeVatAdmin from '@agoric/zoe/src/contractFacet/fakeVatAdmin';
 import { makeRegistrar } from '@agoric/registrar';
 
 import { assert } from '@agoric/assert';

--- a/packages/zoe/src/contractFacet/fakeVatAdmin.js
+++ b/packages/zoe/src/contractFacet/fakeVatAdmin.js
@@ -1,7 +1,7 @@
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
 
-import { evalContractBundle } from '../../../src/contractFacet/evalContractCode';
+import { evalContractBundle } from './evalContractCode';
 
 function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
   // FakeVatPowers isn't intended to support testing of vat termination, it is

--- a/packages/zoe/test/unitTests/contractSupport/test-depositTo.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-depositTo.js
@@ -8,7 +8,7 @@ import bundleSource from '@agoric/bundle-source';
 
 import { setup } from '../setupBasicMints';
 import { makeZoe } from '../../..';
-import { makeFakeVatAdmin } from '../contracts/fakeVatAdmin';
+import { makeFakeVatAdmin } from '../../../src/contractFacet/fakeVatAdmin';
 import { depositToSeat } from '../../../src/contractSupport/zoeHelpers';
 
 const contractRoot = `${__dirname}/../zcf/zcfTesterContract`;

--- a/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
@@ -8,7 +8,7 @@ import bundleSource from '@agoric/bundle-source';
 
 import { setup } from '../setupBasicMints';
 import { makeZoe } from '../../..';
-import { makeFakeVatAdmin } from '../contracts/fakeVatAdmin';
+import { makeFakeVatAdmin } from '../../../src/contractFacet/fakeVatAdmin';
 import { depositToSeat, withdrawFromSeat } from '../../../src/contractSupport';
 import { assertPayoutAmount } from '../../zoeTestHelpers';
 

--- a/packages/zoe/test/unitTests/contracts/test-brokenContract.js
+++ b/packages/zoe/test/unitTests/contracts/test-brokenContract.js
@@ -7,7 +7,7 @@ import bundleSource from '@agoric/bundle-source';
 // noinspection ES6PreferShortImport
 import { makeZoe } from '../../../src/zoeService/zoe';
 import { setup } from '../setupBasicMints';
-import fakeVatAdmin from './fakeVatAdmin';
+import fakeVatAdmin from '../../../src/contractFacet/fakeVatAdmin';
 
 const automaticRefundRoot = `${__dirname}/brokenAutoRefund`;
 

--- a/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
@@ -7,7 +7,7 @@ import { E } from '@agoric/eventual-send';
 
 import { makeZoe } from '../../../src/zoeService/zoe';
 import { setup } from '../setupBasicMints';
-import fakeVatAdmin from './fakeVatAdmin';
+import fakeVatAdmin from '../../../src/contractFacet/fakeVatAdmin';
 
 const contractRoot = `${__dirname}/escrowToVote`;
 

--- a/packages/zoe/test/unitTests/contracts/test-mintPayments.js
+++ b/packages/zoe/test/unitTests/contracts/test-mintPayments.js
@@ -7,7 +7,7 @@ import bundleSource from '@agoric/bundle-source';
 
 import { E } from '@agoric/eventual-send';
 import { makeIssuerKit, makeLocalAmountMath } from '@agoric/ertp';
-import fakeVatAdmin from './fakeVatAdmin';
+import fakeVatAdmin from '../../../src/contractFacet/fakeVatAdmin';
 
 // noinspection ES6PreferShortImport
 import { makeZoe } from '../../../src/zoeService/zoe';

--- a/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
@@ -6,7 +6,7 @@ import bundleSource from '@agoric/bundle-source';
 
 import { makeIssuerKit, makeLocalAmountMath } from '@agoric/ertp';
 import { E } from '@agoric/eventual-send';
-import fakeVatAdmin from './fakeVatAdmin';
+import fakeVatAdmin from '../../../src/contractFacet/fakeVatAdmin';
 
 // noinspection ES6PreferShortImport
 import { makeZoe } from '../../../src/zoeService/zoe';

--- a/packages/zoe/test/unitTests/contracts/test-secondPriceAuction.js
+++ b/packages/zoe/test/unitTests/contracts/test-secondPriceAuction.js
@@ -10,7 +10,7 @@ import { makeZoe } from '../../../src/zoeService/zoe';
 import buildManualTimer from '../../../tools/manualTimer';
 import { setup } from '../setupBasicMints';
 import { setupMixed } from '../setupMixedMints';
-import fakeVatAdmin from './fakeVatAdmin';
+import fakeVatAdmin from '../../../src/contractFacet/fakeVatAdmin';
 
 const secondPriceAuctionRoot = `${__dirname}/../../../src/contracts/auction/secondPriceAuction`;
 

--- a/packages/zoe/test/unitTests/contracts/test-sellTickets.js
+++ b/packages/zoe/test/unitTests/contracts/test-sellTickets.js
@@ -6,7 +6,7 @@ import test from 'ava';
 import bundleSource from '@agoric/bundle-source';
 import { makeIssuerKit, makeLocalAmountMath } from '@agoric/ertp';
 import { E } from '@agoric/eventual-send';
-import fakeVatAdmin from './fakeVatAdmin';
+import fakeVatAdmin from '../../../src/contractFacet/fakeVatAdmin';
 
 // noinspection ES6PreferShortImport
 import { makeZoe } from '../../../src/zoeService/zoe';

--- a/packages/zoe/test/unitTests/contracts/test-useObj.js
+++ b/packages/zoe/test/unitTests/contracts/test-useObj.js
@@ -9,7 +9,7 @@ import bundleSource from '@agoric/bundle-source';
 import { E } from '@agoric/eventual-send';
 import { makeZoe } from '../../../src/zoeService/zoe';
 import { setup } from '../setupBasicMints';
-import fakeVatAdmin from './fakeVatAdmin';
+import fakeVatAdmin from '../../../src/contractFacet/fakeVatAdmin';
 
 const contractRoot = `${__dirname}/useObjExample`;
 

--- a/packages/zoe/test/unitTests/setupBasicMints.js
+++ b/packages/zoe/test/unitTests/setupBasicMints.js
@@ -1,6 +1,6 @@
 import { makeIssuerKit } from '@agoric/ertp';
 import { makeZoe } from '../../src/zoeService/zoe';
-import fakeVatAdmin from './contracts/fakeVatAdmin';
+import fakeVatAdmin from '../../src/contractFacet/fakeVatAdmin';
 
 const setup = () => {
   const moolaBundle = makeIssuerKit('moola');

--- a/packages/zoe/test/unitTests/setupMixedMints.js
+++ b/packages/zoe/test/unitTests/setupMixedMints.js
@@ -1,6 +1,6 @@
 import { makeIssuerKit } from '@agoric/ertp';
 import { makeZoe } from '../../src/zoeService/zoe';
-import fakeVatAdmin from './contracts/fakeVatAdmin';
+import fakeVatAdmin from '../../src/contractFacet/fakeVatAdmin';
 
 const setupMixed = () => {
   const ccBundle = makeIssuerKit('CryptoCats', 'strSet');

--- a/packages/zoe/test/unitTests/setupNonFungibleMints.js
+++ b/packages/zoe/test/unitTests/setupNonFungibleMints.js
@@ -1,6 +1,6 @@
 import { makeIssuerKit } from '@agoric/ertp';
 import { makeZoe } from '../../src/zoeService/zoe';
-import fakeVatAdmin from './contracts/fakeVatAdmin';
+import fakeVatAdmin from '../../src/contractFacet/fakeVatAdmin';
 
 const setupNonFungible = () => {
   const ccBundle = makeIssuerKit('CryptoCats', 'strSet');

--- a/packages/zoe/test/unitTests/zcf/setupZcfTest.js
+++ b/packages/zoe/test/unitTests/zcf/setupZcfTest.js
@@ -3,7 +3,7 @@ import bundleSource from '@agoric/bundle-source';
 
 // noinspection ES6PreferShortImport
 import { makeZoe } from '../../../src/zoeService/zoe';
-import { makeFakeVatAdmin } from '../contracts/fakeVatAdmin';
+import { makeFakeVatAdmin } from '../../../src/contractFacet/fakeVatAdmin';
 
 const contractRoot = `${__dirname}/zcfTesterContract`;
 

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
@@ -9,7 +9,7 @@ import bundleSource from '@agoric/bundle-source';
 // noinspection ES6PreferShortImport
 import { makeZoe } from '../../../src/zoeService/zoe';
 import { setup } from '../setupBasicMints';
-import { makeFakeVatAdmin } from '../contracts/fakeVatAdmin';
+import { makeFakeVatAdmin } from '../../../src/contractFacet/fakeVatAdmin';
 
 import '../../../exported';
 


### PR DESCRIPTION
Properly export this facility so that it's available on NPM.  It is useful outside of internal Zoe tests.

#dapp-encouragement-branch: mfig/fake-vat-admin
