### PR TITLE
fix: export `@agoric/store/exported`

### DIFF
--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -40,6 +40,7 @@
   },
   "files": [
     "src/",
+    "exported.js",
     "NEWS.md"
   ],
   "eslintConfig": {


### PR DESCRIPTION
Needed to make `@agoric/store` viable.
