### PR TITLE
WIP Spike Draft: Big Nats

### DIFF
--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -45,7 +45,7 @@
     "@agoric/eventual-send": "^0.13.0",
     "@agoric/import-manager": "^0.2.0",
     "@agoric/marshal": "^0.3.0",
-    "@agoric/nat": "^2.0.1",
+    "@agoric/nat": "^3.0.1",
     "@agoric/notifier": "^0.3.0",
     "@agoric/promise-kit": "^0.2.0",
     "@agoric/same-structure": "^0.1.0",

--- a/packages/ERTP/src/mathHelpers/natMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/natMathHelpers.js
@@ -4,7 +4,7 @@ import Nat from '@agoric/nat';
 
 import '../types';
 
-const identity = 0;
+const identity = BigInt(0);
 
 /**
  * Fungible digital assets use the natMathHelpers to manage balances -
@@ -19,12 +19,13 @@ const identity = 0;
  * @type {MathHelpers}
  */
 const natMathHelpers = harden({
-  doCoerce: Nat,
+  doCoerce: n => Nat(BigInt(n)),
   doGetEmpty: _ => identity,
   doIsEmpty: nat => nat === identity,
   doIsGTE: (left, right) => left >= right,
   doIsEqual: (left, right) => left === right,
-  doAdd: (left, right) => Nat(left + right),
+  // BigInts don't observably overflow
+  doAdd: (left, right) => left + right,
   doSubtract: (left, right) => Nat(left - right),
 });
 

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -312,6 +312,11 @@
  * values labeled with a brand. AmountMath use mathHelpers to do their value arithmetic,
  * and then brand the results, making a new amount.
  *
+ * The MathHelpers are designed to be called only from AmountMath, and so
+ * all methods but coerce can assume their inputs are valid. They only
+ * need to do output validation, and only when there is a possibility of
+ * invalid output.
+ *
  * @property {(allegedValue: Value) => Value} doCoerce
  * Check the kind of this value and throw if it is not the
  * expected kind.

