### PR TITLE
OfferTo as a Zoe Helper - ready for design review

### DIFF
--- a/packages/zoe/src/contractSupport/index.js
+++ b/packages/zoe/src/contractSupport/index.js
@@ -26,4 +26,5 @@ export {
   depositToSeat,
   withdrawFromSeat,
   saveAllIssuers,
+  offerTo,
 } from './zoeHelpers';

--- a/packages/zoe/src/contractSupport/types.js
+++ b/packages/zoe/src/contractSupport/types.js
@@ -91,8 +91,9 @@
  * @param {ZCFSeat} fromSeat
  *   The seat in contractA to take the offer payments from.
  *
- * @param {ZCFSeat} toSeat
+ * @param {ZCFSeat=} toSeat
  *   The seat in contractA to deposit the payout of the offer to.
+ *   If `toSeat` is not provided, this defaults to the `fromSeat`.
  *
  * @returns {OfferToReturns}
  */

--- a/packages/zoe/src/contractSupport/types.js
+++ b/packages/zoe/src/contractSupport/types.js
@@ -49,3 +49,73 @@
  * @param {string} [rightHasExitedMsg]
  * @returns {string}
  */
+
+/**
+ * @typedef {Object} OfferToReturns
+ *
+ * The return value of offerTo is a promise for the userSeat for the
+ * offer to the other contract, and a promise (`deposited`) which
+ * resolves when the payout for the offer has been deposited to the `toSeat`
+ * @property {Promise<UserSeat>} userSeatPromise
+ * @property {Promise<AmountKeywordRecord>} deposited
+ */
+
+/**
+ * @typedef {Record<Keyword,Keyword>} KeywordKeywordRecord
+ *
+ * A mapping of keywords to keywords.
+ */
+
+/**
+ * @callback OfferTo
+ *
+ * Make an offer to another contract instance (labeled contractB below),
+ * withdrawing the payments for the offer from a seat in the current
+ * contract instance (contractA) and depositing the payouts in another
+ * seat in the current contract instance (contractA).
+ *
+ * @param {ContractFacet} zcf
+ *   Zoe Contract Facet for contractA
+ *
+ * @param {ERef<Invitation>} invitation
+ *   Invitation to contractB
+ *
+ * @param {KeywordKeywordRecord=} keywordMapping
+ *   Mapping of keywords used in contractA to keywords to be used in
+ *   contractB. Note that the pathway to deposit the payout back to
+ *   contractA reverses this mapping.
+ *
+ * @param {Proposal} proposal
+ *   The proposal for the offer to be made to contractB
+ *
+ * @param {ZCFSeat} fromSeat
+ *   The seat in contractA to take the offer payments from.
+ *
+ * @param {ZCFSeat} toSeat
+ *   The seat in contractA to deposit the payout of the offer to.
+ *
+ * @returns {OfferToReturns}
+ */
+
+/**
+ * @callback Reverse
+ *
+ * Given a mapping of keywords to keywords, invert the keys and
+ * values. This is used to map the offers made to another contract
+ * back to the keywords used in the first contract.
+ * @param {KeywordKeywordRecord=} keywordRecord
+ * @returns {KeywordKeywordRecord }
+ */
+
+/**
+ * @callback MapKeywords
+ *
+ * Remap the keywords of an amountKeywordRecord or a
+ * PaymentPKeywordRecord according to a mapping. This is used to remap
+ * from keywords used in contractA to keywords used in contractB and
+ * vice versa in `offerTo`
+ *
+ * @param {AmountKeywordRecord | PaymentPKeywordRecord | undefined }
+ * keywordRecord
+ * @param {KeywordKeywordRecord} keywordMapping
+ */

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -450,6 +450,8 @@ export const offerTo = async (
   fromSeat,
   toSeat,
 ) => {
+  const definedToSeat = toSeat !== undefined ? toSeat : fromSeat;
+
   const zoe = zcf.getZoeService();
   const mappingReversed = reverse(keywordMapping);
 
@@ -479,7 +481,7 @@ export const offerTo = async (
     // Map back to the original contract's keywords
     const mappedAmounts = mapKeywords(amounts, mappingReversed);
     const mappedPayments = mapKeywords(payoutPayments, mappingReversed);
-    await depositToSeat(zcf, toSeat, mappedAmounts, mappedPayments);
+    await depositToSeat(zcf, definedToSeat, mappedAmounts, mappedPayments);
     depositedPromiseKit.resolve(mappedAmounts);
   };
 

--- a/packages/zoe/src/contracts/loan/liquidate.js
+++ b/packages/zoe/src/contracts/loan/liquidate.js
@@ -52,7 +52,7 @@ export const doLiquidation = async (
 
   const offerResultP = E(autoswapUserSeat).getOfferResult();
   await deposited;
-  offerResultP.then(closeSuccessfully, closeWithFailure);
+  await offerResultP.then(closeSuccessfully, closeWithFailure);
 };
 
 /**

--- a/packages/zoe/src/contracts/loan/liquidate.js
+++ b/packages/zoe/src/contracts/loan/liquidate.js
@@ -3,7 +3,7 @@ import '../../../exported';
 
 import { E } from '@agoric/eventual-send';
 
-import { depositToSeat, withdrawFromSeat } from '../../contractSupport';
+import { offerTo } from '../../contractSupport/zoeHelpers';
 
 export const doLiquidation = async (
   zcf,
@@ -11,73 +11,48 @@ export const doLiquidation = async (
   autoswapPublicFacetP,
   lenderSeat,
 ) => {
-  const zoeService = zcf.getZoeService();
   const loanMath = zcf.getTerms().maths.Loan;
 
   const allCollateral = collateralSeat.getAmountAllocated('Collateral');
 
-  const { Collateral: collateralPayment } = await withdrawFromSeat(
-    zcf,
-    collateralSeat,
-    {
-      Collateral: allCollateral,
-    },
-  );
+  const swapInvitation = E(autoswapPublicFacetP).makeSwapInInvitation();
+
+  const toAmounts = harden({ In: allCollateral });
 
   const proposal = harden({
-    give: { In: allCollateral },
+    give: toAmounts,
     want: { Out: loanMath.getEmpty() },
   });
 
-  const payments = harden({ In: collateralPayment });
+  const keywordMapping = harden({
+    Collateral: 'In',
+    Loan: 'Out',
+  });
 
-  const swapInvitation = E(autoswapPublicFacetP).makeSwapInInvitation();
-
-  const autoswapUserSeat = E(zoeService).offer(
+  const { userSeatPromise: autoswapUserSeat, deposited } = await offerTo(
+    zcf,
     swapInvitation,
+    keywordMapping,
     proposal,
-    payments,
+    collateralSeat,
+    lenderSeat,
   );
 
-  /**
-   * @param {{ Out: Promise<Payment>; In: Promise<Payment>; }} payouts
-   */
-  const handlePayoutsAndShutdown = async payouts => {
-    const { Out: loanPayout, In: collateralPayout } = payouts;
-    const { Out: loanAmount, In: collateralAmount } = await E(
-      autoswapUserSeat,
-    ).getCurrentAllocation();
-    // AWAIT ///
-    const amounts = harden({
-      Collateral: collateralAmount,
-      Loan: loanAmount,
-    });
-    const payoutPayments = harden({
-      Collateral: collateralPayout,
-      Loan: loanPayout,
-    });
-    await depositToSeat(zcf, lenderSeat, amounts, payoutPayments);
-
-    const closeSuccessfully = () => {
-      lenderSeat.exit();
-      collateralSeat.exit();
-      zcf.shutdown('your loan had to be liquidated');
-    };
-
-    const closeWithFailure = err => {
-      lenderSeat.kickOut(err);
-      collateralSeat.kickOut(err);
-      zcf.shutdownWithFailure(err);
-    };
-
-    await E(autoswapUserSeat)
-      .getOfferResult()
-      .then(closeSuccessfully, closeWithFailure);
+  const closeSuccessfully = () => {
+    lenderSeat.exit();
+    collateralSeat.exit();
+    zcf.shutdown('your loan had to be liquidated');
   };
 
-  return E(autoswapUserSeat)
-    .getPayouts()
-    .then(handlePayoutsAndShutdown);
+  const closeWithFailure = err => {
+    lenderSeat.fail(err);
+    collateralSeat.fail(err);
+    zcf.shutdownWithFailure(err);
+  };
+
+  const offerResultP = E(autoswapUserSeat).getOfferResult();
+  await deposited;
+  offerResultP.then(closeSuccessfully, closeWithFailure);
 };
 
 /**

--- a/packages/zoe/src/contracts/otcDesk.js
+++ b/packages/zoe/src/contracts/otcDesk.js
@@ -4,8 +4,7 @@ import { E } from '@agoric/eventual-send';
 import { assert } from '@agoric/assert';
 import {
   trade,
-  depositToSeat,
-  withdrawFromSeat,
+  offerTo,
   saveAllIssuers,
   assertProposalShape,
 } from '../contractSupport';
@@ -84,21 +83,16 @@ const start = zcf => {
       },
     });
 
-    const payments = await withdrawFromSeat(zcf, marketMakerSeat, assets);
-    const sellerUserSeat = await E(zoe).offer(
+    const { userSeatPromise: coveredCallUserSeat } = await offerTo(
+      zcf,
       creatorInvitation,
+      undefined,
       proposal,
-      payments,
+      marketMakerSeat,
+      marketMakerSeat,
     );
 
-    E(sellerUserSeat)
-      .getPayouts()
-      .then(async payoutPayments => {
-        const amounts = await E(sellerUserSeat).getCurrentAllocation();
-        await depositToSeat(zcf, marketMakerSeat, amounts, payoutPayments);
-      });
-
-    const option = E(sellerUserSeat).getOfferResult();
+    const option = E(coveredCallUserSeat).getOfferResult();
     return option;
   };
 

--- a/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
@@ -1,0 +1,246 @@
+// @ts-check
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@agoric/install-ses';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import test from 'ava';
+
+import { E } from '@agoric/eventual-send';
+import bundleSource from '@agoric/bundle-source';
+
+import { setup } from '../setupBasicMints';
+import { makeZoe } from '../../..';
+import { makeFakeVatAdmin } from '../../../src/contractFacet/fakeVatAdmin';
+import {
+  offerTo,
+  assertProposalShape,
+  swapExact,
+} from '../../../src/contractSupport/zoeHelpers';
+
+const contractRoot = `${__dirname}/../zcf/zcfTesterContract`;
+
+const makeOffer = async (zoe, zcf, proposal, payments) => {
+  let zcfSeat;
+  const getSeat = seat => {
+    zcfSeat = seat;
+  };
+  const invitation = await zcf.makeInvitation(getSeat, 'seat');
+  const userSeat = await E(zoe).offer(invitation, proposal, payments);
+  return { zcfSeat, userSeat };
+};
+
+const setupContract = async (moolaIssuer, bucksIssuer) => {
+  const instanceToZCF = new Map();
+  const setJig = jig => {
+    instanceToZCF.set(jig.instance, jig.zcf);
+  };
+  const zoe = makeZoe(makeFakeVatAdmin(setJig).admin);
+
+  // pack the contract
+  const bundle = await bundleSource(contractRoot);
+  // install the contract
+  const installation = await zoe.install(bundle);
+
+  // Create TWO instances of the zcfTesterContract which have
+  // different keywords
+  const issuerKeywordRecord1 = harden({
+    TokenA: moolaIssuer,
+    TokenB: bucksIssuer,
+  });
+
+  const issuerKeywordRecord2 = harden({
+    TokenC: moolaIssuer,
+    TokenD: bucksIssuer,
+  });
+
+  // contract instance A
+  const { instance: instanceA } = await E(zoe).startInstance(
+    installation,
+    issuerKeywordRecord1,
+  );
+
+  // contract instance B
+  const { instance: instanceB } = await E(zoe).startInstance(
+    installation,
+    issuerKeywordRecord2,
+  );
+
+  // instanceToZCF a map containing both instances as keys and zcfs as
+  // values
+  return { zoe, instanceToZCF, instanceA, instanceB };
+};
+
+test(`offerTo - basic usage`, async t => {
+  const {
+    moola,
+    moolaIssuer,
+    moolaMint,
+    bucksMint,
+    bucks,
+    bucksIssuer,
+  } = setup();
+  const { zoe, instanceToZCF, instanceA, instanceB } = await setupContract(
+    moolaIssuer,
+    bucksIssuer,
+  );
+
+  const zcfA = instanceToZCF.get(instanceA);
+  const zcfB = instanceToZCF.get(instanceB);
+
+  // Make an offer from contract A to contract B from a seat in
+  // contract A, and deposit the winnings in a different seat on contract A.
+
+  // Create a fromSeat on contract instance A that starts with 5 bucks
+  // under keyword TokenB
+
+  const { zcfSeat: fromSeatContractA } = await makeOffer(
+    zoe,
+    zcfA,
+    harden({ want: {}, give: { TokenB: bucks(5) } }),
+    harden({ TokenB: bucksMint.mintPayment(bucks(5)) }),
+  );
+
+  // Create a seat in contract instance B to exchange with.
+
+  const { zcfSeat: contractBCollateralSeat } = await makeOffer(
+    zoe,
+    zcfB,
+    harden({ want: { TokenD: bucks(5) }, give: { TokenC: moola(10) } }),
+    harden({ TokenC: moolaMint.mintPayment(moola(10)) }),
+  );
+
+  // create an invitation for contract instance B. This offer will
+  // take the 5 bucks and give 10 moola in exchange.
+
+  const successMsg = 'offer to contractB successful';
+
+  const offerHandler = seat => {
+    assertProposalShape(seat, {
+      give: {
+        TokenD: null,
+      },
+      want: {
+        TokenC: null,
+      },
+      exit: {
+        onDemand: null,
+      },
+    });
+
+    swapExact(zcfB, contractBCollateralSeat, seat);
+    return successMsg;
+  };
+  const contractBInvitation = zcfB.makeInvitation(
+    offerHandler,
+    'contractB invitation',
+  );
+
+  // Map the keywords in contract A to the keywords in contract B
+  const keywordMapping = harden({
+    TokenA: 'TokenC',
+    TokenB: 'TokenD',
+  });
+
+  const proposal = harden({
+    give: {
+      TokenD: bucks(5),
+    },
+    want: {
+      TokenC: moola(10),
+    },
+  });
+
+  const { zcfSeat: toSeatContractA } = zcfA.makeEmptySeatKit();
+  t.deepEqual(toSeatContractA.getCurrentAllocation(), {});
+
+  const { userSeatPromise: contractBUserSeat, deposited } = await offerTo(
+    zcfA,
+    contractBInvitation,
+    keywordMapping,
+    proposal,
+    fromSeatContractA,
+    toSeatContractA,
+  );
+
+  await deposited;
+  // The toSeat successfully got the payout from the offer to Contract
+  // Instance B
+  t.deepEqual(toSeatContractA.getCurrentAllocation(), {
+    TokenA: moola(10),
+    TokenB: bucks(0),
+  });
+
+  // The offerResult is as expected
+  t.is(await E(contractBUserSeat).getOfferResult(), successMsg);
+});
+
+test(`offerTo - violates offer safety of fromSeat`, async t => {
+  const { moola, moolaIssuer, bucksMint, bucks, bucksIssuer } = setup();
+  const { zoe, instanceToZCF, instanceA, instanceB } = await setupContract(
+    moolaIssuer,
+    bucksIssuer,
+  );
+
+  const zcfA = instanceToZCF.get(instanceA);
+  const zcfB = instanceToZCF.get(instanceB);
+
+  // Make an offer from contract A to contract B from a seat in
+  // contract A, and deposit the winnings in a different seat on contract A.
+
+  // Create a fromSeat on contract instance A that starts with 5 bucks
+  // under keyword TokenB
+
+  const { zcfSeat: fromSeatContractA } = await makeOffer(
+    zoe,
+    zcfA,
+    // Actually enforce offer safety
+    harden({ want: { TokenA: moola(3) }, give: { TokenB: bucks(5) } }),
+    harden({ TokenB: bucksMint.mintPayment(bucks(5)) }),
+  );
+
+  const offerHandler = () => {};
+  const contractBInvitation = zcfB.makeInvitation(
+    offerHandler,
+    'contractB invitation',
+  );
+
+  // Map the keywords in contract A to the keywords in contract B
+  const keywordMapping = harden({
+    TokenA: 'TokenC',
+    TokenB: 'TokenD',
+  });
+
+  const proposal = harden({
+    give: {
+      TokenD: bucks(5),
+    },
+    want: {
+      TokenC: moola(10),
+    },
+  });
+
+  const { zcfSeat: toSeatContractA } = zcfA.makeEmptySeatKit();
+  t.deepEqual(toSeatContractA.getCurrentAllocation(), {});
+
+  await t.throwsAsync(
+    () =>
+      offerTo(
+        zcfA,
+        contractBInvitation,
+        keywordMapping,
+        proposal,
+        fromSeatContractA,
+        toSeatContractA,
+      ),
+    {
+      message:
+        'The trade between left [object Object] and right [object Object] failed offer safety. Please check the log for more information',
+    },
+  );
+
+  t.deepEqual(fromSeatContractA.getCurrentAllocation(), {
+    TokenA: moola(0),
+    TokenB: bucks(5),
+  });
+  t.falsy(fromSeatContractA.hasExited());
+});

--- a/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
@@ -44,13 +44,13 @@ const setupContract = async (moolaIssuer, bucksIssuer) => {
   // Create TWO instances of the zcfTesterContract which have
   // different keywords
   const issuerKeywordRecord1 = harden({
-    TokenA: moolaIssuer,
-    TokenB: bucksIssuer,
+    TokenJ: moolaIssuer,
+    TokenK: bucksIssuer,
   });
 
   const issuerKeywordRecord2 = harden({
-    TokenC: moolaIssuer,
-    TokenD: bucksIssuer,
+    TokenL: moolaIssuer,
+    TokenM: bucksIssuer,
   });
 
   // contract instance A
@@ -91,13 +91,13 @@ test(`offerTo - basic usage`, async t => {
   // contract A, and deposit the winnings in a different seat on contract A.
 
   // Create a fromSeat on contract instance A that starts with 5 bucks
-  // under keyword TokenB
+  // under keyword TokenK
 
   const { zcfSeat: fromSeatContractA } = await makeOffer(
     zoe,
     zcfA,
-    harden({ want: {}, give: { TokenB: bucks(5) } }),
-    harden({ TokenB: bucksMint.mintPayment(bucks(5)) }),
+    harden({ want: {}, give: { TokenK: bucks(5) } }),
+    harden({ TokenK: bucksMint.mintPayment(bucks(5)) }),
   );
 
   // Create a seat in contract instance B to exchange with.
@@ -105,8 +105,8 @@ test(`offerTo - basic usage`, async t => {
   const { zcfSeat: contractBCollateralSeat } = await makeOffer(
     zoe,
     zcfB,
-    harden({ want: { TokenD: bucks(5) }, give: { TokenC: moola(10) } }),
-    harden({ TokenC: moolaMint.mintPayment(moola(10)) }),
+    harden({ want: { TokenM: bucks(5) }, give: { TokenL: moola(10) } }),
+    harden({ TokenL: moolaMint.mintPayment(moola(10)) }),
   );
 
   // create an invitation for contract instance B. This offer will
@@ -117,10 +117,10 @@ test(`offerTo - basic usage`, async t => {
   const offerHandler = seat => {
     assertProposalShape(seat, {
       give: {
-        TokenD: null,
+        TokenM: null,
       },
       want: {
-        TokenC: null,
+        TokenL: null,
       },
       exit: {
         onDemand: null,
@@ -137,16 +137,16 @@ test(`offerTo - basic usage`, async t => {
 
   // Map the keywords in contract A to the keywords in contract B
   const keywordMapping = harden({
-    TokenA: 'TokenC',
-    TokenB: 'TokenD',
+    TokenJ: 'TokenL',
+    TokenK: 'TokenM',
   });
 
   const proposal = harden({
     give: {
-      TokenD: bucks(5),
+      TokenM: bucks(5),
     },
     want: {
-      TokenC: moola(10),
+      TokenL: moola(10),
     },
   });
 
@@ -166,8 +166,8 @@ test(`offerTo - basic usage`, async t => {
   // The toSeat successfully got the payout from the offer to Contract
   // Instance B
   t.deepEqual(toSeatContractA.getCurrentAllocation(), {
-    TokenA: moola(10),
-    TokenB: bucks(0),
+    TokenJ: moola(10),
+    TokenK: bucks(0),
   });
 
   // The offerResult is as expected
@@ -188,14 +188,14 @@ test(`offerTo - violates offer safety of fromSeat`, async t => {
   // contract A, and deposit the winnings in a different seat on contract A.
 
   // Create a fromSeat on contract instance A that starts with 5 bucks
-  // under keyword TokenB
+  // under keyword TokenK
 
   const { zcfSeat: fromSeatContractA } = await makeOffer(
     zoe,
     zcfA,
     // Actually enforce offer safety
-    harden({ want: { TokenA: moola(3) }, give: { TokenB: bucks(5) } }),
-    harden({ TokenB: bucksMint.mintPayment(bucks(5)) }),
+    harden({ want: { TokenJ: moola(3) }, give: { TokenK: bucks(5) } }),
+    harden({ TokenK: bucksMint.mintPayment(bucks(5)) }),
   );
 
   const offerHandler = () => {};
@@ -206,16 +206,16 @@ test(`offerTo - violates offer safety of fromSeat`, async t => {
 
   // Map the keywords in contract A to the keywords in contract B
   const keywordMapping = harden({
-    TokenA: 'TokenC',
-    TokenB: 'TokenD',
+    TokenJ: 'TokenL',
+    TokenK: 'TokenM',
   });
 
   const proposal = harden({
     give: {
-      TokenD: bucks(5),
+      TokenM: bucks(5),
     },
     want: {
-      TokenC: moola(10),
+      TokenL: moola(10),
     },
   });
 
@@ -239,8 +239,8 @@ test(`offerTo - violates offer safety of fromSeat`, async t => {
   );
 
   t.deepEqual(fromSeatContractA.getCurrentAllocation(), {
-    TokenA: moola(0),
-    TokenB: bucks(5),
+    TokenJ: moola(0),
+    TokenK: bucks(5),
   });
   t.falsy(fromSeatContractA.hasExited());
 });

--- a/packages/zoe/test/unitTests/zcf/zcfTesterContract.js
+++ b/packages/zoe/test/unitTests/zcf/zcfTesterContract.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { E } from '@agoric/eventual-send';
 import '../../../exported';
 
 /**
@@ -7,9 +8,12 @@ import '../../../exported';
  *
  * @type {ContractStartFn}
  */
-const start = zcf => {
-  // make the `zcf` available to the tests
-  zcf.setTestJig();
+const start = async zcf => {
+  // make the `zcf` and `instance` available to the tests
+  const invitation = zcf.makeInvitation(() => {}, 'test');
+  const zoe = zcf.getZoeService();
+  const { instance } = await E(zoe).getInvitationDetails(invitation);
+  zcf.setTestJig(() => harden({ instance }));
   return {};
 };
 


### PR DESCRIPTION
In this PR, `offerTo` is written as a helper. It is incorporated into the loan's liquidation code and the OTC desk code with those contracts' tests passing. This code is in a good state for a cursory design review of the `offerTo` signature:

```js
offerTo(
  zcf,
  invitation,
  keywordMapping = {},
  proposal,
  fromSeat,
  toSeat
);
```

Types:

```js
/**
 * @callback OfferTo
 * @param {ContractFacet} zcf
 * @param {ERef<Invitation>} invitation
 * @param {KeywordKeywordRecord=} keywordMapping
 * @param {Proposal} proposal
 * @param {ZCFSeat} fromSeat
 * @param {ZCFSeat} toSeat
 * @returns {OfferToReturns}
 */
```

Where `invitation` is the invitation to contractB, `proposal` is the proposal to use with the invitation, and `keywordMapping` is a record of the keywords appropriate to contractA mapped to the keywords for contractB. 

Note that when then `offerTo` implementation is moved into Zoe in another PR, we will be able to get rid of the `zcf` parameter:

```js
 const { userSeatPromise: autoswapUserSeat, deposited } = zcf.offerTo(
   swapInvitation,
   keywordMapping, // {}
   proposal,
   fromSeat,
   lenderSeat,
 );

```