### PR TITLE
fix(xs-vat-worker): Disable xs-vat-worker package

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "packages/agoric-cli",
     "packages/deployment",
     "packages/notifier",
-    "packages/xs-vat-worker",
     "packages/xsnap",
     "packages/deploy-script-support"
   ],

--- a/packages/xs-vat-worker/package.json
+++ b/packages/xs-vat-worker/package.json
@@ -8,14 +8,14 @@
   "main": "src/locate.js",
   "module": "src/locate.js",
   "scripts": {
-    "install:xs-lin": "make install-deps",
-    "build:xs-lin": "make",
-    "test": "ava",
+    "install:xs-lin": "exit 0",
+    "build:xs-lin": "exit 0",
+    "test": "exit 0",
     "build": "exit 0",
-    "lint-fix": "eslint --fix '**/*.{js,jsx}'",
-    "lint-check": "eslint '**/*.{js,jsx}'",
-    "lint-fix-jessie": "eslint -c '.eslintrc-jessie.js' --fix '**/*.{js,jsx}'",
-    "lint-check-jessie": "eslint -c '.eslintrc-jessie.js' '**/*.{js,jsx}'"
+    "lint-fix": "exit 0",
+    "lint-check": "exit 0",
+    "lint-fix-jessie": "exit 0",
+    "lint-check-jessie": "exit 0"
   },
   "ava": {
     "files": [


### PR DESCRIPTION
To prevent anomalies in the build step, which we also no longer need.