### PR TITLE
fix(xsnap): Update submodules for build and use CURDIR

### DIFF
--- a/packages/xsnap/makefiles/lin/xsnap.mk
+++ b/packages/xsnap/makefiles/lin/xsnap.mk
@@ -7,16 +7,9 @@ ifneq ($(VERBOSE),1)
 MAKEFLAGS += --silent
 endif
 
-# This Makefile gets invoked as "make" with this directory as the "cwd" using
-# Node.js child_process.spawn. For reasons that remain mysterious to this
-# author, under these circumstances, $(PWD) is two parent directories up
-# from this file. At the shell, (cd makefiles/lin && make) works fine.
-# Regardless, using HERE instead of PWD makes this Makefile work regardless of
-# the working directory.
-HERE = $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
-MODDABLE = $(HERE)/../../moddable
+MODDABLE = $(CURDIR)/../../moddable
 XS_DIR = $(MODDABLE)/xs
-BUILD_DIR = $(HERE)/../../build
+BUILD_DIR = $(CURDIR)/../../build
 
 BIN_DIR = $(BUILD_DIR)/bin/lin/$(GOAL)
 INC_DIR = $(XS_DIR)/includes
@@ -106,11 +99,7 @@ OBJECTS = \
 
 VPATH += $(SRC_DIR) $(TLS_DIR)
 
-build: $(MODDABLE)/README.md $(TMP_DIR) $(BIN_DIR) $(BIN_DIR)/$(NAME)
-
-$(MODDABLE)/README.md:
-	git submodule init
-	git submodule update
+build: $(TMP_DIR) $(BIN_DIR) $(BIN_DIR)/$(NAME)
 
 $(TMP_DIR):
 	mkdir -p $(TMP_DIR)

--- a/packages/xsnap/makefiles/mac/xsnap.mk
+++ b/packages/xsnap/makefiles/mac/xsnap.mk
@@ -7,16 +7,9 @@ ifneq ($(VERBOSE),1)
 MAKEFLAGS += --silent
 endif
 
-# This Makefile gets invoked as "make" with this directory as the "cwd" using
-# Node.js child_process.spawn. For reasons that remain mysterious to this
-# author, under these circumstances, $(PWD) is two parent directories up
-# from this file. At the shell, (cd makefiles/lin && make) works fine.
-# Regardless, using HERE instead of PWD makes this Makefile work regardless of
-# the working directory.
-HERE = $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
-MODDABLE = $(HERE)/../../moddable
+MODDABLE = $(CURDIR)/../../moddable
 XS_DIR = $(MODDABLE)/xs
-BUILD_DIR = $(HERE)/../../build
+BUILD_DIR = $(CURDIR)/../../build
 
 BIN_DIR = $(BUILD_DIR)/bin/mac/$(GOAL)
 INC_DIR = $(XS_DIR)/includes
@@ -115,11 +108,7 @@ OBJECTS = \
 
 VPATH += $(SRC_DIR) $(TLS_DIR)
 
-build: $(MODDABLE)/README.md $(TMP_DIR) $(BIN_DIR) $(BIN_DIR)/$(NAME)
-
-$(MODDABLE)/README.md:
-	git submodule init
-	git submodule update
+build: $(TMP_DIR) $(BIN_DIR) $(BIN_DIR)/$(NAME)
 
 $(TMP_DIR):
 	mkdir -p $(TMP_DIR)

--- a/packages/xsnap/package.json
+++ b/packages/xsnap/package.json
@@ -9,7 +9,7 @@
   },
   "main": "./src/xsnap.js",
   "scripts": {
-    "build": "node -r esm src/build.js",
+    "build": "git submodule update --init && node -r esm src/build.js",
     "clean": "rm -rf build",
     "lint": "yarn lint:js && yarn lint:types",
     "lint:js": "eslint 'src/**/*.js'",


### PR DESCRIPTION
@dtribble observed that xsnap builds would fail once, and succeed on the retry. This is likely due to a failure to coordinate updating the submodule through the Makefile. I’ve instead moved the submodule update into a pre-build command to ensure it gets run before any Makefile rules.

Also, it transpires that `$(CURDIR)` is the proper idiom for `$(shell PWD)` or `$(PWD)`.