### PR TITLE
feat(xsnap): Add machinery for an xsrepl binary

### DIFF
--- a/packages/xsnap/README.md
+++ b/packages/xsnap/README.md
@@ -38,3 +38,32 @@ The parent and child communicate using "commands".
   request and receive a response from the XS child.
 - The Node.js parent can implement an asynchronous `handleCommand` function to
   respond to commands from the XS child.
+
+# xsrepl
+
+With `xsnap` comes an `xsrepl` command line tool.
+Use `yarn global add @agoric/xsnap` to add `xsrepl` to your path.
+During development, run `yarn repl`.
+
+The REPL supports special commands `load` and `save` for snapshots, and `quit`
+to quit.
+Load and save don't take arguments; just type the file name on the next prompt.
+
+```sh
+$ xsrepl
+xs> globalThis.x = 42;
+xs> x
+42
+xs> save
+file> temp.xss
+xs> quit
+```
+
+```sh
+xs> load
+file> temp.xss
+$ xsrepl
+xs> x
+42
+xs> quit
+```

--- a/packages/xsnap/package.json
+++ b/packages/xsnap/package.json
@@ -8,7 +8,11 @@
     "js": "mjs"
   },
   "main": "./src/xsnap.js",
+  "bin": {
+    "xsrepl": "./src/xsrepl"
+  },
   "scripts": {
+    "repl": "node -r esm src/xsrepl.js",
     "build": "git submodule update --init && node -r esm src/build.js",
     "clean": "rm -rf build",
     "lint": "yarn lint:js && yarn lint:types",
@@ -19,11 +23,12 @@
     "test": "ava",
     "postinstall": "yarn build"
   },
-  "dependencies": {},
+  "dependencies": {
+    "esm": "^3.2.5"
+  },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^6.1.0",
     "ava": "^3.12.1",
-    "esm": "^3.2.5",
     "rollup-plugin-terser": "^5.1.3"
   },
   "files": [

--- a/packages/xsnap/src/xsrepl
+++ b/packages/xsnap/src/xsrepl
@@ -1,0 +1,3 @@
+#!/bin/bash
+HERE=$(dirname -- $(readlink -f "$0"))
+node -r esm $HERE/xsrepl.js "@*"

--- a/packages/xsnap/src/xsrepl.js
+++ b/packages/xsnap/src/xsrepl.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 // @ts-check
 /* eslint no-await-in-loop: ["off"] */
 
@@ -72,7 +71,7 @@ async function main() {
       const file = await ask('file> ');
       await vat.snapshot(file);
     } else {
-      await vat.send(answer);
+      await vat.issueStringCommand(answer);
     }
   }
 


### PR DESCRIPTION
With this change, yarn repl will run the XS REPL.

Also, after this is published, yarn global add @agoric/xsnap will
introduce an xsnap executable to the PATH.

Any package that depends on this package will also have xsnap available
in its scripts.