### PR TITLE
fix: reject symbols and unenumerated properties as intended

### DIFF
--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -4,7 +4,8 @@ import {
   Remotable,
   Far,
   getInterfaceOf,
-  mustPassByPresence,
+  passStyleOf,
+  REMOTE_STYLE,
   makeMarshal,
 } from '@agoric/marshal';
 import { assert, details } from '@agoric/assert';
@@ -244,7 +245,7 @@ function build(syscall, forVatID, cacheSize, vatPowers, vatParameters) {
       if (isPromise(val)) {
         slot = exportPromise(val);
       } else {
-        mustPassByPresence(val);
+        assert.equal(passStyleOf(val), REMOTE_STYLE);
         slot = exportPassByPresence();
       }
       parseVatSlot(slot); // assertion
@@ -564,7 +565,7 @@ function build(syscall, forVatID, cacheSize, vatPowers, vatParameters) {
       harden({ D, exitVat, exitVatWithFailure, ...vatPowers }),
       harden(vatParameters),
     );
-    mustPassByPresence(rootObject);
+    assert.equal(passStyleOf(rootObject), REMOTE_STYLE);
 
     const rootSlot = makeVatSlot('object', true, 0);
     valToSlot.set(rootObject, rootSlot);

--- a/packages/marshal/test/test-marshal.js
+++ b/packages/marshal/test/test-marshal.js
@@ -318,10 +318,8 @@ test('records', t => {
   }
   const CSO = /cannot serialize objects/;
   const NOACC = /Records must not contain accessors/;
-  // this error is accidental, and will go away
-  const SYMSTR = /Cannot convert a Symbol value to a string/;
-  // const REMSYM = /Remotables must not have symbol-named properties/;
-  // const RECSYM = /Records must not have symbol-named properties/;
+  const REMSYM = /Remotables must not have symbol-named properties/;
+  const RECSYM = /Records must not have symbol-named properties/;
   const RECENUM = /Record fields must be enumerable/;
   // const REMENUM = /Remotable methods must be enumerable/;
   const NOMETH = /cannot serialize objects with non-methods/;
@@ -386,13 +384,13 @@ test('records', t => {
   shouldThrow(['enumStringGet', 'enumStringFunc'], CSO);
 
   // anything with symbol-named properties is rejected
-  // shouldThrow(['enumSymbol'], REMSYM);
-  shouldThrow(['enumSymbol', 'enumStringData'], SYMSTR);
-  // shouldThrow(['enumSymbol', 'enumStringFunc'], REMSYM);
+  shouldThrow(['enumSymbol'], REMSYM);
+  shouldThrow(['enumSymbol', 'enumStringData'], RECSYM);
+  shouldThrow(['enumSymbol', 'enumStringFunc'], REMSYM);
 
-  // shouldThrow(['nonenumSymbol'], REMSYM);
-  shouldThrow(['nonenumSymbol', 'enumStringData'], SYMSTR);
-  // shouldThrow(['nonenumSymbol', 'enumStringFunc'], REMSYM);
+  shouldThrow(['nonenumSymbol'], REMSYM);
+  shouldThrow(['nonenumSymbol', 'enumStringData'], RECSYM);
+  shouldThrow(['nonenumSymbol', 'enumStringFunc'], REMSYM);
 
   // anything with non-enumerable properties is rejected
   shouldThrow(['nonenumString'], RECENUM);

--- a/packages/marshal/test/test-marshal.js
+++ b/packages/marshal/test/test-marshal.js
@@ -3,6 +3,7 @@ import test from 'ava';
 import {
   Remotable,
   Far,
+  // Data,
   getInterfaceOf,
   makeMarshal,
   mustPassByPresence,
@@ -235,4 +236,166 @@ test('Remotable/getInterfaceOf', t => {
   t.is(getInterfaceOf(p2), 'Alleged: Thing', `interface is Thing`);
   t.is(p2.name(), 'cretin', `name() method is presence`);
   t.is(p2.birthYear(2020), 1956, `birthYear() works`);
+
+  // Remotables and Fars can be serialized, of course
+  function convertValToSlot(_val) {
+    return 'slot';
+  }
+  const m = makeMarshal(convertValToSlot);
+  t.deepEqual(m.serialize(p2), {
+    body: JSON.stringify({
+      '@qclass': 'slot',
+      iface: 'Alleged: Thing',
+      index: 0,
+    }),
+    slots: ['slot'],
+  });
+});
+
+test('records', t => {
+  function convertValToSlot(_val) {
+    return 'slot';
+  }
+  const presence = harden({});
+  function convertSlotToVal(_slot) {
+    return presence;
+  }
+  const m = makeMarshal(convertValToSlot, convertSlotToVal);
+  const ser = val => m.serialize(val);
+  const noIface = {
+    body: JSON.stringify({ '@qclass': 'slot', index: 0 }),
+    slots: ['slot'],
+  };
+  const yesIface = {
+    body: JSON.stringify({
+      '@qclass': 'slot',
+      iface: 'Alleged: iface',
+      index: 0,
+    }),
+    slots: ['slot'],
+  };
+  // const emptyData = { body: JSON.stringify({}), slots: [] };
+
+  // objects with Symbol-named properties
+  const sym = Symbol.for('registered');
+
+  function build(...opts) {
+    const props = {};
+    let mark;
+    for (const opt of opts) {
+      if (opt === 'enumStringData') {
+        props.key1 = { enumerable: true, value: 'data' };
+      } else if (opt === 'enumStringFunc') {
+        props.key2 = { enumerable: true, value: () => 0 };
+      } else if (opt === 'enumStringGet') {
+        props.key3 = { enumerable: true, get: () => 0 };
+      } else if (opt === 'enumSymbol') {
+        props[sym] = { enumerable: true, value: 2 };
+      } else if (opt === 'nonenumSymbol') {
+        props[sym] = { enumerable: false, value: 2 };
+      } else if (opt === 'nonenumString') {
+        props.key4 = { enumerable: false, value: 3 };
+      } else if (opt === 'data') {
+        mark = 'data';
+      } else if (opt === 'far') {
+        mark = 'far';
+      } else {
+        throw Error(`unknown option ${opt}`);
+      }
+    }
+    const o = Object.create(Object.prototype, props);
+    // if (mark === 'data') {
+    //   return Data(o);
+    // }
+    if (mark === 'far') {
+      return Far('iface', o);
+    }
+    return harden(o);
+  }
+
+  function shouldThrow(opts, message = /XXX/) {
+    t.throws(() => ser(build(...opts)), { message });
+  }
+  const CSO = /cannot serialize objects/;
+  const NOACC = /Records must not contain accessors/;
+  // this error is accidental, and will go away
+  const SYMSTR = /Cannot convert a Symbol value to a string/;
+  // const REMSYM = /Remotables must not have symbol-named properties/;
+  // const RECSYM = /Records must not have symbol-named properties/;
+  const RECENUM = /Record fields must be enumerable/;
+  // const REMENUM = /Remotable methods must be enumerable/;
+  const NOMETH = /cannot serialize objects with non-methods/;
+
+  // empty objects
+
+  // rejected because it is not hardened
+  t.throws(
+    () => ser({}),
+    { message: /Cannot pass non-frozen objects/ },
+    'non-frozen data cannot be serialized',
+  );
+
+  // harden({})
+  // old: pass-by-ref without complaint
+  // interim1: pass-by-ref with warning
+  // interim2: rejected
+  // final: pass-by-copy without complaint
+  t.deepEqual(ser(build()), noIface); // old+interim1
+  // t.throws(() => ser(harden({})), { message: /??/ }, 'unmarked empty object rejected'); // int2
+  // t.deepEqual(ser(build()), emptyData); // final
+
+  // Data({})
+  // old: not applicable, Data() not yet added
+  // interim1: pass-by-copy without warning
+  // interim2: pass-by-copy without warning
+  // final: not applicable, Data() removed
+  // t.deepEqual(build('data'), emptyData); // interim 1+2
+
+  // Far('iface', {})
+  // all cases: pass-by-ref
+  t.deepEqual(ser(build('far')), yesIface);
+
+  // Far('iface', {key: func})
+  // all cases: pass-by-ref
+  t.deepEqual(ser(build('far', 'enumStringFunc')), yesIface);
+
+  // { key: data }
+  // all: pass-by-copy without warning
+  t.deepEqual(ser(build('enumStringData')), {
+    body: '{"key1":"data"}',
+    slots: [],
+  });
+
+  // { key: func }
+  // old: pass-by-ref without warning
+  // interim1: pass-by-ref with warning
+  // interim2: reject
+  // final: reject
+  t.deepEqual(ser(build('enumStringFunc')), noIface);
+
+  // Data({ key: data, key: func }) : rejected
+  // shouldThrow('data', 'enumStringData', 'enumStringFunc');
+
+  // Far('iface', { key: data, key: func }) : rejected
+  // (some day this might add auxilliary data, but not now
+  shouldThrow(['far', 'enumStringData', 'enumStringFunc'], CSO);
+
+  // anything with getters is rejected
+  shouldThrow(['enumStringGet'], NOACC);
+  shouldThrow(['enumStringGet', 'enumStringData'], NOACC);
+  shouldThrow(['enumStringGet', 'enumStringFunc'], CSO);
+
+  // anything with symbol-named properties is rejected
+  // shouldThrow(['enumSymbol'], REMSYM);
+  shouldThrow(['enumSymbol', 'enumStringData'], SYMSTR);
+  // shouldThrow(['enumSymbol', 'enumStringFunc'], REMSYM);
+
+  // shouldThrow(['nonenumSymbol'], REMSYM);
+  shouldThrow(['nonenumSymbol', 'enumStringData'], SYMSTR);
+  // shouldThrow(['nonenumSymbol', 'enumStringFunc'], REMSYM);
+
+  // anything with non-enumerable properties is rejected
+  shouldThrow(['nonenumString'], RECENUM);
+  shouldThrow(['nonenumString', 'enumStringData'], RECENUM);
+  shouldThrow(['nonenumString', 'enumStringFunc'], NOMETH);
 });


### PR DESCRIPTION
(This PR targets, and builds upon, the 2018-add-tests branch.)

This changes marshal.js to reject symbol-named and unenumerated properties, as I believe was originally intended.

It carves out exceptions for `Symbol.toStringTag` and a non-enumerable `toString`, because `Remotable()` adds those to the prototype of the newly-generated object, and that prototype is subject to the same requirements as pass-by-reference objects in general. I'm not sure why it does it this way, so perhaps we should not carve out these exceptions, and instead change `Remoteable()` somehow. @erights and @michaelfig I'm especially interested in your opinion on this question.

This is in the context of #2018 (handle empty objects better), but so far this is all just prep work. This should not change any behavior observed by sensible user-level code (where "sensible" means "not fooling around with Symbols or `enumerable: false`).

@warner and @erights agreed to reassign this to @erights and to add @warner as a reviewer. However, github doesn't let us add @warner as a reviewer since he originally filed the PR. So noting here that @warner is de facto reviewer.