### PR TITLE
feat: prepare for widespread use of assert

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "useWorkspaces": true,
   "workspaces": [
     "golang/cosmos",
+    "packages/eslint-plugin",
     "packages/eslint-config",
     "packages/assert",
     "packages/base64",

--- a/packages/assert/src/types.js
+++ b/packages/assert/src/types.js
@@ -191,6 +191,28 @@
  */
 
 /**
+ * @typedef {(template: TemplateStringsArray | string[], ...args: any) => DetailsToken} DetailsTag
+ *
+ * Use the `details` function as a template literal tag to create
+ * informative error messages. The assertion functions take such messages
+ * as optional arguments:
+ * ```js
+ * assert(sky.isBlue(), details`${sky.color} should be "blue"`);
+ * ```
+ * The details template tag returns a `DetailsToken` object that can print
+ * itself with the formatted message in two ways.
+ * It will report the real details to
+ * the console but include only the typeof information in the thrown error
+ * to prevent revealing secrets up the exceptional path. In the example
+ * above, the thrown error may reveal only that `sky.color` is a string,
+ * whereas the same diagnostic printed to the console reveals that the
+ * sky was green.
+ *
+ * The `raw` member of a `template` is ignored, so a simple
+ * `string[]` can also be used as a template.
+ */
+
+/**
  * assert that expr is truthy, with an optional details to describe
  * the assertion. It is a tagged template literal like
  * ```js

--- a/packages/deployment/ag-setup-cosmos
+++ b/packages/deployment/ag-setup-cosmos
@@ -1,11 +1,16 @@
 #! /usr/bin/env node
 
-require = require('esm')(module);
-const deploy = require(`${__dirname}/main.js`).default;
+const esmRequire = require('esm')(module);
+
+esmRequire('@agoric/install-ses');
+
+const deploy = esmRequire(`${__dirname}/main.js`).default;
+
 process.on('SIGINT', () => process.exit(-1));
-deploy(process.argv[1], process.argv.splice(2))
-  .then(res => process.exit(res || 0),
-    rej => {
-      console.error(`error running ag-setup-cosmos:`, rej);
-      process.exit(1);
-    });
+deploy(process.argv[1], process.argv.splice(2)).then(
+  res => process.exit(res || 0),
+  rej => {
+    console.error(`error running ag-setup-cosmos:`, rej);
+    process.exit(1);
+  },
+);

--- a/packages/deployment/package.json
+++ b/packages/deployment/package.json
@@ -17,8 +17,10 @@
   "author": "Agoric",
   "license": "Apache-2.0",
   "dependencies": {
+    "@agoric/install-ses": "^0.5.0",
     "chalk": "^2.4.2",
     "deterministic-json": "^1.0.5",
+    "esm": "^3.2.25",
     "inquirer": "^6.3.1",
     "minimist": "^1.2.0",
     "node-fetch": "^2.6.0",

--- a/packages/eslint-config/eslint-config.json
+++ b/packages/eslint-config/eslint-config.json
@@ -2,7 +2,8 @@
   "extends": [
     "airbnb-base",
     "plugin:prettier/recommended",
-    "plugin:jsdoc/recommended"
+    "plugin:jsdoc/recommended",
+    "plugin:@agoric/recommended"
   ],
   "parser": "@typescript-eslint/parser",
   "env": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -28,6 +28,7 @@
     "singleQuote": true
   },
   "devDependencies": {
+    "@agoric/eslint-plugin": "^0.0.0",
     "@typescript-eslint/parser": "^4.1.0",
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.0.0",

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -1,0 +1,51 @@
+# eslint-plugin-agoric
+
+Agoric-specific plugin
+
+## Installation
+
+You'll first need to install [ESLint](http://eslint.org):
+
+```
+$ npm i eslint --save-dev
+```
+
+Next, install `eslint-plugin-agoric`:
+
+```
+$ npm install eslint-plugin-agoric --save-dev
+```
+
+**Note:** If you installed ESLint globally (using the `-g` flag) then you must also install `eslint-plugin-agoric` globally.
+
+## Usage
+
+Add `agoric` to the plugins section of your `.eslintrc` configuration file. You can omit the `eslint-plugin-` prefix:
+
+```json
+{
+    "plugins": [
+        "agoric"
+    ]
+}
+```
+
+
+Then configure the rules you want to use under the rules section.
+
+```json
+{
+    "rules": {
+        "agoric/rule-name": 2
+    }
+}
+```
+
+## Supported Rules
+
+* Fill in provided rules here
+
+
+
+
+

--- a/packages/eslint-plugin/lib/configs/recommended.js
+++ b/packages/eslint-plugin/lib/configs/recommended.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: ["@agoric"],
+  rules: {
+    "@agoric/assert-fail-as-throw": 2
+  },
+};

--- a/packages/eslint-plugin/lib/index.js
+++ b/packages/eslint-plugin/lib/index.js
@@ -1,0 +1,20 @@
+/**
+ * @fileoverview Agoric-specific plugin
+ * @author Agoric
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var requireIndex = require("requireindex");
+
+//------------------------------------------------------------------------------
+// Plugin Definition
+//------------------------------------------------------------------------------
+
+
+// import all rules in lib/rules
+module.exports.rules = requireIndex(__dirname + "/rules");
+module.exports.configs = requireIndex(__dirname + "/configs");

--- a/packages/eslint-plugin/lib/rules/assert-fail-as-throw.js
+++ b/packages/eslint-plugin/lib/rules/assert-fail-as-throw.js
@@ -1,0 +1,167 @@
+/**
+ * @author Toru Nagashima
+ * See LICENSE file in root directory for full license.
+ * 
+ * Modified by Michael FIG <mfig@agoric.com> for Agoric's assert.fail.
+ * (This file used to be github.com/mysticatea/eslint-plugin-node/.../process-exit-as-throw.js.)
+ */
+"use strict"
+
+const CodePathAnalyzer = safeRequire(
+    "eslint/lib/linter/code-path-analysis/code-path-analyzer",
+    "eslint/lib/code-path-analysis/code-path-analyzer"
+)
+const CodePathSegment = safeRequire(
+    "eslint/lib/linter/code-path-analysis/code-path-segment",
+    "eslint/lib/code-path-analysis/code-path-segment"
+)
+const CodePath = safeRequire(
+    "eslint/lib/linter/code-path-analysis/code-path",
+    "eslint/lib/code-path-analysis/code-path"
+)
+
+const originalLeaveNode =
+    CodePathAnalyzer && CodePathAnalyzer.prototype.leaveNode
+
+/**
+ * Imports a specific module.
+ * @param {...string} moduleNames - module names to import.
+ * @returns {object|null} The imported object, or null.
+ */
+function safeRequire(...moduleNames) {
+    for (const moduleName of moduleNames) {
+        try {
+            return require(moduleName)
+        } catch (_err) {
+            // Ignore.
+        }
+    }
+    return null
+}
+
+/* istanbul ignore next */
+/**
+ * Copied from https://github.com/eslint/eslint/blob/16fad5880bb70e9dddbeab8ed0f425ae51f5841f/lib/code-path-analysis/code-path-analyzer.js#L137
+ *
+ * @param {CodePathAnalyzer} analyzer - The instance.
+ * @param {ASTNode} node - The current AST node.
+ * @returns {void}
+ */
+function forwardCurrentToHead(analyzer, node) {
+    const codePath = analyzer.codePath
+    const state = CodePath.getState(codePath)
+    const currentSegments = state.currentSegments
+    const headSegments = state.headSegments
+    const end = Math.max(currentSegments.length, headSegments.length)
+    let i = 0
+    let currentSegment = null
+    let headSegment = null
+
+    // Fires leaving events.
+    for (i = 0; i < end; ++i) {
+        currentSegment = currentSegments[i]
+        headSegment = headSegments[i]
+
+        if (currentSegment !== headSegment && currentSegment) {
+            if (currentSegment.reachable) {
+                analyzer.emitter.emit(
+                    "onCodePathSegmentEnd",
+                    currentSegment,
+                    node
+                )
+            }
+        }
+    }
+
+    // Update state.
+    state.currentSegments = headSegments
+
+    // Fires entering events.
+    for (i = 0; i < end; ++i) {
+        currentSegment = currentSegments[i]
+        headSegment = headSegments[i]
+
+        if (currentSegment !== headSegment && headSegment) {
+            CodePathSegment.markUsed(headSegment)
+            if (headSegment.reachable) {
+                analyzer.emitter.emit(
+                    "onCodePathSegmentStart",
+                    headSegment,
+                    node
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Checks whether a given node is `assert.fail()` or not.
+ *
+ * @param {ASTNode} node - A node to check.
+ * @returns {boolean} `true` if the node is `assert.fail()`.
+ */
+function isAssertFail(node) {
+    return (
+        node.type === "CallExpression" &&
+        node.callee.type === "MemberExpression" &&
+        node.callee.computed === false &&
+        node.callee.object.type === "Identifier" &&
+        node.callee.object.name === "assert" &&
+        node.callee.property.type === "Identifier" &&
+        node.callee.property.name === "fail"
+    )
+}
+
+/**
+ * The function to override `CodePathAnalyzer.prototype.leaveNode` in order to
+ * address `assert.fail()` as throw.
+ *
+ * @this CodePathAnalyzer
+ * @param {ASTNode} node - A node to be left.
+ * @returns {void}
+ */
+function overrideLeaveNode(node) {
+    if (isAssertFail(node)) {
+        this.currentNode = node
+
+        forwardCurrentToHead(this, node)
+        CodePath.getState(this.codePath).makeThrow()
+
+        this.original.leaveNode(node)
+        this.currentNode = null
+    } else {
+        originalLeaveNode.call(this, node)
+    }
+}
+
+const visitor =
+    CodePathAnalyzer == null
+        ? {}
+        : {
+              Program: function installAssertFailAsThrow() {
+                  CodePathAnalyzer.prototype.leaveNode = overrideLeaveNode
+              },
+              "Program:exit": function restoreAssertFailAsThrow() {
+                  CodePathAnalyzer.prototype.leaveNode = originalLeaveNode
+              },
+          }
+
+module.exports = {
+    meta: {
+        docs: {
+            description:
+                "make `assert.fail()` expressions the same code path as `throw`",
+            category: "Possible Errors",
+            recommended: true,
+            url:
+                "https://github.com/Agoric/agoric-sdk/blob/master/packages/eslint-plugin/lib/rules/assert-fail-as-throw.js",
+        },
+        type: "problem",
+        fixable: null,
+        schema: [],
+        supported: true || CodePathAnalyzer != null,
+    },
+    create() {
+        return visitor
+    },
+}

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@agoric/eslint-plugin",
+  "version": "0.0.0",
+  "description": "Agoric-specific ESLint plugin",
+  "keywords": [
+    "eslint",
+    "eslintplugin",
+    "eslint-plugin"
+  ],
+  "author": "Agoric",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "exit 0",
+    "build": "exit 0",
+    "lint-fix": "exit 0",
+    "lint-check": "exit 0"
+  },
+  "dependencies": {
+    "requireindex": "~1.1.0"
+  },
+  "devDependencies": {
+    "eslint": "^6.8.0",
+    "mocha": "^3.1.2"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "prettier": {
+    "trailingComma": "all",
+    "singleQuote": true
+  },
+  "license": "Apache-2.0"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2274,6 +2274,11 @@ braces@^3.0.1, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
+browser-stdout@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
+  integrity sha1-81HTKWnTL6XXpVZxVCY9korjvR8=
+
 browserslist@^4.0.0:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.12.0.tgz#06c6d5715a1ede6c51fc39ff67fd647f740b656d"
@@ -2796,6 +2801,13 @@ commander@2, commander@^2.11.0, commander@^2.20.0, commander@~2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
+commander@2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
+  integrity sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=
+  dependencies:
+    graceful-readlink ">= 1.0.0"
 
 commander@^5.0.0:
   version "5.0.0"
@@ -3413,6 +3425,13 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
+debug@2.6.8:
+  version "2.6.8"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
+  integrity sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=
+  dependencies:
+    ms "2.0.0"
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -3638,6 +3657,11 @@ dezalgo@^1.0.0:
   dependencies:
     asap "^2.0.0"
     wrappy "1"
+
+diff@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
+  integrity sha1-yc45Okt8vQsFinJck98pkCeGj/k=
 
 dir-glob@^2.2.2:
   version "2.2.2"
@@ -3950,7 +3974,7 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
@@ -4895,6 +4919,18 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
+glob@7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
+  integrity sha1-gFIR3wT6rxxjo2ADBs31reULLsg=
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.2"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
@@ -4987,6 +5023,16 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
+
+"graceful-readlink@>= 1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
+  integrity sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=
+
+growl@1.9.2:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
+  integrity sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=
 
 handlebars@^4.4.0:
   version "4.7.3"
@@ -5094,6 +5140,11 @@ hasha@^5.0.0:
   dependencies:
     is-stream "^2.0.0"
     type-fest "^0.8.0"
+
+he@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
+  integrity sha1-k0EP0hsAlzUVH4howvJx80J+I/0=
 
 hex-color-regex@^1.1.0:
   version "1.1.0"
@@ -6004,6 +6055,11 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
+json3@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
+  integrity sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=
+
 json5@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
@@ -6265,6 +6321,34 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash._baseassign@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"
+  integrity sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=
+  dependencies:
+    lodash._basecopy "^3.0.0"
+    lodash.keys "^3.0.0"
+
+lodash._basecopy@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
+  integrity sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=
+
+lodash._basecreate@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
+  integrity sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=
+
+lodash._getnative@^3.0.0:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
+  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
+
+lodash._isiterateecall@^3.0.0:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
+  integrity sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=
+
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -6280,6 +6364,15 @@ lodash.clonedeep@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
+lodash.create@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.create/-/lodash.create-3.1.1.tgz#d7f2849f0dbda7e04682bb8cd72ab022461debe7"
+  integrity sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=
+  dependencies:
+    lodash._baseassign "^3.0.0"
+    lodash._basecreate "^3.0.0"
+    lodash._isiterateecall "^3.0.0"
+
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
@@ -6290,10 +6383,29 @@ lodash.get@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
+lodash.isarguments@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
+  integrity sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=
+
+lodash.isarray@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
+  integrity sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=
+
 lodash.ismatch@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"
   integrity sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=
+
+lodash.keys@^3.0.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
+  integrity sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=
+  dependencies:
+    lodash._getnative "^3.0.0"
+    lodash.isarguments "^3.0.0"
+    lodash.isarray "^3.0.0"
 
 lodash.memoize@^4.1.2:
   version "4.1.2"
@@ -6691,7 +6803,7 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
-minimatch@^3.0.4:
+minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -6785,7 +6897,7 @@ mkdirp@*:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.3.tgz#4cf2e30ad45959dddea53ad97d518b6c8205e1ea"
   integrity sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g==
 
-mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
@@ -6798,6 +6910,24 @@ mkdirp@~0.5.1:
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
+
+mocha@^3.1.2:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.5.3.tgz#1e0480fe36d2da5858d1eb6acc38418b26eaa20d"
+  integrity sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==
+  dependencies:
+    browser-stdout "1.3.0"
+    commander "2.9.0"
+    debug "2.6.8"
+    diff "3.2.0"
+    escape-string-regexp "1.0.5"
+    glob "7.1.1"
+    growl "1.9.2"
+    he "1.1.1"
+    json3 "3.3.2"
+    lodash.create "3.1.1"
+    mkdirp "0.5.1"
+    supports-color "3.1.2"
 
 modify-values@^1.0.0:
   version "1.0.1"
@@ -8819,6 +8949,11 @@ require-relative@^0.8.7:
   resolved "https://registry.yarnpkg.com/require-relative/-/require-relative-0.8.7.tgz#7999539fc9e047a37928fa196f8e1563dabd36de"
   integrity sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=
 
+requireindex@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
+  integrity sha1-5UBLgVV+91225JxacgBIk/4D4WI=
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
@@ -9888,6 +10023,13 @@ supertap@^1.0.0:
     js-yaml "^3.10.0"
     serialize-error "^2.1.0"
     strip-ansi "^4.0.0"
+
+supports-color@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
+  integrity sha1-cqJiiU2dQIuVbKBf83su2KbiotU=
+  dependencies:
+    has-flag "^1.0.0"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- This creates an eslint plugin that handles treating `assert.fail()` as `throw`.
- Also, update the `@agoric/assert` type declarations.
- And run the deployment system under SES.

Suggested for merging before #2406.
