### PR TITLE
Add zcf.assert which fails by shutting down the contract

### DIFF
--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -31,6 +31,7 @@ const missing = [
   'note',
   'details',
   'quote',
+  'makeAssert',
 ].filter(name => globalAssert[name] === undefined);
 if (missing.length > 0) {
   throw new Error(
@@ -40,11 +41,13 @@ if (missing.length > 0) {
   );
 }
 
-const { details, quote } = globalAssert;
+const { details, quote, makeAssert } = globalAssert;
 
 export { globalAssert as assert, details, quote };
 
 export { quote as q };
+
+export { makeAssert };
 
 /**
  * Prepend the correct indefinite article onto a noun, typically a typeof result

--- a/packages/assert/src/types.js
+++ b/packages/assert/src/types.js
@@ -189,6 +189,27 @@
  */
 
 /**
+ * @callback MakeAssert
+ *
+ * Makes and returns an `assert` function object that shares the bookkeeping
+ * state defined by this module with other `assert` function objects make by
+ * `makeAssert`. This state is per-module-instance and is exposed by the
+ * `loggedErrorHandler` above. We refer to `assert` as a "function object"
+ * because it can be called directly as a function, but also has methods that
+ * can be called.
+ *
+ * If `optRaise` is provided, the returned `assert` function object will call
+ * `optRaise(error)` before throwing the error. This enables `optRaise` to
+ * engage in even more violent termination behavior, like terminating the vat,
+ * that prevents execution from reaching the following throw. However, if
+ * `optRaise` returns normally, which would be unusual, the throw following
+ * `optRaise(error)` would still happen.
+ *
+ * @param {((error: Error) => void)=} optRaise
+ * @returns {Assert}
+ */
+
+/**
  * @typedef {(template: TemplateStringsArray | string[], ...args: any) => DetailsToken} DetailsTag
  *
  * Use the `details` function as a template literal tag to create
@@ -235,6 +256,7 @@
  *   string: AssertString,
  *   note: AssertNote,
  *   details: DetailsTag,
- *   quote: AssertQuote
+ *   quote: AssertQuote,
+ *   makeAssert: MakeAssert,
  * } } Assert
  */

--- a/packages/assert/src/types.js
+++ b/packages/assert/src/types.js
@@ -1,4 +1,4 @@
-/* eslint-disable jsdoc/require-returns-check,jsdoc/valid-types */
+// @ts-check
 // eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
@@ -15,6 +15,18 @@
  * @param {ErrorConstructor=} ErrorConstructor An optional alternate error
  * constructor to use.
  * @returns {asserts flag}
+ */
+
+/**
+ * @callback AssertMakeError
+ *
+ * The `assert.error` method, recording details for the console.
+ *
+ * The optional `optDetails` can be a string.
+ * @param {Details=} optDetails The details of what was asserted
+ * @param {ErrorConstructor=} ErrorConstructor An optional alternate error
+ * constructor to use.
+ * @returns {Error}
  */
 
 /**
@@ -169,6 +181,7 @@
  *   details`${sky.color} should be ${quote(color)}`,
  * );
  * ```
+ *
  * The normal convention is to locally rename `details` to `X` and import `q`
  * and `assert` unmodified.
  * ```js
@@ -189,6 +202,18 @@
  */
 
 /**
+ * @callback Raise
+ *
+ * To make an `assert` which terminates some larger unit of computation
+ * like a transaction, vat, or process, call `makeAssert` with a `Raise`
+ * callback, where that callback actually performs that larger termination.
+ * If possible, the callback should also report its `reason` parameter as
+ * the alleged reason for the termination.
+ *
+ * @param {Error} reason
+ */
+
+/**
  * @callback MakeAssert
  *
  * Makes and returns an `assert` function object that shares the bookkeeping
@@ -199,13 +224,13 @@
  * can be called.
  *
  * If `optRaise` is provided, the returned `assert` function object will call
- * `optRaise(error)` before throwing the error. This enables `optRaise` to
+ * `optRaise(reason)` before throwing the error. This enables `optRaise` to
  * engage in even more violent termination behavior, like terminating the vat,
  * that prevents execution from reaching the following throw. However, if
  * `optRaise` returns normally, which would be unusual, the throw following
- * `optRaise(error)` would still happen.
+ * `optRaise(reason)` would still happen.
  *
- * @param {((error: Error) => void)=} optRaise
+ * @param {Raise=} optRaise
  * @returns {Assert}
  */
 
@@ -251,6 +276,7 @@
  *
  * @typedef { BaseAssert & {
  *   typeof: AssertTypeof,
+ *   error: AssertMakeError,
  *   fail: AssertFail,
  *   equal: AssertEqual,
  *   string: AssertString,

--- a/packages/assert/src/types.js
+++ b/packages/assert/src/types.js
@@ -217,7 +217,7 @@
  * @callback MakeAssert
  *
  * Makes and returns an `assert` function object that shares the bookkeeping
- * state defined by this module with other `assert` function objects make by
+ * state defined by this module with other `assert` function objects made by
  * `makeAssert`. This state is per-module-instance and is exposed by the
  * `loggedErrorHandler` above. We refer to `assert` as a "function object"
  * because it can be called directly as a function, but also has methods that

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -29,6 +29,7 @@
  * @property {MakeInvitation} makeInvitation
  * @property {(completion: Completion) => void} shutdown
  * @property {(reason: TerminationReason) => void} shutdownWithFailure
+ * @property {Assert} assert
  * @property {() => ZoeService} getZoeService
  * @property {() => Issuer} getInvitationIssuer
  * @property {() => Terms} getTerms

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -1198,7 +1198,7 @@ test(`zcf.reallocate 3 seats, rights NOT conserved`, async t => {
 });
 
 test(`zcf.shutdown - userSeat exits`, async t => {
-  const { zoe, zcf } = await setupZCFTest({});
+  const { zoe, zcf } = await setupZCFTest();
   const { userSeat } = await makeOffer(zoe, zcf);
   zcf.shutdown('so long');
   t.deepEqual(await E(userSeat).getPayouts(), {});
@@ -1206,7 +1206,7 @@ test(`zcf.shutdown - userSeat exits`, async t => {
 });
 
 test(`zcf.shutdown - zcfSeat exits`, async t => {
-  const { zoe, zcf } = await setupZCFTest({});
+  const { zoe, zcf } = await setupZCFTest();
   const { zcfSeat, userSeat } = await makeOffer(zoe, zcf);
   t.falsy(zcfSeat.hasExited());
   await t.falsy(await E(userSeat).hasExited());
@@ -1216,7 +1216,7 @@ test(`zcf.shutdown - zcfSeat exits`, async t => {
 });
 
 test(`zcf.shutdown - no further offers accepted`, async t => {
-  const { zoe, zcf, vatAdminState } = await setupZCFTest({});
+  const { zoe, zcf, vatAdminState } = await setupZCFTest();
   const invitation = await zcf.makeInvitation(() => {}, 'seat');
   zcf.shutdown('sayonara');
   await t.throwsAsync(() => E(zoe).offer(invitation), {
@@ -1227,7 +1227,7 @@ test(`zcf.shutdown - no further offers accepted`, async t => {
 });
 
 test(`zcf.shutdownWithFailure - no further offers accepted`, async t => {
-  const { zoe, zcf, vatAdminState } = await setupZCFTest({});
+  const { zoe, zcf, vatAdminState } = await setupZCFTest();
   const invitation = await zcf.makeInvitation(() => {}, 'seat');
   zcf.shutdownWithFailure(`And don't come back`);
   await t.throwsAsync(() => E(zoe).offer(invitation), {
@@ -1238,7 +1238,7 @@ test(`zcf.shutdownWithFailure - no further offers accepted`, async t => {
 });
 
 test(`zcf.assert - no further offers accepted`, async t => {
-  const { zoe, zcf, vatAdminState } = await setupZCFTest({});
+  const { zoe, zcf, vatAdminState } = await setupZCFTest();
   const invitation = await zcf.makeInvitation(() => {}, 'seat');
   t.throws(() => zcf.assert(false, X`And do not come back`), {
     message: /And do not come back/,
@@ -1251,7 +1251,7 @@ test(`zcf.assert - no further offers accepted`, async t => {
 });
 
 test(`zcf.stopAcceptingOffers`, async t => {
-  const { zoe, zcf } = await setupZCFTest({});
+  const { zoe, zcf } = await setupZCFTest();
   const invitation1 = await zcf.makeInvitation(() => {}, 'seat');
   const invitation2 = await zcf.makeInvitation(() => {}, 'seat');
 

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -6,7 +6,7 @@ import test from 'ava';
 
 import { MathKind } from '@agoric/ertp';
 import { E } from '@agoric/eventual-send';
-import { assert } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 
 import { setup } from '../setupBasicMints';
 import buildManualTimer from '../../../tools/manualTimer';
@@ -1234,6 +1234,19 @@ test(`zcf.shutdownWithFailure - no further offers accepted`, async t => {
     message: 'No further offers are accepted',
   });
   t.is(vatAdminState.getExitMessage(), `And don't come back`);
+  t.truthy(vatAdminState.getExitWithFailure());
+});
+
+test(`zcf.assert - no further offers accepted`, async t => {
+  const { zoe, zcf, vatAdminState } = await setupZCFTest({});
+  const invitation = await zcf.makeInvitation(() => {}, 'seat');
+  t.throws(() => zcf.assert(false, X`And do not come back`), {
+    message: /And do not come back/,
+  });
+  await t.throwsAsync(() => E(zoe).offer(invitation), {
+    message: 'No further offers are accepted',
+  });
+  t.deepEqual(vatAdminState.getExitMessage(), Error(`And do not come back`));
   t.truthy(vatAdminState.getExitWithFailure());
 });
 


### PR DESCRIPTION
Introduces our first scoped variant of `assert`. 

`zcf.assert` is like `assert` except that where `assert` indicates failure by throwing an error, `zcf.assert` indicates failure with `zcf.shutdownWithFailure(error)` and then throws the error.