### PR TITLE
Support for calculation with Ratios

### DIFF
--- a/packages/zoe/src/contractSupport/percentMath.js
+++ b/packages/zoe/src/contractSupport/percentMath.js
@@ -21,7 +21,10 @@ const { multiply, floorDivide } = natSafeMath;
 // with the same units. If you divide gallons by miles, the result is not a
 // percentage.
 
-/** @type {MakePercent} */
+/**
+ * @deprecated use Ratio instead
+ * @type {MakePercent}
+ */
 function makePercent(value, amountMath, base = 100n) {
   Nat(value);
   return harden({
@@ -37,9 +40,7 @@ function makePercent(value, amountMath, base = 100n) {
       return makePercent(base - value, amountMath, base);
     },
     // Percent is deprecated. This method supports migration.
-    makeRatio: _ => {
-      return makeRatio(value, amountMath.getBrand(), base);
-    },
+    makeRatio: _ => makeRatio(value, amountMath.getBrand(), base),
   });
 }
 harden(makePercent);

--- a/packages/zoe/src/contractSupport/percentMath.js
+++ b/packages/zoe/src/contractSupport/percentMath.js
@@ -4,6 +4,7 @@ import './types';
 import { assert, details as X } from '@agoric/assert';
 import { Nat } from '@agoric/nat';
 import { natSafeMath } from './safeMath';
+import { makeRatio } from './ratio';
 
 const { multiply, floorDivide } = natSafeMath;
 
@@ -34,6 +35,10 @@ function makePercent(value, amountMath, base = 100n) {
     complement: _ => {
       assert(value <= base, X`cannot take complement when > 100%.`);
       return makePercent(base - value, amountMath, base);
+    },
+    // Percent is deprecated. This method supports migration.
+    makeRatio: _ => {
+      return makeRatio(value, amountMath.getBrand(), base);
     },
   });
 }

--- a/packages/zoe/src/contractSupport/ratio.js
+++ b/packages/zoe/src/contractSupport/ratio.js
@@ -63,20 +63,12 @@ export function makeRatio(
   });
 }
 
