### PR TITLE
fix: message batches reduce wallet setup from 80 to 20 chain trips

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/batched-deliver.js
+++ b/packages/cosmic-swingset/lib/ag-solo/batched-deliver.js
@@ -1,0 +1,35 @@
+const DEFAULT_BATCH_TIMEOUT_MS = 1000;
+
+export function makeBatchedDeliver(
+  deliver,
+  batchTimeoutMs = DEFAULT_BATCH_TIMEOUT_MS,
+) {
+  let batchedMessages = [];
+  let latestAckNum = 0;
+  let deliverTimeout;
+
+  async function batchedDeliver(newMessages, ackNum) {
+    // If we have no existing messages, reset the deliver timeout.
+    //
+    // This defers sending an ack until the timeout expires or we have new
+    // messages.
+    if (!batchedMessages.length) {
+      clearTimeout(deliverTimeout);
+      deliverTimeout = setTimeout(() => {
+        // Transfer the batched messages to the deliver function.
+        const msgs = batchedMessages;
+        batchedMessages = [];
+        deliver(msgs, latestAckNum);
+      }, batchTimeoutMs);
+    }
+
+    // Add new messages to the batch.
+    batchedMessages.push(...newMessages);
+    if (ackNum > latestAckNum) {
+      // Increase the latest ack.
+      latestAckNum = ackNum;
+    }
+  }
+
+  return batchedDeliver;
+}

--- a/packages/cosmic-swingset/lib/ag-solo/chain-cosmos-sdk.js
+++ b/packages/cosmic-swingset/lib/ag-solo/chain-cosmos-sdk.js
@@ -9,6 +9,8 @@ import anylogger from 'anylogger';
 import { makeNotifierKit } from '@agoric/notifier';
 import { makePromiseKit } from '@agoric/promise-kit';
 
+import { makeBatchedDeliver } from './batched-deliver';
+
 const log = anylogger('chain-cosmos-sdk');
 
 const HELPER = 'ag-cosmos-helper';
@@ -412,10 +414,17 @@ ${chainID} chain does not yet know of address ${myAddr}${adviseEgress(myAddr)}
   // Begin the block consumer.
   recurseEachNewBlock();
 
+  let totalDeliveries = 0;
   async function deliver(newMessages, acknum) {
     let tmpInfo;
     try {
-      log(`delivering to chain`, GCI, newMessages, acknum);
+      totalDeliveries += 1;
+      log(
+        `delivering to chain (trips=${totalDeliveries})`,
+        GCI,
+        newMessages,
+        acknum,
+      );
 
       // Peer and submitter are combined in the message format (i.e. we removed
       // the extra 'myAddr' after 'tx swingset deliver'). All messages from
@@ -504,5 +513,5 @@ ${chainID} chain does not yet know of address ${myAddr}${adviseEgress(myAddr)}
 
   // Now that we've started consuming blocks, tell our caller how to deliver
   // messages.
-  return deliver;
+  return makeBatchedDeliver(deliver);
 }

--- a/packages/cosmic-swingset/lib/ag-solo/outbound.js
+++ b/packages/cosmic-swingset/lib/ag-solo/outbound.js
@@ -37,11 +37,8 @@ export function deliver(mbs) {
     // console.debug(` ${newMessages.length} new messages`);
     const acknum = data[target].inboundAck;
     if (newMessages.length || acknum !== t.highestAck) {
-      if (newMessages.length) {
-        t.trips += 1;
-      }
       log(
-        `invoking deliverator; ${newMessages.length} new messages for ${target} (trips=${t.trips})`,
+        `invoking deliverator; ${newMessages.length} new messages for ${target}`,
       );
       t.deliverator(newMessages, acknum);
       if (newMessages.length) {
@@ -57,6 +54,6 @@ export function addDeliveryTarget(target, deliverator) {
     throw new Error(`target ${target} already added`);
   }
   /** @type {TargetRecord} */
-  const targetRecord = { deliverator, highestSent: 0, highestAck: 0, trips: 0 };
+  const targetRecord = { deliverator, highestSent: 0, highestAck: 0 };
   knownTargets.set(target, targetRecord);
 }

--- a/packages/cosmic-swingset/lib/ag-solo/start.js
+++ b/packages/cosmic-swingset/lib/ag-solo/start.js
@@ -398,20 +398,15 @@ export default async function start(basedir, argv) {
   }
 
   // Launch the agoric wallet deploys (if any).
-  exec(
+  const cp = exec(
     `${agoricCli} deploy${verbosity} --provide=wallet --hostport=${hostport} ${agWalletDeploy}`,
-    (err, stdout, stderr) => {
+    err => {
       if (err) {
         console.error(err);
-        return;
-      }
-      if (stderr) {
-        // Report the error.
-        process.stderr.write(stderr);
-      }
-      if (stdout) {
-        process.stdout.write(stdout);
       }
     },
   );
+
+  cp.stderr.pipe(process.stderr);
+  cp.stdout.pipe(process.stdout);
 }


### PR DESCRIPTION
Big performance win, where the ag-solo batches its delivery to the chain by accumulating messages until 1s (configurable) passes.
