### PR TITLE
chore: rename packages/*/exports.js to packages/*/exported.js

### DIFF
--- a/packages/ERTP/jsconfig.json
+++ b/packages/ERTP/jsconfig.json
@@ -14,5 +14,5 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["src/**/*.js", "exports.js"],
+  "include": ["src/**/*.js", "exported.js"],
 }

--- a/packages/SwingSet/jsconfig.json
+++ b/packages/SwingSet/jsconfig.json
@@ -14,5 +14,5 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["src/**/*.js", "exports.js"],
+  "include": ["src/**/*.js", "exported.js"],
 }

--- a/packages/assert/jsconfig.json
+++ b/packages/assert/jsconfig.json
@@ -14,5 +14,5 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["src/**/*.js", "exports.js"],
+  "include": ["src/**/*.js", "exported.js"],
 }

--- a/packages/cosmic-swingset/jsconfig.json
+++ b/packages/cosmic-swingset/jsconfig.json
@@ -14,5 +14,5 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["lib/**/*.js", "exports.js"],
+  "include": ["lib/**/*.js", "exported.js"],
 }

--- a/packages/dapp-svelte-wallet/api/jsconfig.json
+++ b/packages/dapp-svelte-wallet/api/jsconfig.json
@@ -14,5 +14,5 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["src/**/*.js", "test/**/*.js", "exports.js"],
+  "include": ["src/**/*.js", "test/**/*.js", "exported.js"],
 }

--- a/packages/marshal/jsconfig.json
+++ b/packages/marshal/jsconfig.json
@@ -14,6 +14,6 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  //"include": ["src/**/*.js", "exports.js"],
+  //"include": ["src/**/*.js", "exported.js"],
   "include": ["marshal.js"],
 }

--- a/packages/notifier/exported.js
+++ b/packages/notifier/exported.js
@@ -1,0 +1,1 @@
+import './src/types';

--- a/packages/notifier/exports.js
+++ b/packages/notifier/exports.js
@@ -1,1 +1,5 @@
-import './src/types';
+// TODO: Remove this file when all our clients are known to be updated.
+export * from './exported';
+console.warn(
+  `DEPRECATION: '@agoric/notifier/exports' is deprecated in favour of '@agoric/notifier/exported'`,
+);

--- a/packages/notifier/jsconfig.json
+++ b/packages/notifier/jsconfig.json
@@ -14,5 +14,5 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["src/**/*.js", "exports.js"],
+  "include": ["src/**/*.js", "exported.js"],
 }

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -44,6 +44,7 @@
   },
   "files": [
     "src/",
+    "exported.js",
     "NEWS.md"
   ],
   "eslintConfig": {

--- a/packages/promise-kit/jsconfig.json
+++ b/packages/promise-kit/jsconfig.json
@@ -14,5 +14,5 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["src/**/*.js", "exports.js"],
+  "include": ["src/**/*.js", "exported.js"],
 }

--- a/packages/store/jsconfig.json
+++ b/packages/store/jsconfig.json
@@ -14,5 +14,5 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["src/**/*.js", "exports.js"],
+  "include": ["src/**/*.js", "exported.js"],
 }

--- a/packages/zoe/exported.js
+++ b/packages/zoe/exported.js
@@ -3,6 +3,6 @@ import './src/zoeService/types';
 import './src/contractSupport/types';
 import './src/types';
 import './tools/types';
-import '@agoric/notifier/exports';
+import '@agoric/notifier/exported';
 import '@agoric/ertp/exported';
 import '@agoric/store/exported';


### PR DESCRIPTION
Closes #1950

Leave in place a deprecation warning for @agoric/notifier/exports
just in case there's a dapp that still uses it.

Don't break the dapps!
