### PR TITLE
fix(tame-metering): be tolerant to Node.js 14.15.2

### DIFF
--- a/packages/tame-metering/src/tame.js
+++ b/packages/tame-metering/src/tame.js
@@ -242,10 +242,7 @@ export function tameMetering() {
         try {
           defineProperty(o, p, newDesc);
         } catch (e) {
-          // Ignore: TypeError: Cannot redefine property: Symbol(Symbol.hasInstance)
-          if (typeof p !== 'symbol' || !(e instanceof TypeError)) {
-            throw e;
-          }
+          // Ignore: TypeError: Cannot redefine property: ...
         }
       }
     };

--- a/packages/tame-metering/src/tame.js
+++ b/packages/tame-metering/src/tame.js
@@ -38,6 +38,7 @@ export function tameMetering() {
 
   let globalMeter = null;
   const definePropertyFailures = new Set();
+  const frozenPaths = new Set();
   const wrapped = new WeakMap();
   const setWrapped = (...args) => apply(wmSet, wrapped, args);
   const getWrapped = (...args) => apply(wmGet, wrapped, args);
@@ -228,7 +229,7 @@ export function tameMetering() {
       wrap(getPrototypeOf(target), pname && `${pname}.__proto__`),
     );
 
-    const assignToTarget = (p, desc) => {
+    const assignToWrapper = (p, desc) => {
       let newDesc;
       if (constructor && p === 'constructor') {
         newDesc = {
@@ -240,17 +241,24 @@ export function tameMetering() {
       } else {
         newDesc = wrapDescriptor(desc, pname && `${pname}.${String(p)}`);
       }
-      for (const o of [wrapper, target]) {
-        try {
-          defineProperty(o, p, newDesc);
-        } catch (e) {
-          // Ignore: TypeError: Cannot redefine property: ...
-          const path = pname ? `${pname}.${String(p)}` : '*unknown*';
-          if (!definePropertyFailures.has(path)) {
-            definePropertyFailures.add(path);
-            // This is an intentional use of console.log, not a debugging vestige.
-            console.log(`Cannot meter ${path}`);
-          }
+
+      if (Object.isFrozen(wrapper)) {
+        if (!frozenPaths.has(pname)) {
+          frozenPaths.add(pname);
+          console.log(`Cannot meter frozen ${pname}`);
+        }
+        return;
+      }
+
+      try {
+        defineProperty(wrapper, p, newDesc);
+      } catch (e) {
+        // Ignore: TypeError: Cannot redefine property: ...
+        const path = pname ? `${pname}.${String(p)}` : '*unknown*';
+        if (!definePropertyFailures.has(path)) {
+          definePropertyFailures.add(path);
+          // This is an intentional use of console.log, not a debugging vestige.
+          console.log(`Cannot meter defined ${path}`);
         }
       }
     };
@@ -258,10 +266,10 @@ export function tameMetering() {
     // Assign the wrapped descriptors to the target.
     const tdescs = getOwnPropertyDescriptors(target);
     Object.getOwnPropertyNames(tdescs).forEach(p =>
-      assignToTarget(p, tdescs[p]),
+      assignToWrapper(p, tdescs[p]),
     );
     Object.getOwnPropertySymbols(tdescs).forEach(p =>
-      assignToTarget(p, tdescs[p]),
+      assignToWrapper(p, tdescs[p]),
     );
 
     return wrapper;


### PR DESCRIPTION
Closes #2097

With Node.js making some properties non-configurable, we found:

```
> @agoric/tame-metering
$ ava

  ✖ No tests found in test/test-sanity.js

  ─

  istamed › isTamed

  Error thrown in test:

  TypeError {
    messageundefined'Cannot redefine property: constructor',
  }

  › defineProperty (<anonymous>)
  › assignToTarget (src/tame.js:243:11)
  › src/tame.js:256:7
  › Array.forEach (<anonymous>)
  › Array.forEach (src/tame.js:172:20)
  › wrap (src/tame.js:255:40)
  › wrap (src/tame.js:226:7)
  › wrapDescriptor (src/tame.js:67:20)
  › assignToTarget (src/tame.js:239:19)
  › src/tame.js:256:7
```

With the change in this PR, the meter taming doesn't throw.  Do note that our metering has never been bulletproof, more just advisory until we get to XS.