### PR TITLE
Add central `agoric.priceAuthority` and types

### DIFF
--- a/packages/captp/lib/captp.js
+++ b/packages/captp/lib/captp.js
@@ -315,7 +315,8 @@ export function makeCapTP(ourId, rawSend, bootstrapObj = undefined, opts = {}) {
             answerID: questionID,
             exception: serialize(harden(rej)),
           }),
-        );
+        )
+        .catch(rej => quietReject(rej, false));
     },
     // Answer to one of our questions.
     async CTP_RETURN(obj) {

--- a/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
@@ -44,6 +44,7 @@ export function buildRootObject(vatPowers, vatParameters) {
       chainTimerService,
       zoe,
       contractHost,
+      { priceAuthority, adminFacet: priceAuthorityAdmin },
     ] = await Promise.all([
       E(vats.sharing).getSharingService(),
       E(vats.registrar).getSharedRegistrar(),
@@ -51,6 +52,7 @@ export function buildRootObject(vatPowers, vatParameters) {
       E(vats.timer).createTimerService(timerDevice),
       E(vats.zoe).buildZoe(vatAdminSvc),
       E(vats.host).makeHost(),
+      E(vats.priceAuthority).makePriceAuthority(),
     ]);
 
     // Make the other demo mints
@@ -60,6 +62,8 @@ export function buildRootObject(vatPowers, vatParameters) {
         E(vats.mints).makeMintAndIssuer(issuerName),
       ),
     );
+
+    // TODO: Create priceAuthority pairs for
 
     // Register the moola and simolean issuers
     const issuerInfo = await Promise.all(
@@ -85,6 +89,9 @@ export function buildRootObject(vatPowers, vatParameters) {
         if (powerFlags && powerFlags.includes('agoric.vattp')) {
           // Give the authority to create a new host for vattp to share objects with.
           additionalPowers.vattp = makeVattpFrom(vats);
+        }
+        if (powerFlags && powerFlags.includes('agoric.priceAuthorityAdmin')) {
+          additionalPowers.priceAuthorityAdmin = priceAuthorityAdmin;
         }
 
         const pursePetnames = {
@@ -121,6 +128,7 @@ export function buildRootObject(vatPowers, vatParameters) {
           contractHost,
           faucet,
           ibcport,
+          priceAuthority,
           registrar: registry,
           registry,
           board,
@@ -365,6 +373,7 @@ export function buildRootObject(vatPowers, vatParameters) {
                 // to give capabilities to all clients (since we are running
                 // locally with the `--give-me-all-the-agoric-powers` flag).
                 return chainBundler.createUserBundle(nickname, [
+                  'agoric.priceAuthorityAdmin',
                   'agoric.vattp',
                 ]);
               }

--- a/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
@@ -63,7 +63,8 @@ export function buildRootObject(vatPowers, vatParameters) {
       ),
     );
 
-    // TODO: Create priceAuthority pairs for
+    // TODO: Create priceAuthority pairs for moola-simolean based on the
+    // FakePriceAuthority.
 
     // Register the moola and simolean issuers
     const issuerInfo = await Promise.all(

--- a/packages/cosmic-swingset/lib/ag-solo/vats/chain-config.json
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/chain-config.json
@@ -21,6 +21,9 @@
     "network": {
       "sourceSpec": "vat-network.js"
     },
+    "priceAuthority": {
+      "sourceSpec": "vat-priceAuthority.js"
+    },
     "provisioning": {
       "sourceSpec": "vat-provisioning.js"
     },

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-priceAuthority.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-priceAuthority.js
@@ -1,0 +1,7 @@
+import { makePriceAuthorityRegistry } from '@agoric/zoe/tools/priceAuthorityRegistry';
+
+export function buildRootObject(_vatPowers) {
+  return harden({
+    makePriceAuthority: makePriceAuthorityRegistry,
+  });
+}

--- a/packages/promise-kit/src/promiseKit.js
+++ b/packages/promise-kit/src/promiseKit.js
@@ -9,7 +9,7 @@ const BestPipelinablePromise = globalThis.HandledPromise || Promise;
 /**
  * @template T
  * @typedef {Object} PromiseRecord A reified Promise
- * @property {(value: T) => void} resolve
+ * @property {(value: ERef<T>) => void} resolve
  * @property {(reason: any) => void} reject
  * @property {Promise<T>} promise
  */

--- a/packages/zoe/exported.js
+++ b/packages/zoe/exported.js
@@ -2,5 +2,7 @@ import './src/contractFacet/types';
 import './src/zoeService/types';
 import './src/contractSupport/types';
 import './src/types';
+import './tools/types';
+import '@agoric/notifier/exports';
 import '@agoric/ertp/exported';
 import '@agoric/store/exported';

--- a/packages/zoe/jsconfig.json
+++ b/packages/zoe/jsconfig.json
@@ -14,5 +14,5 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["src/**/*.js", "exports.js"],
+  "include": ["src/**/*.js", "exported.js", "tools/**/*.js"],
 }

--- a/packages/zoe/src/contracts/callSpread.js
+++ b/packages/zoe/src/contracts/callSpread.js
@@ -67,11 +67,11 @@ const inverse = percent => subtract(PERCENT_BASE, percent);
  * calculate the portion (as a percentage) of the collateral that should be
  * allocated to the long side.
  *
- * @param strikeMath AmountMath the math to use
- * @param price Amount the value of the underlying asset at closing that
+ * @param {AmountMath} strikeMath the math to use
+ * @param {Amount} price the value of the underlying asset at closing that
  * determines the payouts to the parties
- * @param strikePrice1 Amount the lower strike price
- * @param strikePrice2 Amount the upper strike price
+ * @param {Amount} strikePrice1 the lower strike price
+ * @param {Amount} strikePrice2 the upper strike price
  *
  * if price <= strikePrice1, return 0
  * if price >= strikePrice2, return 100.

--- a/packages/zoe/tools/internal-types.js
+++ b/packages/zoe/tools/internal-types.js
@@ -1,0 +1,14 @@
+/**
+ * @callback ManualTimerTick
+ * @param {string} [msg]
+ * @returns {Promise<void>}
+ */
+
+/**
+ * @typedef {Object} ManualTimerAdmin
+ * @property {ManualTimerTick} tick
+ */
+
+/**
+ * @typedef {ManualTimerAdmin & TimerService} ManualTimer
+ */

--- a/packages/zoe/tools/manualTimer.js
+++ b/packages/zoe/tools/manualTimer.js
@@ -5,10 +5,12 @@ import { makeStore } from '@agoric/store';
 
 import './types';
 
+/* eslint-disable jsdoc/valid-types */
 /**
  * @typedef {Object} ManualTimerAdmin
- * @property {(msg: string | undefined) => Promise<void>} tick
+ * @property {(msg?: string) => Promise<void>} tick
  */
+/* eslint-enable jsdoc/valid-types */
 
 /**
  * @typedef {ManualTimerAdmin & TimerService} ManualTimer

--- a/packages/zoe/tools/priceAuthorityRegistry.js
+++ b/packages/zoe/tools/priceAuthorityRegistry.js
@@ -59,6 +59,10 @@ export const makePriceAuthorityRegistry = () => {
       const record = lookup(brandIn, brandOut);
       return E(record.priceAuthority).getQuoteIssuer(brandIn, brandOut);
     },
+    async getTimerService(brandIn, brandOut) {
+      const record = lookup(brandIn, brandOut);
+      return E(record.priceAuthority).getTimerService(brandIn, brandOut);
+    },
     async getAmountInQuote(amountIn, brandOut) {
       const record = lookup(amountIn.brand, brandOut);
       return E(record.priceAuthority).getAmountInQuote(amountIn, brandOut);
@@ -71,14 +75,9 @@ export const makePriceAuthorityRegistry = () => {
       const record = lookup(brandIn, brandOut);
       return E(record.priceAuthority).getPriceNotifier(brandIn, brandOut);
     },
-    async quoteAtTime(timer, deadline, amountIn, brandOut) {
+    async quoteAtTime(deadline, amountIn, brandOut) {
       const record = lookup(amountIn.brand, brandOut);
-      return E(record.priceAuthority).quoteAtTime(
-        timer,
-        deadline,
-        amountIn,
-        brandOut,
-      );
+      return E(record.priceAuthority).quoteAtTime(deadline, amountIn, brandOut);
     },
     async quoteWhenLT(amountIn, amountOutLimit) {
       const record = lookup(amountIn.brand, amountOutLimit.brand);

--- a/packages/zoe/tools/priceAuthorityRegistry.js
+++ b/packages/zoe/tools/priceAuthorityRegistry.js
@@ -63,13 +63,13 @@ export const makePriceAuthorityRegistry = () => {
       const record = lookup(brandIn, brandOut);
       return E(record.priceAuthority).getTimerService(brandIn, brandOut);
     },
-    async getAmountInQuote(amountIn, brandOut) {
+    async quoteGiven(amountIn, brandOut) {
       const record = lookup(amountIn.brand, brandOut);
-      return E(record.priceAuthority).getAmountInQuote(amountIn, brandOut);
+      return E(record.priceAuthority).quoteGiven(amountIn, brandOut);
     },
-    async getAmountOutQuote(brandIn, amountOut) {
+    async quoteWanted(brandIn, amountOut) {
       const record = lookup(brandIn, amountOut.brand);
-      return E(record.priceAuthority).getAmountOutQuote(brandIn, amountOut);
+      return E(record.priceAuthority).quoteWanted(brandIn, amountOut);
     },
     async getPriceNotifier(brandIn, brandOut) {
       const record = lookup(brandIn, brandOut);

--- a/packages/zoe/tools/priceAuthorityRegistry.js
+++ b/packages/zoe/tools/priceAuthorityRegistry.js
@@ -1,0 +1,139 @@
+// @ts-check
+
+import { E } from '@agoric/eventual-send';
+import { makeStore } from '@agoric/store';
+import { assert, details } from '@agoric/assert';
+
+import '../exported';
+
+/**
+ * @typedef {Object} Deleter
+ * @property {() => void} delete
+ */
+
+/**
+ * @typedef {Object} PriceAuthorityRegistryAdmin
+ * @property {(pa: ERef<PriceAuthority>, assetBrand: Brand, priceBrand: Brand)
+ * => Deleter} registerPriceAuthority Add a unique price authority for a given
+ * asset/price pair
+ */
+
+/**
+ * @typedef {Object} PriceAuthorityRegistry A price authority that is a facade
+ * for other backing price authorities registered for a given asset and price
+ * brand
+ * @property {PriceAuthority} priceAuthority
+ * @property {PriceAuthorityRegistryAdmin} adminFacet
+ */
+
+/**
+ * @returns {PriceAuthorityRegistry}
+ */
+export const makePriceAuthorityRegistry = () => {
+  /**
+   * @typedef {Object} PriceAuthorityRecord A record indicating a registered
+   * price authority
+   * @property {ERef<PriceAuthority>} priceAuthority
+   */
+
+  /** @type {Store<Brand, Store<Brand, PriceAuthorityRecord>>} */
+  const assetToPriceStore = makeStore('assetBrand');
+
+  /**
+   * @param {Brand} assetBrand
+   * @param {Brand} priceBrand
+   */
+  const lookup = (assetBrand, priceBrand) => {
+    const priceStore = assetToPriceStore.get(assetBrand);
+    return priceStore.get(priceBrand);
+  };
+
+  /**
+   * This PriceAuthority is just a wrapper for multiple registered
+   * PriceAuthorities.
+   *
+   * @type {PriceAuthority}
+   */
+  const priceAuthority = {
+    async getQuoteIssuer(assetBrand, priceBrand) {
+      const record = lookup(assetBrand, priceBrand);
+      return E(record.priceAuthority).getQuoteIssuer(assetBrand, priceBrand);
+    },
+    async getInputPrice(amountIn, brandOut) {
+      const record = lookup(amountIn.brand, brandOut);
+      return E(record.priceAuthority).getInputPrice(amountIn, brandOut);
+    },
+    async getOutputPrice(amountOut, brandIn) {
+      const record = lookup(brandIn, amountOut.brand);
+      return E(record.priceAuthority).getOutputPrice(amountOut, brandIn);
+    },
+    async getPriceNotifier(assetBrand, priceBrand) {
+      const record = lookup(assetBrand, priceBrand);
+      return E(record.priceAuthority).getPriceNotifier(assetBrand, priceBrand);
+    },
+    async priceAtTime(timer, deadline, assetAmount, priceBrand) {
+      const record = lookup(assetAmount.brand, priceBrand);
+      return E(record.priceAuthority).priceAtTime(
+        timer,
+        deadline,
+        assetAmount,
+        priceBrand,
+      );
+    },
+    async priceWhenLT(assetAmount, priceLimit) {
+      const record = lookup(assetAmount.brand, priceLimit.brand);
+      return E(record.priceAuthority).priceWhenLT(assetAmount, priceLimit);
+    },
+    async priceWhenLTE(assetAmount, priceLimit) {
+      const record = lookup(assetAmount.brand, priceLimit.brand);
+      return E(record.priceAuthority).priceWhenLTE(assetAmount, priceLimit);
+    },
+    async priceWhenGTE(assetAmount, priceLimit) {
+      const record = lookup(assetAmount.brand, priceLimit.brand);
+      return E(record.priceAuthority).priceWhenGT(assetAmount, priceLimit);
+    },
+    async priceWhenGT(assetAmount, priceLimit) {
+      const record = lookup(assetAmount.brand, priceLimit.brand);
+      return E(record.priceAuthority).priceWhenGT(assetAmount, priceLimit);
+    },
+  };
+
+  /** @type {PriceAuthorityRegistryAdmin} */
+  const adminFacet = {
+    registerPriceAuthority(pa, assetBrand, priceBrand) {
+      /** @type {Store<Brand, PriceAuthorityRecord>} */
+      let priceStore;
+      if (assetToPriceStore.has(assetBrand)) {
+        priceStore = assetToPriceStore.get(assetBrand);
+      } else {
+        priceStore = makeStore('priceBrand');
+        assetToPriceStore.init(assetBrand, priceStore);
+      }
+
+      // Put a box around the authority so that we can be ensured the deleter
+      // won't delete the wrong thing.
+      const record = {
+        priceAuthority: pa,
+      };
+
+      // Set up the record.
+      priceStore.init(priceBrand, harden(record));
+
+      return harden({
+        delete() {
+          assert.equal(
+            priceStore.has(priceBrand) && priceStore.get(priceBrand),
+            record,
+            details`Price authority already dropped`,
+          );
+          priceStore.delete(priceBrand);
+        },
+      });
+    },
+  };
+
+  return harden({
+    priceAuthority,
+    adminFacet,
+  });
+};

--- a/packages/zoe/tools/types.js
+++ b/packages/zoe/tools/types.js
@@ -36,7 +36,7 @@
 
 /**
  * @typedef {Object} TimerRepeater
- * @property {(handler: TimerHandler) => void} schedule Returns the time
+ * @property {(handler: TimerServiceHandler) => void} schedule Returns the time
  * scheduled for the first call on handler.  The handler will continue to be
  * scheduled for a `wake()` call every interval until the repeater is disabled.
  * @property {() => void} disable Disable this repeater, so `schedule()` can't
@@ -72,15 +72,15 @@
  * @property {(brandIn: Brand, brandOut: Brand) => ERef<TimerService>}
  * getTimerService get the timer used in PriceQuotes for a given
  * brandIn/brandOut pair
- * @property {(amountIn: Amount, brandOut: Brand) => Promise<PriceQuote>}
- * getAmountInQuote get a quote corresponding to the specified amountIn
- * @property {(brandIn: Brand, amountOut: Amount) => Promise<PriceQuote>}
- * getAmountOutQuote get a quote corresponding to the specified amountOut
  * @property {(brandIn: Brand, brandOut: Brand) => ERef<Notifier<PriceQuote>>}
  * getPriceNotifier
- * @property {(deadline: number, amountIn: Amount, brandOut: Brand) =>
+ * @property {(deadline: Timestamp, amountIn: Amount, brandOut: Brand) =>
  * Promise<PriceQuote>} quoteAtTime Resolves after `deadline` passes on the
  * priceAuthority's timerService with the price quote of `amountIn` at that time
+ * @property {(amountIn: Amount, brandOut: Brand) => Promise<PriceQuote>}
+ * quoteGiven get a quote corresponding to the specified amountIn
+ * @property {(brandIn: Brand, amountOut: Amount) => Promise<PriceQuote>}
+ * quoteWanted get a quote corresponding to the specified amountOut
  * @property {(amountIn: Amount, amountOutLimit: Amount) => Promise<PriceQuote>}
  * quoteWhenGT Resolve when a price quote of `amountIn` exceeds `amountOutLimit`
  * @property {(amountIn: Amount, amountOutLimit: Amount) => Promise<PriceQuote>}

--- a/packages/zoe/tools/types.js
+++ b/packages/zoe/tools/types.js
@@ -1,0 +1,42 @@
+/**
+ * @typedef {Object} PriceQuote
+ * @property {Payment} quotePayment The quote wrapped as a payment
+ * @property {Amount} quoteAmount Amount of `quotePayment` (`quoteIssuer.getAmountOf(quotePayment)`)
+ */
+
+/**
+ * @typedef {Object} PriceQuoteValue An individual quote's value
+ * @property {Amount} assetAmount The amount of the asset being quoted
+ * @property {Amount} price The quoted price for the `assetAmount`
+ * @property {TimerService} timer The service that gave the `timestamp`
+ * @property {number} timestamp A timestamp for the quote according to `timer`
+ * @property {any=} conditions Additional conditions for the quote
+ */
+
+/**
+ * @typedef {Object} PriceAuthority An object that mints PriceQuotes and handles
+ * triggers and notifiers for changes in the price
+ * @property {(assetBrand: Brand, priceBrand: Brand) => ERef<Issuer>}
+ * getQuoteIssuer Get the ERTP issuer of PriceQuotes
+ * @property {(amountIn: Amount, brandOut: Brand) => Promise<PriceQuote>}
+ * getInputPrice calculate the amount of brandOut that will be returned if the
+ * amountIn is sold at the current price
+ * @property {(amountOut: Amount, brandIn: Brand) => Promise<PriceQuote>}
+ * getOutputPrice calculate the amount of brandIn that is required in order to
+ * get amountOut using the current price
+ * @property {(assetBrand: Brand, priceBrand: Brand) => ERef<Notifier<PriceQuote>>}
+ * getPriceNotifier
+ * @property {(timer: TimerService, deadline: number, assetAmount: Amount,
+ * priceBrand: Brand) => Promise<PriceQuote>} priceAtTime Resolves after
+ * `deadline` passes on `timer`  with the price of `assetAmount` at that time
+ * @property {(assetAmount: Amount, priceLimit: Amount) => Promise<PriceQuote>}
+ * priceWhenGT Resolve when the price of `assetAmount` exceeds `priceLimit`
+ * @property {(assetAmount: Amount, priceLimit: Amount) => Promise<PriceQuote>}
+ * priceWhenGTE Resolve when the price of `assetAmount` reaches or exceeds
+ * `priceLimit`
+ * @property {(assetAmount: Amount, priceLimit: Amount) => Promise<PriceQuote>}
+ * priceWhenLTE Resolve when the price of `assetAmount` reaches or drops below
+ * `priceLimit`
+ * @property {(assetAmount: Amount, priceLimit: Amount) => Promise<PriceQuote>}
+ * priceWhenLT Resolve when the price of `assetAmount` drops below `priceLimit`
+ */

--- a/packages/zoe/tools/types.js
+++ b/packages/zoe/tools/types.js
@@ -51,7 +51,8 @@
  */
 
 /**
- * @typedef {Array<PriceDescription>} PriceQuoteValue A set of PriceDescriptions
+ * @typedef {[PriceDescription]} PriceQuoteValue A single-valued set of
+ * PriceDescriptions
  */
 
 /**
@@ -67,28 +68,39 @@
 /**
  * @typedef {Object} PriceAuthority An object that mints PriceQuotes and handles
  * triggers and notifiers for changes in the price
+ *
  * @property {(brandIn: Brand, brandOut: Brand) => ERef<Issuer>} getQuoteIssuer
  * Get the ERTP issuer of PriceQuotes for a given brandIn/brandOut pair
+ *
  * @property {(brandIn: Brand, brandOut: Brand) => ERef<TimerService>}
  * getTimerService get the timer used in PriceQuotes for a given
  * brandIn/brandOut pair
+ *
  * @property {(brandIn: Brand, brandOut: Brand) => ERef<Notifier<PriceQuote>>}
  * getPriceNotifier
+ *
  * @property {(deadline: Timestamp, amountIn: Amount, brandOut: Brand) =>
- * Promise<PriceQuote>} quoteAtTime Resolves after `deadline` passes on the
+ * Promise<PriceQuote>}
+ * quoteAtTime Resolves after `deadline` passes on the
  * priceAuthority's timerService with the price quote of `amountIn` at that time
+ *
  * @property {(amountIn: Amount, brandOut: Brand) => Promise<PriceQuote>}
  * quoteGiven get a quote corresponding to the specified amountIn
+ *
  * @property {(brandIn: Brand, amountOut: Amount) => Promise<PriceQuote>}
  * quoteWanted get a quote corresponding to the specified amountOut
+ *
  * @property {(amountIn: Amount, amountOutLimit: Amount) => Promise<PriceQuote>}
  * quoteWhenGT Resolve when a price quote of `amountIn` exceeds `amountOutLimit`
+ *
  * @property {(amountIn: Amount, amountOutLimit: Amount) => Promise<PriceQuote>}
  * quoteWhenGTE Resolve when a price quote of `amountIn` reaches or exceeds
  * `amountOutLimit`
+ *
  * @property {(amountIn: Amount, amountOutLimit: Amount) => Promise<PriceQuote>}
  * quoteWhenLTE Resolve when a price quote of `amountIn` reaches or drops below
  * `amountOutLimit`
+ *
  * @property {(amountIn: Amount, amountOutLimit: Amount) => Promise<PriceQuote>}
  * quoteWhenLT Resolve when the price quote of `amountIn` drops below
  * `amountOutLimit`

--- a/packages/zoe/tools/types.js
+++ b/packages/zoe/tools/types.js
@@ -1,42 +1,92 @@
 /**
- * @typedef {Object} PriceQuote
- * @property {Payment} quotePayment The quote wrapped as a payment
- * @property {Amount} quoteAmount Amount of `quotePayment` (`quoteIssuer.getAmountOf(quotePayment)`)
+ * @typedef {Object} TimerService Gives the ability to get the current time,
+ * schedule a single wake() call, create a repeater that will allow scheduling
+ * of events at regular intervals, or remove scheduled calls.
+ * @property {() => Timestamp} getCurrentTimestamp Retrieve the latest timestamp
+ * @property {(baseTime: Timestamp, handler: TimerServiceHandler) => Timestamp}
+ * setWakeup Return value is the time at which the call is scheduled to take
+ * place
+ * @property {(handler: TimerServiceHandler) => Array<Timestamp>} removeWakeup Remove
+ * the handler from all its scheduled wakeup, whether produced by
+ * `timer.setWakeup(h)` or `repeater.schedule(h)`.
+ * @property {(baseTime: Timestamp, interval: RelativeTime) => TimerRepeater}
+ * createRepeater Create and return a repeater that will schedule `wake()` calls
+ * repeatedly at times that are a multiple of interval following baseTime.
+ * Interval is the delay between successive times at which wake will be called.
+ * When `schedule(h)` is called, `h.wake()` will be scheduled to be called after
+ * the next multiple of interval from the base. Since times can be
+ * coarse-grained, the actual call may occur later, but this won't change when
+ * the next event will be called.
  */
 
 /**
- * @typedef {Object} PriceQuoteValue An individual quote's value
- * @property {Amount} assetAmount The amount of the asset being quoted
- * @property {Amount} price The quoted price for the `assetAmount`
+ * @typedef {number} Timestamp An absolute individual stamp returned by a
+ * TimerService.  Note that different timer services may have different
+ * interpretations of actual Timestamp values.
+ * @typedef {number} RelativeTime Difference between two Timestamps.  Note that
+ * different timer services may have different interpretations of actual
+ * RelativeTime values.
+ */
+
+/**
+ * @typedef {Object} TimerServiceHandler
+ * @property {(timestamp: Timestamp) => void} wake The timestamp passed to
+ * `wake()` is the time that the call was scheduled to occur.
+ */
+
+/**
+ * @typedef {Object} TimerRepeater
+ * @property {(handler: TimerHandler) => void} schedule Returns the time
+ * scheduled for the first call on handler.  The handler will continue to be
+ * scheduled for a `wake()` call every interval until the repeater is disabled.
+ * @property {() => void} disable Disable this repeater, so `schedule()` can't
+ * be called, and handlers already scheduled with this repeater won't be
+ * rescheduled again after `wake()` is next called on them.
+ */
+
+/**
+ * @typedef {Object} PriceQuote
+ * @property {Amount} quoteAmount Amount whose value is a PriceQuoteValue
+ * @property {Payment} quotePayment The `quoteAmount` wrapped as a payment
+ */
+
+/**
+ * @typedef {Array<PriceDescription>} PriceQuoteValue A set of PriceDescriptions
+ */
+
+/**
+ * @typedef {Object} PriceDescription A description of a single quote
+ * @property {Amount} amountIn The amount supplied to a trade
+ * @property {Amount} amountOut The quoted result of trading `amountIn`
  * @property {TimerService} timer The service that gave the `timestamp`
- * @property {number} timestamp A timestamp for the quote according to `timer`
+ * @property {Timestamp} timestamp A timestamp according to `timer` for the
+ * quote
  * @property {any=} conditions Additional conditions for the quote
  */
 
 /**
  * @typedef {Object} PriceAuthority An object that mints PriceQuotes and handles
  * triggers and notifiers for changes in the price
- * @property {(assetBrand: Brand, priceBrand: Brand) => ERef<Issuer>}
- * getQuoteIssuer Get the ERTP issuer of PriceQuotes
+ * @property {(brandIn: Brand, brandOut: Brand) => ERef<Issuer>} getQuoteIssuer
+ * Get the ERTP issuer of PriceQuotes
  * @property {(amountIn: Amount, brandOut: Brand) => Promise<PriceQuote>}
- * getInputPrice calculate the amount of brandOut that will be returned if the
- * amountIn is sold at the current price
- * @property {(amountOut: Amount, brandIn: Brand) => Promise<PriceQuote>}
- * getOutputPrice calculate the amount of brandIn that is required in order to
- * get amountOut using the current price
- * @property {(assetBrand: Brand, priceBrand: Brand) => ERef<Notifier<PriceQuote>>}
+ * getAmountInQuote get a quote corresponding to the specified amountIn
+ * @property {(brandIn: Brand, amountOut: Amount) => Promise<PriceQuote>}
+ * getAmountOutQuote get a quote corresponding to the specified amountOut
+ * @property {(brandIn: Brand, brandOut: Brand) => ERef<Notifier<PriceQuote>>}
  * getPriceNotifier
- * @property {(timer: TimerService, deadline: number, assetAmount: Amount,
- * priceBrand: Brand) => Promise<PriceQuote>} priceAtTime Resolves after
- * `deadline` passes on `timer`  with the price of `assetAmount` at that time
- * @property {(assetAmount: Amount, priceLimit: Amount) => Promise<PriceQuote>}
- * priceWhenGT Resolve when the price of `assetAmount` exceeds `priceLimit`
- * @property {(assetAmount: Amount, priceLimit: Amount) => Promise<PriceQuote>}
- * priceWhenGTE Resolve when the price of `assetAmount` reaches or exceeds
- * `priceLimit`
- * @property {(assetAmount: Amount, priceLimit: Amount) => Promise<PriceQuote>}
- * priceWhenLTE Resolve when the price of `assetAmount` reaches or drops below
- * `priceLimit`
- * @property {(assetAmount: Amount, priceLimit: Amount) => Promise<PriceQuote>}
- * priceWhenLT Resolve when the price of `assetAmount` drops below `priceLimit`
+ * @property {(timer: TimerService, deadline: number, amountIn: Amount,
+ * brandOut: Brand) => Promise<PriceQuote>} quoteAtTime Resolves after
+ * `deadline` passes on `timer` with the price quote of `amountIn` at that time
+ * @property {(amountIn: Amount, amountOutLimit: Amount) => Promise<PriceQuote>}
+ * quoteWhenGT Resolve when a price quote of `amountIn` exceeds `amountOutLimit`
+ * @property {(amountIn: Amount, amountOutLimit: Amount) => Promise<PriceQuote>}
+ * quoteWhenGTE Resolve when a price quote of `amountIn` reaches or exceeds
+ * `amountOutLimit`
+ * @property {(amountIn: Amount, amountOutLimit: Amount) => Promise<PriceQuote>}
+ * quoteWhenLTE Resolve when a price quote of `amountIn` reaches or drops below
+ * `amountOutLimit`
+ * @property {(amountIn: Amount, amountOutLimit: Amount) => Promise<PriceQuote>}
+ * quoteWhenLT Resolve when the price quote of `amountIn` drops below
+ * `amountOutLimit`
  */

--- a/packages/zoe/tools/types.js
+++ b/packages/zoe/tools/types.js
@@ -68,16 +68,19 @@
  * @typedef {Object} PriceAuthority An object that mints PriceQuotes and handles
  * triggers and notifiers for changes in the price
  * @property {(brandIn: Brand, brandOut: Brand) => ERef<Issuer>} getQuoteIssuer
- * Get the ERTP issuer of PriceQuotes
+ * Get the ERTP issuer of PriceQuotes for a given brandIn/brandOut pair
+ * @property {(brandIn: Brand, brandOut: Brand) => ERef<TimerService>}
+ * getTimerService get the timer used in PriceQuotes for a given
+ * brandIn/brandOut pair
  * @property {(amountIn: Amount, brandOut: Brand) => Promise<PriceQuote>}
  * getAmountInQuote get a quote corresponding to the specified amountIn
  * @property {(brandIn: Brand, amountOut: Amount) => Promise<PriceQuote>}
  * getAmountOutQuote get a quote corresponding to the specified amountOut
  * @property {(brandIn: Brand, brandOut: Brand) => ERef<Notifier<PriceQuote>>}
  * getPriceNotifier
- * @property {(timer: TimerService, deadline: number, amountIn: Amount,
- * brandOut: Brand) => Promise<PriceQuote>} quoteAtTime Resolves after
- * `deadline` passes on `timer` with the price quote of `amountIn` at that time
+ * @property {(deadline: number, amountIn: Amount, brandOut: Brand) =>
+ * Promise<PriceQuote>} quoteAtTime Resolves after `deadline` passes on the
+ * priceAuthority's timerService with the price quote of `amountIn` at that time
  * @property {(amountIn: Amount, amountOutLimit: Amount) => Promise<PriceQuote>}
  * quoteWhenGT Resolve when a price quote of `amountIn` exceeds `amountOutLimit`
  * @property {(amountIn: Amount, amountOutLimit: Amount) => Promise<PriceQuote>}

--- a/packages/zoe/tools/types.js
+++ b/packages/zoe/tools/types.js
@@ -3,18 +3,17 @@
  * schedule a single wake() call, create a repeater that will allow scheduling
  * of events at regular intervals, or remove scheduled calls.
  * @property {() => Timestamp} getCurrentTimestamp Retrieve the latest timestamp
- * @property {(baseTime: Timestamp, handler: TimerServiceHandler) => Timestamp}
- * setWakeup Return value is the time at which the call is scheduled to take
- * place
- * @property {(handler: TimerServiceHandler) => Array<Timestamp>} removeWakeup Remove
- * the handler from all its scheduled wakeup, whether produced by
- * `timer.setWakeup(h)` or `repeater.schedule(h)`.
- * @property {(baseTime: Timestamp, interval: RelativeTime) => TimerRepeater}
+ * @property {(baseTime: Timestamp, waker: Waker) => Timestamp} setWakeup Return
+ * value is the time at which the call is scheduled to take place
+ * @property {(waker: Waker) => Array<Timestamp>} removeWakeup Remove the waker
+ * from all its scheduled wakeups, whether produced by `timer.setWakeup(h)` or
+ * `repeater.schedule(h)`.
+ * @property {(delay: RelativeTime, interval: RelativeTime) => TimerRepeater}
  * createRepeater Create and return a repeater that will schedule `wake()` calls
- * repeatedly at times that are a multiple of interval following baseTime.
- * Interval is the delay between successive times at which wake will be called.
- * When `schedule(h)` is called, `h.wake()` will be scheduled to be called after
- * the next multiple of interval from the base. Since times can be
+ * repeatedly at times that are a multiple of interval following delay.
+ * Interval is the difference between successive times at which wake will be
+ * called.  When `schedule(w)` is called, `w.wake()` will be scheduled to be
+ * called after the next multiple of interval from the base. Since times can be
  * coarse-grained, the actual call may occur later, but this won't change when
  * the next event will be called.
  */
@@ -29,19 +28,19 @@
  */
 
 /**
- * @typedef {Object} TimerServiceHandler
+ * @typedef {Object} Waker
  * @property {(timestamp: Timestamp) => void} wake The timestamp passed to
  * `wake()` is the time that the call was scheduled to occur.
  */
 
 /**
  * @typedef {Object} TimerRepeater
- * @property {(handler: TimerServiceHandler) => void} schedule Returns the time
- * scheduled for the first call on handler.  The handler will continue to be
- * scheduled for a `wake()` call every interval until the repeater is disabled.
- * @property {() => void} disable Disable this repeater, so `schedule()` can't
- * be called, and handlers already scheduled with this repeater won't be
- * rescheduled again after `wake()` is next called on them.
+ * @property {(waker: Waker) => void} schedule Returns the time scheduled for
+ * the first call to `E(waker).wake()`.  The waker will continue to be scheduled
+ * every interval until the repeater is disabled.
+ * @property {() => void} disable Disable this repeater, so `schedule(w)` can't
+ * be called, and wakers already scheduled with this repeater won't be
+ * rescheduled again after `E(waker).wake()` is next called on them.
  */
 
 /**
@@ -52,7 +51,8 @@
 
 /**
  * @typedef {[PriceDescription]} PriceQuoteValue A single-valued set of
- * PriceDescriptions
+ * PriceDescriptions.  This is the `value` in PriceQuote.quoteAmount (`{ brand,
+ * value: PriceQuoteValue }`).
  */
 
 /**

--- a/packages/zoe/tools/types.js
+++ b/packages/zoe/tools/types.js
@@ -3,9 +3,9 @@
  * schedule a single wake() call, create a repeater that will allow scheduling
  * of events at regular intervals, or remove scheduled calls.
  * @property {() => Timestamp} getCurrentTimestamp Retrieve the latest timestamp
- * @property {(baseTime: Timestamp, waker: Waker) => Timestamp} setWakeup Return
+ * @property {(baseTime: Timestamp, waker: TimerWaker) => Timestamp} setWakeup Return
  * value is the time at which the call is scheduled to take place
- * @property {(waker: Waker) => Array<Timestamp>} removeWakeup Remove the waker
+ * @property {(waker: TimerWaker) => Array<Timestamp>} removeWakeup Remove the waker
  * from all its scheduled wakeups, whether produced by `timer.setWakeup(h)` or
  * `repeater.schedule(h)`.
  * @property {(delay: RelativeTime, interval: RelativeTime) => TimerRepeater}
@@ -28,14 +28,14 @@
  */
 
 /**
- * @typedef {Object} Waker
+ * @typedef {Object} TimerWaker
  * @property {(timestamp: Timestamp) => void} wake The timestamp passed to
  * `wake()` is the time that the call was scheduled to occur.
  */
 
 /**
  * @typedef {Object} TimerRepeater
- * @property {(waker: Waker) => void} schedule Returns the time scheduled for
+ * @property {(waker: TimerWaker) => void} schedule Returns the time scheduled for
  * the first call to `E(waker).wake()`.  The waker will continue to be scheduled
  * every interval until the repeater is disabled.
  * @property {() => void} disable Disable this repeater, so `schedule(w)` can't


### PR DESCRIPTION
Refs #1916, #1943

Implement types for TimerService and PriceAuthority.

This also adds a `priceAuthorityRegistry` that is a simple wrapper for multiple independent price authorities.

Finally, the `agoric.priceAuthority` is a `priceAuthorityRegistry`, administered by ag-solos provisioned with the `"agoric.priceAuthorityAdmin"` Agoric power.

To complete #1943, we need also to add a "moola-simolean" price authority during bootstrap.  That will happen after the fake price authority is ready.

![Screen Shot 2020-10-29 at 7 49 37 PM](https://user-images.githubusercontent.com/457244/97650677-e3050f00-1a1f-11eb-8793-67bd2f87ad7f.png)
