### PR TITLE
Use assert with details rather than conditional throws

### DIFF
--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { Far } from '@agoric/marshal';
 import { mustBeComparable } from '@agoric/same-structure';
 
@@ -87,7 +87,7 @@ function makeAmountMath(brand, amountMathKind) {
   const helpers = mathHelpers[amountMathKind];
   assert(
     helpers !== undefined,
-    details`unrecognized amountMathKind: ${amountMathKind}`,
+    X`unrecognized amountMathKind: ${amountMathKind}`,
   );
 
   // Cache the amount if we can.
@@ -126,11 +126,11 @@ function makeAmountMath(brand, amountMathKind) {
       const { brand: allegedBrand, value } = allegedAmount;
       assert(
         allegedBrand !== undefined,
-        details`The brand in allegedAmount ${allegedAmount} is undefined. Did you pass a value rather than an amount?`,
+        X`The brand in allegedAmount ${allegedAmount} is undefined. Did you pass a value rather than an amount?`,
       );
       assert(
         brand === allegedBrand,
-        details`The brand in the allegedAmount ${allegedAmount} in 'coerce' didn't match the amountMath brand ${brand}.`,
+        X`The brand in the allegedAmount ${allegedAmount} in 'coerce' didn't match the amountMath brand ${brand}.`,
       );
       // Will throw on inappropriate value
       return amountMath.make(value);

--- a/packages/ERTP/src/displayInfo.js
+++ b/packages/ERTP/src/displayInfo.js
@@ -1,4 +1,4 @@
-import { assert, details, q } from '@agoric/assert';
+import { assert, details as X, q } from '@agoric/assert';
 import {
   pureCopy,
   passStyleOf,
@@ -21,7 +21,7 @@ export const assertSubset = (whole, part) => {
     assert.typeof(key, 'string');
     assert(
       whole.includes(key),
-      details`key ${q(key)} was not one of the expected keys ${q(whole)}`,
+      X`key ${q(key)} was not one of the expected keys ${q(whole)}`,
     );
   });
 };
@@ -35,7 +35,7 @@ export const assertKeysAllowed = (allowedKeys, record) => {
   // assert that there are no symbol properties.
   assert(
     Object.getOwnPropertySymbols(record).length === 0,
-    details`no symbol properties allowed`,
+    X`no symbol properties allowed`,
   );
 };
 

--- a/packages/ERTP/src/issuer.js
+++ b/packages/ERTP/src/issuer.js
@@ -2,7 +2,7 @@
 
 // @ts-check
 
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { makeExternalStore } from '@agoric/store';
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
@@ -56,10 +56,7 @@ function makeIssuerKit(
   const paymentLedger = makePaymentWeakStore();
 
   function assertKnownPayment(payment) {
-    assert(
-      paymentLedger.has(payment),
-      details`payment not found for ${allegedName}`,
-    );
+    assert(paymentLedger.has(payment), X`payment not found for ${allegedName}`);
   }
 
   // Methods like deposit() have an optional second parameter `amount`
@@ -69,7 +66,7 @@ function makeIssuerKit(
     if (amount !== undefined) {
       assert(
         amountMath.isEqual(amount, paymentBalance),
-        details`payment balance ${paymentBalance} must equal amount ${amount}`,
+        X`payment balance ${paymentBalance} must equal amount ${amount}`,
       );
     }
   };

--- a/packages/ERTP/src/mathHelpers/setMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/setMathHelpers.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { passStyleOf } from '@agoric/marshal';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { sameStructure } from '@agoric/same-structure';
 
 import '../types';
@@ -43,7 +43,7 @@ const checkForDupes = buckets => {
       for (let j = i + 1; j < maybeMatches.length; j += 1) {
         assert(
           !sameStructure(maybeMatches[i], maybeMatches[j]),
-          details`value has duplicates: ${maybeMatches[i]} and ${maybeMatches[j]}`,
+          X`value has duplicates: ${maybeMatches[i]} and ${maybeMatches[j]}`,
         );
       }
     }
@@ -92,7 +92,7 @@ const setMathHelpers = harden({
     right.forEach(rightElem => {
       assert(
         hasElement(leftBuckets, rightElem),
-        details`right element ${rightElem} was not in left`,
+        X`right element ${rightElem} was not in left`,
       );
     });
     const leftElemNotInRight = leftElem => !hasElement(rightBuckets, leftElem);

--- a/packages/ERTP/src/mathHelpers/strSetMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/strSetMathHelpers.js
@@ -1,13 +1,13 @@
 // @ts-check
 
 import { passStyleOf } from '@agoric/marshal';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 
 const identity = harden([]);
 
 const checkForDupes = list => {
   const set = new Set(list);
-  assert(set.size === list.length, details`value has duplicates: ${list}`);
+  assert(set.size === list.length, X`value has duplicates: ${list}`);
 };
 
 /**
@@ -43,10 +43,7 @@ const strSetMathHelpers = harden({
   doAdd: (left, right) => {
     const union = new Set(left);
     const addToUnion = elem => {
-      assert(
-        !union.has(elem),
-        details`left and right have same element ${elem}`,
-      );
+      assert(!union.has(elem), X`left and right have same element ${elem}`);
       union.add(elem);
     };
     right.forEach(addToUnion);
@@ -58,7 +55,7 @@ const strSetMathHelpers = harden({
     const allRemovedCorrectly = right.every(remove);
     assert(
       allRemovedCorrectly,
-      details`some of the elements in right (${right}) were not present in left (${left})`,
+      X`some of the elements in right (${right}) were not present in left (${left})`,
     );
     return harden(Array.from(leftSet));
   },

--- a/packages/ERTP/test/swingsetTests/splitPayments/bootstrap.js
+++ b/packages/ERTP/test/swingsetTests/splitPayments/bootstrap.js
@@ -1,9 +1,10 @@
 import { E } from '@agoric/eventual-send';
+import { assert, details as X } from '@agoric/assert';
 import { makeIssuerKit } from '../../../src';
 
-const { details: X } = assert;
-
 export function buildRootObject(vatPowers, vatParameters) {
+  const arg0 = vatParameters.argv[0];
+
   function testSplitPayments(aliceMaker) {
     vatPowers.testLog('start test splitPayments');
     const { mint: moolaMint, issuer, amountMath } = makeIssuerKit('moola');
@@ -14,15 +15,14 @@ export function buildRootObject(vatPowers, vatParameters) {
   }
 
   const obj0 = {
-    // eslint-disable-next-line consistent-return
     async bootstrap(vats) {
-      switch (vatParameters.argv[0]) {
+      switch (arg0) {
         case 'splitPayments': {
           const aliceMaker = await E(vats.alice).makeAliceMaker();
           return testSplitPayments(aliceMaker);
         }
         default: {
-          assert.fail(X`unrecognized argument value ${vatParameters.argv[0]}`);
+          assert.fail(X`unrecognized argument value ${arg0}`);
         }
       }
     },

--- a/packages/ERTP/test/swingsetTests/splitPayments/bootstrap.js
+++ b/packages/ERTP/test/swingsetTests/splitPayments/bootstrap.js
@@ -1,6 +1,8 @@
 import { E } from '@agoric/eventual-send';
 import { makeIssuerKit } from '../../../src';
 
+const { details: X } = assert;
+
 export function buildRootObject(vatPowers, vatParameters) {
   function testSplitPayments(aliceMaker) {
     vatPowers.testLog('start test splitPayments');
@@ -12,6 +14,7 @@ export function buildRootObject(vatPowers, vatParameters) {
   }
 
   const obj0 = {
+    // eslint-disable-next-line consistent-return
     async bootstrap(vats) {
       switch (vatParameters.argv[0]) {
         case 'splitPayments': {
@@ -19,7 +22,7 @@ export function buildRootObject(vatPowers, vatParameters) {
           return testSplitPayments(aliceMaker);
         }
         default: {
-          throw Error(`unrecognized argument value ${vatParameters.argv[0]}`);
+          assert.fail(X`unrecognized argument value ${vatParameters.argv[0]}`);
         }
       }
     },

--- a/packages/SwingSet/src/assertOptions.js
+++ b/packages/SwingSet/src/assertOptions.js
@@ -1,10 +1,8 @@
-import { assert } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 
 export function assertKnownOptions(options, knownNames) {
   assert(knownNames instanceof Array);
   for (const name of Object.keys(options)) {
-    if (knownNames.indexOf(name) === -1) {
-      throw Error(`unknown option ${name}`);
-    }
+    assert(knownNames.indexOf(name) !== -1, X`unknown option ${name}`);
   }
 }

--- a/packages/SwingSet/src/capdata.js
+++ b/packages/SwingSet/src/capdata.js
@@ -1,4 +1,4 @@
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 
 /* eslint-disable jsdoc/valid-types,jsdoc/require-returns-check */
 /**
@@ -15,11 +15,11 @@ export function insistCapData(capdata) {
   assert.typeof(
     capdata.body,
     'string',
-    details`capdata has non-string .body ${capdata.body}`,
+    X`capdata has non-string .body ${capdata.body}`,
   );
   assert(
     Array.isArray(capdata.slots),
-    details`capdata has non-Array slots ${capdata.slots}`,
+    X`capdata has non-Array slots ${capdata.slots}`,
   );
   // TODO check that the .slots array elements are actually strings
 }

--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -9,7 +9,7 @@ import * as babelParser from '@agoric/babel-parser';
 import babelGenerate from '@babel/generator';
 import anylogger from 'anylogger';
 
-import { assert } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { isTamed, tameMetering } from '@agoric/tame-metering';
 import { importBundle } from '@agoric/import-bundle';
 import { initSwingStore } from '@agoric/swing-store-simple';
@@ -83,7 +83,7 @@ export async function makeSwingsetController(
       // sure vats get (and stick with) re2 for their 'RegExp'.
       return re2;
     } else {
-      throw Error(`kernelRequire unprepared to satisfy require(${what})`);
+      assert.fail(X`kernelRequire unprepared to satisfy require(${what})`);
     }
   }
   const kernelBundle = JSON.parse(hostStorage.get('kernelBundle'));

--- a/packages/SwingSet/src/devices/bridge-src.js
+++ b/packages/SwingSet/src/devices/bridge-src.js
@@ -1,4 +1,4 @@
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 function sanitize(data) {
   // TODO: Use @agoric/marshal:pureCopy when it exists.

--- a/packages/SwingSet/src/devices/bridge-src.js
+++ b/packages/SwingSet/src/devices/bridge-src.js
@@ -1,3 +1,5 @@
+const { details: X } = assert;
+
 function sanitize(data) {
   // TODO: Use @agoric/marshal:pureCopy when it exists.
   if (data === undefined) {
@@ -15,9 +17,7 @@ export function buildRootDeviceNode(tools) {
   let { inboundHandler } = getDeviceState() || {};
 
   function inboundCallback(...args) {
-    if (!inboundHandler) {
-      throw new Error(`inboundHandler not yet registered`);
-    }
+    assert(inboundHandler, X`inboundHandler not yet registered`);
     const safeArgs = JSON.parse(JSON.stringify(args));
     try {
       SO(inboundHandler).inbound(...harden(safeArgs));

--- a/packages/SwingSet/src/devices/command-src.js
+++ b/packages/SwingSet/src/devices/command-src.js
@@ -1,5 +1,7 @@
 import Nat from '@agoric/nat';
 
+const { details: X } = assert;
+
 export function buildRootDeviceNode(tools) {
   const { SO, getDeviceState, setDeviceState, endowments } = tools;
   const {
@@ -20,7 +22,7 @@ export function buildRootDeviceNode(tools) {
       SO(inboundHandler).inbound(Nat(count), body);
     } catch (e) {
       console.error(`error during inboundCallback:`, e);
-      throw new Error(`error during inboundCallback: ${e}`);
+      assert.fail(X`error during inboundCallback: ${e}`);
     }
   });
 

--- a/packages/SwingSet/src/devices/command-src.js
+++ b/packages/SwingSet/src/devices/command-src.js
@@ -1,6 +1,6 @@
 import Nat from '@agoric/nat';
 
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 export function buildRootDeviceNode(tools) {
   const { SO, getDeviceState, setDeviceState, endowments } = tools;

--- a/packages/SwingSet/src/devices/command.js
+++ b/packages/SwingSet/src/devices/command.js
@@ -1,7 +1,7 @@
 import Nat from '@agoric/nat';
 import { makePromiseKit } from '@agoric/promise-kit';
 
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 export default function buildCommand(broadcastCallback) {
   assert(broadcastCallback, X`broadcastCallback must be provided.`);
@@ -46,10 +46,9 @@ export default function buildCommand(broadcastCallback) {
     if (kResponseString !== undefined) {
       obj = JSON.parse(`${kResponseString}`);
     }
-    if (!responses.has(count)) {
-      // maybe just ignore it
-      assert.fail(X`unknown response index ${count}`);
-    }
+    // TODO this might not qualify as an error, it needs more thought
+    // See https://github.com/Agoric/agoric-sdk/pull/2406#discussion_r575561554
+    assert(responses.has(count), X`unknown response index ${count}`);
     const { resolve, reject } = responses.get(count);
     if (isReject) {
       reject(obj);

--- a/packages/SwingSet/src/devices/command.js
+++ b/packages/SwingSet/src/devices/command.js
@@ -1,10 +1,10 @@
 import Nat from '@agoric/nat';
 import { makePromiseKit } from '@agoric/promise-kit';
 
+const { details: X } = assert;
+
 export default function buildCommand(broadcastCallback) {
-  if (!broadcastCallback) {
-    throw new Error(`broadcastCallback must be provided.`);
-  }
+  assert(broadcastCallback, X`broadcastCallback must be provided.`);
   let inboundCallback;
   const srcPath = require.resolve('./command-src');
   let nextCount = 0;
@@ -18,9 +18,7 @@ export default function buildCommand(broadcastCallback) {
     const count = nextCount;
     nextCount += 1;
     responses.set(count, { resolve, reject });
-    if (!inboundCallback) {
-      throw new Error(`inboundCommand before registerInboundCallback`);
-    }
+    assert(inboundCallback, X`inboundCommand before registerInboundCallback`);
     try {
       inboundCallback(count, JSON.stringify(obj));
     } catch (e) {
@@ -35,9 +33,7 @@ export default function buildCommand(broadcastCallback) {
   }
 
   function registerInboundCallback(cb) {
-    if (inboundCallback) {
-      throw new Error(`registerInboundCallback called more than once`);
-    }
+    assert(!inboundCallback, X`registerInboundCallback called more than once`);
     inboundCallback = cb;
   }
 
@@ -52,7 +48,7 @@ export default function buildCommand(broadcastCallback) {
     }
     if (!responses.has(count)) {
       // maybe just ignore it
-      throw new Error(`unknown response index ${count}`);
+      assert.fail(X`unknown response index ${count}`);
     }
     const { resolve, reject } = responses.get(count);
     if (isReject) {

--- a/packages/SwingSet/src/devices/loopbox-src.js
+++ b/packages/SwingSet/src/devices/loopbox-src.js
@@ -1,3 +1,5 @@
+const { details: X } = assert;
+
 export function buildRootDeviceNode(tools) {
   const { SO, endowments } = tools;
   const { registerPassOneMessage, deliverMode } = endowments;
@@ -17,9 +19,7 @@ export function buildRootDeviceNode(tools) {
 
   return harden({
     registerInboundHandler(name, handler) {
-      if (inboundHandlers.has(name)) {
-        throw new Error(`already registered`);
-      }
+      assert(!inboundHandlers.has(name), X`already registered`);
       inboundHandlers.set(name, handler);
     },
 
@@ -27,9 +27,7 @@ export function buildRootDeviceNode(tools) {
       let count = 1;
       return harden({
         add(peer, msgnum, body) {
-          if (!inboundHandlers.has(peer)) {
-            throw new Error(`unregistered peer '${peer}'`);
-          }
+          assert(inboundHandlers.has(peer), X`unregistered peer '${peer}'`);
           const h = inboundHandlers.get(peer);
           if (deliverMode === 'immediate') {
             SO(h).deliverInboundMessages(sender, harden([[count, body]]));

--- a/packages/SwingSet/src/devices/loopbox-src.js
+++ b/packages/SwingSet/src/devices/loopbox-src.js
@@ -1,4 +1,4 @@
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 export function buildRootDeviceNode(tools) {
   const { SO, endowments } = tools;

--- a/packages/SwingSet/src/devices/loopbox.js
+++ b/packages/SwingSet/src/devices/loopbox.js
@@ -1,4 +1,4 @@
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 /*
  * The "loopbox" is a special device used for unit tests, which glues one

--- a/packages/SwingSet/src/devices/loopbox.js
+++ b/packages/SwingSet/src/devices/loopbox.js
@@ -1,3 +1,5 @@
+const { details: X } = assert;
+
 /*
  * The "loopbox" is a special device used for unit tests, which glues one
  * comms+vattp pair to another, within the same swingset machine. It looks
@@ -15,9 +17,10 @@
  */
 
 export function buildLoopbox(deliverMode) {
-  if (deliverMode !== 'immediate' && deliverMode !== 'queued') {
-    throw Error(`deliverMode=${deliverMode}, must be 'immediate' or 'queued'`);
-  }
+  assert(
+    deliverMode === 'immediate' || deliverMode === 'queued',
+    X`deliverMode=${deliverMode}, must be 'immediate' or 'queued'`,
+  );
   const loopboxSrcPath = require.resolve('./loopbox-src');
 
   let loopboxPassOneMessage;

--- a/packages/SwingSet/src/devices/mailbox-src.js
+++ b/packages/SwingSet/src/devices/mailbox-src.js
@@ -1,5 +1,7 @@
 import Nat from '@agoric/nat';
 
+const { details: X } = assert;
+
 export function buildRootDeviceNode(tools) {
   const { SO, getDeviceState, setDeviceState, endowments } = tools;
   const highestInboundDelivered = harden(new Map());
@@ -55,9 +57,10 @@ export function buildRootDeviceNode(tools) {
 
   // console.debug(`mailbox-src build: inboundHandler is`, inboundHandler);
   deliverInboundMessages = (peer, newMessages) => {
-    if (!inboundHandler) {
-      throw new Error(`deliverInboundMessages before registerInboundHandler`);
-    }
+    assert(
+      inboundHandler,
+      X`deliverInboundMessages before registerInboundHandler`,
+    );
     try {
       SO(inboundHandler).deliverInboundMessages(peer, newMessages);
     } catch (e) {
@@ -66,9 +69,7 @@ export function buildRootDeviceNode(tools) {
   };
 
   deliverInboundAck = (peer, ack) => {
-    if (!inboundHandler) {
-      throw new Error(`deliverInboundAck before registerInboundHandler`);
-    }
+    assert(inboundHandler, X`deliverInboundAck before registerInboundHandler`);
     try {
       SO(inboundHandler).deliverInboundAck(peer, ack);
     } catch (e) {
@@ -79,9 +80,7 @@ export function buildRootDeviceNode(tools) {
   // the Root Device Node.
   return harden({
     registerInboundHandler(handler) {
-      if (inboundHandler) {
-        throw new Error(`already registered`);
-      }
+      assert(!inboundHandler, X`already registered`);
       inboundHandler = handler;
       setDeviceState(harden({ inboundHandler }));
     },
@@ -90,7 +89,7 @@ export function buildRootDeviceNode(tools) {
       try {
         endowments.add(`${peer}`, Nat(msgnum), `${body}`);
       } catch (e) {
-        throw new Error(`error in add: ${e}`);
+        assert.fail(X`error in add: ${e}`);
       }
     },
 
@@ -98,7 +97,7 @@ export function buildRootDeviceNode(tools) {
       try {
         endowments.remove(`${peer}`, Nat(msgnum));
       } catch (e) {
-        throw new Error(`error in remove: ${e}`);
+        assert.fail(X`error in remove: ${e}`);
       }
     },
 
@@ -106,7 +105,7 @@ export function buildRootDeviceNode(tools) {
       try {
         endowments.setAcknum(`${peer}`, Nat(msgnum));
       } catch (e) {
-        throw new Error(`error in ackInbound: ${e}`);
+        assert.fail(X`error in ackInbound: ${e}`);
       }
     },
   });

--- a/packages/SwingSet/src/devices/mailbox-src.js
+++ b/packages/SwingSet/src/devices/mailbox-src.js
@@ -1,6 +1,6 @@
 import Nat from '@agoric/nat';
 
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 export function buildRootDeviceNode(tools) {
   const { SO, getDeviceState, setDeviceState, endowments } = tools;

--- a/packages/SwingSet/src/devices/mailbox.js
+++ b/packages/SwingSet/src/devices/mailbox.js
@@ -66,6 +66,8 @@
 
 import Nat from '@agoric/nat';
 
+const { details: X } = assert;
+
 // This Map-based mailboxState object is a good starting point, but we may
 // replace it with one that tracks which parts of the state have been
 // modified, to build more efficient Merkle proofs.
@@ -130,16 +132,14 @@ export function buildMailboxStateMap(state = harden(new Map())) {
   }
 
   function populateFromData(data) {
-    if (state.size) {
-      throw new Error(`cannot populateFromData: outbox is not empty`);
-    }
+    assert(!state.size, X`cannot populateFromData: outbox is not empty`);
     for (const peer of Object.getOwnPropertyNames(data)) {
       const inout = getOrCreatePeer(peer);
-      const d = data[peer];
+      const dp = data[peer];
       importMailbox(
         {
-          ack: d.inboundAck,
-          outbox: d.outbox,
+          ack: dp.inboundAck,
+          outbox: dp.outbox,
         },
         inout,
       );
@@ -185,7 +185,7 @@ export function buildMailbox(state) {
     try {
       return Boolean(inboundCallback(peer, messages, ack));
     } catch (e) {
-      throw new Error(`error in inboundCallback: ${e}`);
+      assert.fail(X`error in inboundCallback: ${e}`);
     }
   }
 

--- a/packages/SwingSet/src/devices/mailbox.js
+++ b/packages/SwingSet/src/devices/mailbox.js
@@ -66,7 +66,7 @@
 
 import Nat from '@agoric/nat';
 
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 // This Map-based mailboxState object is a good starting point, but we may
 // replace it with one that tracks which parts of the state have been
@@ -135,11 +135,11 @@ export function buildMailboxStateMap(state = harden(new Map())) {
     assert(!state.size, X`cannot populateFromData: outbox is not empty`);
     for (const peer of Object.getOwnPropertyNames(data)) {
       const inout = getOrCreatePeer(peer);
-      const dp = data[peer];
+      const d = data[peer];
       importMailbox(
         {
-          ack: dp.inboundAck,
-          outbox: dp.outbox,
+          ack: d.inboundAck,
+          outbox: d.outbox,
         },
         inout,
       );

--- a/packages/SwingSet/src/devices/plugin-src.js
+++ b/packages/SwingSet/src/devices/plugin-src.js
@@ -2,6 +2,8 @@
 
 import { makeCapTP } from '@agoric/captp';
 
+const { details: X } = assert;
+
 export function buildRootDeviceNode(tools) {
   const { SO, getDeviceState, setDeviceState, endowments } = tools;
   const restart = getDeviceState();
@@ -95,9 +97,7 @@ export function buildRootDeviceNode(tools) {
   function send(index, obj) {
     const mod = connectedMods[index];
     // console.info('send', index, obj, mod);
-    if (!mod) {
-      throw TypeError(`No module associated with ${index}`);
-    }
+    assert(mod, X`No module associated with ${index}`, TypeError);
     let sender = senders[index];
     if (!sender) {
       // Lazily create a fresh sender.
@@ -124,9 +124,7 @@ export function buildRootDeviceNode(tools) {
     connect,
     send,
     registerReceiver(receiver) {
-      if (registeredReceiver) {
-        throw Error(`registered receiver already set`);
-      }
+      assert(!registeredReceiver, X`registered receiver already set`);
       registeredReceiver = receiver;
       saveState();
     },

--- a/packages/SwingSet/src/devices/plugin-src.js
+++ b/packages/SwingSet/src/devices/plugin-src.js
@@ -2,7 +2,7 @@
 
 import { makeCapTP } from '@agoric/captp';
 
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 export function buildRootDeviceNode(tools) {
   const { SO, getDeviceState, setDeviceState, endowments } = tools;

--- a/packages/SwingSet/src/devices/timer-src.js
+++ b/packages/SwingSet/src/devices/timer-src.js
@@ -23,7 +23,7 @@
  */
 
 import Nat from '@agoric/nat';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 
 // Since we use harden when saving the state, we need to copy the arrays so they
 // will continue to be mutable. each record inside handlers is immutable, so we
@@ -229,7 +229,7 @@ export function buildRootDeviceNode(tools) {
   function updateTime(time) {
     assert(
       time >= lastPolled,
-      details`Time is monotonic. ${time} cannot be less than ${lastPolled}`,
+      X`Time is monotonic. ${time} cannot be less than ${lastPolled}`,
     );
     lastPolled = time;
     saveState();

--- a/packages/SwingSet/src/devices/timer.js
+++ b/packages/SwingSet/src/devices/timer.js
@@ -1,6 +1,6 @@
 import Nat from '@agoric/nat';
 
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 /**
  * Endowments for a Timer device that can be made available to SwingSet vats.

--- a/packages/SwingSet/src/devices/timer.js
+++ b/packages/SwingSet/src/devices/timer.js
@@ -1,5 +1,7 @@
 import Nat from '@agoric/nat';
 
+const { details: X } = assert;
+
 /**
  * Endowments for a Timer device that can be made available to SwingSet vats.
  *
@@ -23,7 +25,7 @@ export function buildTimer() {
     try {
       return Boolean(devicePollFunction(Nat(time)));
     } catch (e) {
-      throw new Error(`error in devicePollFunction: ${e}`);
+      assert.fail(X`error in devicePollFunction: ${e}`);
     }
   }
 

--- a/packages/SwingSet/src/hostStorage.js
+++ b/packages/SwingSet/src/hostStorage.js
@@ -1,6 +1,6 @@
 import { initSwingStore } from '@agoric/swing-store-simple';
 
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 /*
 The "Storage API" is a set of functions { has, getKeys, get, set, delete } that

--- a/packages/SwingSet/src/hostStorage.js
+++ b/packages/SwingSet/src/hostStorage.js
@@ -1,5 +1,7 @@
 import { initSwingStore } from '@agoric/swing-store-simple';
 
+const { details: X } = assert;
+
 /*
 The "Storage API" is a set of functions { has, getKeys, get, set, delete } that
 work on string keys and accept string values.  A lot of kernel-side code
@@ -97,21 +99,15 @@ export function buildHostDBInMemory(storage) {
     // after earlier changes have actually been applied, potentially leaving
     // the store in an indeterminate state.  Problem?  I suspect so...
     for (const c of changes) {
-      if (`${c.op}` !== c.op) {
-        throw new Error(`non-string c.op ${c.op}`);
-      }
-      if (`${c.key}` !== c.key) {
-        throw new Error(`non-string c.key ${c.key}`);
-      }
+      assert(`${c.op}` === c.op, X`non-string c.op ${c.op}`);
+      assert(`${c.key}` === c.key, X`non-string c.key ${c.key}`);
       if (c.op === 'set') {
-        if (`${c.value}` !== c.value) {
-          throw new Error(`non-string c.value ${c.value}`);
-        }
+        assert(`${c.value}` === c.value, X`non-string c.value ${c.value}`);
         storage.set(c.key, c.value);
       } else if (c.op === 'delete') {
         storage.delete(c.key);
       } else {
-        throw new Error(`unknown c.op ${c.op}`);
+        assert.fail(X`unknown c.op ${c.op}`);
       }
     }
   }

--- a/packages/SwingSet/src/initializeSwingset.js
+++ b/packages/SwingSet/src/initializeSwingset.js
@@ -204,13 +204,11 @@ export function loadSwingsetConfigFile(configPath) {
     normalizeConfigDescriptor(config.vats, dirname, true);
     normalizeConfigDescriptor(config.bundles, dirname, false);
     // normalizeConfigDescriptor(config.devices, dirname, true); // TODO: represent devices
-    if (!config.bootstrap) {
-      assert.fail(X`no designated bootstrap vat in ${configPath}`);
-    } else if (!config.vats[config.bootstrap]) {
-      throw Error(
-        `bootstrap vat ${config.bootstrap} not found in ${configPath}`,
-      );
-    }
+    assert(config.bootstrap, X`no designated bootstrap vat in ${configPath}`);
+    assert(
+      config.vats[config.bootstrap],
+      X`bootstrap vat ${config.bootstrap} not found in ${configPath}`,
+    );
     return config;
   } catch (e) {
     if (e.code === 'ENOENT') {

--- a/packages/SwingSet/src/initializeSwingset.js
+++ b/packages/SwingSet/src/initializeSwingset.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import { assert } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import bundleSource from '@agoric/bundle-source';
 import { initSwingStore } from '@agoric/swing-store-simple';
 
@@ -205,7 +205,7 @@ export function loadSwingsetConfigFile(configPath) {
     normalizeConfigDescriptor(config.bundles, dirname, false);
     // normalizeConfigDescriptor(config.devices, dirname, true); // TODO: represent devices
     if (!config.bootstrap) {
-      throw Error(`no designated bootstrap vat in ${configPath}`);
+      assert.fail(X`no designated bootstrap vat in ${configPath}`);
     } else if (!config.vats[config.bootstrap]) {
       throw Error(
         `bootstrap vat ${config.bootstrap} not found in ${configPath}`,
@@ -233,9 +233,10 @@ export async function initializeSwingset(
 ) {
   insistStorageAPI(hostStorage);
 
-  if (swingsetIsInitialized(hostStorage)) {
-    throw Error(`kernel store already initialized`);
-  }
+  assert(
+    !swingsetIsInitialized(hostStorage),
+    X`kernel store already initialized`,
+  );
 
   // copy config so we can safely mess with it even if it's shared or hardened
   config = JSON.parse(JSON.stringify(config));

--- a/packages/SwingSet/src/kernel/deviceSlots.js
+++ b/packages/SwingSet/src/kernel/deviceSlots.js
@@ -1,5 +1,5 @@
 import { Remotable, mustPassByPresence, makeMarshal } from '@agoric/marshal';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { insistVatType, makeVatSlot, parseVatSlot } from '../parseVatSlots';
 import { insistCapData } from '../capdata';
 
@@ -80,16 +80,16 @@ export function makeDeviceSlots(
     if (!slotToVal.has(slot)) {
       let val;
       const { type, allocatedByVat } = parseVatSlot(slot);
-      assert(!allocatedByVat, details`I don't remember allocating ${slot}`);
+      assert(!allocatedByVat, X`I don't remember allocating ${slot}`);
       if (type === 'object') {
         // this is a new import value
         // lsdebug(`assigning new import ${slot}`);
         val = makePresence(slot, iface);
         // lsdebug(` for presence`, val);
       } else if (type === 'device') {
-        throw Error(`devices should not be given other devices '${slot}'`);
+        assert.fail(X`devices should not be given other devices '${slot}'`);
       } else {
-        throw Error(`unrecognized slot type '${type}'`);
+        assert.fail(X`unrecognized slot type '${type}'`);
       }
       slotToVal.set(slot, val);
       valToSlot.set(val, slot);
@@ -132,9 +132,10 @@ export function makeDeviceSlots(
       throw new Error('SO(SO(x)) is invalid');
     }
     const slot = valToSlot.get(x);
-    if (!slot || parseVatSlot(slot).type !== 'object') {
-      throw new Error(`SO(x) must be called on a Presence, not ${x}`);
-    }
+    assert(
+      slot && parseVatSlot(slot).type === 'object',
+      X`SO(x) must be called on a Presence, not ${x}`,
+    );
     const handler = PresenceHandler(slot);
     const p = harden(new Proxy({}, handler));
     outstandingProxies.add(p);

--- a/packages/SwingSet/src/kernel/deviceSlots.js
+++ b/packages/SwingSet/src/kernel/deviceSlots.js
@@ -128,9 +128,7 @@ export function makeDeviceSlots(
     // since devices don't accept Promises either, SO(x) must be given a
     // presence, not a promise that might resolve to a presence.
 
-    if (outstandingProxies.has(x)) {
-      throw new Error('SO(SO(x)) is invalid');
-    }
+    assert(!outstandingProxies.has(x), X`SO(SO(x)) is invalid`);
     const slot = valToSlot.get(x);
     assert(
       slot && parseVatSlot(slot).type === 'object',

--- a/packages/SwingSet/src/kernel/deviceTranslator.js
+++ b/packages/SwingSet/src/kernel/deviceTranslator.js
@@ -1,4 +1,4 @@
-import { assert } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { insistMessage } from '../message';
 import { insistKernelType } from './parseKernelSlots';
 import { insistVatType, parseVatSlot } from '../parseVatSlots';
@@ -19,7 +19,7 @@ export function makeKDTranslator(deviceID, kernelKeeper) {
     insistCapData(args);
     const targetSlot = mapKernelSlotToDeviceSlot(target);
     const { allocatedByVat } = parseVatSlot(targetSlot);
-    assert(allocatedByVat, `invoke() to someone else's device`);
+    assert(allocatedByVat, X`invoke() to someone else's device`);
     const slots = args.slots.map(slot => mapKernelSlotToDeviceSlot(slot));
     const deviceArgs = { ...args, slots };
     const deviceInvocation = harden([targetSlot, method, deviceArgs]);
@@ -90,7 +90,7 @@ export function makeDSTranslator(deviceID, deviceName, kernelKeeper) {
       case 'sendOnly':
         return translateSendOnly(...args); // becomes ['send' .. result=null]
       default:
-        throw Error(`unknown deviceSyscall type ${type}`);
+        assert.fail(X`unknown deviceSyscall type ${type}`);
     }
   }
 

--- a/packages/SwingSet/src/kernel/id.js
+++ b/packages/SwingSet/src/kernel/id.js
@@ -27,7 +27,7 @@ export function insistVatID(s) {
     assert(s.startsWith(`v`), X`does not start with 'v'`);
     Nat(Number(s.slice(1)));
   } catch (e) {
-    assert.fail(X`'${s} is not a 'vNN'-style VatID: ${e.message}`);
+    assert.fail(X`'${s} is not a 'vNN'-style VatID: ${e}`);
   }
 }
 
@@ -59,7 +59,7 @@ export function insistDeviceID(s) {
     assert(s.startsWith(`d`), X`does not start with 'd'`);
     Nat(Number(s.slice(1)));
   } catch (e) {
-    assert.fail(X`'${s} is not a 'dNN'-style DeviceID: ${e.message}`);
+    assert.fail(X`'${s} is not a 'dNN'-style DeviceID: ${e}`);
   }
 }
 

--- a/packages/SwingSet/src/kernel/id.js
+++ b/packages/SwingSet/src/kernel/id.js
@@ -1,5 +1,7 @@
 import Nat from '@agoric/nat';
 
+const { details: X } = assert;
+
 // Vats are identified by an integer index, which (for typechecking purposes)
 // is encoded as `vNN`. Devices are similarly identified as `dNN`. Both have
 // human-readable names, which are provided to controller.addGenesisVat(),
@@ -21,15 +23,11 @@ import Nat from '@agoric/nat';
  */
 export function insistVatID(s) {
   try {
-    if (s !== `${s}`) {
-      throw new Error(`not a string`);
-    }
-    if (!s.startsWith(`v`)) {
-      throw new Error(`does not start with 'v'`);
-    }
+    assert(s === `${s}`, X`not a string`);
+    assert(s.startsWith(`v`), X`does not start with 'v'`);
     Nat(Number(s.slice(1)));
   } catch (e) {
-    throw new Error(`'${s} is not a 'vNN'-style VatID: ${e.message}`);
+    assert.fail(X`'${s} is not a 'vNN'-style VatID: ${e.message}`);
   }
 }
 
@@ -57,15 +55,11 @@ export function makeVatID(index) {
  */
 export function insistDeviceID(s) {
   try {
-    if (s !== `${s}`) {
-      throw new Error(`not a string`);
-    }
-    if (!s.startsWith(`d`)) {
-      throw new Error(`does not start with 'd'`);
-    }
+    assert(s === `${s}`, X`not a string`);
+    assert(s.startsWith(`d`), X`does not start with 'd'`);
     Nat(Number(s.slice(1)));
   } catch (e) {
-    throw new Error(`'${s} is not a 'dNN'-style DeviceID: ${e.message}`);
+    assert.fail(X`'${s} is not a 'dNN'-style DeviceID: ${e.message}`);
   }
 }
 
@@ -93,9 +87,7 @@ export function makeDeviceID(index) {
  * @throws {Error} if the parameter is not a string or is malformed.
  */
 export function parseVatOrDeviceID(s) {
-  if (s !== `${s}`) {
-    throw new Error(`${s} is not a string, so cannot be a VatID/DeviceID`);
-  }
+  assert(s === `${s}`, X`${s} is not a string, so cannot be a VatID/DeviceID`);
   s = `${s}`;
   let type;
   let idSuffix;
@@ -106,7 +98,7 @@ export function parseVatOrDeviceID(s) {
     type = 'device';
     idSuffix = s.slice(1);
   } else {
-    throw new Error(`'${s}' is neither a VatID nor a DeviceID`);
+    assert.fail(X`'${s}' is neither a VatID nor a DeviceID`);
   }
   return harden({ type, id: Nat(Number(idSuffix)) });
 }

--- a/packages/SwingSet/src/kernel/id.js
+++ b/packages/SwingSet/src/kernel/id.js
@@ -23,7 +23,7 @@ import { assert, details as X } from '@agoric/assert';
  */
 export function insistVatID(s) {
   try {
-    assert(s === `${s}`, X`not a string`);
+    assert.typeof(s, 'string', X`not a string`);
     assert(s.startsWith(`v`), X`does not start with 'v'`);
     Nat(Number(s.slice(1)));
   } catch (e) {
@@ -55,7 +55,7 @@ export function makeVatID(index) {
  */
 export function insistDeviceID(s) {
   try {
-    assert(s === `${s}`, X`not a string`);
+    assert.typeof(s, 'string', X`not a string`);
     assert(s.startsWith(`d`), X`does not start with 'd'`);
     Nat(Number(s.slice(1)));
   } catch (e) {
@@ -87,7 +87,11 @@ export function makeDeviceID(index) {
  * @throws {Error} if the parameter is not a string or is malformed.
  */
 export function parseVatOrDeviceID(s) {
-  assert(s === `${s}`, X`${s} is not a string, so cannot be a VatID/DeviceID`);
+  assert.typeof(
+    s,
+    'string',
+    X`${s} is not a string, so cannot be a VatID/DeviceID`,
+  );
   s = `${s}`;
   let type;
   let idSuffix;

--- a/packages/SwingSet/src/kernel/id.js
+++ b/packages/SwingSet/src/kernel/id.js
@@ -1,6 +1,6 @@
 import Nat from '@agoric/nat';
 
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 // Vats are identified by an integer index, which (for typechecking purposes)
 // is encoded as `vNN`. Devices are similarly identified as `dNN`. Both have

--- a/packages/SwingSet/src/kernel/initializeKernel.js
+++ b/packages/SwingSet/src/kernel/initializeKernel.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-use-before-define */
 
 import { makeMarshal, Far } from '@agoric/marshal';
-import { assert } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { assertKnownOptions } from '../assertOptions';
 import { insistVatID } from './id';
 import { makeVatSlot } from '../parseVatSlots';
@@ -44,12 +44,12 @@ export function initializeKernel(config, hostStorage, verbose = false) {
       logStartup(`adding vat '${name}' from bundle ${bundleName}`);
 
       if (bundle) {
-        if (typeof bundle !== 'object') {
-          throw Error(`bundle is not an object, rather ${bundle}`);
-        }
-      } else if (!bundleName) {
-        throw Error(`no bundle specified for vat ${name}`);
-      }
+        assert.typeof(
+          bundle,
+          'object',
+          X`bundle is not an object, rather ${bundle}`,
+        );
+      } else assert(bundleName, X`no bundle specified for vat ${name}`);
 
       // todo: consider having vats indicate 'enablePipelining' by exporting a
       // boolean, rather than options= . We'd have to retrieve the flag from
@@ -86,9 +86,11 @@ export function initializeKernel(config, hostStorage, verbose = false) {
 
       const bundle =
         config.devices[name].bundle || config.bundles[bundleName].bundle;
-      if (typeof bundle !== 'object') {
-        throw Error(`bundle is not an object, rather ${bundle}`);
-      }
+      assert.typeof(
+        bundle,
+        'object',
+        X`bundle is not an object, rather ${bundle}`,
+      );
       creationOptions.deviceParameters = deviceParameters;
 
       const deviceID = kernelKeeper.allocateDeviceIDForNameIfNeeded(name);
@@ -99,9 +101,7 @@ export function initializeKernel(config, hostStorage, verbose = false) {
         haveAdminDevice = true;
       }
     }
-    if (!haveAdminDevice) {
-      throw Error(`a vat admin device is required`);
-    }
+    assert(haveAdminDevice, X`a vat admin device is required`);
   }
 
   // And enqueue the bootstrap() call. If we're reloading from an

--- a/packages/SwingSet/src/kernel/initializeKernel.js
+++ b/packages/SwingSet/src/kernel/initializeKernel.js
@@ -49,7 +49,9 @@ export function initializeKernel(config, hostStorage, verbose = false) {
           'object',
           X`bundle is not an object, rather ${bundle}`,
         );
-      } else assert(bundleName, X`no bundle specified for vat ${name}`);
+      } else {
+        assert(bundleName, X`no bundle specified for vat ${name}`);
+      }
 
       // todo: consider having vats indicate 'enablePipelining' by exporting a
       // boolean, rather than options= . We'd have to retrieve the flag from

--- a/packages/SwingSet/src/kernel/kdebug.js
+++ b/packages/SwingSet/src/kernel/kdebug.js
@@ -1,3 +1,5 @@
+const { details: X } = assert;
+
 let enableKDebug = false;
 
 export function kdebugEnable(flag) {
@@ -39,7 +41,7 @@ export function legibilizeValue(val, slots) {
         case 'ibid':
           return `ibid(${val.index})`;
         default:
-          throw new Error(`unknown qClass ${qClass} in legibilizeValue`);
+          assert.fail(X`unknown qClass ${qClass} in legibilizeValue`);
       }
     } else {
       let result = '{';

--- a/packages/SwingSet/src/kernel/kdebug.js
+++ b/packages/SwingSet/src/kernel/kdebug.js
@@ -1,4 +1,4 @@
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 let enableKDebug = false;
 

--- a/packages/SwingSet/src/kernel/kernelSyscall.js
+++ b/packages/SwingSet/src/kernel/kernelSyscall.js
@@ -1,4 +1,4 @@
-import { assert } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { insistKernelType, parseKernelSlot } from './parseKernelSlots';
 import { insistMessage } from '../message';
 import { insistCapData } from '../capdata';
@@ -73,9 +73,7 @@ export function makeKernelSyscallHandler(tools) {
     const deviceID = kernelKeeper.ownerOfKernelDevice(deviceSlot);
     insistDeviceID(deviceID);
     const dev = ephemeral.devices.get(deviceID);
-    if (!dev) {
-      throw new Error(`unknown deviceRef ${deviceSlot}`);
-    }
+    assert(dev, X`unknown deviceRef ${deviceSlot}`);
     const ki = harden([deviceSlot, method, args]);
     const di = dev.translators.kernelInvocationToDeviceInvocation(ki);
     const dr = dev.manager.invoke(di);
@@ -176,7 +174,7 @@ export function makeKernelSyscallHandler(tools) {
       case 'vatstoreDelete':
         return vatstoreDelete(...args);
       default:
-        throw Error(`unknown vatSyscall type ${type}`);
+        assert.fail(X`unknown vatSyscall type ${type}`);
     }
   }
 

--- a/packages/SwingSet/src/kernel/loadVat.js
+++ b/packages/SwingSet/src/kernel/loadVat.js
@@ -1,4 +1,4 @@
-import { assert } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { assertKnownOptions } from '../assertOptions';
 import { makeVatSlot } from '../parseVatSlots';
 import { insistCapData } from '../capdata';
@@ -144,9 +144,7 @@ export function makeVatLoader(stuff) {
     assert(source.bundle || source.bundleName, 'broken source');
     const vatSourceBundle =
       source.bundle || kernelKeeper.getBundle(source.bundleName);
-    if (!vatSourceBundle) {
-      throw Error(`Bundle ${source.bundleName} not found`);
-    }
+    assert(vatSourceBundle, X`Bundle ${source.bundleName} not found`);
 
     assertKnownOptions(
       options,
@@ -196,9 +194,11 @@ export function makeVatLoader(stuff) {
     }
 
     async function build() {
-      if (typeof vatSourceBundle !== 'object') {
-        throw Error(`vat creation requires a bundle, not a plain string`);
-      }
+      assert.typeof(
+        vatSourceBundle,
+        'object',
+        X`vat creation requires a bundle, not a plain string`,
+      );
 
       kernelSlog.addVat(vatID, isDynamic, description, name, vatSourceBundle);
       const managerOptions = {

--- a/packages/SwingSet/src/kernel/parseKernelSlots.js
+++ b/packages/SwingSet/src/kernel/parseKernelSlots.js
@@ -1,5 +1,5 @@
 import Nat from '@agoric/nat';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 
 // Object/promise references (in the kernel) contain a two-tuple of (type,
 // index). All object references point to entries in the kernel Object
@@ -37,7 +37,7 @@ export function parseKernelSlot(s) {
     type = 'promise';
     idSuffix = s.slice(2);
   } else {
-    throw new Error(`invalid kernelSlot ${s}`);
+    assert.fail(X`invalid kernelSlot ${s}`);
   }
   const id = Nat(Number(idSuffix));
   return { type, id };
@@ -63,7 +63,7 @@ export function makeKernelSlot(type, id) {
   if (type === 'promise') {
     return `kp${Nat(id)}`;
   }
-  throw new Error(`unknown type ${type}`);
+  assert.fail(X`unknown type ${type}`);
 }
 
 /**
@@ -80,6 +80,6 @@ export function makeKernelSlot(type, id) {
 export function insistKernelType(type, kernelSlot) {
   assert(
     type === parseKernelSlot(kernelSlot).type,
-    details`kernelSlot ${kernelSlot} is not of type ${type}`,
+    X`kernelSlot ${kernelSlot} is not of type ${type}`,
   );
 }

--- a/packages/SwingSet/src/kernel/slogger.js
+++ b/packages/SwingSet/src/kernel/slogger.js
@@ -1,4 +1,4 @@
-import { assert } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 
 const IDLE = 'idle';
 const STARTUP = 'startup';
@@ -28,7 +28,7 @@ export function makeSlogger(writeObj) {
     let syscallNum;
 
     function assertOldState(exp, msg) {
-      assert(state === exp, `vat ${vatID} in ${state}, not ${exp}: ${msg}`);
+      assert(state === exp, X`vat ${vatID} in ${state}, not ${exp}: ${msg}`);
     }
 
     function vatConsole(origConsole) {
@@ -108,7 +108,7 @@ export function makeSlogger(writeObj) {
   }
 
   function addVat(vatID, dynamic, description, name, vatSourceBundle) {
-    assert(!vatSlogs.has(vatID), `already have slog for ${vatID}`);
+    assert(!vatSlogs.has(vatID), X`already have slog for ${vatID}`);
     const vatSlog = makeVatSlog(vatID);
     vatSlogs.set(vatID, vatSlog);
     write({

--- a/packages/SwingSet/src/kernel/state/deviceKeeper.js
+++ b/packages/SwingSet/src/kernel/state/deviceKeeper.js
@@ -3,7 +3,7 @@
  */
 
 import Nat from '@agoric/nat';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { parseKernelSlot } from '../parseKernelSlots';
 import { makeVatSlot, parseVatSlot } from '../../parseVatSlots';
 import { insistDeviceID } from '../id';
@@ -59,7 +59,7 @@ export function makeDeviceKeeper(storage, deviceID, addKernelDeviceNode) {
    *    or is otherwise invalid.
    */
   function mapDeviceSlotToKernelSlot(devSlot) {
-    assert(`${devSlot}` === devSlot, details`non-string devSlot: ${devSlot}`);
+    assert(`${devSlot}` === devSlot, X`non-string devSlot: ${devSlot}`);
     // kdebug(`mapOutbound ${devSlot}`);
     const devKey = `${deviceID}.c.${devSlot}`;
     if (!storage.has(devKey)) {
@@ -68,13 +68,13 @@ export function makeDeviceKeeper(storage, deviceID, addKernelDeviceNode) {
       if (allocatedByVat) {
         let kernelSlot;
         if (type === 'object') {
-          throw new Error(`devices cannot export Objects`);
+          assert.fail(X`devices cannot export Objects`);
         } else if (type === 'promise') {
-          throw new Error(`devices cannot export Promises`);
+          assert.fail(X`devices cannot export Promises`);
         } else if (type === 'device') {
           kernelSlot = addKernelDeviceNode(deviceID);
         } else {
-          throw new Error(`unknown type ${type}`);
+          assert.fail(X`unknown type ${type}`);
         }
         const kernelKey = `${deviceID}.c.${kernelSlot}`;
         storage.set(kernelKey, devSlot);
@@ -82,7 +82,7 @@ export function makeDeviceKeeper(storage, deviceID, addKernelDeviceNode) {
       } else {
         // the vat didn't allocate it, and the kernel didn't allocate it
         // (else it would have been in the c-list), so it must be bogus
-        throw new Error(`unknown devSlot ${devSlot}`);
+        assert.fail(X`unknown devSlot ${devSlot}`);
       }
     }
 
@@ -115,7 +115,7 @@ export function makeDeviceKeeper(storage, deviceID, addKernelDeviceNode) {
       } else if (type === 'promise') {
         throw new Error('devices cannot import Promises');
       } else {
-        throw new Error(`unknown type ${type}`);
+        assert.fail(X`unknown type ${type}`);
       }
       const devSlot = makeVatSlot(type, false, id);
 

--- a/packages/SwingSet/src/kernel/state/deviceKeeper.js
+++ b/packages/SwingSet/src/kernel/state/deviceKeeper.js
@@ -59,7 +59,7 @@ export function makeDeviceKeeper(storage, deviceID, addKernelDeviceNode) {
    *    or is otherwise invalid.
    */
   function mapDeviceSlotToKernelSlot(devSlot) {
-    assert(`${devSlot}` === devSlot, X`non-string devSlot: ${devSlot}`);
+    assert.typeof(devSlot, 'string', X`non-string devSlot: ${devSlot}`);
     // kdebug(`mapOutbound ${devSlot}`);
     const devKey = `${deviceID}.c.${devSlot}`;
     if (!storage.has(devKey)) {
@@ -101,7 +101,7 @@ export function makeDeviceKeeper(storage, deviceID, addKernelDeviceNode) {
    *    devices or is otherwise invalid.
    */
   function mapKernelSlotToDeviceSlot(kernelSlot) {
-    assert(`${kernelSlot}` === kernelSlot, 'non-string kernelSlot');
+    assert.typeof(kernelSlot, 'string', 'non-string kernelSlot');
     const kernelKey = `${deviceID}.c.${kernelSlot}`;
     if (!storage.has(kernelKey)) {
       const { type } = parseKernelSlot(kernelSlot);

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -1,5 +1,5 @@
 import Nat from '@agoric/nat';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X, q } from '@agoric/assert';
 import { initializeVatState, makeVatKeeper } from './vatKeeper';
 import { initializeDeviceState, makeDeviceKeeper } from './deviceKeeper';
 import { insistEnhancedStorageAPI } from '../../storageAPI';
@@ -104,9 +104,7 @@ export default function makeKernelKeeper(storage, kernelSlog) {
   insistEnhancedStorageAPI(storage);
 
   function getRequired(key) {
-    if (!storage.has(key)) {
-      throw new Error(`storage lacks required key ${key}`);
-    }
+    assert(storage.has(key), X`storage lacks required key ${key}`);
     return storage.get(key);
   }
 
@@ -313,7 +311,7 @@ export default function makeKernelKeeper(storage, kernelSlog) {
     const p = { state: storage.get(`${kernelSlot}.state`) };
     switch (p.state) {
       case undefined:
-        throw new Error(`unknown kernelPromise '${kernelSlot}'`);
+        assert.fail(X`unknown kernelPromise '${kernelSlot}'`);
       case 'unresolved':
         p.refCount = Number(storage.get(`${kernelSlot}.refCount`));
         p.decider = storage.get(`${kernelSlot}.decider`);
@@ -348,7 +346,7 @@ export default function makeKernelKeeper(storage, kernelSlog) {
         p.data.slots.map(parseKernelSlot);
         break;
       default:
-        throw new Error(`unknown state for ${kernelSlot}: ${p.state}`);
+        assert.fail(X`unknown state for ${kernelSlot}: ${p.state}`);
     }
     return harden(p);
   }
@@ -359,17 +357,14 @@ export default function makeKernelKeeper(storage, kernelSlog) {
       insistVatID(expectedDecider);
     }
     const p = getKernelPromise(kpid);
-    assert(p.state === 'unresolved', details`${kpid} was already resolved`);
+    assert(p.state === 'unresolved', X`${kpid} was already resolved`);
     if (expectedDecider) {
       assert(
         p.decider === expectedDecider,
-        details`${kpid} is decided by ${p.decider}, not ${expectedDecider}`,
+        X`${kpid} is decided by ${p.decider}, not ${expectedDecider}`,
       );
     } else {
-      assert(
-        !p.decider,
-        details`${kpid} is decided by ${p.decider}, not the kernel`,
-      );
+      assert(!p.decider, X`${kpid} is decided by ${p.decider}, not the kernel`);
     }
     return p;
   }
@@ -407,7 +402,7 @@ export default function makeKernelKeeper(storage, kernelSlog) {
         decStat('kpRejected');
         break;
       default:
-        throw new Error(`unknown state for ${kpid}: ${state}`);
+        assert.fail(X`unknown state for ${kpid}: ${state}`);
     }
     decStat('kernelPromises');
     deleteKernelPromiseState(kpid);
@@ -523,9 +518,10 @@ export default function makeKernelKeeper(storage, kernelSlog) {
     insistKernelType('promise', kernelSlot);
 
     const p = getKernelPromise(kernelSlot);
-    if (p.state !== 'unresolved') {
-      throw new Error(`${kernelSlot} is '${p.state}', not 'unresolved'`);
-    }
+    assert(
+      p.state === 'unresolved',
+      X`${kernelSlot} is '${p.state}', not 'unresolved'`,
+    );
     const nkey = `${kernelSlot}.queue.nextID`;
     const nextID = Nat(Number(storage.get(nkey)));
     storage.set(nkey, `${nextID + 1}`);
@@ -536,14 +532,14 @@ export default function makeKernelKeeper(storage, kernelSlog) {
   function setDecider(kpid, decider) {
     insistVatID(decider);
     const p = getKernelPromise(kpid);
-    assert(p.state === 'unresolved', details`${kpid} was already resolved`);
-    assert(!p.decider, details`${kpid} has decider ${p.decider}, not empty`);
+    assert(p.state === 'unresolved', X`${kpid} was already resolved`);
+    assert(!p.decider, X`${kpid} has decider ${p.decider}, not empty`);
     storage.set(`${kpid}.decider`, decider);
   }
 
   function clearDecider(kpid) {
     const p = getKernelPromise(kpid);
-    assert(p.state === 'unresolved', details`${kpid} was already resolved`);
+    assert(p.state === 'unresolved', X`${kpid} was already resolved`);
     storage.set(`${kpid}.decider`, '');
   }
 
@@ -593,9 +589,7 @@ export default function makeKernelKeeper(storage, kernelSlog) {
   function getVatIDForName(name) {
     assert.typeof(name, 'string');
     const k = `vat.name.${name}`;
-    if (!storage.has(k)) {
-      throw new Error(`vat name ${name} must exist, but doesn't`);
-    }
+    assert(storage.has(k), X`vat name ${q(name)} must exist, but doesn't`);
     return storage.get(k);
   }
 
@@ -682,7 +676,7 @@ export default function makeKernelKeeper(storage, kernelSlog) {
   function decrementRefCount(kernelSlot, tag) {
     if (kernelSlot && parseKernelSlot(kernelSlot).type === 'promise') {
       let refCount = Nat(Number(storage.get(`${kernelSlot}.refCount`)));
-      assert(refCount > 0, details`refCount underflow {kernelSlot} ${tag}`);
+      assert(refCount > 0, X`refCount underflow {kernelSlot} ${tag}`);
       refCount -= 1;
       // kdebug(`-- ${kernelSlot}  ${tag} ${refCount}`);
       storage.set(`${kernelSlot}.refCount`, `${refCount}`);
@@ -726,10 +720,7 @@ export default function makeKernelKeeper(storage, kernelSlog) {
     if (!storage.has(`${vatID}.o.nextID`)) {
       initializeVatState(storage, vatID);
     }
-    assert(
-      !ephemeral.vatKeepers.has(vatID),
-      details`vatID ${vatID} already defined`,
-    );
+    assert(!ephemeral.vatKeepers.has(vatID), X`vatID ${vatID} already defined`);
     const vk = makeVatKeeper(
       storage,
       kernelSlog,
@@ -761,9 +752,7 @@ export default function makeKernelKeeper(storage, kernelSlog) {
   function getDeviceIDForName(name) {
     assert.typeof(name, 'string');
     const k = `device.name.${name}`;
-    if (!storage.has(k)) {
-      throw new Error(`device name ${name} must exist, but doesn't`);
-    }
+    assert(storage.has(k), X`device name ${q(name)} must exist, but doesn't`);
     return storage.get(k);
   }
 

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -1,5 +1,5 @@
 import Nat from '@agoric/nat';
-import { assert, details as X, q } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { initializeVatState, makeVatKeeper } from './vatKeeper';
 import { initializeDeviceState, makeDeviceKeeper } from './deviceKeeper';
 import { insistEnhancedStorageAPI } from '../../storageAPI';
@@ -589,7 +589,7 @@ export default function makeKernelKeeper(storage, kernelSlog) {
   function getVatIDForName(name) {
     assert.typeof(name, 'string');
     const k = `vat.name.${name}`;
-    assert(storage.has(k), X`vat name ${q(name)} must exist, but doesn't`);
+    assert(storage.has(k), X`vat name ${name} must exist, but doesn't`);
     return storage.get(k);
   }
 
@@ -752,7 +752,7 @@ export default function makeKernelKeeper(storage, kernelSlog) {
   function getDeviceIDForName(name) {
     assert.typeof(name, 'string');
     const k = `device.name.${name}`;
-    assert(storage.has(k), X`device name ${q(name)} must exist, but doesn't`);
+    assert(storage.has(k), X`device name ${name} must exist, but doesn't`);
     return storage.get(k);
   }
 

--- a/packages/SwingSet/src/kernel/state/storageWrapper.js
+++ b/packages/SwingSet/src/kernel/state/storageWrapper.js
@@ -1,4 +1,4 @@
-import { assert } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { insistStorageAPI } from '../../storageAPI';
 
 // We manage a host-realm Storage object with a has/getKeys/get/set/del API.
@@ -40,7 +40,7 @@ export function guardStorage(hostStorage) {
       return hostStorage[method](...args);
     } catch (err) {
       console.error(`error invoking hostStorage.${method}(${args})`, err);
-      throw new Error(`error invoking hostStorage.${method}(${args}): ${err}`);
+      assert.fail(X`error invoking hostStorage.${method}(${args}): ${err}`);
     }
   }
 

--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -3,7 +3,7 @@
  */
 
 import Nat from '@agoric/nat';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { parseKernelSlot } from '../parseKernelSlots';
 import { makeVatSlot, parseVatSlot } from '../../parseVatSlots';
 import { insistVatID } from '../id';
@@ -88,7 +88,7 @@ export function makeVatKeeper(
    *    or is otherwise invalid.
    */
   function mapVatSlotToKernelSlot(vatSlot) {
-    assert(`${vatSlot}` === vatSlot, details`non-string vatSlot: ${vatSlot}`);
+    assert(`${vatSlot}` === vatSlot, X`non-string vatSlot: ${vatSlot}`);
     const vatKey = `${vatID}.c.${vatSlot}`;
     if (!storage.has(vatKey)) {
       const { type, allocatedByVat } = parseVatSlot(vatSlot);
@@ -98,11 +98,11 @@ export function makeVatKeeper(
         if (type === 'object') {
           kernelSlot = addKernelObject(vatID);
         } else if (type === 'device') {
-          throw new Error(`normal vats aren't allowed to export device nodes`);
+          assert.fail(X`normal vats aren't allowed to export device nodes`);
         } else if (type === 'promise') {
           kernelSlot = addKernelPromiseForVat(vatID);
         } else {
-          throw new Error(`unknown type ${type}`);
+          assert.fail(X`unknown type ${type}`);
         }
         incrementRefCount(kernelSlot, `${vatID}|vk|clist`);
         const kernelKey = `${vatID}.c.${kernelSlot}`;
@@ -121,7 +121,7 @@ export function makeVatKeeper(
       } else {
         // the vat didn't allocate it, and the kernel didn't allocate it
         // (else it would have been in the c-list), so it must be bogus
-        throw new Error(`unknown vatSlot ${vatSlot}`);
+        assert.fail(X`unknown vatSlot ${vatSlot}`);
       }
     }
 
@@ -156,7 +156,7 @@ export function makeVatKeeper(
         id = Nat(Number(storage.get(`${vatID}.p.nextID`)));
         storage.set(`${vatID}.p.nextID`, `${id + 1}`);
       } else {
-        throw new Error(`unknown type ${type}`);
+        assert.fail(X`unknown type ${type}`);
       }
       incrementRefCount(kernelSlot, `${vatID}[kv|clist`);
       const vatSlot = makeVatSlot(type, false, id);

--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -88,7 +88,7 @@ export function makeVatKeeper(
    *    or is otherwise invalid.
    */
   function mapVatSlotToKernelSlot(vatSlot) {
-    assert(`${vatSlot}` === vatSlot, X`non-string vatSlot: ${vatSlot}`);
+    assert.typeof(vatSlot, 'string', X`non-string vatSlot: ${vatSlot}`);
     const vatKey = `${vatID}.c.${vatSlot}`;
     if (!storage.has(vatKey)) {
       const { type, allocatedByVat } = parseVatSlot(vatSlot);
@@ -140,7 +140,7 @@ export function makeVatKeeper(
    *    or is otherwise invalid.
    */
   function mapKernelSlotToVatSlot(kernelSlot) {
-    assert(`${kernelSlot}` === kernelSlot, 'non-string kernelSlot');
+    assert.typeof(kernelSlot, 'string', 'non-string kernelSlot');
     const kernelKey = `${vatID}.c.${kernelSlot}`;
     if (!storage.has(kernelKey)) {
       const { type } = parseKernelSlot(kernelSlot);

--- a/packages/SwingSet/src/kernel/vatManager/deliver.js
+++ b/packages/SwingSet/src/kernel/vatManager/deliver.js
@@ -1,6 +1,5 @@
+import { assert, details as X } from '@agoric/assert';
 import { insistMessage } from '../../message';
-
-const { details: X } = assert;
 
 export function makeDeliver(tools, dispatch) {
   const {

--- a/packages/SwingSet/src/kernel/vatManager/deliver.js
+++ b/packages/SwingSet/src/kernel/vatManager/deliver.js
@@ -1,5 +1,7 @@
 import { insistMessage } from '../../message';
 
+const { details: X } = assert;
+
 export function makeDeliver(tools, dispatch) {
   const {
     meterRecord,
@@ -107,7 +109,7 @@ export function makeDeliver(tools, dispatch) {
       case 'notify':
         return deliverOneNotification(...args);
       default:
-        throw Error(`unknown delivery type ${type}`);
+        assert.fail(X`unknown delivery type ${type}`);
     }
   }
 

--- a/packages/SwingSet/src/kernel/vatManager/factory.js
+++ b/packages/SwingSet/src/kernel/vatManager/factory.js
@@ -1,4 +1,4 @@
-import { assert } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { assertKnownOptions } from '../../assertOptions';
 import { makeLocalVatManagerFactory } from './manager-local';
 import { makeNodeWorkerVatManagerFactory } from './manager-nodeworker';
@@ -70,7 +70,7 @@ export function makeVatManagerFactory({
       !bundle || typeof bundle === 'object',
       `bundle must be object, not a plain string`,
     );
-    assert(!(setup && !enableSetup), `setup() provided, but not enabled`); // todo maybe useless
+    assert(!setup || enableSetup, X`setup() provided, but not enabled`); // todo maybe useless
   }
 
   // returns promise for new vatManager

--- a/packages/SwingSet/src/kernel/vatManager/factory.js
+++ b/packages/SwingSet/src/kernel/vatManager/factory.js
@@ -70,7 +70,8 @@ export function makeVatManagerFactory({
       !bundle || typeof bundle === 'object',
       `bundle must be object, not a plain string`,
     );
-    assert(!setup || enableSetup, X`setup() provided, but not enabled`); // todo maybe useless
+    // todo maybe useless
+    assert(!(setup && !enableSetup), X`setup() provided, but not enabled`);
   }
 
   // returns promise for new vatManager

--- a/packages/SwingSet/src/kernel/vatManager/manager-local.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-local.js
@@ -1,4 +1,4 @@
-import { assert } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { importBundle } from '@agoric/import-bundle';
 import { makeLiveSlots } from '../liveSlots';
 import { createSyscall } from './syscall';
@@ -72,8 +72,8 @@ export function makeLocalVatManagerFactory(tools) {
   }
 
   function createFromSetup(vatID, setup, managerOptions) {
-    assert(!managerOptions.metered, `unsupported`);
-    assert(!managerOptions.enableInternalMetering, `unsupported`);
+    assert(!managerOptions.metered, X`unsupported`);
+    assert(!managerOptions.enableInternalMetering, X`unsupported`);
     assert(setup instanceof Function, 'setup is not an in-realm function');
     const { syscall, finish } = prepare(vatID, managerOptions);
 
@@ -164,7 +164,7 @@ export function makeLocalVatManagerFactory(tools) {
       dispatch = ls.dispatch;
     } else if (enableSetup) {
       const setup = vatNS.default;
-      assert(setup, `vat source bundle lacks (default) setup() function`);
+      assert(setup, X`vat source bundle lacks (default) setup() function`);
       assert(
         setup instanceof Function,
         `vat source bundle default export is not a function`,
@@ -173,7 +173,7 @@ export function makeLocalVatManagerFactory(tools) {
       const state = null; // TODO remove from setup()
       dispatch = setup(syscall, state, helpers, vatPowers);
     } else {
-      throw Error(`vat source bundle lacks buildRootObject() function`);
+      assert.fail(X`vat source bundle lacks buildRootObject() function`);
     }
 
     const manager = finish(dispatch, meterRecord);

--- a/packages/SwingSet/src/kernel/vatManager/manager-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-nodeworker.js
@@ -1,5 +1,5 @@
 // import { Worker } from 'worker_threads'; // not from a Compartment
-import { assert } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { makePromiseKit } from '@agoric/promise-kit';
 import { makeTranscriptManager } from './transcript';
 
@@ -61,9 +61,10 @@ export function makeNodeWorkerVatManagerFactory(tools) {
       // vat code has moved on (it really wants a synchronous/immediate
       // syscall)
       const type = vatSyscallObject[0];
-      if (type === 'callNow') {
-        throw Error(`nodeWorker cannot block, cannot use syscall.callNow`);
-      }
+      assert(
+        type !== 'callNow',
+        X`nodeWorker cannot block, cannot use syscall.callNow`,
+      );
       // This might throw an Error if the syscall was faulty, in which case
       // the vat will be terminated soon. It returns a vatSyscallResults,
       // which we discard because there is nobody to send it to.
@@ -130,7 +131,7 @@ export function makeNodeWorkerVatManagerFactory(tools) {
 
     function deliver(delivery) {
       parentLog(`sending delivery`, delivery);
-      assert(!waiting, `already waiting for delivery`);
+      assert(!waiting, X`already waiting for delivery`);
       const pr = makePromiseKit();
       waiting = pr.resolve;
       sendToWorker(['deliver', ...delivery]);

--- a/packages/SwingSet/src/kernel/vatManager/manager-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-subprocess-node.js
@@ -1,6 +1,6 @@
 // import { spawn } from 'child_process'; // not from Compartment
 
-import { assert } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { makePromiseKit } from '@agoric/promise-kit';
 import { makeTranscriptManager } from './transcript';
 
@@ -64,9 +64,10 @@ export function makeNodeSubprocessFactory(tools) {
       // by doing a blocking read from the pipe, so we could fix this, and
       // re-enable syscall.callNow
       const type = vatSyscallObject[0];
-      if (type === 'callNow') {
-        throw Error(`nodeWorker cannot block, cannot use syscall.callNow`);
-      }
+      assert(
+        type !== 'callNow',
+        X`nodeWorker cannot block, cannot use syscall.callNow`,
+      );
       // This might throw an Error if the syscall was faulty, in which case
       // the vat will be terminated soon. It returns a vatSyscallResults,
       // which we discard because there is currently nobody to send it to.
@@ -130,7 +131,7 @@ export function makeNodeSubprocessFactory(tools) {
 
     function deliver(delivery) {
       parentLog(`sending delivery`, delivery);
-      assert(!waiting, `already waiting for delivery`);
+      assert(!waiting, X`already waiting for delivery`);
       const pr = makePromiseKit();
       waiting = pr.resolve;
       sendToWorker(['deliver', ...delivery]);

--- a/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
@@ -6,6 +6,8 @@ import { createSyscall } from './syscall';
 import '../../types';
 import './types';
 
+const { details: X } = assert;
+
 // eslint-disable-next-line no-unused-vars
 function parentLog(first, ...args) {
   // console.error(`--parent: ${first}`, ...args);
@@ -115,7 +117,7 @@ export function makeXsSubprocessFactory({
           }
         }
         default:
-          throw new Error(`unrecognized uplink message ${type}`);
+          assert.fail(X`unrecognized uplink message ${type}`);
       }
     }
 
@@ -158,7 +160,7 @@ export function makeXsSubprocessFactory({
     if (bundleReply[0] === 'dispatchReady') {
       parentLog(vatID, `bundle loaded. dispatch ready.`);
     } else {
-      throw new Error(`failed to setBundle: ${bundleReply}`);
+      assert.fail(X`failed to setBundle: ${bundleReply}`);
     }
 
     /** @type { (item: Tagged) => Promise<Tagged> } */

--- a/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
@@ -1,12 +1,10 @@
 // @ts-check
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { makeTranscriptManager } from './transcript';
 import { createSyscall } from './syscall';
 
 import '../../types';
 import './types';
-
-const { details: X } = assert;
 
 // eslint-disable-next-line no-unused-vars
 function parentLog(first, ...args) {
@@ -134,7 +132,7 @@ export function makeXsSubprocessFactory({
       parentLog(vatID, 'eval bundle', it);
       assert(
         superCode.moduleFormat === 'getExport',
-        details`${it} unexpected: ${superCode.moduleFormat}`,
+        X`${it} unexpected: ${superCode.moduleFormat}`,
       );
       await worker.evaluate(`(${superCode.source}\n)()`.trim());
     }

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-nodeworker.js
@@ -4,7 +4,7 @@ import '@agoric/install-ses';
 import { parentPort } from 'worker_threads';
 import anylogger from 'anylogger';
 
-import { assert } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { importBundle } from '@agoric/import-bundle';
 import { Remotable, getInterfaceOf, makeMarshal } from '@agoric/marshal';
 import { WeakRef, FinalizationRegistry } from '../../weakref';
@@ -35,7 +35,7 @@ function runAndWait(f, errmsg) {
 }
 
 function sendUplink(msg) {
-  assert(msg instanceof Array, `msg must be an Array`);
+  assert(msg instanceof Array, X`msg must be an Array`);
   parentPort.postMessage(msg);
 }
 
@@ -83,7 +83,7 @@ parentPort.on('message', ([type, ...margs]) => {
     const syscall = harden({
       send: (...args) => doSyscall(['send', ...args]),
       callNow: (..._args) => {
-        throw Error(`nodeWorker cannot syscall.callNow`);
+        assert.fail(X`nodeWorker cannot syscall.callNow`);
       },
       subscribe: (...args) => doSyscall(['subscribe', ...args]),
       resolve: (...args) => doSyscall(['resolve', ...args]),
@@ -135,7 +135,7 @@ parentPort.on('message', ([type, ...margs]) => {
     } else if (dtype === 'notify') {
       doNotify(...dargs).then(res => sendUplink(['deliverDone', ...res]));
     } else {
-      throw Error(`bad delivery type ${dtype}`);
+      assert.fail(X`bad delivery type ${dtype}`);
     }
   } else {
     workerLog(`unrecognized downlink message ${type}`);

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-node.js
@@ -4,7 +4,7 @@ import '@agoric/install-ses';
 import anylogger from 'anylogger';
 import fs from 'fs';
 
-import { assert } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { importBundle } from '@agoric/import-bundle';
 import { Remotable, getInterfaceOf, makeMarshal } from '@agoric/marshal';
 import { WeakRef, FinalizationRegistry } from '../../weakref';
@@ -75,7 +75,7 @@ const fromParent = fs
   .pipe(arrayDecoderStream());
 
 function sendUplink(msg) {
-  assert(msg instanceof Array, `msg must be an Array`);
+  assert(msg instanceof Array, X`msg must be an Array`);
   toParent.write(msg);
 }
 
@@ -103,7 +103,7 @@ fromParent.on('data', ([type, ...margs]) => {
     const syscall = harden({
       send: (...args) => doSyscall(['send', ...args]),
       callNow: (..._args) => {
-        throw Error(`nodeWorker cannot syscall.callNow`);
+        assert.fail(X`nodeWorker cannot syscall.callNow`);
       },
       subscribe: (...args) => doSyscall(['subscribe', ...args]),
       resolve: (...args) => doSyscall(['resolve', ...args]),
@@ -155,7 +155,7 @@ fromParent.on('data', ([type, ...margs]) => {
     } else if (dtype === 'notify') {
       doNotify(...dargs).then(res => sendUplink(['deliverDone', ...res]));
     } else {
-      throw Error(`bad delivery type ${dtype}`);
+      assert.fail(X`bad delivery type ${dtype}`);
     }
   } else {
     workerLog(`unrecognized downlink message ${type}`);

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
@@ -7,6 +7,8 @@ import { waitUntilQuiescent } from '../../waitUntilQuiescent';
 
 import { makeLiveSlots } from '../liveSlots';
 
+const { details: X } = assert;
+
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
@@ -237,7 +239,7 @@ function makeWorker(port) {
           case 'notify':
             return doNotify(dargs[0]);
           default:
-            throw Error(`bad delivery type ${dtype}`);
+            assert.fail(X`bad delivery type ${dtype}`);
         }
       }
       default:

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
@@ -1,13 +1,11 @@
 // @ts-check
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { importBundle } from '@agoric/import-bundle';
 import { Remotable, getInterfaceOf, makeMarshal } from '@agoric/marshal';
 // grumble... waitUntilQuiescent is exported and closes over ambient authority
 import { waitUntilQuiescent } from '../../waitUntilQuiescent';
 
 import { makeLiveSlots } from '../liveSlots';
-
-const { details: X } = assert;
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -38,8 +36,8 @@ function managerPort(issueCommand) {
   function decode(msg) {
     /** @type { Tagged } */
     const item = decodeData(msg);
-    assert(Array.isArray(item), details`expected array`);
-    assert(item.length > 0, details`empty array lacks tag`);
+    assert(Array.isArray(item), X`expected array`);
+    assert(item.length > 0, X`empty array lacks tag`);
     return item;
   }
 

--- a/packages/SwingSet/src/kernel/vatTranslator.js
+++ b/packages/SwingSet/src/kernel/vatTranslator.js
@@ -1,4 +1,4 @@
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { insistMessage } from '../message';
 import { insistKernelType, parseKernelSlot } from './parseKernelSlots';
 import { insistVatType, parseVatSlot } from '../parseVatSlots';
@@ -31,11 +31,11 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
       const p = kernelKeeper.getKernelPromise(msg.result);
       assert(
         p.state === 'unresolved',
-        details`result ${msg.result} already resolved`,
+        X`result ${msg.result} already resolved`,
       );
       assert(
         !p.decider,
-        details`result ${msg.result} already has decider ${p.decider}`,
+        X`result ${msg.result} already has decider ${p.decider}`,
       );
       resultSlot = vatKeeper.mapKernelSlotToVatSlot(msg.result);
       insistVatType('promise', resultSlot);
@@ -72,7 +72,7 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
       // TODO unimplemented
       throw new Error('not implemented yet');
     } else {
-      throw new Error(`unknown kernelPromise state '${kp.state}'`);
+      assert.fail(X`unknown kernelPromise state '${kp.state}'`);
     }
   }
 
@@ -81,7 +81,7 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
     let idx = 0;
     for (const resolution of kResolutions) {
       const [kpid, p] = resolution;
-      assert(p.state !== 'unresolved', details`spurious notification ${kpid}`);
+      assert(p.state !== 'unresolved', X`spurious notification ${kpid}`);
       const vpid = mapKernelSlotToVatSlot(kpid);
       const vres = translatePromiseDescriptor(p);
       vResolutions.push([vpid, vres]);
@@ -100,7 +100,7 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
       case 'notify':
         return translateNotify(...args);
       default:
-        throw Error(`unknown kernelDelivery.type ${type}`);
+        assert.fail(X`unknown kernelDelivery.type ${type}`);
     }
     // returns ['message', target, msg] or ['notify', resolutions] or null
   }
@@ -138,11 +138,11 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
       const p = kernelKeeper.getKernelPromise(result);
       assert(
         p.state === 'unresolved',
-        details`send() result ${result} is already resolved`,
+        X`send() result ${result} is already resolved`,
       );
       assert(
         p.decider === vatID,
-        details`send() result ${result} is decided by ${p.decider} not ${vatID}`,
+        X`send() result ${result} is decided by ${p.decider} not ${vatID}`,
       );
       kernelKeeper.clearDecider(result);
       // resolution authority now held by run-queue
@@ -194,9 +194,7 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
     insistCapData(args);
     const dev = mapVatSlotToKernelSlot(target);
     const { type } = parseKernelSlot(dev);
-    if (type !== 'device') {
-      throw new Error(`doCallNow must target a device, not ${dev}`);
-    }
+    assert(type === 'device', X`doCallNow must target a device, not ${dev}`);
     for (const slot of args.slots) {
       assert(
         parseVatSlot(slot).type !== 'promise',
@@ -213,9 +211,10 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
   function translateSubscribe(vpid) {
     const kpid = mapVatSlotToKernelSlot(vpid);
     kdebug(`syscall[${vatID}].subscribe(${vpid}/${kpid})`);
-    if (!kernelKeeper.hasKernelPromise(kpid)) {
-      throw new Error(`unknown kernelPromise id '${kpid}'`);
-    }
+    assert(
+      kernelKeeper.hasKernelPromise(kpid),
+      X`unknown kernelPromise id '${kpid}'`,
+    );
     const ks = harden(['subscribe', vatID, kpid]);
     return ks;
   }
@@ -267,7 +266,7 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
       case 'vatstoreDelete':
         return translateVatstoreDelete(...args);
       default:
-        throw Error(`unknown vatSyscall type ${type}`);
+        assert.fail(X`unknown vatSyscall type ${type}`);
     }
   }
 

--- a/packages/SwingSet/src/kernel/vatTranslator.js
+++ b/packages/SwingSet/src/kernel/vatTranslator.js
@@ -117,7 +117,7 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
   const { mapVatSlotToKernelSlot } = vatKeeper;
 
   function translateSend(targetSlot, method, args, resultSlot) {
-    assert(`${targetSlot}` === targetSlot, 'non-string targetSlot');
+    assert.typeof(targetSlot, 'string', 'non-string targetSlot');
     insistCapData(args);
     // TODO: disable send-to-self for now, qv issue #43
     const target = mapVatSlotToKernelSlot(targetSlot);

--- a/packages/SwingSet/src/kernel/virtualObjectManager.js
+++ b/packages/SwingSet/src/kernel/virtualObjectManager.js
@@ -1,4 +1,4 @@
-import { assert, details as d, quote as q } from '@agoric/assert';
+import { assert, details as X, quote as q } from '@agoric/assert';
 import { parseVatSlot } from '../parseVatSlots';
 
 const initializationsInProgress = new WeakSet();
@@ -29,9 +29,10 @@ export function makeCache(size, fetch, store) {
         if (initializationsInProgress.has(lruTail.rawData)) {
           let refreshCount = 1;
           while (initializationsInProgress.has(lruTail.rawData)) {
-            if (refreshCount > size) {
-              throw Error(`cache overflowed with objects being initialized`);
-            }
+            assert(
+              refreshCount <= size,
+              X`cache overflowed with objects being initialized`,
+            );
             cache.refresh(lruTail);
             refreshCount += 1;
           }
@@ -197,7 +198,7 @@ export function makeVirtualObjectManager(
     if (reanimator) {
       return reanimator(vobjID);
     } else {
-      throw Error(`unknown kind ${kindID}`);
+      assert.fail(X`unknown kind ${kindID}`);
     }
   }
 
@@ -230,11 +231,11 @@ export function makeVirtualObjectManager(
     nextWeakStoreID += 1;
 
     function assertKeyDoesNotExist(key) {
-      assert(!backingMap.has(key), d`${q(keyName)} already registered: ${key}`);
+      assert(!backingMap.has(key), X`${q(keyName)} already registered: ${key}`);
     }
 
     function assertKeyExists(key) {
-      assert(backingMap.has(key), d`${q(keyName)} not found: ${key}`);
+      assert(backingMap.has(key), X`${q(keyName)} not found: ${key}`);
     }
 
     function virtualObjectKey(key) {
@@ -265,7 +266,7 @@ export function makeVirtualObjectManager(
         if (vkey) {
           assert(
             !syscall.vatstoreGet(vkey),
-            d`${q(keyName)} already registered: ${key}`,
+            X`${q(keyName)} already registered: ${key}`,
           );
           syscall.vatstoreSet(vkey, JSON.stringify(m.serialize(value)));
         } else {
@@ -277,7 +278,7 @@ export function makeVirtualObjectManager(
         const vkey = virtualObjectKey(key);
         if (vkey) {
           const rawValue = syscall.vatstoreGet(vkey);
-          assert(rawValue, d`${q(keyName)} not found: ${key}`);
+          assert(rawValue, X`${q(keyName)} not found: ${key}`);
           return m.unserialize(JSON.parse(rawValue));
         } else {
           assertKeyExists(key);
@@ -287,7 +288,7 @@ export function makeVirtualObjectManager(
       set(key, value) {
         const vkey = virtualObjectKey(key);
         if (vkey) {
-          assert(syscall.vatstoreGet(vkey), d`${q(keyName)} not found: ${key}`);
+          assert(syscall.vatstoreGet(vkey), X`${q(keyName)} not found: ${key}`);
           syscall.vatstoreSet(vkey, JSON.stringify(m.serialize(harden(value))));
         } else {
           assertKeyExists(key);
@@ -297,7 +298,7 @@ export function makeVirtualObjectManager(
       delete(key) {
         const vkey = virtualObjectKey(key);
         if (vkey) {
-          assert(syscall.vatstoreGet(vkey), d`${q(keyName)} not found: ${key}`);
+          assert(syscall.vatstoreGet(vkey), X`${q(keyName)} not found: ${key}`);
           syscall.vatstoreSet(vkey, undefined);
         } else {
           assertKeyExists(key);

--- a/packages/SwingSet/src/message.js
+++ b/packages/SwingSet/src/message.js
@@ -1,4 +1,4 @@
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { insistCapData } from './capdata';
 
 /**
@@ -18,14 +18,14 @@ export function insistMessage(message) {
   assert.typeof(
     message.method,
     'string',
-    details`message has non-string .method ${message.method}`,
+    X`message has non-string .method ${message.method}`,
   );
   insistCapData(message.args);
   if (message.result) {
     assert.typeof(
       message.result,
       'string',
-      details`message has non-string non-null .result ${message.result}`,
+      X`message has non-string non-null .result ${message.result}`,
     );
   }
 }

--- a/packages/SwingSet/src/netstring.js
+++ b/packages/SwingSet/src/netstring.js
@@ -1,4 +1,4 @@
-import { assert, details as X, q } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 
 // adapted from 'netstring-stream', https://github.com/tlivings/netstring-stream/
 const { Transform } = require('stream');
@@ -51,7 +51,7 @@ export function decode(data) {
     const size = parseInt(sizeString, 10);
     if (!(size > -1)) {
       // reject NaN, all negative numbers
-      assert.fail(X`unparseable size ${q(sizeString)}, should be integer`);
+      assert.fail(X`unparseable size ${sizeString}, should be integer`);
     }
     if (data.length < colon + 1 + size + 1) {
       break; // still waiting for `${DATA}.`

--- a/packages/SwingSet/src/netstring.js
+++ b/packages/SwingSet/src/netstring.js
@@ -1,7 +1,7 @@
+import { assert, details as X, q } from '@agoric/assert';
+
 // adapted from 'netstring-stream', https://github.com/tlivings/netstring-stream/
 const { Transform } = require('stream');
-
-const { details: X, quote: q } = assert;
 
 const COLON = 58;
 const COMMA = 44;

--- a/packages/SwingSet/src/netstring.js
+++ b/packages/SwingSet/src/netstring.js
@@ -1,6 +1,8 @@
 // adapted from 'netstring-stream', https://github.com/tlivings/netstring-stream/
 const { Transform } = require('stream');
 
+const { details: X, quote: q } = assert;
+
 const COLON = 58;
 const COMMA = 44;
 
@@ -49,14 +51,15 @@ export function decode(data) {
     const size = parseInt(sizeString, 10);
     if (!(size > -1)) {
       // reject NaN, all negative numbers
-      throw Error(`unparseable size '${sizeString}', should be integer`);
+      assert.fail(X`unparseable size ${q(sizeString)}, should be integer`);
     }
     if (data.length < colon + 1 + size + 1) {
       break; // still waiting for `${DATA}.`
     }
-    if (data[colon + 1 + size] !== COMMA) {
-      throw Error(`malformed netstring: not terminated by comma`);
-    }
+    assert(
+      data[colon + 1 + size] === COMMA,
+      X`malformed netstring: not terminated by comma`,
+    );
     payloads.push(data.subarray(colon + 1, colon + 1 + size));
     start = colon + 1 + size + 1;
   }

--- a/packages/SwingSet/src/parseVatSlots.js
+++ b/packages/SwingSet/src/parseVatSlots.js
@@ -1,5 +1,5 @@
 import Nat from '@agoric/nat';
-import { assert } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 
 // NOTE: confusing terminology: "slot" vs. "reference".  All these things
 // called "slots" are references, but the word "slot" suggests something into
@@ -48,7 +48,7 @@ export function parseVatSlot(s) {
   } else if (typechar === 'p') {
     type = 'promise';
   } else {
-    throw new Error(`invalid vatSlot ${s}`);
+    assert.fail(X`invalid vatSlot ${s}`);
   }
 
   if (allocchar === '+') {
@@ -56,7 +56,7 @@ export function parseVatSlot(s) {
   } else if (allocchar === '-') {
     allocatedByVat = false;
   } else {
-    throw new Error(`invalid vatSlot ${s}`);
+    assert.fail(X`invalid vatSlot ${s}`);
   }
 
   const delim = idSuffix.indexOf('/');
@@ -64,9 +64,7 @@ export function parseVatSlot(s) {
   let subid;
   let virtual = false;
   if (delim > 0) {
-    if (type !== 'object' || !allocatedByVat) {
-      throw new Error(`invalid vatSlot ${s}`);
-    }
+    assert(type === 'object' && allocatedByVat, X`invalid vatSlot ${s}`);
     virtual = true;
     id = Nat(Number(idSuffix.substr(0, delim)));
     subid = Nat(Number(idSuffix.slice(delim + 1)));
@@ -105,7 +103,7 @@ export function makeVatSlot(type, allocatedByVat, id) {
   if (type === 'promise') {
     return `p${idSuffix}`;
   }
-  throw new Error(`unknown type ${type}`);
+  assert.fail(X`unknown type ${type}`);
 }
 
 /**

--- a/packages/SwingSet/src/storageAPI.js
+++ b/packages/SwingSet/src/storageAPI.js
@@ -1,3 +1,5 @@
+const { details: X } = assert;
+
 /**
  * Assert function to ensure that something expected to be a storage object
  * actually implements the storage API.  It should have methods `has`,
@@ -12,9 +14,7 @@
  */
 export function insistStorageAPI(storage) {
   for (const n of ['has', 'getKeys', 'get', 'set', 'delete']) {
-    if (!(n in storage)) {
-      throw new Error(`storage.${n} is missing, cannot use`);
-    }
+    assert(n in storage, X`storage.${n} is missing, cannot use`);
   }
 }
 
@@ -38,8 +38,6 @@ export function insistEnhancedStorageAPI(storage) {
     'getPrefixedValues',
     'deletePrefixedKeys',
   ]) {
-    if (!(n in storage)) {
-      throw new Error(`storage.${n} is missing, cannot use`);
-    }
+    assert(n in storage, X`storage.${n} is missing, cannot use`);
   }
 }

--- a/packages/SwingSet/src/storageAPI.js
+++ b/packages/SwingSet/src/storageAPI.js
@@ -1,4 +1,4 @@
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 /**
  * Assert function to ensure that something expected to be a storage object

--- a/packages/SwingSet/src/vats/comms/clist-inbound.js
+++ b/packages/SwingSet/src/vats/comms/clist-inbound.js
@@ -1,4 +1,4 @@
-import { assert } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { makeVatSlot } from '../../parseVatSlots';
 import {
   flipRemoteSlot,
@@ -29,7 +29,7 @@ export function makeInbound(state, stateKit) {
   function getLocalForRemote(remoteID, rref) {
     const remote = getRemote(state, remoteID);
     const lref = remote.fromRemote.get(rref);
-    assert(lref, `${rref} must already be in ${rname(remote)}`);
+    assert(lref, X`${rref} must already be in ${rname(remote)}`);
     return lref;
   }
 
@@ -81,7 +81,7 @@ export function makeInbound(state, stateKit) {
       } else if (type === 'promise') {
         addLocalPromiseForRemote(remote, rref);
       } else {
-        throw Error(`cannot accept type ${type} from remote`);
+        assert.fail(X`cannot accept type ${type} from remote`);
       }
     }
     return remote.fromRemote.get(rref);

--- a/packages/SwingSet/src/vats/comms/clist-kernel.js
+++ b/packages/SwingSet/src/vats/comms/clist-kernel.js
@@ -1,4 +1,4 @@
-import { assert } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { parseVatSlot } from '../../parseVatSlots';
 
 export function makeKernel(state, syscall, stateKit) {
@@ -45,7 +45,7 @@ export function makeKernel(state, syscall, stateKit) {
       // receipt of a remote promise, and p-NN is added upon receipt of a
       // kernel promise. We retain the promiseTable entry even after the
       // promise is retired (to remember the resolution).
-      assert(p, `how did I forget about ${vpid}`);
+      assert(p, X`how did I forget about ${vpid}`);
 
       if (p.kernelAwaitingResolve) {
         return vpid;
@@ -78,7 +78,7 @@ export function makeKernel(state, syscall, stateKit) {
       }
       return vpid;
     }
-    throw Error(`cannot give type ${type} to kernel`);
+    assert.fail(X`cannot give type ${type} to kernel`);
   }
 
   function provideKernelForLocalResult(vpid) {
@@ -86,7 +86,7 @@ export function makeKernel(state, syscall, stateKit) {
       return null;
     }
     const p = state.promiseTable.get(vpid);
-    assert(!p.resolved, `result ${vpid} is already resolved`);
+    assert(!p.resolved, X`result ${vpid} is already resolved`);
     // TODO: reject somehow rather than crashing weirdly if we are not
     // already the decider, but I'm not sure how we could hit that case.
     changeDeciderToKernel(vpid);
@@ -103,7 +103,7 @@ export function makeKernel(state, syscall, stateKit) {
     if (type !== 'object' && type !== 'promise') {
       // TODO: reject the message rather than crashing weirdly, we
       // can't prevent vats from attempting this
-      throw Error(`cannot accept type ${type} from kernel`);
+      assert.fail(X`cannot accept type ${type} from kernel`);
     }
     if (type === 'object') {
       if (allocatedByVat) {
@@ -124,7 +124,7 @@ export function makeKernel(state, syscall, stateKit) {
         if (p) {
           // hey, we agreed to never speak of the resolved VPID again. maybe
           // the kernel is recycling p-NN VPIDs, or is just confused
-          assert(!p.resolved, `kernel sent retired ${vpid}`);
+          assert(!p.resolved, X`kernel sent retired ${vpid}`);
         } else {
           // the kernel is telling us about a new promise, so it's the decider
           trackUnresolvedPromise(vpid);
@@ -149,12 +149,12 @@ export function makeKernel(state, syscall, stateKit) {
     // we know to be resolved. We agreed to never speak of the resolved VPID
     // again. maybe the kernel is recycling p-NN VPIDs, or is just confused
     if (p) {
-      assert(!p.resolved, `kernel sent retired ${vpid}`);
+      assert(!p.resolved, X`kernel sent retired ${vpid}`);
     }
 
     // if we're supposed to have allocated the number, we better recognize it
     if (allocatedByVat) {
-      assert(p, `I don't remember giving ${vpid} to the kernel`);
+      assert(p, X`I don't remember giving ${vpid} to the kernel`);
     }
 
     if (p) {

--- a/packages/SwingSet/src/vats/comms/clist-outbound.js
+++ b/packages/SwingSet/src/vats/comms/clist-outbound.js
@@ -1,4 +1,4 @@
-import { assert } from '@agoric/assert';
+import { assert, details as X, q } from '@agoric/assert';
 import { parseVatSlot, insistVatType } from '../../parseVatSlots';
 import {
   flipRemoteSlot,
@@ -28,7 +28,7 @@ export function makeOutbound(state, stateKit) {
   function getRemoteForLocal(remoteID, lref) {
     const remote = getRemote(state, remoteID);
     const rref = remote.toRemote.get(lref);
-    assert(rref, `${lref} must already be in ${rname(remote)}`);
+    assert(rref, X`${lref} must already be in ${rname(remote)}`);
     return rref;
   }
 
@@ -44,7 +44,10 @@ export function makeOutbound(state, stateKit) {
       const owner = state.objectTable.get(vatoid);
       // make sure it's not a local object (like one of the receivers): those
       // aren't supposed to be sent off-device
-      assert(owner, `sending non-remote object ${vatoid} to remote machine`);
+      assert(
+        owner,
+        X`sending non-remote object ${q(vatoid)} to remote machine`,
+      );
       assert(
         owner !== remote,
         `hey ${vatoid} already came from ${rname(remote)}`,
@@ -65,7 +68,7 @@ export function makeOutbound(state, stateKit) {
 
   function addRemotePromiseForLocal(remote, vpid) {
     const p = state.promiseTable.get(vpid);
-    assert(p, `promise ${vpid} wasn't being tracked`);
+    assert(p, X`promise ${vpid} wasn't being tracked`);
 
     const index = remote.nextPromiseIndex;
     remote.nextPromiseIndex += 1;
@@ -98,7 +101,7 @@ export function makeOutbound(state, stateKit) {
       } else if (type === 'promise') {
         addRemotePromiseForLocal(remote, lref);
       } else {
-        throw Error(`cannot send type ${type} to remote`);
+        assert.fail(X`cannot send type ${type} to remote`);
       }
     }
     return remote.toRemote.get(lref);

--- a/packages/SwingSet/src/vats/comms/clist-xgress.js
+++ b/packages/SwingSet/src/vats/comms/clist-xgress.js
@@ -1,5 +1,5 @@
 import Nat from '@agoric/nat';
-import { assert } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { parseVatSlot, insistVatType } from '../../parseVatSlots';
 import { flipRemoteSlot, makeRemoteSlot } from './parseRemoteSlot';
 import { getRemote } from './remote';
@@ -14,13 +14,13 @@ export function makeIngressEgress(state, provideLocalForRemote) {
     Nat(remoteRefID);
     insistVatType('object', vatoid);
     const { allocatedByVat } = parseVatSlot(vatoid);
-    assert(!allocatedByVat, `vatoid should be kernel-allocated`);
-    assert(!remote.toRemote.has(vatoid), `already present ${vatoid}`);
+    assert(!allocatedByVat, X`vatoid should be kernel-allocated`);
+    assert(!remote.toRemote.has(vatoid), X`already present ${vatoid}`);
 
     const inboundRRef = makeRemoteSlot('object', true, remoteRefID);
     const outboundRRef = flipRemoteSlot(inboundRRef);
-    assert(!remote.fromRemote.has(inboundRRef), `already have ${inboundRRef}`);
-    assert(!remote.toRemote.has(outboundRRef), `already have ${outboundRRef}`);
+    assert(!remote.fromRemote.has(inboundRRef), X`already have ${inboundRRef}`);
+    assert(!remote.toRemote.has(outboundRRef), X`already have ${outboundRRef}`);
     remote.fromRemote.set(inboundRRef, vatoid);
     remote.toRemote.set(vatoid, outboundRRef);
     if (remote.nextObjectIndex <= remoteRefID) {

--- a/packages/SwingSet/src/vats/comms/controller.js
+++ b/packages/SwingSet/src/vats/comms/controller.js
@@ -1,5 +1,5 @@
 import Nat from '@agoric/nat';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { addRemote } from './remote';
 
 const UNDEFINED = harden({
@@ -39,13 +39,15 @@ export function deliverToController(
     const { slots } = controllerArgs;
 
     const name = args[0];
-    assert.typeof(name, 'string', details`bad addRemote name ${name}`);
-    if (args[1]['@qclass'] !== 'slot' || args[1].index !== 0) {
-      throw new Error(`unexpected args for addRemote(): ${controllerArgs}`);
-    }
-    if (args[2]['@qclass'] !== 'slot' || args[2].index !== 1) {
-      throw new Error(`unexpected args for addRemote(): ${controllerArgs}`);
-    }
+    assert.typeof(name, 'string', X`bad addRemote name ${name}`);
+    assert(
+      args[1]['@qclass'] === 'slot' && args[1].index === 0,
+      X`unexpected args for addRemote(): ${controllerArgs}`,
+    );
+    assert(
+      args[2]['@qclass'] === 'slot' && args[2].index === 1,
+      X`unexpected args for addRemote(): ${controllerArgs}`,
+    );
     const transmitterID = slots[args[1].index];
     const setReceiverID = slots[args[2].index];
 
@@ -69,15 +71,13 @@ export function deliverToController(
     const { slots } = controllerArgs;
 
     const remoteName = args[0];
-    assert(
-      state.names.has(remoteName),
-      details`unknown remote name ${remoteName}`,
-    );
+    assert(state.names.has(remoteName), X`unknown remote name ${remoteName}`);
     const remoteID = state.names.get(remoteName);
     const remoteRefID = Nat(args[1]);
-    if (args[2]['@qclass'] !== 'slot' || args[2].index !== 0) {
-      throw new Error(`unexpected args for addEgress(): ${controllerArgs}`);
-    }
+    assert(
+      args[2]['@qclass'] === 'slot' && args[2].index === 0,
+      X`unexpected args for addEgress(): ${controllerArgs}`,
+    );
     const localRef = slots[args[2].index];
     addEgress(remoteID, remoteRefID, localRef);
     syscall.resolve([[result, false, UNDEFINED]]);
@@ -88,10 +88,7 @@ export function deliverToController(
     const args = JSON.parse(controllerArgs.body);
 
     const remoteName = args[0];
-    assert(
-      state.names.has(remoteName),
-      details`unknown remote name ${remoteName}`,
-    );
+    assert(state.names.has(remoteName), X`unknown remote name ${remoteName}`);
     const remoteID = state.names.get(remoteName);
     const remoteRefID = Nat(args[1]);
     const localRef = addIngress(remoteID, remoteRefID);
@@ -110,6 +107,6 @@ export function deliverToController(
     case 'addIngress':
       return doAddIngress();
     default:
-      throw new Error(`method ${method} is not available`);
+      assert.fail(X`method ${method} is not available`);
   }
 }

--- a/packages/SwingSet/src/vats/comms/delivery.js
+++ b/packages/SwingSet/src/vats/comms/delivery.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-use-before-define */
 
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { insistVatType, parseVatSlot } from '../../parseVatSlots';
 import { makeUndeliverableError } from '../../makeUndeliverableError';
 import { insistCapData } from '../../capdata';
@@ -114,13 +114,13 @@ export function makeDeliveryKit(state, syscall, transmit, clistKit, stateKit) {
     if (command === 'resolve') {
       return resolveFromRemote(remoteID, message);
     }
-    throw Error(`unrecognized '${command}' in received message ${message}`);
+    assert.fail(X`unrecognized '${command}' in received message ${message}`);
   }
 
   function sendFromRemote(remoteID, message) {
     // deliver:$target:$method:[$result][:$slots..];body
     const sci = message.indexOf(';');
-    assert(sci !== -1, details`missing semicolon in deliver ${message}`);
+    assert(sci !== -1, X`missing semicolon in deliver ${message}`);
     const fields = message
       .slice(0, sci)
       .split(':')
@@ -151,7 +151,7 @@ export function makeDeliveryKit(state, syscall, transmit, clistKit, stateKit) {
     const resolutions = [];
     for (const submsg of subMessages) {
       const sci = submsg.indexOf(';');
-      assert(sci !== -1, details`missing semicolon in resolve ${submsg}`);
+      assert(sci !== -1, X`missing semicolon in resolve ${submsg}`);
 
       const pieces = submsg.slice(0, sci).split(':');
       assert(pieces[0] === 'resolve');
@@ -267,7 +267,7 @@ export function makeDeliveryKit(state, syscall, transmit, clistKit, stateKit) {
       return;
     }
 
-    throw Error(`unknown where ${where}`);
+    assert.fail(X`unknown where ${where}`);
   }
 
   function sendToKernel(target, delivery) {
@@ -281,7 +281,7 @@ export function makeDeliveryKit(state, syscall, transmit, clistKit, stateKit) {
   }
 
   function sendToRemote(target, remoteID, localDelivery) {
-    assert(remoteID, details`oops ${target}`);
+    assert(remoteID, X`oops ${target}`);
     insistCapData(localDelivery.args);
 
     const {

--- a/packages/SwingSet/src/vats/comms/dispatch.js
+++ b/packages/SwingSet/src/vats/comms/dispatch.js
@@ -1,4 +1,4 @@
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { makeVatSlot } from '../../parseVatSlots';
 import { getRemote } from './remote';
 import { makeState, makeStateKit } from './state';
@@ -54,12 +54,12 @@ export function buildCommsDispatch(syscall) {
     if (state.objectTable.has(target) || state.promiseTable.has(target)) {
       assert(
         method.indexOf(':') === -1 && method.indexOf(';') === -1,
-        details`illegal method name ${method}`,
+        X`illegal method name ${method}`,
       );
       return sendFromKernel(target, method, args, result);
     }
     if (state.remoteReceivers.has(target)) {
-      assert(method === 'receive', details`unexpected method ${method}`);
+      assert(method === 'receive', X`unexpected method ${method}`);
       // the vat-tp integrity layer is a regular vat, so when they send the
       // received message to us, it will be embedded in a JSON array
       const remoteID = state.remoteReceivers.get(target);
@@ -69,7 +69,7 @@ export function buildCommsDispatch(syscall) {
 
     // TODO: if promise target not in PromiseTable: resolve result to error
     //   this will happen if someone pipelines to our controller/receiver
-    throw Error(`unknown target ${target}`);
+    assert.fail(X`unknown target ${target}`);
   }
 
   function notify(resolutions) {

--- a/packages/SwingSet/src/vats/comms/parseRemoteSlot.js
+++ b/packages/SwingSet/src/vats/comms/parseRemoteSlot.js
@@ -1,5 +1,5 @@
 import Nat from '@agoric/nat';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 
 // Object/promise references (in remote messages) contain a three-tuple of
 // (type, allocator flag, index). The allocator flag inside an inbound
@@ -21,7 +21,7 @@ export function parseRemoteSlot(s) {
   } else if (typechars === 'rr') {
     type = 'resolver';
   } else {
-    throw new Error(`invalid remoteSlot ${s}`);
+    assert.fail(X`invalid remoteSlot ${s}`);
   }
 
   if (allocchar === '+') {
@@ -29,7 +29,7 @@ export function parseRemoteSlot(s) {
   } else if (allocchar === '-') {
     allocatedByRecipient = false;
   } else {
-    throw new Error(`invalid remoteSlot ${s}`);
+    assert.fail(X`invalid remoteSlot ${s}`);
   }
 
   const id = Nat(Number(indexSuffix));
@@ -53,13 +53,13 @@ export function makeRemoteSlot(type, allocatedByRecipient, id) {
   if (type === 'resolver') {
     return `rr${indexSuffix}`;
   }
-  throw new Error(`unknown type ${type}`);
+  assert.fail(X`unknown type ${type}`);
 }
 
 export function insistRemoteType(type, remoteSlot) {
   assert(
     type === parseRemoteSlot(remoteSlot).type,
-    details`remoteSlot ${remoteSlot} is not of type ${type}`,
+    X`remoteSlot ${remoteSlot} is not of type ${type}`,
   );
 }
 

--- a/packages/SwingSet/src/vats/comms/remote.js
+++ b/packages/SwingSet/src/vats/comms/remote.js
@@ -1,5 +1,5 @@
 import Nat from '@agoric/nat';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { makeVatSlot, insistVatType } from '../../parseVatSlots';
 
 function makeRemoteID(index) {
@@ -7,19 +7,19 @@ function makeRemoteID(index) {
 }
 
 export function insistRemoteID(remoteID) {
-  assert(remoteID.startsWith('remote'), details`not a remoteID: ${remoteID}`);
+  assert(remoteID.startsWith('remote'), X`not a remoteID: ${remoteID}`);
 }
 
 export function getRemote(state, remoteID) {
   insistRemoteID(remoteID);
   const remote = state.remotes.get(remoteID);
-  assert(remote, `missing ${remoteID}`);
+  assert(remote, X`missing ${remoteID}`);
   return remote;
 }
 
 export function addRemote(state, name, transmitterID) {
   insistVatType('object', transmitterID);
-  assert(!state.names.has(name), details`remote name ${name} already in use`);
+  assert(!state.names.has(name), X`remote name ${name} already in use`);
 
   const remoteID = makeRemoteID(state.nextRemoteIndex);
   state.nextRemoteIndex += 1;

--- a/packages/SwingSet/src/vats/comms/state.js
+++ b/packages/SwingSet/src/vats/comms/state.js
@@ -1,4 +1,4 @@
-import { assert } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { insistCapData } from '../../capdata';
 import { makeVatSlot } from '../../parseVatSlots';
 import { insistRemoteID } from './remote';
@@ -78,7 +78,7 @@ export function dumpState(state) {
 
 export function makeStateKit(state) {
   function trackUnresolvedPromise(vpid) {
-    assert(!state.promiseTable.has(vpid), `${vpid} already present`);
+    assert(!state.promiseTable.has(vpid), X`${vpid} already present`);
     state.promiseTable.set(vpid, {
       resolved: false,
       decider: COMMS,
@@ -105,14 +105,14 @@ export function makeStateKit(state) {
 
   function deciderIsKernel(vpid) {
     const p = state.promiseTable.get(vpid);
-    assert(p, `unknown ${vpid}`);
+    assert(p, X`unknown ${vpid}`);
     const { decider } = p;
     return decider === KERNEL;
   }
 
   function deciderIsRemote(vpid) {
     const p = state.promiseTable.get(vpid);
-    assert(p, `unknown ${vpid}`);
+    assert(p, X`unknown ${vpid}`);
     const { decider } = p;
     if (decider === KERNEL || decider === COMMS) {
       return undefined;
@@ -123,7 +123,7 @@ export function makeStateKit(state) {
 
   function insistDeciderIsRemote(vpid, remoteID) {
     const p = state.promiseTable.get(vpid);
-    assert(p, `unknown ${vpid}`);
+    assert(p, X`unknown ${vpid}`);
     const { decider } = p;
     assert.equal(
       decider,
@@ -134,7 +134,7 @@ export function makeStateKit(state) {
 
   function insistDeciderIsComms(vpid) {
     const p = state.promiseTable.get(vpid);
-    assert(p, `unknown ${vpid}`);
+    assert(p, X`unknown ${vpid}`);
     const { decider } = p;
     assert.equal(
       decider,
@@ -145,7 +145,7 @@ export function makeStateKit(state) {
 
   function insistDeciderIsKernel(vpid) {
     const p = state.promiseTable.get(vpid);
-    assert(p, `unknown ${vpid}`);
+    assert(p, X`unknown ${vpid}`);
     const { decider } = p;
     assert.equal(
       decider,
@@ -161,7 +161,7 @@ export function makeStateKit(state) {
     // console.log(`changeDecider ${vpid}: COMMS->${newDecider}`);
     insistRemoteID(newDecider);
     const p = state.promiseTable.get(vpid);
-    assert(p, `unknown ${vpid}`);
+    assert(p, X`unknown ${vpid}`);
     assert.equal(p.decider, COMMS);
     p.decider = newDecider;
   }
@@ -170,7 +170,7 @@ export function makeStateKit(state) {
     // console.log(`changeDecider ${vpid}: ${oldDecider}->COMMS`);
     insistRemoteID(oldDecider);
     const p = state.promiseTable.get(vpid);
-    assert(p, `unknown ${vpid}`);
+    assert(p, X`unknown ${vpid}`);
     assert.equal(p.decider, oldDecider);
     p.decider = COMMS;
   }
@@ -178,8 +178,8 @@ export function makeStateKit(state) {
   function changeDeciderToKernel(vpid) {
     // console.log(`changeDecider ${vpid}: COMMS->KERNEL`);
     const p = state.promiseTable.get(vpid);
-    assert(p, `unknown ${vpid}`);
-    assert(p, `unknown ${vpid}`);
+    assert(p, X`unknown ${vpid}`);
+    assert(p, X`unknown ${vpid}`);
     assert.equal(p.decider, COMMS);
     p.decider = KERNEL;
   }
@@ -187,60 +187,60 @@ export function makeStateKit(state) {
   function changeDeciderFromKernelToComms(vpid) {
     // console.log(`changeDecider ${vpid}: KERNEL->COMMS`);
     const p = state.promiseTable.get(vpid);
-    assert(p, `unknown ${vpid}`);
-    assert(p, `unknown ${vpid}`);
+    assert(p, X`unknown ${vpid}`);
+    assert(p, X`unknown ${vpid}`);
     assert.equal(p.decider, KERNEL);
     p.decider = COMMS;
   }
 
   function getPromiseSubscribers(vpid) {
     const p = state.promiseTable.get(vpid);
-    assert(p, `unknown ${vpid}`);
-    assert(p, `unknown ${vpid}`);
+    assert(p, X`unknown ${vpid}`);
+    assert(p, X`unknown ${vpid}`);
     const { subscribers, kernelIsSubscribed } = p;
     return { subscribers, kernelIsSubscribed };
   }
 
   function subscribeRemoteToPromise(vpid, subscriber) {
     const p = state.promiseTable.get(vpid);
-    assert(p, `unknown ${vpid}`);
-    assert(!p.resolved, `${vpid} already resolved`);
+    assert(p, X`unknown ${vpid}`);
+    assert(!p.resolved, X`${vpid} already resolved`);
     p.subscribers.push(subscriber);
   }
 
   function unsubscribeRemoteFromPromise(vpid, subscriber) {
     const p = state.promiseTable.get(vpid);
-    assert(p, `unknown ${vpid}`);
-    assert(!p.resolved, `${vpid} already resolved`);
+    assert(p, X`unknown ${vpid}`);
+    assert(!p.resolved, X`${vpid} already resolved`);
     p.subscribers = p.subscribers.filter(s => s !== subscriber);
   }
 
   function subscribeKernelToPromise(vpid) {
     const p = state.promiseTable.get(vpid);
     // console.log(`subscribeKernelToPromise ${vpid} d=${p.decider}`);
-    assert(p, `unknown ${vpid}`);
-    assert(!p.resolved, `${vpid} already resolved`);
-    assert(p.decider !== KERNEL, `kernel is decider for ${vpid}, hush`);
+    assert(p, X`unknown ${vpid}`);
+    assert(!p.resolved, X`${vpid} already resolved`);
+    assert(p.decider !== KERNEL, X`kernel is decider for ${vpid}, hush`);
     p.kernelIsSubscribed = true;
   }
 
   function unsubscribeKernelFromPromise(vpid) {
     const p = state.promiseTable.get(vpid);
     // console.log(`unsubscribeKernelToPromise ${vpid} d=${p.decider}`);
-    assert(p, `unknown ${vpid}`);
-    assert(!p.resolved, `${vpid} already resolved`);
+    assert(p, X`unknown ${vpid}`);
+    assert(!p.resolved, X`${vpid} already resolved`);
     p.kernelIsSubscribed = false;
   }
 
   function insistPromiseIsUnresolved(vpid) {
     const p = state.promiseTable.get(vpid);
-    assert(p, `unknown ${vpid}`);
-    assert(!p.resolved, `${vpid} was already resolved`);
+    assert(p, X`unknown ${vpid}`);
+    assert(!p.resolved, X`${vpid} was already resolved`);
   }
 
   function markPromiseAsResolved(vpid, resolution) {
     const p = state.promiseTable.get(vpid);
-    assert(p, `unknown ${vpid}`);
+    assert(p, X`unknown ${vpid}`);
     assert(!p.resolved);
     insistCapData(resolution.data);
     p.resolved = true;
@@ -253,7 +253,7 @@ export function makeStateKit(state) {
 
   function markPromiseAsResolvedInKernel(vpid) {
     const p = state.promiseTable.get(vpid);
-    assert(p, `unknown ${vpid}`);
+    assert(p, X`unknown ${vpid}`);
     assert(p.resolved && p.kernelAwaitingResolve);
     p.kernelAwaitingResolve = false;
   }

--- a/packages/SwingSet/src/vats/network/router.js
+++ b/packages/SwingSet/src/vats/network/router.js
@@ -2,6 +2,7 @@
 
 import { E as defaultE } from '@agoric/eventual-send';
 import makeStore from '@agoric/store';
+import { assert, details as X } from '@agoric/assert';
 import { makeNetworkProtocol, ENDPOINT_SEPARATOR } from './network';
 
 import '@agoric/store/exported';
@@ -53,9 +54,11 @@ export default function makeRouter() {
       prefixToRoute.init(prefix, route);
     },
     unregister(prefix, route) {
-      if (prefixToRoute.get(prefix) !== route) {
-        throw TypeError(`Router is not registered at prefix ${prefix}`);
-      }
+      assert(
+        prefixToRoute.get(prefix) === route,
+        X`Router is not registered at prefix ${prefix}`,
+        TypeError,
+      );
       prefixToRoute.delete(prefix);
     },
   });
@@ -90,9 +93,11 @@ export function makeRouterProtocol(E = defaultE) {
   // Needs to account for multiple paths.
   function unregisterProtocolHandler(prefix, protocolHandler) {
     const ph = protocolHandlers.get(prefix);
-    if (ph !== protocolHandler) {
-      throw TypeError(`Protocol handler is not registered at prefix ${prefix}`);
-    }
+    assert(
+      ph === protocolHandler,
+      X`Protocol handler is not registered at prefix ${prefix}`,
+      TypeError,
+    );
     router.unregister(prefix, ph);
     protocols.delete(prefix);
     protocolHandlers.delete(prefix);
@@ -103,9 +108,11 @@ export function makeRouterProtocol(E = defaultE) {
   /* eslint-enable jsdoc/valid-types */
   async function bind(localAddr) {
     const [route] = router.getRoutes(localAddr);
-    if (route === undefined) {
-      throw TypeError(`No registered router for ${localAddr}`);
-    }
+    assert(
+      route !== undefined,
+      X`No registered router for ${localAddr}`,
+      TypeError,
+    );
     return E(route[1]).bind(localAddr);
   }
 

--- a/packages/SwingSet/src/vats/vat-timerWrapper.js
+++ b/packages/SwingSet/src/vats/vat-timerWrapper.js
@@ -1,5 +1,5 @@
 import Nat from '@agoric/nat';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { makeNotifierKit } from '@agoric/notifier';
 
 export function buildRootObject(vatPowers) {
@@ -28,7 +28,7 @@ export function buildRootObject(vatPowers) {
         Nat(delaySecs);
         assert(
           Nat(interval) > 0,
-          details`makeRepeater's second parameter must be a positive integer: ${interval}`,
+          X`makeRepeater's second parameter must be a positive integer: ${interval}`,
         );
 
         const index = D(timerNode).makeRepeater(delaySecs, interval);
@@ -49,7 +49,7 @@ export function buildRootObject(vatPowers) {
         Nat(delaySecs);
         assert(
           Nat(interval) > 0,
-          details`makeNotifier's second parameter must be a positive integer: ${interval}`,
+          X`makeNotifier's second parameter must be a positive integer: ${interval}`,
         );
 
         const index = D(timerNode).makeRepeater(delaySecs, interval);

--- a/packages/SwingSet/src/vats/vat-tp.js
+++ b/packages/SwingSet/src/vats/vat-tp.js
@@ -1,4 +1,4 @@
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
 
@@ -81,7 +81,7 @@ export function buildRootObject(vatPowers) {
     } = makePromiseKit();
     const name = makeConnectionName();
     let openCalled = false;
-    assert(!connectionNames.has(name), `already have host for ${name}`);
+    assert(!connectionNames.has(name), X`already have host for ${name}`);
     const host = harden({
       publish(obj) {
         const address = makeAddress();
@@ -96,7 +96,7 @@ export function buildRootObject(vatPowers) {
     const handler = harden({
       async onOpen(connection, ..._args) {
         // make a new Remote for this new connection
-        assert(!openCalled, `host ${name} already opened`);
+        assert(!openCalled, X`host ${name} already opened`);
         openCalled = true;
 
         // transmitter
@@ -146,7 +146,7 @@ export function buildRootObject(vatPowers) {
      * deliverInboundMessages/deliverInboundAck
      */
     addRemote(name) {
-      assert(!remotes.has(name), details`already have remote ${name}`);
+      assert(!remotes.has(name), X`already have remote ${name}`);
       const r = getRemote(name);
       const transmitter = harden({
         transmit(msg) {
@@ -159,9 +159,7 @@ export function buildRootObject(vatPowers) {
       });
       const setReceiver = harden({
         setReceiver(newReceiver) {
-          if (r.inbound.receiver) {
-            throw new Error(`setReceiver is call-once`);
-          }
+          assert(!r.inbound.receiver, X`setReceiver is call-once`);
           r.inbound.receiver = newReceiver;
         },
       });

--- a/packages/SwingSet/src/weakref.js
+++ b/packages/SwingSet/src/weakref.js
@@ -1,4 +1,4 @@
-import { assert, details as d } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 
 const { defineProperties } = Object;
 
@@ -29,13 +29,13 @@ const weakRefTarget = new WeakMap();
 const FakeWeakRef = function WeakRef(target) {
   assert(
     new.target !== undefined,
-    d`WeakRef Constructor requires 'new'`,
+    X`WeakRef Constructor requires 'new'`,
     TypeError,
   );
   assert.equal(
     Object(target),
     target,
-    d`WeakRef target must be an object`,
+    X`WeakRef target must be an object`,
     TypeError,
   );
   weakRefTarget.set(this, target);
@@ -77,13 +77,13 @@ const FakeFinalizationRegistry = function FinalizationRegistry(
 ) {
   assert(
     new.target !== undefined,
-    d`FinalizationRegistry Constructor requires 'new'`,
+    X`FinalizationRegistry Constructor requires 'new'`,
     TypeError,
   );
   assert.typeof(
     cleanupCallback,
     'function',
-    d`cleanupCallback must be a function`,
+    X`cleanupCallback must be a function`,
   );
   // fall off the end with an empty instance
 };

--- a/packages/SwingSet/test/basedir-promises-2/bootstrap.js
+++ b/packages/SwingSet/test/basedir-promises-2/bootstrap.js
@@ -1,6 +1,8 @@
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
 
+const { details: X } = assert;
+
 export function buildRootObject(vatPowers, vatParameters) {
   const log = vatPowers.testLog;
   return harden({
@@ -28,7 +30,7 @@ export function buildRootObject(vatPowers, vatParameters) {
           log(`b.harden-promise-1.finish`);
         });
       } else {
-        throw Error(`unknown mode ${mode}`);
+        assert.fail(X`unknown mode ${mode}`);
       }
     },
   });

--- a/packages/SwingSet/test/basedir-promises-2/bootstrap.js
+++ b/packages/SwingSet/test/basedir-promises-2/bootstrap.js
@@ -1,7 +1,7 @@
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
 
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 export function buildRootObject(vatPowers, vatParameters) {
   const log = vatPowers.testLog;

--- a/packages/SwingSet/test/basedir-promises/bootstrap.js
+++ b/packages/SwingSet/test/basedir-promises/bootstrap.js
@@ -1,6 +1,8 @@
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
 
+const { details: X } = assert;
+
 export function buildRootObject(vatPowers, vatParameters) {
   const log = vatPowers.testLog;
   return harden({
@@ -74,7 +76,7 @@ export function buildRootObject(vatPowers, vatParameters) {
         p2.then(x => log(`b.resolved ${x}`));
         log(`b.call-promise1.finish`);
       } else {
-        throw Error(`unknown mode ${mode}`);
+        assert.fail(X`unknown mode ${mode}`);
       }
     },
   });

--- a/packages/SwingSet/test/basedir-promises/bootstrap.js
+++ b/packages/SwingSet/test/basedir-promises/bootstrap.js
@@ -1,7 +1,7 @@
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
 
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 export function buildRootObject(vatPowers, vatParameters) {
   const log = vatPowers.testLog;

--- a/packages/SwingSet/test/basedir-transcript/bootstrap.js
+++ b/packages/SwingSet/test/basedir-transcript/bootstrap.js
@@ -1,5 +1,7 @@
 import { E } from '@agoric/eventual-send';
 
+const { details: X } = assert;
+
 export function buildRootObject(vatPowers, vatParameters) {
   return harden({
     bootstrap(vats) {
@@ -12,7 +14,7 @@ export function buildRootObject(vatPowers, vatParameters) {
             err => vatPowers.testLog(`b.rejected ${err}`),
           );
       } else {
-        throw Error(`unknown mode ${mode}`);
+        assert.fail(X`unknown mode ${mode}`);
       }
     },
   });

--- a/packages/SwingSet/test/basedir-transcript/bootstrap.js
+++ b/packages/SwingSet/test/basedir-transcript/bootstrap.js
@@ -1,6 +1,6 @@
 import { E } from '@agoric/eventual-send';
 
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 export function buildRootObject(vatPowers, vatParameters) {
   return harden({

--- a/packages/SwingSet/test/device-plugin/bootstrap.js
+++ b/packages/SwingSet/test/device-plugin/bootstrap.js
@@ -1,6 +1,8 @@
 import { E } from '@agoric/eventual-send';
 import { makePluginManager } from '../../src/vats/plugin-manager';
 
+const { details: X } = assert;
+
 export function buildRootObject(vatPowers, vatParameters) {
   const { D } = vatPowers;
   const log = vatPowers.testLog;
@@ -20,7 +22,7 @@ export function buildRootObject(vatPowers, vatParameters) {
           E(vats.bridge).init(pingPongP);
           D(devices.bridge).registerInboundHandler(vats.bridge);
         } else {
-          throw new Error(`unknown argv mode '${argv[0]}'`);
+          assert.fail(X`unknown argv mode '${argv[0]}'`);
         }
       } catch (e) {
         console.error('have error', e);

--- a/packages/SwingSet/test/device-plugin/bootstrap.js
+++ b/packages/SwingSet/test/device-plugin/bootstrap.js
@@ -1,7 +1,6 @@
 import { E } from '@agoric/eventual-send';
+import { assert, details as X } from '@agoric/assert';
 import { makePluginManager } from '../../src/vats/plugin-manager';
-
-const { details: X } = assert;
 
 export function buildRootObject(vatPowers, vatParameters) {
   const { D } = vatPowers;

--- a/packages/SwingSet/test/device-plugin/vat-bridge.js
+++ b/packages/SwingSet/test/device-plugin/vat-bridge.js
@@ -1,5 +1,7 @@
 import { E } from '@agoric/eventual-send';
 
+const { details: X } = assert;
+
 export function buildRootObject(vatPowers, _vatParameters) {
   const log = vatPowers.testLog;
   let pingPongP;
@@ -18,7 +20,7 @@ export function buildRootObject(vatPowers, _vatParameters) {
             break;
           }
           default: {
-            throw new Error(`unknown bridge input ${msg}`);
+            assert.fail(X`unknown bridge input ${msg}`);
           }
         }
       } catch (e) {

--- a/packages/SwingSet/test/device-plugin/vat-bridge.js
+++ b/packages/SwingSet/test/device-plugin/vat-bridge.js
@@ -1,6 +1,6 @@
 import { E } from '@agoric/eventual-send';
 
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 export function buildRootObject(vatPowers, _vatParameters) {
   const log = vatPowers.testLog;

--- a/packages/SwingSet/test/files-devices/bootstrap-1.js
+++ b/packages/SwingSet/test/files-devices/bootstrap-1.js
@@ -1,4 +1,4 @@
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 export default function setup(syscall, state, _helpers, vatPowers) {
   const { testLog } = vatPowers;

--- a/packages/SwingSet/test/files-devices/bootstrap-1.js
+++ b/packages/SwingSet/test/files-devices/bootstrap-1.js
@@ -1,3 +1,5 @@
+const { details: X } = assert;
+
 export default function setup(syscall, state, _helpers, vatPowers) {
   const { testLog } = vatPowers;
   let deviceRef;
@@ -7,9 +9,7 @@ export default function setup(syscall, state, _helpers, vatPowers) {
         const argb = JSON.parse(args.body);
         const deviceIndex = argb[1].d1.index;
         deviceRef = args.slots[deviceIndex];
-        if (deviceRef !== 'd-70') {
-          throw new Error(`bad deviceRef ${deviceRef}`);
-        }
+        assert(deviceRef === 'd-70', X`bad deviceRef ${deviceRef}`);
       } else if (method === 'step1') {
         testLog(`callNow`);
         const setArgs = harden({ body: JSON.stringify([1, 2]), slots: [] });

--- a/packages/SwingSet/test/files-devices/bootstrap-2.js
+++ b/packages/SwingSet/test/files-devices/bootstrap-2.js
@@ -1,6 +1,6 @@
 import { E } from '@agoric/eventual-send';
 
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 export function buildRootObject(vatPowers, vatParameters) {
   const { D, testLog: log } = vatPowers;

--- a/packages/SwingSet/test/files-devices/bootstrap-2.js
+++ b/packages/SwingSet/test/files-devices/bootstrap-2.js
@@ -1,5 +1,7 @@
 import { E } from '@agoric/eventual-send';
 
+const { details: X } = assert;
+
 export function buildRootObject(vatPowers, vatParameters) {
   const { D, testLog: log } = vatPowers;
   return harden({
@@ -95,7 +97,7 @@ export function buildRootObject(vatPowers, vatParameters) {
           log('good: callNow failed');
         }
       } else {
-        throw new Error(`unknown argv mode '${argv[0]}'`);
+        assert.fail(X`unknown argv mode '${argv[0]}'`);
       }
     },
     ping() {

--- a/packages/SwingSet/test/files-devices/bootstrap-3.js
+++ b/packages/SwingSet/test/files-devices/bootstrap-3.js
@@ -1,3 +1,5 @@
+const { details: X } = assert;
+
 export function buildRootObject(vatPowers, vatParameters) {
   const { D, testLog: log } = vatPowers;
   return harden({
@@ -9,7 +11,7 @@ export function buildRootObject(vatPowers, vatParameters) {
         const s = D(devices.d3).getState();
         log(`got ${JSON.stringify(s)}`);
       } else {
-        throw new Error(`unknown argv mode '${vatParameters.argv[0]}'`);
+        assert.fail(X`unknown argv mode '${vatParameters.argv[0]}'`);
       }
     },
   });

--- a/packages/SwingSet/test/files-devices/bootstrap-3.js
+++ b/packages/SwingSet/test/files-devices/bootstrap-3.js
@@ -1,4 +1,4 @@
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 export function buildRootObject(vatPowers, vatParameters) {
   const { D, testLog: log } = vatPowers;

--- a/packages/SwingSet/test/files-vattp/bootstrap-test-vattp.js
+++ b/packages/SwingSet/test/files-vattp/bootstrap-test-vattp.js
@@ -1,5 +1,7 @@
 import { E } from '@agoric/eventual-send';
 
+const { details: X } = assert;
+
 export function buildRootObject(vatPowers, vatParameters) {
   const { D, testLog: log } = vatPowers;
   const receiver = harden({
@@ -23,7 +25,7 @@ export function buildRootObject(vatPowers, vatParameters) {
       } else if (argv[0] === '2') {
         E(transmitter).transmit('out1');
       } else {
-        throw new Error(`unknown argv mode '${argv[0]}'`);
+        assert.fail(X`unknown argv mode '${argv[0]}'`);
       }
     },
   });

--- a/packages/SwingSet/test/files-vattp/bootstrap-test-vattp.js
+++ b/packages/SwingSet/test/files-vattp/bootstrap-test-vattp.js
@@ -1,6 +1,6 @@
 import { E } from '@agoric/eventual-send';
 
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 export function buildRootObject(vatPowers, vatParameters) {
   const { D, testLog: log } = vatPowers;

--- a/packages/SwingSet/test/metering/test-metering.js
+++ b/packages/SwingSet/test/metering/test-metering.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/order
 import { replaceGlobalMeter } from './install-global-metering';
 import '@agoric/install-ses';
-import { assert } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import bundleSource from '@agoric/bundle-source';
 import { importBundle } from '@agoric/import-bundle';
 import { makeMeter, makeMeteringTransformer } from '@agoric/transform-metering';
@@ -72,9 +72,7 @@ async function meteredImportBundle(bundle, endowments) {
   }
   // this throws if top-level code exhausts meter
   const topLevelOk = await runUnderMeter(meter, doImport);
-  if (!topLevelOk) {
-    throw Error(`top-level code exhausted the meter`);
-  }
+  assert(topLevelOk, X`top-level code exhausted the meter`);
   assert(ns, 'bundle failed to produce namespace object before quiesence');
 
   function runBundleThunkUnderMeter(thunk) {

--- a/packages/SwingSet/test/test-comms.js
+++ b/packages/SwingSet/test/test-comms.js
@@ -19,7 +19,7 @@ test('provideRemoteForLocal', t => {
   t.is(provideRemoteForLocal(remoteID, 'o-4'), 'ro-20');
   t.is(provideRemoteForLocal(remoteID, 'o-5'), 'ro-21');
   t.throws(() => provideRemoteForLocal(remoteID, 'o+5'), {
-    message: /sending non-remote object o\+5 to remote machine/,
+    message: /sending non-remote object "o\+5" to remote machine/,
   });
 });
 

--- a/packages/SwingSet/test/test-devices.js
+++ b/packages/SwingSet/test/test-devices.js
@@ -536,6 +536,6 @@ test.serial('syscall.callNow(promise) is vat-fatal', async t => {
   // now check that the vat was terminated: this should throw an exception
   // because the entire bootstrap vat was deleted
   t.throws(() => c.queueToVatExport('bootstrap', 'o+0', 'ping', capargs([])), {
-    message: `vat name "bootstrap" must exist, but doesn't`,
+    message: /vat name .* must exist, but doesn't/,
   });
 });

--- a/packages/SwingSet/test/test-devices.js
+++ b/packages/SwingSet/test/test-devices.js
@@ -536,6 +536,6 @@ test.serial('syscall.callNow(promise) is vat-fatal', async t => {
   // now check that the vat was terminated: this should throw an exception
   // because the entire bootstrap vat was deleted
   t.throws(() => c.queueToVatExport('bootstrap', 'o+0', 'ping', capargs([])), {
-    message: `vat name bootstrap must exist, but doesn't`,
+    message: `vat name "bootstrap" must exist, but doesn't`,
   });
 });

--- a/packages/SwingSet/test/test-kernel.js
+++ b/packages/SwingSet/test/test-kernel.js
@@ -2,6 +2,7 @@ import '@agoric/install-ses';
 import test from 'ava';
 import anylogger from 'anylogger';
 import { initSwingStore } from '@agoric/swing-store-simple';
+import { assert, details as X } from '@agoric/assert';
 import { WeakRef, FinalizationRegistry } from '../src/weakref';
 import { waitUntilQuiescent } from '../src/waitUntilQuiescent';
 
@@ -9,8 +10,6 @@ import buildKernel from '../src/kernel/index';
 import { initializeKernel } from '../src/kernel/initializeKernel';
 import { makeVatSlot } from '../src/parseVatSlots';
 import { checkKT } from './util';
-
-const { details: X } = assert;
 
 function capdata(body, slots = []) {
   return harden({ body, slots });

--- a/packages/SwingSet/test/test-kernel.js
+++ b/packages/SwingSet/test/test-kernel.js
@@ -10,6 +10,8 @@ import { initializeKernel } from '../src/kernel/initializeKernel';
 import { makeVatSlot } from '../src/parseVatSlots';
 import { checkKT } from './util';
 
+const { details: X } = assert;
+
 function capdata(body, slots = []) {
   return harden({ body, slots });
 }
@@ -144,7 +146,7 @@ test('vat store', async t => {
           syscall.vatstoreDelete('zot');
           break;
         default:
-          throw Error(`this can't happen`);
+          assert.fail(X`this can't happen`);
       }
     }
     return { deliver };

--- a/packages/SwingSet/test/test-liveslots.js
+++ b/packages/SwingSet/test/test-liveslots.js
@@ -6,6 +6,8 @@ import { WeakRef, FinalizationRegistry } from '../src/weakref';
 import { waitUntilQuiescent } from '../src/waitUntilQuiescent';
 import { makeLiveSlots } from '../src/kernel/liveSlots';
 
+const { details: X } = assert;
+
 function capdata(body, slots = []) {
   return harden({ body, slots });
 }
@@ -307,7 +309,7 @@ async function doOutboundPromise(t, mode) {
     resolveSyscall.resolutions[0][1] = true;
     resolveSyscall.resolutions[0][2] = capargs('reject', []);
   } else {
-    throw Error(`unknown mode ${mode}`);
+    assert.fail(X`unknown mode ${mode}`);
   }
 
   // function deliver(target, method, argsdata, result) {
@@ -434,7 +436,7 @@ async function doResultPromise(t, mode) {
   } else if (mode === 'reject') {
     dispatch.notify(oneResolution(expectedP1, true, capargs('error', [])));
   } else {
-    throw Error(`unknown mode ${mode}`);
+    assert.fail(X`unknown mode ${mode}`);
   }
   await waitUntilQuiescent();
   t.deepEqual(log, []);
@@ -458,7 +460,7 @@ async function doResultPromise(t, mode) {
     // Resolving to a non-target means a locally-generated error, and no
     // send() call
   } else {
-    throw Error(`unknown mode ${mode}`);
+    assert.fail(X`unknown mode ${mode}`);
   }
   // #823 fails here for the non-presence cases: we expect no syscalls, but
   // instead we get a send to p+5

--- a/packages/SwingSet/test/test-liveslots.js
+++ b/packages/SwingSet/test/test-liveslots.js
@@ -2,11 +2,10 @@ import '@agoric/install-ses';
 import test from 'ava';
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
+import { assert, details as X } from '@agoric/assert';
 import { WeakRef, FinalizationRegistry } from '../src/weakref';
 import { waitUntilQuiescent } from '../src/waitUntilQuiescent';
 import { makeLiveSlots } from '../src/kernel/liveSlots';
-
-const { details: X } = assert;
 
 function capdata(body, slots = []) {
   return harden({ body, slots });

--- a/packages/SwingSet/test/test-netstring.js
+++ b/packages/SwingSet/test/test-netstring.js
@@ -106,7 +106,7 @@ test('decode', t => {
   }
 
   // bad('a', 'non-numeric length prefix');
-  bad('a:', `unparseable size 'a', should be integer`);
+  bad('a:', `unparseable size "a", should be integer`);
   bad('1:ab', 'malformed netstring: not terminated by comma');
 });
 

--- a/packages/SwingSet/test/test-netstring.js
+++ b/packages/SwingSet/test/test-netstring.js
@@ -106,7 +106,7 @@ test('decode', t => {
   }
 
   // bad('a', 'non-numeric length prefix');
-  bad('a:', `unparseable size "a", should be integer`);
+  bad('a:', /unparseable size .*, should be integer/);
   bad('1:ab', 'malformed netstring: not terminated by comma');
 });
 

--- a/packages/SwingSet/test/test-vpid-kernel.js
+++ b/packages/SwingSet/test/test-vpid-kernel.js
@@ -10,6 +10,8 @@ import { initializeKernel } from '../src/kernel/initializeKernel';
 
 import { buildDispatch } from './util';
 
+const { details: X } = assert;
+
 function capdata(body, slots = []) {
   return harden({ body, slots });
 }
@@ -127,7 +129,7 @@ function doResolveSyscall(syscallA, vpid, mode, targets) {
       syscallA.resolve([[vpid, true, capargs([slot0arg], [targets.p1])]]);
       break;
     default:
-      throw Error(`unknown mode ${mode}`);
+      assert.fail(X`unknown mode ${mode}`);
   }
 }
 
@@ -180,7 +182,7 @@ function resolutionOf(vpid, mode, targets) {
         ),
       };
     default:
-      throw Error(`unknown mode ${mode}`);
+      assert.fail(X`unknown mode ${mode}`);
   }
 }
 
@@ -389,9 +391,9 @@ async function doTest4567(t, which, mode) {
   await kernel.start(undefined); // no bootstrapVatName, so no bootstrap call
   // vatA is our primary actor
   let onDispatchCallback;
-  function odc(d) {
+  function odc(dp) {
     if (onDispatchCallback) {
-      onDispatchCallback(d);
+      onDispatchCallback(dp);
     }
   }
   const { log: logA, getSyscall: getSyscallA } = await buildRawVat(
@@ -544,8 +546,8 @@ async function doTest4567(t, which, mode) {
     localTarget: localTargetA,
     p1: dataPromiseA,
   };
-  onDispatchCallback = function odc1(d) {
-    t.deepEqual(d, resolutionOf(p1VatA, mode, targetsA));
+  onDispatchCallback = function odc1(dp) {
+    t.deepEqual(dp, resolutionOf(p1VatA, mode, targetsA));
     t.is(inCList(kernel, vatA, p1kernel, p1VatA), false);
   };
   const targetsB = {
@@ -581,9 +583,9 @@ test(`kernel vpid handling crossing resolutions`, async t => {
   await kernel.start(undefined); // no bootstrapVatName, so no bootstrap call
   // vatX controls the scenario, vatA and vatB are the players
   let onDispatchCallback;
-  function odc(d) {
+  function odc(dp) {
     if (onDispatchCallback) {
-      onDispatchCallback(d);
+      onDispatchCallback(dp);
     }
   }
   const { log: logA, getSyscall: getSyscallA } = await buildRawVat(

--- a/packages/SwingSet/test/test-vpid-kernel.js
+++ b/packages/SwingSet/test/test-vpid-kernel.js
@@ -582,9 +582,9 @@ test(`kernel vpid handling crossing resolutions`, async t => {
   await kernel.start(undefined); // no bootstrapVatName, so no bootstrap call
   // vatX controls the scenario, vatA and vatB are the players
   let onDispatchCallback;
-  function odc(dp) {
+  function odc(d) {
     if (onDispatchCallback) {
-      onDispatchCallback(dp);
+      onDispatchCallback(d);
     }
   }
   const { log: logA, getSyscall: getSyscallA } = await buildRawVat(

--- a/packages/SwingSet/test/test-vpid-kernel.js
+++ b/packages/SwingSet/test/test-vpid-kernel.js
@@ -2,6 +2,7 @@ import '@agoric/install-ses';
 import test from 'ava';
 import anylogger from 'anylogger';
 import { initSwingStore } from '@agoric/swing-store-simple';
+import { assert, details as X } from '@agoric/assert';
 import { WeakRef, FinalizationRegistry } from '../src/weakref';
 import { waitUntilQuiescent } from '../src/waitUntilQuiescent';
 
@@ -9,8 +10,6 @@ import buildKernel from '../src/kernel/index';
 import { initializeKernel } from '../src/kernel/initializeKernel';
 
 import { buildDispatch } from './util';
-
-const { details: X } = assert;
 
 function capdata(body, slots = []) {
   return harden({ body, slots });
@@ -391,9 +390,9 @@ async function doTest4567(t, which, mode) {
   await kernel.start(undefined); // no bootstrapVatName, so no bootstrap call
   // vatA is our primary actor
   let onDispatchCallback;
-  function odc(dp) {
+  function odc(d) {
     if (onDispatchCallback) {
-      onDispatchCallback(dp);
+      onDispatchCallback(d);
     }
   }
   const { log: logA, getSyscall: getSyscallA } = await buildRawVat(
@@ -546,8 +545,8 @@ async function doTest4567(t, which, mode) {
     localTarget: localTargetA,
     p1: dataPromiseA,
   };
-  onDispatchCallback = function odc1(dp) {
-    t.deepEqual(dp, resolutionOf(p1VatA, mode, targetsA));
+  onDispatchCallback = function odc1(d) {
+    t.deepEqual(d, resolutionOf(p1VatA, mode, targetsA));
     t.is(inCList(kernel, vatA, p1kernel, p1VatA), false);
   };
   const targetsB = {

--- a/packages/SwingSet/test/test-vpid-liveslots.js
+++ b/packages/SwingSet/test/test-vpid-liveslots.js
@@ -6,10 +6,9 @@ import test from 'ava';
 
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
+import { assert, details as X } from '@agoric/assert';
 import { WeakRef, FinalizationRegistry } from '../src/weakref';
 import { makeLiveSlots } from '../src/kernel/liveSlots';
-
-const { details: X } = assert;
 
 function capdata(body, slots = []) {
   return harden({ body, slots });

--- a/packages/SwingSet/test/test-vpid-liveslots.js
+++ b/packages/SwingSet/test/test-vpid-liveslots.js
@@ -9,6 +9,8 @@ import { makePromiseKit } from '@agoric/promise-kit';
 import { WeakRef, FinalizationRegistry } from '../src/weakref';
 import { makeLiveSlots } from '../src/kernel/liveSlots';
 
+const { details: X } = assert;
+
 function capdata(body, slots = []) {
   return harden({ body, slots });
 }
@@ -133,7 +135,7 @@ function resolvePR(pr, mode, targets) {
       pr.reject([targets.p1]);
       break;
     default:
-      throw Error(`unknown mode ${mode}`);
+      assert.fail(X`unknown mode ${mode}`);
   }
 }
 
@@ -173,7 +175,7 @@ function resolutionOf(vpid, mode, targets) {
       resolution.resolutions[0][2] = capargs([slot0arg], [targets.p1]);
       break;
     default:
-      throw Error(`unknown mode ${mode}`);
+      assert.fail(X`unknown mode ${mode}`);
   }
   return resolution;
 }
@@ -385,7 +387,7 @@ async function doVatResolveCase23(t, which, mode, stalls) {
     dispatch.deliver(rootA, 'promise', capargs([slot0arg], [p1]));
     dispatch.deliver(rootA, 'result', capargs([], []), p1);
   } else {
-    throw Error(`bad which=${which}`);
+    assert.fail(X`bad which=${which}`);
   }
   await endOfCrank();
   t.deepEqual(log.shift(), { type: 'subscribe', target: p1 });
@@ -638,7 +640,7 @@ async function doVatResolveCase4(t, mode) {
   } else if (mode === 'promise-reject') {
     dispatch.notify(oneResolution(p1, true, capargs([slot0arg], [p1])));
   } else {
-    throw Error(`unknown mode ${mode}`);
+    assert.fail(X`unknown mode ${mode}`);
   }
   await endOfCrank();
   t.deepEqual(log, []);

--- a/packages/SwingSet/test/timer-device/bootstrap.js
+++ b/packages/SwingSet/test/timer-device/bootstrap.js
@@ -1,4 +1,4 @@
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 export function buildRootObject(vatPowers, vatParameters) {
   const { D } = vatPowers;

--- a/packages/SwingSet/test/timer-device/bootstrap.js
+++ b/packages/SwingSet/test/timer-device/bootstrap.js
@@ -1,3 +1,5 @@
+const { details: X } = assert;
+
 export function buildRootObject(vatPowers, vatParameters) {
   const { D } = vatPowers;
   const log = vatPowers.testLog;
@@ -27,7 +29,7 @@ export function buildRootObject(vatPowers, vatParameters) {
         const nextTime = D(devices.timer).schedule(rptr, handler);
         log(`next scheduled time: ${nextTime}`);
       } else {
-        throw new Error(`unknown argv mode '${argv[0]}'`);
+        assert.fail(X`unknown argv mode '${argv[0]}'`);
       }
     },
   });

--- a/packages/SwingSet/test/vat-admin/bootstrap.js
+++ b/packages/SwingSet/test/vat-admin/bootstrap.js
@@ -1,5 +1,7 @@
 import { E } from '@agoric/eventual-send';
 
+const { details: X } = assert;
+
 export function buildRootObject(vatPowers, vatParameters) {
   const log = vatPowers.testLog;
   return harden({
@@ -61,7 +63,7 @@ export function buildRootObject(vatPowers, vatParameters) {
           return;
         }
         default:
-          throw new Error(`unknown argv mode '${argv[0]}'`);
+          assert.fail(X`unknown argv mode '${argv[0]}'`);
       }
     },
   });

--- a/packages/SwingSet/test/vat-admin/bootstrap.js
+++ b/packages/SwingSet/test/vat-admin/bootstrap.js
@@ -1,6 +1,6 @@
 import { E } from '@agoric/eventual-send';
 
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 export function buildRootObject(vatPowers, vatParameters) {
   const log = vatPowers.testLog;

--- a/packages/SwingSet/test/vat-admin/test-innerVat.js
+++ b/packages/SwingSet/test/vat-admin/test-innerVat.js
@@ -50,7 +50,7 @@ test('error creating vat from non-bundle', async t => {
   await c.run();
   t.deepEqual(c.dump().log, [
     'starting non-bundle test',
-    'yay, rejected: Error: Vat Creation Error: Error: vat creation requires a bundle, not a plain string',
+    'yay, rejected: Error: Vat Creation Error: TypeError: vat creation requires a bundle, not a plain string',
   ]);
   await c.run();
 });

--- a/packages/agoric-cli/lib/main.js
+++ b/packages/agoric-cli/lib/main.js
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 
+import { assert, details as X } from '@agoric/assert';
 import cosmosMain from './cosmos';
 import deployMain from './deploy';
 import initMain from './init';
@@ -7,8 +8,6 @@ import installMain from './install';
 import setDefaultsMain from './set-defaults';
 import startMain from './start';
 import walletMain from './open';
-
-const { details: X } = assert;
 
 const DEFAULT_DAPP_TEMPLATE = 'dapp-fungible-faucet';
 const DEFAULT_DAPP_URL_BASE = 'git://github.com/Agoric/';
@@ -77,13 +76,12 @@ const main = async (progname, rawArgs, powers) => {
       '--repl [yes | only | no]',
       'whether to show the Read-eval-print loop [yes]',
       value => {
-        if (['yes', 'only', 'no'].includes(value)) {
-          return value;
-        }
-        assert.fail(
+        assert(
+          ['yes', 'only', 'no'].includes(value),
           X`--repl must be one of 'yes', 'no', or 'only'`,
           TypeError,
         );
+        return value;
       },
     )
     .action(async cmd => {

--- a/packages/agoric-cli/lib/main.js
+++ b/packages/agoric-cli/lib/main.js
@@ -8,6 +8,8 @@ import setDefaultsMain from './set-defaults';
 import startMain from './start';
 import walletMain from './open';
 
+const { details: X } = assert;
+
 const DEFAULT_DAPP_TEMPLATE = 'dapp-fungible-faucet';
 const DEFAULT_DAPP_URL_BASE = 'git://github.com/Agoric/';
 
@@ -78,7 +80,10 @@ const main = async (progname, rawArgs, powers) => {
         if (['yes', 'only', 'no'].includes(value)) {
           return value;
         }
-        throw TypeError(`--repl must be one of 'yes', 'no', or 'only'`);
+        assert.fail(
+          X`--repl must be one of 'yes', 'no', or 'only'`,
+          TypeError,
+        );
       },
     )
     .action(async cmd => {

--- a/packages/agoric-cli/lib/open.js
+++ b/packages/agoric-cli/lib/open.js
@@ -5,7 +5,7 @@ import path from 'path';
 
 import { openSwingStore } from '@agoric/swing-store-simple';
 
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 // Adapted from https://stackoverflow.com/a/43866992/14073862
 export function generateAccessToken({

--- a/packages/agoric-cli/lib/open.js
+++ b/packages/agoric-cli/lib/open.js
@@ -5,6 +5,8 @@ import path from 'path';
 
 import { openSwingStore } from '@agoric/swing-store-simple';
 
+const { details: X } = assert;
+
 // Adapted from https://stackoverflow.com/a/43866992/14073862
 export function generateAccessToken({
   stringBase = 'base64url',
@@ -71,7 +73,10 @@ export default async function walletMain(progname, rawArgs, powers, opts) {
       suffix = '?w=0';
       break;
     default:
-      throw TypeError(`Unexpected --repl option ${JSON.stringify(opts.repl)}`);
+      assert.fail(
+        X`Unexpected --repl option ${JSON.stringify(opts.repl)}`,
+        TypeError,
+      );
   }
 
   process.stderr.write(`Launching wallet...`);

--- a/packages/agoric-cli/lib/set-defaults.js
+++ b/packages/agoric-cli/lib/set-defaults.js
@@ -1,11 +1,10 @@
 import { basename } from 'path';
+import { assert, details as X } from '@agoric/assert';
 import {
   finishCosmosApp,
   finishCosmosConfig,
   finishCosmosGenesis,
 } from './chain-config';
-
-const { details: X } = assert;
 
 export default async function setDefaultsMain(progname, rawArgs, powers, opts) {
   const { anylogger, fs } = powers;

--- a/packages/agoric-cli/lib/set-defaults.js
+++ b/packages/agoric-cli/lib/set-defaults.js
@@ -5,15 +5,18 @@ import {
   finishCosmosGenesis,
 } from './chain-config';
 
+const { details: X } = assert;
+
 export default async function setDefaultsMain(progname, rawArgs, powers, opts) {
   const { anylogger, fs } = powers;
   const log = anylogger('agoric:set-defaults');
 
   const [prog, configDir] = rawArgs.slice(1);
 
-  if (prog !== 'ag-chain-cosmos') {
-    throw Error(`<prog> must currently be 'ag-chain-cosmos'`);
-  }
+  assert(
+    prog === 'ag-chain-cosmos',
+    X`<prog> must currently be 'ag-chain-cosmos'`,
+  );
 
   let appFile;
   let configFile;

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -26,6 +26,7 @@
     "tmp": "^0.1.0"
   },
   "dependencies": {
+    "@agoric/assert": "^0.2.0",
     "@agoric/bundle-source": "^1.2.0",
     "@agoric/captp": "^1.7.0",
     "@agoric/install-ses": "^0.5.0",

--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -48,7 +48,7 @@ export { globalAssert as assert, details, quote };
 // abbreviation 'q' for quote.
 //
 // ```js
-// import { quote as q, details as d } from '@agoric/assert';
+// import { quote as q, details as X } from '@agoric/assert';
 // ```
 export { quote as q };
 

--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -44,12 +44,6 @@ const { details, quote } = globalAssert;
 
 export { globalAssert as assert, details, quote };
 
-// DEPRECATED: Going forward we encourage the pattern over importing the
-// abbreviation 'q' for quote.
-//
-// ```js
-// import { quote as q, details as X } from '@agoric/assert';
-// ```
 export { quote as q };
 
 /**

--- a/packages/assert/src/types.js
+++ b/packages/assert/src/types.js
@@ -151,8 +151,6 @@
  */
 
 /**
- * @callback AssertQuote
- *
  * To "declassify" and quote a substitution value used in a
  * details`...` template literal, enclose that substitution expression
  * in a call to `quote`. This states that the argument should appear quoted
@@ -171,11 +169,10 @@
  *   details`${sky.color} should be ${quote(color)}`,
  * );
  * ```
- *
- * The normal convention is to locally rename `quote` to `q` and
- * `details` to `X`
+ * The normal convention is to locally rename `details` to `X` and import `q`
+ * and `assert` unmodified.
  * ```js
- * const { details: X, quote: q } = assert;
+ * import { assert, details as X, q } from \'@agoric/assert\';
  * ```
  * so the above example would then be
  * ```js
@@ -186,6 +183,7 @@
  * );
  * ```
  *
+ * @callback AssertQuote
  * @param {*} payload What to declassify
  * @returns {StringablePayload} The declassified payload
  */

--- a/packages/assert/src/types.js
+++ b/packages/assert/src/types.js
@@ -173,16 +173,16 @@
  * ```
  *
  * The normal convention is to locally rename `quote` to `q` and
- * `details` to `d`
+ * `details` to `X`
  * ```js
- * const { details: d, quote: q } = assert;
+ * const { details: X, quote: q } = assert;
  * ```
  * so the above example would then be
  * ```js
  * assert.equal(
  *   sky.color,
  *   color,
- *   d`${sky.color} should be ${q(color)}`,
+ *   X`${sky.color} should be ${q(color)}`,
  * );
  * ```
  *

--- a/packages/cosmic-swingset/calc-rpcport.js
+++ b/packages/cosmic-swingset/calc-rpcport.js
@@ -4,6 +4,8 @@ const process = require('process');
 const fs = require('fs');
 const toml = require('@iarna/toml');
 
+const { details: X } = assert;
+
 // point this at ~/.ag-cosmos-chain/config/config.toml
 
 const configString = fs.readFileSync(process.argv[2]).toString();
@@ -11,9 +13,7 @@ const config = toml.parse(configString);
 const { laddr } = config.rpc; // like tcp://0.0.0.0:26657
 // eslint-disable-next-line no-useless-escape
 const m = laddr.match(/^tcp:\/\/([\d\.]+):(\d+)$/);
-if (!m) {
-  throw new Error(`error, unexpected laddr format ${laddr}`);
-}
+assert(m, X`error, unexpected laddr format ${laddr}`);
 let addr = m[1];
 if (addr === '0.0.0.0') {
   addr = '127.0.0.1';

--- a/packages/cosmic-swingset/calc-rpcport.js
+++ b/packages/cosmic-swingset/calc-rpcport.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
+// NOTE: Runs outside SES
+
 const process = require('process');
 const fs = require('fs');
 const toml = require('@iarna/toml');
-
-const { details: X } = assert;
 
 // point this at ~/.ag-cosmos-chain/config/config.toml
 
@@ -13,7 +13,9 @@ const config = toml.parse(configString);
 const { laddr } = config.rpc; // like tcp://0.0.0.0:26657
 // eslint-disable-next-line no-useless-escape
 const m = laddr.match(/^tcp:\/\/([\d\.]+):(\d+)$/);
-assert(m, X`error, unexpected laddr format ${laddr}`);
+if (!m) {
+  throw new Error(`error, unexpected laddr format ${laddr}`);
+}
 let addr = m[1];
 if (addr === '0.0.0.0') {
   addr = '127.0.0.1';

--- a/packages/cosmic-swingset/lib/ag-solo/add-chain.js
+++ b/packages/cosmic-swingset/lib/ag-solo/add-chain.js
@@ -4,9 +4,8 @@ import djson from 'deterministic-json';
 import path from 'path';
 import fs from 'fs';
 
+import { assert, details as X } from '@agoric/assert';
 import setGCIIngress from './set-gci-ingress';
-
-const { details: X } = assert;
 
 const DEFAULT_CHAIN_CONFIG = 'https://testnet.agoric.com/network-config';
 

--- a/packages/cosmic-swingset/lib/ag-solo/add-chain.js
+++ b/packages/cosmic-swingset/lib/ag-solo/add-chain.js
@@ -6,6 +6,8 @@ import fs from 'fs';
 
 import setGCIIngress from './set-gci-ingress';
 
+const { details: X } = assert;
+
 const DEFAULT_CHAIN_CONFIG = 'https://testnet.agoric.com/network-config';
 
 /**
@@ -62,9 +64,7 @@ async function addChain(basedir, chainConfig, force = false) {
     netconf.gci = gci;
   }
 
-  if (!netconf.gci) {
-    throw Error(`${url.href} does not contain a "gci" entry`);
-  }
+  assert(netconf.gci, X`${url.href} does not contain a "gci" entry`);
 
   const connFile = path.join(basedir, 'connections.json');
   const conns = JSON.parse(fs.readFileSync(connFile));

--- a/packages/cosmic-swingset/lib/ag-solo/chain-cosmos-sdk.js
+++ b/packages/cosmic-swingset/lib/ag-solo/chain-cosmos-sdk.js
@@ -11,6 +11,8 @@ import { makePromiseKit } from '@agoric/promise-kit';
 
 import { makeBatchedDeliver } from './batched-deliver';
 
+const { details: X } = assert;
+
 const log = anylogger('chain-cosmos-sdk');
 
 const HELPER = 'ag-cosmos-helper';
@@ -391,9 +393,7 @@ ${chainID} chain does not yet know of address ${myAddr}${adviseEgress(myAddr)}
     blockNotifier
       .getUpdateSince(lastBlockUpdate)
       .then(({ updateCount, value }) => {
-        if (!value) {
-          throw Error(`${GCI} unexpectedly finished!`);
-        }
+        assert(value, X`${GCI} unexpectedly finished!`);
         log.debug(`new block on ${GCI}, fetching mailbox`);
         getMailbox()
           .then(ret => {
@@ -498,7 +498,7 @@ ${chainID} chain does not yet know of address ${myAddr}${adviseEgress(myAddr)}
             // We submitted the transaction successfully.
             return {};
           }
-          throw Error(`Unexpected output: ${stdout.trimRight()}`);
+          assert.fail(X`Unexpected output: ${stdout.trimRight()}`);
         },
         undefined,
         {}, // defaultIfCancelled

--- a/packages/cosmic-swingset/lib/ag-solo/chain-cosmos-sdk.js
+++ b/packages/cosmic-swingset/lib/ag-solo/chain-cosmos-sdk.js
@@ -9,9 +9,8 @@ import anylogger from 'anylogger';
 import { makeNotifierKit } from '@agoric/notifier';
 import { makePromiseKit } from '@agoric/promise-kit';
 
+import { assert, details as X } from '@agoric/assert';
 import { makeBatchedDeliver } from './batched-deliver';
-
-const { details: X } = assert;
 
 const log = anylogger('chain-cosmos-sdk');
 
@@ -112,7 +111,6 @@ export async function connectToChain(
     throwIfCancelled = () => undefined,
     defaultIfCancelled = WAS_CANCELLED_EXCEPTION,
   ) {
-    // eslint-disable-next-line consistent-return
     return retryRpcAddr(async rpcAddr => {
       await throwIfCancelled();
 

--- a/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
+++ b/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
@@ -9,12 +9,11 @@ import {
 
 import anylogger from 'anylogger';
 
+import { assert, details as X } from '@agoric/assert';
 import { launch } from '../launch-chain';
 import makeBlockManager from '../block-manager';
 import { makeWithQueue } from './vats/queue';
 import { makeBatchedDeliver } from './batched-deliver';
-
-const { details: X } = assert;
 
 const log = anylogger('fake-chain');
 

--- a/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
+++ b/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
@@ -14,6 +14,8 @@ import makeBlockManager from '../block-manager';
 import { makeWithQueue } from './vats/queue';
 import { makeBatchedDeliver } from './batched-deliver';
 
+const { details: X } = assert;
+
 const log = anylogger('fake-chain');
 
 const PRETEND_BLOCK_DELAY = 5;
@@ -60,9 +62,7 @@ export async function connectToFakeChain(basedir, GCI, delay, inbound) {
     return `Bridge device (${dstID}) not implemented for fake-chain`;
   }
   function flushChainSends(replay) {
-    if (replay) {
-      throw Error(`Replay not implemented`);
-    }
+    assert(!replay, X`Replay not implemented`);
   }
   const s = await launch(
     stateDBdir,

--- a/packages/cosmic-swingset/lib/ag-solo/html/main.js
+++ b/packages/cosmic-swingset/lib/ag-solo/html/main.js
@@ -1,3 +1,5 @@
+const { details: X } = assert;
+
 /* global WebSocket fetch document window walletFrame localStorage */
 const RECONNECT_BACKOFF_SECONDS = 3;
 // Functions to run to reset the HTML state to what it was.
@@ -63,7 +65,7 @@ function run() {
     if (j.ok) {
       return j.res;
     }
-    throw new Error(`server error: ${JSON.stringify(j.rej)}`);
+    assert.fail(X`server error: ${JSON.stringify(j.rej)}`);
   }
 
   const protocol = window.location.protocol.replace(/^http/, 'ws');
@@ -300,9 +302,7 @@ run();
 const fetches = [];
 const fgr = fetch('/git-revision.txt')
   .then(resp => {
-    if (resp.status < 200 || resp.status >= 300) {
-      throw Error(`status ${resp.status}`);
-    }
+    assert(resp.status >= 200 && resp.status < 300, X`status ${resp.status}`);
     return resp.text();
   })
   .then(text => {
@@ -329,9 +329,7 @@ if (
 ) {
   fetch(`wallet/${accessTokenParams}`)
     .then(resp => {
-      if (resp.status < 200 || resp.status >= 300) {
-        throw Error(`status ${resp.status}`);
-      }
+      assert(resp.status >= 200 && resp.status < 300, X`status ${resp.status}`);
       walletFrame.style.display = 'block';
       walletFrame.src = `wallet/#${accessTokenParams.slice(1)}`;
     })

--- a/packages/cosmic-swingset/lib/ag-solo/html/main.js
+++ b/packages/cosmic-swingset/lib/ag-solo/html/main.js
@@ -1,4 +1,4 @@
-const { details: X } = assert;
+// NOTE: Runs outside SES
 
 /* global WebSocket fetch document window walletFrame localStorage */
 const RECONNECT_BACKOFF_SECONDS = 3;
@@ -65,7 +65,7 @@ function run() {
     if (j.ok) {
       return j.res;
     }
-    assert.fail(X`server error: ${JSON.stringify(j.rej)}`);
+    throw new Error(`server error: ${JSON.stringify(j.rej)}`);
   }
 
   const protocol = window.location.protocol.replace(/^http/, 'ws');
@@ -302,7 +302,9 @@ run();
 const fetches = [];
 const fgr = fetch('/git-revision.txt')
   .then(resp => {
-    assert(resp.status >= 200 && resp.status < 300, X`status ${resp.status}`);
+    if (resp.status < 200 || resp.status >= 300) {
+      throw Error(`status ${resp.status}`);
+    }
     return resp.text();
   })
   .then(text => {
@@ -329,7 +331,9 @@ if (
 ) {
   fetch(`wallet/${accessTokenParams}`)
     .then(resp => {
-      assert(resp.status >= 200 && resp.status < 300, X`status ${resp.status}`);
+      if (resp.status < 200 || resp.status >= 300) {
+        throw Error(`status ${resp.status}`);
+      }
       walletFrame.style.display = 'block';
       walletFrame.src = `wallet/#${accessTokenParams.slice(1)}`;
     })

--- a/packages/cosmic-swingset/lib/ag-solo/outbound.js
+++ b/packages/cosmic-swingset/lib/ag-solo/outbound.js
@@ -1,5 +1,7 @@
 import anylogger from 'anylogger';
 
+const { details: X } = assert;
+
 const log = anylogger('outbound');
 
 /**
@@ -50,9 +52,7 @@ export function deliver(mbs) {
 }
 
 export function addDeliveryTarget(target, deliverator) {
-  if (knownTargets.has(target)) {
-    throw new Error(`target ${target} already added`);
-  }
+  assert(!knownTargets.has(target), X`target ${target} already added`);
   /** @type {TargetRecord} */
   const targetRecord = { deliverator, highestSent: 0, highestAck: 0 };
   knownTargets.set(target, targetRecord);

--- a/packages/cosmic-swingset/lib/ag-solo/outbound.js
+++ b/packages/cosmic-swingset/lib/ag-solo/outbound.js
@@ -1,6 +1,6 @@
 import anylogger from 'anylogger';
 
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 const log = anylogger('outbound');
 

--- a/packages/cosmic-swingset/lib/ag-solo/start.js
+++ b/packages/cosmic-swingset/lib/ag-solo/start.js
@@ -279,7 +279,7 @@ export default async function start(basedir, argv) {
 
   const vatsDir = path.join(basedir, 'vats');
   const stateDBDir = path.join(basedir, 'swingset-kernel-state');
-  const dp = await buildSwingset(
+  const d = await buildSwingset(
     stateDBDir,
     mailboxStateFile,
     vatsDir,
@@ -293,7 +293,7 @@ export default async function start(basedir, argv) {
     deliverOutbound,
     startTimer,
     resetOutdatedState,
-  } = dp;
+  } = d;
 
   // Remove wallet traces.
   await unlink('html/wallet').catch(_ => {});

--- a/packages/cosmic-swingset/lib/ag-solo/start.js
+++ b/packages/cosmic-swingset/lib/ag-solo/start.js
@@ -10,7 +10,7 @@ import anylogger from 'anylogger';
 // import connect from 'lotion-connect';
 // import djson from 'deterministic-json';
 
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import {
   loadBasedir,
   loadSwingsetConfigFile,
@@ -104,7 +104,7 @@ async function buildSwingset(
     const pluginFile = path.resolve(pluginsPrefix, mod);
     assert(
       pluginFile.startsWith(pluginsPrefix),
-      details`Cannot load ${pluginFile} plugin; outside of ${pluginDir}`,
+      X`Cannot load ${pluginFile} plugin; outside of ${pluginDir}`,
     );
 
     // eslint-disable-next-line import/no-dynamic-require,global-require
@@ -169,9 +169,7 @@ async function buildSwingset(
   // other inbound messages.
   const queuedDeliverInboundToMbx = withInputQueue(
     async function deliverInboundToMbx(sender, messages, ack) {
-      if (!Array.isArray(messages)) {
-        throw new Error(`inbound given non-Array: ${messages}`);
-      }
+      assert(Array.isArray(messages), X`inbound given non-Array: ${messages}`);
       // console.debug(`deliverInboundToMbx`, messages, ack);
       if (mb.deliverInbound(sender, messages, ack, true)) {
         await processKernel();
@@ -281,7 +279,7 @@ export default async function start(basedir, argv) {
 
   const vatsDir = path.join(basedir, 'vats');
   const stateDBDir = path.join(basedir, 'swingset-kernel-state');
-  const d = await buildSwingset(
+  const dp = await buildSwingset(
     stateDBDir,
     mailboxStateFile,
     vatsDir,
@@ -295,7 +293,7 @@ export default async function start(basedir, argv) {
     deliverOutbound,
     startTimer,
     resetOutdatedState,
-  } = d;
+  } = dp;
 
   // Remove wallet traces.
   await unlink('html/wallet').catch(_ => {});
@@ -350,9 +348,7 @@ export default async function start(basedir, argv) {
         }
         case 'http':
           log(`adding HTTP/WS listener on ${c.host}:${c.port}`);
-          if (broadcastJSON) {
-            throw new Error(`duplicate type=http in connections.json`);
-          }
+          assert(!broadcastJSON, X`duplicate type=http in connections.json`);
           hostport = `${c.host}:${c.port}`;
           broadcastJSON = await makeHTTPListener(
             basedir,
@@ -362,7 +358,7 @@ export default async function start(basedir, argv) {
           );
           break;
         default:
-          throw new Error(`unknown connection type in ${c}`);
+          assert.fail(X`unknown connection type in ${c}`);
       }
     }),
   );

--- a/packages/cosmic-swingset/lib/ag-solo/upload-contract.js
+++ b/packages/cosmic-swingset/lib/ag-solo/upload-contract.js
@@ -6,7 +6,7 @@
 
 import { E } from '@agoric/eventual-send';
 
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 export default async function uploadContracts({ home, bundle }) {
   console.error(`Installing targeted contracts...`);

--- a/packages/cosmic-swingset/lib/ag-solo/upload-contract.js
+++ b/packages/cosmic-swingset/lib/ag-solo/upload-contract.js
@@ -6,6 +6,8 @@
 
 import { E } from '@agoric/eventual-send';
 
+const { details: X } = assert;
+
 export default async function uploadContracts({ home, bundle }) {
   console.error(`Installing targeted contracts...`);
   // eslint-disable-next-line no-use-before-define
@@ -24,9 +26,7 @@ export async function upload(homeP, bundle, keys, verbose = false) {
   const contractsAP = [];
   for (const key of keys) {
     const match = key.match(/^(([^:]+):.+)$/);
-    if (!match) {
-      throw Error(`${key} isn't TARGET:NAME`);
-    }
+    assert(match, X`${key} isn't TARGET:NAME`);
     const name = match[1];
     const target = match[2];
     const { source, moduleFormat } = bundle[key];

--- a/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
@@ -9,10 +9,9 @@ import { E } from '@agoric/eventual-send';
 // this will return { undefined } until `ag-solo set-gci-ingress`
 // has been run to update gci.js
 import { makePluginManager } from '@agoric/swingset-vat/src/vats/plugin-manager';
+import { assert, details as X } from '@agoric/assert';
 import { GCI } from './gci';
 import { makeBridgeManager } from './bridge';
-
-const { details: X } = assert;
 
 const NUM_IBC_PORTS = 3;
 const CENTRAL_ISSUER_NAME = 'Testnet.$USD';

--- a/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
@@ -12,6 +12,8 @@ import { makePluginManager } from '@agoric/swingset-vat/src/vats/plugin-manager'
 import { GCI } from './gci';
 import { makeBridgeManager } from './bridge';
 
+const { details: X } = assert;
+
 const NUM_IBC_PORTS = 3;
 const CENTRAL_ISSUER_NAME = 'Testnet.$USD';
 const QUOTE_INTERVAL = 30;
@@ -328,7 +330,7 @@ export function buildRootObject(vatPowers, vatParameters) {
                 );
             }
             default:
-              throw Error(`Unrecognized request ${obj.type}`);
+              assert.fail(X`Unrecognized request ${obj.type}`);
           }
         },
       });
@@ -447,9 +449,7 @@ export function buildRootObject(vatPowers, vatParameters) {
 
         // ag-setup-solo runs this.
         case 'client': {
-          if (!GCI) {
-            throw new Error(`client must be given GCI`);
-          }
+          assert(GCI, X`client must be given GCI`);
 
           const localTimerService = await E(vats.timer).createTimerService(
             devices.timer,
@@ -527,7 +527,7 @@ export function buildRootObject(vatPowers, vatParameters) {
           break;
         }
         default:
-          throw new Error(`ROLE was not recognized: ${ROLE}`);
+          assert.fail(X`ROLE was not recognized: ${ROLE}`);
       }
 
       console.debug(`all vats initialized for ${ROLE}`);

--- a/packages/cosmic-swingset/lib/ag-solo/vats/bridge.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bridge.js
@@ -2,6 +2,7 @@
 
 import makeStore from '@agoric/store';
 import '@agoric/store/exported';
+import { assert, details as X } from '@agoric/assert';
 
 /**
  * @template T
@@ -55,9 +56,7 @@ export function makeBridgeManager(E, D, bridgeDevice) {
   const bridgeHandler = harden({ inbound: bridgeInbound });
 
   function callOutbound(dstID, obj) {
-    if (!bridgeDevice) {
-      throw Error(`bridge device not yet connected`);
-    }
+    assert(bridgeDevice, X`bridge device not yet connected`);
     const retobj = D(bridgeDevice).callOutbound(dstID, obj);
     // note: *we* get this return value synchronously, but any callers (in
     // separate vats) only get a Promise, and will receive the value in some
@@ -79,9 +78,10 @@ export function makeBridgeManager(E, D, bridgeDevice) {
       srcHandlers.init(srcID, handler);
     },
     unregister(srcID, handler) {
-      if (srcHandlers.get(srcID) !== handler) {
-        throw Error(`Handler was not registered for ${srcID}`);
-      }
+      assert(
+        srcHandlers.get(srcID) === handler,
+        X`Handler was not registered for ${srcID}`,
+      );
       srcHandlers.delete(srcID);
     },
   });

--- a/packages/cosmic-swingset/lib/ag-solo/vats/ibc.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/ibc.js
@@ -7,6 +7,7 @@ import {
 } from '@agoric/swingset-vat/src/vats/network';
 import makeStore from '@agoric/store';
 import { makePromiseKit } from '@agoric/promise-kit';
+import { assert, details as X } from '@agoric/assert';
 
 import '@agoric/store/exported';
 import '@agoric/swingset-vat/src/vats/network/types';
@@ -409,9 +410,7 @@ EOF
             },
           );
 
-          if (oidx < 0) {
-            throw Error(`${portID}: did not expect channelOpenInit`);
-          }
+          assert(oidx >= 0, X`${portID}: did not expect channelOpenInit`);
 
           // Continue the handshake by extracting the outbound information.
           const { onConnectP, ...chanInfo } = outbounds[oidx];
@@ -512,9 +511,10 @@ EOF
             counterpartyVersion: rVersion,
           } = obj;
           const channelKey = `${channelID}:${portID}`;
-          if (!channelKeyToOnConnectP.has(channelKey)) {
-            throw Error(`${channelKey}: did not expect channelOpenAck`);
-          }
+          assert(
+            channelKeyToOnConnectP.has(channelKey),
+            X`${channelKey}: did not expect channelOpenAck`,
+          );
           const onConnectP = channelKeyToOnConnectP.get(channelKey);
           channelKeyToOnConnectP.delete(channelKey);
 
@@ -540,9 +540,10 @@ EOF
         case 'channelOpenConfirm': {
           const { portID, channelID } = obj;
           const channelKey = `${channelID}:${portID}`;
-          if (!channelKeyToAttemptP.has(channelKey)) {
-            throw Error(`${channelKey}: did not expect channelOpenConfirm`);
-          }
+          assert(
+            channelKeyToAttemptP.has(channelKey),
+            X`${channelKey}: did not expect channelOpenConfirm`,
+          );
           const attemptP = channelKeyToAttemptP.get(channelKey);
           channelKeyToAttemptP.delete(channelKey);
 
@@ -643,7 +644,7 @@ EOF
 
         default:
           console.error('Unexpected IBC_EVENT', obj.event);
-          throw TypeError(`unrecognized method ${obj.event}`);
+          assert.fail(X`unrecognized method ${obj.event}`, TypeError);
       }
     },
   });

--- a/packages/cosmic-swingset/lib/ag-solo/vats/lib-board.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/lib-board.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { generateSparseInts } from '@agoric/sparse-ints';
-import { assert, details, q } from '@agoric/assert';
+import { assert, details as X, q } from '@agoric/assert';
 import makeStore from '@agoric/store';
 import { models as crcmodels } from 'polycrc';
 
@@ -57,10 +57,10 @@ function makeBoard(seed = 0) {
       return valToId.get(value);
     },
     getValue: id => {
-      assert.equal(typeof id, 'string', details`id must be string ${id}`);
+      assert.equal(typeof id, 'string', X`id must be string ${id}`);
       assert(
         id.match(ID_REGEXP),
-        details`id must consist of at least ${q(CRC_NUM_DIGITS + 1)} digits`,
+        X`id must consist of at least ${q(CRC_NUM_DIGITS + 1)} digits`,
       );
       const num = Number(id.slice(0, -CRC_NUM_DIGITS));
       const allegedCrc = id.slice(-CRC_NUM_DIGITS);
@@ -68,9 +68,9 @@ function makeBoard(seed = 0) {
       assert.equal(
         allegedCrc,
         crc,
-        details`id is probably a typo, cannot verify CRC: ${id}`,
+        X`id is probably a typo, cannot verify CRC: ${id}`,
       );
-      assert(idToVal.has(id), details`board does not have id: ${id}`);
+      assert(idToVal.has(id), X`board does not have id: ${id}`);
       return idToVal.get(id);
     },
     has: valToId.has,

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-http.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-http.js
@@ -1,9 +1,8 @@
 import { makeNotifierKit } from '@agoric/notifier';
 import { E } from '@agoric/eventual-send';
+import { assert, details as X } from '@agoric/assert';
 import { getReplHandler } from './repl';
 import { getCapTPHandler } from './captp';
-
-const { details: X } = assert;
 
 // This vat contains the HTTP request handler.
 export function buildRootObject(vatPowers) {

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-http.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-http.js
@@ -3,6 +3,8 @@ import { E } from '@agoric/eventual-send';
 import { getReplHandler } from './repl';
 import { getCapTPHandler } from './captp';
 
+const { details: X } = assert;
+
 // This vat contains the HTTP request handler.
 export function buildRootObject(vatPowers) {
   const { D } = vatPowers;
@@ -71,8 +73,8 @@ export function buildRootObject(vatPowers) {
   }
 
   return harden({
-    setCommandDevice(d) {
-      commandDevice = d;
+    setCommandDevice(dp) {
+      commandDevice = dp;
 
       const replHandler = getReplHandler(replObjects, send, vatPowers);
       registerURLHandler(replHandler, '/private/repl');
@@ -187,7 +189,7 @@ export function buildRootObject(vatPowers) {
 
         if (dispatcher === 'onMessage') {
           sendResponse(count, false, { type: 'doesNotUnderstand', obj });
-          throw Error(`No handler for ${url} ${type}`);
+          assert.fail(X`No handler for ${url} ${type}`);
         }
         sendResponse(count, false, true);
       } catch (rej) {

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-http.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-http.js
@@ -72,8 +72,8 @@ export function buildRootObject(vatPowers) {
   }
 
   return harden({
-    setCommandDevice(dp) {
-      commandDevice = dp;
+    setCommandDevice(d) {
+      commandDevice = d;
 
       const replHandler = getReplHandler(replObjects, send, vatPowers);
       registerURLHandler(replHandler, '/private/repl');

--- a/packages/cosmic-swingset/lib/block-manager.js
+++ b/packages/cosmic-swingset/lib/block-manager.js
@@ -1,6 +1,6 @@
 import anylogger from 'anylogger';
 
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 const log = anylogger('block-manager');
 

--- a/packages/cosmic-swingset/lib/block-manager.js
+++ b/packages/cosmic-swingset/lib/block-manager.js
@@ -1,5 +1,7 @@
 import anylogger from 'anylogger';
 
+const { details: X } = assert;
+
 const log = anylogger('block-manager');
 
 const BEGIN_BLOCK = 'BEGIN_BLOCK';
@@ -64,7 +66,7 @@ export default function makeBlockManager({
         break;
 
       default:
-        throw new Error(`${action.type} not recognized`);
+        assert.fail(X`${action.type} not recognized`);
     }
     p.then(finish, finish);
     return p;

--- a/packages/cosmic-swingset/lib/chain-main.js
+++ b/packages/cosmic-swingset/lib/chain-main.js
@@ -10,13 +10,16 @@ import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
 import { launch } from './launch-chain';
 import makeBlockManager from './block-manager';
 
+const { details: X } = assert;
+
 const AG_COSMOS_INIT = 'AG_COSMOS_INIT';
 
 const toNumber = specimen => {
   const number = parseInt(specimen, 10);
-  if (String(number) !== String(specimen)) {
-    throw Error(`Could not parse ${JSON.stringify(specimen)} as a number`);
-  }
+  assert(
+    String(number) === String(specimen),
+    X`Could not parse ${JSON.stringify(specimen)} as a number`,
+  );
   return number;
 };
 
@@ -214,7 +217,9 @@ export default async function main(progname, args, { path, env, agcc }) {
       try {
         return JSON.parse(retStr);
       } catch (e) {
-        throw Error(`cannot JSON.parse(${JSON.stringify(retStr)}): ${e}`);
+        assert.fail(
+          X`cannot JSON.parse(${JSON.stringify(retStr)}): ${e}`,
+        );
       }
     }
 

--- a/packages/cosmic-swingset/lib/chain-main.js
+++ b/packages/cosmic-swingset/lib/chain-main.js
@@ -7,10 +7,9 @@ import {
 import { MeterProvider } from '@opentelemetry/metrics';
 import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
 
+import { assert, details as X } from '@agoric/assert';
 import { launch } from './launch-chain';
 import makeBlockManager from './block-manager';
-
-const { details: X } = assert;
 
 const AG_COSMOS_INIT = 'AG_COSMOS_INIT';
 
@@ -217,9 +216,7 @@ export default async function main(progname, args, { path, env, agcc }) {
       try {
         return JSON.parse(retStr);
       } catch (e) {
-        assert.fail(
-          X`cannot JSON.parse(${JSON.stringify(retStr)}): ${e}`,
-        );
+        assert.fail(X`cannot JSON.parse(${JSON.stringify(retStr)}): ${e}`);
       }
     }
 

--- a/packages/cosmic-swingset/lib/check-lmdb.js
+++ b/packages/cosmic-swingset/lib/check-lmdb.js
@@ -8,6 +8,8 @@ import {
   initSwingStore as initSwingStoreSimple,
 } from '@agoric/swing-store-simple';
 
+const { details: X } = assert;
+
 /*
  * Return an 'openSwingStore' function for the best kind of DB that works on
  * this platform. This will be LMDB if possible, else Simple.
@@ -33,13 +35,12 @@ export function getBestSwingStore(tempdir) {
     tdb1.close();
 
     const tdb2 = openSwingStoreLMDB(tempdir);
-    if (!tdb2.storage.has('test key')) {
-      throw Error(`LMDB test disavows test key`);
-    }
+    assert(tdb2.storage.has('test key'), X`LMDB test disavows test key`);
     const val = tdb2.storage.get('test key');
-    if (val !== 'test value') {
-      throw Error(`LMDB test returned '${val}', not 'test value'`);
-    }
+    assert(
+      val === 'test value',
+      X`LMDB test returned '${val}', not 'test value'`,
+    );
     tdb2.close();
     // if we made it this far, LMDB works
     return {

--- a/packages/cosmic-swingset/lib/check-lmdb.js
+++ b/packages/cosmic-swingset/lib/check-lmdb.js
@@ -8,7 +8,7 @@ import {
   initSwingStore as initSwingStoreSimple,
 } from '@agoric/swing-store-simple';
 
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 /*
  * Return an 'openSwingStore' function for the best kind of DB that works on

--- a/packages/cosmic-swingset/lib/launch-chain.js
+++ b/packages/cosmic-swingset/lib/launch-chain.js
@@ -14,10 +14,9 @@ import {
   loadBasedir,
   loadSwingsetConfigFile,
 } from '@agoric/swingset-vat';
+import { assert, details as X } from '@agoric/assert';
 import { getBestSwingStore } from './check-lmdb';
 import { exportKernelStats } from './kernel-stats';
-
-const { details: X } = assert;
 
 const log = anylogger('launch-chain');
 

--- a/packages/cosmic-swingset/lib/launch-chain.js
+++ b/packages/cosmic-swingset/lib/launch-chain.js
@@ -17,6 +17,8 @@ import {
 import { getBestSwingStore } from './check-lmdb';
 import { exportKernelStats } from './kernel-stats';
 
+const { details: X } = assert;
+
 const log = anylogger('launch-chain');
 
 const SWING_STORE_META_KEY = 'cosmos/meta';
@@ -130,9 +132,7 @@ export async function launch(
   }
 
   async function deliverInbound(sender, messages, ack) {
-    if (!Array.isArray(messages)) {
-      throw new Error(`inbound given non-Array: ${messages}`);
-    }
+    assert(Array.isArray(messages), X`inbound given non-Array: ${messages}`);
     if (!mb.deliverInbound(sender, messages, ack)) {
       return;
     }

--- a/packages/dapp-svelte-wallet/api/deploy.js
+++ b/packages/dapp-svelte-wallet/api/deploy.js
@@ -3,7 +3,7 @@
 // FIXME: This is just hacked together for the legacy wallet.
 
 import { E } from '@agoric/eventual-send';
-import { assert } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 
 export default async function deployWallet(
   homePromise,
@@ -40,7 +40,7 @@ export default async function deployWallet(
       issuers.map(async ([issuerPetname, issuer]) => {
         const brand = await E(issuer).getBrand();
         const brandMatches = E(brand).isMyIssuer(issuer);
-        assert(brandMatches, `issuer was using a brand which was not its own`);
+        assert(brandMatches, X`issuer was using a brand which was not its own`);
         brandToIssuer.set(brand, { issuerPetname, issuer });
       }),
     ]);

--- a/packages/dapp-svelte-wallet/api/src/findOrMakeInvitation.js
+++ b/packages/dapp-svelte-wallet/api/src/findOrMakeInvitation.js
@@ -141,7 +141,5 @@ export const findOrMakeInvitation = async (
     );
   }
 
-  assert.fail(
-    X`no invitation was found or made for this offer ${offer.id}`,
-  );
+  assert.fail(X`no invitation was found or made for this offer ${offer.id}`);
 };

--- a/packages/dapp-svelte-wallet/api/src/findOrMakeInvitation.js
+++ b/packages/dapp-svelte-wallet/api/src/findOrMakeInvitation.js
@@ -1,4 +1,4 @@
-import { assert, details, q } from '@agoric/assert';
+import { assert, details as X, q } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
 import { passStyleOf } from '@agoric/marshal';
 
@@ -9,13 +9,11 @@ const assertFirstCapASCII = str => {
   const firstCapASCII = /^[A-Z][a-zA-Z0-9_$]*$/;
   assert(
     firstCapASCII.test(str),
-    details`The string ${q(
-      str,
-    )} must be ascii and must start with a capital letter.`,
+    X`The string ${q(str)} must be ascii and must start with a capital letter.`,
   );
   assert(
     str !== 'NaN' && str !== 'Infinity',
-    details`keyword ${q(str)} must not be a number's name`,
+    X`keyword ${q(str)} must not be a number's name`,
   );
 };
 
@@ -34,7 +32,7 @@ const findByBoardId = async (invitationPurseBalance, { board, boardId }) => {
   const matchingValue = invitationPurseBalance.value.find(match);
   assert(
     matchingValue,
-    details`Cannot find invitation corresponding to ${q(boardId)}`,
+    X`Cannot find invitation corresponding to ${q(boardId)}`,
   );
 
   return harden([matchingValue]);
@@ -58,10 +56,7 @@ const findByKeyValuePairs = async (invitationPurseBalance, kvs) => {
     );
 
   const matchingValue = invitationPurseBalance.value.find(matches);
-  assert(
-    matchingValue,
-    details`Cannot find invitation corresponding to ${q(kvs)}`,
-  );
+  assert(matchingValue, X`Cannot find invitation corresponding to ${q(kvs)}`);
   return harden([matchingValue]);
 };
 
@@ -146,5 +141,7 @@ export const findOrMakeInvitation = async (
     );
   }
 
-  throw Error(`no invitation was found or made for this offer ${offer.id}`);
+  assert.fail(
+    X`no invitation was found or made for this offer ${offer.id}`,
+  );
 };

--- a/packages/dapp-svelte-wallet/api/src/lib-dehydrate.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-dehydrate.js
@@ -2,7 +2,7 @@
 
 import { makeMarshal } from '@agoric/marshal';
 import makeStore from '@agoric/store';
-import { assert, details, q } from '@agoric/assert';
+import { assert, details as X, q } from '@agoric/assert';
 
 /* eslint-disable jsdoc/valid-types */
 /**
@@ -16,7 +16,7 @@ export const isPath = x => {
   if (!Array.isArray(x)) {
     return false;
   }
-  assert(x.length > 0, details`Path ${q(x)} must not be empty`);
+  assert(x.length > 0, X`Path ${q(x)} must not be empty`);
   for (const name of x) {
     if (typeof name !== 'string') {
       return false;
@@ -49,7 +49,7 @@ export const makeDehydrator = (initialUnnamedCount = 0) => {
   const explode = data => {
     assert(
       data.startsWith(IMPLODE_PREFIX),
-      details`exploded string ${data} must start with ${q(IMPLODE_PREFIX)}`,
+      X`exploded string ${data} must start with ${q(IMPLODE_PREFIX)}`,
     );
     const strongname = JSON.parse(data.slice(IMPLODE_PREFIX.length));
     if (!isPath(strongname)) {
@@ -78,7 +78,7 @@ export const makeDehydrator = (initialUnnamedCount = 0) => {
     const { petnameToVal: petnameToRoot } = edgeMapping;
     if (!petnameToRoot.has(path[0])) {
       // Avoid asserting, which fills up the logs.
-      throw Error(`Edgename for ${q(path[0])} petname not found`);
+      assert.fail(X`Edgename for ${q(path[0])} petname not found`);
     }
     const root = petnameToRoot.get(path[0]);
     path[0] = root;
@@ -92,7 +92,7 @@ export const makeDehydrator = (initialUnnamedCount = 0) => {
    * @returns {Mapping<T>}
    */
   const makeMapping = kind => {
-    assert.typeof(kind, 'string', details`kind ${kind} must be a string`);
+    assert.typeof(kind, 'string', X`kind ${kind} must be a string`);
     /** @type {Store<T, string>} */
     const rawValToPetname = makeStore('value');
     /** @type {Store<T, string | Path>} */
@@ -156,10 +156,7 @@ export const makeDehydrator = (initialUnnamedCount = 0) => {
      * @param {any} val
      */
     const addPath = (path, val) => {
-      assert(
-        isPath(path),
-        details`path ${q(path)} must be an array of strings`,
-      );
+      assert(isPath(path), X`path ${q(path)} must be an array of strings`);
 
       if (
         !valToPetname.has(val) &&
@@ -202,9 +199,9 @@ export const makeDehydrator = (initialUnnamedCount = 0) => {
       }
       assert(
         !petnameToVal.has(petname),
-        details`petname ${petname} is already in use`,
+        X`petname ${petname} is already in use`,
       );
-      assert(!valToPetname.has(val), details`val ${val} already has a petname`);
+      assert(!valToPetname.has(val), X`val ${val} already has a petname`);
       petnameToVal.init(petname, val);
       valToPetname.init(val, petname);
 
@@ -216,11 +213,11 @@ export const makeDehydrator = (initialUnnamedCount = 0) => {
     const renamePetname = (petname, val) => {
       assert(
         valToPetname.has(val),
-        details`val ${val} has not been previously named, would you like to add it instead?`,
+        X`val ${val} has not been previously named, would you like to add it instead?`,
       );
       assert(
         !petnameToVal.has(petname),
-        details`petname ${petname} is already in use`,
+        X`petname ${petname} is already in use`,
       );
       // Delete the old mappings.
       const oldPetname = valToPetname.get(val);
@@ -268,7 +265,7 @@ export const makeDehydrator = (initialUnnamedCount = 0) => {
     const deletePetname = petname => {
       assert(
         petnameToVal.has(petname),
-        details`petname ${q(
+        X`petname ${q(
           petname,
         )} has not been previously named, would you like to add it instead?`,
       );

--- a/packages/dapp-svelte-wallet/api/src/lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-wallet.js
@@ -11,7 +11,7 @@
  * and dapps.
  */
 
-import { assert, details, q } from '@agoric/assert';
+import { assert, details as X, q } from '@agoric/assert';
 import { makeStore, makeWeakStore } from '@agoric/store';
 import { makeIssuerTable } from '@agoric/zoe/src/issuerTable';
 
@@ -478,7 +478,7 @@ export function makeWallet({
         const purse = purseKeywordRecord[keyword];
         assert(
           purse !== undefined,
-          details`purse was not found for keyword ${q(keyword)}`,
+          X`purse was not found for keyword ${q(keyword)}`,
         );
         keywords.push(keyword);
         return E(purse).withdraw(amount);
@@ -602,7 +602,7 @@ export function makeWallet({
 
     assert(
       !found,
-      details`${q(found && found[0])} is already the petname for board ID ${q(
+      X`${q(found && found[0])} is already the petname for board ID ${q(
         depositBoardId,
       )}`,
     );
@@ -1366,7 +1366,7 @@ export function makeWallet({
       passStyleOf(offerResult) === 'copyRecord',
       `offerResult must be a record to have a uiNotifier`,
     );
-    assert(offerResult.uiNotifier, `offerResult does not have a uiNotifier`);
+    assert(offerResult.uiNotifier, X`offerResult does not have a uiNotifier`);
     return offerResult.uiNotifier;
   }
 
@@ -1427,7 +1427,7 @@ export function makeWallet({
     async addOfferInvitation(_offer, _invitation, _dappOrigin = undefined) {
       // Will be part of the Rendezvous system, when landed.
       // TODO unimplemented
-      throw Error(`Adding an invitation to an offer is unimplemented`);
+      assert.fail(X`Adding an invitation to an offer is unimplemented`);
     },
     declineOffer,
     cancelOffer,

--- a/packages/dapp-svelte-wallet/ui/package.json
+++ b/packages/dapp-svelte-wallet/ui/package.json
@@ -36,6 +36,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@agoric/assert": "^0.2.0",
     "@rollup/plugin-replace": "^2.3.4"
   }
 }

--- a/packages/dapp-svelte-wallet/ui/src/Import.svelte
+++ b/packages/dapp-svelte-wallet/ui/src/Import.svelte
@@ -1,5 +1,6 @@
 <script>
   import { E } from "@agoric/captp";
+  import { assert, details as d } from '@agoric/assert';
 
   import Button from 'smelte/src/components/Button';
   import Dialog from 'smelte/src/components/Dialog';
@@ -30,13 +31,9 @@
     <DefaultButton on:click={async () => {
       try {
         petname = petname.trim();
-        if (!petname) {
-          throw TypeError(`Need to specify a ${name} petname`);
-        }
+        assert(petname, d`Need to specify a ${name} petname`, TypeError);
         boardId = boardId.trim();
-        if (!boardId) {
-          throw TypeError(`Need to specify a ${name} "board:..."" ID`);
-        }
+        assert(boardId, d`Need to specify a ${name} "board:..."" ID`, TypeError);
         const trimmed = boardId.startsWith(prefix) ? boardId.slice(prefix.length) : boardId;
         const obj = await E(boardP).getValue(trimmed);
         await adder(petname, obj);

--- a/packages/dapp-svelte-wallet/ui/src/MakePurse.svelte
+++ b/packages/dapp-svelte-wallet/ui/src/MakePurse.svelte
@@ -5,11 +5,11 @@
   import Button from "smelte/src/components/Button";
   import TextField from "smelte/src/components/TextField";
   import Select from "smelte/src/components/Select";
-  
+
   import CancelButton from '../lib/CancelButton.svelte';
   import DefaultButton from '../lib/DefaultButton.svelte';
   import { walletP } from './store';
-  import { q } from '@agoric/assert';
+  import { assert, details as d } from '@agoric/assert';
 
   import { issuers } from './store';
   const title = "Make Purse";
@@ -34,13 +34,9 @@
   <div slot="actions">
     <DefaultButton on:click={async () => {
       try {
-        if (!issuerPetname) {
-          throw TypeError(`Need to specify an Issuer`);
-        }
+        assert(issuerPetname, d`Need to specify an Issuer`, TypeError);
         petname = petname.trim();
-        if (!petname) {
-          throw TypeError(`Need to specify a ${name} petname`);
-        }
+        assert(petname, d`Need to specify a ${name} petname`, TypeError);
         await E(walletP).makeEmptyPurse(issuerPetname, petname);
         showModal = false;
       } catch (e) {

--- a/packages/dapp-svelte-wallet/ui/src/display.js
+++ b/packages/dapp-svelte-wallet/ui/src/display.js
@@ -1,6 +1,6 @@
 // @ts-check
 import JSON5 from 'json5';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { MathKind } from '@agoric/ertp';
 
 const CONVENTIONAL_DECIMAL_PLACES = 2;
@@ -15,13 +15,10 @@ const CONVENTIONAL_DECIMAL_PLACES = 2;
  * @param {AmountDisplayInfo} displayInfo
  */
 export function parseValue(str, displayInfo) {
-  const { amountMathKind = MathKind.NAT, decimalPlaces = 0 } = displayInfo || {};
+  const { amountMathKind = MathKind.NAT, decimalPlaces = 0 } =
+    displayInfo || {};
 
-  assert.typeof(
-    str,
-    'string',
-    details`valueString ${str} is not a string`,
-  );
+  assert.typeof(str, 'string', X`valueString ${str} is not a string`);
 
   if (amountMathKind !== MathKind.NAT) {
     // Punt to JSON5 parsing.
@@ -30,17 +27,14 @@ export function parseValue(str, displayInfo) {
 
   // Parse the string as a number.
   const match = str.match(/^0*(\d+)(\.(\d*[1-9])?0*)?$/);
-  assert(
-    match,
-    details`${str} must be a non-negative decimal number`,
-  );
+  assert(match, X`${str} must be a non-negative decimal number`);
 
   const unitstr = match[1];
   const dec0str = match[3] || '';
   const dec0str0 = dec0str.padEnd(decimalPlaces, '0');
   assert(
     dec0str0.length <= decimalPlaces,
-    details`${str} exceeds ${decimalPlaces} decimal places`,
+    X`${str} exceeds ${decimalPlaces} decimal places`,
   );
 
   return parseInt(`${unitstr}${dec0str0}`, 10);

--- a/packages/deploy-script-support/src/assertOfferResult.js
+++ b/packages/deploy-script-support/src/assertOfferResult.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
 
 /** @type {AssertOfferResult} */
@@ -7,6 +7,6 @@ export const assertOfferResult = async (seat, expectedOfferResult) => {
   const actualOfferResult = await E(seat).getOfferResult();
   assert(
     actualOfferResult === expectedOfferResult,
-    details`offerResult (${actualOfferResult}) did not equal expected: ${expectedOfferResult}`,
+    X`offerResult (${actualOfferResult}) did not equal expected: ${expectedOfferResult}`,
   );
 };

--- a/packages/deployment/files.js
+++ b/packages/deployment/files.js
@@ -17,6 +17,8 @@ import { Readable } from 'stream';
 import { open as tempOpen } from 'temp';
 import chalk from 'chalk';
 
+const { details: X } = assert;
+
 export const chmod = util.promisify(rawChmod);
 export const exists = util.promisify(rawExists);
 export const mkdir = util.promisify(rawMkdir);
@@ -31,9 +33,7 @@ const fsClose = util.promisify(rawClose);
 export { resolve, dirname, basename };
 
 export const needNotExists = async filename => {
-  if (await exists(filename)) {
-    throw Error(`${filename} already exists`);
-  }
+  assert(!(await exists(filename)), X`${filename} already exists`);
 };
 
 export const createFile = async (path, contents) => {

--- a/packages/deployment/files.js
+++ b/packages/deployment/files.js
@@ -17,7 +17,7 @@ import { Readable } from 'stream';
 import { open as tempOpen } from 'temp';
 import chalk from 'chalk';
 
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 export const chmod = util.promisify(rawChmod);
 export const exists = util.promisify(rawExists);
@@ -32,8 +32,9 @@ const fsWrite = util.promisify(rawWrite);
 const fsClose = util.promisify(rawClose);
 export { resolve, dirname, basename };
 
-export const needNotExists = async filename => {
-  assert(!(await exists(filename)), X`${filename} already exists`);
+export const mustNotExist = async filename => {
+  const fileExists = await exists(filename);
+  assert(!fileExists, X`${filename} already exists`);
 };
 
 export const createFile = async (path, contents) => {

--- a/packages/deployment/init.js
+++ b/packages/deployment/init.js
@@ -1,17 +1,16 @@
 import fetch from 'node-fetch';
 import inquirer from 'inquirer';
+import { assert, details as X } from '@agoric/assert';
 import { SETUP_HOME, PLAYBOOK_WRAPPER, SETUP_DIR, SSH_TYPE } from './setup';
 import {
   basename,
   chmod,
   createFile,
   mkdir,
-  needNotExists,
+  mustNotExist,
   resolve,
 } from './files';
 import { chdir, needDoRun, shellEscape } from './run';
-
-const { details: X } = assert;
 
 const calculateTotal = placement =>
   (placement ? Object.values(placement) : []).reduce(
@@ -255,7 +254,7 @@ const doInit = async (progname, args) => {
     dir = SETUP_HOME;
   }
   assert(dir, X`Need: [dir] [[network name]]`);
-  await needNotExists(`${dir}/network.txt`);
+  await mustNotExist(`${dir}/network.txt`);
 
   const adir = resolve(process.cwd(), dir);
   const SSH_PRIVATE_KEY_FILE = resolve(adir, `id_${SSH_TYPE}`);

--- a/packages/deployment/init.js
+++ b/packages/deployment/init.js
@@ -11,6 +11,8 @@ import {
 } from './files';
 import { chdir, needDoRun, shellEscape } from './run';
 
+const { details: X } = assert;
+
 const calculateTotal = placement =>
   (placement ? Object.values(placement) : []).reduce(
     (prior, cur) => prior + cur,
@@ -252,9 +254,7 @@ const doInit = async (progname, args) => {
   if (!dir) {
     dir = SETUP_HOME;
   }
-  if (!dir) {
-    throw Error(`Need: [dir] [[network name]]`);
-  }
+  assert(dir, X`Need: [dir] [[network name]]`);
   await needNotExists(`${dir}/network.txt`);
 
   const adir = resolve(process.cwd(), dir);
@@ -420,9 +420,7 @@ const doInit = async (progname, args) => {
     OFFSETS[PLACEMENT] = offset;
   }
 
-  if (instance === 0) {
-    throw Error(`Aborting due to no nodes configured!`);
-  }
+  assert(instance !== 0, X`Aborting due to no nodes configured!`);
 
   await createFile(
     `vars.tf`,

--- a/packages/deployment/main.js
+++ b/packages/deployment/main.js
@@ -4,6 +4,7 @@ import djson from 'deterministic-json';
 import crypto from 'crypto';
 import chalk from 'chalk';
 import parseArgs from 'minimist';
+import { assert, details as X } from '@agoric/assert';
 import doInit from './init';
 import {
   chdir,
@@ -32,8 +33,6 @@ import {
   sleep,
   SSH_TYPE,
 } from './setup';
-
-const { details: X } = assert;
 
 const PROVISION_DIR = 'provision';
 const PROVISIONER_NODE = 'node0'; // FIXME: Allow configuration.
@@ -580,7 +579,7 @@ ${chalk.yellow.bold(`ag-setup-solo --netconfig='${dwebHost}/network-config'`)}
       }
 
       const nodes = Object.keys(nodeMap).sort();
-      assert(nodes.length !== 0, X`Need at least one node`);
+      assert(nodes.length > 0, X`Need at least one node`);
 
       for (const node of nodes) {
         const nodePlaybook = (book, ...pbargs) =>
@@ -689,7 +688,7 @@ ${chalk.yellow.bold(`ag-setup-solo --netconfig='${dwebHost}/network-config'`)}
         const raw = await trimReadFile(idPath);
         const ID = String(raw);
 
-        assert(ID, X`${idPath} does not contain a node ID`);
+        assert(ID, X`${idPath} must contain a node ${ID}`);
         assert(
           ID.match(/^[a-f0-9]+/),
           X`${idPath} contains an invalid ID ${ID}`,

--- a/packages/deployment/package.json
+++ b/packages/deployment/package.json
@@ -17,6 +17,7 @@
   "author": "Agoric",
   "license": "Apache-2.0",
   "dependencies": {
+    "@agoric/assert": "^0.2.0",
     "@agoric/install-ses": "^0.5.0",
     "chalk": "^2.4.2",
     "deterministic-json": "^1.0.5",

--- a/packages/deployment/run.js
+++ b/packages/deployment/run.js
@@ -1,7 +1,7 @@
 import { exec as rawExec, spawn } from 'child_process';
 import { Writable } from 'stream';
 
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 export const shellMetaRegexp = /(\s|[[\]'"\\`$;*?{}])/;
 export const shellEscape = arg =>

--- a/packages/deployment/run.js
+++ b/packages/deployment/run.js
@@ -1,6 +1,8 @@
 import { exec as rawExec, spawn } from 'child_process';
 import { Writable } from 'stream';
 
+const { details: X } = assert;
+
 export const shellMetaRegexp = /(\s|[[\]'"\\`$;*?{}])/;
 export const shellEscape = arg =>
   arg.match(shellMetaRegexp) ? `"${arg.replace(/(["\\])/g, '\\$1')}"` : arg;
@@ -44,9 +46,10 @@ export const backtick = async cmd => {
 
 export const needBacktick = async cmd => {
   const ret = await getStdout(cmd);
-  if (ret.code !== 0) {
-    throw Error(`Unexpected ${JSON.stringify(cmd)} exit code: ${ret.code}`);
-  }
+  assert(
+    ret.code === 0,
+    X`Unexpected ${JSON.stringify(cmd)} exit code: ${ret.code}`,
+  );
   return ret.stdout;
 };
 
@@ -97,8 +100,6 @@ export const doRun = (cmd, readable, writeCb) => {
 
 export const needDoRun = async (cmd, ...opts) => {
   const ret = await doRun(cmd, ...opts);
-  if (ret !== 0) {
-    throw Error(`Aborted with exit code ${ret}`);
-  }
+  assert(ret === 0, X`Aborted with exit code ${ret}`);
   return ret;
 };

--- a/packages/eventual-send/src/index.js
+++ b/packages/eventual-send/src/index.js
@@ -379,7 +379,7 @@ export function makeHandledPromise() {
         const ftype = ntypeof(t[method]);
         if (ftype === 'undefined') {
           const names = Object.getOwnPropertyNames(t).sort();
-          throw TypeError(`target has no method ${q(method)}, has [${names}]`);
+          throw TypeError(`target has no method ${q(method)}, has ${q(names)}`);
         }
         throw TypeError(
           `invoked method ${q(method)} is not a function; it is a ${q(ftype)}`,

--- a/packages/eventual-send/src/track-turns.js
+++ b/packages/eventual-send/src/track-turns.js
@@ -1,7 +1,7 @@
 // @ts-nocheck
 
 // NOTE: We can't import these because they're not in scope before lockdown.
-// import { assert, details as d } from '@agoric/assert';
+// import { assert, details as X } from '@agoric/assert';
 
 // WARNING: Global Mutable State!
 // This state is communicated to `assert` that makes it available to the
@@ -41,14 +41,14 @@ export const trackTurns = funcs => {
   if (typeof globalThis === 'undefined' || !globalThis.assert) {
     return funcs;
   }
-  const { details: d } = assert;
+  const { details: X } = assert;
 
   hiddenCurrentEvent += 1;
   const sendingError = new Error(
     `Event: ${hiddenCurrentTurn}.${hiddenCurrentEvent}`,
   );
   if (hiddenPriorError !== undefined) {
-    assert.note(sendingError, d`Caused by: ${hiddenPriorError}`);
+    assert.note(sendingError, X`Caused by: ${hiddenPriorError}`);
   }
 
   return funcs.map(
@@ -66,7 +66,7 @@ export const trackTurns = funcs => {
             if (err instanceof Error) {
               assert.note(
                 err,
-                d`Thrown from: ${hiddenPriorError}:${hiddenCurrentTurn}.${hiddenCurrentEvent}`,
+                X`Thrown from: ${hiddenPriorError}:${hiddenCurrentTurn}.${hiddenCurrentEvent}`,
               );
             }
             if (VERBOSE) {
@@ -75,7 +75,7 @@ export const trackTurns = funcs => {
             throw err;
           }
           // Must capture this now, not when the catch triggers.
-          const detailsNote = d`Rejection from: ${hiddenPriorError}:${hiddenCurrentTurn}.${hiddenCurrentEvent}`;
+          const detailsNote = X`Rejection from: ${hiddenPriorError}:${hiddenCurrentTurn}.${hiddenCurrentEvent}`;
           Promise.resolve(result).catch(reason => {
             if (reason instanceof Error) {
               assert.note(reason, detailsNote);

--- a/packages/eventual-send/test/test-e.js
+++ b/packages/eventual-send/test/test-e.js
@@ -75,7 +75,7 @@ test('E call missing method', async t => {
     },
   };
   await t.throwsAsync(() => E(x).triple(6), {
-    message: 'target has no method "triple", has [double]',
+    message: 'target has no method "triple", has ["double"]',
   });
 });
 
@@ -100,7 +100,7 @@ test.skip('E sendOnly call missing method', async t => {
       await testDecrDone;
     },
     {
-      message: 'target has no method "decr", has [incr]',
+      message: 'target has no method "decr", has ["incr"]',
     },
   );
 });

--- a/packages/eventual-send/test/test-eventual-send.js
+++ b/packages/eventual-send/test/test-eventual-send.js
@@ -4,6 +4,8 @@ import { HandledPromise } from './get-hp';
 
 const { getPrototypeOf } = Object;
 
+const { details: X } = assert;
+
 if (typeof window !== 'undefined') {
   // Let the browser detect when the tests are done.
   /* eslint-disable-next-line no-undef */
@@ -207,7 +209,7 @@ test('new HandledPromise expected errors', async t => {
         );
         break;
       default:
-        throw TypeError(`Unrecognized method type ${method}`);
+        assert.fail(X`Unrecognized method type ${method}`, TypeError);
     }
   }
 
@@ -388,7 +390,7 @@ test('eventual send expected errors', async t => {
     HandledPromise.applyMethod({ present() {}, other() {} }, 'notfound', []),
     {
       instanceOf: TypeError,
-      message: 'target has no method "notfound", has [other,present]',
+      message: 'target has no method "notfound", has ["other","present"]',
     },
     'applyMethod ({}).notfound()',
   );

--- a/packages/eventual-send/test/test-eventual-send.js
+++ b/packages/eventual-send/test/test-eventual-send.js
@@ -1,10 +1,9 @@
 import '@agoric/install-ses';
 import test from 'ava';
+import { assert, details as X } from '@agoric/assert';
 import { HandledPromise } from './get-hp';
 
 const { getPrototypeOf } = Object;
-
-const { details: X } = assert;
 
 if (typeof window !== 'undefined') {
   // Let the browser detect when the tests are done.

--- a/packages/import-bundle/src/index.js
+++ b/packages/import-bundle/src/index.js
@@ -2,6 +2,8 @@ import { parseArchive } from '@agoric/compartment-mapper';
 import { decodeBase64 } from '@agoric/base64';
 import { wrapInescapableCompartment } from './compartment-wrapper';
 
+const { details: X } = assert;
+
 // importBundle takes the output of bundle-source, and returns a namespace
 // object (with .default, and maybe other properties for named exports)
 
@@ -74,7 +76,7 @@ export async function importBundle(bundle, options = {}) {
     // `filePrefix` and the relative import path of each module.
     endowments.nestedEvaluate = src => c.evaluate(src);
   } else {
-    throw Error(`unrecognized moduleFormat '${moduleFormat}'`);
+    assert.fail(X`unrecognized moduleFormat '${moduleFormat}'`);
   }
 
   c = new CompartmentToUse(endowments, {}, { globalLexicals, transforms });

--- a/packages/import-bundle/src/index.js
+++ b/packages/import-bundle/src/index.js
@@ -1,8 +1,7 @@
 import { parseArchive } from '@agoric/compartment-mapper';
 import { decodeBase64 } from '@agoric/base64';
+import { assert, details as X } from '@agoric/assert';
 import { wrapInescapableCompartment } from './compartment-wrapper';
-
-const { details: X } = assert;
 
 // importBundle takes the output of bundle-source, and returns a namespace
 // object (with .default, and maybe other properties for named exports)

--- a/packages/import-bundle/test/test-compartment-wrapper.js
+++ b/packages/import-bundle/test/test-compartment-wrapper.js
@@ -1,8 +1,7 @@
 import '@agoric/install-ses';
 import test from 'ava';
+import { assert, details as X } from '@agoric/assert';
 import { wrapInescapableCompartment } from '../src/compartment-wrapper.js';
-
-const { details: X } = assert;
 
 // We build a transform that allows oldSrc to increment the odometer, but not
 // read it. Note, of course, that SES provides a far easier way to accomplish

--- a/packages/import-bundle/test/test-compartment-wrapper.js
+++ b/packages/import-bundle/test/test-compartment-wrapper.js
@@ -2,15 +2,18 @@ import '@agoric/install-ses';
 import test from 'ava';
 import { wrapInescapableCompartment } from '../src/compartment-wrapper.js';
 
+const { details: X } = assert;
+
 // We build a transform that allows oldSrc to increment the odometer, but not
 // read it. Note, of course, that SES provides a far easier way to accomplish
 // this (pass in a hardened `addMilage` endowment), but there are metering
 // use cases that don't involve voluntary participation by oldSrc.
 
 function milageTransform(oldSrc) {
-  if (oldSrc.indexOf('getOdometer') !== -1) {
-    throw Error(`forbidden access to 'getOdometer' in oldSrc`);
-  }
+  assert(
+    oldSrc.indexOf('getOdometer') === -1,
+    X`forbidden access to 'getOdometer' in oldSrc`,
+  );
   return oldSrc.replace(/addMilage\(\)/g, 'getOdometer().add(1)');
 }
 

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -36,7 +36,6 @@ export function getInterfaceOf(maybeRemotable) {
  * @param {WeakMap<any,any>} [already=new WeakMap()]
  * @returns {T & PureData} pure, hardened copy
  */
-// eslint-disable-next-line consistent-return
 function pureCopy(val, already = new WeakMap()) {
   // eslint-disable-next-line no-use-before-define
   const passStyle = passStyleOf(val);
@@ -97,12 +96,10 @@ function pureCopy(val, already = new WeakMap()) {
         )} cannot be copied as it must be passed by reference`,
         TypeError,
       );
-      break;
     }
 
     case 'promise': {
       assert.fail(X`Promises cannot be copied`, TypeError);
-      break;
     }
 
     default:
@@ -353,7 +350,6 @@ export function sameValueZero(x, y) {
  * @param {Passable} val
  * @returns {PassStyle}
  */
-// eslint-disable-next-line consistent-return
 export function passStyleOf(val) {
   const typestr = typeof val;
   switch (typestr) {
@@ -393,7 +389,6 @@ export function passStyleOf(val) {
     }
     case 'function': {
       assert.fail(X`Bare functions like ${val} are disabled for now`);
-      break;
     }
     case 'undefined':
     case 'string':
@@ -455,7 +450,6 @@ function makeReviverIbidTable(cyclePolicy) {
           }
           case 'forbidCycles': {
             assert.fail(X`Ibid cycle at ${q(index)}`, TypeError);
-            break;
           }
           default: {
             assert.fail(
@@ -592,7 +586,6 @@ export function makeMarshal(
      * @param {Passable} val
      * @returns {PlainJSONData}
      */
-    // eslint-disable-next-line consistent-return
     const encode = val => {
       // First we handle all primitives. Some can be represented directly as
       // JSON, and some must be encoded as [QCLASS] composites.
@@ -640,7 +633,6 @@ export function makeMarshal(
               assert.fail(X`Unsupported symbol ${q(String(val))}`);
             }
           }
-          break;
         }
         default: {
           // if we've seen this object before, serialize a backref
@@ -752,7 +744,6 @@ export function makeMarshal(
     // produced by JSON.stringify on the replacer above, i.e., it
     // cannot rely on it being a valid marshalled
     // representation. Rather, fullRevive must validate that.
-    // eslint-disable-next-line consistent-return
     return function fullRevive(rawTree) {
       if (Object(rawTree) !== rawTree) {
         // primitives pass through

--- a/packages/notifier/test/map-unum.js
+++ b/packages/notifier/test/map-unum.js
@@ -8,7 +8,7 @@
 // from test/ to src/
 
 // @ts-check
-import { assert, details as d, q } from '@agoric/assert';
+import { assert, details as X, q } from '@agoric/assert';
 import {
   makeNotifierKit,
   makeSubscriptionKit,
@@ -109,7 +109,7 @@ export const makeMapFollower = snapshotNotifierP => {
           break;
         }
         default: {
-          throw assert.fail(d`unexpected deltaKind ${q(deltaKind)}`);
+          assert.fail(X`unexpected deltaKind ${q(deltaKind)}`);
         }
       }
     },

--- a/packages/registrar/src/registrar.js
+++ b/packages/registrar/src/registrar.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
 import { generateSparseInts } from '@agoric/sparse-ints';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 
 // TODO(https://github.com/Agoric/agoric-sdk/issues/827), rename internally to
 //  match teh way it's now published.
@@ -44,13 +44,13 @@ function makeRegistrar(systemVersion, seed = 0) {
       return key;
     },
     get(key, version = null) {
-      assert.typeof(key, 'string', details`Key must be string ${key}`);
-      assert(keyFormat.test(key), details`Key must end with _<digits> ${key}`);
+      assert.typeof(key, 'string', X`Key must be string ${key}`);
+      assert(keyFormat.test(key), X`Key must end with _<digits> ${key}`);
       if (version) {
         assert.equal(
           version,
           systemVersion,
-          details`Key is from incompatible version: ${version} should be ${systemVersion}`,
+          X`Key is from incompatible version: ${version} should be ${systemVersion}`,
         );
       }
       return contents.get(key);

--- a/packages/same-structure/src/sameStructure.js
+++ b/packages/same-structure/src/sameStructure.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { sameValueZero, passStyleOf, REMOTE_STYLE } from '@agoric/marshal';
-import { assert, details, q } from '@agoric/assert';
+import { assert, details as X, q } from '@agoric/assert';
 
 // Shim of Object.fromEntries from
 // https://github.com/tc39/proposal-object-from-entries/blob/master/polyfill.js
@@ -55,6 +55,7 @@ function objectFromEntries(iter) {
  * @param {Passable} passable
  * @returns {Promise<Comparable>}
  */
+// eslint-disable-next-line consistent-return
 function allComparable(passable) {
   const passStyle = passStyleOf(passable);
   switch (passStyle) {
@@ -83,7 +84,7 @@ function allComparable(passable) {
       );
     }
     default: {
-      throw new TypeError(`unrecognized passStyle ${passStyle}`);
+      assert.fail(X`unrecognized passStyle ${passStyle}`, TypeError);
     }
   }
 }
@@ -102,16 +103,17 @@ harden(allComparable);
  * @param {Comparable} right
  * @returns {boolean}
  */
+// eslint-disable-next-line consistent-return
 function sameStructure(left, right) {
   const leftStyle = passStyleOf(left);
   const rightStyle = passStyleOf(right);
   assert(
     leftStyle !== 'promise',
-    details`Cannot structurally compare promises: ${left}`,
+    X`Cannot structurally compare promises: ${left}`,
   );
   assert(
     rightStyle !== 'promise',
-    details`Cannot structurally compare promises: ${right}`,
+    X`Cannot structurally compare promises: ${right}`,
   );
 
   if (leftStyle !== rightStyle) {
@@ -150,7 +152,7 @@ function sameStructure(left, right) {
       return left.name === right.name && left.message === right.message;
     }
     default: {
-      throw new TypeError(`unrecognized passStyle ${leftStyle}`);
+      assert.fail(X`unrecognized passStyle ${leftStyle}`, TypeError);
     }
   }
 }
@@ -177,7 +179,7 @@ function pathStr(path) {
 function mustBeSameStructureInternal(left, right, message, path) {
   function complain(problem) {
     assert.fail(
-      details`${q(message)}: ${q(problem)} at ${q(
+      X`${q(message)}: ${q(problem)} at ${q(
         pathStr(path),
       )}: (${left}) vs (${right})`,
     );

--- a/packages/same-structure/src/sameStructure.js
+++ b/packages/same-structure/src/sameStructure.js
@@ -55,7 +55,6 @@ function objectFromEntries(iter) {
  * @param {Passable} passable
  * @returns {Promise<Comparable>}
  */
-// eslint-disable-next-line consistent-return
 function allComparable(passable) {
   const passStyle = passStyleOf(passable);
   switch (passStyle) {
@@ -103,7 +102,6 @@ harden(allComparable);
  * @param {Comparable} right
  * @returns {boolean}
  */
-// eslint-disable-next-line consistent-return
 function sameStructure(left, right) {
   const leftStyle = passStyleOf(left);
   const rightStyle = passStyleOf(right);

--- a/packages/sharing-service/src/sharedMap.js
+++ b/packages/sharing-service/src/sharedMap.js
@@ -1,6 +1,6 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 // Allows multiple parties to store values for retrieval by others.
 function makeSharedMap(name) {

--- a/packages/sharing-service/src/sharedMap.js
+++ b/packages/sharing-service/src/sharedMap.js
@@ -1,5 +1,7 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
+const { details: X } = assert;
+
 // Allows multiple parties to store values for retrieval by others.
 function makeSharedMap(name) {
   const namedEntries = new Map();
@@ -13,9 +15,10 @@ function makeSharedMap(name) {
       return namedEntries.get(propertyName)[0];
     },
     addEntry(key, value) {
-      if (namedEntries.has(key)) {
-        throw new Error(`SharedMap ${name} already has an entry for ${key}.`);
-      }
+      assert(
+        !namedEntries.has(key),
+        X`SharedMap ${name} already has an entry for ${key}.`,
+      );
       orderedEntries.push([key, value]);
       namedEntries.set(key, [value, orderedEntries.length]);
       return orderedEntries.length;

--- a/packages/sharing-service/src/sharing.js
+++ b/packages/sharing-service/src/sharing.js
@@ -1,6 +1,6 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { makeSharedMap } from './sharedMap';
 
 function makeSharingService() {
@@ -15,18 +15,20 @@ function makeSharingService() {
       if (!sharedMaps.has(key)) {
         return undefined;
       }
-      if (sharedMaps.get(key) === tombstone) {
-        throw new Error(`Entry for ${key} has already been collected.`);
-      }
+      assert(
+        sharedMaps.get(key) !== tombstone,
+        X`Entry for ${key} has already been collected.`,
+      );
       const result = sharedMaps.get(key);
       // these are single-use entries. Leave a tombstone to prevent MITM.
       sharedMaps.set(key, tombstone);
       return result;
     },
     createSharedMap(preferredName) {
-      if (sharedMaps.has(preferredName)) {
-        throw new Error(`Entry already exists: ${preferredName}`);
-      }
+      assert(
+        !sharedMaps.has(preferredName),
+        X`Entry already exists: ${preferredName}`,
+      );
       const sharedMap = makeSharedMap(preferredName);
       sharedMaps.set(preferredName, sharedMap);
       brand.add(sharedMap);
@@ -35,7 +37,7 @@ function makeSharingService() {
     validate(allegedSharedMap) {
       assert(
         brand.has(allegedSharedMap),
-        details`Unrecognized sharedMap: ${allegedSharedMap}`,
+        X`Unrecognized sharedMap: ${allegedSharedMap}`,
       );
       return allegedSharedMap;
     },

--- a/packages/sharing-service/test/swingsetTests/sharingService/bootstrap.js
+++ b/packages/sharing-service/test/swingsetTests/sharingService/bootstrap.js
@@ -1,10 +1,9 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
 import { E } from '@agoric/eventual-send';
+import { assert, details as X } from '@agoric/assert';
 import { makeSharedMap } from '../../../src/sharedMap';
 import { makeSharingService } from '../../../src/sharing';
-
-const { details: X } = assert;
 
 export function buildRootObject(vatPowers, vatParameters) {
   const log = vatPowers.testLog;
@@ -82,7 +81,6 @@ export function buildRootObject(vatPowers, vatParameters) {
   }
 
   const obj0 = {
-    // eslint-disable-next-line consistent-return
     async bootstrap(vats) {
       switch (vatParameters.argv[0]) {
         case 'sharedMap': {

--- a/packages/sharing-service/test/swingsetTests/sharingService/bootstrap.js
+++ b/packages/sharing-service/test/swingsetTests/sharingService/bootstrap.js
@@ -4,6 +4,8 @@ import { E } from '@agoric/eventual-send';
 import { makeSharedMap } from '../../../src/sharedMap';
 import { makeSharingService } from '../../../src/sharing';
 
+const { details: X } = assert;
+
 export function buildRootObject(vatPowers, vatParameters) {
   const log = vatPowers.testLog;
   function testSharedMapStorage() {
@@ -80,6 +82,7 @@ export function buildRootObject(vatPowers, vatParameters) {
   }
 
   const obj0 = {
+    // eslint-disable-next-line consistent-return
     async bootstrap(vats) {
       switch (vatParameters.argv[0]) {
         case 'sharedMap': {
@@ -95,7 +98,7 @@ export function buildRootObject(vatPowers, vatParameters) {
           return testTwoVatSharing(aliceMaker, bobMaker, sharingService);
         }
         default: {
-          throw Error(`unrecognized argument value ${vatParameters.argv[0]}`);
+          assert.fail(X`unrecognized argument value ${vatParameters.argv[0]}`);
         }
       }
     },

--- a/packages/spawner/src/contractHost.js
+++ b/packages/spawner/src/contractHost.js
@@ -2,7 +2,7 @@
 
 import { importBundle } from '@agoric/import-bundle';
 import { makeWeakStore } from '@agoric/store';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { allComparable } from '@agoric/same-structure';
 import { makeIssuerKit } from '@agoric/ertp';
 
@@ -35,7 +35,7 @@ function makeContractHost(vatPowers, additionalEndowments = {}) {
 
   function redeem(allegedInvitePayment) {
     return inviteIssuer.getAmountOf(allegedInvitePayment).then(inviteAmount => {
-      assert(!inviteAmountMath.isEmpty(inviteAmount), details`No invites left`);
+      assert(!inviteAmountMath.isEmpty(inviteAmount), X`No invites left`);
       const [{ seatIdentity }] = inviteAmountMath.getValue(inviteAmount);
       return Promise.resolve(
         inviteIssuer.burn(allegedInvitePayment, inviteAmount),

--- a/packages/spawner/test/swingsetTests/contractHost/bootstrap.js
+++ b/packages/spawner/test/swingsetTests/contractHost/bootstrap.js
@@ -7,6 +7,8 @@ import { bundleFunction } from '../../make-function-bundle';
 import { escrowExchangeSrcs } from '../../../src/escrow';
 import { coveredCallSrcs } from '../../../src/coveredCall';
 
+const { details: X } = assert;
+
 export function buildRootObject(vatPowers, vatParameters) {
   const log = vatPowers.testLog;
 
@@ -77,9 +79,7 @@ export function buildRootObject(vatPowers, vatParameters) {
 
           eightP.then(res => {
             log('++ eightP resolved to ', res, ' (should be 8)');
-            if (res !== 8) {
-              throw new Error(`eightP resolved to ${res}, not 8`);
-            }
+            assert(res === 8, X`eightP resolved to ${res}, not 8`);
             log('++ DONE');
           });
           return eightP;
@@ -356,6 +356,7 @@ export function buildRootObject(vatPowers, vatParameters) {
   }
 
   const obj0 = {
+    // eslint-disable-next-line consistent-return
     async bootstrap(vats) {
       switch (vatParameters.argv[0]) {
         case 'trivial-oldformat': {
@@ -412,7 +413,7 @@ export function buildRootObject(vatPowers, vatParameters) {
           );
         }
         default: {
-          throw Error(`unrecognized argument value ${vatParameters.argv[0]}`);
+          assert.fail(X`unrecognized argument value ${vatParameters.argv[0]}`);
         }
       }
     },

--- a/packages/spawner/test/swingsetTests/contractHost/bootstrap.js
+++ b/packages/spawner/test/swingsetTests/contractHost/bootstrap.js
@@ -2,12 +2,11 @@
 
 import { E } from '@agoric/eventual-send';
 import { makeLocalAmountMath } from '@agoric/ertp';
+import { assert, details as X } from '@agoric/assert';
 import { bundleFunction } from '../../make-function-bundle';
 
 import { escrowExchangeSrcs } from '../../../src/escrow';
 import { coveredCallSrcs } from '../../../src/coveredCall';
-
-const { details: X } = assert;
 
 export function buildRootObject(vatPowers, vatParameters) {
   const log = vatPowers.testLog;
@@ -356,7 +355,6 @@ export function buildRootObject(vatPowers, vatParameters) {
   }
 
   const obj0 = {
-    // eslint-disable-next-line consistent-return
     async bootstrap(vats) {
       switch (vatParameters.argv[0]) {
         case 'trivial-oldformat': {

--- a/packages/spawner/test/swingsetTests/contractHost/vat-bob.js
+++ b/packages/spawner/test/swingsetTests/contractHost/vat-bob.js
@@ -6,6 +6,8 @@ import { makeLocalAmountMath } from '@agoric/ertp';
 
 import { makeCollect } from '../../../src/makeCollect';
 
+const { details: X } = assert;
+
 function makeBobMaker(host, log) {
   const collect = makeCollect(E, log);
 
@@ -43,7 +45,7 @@ function makeBobMaker(host, log) {
               break;
             }
             default: {
-              throw new Error(`unknown desc: ${desc}`);
+              assert.fail(X`unknown desc: ${desc}`);
             }
           }
 

--- a/packages/spawner/test/swingsetTests/contractHost/vat-bob.js
+++ b/packages/spawner/test/swingsetTests/contractHost/vat-bob.js
@@ -4,9 +4,8 @@
 import { E } from '@agoric/eventual-send';
 import { makeLocalAmountMath } from '@agoric/ertp';
 
+import { assert, details as X } from '@agoric/assert';
 import { makeCollect } from '../../../src/makeCollect';
-
-const { details: X } = assert;
 
 function makeBobMaker(host, log) {
   const collect = makeCollect(E, log);

--- a/packages/spawner/test/swingsetTests/escrow/bootstrap.js
+++ b/packages/spawner/test/swingsetTests/escrow/bootstrap.js
@@ -174,7 +174,6 @@ export function buildRootObject(vatPowers, vatParameters) {
   }
 
   const obj0 = {
-    // eslint-disable-next-line consistent-return
     async bootstrap(vats) {
       const host = await E(vats.host).makeHost();
       const { mint: randMintP } = E(vats.mint).makeIssuerKit('rand');

--- a/packages/spawner/test/swingsetTests/escrow/bootstrap.js
+++ b/packages/spawner/test/swingsetTests/escrow/bootstrap.js
@@ -3,7 +3,7 @@
 import { E } from '@agoric/eventual-send';
 import { makeIssuerKit } from '@agoric/ertp';
 import { allComparable } from '@agoric/same-structure';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 
 import { escrowExchangeSrcs } from '../../../src/escrow';
 
@@ -65,7 +65,7 @@ export function buildRootObject(vatPowers, vatParameters) {
         });
     });
     result.then(r => {
-      assert(r, details`expected successful check ${result}`);
+      assert(r, X`expected successful check ${result}`);
     });
   }
 
@@ -174,6 +174,7 @@ export function buildRootObject(vatPowers, vatParameters) {
   }
 
   const obj0 = {
+    // eslint-disable-next-line consistent-return
     async bootstrap(vats) {
       const host = await E(vats.host).makeHost();
       const { mint: randMintP } = E(vats.mint).makeIssuerKit('rand');
@@ -196,7 +197,7 @@ export function buildRootObject(vatPowers, vatParameters) {
           return testEscrowCheckPartialWrongStock(host, randMintP, artMintP);
         }
         default: {
-          throw Error(`unrecognized argument value ${vatParameters.argv[0]}`);
+          assert.fail(X`unrecognized argument value ${vatParameters.argv[0]}`);
         }
       }
     },

--- a/packages/stat-logger/src/statGraph.js
+++ b/packages/stat-logger/src/statGraph.js
@@ -2,6 +2,8 @@ import fs from 'fs';
 import path from 'path';
 import * as vega from 'vega';
 
+const { details: X } = assert;
+
 function scanMax(filePath, fields) {
   const lines = fs.readFileSync(filePath, { encoding: 'utf8' }).split('\n');
   const headers = lines[0].split('\t');
@@ -16,7 +18,7 @@ function scanMax(filePath, fields) {
       }
     }
     if (hit < 0) {
-      throw new Error(`field ${field} not found in ${filePath}`);
+      assert.fail(X`field ${field} not found in ${filePath}`);
     } else {
       headerMap[hit] = field;
     }
@@ -156,9 +158,10 @@ export async function renderGraph(spec, outputPath, type = 'png') {
   } else if (spec.marks.length === 0) {
     throw new Error('graph spec has no graphs defined');
   }
-  if (type !== 'png' && type !== 'pdf') {
-    throw new Error(`invalid output type ${type}, valid types are png or pdf`);
-  }
+  assert(
+    type === 'png' || type === 'pdf',
+    X`invalid output type ${type}, valid types are png or pdf`,
+  );
 
   let loadDir = '.';
   let out = process.stdout;

--- a/packages/store/src/store.js
+++ b/packages/store/src/store.js
@@ -2,7 +2,7 @@
 
 // @ts-check
 
-import { assert, details, q } from '@agoric/assert';
+import { assert, details as X, q } from '@agoric/assert';
 
 /**
  * Distinguishes between adding a new key (init) and updating or
@@ -18,9 +18,9 @@ import { assert, details, q } from '@agoric/assert';
 export function makeStore(keyName = 'key') {
   const store = new Map();
   const assertKeyDoesNotExist = key =>
-    assert(!store.has(key), details`${q(keyName)} already registered: ${key}`);
+    assert(!store.has(key), X`${q(keyName)} already registered: ${key}`);
   const assertKeyExists = key =>
-    assert(store.has(key), details`${q(keyName)} not found: ${key}`);
+    assert(store.has(key), X`${q(keyName)} not found: ${key}`);
   return harden({
     has: key => store.has(key),
     init: (key, value) => {

--- a/packages/store/src/weak-store.js
+++ b/packages/store/src/weak-store.js
@@ -2,7 +2,7 @@
 
 // @ts-check
 
-import { assert, details, q } from '@agoric/assert';
+import { assert, details as X, q } from '@agoric/assert';
 import './types';
 
 /**
@@ -14,9 +14,9 @@ import './types';
 export function makeWeakStore(keyName = 'key') {
   const wm = new WeakMap();
   const assertKeyDoesNotExist = key =>
-    assert(!wm.has(key), details`${q(keyName)} already registered: ${key}`);
+    assert(!wm.has(key), X`${q(keyName)} already registered: ${key}`);
   const assertKeyExists = key =>
-    assert(wm.has(key), details`${q(keyName)} not found: ${key}`);
+    assert(wm.has(key), X`${q(keyName)} not found: ${key}`);
   return harden({
     has: key => wm.has(key),
     init: (key, value) => {

--- a/packages/swing-store-lmdb/lmdbSwingStore.js
+++ b/packages/swing-store-lmdb/lmdbSwingStore.js
@@ -66,7 +66,7 @@ function makeSwingStore(dirPath, forceReset = false) {
    * @throws if key is not a string.
    */
   function get(key) {
-    assert(`${key}` === key, X`non-string key ${key}`);
+    assert.typeof(key, 'string', X`non-string key ${key}`);
     ensureTxn();
     let result = txn.getString(dbi, key);
     if (result === null) {
@@ -90,8 +90,8 @@ function makeSwingStore(dirPath, forceReset = false) {
    * @throws if either parameter is not a string.
    */
   function* getKeys(start, end) {
-    assert(`${start}` === start, X`non-string start ${start}`);
-    assert(`${end}` === end, X`non-string end ${end}`);
+    assert.typeof(start, 'string', X`non-string start ${start}`);
+    assert.typeof(end, 'string', X`non-string end ${end}`);
 
     ensureTxn();
     const cursor = new lmdb.Cursor(txn, dbi);
@@ -113,7 +113,7 @@ function makeSwingStore(dirPath, forceReset = false) {
    * @throws if key is not a string.
    */
   function has(key) {
-    assert(`${key}` === key, X`non-string key ${key}`);
+    assert.typeof(key, 'string', X`non-string key ${key}`);
     return get(key) !== undefined;
   }
 
@@ -127,8 +127,8 @@ function makeSwingStore(dirPath, forceReset = false) {
    * @throws if either parameter is not a string.
    */
   function set(key, value) {
-    assert(`${key}` === key, X`non-string key ${key}`);
-    assert(`${value}` === value, X`non-string value ${value}`);
+    assert.typeof(key, 'string', X`non-string key ${key}`);
+    assert.typeof(value, 'string', X`non-string value ${value}`);
     ensureTxn();
     txn.putString(dbi, key, value);
   }
@@ -142,7 +142,7 @@ function makeSwingStore(dirPath, forceReset = false) {
    * @throws if key is not a string.
    */
   function del(key) {
-    assert(`${key}` === key, X`non-string key ${key}`);
+    assert.typeof(key, 'string', X`non-string key ${key}`);
     if (has(key)) {
       ensureTxn();
       txn.del(dbi, key);

--- a/packages/swing-store-lmdb/lmdbSwingStore.js
+++ b/packages/swing-store-lmdb/lmdbSwingStore.js
@@ -4,6 +4,8 @@ import path from 'path';
 
 import lmdb from 'node-lmdb';
 
+const { details: X } = assert;
+
 /**
  * Do the work of `initSwingStore` and `openSwingStore`.
  *
@@ -64,9 +66,7 @@ function makeSwingStore(dirPath, forceReset = false) {
    * @throws if key is not a string.
    */
   function get(key) {
-    if (`${key}` !== key) {
-      throw new Error(`non-string key ${key}`);
-    }
+    assert(`${key}` === key, X`non-string key ${key}`);
     ensureTxn();
     let result = txn.getString(dbi, key);
     if (result === null) {
@@ -90,12 +90,8 @@ function makeSwingStore(dirPath, forceReset = false) {
    * @throws if either parameter is not a string.
    */
   function* getKeys(start, end) {
-    if (`${start}` !== start) {
-      throw new Error(`non-string start ${start}`);
-    }
-    if (`${end}` !== end) {
-      throw new Error(`non-string end ${end}`);
-    }
+    assert(`${start}` === start, X`non-string start ${start}`);
+    assert(`${end}` === end, X`non-string end ${end}`);
 
     ensureTxn();
     const cursor = new lmdb.Cursor(txn, dbi);
@@ -117,9 +113,7 @@ function makeSwingStore(dirPath, forceReset = false) {
    * @throws if key is not a string.
    */
   function has(key) {
-    if (`${key}` !== key) {
-      throw new Error(`non-string key ${key}`);
-    }
+    assert(`${key}` === key, X`non-string key ${key}`);
     return get(key) !== undefined;
   }
 
@@ -133,12 +127,8 @@ function makeSwingStore(dirPath, forceReset = false) {
    * @throws if either parameter is not a string.
    */
   function set(key, value) {
-    if (`${key}` !== key) {
-      throw new Error(`non-string key ${key}`);
-    }
-    if (`${value}` !== value) {
-      throw new Error(`non-string value ${value}`);
-    }
+    assert(`${key}` === key, X`non-string key ${key}`);
+    assert(`${value}` === value, X`non-string value ${value}`);
     ensureTxn();
     txn.putString(dbi, key, value);
   }
@@ -152,9 +142,7 @@ function makeSwingStore(dirPath, forceReset = false) {
    * @throws if key is not a string.
    */
   function del(key) {
-    if (`${key}` !== key) {
-      throw new Error(`non-string key ${key}`);
-    }
+    assert(`${key}` === key, X`non-string key ${key}`);
     if (has(key)) {
       ensureTxn();
       txn.del(dbi, key);

--- a/packages/swingset-runner/demo/vatStore2/bootstrap.js
+++ b/packages/swingset-runner/demo/vatStore2/bootstrap.js
@@ -1,7 +1,6 @@
 import { E } from '@agoric/eventual-send';
+import { assert, details as X } from '@agoric/assert';
 import { makeXorShift128 } from './xorshift128';
-
-const { details: X } = assert;
 
 const p = console.log;
 

--- a/packages/swingset-runner/demo/vatStore2/bootstrap.js
+++ b/packages/swingset-runner/demo/vatStore2/bootstrap.js
@@ -1,6 +1,8 @@
 import { E } from '@agoric/eventual-send';
 import { makeXorShift128 } from './xorshift128';
 
+const { details: X } = assert;
+
 const p = console.log;
 
 const randomness = makeXorShift128();
@@ -70,7 +72,7 @@ export function buildRootObject(_vatPowers) {
             break;
           }
           default:
-            throw Error(`this can't happen`);
+            assert.fail(X`this can't happen`);
         }
       }
       return 'done';

--- a/packages/swingset-runner/demo/zoeTests/vat-alice.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-alice.js
@@ -4,6 +4,8 @@ import { showPurseBalance, setupIssuers } from './helpers';
 
 import { makePrintLog } from './printLog';
 
+const { details: X } = assert;
+
 const build = async (log, zoe, issuers, payments, installations, timer) => {
   const { moola, simoleans, bucks, purses } = await setupIssuers(zoe, issuers);
   const [moolaPurseP, simoleanPurseP] = purses;
@@ -484,6 +486,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
   };
 
   return harden({
+    // eslint-disable-next-line consistent-return
     startTest: async (testName, bobP, carolP, daveP) => {
       switch (testName) {
         case 'automaticRefundOk': {
@@ -517,7 +520,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
           return doOTCDesk(bobP);
         }
         default: {
-          throw new Error(`testName ${testName} not recognized`);
+          assert.fail(X`testName ${testName} not recognized`);
         }
       }
     },

--- a/packages/swingset-runner/demo/zoeTests/vat-alice.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-alice.js
@@ -1,10 +1,9 @@
 import { E } from '@agoric/eventual-send';
 import { makeLocalAmountMath } from '@agoric/ertp';
+import { assert, details as X } from '@agoric/assert';
 import { showPurseBalance, setupIssuers } from './helpers';
 
 import { makePrintLog } from './printLog';
-
-const { details: X } = assert;
 
 const build = async (log, zoe, issuers, payments, installations, timer) => {
   const { moola, simoleans, bucks, purses } = await setupIssuers(zoe, issuers);
@@ -486,7 +485,6 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
   };
 
   return harden({
-    // eslint-disable-next-line consistent-return
     startTest: async (testName, bobP, carolP, daveP) => {
       switch (testName) {
         case 'automaticRefundOk': {

--- a/packages/swingset-runner/demo/zoeTests/vat-bob.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-bob.js
@@ -1,5 +1,5 @@
 import { E } from '@agoric/eventual-send';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { sameStructure } from '@agoric/same-structure';
 import { makeLocalAmountMath } from '@agoric/ertp';
 import { showPurseBalance, setupIssuers } from './helpers';
@@ -33,16 +33,16 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       // Bob ensures it's the contract he expects
       assert(
         installations.automaticRefund === installation,
-        details`should be the expected automaticRefund`,
+        X`should be the expected automaticRefund`,
       );
 
       assert(
         issuerKeywordRecord.Contribution1 === moolaIssuer,
-        details`The first issuer should be the moola issuer`,
+        X`The first issuer should be the moola issuer`,
       );
       assert(
         issuerKeywordRecord.Contribution2 === simoleanIssuer,
-        details`The second issuer should be the simolean issuer`,
+        X`The second issuer should be the simolean issuer`,
       );
 
       // 1. Bob escrows his offer
@@ -89,13 +89,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const { value: optionValue } = await E(invitationIssuer).getAmountOf(
         exclInvitation,
       );
-      assert(
-        installation === installations.coveredCall,
-        details`wrong installation`,
-      );
+      assert(installation === installations.coveredCall, X`wrong installation`);
       assert(
         optionValue[0].description === 'exerciseOption',
-        details`wrong invitation`,
+        X`wrong invitation`,
       );
       assert(
         moolaAmountMath.isEqual(
@@ -109,20 +106,17 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
           simoleans(7),
         ),
       );
-      assert(
-        optionValue[0].expirationDate === 1,
-        details`wrong expirationDate`,
-      );
+      assert(optionValue[0].expirationDate === 1, X`wrong expirationDate`);
       assert(optionValue[0].timeAuthority === timer, 'wrong timer');
       const { UnderlyingAsset, StrikePrice } = issuerKeywordRecord;
 
       assert(
         UnderlyingAsset === moolaIssuer,
-        details`The underlying asset issuer should be the moola issuer`,
+        X`The underlying asset issuer should be the moola issuer`,
       );
       assert(
         StrikePrice === simoleanIssuer,
-        details`The strike price issuer should be the simolean issuer`,
+        X`The strike price issuer should be the simolean issuer`,
       );
 
       const bobPayments = { StrikePrice: simoleanPayment };
@@ -161,40 +155,34 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       );
       const optionValue = optionAmounts.value;
 
-      assert(
-        installation === installations.coveredCall,
-        details`wrong installation`,
-      );
+      assert(installation === installations.coveredCall, X`wrong installation`);
       assert(
         optionValue[0].description === 'exerciseOption',
-        details`wrong invitation`,
+        X`wrong invitation`,
       );
       assert(
         moolaAmountMath.isEqual(
           optionValue[0].underlyingAssets.UnderlyingAsset,
           moola(3),
         ),
-        details`wrong underlying asset`,
+        X`wrong underlying asset`,
       );
       assert(
         simoleanAmountMath.isEqual(
           optionValue[0].strikePrice.StrikePrice,
           simoleans(7),
         ),
-        details`wrong strike price`,
+        X`wrong strike price`,
       );
-      assert(
-        optionValue[0].expirationDate === 100,
-        details`wrong expiration date`,
-      );
-      assert(optionValue[0].timeAuthority === timer, details`wrong timer`);
+      assert(optionValue[0].expirationDate === 100, X`wrong expiration date`);
+      assert(optionValue[0].timeAuthority === timer, X`wrong timer`);
       assert(
         UnderlyingAsset === moolaIssuer,
-        details`The underlyingAsset issuer should be the moola issuer`,
+        X`The underlyingAsset issuer should be the moola issuer`,
       );
       assert(
         StrikePrice === simoleanIssuer,
-        details`The strikePrice issuer should be the simolean issuer`,
+        X`The strikePrice issuer should be the simolean issuer`,
       );
 
       // Let's imagine that Bob wants to create a swap to trade this
@@ -248,14 +236,14 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
       assert(
         installation === installations.secondPriceAuction,
-        details`wrong installation`,
+        X`wrong installation`,
       );
       assert(
         sameStructure(
           harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),
           issuerKeywordRecord,
         ),
-        details`issuerKeywordRecord was not as expected`,
+        X`issuerKeywordRecord was not as expected`,
       );
       assert(sameStructure(invitationValue[0].minimumBid, simoleans(3)));
       assert(sameStructure(invitationValue[0].auctionedAssets, moola(1)));
@@ -292,25 +280,22 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         exclInvitation,
       );
 
-      assert(
-        installation === installations.atomicSwap,
-        details`wrong installation`,
-      );
+      assert(installation === installations.atomicSwap, X`wrong installation`);
       assert(
         sameStructure(
           harden({ Asset: moolaIssuer, Price: simoleanIssuer }),
           issuerKeywordRecord,
         ),
-        details`issuers were not as expected`,
+        X`issuers were not as expected`,
       );
 
       assert(
         sameStructure(invitationValue[0].asset, moola(3)),
-        details`Alice made a different offer than expected`,
+        X`Alice made a different offer than expected`,
       );
       assert(
         sameStructure(invitationValue[0].price, simoleans(7)),
-        details`Alice made a different offer than expected`,
+        X`Alice made a different offer than expected`,
       );
 
       const proposal = harden({
@@ -345,15 +330,15 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
       assert(
         installation === installations.simpleExchange,
-        details`wrong installation`,
+        X`wrong installation`,
       );
       assert(
         issuerKeywordRecord.Asset === moolaIssuer,
-        details`The first issuer should be the moola issuer`,
+        X`The first issuer should be the moola issuer`,
       );
       assert(
         issuerKeywordRecord.Price === simoleanIssuer,
-        details`The second issuer should be the simolean issuer`,
+        X`The second issuer should be the simolean issuer`,
       );
 
       const bobBuyOrderProposal = harden({
@@ -388,15 +373,15 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
       assert(
         installation === installations.simpleExchange,
-        details`wrong installation`,
+        X`wrong installation`,
       );
       assert(
         issuerKeywordRecord.Asset === moolaIssuer,
-        details`The first issuer should be the moola issuer`,
+        X`The first issuer should be the moola issuer`,
       );
       assert(
         issuerKeywordRecord.Price === simoleanIssuer,
-        details`The second issuer should be the simolean issuer`,
+        X`The second issuer should be the simolean issuer`,
       );
       const bobBuyOrderProposal = harden({
         want: { Asset: moola(m) },
@@ -435,10 +420,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const buyBInvitation = await E(publicFacet).makeSwapInInvitation();
       const installation = await E(zoe).getInstallation(buyBInvitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
-      assert(
-        installation === installations.autoswap,
-        details`wrong installation`,
-      );
+      assert(installation === installations.autoswap, X`wrong installation`);
       const liquidityIssuer = await E(publicFacet).getLiquidityIssuer();
       assert(
         sameStructure(
@@ -449,7 +431,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
           }),
           issuerKeywordRecord,
         ),
-        details`issuers were not as expected`,
+        X`issuers were not as expected`,
       );
 
       // bob checks how many simoleans he can get for 3 moola

--- a/packages/swingset-runner/demo/zoeTests/vat-carol.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-carol.js
@@ -1,5 +1,5 @@
 import { E } from '@agoric/eventual-send';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { sameStructure } from '@agoric/same-structure';
 import { showPurseBalance, setupIssuers } from './helpers';
 
@@ -26,14 +26,14 @@ const build = async (log, zoe, issuers, payments, installations) => {
 
       assert(
         installation === installations.secondPriceAuction,
-        details`wrong installation`,
+        X`wrong installation`,
       );
       assert(
         sameStructure(
           harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),
           issuerKeywordRecord,
         ),
-        details`issuerKeywordRecord were not as expected`,
+        X`issuerKeywordRecord were not as expected`,
       );
       assert(sameStructure(invitationValue[0].minimumBid, simoleans(3)));
       assert(sameStructure(invitationValue[0].auctionedAssets, moola(1)));

--- a/packages/swingset-runner/demo/zoeTests/vat-dave.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-dave.js
@@ -1,5 +1,5 @@
 import { E } from '@agoric/eventual-send';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { sameStructure } from '@agoric/same-structure';
 import { showPurseBalance, setupIssuers } from './helpers';
 
@@ -33,14 +33,14 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
       assert(
         installation === installations.secondPriceAuction,
-        details`wrong installation`,
+        X`wrong installation`,
       );
       assert(
         sameStructure(
           harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),
           issuerKeywordRecord,
         ),
-        details`issuerKeywordRecord were not as expected`,
+        X`issuerKeywordRecord were not as expected`,
       );
       assert(sameStructure(invitationValue[0].minimumBid, simoleans(3)));
       assert(sameStructure(invitationValue[0].auctionedAssets, moola(1)));
@@ -84,62 +84,56 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       // pick some arbitrary code points as a signature.
       assert(
         source.includes('asset: give.Asset,'),
-        details`source bundle didn't match at "asset: give.Asset,"`,
+        X`source bundle didn't match at "asset: give.Asset,"`,
       );
       assert(
         source.includes('swap(zcf, firstSeat, matchingSeat)'),
-        details`source bundle didn't match at "swap(zcf, firstSeat, matchingSeat)"`,
+        X`source bundle didn't match at "swap(zcf, firstSeat, matchingSeat)"`,
       );
       assert(
         source.includes('makeMatchingInvitation'),
-        details`source bundle didn't match at "makeMatchingInvitation"`,
+        X`source bundle didn't match at "makeMatchingInvitation"`,
       );
-      assert(
-        installation === installations.atomicSwap,
-        details`wrong installation`,
-      );
+      assert(installation === installations.atomicSwap, X`wrong installation`);
       assert(
         sameStructure(
           harden({ Asset: invitationIssuer, Price: bucksIssuer }),
           issuerKeywordRecord,
         ),
-        details`issuerKeywordRecord were not as expected`,
+        X`issuerKeywordRecord were not as expected`,
       );
 
       // Dave expects that Bob has already made an offer in the swap
       // with the following rules:
       assert(
         sameStructure(invitationValue[0].asset, optionAmounts),
-        details`asset is the option`,
+        X`asset is the option`,
       );
       assert(
         sameStructure(invitationValue[0].price, bucks(1)),
-        details`price is 1 buck`,
+        X`price is 1 buck`,
       );
       const optionValue = optionAmounts.value;
       assert(
         optionValue[0].description === 'exerciseOption',
-        details`wrong invitation`,
+        X`wrong invitation`,
       );
       assert(
         moolaAmountMath.isEqual(
           optionValue[0].underlyingAssets.UnderlyingAsset,
           moola(3),
         ),
-        details`wrong underlying asset`,
+        X`wrong underlying asset`,
       );
       assert(
         simoleanAmountMath.isEqual(
           optionValue[0].strikePrice.StrikePrice,
           simoleans(7),
         ),
-        details`wrong strike price`,
+        X`wrong strike price`,
       );
-      assert(
-        optionValue[0].expirationDate === 100,
-        details`wrong expiration date`,
-      );
-      assert(optionValue[0].timeAuthority === timer, details`wrong timer`);
+      assert(optionValue[0].expirationDate === 100, X`wrong expiration date`);
+      assert(optionValue[0].timeAuthority === timer, X`wrong timer`);
 
       // Dave escrows his 1 buck with Zoe and forms his proposal
       const daveSwapProposal = harden({

--- a/packages/swingset-runner/src/auditstore.js
+++ b/packages/swingset-runner/src/auditstore.js
@@ -1,4 +1,4 @@
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 /* eslint-disable no-use-before-define */
 export function auditRefCounts(store) {

--- a/packages/swingset-runner/src/auditstore.js
+++ b/packages/swingset-runner/src/auditstore.js
@@ -1,3 +1,5 @@
+const { details: X } = assert;
+
 /* eslint-disable no-use-before-define */
 export function auditRefCounts(store) {
   const refCounts = new Map();
@@ -48,7 +50,7 @@ export function auditRefCounts(store) {
         break;
       }
       default:
-        throw new Error(`unknown state for ${kpid}: ${state}`);
+        assert.fail(X`unknown state for ${kpid}: ${state}`);
     }
   }
 
@@ -77,7 +79,7 @@ export function auditRefCounts(store) {
         slotNum += 1;
       }
     } else {
-      throw new Error(`unknown message type ${msg.type}`);
+      assert.fail(X`unknown message type ${msg.type}`);
     }
   }
 

--- a/packages/swingset-runner/src/slogulator.js
+++ b/packages/swingset-runner/src/slogulator.js
@@ -3,6 +3,8 @@ import process from 'process';
 import Readlines from 'n-readlines';
 import yargs from 'yargs';
 
+const { details: X } = assert;
+
 /* eslint-disable no-use-before-define */
 
 function usage() {
@@ -246,7 +248,7 @@ export function main() {
             result = `ibid(${val.index})`;
             break;
           default:
-            throw new Error(`unknown qClass ${qClass} in legibilizeValue`);
+            assert.fail(X`unknown qClass ${qClass} in legibilizeValue`);
         }
       } else {
         result = '{';

--- a/packages/swingset-runner/src/slogulator.js
+++ b/packages/swingset-runner/src/slogulator.js
@@ -3,7 +3,7 @@ import process from 'process';
 import Readlines from 'n-readlines';
 import yargs from 'yargs';
 
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 /* eslint-disable no-use-before-define */
 

--- a/packages/zoe/src/cleanProposal.js
+++ b/packages/zoe/src/cleanProposal.js
@@ -1,4 +1,4 @@
-import { assert, details, q } from '@agoric/assert';
+import { assert, details as X, q } from '@agoric/assert';
 import { mustBeComparable } from '@agoric/same-structure';
 
 import '../exported';
@@ -20,13 +20,13 @@ export const assertKeywordName = keyword => {
   const firstCapASCII = /^[A-Z][a-zA-Z0-9_$]*$/;
   assert(
     firstCapASCII.test(keyword),
-    details`keyword ${q(
+    X`keyword ${q(
       keyword,
     )} must be ascii and must start with a capital letter.`,
   );
   assert(
     keyword !== 'NaN' && keyword !== 'Infinity',
-    details`keyword ${q(keyword)} must not be a number's name`,
+    X`keyword ${q(keyword)} must not be a number's name`,
   );
 };
 
@@ -39,7 +39,7 @@ const assertKeysAllowed = (allowedKeys, record) => {
   // assert that there are no symbol properties.
   assert(
     Object.getOwnPropertySymbols(record).length === 0,
-    details`no symbol properties allowed`,
+    X`no symbol properties allowed`,
   );
 };
 
@@ -77,7 +77,7 @@ export const cleanKeywords = keywordRecord => {
   // Insist that there are no symbol properties.
   assert(
     Object.getOwnPropertySymbols(keywordRecord).length === 0,
-    details`no symbol properties allowed`,
+    X`no symbol properties allowed`,
   );
 
   // Assert all key characters are ascii and keys start with a
@@ -118,7 +118,7 @@ export const cleanProposal = (getAmountMath, proposal) => {
   // Check exit
   assert(
     Object.getOwnPropertyNames(exit).length === 1,
-    details`exit ${proposal.exit} should only have one key`,
+    X`exit ${proposal.exit} should only have one key`,
   );
   // We expect the single exit key to be one of the following:
   const allowedExitKeys = ['onDemand', 'afterDeadline', 'waived'];
@@ -132,13 +132,10 @@ export const cleanProposal = (getAmountMath, proposal) => {
   if (exitKey === 'afterDeadline') {
     const expectedAfterDeadlineKeys = ['timer', 'deadline'];
     assertKeysAllowed(expectedAfterDeadlineKeys, exit.afterDeadline);
-    assert(
-      exit.afterDeadline.timer !== undefined,
-      details`timer must be defined`,
-    );
+    assert(exit.afterDeadline.timer !== undefined, X`timer must be defined`);
     assert(
       exit.afterDeadline.deadline !== undefined,
-      details`deadline must be defined`,
+      X`deadline must be defined`,
     );
     // timers must have a 'setWakeup' function which takes a deadline
     // and an object as arguments.
@@ -154,7 +151,7 @@ export const cleanProposal = (getAmountMath, proposal) => {
   giveKeywords.forEach(keyword => {
     assert(
       !wantKeywordSet.has(keyword),
-      details`a keyword cannot be in both 'want' and 'give'`,
+      X`a keyword cannot be in both 'want' and 'give'`,
     );
   });
 

--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -7,7 +7,7 @@
 // time this file is edited, the bundle must be manually rebuilt with
 // `yarn build-zcfBundle`.
 
-import { assert, details, q } from '@agoric/assert';
+import { assert, details as X, q } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
 import { makeStore, makeWeakStore } from '@agoric/store';
 
@@ -85,7 +85,7 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
       assertKeywordName(keyword);
       assert(
         !getKeywords(instanceRecord.terms.issuers).includes(keyword),
-        details`keyword ${q(keyword)} must be unique`,
+        X`keyword ${q(keyword)} must be unique`,
       );
       return registerIssuerRecord(keyword, issuerRecord);
     };
@@ -111,12 +111,12 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
       seatStagings.forEach(seatStaging => {
         assert(
           allSeatStagings.has(seatStaging),
-          details`The seatStaging ${seatStaging} was not recognized`,
+          X`The seatStaging ${seatStaging} was not recognized`,
         );
         const seat = seatStaging.getSeat();
         assert(
           !seatsSoFar.has(seat),
-          details`Seat (${seat}) was already an argument to reallocate`,
+          X`Seat (${seat}) was already an argument to reallocate`,
         );
         seatsSoFar.add(seat);
       });
@@ -199,7 +199,7 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
     ) => {
       assert(
         !(keyword in instanceRecord.terms.issuers),
-        details`Keyword ${keyword} already registered`,
+        X`Keyword ${keyword} already registered`,
       );
 
       const zoeMintP = E(zoeInstanceAdmin).makeZoeMint(
@@ -229,7 +229,7 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
           assert.typeof(
             gains,
             'object',
-            details`gains ${gains} must be an amountKeywordRecord`,
+            X`gains ${gains} must be an amountKeywordRecord`,
           );
           if (zcfSeat === undefined) {
             zcfSeat = makeEmptySeatKit().zcfSeat;
@@ -239,7 +239,7 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
           const updates = objectMap(gains, ([seatKeyword, amountToAdd]) => {
             assert(
               totalToMint.brand === amountToAdd.brand,
-              details`Only digital assets of brand ${totalToMint.brand} can be minted in this call. ${amountToAdd} has the wrong brand.`,
+              X`Only digital assets of brand ${totalToMint.brand} can be minted in this call. ${amountToAdd} has the wrong brand.`,
             );
             totalToMint = mintyAmountMath.add(totalToMint, amountToAdd);
             const oldAmount = oldAllocation[seatKeyword];
@@ -267,7 +267,7 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
           assert.typeof(
             losses,
             'object',
-            details`losses ${losses} must be an amountKeywordRecord`,
+            X`losses ${losses} must be an amountKeywordRecord`,
           );
           let totalToBurn = mintyAmountMath.getEmpty();
           const oldAllocation = zcfSeat.getCurrentAllocation();
@@ -276,7 +276,7 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
             ([seatKeyword, amountToSubtract]) => {
               assert(
                 totalToBurn.brand === amountToSubtract.brand,
-                details`Only digital assets of brand ${totalToBurn.brand} can be burned in this call. ${amountToSubtract} has the wrong brand.`,
+                X`Only digital assets of brand ${totalToBurn.brand} can be burned in this call. ${amountToSubtract} has the wrong brand.`,
               );
               totalToBurn = mintyAmountMath.add(totalToBurn, amountToSubtract);
               const oldAmount = oldAllocation[seatKeyword];
@@ -311,7 +311,7 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
         // Discussion at: https://github.com/Agoric/agoric-sdk/issues/1017
         assert(
           seatStagings.length >= 2,
-          details`reallocating must be done over two or more seats`,
+          X`reallocating must be done over two or more seats`,
         );
 
         // Ensure that rights are conserved overall. Offer safety was
@@ -337,7 +337,7 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
         assertKeywordName(keyword);
         assert(
           !getKeywords(instanceRecord.terms.issuers).includes(keyword),
-          details`keyword ${q(keyword)} must be unique`,
+          X`keyword ${q(keyword)} must be unique`,
         );
       },
       saveIssuer: async (issuerP, keyword) => {
@@ -359,7 +359,7 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
         assert.typeof(
           description,
           'string',
-          details`invitations must have a description string: ${description}`,
+          X`invitations must have a description string: ${description}`,
         );
 
         const invitationHandle = makeHandle('Invitation');

--- a/packages/zoe/src/contractFacet/exit.js
+++ b/packages/zoe/src/contractFacet/exit.js
@@ -1,4 +1,4 @@
-import { assert, details, q } from '@agoric/assert';
+import { assert, details as X, q } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
 
 /**
@@ -56,7 +56,7 @@ export const makeExitObj = (proposal, zoeSeatAdmin, zcfSeatAdmin) => {
     // on demand
     assert(
       exitKind === 'waived',
-      details`exit kind was not recognized: ${q(exitKind)}`,
+      X`exit kind was not recognized: ${q(exitKind)}`,
     );
   }
   return exitObj;

--- a/packages/zoe/src/contractFacet/fakeVatAdmin.js
+++ b/packages/zoe/src/contractFacet/fakeVatAdmin.js
@@ -3,6 +3,8 @@ import { makePromiseKit } from '@agoric/promise-kit';
 
 import { evalContractBundle } from './evalContractCode';
 
+const { details: X } = assert;
+
 function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
   // FakeVatPowers isn't intended to support testing of vat termination, it is
   // provided to allow unit testing of contracts that call zcf.shutdown()
@@ -49,7 +51,7 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
       });
     },
     createVatByName: _name => {
-      throw Error(`createVatByName not supported in fake mode`);
+      assert.fail(X`createVatByName not supported in fake mode`);
     },
   });
   const vatAdminState = {

--- a/packages/zoe/src/contractFacet/fakeVatAdmin.js
+++ b/packages/zoe/src/contractFacet/fakeVatAdmin.js
@@ -1,9 +1,8 @@
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
 
+import { assert, details as X } from '@agoric/assert';
 import { evalContractBundle } from './evalContractCode';
-
-const { details: X } = assert;
 
 function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
   // FakeVatPowers isn't intended to support testing of vat termination, it is

--- a/packages/zoe/src/contractFacet/rightsConservation.js
+++ b/packages/zoe/src/contractFacet/rightsConservation.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import makeStore from '@agoric/store';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 
 import '../../exported';
 import '../internal-types';
@@ -49,7 +49,7 @@ const assertEqualPerBrand = (
   assert.equal(
     leftKeys.length,
     rightKeys.length,
-    details`${leftKeys.length} should be equal to ${rightKeys.length}`,
+    X`${leftKeys.length} should be equal to ${rightKeys.length}`,
   );
   leftSumsByBrand
     .keys()
@@ -59,7 +59,7 @@ const assertEqualPerBrand = (
           leftSumsByBrand.get(brand),
           rightSumsByBrand.get(brand),
         ),
-        details`rights were not conserved for brand ${brand}`,
+        X`rights were not conserved for brand ${brand}`,
       ),
     );
 };

--- a/packages/zoe/src/contractFacet/seat.js
+++ b/packages/zoe/src/contractFacet/seat.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { E } from '@agoric/eventual-send';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { Far } from '@agoric/marshal';
 
 import { isOfferSafe } from './offerSafety';
@@ -23,8 +23,7 @@ export const makeZcfSeatAdminKit = (
   let currentAllocation = harden(seatData.initialAllocation);
   let exited = false; // seat is "active"
 
-  const assertExitedFalse = () =>
-    assert(!exited, details`seat has been exited`);
+  const assertExitedFalse = () => assert(!exited, X`seat has been exited`);
 
   /** @type {ZCFSeatAdmin} */
   const zcfSeatAdmin = harden({
@@ -34,7 +33,7 @@ export const makeZcfSeatAdminKit = (
       assertExitedFalse();
       assert(
         allSeatStagings.has(seatStaging),
-        details`The seatStaging ${seatStaging} was not recognized`,
+        X`The seatStaging ${seatStaging} was not recognized`,
       );
       currentAllocation = seatStaging.getStagedAllocation();
     },
@@ -77,7 +76,10 @@ export const makeZcfSeatAdminKit = (
       if (currentAllocation[keyword] !== undefined) {
         return currentAllocation[keyword];
       }
-      assert(brand, `A brand must be supplied when the keyword is not defined`);
+      assert(
+        brand,
+        X`A brand must be supplied when the keyword is not defined`,
+      );
       return getAmountMath(brand).getEmpty();
     },
     getCurrentAllocation: () => {
@@ -103,7 +105,7 @@ export const makeZcfSeatAdminKit = (
 
       assert(
         isOfferSafe(getAmountMath, proposal, allocation),
-        details`The reallocation was not offer safe`,
+        X`The reallocation was not offer safe`,
       );
 
       const seatStaging = {

--- a/packages/zoe/src/contractSupport/bondingCurves.js
+++ b/packages/zoe/src/contractSupport/bondingCurves.js
@@ -1,4 +1,4 @@
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import Nat from '@agoric/nat';
 import { natSafeMath } from './safeMath';
 
@@ -37,15 +37,9 @@ export const getInputPrice = (
   outputReserve,
   feeBasisPoints = 30,
 ) => {
-  assert(inputValue > 0, details`inputValue ${inputValue} must be positive`);
-  assert(
-    inputReserve > 0,
-    details`inputReserve ${inputReserve} must be positive`,
-  );
-  assert(
-    outputReserve > 0,
-    details`outputReserve ${outputReserve} must be positive`,
-  );
+  assert(inputValue > 0, X`inputValue ${inputValue} must be positive`);
+  assert(inputReserve > 0, X`inputReserve ${inputReserve} must be positive`);
+  assert(outputReserve > 0, X`outputReserve ${outputReserve} must be positive`);
 
   const oneMinusFeeScaled = BIG_10000 - BigInt(feeBasisPoints);
   const inputWithFee = BigInt(inputValue) * oneMinusFeeScaled;
@@ -79,17 +73,11 @@ export const getOutputPrice = (
   outputReserve,
   feeBasisPoints = 30,
 ) => {
-  assert(
-    inputReserve > 0,
-    details`inputReserve ${inputReserve} must be positive`,
-  );
-  assert(
-    outputReserve > 0,
-    details`outputReserve ${outputReserve} must be positive`,
-  );
+  assert(inputReserve > 0, X`inputReserve ${inputReserve} must be positive`);
+  assert(outputReserve > 0, X`outputReserve ${outputReserve} must be positive`);
   assert(
     outputReserve > outputValue,
-    details`outputReserve ${outputReserve} must be greater than outputValue ${outputValue}`,
+    X`outputReserve ${outputReserve} must be greater than outputValue ${outputValue}`,
   );
 
   const oneMinusFeeScaled = BIG_10000 - BigInt(feeBasisPoints);
@@ -100,7 +88,7 @@ export const getOutputPrice = (
 };
 
 function assertDefined(label, value) {
-  assert(value !== undefined, details`${label} value required`);
+  assert(value !== undefined, X`${label} value required`);
 }
 
 // Calculate how many liquidity tokens we should be minting to send back to the

--- a/packages/zoe/src/contractSupport/percentMath.js
+++ b/packages/zoe/src/contractSupport/percentMath.js
@@ -1,5 +1,5 @@
 import './types';
-import { assert } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import Nat from '@agoric/nat';
 import { natSafeMath } from './safeMath';
 
@@ -29,9 +29,7 @@ function makePercent(value, amountMath, base = 100) {
       return amountMath.make(floorDivide(multiply(amount.value, value), base));
     },
     complement: _ => {
-      if (value > base) {
-        throw Error(`cannot take complement when > 100%.`);
-      }
+      assert(value <= base, X`cannot take complement when > 100%.`);
       return makePercent(base - value, amountMath, base);
     },
   });

--- a/packages/zoe/src/contractSupport/priceAuthority.js
+++ b/packages/zoe/src/contractSupport/priceAuthority.js
@@ -1,5 +1,5 @@
 import { E } from '@agoric/eventual-send';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { makePromiseKit } from '@agoric/promise-kit';
 
 import '../../exported';
@@ -141,12 +141,12 @@ export function makeOnewayPriceAuthorityKit(opts) {
     assert.equal(
       brandIn,
       paBrandIn,
-      details`Desired brandIn ${brandIn} must match ${paBrandIn}`,
+      X`Desired brandIn ${brandIn} must match ${paBrandIn}`,
     );
     assert.equal(
       brandOut,
       paBrandOut,
-      details`Desired brandOut ${brandOut} must match ${paBrandOut}`,
+      X`Desired brandOut ${brandOut} must match ${paBrandOut}`,
     );
   };
 
@@ -186,7 +186,7 @@ export function makeOnewayPriceAuthorityKit(opts) {
 
         assert(
           mathOut.isGTE(actualAmountOut, amountOut),
-          details`Calculation of ${actualAmountOut} didn't cover expected ${amountOut}`,
+          X`Calculation of ${actualAmountOut} didn't cover expected ${amountOut}`,
         );
         return { amountIn, amountOut };
       });

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -1,7 +1,7 @@
 // @ts-check
 import '../../exported';
 
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { sameStructure } from '@agoric/same-structure';
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
@@ -91,7 +91,7 @@ export const assertIssuerKeywords = (zcf, expected) => {
   expected.sort();
   assert(
     sameStructure(actual, harden(expected)),
-    details`keywords: ${actual} were not as expected: ${expected}`,
+    X`keywords: ${actual} were not as expected: ${expected}`,
   );
 };
 
@@ -129,7 +129,7 @@ export const trade = (
   leftHasExitedMsg = 'the left seat has exited',
   rightHasExitedMsg = 'the right seat has exited',
 ) => {
-  assert(left.seat !== right.seat, details`a seat cannot trade with itself`);
+  assert(left.seat !== right.seat, X`a seat cannot trade with itself`);
   assert(!left.seat.hasExited(), leftHasExitedMsg);
   assert(!right.seat.hasExited(), rightHasExitedMsg);
   let leftAllocation = left.seat.getCurrentAllocation();
@@ -155,7 +155,7 @@ export const trade = (
     const newErr = new Error(
       `The trade between left ${left} and right ${right} failed.`,
     );
-    assert.note(newErr, details`due to ${err}`);
+    assert.note(newErr, X`due to ${err}`);
     throw newErr;
   }
 
@@ -190,7 +190,7 @@ export const trade = (
     );
   } catch (err) {
     const newErr = Error(`The reallocation failed to conserve rights.`);
-    assert.note(newErr, details`due to ${err}`);
+    assert.note(newErr, X`due to ${err}`);
     throw newErr;
   }
 };
@@ -292,13 +292,13 @@ export const swapExact = (
  */
 export const assertProposalShape = (seat, expected) => {
   assert.typeof(expected, 'object');
-  assert(!Array.isArray(expected), `Expected must be an non-array object`);
+  assert(!Array.isArray(expected), X`Expected must be an non-array object`);
   const assertValuesNull = e => {
     if (e !== undefined) {
       Object.values(e).forEach(value =>
         assert(
           value === null,
-          details`The value of the expected record must be null but was ${value}`,
+          X`The value of the expected record must be null but was ${value}`,
         ),
       );
     }
@@ -315,7 +315,7 @@ export const assertProposalShape = (seat, expected) => {
     if (e !== undefined) {
       assert(
         sameStructure(getKeysSorted(a), getKeysSorted(e)),
-        details`actual ${a} did not match expected ${e}`,
+        X`actual ${a} did not match expected ${e}`,
       );
     }
   };
@@ -329,7 +329,7 @@ export const assertUsesNatMath = (zcf, brand) => {
   const amountMath = zcf.getAmountMath(brand);
   assert(
     amountMath.getAmountMathKind() === MathKind.NAT,
-    details`issuer must use NAT amountMath`,
+    X`issuer must use NAT amountMath`,
   );
 };
 

--- a/packages/zoe/src/contracts/auction/assertBidSeat.js
+++ b/packages/zoe/src/contracts/auction/assertBidSeat.js
@@ -1,4 +1,4 @@
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 
 export const assertBidSeat = (zcf, sellSeat, bidSeat) => {
   const {
@@ -8,12 +8,12 @@ export const assertBidSeat = (zcf, sellSeat, bidSeat) => {
   const bid = bidSeat.getAmountAllocated('Bid', minBid.brand);
   assert(
     bidMath.isGTE(bid, minBid),
-    details`bid ${bid} is under the minimum bid ${minBid}`,
+    X`bid ${bid} is under the minimum bid ${minBid}`,
   );
   const assetAtAuction = sellSeat.getProposal().give.Asset;
   const assetWanted = bidSeat.getAmountAllocated('Asset', assetAtAuction.brand);
   assert(
     assetMath.isGTE(assetAtAuction, assetWanted),
-    details`more assets were wanted ${assetWanted} than were available ${assetAtAuction}`,
+    X`more assets were wanted ${assetWanted} than were available ${assetAtAuction}`,
   );
 };

--- a/packages/zoe/src/contracts/callSpread/fundedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/fundedCallSpread.js
@@ -2,7 +2,7 @@
 import '../../../exported';
 import './types';
 
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { makePromiseKit } from '@agoric/promise-kit';
 import { E } from '@agoric/eventual-send';
 import {
@@ -65,7 +65,7 @@ const start = async zcf => {
 
   assert(
     strikeMath.isGTE(terms.strikePrice2, terms.strikePrice1),
-    details`strikePrice2 must be greater than strikePrice1`,
+    X`strikePrice2 must be greater than strikePrice1`,
   );
 
   await zcf.saveIssuer(zcf.getInvitationIssuer(), 'Options');

--- a/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
@@ -2,7 +2,7 @@
 import '../../../exported';
 import './types';
 
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { makePromiseKit } from '@agoric/promise-kit';
 import { E } from '@agoric/eventual-send';
 import {
@@ -64,7 +64,7 @@ const start = zcf => {
 
   assert(
     strikeMath.isGTE(terms.strikePrice2, terms.strikePrice1),
-    details`strikePrice2 must be greater than strikePrice1`,
+    X`strikePrice2 must be greater than strikePrice1`,
   );
 
   zcf.saveIssuer(zcf.getInvitationIssuer(), 'Options');
@@ -115,14 +115,14 @@ const start = zcf => {
       // assert that the allocation includes the amount of collateral required
       assert(
         collateralMath.isEqual(newCollateral, required),
-        details`Collateral required: ${required.value}`,
+        X`Collateral required: ${required.value}`,
       );
 
       // assert that the requested option was the right one.
       assert(
         spreadAmount.Option.value[0].instance ===
           desiredOption.value[0].instance,
-        details`wanted option not a match`,
+        X`wanted option not a match`,
       );
 
       trade(

--- a/packages/zoe/src/contracts/loan/borrow.js
+++ b/packages/zoe/src/contracts/loan/borrow.js
@@ -1,7 +1,7 @@
 // @ts-check
 import '../../../exported';
 
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
 
@@ -59,7 +59,7 @@ export const makeBorrowInvitation = (zcf, config) => {
         loanMath.make(collateralPriceInLoanBrand.value),
         mmr.scale(loanWanted),
       ),
-      details`The required margin is approximately ${approxForMsg.value}% but collateral only had value of ${collateralPriceInLoanBrand.value}`,
+      X`The required margin is approximately ${approxForMsg.value}% but collateral only had value of ${collateralPriceInLoanBrand.value}`,
     );
 
     // Assert that the collateralGiven has not changed after the AWAIT
@@ -74,7 +74,7 @@ export const makeBorrowInvitation = (zcf, config) => {
     // Assert that loanWanted <= maxLoan
     assert(
       loanMath.isGTE(maxLoan, loanWanted),
-      details`The wanted loan ${loanWanted} must be below or equal to the maximum possible loan ${maxLoan}`,
+      X`The wanted loan ${loanWanted} must be below or equal to the maximum possible loan ${maxLoan}`,
     );
 
     const { zcfSeat: collateralSeat } = zcf.makeEmptySeatKit();

--- a/packages/zoe/src/contracts/loan/close.js
+++ b/packages/zoe/src/contracts/loan/close.js
@@ -2,7 +2,7 @@
 
 import './types';
 
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 
 import { assertProposalShape, trade } from '../../contractSupport';
 
@@ -35,7 +35,7 @@ export const makeCloseLoanInvitation = (zcf, config) => {
     // All debt must be repaid.
     assert(
       loanMath.isGTE(repaid, debt),
-      details`Not enough Loan assets have been repaid.  ${debt} is required, but only ${repaid} was repaid.`,
+      X`Not enough Loan assets have been repaid.  ${debt} is required, but only ${repaid} was repaid.`,
     );
 
     // We cannot use `swap` or `swapExact` helper because the collateralSeat

--- a/packages/zoe/src/contracts/loan/index.js
+++ b/packages/zoe/src/contracts/loan/index.js
@@ -1,7 +1,7 @@
 // @ts-check
 import '../../../exported';
 
-import { assert } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import Nat from '@agoric/nat';
 
 import { assertIssuerKeywords } from '../../contractSupport';
@@ -70,9 +70,9 @@ const start = async zcf => {
     interestPeriod,
   } = zcf.getTerms();
 
-  assert(autoswapInstance, `autoswapInstance must be provided`);
-  assert(priceAuthority, `priceAuthority must be provided`);
-  assert(periodNotifier, `periodNotifier must be provided`);
+  assert(autoswapInstance, X`autoswapInstance must be provided`);
+  assert(priceAuthority, X`priceAuthority must be provided`);
+  assert(periodNotifier, X`periodNotifier must be provided`);
   Nat(interestRate);
   Nat(interestPeriod);
 

--- a/packages/zoe/src/contracts/multipoolAutoswap/getCurrentPrice.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/getCurrentPrice.js
@@ -1,6 +1,6 @@
 import '../../../exported';
 
-const { details: X } = assert;
+import { assert, details as X } from '@agoric/assert';
 
 /**
  * Build functions to calculate prices for multipoolAutoswap. Four methods are

--- a/packages/zoe/src/contracts/multipoolAutoswap/getCurrentPrice.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/getCurrentPrice.js
@@ -1,5 +1,7 @@
 import '../../../exported';
 
+const { details: X } = assert;
+
 /**
  * Build functions to calculate prices for multipoolAutoswap. Four methods are
  * returned, as two complementary pairs. In one pair of methods the caller
@@ -64,7 +66,7 @@ export const makeGetCurrentPrice = (
       };
     }
 
-    throw new Error(`brands were not recognized`);
+    assert.fail(X`brands were not recognized`);
   };
 
   const getPriceGivenRequiredOutput = (brandIn, amountOut) => {
@@ -110,7 +112,7 @@ export const makeGetCurrentPrice = (
       };
     }
 
-    throw new Error(`brands were not recognized`);
+    assert.fail(X`brands were not recognized`);
   };
 
   /**

--- a/packages/zoe/src/contracts/multipoolAutoswap/multipoolAutoswap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/multipoolAutoswap.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { makeWeakStore } from '@agoric/store';
 
 import { assertIssuerKeywords } from '../../contractSupport';
@@ -59,7 +59,7 @@ const start = zcf => {
     brands: { Central: centralBrand },
   } = zcf.getTerms();
   assertIssuerKeywords(zcf, ['Central']);
-  assert(centralBrand !== undefined, details`centralBrand must be present`);
+  assert(centralBrand !== undefined, X`centralBrand must be present`);
 
   /** @type {WeakStore<Brand,Pool>} */
   const secondaryBrandToPool = makeWeakStore();

--- a/packages/zoe/src/contracts/multipoolAutoswap/pool.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/pool.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { E } from '@agoric/eventual-send';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { MathKind } from '@agoric/ertp/src/amountMath';
 
 import {
@@ -62,7 +62,7 @@ export const makeAddPool = (zcf, isSecondary, initPool, centralBrand) => {
     const assertPoolInitialized = pool =>
       assert(
         !pool.getAmountMath().isEmpty(pool.getSecondaryAmount()),
-        details`pool not initialized`,
+        X`pool not initialized`,
       );
 
     const reservesAndMath = (pool, inputBrand, outputBrand) => {
@@ -242,11 +242,11 @@ export const makeAddPool = (zcf, isSecondary, initPool, centralBrand) => {
 
     assert(
       !isSecondary(secondaryBrand),
-      details`issuer ${secondaryIssuer} already has a pool`,
+      X`issuer ${secondaryIssuer} already has a pool`,
     );
     assert(
       secondaryMathKind === MathKind.NAT,
-      details`${keyword} issuer must use NAT math`,
+      X`${keyword} issuer must use NAT math`,
     );
 
     // We've checked all the foreseeable exceptions (except

--- a/packages/zoe/src/contracts/multipoolAutoswap/swap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/swap.js
@@ -2,6 +2,8 @@ import { assertProposalShape, trade } from '../../contractSupport';
 
 import '../../../exported';
 
+const { details: X } = assert;
+
 /**
  * typedef {Object} PriceAmountTriple
  *
@@ -135,7 +137,7 @@ export const makeMakeSwapInvitation = (
       return `Swap successfully completed.`;
     }
 
-    throw new Error(`brands were not recognized`);
+    assert.fail(X`brands were not recognized`);
   };
 
   // trade with a stated amount out.
@@ -252,7 +254,7 @@ export const makeMakeSwapInvitation = (
       return `Swap successfully completed.`;
     }
 
-    throw new Error(`brands were not recognized`);
+    assert.fail(X`brands were not recognized`);
   };
 
   const makeSwapInInvitation = () =>

--- a/packages/zoe/src/contracts/multipoolAutoswap/swap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/swap.js
@@ -1,8 +1,8 @@
+import { assert, details as X } from '@agoric/assert';
+
 import { assertProposalShape, trade } from '../../contractSupport';
 
 import '../../../exported';
-
-const { details: X } = assert;
 
 /**
  * typedef {Object} PriceAmountTriple

--- a/packages/zoe/src/contracts/oracle.js
+++ b/packages/zoe/src/contracts/oracle.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import '../../exported';
 
 import { E } from '@agoric/eventual-send';
@@ -68,7 +68,7 @@ const start = async zcf => {
         const { requiredFee, reply } = await E(handler).onQuery(query, noFee);
         assert(
           !requiredFee || feeMath.isGTE(noFee, requiredFee),
-          details`Oracle required a fee but the query had none`,
+          X`Oracle required a fee but the query had none`,
         );
         return reply;
       } catch (e) {

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -2,7 +2,7 @@
 import { E } from '@agoric/eventual-send';
 import { makeNotifierKit } from '@agoric/notifier';
 import makeStore from '@agoric/store';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import {
   calculateMedian,
   natSafeMath,
@@ -224,10 +224,7 @@ const start = async zcf => {
       ({ priceAuthority, adminFacet: priceAuthorityAdmin } = paKit);
     },
     async initOracle(oracleInstance, query = undefined) {
-      assert(
-        quoteKit,
-        details`Must initializeQuoteMint before adding an oracle`,
-      );
+      assert(quoteKit, X`Must initializeQuoteMint before adding an oracle`);
 
       /** @type {OracleRecord} */
       const record = { querier: undefined, lastSample: NaN };
@@ -252,15 +249,12 @@ const start = async zcf => {
 
       // Obtain the oracle's publicFacet.
       const oracle = await E(zoe).getPublicFacet(oracleInstance);
-      assert(records.has(record), details`Oracle record is already deleted`);
+      assert(records.has(record), X`Oracle record is already deleted`);
 
       /** @type {OracleAdmin} */
       const oracleAdmin = {
         async delete() {
-          assert(
-            records.has(record),
-            details`Oracle record is already deleted`,
-          );
+          assert(records.has(record), X`Oracle record is already deleted`);
 
           // The actual deletion is synchronous.
           oracleRecords.delete(record);

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -12,6 +12,8 @@ import {
 
 import '../../exported';
 
+const { details: X } = assert;
+
 /**
  * Sell items in exchange for money. Items may be fungible or
  * non-fungible and multiple items may be bought at once. Money must
@@ -54,7 +56,7 @@ const start = zcf => {
   /** @type {SellItemsPublicFacet} */
   const publicFacet = {
     getAvailableItems: () => {
-      assert(sellerSeat && !sellerSeat.hasExited(), `no items are for sale`);
+      assert(sellerSeat && !sellerSeat.hasExited(), X`no items are for sale`);
       return sellerSeat.getAmountAllocated('Items');
     },
     getItemsIssuer: () => issuers.Items,

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-use-before-define */
 // @ts-check
 
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import {
   assertIssuerKeywords,
   trade,
@@ -11,8 +11,6 @@ import {
 } from '../contractSupport';
 
 import '../../exported';
-
-const { details: X } = assert;
 
 /**
  * Sell items in exchange for money. Items may be fungible or
@@ -88,7 +86,7 @@ const start = zcf => {
     // Check that the money provided to pay for the items is greater than the totalCost.
     assert(
       moneyMath.isGTE(providedMoney, totalCost),
-      details`More money (${totalCost}) is required to buy these items`,
+      X`More money (${totalCost}) is required to buy these items`,
     );
 
     // Reallocate. We are able to trade by only defining the gains
@@ -116,7 +114,7 @@ const start = zcf => {
       const itemsAmount = sellerSeat.getAmountAllocated('Items');
       assert(
         sellerSeat && !itemsMath.isEmpty(itemsAmount),
-        details`no items are for sale`,
+        X`no items are for sale`,
       );
       return zcf.makeInvitation(buy, 'buyer');
     },

--- a/packages/zoe/src/objArrayConversion.js
+++ b/packages/zoe/src/objArrayConversion.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { assert, details, q } from '@agoric/assert';
+import { assert, details as X, q } from '@agoric/assert';
 
 /**
  * @typedef {bigint|boolean|null|number|string|symbol|undefined} Primitive
@@ -16,7 +16,7 @@ import { assert, details, q } from '@agoric/assert';
 export const arrayToObj = (array, keys) => {
   assert(
     array.length === keys.length,
-    details`array and keys must be of equal length`,
+    X`array and keys must be of equal length`,
   );
   const obj =
     /** @type {Record<U, T>} */
@@ -36,7 +36,7 @@ export const assertSubset = (whole, part) => {
     assert.typeof(key, 'string');
     assert(
       whole.includes(key),
-      details`key ${q(key)} was not one of the expected keys ${q(whole)}`,
+      X`key ${q(key)} was not one of the expected keys ${q(whole)}`,
     );
   });
 };

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { makeWeakStore } from '@agoric/store';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
 
@@ -56,7 +56,7 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
    */
   /** @type {Install} */
   const install = async bundle => {
-    assert(bundle, `a bundle must be provided`);
+    assert(bundle, X`a bundle must be provided`);
     /** @type {Installation} */
     const installation = Far('Installation', {
       getBundle: () => bundle,
@@ -69,7 +69,7 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
   /** @type {GetAmountOfInvitationThen} */
   const getAmountOfInvitationThen = async (invitationP, onFulfilled) => {
     const onRejected = () =>
-      assert.fail(details`A Zoe invitation is required, not ${invitationP}`);
+      assert.fail(X`A Zoe invitation is required, not ${invitationP}`);
     return E(invitationKit.issuer)
       .getAmountOf(invitationP)
       .then(onFulfilled, onRejected);
@@ -108,7 +108,7 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
       const installation = await Promise.resolve(installationP);
       assert(
         installations.has(installation),
-        details`${installation} was not a valid installation`,
+        X`${installation} was not a valid installation`,
       );
 
       const instance = makeHandle('Instance');
@@ -376,7 +376,7 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
         if (creatorInvitation !== undefined) {
           assert(
             isLiveResult.status === 'fulfilled' && isLiveResult.value,
-            details`The contract did not correctly return a creatorInvitation`,
+            X`The contract did not correctly return a creatorInvitation`,
           );
         }
         const adminFacet = harden({
@@ -485,9 +485,7 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
           });
         },
         () => {
-          throw assert.fail(
-            details`A Zoe invitation is required, not ${invitation}`,
-          );
+          assert.fail(X`A Zoe invitation is required, not ${invitation}`);
         },
       );
     },

--- a/packages/zoe/test/swingsetTests/brokenContracts/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/vat-alice.js
@@ -1,5 +1,5 @@
 import { E } from '@agoric/eventual-send';
-import { assert } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { showPurseBalance, setupIssuers } from '../helpers';
 
 async function logCounter(log, publicAPI) {
@@ -109,7 +109,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
       .getOfferResult()
       .then(
         o => log(`Swap outcome resolves to an invitation: ${o}`),
-        e => assert(false, `Expected swap outcome to succeed ${e}`),
+        e => assert(false, X`Expected swap outcome to succeed ${e}`),
       );
     // the refunds for swap won't happen till later
     E(seat)
@@ -241,7 +241,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
       .getOfferResult()
       .then(
         o => log(`Successful refund: ${o}`),
-        e => assert(false, `Expected swap outcome to succeed ${e}`),
+        e => assert(false, X`Expected swap outcome to succeed ${e}`),
       );
     const newPurse = await E(moolaIssuer).makeEmptyPurse();
     const swapMoolaPayout = await E(secondSeat).getPayout('Asset');
@@ -293,7 +293,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
               return log(`Swap outcome is an invitation (${val}).`);
             });
         },
-        e => assert(false, `expected outcome not to resolve yet ${e}`),
+        e => assert(false, X`expected outcome not to resolve yet ${e}`),
       );
     logCounter(log, publicFacet);
 
@@ -345,7 +345,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
       .getOfferResult()
       .then(
         o => log(`outcome correctly resolves: "${o}"`),
-        e => assert(false, `expected outcome to succeed ${e}`),
+        e => assert(false, X`expected outcome to succeed ${e}`),
       );
     const moolaSwapTwoPayout = await E(swapSeatTwo).getPayout('Asset');
     const simoleanSwapTwoPayout = await E(swapSeatTwo).getPayout('Price');
@@ -386,14 +386,14 @@ const build = async (log, zoe, issuers, payments, installations) => {
     E(publicFacet)
       .meterException()
       .then(
-        () => assert(false, `meterException in an API call should kill vat`),
+        () => assert(false, X`meterException in an API call should kill vat`),
         e => log(`Vat correctly died for ${e}`),
       );
     E(seat)
       .getOfferResult()
       .then(
         o => log(`outcome correctly resolves to "${o}"`),
-        e => assert(false, `expected outcome to succeed: ${e}`),
+        e => assert(false, X`expected outcome to succeed: ${e}`),
       );
 
     const moolaPayout = await E(seat).getPayout('Asset');
@@ -657,7 +657,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
           return doSadTermination();
         }
         default: {
-          throw new Error(`testName ${testName} not recognized`);
+          assert.fail(X`testName ${testName} not recognized`);
         }
       }
     },

--- a/packages/zoe/test/swingsetTests/zoe/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-alice.js
@@ -1,8 +1,7 @@
 import { E } from '@agoric/eventual-send';
 import { makeLocalAmountMath } from '@agoric/ertp';
+import { assert, details as X } from '@agoric/assert';
 import { showPurseBalance, setupIssuers } from '../helpers';
-
-const { details: X } = assert;
 
 const build = async (log, zoe, issuers, payments, installations, timer) => {
   const { moola, simoleans, bucks, purses } = await setupIssuers(zoe, issuers);

--- a/packages/zoe/test/swingsetTests/zoe/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-alice.js
@@ -2,6 +2,8 @@ import { E } from '@agoric/eventual-send';
 import { makeLocalAmountMath } from '@agoric/ertp';
 import { showPurseBalance, setupIssuers } from '../helpers';
 
+const { details: X } = assert;
+
 const build = async (log, zoe, issuers, payments, installations, timer) => {
   const { moola, simoleans, bucks, purses } = await setupIssuers(zoe, issuers);
   const [moolaPurseP, simoleanPurseP] = purses;
@@ -568,7 +570,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
           return doBadTimer();
         }
         default: {
-          throw new Error(`testName ${testName} not recognized`);
+          assert.fail(X`testName ${testName} not recognized`);
         }
       }
     },

--- a/packages/zoe/test/swingsetTests/zoe/vat-bob.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-bob.js
@@ -1,5 +1,5 @@
 import { E } from '@agoric/eventual-send';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { sameStructure } from '@agoric/same-structure';
 import { makeLocalAmountMath } from '@agoric/ertp';
 import { showPurseBalance, setupIssuers } from '../helpers';
@@ -31,16 +31,16 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       // Bob ensures it's the contract he expects
       assert(
         installations.automaticRefund === installation,
-        details`should be the expected automaticRefund`,
+        X`should be the expected automaticRefund`,
       );
 
       assert(
         issuerKeywordRecord.Contribution1 === moolaIssuer,
-        details`The first issuer should be the moola issuer`,
+        X`The first issuer should be the moola issuer`,
       );
       assert(
         issuerKeywordRecord.Contribution2 === simoleanIssuer,
-        details`The second issuer should be the simolean issuer`,
+        X`The second issuer should be the simolean issuer`,
       );
 
       // 1. Bob escrows his offer
@@ -87,13 +87,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const { value: optionValue } = await E(invitationIssuer).getAmountOf(
         exclInvitation,
       );
-      assert(
-        installation === installations.coveredCall,
-        details`wrong installation`,
-      );
+      assert(installation === installations.coveredCall, X`wrong installation`);
       assert(
         optionValue[0].description === 'exerciseOption',
-        details`wrong invitation`,
+        X`wrong invitation`,
       );
       assert(
         moolaAmountMath.isEqual(
@@ -107,20 +104,17 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
           simoleans(7),
         ),
       );
-      assert(
-        optionValue[0].expirationDate === 1,
-        details`wrong expirationDate`,
-      );
+      assert(optionValue[0].expirationDate === 1, X`wrong expirationDate`);
       assert(optionValue[0].timeAuthority === timer, 'wrong timer');
       const { UnderlyingAsset, StrikePrice } = issuerKeywordRecord;
 
       assert(
         UnderlyingAsset === moolaIssuer,
-        details`The underlying asset issuer should be the moola issuer`,
+        X`The underlying asset issuer should be the moola issuer`,
       );
       assert(
         StrikePrice === simoleanIssuer,
-        details`The strike price issuer should be the simolean issuer`,
+        X`The strike price issuer should be the simolean issuer`,
       );
 
       const bobPayments = { StrikePrice: simoleanPayment };
@@ -159,40 +153,34 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       );
       const optionValue = optionAmounts.value;
 
-      assert(
-        installation === installations.coveredCall,
-        details`wrong installation`,
-      );
+      assert(installation === installations.coveredCall, X`wrong installation`);
       assert(
         optionValue[0].description === 'exerciseOption',
-        details`wrong invitation`,
+        X`wrong invitation`,
       );
       assert(
         moolaAmountMath.isEqual(
           optionValue[0].underlyingAssets.UnderlyingAsset,
           moola(3),
         ),
-        details`wrong underlying asset`,
+        X`wrong underlying asset`,
       );
       assert(
         simoleanAmountMath.isEqual(
           optionValue[0].strikePrice.StrikePrice,
           simoleans(7),
         ),
-        details`wrong strike price`,
+        X`wrong strike price`,
       );
-      assert(
-        optionValue[0].expirationDate === 100,
-        details`wrong expiration date`,
-      );
-      assert(optionValue[0].timeAuthority === timer, details`wrong timer`);
+      assert(optionValue[0].expirationDate === 100, X`wrong expiration date`);
+      assert(optionValue[0].timeAuthority === timer, X`wrong timer`);
       assert(
         UnderlyingAsset === moolaIssuer,
-        details`The underlyingAsset issuer should be the moola issuer`,
+        X`The underlyingAsset issuer should be the moola issuer`,
       );
       assert(
         StrikePrice === simoleanIssuer,
-        details`The strikePrice issuer should be the simolean issuer`,
+        X`The strikePrice issuer should be the simolean issuer`,
       );
 
       // Let's imagine that Bob wants to create a swap to trade this
@@ -246,14 +234,14 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
       assert(
         installation === installations.secondPriceAuction,
-        details`wrong installation`,
+        X`wrong installation`,
       );
       assert(
         sameStructure(
           harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),
           issuerKeywordRecord,
         ),
-        details`issuerKeywordRecord was not as expected`,
+        X`issuerKeywordRecord was not as expected`,
       );
       assert(sameStructure(invitationValue[0].minimumBid, simoleans(3)));
       assert(sameStructure(invitationValue[0].auctionedAssets, moola(1)));
@@ -290,25 +278,22 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         exclInvitation,
       );
 
-      assert(
-        installation === installations.atomicSwap,
-        details`wrong installation`,
-      );
+      assert(installation === installations.atomicSwap, X`wrong installation`);
       assert(
         sameStructure(
           harden({ Asset: moolaIssuer, Price: simoleanIssuer }),
           issuerKeywordRecord,
         ),
-        details`issuers were not as expected`,
+        X`issuers were not as expected`,
       );
 
       assert(
         sameStructure(invitationValue[0].asset, moola(3)),
-        details`Alice made a different offer than expected`,
+        X`Alice made a different offer than expected`,
       );
       assert(
         sameStructure(invitationValue[0].price, simoleans(7)),
-        details`Alice made a different offer than expected`,
+        X`Alice made a different offer than expected`,
       );
 
       const proposal = harden({
@@ -343,15 +328,15 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
       assert(
         installation === installations.simpleExchange,
-        details`wrong installation`,
+        X`wrong installation`,
       );
       assert(
         issuerKeywordRecord.Asset === moolaIssuer,
-        details`The first issuer should be the moola issuer`,
+        X`The first issuer should be the moola issuer`,
       );
       assert(
         issuerKeywordRecord.Price === simoleanIssuer,
-        details`The second issuer should be the simolean issuer`,
+        X`The second issuer should be the simolean issuer`,
       );
 
       const bobBuyOrderProposal = harden({
@@ -386,15 +371,15 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
       assert(
         installation === installations.simpleExchange,
-        details`wrong installation`,
+        X`wrong installation`,
       );
       assert(
         issuerKeywordRecord.Asset === moolaIssuer,
-        details`The first issuer should be the moola issuer`,
+        X`The first issuer should be the moola issuer`,
       );
       assert(
         issuerKeywordRecord.Price === simoleanIssuer,
-        details`The second issuer should be the simolean issuer`,
+        X`The second issuer should be the simolean issuer`,
       );
       const bobBuyOrderProposal = harden({
         want: { Asset: moola(m) },
@@ -433,10 +418,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const buyBInvitation = await E(publicFacet).makeSwapInInvitation();
       const installation = await E(zoe).getInstallation(buyBInvitation);
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
-      assert(
-        installation === installations.autoswap,
-        details`wrong installation`,
-      );
+      assert(installation === installations.autoswap, X`wrong installation`);
       const liquidityIssuer = await E(publicFacet).getLiquidityIssuer();
       assert(
         sameStructure(
@@ -447,7 +429,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
           }),
           issuerKeywordRecord,
         ),
-        details`issuers were not as expected`,
+        X`issuers were not as expected`,
       );
 
       // bob checks how many simoleans he can get for 3 moola

--- a/packages/zoe/test/swingsetTests/zoe/vat-carol.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-carol.js
@@ -1,5 +1,5 @@
 import { E } from '@agoric/eventual-send';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { sameStructure } from '@agoric/same-structure';
 import { showPurseBalance, setupIssuers } from '../helpers';
 
@@ -24,14 +24,14 @@ const build = async (log, zoe, issuers, payments, installations) => {
 
       assert(
         installation === installations.secondPriceAuction,
-        details`wrong installation`,
+        X`wrong installation`,
       );
       assert(
         sameStructure(
           harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),
           issuerKeywordRecord,
         ),
-        details`issuerKeywordRecord were not as expected`,
+        X`issuerKeywordRecord were not as expected`,
       );
       assert(sameStructure(invitationValue[0].minimumBid, simoleans(3)));
       assert(sameStructure(invitationValue[0].auctionedAssets, moola(1)));

--- a/packages/zoe/test/swingsetTests/zoe/vat-dave.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-dave.js
@@ -1,5 +1,5 @@
 import { E } from '@agoric/eventual-send';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { sameStructure } from '@agoric/same-structure';
 import { showPurseBalance, setupIssuers } from '../helpers';
 
@@ -31,14 +31,14 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
       assert(
         installation === installations.secondPriceAuction,
-        details`wrong installation`,
+        X`wrong installation`,
       );
       assert(
         sameStructure(
           harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),
           issuerKeywordRecord,
         ),
-        details`issuerKeywordRecord were not as expected`,
+        X`issuerKeywordRecord were not as expected`,
       );
       assert(sameStructure(invitationValue[0].minimumBid, simoleans(3)));
       assert(sameStructure(invitationValue[0].auctionedAssets, moola(1)));
@@ -82,62 +82,56 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       // pick some arbitrary code points as a signature.
       assert(
         source.includes('asset: give.Asset,'),
-        details`source bundle didn't match at "asset: give.Asset,"`,
+        X`source bundle didn't match at "asset: give.Asset,"`,
       );
       assert(
         source.includes('swap(zcf, firstSeat, matchingSeat)'),
-        details`source bundle didn't match at "swap(zcf, firstSeat, matchingSeat)"`,
+        X`source bundle didn't match at "swap(zcf, firstSeat, matchingSeat)"`,
       );
       assert(
         source.includes('makeMatchingInvitation'),
-        details`source bundle didn't match at "makeMatchingInvitation"`,
+        X`source bundle didn't match at "makeMatchingInvitation"`,
       );
-      assert(
-        installation === installations.atomicSwap,
-        details`wrong installation`,
-      );
+      assert(installation === installations.atomicSwap, X`wrong installation`);
       assert(
         sameStructure(
           harden({ Asset: invitationIssuer, Price: bucksIssuer }),
           issuerKeywordRecord,
         ),
-        details`issuerKeywordRecord were not as expected`,
+        X`issuerKeywordRecord were not as expected`,
       );
 
       // Dave expects that Bob has already made an offer in the swap
       // with the following rules:
       assert(
         sameStructure(invitationValue[0].asset, optionAmounts),
-        details`asset is the option`,
+        X`asset is the option`,
       );
       assert(
         sameStructure(invitationValue[0].price, bucks(1)),
-        details`price is 1 buck`,
+        X`price is 1 buck`,
       );
       const optionValue = optionAmounts.value;
       assert(
         optionValue[0].description === 'exerciseOption',
-        details`wrong invitation`,
+        X`wrong invitation`,
       );
       assert(
         moolaAmountMath.isEqual(
           optionValue[0].underlyingAssets.UnderlyingAsset,
           moola(3),
         ),
-        details`wrong underlying asset`,
+        X`wrong underlying asset`,
       );
       assert(
         simoleanAmountMath.isEqual(
           optionValue[0].strikePrice.StrikePrice,
           simoleans(7),
         ),
-        details`wrong strike price`,
+        X`wrong strike price`,
       );
-      assert(
-        optionValue[0].expirationDate === 100,
-        details`wrong expiration date`,
-      );
-      assert(optionValue[0].timeAuthority === timer, details`wrong timer`);
+      assert(optionValue[0].expirationDate === 100, X`wrong expiration date`);
+      assert(optionValue[0].timeAuthority === timer, X`wrong timer`);
 
       // Dave escrows his 1 buck with Zoe and forms his proposal
       const daveSwapProposal = harden({

--- a/packages/zoe/test/unitTests/bounty.js
+++ b/packages/zoe/test/unitTests/bounty.js
@@ -1,5 +1,5 @@
 import { E } from '@agoric/eventual-send';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 
 /**
  * This contract lets a funder endow a bounty that will pay out if an Oracle
@@ -51,7 +51,7 @@ const start = async zcf => {
       const feeAmount = bountySeat.getCurrentAllocation().Fee;
       assert(
         feeMath.isGTE(feeAmount, fee),
-        details`Fee was required to be at least ${fee}`,
+        X`Fee was required to be at least ${fee}`,
       );
 
       // The funder gets the fee regardless of the outcome.

--- a/packages/zoe/test/unitTests/contracts/escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/escrowToVote.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { assert, details, q } from '@agoric/assert';
+import { assert, details as X, q } from '@agoric/assert';
 import makeStore from '@agoric/store';
 // Eventually will be importable from '@agoric/zoe-contract-support'
 import {
@@ -40,7 +40,7 @@ const start = zcf => {
   const assertResponse = response => {
     assert(
       response === 'NO' || response === 'YES',
-      details`the answer ${q(response)} was not 'YES' or 'NO'`,
+      X`the answer ${q(response)} was not 'YES' or 'NO'`,
     );
     // Throw an error if the response is not valid, but do not
     // exit the seat. We should allow the voter to recast their vote.
@@ -59,7 +59,7 @@ const start = zcf => {
       vote: response => {
         // Throw if the offer is no longer active, i.e. the user has
         // completed their offer and the assets are no longer escrowed.
-        assert(!voterSeat.hasExited(), details`the voter seat has exited`);
+        assert(!voterSeat.hasExited(), X`the voter seat has exited`);
 
         assertResponse(response);
 

--- a/packages/zoe/test/unitTests/contracts/test-oracle.js
+++ b/packages/zoe/test/unitTests/contracts/test-oracle.js
@@ -6,7 +6,7 @@ import test from 'ava';
 import bundleSource from '@agoric/bundle-source';
 
 import { makeIssuerKit, MathKind } from '@agoric/ertp';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
 
 import { makeFakeVatAdmin } from '../../../src/contractFacet/fakeVatAdmin';
@@ -60,7 +60,7 @@ test.before(
             requiredFee = feeAmount;
             assert(
               link.amountMath.isGTE(fee, requiredFee),
-              details`Minimum fee of ${feeAmount} not met; have ${fee}`,
+              X`Minimum fee of ${feeAmount} not met; have ${fee}`,
             );
           }
           const reply = { pong: query };

--- a/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
+++ b/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
@@ -6,7 +6,7 @@ import test from 'ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { E } from '@agoric/eventual-send';
 
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 // noinspection ES6PreferShortImport
 import { setup } from '../setupBasicMints';
 import { setupNonFungible } from '../setupNonFungibleMints';
@@ -121,11 +121,11 @@ test('simpleExchange with valid offers', async t => {
 
   assert(
     bobIssuers.Asset === moolaIssuer,
-    details`The Asset issuer should be the moola issuer`,
+    X`The Asset issuer should be the moola issuer`,
   );
   assert(
     bobIssuers.Price === simoleanIssuer,
-    details`The Price issuer should be the simolean issuer`,
+    X`The Price issuer should be the simolean issuer`,
   );
 
   // Bob creates a buy order, saying that he wants exactly 3 moola,
@@ -350,11 +350,11 @@ test('simpleExchange with non-fungible assets', async t => {
   const bobIssuers = zoe.getIssuers(bobInstance);
   assert(
     bobIssuers.Asset === rpgIssuer,
-    details`The Asset issuer should be the RPG issuer`,
+    X`The Asset issuer should be the RPG issuer`,
   );
   assert(
     bobIssuers.Price === ccIssuer,
-    details`The Price issuer should be the CryptoCat issuer`,
+    X`The Price issuer should be the CryptoCat issuer`,
   );
 
   // Bob creates a buy order, saying that he wants the Spell of Binding,

--- a/packages/zoe/test/unitTests/contracts/useObjExample.js
+++ b/packages/zoe/test/unitTests/contracts/useObjExample.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 // Eventually will be importable from '@agoric/zoe-contract-support'
 import {
   assertIssuerKeywords,
@@ -33,7 +33,7 @@ const start = zcf => {
       colorPixels: (color, amountToColor = undefined) => {
         // Throw if the offer is no longer active, i.e. the user has
         // completed their offer and the assets are no longer escrowed.
-        assert(!seat.hasExited(), `the escrowing offer is no longer active`);
+        assert(!seat.hasExited(), X`the escrowing offer is no longer active`);
         const escrowedAmount = seat.getAmountAllocated('Pixels', pixelBrand);
         // If no amountToColor is provided, color all the pixels
         // escrowed for this offer.
@@ -44,7 +44,7 @@ const start = zcf => {
         // covered by what is actually escrowed.
         assert(
           amountMath.isGTE(escrowedAmount, amountToColor),
-          details`The pixels to color were not all escrowed. Currently escrowed: ${escrowedAmount}, amount to color: ${amountToColor}`,
+          X`The pixels to color were not all escrowed. Currently escrowed: ${escrowedAmount}, amount to color: ${amountToColor}`,
         );
 
         // Pretend to color

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -214,7 +214,7 @@ test(`zcf.saveIssuer - bad issuer`, async t => {
     // TODO: improve error message
     // https://github.com/Agoric/agoric-sdk/issues/1701
     message:
-      'target has no method "getBrand", has [getAllegedName,getDisplayInfo,isMyIssuer]',
+      'target has no method "getBrand", has ["getAllegedName","getDisplayInfo","isMyIssuer"]',
   });
 });
 

--- a/packages/zoe/tools/fakePriceAuthority.js
+++ b/packages/zoe/tools/fakePriceAuthority.js
@@ -6,7 +6,7 @@ import {
   makeNotifierFromAsyncIterable,
 } from '@agoric/notifier';
 import { E } from '@agoric/eventual-send';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 
 import { natSafeMath } from '../src/contractSupport';
 
@@ -46,7 +46,7 @@ export async function makeFakePriceAuthority(options) {
 
   assert(
     tradeList || priceList,
-    details`One of priceList or tradeList must be specified`,
+    X`One of priceList or tradeList must be specified`,
   );
 
   const unitValueIn = mathIn.getValue(unitAmountIn);
@@ -71,12 +71,12 @@ export async function makeFakePriceAuthority(options) {
     assert.equal(
       brandIn,
       mathIn.getBrand(),
-      details`${brandIn} is not an expected input brand`,
+      X`${brandIn} is not an expected input brand`,
     );
     assert.equal(
       brandOut,
       mathOut.getBrand(),
-      details`${brandOut} is not an expected output brand`,
+      X`${brandOut} is not an expected output brand`,
     );
   };
 

--- a/packages/zoe/tools/manualTimer.js
+++ b/packages/zoe/tools/manualTimer.js
@@ -2,6 +2,7 @@
 
 import { E } from '@agoric/eventual-send';
 import { makeStore } from '@agoric/store';
+import { assert, details as X } from '@agoric/assert';
 
 import './types';
 import './internal-types';
@@ -40,9 +41,7 @@ export default function buildManualTimer(log, startValue = 0) {
     /** @type {TimerRepeater} */
     const repeater = {
       schedule(waker) {
-        if (!wakers) {
-          throw Error(`Cannot schedule on a disabled repeater`);
-        }
+        assert(wakers, X`Cannot schedule on a disabled repeater`);
         wakers.push(waker);
         return nextWakeup;
       },

--- a/packages/zoe/tools/priceAuthorityRegistry.js
+++ b/packages/zoe/tools/priceAuthorityRegistry.js
@@ -2,7 +2,7 @@
 
 import { E } from '@agoric/eventual-send';
 import { makeStore } from '@agoric/store';
-import { assert, details } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 
 /**
  * @typedef {Object} Deleter
@@ -139,7 +139,7 @@ export const makePriceAuthorityRegistry = () => {
           assert.equal(
             priceStore.has(brandOut) && priceStore.get(brandOut),
             record,
-            details`Price authority already dropped`,
+            X`Price authority already dropped`,
           );
           priceStore.delete(brandOut);
         },


### PR DESCRIPTION
Packages needing review. Please check off what you've reviewed. Thanks.

- [x] ERTP
- [x] SwingSet
- [x] agoric-cli
- [x] assert
- [x] cosmic-swingset
- [x] dapp-svelte-wallet
- [x] deployment
- [x] eventual-send
- [x] import-bundle
- [x] marshal
- [x] notifier
- [x] same-structure
- [x] sharing-service
- [x] spawner
- [x] stat-logger
- [x] swing-store-lmdb
- [x] swingset-runner
- [x] zoe




Addresses #2390 
Addresses #2389 


Hello my reviewers,

I've made you all reviewers because I want all of you to take a look at least at some of the files in here that you're most familiar with, and skim some of the rest. After that, I think it makes sense to divide these files up among us to review. It is all very mechanical-ish. But it was not done in an automated enough manner that we can assume that all lines were transformed reliably according to the same rules.

Besides reviewing for correctness and approval, I'd also like to get your reactions. Is your code more readable? Speaking for myself, rewriting conditions from negative `if` conditions to positive `assert` conditions made things more understandable. Especially for complex compound conditions.

We get lots of benefits beyond readability of course. An example of a non-obvious benefit, on `chain-main.js` we see on the left the original

```js
      } catch (e) {
        throw Error(`cannot JSON.parse(${JSON.stringify(retStr)}): ${e}`);
      }
```

and on the right new

```js
      } catch (e) {
        throw assert.fail(
          d`cannot JSON.parse(${JSON.stringify(retStr)}): ${e}`,
        );
      }
```

The original code is throwing a new error, dropping the old error on the floor, potentially obscuring the source of the root problem. In the new code, the thrown error is linked to the old error. If the thrown error is logged, the caught error would appear on the log along with it, nested. When looking at the log output of the new error, you should see in the stack trace of the nested error the location from which that original error was thrown.

I suspect the `JSON.stringify` within the `assert` is no longer needed either. But when touching this much code I was very conservative about making semantic changes to code I am not familiar with. As you review things, where you spot further simplifications that are naturally made as part of this PR, please add a review comment.

Thanks!