### PR TITLE
fix(xsnap): orderly fail-stop on heap exhaustion

### DIFF
--- a/packages/xsnap/test/test-xsnap.js
+++ b/packages/xsnap/test/test-xsnap.js
@@ -355,9 +355,10 @@ test('heap exhaustion: orderly fail-stop', async t => {
     stuff = stuff + stuff;
   }
   `;
-  for await (const debug of [false, true]) {
+  for (const debug of [false, true]) {
     const vat = xsnap({ ...xsnapOptions, meteringLimit: 0, debug });
     t.teardown(() => vat.terminate());
+    // eslint-disable-next-line no-await-in-loop
     await t.throwsAsync(vat.evaluate(grow));
   }
 });

--- a/packages/xsnap/test/test-xsnap.js
+++ b/packages/xsnap/test/test-xsnap.js
@@ -347,3 +347,17 @@ test('normal close of pathological script', async t => {
   await vat.terminate();
   await hang;
 });
+
+test('heap exhaustion: orderly fail-stop', async t => {
+  const grow = `
+  let stuff = '1234';
+  while (true) {
+    stuff = stuff + stuff;
+  }
+  `;
+  for await (const debug of [false, true]) {
+    const vat = xsnap({ ...xsnapOptions, meteringLimit: 0, debug });
+    t.teardown(() => vat.terminate());
+    await t.throwsAsync(vat.evaluate(grow));
+  }
+});


### PR DESCRIPTION
Note https://github.com/Moddable-OpenSource/moddable/issues/567 is only fixed for certain cases.