### PR TITLE
style: Regularize lint

### DIFF
--- a/eslint-config-template.json
+++ b/eslint-config-template.json
@@ -1,0 +1,66 @@
+{
+  "extends": [
+    "airbnb-base",
+    "plugin:prettier/recommended",
+    "plugin:jsdoc/recommended"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "env": {
+    "es6": true
+  },
+  "globals": {
+    "globalThis": "readonly",
+    "BigInt": "readonly",
+    "assert": "readonly",
+    "harden": "readonly",
+    "lockdown": "readonly",
+    "Compartment": "readonly",
+    "StaticModuleRecord": "readonly"
+  },
+  "rules": {
+    "implicit-arrow-linebreak": "off",
+    "function-paren-newline": "off",
+    "arrow-parens": "off",
+    "strict": "off",
+    "prefer-destructuring": "off",
+    "no-else-return": "off",
+    "no-console": "off",
+    "no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_"
+      }
+    ],
+    "no-return-assign": "off",
+    "no-param-reassign": "off",
+    "no-restricted-syntax": [
+      "off",
+      "ForOfStatement"
+    ],
+    "no-unused-expressions": "off",
+    "no-loop-func": "off",
+    "no-inner-declarations": "off",
+    "import/extensions": "off",
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        "devDependencies": [
+          "rollup.config.js",
+          "test/**/*.js",
+          "scripts/**/*.js"
+        ]
+      }
+    ],
+    "import/prefer-default-export": "off",
+    "jsdoc/no-undefined-types": "off",
+    "jsdoc/require-jsdoc": "off",
+    "jsdoc/require-property-description": "off",
+    "jsdoc/require-param-description": "off",
+    "jsdoc/require-returns": "off",
+    "jsdoc/require-returns-description": "off"
+  },
+  "ignorePatterns": [
+    "**/dist/**"
+  ]
+}

--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -84,7 +84,13 @@
       "es6": true
     },
     "globals": {
-      "harden": "readonly"
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
     },
     "rules": {
       "implicit-arrow-linebreak": "off",
@@ -110,6 +116,17 @@
       "no-unused-expressions": "off",
       "no-loop-func": "off",
       "no-inner-declarations": "off",
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
       "import/prefer-default-export": "off",
       "jsdoc/no-undefined-types": "off",
       "jsdoc/require-jsdoc": "off",
@@ -117,7 +134,10 @@
       "jsdoc/require-param-description": "off",
       "jsdoc/require-returns": "off",
       "jsdoc/require-returns-description": "off"
-    }
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   },
   "prettier": {
     "trailingComma": "all",

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -86,7 +86,13 @@
       "es6": true
     },
     "globals": {
-      "harden": "readonly"
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
     },
     "rules": {
       "implicit-arrow-linebreak": "off",
@@ -112,6 +118,17 @@
       "no-unused-expressions": "off",
       "no-loop-func": "off",
       "no-inner-declarations": "off",
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
       "import/prefer-default-export": "off",
       "jsdoc/no-undefined-types": "off",
       "jsdoc/require-jsdoc": "off",
@@ -119,7 +136,10 @@
       "jsdoc/require-param-description": "off",
       "jsdoc/require-returns": "off",
       "jsdoc/require-returns-description": "off"
-    }
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   },
   "publishConfig": {
     "access": "public"

--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -1,5 +1,3 @@
-/* global Compartment */
-
 import fs from 'fs';
 import path from 'path';
 import process from 'process';

--- a/packages/SwingSet/src/weakref.js
+++ b/packages/SwingSet/src/weakref.js
@@ -1,5 +1,3 @@
-/* global globalThis */
-
 import { assert, details as d } from '@agoric/assert';
 
 const { defineProperties } = Object;

--- a/packages/acorn-eventual-send/package.json
+++ b/packages/acorn-eventual-send/package.json
@@ -43,5 +43,71 @@
     "require": [
       "esm"
     ]
+  },
+  "eslintConfig": {
+    "extends": [
+      "airbnb-base",
+      "plugin:prettier/recommended",
+      "plugin:jsdoc/recommended"
+    ],
+    "parser": "@typescript-eslint/parser",
+    "env": {
+      "es6": true
+    },
+    "globals": {
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
+    },
+    "rules": {
+      "implicit-arrow-linebreak": "off",
+      "function-paren-newline": "off",
+      "arrow-parens": "off",
+      "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
+      "no-console": "off",
+      "no-unused-vars": [
+        "error",
+        {
+          "argsIgnorePattern": "^_",
+          "varsIgnorePattern": "^_"
+        }
+      ],
+      "no-return-assign": "off",
+      "no-param-reassign": "off",
+      "no-restricted-syntax": [
+        "off",
+        "ForOfStatement"
+      ],
+      "no-unused-expressions": "off",
+      "no-loop-func": "off",
+      "no-inner-declarations": "off",
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
+      "import/prefer-default-export": "off",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/require-jsdoc": "off",
+      "jsdoc/require-property-description": "off",
+      "jsdoc/require-param-description": "off",
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off"
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   }
 }

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -50,5 +50,71 @@
   "bugs": {
     "url": "https://github.com/Agoric/agoric/agoric-sdk"
   },
