### PR TITLE
Add support for automated benchmarking as part of CI

### DIFF
--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -78,6 +78,38 @@ jobs:
     - name: lint check
       run: yarn lint-check
 
+  benchmark:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['14.x']
+    steps:
+    - uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    # BEGIN-RESTORE-BOILERPLATE
+    - name: restore built files
+      id: built
+      uses: actions/cache@v1
+      with:
+        path: .
+        key: ${{ runner.os }}-${{ matrix.node-version }}-built-${{ github.sha }}
+    - uses: actions/checkout@v1
+      with:
+        submodules: 'true'
+      if: steps.built.outputs.cache-hit != 'true'
+    - name: yarn install
+      run: yarn install
+      if: steps.built.outputs.cache-hit != 'true'
+    - name: yarn build
+      run: yarn build
+      if: steps.built.outputs.cache-hit != 'true'
+    # END-RESTORE-BOILERPLATE
+
+    - name: benchmark changes
+      run: cd packages/swingset-runner && yarn ci:autobench
+
 ##################
 # Fast-running tests run as a group:
   test-quick:

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -84,6 +84,7 @@ jobs:
     strategy:
       matrix:
         node-version: ['14.x']
+    if: ${{github.event_name == 'push' && github.ref == 'refs/heads/master'}}
     steps:
     - uses: actions/setup-node@v1
       with:
@@ -109,6 +110,10 @@ jobs:
 
     - name: benchmark changes
       run: cd packages/swingset-runner && yarn ci:autobench
+    - uses: actions/upload-artifact@v2
+      with:
+        name: benchmarkstats.json
+        path: packages/swingset-runner/benchstats.json
 
 ##################
 # Fast-running tests run as a group:

--- a/packages/swingset-runner/autobench
+++ b/packages/swingset-runner/autobench
@@ -1,2 +1,2 @@
 #!/bin/sh
-bin/runner --init --benchmark 100 --statsfile benchstats.json --config demo/exchangeBenchmark/swingset.json run -- --quiet --prime
+node --expose-gc -r esm bin/runner --init --benchmark 100 --statsfile benchstats.json --config demo/exchangeBenchmark/swingset.json run -- --quiet --prime

--- a/packages/swingset-runner/autobench
+++ b/packages/swingset-runner/autobench
@@ -1,0 +1,2 @@
+#!/bin/sh
+bin/runner --init --benchmark 100 --statsfile benchstats.json --config demo/exchangeBenchmark/swingset.json run -- --quiet --prime

--- a/packages/swingset-runner/autobench
+++ b/packages/swingset-runner/autobench
@@ -1,2 +1,3 @@
 #!/bin/sh
+node -r esm demo/exchangeBenchmark/prepareContracts.js
 node --expose-gc -r esm bin/runner --init --benchmark 100 --statsfile benchstats.json --config demo/exchangeBenchmark/swingset.json run -- --quiet --prime

