### PR TITLE
feat: use xsnap worker CPU meter and start reporting consumption

### DIFF
--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -317,10 +317,13 @@ jobs:
       run: cd packages/SwingSet && yarn test
       env:
         ESM_DISABLE_CACHE: true
+    - name: yarn test (xsnap)
+      run: cd packages/xsnap && yarn test
+      env:
+        ESM_DISABLE_CACHE: true
     # explicitly test the XS worker, for visibility
     - name: yarn test (SwingSet XS Worker)
-      working-directory: ./packages/SwingSet
-      run: yarn test:xs-worker
+      run: cd packages/SwingSet && yarn test:xs-worker
       env:
         ESM_DISABLE_CACHE: true
 

--- a/packages/SwingSet/src/kernel/vatManager/types.js
+++ b/packages/SwingSet/src/kernel/vatManager/types.js
@@ -1,0 +1,6 @@
+/**
+ * @typedef { [unknown, ...unknown[]] } Tagged
+ * @typedef { { workerType: string, allocate: number, compute: number } }
+ * CrankStats
+ * @typedef { { reply: Tagged, crankStats: CrankStats } } CrankResults
+ */

--- a/packages/SwingSet/src/kernel/vatManager/types.js
+++ b/packages/SwingSet/src/kernel/vatManager/types.js
@@ -1,6 +1,6 @@
 /**
  * @typedef { [unknown, ...unknown[]] } Tagged
- * @typedef { { workerType: string, allocate: number, compute: number } }
+ * @typedef { { meterType: string, allocate: number|null, compute: number|null } }
  * CrankStats
  * @typedef { { reply: Tagged, crankStats: CrankStats } } CrankResults
  */

--- a/packages/xsnap/makefiles/lin/xsnap.mk
+++ b/packages/xsnap/makefiles/lin/xsnap.mk
@@ -25,6 +25,7 @@ C_OPTIONS = \
 	-fno-common \
 	-DINCLUDE_XSPLATFORM \
 	-DXSPLATFORM=\"xsnap.h\" \
+	-DXSNAP_VERSION=\"$(XSNAP_VERSION)\" \
 	-DmxParse=1 \
 	-DmxRun=1 \
 	-DmxSloppy=1 \

--- a/packages/xsnap/makefiles/lin/xsnap.mk
+++ b/packages/xsnap/makefiles/lin/xsnap.mk
@@ -30,6 +30,7 @@ C_OPTIONS = \
 	-DmxRun=1 \
 	-DmxSloppy=1 \
 	-DmxSnapshot=1 \
+	-DmxMetering=1 \
 	-DmxRegExpUnicodePropertyEscapes=1 \
 	-I$(INC_DIR) \
 	-I$(PLT_DIR) \

--- a/packages/xsnap/makefiles/mac/xsnap.mk
+++ b/packages/xsnap/makefiles/mac/xsnap.mk
@@ -28,6 +28,7 @@ C_OPTIONS = \
 	$(MACOS_VERSION_MIN) \
 	-DINCLUDE_XSPLATFORM \
 	-DXSPLATFORM=\"xsnap.h\" \
+	-DXSNAP_VERSION=\"$(XSNAP_VERSION)\" \
 	-DmxParse=1 \
 	-DmxRun=1 \
 	-DmxSloppy=1 \

--- a/packages/xsnap/makefiles/mac/xsnap.mk
+++ b/packages/xsnap/makefiles/mac/xsnap.mk
@@ -32,6 +32,7 @@ C_OPTIONS = \
 	-DmxRun=1 \
 	-DmxSloppy=1 \
 	-DmxSnapshot=1 \
+	-DmxMetering=1 \
 	-DmxRegExpUnicodePropertyEscapes=1 \
 	-I$(INC_DIR) \
 	-I$(PLT_DIR) \

