### PR TITLE
chore: import types

### DIFF
--- a/packages/zoe/exported.js
+++ b/packages/zoe/exported.js
@@ -7,3 +7,4 @@ import './tools/types';
 import '@agoric/notifier/exported';
 import '@agoric/ertp/exported';
 import '@agoric/store/exported';
+import '@agoric/swingset-vat/exported';

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -9,15 +9,7 @@ import {
   makeOnewayPriceAuthorityKit,
 } from '../contractSupport';
 
-// the bulk import style for typescript declarations doesn't seem to work here.
-/**
- * @typedef {import('../../tools/types').PriceAuthority} PriceAuthority
- * @typedef {import('../../tools/types').PriceAuthorityAdmin} PriceAuthorityAdmin
- * @typedef {import('../../tools/types').PriceQuote} PriceQuote
- * @typedef {import('../../tools/types').PriceQuoteValue} PriceQuoteValue
- * @typedef {import('../../tools/types').PriceQuery} PriceQuery
- * @typedef {import('../../tools/types').PriceDescription} PriceDescription
- */
+import '../../exported';
 
 const { add, multiply, floorDivide, ceilDivide, isGTE } = natSafeMath;
 

--- a/packages/zoe/tools/types.js
+++ b/packages/zoe/tools/types.js
@@ -1,5 +1,3 @@
-import '@agoric/swingset-vat/exported';
-
 /**
  * @typedef {Object} PriceQuote
  * @property {Amount} quoteAmount Amount whose value is a PriceQuoteValue


### PR DESCRIPTION
@Chris-Hibbert  this fixes the import problem you were seeing. For whatever reason, it does not allow for importing an entire file from somewhere else and defining in the same file. Files like `exported.js` which are entirely imports and no definitions seem to work.