-export function makeRatioFromAmounts(
-  numeratorAmount,
-  denominatorAmount,
-  base = BASIS_POINTS,
-) {
+export function makeRatioFromAmounts(numeratorAmount, denominatorAmount) {
   assert(denominatorAmount.value > 0, X`No infinite ratios!`);
 
-  const numerator = floorDivide(
-    multiply(Nat(base), numeratorAmount.value),
-    denominatorAmount.value,
-  );
   return harden({
-    numerator,
-    denominator: Nat(base),
+    numerator: Nat(numeratorAmount.value),
+    denominator: Nat(denominatorAmount.value),
     numeratorBrand: numeratorAmount.brand,
     denominatorBrand: denominatorAmount.brand,
   });
@@ -153,7 +145,7 @@ export function complementPercent(ratio) {
   assertIsRatio(ratio);
   assert(
     ratio.numerator <= ratio.denominator,
-    X`Ratio must be less than 1 to take its complement`,
+    X`Ratio must be less than or equal to 1 to take its complement`,
   );
   return makeRatio(
     subtract(ratio.denominator, ratio.numerator),

--- a/packages/zoe/src/contractSupport/ratio.js
+++ b/packages/zoe/src/contractSupport/ratio.js
@@ -33,11 +33,14 @@ const ratioPropertyNames = [
 
 function assertIsRatio(ratio) {
   const propertyNames = Object.getOwnPropertyNames(ratio);
-  assert(propertyNames.length === 4, X`Ratio must be a record with 4 fields`);
-  for (let i = 0; i < 4; i += 1) {
+  assert(
+    propertyNames.length === 4,
+    X`Ratio ${ratio} must be a record with 4 fields.`,
+  );
+  for (const name of propertyNames) {
     assert(
-      ratioPropertyNames[i] === propertyNames[i],
-      X`parameter must be a Ratio record`,
+      ratioPropertyNames.includes(name),
+      X`Parameter must be a Ratio record, but ${ratio} has ${name}`,
     );
   }
   Nat(ratio.numerator);

--- a/packages/zoe/src/contractSupport/ratio.js
+++ b/packages/zoe/src/contractSupport/ratio.js
@@ -68,13 +68,6 @@ export const makeRatioFromAmounts = (numeratorAmount, denominatorAmount) => {
   // TODO(https://github.com/Agoric/agoric-sdk/pull/2310) after the refactoring
   // coerce amounts using a native amountMath operation.
 
-  assert(
-    denominatorAmount.value > 0,
-    X`No infinite ratios! Denoninator was 0/${q(
-      denominatorAmount.brand.getAllegedName(),
-    )}`,
-  );
-
   return makeRatio(
     Nat(numeratorAmount.value),
     numeratorAmount.brand,

--- a/packages/zoe/src/contractSupport/ratio.js
+++ b/packages/zoe/src/contractSupport/ratio.js
@@ -1,0 +1,169 @@
+import './types';
+import { assert, details as X } from '@agoric/assert';
+import { Nat } from '@agoric/nat';
+import { natSafeMath } from './safeMath';
+
+const { multiply, floorDivide, subtract } = natSafeMath;
+
+// make a Ratio, which represents a fraction. It is a pass-by-copy record.
+//
+// The natural syntax for the most common operations we want to support
+// are Amount * Ratio and Amount / Ratio. Since the operations want to adhere to
+// the ratio rather than the amount, we settled on a calling convention of
+// multiplyBy(Amount, Ratio) and divideBy(Amount, Ratio).
+//
+// The most common kind of Ratio can be applied to Amounts of a particular
+// brand, and produces results of the same brand. This represents a multiplier
+// that is only applicable to that brand. The less common kind of Ratio can be
+// applied to one particular brand of amounts, and produces results of another
+// particular brand. This represents some kind of exchange rate. The
+// brand-checking helps us ensure that normal Ratios aren't applied to amounts
+// of the wrong brand, and that exchange rates are only used in the appropriate
+// direction.
+
+const BASIS_POINTS = 10000n;
+const PERCENT = 100n;
+
+const ratioPropertyNames = [
+  'numerator',
+  'denominator',
+  'numeratorBrand',
+  'denominatorBrand',
+];
+
+function assertIsRatio(ratio) {
+  const propertyNames = Object.getOwnPropertyNames(ratio);
+  assert(propertyNames.length === 4, X`Ratio must be a record with 4 fields`);
+  for (let i = 0; i < 4; i += 1) {
+    assert(
+      ratioPropertyNames[i] === propertyNames[i],
+      X`parameter must be a Ratio record`,
+    );
+  }
+  Nat(ratio.numerator);
+  Nat(ratio.denominator);
+}
+
+export function makeRatio(
+  numerator,
+  numeratorBrand,
+  denominator = PERCENT,
+  denominatorBrand = numeratorBrand,
+) {
+  assert(denominator > 0, X`No infinite ratios!`);
+
+  return harden({
+    numerator: Nat(numerator),
+    denominator: Nat(denominator),
+    numeratorBrand,
+    denominatorBrand,
+  });
+}
+
+export function makeRatioFromAmounts(
+  numeratorAmount,
+  denominatorAmount,
+  base = BASIS_POINTS,
+) {
+  assert(denominatorAmount.value > 0, X`No infinite ratios!`);
+
+  const numerator = floorDivide(
+    multiply(Nat(base), numeratorAmount.value),
+    denominatorAmount.value,
+  );
+  return harden({
+    numerator,
+    denominator: Nat(base),
+    numeratorBrand: numeratorAmount.brand,
+    denominatorBrand: denominatorAmount.brand,
+  });
+}
+
+export function multiplyBy(amount, ratio) {
+  assertIsRatio(ratio);
+  assert(
+    amount.brand === ratio.denominatorBrand,
+    X`amount's brand ${amount.brand} must match ratio's denominator ${ratio.denominatorBrand}`,
+  );
+
+  return harden({
+    value: floorDivide(
+      multiply(amount.value, ratio.numerator),
+      ratio.denominator,
+    ),
+    brand: ratio.numeratorBrand,
+  });
+}
+
+export function divideBy(amount, ratio) {
+  assertIsRatio(ratio);
+  assert(
+    amount.brand === ratio.numeratorBrand,
+    X`amount's brand ${amount.brand} must match ratio's numerator ${ratio.numeratorBrand}`,
+  );
+  return harden({
+    value: floorDivide(
+      multiply(amount.value, ratio.denominator),
+      ratio.numerator,
+    ),
+    brand: ratio.denominatorBrand,
+  });
+}
+
+export function invertRatio(ratio) {
+  assertIsRatio(ratio);
+
+  return makeRatio(
+    ratio.denominator,
+    ratio.denominatorBrand,
+    ratio.numerator,
+    ratio.numeratorBrand,
+  );
+}
+
+export function multiplyRatios(ratioA, ratioB) {
+  assertIsRatio(ratioA);
+  assertIsRatio(ratioB);
+
+  if (ratioA.numeratorBrand === ratioB.denominatorBrand) {
+    return makeRatio(
+      multiply(ratioA.numerator, ratioB.numerator),
+      ratioB.numeratorBrand,
+      multiply(ratioA.denominator, ratioB.denominator),
+      ratioA.denominatorBrand,
+    );
+  } else if (ratioA.denominatorBrand === ratioB.numeratorBrand) {
+    return makeRatio(
+      multiply(ratioA.numerator, ratioB.numerator),
+      ratioA.numeratorBrand,
+      multiply(ratioA.denominator, ratioB.denominator),
+      ratioB.denominatorBrand,
+    );
+  }
+  assert.fail(X`Ratios must have a common unit`);
+}
+
+// ///// PERCENT ///////////////////
+
+// If ratio is between 0 and 1, subtract from 1.
+export function complementPercent(ratio) {
+  assertIsRatio(ratio);
+  assert(
+    ratio.numerator <= ratio.denominator,
+    X`Ratio must be less than 1 to take its complement`,
+  );
+  return makeRatio(
+    subtract(ratio.denominator, ratio.numerator),
+    ratio.numeratorBrand,
+    ratio.denominator,
+    ratio.denominatorBrand,
+  );
+}
+
+export function make100Percent(brand) {
+  return makeRatio(BASIS_POINTS, brand, BASIS_POINTS);
+}
+
+export function make0Percent(brand) {
+  return makeRatio(0, brand);
+}

--- a/packages/zoe/src/contractSupport/ratio.js
+++ b/packages/zoe/src/contractSupport/ratio.js
@@ -53,7 +53,7 @@ export function makeRatio(
   denominator = PERCENT,
   denominatorBrand = numeratorBrand,
 ) {
-  assert(denominator > 0, X`No infinite ratios!`);
+  assert(denominator > 0n, X`No infinite ratios!`);
 
   return harden({
     numerator: Nat(numerator),
@@ -141,11 +141,11 @@ export function multiplyRatios(ratioA, ratioB) {
 // ///// PERCENT ///////////////////
 
 // If ratio is between 0 and 1, subtract from 1.
-export function complementPercent(ratio) {
+export function oneMinus(ratio) {
   assertIsRatio(ratio);
   assert(
     ratio.numerator <= ratio.denominator,
-    X`Ratio must be less than or equal to 1 to take its complement`,
+    X`Parameter must be less than or equal to 1: ${ratio.numerator}/${ratio.denominator}`,
   );
   return makeRatio(
     subtract(ratio.denominator, ratio.numerator),

--- a/packages/zoe/src/contractSupport/types.js
+++ b/packages/zoe/src/contractSupport/types.js
@@ -162,10 +162,3 @@
  * @param {Ratio} ratio
  * @returns {Ratio}
  */
-
-/**
- * @callback MultiplyRatios
- * @param {Ratio} ratioA
- * @param {Ratio} ratioB
- * @returns {Ratio}
- */

--- a/packages/zoe/src/contractSupport/types.js
+++ b/packages/zoe/src/contractSupport/types.js
@@ -174,7 +174,7 @@
  */
 
 /**
- * @callback ComplementPercent
+ * @callback oneMinus
  * @param {Ratio} ratio
  * @returns {Ratio}
  */

--- a/packages/zoe/src/contractSupport/types.js
+++ b/packages/zoe/src/contractSupport/types.js
@@ -123,10 +123,8 @@
 
 /**
  * @typedef {Object} Ratio
- * @property {bigint} numerator
- * @property {Brand} numeratorBrand
- * @property {bigint} denominator
- * @property {Brand} denominatorBrand
+ * @property {Amount} numerator
+ * @property {Amount} denominator
  */
 
 /**
@@ -170,23 +168,5 @@
  * @callback MultiplyRatios
  * @param {Ratio} ratioA
  * @param {Ratio} ratioB
- * @returns {Ratio}
- */
-
-/**
- * @callback oneMinus
- * @param {Ratio} ratio
- * @returns {Ratio}
- */
-
-/**
- * @callback Make100Percent
- * @param {Brand} brand
- * @returns {Ratio}
- */
-
-/**
- * @callback Make0Percent
- * @param {Brand} brand
  * @returns {Ratio}
  */

--- a/packages/zoe/src/contractSupport/types.js
+++ b/packages/zoe/src/contractSupport/types.js
@@ -120,3 +120,73 @@
  * keywordRecord
  * @param {KeywordKeywordRecord} keywordMapping
  */
+
+/**
+ * @typedef {Object} Ratio
+ * @property {bigint} numerator
+ * @property {Brand} numeratorBrand
+ * @property {bigint} denominator
+ * @property {Brand} denominatorBrand
+ */
+
+/**
+ * @callback MakeRatio
+ * @param {bigint} numerator
+ * @param {Brand} numeratorBrand
+ * @param {bigint=} denominator The default denomiator is 100
+ * @param {Brand=} denominatorBrand The default is to reuse the numeratorBrand
+ * @returns {Ratio}
+ */
+
+/**
+ * @callback MakeRatioFromAmounts
+ * @param {Amount} numerator
+ * @param {Amount} denominator
+ * @param {bigint=} base The default base is 10000
+ * @returns {Ratio}
+ */
+
+/**
+ * @callback MultiplyBy
+ * @param {Amount} amount
+ * @param {Ratio} ratio
+ * @returns {amount}
+ */
+
+/**
+ * @callback DivideBy
+ * @param {Amount} amount
+ * @param {Ratio} ratio
+ * @returns {amount}
+ */
+
+/**
+ * @callback InvertRatio
+ * @param {Ratio} ratio
+ * @returns {Ratio}
+ */
+
+/**
+ * @callback MultiplyRatios
+ * @param {Ratio} ratioA
+ * @param {Ratio} ratioB
+ * @returns {Ratio}
+ */
+
+/**
+ * @callback ComplementPercent
+ * @param {Ratio} ratio
+ * @returns {Ratio}
+ */
+
+/**
+ * @callback Make100Percent
+ * @param {Brand} brand
+ * @returns {Ratio}
+ */
+
+/**
+ * @callback Make0Percent
+ * @param {Brand} brand
+ * @returns {Ratio}
+ */

--- a/packages/zoe/src/contractSupport/types.js
+++ b/packages/zoe/src/contractSupport/types.js
@@ -140,7 +140,6 @@
  * @callback MakeRatioFromAmounts
  * @param {Amount} numerator
  * @param {Amount} denominator
- * @param {bigint=} base The default base is 10000
  * @returns {Ratio}
  */
 

--- a/packages/zoe/src/contracts/callSpread/percent.js
+++ b/packages/zoe/src/contracts/callSpread/percent.js
@@ -11,6 +11,10 @@ const BASIS_POINTS = 10000n;
 
 // If ratio is between 0 and 1, subtract from 1.
 export function oneMinus(ratio) {
+  assert(
+    ratio.numerator.brand === ratio.denominator.brand,
+    X`oneMinus only supports ratios with a single brand, but ${ratio.numerator.brand} doesn't match ${ratio.denominator.brand}`,
+  );
   assertIsRatio(ratio);
   assert(
     ratio.numerator.value <= ratio.denominator.value,

--- a/packages/zoe/src/contracts/callSpread/percent.js
+++ b/packages/zoe/src/contracts/callSpread/percent.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // some tools to make treating ratios as percents easier
 
 import { assert, details as X } from '@agoric/assert';

--- a/packages/zoe/src/contracts/callSpread/percent.js
+++ b/packages/zoe/src/contracts/callSpread/percent.js
@@ -1,0 +1,33 @@
+// some tools to make treating ratios as percents easier
+
+import { assert, details as X } from '@agoric/assert';
+
+import { makeRatio, assertIsRatio } from '../../contractSupport/ratio';
+import { natSafeMath } from '../../contractSupport';
+
+const { subtract } = natSafeMath;
+
+const BASIS_POINTS = 10000n;
+
+// If ratio is between 0 and 1, subtract from 1.
+export function oneMinus(ratio) {
+  assertIsRatio(ratio);
+  assert(
+    ratio.numerator.value <= ratio.denominator.value,
+    X`Parameter must be less than or equal to 1: ${ratio.numerator.value}/${ratio.denominator.value}`,
+  );
+  return makeRatio(
+    subtract(ratio.denominator.value, ratio.numerator.value),
+    ratio.numerator.brand,
+    ratio.denominator.value,
+    ratio.denominator.brand,
+  );
+}
+
+export function make100Percent(brand) {
+  return makeRatio(BASIS_POINTS, brand, BASIS_POINTS);
+}
+
+export function make0Percent(brand) {
+  return makeRatio(0, brand);
+}

--- a/packages/zoe/src/contracts/callSpread/types.js
+++ b/packages/zoe/src/contracts/callSpread/types.js
@@ -55,6 +55,7 @@
  * @typedef {Object} Percent
  * @property {Scale} scale
  * @property {() => Percent} complement
+ * @property {() => Ratio} makeRatio
  */
 
 /**
@@ -82,4 +83,22 @@
  * @param {Amount} strikePrice1
  * @param {Amount} strikePrice2
  * @returns {CalculateSharesReturn  }
+ */
+
+/**
+ * @callback oneMinus
+ * @param {Ratio} ratio
+ * @returns {Ratio}
+ */
+
+/**
+ * @callback Make100Percent
+ * @param {Brand} brand
+ * @returns {Ratio}
+ */
+
+/**
+ * @callback Make0Percent
+ * @param {Brand} brand
+ * @returns {Ratio}
  */

--- a/packages/zoe/test/unitTests/contractSupport/test-percentSupport.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-percentSupport.js
@@ -1,0 +1,77 @@
+import '@agoric/install-ses';
+import test from 'ava';
+import { makeIssuerKit } from '@agoric/ertp';
+
+import {
+  multiplyBy,
+  makeRatioFromAmounts,
+} from '../../../src/contractSupport/ratio';
+import {
+  make100Percent,
+  make0Percent,
+  oneMinus,
+} from '../../../src/contracts/callSpread/percent';
+
+// duplicated from test-ratio, but should go away with the amount refactoring
+function amountsEqual(t, a1, a2, brand) {
+  const brandEqual = a1.brand === a2.brand;
+  const valueEqual = a1.value === a2.value;
+  const correctBrand = a1.brand === brand;
+  if (brandEqual && valueEqual && correctBrand) {
+    t.truthy(brandEqual);
+  } else if (brandEqual && correctBrand) {
+    t.fail(`expected equal values: ${a1.value} !== ${a2.value}`);
+  } else if (valueEqual) {
+    t.fail(`Expected brand ${brand}, but got ${a1.brand} and ${a2.brand}`);
+  } else if (!brandEqual && !valueEqual && !correctBrand) {
+    t.fail(`nothing matches ${a1}, ${a2}, ${brand}`);
+  } else {
+    t.fail(
+      `neither values: (${a1.value}, ${a2.value}) nor brands matched (${brand} expected) ${a1.brand}, ${a2.brand})`,
+    );
+  }
+}
+
+test('ratio - ALL', t => {
+  const { amountMath, brand } = makeIssuerKit('moe');
+  const moe = amountMath.make;
+
+  amountsEqual(
+    t,
+    multiplyBy(moe(100_000), make100Percent(brand)),
+    moe(100_000),
+    brand,
+  );
+});
+
+test('ratio - NONE', t => {
+  const { amountMath, brand } = makeIssuerKit('moe');
+  const moe = amountMath.make;
+
+  amountsEqual(
+    t,
+    amountMath.getEmpty(),
+    multiplyBy(moe(100000), make0Percent(brand)),
+    brand,
+  );
+});
+
+test('ratio - complement', t => {
+  const { amountMath, brand } = makeIssuerKit('moe');
+  const moe = amountMath.make;
+
+  const oneThird = makeRatioFromAmounts(moe(1), moe(3));
+  const twoThirds = oneMinus(oneThird);
+
+  amountsEqual(t, multiplyBy(moe(100000), oneThird), moe(33333), brand);
+  amountsEqual(t, multiplyBy(moe(100000), twoThirds), moe(66666), brand);
+
+  t.throws(() =>
+    oneMinus(moe(3), {
+      message: 'Ratio must be a record with 4 fields',
+    }),
+  );
+  t.throws(() => oneMinus(makeRatioFromAmounts(moe(30), moe(20))), {
+    message: 'Parameter must be less than or equal to 1: (a bigint)/(a bigint)',
+  });
+});

--- a/packages/zoe/test/unitTests/contractSupport/test-percentSupport.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-percentSupport.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import '@agoric/install-ses';
 import test from 'ava';
 import { makeIssuerKit } from '@agoric/ertp';

--- a/packages/zoe/test/unitTests/contractSupport/test-ratio.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-ratio.js
@@ -52,11 +52,9 @@ test('ratio - onethird', t => {
   const { amountMath, brand } = makeIssuerKit('moe');
   const moe = amountMath.make;
 
-  const oneThirdPer100 = makeRatioFromAmounts(moe(1), moe(3), 100);
-  const oneThirdPrecise = makeRatioFromAmounts(moe(1), moe(3));
+  const oneThird = makeRatioFromAmounts(moe(1), moe(3));
 
-  amountsEqual(t, multiplyBy(moe(100000), oneThirdPer100), moe(33000), brand);
-  amountsEqual(t, multiplyBy(moe(100000), oneThirdPrecise), moe(33330), brand);
+  amountsEqual(t, multiplyBy(moe(100000), oneThird), moe(33333), brand);
 });
 
 test('ratio - brand mismatch', t => {
@@ -65,11 +63,7 @@ test('ratio - brand mismatch', t => {
   const moe = amountMath.make;
   const ast = astAmountMath.make;
 
-  const convertToMoe = makeRatioFromAmounts(
-    moe(1),
-    astAmountMath.make(3),
-    10000,
-  );
+  const convertToMoe = makeRatioFromAmounts(moe(1), astAmountMath.make(3));
   amountsEqual(t, multiplyBy(ast(10_000), convertToMoe), moe(3333), moeBrand);
 });
 
@@ -101,14 +95,11 @@ test('ratio - complement', t => {
   const { amountMath, brand } = makeIssuerKit('moe');
   const moe = amountMath.make;
 
-  const oneThirdPer100 = makeRatioFromAmounts(moe(1), moe(3), 100);
-  const twoThirdsPer100 = complementPercent(oneThirdPer100);
-  const oneThirdPrecise = makeRatioFromAmounts(moe(1), moe(3));
-  const twoThirdsPrecise = complementPercent(oneThirdPrecise);
+  const oneThird = makeRatioFromAmounts(moe(1), moe(3));
+  const twoThirds = complementPercent(oneThird);
 
-  amountsEqual(t, multiplyBy(moe(100000), oneThirdPer100), moe(33000), brand);
-  amountsEqual(t, multiplyBy(moe(100000), twoThirdsPer100), moe(67000), brand);
-  amountsEqual(t, multiplyBy(moe(100000), twoThirdsPrecise), moe(66670), brand);
+  amountsEqual(t, multiplyBy(moe(100000), oneThird), moe(33333), brand);
+  amountsEqual(t, multiplyBy(moe(100000), twoThirds), moe(66666), brand);
 
   t.throws(() =>
     complementPercent(moe(3), {
@@ -116,34 +107,18 @@ test('ratio - complement', t => {
     }),
   );
   t.throws(() => complementPercent(makeRatioFromAmounts(moe(30), moe(20))), {
-    message: 'Ratio must be less than 1 to take its complement',
+    message: 'Ratio must be less than or equal to 1 to take its complement',
   });
-});
-
-test('ratio - non-standard thirds', t => {
-  const { amountMath, brand: moeBrand } = makeIssuerKit('moe');
-  const moe = amountMath.make;
-
-  const oneThirdPer100 = makeRatioFromAmounts(moe(1), moe(3), 100);
-  const oneThirdBetter = makeRatioFromAmounts(moe(1), moe(3), 1000);
-  const oneThirdPrecise = makeRatio(1, moeBrand, 3, moeBrand);
-
-  amountsEqual(t, multiplyBy(moe(9000), oneThirdPer100), moe(2970), moeBrand);
-  amountsEqual(t, multiplyBy(moe(9000), oneThirdBetter), moe(2997), moeBrand);
-  amountsEqual(t, multiplyBy(moe(9000), oneThirdPrecise), moe(3000), moeBrand);
 });
 
 test('ratio - larger than 100%', t => {
   const { amountMath, brand } = makeIssuerKit('moe');
   const moe = amountMath.make;
 
-  const oneFiftyPer100 = makeRatioFromAmounts(moe(5), moe(3), 100);
-  const oneFiftyBetter = makeRatioFromAmounts(moe(5), moe(3), 1000);
+  const fiveThirds = makeRatioFromAmounts(moe(5), moe(3));
 
-  // 1.66 * 7777
-  amountsEqual(t, multiplyBy(moe(7777), oneFiftyPer100), moe(12909), brand);
-  // 1.666 * 7777
-  amountsEqual(t, multiplyBy(moe(7777), oneFiftyBetter), moe(12956), brand);
+  // 5/3 * 7777
+  amountsEqual(t, multiplyBy(moe(7777), fiveThirds), moe(12961), brand);
 });
 
 test('ratio - Nats', t => {
@@ -184,7 +159,7 @@ test('ratio multiple Ratios', t => {
 
   const fourFifths = makeRatioFromAmounts(larry(4), moe(5));
   const half = makeRatioFromAmounts(moe(10), curly(20));
-  const fiveEighths = makeRatioFromAmounts(moe(25), curly(40), 1000);
+  const fiveEighths = makeRatioFromAmounts(moe(25), curly(40));
 
   amountsEqual(
     t,

--- a/packages/zoe/test/unitTests/contractSupport/test-ratio.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-ratio.js
@@ -11,7 +11,7 @@ import {
   divideBy,
   invertRatio,
   multiplyRatios,
-  complementPercent,
+  oneMinus,
   make100Percent,
   make0Percent,
 } from '../../../src/contractSupport/ratio';
@@ -96,18 +96,18 @@ test('ratio - complement', t => {
   const moe = amountMath.make;
 
   const oneThird = makeRatioFromAmounts(moe(1), moe(3));
-  const twoThirds = complementPercent(oneThird);
+  const twoThirds = oneMinus(oneThird);
 
   amountsEqual(t, multiplyBy(moe(100000), oneThird), moe(33333), brand);
   amountsEqual(t, multiplyBy(moe(100000), twoThirds), moe(66666), brand);
 
   t.throws(() =>
-    complementPercent(moe(3), {
+    oneMinus(moe(3), {
       message: 'Ratio must be a record with 4 fields',
     }),
   );
-  t.throws(() => complementPercent(makeRatioFromAmounts(moe(30), moe(20))), {
-    message: 'Ratio must be less than or equal to 1 to take its complement',
+  t.throws(() => oneMinus(makeRatioFromAmounts(moe(30), moe(20))), {
+    message: 'Parameter must be less than or equal to 1: (a bigint)/(a bigint)',
   });
 });
 

--- a/packages/zoe/test/unitTests/contractSupport/test-ratio.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-ratio.js
@@ -1,0 +1,229 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@agoric/install-ses';
+import test from 'ava';
+import '../../../src/contractSupport/types';
+
+import { makeIssuerKit } from '@agoric/ertp';
+import {
+  makeRatio,
+  makeRatioFromAmounts,
+  multiplyBy,
+  divideBy,
+  invertRatio,
+  multiplyRatios,
+  complementPercent,
+  make100Percent,
+  make0Percent,
+} from '../../../src/contractSupport/ratio';
+
+function amountsEqual(t, a1, a2, brand) {
+  const brandEqual = a1.brand === a2.brand;
+  const valueEqual = a1.value === a2.value;
+  const correctBrand = a1.brand === brand;
+  if (brandEqual && valueEqual && correctBrand) {
+    t.truthy(brandEqual);
+  } else if (brandEqual && correctBrand) {
+    t.fail(`expected equal values: ${a1.value} !== ${a2.value}`);
+  } else if (valueEqual) {
+    t.fail(`Expected brand ${brand}, but got ${a1.brand} and ${a2.brand}`);
+  } else if (!brandEqual && !valueEqual && !correctBrand) {
+    t.fail(`nothing matches ${a1}, ${a2}, ${brand}`);
+  } else {
+    t.fail(
+      `neither values: (${a1.value}, ${a2.value}) nor brands matched (${brand} expected) ${a1.brand}, ${a2.brand})`,
+    );
+  }
+}
+
+test('ratio - basic', t => {
+  const { amountMath, brand } = makeIssuerKit('moe');
+  const moe = amountMath.make;
+
+  const halfDefault = makeRatio(50, brand);
+  const halfPrecise = makeRatio(5000, brand, 10000);
+
+  amountsEqual(t, multiplyBy(moe(1333), halfDefault), moe(666), brand);
+  amountsEqual(t, multiplyBy(moe(13333333), halfDefault), moe(6666666), brand);
+  amountsEqual(t, multiplyBy(moe(1333), halfPrecise), moe(666), brand);
+  amountsEqual(t, multiplyBy(moe(13333333), halfPrecise), moe(6666666), brand);
+});
+
+test('ratio - onethird', t => {
+  const { amountMath, brand } = makeIssuerKit('moe');
+  const moe = amountMath.make;
+
+  const oneThirdPer100 = makeRatioFromAmounts(moe(1), moe(3), 100);
+  const oneThirdPrecise = makeRatioFromAmounts(moe(1), moe(3));
+
+  amountsEqual(t, multiplyBy(moe(100000), oneThirdPer100), moe(33000), brand);
+  amountsEqual(t, multiplyBy(moe(100000), oneThirdPrecise), moe(33330), brand);
+});
+
+test('ratio - brand mismatch', t => {
+  const { amountMath, brand: moeBrand } = makeIssuerKit('moe');
+  const { amountMath: astAmountMath } = makeIssuerKit('ast');
+  const moe = amountMath.make;
+  const ast = astAmountMath.make;
+
+  const convertToMoe = makeRatioFromAmounts(
+    moe(1),
+    astAmountMath.make(3),
+    10000,
+  );
+  amountsEqual(t, multiplyBy(ast(10_000), convertToMoe), moe(3333), moeBrand);
+});
+
+test('ratio - ALL', t => {
+  const { amountMath, brand } = makeIssuerKit('moe');
+  const moe = amountMath.make;
+
+  amountsEqual(
+    t,
+    multiplyBy(moe(100_000), make100Percent(brand)),
+    moe(100_000),
+    brand,
+  );
+});
+
+test('ratio - NONE', t => {
+  const { amountMath, brand } = makeIssuerKit('moe');
+  const moe = amountMath.make;
+
+  amountsEqual(
+    t,
+    amountMath.getEmpty(),
+    multiplyBy(moe(100000), make0Percent(brand)),
+    brand,
+  );
+});
+
+test('ratio - complement', t => {
+  const { amountMath, brand } = makeIssuerKit('moe');
+  const moe = amountMath.make;
+
+  const oneThirdPer100 = makeRatioFromAmounts(moe(1), moe(3), 100);
+  const twoThirdsPer100 = complementPercent(oneThirdPer100);
+  const oneThirdPrecise = makeRatioFromAmounts(moe(1), moe(3));
+  const twoThirdsPrecise = complementPercent(oneThirdPrecise);
+
+  amountsEqual(t, multiplyBy(moe(100000), oneThirdPer100), moe(33000), brand);
+  amountsEqual(t, multiplyBy(moe(100000), twoThirdsPer100), moe(67000), brand);
+  amountsEqual(t, multiplyBy(moe(100000), twoThirdsPrecise), moe(66670), brand);
+
+  t.throws(() =>
+    complementPercent(moe(3), {
+      message: 'Ratio must be a record with 4 fields',
+    }),
+  );
+  t.throws(() => complementPercent(makeRatioFromAmounts(moe(30), moe(20))), {
+    message: 'Ratio must be less than 1 to take its complement',
+  });
+});
+
+test('ratio - non-standard thirds', t => {
+  const { amountMath, brand: moeBrand } = makeIssuerKit('moe');
+  const moe = amountMath.make;
+
+  const oneThirdPer100 = makeRatioFromAmounts(moe(1), moe(3), 100);
+  const oneThirdBetter = makeRatioFromAmounts(moe(1), moe(3), 1000);
+  const oneThirdPrecise = makeRatio(1, moeBrand, 3, moeBrand);
+
+  amountsEqual(t, multiplyBy(moe(9000), oneThirdPer100), moe(2970), moeBrand);
+  amountsEqual(t, multiplyBy(moe(9000), oneThirdBetter), moe(2997), moeBrand);
+  amountsEqual(t, multiplyBy(moe(9000), oneThirdPrecise), moe(3000), moeBrand);
+});
+
+test('ratio - larger than 100%', t => {
+  const { amountMath, brand } = makeIssuerKit('moe');
+  const moe = amountMath.make;
+
+  const oneFiftyPer100 = makeRatioFromAmounts(moe(5), moe(3), 100);
+  const oneFiftyBetter = makeRatioFromAmounts(moe(5), moe(3), 1000);
+
+  // 1.66 * 7777
+  amountsEqual(t, multiplyBy(moe(7777), oneFiftyPer100), moe(12909), brand);
+  // 1.666 * 7777
+  amountsEqual(t, multiplyBy(moe(7777), oneFiftyBetter), moe(12956), brand);
+});
+
+test('ratio - Nats', t => {
+  const { brand } = makeIssuerKit('moe');
+
+  t.throws(() => makeRatio(10.1, brand), {
+    message: '10.1 not a safe integer',
+  });
+});
+
+test('ratio division', t => {
+  const { amountMath, brand: moeBrand } = makeIssuerKit('moe');
+  const moe = amountMath.make;
+
+  const twoFifths = makeRatioFromAmounts(moe(2), moe(5));
+  amountsEqual(t, divideBy(moe(100), twoFifths), moe(250), moeBrand);
+  amountsEqual(t, multiplyBy(moe(100), twoFifths), moe(40), moeBrand);
+});
+
+test('ratio inverse', t => {
+  const { amountMath, brand: moeBrand } = makeIssuerKit('moe');
+  const moe = amountMath.make;
+
+  const twoFifths = makeRatioFromAmounts(moe(2), moe(5));
+  const fiveHalves = invertRatio(twoFifths);
+
+  amountsEqual(t, divideBy(moe(100), fiveHalves), moe(40), moeBrand);
+  amountsEqual(t, multiplyBy(moe(100), fiveHalves), moe(250), moeBrand);
+});
+
+test('ratio multiple Ratios', t => {
+  const { amountMath: moeMath } = makeIssuerKit('moe');
+  const { amountMath: curlyMath } = makeIssuerKit('curly');
+  const { amountMath: larryMath, brand: larryBrand } = makeIssuerKit('larry');
+  const moe = moeMath.make;
+  const larry = larryMath.make;
+  const curly = curlyMath.make;
+
+  const fourFifths = makeRatioFromAmounts(larry(4), moe(5));
+  const half = makeRatioFromAmounts(moe(10), curly(20));
+  const fiveEighths = makeRatioFromAmounts(moe(25), curly(40), 1000);
+
+  amountsEqual(
+    t,
+    multiplyBy(curly(1000), multiplyRatios(fourFifths, fiveEighths)),
+    larry(500),
+    larryBrand,
+  );
+
+  amountsEqual(
+    t,
+    multiplyBy(curly(100), multiplyRatios(half, fourFifths)),
+    larry(40),
+    larryBrand,
+  );
+
+  t.throws(() => multiplyRatios(half, fiveEighths), {
+    message: 'Ratios must have a common unit',
+  });
+  t.throws(() => multiplyRatios(moe(5), fiveEighths), {
+    message: 'Ratio must be a record with 4 fields',
+  });
+});
+
+test('ratio bad inputs', t => {
+  const { amountMath, brand: moeBrand } = makeIssuerKit('moe');
+  const moe = amountMath.make;
+  t.throws(() => makeRatio(-3, moeBrand), {
+    message: '-3 is negative',
+  });
+  t.throws(() => makeRatio(3, moeBrand, 100.5), {
+    message: '100.5 not a safe integer',
+  });
+  t.throws(() => makeRatioFromAmounts(3, moe(30)), {
+    message: 'undefined is a undefined but must be a bigint or a number',
+  });
+  t.throws(() => multiplyBy(37, makeRatioFromAmounts(moe(3), moe(5))), {
+    message: `amount's brand (an undefined) must match ratio's denominator (an object)`,
+  });
+  t.throws(() => divideBy(makeRatioFromAmounts(moe(3), moe(5)), 37), {
+    message: `Ratio must be a record with 4 fields`,
+  });
+});

--- a/packages/zoe/test/unitTests/contractSupport/test-ratio.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-ratio.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 import test from 'ava';
 import '../../../src/contractSupport/types';
@@ -11,9 +10,6 @@ import {
   divideBy,
   invertRatio,
   multiplyRatios,
-  oneMinus,
-  make100Percent,
-  make0Percent,
 } from '../../../src/contractSupport/ratio';
 
 function amountsEqual(t, a1, a2, brand) {
@@ -65,50 +61,6 @@ test('ratio - brand mismatch', t => {
 
   const convertToMoe = makeRatioFromAmounts(moe(1), astAmountMath.make(3));
   amountsEqual(t, multiplyBy(ast(10_000), convertToMoe), moe(3333), moeBrand);
-});
-
-test('ratio - ALL', t => {
-  const { amountMath, brand } = makeIssuerKit('moe');
-  const moe = amountMath.make;
-
-  amountsEqual(
-    t,
-    multiplyBy(moe(100_000), make100Percent(brand)),
-    moe(100_000),
-    brand,
-  );
-});
-
-test('ratio - NONE', t => {
-  const { amountMath, brand } = makeIssuerKit('moe');
-  const moe = amountMath.make;
-
-  amountsEqual(
-    t,
-    amountMath.getEmpty(),
-    multiplyBy(moe(100000), make0Percent(brand)),
-    brand,
-  );
-});
-
-test('ratio - complement', t => {
-  const { amountMath, brand } = makeIssuerKit('moe');
-  const moe = amountMath.make;
-
-  const oneThird = makeRatioFromAmounts(moe(1), moe(3));
-  const twoThirds = oneMinus(oneThird);
-
-  amountsEqual(t, multiplyBy(moe(100000), oneThird), moe(33333), brand);
-  amountsEqual(t, multiplyBy(moe(100000), twoThirds), moe(66666), brand);
-
-  t.throws(() =>
-    oneMinus(moe(3), {
-      message: 'Ratio must be a record with 4 fields',
-    }),
-  );
-  t.throws(() => oneMinus(makeRatioFromAmounts(moe(30), moe(20))), {
-    message: 'Parameter must be less than or equal to 1: (a bigint)/(a bigint)',
-  });
 });
 
 test('ratio - larger than 100%', t => {
@@ -179,7 +131,7 @@ test('ratio multiple Ratios', t => {
     message: 'Ratios must have a common unit',
   });
   t.throws(() => multiplyRatios(moe(5), fiveEighths), {
-    message: 'Ratio (an object) must be a record with 4 fields.',
+    message: 'Parameter must be a Ratio record, but (an object) has "brand"',
   });
 });
 
@@ -199,6 +151,6 @@ test('ratio bad inputs', t => {
     message: `amount's brand (an undefined) must match ratio's denominator (an object)`,
   });
   t.throws(() => divideBy(makeRatioFromAmounts(moe(3), moe(5)), 37), {
-    message: `Ratio (a number) must be a record with 4 fields.`,
+    message: `Ratio (a number) must be a record with 2 fields.`,
   });
 });

--- a/packages/zoe/test/unitTests/contractSupport/test-ratio.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-ratio.js
@@ -204,7 +204,7 @@ test('ratio multiple Ratios', t => {
     message: 'Ratios must have a common unit',
   });
   t.throws(() => multiplyRatios(moe(5), fiveEighths), {
-    message: 'Ratio must be a record with 4 fields',
+    message: 'Ratio (an object) must be a record with 4 fields.',
   });
 });
 
@@ -224,6 +224,6 @@ test('ratio bad inputs', t => {
     message: `amount's brand (an undefined) must match ratio's denominator (an object)`,
   });
   t.throws(() => divideBy(makeRatioFromAmounts(moe(3), moe(5)), 37), {
-    message: `Ratio must be a record with 4 fields`,
+    message: `Ratio (a number) must be a record with 4 fields.`,
   });
 });


### PR DESCRIPTION
The representation of Ratios has changed to a numeratorAmount and a denominatorAmount. 

The support for percents has been moved to the callSpread contract. `complementPercent()` has been renamed to `oneMinus(ratio)`

closes #2417
