### PR TITLE
Make resolution descriptions uniform everywhere

### DIFF
--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -561,8 +561,8 @@ function build(syscall, forVatID, cacheSize, vatPowers, vatParameters) {
     assert(didRoot);
     beginCollectingPromiseImports();
     for (const resolution of resolutions) {
-      const [vpid, vp] = resolution;
-      notifyOnePromise(vpid, vp.rejected, vp.data);
+      const [vpid, rejected, data] = resolution;
+      notifyOnePromise(vpid, rejected, data);
     }
     for (const resolution of resolutions) {
       const [vpid] = resolution;

--- a/packages/SwingSet/src/kernel/vatTranslator.js
+++ b/packages/SwingSet/src/kernel/vatTranslator.js
@@ -53,13 +53,13 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
 
   function translatePromiseDescriptor(kp) {
     if (kp.state === 'fulfilled' || kp.state === 'rejected') {
-      return {
-        rejected: kp.state === 'rejected',
-        data: {
+      return [
+        kp.state === 'rejected',
+        {
           ...kp.data,
           slots: kp.data.slots.map(slot => mapKernelSlotToVatSlot(slot)),
         },
-      };
+      ];
     } else if (kp.state === 'redirected') {
       // TODO unimplemented
       throw new Error('not implemented yet');
@@ -75,9 +75,9 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
       const [kpid, p] = resolution;
       assert(p.state !== 'unresolved', X`spurious notification ${kpid}`);
       const vpid = mapKernelSlotToVatSlot(kpid);
-      const vres = translatePromiseDescriptor(p);
-      vResolutions.push([vpid, vres]);
-      kdebug(`notify ${idx} ${kpid}/${vpid} ${JSON.stringify(vres)}`);
+      const vres = [vpid, ...translatePromiseDescriptor(p)];
+      vResolutions.push(vres);
+      kdebug(`notify ${idx} ${kpid} ${JSON.stringify(vres)}`);
       idx += 1;
     }
     const vatDelivery = harden(['notify', vResolutions]);

--- a/packages/SwingSet/src/vats/comms/clist-kernel.js
+++ b/packages/SwingSet/src/vats/comms/clist-kernel.js
@@ -63,10 +63,12 @@ export function makeKernel(state, syscall, stateKit) {
         // the resolution and then immediately retire the vpid again.
 
         const fresh = allocateResolvedPromiseID();
-        // console.log(`fresh: ${fresh} for ${vpid}`, p.resolution);
+        // console.log(`fresh: ${fresh} for ${vpid}`, p.rejected, p.data);
         // we must tell the kernel about the resolution *after* the message
         // which introduces it
-        Promise.resolve().then(() => resolveToKernel([[fresh, p.resolution]]));
+        Promise.resolve().then(() =>
+          resolveToKernel([[fresh, p.rejected, p.data]]),
+        );
         return fresh;
       }
 

--- a/packages/SwingSet/src/vats/comms/clist-outbound.js
+++ b/packages/SwingSet/src/vats/comms/clist-outbound.js
@@ -81,7 +81,7 @@ export function makeOutbound(state, stateKit) {
       // we must send the resolution *after* the message which introduces it
       const { remoteID } = remote;
       Promise.resolve().then(() =>
-        resolveToRemote(remoteID, [[vpid, p.resolution]]),
+        resolveToRemote(remoteID, [[vpid, p.rejected, p.data]]),
       );
     } else {
       // or arrange to send it later, once it resolves

--- a/packages/SwingSet/src/vats/comms/dispatch.js
+++ b/packages/SwingSet/src/vats/comms/dispatch.js
@@ -75,11 +75,10 @@ export function buildCommsDispatch(syscall) {
   function notify(resolutions) {
     const willBeResolved = new Set();
     for (const resolution of resolutions) {
-      const [vpid, value] = resolution;
+      const [vpid, _rejected, data] = resolution;
       willBeResolved.add(vpid);
-      assert(typeof value === 'object');
-      insistCapData(value.data);
-      // console.debug(`comms.notify(${vpid}, ${value})`);
+      insistCapData(data);
+      // console.debug(`comms.notify(${vpid}, ${rejected}, ${data})`);
       // dumpState(state);
     }
     resolveFromKernel(resolutions, willBeResolved);

--- a/packages/SwingSet/src/vats/comms/state.js
+++ b/packages/SwingSet/src/vats/comms/state.js
@@ -238,14 +238,20 @@ export function makeStateKit(state) {
     assert(!p.resolved, X`${vpid} was already resolved`);
   }
 
-  function markPromiseAsResolved(vpid, resolution) {
+  function markPromiseAsResolved(vpid, rejected, data) {
     const p = state.promiseTable.get(vpid);
     assert(p, X`unknown ${vpid}`);
     assert(!p.resolved);
-    insistCapData(resolution.data);
+    assert.typeof(
+      rejected,
+      'boolean',
+      X`non-boolean "rejected" flag: ${rejected}`,
+    );
+    insistCapData(data);
     p.resolved = true;
     p.kernelAwaitingResolve = true;
-    p.resolution = resolution;
+    p.rejected = rejected;
+    p.data = data;
     p.decider = undefined;
     p.subscribers = undefined;
     p.kernelIsSubscribed = undefined;

--- a/packages/SwingSet/test/test-kernel.js
+++ b/packages/SwingSet/test/test-kernel.js
@@ -22,7 +22,7 @@ function capargs(args, slots = []) {
 const slot0arg = { '@qclass': 'slot', index: 0 };
 
 function oneResolution(promiseID, rejected, data) {
-  return [[promiseID, { rejected, data }]];
+  return [[promiseID, rejected, data]];
 }
 
 function checkPromises(t, kernel, expected) {

--- a/packages/SwingSet/test/test-liveslots.js
+++ b/packages/SwingSet/test/test-liveslots.js
@@ -16,7 +16,7 @@ function capargs(args, slots = []) {
 }
 
 function oneResolution(promiseID, rejected, data) {
-  return [[promiseID, { rejected, data }]];
+  return [[promiseID, rejected, data]];
 }
 
 function buildSyscall() {

--- a/packages/SwingSet/test/test-vpid-kernel.js
+++ b/packages/SwingSet/test/test-vpid-kernel.js
@@ -20,7 +20,7 @@ function capargs(args, slots = []) {
 }
 
 function oneResolution(promiseID, rejected, data) {
-  return [[promiseID, { rejected, data }]];
+  return [[promiseID, rejected, data]];
 }
 
 function makeConsole(tag) {
@@ -743,25 +743,15 @@ test(`kernel vpid handling crossing resolutions`, async t => {
   await kernel.run();
   t.deepEqual(logX.shift(), {
     type: 'notify',
-    resolutions: [
-      [
-        exportedUseResultAvatX,
-        {
-          rejected: false,
-          data: capargs(undefinedArg, []),
-        },
-      ],
-    ],
+    resolutions: [[exportedUseResultAvatX, false, capargs(undefinedArg, [])]],
   });
   t.deepEqual(logX.shift(), {
     type: 'notify',
     resolutions: [
       [
         exportedGenResultAvatX,
-        {
-          rejected: false,
-          data: capargs([slot0arg], [exportedGenResultBvatX]),
-        },
+        false,
+        capargs([slot0arg], [exportedGenResultBvatX]),
       ],
     ],
   });
@@ -795,32 +785,20 @@ test(`kernel vpid handling crossing resolutions`, async t => {
   await kernel.run();
   t.deepEqual(logX.shift(), {
     type: 'notify',
-    resolutions: [
-      [
-        exportedUseResultBvatX,
-        {
-          rejected: false,
-          data: capargs(undefinedArg, []),
-        },
-      ],
-    ],
+    resolutions: [[exportedUseResultBvatX, false, capargs(undefinedArg, [])]],
   });
   t.deepEqual(logX.shift(), {
     type: 'notify',
     resolutions: [
       [
         exportedGenResultBvatX,
-        {
-          rejected: false,
-          data: capargs([slot0arg], [importedGenResultAvatX]),
-        },
+        false,
+        capargs([slot0arg], [importedGenResultAvatX]),
       ],
       [
         importedGenResultAvatX,
-        {
-          rejected: false,
-          data: capargs([slot0arg], [exportedGenResultBvatX]),
-        },
+        false,
+        capargs([slot0arg], [exportedGenResultBvatX]),
       ],
     ],
   });
@@ -830,17 +808,13 @@ test(`kernel vpid handling crossing resolutions`, async t => {
     resolutions: [
       [
         importedGenResultAvatB,
-        {
-          rejected: false,
-          data: capargs([slot0arg], [importedGenResultB2vatB]),
-        },
+        false,
+        capargs([slot0arg], [importedGenResultB2vatB]),
       ],
       [
         importedGenResultB2vatB,
-        {
-          rejected: false,
-          data: capargs([slot0arg], [importedGenResultAvatB]),
-        },
+        false,
+        capargs([slot0arg], [importedGenResultAvatB]),
       ],
     ],
   });
@@ -850,17 +824,13 @@ test(`kernel vpid handling crossing resolutions`, async t => {
     resolutions: [
       [
         importedGenResultBvatA,
-        {
-          rejected: false,
-          data: capargs([slot0arg], [importedGenResultA2vatA]),
-        },
+        false,
+        capargs([slot0arg], [importedGenResultA2vatA]),
       ],
       [
         importedGenResultA2vatA,
-        {
-          rejected: false,
-          data: capargs([slot0arg], [importedGenResultBvatA]),
-        },
+        false,
+        capargs([slot0arg], [importedGenResultBvatA]),
       ],
     ],
   });

--- a/packages/SwingSet/test/test-vpid-liveslots.js
+++ b/packages/SwingSet/test/test-vpid-liveslots.js
@@ -19,7 +19,7 @@ function capargs(args, slots = []) {
 }
 
 function oneResolution(promiseID, rejected, data) {
-  return [[promiseID, { rejected, data }]];
+  return [[promiseID, rejected, data]];
 }
 
 function buildSyscall() {


### PR DESCRIPTION
This takes care of issue #2248, wherein resolutions are represented in some places as `[promiseID, { rejected: rejectedFlag, data: capdata }]` and in other places as `[promiseID, rejectedFlag, capdata]`.  Now it's the latter form everywhere.
