### PR TITLE
Remove Pointless Excessive Abstraction

### DIFF
--- a/packages/zoe/src/contractSupport/bondingCurves.js
+++ b/packages/zoe/src/contractSupport/bondingCurves.js
@@ -4,8 +4,7 @@ import { natSafeMath } from './safeMath';
 
 const { multiply, floorDivide } = natSafeMath;
 
-const BIG_10000 = 10000n;
-const BIG_ONE = 1n;
+const BASIS_POINTS = 10000n; // TODO change to 10_000n once tooling copes.
 
 /**
  * Calculations for constant product markets like Uniswap.
@@ -41,10 +40,10 @@ export const getInputPrice = (
   assert(inputReserve > 0, X`inputReserve ${inputReserve} must be positive`);
   assert(outputReserve > 0, X`outputReserve ${outputReserve} must be positive`);
 
-  const oneMinusFeeScaled = BIG_10000 - BigInt(feeBasisPoints);
+  const oneMinusFeeScaled = BASIS_POINTS - BigInt(feeBasisPoints);
   const inputWithFee = BigInt(inputValue) * oneMinusFeeScaled;
   const numerator = inputWithFee * BigInt(outputReserve);
-  const denominator = BigInt(inputReserve) * BIG_10000 + inputWithFee;
+  const denominator = BigInt(inputReserve) * BASIS_POINTS + inputWithFee;
   return Nat(Number(numerator / denominator));
 };
 
@@ -80,11 +79,11 @@ export const getOutputPrice = (
     X`outputReserve ${outputReserve} must be greater than outputValue ${outputValue}`,
   );
 
-  const oneMinusFeeScaled = BIG_10000 - BigInt(feeBasisPoints);
-  const numerator = BigInt(outputValue) * BigInt(inputReserve) * BIG_10000;
+  const oneMinusFeeScaled = BASIS_POINTS - BigInt(feeBasisPoints);
+  const numerator = BigInt(outputValue) * BigInt(inputReserve) * BASIS_POINTS;
   const denominator =
     (BigInt(outputReserve) - BigInt(outputValue)) * oneMinusFeeScaled;
-  return Nat(Number(numerator / denominator + BIG_ONE));
+  return Nat(Number(numerator / denominator + 1n));
 };
 
 function assertDefined(label, value) {


### PR DESCRIPTION
I see no way in which `BIG_ONE` is clearer than `1n`. There is one way in which the constant `10000n` is unclear. You might, at a glance, mistake the number of zeros you're looking at. However, `BIG_10000n` is no clearer. TC39 already addressed the readability issue of big numerical literals like that by letting us use underbars where on paper we'd use commas. `10_000n` is clearer than both. It is actually clear.

The issue in this PR is really a microcosm of issues raised by #2420 . For all the wonder of abstraction it can be used excessively, at a cost to readability. We need to be sensitive to both sides of that tradeoff.

Historically, the origin of some of this stuff was when we did not yet have good enough toolchain support for BigInts. Today, some of it may come from worry about the efficiency of small BigInts compared to floats (aka `numbers`). However, we know that small BigInts are as efficient as floats on all JS engines other than XS. We do not yet know whether the extra cost on XS is significant for us. But we do know that, if it is, we can fix XS rather than make our code less readable.

I expect these points to be controversial. Let's have that discussion first on this PR where the issue is narrow and focused.