### PR TITLE
feat(marshal): add Data() to mark pass-by-copy empty objects

### DIFF
--- a/packages/marshal/index.js
+++ b/packages/marshal/index.js
@@ -9,6 +9,7 @@ export {
   makeMarshal,
   Remotable,
   Far,
+  Data,
 } from './src/marshal';
 
 export { stringify, parse } from './src/marshal-stringify';

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -257,10 +257,16 @@ function isPassByCopyRecord(val) {
   }
   const descs = getOwnPropertyDescriptors(val);
   const descKeys = ownKeys(descs);
+  // Empty non-array objects must be registered with Far/Remotable, or Data
+  // (in which case they won't be empty, because Data() attaches a PASS_STYLE
+  // property). This causes a warning for now, eventually it will become an
+  // error, then it will go back to pass-by-copy.
   if (descKeys.length === 0) {
     // empty non-array objects are pass-by-remote, not pass-by-copy
     // TODO Beware: Unmarked empty records will become pass-by-copy
     // See https://github.com/Agoric/agoric-sdk/issues/2018
+    // console.log(`--- @@marshal: empty object without Data/Far/Remotable`);
+    // assert.fail(X`empty object without Data/Far/Remotable`);
     return false;
   }
 
@@ -494,6 +500,8 @@ export function passStyleOf(val) {
         return 'copyRecord';
       }
       assertRemotable(val);
+      // console.log(`--- @@marshal: pass-by-ref object without Far/Remotable`);
+      // assert.fail(X`pass-by-ref object without Far/Remotable`);
       return REMOTE_STYLE;
     }
     case 'function': {

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -274,6 +274,13 @@ function isPassByCopyRecord(val) {
     );
   }
 
+  if (descKeys.length === 1) {
+    if (ignorePassStyle(descKeys[0])) {
+      // the only key is the Data() marker, therefore this is pass-by-data
+      return true;
+    }
+  }
+
   for (const descKey of descKeys) {
     // we tolerate and ignore a non-enumerable PASS_STYLE symbol-named key, the Data marker
     if (ignorePassStyle(descKey)) {

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -1004,6 +1004,12 @@ export function makeMarshal(
           assert.typeof(name, 'string');
           result[name] = fullRevive(rawTree[name]);
         }
+        if (names.length === 0) {
+          Object.defineProperty(result, PASS_STYLE, {
+            enumerable: false,
+            value: 'copyRecord',
+          });
+        }
         return ibidTable.finish(result);
       }
     };

--- a/packages/marshal/test/test-marshal.js
+++ b/packages/marshal/test/test-marshal.js
@@ -524,7 +524,7 @@ test('records', t => {
   t.deepEqual(unser(ser(harden({ key1: 'data' }))), { key1: 'data' });
 
   // unserialized data can be serialized again
-  // t.deepEqual(ser(unser(emptyData)), emptyData);
+  t.deepEqual(ser(unser(emptyData)), emptyData);
   t.deepEqual(ser(unser(key1Data)), key1Data);
 
   // Data({})

--- a/packages/marshal/test/test-marshal.js
+++ b/packages/marshal/test/test-marshal.js
@@ -429,7 +429,7 @@ test('records', t => {
     }),
     slots: ['slot'],
   };
-  // const emptyData = { body: JSON.stringify({}), slots: [] };
+  const emptyData = { body: JSON.stringify({}), slots: [] };
 
   // For objects with Symbol-named properties
   const symEnumData = Symbol.for('symEnumData');
@@ -532,7 +532,7 @@ test('records', t => {
   // interim1: pass-by-copy without warning
   // interim2: pass-by-copy without warning
   // final: not applicable, Data() removed
-  // t.deepEqual(build('data'), emptyData); // interim 1+2
+  t.deepEqual(ser(build('data')), emptyData); // interim 1+2
 
   // Far('iface', {})
   // all cases: pass-by-ref


### PR DESCRIPTION
marshal now exports a `Data` function, which acts somewhat like `Remotable` and `Far`, to mark an object as explicitly pass-by-copy. We will use this for a short while to mark empty objects that should arrive at their destination as empty records, rather than as identity-bearing pass-by-reference Presences.

There will be an interim period during which unmarked empty objects will cause an error, so we can become confident that we won't change the handling of empty objects in a surprising way. This PR adds placeholder warnings/errors which can be uncommented to help us track down client code that needs to be changed. At some point we'll commit the uncommented lines.

When we're done with the transition, unmarked empty objects will be pass-by-copy, all pass-by-reference objects must be marked with `Far` or `Remotable`, and we'll remove `Data`.

`Data` works by adding an unenumerable Symbol-named property to the not-yet-hardened object, then hardens it. Callers should change their `harden({...})` to `Data({...})`. The property is the same one used by `Remotable`/`Far`, except that `Data` puts it directly on the object, whereas `Remotable` puts it on a newly injected prototype object. Pass-by-copy serialization was changed to ignore Symbol-named properties during encoding, so the wire format has not changed. Unserialization was modified to add the new property to any otherwise-empty objects it emits, so that unserialized empty objects can be passed back into `serialize()` without problems.
