### PR TITLE
fix: refactor liveSlots so it could provide vat globals

### DIFF
--- a/packages/SwingSet/src/kernel/vatManager/localVatManager.js
+++ b/packages/SwingSet/src/kernel/vatManager/localVatManager.js
@@ -137,14 +137,9 @@ export function makeLocalVatManagerFactory(tools) {
     let dispatch;
     if (typeof vatNS.buildRootObject === 'function') {
       const { buildRootObject } = vatNS;
-      dispatch = makeLiveSlots(
-        syscall,
-        state,
-        buildRootObject,
-        vatID,
-        vatPowers,
-        vatParameters,
-      );
+      const r = makeLiveSlots(syscall, state, vatID, vatPowers, vatParameters);
+      r.setBuildRootObject(buildRootObject);
+      dispatch = r.dispatch;
     } else if (enableSetup) {
       const setup = vatNS.default;
       assert(setup, `vat source bundle lacks (default) setup() function`);

--- a/packages/SwingSet/src/kernel/vatManager/nodeWorkerSupervisor.js
+++ b/packages/SwingSet/src/kernel/vatManager/nodeWorkerSupervisor.js
@@ -121,14 +121,9 @@ parentPort.on('message', ([type, ...margs]) => {
         makeMarshal,
         testLog,
       };
-      dispatch = makeLiveSlots(
-        syscall,
-        state,
-        vatNS.buildRootObject,
-        vatID,
-        vatPowers,
-        vatParameters,
-      );
+      const r = makeLiveSlots(syscall, state, vatID, vatPowers, vatParameters);
+      r.setBuildRootObject(vatNS.buildRootObject);
+      dispatch = r.dispatch;
       workerLog(`got dispatch:`, Object.keys(dispatch).join(','));
       sendUplink(['dispatchReady']);
     });

--- a/packages/SwingSet/src/kernel/vatManager/subprocessSupervisor.js
+++ b/packages/SwingSet/src/kernel/vatManager/subprocessSupervisor.js
@@ -142,14 +142,9 @@ fromParent.on('data', data => {
         makeMarshal,
         testLog,
       };
-      dispatch = makeLiveSlots(
-        syscall,
-        state,
-        vatNS.buildRootObject,
-        vatID,
-        vatPowers,
-        vatParameters,
-      );
+      const r = makeLiveSlots(syscall, state, vatID, vatPowers, vatParameters);
+      r.setBuildRootObject(vatNS.buildRootObject);
+      dispatch = r.dispatch;
       workerLog(`got dispatch:`, Object.keys(dispatch).join(','));
       sendUplink(['dispatchReady']);
     });

--- a/packages/SwingSet/test/test-liveslots.js
+++ b/packages/SwingSet/test/test-liveslots.js
@@ -36,6 +36,12 @@ function buildSyscall() {
   return { log, syscall };
 }
 
+function makeDispatch(syscall, build) {
+  const { setBuildRootObject, dispatch } = makeLiveSlots(syscall, null, 'vatA');
+  setBuildRootObject(build);
+  return dispatch;
+}
+
 test('calls', async t => {
   const { log, syscall } = buildSyscall();
 
@@ -53,7 +59,7 @@ test('calls', async t => {
       },
     });
   }
-  const dispatch = makeLiveSlots(syscall, {}, build, 'vatA');
+  const dispatch = makeDispatch(syscall, build);
   t.deepEqual(log, []);
   const rootA = 'o+0';
 
@@ -113,7 +119,7 @@ test('liveslots pipelines to syscall.send', async t => {
       },
     });
   }
-  const dispatch = makeLiveSlots(syscall, {}, build, 'vatA');
+  const dispatch = makeDispatch(syscall, build);
   t.deepEqual(log, []);
   const rootA = 'o+0';
   const x = 'o-5';
@@ -177,7 +183,7 @@ test('liveslots pipeline/non-pipeline calls', async t => {
       },
     });
   }
-  const dispatch = makeLiveSlots(syscall, {}, build, 'vatA');
+  const dispatch = makeDispatch(syscall, build);
 
   t.deepEqual(log, []);
 
@@ -258,7 +264,7 @@ async function doOutboundPromise(t, mode) {
       },
     });
   }
-  const dispatch = makeLiveSlots(syscall, {}, build, 'vatA');
+  const dispatch = makeDispatch(syscall, build);
 
   t.deepEqual(log, []);
 
@@ -371,7 +377,7 @@ async function doResultPromise(t, mode) {
       },
     });
   }
-  const dispatch = makeLiveSlots(syscall, {}, build, 'vatA');
+  const dispatch = makeDispatch(syscall, build);
   t.deepEqual(log, []);
 
   const slot0arg = { '@qclass': 'slot', index: 0 };

--- a/packages/SwingSet/test/test-vpid-liveslots.js
+++ b/packages/SwingSet/test/test-vpid-liveslots.js
@@ -189,6 +189,12 @@ function resolutionOf(vpid, mode, targets) {
   }
 }
 
+function makeDispatch(syscall, build) {
+  const { setBuildRootObject, dispatch } = makeLiveSlots(syscall, null, 'vatA');
+  setBuildRootObject(build);
+  return dispatch;
+}
+
 async function doVatResolveCase1(t, mode) {
   // case 1
   const { log, syscall } = buildSyscall();
@@ -207,7 +213,7 @@ async function doVatResolveCase1(t, mode) {
       },
     });
   }
-  const dispatch = makeLiveSlots(syscall, {}, build, 'vatA');
+  const dispatch = makeDispatch(syscall, build);
   t.deepEqual(log, []);
 
   const rootA = 'o+0';
@@ -374,7 +380,7 @@ async function doVatResolveCase23(t, which, mode, stalls) {
       },
     });
   }
-  const dispatch = makeLiveSlots(syscall, {}, build, 'vatA');
+  const dispatch = makeDispatch(syscall, build);
   t.deepEqual(log, []);
 
   const rootA = 'o+0';
@@ -605,7 +611,7 @@ async function doVatResolveCase4(t, mode) {
       four() {},
     });
   }
-  const dispatch = makeLiveSlots(syscall, {}, build, 'vatA');
+  const dispatch = makeDispatch(syscall, build);
   t.deepEqual(log, []);
 
   const rootA = 'o+0';


### PR DESCRIPTION
This splits up `makeLiveslots` so that the `buildRootObject` function is
provided later, after it returns. This makes it possible to delay the import
of the vat code until after liveslots has provided globals to put into its
Compartment.

This does not yet provide any globals (the `vatGlobals` which `makeLiveslots`
returns is empty). Nor does it change the vat managers to use the
`vatGlobals` in any way. But these changes should be a lot easier now.

refs #1867