### PR TITLE
Little fixes pulled from the rendezvous PR

### DIFF
--- a/golang/cosmos/Makefile
+++ b/golang/cosmos/Makefile
@@ -1,3 +1,5 @@
+# sed is more fragile, but we don't want to take a Node.js or jq dependency
+# just to compile the Golang pieces under Docker.
 NAME := $(shell sed -ne 's/.*"name": "\([^"]*\)".*/\1/p' package.json)
 VERSION := $(shell sed -ne 's/.*"version": "\([^"]*\)".*/\1/p' package.json)
 COMMIT = $(shell hash=`git rev-parse --short HEAD 2>/dev/null`; if test -n "$$hash"; then echo $$hash`git diff --quiet || echo -dirty`; else cat git-revision.txt; fi)

--- a/golang/cosmos/Makefile
+++ b/golang/cosmos/Makefile
@@ -1,5 +1,5 @@
-NAME := $(shell node -e 'console.log(require("./package.json").name)')
-VERSION := $(shell node -e 'console.log(require("./package.json").version)')
+NAME := $(shell sed -ne 's/.*"name": "\([^"]*\)".*/\1/p' package.json)
+VERSION := $(shell sed -ne 's/.*"version": "\([^"]*\)".*/\1/p' package.json)
 COMMIT = $(shell hash=`git rev-parse --short HEAD 2>/dev/null`; if test -n "$$hash"; then echo $$hash`git diff --quiet || echo -dirty`; else cat git-revision.txt; fi)
 
 default: all

--- a/packages/agoric-cli/lib/deploy.js
+++ b/packages/agoric-cli/lib/deploy.js
@@ -139,7 +139,7 @@ export default async function deployMain(progname, rawArgs, powers, opts) {
           }
           if (!needsProvide) {
             console.info(`Don't need our provides: ${notNeeded.join(', ')}`);
-            return;
+            process.exit(0);
           }
 
           const nextLoading = [];

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-http.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-http.js
@@ -40,7 +40,7 @@ export function buildRootObject(vatPowers) {
       const channelID = channelHandleToId.get(channelHandle);
       if (channelID) {
         const o = { ...obj, meta: { channelID } };
-        D(commandDevice).sendBroadcast(JSON.parse(JSON.stringify(o)));
+        D(commandDevice).sendBroadcast(o);
       }
     }
   };
