### PR TITLE
chore: change the loan contract so it accepts a periodNotifier instead of a periodAsyncIterable

### DIFF
--- a/packages/zoe/src/contracts/loan/index.js
+++ b/packages/zoe/src/contracts/loan/index.js
@@ -3,6 +3,7 @@ import '../../../exported';
 
 import { assert } from '@agoric/assert';
 
+import { makeAsyncIterableFromNotifier } from '@agoric/notifier';
 import { assertIssuerKeywords } from '../../contractSupport';
 import { makeLendInvitation } from './lend';
 
@@ -35,9 +36,10 @@ import { makeLendInvitation } from './lend';
  *    or Multipool Autoswap installation. The publicFacet of the
  *    instance is used for producing an invitation to sell the
  *    collateral on liquidation.
- *  * periodAsyncIterable - the asyncIterable used for notifications
+ *  * periodNotifier - the notifier used for notifications
  *    that a period has passed, on which compound interest will be
- *    calculated using the interestRate.
+ *    calculated using the interestRate. Note that this is lossy, and
+ *    therefore could be missing periods. There is a TODO to fix this (https://github.com/Agoric/agoric-sdk/issues/2108)
  *  * interestRate - the rate in basis points that will be multiplied
  *    with the debt on every period to compound interest.
  *
@@ -59,14 +61,18 @@ const start = async zcf => {
     mmr = 150, // Maintenance Margin Requirement
     autoswapInstance,
     priceAuthority,
-    periodAsyncIterable,
+    periodNotifier,
     interestRate,
   } = zcf.getTerms();
 
   assert(autoswapInstance, `autoswapInstance must be provided`);
   assert(priceAuthority, `priceAuthority must be provided`);
-  assert(periodAsyncIterable, `periodAsyncIterable must be provided`);
+  assert(periodNotifier, `periodNotifier must be provided`);
   assert(interestRate, `interestRate must be provided`);
+
+  // TODO: make this non-lossy (notifier is lossy)
+  // https://github.com/Agoric/agoric-sdk/issues/2108
+  const periodAsyncIterable = makeAsyncIterableFromNotifier(periodNotifier);
 
   /** @type {LoanTerms} */
   const config = {

--- a/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
@@ -64,9 +64,11 @@ const setupBorrow = async (maxLoanValue = 100) => {
     initialLiquidityKeywordRecord,
   );
 
+  // In the config that the borrow code sees, the periodNotifier has
+  // been adapted to a periodAsyncIterable
   const {
     publication: periodUpdater,
-    subscription: periodSubscription,
+    subscription: periodAsyncIterable,
   } = makeSubscriptionKit();
 
   const interestRate = 5;
@@ -78,7 +80,7 @@ const setupBorrow = async (maxLoanValue = 100) => {
     priceAuthority,
     makeCloseLoanInvitation,
     makeAddCollateralInvitation,
-    periodAsyncIterable: periodSubscription,
+    periodAsyncIterable,
     interestRate,
   };
   // @ts-ignore
@@ -89,7 +91,7 @@ const setupBorrow = async (maxLoanValue = 100) => {
     maxLoan,
     lenderUserSeat,
     periodUpdater,
-    periodAsyncIterable: periodSubscription,
+    periodAsyncIterable,
     timer,
     priceAuthority,
   };

--- a/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
@@ -8,7 +8,7 @@ import test from 'ava';
 import { E } from '@agoric/eventual-send';
 
 import bundleSource from '@agoric/bundle-source';
-import { makeSubscriptionKit } from '@agoric/notifier';
+import { makeNotifierKit } from '@agoric/notifier';
 
 import { checkDetails, checkPayout } from './helpers';
 import { setup } from '../../setupBasicMints';
@@ -56,13 +56,13 @@ test('loan - lend - exit before borrow', async t => {
     timer,
   });
 
-  const { subscription: periodAsyncIterable } = makeSubscriptionKit();
+  const { notifier: periodNotifier } = makeNotifierKit();
 
   const terms = {
     mmr: 150,
     autoswapInstance,
     priceAuthority,
-    periodAsyncIterable,
+    periodNotifier,
     interestRate: 5,
   };
 


### PR DESCRIPTION
This PR is a temporary fix for the demo while we are sorting out the problems of handling `asyncIterables` in Swingset (https://github.com/Agoric/agoric-sdk/issues/2092). 

It is a temporary fix because the contract is designed to have a non-lossy indication of when a period has ended/begun and thus when interest should be charged. This change makes the indications lossy. 

There is an Github ticket to fix the lossy data issue: https://github.com/Agoric/agoric-sdk/issues/2108

Closes #2114

#documentation-branch: 2114-loan-period-notifier