### PR TITLE
feat: changes needed to run under Electron on Windows

### DIFF
--- a/packages/agoric-cli/lib/deploy.js
+++ b/packages/agoric-cli/lib/deploy.js
@@ -21,7 +21,7 @@ import { getAccessToken } from './open';
 
 const RETRY_DELAY_MS = 1000;
 
-const PATH_SEP_RE = new RegExp(`${path.sep}`, 'g');
+const PATH_SEP_RE = new RegExp(`${path.sep.replace(/\\/g, '\\\\')}`, 'g');
 
 export default async function deployMain(progname, rawArgs, powers, opts) {
   const { anylogger, fs, makeWebSocket } = powers;

--- a/packages/agoric-cli/lib/open.js
+++ b/packages/agoric-cli/lib/open.js
@@ -102,9 +102,6 @@ export default async function walletMain(progname, rawArgs, powers, opts) {
   process.stdout.write(`${walletUrl}\n`);
   if (opts.browser) {
     const browser = opener(walletUrl);
-    browser.unref();
-    process.stdout.unref();
-    process.stderr.unref();
-    process.stdin.unref();
+    await new Promise(resolve => browser.on('exit', resolve));
   }
 }

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -28,7 +28,7 @@
     "@agoric/transform-eventual-send": "^1.4.1",
     "@babel/generator": "^7.6.4",
     "@babel/traverse": "^7.8.3",
-    "@rollup/plugin-commonjs": "^11.0.2",
+    "@rollup/plugin-commonjs": "~11.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",
     "acorn": "^7.1.0",
     "esm": "^3.2.5",

--- a/packages/cosmic-swingset/lib/ag-solo/init-basedir.js
+++ b/packages/cosmic-swingset/lib/ag-solo/init-basedir.js
@@ -86,7 +86,7 @@ export default function initBasedir(
     dots += '../';
     nm = path.resolve(here, dots, 'node_modules');
   }
-  fs.symlinkSync(nm, path.join(basedir, 'node_modules'));
+  fs.symlinkSync(nm, path.join(basedir, 'node_modules'), 'junction');
 
   // cosmos-sdk keypair
   if (egresses.includes('cosmos')) {

--- a/packages/cosmic-swingset/lib/ag-solo/start.js
+++ b/packages/cosmic-swingset/lib/ag-solo/start.js
@@ -38,7 +38,6 @@ let swingSetRunning = false;
 
 const fsWrite = promisify(fs.write);
 const fsClose = promisify(fs.close);
-const mkdir = promisify(fs.mkdir);
 const rename = promisify(fs.rename);
 const symlink = promisify(fs.symlink);
 const unlink = promisify(fs.unlink);
@@ -97,7 +96,7 @@ async function buildSwingset(
   });
 
   const pluginDir = path.resolve('./plugins');
-  await mkdir(pluginDir, { recursive: true });
+  fs.mkdirSync(pluginDir, { recursive: true });
   const pluginsPrefix = `${pluginDir}${path.sep}`;
   const pluginRequire = mod => {
     // Ensure they can't traverse out of the plugins prefix.
@@ -311,7 +310,7 @@ export default async function start(basedir, argv) {
 
   const agWallet = path.dirname(pjs);
   const agWalletHtml = path.resolve(agWallet, htmlBasedir);
-  symlink(agWalletHtml, 'html/wallet').catch(e => {
+  symlink(agWalletHtml, 'html/wallet', 'junction').catch(e => {
     console.error('Cannot link html/wallet:', e);
   });
 

--- a/packages/xsnap/package.json
+++ b/packages/xsnap/package.json
@@ -36,6 +36,7 @@
   },
   "files": [
     "LICENSE*",
+    "lib",
     "makefiles",
     "src"
   ],


### PR DESCRIPTION
Closes: agoric-labs/Pledger#7

With these changes to the SDK, Windows testnet clients work correctly.  I don't expect these to be tested yet (Pledger work is ongoing), but at least ensure they don't introduce problems.

- Allow `path.sep` to be `\` when we use it in a RegExp
- Don't exit `agoric open` until the opening browser process ends
- Downgrade `@rollup/plugin-commonjs` to make `bundle-source` work on Windows
- Use `'junction'` as an option when symlinking directories; it's required for Windows and harmless on other systems
- Include the `lib` directory to make `@agoric/xsnap` a viable package
