### PR TITLE
chore: add new ways of getting an invitation for an offer

### DIFF
--- a/packages/dapp-svelte-wallet/api/src/findOrMakeInvitation.js
+++ b/packages/dapp-svelte-wallet/api/src/findOrMakeInvitation.js
@@ -1,0 +1,134 @@
+import { assert, details, q } from '@agoric/assert';
+import { E } from '@agoric/eventual-send';
+import { passStyleOf } from '@agoric/marshal';
+
+export const makeId = (dappOrigin, rawId) => `${dappOrigin}#${rawId}`;
+
+const assertFirstCapASCII = str => {
+  assert.typeof(str, 'string');
+  const firstCapASCII = /^[A-Z][a-zA-Z0-9_$]*$/;
+  assert(
+    firstCapASCII.test(str),
+    details`The string ${q(
+      str,
+    )} must be ascii and must start with a capital letter.`,
+  );
+  assert(
+    str !== 'NaN' && str !== 'Infinity',
+    details`keyword ${q(str)} must not be a number's name`,
+  );
+};
+
+/**
+ * @param {Amount} invitationPurseBalance
+ * @param {Object} query
+ * @param {Board} query.board
+ * @param {string} query.boardId
+ * @returns {Array}
+ * @deprecated
+ */
+const findByBoardId = async (invitationPurseBalance, { board, boardId }) => {
+  assert.typeof(boardId, 'string');
+  const invitationHandle = await E(board).getValue(boardId);
+  const match = element => element.handle === invitationHandle;
+  const matchingValue = invitationPurseBalance.value.find(match);
+  assert(
+    matchingValue,
+    details`Cannot find invitation corresponding to ${q(boardId)}`,
+  );
+  const value =
+    matchingValue === undefined ? harden([]) : harden([matchingValue]);
+  return value;
+};
+
+// An invitation matching the query parameters is already expected
+// to be deposited in the default Zoe invitation purse
+/**
+ * @param {Amount} invitationPurseBalance
+ * @param {Record<string, any>} kvs
+ */
+const findByKeyValuePairs = async (invitationPurseBalance, kvs) => {
+  // TODO: use an AmountMath method instead to improve efficiency
+
+  // For every key and value in `query`, return an amount
+  // with any matches for those exact keys and values. Keys not in
+  // `query` count as a match
+  const matches = invitationDetail =>
+    Object.entries(kvs).every(
+      ([key, value]) => invitationDetail[key] === value,
+    );
+
+  const matchingValue = invitationPurseBalance.value.find(matches);
+  const value =
+    matchingValue === undefined ? harden([]) : harden([matchingValue]);
+  return value;
+};
+
+const makeFindInvitation = (invitationPurse, invitationMath) => {
+  const findInvitation = async (queryFn, queryParams) => {
+    const purseBalance = await E(invitationPurse).getCurrentAmount();
+    const value = await queryFn(purseBalance, queryParams);
+    const invitationAmount = invitationMath.make(value);
+    const invitationP = E(invitationPurse).withdraw(invitationAmount);
+    return invitationP;
+  };
+  return findInvitation;
+};
+
+const makeFurtherInvitation = (
+  { priorOfferId: rawPriorOfferId, idToOfferResult, description },
+  dappOrigin,
+) => {
+  assertFirstCapASCII(description);
+
+  const priorOfferId = makeId(dappOrigin, rawPriorOfferId);
+  const offerResult = idToOfferResult.get(priorOfferId);
+  assert(
+    passStyleOf(offerResult) === 'copyRecord',
+    `offerResult must be a record to have an invitationMakers property`,
+  );
+  assert(
+    offerResult.invitationMakers,
+    `offerResult does not have an invitationMakers property`,
+  );
+
+  const invitationP = E(offerResult.invitationMakers)[description]();
+  return invitationP;
+};
+
+export const findOrMakeInvitation = async (
+  board,
+  invitationPurse,
+  invitationMath,
+  offer,
+) => {
+  const findInvitation = makeFindInvitation(invitationPurse, invitationMath);
+
+  // Deprecated
+  if (offer.inviteHandleBoardId) {
+    const queryParams = {
+      board,
+      boardId: offer.inviteHandleBoardId,
+    };
+    return findInvitation(findByBoardId, queryParams);
+  }
+
+  // Deprecated
+  if (offer.invitationHandleBoardId) {
+    const queryParams = {
+      board,
+      boardId: offer.invitationHandleBoardId,
+    };
+    return findInvitation(findByBoardId, queryParams);
+  }
+
+  if (offer.invitationQuery) {
+    return findInvitation(findByKeyValuePairs, offer.invitationQuery);
+  }
+
+  if (offer.furtherInvitation) {
+    return makeFurtherInvitation(offer.furtherInvitation);
+  }
+
+  throw Error(`no invitation was found or made for this offer ${offer.id}`);
+};

