### PR TITLE
ci: trigger repository_dispatch.test-agoric-sdk on TEST_REPOS

### DIFF
--- a/.github/workflows/webhooks.yml
+++ b/.github/workflows/webhooks.yml
@@ -3,6 +3,7 @@ name: Webhooks
 on:
   push:
     branches: [ $default-branch ]
+  pull_request:
 
 jobs:
   test-agoric-sdk:
@@ -10,12 +11,38 @@ jobs:
     strategy:
       matrix:
         # TEST_REPOS format: [ <ORG>/<REPO>, ... ]
-        repo: ${{ secrets.TEST_REPOS }}
+        owner_repo: ${{ secrets.TEST_REPOS }}
 
     steps:
+    # Trigger the
+    # on:
+    #  repository_dispatch:
+    #    types: [test-agoric-sdk]
+    # actions.
     - name: Repository Dispatch
       uses: peter-evans/repository-dispatch@v1
       with:
         token: ${{ secrets.TEST_REPO_TOKEN }}
-        repository: ${{ matrix.repo }}
-        event_type: test-agoric-sdk
+        repository: ${{ matrix.owner_repo }}
+        event-type: test-agoric-sdk
+        client-payload: '{"ref": "${{ github.ref }}"}'
+
+    - id: split
+      uses: actions/github-script@0.9.0
+      with:
+        script: |
+          const [owner, repo] = '${{ matrix.owner_repo }}'.split('/');
+          core.setOutput('owner', owner);
+          core.setOutput('repo', repo);
+
+    # This step will retry until required check passes
+    # and will fail the whole workflow if the check conclusion is not a success
+    - name: Wait on build
+      uses: fountainhead/action-wait-for-check@v1.0.0
+      with:
+        ref: main # can be commit SHA or tag too
+        owner: ${{ steps.split.outputs.owner }}
+        repo: ${{ steps.split.outputs.repo }}
+        check-name: build # name of the existing check
+        repo-token: ${{ secrets.TEST_REPO_TOKEN }}
+        wait-interval: 20 # seconds

--- a/.github/workflows/webhooks.yml
+++ b/.github/workflows/webhooks.yml
@@ -27,22 +27,24 @@ jobs:
         event-type: test-agoric-sdk
         client-payload: '{"ref": "${{ github.ref }}"}'
 
-    - id: split
-      uses: actions/github-script@0.9.0
-      with:
-        script: |
-          const [owner, repo] = '${{ matrix.owner_repo }}'.split('/');
-          core.setOutput('owner', owner);
-          core.setOutput('repo', repo);
+    # # FIXME: It would be nice to wait for the test to complete, but I couldn't
+    # # get it to work.
+    # - id: split
+    #   uses: actions/github-script@0.9.0
+    #   with:
+    #     script: |
+    #       const [owner, repo] = '${{ matrix.owner_repo }}'.split('/');
+    #       core.setOutput('owner', owner);
+    #       core.setOutput('repo', repo);
 
-    # This step will retry until required check passes
-    # and will fail the whole workflow if the check conclusion is not a success
-    - name: Wait on build (14.x)
-      uses: fountainhead/action-wait-for-check@v1.0.0
-      with:
-        ref: main # can be commit SHA or tag too
-        owner: ${{ steps.split.outputs.owner }}
-        repo: ${{ steps.split.outputs.repo }}
-        checkName: "build (14.x)" # name of the existing check
-        token: ${{ secrets.TEST_REPO_TOKEN }}
-        intervalSeconds: 20 # seconds
+    # # This step will retry until required check passes
+    # # and will fail the whole workflow if the check conclusion is not a success
+    # - name: Wait on build (14.x)
+    #   uses: fountainhead/action-wait-for-check@v1.0.0
+    #   with:
+    #     ref: main # can be commit SHA or tag too
+    #     owner: ${{ steps.split.outputs.owner }}
+    #     repo: ${{ steps.split.outputs.repo }}
+    #     checkName: "build (14.x)" # name of the existing check
+    #     token: ${{ secrets.TEST_REPO_TOKEN }}
+    #     intervalSeconds: 20 # seconds

--- a/.github/workflows/webhooks.yml
+++ b/.github/workflows/webhooks.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # TEST_REPOS format: [ <ORG>/<REPO>, ... ]
-        owner_repo: ${{ secrets.TEST_REPOS }}
+        owner_repo:
+        - agoric-labs/dapp-token-economy
 
     steps:
     # Trigger the
@@ -43,6 +43,6 @@ jobs:
         ref: main # can be commit SHA or tag too
         owner: ${{ steps.split.outputs.owner }}
         repo: ${{ steps.split.outputs.repo }}
-        check-name: build # name of the existing check
-        repo-token: ${{ secrets.TEST_REPO_TOKEN }}
-        wait-interval: 20 # seconds
+        checkName: build # name of the existing check
+        token: ${{ secrets.TEST_REPO_TOKEN }}
+        intervalSeconds: 20 # seconds

--- a/.github/workflows/webhooks.yml
+++ b/.github/workflows/webhooks.yml
@@ -37,12 +37,12 @@ jobs:
 
     # This step will retry until required check passes
     # and will fail the whole workflow if the check conclusion is not a success
-    - name: Wait on build
+    - name: Wait on build (14.x)
       uses: fountainhead/action-wait-for-check@v1.0.0
       with:
         ref: main # can be commit SHA or tag too
         owner: ${{ steps.split.outputs.owner }}
         repo: ${{ steps.split.outputs.repo }}
-        checkName: build # name of the existing check
+        checkName: "build (14.x)" # name of the existing check
         token: ${{ secrets.TEST_REPO_TOKEN }}
         intervalSeconds: 20 # seconds

--- a/.github/workflows/webhooks.yml
+++ b/.github/workflows/webhooks.yml
@@ -1,0 +1,21 @@
+name: Webhooks
+
+on:
+  push:
+    branches: [ $default-branch ]
+
+jobs:
+  test-agoric-sdk:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # TEST_REPOS format: [ <ORG>/<REPO>, ... ]
+        repo: ${{ secrets.TEST_REPOS }}
+
+    steps:
+    - name: Repository Dispatch
+      uses: peter-evans/repository-dispatch@v1
+      with:
+        token: ${{ secrets.TEST_REPO_TOKEN }}
+        repository: ${{ matrix.repo }}
+        event_type: test-agoric-sdk


### PR DESCRIPTION
Better than polling from our TEST_REPOS.
