### PR TITLE
Ask git to ignore xsnap/dist

### DIFF
--- a/packages/xsnap/.gitignore
+++ b/packages/xsnap/.gitignore
@@ -1,1 +1,2 @@
 build
+dist


### PR DESCRIPTION
Currently, after rebuilding all of agoric-sdk I get

```
$ git status
On branch master
Your branch is up to date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        packages/xsnap/dist/
```

This confuses my git-sensitive prompt coloring. Looking at our other packages, "dist" is usually in their `.gitignore`