### PR TITLE
Revert "Add support for post-CI automated benchmarking"

### DIFF
--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -5,7 +5,7 @@ name: Test all Packages
 
 on:
  push:
-   branches: [master, test-post-ci-benchmark-support]
+   branches: [master]
  pull_request:
 
 # set ESM_DISABLE_CACHE=true (will be JSON parsed)


### PR DESCRIPTION
Reverts Agoric/agoric-sdk#1966, as part of debugging ci benchmarks