### PR TITLE
refactor: use for-await-of in updateDebt.js

### DIFF
--- a/packages/zoe/src/contracts/loan/borrow.js
+++ b/packages/zoe/src/contracts/loan/borrow.js
@@ -11,6 +11,7 @@ import {
   trade,
   getAmountOut,
   multiplyBy,
+  getTimestamp,
 } from '../../contractSupport';
 
 import { scheduleLiquidation } from './scheduleLiquidation';
@@ -59,6 +60,8 @@ export const makeBorrowInvitation = (zcf, config) => {
       loanMath.isGTE(collateralPriceInLoanBrand, requiredMargin),
       X`The required margin is ${requiredMargin.value}% but collateral only had value of ${collateralPriceInLoanBrand.value}`,
     );
+
+    const timestamp = getTimestamp(quote);
 
     // Assert that the collateralGiven has not changed after the AWAIT
     assert(
@@ -113,6 +116,7 @@ export const makeBorrowInvitation = (zcf, config) => {
       periodNotifier,
       interestRate,
       interestPeriod,
+      basetime: timestamp,
       zcf,
       configMinusGetDebt: {
         ...config,
@@ -124,7 +128,7 @@ export const makeBorrowInvitation = (zcf, config) => {
       getDebt,
       getDebtNotifier,
       getLastCalculationTimestamp,
-    } = makeDebtCalculator(harden(debtCalculatorConfig));
+    } = await makeDebtCalculator(harden(debtCalculatorConfig));
 
     /** @type {LoanConfigWithBorrower} */
     const configWithBorrower = {

--- a/packages/zoe/src/contracts/loan/borrow.js
+++ b/packages/zoe/src/contracts/loan/borrow.js
@@ -128,7 +128,7 @@ export const makeBorrowInvitation = (zcf, config) => {
       getDebt,
       getDebtNotifier,
       getLastCalculationTimestamp,
-    } = await makeDebtCalculator(harden(debtCalculatorConfig));
+    } = makeDebtCalculator(harden(debtCalculatorConfig));
 
     /** @type {LoanConfigWithBorrower} */
     const configWithBorrower = {

--- a/packages/zoe/src/contracts/loan/index.js
+++ b/packages/zoe/src/contracts/loan/index.js
@@ -72,7 +72,6 @@ const start = async zcf => {
   assert(autoswapInstance, X`autoswapInstance must be provided`);
   assert(priceAuthority, X`priceAuthority must be provided`);
   assert(periodNotifier, X`periodNotifier must be provided`);
-  Nat(interestRate);
   Nat(interestPeriod);
 
   /** @type {LoanTerms} */

--- a/packages/zoe/src/contracts/loan/types.js
+++ b/packages/zoe/src/contracts/loan/types.js
@@ -177,6 +177,8 @@
  * @property {ContractFacet} zcf
  *
  * @property {LoanConfigWithBorrowerMinusDebt} configMinusGetDebt
+ * @property {Timestamp} basetime The starting point from which to calculate
+ * interest.
  */
 
 /**

--- a/packages/zoe/src/contracts/loan/updateDebt.js
+++ b/packages/zoe/src/contracts/loan/updateDebt.js
@@ -26,7 +26,7 @@ export const calculateInterest = (oldDebt, interestRate) =>
   multiplyBy(oldDebt, interestRate);
 
 /** @type {MakeDebtCalculator} */
-export const makeDebtCalculator = async debtCalculatorConfig => {
+export const makeDebtCalculator = debtCalculatorConfig => {
   const {
     calcInterestFn = calculateInterest,
     originalDebt,

--- a/packages/zoe/src/contracts/loan/updateDebt.js
+++ b/packages/zoe/src/contracts/loan/updateDebt.js
@@ -4,8 +4,10 @@ import '../../../exported';
 import { Far } from '@agoric/marshal';
 import {
   makeNotifierKit,
-  makeAsyncIterableFromNotifier,
+  // After #2511, replace with observeNotifier with swapped arguments
+  updateFromNotifier,
 } from '@agoric/notifier';
+import { assert, details as X } from '@agoric/assert';
 
 import { scheduleLiquidation } from './scheduleLiquidation';
 import { makeRatio, multiplyBy } from '../../contractSupport';
@@ -73,16 +75,38 @@ export const makeDebtCalculator = debtCalculatorConfig => {
     }
   };
 
-  const handleDebt = async () => {
-    for await (const value of makeAsyncIterableFromNotifier(periodNotifier)) {
-      updateDebt(value);
-    }
-  };
-  handleDebt().catch(() =>
-    console.error(
-      `Unable to updateDebt originally:${originalDebt}, started: ${basetime}, debt: ${debt}`,
-    ),
-  );
+  const periodObserver = harden({
+    updateState: timestamp => {
+      let updatedLoan = false;
+      // we could calculate the number of required updates and multiply by a power
+      // of the interest rate, but this seems easier to read.
+      while (lastCalculationTimestamp + interestPeriod <= timestamp) {
+        lastCalculationTimestamp += interestPeriod;
+        const interest = calcInterestFn(debt, interestRate);
+        debt = loanMath.add(debt, interest);
+        updatedLoan = true;
+      }
+      if (updatedLoan) {
+        debtNotifierUpdater.updateState(debt);
+        scheduleLiquidation(zcf, config);
+      }
+    },
+    fail: reason => {
+      assert.note(
+        reason,
+        X`Period problem: ${originalDebt}, started: ${basetime}, debt: ${debt}`,
+      );
+      console.error(reason);
+    },
+  });
+
+  updateFromNotifier(periodObserver, periodNotifier).catch(reason => {
+    assert.note(
+      reason,
+      X`Unable to updateDebt originally: ${originalDebt}, started: ${basetime}, debt: ${debt}`,
+    );
+    console.error(reason);
+  });
 
   debtNotifierUpdater.updateState(debt);
 

--- a/packages/zoe/src/contracts/loan/updateDebt.js
+++ b/packages/zoe/src/contracts/loan/updateDebt.js
@@ -6,12 +6,10 @@ import { makeNotifierKit, observeNotifier } from '@agoric/notifier';
 import { assert, details as X } from '@agoric/assert';
 
 import { scheduleLiquidation } from './scheduleLiquidation';
-import { makeRatio, multiplyBy } from '../../contractSupport';
+import { multiplyBy } from '../../contractSupport';
 
 // Update the debt by adding the new interest on every period, as
 // indicated by the periodNotifier
-
-const BASIS_POINT_DENOMINATOR = 10000n;
 
 /**
  * @type {CalcInterestFn} Calculate the interest using an interest
@@ -37,11 +35,6 @@ export const makeDebtCalculator = debtCalculatorConfig => {
     configMinusGetDebt,
   } = debtCalculatorConfig;
   let debt = originalDebt;
-  const interestRatio = makeRatio(
-    interestRate,
-    debt.brand,
-    BASIS_POINT_DENOMINATOR,
-  );
 
   // the last period-end for which interest has been added
   let lastCalculationTimestamp = basetime;

--- a/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
@@ -310,14 +310,14 @@ test('getDebtNotifier with interest', async t => {
   ).getUpdateSince();
   t.deepEqual(originalDebt, maxLoan);
 
-  periodUpdater.updateState(5);
+  periodUpdater.updateState(6);
 
   const { value: debtCompounded1, updateCount: updateCount1 } = await E(
     debtNotifier,
   ).getUpdateSince(updateCount);
   t.deepEqual(debtCompounded1, loanKit.amountMath.make(40020));
 
-  periodUpdater.updateState(10);
+  periodUpdater.updateState(11);
 
   const { value: debtCompounded2 } = await E(debtNotifier).getUpdateSince(
     updateCount1,
@@ -375,7 +375,7 @@ test('aperiodic interest', async t => {
   ).getUpdateSince();
   t.deepEqual(originalDebt, maxLoan);
 
-  periodUpdater.updateState(5);
+  periodUpdater.updateState(6);
 
   const { value: debtCompounded1, updateCount: updateCount1 } = await E(
     debtNotifier,
@@ -383,16 +383,16 @@ test('aperiodic interest', async t => {
   t.deepEqual(debtCompounded1, loanKit.amountMath.make(40020));
 
   // skip ahead a notification
-  periodUpdater.updateState(15);
+  periodUpdater.updateState(16);
 
   // both debt notifications are received
   const { value: debtCompounded2, updateCount: updateCount2 } = await E(
     debtNotifier,
   ).getUpdateSince(updateCount1);
-  t.is(15, await E(borrowFacet).getLastCalculationTimestamp());
+  t.is(await E(borrowFacet).getLastCalculationTimestamp(), 16);
   t.deepEqual(debtCompounded2, loanKit.amountMath.make(40060));
 
-  periodUpdater.updateState(20);
+  periodUpdater.updateState(21);
   const { value: debtCompounded3 } = await E(debtNotifier).getUpdateSince(
     updateCount2,
   );
@@ -400,7 +400,8 @@ test('aperiodic interest', async t => {
 });
 
 // In this test, the updates are expected at multiples of 5, but they show up at
-// multiples of 4 instead. We should charge interest after 8, 12, 16, 20, 28
+// multiples of 4 instead. The starting time is 1. We should charge interest
+// after 9, 13, 17, 21, 29
 test('short periods', async t => {
   const {
     borrowFacet,
@@ -417,46 +418,46 @@ test('short periods', async t => {
   ).getUpdateSince();
   t.deepEqual(originalDebt, maxLoan);
 
-  periodUpdater.updateState(4);
-  t.is(0, await E(borrowFacet).getLastCalculationTimestamp());
+  periodUpdater.updateState(5);
+  t.is(await E(borrowFacet).getLastCalculationTimestamp(), 1n);
 
-  periodUpdater.updateState(8);
+  periodUpdater.updateState(9);
   const { value: debtCompounded1, updateCount: updateCount1 } = await E(
     debtNotifier,
   ).getUpdateSince(updateCount);
   t.deepEqual(debtCompounded1, loanKit.amountMath.make(40020));
-  t.is(5, await E(borrowFacet).getLastCalculationTimestamp());
+  t.is(await E(borrowFacet).getLastCalculationTimestamp(), 6n);
 
-  periodUpdater.updateState(12);
+  periodUpdater.updateState(14);
   const { value: debtCompounded2, updateCount: updateCount2 } = await E(
     debtNotifier,
   ).getUpdateSince(updateCount1);
   t.deepEqual(debtCompounded2, loanKit.amountMath.make(40040));
-  t.is(10, await E(borrowFacet).getLastCalculationTimestamp());
+  t.is(await E(borrowFacet).getLastCalculationTimestamp(), 11n);
 
-  periodUpdater.updateState(16);
+  periodUpdater.updateState(17);
   const { value: debtCompounded3, updateCount: updateCount3 } = await E(
     debtNotifier,
   ).getUpdateSince(updateCount2);
   t.deepEqual(debtCompounded3, loanKit.amountMath.make(40060));
-  t.is(15, await E(borrowFacet).getLastCalculationTimestamp());
+  t.is(await E(borrowFacet).getLastCalculationTimestamp(), 16n);
 
-  periodUpdater.updateState(20);
+  periodUpdater.updateState(21);
   const { value: debtCompounded4, updateCount: updateCount4 } = await E(
     debtNotifier,
   ).getUpdateSince(updateCount3);
   t.deepEqual(debtCompounded4, loanKit.amountMath.make(40080));
-  t.is(20, await E(borrowFacet).getLastCalculationTimestamp());
+  t.is(await E(borrowFacet).getLastCalculationTimestamp(), 21n);
 
-  periodUpdater.updateState(24);
-  t.is(20, await E(borrowFacet).getLastCalculationTimestamp());
+  periodUpdater.updateState(25);
+  t.is(await E(borrowFacet).getLastCalculationTimestamp(), 21n);
 
-  periodUpdater.updateState(28);
+  periodUpdater.updateState(29);
   const { value: debtCompounded5 } = await E(debtNotifier).getUpdateSince(
     updateCount4,
   );
   t.deepEqual(debtCompounded5, loanKit.amountMath.make(40100));
-  t.is(25, await E(borrowFacet).getLastCalculationTimestamp());
+  t.is(await E(borrowFacet).getLastCalculationTimestamp(), 26n);
 });
 
 test.todo('borrow bad proposal');

--- a/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
@@ -85,7 +85,7 @@ const setupBorrow = async (
     makeAddCollateralInvitation,
     periodNotifier,
     interestRate,
-    interestPeriod: 5,
+    interestPeriod: 5n,
   };
   const borrowInvitation = makeBorrowInvitation(zcf, config);
   return {
@@ -303,7 +303,7 @@ test('getDebtNotifier with interest', async t => {
     zoe,
     loanKit,
   } = await setupBorrowFacet(100000, 40000);
-  periodUpdater.updateState(0);
+  periodUpdater.updateState(0n);
 
   const debtNotifier = await E(borrowFacet).getDebtNotifier();
 
@@ -391,7 +391,7 @@ test('aperiodic interest', async t => {
   const { value: debtCompounded2, updateCount: updateCount2 } = await E(
     debtNotifier,
   ).getUpdateSince(updateCount1);
-  t.is(await E(borrowFacet).getLastCalculationTimestamp(), 16);
+  t.is(await E(borrowFacet).getLastCalculationTimestamp(), 16n);
   t.deepEqual(debtCompounded2, loanKit.amountMath.make(40060));
 
   periodUpdater.updateState(21);
@@ -447,7 +447,7 @@ test('interest starting from non-zero time', async t => {
     updateCount,
   );
   t.deepEqual(debtCompounded2, loanKit.amountMath.make(40020));
-  t.is(await E(borrowFacet).getLastCalculationTimestamp(), 9);
+  t.is(await E(borrowFacet).getLastCalculationTimestamp(), 9n);
 });
 
 // In this test, the updates are expected at multiples of 5, but they show up at

--- a/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
@@ -30,6 +30,8 @@ import { makeAddCollateralInvitation } from '../../../../src/contracts/loan/addC
 import { makeCloseLoanInvitation } from '../../../../src/contracts/loan/close';
 import { makeRatio } from '../../../../src/contractSupport';
 
+const BASIS_POINTS = 10000;
+
 const setupBorrow = async (
   maxLoanValue = 100,
   timer = buildManualTimer(console.log),
@@ -74,7 +76,7 @@ const setupBorrow = async (
     notifier: periodNotifier,
   } = makeNotifierKit();
 
-  const interestRate = 5;
+  const interestRate = makeRatio(5, loanKit.brand, BASIS_POINTS);
 
   const config = {
     lenderSeat,


### PR DESCRIPTION
replaced a complex pile of iteration handling with a for-await-of loop.

Uncovered a bug in initializing the debt calculator: it would have
charged interest from the beginning of time.

It's not at all clear to me what the loan contract should do in case of failure in adding debt.

closes: #2258