### PR TITLE
Rename `current` amounts to `recent`, etc. Deprecate old.

### DIFF
--- a/packages/ERTP/src/issuer.js
+++ b/packages/ERTP/src/issuer.js
@@ -137,8 +137,10 @@ function makeIssuerKit(
           paymentLedger.init(payment, amount);
           return payment;
         },
-        getCurrentAmount: () => currentBalance,
+        getCurrentAmount: async () => currentBalance,
         getCurrentAmountNotifier: () => balanceNotifier,
+        getRecentAmount: async () => currentBalance,
+        getRecentAmountNotifier: () => balanceNotifier,
         getAllegedBrand: () => brand,
         // eslint-disable-next-line no-use-before-define
         getDepositFacet: () => depositFacet,

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -261,10 +261,21 @@
  *
  * @property {() => Brand} getAllegedBrand Get the alleged Brand for this Purse
  *
- * @property {() => Amount} getCurrentAmount
- * Get the amount contained in this purse.
+ * @property {() => Promise<Amount>} getCurrentAmount
+ * at-deprecated Use `getRecentAmount` instead.
+ * TODO How to I tell jsdoc something in this position is deprecated?
  *
  * @property {() => Notifier<Amount>} getCurrentAmountNotifier
+ * at-deprecated Use `getRecentAmountNotifier` instead.
+ * TODO How to I tell jsdoc something in this position is deprecated?
+ *
+ * @property {() => Promise<Amount>} getRecentAmount
+ * Get an amount that was recent contained in this purse. If asked repeatedly
+ * the answer should be eventually consistent. Under quiescence it should eventually
+ * converge on the correct amount. Any amount reported should have been a correct
+ * amount at some point in the past.
+ *
+ * @property {() => Notifier<Amount>} getRecentAmountNotifier
  * Get a lossy notifier for changes to this purse's balance.
  *
  * @property {(payment: Payment, optAmount: Amount=) => Amount} deposit

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -76,20 +76,20 @@ test('issuer.makeEmptyPurse', async t => {
   const purse = issuer.makeEmptyPurse();
   const payment = mint.mintPayment(amountMath.make(837));
 
-  const notifier = purse.getCurrentAmountNotifier();
+  const notifier = purse.getRecentAmountNotifier();
   let nextUpdate = notifier.getUpdateSince();
 
   const checkNotifier = async () => {
     const { value: balance, updateCount } = await nextUpdate;
     t.assert(
-      amountMath.isEqual(purse.getCurrentAmount(), balance),
+      amountMath.isEqual(await purse.getRecentAmount(), balance),
       `the notifier balance is the same as the purse`,
     );
     nextUpdate = notifier.getUpdateSince(updateCount);
   };
 
   t.assert(
-    amountMath.isEqual(purse.getCurrentAmount(), amountMath.getEmpty()),
+    amountMath.isEqual(await purse.getRecentAmount(), amountMath.getEmpty()),
     `empty purse is empty`,
   );
   await checkNotifier();
@@ -102,7 +102,7 @@ test('issuer.makeEmptyPurse', async t => {
       `the balance returned is the purse balance`,
     );
     t.assert(
-      amountMath.isEqual(purse.getCurrentAmount(), fungible837),
+      amountMath.isEqual(await purse.getRecentAmount(), fungible837),
       `the new purse balance is the payment's old balance`,
     );
     await checkNotifier();
@@ -118,7 +118,7 @@ test('issuer.makeEmptyPurse', async t => {
       );
     });
     t.assert(
-      amountMath.isEqual(purse.getCurrentAmount(), amountMath.getEmpty()),
+      amountMath.isEqual(await purse.getRecentAmount(), amountMath.getEmpty()),
       `the purse is empty again`,
     );
     await checkNotifier();
@@ -140,7 +140,7 @@ test('purse.deposit', async t => {
   const fungibleSum = amountMath.add(fungible17, fungible25);
 
   const purse = issuer.makeEmptyPurse();
-  const notifier = purse.getCurrentAmountNotifier();
+  const notifier = purse.getRecentAmountNotifier();
   const payment17 = mint.mintPayment(fungible17);
   const payment25 = mint.mintPayment(fungible25);
 
@@ -149,7 +149,7 @@ test('purse.deposit', async t => {
   const checkNotifier = async () => {
     const { value: balance, updateCount } = await nextUpdate;
     t.assert(
-      amountMath.isEqual(purse.getCurrentAmount(), balance),
+      amountMath.isEqual(await purse.getRecentAmount(), balance),
       `the notifier balance is the same as the purse`,
     );
     nextUpdate = notifier.getUpdateSince(updateCount);
@@ -165,7 +165,7 @@ test('purse.deposit', async t => {
       `the balance changes by the deposited amount: ${delta.value}`,
     );
     t.assert(
-      amountMath.isEqual(purse.getCurrentAmount(), expectedNewBalance),
+      amountMath.isEqual(await purse.getRecentAmount(), expectedNewBalance),
       `the new purse balance ${depositResult.value} is the expected amount: ${expectedNewBalance.value}`,
     );
     await checkNotifier();
@@ -204,14 +204,14 @@ test('purse.getDepositFacet', async t => {
 
   const purse = issuer.makeEmptyPurse();
   const payment = mint.mintPayment(fungible25);
-  const notifier = purse.getCurrentAmountNotifier();
+  const notifier = purse.getRecentAmountNotifier();
 
   let nextUpdate = notifier.getUpdateSince();
   const checkNotifier = async () => {
     const { value: balance, updateCount } = await nextUpdate;
     nextUpdate = notifier.getUpdateSince(updateCount);
     t.assert(
-      amountMath.isEqual(purse.getCurrentAmount(), balance),
+      amountMath.isEqual(await purse.getRecentAmount(), balance),
       `the notifier balance is the same as the purse's`,
     );
   };
@@ -222,7 +222,7 @@ test('purse.getDepositFacet', async t => {
       `the balance returned is the purse balance`,
     );
     t.assert(
-      amountMath.isEqual(purse.getCurrentAmount(), fungible25),
+      amountMath.isEqual(await purse.getRecentAmount(), fungible25),
       `the new purse balance is the payment's old balance`,
     );
     await checkNotifier();

--- a/packages/cosmic-swingset/test/test-home.js
+++ b/packages/cosmic-swingset/test/test-home.js
@@ -94,7 +94,7 @@ test.serial('home.wallet - receive zoe invite', async t => {
   await E(depositFacet).receive(invite);
 
   // The invite was successfully received in the user's wallet.
-  const invitePurseBalance = await E(invitePurse).getCurrentAmount();
+  const invitePurseBalance = await E(invitePurse).getRecentAmount();
   t.is(
     invitePurseBalance.value[0].description,
     'getRefund',

--- a/packages/dapp-svelte-wallet/api/deploy.js
+++ b/packages/dapp-svelte-wallet/api/deploy.js
@@ -85,7 +85,7 @@ export default async function deployWallet(
       if (!payment && purse) {
         // Withdraw the payment from the purse.
         payment = E(purse)
-          .getCurrentAmount()
+          .getRecentAmount()
           .then(amount => E(purse).withdraw(amount));
       }
 

--- a/packages/dapp-svelte-wallet/api/src/lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-wallet.js
@@ -172,10 +172,10 @@ export function makeWallet({
         pursesState.delete(key);
       }
     }
-    const currentAmount = await E(purse).getCurrentAmount();
-    const { value, brand } = currentAmount;
+    const recentAmount = await E(purse).getRecentAmount();
+    const { value, brand } = recentAmount;
     const brandPetname = brandMapping.valToPetname.get(brand);
-    const dehydratedCurrentAmount = dehydrate(currentAmount);
+    const dehydratedRecentAmount = dehydrate(recentAmount);
     const brandBoardId = await E(board).getId(brand);
 
     let depositBoardId;
@@ -200,8 +200,8 @@ export function makeWallet({
       pursePetname,
       displayInfo: (issuerRecord && issuerRecord.displayInfo),
       value,
-      currentAmountSlots: dehydratedCurrentAmount,
-      currentAmount: fillInSlots(dehydratedCurrentAmount),
+      recentAmountSlots: dehydratedRecentAmount,
+      recentAmount: fillInSlots(dehydratedRecentAmount),
     };
     pursesState.set(purseKey, jstate);
 
@@ -593,7 +593,7 @@ export function makeWallet({
 
     // Just notice the balance updates for the purse.
     observeIteration(
-      makeAsyncIterableFromNotifier(E(purse).getCurrentAmountNotifier()),
+      makeAsyncIterableFromNotifier(E(purse).getRecentAmountNotifier()),
       {
         updateState(_balance) {
           updatePursesState(

--- a/packages/dapp-svelte-wallet/api/src/types.js
+++ b/packages/dapp-svelte-wallet/api/src/types.js
@@ -94,8 +94,8 @@
  * @property {Petname} pursePetname the petname for this purse
  * @property {any} displayInfo the brand's displayInfo
  * @property {any} value the purse's current balance
- * @property {any} currentAmountSlots
- * @property {any} currentAmount
+ * @property {any} recentAmountSlots TODO do we also need a deprecated currentAmountSlots?
+ * @property {any} recentAmount TODO do we also need a deprecated currentAmount?
  */
 
 /**

--- a/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
@@ -149,7 +149,7 @@ test('lib-wallet issuer and purse methods', async t => {
   await wallet.makeEmptyPurse('moola', 'fun money');
   const moolaPurse = wallet.getPurse('fun money');
   t.deepEqual(
-    await moolaPurse.getCurrentAmount(),
+    await moolaPurse.getRecentAmount(),
     moolaBundle.amountMath.getEmpty(),
     `empty purse is empty`,
   );
@@ -169,11 +169,11 @@ test('lib-wallet issuer and purse methods', async t => {
   const moolaPayment = moolaBundle.mint.mintPayment(
     moolaBundle.amountMath.make(100),
   );
-  await waitForUpdate(E(moolaPurse).getCurrentAmountNotifier(), () =>
+  await waitForUpdate(E(moolaPurse).getRecentAmountNotifier(), () =>
     wallet.deposit('fun money', moolaPayment),
   );
   t.deepEqual(
-    await moolaPurse.getCurrentAmount(),
+    await moolaPurse.getRecentAmount(),
     moolaBundle.amountMath.make(100),
     `deposit successful`,
   );
@@ -190,12 +190,12 @@ test('lib-wallet issuer and purse methods', async t => {
         brandPetname: 'zoe invite',
         pursePetname: 'Default Zoe invite purse',
         value: [],
-        currentAmountSlots: {
+        recentAmountSlots: {
           body:
             '{"brand":{"@qclass":"slot","iface":"Alleged: Zoe Invitation brand","index":0},"value":[]}',
           slots: [{ kind: 'brand', petname: 'zoe invite' }],
         },
-        currentAmount: {
+        recentAmount: {
           brand: { kind: 'brand', petname: 'zoe invite' },
           value: [],
         },
@@ -208,12 +208,12 @@ test('lib-wallet issuer and purse methods', async t => {
         },
         pursePetname: 'fun money',
         value: 100,
-        currentAmountSlots: {
+        recentAmountSlots: {
           body:
             '{"brand":{"@qclass":"slot","iface":"Alleged: moola brand","index":0},"value":100}',
           slots: [{ kind: 'brand', petname: 'moola' }],
         },
-        currentAmount: {
+        recentAmount: {
           brand: { kind: 'brand', petname: 'moola' },
           value: 100,
         },
@@ -288,13 +288,13 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
     value: [{ handle: inviteHandle2 }],
   } = await E(inviteIssuer).getAmountOf(invite2);
 
-  await waitForUpdate(E(zoeInvitePurse).getCurrentAmountNotifier(), () =>
+  await waitForUpdate(E(zoeInvitePurse).getRecentAmountNotifier(), () =>
     wallet.deposit('Default Zoe invite purse', invite2),
   );
 
-  const currentAmount = await E(zoeInvitePurse).getCurrentAmount();
+  const recentAmount = await E(zoeInvitePurse).getRecentAmount();
   t.deepEqual(
-    currentAmount.value,
+    recentAmount.value,
     [
       {
         description: 'getRefund',
@@ -328,7 +328,7 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
           installation: {},
         },
       ],
-      currentAmountSlots: {
+      recentAmountSlots: {
         body:
           '{"brand":{"@qclass":"slot","iface":"Alleged: Zoe Invitation brand","index":0},"value":[{"description":"getRefund","handle":{"@qclass":"slot","index":1},"instance":{"@qclass":"slot","index":2},"installation":{"@qclass":"slot","index":3}}]}',
         slots: [
@@ -338,7 +338,7 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
           { kind: 'unnamed', petname: 'unnamed-3' },
         ],
       },
-      currentAmount: {
+      recentAmount: {
         brand: { kind: 'brand', petname: 'zoe invite' },
         value: [
           {
@@ -410,7 +410,7 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
           installation: {},
         },
       ],
-      currentAmountSlots: {
+      recentAmountSlots: {
         body:
           '{"brand":{"@qclass":"slot","iface":"Alleged: Zoe Invitation brand","index":0},"value":[{"description":"getRefund","handle":{"@qclass":"slot","index":1},"instance":{"@qclass":"slot","index":2},"installation":{"@qclass":"slot","index":3}}]}',
         slots: [
@@ -420,7 +420,7 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
           { kind: 'installation', petname: 'automaticRefund' },
         ],
       },
-      currentAmount: {
+      recentAmount: {
         brand: { kind: 'brand', petname: 'zoe invite' },
         value: [
           {
@@ -473,9 +473,9 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
 
   // We need this await for the pursesStateChangeLog to be updated
   // by the time we check it.
-  const currentAmount2 = await E(zoeInvitePurse).getCurrentAmount();
+  const recentAmount2 = await E(zoeInvitePurse).getRecentAmount();
   t.deepEqual(
-    currentAmount2.value,
+    recentAmount2.value,
     [
       {
         description: 'getRefund',
@@ -509,7 +509,7 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
           installation: {},
         },
       ],
-      currentAmountSlots: {
+      recentAmountSlots: {
         body:
           '{"brand":{"@qclass":"slot","iface":"Alleged: Zoe Invitation brand","index":0},"value":[{"description":"getRefund","handle":{"@qclass":"slot","index":1},"instance":{"@qclass":"slot","index":2},"installation":{"@qclass":"slot","index":3}}]}',
         slots: [
@@ -519,7 +519,7 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
           { kind: 'installation', petname: 'automaticRefund2' },
         ],
       },
-      currentAmount: {
+      recentAmount: {
         brand: { kind: 'brand', petname: 'zoe invite' },
         value: [
           {
@@ -571,7 +571,7 @@ test('lib-wallet offer methods', async t => {
   await wallet.makeEmptyPurse('moola', 'Fun budget');
   const moolaPurse = wallet.getPurse('Fun budget');
 
-  await waitForUpdate(E(moolaPurse).getCurrentAmountNotifier(), () =>
+  await waitForUpdate(E(moolaPurse).getRecentAmountNotifier(), () =>
     wallet.deposit(
       'Fun budget',
       moolaBundle.mint.mintPayment(moolaBundle.amountMath.make(100)),
@@ -636,7 +636,7 @@ test('lib-wallet offer methods', async t => {
   const seat = wallet.getSeat(id);
   t.is(seat, seats[0], `both getSeat(s) methods work`);
   t.deepEqual(
-    await moolaPurse.getCurrentAmount(),
+    await moolaPurse.getRecentAmount(),
     moolaBundle.amountMath.make(100),
     `moolaPurse balance`,
   );
@@ -657,7 +657,7 @@ test('lib-wallet offer methods', async t => {
   // TODO: test cancelOffer with a contract that holds offers, like
   // simpleExchange
   const zoeInvitePurse = await E(wallet).getPurse('Default Zoe invite purse');
-  const zoePurseAmount = await E(zoeInvitePurse).getCurrentAmount();
+  const zoePurseAmount = await E(zoeInvitePurse).getRecentAmount();
   t.deepEqual(zoePurseAmount.value, [], `zoeInvitePurse balance`);
   const lastPurseState = JSON.parse(pursesStateChangeLog.pop());
   const [zoeInvitePurseState, moolaPurseState] = lastPurseState;
@@ -672,12 +672,12 @@ test('lib-wallet offer methods', async t => {
       },
       pursePetname: 'Default Zoe invite purse',
       value: [],
-      currentAmountSlots: {
+      recentAmountSlots: {
         body:
           '{"brand":{"@qclass":"slot","iface":"Alleged: Zoe Invitation brand","index":0},"value":[]}',
         slots: [{ kind: 'brand', petname: 'zoe invite' }],
       },
-      currentAmount: {
+      recentAmount: {
         brand: { kind: 'brand', petname: 'zoe invite' },
         value: [],
       },
@@ -694,12 +694,12 @@ test('lib-wallet offer methods', async t => {
       },
       pursePetname: 'Fun budget',
       value: 100,
-      currentAmountSlots: {
+      recentAmountSlots: {
         body:
           '{"brand":{"@qclass":"slot","iface":"Alleged: moola brand","index":0},"value":100}',
         slots: [{ kind: 'brand', petname: 'moola' }],
       },
-      currentAmount: {
+      recentAmount: {
         brand: { kind: 'brand', petname: 'moola' },
         value: 100,
       },
@@ -890,12 +890,12 @@ test('lib-wallet addOffer for autoswap swap', async t => {
   const seat = wallet.getSeat(id);
   t.is(seat, seats[0], `both getSeat(s) methods work`);
   t.deepEqual(
-    await moolaPurse.getCurrentAmount(),
+    await moolaPurse.getRecentAmount(),
     moolaBundle.amountMath.make(70),
     `moola purse balance`,
   );
   t.deepEqual(
-    await simoleanPurse.getCurrentAmount(),
+    await simoleanPurse.getRecentAmount(),
     simoleanBundle.amountMath.make(516),
     `simolean purse balance`,
   );

--- a/packages/spawner/test/swingsetTests/contractHost/bootstrap.js
+++ b/packages/spawner/test/swingsetTests/contractHost/bootstrap.js
@@ -27,7 +27,7 @@ export function buildRootObject(vatPowers, vatParameters) {
   function showPurseBalances(name, purseP) {
     return Promise.all([
       E(purseP)
-        .getCurrentAmount()
+        .getRecentAmount()
         .then(amount => log(name, ' balance ', amount))
         .catch(err => console.log(err)),
     ]);

--- a/packages/swingset-runner/demo/exchangeBenchmark/helpers.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/helpers.js
@@ -5,7 +5,7 @@ import '@agoric/zoe/exported';
 
 export async function showPurseBalance(purseP, name, log) {
   try {
-    const amount = await E(purseP).getCurrentAmount();
+    const amount = await E(purseP).getRecentAmount();
     log(name, ': balance ', amount);
   } catch (err) {
     console.error(err);

--- a/packages/swingset-runner/demo/swapBenchmark/helpers.js
+++ b/packages/swingset-runner/demo/swapBenchmark/helpers.js
@@ -5,7 +5,7 @@ import '@agoric/zoe/exported';
 
 export async function showPurseBalance(purseP, name, log) {
   try {
-    const amount = await E(purseP).getCurrentAmount();
+    const amount = await E(purseP).getRecentAmount();
     log(name, ': balance ', amount);
   } catch (err) {
     console.error(err);

--- a/packages/swingset-runner/demo/zoeTests/helpers.js
+++ b/packages/swingset-runner/demo/zoeTests/helpers.js
@@ -3,7 +3,7 @@ import { makeLocalAmountMath } from '@agoric/ertp';
 
 export const showPurseBalance = async (purseP, name, log) => {
   try {
-    const amount = await E(purseP).getCurrentAmount();
+    const amount = await E(purseP).getRecentAmount();
     log(name, ': balance ', amount);
   } catch (err) {
     console.error(err);

--- a/packages/swingset-runner/demo/zoeTests/vat-alice.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-alice.js
@@ -413,7 +413,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
     const moneyPayment = await E(sellItemsCreatorSeat).getPayout('Money');
     await E(moolaPurseP).deposit(moneyPayment);
-    const currentPurseBalance = await E(moolaPurseP).getCurrentAmount();
+    const currentPurseBalance = await E(moolaPurseP).getRecentAmount();
 
     log('alice earned: ', currentPurseBalance);
   };

--- a/packages/zoe/test/swingsetTests/brokenContracts/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/vat-alice.js
@@ -124,7 +124,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
         showPurseBalance(moolaPurseP, 'aliceMoolaPurse', log);
         showPurseBalance(simoleanPurseP, 'aliceSimoleanPurse', log);
         E(moolaPurseP)
-          .getCurrentAmount()
+          .getRecentAmount()
           .then(amount => log(`swap value, ${amount.value}`));
       });
 
@@ -166,7 +166,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
         showPurseBalance(moolaPurseP, 'aliceMoolaPurse', log);
         showPurseBalance(simoleanPurseP, 'aliceSimoleanPurse', log);
         E(moolaPurseP)
-          .getCurrentAmount()
+          .getRecentAmount()
           .then(amount => log(`refund value, ${amount.value}`));
       });
 

--- a/packages/zoe/test/swingsetTests/helpers.js
+++ b/packages/zoe/test/swingsetTests/helpers.js
@@ -3,7 +3,7 @@ import { makeLocalAmountMath } from '@agoric/ertp';
 
 export const showPurseBalance = async (purseP, name, log) => {
   try {
-    const amount = await E(purseP).getCurrentAmount();
+    const amount = await E(purseP).getRecentAmount();
     log(name, ': balance ', amount);
   } catch (err) {
     console.error(err);

--- a/packages/zoe/test/swingsetTests/zoe/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-alice.js
@@ -419,7 +419,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
     const moneyPayment = await E(sellItemsCreatorSeat).getPayout('Money');
     await E(moolaPurseP).deposit(moneyPayment);
-    const currentPurseBalance = await E(moolaPurseP).getCurrentAmount();
+    const currentPurseBalance = await E(moolaPurseP).getRecentAmount();
 
     log('alice earned: ', currentPurseBalance);
   };

--- a/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
+++ b/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
@@ -440,6 +440,6 @@ test('zoe - atomicSwap like-for-like', async t => {
   // Assert that the correct payouts were received.
   // Alice had 3 moola from Asset and 0 from Price.
   // Bob had 0 moola from Asset and 7 from Price.
-  t.is(aliceMoolaPurse.getCurrentAmount().value, 7);
-  t.is(bobMoolaPurse.getCurrentAmount().value, 3);
+  t.is((await aliceMoolaPurse.getRecentAmount()).value, 7);
+  t.is((await bobMoolaPurse.getRecentAmount()).value, 3);
 });

--- a/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
+++ b/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
@@ -212,10 +212,10 @@ test('zoe with automaticRefund', async t => {
   // Assert that the correct refund was achieved.
   // Alice had 3 moola and 0 simoleans.
   // Bob had 0 moola and 7 simoleans.
-  t.is(aliceMoolaPurse.getCurrentAmount().value, 3);
-  t.is(aliceSimoleanPurse.getCurrentAmount().value, 0);
-  t.is(bobMoolaPurse.getCurrentAmount().value, 0);
-  t.is(bobSimoleanPurse.getCurrentAmount().value, 17);
+  t.is((await aliceMoolaPurse.getRecentAmount()).value, 3);
+  t.is((await aliceSimoleanPurse.getRecentAmount()).value, 0);
+  t.is((await bobMoolaPurse.getRecentAmount()).value, 0);
+  t.is((await bobSimoleanPurse.getRecentAmount()).value, 17);
 });
 
 test('multiple instances of automaticRefund for the same Zoe', async t => {
@@ -361,8 +361,8 @@ test('zoe - alice tries to complete after completion has already occurred', asyn
 
   // Assert that the correct refund was achieved.
   // Alice had 3 moola and 0 simoleans.
-  t.is(aliceMoolaPurse.getCurrentAmount().value, 3);
-  t.is(aliceSimoleanPurse.getCurrentAmount().value, 0);
+  t.is((await aliceMoolaPurse.getRecentAmount()).value, 3);
+  t.is((await aliceSimoleanPurse.getRecentAmount()).value, 0);
 });
 
 test('zoe - automaticRefund non-fungible', async t => {

--- a/packages/zoe/test/unitTests/contracts/test-coveredCall.js
+++ b/packages/zoe/test/unitTests/contracts/test-coveredCall.js
@@ -326,10 +326,10 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
   // Assert that the correct outcome was achieved.
   // Alice had 3 moola and 0 simoleans.
   // Bob had 0 moola and 7 simoleans.
-  t.deepEqual(aliceMoolaPurse.getCurrentAmount(), moola(3));
-  t.deepEqual(aliceSimoleanPurse.getCurrentAmount(), simoleans(0));
-  t.deepEqual(bobMoolaPurse.getCurrentAmount(), moola(0));
-  t.deepEqual(bobSimoleanPurse.getCurrentAmount(), simoleans(7));
+  t.deepEqual(await aliceMoolaPurse.getRecentAmount(), moola(3));
+  t.deepEqual(await aliceSimoleanPurse.getRecentAmount(), simoleans(0));
+  t.deepEqual(await bobMoolaPurse.getRecentAmount(), moola(0));
+  t.deepEqual(await bobSimoleanPurse.getRecentAmount(), simoleans(7));
 });
 
 // Alice makes a covered call and escrows. She shares the invitation to
@@ -572,16 +572,16 @@ test('zoe - coveredCall with swap for invitation', async t => {
   await daveSimoleanPurse.deposit(daveSimoleanPayout);
   await daveBucksPurse.deposit(daveBucksPayout);
 
-  t.is(aliceMoolaPurse.getCurrentAmount().value, 0);
-  t.is(aliceSimoleanPurse.getCurrentAmount().value, 7);
+  t.is((await aliceMoolaPurse.getRecentAmount()).value, 0);
+  t.is((await aliceSimoleanPurse.getRecentAmount()).value, 7);
 
-  t.is(bobMoolaPurse.getCurrentAmount().value, 0);
-  t.is(bobSimoleanPurse.getCurrentAmount().value, 0);
-  t.is(bobBucksPurse.getCurrentAmount().value, 1);
+  t.is((await bobMoolaPurse.getRecentAmount()).value, 0);
+  t.is((await bobSimoleanPurse.getRecentAmount()).value, 0);
+  t.is((await bobBucksPurse.getRecentAmount()).value, 1);
 
-  t.is(daveMoolaPurse.getCurrentAmount().value, 3);
-  t.is(daveSimoleanPurse.getCurrentAmount().value, 0);
-  t.is(daveBucksPurse.getCurrentAmount().value, 0);
+  t.is((await daveMoolaPurse.getRecentAmount()).value, 3);
+  t.is((await daveSimoleanPurse.getRecentAmount()).value, 0);
+  t.is((await daveBucksPurse.getRecentAmount()).value, 0);
 });
 
 // Alice makes a covered call and escrows. She shares the invitation to
@@ -846,16 +846,16 @@ test('zoe - coveredCall with coveredCall for invitation', async t => {
   await daveSimoleanPurse.deposit(daveSimoleanPayout);
   await daveBucksPurse.deposit(daveBucksPayout);
 
-  t.is(aliceMoolaPurse.getCurrentAmount().value, 0);
-  t.is(aliceSimoleanPurse.getCurrentAmount().value, 7);
+  t.is((await aliceMoolaPurse.getRecentAmount()).value, 0);
+  t.is((await aliceSimoleanPurse.getRecentAmount()).value, 7);
 
-  t.is(bobMoolaPurse.getCurrentAmount().value, 0);
-  t.is(bobSimoleanPurse.getCurrentAmount().value, 0);
-  t.is(bobBucksPurse.getCurrentAmount().value, 1);
+  t.is((await bobMoolaPurse.getRecentAmount()).value, 0);
+  t.is((await bobSimoleanPurse.getRecentAmount()).value, 0);
+  t.is((await bobBucksPurse.getRecentAmount()).value, 1);
 
-  t.is(daveMoolaPurse.getCurrentAmount().value, 3);
-  t.is(daveSimoleanPurse.getCurrentAmount().value, 0);
-  t.is(daveBucksPurse.getCurrentAmount().value, 0);
+  t.is((await daveMoolaPurse.getRecentAmount()).value, 3);
+  t.is((await daveSimoleanPurse.getRecentAmount()).value, 0);
+  t.is((await daveBucksPurse.getRecentAmount()).value, 0);
 });
 
 // Alice uses a covered call to sell a cryptoCat to Bob for the
@@ -993,8 +993,8 @@ test('zoe - coveredCall non-fungible', async t => {
   // Assert that the correct payouts were received.
   // Alice had growlTiger and no RPG tokens.
   // Bob had an empty CryptoCat purse and the Glorious Shield.
-  t.deepEqual(aliceCcPurse.getCurrentAmount().value, []);
-  t.deepEqual(aliceRpgPurse.getCurrentAmount().value, aGloriousShield);
-  t.deepEqual(bobCcPurse.getCurrentAmount().value, ['GrowlTiger']);
-  t.deepEqual(bobRpgPurse.getCurrentAmount().value, []);
+  t.deepEqual((await aliceCcPurse.getRecentAmount()).value, []);
+  t.deepEqual((await aliceRpgPurse.getRecentAmount()).value, aGloriousShield);
+  t.deepEqual((await bobCcPurse.getRecentAmount()).value, ['GrowlTiger']);
+  t.deepEqual((await bobRpgPurse.getRecentAmount()).value, []);
 });

--- a/packages/zoe/test/unitTests/contracts/test-secondPriceAuction.js
+++ b/packages/zoe/test/unitTests/contracts/test-secondPriceAuction.js
@@ -379,10 +379,10 @@ test('zoe - secondPriceAuction - alice tries to exit', async t => {
   );
 
   // Assert that the correct refunds were received.
-  t.is(aliceMoolaPurse.getCurrentAmount().value, 0);
-  t.is(aliceSimoleanPurse.getCurrentAmount().value, 8);
-  t.is(bobMoolaPurse.getCurrentAmount().value, 0);
-  t.is(bobSimoleanPurse.getCurrentAmount().value, 11);
+  t.is((await aliceMoolaPurse.getRecentAmount()).value, 0);
+  t.is((await aliceSimoleanPurse.getRecentAmount()).value, 8);
+  t.is((await bobMoolaPurse.getRecentAmount()).value, 0);
+  t.is((await bobSimoleanPurse.getRecentAmount()).value, 11);
 });
 
 // Three bidders with (fungible) moola bid for a CryptoCat
@@ -665,12 +665,12 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
   // Bob: the CryptoCat and 4 moola
   // Carol: an empty CryptoCat purse and 7 moola
   // Dave: an empty CryptoCat purse and 5 moola
-  t.deepEqual(aliceCcPurse.getCurrentAmount().value, []);
-  t.is(aliceMoolaPurse.getCurrentAmount().value, 7);
-  t.deepEqual(bobCcPurse.getCurrentAmount().value, ['Felix']);
-  t.is(bobMoolaPurse.getCurrentAmount().value, 4);
-  t.deepEqual(carolCcPurse.getCurrentAmount().value, []);
-  t.is(carolMoolaPurse.getCurrentAmount().value, 7);
-  t.deepEqual(daveCcPurse.getCurrentAmount().value, []);
-  t.is(daveMoolaPurse.getCurrentAmount().value, 5);
+  t.deepEqual((await aliceCcPurse.getRecentAmount()).value, []);
+  t.is((await aliceMoolaPurse.getRecentAmount()).value, 7);
+  t.deepEqual((await bobCcPurse.getRecentAmount()).value, ['Felix']);
+  t.is((await bobMoolaPurse.getRecentAmount()).value, 4);
+  t.deepEqual((await carolCcPurse.getRecentAmount()).value, []);
+  t.is((await carolMoolaPurse.getRecentAmount()).value, 7);
+  t.deepEqual((await daveCcPurse.getRecentAmount()).value, []);
+  t.is((await daveMoolaPurse.getRecentAmount()).value, 5);
 });

--- a/packages/zoe/test/unitTests/contracts/test-sellTickets.js
+++ b/packages/zoe/test/unitTests/contracts/test-sellTickets.js
@@ -487,7 +487,7 @@ test(`mint and sell opera tickets`, async t => {
 
     const moneyPayment = await E(sellItemsCreatorSeat).getPayout('Money');
     await E(operaPurse).deposit(moneyPayment);
-    const currentPurseBalance = await E(operaPurse).getCurrentAmount();
+    const currentPurseBalance = await E(operaPurse).getRecentAmount();
 
     t.is(
       currentPurseBalance.value,


### PR DESCRIPTION
Fixes #2100 

#documentation-branch: current-patch-21-12-20