### PR TITLE
fix: more support for hacktheorb

### DIFF
--- a/packages/agoric-cli/lib/chain-config.js
+++ b/packages/agoric-cli/lib/chain-config.js
@@ -28,6 +28,7 @@ export function finishCosmosConfig({
   config.p2p.laddr = `tcp://0.0.0.0:${rpcPort - 1}`;
   config.p2p.persistent_peers = persistentPeers;
   config.rpc.laddr = `tcp://0.0.0.0:${rpcPort}`;
+  config.rpc.max_body_bytes = 15 * 10 ** 6;
 
   // Needed for IBC.
   config.tx_index.index_all_keys = true;

--- a/packages/agoric-cli/lib/start.js
+++ b/packages/agoric-cli/lib/start.js
@@ -349,6 +349,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
 
   async function startLocalSolo(profileName, startArgs, popts) {
     const portNum = startArgs[0] === undefined ? PORT : startArgs[0];
+    const provisionPowers = startArgs[1] === undefined ? [] : [startArgs[1]];
     if (`${portNum}` !== `${Number(portNum)}`) {
       log.error(`Argument to local-solo must be a port number`);
       return 1;
@@ -424,7 +425,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
       if (!opts.sdk) {
         initArgs.push(`--webhost=0.0.0.0`);
       }
-      const exitStatus = await soloSpawn(['init', ...initArgs]);
+      const exitStatus = await soloSpawn(['init', agServer, ...initArgs]);
       if (exitStatus) {
         return exitStatus;
       }
@@ -476,6 +477,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
               `--node=tcp://${rpcAddr}`,
               `local-solo-${portNum}`,
               soloAddr,
+              ...provisionPowers,
             ],
             true,
           );

--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -29,12 +29,12 @@ comma := ,
 build_tags_comma_sep := $(subst $(whitespace),$(comma),$(build_tags))
 
 # process linker flags
-
 ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=$(NAME) \
-		  -X github.com/cosmos/cosmos-sdk/version.AppName=ag-chain-cosmos \
-		  -X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
-		  -X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
-		  -X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep)"
+		-X github.com/cosmos/cosmos-sdk/version.AppName=ag-cosmos-server \
+		-X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
+		-X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
+		-X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep)"
+
 gcflags =
 
 ifneq ($(GO_DEBUG),)
@@ -42,7 +42,11 @@ ldflags += -compressdwarf=false
 gcflags += -N -l
 endif
 
+
+ldflags_helper = $(ldflags) \
+		  -X github.com/cosmos/cosmos-sdk/version.AppName=ag-cosmos-helper
 BUILD_FLAGS := -tags "$(build_tags)" -gcflags '$(gcflags)' -ldflags '$(ldflags)'
+BUILD_FLAGS_HELPER :=  -tags "$(build_tags)" -gcflags '$(gcflags)' -ldflags '$(ldflags_helper)'
 
 include Makefile.ledger
 all: build-cosmos install
@@ -145,7 +149,7 @@ docker-install: docker-pull
 	install -m 755 docker/* /usr/local/bin/
 
 compile-go: go.sum
-	go install -v $(MOD_READONLY) $(BUILD_FLAGS) ./cmd/ag-cosmos-helper
+	go install -v $(MOD_READONLY) $(BUILD_FLAGS_HELPER) ./cmd/ag-cosmos-helper
 	go build -v $(MOD_READONLY) $(BUILD_FLAGS) -buildmode=c-shared -o lib/libagcosmosdaemon.so lib/agcosmosdaemon.go
 	test "`uname -s 2>/dev/null`" != Darwin || install_name_tool -id `pwd`/lib/libagcosmosdaemon.so lib/libagcosmosdaemon.so
 

--- a/packages/deployment/Makefile
+++ b/packages/deployment/Makefile
@@ -3,7 +3,7 @@ REPOSITORY_SDK = agoric/agoric-sdk
 SS := ../cosmic-swingset/
 TAG := $(shell test ! -f ../../package.json || sed -ne 's/.*"version": "\(.*\)".*/\1/p' ../../package.json)
 
-# Don't push alpha tags as ":latest".
+# Don't push alpha tags as ":$(TAG)".
 DONT_PUSH_LATEST := $(if $(findstring -,$(TAG)),:,)
 
 docker-show-fat:
@@ -14,22 +14,22 @@ docker-build: docker-build-base docker-build-sdk docker-build-solo \
 	docker-build-setup docker-build-deployment
 
 docker-build-sdk:
