### PR TITLE
enable and test all manager types

### DIFF
--- a/packages/SwingSet/src/kernel/loadVat.js
+++ b/packages/SwingSet/src/kernel/loadVat.js
@@ -147,6 +147,7 @@ export function makeVatLoader(stuff) {
     const {
       metered = isDynamic,
       vatParameters = {},
+      managerType,
       enableSetup = false,
       enablePipelining = false,
       virtualObjectCacheSize,
@@ -193,6 +194,7 @@ export function makeVatLoader(stuff) {
 
       kernelSlog.addVat(vatID, isDynamic, description, name, vatSourceBundle);
       const managerOptions = {
+        managerType,
         bundle: vatSourceBundle,
         metered,
         enableSetup,

--- a/packages/SwingSet/src/kernel/vatManager/nodeWorker.js
+++ b/packages/SwingSet/src/kernel/vatManager/nodeWorker.js
@@ -33,7 +33,9 @@ export function makeNodeWorkerVatManagerFactory(tools) {
       // TODO: warn+ignore, rather than throw, because the kernel enables it
       // for all vats, because the Spawner still needs it. When the kernel
       // stops doing that, turn this into a regular assert
-      console.log(`node-worker does not support enableInternalMetering`);
+      console.log(
+        `node-worker does not support enableInternalMetering, ignoring`,
+      );
     }
     const vatKeeper = kernelKeeper.getVatKeeper(vatID);
     const transcriptManager = makeTranscriptManager(
@@ -135,9 +137,16 @@ export function makeNodeWorkerVatManagerFactory(tools) {
       return pr.promise;
     }
 
-    function replayTranscript() {
-      // TODO unimplemented
-      throw Error(`replayTranscript not yet implemented`);
+    async function replayTranscript() {
+      transcriptManager.startReplay();
+      for (const t of vatKeeper.getTranscript()) {
+        transcriptManager.checkReplayError();
+        transcriptManager.startReplayDelivery(t.syscalls);
+        // eslint-disable-next-line no-await-in-loop
+        await deliver(t.d);
+      }
+      transcriptManager.checkReplayError();
+      transcriptManager.finishReplay();
     }
 
     function shutdown() {

--- a/packages/SwingSet/test/workers/test-worker.js
+++ b/packages/SwingSet/test/workers/test-worker.js
@@ -1,14 +1,12 @@
 import '@agoric/install-ses';
 import test from 'ava';
-import { resolve } from 'path';
-import { existsSync } from 'fs';
-import { locateWorkerBin } from '@agoric/xs-vat-worker';
 import { loadBasedir, buildVatController } from '../../src/index';
 
-const xsWorkerBin = locateWorkerBin({ resolve });
-const maybeTestXS = existsSync(xsWorkerBin) ? test : test.skip;
+// The XS worker is disabled until the xsnap-based approach is ready for
+// testing. Unlike the old approach, I think we'll build xsnap
+// unconditionally, so we won't need the old 'maybeTestXS' conditional.
 
-maybeTestXS('xs vat manager', async t => {
+test.skip('xs vat manager', async t => {
   const config = await loadBasedir(__dirname);
   config.vats.target.creationOptions = { managerType: 'xs-worker' };
   const c = await buildVatController(config, []);


### PR DESCRIPTION
fixes #2213 

Our `test-worker.js` test was attempting to exercise our three secondary vat types: Node.js `Worker` (threads), a subprocess running Node.js, and a subprocess running XS. However a bug in `loadVat.js` meant that all three were actually using the default "local" type, so all that code wasn't getting exercised at all.

This fixes `loadVat.js` to allow them to be exercised properly. It also fixes a handful of problems that crept in while we weren't correctly testing them:

* `recreateStaticVat()` wasn't helping the caller correctly wait for the new vat to be ready for use
* `replayTranscript` was unimplemented for the secondary vat types

It also removes the subprocess+XS test, while that implementation is in the process of being replaced by a new `xsnap`-based approach.
