### PR TITLE
feat(import-bundle): Support Endo zip hex bundle format

### DIFF
--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/ertp",
   "version": "0.8.0",
   "description": "Electronic Rights Transfer Protocol (ERTP). A smart contract framework for exchanging electronic rights",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "src/index.js",
   "engines": {
     "node": ">=11.0"

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -32,8 +32,8 @@
   },
   "dependencies": {
     "@agoric/assert": "^0.1.0",
-    "@agoric/base64": "^0.0.0+1-dev",
     "@agoric/babel-parser": "^7.6.4",
+    "@agoric/base64": "^0.0.0+1-dev",
     "@agoric/bundle-source": "^1.1.10",
     "@agoric/captp": "^1.6.0",
     "@agoric/eventual-send": "^0.12.0",

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/swingset-vat",
   "version": "0.10.0",
   "description": "Vat/Container Launcher",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "src/main.js",
   "module": "src/index.js",
   "engines": {

--- a/packages/acorn-eventual-send/package.json
+++ b/packages/acorn-eventual-send/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/acorn-eventual-send",
   "version": "2.0.10",
   "description": "Eventual send (wavy dot) parser plugin for Acorn",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "index.js",
   "scripts": {
     "build": "exit 0",

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -2,6 +2,9 @@
   "name": "agoric",
   "version": "0.10.1",
   "description": "Manage the Agoric Javascript smart contract platform",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "lib/main.js",
   "bin": "bin/agoric",
   "files": [

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/assert",
   "version": "0.1.0",
   "description": "Assert expression support that protects sensitive data",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "src/assert.js",
   "engines": {
     "node": ">=11.0"

--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/base64",
   "version": "0.0.0+1-dev",
   "description": "Transcodes base64",
+  "parsers": {
+    "js": "mjs"
+  },
   "author": "Agoric",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/bundle-source",
   "version": "1.1.10",
   "description": "Create source bundles from ES Modules",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "src/index.js",
   "scripts": {
     "build": "exit 0",
@@ -19,7 +22,9 @@
   },
   "dependencies": {
     "@agoric/acorn-eventual-send": "^2.0.10",
+    "@agoric/base64": "0.0.0+1-dev",
     "@agoric/babel-parser": "^7.6.4",
+    "@agoric/compartment-mapper": "^0.2.3",
     "@agoric/transform-eventual-send": "^1.3.5",
     "@babel/generator": "^7.6.4",
     "@babel/traverse": "^7.8.3",

--- a/packages/bundle-source/src/index.js
+++ b/packages/bundle-source/src/index.js
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import { rollup as rollup0 } from 'rollup';
 import path from 'path';
 import resolve0 from '@rollup/plugin-node-resolve';
@@ -6,16 +7,21 @@ import * as babelParser from '@agoric/babel-parser';
 import babelGenerate from '@babel/generator';
 import babelTraverse from '@babel/traverse';
 import { makeTransform } from '@agoric/transform-eventual-send';
+import { makeArchive } from '@agoric/compartment-mapper';
+import { encodeBase64 } from '@agoric/base64';
 
 import { SourceMapConsumer } from 'source-map';
 
 const DEFAULT_MODULE_FORMAT = 'nestedEvaluate';
 const DEFAULT_FILE_PREFIX = '/bundled-source';
-const SUPPORTED_FORMATS = ['getExport', 'nestedEvaluate'];
+const SUPPORTED_FORMATS = ['getExport', 'nestedEvaluate', 'endoZipBase64'];
 
 const IMPORT_RE = new RegExp('\\b(import)(\\s*(?:\\(|/[/*]))', 'sg');
 const HTML_COMMENT_START_RE = new RegExp(`${'<'}!--`, 'g');
 const HTML_COMMENT_END_RE = new RegExp(`--${'>'}`, 'g');
+
+const read = async location => fs.promises.readFile(new URL(location).pathname);
+const base = new URL(`file://${__filename}`).toString();
 
 export function tildotPlugin() {
   const transformer = makeTransform(babelParser, babelGenerate);
@@ -37,6 +43,18 @@ export default async function bundleSource(
   if (!SUPPORTED_FORMATS.includes(moduleFormat)) {
     throw Error(`moduleFormat ${moduleFormat} is not implemented`);
   }
+  if (moduleFormat === 'endoZipBase64') {
+    // TODO endoZipBase64 format does not yet support the tildot transform, as
+    // Compartment Mapper does not yet reveal a pre-archive transform facility.
+    // Such a facility might be better served by a transform specified in
+    // individual package.jsons and driven by the compartment mapper.
+    const entry = new URL(startFilename, base).toString();
+    const bytes = await makeArchive(read, entry);
+    const source = encodeBase64(bytes);
+    let sourceMap;
+    return { source, sourceMap, moduleFormat };
+  }
+
   const {
     commonjsPlugin = commonjs0,
     rollup = rollup0,

--- a/packages/bundle-source/src/index.js
+++ b/packages/bundle-source/src/index.js
@@ -21,7 +21,6 @@ const HTML_COMMENT_START_RE = new RegExp(`${'<'}!--`, 'g');
 const HTML_COMMENT_END_RE = new RegExp(`--${'>'}`, 'g');
 
 const read = async location => fs.promises.readFile(new URL(location).pathname);
-const base = new URL(`file://${__filename}`).toString();
 
 export function tildotPlugin() {
   const transformer = makeTransform(babelParser, babelGenerate);
@@ -48,6 +47,7 @@ export default async function bundleSource(
     // Compartment Mapper does not yet reveal a pre-archive transform facility.
     // Such a facility might be better served by a transform specified in
     // individual package.jsons and driven by the compartment mapper.
+    const base = new URL(`file://${process.cwd()}`).toString();
     const entry = new URL(startFilename, base).toString();
     const bytes = await makeArchive(read, entry);
     const endoZipBase64 = encodeBase64(bytes);

--- a/packages/bundle-source/src/index.js
+++ b/packages/bundle-source/src/index.js
@@ -50,9 +50,8 @@ export default async function bundleSource(
     // individual package.jsons and driven by the compartment mapper.
     const entry = new URL(startFilename, base).toString();
     const bytes = await makeArchive(read, entry);
-    const source = encodeBase64(bytes);
-    let sourceMap;
-    return { source, sourceMap, moduleFormat };
+    const endoZipBase64 = encodeBase64(bytes);
+    return { endoZipBase64, moduleFormat };
   }
 
   const {

--- a/packages/bundle-source/test/test-sanity.js
+++ b/packages/bundle-source/test/test-sanity.js
@@ -1,6 +1,8 @@
 /* global Compartment */
 
 import '@agoric/install-ses';
+import { decodeBase64 } from '@agoric/base64';
+import { parseArchive } from '@agoric/compartment-mapper';
 import test from 'ava';
 import bundleSource from '..';
 
@@ -8,6 +10,21 @@ function evaluate(src, endowments) {
   const c = new Compartment(endowments, {}, {});
   return c.evaluate(src);
 }
+
+test('endoZipBase64', async t => {
+  const { source } = await bundleSource(
+    `${__dirname}/../demo/dir1/encourage.js`,
+    'endoZipBase64',
+  );
+
+  const bytes = decodeBase64(source);
+  const archive = await parseArchive(bytes);
+  const { namespace } = await archive.import('.');
+  const { message, encourage } = namespace;
+
+  t.is(message, `You're great!`);
+  t.is(encourage('you'), `Hey you!  You're great!`);
+});
 
 test('nestedEvaluate', async t => {
   const {

--- a/packages/bundle-source/test/test-sanity.js
+++ b/packages/bundle-source/test/test-sanity.js
@@ -12,14 +12,14 @@ function evaluate(src, endowments) {
 }
 
 test('endoZipBase64', async t => {
-  const { source } = await bundleSource(
+  const { endoZipBase64 } = await bundleSource(
     `${__dirname}/../demo/dir1/encourage.js`,
     'endoZipBase64',
   );
 
-  const bytes = decodeBase64(source);
+  const bytes = decodeBase64(endoZipBase64);
   const archive = await parseArchive(bytes);
-  const { namespace } = await archive.import('.');
+  const { namespace } = await archive['import']('.');
   const { message, encourage } = namespace;
 
   t.is(message, `You're great!`);

--- a/packages/bundle-source/test/test-sanity.js
+++ b/packages/bundle-source/test/test-sanity.js
@@ -19,6 +19,8 @@ test('endoZipBase64', async t => {
 
   const bytes = decodeBase64(endoZipBase64);
   const archive = await parseArchive(bytes);
+  // Call import by property to bypass SES censoring for dynamic import.
+  // eslint-disable-next-line dot-notation
   const { namespace } = await archive['import']('.');
   const { message, encourage } = namespace;
 

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/captp",
   "version": "1.6.0",
   "description": "Capability Transfer Protocol for distributed objects",
+  "parsers": {
+    "js": "mjs"
+  },
   "keywords": [
     "agoric",
     "captp",

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/cosmic-swingset",
   "version": "0.23.0",
   "description": "Agoric's Cosmos blockchain integration",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "lib/ag-solo/main.js",
   "repository": "https://github.com/Agoric/agoric-sdk",
   "scripts": {

--- a/packages/dapp-svelte-wallet/package.json
+++ b/packages/dapp-svelte-wallet/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@agoric/dapp-svelte-wallet",
   "version": "0.5.0",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "index.js",
   "license": "Apache-2.0",
   "author": "Agoric",

--- a/packages/dapp-svelte-wallet/ui/package.json
+++ b/packages/dapp-svelte-wallet/ui/package.json
@@ -8,7 +8,7 @@
     "dev": "rollup -c -w",
     "start": "sirv public",
     "lint-check": "yarn lint",
-    "lint-fix": "yarn lint --fix",
+    "lint-fix": "exit 0",
     "lint": "exit 0",
     "test": "exit 0"
   },

--- a/packages/deployment/package.json
+++ b/packages/deployment/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/deployment",
   "version": "1.23.0",
   "description": "Set up Agoric public chain nodes",
+  "parsers": {
+    "js": "mjs"
+  },
   "private": true,
   "main": "main.js",
   "scripts": {

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/eventual-send",
   "version": "0.12.0",
   "description": "Extend a Promise class to implement the eventual-send API",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "src/no-shim.js",
   "types": "src/index.d.ts",
   "scripts": {

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "load modules created by @agoric/bundle-source",
   "main": "src/index.js",
+  "parsers": {
+    "js": "mjs"
+  },
   "module": "src/index.js",
   "engines": {
     "node": ">=10.15.1"
@@ -13,6 +16,11 @@
     "build": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint-check": "eslint '**/*.js'"
+  },
+  "dependencies": {
+    "@agoric/base64": "^0.0.0+1-dev",
+    "@agoric/assert": "^0.1.0",
+    "@agoric/compartment-mapper": "0.2.3"
   },
   "devDependencies": {
     "@agoric/bundle-source": "^1.1.10",

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@agoric/base64": "^0.0.0+1-dev",
     "@agoric/assert": "^0.1.0",
-    "@agoric/compartment-mapper": "0.2.3"
+    "@agoric/compartment-mapper": "^0.2.3"
   },
   "devDependencies": {
     "@agoric/bundle-source": "^1.1.10",

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -2,10 +2,10 @@
   "name": "@agoric/import-bundle",
   "version": "0.1.0",
   "description": "load modules created by @agoric/bundle-source",
-  "main": "src/index.js",
   "parsers": {
     "js": "mjs"
   },
+  "main": "src/index.js",
   "module": "src/index.js",
   "engines": {
     "node": ">=10.15.1"

--- a/packages/import-bundle/src/index.js
+++ b/packages/import-bundle/src/index.js
@@ -1,4 +1,6 @@
 /* global harden Compartment */
+import { parseArchive } from '@agoric/compartment-mapper';
+import { decodeBase64 } from '@agoric/base64';
 import { wrapInescapableCompartment } from './compartment-wrapper';
 
 // importBundle takes the output of bundle-source, and returns a namespace
@@ -8,13 +10,49 @@ export async function importBundle(bundle, options = {}) {
   const {
     filePrefix,
     endowments: optEndowments = {},
+    globalLexicals = {},
+    // transforms are indeed __shimTransforms__, intended to apply to both
+    // evaluated programs and modules shimmed to programs.
+    transforms = [],
     inescapableTransforms = [],
     inescapableGlobalLexicals = {},
-    ...compartmentOptions
   } = options;
-  const endowments = { ...optEndowments };
-  const { source, sourceMap, moduleFormat } = bundle;
+  const endowments = {
+    TextEncoder,
+    TextDecoder,
+    ...optEndowments,
+  };
+
+  let CompartmentToUse = Compartment;
+  if (
+    inescapableTransforms.length ||
+    Object.keys(inescapableGlobalLexicals).length
+  ) {
+    CompartmentToUse = wrapInescapableCompartment(
+      Compartment,
+      inescapableTransforms,
+      inescapableGlobalLexicals,
+    );
+  }
+
+  const { moduleFormat } = bundle;
+  if (moduleFormat === 'endoZipBase64') {
+    const { endoZipBase64 } = bundle;
+    const bytes = decodeBase64(endoZipBase64);
+    const archive = await parseArchive(bytes);
+    // Call import by property to bypass SES censoring for dynamic import.
+    // eslint-disable-next-line dot-notation
+    const { namespace } = await archive['import']({
+      globals: endowments,
+      __shimTransforms__: transforms,
+      Compartment: CompartmentToUse,
+    });
+    // namespace.default has the default export
+    return namespace;
+  }
+
   let c;
+  const { source, sourceMap } = bundle;
   if (moduleFormat === 'getExport') {
     // The 'getExport' format is a string which defines a wrapper function
     // named `getExport()`. This function provides a `module` to the
@@ -40,18 +78,7 @@ export async function importBundle(bundle, options = {}) {
     throw Error(`unrecognized moduleFormat '${moduleFormat}'`);
   }
 
-  let CompartmentToUse = Compartment;
-  if (
-    inescapableTransforms.length ||
-    Object.keys(inescapableGlobalLexicals).length
-  ) {
-    CompartmentToUse = wrapInescapableCompartment(
-      Compartment,
-      inescapableTransforms,
-      inescapableGlobalLexicals,
-    );
-  }
-  c = new CompartmentToUse(endowments, {}, compartmentOptions);
+  c = new CompartmentToUse(endowments, {}, { globalLexicals, transforms });
   harden(c.globalThis);
   const actualSource = `(${source})\n${sourceMap || ''}`;
   const namespace = c.evaluate(actualSource)(filePrefix);

--- a/packages/import-bundle/test/bundle1.js
+++ b/packages/import-bundle/test/bundle1.js
@@ -34,11 +34,6 @@ export function f6ReadGlobal() {
   return globalThis.sneakyChannel;
 }
 
-export function f7WriteGlobal(a) {
-  // this will throw TypeError
-  globalThis.sneakyChannel = a;
-}
-
-export function f8ReadGlobalSubmodule() {
+export function f7ReadGlobalSubmodule() {
   return bundle2ReadGlobal();
 }

--- a/packages/import-manager/package.json
+++ b/packages/import-manager/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/import-manager",
   "version": "0.1.3",
   "description": "Share code across vat boundaries",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "src/importManager.js",
   "engines": {
     "node": ">=11.0"

--- a/packages/install-metering-and-ses/package.json
+++ b/packages/install-metering-and-ses/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/install-metering-and-ses",
   "version": "0.1.5",
   "description": "tame metering and install SES at import time",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "install-metering-and-ses.js",
   "scripts": {
     "build": "exit 0",

--- a/packages/install-ses/install-ses.js
+++ b/packages/install-ses/install-ses.js
@@ -1,4 +1,4 @@
-/* global lockdown */
+/* global lockdown, harden */
 
 // 'lockdown' appears on the global as a side-effect of importing 'ses'
 import 'ses';
@@ -18,3 +18,8 @@ lockdown({ errorTaming: 'unsafe' });
 // Even on non-v8, we tame the start compartment's Error constructor so
 // this assignment is not rejected, even if it does nothing.
 Error.stackTraceLimit = Infinity;
+
+harden(TextEncoder.prototype);
+harden(TextEncoder);
+harden(TextDecoder.prototype);
+harden(TextDecoder);

--- a/packages/install-ses/install-ses.js
+++ b/packages/install-ses/install-ses.js
@@ -19,7 +19,5 @@ lockdown({ errorTaming: 'unsafe' });
 // this assignment is not rejected, even if it does nothing.
 Error.stackTraceLimit = Infinity;
 
-harden(TextEncoder.prototype);
 harden(TextEncoder);
-harden(TextDecoder.prototype);
 harden(TextDecoder);

--- a/packages/install-ses/package.json
+++ b/packages/install-ses/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/install-ses",
   "version": "0.4.0",
   "description": "install SES at import time",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "install-ses.js",
   "scripts": {
     "build": "exit 0",

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/marshal",
   "version": "0.2.7",
   "description": "marshal",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "index.js",
   "directories": {
     "test": "test"

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/notifier",
   "version": "0.2.3",
   "description": "Notifier allows services to update clients about state changes using a stream of promises",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "src/index.js",
   "engines": {
     "node": ">=11.0"

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/promise-kit",
   "version": "0.1.7",
   "description": "Helper for making promises",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "src/promiseKit.js",
   "engines": {
     "node": ">=11.0"

--- a/packages/registrar/package.json
+++ b/packages/registrar/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/registrar",
   "version": "0.1.7",
   "description": "Register objects for public use",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "src/registrar.js",
   "engines": {
     "node": ">=11.0"

--- a/packages/same-structure/package.json
+++ b/packages/same-structure/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/same-structure",
   "version": "0.0.12",
   "description": "Deep equals",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "index.js",
   "engines": {
     "node": ">=11.0"

--- a/packages/sharing-service/package.json
+++ b/packages/sharing-service/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/sharing-service",
   "version": "0.0.12",
   "description": "Share objects with another party but not publicly",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "src/sharing.js",
   "engines": {
     "node": ">=11.0"

--- a/packages/sparse-ints/package.json
+++ b/packages/sparse-ints/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/sparse-ints",
   "version": "0.0.11",
   "description": "Share code across vat boundaries",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "src/sparseInts.js",
   "engines": {
     "node": ">=11.0"

--- a/packages/spawner/package.json
+++ b/packages/spawner/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/spawner",
   "version": "0.3.0",
   "description": "Wrapper for JavaScript map",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "src/contractHost.js",
   "engines": {
     "node": ">=11.0"

--- a/packages/stat-logger/package.json
+++ b/packages/stat-logger/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/stat-logger",
   "version": "0.3.4",
   "description": "Simple library for logging and graphing performance statistics",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "src/index.js",
   "repository": "https://github.com/Agoric/agoric-sdk",
   "author": "Agoric",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/store",
   "version": "0.3.1",
   "description": "Wrapper for JavaScript map",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "src/index.js",
   "engines": {
     "node": ">=11.0"

--- a/packages/swing-store-lmdb/package.json
+++ b/packages/swing-store-lmdb/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/swing-store-lmdb",
   "version": "0.3.7",
   "description": "Persistent storage for SwingSet, based on an LMDB key-value database",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "lmdbSwingStore.js",
   "repository": "https://github.com/Agoric/agoric-sdk",
   "author": "Agoric",

--- a/packages/swing-store-simple/package.json
+++ b/packages/swing-store-simple/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/swing-store-simple",
   "version": "0.2.7",
   "description": "Persistent storage for SwingSet, based on a Map, optionally backed by a simple JSON file",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "simpleSwingStore.js",
   "repository": "https://github.com/Agoric/agoric-sdk",
   "author": "Agoric",

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -3,6 +3,9 @@
   "version": "0.9.0",
   "private": true,
   "description": "Application to launch SwingSet instances for development and testing",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "src/main.js",
   "repository": "https://github.com/Agoric/agoric-sdk",
   "author": "Agoric",

--- a/packages/tame-metering/package.json
+++ b/packages/tame-metering/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/tame-metering",
   "version": "1.2.7",
   "description": "tame-metering",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "src/index.js",
   "scripts": {
     "test": "ava",

--- a/packages/transform-eventual-send/package.json
+++ b/packages/transform-eventual-send/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/transform-eventual-send",
   "version": "1.3.5",
   "description": "transform-eventual-send",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "src/index.js",
   "scripts": {
     "test": "ava",

--- a/packages/transform-metering/package.json
+++ b/packages/transform-metering/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/transform-metering",
   "version": "1.3.4",
   "description": "transform-metering",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "src/index.js",
   "scripts": {
     "test": "ava",

--- a/packages/xs-vat-worker/package.json
+++ b/packages/xs-vat-worker/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/xs-vat-worker",
   "version": "0.3.0",
   "description": "swingset-vat worker for XS js runtime",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "src/locate.js",
   "module": "src/locate.js",
   "scripts": {

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -56,7 +56,8 @@
     "@agoric/swingset-vat": "^0.10.0",
     "ava": "^3.12.1",
     "esm": "^3.2.25",
-    "nyc": "^15.1.0"
+    "nyc": "^15.1.0",
+    "ses": "^0.11.0"
   },
   "files": [
     "src/",
@@ -111,6 +112,15 @@
       "no-unused-expressions": "off",
       "no-loop-func": "off",
       "no-inner-declarations": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
       "import/prefer-default-export": "off",
       "jsdoc/no-undefined-types": "off",
       "jsdoc/require-jsdoc": "off",

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -2,6 +2,9 @@
   "name": "@agoric/zoe",
   "version": "0.10.0",
   "description": "Zoe: the Smart Contract Framework for Offer Enforcement",
+  "parsers": {
+    "js": "mjs"
+  },
   "main": "src/zoeService/zoe.js",
   "engines": {
     "node": ">=11.0"

--- a/packages/zoe/scripts/build-zcfBundle.js
+++ b/packages/zoe/scripts/build-zcfBundle.js
@@ -1,3 +1,4 @@
+import 'ses';
 import fs from 'fs';
 import process from 'process';
 import bundleSource from '@agoric/bundle-source';

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,7 +12,7 @@
   resolved "https://registry.yarnpkg.com/@agoric/babel-standalone/-/babel-standalone-7.9.5.tgz#1ca0c17844924199d31e49d6b67e8b2a629b8599"
   integrity sha512-1Aa23oPuRi4kywUyZODo8zey9Gq2NpD2xUnNvgJLoT8orMQRlVOtvbG3JeHq5sjJERlF/q6csg4/P8t8/5IABA==
 
-"@agoric/compartment-mapper@0.2.3":
+"@agoric/compartment-mapper@^0.2.3":
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@agoric/compartment-mapper/-/compartment-mapper-0.2.3.tgz#f0f9d048528a98d99329c593ff813952c9e7de29"
   integrity sha512-2xTFCMLhbT1aiClD3GpEDcPilczM5je2sSyAZPqrguciIXgdQVb/qF6uLFj/L9gVL2LS2yrPV4ZC8B+xRn7YpQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,13 @@
   resolved "https://registry.yarnpkg.com/@agoric/babel-standalone/-/babel-standalone-7.9.5.tgz#1ca0c17844924199d31e49d6b67e8b2a629b8599"
   integrity sha512-1Aa23oPuRi4kywUyZODo8zey9Gq2NpD2xUnNvgJLoT8orMQRlVOtvbG3JeHq5sjJERlF/q6csg4/P8t8/5IABA==
 
+"@agoric/compartment-mapper@0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@agoric/compartment-mapper/-/compartment-mapper-0.2.3.tgz#f0f9d048528a98d99329c593ff813952c9e7de29"
+  integrity sha512-2xTFCMLhbT1aiClD3GpEDcPilczM5je2sSyAZPqrguciIXgdQVb/qF6uLFj/L9gVL2LS2yrPV4ZC8B+xRn7YpQ==
+  dependencies:
+    ses "^0.11.0"
+
 "@agoric/make-hardener@^0.1.0":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@agoric/make-hardener/-/make-hardener-0.1.1.tgz#9b887da47aeec6637d9db4f0a92a4e740b8262bb"


### PR DESCRIPTION
This change introduces `endoZipHex` as a supported bundle format for `importBundle`. A corresponding change to `bundleSource` is forthcoming. I may quickly amend this to a base64 format, given that we have a library for that in SwingSet that we can factor into a shared dependency package.