### PR TITLE
fix: don't rely on OS exec semantics for agoric-cli; fork instead

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/init-basedir.js
+++ b/packages/cosmic-swingset/lib/ag-solo/init-basedir.js
@@ -21,12 +21,12 @@ export default function initBasedir(
   options.wallet = wallet;
 
   const here = __dirname;
-  if (
-    fs.existsSync(basedir) &&
-    !fs.existsSync(path.join(basedir, 'ag-cosmos-helper-address'))
-  ) {
-    assert.fail(X`${basedir} must not already exist`);
-  }
+  // We either need a basedir with an initialised key, or no basedir.
+  assert(
+    fs.existsSync(path.join(basedir, 'ag-cosmos-helper-address')) ||
+      !fs.existsSync(basedir),
+    X`${basedir} must not already exist`,
+  );
 
   fs.mkdirSync(basedir, { mode: 0o700, recursive: true });
 

--- a/packages/cosmic-swingset/lib/ag-solo/start.js
+++ b/packages/cosmic-swingset/lib/ag-solo/start.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import temp from 'temp';
-import { exec } from 'child_process';
+import { fork } from 'child_process';
 import { promisify } from 'util';
 // import { createHash } from 'crypto';
 
@@ -380,28 +380,35 @@ export default async function start(basedir, argv) {
     .map(dep => path.resolve(agWallet, dep))
     .join(' ');
 
-  const agoricCli = require.resolve('.bin/agoric');
+  const agoricCli = require.resolve('agoric/bin/agoric');
 
   // Use the same verbosity as our caller did for us.
   let verbosity;
   if (process.env.DEBUG === undefined) {
-    verbosity = '';
+    verbosity = [];
   } else if (process.env.DEBUG.includes('agoric')) {
-    verbosity = ' -vv';
+    verbosity = ['-vv'];
   } else {
-    verbosity = ' -v';
+    verbosity = ['-v'];
   }
 
-  // Launch the agoric wallet deploys (if any).
-  const cp = exec(
-    `${agoricCli} deploy${verbosity} --provide=wallet --hostport=${hostport} ${agWalletDeploy}`,
+  // Launch the agoric wallet deploys (if any).  The assumption is that the CLI
+  // runs correctly under the same version of the JS engine we're currently
+  // using.
+  fork(
+    agoricCli,
+    [
+      `deploy`,
+      ...verbosity,
+      `--provide=wallet`,
+      `--hostport=${hostport}`,
+      `${agWalletDeploy}`,
+    ],
+    { stdio: 'inherit' },
     err => {
       if (err) {
         console.error(err);
       }
     },
   );
-
-  cp.stderr.pipe(process.stderr);
-  cp.stdout.pipe(process.stdout);
 }


### PR DESCRIPTION
This allows MacOS Electron to work correctly, since it doesn't
bundle the `node_modules/.bin/agoric` itself.
