### PR TITLE
fix: prevent infinite loop when metering BigInt values

### DIFF
--- a/packages/transform-metering/src/meter.js
+++ b/packages/transform-metering/src/meter.js
@@ -7,7 +7,7 @@ const { ceil } = Math;
 const ObjectConstructor = Object;
 
 // eslint-disable-next-line no-bitwise
-const bigIntWord = typeof BigInt !== 'undefined' && BigInt(1 << 32);
+const bigIntWord = typeof BigInt !== 'undefined' && BigInt(2) ** BigInt(64);
 const bigIntZero = bigIntWord && BigInt(0);
 
 // Stop deducting when we reach a negative number.
@@ -99,7 +99,6 @@ export function makeAllocateMeter(maybeAbort, meter, allocateCounter = null) {
               remaining = -remaining;
             }
             while (remaining > bigIntZero) {
-              meter[c.METER_COMPUTE](undefined, throwForever);
               remaining /= bigIntWord;
               cost += 1;
             }

--- a/packages/transform-metering/test/test-meter.js
+++ b/packages/transform-metering/test/test-meter.js
@@ -1,3 +1,4 @@
+/* globals BigInt */
 /* eslint-disable no-await-in-loop */
 import test from 'ava';
 
@@ -111,4 +112,11 @@ test('getBalance', async t => {
   t.is(refillFacet.getComputeBalance(), 7);
   t.is(refillFacet.getAllocateBalance(), c.DEFAULT_COMBINED_METER);
   t.is(refillFacet.getCombinedBalance(), c.DEFAULT_COMBINED_METER);
+});
+
+test('BigInt', async t => {
+  const { meter, refillFacet } = makeMeter({ budgetAllocate: 10 });
+  t.is(refillFacet.getAllocateBalance(), 10);
+  meter[c.METER_ALLOCATE](BigInt('1234567890123456789012345678901234567890'));
+  t.is(refillFacet.getAllocateBalance(), 6);
 });


### PR DESCRIPTION
With the old behaviour, we hit an infinite loop and the compute meter would be exceeded whenever trying to meter `BigInt('xxx')`.  Now we just meter it for allocation.
