### PR TITLE
Payments are virtual objects.

### DIFF
--- a/packages/ERTP/globals.d.ts
+++ b/packages/ERTP/globals.d.ts
@@ -1,0 +1,2 @@
+declare var makeKind: function;
+declare var makeWeakStore: function;

--- a/packages/ERTP/jsconfig.json
+++ b/packages/ERTP/jsconfig.json
@@ -14,5 +14,5 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["src/**/*.js", "exported.js"],
+  "include": ["src/**/*.js", "exported.js", "globals.d.ts"],
 }

--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -73,8 +73,7 @@
       "test/**/test-*.js"
     ],
     "require": [
-      "esm",
-      "@agoric/install-ses"
+      "esm"
     ]
   },
   "eslintConfig": {

--- a/packages/ERTP/src/payment.js
+++ b/packages/ERTP/src/payment.js
@@ -1,0 +1,22 @@
+// @ts-check
+/* global makeKind */
+
+import { Far } from '@agoric/marshal';
+import { makeFarName, ERTPKind } from './interfaces';
+
+export const makePaymentMaker = (allegedName, brand) => {
+  const paymentVOFactory = state => {
+    return {
+      init: b => (state.brand = b),
+      self: Far(makeFarName(allegedName, ERTPKind.PAYMENT), {
+        getAllegedBrand: () => state.brand,
+      }),
+    };
+  };
+
+  const paymentMaker = makeKind(paymentVOFactory);
+
+  const makePayment = () => paymentMaker(brand);
+
+  return makePayment;
+};

--- a/packages/ERTP/test/swingsetTests/basicFunctionality/bootstrap.js
+++ b/packages/ERTP/test/swingsetTests/basicFunctionality/bootstrap.js
@@ -1,0 +1,31 @@
+import { E } from '@agoric/eventual-send';
+import { assert, details as X } from '@agoric/assert';
+import { makeIssuerKit } from '../../../src';
+
+export function buildRootObject(vatPowers, vatParameters) {
+  const arg0 = vatParameters.argv[0];
+
+  function testBasicFunctionality(aliceMaker) {
+    vatPowers.testLog('start test basic functionality');
+    const { mint: moolaMint, issuer, amountMath } = makeIssuerKit('moola');
+    const moolaPayment = moolaMint.mintPayment(amountMath.make(1000));
+
+    const aliceP = E(aliceMaker).make(issuer, amountMath, moolaPayment);
+    return E(aliceP).testBasicFunctionality();
+  }
+
+  const obj0 = {
+    async bootstrap(vats) {
+      switch (arg0) {
+        case 'basicFunctionality': {
+          const aliceMaker = await E(vats.alice).makeAliceMaker();
+          return testBasicFunctionality(aliceMaker);
+        }
+        default: {
+          assert.fail(X`unrecognized argument value ${arg0}`);
+        }
+      }
+    },
+  };
+  return harden(obj0);
+}

--- a/packages/ERTP/test/swingsetTests/basicFunctionality/test-basicFunctionality.js
+++ b/packages/ERTP/test/swingsetTests/basicFunctionality/test-basicFunctionality.js
@@ -1,0 +1,34 @@
+// @ts-check
+/* global __dirname */
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@agoric/swingset-vat/tools/prepare-test-env';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import test from 'ava';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { loadBasedir, buildVatController } from '@agoric/swingset-vat';
+import path from 'path';
+
+async function main(basedir, argv) {
+  const dir = path.resolve(`${__dirname}/..`, basedir);
+  const config = await loadBasedir(dir);
+  const controller = await buildVatController(config, argv);
+  await controller.run();
+  return controller.dump();
+}
+
+const expected = [
+  'start test basic functionality',
+  'isLive: true',
+  'getAmountOf: {"brand":{},"value":1000}',
+  'newPayment amount: {"brand":{},"value":1000}',
+  'burned amount: {"brand":{},"value":200}',
+  'claimedPayment amount: {"brand":{},"value":200}',
+  'combinedPayment amount: {"brand":{},"value":600}',
+];
+
+test('test splitPayments', async t => {
+  const dump = await main('basicFunctionality', ['basicFunctionality']);
+  t.deepEqual(dump.log, expected);
+});

--- a/packages/ERTP/test/swingsetTests/basicFunctionality/vat-alice.js
+++ b/packages/ERTP/test/swingsetTests/basicFunctionality/vat-alice.js
@@ -1,0 +1,69 @@
+import { E } from '@agoric/eventual-send';
+
+function makeAliceMaker(log) {
+  return harden({
+    make(issuer, amountMath, oldPaymentP) {
+      const alice = harden({
+        async testBasicFunctionality() {
+          // isLive
+          const alive = await E(issuer).isLive(oldPaymentP);
+          log('isLive: ', alive);
+
+          // getAmountOf
+          const amount = await E(issuer).getAmountOf(oldPaymentP);
+          log('getAmountOf: ', amount);
+
+          // Make Purse
+
+          const purse = E(issuer).makeEmptyPurse();
+
+          // Deposit Payment
+
+          const payment = await oldPaymentP;
+          await E(purse).deposit(payment);
+
+          // Withdraw Payment
+          const newPayment = E(purse).withdraw(amount);
+          const newAmount = await E(issuer).getAmountOf(newPayment);
+          log('newPayment amount: ', newAmount);
+
+          // splitMany
+          const moola200 = await E(amountMath).make(200);
+          const [paymentToBurn, paymentToClaim, ...payments] = await E(
+            issuer,
+          ).splitMany(
+            newPayment,
+            harden([moola200, moola200, moola200, moola200, moola200]),
+          );
+
+          // burn
+          const burnedAmount = await E(issuer).burn(paymentToBurn);
+          log('burned amount: ', burnedAmount);
+
+          // claim
+          const claimedPayment = await E(issuer).claim(paymentToClaim);
+          const claimedPaymentAmount = await E(issuer).getAmountOf(
+            claimedPayment,
+          );
+          log('claimedPayment amount: ', claimedPaymentAmount);
+
+          // combine
+          const combinedPayment = E(issuer).combine(payments);
+          const combinedPaymentAmount = await E(issuer).getAmountOf(
+            combinedPayment,
+          );
+          log('combinedPayment amount: ', combinedPaymentAmount);
+        },
+      });
+      return alice;
+    },
+  });
+}
+
+export function buildRootObject(vatPowers) {
+  return harden({
+    makeAliceMaker() {
+      return harden(makeAliceMaker(vatPowers.testLog));
+    },
+  });
+}

--- a/packages/ERTP/test/swingsetTests/splitPayments/test-splitPayments.js
+++ b/packages/ERTP/test/swingsetTests/splitPayments/test-splitPayments.js
@@ -2,6 +2,9 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
+import '@agoric/swingset-vat/tools/prepare-test-env';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
@@ -1,6 +1,9 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
+import '@agoric/swingset-vat/tools/prepare-test-env';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { Far } from '@agoric/marshal';
 import { amountMath as m, MathKind } from '../../../src';

--- a/packages/ERTP/test/unitTests/mathHelpers/test-setMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-setMathHelpers.js
@@ -1,6 +1,9 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
+import '@agoric/swingset-vat/tools/prepare-test-env';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 
 import { Far, Data } from '@agoric/marshal';

--- a/packages/ERTP/test/unitTests/mathHelpers/test-strSetMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-strSetMathHelpers.js
@@ -1,6 +1,9 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
+import '@agoric/swingset-vat/tools/prepare-test-env';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { amountMath as m, MathKind } from '../../../src';
 import { mockBrand } from './mockBrand';

--- a/packages/ERTP/test/unitTests/test-interfaces.js
+++ b/packages/ERTP/test/unitTests/test-interfaces.js
@@ -1,6 +1,9 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
+import '@agoric/swingset-vat/tools/prepare-test-env';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { getInterfaceOf } from '@agoric/marshal';
 import { makeIssuerKit, amountMath } from '../../src';

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -1,6 +1,9 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
+import '@agoric/swingset-vat/tools/prepare-test-env';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { E } from '@agoric/eventual-send';
 import { Data } from '@agoric/marshal';

--- a/packages/ERTP/test/unitTests/test-mintObj.js
+++ b/packages/ERTP/test/unitTests/test-mintObj.js
@@ -1,4 +1,6 @@
 // @ts-check
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@agoric/swingset-vat/tools/prepare-test-env';
 
 import { Far } from '@agoric/marshal';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -63,7 +63,8 @@
   "files": [
     "bin/vat",
     "src/**/*.js",
-    "exported.js"
+    "exported.js",
+    "tools"
   ],
   "repository": {
     "type": "git",

--- a/packages/cosmic-swingset/globals.d.ts
+++ b/packages/cosmic-swingset/globals.d.ts
@@ -1,0 +1,2 @@
+declare var makeKind: function;
+declare var makeWeakStore: function;

--- a/packages/cosmic-swingset/jsconfig.json
+++ b/packages/cosmic-swingset/jsconfig.json
@@ -14,5 +14,5 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["lib/**/*.js", "exported.js"],
+  "include": ["lib/**/*.js", "exported.js", "globals.d.ts"],
 }

--- a/packages/dapp-svelte-wallet/api/test/test-getPursesNotifier.js
+++ b/packages/dapp-svelte-wallet/api/test/test-getPursesNotifier.js
@@ -1,6 +1,6 @@
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses'; // calls lockdown()
+import '@agoric/zoe/tools/prepare-test-env'; // calls lockdown()
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/dapp-svelte-wallet/api/test/test-lib-dehydrate.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-dehydrate.js
@@ -1,4 +1,4 @@
-import '@agoric/install-ses'; // calls lockdown()
+import '@agoric/zoe/tools/prepare-test-env'; // calls lockdown()
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { Far } from '@agoric/marshal';

--- a/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
@@ -1,7 +1,7 @@
 /* global require */
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses'; // calls lockdown()
+import '@agoric/zoe/tools/prepare-test-env'; // calls lockdown()
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/deploy-script-support/globals.d.ts
+++ b/packages/deploy-script-support/globals.d.ts
@@ -1,0 +1,2 @@
+declare var makeKind: function;
+declare var makeWeakStore: function;

--- a/packages/deploy-script-support/jsconfig.json
+++ b/packages/deploy-script-support/jsconfig.json
@@ -14,5 +14,5 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["src/**/*.js", "exported.js"],
+  "include": ["src/**/*.js", "exported.js", "globals.d.ts"],
 }