-	docker build -t $(REPOSITORY_SDK):latest --file=Dockerfile.sdk ../..
+	docker build --build-arg=SWINGSET_TAG=$(TAG) -t $(REPOSITORY_SDK):$(TAG) --file=Dockerfile.sdk ../..
 
 docker-build-setup:
-	docker build -t $(REPOSITORY)-setup:latest .
+	docker build -t $(REPOSITORY)-setup:$(TAG) .
 
 docker-build-base:
 	hash=`git rev-parse --short HEAD`; \
 	  dirty=`git diff --quiet || echo -dirty`; \
 	  echo "$$hash$$dirty" > $(SS)lib/git-revision.txt
-	docker build -t $(REPOSITORY):latest $(SS)
+	docker build -t $(REPOSITORY):$(TAG) $(SS)
 
 docker-build-solo:
-	docker build -t $(REPOSITORY)-solo:latest $(SS)lib/ag-solo
+	docker build -t $(REPOSITORY)-solo:$(TAG) $(SS)lib/ag-solo
 
 docker-build-deployment:
-	docker build -t agoric/deployment:latest --file=Dockerfile.deployment ./docker
+	docker build -t agoric/deployment:$(TAG) --file=Dockerfile.deployment ./docker
 
 # Just push $(TAG)
 docker-push-only:
@@ -40,25 +40,27 @@ docker-push: docker-push-base docker-push-solo docker-push-setup \
 
 # ./docker is an emptyish directory.
 docker-build-ibc-alpha:
-	docker build -t $(REPOSITORY_SDK):ibc-alpha --file=Dockerfile.ibc-alpha ./docker
+	docker build --build-arg=SDK_TAG=$(TAG) -t $(REPOSITORY_SDK):ibc-alpha --file=Dockerfile.ibc-alpha ./docker
 
 docker-push-ibc-alpha: docker-build-ibc-alpha
 	docker push $(REPOSITORY_SDK):ibc-alpha
 
 docker-push-setup:
-	docker tag $(REPOSITORY)-setup:latest $(REPOSITORY)-setup:$(TAG)
+	$(DONT_PUSH_LATEST) docker tag $(REPOSITORY)-setup:$(TAG) $(REPOSITORY)-setup:latest
 	$(DONT_PUSH_LATEST) docker push $(REPOSITORY)-setup:latest
 	docker push $(REPOSITORY)-setup:$(TAG)
 
 docker-push-base:
-	docker tag $(REPOSITORY_SDK):latest $(REPOSITORY_SDK):$(TAG)
+	$(DONT_PUSH_LATEST) docker tag $(REPOSITORY_SDK):$(TAG) $(REPOSITORY_SDK):latest
 	$(DONT_PUSH_LATEST) docker push $(REPOSITORY_SDK):latest
 	docker push $(REPOSITORY_SDK):$(TAG)
 
 docker-push-solo:
-	docker tag $(REPOSITORY)-solo:latest $(REPOSITORY)-solo:$(TAG)
+	$(DONT_PUSH_LATEST) docker tag $(REPOSITORY)-solo:$(TAG) $(REPOSITORY)-solo:latest
 	$(DONT_PUSH_LATEST) docker push $(REPOSITORY)-solo:latest
 	docker push $(REPOSITORY)-solo:$(TAG)
 
 docker-push-deployment:
+	$(DONT_PUSH_LATEST) docker tag agoric/deployment:$(TAG) agoric/deployment:latest
 	$(DONT_PUSH_LATEST) docker push agoric/deployment:latest
+	docker push $(REPOSITORY)-solo:$(TAG)

--- a/packages/deployment/docker/ag-setup-cosmos
+++ b/packages/deployment/docker/ag-setup-cosmos
@@ -2,7 +2,7 @@
 PORT=26657
 NETWORK_NAME=${NETWORK_NAME-agoric}
 SETUP_HOME=${SETUP_HOME-$NETWORK_NAME}
-IMAGE=agoric/cosmic-swingset-setup:latest$DEV
+IMAGE=agoric/cosmic-swingset-setup:${TAG-latest}
 TTY=-i
 test -t 0 && test -t 1 && TTY=-it
 FLAGS=


### PR DESCRIPTION
More things to merge in the hackathon branch.

- increase the chain's allowed postdata body size from 1MB to 15MB (the oracle on-chain contracts were triggering `Error: RPC error -32600 - Invalid Request: error reading request body: http: request body too large`)
- pass through `provisionPowers` like `agoric.vattp` to provisioning step from `agoric start local-solo 8000 agoric.vattp`
- properly display the `ag-cosmos-helper` name when help is requested from it
- more support for pushing a custom docker tag (like `TAG=hacktheorb`) instead of `latest`
