### PR TITLE
Suggested changes to #2488

### DIFF
--- a/packages/zoe/src/contracts/loan/borrow.js
+++ b/packages/zoe/src/contracts/loan/borrow.js
@@ -46,7 +46,10 @@ export const makeBorrowInvitation = (zcf, config) => {
     );
     // AWAIT ///
 
-    const collateralPriceInLoanBrand = quoteAmount.value[0].amountOut;
+    const {
+      amountOut: collateralPriceInLoanBrand,
+      timestamp,
+    } = quoteAmount.value[0];
 
     // formula: assert collateralValue*100 >= loanWanted*mmr
 
@@ -115,6 +118,7 @@ export const makeBorrowInvitation = (zcf, config) => {
       periodNotifier,
       interestRate,
       interestPeriod,
+      basetime: timestamp,
       zcf,
       configMinusGetDebt: {
         ...config,
@@ -126,7 +130,7 @@ export const makeBorrowInvitation = (zcf, config) => {
       getDebt,
       getDebtNotifier,
       getLastCalculationTimestamp,
-    } = makeDebtCalculator(harden(debtCalculatorConfig));
+    } = await makeDebtCalculator(harden(debtCalculatorConfig));
 
     /** @type {LoanConfigWithBorrower} */
     const configWithBorrower = {

--- a/packages/zoe/src/contracts/loan/types.js
+++ b/packages/zoe/src/contracts/loan/types.js
@@ -189,6 +189,8 @@
  * @property {ContractFacet} zcf
  *
  * @property {LoanConfigWithBorrowerMinusDebt} configMinusGetDebt
+ * @property {Timestamp} basetime The starting point from which to calculate
+ * interest.
  */
 
 /**

--- a/packages/zoe/src/contracts/loan/updateDebt.js
+++ b/packages/zoe/src/contracts/loan/updateDebt.js
@@ -2,6 +2,7 @@
 
 import '../../../exported';
 import { makeNotifierKit } from '@agoric/notifier';
+import { assert, details as X } from '@agoric/assert';
 
 import { natSafeMath } from '../../contractSupport';
 import { scheduleLiquidation } from './scheduleLiquidation';
@@ -72,11 +73,13 @@ export const makeDebtCalculator = async debtCalculatorConfig => {
       updateDebt(value);
     }
   };
-  handleDebt().catch(() =>
-    console.error(
-      `Unable to updateDebt originally:${originalDebt}, started: ${basetime}, debt: ${debt}`,
-    ),
-  );
+  handleDebt().catch(reason => {
+    assert.note(
+      reason,
+      X`Unable to updateDebt originally:${originalDebt}, started: ${basetime}, debt: ${debt}`,
+    );
+    console.error(reason);
+  });
 
   debtNotifierUpdater.updateState(debt);
 

--- a/packages/zoe/src/contracts/loan/updateDebt.js
+++ b/packages/zoe/src/contracts/loan/updateDebt.js
@@ -1,10 +1,7 @@
 // @ts-check
 
 import '../../../exported';
-import {
-  makeNotifierKit,
-  makeAsyncIterableFromNotifier,
-} from '@agoric/notifier';
+import { makeNotifierKit } from '@agoric/notifier';
 
 import { natSafeMath } from '../../contractSupport';
 import { scheduleLiquidation } from './scheduleLiquidation';
@@ -71,7 +68,7 @@ export const makeDebtCalculator = async debtCalculatorConfig => {
   };
 
   const handleDebt = async () => {
-    for await (const value of makeAsyncIterableFromNotifier(periodNotifier)) {
+    for await (const value of periodNotifier) {
       updateDebt(value);
     }
   };

--- a/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
@@ -310,14 +310,14 @@ test('getDebtNotifier with interest', async t => {
   ).getUpdateSince();
   t.deepEqual(originalDebt, maxLoan);
 
-  periodUpdater.updateState(5);
+  periodUpdater.updateState(6);
 
   const { value: debtCompounded1, updateCount: updateCount1 } = await E(
     debtNotifier,
   ).getUpdateSince(updateCount);
   t.deepEqual(debtCompounded1, loanKit.amountMath.make(40020));
 
-  periodUpdater.updateState(10);
+  periodUpdater.updateState(11);
 
   const { value: debtCompounded2 } = await E(debtNotifier).getUpdateSince(
     updateCount1,
@@ -375,7 +375,7 @@ test('aperiodic interest', async t => {
   ).getUpdateSince();
   t.deepEqual(originalDebt, maxLoan);
 
-  periodUpdater.updateState(5);
+  periodUpdater.updateState(6);
 
   const { value: debtCompounded1, updateCount: updateCount1 } = await E(
     debtNotifier,
@@ -383,16 +383,16 @@ test('aperiodic interest', async t => {
   t.deepEqual(debtCompounded1, loanKit.amountMath.make(40020));
 
   // skip ahead a notification
-  periodUpdater.updateState(15);
+  periodUpdater.updateState(16);
 
   // both debt notifications are received
   const { value: debtCompounded2, updateCount: updateCount2 } = await E(
     debtNotifier,
   ).getUpdateSince(updateCount1);
-  t.is(15, await E(borrowFacet).getLastCalculationTimestamp());
+  t.is(await E(borrowFacet).getLastCalculationTimestamp(), 16);
   t.deepEqual(debtCompounded2, loanKit.amountMath.make(40060));
 
-  periodUpdater.updateState(20);
+  periodUpdater.updateState(21);
   const { value: debtCompounded3 } = await E(debtNotifier).getUpdateSince(
     updateCount2,
   );
@@ -400,7 +400,8 @@ test('aperiodic interest', async t => {
 });
 
 // In this test, the updates are expected at multiples of 5, but they show up at
-// multiples of 4 instead. We should charge interest after 8, 12, 16, 20, 28
+// multiples of 4 instead. The starting time is 1. We should charge interest
+// after 9, 13, 17, 21, 29
 test('short periods', async t => {
   const {
     borrowFacet,
@@ -417,46 +418,46 @@ test('short periods', async t => {
   ).getUpdateSince();
   t.deepEqual(originalDebt, maxLoan);
 
-  periodUpdater.updateState(4);
-  t.is(0, await E(borrowFacet).getLastCalculationTimestamp());
+  periodUpdater.updateState(5);
+  t.is(await E(borrowFacet).getLastCalculationTimestamp(), 1);
 
-  periodUpdater.updateState(8);
+  periodUpdater.updateState(9);
   const { value: debtCompounded1, updateCount: updateCount1 } = await E(
     debtNotifier,
   ).getUpdateSince(updateCount);
   t.deepEqual(debtCompounded1, loanKit.amountMath.make(40020));
-  t.is(5, await E(borrowFacet).getLastCalculationTimestamp());
+  t.is(await E(borrowFacet).getLastCalculationTimestamp(), 6);
 
-  periodUpdater.updateState(12);
+  periodUpdater.updateState(14);
   const { value: debtCompounded2, updateCount: updateCount2 } = await E(
     debtNotifier,
   ).getUpdateSince(updateCount1);
   t.deepEqual(debtCompounded2, loanKit.amountMath.make(40040));
-  t.is(10, await E(borrowFacet).getLastCalculationTimestamp());
+  t.is(await E(borrowFacet).getLastCalculationTimestamp(), 11);
 
-  periodUpdater.updateState(16);
+  periodUpdater.updateState(17);
   const { value: debtCompounded3, updateCount: updateCount3 } = await E(
     debtNotifier,
   ).getUpdateSince(updateCount2);
   t.deepEqual(debtCompounded3, loanKit.amountMath.make(40060));
-  t.is(15, await E(borrowFacet).getLastCalculationTimestamp());
+  t.is(await E(borrowFacet).getLastCalculationTimestamp(), 16);
 
-  periodUpdater.updateState(20);
+  periodUpdater.updateState(21);
   const { value: debtCompounded4, updateCount: updateCount4 } = await E(
     debtNotifier,
   ).getUpdateSince(updateCount3);
   t.deepEqual(debtCompounded4, loanKit.amountMath.make(40080));
-  t.is(20, await E(borrowFacet).getLastCalculationTimestamp());
+  t.is(await E(borrowFacet).getLastCalculationTimestamp(), 21);
 
-  periodUpdater.updateState(24);
-  t.is(20, await E(borrowFacet).getLastCalculationTimestamp());
+  periodUpdater.updateState(25);
+  t.is(await E(borrowFacet).getLastCalculationTimestamp(), 21);
 
-  periodUpdater.updateState(28);
+  periodUpdater.updateState(29);
   const { value: debtCompounded5 } = await E(debtNotifier).getUpdateSince(
     updateCount4,
   );
   t.deepEqual(debtCompounded5, loanKit.amountMath.make(40100));
-  t.is(25, await E(borrowFacet).getLastCalculationTimestamp());
+  t.is(await E(borrowFacet).getLastCalculationTimestamp(), 26);
 });
 
 test.todo('borrow bad proposal');


### PR DESCRIPTION
This PR serves as a review comment on #2488 .

A local notifier already is an async iterable you can iterate with a `for/await/of` loop.

When catching errors and issuing diagnostics, don't throw away the original error as it likely has the most relevant diagnostic info anyway.