### PR TITLE
fix: update dibc for cosmos-sdk v0.41.0

### DIFF
--- a/golang/cosmos/Makefile
+++ b/golang/cosmos/Makefile
@@ -89,10 +89,13 @@ proto-lint: proto-tools
 proto-check-breaking: proto-tools
 	buf check breaking --against-input '.git#branch=master'
 
-TM_URL           = https://raw.githubusercontent.com/tendermint/tendermint/v0.34.0-rc3/proto/tendermint
+TMVER = v0.34.3
+COSMOSVER = v0.41.0
+
+TM_URL           = https://raw.githubusercontent.com/tendermint/tendermint/$(TMVER)/proto/tendermint
 GOGO_PROTO_URL   = https://raw.githubusercontent.com/regen-network/protobuf/cosmos
-IBC_PROTO_URL = https://raw.githubusercontent.com/cosmos/cosmos-sdk/master/proto/ibc/core
-COSMOS_SDK_PROTO_URL = https://raw.githubusercontent.com/cosmos/cosmos-sdk/master/proto/cosmos/base
+IBC_PROTO_URL = https://raw.githubusercontent.com/cosmos/cosmos-sdk/$(COSMOSVER)/proto/ibc/core
+COSMOS_SDK_PROTO_URL = https://raw.githubusercontent.com/cosmos/cosmos-sdk/$(COSMOSVER)/proto/cosmos/base
 
 GOGO_PROTO_TYPES  = third_party/proto/gogoproto
 IBC_CHANNEL_TYPES = third_party/proto/ibc/core/channel/v1

--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -550,7 +550,7 @@ func (app *GaiaApp) InitChainer(ctx sdk.Context, req abci.RequestInitChain) abci
 
 	// Set Historical infos in InitChain to ignore genesis params
 	stakingParams := app.StakingKeeper.GetParams(ctx)
-	stakingParams.HistoricalEntries = 1000
+	stakingParams.HistoricalEntries = 10000
 	app.StakingKeeper.SetParams(ctx, stakingParams)
 
 	return res

