### PR TITLE
fix: remove crankNumber from transcript entries

### DIFF
--- a/packages/SwingSet/src/kernel/vatManager/manager-local.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-local.js
@@ -32,11 +32,7 @@ export function makeLocalVatManagerFactory(tools) {
 
   function prepare(vatID) {
     const vatKeeper = kernelKeeper.getVatKeeper(vatID);
-    const transcriptManager = makeTranscriptManager(
-      kernelKeeper,
-      vatKeeper,
-      vatID,
-    );
+    const transcriptManager = makeTranscriptManager(vatKeeper, vatID);
     const { syscall, setVatSyscallHandler } = createSyscall(transcriptManager);
     function finish(dispatch, meterRecord) {
       assert(

--- a/packages/SwingSet/src/kernel/vatManager/manager-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-nodeworker.js
@@ -38,11 +38,7 @@ export function makeNodeWorkerVatManagerFactory(tools) {
       );
     }
     const vatKeeper = kernelKeeper.getVatKeeper(vatID);
-    const transcriptManager = makeTranscriptManager(
-      kernelKeeper,
-      vatKeeper,
-      vatID,
-    );
+    const transcriptManager = makeTranscriptManager(vatKeeper, vatID);
 
     // prepare to accept syscalls from the worker
 

--- a/packages/SwingSet/src/kernel/vatManager/manager-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-subprocess-node.js
@@ -39,11 +39,7 @@ export function makeNodeSubprocessFactory(tools) {
       );
     }
     const vatKeeper = kernelKeeper.getVatKeeper(vatID);
-    const transcriptManager = makeTranscriptManager(
-      kernelKeeper,
-      vatKeeper,
-      vatID,
-    );
+    const transcriptManager = makeTranscriptManager(vatKeeper, vatID);
 
     // prepare to accept syscalls from the worker
 

--- a/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
@@ -57,11 +57,7 @@ export function makeXsSubprocessFactory({
       console.log(`xsnap worker does not support enableInternalMetering`);
     }
     const vatKeeper = kernelKeeper.getVatKeeper(vatID);
-    const transcriptManager = makeTranscriptManager(
-      kernelKeeper,
-      vatKeeper,
-      vatID,
-    );
+    const transcriptManager = makeTranscriptManager(vatKeeper, vatID);
 
     const { doSyscall, setVatSyscallHandler } = createSyscall(
       transcriptManager,

--- a/packages/SwingSet/src/kernel/vatManager/transcript.js
+++ b/packages/SwingSet/src/kernel/vatManager/transcript.js
@@ -1,6 +1,6 @@
 import djson from '../djson';
 
-export function makeTranscriptManager(kernelKeeper, vatKeeper, vatID) {
+export function makeTranscriptManager(vatKeeper, vatID) {
   let weAreInReplay = false;
   let playbackSyscalls;
   let currentEntry;
@@ -9,7 +9,6 @@ export function makeTranscriptManager(kernelKeeper, vatKeeper, vatID) {
     currentEntry = {
       d,
       syscalls: [],
-      crankNumber: kernelKeeper.getCrankNumber(),
     };
   }
 

--- a/packages/SwingSet/test/test-kernel.js
+++ b/packages/SwingSet/test/test-kernel.js
@@ -989,7 +989,6 @@ test('transcript', async t => {
         response: null,
       },
     ],
-    crankNumber: 1,
   });
 });
 


### PR DESCRIPTION
The VatManager is responsible for maintaining a transcript of all deliveries
to their vat worker, so the vat can be reloaded later. These transcript
entries have been including the `crankNumber`: a global counter indicating
how many cranks have been delivered (to all vats, not just the one for which
the transcript entry is being created).

This removes that crankNumber from the transcript:

* each vat should be independent, this global crankNumber is revealing
information about what happens in other vats
* #2400 is changing the type of `crankNumber` to a BigInt, which cannot be
serialized by the simple `JSON.stringify` used in vatKeeper.js

It also removes the now-unnecessary `kernelKeeper` argument from
`makeTranscriptManager`, and changes one test that happened to depend upon
the presence of the crankNumber field.

closes #2428

cc @katelynsills 
