### PR TITLE
Pledger refinements

### DIFF
--- a/packages/agoric-cli/lib/open.js
+++ b/packages/agoric-cli/lib/open.js
@@ -2,6 +2,7 @@ import { promises as defaultFs } from 'fs';
 import opener from 'opener';
 import crypto from 'crypto';
 import path from 'path';
+import os from 'os';
 
 import { openSwingStore } from '@agoric/swing-store-simple';
 
@@ -37,7 +38,7 @@ export async function getAccessToken(port, powers = {}) {
   }
 
   // Ensure we're protected with a unique accessToken for this basedir.
-  const sharedStateDir = path.join(process.env.HOME || '', '.agoric');
+  const sharedStateDir = path.join(os.homedir(), '.agoric');
   await fs.mkdir(sharedStateDir, { mode: 0o700, recursive: true });
 
   // Ensure an access token exists.

--- a/packages/cosmic-swingset/lib/ag-solo/access-token.js
+++ b/packages/cosmic-swingset/lib/ag-solo/access-token.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import crypto from 'crypto';
+import os from 'os';
 import path from 'path';
 
 import { openSwingStore } from '@agoric/swing-store-simple';
@@ -27,7 +28,7 @@ export function generateAccessToken({
 
 export async function getAccessToken(port) {
   // Ensure we're protected with a unique accessToken for this basedir.
-  const sharedStateDir = path.join(process.env.HOME || '', '.agoric');
+  const sharedStateDir = path.join(os.homedir(), '.agoric');
   await fs.promises.mkdir(sharedStateDir, { mode: 0o700, recursive: true });
 
   // Ensure an access token exists.

--- a/packages/cosmic-swingset/lib/ag-solo/html/main.js
+++ b/packages/cosmic-swingset/lib/ag-solo/html/main.js
@@ -6,29 +6,48 @@ const RECONNECT_BACKOFF_SECONDS = 3;
 const resetFns = [];
 let inpBackground;
 
-// Fetch the access token from the window's URL.
-let accessTokenParams = `?${window.location.hash.slice(1)}`;
-let hasAccessToken = new URLSearchParams(accessTokenParams).get('accessToken');
+let accessTokenParams;
+let hasAccessToken;
 
-try {
-  if (hasAccessToken) {
-    // Store the access token for later use.
-    localStorage.setItem('accessTokenParams', accessTokenParams);
-  } else {
-    // Try reviving it from localStorage.
-    accessTokenParams = localStorage.getItem('accessTokenParams') || '?';
-    hasAccessToken = new URLSearchParams(accessTokenParams).get('accessToken');
+function getAccessToken() {
+  // Fetch the access token from the window's URL.
+  accessTokenParams = `?${window.location.hash.slice(1)}`;
+  hasAccessToken = new URLSearchParams(accessTokenParams).get('accessToken');
+
+  try {
+    if (hasAccessToken) {
+      // Store the access token for later use.
+      localStorage.setItem('accessTokenParams', accessTokenParams);
+    } else {
+      // Try reviving it from localStorage.
+      accessTokenParams = localStorage.getItem('accessTokenParams') || '?';
+      hasAccessToken = new URLSearchParams(accessTokenParams).get(
+        'accessToken',
+      );
+    }
+  } catch (e) {
+    console.log('Error fetching accessTokenParams', e);
   }
-} catch (e) {
-  console.log('Error fetching accessTokenParams', e);
-}
 
-// Now that we've captured it, clear out the access token from the URL bar.
-window.location.hash = '';
-window.addEventListener('hashchange', _ev => {
-  // Keep it clear.
+  // Now that we've captured it, clear out the access token from the URL bar.
   window.location.hash = '';
-});
+  window.addEventListener('hashchange', _ev => {
+    // See if we should update the access token params.
+    const atp = `?${window.location.hash.slice(1)}`;
+    const hat = new URLSearchParams(atp).get('accessToken');
+
+    if (hat) {
+      // We have new params, so replace them.
+      accessTokenParams = atp;
+      hasAccessToken = hat;
+      localStorage.setItem('accessTokenParams', accessTokenParams);
+    }
+
+    // Keep it clear.
+    window.location.hash = '';
+  });
+}
+getAccessToken();
 
 if (!hasAccessToken) {
   // This is friendly advice to the user who doesn't know.

--- a/packages/cosmic-swingset/lib/chain-entrypoint.js
+++ b/packages/cosmic-swingset/lib/chain-entrypoint.js
@@ -12,6 +12,7 @@ const agcc = require('@agoric/cosmos');
 esmRequire('@agoric/install-metering-and-ses');
 
 const path = require('path');
+const os = require('os');
 
 esmRequire('./anylogger-agoric');
 const anylogger = require('anylogger');
@@ -22,6 +23,7 @@ const main = esmRequire('./chain-main.js').default;
 
 main(process.argv[1], process.argv.splice(2), {
   path,
+  homedir: os.homedir(),
   env: process.env,
   agcc,
 }).then(

--- a/packages/cosmic-swingset/lib/chain-main.js
+++ b/packages/cosmic-swingset/lib/chain-main.js
@@ -5,7 +5,6 @@ import {
 } from '@agoric/swingset-vat/src/devices/mailbox';
 
 import { assert, details as X } from '@agoric/assert';
-import os from 'os';
 
 import { launch } from './launch-chain';
 import makeBlockManager from './block-manager';
@@ -77,7 +76,11 @@ const makeChainStorage = (call, prefix = '', imp = x => x, exp = x => x) => {
   return storage;
 };
 
-export default async function main(progname, args, { path, env, agcc }) {
+export default async function main(
+  progname,
+  args,
+  { path, env, homedir, agcc },
+) {
   const portNums = {};
 
   // TODO: use the 'basedir' pattern
@@ -105,7 +108,7 @@ export default async function main(progname, args, { path, env, agcc }) {
 
   // We try to find the actual cosmos state directory (default=~/.ag-chain-cosmos), which
   // is better than scribbling into the current directory.
-  const cosmosHome = getFlagValue('home', `${os.homedir()}/.ag-chain-cosmos`);
+  const cosmosHome = getFlagValue('home', `${homedir}/.ag-chain-cosmos`);
   const stateDBDir = `${cosmosHome}/data/ag-cosmos-chain-state`;
 
   // console.log('Have AG_COSMOS', agcc);
@@ -223,9 +226,9 @@ export default async function main(progname, args, { path, env, agcc }) {
     const vatsdir = path.resolve(__dirname, '../lib/ag-solo/vats');
     const argv = {
       ROLE: 'chain',
-      noFakeCurrencies: process.env.NO_FAKE_CURRENCIES,
+      noFakeCurrencies: env.NO_FAKE_CURRENCIES,
     };
-    const meterProvider = getMeterProvider(console, process.env);
+    const meterProvider = getMeterProvider(console, env);
     const s = await launch(
       stateDBDir,
       mailboxStorage,

--- a/packages/cosmic-swingset/lib/chain-main.js
+++ b/packages/cosmic-swingset/lib/chain-main.js
@@ -5,6 +5,8 @@ import {
 } from '@agoric/swingset-vat/src/devices/mailbox';
 
 import { assert, details as X } from '@agoric/assert';
+import os from 'os';
+
 import { launch } from './launch-chain';
 import makeBlockManager from './block-manager';
 import { getMeterProvider } from './kernel-stats';
@@ -103,7 +105,7 @@ export default async function main(progname, args, { path, env, agcc }) {
 
   // We try to find the actual cosmos state directory (default=~/.ag-chain-cosmos), which
   // is better than scribbling into the current directory.
-  const cosmosHome = getFlagValue('home', `${env.HOME}/.ag-chain-cosmos`);
+  const cosmosHome = getFlagValue('home', `${os.homedir()}/.ag-chain-cosmos`);
   const stateDBDir = `${cosmosHome}/data/ag-cosmos-chain-state`;
 
   // console.log('Have AG_COSMOS', agcc);


### PR DESCRIPTION
Fix some more problems found on Windows:

- If the wallet was loaded with the wrong access token, allow changes to the address bar to take effect
- We need `os.homedir()` instead of `process.env.HOME`
