### PR TITLE
fix(kernel): don't lose managerType

### DIFF
--- a/packages/SwingSet/src/kernel/loadVat.js
+++ b/packages/SwingSet/src/kernel/loadVat.js
@@ -147,6 +147,7 @@ export function makeVatLoader(stuff) {
     const {
       metered = isDynamic,
       vatParameters = {},
+      managerType,
       enableSetup = false,
       enablePipelining = false,
       virtualObjectCacheSize,
@@ -193,6 +194,7 @@ export function makeVatLoader(stuff) {
 
       kernelSlog.addVat(vatID, isDynamic, description, name, vatSourceBundle);
       const managerOptions = {
+        managerType,
         bundle: vatSourceBundle,
         metered,
         enableSetup,


### PR DESCRIPTION
I think `managerType` has been `local` in all ci testing to date.

This PR is mostly to ask the robots what happens if we don't lose managerType...