### PR TITLE
Enable Agoric-specific metrics for telemetry

### DIFF
--- a/golang/cosmos/x/swingset/abci.go
+++ b/golang/cosmos/x/swingset/abci.go
@@ -2,10 +2,14 @@ package swingset
 
 import (
 	"encoding/json"
+	"time"
 
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	abci "github.com/tendermint/tendermint/abci/types"
+
+	"github.com/Agoric/agoric-sdk/golang/cosmos/x/swingset/types"
 )
 
 type beginBlockAction struct {
@@ -30,6 +34,8 @@ type commitBlockAction struct {
 }
 
 func BeginBlock(ctx sdk.Context, req abci.RequestBeginBlock, keeper Keeper) error {
+	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), telemetry.MetricKeyBeginBlocker)
+
 	action := &beginBlockAction{
 		Type:        "BEGIN_BLOCK",
 		StoragePort: GetPort("storage"),
@@ -52,6 +58,7 @@ var endBlockHeight int64
 var endBlockTime int64
 
 func EndBlock(ctx sdk.Context, req abci.RequestEndBlock, keeper Keeper) ([]abci.ValidatorUpdate, error) {
+	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), telemetry.MetricKeyEndBlocker)
 	action := &endBlockAction{
 		Type:        "END_BLOCK",
 		BlockHeight: ctx.BlockHeight(),
@@ -80,6 +87,8 @@ func EndBlock(ctx sdk.Context, req abci.RequestEndBlock, keeper Keeper) ([]abci.
 }
 
 func CommitBlock(keeper Keeper) error {
+	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), "commit_blocker")
+
 	action := &commitBlockAction{
 		Type:        "COMMIT_BLOCK",
 		BlockHeight: endBlockHeight,

--- a/packages/agoric-cli/lib/main.js
+++ b/packages/agoric-cli/lib/main.js
@@ -119,6 +119,11 @@ const main = async (progname, rawArgs, powers) => {
       'set the config.toml p2p.persistent_peers value',
       '',
     )
+    .option(
+      '--export-metrics',
+      'open ports to export Prometheus metrics',
+      false,
+    )
     .action(async (prog, configDir, cmd) => {
       const opts = { ...program.opts(), ...cmd.opts() };
       return subMain(setDefaultsMain, ['set-defaults', prog, configDir], opts);

--- a/packages/agoric-cli/lib/set-defaults.js
+++ b/packages/agoric-cli/lib/set-defaults.js
@@ -2,7 +2,7 @@ import { basename } from 'path';
 import { assert, details as X } from '@agoric/assert';
 import {
   finishCosmosApp,
-  finishCosmosConfig,
+  finishTendermintConfig,
   finishCosmosGenesis,
 } from './chain-config';
 
@@ -16,6 +16,8 @@ export default async function setDefaultsMain(progname, rawArgs, powers, opts) {
     prog === 'ag-chain-cosmos',
     X`<prog> must currently be 'ag-chain-cosmos'`,
   );
+
+  const { exportMetrics } = opts;
 
   let appFile;
   let configFile;
@@ -49,6 +51,7 @@ export default async function setDefaultsMain(progname, rawArgs, powers, opts) {
 
     const newAppToml = finishCosmosApp({
       appToml,
+      exportMetrics,
     });
     await create(appFile, newAppToml);
   }
@@ -58,9 +61,10 @@ export default async function setDefaultsMain(progname, rawArgs, powers, opts) {
     const { persistentPeers } = opts;
     const configToml = await fs.readFile(configFile, 'utf-8');
 
-    const newConfigToml = finishCosmosConfig({
+    const newConfigToml = finishTendermintConfig({
       configToml,
       persistentPeers,
+      exportMetrics,
     });
     await create(configFile, newConfigToml);
   }

--- a/packages/agoric-cli/lib/start.js
+++ b/packages/agoric-cli/lib/start.js
@@ -5,7 +5,7 @@ import { createHash } from 'crypto';
 import {
   STAKING_DENOM,
   MINT_DENOM,
-  finishCosmosConfig,
+  finishTendermintConfig,
   finishCosmosGenesis,
   finishCosmosApp,
 } from './chain-config';
@@ -314,7 +314,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
     const newGenesisJson = finishCosmosGenesis({
       genesisJson,
     });
-    const newConfigToml = finishCosmosConfig({
+    const newConfigToml = finishTendermintConfig({
       configToml,
       portNum,
     });

--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -110,7 +110,7 @@ scenario3-run-client: scenario3-run
 scenario3-run:
 	(cd t3 && \
 			../bin/ag-solo set-fake-chain --delay=$(FAKE_CHAIN_DELAY) mySimGCI)
-	cd t3 && ../bin/ag-solo start
+	cd t3 && OTEL_EXPORTER_PROMETHEUS_PORT=9464 ../bin/ag-solo start
 
 docker-pull:
 	for f in '' -setup -solo; do \

--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -61,12 +61,13 @@ scenario2-setup-nobuild:
 	$(AGC) --home=t1/n0 --keyring-dir=t1/bootstrap gentx --keyring-backend=test bootstrap 1000000uagstake --chain-id=$(CHAIN_ID)
 	$(AGC) --home=t1/n0 collect-gentxs
 	$(AGC) --home=t1/n0 validate-genesis
-	../agoric-cli/bin/agoric set-defaults ag-chain-cosmos t1/n0/config
+	../agoric-cli/bin/agoric set-defaults --export-metrics ag-chain-cosmos t1/n0/config
 	# Set the chain address in all the ag-solos.
 	$(MAKE) set-local-gci-ingress
 
 scenario2-run-chain:
-	$(AGC) `$(BREAK_CHAIN) && echo --inspect-brk` --home=t1/n0 start --log_level=warn
+	OTEL_EXPORTER_PROMETHEUS_PORT=9464 \
+		$(AGC) `$(BREAK_CHAIN) && echo --inspect-brk` --home=t1/n0 start --log_level=warn
 
 # Provision and start a client.
 scenario2-run-client: t1-provision-one-with-powers t1-start-ag-solo

--- a/packages/cosmic-swingset/README-telemetry.md
+++ b/packages/cosmic-swingset/README-telemetry.md
@@ -1,0 +1,82 @@
+# Cosmic SwingSet Telemetry
+
+The Cosmic SwingSet chain node (`ag-chain-cosmos`) is instrumented to export
+useful metrics via [Prometheus](https://prometheus.io/) endpoints on different
+inbound TCP ports.
+
+These metrics apply both to validators and regular full nodes.
+
+The following sections explain how to enable each of these metric exporters.
+You can enable telemetry just be setting the configuration, then by restarting
+your node, which will quickly catch up to where it was.  Enabling or disabling
+telemetry does not affect the correctness of your node.
+
+## Caveats
+
+**NOTE:** the exposed metric ports may need additional firewall rules to accept
+TCP connections from your Prometheus host's IP address.
+
+## Agoric VM (SwingSet) metrics
+
+SwingSet is responsible for the chain's Javascript execution.  It is
+instrumented with the [OpenTelemetry](https://opentelemetry.io/) (*OTEL*)
+system.
+
+To enable the Prometheus exporter, set the desired listening TCP port number in
+the `$OTEL_EXPORTER_PROMETHEUS_PORT` environment variable before running the
+node.  To listen on http://0.0.0.0:9464/metrics use:
+
+```sh
+OTEL_EXPORTER_PROMETHEUS_PORT=9464 ag-chain-cosmos start ...
+```
+
+You can choose a different host than `0.0.0.0` by setting the
+`$OTEL_EXPORTER_PROMETHEUS_HOST` environment variable.
+
+## Cosmos SDK metrics
+
+The [Cosmos SDK](https://docs.cosmos.network/) layer of the system is
+responsible for transaction processing, as well as forwarding to the SwingSet layerdispatching and processing.
+
+To enable the exporting of Cosmos metrics, you need to change the contents of
+your `~/.ag-chain-cosmos/config/app.toml` (**not** `config.toml`) in the
+`[telemetry]` section:
+
+```toml
+[telemetry]
+enabled = true
+prometheus-retention-time = 60
+
+[api]
+# Note: this key is "enable" (without a "d", not "enabled")
+enable = true
+address = "tcp://0.0.0.0:1317"
+```
+
+If the API server is enabled, then this will export metrics at
+http://0.0.0.0:1317/metrics?format=prometheus (at your enabled API server port).
+The metrics will also be exported at the Tendermint Prometheus port if enabled
+in the next section.
+
+The exported metrics are listed at:
+https://docs.cosmos.network/v0.40/core/telemetry.html
+
+## Tendermint metrics
+
+The [Tendermint Core](https://tendermint.com/core/) layer of the system is
+responsible for the basic blockchain functionality (BFT consensus and validator
+sets).  It forwards transactions to the Cosmos SDK.
+
+To enable the exporting of Tendermint metrics, you need to change the contents
+of your `~/.ag-chain-cosmos/config/config.toml` (**not** `app.toml`) in the
+`[instrumentation]` section:
+
+```toml
+[instrumentation]
+prometheus = true
+prometheus_listen_addr = ":26660"
+```
+
+This will export Tendermint metrics at http://0.0.0.0:26660/metrics The metrics
+will also be exported at the Cosmos SDK API server port if enabled in the
+previous section.

--- a/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
+++ b/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
@@ -14,6 +14,7 @@ import { launch } from '../launch-chain';
 import makeBlockManager from '../block-manager';
 import { makeWithQueue } from './vats/queue';
 import { makeBatchedDeliver } from './batched-deliver';
+import { getMeterProvider } from '../kernel-stats';
 
 const log = anylogger('fake-chain');
 
@@ -63,6 +64,8 @@ export async function connectToFakeChain(basedir, GCI, delay, inbound) {
   function flushChainSends(replay) {
     assert(!replay, X`Replay not implemented`);
   }
+
+  const meterProvider = getMeterProvider(log, process.env);
   const s = await launch(
     stateDBdir,
     mailboxStorage,
@@ -70,6 +73,7 @@ export async function connectToFakeChain(basedir, GCI, delay, inbound) {
     vatsdir,
     argv,
     GCI, // debugName
+    meterProvider,
   );
 
   const { savedHeight, savedActions, savedChainSends } = s;

--- a/packages/cosmic-swingset/lib/chain-main.js
+++ b/packages/cosmic-swingset/lib/chain-main.js
@@ -226,18 +226,26 @@ export default async function main(progname, args, { path, env, agcc }) {
       noFakeCurrencies: process.env.NO_FAKE_CURRENCIES,
     };
     let meterProvider;
-    if (process.env.AG_CHAIN_COSMOS_PROMETHEUS) {
+    if (
+      process.env.OTEL_EXPORTER_PROMETHEUS_HOST ||
+      process.env.OTEL_EXPORTER_PROMETHEUS_PORT
+    ) {
+      const host =
+        process.env.OTEL_EXPORTER_PROMETHEUS_HOST ||
+        PrometheusExporter.DEFAULT_OPTIONS.host ||
+        '0.0.0.0';
       const port =
-        Number(process.env.AG_CHAIN_COSMOS_PROMETHEUS) ||
+        Number(process.env.OTEL_EXPORTER_PROMETHEUS_PORT) ||
         PrometheusExporter.DEFAULT_OPTIONS.port;
       const exporter = new PrometheusExporter(
         {
           startServer: true,
+          host,
           port,
         },
         () => {
           console.log(
-            `prometheus scrape endpoint: http://localhost:${port}${PrometheusExporter.DEFAULT_OPTIONS.endpoint}`,
+            `Prometheus scrape endpoint: http://${host}:${port}${PrometheusExporter.DEFAULT_OPTIONS.endpoint}`,
           );
         },
       );

--- a/packages/cosmic-swingset/lib/chain-main.js
+++ b/packages/cosmic-swingset/lib/chain-main.js
@@ -4,12 +4,10 @@ import {
   exportMailbox,
 } from '@agoric/swingset-vat/src/devices/mailbox';
 
-import { MeterProvider } from '@opentelemetry/metrics';
-import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
-
 import { assert, details as X } from '@agoric/assert';
 import { launch } from './launch-chain';
 import makeBlockManager from './block-manager';
+import { getMeterProvider } from './kernel-stats';
 
 const AG_COSMOS_INIT = 'AG_COSMOS_INIT';
 
@@ -225,32 +223,7 @@ export default async function main(progname, args, { path, env, agcc }) {
       ROLE: 'chain',
       noFakeCurrencies: process.env.NO_FAKE_CURRENCIES,
     };
-    let meterProvider;
-    if (
-      process.env.OTEL_EXPORTER_PROMETHEUS_HOST ||
-      process.env.OTEL_EXPORTER_PROMETHEUS_PORT
-    ) {
-      const host =
-        process.env.OTEL_EXPORTER_PROMETHEUS_HOST ||
-        PrometheusExporter.DEFAULT_OPTIONS.host ||
-        '0.0.0.0';
-      const port =
-        Number(process.env.OTEL_EXPORTER_PROMETHEUS_PORT) ||
-        PrometheusExporter.DEFAULT_OPTIONS.port;
-      const exporter = new PrometheusExporter(
-        {
-          startServer: true,
-          host,
-          port,
-        },
-        () => {
-          console.log(
-            `Prometheus scrape endpoint: http://${host}:${port}${PrometheusExporter.DEFAULT_OPTIONS.endpoint}`,
-          );
-        },
-      );
-      meterProvider = new MeterProvider({ exporter, interval: 1000 });
-    }
+    const meterProvider = getMeterProvider(console, process.env);
     const s = await launch(
       stateDBDir,
       mailboxStorage,

--- a/packages/cosmic-swingset/lib/kernel-stats.js
+++ b/packages/cosmic-swingset/lib/kernel-stats.js
@@ -95,8 +95,14 @@ const KERNEL_STATS_UPDOWN_METRICS = [
  * @param {any} param0.controller
  * @param {import('@opentelemetry/metrics').Meter} param0.metricMeter
  * @param {Console} param0.log
+ * @param {Record<string, any>} param0.labels
  */
-export function exportKernelStats({ controller, metricMeter, log = console }) {
+export function exportKernelStats({
+  controller,
+  metricMeter,
+  log = console,
+  labels,
+}) {
   const kernelStatsMetrics = new Map();
   const expectedKernelStats = new Set();
 
@@ -145,6 +151,6 @@ export function exportKernelStats({ controller, metricMeter, log = console }) {
         observations.push(metric.observation(value));
       }
     });
-    batchObserverResult.observe({ app: 'ag-chain-cosmos' }, observations);
+    batchObserverResult.observe(labels, observations);
   });
 }

--- a/packages/dapp-svelte-wallet/ui/src/Import.svelte
+++ b/packages/dapp-svelte-wallet/ui/src/Import.svelte
@@ -1,6 +1,6 @@
 <script>
   import { E } from "@agoric/captp";
-  import { assert, details as d } from '@agoric/assert';
+  import { assert, details as X } from '@agoric/assert';
 
   import Button from 'smelte/src/components/Button';
   import Dialog from 'smelte/src/components/Dialog';
@@ -31,9 +31,9 @@
     <DefaultButton on:click={async () => {
       try {
         petname = petname.trim();
-        assert(petname, d`Need to specify a ${name} petname`, TypeError);
+        assert(petname, X`Need to specify a ${name} petname`, TypeError);
         boardId = boardId.trim();
-        assert(boardId, d`Need to specify a ${name} "board:..."" ID`, TypeError);
+        assert(boardId, X`Need to specify a ${name} "board:..."" ID`, TypeError);
         const trimmed = boardId.startsWith(prefix) ? boardId.slice(prefix.length) : boardId;
         const obj = await E(boardP).getValue(trimmed);
         await adder(petname, obj);

--- a/packages/dapp-svelte-wallet/ui/src/MakePurse.svelte
+++ b/packages/dapp-svelte-wallet/ui/src/MakePurse.svelte
@@ -9,7 +9,7 @@
   import CancelButton from '../lib/CancelButton.svelte';
   import DefaultButton from '../lib/DefaultButton.svelte';
   import { walletP } from './store';
-  import { assert, details as d } from '@agoric/assert';
+  import { assert, details as X } from '@agoric/assert';
 
   import { issuers } from './store';
   const title = "Make Purse";
@@ -34,9 +34,9 @@
   <div slot="actions">
     <DefaultButton on:click={async () => {
       try {
-        assert(issuerPetname, d`Need to specify an Issuer`, TypeError);
+        assert(issuerPetname, X`Need to specify an Issuer`, TypeError);
         petname = petname.trim();
-        assert(petname, d`Need to specify a ${name} petname`, TypeError);
+        assert(petname, X`Need to specify a ${name} petname`, TypeError);
         await E(walletP).makeEmptyPurse(issuerPetname, petname);
         showModal = false;
       } catch (e) {


### PR DESCRIPTION
- Report SwingSet `BeginBlock` and `EndBlock` timings as an old-style Prometheus summary with quantile data.
- Move to standard https://opentelemetry.io environment variables and describe how to enable with `$OTEL_EXPORTER_PROMETHEUS_PORT`.
- **Bonus commit**: rename some more `import { details as d }` to `import { details as X }`.
