### PR TITLE
export callSpread from contracts so Percent is visible

### DIFF
--- a/packages/zoe/src/contracts/exported.js
+++ b/packages/zoe/src/contracts/exported.js
@@ -2,3 +2,4 @@ import './types';
 import './loan/types';
 import './multipoolAutoswap/types';
 import './priceAggregatorTypes';
+import './callSpread/types';


### PR DESCRIPTION
export callSpread  from contracts so Percent type is visible using

import '@agoric/zoe/exported';