### PR TITLE
observeNotifier deprecates updateFromNotifier

### DIFF
--- a/packages/dapp-svelte-wallet/api/src/lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-wallet.js
@@ -18,11 +18,7 @@ import { makeIssuerTable } from '@agoric/zoe/src/issuerTable';
 import { E } from '@agoric/eventual-send';
 
 import { makeMarshal, passStyleOf } from '@agoric/marshal';
-import {
-  makeNotifierKit,
-  observeIteration,
-  observeNotifier,
-} from '@agoric/notifier';
+import { makeNotifierKit, observeNotifier } from '@agoric/notifier';
 import { makePromiseKit } from '@agoric/promise-kit';
 
 import { makeDehydrator } from './lib-dehydrate';

--- a/packages/dapp-svelte-wallet/api/src/lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-wallet.js
@@ -21,7 +21,7 @@ import { makeMarshal, passStyleOf } from '@agoric/marshal';
 import {
   makeNotifierKit,
   observeIteration,
-  makeAsyncIterableFromNotifier,
+  observeNotifier,
 } from '@agoric/notifier';
 import { makePromiseKit } from '@agoric/promise-kit';
 
@@ -640,20 +640,17 @@ export function makeWallet({
     await updatePursesState(petnameForPurse, purse);
 
     // Just notice the balance updates for the purse.
-    observeIteration(
-      makeAsyncIterableFromNotifier(E(purse).getCurrentAmountNotifier()),
-      {
-        updateState(_balance) {
-          updatePursesState(
-            purseMapping.valToPetname.get(purse),
-            purse,
-          ).catch(e => console.error('cannot updateState', e));
-        },
-        fail(reason) {
-          console.error(`failed updateState observer`, reason);
-        },
+    observeNotifier(E(purse).getCurrentAmountNotifier(), {
+      updateState(_balance) {
+        updatePursesState(
+          purseMapping.valToPetname.get(purse),
+          purse,
+        ).catch(e => console.error('cannot updateState', e));
       },
-    );
+      fail(reason) {
+        console.error(`failed updateState observer`, reason);
+      },
+    });
   };
 
   async function deposit(pursePetname, payment) {

--- a/packages/dapp-svelte-wallet/ui/src/store.js
+++ b/packages/dapp-svelte-wallet/ui/src/store.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { writable } from 'svelte/store';
 import { E } from '@agoric/eventual-send';
-import { updateFromNotifier } from '@agoric/notifier';
+import { observeNotifier } from '@agoric/notifier';
 
 import { makeWebSocket } from './websocket';
 import { makeCapTPConnection } from './captp';
@@ -94,37 +94,65 @@ function onReset(readyP) {
   readyP.then(() => resetAlls.forEach(fn => fn()));
   E(walletP).getSelfContact().then(sc => setSelfContact({ contactPetname: 'Self', ...kv('Self', sc) }));
   // Set up our subscriptions.
-  updateFromNotifier({
+  observeNotifier(E(walletP).getOffersNotifier(), {
     updateState(state) {
-      setInbox(state.map(tx => ({ ...tx, offerId: tx.id, id: `${tx.requestContext.date}-${tx.requestContext.dappOrigin}-${tx.id}`}))
-        .sort((a, b) => cmp(b.id, a.id)));
+      setInbox(
+        state
+          .map(tx => ({
+            ...tx,
+            offerId: tx.id,
+            id: `${tx.requestContext.date}-${tx.requestContext.dappOrigin}-${tx.id}`,
+          }))
+          .sort((a, b) => cmp(b.id, a.id)),
+      );
     },
-  }, E(walletP).getOffersNotifier());
-  updateFromNotifier({
+  });
+  observeNotifier(E(walletP).getPursesNotifier(), {
     updateState(state) {
-      setPurses(state.map(purse => kv({ pursePetname: purse.pursePetname }, purse))
-        .sort((a, b) => cmp(a.brandPetname, b.brandPetname) || cmp(a.pursePetname, b.pursePetname)));
+      setPurses(
+        state
+          .map(purse => kv({ pursePetname: purse.pursePetname }, purse))
+          .sort(
+            (a, b) =>
+              cmp(a.brandPetname, b.brandPetname) ||
+              cmp(a.pursePetname, b.pursePetname),
+          ),
+      );
     },
-  }, E(walletP).getPursesNotifier());
-  updateFromNotifier({
+  });
+  observeNotifier(E(walletP).getDappsNotifier(), {
     updateState(state) {
-      setDapps(state.map(dapp => ({ ...dapp, id: dapp.origin }))
-        .sort((a, b) => cmp(a.petname, b.petname) || cmp(a.id, b.id)));
+      setDapps(
+        state
+          .map(dapp => ({ ...dapp, id: dapp.origin }))
+          .sort((a, b) => cmp(a.petname, b.petname) || cmp(a.id, b.id)),
+      );
     },
-  }, E(walletP).getDappsNotifier());
-  updateFromNotifier({
+  });
+  observeNotifier(E(walletP).getContactsNotifier(), {
     updateState(state) {
-      setContacts(state.map(([contactPetname, contact]) => kv({ contactPetname }, contact))
-        .sort((a, b) => cmp(a.contactPetname, b.contactPetname) || cmp(a.id, b.id)));
+      setContacts(
+        state
+          .map(([contactPetname, contact]) => kv({ contactPetname }, contact))
+          .sort(
+            (a, b) =>
+              cmp(a.contactPetname, b.contactPetname) || cmp(a.id, b.id),
+          ),
+      );
     },
-  }, E(walletP).getContactsNotifier());
-  updateFromNotifier({ updateState: setPayments }, E(walletP).getPaymentsNotifier());
-  updateFromNotifier({
+  });
+  observeNotifier(E(walletP).getPaymentsNotifier(), {
+    updateState: setPayments,
+  });
+  observeNotifier(E(walletP).getIssuersNotifier(), {
     updateState(state) {
-      setIssuers(state.map(([issuerPetname, issuer]) => kv({ issuerPetname }, issuer))
-        .sort((a, b) => cmp(a.id, b.id)));
+      setIssuers(
+        state
+          .map(([issuerPetname, issuer]) => kv({ issuerPetname }, issuer))
+          .sort((a, b) => cmp(a.id, b.id)),
+      );
     },
-  }, E(walletP).getIssuersNotifier());
+  });
 }
 
 /**

--- a/packages/notifier/src/asyncIterableAdaptor.js
+++ b/packages/notifier/src/asyncIterableAdaptor.js
@@ -106,7 +106,7 @@ export const observeIterator = (asyncIteratorP, iterationObserver) => {
         ({ value, done }) => {
           if (done) {
             iterationObserver.finish && iterationObserver.finish(value);
-            ack();
+            ack(undefined);
           } else {
             iterationObserver.updateState &&
               iterationObserver.updateState(value);
@@ -115,7 +115,7 @@ export const observeIterator = (asyncIteratorP, iterationObserver) => {
         },
         reason => {
           iterationObserver.fail && iterationObserver.fail(reason);
-          ack();
+          ack(undefined);
         },
       );
     };
@@ -155,6 +155,16 @@ export const updateFromIterable = (iterationObserver, asyncIterableP) =>
  * are lossy, i.e., once a more recent state can be reported, less recent
  * states are assumed irrelevant and dropped.
  *
+ * @template T
+ * @param {ERef<Notifier<T>>} notifierP
+ * @param {Partial<IterationObserver<T>>} iterationObserver
+ * @returns {Promise<undefined>}
+ */
+export const observeNotifier = (notifierP, iterationObserver) =>
+  observeIteration(makeAsyncIterableFromNotifier(notifierP), iterationObserver);
+
+/**
+ * @deprecated Use 'observeNotifier` instead.
  * @template T
  * @param {Partial<IterationObserver<T>>} iterationObserver
  * @param {ERef<Notifier<T>>} notifierP

--- a/packages/notifier/src/index.js
+++ b/packages/notifier/src/index.js
@@ -1,3 +1,16 @@
-export * from './notifier';
-export * from './subscriber';
-export * from './asyncIterableAdaptor';
+export {
+  makeNotifier,
+  makeNotifierKit,
+  makeNotifierFromAsyncIterable,
+} from './notifier';
+export { makeSubscription, makeSubscriptionKit } from './subscriber';
+export {
+  observeNotifier,
+  observeIterator,
+  observeIteration,
+  // deprecated. Consider not reexporting
+  updateFromIterable,
+  updateFromNotifier,
+  // Consider deprecating or not reexporting
+  makeAsyncIterableFromNotifier,
+} from './asyncIterableAdaptor';

--- a/packages/notifier/test/test-notifier-adaptor.js
+++ b/packages/notifier/test/test-notifier-adaptor.js
@@ -5,7 +5,7 @@ import {
   makeAsyncIterableFromNotifier,
   makeNotifierFromAsyncIterable,
   observeIteration,
-  updateFromNotifier,
+  observeNotifier,
 } from '../src/index';
 import {
   finiteStream,
@@ -81,11 +81,11 @@ test('notifier adaptor - for await fails', async t => {
 test('notifier adaptor - update from notifier finishes', t => {
   const u = makeTestIterationObserver(t, true, false);
   const n = makeNotifierFromAsyncIterable(finiteStream);
-  return updateFromNotifier(u, n);
+  return observeNotifier(n, u);
 });
 
 test('notifier adaptor - update from notifier fails', t => {
   const u = makeTestIterationObserver(t, true, true);
   const n = makeNotifierFromAsyncIterable(explodingStream);
-  return updateFromNotifier(u, n);
+  return observeNotifier(n, u);
 });

--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -12,7 +12,7 @@ import { E } from '@agoric/eventual-send';
 import { makeStore, makeWeakStore } from '@agoric/store';
 
 import { makeAmountMath, MathKind } from '@agoric/ertp';
-import { makeNotifierKit, updateFromNotifier } from '@agoric/notifier';
+import { makeNotifierKit, observeNotifier } from '@agoric/notifier';
 import { makePromiseKit } from '@agoric/promise-kit';
 import { assertRightsConserved } from './rightsConservation';
 import { makeIssuerTable } from '../issuerTable';
@@ -183,7 +183,7 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
       E(zoeInstanceAdmin)
         .makeNoEscrowSeat(initialAllocation, proposal, exitObj, seatHandle)
         .then(({ zoeSeatAdmin, notifier: zoeNotifier, userSeat }) => {
-          updateFromNotifier(updater, zoeNotifier);
+          observeNotifier(zoeNotifier, updater);
           zoeSeatAdminPromiseKit.resolve(zoeSeatAdmin);
           userSeatPromiseKit.resolve(userSeat);
         });


### PR DESCRIPTION
There was a hole in our notifier API. We had deprecated `updateFromIterable` in favor of `observeIteration` which just swaps the argument order. This PR similarly deprecates `updateFromNotifier` in favor of `observeNotifier` which just swaps the argument order.

Outside the `notifier` package `makeAsyncIterableFromNotifier` should rarely be used. Perhaps it should be deprecated or not even be exported. In any case, replaced a use of that with `observeNotifier`, which does the same thing internally.