### PR TITLE
fix: tolerate symbols as property names

### DIFF
--- a/packages/SwingSet/src/kernel/deviceSlots.js
+++ b/packages/SwingSet/src/kernel/deviceSlots.js
@@ -104,8 +104,8 @@ export function makeDeviceSlots(
   function PresenceHandler(importSlot) {
     return {
       get(target, prop) {
-        lsdebug(`PreH proxy.get(${prop})`);
-        if (prop !== `${prop}`) {
+        lsdebug(`PreH proxy.get(${String(prop)})`);
+        if (typeof prop !== 'string' && typeof prop !== 'symbol') {
           return undefined;
         }
         const p = (...args) => {

--- a/packages/SwingSet/src/kernel/kdebug.js
+++ b/packages/SwingSet/src/kernel/kdebug.js
@@ -47,7 +47,7 @@ export function legibilizeValue(val, slots) {
         if (result.length !== 1) {
           result += ', ';
         }
-        result += `${prop}: ${legibilizeValue(val[prop], slots)}`;
+        result += `${String(prop)}: ${legibilizeValue(val[prop], slots)}`;
       }
       result += '}';
       return result;

--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -307,7 +307,7 @@ function build(syscall, forVatID, cacheSize, vatPowers, vatParameters) {
     const p = makeImportedPromise(resultVPID);
 
     lsdebug(
-      `ls.qm send(${JSON.stringify(targetSlot)}, ${prop}) -> ${resultVPID}`,
+      `ls.qm send(${JSON.stringify(targetSlot)}, ${String(prop)}) -> ${resultVPID}`,
     );
     syscall.send(targetSlot, prop, serArgs, resultVPID);
 
@@ -342,7 +342,7 @@ function build(syscall, forVatID, cacheSize, vatPowers, vatParameters) {
   function DeviceHandler(slot) {
     return {
       get(target, prop) {
-        if (prop !== `${prop}`) {
+        if (typeof prop !== 'string' && typeof prop !== 'symbol') {
           return undefined;
         }
         return (...args) => {

--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -307,7 +307,9 @@ function build(syscall, forVatID, cacheSize, vatPowers, vatParameters) {
     const p = makeImportedPromise(resultVPID);
 
     lsdebug(
-      `ls.qm send(${JSON.stringify(targetSlot)}, ${String(prop)}) -> ${resultVPID}`,
+      `ls.qm send(${JSON.stringify(targetSlot)}, ${String(
+        prop,
+      )}) -> ${resultVPID}`,
     );
     syscall.send(targetSlot, prop, serArgs, resultVPID);
 

--- a/packages/SwingSet/src/kernel/virtualObjectManager.js
+++ b/packages/SwingSet/src/kernel/virtualObjectManager.js
@@ -449,7 +449,7 @@ export function makeVirtualObjectManager(
         try {
           rawData[prop] = m.serialize(initialData[prop]);
         } catch (e) {
-          console.error(`state property ${prop} is not serializable`);
+          console.error(`state property ${String(prop)} is not serializable`);
           throw e;
         }
       }

--- a/packages/swingset-runner/src/slogulator.js
+++ b/packages/swingset-runner/src/slogulator.js
@@ -254,7 +254,7 @@ export function main() {
           if (result.length !== 1) {
             result += ', ';
           }
-          result += `${prop}: ${legibilizeValue(val[prop], slots)}`;
+          result += `${String(prop)}: ${legibilizeValue(val[prop], slots)}`;
         }
         result += '}';
       }


### PR DESCRIPTION
If the value of `prop` is a symbol `${prop}` throws whereas `${String(prop)}` produces a pleasing diagnostic. Should only be used to generate diagnostic text since the stringified from of a symbol is a valid string name for a property.

See https://github.com/Agoric/SES-shim/pull/547
See #2092 