### PR TITLE
fix: add liveslots-provided globals to vat Compartments

### DIFF
--- a/packages/SwingSet/src/kernel/vatManager/localVatManager.js
+++ b/packages/SwingSet/src/kernel/vatManager/localVatManager.js
@@ -124,6 +124,7 @@ export function makeLocalVatManagerFactory(tools) {
 
     const endowments = harden({
       ...vatEndowments,
+      ...ls.vatGlobals,
       console: vatConsole,
     });
     const inescapableTransforms = [];

--- a/packages/SwingSet/src/kernel/vatManager/localVatManager.js
+++ b/packages/SwingSet/src/kernel/vatManager/localVatManager.js
@@ -96,6 +96,19 @@ export function makeLocalVatManagerFactory(tools) {
     } = managerOptions;
     assert(vatConsole, 'vats need managerOptions.vatConsole');
 
+    const { syscall, finish } = prepare(vatID, managerOptions);
+    const imVP = enableInternalMetering ? internalMeteringVP : {};
+    const vatPowers = harden({
+      ...baseVP,
+      ...imVP,
+      vatParameters,
+      testLog: allVatPowers.testLog,
+    });
+
+    // we might or might not use this, depending upon whether the vat exports
+    // 'buildRootObject' or a default 'setup' function
+    const ls = makeLiveSlots(syscall, vatID, vatPowers, vatParameters);
+
     let meterRecord = null;
     if (metered) {
       // fail-stop: we refill the meter after each crank (in vatManager
@@ -109,6 +122,10 @@ export function makeLocalVatManagerFactory(tools) {
       });
     }
 
