### PR TITLE
fix(xsnap): bounds checking in release builds

### DIFF
--- a/packages/xsnap/makefiles/lin/xsnap.mk
+++ b/packages/xsnap/makefiles/lin/xsnap.mk
@@ -41,9 +41,9 @@ C_OPTIONS += \
 	-Wno-misleading-indentation \
 	-Wno-implicit-fallthrough
 ifeq ($(GOAL),debug)
-	C_OPTIONS += -g -O0 -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter -DmxDebug=1
+	C_OPTIONS += -DmxDebug=1 -g -O0 -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter
 else
-	C_OPTIONS += -O3
+	C_OPTIONS += -DmxBoundsCheck=1 -O3
 endif
 
 LIBRARIES = -ldl -lm -lpthread

--- a/packages/xsnap/makefiles/mac/xsnap.mk
+++ b/packages/xsnap/makefiles/mac/xsnap.mk
@@ -44,9 +44,9 @@ ifneq ("x$(SDKROOT)", "x")
 	C_OPTIONS += -isysroot $(SDKROOT)
 endif
 ifeq ($(GOAL),debug)
-	C_OPTIONS += -g -O0 -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter -DmxDebug=1
+	C_OPTIONS += -DmxDebug=1 -g -O0 -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter
 else
-	C_OPTIONS += -O3
+	C_OPTIONS += -DmxBoundsCheck=1 -O3
 endif
 
 LIBRARIES = -framework CoreServices

--- a/packages/xsnap/makefiles/win/xsnap.mak
+++ b/packages/xsnap/makefiles/win/xsnap.mak
@@ -43,6 +43,7 @@ C_OPTIONS = $(C_OPTIONS) \
 !ELSE
 C_OPTIONS = $(C_OPTIONS) \
 	/D NDEBUG \
+	/D mxBoundsCheck=1 \
 	/Fp$(TMP_DIR_RLS)\ \
 	/O2 \
 	/W0

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -32,6 +32,8 @@ const importMetaUrl = `file://${__filename}`;
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
+const { freeze } = Object;
+
 /**
  * @param {Uint8Array} arg
  * @returns {Uint8Array}
@@ -276,7 +278,7 @@ export function xsnap(options) {
     return vatExit.promise.catch(() => {});
   }
 
-  return {
+  return freeze({
     issueCommand,
     issueStringCommand,
     close,
@@ -285,5 +287,5 @@ export function xsnap(options) {
     execute,
     import: importModule,
     snapshot: writeSnapshot,
-  };
+  });
 }

--- a/packages/xsnap/src/xsrepl
+++ b/packages/xsnap/src/xsrepl
@@ -1,4 +1,4 @@
 #!/bin/bash
 real0=$(readlink "${BASH_SOURCE[0]}" || echo "${BASH_SOURCE[0]}")
 thisdir=$(cd "$(dirname -- "$real0")" > /dev/null && pwd -P)
-node -r esm "$thisdir/xsrepl.js" "@*"
+node -r esm "$thisdir/xsrepl.js" "$*"


### PR DESCRIPTION
fixes #2276

791d875 is tangentially related; it makes `xsrepl --debug` work

5c3f1dc is more or less unrelated but seems like good hygiene while we're at it.