### PR TITLE
chore: pass invitation as property in `addOffer`

### DIFF
--- a/packages/dapp-svelte-wallet/api/src/findOrMakeInvitation.js
+++ b/packages/dapp-svelte-wallet/api/src/findOrMakeInvitation.js
@@ -105,11 +105,12 @@ export const findOrMakeInvitation = async (
   invitationMath,
   offer,
 ) => {
-  const findInvitation = makeFindInvitation(invitationPurse, invitationMath);
-
   if (offer.invitation) {
+    // The invitation is directly specified.
     return offer.invitation;
   }
+
+  const findInvitation = makeFindInvitation(invitationPurse, invitationMath);
 
   // Deprecated
   if (offer.inviteHandleBoardId) {

--- a/packages/dapp-svelte-wallet/api/src/findOrMakeInvitation.js
+++ b/packages/dapp-svelte-wallet/api/src/findOrMakeInvitation.js
@@ -107,6 +107,10 @@ export const findOrMakeInvitation = async (
 ) => {
   const findInvitation = makeFindInvitation(invitationPurse, invitationMath);
 
+  if (offer.invitation) {
+    return offer.invitation;
+  }
+
   // Deprecated
   if (offer.inviteHandleBoardId) {
     const queryParams = {


### PR DESCRIPTION
This PR enables dapps passing an invitation as a property in `addOffer`, removing the need to use the `depositFacetId` to deposit the invitation. This can only be used with the CapTP connection, as the invitation is a presence. 