### PR TITLE
chore: remove dependency on dapp-svelte-wallet-api types for now

### DIFF
--- a/packages/deploy-script-support/exported.js
+++ b/packages/deploy-script-support/exported.js
@@ -1,5 +1,4 @@
 import '@agoric/bundle-source/exported';
-import '@agoric/dapp-svelte-wallet-api/exported';
 import '@agoric/cosmic-swingset/exported';
 
 import './src/externalTypes';

--- a/packages/deploy-script-support/package.json
+++ b/packages/deploy-script-support/package.json
@@ -44,7 +44,6 @@
     "@agoric/assert": "^0.2.0",
     "@agoric/bundle-source": "^1.2.0",
     "@agoric/cosmic-swingset": "^0.24.0",
-    "@agoric/dapp-svelte-wallet-api": "^0.5.1",
     "@agoric/ertp": "^0.9.0",
     "@agoric/eventual-send": "^0.13.0",
     "@agoric/import-manager": "^0.2.0",

--- a/packages/deploy-script-support/src/externalTypes.js
+++ b/packages/deploy-script-support/src/externalTypes.js
@@ -105,3 +105,10 @@
  * @param {string} expectedOfferResult
  * @returns {Promise<void>}
  */
+
+/**
+ * @typedef {string | string[]} Petname A petname can either be a plain string
+ * or a path for which the first element is a petname for the origin, and the
+ * rest of the elements are a snapshot of the names that were first given by that
+ * origin.  We are migrating away from using plain strings, for consistency.
+ */


### PR DESCRIPTION
See failing CI in https://github.com/Agoric/dapp-token-economy/pull/51/checks?check_run_id=1665686013