### PR TITLE
fix: add vatDecRef to kernel, offer to liveslots

### DIFF
--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -46,7 +46,12 @@ export async function makeSwingsetController(
   insistStorageAPI(hostStorage);
 
   // build console early so we can add console.log to diagnose early problems
-  const { verbose, debugPrefix = '', slogFile } = runtimeOptions;
+  const {
+    verbose,
+    debugPrefix = '',
+    slogFile,
+    testTrackDecref,
+  } = runtimeOptions;
   if (typeof Compartment === 'undefined') {
     throw Error('SES must be installed before calling makeSwingsetController');
   }
@@ -188,7 +193,7 @@ export async function makeSwingsetController(
     FinalizationRegistry,
   };
 
-  const kernelOptions = { verbose };
+  const kernelOptions = { verbose, testTrackDecref };
   const kernel = buildKernel(kernelEndowments, deviceEndowments, kernelOptions);
 
   if (runtimeOptions.verbose) {
@@ -280,8 +285,9 @@ export async function buildVatController(
     verbose,
     kernelBundles,
     debugPrefix,
+    testTrackDecref,
   } = runtimeOptions;
-  const actualRuntimeOptions = { verbose, debugPrefix };
+  const actualRuntimeOptions = { verbose, debugPrefix, testTrackDecref };
   const initializationOptions = { verbose, kernelBundles };
   let bootstrapResult;
   if (!swingsetIsInitialized(hostStorage)) {

--- a/packages/SwingSet/src/kernel/vatManager/factory.js
+++ b/packages/SwingSet/src/kernel/vatManager/factory.js
@@ -30,18 +30,21 @@ export function makeVatManagerFactory({
     makeNodeWorker,
     kernelKeeper,
     testLog: allVatPowers.testLog,
+    decref: gcTools.decref,
   });
 
   const nodeSubprocessFactory = makeNodeSubprocessFactory({
     startSubprocessWorker: startSubprocessWorkerNode,
     kernelKeeper,
     testLog: allVatPowers.testLog,
+    decref: gcTools.decref,
   });
 
   const xsWorkerFactory = makeNodeSubprocessFactory({
     startSubprocessWorker: startSubprocessWorkerXS,
     kernelKeeper,
     testLog: allVatPowers.testLog,
+    decref: gcTools.decref,
   });
 
   function validateManagerOptions(managerOptions) {

--- a/packages/SwingSet/src/kernel/vatManager/nodeWorker.js
+++ b/packages/SwingSet/src/kernel/vatManager/nodeWorker.js
@@ -23,7 +23,7 @@ function parentLog(first, ...args) {
 }
 
 export function makeNodeWorkerVatManagerFactory(tools) {
-  const { makeNodeWorker, kernelKeeper, testLog } = tools;
+  const { makeNodeWorker, kernelKeeper, testLog, decref } = tools;
 
   function createFromBundle(vatID, bundle, managerOptions) {
     const { vatParameters } = managerOptions;
@@ -68,6 +68,10 @@ export function makeNodeWorkerVatManagerFactory(tools) {
       doSyscall(vatSyscallObject);
     }
 
+    function vatDecref(vref, count) {
+      decref(vatID, vref, count);
+    }
+
     // start the worker and establish a connection
 
     const { promise: workerP, resolve: gotWorker } = makePromiseKit();
@@ -107,6 +111,9 @@ export function makeNodeWorkerVatManagerFactory(tools) {
           const deliveryResult = args;
           resolve(deliveryResult);
         }
+      } else if (type === 'decref') {
+        const [vref, count] = args;
+        vatDecref(vref, count);
       } else {
         parentLog(`unrecognized uplink message ${type}`);
       }

--- a/packages/SwingSet/src/kernel/vatManager/worker-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/worker-subprocess-node.js
@@ -24,7 +24,7 @@ function parentLog(first, ...args) {
 }
 
 export function makeNodeSubprocessFactory(tools) {
-  const { startSubprocessWorker, kernelKeeper, testLog } = tools;
+  const { startSubprocessWorker, kernelKeeper, testLog, decref } = tools;
 
   function createFromBundle(vatID, bundle, managerOptions) {
     const { vatParameters } = managerOptions;
@@ -71,6 +71,10 @@ export function makeNodeSubprocessFactory(tools) {
       doSyscall(vatSyscallObject);
     }
 
+    function vatDecref(vref, count) {
+      decref(vatID, vref, count);
+    }
+
     // start the worker and establish a connection
     const { fromChild, toChild, terminate, done } = startSubprocessWorker();
 
@@ -109,6 +113,9 @@ export function makeNodeSubprocessFactory(tools) {
           const deliveryResult = args;
           resolve(deliveryResult);
         }
+      } else if (type === 'decref') {
+        const [vref, count] = args;
+        vatDecref(vref, count);
       } else {
         parentLog(`unrecognized uplink message ${type}`);
       }

--- a/packages/SwingSet/test/test-vpid-liveslots.js
+++ b/packages/SwingSet/test/test-vpid-liveslots.js
@@ -191,7 +191,8 @@ function resolutionOf(vpid, mode, targets) {
 }
 
 function makeDispatch(syscall, build) {
-  const gcTools = harden({ WeakRef, FinalizationRegistry });
+  function vatDecref() {}
+  const gcTools = harden({ WeakRef, FinalizationRegistry, vatDecref });
   const { setBuildRootObject, dispatch } = makeLiveSlots(
     syscall,
     'vatA',


### PR DESCRIPTION
In the future, when liveslots implements GC and discovers that a Presence has
ceased to be referenced by the user-level vat code, it will call this
function to decrement the kernel's reference count for the imported object's
c-list entry.

`vatDecRef` might be called at any time (although always in its own turn).
The kernel will eventually add the decref information to a queue, to be
processed between cranks. For now, the kernel only records the information if
an option was set to enable it (for future unit tests).

Most of this patch is the kernel-worker protocol wiring to allow
child-process vat workers to deliver the decref back up to the kernel
process.

Liveslots does not use this yet. A future patch will switch it on.

refs #1872