### PR TITLE
feat: add a decimals parameter, and decimals method to brand

### DIFF
--- a/packages/ERTP/src/displayInfo.js
+++ b/packages/ERTP/src/displayInfo.js
@@ -1,5 +1,10 @@
 import { assert, details, q } from '@agoric/assert';
-import { pureCopy, passStyleOf, REMOTE_STYLE } from '@agoric/marshal';
+import {
+  pureCopy,
+  passStyleOf,
+  REMOTE_STYLE,
+  getInterfaceOf,
+} from '@agoric/marshal';
 
 // TODO: assertSubset and assertKeysAllowed are copied from Zoe. Move
 // this code to a location where it can be used by ERTP and Zoe
@@ -44,6 +49,18 @@ export const assertDisplayInfo = allegedDisplayInfo => {
 
 export const coerceDisplayInfo = allegedDisplayInfo => {
   if (passStyleOf(allegedDisplayInfo) === REMOTE_STYLE) {
+    // These condition together try to ensure that `allegedDisplayInfo`
+    // is a plain empty object. It will accept all plain empty objects
+    // that it should. It will reject most things we want to reject including
+    // remotables that are explicitly declared `Remotable`. But a normal
+    // HandledPromise presence not explicitly declared `Remotable` will
+    // be mistaken for a plain empty object. Even in this case, the copy
+    // has a new identity, so the only danger is that we didn't reject
+    // with a diagnostic, potentially masking a programmer error.
+    assert(Object.isFrozen(allegedDisplayInfo));
+    assert.equal(Reflect.ownKeys(allegedDisplayInfo).length, 0);
+    assert.equal(Object.getPrototypeOf(allegedDisplayInfo), Object.prototype);
+    assert.equal(getInterfaceOf(allegedDisplayInfo), undefined);
     return harden({});
   }
   allegedDisplayInfo = pureCopy(allegedDisplayInfo);

--- a/packages/ERTP/src/displayInfo.js
+++ b/packages/ERTP/src/displayInfo.js
@@ -1,4 +1,5 @@
 import { assert, details, q } from '@agoric/assert';
+import { pureCopy, passStyleOf, REMOTE_STYLE } from '@agoric/marshal';
 
 // TODO: assertSubset and assertKeysAllowed are copied from Zoe. Move
 // this code to a location where it can be used by ERTP and Zoe
@@ -39,4 +40,13 @@ export const assertDisplayInfo = allegedDisplayInfo => {
   }
   const displayInfoKeys = harden(['decimalPlaces']);
   assertKeysAllowed(displayInfoKeys, allegedDisplayInfo);
+};
+
+export const coerceDisplayInfo = allegedDisplayInfo => {
+  if (passStyleOf(allegedDisplayInfo) === REMOTE_STYLE) {
+    return harden({});
+  }
+  allegedDisplayInfo = pureCopy(allegedDisplayInfo);
+  assertDisplayInfo(allegedDisplayInfo);
+  return allegedDisplayInfo;
 };

--- a/packages/ERTP/src/displayInfo.js
+++ b/packages/ERTP/src/displayInfo.js
@@ -1,5 +1,9 @@
 import { assert, details, q } from '@agoric/assert';
 
+// TODO: assertSubset and assertKeysAllowed are copied from Zoe. Move
+// this code to a location where it can be used by ERTP and Zoe
+// easily. Perhaps another package.
+
 /**
  * Assert all values from `part` appear in `whole`.
  *

--- a/packages/ERTP/src/displayInfo.js
+++ b/packages/ERTP/src/displayInfo.js
@@ -1,0 +1,38 @@
+import { assert, details, q } from '@agoric/assert';
+
+/**
+ * Assert all values from `part` appear in `whole`.
+ *
+ * @param {string[]} whole
+ * @param {string[]} part
+ */
+export const assertSubset = (whole, part) => {
+  part.forEach(key => {
+    assert.typeof(key, 'string');
+    assert(
+      whole.includes(key),
+      details`key ${q(key)} was not one of the expected keys ${q(whole)}`,
+    );
+  });
+};
+
+// Assert that the keys of `record` are all in `allowedKeys`. If a key
+// of `record` is not in `allowedKeys`, throw an error. If a key in
+// `allowedKeys` is not a key of record, we do not throw an error.
+export const assertKeysAllowed = (allowedKeys, record) => {
+  const keys = Object.getOwnPropertyNames(record);
+  assertSubset(allowedKeys, keys);
+  // assert that there are no symbol properties.
+  assert(
+    Object.getOwnPropertySymbols(record).length === 0,
+    details`no symbol properties allowed`,
+  );
+};
+
+export const assertDisplayInfo = allegedDisplayInfo => {
+  if (allegedDisplayInfo === undefined) {
+    return;
+  }
+  const displayInfoKeys = harden(['decimalPlaces']);
+  assertKeysAllowed(displayInfoKeys, allegedDisplayInfo);
+};

--- a/packages/ERTP/src/issuer.js
+++ b/packages/ERTP/src/issuer.js
@@ -10,7 +10,7 @@ import { isPromise } from '@agoric/promise-kit';
 
 import { makeAmountMath, MathKind } from './amountMath';
 import { makeInterface, ERTPKind } from './interfaces';
-import { assertDisplayInfo } from './displayInfo';
+import { coerceDisplayInfo } from './displayInfo';
 
 import './types';
 
@@ -23,7 +23,7 @@ function makeIssuerKit(
   displayInfo = undefined,
 ) {
   assert.typeof(allegedName, 'string');
-  assertDisplayInfo(displayInfo);
+  displayInfo = coerceDisplayInfo(displayInfo);
 
   const brand = Remotable(
     makeInterface(allegedName, ERTPKind.BRAND),

--- a/packages/ERTP/src/issuer.js
+++ b/packages/ERTP/src/issuer.js
@@ -16,11 +16,7 @@ import './types';
 /**
  * @type {MakeIssuerKit}
  */
-function makeIssuerKit(
-  allegedName,
-  amountMathKind = MathKind.NAT,
-  decimals = undefined,
-) {
+function makeIssuerKit(allegedName, amountMathKind = MathKind.NAT, decimals) {
   assert.typeof(allegedName, 'string');
 
   const brand = Remotable(

--- a/packages/ERTP/src/issuer.js
+++ b/packages/ERTP/src/issuer.js
@@ -14,11 +14,13 @@ import { makeInterface, ERTPKind } from './interfaces';
 import './types';
 
 /**
- * @param {string} allegedName
- * @param {AmountMathKind} [amountMathKind=MathKind.NAT]
- * @returns {IssuerKit}
+ * @type {MakeIssuerKit}
  */
-function makeIssuerKit(allegedName, amountMathKind = MathKind.NAT) {
+function makeIssuerKit(
+  allegedName,
+  amountMathKind = MathKind.NAT,
+  decimals = undefined,
+) {
   assert.typeof(allegedName, 'string');
 
   const brand = Remotable(
@@ -32,6 +34,12 @@ function makeIssuerKit(allegedName, amountMathKind = MathKind.NAT) {
         });
       },
       getAllegedName: () => allegedName,
+
+      // Give information to UI on how to display the amount.
+      // Fungible digital assets should be represented in integers, in
+      // the smallest unit (i.e. USD might be represented in mill,
+      // a thousandth of a dollar. In that case, `decimals` would be 3).
+      decimals: () => decimals,
     },
   );
 

--- a/packages/ERTP/src/issuer.js
+++ b/packages/ERTP/src/issuer.js
@@ -10,14 +10,20 @@ import { isPromise } from '@agoric/promise-kit';
 
 import { makeAmountMath, MathKind } from './amountMath';
 import { makeInterface, ERTPKind } from './interfaces';
+import { assertDisplayInfo } from './displayInfo';
 
 import './types';
 
 /**
  * @type {MakeIssuerKit}
  */
-function makeIssuerKit(allegedName, amountMathKind = MathKind.NAT, decimals) {
+function makeIssuerKit(
+  allegedName,
+  amountMathKind = MathKind.NAT,
+  displayInfo = undefined,
+) {
   assert.typeof(allegedName, 'string');
+  assertDisplayInfo(displayInfo);
 
   const brand = Remotable(
     makeInterface(allegedName, ERTPKind.BRAND),
@@ -32,10 +38,7 @@ function makeIssuerKit(allegedName, amountMathKind = MathKind.NAT, decimals) {
       getAllegedName: () => allegedName,
 
       // Give information to UI on how to display the amount.
-      // Fungible digital assets should be represented in integers, in
-      // the smallest unit (i.e. USD might be represented in mill,
-      // a thousandth of a dollar. In that case, `decimals` would be 3).
-      decimals: () => decimals,
+      getDisplayInfo: () => displayInfo,
     },
   );
 

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -112,6 +112,12 @@
  * @property {(allegedIssuer: ERef<Issuer>) => Promise<boolean>} isMyIssuer Should be used with
  * `issuer.getBrand` to ensure an issuer and brand match.
  * @property {() => string} getAllegedName
+ * @property {() => number} decimals
+ *  Give information to UI on how to display the amount.
+ *  Fungible digital assets should be represented in integers, in
+ *  the smallest unit (i.e. USD might be represented in mill,
+ *  a thousandth of a dollar. In that case, `decimals` would be 3).
+ *  Should not be used for nonfungible digital assets.
  */
 
 /**
@@ -188,7 +194,8 @@
 /**
  * @callback MakeIssuerKit
  * @param {string} allegedName
- * @param {AmountMathKind=} amountMathKind
+ * @param {AmountMathKind} [amountMathKind=MathKind.NAT]
+ * @param {number} [decimals=undefined]
  * @returns {IssuerKit}
  *
  * The allegedName becomes part of the brand in asset descriptions. The
@@ -199,6 +206,12 @@
  * The amountMathKind will be used to import a specific mathHelpers
  * from the mathHelpers library. For example, natMathHelpers, the
  * default, is used for basic fungible tokens.
+ *
+ *  `decimals` gives information to UI on how to display the amount.
+ *  Fungible digital assets should be represented in integers, in
+ *  the smallest unit (i.e. USD might be represented in mill,
+ *  a thousandth of a dollar. In that case, `decimals` would be 3).
+ *  `decimals` should not be used for nonfungible digital assets.
  *
  * @typedef {Object} IssuerKit
  * The return value of makeIssuerKit

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -98,6 +98,19 @@
  */
 
 /**
+ * @typedef {Object} DisplayInfo
+ * @property {number} decimalPlaces
+ *   Tells the display software how many decimal places to move the
+ *   decimal over to the left, or in other words, which position corresponds to whole
+ *   numbers. We require fungible digital assets to be represented in
+ *   integers, in the smallest unit (i.e. USD might be represented in mill,
+ *   a thousandth of a dollar. In that case, `decimalPlaces` would be 3.)
+ *   For non-fungible digital assets, this should be left as undefined.
+ *   The decimalPlaces property should be used for *display purposes only*. Any
+ *   other use is an anti-pattern.
+ */
+
+/**
  * @typedef {Object} Brand
  * The brand identifies the kind of issuer, and has a function to get the
  * alleged name for the kind of asset described. The alleged name (such
@@ -112,12 +125,8 @@
  * @property {(allegedIssuer: ERef<Issuer>) => Promise<boolean>} isMyIssuer Should be used with
  * `issuer.getBrand` to ensure an issuer and brand match.
  * @property {() => string} getAllegedName
- * @property {() => number} decimals
+ * @property {() => DisplayInfo} getDisplayInfo
  *  Give information to UI on how to display the amount.
- *  Fungible digital assets should be represented in integers, in
- *  the smallest unit (i.e. USD might be represented in mill,
- *  a thousandth of a dollar. In that case, `decimals` would be 3).
- *  Should not be used for nonfungible digital assets.
  */
 
 /**
@@ -195,7 +204,7 @@
  * @callback MakeIssuerKit
  * @param {string} allegedName
  * @param {AmountMathKind} [amountMathKind=MathKind.NAT]
- * @param {number} [decimals]
+ * @param {DisplayInfo=} [displayInfo=undefined]
  * @returns {IssuerKit}
  *
  * The allegedName becomes part of the brand in asset descriptions. The
@@ -207,11 +216,7 @@
  * from the mathHelpers library. For example, natMathHelpers, the
  * default, is used for basic fungible tokens.
  *
- *  `decimals` gives information to UI on how to display the amount.
- *  Fungible digital assets should be represented in integers, in
- *  the smallest unit (i.e. USD might be represented in mill,
- *  a thousandth of a dollar. In that case, `decimals` would be 3).
- *  `decimals` should not be used for nonfungible digital assets.
+ *  `displayInfo` gives information to UI on how to display the amount.
  *
  * @typedef {Object} IssuerKit
  * The return value of makeIssuerKit

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -99,13 +99,14 @@
 
 /**
  * @typedef {Object} DisplayInfo
- * @property {number} decimalPlaces
+ * @property {number=} decimalPlaces
  *   Tells the display software how many decimal places to move the
  *   decimal over to the left, or in other words, which position corresponds to whole
  *   numbers. We require fungible digital assets to be represented in
  *   integers, in the smallest unit (i.e. USD might be represented in mill,
  *   a thousandth of a dollar. In that case, `decimalPlaces` would be 3.)
- *   For non-fungible digital assets, this should be left as undefined.
+ *   This property is optional, and for non-fungible digital assets,
+ *   should not be specified.
  *   The decimalPlaces property should be used for *display purposes only*. Any
  *   other use is an anti-pattern.
  */

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -195,7 +195,7 @@
  * @callback MakeIssuerKit
  * @param {string} allegedName
  * @param {AmountMathKind} [amountMathKind=MathKind.NAT]
- * @param {number} [decimals=undefined]
+ * @param {number} [decimals]
  * @returns {IssuerKit}
  *
  * The allegedName becomes part of the brand in asset descriptions. The

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -14,24 +14,33 @@ test('issuer.getBrand, brand.isMyIssuer', t => {
   );
   t.is(issuer.getAllegedName(), myBrand.getAllegedName());
   t.is(issuer.getAllegedName(), 'fungible');
-  t.is(brand.decimals(), undefined);
+  t.is(brand.getDisplayInfo(), undefined);
 });
 
-test('brand decimals', t => {
-  const { brand } = makeIssuerKit('fungible', MathKind.NAT, 3);
-  t.is(brand.decimals(), 3);
+test('brand.getDisplayInfo()', t => {
+  const displayInfo = harden({ decimalPlaces: 3 });
+  const { brand } = makeIssuerKit('fungible', MathKind.NAT, displayInfo);
+  t.is(brand.getDisplayInfo(), displayInfo);
   const display = amount => {
     const { brand: myBrand, value } = amount;
-    const decimals = myBrand.decimals();
+    const { decimalPlaces } = myBrand.getDisplayInfo();
     const valueDisplay = value.toString();
     const length = valueDisplay.length;
     return [
-      valueDisplay.slice(0, length - decimals),
+      valueDisplay.slice(0, length - decimalPlaces),
       '.',
-      valueDisplay.slice(length - decimals),
+      valueDisplay.slice(length - decimalPlaces),
     ].join('');
   };
   t.is(display({ brand, value: 3000 }), '3.000');
+});
+
+test('bad display info', t => {
+  const displayInfo = harden({ somethingUnexpected: 3 });
+  t.throws(() => makeIssuerKit('fungible', MathKind.NAT, displayInfo), {
+    message:
+      'key "somethingUnexpected" was not one of the expected keys ["decimalPlaces"]',
+  });
 });
 
 test('amountMath from makeIssuerKit', async t => {

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -20,7 +20,7 @@ test('issuer.getBrand, brand.isMyIssuer', t => {
 test('brand.getDisplayInfo()', t => {
   const displayInfo = harden({ decimalPlaces: 3 });
   const { brand } = makeIssuerKit('fungible', MathKind.NAT, displayInfo);
-  t.is(brand.getDisplayInfo(), displayInfo);
+  t.deepEqual(brand.getDisplayInfo(), displayInfo);
   const display = amount => {
     const { brand: myBrand, value } = amount;
     const { decimalPlaces } = myBrand.getDisplayInfo();
@@ -37,10 +37,17 @@ test('brand.getDisplayInfo()', t => {
 
 test('bad display info', t => {
   const displayInfo = harden({ somethingUnexpected: 3 });
+  // @ts-ignore
   t.throws(() => makeIssuerKit('fungible', MathKind.NAT, displayInfo), {
     message:
       'key "somethingUnexpected" was not one of the expected keys ["decimalPlaces"]',
   });
+});
+
+test('empty display info', t => {
+  const displayInfo = harden({});
+  const { brand } = makeIssuerKit('fungible', MathKind.NAT, displayInfo);
+  t.deepEqual(brand.getDisplayInfo(), displayInfo);
 });
 
 test('amountMath from makeIssuerKit', async t => {

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -213,7 +213,8 @@ test(`zcf.saveIssuer - bad issuer`, async t => {
   await t.throwsAsync(() => zcf.saveIssuer(moolaKit.brand, 'A'), {
     // TODO: improve error message
     // https://github.com/Agoric/agoric-sdk/issues/1701
-    message: 'target has no method "getBrand", has [getAllegedName,isMyIssuer]',
+    message:
+      'target has no method "getBrand", has [getAllegedName,getDisplayInfo,isMyIssuer]',
   });
 });
 


### PR DESCRIPTION
This PR adds a `displayInfo` object to an ERTP issuerKit, including a `decimalPlaces` property in the same way that Ethereum uses their `decimals` property. We intend for fungible digital assets to be represented as integers in the smallest unit. (In finance, this is often [mills](https://en.wikipedia.org/wiki/Mill_(currency)).) However, we want to display in a more user-friendly way. `decimalPlaces` is meant **only for display**, and informs the UI how many decimal places to move the decimal over to the left. For instance, for mills, one thousandth of a dollar, decimals would be 3.

The downside is that this hardcodes a certain interpretation. For instance, it would hard-code a dollar as the standard representation instead of millions or thousands of dollars. However, the UI is free to ignore `decimals`. 

One upside is that compared to something like a custom `toString`, decimals is very safe. An attacker can't do much with the ability to choose an integer that will later be returned.

Closes #119 