### PR TITLE
Reenable Docker builds and ag-setup-cosmos bootstrap

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,4 @@ packages/stat-logger
 **/swingset-kernel-state
 **/_agstate
 .vagrant
+packages/xsnap/moddable

--- a/go.mod
+++ b/go.mod
@@ -28,8 +28,9 @@ replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.2-alp
 // At least until tendermint v0.34.4 is released.
 // replace github.com/tendermint/tendermint => github.com/agoric-labs/tendermint v0.33.1-dev2.0.20210126214117-87803b32fbb4
 
-// At least until cosmos-sdk v0.40.0-rc3 is released.
-// replace github.com/cosmos/cosmos-sdk => github.com/agoric-labs/cosmos-sdk v0.34.4-0.20201011165527-9684bf64c2db
+// At least until https://github.com/cosmos/cosmos-sdk/issues/8478 is solved and
+// released.
+replace github.com/cosmos/cosmos-sdk => github.com/agoric-labs/cosmos-sdk v0.34.4-0.20210129184725-f1afab29a888
 
 // For testing against a local cosmos-sdk or tendermint
 // replace github.com/cosmos/cosmos-sdk => ../forks/cosmos-sdk

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBA
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agoric-labs/cosmos-sdk v0.34.4-0.20201011165527-9684bf64c2db h1:UqImtwkjSMlTdQrE+9YYvVUtpbinoS7xHuYLO/NQWyg=
 github.com/agoric-labs/cosmos-sdk v0.34.4-0.20201011165527-9684bf64c2db/go.mod h1:YZcO00Tq/qqj4ncsfn+PobyTelsot7wEMGPpxEbEAT0=
+github.com/agoric-labs/cosmos-sdk v0.34.4-0.20210129184725-f1afab29a888 h1:0be7uMLEqiZ4Bqp2VD8agsf7DmJEFNdKrRBRIYKAb5s=
+github.com/agoric-labs/cosmos-sdk v0.34.4-0.20210129184725-f1afab29a888/go.mod h1:vlgqdPpUGSxgqSbZea6fjszoLkPKwCuiqSBySLlv4ro=
 github.com/agoric-labs/tendermint v0.33.1-dev2.0.20210122151802-a81eb67c924d h1:/4mrvbNZs/K6ZDppuy0/Drm9Yb/dr5j+15Y6n2x4pVY=
 github.com/agoric-labs/tendermint v0.33.1-dev2.0.20210122151802-a81eb67c924d/go.mod h1:FxbRbTEQsxz1LUmY4cVFFcjcdNT6VwVm7Ajw5HQmf04=
 github.com/agoric-labs/tendermint v0.33.1-dev2.0.20210126214117-87803b32fbb4 h1:oHNB57wl8KSb6oo1w32FW19PdB5uFfPjfnFYX6/pbn8=

--- a/packages/deployment/Dockerfile.sdk
+++ b/packages/deployment/Dockerfile.sdk
@@ -31,6 +31,7 @@ RUN cd packages/cosmic-swingset && make install install-helper
 RUN yarn build
 
 # Remove dev dependencies.
+RUN rm -rf packages/xsnap/moddable
 RUN find . -name node_modules -prune -print0 | xargs -0 rm -rf
 RUN yarn install --frozen-lockfile --production
 

--- a/packages/deployment/Makefile
+++ b/packages/deployment/Makefile
@@ -24,15 +24,19 @@ docker-build-sdk:
 	  dirty=`git diff --quiet || echo -dirty`; \
 	  echo "$$hash$$dirty" > $(SS)lib/git-revision.txt && \
 		docker build -t $(REPOSITORY_SDK):$(TAG) --file=Dockerfile.sdk ../..
+	docker tag $(REPOSITORY_SDK):$(TAG) $(REPOSITORY_SDK):latest
 
 docker-build-setup:
-	docker build -t $(REPOSITORY)-setup:$(TAG) .
+	docker build --build-arg=TAG=$(TAG)  -t $(REPOSITORY)-setup:$(TAG) .
+	docker tag $(REPOSITORY)-setup:$(TAG) $(REPOSITORY)-setup:latest
 
 docker-build-solo:
-	docker build -t $(REPOSITORY)-solo:$(TAG) $(SS)lib/ag-solo
+	docker build --build-arg=TAG=$(TAG) -t $(REPOSITORY)-solo:$(TAG) $(SS)lib/ag-solo
+	docker tag $(REPOSITORY)-solo:$(TAG) $(REPOSITORY)-solo:latest
 
 docker-build-deployment:
-	docker build -t agoric/deployment:$(TAG) --file=Dockerfile.deployment ./docker
+	docker build --build-arg=TAG=$(TAG)  -t agoric/deployment:$(TAG) --file=Dockerfile.deployment ./docker
+	docker tag agoric/deployment:$(TAG) agoric/deployment:latest
 
 # Just push $(TAG)
 docker-push-only:
@@ -49,21 +53,17 @@ docker-push-ibc-alpha: docker-build-ibc-alpha
 	docker push $(REPOSITORY_SDK):ibc-alpha
 
 docker-push-setup:
-	$(DONT_PUSH_LATEST) docker tag $(REPOSITORY)-setup:$(TAG) $(REPOSITORY)-setup:latest
 	$(DONT_PUSH_LATEST) docker push $(REPOSITORY)-setup:latest
 	docker push $(REPOSITORY)-setup:$(TAG)
 
 docker-push-base:
-	$(DONT_PUSH_LATEST) docker tag $(REPOSITORY_SDK):$(TAG) $(REPOSITORY_SDK):latest
 	$(DONT_PUSH_LATEST) docker push $(REPOSITORY_SDK):latest
 	docker push $(REPOSITORY_SDK):$(TAG)
 
 docker-push-solo:
-	$(DONT_PUSH_LATEST) docker tag $(REPOSITORY)-solo:$(TAG) $(REPOSITORY)-solo:latest
 	$(DONT_PUSH_LATEST) docker push $(REPOSITORY)-solo:latest
 	docker push $(REPOSITORY)-solo:$(TAG)
 
 docker-push-deployment:
-	$(DONT_PUSH_LATEST) docker tag agoric/deployment:$(TAG) agoric/deployment:latest
 	$(DONT_PUSH_LATEST) docker push agoric/deployment:latest
 	docker push $(REPOSITORY)-solo:$(TAG)

--- a/packages/deployment/ansible/roles/cosmos-clone-config/tasks/main.yml
+++ b/packages/deployment/ansible/roles/cosmos-clone-config/tasks/main.yml
@@ -4,6 +4,12 @@
     state: directory
     path: "{{ data | default(service + '/data') }}/{{ inventory_hostname }}.dst"
 
+- name: "Copy to data/*.dst/app.toml"
+  delegate_to: localhost
+  copy:
+    src: "{{ data | default(service + '/data') }}/{{ inventory_hostname }}/app.toml"
+    dest: "{{ data | default(service + '/data') }}/{{ inventory_hostname }}.dst/app.toml"
+
 - name: "Copy to data/*.dst/config.toml"
   delegate_to: localhost
   copy:

--- a/packages/deployment/ansible/roles/cosmos-genesis/tasks/main.yml
+++ b/packages/deployment/ansible/roles/cosmos-genesis/tasks/main.yml
@@ -88,10 +88,11 @@
   become_user: "{{ service }}"
   shell: "\
     {{ service }} gentx --keyring-dir=/home/{{ service }}/.ag-cosmos-helper \
-      --keyring-backend=test {{ STAKER_AMOUNT }} \
+      --keyring-backend=test \
       {{ (website | default(None)) and '--website=' ~ website }} \
       {{ (identity | default(None)) and '--identity=' ~ identity }} \
-      {{ STAKER }}-{{ STAKER_NODE }} --chain-id={{ CHAIN_NAME }} --output-document={{ json }}"
+      {{ STAKER }}-{{ STAKER_NODE }} {{ STAKER_AMOUNT }} \
+      --chain-id={{ CHAIN_NAME }} --output-document={{ json }}"
   vars:
     json: "/home/{{ service }}/.{{ service }}/config/gentx/{{ STAKER_NODE }}.json"
   args:

--- a/packages/deployment/ansible/roles/fetch-cosmos/tasks/main.yml
+++ b/packages/deployment/ansible/roles/fetch-cosmos/tasks/main.yml
@@ -4,6 +4,12 @@
     flat: yes
     src: "/home/{{ service }}/.{{ service }}/config/genesis.json"
 
+- name: "Fetch {{ data | default(service + '/data') }}/*/app.toml"
+  fetch:
+    dest: "{{ data | default(service + '/data') }}/{{ inventory_hostname }}/"
+    flat: yes
+    src: "/home/{{ service }}/.{{ service }}/config/app.toml"
+
 - name: "Fetch {{ data | default(service + '/data') }}/*/config.toml"
   fetch:
     dest: "{{ data | default(service + '/data') }}/{{ inventory_hostname }}/"

--- a/packages/deployment/ansible/roles/install-cosmos/tasks/main.yml
+++ b/packages/deployment/ansible/roles/install-cosmos/tasks/main.yml
@@ -10,6 +10,16 @@
     group: "{{ service }}"
     mode: 0644
 
+- name: "Install {{ data | default(service + '/data') }}/*.dst/config/app.toml"
+  become_user: root
+  become: true
+  copy:
+    src: "{{ data | default(service + '/data') }}/{{ inventory_hostname }}.dst/app.toml"
+    dest: "/home/{{ service }}/.{{ service }}/config/app.toml"
+    owner: "{{ service }}"
+    group: "{{ service }}"
+    mode: 0644
+
 - name: "Install {{ data | default(service + '/data') }}/*.dst/config/config.toml"
   become_user: root
   become: true

--- a/packages/deployment/main.js
+++ b/packages/deployment/main.js
@@ -614,10 +614,10 @@ ${chalk.yellow.bold(`ag-setup-solo --netconfig='${dwebHost}/network-config'`)}
           ),
         buf => {
           const match = buf.match(
-            /Committed state.*module=state.*height=([1-9]\d*)/,
+            /( block-manager: block ([1-9]\d*) commit|Committed state.*module=state.*height=([1-9]\d*))/,
           );
           if (match) {
-            return match[1];
+            return match[2] || match[3];
           }
           return undefined;
         },

--- a/packages/xsnap/package.json
+++ b/packages/xsnap/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "repl": "node -r esm src/xsrepl.js",
     "build:bundle": "rollup --config rollup.config.js",
-    "build:bin": "git submodule update --init && node -r esm src/build.js",
+    "build:bin": "node -r esm src/build.js",
     "build": "yarn build:bin && yarn build:bundle",
     "clean": "rm -rf build",
     "lint": "yarn lint:js && yarn lint:types",
@@ -22,8 +22,7 @@
     "lint:types": "tsc -p jsconfig.json",
     "lint-fix": "eslint --fix 'src/**/*.js' 'lib/**/*.js'",
     "lint-check": "yarn lint",
-    "test": "ava",
-    "postinstall": "yarn build"
+    "test": "ava"
   },
   "dependencies": {
     "@agoric/eventual-send": "^0.13.0",


### PR DESCRIPTION
This fixes `xsnap` to be able to build as part of `cd packages/deployment && make docker-build`.

We remove the build from the Node.js `postinstall` script, since our Docker build relies on building only during the `build` script.

The other changes are needed to make the resulting Docker images viable.  Can be tested with `NETWORK_NAME=mytestnet packages/deployment/docker/ag-setup-cosmos bootstrap` and provisioning some Docker nodes (2 is fine).

The patch to v0.41.0 proper is mentioned in https://github.com/cosmos/cosmos-sdk/issues/8478#issuecomment-770084797