### PR TITLE
Release tweaks

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/init-basedir.js
+++ b/packages/cosmic-swingset/lib/ag-solo/init-basedir.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { execFileSync } from 'child_process';
 
+import { assert, details as X } from '@agoric/assert';
 import anylogger from 'anylogger';
 
 const log = anylogger('ag-solo:init');
@@ -20,16 +21,14 @@ export default function initBasedir(
   options.wallet = wallet;
 
   const here = __dirname;
-  try {
-    fs.mkdirSync(basedir, 0o700);
-  } catch (e) {
-    if (!fs.existsSync(path.join(basedir, 'ag-cosmos-helper-address'))) {
-      log.error(
-        `unable to create basedir ${basedir}, it must not already exist`,
-      );
-      throw e;
-    }
+  if (
+    fs.existsSync(basedir) &&
+    !fs.existsSync(path.join(basedir, 'ag-cosmos-helper-address'))
+  ) {
+    assert.fail(X`${basedir} must not already exist`);
   }
+
+  fs.mkdirSync(basedir, { mode: 0o700, recursive: true });
 
   const connections = [{ type: 'http', port: webport, host: webhost }];
   fs.writeFileSync(

--- a/scripts/get-released-tags
+++ b/scripts/get-released-tags
@@ -8,6 +8,13 @@ fi
 for tag in $(git tag -l | egrep -e '@[0-9]+\.[0-9]+\.[0-9]+$'); do
   case $tag in
   @agoric/sdk@*) sdkTags="$sdkTags $tag" ;;
+  @agoric/cosmos@*)
+    # This logic publishes the golang tag needed for go get downloads.
+    # Format needs to be vNN.MM.PP
+    goTag=v$(echo "$tag" | sed -e 's/.*@//')
+    git tag -f "$goTag" "$tag"
+    otherTags="$otherTags $tag $goTag"
+    ;;
   *) otherTags="$otherTags $tag" ;;
   esac
 done

--- a/yarn.lock
+++ b/yarn.lock
@@ -1407,17 +1407,6 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.11.tgz#aeb16f50649a91af79dbe36574b66d0f9e4d9f71"
   integrity sha512-3NsZsJIA/22P3QUyrEDNA2D133H4j224twJrdipXN38dpnIOzAbUDtOwkcJ5pXmn75w7LSQDjA4tO9dm1XlqlA==
 
-"@rollup/plugin-commonjs@^11.0.2":
-  version "11.0.2"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-11.0.2.tgz#837cc6950752327cb90177b608f0928a4e60b582"
-  integrity sha512-MPYGZr0qdbV5zZj8/2AuomVpnRVXRU5XKXb3HVniwRoRCreGlf5kOE081isNWeiLIi6IYkwTX9zE0/c7V8g81g==
-  dependencies:
-    "@rollup/pluginutils" "^3.0.0"
-    estree-walker "^1.0.1"
-    is-reference "^1.1.2"
-    magic-string "^0.25.2"
-    resolve "^1.11.0"
-
 "@rollup/plugin-commonjs@^12.0.0":
   version "12.0.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-12.0.0.tgz#e2f308ae6057499e0f413f878fff7c3a0fdc02a1"
@@ -1427,6 +1416,17 @@
     commondir "^1.0.1"
     estree-walker "^1.0.1"
     glob "^7.1.2"
+    is-reference "^1.1.2"
+    magic-string "^0.25.2"
+    resolve "^1.11.0"
+
+"@rollup/plugin-commonjs@~11.0.2":
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-11.0.2.tgz#837cc6950752327cb90177b608f0928a4e60b582"
+  integrity sha512-MPYGZr0qdbV5zZj8/2AuomVpnRVXRU5XKXb3HVniwRoRCreGlf5kOE081isNWeiLIi6IYkwTX9zE0/c7V8g81g==
+  dependencies:
+    "@rollup/pluginutils" "^3.0.0"
+    estree-walker "^1.0.1"
     is-reference "^1.1.2"
     magic-string "^0.25.2"
     resolve "^1.11.0"


### PR DESCRIPTION
These commits were needed to finish the most recent release.

Update golang semantic version tag needed for `go get github.com/Agoric/agoric-sdk@v0.24.1` to work.

Adjust yarn.lock (should have landed earlier).
