### PR TITLE
fix: multipoolAutoswap was calculating output prices incorrectly.

### DIFF
--- a/packages/zoe/src/contracts/multipoolAutoswap/getCurrentPrice.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/getCurrentPrice.js
@@ -1,9 +1,14 @@
 import '../../../exported';
 
 /**
- * Build functions to calculate prices for multipoolAutoswap. Two methods are
- * returned. In one the caller specifies the amount they will pay, and in the
- * other they specify the amount they wish to receive.
+ * Build functions to calculate prices for multipoolAutoswap. Four methods are
+ * returned, as two complementary pairs. In one pair of methods the caller
+ * specifies the amount they will pay, and in the other they specify the amount
+ * they wish to receive. The two with shorter names (getOutputForGivenInput,
+ * getInputForGivenOutput) are consistent with the uniswap interface. They each
+ * return a single amount. The other two return { amountIn, centralAmount,
+ * amountOut }, which specifies the best exchange consistent with the request.
+ * centralAmount is omitted from these methods' results in the publicFacet.
  *
  * @param {(brand: Brand) => boolean} isSecondary
  * @param {(brand: Brand) => boolean} isCentral

--- a/packages/zoe/src/contracts/multipoolAutoswap/multipoolAutoswap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/multipoolAutoswap.js
@@ -80,7 +80,7 @@ const start = zcf => {
   const {
     getOutputForGivenInput,
     getInputForGivenOutput,
-  } = makeGetCurrentPrice(isSecondary, isCentral, getPool);
+  } = makeGetCurrentPrice(isSecondary, isCentral, getPool, centralBrand);
   const {
     makeSwapInInvitation,
     makeSwapOutInvitation,

--- a/packages/zoe/src/contracts/multipoolAutoswap/multipoolAutoswap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/multipoolAutoswap.js
@@ -80,11 +80,39 @@ const start = zcf => {
   const {
     getOutputForGivenInput,
     getInputForGivenOutput,
+    getPriceGivenAvailableInput: getInternalPriceGivenAvailableInput,
+    getPriceGivenRequiredOutput: getInternalPriceGivenRequiredOutput,
   } = makeGetCurrentPrice(isSecondary, isCentral, getPool, centralBrand);
+
+  const getPriceGivenRequiredOutput = (brandIn, amountOutInitial) => {
+    const { amountIn, amountOut } = getInternalPriceGivenRequiredOutput(
+      brandIn,
+      amountOutInitial,
+    );
+    // dropping centralAmount from the public method
+    return { amountIn, amountOut };
+  };
+
+  const getPriceGivenAvailableInput = (amountInInitial, brandOut) => {
+    const { amountIn, amountOut } = getInternalPriceGivenAvailableInput(
+      amountInInitial,
+      brandOut,
+    );
+    // dropping centralAmount from the public method
+    return { amountIn, amountOut };
+  };
+
   const {
     makeSwapInInvitation,
     makeSwapOutInvitation,
-  } = makeMakeSwapInvitation(zcf, isSecondary, isCentral, getPool);
+  } = makeMakeSwapInvitation(
+    zcf,
+    isSecondary,
+    isCentral,
+    getPool,
+    getInternalPriceGivenAvailableInput,
+    getInternalPriceGivenRequiredOutput,
+  );
   const makeAddLiquidityInvitation = makeMakeAddLiquidityInvitation(
     zcf,
     getPool,
@@ -103,6 +131,8 @@ const start = zcf => {
     getLiquiditySupply,
     getInputPrice: getOutputForGivenInput,
     getOutputPrice: getInputForGivenOutput,
+    getPriceGivenRequiredOutput,
+    getPriceGivenAvailableInput,
     makeSwapInvitation: makeSwapInInvitation,
     makeSwapInInvitation,
     makeSwapOutInvitation,

--- a/packages/zoe/src/contracts/multipoolAutoswap/pool.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/pool.js
@@ -97,44 +97,6 @@ export const makeAddPool = (zcf, isSecondary, initPool, centralBrand) => {
         poolSeat.getAmountAllocated('Central', centralBrand),
       getSecondaryAmount: () =>
         poolSeat.getAmountAllocated('Secondary', secondaryBrand),
-      getCentralToSecondaryInputPrice: inputValue => {
-        assertPoolInitialized(pool);
-        const result = getInputPrice(
-          inputValue,
-          pool.getCentralAmount().value,
-          pool.getSecondaryAmount().value,
-        );
-        return pool.getAmountMath().make(result);
-      },
-      getSecondaryToCentralInputPrice: inputValue => {
-        assertPoolInitialized(pool);
-        const result = getInputPrice(
-          inputValue,
-          pool.getSecondaryAmount().value,
-          pool.getCentralAmount().value,
-        );
-        return pool.getCentralAmountMath().make(result);
-      },
-      // price in central tokens required to gain outputValue secondary units
-      getCentralToSecondaryOutputPrice: outputValue => {
-        assertPoolInitialized(pool);
-        const result = getOutputPrice(
-          outputValue,
-          pool.getCentralAmount().value,
-          pool.getSecondaryAmount().value,
-        );
-        return pool.getCentralAmountMath().make(result);
-      },
-      // price in secondary units required to gain outputValue in central tokens
-      getSecondaryToCentralOutputPrice: outputValue => {
-        assertPoolInitialized(pool);
-        const result = getOutputPrice(
-          outputValue,
-          pool.getSecondaryAmount().value,
-          pool.getCentralAmount().value,
-        );
-        return pool.getAmountMath().make(result);
-      },
 
       // The caller wants to sell inputAmount. if that could produce at most N,
       // but they could also get N by only selling inputAmount - epsilon
@@ -170,7 +132,6 @@ export const makeAddPool = (zcf, isSecondary, initPool, centralBrand) => {
           amountMathOut,
           amountMathIn,
         } = reservesAndMath(pool, inputBrand, outputAmount.brand);
-
         const valueIn = getOutputPrice(
           outputAmount.value,
           inputReserve,

--- a/packages/zoe/src/contracts/multipoolAutoswap/pool.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/pool.js
@@ -94,6 +94,7 @@ export const makeAddPool = (zcf, isSecondary, initPool, centralBrand) => {
         );
         return pool.getCentralAmountMath().make(result);
       },
+      // price in central tokens required to gain outputValue secondary units
       getCentralToSecondaryOutputPrice: outputValue => {
         assertPoolInitialized(pool);
         const result = getOutputPrice(
@@ -101,8 +102,9 @@ export const makeAddPool = (zcf, isSecondary, initPool, centralBrand) => {
           pool.getCentralAmount().value,
           pool.getSecondaryAmount().value,
         );
-        return pool.getAmountMath().make(result);
+        return pool.getCentralAmountMath().make(result);
       },
+      // price in secondary units required to gain outputValue in central tokens
       getSecondaryToCentralOutputPrice: outputValue => {
         assertPoolInitialized(pool);
         const result = getOutputPrice(
@@ -110,7 +112,7 @@ export const makeAddPool = (zcf, isSecondary, initPool, centralBrand) => {
           pool.getSecondaryAmount().value,
           pool.getCentralAmount().value,
         );
-        return pool.getCentralAmountMath().make(result);
+        return pool.getAmountMath().make(result);
       },
       addLiquidity: userSeat => {
         if (liqTokenSupply === 0) {

--- a/packages/zoe/src/contracts/multipoolAutoswap/pool.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/pool.js
@@ -30,10 +30,10 @@ export const makeAddPool = (zcf, isSecondary, initPool, centralBrand) => {
       issuer: liquidityIssuer,
     } = liquidityZcfMint.getIssuerRecord();
 
-    const addLiquidityActual = (pool, userSeat, secondaryAmount) => {
+    const addLiquidityActual = (pool, zcfSeat, secondaryAmount) => {
       const liquidityValueOut = calcLiqValueToMint(
         liqTokenSupply,
-        userSeat.getAmountAllocated('Central').value,
+        zcfSeat.getAmountAllocated('Central').value,
         pool.getCentralAmount().value,
       );
 
@@ -46,16 +46,16 @@ export const makeAddPool = (zcf, isSecondary, initPool, centralBrand) => {
         {
           seat: poolSeat,
           gains: {
-            Central: userSeat.getCurrentAllocation().Central,
+            Central: zcfSeat.getCurrentAllocation().Central,
             Secondary: secondaryAmount,
           },
         },
         {
-          seat: userSeat,
+          seat: zcfSeat,
           gains: { Liquidity: liquidityAmountOut },
         },
       );
-      userSeat.exit();
+      zcfSeat.exit();
       return 'Added liquidity.';
     };
 
@@ -64,6 +64,27 @@ export const makeAddPool = (zcf, isSecondary, initPool, centralBrand) => {
         !pool.getAmountMath().isEmpty(pool.getSecondaryAmount()),
         details`pool not initialized`,
       );
+
+    const reservesAndMath = (pool, inputBrand, outputBrand) => {
+      let inputReserve;
+      let outputReserve;
+      let amountMathOut;
+      let amountMathIn;
+      if (isSecondary(outputBrand) && centralBrand === inputBrand) {
+        inputReserve = pool.getCentralAmount().value;
+        outputReserve = pool.getSecondaryAmount().value;
+        amountMathOut = pool.getAmountMath();
+        amountMathIn = pool.getCentralAmountMath();
+      } else if (isSecondary(inputBrand) && centralBrand === outputBrand) {
+        inputReserve = pool.getSecondaryAmount().value;
+        outputReserve = pool.getCentralAmount().value;
+        amountMathOut = pool.getCentralAmountMath();
+        amountMathIn = pool.getAmountMath();
+      } else {
+        throw Error('brands must be central and secondary');
+      }
+      return { inputReserve, outputReserve, amountMathIn, amountMathOut };
+    };
 
     /** @type {Pool} */
     const pool = {
@@ -114,13 +135,60 @@ export const makeAddPool = (zcf, isSecondary, initPool, centralBrand) => {
         );
         return pool.getAmountMath().make(result);
       },
