### PR TITLE
chore: remove other versions of nat entirely from agoric-sdk

### DIFF
--- a/packages/SwingSet/src/devices/timer-src.js
+++ b/packages/SwingSet/src/devices/timer-src.js
@@ -39,6 +39,7 @@ function copyState(schedState) {
 
   const newSchedule = [];
   for (const { time, handlers } of schedState) {
+    assert.typeof(time, 'bigint');
     // we want a mutable copy of the handlers array, but not its contents.
     newSchedule.push({ time, handlers: handlers.slice(0) });
   }
@@ -47,7 +48,7 @@ function copyState(schedState) {
 
 /**
  * @typedef {Object} Event
- * @property {number} time
+ * @property {bigint} time
  * @property {Array<IndexedHandler>} handlers
  *
  * @typedef {Object} IndexedHandler
@@ -55,7 +56,7 @@ function copyState(schedState) {
  * @property {Waker} handler
  *
  * @typedef {Object} Waker
- * @property {(now: number) => void} wake
+ * @property {(now: bigint) => void} wake
  */
 
 /**
@@ -85,6 +86,7 @@ function makeTimerMap(state = undefined) {
   }
 
   function eventsFor(time) {
+    assert.typeof(time, 'bigint');
     for (let i = 0; i < schedule.length && schedule[i].time <= time; i += 1) {
       if (schedule[i].time === time) {
         return schedule[i];
@@ -99,6 +101,7 @@ function makeTimerMap(state = undefined) {
   // in the order of their deadlines. If so, we should probably ensure that the
   // recorded deadlines don't have finer granularity than the turns.
   function add(time, handler, repeater = undefined) {
+    assert.typeof(time, 'bigint');
     const handlerRecord =
       typeof repeater === 'number' ? { handler, index: repeater } : { handler };
     const { handlers: records } = eventsFor(time);
@@ -109,6 +112,7 @@ function makeTimerMap(state = undefined) {
 
   // Remove and return all pairs indexed by numbers up to target
   function removeEventsThrough(target) {
+    assert.typeof(target, 'bigint');
     const returnValues = [];
     // remove events from last to first so as not to disturb the indexes.
     const reversedIndexesToRemove = [];
@@ -155,7 +159,10 @@ function makeTimerMap(state = undefined) {
 }
 
 function nextScheduleTime(index, repeaters, lastPolled) {
+  assert.typeof(lastPolled, 'bigint');
   const { startTime, interval } = repeaters[index];
+  assert.typeof(startTime, 'bigint');
+  assert.typeof(interval, 'bigint');
   // return the smallest value of `startTime + N * interval` after lastPolled
   return lastPolled + interval - ((lastPolled - startTime) % interval);
 }
@@ -169,6 +176,7 @@ function curryPollFn(SO, repeaters, deadlines, getLastPolledFn, saveStateFn) {
     let wokeAnything = false;
     timeAndEvents.forEach(events => {
       const { time, handlers } = events;
+      assert.typeof(time, 'bigint');
       for (const { index, handler } of handlers) {
         if (typeof index === 'number') {
           SO(handler).wake(time);
@@ -280,7 +288,7 @@ export function buildRootDeviceNode(tools) {
         startTime: Nat(startTime),
         interval: Nat(interval),
       });
-      nextRepeater += 1;
+      nextRepeater += 1n;
       saveState();
       return index;
     },

--- a/packages/SwingSet/src/devices/timer-src.js
+++ b/packages/SwingSet/src/devices/timer-src.js
@@ -216,7 +216,7 @@ export function buildRootDeviceNode(tools) {
   // might be a time from Date.now(). The current time is not reflected back
   // to the user.
   let lastPolled = restart ? restart.lastPolled : 0n;
-  let nextRepeater = restart ? restart.nextRepeater : 0n;
+  let nextRepeater = restart ? restart.nextRepeater : 0;
 
   function getLastPolled() {
     return lastPolled;
@@ -288,7 +288,7 @@ export function buildRootDeviceNode(tools) {
         startTime: Nat(startTime),
         interval: Nat(interval),
       });
-      nextRepeater += 1n;
+      nextRepeater += 1;
       saveState();
       return index;
     },

--- a/packages/SwingSet/test/test-timer-device.js
+++ b/packages/SwingSet/test/test-timer-device.js
@@ -4,38 +4,38 @@ import { makeTimerMap, curryPollFn } from '../src/devices/timer-src';
 
 test('multiMap multi store', t => {
   const mm = makeTimerMap();
-  mm.add(3, 'threeA');
-  mm.add(3, 'threeB');
-  const threes = mm.removeEventsThrough(4);
+  mm.add(3n, 'threeA');
+  mm.add(3n, 'threeB');
+  const threes = mm.removeEventsThrough(4n);
   t.is(threes.length, 1);
   t.deepEqual(threes[0], {
-    time: 3,
+    time: 3n,
     handlers: [{ handler: 'threeA' }, { handler: 'threeB' }],
   });
-  t.is(mm.removeEventsThrough(10).length, 0);
+  t.is(mm.removeEventsThrough(10n).length, 0);
 });
 
 test('multiMap store multiple keys', t => {
   const mm = makeTimerMap();
-  mm.add(3, 'threeA');
-  mm.add(13, 'threeB');
-  t.is(mm.removeEventsThrough(4).length, 1);
-  t.is(mm.removeEventsThrough(10).length, 0);
-  const thirteens = mm.removeEventsThrough(13);
+  mm.add(3n, 'threeA');
+  mm.add(13n, 'threeB');
+  t.is(mm.removeEventsThrough(4n).length, 1);
+  t.is(mm.removeEventsThrough(10n).length, 0);
+  const thirteens = mm.removeEventsThrough(13n);
   t.is(thirteens.length, 1, `${thirteens}`);
 });
 
 test('multiMap remove key', t => {
   const mm = makeTimerMap();
-  mm.add(3, 'threeA');
-  mm.add(13, 'threeB');
+  mm.add(3n, 'threeA');
+  mm.add(13n, 'threeB');
   t.deepEqual(mm.remove('not There'), []);
-  t.deepEqual(mm.remove('threeA'), [3]);
-  mm.remove(3, 'threeA');
-  t.is(mm.removeEventsThrough(10).length, 0);
-  const thirteens = mm.removeEventsThrough(13);
+  t.deepEqual(mm.remove('threeA'), [3n]);
+  mm.remove(3n, 'threeA');
+  t.is(mm.removeEventsThrough(10n).length, 0);
+  const thirteens = mm.removeEventsThrough(13n);
   t.is(thirteens.length, 1);
-  t.deepEqual(thirteens[0], { time: 13, handlers: [{ handler: 'threeB' }] });
+  t.deepEqual(thirteens[0], { time: 13n, handlers: [{ handler: 'threeB' }] });
 });
 
 function fakeSO(o) {
@@ -77,16 +77,16 @@ function makeFakeTimer(initialVal) {
 
 test('Timer schedule single event', t => {
   const schedule = makeTimerMap();
-  const fakeTimer = makeFakeTimer(1);
+  const fakeTimer = makeFakeTimer(1n);
   const lastPolled = fakeTimer.getLastPolled;
   const poll = curryPollFn(fakeSO, [], schedule, lastPolled, _ => {});
-  t.falsy(poll(1)); // false when nothing is woken
+  t.falsy(poll(1n)); // false when nothing is woken
   const handler = makeHandler();
-  schedule.add(2, handler);
-  t.is(fakeTimer.getLastPolled(), 1);
-  t.truthy(poll(4));
+  schedule.add(2n, handler);
+  t.is(fakeTimer.getLastPolled(), 1n);
+  t.truthy(poll(4n));
   t.is(handler.getCalls(), 1);
-  t.is(handler.getArgs()[0], 2);
+  t.is(handler.getArgs()[0], 2n);
 });
 
 test('Timer schedule multiple events', t => {
@@ -94,47 +94,47 @@ test('Timer schedule multiple events', t => {
   const fakeTimer = makeFakeTimer(1);
   const lastPolled = fakeTimer.getLastPolled;
   const poll = curryPollFn(fakeSO, [], schedule, lastPolled, _ => {});
-  t.falsy(poll(1)); // false when nothing is woken
+  t.falsy(poll(1n)); // false when nothing is woken
   const handler1 = makeHandler();
   const handler2 = makeHandler();
-  schedule.add(3, handler1);
-  schedule.add(4, handler1);
-  schedule.add(2, handler2);
+  schedule.add(3n, handler1);
+  schedule.add(4n, handler1);
+  schedule.add(2n, handler2);
   t.is(lastPolled(), 1);
-  t.truthy(poll(4));
+  t.truthy(poll(4n));
   t.is(handler1.getCalls(), 2);
   t.is(handler2.getCalls(), 1);
-  t.deepEqual(handler1.getArgs(), [3, 4]);
-  t.deepEqual(handler2.getArgs(), [2]);
+  t.deepEqual(handler1.getArgs(), [3n, 4n]);
+  t.deepEqual(handler2.getArgs(), [2n]);
 });
 
 test('Timer schedule repeated event first', t => {
   const repeaterIndex = 0;
   const schedule = makeTimerMap();
-  const fakeTimer = makeFakeTimer(1);
+  const fakeTimer = makeFakeTimer(1n);
   const lastPolled = fakeTimer.getLastPolled;
-  const repeater = { startTime: 3, interval: 4 };
+  const repeater = { startTime: 3n, interval: 4n };
   const poll = curryPollFn(fakeSO, [repeater], schedule, lastPolled, _ => {});
-  t.falsy(poll(1)); // false when nothing is woken
+  t.falsy(poll(1n)); // false when nothing is woken
   const handler = makeHandler();
-  schedule.add(5, handler, repeaterIndex);
-  t.falsy(poll(4));
-  t.truthy(poll(5));
+  schedule.add(5n, handler, repeaterIndex);
+  t.falsy(poll(4n));
+  t.truthy(poll(5n));
   t.is(handler.getCalls(), 1);
-  t.deepEqual(handler.getArgs(), [5]);
-  const expected = [{ time: 7, handlers: [{ handler, index: repeaterIndex }] }];
-  t.deepEqual(schedule.removeEventsThrough(8), expected);
+  t.deepEqual(handler.getArgs(), [5n]);
+  const expected = [{ time: 7n, handlers: [{ handler, index: repeaterIndex }] }];
+  t.deepEqual(schedule.removeEventsThrough(8n), expected);
 });
 
 test('multiMap remove repeater key', t => {
   const repeaterIndex = 0;
-  const scheduleTime = 3;
+  const scheduleTime = 3n;
   const schedule = makeTimerMap();
   const fakeTimer = makeFakeTimer(1);
   const lastPolled = fakeTimer.getLastPolled;
-  const repeater = { startTime: 2, interval: 4 };
+  const repeater = { startTime: 2n, interval: 4n };
   const poll = curryPollFn(fakeSO, [repeater], schedule, lastPolled, _ => {});
-  t.falsy(poll(1)); // false when nothing is woken
+  t.falsy(poll(1n)); // false when nothing is woken
   const handler = makeHandler();
   schedule.add(scheduleTime, handler, repeaterIndex);
   t.deepEqual(schedule.remove(handler), [scheduleTime]);
@@ -143,27 +143,27 @@ test('multiMap remove repeater key', t => {
 test('Timer schedule repeated event, repeatedly', t => {
   const repeaterIndex = 0;
   const schedule = makeTimerMap();
-  const fakeTimer = makeFakeTimer(4);
+  const fakeTimer = makeFakeTimer(4n);
   const lastPolled = fakeTimer.getLastPolled;
-  const repeater = { startTime: 6, interval: 3 };
+  const repeater = { startTime: 6n, interval: 3n };
   const poll = curryPollFn(fakeSO, [repeater], schedule, lastPolled, _ => {});
-  t.falsy(poll(4)); // false when nothing is woken
+  t.falsy(poll(4n)); // false when nothing is woken
   const handler = makeHandler();
-  schedule.add(9, handler, repeaterIndex);
+  schedule.add(9n, handler, repeaterIndex);
 
   t.is(handler.getCalls(), 0);
-  fakeTimer.setTime(8);
-  t.falsy(poll(8));
+  fakeTimer.setTime(8n);
+  t.falsy(poll(8n));
   t.is(handler.getCalls(), 0);
 
-  fakeTimer.setTime(10);
-  t.truthy(poll(10));
+  fakeTimer.setTime(10n);
+  t.truthy(poll(10n));
   t.is(handler.getCalls(), 1);
 
-  fakeTimer.setTime(12);
-  t.truthy(poll(12));
+  fakeTimer.setTime(12n);
+  t.truthy(poll(12n));
   t.is(handler.getCalls(), 2);
-  t.deepEqual(handler.getArgs(), [9, 12]);
+  t.deepEqual(handler.getArgs(), [9n, 12n]);
 });
 
 test('Timer schedule multiple repeaters', t => {
@@ -173,45 +173,45 @@ test('Timer schedule multiple repeaters', t => {
   const schedule = makeTimerMap();
   const fakeTimer = makeFakeTimer(4);
   const lastPolled = fakeTimer.getLastPolled;
-  const repeater0 = { startTime: 6, interval: 3 };
-  const repeater1 = { startTime: 7, interval: 5 };
-  const repeater2 = { startTime: 5, interval: 4 };
+  const repeater0 = { startTime: 6n, interval: 3n };
+  const repeater1 = { startTime: 7n, interval: 5n };
+  const repeater2 = { startTime: 5n, interval: 4n };
   const repeaters = [repeater0, repeater1, repeater2];
   const poll = curryPollFn(fakeSO, repeaters, schedule, lastPolled, _ => {});
   const handler0 = makeHandler();
   const handler1 = makeHandler();
   const handler2 = makeHandler();
-  schedule.add(9, handler0, repeaterIndex0);
-  schedule.add(12, handler1, repeaterIndex1);
-  schedule.add(9, handler2, repeaterIndex2);
+  schedule.add(9n, handler0, repeaterIndex0);
+  schedule.add(12n, handler1, repeaterIndex1);
+  schedule.add(9n, handler2, repeaterIndex2);
 
-  fakeTimer.setTime(7);
-  poll(7);
+  fakeTimer.setTime(7n);
+  poll(7n);
   t.is(handler0.getCalls(), 0);
   t.is(handler1.getCalls(), 0);
   t.is(handler2.getCalls(), 0);
 
-  fakeTimer.setTime(10);
-  t.truthy(poll(10));
+  fakeTimer.setTime(10n);
+  t.truthy(poll(10n));
   t.is(handler0.getCalls(), 1); // 9; next is 12
   t.is(handler1.getCalls(), 0); // first is 12
   t.is(handler2.getCalls(), 1); // 9; next is 13
 
   repeaters[repeaterIndex0] = undefined;
-  fakeTimer.setTime(12);
-  t.truthy(poll(12));
+  fakeTimer.setTime(12n);
+  t.truthy(poll(12n));
   t.is(handler0.getCalls(), 2); // 12; next won't happen
   t.is(handler1.getCalls(), 1); // 12; next is 17
   t.is(handler2.getCalls(), 1); // next is 13
 
-  fakeTimer.setTime(14);
-  t.truthy(poll(14));
+  fakeTimer.setTime(14n);
+  t.truthy(poll(14n));
   t.is(handler0.getCalls(), 2); // next is not scheduled
   t.is(handler1.getCalls(), 1); // next is 17
   t.is(handler2.getCalls(), 2); // 13; next is 17
 
-  fakeTimer.setTime(16);
-  t.falsy(poll(16)); // false when nothing is woken
+  fakeTimer.setTime(16n);
+  t.falsy(poll(16n)); // false when nothing is woken
   t.is(handler0.getCalls(), 2); // next didn't happen
   t.is(handler1.getCalls(), 1); // next is 17
   t.is(handler2.getCalls(), 2); // next is 17
@@ -220,5 +220,5 @@ test('Timer schedule multiple repeaters', t => {
     { handler: handler1, index: repeaterIndex1 },
     { handler: handler2, index: repeaterIndex2 },
   ];
-  t.deepEqual(schedule.cloneSchedule(), [{ time: 17, handlers: h }]);
+  t.deepEqual(schedule.cloneSchedule(), [{ time: 17n, handlers: h }]);
 });

--- a/packages/SwingSet/test/test-timer-device.js
+++ b/packages/SwingSet/test/test-timer-device.js
@@ -122,7 +122,9 @@ test('Timer schedule repeated event first', t => {
   t.truthy(poll(5n));
   t.is(handler.getCalls(), 1);
   t.deepEqual(handler.getArgs(), [5n]);
-  const expected = [{ time: 7n, handlers: [{ handler, index: repeaterIndex }] }];
+  const expected = [
+    { time: 7n, handlers: [{ handler, index: repeaterIndex }] },
+  ];
   t.deepEqual(schedule.removeEventsThrough(8n), expected);
 });
 

--- a/packages/SwingSet/test/timer-device/bootstrap.js
+++ b/packages/SwingSet/test/timer-device/bootstrap.js
@@ -1,4 +1,5 @@
 import { assert, details as X } from '@agoric/assert';
+import { Nat } from '@agoric/nat';
 
 export function buildRootObject(vatPowers, vatParameters) {
   const { D } = vatPowers;
@@ -25,7 +26,7 @@ export function buildRootObject(vatPowers, vatParameters) {
             );
           },
         });
-        const rptr = D(devices.timer).makeRepeater(argv[1], argv[2]);
+        const rptr = D(devices.timer).makeRepeater(Nat(argv[1]), Nat(argv[2]));
         const nextTime = D(devices.timer).schedule(rptr, handler);
         log(`next scheduled time: ${nextTime}`);
       } else {

--- a/packages/SwingSet/test/timer-device/test-device.js
+++ b/packages/SwingSet/test/timer-device/test-device.js
@@ -66,11 +66,11 @@ test('repeater2', async t => {
 
   await initializeSwingset(timerConfig, ['repeater', 3, 2], hostStorage);
   const c = await makeSwingsetController(hostStorage, deviceEndowments);
-  timer.poll(1);
+  timer.poll(1n);
   await c.step();
-  timer.poll(5);
+  timer.poll(5n);
   await c.step();
-  timer.poll(8);
+  timer.poll(8n);
   await c.step();
   t.deepEqual(c.dump().log, [
     'starting repeater test',

--- a/packages/captp/lib/index.js
+++ b/packages/captp/lib/index.js
@@ -1,4 +1,4 @@
-import Nat from '@agoric/nat';
+import { Nat } from '@agoric/nat';
 
 export * from '@agoric/marshal';
 

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@agoric/eventual-send": "^0.13.1",
     "@agoric/marshal": "^0.3.1",
-    "@agoric/nat": "^2.0.1",
+    "@agoric/nat": "^4.0.0",
     "@agoric/promise-kit": "^0.2.1",
     "esm": "^3.2.5"
   },

--- a/packages/cosmic-swingset/lib/ag-solo/vats/repl.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/repl.js
@@ -1,7 +1,7 @@
 import { isPromise } from '@agoric/promise-kit';
 import { E } from '@agoric/eventual-send';
 
-import Nat from '@agoric/nat';
+import { Nat } from '@agoric/nat';
 import makeUIAgentMakers from './ui-agent';
 
 // A REPL-specific JSON stringify.

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -35,7 +35,7 @@
     "@agoric/install-metering-and-ses": "^0.2.1",
     "@agoric/install-ses": "^0.5.1",
     "@agoric/marshal": "^0.3.1",
-    "@agoric/nat": "2.0.1",
+    "@agoric/nat": "^4.0.0",
     "@agoric/notifier": "^0.3.1",
     "@agoric/promise-kit": "^0.2.1",
     "@agoric/registrar": "^0.2.1",

--- a/packages/cosmic-swingset/test/test-home.js
+++ b/packages/cosmic-swingset/test/test-home.js
@@ -150,10 +150,10 @@ function makeHandler() {
 test.serial('home.localTimerService createRepeater', async t => {
   const { localTimerService } = E.G(home);
   const timestamp = await E(localTimerService).getCurrentTimestamp();
-  const repeater = E(localTimerService).createRepeater(1, 1);
+  const repeater = E(localTimerService).createRepeater(1n, 1n);
   const handler = makeHandler();
   await E(repeater).schedule(handler);
-  const notifier = E(localTimerService).makeNotifier(1, 1);
+  const notifier = E(localTimerService).makeNotifier(1n, 1n);
   await E(notifier).getUpdateSince();
 
   t.is(1, handler.getCalls());

--- a/packages/deploy-script-support/package.json
+++ b/packages/deploy-script-support/package.json
@@ -48,7 +48,7 @@
     "@agoric/eventual-send": "^0.13.1",
     "@agoric/import-manager": "^0.2.1",
     "@agoric/marshal": "^0.3.1",
-    "@agoric/nat": "^2.0.1",
+    "@agoric/nat": "^4.0.0",
     "@agoric/notifier": "^0.3.1",
     "@agoric/promise-kit": "^0.2.1",
     "@agoric/same-structure": "^0.1.1",

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@agoric/assert": "^0.2.1",
     "@agoric/eventual-send": "^0.13.1",
-    "@agoric/nat": "^2.0.1",
+    "@agoric/nat": "^4.0.0",
     "@agoric/promise-kit": "^0.2.1"
   },
   "devDependencies": {

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -3,7 +3,7 @@
 // eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
-import Nat from '@agoric/nat';
+import { Nat } from '@agoric/nat';
 import { assert, details as X, q } from '@agoric/assert';
 import { isPromise } from '@agoric/promise-kit';
 
@@ -513,7 +513,7 @@ function makeReviverIbidTable(cyclePolicy) {
 
   return harden({
     get(allegedIndex) {
-      const index = Nat(allegedIndex);
+      const index = Number(Nat(allegedIndex));
       assert(index < ibids.length, X`ibid out of range: ${index}`, RangeError);
       const result = ibids[index];
       if (unfinishedIbids.has(result)) {
@@ -884,7 +884,7 @@ export function makeMarshal(
           }
 
           case 'slot': {
-            const slot = slots[Nat(rawTree.index)];
+            const slot = slots[Number(Nat(rawTree.index))];
             return ibidTable.register(convertSlotToVal(slot, rawTree.iface));
           }
 

--- a/packages/spawner/package.json
+++ b/packages/spawner/package.json
@@ -36,7 +36,7 @@
     "@agoric/ertp": "^0.9.1",
     "@agoric/eventual-send": "^0.13.1",
     "@agoric/import-bundle": "^0.2.1",
-    "@agoric/nat": "^2.0.1",
+    "@agoric/nat": "^4.0.0",
     "@agoric/promise-kit": "^0.2.1",
     "@agoric/same-structure": "^0.1.1",
     "@agoric/store": "^0.4.1",

--- a/packages/transform-metering/package.json
+++ b/packages/transform-metering/package.json
@@ -23,7 +23,7 @@
     "rollup-plugin-node-resolve": "^5.2.0"
   },
   "dependencies": {
-    "@agoric/nat": "^2.0.1",
+    "@agoric/nat": "^4.0.0",
     "@agoric/tame-metering": "^1.3.1",
     "re2": "^1.10.5"
   },

--- a/packages/zoe/src/contracts/priceAggregatorTypes.js
+++ b/packages/zoe/src/contracts/priceAggregatorTypes.js
@@ -56,7 +56,6 @@
  * @property {OracleInitializationFacet} creatorFacet
  * @property {OraclePublicFacet} publicFacet
  * @property {Instance} instance
- * @property {Invitation} creatorInvitation
  */
 
 /**
@@ -64,14 +63,19 @@
  * @property {OracleCreatorFacet} creatorFacet
  * @property {OraclePublicFacet} publicFacet
  * @property {Instance} instance
- * @property {Invitation} creatorInvitation
+ */
+
+/**
+ * @typedef {Object} OracleReply
+ * @property {any} reply
+ * @property {Amount} [requiredFee]
  */
 
 /**
  * @typedef {Object} OracleHandler
- * @property {(query: any, fee: Amount) => Promise<{ reply:
- * any, requiredFee: Amount | undefined }>} onQuery callback to reply to a query
+ * @property {(query: any, fee: Amount) => Promise<OracleReply>} onQuery
+ * callback to reply to a query
  * @property {(query: any, reason: any) => void} onError notice an error
- * @property {(query: any, reply: any, requiredFee: Amount | undefined) => void} onReply
- * notice a successful reply
+ * @property {(query: any, reply: any, requiredFee: Amount | undefined) => void}
+ * onReply notice a successful reply
  */

--- a/packages/zoe/test/jsconfig.json
+++ b/packages/zoe/test/jsconfig.json
@@ -1,0 +1,18 @@
+// This file can contain .js-specific Typescript compiler config.
+{
+  "compilerOptions": {
+    "target": "esnext",
+
+    "noEmit": true,
+/*
+    // The following flags are for creating .d.ts files:
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+*/
+    "downlevelIteration": true,
+    "strictNullChecks": true,
+    "moduleResolution": "node",
+  },
+  "include": ["**/*.js"],
+}

--- a/packages/zoe/test/unitTests/contracts/test-oracle.js
+++ b/packages/zoe/test/unitTests/contracts/test-oracle.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import anyTest from 'ava';
 import bundleSource from '@agoric/bundle-source';
 
 import { makeIssuerKit, MathKind } from '@agoric/ertp';
@@ -26,6 +26,8 @@ import '../../../src/contracts/exported';
  */
 
 const contractPath = `${__dirname}/../../../src/contracts/oracle`;
+
+const test = /** @type {import('ava').TestInterface<TestContext>} */ (anyTest);
 
 test.before(
   'setup oracle',

--- a/packages/zoe/test/unitTests/test-scriptedOracle.js
+++ b/packages/zoe/test/unitTests/test-scriptedOracle.js
@@ -2,11 +2,12 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import anyTest from 'ava';
 import bundleSource from '@agoric/bundle-source';
 
 import { E } from '@agoric/eventual-send';
 
+import { assert } from '@agoric/assert';
 import { makeFakeVatAdmin } from '../../src/contractFacet/fakeVatAdmin';
 import { makeZoe } from '../..';
 
@@ -21,6 +22,20 @@ import { makeScriptedOracle } from '../../tools/scriptedOracle';
 
 const oracleContractPath = `${__dirname}/../../src/contracts/oracle`;
 const bountyContractPath = `${__dirname}/bounty`;
+
+/**
+ * @typedef {Object} TestContext
+ * @property {ZoeService} zoe
+ * @property {Installation} oracleInstallation
+ * @property {Installation} bountyInstallation
+ * @property {Mint} moolaMint
+ * @property {Issuer} moolaIssuer
+ * @property {AmountMath['make']} moola
+ *
+ * @typedef {import('ava').ExecutionContext<TestContext>} ExecutionContext
+ */
+
+const test = /** @type {import('ava').TestInterface<TestContext>} */ (anyTest);
 
 test.before(
   'setup oracle',
@@ -76,6 +91,7 @@ test('pay bounty', async t => {
   );
 
   // Alice funds a bounty
+  assert(funderInvitation);
   const funderSeat = await E(zoe).offer(
     funderInvitation,
     harden({
@@ -144,6 +160,7 @@ test('pay no bounty', async t => {
   );
 
   // Alice funds a bounty
+  assert(funderInvitation);
   const funderSeat = await E(zoe).offer(
     funderInvitation,
     harden({

--- a/packages/zoe/tools/scriptedOracle.js
+++ b/packages/zoe/tools/scriptedOracle.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { E } from '@agoric/eventual-send';
 
 /**
@@ -10,12 +11,11 @@ import { E } from '@agoric/eventual-send';
  * result, but has no impact on the result. If the script has no entry for the
  * time, the event is 'nothing to report'.
  *
- * @param {Array} script
+ * @param {Record<string, any>} script
  * @param {Installation} oracleInstallation
- * @param {Timer} timer
+ * @param {TimerService} timer
  * @param {ZoeService} zoe
  * @param {Issuer} feeIssuer
- * @returns {Promise<unknown[]>}
  */
 
 export async function makeScriptedOracle(
@@ -29,7 +29,7 @@ export async function makeScriptedOracle(
   const oracleHandler = harden({
     async onQuery(query) {
       const time = await E(timer).getCurrentTimestamp();
-      const event = script[time] || 'Nothing to report';
+      const event = script[`${time}`] || 'Nothing to report';
       const reply = { event, time, query };
       return harden({ reply });
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,11 +29,6 @@
   resolved "https://registry.yarnpkg.com/@agoric/make-hardener/-/make-hardener-0.1.2.tgz#b9a72d98ae23a4c6918cd7dc4a9a72deebafde45"
   integrity sha512-l5O7TCVDcl6NcWW5Rp/lAQaFLmje97wHrKPJbYV08M4TNDgSiMlesYtar40OnAR2pnzgsyilSQc+hU5mEvCJWg==
 
-"@agoric/nat@2.0.1", "@agoric/nat@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@agoric/nat/-/nat-2.0.1.tgz#28aba18367deba354bdd424bdf6daa48f5e7d37f"
-  integrity sha512-puvWkoaJovQib/YaSRSGJ8Kn9rogi/yyaVa3d5znSZb5WiYfUiEKW35BfexHhAdi0VfPz2anFHoRBoBSUIijNA==
-
 "@agoric/nat@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@agoric/nat/-/nat-4.0.0.tgz#330dcde37fcf8882dbc5012a3b2c4c135eee4930"


### PR DESCRIPTION
Stacked on https://github.com/Agoric/agoric-sdk/pull/2482

Does not include ERTP or Zoe changes. Previous Swingset changes merged to master already.

I noticed that we have a lot of comparison of deadlines in ways that will fail silently when the deadline is not a BigInt but should be. For instance, `deadline === 3n` is false if deadline is 3. So I decided to strictly enforce that all times/deadlines/expiration dates are BigInts, so that the failures are represented as errors. 

#dapp-otc-branch: nat-4.0.0