### PR TITLE
feat: add amountMath.find

### DIFF
--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -94,7 +94,7 @@ function makeAmountMath(brand, amountMathKind) {
   const cache = new WeakSet();
 
   /** @type {AmountMath} */
-  const amountMath = harden({
+  const amountMath = {
     getBrand: () => brand,
     getAmountMathKind: () => amountMathKind,
 
@@ -181,9 +181,21 @@ function makeAmountMath(brand, amountMathKind) {
           amountMath.getValue(rightAmount),
         ),
       ),
-  });
+    // Return the amount included in leftAmount that matches
+    // searchAmount, a potentially partial description of digital
+    // assets. This method is used especially in non-fungible token
+    // cases to find an amount describing digital assets based on a
+    // partial description of the assets.
+    find: (leftAmount, searchAmount) =>
+      amountMath.make(
+        helpers.doFind(
+          amountMath.getValue(leftAmount),
+          amountMath.getValue(searchAmount),
+        ),
+      ),
+  };
   const empty = amountMath.make(helpers.doGetEmpty());
-  return amountMath;
+  return harden(amountMath);
 }
 
 harden(makeAmountMath);

--- a/packages/ERTP/src/mathHelpers/natMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/natMathHelpers.js
@@ -18,7 +18,7 @@ const identity = 0;
  *
  * @type {MathHelpers}
  */