-      addLiquidity: userSeat => {
+
+      // The caller wants to sell inputAmount. if that could produce at most N,
+      // but they could also get N by only selling inputAmount - epsilon
+      // we'll reply with { amountIn: inputAmount - epsilon, amountOut: N }.
+      getPriceGivenAvailableInput: (inputAmount, outputBrand) => {
+        assertPoolInitialized(pool);
+        const {
+          inputReserve,
+          outputReserve,
+          amountMathOut,
+          amountMathIn,
+        } = reservesAndMath(pool, inputAmount.brand, outputBrand);
+        const valueOut = getInputPrice(
+          inputAmount.value,
+          inputReserve,
+          outputReserve,
+        );
+        const valueIn = getOutputPrice(valueOut, inputReserve, outputReserve);
+        return {
+          amountOut: amountMathOut.make(valueOut),
+          amountIn: amountMathIn.make(valueIn),
+        };
+      },
+
+      // The caller wants at least outputAmount. if that requires at least N,
+      // but they can get outputAmount + delta for N, we'll reply with
+      // { amountIn: N, amountOut: outputAmount + delta }.
+      getPriceGivenRequiredOutput: (inputBrand, outputAmount) => {
+        assertPoolInitialized(pool);
+        const {
+          inputReserve,
+          outputReserve,
+          amountMathOut,
+          amountMathIn,
+        } = reservesAndMath(pool, inputBrand, outputAmount.brand);
+
+        const valueIn = getOutputPrice(
+          outputAmount.value,
+          inputReserve,
+          outputReserve,
+        );
+        const valueOut = getInputPrice(valueIn, inputReserve, outputReserve);
+        return {
+          amountOut: amountMathOut.make(valueOut),
+          amountIn: amountMathIn.make(valueIn),
+        };
+      },
+      addLiquidity: zcfSeat => {
         if (liqTokenSupply === 0) {
-          const userAllocation = userSeat.getCurrentAllocation();
-          return addLiquidityActual(pool, userSeat, userAllocation.Secondary);
+          const userAllocation = zcfSeat.getCurrentAllocation();
+          return addLiquidityActual(pool, zcfSeat, userAllocation.Secondary);
         }
 
-        const userAllocation = userSeat.getCurrentAllocation();
+        const userAllocation = zcfSeat.getCurrentAllocation();
         const secondaryIn = userAllocation.Secondary;
 
         // To calculate liquidity, we'll need to calculate alpha from the primary
@@ -142,7 +210,7 @@ export const makeAddPool = (zcf, isSecondary, initPool, centralBrand) => {
           'insufficient Secondary deposited',
         );
 
-        return addLiquidityActual(pool, userSeat, secondaryOut);
+        return addLiquidityActual(pool, zcfSeat, secondaryOut);
       },
       removeLiquidity: userSeat => {
         const liquidityIn = userSeat.getAmountAllocated(

--- a/packages/zoe/src/contracts/multipoolAutoswap/swap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/swap.js
@@ -145,7 +145,7 @@ export const makeMakeSwapInvitation = (
 
     if (isCentral(brandOut) && isSecondary(brandIn)) {
       const pool = getPool(brandIn);
-      const amountIn = pool.getCentralToSecondaryOutputPrice(outputValue);
+      const amountIn = pool.getSecondaryToCentralOutputPrice(outputValue);
 
       const brandInAmountMath = getPool(brandIn).getAmountMath();
       if (!brandInAmountMath.isGTE(offeredAmountIn, amountIn)) {
@@ -172,7 +172,7 @@ export const makeMakeSwapInvitation = (
 
     if (isSecondary(brandOut) && isCentral(brandIn)) {
       const pool = getPool(brandOut);
-      const amountIn = pool.getSecondaryToCentralOutputPrice(outputValue);
+      const amountIn = pool.getCentralToSecondaryOutputPrice(outputValue);
       trade(
         zcf,
         {

--- a/packages/zoe/src/contracts/multipoolAutoswap/swap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/swap.js
@@ -132,7 +132,7 @@ export const makeMakeSwapInvitation = (
       give: { In: null },
       want: { Out: null },
     });
-    // The offer's amountOut is exact; the offeredAmountIn is a max.
+    // The offer's amountOut is a minimum; the offeredAmountIn is a max.
     const {
       give: { In: offeredAmountIn },
       want: { Out: amountOut },
@@ -158,11 +158,11 @@ export const makeMakeSwapInvitation = (
         {
           seat: pool.getPoolSeat(),
           gains: { Secondary: amountIn },
-          losses: { Central: amountOut },
+          losses: { Central: availableAmountOut },
         },
         {
           seat,
-          gains: { Out: amountOut },
+          gains: { Out: availableAmountOut },
           losses: { In: amountIn },
         },
       );

--- a/packages/zoe/src/contracts/multipoolAutoswap/swap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/swap.js
@@ -146,11 +146,14 @@ export const makeMakeSwapInvitation = (
     if (isCentral(brandOut) && isSecondary(brandIn)) {
       const pool = getPool(brandIn);
       const amountIn = pool.getSecondaryToCentralOutputPrice(outputValue);
+      const availableAmountOut = pool.getSecondaryToCentralInputPrice(
+        amountIn.value,
+      );
 
       const brandInAmountMath = getPool(brandIn).getAmountMath();
       if (!brandInAmountMath.isGTE(offeredAmountIn, amountIn)) {
         seat.fail();
-        return `insufficient funds offered`;
+        return `offeredAmountIn ${offeredAmountIn} is insufficient to buy amountOut ${amountOut}`;
       }
 
       trade(

--- a/packages/zoe/src/contracts/multipoolAutoswap/types.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/types.js
@@ -73,6 +73,14 @@
  * @property {(amountOut: Amount, brandIn: Brand) => Amount} getOutputPrice
  * calculate the amount of brandIn that is required in order to get amountOut
  * using makeSwapOutInvitation at the current price
+ * @property {(amountIn: Amount, brandOut: Brand) => PriceAmountPair} getPriceGivenAvailableInput
+ * calculate the amount of brandOut that will be returned if the amountIn is
+ * offered using makeSwapInInvitation at the current price. Include the minimum
+ * amountIn required to gain that much.
+ * @property {(amountOut: Amount, brandIn: Brand) => PriceAmountPair} getPriceGivenRequiredOutput
+ * calculate the amount of brandIn that is required in order to get amountOut
+ * using makeSwapOutInvitation at the current price. Include the maximum amount
+ * of amountOut that can be gained for that amountIn.
  * @property {(brand: Brand) => Record<string, Amount>} getPoolAllocation get an
  * AmountKeywordRecord showing the current balances in the pool for brand.
  */

--- a/packages/zoe/src/contracts/multipoolAutoswap/types.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/types.js
@@ -26,11 +26,16 @@
  */
 
 /**
+ * typedef {Object} PriceAmountPair
+ *
+ * @property {Amount} amountOut
+ * @property {Amount} amountIn
+ */
+
+/**
  * @typedef {Object} Pool
- * @property {(inputValue: Value) => Amount } getSecondaryToCentralInputPrice
- * @property {(inputValue: Value) => Amount } getCentralToSecondaryInputPrice
- * @property {(inputValue: Value) => Amount } getSecondaryToCentralOutputPrice
- * @property {(inputValue: Value) => Amount } getCentralToSecondaryOutputPrice
+ * @property {(inputAmount: Amount, outputBrand: Brand) => PriceAmountPair } getPriceGivenAvailableInput
+ * @property {(inputBrand: Brand, outputAmount: Amount) => PriceAmountPair } getPriceGivenRequiredOutput
  * @property {() => number} getLiquiditySupply
  * @property {() => Issuer} getLiquidityIssuer
  * @property {(seat: ZCFSeat) => string} addLiquidity

--- a/packages/zoe/test/unitTests/contracts/test-autoswapPool.js
+++ b/packages/zoe/test/unitTests/contracts/test-autoswapPool.js
@@ -1,0 +1,191 @@
+// isolated unit test of price calculations in pool in multipoolAutoswap
+
+import '@agoric/install-ses';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import test from 'ava';
+
+import { E } from '@agoric/eventual-send';
+import { setupZCFTest } from '../zcf/setupZcfTest';
+
+import { setup } from '../setupBasicMints';
+import { makeAddPool } from '../../../src/contracts/multipoolAutoswap/pool';
+import { outputFromInputPrice, priceFromTargetOutput } from '../../autoswapJig';
+import { depositToSeat } from '../../../src/contractSupport';
+
+async function setupPool(poolBalances) {
+  const {
+    bucksIssuer,
+    bucks,
+    moolaIssuer,
+    moola,
+    brands,
+    moolaMint,
+    bucksMint,
+  } = setup();
+  const centralBrand = brands.get('bucks');
+  const secondaryBrand = brands.get('moola');
+
+  const issuerKeywordRecord = harden({
+    Central: bucksIssuer,
+    Secondary: moolaIssuer,
+  });
+  const { zcf } = await setupZCFTest(issuerKeywordRecord);
+  let poolInitialized = false;
+  let pool;
+  const initPool = (_, newPool) => {
+    poolInitialized = true;
+    pool = newPool;
+  };
+  const isSecondary = b => poolInitialized && b === secondaryBrand;
+  const addPool = makeAddPool(zcf, isSecondary, initPool, centralBrand);
+  await addPool(moolaIssuer, 'Moola');
+
+  const moolaAmount = moola(poolBalances.secondary);
+  const bucksAmount = bucks(poolBalances.central);
+  const { zcfSeat } = zcf.makeEmptySeatKit();
+  await depositToSeat(
+    zcf,
+    zcfSeat,
+    { Secondary: moolaAmount, Central: bucksAmount },
+    {
+      Secondary: moolaMint.mintPayment(moolaAmount),
+      Central: bucksMint.mintPayment(bucksAmount),
+    },
+  );
+
+  pool.addLiquidity(zcfSeat);
+  return {
+    pool,
+    centralBrand,
+    secondaryBrand,
+    central: bucks,
+    secondary: moola,
+  };
+}
+
+test('pool getPrice centToSec', async t => {
+  const allocations = { central: 100, secondary: 100 };
+  const { pool, secondaryBrand, central, secondary } = await setupPool(
+    allocations,
+  );
+  const valueIn = 40;
+  const { amountOut, amountIn } = await E(pool).getPriceGivenAvailableInput(
+    central(valueIn),
+    secondaryBrand,
+  );
+  const expected = outputFromInputPrice(100, 100, valueIn, 3);
+  t.deepEqual(amountOut, secondary(expected));
+  t.deepEqual(amountIn, central(valueIn));
+});
+
+test('pool getPrice secToCent', async t => {
+  const allocations = { central: 100, secondary: 100 };
+  const { pool, centralBrand, central, secondary } = await setupPool(
+    allocations,
+  );
+  const valueIn = 40;
+  const { amountOut, amountIn } = await E(pool).getPriceGivenAvailableInput(
+    secondary(valueIn),
+    centralBrand,
+  );
+  const expected = outputFromInputPrice(100, 100, valueIn, 3);
+  t.deepEqual(amountOut, central(expected));
+  t.deepEqual(amountIn, secondary(valueIn));
+});
+
+test('pool getPrice secToSec', async t => {
+  const allocations = { central: 100, secondary: 100 };
+  const { pool, secondaryBrand, secondary } = await setupPool(allocations);
+  const valueIn = 40;
+  await t.throwsAsync(
+    () =>
+      E(pool).getPriceGivenAvailableInput(secondary(valueIn), secondaryBrand),
+    { message: 'brands must be central and secondary' },
+  );
+});
+
+test('pool getPrice amountIn != available', async t => {
+  const allocations = { central: 100, secondary: 1000 };
+  const { pool, centralBrand, central, secondary } = await setupPool(
+    allocations,
+  );
+  const valueIn = 40;
+  const { amountOut, amountIn } = await E(pool).getPriceGivenAvailableInput(
+    secondary(valueIn),
+    centralBrand,
+  );
+  t.deepEqual(amountOut, central(3));
+  // 40 would get you 3, but you can get 3 for 32 if that's better.
+  t.deepEqual(amountIn, secondary(32));
+});
+
+test('pool getOutputPrice cenToSec', async t => {
+  const poolBalances = { central: 100, secondary: 100 };
+  const { pool, centralBrand, central, secondary } = await setupPool(
+    poolBalances,
+  );
+  const valueOut = 40;
+  const { amountOut, amountIn } = await E(pool).getPriceGivenRequiredOutput(
+    centralBrand,
+    secondary(valueOut),
+  );
+  const expected = priceFromTargetOutput(valueOut, 100, 100, 3);
+  t.deepEqual(amountOut, secondary(valueOut));
+  t.deepEqual(amountIn, central(expected));
+});
+
+test('pool getOutputPrice secToCent', async t => {
+  const poolBalances = { central: 100, secondary: 100 };
+  const { pool, secondaryBrand, central, secondary } = await setupPool(
+    poolBalances,
+  );
+  const valueOut = 40;
+  const { amountOut, amountIn } = await E(pool).getPriceGivenRequiredOutput(
+    secondaryBrand,
+    central(valueOut),
+  );
+  const expected = priceFromTargetOutput(valueOut, 100, 100, 3);
+  t.deepEqual(amountOut, central(valueOut));
+  t.deepEqual(amountIn, secondary(expected));
+});
+
+test('pool getOutputPrice amountOut != requested', async t => {
+  const poolBalances = { central: 1000, secondary: 100 };
+  const { pool, secondaryBrand, central, secondary } = await setupPool(
+    poolBalances,
+  );
+  const valueOut = 4;
+  const { amountOut, amountIn } = await E(pool).getPriceGivenRequiredOutput(
+    secondaryBrand,
+    central(valueOut),
+  );
+  // central(4) requires spending secondary(1), but you can get central(9) for
+  // secondary(1)
+  t.deepEqual(amountOut, central(9));
+  t.deepEqual(amountIn, secondary(1));
+});
+
+test('pool getOutputPrice secToSec', async t => {
+  const poolBalances = { central: 100, secondary: 100 };
+  const { pool, secondaryBrand, secondary } = await setupPool(poolBalances);
+  const valueOut = 40;
+  await t.throwsAsync(
+    () =>
+      E(pool).getPriceGivenRequiredOutput(secondaryBrand, secondary(valueOut)),
+    {
+      message: 'brands must be central and secondary',
+    },
+  );
+});
+
+test('pool getOutputPrice cenToCen', async t => {
+  const poolBalances = { central: 100, secondary: 100 };
+  const { pool, centralBrand, central } = await setupPool(poolBalances);
+  const valueOut = 40;
+  await t.throwsAsync(
+    () => E(pool).getPriceGivenRequiredOutput(centralBrand, central(valueOut)),
+    {
+      message: 'brands must be central and secondary',
+    },
+  );
+});

--- a/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
@@ -388,15 +388,15 @@ test('multipoolAutoSwap with valid offers', async t => {
   );
   t.deepEqual(
     await simoleanR.issuer.getAmountOf(bobSimsPayout3),
-    simoleans(0),
-    `bob gets no simoleans back`,
+    simoleans(9),
+    `bob gets 9 simoleans back because 74 was more than required`,
   );
 
   t.deepEqual(
     await E(bobPublicFacet).getPoolAllocation(simoleanR.brand),
     harden({
-      // 398 + 74
-      Secondary: simoleans(472),
+      // 398 + 65
+      Secondary: simoleans(463),
       // 43 - 6
       Central: centralTokens(37),
       Liquidity: simoleanLiquidity(0),

--- a/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
@@ -907,10 +907,10 @@ test('multipoolAutoSwap jig - swapOut', async t => {
   );
   sPoolState = updatePoolState(sPoolState, initSimLiqExpected);
 
-  // trade for central specifying 300 output: moola price 310
+  // trade for central specifying 300 output: moola price 311
   const gain = 300;
   const mPrice = priceFromTargetOutput(gain, mPoolState.c, mPoolState.s, 30);
-  t.is(mPrice, 310);
+  t.is(mPrice, 311);
 
   const tradeDetailsB = {
     inAmount: moola(500),
@@ -935,10 +935,10 @@ test('multipoolAutoSwap jig - swapOut', async t => {
   );
   mPoolState = updatePoolState(mPoolState, expectedB);
 
-  // trade for moola specifying 250 output: central price: 241. don't overpay
+  // trade for moola specifying 250 output: central price: 242. don't overpay
   const gainC = 250;
   const mPriceC = priceFromTargetOutput(gainC, mPoolState.s, mPoolState.c, 30);
-  t.is(mPriceC, 241);
+  t.is(mPriceC, 242);
 
   const tradeDetailsC = {
     inAmount: centralTokens(mPriceC),
@@ -963,10 +963,10 @@ test('multipoolAutoSwap jig - swapOut', async t => {
   );
   mPoolState = updatePoolState(mPoolState, expectedC);
 
-  // trade simoleans for moola specifying 305 moola output: requires 311 Sim
+  // trade simoleans for moola specifying 305 moola output: requires 312 Sim
   const gainD = 305;
   const mPriceD = priceFromTargetOutput(gainD, mPoolState.s, mPoolState.c, 30);
-  t.is(mPriceD, 311);
+  t.is(mPriceD, 312);
 
   const tradeDetailsD = {
     inAmount: centralTokens(mPriceD),
@@ -1115,24 +1115,24 @@ test('multipoolAutoSwap jig - swapOut uneven', async t => {
   );
   sPoolState = updatePoolState(sPoolState, initSimLiqExpected);
 
-  // trade for central specifying 300 output: moola price 155
+  // trade for central specifying 300 output: moola price 156
   // Notice that it takes half as much moola as the desired Central
   const gain = 300;
   const mPrice = priceFromTargetOutput(gain, mPoolState.c, mPoolState.s, 30);
 
   const moolaIn = 160;
-  t.is(mPrice, 155);
+  t.is(mPrice, 156);
   const tradeDetailsB = {
     inAmount: moola(moolaIn),
     outAmount: centralTokens(gain),
   };
 
   const expectedB = {
-    c: mPoolState.c - gain,
+    c: mPoolState.c - gain - 1,
     s: mPoolState.s + mPrice,
     l: 10000,
-    k: (mPoolState.c - gain) * (mPoolState.s + mPrice),
-    out: gain,
+    k: (mPoolState.c - gain - 1) * (mPoolState.s + mPrice),
+    out: gain + 1,
     in: moolaIn - mPrice,
   };
   await alice.tradeAndCheck(
@@ -1145,10 +1145,10 @@ test('multipoolAutoSwap jig - swapOut uneven', async t => {
   );
   mPoolState = updatePoolState(mPoolState, expectedB);
 
-  // trade for moola specifying 250 output: central price: 495, roughly double.
+  // trade for moola specifying 250 output: central price: 496, roughly double.
   const gainC = 250;
   const mPriceC = priceFromTargetOutput(gainC, mPoolState.s, mPoolState.c, 30);
-  t.is(mPriceC, 495);
+  t.is(mPriceC, 496);
 
   const tradeDetailsC = {
     inAmount: centralTokens(mPriceC),

--- a/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
@@ -1160,7 +1160,7 @@ test('multipoolAutoSwap jig - swapOut uneven', async t => {
     s: mPoolState.s - gainC,
     l: 10000,
     k: (mPoolState.c + mPriceC) * (mPoolState.s - gainC),
-    out: gainC, // 250 should be 0??
+    out: gainC,
     in: 0,
   };
   await alice.tradeAndCheck(


### PR DESCRIPTION
It effectively had the two pools swapped. We didn't notice because all our tests had the two pools
at rough parity. While trying to make the staking contract work, I kept geting prices that were 2x
the input rather than half when I expected the opposite.

The tests were correspondingly broken. The tests called priceFromTargetOutput() to calculate
expected values, and consistently had the pools reversed in the call. The correct call is
`priceFromTargetOutput(deltaY, yPre, xPre, fee)`. Notice that the first two parameters are both in
`Y` units. The calls from the test have been corrected so the second parameter is the pool that
matches the requested output amount.

In the newly added test, the pool is set up with a ratio of 500 Moola to 1000 Central tokens. When
Alice asks the price for 300 Central, the price will now be 155. When she trades back, it takes
roughly twice the number of central tokens to purchase the moola she wants.

As part of cleaning this up, we ended up adding in three other refactorings:

* There were four methods in the pools for calculating prices, depending on whether input or output was specified and which pair of pools were being used. There are now just two
* the functions that compute prices now take amounts rather than values,
* `getPriceGivenAvailableInput()` and `getPriceGivenRequiredOutput()` now return an inputAmount and outputAmount. When the minimum outputAmount is specified, we tell what input is required to get it, and how much output that input actually produces. When the available input is specified, we tell what output can be gotten for that, and the minimum amount required to get it.
