### PR TITLE
agorictest-6 deployment fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/btcsuite/btcd v0.21.0-beta
 	github.com/btcsuite/btcutil v1.0.2
-	github.com/cosmos/cosmos-sdk v0.40.1
+	github.com/cosmos/cosmos-sdk v0.41.1
 	github.com/ethereum/go-ethereum v1.9.22
 	github.com/gogo/protobuf v1.3.3
 	github.com/gorilla/mux v1.8.0
@@ -14,8 +14,8 @@ require (
 	github.com/rakyll/statik v0.1.7
 	github.com/spf13/cast v1.3.1
 	github.com/spf13/cobra v1.1.1
-	github.com/tendermint/tendermint v0.34.3
-	github.com/tendermint/tm-db v0.6.3
+	github.com/tendermint/tendermint v0.34.4
+	github.com/tendermint/tm-db v0.6.4
 	google.golang.org/genproto v0.0.0-20210114201628-6edceaf6022f
 	google.golang.org/grpc v1.35.0
 )
@@ -30,7 +30,7 @@ replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.2-alp
 
 // At least until https://github.com/cosmos/cosmos-sdk/issues/8478 is solved and
 // released.
-replace github.com/cosmos/cosmos-sdk => github.com/agoric-labs/cosmos-sdk v0.34.4-0.20210129184725-f1afab29a888
+// replace github.com/cosmos/cosmos-sdk => github.com/agoric-labs/cosmos-sdk v0.34.4-0.20210129184725-f1afab29a888
 
 // For testing against a local cosmos-sdk or tendermint
 // replace github.com/cosmos/cosmos-sdk => ../forks/cosmos-sdk

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,8 @@ github.com/cosmos/cosmos-sdk v0.40.0-rc4 h1:jWdbXON/cIs/XbIAA/4dlUH8xtyNjdWTEF4f
 github.com/cosmos/cosmos-sdk v0.40.0-rc4/go.mod h1:eKgbkQO4FEvC+a1+eyRuL7UgluGK1ad4PufPTpQc6ZA=
 github.com/cosmos/cosmos-sdk v0.40.1 h1:gjrtV3MQj/CMeyXN4+sosHMG6Xwa2uH6HITSjSNL/0E=
 github.com/cosmos/cosmos-sdk v0.40.1/go.mod h1:vlgqdPpUGSxgqSbZea6fjszoLkPKwCuiqSBySLlv4ro=
+github.com/cosmos/cosmos-sdk v0.41.1 h1:QatVRc8EaEObHtOFDNYHoF6di/jvSFVkXBK3I3SQ+/4=
+github.com/cosmos/cosmos-sdk v0.41.1/go.mod h1:mCaJm2k+fqY7+qwvwd7WDHZZFG3avW4+I6c4lizAkIY=
 github.com/cosmos/go-bip39 v0.0.0-20180618194314-52158e4697b8/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d h1:49RLWk1j44Xu4fjHb6JFYmeUnDORVwHNkDxaQ0ctCVU=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
@@ -612,6 +614,7 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/sasha-s/go-deadlock v0.2.0/go.mod h1:StQn567HiB1fF2yJ44N9au7wOhrPS3iZqiDbRupzT10=
+github.com/sasha-s/go-deadlock v0.2.1-0.20190427202633-1595213edefa/go.mod h1:F73l+cr82YSh10GxyRI6qZiCgK64VaZjwesgfQ1/iLM=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
@@ -702,6 +705,8 @@ github.com/tendermint/tendermint v0.34.0-rc6/go.mod h1:ugzyZO5foutZImv0Iyx/gOFCX
 github.com/tendermint/tendermint v0.34.0/go.mod h1:Aj3PIipBFSNO21r+Lq3TtzQ+uKESxkbA3yo/INM4QwQ=
 github.com/tendermint/tendermint v0.34.3 h1:9yEsf3WO5VAwPVwrmM+RffDMiijmNfWaBwNttHm0q5w=
 github.com/tendermint/tendermint v0.34.3/go.mod h1:h57vnXeOlrdvvNFCqPBSaOrpOivl+2swWEtlUAqStYE=