+    const endowments = harden({
+      ...vatEndowments,
+      console: vatConsole,
+    });
     const inescapableTransforms = [];
     const inescapableGlobalLexicals = {};
     if (metered) {
@@ -119,26 +136,16 @@ export function makeLocalVatManagerFactory(tools) {
 
     const vatNS = await importBundle(bundle, {
       filePrefix: vatID,
-      endowments: harden({ ...vatEndowments, console: vatConsole }),
+      endowments,
       inescapableTransforms,
       inescapableGlobalLexicals,
-    });
-
-    const { syscall, finish } = prepare(vatID, managerOptions);
-    const imVP = enableInternalMetering ? internalMeteringVP : {};
-    const vatPowers = harden({
-      ...baseVP,
-      ...imVP,
-      vatParameters,
-      testLog: allVatPowers.testLog,
     });
 
     let dispatch;
     if (typeof vatNS.buildRootObject === 'function') {
       const { buildRootObject } = vatNS;
-      const r = makeLiveSlots(syscall, vatID, vatPowers, vatParameters);
-      r.setBuildRootObject(buildRootObject);
-      dispatch = r.dispatch;
+      ls.setBuildRootObject(buildRootObject);
+      dispatch = ls.dispatch;
     } else if (enableSetup) {
       const setup = vatNS.default;
       assert(setup, `vat source bundle lacks (default) setup() function`);

--- a/packages/SwingSet/src/kernel/vatManager/nodeWorkerSupervisor.js
+++ b/packages/SwingSet/src/kernel/vatManager/nodeWorkerSupervisor.js
@@ -83,46 +83,47 @@ parentPort.on('message', ([type, ...margs]) => {
     sendUplink(['gotStart']);
   } else if (type === 'setBundle') {
     const [bundle, vatParameters] = margs;
+
+    function testLog(...args) {
+      sendUplink(['testLog', ...args]);
+    }
+
+    function doSyscall(vatSyscallObject) {
+      sendUplink(['syscall', ...vatSyscallObject]);
+    }
+    const syscall = harden({
+      send: (...args) => doSyscall(['send', ...args]),
+      callNow: (..._args) => {
+        throw Error(`nodeWorker cannot syscall.callNow`);
+      },
+      subscribe: (...args) => doSyscall(['subscribe', ...args]),
+      fulfillToData: (...args) => doSyscall(['fulfillToData', ...args]),
+      fulfillToPresence: (...args) => doSyscall(['fulfillToPresence', ...args]),
+      reject: (...args) => doSyscall(['reject', ...args]),
+    });
+
+    const vatID = 'demo-vatID';
+    // todo: maybe add transformTildot, makeGetMeter/transformMetering to
+    // vatPowers, but only if options tell us they're wanted. Maybe
+    // transformTildot should be async and outsourced to the kernel
+    // process/thread.
+    const vatPowers = {
+      Remotable,
+      getInterfaceOf,
+      makeMarshal,
+      testLog,
+    };
+    const ls = makeLiveSlots(syscall, vatID, vatPowers, vatParameters);
+
     const endowments = {
       console: makeConsole(`SwingSet:vatWorker`),
     };
+
     importBundle(bundle, { endowments }).then(vatNS => {
       workerLog(`got vatNS:`, Object.keys(vatNS).join(','));
       sendUplink(['gotBundle']);
-
-      function doSyscall(vatSyscallObject) {
-        sendUplink(['syscall', ...vatSyscallObject]);
-      }
-      const syscall = harden({
-        send: (...args) => doSyscall(['send', ...args]),
-        callNow: (..._args) => {
-          throw Error(`nodeWorker cannot syscall.callNow`);
-        },
-        subscribe: (...args) => doSyscall(['subscribe', ...args]),
-        fulfillToData: (...args) => doSyscall(['fulfillToData', ...args]),
-        fulfillToPresence: (...args) =>
-          doSyscall(['fulfillToPresence', ...args]),
-        reject: (...args) => doSyscall(['reject', ...args]),
-      });
-
-      function testLog(...args) {
-        sendUplink(['testLog', ...args]);
-      }
-
-      const vatID = 'demo-vatID';
-      // todo: maybe add transformTildot, makeGetMeter/transformMetering to
-      // vatPowers, but only if options tell us they're wanted. Maybe
-      // transformTildot should be async and outsourced to the kernel
-      // process/thread.
-      const vatPowers = {
-        Remotable,
-        getInterfaceOf,
-        makeMarshal,
-        testLog,
-      };
-      const r = makeLiveSlots(syscall, vatID, vatPowers, vatParameters);
-      r.setBuildRootObject(vatNS.buildRootObject);
-      dispatch = r.dispatch;
+      ls.setBuildRootObject(vatNS.buildRootObject);
+      dispatch = ls.dispatch;
       workerLog(`got dispatch:`, Object.keys(dispatch).join(','));
       sendUplink(['dispatchReady']);
     });

--- a/packages/SwingSet/src/kernel/vatManager/nodeWorkerSupervisor.js
+++ b/packages/SwingSet/src/kernel/vatManager/nodeWorkerSupervisor.js
@@ -116,6 +116,7 @@ parentPort.on('message', ([type, ...margs]) => {
     const ls = makeLiveSlots(syscall, vatID, vatPowers, vatParameters);
 
     const endowments = {
+      ...ls.vatGlobals,
       console: makeConsole(`SwingSet:vatWorker`),
     };
 

--- a/packages/SwingSet/src/kernel/vatManager/subprocessSupervisor.js
+++ b/packages/SwingSet/src/kernel/vatManager/subprocessSupervisor.js
@@ -95,8 +95,7 @@ function sendUplink(msg) {
 //  toParent.write('child ack');
 // });
 
-fromParent.on('data', data => {
-  const [type, ...margs] = data;
+fromParent.on('data', ([type, ...margs]) => {
   workerLog(`received`, type);
   if (type === 'start') {
     // TODO: parent should send ['start', vatID]
@@ -104,46 +103,47 @@ fromParent.on('data', data => {
     sendUplink(['gotStart']);
   } else if (type === 'setBundle') {
     const [bundle, vatParameters] = margs;
+
+    function testLog(...args) {
+      sendUplink(['testLog', ...args]);
+    }
+
+    function doSyscall(vatSyscallObject) {
+      sendUplink(['syscall', ...vatSyscallObject]);
+    }
+    const syscall = harden({
+      send: (...args) => doSyscall(['send', ...args]),
+      callNow: (..._args) => {
+        throw Error(`nodeWorker cannot syscall.callNow`);
+      },
+      subscribe: (...args) => doSyscall(['subscribe', ...args]),
+      fulfillToData: (...args) => doSyscall(['fulfillToData', ...args]),
+      fulfillToPresence: (...args) => doSyscall(['fulfillToPresence', ...args]),
+      reject: (...args) => doSyscall(['reject', ...args]),
+    });
+
+    const vatID = 'demo-vatID';
+    // todo: maybe add transformTildot, makeGetMeter/transformMetering to
+    // vatPowers, but only if options tell us they're wanted. Maybe
+    // transformTildot should be async and outsourced to the kernel
+    // process/thread.
+    const vatPowers = {
+      Remotable,
+      getInterfaceOf,
+      makeMarshal,
+      testLog,
+    };
+    const ls = makeLiveSlots(syscall, vatID, vatPowers, vatParameters);
+
     const endowments = {
       console: makeConsole(`SwingSet:vatWorker`),
     };
+
     importBundle(bundle, { endowments }).then(vatNS => {
       workerLog(`got vatNS:`, Object.keys(vatNS).join(','));
       sendUplink(['gotBundle']);
-
-      function doSyscall(vatSyscallObject) {
-        sendUplink(['syscall', ...vatSyscallObject]);
-      }
-      const syscall = harden({
-        send: (...args) => doSyscall(['send', ...args]),
-        callNow: (..._args) => {
-          throw Error(`nodeWorker cannot syscall.callNow`);
-        },
-        subscribe: (...args) => doSyscall(['subscribe', ...args]),
-        fulfillToData: (...args) => doSyscall(['fulfillToData', ...args]),
-        fulfillToPresence: (...args) =>
-          doSyscall(['fulfillToPresence', ...args]),
-        reject: (...args) => doSyscall(['reject', ...args]),
-      });
-
-      function testLog(...args) {
-        sendUplink(['testLog', ...args]);
-      }
-
-      const vatID = 'demo-vatID';
-      // todo: maybe add transformTildot, makeGetMeter/transformMetering to
-      // vatPowers, but only if options tell us they're wanted. Maybe
-      // transformTildot should be async and outsourced to the kernel
-      // process/thread.
-      const vatPowers = {
-        Remotable,
-        getInterfaceOf,
-        makeMarshal,
-        testLog,
-      };
-      const r = makeLiveSlots(syscall, vatID, vatPowers, vatParameters);
-      r.setBuildRootObject(vatNS.buildRootObject);
-      dispatch = r.dispatch;
+      ls.setBuildRootObject(vatNS.buildRootObject);
+      dispatch = ls.dispatch;
       workerLog(`got dispatch:`, Object.keys(dispatch).join(','));
       sendUplink(['dispatchReady']);
     });

--- a/packages/SwingSet/src/kernel/vatManager/subprocessSupervisor.js
+++ b/packages/SwingSet/src/kernel/vatManager/subprocessSupervisor.js
@@ -136,6 +136,7 @@ fromParent.on('data', ([type, ...margs]) => {
     const ls = makeLiveSlots(syscall, vatID, vatPowers, vatParameters);
 
     const endowments = {
+      ...ls.vatGlobals,
       console: makeConsole(`SwingSet:vatWorker`),
     };
 


### PR DESCRIPTION
Liveslots does not yet provide any `vatGlobals`, but this ensures that any
ones it does provide in the future will be added to the `endowments` on the
vat's Compartment. We'll use this to populate `makeExternalStore` -type
functions, which want to be globals (because threading them from `vatPowers`
into modules that need them would be too annoying), but must also be in
cahoots with closely-held WeakMaps and "Representative" state management code
from liveslots, as described in #455 and #1846.

closes #1867

@FUDCo reviewer note: the first commit is pure refactoring, the only behavioral changes are in the second commit, feel free to review them separately
