### PR TITLE
run ERTP tests in ava work-alike for XS, xs-worker

### DIFF
--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -12,6 +12,9 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
+    "test:xs": "yarn test:xs-unit && yarn test:xs-worker",
+    "test:xs-unit": "node -r esm ../xsnap/src/avaXS.js test/unitTests/test-*.js",
+    "test:xs-worker": "WORKER_TYPE=xs-worker ava",
     "test:nyc": "nyc ava",
     "pretty-fix": "prettier --write '**/*.js'",
     "pretty-check": "prettier --check '**/*.js'",

--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "build": "exit 0",
-    "test": "ava",
+    "test": "yarn test:node && yarn test:xs",
+    "test:node": "ava",
     "test:xs": "yarn test:xs-unit && yarn test:xs-worker",
     "test:xs-unit": "node -r esm ../xsnap/src/avaXS.js test/unitTests/test-*.js",
     "test:xs-worker": "WORKER_TYPE=xs-worker ava",

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
@@ -91,6 +91,8 @@ function managerPort(issueCommand) {
 // please excuse copy-and-paste from kernel.js
 function abbreviateReplacer(_, arg) {
   if (typeof arg === 'bigint') {
+    // since testLog is only for testing, 2^53 is enough.
+    // precedent: 32a1dd3
     return Number(arg);
   }
   if (typeof arg === 'string' && arg.length >= 40) {
@@ -215,8 +217,6 @@ function makeWorker(port) {
       testLog: (...args) =>
         port.send([
           'testLog',
-          // since testLog is only for testing, 2^53 is enough.
-          // precedent: 32a1dd3
           ...args.map(arg =>
             typeof arg === 'string'
               ? arg

--- a/packages/xsnap/jsconfig.json
+++ b/packages/xsnap/jsconfig.json
@@ -14,5 +14,5 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["src/**/*.js", "exported.js", "tools/**/*.js"],
+  "include": ["src/**/*.js", "src/**/*.d.ts", "exported.js", "tools/**/*.js"],
 }

--- a/packages/xsnap/package.json
+++ b/packages/xsnap/package.json
@@ -25,7 +25,9 @@
     "test": "ava"
   },
   "dependencies": {
+    "@agoric/bundle-source": "^1.2.1",
     "@agoric/eventual-send": "^0.13.2",
+    "@agoric/install-ses": "^0.5.1",
     "esm": "^3.2.5",
     "ses": "^0.12.2"
   },

--- a/packages/xsnap/src/avaAssertXS.js
+++ b/packages/xsnap/src/avaAssertXS.js
@@ -1,0 +1,345 @@
+/* eslint-disable no-await-in-loop */
+// @ts-check
+
+/** global print */
+
+const { freeze, keys } = Object;
+
+// ack Paul Roub Aug 2014
+// https://stackoverflow.com/a/25456134/7963
+/** @type {(x: unknown, y: unknown) => boolean } */
+function deepEqual(x, y) {
+  if (Object.is(x, y)) {
+    return true;
+  }
+  if (
+    typeof x === 'object' &&
+    x != null &&
+    typeof y === 'object' &&
+    y != null
+  ) {
+    if (keys(x).length !== keys(y).length) {
+      const detail = JSON.stringify({
+        actual: {
+          length: keys(x).length,
+          keys: keys(x),
+        },
+        expected: {
+          length: keys(y).length,
+          keys: keys(y),
+        },
+      });
+      throw new Error(`Object keys length: ${detail}`);
+    }
+
+    const { hasOwnProperty } = Object.prototype;
+    /** @type {(obj: Object, prop: string | symbol | number) => boolean} */
+    const hasOwnPropertyOf = (obj, prop) =>
+      Reflect.apply(hasOwnProperty, obj, [prop]);
+    for (const prop of Reflect.ownKeys(x)) {
+      if (hasOwnPropertyOf(y, prop)) {
+        if (!deepEqual(x[prop], y[prop])) {
+          return false;
+        }
+      } else {
+        // Separately, should this have the same detail structure as the other errors you're throwing?
+        throw new Error(`missing property ${String(prop)}`);
+      }
+    }
+
+    return true;
+  }
+  const detail = JSON.stringify({
+    actual: { type: typeof x, value: x },
+    expected: { type: typeof y, value: y },
+  });
+  throw new Error(detail);
+}
+
+/**
+ * ref https://testanything.org/tap-specification.html
+ *
+ * @param {(msg: TapMessage) => void} send
+ *
+ * @typedef { ReturnType<typeof tapFormat> } TapFormat
+ * @typedef {import('./avaXS').TapMessage} TapMessage
+ */
+function tapFormat(send) {
+  return freeze({
+    /** @type {(qty: number) => void} */
+    plan(qty) {
+      send({ plan: qty });
+    },
+    /** @type {(n: number, t?: string) => void} */
+    ok(testNum, txt) {
+      send({ status: 'ok', id: testNum, message: txt });
+    },
+    /** @type {(n: number, t: string) => void} */
+    skip(testNum, txt) {
+      send({ status: 'SKIP', id: testNum, message: txt });
+    },
+    /** @type {(n: number, t?: string) => void} */
+    notOk(testNum, txt) {
+      send({ status: 'not ok', id: testNum, message: txt });
+    },
+    /** @type {(t: string, label?: string) => void} */
+    diagnostic(txt, label) {
+      send({ note: txt, label });
+    },
+  });
+}
+
+/** @type { Harness | null } */
+let theHarness = null; // ISSUE: ambient
+
+/**
+ * @param {(msg: TapMessage) => void} send
+ *
+ * @typedef { ReturnType<typeof createHarness>} Harness
+ */
+function createHarness(send) {
+  let testNum = 0;
+  let passCount = 0;
+  /** @type {((ot: { context: Object }) => Promise<void>)[]} */
+  let beforeHooks = [];
+  /** @type {(() => Promise<void>)[]} */
+  let suitesToRun = [];
+  const context = {};
+
+  /**
+   * @returns { Summary }
+   * @typedef {import('./avaXS').Summary} Summary
+   */
+  function summary() {
+    return {
+      pass: passCount,
+      fail: testNum - passCount,
+      total: testNum,
+    };
+  }
+
+  const it = freeze({
+    send,
+    get context() {
+      return context;
+    },
+    /** @type {(l: string, f: () => Promise<void>) => void } */
+    before(_label, hook) {
+      beforeHooks.push(hook);
+    },
+    /** @type { (ok: boolean) => number } */
+    finish(ok) {
+      testNum += 1;
+      if (ok) {
+        passCount += 1;
+      }
+      return testNum;
+    },
+    /** @type { (f: () => Promise<void>) => Promise<void> } */
+    async defer(thunk) {
+      suitesToRun.push(thunk);
+    },
+    summary,
+    async result() {
+      for await (const hook of beforeHooks) {
+        await hook({ context });
+      }
+      beforeHooks = [];
+      for await (const suite of suitesToRun) {
+        await suite();
+      }
+      suitesToRun = [];
+
+      return summary();
+    },
+  });
+
+  if (!theHarness) {
+    theHarness = it;
+  }
+  return it;
+}
+
+/**
+ * @param {*} exc
+ * @param {Expectation} expectation
+ *
+ * @typedef {{ instanceOf: Function } | { message: string | RegExp }=} Expectation
+ */
+function checkExpectation(exc, expectation) {
+  if (!expectation) return true;
+  if ('instanceOf' in expectation) return exc instanceof expectation.instanceOf;
+  if ('message' in expectation) {
+    const { message } = expectation;
+    return typeof message === 'string'
+      ? exc.message === message
+      : exc.message.match(message);
+  }
+  throw Error(`not implemented: ${JSON.stringify(expectation)}`);
+}
+
+/**
+ * @param {Harness} htest
+ * @param {TapFormat} out
+ *
+ * @typedef {ReturnType<typeof makeTester>} Tester
+ */
+function makeTester(htest, out) {
+  /** @type {number?} */
+  let pending;
+
+  /** @type {(r: boolean, info?: string) => void} */
+  function assert(result, info) {
+    if (typeof pending === 'number') {
+      pending -= 1;
+    }
+    const testNum = htest.finish(result);
+    if (result) {
+      out.ok(testNum, info);
+    } else {
+      out.notOk(testNum, info);
+    }
+  }
+
+  function truthy(/** @type {unknown} */ value, msg = 'should be truthy') {
+    assert(!!value, msg);
+  }
+
+  /** @type {(a: unknown, e: unknown) => void } */
+  function deepEqTest(actual, expected) {
+    try {
+      assert(deepEqual(actual, expected), 'should be deep equal');
+    } catch (detail) {
+      const summary = JSON.stringify({ actual, expected });
+      assert(false, `should be deep equal: ${summary} : ${detail.message}`);
+    }
+  }
+
+  const t = freeze({
+    plan(/** @type {number} */ count) {
+      pending = count;
+    },
+    get pending() {
+      return pending;
+    },
+    get context() {
+      return htest.context;
+    },
+    pass(/** @type {string} */ message) {
+      assert(true, message);
+    },
+    fail(/** @type {string} */ message) {
+      assert(false, message);
+    },
+    assert,
+    truthy,
+    falsy(/** @type {unknown} */ value, message = 'should be falsy') {
+      assert(!value, message);
+    },
+    true(/** @type {unknown} */ value, message = 'should be true') {
+      assert(value === true, message);
+    },
+    false(/** @type {unknown} */ value, message = 'should be false') {
+      assert(value === false, message);
+    },
+    /** @type {(a: unknown, b: unknown, m?: string) => void} */
+    is(a, b, message = 'should be identical') {
+      assert(Object.is(a, b), message);
+    },
+    /** @type {(a: unknown, b: unknown, m?: string) => void} */
+    not(a, b, message = 'should not be identical') {
+      assert(!Object.is(a, b), message);
+    },
+    deepEqual: deepEqTest,
+    /** @type {(a: unknown, b: unknown, m?: string) => void} */
+    notDeepEqual(a, b, message = 'should not be deep equal') {
+      assert(!deepEqual(a, b), message);
+    },
+    /** @type {(a: unknown, b: unknown, m?: string) => void} */
+    like(_a, _b, _message = 'should be like') {
+      throw Error('not implemented');
+    },
+    /** @type {(fn: () => unknown, e?: Expectation, m?: string) => void } */
+    throws(fn, expectation, message = `should throw like ${expectation}`) {
+      try {
+        fn();
+        assert(false, message);
+      } catch (ex) {
+        assert(checkExpectation(ex, expectation), message);
+      }
+    },
+    /** @type {(fn: () => unknown, m?: string) => void } */
+    notThrows(fn, message) {
+      try {
+        fn();
+      } catch (ex) {
+        assert(false, message);
+      }
+    },
+    /** @type {(thrower: () => Promise<unknown>, e?: Expectation, m?: string) => Promise<void> } */
+    async throwsAsync(
+      thrower,
+      expectation,
+      message = `should reject like ${expectation}`,
+    ) {
+      try {
+        await (typeof thrower === 'function' ? thrower() : thrower);
+        assert(false, message);
+      } catch (ex) {
+        assert(checkExpectation(ex, expectation), message);
+      }
+    },
+    /** @type {(thrower: () => Promise<unknown>, m?: string) => Promise<void> } */
+    async notThrowsAsync(nonThrower, message) {
+      try {
+        await (typeof nonThrower === 'function' ? nonThrower() : nonThrower);
+      } catch (ex) {
+        assert(false, message);
+      }
+    },
+  });
+
+  return t;
+}
+
+/** @type {(l: string, run: (t: Tester) => Promise<void>, opt: Harness?) => void } */
+function test(label, run, htestOpt) {
+  const htest = htestOpt || theHarness;
+  if (!htest) throw Error('no harness');
+
+  htest.defer(async () => {
+    const out = tapFormat(htest.send);
+    const t = makeTester(htest, out);
+    try {
+      out.diagnostic('start', label);
+      await run(t);
+      out.diagnostic('end', label);
+    } catch (ex) {
+      t.fail(`${label} threw: ${ex.message}`);
+    }
+    const pending = t.pending;
+    if (typeof pending === 'number' && pending !== 0) {
+      t.fail(`bad plan: ${t.pending} still to go`);
+    }
+  });
+}
+
+// TODO: test.skip, test.failing
+
+test.createHarness = createHarness;
+
+/** @type {(l: string, fn: () => Promise<void>) => void } */
+test.before = (label, fn) => {
+  if (typeof label === 'function') {
+    fn = label;
+    label = '';
+  }
+  if (!theHarness) throw Error('no harness');
+  theHarness.before(label, fn);
+};
+
+freeze(test);
+
+// export default test;
+// export { test };
+globalThis.test = test;

--- a/packages/xsnap/src/avaAssertXS.js
+++ b/packages/xsnap/src/avaAssertXS.js
@@ -13,9 +13,6 @@ const { freeze, keys } = Object;
  *
  * @type {(x: unknown, y: unknown) => Delta }
  * @typedef { null | { actual: unknown, expected?: unknown }} Delta
- * @throws { NotEqualError } when non-primitive objects differ
- *         with some details the difference;
- *         for example, what property is missing.
  */
 function deepDifference(x, y) {
   if (Object.is(x, y)) {

--- a/packages/xsnap/src/avaHandler.js
+++ b/packages/xsnap/src/avaHandler.js
@@ -1,0 +1,87 @@
+/* set up globalThis.handleCommand for running test scripts
+
+This is run using xsnap.evaluate() from avaXS.js .
+
+issueCommand is provided by xsnap.
+test global is defined in avaAssertXS.js .
+HandledPromise is defined by eventual send shim.
+
+*/
+/* global HandledPromise, issueCommand, test */
+// @ts-check
+// eslint-disable-next-line spaced-comment
+/// <reference types="ses" />
+// eslint-disable-next-line spaced-comment
+/// <reference types="@agoric/eventual-send" />
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+/**
+ * @param { TapMessage | { bundleSource: [string, ...unknown[]] } | Summary } item
+ * @typedef {import('./avaXS').Summary} Summary
+ */
+function send(item) {
+  const msg = encoder.encode(JSON.stringify(item)).buffer;
+  return issueCommand(msg);
+}
+
+/**
+ * @param { string } startFilename
+ * @param {...unknown} args
+ */
+const bundleSource = async (startFilename, ...args) => {
+  const msg = await send({ bundleSource: [startFilename, ...args] });
+  return JSON.parse(decoder.decode(msg));
+};
+
+const harness = test.createHarness(send);
+const testRequire = function require(specifier) {
+  switch (specifier) {
+    case 'ava':
+      return test;
+    case '@agoric/install-ses':
+      return undefined;
+    case '@agoric/install-metering-and-ses':
+      console.log('TODO: @agoric/install-metering-and-ses');
+      return undefined;
+    case '@agoric/bundle-source':
+      return bundleSource;
+    default:
+      throw Error(specifier);
+  }
+};
+
+function handler(msg) {
+  const src = decoder.decode(msg);
+  // @ts-ignore How do I get ses types in scope?!?!?!
+  const c = new Compartment({
+    require: testRequire,
+    __dirname,
+    __filename,
+    console,
+    // @ts-ignore
+    assert,
+    harden,
+    // @ts-ignore
+    HandledPromise,
+    TextEncoder,
+    TextDecoder,
+  });
+  try {
+    c.evaluate(`(${src}\n)()`);
+  } catch (ex) {
+    send({ status: 'not ok', message: `running test script: ${ex.message}` });
+  }
+  harness
+    .result()
+    .then(send)
+    .catch(ex =>
+      send({
+        status: 'not ok',
+        message: `getting test results: ${ex.message}`,
+      }),
+    );
+}
+
+globalThis.handleCommand = harden(handler);

--- a/packages/xsnap/src/avaXS.js
+++ b/packages/xsnap/src/avaXS.js
@@ -2,56 +2,98 @@
 
 Usage:
 
-agoric-sdk/packages/ERTP$ node -r esm ../xsnap/src/avaXS.js test/unitTests/test-*.js
+  node -r esm avaXS.js [--debug] test-*.js
 
 */
+
 // @ts-check
 
 /* eslint-disable no-await-in-loop */
 import '@agoric/install-ses';
 import { xsnap } from './xsnap';
 
+// scripts for use in xsnap subprocesses
+const SESboot = `../dist/bootstrap.umd.js`;
+const avaAssert = `./avaAssertXS.js`;
+const avaHandler = `./avaHandler.js`;
+
 const importMetaUrl = `file://${__filename}`;
 /** @type { (ref: string, readFile: typeof import('fs').promises.readFile ) => Promise<string> } */
 const asset = (ref, readFile) =>
   readFile(new URL(ref, importMetaUrl).pathname, 'utf8');
 
+/**
+ * When we bundle test scripts, we leave these externals
+ * as `require(...)` style graph exits and (in avaHandler.js)
+ * supply them via a `require` endowment
+ * on the Compartment used to run the script.
+ */
+const externals = [
+  'ava',
+  '@agoric/bundle-source',
+  '@agoric/install-ses',
+  '@agoric/install-metering-and-ses',
+];
+
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
 /**
- * @param {string} input
- * @param {string} src
- * @param {{
- *   withXSnap: (o: Object, fn: ((w: XSnap) => Promise<void>)) => Promise<void>,
- *   bundleSource: (...args: [string, ...unknown[]]) => Promise<Bundle>,
- *   resolve: typeof import('path').resolve,
- *   dirname: typeof import('path').dirname,
- *   debug: boolean,
- * }} io
+ * Run one test script in an xsnap subprocess.
  *
- * @typedef {{
- *   id?: number, status: 'ok' | 'not ok' | 'SKIP', message?: string
- * } | { plan: number} | { note: string, label?: string }} TapMessage
- * @typedef {ReturnType<typeof import('./xsnap').xsnap>} XSnap
- * @typedef {{ moduleFormat: string }} Bundle
+ * The subprocess reports back once for each test assertion.
+ *
+ * @typedef {{ id?: number, status: Status, message?: string }
+ *         | { plan: number}
+ *         | { note: string, label?: string }
+ * } TapMessage
+ *
+ * It also calls back if a test calls `bundleSource`.
+ *
+ * @typedef {{ moduleFormat: string, source: string }} Bundle
+ *
+ * And finally it reports back a summary of assertion results.
  *
  * @typedef {{
  *   pass: number,
  *   fail: number,
  *   total: number,
  * }} Summary
+ *
+ * @param { string } filename
+ * @param { string[] } preamble scripts to run in XS start compartment
+ * @param { boolean } verbose
+ * @param {{
+ *   spawnXSnap: (opts: object) => XSnap,
+ *   bundleSource: (...args: [string, ...unknown[]]) => Promise<Bundle>,
+ *   resolve: typeof import('path').resolve,
+ *   dirname: typeof import('path').dirname,
+ * }} io
+ * @returns {Promise<{
+ *   qty: number,
+ *   byStatus: Record<Status, number>
+ * }>} quantity of tests run and breakdown by status
+ *
+ * @typedef { 'ok' | 'not ok' | 'SKIP' } Status
+ * @typedef {ReturnType<typeof import('./xsnap').xsnap>} XSnap
  */
-async function runTest(
-  input,
-  src,
-  { withXSnap, bundleSource, resolve, dirname, debug },
+async function runTestScript(
+  filename,
+  preamble,
+  verbose,
+  { spawnXSnap, bundleSource, resolve, dirname },
 ) {
-  let label = '';
+  const testBundle = await bundleSource(filename, 'getExport', { externals });
+
   let qty = 0;
   const byStatus = { ok: 0, 'not ok': 0, SKIP: 0 };
+  let label = '';
 
-  /** @type { (msg: ArrayBuffer) => Promise<ArrayBuffer> } */
+  /**
+   * Handle callback "command" from xsnap subprocess.
+   *
+   *  @type { (msg: ArrayBuffer) => Promise<ArrayBuffer> }
+   */
   async function handleCommand(message) {
     /**
      * See also send() in avaHandler.js
@@ -69,43 +111,43 @@ async function runTest(
 
     if ('label' in msg) {
       label = msg.label || label;
-      if (debug) console.log(`${input}: ${msg.label} ${msg.note}`);
+      if (verbose) {
+        console.log(`${filename}: ${msg.label} ${msg.note}`);
+      }
     }
     if ('status' in msg) {
       byStatus[msg.status] += 1;
       qty += 1;
       if (msg.status === 'not ok') {
-        console.warn({ ...msg, input, label });
+        console.warn({ ...msg, filename, label });
       }
     }
     return encoder.encode('null');
   }
 
-  const testPath = resolve(input);
-  const literal = JSON.stringify;
-
   // ISSUE: only works in one file / dir
-  // TODO: migrate to import.meta.url
+  const literal = JSON.stringify;
+  const testPath = resolve(filename);
   const pathGlobalsKludge = `
     globalThis.__filename = ${literal(testPath)};
     globalThis.__dirname = ${literal(dirname(testPath))};
    `;
-  await withXSnap({ name: input, handleCommand }, async worker => {
+
+  const worker = spawnXSnap({ handleCommand });
+  try {
+    for (const script of preamble) {
+      await worker.evaluate(script);
+    }
+
     await worker.evaluate(pathGlobalsKludge);
-    await worker.issueStringCommand(src);
-  });
+
+    // Send the test script to avaHandler.
+    await worker.issueStringCommand(testBundle.source);
+  } finally {
+    await worker.terminate();
+  }
 
   return { qty, byStatus };
-}
-
-/** @type {(argv: string[], name: string) => boolean } */
-function extractFlag(argv, name) {
-  const ix = argv.indexOf(name);
-  if (ix >= 0) {
-    argv.splice(ix, 1);
-    return true;
-  }
-  return false;
 }
 
 /**
@@ -123,60 +165,42 @@ async function main(
   argv,
   { bundleSource, spawn, osType, readFile, resolve, dirname },
 ) {
-  async function testSource(input) {
-    const bundle = await bundleSource(input, 'getExport', {
-      externals: [
-        'ava',
-        '@agoric/bundle-source',
-        '@agoric/install-ses',
-        '@agoric/install-metering-and-ses',
-      ],
+  const args = argv.slice(2);
+  const debug = args[0] === '--debug';
+  const files = debug ? args.slice(1) : args;
+
+  const spawnXSnap = opts =>
+    xsnap({
+      ...opts,
+      debug,
+      spawn,
+      os: osType(),
+      meteringLimit: 0,
+      stdout: 'inherit',
+      stderr: 'inherit',
     });
-    return bundle.source;
-  }
-
-  const sesShim = await asset(`../dist/bootstrap.umd.js`, readFile);
-  const tinyAva = await asset(`./avaAssertXS.js`, readFile);
-  const avaHandler = await asset(`./avaHandler.js`, readFile);
-
-  const debug = extractFlag(argv, '--debug');
 
   // we only use import() in type annotations
   const hideImport = (/** @type { string } */ src) =>
     src.replace(/import\(/g, '');
 
-  async function withXSnap(opts, thunk) {
-    const worker = xsnap({
-      meteringLimit: 0,
-      spawn,
-      os: osType(),
-      stdout: 'inherit',
-      stderr: 'inherit',
-      debug,
-      ...opts,
-    });
-    try {
-      await worker.evaluate(sesShim);
-      await worker.evaluate(hideImport(tinyAva));
-      await worker.evaluate(hideImport(avaHandler));
-      return await thunk(worker);
-    } finally {
-      worker.terminate();
-    }
-  }
+  const preamble = [
+    await asset(SESboot, readFile),
+    hideImport(await asset(avaAssert, readFile)),
+    hideImport(await asset(avaHandler, readFile)),
+  ];
 
   let totalTests = 0;
   const stats = { ok: 0, 'not ok': 0, SKIP: 0 };
-  for (const input of argv.slice(2)) {
-    console.log('# test script:', input);
-    const src = await testSource(input);
 
-    const { qty, byStatus } = await runTest(input, src, {
-      withXSnap,
+  for (const filename of files) {
+    console.log('# test script:', filename);
+
+    const { qty, byStatus } = await runTestScript(filename, preamble, debug, {
+      spawnXSnap,
       bundleSource,
       resolve,
       dirname,
-      debug,
     });
 
     totalTests += qty;
@@ -191,7 +215,7 @@ async function main(
 
 /* eslint-disable global-require */
 if (require.main === module) {
-  main(process.argv, {
+  main([...process.argv], {
     bundleSource: require('@agoric/bundle-source').default,
     spawn: require('child_process').spawn,
     osType: require('os').type,

--- a/packages/xsnap/src/avaXS.js
+++ b/packages/xsnap/src/avaXS.js
@@ -1,0 +1,209 @@
+/* avaXS - ava style test runner for XS
+
+Usage:
+
+agoric-sdk/packages/ERTP$ node -r esm ../xsnap/src/avaXS.js test/unitTests/test-*.js
+
+*/
+// @ts-check
+
+/* eslint-disable no-await-in-loop */
+import '@agoric/install-ses';
+import { xsnap } from './xsnap';
+
+const importMetaUrl = `file://${__filename}`;
+/** @type { (ref: string, readFile: typeof import('fs').promises.readFile ) => Promise<string> } */
+const asset = (ref, readFile) =>
+  readFile(new URL(ref, importMetaUrl).pathname, 'utf8');
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+/**
+ * @param {string} input
+ * @param {string} src
+ * @param {{
+ *   withXSnap: (o: Object, fn: ((w: XSnap) => Promise<void>)) => Promise<void>,
+ *   bundleSource: (...args: [string, ...unknown[]]) => Promise<Bundle>,
+ *   resolve: typeof import('path').resolve,
+ *   dirname: typeof import('path').dirname,
+ *   debug: boolean,
+ * }} io
+ *
+ * @typedef {{
+ *   id?: number, status: 'ok' | 'not ok' | 'SKIP', message?: string
+ * } | { plan: number} | { note: string, label?: string }} TapMessage
+ * @typedef {ReturnType<typeof import('./xsnap').xsnap>} XSnap
+ * @typedef {{ moduleFormat: string }} Bundle
+ *
+ * @typedef {{
+ *   pass: number,
+ *   fail: number,
+ *   total: number,
+ * }} Summary
+ */
+async function runTest(
+  input,
+  src,
+  { withXSnap, bundleSource, resolve, dirname, debug },
+) {
+  let label = '';
+  let qty = 0;
+  const byStatus = { ok: 0, 'not ok': 0, SKIP: 0 };
+
+  /** @type { (msg: ArrayBuffer) => Promise<ArrayBuffer> } */
+  async function handleCommand(message) {
+    /**
+     * See also send() in avaHandler.js
+     *
+     * @type { TapMessage | { bundleSource: [string, ...unknown[]] } | Summary }
+     */
+    const msg = JSON.parse(decoder.decode(message));
+    // console.log(input, msg, qty, byStatus);
+
+    if ('bundleSource' in msg) {
+      const [startFilename, ...rest] = msg.bundleSource;
+      const bundle = await bundleSource(startFilename, ...rest);
+      return encoder.encode(JSON.stringify(bundle));
+    }
+
+    if ('label' in msg) {
+      label = msg.label || label;
+      if (debug) console.log(`${input}: ${msg.label} ${msg.note}`);
+    }
+    if ('status' in msg) {
+      byStatus[msg.status] += 1;
+      qty += 1;
+      if (msg.status === 'not ok') {
+        console.warn({ ...msg, input, label });
+      }
+    }
+    return encoder.encode('null');
+  }
+
+  const testPath = resolve(input);
+  const literal = JSON.stringify;
+
+  // ISSUE: only works in one file / dir
+  // TODO: migrate to import.meta.url
+  const pathGlobalsKludge = `
+    globalThis.__filename = ${literal(testPath)};
+    globalThis.__dirname = ${literal(dirname(testPath))};
+   `;
+  await withXSnap({ name: input, handleCommand }, async worker => {
+    await worker.evaluate(pathGlobalsKludge);
+    await worker.issueStringCommand(src);
+  });
+
+  return { qty, byStatus };
+}
+
+/** @type {(argv: string[], name: string) => boolean } */
+function extractFlag(argv, name) {
+  const ix = argv.indexOf(name);
+  if (ix >= 0) {
+    argv.splice(ix, 1);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * @param {string[]} argv
+ * @param {{
+ *   bundleSource: typeof import('@agoric/bundle-source').default,
+ *   spawn: typeof import('child_process')['spawn'],
+ *   osType: typeof import('os')['type'],
+ *   readFile: typeof import('fs')['promises']['readFile'],
+ *   resolve: typeof import('path').resolve,
+ *   dirname: typeof import('path').dirname,
+ * }} io
+ */
+async function main(
+  argv,
+  { bundleSource, spawn, osType, readFile, resolve, dirname },
+) {
+  async function testSource(input) {
+    const bundle = await bundleSource(input, 'getExport', {
+      externals: [
+        'ava',
+        '@agoric/bundle-source',
+        '@agoric/install-ses',
+        '@agoric/install-metering-and-ses',
+      ],
+    });
+    return bundle.source;
+  }
+
+  const sesShim = await asset(`../dist/bootstrap.umd.js`, readFile);
+  const tinyAva = await asset(`./avaAssertXS.js`, readFile);
+  const avaHandler = await asset(`./avaHandler.js`, readFile);
+
+  const debug = extractFlag(argv, '--debug');
+
+  // we only use import() in type annotations
+  const hideImport = (/** @type { string } */ src) =>
+    src.replace(/import\(/g, '');
+
+  async function withXSnap(opts, thunk) {
+    const worker = xsnap({
+      meteringLimit: 0,
+      spawn,
+      os: osType(),
+      stdout: 'inherit',
+      stderr: 'inherit',
+      debug,
+      ...opts,
+    });
+    try {
+      await worker.evaluate(sesShim);
+      await worker.evaluate(hideImport(tinyAva));
+      await worker.evaluate(hideImport(avaHandler));
+      return await thunk(worker);
+    } finally {
+      worker.terminate();
+    }
+  }
+
+  let totalTests = 0;
+  const stats = { ok: 0, 'not ok': 0, SKIP: 0 };
+  for (const input of argv.slice(2)) {
+    console.log('# test script:', input);
+    const src = await testSource(input);
+
+    const { qty, byStatus } = await runTest(input, src, {
+      withXSnap,
+      bundleSource,
+      resolve,
+      dirname,
+      debug,
+    });
+
+    totalTests += qty;
+    Object.entries(byStatus).forEach(([status, q]) => {
+      stats[status] += q;
+    });
+  }
+
+  console.log({ totalTests, stats });
+  return stats['not ok'] > 0 ? 1 : 0;
+}
+
+/* eslint-disable global-require */
+if (require.main === module) {
+  main(process.argv, {
+    bundleSource: require('@agoric/bundle-source').default,
+    spawn: require('child_process').spawn,
+    osType: require('os').type,
+    readFile: require('fs').promises.readFile,
+    resolve: require('path').resolve,
+    dirname: require('path').dirname,
+  })
+    .then(status => {
+      process.exit(status);
+    })
+    .catch(err => {
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/packages/xsnap/src/globals.d.ts
+++ b/packages/xsnap/src/globals.d.ts
@@ -1,0 +1,5 @@
+declare var issueCommand: (msg: ArrayBuffer) => ArrayBuffer;
+
+namespace global {
+  declare var issueCommand: (msg: ArrayBuffer) => ArrayBuffer;
+}


### PR DESCRIPTION
progress toward #370 ; zoe is still TODO

We add the following scripts for ERTP, zoe:

```json
    "test:xs": "yarn test:xs-unit && yarn test:xs-worker",
    "test:xs-unit": "node -r esm ../xsnap/src/avaXS.js test/unitTests/test-*.js",
    "test:xs-worker": "WORKER_TYPE=xs-worker ava",
```

The following parts were broken out as their own PRs:
  - fix(xsnap): shim HandledPromise before lockdown() 86ff061
  - chore: xsnap maintenance (unhandled rejections, stack bounds checking)

and we decided against...
  - feat(bundle-source): support import.meta.url d2fd954