### PR TITLE
fix: work around Firefox's lack of Error.stackTraceLimit

### DIFF
--- a/packages/dapp-svelte-wallet/ui/src/install-ses-lockdown.js
+++ b/packages/dapp-svelte-wallet/ui/src/install-ses-lockdown.js
@@ -1,8 +1,14 @@
 import 'ses/lockdown';
 import '@agoric/eventual-send/shim';
 
-lockdown({ errorTaming: 'unsafe' });
+lockdown();
 
 // Even on non-v8, we tame the start compartment's Error constructor so
 // this assignment is not rejected, even if it does nothing.
-Error.stackTraceLimit = Infinity;
+// FIXME: The claim is the following should work:
+// Error.stackTraceLimit = Infinity;
+try {
+  Error.stackTraceLimit = Infinity;
+} catch (e) {
+  console.log('NOTE:', e);
+}


### PR DESCRIPTION
The wallet doesn't display under Firefox, instead:
![Screen Shot 2020-11-13 at 11 49 39 AM](https://user-images.githubusercontent.com/457244/99105064-7a816a80-25a7-11eb-8467-cccd88aac5da.png)

Be tolerant.
