### PR TITLE
Prevent tests from installing like a kajillion unhandled rejection handlers

### DIFF
--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -37,6 +37,10 @@ function makeConsole(tag) {
   return harden(cons);
 }
 
+function unhandledRejectionHandler(e) {
+  console.error('UnhandledPromiseRejectionWarning:', e);
+}
+
 export async function makeSwingsetController(
   hostStorage = initSwingStore().storage,
   deviceEndowments = {},
@@ -68,9 +72,17 @@ export async function makeSwingsetController(
   harden(console);
 
   // FIXME: Put this somewhere better.
-  process.on('unhandledRejection', e =>
-    console.error('UnhandledPromiseRejectionWarning:', e),
-  );
+  const handlers = process.listeners('unhandledRejection');
+  let haveUnhandledRejectionHandler = false;
+  for (const handler of handlers) {
+    if (handler === unhandledRejectionHandler) {
+      haveUnhandledRejectionHandler = true;
+      break;
+    }
+  }
+  if (!haveUnhandledRejectionHandler) {
+    process.on('unhandledRejection', unhandledRejectionHandler);
+  }
 
   function kernelRequire(what) {
     if (what === 're2') {


### PR DESCRIPTION
Sometimes tests will create multiple controller instances, each of which would install a redundant unhandled rejection handler on the process.  But Node will whine if there are too many and we only need one.