### PR TITLE
feat: allow flexible wants in Zoe

### DIFF
--- a/packages/zoe/src/contractFacet/offerSafety.js
+++ b/packages/zoe/src/contractFacet/offerSafety.js
@@ -18,7 +18,22 @@ const satisfiesInternal = (getAmountMath, giveOrWant = {}, allocation) => {
     }
     const amountMath = getAmountMath(requiredAmount.brand);
     const allocationAmount = allocation[keyword];
-    return amountMath.isGTE(allocationAmount, requiredAmount);
+
+    // if requiredAmount is empty, it is not a useful searchAmount and
+    // we can return early
+    if (amountMath.isEmpty(requiredAmount)) {
+      return amountMath.isGTE(allocationAmount, requiredAmount);
+    }
+
+    const matchingAmount = amountMath.find(allocationAmount, requiredAmount);
+    // If matchingAmount is empty, no match was found and
+    // requiredAmount is not satisfied
+    if (amountMath.isEmpty(matchingAmount)) {
+      return false;
+    }
+    // A match was found, but allocationAmount needs to be GTE to
+    // matchingAmount for requiredAmount to be satisfied
+    return amountMath.isGTE(allocationAmount, matchingAmount);
   };
   return Object.entries(giveOrWant).every(isGTEByKeyword);
 };

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -69,11 +69,15 @@ const start = zcf => {
     const providedMoney = buyerSeat.getAmountAllocated('Money');
 
     const {
-      want: { Items: wantedItems },
+      want: { Items: wantedSearchAmount },
     } = buyerSeat.getProposal();
 
     // Check that the wanted items are still for sale.
-    if (!itemsMath.isGTE(currentItemsForSale, wantedItems)) {
+    const wantedItems = itemsMath.find(currentItemsForSale, wantedSearchAmount);
+    if (
+      itemsMath.isEmpty(wantedItems) ||
+      !itemsMath.isGTE(currentItemsForSale, wantedItems)
+    ) {
       const rejectMsg = `Some of the wanted items were not available for sale`;
       throw buyerSeat.fail(new Error(rejectMsg));
     }

--- a/packages/zoe/test/unitTests/contracts/test-coveredCall.js
+++ b/packages/zoe/test/unitTests/contracts/test-coveredCall.js
@@ -490,8 +490,20 @@ test('zoe - coveredCall with swap for invitation', async t => {
   // knows this to be true because he knows the swap.
 
   // Dave escrows his 1 buck with Zoe and forms his proposal
+  const searchAmountForOption = invitationAmountMath.make(
+    harden([
+      {
+        installation: coveredCallInstallation,
+        description: 'exerciseOption',
+        underlyingAssets: { UnderlyingAsset: moola(3) },
+        strikePrice: { StrikePrice: simoleans(7) },
+        expirationDate: 100,
+        timeAuthority: timer,
+      },
+    ]),
+  );
   const daveSwapProposal = harden({
-    want: { Asset: optionAmount },
+    want: { Asset: searchAmountForOption },
     give: { Price: bucks(1) },
   });
 
@@ -752,8 +764,19 @@ test('zoe - coveredCall with coveredCall for invitation', async t => {
   );
 
   // Dave's planned proposal
+  const searchAmount = invitationAmountMath.make(
+    harden([
+      {
+        description: 'exerciseOption',
+        expirationDate: 100,
+        strikePrice: { StrikePrice: simoleans(7) },
+        timeAuthority: timer,
+        installation: coveredCallInstallation,
+      },
+    ]),
+  );
   const daveProposalCoveredCall = harden({
-    want: daveOptionValue.underlyingAssets,
+    want: { UnderlyingAsset: searchAmount },
     give: { StrikePrice: bucks(1) },
   });
 

--- a/packages/zoe/test/unitTests/contracts/test-sellTickets.js
+++ b/packages/zoe/test/unitTests/contracts/test-sellTickets.js
@@ -222,16 +222,9 @@ test(`mint and sell opera tickets`, async t => {
       `availableTickets contains ticket number 3`,
     );
 
-    // find the value corresponding to ticket #1
-    const ticket1Value = availableTickets.value.find(
-      ticket => ticket.number === 1,
-    );
-    // make the corresponding amount
-    const ticket1Amount = ticketAmountMath.make(harden([ticket1Value]));
-
     const aliceProposal = harden({
       give: { Money: terms.pricePerItem },
-      want: { Items: ticket1Amount },
+      want: { Items: ticketAmountMath.make(harden([{ number: 1 }])) },
     });
 
     const alicePaymentForTicket = alicePurse.withdraw(terms.pricePerItem);
@@ -246,6 +239,10 @@ test(`mint and sell opera tickets`, async t => {
     const aliceTickets = seat.getPayout('Items');
     const aliceBoughtTicketAmount = await E(ticketIssuer).getAmountOf(
       aliceTickets,
+    );
+    t.is(
+      await E(seat).getOfferResult(),
+      'The offer has been accepted. Once the contract has been completed, please check your payout',
     );
 
     t.is(
@@ -282,11 +279,9 @@ test(`mint and sell opera tickets`, async t => {
 
     // Joker does NOT check available tickets and tries to buy the ticket
     // number 1(already bought by Alice, but he doesn't know)
-    const ticket1Amount = ticketAmountMath.make(
+    const ticket1SearchAmount = ticketAmountMath.make(
       harden([
         {
-          show: 'Steven Universe, the Opera',
-          start: 'Wed, March 25th 2020 at 8pm',
           number: 1,
         },
       ]),
@@ -294,7 +289,7 @@ test(`mint and sell opera tickets`, async t => {
 
     const jokerProposal = harden({
       give: { Money: pricePerItem },
-      want: { Items: ticket1Amount },
+      want: { Items: ticket1SearchAmount },
     });
 
     const jokerPaymentForTicket = jokerPurse.withdraw(pricePerItem);
@@ -350,11 +345,9 @@ test(`mint and sell opera tickets`, async t => {
     const jokerPurse = await E(moolaIssuer).makeEmptyPurse();
     await E(jokerPurse).deposit(moola100Payment);
 
-    const ticket2Amount = ticketAmountMath.make(
+    const ticket2SearchAmount = ticketAmountMath.make(
       harden([
         {
-          show: 'Steven Universe, the Opera',
-          start: 'Wed, March 25th 2020 at 8pm',
           number: 2,
         },
       ]),
@@ -363,7 +356,7 @@ test(`mint and sell opera tickets`, async t => {
     const insufficientAmount = moola(1);
     const jokerProposal = harden({
       give: { Money: insufficientAmount },
-      want: { Items: ticket2Amount },
+      want: { Items: ticket2SearchAmount },
     });
 
     const jokerInsufficientPaymentForTicket = jokerPurse.withdraw(
@@ -443,18 +436,15 @@ test(`mint and sell opera tickets`, async t => {
     );
 
     // Bob buys tickets 2 and 3
-    const ticket2and3Amount = ticketAmountMath.make(
-      harden([
-        availableTickets.value.find(ticket => ticket.number === 2),
-        availableTickets.value.find(ticket => ticket.number === 3),
-      ]),
+    const ticket2and3SearchAmount = ticketAmountMath.make(
+      harden([{ number: 2 }, { number: 3 }]),
     );
 
     const totalCost = moola(2 * terms.pricePerItem.value);
 
     const bobProposal = harden({
       give: { Money: totalCost },
-      want: { Items: ticket2and3Amount },
+      want: { Items: ticket2and3SearchAmount },
     });
     const bobPaymentForTicket = await E(bobPurse).withdraw(totalCost);
     const paymentKeywordRecord = harden({

--- a/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
@@ -92,7 +92,7 @@ test(`zoeHelper with zcf - swap no match`, async t => {
     () => swap(zcf, aZcfSeat, bZcfSeat),
     {
       message:
-        'The trade between left [object Object] and right [object Object] failed.',
+        'The trade between fromSeat (an object) and toSeat (an object) failed because (an object) was not found.',
     },
     'mismatched offers',
   );


### PR DESCRIPTION
This PR is stacked on top of #2155.

It uses `amountMath.find` in Zoe to allow for flexible wants. This is primarily a change in `offerSafety.js`, but in order for `swap` and `swapExact` to still work, a helper (`findFromOtherSeat`) was added. 

The tests take advantage of the new-found flexibility in the locations listed [here](https://github.com/Agoric/agoric-sdk/pull/1905#issuecomment-715626426).

Closes #1913
Closes #1915