--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -1,5 +1,7 @@
 // @ts-check
 
+/* global makeWeakStore */
+
 // This is the Zoe contract facet. Each time we make a new instance of a
 // contract we will start by creating a new vat and running this code in it. In
 // order to install this code in a vat, Zoe needs to import a bundle containing
@@ -9,7 +11,7 @@
 
 import { assert, details as X, q, makeAssert } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
-import { makeStore, makeWeakStore } from '@agoric/store';
+import { makeStore } from '@agoric/store';
 import { Far, Data } from '@agoric/marshal';
 
 import { makeAmountMath, MathKind } from '@agoric/ertp';

--- a/packages/zoe/src/contractFacet/evalContractCode.js
+++ b/packages/zoe/src/contractFacet/evalContractCode.js
@@ -1,5 +1,7 @@
 // @ts-check
 
+/* global makeKind makeWeakStore */
+
 import { importBundle } from '@agoric/import-bundle';
 import { assert } from '@agoric/assert';
 
@@ -13,6 +15,8 @@ const evalContractBundle = (bundle, additionalEndowments = {}) => {
   const defaultEndowments = {
     console: louderConsole,
     assert,
+    makeKind,
+    makeWeakStore,
   };
 
   const fullEndowments = Object.create(null, {

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { makeWeakStore } from '@agoric/store';
+import { makeWeakStore as makeNonVOWeakStore } from '@agoric/store';
 import { assert, details as X } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
@@ -39,16 +39,16 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
   const installations = new WeakSet();
 
   /** @type {WeakStore<Instance,InstanceAdmin>} */
-  const instanceToInstanceAdmin = makeWeakStore('instance');
+  const instanceToInstanceAdmin = makeNonVOWeakStore('instance');
 
   /** @type {GetAmountMath} */
   const getAmountMath = brand => issuerTable.getByBrand(brand).amountMath;
 
   /** @type {WeakStore<Brand, ERef<Purse>>} */
-  const brandToPurse = makeWeakStore('brand');
+  const brandToPurse = makeNonVOWeakStore('brand');
 
   /** @type {WeakStore<SeatHandle, ZoeSeatAdmin>} */
-  const seatHandleToZoeSeatAdmin = makeWeakStore('seatHandle');
+  const seatHandleToZoeSeatAdmin = makeNonVOWeakStore('seatHandle');
 
   /**
    * Create an installation by permanently storing the bundle. It will be

--- a/packages/zoe/test/minimalMakeKindContract.js
+++ b/packages/zoe/test/minimalMakeKindContract.js
@@ -1,0 +1,10 @@
+/* global makeKind makeWeakStore */
+
+const start = _zcf => {
+  makeKind();
+  makeWeakStore();
+
+  return harden({});
+};
+harden(start);
+export { start };

--- a/packages/zoe/test/swingsetTests/makeKind/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/makeKind/bootstrap.js
@@ -1,0 +1,20 @@
+import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
+
+export function buildRootObject(vatPowers, vatParameters) {
+  const { contractBundles: cb } = vatParameters;
+  return Far('root', {
+    async bootstrap(vats, devices) {
+      const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
+        devices.vatAdmin,
+      );
+      const zoe = await E(vats.zoe).buildZoe(vatAdminSvc);
+      const installations = {
+        minimalMakeKind: await E(zoe).install(cb.minimalMakeKindContract),
+      };
+
+      const aliceP = E(vats.alice).build(zoe, installations);
+      await E(aliceP).minimalMakeKindTest();
+    },
+  });
+}

--- a/packages/zoe/test/swingsetTests/makeKind/test-makeKind.js
+++ b/packages/zoe/test/swingsetTests/makeKind/test-makeKind.js
@@ -1,0 +1,74 @@
+/* global __dirname */
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@agoric/install-metering-and-ses';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import test from 'ava';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { buildVatController, buildKernelBundles } from '@agoric/swingset-vat';
+import bundleSource from '@agoric/bundle-source';
+
+const CONTRACT_FILES = ['minimalMakeKindContract'];
+
+test.before(async t => {
+  const start = Date.now();
+  const kernelBundles = await buildKernelBundles();
+  const step2 = Date.now();
+  const contractBundles = {};
+  await Promise.all(
+    CONTRACT_FILES.map(async settings => {
+      let bundleName;
+      let contractPath;
+      if (typeof settings === 'string') {
+        bundleName = settings;
+        contractPath = settings;
+      } else {
+        ({ bundleName, contractPath } = settings);
+      }
+      const source = `${__dirname}/../../${contractPath}`;
+      const bundle = await bundleSource(source);
+      contractBundles[bundleName] = bundle;
+    }),
+  );
+  const step3 = Date.now();
+
+  const vats = {};
+  await Promise.all(
+    ['alice', 'zoe'].map(async name => {
+      const source = `${__dirname}/vat-${name}.js`;
+      const bundle = await bundleSource(source);
+      vats[name] = { bundle };
+    }),
+  );
+  const bootstrapSource = `${__dirname}/bootstrap.js`;
+  vats.bootstrap = {
+    bundle: await bundleSource(bootstrapSource),
+    parameters: { contractBundles }, // argv will be added to this
+  };
+  const config = { bootstrap: 'bootstrap', vats };
+
+  const step4 = Date.now();
+  const ktime = `${(step2 - start) / 1000}s kernel`;
+  const ctime = `${(step3 - step2) / 1000}s contracts`;
+  const vtime = `${(step4 - step3) / 1000}s vats`;
+  const ttime = `${(step4 - start) / 1000}s total`;
+  console.log(`bundling: ${ktime}, ${ctime}, ${vtime}, ${ttime}`);
+
+  t.context.data = { kernelBundles, config };
+});
+
+async function main(t, argv) {
+  const { kernelBundles, config } = t.context.data;
+  const controller = await buildVatController(config, argv, { kernelBundles });
+  await controller.run();
+  return controller.dump();
+}
+
+const expected = [
+  '{"adminFacet":{},"creatorFacet":{},"instance":{},"publicFacet":{}}',
+];
+
+test.serial('makeKind swingset', async t => {
+  const dump = await main(t);
+  t.deepEqual(dump.log, expected);
+});

--- a/packages/zoe/test/swingsetTests/makeKind/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/makeKind/vat-alice.js
@@ -1,0 +1,17 @@
+import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
+
+const build = async (log, zoe, installations) => {
+  return Far('build', {
+    minimalMakeKindTest: async () => {
+      const result = await E(zoe).startInstance(installations.minimalMakeKind);
+      log(result);
+    },
+  });
+};
+
+export function buildRootObject(vatPowers) {
+  return Far('root', {
+    build: (...args) => build(vatPowers.testLog, ...args),
+  });
+}

--- a/packages/zoe/test/swingsetTests/makeKind/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/makeKind/vat-zoe.js
@@ -1,0 +1,10 @@
+import { Far } from '@agoric/marshal';
+
+// noinspection ES6PreferShortImport
+import { makeZoe } from '../../../src/zoeService/zoe';
+
+export function buildRootObject(_vatPowers) {
+  return Far('root', {
+    buildZoe: vatAdminSvc => makeZoe(vatAdminSvc),
+  });
+}

--- a/packages/zoe/test/unitTests/contractSupport/test-bondingCurves.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-bondingCurves.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 import test from 'ava';
 
 import {

--- a/packages/zoe/test/unitTests/contractSupport/test-depositTo.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-depositTo.js
@@ -1,6 +1,6 @@
 /* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
@@ -2,7 +2,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/contractSupport/test-percentMath.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-percentMath.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/contractSupport/test-percentSupport.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-percentSupport.js
@@ -1,6 +1,8 @@
 // @ts-check
 
-import '@agoric/install-ses';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@agoric/zoe/tools/prepare-test-env';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { makeIssuerKit } from '@agoric/ertp';
 

--- a/packages/zoe/test/unitTests/contractSupport/test-ratio.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-ratio.js
@@ -1,6 +1,8 @@
 // @ts-check
 
-import '@agoric/install-ses';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@agoric/zoe/tools/prepare-test-env';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import '../../../src/contractSupport/types';
 

--- a/packages/zoe/test/unitTests/contractSupport/test-stateMachine.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-stateMachine.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 import test from 'ava';
 
 import { makeStateMachine } from '../../../src/contractSupport';

--- a/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
@@ -1,6 +1,6 @@
 /* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { Far, Data } from '@agoric/marshal';

--- a/packages/zoe/test/unitTests/contracts/loan/helpers.js
+++ b/packages/zoe/test/unitTests/contracts/loan/helpers.js
@@ -2,7 +2,7 @@
 import '../../../../exported';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 import { E } from '@agoric/eventual-send';
 
 import bundleSource from '@agoric/bundle-source';

--- a/packages/zoe/test/unitTests/contracts/loan/test-addCollateral.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-addCollateral.js
@@ -3,7 +3,7 @@
 import '../../../../exported';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
@@ -3,7 +3,7 @@
 import '../../../../exported';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/contracts/loan/test-close.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-close.js
@@ -2,7 +2,7 @@
 import '../../../../exported';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { E } from '@agoric/eventual-send';

--- a/packages/zoe/test/unitTests/contracts/loan/test-lend.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-lend.js
@@ -2,7 +2,7 @@
 import '../../../../exported';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { E } from '@agoric/eventual-send';

--- a/packages/zoe/test/unitTests/contracts/loan/test-liquidate.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-liquidate.js
@@ -3,7 +3,7 @@
 import '../../../../exported';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
@@ -3,7 +3,7 @@
 import '../../../../exported';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { E } from '@agoric/eventual-send';

--- a/packages/zoe/test/unitTests/contracts/loan/test-updateDebt.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-updateDebt.js
@@ -3,7 +3,7 @@
 import '../../../../exported';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
+++ b/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
@@ -1,6 +1,6 @@
 /* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
+++ b/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
@@ -1,6 +1,6 @@
 /* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import bundleSource from '@agoric/bundle-source';

--- a/packages/zoe/test/unitTests/contracts/test-autoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-autoswap.js
@@ -1,6 +1,6 @@
 /* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { E } from '@agoric/eventual-send';

--- a/packages/zoe/test/unitTests/contracts/test-autoswapPool.js
+++ b/packages/zoe/test/unitTests/contracts/test-autoswapPool.js
@@ -1,6 +1,7 @@
 // isolated unit test of price calculations in pool in multipoolAutoswap
 
-import '@agoric/install-ses';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/contracts/test-barter.js
+++ b/packages/zoe/test/unitTests/contracts/test-barter.js
@@ -1,6 +1,6 @@
 /* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { E } from '@agoric/eventual-send';

--- a/packages/zoe/test/unitTests/contracts/test-brokenContract.js
+++ b/packages/zoe/test/unitTests/contracts/test-brokenContract.js
@@ -1,5 +1,6 @@
 /* global __dirname */
-import '@agoric/install-ses';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/test-callSpread-calculation.js
+++ b/packages/zoe/test/unitTests/contracts/test-callSpread-calculation.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import '../../../exported';

--- a/packages/zoe/test/unitTests/contracts/test-callSpread.js
+++ b/packages/zoe/test/unitTests/contracts/test-callSpread.js
@@ -1,6 +1,6 @@
 /* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { E } from '@agoric/eventual-send';

--- a/packages/zoe/test/unitTests/contracts/test-coveredCall.js
+++ b/packages/zoe/test/unitTests/contracts/test-coveredCall.js
@@ -1,6 +1,6 @@
 /* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import bundleSource from '@agoric/bundle-source';

--- a/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
@@ -1,5 +1,6 @@
 /* global __dirname */
-import '@agoric/install-ses';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/test-mintPayments.js
+++ b/packages/zoe/test/unitTests/contracts/test-mintPayments.js
@@ -1,6 +1,6 @@
 /* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
@@ -1,5 +1,6 @@
 /* global __dirname */
-import '@agoric/install-ses';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/test-oracle.js
+++ b/packages/zoe/test/unitTests/contracts/test-oracle.js
@@ -1,7 +1,7 @@
 /* global __dirname */
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import anyTest from 'ava';
 import bundleSource from '@agoric/bundle-source';

--- a/packages/zoe/test/unitTests/contracts/test-otcDesk.js
+++ b/packages/zoe/test/unitTests/contracts/test-otcDesk.js
@@ -1,6 +1,6 @@
 /* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
@@ -1,7 +1,7 @@
 /* global __dirname */
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import anyTest from 'ava';
 import bundleSource from '@agoric/bundle-source';

--- a/packages/zoe/test/unitTests/contracts/test-secondPriceAuction.js
+++ b/packages/zoe/test/unitTests/contracts/test-secondPriceAuction.js
@@ -1,6 +1,6 @@
 /* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import bundleSource from '@agoric/bundle-source';

--- a/packages/zoe/test/unitTests/contracts/test-sellTickets.js
+++ b/packages/zoe/test/unitTests/contracts/test-sellTickets.js
@@ -1,6 +1,6 @@
 /* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
+++ b/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
@@ -1,6 +1,6 @@
 /* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';

--- a/packages/zoe/test/unitTests/contracts/test-throwInOfferHandler.js
+++ b/packages/zoe/test/unitTests/contracts/test-throwInOfferHandler.js
@@ -1,6 +1,6 @@
 /* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/contracts/test-useObj.js
+++ b/packages/zoe/test/unitTests/contracts/test-useObj.js
@@ -1,6 +1,6 @@
 /* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/test-cleanProposal.js
+++ b/packages/zoe/test/unitTests/test-cleanProposal.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { makeWeakStore } from '@agoric/store';

--- a/packages/zoe/test/unitTests/test-fakePriceAuthority.js
+++ b/packages/zoe/test/unitTests/test-fakePriceAuthority.js
@@ -1,6 +1,6 @@
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { E } from '@agoric/eventual-send';

--- a/packages/zoe/test/unitTests/test-makeKind.js
+++ b/packages/zoe/test/unitTests/test-makeKind.js
@@ -1,0 +1,23 @@
+// @ts-check
+/* global __dirname makeKind makeWeakStore */
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@agoric/zoe/tools/prepare-test-env';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import test from 'ava';
+import bundleSource from '@agoric/bundle-source';
+
+import { E } from '@agoric/eventual-send';
+import { makeZoe } from '../../src/zoeService/zoe';
+import fakeVatAdmin from '../../src/contractFacet/fakeVatAdmin';
+
+const root = `${__dirname}/../minimalMakeKindContract`;
+
+test('makeKind non-swingset', async t => {
+  const bundle = await bundleSource(root);
+  const zoe = makeZoe(fakeVatAdmin);
+  const installation = await E(zoe).install(bundle);
+  t.notThrows(() => makeKind());
+  t.notThrows(() => makeWeakStore());
+  await t.notThrowsAsync(() => zoe.startInstance(installation));
+});

--- a/packages/zoe/test/unitTests/test-manualTimer.js
+++ b/packages/zoe/test/unitTests/test-manualTimer.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';

--- a/packages/zoe/test/unitTests/test-objArrayConversion.js
+++ b/packages/zoe/test/unitTests/test-objArrayConversion.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/test-offerSafety.js
+++ b/packages/zoe/test/unitTests/test-offerSafety.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 
 import { isOfferSafe } from '../../src/contractFacet/offerSafety';

--- a/packages/zoe/test/unitTests/test-rightsConservation.js
+++ b/packages/zoe/test/unitTests/test-rightsConservation.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/test-scriptedOracle.js
+++ b/packages/zoe/test/unitTests/test-scriptedOracle.js
@@ -1,7 +1,7 @@
 /* global __dirname */
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import anyTest from 'ava';
 import bundleSource from '@agoric/bundle-source';

--- a/packages/zoe/test/unitTests/test-zoe-env.js
+++ b/packages/zoe/test/unitTests/test-zoe-env.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env';
 /* global makeKind, makeWeakStore */

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -1,7 +1,7 @@
 /* global __dirname */
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -1,6 +1,6 @@
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
@@ -1,6 +1,6 @@
 /* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-ses';
+import '@agoric/zoe/tools/prepare-test-env';
 import { E } from '@agoric/eventual-send';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';

--- a/packages/zoe/tools/prepare-test-env.js
+++ b/packages/zoe/tools/prepare-test-env.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Prepare global environment for zoe tests.
  *


### PR DESCRIPTION
First attempt to try to use virtual objects, just for payments in issuer.js in ERTP. 

TODO:
- [x] Rename `paymentVOMaker` to `paymentVOFactory`. 
- [x] Add more Swingset Tests to ERTP for key functionality to test virtual objects
- [x] Inspect the aliasing check that relies on identity in https://github.com/Agoric/agoric-sdk/blob/55bdaf75df70d6942a8c839bf262adfe17689b66/packages/ERTP/src/issuer.js#L163-L170 and figure out a different solution (or wait on collections for virtual objects).
- [x] Once we have mocks for `makeKind` and `makeWeakStore`, ensure unitTests pass
- [x] Ask @dckc for help in getting `makeKind` and `makeWeakStore` as globals in XS tests
- [x] Make globals `makeKind` and `makeWeakStore` available in dapp tests
    - [x] dapp-fungible-faucet
    - [x] dapp-card-store
    - [x] dapp-otc
    - [x] dapp-oracle
    - [x] dapp-pegasus
    - [x] dapp-encouragement
    - [x] dapp-autoswap
    - [x] dapp-simple-exchange
    - [x] dapp-svelte-wallet
    - [x] dapp-token-economy
    - [x] documentation
    
#dapp-fungible-faucet-branch: prepare-test-env
#dapp-card-store-branch: prepare-test-env
#dapp-otc-branch: prepare-test-env
#dapp-oracle-branch: prepare-test-env
#dapp-pegasus-branch: prepare-test-env
#dapp-encouragement-branch: prepare-test-env
#dapp-simple-exchange-branch:prepare-test-env
#dapp-svelte-wallet-branch: prepare-test-env
#dapp-token-economy-branch: prepare-test-env
#documentation-branch: prepare-test-env