--- a/packages/swingset-runner/demo/exchangeBenchmark/bootstrap.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/bootstrap.js
@@ -13,7 +13,6 @@ export function buildRootObject(_vatPowers, vatParameters) {
   return harden({
     async bootstrap(vats, devices) {
       let primeContracts = false;
-      console.log(`@@ params = ${JSON.stringify(vatParameters)}`);
       for (const arg of vatParameters.argv) {
         if (arg === '--prime') {
           primeContracts = true;

--- a/packages/swingset-runner/demo/exchangeBenchmark/exchanger.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/exchanger.js
@@ -25,14 +25,16 @@ async function build(name, zoe, issuers, payments, publicFacet) {
 
   const invitationIssuer = await E(zoe).getInvitationIssuer();
 
-  async function preReport() {
-    await showPurseBalance(moolaPurseP, `${name} moola before`, log);
-    await showPurseBalance(simoleanPurseP, `${name} simoleans before`, log);
+  async function preReport(quiet) {
+    const useLog = quiet ? () => {} : log;
+    await showPurseBalance(moolaPurseP, `${name} moola before`, useLog);
+    await showPurseBalance(simoleanPurseP, `${name} simoleans before`, useLog);
   }
 
-  async function postReport() {
-    await showPurseBalance(moolaPurseP, `${name} moola after`, log);
-    await showPurseBalance(simoleanPurseP, `${name} simoleans after`, log);
+  async function postReport(quiet) {
+    const useLog = quiet ? () => {} : log;
+    await showPurseBalance(moolaPurseP, `${name} moola after`, useLog);
+    await showPurseBalance(simoleanPurseP, `${name} simoleans after`, useLog);
   }
 
   async function receivePayout(payoutP) {
@@ -44,8 +46,8 @@ async function build(name, zoe, issuers, payments, publicFacet) {
     await E(simoleanPurseP).deposit(simoleanPayout);
   }
 
-  async function initiateTrade(otherP) {
-    await preReport();
+  async function initiateTrade(otherP, quiet) {
+    await preReport(quiet);
 
     const buyOrderInvitation = await E(publicFacet).makeInvitation();
 
@@ -65,14 +67,14 @@ async function build(name, zoe, issuers, payments, publicFacet) {
     const payoutP = E(seat).getPayouts();
 
     const invitationP = E(publicFacet).makeInvitation();
-    await E(otherP).respondToTrade(invitationP);
+    await E(otherP).respondToTrade(invitationP, quiet);
 
     await receivePayout(payoutP);
-    await postReport();
+    await postReport(quiet);
   }
 
-  async function respondToTrade(invitationP) {
-    await preReport();
+  async function respondToTrade(invitationP, quiet) {
+    await preReport(quiet);
 
     const invitation = await invitationP;
     const exclInvitation = await E(invitationIssuer).claim(invitation);
@@ -94,7 +96,7 @@ async function build(name, zoe, issuers, payments, publicFacet) {
     const payoutP = E(seatP).getPayouts();
 
     await receivePayout(payoutP);
-    await postReport();
+    await postReport(quiet);
   }
 
   return harden({

--- a/packages/swingset-runner/demo/exchangeBenchmark/prepareContracts.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/prepareContracts.js
@@ -1,3 +1,4 @@
+import '@agoric/install-ses';
 import bundleSource from '@agoric/bundle-source';
 
 import fs from 'fs';

--- a/packages/swingset-runner/demo/swapBenchmark/prepareContracts.js
+++ b/packages/swingset-runner/demo/swapBenchmark/prepareContracts.js
@@ -1,3 +1,4 @@
+import '@agoric/install-ses';
 import bundleSource from '@agoric/bundle-source';
 
 import fs from 'fs';

--- a/packages/swingset-runner/demo/zoeTests/prepareContracts.js
+++ b/packages/swingset-runner/demo/zoeTests/prepareContracts.js
@@ -1,3 +1,4 @@
+import '@agoric/install-ses';
 import bundleSource from '@agoric/bundle-source';
 
 import fs from 'fs';

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -15,7 +15,8 @@
     "test": "ava",
     "test:nyc": "nyc ava",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint-check": "eslint '**/*.js'"
+    "lint-check": "eslint '**/*.js'",
+    "ci:autobench": "./autobench"
   },
   "dependencies": {
     "@agoric/assert": "^0.2.0",

--- a/packages/swingset-runner/src/kerneldump.js
+++ b/packages/swingset-runner/src/kerneldump.js
@@ -7,7 +7,7 @@ import { openSwingStore as openSimpleSwingStore } from '@agoric/swing-store-simp
 
 import { dumpStore } from './dumpstore';
 import { auditRefCounts } from './auditstore';
-import { printStats } from './printStats';
+import { organizeMainStats, printMainStats } from './printStats';
 
 function usage() {
   console.log(`
@@ -130,9 +130,9 @@ export function main() {
       fail(`invalid database mode ${dbMode}`, true);
   }
   if (justStats) {
-    const stats = JSON.parse(store.storage.get('kernelStats'));
+    const rawStats = JSON.parse(store.storage.get('kernelStats'));
     const cranks = Number(store.storage.get('crankNumber'));
-    printStats(stats, cranks);
+    printMainStats(organizeMainStats(rawStats, cranks));
   } else {
     if (doDump) {
       dumpStore(store.storage, outfile, rawMode);


### PR DESCRIPTION
This PR is a reincarnation of #1966, which got closed (without ever being landed) as a side effect of testing it, because GitHub.  The previous PR was approved by the relevant reviewers but was still lacking some essentials which have now been added.  These additions combined with the passage of time motivate re-review.

This PR adds the beginnings of automated benchmark testing to our CI process.  When changes are merged into the master branch, as part of the associated CI actions a performance benchmark test (minimal at this point, but it's a start) will automatically be run and a stats report published as a GitHub artifact associated with the CI job.

Eventually we will want to enhance this to either collect these artifacts and graph them on a dashboard page somewhere, or to have the report generation script directly submit the data to some kind of external stats collection/monitoring/graphing service.  Either way, automatically running the tests and collecting the results is a prerequisite, so this PR provides the seed for automated tracking of the performance consequences of code changes.