### PR TITLE
chore: change E(zoe).startInstance to accept promises for installations

### DIFF
--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -67,7 +67,7 @@
  * the creator facet, public facet, and creator invitation as defined
  * by the contract.
  *
- * @param {Installation} installation
+ * @param {ERef<Installation>} installation
  * @param {IssuerKeywordRecord=} issuerKeywordRecord
  * @param {Object=} terms
  * @returns {Promise<StartInstanceResult>}

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -94,13 +94,15 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
       return getAmountOfInvitationThen(invitation, onFulfilled);
     },
     startInstance: async (
-      installation,
+      installationP,
       uncleanIssuerKeywordRecord = harden({}),
       customTerms = harden({}),
     ) => {
       /** @param {Issuer[]} issuers */
       const initIssuers = issuers =>
         Promise.all(issuers.map(issuerTable.initIssuer));
+
+      const installation = await Promise.resolve(installationP);
       assert(
         installations.has(installation),
         details`${installation} was not a valid installation`,

--- a/packages/zoe/test/swingsetTests/zoe/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-alice.js
@@ -222,7 +222,8 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     });
     const { simpleExchange } = installations;
     const { publicFacet } = await E(zoe).startInstance(
-      simpleExchange,
+      // Either installations or promises for installations can be used
+      Promise.resolve(simpleExchange),
       issuerKeywordRecord,
     );
 

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -4,6 +4,7 @@ import '@agoric/install-ses';
 import test from 'ava';
 
 import { E } from '@agoric/eventual-send';
+import { makePromiseKit } from '@agoric/promise-kit';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import bundleSource from '@agoric/bundle-source';
@@ -54,6 +55,35 @@ test(`zoe.startInstance bad installation`, async t => {
 test(`zoe.startInstance no issuerKeywordRecord, no terms`, async t => {
   const { zoe, installation } = await setupZCFTest();
   const result = await E(zoe).startInstance(installation);
+  // Note that deepEqual treats all empty objects (handles) as interchangeable.
+  t.deepEqual(Object.getOwnPropertyNames(result).sort(), [
+    'adminFacet',
+    'creatorFacet',
+    'creatorInvitation',
+    'instance',
+    'publicFacet',
+  ]);
+  t.deepEqual(result.creatorFacet, {});
+  t.deepEqual(result.creatorInvitation, undefined);
+  t.deepEqual(result.instance, result.instance);
+  t.deepEqual(result.publicFacet, {});
+  t.deepEqual(Object.getOwnPropertyNames(result.adminFacet).sort(), [
+    'getVatShutdownPromise',
+    'getVatStats',
+  ]);
+});
+
+test(`zoe.startInstance promise for installation`, async t => {
+  const { zoe, installation } = await setupZCFTest();
+  const {
+    promise: installationP,
+    resolve: installationPResolve,
+  } = makePromiseKit();
+
+  const resultP = E(zoe).startInstance(installationP);
+  installationPResolve(installation);
+
+  const result = await resultP;
   // Note that deepEqual treats all empty objects (handles) as interchangeable.
   t.deepEqual(Object.getOwnPropertyNames(result).sort(), [
     'adminFacet',

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -65,7 +65,6 @@ test(`zoe.startInstance no issuerKeywordRecord, no terms`, async t => {
   ]);
   t.deepEqual(result.creatorFacet, {});
   t.deepEqual(result.creatorInvitation, undefined);
-  t.deepEqual(result.instance, result.instance);
   t.deepEqual(result.publicFacet, {});
   t.deepEqual(Object.getOwnPropertyNames(result.adminFacet).sort(), [
     'getVatShutdownPromise',
@@ -94,7 +93,6 @@ test(`zoe.startInstance promise for installation`, async t => {
   ]);
   t.deepEqual(result.creatorFacet, {});
   t.deepEqual(result.creatorInvitation, undefined);
-  t.deepEqual(result.instance, result.instance);
   t.deepEqual(result.publicFacet, {});
   t.deepEqual(Object.getOwnPropertyNames(result.adminFacet).sort(), [
     'getVatShutdownPromise',


### PR DESCRIPTION
This PR changes `E(zoe).startInstance` to accept promises for installations in addition to installations. This is useful for the deploy scripts, such that there are fewer roundtrips.