### PR TITLE
chore: Change `.catch` clauses to not suppress error if unnecessary

### DIFF
--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -152,13 +152,11 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
       /** @type {PromiseRecord<ZoeSeatAdmin>} */
       const zoeSeatAdminPromiseKit = makePromiseKit();
       zoeSeatAdminPromiseKit.promise.catch(err => {
-        console.error(err);
         // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
         throw err;
       });
       const userSeatPromiseKit = makePromiseKit();
       userSeatPromiseKit.promise.catch(err => {
-        console.error(err);
         // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
         throw err;
       });
@@ -455,7 +453,6 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
     // First, evaluate the contract code bundle.
     const contractCode = evalContractBundle(bundle);
     contractCode.catch(err => {
-      console.error(err);
       // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
       throw err;
     });

--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -151,11 +151,17 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
       const { notifier, updater } = makeNotifierKit();
       /** @type {PromiseRecord<ZoeSeatAdmin>} */
       const zoeSeatAdminPromiseKit = makePromiseKit();
-      // Don't trigger Node.js's UnhandledPromiseRejectionWarning
-      zoeSeatAdminPromiseKit.promise.catch(_ => {});
+      zoeSeatAdminPromiseKit.promise.catch(err => {
+        console.error(err);
+        // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
+        throw err;
+      });
       const userSeatPromiseKit = makePromiseKit();
-      // Don't trigger Node.js's UnhandledPromiseRejectionWarning
-      userSeatPromiseKit.promise.catch(_ => {});
+      userSeatPromiseKit.promise.catch(err => {
+        console.error(err);
+        // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
+        throw err;
+      });
       const seatHandle = makeHandle('SeatHandle');
 
       const seatData = harden({
@@ -448,23 +454,24 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
 
     // First, evaluate the contract code bundle.
     const contractCode = evalContractBundle(bundle);
-    // Don't trigger Node.js's UnhandledPromiseRejectionWarning
-    contractCode.catch(() => {});
+    contractCode.catch(err => {
+      console.error(err);
+      // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
+      throw err;
+    });
 
     // Next, execute the contract code, passing in zcf
+    const { creatorFacet, publicFacet, creatorInvitation } = await E(
+      contractCode,
+    ).start(zcf);
+
     /** @type {Promise<ExecuteContractResult>} */
-    const result = E(contractCode)
-      .start(zcf)
-      .then(({ creatorFacet, publicFacet, creatorInvitation }) => {
-        return harden({
-          creatorFacet,
-          publicFacet,
-          creatorInvitation,
-          addSeatObj,
-        });
-      });
-    result.catch(() => {}); // Don't trigger Node.js's UnhandledPromiseRejectionWarning
-    return result;
+    return harden({
+      creatorFacet,
+      publicFacet,
+      creatorInvitation,
+      addSeatObj,
+    });
   };
 
   return harden({ executeContract });

--- a/packages/zoe/src/contractFacet/evalContractCode.js
+++ b/packages/zoe/src/contractFacet/evalContractCode.js
@@ -27,7 +27,6 @@ const evalContractBundle = (bundle, additionalEndowments = {}) => {
     endowments: fullEndowments,
   });
   installation.catch(err => {
-    console.error(err);
     // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
     throw err;
   });

--- a/packages/zoe/src/contractFacet/evalContractCode.js
+++ b/packages/zoe/src/contractFacet/evalContractCode.js
@@ -26,8 +26,11 @@ const evalContractBundle = (bundle, additionalEndowments = {}) => {
   const installation = importBundle(bundle, {
     endowments: fullEndowments,
   });
-  // Don't trigger Node.js's UnhandledPromiseRejectionWarning
-  installation.catch(() => {});
+  installation.catch(err => {
+    console.error(err);
+    // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
+    throw err;
+  });
   return installation;
 };
 

