### PR TITLE
test(xsnap): Test xsnap close and terminate

### DIFF
--- a/packages/xsnap/src/netstring.js
+++ b/packages/xsnap/src/netstring.js
@@ -17,7 +17,7 @@ const encoder = new TextEncoder();
  * @param {AsyncIterable<Uint8Array>} input
  * @param {string=} name
  * @param {number=} capacity
- * @returns {AsyncIterableIterator<Uint8Array>} input
+ * @returns {AsyncGenerator<Uint8Array>} input
  */
 export async function* reader(input, name = '<unknown>', capacity = 1024) {
   let length = 0;

--- a/packages/xsnap/src/node-stream.js
+++ b/packages/xsnap/src/node-stream.js
@@ -21,10 +21,11 @@ const continues = { value: undefined };
  * Back pressure emerges from awaiting on the promise
  * returned by `next` before calling `next` again.
  *
- * @param {NodeJS.WritableStream} output
+ * @param {NodeJS.WritableStream} output the destination Node.js writer
+ * @param {string} [name] a debug name for stream errors
  * @returns {Stream<void, Uint8Array, void>}
  */
-export function writer(output) {
+export function writer(output, name = '<unnamed stream>') {
   /**
    * @type {Deferred<IteratorResult<void>>}
    */
@@ -32,8 +33,7 @@ export function writer(output) {
   drained.resolve(continues);
 
   output.on('error', err => {
-    console.log('err', err);
-    drained.reject(err);
+    drained.reject(new Error(`Cannot write ${name}: ${err.message}`));
   });
 
   output.on('drain', () => {


### PR DESCRIPTION
This change adds tests to verify the behavior of graceful shutdown and graceless termination of an xsnap worker. Close signals to the xsnap worker that it will receive no further commands by closing the parentToChild file descriptor. Terminate sends a kill signal, and does not wait for the pending sequence of commands to flush (the “baton”).

Also added are some more debugging conveniences, like the threading of the Node.js writer stream and improved error messages. This also cleans up some of the debug vs non-debug switching.