-  "homepage": "https://github.com/Agoric/agoric-sdk#readme"
+  "homepage": "https://github.com/Agoric/agoric-sdk#readme",
+  "eslintConfig": {
+    "extends": [
+      "airbnb-base",
+      "plugin:prettier/recommended",
+      "plugin:jsdoc/recommended"
+    ],
+    "parser": "@typescript-eslint/parser",
+    "env": {
+      "es6": true
+    },
+    "globals": {
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
+    },
+    "rules": {
+      "implicit-arrow-linebreak": "off",
+      "function-paren-newline": "off",
+      "arrow-parens": "off",
+      "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
+      "no-console": "off",
+      "no-unused-vars": [
+        "error",
+        {
+          "argsIgnorePattern": "^_",
+          "varsIgnorePattern": "^_"
+        }
+      ],
+      "no-return-assign": "off",
+      "no-param-reassign": "off",
+      "no-restricted-syntax": [
+        "off",
+        "ForOfStatement"
+      ],
+      "no-unused-expressions": "off",
+      "no-loop-func": "off",
+      "no-inner-declarations": "off",
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
+      "import/prefer-default-export": "off",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/require-jsdoc": "off",
+      "jsdoc/require-property-description": "off",
+      "jsdoc/require-param-description": "off",
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off"
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
+  }
 }

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -64,7 +64,13 @@
       "es6": true
     },
     "globals": {
-      "harden": "readonly"
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
     },
     "rules": {
       "implicit-arrow-linebreak": "off",
@@ -90,15 +96,28 @@
       "no-unused-expressions": "off",
       "no-loop-func": "off",
       "no-inner-declarations": "off",
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
       "import/prefer-default-export": "off",
-      "import/no-extraneous-dependencies": "off",
       "jsdoc/no-undefined-types": "off",
       "jsdoc/require-jsdoc": "off",
       "jsdoc/require-property-description": "off",
       "jsdoc/require-param-description": "off",
       "jsdoc/require-returns": "off",
       "jsdoc/require-returns-description": "off"
-    }
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   },
   "eslintIgnore": [
     "bundle-*.js"

--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -1,5 +1,4 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
-/* global globalThis */
 // @ts-check
 
 // This module assumes the existence of a non-standard `assert` host object.

--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -59,10 +59,21 @@
   "eslintConfig": {
     "extends": [
       "airbnb-base",
-      "plugin:prettier/recommended"
+      "plugin:prettier/recommended",
+      "plugin:jsdoc/recommended"
     ],
+    "parser": "@typescript-eslint/parser",
     "env": {
       "es6": true
+    },
+    "globals": {
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
     },
     "rules": {
       "implicit-arrow-linebreak": "off",
@@ -88,8 +99,24 @@
       "no-unused-expressions": "off",
       "no-loop-func": "off",
       "no-inner-declarations": "off",
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
       "import/prefer-default-export": "off",
-      "import/extensions": "off"
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/require-jsdoc": "off",
+      "jsdoc/require-property-description": "off",
+      "jsdoc/require-param-description": "off",
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off"
     },
     "ignorePatterns": [
       "**/dist/**"

--- a/packages/base64/src/main.js
+++ b/packages/base64/src/main.js
@@ -10,6 +10,7 @@ const alphabet64 =
  * The numeric value corresponding to each letter of the alphabet.
  * If an alphabet is named for the Greek letters alpha and beta, then clearly a
  * monodu is named for the corresponding Greek numbers mono and duo.
+ *
  * @type {Record<string, number>}
  */
 const monodu64 = {};

--- a/packages/base64/test/bench-main.js
+++ b/packages/base64/test/bench-main.js
@@ -1,4 +1,4 @@
-import { encodeBase64, decodeBase64 } from '../src/main.js';
+import { encodeBase64, decodeBase64 } from '../src/main';
 
 const string = new Array(100)
   .fill(

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -59,5 +59,71 @@
     "require": [
       "esm"
     ]
+  },
+  "eslintConfig": {
+    "extends": [
+      "airbnb-base",
+      "plugin:prettier/recommended",
+      "plugin:jsdoc/recommended"
+    ],
+    "parser": "@typescript-eslint/parser",
+    "env": {
+      "es6": true
+    },
+    "globals": {
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
+    },
+    "rules": {
+      "implicit-arrow-linebreak": "off",
+      "function-paren-newline": "off",
+      "arrow-parens": "off",
+      "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
+      "no-console": "off",
+      "no-unused-vars": [
+        "error",
+        {
+          "argsIgnorePattern": "^_",
+          "varsIgnorePattern": "^_"
+        }
+      ],
+      "no-return-assign": "off",
+      "no-param-reassign": "off",
+      "no-restricted-syntax": [
+        "off",
+        "ForOfStatement"
+      ],
+      "no-unused-expressions": "off",
+      "no-loop-func": "off",
+      "no-inner-declarations": "off",
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
+      "import/prefer-default-export": "off",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/require-jsdoc": "off",
+      "jsdoc/require-property-description": "off",
+      "jsdoc/require-param-description": "off",
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off"
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   }
 }

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -61,5 +61,71 @@
       "esm"
     ],
     "timeout": "2m"
+  },
+  "eslintConfig": {
+    "extends": [
+      "airbnb-base",
+      "plugin:prettier/recommended",
+      "plugin:jsdoc/recommended"
+    ],
+    "parser": "@typescript-eslint/parser",
+    "env": {
+      "es6": true
+    },
+    "globals": {
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
+    },
+    "rules": {
+      "implicit-arrow-linebreak": "off",
+      "function-paren-newline": "off",
+      "arrow-parens": "off",
+      "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
+      "no-console": "off",
+      "no-unused-vars": [
+        "error",
+        {
+          "argsIgnorePattern": "^_",
+          "varsIgnorePattern": "^_"
+        }
+      ],
+      "no-return-assign": "off",
+      "no-param-reassign": "off",
+      "no-restricted-syntax": [
+        "off",
+        "ForOfStatement"
+      ],
+      "no-unused-expressions": "off",
+      "no-loop-func": "off",
+      "no-inner-declarations": "off",
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
+      "import/prefer-default-export": "off",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/require-jsdoc": "off",
+      "jsdoc/require-property-description": "off",
+      "jsdoc/require-param-description": "off",
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off"
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   }
 }

--- a/packages/cosmic-swingset/lib/ag-solo/vats/lib-board.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/lib-board.js
@@ -53,7 +53,7 @@ function makeBoard(seed = 0) {
         // Retry until we have a unique id.
         let id;
         do {
-          const num = sparseInts.next().value;
+          const num = /** @type {number} */ (sparseInts.next().value);
           id = `${num}${calcCrc(num)}`;
         } while (idToVal.has(id));
 

--- a/packages/cosmic-swingset/lib/ag-solo/vats/repl.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/repl.js
@@ -1,5 +1,3 @@
-/* global Compartment */
-
 import { isPromise } from '@agoric/promise-kit';
 import { E } from '@agoric/eventual-send';
 

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -87,7 +87,13 @@
       "es6": true
     },
     "globals": {
-      "harden": "readonly"
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
     },
     "rules": {
       "implicit-arrow-linebreak": "off",
@@ -113,6 +119,17 @@
       "no-unused-expressions": "off",
       "no-loop-func": "off",
       "no-inner-declarations": "off",
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
       "import/prefer-default-export": "off",
       "jsdoc/no-undefined-types": "off",
       "jsdoc/require-jsdoc": "off",
@@ -120,7 +137,10 @@
       "jsdoc/require-param-description": "off",
       "jsdoc/require-returns": "off",
       "jsdoc/require-returns-description": "off"
-    }
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   },
   "publishConfig": {
     "access": "public"

--- a/packages/dapp-svelte-wallet/package.json
+++ b/packages/dapp-svelte-wallet/package.json
@@ -38,5 +38,71 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "eslintConfig": {
+    "extends": [
+      "airbnb-base",
+      "plugin:prettier/recommended",
+      "plugin:jsdoc/recommended"
+    ],
+    "parser": "@typescript-eslint/parser",
+    "env": {
+      "es6": true
+    },
+    "globals": {
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
+    },
+    "rules": {
+      "implicit-arrow-linebreak": "off",
+      "function-paren-newline": "off",
+      "arrow-parens": "off",
+      "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
+      "no-console": "off",
+      "no-unused-vars": [
+        "error",
+        {
+          "argsIgnorePattern": "^_",
+          "varsIgnorePattern": "^_"
+        }
+      ],
+      "no-return-assign": "off",
+      "no-param-reassign": "off",
+      "no-restricted-syntax": [
+        "off",
+        "ForOfStatement"
+      ],
+      "no-unused-expressions": "off",
+      "no-loop-func": "off",
+      "no-inner-declarations": "off",
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
+      "import/prefer-default-export": "off",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/require-jsdoc": "off",
+      "jsdoc/require-property-description": "off",
+      "jsdoc/require-param-description": "off",
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off"
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   }
 }

--- a/packages/deployment/package.json
+++ b/packages/deployment/package.json
@@ -26,5 +26,71 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "eslintConfig": {
+    "extends": [
+      "airbnb-base",
+      "plugin:prettier/recommended",
+      "plugin:jsdoc/recommended"
+    ],
+    "parser": "@typescript-eslint/parser",
+    "env": {
+      "es6": true
+    },
+    "globals": {
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
+    },
+    "rules": {
+      "implicit-arrow-linebreak": "off",
+      "function-paren-newline": "off",
+      "arrow-parens": "off",
+      "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
+      "no-console": "off",
+      "no-unused-vars": [
+        "error",
+        {
+          "argsIgnorePattern": "^_",
+          "varsIgnorePattern": "^_"
+        }
+      ],
+      "no-return-assign": "off",
+      "no-param-reassign": "off",
+      "no-restricted-syntax": [
+        "off",
+        "ForOfStatement"
+      ],
+      "no-unused-expressions": "off",
+      "no-loop-func": "off",
+      "no-inner-declarations": "off",
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
+      "import/prefer-default-export": "off",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/require-jsdoc": "off",
+      "jsdoc/require-property-description": "off",
+      "jsdoc/require-param-description": "off",
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off"
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   }
 }

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -44,10 +44,21 @@
   "eslintConfig": {
     "extends": [
       "airbnb-base",
-      "plugin:prettier/recommended"
+      "plugin:prettier/recommended",
+      "plugin:jsdoc/recommended"
     ],
+    "parser": "@typescript-eslint/parser",
     "env": {
       "es6": true
+    },
+    "globals": {
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
     },
     "rules": {
       "implicit-arrow-linebreak": "off",
@@ -73,9 +84,28 @@
       "no-unused-expressions": "off",
       "no-loop-func": "off",
       "no-inner-declarations": "off",
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
       "import/prefer-default-export": "off",
-      "import/extensions": "off"
-    }
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/require-jsdoc": "off",
+      "jsdoc/require-property-description": "off",
+      "jsdoc/require-param-description": "off",
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off"
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   },
   "prettier": {
     "trailingComma": "all",

--- a/packages/eventual-send/shim.js
+++ b/packages/eventual-send/shim.js
@@ -1,5 +1,3 @@
-/* global globalThis */
-
 import { makeHandledPromise } from './src/index';
 
 if (typeof HandledPromise === 'undefined') {

--- a/packages/eventual-send/src/E.js
+++ b/packages/eventual-send/src/E.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { trackTurns } from './track-turns';
 
 // eslint-disable-next-line spaced-comment
@@ -24,6 +22,7 @@ const readOnlyProxyHandler = {
  * A Proxy handler for E(x).
  *
  * @param {*} x Any value passed to E(x)
+ * @param {*} HandledPromise
  * @returns {ProxyHandler} the Proxy handler
  */
 function EProxyHandler(x, HandledPromise) {
@@ -52,6 +51,7 @@ function EProxyHandler(x, HandledPromise) {
  * For now it is just a variant on the E(x) Proxy handler.
  *
  * @param {*} x Any value passed to E.sendOnly(x)
+ * @param {*} HandledPromise
  * @returns {ProxyHandler} the Proxy handler
  */
 function EsendOnlyProxyHandler(x, HandledPromise) {

--- a/packages/eventual-send/src/index.js
+++ b/packages/eventual-send/src/index.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { trackTurns } from './track-turns';
 
 const {
@@ -26,7 +24,7 @@ const q = JSON.stringify;
  * Original spec for the infix-bang (predecessor to wavy-dot) desugaring:
  * https://web.archive.org/web/20161026162206/http://wiki.ecmascript.org/doku.php?id=strawman:concurrency
  *
- * @return {typeof HandledPromise} Handled promise
+ * @returns {typeof HandledPromise} Handled promise
  */
 export function makeHandledPromise() {
   // xs doesn't support WeakMap in pre-loaded closures

--- a/packages/eventual-send/src/track-turns.js
+++ b/packages/eventual-send/src/track-turns.js
@@ -1,5 +1,4 @@
 // @ts-nocheck
-/* global assert globalThis */
 
 // NOTE: We can't import these because they're not in scope before lockdown.
 // import { assert, details as d } from '@agoric/assert';

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -47,10 +47,21 @@
   "eslintConfig": {
     "extends": [
       "airbnb-base",
-      "plugin:prettier/recommended"
+      "plugin:prettier/recommended",
+      "plugin:jsdoc/recommended"
     ],
+    "parser": "@typescript-eslint/parser",
     "env": {
       "es6": true
+    },
+    "globals": {
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
     },
     "rules": {
       "implicit-arrow-linebreak": "off",
@@ -76,9 +87,28 @@
       "no-unused-expressions": "off",
       "no-loop-func": "off",
       "no-inner-declarations": "off",
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
       "import/prefer-default-export": "off",
-      "import/extensions": "off"
-    }
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/require-jsdoc": "off",
+      "jsdoc/require-property-description": "off",
+      "jsdoc/require-param-description": "off",
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off"
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   },
   "prettier": {
     "trailingComma": "all",

--- a/packages/import-bundle/src/index.js
+++ b/packages/import-bundle/src/index.js
@@ -1,4 +1,3 @@
-/* global harden Compartment */
 import { parseArchive } from '@agoric/compartment-mapper';
 import { decodeBase64 } from '@agoric/base64';
 import { wrapInescapableCompartment } from './compartment-wrapper';

--- a/packages/import-bundle/test/bundle1.js
+++ b/packages/import-bundle/test/bundle1.js
@@ -1,4 +1,4 @@
-/* global globalThis endow1 */
+/* global endow1 */
 
 import { bundle2Add, bundle2Transform, bundle2ReadGlobal } from './bundle2.js';
 

--- a/packages/import-bundle/test/bundle2.js
+++ b/packages/import-bundle/test/bundle2.js
@@ -1,5 +1,3 @@
-/* global globalThis */
-
 export function bundle2Add(a) {
   return a + 2;
 }

--- a/packages/import-bundle/test/test-compartment-wrapper.js
+++ b/packages/import-bundle/test/test-compartment-wrapper.js
@@ -1,4 +1,3 @@
-/* global Compartment */
 import '@agoric/install-ses';
 import test from 'ava';
 import { wrapInescapableCompartment } from '../src/compartment-wrapper.js';

--- a/packages/import-bundle/test/test-import-bundle.js
+++ b/packages/import-bundle/test/test-import-bundle.js
@@ -1,4 +1,3 @@
-/* global harden */
 import '@agoric/install-ses';
 import { encodeBase64 } from '@agoric/base64';
 import * as fs from 'fs';

--- a/packages/import-manager/package.json
+++ b/packages/import-manager/package.json
@@ -51,10 +51,21 @@
   "eslintConfig": {
     "extends": [
       "airbnb-base",
-      "plugin:prettier/recommended"
+      "plugin:prettier/recommended",
+      "plugin:jsdoc/recommended"
     ],
+    "parser": "@typescript-eslint/parser",
     "env": {
       "es6": true
+    },
+    "globals": {
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
     },
     "rules": {
       "implicit-arrow-linebreak": "off",
@@ -80,8 +91,28 @@
       "no-unused-expressions": "off",
       "no-loop-func": "off",
       "no-inner-declarations": "off",
-      "import/prefer-default-export": "off"
-    }
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
+      "import/prefer-default-export": "off",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/require-jsdoc": "off",
+      "jsdoc/require-property-description": "off",
+      "jsdoc/require-param-description": "off",
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off"
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   },
   "eslintIgnore": [
     "bundle-*.js"

--- a/packages/import-manager/src/importManager.js
+++ b/packages/import-manager/src/importManager.js
@@ -1,7 +1,5 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
-/* global harden */
-
 /**
  * ImportManager allows a package to make some code available that can be run
  * locally by a calling vat without requiring a remote round trip to the hosting

--- a/packages/install-metering-and-ses/package.json
+++ b/packages/install-metering-and-ses/package.json
@@ -39,10 +39,21 @@
   "eslintConfig": {
     "extends": [
       "airbnb-base",
-      "plugin:prettier/recommended"
+      "plugin:prettier/recommended",
+      "plugin:jsdoc/recommended"
     ],
+    "parser": "@typescript-eslint/parser",
     "env": {
       "es6": true
+    },
+    "globals": {
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
     },
     "rules": {
       "implicit-arrow-linebreak": "off",
@@ -68,8 +79,28 @@
       "no-unused-expressions": "off",
       "no-loop-func": "off",
       "no-inner-declarations": "off",
-      "import/prefer-default-export": "off"
-    }
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
+      "import/prefer-default-export": "off",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/require-jsdoc": "off",
+      "jsdoc/require-property-description": "off",
+      "jsdoc/require-param-description": "off",
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off"
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   },
   "eslintIgnore": [
     "bundle-*.js"

--- a/packages/install-metering-and-ses/test/test-install-metering-and-ses.js
+++ b/packages/install-metering-and-ses/test/test-install-metering-and-ses.js
@@ -1,4 +1,3 @@
-/* global Compartment harden */
 import '../install-metering-and-ses';
 import test from 'ava';
 import { makeMeter } from '@agoric/transform-metering';

--- a/packages/install-ses/install-ses.js
+++ b/packages/install-ses/install-ses.js
@@ -1,5 +1,3 @@
-/* global lockdown, harden */
-
 // 'lockdown' appears on the global as a side-effect of importing 'ses'
 import 'ses';
 

--- a/packages/install-ses/package.json
+++ b/packages/install-ses/package.json
@@ -45,10 +45,21 @@
   "eslintConfig": {
     "extends": [
       "airbnb-base",
-      "plugin:prettier/recommended"
+      "plugin:prettier/recommended",
+      "plugin:jsdoc/recommended"
     ],
+    "parser": "@typescript-eslint/parser",
     "env": {
       "es6": true
+    },
+    "globals": {
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
     },
     "rules": {
       "implicit-arrow-linebreak": "off",
@@ -74,8 +85,28 @@
       "no-unused-expressions": "off",
       "no-loop-func": "off",
       "no-inner-declarations": "off",
-      "import/prefer-default-export": "off"
-    }
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
+      "import/prefer-default-export": "off",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/require-jsdoc": "off",
+      "jsdoc/require-property-description": "off",
+      "jsdoc/require-param-description": "off",
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off"
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   },
   "eslintIgnore": [
     "bundle-*.js"

--- a/packages/install-ses/test/test-install-ses.js
+++ b/packages/install-ses/test/test-install-ses.js
@@ -1,4 +1,3 @@
-/* global Compartment harden */
 import '../install-ses';
 import test from 'ava';
 

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -62,7 +62,13 @@
       "es6": true
     },
     "globals": {
-      "harden": "readonly"
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
     },
     "rules": {
       "implicit-arrow-linebreak": "off",
@@ -88,15 +94,28 @@
       "no-unused-expressions": "off",
       "no-loop-func": "off",
       "no-inner-declarations": "off",
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
       "import/prefer-default-export": "off",
-      "import/no-extraneous-dependencies": "off",
       "jsdoc/no-undefined-types": "off",
       "jsdoc/require-jsdoc": "off",
       "jsdoc/require-property-description": "off",
       "jsdoc/require-param-description": "off",
       "jsdoc/require-returns": "off",
       "jsdoc/require-returns-description": "off"
-    }
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   },
   "publishConfig": {
     "access": "public"

--- a/packages/marshal/test/test-marshal.js
+++ b/packages/marshal/test/test-marshal.js
@@ -1,5 +1,3 @@
-/* global BigInt */
-
 import '@agoric/install-ses';
 import test from 'ava';
 import {

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -61,7 +61,13 @@
       "es6": true
     },
     "globals": {
-      "harden": "readonly"
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
     },
     "rules": {
       "implicit-arrow-linebreak": "off",
@@ -87,15 +93,28 @@
       "no-unused-expressions": "off",
       "no-loop-func": "off",
       "no-inner-declarations": "off",
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
       "import/prefer-default-export": "off",
-      "import/no-extraneous-dependencies": "off",
       "jsdoc/no-undefined-types": "off",
       "jsdoc/require-jsdoc": "off",
       "jsdoc/require-property-description": "off",
       "jsdoc/require-param-description": "off",
       "jsdoc/require-returns": "off",
       "jsdoc/require-returns-description": "off"
-    }
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   },
   "eslintIgnore": [
     "bundle-*.js"

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -55,6 +55,15 @@
     "env": {
       "es6": true
     },
+    "globals": {
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
+    },
     "rules": {
       "implicit-arrow-linebreak": "off",
       "function-paren-newline": "off",
@@ -79,15 +88,28 @@
       "no-unused-expressions": "off",
       "no-loop-func": "off",
       "no-inner-declarations": "off",
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
       "import/prefer-default-export": "off",
-      "import/no-extraneous-dependencies": "off",
       "jsdoc/no-undefined-types": "off",
       "jsdoc/require-jsdoc": "off",
       "jsdoc/require-property-description": "off",
       "jsdoc/require-param-description": "off",
       "jsdoc/require-returns": "off",
       "jsdoc/require-returns-description": "off"
-    }
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   },
   "eslintIgnore": [
     "bundle-*.js"

--- a/packages/promise-kit/src/promiseKit.js
+++ b/packages/promise-kit/src/promiseKit.js
@@ -1,4 +1,3 @@
-/* global harden globalThis */
 // @ts-check
 
 // eslint-disable-next-line spaced-comment

--- a/packages/registrar/package.json
+++ b/packages/registrar/package.json
@@ -46,10 +46,21 @@
   "eslintConfig": {
     "extends": [
       "airbnb-base",
-      "plugin:prettier/recommended"
+      "plugin:prettier/recommended",
+      "plugin:jsdoc/recommended"
     ],
+    "parser": "@typescript-eslint/parser",
     "env": {
       "es6": true
+    },
+    "globals": {
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
     },
     "rules": {
       "implicit-arrow-linebreak": "off",
@@ -75,8 +86,28 @@
       "no-unused-expressions": "off",
       "no-loop-func": "off",
       "no-inner-declarations": "off",
-      "import/prefer-default-export": "off"
-    }
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
+      "import/prefer-default-export": "off",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/require-jsdoc": "off",
+      "jsdoc/require-property-description": "off",
+      "jsdoc/require-param-description": "off",
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off"
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   },
   "eslintIgnore": [
     "bundle-*.js"

--- a/packages/registrar/src/registrar.js
+++ b/packages/registrar/src/registrar.js
@@ -1,7 +1,5 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
-/* global harden */
-
 import { generateSparseInts } from '@agoric/sparse-ints';
 import { assert, details } from '@agoric/assert';
 

--- a/packages/same-structure/package.json
+++ b/packages/same-structure/package.json
@@ -48,10 +48,21 @@
   "eslintConfig": {
     "extends": [
       "airbnb-base",
-      "plugin:prettier/recommended"
+      "plugin:prettier/recommended",
+      "plugin:jsdoc/recommended"
     ],
+    "parser": "@typescript-eslint/parser",
     "env": {
       "es6": true
+    },
+    "globals": {
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
     },
     "rules": {
       "implicit-arrow-linebreak": "off",
@@ -77,8 +88,28 @@
       "no-unused-expressions": "off",
       "no-loop-func": "off",
       "no-inner-declarations": "off",
-      "import/prefer-default-export": "off"
-    }
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
+      "import/prefer-default-export": "off",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/require-jsdoc": "off",
+      "jsdoc/require-property-description": "off",
+      "jsdoc/require-param-description": "off",
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off"
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   },
   "eslintIgnore": [
     "bundle-*.js"

--- a/packages/same-structure/src/sameStructure.js
+++ b/packages/same-structure/src/sameStructure.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 // @ts-check
 
 import { sameValueZero, passStyleOf, REMOTE_STYLE } from '@agoric/marshal';
@@ -46,10 +44,10 @@ function objectFromEntries(iter) {
  * potentially exponential cost, and cycles cause failure to
  * terminate. We must fix both problems, making all these algorithms
  * graph-aware.
-
+ *
  * We say that a function *reveals* an X when it returns either an X
  * or a promise for an X.
-
+ *
  * Given a passable, reveal a corresponding comparable, where each
  * leaf promise of the passable has been replaced with its
  * corresponding comparable.
@@ -251,6 +249,7 @@ function mustBeSameStructureInternal(left, right, message, path) {
 /**
  * @param {Comparable} left
  * @param {Comparable} right
+ * @param {string} message
  */
 function mustBeSameStructure(left, right, message) {
   mustBeSameStructureInternal(left, right, `${message}`, null);

--- a/packages/sharing-service/package.json
+++ b/packages/sharing-service/package.json
@@ -47,10 +47,21 @@
   "eslintConfig": {
     "extends": [
       "airbnb-base",
-      "plugin:prettier/recommended"
+      "plugin:prettier/recommended",
+      "plugin:jsdoc/recommended"
     ],
+    "parser": "@typescript-eslint/parser",
     "env": {
       "es6": true
+    },
+    "globals": {
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
     },
     "rules": {
       "implicit-arrow-linebreak": "off",
@@ -76,8 +87,28 @@
       "no-unused-expressions": "off",
       "no-loop-func": "off",
       "no-inner-declarations": "off",
-      "import/prefer-default-export": "off"
-    }
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
+      "import/prefer-default-export": "off",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/require-jsdoc": "off",
+      "jsdoc/require-property-description": "off",
+      "jsdoc/require-param-description": "off",
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off"
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   },
   "eslintIgnore": [
     "bundle-*.js"

--- a/packages/sharing-service/src/sharedMap.js
+++ b/packages/sharing-service/src/sharedMap.js
@@ -1,7 +1,5 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
-/* global harden */
-
 // Allows multiple parties to store values for retrieval by others.
 function makeSharedMap(name) {
   const namedEntries = new Map();

--- a/packages/sharing-service/src/sharing.js
+++ b/packages/sharing-service/src/sharing.js
@@ -1,7 +1,5 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
-/* global harden */
-
 import { assert, details } from '@agoric/assert';
 import { makeSharedMap } from './sharedMap';
 

--- a/packages/sharing-service/test/swingsetTests/sharingService/bootstrap.js
+++ b/packages/sharing-service/test/swingsetTests/sharingService/bootstrap.js
@@ -1,6 +1,5 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
-/* global harden */
 import { E } from '@agoric/eventual-send';
 import { makeSharedMap } from '../../../src/sharedMap';
 import { makeSharingService } from '../../../src/sharing';

--- a/packages/sharing-service/test/swingsetTests/sharingService/vat-alice.js
+++ b/packages/sharing-service/test/swingsetTests/sharingService/vat-alice.js
@@ -1,6 +1,5 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
-/* global harden */
 import { E } from '@agoric/eventual-send';
 
 function makeAliceMaker() {

--- a/packages/sharing-service/test/swingsetTests/sharingService/vat-bob.js
+++ b/packages/sharing-service/test/swingsetTests/sharingService/vat-bob.js
@@ -1,6 +1,5 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
-/* global harden */
 import { E } from '@agoric/eventual-send';
 
 function makeBobMaker() {

--- a/packages/sharing-service/test/swingsetTests/sharingService/vat-sharing.js
+++ b/packages/sharing-service/test/swingsetTests/sharingService/vat-sharing.js
@@ -1,7 +1,5 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
-/* global harden */
-
 import { makeSharingService } from '../../../src/sharing';
 
 export function buildRootObject(_vatPowers) {

--- a/packages/sparse-ints/package.json
+++ b/packages/sparse-ints/package.json
@@ -48,10 +48,21 @@
   "eslintConfig": {
     "extends": [
       "airbnb-base",
-      "plugin:prettier/recommended"
+      "plugin:prettier/recommended",
+      "plugin:jsdoc/recommended"
     ],
+    "parser": "@typescript-eslint/parser",
     "env": {
       "es6": true
+    },
+    "globals": {
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
     },
     "rules": {
       "implicit-arrow-linebreak": "off",
@@ -77,8 +88,28 @@
       "no-unused-expressions": "off",
       "no-loop-func": "off",
       "no-inner-declarations": "off",
-      "import/prefer-default-export": "off"
-    }
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
+      "import/prefer-default-export": "off",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/require-jsdoc": "off",
+      "jsdoc/require-property-description": "off",
+      "jsdoc/require-param-description": "off",
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off"
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   },
   "eslintIgnore": [
     "bundle-*.js"

--- a/packages/sparse-ints/src/sparseInts.js
+++ b/packages/sparse-ints/src/sparseInts.js
@@ -1,13 +1,13 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
-/* global harden */
-
 /**
  * Generator function to produce a stream of positive integers that are
  * sparsely scattered across the number space. This supports IDs that
  * are guessable, but for example mistyping a correct ID is unlikely to
  * mistakenly match another generated ID.
- * @returns {Generator<number, number, number>}
+ *
+ * @param {number} seed
+ * @yields {number}
  */
 function* generateSparseInts(seed) {
   // This is a linear-feedback shift register with computed startState.

--- a/packages/spawner/package.json
+++ b/packages/spawner/package.json
@@ -57,10 +57,21 @@
   "eslintConfig": {
     "extends": [
       "airbnb-base",
-      "plugin:prettier/recommended"
+      "plugin:prettier/recommended",
+      "plugin:jsdoc/recommended"
     ],
+    "parser": "@typescript-eslint/parser",
     "env": {
       "es6": true
+    },
+    "globals": {
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
     },
     "rules": {
       "implicit-arrow-linebreak": "off",
@@ -86,8 +97,28 @@
       "no-unused-expressions": "off",
       "no-loop-func": "off",
       "no-inner-declarations": "off",
-      "import/prefer-default-export": "off"
-    }
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
+      "import/prefer-default-export": "off",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/require-jsdoc": "off",
+      "jsdoc/require-property-description": "off",
+      "jsdoc/require-param-description": "off",
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off"
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   },
   "eslintIgnore": [
     "bundle-*.js"

--- a/packages/spawner/src/allSettled.js
+++ b/packages/spawner/src/allSettled.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { makePromiseKit } from '@agoric/promise-kit';
 
 // TODO Reconcile with spec of Promise.allSettled

--- a/packages/spawner/src/contractHost.js
+++ b/packages/spawner/src/contractHost.js
@@ -1,7 +1,5 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
-/* global harden */
-
 import { importBundle } from '@agoric/import-bundle';
 import { makeWeakStore } from '@agoric/store';
 import { assert, details } from '@agoric/assert';
@@ -10,7 +8,7 @@ import { makeIssuerKit } from '@agoric/ertp';
 
 export { makeCollect } from './makeCollect';
 
-/**
+/*
  * Make a reusable host that can reliably install and execute contracts.
  *
  * @param E eventual-send method proxy

--- a/packages/spawner/src/coveredCall.js
+++ b/packages/spawner/src/coveredCall.js
@@ -1,6 +1,6 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
-/* global harden E */
+/* global E */
 
 import { mustBeSameStructure, sameStructure } from '@agoric/same-structure';
 

--- a/packages/spawner/src/escrow.js
+++ b/packages/spawner/src/escrow.js
@@ -1,6 +1,6 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
-/* global harden E makePromiseKit */
+/* global E makePromiseKit */
 
 import { mustBeSameStructure } from '@agoric/same-structure';
 

--- a/packages/spawner/src/makeCollect.js
+++ b/packages/spawner/src/makeCollect.js
@@ -1,5 +1,3 @@
-/* global harden */
-
 import { allSettled } from './allSettled';
 
 function makeCollect(E, log) {

--- a/packages/spawner/test/swingsetTests/contractHost/bootstrap.js
+++ b/packages/spawner/test/swingsetTests/contractHost/bootstrap.js
@@ -1,6 +1,5 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
-/* global harden */
 import { E } from '@agoric/eventual-send';
 import { makeLocalAmountMath } from '@agoric/ertp';
 import { bundleFunction } from '../../make-function-bundle';

--- a/packages/spawner/test/swingsetTests/contractHost/vat-alice.js
+++ b/packages/spawner/test/swingsetTests/contractHost/vat-alice.js
@@ -1,6 +1,5 @@
 // Copyright (C) 2018 Agoric, under Apache License 2.0
 
-/* global harden */
 import { E } from '@agoric/eventual-send';
 import { allComparable } from '@agoric/same-structure';
 import { makeLocalAmountMath } from '@agoric/ertp';

--- a/packages/spawner/test/swingsetTests/contractHost/vat-bob.js
+++ b/packages/spawner/test/swingsetTests/contractHost/vat-bob.js
@@ -1,7 +1,6 @@
 // Copyright (C) 2013 Google Inc, under Apache License 2.0
 // Copyright (C) 2018 Agoric, under Apache License 2.0
 
-/* global harden */
 import { E } from '@agoric/eventual-send';
 import { makeLocalAmountMath } from '@agoric/ertp';
 
@@ -27,7 +26,7 @@ function makeBobMaker(host, log) {
       const stockNeeded = stockMath.make(7);
 
       const bob = harden({
-        /**
+        /*
          * This is not an imperative to Bob to buy something but rather
          * the opposite. It is a request by a client to buy something from
          * Bob, and therefore a request that Bob sell something. OO naming

--- a/packages/spawner/test/swingsetTests/contractHost/vat-fred.js
+++ b/packages/spawner/test/swingsetTests/contractHost/vat-fred.js
@@ -1,7 +1,6 @@
 // Copyright (C) 2013 Google Inc, under Apache License 2.0
 // Copyright (C) 2018 Agoric, under Apache License 2.0
 
-/* global harden */
 import { E } from '@agoric/eventual-send';
 import { makeLocalAmountMath } from '@agoric/ertp';
 import { allComparable } from '@agoric/same-structure';

--- a/packages/spawner/test/swingsetTests/contractHost/vat-host.js
+++ b/packages/spawner/test/swingsetTests/contractHost/vat-host.js
@@ -1,7 +1,5 @@
 // Copyright (C) 2018 Agoric, under Apache License 2.0
 
-/* global harden */
-
 import { makeContractHost } from '../../../src/contractHost';
 
 export function buildRootObject(vatPowers) {

--- a/packages/spawner/test/swingsetTests/contractHost/vat-mint.js
+++ b/packages/spawner/test/swingsetTests/contractHost/vat-mint.js
@@ -1,7 +1,5 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
-/* global harden */
-
 import { makeIssuerKit } from '@agoric/ertp';
 
 export function buildRootObject(_vatPowers) {

--- a/packages/spawner/test/swingsetTests/escrow/bootstrap.js
+++ b/packages/spawner/test/swingsetTests/escrow/bootstrap.js
@@ -1,6 +1,5 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
-/* global harden */
 import { E } from '@agoric/eventual-send';
 import { makeIssuerKit } from '@agoric/ertp';
 import { allComparable } from '@agoric/same-structure';

--- a/packages/spawner/test/swingsetTests/escrow/vat-host.js
+++ b/packages/spawner/test/swingsetTests/escrow/vat-host.js
@@ -1,7 +1,5 @@
 // Copyright (C) 2018 Agoric, under Apache License 2.0
 
-/* global harden */
-
 import { makeContractHost } from '../../../src/contractHost';
 
 export function buildRootObject(vatPowers) {

--- a/packages/spawner/test/swingsetTests/escrow/vat-mint.js
+++ b/packages/spawner/test/swingsetTests/escrow/vat-mint.js
@@ -1,7 +1,5 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
-/* global harden */
-
 import { makeIssuerKit } from '@agoric/ertp';
 
 export function buildRootObject(_vatPowers) {

--- a/packages/stat-logger/package.json
+++ b/packages/stat-logger/package.json
@@ -36,5 +36,71 @@
       "esm"
     ],
     "timeout": "2m"
+  },
+  "eslintConfig": {
+    "extends": [
+      "airbnb-base",
+      "plugin:prettier/recommended",
+      "plugin:jsdoc/recommended"
+    ],
+    "parser": "@typescript-eslint/parser",
+    "env": {
+      "es6": true
+    },
+    "globals": {
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
+    },
+    "rules": {
+      "implicit-arrow-linebreak": "off",
+      "function-paren-newline": "off",
+      "arrow-parens": "off",
+      "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
+      "no-console": "off",
+      "no-unused-vars": [
+        "error",
+        {
+          "argsIgnorePattern": "^_",
+          "varsIgnorePattern": "^_"
+        }
+      ],
+      "no-return-assign": "off",
+      "no-param-reassign": "off",
+      "no-restricted-syntax": [
+        "off",
+        "ForOfStatement"
+      ],
+      "no-unused-expressions": "off",
+      "no-loop-func": "off",
+      "no-inner-declarations": "off",
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
+      "import/prefer-default-export": "off",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/require-jsdoc": "off",
+      "jsdoc/require-property-description": "off",
+      "jsdoc/require-param-description": "off",
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off"
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   }
 }

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -49,13 +49,21 @@
   "eslintConfig": {
     "extends": [
       "airbnb-base",
-      "plugin:prettier/recommended"
+      "plugin:prettier/recommended",
+      "plugin:jsdoc/recommended"
     ],
+    "parser": "@typescript-eslint/parser",
     "env": {
       "es6": true
     },
     "globals": {
-      "harden": "readonly"
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
     },
     "rules": {
       "implicit-arrow-linebreak": "off",
@@ -81,8 +89,28 @@
       "no-unused-expressions": "off",
       "no-loop-func": "off",
       "no-inner-declarations": "off",
-      "import/prefer-default-export": "off"
-    }
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
+      "import/prefer-default-export": "off",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/require-jsdoc": "off",
+      "jsdoc/require-property-description": "off",
+      "jsdoc/require-param-description": "off",
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off"
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   },
   "eslintIgnore": [
     "bundle-*.js"

--- a/packages/store/src/store.js
+++ b/packages/store/src/store.js
@@ -10,6 +10,7 @@ import { assert, details, q } from '@agoric/assert';
  *
  * `init` is only allowed if the key does not already exist. `Get`,
  * `set` and `delete` are only allowed if the key does already exist.
+ *
  * @template K,V
  * @param  {string} [keyName='key'] - the column name for the key
  * @returns {Store<K,V>}

--- a/packages/store/src/types.js
+++ b/packages/store/src/types.js
@@ -37,6 +37,7 @@
  *
  * `init` is only allowed if the key does not already exist. `Get`,
  * `set` and `delete` are only allowed if the key does already exist.
+ *
  * @template K,V
  * @callback MakeWeakStore
  * @param {string} [keyName='key'] - the column name for the key

--- a/packages/swing-store-lmdb/package.json
+++ b/packages/swing-store-lmdb/package.json
@@ -37,5 +37,71 @@
       "esm"
     ],
     "timeout": "2m"
+  },
+  "eslintConfig": {
+    "extends": [
+      "airbnb-base",
+      "plugin:prettier/recommended",
+      "plugin:jsdoc/recommended"
+    ],
+    "parser": "@typescript-eslint/parser",
+    "env": {
+      "es6": true
+    },
+    "globals": {
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
+    },
+    "rules": {
+      "implicit-arrow-linebreak": "off",
+      "function-paren-newline": "off",
+      "arrow-parens": "off",
+      "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
+      "no-console": "off",
+      "no-unused-vars": [
+        "error",
+        {
+          "argsIgnorePattern": "^_",
+          "varsIgnorePattern": "^_"
+        }
+      ],
+      "no-return-assign": "off",
+      "no-param-reassign": "off",
+      "no-restricted-syntax": [
+        "off",
+        "ForOfStatement"
+      ],
+      "no-unused-expressions": "off",
+      "no-loop-func": "off",
+      "no-inner-declarations": "off",
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
+      "import/prefer-default-export": "off",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/require-jsdoc": "off",
+      "jsdoc/require-property-description": "off",
+      "jsdoc/require-param-description": "off",
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off"
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   }
 }

--- a/packages/swing-store-simple/package.json
+++ b/packages/swing-store-simple/package.json
@@ -35,5 +35,71 @@
       "esm"
     ],
     "timeout": "2m"
+  },
+  "eslintConfig": {
+    "extends": [
+      "airbnb-base",
+      "plugin:prettier/recommended",
+      "plugin:jsdoc/recommended"
+    ],
+    "parser": "@typescript-eslint/parser",
+    "env": {
+      "es6": true
+    },
+    "globals": {
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
+    },
+    "rules": {
+      "implicit-arrow-linebreak": "off",
+      "function-paren-newline": "off",
+      "arrow-parens": "off",
+      "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
+      "no-console": "off",
+      "no-unused-vars": [
+        "error",
+        {
+          "argsIgnorePattern": "^_",
+          "varsIgnorePattern": "^_"
+        }
+      ],
+      "no-return-assign": "off",
+      "no-param-reassign": "off",
+      "no-restricted-syntax": [
+        "off",
+        "ForOfStatement"
+      ],
+      "no-unused-expressions": "off",
+      "no-loop-func": "off",
+      "no-inner-declarations": "off",
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
+      "import/prefer-default-export": "off",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/require-jsdoc": "off",
+      "jsdoc/require-property-description": "off",
+      "jsdoc/require-param-description": "off",
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off"
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   }
 }

--- a/packages/swingset-runner/demo/resolveChain/bootstrap.js
+++ b/packages/swingset-runner/demo/resolveChain/bootstrap.js
@@ -9,7 +9,7 @@ export function buildRootObject(_vatPowers, options) {
   function waitFor(who, p) {
     p.then(
       answer => {
-        if (0 < count && count < 50) {
+        if (count > 0 && count < 50) {
           log(`Alice: Bob answers with value ${answer[0]}`);
         }
         if (answer[0] < count || count < 0) {

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -29,7 +29,6 @@
     "@agoric/swing-store-simple": "^0.2.7",
     "@agoric/swingset-vat": "^0.10.0",
     "@agoric/tame-metering": "^1.2.7",
-    "@agoric/zoe": "^0.10.0",
     "@agoric/zoe": "^0.10.0-dev.0",
     "n-readlines": "^1.0.1",
     "yargs": "^16.1.0"
@@ -42,10 +41,21 @@
   "eslintConfig": {
     "extends": [
       "airbnb-base",
-      "plugin:prettier/recommended"
+      "plugin:prettier/recommended",
+      "plugin:jsdoc/recommended"
     ],
+    "parser": "@typescript-eslint/parser",
     "env": {
       "es6": true
+    },
+    "globals": {
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
     },
     "rules": {
       "implicit-arrow-linebreak": "off",
@@ -71,20 +81,28 @@
       "no-unused-expressions": "off",
       "no-loop-func": "off",
       "no-inner-declarations": "off",
-      "import/prefer-default-export": "off",
-      "no-lonely-if": "off",
-      "yoda": [
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
         "error",
-        "never",
         {
-          "exceptRange": true
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
         }
-      ]
+      ],
+      "import/prefer-default-export": "off",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/require-jsdoc": "off",
+      "jsdoc/require-property-description": "off",
+      "jsdoc/require-param-description": "off",
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off"
     },
-    "globals": {
-      "harden": "readonly",
-      "BigInt": "readonly"
-    }
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   },
   "eslintIgnore": [
     "bundle-*.js"

--- a/packages/swingset-runner/src/vat-launcher.js
+++ b/packages/swingset-runner/src/vat-launcher.js
@@ -1,6 +1,6 @@
 import { E } from '@agoric/eventual-send';
 
-/**
+/*
  * Vat to launch other vats.
  *
  * This vat is designed to enable a statically configured swingset vat group to

--- a/packages/tame-metering/package.json
+++ b/packages/tame-metering/package.json
@@ -46,5 +46,71 @@
       "esm"
     ],
     "timeout": "2m"
+  },
+  "eslintConfig": {
+    "extends": [
+      "airbnb-base",
+      "plugin:prettier/recommended",
+      "plugin:jsdoc/recommended"
+    ],
+    "parser": "@typescript-eslint/parser",
+    "env": {
+      "es6": true
+    },
+    "globals": {
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
+    },
+    "rules": {
+      "implicit-arrow-linebreak": "off",
+      "function-paren-newline": "off",
+      "arrow-parens": "off",
+      "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
+      "no-console": "off",
+      "no-unused-vars": [
+        "error",
+        {
+          "argsIgnorePattern": "^_",
+          "varsIgnorePattern": "^_"
+        }
+      ],
+      "no-return-assign": "off",
+      "no-param-reassign": "off",
+      "no-restricted-syntax": [
+        "off",
+        "ForOfStatement"
+      ],
+      "no-unused-expressions": "off",
+      "no-loop-func": "off",
+      "no-inner-declarations": "off",
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
+      "import/prefer-default-export": "off",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/require-jsdoc": "off",
+      "jsdoc/require-property-description": "off",
+      "jsdoc/require-param-description": "off",
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off"
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   }
 }

--- a/packages/transform-eventual-send/package.json
+++ b/packages/transform-eventual-send/package.json
@@ -47,5 +47,71 @@
       "esm"
     ],
     "timeout": "2m"
+  },
+  "eslintConfig": {
+    "extends": [
+      "airbnb-base",
+      "plugin:prettier/recommended",
+      "plugin:jsdoc/recommended"
+    ],
+    "parser": "@typescript-eslint/parser",
+    "env": {
+      "es6": true
+    },
+    "globals": {
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
+    },
+    "rules": {
+      "implicit-arrow-linebreak": "off",
+      "function-paren-newline": "off",
+      "arrow-parens": "off",
+      "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
+      "no-console": "off",
+      "no-unused-vars": [
+        "error",
+        {
+          "argsIgnorePattern": "^_",
+          "varsIgnorePattern": "^_"
+        }
+      ],
+      "no-return-assign": "off",
+      "no-param-reassign": "off",
+      "no-restricted-syntax": [
+        "off",
+        "ForOfStatement"
+      ],
+      "no-unused-expressions": "off",
+      "no-loop-func": "off",
+      "no-inner-declarations": "off",
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
+      "import/prefer-default-export": "off",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/require-jsdoc": "off",
+      "jsdoc/require-property-description": "off",
+      "jsdoc/require-param-description": "off",
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off"
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   }
 }

--- a/packages/transform-metering/package.json
+++ b/packages/transform-metering/package.json
@@ -53,5 +53,71 @@
       "esm"
     ],
     "timeout": "2m"
+  },
+  "eslintConfig": {
+    "extends": [
+      "airbnb-base",
+      "plugin:prettier/recommended",
+      "plugin:jsdoc/recommended"
+    ],
+    "parser": "@typescript-eslint/parser",
+    "env": {
+      "es6": true
+    },
+    "globals": {
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
+    },
+    "rules": {
+      "implicit-arrow-linebreak": "off",
+      "function-paren-newline": "off",
+      "arrow-parens": "off",
+      "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
+      "no-console": "off",
+      "no-unused-vars": [
+        "error",
+        {
+          "argsIgnorePattern": "^_",
+          "varsIgnorePattern": "^_"
+        }
+      ],
+      "no-return-assign": "off",
+      "no-param-reassign": "off",
+      "no-restricted-syntax": [
+        "off",
+        "ForOfStatement"
+      ],
+      "no-unused-expressions": "off",
+      "no-loop-func": "off",
+      "no-inner-declarations": "off",
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
+      "import/prefer-default-export": "off",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/require-jsdoc": "off",
+      "jsdoc/require-property-description": "off",
+      "jsdoc/require-param-description": "off",
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off"
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   }
 }

--- a/packages/xs-vat-worker/package.json
+++ b/packages/xs-vat-worker/package.json
@@ -69,5 +69,71 @@
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "publishConfig": {
     "access": "public"
+  },
+  "eslintConfig": {
+    "extends": [
+      "airbnb-base",
+      "plugin:prettier/recommended",
+      "plugin:jsdoc/recommended"
+    ],
+    "parser": "@typescript-eslint/parser",
+    "env": {
+      "es6": true
+    },
+    "globals": {
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
+    },
+    "rules": {
+      "implicit-arrow-linebreak": "off",
+      "function-paren-newline": "off",
+      "arrow-parens": "off",
+      "strict": "off",
+      "prefer-destructuring": "off",
+      "no-else-return": "off",
+      "no-console": "off",
+      "no-unused-vars": [
+        "error",
+        {
+          "argsIgnorePattern": "^_",
+          "varsIgnorePattern": "^_"
+        }
+      ],
+      "no-return-assign": "off",
+      "no-param-reassign": "off",
+      "no-restricted-syntax": [
+        "off",
+        "ForOfStatement"
+      ],
+      "no-unused-expressions": "off",
+      "no-loop-func": "off",
+      "no-inner-declarations": "off",
+      "import/extensions": "off",
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "rollup.config.js",
+            "test/**/*.js",
+            "scripts/**/*.js"
+          ]
+        }
+      ],
+      "import/prefer-default-export": "off",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/require-jsdoc": "off",
+      "jsdoc/require-property-description": "off",
+      "jsdoc/require-param-description": "off",
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off"
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   }
 }

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -89,7 +89,13 @@
       "es6": true
     },
     "globals": {
-      "harden": "readonly"
+      "globalThis": "readonly",
+      "BigInt": "readonly",
+      "assert": "readonly",
+      "harden": "readonly",
+      "lockdown": "readonly",
+      "Compartment": "readonly",
+      "StaticModuleRecord": "readonly"
     },
     "rules": {
       "implicit-arrow-linebreak": "off",
@@ -115,10 +121,12 @@
       "no-unused-expressions": "off",
       "no-loop-func": "off",
       "no-inner-declarations": "off",
+      "import/extensions": "off",
       "import/no-extraneous-dependencies": [
         "error",
         {
           "devDependencies": [
+            "rollup.config.js",
             "test/**/*.js",
             "scripts/**/*.js"
           ]
@@ -131,7 +139,10 @@
       "jsdoc/require-param-description": "off",
       "jsdoc/require-returns": "off",
       "jsdoc/require-returns-description": "off"
-    }
+    },
+    "ignorePatterns": [
+      "**/dist/**"
+    ]
   },
   "eslintIgnore": [
     "bundle-*.js"

--- a/scripts/sync-eslint-config.sh
+++ b/scripts/sync-eslint-config.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -ueo pipefail
+DIR=$(dirname -- "${BASH_SOURCE[0]}")
+cd -- "$DIR/.."
+
+find packages -depth 1 | while read NAME; do
+  HASH=$(
+    jq \
+      --argfile eslintConfig eslint-config-template.json \
+      '. + {$eslintConfig}' \
+      "$NAME/package.json" |
+      git hash-object -w --stdin
+  )
+  git cat-file blob "$HASH" > "$NAME/package.json"
+done


### PR DESCRIPTION
This change makes the `eslintConfig` block the same in every package. A new `eslint-config-template.json` appears at the top-level with a `scripts/sync-eslint-config.sh` that will push this block into every package’s `package.json` centrally. This should eventually be replaced with a lint config package.

This subsumes many global declarations common to the Agoric execution environment and removes the explicit global hints from every file that previously had them.

The consolidated configuration requires valid jsdocs. To get lint passing, some are fixed, others are demoted to normal comments where the gap is too vast and ts-check is not yet enabled.

One file had DOS line-endings, which will now be UNIX line-endings.