### PR TITLE
Three-party forwarding of device nodes

### DIFF
--- a/packages/SwingSet/src/vats/comms/dispatch.js
+++ b/packages/SwingSet/src/vats/comms/dispatch.js
@@ -38,6 +38,8 @@ export function buildCommsDispatch(syscall) {
   const controller = makeVatSlot('object', true, 0);
 
   function deliver(target, method, args, result) {
+    console.info(`-- start: deliver ${target} ${method}`);
+    try {
     insistCapData(args);
     if (target === controller) {
       return deliverToController(
@@ -49,7 +51,7 @@ export function buildCommsDispatch(syscall) {
         syscall,
       );
     }
-    // console.debug(`comms.deliver ${target} r=${result}`);
+    // console.info(`comms.deliver ${target} r=${result}`);
     // dumpState(state);
     if (state.objectTable.has(target) || state.promiseTable.has(target)) {
       assert(
@@ -70,11 +72,17 @@ export function buildCommsDispatch(syscall) {
     // TODO: if promise target not in PromiseTable: resolve result to error
     //   this will happen if someone pipelines to our controller/receiver
     throw Error(`unknown target ${target}`);
+      } catch (e) {
+        console.info(`   error: deliver`, e);
+        throw e;
+      }
   }
 
   function notifyFulfillToData(promiseID, data) {
+    console.info(`-- start: fulfillToData ${promiseID} ${data}`);
+    try {
     insistCapData(data);
-    // console.debug(`comms.notifyFulfillToData(${promiseID})`);
+    // console.info(`comms.notifyFulfillToData(${promiseID})`);
     // dumpState(state);
 
     // I *think* we should never get here for local promises, since the
@@ -94,19 +102,35 @@ export function buildCommsDispatch(syscall) {
 
     const resolution = harden({ type: 'data', data });
     resolveFromKernel(promiseID, resolution);
+      } catch (e) {
+        console.info(`   error: fulfillToData`, e);
+        throw e;
+      }
   }
 
   function notifyFulfillToPresence(promiseID, slot) {
-    // console.debug(`comms.notifyFulfillToPresence(${promiseID}) = ${slot}`);
+    console.info(`-- start: fulfillToPresence ${promiseID} ${slot}`);
+    try {
+    // console.info(`comms.notifyFulfillToPresence(${promiseID}) = ${slot}`);
     const resolution = harden({ type: 'object', slot });
     resolveFromKernel(promiseID, resolution);
+      } catch (e) {
+        console.info(`   error: fulfillToPresence`, e);
+        throw e;
+      }
   }
 
   function notifyReject(promiseID, data) {
+    console.info(`-- start: notifyReject ${promiseID} ${data}`);
+    try {
     insistCapData(data);
-    // console.debug(`comms.notifyReject(${promiseID})`);
+    // console.info(`comms.notifyReject(${promiseID})`);
     const resolution = harden({ type: 'reject', data });
     resolveFromKernel(promiseID, resolution);
+      } catch (e) {
+        console.info(`   error: reject`, e);
+        throw e;
+      }
   }
 
   const dispatch = harden({

--- a/packages/SwingSet/test/message-patterns.js
+++ b/packages/SwingSet/test/message-patterns.js
@@ -837,62 +837,53 @@ export function buildPatterns(log) {
   test('a91');
 
   // bug #1844
-  // chain is talking to ag-solo1 and ag-solo2
   //
-  // a promise is created on ag-solo2 (carol), returned to ag-solo1. Later,
-  // the promise is resolved to an object on carol.
+  // a device node is created on ag-solo1 (bob), forwarded to ag-solo-2 (carol)
+  // it never arrives.
   //
-  // ag-solo1 sends message to ag-solo2 with an argument
-  // when the argument is plain data, it works
   // chain=A, ag-solo-1=B, ag-solo-2=C
 
-  // A: b~.c92_one(carol)
-  // B: carol~.c92_two(data)
+  // A: b~.b92_one(c)
+  // B: c~.c92_one(BDeviceNode)
   {
     objA.a92 = async () => {
+      log('alice calling bob');
       await E(b.bob).b92_one(c.carol);
+      log('alice continues');
     };
-    objB.b92_one = carol => {
-      log('bob got carol');
-      E(carol).c92_two('data');
+    objB.b92_one = async carol => {
+      // FIXME: BDeviceNode should actually be a device node from bob, then
+      // carol never receives it.
+      const BDeviceNode = {};
+
+      log('bob sending carol BDeviceNode');
+      await E(carol).c92_one(BDeviceNode);
+      log('bob continues');
     };
-    objC.c92_two = data => {
-      log(`carol got ${data}`);
+    objC.c92_one = BDeviceNode => {
+      log(`carol got BDeviceNode`);
+      log(
+        `BDeviceNode has ${
+          Object.getOwnPropertyNames(BDeviceNode).length
+        } names`,
+      );
+      log(
+        `BDeviceNode has ${
+          Object.getOwnPropertySymbols(BDeviceNode).length
+        } syms`,
+      );
     };
   }
-  out.a92 = ['bob got carol', 'carol got data'];
+  out.a92 = [
+    'alice calling bob',
+    'bob sending carol BDeviceNode',
+    'carol got BDeviceNode',
+    'BDeviceNode has 0 names',
+    'BDeviceNode has 0 syms',
+    'bob continues',
+    'alice continues',
+  ];
   test('a92');
-
-  // more bug #1844
-  // when the argument is an object that lives on ag-solo2, it fails
-
-  // A: b~.c93_one(carol, alice)
-  // B: carol~.c93_two(alice)
-  {
-    objA.a93 = async () => {
-      await E(b.bob).b93_one(c.carol, a.amy);
-    };
-    objB.b93_one = async (carol, amy) => {
-      log('bob got carol');
-      const { charlieP } = await E(carol).c93_two();
-      E(charlieP).hello('hi charlie', amy);
-      E(carol).c93_three();
-    };
-    const pk = makePromiseKit();
-    objC.c93_two = () => {
-      return { charlieP: pk.promise };
-    };
-    objC.c93_three = () => {
-      const charlie = harden({
-        hello(data, amy) {
-          log(`charlie got ${data} amy is ${amy}`);
-        },
-      });
-      pk.resolve(charlie); // delay whole crank
-    };
-  }
-  out.a93 = ['bob got carol', 'charlie got hi charlie'];
-  test('a93');
 
   // TODO: kernel-allocated promise, either comms or kernel resolves it,
   // comms needs to send into kernel again


### PR DESCRIPTION
Closes #1844

I found it!  When Alice receives an empty object from one of her devices, it is marshalled as a device node.  Attempting to sending that node as part of an argument to an eventual method send to Carol (`E(carol).method({ aliceDeviceNode })`) proxying via Bob is never received by Carol.  Also, Alice's resulting HandledPromise never settles (fulfils nor rejects). The same thing works fine if the device node is sent without an intervening proxy... it's wrapped and unwrapped as a presence.  I don't yet have a test case, but the scaffold is there as a94.

I worked around it in the `vat-http.js` by `JSON.parse(JSON.stringify(obj))` to translate the device nodes into empty objects which are conveyed as presences that can be used as an empty object, so it's no longer blocking my #1861 PR.

We're probably just not handling device nodes in the introduction-by-proxying case (didn't see them on @warner's pretty diagram).
