### PR TITLE
chore: store rawId for offers

### DIFF
--- a/packages/dapp-svelte-wallet/api/src/lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-wallet.js
@@ -809,6 +809,7 @@ export function makeWallet({
     const id = makeId(dappOrigin, rawId);
     const offer = harden({
       ...rawOffer,
+      rawId,
       id,
       requestContext: { ...requestContext, dappOrigin },
       status: undefined,
@@ -826,7 +827,7 @@ export function makeWallet({
     const { installation, instance } = await compiledOfferP;
 
     if (!idToOffer.has(id)) {
-      return id;
+      return rawId;
     }
     idToOffer.set(
       id,
@@ -837,7 +838,7 @@ export function makeWallet({
       }),
     );
     await updateInboxState(id, idToOffer.get(id));
-    return id;
+    return rawId;
   }
 
   function consummated(offer) {

--- a/packages/dapp-svelte-wallet/api/src/wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/wallet.js
@@ -130,9 +130,9 @@ export function buildRootObject(_vatPowers) {
           offer.requestContext &&
           offer.requestContext.dappOrigin === dappOrigin;
         const filteredOffers = offers => {
-          return offers.filter(filter).map(({ id, ...v }) => ({
+          return offers.filter(filter).map(({ rawId, ...v }) => ({
             ...v,
-            id: id.slice(dappOrigin.length + 1),
+            id: rawId,
           }));
         };
 

--- a/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
@@ -445,6 +445,7 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
     inboxState1,
     {
       id: 'unknown#1588645041696',
+      rawId: '1588645041696',
       inviteHandleBoardId: '727995140',
       proposalTemplate: {},
       requestContext: { dappOrigin: 'unknown' },
@@ -543,6 +544,7 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
     inboxState2,
     {
       id: 'unknown#1588645041696',
+      rawId: '1588645041696',
       inviteHandleBoardId: '727995140',
       proposalTemplate: {},
       requestContext: { dappOrigin: 'unknown' },
@@ -615,6 +617,7 @@ test('lib-wallet offer methods', async t => {
     [
       {
         id: 'unknown#1588645041696',
+        rawId: '1588645041696',
         inviteHandleBoardId: '727995140',
         instance,
         installation,
@@ -712,6 +715,7 @@ test('lib-wallet offer methods', async t => {
     [
       {
         id: 'unknown#1588645041696',
+        rawId: '1588645041696',
         inviteHandleBoardId: '727995140',
         proposalTemplate: {
           give: { Contribution: { pursePetname: 'Fun budget', value: 1 } },
@@ -743,6 +747,7 @@ test('lib-wallet offer methods', async t => {
       },
       {
         id: 'unknown#1588645230204',
+        rawId: '1588645230204',
         inviteHandleBoardId: '371571443',
         proposalTemplate: {
           give: { Contribution: { pursePetname: 'Fun budget', value: 1 } },


### PR DESCRIPTION
Stacked PR to merge into #2184 

Stores a `rawId`, which is later exposed as `id`. Also changes the return value of `addOffer` to only be the `rawId`, not concatenated `id`.