### PR TITLE
fix(xs-worker): restore xs vat manager test to working order

### DIFF
--- a/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
@@ -161,14 +161,14 @@ export function makeXsSubprocessFactory({
       throw new Error(`failed to setBundle: ${bundleReply}`);
     }
 
-    /** @type { (item: Tagged) => Promise<CrankResults> } */
+    /** @type { (item: Tagged) => Promise<Tagged> } */
     async function deliver(delivery) {
       parentLog(vatID, `sending delivery`, delivery);
       transcriptManager.startDispatch(delivery);
       const result = await issueTagged(['deliver', ...delivery]);
       parentLog(vatID, `deliverDone`, result.reply[0], result.reply.length);
       transcriptManager.finishDispatch();
-      return result;
+      return result.reply;
     }
 
     async function replayTranscript() {

--- a/packages/SwingSet/test/workers/test-worker.js
+++ b/packages/SwingSet/test/workers/test-worker.js
@@ -28,7 +28,7 @@ test('local vat manager', async t => {
   t.deepEqual(JSON.parse(c.kpResolution(c.bootstrapResult).body), expected);
 });
 
-test.skip('xs vat manager', async t => {
+test('xs vat manager', async t => {
   const c = await makeController('xs-worker');
   t.teardown(c.shutdown);
 


### PR DESCRIPTION
In 94e007867 on Feb 7, the 'xs vat manager' grew a `test.skip`. (It's
not entirely clear to me why. I can't reproduce the failure as of that
version.) So in 43344ad Feb 10, we didn't notice that xs's deliver now
returns `Promise<CrankResults>` while kernel.js still expects deliver
to return `Promise<Tagged>`.

Taking out the `test.skip` results in...

    TypeError#2: deliveryResult is not iterable

at kernel.js:374 `const [status, problem] = deliveryResult;`

So this changes xs's deliver to just return the .reply part of the
CrankResults. I trust it's more or less by design that the actual
metering part is not being consumed by anything at this point.