--- a/golang/cosmos/x/dibc/ibc.go
+++ b/golang/cosmos/x/dibc/ibc.go
@@ -307,13 +307,14 @@ func (am AppModule) OnChanOpenTry(
 }
 
 type channelOpenAckEvent struct {
-	Type                string `json:"type"`  // IBC
-	Event               string `json:"event"` // channelOpenAck
-	PortID              string `json:"portID"`
-	ChannelID           string `json:"channelID"`
-	CounterpartyVersion string `json:"counterpartyVersion"`
-	BlockHeight         int64  `json:"blockHeight"`
-	BlockTime           int64  `json:"blockTime"`
+	Type                string                    `json:"type"`  // IBC
+	Event               string                    `json:"event"` // channelOpenAck
+	PortID              string                    `json:"portID"`
+	ChannelID           string                    `json:"channelID"`
+	CounterpartyVersion string                    `json:"counterpartyVersion"`
+	Counterparty        channeltypes.Counterparty `json:"counterparty"`
+	BlockHeight         int64                     `json:"blockHeight"`
+	BlockTime           int64                     `json:"blockTime"`
 }
 
 func (am AppModule) OnChanOpenAck(
@@ -330,12 +331,15 @@ func (am AppModule) OnChanOpenAck(
 		ctx = ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
 	}
 
+	channel, _ := am.keeper.GetChannel(ctx, portID, channelID)
+
 	event := channelOpenAckEvent{
 		Type:                "IBC_EVENT",
 		Event:               "channelOpenAck",
 		PortID:              portID,
 		ChannelID:           channelID,
 		CounterpartyVersion: counterpartyVersion,
+		Counterparty:        channel.Counterparty,
 		BlockHeight:         ctx.BlockHeight(),
 		BlockTime:           ctx.BlockTime().Unix(),
 	}

--- a/golang/cosmos/x/dibc/keeper/keeper.go
+++ b/golang/cosmos/x/dibc/keeper/keeper.go
@@ -61,10 +61,16 @@ func (k Keeper) GetNextSequenceSend(ctx sdk.Context, portID, channelID string) (
 	return k.channelKeeper.GetNextSequenceSend(ctx, portID, channelID)
 }
 
+// GetChannel defines a wrapper function for the channel Keeper's function
+// in order to expose it to the dibc IBC handler.
+func (k Keeper) GetChannel(ctx sdk.Context, portID, channelID string) (channeltypes.Channel, bool) {
+	return k.channelKeeper.GetChannel(ctx, portID, channelID)
+}
+
 // ChanOpenInit defines a wrapper function for the channel Keeper's function
 // in order to expose it to the dibc IBC handler.
 func (k Keeper) ChanOpenInit(ctx sdk.Context, order channeltypes.Order, connectionHops []string,
-	portID, rPortID, rChannelID, version string,
+	portID, rPortID, version string,
 ) error {
 	capName := host.PortPath(portID)
 	portCap, ok := k.GetCapability(ctx, capName)
@@ -72,8 +78,7 @@ func (k Keeper) ChanOpenInit(ctx sdk.Context, order channeltypes.Order, connecti
 		return sdkerrors.Wrapf(porttypes.ErrInvalidPort, "could not retrieve port capability at: %s", capName)
 	}
 	counterparty := channeltypes.Counterparty{
-		ChannelId: rChannelID,
-		PortId:    rPortID,
+		PortId: rPortID,
 	}
 	channelID, chanCap, err := k.channelKeeper.ChanOpenInit(ctx, order, connectionHops, portID, portCap, counterparty, version)
 	if err != nil {

--- a/packages/cosmic-swingset/bin/ag-nchainz
+++ b/packages/cosmic-swingset/bin/ag-nchainz
@@ -118,10 +118,12 @@ start-solos)
       rpcport=`$thisdir/../calc-rpcport.js $n0d/config/config.toml`
 
       addr=$(cat ag-cosmos-helper-address)
-      $CLI --home=./$CLI-statedir tx swingset provision-one \
+      while ! $CLI --home=./$CLI-statedir tx swingset provision-one \
         "$solo" "$addr" agoric.vattp \
         --node="tcp://$rpcport" --chain-id="$chainid" \
-        --keyring-backend=test --from=ag-solo --yes
+        --keyring-backend=test --from=ag-solo --yes; do
+        sleep 5
+      done
 
       # Now wire into the chain.
       gci=`$thisdir/../calc-gci.js $n0d/config/genesis.json`
@@ -154,7 +156,9 @@ start-relayer)
 
   echo "Reading path specification (Control-D to finish, Control-C to abort)..."
   tmpfile=$(mktemp ${TMPDIR-/tmp}/relayer-start.XXXXXX)
-  trap "rm -f '$tmpfile'" EXIT
+  cfgfile=$(mktemp ${TMPDIR-/tmp}/relayer-config.XXXXXX)
+  trap "rm -f '$tmpfile' '$cfgfile'" EXIT 
+  rly config show --json > "$cfgfile"
   cat > "$tmpfile"
 
   srccid=$(jq -r '.src["connection-id"]' "$tmpfile")
@@ -162,6 +166,12 @@ start-relayer)
     echo 1>&2 "You must specify .src[\"connection-id\"]"
     exit 1
   fi
+
+  # Extract existing config.
+  for path in $(jq '.paths | keys | .[]' "$cfgfile"); do
+    rawpath=$(echo "$path" | jq -r .)
+    jq -r ".paths[$path]" "$cfgfile" > "nchainz/config/$rawpath.json"
+  done
 
   jqexpr=
   for fname in nchainz/config/*.json; do
@@ -197,6 +207,9 @@ start-relayer)
     exit 1
   fi
 
+  # Trim off the channel ids.
+  jqexpr=$jqexpr' | del(.src["channel-id"]) | del(.dst["channel-id"])'
+
   if [[ $replace == yes ]]; then
     # Overwrite existing path.
     echo "Replacing path \`$path'"
@@ -220,8 +233,6 @@ start-relayer)
   echo "$ rly config add-dir nchainz/config/"
   rly config add-dir nchainz/config/
 
-  echo "$ rly start -d $path"
-  rly start -d "$path" &
   try=0
   while ! rly tx link $path --timeout=3s -d >> "nchainz/logs/$path.log" 2>&1; do
     try=$(( $try + 1 ))
@@ -232,7 +243,8 @@ start-relayer)
   echo "$path tx link initialized (try=$try)"
 
   # Wait for the rly start command.
-  wait
+  echo "$ rly start -d $path"
+  rly start -d "$path"
   ;;
 *)
   echo 1>&2 "$progname: unrecognized command \`$COMMAND'"


### PR DESCRIPTION
These are the changes needed to complete the Agoric dIBC (JS dynamic IBC) side of #2067 .

Note that there are still problems with the Go relayer that prevent outbound connections from sending packets.

The main change was to allow the remote channelID to be negotiated dynamically.