@@ -143,6 +143,7 @@ export function buildRootObject(vatPowers) {
     async inbound(count, rawObj) {
       // Launder the data, since the command device tends to pass device nodes
       // when there are empty objects, which screw things up for us.
+      // Analysis is in https://github.com/Agoric/agoric-sdk/pull/1956
       const obj = JSON.parse(JSON.stringify(rawObj));
       console.debug(
         `vat-http.inbound (from browser) ${count}`,

--- a/packages/eventual-send/src/index.js
+++ b/packages/eventual-send/src/index.js
@@ -354,33 +354,35 @@ export function makeHandledPromise() {
     };
   }
 
+  const ntypeof = specimen => (specimen === null ? 'null' : typeof specimen);
+
   // eslint-disable-next-line prefer-const
   forwardingHandler = {
     get: makeForwarder('get', (o, key) => o[key]),
     applyMethod: makeForwarder('applyMethod', (t, method, args) => {
       if (method === undefined || method === null) {
         if (!(t instanceof Function)) {
-          const ftype = typeof t;
+          const ftype = ntypeof(t);
           throw TypeError(
-            `Cannot invoke target as a function, the type is ${ftype}`,
+            `Cannot invoke target as a function; typeof target is ${q(ftype)}`,
           );
         }
         return t(...args);
       }
-      if (!t) {
-        const ftype = typeof t;
+      if (t === undefined || t === null) {
+        const ftype = ntypeof(t);
         throw TypeError(
-          `Cannot deliver ${q(method)} to target; typeof target is "${ftype}"`,
+          `Cannot deliver ${q(method)} to target; typeof target is ${q(ftype)}`,
         );
       }
-      if (!(method in t)) {
-        const names = Object.getOwnPropertyNames(t).sort();
-        throw TypeError(`target has no method ${q(method)}, has [${names}]`);
-      }
       if (!(t[method] instanceof Function)) {
-        const ftype = typeof t[method];
+        const ftype = ntypeof(t[method]);
+        if (ftype === 'undefined') {
+          const names = Object.getOwnPropertyNames(t).sort();
+          throw TypeError(`target has no method ${q(method)}, has [${names}]`);
+        }
         throw TypeError(
-          `invoked method ${q(method)} is not a function, it is a ${ftype}`,
+          `invoked method ${q(method)} is not a function; it is a ${q(ftype)}`,
         );
       }
       return t[method](...args);

--- a/packages/eventual-send/test/test-e.js
+++ b/packages/eventual-send/test/test-e.js
@@ -112,14 +112,14 @@ test('E call undefined method', async t => {
     },
   };
   await t.throwsAsync(() => E(x)(6), {
-    message: 'Cannot invoke target as a function, the type is object',
+    message: 'Cannot invoke target as a function; typeof target is "object"',
   });
 });
 
 test('E invoke a non-method', async t => {
   const x = { double: 24 };
   await t.throwsAsync(() => E(x).double(6), {
-    message: 'invoked method "double" is not a function, it is a number',
+    message: 'invoked method "double" is not a function; it is a "number"',
   });
 });
 

--- a/packages/eventual-send/test/test-eventual-send.js
+++ b/packages/eventual-send/test/test-eventual-send.js
@@ -269,3 +269,127 @@ test('handled promises are promises', t => {
   t.is(hp.constructor, Promise, 'The constructor is Promise');
   t.is(HandledPromise.prototype, Promise.prototype, 'shared prototype');
 });
+
+test('eventual send expected errors', async t => {
+  t.is(
+    await HandledPromise.get(true, 'toString'),
+    true.toString,
+    'true.toString',
+  );
+  t.is(
+    await HandledPromise.get(false, 'toString'),
+    false.toString,
+    'false.toString',
+  );
+  await t.throwsAsync(
+    HandledPromise.get(null, 'toString'),
+    { instanceOf: TypeError },
+    'get null.toString',
+  );
+  await t.throwsAsync(
+    HandledPromise.applyFunction(true, []),
+    {
+      instanceOf: TypeError,
+      message: 'Cannot invoke target as a function; typeof target is "boolean"',
+    },
+    'applyFunction true',
+  );
+  await t.throwsAsync(
+    HandledPromise.applyFunction(false, []),
+    {
+      instanceOf: TypeError,
+      message: 'Cannot invoke target as a function; typeof target is "boolean"',
+    },
+    'applyFunction false',
+  );
+  await t.throwsAsync(
+    HandledPromise.applyFunction(undefined, []),
+    {
+      instanceOf: TypeError,
+      message:
+        'Cannot invoke target as a function; typeof target is "undefined"',
+    },
+    'applyFunction undefined',
+  );
+  await t.throwsAsync(
+    HandledPromise.applyFunction(null, []),
+    {
+      instanceOf: TypeError,
+      message: 'Cannot invoke target as a function; typeof target is "null"',
+    },
+    'applyFunction null',
+  );
+  t.is(
+    await HandledPromise.applyMethod(true, 'toString', []),
+    'true',
+    'applyMethod true.toString()',
+  );
+  t.is(
+    await HandledPromise.applyMethod(false, 'toString', []),
+    'false',
+    'applyMethod false.toString()',
+  );
+  await t.throwsAsync(
+    HandledPromise.applyMethod(undefined, 'toString', []),
+    {
+      instanceOf: TypeError,
+      message:
+        'Cannot deliver "toString" to target; typeof target is "undefined"',
+    },
+    'applyMethod undefined.toString()',
+  );
+  await t.throwsAsync(
+    HandledPromise.applyMethod(null, 'toString', []),
+    {
+      instanceOf: TypeError,
+      message: 'Cannot deliver "toString" to target; typeof target is "null"',
+    },
+    'applyMethod null.toString()',
+  );
+  t.is(
+    await HandledPromise.applyMethod({}, 'toString', []),
+    '[object Object]',
+    'applyMethod ({}).toString()',
+  );
+  await t.throwsAsync(
+    HandledPromise.applyMethod(true, 'notfound', []),
+    {
+      instanceOf: TypeError,
+      message: 'target has no method "notfound", has []',
+    },
+    'applyMethod true.notfound()',
+  );
+  await t.throwsAsync(
+    HandledPromise.applyMethod(false, 'notfound', []),
+    {
+      instanceOf: TypeError,
+      message: 'target has no method "notfound", has []',
+    },
+    'applyMethod false.notfound()',
+  );
+  await t.throwsAsync(
+    HandledPromise.applyMethod(undefined, 'notfound', []),
+    {
+      instanceOf: TypeError,
+      message:
+        'Cannot deliver "notfound" to target; typeof target is "undefined"',
+    },
+    'applyMethod undefined.notfound()',
+  );
+  await t.throwsAsync(
+    HandledPromise.applyMethod(null, 'notfound', []),
+    {
+      instanceOf: TypeError,
+      message: 'Cannot deliver "notfound" to target; typeof target is "null"',
+    },
+    'applyMethod null.notfound()',
+  );
+  await t.throwsAsync(
+    HandledPromise.applyMethod({ present() {}, other() {} }, 'notfound', []),
+    {
+      instanceOf: TypeError,
+      message: 'target has no method "notfound", has [other,present]',
+    },
+    'applyMethod ({}).notfound()',
+  );
+});


### PR DESCRIPTION
* launder command device data, which may incidentally contain device nodes because `@agoric/marshal` transmits empty objects that way
* have only a single handler per URL (the last one installed)
* make eventual-send error messages more robust and test them
* remove the dependency on node from golang/cosmos/Makefile
* prevent a hang when rerunning `agoric start`