### PR TITLE
fix: properly return .pluginRoot when deploying plugins

### DIFF
--- a/packages/agoric-cli/lib/deploy.js
+++ b/packages/agoric-cli/lib/deploy.js
@@ -207,7 +207,7 @@ export { bootPlugin } from ${JSON.stringify(absPath)};
                 // Return the bootstrap object for this plugin.
                 console.info(`Loading plugin ${JSON.stringify(pluginFile)}`);
                 return E.G(E(pluginManager).load(pluginName, pluginOpts))
-                  .bootstrap;
+                  .pluginRoot;
               } catch (e) {
                 throw Error(
                   `Cannot install unsafe plugin: ${(e && e.stack) || e}`,


### PR DESCRIPTION
We had changed what the `pluginManager` returns without updating the `packages/agoric-cli/lib/deploy.js`.