### PR TITLE
Alternate suggested changes to #2488

### DIFF
--- a/packages/zoe/src/contracts/loan/updateDebt.js
+++ b/packages/zoe/src/contracts/loan/updateDebt.js
@@ -2,6 +2,7 @@
 
 import '../../../exported';
 import { makeNotifierKit } from '@agoric/notifier';
+import { assert, details as X } from '@agoric/assert';
 
 import { natSafeMath } from '../../contractSupport';
 import { scheduleLiquidation } from './scheduleLiquidation';
@@ -72,11 +73,13 @@ export const makeDebtCalculator = async debtCalculatorConfig => {
       updateDebt(value);
     }
   };
-  handleDebt().catch(() =>
-    console.error(
-      `Unable to updateDebt originally:${originalDebt}, started: ${basetime}, debt: ${debt}`,
-    ),
-  );
+  handleDebt().catch(reason => {
+    assert.note(
+      reason,
+      X`Unable to updateDebt originally:${originalDebt}, started: ${basetime}, debt: ${debt}`,
+    );
+    console.error(reason);
+  });
 
   debtNotifierUpdater.updateState(debt);
 

--- a/packages/zoe/src/contracts/loan/updateDebt.js
+++ b/packages/zoe/src/contracts/loan/updateDebt.js
@@ -1,10 +1,7 @@
 // @ts-check
 
 import '../../../exported';
-import {
-  makeNotifierKit,
-  makeAsyncIterableFromNotifier,
-} from '@agoric/notifier';
+import { makeNotifierKit } from '@agoric/notifier';
 
 import { natSafeMath } from '../../contractSupport';
 import { scheduleLiquidation } from './scheduleLiquidation';
@@ -71,7 +68,7 @@ export const makeDebtCalculator = async debtCalculatorConfig => {
   };
 
   const handleDebt = async () => {
-    for await (const value of makeAsyncIterableFromNotifier(periodNotifier)) {
+    for await (const value of periodNotifier) {
       updateDebt(value);
     }
   };


### PR DESCRIPTION
Like #2513 this PR is a review comment on #2488 .

Rather than use iteration explicitly, just use the notifier observer API to notify an observer for each notification.

This splits the error paths, which is either good or bad, depending. The `fail` method in the observer gets notified about the notifier failing --- terminating with a rejection. However, if the `updateState` method itself throws, it doesn't go there. You could but a `try/catch` at the top of the `updateState` method itself. Instead this PR sticks closer to the original and catches a rejection of the promise for the end-of-observation signal.