### PR TITLE
feat: allow network-config.gci to specify a URL to genesis

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/add-chain.js
+++ b/packages/cosmic-swingset/lib/ag-solo/add-chain.js
@@ -34,8 +34,8 @@ async function addChain(basedir, chainConfig, force = false) {
     const r = await fetch(url.href);
     netconf = await r.json();
   }
-  const gciUrl = new URL(netconf.gci, 'hex://');
-  if (gciUrl.protocol !== 'hex:') {
+  const gciUrl = new URL(netconf.gci, 'unspecified://');
+  if (gciUrl.protocol !== 'unspecified:') {
     const g = await fetch(gciUrl.href);
     const resp = await g.json();
     let genesis = resp;


### PR DESCRIPTION
This is crucial for the Chainlink integration.  The demo runs in a bunch of Docker containers with a local chain (and no web service to provide network-config).

It allows a network-config to be a local file that specifies an URL from which to fetch the actual genesis.
