### PR TITLE
Release fixups

### DIFF
--- a/golang/cosmos/package.json
+++ b/golang/cosmos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/cosmos",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Connect JS to the Cosmos blockchain SDK",
   "parsers": {
     "js": "mjs"

--- a/lerna.json
+++ b/lerna.json
@@ -8,6 +8,7 @@
   },
   "packages": [
     ".",
+    "golang/cosmos",
     "packages/*", 
     "packages/dapp-*-wallet/api",
     "packages/dapp-*-wallet/contract",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/sdk",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "private": true,
   "useWorkspaces": true,
   "workspaces": [

--- a/packages/cosmic-swingset/lib/kernel-stats.js
+++ b/packages/cosmic-swingset/lib/kernel-stats.js
@@ -67,14 +67,9 @@ const KERNEL_STATS_UPDOWN_METRICS = [
     description: 'Unresolved kernel promises',
   },
   {
-    key: 'kpFulfilledToPresence',
-    name: 'swingset_presence_kernel_promises',
-    description: 'Kernel promises fulfilled to presences',
-  },
-  {
-    key: 'kpFulfilledToData',
-    name: 'swingset_data_kernel_promises',
-    description: 'Kernel promises fulfilled to data',
+    key: 'kpFulfilled',
+    name: 'swingset_fulfilled_kernel_promises',
+    description: 'Fulfilled kernel promises',
   },
   {
     key: 'kpRejected',

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -27,7 +27,7 @@
     "@agoric/babel-parser": "^7.6.4",
     "@agoric/bundle-source": "^1.2.1",
     "@agoric/captp": "^1.7.1",
-    "@agoric/cosmos": "^0.23.0",
+    "@agoric/cosmos": "^0.24.0",
     "@agoric/dapp-svelte-wallet": "^0.6.1",
     "@agoric/ertp": "^0.9.1",
     "@agoric/eventual-send": "^0.13.1",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -24,6 +24,9 @@
   "engines": {
     "node": ">=0.10.0"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "prettier": {
     "trailingComma": "all",
     "singleQuote": true


### PR DESCRIPTION
These are the changes required when making the last release (`@agoric/sdk@2.12.0`), as well as silencing warnings that were logged to the `cosmic-swingset` console.

The following change was the instigator for the warnings by replacing `kpFulfilledToData` and `kpFulfilledToPresence` with `kpFulfilled`:

```diff
diff --git a/packages/SwingSet/src/kernel/state/kernelKeeper.js b/packages/SwingSet/src/kernel/state/kernelKeeper.js
index 4e86d5e0..24bd3fd5 100644
--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -392,11 +377,8 @@ export default function makeKernelKeeper(storage, kernelSlog) {
       case 'unresolved':
         decStat('kpUnresolved');
         break;
-      case 'fulfilledToPresence':
-        decStat('kpFulfilledToPresence');
-        break;
-      case 'fulfilledToData':
-        decStat('kpFulfilledToData');
+      case 'fulfilled':
+        decStat('kpFulfilled');
         break;
       case 'rejected':
         decStat('kpRejected');
```
