### PR TITLE
Thread stack traces to console, add entangled assert

### DIFF
--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -88,6 +88,7 @@ export async function makeSwingsetController(
     filePrefix: 'kernel',
     endowments: {
       console: makeConsole(`${debugPrefix}SwingSet:kernel`),
+      assert,
       require: kernelRequire,
     },
   });

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -810,7 +810,7 @@ export default function buildKernel(
       // eslint-disable-next-line no-await-in-loop
       const NS = await importBundle(source.bundle, {
         filePrefix: `dev-${name}`,
-        endowments: harden({ ...vatEndowments, console: devConsole }),
+        endowments: harden({ ...vatEndowments, console: devConsole, assert }),
       });
       assert(
         typeof NS.buildRootDeviceNode === 'function',

--- a/packages/SwingSet/src/kernel/vatManager/localVatManager.js
+++ b/packages/SwingSet/src/kernel/vatManager/localVatManager.js
@@ -140,6 +140,7 @@ export function makeLocalVatManagerFactory(tools) {
       ...vatEndowments,
       ...ls.vatGlobals,
       console: vatConsole,
+      assert,
     });
     const inescapableTransforms = [];
     const inescapableGlobalLexicals = {};

--- a/packages/SwingSet/src/kernel/vatManager/nodeWorkerSupervisor.js
+++ b/packages/SwingSet/src/kernel/vatManager/nodeWorkerSupervisor.js
@@ -127,6 +127,7 @@ parentPort.on('message', ([type, ...margs]) => {
     const endowments = {
       ...ls.vatGlobals,
       console: makeConsole(`SwingSet:vatWorker`),
+      assert,
     };
 
     importBundle(bundle, { endowments }).then(vatNS => {

--- a/packages/SwingSet/src/kernel/vatManager/subprocessSupervisor.js
+++ b/packages/SwingSet/src/kernel/vatManager/subprocessSupervisor.js
@@ -147,6 +147,7 @@ fromParent.on('data', ([type, ...margs]) => {
     const endowments = {
       ...ls.vatGlobals,
       console: makeConsole(`SwingSet:vatWorker`),
+      assert,
     };
 
     importBundle(bundle, { endowments }).then(vatNS => {

--- a/packages/SwingSet/src/kernel/virtualObjectManager.js
+++ b/packages/SwingSet/src/kernel/virtualObjectManager.js
@@ -1,4 +1,4 @@
-import { assert, details, q } from '@agoric/assert';
+import { assert, details as d, quote as q } from '@agoric/assert';
 import { parseVatSlot } from '../parseVatSlots';
 
 const initializationInProgress = Symbol('initializing');
@@ -106,17 +106,16 @@ export function makeCache(size, fetch, store) {
 /**
  * Create a new virtual object manager.  There is one of these for each vat.
  *
- * @param {*} syscall  Vat's syscall object, used to access the `vatstoreGet` and
- *    `vatstoreSet` operations.
+ * @param {*} syscall  Vat's syscall object, used to access the `vatstoreGet`
+ *   and `vatstoreSet` operations.
  * @param {() => number} allocateExportID  Function to allocate the next object
- *    export ID for the enclosing vat.
- * @param valToSlotTable {*}  The vat's table that maps object identities to their
- *    corresponding export IDs
- * @param m {*}  The vat's marshaler.
- * @param cacheSize {number}  How many virtual objects this manager should cache
+ *   export ID for the enclosing vat.
+ * @param {*} valToSlotTable  The vat's table that maps object identities to
+ *   their corresponding export IDs
+ * @param {*} m The vat's marshaler.
+ * @param {number} cacheSize How many virtual objects this manager should cache
  *   in memory.
- *
- * @returns a new virtual object manager.
+ * @returns {*} a new virtual object manager.
  *
  * The virtual object manager allows the creation of persistent objects that do
  * not need to occupy memory when they are not in use.  It provides four
@@ -155,7 +154,6 @@ export function makeVirtualObjectManager(
    *
    * @param {string} vobjID  The virtual object ID of the object whose state is
    *    being fetched.
-   *
    * @returns {*} an object representing the object's stored state.
    */
   function fetch(vobjID) {
@@ -229,14 +227,11 @@ export function makeVirtualObjectManager(
     nextWeakStoreID += 1;
 
     function assertKeyDoesNotExist(key) {
-      assert(
-        !backingMap.has(key),
-        details`${q(keyName)} already registered: ${key}`,
-      );
+      assert(!backingMap.has(key), d`${q(keyName)} already registered: ${key}`);
     }
 
     function assertKeyExists(key) {
-      assert(backingMap.has(key), details`${q(keyName)} not found: ${key}`);
+      assert(backingMap.has(key), d`${q(keyName)} not found: ${key}`);
     }
 
     function virtualObjectKey(key) {
@@ -267,7 +262,7 @@ export function makeVirtualObjectManager(
         if (vkey) {
           assert(
             !syscall.vatstoreGet(vkey),
-            details`${q(keyName)} already registered: ${key}`,
+            d`${q(keyName)} already registered: ${key}`,
           );
           syscall.vatstoreSet(vkey, JSON.stringify(m.serialize(value)));
         } else {
@@ -279,7 +274,7 @@ export function makeVirtualObjectManager(
         const vkey = virtualObjectKey(key);
         if (vkey) {
           const rawValue = syscall.vatstoreGet(vkey);
-          assert(rawValue, details`${q(keyName)} not found: ${key}`);
+          assert(rawValue, d`${q(keyName)} not found: ${key}`);
           return m.unserialize(JSON.parse(rawValue));
         } else {
           assertKeyExists(key);
@@ -289,10 +284,7 @@ export function makeVirtualObjectManager(
       set(key, value) {
         const vkey = virtualObjectKey(key);
         if (vkey) {
-          assert(
-            syscall.vatstoreGet(vkey),
-            details`${q(keyName)} not found: ${key}`,
-          );
+          assert(syscall.vatstoreGet(vkey), d`${q(keyName)} not found: ${key}`);
           syscall.vatstoreSet(vkey, JSON.stringify(m.serialize(harden(value))));
         } else {
           assertKeyExists(key);
@@ -302,10 +294,7 @@ export function makeVirtualObjectManager(
       delete(key) {
         const vkey = virtualObjectKey(key);
         if (vkey) {
-          assert(
-            syscall.vatstoreGet(vkey),
-            details`${q(keyName)} not found: ${key}`,
-          );
+          assert(syscall.vatstoreGet(vkey), d`${q(keyName)} not found: ${key}`);
           syscall.vatstoreSet(vkey, undefined);
         } else {
           assertKeyExists(key);

--- a/packages/SwingSet/test/metering/metered-dynamic-vat.js
+++ b/packages/SwingSet/test/metering/metered-dynamic-vat.js
@@ -1,3 +1,4 @@
+import { assert } from '@agoric/assert';
 import { importBundle } from '@agoric/import-bundle';
 import { makePromiseKit } from '@agoric/promise-kit';
 import { meterMe } from './metered-code';
@@ -23,7 +24,7 @@ export function buildRootObject(_dynamicVatPowers) {
     async load(bundle) {
       const require = harden(() => 0);
       grandchildNS = await importBundle(bundle, {
-        endowments: { console, require },
+        endowments: { console, assert, require },
       });
     },
 

--- a/packages/SwingSet/test/metering/test-metering.js
+++ b/packages/SwingSet/test/metering/test-metering.js
@@ -91,7 +91,7 @@ async function meteredImportBundle(bundle, endowments) {
 test('metering a single bundle', async function testSingleBundle(t) {
   const bundle = await bundleSource(require.resolve('./metered-code.js'));
   harden(Object.getPrototypeOf(console));
-  const endowments = { console };
+  const endowments = { console, assert };
   const {
     ns,
     runBundleThunkUnderMeter,

--- a/packages/SwingSet/test/metering/vat-within.js
+++ b/packages/SwingSet/test/metering/vat-within.js
@@ -1,3 +1,4 @@
+import { assert } from '@agoric/assert';
 import { importBundle } from '@agoric/import-bundle';
 
 export function buildRootObject(vatPowers) {
@@ -24,7 +25,7 @@ export function buildRootObject(vatPowers) {
     async start(bundle) {
       // console.log(`vatPowers`, vatPowers);
       // console.log('bundle', bundle);
-      const endowments = { console, getMeter };
+      const endowments = { console, assert, getMeter };
       // console.log('doing importBundle');
       log('importing');
       const ns = await importBundle(bundle, {

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -106,5 +106,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "ses": "^0.11.0"
   }
 }

--- a/packages/assert/src/types.js
+++ b/packages/assert/src/types.js
@@ -6,6 +6,9 @@
 // thems the breaks with Typescript 4.0.
 /* eslint-disable jsdoc/valid-types */
 /**
+ * @typedef {'bigint' | 'boolean' | 'function' | 'number' | 'object' |
+ *   'string' | 'symbol' | 'undefined'} TypeName
+ *
  * @callback AssertTypeofBigint
  * @param {any} specimen
  * @param {'bigint'} typename
@@ -57,5 +60,8 @@
 /* eslint-enable jsdoc/valid-types */
 
 /**
- * @typedef {AssertTypeofBigint & AssertTypeofBoolean & AssertTypeofFunction & AssertTypeofNumber & AssertTypeofObject & AssertTypeofString & AssertTypeofSymbol & AssertTypeofUndefined} AssertTypeof
+ * @typedef {AssertTypeofBigint & AssertTypeofBoolean & AssertTypeofFunction &
+ *   AssertTypeofNumber & AssertTypeofObject & AssertTypeofString &
+ *   AssertTypeofSymbol & AssertTypeofUndefined
+ * } AssertTypeof
  */

--- a/packages/captp/test/test-crosstalk.js
+++ b/packages/captp/test/test-crosstalk.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import '@agoric/install-ses';
 import test from 'ava';
 import { makeLoopback, E } from '../lib/captp';

--- a/packages/captp/test/test-loopback.js
+++ b/packages/captp/test/test-loopback.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import '@agoric/install-ses';
 import test from 'ava';
 import { E, makeLoopback } from '../lib/captp';

--- a/packages/dapp-svelte-wallet/ui/package.json
+++ b/packages/dapp-svelte-wallet/ui/package.json
@@ -21,7 +21,7 @@
     "rollup-plugin-livereload": "^1.0.0",
     "rollup-plugin-svelte": "^5.0.3",
     "rollup-plugin-terser": "^6.1.0",
-    "ses": "^0.10.1",
+    "ses": "^0.11.0",
     "sirv-cli": "^1.0.0",
     "smelte": "^1.0.15",
     "svelte": "^3.0.0",

--- a/packages/dapp-svelte-wallet/ui/src/install-ses-lockdown.js
+++ b/packages/dapp-svelte-wallet/ui/src/install-ses-lockdown.js
@@ -2,3 +2,7 @@ import 'ses/lockdown';
 import '@agoric/eventual-send/shim';
 
 lockdown({ errorTaming: 'unsafe' });
+
+// Even on non-v8, we tame the start compartment's Error constructor so
+// this assignment is not rejected, even if it does nothing.
+Error.stackTraceLimit = Infinity;

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -22,7 +22,7 @@
     "nyc": "^15.1.0"
   },
   "peerDependencies": {
-    "ses": "^0.10.1"
+    "ses": "^0.11.0"
   },
   "files": [
     "README.md",
@@ -78,9 +78,6 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "dependencies": {
-    "ses": "^0.10.1"
   },
   "ava": {
     "files": [

--- a/packages/install-ses/install-ses.js
+++ b/packages/install-ses/install-ses.js
@@ -14,3 +14,7 @@ lockdown({ errorTaming: 'unsafe' });
 
 // 'Compartment' and 'harden' (and `StaticModuleRecord`) are now present in
 // our global scope.
+
+// Even on non-v8, we tame the start compartment's Error constructor so
+// this assignment is not rejected, even if it does nothing.
+Error.stackTraceLimit = Infinity;

--- a/packages/install-ses/package.json
+++ b/packages/install-ses/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@agoric/eventual-send": "^0.12.0-dev.0",
-    "ses": "^0.10.1"
+    "ses": "^0.11.0"
   },
   "files": [
     "src/**/*.js"

--- a/packages/spawner/src/contractHost.js
+++ b/packages/spawner/src/contractHost.js
@@ -47,6 +47,7 @@ function makeContractHost(vatPowers, additionalEndowments = {}) {
 
   const defaultEndowments = {
     console,
+    assert,
   };
 
   // note: support for check functions was removed during warner's

--- a/packages/xs-vat-worker/src/vatWorker.js
+++ b/packages/xs-vat-worker/src/vatWorker.js
@@ -102,6 +102,7 @@ function makeWorker(io, setImmediate) {
       const [bundle, vatParameters, virtualObjectCacheSize] = margs;
       const endowments = {
         console: makeConsole(`SwingSet:vatWorker`),
+        assert,
         HandledPromise,
       };
       // ISSUE: this draft code is contorted because it started

--- a/packages/zoe/src/contractFacet/evalContractCode.js
+++ b/packages/zoe/src/contractFacet/evalContractCode.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import { importBundle } from '@agoric/import-bundle';
+import { assert } from '@agoric/assert';
 
 const evalContractBundle = (bundle, additionalEndowments = {}) => {
   // Make the console more verbose.
@@ -11,6 +12,7 @@ const evalContractBundle = (bundle, additionalEndowments = {}) => {
 
   const defaultEndowments = {
     console: louderConsole,
+    assert,
   };
 
   const fullEndowments = Object.create(null, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,23 +12,6 @@
   resolved "https://registry.yarnpkg.com/@agoric/babel-standalone/-/babel-standalone-7.9.5.tgz#1ca0c17844924199d31e49d6b67e8b2a629b8599"
   integrity sha512-1Aa23oPuRi4kywUyZODo8zey9Gq2NpD2xUnNvgJLoT8orMQRlVOtvbG3JeHq5sjJERlF/q6csg4/P8t8/5IABA==
 
-"@agoric/default-evaluate-options@^0.3.6":
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/@agoric/default-evaluate-options/-/default-evaluate-options-0.3.6.tgz#ff71479f1709c7a2d264e102264191281a83f321"
-  integrity sha512-26L3QdtFPolca9S7p7+SE8YOGfZ9Jxsa1P2Kf2bQ1VqjuiPrFj0ad06iXHWWkBpMfDwGeVPwLlc0LSmfn/xtjw==
-  dependencies:
-    "@agoric/babel-parser" "^7.6.4"
-    "@agoric/transform-eventual-send" "^1.3.0"
-    "@babel/generator" "^7.6.4"
-
-"@agoric/evaluate@^2.1.3":
-  version "2.2.6"
-  resolved "https://registry.yarnpkg.com/@agoric/evaluate/-/evaluate-2.2.6.tgz#757c90f67f5437cd904f3d0205743331f0b69c9b"
-  integrity sha512-LWHM3h3z020O/oiPLTWbWVuShhPYb5cCsFxx3K2i1H36aKZoAKHENlehwlBzlKqDdDRbdrUnu9+dqojbj8Bvwg==
-  dependencies:
-    "@agoric/default-evaluate-options" "^0.3.6"
-    esm "^3.2.5"
-
 "@agoric/make-hardener@^0.1.0":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@agoric/make-hardener/-/make-hardener-0.1.1.tgz#9b887da47aeec6637d9db4f0a92a4e740b8262bb"
@@ -39,21 +22,10 @@
   resolved "https://registry.yarnpkg.com/@agoric/nat/-/nat-2.0.1.tgz#28aba18367deba354bdd424bdf6daa48f5e7d37f"
   integrity sha512-puvWkoaJovQib/YaSRSGJ8Kn9rogi/yyaVa3d5znSZb5WiYfUiEKW35BfexHhAdi0VfPz2anFHoRBoBSUIijNA==
 
-"@agoric/transform-eventual-send@^1.3.0":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@agoric/transform-eventual-send/-/transform-eventual-send-1.3.4.tgz#43d90ac1f85809d87bf02df6a65238fce3678a2a"
-  integrity sha512-bnLBYL8Zooy0vMmHjIffcOgxd6whBCFxAlJlKcnM3V3TJ05YyuycCJ5QKLVq3KWT2Io9szfs5EzM9LgPIPr/Sg==
-
-"@agoric/transform-module@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@agoric/transform-module/-/transform-module-0.3.0.tgz#da0c4ba3b200e270db32ac5d8a56d4f5c955b89d"
-  integrity sha512-thK/Gro0NJdBzer8cbJ0AKTakqWwDon2IwqzaKlKJRR9CoYbtd5TBrI7g8H4LrmnFSGDNG8HiFzlDHYvzVHI9A==
-  dependencies:
-    "@agoric/evaluate" "^2.1.3"
-    "@babel/core" "^7.7.2"
-    esm "^3.2.5"
-    rollup "^1.17.0"
-    rollup-plugin-node-resolve "^5.2.0"
+"@agoric/transform-module@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@agoric/transform-module/-/transform-module-0.4.1.tgz#9fb152364faf372e1bda535cb4ef89717724f57c"
+  integrity sha512-4TJJHXeXAWu1FCA7yXCAZmhBNoGTB/BEAe2pv+J2X8W/mJTr9b395OkDCSRMpzvmSshLfBx6wT0D7dqWIWEC1w==
 
 "@babel/code-frame@^7.0.0":
   version "7.5.5"
@@ -61,13 +33,6 @@
   integrity sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==
   dependencies:
     "@babel/highlight" "^7.0.0"
-
-"@babel/code-frame@^7.10.3":
-  version "7.10.3"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.3.tgz#324bcfd8d35cd3d47dae18cde63d752086435e9a"
-  integrity sha512-fDx9eNW0qz0WkUeqL6tXEXzVlPh6Y5aCDEZesl0xBGA8ndRukX91Uk44ZqnkECp01NAZUdCAl+aiQNGi0k88Eg==
-  dependencies:
-    "@babel/highlight" "^7.10.3"
 
 "@babel/code-frame@^7.10.4":
   version "7.10.4"
@@ -104,28 +69,6 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.7.2":
-  version "7.10.3"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.10.3.tgz#73b0e8ddeec1e3fdd7a2de587a60e17c440ec77e"
-  integrity sha512-5YqWxYE3pyhIi84L84YcwjeEgS+fa7ZjK6IBVGTjDVfm64njkR2lfDhVR5OudLk8x2GK59YoSyVv+L/03k1q9w==
-  dependencies:
-    "@babel/code-frame" "^7.10.3"
-    "@babel/generator" "^7.10.3"
-    "@babel/helper-module-transforms" "^7.10.1"
-    "@babel/helpers" "^7.10.1"
-    "@babel/parser" "^7.10.3"
-    "@babel/template" "^7.10.3"
-    "@babel/traverse" "^7.10.3"
-    "@babel/types" "^7.10.3"
-    convert-source-map "^1.7.0"
-    debug "^4.1.0"
-    gensync "^1.0.0-beta.1"
-    json5 "^2.1.2"
-    lodash "^4.17.13"
-    resolve "^1.3.2"
-    semver "^5.4.1"
-    source-map "^0.5.0"
-
 "@babel/core@^7.7.5":
   version "7.11.6"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.11.6.tgz#3a9455dc7387ff1bac45770650bc13ba04a15651"
@@ -146,16 +89,6 @@
     lodash "^4.17.19"
     resolve "^1.3.2"
     semver "^5.4.1"
-    source-map "^0.5.0"
-
-"@babel/generator@^7.10.3":
-  version "7.10.3"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.10.3.tgz#32b9a0d963a71d7a54f5f6c15659c3dbc2a523a5"
-  integrity sha512-drt8MUHbEqRzNR0xnF8nMehbY11b1SDkRw03PSNH/3Rb2Z35oxkddVSi3rcaak0YJQ86PCuE7Qx1jSFhbLNBMA==
-  dependencies:
-    "@babel/types" "^7.10.3"
-    jsesc "^2.5.1"
-    lodash "^4.17.13"
     source-map "^0.5.0"
 
 "@babel/generator@^7.11.5", "@babel/generator@^7.11.6":
@@ -187,15 +120,6 @@
     lodash "^4.17.13"
     source-map "^0.5.0"
 
-"@babel/helper-function-name@^7.10.3":
-  version "7.10.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.10.3.tgz#79316cd75a9fa25ba9787ff54544307ed444f197"
-  integrity sha512-FvSj2aiOd8zbeqijjgqdMDSyxsGHaMt5Tr0XjQsGKHD3/1FP3wksjnLAWzxw7lvXiej8W1Jt47SKTZ6upQNiRw==
-  dependencies:
-    "@babel/helper-get-function-arity" "^7.10.3"
-    "@babel/template" "^7.10.3"
-    "@babel/types" "^7.10.3"
-
 "@babel/helper-function-name@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz#d2d3b20c59ad8c47112fa7d2a94bc09d5ef82f1a"
@@ -214,13 +138,6 @@
     "@babel/template" "^7.8.3"
     "@babel/types" "^7.8.3"
 
-"@babel/helper-get-function-arity@^7.10.3":
-  version "7.10.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.3.tgz#3a28f7b28ccc7719eacd9223b659fdf162e4c45e"
-  integrity sha512-iUD/gFsR+M6uiy69JA6fzM5seno8oE85IYZdbVVEuQaZlEzMO2MXblh+KSPJgsZAUx0EEbWXU0yJaW7C9CdAVg==
-  dependencies:
-    "@babel/types" "^7.10.3"
-
 "@babel/helper-get-function-arity@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz#98c1cbea0e2332f33f9a4661b8ce1505b2c19ba2"
@@ -235,13 +152,6 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
-"@babel/helper-member-expression-to-functions@^7.10.1":
-  version "7.10.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.3.tgz#bc3663ac81ac57c39148fef4c69bf48a77ba8dd6"
-  integrity sha512-q7+37c4EPLSjNb2NmWOjNwj0+BOyYlssuQ58kHEWk1Z78K5i8vTUsteq78HMieRPQSl/NtpQyJfdjt3qZ5V2vw==
-  dependencies:
-    "@babel/types" "^7.10.3"
-
 "@babel/helper-member-expression-to-functions@^7.10.4":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz#ae69c83d84ee82f4b42f96e2a09410935a8f26df"
@@ -249,32 +159,12 @@
   dependencies:
     "@babel/types" "^7.11.0"
 
-"@babel/helper-module-imports@^7.10.1":
-  version "7.10.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.10.3.tgz#766fa1d57608e53e5676f23ae498ec7a95e1b11a"
-  integrity sha512-Jtqw5M9pahLSUWA+76nhK9OG8nwYXzhQzVIGFoNaHnXF/r4l7kz4Fl0UAW7B6mqC5myoJiBP5/YQlXQTMfHI9w==
-  dependencies:
-    "@babel/types" "^7.10.3"
-
 "@babel/helper-module-imports@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz#4c5c54be04bd31670a7382797d75b9fa2e5b5620"
   integrity sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==
   dependencies:
     "@babel/types" "^7.10.4"
-
-"@babel/helper-module-transforms@^7.10.1":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.10.1.tgz#24e2f08ee6832c60b157bb0936c86bef7210c622"
-  integrity sha512-RLHRCAzyJe7Q7sF4oy2cB+kRnU4wDZY/H2xJFGof+M+SJEGhZsb+GFj5j1AD8NiSaVBJ+Pf0/WObiXu/zxWpFg==
-  dependencies:
-    "@babel/helper-module-imports" "^7.10.1"
-    "@babel/helper-replace-supers" "^7.10.1"
-    "@babel/helper-simple-access" "^7.10.1"
-    "@babel/helper-split-export-declaration" "^7.10.1"
-    "@babel/template" "^7.10.1"
-    "@babel/types" "^7.10.1"
-    lodash "^4.17.13"
 
 "@babel/helper-module-transforms@^7.11.0":
   version "7.11.0"
@@ -289,29 +179,12 @@
     "@babel/types" "^7.11.0"
     lodash "^4.17.19"
 
-"@babel/helper-optimise-call-expression@^7.10.1":
-  version "7.10.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.3.tgz#f53c4b6783093195b0f69330439908841660c530"
-  integrity sha512-kT2R3VBH/cnSz+yChKpaKRJQJWxdGoc6SjioRId2wkeV3bK0wLLioFpJROrX0U4xr/NmxSSAWT/9Ih5snwIIzg==
-  dependencies:
-    "@babel/types" "^7.10.3"
-
 "@babel/helper-optimise-call-expression@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz#50dc96413d594f995a77905905b05893cd779673"
   integrity sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==
   dependencies:
     "@babel/types" "^7.10.4"
-
-"@babel/helper-replace-supers@^7.10.1":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.10.1.tgz#ec6859d20c5d8087f6a2dc4e014db7228975f13d"
-  integrity sha512-SOwJzEfpuQwInzzQJGjGaiG578UYmyi2Xw668klPWV5n07B73S0a9btjLk/52Mlcxa+5AdIYqws1KyXRfMoB7A==
-  dependencies:
-    "@babel/helper-member-expression-to-functions" "^7.10.1"
-    "@babel/helper-optimise-call-expression" "^7.10.1"
-    "@babel/traverse" "^7.10.1"
-    "@babel/types" "^7.10.1"
 
 "@babel/helper-replace-supers@^7.10.4":
   version "7.10.4"
@@ -323,14 +196,6 @@
     "@babel/traverse" "^7.10.4"
     "@babel/types" "^7.10.4"
 
-"@babel/helper-simple-access@^7.10.1":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.10.1.tgz#08fb7e22ace9eb8326f7e3920a1c2052f13d851e"
-  integrity sha512-VSWpWzRzn9VtgMJBIWTZ+GP107kZdQ4YplJlCmIrjoLVSi/0upixezHCDG8kpPVTBJpKfxTH01wDhh+jS2zKbw==
-  dependencies:
-    "@babel/template" "^7.10.1"
-    "@babel/types" "^7.10.1"
-
 "@babel/helper-simple-access@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz#0f5ccda2945277a2a7a2d3a821e15395edcf3461"
@@ -338,13 +203,6 @@
   dependencies:
     "@babel/template" "^7.10.4"
     "@babel/types" "^7.10.4"
-
-"@babel/helper-split-export-declaration@^7.10.1":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz#c6f4be1cbc15e3a868e4c64a17d5d31d754da35f"
-  integrity sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==
-  dependencies:
-    "@babel/types" "^7.10.1"
 
 "@babel/helper-split-export-declaration@^7.11.0":
   version "7.11.0"
@@ -360,24 +218,10 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
-"@babel/helper-validator-identifier@^7.10.3":
-  version "7.10.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.3.tgz#60d9847f98c4cea1b279e005fdb7c28be5412d15"
-  integrity sha512-bU8JvtlYpJSBPuj1VUmKpFGaDZuLxASky3LhaKj3bmpSTY6VWooSM8msk+Z0CZoErFye2tlABF6yDkT3FOPAXw==
-
 "@babel/helper-validator-identifier@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
   integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
-
-"@babel/helpers@^7.10.1":
-  version "7.10.1"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.10.1.tgz#a6827b7cb975c9d9cef5fd61d919f60d8844a973"
-  integrity sha512-muQNHF+IdU6wGgkaJyhhEmI54MOZBKsFfsXFhboz1ybwJ1Kl7IHlbm2a++4jwrmY5UYsgitt5lfqo1wMFcHmyw==
-  dependencies:
-    "@babel/template" "^7.10.1"
-    "@babel/traverse" "^7.10.1"
-    "@babel/types" "^7.10.1"
 
 "@babel/helpers@^7.10.4":
   version "7.10.4"
@@ -406,15 +250,6 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/highlight@^7.10.3":
-  version "7.10.3"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.10.3.tgz#c633bb34adf07c5c13156692f5922c81ec53f28d"
-  integrity sha512-Ih9B/u7AtgEnySE2L2F0Xm0GaM729XqqLfHkalTsbjXGyqmf/6M0Cu0WpvqueUlW+xk88BHw9Nkpj49naU+vWw==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.10.3"
-    chalk "^2.0.0"
-    js-tokens "^4.0.0"
-
 "@babel/highlight@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.10.4.tgz#7d1bdfd65753538fabe6c38596cdb76d9ac60143"
@@ -438,11 +273,6 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.4.tgz#6fa1a118b8b0d80d0267b719213dc947e88cc0ca"
   integrity sha512-MggwidiH+E9j5Sh8pbrX5sJvMcsqS5o+7iB42M9/k0CD63MjYbdP4nhSh7uB5wnv2/RVzTZFTxzF/kIa5mrCqA==
 
-"@babel/parser@^7.10.3":
-  version "7.10.3"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.10.3.tgz#7e71d892b0d6e7d04a1af4c3c79d72c1f10f5315"
-  integrity sha512-oJtNJCMFdIMwXGmx+KxuaD7i3b8uS7TTFYW/FNG2BT8m+fmGHoiPYoH0Pe3gya07WuFmM5FCDIr1x0irkD/hyA==
-
 "@babel/parser@^7.10.4", "@babel/parser@^7.11.5":
   version "7.11.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.5.tgz#c7ff6303df71080ec7a4f5b8c003c58f1cf51037"
@@ -459,15 +289,6 @@
   integrity sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==
   dependencies:
     regenerator-runtime "^0.13.2"
-
-"@babel/template@^7.10.1", "@babel/template@^7.10.3":
-  version "7.10.3"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.3.tgz#4d13bc8e30bf95b0ce9d175d30306f42a2c9a7b8"
-  integrity sha512-5BjI4gdtD+9fHZUsaxPHPNpwa+xRkDO7c7JbhYn2afvrkDu5SfAAbi9AIMXw2xEhO/BR35TqiW97IqNvCo/GqA==
-  dependencies:
-    "@babel/code-frame" "^7.10.3"
-    "@babel/parser" "^7.10.3"
-    "@babel/types" "^7.10.3"
 
 "@babel/template@^7.10.4":
   version "7.10.4"
@@ -486,21 +307,6 @@
     "@babel/code-frame" "^7.8.3"
     "@babel/parser" "^7.8.3"
     "@babel/types" "^7.8.3"
-
-"@babel/traverse@^7.10.1", "@babel/traverse@^7.10.3":
-  version "7.10.3"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.10.3.tgz#0b01731794aa7b77b214bcd96661f18281155d7e"
-  integrity sha512-qO6623eBFhuPm0TmmrUFMT1FulCmsSeJuVGhiLodk2raUDFhhTECLd9E9jC4LBIWziqt4wgF6KuXE4d+Jz9yug==
-  dependencies:
-    "@babel/code-frame" "^7.10.3"
-    "@babel/generator" "^7.10.3"
-    "@babel/helper-function-name" "^7.10.3"
-    "@babel/helper-split-export-declaration" "^7.10.1"
-    "@babel/parser" "^7.10.3"
-    "@babel/types" "^7.10.3"
-    debug "^4.1.0"
-    globals "^11.1.0"
-    lodash "^4.17.13"
 
 "@babel/traverse@^7.10.4", "@babel/traverse@^7.11.5":
   version "7.11.5"
@@ -531,15 +337,6 @@
     debug "^4.1.0"
     globals "^11.1.0"
     lodash "^4.17.13"
-
-"@babel/types@^7.10.1", "@babel/types@^7.10.3":
-  version "7.10.3"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.10.3.tgz#6535e3b79fea86a6b09e012ea8528f935099de8e"
-  integrity sha512-nZxaJhBXBQ8HVoIcGsf9qWep3Oh3jCENK54V4mRF7qaJabVsAYdbTtmSD8WmAp1R6ytPiu5apMwSXyxB1WlaBA==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.10.3"
-    lodash "^4.17.13"
-    to-fast-properties "^2.0.0"
 
 "@babel/types@^7.10.4", "@babel/types@^7.11.0", "@babel/types@^7.11.5":
   version "7.11.5"
@@ -9057,15 +8854,6 @@ rollup@^1.16.6, rollup@^1.16.7, rollup@^1.2.2, rollup@^1.23.1, rollup@^1.26.2:
     "@types/node" "*"
     acorn "^7.1.0"
 
-rollup@^1.17.0:
-  version "1.32.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.32.1.tgz#4480e52d9d9e2ae4b46ba0d9ddeaf3163940f9c4"
-  integrity sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==
-  dependencies:
-    "@types/estree" "*"
-    "@types/node" "*"
-    acorn "^7.1.0"
-
 rollup@^1.32.0:
   version "1.32.0"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.32.0.tgz#c65ce134850aca1ce595fcac07d1dc5d53bf227c"
@@ -9232,14 +9020,14 @@ serve-static@1.14.1:
     parseurl "~1.3.3"
     send "0.17.1"
 
-ses@^0.10.1:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/ses/-/ses-0.10.1.tgz#7506ce0e48e98a518fde20604072b523228b9441"
-  integrity sha512-OqYfhG7naLai6fuIMa3mbIW7lImdrFC0IqzkokPp+1SvwXfjr4r4U4jYkUjJQTB3NUnq2sLEbJ+1wBO5tdGwAQ==
+ses@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/ses/-/ses-0.11.0.tgz#1e470112ed320d169f0b850525858129c0be0881"
+  integrity sha512-3HH+23C4bijk9VegfiP+cBMqkGim/TMsj/DK5nh/pJFiNrCMfi5euvVluIV66ry202+uckg7nXKrgrEcBwU8SA==
   dependencies:
     "@agoric/babel-standalone" "^7.9.5"
     "@agoric/make-hardener" "^0.1.0"
-    "@agoric/transform-module" "^0.3.0"
+    "@agoric/transform-module" "^0.4.1"
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This change upgrades Agoric SDK packages to use the new SES 0.11.0, which includes the newly entangled Error, assert, and console objects, which collectively hide error details including the stack from callers, while safely revealing them to the console.

To facilitate this, the implementation of the `@agoric/assert` package shifts into SES, while the package remains useful as a vehicle for TypeScript definitions. All compartments that use `@agoric/assert` must now be endowed with the global `assert`.

Much of this change is mechanical, except for the `assert.js` module itself which may benefit from closer review.