### PR TITLE
Let errorTaming default to safe

### DIFF
--- a/packages/install-ses/install-ses.js
+++ b/packages/install-ses/install-ses.js
@@ -4,7 +4,7 @@ import 'ses';
 // Install our HandledPromise global.
 import '@agoric/eventual-send/shim';
 
-lockdown({ errorTaming: 'unsafe' });
+lockdown();
 // We are now in the "Start Compartment". Our global has all the same
 // powerful things it had before, but the primordials have changed to make
 // them safe to use in the arguments of API calls we make into more limited


### PR DESCRIPTION
The `errorTaming: 'unsafe'` setting left the unsafe `.stack` property on error instances as an uncontrolled source of information that is both non-deterministic and encapsulation violating. (See https://github.com/endojs/endo/blob/master/packages/ses/lockdown-options.md )

This PR has been draft for a while because something was failing under CI with this change. With CI now green, this PR is ready for review.