### PR TITLE
feat: implement makeQuoteNotifier(amountIn, brandOut)

### DIFF
--- a/packages/zoe/tools/priceAuthorityRegistry.js
+++ b/packages/zoe/tools/priceAuthorityRegistry.js
@@ -92,8 +92,11 @@ export const makePriceAuthorityRegistry = () => {
     async quoteWanted(brandIn, amountOut) {
       return E(paFor(brandIn, amountOut.brand)).quoteWanted(brandIn, amountOut);
     },
-    async getQuoteNotifier(brandIn, brandOut) {
-      return E(paFor(brandIn, brandOut)).getQuoteNotifier(brandIn, brandOut);
+    async makeQuoteNotifier(amountIn, brandOut) {
+      return E(paFor(amountIn.brand, brandOut)).makeQuoteNotifier(
+        amountIn,
+        brandOut,
+      );
     },
     async quoteAtTime(deadline, amountIn, brandOut) {
       return E(paFor(amountIn.brand, brandOut)).quoteAtTime(

--- a/packages/zoe/tools/types.js
+++ b/packages/zoe/tools/types.js
@@ -98,12 +98,10 @@
  * getTimerService get the timer used in PriceQuotes for a given
  * brandIn/brandOut pair
  *
- * @property {(brandIn: Brand, brandOut: Brand) => ERef<Notifier<PriceQuote>>}
- * getQuoteNotifier be notified of the latest PriceQuotes for a given
- * brandIn/brandOut pair.  Note that these are not necessarily all for a
- * constant amountIn (or amountOut), though some authorities may do that.  The
- * fact that they are raw quotes means that a PriceAuthority can implement
- * quotes for both fungible and non-fungible brands.
+ * @property {(amountIn: Amount, brandOut: Brand) => ERef<Notifier<PriceQuote>>}
+ * makeQuoteNotifier Be notified of the latest PriceQuotes for a given
+ * `amountIn`.  The rate at which these are issued may be very different between
+ * `priceAuthorities`.
  *
  * @property {(deadline: Timestamp, amountIn: Amount, brandOut: Brand) =>
  * Promise<PriceQuote>} quoteAtTime Resolves after `deadline` passes on the


### PR DESCRIPTION
An API pivot to resolve the concerns that @katelynsills and @Chris-Hibbert had about the "raw" quote notifier.

Basically, to receive a quote notifier we supply a specific `amountIn`.  That `amountIn` will be a parameter for aggregators like the median aggregator.  This allows tracking the price of a specific asset over time, which is useful as a building block.
