### PR TITLE
fix: properly generate a quote for the "player piano"

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -18,14 +18,17 @@ git push -u origin release-$now
 scripts/have-news HEAD^ > have-news.md
 ```
 
-Then, create a release PR, pasting `have-news.md` into the body.
-
-Then, once tests pass, you can run the following:
+Create a release PR, pasting `have-news.md` into the body.  Then build the SDK:
 
 ```sh
 # Build all package generated files.
 yarn install
 yarn build
+```
+
+Once tests pass, you can publish to NPM with the following:
+
+```sh
 # Publish to NPM. NOTE: You may have to repeat this several times if there are failures.
 yarn lerna publish from-package
 ```

--- a/packages/agoric-cli/lib/start.js
+++ b/packages/agoric-cli/lib/start.js
@@ -34,7 +34,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
     cargs,
     { stdio = 'inherit', env = pspawnEnv, ...rest } = {},
   ) => {
-    log.debug(chalk.blueBright(cmd, ...cargs));
+    log(chalk.blueBright(cmd, ...cargs));
     const cp = spawn(cmd, cargs, { stdio, env, ...rest });
     const pr = new Promise((resolve, _reject) => {
       cp.on('exit', resolve);
@@ -56,7 +56,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
           'run',
           `--volume=${process.cwd()}:/usr/src/dapp`,
           `--rm`,
-          `-it`,
+          // `-it`,
           `--entrypoint=ag-cosmos-helper`,
           'agoric/agoric-sdk',
           `--home=/usr/src/dapp/_agstate/keys`,
@@ -211,7 +211,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
             `--volume=${process.cwd()}:/usr/src/dapp`,
             `--rm`,
             ...dockerArgs,
-            `-it`,
+            // `-it`,
             SDK_IMAGE,
             ...args,
             `--home=/usr/src/dapp/${agServer}`,
@@ -298,7 +298,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
       if (exitStatus) {
         return exitStatus;
       }
-      exitStatus = await fs.writeFile(`${genesisFile}.stamp`, Date.now());
+      exitStatus = await fs.writeFile(`${genesisFile}.stamp`, `${Date.now()}`);
       if (exitStatus) {
         return exitStatus;
       }
@@ -383,7 +383,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
             `--volume=${process.env.HOME}/.agoric:/root/.agoric`,
             `-eAG_SOLO_BASEDIR=/usr/src/dapp/${agServer}`,
             `--rm`,
-            `-it`,
+            // `-it`,
             `--entrypoint=/usr/src/app/bin/ag-solo`,
             ...dockerArgs,
             SOLO_IMAGE,

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -21,7 +21,7 @@ export { mustPassByRemote as mustPassByPresence };
  */
 const remotableToInterface = new WeakMap();
 
-/** @type {GetInterfaceOf} */
+/** @type {MarshalGetInterfaceOf} */
 export function getInterfaceOf(maybeRemotable) {
   return remotableToInterface.get(maybeRemotable);
 }

--- a/packages/marshal/src/types.js
+++ b/packages/marshal/src/types.js
@@ -139,7 +139,7 @@
  */
 
 /**
- * @callback GetInterfaceOf
+ * @callback MarshalGetInterfaceOf
  * Simple semantics, just tell what interface (or undefined) a remotable has.
  *
  * @param {*} maybeRemotable the value to check

--- a/packages/zoe/src/contracts/exported.js
+++ b/packages/zoe/src/contracts/exported.js
@@ -185,7 +185,7 @@
 /**
  * @typedef {Object} OracleHandler
  * @property {(query: any, fee: Amount) => Promise<{ reply:
- * any, requiredFee: Amount }>} onQuery callback to reply to a query
+ * any, requiredFee: Amount | undefined }>} onQuery callback to reply to a query
  * @property {(query: any, reason: any) => void} onError notice an error
  * @property {(query: any, reply: any, requiredFee: Amount) => void} onReply
  * notice a successful reply

--- a/packages/zoe/src/contracts/exported.js
+++ b/packages/zoe/src/contracts/exported.js
@@ -187,7 +187,7 @@
  * @property {(query: any, fee: Amount) => Promise<{ reply:
  * any, requiredFee: Amount | undefined }>} onQuery callback to reply to a query
  * @property {(query: any, reason: any) => void} onError notice an error
- * @property {(query: any, reply: any, requiredFee: Amount) => void} onReply
+ * @property {(query: any, reply: any, requiredFee: Amount | undefined) => void} onReply
  * notice a successful reply
  */
 

--- a/packages/zoe/tools/fakePriceAuthority.js
+++ b/packages/zoe/tools/fakePriceAuthority.js
@@ -111,7 +111,6 @@ export async function makeFakePriceAuthority(options) {
       quotePayment: E(quoteMint).mintPayment(quoteAmount),
       quoteAmount,
     });
-    updater.updateState(quote);
     return quote;
   }
 
@@ -141,6 +140,13 @@ export async function makeFakePriceAuthority(options) {
         } else {
           currentPriceIndex += 1;
         }
+        const [tradeValueIn] = currentTrade();
+        const rawQuote = priceInQuote(
+          mathIn.make(tradeValueIn),
+          mathOut.getBrand(),
+          t,
+        );
+        updater.updateState(rawQuote);
         for (const req of comparisonQueue) {
           // eslint-disable-next-line no-await-in-loop
           const priceQuote = priceInQuote(req.amountIn, req.brandOut, t);


### PR DESCRIPTION
We're still working on the refactoring of the price aggregator, but this little tweak improves the sim and actual chain experience for fake price authorities (like `moola -> Testnet.$USD` and vice versa).

Before, the fakePriceAuthority quote notifier only produced quotes if and when there were queries.  Now, it notifies of quotes when (and only when) the data is pushed.

This is also a grab bag of other changes:

- allow agoric start to run in the background without `unable to setup input stream: unable to set IO streams as raw terminal: interrupted system call` (don't supply `-it` to Docker)
- doc fixes
- typing fixes
