### PR TITLE
Add 'getRecentCollateralAmount` to loan contract's `borrowFacet`

### DIFF
--- a/packages/zoe/src/contracts/exported.js
+++ b/packages/zoe/src/contracts/exported.js
@@ -399,4 +399,8 @@
  *
  * Get notified when the current debt (an Amount in the Loan Brand) changes. This will
  * increase as interest is added.
+ *
+ * @property {() => Amount} getRecentCollateralAmount
+ *
+ * Get a recent report of the amount of collateral in the loan
  */

--- a/packages/zoe/src/contracts/loan/borrow.js
+++ b/packages/zoe/src/contracts/loan/borrow.js
@@ -157,6 +157,8 @@ export const makeBorrowInvitation = (zcf, config) => {
         makeAddCollateralInvitation(zcf, configWithBorrower),
       getLiquidationPromise: () => liquidationPromiseKit.promise,
       getDebtNotifier,
+      getRecentCollateralAmount: () =>
+        collateralSeat.getAmountAllocated('Collateral'),
     };
 
     return harden(borrowFacet);

--- a/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
@@ -113,6 +113,7 @@ const setupBorrowFacet = async (collateralValue = 1000, maxLoanValue = 100) => {
 
   return {
     ...setup,
+    collateral,
     borrowSeat,
     borrowFacet,
   };
@@ -170,6 +171,12 @@ test('borrow getDebtNotifier', async t => {
   const debtNotifier = await E(borrowFacet).getDebtNotifier();
   const state = await debtNotifier.getUpdateSince();
   t.deepEqual(state.value, maxLoan);
+});
+
+test('borrow getRecentCollateralAmount', async t => {
+  const { borrowFacet, collateral } = await setupBorrowFacet();
+  const collateralAmount = await E(borrowFacet).getRecentCollateralAmount();
+  t.deepEqual(collateralAmount, collateral);
 });
 
 test('borrow getLiquidationPromise', async t => {
@@ -289,7 +296,6 @@ test('getDebtNotifier with interest', async t => {
     maxLoan,
     periodUpdater,
     zoe,
-    collateralKit,
     loanKit,
   } = await setupBorrowFacet(100000, 40000);
   const debtNotifier = await E(borrowFacet).getDebtNotifier();
@@ -318,9 +324,11 @@ test('getDebtNotifier with interest', async t => {
   const closeLoanInvitation = E(borrowFacet).makeCloseLoanInvitation();
   await checkDescription(t, zoe, closeLoanInvitation, 'repayAndClose');
 
+  const collateral = await E(borrowFacet).getRecentCollateralAmount();
+
   const proposal = harden({
     give: { Loan: loanKit.amountMath.make(40000) },
-    want: { Collateral: collateralKit.amountMath.make(10) },
+    want: { Collateral: collateral },
   });
 
   const payments = harden({


### PR DESCRIPTION
This PR adds a method to the borrowFacet to allow the borrower to query the recent amount of collateral escrowed in the loan contract. This is needed for the demo. 

Closes #2111 