--- a/packages/zoe/src/contractFacet/fakeVatAdmin.js
+++ b/packages/zoe/src/contractFacet/fakeVatAdmin.js
@@ -39,7 +39,6 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
           done: () => {
             const kit = makePromiseKit();
             kit.promise.catch(err => {
-              console.error(err);
               // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
               throw err;
             });

--- a/packages/zoe/src/contractFacet/fakeVatAdmin.js
+++ b/packages/zoe/src/contractFacet/fakeVatAdmin.js
@@ -38,8 +38,11 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
         adminNode: {
           done: () => {
             const kit = makePromiseKit();
-            // Don't trigger Node.js's UnhandledPromiseRejectionWarning
-            kit.promise.catch(_ => {});
+            kit.promise.catch(err => {
+              console.error(err);
+              // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
+              throw err;
+            });
             return kit.promise;
           },
           terminateWithFailure: () => {},

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -214,13 +214,11 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
       const bundle = installation.getBundle();
       const addSeatObjPromiseKit = makePromiseKit();
       addSeatObjPromiseKit.promise.catch(err => {
-        console.error(err);
         // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
         throw err;
       });
       const publicFacetPromiseKit = makePromiseKit();
       publicFacetPromiseKit.promise.catch(err => {
-        console.error(err);
         // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
         throw err;
       });
@@ -445,7 +443,6 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
             });
             const exitObjPromiseKit = makePromiseKit();
             exitObjPromiseKit.promise.catch(err => {
-              console.error(err);
               // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
               throw err;
             });
@@ -477,7 +474,6 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
                 exitObjPromiseKit.resolve(exitObj);
               })
               .catch(err => {
-                console.error(err);
                 // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
                 throw err;
               });

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -436,9 +436,7 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
             );
 
             const offerResultPromiseKit = makePromiseKit();
