### PR TITLE
improve test-worker.js to exercise all worker types, and syscall.callNow

### DIFF
--- a/packages/SwingSet/test/workers/bootstrap.js
+++ b/packages/SwingSet/test/workers/bootstrap.js
@@ -40,22 +40,32 @@ export function buildRootObject() {
     return 'F good';
   }
 
-  function checkA([pB, pC, pF]) {
+  function checkThree(three) {
+    return three === 3 ? 'three good' : `not three, got ${three}`;
+  }
+
+  function checkA([pB, pC, pF, three]) {
     return Promise.all([
       pB.then(checkResB),
       pC.then(checkResC, checkErrC),
       pF.then(checkResF),
+      Promise.resolve(three).then(checkThree),
     ]);
   }
 
   return harden({
-    bootstrap(vats) {
-      const pA = E(vats.target).zero(callbackObj, precD.promise, precE.promise);
+    bootstrap(vats, devices) {
+      const pA = E(vats.target).zero(
+        callbackObj,
+        precD.promise,
+        precE.promise,
+        devices.add,
+      );
       const rp3 = E(vats.target).one();
       precD.resolve(callbackObj); // two
       precE.reject(Error('four')); // three
       const done = Promise.all([pA.then(checkA), rp3]);
-      return done; // expect: [['B good', 'C good', 'F good'], 'rp3 good']
+      return done; // expect: [['B good', 'C good', 'F good', 'three good'], 'rp3 good']
     },
   });
 }

--- a/packages/SwingSet/test/workers/bootstrap.js
+++ b/packages/SwingSet/test/workers/bootstrap.js
@@ -3,8 +3,8 @@ import { makePromiseKit } from '@agoric/promise-kit';
 
 export function buildRootObject() {
   const callbackObj = harden({
-    callback(arg1, arg2) {
-      console.log(`callback`, arg1, arg2);
+    callback(_arg1, _arg2) {
+      // console.log(`callback`, arg1, arg2);
       return ['data', callbackObj]; // four, resolves pF
     },
   });
@@ -12,17 +12,50 @@ export function buildRootObject() {
   const precD = makePromiseKit();
   const precE = makePromiseKit();
 
+  function checkResB(resB) {
+    if (resB === callbackObj) {
+      return 'B good';
+    }
+    return `B bad: ${resB}`;
+  }
+
+  function checkResC(resC) {
+    return `C bad: not error, got ${resC}`;
+  }
+
+  function checkErrC(errC) {
+    if (errC.message === 'oops') {
+      return 'C good';
+    }
+    return `C wrong error ${errC.message}`;
+  }
+
+  function checkResF([resF1, resF2]) {
+    if (resF1 !== 'data') {
+      return 'F bad: data';
+    }
+    if (resF2 !== callbackObj) {
+      return `F bad: callbackObj was ${callbackObj}`;
+    }
+    return 'F good';
+  }
+
+  function checkA([pB, pC, pF]) {
+    return Promise.all([
+      pB.then(checkResB),
+      pC.then(checkResC, checkErrC),
+      pF.then(checkResF),
+    ]);
+  }
+
   return harden({
     bootstrap(vats) {
       const pA = E(vats.target).zero(callbackObj, precD.promise, precE.promise);
       const rp3 = E(vats.target).one();
       precD.resolve(callbackObj); // two
       precE.reject(Error('four')); // three
-      const done = Promise.all([
-        pA.then(([pB, pC, pF]) => Promise.all([pB, pC.catch(() => 0), pF])),
-        rp3,
-      ]);
-      return done;
+      const done = Promise.all([pA.then(checkA), rp3]);
+      return done; // expect: [['B good', 'C good', 'F good'], 'rp3 good']
     },
   });
 }

--- a/packages/SwingSet/test/workers/device-add.js
+++ b/packages/SwingSet/test/workers/device-add.js
@@ -1,0 +1,7 @@
+export function buildRootDeviceNode() {
+  return harden({
+    add(x, y) {
+      return x + y;
+    },
+  });
+}

--- a/packages/SwingSet/test/workers/test-worker.js
+++ b/packages/SwingSet/test/workers/test-worker.js
@@ -2,11 +2,19 @@ import '@agoric/install-ses';
 import test from 'ava';
 import { loadBasedir, buildVatController } from '../../src/index';
 
-const expected = [['B good', 'C good', 'F good'], 'rp3 good'];
+const expected = [['B good', 'C good', 'F good', 'three good'], 'rp3 good'];
 
 async function makeController(managerType) {
   const config = await loadBasedir(__dirname);
   config.vats.target.creationOptions = { managerType };
+  const canCallNow = ['local'].indexOf(managerType) !== -1;
+  // const canCallNow = ['local', 'xs-worker'].indexOf(managerType) !== -1;
+  config.vats.target.parameters = { canCallNow };
+  config.devices = {
+    add: {
+      sourceSpec: require.resolve('./device-add.js'),
+    },
+  };
   const c = await buildVatController(config, []);
   return c;
 }

--- a/packages/SwingSet/test/workers/test-worker.js
+++ b/packages/SwingSet/test/workers/test-worker.js
@@ -2,39 +2,55 @@ import '@agoric/install-ses';
 import test from 'ava';
 import { loadBasedir, buildVatController } from '../../src/index';
 
+const expected = [['B good', 'C good', 'F good'], 'rp3 good'];
+
+async function makeController(managerType) {
+  const config = await loadBasedir(__dirname);
+  config.vats.target.creationOptions = { managerType };
+  const c = await buildVatController(config, []);
+  return c;
+}
+
+test('local vat manager', async t => {
+  const c = await makeController('local');
+  t.teardown(c.shutdown);
+
+  await c.run();
+  t.is(c.kpStatus(c.bootstrapResult), 'fulfilled');
+  t.deepEqual(c.dump().log, ['testLog works']);
+  t.deepEqual(JSON.parse(c.kpResolution(c.bootstrapResult).body), expected);
+});
+
 // The XS worker is disabled until the xsnap-based approach is ready for
 // testing. Unlike the old approach, I think we'll build xsnap
 // unconditionally, so we won't need the old 'maybeTestXS' conditional.
 
 test.skip('xs vat manager', async t => {
-  const config = await loadBasedir(__dirname);
-  config.vats.target.creationOptions = { managerType: 'xs-worker' };
-  const c = await buildVatController(config, []);
+  const c = await makeController('xs-worker');
   t.teardown(c.shutdown);
 
   await c.run();
   t.is(c.kpStatus(c.bootstrapResult), 'fulfilled');
   t.deepEqual(c.dump().log, ['testLog works']);
+  t.deepEqual(JSON.parse(c.kpResolution(c.bootstrapResult).body), expected);
 });
 
 test('nodeWorker vat manager', async t => {
-  const config = await loadBasedir(__dirname);
-  config.vats.target.creationOptions = { managerType: 'nodeWorker' };
-  const c = await buildVatController(config, []);
+  const c = await makeController('nodeWorker');
   t.teardown(c.shutdown);
 
   await c.run();
   t.is(c.kpStatus(c.bootstrapResult), 'fulfilled');
   t.deepEqual(c.dump().log, ['testLog works']);
+  t.deepEqual(JSON.parse(c.kpResolution(c.bootstrapResult).body), expected);
 });
 
 test('node-subprocess vat manager', async t => {
-  const config = await loadBasedir(__dirname);
-  config.vats.target.creationOptions = { managerType: 'node-subprocess' };
-  const c = await buildVatController(config, []);
+  const c = await makeController('node-subprocess');
   t.teardown(c.shutdown);
 
   await c.run();
   t.is(c.kpStatus(c.bootstrapResult), 'fulfilled');
   t.deepEqual(c.dump().log, ['testLog works']);
+  t.deepEqual(JSON.parse(c.kpResolution(c.bootstrapResult).body), expected);
 });

--- a/packages/SwingSet/test/workers/vat-target.js
+++ b/packages/SwingSet/test/workers/vat-target.js
@@ -21,12 +21,13 @@ export function buildRootObject(vatPowers) {
   const precC = makePromiseKit();
   let callbackObj;
 
-  // zero: dispatch.deliver(target, method="one", result=pA, args=[callbackObj, pD, pE])
-  //       syscall.subscribe(pD)
-  //       syscall.subscribe(pE)
-  //       syscall.send(callbackObj, method="callback", result=rp2, args=[11, 12]);
-  //       syscall.subscribe(rp2)
-  //       syscall.fulfillToData(pA, [pB, pC]);
+  // crank 1:
+  //   dispatch.deliver(target, method="zero", result=pA, args=[callbackObj, pD, pE])
+  //   syscall.subscribe(pD)
+  //   syscall.subscribe(pE)
+  //   syscall.send(callbackObj, method="callback", result=rp2, args=[11, 12]);
+  //   syscall.subscribe(rp2)
+  //   syscall.fulfillToData(pA, [pB, pC]);
   function zero(obj, pD, pE) {
     callbackObj = obj;
     const pF = E(callbackObj).callback(11, 12); // syscall.send
@@ -35,20 +36,21 @@ export function buildRootObject(vatPowers) {
     return [precB.promise, precC.promise, pF]; // syscall.fulfillToData
   }
 
-  // one: dispatch.deliver(target, method="two", result=rp3, args=[])
-  //      syscall.fulfillToPresence(pB, callbackObj)
-  //      syscall.reject(pC, Error('oops'))
-  //      syscall.fulfillToData(rp3, 1)
+  // crank 2:
+  //   dispatch.deliver(target, method="one", result=rp3, args=[])
+  //   syscall.fulfillToPresence(pB, callbackObj)
+  //   syscall.reject(pC, Error('oops'))
+  //   syscall.fulfillToData(rp3, 'rp3 good')
   function one() {
     precB.resolve(callbackObj); // syscall.fulfillToPresence
     precC.reject(Error('oops')); // syscall.reject
-    return 1;
+    return 'rp3 good';
   }
 
-  // two: dispatch.notify(pD, false, callbackObj)
-  // three: dispatch.notify(pE, true, Error('four'))
+  // crank 3: dispatch.notify(pD, false, callbackObj)
+  // crank 4: dispatch.notify(pE, true, Error('four'))
 
-  // four: dispatch.notify(pF, false, ['data', callbackObj])
+  // crank 5: dispatch.notify(pF, false, ['data', callbackObj])
 
   const target = harden({
     zero,


### PR DESCRIPTION
This fixes and improves test-worker.js to:

* exercise all worker types, with the same code in each
* validate the results of the messages, not just the ability to run without crashing
* exercise `syscall.callNow` for the workers that can handle it (only `local` for now, but the upcoming `xsnap` -based XS worker should be capable too)