--- a/packages/xsnap/makefiles/win/xsnap.mak
+++ b/packages/xsnap/makefiles/win/xsnap.mak
@@ -20,6 +20,7 @@ C_OPTIONS = \
 	/D _CRT_SECURE_NO_DEPRECATE \
 	/D INCLUDE_XSPLATFORM \
 	/D XSPLATFORM=\"xsnap.h\" \
+	/D XSNAP_VERSION=\"$(XSNAP_VERSION)\" \
 	/D mxParse=1 \
 	/D mxRun=1 \
 	/D mxSloppy=1 \

--- a/packages/xsnap/makefiles/win/xsnap.mak
+++ b/packages/xsnap/makefiles/win/xsnap.mak
@@ -25,6 +25,7 @@ C_OPTIONS = \
 	/D mxRun=1 \
 	/D mxSloppy=1 \
 	/D mxSnapshot=1 \
+	/D mxMetering=1 \
 	/D mxRegExpUnicodePropertyEscapes=1 \
 	/I$(INC_DIR) \
 	/I$(PLT_DIR) \

--- a/packages/xsnap/src/build.js
+++ b/packages/xsnap/src/build.js
@@ -1,5 +1,5 @@
 import * as childProcess from 'child_process';
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import os from 'os';
 
 function exec(command, cwd, args = []) {
@@ -47,16 +47,20 @@ function exec(command, cwd, args = []) {
     await exec('git', '.', ['submodule', 'update', '--init']);
   }
 
+  const pjson = readFileSync(`${__dirname}/../package.json`, 'utf-8');
+  const pkg = JSON.parse(pjson);
+  const XSNAP_VERSION = `XSNAP_VERSION=${pkg.version}`;
+
   // Run command depending on the OS
   if (os.type() === 'Linux') {
-    await exec('make', 'makefiles/lin');
-    await exec('make', 'makefiles/lin', ['GOAL=debug']);
+    await exec('make', 'makefiles/lin', [XSNAP_VERSION]);
+    await exec('make', 'makefiles/lin', ['GOAL=debug', XSNAP_VERSION]);
   } else if (os.type() === 'Darwin') {
-    await exec('make', 'makefiles/mac');
-    await exec('make', 'makefiles/mac', ['GOAL=debug']);
+    await exec('make', 'makefiles/mac', [XSNAP_VERSION]);
+    await exec('make', 'makefiles/mac', ['GOAL=debug', XSNAP_VERSION]);
   } else if (os.type() === 'Windows_NT') {
-    await exec('nmake', 'makefiles/win');
-    await exec('make', 'makefiles/win', ['GOAL=debug']);
+    await exec('nmake', 'makefiles/win', [XSNAP_VERSION]);
+    await exec('make', 'makefiles/win', ['GOAL=debug', XSNAP_VERSION]);
   } else {
     throw new Error(`Unsupported OS found: ${os.type()}`);
   }

--- a/packages/xsnap/src/netstring.js
+++ b/packages/xsnap/src/netstring.js
@@ -17,7 +17,7 @@ const encoder = new TextEncoder();
  * @param {AsyncIterable<Uint8Array>} input
  * @param {string=} name
  * @param {number=} capacity
- * @returns {AsyncGenerator<Uint8Array>} input
+ * @returns {AsyncGenerator<Uint8Array, Uint8Array, unknown>} input
  */
 export async function* reader(input, name = '<unknown>', capacity = 1024) {
   let length = 0;
@@ -72,6 +72,7 @@ export async function* reader(input, name = '<unknown>', capacity = 1024) {
       `Unexpected dangling message at offset ${offset} of ${name}`,
     );
   }
+  return new Uint8Array(0);
 }
 
 /**

--- a/packages/xsnap/src/xsnap.c
+++ b/packages/xsnap/src/xsnap.c
@@ -3,6 +3,8 @@
 #include "xsSnapshot.h"
 #include "xs.h"
 
+#define XSNAP_VERSION "0.1.0"
+
 extern txScript* fxLoadScript(txMachine* the, txString path, txUnsigned flags);
 
 typedef struct sxAliasIDLink txAliasIDLink;
@@ -68,7 +70,8 @@ static void fxRunLoop(txMachine* the);
 
 static int fxReadNetString(FILE *inStream, char** dest, size_t* len);
 static char* fxReadNetStringError(int code);
-static int fxWriteNetString(FILE* outStream, char prefix, char* buf, size_t len);
+static int fxWriteOkay(FILE* outStream, xsUnsignedValue meterIndex, char* buf, size_t len);
+static int fxWriteNetString(FILE* outStream, char* prefix, char* buf, size_t len);
 static char* fxWriteNetStringError(int code);
 
 // The order of the callbacks materially affects how they are introduced to
@@ -160,21 +163,30 @@ static int fxSnapshotWrite(void* stream, void* address, size_t size)
 	fxPop())
 #define xsMeterHostFunction(_COUNT) \
 	fxMeterHostFunction(the, _COUNT)
+#define xsBeginCrank(_THE, _LIMIT) \
+	((_THE)->meterIndex = 0, \
+	gxCurrentMeter = _LIMIT)
+#define xsEndCrank(_THE) \
+	(gxCurrentMeter = 0, \
+	(_THE)->meterIndex)
 #else
 	#define xsBeginMetering(_THE, _CALLBACK, _STEP)
 	#define xsEndMetering(_THE)
 	#define xsPatchHostFunction(_FUNCTION,_PATCH)
 	#define xsMeterHostFunction(_COUNT)
+  #define xsBeginCrank(_THE, _LIMIT)
+  #define xsEndCrank(_THE) 0
 #endif
 
-static xsUnsignedValue gxMeteringLimit = 0;
+static xsUnsignedValue gxCrankMeteringLimit = 0;
+static xsUnsignedValue gxCurrentMeter = 0;
 static xsBooleanValue fxMeteringCallback(xsMachine* the, xsUnsignedValue index)
 {
-	if (index > gxMeteringLimit) {
-		fprintf(stderr, "too much computation\n");
+	if (gxCurrentMeter > 0 && index > gxCurrentMeter) {
+		// Just throw right out of the main loop and exit.
 		return 0;
 	}
-//	fprintf(stderr, "%d\n", index);
+	// fprintf(stderr, "metering up to %d\n", index);
 	return 1;
 }
 static xsBooleanValue gxMeteringPrint = 0;
@@ -204,7 +216,7 @@ int main(int argc, char* argv[])
 	xsCreation* creation = &_creation;
 
 	txSnapshot snapshot = {
-		"xsnap 0.1.0",
+		"xsnap-" XSNAP_VERSION,
 		11,
 		gxSnapshotCallbacks,
 		mxSnapshotCallbackCount,
@@ -242,7 +254,7 @@ int main(int argc, char* argv[])
 		else if (!strcmp(argv[argi], "-l")) {
 			argi++;
 			if (argi < argc)
-				gxMeteringLimit = atoi(argv[argi]);
+				gxCrankMeteringLimit = atoi(argv[argi]);
 			else {
 				fxPrintUsage();
 				return 1;
@@ -260,14 +272,14 @@ int main(int argc, char* argv[])
 			}
 		}
 		else if (!strcmp(argv[argi], "-v")) {
-			printf("XS %d.%d.%d\n", XS_MAJOR_VERSION, XS_MINOR_VERSION, XS_PATCH_VERSION);
+			printf("xsnap %s (XS %d.%d.%d)\n", XSNAP_VERSION, XS_MAJOR_VERSION, XS_MINOR_VERSION, XS_PATCH_VERSION);
 			return 0;
 		} else {
 			fxPrintUsage();
 			return 1;
 		}
 	}
-	if (gxMeteringLimit) {
+	if (gxCrankMeteringLimit) {
 		if (interval == 0)
 			interval = 1;
 	}
@@ -308,10 +320,15 @@ int main(int argc, char* argv[])
 	{
 		char done = 0;
 		while (!done) {
+			// By default, use the infinite meter.
+      gxCurrentMeter = 0;
+
+			xsUnsignedValue meterIndex = 0;
 			char* nsbuf;
 			size_t nslen;
 			int readError = fxReadNetString(fromParent, &nsbuf, &nslen);
 			int writeError = 0;
+
 			if (readError != 0) {
 				if (feof(fromParent)) {
 					break;
@@ -325,6 +342,7 @@ int main(int argc, char* argv[])
 			switch(command) {
 			case '?':
 			case 'e':
+				xsBeginCrank(machine, gxCrankMeteringLimit);
 				error = 0;
 				xsBeginHost(machine);
 				{
@@ -348,10 +366,11 @@ int main(int argc, char* argv[])
 					}
 				}
 				fxRunLoop(machine);
+				meterIndex = xsEndCrank(machine);
 				{
 					if (error) {
 						xsStringValue message = xsToString(xsVar(1));
-						writeError = fxWriteNetString(toParent, '!', message, strlen(message));
+						writeError = fxWriteNetString(toParent, "!", message, strlen(message));
 						// fprintf(stderr, "error: %d, writeError: %d %s\n", error, writeError, message);
 					} else {
 						char* response = NULL;
@@ -379,7 +398,7 @@ int main(int argc, char* argv[])
 							}
 						}
 						// fprintf(stderr, "response of %d bytes\n", responseLength);
-						writeError = fxWriteNetString(toParent, '.', response, responseLength);
+						writeError = fxWriteOkay(toParent, meterIndex, response, responseLength);
 					}
 				}
 				xsEndHost(machine);
@@ -390,6 +409,7 @@ int main(int argc, char* argv[])
 				break;
 			case 's':
 			case 'm':
+				xsBeginCrank(machine, gxCrankMeteringLimit);
 				path = nsbuf + 1;
 				xsBeginHost(machine);
 				{
@@ -412,15 +432,16 @@ int main(int argc, char* argv[])
 				}
 				xsEndHost(machine);
 				fxRunLoop(machine);
+				meterIndex = xsEndCrank(machine);
 				if (error == 0) {
-					int writeError = fxWriteNetString(toParent, '.', "", 0);
+					int writeError = fxWriteOkay(toParent, meterIndex, "", 0);
 					if (writeError != 0) {
 						fprintf(stderr, "%s\n", fxWriteNetStringError(writeError));
 						c_exit(1);
 					}
 				} else {
 					// TODO: dynamically build error message including Exception message.
-					int writeError = fxWriteNetString(toParent, '!', "", 0);
+					int writeError = fxWriteNetString(toParent, "!", "", 0);
 					if (writeError != 0) {
 						fprintf(stderr, "%s\n", fxWriteNetStringError(writeError));
 						c_exit(1);
@@ -442,14 +463,14 @@ int main(int argc, char* argv[])
 							path, strerror(snapshot.error));
 				}
 				if (snapshot.error == 0) {
-					int writeError = fxWriteNetString(toParent, '.', "", 0);
+					int writeError = fxWriteOkay(toParent, meterIndex, "", 0);
 					if (writeError != 0) {
 						fprintf(stderr, "%s\n", fxWriteNetStringError(writeError));
 						c_exit(1);
 					}
 				} else {
 					// TODO: dynamically build error message including Exception message.
-					int writeError = fxWriteNetString(toParent, '!', "", 0);
+					int writeError = fxWriteNetString(toParent, "!", "", 0);
 					if (writeError != 0) {
 						fprintf(stderr, "%s\n", fxWriteNetStringError(writeError));
 						c_exit(1);
@@ -802,6 +823,11 @@ void fx_Array_prototype_meter(xsMachine* the)
 
 void fxPatchBuiltIns(txMachine* machine)
 {
+  // FIXME: This function is disabled because it caused failures.
+  // https://github.com/Moddable-OpenSource/moddable/issues/550
+
+  // TODO: Provide complete metering of builtins and operators.
+#if 0
 	xsBeginHost(machine);
 	xsVars(2);
 	xsVar(0) = xsGet(xsGlobal, xsID("Array"));
@@ -811,11 +837,12 @@ void fxPatchBuiltIns(txMachine* machine)
 	xsVar(1) = xsGet(xsVar(0), xsID("sort"));
 	xsPatchHostFunction(xsVar(1), fx_Array_prototype_meter);
 	xsEndHost(machine);
+#endif
 }
 
 void fxPrintUsage()
 {
-	printf("xsnap [-h] [-f] [i <interval>] [l <limit] [-m] [-r <snapshot>] [-s] [-v]\n");
+	printf("xsnap [-h] [-f] [-i <interval>] [-l <limit>] [-m] [-r <snapshot>] [-s] [-v]\n");
 	printf("\t-f: freeze the XS machine\n");
 	printf("\t-h: print this help message\n");
 	printf("\t-i <interval>: metering interval (default to 1)\n");
@@ -880,8 +907,8 @@ void fx_clearTimer(txMachine* the)
 {
 	txJob* job = xsGetHostData(xsArg(0));
 	if (job) {
-        xsForget(job->self);
-        xsSetHostData(xsArg(0), NULL);
+		xsForget(job->self);
+		xsSetHostData(xsArg(0), NULL);
 		job->the = NULL;
 	}
 }
@@ -1295,9 +1322,16 @@ static char* fxReadNetStringError(int code)
 	}
 }
 
-static int fxWriteNetString(FILE* outStream, char prefix, char* buf, size_t length)
+static int fxWriteOkay(FILE* outStream, xsUnsignedValue meterIndex, char* buf, size_t length) {
+	char prefix[32];
+	// Prepend the meter usage to the reply.
+	snprintf(prefix, sizeof(prefix) - 1, ".%u;", meterIndex);
+	return fxWriteNetString(outStream, prefix, buf, length);
+}
+
+static int fxWriteNetString(FILE* outStream, char* prefix, char* buf, size_t length)
 {
-	if (fprintf(outStream, "%lu:%c", length + 1, prefix) < 1) {
+	if (fprintf(outStream, "%lu:%s", length + strlen(prefix), prefix) < 1) {
 		return 1;
 	} else if (fwrite(buf, 1, length, outStream) < length) {
 		return 2;
@@ -1337,7 +1371,7 @@ static void fx_issueCommand(xsMachine *the)
 	buf = malloc(length);
 
 	fxGetArrayBufferData(the, arrayBuffer, 0, buf, length);
-	int writeError = fxWriteNetString(toParent, '?', buf, length);
+	int writeError = fxWriteNetString(toParent, "?", buf, length);
 
 	free(buf);
 

--- a/packages/xsnap/src/xsnap.c
+++ b/packages/xsnap/src/xsnap.c
@@ -175,14 +175,14 @@ static int fxSnapshotWrite(void* stream, void* address, size_t size)
 	#define xsBeginMetering(_THE, _CALLBACK, _STEP)
 	#define xsEndMetering(_THE)
 	#define xsPatchHostFunction(_FUNCTION,_PATCH)
-	#define xsMeterHostFunction(_COUNT)
+	#define xsMeterHostFunction(_COUNT) (void)(_COUNT)
   #define xsBeginCrank(_THE, _LIMIT)
   #define xsEndCrank(_THE) 0
 #endif
 
 static xsUnsignedValue gxCrankMeteringLimit = 0;
 static xsUnsignedValue gxCurrentMeter = 0;
-static xsBooleanValue fxMeteringCallback(xsMachine* the, xsUnsignedValue index)
+xsBooleanValue fxMeteringCallback(xsMachine* the, xsUnsignedValue index)
 {
 	if (gxCurrentMeter > 0 && index > gxCurrentMeter) {
 		// Just throw right out of the main loop and exit.
@@ -254,6 +254,7 @@ int main(int argc, char* argv[])
 			}
 		}
 		else if (!strcmp(argv[argi], "-l")) {
+#if mxMetering
 			argi++;
 			if (argi < argc)
 				gxCrankMeteringLimit = atoi(argv[argi]);
@@ -261,6 +262,10 @@ int main(int argc, char* argv[])
 				fxPrintUsage();
 				return 1;
 			}
+#else
+			fprintf(stderr, "%s flag not implemented; mxMetering is not enabled\n", argv[argi]);
+			return 1;
+#endif
 		}
 		else if (!strcmp(argv[argi], "-p"))
 			gxMeteringPrint = 1;

--- a/packages/xsnap/src/xsnap.c
+++ b/packages/xsnap/src/xsnap.c
@@ -3,7 +3,9 @@
 #include "xsSnapshot.h"
 #include "xs.h"
 
-#define XSNAP_VERSION "0.1.0"
+#ifndef XSNAP_VERSION
+# error "You must define XSNAP_VERSION in the right Makefile"
+#endif
 
 extern txScript* fxLoadScript(txMachine* the, txString path, txUnsigned flags);
 

--- a/packages/xsnap/src/xsnap.c
+++ b/packages/xsnap/src/xsnap.c
@@ -3,6 +3,7 @@
 #include "xsSnapshot.h"
 #include "xs.h"
 
+#define SNAPSHOT_SIGNATURE "xsnap 1"
 #ifndef XSNAP_VERSION
 # error "You must define XSNAP_VERSION in the right Makefile"
 #endif
@@ -176,8 +177,8 @@ static int fxSnapshotWrite(void* stream, void* address, size_t size)
 	#define xsEndMetering(_THE)
 	#define xsPatchHostFunction(_FUNCTION,_PATCH)
 	#define xsMeterHostFunction(_COUNT) (void)(_COUNT)
-  #define xsBeginCrank(_THE, _LIMIT)
-  #define xsEndCrank(_THE) 0
+	#define xsBeginCrank(_THE, _LIMIT)
+	#define xsEndCrank(_THE) 0
 #endif
 
 static xsUnsignedValue gxCrankMeteringLimit = 0;
@@ -218,8 +219,8 @@ int main(int argc, char* argv[])
 	xsCreation* creation = &_creation;
 
 	txSnapshot snapshot = {
-		"xsnap-" XSNAP_VERSION,
-		11,
+		SNAPSHOT_SIGNATURE,
+		sizeof(SNAPSHOT_SIGNATURE) - 1,
 		gxSnapshotCallbacks,
 		mxSnapshotCallbackCount,
 		fxSnapshotRead,
@@ -328,7 +329,7 @@ int main(int argc, char* argv[])
 		char done = 0;
 		while (!done) {
 			// By default, use the infinite meter.
-      gxCurrentMeter = 0;
+			gxCurrentMeter = 0;
 
 			xsUnsignedValue meterIndex = 0;
 			char* nsbuf;
@@ -830,10 +831,10 @@ void fx_Array_prototype_meter(xsMachine* the)
 
 void fxPatchBuiltIns(txMachine* machine)
 {
-  // FIXME: This function is disabled because it caused failures.
-  // https://github.com/Moddable-OpenSource/moddable/issues/550
+	// FIXME: This function is disabled because it caused failures.
+	// https://github.com/Moddable-OpenSource/moddable/issues/550
 
-  // TODO: Provide complete metering of builtins and operators.
+	// TODO: Provide complete metering of builtins and operators.
 #if 0
 	xsBeginHost(machine);
 	xsVars(2);
@@ -1332,7 +1333,7 @@ static char* fxReadNetStringError(int code)
 static int fxWriteOkay(FILE* outStream, xsUnsignedValue meterIndex, char* buf, size_t length) {
 	char prefix[32];
 	// Prepend the meter usage to the reply.
-	snprintf(prefix, sizeof(prefix) - 1, ".%u;", meterIndex);
+	snprintf(prefix, sizeof(prefix) - 1, ".%u\1", meterIndex);
 	return fxWriteNetString(outStream, prefix, buf, length);
 }
 

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -166,7 +166,7 @@ export function xsnap(options) {
         let compute = NaN;
         const semi = message.indexOf(SEMI, 1);
         if (semi >= 0) {
-          // The message is `.938586;`.
+          // The message is `.938586;reply`.
           const computeBuf = message.slice(1, semi);
           const computeStr = decoder.decode(computeBuf);
           compute = JSON.parse(computeStr);

--- a/packages/xsnap/src/xsrepl
+++ b/packages/xsnap/src/xsrepl
@@ -1,3 +1,4 @@
 #!/bin/bash
-HERE=$(dirname -- $(readlink -f "$0"))
-node -r esm $HERE/xsrepl.js "@*"
+real0=$(readlink "${BASH_SOURCE[0]}" || echo "${BASH_SOURCE[0]}")
+thisdir=$(cd "$(dirname -- "$real0")" > /dev/null && pwd -P)
+node -r esm "$thisdir/xsrepl.js" "@*"

--- a/packages/xsnap/src/xsrepl.js
+++ b/packages/xsnap/src/xsrepl.js
@@ -17,6 +17,7 @@ async function main() {
   const xsnapOptions = {
     spawn: childProcess.spawn,
     os: os.type(),
+    meteringLimit: 0,
   };
 
   /**

--- a/packages/xsnap/test/test-xsnap.js
+++ b/packages/xsnap/test/test-xsnap.js
@@ -45,6 +45,37 @@ test('evaluate until idle', async t => {
   t.deepEqual(['Hello, World!'], opts.messages);
 });
 
+test('evaluate infinite loop', async t => {
+  const opts = options();
+  const vat = xsnap(opts);
+  await t.throwsAsync(vat.evaluate(`for (;;) {}`), {
+    message: 'xsnap test worker exited',
+    instanceOf: Error,
+  });
+  await vat.close();
+  t.deepEqual([], opts.messages);
+});
+
+// TODO: Reenable when this doesn't take 3.6 seconds.
+test.skip('evaluate promise loop', async t => {
+  const opts = options();
+  const vat = xsnap(opts);
+  await t.throwsAsync(
+    vat.evaluate(`
+    function f() {
+      Promise.resolve().then(f);
+    }
+    f();
+  `),
+    {
+      message: /^xsnap test worker exited; meter was /,
+      instanceOf: Error,
+    },
+  );
+  await vat.close();
+  t.deepEqual([], opts.messages);
+});
+
 test('evaluate and report', async t => {
   const opts = options();
   const vat = xsnap(opts);
@@ -56,7 +87,8 @@ test('evaluate and report', async t => {
     return report;
   })()`);
   await vat.close();
-  t.deepEqual('hi', decoder.decode(result));
+  const { reply } = result;
+  t.deepEqual('hi', decoder.decode(reply));
 });
 
 test('evaluate error', async t => {
@@ -202,9 +234,9 @@ test('receive a response', async t => {
       return ArrayBuffer.fromString(String(number + 1));
     };
   `);
-  t.is('1', await vat.issueStringCommand('0'));
-  t.is('2', await vat.issueStringCommand('1'));
-  t.is('3', await vat.issueStringCommand('2'));
+  t.is('1', (await vat.issueStringCommand('0')).reply);
+  t.is('2', (await vat.issueStringCommand('1')).reply);
+  t.is('3', (await vat.issueStringCommand('2')).reply);
   await vat.close();
 });
 
@@ -261,7 +293,7 @@ function delay(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-test('fail to send command to already-closed xnsap worker', async t => {
+test('fail to send command to already-closed xsnap worker', async t => {
   const vat = xsnap({ ...xsnapOptions });
   await vat.close();
   await vat.evaluate(``).catch(err => {
@@ -269,7 +301,7 @@ test('fail to send command to already-closed xnsap worker', async t => {
   });
 });
 
-test('fail to send command to already-terminated xnsap worker', async t => {
+test('fail to send command to already-terminated xsnap worker', async t => {
   const vat = xsnap({ ...xsnapOptions });
   await vat.terminate();
   await vat.evaluate(``).catch(err => {
@@ -277,30 +309,25 @@ test('fail to send command to already-terminated xnsap worker', async t => {
   });
 });
 
-test('fail to send command to terminated xnsap worker', async t => {
-  const vat = xsnap({ ...xsnapOptions });
-  const hang = vat.evaluate(`for (;;) {}`).then(
-    () => t.fail('command should not complete'),
-    err => {
-      t.is(
-        err.message,
-        'Cannot write messages to xsnap test worker: write EPIPE',
-      );
-    },
-  );
+test('fail to send command to terminated xsnap worker', async t => {
+  const vat = xsnap({ ...xsnapOptions, meteringLimit: 0 });
+  const hang = t.throwsAsync(vat.evaluate(`for (;;) {}`), {
+    instanceOf: Error,
+    message: 'Cannot write messages to xsnap test worker: write EPIPE',
+  });
 
   await vat.terminate();
   await hang;
 });
 
 test('abnormal termination', async t => {
-  const vat = xsnap({ ...xsnapOptions });
-  const hang = vat.evaluate(`for (;;) {}`).then(
-    () => t.fail('command should not complete'),
-    err => {
-      t.is(err.message, 'xsnap test worker exited due to signal SIGTERM');
-    },
-  );
+  const vat = xsnap({ ...xsnapOptions, meteringLimit: 0 });
+  // Wait for xsnap to wake up.
+  await vat.evaluate(``);
+  const hang = t.throwsAsync(vat.evaluate(`for (;;) {}`), {
+    instanceOf: Error,
+    message: 'xsnap test worker exited due to signal SIGTERM',
+  });
 
   // Allow the evaluate command to flush.
   await delay(10);
@@ -309,7 +336,7 @@ test('abnormal termination', async t => {
 });
 
 test('normal close of pathological script', async t => {
-  const vat = xsnap({ ...xsnapOptions });
+  const vat = xsnap({ ...xsnapOptions, meteringLimit: 0 });
   const hang = vat.evaluate(`for (;;) {}`).then(
     () => t.fail('command should not complete'),
     err => {

--- a/packages/xsnap/test/test-xsnap.js
+++ b/packages/xsnap/test/test-xsnap.js
@@ -68,7 +68,7 @@ test.skip('evaluate promise loop', async t => {
     f();
   `),
     {
-      message: /^xsnap test worker exited; meter was /,
+      message: 'xsnap test worker exited',
       instanceOf: Error,
     },
   );
@@ -313,7 +313,7 @@ test('fail to send command to terminated xsnap worker', async t => {
   const vat = xsnap({ ...xsnapOptions, meteringLimit: 0 });
   const hang = t.throwsAsync(vat.evaluate(`for (;;) {}`), {
     instanceOf: Error,
-    message: 'Cannot write messages to xsnap test worker: write EPIPE',
+    message: /^(Cannot write messages to xsnap test worker: write EPIPE|xsnap test worker exited due to signal SIGTERM)$/,
   });
 
   await vat.terminate();
@@ -322,8 +322,6 @@ test('fail to send command to terminated xsnap worker', async t => {
 
 test('abnormal termination', async t => {
   const vat = xsnap({ ...xsnapOptions, meteringLimit: 0 });
-  // Wait for xsnap to wake up.
-  await vat.evaluate(``);
   const hang = t.throwsAsync(vat.evaluate(`for (;;) {}`), {
     instanceOf: Error,
     message: 'xsnap test worker exited due to signal SIGTERM',


### PR DESCRIPTION
Refs #2322

We implement the same basic policy as in the local worker: refill the meter with a constant value (`1e7` computrons) before every crank and terminate the vat if it consumes more than that in a crank.

There is still a long way to go, but at least now we detect and terminate an xsnap vat upon infinite loops.
