### PR TITLE
refactor: percents support values > 1, enforce consistent brand

### DIFF
--- a/packages/zoe/src/contractSupport/percentMath.js
+++ b/packages/zoe/src/contractSupport/percentMath.js
@@ -6,7 +6,7 @@ import { natSafeMath } from './safeMath';
 const { multiply, floorDivide } = natSafeMath;
 
 // make a percentMath object, which represents a unitless fraction. It can be
-// multiplied by ERTP amounts that match amountMath to take a percentage.
+// multiplied by ERTP amounts that have the same brand to take a percentage.
 // complement() produces a new percent object that adds to the original to
 // produce 100%. complement() throws if the receiver is greater than 100%.
 //

--- a/packages/zoe/src/contracts/callSpread/calculateShares.js
+++ b/packages/zoe/src/contracts/callSpread/calculateShares.js
@@ -2,7 +2,11 @@
 import '../../../exported';
 import './types';
 
-import { ALL, NONE, calculatePercent } from '../../contractSupport/percentMath';
+import {
+  makeAll,
+  makeNone,
+  calculatePercent,
+} from '../../contractSupport/percentMath';
 
 /**
  * Calculate the portion (as a percentage) of the collateral that should be
@@ -10,16 +14,33 @@ import { ALL, NONE, calculatePercent } from '../../contractSupport/percentMath';
  * of the underlying asset at closing that determines the payouts to the parties
  *
  * @type {CalculateShares} */
