### PR TITLE
WIP Correlate sent errors with received errors.

### DIFF
--- a/packages/SwingSet/test/test-exomessages.js
+++ b/packages/SwingSet/test/test-exomessages.js
@@ -58,13 +58,14 @@ async function testFailure(t) {
     failureHappened = true;
     t.is(
       e.message,
-      'kernel panic kp40.policy panic: rejection {"body":"{\\"@qclass\\":\\"error\\",\\"name\\":\\"Error\\",\\"message\\":\\"gratuitous error\\"}","slots":[]}',
+      'kernel panic kp40.policy panic: rejection {"body":"{\\"@qclass\\":\\"error\\",\\"name\\":\\"Error\\",\\"message\\":\\"gratuitous error\\",\\"errorId\\":\\"error#1\\"}","slots":[]}',
     );
   }
   t.truthy(failureHappened);
   t.is(controller.kpStatus(controller.bootstrapResult), 'rejected');
   t.deepEqual(controller.kpResolution(controller.bootstrapResult), {
-    body: '{"@qclass":"error","name":"Error","message":"gratuitous error"}',
+    body:
+      '{"@qclass":"error","name":"Error","message":"gratuitous error","errorId":"error#1"}',
     slots: [],
   });
 }
@@ -122,7 +123,7 @@ test('extra message rejects', async t => {
     t,
     'reject',
     'rejected',
-    '{"@qclass":"error","name":"Error","message":"gratuitous error"}',
+    '{"@qclass":"error","name":"Error","message":"gratuitous error","errorId":"error#1"}',
     [],
   );
 });

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -601,8 +601,8 @@ export function makeMarshal(
               // TODO in order to reliably correlate sent and received errors
               // we will need something more globally identufying than the count
               // relative to this marshal instance.
-              const errorId = `${errorCount}`;
-              assert.note(val, d`sent as error#${errorId}`);
+              const errorId = `error#${errorCount}`;
+              assert.note(val, d`Sent as ${errorId}`);
               // TODO we need to instead log to somewhere hidden
               // to be revealed when correlating with the received error.
               console.error('Temporary logging of sent error', val);
@@ -738,7 +738,8 @@ export function makeMarshal(
             const error = harden(new EC(`${rawTree.message}`));
             ibidTable.register(error);
             if (typeof rawTree.errorId === 'string') {
-              assert.note(error, d`received as error#${rawTree.errorId}`);
+              // errorId is a late addition so be tolerant of its absence.
+              assert.note(error, d`Received as ${rawTree.errorId}`);
             }
             return error;
           }

--- a/packages/marshal/test/test-marshal.js
+++ b/packages/marshal/test/test-marshal.js
@@ -72,7 +72,7 @@ test('serialize static data', t => {
     emptyem = harden(e);
   }
   t.deepEqual(ser(emptyem), {
-    body: '{"@qclass":"error","name":"Error","message":""}',
+    body: '{"@qclass":"error","name":"Error","message":"","errorId":"error#1"}',
     slots: [],
   });
 
@@ -83,7 +83,8 @@ test('serialize static data', t => {
     em = harden(e);
   }
   t.deepEqual(ser(em), {
-    body: '{"@qclass":"error","name":"ReferenceError","message":"msg"}',
+    body:
+      '{"@qclass":"error","name":"ReferenceError","message":"msg","errorId":"error#2"}',
     slots: [],
   });
 


### PR DESCRIPTION
This is a delta to the hackathon branch as a temporary approximation of a future change.

When sending errors over marshal, generate an errorId to uniquely identify this error sending and use `assert.note` to associate that errorId with both the error as sent and the copy of that error as received. Somehow remember the association of that errorId with the sent error so that the sent error's hidden debug information --- details and stack trace --- can be correlated with the received error, should the received error be reported.

As a temporary stopgap for the hackathon, this PR takes the following shortcuts:
   * Rather than use some internal log or bookkeeping mechanism to associate the errorId with the sent error, just log the sent error to the console, so the association gets printed to the log. This is adequate but painful for human eyeballs for find the association. It is not suitable for a Causeway-like automated tool to stitch together the distributed causality graph.
   * The errorId is not very unique. We're currently only using increasing counts relative to a marshal instance.

This is currently a WIP Draft because it does not yet have new tests for this functionality.