### PR TITLE
Fix filtered offers notifier

### DIFF
--- a/packages/dapp-svelte-wallet/api/src/lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-wallet.js
@@ -809,6 +809,7 @@ export function makeWallet({
     const id = makeId(dappOrigin, rawId);
     const offer = harden({
       ...rawOffer,
+      rawId,
       id,
       requestContext: { ...requestContext, dappOrigin },
       status: undefined,
@@ -826,7 +827,7 @@ export function makeWallet({
     const { installation, instance } = await compiledOfferP;
 
     if (!idToOffer.has(id)) {
-      return id;
+      return rawId;
     }
     idToOffer.set(
       id,
@@ -837,7 +838,7 @@ export function makeWallet({
       }),
     );
     await updateInboxState(id, idToOffer.get(id));
-    return id;
+    return rawId;
   }
 
   function consummated(offer) {

--- a/packages/dapp-svelte-wallet/api/src/wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/wallet.js
@@ -128,14 +128,20 @@ export function buildRootObject(_vatPowers) {
         const filter = offer =>
           (status === null || offer.status === status) &&
           offer.requestContext &&
-          offer.requestContext.origin === dappOrigin;
+          offer.requestContext.dappOrigin === dappOrigin;
+        const filteredOffers = offers => {
+          return offers.filter(filter).map(({ rawId, ...v }) => ({
+            ...v,
+            id: rawId,
+          }));
+        };
 
         observeIteration(makeApprovedNotifier(offerNotifier), {
           updateState(offers) {
-            updater.updateState(offers.filter(filter));
+            updater.updateState(filteredOffers(offers));
           },
           finish(offers) {
-            updater.finish(offers.filter(filter));
+            updater.finish(filteredOffers(offers));
           },
           fail(e) {
             updater.fail(e);

--- a/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
@@ -445,6 +445,7 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
     inboxState1,
     {
       id: 'unknown#1588645041696',
+      rawId: '1588645041696',
       inviteHandleBoardId: '727995140',
       proposalTemplate: {},
       requestContext: { dappOrigin: 'unknown' },
@@ -543,6 +544,7 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
     inboxState2,
     {
       id: 'unknown#1588645041696',
+      rawId: '1588645041696',
       inviteHandleBoardId: '727995140',
       proposalTemplate: {},
       requestContext: { dappOrigin: 'unknown' },
@@ -615,6 +617,7 @@ test('lib-wallet offer methods', async t => {
     [
       {
         id: 'unknown#1588645041696',
+        rawId: '1588645041696',
         inviteHandleBoardId: '727995140',
         instance,
         installation,
@@ -712,6 +715,7 @@ test('lib-wallet offer methods', async t => {
     [
       {
         id: 'unknown#1588645041696',
+        rawId: '1588645041696',
         inviteHandleBoardId: '727995140',
         proposalTemplate: {
           give: { Contribution: { pursePetname: 'Fun budget', value: 1 } },
@@ -743,6 +747,7 @@ test('lib-wallet offer methods', async t => {
       },
       {
         id: 'unknown#1588645230204',
+        rawId: '1588645230204',
         inviteHandleBoardId: '371571443',
         proposalTemplate: {
           give: { Contribution: { pursePetname: 'Fun budget', value: 1 } },


### PR DESCRIPTION
fix: dapp offersNotifiers should use dapp-local keys

Remove the dappOrigin# from the offer IDs in the `getOffersNotifier` so that the ID can be 
used to request the `getUiNotifier` and other offer services.  Also changed it to correctly filter
using the `dappOrigin` rather than the `origin`
