### PR TITLE
test: fix arguments passed to makeLiveSlots()

### DIFF
--- a/packages/SwingSet/test/test-liveslots.js
+++ b/packages/SwingSet/test/test-liveslots.js
@@ -43,6 +43,7 @@ function makeDispatch(syscall, build) {
     'vatA',
     {},
     {},
+    undefined,
     gcTools,
   );
   setBuildRootObject(build);

--- a/packages/SwingSet/test/test-vpid-liveslots.js
+++ b/packages/SwingSet/test/test-vpid-liveslots.js
@@ -189,6 +189,7 @@ function makeDispatch(syscall, build, vatID = 'vatA') {
     vatID,
     {},
     {},
+    undefined,
     gcTools,
   );
   setBuildRootObject(build);


### PR DESCRIPTION
API drift was causing us to pass `gcTools` into the parameter slot that was
expecting a numeric virtual-object cache size. These tests don't use virtual
objects or `gcTools`, so we didn't notice. Clearly this is a job for static
type annotation...
