### PR TITLE
fix: Dependency checker yarn argument order

### DIFF
--- a/scripts/check-mismatched-dependencies.js
+++ b/scripts/check-mismatched-dependencies.js
@@ -2,7 +2,7 @@
 
 const { spawnSync } = require('child_process');
 console.log(`running 'yarn workspaces info' to check for mismatched dependencies`);
-const s = spawnSync('yarn', ['workspaces', 'info', '--silent'], {
+const s = spawnSync('yarn', ['--silent', 'workspaces', 'info'], {
   stdio: ['ignore', 'pipe', 'inherit']
 });
 if (s.status !== 0) {


### PR DESCRIPTION
`yarn check-dependencies` consistently failed for me locally because I could find no version of `yarn` where the `--silent` suffix actually suppressed the yarn log messages. By adjusting the argument order, I was able to get it working locally.