-            offerResultPromiseKit.promise.catch(err => {
-              console.log('An offerHandler has errored.');
-              console.error(err);
+            offerResultPromiseKit.promise.catch(_err => {
               // Error suppressed to not trigger Node.js's UnhandledPromiseRejectionWarning
             });
             const exitObjPromiseKit = makePromiseKit();

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -213,11 +213,17 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
 
       const bundle = installation.getBundle();
       const addSeatObjPromiseKit = makePromiseKit();
-      // Don't trigger Node.js's UnhandledPromiseRejectionWarning
-      addSeatObjPromiseKit.promise.catch(_ => {});
+      addSeatObjPromiseKit.promise.catch(err => {
+        console.error(err);
+        // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
+        throw err;
+      });
       const publicFacetPromiseKit = makePromiseKit();
-      // Don't trigger Node.js's UnhandledPromiseRejectionWarning
-      publicFacetPromiseKit.promise.catch(_ => {});
+      publicFacetPromiseKit.promise.catch(err => {
+        console.error(err);
+        // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
+        throw err;
+      });
 
       const makeInstanceAdmin = () => {
         /** @type {Set<ZoeSeatAdmin>} */
@@ -333,7 +339,8 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
         stopAcceptingOffers: () => instanceAdmin.stopAcceptingOffers(),
       };
 
-      // At this point, the contract will start executing. All must be ready
+      // At this point, the contract will start executing. All must be
+      // ready
 
       const {
         creatorFacet = {},
@@ -431,11 +438,17 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
             );
 
             const offerResultPromiseKit = makePromiseKit();
-            // Don't trigger Node.js's UnhandledPromiseRejectionWarning
-            offerResultPromiseKit.promise.catch(_ => {});
+            offerResultPromiseKit.promise.catch(err => {
+              console.log('An offerHandler has errored.');
+              console.error(err);
+              // Error suppressed to not trigger Node.js's UnhandledPromiseRejectionWarning
+            });
             const exitObjPromiseKit = makePromiseKit();
-            // Don't trigger Node.js's UnhandledPromiseRejectionWarning
-            exitObjPromiseKit.promise.catch(_ => {});
+            exitObjPromiseKit.promise.catch(err => {
+              console.error(err);
+              // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
+              throw err;
+            });
             const seatHandle = makeHandle('SeatHandle');
 
             const { userSeat, notifier, zoeSeatAdmin } = makeZoeSeatAdminKit(
@@ -464,7 +477,9 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
                 exitObjPromiseKit.resolve(exitObj);
               })
               .catch(err => {
-                console.log(err);
+                console.error(err);
+                // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
+                throw err;
               });
 
             return userSeat;

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -31,8 +31,11 @@ export const makeZoeSeatAdminKit = (
   offerResult,
 ) => {
   const payoutPromiseKit = makePromiseKit();
-  // Don't trigger Node.js's UnhandledPromiseRejectionWarning
-  payoutPromiseKit.promise.catch(_ => {});
+  payoutPromiseKit.promise.catch(err => {
+    console.error(err);
+    // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
+    throw err;
+  });
   const { notifier, updater } = makeNotifierKit();
 
   let currentAllocation = initialAllocation;

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -32,7 +32,6 @@ export const makeZoeSeatAdminKit = (
 ) => {
   const payoutPromiseKit = makePromiseKit();
   payoutPromiseKit.promise.catch(err => {
-    console.error(err);
     // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
     throw err;
   });

--- a/packages/zoe/test/unitTests/contracts/test-throwInOfferHandler.js
+++ b/packages/zoe/test/unitTests/contracts/test-throwInOfferHandler.js
@@ -1,0 +1,45 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@agoric/install-ses';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import test from 'ava';
+
+import bundleSource from '@agoric/bundle-source';
+
+import { E } from '@agoric/eventual-send';
+import { makeZoe } from '../../../src/zoeService/zoe';
+import fakeVatAdmin from '../../../src/contractFacet/fakeVatAdmin';
+
+const contractRoot = `${__dirname}/throwInOfferHandler`;
+
+test('throw in offerHandler', async t => {
+  const zoe = makeZoe(fakeVatAdmin);
+
+  // pack the contract
+  const bundle = await bundleSource(contractRoot);
+  // install the contract
+  const installation = await E(zoe).install(bundle);
+
+  const { creatorFacet } = await E(zoe).startInstance(installation);
+
+  const throwInOfferHandlerInvitation = E(
+    creatorFacet,
+  ).makeThrowInOfferHandlerInvitation();
+
+  const throwInDepositToSeatInvitation = E(
+    creatorFacet,
+  ).makeThrowInDepositToSeatInvitation();
+
+  const throwsInOfferHandlerSeat = E(zoe).offer(throwInOfferHandlerInvitation);
+
+  await t.throwsAsync(() => E(throwsInOfferHandlerSeat).getOfferResult(), {
+    message: 'error thrown in offerHandler in contract',
+  });
+
+  const throwsInDepositToSeatSeat = E(zoe).offer(
+    throwInDepositToSeatInvitation,
+  );
+
+  await t.throwsAsync(() => E(throwsInDepositToSeatSeat).getOfferResult(), {
+    message: `"brand" not found: (an object)`,
+  });
+});

--- a/packages/zoe/test/unitTests/contracts/throwInOfferHandler.js
+++ b/packages/zoe/test/unitTests/contracts/throwInOfferHandler.js
@@ -1,0 +1,42 @@
+// @ts-check
+import '../../../exported';
+
+import { makeIssuerKit } from '@agoric/ertp';
+
+import { depositToSeat } from '../../../src/contractSupport';
+
+/**
+ * This is a a broken contact to test that
+ * errors in offerHandlers are appropriately handled
+ *
+ * @type {ContractStartFn}
+ */
+const start = zcf => {
+  const throwInOfferHandler = _seat => {
+    throw Error('error thrown in offerHandler in contract');
+  };
+
+  const throwInDepositToSeat = async seat => {
+    const issuerKit = makeIssuerKit('token');
+    const tokens10 = issuerKit.amountMath.make(10);
+    const payment = issuerKit.mint.mintPayment(tokens10);
+    const amounts = harden({ Token: tokens10 });
+    const payments = harden({ Tokens: payment });
+    await depositToSeat(zcf, seat, amounts, payments);
+    return 'Should not get here';
+  };
+  const makeThrowInOfferHandlerInvitation = () =>
+    zcf.makeInvitation(throwInOfferHandler, 'throwInOfferHandler');
+
+  const makeThrowInDepositToSeatInvitation = () =>
+    zcf.makeInvitation(throwInDepositToSeat, 'throwInDepositToSeat');
+
+  const creatorFacet = {
+    makeThrowInOfferHandlerInvitation,
+    makeThrowInDepositToSeatInvitation,
+  };
+  return harden({ creatorFacet });
+};
+
+harden(start);
+export { start };


### PR DESCRIPTION
AVA doesn't allow unhandled promise rejections (tests will fail in an unhelpful way). So to fix this when switching to AVA in a rush, we added `catch` clauses within Zoe and ZCF. However, we added more than was necessary, causing errors to be suppressed.

This became apparent when in @Chris-Hibbert 's call spread contract, an error was occurring within the `offerHandler` in `depositToSeat`, but wasn't being logged in the console at all. 

This PR changes how we are handling things to only catch errors without re-throwing if we have confirmed that under normal usage it results in an UnhandledPromiseRejectionWarning.

Closes #2023 