### PR TITLE
annotate ERTP with Data/Far

### DIFF
--- a/packages/ERTP/src/displayInfo.js
+++ b/packages/ERTP/src/displayInfo.js
@@ -4,6 +4,7 @@ import {
   passStyleOf,
   REMOTE_STYLE,
   getInterfaceOf,
+  Data,
 } from '@agoric/marshal';
 
 // TODO: assertSubset and assertKeysAllowed are copied from Zoe. Move
@@ -61,7 +62,7 @@ export const coerceDisplayInfo = allegedDisplayInfo => {
     assert.equal(Reflect.ownKeys(allegedDisplayInfo).length, 0);
     assert.equal(Object.getPrototypeOf(allegedDisplayInfo), Object.prototype);
     assert.equal(getInterfaceOf(allegedDisplayInfo), undefined);
-    return harden({});
+    return Data({});
   }
   allegedDisplayInfo = pureCopy(allegedDisplayInfo);
   assertDisplayInfo(allegedDisplayInfo);

--- a/packages/ERTP/test/swingsetTests/splitPayments/bootstrap.js
+++ b/packages/ERTP/test/swingsetTests/splitPayments/bootstrap.js
@@ -1,5 +1,6 @@
 import { E } from '@agoric/eventual-send';
 import { assert, details as X } from '@agoric/assert';
+import { Far } from '@agoric/marshal';
 import { makeIssuerKit } from '../../../src';
 
 export function buildRootObject(vatPowers, vatParameters) {
@@ -27,5 +28,5 @@ export function buildRootObject(vatPowers, vatParameters) {
       }
     },
   };
-  return harden(obj0);
+  return Far('root', obj0);
 }

