### PR TITLE
chore: revert #2025, but keep the additional tests.

### DIFF
--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -151,15 +151,13 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
       const { notifier, updater } = makeNotifierKit();
       /** @type {PromiseRecord<ZoeSeatAdmin>} */
       const zoeSeatAdminPromiseKit = makePromiseKit();
-      zoeSeatAdminPromiseKit.promise.catch(err => {
-        // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
-        throw err;
-      });
+      // Don't trigger Node.js's UnhandledPromiseRejectionWarning.
+      // This does not suppress any error messages.
+      zoeSeatAdminPromiseKit.promise.catch(_ => {});
       const userSeatPromiseKit = makePromiseKit();
-      userSeatPromiseKit.promise.catch(err => {
-        // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
-        throw err;
-      });
+      // Don't trigger Node.js's UnhandledPromiseRejectionWarning.
+      // This does not suppress any error messages.
+      userSeatPromiseKit.promise.catch(_ => {});
       const seatHandle = makeHandle('SeatHandle');
 
       const seatData = harden({
@@ -452,23 +450,26 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
 
     // First, evaluate the contract code bundle.
     const contractCode = evalContractBundle(bundle);
-    contractCode.catch(err => {
-      // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
-      throw err;
-    });
+    // Don't trigger Node.js's UnhandledPromiseRejectionWarning.
+    // This does not suppress any error messages.
+    contractCode.catch(() => {});
 
     // Next, execute the contract code, passing in zcf
-    const { creatorFacet, publicFacet, creatorInvitation } = await E(
-      contractCode,
-    ).start(zcf);
-
     /** @type {Promise<ExecuteContractResult>} */
-    return harden({
-      creatorFacet,
-      publicFacet,
-      creatorInvitation,
-      addSeatObj,
-    });
+    const result = E(contractCode)
+      .start(zcf)
+      .then(({ creatorFacet, publicFacet, creatorInvitation }) => {
+        return harden({
+          creatorFacet,
+          publicFacet,
+          creatorInvitation,
+          addSeatObj,
+        });
+      });
+    // Don't trigger Node.js's UnhandledPromiseRejectionWarning.
+    // This does not suppress any error messages.
+    result.catch(() => {});
+    return result;
   };
 
   return harden({ executeContract });

--- a/packages/zoe/src/contractFacet/evalContractCode.js
+++ b/packages/zoe/src/contractFacet/evalContractCode.js
@@ -26,10 +26,9 @@ const evalContractBundle = (bundle, additionalEndowments = {}) => {
   const installation = importBundle(bundle, {
     endowments: fullEndowments,
   });
-  installation.catch(err => {
-    // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
-    throw err;
-  });
+  // Don't trigger Node.js's UnhandledPromiseRejectionWarning.
+  // This does not suppress any error messages.
+  installation.catch(() => {});
   return installation;
 };
 

--- a/packages/zoe/src/contractFacet/fakeVatAdmin.js
+++ b/packages/zoe/src/contractFacet/fakeVatAdmin.js
@@ -38,10 +38,9 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
         adminNode: {
           done: () => {
             const kit = makePromiseKit();
-            kit.promise.catch(err => {
-              // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
-              throw err;
-            });
+            // Don't trigger Node.js's UnhandledPromiseRejectionWarning.
+            // This does not suppress any error messages.
+            kit.promise.catch(_ => {});
             return kit.promise;
           },
           terminateWithFailure: () => {},

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -213,15 +213,13 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
 
       const bundle = installation.getBundle();
       const addSeatObjPromiseKit = makePromiseKit();
-      addSeatObjPromiseKit.promise.catch(err => {
-        // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
-        throw err;
-      });
+      // Don't trigger Node.js's UnhandledPromiseRejectionWarning.
+      // This does not suppress any error messages.
+      addSeatObjPromiseKit.promise.catch(_ => {});
       const publicFacetPromiseKit = makePromiseKit();
-      publicFacetPromiseKit.promise.catch(err => {
-        // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
-        throw err;
-      });
+      // Don't trigger Node.js's UnhandledPromiseRejectionWarning.
+      // This does not suppress any error messages.
+      publicFacetPromiseKit.promise.catch(_ => {});
 
       const makeInstanceAdmin = () => {
         /** @type {Set<ZoeSeatAdmin>} */
@@ -436,14 +434,13 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
             );
 
             const offerResultPromiseKit = makePromiseKit();
-            offerResultPromiseKit.promise.catch(_err => {
-              // Error suppressed to not trigger Node.js's UnhandledPromiseRejectionWarning
-            });
+            // Don't trigger Node.js's UnhandledPromiseRejectionWarning.
+            // This does not suppress any error messages.
+            offerResultPromiseKit.promise.catch(_ => {});
             const exitObjPromiseKit = makePromiseKit();
-            exitObjPromiseKit.promise.catch(err => {
-              // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
-              throw err;
-            });
+            // Don't trigger Node.js's UnhandledPromiseRejectionWarning.
+            // This does not suppress any error messages.
+            exitObjPromiseKit.promise.catch(_ => {});
             const seatHandle = makeHandle('SeatHandle');
 
             const { userSeat, notifier, zoeSeatAdmin } = makeZoeSeatAdminKit(
@@ -471,10 +468,9 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
                 offerResultPromiseKit.resolve(offerResultP);
                 exitObjPromiseKit.resolve(exitObj);
               })
-              .catch(err => {
-                // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
-                throw err;
-              });
+              // Don't trigger Node.js's UnhandledPromiseRejectionWarning.
+              // This does not suppress any error messages.
+              .catch(() => {});
 
             return userSeat;
           });

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -31,10 +31,9 @@ export const makeZoeSeatAdminKit = (
   offerResult,
 ) => {
   const payoutPromiseKit = makePromiseKit();
-  payoutPromiseKit.promise.catch(err => {
-    // Remove to suppress Node.js's UnhandledPromiseRejectionWarning
-    throw err;
-  });
+  // Don't trigger Node.js's UnhandledPromiseRejectionWarning.
+  // This does not suppress any error messages.
+  payoutPromiseKit.promise.catch(_ => {});
   const { notifier, updater } = makeNotifierKit();
 
   let currentAllocation = initialAllocation;

--- a/packages/zoe/test/unitTests/contracts/test-throwInOfferHandler.js
+++ b/packages/zoe/test/unitTests/contracts/test-throwInOfferHandler.js
@@ -31,7 +31,14 @@ test('throw in offerHandler', async t => {
 
   const throwsInOfferHandlerSeat = E(zoe).offer(throwInOfferHandlerInvitation);
 
-  await t.throwsAsync(() => E(throwsInOfferHandlerSeat).getOfferResult(), {
+  const throwsInOfferHandlerResult = E(
+    throwsInOfferHandlerSeat,
+  ).getOfferResult();
+
+  // Uncomment below to see what the user would see
+  // await throwsInOfferHandlerResult;
+
+  await t.throwsAsync(() => throwsInOfferHandlerResult, {
     message: 'error thrown in offerHandler in contract',
   });
 
@@ -39,7 +46,35 @@ test('throw in offerHandler', async t => {
     throwInDepositToSeatInvitation,
   );
 
-  await t.throwsAsync(() => E(throwsInDepositToSeatSeat).getOfferResult(), {
+  const throwsInDepositToSeatResult = E(
+    throwsInDepositToSeatSeat,
+  ).getOfferResult();
+
+  // Uncomment below to see what the user would see
+  // await throwsInDepositToSeatResult;
+
+  // TODO: make this logging more informative, including information
+  // about the error originating in the offerHandler in depositToSeat
+
+  // Currently the entirety of the log is:
+
+  // "Rejected promise returned by test. Reason:
+  // Error {
+  //   message: '"brand" not found: (an object)',
+  // }
+  // › makeDetailedError (/Users/katesills/code/agoric-sdk/node_modules/ses/dist/ses.cjs:3437:17)
+  // › fail (/Users/katesills/code/agoric-sdk/node_modules/ses/dist/ses.cjs:3582:19)
+  // › baseAssert (/Users/katesills/code/agoric-sdk/node_modules/ses/dist/ses.cjs:3600:13)
+  // › assertKeyExists (/Users/katesills/code/agoric-sdk/packages/store/src/weak-store.js:19:5)
+  // › Object.get [as getByBrand] (/Users/katesills/code/agoric-sdk/packages/store/src/weak-store.js:27:7)
+  // › getAmountMath (src/zoeService/zoe.js:44:46)
+  // › src/cleanProposal.js:65:5
+  // › Array.map (<anonymous>)
+  // › coerceAmountKeywordRecord (src/cleanProposal.js:64:34)
+  // › cleanProposal (src/cleanProposal.js:116:10)
+  // › src/zoeService/zoe.js:408:28"
+
+  await t.throwsAsync(() => throwsInDepositToSeatResult, {
     message: `"brand" not found: (an object)`,
   });
 });


### PR DESCRIPTION
@erights helped @Chris-Hibbert  and I understand that adding `catch` to a promise alone cannot suppress any error messages unless it is `promise.catch(...` that is returned.

This means that my previous PR #2025 was the wrong fix, and we were in a safe position previously.

This PR reverts #2025. It also adds more comments to make the above point more clearly. And, it retains a test that #2025 added. 

@erights, PTAL at `test-throwInOfferHandler.js` line 56. It shows what the user sees when `depositToSeat` fails. The user doesn't see any information about `depositToSeat` and the error stack stops at within the `offer` call. I think this is a good start at reproducing the issue that Chris experienced. If I recall correctly, his error was even worse, so I will work on reproducing that as well.