--- a/packages/dapp-svelte-wallet/api/src/findOrMakeInvitation.js
+++ b/packages/dapp-svelte-wallet/api/src/findOrMakeInvitation.js
@@ -75,9 +75,10 @@ const makeFindInvitation = (invitationPurse, invitationMath) => {
   return findInvitation;
 };
 
-const makeFurtherInvitation = (
-  { priorOfferId: rawPriorOfferId, idToOfferResult, description },
+const makeContinuingInvitation = (
+  idToOfferResult,
   dappOrigin,
+  { priorOfferId: rawPriorOfferId, description },
 ) => {
   assertFirstCapASCII(description);
 
@@ -97,6 +98,7 @@ const makeFurtherInvitation = (
 };
 
 export const findOrMakeInvitation = async (
+  idToOfferResult,
   board,
   invitationPurse,
   invitationMath,
@@ -126,8 +128,16 @@ export const findOrMakeInvitation = async (
     return findInvitation(findByKeyValuePairs, offer.invitationQuery);
   }
 
-  if (offer.furtherInvitation) {
-    return makeFurtherInvitation(offer.furtherInvitation);
+  if (offer.continuingInvitation) {
+    const dappOrigin =
+      offer.requestContext && offer.requestContext.dappOrigin
+        ? offer.requestContext.dappOrigin
+        : `unknown`;
+    return makeContinuingInvitation(
+      idToOfferResult,
+      dappOrigin,
+      offer.continuingInvitation,
+    );
   }
 
   throw Error(`no invitation was found or made for this offer ${offer.id}`);

--- a/packages/dapp-svelte-wallet/api/src/findOrMakeInvitation.js
+++ b/packages/dapp-svelte-wallet/api/src/findOrMakeInvitation.js
@@ -36,9 +36,8 @@ const findByBoardId = async (invitationPurseBalance, { board, boardId }) => {
     matchingValue,
     details`Cannot find invitation corresponding to ${q(boardId)}`,
   );
-  const value =
-    matchingValue === undefined ? harden([]) : harden([matchingValue]);
-  return value;
+
+  return harden([matchingValue]);
 };
 
 // An invitation matching the query parameters is already expected
@@ -59,9 +58,11 @@ const findByKeyValuePairs = async (invitationPurseBalance, kvs) => {
     );
 
   const matchingValue = invitationPurseBalance.value.find(matches);
-  const value =
-    matchingValue === undefined ? harden([]) : harden([matchingValue]);
-  return value;
+  assert(
+    matchingValue,
+    details`Cannot find invitation corresponding to ${q(kvs)}`,
+  );
+  return harden([matchingValue]);
 };
 
 const makeFindInvitation = (invitationPurse, invitationMath) => {

--- a/packages/dapp-svelte-wallet/api/src/lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-wallet.js
@@ -680,6 +680,7 @@ export function makeWallet({
     const zoeIssuer = issuerManager.get(ZOE_INVITE_BRAND_PETNAME);
     const { amountMath: invitationMath } = brandTable.getByIssuer(zoeIssuer);
     const invitationP = findOrMakeInvitation(
+      idToOfferResult,
       board,
       zoeInvitePurse,
       invitationMath,

--- a/packages/dapp-svelte-wallet/api/test/continuingInvitationExample.js
+++ b/packages/dapp-svelte-wallet/api/test/continuingInvitationExample.js
@@ -1,0 +1,33 @@
+// @ts-check
+
+import { makeNotifierKit } from '@agoric/notifier';
+
+import '@agoric/zoe/exported';
+
+export const start = zcf => {
+  const { notifier, updater } = makeNotifierKit();
+
+  const secondOfferHandler = seat => {
+    updater.updateState('second offer made');
+    seat.exit();
+    return 'done';
+  };
+
+  const makeDoSecondThingInvitation = () =>
+    zcf.makeInvitation(secondOfferHandler, 'SecondThing');
+
+  const offerHandler = seat => {
+    seat.exit();
+    updater.updateState('first offer made');
+    return harden({
+      uiNotifier: notifier,
+      invitationMakers: {
+        SecondThing: makeDoSecondThingInvitation,
+      },
+    });
+  };
+
+  const creatorInvitation = zcf.makeInvitation(offerHandler, 'FirstThing');
+
+  return harden({ creatorInvitation });
+};

--- a/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
@@ -900,3 +900,126 @@ test('lib-wallet addOffer for autoswap swap', async t => {
     `simolean purse balance`,
   );
 });
+
+test('addOffer invitationQuery', async t => {
+  const {
+    zoe,
+    moolaBundle,
+    simoleanBundle,
+    wallet,
+    addLiquidityInvite,
+    autoswapInstanceHandle,
+    board,
+  } = await setupTest();
+
+  const issuerManager = wallet.getIssuerManager();
+  await issuerManager.add('moola', moolaBundle.issuer);
+  await wallet.makeEmptyPurse('moola', 'Fun budget');
+  await wallet.deposit(
+    'Fun budget',
+    moolaBundle.mint.mintPayment(moolaBundle.amountMath.make(1000)),
+  );
+
+  await issuerManager.add('simolean', simoleanBundle.issuer);
+  await wallet.makeEmptyPurse('simolean', 'Nest egg');
+  await wallet.deposit(
+    'Nest egg',
+    simoleanBundle.mint.mintPayment(simoleanBundle.amountMath.make(1000)),
+  );
+
+  /** @type {{ getLiquidityIssuer: () => Issuer, makeSwapInvitation: () => Invitation }} */
+  const publicAPI = await E(zoe).getPublicFacet(autoswapInstanceHandle);
+  const liquidityIssuer = await E(publicAPI).getLiquidityIssuer();
+
+  const liquidityAmountMath = await makeLocalAmountMath(liquidityIssuer);
+
+  // Let's add liquidity using our wallet and the addLiquidityInvite
+  // we have.
+  const proposal = harden({
+    give: {
+      Central: moolaBundle.amountMath.make(900),
+      Secondary: simoleanBundle.amountMath.make(500),
+    },
+    want: {
+      Liquidity: liquidityAmountMath.getEmpty(),
+    },
+  });
+
+  const pursesArray = await E(wallet).getPurses();
+  const purses = new Map(pursesArray);
+
+  const moolaPurse = purses.get('Fun budget');
+  const simoleanPurse = purses.get('Nest egg');
+  assert(moolaPurse);
+  assert(simoleanPurse);
+
+  const moolaPayment = await E(moolaPurse).withdraw(proposal.give.Central);
+  const simoleanPayment = await E(simoleanPurse).withdraw(
+    proposal.give.Secondary,
+  );
+
+  const payments = harden({
+    Central: moolaPayment,
+    Secondary: simoleanPayment,
+  });
+  const liqSeat = await E(zoe).offer(addLiquidityInvite, proposal, payments);
+  await E(liqSeat).getOfferResult();
+
+  const swapInvitation = await E(publicAPI).makeSwapInvitation();
+  const zoeInvitePurse = purses.get('Default Zoe invite purse');
+  assert(zoeInvitePurse);
+
+  await E(zoeInvitePurse).deposit(swapInvitation);
+
+  const rawId = '1593482020370';
+  const id = `unknown#${rawId}`;
+
+  const offer = {
+    id: rawId,
+    invitationQuery: {
+      instance: autoswapInstanceHandle,
+      description: 'autoswap swap',
+    },
+    proposalTemplate: {
+      give: {
+        In: {
+          pursePetname: 'Fun budget',
+          value: 30,
+        },
+      },
+      want: {
+        Out: {
+          pursePetname: 'Nest egg',
+          value: 1,
+        },
+      },
+      exit: {
+        onDemand: null,
+      },
+    },
+  };
+
+  await wallet.addOffer(offer);
+
+  const accepted = await wallet.acceptOffer(id);
+  assert(accepted);
+  const { depositedP } = accepted;
+  await t.throwsAsync(() => wallet.getUINotifier(rawId, `unknown`), {
+    message: 'offerResult must be a record to have a uiNotifier',
+  });
+
+  await depositedP;
+  const seats = wallet.getSeats(harden([id]));
+  const seat = wallet.getSeat(id);
+  t.is(seat, seats[0], `both getSeat(s) methods work`);
+  t.deepEqual(
+    await moolaPurse.getCurrentAmount(),
+    moolaBundle.amountMath.make(70),
+    `moola purse balance`,
+  );
+  t.deepEqual(
+    await simoleanPurse.getCurrentAmount(),
+    simoleanBundle.amountMath.make(516),
+    `simolean purse balance`,
+  );
+});


### PR DESCRIPTION
This PR takes the code for finding an invitation for an offer and moves it to a separate file. It also adds two new ways of finding or making an invitation for an offer:

1. Find an invitation that already exists in the wallet with a more flexible search query (previously, had to be an invitation handle). As part of the `offer` in `addOffer(offer)`, include an `invitationQuery` property with the keys and values you want to use to match to an invitation:

```js
const offer = {
    id: rawId,
    invitationQuery: {
      instance: autoswapInstanceHandle,
      description: 'autoswap swap',
    },
    proposalTemplate: {
      give: {
...
```
The keys and values must match exactly to those of the invitation, but the query can leave out keys, such as in this case, where only `instance` and `description` are used as query keys. 

2. Make an invitation from a prior `offerResult`. As part of the `offer` in `addOffer`, include a `continuingInvitation` property with the `priorOfferId` that you want to use the offerResult from and the `description` of the invitation you want to create. Note that the description must equal the method name to create the invitation, and it must be capitalized. 

```js
const offer = {
    id: rawId,
    continuingInvitation: {
      priorOfferId,
      description: 'CloseLoan',
    },
    proposalTemplate: {
      give: {
...
```

Still TODO:

- [x] Get feedback on design
- [x] Test `continuingInvitation` property usage (`invitationQuery` is tested).