--- a/packages/ERTP/test/swingsetTests/splitPayments/vat-alice.js
+++ b/packages/ERTP/test/swingsetTests/splitPayments/vat-alice.js
@@ -1,9 +1,10 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 function makeAliceMaker(log) {
-  return harden({
+  return Far('aliceMaker', {
     make(issuer, amountMath, oldPaymentP) {
-      const alice = harden({
+      const alice = Far('alice', {
         async testSplitPayments() {
           log('oldPayment balance:', await E(issuer).getAmountOf(oldPaymentP));
           const splitPayments = await E(issuer).split(
@@ -26,9 +27,9 @@ function makeAliceMaker(log) {
 }
 
 export function buildRootObject(vatPowers) {
-  return harden({
+  return Far('root', {
     makeAliceMaker(host) {
-      return harden(makeAliceMaker(vatPowers.testLog, host));
+      return makeAliceMaker(vatPowers.testLog, host);
     },
   });
 }

--- a/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
@@ -1,12 +1,12 @@
 import test from 'ava';
-
+import { Far } from '@agoric/marshal';
 import { makeAmountMath, MathKind } from '../../../src';
 
 // The "unit tests" for MathHelpers actually make the calls through
 // AmountMath so that we can test that any duplication is handled
 // correctly.
 
-const mockBrand = harden({
+const mockBrand = Far('brand', {
   isMyIssuer: () => false,
   getAllegedName: () => 'mock',
 });

--- a/packages/ERTP/test/unitTests/mathHelpers/test-setMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-setMathHelpers.js
@@ -1,12 +1,12 @@
 import test from 'ava';
-
+import { Far, Data } from '@agoric/marshal';
 import { makeAmountMath, MathKind } from '../../../src';
 
 // The "unit tests" for MathHelpers actually make the calls through
 // AmountMath so that we can test that any duplication is handled
 // correctly.
 
-const mockBrand = harden({
+const mockBrand = Far('brand', {
   isMyIssuer: () => false,
   getAllegedName: () => 'mock',
 });
@@ -133,7 +133,7 @@ const runSetMathHelpersTests = (t, [a, b, c], a2 = undefined) => {
   // isEmpty
   t.assert(isEmpty(make(harden([]))), `isEmpty([]) is true`);
   t.throws(
-    () => isEmpty(harden({ brand: mockBrand, value: {} })),
+    () => isEmpty(harden({ brand: mockBrand, value: Data({}) })),
     { message: /list must be an array/ },
     `isEmpty({}) throws`,
   );
@@ -381,9 +381,9 @@ const runSetMathHelpersTests = (t, [a, b, c], a2 = undefined) => {
 };
 
 test('setMathHelpers with handles', t => {
-  const a = harden({});
-  const b = harden({});
-  const c = harden({});
+  const a = Far('iface', {});
+  const b = Far('iface', {});
+  const c = Far('iface', {});
 
   runSetMathHelpersTests(t, harden([a, b, c]));
 });
@@ -399,9 +399,21 @@ test('setMathHelpers with basic objects', t => {
 });
 
 test('setMathHelpers with complex objects', t => {
-  const a = { handle: {}, instanceHandle: {}, name: 'a' };
-  const b = { handle: {}, instanceHandle: a.instanceHandle, name: 'b' };
-  const c = { handle: {}, instanceHandle: {}, name: 'c' };
+  const a = {
+    handle: Far('handle', {}),
+    instanceHandle: Far('ihandle', {}),
+    name: 'a',
+  };
+  const b = {
+    handle: Far('handle', {}),
+    instanceHandle: a.instanceHandle,
+    name: 'b',
+  };
+  const c = {
+    handle: Far('handle', {}),
+    instanceHandle: Far('ihandle', {}),
+    name: 'c',
+  };
 
   const a2 = harden({ ...a });
 

--- a/packages/ERTP/test/unitTests/mathHelpers/test-strSetMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-strSetMathHelpers.js
@@ -1,12 +1,12 @@
 import test from 'ava';
-
+import { Far } from '@agoric/marshal';
 import { makeAmountMath, MathKind } from '../../../src';
 
 // The "unit tests" for MathHelpers actually make the calls through
 // AmountMath so that we can test that any duplication is handled
 // correctly.
 
-const mockBrand = harden({
+const mockBrand = Far('brand', {
   isMyIssuer: () => false,
   getAllegedName: () => 'mock',
 });

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -2,6 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { E } from '@agoric/eventual-send';
+import { Data } from '@agoric/marshal';
 import { MathKind, makeIssuerKit } from '../../src';
 
 test('issuer.getBrand, brand.isMyIssuer', t => {
@@ -46,7 +47,7 @@ test('bad display info', t => {
 });
 
 test('empty display info', t => {
-  const displayInfo = harden({});
+  const displayInfo = Data({});
   const { brand } = makeIssuerKit('fungible', MathKind.NAT, displayInfo);
   t.deepEqual(brand.getDisplayInfo(), displayInfo);
 });

--- a/packages/ERTP/test/unitTests/test-mintObj.js
+++ b/packages/ERTP/test/unitTests/test-mintObj.js
@@ -1,5 +1,6 @@
 import test from 'ava';
 
+import { Far } from '@agoric/marshal';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { makeIssuerKit, MathKind } from '../../src';
 
@@ -38,9 +39,9 @@ test('mint.mintPayment strSet MathKind', async t => {
 
 test('mint.mintPayment set MathKind', async t => {
   const { mint, issuer, amountMath } = makeIssuerKit('items', MathKind.SET);
-  const item1handle = {};
-  const item2handle = {};
-  const item3handle = {};
+  const item1handle = Far('iface', {});
+  const item2handle = Far('iface', {});
+  const item3handle = Far('iface', {});
   const items1and2 = amountMath.make(harden([item1handle, item2handle]));
   const payment1 = mint.mintPayment(items1and2);
   const paymentBalance1 = await issuer.getAmountOf(payment1);
@@ -60,10 +61,19 @@ test('mint.mintPayment set MathKind', async t => {
 
 test('mint.mintPayment set MathKind with invites', async t => {
   const { mint, issuer, amountMath } = makeIssuerKit('items', MathKind.SET);
-  const instanceHandle1 = {};
-  const invite1Value = { handle: {}, instanceHandle: instanceHandle1 };
-  const invite2Value = { handle: {}, instanceHandle: instanceHandle1 };
-  const invite3Value = { handle: {}, instanceHandle: {} };
+  const instanceHandle1 = Far('iface', {});
+  const invite1Value = {
+    handle: Far('iface', {}),
+    instanceHandle: instanceHandle1,
+  };
+  const invite2Value = {
+    handle: Far('iface', {}),
+    instanceHandle: instanceHandle1,
+  };
+  const invite3Value = {
+    handle: Far('iface', {}),
+    instanceHandle: Far('iface', {}),
+  };
   const invites1and2 = amountMath.make(harden([invite1Value, invite2Value]));
   const payment1 = mint.mintPayment(invites1and2);
   const paymentBalance1 = await issuer.getAmountOf(payment1);


### PR DESCRIPTION
This updates the ERTP and CapTP packages to use Data and Far (#2018) as necessary to allow tests to pass while the marshal.js "throw errors upon unmarked empty objects and unmarked pass-by-reference objects" switches are turned on.

Note that all vats must change their `buildRootObject` function to mark the return value with `Far`, as well as any other code that might run in a vat and wants to traffic in a pass-by-reference object. In general, any time you see `harden({ methods.. })`, you should replace it with `Far('interface name', { methods.. })`. And any time you see `harden({})` where the object is meant to be pass-by-copy, you should replace it with `Data({})`. When #2018 is all done, we'll revert the Data changes (so `harden({})` will be pass-by-copy), but `Far` is the new normal.

This builds upon the 2018-update-swingset-far branch (which does the same thing for swingset tests), and should not land until PR #2530 has landed.

@katelynsills please take a look at the ERTP changes to see if I correctly figured out which things are pass-by-copy `Data` and which things are pass-by-reference `Far`. Also see if the interface names I applied make sense. I think they're mostly cosmetic, but it'll probably save some confusion down the road if they aren't completely misleading.

@michaelfig same for CapTP please.
