### PR TITLE
feat(xsnap): Thread a metering API

### DIFF
--- a/packages/xsnap/src/netstring.js
+++ b/packages/xsnap/src/netstring.js
@@ -17,7 +17,7 @@ const encoder = new TextEncoder();
  * @param {AsyncIterable<Uint8Array>} input
  * @param {string=} name
  * @param {number=} capacity
- * @returns {AsyncIterableIterator<Uint8Array>} input
+ * @returns {AsyncGenerator<Uint8Array>} input
  */
 export async function* reader(input, name = '<unknown>', capacity = 1024) {
   let length = 0;

--- a/packages/xsnap/src/node-stream.js
+++ b/packages/xsnap/src/node-stream.js
@@ -21,10 +21,11 @@ const continues = { value: undefined };
  * Back pressure emerges from awaiting on the promise
  * returned by `next` before calling `next` again.
  *
- * @param {NodeJS.WritableStream} output
+ * @param {NodeJS.WritableStream} output the destination Node.js writer
+ * @param {string} [name] a debug name for stream errors
  * @returns {Stream<void, Uint8Array, void>}
  */
-export function writer(output) {
+export function writer(output, name = '<unnamed stream>') {
   /**
    * @type {Deferred<IteratorResult<void>>}
    */
@@ -32,8 +33,7 @@ export function writer(output) {
   drained.resolve(continues);
 
   output.on('error', err => {
-    console.log('err', err);
-    drained.reject(err);
+    drained.reject(new Error(`Cannot write ${name}: ${err.message}`));
   });
 
   output.on('drain', () => {

--- a/packages/xsnap/src/xsrepl.js
+++ b/packages/xsnap/src/xsrepl.js
@@ -70,6 +70,15 @@ async function main() {
     } else if (answer === 'save') {
       const file = await ask('file> ');
       await vat.snapshot(file);
+    } else if (answer === 'meter') {
+      const steps = Number(await ask('steps> '));
+      if (Number.isNaN(steps)) {
+        console.error('Meter steps must be a number');
+      } else if (steps === 0) {
+        await vat.resetMeter();
+      } else {
+        await vat.setMeter(steps);
+      }
     } else {
       await vat.issueStringCommand(answer);
     }

--- a/packages/xsnap/test/test-xsnap.js
+++ b/packages/xsnap/test/test-xsnap.js
@@ -232,3 +232,19 @@ test('normal close of pathological script', async t => {
   await vat.terminate();
   await hang;
 });
+
+test('the meter runneth out', async t => {
+  const vat = xsnap({ ...xsnapOptions });
+  await vat.setMeter(100);
+  const hang = vat.evaluate(`for (;;) {}`).then(
+    () => t.fail('command should not complete'),
+    err => {
+      t.is(err.message, 'Meter limit exceeded by xsnap test worker')
+    },
+  );
+  await Promise.race([
+    hang,
+    delay(100).then(() => t.fail('test timed out'))
+  ]);
+  await vat.terminate();
+});


### PR DESCRIPTION
This change introduces the wiring to meter evaluation and commands in C, JS API, and the JS REPL. The only catch so far is that it doesn’t work. Failing test case included. Can be induced in REPL.