-function calculateShares(strikeMath, price, strikePrice1, strikePrice2) {
+function calculateShares(
+  strikeMath,
+  collateralMath,
+  price,
+  strikePrice1,
+  strikePrice2,
+) {
   if (strikeMath.isGTE(strikePrice1, price)) {
-    return { longShare: NONE, shortShare: ALL };
+    return {
+      longShare: makeNone(collateralMath),
+      shortShare: makeAll(collateralMath),
+    };
   } else if (strikeMath.isGTE(price, strikePrice2)) {
-    return { longShare: ALL, shortShare: NONE };
+    return {
+      longShare: makeAll(collateralMath),
+      shortShare: makeNone(collateralMath),
+    };
   }
 
   const denominator = strikeMath.subtract(strikePrice2, strikePrice1);
   const numerator = strikeMath.subtract(price, strikePrice1);
-  const longShare = calculatePercent(numerator, denominator);
+  const longShare = calculatePercent(
+    numerator,
+    denominator,
+    collateralMath,
+    10000,
+  );
   return { longShare, shortShare: longShare.complement() };
 }
 

--- a/packages/zoe/src/contracts/callSpread/payoffHandler.js
+++ b/packages/zoe/src/contracts/callSpread/payoffHandler.js
@@ -36,7 +36,7 @@ function makePayoffHandler(zcf, seatPromiseKits, collateralSeat) {
   function reallocateToSeat(seatPromise, sharePercent) {
     seatPromise.then(seat => {
       const totalCollateral = terms.settlementAmount;
-      const seatPortion = sharePercent.scale(collateralMath, totalCollateral);
+      const seatPortion = sharePercent.scale(totalCollateral);
       trade(
         zcf,
         { seat, gains: { Collateral: seatPortion } },
@@ -56,6 +56,7 @@ function makePayoffHandler(zcf, seatPromiseKits, collateralSeat) {
     const strike2 = terms.strikePrice2;
     const { longShare, shortShare } = calculateShares(
       strikeMath,
+      collateralMath,
       quoteAmount,
       strike1,
       strike2,

--- a/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
@@ -50,7 +50,6 @@ import { makePercent } from '../../contractSupport/percentMath';
  *
  * Future enhancements:
  * + issue multiple option pairs with the same expiration from a single instance
- * + increase the precision of the calculations. (use Percents with base=10000)
  */
 
 /** @type {ContractStartFn} */
@@ -98,7 +97,7 @@ const start = zcf => {
     await depositToSeat(zcf, collateralSeat, spreadAmount, payment);
     // AWAIT ////
 
-    const required = share.scale(collateralMath, terms.settlementAmount);
+    const required = share.scale(terms.settlementAmount);
 
     /** @type {OfferHandler} */
     const optionPosition = depositSeat => {
@@ -146,7 +145,11 @@ const start = zcf => {
   }
 
   function makeInvitationPair(longCollateralShare) {
-    const longPercent = makePercent(longCollateralShare);
+    const longPercent = makePercent(
+      longCollateralShare * 100,
+      collateralMath,
+      10000,
+    );
 
     const longInvitation = makeOptionInvitation(Position.LONG, longPercent);
     const shortInvitation = makeOptionInvitation(

--- a/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
@@ -144,6 +144,8 @@ const start = zcf => {
     });
   }
 
+  // TODO(2282): change the API so the caller can provide share in basis points
+  //  rather than percent
   function makeInvitationPair(longCollateralShare) {
     const longPercent = makePercent(
       longCollateralShare * 100,

--- a/packages/zoe/src/contracts/callSpread/types.js
+++ b/packages/zoe/src/contracts/callSpread/types.js
@@ -24,7 +24,6 @@
 
 /**
  * @callback Scale
- * @param {AmountMath} amountMath
  * @param {Amount} amount
  * @returns {Amount}
  */
@@ -32,7 +31,14 @@
 /**
  * @callback MakePercent
  * @param {number} value
- * @param {number} base
+ * @param {AmountMath} amountMath
+ * @param {number=} base
+ * @returns {Percent}
+ */
+
+/**
+ * @callback MakeCanonicalPercent
+ * @param {AmountMath} amountMath
  * @returns {Percent}
  */
 
@@ -40,6 +46,7 @@
  * @callback CalculatePercent
  * @param {Amount} numerator
  * @param {Amount} denominator
+ * @param {AmountMath} amountMath
  * @param {number=} base
  * @returns {Percent}
  */
@@ -70,6 +77,7 @@
  * Otherwise return a number between 1 and 99 reflecting the position of price
  * in the range from strikePrice1 to strikePrice2.
  * @param {AmountMath} strikeMath
+ * @param {AmountMath} collateralMath
  * @param {Amount} price
  * @param {Amount} strikePrice1
  * @param {Amount} strikePrice2

--- a/packages/zoe/src/contracts/loan/borrow.js
+++ b/packages/zoe/src/contracts/loan/borrow.js
@@ -50,9 +50,7 @@ export const makeBorrowInvitation = (zcf, config) => {
     // formula: assert collateralValue*100 >= loanWanted*mmr
 
     // Calculate approximate value just for the error message if needed
-    const approxForMsg = loanMath.make(
-      natSafeMath.floorDivide(natSafeMath.multiply(loanWanted.value, mmr), 100),
-    );
+    const approxForMsg = mmr.scale(loanWanted);
 
     // Assert the required collateral was escrowed.
     assert(
@@ -60,7 +58,7 @@ export const makeBorrowInvitation = (zcf, config) => {
         loanMath.make(
           natSafeMath.multiply(collateralPriceInLoanBrand.value, 100),
         ),
-        loanMath.make(natSafeMath.multiply(loanWanted.value, mmr)),
+        mmr.scale(loanWanted),
       ),
       details`The required margin is approximately ${approxForMsg} but collateral only had value of ${collateralPriceInLoanBrand}`,
     );

--- a/packages/zoe/src/contracts/loan/borrow.js
+++ b/packages/zoe/src/contracts/loan/borrow.js
@@ -60,7 +60,7 @@ export const makeBorrowInvitation = (zcf, config) => {
         ),
         mmr.scale(loanWanted),
       ),
-      details`The required margin is approximately ${approxForMsg} but collateral only had value of ${collateralPriceInLoanBrand}`,
+      details`The required margin is approximately ${approxForMsg.value}% but collateral only had value of ${collateralPriceInLoanBrand.value}`,
     );
 
     // Assert that the collateralGiven has not changed after the AWAIT

--- a/packages/zoe/src/contracts/loan/index.js
+++ b/packages/zoe/src/contracts/loan/index.js
@@ -6,6 +6,7 @@ import { assert } from '@agoric/assert';
 import { makeAsyncIterableFromNotifier } from '@agoric/notifier';
 import { assertIssuerKeywords } from '../../contractSupport';
 import { makeLendInvitation } from './lend';
+import { makePercent } from '../../contractSupport/percentMath';
 
 /**
  * Add collateral of a particular brand and get a loan of another
@@ -53,12 +54,13 @@ import { makeLendInvitation } from './lend';
  */
 const start = async zcf => {
   assertIssuerKeywords(zcf, harden(['Collateral', 'Loan']));
+  const loanMath = zcf.getTerms().maths.Loan;
 
   // Rather than grabbing the terms each time we use them, let's set
   // some defaults and add them to a contract-wide config.
 
   const {
-    mmr = 150, // Maintenance Margin Requirement
+    mmr = makePercent(150, loanMath), // Maintenance Margin Requirement
     autoswapInstance,
     priceAuthority,
     periodNotifier,

--- a/packages/zoe/src/contracts/loan/scheduleLiquidation.js
+++ b/packages/zoe/src/contracts/loan/scheduleLiquidation.js
@@ -4,8 +4,6 @@ import '../../../exported';
 
 import { E } from '@agoric/eventual-send';
 
-import { natSafeMath } from '../../contractSupport';
-
 import { liquidate } from './liquidate';
 
 /** @type {ScheduleLiquidation} */
@@ -19,16 +17,12 @@ export const scheduleLiquidation = (zcf, configWithBorrower) => {
     mmr,
   } = configWithBorrower;
 
-  const loanMath = zcf.getTerms().maths.Loan;
-
   const currentDebt = getDebt();
 
   // The liquidationTriggerValue is when the value of the collateral
   // equals mmr percent of the current debt
   // Formula: liquidationTriggerValue = (currentDebt * mmr) / 100
-  const liquidationTriggerValue = loanMath.make(
-    natSafeMath.floorDivide(natSafeMath.multiply(currentDebt.value, mmr), 100),
-  );
+  const liquidationTriggerValue = mmr.scale(currentDebt);
 
   const collateralMath = zcf.getTerms().maths.Collateral;
 

--- a/packages/zoe/src/contracts/loan/types.js
+++ b/packages/zoe/src/contracts/loan/types.js
@@ -31,7 +31,8 @@
 /**
  * @typedef LoanTerms
  *
- * @property {MMR} [mmr=150]
+ * @property {Percent} mmr - Maintenance Margin Requirement, a Percent object.
+ * Default is 150%
  *
  * @property {AutoswapInstance} autoswapInstance
  *

--- a/packages/zoe/test/unitTests/contractSupport/test-percentMath.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-percentMath.js
@@ -7,32 +7,32 @@ import { makeIssuerKit } from '@agoric/ertp';
 import {
   makePercent,
   calculatePercent,
-  ALL,
-  NONE,
+  makeNone,
+  makeAll,
 } from '../../../src/contractSupport/percentMath';
 
 test('percentMath - basic', t => {
-  const halfDefault = makePercent(50);
-  const halfPrecise = makePercent(5000, 10000);
-
   const { amountMath } = makeIssuerKit('moe');
   const moe = amountMath.make;
 
-  t.deepEqual(moe(666), halfDefault.scale(amountMath, moe(1333)));
-  t.deepEqual(moe(6666666), halfDefault.scale(amountMath, moe(13333333)));
-  t.deepEqual(moe(666), halfPrecise.scale(amountMath, moe(1333)));
-  t.deepEqual(moe(6666666), halfPrecise.scale(amountMath, moe(13333333)));
+  const halfDefault = makePercent(50, amountMath);
+  const halfPrecise = makePercent(5000, amountMath, 10000);
+
+  t.deepEqual(moe(666), halfDefault.scale(moe(1333)));
+  t.deepEqual(moe(6666666), halfDefault.scale(moe(13333333)));
+  t.deepEqual(moe(666), halfPrecise.scale(moe(1333)));
+  t.deepEqual(moe(6666666), halfPrecise.scale(moe(13333333)));
 });
 
 test('percentMath - onethird', t => {
   const { amountMath } = makeIssuerKit('moe');
   const moe = amountMath.make;
 
-  const oneThirdDefault = calculatePercent(moe(1), moe(3));
-  const oneThirdPrecise = calculatePercent(moe(1), moe(3), 10000);
+  const oneThirdDefault = calculatePercent(moe(1), moe(3), amountMath);
+  const oneThirdPrecise = calculatePercent(moe(1), moe(3), amountMath, 10000);
 
-  t.deepEqual(moe(33000), oneThirdDefault.scale(amountMath, moe(100000)));
-  t.deepEqual(moe(33330), oneThirdPrecise.scale(amountMath, moe(100000)));
+  t.deepEqual(moe(33000), oneThirdDefault.scale(moe(100000)));
+  t.deepEqual(moe(33330), oneThirdPrecise.scale(moe(100000)));
 });
 
 test('percentMath - brand mismatch', t => {
@@ -40,12 +40,15 @@ test('percentMath - brand mismatch', t => {
   const { amountMath: astAmountMath } = makeIssuerKit('ast');
   const moe = amountMath.make;
 
-  const oneThirdDefault = calculatePercent(moe(1), moe(3));
-  t.throws(() => calculatePercent(moe(1), astAmountMath.make(3), 10000), {
-    message: `Dividing amounts of different brands doesn't produce a percent.`,
-  });
+  const oneThirdDefault = calculatePercent(moe(1), moe(3), amountMath);
+  t.throws(
+    () => calculatePercent(moe(1), amountMath, astAmountMath.make(3), 10000),
+    {
+      message: `Dividing amounts of different brands doesn't produce a percent.`,
+    },
+  );
 
-  t.throws(() => oneThirdDefault.scale(astAmountMath, moe(100000)), {
+  t.throws(() => oneThirdDefault.scale(astAmountMath.make(100000)), {
     message: `amountMath must have the same brand as amount`,
   });
 });
@@ -54,39 +57,64 @@ test('percentMath - ALL', t => {
   const { amountMath } = makeIssuerKit('moe');
   const moe = amountMath.make;
 
-  t.deepEqual(moe(100000), ALL.scale(amountMath, moe(100000)));
+  t.deepEqual(moe(100000), makeAll(amountMath).scale(moe(100000)));
 });
 
 test('percentMath - NONE', t => {
   const { amountMath } = makeIssuerKit('moe');
   const moe = amountMath.make;
 
-  t.deepEqual(amountMath.getEmpty(), NONE.scale(amountMath, moe(100000)));
+  t.deepEqual(amountMath.getEmpty(), makeNone(amountMath).scale(moe(100000)));
 });
 
 test('percentMath - complement', t => {
   const { amountMath } = makeIssuerKit('moe');
   const moe = amountMath.make;
 
-  const oneThirdDefault = calculatePercent(moe(1), moe(3));
+  const oneThirdDefault = calculatePercent(moe(1), moe(3), amountMath);
   const twoThirdsDefault = oneThirdDefault.complement();
-  const oneThirdPrecise = calculatePercent(moe(1), moe(3), 10000);
+  const oneThirdPrecise = calculatePercent(moe(1), moe(3), amountMath, 10000);
   const twoThirdsPrecise = oneThirdPrecise.complement();
 
-  t.deepEqual(moe(33000), oneThirdDefault.scale(amountMath, moe(100000)));
-  t.deepEqual(moe(67000), twoThirdsDefault.scale(amountMath, moe(100000)));
-  t.deepEqual(moe(66670), twoThirdsPrecise.scale(amountMath, moe(100000)));
+  t.deepEqual(moe(33000), oneThirdDefault.scale(moe(100000)));
+  t.deepEqual(moe(67000), twoThirdsDefault.scale(moe(100000)));
+  t.deepEqual(moe(66670), twoThirdsPrecise.scale(moe(100000)));
 });
 
 test('percentMath - non-standard thirds', t => {
   const { amountMath } = makeIssuerKit('moe');
   const moe = amountMath.make;
 
-  const oneThirdDefault = calculatePercent(moe(1), moe(3));
-  const oneThirdBetter = calculatePercent(moe(1), moe(3), 1000);
-  const oneThirdPrecise = makePercent(1, 3);
+  const oneThirdDefault = calculatePercent(moe(1), moe(3), amountMath);
+  const oneThirdBetter = calculatePercent(moe(1), moe(3), amountMath, 1000);
+  const oneThirdPrecise = makePercent(1, amountMath, 3);
 
-  t.deepEqual(moe(2970), oneThirdDefault.scale(amountMath, moe(9000)));
-  t.deepEqual(moe(2997), oneThirdBetter.scale(amountMath, moe(9000)));
-  t.deepEqual(moe(3000), oneThirdPrecise.scale(amountMath, moe(9000)));
+  t.deepEqual(moe(2970), oneThirdDefault.scale(moe(9000)));
+  t.deepEqual(moe(2997), oneThirdBetter.scale(moe(9000)));
+  t.deepEqual(moe(3000), oneThirdPrecise.scale(moe(9000)));
+});
+
+test('percentMath - larger than 100%', t => {
+  const { amountMath } = makeIssuerKit('moe');
+  const moe = amountMath.make;
+
+  const oneFiftyDefault = calculatePercent(moe(5), moe(3), amountMath);
+  const oneFiftyBetter = calculatePercent(moe(5), moe(3), amountMath, 1000);
+
+  // 1.66 * 7777
+  t.deepEqual(moe(12909), oneFiftyDefault.scale(moe(7777)));
+  // 1.666 * 7777
+  t.deepEqual(moe(12956), oneFiftyBetter.scale(moe(7777)));
+});
+
+test('percentMath - Nats only', t => {
+  const { amountMath } = makeIssuerKit('moe');
+
+  t.throws(() => makePercent(10.1, amountMath), {
+    message: 'not a safe integer',
+  });
+
+  t.throws(() => makePercent(BigInt(47), amountMath), {
+    message: 'not a safe integer',
+  });
 });

--- a/packages/zoe/test/unitTests/contracts/loan/helpers.js
+++ b/packages/zoe/test/unitTests/contracts/loan/helpers.js
@@ -86,14 +86,15 @@ export const checkPayouts = async (
   t.truthy(seat.hasExited());
 };
 
-export const setupLoanUnitTest = async (
-  terms = harden({
-    mmr: makePercent(150),
-    autoswapInstance: {},
-  }),
-) => {
+export const setupLoanUnitTest = async terms => {
   const { moolaKit: collateralKit, simoleanKit: loanKit } = setup();
 
+  if (!terms) {
+    terms = harden({
+      mmr: makePercent(150, collateralKit.amountMath),
+      autoswapInstance: {},
+    });
+  }
   const issuerKeywordRecord = harden({
     Collateral: collateralKit.issuer,
     Loan: loanKit.issuer,

--- a/packages/zoe/test/unitTests/contracts/loan/helpers.js
+++ b/packages/zoe/test/unitTests/contracts/loan/helpers.js
@@ -10,6 +10,7 @@ import { makeLocalAmountMath } from '@agoric/ertp';
 import { setup } from '../../setupBasicMints';
 
 import { setupZCFTest } from '../../zcf/setupZcfTest';
+import { makePercent } from '../../../../src/contractSupport/percentMath';
 
 /**
  * @param {import("ava").ExecutionContext<unknown>} t
@@ -87,7 +88,7 @@ export const checkPayouts = async (
 
 export const setupLoanUnitTest = async (
   terms = harden({
-    mmr: 150,
+    mmr: makePercent(150),
     autoswapInstance: {},
   }),
 ) => {

--- a/packages/zoe/test/unitTests/contracts/loan/test-addCollateral.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-addCollateral.js
@@ -16,6 +16,7 @@ import {
   makeSeatKit,
   performAddCollateral,
 } from './helpers';
+import { makePercent } from '../../../../src/contractSupport/percentMath';
 
 test.todo('makeAddCollateralInvitation - test bad proposal');
 
@@ -53,7 +54,7 @@ test('makeAddCollateralInvitation', async t => {
     autoswapInstance,
     priceAuthority,
     getDebt,
-    mmr: 150,
+    mmr: makePercent(150, loanKit.amountMath),
   };
   const addCollateralInvitation = makeAddCollateralInvitation(zcf, config);
 

--- a/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
@@ -28,6 +28,7 @@ import buildManualTimer from '../../../../tools/manualTimer';
 import { makeBorrowInvitation } from '../../../../src/contracts/loan/borrow';
 import { makeAddCollateralInvitation } from '../../../../src/contracts/loan/addCollateral';
 import { makeCloseLoanInvitation } from '../../../../src/contracts/loan/close';
+import { makePercent } from '../../../../src/contractSupport/percentMath';
 
 const setupBorrow = async (maxLoanValue = 100) => {
   const setup = await setupLoanUnitTest();
@@ -39,7 +40,7 @@ const setupBorrow = async (maxLoanValue = 100) => {
     { give: { Loan: maxLoan } },
     { Loan: loanKit.mint.mintPayment(maxLoan) },
   );
-  const mmr = 150;
+  const mmr = makePercent(150, loanKit.amountMath);
 
   const priceList = [2, 1, 1, 1];
   const timer = buildManualTimer(console.log);

--- a/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
@@ -145,7 +145,7 @@ test('borrow not enough collateral', async t => {
   const { borrowSeat } = await setupBorrowFacet(0);
   await t.throwsAsync(() => E(borrowSeat).getOfferResult(), {
     message:
-      'The required margin is approximately (an object) but collateral only had value of (an object)',
+      'The required margin is approximately (a number)% but collateral only had value of (a number)',
   });
 });
 

--- a/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
@@ -14,6 +14,7 @@ import { checkDetails, checkPayout } from './helpers';
 import { setup } from '../../setupBasicMints';
 import { makeFakePriceAuthority } from '../../../../tools/fakePriceAuthority';
 import buildManualTimer from '../../../../tools/manualTimer';
+import { makePercent } from '../../../../src/contractSupport/percentMath';
 
 const loanRoot = `${__dirname}/../../../../src/contracts/loan/`;
 const autoswapRoot = `${__dirname}/../../../../src/contracts/autoswap`;
@@ -59,7 +60,7 @@ test('loan - lend - exit before borrow', async t => {
   const { notifier: periodNotifier } = makeNotifierKit();
 
   const terms = {
-    mmr: 150,
+    mmr: makePercent(150, loanKit.amountMath),
     autoswapInstance,
     priceAuthority,
     periodNotifier,

--- a/packages/zoe/test/unitTests/contracts/test-callSpread-calculation.js
+++ b/packages/zoe/test/unitTests/contracts/test-callSpread-calculation.js
@@ -6,99 +6,127 @@ import '../../../exported';
 
 import { setup } from '../setupBasicMints';
 import { calculateShares } from '../../../src/contracts/callSpread/calculateShares';
-import { ALL, NONE } from '../../../src/contractSupport/percentMath';
+import { makeAll, makeNone } from '../../../src/contractSupport/percentMath';
+
+function compareSharePercents(t, expected, actual, amount) {
+  t.deepEqual(expected.longShare.scale(amount), actual.longShare.scale(amount));
+  t.deepEqual(
+    expected.shortShare.scale(amount),
+    actual.shortShare.scale(amount),
+  );
+}
 
 test('callSpread-calculation, at lower bound', async t => {
-  const { moola, amountMaths } = setup();
+  const { moola, amountMaths, bucks } = setup();
   const moolaMath = amountMaths.get('moola');
+  const bucksMath = amountMaths.get('bucks');
 
   const strike1 = moola(20);
   const strike2 = moola(70);
   const price = moola(20);
-  t.deepEqual(
-    { longShare: NONE, shortShare: ALL },
-    calculateShares(moolaMath, price, strike1, strike2),
+  compareSharePercents(
+    t,
+    { longShare: makeNone(bucksMath), shortShare: makeAll(bucksMath) },
+    calculateShares(moolaMath, bucksMath, price, strike1, strike2),
+    bucks(1000),
   );
 });
 
 test('callSpread-calculation, at upper bound', async t => {
-  const { moola, amountMaths } = setup();
+  const { moola, amountMaths, bucks } = setup();
   const moolaMath = amountMaths.get('moola');
+  const bucksMath = amountMaths.get('bucks');
 
   const strike1 = moola(20);
   const strike2 = moola(55);
   const price = moola(55);
-  t.deepEqual(
-    { longShare: ALL, shortShare: NONE },
-    calculateShares(moolaMath, price, strike1, strike2),
+  compareSharePercents(
+    t,
+    { longShare: makeAll(bucksMath), shortShare: makeNone(bucksMath) },
+    calculateShares(moolaMath, bucksMath, price, strike1, strike2),
+    bucks(1000),
   );
 });
 
 test('callSpread-calculation, below lower bound', async t => {
-  const { moola, amountMaths } = setup();
+  const { moola, amountMaths, bucks } = setup();
   const moolaMath = amountMaths.get('moola');
+  const bucksMath = amountMaths.get('bucks');
 
   const strike1 = moola(15);
   const strike2 = moola(55);
   const price = moola(0);
-  t.deepEqual(
-    { longShare: NONE, shortShare: ALL },
-    calculateShares(moolaMath, price, strike1, strike2),
+  compareSharePercents(
+    t,
+    { longShare: makeNone(bucksMath), shortShare: makeAll(bucksMath) },
+    calculateShares(moolaMath, bucksMath, price, strike1, strike2),
+    bucks(1000),
   );
 });
 
 test('callSpread-calculation, above upper bound', async t => {
-  const { moola, amountMaths } = setup();
+  const { moola, amountMaths, bucks } = setup();
   const moolaMath = amountMaths.get('moola');
+  const bucksMath = amountMaths.get('bucks');
 
   const strike1 = moola(15);
   const strike2 = moola(55);
   const price = moola(60);
-  t.deepEqual(
-    { longShare: ALL, shortShare: NONE },
-    calculateShares(moolaMath, price, strike1, strike2),
+  compareSharePercents(
+    t,
+    { longShare: makeAll(bucksMath), shortShare: makeNone(bucksMath) },
+    calculateShares(moolaMath, bucksMath, price, strike1, strike2),
+    bucks(1000),
   );
 });
 
 test('callSpread-calculation, mid-way', async t => {
-  const { moola, amountMaths } = setup();
+  const { moola, amountMaths, bucks } = setup();
   const moolaMath = amountMaths.get('moola');
+  const bucksMath = amountMaths.get('bucks');
 
   const strike1 = moola(15);
   const strike2 = moola(45);
   const price = moola(40);
   const { longShare, shortShare } = calculateShares(
     moolaMath,
+    bucksMath,
     price,
     strike1,
     strike2,
   );
-  t.deepEqual(moola(83), longShare.scale(moolaMath, moola(100)));
-  t.deepEqual(moola(17), shortShare.scale(moolaMath, moola(100)));
+  t.deepEqual(bucks(833), longShare.scale(bucks(1000)));
+  t.deepEqual(bucks(166), shortShare.scale(bucks(1000)));
 });
 
 test('callSpread-calculation, zero', async t => {
-  const { moola, amountMaths } = setup();
+  const { moola, amountMaths, bucks } = setup();
   const moolaMath = amountMaths.get('moola');
+  const bucksMath = amountMaths.get('bucks');
 
   const strike1 = moola(15);
   const strike2 = moola(45);
   const price = moola(0);
-  t.deepEqual(
-    { longShare: NONE, shortShare: ALL },
-    calculateShares(moolaMath, price, strike1, strike2),
+  compareSharePercents(
+    t,
+    { longShare: makeNone(bucksMath), shortShare: makeAll(bucksMath) },
+    calculateShares(moolaMath, bucksMath, price, strike1, strike2),
+    bucks(1000),
   );
 });
 
 test('callSpread-calculation, large', async t => {
-  const { moola, amountMaths } = setup();
+  const { moola, amountMaths, bucks } = setup();
   const moolaMath = amountMaths.get('moola');
+  const bucksMath = amountMaths.get('bucks');
 
   const strike1 = moola(15);
   const strike2 = moola(45);
   const price = moola(10000000000);
-  t.deepEqual(
-    { longShare: ALL, shortShare: NONE },
-    calculateShares(moolaMath, price, strike1, strike2),
+  compareSharePercents(
+    t,
+    { longShare: makeAll(bucksMath), shortShare: makeNone(bucksMath) },
+    calculateShares(moolaMath, bucksMath, price, strike1, strike2),
+    bucks(1000),
   );
 });


### PR DESCRIPTION
increased precision in callSpread
use percent for MMR in loan contract

#documentation-branch: percents

closes: #2245