--- a/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
@@ -35,15 +35,15 @@ test('natMathHelpers', t => {
   t.deepEqual(getAmountMathKind(), MathKind.NAT, 'amountMathKind is nat');
 
   // make
-  t.deepEqual(make(4), { brand: mockBrand, value: 4 });
+  t.deepEqual(make(4), { brand: mockBrand, value: BigInt(4) });
   t.throws(
     () => make('abc'),
-    { instanceOf: RangeError, message: 'not a safe integer' },
-    `'abc' is not a nat`,
+    { instanceOf: SyntaxError, message: 'Cannot convert abc to a BigInt' },
+    `Cannot convert abc to a BigInt`,
   );
   t.throws(
     () => make(-1),
-    { instanceOf: RangeError, message: 'negative' },
+    { instanceOf: RangeError, message: '-1 is negative' },
     `- 1 is not a valid Nat`,
   );
 
@@ -52,7 +52,7 @@ test('natMathHelpers', t => {
     coerce(harden({ brand: mockBrand, value: 4 })),
     {
       brand: mockBrand,
-      value: 4,
+      value: BigInt(4),
     },
     `coerce can take an amount`,
   );
@@ -71,7 +71,7 @@ test('natMathHelpers', t => {
   );
 
   // getValue
-  t.is(getValue(make(4)), 4);
+  t.is(getValue(make(4)), BigInt(4));
 
   // getEmpty
   t.deepEqual(getEmpty(), make(0), `empty is 0`);
@@ -88,7 +88,7 @@ test('natMathHelpers', t => {
   );
   t.throws(
     () => isEmpty({ brand: mockBrand, value: 'abc' }),
-    { instanceOf: RangeError, message: 'not a safe integer' },
+    { instanceOf: SyntaxError, message: 'Cannot convert abc to a BigInt' },
     `isEmpty('abc') throws because it cannot be coerced`,
   );
   t.throws(

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -61,7 +61,7 @@ test('amountMath from makeIssuerKit', async t => {
       fungible(150),
     ),
   );
-  t.is(fungible(4000).value, 4000);
+  t.is(fungible(4000).value, BigInt(4000));
   t.is(fungible(0).brand, brand);
 });
 
@@ -399,7 +399,7 @@ test('issuer.combine array of promises', async t => {
 
   const checkCombinedResult = paymentP => {
     issuer.getAmountOf(paymentP).then(pAmount => {
-      t.is(pAmount.value, 100);
+      t.is(pAmount.value, BigInt(100));
     });
   };
 

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -40,7 +40,7 @@
     "@agoric/import-bundle": "^0.2.0",
     "@agoric/install-ses": "^0.5.0",
     "@agoric/marshal": "^0.3.0",
-    "@agoric/nat": "^2.0.1",
+    "@agoric/nat": "^3.0.1",
     "@agoric/notifier": "^0.3.0",
     "@agoric/promise-kit": "^0.2.0",
     "@agoric/store": "^0.4.0",

--- a/packages/SwingSet/src/devices/command-src.js
+++ b/packages/SwingSet/src/devices/command-src.js
@@ -17,7 +17,7 @@ export function buildRootDeviceNode(tools) {
     }
     try {
       const body = JSON.parse(`${bodyString}`);
-      SO(inboundHandler).inbound(Nat(count), body);
+      SO(inboundHandler).inbound(Nat(BigInt(count)), body);
     } catch (e) {
       console.error(`error during inboundCallback:`, e);
       throw new Error(`error during inboundCallback: ${e}`);

--- a/packages/SwingSet/src/devices/command.js
+++ b/packages/SwingSet/src/devices/command.js
@@ -42,7 +42,7 @@ export default function buildCommand(broadcastCallback) {
   }
 
   function deliverResponse(kCount, kIsReject, kResponseString) {
-    const count = Nat(kCount);
+    const count = Nat(BigInt(kCount));
     const isReject = Boolean(kIsReject);
     let obj;
     // TODO: is this safe against kernel-realm trickery? It's awfully handy

--- a/packages/SwingSet/src/devices/mailbox-src.js
+++ b/packages/SwingSet/src/devices/mailbox-src.js
@@ -1,5 +1,7 @@
 import Nat from '@agoric/nat';
 
+const { details: d } = assert;
+
 export function buildRootDeviceNode(tools) {
   const { SO, getDeviceState, setDeviceState, endowments } = tools;
   const highestInboundDelivered = harden(new Map());
@@ -15,7 +17,7 @@ export function buildRootDeviceNode(tools) {
         `mailbox.inboundCallback(${peer}) called before handler was registered`,
       );
     }
-    const ack = Nat(hAck);
+    const ack = Nat(BigInt(hAck));
     let didSomething = false;
 
     let latestMsg = 0;
@@ -25,7 +27,7 @@ export function buildRootDeviceNode(tools) {
     const newMessages = [];
     hMessages.forEach(m => {
       const [hNum, hMsg] = m;
-      const num = Nat(hNum);
+      const num = Nat(BigInt(hNum));
       if (num > latestMsg) {
         newMessages.push([num, `${hMsg}`]);
         latestMsg = num;
@@ -56,7 +58,7 @@ export function buildRootDeviceNode(tools) {
   // console.debug(`mailbox-src build: inboundHandler is`, inboundHandler);
   deliverInboundMessages = (peer, newMessages) => {
     if (!inboundHandler) {
-      throw new Error(`deliverInboundMessages before registerInboundHandler`);
+      assert.fail(d`deliverInboundMessages before registerInboundHandler`);
     }
     try {
       SO(inboundHandler).deliverInboundMessages(peer, newMessages);
@@ -67,7 +69,7 @@ export function buildRootDeviceNode(tools) {
 
   deliverInboundAck = (peer, ack) => {
     if (!inboundHandler) {
-      throw new Error(`deliverInboundAck before registerInboundHandler`);
+      assert.fail(d`deliverInboundAck before registerInboundHandler`);
     }
     try {
       SO(inboundHandler).deliverInboundAck(peer, ack);
@@ -80,7 +82,7 @@ export function buildRootDeviceNode(tools) {
   return harden({
     registerInboundHandler(handler) {
       if (inboundHandler) {
-        throw new Error(`already registered`);
+        assert.fail(d`already registered`);
       }
       inboundHandler = handler;
       setDeviceState(harden({ inboundHandler }));
@@ -88,25 +90,25 @@ export function buildRootDeviceNode(tools) {
 
     add(peer, msgnum, body) {
       try {
-        endowments.add(`${peer}`, Nat(msgnum), `${body}`);
+        endowments.add(`${peer}`, Nat(BigInt(msgnum)), `${body}`);
       } catch (e) {
-        throw new Error(`error in add: ${e}`);
+        assert.fail(d`error in add: ${e}`);
       }
     },
 
     remove(peer, msgnum) {
       try {
-        endowments.remove(`${peer}`, Nat(msgnum));
+        endowments.remove(`${peer}`, Nat(BigInt(msgnum)));
       } catch (e) {
-        throw new Error(`error in remove: ${e}`);
+        assert.fail(d`error in remove: ${e}`);
       }
     },
 
     ackInbound(peer, msgnum) {
       try {
-        endowments.setAcknum(`${peer}`, Nat(msgnum));
+        endowments.setAcknum(`${peer}`, Nat(BigInt(msgnum)));
       } catch (e) {
-        throw new Error(`error in ackInbound: ${e}`);
+        assert.fail(d`error in ackInbound: ${e}`);
       }
     },
   });

--- a/packages/SwingSet/src/devices/mailbox.js
+++ b/packages/SwingSet/src/devices/mailbox.js
@@ -73,7 +73,7 @@ import Nat from '@agoric/nat';
 export function importMailbox(data, inout = {}) {
   const outbox = new Map();
   data.outbox.forEach(m => {
-    outbox.set(Nat(m[0]), m[1]);
+    outbox.set(Nat(BigInt(m[0]), m[1]));
   });
   inout.ack = data.ack;
   inout.outbox = outbox;
@@ -85,7 +85,7 @@ export function exportMailbox(inout) {
   inout.outbox.forEach((body, msgnum) => {
     messages.push([msgnum, body]);
   });
-  messages.sort((a, b) => a[0] - b[0]);
+  messages.sort((a, b) => Number(a[0] - b[0]));
   return {
     ack: inout.ack,
     outbox: messages,
@@ -105,16 +105,16 @@ export function buildMailboxStateMap(state = harden(new Map())) {
   }
 
   function add(peer, msgnum, body) {
-    getOrCreatePeer(`${peer}`).outbox.set(Nat(msgnum), `${body}`);
+    getOrCreatePeer(`${peer}`).outbox.set(Nat(BigInt(msgnum)), `${body}`);
   }
 
   function remove(peer, msgnum) {
     const messages = getOrCreatePeer(`${peer}`).outbox;
-    messages.delete(Nat(msgnum));
+    messages.delete(Nat(BigInt(msgnum)));
   }
 
   function setAcknum(peer, msgnum) {
-    getOrCreatePeer(`${peer}`).ack = Nat(msgnum);
+    getOrCreatePeer(`${peer}`).ack = Nat(BigInt(msgnum));
   }
 
   function exportToData() {
@@ -166,15 +166,15 @@ export function buildMailbox(state) {
   }
 
   function add(peer, msgnum, body) {
-    state.add(`${peer}`, Nat(msgnum), `${body}`);
+    state.add(`${peer}`, Nat(BigInt(msgnum)), `${body}`);
   }
 
   function remove(peer, msgnum) {
-    state.remove(`${peer}`, Nat(msgnum));
+    state.remove(`${peer}`, Nat(BigInt(msgnum)));
   }
 
   function setAcknum(peer, msgnum) {
-    state.setAcknum(`${peer}`, Nat(msgnum));
+    state.setAcknum(`${peer}`, Nat(BigInt(msgnum)));
   }
 
   // deliverInbound is made available to the host; it is used for inbound
@@ -185,6 +185,13 @@ export function buildMailbox(state) {
     try {
       return Boolean(inboundCallback(peer, messages, ack));
     } catch (e) {
+      // TODO after https://github.com/Agoric/SES-shim/pull/555 is merged,
+      // fix this to
+      // assert.fail(d`error in inboundCallback: ${e}`);
+      // or
+      // assert.note(e, 'error in inboundCallback:');
+      // throw e;
+      console.log('error in inboundCallback:', e);
       throw new Error(`error in inboundCallback: ${e}`);
     }
   }

--- a/packages/SwingSet/src/devices/timer-src.js
+++ b/packages/SwingSet/src/devices/timer-src.js
@@ -257,9 +257,9 @@ export function buildRootDeviceNode(tools) {
   // point will be reached at consistent intervals.
   return harden({
     setWakeup(delaySecs, handler) {
-      deadlines.add(lastPolled + Nat(delaySecs), handler);
+      deadlines.add(lastPolled + Nat(BigInt(delaySecs)), handler);
       saveState();
-      return lastPolled + Nat(delaySecs);
+      return lastPolled + Nat(BigInt(delaySecs));
     },
     removeWakeup(handler) {
       const times = deadlines.remove(handler);
@@ -276,8 +276,8 @@ export function buildRootDeviceNode(tools) {
     makeRepeater(startTime, interval) {
       const index = nextRepeater;
       repeaters.push({
-        startTime: Nat(startTime),
-        interval: Nat(interval),
+        startTime: Nat(BigInt(startTime)),
+        interval: Nat(BigInt(interval)),
       });
       nextRepeater += 1;
       saveState();

--- a/packages/SwingSet/src/devices/timer.js
+++ b/packages/SwingSet/src/devices/timer.js
@@ -21,7 +21,7 @@ export function buildTimer() {
   // poll() is made available to the host loop so it can provide the time.
   function poll(time) {
     try {
-      return Boolean(devicePollFunction(Nat(time)));
+      return Boolean(devicePollFunction(Nat(BigInt(time))));
     } catch (e) {
       throw new Error(`error in devicePollFunction: ${e}`);
     }

--- a/packages/SwingSet/src/kernel/id.js
+++ b/packages/SwingSet/src/kernel/id.js
@@ -27,7 +27,7 @@ export function insistVatID(s) {
     if (!s.startsWith(`v`)) {
       throw new Error(`does not start with 'v'`);
     }
-    Nat(Number(s.slice(1)));
+    Nat(BigInt(s.slice(1)));
   } catch (e) {
     throw new Error(`'${s} is not a 'vNN'-style VatID: ${e.message}`);
   }
@@ -41,7 +41,7 @@ export function insistVatID(s) {
  * @returns {string} a vat ID string of the form "vNN" where NN is the index.
  */
 export function makeVatID(index) {
-  return `v${Nat(index)}`;
+  return `v${Nat(BigInt(index))}`;
 }
 
 /**
@@ -63,7 +63,7 @@ export function insistDeviceID(s) {
     if (!s.startsWith(`d`)) {
       throw new Error(`does not start with 'd'`);
     }
-    Nat(Number(s.slice(1)));
+    Nat(BigInt(s.slice(1)));
   } catch (e) {
     throw new Error(`'${s} is not a 'dNN'-style DeviceID: ${e.message}`);
   }
@@ -77,7 +77,7 @@ export function insistDeviceID(s) {
  * @returns {string} a device ID string of the form "dNN" where NN is the index.
  */
 export function makeDeviceID(index) {
-  return `d${Nat(index)}`;
+  return `d${Nat(BigInt(index))}`;
 }
 
 /**
@@ -108,5 +108,5 @@ export function parseVatOrDeviceID(s) {
   } else {
     throw new Error(`'${s}' is neither a VatID nor a DeviceID`);
   }
-  return harden({ type, id: Nat(Number(idSuffix)) });
+  return harden({ type, id: Nat(BigInt(idSuffix)) });
 }

--- a/packages/SwingSet/src/kernel/parseKernelSlots.js
+++ b/packages/SwingSet/src/kernel/parseKernelSlots.js
@@ -39,7 +39,7 @@ export function parseKernelSlot(s) {
   } else {
     throw new Error(`invalid kernelSlot ${s}`);
   }
-  const id = Nat(Number(idSuffix));
+  const id = Nat(BigInt(idSuffix));
   return { type, id };
 }
 
@@ -55,13 +55,13 @@ export function parseKernelSlot(s) {
  */
 export function makeKernelSlot(type, id) {
   if (type === 'object') {
-    return `ko${Nat(id)}`;
+    return `ko${Nat(BigInt(id))}`;
   }
   if (type === 'device') {
-    return `kd${Nat(id)}`;
+    return `kd${Nat(BigInt(id))}`;
   }
   if (type === 'promise') {
-    return `kp${Nat(id)}`;
+    return `kp${Nat(BigInt(id))}`;
   }
   throw new Error(`unknown type ${type}`);
 }

--- a/packages/SwingSet/src/kernel/state/deviceKeeper.js
+++ b/packages/SwingSet/src/kernel/state/deviceKeeper.js
@@ -108,8 +108,8 @@ export function makeDeviceKeeper(storage, deviceID, addKernelDeviceNode) {
 
       let id;
       if (type === 'object') {
-        id = Nat(Number(storage.get(`${deviceID}.o.nextID`)));
-        storage.set(`${deviceID}.o.nextID`, `${id + 1}`);
+        id = Nat(BigInt(storage.get(`${deviceID}.o.nextID`)));
+        storage.set(`${deviceID}.o.nextID`, `${id + BigInt(1)}`);
       } else if (type === 'device') {
         throw new Error('devices cannot import other device nodes');
       } else if (type === 'promise') {

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -220,12 +220,12 @@ export default function makeKernelKeeper(storage, kernelSlog) {
   }
 
   function getCrankNumber() {
-    return Nat(Number(getRequired('crankNumber')));
+    return Nat(BigInt(getRequired('crankNumber')));
   }
 
   function incrementCrankNumber() {
-    const crankNumber = Nat(Number(getRequired('crankNumber')));
-    storage.set('crankNumber', `${crankNumber + 1}`);
+    const crankNumber = Nat(BigInt(getRequired('crankNumber')));
+    storage.set('crankNumber', `${crankNumber + BigInt(1)}`);
   }
 
   function createStartingKernelState() {
@@ -251,9 +251,9 @@ export default function makeKernelKeeper(storage, kernelSlog) {
 
   function addKernelObject(ownerID) {
     insistVatID(ownerID);
-    const id = Nat(Number(getRequired('ko.nextID')));
+    const id = Nat(BigInt(getRequired('ko.nextID')));
     kdebug(`Adding kernel object ko${id} for ${ownerID}`);
-    storage.set('ko.nextID', `${id + 1}`);
+    storage.set('ko.nextID', `${id + BigInt(1)}`);
     const s = makeKernelSlot('object', id);
     storage.set(`${s}.owner`, ownerID);
     incStat('kernelObjects');
@@ -271,9 +271,9 @@ export default function makeKernelKeeper(storage, kernelSlog) {
 
   function addKernelDeviceNode(deviceID) {
     insistDeviceID(deviceID);
-    const id = Nat(Number(getRequired('kd.nextID')));
+    const id = Nat(BigInt(getRequired('kd.nextID')));
     kdebug(`Adding kernel device kd${id} for ${deviceID}`);
-    storage.set('kd.nextID', `${id + 1}`);
+    storage.set('kd.nextID', `${id + BigInt(1)}`);
     const s = makeKernelSlot('device', id);
     storage.set(`${s}.owner`, deviceID);
     incStat('kernelDevices');
@@ -288,8 +288,8 @@ export default function makeKernelKeeper(storage, kernelSlog) {
   }
 
   function addKernelPromise(policy) {
-    const kpidNum = Nat(Number(getRequired('kp.nextID')));
-    storage.set('kp.nextID', `${kpidNum + 1}`);
+    const kpidNum = Nat(BigInt(getRequired('kp.nextID')));
+    storage.set('kp.nextID', `${kpidNum + BigInt(1)}`);
     const kpid = makeKernelSlot('promise', kpidNum);
     storage.set(`${kpid}.state`, 'unresolved');
     storage.set(`${kpid}.subscribers`, '');
@@ -532,8 +532,8 @@ export default function makeKernelKeeper(storage, kernelSlog) {
       throw new Error(`${kernelSlot} is '${p.state}', not 'unresolved'`);
     }
     const nkey = `${kernelSlot}.queue.nextID`;
-    const nextID = Nat(Number(storage.get(nkey)));
-    storage.set(nkey, `${nextID + 1}`);
+    const nextID = Nat(BigInt(storage.get(nkey)));
+    storage.set(nkey, `${nextID + BigInt(1)}`);
     const qid = `${kernelSlot}.queue.${nextID}`;
     storage.set(qid, JSON.stringify(msg));
   }
@@ -605,8 +605,8 @@ export default function makeKernelKeeper(storage, kernelSlog) {
   }
 
   function allocateUnusedVatID() {
-    const nextID = Nat(Number(getRequired(`vat.nextID`)));
-    storage.set(`vat.nextID`, `${nextID + 1}`);
+    const nextID = Nat(BigInt(getRequired(`vat.nextID`)));
+    storage.set(`vat.nextID`, `${nextID + BigInt(1)}`);
     return makeVatID(nextID);
   }
 
@@ -667,7 +667,7 @@ export default function makeKernelKeeper(storage, kernelSlog) {
    */
   function incrementRefCount(kernelSlot, _tag) {
     if (kernelSlot && parseKernelSlot(kernelSlot).type === 'promise') {
-      const refCount = Nat(Number(storage.get(`${kernelSlot}.refCount`))) + 1;
+      const refCount = Nat(BigInt(storage.get(`${kernelSlot}.refCount`) + 1));
       // kdebug(`++ ${kernelSlot}  ${tag} ${refCount}`);
       storage.set(`${kernelSlot}.refCount`, `${refCount}`);
     }
@@ -686,9 +686,9 @@ export default function makeKernelKeeper(storage, kernelSlog) {
    */
   function decrementRefCount(kernelSlot, tag) {
     if (kernelSlot && parseKernelSlot(kernelSlot).type === 'promise') {
-      let refCount = Nat(Number(storage.get(`${kernelSlot}.refCount`)));
+      let refCount = Nat(BigInt(storage.get(`${kernelSlot}.refCount`)));
       assert(refCount > 0, details`refCount underflow {kernelSlot} ${tag}`);
-      refCount -= 1;
+      refCount -= BigInt(1);
       // kdebug(`-- ${kernelSlot}  ${tag} ${refCount}`);
       storage.set(`${kernelSlot}.refCount`, `${refCount}`);
       if (refCount === 0) {
@@ -752,7 +752,7 @@ export default function makeKernelKeeper(storage, kernelSlog) {
   }
 
   function getAllVatIDs() {
-    const nextID = Nat(Number(getRequired(`vat.nextID`)));
+    const nextID = Nat(BigInt(getRequired(`vat.nextID`)));
     const vatIDs = [];
     for (let i = FIRST_VAT_ID; i < nextID; i += 1) {
       const vatID = makeVatID(i);
@@ -776,8 +776,8 @@ export default function makeKernelKeeper(storage, kernelSlog) {
     assert.typeof(name, 'string');
     const k = `device.name.${name}`;
     if (!storage.has(k)) {
-      const nextID = Nat(Number(getRequired(`device.nextID`)));
-      storage.set(`device.nextID`, `${nextID + 1}`);
+      const nextID = Nat(BigInt(getRequired(`device.nextID`)));
+      storage.set(`device.nextID`, `${nextID + BigInt(1)}`);
       storage.set(k, makeDeviceID(nextID));
       const names = JSON.parse(getRequired('device.names'));
       names.push(name);
@@ -799,7 +799,7 @@ export default function makeKernelKeeper(storage, kernelSlog) {
   }
 
   function getAllDeviceIDs() {
-    const nextID = Nat(Number(getRequired(`device.nextID`)));
+    const nextID = Nat(BigInt(getRequired(`device.nextID`)));
     const deviceIDs = [];
     for (let i = FIRST_DEVICE_ID; i < nextID; i += 1) {
       const deviceID = makeDeviceID(i);
@@ -864,7 +864,7 @@ export default function makeKernelKeeper(storage, kernelSlog) {
 
     const promises = [];
 
-    const nextPromiseID = Nat(Number(getRequired('kp.nextID')));
+    const nextPromiseID = Nat(BigInt(getRequired('kp.nextID')));
     for (let i = FIRST_PROMISE_ID; i < nextPromiseID; i += 1) {
       const kpid = makeKernelSlot('promise', i);
       if (hasKernelPromise(kpid)) {

--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -5,16 +5,20 @@
 import Nat from '@agoric/nat';
 import { assert, details } from '@agoric/assert';
 import { parseKernelSlot } from '../parseKernelSlots';
-import { makeVatSlot, parseVatSlot } from '../../parseVatSlots';
+import {
+  makeVatSlot,
+  parseVatSlot,
+  safeBigIntStringify,
+} from '../../parseVatSlots';
 import { insistVatID } from '../id';
 import { kdebug } from '../kdebug';
 
 // makeVatKeeper is a pure function: all state is kept in the argument object
 
 // TODO: tests rely on these numbers and haven't been updated to use names.
-const FIRST_OBJECT_ID = 50;
-const FIRST_PROMISE_ID = 60;
-const FIRST_DEVICE_ID = 70;
+const FIRST_OBJECT_ID = BigInt(50);
+const FIRST_PROMISE_ID = BigInt(60);
+const FIRST_DEVICE_ID = BigInt(70);
 const FIRST_TRANSCRIPT_ID = 0;
 
 /**
@@ -66,8 +70,8 @@ export function makeVatKeeper(
     assert.typeof(source, 'object');
     assert(source.bundle || source.bundleName);
     assert.typeof(options, 'object');
-    storage.set(`${vatID}.source`, JSON.stringify(source));
-    storage.set(`${vatID}.options`, JSON.stringify(options));
+    storage.set(`${vatID}.source`, safeBigIntStringify(source));
+    storage.set(`${vatID}.options`, safeBigIntStringify(options));
   }
 
   function getSourceAndOptions() {
@@ -147,14 +151,14 @@ export function makeVatKeeper(
 
       let id;
       if (type === 'object') {
-        id = Nat(Number(storage.get(`${vatID}.o.nextID`)));
-        storage.set(`${vatID}.o.nextID`, `${id + 1}`);
+        id = Nat(BigInt(storage.get(`${vatID}.o.nextID`)));
+        storage.set(`${vatID}.o.nextID`, `${id + BigInt(1)}`);
       } else if (type === 'device') {
-        id = Nat(Number(storage.get(`${vatID}.d.nextID`)));
-        storage.set(`${vatID}.d.nextID`, `${id + 1}`);
+        id = Nat(BigInt(storage.get(`${vatID}.d.nextID`)));
+        storage.set(`${vatID}.d.nextID`, `${id + BigInt(1)}`);
       } else if (type === 'promise') {
-        id = Nat(Number(storage.get(`${vatID}.p.nextID`)));
-        storage.set(`${vatID}.p.nextID`, `${id + 1}`);
+        id = Nat(BigInt(storage.get(`${vatID}.p.nextID`)));
+        storage.set(`${vatID}.p.nextID`, `${id + BigInt(1)}`);
       } else {
         throw new Error(`unknown type ${type}`);
       }
@@ -222,14 +226,14 @@ export function makeVatKeeper(
    * @param {string} msg  The message to append.
    */
   function addToTranscript(msg) {
-    const id = Nat(Number(storage.get(`${vatID}.t.nextID`)));
-    storage.set(`${vatID}.t.nextID`, `${id + 1}`);
-    storage.set(`${vatID}.t.${id}`, JSON.stringify(msg));
+    const id = Nat(BigInt(storage.get(`${vatID}.t.nextID`)));
+    storage.set(`${vatID}.t.nextID`, `${id + BigInt(1)}`);
+    storage.set(`${vatID}.t.${id}`, safeBigIntStringify(msg));
   }
 
   function vatStats() {
     function getStringAsNat(ostr) {
-      return Nat(Number(storage.get(ostr)));
+      return Nat(BigInt(storage.get(ostr)));
     }
 
     const objectCount = getStringAsNat(`${vatID}.o.nextID`) - FIRST_OBJECT_ID;
@@ -238,10 +242,10 @@ export function makeVatKeeper(
     const transcriptCount =
       storage.get(`${vatID}.t.nextID`) - FIRST_TRANSCRIPT_ID;
     return harden({
-      objectCount: Nat(objectCount),
-      promiseCount: Nat(promiseCount),
-      deviceCount: Nat(deviceCount),
-      transcriptCount: Nat(Number(transcriptCount)),
+      objectCount: Nat(BigInt(objectCount)),
+      promiseCount: Nat(BigInt(promiseCount)),
+      deviceCount: Nat(BigInt(deviceCount)),
+      transcriptCount: Nat(BigInt(transcriptCount)),
     });
   }
 

--- a/packages/SwingSet/src/kernel/vatManager/deliver.js
+++ b/packages/SwingSet/src/kernel/vatManager/deliver.js
@@ -34,7 +34,7 @@ export function makeDeliver(tools, dispatch) {
       .then(f)
       .then(
         undefined,
-        err => console.log(`doProcess: ${errmsg}: ${err.message}`),
+        err => console.log(`doProcess: ${errmsg}:`, err),
       );
     return waitUntilQuiescent();
   }

--- a/packages/SwingSet/src/vats/comms/clist-xgress.js
+++ b/packages/SwingSet/src/vats/comms/clist-xgress.js
@@ -11,7 +11,7 @@ export function makeIngressEgress(state, provideLocalForRemote) {
     // allocating a new one. This is used to bootstrap initial connectivity
     // between machines.
     const remote = getRemote(state, remoteID);
-    Nat(remoteRefID);
+    Nat(BigInt(remoteRefID));
     insistVatType('object', vatoid);
     const { allocatedByVat } = parseVatSlot(vatoid);
     assert(!allocatedByVat, `vatoid should be kernel-allocated`);
@@ -24,7 +24,7 @@ export function makeIngressEgress(state, provideLocalForRemote) {
     remote.fromRemote.set(inboundRRef, vatoid);
     remote.toRemote.set(vatoid, outboundRRef);
     if (remote.nextObjectIndex <= remoteRefID) {
-      remote.nextObjectIndex = remoteRefID + 1;
+      remote.nextObjectIndex = remoteRefID + BigInt(1);
     }
   }
 

--- a/packages/SwingSet/src/vats/comms/controller.js
+++ b/packages/SwingSet/src/vats/comms/controller.js
@@ -74,7 +74,7 @@ export function deliverToController(
       details`unknown remote name ${remoteName}`,
     );
     const remoteID = state.names.get(remoteName);
-    const remoteRefID = Nat(args[1]);
+    const remoteRefID = Nat(BigInt(args[1]));
     if (args[2]['@qclass'] !== 'slot' || args[2].index !== 0) {
       throw new Error(`unexpected args for addEgress(): ${controllerArgs}`);
     }
@@ -93,7 +93,7 @@ export function deliverToController(
       details`unknown remote name ${remoteName}`,
     );
     const remoteID = state.names.get(remoteName);
-    const remoteRefID = Nat(args[1]);
+    const remoteRefID = Nat(BigInt(args[1]));
     const localRef = addIngress(remoteID, remoteRefID);
     syscall.fulfillToPresence(result, localRef);
   }

--- a/packages/SwingSet/src/vats/comms/parseRemoteSlot.js
+++ b/packages/SwingSet/src/vats/comms/parseRemoteSlot.js
@@ -32,16 +32,16 @@ export function parseRemoteSlot(s) {
     throw new Error(`invalid remoteSlot ${s}`);
   }
 
-  const id = Nat(Number(indexSuffix));
+  const id = Nat(BigInt(indexSuffix));
   return { type, allocatedByRecipient, id };
 }
 
 export function makeRemoteSlot(type, allocatedByRecipient, id) {
   let indexSuffix;
   if (allocatedByRecipient) {
-    indexSuffix = `+${Nat(id)}`;
+    indexSuffix = `+${Nat(BigInt(id))}`;
   } else {
-    indexSuffix = `-${Nat(id)}`;
+    indexSuffix = `-${Nat(BigInt(id))}`;
   }
 
   if (type === 'object') {

--- a/packages/SwingSet/src/vats/comms/remote.js
+++ b/packages/SwingSet/src/vats/comms/remote.js
@@ -3,7 +3,7 @@ import { assert, details } from '@agoric/assert';
 import { makeVatSlot, insistVatType } from '../../parseVatSlots';
 
 function makeRemoteID(index) {
-  return `remote${Nat(index)}`;
+  return `remote${Nat(BigInt(index))}`;
 }
 
 export function insistRemoteID(remoteID) {

--- a/packages/SwingSet/src/vats/vat-timerWrapper.js
+++ b/packages/SwingSet/src/vats/vat-timerWrapper.js
@@ -25,9 +25,9 @@ export function buildRootObject(vatPowers) {
         return this.makeRepeater(delaySecs, interval);
       },
       makeRepeater(delaySecs, interval) {
-        Nat(delaySecs);
+        Nat(BigInt(delaySecs));
         assert(
-          Nat(interval) > 0,
+          Nat(BigInt(interval)) > 0,
           details`makeRepeater's second parameter must be a positive integer: ${interval}`,
         );
 
@@ -46,9 +46,9 @@ export function buildRootObject(vatPowers) {
         return vatRepeater;
       },
       makeNotifier(delaySecs, interval) {
-        Nat(delaySecs);
+        Nat(BigInt(delaySecs));
         assert(
-          Nat(interval) > 0,
+          Nat(BigInt(interval)) > 0,
           details`makeNotifier's second parameter must be a positive integer: ${interval}`,
         );
 

--- a/packages/SwingSet/test/test-devices.js
+++ b/packages/SwingSet/test/test-devices.js
@@ -263,10 +263,10 @@ test.serial('mailbox outbound', async t => {
   await c.run();
   t.deepEqual(s.exportToData(), {
     peer1: {
-      inboundAck: 13,
+      inboundAck: BigInt(13),
       outbox: [
-        [2, 'data2'],
-        [3, 'data3'],
+        [BigInt(2), 'data2'],
+        [BigInt(3), 'data3'],
       ],
     },
     peer2: {
@@ -275,7 +275,7 @@ test.serial('mailbox outbound', async t => {
     },
     peer3: {
       inboundAck: 0,
-      outbox: [[5, 'data5']],
+      outbox: [[BigInt(5), 'data5']],
     },
   });
 

--- a/packages/SwingSet/test/test-vattp.js
+++ b/packages/SwingSet/test/test-vattp.js
@@ -47,7 +47,9 @@ test('vattp', async t => {
     'ch.receive msg1',
     'ch.receive msg2',
   ]);
-  t.deepEqual(s.exportToData(), { remote1: { outbox: [], inboundAck: 2 } });
+  t.deepEqual(s.exportToData(), {
+    remote1: { outbox: [], inboundAck: BigInt(2) },
+  });
 
   t.is(
     mb.deliverInbound(
@@ -61,7 +63,9 @@ test('vattp', async t => {
     false,
   );
   await c.run();
-  t.deepEqual(s.exportToData(), { remote1: { outbox: [], inboundAck: 2 } });
+  t.deepEqual(s.exportToData(), {
+    remote1: { outbox: [], inboundAck: BigInt(2) },
+  });
 });
 
 test('vattp 2', async t => {
@@ -89,7 +93,7 @@ test('vattp 2', async t => {
   const c = await makeSwingsetController(hostStorage, deviceEndowments);
   await c.run();
   t.deepEqual(s.exportToData(), {
-    remote1: { outbox: [[1, 'out1']], inboundAck: 0 },
+    remote1: { outbox: [[BigInt(1), 'out1']], inboundAck: 0 },
   });
 
   t.is(mb.deliverInbound('remote1', [], 1), true);
@@ -100,7 +104,9 @@ test('vattp 2', async t => {
   t.is(mb.deliverInbound('remote1', [[1, 'msg1']], 1), true);
   await c.run();
   t.deepEqual(c.dump().log, ['ch.receive msg1']);
-  t.deepEqual(s.exportToData(), { remote1: { outbox: [], inboundAck: 1 } });
+  t.deepEqual(s.exportToData(), {
+    remote1: { outbox: [], inboundAck: BigInt(1) },
+  });
 
   t.is(mb.deliverInbound('remote1', [[1, 'msg1']], 1), false);
 
@@ -117,5 +123,7 @@ test('vattp 2', async t => {
   );
   await c.run();
   t.deepEqual(c.dump().log, ['ch.receive msg1', 'ch.receive msg2']);
-  t.deepEqual(s.exportToData(), { remote1: { outbox: [], inboundAck: 2 } });
+  t.deepEqual(s.exportToData(), {
+    remote1: { outbox: [], inboundAck: BigInt(2) },
+  });
 });

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@agoric/eventual-send": "^0.13.0",
     "@agoric/marshal": "^0.3.0",
-    "@agoric/nat": "^2.0.1",
+    "@agoric/nat": "^3.0.1",
     "@agoric/promise-kit": "^0.2.0",
     "esm": "^3.2.5"
   },

--- a/packages/cosmic-swingset/lib/ag-solo/vats/repl.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/repl.js
@@ -189,7 +189,7 @@ export function getReplHandler(replObjects, send, vatPowers) {
     doEval(obj, _meta) {
       const { number: histnum, body } = obj;
       console.debug(`doEval`, histnum, body);
-      Nat(histnum);
+      Nat(BigInt(histnum));
       if (histnum <= highestHistory) {
         throw new Error(
           `histnum ${histnum} is not larger than highestHistory ${highestHistory}`,

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -35,7 +35,7 @@
     "@agoric/install-metering-and-ses": "^0.2.0",
     "@agoric/install-ses": "^0.5.0",
     "@agoric/marshal": "^0.3.0",
-    "@agoric/nat": "2.0.1",
+    "@agoric/nat": "^3.0.1",
     "@agoric/notifier": "^0.3.0",
     "@agoric/promise-kit": "^0.2.0",
     "@agoric/registrar": "^0.2.0",

--- a/packages/deploy-script-support/package.json
+++ b/packages/deploy-script-support/package.json
@@ -48,7 +48,7 @@
     "@agoric/eventual-send": "^0.13.0",
     "@agoric/import-manager": "^0.2.0",
     "@agoric/marshal": "^0.3.0",
-    "@agoric/nat": "^2.0.1",
+    "@agoric/nat": "^3.0.1",
     "@agoric/notifier": "^0.3.0",
     "@agoric/promise-kit": "^0.2.0",
     "@agoric/same-structure": "^0.1.0",

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@agoric/assert": "^0.2.0",
     "@agoric/eventual-send": "^0.13.0",
-    "@agoric/nat": "^2.0.1",
+    "@agoric/nat": "^3.0.1",
     "@agoric/promise-kit": "^0.2.0"
   },
   "devDependencies": {

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -422,10 +422,12 @@ function makeReviverIbidTable(cyclePolicy) {
 
   return harden({
     get(allegedIndex) {
-      const index = Nat(allegedIndex);
+      const index = Nat(BigInt(allegedIndex));
       if (index >= ibids.length) {
         throw new RangeError(`ibid out of range: ${index}`);
       }
+      // @ts-ignore For some reason, TypeScript thinks BigInts are not an
+      // index type. They are. TypeScript is wrong.
       const result = ibids[index];
       if (unfinishedIbids.has(result)) {
         switch (cyclePolicy) {
@@ -750,7 +752,9 @@ export function makeMarshal(
           }
 
           case 'slot': {
-            const slot = slots[Nat(rawTree.index)];
+            // @ts-ignore For some reason, TypeScript thinks BigInts are not an
+            // index type. They are. TypeScript is wrong.
+            const slot = slots[Nat(BigInt(rawTree.index))];
             return ibidTable.register(convertSlotToVal(slot, rawTree.iface));
           }
 

--- a/packages/spawner/package.json
+++ b/packages/spawner/package.json
@@ -36,7 +36,7 @@
     "@agoric/ertp": "^0.9.0",
     "@agoric/eventual-send": "^0.13.0",
     "@agoric/import-bundle": "^0.2.0",
-    "@agoric/nat": "^2.0.1",
+    "@agoric/nat": "^3.0.1",
     "@agoric/promise-kit": "^0.2.0",
     "@agoric/same-structure": "^0.1.0",
     "@agoric/store": "^0.4.0",

--- a/packages/transform-metering/package.json
+++ b/packages/transform-metering/package.json
@@ -23,7 +23,7 @@
     "rollup-plugin-node-resolve": "^5.2.0"
   },
   "dependencies": {
-    "@agoric/nat": "^2.0.1",
+    "@agoric/nat": "^3.0.1",
     "@agoric/tame-metering": "^1.3.0",
     "re2": "^1.10.5"
   },

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -46,7 +46,7 @@
     "@agoric/eventual-send": "^0.13.0",
     "@agoric/import-bundle": "^0.2.0",
     "@agoric/marshal": "^0.3.0",
-    "@agoric/nat": "^2.0.1",
+    "@agoric/nat": "^3.0.1",
     "@agoric/notifier": "^0.3.0",
     "@agoric/promise-kit": "^0.2.0",
     "@agoric/same-structure": "^0.1.0",

--- a/packages/zoe/src/contractSupport/bondingCurves.js
+++ b/packages/zoe/src/contractSupport/bondingCurves.js
@@ -54,7 +54,7 @@ export const getInputPrice = (
   const inputWithFee = BigInt(inputValue) * oneMinusFeeScaled;
   const numerator = inputWithFee * BigInt(outputReserve);
   const denominator = BigInt(inputReserve) * BIG_10000 + inputWithFee;
-  return Nat(Number(numerator / denominator));
+  return Nat(BigInt(numerator / denominator));
 };
 
 /**
@@ -99,7 +99,7 @@ export const getOutputPrice = (
   const numerator = BigInt(outputValue) * BigInt(inputReserve) * BIG_10000;
   const denominator =
     (BigInt(outputReserve) - BigInt(outputValue)) * oneMinusFeeScaled;
-  return Nat(Number(numerator / denominator + BIG_ONE));
+  return Nat(BigInt(numerator / denominator + BIG_ONE));
 };
 
 function assertDefined(label, value) {
@@ -120,7 +120,10 @@ export const calcLiqValueToMint = (
   assertDefined('inputValue', inputValue);
   assertDefined('inputReserve', inputReserve);
 
-  if (liqTokenSupply === 0) {
+  // `==` is the correct way to compare numbers and bitints for magnitude
+  // equality.
+  // eslint-disable-next-line eqeqeq
+  if (liqTokenSupply == 0) {
     return inputValue;
   }
   return floorDivide(multiply(inputValue, liqTokenSupply), inputReserve);
@@ -147,7 +150,10 @@ export const calcSecondaryRequired = (
   assertDefined('centralIn', centralIn);
   assertDefined('centralPool', centralPool);
   assertDefined('secondaryReserve', secondaryPool);
-  if (centralPool === 0 || secondaryPool === 0) {
+  // `==` is the correct way to compare numbers and bitints for magnitude
+  // equality.
+  // eslint-disable-next-line eqeqeq
+  if (centralPool == 0 || secondaryPool == 0) {
     return secondaryIn;
   }
 

--- a/packages/zoe/src/contractSupport/percentMath.js
+++ b/packages/zoe/src/contractSupport/percentMath.js
@@ -17,9 +17,13 @@ const { multiply, floorDivide } = natSafeMath;
 // with the same units. If you divide gallons by miles, the result is not a
 // percentage.
 /** @type {MakePercent} */
-function makePercent(value, base = 100) {
+function makePercent(value, base = BigInt(100)) {
+  // TODO remove these once all callers are converted?
+  value = BigInt(value);
+  base = BigInt(base);
+
   assert(
-    value >= 0 && value <= base,
+    value >= BigInt(0) && value <= base,
     `percentages (${value}) must be between 0 and base (${base})`,
   );
 
@@ -39,7 +43,10 @@ harden(makePercent);
 // calculatePercent is an alternative method of producing a percent object by
 // dividing two amounts of the same brand.
 /** @type {CalculatePercent} */
-function calculatePercent(numerator, denominator, base = 100) {
+function calculatePercent(numerator, denominator, base = BigInt(100)) {
+  // TODO remove once all callers are converted?
+  base = BigInt(base);
+
   assert(
     numerator.brand === denominator.brand,
     `Dividing amounts of different brands doesn't produce a percent.`,
@@ -50,7 +57,7 @@ function calculatePercent(numerator, denominator, base = 100) {
 }
 harden(calculatePercent);
 
-const ALL = harden(makePercent(100));
-const NONE = harden(makePercent(0));
+const ALL = harden(makePercent(BigInt(100)));
+const NONE = harden(makePercent(BigInt(0)));
 
 export { makePercent, calculatePercent, ALL, NONE };

--- a/packages/zoe/src/contractSupport/safeMath.js
+++ b/packages/zoe/src/contractSupport/safeMath.js
@@ -1,14 +1,30 @@
 import Nat from '@agoric/nat';
 
+const coerce = v => Nat(BigInt(v));
+
 /**
  * These operations should be used for calculations with the
  * values of basic fungible tokens.
+ *
+ * The ERTP natMathHelpers are designed to be called only from ERTP's
+ * amountMath.js, so they can assume the inputs are already valid and they only
+ * need to validate the outputs when necessary. By contrast, safeMath is
+ * designed to be used directly, and so it needs to validate the inputs,
+ * as well as the outputs when necessary.
+ *
+ * TODO for now we coerce inputs rather than just validate them.
+ * Once all callers are converted, should we remove this?
  */
 export const natSafeMath = harden({
-  add: (x, y) => Nat(x + y),
-  subtract: (x, y) => Nat(x - y),
-  multiply: (x, y) => Nat(x * y),
-  floorDivide: (x, y) => Nat(Math.floor(x / y)),
-  ceilDivide: (x, y) => Nat(Math.ceil(x / y)),
+  // BigInts don't observably overflow
+  add: (x, y) => coerce(x) + coerce(y),
+  subtract: (x, y) => Nat(coerce(x) - coerce(y)),
+  multiply: (x, y) => coerce(x) * coerce(y),
+  floorDivide: (x, y) => coerce(x) / coerce(y),
+  ceilDivide: (x, y) => {
+    y = coerce(y);
+    return Nat(coerce(x) + y - BigInt(1)) / y;
+  },
+  // Numbers and BigInts already compare magnitudes correctly.
   isGTE: (x, y) => x >= y,
 });

--- a/packages/zoe/src/contracts/autoswap.js
+++ b/packages/zoe/src/contracts/autoswap.js
@@ -64,7 +64,7 @@ const start = async zcf => {
     issuer: liquidityIssuer,
     amountMath: liquidityMath,
   } = liquidityMint.getIssuerRecord();
-  let liqTokenSupply = 0;
+  let liqTokenSupply = BigInt(0);
 
   // In order to get all the brands, we must call zcf.getTerms() after
   // we create the liquidityIssuer

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -80,7 +80,7 @@ const start = zcf => {
 
     // All items are the same price.
     const totalCost = moneyMath.make(
-      pricePerItem.value * wantedItems.value.length,
+      pricePerItem.value * BigInt(wantedItems.value.length),
     );
 
     // Check that the money provided to pay for the items is greater than the totalCost.

--- a/packages/zoe/test/unitTests/contractSupport/test-bondingCurves.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-bondingCurves.js
@@ -50,9 +50,9 @@ const getOutputPricethrows = (
 // diverged from the calculation in the Uniswap paper.
 test('getInputPrice no reserves', t => {
   const input = {
-    inputReserve: 0,
-    outputReserve: 0,
-    inputValue: 1,
+    inputReserve: BigInt(0),
+    outputReserve: BigInt(0),
+    inputValue: BigInt(1),
   };
   const message = 'inputReserve (a number) must be positive';
   getInputPricethrows(t, input, message);
@@ -70,11 +70,11 @@ test('getInputPrice ok 2', t => {
 
 test('getInputPrice ok 3', t => {
   const input = {
-    inputReserve: 8160,
-    outputReserve: 7743,
-    inputValue: 6635,
+    inputReserve: BigInt(8160),
+    outputReserve: BigInt(7743),
+    inputValue: BigInt(6635),
   };
-  const expectedOutput = 3466;
+  const expectedOutput = BigInt(3466);
   testGetPrice(t, input, expectedOutput);
 });
 
@@ -90,29 +90,29 @@ test('getInputPrice ok 4', t => {
 
 test('getInputPrice ok 5', t => {
   const input = {
-    inputReserve: 100,
-    outputReserve: 50,
-    inputValue: 17,
+    inputReserve: BigInt(100),
+    outputReserve: BigInt(50),
+    inputValue: BigInt(17),
   };
-  const expectedOutput = 7;
+  const expectedOutput = BigInt(7);
   testGetPrice(t, input, expectedOutput);
 });
 
 test('getInputPrice ok 6', t => {
   const input = {
-    outputReserve: 117,
-    inputReserve: 43,
-    inputValue: 7,
+    outputReserve: BigInt(117),
+    inputReserve: BigInt(43),
+    inputValue: BigInt(7),
   };
-  const expectedOutput = 16;
+  const expectedOutput = BigInt(16);
   testGetPrice(t, input, expectedOutput);
 });
 
 test('getInputPrice negative', t => {
   const input = {
-    outputReserve: 117,
-    inputReserve: 43,
-    inputValue: -7,
+    outputReserve: BigInt(117),
+    inputReserve: BigInt(43),
+    inputValue: BigInt(-7),
   };
   const message = 'inputValue (a number) must be positive';
   getInputPricethrows(t, input, message);
@@ -120,9 +120,9 @@ test('getInputPrice negative', t => {
 
 test('getInputPrice bad reserve 1', t => {
   const input = {
-    outputReserve: 0,
-    inputReserve: 43,
-    inputValue: 347,
+    outputReserve: BigInt(0),
+    inputReserve: BigInt(43),
+    inputValue: BigInt(347),
   };
   const message = 'outputReserve (a number) must be positive';
   getInputPricethrows(t, input, message);
@@ -130,9 +130,9 @@ test('getInputPrice bad reserve 1', t => {
 
 test('getInputPrice bad reserve 2', t => {
   const input = {
-    outputReserve: 50,
-    inputReserve: 0,
-    inputValue: 828,
+    outputReserve: BigInt(50),
+    inputReserve: BigInt(0),
+    inputValue: BigInt(828),
   };
   const message = 'inputReserve (a number) must be positive';
   getInputPricethrows(t, input, message);
@@ -140,9 +140,9 @@ test('getInputPrice bad reserve 2', t => {
 
 test('getInputPrice zero input', t => {
   const input = {
-    outputReserve: 50,
-    inputReserve: 320,
-    inputValue: 0,
+    outputReserve: BigInt(50),
+    inputReserve: BigInt(320),
+    inputValue: BigInt(0),
   };
   const message = 'inputValue (a number) must be positive';
   getInputPricethrows(t, input, message);
@@ -150,44 +150,48 @@ test('getInputPrice zero input', t => {
 
 test('getInputPrice big product', t => {
   const input = {
-    outputReserve: 100000000,
-    inputReserve: 100000000,
-    inputValue: 1000,
+    outputReserve: BigInt(100000000),
+    inputReserve: BigInt(100000000),
+    inputValue: BigInt(1000),
   };
-  const expectedOutput = 996;
+  const expectedOutput = BigInt(996);
   testGetPrice(t, input, expectedOutput);
 });
 
 test('calculate value to mint - positive supply 1', t => {
-  const res = calcLiqValueToMint(20, 30, 5);
-  t.is(res, (20 * 30) / 5, 'When supply is present, floor(x*y/z)');
+  const res = calcLiqValueToMint(BigInt(20), BigInt(30), BigInt(5));
+  t.is(
+    res,
+    (BigInt(20) * BigInt(30)) / BigInt(5),
+    'When supply is present, floor(x*y/z)',
+  );
 });
 
 test('calculate value to mint - positive supply 2', t => {
-  const res = calcLiqValueToMint(5, 8, 7);
-  t.is(res, 5, 'When supply is present, floor(x*y/z)');
+  const res = calcLiqValueToMint(BigInt(5), BigInt(8), BigInt(7));
+  t.is(res, BigInt(5), 'When supply is present, floor(x*y/z)');
 });
 
 test('calculate value to mint - no supply', t => {
-  const res = calcLiqValueToMint(0, 30, 5);
-  t.is(res, 30, 'When the supply is empty, return inputValue');
+  const res = calcLiqValueToMint(BigInt(0), BigInt(30), BigInt(5));
+  t.is(res, BigInt(30), 'When the supply is empty, return inputValue');
 });
 
 test('getOutputPrice ok', t => {
   const input = {
-    outputReserve: 117,
-    inputReserve: 43,
-    outputValue: 37,
+    outputReserve: BigInt(117),
+    inputReserve: BigInt(43),
+    outputValue: BigInt(37),
   };
-  const expectedOutput = 20;
+  const expectedOutput = BigInt(20);
   testGetOutputPrice(t, input, expectedOutput);
 });
 
 test('getOutputPrice zero output reserve', t => {
   const input = {
-    outputReserve: 0,
-    inputReserve: 43,
-    outputValue: 37,
+    outputReserve: BigInt(0),
+    inputReserve: BigInt(43),
+    outputValue: BigInt(37),
   };
   const message = 'outputReserve (a number) must be positive';
   getOutputPricethrows(t, input, message);
@@ -195,9 +199,9 @@ test('getOutputPrice zero output reserve', t => {
 
 test('getOutputPrice zero input reserve', t => {
   const input = {
-    outputReserve: 92,
-    inputReserve: 0,
-    outputValue: 37,
+    outputReserve: BigInt(92),
+    inputReserve: BigInt(0),
+    outputValue: BigInt(37),
   };
   const message = 'inputReserve (a number) must be positive';
   getOutputPricethrows(t, input, message);
@@ -205,9 +209,9 @@ test('getOutputPrice zero input reserve', t => {
 
 test('getOutputPrice too much output', t => {
   const input = {
-    outputReserve: 1024,
-    inputReserve: 1132,
-    outputValue: 20923,
+    outputReserve: BigInt(1024),
+    inputReserve: BigInt(1132),
+    outputValue: BigInt(20923),
   };
   const message =
     'outputReserve (a number) must be greater than outputValue (a number)';
@@ -216,9 +220,9 @@ test('getOutputPrice too much output', t => {
 
 test('getOutputPrice too much output 2', t => {
   const input = {
-    outputReserve: 345,
-    inputReserve: 1132,
-    outputValue: 345,
+    outputReserve: BigInt(345),
+    inputReserve: BigInt(1132),
+    outputValue: BigInt(345),
   };
   const message =
     'outputReserve (a number) must be greater than outputValue (a number)';
@@ -227,20 +231,20 @@ test('getOutputPrice too much output 2', t => {
 
 test('getOutputPrice big product', t => {
   const input = {
-    outputReserve: 100000000,
-    inputReserve: 100000000,
-    outputValue: 1000,
+    outputReserve: BigInt(100000000),
+    inputReserve: BigInt(100000000),
+    outputValue: BigInt(1000),
   };
-  const expectedOutput = 1004;
+  const expectedOutput = BigInt(1004);
   testGetOutputPrice(t, input, expectedOutput);
 });
 
 test('getOutputPrice minimum price', t => {
   const input = {
-    outputReserve: 10,
-    inputReserve: 1,
-    outputValue: 1,
+    outputReserve: BigInt(10),
+    inputReserve: BigInt(1),
+    outputValue: BigInt(1),
   };
-  const expectedOutput = 1;
+  const expectedOutput = BigInt(1);
   testGetOutputPrice(t, input, expectedOutput);
 });

--- a/packages/zoe/test/unitTests/contractSupport/test-percentMath.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-percentMath.js
@@ -12,8 +12,8 @@ import {
 } from '../../../src/contractSupport/percentMath';
 
 test('percentMath - basic', t => {
-  const halfDefault = makePercent(50);
-  const halfPrecise = makePercent(5000, 10000);
+  const halfDefault = makePercent(BigInt(50));
+  const halfPrecise = makePercent(BigInt(5000), BigInt(10000));
 
   const { amountMath } = makeIssuerKit('moe');
   const moe = amountMath.make;

--- a/packages/zoe/test/unitTests/contracts/test-callSpread.js
+++ b/packages/zoe/test/unitTests/contracts/test-callSpread.js
@@ -655,7 +655,7 @@ test('pricedCallSpread, mid-strike', async t => {
     issuerKeywordRecord,
     terms,
   );
-  const invitationPair = await E(creatorFacet).makeInvitationPair(75);
+  const invitationPair = await E(creatorFacet).makeInvitationPair(BigInt(75));
   const { longInvitation, shortInvitation } = invitationPair;
 
   const invitationIssuer = await E(zoe).getInvitationIssuer();

--- a/packages/zoe/test/unitTests/contracts/test-sellTickets.js
+++ b/packages/zoe/test/unitTests/contracts/test-sellTickets.js
@@ -450,7 +450,7 @@ test(`mint and sell opera tickets`, async t => {
       ]),
     );
 
-    const totalCost = moola(2 * terms.pricePerItem.value);
+    const totalCost = moola(BigInt(2) * terms.pricePerItem.value);
 
     const bobProposal = harden({
       give: { Money: totalCost },
@@ -472,11 +472,15 @@ test(`mint and sell opera tickets`, async t => {
     );
     t.is(bobTicketAmount.value.length, 2, 'Bob should have received 2 tickets');
     t.truthy(
-      bobTicketAmount.value.find(ticket => ticket.number === 2),
+      // Numeric magnitude comparison
+      // eslint-disable-next-line eqeqeq
+      bobTicketAmount.value.find(ticket => ticket.number == 2),
       'Bob should have received tickets #2',
     );
     t.truthy(
-      bobTicketAmount.value.find(ticket => ticket.number === 3),
+      // Numeric magnitude comparison
+      // eslint-disable-next-line eqeqeq
+      bobTicketAmount.value.find(ticket => ticket.number == 3),
       'Bob should have received tickets #3',
     );
   };
@@ -491,8 +495,8 @@ test(`mint and sell opera tickets`, async t => {
 
     t.is(
       currentPurseBalance.value,
-      3 * 22,
-      `The Opera should get ${3 * 22} moolas from ticket sales`,
+      BigInt(3) * BigInt(22),
+      `The Opera should get ${BigInt(3) * BigInt(22)} moolas from ticket sales`,
     );
   };
 

--- a/packages/zoe/test/zoeTestHelpers.js
+++ b/packages/zoe/test/zoeTestHelpers.js
@@ -2,6 +2,8 @@ import { E } from '@agoric/eventual-send';
 
 import '../exported';
 
+const { details: d } = assert;
+
 export const assertPayoutAmount = async (
   t,
   issuer,
@@ -33,7 +35,7 @@ export const assertOfferResult = (t, seat, expected, msg = expected) => {
     .getOfferResult()
     .then(
       result => t.is(result, expected, msg),
-      e => t.fail(`expecting offer result to be ${expected}, ${e}`),
+      e => t.fail(d`expecting offer result to be ${expected}, ${e}`),
     );
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,10 +24,10 @@
   resolved "https://registry.yarnpkg.com/@agoric/make-hardener/-/make-hardener-0.1.1.tgz#9b887da47aeec6637d9db4f0a92a4e740b8262bb"
   integrity sha512-3emNc+yWJoFK5JMLoEFPs6rCzkntWQKxpR4gt3jaZYLKoUG4LrTmID3XNe8y40B6SJ3k/wLPodKa0ToQGlhrwQ==
 
-"@agoric/nat@2.0.1", "@agoric/nat@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@agoric/nat/-/nat-2.0.1.tgz#28aba18367deba354bdd424bdf6daa48f5e7d37f"
-  integrity sha512-puvWkoaJovQib/YaSRSGJ8Kn9rogi/yyaVa3d5znSZb5WiYfUiEKW35BfexHhAdi0VfPz2anFHoRBoBSUIijNA==
+"@agoric/nat@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@agoric/nat/-/nat-3.0.1.tgz#19cfe575e707ae1024f123b49a9c745d88381cbf"
+  integrity sha512-/i5d77UZSAw+9h19nvid4/YrEYO7E8xx4ZPcOKLvjH96mfALSjYR9QU77MRZbbqKOF4PwdS2xLupzo/vg46eKA==
 
 "@agoric/transform-module@^0.4.1":
   version "0.4.1"


### PR DESCRIPTION
Fixes #2210 

Depend on a more recent `@agoric/nat` where nats are bignums rather than JavaScript numbers (aka floats). As start on following through on the consequences. Many tests pass. Many tests do not.

My first conclusion from this is that the `@agoric/nat` package should export several things. `Nat` itself should be a coercer rather than a validator, so every call site I changed to `Nat(BigInt(...))` can go back to `Nat(...)`. However, validators are safer than coercers because they validate the input as well as the output. So `@agoric/nat` should also export a validator. And also an `isNat` predicate that returns false on invalid input rather than throwing.

Thus, this PR is blocked on https://github.com/Agoric/nat/issues/137

Closes #325 