+github.com/tendermint/tendermint v0.34.4 h1:E7qkvFGx27d8ugVLiAY2iWP6DL5cep3l/mpTaWKHyBA=
+github.com/tendermint/tendermint v0.34.4/go.mod h1:JVuu3V1ZexOaZG8VJMRl8lnfrGw6hEB2TVnoUwKRbss=
 github.com/tendermint/tm-db v0.4.1/go.mod h1:JsJ6qzYkCGiGwm5GHl/H5GLI9XLb6qZX7PRe425dHAY=
 github.com/tendermint/tm-db v0.5.0/go.mod h1:lSq7q5WRR/njf1LnhiZ/lIJHk2S8Y1Zyq5oP/3o9C2U=
 github.com/tendermint/tm-db v0.6.1/go.mod h1:m3x9kRP4UFd7JODJL0yBAZqE7wTw+S37uAE90cTx7OA=
@@ -709,6 +714,8 @@ github.com/tendermint/tm-db v0.6.2 h1:DOn8jwCdjJblrCFJbtonEIPD1IuJWpbRUUdR8GWE4R
 github.com/tendermint/tm-db v0.6.2/go.mod h1:GYtQ67SUvATOcoY8/+x6ylk8Qo02BQyLrAs+yAcLvGI=
 github.com/tendermint/tm-db v0.6.3 h1:ZkhQcKnB8/2jr5EaZwGndN4owkPsGezW2fSisS9zGbg=
 github.com/tendermint/tm-db v0.6.3/go.mod h1:lfA1dL9/Y/Y8wwyPp2NMLyn5P5Ptr/gvDFNWtrCWSf8=
+github.com/tendermint/tm-db v0.6.4 h1:3N2jlnYQkXNQclQwd/eKV/NzlqPlfK21cpRRIx80XXQ=
+github.com/tendermint/tm-db v0.6.4/go.mod h1:dptYhIpJ2M5kUuenLr+Yyf3zQOv1SgBZcl8/BmWlMBw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/packages/deployment/Dockerfile
+++ b/packages/deployment/Dockerfile
@@ -1,10 +1,13 @@
 ARG TAG=latest
 ARG REPO=agoric/agoric-sdk
-FROM golang:buster AS go-build
 
-WORKDIR /usr/src/journalbeat
-RUN apt-get update -y && apt-get install -y libsystemd-dev
-RUN go get github.com/mheese/journalbeat
+# FIXME: Journalbeat compilation is currently broken, but non-essential.
+# Removed from the build.
+# FROM golang:buster AS go-build
+
+# WORKDIR /usr/src/journalbeat
+# RUN apt-get update -y && apt-get install -y libsystemd-dev
+# RUN go get github.com/mheese/journalbeat
 
 FROM $REPO:$TAG
 
@@ -20,8 +23,8 @@ RUN echo 'deb http://ppa.launchpad.net/ansible/ansible/ubuntu trusty main' >> /e
     apt-get install -y ansible rsync curl sudo gnupg2 jq python-jmespath && \
     apt-get clean -y
 
-# Copy journalbeat for logging support
-COPY --from=go-build /go/bin/journalbeat /usr/local/bin/
+# # Copy journalbeat for logging support
+# COPY --from=go-build /go/bin/journalbeat /usr/local/bin/
 
 WORKDIR /usr/src/app
 RUN ln -sf $PWD/setup/ag-setup-cosmos /usr/local/bin/

--- a/packages/deployment/Makefile
+++ b/packages/deployment/Makefile
@@ -66,4 +66,4 @@ docker-push-solo:
 
 docker-push-deployment:
 	$(DONT_PUSH_LATEST) docker push agoric/deployment:latest
-	docker push $(REPOSITORY)-solo:$(TAG)
+	docker push agoric/deployment:$(TAG)

--- a/packages/deployment/ansible/roles/cosmos-genesis/tasks/main.yml
+++ b/packages/deployment/ansible/roles/cosmos-genesis/tasks/main.yml
@@ -69,6 +69,7 @@
   shell: "\
     {{ service }} add-genesis-account \
     {{ item | regex_replace('^([^:]*):([^:]*).*$', '\\1 \\2') }}"
+  ignore_errors: true
   with_items:
     - "{{ delegates.splitlines() }}"
   when: delegates != ""


### PR DESCRIPTION
These are some minor fixes that would have helped deploy the latest testnet more smoothly.  We remove the deprecated `journalbeat` part of the docker containers, and push the correct `agoric/deployment:latest` tag.  We also ignore errors when creating transactions from the `cosmos-delegates.txt` file.

Aside from that, we move off of a custom cosmos-sdk (which was based on v0.41.0) to the official v0.41.1 release since cosmos/cosmos-sdk#8478 has been fixed and released.
