### PR TITLE
Add test dapp workflow template

### DIFF
--- a/.github/workflow-templates/test-dapp.yml
+++ b/.github/workflow-templates/test-dapp.yml
@@ -40,7 +40,7 @@ jobs:
       with:
         result-encoding: string
         script: |
-          let branch = 'master';
+          let branch = 'main';
           if (context.payload.pull_request) {
             const { body } = context.payload.pull_request;
             const regex = /.*\#[[INSERT_DAPP_NAME]]-branch:\s+(\S+)/;

--- a/.github/workflow-templates/test-dapp.yml
+++ b/.github/workflow-templates/test-dapp.yml
@@ -1,0 +1,61 @@
+name: Test Dapp
+
+# run CI on pushes to master, and on all PRs (even the ones that target other
+# branches)
+
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+
+jobs:
+  test-dapp:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['14.x']
+
+    steps:
+
+    - name: Checkout agoric-sdk
+      uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: cache node modules
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/yarn
+        key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+
+    - name: yarn install
+      run: yarn install
+    # 'yarn build' loops over all workspaces
+    - name: yarn build
+      run: yarn build
+    - name: yarn link
+      run: |
+        yarn link-cli ~/bin/agoric
+        echo "::add-path::/home/runner/bin"
+
+    - name: Check out dapp
+      uses: actions/checkout@v2
+      with:
+        repository: Agoric/[[INSERT_DAPP_NAME]]
+        path: dapp
+        ref: ${{steps.get-branch.outputs.result}}
+
+    - name: Agoric install in dapp
+      run: agoric install
+      working-directory: ./dapp
+
+    - name: yarn build in dapp
+      run: yarn build
+      working-directory: ./dapp
+    
+    - name: yarn test in dapp
+      run: yarn test
+      working-directory: ./dapp

--- a/.github/workflow-templates/test-dapp.yml
+++ b/.github/workflow-templates/test-dapp.yml
@@ -33,7 +33,7 @@ jobs:
 
     # Select a branch on dapp to test against by adding text to the body of the
     # pull request. For example: #dapp-encouragement-branch: zoe-release-0.7.0
-    # The default is 'master'
+    # The default is 'main'
     - name: Get the appropriate dapp branch
       id: get-branch
       uses: actions/github-script@0.9.0

--- a/.github/workflow-templates/test-dapp.yml
+++ b/.github/workflow-templates/test-dapp.yml
@@ -31,6 +31,27 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-yarn-
 
+    # Select a branch on dapp to test against by adding text to the body of the
+    # pull request. For example: #dapp-encouragement-branch: zoe-release-0.7.0
+    # The default is 'master'
+    - name: Get the appropriate dapp branch
+      id: get-branch
+      uses: actions/github-script@0.9.0
+      with:
+        result-encoding: string
+        script: |
+          let branch = 'master';
+          if (context.payload.pull_request) {
+            const { body } = context.payload.pull_request;
+            const regex = /.*\#[[INSERT_DAPP_NAME]]-branch:\s+(\S+)/;
+            const result = regex.exec(body);
+            if (result) {
+              branch = result[1];
+            }
+          }
+          console.log(branch);
+          return branch;
+
     - name: yarn install
       run: yarn install
     # 'yarn build' loops over all workspaces

--- a/.github/workflows/test-dapp-encouragement.yml
+++ b/.github/workflows/test-dapp-encouragement.yml
@@ -4,16 +4,17 @@ name: Test Dapp Encouragement
 # branches)
 
 on:
- push:
-   branches: [master]
- pull_request:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
 
 jobs:
-  dapp-encouragement:
+  test-dapp:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['12.14.1', '12.x', '14.x']
+        node-version: ['14.x']
+
     steps:
 
     - name: Checkout agoric-sdk
@@ -31,10 +32,10 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-yarn-
 
-    # Select a branch on dapp-encouragement to test against by adding text to the body of the
+    # Select a branch on dapp to test against by adding text to the body of the
     # pull request. For example: #dapp-encouragement-branch: zoe-release-0.7.0
     # The default is 'master'
-    - name: Get the appropriate dapp-encouragement branch
+    - name: Get the appropriate dapp branch
       id: get-branch
       uses: actions/github-script@0.9.0
       with:
@@ -54,8 +55,6 @@ jobs:
 
     - name: yarn install
       run: yarn install
-    - name: check dependencies
-      run: yarn check-dependencies
     # 'yarn build' loops over all workspaces
     - name: yarn build
       run: yarn build
@@ -64,21 +63,21 @@ jobs:
         yarn link-cli ~/bin/agoric
         echo "/home/runner/bin" >> $GITHUB_PATH
 
-    - name: Check out dapp-encouragement
+    - name: Check out dapp
       uses: actions/checkout@v2
       with:
         repository: Agoric/dapp-encouragement
-        path: dapp-encouragement
+        path: dapp
         ref: ${{steps.get-branch.outputs.result}}
 
-    - name: Agoric install in dapp-encouragement
+    - name: Agoric install in dapp
       run: agoric install
-      working-directory: ./dapp-encouragement
+      working-directory: ./dapp
 
-    - name: yarn build in dapp-encouragement
+    - name: yarn build in dapp
       run: yarn build
-      working-directory: ./dapp-encouragement
+      working-directory: ./dapp
     
-    - name: yarn test in dapp-encouragement
+    - name: yarn test in dapp
       run: yarn test
-      working-directory: ./dapp-encouragement
+      working-directory: ./dapp

--- a/.github/workflows/test-dapp-encouragement.yml
+++ b/.github/workflows/test-dapp-encouragement.yml
@@ -34,14 +34,14 @@ jobs:
 
     # Select a branch on dapp to test against by adding text to the body of the
     # pull request. For example: #dapp-encouragement-branch: zoe-release-0.7.0
-    # The default is 'master'
+    # The default is 'main'
     - name: Get the appropriate dapp branch
       id: get-branch
       uses: actions/github-script@0.9.0
       with:
         result-encoding: string
         script: |
-          let branch = 'master';
+          let branch = 'main';
           if (context.payload.pull_request) {
             const { body } = context.payload.pull_request;
             const regex = /.*\#dapp-encouragement-branch:\s+(\S+)/;

--- a/.github/workflows/test-documentation.yml
+++ b/.github/workflows/test-documentation.yml
@@ -34,14 +34,14 @@ jobs:
 
     # Select a branch on dapp to test against by adding text to the body of the
     # pull request. For example: #dapp-encouragement-branch: zoe-release-0.7.0
-    # The default is 'master'
+    # The default is 'main'
     - name: Get the appropriate dapp branch
       id: get-branch
       uses: actions/github-script@0.9.0
       with:
         result-encoding: string
         script: |
-          let branch = 'master';
+          let branch = 'main';
           if (context.payload.pull_request) {
             const { body } = context.payload.pull_request;
             const regex = /.*\#documentation-branch:\s+(\S+)/;

--- a/.github/workflows/test-documentation.yml
+++ b/.github/workflows/test-documentation.yml
@@ -4,16 +4,17 @@ name: Test Documentation
 # branches)
 
 on:
- push:
-   branches: [master]
- pull_request:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
 
 jobs:
-  documentation:
+  test-dapp:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: ['14.x']
+
     steps:
 
     - name: Checkout agoric-sdk
@@ -31,10 +32,10 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-yarn-
 
-    # Select a branch on documentation to test against by adding text to the body of the
-    # pull request. For example: #documentation-branch: zoe-release-0.7.0
+    # Select a branch on dapp to test against by adding text to the body of the
+    # pull request. For example: #dapp-encouragement-branch: zoe-release-0.7.0
     # The default is 'master'
-    - name: Get the appropriate documentation branch
+    - name: Get the appropriate dapp branch
       id: get-branch
       uses: actions/github-script@0.9.0
       with:
@@ -54,8 +55,6 @@ jobs:
 
     - name: yarn install
       run: yarn install
-    - name: check dependencies
-      run: yarn check-dependencies
     # 'yarn build' loops over all workspaces
     - name: yarn build
       run: yarn build
@@ -64,17 +63,21 @@ jobs:
         yarn link-cli ~/bin/agoric
         echo "/home/runner/bin" >> $GITHUB_PATH
 
-    - name: Check out documentation
+    - name: Check out dapp
       uses: actions/checkout@v2
       with:
         repository: Agoric/documentation
-        path: documentation
+        path: dapp
         ref: ${{steps.get-branch.outputs.result}}
 
-    - name: Agoric install in documentation
+    - name: Agoric install in dapp
       run: agoric install
-      working-directory: ./documentation
+      working-directory: ./dapp
+
+    - name: yarn build in dapp
+      run: yarn build
+      working-directory: ./dapp
     
-    - name: yarn test in documentation
+    - name: yarn test in dapp
       run: yarn test
-      working-directory: ./documentation
+      working-directory: ./dapp


### PR DESCRIPTION
I'm hoping to test against a number of dapps in the agoric-sdk CI. To do so, I'd like to add a workflow template for testing dapps. Currently the only way to use it is to copy and paste and add the dapp name in [[INSERT_DAPP_NAME]] slots. Let me know if you know of a better way to do it.

Also changes the current workflow for testing dapp encouragement  and the documentation to fit the template.