### PR TITLE
refactor: remove all unnecessary @ts-ignore annotations

### DIFF
--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -1,3 +1,4 @@
+// @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { E } from '@agoric/eventual-send';
@@ -37,7 +38,7 @@ test('brand.getDisplayInfo()', t => {
 
 test('bad display info', t => {
   const displayInfo = harden({ somethingUnexpected: 3 });
-  // @ts-ignore
+  // @ts-ignore deliberate invalid arguments for testing
   t.throws(() => makeIssuerKit('fungible', MathKind.NAT, displayInfo), {
     message:
       'key "somethingUnexpected" was not one of the expected keys ["decimalPlaces"]',
@@ -190,7 +191,7 @@ test('purse.deposit promise', async t => {
   const exclusivePaymentP = E(issuer).claim(payment);
 
   await t.throwsAsync(
-    // @ts-ignore
+    // @ts-ignore deliberate invalid arguments for testing
     () => E(purse).deposit(exclusivePaymentP, fungible25),
     { message: /deposit does not accept promises/ },
     'failed to reject a promise for a payment',

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
@@ -12,7 +12,6 @@ const decoder = new TextDecoder();
 
 // eslint-disable-next-line no-unused-vars
 function workerLog(first, ...args) {
-  // @ts-ignore
   // eslint-disable-next-line
   // console.log(`---worker: ${first}`, ...args);
 }
@@ -225,13 +224,17 @@ function makeWorker(port) {
         ]),
     };
 
+    const cacheSize =
+      typeof virtualObjectCacheSize === 'number'
+        ? virtualObjectCacheSize
+        : undefined;
+
     const ls = makeLiveSlots(
       syscall,
       vatID,
       vatPowers,
       vatParameters,
-      // @ts-ignore  TODO: defend against non-numeric?
-      virtualObjectCacheSize,
+      cacheSize,
       // TODO: lsgc? API drift?
     );
 
@@ -239,9 +242,8 @@ function makeWorker(port) {
       ...ls.vatGlobals,
       console: makeConsole(`SwingSet:vatWorker`),
       assert,
-      // @ts-ignore bootstrap provides HandledPromise
-      // eslint-disable-next-line no-undef
-      HandledPromise,
+      // bootstrap provides HandledPromise
+      HandledPromise: globalThis.HandledPromise,
     };
     const vatNS = await importBundle(bundle, { endowments });
     workerLog(`got vatNS:`, Object.keys(vatNS).join(','));
@@ -282,8 +284,7 @@ function makeWorker(port) {
   });
 }
 
-// @ts-ignore xsnap provides issueCommand global
-// eslint-disable-next-line no-undef
-const port = managerPort(issueCommand);
+// xsnap provides issueCommand global
+const port = managerPort(globalThis.issueCommand);
 const worker = makeWorker(port);
 globalThis.handleCommand = port.handlerFrom(worker.handleItem);

--- a/packages/SwingSet/src/vats/types.js
+++ b/packages/SwingSet/src/vats/types.js
@@ -3,9 +3,9 @@
  * schedule a single wake() call, create a repeater that will allow scheduling
  * of events at regular intervals, or remove scheduled calls.
  * @property {() => Timestamp} getCurrentTimestamp Retrieve the latest timestamp
- * @property {(baseTime: Timestamp, waker: TimerWaker) => Timestamp} setWakeup Return
+ * @property {(baseTime: Timestamp, waker: ERef<TimerWaker>) => Timestamp} setWakeup Return
  * value is the time at which the call is scheduled to take place
- * @property {(waker: TimerWaker) => Array<Timestamp>} removeWakeup Remove the waker
+ * @property {(waker: ERef<TimerWaker>) => Array<Timestamp>} removeWakeup Remove the waker
  * from all its scheduled wakeups, whether produced by `timer.setWakeup(h)` or
  * `repeater.schedule(h)`.
  * @property {(delay: RelativeTime, interval: RelativeTime) => TimerRepeater} createRepeater
@@ -40,7 +40,7 @@
 
 /**
  * @typedef {Object} TimerRepeater
- * @property {(waker: TimerWaker) => Timestamp} schedule Returns the time scheduled for
+ * @property {(waker: ERef<TimerWaker>) => Timestamp} schedule Returns the time scheduled for
  * the first call to `E(waker).wake()`.  The waker will continue to be scheduled
  * every interval until the repeater is disabled.
  * @property {() => void} disable Disable this repeater, so `schedule(w)` can't

--- a/packages/dapp-svelte-wallet/api/test/test-getPursesNotifier.js
+++ b/packages/dapp-svelte-wallet/api/test/test-getPursesNotifier.js
@@ -86,10 +86,8 @@ test('getAttenuatedPursesNotifier', async t => {
   // Has the default Zoe invitation purse and a moola purse
   t.is(update.value.length, 2);
   const moolaPurseInfo = update.value[1];
-  // @ts-ignore
-  t.is(moolaPurseInfo.actions, undefined);
-  // @ts-ignore
-  t.is(moolaPurseInfo.brand, undefined);
+  t.false('actions' in moolaPurseInfo);
+  t.false('brand' in moolaPurseInfo);
   t.is(moolaPurseInfo.brandBoardId, '1532665031');
   t.is(moolaPurseInfo.brandPetname, MOOLA_ISSUER_PETNAME);
   t.deepEqual(moolaPurseInfo.currentAmount, {
@@ -110,8 +108,7 @@ test('getAttenuatedPursesNotifier', async t => {
     amountMathKind: 'nat',
   });
 
-  // @ts-ignore
-  t.is(moolaPurseInfo.purse, undefined);
+  t.false('purse' in moolaPurseInfo);
   t.is(moolaPurseInfo.pursePetname, MOOLA_PURSE_PETNAME);
   t.is(moolaPurseInfo.value, 0n);
 });

--- a/packages/deploy-script-support/test/unitTests/test-install.js
+++ b/packages/deploy-script-support/test/unitTests/test-install.js
@@ -27,7 +27,6 @@ test('install', async t => {
   };
 
   const board = makeBoard();
-  // @ts-ignore
   const install = makeInstall(bundleSource, zoe, installationManager, board);
 
   const resolvedPath = resolvePathForPackagedContract(

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -343,6 +343,15 @@ const makeRemotableProto = (oldProto, allegedName) => {
   );
 };
 
+/**
+ * Throw if val is not the correct shape for the prototype of a Remotable.
+ *
+ * TODO: It would be nice to typedef this shape and then declare that this
+ * function asserts it, but we can't declare a type with PASS_STYLE from JSDoc.
+ *
+ * @param {{ [PASS_STYLE]: string, [Symbol.toStringTag]: string, toString: () =>
+ * void}} val the value to verify
+ */
 const assertRemotableProto = val => {
   assert.typeof(val, 'object', X`cannot serialize non-objects like ${val}`);
   assert(!Array.isArray(val), X`Arrays cannot be pass-by-remote`);
@@ -355,11 +364,9 @@ const assertRemotableProto = val => {
   );
   assert(isFrozen(val), X`The Remotable proto must be frozen`);
   const {
-    // @ts-ignore
     [PASS_STYLE]: { value: passStyleValue },
-    // @ts-ignore
     toString: { value: toStringValue },
-    // @ts-ignore
+    // @ts-ignore https://github.com/microsoft/TypeScript/issues/1863
     [Symbol.toStringTag]: { value: toStringTagValue },
     ...rest
   } = getOwnPropertyDescriptors(val);
@@ -392,8 +399,8 @@ function assertCanBeRemotable(val) {
   const keys = ownKeys(descs); // enumerable-and-not, string-or-Symbol
   keys.forEach(key => {
     assert(
-      // @ts-ignore
-      !('get' in descs[key]),
+      // Typecast needed due to https://github.com/microsoft/TypeScript/issues/1863
+      !('get' in descs[/** @type {string} */ (key)]),
       X`cannot serialize objects with getters like ${q(String(key))} in ${val}`,
     );
     assert.typeof(

--- a/packages/notifier/test/test-subscriber-examples.js
+++ b/packages/notifier/test/test-subscriber-examples.js
@@ -35,9 +35,9 @@ test('subscription for-await-of cannot eat promise', async t => {
   const { publication, subscription } = makeSubscriptionKit();
   paula(publication);
   const subP = Promise.resolve(subscription);
-  // @ts-ignore because this test demonstrates the failure that results from
+  // Type cast because this test demonstrates the failure that results from
   // giving Alice a promise for a subscription.
-  const log = await alice(subP);
+  const log = await alice(/** @type {any} */ (subP));
 
   // This TypeError is thrown by JavaScript when a for-await-in loop
   // attempts to iterate a promise that is not an async iterable.

--- a/packages/xsnap/lib/lockdown-shim.js
+++ b/packages/xsnap/lib/lockdown-shim.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import 'ses/lockdown';
 
 lockdown();

--- a/packages/xsnap/lib/lockdown-shim.js
+++ b/packages/xsnap/lib/lockdown-shim.js
@@ -1,4 +1,3 @@
-// @ts-ignore
 import 'ses/lockdown';
 
 lockdown();

--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -43,6 +43,7 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
     const issuerTable = makeIssuerTable();
     const getAmountMath = brand => issuerTable.getByBrand(brand).amountMath;
 
+    /** @type {WeakStore<InvitationHandle, (seat: ZCFSeat) => unknown>} */
     const invitationHandleToHandler = makeWeakStore('invitationHandle');
 
     /** @type {Store<ZCFSeat,ZCFSeatAdmin>} */
@@ -441,7 +442,6 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
         zcfSeatToZCFSeatAdmin.init(zcfSeat, zcfSeatAdmin);
         zcfSeatToSeatHandle.init(zcfSeat, seatHandle);
         const offerHandler = invitationHandleToHandler.get(invitationHandle);
-        // @ts-ignore
         const offerResultP = E(offerHandler)(zcfSeat).catch(reason => {
           throw zcfSeat.fail(reason);
         });

--- a/packages/zoe/src/contracts/autoswap.js
+++ b/packages/zoe/src/contracts/autoswap.js
@@ -83,8 +83,9 @@ const start = async zcf => {
    */
   const getPoolKeyword = brand => {
     assert(brandToKeyword.has(brand), 'getPoolKeyword: brand not found');
-    // @ts-ignore
-    return brandToKeyword.get(brand);
+    const keyword = brandToKeyword.get(brand);
+    assert.typeof(keyword, 'string');
+    return keyword;
   };
 
   const { zcfSeat: poolSeat } = zcf.makeEmptySeatKit();

--- a/packages/zoe/test/swingsetTests/brokenContracts/crashingAutoRefund.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/crashingAutoRefund.js
@@ -25,8 +25,7 @@ const start = zcf => {
   if (terms.throw) {
     throw new Error('blowup in makeContract');
   } else if (terms.meter) {
-    // @ts-ignore
-    return new Array(1e9);
+    return { publicFacet: new Array(1e9) };
   }
 
   const safeAutoRefund = seat => {

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -1,3 +1,4 @@
+// @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -29,7 +30,7 @@ test(`zoe.getInvitationIssuer`, async t => {
 
 test(`zoe.install bad bundle`, async t => {
   const { zoe } = setup();
-  // @ts-ignore
+  // @ts-ignore deliberate invalid arguments for testing
   await t.throwsAsync(() => E(zoe).install(), {
     message: 'a bundle must be provided',
   });
@@ -46,7 +47,7 @@ test(`zoe.install`, async t => {
 
 test(`zoe.startInstance bad installation`, async t => {
   const { zoe } = setup();
-  // @ts-ignore
+  // @ts-ignore deliberate invalid arguments for testing
   await t.throwsAsync(() => E(zoe).startInstance(), {
     message: `(an undefined) was not a valid installation`,
   });
@@ -107,7 +108,7 @@ test(`zoe.startInstance - terms, issuerKeywordRecord switched`, async t => {
     () =>
       E(zoe).startInstance(
         installation,
-        // @ts-ignore
+        // @ts-ignore deliberate invalid arguments for testing
         { something: 2 },
         { Moola: moolaKit.issuer },
       ),
@@ -126,6 +127,7 @@ test(`zoe.offer`, async t => {
 
 test(`zoe.offer - no invitation`, async t => {
   const { zoe } = await setupZCFTest();
+  // @ts-ignore deliberate invalid arguments for testing
   await t.throwsAsync(() => E(zoe).offer(), {
     message: `A Zoe invitation is required, not (an undefined)`,
   });
@@ -144,7 +146,7 @@ test(`zoe.getPublicFacet`, async t => {
 
 test(`zoe.getPublicFacet - no instance`, async t => {
   const { zoe } = setup();
-  // @ts-ignore
+  // @ts-ignore deliberate invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getPublicFacet(), {
     message: `"instance" not found: (an undefined)`,
   });
@@ -172,7 +174,7 @@ test(`zoe.getIssuers - none`, async t => {
 
 test(`zoe.getIssuers - no instance`, async t => {
   const { zoe } = setup();
-  // @ts-ignore
+  // @ts-ignore invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getIssuers(), {
     message: `"instance" not found: (an undefined)`,
   });
@@ -200,7 +202,7 @@ test(`zoe.getBrands - none`, async t => {
 
 test(`zoe.getBrands - no instance`, async t => {
   const { zoe } = setup();
-  // @ts-ignore
+  // @ts-ignore invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getBrands(), {
     message: `"instance" not found: (an undefined)`,
   });
@@ -257,7 +259,7 @@ test(`zoe.getTerms`, async t => {
 
 test(`zoe.getTerms - no instance`, async t => {
   const { zoe } = setup();
-  // @ts-ignore
+  // @ts-ignore invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getTerms(), {
     message: `"instance" not found: (an undefined)`,
   });
@@ -272,6 +274,7 @@ test(`zoe.getInstance`, async t => {
 
 test(`zoe.getInstance - no invitation`, async t => {
   const { zoe } = await setupZCFTest();
+  // @ts-ignore invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getInstance(), {
     message: `A Zoe invitation is required, not (an undefined)`,
   });
@@ -286,6 +289,7 @@ test(`zoe.getInstallation`, async t => {
 
 test(`zoe.getInstallation - no invitation`, async t => {
   const { zoe } = await setupZCFTest();
+  // @ts-ignore invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getInstallation(), {
     message: `A Zoe invitation is required, not (an undefined)`,
   });
@@ -305,6 +309,7 @@ test(`zoe.getInvitationDetails`, async t => {
 
 test(`zoe.getInvitationDetails - no invitation`, async t => {
   const { zoe } = await setupZCFTest();
+  // @ts-ignore invalid arguments for testing
   await t.throwsAsync(() => E(zoe).getInvitationDetails(), {
     message: `A Zoe invitation is required, not (an undefined)`,
   });

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -1,3 +1,4 @@
+// @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -209,7 +210,7 @@ test(`zcf.saveIssuer & zoe.getTerms`, async t => {
 test(`zcf.saveIssuer - bad issuer`, async t => {
   const { moolaKit } = setup();
   const { zcf } = await setupZCFTest();
-  // @ts-ignore
+  // @ts-ignore deliberate invalid arguments for testing
   await t.throwsAsync(() => zcf.saveIssuer(moolaKit.brand, 'A'), {
     // TODO: improve error message
     // https://github.com/Agoric/agoric-sdk/issues/1701
@@ -234,7 +235,7 @@ test(`zcf.saveIssuer - args reversed`, async t => {
   const { zcf } = await setupZCFTest();
   // TODO: improve error message
   // https://github.com/Agoric/agoric-sdk/issues/1702
-  // @ts-ignore
+  // @ts-ignore deliberate invalid arguments for testing
   await t.throwsAsync(async () => zcf.saveIssuer('A', moolaKit.issuer), {
     message: `(an object) must be a string`,
   });
@@ -279,7 +280,7 @@ test(`zcf.makeInvitation - throwing offerHandler`, async t => {
 
 test(`zcf.makeInvitation - no description`, async t => {
   const { zcf } = await setupZCFTest();
-  // @ts-ignore
+  // @ts-ignore deliberate invalid arguments for testing
   t.throws(() => zcf.makeInvitation(() => {}), {
     message: `invitations must have a description string: (an undefined)`,
   });
@@ -289,7 +290,7 @@ test(`zcf.makeInvitation - non-string description`, async t => {
   const { zcf } = await setupZCFTest();
   // TODO: improve error message
   // https://github.com/Agoric/agoric-sdk/issues/1704
-  // @ts-ignore
+  // @ts-ignore deliberate invalid arguments for testing
   t.throws(() => zcf.makeInvitation(() => {}, { something: 'a' }), {
     message: `invitations must have a description string: (an object)`,
   });
@@ -298,9 +299,6 @@ test(`zcf.makeInvitation - non-string description`, async t => {
 test(`zcf.makeInvitation - no customProperties`, async t => {
   const { zcf, zoe, instance, installation } = await setupZCFTest();
   const invitationP = zcf.makeInvitation(() => {}, 'myInvitation');
-  // TODO: allow promises for payments
-  // https://github.com/Agoric/agoric-sdk/issues/1705
-  // @ts-ignore
   const details = await E(zoe).getInvitationDetails(invitationP);
   t.deepEqual(details, {
     description: 'myInvitation',
@@ -317,9 +315,6 @@ test(`zcf.makeInvitation - customProperties`, async t => {
     whatever: 'whatever',
     timer,
   });
-  // TODO: allow promises for payments
-  // https://github.com/Agoric/agoric-sdk/issues/1705
-  // @ts-ignore
   const details = await E(zoe).getInvitationDetails(invitationP);
   t.deepEqual(details, {
     description: 'myInvitation',
@@ -338,9 +333,6 @@ test(`zcf.makeInvitation - customProperties overwritten`, async t => {
     installation: 'whatever',
     instance: 'whatever',
   });
-  // TODO: allow promises for payments
-  // https://github.com/Agoric/agoric-sdk/issues/1705
-  // @ts-ignore
   const details = await E(zoe).getInvitationDetails(invitationP);
   t.deepEqual(details, {
     description: 'myInvitation',
@@ -353,7 +345,7 @@ test(`zcf.makeInvitation - customProperties overwritten`, async t => {
 
 test(`zcf.makeZCFMint - no keyword`, async t => {
   const { zcf } = await setupZCFTest();
-  // @ts-ignore
+  // @ts-ignore deliberate invalid arguments for testing
   await t.throwsAsync(() => zcf.makeZCFMint(), {
     message: '(an undefined) must be a string',
   });
@@ -376,7 +368,7 @@ test(`zcf.makeZCFMint - bad keyword`, async t => {
 
 test(`zcf.makeZCFMint - not a math kind`, async t => {
   const { zcf } = await setupZCFTest();
-  // @ts-ignore
+  // @ts-ignore deliberate invalid arguments for testing
   await t.throwsAsync(() => zcf.makeZCFMint('A', 'whatever'), {
     message: 'unrecognized amountMathKind: (a string)',
   });
@@ -425,7 +417,7 @@ test(`zcf.makeZCFMint - SET`, async t => {
 test(`zcf.makeZCFMint - mintGains - no args`, async t => {
   const { zcf } = await setupZCFTest();
   const zcfMint = await zcf.makeZCFMint('A', MathKind.SET);
-  // @ts-ignore
+  // @ts-ignore deliberate invalid arguments for testing
   t.throws(() => zcfMint.mintGains(), {
     message: `gains (an undefined) must be an amountKeywordRecord`,
   });
@@ -446,7 +438,7 @@ test(`zcf.makeZCFMint - mintGains - no gains`, async t => {
   const { zcfSeat } = zcf.makeEmptySeatKit();
   // TODO: create seat if one is not provided
   // https://github.com/Agoric/agoric-sdk/issues/1696
-  // @ts-ignore
+  // @ts-ignore deliberate invalid arguments for testing
   t.throws(() => zcfMint.mintGains(undefined, zcfSeat), {
     message: 'gains (an undefined) must be an amountKeywordRecord',
   });
@@ -455,7 +447,7 @@ test(`zcf.makeZCFMint - mintGains - no gains`, async t => {
 test(`zcf.makeZCFMint - burnLosses - no args`, async t => {
   const { zcf } = await setupZCFTest();
   const zcfMint = await zcf.makeZCFMint('A', MathKind.SET);
-  // @ts-ignore
+  // @ts-ignore deliberate invalid arguments for testing
   t.throws(() => zcfMint.burnLosses(), {
     message: 'losses (an undefined) must be an amountKeywordRecord',
   });
@@ -465,7 +457,7 @@ test(`zcf.makeZCFMint - burnLosses - no losses`, async t => {
   const { zcf } = await setupZCFTest();
   const zcfMint = await zcf.makeZCFMint('A', MathKind.SET);
   const { zcfSeat } = zcf.makeEmptySeatKit();
-  // @ts-ignore
+  // @ts-ignore deliberate invalid arguments for testing
   t.throws(() => zcfMint.burnLosses(undefined, zcfSeat), {
     message: 'losses (an undefined) must be an amountKeywordRecord',
   });
@@ -696,7 +688,7 @@ test(`zcfSeat.isOfferSafe from zcf.makeEmptySeatKit`, async t => {
   const { moola } = setup();
   const { zcfSeat } = zcf.makeEmptySeatKit();
   // Anything is offer safe with no want or give
-  // @ts-ignore
+  // @ts-ignore deliberate invalid arguments for testing
   t.truthy(zcfSeat.isOfferSafe());
   t.truthy(zcfSeat.isOfferSafe({ Moola: moola(0) }));
   t.truthy(zcfSeat.isOfferSafe({ Moola: moola(10) }));
@@ -1067,7 +1059,7 @@ test(`userSeat.getPayouts, getPayout from zcf.makeEmptySeatKit`, async t => {
 test(`userSeat.getPayout() should throw from zcf.makeEmptySeatKit`, async t => {
   const { zcf } = await setupZCFTest();
   const { userSeat } = zcf.makeEmptySeatKit();
-  // @ts-ignore
+  // @ts-ignore deliberate invalid arguments for testing
   await t.throwsAsync(() => E(userSeat).getPayout(), {
     message: 'A keyword must be provided',
   });
@@ -1075,7 +1067,7 @@ test(`userSeat.getPayout() should throw from zcf.makeEmptySeatKit`, async t => {
 
 test(`zcf.reallocate < 2 seats`, async t => {
   const { zcf } = await setupZCFTest();
-  // @ts-ignore
+  // @ts-ignore deliberate invalid arguments for testing
   t.throws(() => zcf.reallocate(), {
     message: 'reallocating must be done over two or more seats',
   });
@@ -1175,19 +1167,16 @@ test(`zcf.reallocate 3 seats, rights NOT conserved`, async t => {
     }),
   );
 
-  // @ts-ignore
   const staging1 = zcfSeat1.stage({
     A: simoleans(100),
     B: moola(0),
   });
 
-  // @ts-ignore
   const staging2 = zcfSeat2.stage({
     Whatever: moola(2),
     Whatever2: simoleans(0),
   });
 
-  // @ts-ignore
   const staging3 = zcfSeat3.stage({
     Whatever: moola(1),
     Whatever2: simoleans(0),

--- a/packages/zoe/tools/manualTimer.js
+++ b/packages/zoe/tools/manualTimer.js
@@ -19,13 +19,13 @@ import { makeNotifierKit } from '@agoric/notifier';
 export default function buildManualTimer(log, startValue = 0n) {
   let ticks = Nat(startValue);
 
-  /** @type {Store<Timestamp, Array<TimerWaker>>} */
+  /** @type {Store<Timestamp, Array<ERef<TimerWaker>>>} */
   const schedule = makeStore('Timestamp');
 
   const makeRepeater = (delaySecs, interval, timer) => {
     assert.typeof(delaySecs, 'bigint');
     assert.typeof(interval, 'bigint');
-    /** @type {Array<TimerWaker> | null} */
+    /** @type {Array<ERef<TimerWaker>> | null} */
     let wakers = [];
     let nextWakeup;
 


### PR DESCRIPTION
Either updates to the Typescript version we use in agoric-sdk, or cargo-culting means many of our `@ts-ignore` annotations are unnecessary.

I suggest that we should avoid `@ts-ignore` whenever we can: only use it when Typescript really has a bug we can't work around, such as https://github.com/Agoric/agoric-sdk/pull/2438#discussion_r576948615.  Then, link to the corresponding open issue on the TypeScript repository in the same line as `@ts-ignore`.
