### PR TITLE
chore: add getBrandPetnames to walletBridge

### DIFF
--- a/packages/dapp-svelte-wallet/api/src/lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-wallet.js
@@ -1228,6 +1228,10 @@ export function makeWallet({
     return brand;
   }
 
+  function getBrandPetnames(brands) {
+    return brands.map(brandMapping.valToPetname.get);
+  }
+
   function getSelfContact() {
     return selfContact;
   }
@@ -1337,6 +1341,7 @@ export function makeWallet({
     /** @deprecated use issuerManager.add instead */
     addIssuer: issuerManager.add,
     getBrand,
+    getBrandPetnames,
     publishIssuer,
     /** @deprecated use instanceManager.add instead */
     addInstance: instanceManager.add,

--- a/packages/dapp-svelte-wallet/api/src/types.js
+++ b/packages/dapp-svelte-wallet/api/src/types.js
@@ -83,6 +83,9 @@
  * Get the Zoe Service
  * @property {() => Promise<Board>} getBoard
  * Get the Board
+ * @property {(brands: Array<Brand>) => Promise<Array<Petname>>}
+ * getBrandPetnames
+ * Get the petnames for the brands that are passed in
  */
 
 /**

--- a/packages/dapp-svelte-wallet/api/src/wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/wallet.js
@@ -171,6 +171,10 @@ export function buildRootObject(_vatPowers) {
         await approve();
         return walletAdmin.getBoard();
       },
+      async getBrandPetnames(brands) {
+        await approve();
+        return walletAdmin.getBrandPetnames(brands);
+      },
     };
     return harden(bridge);
   };
@@ -215,6 +219,9 @@ export function buildRootObject(_vatPowers) {
     },
     async getBoard() {
       return walletAdmin.getBoard();
+    },
+    async getBrandPetnames(brands) {
+      return walletAdmin.getBrandPetnames(brands);
     },
   };
   harden(preapprovedBridge);


### PR DESCRIPTION
Adds getBrandPetnames to the walletBridge. Needed for https://github.com/Agoric/dapp-token-economy/pull/68. Ideally this would be part of a larger design change. Open to suggestions for improvement.