### PR TITLE
chore: convert ERTP to Nat 4.0.0

### DIFF
--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -45,7 +45,7 @@
     "@agoric/eventual-send": "^0.13.1",
     "@agoric/import-manager": "^0.2.1",
     "@agoric/marshal": "^0.3.1",
-    "@agoric/nat": "^2.0.1",
+    "@agoric/nat": "^4.0.0",
     "@agoric/notifier": "^0.3.1",
     "@agoric/promise-kit": "^0.2.1",
     "@agoric/same-structure": "^0.1.1",

--- a/packages/ERTP/src/mathHelpers/natMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/natMathHelpers.js
@@ -1,10 +1,10 @@
 // @ts-check
 
-import Nat from '@agoric/nat';
+import { Nat } from '@agoric/nat';
 
 import '../types';
 
-const identity = 0;
+const identity = 0n;
 
 /**
  * Fungible digital assets use the natMathHelpers to manage balances -
@@ -24,7 +24,8 @@ const natMathHelpers = harden({
   doIsEmpty: nat => nat === identity,
   doIsGTE: (left, right) => left >= right,
   doIsEqual: (left, right) => left === right,
-  doAdd: (left, right) => Nat(left + right),
+  // BigInts don't observably overflow
+  doAdd: (left, right) => left + right,
   doSubtract: (left, right) => Nat(left - right),
 });
 

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -312,6 +312,11 @@
  * values labeled with a brand. AmountMath use mathHelpers to do their value arithmetic,
  * and then brand the results, making a new amount.
  *
+ * The MathHelpers are designed to be called only from AmountMath, and so
+ * all methods but coerce can assume their inputs are valid. They only
+ * need to do output validation, and only when there is a possibility of
+ * invalid output.
+ *
  * @property {(allegedValue: Value) => Value} doCoerce
  * Check the kind of this value and throw if it is not the
  * expected kind.

--- a/packages/ERTP/test/swingsetTests/splitPayments/test-splitPayments.js
+++ b/packages/ERTP/test/swingsetTests/splitPayments/test-splitPayments.js
@@ -12,9 +12,9 @@ async function main(basedir, argv) {
 
 const expectedTapFaucetLog = [
   'start test splitPayments',
-  'oldPayment balance:{"brand":{},"value":1000}',
-  'splitPayment[0] balance: {"brand":{},"value":10}',
-  'splitPayment[1] balance: {"brand":{},"value":990}',
+  'oldPayment balance:{"brand":{},"value":"1000"}',
+  'splitPayment[0] balance: {"brand":{},"value":"10"}',
+  'splitPayment[1] balance: {"brand":{},"value":"990"}',
 ];
 
 test('test splitPayments', async t => {

--- a/packages/ERTP/test/swingsetTests/splitPayments/test-splitPayments.js
+++ b/packages/ERTP/test/swingsetTests/splitPayments/test-splitPayments.js
@@ -12,9 +12,9 @@ async function main(basedir, argv) {
 
 const expectedTapFaucetLog = [
   'start test splitPayments',
-  'oldPayment balance:{"brand":{},"value":"1000"}',
-  'splitPayment[0] balance: {"brand":{},"value":"10"}',
-  'splitPayment[1] balance: {"brand":{},"value":"990"}',
+  'oldPayment balance:{"brand":{},"value":1000}',
+  'splitPayment[0] balance: {"brand":{},"value":10}',
+  'splitPayment[1] balance: {"brand":{},"value":990}',
 ];
 
 test('test splitPayments', async t => {

--- a/packages/ERTP/test/swingsetTests/splitPayments/vat-alice.js
+++ b/packages/ERTP/test/swingsetTests/splitPayments/vat-alice.js
@@ -2,13 +2,13 @@ import { E } from '@agoric/eventual-send';
 
 function makeAliceMaker(log) {
   return harden({
-    make(issuer, unitOps, oldPaymentP) {
+    make(issuer, amountMath, oldPaymentP) {
       const alice = harden({
         async testSplitPayments() {
           log('oldPayment balance:', await E(issuer).getAmountOf(oldPaymentP));
           const splitPayments = await E(issuer).split(
             oldPaymentP,
-            await E(unitOps).make(10),
+            await E(amountMath).make(10),
           );
           log(
             'splitPayment[0] balance: ',

--- a/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
@@ -35,15 +35,18 @@ test('natMathHelpers', t => {
   t.deepEqual(getAmountMathKind(), MathKind.NAT, 'amountMathKind is nat');
 
   // make
-  t.deepEqual(make(4), { brand: mockBrand, value: 4 });
+  t.deepEqual(make(4), { brand: mockBrand, value: 4n });
   t.throws(
     () => make('abc'),
-    { instanceOf: RangeError, message: 'not a safe integer' },
+    {
+      instanceOf: TypeError,
+      message: 'abc is a string but must be a bigint or a number',
+    },
     `'abc' is not a nat`,
   );
   t.throws(
     () => make(-1),
-    { instanceOf: RangeError, message: 'negative' },
+    { instanceOf: RangeError, message: '-1 is negative' },
     `- 1 is not a valid Nat`,
   );
 
@@ -52,13 +55,15 @@ test('natMathHelpers', t => {
     coerce(harden({ brand: mockBrand, value: 4 })),
     {
       brand: mockBrand,
-      value: 4,
+      value: 4n,
     },
     `coerce can take an amount`,
   );
   t.throws(
     () =>
-      coerce(harden({ brand: { getAllegedName: () => 'somename' }, value: 4 })),
+      coerce(
+        harden({ brand: { getAllegedName: () => 'somename' }, value: 4n }),
+      ),
     {
       message: /The brand in the allegedAmount .* in 'coerce' didn't match the amountMath brand/,
     },
@@ -71,14 +76,14 @@ test('natMathHelpers', t => {
   );
 
   // getValue
-  t.is(getValue(make(4)), 4);
+  t.is(getValue(make(4)), 4n);
 
   // getEmpty
   t.deepEqual(getEmpty(), make(0), `empty is 0`);
 
   // isEmpty
-  t.assert(isEmpty({ brand: mockBrand, value: 0 }), `isEmpty(0) is true`);
-  t.falsy(isEmpty({ brand: mockBrand, value: 6 }), `isEmpty(6) is false`);
+  t.assert(isEmpty({ brand: mockBrand, value: 0n }), `isEmpty(0) is true`);
+  t.falsy(isEmpty({ brand: mockBrand, value: 6n }), `isEmpty(6) is false`);
   t.assert(isEmpty(make(0)), `isEmpty(0) is true`);
   t.falsy(isEmpty(make(6)), `isEmpty(6) is false`);
   t.throws(
@@ -88,7 +93,10 @@ test('natMathHelpers', t => {
   );
   t.throws(
     () => isEmpty({ brand: mockBrand, value: 'abc' }),
-    { instanceOf: RangeError, message: 'not a safe integer' },
+    {
+      instanceOf: TypeError,
+      message: 'abc is a string but must be a bigint or a number',
+    },
     `isEmpty('abc') throws because it cannot be coerced`,
   );
   t.throws(

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -61,7 +61,7 @@ test('amountMath from makeIssuerKit', async t => {
       fungible(150),
     ),
   );
-  t.is(fungible(4000).value, 4000);
+  t.is(fungible(4000).value, 4000n);
   t.is(fungible(0).brand, brand);
 });
 
@@ -399,7 +399,7 @@ test('issuer.combine array of promises', async t => {
 
   const checkCombinedResult = paymentP => {
     issuer.getAmountOf(paymentP).then(pAmount => {
-      t.is(pAmount.value, 100);
+      t.is(pAmount.value, 100n);
     });
   };
 


### PR DESCRIPTION
Stacked on #2475. (The Nat 4.0.0 changes will not be merged into master until the documentation and other changes are ready.)

This PR converts the ERTP package to use Nat 4.0.0.

Note: The dapp and documentation tests will likely not pass until we change them to also use BigInts.