### PR TITLE
Update IBC to match relayer v1.0.0-rc1

### DIFF
--- a/golang/cosmos/daemon/cmd/testnet.go
+++ b/golang/cosmos/daemon/cmd/testnet.go
@@ -46,7 +46,7 @@ var (
 func testnetCmd(mbm module.BasicManager, genBalIterator banktypes.GenesisBalancesIterator) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "testnet",
-		Short: "Initialize files for a simapp testnet",
+		Short: "Initialize files for an Agoric testnet",
 		Long: `testnet will create "v" number of directories and populate each with
 necessary files (private validator, genesis, config, etc.).
 
@@ -81,10 +81,10 @@ Example:
 	cmd.Flags().Int(flagNumValidators, 4, "Number of validators to initialize the testnet with")
 	cmd.Flags().StringP(flagOutputDir, "o", "./mytestnet", "Directory to store initialization data for the testnet")
 	cmd.Flags().String(flagNodeDirPrefix, "node", "Prefix the directory name for each node with (node results in node0, node1, ...)")
-	cmd.Flags().String(flagNodeDaemonHome, "simd", "Home directory of the node's daemon configuration")
+	cmd.Flags().String(flagNodeDaemonHome, "ag-chain-cosmos", "Home directory of the node's daemon configuration")
 	cmd.Flags().String(flagStartingIPAddress, "192.168.0.1", "Starting IP address (192.168.0.1 results in persistent peers list ID0@192.168.0.1:46656, ID1@192.168.0.2:46656, ...)")
 	cmd.Flags().String(flags.FlagChainID, "", "genesis file chain-id, if left blank will be randomly created")
-	cmd.Flags().String(server.FlagMinGasPrices, fmt.Sprintf("0.000006%s", sdk.DefaultBondDenom), "Minimum gas prices to accept for transactions; All fees in a tx must meet this minimum (e.g. 0.01photino,0.001stake)")
+	cmd.Flags().String(server.FlagMinGasPrices, "", "Minimum gas prices to accept for transactions; All fees in a tx must meet this minimum (e.g. 0.01photino,0.001stake)")
 	cmd.Flags().String(flags.FlagKeyringBackend, flags.DefaultKeyringBackend, "Select keyring's backend (os|file|test)")
 	cmd.Flags().String(flags.FlagKeyAlgorithm, string(hd.Secp256k1Type), "Key signing algorithm to generate keys for")
 

--- a/packages/agoric-cli/lib/chain-config.js
+++ b/packages/agoric-cli/lib/chain-config.js
@@ -4,7 +4,12 @@ import TOML from '@iarna/toml';
 export const MINT_DENOM = 'uag';
 export const STAKING_DENOM = 'uagstake';
 export const GOV_DEPOSIT_COINS = [{ amount: '10000000', denom: MINT_DENOM }];
-export const BLOCK_CADENCE_S = 2;
+
+// Can't beat the speed of light, we need 600ms round trip time for the other
+// side of Earth, and multiple round trips per block.
+//
+// 5 seconds is about as fast as we can go without penalising validators.
+export const BLOCK_CADENCE_S = 5;
 
 export const ORIG_BLOCK_CADENCE_S = 5;
 export const ORIG_SIGNED_BLOCKS_WINDOW = 100;
@@ -88,10 +93,6 @@ export function finishCosmosGenesis({ genesisJson, exportedGenesisJson }) {
   if ('initial_height' in exported) {
     genesis.initial_height = exported.initial_height;
   }
-
-  // Should be equal to the block cadence in milliseconds, according to @melekes
-  // on Discord.
-  genesis.consensus_params.block.time_iota_ms = `${BLOCK_CADENCE_S * 1000}`;
 
   return djson.stringify(genesis);
 }

--- a/packages/cosmic-swingset/bin/ag-nchainz
+++ b/packages/cosmic-swingset/bin/ag-nchainz
@@ -60,7 +60,7 @@ testnet)
   portend=$(( $portstart + $NUM_SOLOS - 1 ))
   SOLO_ADDRS=()
   SOLO_NAMES=()
-  POWER_FLAGS='["agoric.vattp"]'
+  POWER_FLAGS='[\"agoric.vattp\"]'
   egresses=
   sep=''
   for port in `seq $portstart $portend`; do
@@ -72,7 +72,7 @@ testnet)
       $($CLI --home=$solo/$CLI-statedir --keyring-backend=test keys show -a ag-solo) \
       1000uag,1provisionpass
     # Generate powerful SwingSet egresses.
-    egresses="$egresses$sep{\"nickname\":\"$solo\",\"peer\":\"$addr\",\"powerFlags\":$POWER_FLAGS}"
+    egresses="$egresses$sep\"egress.$addr\":\"{\\\"nickname\\\":\\\"$solo\\\",\\\"peer\\\":\\\"$addr\\\",\\\"powerFlags\\\":$POWER_FLAGS}\""
     sep=,
 	done
   for node in `ls -d $chainid/n* 2>/dev/null || true`; do
@@ -80,7 +80,7 @@ testnet)
 	  "$thisdir/../../agoric-cli/bin/agoric" set-defaults ag-chain-cosmos $node/$DAEMON/config
     cp "$node/$DAEMON/config/genesis.json" "$node/$DAEMON/config/genesis-orig.json"
     # Append the egresses to the genesis and reset bond_denom.
-    jq ".*{app_state:{staking:{params:{bond_denom:\"stake\"}},swingset:{egresses:(.app_state.swingset.egresses+[$egresses])}}}" \
+    jq ".*{app_state:{staking:{params:{bond_denom:\"stake\"}},swingset:{storage:{$egresses}}}}" \
       "$node/$DAEMON/config/genesis-orig.json" > "$node/$DAEMON/config/genesis.json"
   done
   exit 0
@@ -93,9 +93,9 @@ start-daemon)
   BASEDIR=$1
   shift
   for solo in `ls -d $BASEDIR/ag-solo-* 2>&1`; do
-    cp -r "$BASEDIR/n0/$CLI/config" "$solo/$CLI-statedir/"
+    cp -r "$BASEDIR/n0/$DAEMON/config" "$solo/$CLI-statedir/"
   done
-  # "$($CLI --home "$BASEDIR/n0/$CLI" keys show n0 --keyring-backend=test | jq -r .address)"
+  # "$($CLI --home "$BASEDIR/n0/$DAEMON" keys show n0 --keyring-backend=test | jq -r .address)"
   echo "Starting $DAEMON ${1+"$@"}"
   if [[ $debug == yes ]]; then
     DEBUG=agoric ROLE=two_chain node --inspect-brk $(which $DAEMON) ${1+"$@"}
@@ -120,15 +120,16 @@ start-solos)
       cd "$solo"
       n0d=../n0/$DAEMON
 
+      rpcport=`$thisdir/../calc-rpcport.js $n0d/config/config.toml`
+
       addr=$(cat ag-cosmos-helper-address)
       $CLI --home=./$CLI-statedir tx swingset provision-one \
         "$solo" "$addr" agoric.vattp \
+        --node="tcp://$rpcport" --chain-id="$chainid" \
         --keyring-backend=test --from=ag-solo --yes
 
       # Now wire into the chain.
       gci=`$thisdir/../calc-gci.js $n0d/config/genesis.json`
-      rpcport=`$thisdir/../calc-rpcport.js $n0d/config/config.toml`
-
       $SOLO set-gci-ingress --chainID="$chainid" "$gci" "$rpcport"
 
       DEBUG=agoric $SOLO start


### PR DESCRIPTION
Refs #2067

Also, it turns out that global round-trip time is 600ms (speed-of-light, and other reasons), so a 2-second block was just wishful thinking.  We should optimise with promise pipelining instead of trying to have blocks of less than 5 seconds.