-const natMathHelpers = harden({
+const natMathHelpers = {
   doCoerce: Nat,
   doGetEmpty: _ => identity,
   doIsEmpty: nat => nat === identity,
@@ -26,7 +26,14 @@ const natMathHelpers = harden({
   doIsEqual: (left, right) => left === right,
   doAdd: (left, right) => Nat(left + right),
   doSubtract: (left, right) => Nat(left - right),
-});
+  doFind: (left, searchParameters) => {
+    if (natMathHelpers.doIsGTE(left, searchParameters)) {
+      return searchParameters;
+    }
+    // No match found.
+    return identity;
+  },
+};
 
 harden(natMathHelpers);
 export default natMathHelpers;

--- a/packages/ERTP/src/mathHelpers/strSetMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/strSetMathHelpers.js
@@ -21,7 +21,7 @@ const checkForDupes = list => {
  *
  * @type {MathHelpers}
  */
-const strSetMathHelpers = harden({
+const strSetMathHelpers = {
   doCoerce: list => {
     assert(passStyleOf(list) === 'copyArray', 'value must be an array');
     list.forEach(elem => assert.typeof(elem, 'string'));
@@ -62,7 +62,36 @@ const strSetMathHelpers = harden({
     );
     return harden(Array.from(leftSet));
   },
-});
+  doFind: (left, searchParameters) => {
+    const makeIsPrefix = prefix => {
+      const isPrefix = str => str.startsWith(prefix);
+      return isPrefix;
+    };
+    let matchNotFound = false;
+    let arrayOfArrays;
+    try {
+      arrayOfArrays = searchParameters.map(prefix => {
+        const isPrefix = makeIsPrefix(prefix);
+        const arrayOfMatchingStrs = left.filter(isPrefix);
+        if (arrayOfMatchingStrs.length <= 0) {
+          matchNotFound = true;
+          throw Error('match was not found');
+        }
+        return arrayOfMatchingStrs;
+      });
+    } catch (err) {
+      if (matchNotFound) {
+        // At least one prefix did not have a match
+        return identity;
+      } else {
+        throw err;
+      }
+    }
+    // remove duplicates by using a Set
+    const matchingSet = new Set(arrayOfArrays.flat());
+    return harden(Array.from(matchingSet));
+  },
+};
 
 harden(strSetMathHelpers);
 export default strSetMathHelpers;

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -104,7 +104,10 @@
  * keys and values with some keys and values omitted in the case of MathKind.SET.
  * If searchAmount.value is an array as in the case of MathKind.STRING_SET
  * and MathKind.SET, every element of the array must have a match or
- * the identity element is returned.
+ * the identity element is returned. Additionally, if
+ * searchAmount.value is an array, a separate search is performed for each element
+ * in searchAmount.value and the results are returned in an array with
+ * any duplicates among the searches removed.
  */
 
 /**

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -95,6 +95,16 @@
  * (subtraction results in a negative), throw  an error. Because the
  * left amount must include the right amount, this is NOT equivalent
  * to set subtraction.
+ *
+ * @property {(leftAmount: Amount, searchAmount: Amount) => Amount} find
+ * Returns a new amount that represents the parts of leftAmount that "match" the
+ * value of searchAmount. If nothing matches, the identity element is returned.
+ * Use this method to find an amount in leftAmount using partial descriptions in
+ * searchAmount, such as string prefixes in the case of MathKind.STRING_SET or
+ * keys and values with some keys and values omitted in the case of MathKind.SET.
+ * If searchAmount.value is an array as in the case of MathKind.STRING_SET
+ * and MathKind.SET, every element of the array must have a match or
+ * the identity element is returned.
  */
 
 /**
@@ -335,8 +345,17 @@
  * @property {(left: Value, right: Value) => Value} doSubtract
  * Return what remains after removing the right from the left. If
  * something in the right was not in the left, we throw an error.
- */
-
+ *
+ * @property {(left: Value, searchParameters: Value) => Value} doFind
+ * Return the parts of left that "match" the searchParameters. The
+ * searchParameters must be a Value themselves, but may
+ * represent a partial description of parts of left. For example, a
+ * partial description might be a prefix of a string, or a record with
+ * keys and values where some keys and values are omitted. If
+ * searchParameters is an array as in the case of MathKind.STRING_SET
+ * and MathKind.SET, every element of the array must have a match or
+ * the identity element is returned.
+ 
 /**
  * @typedef {{ISSUER: 'issuer', BRAND: 'brand', PURSE: 'purse', PAYMENT:
  * 'payment', MINT: 'mint', DEPOSIT_FACET: 'depositFacet' }} ERTPKind

--- a/packages/ERTP/test/unitTests/mathHelpers/test-setMathHelpersInternal.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-setMathHelpersInternal.js
@@ -1,0 +1,160 @@
+// @ts-check
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import test from 'ava';
+
+import {
+  hashBadly,
+  makeBuckets,
+  removeDuplicates,
+  makeGetStr,
+  makeGetBucketKeyBasedOnSearchRecord,
+} from '../../../src/mathHelpers/setMathHelpers';
+import { makeIssuerKit } from '../../../src';
+
+test('hashBadly basics', t => {
+  t.is(hashBadly({}), '');
+  t.is(hashBadly({ name: 'a' }), 'name,a');
+  t.is(hashBadly({ instance: {} }), 'instance');
+});
+
+// Note that hashBadly is not narrowing the comparisons very well for
+// invitations, apart from the description value, because most values
+// are not strings
+test('hashBadly invitationDetails', t => {
+  const mockTimeAuthority = {
+    tick: () => {},
+  };
+  const mockInstallation = {
+    getBundle: () => {},
+  };
+  const { amountMath: moolaAmountMath } = makeIssuerKit('moola');
+  const { amountMath: simoleanAmountMath } = makeIssuerKit('simolean');
+  const underlyingAssets = {
+    UnderlyingAssets: moolaAmountMath.make(3),
+  };
+  const strikePrice = {
+    StrikePrice: simoleanAmountMath.make(7),
+  };
+  const invitationDetails = {
+    expirationDate: 100,
+    timeAuthority: mockTimeAuthority,
+    underlyingAssets,
+    strikePrice,
+    description: 'exerciseOption',
+    handle: {},
+    instance: {},
+    installation: mockInstallation,
+  };
+  t.is(
+    hashBadly(invitationDetails),
+    'description,expirationDate,handle,installation,instance,strikePrice,timeAuthority,underlyingAssets,exerciseOption',
+  );
+
+  const invitationDetailsPartial = {
+    expirationDate: 100,
+    strikePrice,
+    timeAuthority: mockTimeAuthority,
+    installation: mockInstallation,
+    description: 'exerciseOption',
+  };
+  t.is(
+    hashBadly(invitationDetailsPartial),
+    'description,expirationDate,installation,strikePrice,timeAuthority,exerciseOption',
+  );
+});
+
+test('hashBadly tickets', t => {
+  const record = { number: 1, show: 'Les Mis' };
+  t.is(hashBadly(record), 'number,show,Les Mis');
+});
+
+test('removeDuplicates empty array', t => {
+  const buckets = makeBuckets(harden([]));
+  t.deepEqual(removeDuplicates(buckets), []);
+});
+
+test('removeDuplicates one element array', t => {
+  const buckets = makeBuckets(harden([{ a: 'b' }]));
+  t.deepEqual(removeDuplicates(buckets), [{ a: 'b' }]);
+});
+
+test('removeDuplicates duplicate', t => {
+  const buckets = makeBuckets(harden([{ a: 'b' }, { a: 'b' }]));
+  t.deepEqual(removeDuplicates(buckets), [{ a: 'b' }]);
+});
+
+test('removeDuplicates not duplicate', t => {
+  const buckets = makeBuckets(harden([{ a: 'b' }, { a: 'not b' }]));
+  t.deepEqual(removeDuplicates(buckets), [{ a: 'b' }, { a: 'not b' }]);
+});
+
+test('removeDuplicates not duplicate with non-string values', t => {
+  const value1 = {};
+  const value2 = {};
+  const buckets = makeBuckets(harden([{ a: value1 }, { a: value2 }]));
+  t.deepEqual(removeDuplicates(buckets), [{ a: value1 }, { a: value2 }]);
+});
+
+test('getStr', t => {
+  const getStr = makeGetStr();
+  t.is(getStr('a'), 'a');
+  // Anything not a string and not a presence gets a default string value
+  t.is(getStr(harden(Promise.resolve())), '0');
+  const presence = { doSomething: () => {} };
+  const presence2 = { ...presence };
+  t.is(getStr(harden(presence)), '1');
+  // repeated actions get same answer
+  t.is(getStr(harden(presence)), '1');
+  // presences not yet seen get a new string
+  t.is(getStr(harden(presence2)), '2');
+  t.is(getStr(harden(presence2)), '2');
+
+  // Anything not a string and not a presence gets a default string value
+  t.is(getStr(harden({ name: 'a ' })), '0');
+});
+
+test('getBucketKeyBasedOnSearchRecord', t => {
+  const mockTimeAuthority = {
+    tick: () => {},
+  };
+  const mockInstallation = {
+    getBundle: () => {},
+  };
+  const { amountMath: moolaAmountMath } = makeIssuerKit('moola');
+  const { amountMath: simoleanAmountMath } = makeIssuerKit('simolean');
+  const underlyingAssets = {
+    UnderlyingAssets: moolaAmountMath.make(3),
+  };
+  const strikePrice = {
+    StrikePrice: simoleanAmountMath.make(7),
+  };
+  const invitationDetails = harden({
+    expirationDate: 100,
+    timeAuthority: mockTimeAuthority,
+    underlyingAssets,
+    strikePrice,
+    description: 'exerciseOption',
+    handle: {},
+    instance: {},
+    installation: mockInstallation,
+  });
+  const searchRecord = harden({
+    expirationDate: 100,
+    strikePrice,
+    timeAuthority: mockTimeAuthority,
+    installation: mockInstallation,
+    description: 'exerciseOption',
+  });
+  const getBucketKey = makeGetBucketKeyBasedOnSearchRecord(searchRecord);
+  t.is(
+    getBucketKey(invitationDetails),
+    'description,exerciseOption,expirationDate,0,installation,1,strikePrice,0,timeAuthority,2',
+  );
+  t.is(
+    getBucketKey(searchRecord),
+    'description,exerciseOption,expirationDate,0,installation,1,strikePrice,0,timeAuthority,2',
+  );
+  // Our searchRecord MUST be in the same bucket as the full thing
+  t.is(getBucketKey(invitationDetails), getBucketKey(searchRecord));
+});


### PR DESCRIPTION
This PR adds `amountMath.find`. 

`amountMath.find` takes in a `leftAmount` and a `searchAmount`. It returns a new amount that represents the parts of leftAmount that "match" the value of searchAmount. If nothing matches, the identity element is returned. For example:

```js
const leftAmount = make(harden(['abc', 'ab', 'b']));
const searchAmount = make(harden(['a']));
find(leftAmount, searchAmount);
// returns equivalent of make(harden(['abc', 'ab']));
```


and

```js
const leftAmount = make(harden([{ name: 'a', handle: {} }, { name: 'b', handle: {} }]));
const searchAmount = make(harden([{ name: 'b'}]));
find(leftAmount, searchAmount)
// returns equivalent of make(harden([{ name: 'b', handle: {} }]))
``` 

This method can be used to find an amount in leftAmount using partial descriptions in searchAmount, such as string prefixes in the case of MathKind.STRING_SET or keys and values with some keys and values omitted in the case of MathKind.SET. If searchAmount.value is an array as in the case of MathKind.STRING_SET and MathKind.SET, every element of the array must have a match or the identity element is returned. Additionally, if searchAmount.value is an array, a separate search is performed for each element in searchAmount.value and the results are returned in an array with any duplicates among the searches removed.

This PR adds a number of tests, but further usages of `amountMath.find` are left out. I will follow up with a few PRs stacked on this one.

Business value with further usages:
* Enables support for denoms (https://github.com/Agoric/agoric-sdk/issues/1913)
* Enables support for flexible wants in Zoe (https://github.com/Agoric/agoric-sdk/issues/1915)
* Enables searching for and withdrawing an invitation from the wallet without knowing the invitation handle (https://github.com/Agoric/agoric-sdk/issues/2120)

### Changes to setMathHelpers
It was significantly easier to implement this by reducing the flexibility of `setMathHelpers`. Instead of allowing arrays of anything comparable, I restricted `setMathHelpers` to only operate on arrays of records with string keys. 

Related https://github.com/Agoric/agoric-sdk/pull/1905