### PR TITLE
chore: add getUINotifier to wallet bridge

### DIFF
--- a/packages/dapp-svelte-wallet/api/src/lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-wallet.js
@@ -1329,7 +1329,7 @@ export function makeWallet({
       passStyleOf(offerResult) === 'copyRecord',
       `offerResult must be a record to have a uiNotifier`,
     );
-    assert(offerResult.uiNotifier);
+    assert(offerResult.uiNotifier, `offerResult does not have a uiNotifier`);
     return offerResult.uiNotifier;
   }
 

--- a/packages/dapp-svelte-wallet/api/src/types.js
+++ b/packages/dapp-svelte-wallet/api/src/types.js
@@ -75,6 +75,9 @@
  * @property {(petname: Petname, instanceBoardId: string) => Promise<void>}
  * suggestInstance Introduce a Zoe contract instance to the wallet, with
  * suggested petname.
+ * @property {(rawId: string) => Promise<Notifier<any>>} getUINotifier Get the UI notifier from the offerResult
+ * for a particular offer, identified by id. This notifier should only
+ * contain information that is safe to pass to the dapp UI.
  */
 
 /**

--- a/packages/dapp-svelte-wallet/api/src/wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/wallet.js
@@ -159,6 +159,10 @@ export function buildRootObject(_vatPowers) {
         await approve();
         return walletAdmin.suggestInstance(petname, boardId, dappOrigin);
       },
+      async getUINotifier(rawId) {
+        await approve();
+        return walletAdmin.getUINotifier(rawId, dappOrigin);
+      },
     };
     return harden(bridge);
   };
@@ -194,6 +198,9 @@ export function buildRootObject(_vatPowers) {
     },
     suggestIssuer(petname, issuerBoardId) {
       return walletAdmin.suggestIssuer(petname, issuerBoardId);
+    },
+    getUINotifier(rawId) {
+      return walletAdmin.getUINotifier(rawId);
     },
   };
   harden(preapprovedBridge);
@@ -386,32 +393,6 @@ export function buildRootObject(_vatPowers) {
               case 'walletAddOffer': {
                 let handled = false;
                 const actions = harden({
-                  result(offer, outcome) {
-                    httpSend(
-                      {
-                        type: 'walletOfferResult',
-                        data: {
-                          id: offer.id,
-                          dappContext: offer.dappContext,
-                          outcome,
-                        },
-                      },
-                      [meta.channelHandle],
-                    );
-                  },
-                  error(offer, reason) {
-                    httpSend(
-                      {
-                        type: 'walletOfferResult',
-                        data: {
-                          id: offer.id,
-                          dappContext: offer.dappContext,
-                          error: `${(reason && reason.stack) || reason}`,
-                        },
-                      },
-                      [meta.channelHandle],
-                    );
-                  },
                   handled(offer) {
                     if (handled) {
                       return;

--- a/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
@@ -555,7 +555,7 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
 });
 
 test('lib-wallet offer methods', async t => {
-  t.plan(8);
+  t.plan(7);
   const {
     moolaBundle,
     wallet,

--- a/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
@@ -630,8 +630,7 @@ test('lib-wallet offer methods', async t => {
   );
   const accepted = await wallet.acceptOffer(id);
   assert(accepted);
-  const { outcome, depositedP } = accepted;
-  t.is(await outcome, 'The offer was accepted', `offer was accepted`);
+  const { depositedP } = accepted;
   await depositedP;
   const seats = wallet.getSeats(harden([id]));
   const seat = wallet.getSeat(id);
@@ -881,8 +880,11 @@ test('lib-wallet addOffer for autoswap swap', async t => {
 
   const accepted = await wallet.acceptOffer(id);
   assert(accepted);
-  const { outcome, depositedP } = accepted;
-  t.is(await outcome, 'Swap successfully completed.', `offer was accepted`);
+  const { depositedP } = accepted;
+  await t.throwsAsync(() => wallet.getUINotifier(rawId, `unknown`), {
+    message: 'offerResult must be a record to have a uiNotifier',
+  });
+
   await depositedP;
   const seats = wallet.getSeats(harden([id]));
   const seat = wallet.getSeat(id);


### PR DESCRIPTION
This PR adds the method `getUINotifier` to the wallet bridge.

When an offer is accepted, the `offerResult` is saved in the wallet under the offer id. When `E(bridge).getUINotifier(rawId)` is called, the `uiNotifier` is returned from the `offerResult`. If it does not exist, an error is thrown. 

The `offerResult` (aka `outcome`) is removed from the message sent back to the dapp. 

Closes #2127

References #2043
And #2060 