### PR TITLE
update SwingSet to use Far()

### DIFF
--- a/packages/SwingSet/demo/encouragementBot/bootstrap.js
+++ b/packages/SwingSet/demo/encouragementBot/bootstrap.js
@@ -1,10 +1,11 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 console.log(`=> loading bootstrap.js`);
 
 export function buildRootObject(vatPowers) {
   const log = vatPowers.testLog;
-  return harden({
+  return Far('root', {
     bootstrap(vats) {
       console.log('=> bootstrap() called');
       E(vats.user)

--- a/packages/SwingSet/demo/encouragementBot/vat-bot.js
+++ b/packages/SwingSet/demo/encouragementBot/vat-bot.js
@@ -1,5 +1,7 @@
+import { Far } from '@agoric/marshal';
+
 export function buildRootObject(vatPowers) {
-  return harden({
+  return Far('root', {
     encourageMe(name) {
       vatPowers.testLog(
         `=> encouragementBot.encourageMe got the name: ${name}`,

--- a/packages/SwingSet/demo/encouragementBot/vat-user.js
+++ b/packages/SwingSet/demo/encouragementBot/vat-user.js
@@ -1,8 +1,9 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 export function buildRootObject(vatPowers) {
   const log = vatPowers.testLog;
-  return harden({
+  return Far('root', {
     talkToBot(bot, botName) {
       log(`=> user.talkToBot is called with ${botName}`);
       E(bot)

--- a/packages/SwingSet/demo/encouragementBotComms/bootstrap.js
+++ b/packages/SwingSet/demo/encouragementBotComms/bootstrap.js
@@ -1,10 +1,11 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 console.log(`=> loading bootstrap.js`);
 
 export function buildRootObject(vatPowers) {
   const { D, testLog: log } = vatPowers;
-  return harden({
+  return Far('root', {
     async bootstrap(vats, devices) {
       console.log('=> bootstrap() called');
 

--- a/packages/SwingSet/demo/encouragementBotComms/vat-bot.js
+++ b/packages/SwingSet/demo/encouragementBotComms/vat-bot.js
@@ -1,5 +1,7 @@
+import { Far } from '@agoric/marshal';
+
 export function buildRootObject(vatPowers) {
-  return harden({
+  return Far('root', {
     encourageMe(name) {
       vatPowers.testLog(
         `=> encouragementBot.encourageMe got the name: ${name}`,

--- a/packages/SwingSet/demo/encouragementBotComms/vat-user.js
+++ b/packages/SwingSet/demo/encouragementBotComms/vat-user.js
@@ -1,8 +1,9 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 export function buildRootObject(vatPowers) {
   const log = vatPowers.testLog;
-  return harden({
+  return Far('root', {
     talkToBot(pbot, botName) {
       log(`=> user.talkToBot is called with ${botName}`);
       E(pbot)

--- a/packages/SwingSet/demo/encouragementBotCommsWavyDot/bootstrap.js
+++ b/packages/SwingSet/demo/encouragementBotCommsWavyDot/bootstrap.js
@@ -1,3 +1,4 @@
+import { Far } from '@agoric/marshal';
 
 // This javascript source file uses the "tildot" syntax (foo~.bar()) for
 // eventual sends.
@@ -9,7 +10,7 @@ console.log(`=> loading bootstrap.js`);
 
 export function buildRootObject(vatPowers) {
   const { D, testLog: log } = vatPowers;
-  return harden({
+  return Far('root', {
     async bootstrap(vats, devices) {
       console.log('=> bootstrap() called');
 

--- a/packages/SwingSet/demo/encouragementBotCommsWavyDot/vat-bot.js
+++ b/packages/SwingSet/demo/encouragementBotCommsWavyDot/vat-bot.js
@@ -1,3 +1,4 @@
+import { Far } from '@agoric/marshal';
 
 // This javascript source file uses the "tildot" syntax (foo~.bar()) for
 // eventual sends.
@@ -6,7 +7,7 @@
 // https://github.com/tc39/proposal-wavy-dot
 
 export function buildRootObject(vatPowers) {
-  return harden({
+  return Far('root', {
     encourageMe(nameObj) {
       // Test of tildot property get.
       return nameObj~.name.then(name => {

--- a/packages/SwingSet/demo/encouragementBotCommsWavyDot/vat-user.js
+++ b/packages/SwingSet/demo/encouragementBotCommsWavyDot/vat-user.js
@@ -1,3 +1,4 @@
+import { Far } from '@agoric/marshal';
 
 // This javascript source file uses the "tildot" syntax (foo~.bar()) for
 // eventual sends.
@@ -7,7 +8,7 @@
 
 export function buildRootObject(vatPowers) {
   const log = vatPowers.testLog;
-  return harden({
+  return Far('root', {
     talkToBot(pbot, botName) {
       log(`=> user.talkToBot is called with ${botName}`);
       pbot

--- a/packages/SwingSet/src/devices/bridge-src.js
+++ b/packages/SwingSet/src/devices/bridge-src.js
@@ -1,4 +1,5 @@
 import { assert, details as X } from '@agoric/assert';
+import { Far } from '@agoric/marshal';
 
 function sanitize(data) {
   // TODO: Use @agoric/marshal:pureCopy when it exists.
@@ -27,7 +28,7 @@ export function buildRootDeviceNode(tools) {
   }
   registerInboundCallback(inboundCallback);
 
-  return harden({
+  return Far('root', {
     registerInboundHandler(handler) {
       if (inboundHandler) {
         throw Error('inboundHandler already registered');

--- a/packages/SwingSet/src/devices/command-src.js
+++ b/packages/SwingSet/src/devices/command-src.js
@@ -1,4 +1,5 @@
 import { Nat } from '@agoric/nat';
+import { Far } from '@agoric/marshal';
 
 import { assert, details as X } from '@agoric/assert';
 
@@ -26,7 +27,7 @@ export function buildRootDeviceNode(tools) {
     }
   });
 
-  return harden({
+  return Far('root', {
     registerInboundHandler(handler) {
       inboundHandler = handler;
       setDeviceState(harden({ inboundHandler }));

--- a/packages/SwingSet/src/devices/loopbox-src.js
+++ b/packages/SwingSet/src/devices/loopbox-src.js
@@ -1,4 +1,5 @@
 import { assert, details as X } from '@agoric/assert';
+import { Far } from '@agoric/marshal';
 
 export function buildRootDeviceNode(tools) {
   const { SO, endowments } = tools;
@@ -17,7 +18,7 @@ export function buildRootDeviceNode(tools) {
   }
   registerPassOneMessage(loopboxPassOneMessage);
 
-  return harden({
+  return Far('root', {
     registerInboundHandler(name, handler) {
       assert(!inboundHandlers.has(name), X`already registered`);
       inboundHandlers.set(name, handler);
@@ -25,7 +26,7 @@ export function buildRootDeviceNode(tools) {
 
     makeSender(sender) {
       let count = 1;
-      return harden({
+      return Far('sender', {
         add(peer, msgnum, body) {
           assert(inboundHandlers.has(peer), X`unregistered peer '${peer}'`);
           const h = inboundHandlers.get(peer);

--- a/packages/SwingSet/src/devices/mailbox-src.js
+++ b/packages/SwingSet/src/devices/mailbox-src.js
@@ -1,4 +1,5 @@
 import { Nat } from '@agoric/nat';
+import { Far } from '@agoric/marshal';
 
 import { assert, details as X } from '@agoric/assert';
 
@@ -78,7 +79,7 @@ export function buildRootDeviceNode(tools) {
   };
 
   // the Root Device Node.
-  return harden({
+  return Far('root', {
     registerInboundHandler(handler) {
       assert(!inboundHandler, X`already registered`);
       inboundHandler = handler;

--- a/packages/SwingSet/src/devices/plugin-src.js
+++ b/packages/SwingSet/src/devices/plugin-src.js
@@ -1,7 +1,7 @@
 /* global HandledPromise */
 
 import { makeCapTP } from '@agoric/captp';
-
+import { Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
 
 export function buildRootDeviceNode(tools) {
@@ -117,7 +117,7 @@ export function buildRootDeviceNode(tools) {
     });
   });
 
-  return harden({
+  return Far('root', {
     getPluginDir() {
       return endowments.getPluginDir();
     },

--- a/packages/SwingSet/src/devices/timer-src.js
+++ b/packages/SwingSet/src/devices/timer-src.js
@@ -24,6 +24,7 @@
 
 import { Nat } from '@agoric/nat';
 import { assert, details as X } from '@agoric/assert';
+import { Far } from '@agoric/marshal';
 
 // Since we use harden when saving the state, we need to copy the arrays so they
 // will continue to be mutable. each record inside handlers is immutable, so we
@@ -263,7 +264,7 @@ export function buildRootDeviceNode(tools) {
   // guarantee that the handler will be called at the precise desired time,
   // but the repeated calls won't accumulate timing drift, so the trigger
   // point will be reached at consistent intervals.
-  return harden({
+  return Far('root', {
     setWakeup(delaySecs, handler) {
       assert.typeof(delaySecs, 'bigint');
       deadlines.add(lastPolled + Nat(delaySecs), handler);

--- a/packages/SwingSet/src/kernel/vatAdmin/vatAdmin-src.js
+++ b/packages/SwingSet/src/kernel/vatAdmin/vatAdmin-src.js
@@ -16,6 +16,9 @@
  * @param {Record<string, any>} param0.endowments
  * @param {*} param0.serialize
  */
+
+import { Far } from '@agoric/marshal';
+
 export function buildRootDeviceNode({ endowments, serialize }) {
   const {
     create: kernelVatCreationFn,
@@ -24,7 +27,7 @@ export function buildRootDeviceNode({ endowments, serialize }) {
   } = endowments;
 
   // The Root Device Node.
-  return harden({
+  return Far('root', {
     // Called by the wrapper vat to create a new vat. Gets a new ID from the
     // kernel's vat creator fn. Remember that the root object will arrive
     // separately. Clean up the outgoing and incoming arguments.

--- a/packages/SwingSet/src/kernel/vatAdmin/vatAdminWrapper.js
+++ b/packages/SwingSet/src/kernel/vatAdmin/vatAdminWrapper.js
@@ -6,6 +6,7 @@
  * device affordances into objects that can be used by code in other vats.
  */
 import { makePromiseKit } from '@agoric/promise-kit';
+import { Far } from '@agoric/marshal';
 
 function producePRR() {
   const { promise, resolve, reject } = makePromiseKit();
@@ -25,7 +26,7 @@ export function buildRootObject(vatPowers) {
     running.set(vatID, doneRR);
     doneP.catch(() => {}); // shut up false whine about unhandled rejection
 
-    const adminNode = harden({
+    const adminNode = Far('adminNode', {
       terminateWithFailure(reason) {
         D(vatAdminNode).terminateWithFailure(vatID, reason);
       },
@@ -42,7 +43,7 @@ export function buildRootObject(vatPowers) {
   }
 
   function createVatAdminService(vatAdminNode) {
-    return harden({
+    return Far('vatAdminService', {
       createVat(code, options) {
         const vatID = D(vatAdminNode).create(code, options);
         return finishVatCreation(vatAdminNode, vatID);
@@ -76,7 +77,7 @@ export function buildRootObject(vatPowers) {
     }
   }
 
-  return harden({
+  return Far('root', {
     createVatAdminService,
     newVatCallback,
     vatTerminated,

--- a/packages/SwingSet/src/vats/comms/controller.js
+++ b/packages/SwingSet/src/vats/comms/controller.js
@@ -91,11 +91,15 @@ export function deliverToController(
     assert(state.names.has(remoteName), X`unknown remote name ${remoteName}`);
     const remoteID = state.names.get(remoteName);
     const remoteRefID = Nat(args[1]);
+    const iface = args[2];
     const localRef = addIngress(remoteID, remoteRefID);
     const data = {
       body: '{"@qclass":"slot","index":0}',
       slots: [localRef],
     };
+    if (iface) {
+      data.body = `{"@qclass":"slot","iface":"${iface}","index":0}`;
+    }
     syscall.resolve([[result, false, data]]);
   }
 

--- a/packages/SwingSet/src/vats/plugin-manager.js
+++ b/packages/SwingSet/src/vats/plugin-manager.js
@@ -4,6 +4,7 @@ import makeStore from '@agoric/store';
 import { makeCapTP } from '@agoric/captp';
 import { makePromiseKit } from '@agoric/promise-kit';
 import { E, HandledPromise } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 import '@agoric/store/exported';
 
@@ -13,10 +14,10 @@ import '@agoric/store/exported';
  */
 
 /** @type {{ onReset: (firstTime: Promise<boolean>) => void}} */
-const DEFAULT_RESETTER = harden({ onReset: _ => {} });
+const DEFAULT_RESETTER = Far('resetter', { onReset: _ => {} });
 
 /** @type {{ walk: (pluginRootP: any) => any }} */
-const DEFAULT_WALKER = harden({ walk: pluginRootP => pluginRootP });
+const DEFAULT_WALKER = Far('walker', { walk: pluginRootP => pluginRootP });
 
 /**
  * @template T
@@ -78,7 +79,7 @@ export function makePluginManager(pluginDevice, { D, ...vatPowers }) {
 
   // Dispatch object to the right index.
   D(pluginDevice).registerReceiver(
-    harden({
+    Far('receiver', {
       dispatch(index, obj) {
         const conn = modConnection.get(index);
         conn.dispatch(obj);
@@ -90,7 +91,7 @@ export function makePluginManager(pluginDevice, { D, ...vatPowers }) {
     }),
   );
 
-  return harden({
+  return Far('plugin-manager', {
     getPluginDir() {
       return D(pluginDevice).getPluginDir();
     },
@@ -121,7 +122,7 @@ export function makePluginManager(pluginDevice, { D, ...vatPowers }) {
       // Register our stable callbacks for this connect index.
       modConnection.init(
         index,
-        harden({
+        Far('connection', {
           dispatch(obj) {
             if (obj.epoch !== currentEpoch) {
               return false;
@@ -172,7 +173,7 @@ export function makePluginManager(pluginDevice, { D, ...vatPowers }) {
         pluginRootPK.resolve(E(getBootstrap()).start(opts));
       };
 
-      const actions = harden({
+      const actions = Far('actions', {
         /**
          * Create a stable identity that just forwards to the current implementation.
          *
@@ -195,7 +196,7 @@ export function makePluginManager(pluginDevice, { D, ...vatPowers }) {
               },
             });
           });
-          return pr;
+          return Far('stableForwarder', pr);
         },
       });
 

--- a/packages/SwingSet/src/vats/vat-timerWrapper.js
+++ b/packages/SwingSet/src/vats/vat-timerWrapper.js
@@ -1,5 +1,6 @@
 import { Nat } from '@agoric/nat';
 import { assert, details as X } from '@agoric/assert';
+import { Far } from '@agoric/marshal';
 import { makeNotifierKit } from '@agoric/notifier';
 
 export function buildRootObject(vatPowers) {
@@ -62,8 +63,8 @@ export function buildRootObject(vatPowers) {
         return notifier;
       },
     };
-    return harden(timerService);
+    return Far('timerService', timerService);
   }
 
-  return harden({ createTimerService });
+  return Far('root', { createTimerService });
 }

--- a/packages/SwingSet/src/vats/vat-tp.js
+++ b/packages/SwingSet/src/vats/vat-tp.js
@@ -1,6 +1,7 @@
 import { assert, details as X } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
+import { Far } from '@agoric/marshal';
 
 // See ../../docs/delivery.md for a description of the architecture of the
 // comms system.
@@ -82,7 +83,7 @@ export function buildRootObject(vatPowers) {
     const name = makeConnectionName();
     let openCalled = false;
     assert(!connectionNames.has(name), X`already have host for ${name}`);
-    const host = harden({
+    const host = Far('host', {
       publish(obj) {
         const address = makeAddress();
         exportedObjects.set(address, obj);
@@ -93,7 +94,7 @@ export function buildRootObject(vatPowers) {
       },
     });
 
-    const handler = harden({
+    const handler = Far('host handler', {
       async onOpen(connection, ..._args) {
         // make a new Remote for this new connection
         assert(!openCalled, X`host ${name} already opened`);
@@ -136,7 +137,7 @@ export function buildRootObject(vatPowers) {
     return harden({ host, handler });
   }
 
-  const handler = harden({
+  const handler = Far('vat-tp handler', {
     registerMailboxDevice(mailboxDevnode) {
       mailbox = mailboxDevnode;
     },
@@ -148,7 +149,7 @@ export function buildRootObject(vatPowers) {
     addRemote(name) {
       assert(!remotes.has(name), X`already have remote ${name}`);
       const r = getRemote(name);
-      const transmitter = harden({
+      const transmitter = Far('transmitter', {
         transmit(msg) {
           const o = r.outbound;
           const num = o.highestAdded + 1;
@@ -157,7 +158,7 @@ export function buildRootObject(vatPowers) {
           o.highestAdded = num;
         },
       });
-      const setReceiver = harden({
+      const setReceiver = Far('receiver setter', {
         setReceiver(newReceiver) {
           assert(!r.inbound.receiver, X`setReceiver is call-once`);
           r.inbound.receiver = newReceiver;

--- a/packages/SwingSet/test/basedir-circular/bootstrap.js
+++ b/packages/SwingSet/test/basedir-circular/bootstrap.js
@@ -1,7 +1,8 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 export function buildRootObject(_vatPowers) {
-  return harden({
+  return Far('root', {
     bootstrap(vats) {
       const pa = E(vats.bob).genPromise1();
       const pb = E(vats.bob).genPromise2();

--- a/packages/SwingSet/test/basedir-circular/vat-bob.js
+++ b/packages/SwingSet/test/basedir-circular/vat-bob.js
@@ -1,3 +1,5 @@
+import { Far } from '@agoric/marshal';
+
 function makePR() {
   let r;
   const p = new Promise((resolve, _reject) => {
@@ -11,7 +13,7 @@ export function buildRootObject(_vatPowers) {
   let r1;
   let p2;
   let r2;
-  return harden({
+  return Far('root', {
     genPromise1() {
       [p1, r1] = makePR();
       return p1;

--- a/packages/SwingSet/test/basedir-controller-2/bootstrap.js
+++ b/packages/SwingSet/test/basedir-controller-2/bootstrap.js
@@ -1,4 +1,6 @@
+import { Far } from '@agoric/marshal';
+
 export function buildRootObject(vatPowers) {
   vatPowers.testLog(`bootstrap called`);
-  return harden({});
+  return Far('root', {});
 }

--- a/packages/SwingSet/test/basedir-controller-3/bootstrap.js
+++ b/packages/SwingSet/test/basedir-controller-3/bootstrap.js
@@ -1,7 +1,8 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 export function buildRootObject(vatPowers) {
-  return harden({
+  return Far('root', {
     bootstrap(vats) {
       vatPowers.testLog(`bootstrap.obj0.bootstrap()`);
       E(vats.left).foo(1, vats.right);

--- a/packages/SwingSet/test/basedir-controller-3/vat-left.js
+++ b/packages/SwingSet/test/basedir-controller-3/vat-left.js
@@ -1,7 +1,8 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 export function buildRootObject(vatPowers) {
-  return harden({
+  return Far('root', {
     foo(arg1, right) {
       vatPowers.testLog(`left.foo ${arg1}`);
       E(right).bar(2, right);

--- a/packages/SwingSet/test/basedir-controller-3/vat-right.js
+++ b/packages/SwingSet/test/basedir-controller-3/vat-right.js
@@ -1,3 +1,5 @@
+import { Far } from '@agoric/marshal';
+
 export function buildRootObject(vatPowers) {
   const obj0 = {
     bar(arg2, self) {
@@ -5,5 +7,5 @@ export function buildRootObject(vatPowers) {
       return 3;
     },
   };
-  return harden(obj0);
+  return Far('root', obj0);
 }

--- a/packages/SwingSet/test/basedir-message-patterns/bootstrap-comms.js
+++ b/packages/SwingSet/test/basedir-message-patterns/bootstrap-comms.js
@@ -1,4 +1,5 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 // machine names, to link vattp messages and loopbox channels
 const A = 'A';
@@ -7,7 +8,7 @@ const C = 'C';
 
 export function buildRootObject(vatPowers, vatParameters) {
   const { D } = vatPowers;
-  return harden({
+  return Far('root', {
     async bootstrap(vats, devices) {
       const { loopbox } = devices;
 
@@ -47,9 +48,9 @@ export function buildRootObject(vatPowers, vatParameters) {
       const BOB_INDEX = 12;
       const BERT_INDEX = 13;
       await E(commsB).addEgress(A, BOB_INDEX, bob);
-      const aBob = await E(commsA).addIngress(B, BOB_INDEX);
+      const aBob = await E(commsA).addIngress(B, BOB_INDEX, 'Alleged: bob');
       await E(commsB).addEgress(A, BERT_INDEX, bert);
-      const aBert = await E(commsA).addIngress(B, BERT_INDEX);
+      const aBert = await E(commsA).addIngress(B, BERT_INDEX, 'Alleged: bert');
 
       // initialize C, to get the object that we'll export to A
       const { carol } = await E(vats.c).init();
@@ -57,7 +58,11 @@ export function buildRootObject(vatPowers, vatParameters) {
       // export C's objects to A
       const CAROL_INDEX = 25;
       await E(commsC).addEgress(A, CAROL_INDEX, carol);
-      const aCarol = await E(commsA).addIngress(C, CAROL_INDEX);
+      const aCarol = await E(commsA).addIngress(
+        C,
+        CAROL_INDEX,
+        'Alleged: carol',
+      );
 
       // initialize A, and give it objects from B and C
       await E(vats.a).init(aBob, aBert, aCarol);

--- a/packages/SwingSet/test/basedir-message-patterns/bootstrap-local.js
+++ b/packages/SwingSet/test/basedir-message-patterns/bootstrap-local.js
@@ -1,7 +1,8 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 export function buildRootObject(_vatPowers, vatParameters) {
-  return harden({
+  return Far('root', {
     async bootstrap(vats, _devices) {
       // initialize B, to get the object that we'll export to A
       const { bob, bert } = await E(vats.b).init();

--- a/packages/SwingSet/test/basedir-message-patterns/vat-a.js
+++ b/packages/SwingSet/test/basedir-message-patterns/vat-a.js
@@ -1,13 +1,14 @@
+import { Far } from '@agoric/marshal';
 import { buildPatterns } from '../message-patterns';
 
 export function buildRootObject(vatPowers) {
-  const amy = harden({ toString: () => 'obj-amy' });
+  const amy = Far('amy', {});
   let alice;
 
-  const root = harden({
+  const root = Far('root', {
     init(bob, bert, carol) {
       const { setA, setB, setC, objA } = buildPatterns(vatPowers.testLog);
-      alice = objA;
+      alice = Far('alice', objA);
       const a = harden({ alice, amy });
       setA(a);
       setB(harden({ bob, bert }));

--- a/packages/SwingSet/test/basedir-message-patterns/vat-b.js
+++ b/packages/SwingSet/test/basedir-message-patterns/vat-b.js
@@ -1,22 +1,24 @@
+import { Far } from '@agoric/marshal';
 import { buildPatterns } from '../message-patterns';
 
 export function buildRootObject(vatPowers) {
-  const bert = harden({
+  const bert = Far('bert', {
     toString: () => 'obj-bert',
     log_bert: msg => {
       vatPowers.testLog(msg);
     },
   });
-  const bill = harden({
+  const bill = Far('bill', {
     toString: () => 'obj-bill',
     log_bill(msg) {
       vatPowers.testLog(msg);
     },
   });
 
-  const root = harden({
+  const root = Far('root', {
     init() {
-      const { setB, objB: bob } = buildPatterns(vatPowers.testLog);
+      const { setB, objB } = buildPatterns(vatPowers.testLog);
+      const bob = Far('bob', objB);
       const b = harden({ bob, bert, bill });
       setB(b);
       return harden({ bob, bert });

--- a/packages/SwingSet/test/basedir-message-patterns/vat-c.js
+++ b/packages/SwingSet/test/basedir-message-patterns/vat-c.js
@@ -1,9 +1,11 @@
+import { Far } from '@agoric/marshal';
 import { buildPatterns } from '../message-patterns';
 
 export function buildRootObject(vatPowers) {
-  const root = harden({
+  const root = Far('root', {
     init() {
-      const { setC, objC: carol } = buildPatterns(vatPowers.testLog);
+      const { setC, objC } = buildPatterns(vatPowers.testLog);
+      const carol = Far('carol', objC);
       const c = harden({ carol });
       setC(c);
       return harden({ carol });

--- a/packages/SwingSet/test/basedir-promises-2/bootstrap.js
+++ b/packages/SwingSet/test/basedir-promises-2/bootstrap.js
@@ -1,11 +1,11 @@
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
-
+import { Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
 
 export function buildRootObject(vatPowers, vatParameters) {
   const log = vatPowers.testLog;
-  return harden({
+  return Far('root', {
     bootstrap(vats) {
       const { argv } = vatParameters;
       const mode = argv[0];

--- a/packages/SwingSet/test/basedir-promises-2/vat-left.js
+++ b/packages/SwingSet/test/basedir-promises-2/vat-left.js
@@ -1,9 +1,11 @@
+import { Far } from '@agoric/marshal';
+
 export function buildRootObject(vatPowers) {
-  const obj0 = {
+  const obj0 = Far('root', {
     checkHarden(o1) {
       vatPowers.testLog(`o1 frozen ${Object.isFrozen(o1)}`);
-      return harden(obj0);
+      return obj0;
     },
-  };
-  return harden(obj0);
+  });
+  return obj0;
 }

--- a/packages/SwingSet/test/basedir-promises/bootstrap.js
+++ b/packages/SwingSet/test/basedir-promises/bootstrap.js
@@ -1,11 +1,12 @@
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
+import { Far } from '@agoric/marshal';
 
 import { assert, details as X } from '@agoric/assert';
 
 export function buildRootObject(vatPowers, vatParameters) {
   const log = vatPowers.testLog;
-  return harden({
+  return Far('root', {
     bootstrap(vats) {
       const mode = vatParameters.argv[0];
       if (mode === 'flush') {
@@ -29,7 +30,7 @@ export function buildRootObject(vatPowers, vatParameters) {
         p2.then(x => log(`b.resolved ${x}`));
         log(`b.call2`);
       } else if (mode === 'local1') {
-        const t1 = harden({
+        const t1 = Far('t1', {
           foo(arg) {
             log(`local.foo ${arg}`);
             return 2;
@@ -39,7 +40,7 @@ export function buildRootObject(vatPowers, vatParameters) {
         p1.then(x => log(`b.resolved ${x}`));
         log(`b.local1.finish`);
       } else if (mode === 'local2') {
-        const t1 = harden({
+        const t1 = Far('t1', {
           foo(arg) {
             log(`local.foo ${arg}`);
             return 3;
@@ -50,7 +51,7 @@ export function buildRootObject(vatPowers, vatParameters) {
         p2.then(x => log(`b.resolved ${x}`));
         log(`b.local2.finish`);
       } else if (mode === 'send-promise1') {
-        const t1 = harden({
+        const t1 = Far('t1', {
           foo(arg) {
             log(`local.foo ${arg}`);
             return 3;

--- a/packages/SwingSet/test/basedir-promises/vat-left.js
+++ b/packages/SwingSet/test/basedir-promises/vat-left.js
@@ -1,4 +1,5 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 export function buildRootObject(vatPowers) {
   const log = vatPowers.testLog;
@@ -12,7 +13,7 @@ export function buildRootObject(vatPowers) {
     },
     call2(arg) {
       log(`left.call2 ${arg}`);
-      return harden({
+      return Far('iface', {
         call3(x) {
           log(`left.call3 ${x}`);
           return 3;
@@ -26,7 +27,7 @@ export function buildRootObject(vatPowers) {
     },
 
     returnMyObject() {
-      return harden({
+      return Far('iface', {
         foo(x) {
           log(`left.myobject.call ${x}`);
         },
@@ -44,5 +45,5 @@ export function buildRootObject(vatPowers) {
       );
     },
   };
-  return harden(obj0);
+  return Far('root', obj0);
 }

--- a/packages/SwingSet/test/basedir-promises/vat-right.js
+++ b/packages/SwingSet/test/basedir-promises/vat-right.js
@@ -1,5 +1,7 @@
+import { Far } from '@agoric/marshal';
+
 export function buildRootObject(vatPowers) {
-  return harden({
+  return Far('root', {
     bar(arg2) {
       vatPowers.testLog(`right ${arg2}`);
       return 4;

--- a/packages/SwingSet/test/basedir-transcript/bootstrap.js
+++ b/packages/SwingSet/test/basedir-transcript/bootstrap.js
@@ -1,9 +1,9 @@
 import { E } from '@agoric/eventual-send';
-
+import { Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
 
 export function buildRootObject(vatPowers, vatParameters) {
-  return harden({
+  return Far('root', {
     bootstrap(vats) {
       const mode = vatParameters.argv[0];
       if (mode === 'one') {

--- a/packages/SwingSet/test/basedir-transcript/vat-left.js
+++ b/packages/SwingSet/test/basedir-transcript/vat-left.js
@@ -1,8 +1,9 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 export function buildRootObject(vatPowers) {
   const log = vatPowers.testLog;
-  const obj0 = {
+  const obj0 = Far('root', {
     callRight(arg1, right) {
       log(`left.callRight ${arg1}`);
       E(right)
@@ -10,6 +11,6 @@ export function buildRootObject(vatPowers) {
         .then(a => log(`left.then ${a}`));
       return 3;
     },
-  };
-  return harden(obj0);
+  });
+  return obj0;
 }

--- a/packages/SwingSet/test/basedir-transcript/vat-right.js
+++ b/packages/SwingSet/test/basedir-transcript/vat-right.js
@@ -1,5 +1,7 @@
+import { Far } from '@agoric/marshal';
+
 export function buildRootObject(vatPowers) {
-  return harden({
+  return Far('root', {
     bar(arg2) {
       vatPowers.testLog(`right ${arg2}`);
       return 4;

--- a/packages/SwingSet/test/bootstrap-syscall-failure.js
+++ b/packages/SwingSet/test/bootstrap-syscall-failure.js
@@ -1,14 +1,15 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 export function buildRootObject(vatPowers, vatParameters) {
   const { testLog } = vatPowers;
 
-  const ourThing = harden({
+  const ourThing = Far('ourThing', {
     pretendToBeAThing(from) {
       testLog(`pretendToBeAThing invoked from ${from}`);
     },
   });
-  const self = harden({
+  const self = Far('root', {
     async bootstrap(vats, devices) {
       testLog('bootstrap');
       let badvat;

--- a/packages/SwingSet/test/definition/vat-liveslots.js
+++ b/packages/SwingSet/test/definition/vat-liveslots.js
@@ -1,6 +1,8 @@
+import { Far, getInterfaceOf } from '@agoric/marshal';
+
 export function buildRootObject(vatPowers) {
   let counter = 0;
-  return harden({
+  return Far('root', {
     increment() {
       counter += 1;
     },
@@ -11,8 +13,8 @@ export function buildRootObject(vatPowers) {
       return vatPowers.transformTildot('x~.foo(arg1)');
     },
     remotable() {
-      const r = vatPowers.Far('iface1');
-      return vatPowers.getInterfaceOf(r);
+      const r = Far('iface1');
+      return getInterfaceOf(r);
     },
   });
 }

--- a/packages/SwingSet/test/definition/vat-setup.js
+++ b/packages/SwingSet/test/definition/vat-setup.js
@@ -1,6 +1,8 @@
+import { Far, getInterfaceOf } from '@agoric/marshal';
+
 export function buildRootObject(vatPowers) {
   let counter = 0;
-  return harden({
+  return Far('root', {
     increment() {
       counter += 1;
     },
@@ -11,8 +13,8 @@ export function buildRootObject(vatPowers) {
       return vatPowers.transformTildot('x~.foo(arg1)');
     },
     remotable() {
-      const r = vatPowers.Far('iface1');
-      return vatPowers.getInterfaceOf(r);
+      const r = Far('iface1');
+      return getInterfaceOf(r);
     },
   });
 }

--- a/packages/SwingSet/test/device-bridge-bootstrap.js
+++ b/packages/SwingSet/test/device-bridge-bootstrap.js
@@ -1,13 +1,15 @@
+import { Far } from '@agoric/marshal';
+
 export function buildRootObject(vatPowers, vatParameters) {
   const { D, testLog } = vatPowers;
-  const handler = harden({
+  const handler = Far('handler', {
     inbound(...args) {
       testLog('inbound');
       testLog(JSON.stringify(args));
     },
   });
 
-  return harden({
+  return Far('root', {
     async bootstrap(vats, devices) {
       const { argv } = vatParameters;
       harden(argv);

--- a/packages/SwingSet/test/device-plugin/bootstrap.js
+++ b/packages/SwingSet/test/device-plugin/bootstrap.js
@@ -1,11 +1,12 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
 import { makePluginManager } from '../../src/vats/plugin-manager';
 
 export function buildRootObject(vatPowers, vatParameters) {
   const { D } = vatPowers;
   const log = vatPowers.testLog;
-  return harden({
+  return Far('root', {
     async bootstrap(vats, devices) {
       try {
         const { argv } = vatParameters;

--- a/packages/SwingSet/test/device-plugin/pingpong.js
+++ b/packages/SwingSet/test/device-plugin/pingpong.js
@@ -1,8 +1,10 @@
+import { Far } from '@agoric/marshal';
+
 export function bootPlugin() {
-  return harden({
+  return Far('iface', {
     start(opts) {
       const { prefix } = opts;
-      return harden({
+      return Far('iface2', {
         ping(msg) {
           return `${prefix}${msg}`;
         },

--- a/packages/SwingSet/test/device-plugin/vat-bridge.js
+++ b/packages/SwingSet/test/device-plugin/vat-bridge.js
@@ -1,11 +1,11 @@
 import { E } from '@agoric/eventual-send';
-
+import { Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
 
 export function buildRootObject(vatPowers, _vatParameters) {
   const log = vatPowers.testLog;
   let pingPongP;
-  return harden({
+  return Far('root', {
     init(pingPong) {
       log(`installing pingPongP`);
       pingPongP = pingPong;

--- a/packages/SwingSet/test/files-devices/bootstrap-2.js
+++ b/packages/SwingSet/test/files-devices/bootstrap-2.js
@@ -1,10 +1,10 @@
 import { E } from '@agoric/eventual-send';
-
+import { Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
 
 export function buildRootObject(vatPowers, vatParameters) {
   const { D, testLog: log } = vatPowers;
-  return harden({
+  return Far('root', {
     async bootstrap(vats, devices) {
       const { argv } = vatParameters;
       if (argv[0] === '1') {
@@ -20,13 +20,13 @@ export function buildRootObject(vatPowers, vatParameters) {
         log(`calling d2.method3`);
         // devices can't yet do sendOnly on pass-by-presence objects, but
         // they should still be able to accept and return them
-        const o = harden({});
+        const o = Far('iface', {});
         const ret = D(devices.d2).method3(o);
         log(`ret ${ret === o}`);
       } else if (argv[0] === '4') {
         log(`calling d2.method4`);
         // now exercise sendOnly on pass-by-presence objects
-        const o = harden({
+        const o = Far('o', {
           foo(obj) {
             log(`d2.m4 foo`);
             D(obj).bar('hello');
@@ -61,7 +61,7 @@ export function buildRootObject(vatPowers, vatParameters) {
         D(devices.mailbox).remove('peer2', 4, 'data4');
         // should leave peer1: [data2,data3], peer2: [], peer3: [data5]
       } else if (argv[0] === 'mailbox2') {
-        const handler = harden({
+        const handler = Far('mailbox', {
           deliverInboundMessages(peer, messages) {
             log(`dm-${peer}`);
             messages.forEach(m => {
@@ -76,7 +76,7 @@ export function buildRootObject(vatPowers, vatParameters) {
       } else if (argv[0] === 'command1') {
         D(devices.command).sendBroadcast({ hello: 'everybody' });
       } else if (argv[0] === 'command2') {
-        const handler = harden({
+        const handler = Far('handler', {
           inbound(count, body) {
             log(`handle-${count}-${body.piece}`);
             D(devices.command).sendResponse(count, body.doReject, {

--- a/packages/SwingSet/test/files-devices/bootstrap-3.js
+++ b/packages/SwingSet/test/files-devices/bootstrap-3.js
@@ -1,8 +1,9 @@
 import { assert, details as X } from '@agoric/assert';
+import { Far } from '@agoric/marshal';
 
 export function buildRootObject(vatPowers, vatParameters) {
   const { D, testLog: log } = vatPowers;
-  return harden({
+  return Far('root', {
     async bootstrap(vats, devices) {
       if (vatParameters.argv[0] === 'write+read') {
         log(`w+r`);

--- a/packages/SwingSet/test/files-devices/device-0.js
+++ b/packages/SwingSet/test/files-devices/device-0.js
@@ -1,3 +1,5 @@
+import { Far } from '@agoric/marshal';
+
 export function buildRootDeviceNode() {
-  return harden({});
+  return Far('root', {});
 }

--- a/packages/SwingSet/test/files-devices/device-1.js
+++ b/packages/SwingSet/test/files-devices/device-1.js
@@ -1,5 +1,7 @@
+import { Far } from '@agoric/marshal';
+
 export function buildRootDeviceNode({ testLog, endowments }) {
-  return harden({
+  return Far('root', {
     set(arg1, arg2) {
       testLog(`invoke ${arg1} ${arg2}`);
       endowments.shared.push('pushed');

--- a/packages/SwingSet/test/files-devices/device-2.js
+++ b/packages/SwingSet/test/files-devices/device-2.js
@@ -1,17 +1,19 @@
+import { Far } from '@agoric/marshal';
+
 export function buildRootDeviceNode({
   SO,
   testLog: log,
   getDeviceState,
   setDeviceState,
 }) {
-  return harden({
+  return Far('root', {
     method1(arg) {
       log(`method1 ${arg}`);
       return 'done';
     },
     method2() {
-      const d2 = harden({});
-      const d3 = harden({
+      const d2 = Far('empty', {});
+      const d3 = Far('d3', {
         method3(arg) {
           log(`method3 ${arg === d2}`);
           return harden({ key: 'value' });
@@ -26,7 +28,7 @@ export function buildRootDeviceNode({
     },
     method4(o) {
       log(`method4`);
-      const obj = harden({
+      const obj = Far('obj', {
         bar(arg) {
           log(`method4.bar ${arg}`);
         },

--- a/packages/SwingSet/test/files-devices/device-3.js
+++ b/packages/SwingSet/test/files-devices/device-3.js
@@ -1,3 +1,5 @@
+import { Far } from '@agoric/marshal';
+
 export function buildRootDeviceNode({
   setDeviceState,
   getDeviceState,
@@ -5,7 +7,7 @@ export function buildRootDeviceNode({
 }) {
   testLog(typeof getDeviceState());
 
-  return harden({
+  return Far('root', {
     setState(arg) {
       setDeviceState(arg);
       return 'ok';

--- a/packages/SwingSet/test/files-devices/vat-left.js
+++ b/packages/SwingSet/test/files-devices/vat-left.js
@@ -1,6 +1,8 @@
+import { Far } from '@agoric/marshal';
+
 export function buildRootObject(vatPowers) {
   const { D, testLog: log } = vatPowers;
-  return harden({
+  return Far('root', {
     left5(d2) {
       log(`left5`);
       const ret = D(d2).method5('hello');

--- a/packages/SwingSet/test/files-vattp/bootstrap-test-vattp.js
+++ b/packages/SwingSet/test/files-vattp/bootstrap-test-vattp.js
@@ -1,16 +1,16 @@
 import { E } from '@agoric/eventual-send';
-
+import { Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
 
 export function buildRootObject(vatPowers, vatParameters) {
   const { D, testLog: log } = vatPowers;
-  const receiver = harden({
+  const receiver = Far('receiver', {
     receive(body) {
       log(`ch.receive ${body}`);
     },
   });
 
-  return harden({
+  return Far('root', {
     async bootstrap(vats, devices) {
       const { argv } = vatParameters;
       D(devices.mailbox).registerInboundHandler(vats.vattp);

--- a/packages/SwingSet/test/message-patterns.js
+++ b/packages/SwingSet/test/message-patterns.js
@@ -6,6 +6,7 @@
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
 import { quote as q } from '@agoric/assert';
+import { Far } from '@agoric/marshal';
 import { ignore } from './util';
 
 // Exercise a set of increasingly complex object-capability message patterns,
@@ -135,7 +136,7 @@ export function buildPatterns(log) {
       log(`match: ${b20amy === data}`);
     };
   }
-  out.a20 = ['b20 got [Alleged: presence o-50]', 'match: true', 'a20 done'];
+  out.a20 = ['b20 got [Alleged: amy]', 'match: true', 'a20 done'];
   test('a20');
 
   // bob!x({key: amy})
@@ -154,7 +155,7 @@ export function buildPatterns(log) {
       log(`match: ${b21amy === data.key2}`);
     };
   }
-  out.a21 = ['b21 got [Alleged: presence o-50]', 'match: true', 'a21 done'];
+  out.a21 = ['b21 got [Alleged: amy]', 'match: true', 'a21 done'];
   test('a21');
 
   // bob!x(bob)
@@ -232,7 +233,7 @@ export function buildPatterns(log) {
       return b.bill;
     };
   }
-  out.a42 = ['a42 done, [Alleged: presence o-53] match true'];
+  out.a42 = ['a42 done, [Alleged: bill] match true'];
   test('a42');
 
   // bob!x() -> <nada> // rejection
@@ -308,7 +309,7 @@ export function buildPatterns(log) {
     };
   }
   // TODO https://github.com/Agoric/agoric-sdk/issues/1631
-  out.a51 = ['a51 done, got [Alleged: presence o-74], match true true'];
+  out.a51 = ['a51 done, got [Alleged: bert], match true true'];
   test('a51');
 
   // bob!x() -> P(bill) // new reference
@@ -329,7 +330,7 @@ export function buildPatterns(log) {
       return b.bill;
     };
   }
-  out.a52 = ['a52 done, got [Alleged: presence o-53], match true'];
+  out.a52 = ['a52 done, got [Alleged: bill], match true'];
   test('a52');
 
   // bob!x(amy) -> P(amy) // new to bob
@@ -397,7 +398,7 @@ export function buildPatterns(log) {
       p1.resolve(b.bill);
     };
   }
-  out.a62 = ['a62 done, got [Alleged: presence o-53]'];
+  out.a62 = ['a62 done, got [Alleged: bill]'];
   test('a62');
 
   // bob!x(amy) -> P(amy) // resolve after receipt
@@ -499,10 +500,10 @@ export function buildPatterns(log) {
     };
     objB.b70_pipe1 = async () => {
       log(`pipe1`);
-      const pipe2 = harden({
+      const pipe2 = Far('pipe2', {
         pipe2() {
           log(`pipe2`);
-          const pipe3 = harden({
+          const pipe3 = Far('pipe3', {
             pipe3() {
               log(`pipe3`);
             },
@@ -543,13 +544,13 @@ export function buildPatterns(log) {
     const p1 = makePromiseKit();
     objB.b71_getpx = async () => p1.promise;
     objB.b71_resolvex = async () => {
-      const x = harden({
+      const x = Far('x', {
         pipe1() {
           log(`pipe1`);
-          const pipe2 = harden({
+          const pipe2 = Far('pipe2', {
             pipe2() {
               log(`pipe2`);
-              const pipe3 = harden({
+              const pipe3 = Far('pipe3', {
                 pipe3() {
                   log(`pipe3`);
                 },
@@ -594,13 +595,13 @@ export function buildPatterns(log) {
     objB.b72_wait = async () => 0;
     objB.b72_getpx = async () => p1.promise;
     objB.b72_resolvex = async () => {
-      const x = harden({
+      const x = Far('x', {
         pipe1() {
           log(`pipe1`);
-          const pipe2 = harden({
+          const pipe2 = Far('pipe2', {
             pipe2() {
               log(`pipe2`);
-              const pipe3 = harden({
+              const pipe3 = Far('pipe3', {
                 pipe3() {
                   log(`pipe3`);
                 },
@@ -639,7 +640,7 @@ export function buildPatterns(log) {
       ignore(p2);
     };
     objB.b73_one = () =>
-      harden({
+      Far('one', {
         two: () => log('two'),
       });
   }
@@ -954,7 +955,10 @@ export function buildPatterns(log) {
   // TODO: vat-allocated promise, either comms or kernel resolves it, comms
   // needs to send into kernel again
 
-  return harden({
+  // note: we don't harden() this return value because certain callers
+  // (vat-a/b/c.js) need to Far() the objA/B/C pieces (which isn't convenient
+  // to do here), and you can't Far() something that's already hardened.
+  return {
     setA,
     setB,
     setC,
@@ -964,5 +968,5 @@ export function buildPatterns(log) {
     objC,
     expected: out,
     expected_pipelined: outPipelined,
-  });
+  };
 }

--- a/packages/SwingSet/test/metering/metered-dynamic-vat.js
+++ b/packages/SwingSet/test/metering/metered-dynamic-vat.js
@@ -1,12 +1,13 @@
 import { assert } from '@agoric/assert';
 import { importBundle } from '@agoric/import-bundle';
 import { makePromiseKit } from '@agoric/promise-kit';
+import { Far } from '@agoric/marshal';
 import { meterMe } from './metered-code';
 
 export function buildRootObject(_dynamicVatPowers) {
   let grandchildNS;
 
-  return harden({
+  return Far('root', {
     never() {
       return makePromiseKit().promise;
     },

--- a/packages/SwingSet/test/metering/vat-load-dynamic.js
+++ b/packages/SwingSet/test/metering/vat-load-dynamic.js
@@ -1,11 +1,12 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 export function buildRootObject(vatPowers) {
   const log = vatPowers.testLog;
   let service;
   let control;
 
-  return harden({
+  return Far('root', {
     async bootstrap(vats, devices) {
       service = await E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
     },

--- a/packages/SwingSet/test/metering/vat-within.js
+++ b/packages/SwingSet/test/metering/vat-within.js
@@ -1,5 +1,6 @@
 import { assert } from '@agoric/assert';
 import { importBundle } from '@agoric/import-bundle';
+import { Far } from '@agoric/marshal';
 
 export function buildRootObject(vatPowers) {
   const { makeGetMeter, transformMetering } = vatPowers;
@@ -21,7 +22,7 @@ export function buildRootObject(vatPowers) {
   const log2 = [];
   let meterMe;
 
-  const root = {
+  return Far('root', {
     async start(bundle) {
       // console.log(`vatPowers`, vatPowers);
       // console.log('bundle', bundle);
@@ -71,6 +72,5 @@ export function buildRootObject(vatPowers) {
     async refill(mode) {
       refillFacet[mode](10000000);
     },
-  };
-  return harden(root);
+  });
 }

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -141,7 +141,7 @@ test('bootstrap export', async t => {
         method: 'bootstrap',
         args: {
           body:
-            '[{"bootstrap":{"@qclass":"slot","iface":"Alleged: vref","index":0},"comms":{"@qclass":"slot","iface":"Alleged: vref","index":1},"left":{"@qclass":"slot","iface":"Alleged: vref","index":2},"right":{"@qclass":"slot","iface":"Alleged: vref","index":3},"timer":{"@qclass":"slot","iface":"Alleged: vref","index":4},"vatAdmin":{"@qclass":"slot","iface":"Alleged: vref","index":5},"vattp":{"@qclass":"slot","iface":"Alleged: vref","index":6}},{"vatAdmin":{"@qclass":"slot","index":7}}]',
+            '[{"bootstrap":{"@qclass":"slot","iface":"Alleged: vref","index":0},"comms":{"@qclass":"slot","iface":"Alleged: vref","index":1},"left":{"@qclass":"slot","iface":"Alleged: vref","index":2},"right":{"@qclass":"slot","iface":"Alleged: vref","index":3},"timer":{"@qclass":"slot","iface":"Alleged: vref","index":4},"vatAdmin":{"@qclass":"slot","iface":"Alleged: vref","index":5},"vattp":{"@qclass":"slot","iface":"Alleged: vref","index":6}},{"vatAdmin":{"@qclass":"slot","iface":"Alleged: device","index":7}}]',
           slots: [
             boot0,
             comms0,

--- a/packages/SwingSet/test/test-devices.js
+++ b/packages/SwingSet/test/test-devices.js
@@ -69,8 +69,8 @@ test.serial('d0', async t => {
       vattp: { '@qclass': 'slot', iface: 'Alleged: vref', index: 4 },
     },
     {
-      d0: { '@qclass': 'slot', index: 5 },
-      vatAdmin: { '@qclass': 'slot', index: 6 },
+      d0: { '@qclass': 'slot', iface: 'Alleged: device', index: 5 },
+      vatAdmin: { '@qclass': 'slot', iface: 'Alleged: device', index: 6 },
     },
   ]);
   t.deepEqual(JSON.parse(c.dump().log[1]), [

--- a/packages/SwingSet/test/test-exomessages.js
+++ b/packages/SwingSet/test/test-exomessages.js
@@ -40,7 +40,7 @@ test('bootstrap returns presence', async t => {
   await bootstrapSuccessfully(
     t,
     'presence',
-    '{"@qclass":"slot","index":0}',
+    '{"@qclass":"slot","iface":"Alleged: other","index":0}',
     ['ko25'],
   );
 });
@@ -109,7 +109,7 @@ test('extra message returns presence', async t => {
     t,
     'presence',
     'fulfilled',
-    '{"@qclass":"slot","index":0}',
+    '{"@qclass":"slot","iface":"Alleged: other","index":0}',
     ['ko25'],
   );
 });

--- a/packages/SwingSet/test/test-liveslots.js
+++ b/packages/SwingSet/test/test-liveslots.js
@@ -55,7 +55,7 @@ test('calls', async t => {
   const { log, syscall } = buildSyscall();
 
   function build(_vatPowers) {
-    return harden({
+    return Far('root', {
       one() {
         log.push('one');
       },
@@ -119,7 +119,7 @@ test('liveslots pipelines to syscall.send', async t => {
   const { log, syscall } = buildSyscall();
 
   function build(_vatPowers) {
-    return harden({
+    return Far('root', {
       one(x) {
         const p1 = E(x).pipe1();
         const p2 = E(p1).pipe2();
@@ -253,7 +253,7 @@ async function doOutboundPromise(t, mode) {
   const { log, syscall } = buildSyscall();
 
   function build(_vatPowers) {
-    return harden({
+    return Far('root', {
       run(target, resolution) {
         let p; // vat creates the promise
         if (resolution === 'reject') {
@@ -371,7 +371,7 @@ async function doResultPromise(t, mode) {
   const { log, syscall } = buildSyscall();
 
   function build(_vatPowers) {
-    return harden({
+    return Far('root', {
       async run(target1) {
         const p1 = E(target1).getTarget2();
         hush(p1);

--- a/packages/SwingSet/test/timer-device/bootstrap.js
+++ b/packages/SwingSet/test/timer-device/bootstrap.js
@@ -1,15 +1,16 @@
 import { assert, details as X } from '@agoric/assert';
 import { Nat } from '@agoric/nat';
+import { Far } from '@agoric/marshal';
 
 export function buildRootObject(vatPowers, vatParameters) {
   const { D } = vatPowers;
   const log = vatPowers.testLog;
-  return harden({
+  return Far('root', {
     async bootstrap(vats, devices) {
       const { argv } = vatParameters;
       if (argv[0] === 'timer') {
         log(`starting wake test`);
-        const handler = harden({
+        const handler = Far('handler', {
           wake() {
             log(`handler.wake()`);
           },
@@ -18,7 +19,7 @@ export function buildRootObject(vatPowers, vatParameters) {
       } else if (argv[0] === 'repeater') {
         log(`starting repeater test`);
         let handlerCalled = 0;
-        const handler = harden({
+        const handler = Far('handler', {
           wake(h) {
             handlerCalled += 1;
             log(

--- a/packages/SwingSet/test/vat-admin/bootstrap.js
+++ b/packages/SwingSet/test/vat-admin/bootstrap.js
@@ -1,10 +1,10 @@
 import { E } from '@agoric/eventual-send';
-
+import { Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
 
 export function buildRootObject(vatPowers, vatParameters) {
   const log = vatPowers.testLog;
-  return harden({
+  return Far('root', {
     async bootstrap(vats, devices) {
       const { argv } = vatParameters;
       const bundles = argv[1];

--- a/packages/SwingSet/test/vat-admin/new-vat.js
+++ b/packages/SwingSet/test/vat-admin/new-vat.js
@@ -1,10 +1,11 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 export function buildRootObject(_vatPowers) {
   function rcvrMaker(seed) {
     let count = 0;
     let sum = seed;
-    return harden({
+    return Far('rcvr', {
       increment(val) {
         sum += val;
         count += 1;
@@ -15,7 +16,7 @@ export function buildRootObject(_vatPowers) {
       },
     });
   }
-  return harden({
+  return Far('root', {
     getANumber() {
       return 13;
     },

--- a/packages/SwingSet/test/vat-admin/replay-bootstrap.js
+++ b/packages/SwingSet/test/vat-admin/replay-bootstrap.js
@@ -1,11 +1,12 @@
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
+import { Far } from '@agoric/marshal';
 
 export function buildRootObject(_vatPowers, vatParameters) {
   const { promise: vatAdminSvc, resolve: gotVatAdminSvc } = makePromiseKit();
   let root;
 
-  return harden({
+  return Far('root', {
     async bootstrap(vats, devices) {
       gotVatAdminSvc(E(vats.vatAdmin).createVatAdminService(devices.vatAdmin));
     },

--- a/packages/SwingSet/test/vat-admin/replay-dynamic.js
+++ b/packages/SwingSet/test/vat-admin/replay-dynamic.js
@@ -1,6 +1,8 @@
+import { Far } from '@agoric/marshal';
+
 export function buildRootObject() {
   let counter = 0;
-  return harden({
+  return Far('root', {
     first() {
       counter += 1;
       return counter;

--- a/packages/SwingSet/test/vat-admin/terminate/bootstrap-die-cleanly.js
+++ b/packages/SwingSet/test/vat-admin/terminate/bootstrap-die-cleanly.js
@@ -1,9 +1,10 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 export function buildRootObject() {
   let dude;
 
-  const self = harden({
+  const self = Far('root', {
     async bootstrap(vats, devices) {
       const vatMaker = E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
 

--- a/packages/SwingSet/test/vat-admin/terminate/bootstrap-die-with-presence.js
+++ b/packages/SwingSet/test/vat-admin/terminate/bootstrap-die-with-presence.js
@@ -1,9 +1,10 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 export function buildRootObject(vatPowers) {
   const { testLog } = vatPowers;
 
-  const self = harden({
+  const self = Far('root', {
     async bootstrap(vats, devices) {
       testLog('preparing dynamic vat');
       const vatMaker = E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);

--- a/packages/SwingSet/test/vat-admin/terminate/bootstrap-no-zombies.js
+++ b/packages/SwingSet/test/vat-admin/terminate/bootstrap-no-zombies.js
@@ -1,7 +1,8 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 export function buildRootObject() {
-  const self = harden({
+  const self = Far('root', {
     async bootstrap(vats, devices) {
       const vatMaker = E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
 

--- a/packages/SwingSet/test/vat-admin/terminate/bootstrap-speak-to-dead.js
+++ b/packages/SwingSet/test/vat-admin/terminate/bootstrap-speak-to-dead.js
@@ -1,5 +1,6 @@
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
+import { Far } from '@agoric/marshal';
 
 export function buildRootObject(vatPowers) {
   const { testLog } = vatPowers;
@@ -7,7 +8,7 @@ export function buildRootObject(vatPowers) {
   let weatherwaxRoot;
   let rAfterG;
 
-  const self = harden({
+  const self = Far('root', {
     async bootstrap(vats, devices) {
       const vatMaker = E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
       mediumRoot = vats.medium;

--- a/packages/SwingSet/test/vat-admin/terminate/bootstrap-terminate.js
+++ b/packages/SwingSet/test/vat-admin/terminate/bootstrap-terminate.js
@@ -1,10 +1,11 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 export function buildRootObject(vatPowers, vatParameters) {
   const { testLog } = vatPowers;
   const mode = vatParameters.argv[0];
 
-  const self = harden({
+  const self = Far('root', {
     async bootstrap(vats, devices) {
       const vatMaker = E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
 

--- a/packages/SwingSet/test/vat-admin/terminate/vat-dude-terminate.js
+++ b/packages/SwingSet/test/vat-admin/terminate/vat-dude-terminate.js
@@ -1,12 +1,13 @@
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
+import { Far } from '@agoric/marshal';
 
 export function buildRootObject(vatPowers) {
   // we use testLog to attempt to deliver messages even after we're supposed
   // to be cut off
   const { testLog } = vatPowers;
 
-  return harden({
+  return Far('root', {
     foo(arg) {
       testLog(`FOO ${arg}`);
       return `FOO SAYS ${arg}`;

--- a/packages/SwingSet/test/vat-admin/terminate/vat-medium-terminate.js
+++ b/packages/SwingSet/test/vat-admin/terminate/vat-medium-terminate.js
@@ -1,9 +1,10 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 export function buildRootObject(vatPowers) {
   const { testLog } = vatPowers;
 
-  return harden({
+  return Far('root', {
     async speak(target, tag) {
       try {
         await E(target).live();

--- a/packages/SwingSet/test/vat-admin/terminate/vat-weatherwax-terminate.js
+++ b/packages/SwingSet/test/vat-admin/terminate/vat-weatherwax-terminate.js
@@ -1,4 +1,5 @@
 import { makePromiseKit } from '@agoric/promise-kit';
+import { Far } from '@agoric/marshal';
 
 export function buildRootObject(vatPowers) {
   // we use testLog to attempt to deliver messages even after we're supposed
@@ -6,7 +7,7 @@ export function buildRootObject(vatPowers) {
   const { testLog } = vatPowers;
   let resolvers;
 
-  return harden({
+  return Far('root', {
     live() {
       testLog(`w: I ate'nt dead`);
       if (resolvers && resolvers.length) {

--- a/packages/SwingSet/test/vat-exomessages.js
+++ b/packages/SwingSet/test/vat-exomessages.js
@@ -1,5 +1,7 @@
+import { Far } from '@agoric/marshal';
+
 export function buildRootObject(_vatPowers, vatParameters) {
-  const other = harden({
+  const other = Far('other', {
     something(arg) {
       return arg;
     },
@@ -16,7 +18,7 @@ export function buildRootObject(_vatPowers, vatParameters) {
     return undefined;
   }
 
-  return harden({
+  return Far('root', {
     bootstrap(_vats) {
       return behave(vatParameters.argv[0]);
     },

--- a/packages/SwingSet/test/vat-tildot.js
+++ b/packages/SwingSet/test/vat-tildot.js
@@ -1,3 +1,4 @@
+import { Far } from '@agoric/marshal';
 
 export function buildRootObject(vatPowers) {
   const log = vatPowers.testLog;
@@ -14,5 +15,5 @@ export function buildRootObject(vatPowers) {
       log(arg);
     },
   };
-  return harden(root);
+  return Far('root', root);
 }

--- a/packages/SwingSet/test/virtualObjects/test-representatives.js
+++ b/packages/SwingSet/test/virtualObjects/test-representatives.js
@@ -12,9 +12,9 @@ function capargs(args, slots = []) {
   return capdata(JSON.stringify(args), slots);
 }
 
-function slot0(kid) {
+function slot0(iface, kid) {
   return {
-    body: '{"@qclass":"slot","index":0}',
+    body: `{"@qclass":"slot","iface":"Alleged: ${iface}","index":0}`,
     slots: [kid],
   };
 }
@@ -48,7 +48,7 @@ test('virtual object representatives', async t => {
     await c.run();
     t.is(c.kpStatus(r), 'fulfilled');
     t.deepEqual(nextLog(), []);
-    t.deepEqual(c.kpResolution(r), slot0(result));
+    t.deepEqual(c.kpResolution(r), slot0('thing', result));
   }
   await doTestA(1, 'ko25');
   await doTestA(2, 'ko26');
@@ -68,7 +68,7 @@ test('virtual object representatives', async t => {
       `test${mode} thing.name after rename "thing${mode} modified"`,
       `test${mode} initialSelf.name after rename "thing${mode} modified"`,
     ]);
-    t.deepEqual(c.kpResolution(r), slot0(result));
+    t.deepEqual(c.kpResolution(r), slot0('thing', result));
   }
   await doTestB(3, 'ko27');
   await doTestB(4, 'ko28');
@@ -134,7 +134,7 @@ test('virtual object representatives', async t => {
   await c.run();
   t.is(c.kpStatus(rz1), 'fulfilled');
   t.deepEqual(nextLog(), []);
-  t.deepEqual(c.kpResolution(rz1), slot0('ko31'));
+  t.deepEqual(c.kpResolution(rz1), slot0('zot', 'ko31'));
 
   const rz2 = c.queueToVatExport(
     'bootstrap',

--- a/packages/SwingSet/test/virtualObjects/test-virtualObjectManager.js
+++ b/packages/SwingSet/test/virtualObjects/test-virtualObjectManager.js
@@ -1,6 +1,6 @@
 import '@agoric/install-ses';
 import test from 'ava';
-import { makeMarshal } from '@agoric/marshal';
+import { makeMarshal, Far } from '@agoric/marshal';
 import { assert } from '@agoric/assert';
 import { parseVatSlot } from '../../src/parseVatSlots';
 import { makeVirtualObjectManager } from '../../src/kernel/virtualObjectManager';
@@ -81,7 +81,7 @@ function makeThingInstance(state) {
       state.label = label;
       state.resetCounter = 0;
     },
-    self: {
+    self: Far('thing', {
       inc() {
         state.counter += 1;
         return state.counter;
@@ -100,7 +100,7 @@ function makeThingInstance(state) {
       describe() {
         return `${state.label} counter has been reset ${state.resetCounter} times and is now ${state.counter}`;
       },
-    },
+    }),
   };
 }
 
@@ -112,7 +112,7 @@ function makeZotInstance(state) {
       state.tag = tag;
       state.count = 0;
     },
-    self: {
+    self: Far('zot', {
       sayHello(msg) {
         state.count += 1;
         return `${msg} ${state.name}`;
@@ -126,7 +126,7 @@ function makeZotInstance(state) {
         state.count += 1;
         return `zot ${state.name} tag=${state.tag} count=${state.count} arbitrary=${state.arbitrary}`;
       },
-    },
+    }),
   };
 }
 

--- a/packages/SwingSet/test/virtualObjects/vat-representative-bootstrap.js
+++ b/packages/SwingSet/test/virtualObjects/vat-representative-bootstrap.js
@@ -1,4 +1,6 @@
 /* global makeKind makeWeakStore */
+import { Far } from '@agoric/marshal';
+
 const stuff = makeWeakStore();
 
 let initialSelf;
@@ -9,7 +11,7 @@ function makeThingInstance(state) {
     // eslint-disable-next-line no-use-before-define
     initialSelf = self;
   }
-  const self = {
+  const self = Far('thing', {
     getName() {
       return state.name;
     },
@@ -19,7 +21,7 @@ function makeThingInstance(state) {
     getSelf() {
       return self;
     },
-  };
+  });
   return { init, self };
 }
 
@@ -37,14 +39,14 @@ function makeZotInstance(state) {
       zotMaker('recur', true);
     }
   }
-  const self = {
+  const self = Far('zot', {
     getName() {
       return state.name;
     },
     rename(newName) {
       state.name = newName;
     },
-  };
+  });
   return { init, self };
 }
 
@@ -53,7 +55,7 @@ const zotMaker = makeKind(makeZotInstance);
 export function buildRootObject(vatPowers) {
   const { testLog } = vatPowers;
 
-  return harden({
+  return Far('root', {
     bootstrap() {
       return 'bootstrap done';
     },

--- a/packages/SwingSet/test/workers/bootstrap.js
+++ b/packages/SwingSet/test/workers/bootstrap.js
@@ -1,8 +1,9 @@
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
+import { Far } from '@agoric/marshal';
 
 export function buildRootObject() {
-  const callbackObj = harden({
+  const callbackObj = Far('callback', {
     callback(_arg1, _arg2) {
       // console.log(`callback`, arg1, arg2);
       return ['data', callbackObj]; // four, resolves pF
@@ -53,7 +54,7 @@ export function buildRootObject() {
     ]);
   }
 
-  return harden({
+  return Far('root', {
     bootstrap(vats, devices) {
       const pA = E(vats.target).zero(
         callbackObj,

--- a/packages/SwingSet/test/workers/device-add.js
+++ b/packages/SwingSet/test/workers/device-add.js
@@ -1,5 +1,7 @@
+import { Far } from '@agoric/marshal';
+
 export function buildRootDeviceNode() {
-  return harden({
+  return Far('root', {
     add(x, y) {
       return x + y;
     },

--- a/packages/SwingSet/test/workers/vat-target.js
+++ b/packages/SwingSet/test/workers/vat-target.js
@@ -1,5 +1,6 @@
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
+import { Far } from '@agoric/marshal';
 
 function ignore(p) {
   p.then(
@@ -55,7 +56,7 @@ export function buildRootObject(vatPowers, vatParameters) {
 
   // crank 5: dispatch.notify(pF, false, ['data', callbackObj])
 
-  const target = harden({
+  const target = Far('root', {
     zero,
     one,
   });


### PR DESCRIPTION
This ought to cover every part of swingset that creates a pass-by-reference object, marking all of them with `Far()` and a vaguely-descriptive interface name.

It's mostly mechanical, with one tiny extra piece: the Presence that we synthesize in the comms vat when you call `addIngress` (to bootstrap the comms connection) is now created with an `iface:` property in the serialized data, so that the Presence you get back will be marked as such. To support this, `addIngress` now takes an extra parameter with the interface name.

@FUDCo you're the main reviewer

@erights I'm not sure how the "Alleged:" part works, and whether this extra parameter ought to impose the Alleged prefix, or accept it from the caller (who has full control over what sort of Presence we get back, in case that influences the decision). Any thoughts?:

https://github.com/Agoric/agoric-sdk/blob/218a4baf5433533ee81744b35fceee68dedb98ca/packages/SwingSet/src/vats/comms/controller.js#L96-L103
