### PR TITLE
fix: wire through the actual CapTP bootstrap message

### DIFF
--- a/packages/captp/lib/captp.js
+++ b/packages/captp/lib/captp.js
@@ -259,7 +259,7 @@ export function makeCapTP(ourId, rawSend, bootstrapObj = undefined, opts = {}) {
     async CTP_BOOTSTRAP(obj) {
       const { questionID } = obj;
       const bootstrap =
-        typeof bootstrapObj === 'function' ? bootstrapObj() : bootstrapObj;
+        typeof bootstrapObj === 'function' ? bootstrapObj(obj) : bootstrapObj;
       E.when(bootstrap, bs => {
         // console.log('sending bootstrap', bootstrap);
         answers.set(questionID, bs);

--- a/packages/cosmic-swingset/lib/ag-solo/vats/captp.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/captp.js
@@ -25,7 +25,7 @@ export const getCapTPHandler = (
       const { dispatch, abort, getBootstrap: getRemoteBootstrap } = makeCapTP(
         origin,
         sendObj,
-        async () => getLocalBootstrap(getRemoteBootstrap(), meta),
+        async o => getLocalBootstrap(getRemoteBootstrap(), meta, o),
         {
           onReject(err) {
             // Be quieter for sanity's sake.

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-http.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-http.js
@@ -61,9 +61,9 @@ export function buildRootObject(vatPowers) {
       .catch(_ => undefined);
     const commandHandler = getCapTPHandler(
       send,
-      (otherSide, meta) =>
+      (otherSide, meta, obj) =>
         E(handler)
-          .getBootstrap(otherSide, meta)
+          .getBootstrap(otherSide, meta, obj)
           .catch(_e => undefined),
       fallback,
     );

--- a/packages/dapp-svelte-wallet/api/src/wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/wallet.js
@@ -290,9 +290,10 @@ export function buildRootObject(_vatPowers) {
        *
        * @param {ERef<WalletOtherSide>} otherSide
        * @param {Record<string, any>} meta
+       * @param {Record<string, any>} obj
        */
-      async getBootstrap(otherSide, meta) {
-        const dappOrigin = meta.origin;
+      async getBootstrap(otherSide, meta, obj) {
+        const { dappOrigin = meta.origin } = obj;
         const suggestedDappPetname = String(
           (meta.query && meta.query.suggestedDappPetname) ||
             meta.dappOrigin ||


### PR DESCRIPTION
This allows the bootstrap function to examine any
additional properties on the `CTP_BOOTSTRAP` message (such
as the `dappOrigin`).  Necessary for the wallet CapTP bridge.
