### PR TITLE
DRAFT FOR DESIGN ONLY: refactor amountMath w/ mathKind property on the brand presence

### DIFF
--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -6,6 +6,7 @@ import './types';
 import natMathHelpers from './mathHelpers/natMathHelpers';
 import strSetMathHelpers from './mathHelpers/strSetMathHelpers';
 import setMathHelpers from './mathHelpers/setMathHelpers';
+import { mustBeComparable } from '@agoric/same-structure';
 
 // We want an enum, but narrowed to the AmountMathKind type.
 /**
@@ -79,6 +80,7 @@ const getHelpers = amount => {
 
 const optionalBrandCheck = (amount, brand) => {
   if (brand !== undefined) {
+    mustBeComparable(brand);
     assert.equal(amount.brand, brand);
   }
 };
@@ -91,11 +93,13 @@ const noCoerceMake = (value, brand) => {
 /** @type {M} */
 const M = {
   make: (allegedValue, brand) => {
+    mustBeComparable(brand);
     const value = getHelpersFromBrand(brand).doCoerce(allegedValue);
     const amount = harden({ brand, value });
     return amount;
   },
   coerce: (allegedAmount, brand) => {
+    mustBeComparable(brand);
     const { brand: allegedBrand, value } = allegedAmount;
     assert(
       allegedBrand !== undefined,
@@ -108,19 +112,25 @@ const M = {
     // Will throw on inappropriate value
     return M.make(value, brand);
   },
-  getValue: (amount, brand) => M.coerce(amount, brand).value,
-  getEmpty: brand => getHelpersFromBrand(brand).doGetEmpty(),
-  isEmpty: (amount, brand) => {
+  getValue: (amount, brand) => {
+    mustBeComparable(brand);
+    return M.coerce(amount, brand).value;
+  },
+  getEmpty: brand => {
+    mustBeComparable(brand);
+    return getHelpersFromBrand(brand).doGetEmpty();
+  },
+  isEmpty: (amount, brand = undefined) => {
     optionalBrandCheck(amount, brand);
     return getHelpers(amount).doIsEmpty(amount.value);
   },
-  isGTE: (leftAmount, rightAmount, brand) => {
+  isGTE: (leftAmount, rightAmount, brand = undefined) => {
     optionalBrandCheck(leftAmount, brand);
     optionalBrandCheck(rightAmount, brand);
     assert.equal(leftAmount.brand, rightAmount.brand);
     return getHelpers(leftAmount).doIsGTE(leftAmount.value, rightAmount.value);
   },
-  isEqual: (leftAmount, rightAmount, brand) => {
+  isEqual: (leftAmount, rightAmount, brand = undefined) => {
     optionalBrandCheck(leftAmount, brand);
     optionalBrandCheck(rightAmount, brand);
     assert.equal(leftAmount.brand, rightAmount.brand);
@@ -129,7 +139,7 @@ const M = {
       rightAmount.value,
     );
   },
-  add: (leftAmount, rightAmount, brand) => {
+  add: (leftAmount, rightAmount, brand = undefined) => {
     optionalBrandCheck(leftAmount, brand);
     optionalBrandCheck(rightAmount, brand);
     assert.equal(leftAmount.brand, rightAmount.brand);
@@ -138,7 +148,7 @@ const M = {
       leftAmount.brand,
     );
   },
-  subtract: (leftAmount, rightAmount, brand) => {
+  subtract: (leftAmount, rightAmount, brand = undefined) => {
     optionalBrandCheck(leftAmount, brand);
     optionalBrandCheck(rightAmount, brand);
     assert.equal(leftAmount.brand, rightAmount.brand);

--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -1,12 +1,12 @@
 // @ts-check
 
 import { assert, details } from '@agoric/assert';
+import { mustBeComparable } from '@agoric/same-structure';
 
 import './types';
 import natMathHelpers from './mathHelpers/natMathHelpers';
 import strSetMathHelpers from './mathHelpers/strSetMathHelpers';
 import setMathHelpers from './mathHelpers/setMathHelpers';
-import { mustBeComparable } from '@agoric/same-structure';
 
 // We want an enum, but narrowed to the AmountMathKind type.
 /**

--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -1,8 +1,6 @@
 // @ts-check
 
 import { assert, details } from '@agoric/assert';
-import { Far } from '@agoric/marshal';
-import { mustBeComparable } from '@agoric/same-structure';
 
 import './types';
 import natMathHelpers from './mathHelpers/natMathHelpers';
@@ -54,138 +52,102 @@ export { MathKind };
  * function `coerce` takes an amount and checks it, returning an amount (amount
  * -> amount).
  *
- * `makeAmountMath` takes in a brand and the kind of amountMath to use.
- *
- * amountMath is not pass-by-copy, but everything it does can be done
- * locally in each vat that needs the functionality. If the operations
- * are done against a remote version, they have the same semantics, but
- * require an extra messaging round-trip per call. The best way to use
- * it is to make a local copy, which can be done by calling
- * makeLocalAmountMath(issuer).
- *
- * AmountMath exports MathKind, which contains constants for the kinds:
- * NAT, SET, and STRING_SET.
- *
  * Each issuer of digital assets has an associated brand in a one-to-one
  * mapping. In untrusted contexts, such as in analyzing payments and
  * amounts, we can get the brand and find the issuer which matches the
  * brand. The issuer and the brand mutually validate each other.
- *
- * @param {Brand} brand
- * @param {AmountMathKind} amountMathKind
- * @returns {AmountMath}
  */
-function makeAmountMath(brand, amountMathKind) {
-  mustBeComparable(brand);
-  assert.typeof(amountMathKind, 'string');
+
+// Setup
+const getHelpersFromBrand = brand => {
+  const { mathKind } = brand;
+  assert.typeof(mathKind, 'string');
 
   const mathHelpers = {
     nat: natMathHelpers,
     strSet: strSetMathHelpers,
     set: setMathHelpers,
   };
-  const helpers = mathHelpers[amountMathKind];
-  assert(
-    helpers !== undefined,
-    details`unrecognized amountMathKind: ${amountMathKind}`,
-  );
+  const helpers = mathHelpers[mathKind];
+  assert(helpers !== undefined, details`unrecognized mathKind: ${mathKind}`);
+  return helpers;
+};
 
-  // Cache the amount if we can.
-  const cache = new WeakSet();
+const getHelpers = amount => {
+  return getHelpersFromBrand(amount.brand);
+};
 
-  /** @type {AmountMath} */
-  const amountMath = Far('amountMath', {
-    getBrand: () => brand,
-    getAmountMathKind: () => amountMathKind,
+const optionalBrandCheck = (amount, brand) => {
+  if (brand !== undefined) {
+    assert.equal(amount.brand, brand);
+  }
+};
 
-    /**
-     * Make an amount from a value by adding the brand.
-     *
-     * @param {Value} allegedValue
-     * @returns {Amount}
-     */
-    make: allegedValue => {
-      const value = helpers.doCoerce(allegedValue);
-      const amount = harden({ brand, value });
-      cache.add(amount);
-      return amount;
-    },
+const noCoerceMake = (value, brand) => {
+  const amount = harden({ brand, value });
+  return amount;
+};
 
-    /**
-     * Make sure this amount is valid and return it if so, throwing if invalid.
-     *
-     * @param {Amount} allegedAmount
-     * @returns {Amount} or throws if invalid
-     */
-    coerce: allegedAmount => {
-      // If the cache already has the allegedAmount, that
-      // means it is a valid amount.
-      if (cache.has(allegedAmount)) {
-        return allegedAmount;
-      }
-      const { brand: allegedBrand, value } = allegedAmount;
-      assert(
-        allegedBrand !== undefined,
-        details`The brand in allegedAmount ${allegedAmount} is undefined. Did you pass a value rather than an amount?`,
-      );
-      assert(
-        brand === allegedBrand,
-        details`The brand in the allegedAmount ${allegedAmount} in 'coerce' didn't match the amountMath brand ${brand}.`,
-      );
-      // Will throw on inappropriate value
-      return amountMath.make(value);
-    },
+/** @type {M} */
+const M = {
+  make: (allegedValue, brand) => {
+    const value = getHelpersFromBrand(brand).doCoerce(allegedValue);
+    const amount = harden({ brand, value });
+    return amount;
+  },
+  coerce: (allegedAmount, brand) => {
+    const { brand: allegedBrand, value } = allegedAmount;
+    assert(
+      allegedBrand !== undefined,
+      details`The brand in allegedAmount ${allegedAmount} is undefined. Did you pass a value rather than an amount?`,
+    );
+    assert(
+      brand === allegedBrand,
+      details`The brand in the allegedAmount ${allegedAmount} in 'coerce' didn't match the amountMath brand ${brand}.`,
+    );
+    // Will throw on inappropriate value
+    return M.make(value, brand);
+  },
+  getValue: (amount, brand) => M.coerce(amount, brand).value,
+  getEmpty: brand => getHelpersFromBrand(brand).doGetEmpty(),
+  isEmpty: (amount, brand) => {
+    optionalBrandCheck(amount, brand);
+    return getHelpers(amount).doIsEmpty(amount.value);
+  },
+  isGTE: (leftAmount, rightAmount, brand) => {
+    optionalBrandCheck(leftAmount, brand);
+    optionalBrandCheck(rightAmount, brand);
+    assert.equal(leftAmount.brand, rightAmount.brand);
+    return getHelpers(leftAmount).doIsGTE(leftAmount.value, rightAmount.value);
+  },
+  isEqual: (leftAmount, rightAmount, brand) => {
+    optionalBrandCheck(leftAmount, brand);
+    optionalBrandCheck(rightAmount, brand);
+    assert.equal(leftAmount.brand, rightAmount.brand);
+    return getHelpers(leftAmount).doIsEqual(
+      leftAmount.value,
+      rightAmount.value,
+    );
+  },
+  add: (leftAmount, rightAmount, brand) => {
+    optionalBrandCheck(leftAmount, brand);
+    optionalBrandCheck(rightAmount, brand);
+    assert.equal(leftAmount.brand, rightAmount.brand);
+    return noCoerceMake(
+      getHelpers(leftAmount).doIsAdd(leftAmount.value, rightAmount.value),
+      leftAmount.brand,
+    );
+  },
+  subtract: (leftAmount, rightAmount, brand) => {
+    optionalBrandCheck(leftAmount, brand);
+    optionalBrandCheck(rightAmount, brand);
+    assert.equal(leftAmount.brand, rightAmount.brand);
+    return noCoerceMake(
+      getHelpers(leftAmount).doIsSubtract(leftAmount.value, rightAmount.value),
+      leftAmount.brand,
+    );
+  },
+};
+harden(M);
 
-    // Get the value from the amount.
-    getValue: amount => amountMath.coerce(amount).value,
-
-    // Represents the empty set/mathematical identity.
-    // eslint-disable-next-line no-use-before-define
-    getEmpty: () => empty,
-
-    // Is the amount equal to the empty set?
-    isEmpty: amount => helpers.doIsEmpty(amountMath.getValue(amount)),
-
-    // Is leftAmount greater than or equal to rightAmount? In other
-    // words, is everything in the rightAmount included in the
-    // leftAmount?
-    isGTE: (leftAmount, rightAmount) =>
-      helpers.doIsGTE(
-        amountMath.getValue(leftAmount),
-        amountMath.getValue(rightAmount),
-      ),
-
-    // Is leftAmount equal to rightAmount?
-    isEqual: (leftAmount, rightAmount) =>
-      helpers.doIsEqual(
-        amountMath.getValue(leftAmount),
-        amountMath.getValue(rightAmount),
-      ),
-
-    // Combine leftAmount and rightAmount.
-    add: (leftAmount, rightAmount) =>
-      amountMath.make(
-        helpers.doAdd(
-          amountMath.getValue(leftAmount),
-          amountMath.getValue(rightAmount),
-        ),
-      ),
-
-    // Return the amount included in leftAmount but not included in
-    // rightAmount. If leftAmount does not include all of rightAmount,
-    // error.
-    subtract: (leftAmount, rightAmount) =>
-      amountMath.make(
-        helpers.doSubtract(
-          amountMath.getValue(leftAmount),
-          amountMath.getValue(rightAmount),
-        ),
-      ),
-  });
-  const empty = amountMath.make(helpers.doGetEmpty());
-  return amountMath;
-}
-
-harden(makeAmountMath);
-
-export { makeAmountMath };
+export { M };

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -41,7 +41,7 @@
  */
 
 /**
- * @typedef {Object} AmountMath
+ * @typedef {Object} M
  * Logic for manipulating amounts.
  *
  * Amounts are the canonical description of tradable goods. They are manipulated
@@ -49,46 +49,41 @@
  * payments. They can be used to represent things like currency, stock, and the
  * abstract right to participate in a particular exchange.
  *
- * @property {() => Brand} getBrand Return the brand.
- * @property {() => AmountMathKind} getAmountMathKind
- * Get the kind of amountMath used. This can be passed as an
- * argument to `makeAmountMath` to create local amountMath.
- *
- * @property {(allegedValue: Value) => Amount} make
+ * @property {(allegedValue: Value, brand: Brand) => Amount} make
  * Make an amount from a value by adding the brand.
  *
- * @property {(allegedAmount: Amount) => Amount} coerce
+ * @property {(allegedAmount: Amount, brand: Brand) => Amount} coerce
  * Make sure this amount is valid and return it if so.
  *
- * @property {(amount: Amount) => Value} getValue
+ * @property {(amount: Amount, brand: Brand) => Value} getValue
  * Extract and return the value.
  *
- * @property {() => Amount} getEmpty
+ * @property {(brand: Brand) => Amount} getEmpty
  * Return the amount representing an empty amount. This is the
  * identity element for MathHelpers.add and MatHelpers.subtract.
  *
- * @property {(amount: Amount) => boolean} isEmpty
+ * @property {(amount: Amount, brand?: Brand) => boolean} isEmpty
  * Return true if the Amount is empty. Otherwise false.
  *
- * @property {(leftAmount: Amount, rightAmount: Amount) => boolean} isGTE
+ * @property {(leftAmount: Amount, rightAmount: Amount, brand?: Brand) => boolean} isGTE
  * Returns true if the leftAmount is greater than or equal to the
  * rightAmount. For non-scalars, "greater than or equal to" depends
  * on the kind of amount, as defined by the MathHelpers. For example,
  * whether rectangle A is greater than rectangle B depends on whether rectangle
  * A includes rectangle B as defined by the logic in MathHelpers.
  *
- * @property {(leftAmount: Amount, rightAmount: Amount) => boolean} isEqual
+ * @property {(leftAmount: Amount, rightAmount: Amount, brand?: Brand) => boolean} isEqual
  * Returns true if the leftAmount equals the rightAmount. We assume
  * that if isGTE is true in both directions, isEqual is also true
  *
- * @property {(leftAmount: Amount, rightAmount: Amount) => Amount} add
+ * @property {(leftAmount: Amount, rightAmount: Amount, brand?: Brand) => Amount} add
  * Returns a new amount that is the union of both leftAmount and rightAmount.
  *
  * For fungible amount this means adding the values. For other kinds of
  * amount, it usually means including all of the elements from both
  * left and right.
  *
- * @property {(leftAmount: Amount, rightAmount: Amount) => Amount} subtract
+ * @property {(leftAmount: Amount, rightAmount: Amount, brand?: Brand) => Amount} subtract
  * Returns a new amount that is the leftAmount minus the rightAmount
  * (i.e. everything in the leftAmount that is not in the
  * rightAmount). If leftAmount doesn't include rightAmount
@@ -224,7 +219,6 @@
  *
  * @property {Mint} mint
  * @property {Issuer} issuer
- * @property {AmountMath} amountMath
  * @property {Brand} brand
  */
 

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -41,9 +41,6 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
   /** @type {WeakStore<Instance,InstanceAdmin>} */
   const instanceToInstanceAdmin = makeWeakStore('instance');
 
-  /** @type {GetAmountMath} */
-  const getAmountMath = brand => issuerTable.getByBrand(brand).amountMath;
-
   /** @type {WeakStore<Brand, ERef<Purse>>} */
   const brandToPurse = makeWeakStore('brand');
 
@@ -136,10 +133,6 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
         issuerRecords.map(record => record.brand),
         keywords,
       );
-      const maths = arrayToObj(
-        issuerRecords.map(record => record.amountMath),
-        keywords,
-      );
 
       let instanceRecord = {
         installation,
@@ -147,7 +140,6 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
           ...customTerms,
           issuers,
           brands,
-          maths,
         },
       };
 
@@ -170,10 +162,6 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
             brands: {
               ...instanceRecord.terms.brands,
               [keyword]: issuerRecord.brand,
-            },
-            maths: {
-              ...instanceRecord.terms.maths,
-              [keyword]: issuerRecord.amountMath,
             },
           },
         };


### PR DESCRIPTION
This PR refactors AmountMath, assuming a brand has a synchronously obtainable property called `mathKind`. The goal is to be able to import `M` (math) from `@agoric/ertp`, and be able to use it to add, subtract, etc.

AmountMath was serving two purposes simultaneously, which can be teased out separately:

1. An "absolute" check on the brand in the amounts, against the brand directly from the issuer.
2. A "relative" check to ensure that we are manipulating amounts of the same brand, regardless of whether the brands in the amounts match the brand directly from the issuer.

This refactoring tries to separate these two purposes. For instance, in `add`, if an absolute check is necessary, you must pass the brand that you got from the issuer (or from Zoe) as an optional third parameter:

```
M.add(amount1, amount2, brandFromIssuer)
```

If only a relative check is required, you can leave out the optional brand, and `add` will error if the two amounts have different brands:

```
M.add(amount1, amount2);
```

If this refactoring or something like it is sufficient, that means that we can do without having synchronous methods on brands.
