### PR TITLE
Fix redundant resolves in comms vat interaction

### DIFF
--- a/packages/SwingSet/src/vats/comms/clist-outbound.js
+++ b/packages/SwingSet/src/vats/comms/clist-outbound.js
@@ -77,14 +77,8 @@ export function makeOutbound(state, stateKit) {
     remote.toRemote.set(vpid, rpid);
     remote.fromRemote.set(flipRemoteSlot(rpid), vpid);
 
-    if (p.resolved) {
-      // we must send the resolution *after* the message which introduces it
-      const { remoteID } = remote;
-      Promise.resolve().then(() =>
-        resolveToRemote(remoteID, [[vpid, p.rejected, p.data]]),
-      );
-    } else {
-      // or arrange to send it later, once it resolves
+    if (!p.resolved) {
+      // arrange to send it later, once it resolves
       subscribeRemoteToPromise(vpid, remote.remoteID);
     }
   }

--- a/packages/SwingSet/src/vats/comms/clist-outbound.js
+++ b/packages/SwingSet/src/vats/comms/clist-outbound.js
@@ -19,12 +19,6 @@ export function makeOutbound(state, stateKit) {
     changeDeciderToRemote,
   } = stateKit;
 
-  let resolveToRemote; // cyclic, set later
-
-  function setDeliveryKit(deliveryKit) {
-    resolveToRemote = deliveryKit.resolveToRemote;
-  }
-
   function getRemoteForLocal(remoteID, lref) {
     const remote = getRemote(state, remoteID);
     const rref = remote.toRemote.get(lref);
@@ -131,8 +125,6 @@ export function makeOutbound(state, stateKit) {
   }
 
   return harden({
-    setDeliveryKit,
-
     getRemoteForLocal,
     provideRemoteForLocal,
     provideRemoteForLocalResult,

--- a/packages/SwingSet/src/vats/comms/clist.js
+++ b/packages/SwingSet/src/vats/comms/clist.js
@@ -77,7 +77,6 @@ export function makeCListKit(state, syscall, stateKit) {
   );
 
   function setDeliveryKit(deliveryKit) {
-    outbound.setDeliveryKit(deliveryKit);
     kernel.setDeliveryKit(deliveryKit);
   }
 


### PR DESCRIPTION
This appears to be the fix for #2393 

The issue was nothing like we imagined.

Turns out the comms vat already had some code that was kinda sorta doing the "fill in reintroduced promises" thing that our new multi-promise resolve does, sorta kinda.  This is a simple change, but it probably warrants more scrutiny than most, just because.