### PR TITLE
Use ratios

### DIFF
--- a/packages/zoe/src/contractSupport/index.js
+++ b/packages/zoe/src/contractSupport/index.js
@@ -43,5 +43,4 @@ export {
   divideBy,
   assertIsRatio,
   invertRatio,
-  multiplyRatios,
 } from './ratio';

--- a/packages/zoe/src/contractSupport/index.js
+++ b/packages/zoe/src/contractSupport/index.js
@@ -35,3 +35,13 @@ export {
   saveAllIssuers,
   offerTo,
 } from './zoeHelpers';
+
+export {
+  makeRatio,
+  makeRatioFromAmounts,
+  multiplyBy,
+  divideBy,
+  assertIsRatio,
+  invertRatio,
+  multiplyRatios,
+} from './ratio';

--- a/packages/zoe/src/contractSupport/ratio.js
+++ b/packages/zoe/src/contractSupport/ratio.js
@@ -3,7 +3,7 @@
 import './types';
 import { assert, details as X, q } from '@agoric/assert';
 import { Nat } from '@agoric/nat';
-import { natSafeMath } from '.';
+import { natSafeMath } from './safeMath';
 
 const { multiply, floorDivide } = natSafeMath;
 

--- a/packages/zoe/src/contractSupport/ratio.js
+++ b/packages/zoe/src/contractSupport/ratio.js
@@ -79,7 +79,8 @@ export const makeRatioFromAmounts = (numeratorAmount, denominatorAmount) => {
 export const multiplyBy = (amount, ratio) => {
   // TODO(https://github.com/Agoric/agoric-sdk/pull/2310) after the refactoring
   // coerce amount using a native amountMath operation.
-  assert(amount.value && amount.brand, X`Expected an amount: ${amount}`);
+  assert(amount.brand, X`Expected an amount: ${amount}`);
+  Nat(amount.value);
 
   assertIsRatio(ratio);
   assert(
@@ -105,7 +106,8 @@ export const multiplyBy = (amount, ratio) => {
 export const divideBy = (amount, ratio) => {
   // TODO(https://github.com/Agoric/agoric-sdk/pull/2310) after the refactoring
   // coerce amount using a native amountMath operation.
-  assert(amount.value && amount.brand, X`Expected an amount: ${amount}`);
+  assert(amount.brand, X`Expected an amount: ${amount}`);
+  Nat(amount.value);
 
   assertIsRatio(ratio);
   assert(

--- a/packages/zoe/src/contractSupport/ratio.js
+++ b/packages/zoe/src/contractSupport/ratio.js
@@ -51,9 +51,7 @@ export const makeRatio = (
 ) => {
   assert(
     denominator > 0n,
-    X`No infinite ratios! Denoninator was 0/${q(
-      denominatorBrand.getAllegedName(),
-    )}`,
+    X`No infinite ratios! Denoninator was 0/${q(denominatorBrand)}`,
   );
 
   // TODO(https://github.com/Agoric/agoric-sdk/pull/2310) after the refactoring
@@ -85,10 +83,8 @@ export const multiplyBy = (amount, ratio) => {
   assertIsRatio(ratio);
   assert(
     amount.brand === ratio.denominator.brand,
-    X`amount's brand ${q(
-      amount.brand.getAllegedName(),
-    )} must match ratio's denominator ${q(
-      ratio.denominator.brand.getAllegedName(),
+    X`amount's brand ${q(amount.brand)} must match ratio's denominator ${q(
+      ratio.denominator.brand,
     )}`,
   );
 
@@ -112,10 +108,8 @@ export const divideBy = (amount, ratio) => {
   assertIsRatio(ratio);
   assert(
     amount.brand === ratio.numerator.brand,
-    X`amount's brand ${q(
-      amount.brand.getAllegedName(),
-    )} must match ratio's numerator ${q(
-      ratio.numerator.brand.getAllegedName(),
+    X`amount's brand ${q(amount.brand)} must match ratio's numerator ${q(
+      ratio.numerator.brand,
     )}`,
   );
 

--- a/packages/zoe/src/contracts/callSpread/calculateShares.js
+++ b/packages/zoe/src/contracts/callSpread/calculateShares.js
@@ -6,7 +6,7 @@ import { makeRatio } from '../../contractSupport';
 import { oneMinus, make100Percent, make0Percent } from './percent';
 
 /**
- * Calculate the portion (as a percentage) of the collateral that should be
+ * Calculate the portion (as a Ratio) of the collateral that should be
  * allocated to the long side of a call spread contract. price gives the value
  * of the underlying asset at closing that determines the payouts to the parties
  *

--- a/packages/zoe/src/contracts/callSpread/calculateShares.js
+++ b/packages/zoe/src/contracts/callSpread/calculateShares.js
@@ -2,11 +2,8 @@
 import '../../../exported';
 import './types';
 
-import {
-  makeAll,
-  makeNone,
-  calculatePercent,
-} from '../../contractSupport/percentMath';
+import { makeRatio } from '../../contractSupport';
+import { oneMinus, make100Percent, make0Percent } from './percent';
 
 /**
  * Calculate the portion (as a percentage) of the collateral that should be
@@ -21,27 +18,27 @@ function calculateShares(
   strikePrice1,
   strikePrice2,
 ) {
+  const collateralBrand = collateralMath.getBrand();
   if (strikeMath.isGTE(strikePrice1, price)) {
     return {
-      longShare: makeNone(collateralMath),
-      shortShare: makeAll(collateralMath),
+      longShare: make0Percent(collateralBrand),
+      shortShare: make100Percent(collateralBrand),
     };
   } else if (strikeMath.isGTE(price, strikePrice2)) {
     return {
-      longShare: makeAll(collateralMath),
-      shortShare: makeNone(collateralMath),
+      longShare: make100Percent(collateralBrand),
+      shortShare: make0Percent(collateralBrand),
     };
   }
 
   const denominator = strikeMath.subtract(strikePrice2, strikePrice1);
   const numerator = strikeMath.subtract(price, strikePrice1);
-  const longShare = calculatePercent(
-    numerator,
-    denominator,
-    collateralMath,
-    10000n,
+  const longShare = makeRatio(
+    numerator.value,
+    collateralBrand,
+    denominator.value,
   );
-  return { longShare, shortShare: longShare.complement() };
+  return { longShare, shortShare: oneMinus(longShare) };
 }
 
 harden(calculateShares);

--- a/packages/zoe/src/contracts/callSpread/fundedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/fundedCallSpread.js
@@ -50,7 +50,8 @@ import { Position } from './position';
  *
  * Future enhancements:
  * + issue multiple option pairs with the same expiration from a single instance
- * + increase the precision of the calculations. (use Percents with base=10000)
+ * + increase the precision of the calculations. (use Ratios with
+ *   denominator.value=10000)
  */
 
 /** @type {ContractStartFn} */

--- a/packages/zoe/src/contracts/callSpread/payoffHandler.js
+++ b/packages/zoe/src/contracts/callSpread/payoffHandler.js
@@ -3,7 +3,7 @@ import '../../../exported';
 import './types';
 
 import { E } from '@agoric/eventual-send';
-import { trade, getAmountOut } from '../../contractSupport';
+import { trade, getAmountOut, multiplyBy } from '../../contractSupport';
 import { Position } from './position';
 import { calculateShares } from './calculateShares';
 
@@ -36,7 +36,7 @@ function makePayoffHandler(zcf, seatPromiseKits, collateralSeat) {
   function reallocateToSeat(seatPromise, sharePercent) {
     seatPromise.then(seat => {
       const totalCollateral = terms.settlementAmount;
-      const seatPortion = sharePercent.scale(totalCollateral);
+      const seatPortion = multiplyBy(totalCollateral, sharePercent);
       trade(
         zcf,
         { seat, gains: { Collateral: seatPortion } },

--- a/packages/zoe/src/contracts/callSpread/percent.js
+++ b/packages/zoe/src/contracts/callSpread/percent.js
@@ -4,8 +4,7 @@
 
 import { assert, details as X } from '@agoric/assert';
 
-import { makeRatio, assertIsRatio } from '../../contractSupport/ratio';
-import { natSafeMath } from '../../contractSupport';
+import { makeRatio, assertIsRatio, natSafeMath } from '../../contractSupport';
 
 const { subtract } = natSafeMath;
 

--- a/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
@@ -154,7 +154,7 @@ const start = zcf => {
   //  rather than percent
   function makeInvitationPair(longCollateralShare) {
     const longPercent = makeRatio(
-      longCollateralShare * PERCENT_BASE,
+      (longCollateralShare * BASIS_POINTS) / PERCENT_BASE,
       collateralMath.getBrand(),
       BASIS_POINTS,
     );

--- a/packages/zoe/src/contracts/callSpread/types.js
+++ b/packages/zoe/src/contracts/callSpread/types.js
@@ -63,8 +63,8 @@
  * Return value from calculateShares, which represents the portions assigned to
  * the long and short side of a transaction. These will be two non-negative
  * integers that sum to 100.
- * @property {Percent} longShare
- * @property {Percent} shortShare
+ * @property {Ratio} longShare
+ * @property {Ratio} shortShare
  */
 
 /**
@@ -73,10 +73,11 @@
  * allocated to the long side of a call spread contract. price gives the value
  * of the underlying asset at closing that determines the payouts to the parties
  *
- * if price <= strikePrice1, return Percent.NONE
- * if price >= strikePrice2, return Percent.ALL.
- * Otherwise return a number between 1 and 99 reflecting the position of price
- * in the range from strikePrice1 to strikePrice2.
+ * if price <= strikePrice1, return Ratio representing 0
+ * if price >= strikePrice2, return Ratio representing 1.
+ * Otherwise return longShare and shortShare representing ratios between 0% and
+ * 100% reflecting the position of the price in the range from strikePrice1 to
+ * strikePrice2.
  * @param {AmountMath} strikeMath
  * @param {AmountMath} collateralMath
  * @param {Amount} price

--- a/packages/zoe/src/contracts/loan/index.js
+++ b/packages/zoe/src/contracts/loan/index.js
@@ -26,8 +26,8 @@ import { makeLendInvitation } from './lend';
  * loaned amount and interest must be of the same (separate) brand.
  *
  * Terms:
- *  * mmr (default = 150) - the Maintenance Margin Requirement, as a
- *    ratio. The default is 1.5, meaning that collateral should be
+ *  * mmr (default = 150/100) - the Maintenance Margin Requirement, as a
+ *    ratio. The default is 150/100, meaning that collateral should be
  *    worth at least 150% of the loan. If the value of the collateral
  *    drops below mmr, liquidation occurs.
  *  * priceAuthority - will be used for getting the current value of

--- a/packages/zoe/src/contracts/loan/index.js
+++ b/packages/zoe/src/contracts/loan/index.js
@@ -12,7 +12,7 @@ import { makePercent } from '../../contractSupport/percentMath';
  * Add collateral of a particular brand and get a loan of another
  * brand. Collateral (also known as margin) must be greater than the
  * loan value, at an amount set by the Maintenance Margin Requirement
- * (mmr) in the terms of the contract. The loan does not have a
+ * (mmrRatio) in the terms of the contract. The loan does not have a
  * distinct end time. Rather, if the value of the collateral changes
  * such that insufficient margin is provided, the collateral is
  * liquidated, and the loan is closed. At any time, the borrower can
@@ -27,10 +27,12 @@ import { makePercent } from '../../contractSupport/percentMath';
  * loaned amount and interest must be of the same (separate) brand.
  *
  * Terms:
- *  * mmr (default = 150) - the Maintenance Margin Requirement, in
- *    percent. The default is 150, meaning that collateral should be
+ *  * mmr (default = 150) - the Maintenance Margin Requirement, as a Percent.
+ *    This value is deprecated and will be dropped before Beta.
+ *  * mmrRatio (default = 150) - the Maintenance Margin Requirement, as a
+ *    ratio. The default is 1.5, meaning that collateral should be
  *    worth at least 150% of the loan. If the value of the collateral
- *    drops below mmr, liquidation occurs.
+ *    drops below mmrRatio, liquidation occurs.
  *  * priceAuthority - will be used for getting the current value of
  *    collateral and setting liquidation triggers.
  *  * autoswapInstance - The running contract instance for an Autoswap
@@ -70,6 +72,12 @@ const start = async zcf => {
     interestPeriod,
   } = zcf.getTerms();
 
+  // TODO(hibbert) drop mmr as Percent before Beta
+  let { mmrRatio } = zcf.getTerms();
+  if (!mmrRatio) {
+    mmrRatio = mmr.makeRatio();
+  }
+
   assert(autoswapInstance, X`autoswapInstance must be provided`);
   assert(priceAuthority, X`priceAuthority must be provided`);
   assert(periodNotifier, X`periodNotifier must be provided`);
@@ -79,6 +87,7 @@ const start = async zcf => {
   /** @type {LoanTerms} */
   const config = {
     mmr,
+    mmrRatio,
     autoswapInstance,
     priceAuthority,
     periodNotifier,

--- a/packages/zoe/src/contracts/loan/liquidate.js
+++ b/packages/zoe/src/contracts/loan/liquidate.js
@@ -58,7 +58,7 @@ export const doLiquidation = async (
 
 /**
  * This function is triggered by the priceAuthority when the value of the
- * collateral is below the mmrRatio. The function performs the
+ * collateral is below the mmr. The function performs the
  * liquidation and then shuts down the contract. Note that if a
  * liquidation occurs, the borrower gets nothing and they can take no
  * further action.

--- a/packages/zoe/src/contracts/loan/liquidate.js
+++ b/packages/zoe/src/contracts/loan/liquidate.js
@@ -58,7 +58,7 @@ export const doLiquidation = async (
 
 /**
  * This function is triggered by the priceAuthority when the value of the
- * collateral is below the mmr percentage. The function performs the
+ * collateral is below the mmrRatio. The function performs the
  * liquidation and then shuts down the contract. Note that if a
  * liquidation occurs, the borrower gets nothing and they can take no
  * further action.

--- a/packages/zoe/src/contracts/loan/scheduleLiquidation.js
+++ b/packages/zoe/src/contracts/loan/scheduleLiquidation.js
@@ -18,20 +18,12 @@ export const scheduleLiquidation = (zcf, configWithBorrower) => {
     mmr,
   } = configWithBorrower;
 
-  // TODO(hibbert) drop mmr as Percent before Beta
-  let {
-    mmrRatio, // Maintenance Margin Requirement, as a ratio
-  } = configWithBorrower;
-  if (!mmrRatio) {
-    mmrRatio = mmr.makeRatio();
-  }
-
   const currentDebt = getDebt();
 
   // The liquidationTriggerValue is when the value of the collateral
-  // equals mmrRatio of the current debt
-  // Formula: liquidationTriggerValue = (currentDebt * mmrRatio) / 100
-  const liquidationTriggerValue = multiplyBy(currentDebt, mmrRatio);
+  // equals mmr of the current debt
+  // Formula: liquidationTriggerValue = (currentDebt * mmr)
+  const liquidationTriggerValue = multiplyBy(currentDebt, mmr);
 
   const collateralMath = zcf.getTerms().maths.Collateral;
 

--- a/packages/zoe/src/contracts/loan/scheduleLiquidation.js
+++ b/packages/zoe/src/contracts/loan/scheduleLiquidation.js
@@ -5,7 +5,7 @@ import '../../../exported';
 import { E } from '@agoric/eventual-send';
 
 import { liquidate } from './liquidate';
-import { getAmountIn } from '../../contractSupport';
+import { getAmountIn, multiplyBy } from '../../contractSupport';
 
 /** @type {ScheduleLiquidation} */
 export const scheduleLiquidation = (zcf, configWithBorrower) => {
@@ -18,12 +18,20 @@ export const scheduleLiquidation = (zcf, configWithBorrower) => {
     mmr,
   } = configWithBorrower;
 
+  // TODO(hibbert) drop mmr as Percent before Beta
+  let {
+    mmrRatio, // Maintenance Margin Requirement, as a ratio
+  } = configWithBorrower;
+  if (!mmrRatio) {
+    mmrRatio = mmr.makeRatio();
+  }
+
   const currentDebt = getDebt();
 
   // The liquidationTriggerValue is when the value of the collateral
-  // equals mmr percent of the current debt
-  // Formula: liquidationTriggerValue = (currentDebt * mmr) / 100
-  const liquidationTriggerValue = mmr.scale(currentDebt);
+  // equals mmrRatio of the current debt
+  // Formula: liquidationTriggerValue = (currentDebt * mmrRatio) / 100
+  const liquidationTriggerValue = multiplyBy(currentDebt, mmrRatio);
 
   const collateralMath = zcf.getTerms().maths.Collateral;
 

--- a/packages/zoe/src/contracts/loan/types.js
+++ b/packages/zoe/src/contracts/loan/types.js
@@ -16,19 +16,10 @@
  *   collateral on liquidation.
  */
 
-/** @typedef {bigint} InterestRate
- *
- *   The rate in basis points that will be multiplied with the debt on
- *   every period to compound interest.
- */
-
 /**
  * @typedef LoanTerms
  *
- * @property {Percent} mmr - Maintenance Margin Requirement, a Percent object.
- * Default is 150%. Percents are deprecated. This value will be dropped by Beta
- *
- * @property {Ratio} mmrRatio - Maintenance Margin Requirement, a Ratio record.
+ * @property {Ratio} mmr - Maintenance Margin Requirement, a Ratio record.
  * Default is 150%
  *
  * @property {AutoswapInstance} autoswapInstance
@@ -40,8 +31,10 @@
  *
  * @property {PeriodNotifier} periodNotifier
  *
- * @property {InterestRate} interestRate
- *
+ * @property {Ratio} interestRate
+ *   The rate in basis points that will be multiplied with the debt on
+ *   every period to compound interest.
+ 
  * @property {RelativeTime} interestPeriod
  */
 
@@ -176,7 +169,7 @@
  *
  *   The AsyncIterable to notify when a period has occurred
  *
- * @property {bigint} interestRate
+ * @property {Ratio} interestRate
  * @property {RelativeTime} interestPeriod
  *
  *  the period at which the outstanding debt increases by the interestRate

--- a/packages/zoe/src/contracts/loan/types.js
+++ b/packages/zoe/src/contracts/loan/types.js
@@ -9,14 +9,6 @@
  */
 
 /**
- * @typedef {bigint} MMR
- *  The Maintenance Margin Requirement, in percent. The default is
- *  150, meaning that collateral should be worth at least 150% of the
- *  loan. If the value of the collateral drops below mmr, liquidation
- *  occurs.
- */
-
-/**
  * @typedef {Instance} AutoswapInstance
  *   The running contract instance for an Autoswap or Multipool
  *   Autoswap installation.  The publicFacet from the Autoswap
@@ -34,6 +26,9 @@
  * @typedef LoanTerms
  *
  * @property {Percent} mmr - Maintenance Margin Requirement, a Percent object.
+ * Default is 150%. Percents are deprecated. This value will be dropped by Beta
+ *
+ * @property {Ratio} mmrRatio - Maintenance Margin Requirement, a Ratio record.
  * Default is 150%
  *
  * @property {AutoswapInstance} autoswapInstance
@@ -157,9 +152,9 @@
 
 /**
  * @callback CalcInterestFn
- * @param {bigint} oldDebtValue
- * @param {bigint} interestRate
- * @returns {bigint} interest
+ * @param {Amount} oldDebt
+ * @param {Ratio} interestRate
+ * @returns {Amount} interest
  */
 
 /**

--- a/packages/zoe/test/unitTests/contractSupport/test-percentSupport.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-percentSupport.js
@@ -4,10 +4,7 @@ import '@agoric/install-ses';
 import test from 'ava';
 import { makeIssuerKit } from '@agoric/ertp';
 
-import {
-  multiplyBy,
-  makeRatioFromAmounts,
-} from '../../../src/contractSupport/ratio';
+import { multiplyBy, makeRatioFromAmounts } from '../../../src/contractSupport';
 import {
   make100Percent,
   make0Percent,

--- a/packages/zoe/test/unitTests/contractSupport/test-ratio.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-ratio.js
@@ -80,7 +80,22 @@ test('ratio - different brands', t => {
   amountsEqual(t, multiplyBy(ast(10_000), convertToMoe), moe(3333), moeBrand);
 });
 
-test.failing('ratio - brand mismatch', t => {
+test('ratio - brand mismatch', t => {
+  const { amountMath } = makeIssuerKit('moe');
+  const { amountMath: astAmountMath } = makeIssuerKit('ast');
+  const moe = amountMath.make;
+  const ast = astAmountMath.make;
+
+  const convertToMoe = makeRatioFromAmounts(moe(1), astAmountMath.make(3));
+  t.throws(() => divideBy(ast(10_000), convertToMoe), {
+    message: /amount's brand .* must match ratio's numerator .*/,
+  });
+  t.throws(() => multiplyBy(moe(10_000), convertToMoe), {
+    message: /amount's brand .* must match ratio's denominator .*/,
+  });
+});
+
+test.failing('ratio - brand mismatch & details', t => {
   const { amountMath } = makeIssuerKit('moe');
   const { amountMath: astAmountMath } = makeIssuerKit('ast');
   const moe = amountMath.make;
@@ -134,7 +149,7 @@ test('ratio inverse', t => {
   amountsEqual(t, multiplyBy(moe(100), fiveHalves), moe(250), moeBrand);
 });
 
-test.failing('ratio bad inputs', t => {
+test('ratio bad inputs', t => {
   const { amountMath, brand: moeBrand } = makeIssuerKit('moe');
   const moe = amountMath.make;
   t.throws(() => makeRatio(-3, moeBrand), {
@@ -152,6 +167,20 @@ test.failing('ratio bad inputs', t => {
   t.throws(() => divideBy(makeRatioFromAmounts(moe(3), moe(5)), 37), {
     message: `Expected an amount: (an object)`,
   });
+  t.throws(() => makeRatio(3, moeBrand, 0), {
+    message: /No infinite ratios! Denoninator was 0/,
+  });
+  t.throws(() => makeRatioFromAmounts(moe(37), moe(0)), {
+    message: /No infinite ratios! Denoninator was 0/,
+  });
+  t.throws(() => makeRatioFromAmounts(moe(37), moe(0)), {
+    message: /No infinite ratios! Denoninator was 0/,
+  });
+});
+
+test.failing('ratio bad inputs w/brand names', t => {
+  const { amountMath, brand: moeBrand } = makeIssuerKit('moe');
+  const moe = amountMath.make;
   t.throws(() => makeRatio(3, moeBrand, 0), {
     message: 'No infinite ratios! Denoninator was 0/"moe"',
   });

--- a/packages/zoe/test/unitTests/contractSupport/test-ratio.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-ratio.js
@@ -80,7 +80,7 @@ test('ratio - different brands', t => {
   amountsEqual(t, multiplyBy(ast(10_000), convertToMoe), moe(3333), moeBrand);
 });
 
-test('ratio - brand mismatch', t => {
+test.failing('ratio - brand mismatch', t => {
   const { amountMath } = makeIssuerKit('moe');
   const { amountMath: astAmountMath } = makeIssuerKit('ast');
   const moe = amountMath.make;
@@ -91,7 +91,7 @@ test('ratio - brand mismatch', t => {
     message: `amount's brand "ast" must match ratio's numerator "moe"`,
   });
   t.throws(() => multiplyBy(moe(10_000), convertToMoe), {
-    message: 'amount\'s brand "moe" must match ratio\'s denominator "ast"',
+    message: `amount's brand "moe" must match ratio's denominator "ast"`,
   });
 });
 
@@ -134,7 +134,7 @@ test('ratio inverse', t => {
   amountsEqual(t, multiplyBy(moe(100), fiveHalves), moe(250), moeBrand);
 });
 
-test('ratio bad inputs', t => {
+test.failing('ratio bad inputs', t => {
   const { amountMath, brand: moeBrand } = makeIssuerKit('moe');
   const moe = amountMath.make;
   t.throws(() => makeRatio(-3, moeBrand), {

--- a/packages/zoe/test/unitTests/contractSupport/test-ratio.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-ratio.js
@@ -11,7 +11,7 @@ import {
   multiplyBy,
   divideBy,
   invertRatio,
-} from '../../../src/contractSupport/ratio';
+} from '../../../src/contractSupport';
 
 function amountsEqual(t, a1, a2, brand) {
   const brandEqual = a1.brand === a2.brand;

--- a/packages/zoe/test/unitTests/contractSupport/test-ratio.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-ratio.js
@@ -43,6 +43,7 @@ test('ratio - basic', t => {
   amountsEqual(t, multiplyBy(moe(13333333), halfDefault), moe(6666666), brand);
   amountsEqual(t, multiplyBy(moe(1333), halfPrecise), moe(666), brand);
   amountsEqual(t, multiplyBy(moe(13333333), halfPrecise), moe(6666666), brand);
+  amountsEqual(t, multiplyBy(moe(0), halfPrecise), moe(0), brand);
 });
 
 test('ratio - multiplyBy non Amount', t => {
@@ -119,6 +120,7 @@ test('ratio division', t => {
   const twoFifths = makeRatioFromAmounts(moe(2), moe(5));
   amountsEqual(t, divideBy(moe(100), twoFifths), moe(250), moeBrand);
   amountsEqual(t, multiplyBy(moe(100), twoFifths), moe(40), moeBrand);
+  amountsEqual(t, divideBy(moe(0), twoFifths), moe(0), moeBrand);
 });
 
 test('ratio inverse', t => {

--- a/packages/zoe/test/unitTests/contracts/loan/helpers.js
+++ b/packages/zoe/test/unitTests/contracts/loan/helpers.js
@@ -91,7 +91,7 @@ export const setupLoanUnitTest = async terms => {
 
   if (!terms) {
     terms = harden({
-      mmrRatio: makeRatio(150n, collateralKit.brand),
+      mmr: makeRatio(150n, collateralKit.brand),
       autoswapInstance: {},
     });
   }

--- a/packages/zoe/test/unitTests/contracts/loan/helpers.js
+++ b/packages/zoe/test/unitTests/contracts/loan/helpers.js
@@ -10,7 +10,7 @@ import { makeLocalAmountMath } from '@agoric/ertp';
 import { setup } from '../../setupBasicMints';
 
 import { setupZCFTest } from '../../zcf/setupZcfTest';
-import { makePercent } from '../../../../src/contractSupport/percentMath';
+import { makeRatio } from '../../../../src/contractSupport';
 
 /**
  * @param {import("ava").ExecutionContext<unknown>} t
@@ -91,7 +91,7 @@ export const setupLoanUnitTest = async terms => {
 
   if (!terms) {
     terms = harden({
-      mmr: makePercent(150n, collateralKit.amountMath),
+      mmrRatio: makeRatio(150n, collateralKit.brand),
       autoswapInstance: {},
     });
   }

--- a/packages/zoe/test/unitTests/contracts/loan/test-addCollateral.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-addCollateral.js
@@ -17,6 +17,7 @@ import {
   performAddCollateral,
 } from './helpers';
 import { makePercent } from '../../../../src/contractSupport/percentMath';
+import { makeRatio } from '../../../../src/contractSupport';
 
 test.todo('makeAddCollateralInvitation - test bad proposal');
 
@@ -55,6 +56,7 @@ test('makeAddCollateralInvitation', async t => {
     priceAuthority,
     getDebt,
     mmr: makePercent(150, loanKit.amountMath),
+    mmrRatio: makeRatio(150, loanKit.brand),
   };
   const addCollateralInvitation = makeAddCollateralInvitation(zcf, config);
 

--- a/packages/zoe/test/unitTests/contracts/loan/test-addCollateral.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-addCollateral.js
@@ -16,7 +16,6 @@ import {
   makeSeatKit,
   performAddCollateral,
 } from './helpers';
-import { makePercent } from '../../../../src/contractSupport/percentMath';
 import { makeRatio } from '../../../../src/contractSupport';
 
 test.todo('makeAddCollateralInvitation - test bad proposal');
@@ -55,8 +54,7 @@ test('makeAddCollateralInvitation', async t => {
     autoswapInstance,
     priceAuthority,
     getDebt,
-    mmr: makePercent(150, loanKit.amountMath),
-    mmrRatio: makeRatio(150, loanKit.brand),
+    mmr: makeRatio(150, loanKit.brand),
   };
   const addCollateralInvitation = makeAddCollateralInvitation(zcf, config);
 

--- a/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
@@ -28,7 +28,7 @@ import buildManualTimer from '../../../../tools/manualTimer';
 import { makeBorrowInvitation } from '../../../../src/contracts/loan/borrow';
 import { makeAddCollateralInvitation } from '../../../../src/contracts/loan/addCollateral';
 import { makeCloseLoanInvitation } from '../../../../src/contracts/loan/close';
-import { makePercent } from '../../../../src/contractSupport/percentMath';
+import { makeRatio } from '../../../../src/contractSupport';
 
 const setupBorrow = async (maxLoanValue = 100) => {
   const setup = await setupLoanUnitTest();
@@ -41,11 +41,7 @@ const setupBorrow = async (maxLoanValue = 100) => {
     { Loan: loanKit.mint.mintPayment(maxLoan) },
   );
 
-  // TODO(hibbert): mmr is deprecated. replace with mmrRatio. mmr remains here
-  // to test backward compatibility
-  const mmr = makePercent(150, loanKit.amountMath);
-  // const mmrRatio = makeRatio(150, loanKit.brand);
-
+  const mmr = makeRatio(150, loanKit.brand);
   const priceList = [2, 1, 1, 1];
   const timer = buildManualTimer(console.log);
 
@@ -149,7 +145,7 @@ test('borrow not enough collateral', async t => {
   const { borrowSeat } = await setupBorrowFacet(0);
   await t.throwsAsync(() => E(borrowSeat).getOfferResult(), {
     message:
-      'The required margin is approximately (a bigint)% but collateral only had value of (a bigint)',
+      'The required margin is (a bigint)% but collateral only had value of (a bigint)',
   });
 });
 
@@ -359,7 +355,7 @@ test('borrow collateral just too low', async t => {
   const { borrowSeat: borrowSeatBad } = await setupBorrowFacet(74);
   await t.throwsAsync(() => E(borrowSeatBad).getOfferResult(), {
     message:
-      'The required margin is approximately (a bigint)% but collateral only had value of (a bigint)',
+      'The required margin is (a bigint)% but collateral only had value of (a bigint)',
   });
 });
 

--- a/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
@@ -40,7 +40,11 @@ const setupBorrow = async (maxLoanValue = 100) => {
     { give: { Loan: maxLoan } },
     { Loan: loanKit.mint.mintPayment(maxLoan) },
   );
+
+  // TODO(hibbert): mmr is deprecated. replace with mmrRatio. mmr remains here
+  // to test backward compatibility
   const mmr = makePercent(150, loanKit.amountMath);
+  // const mmrRatio = makeRatio(150, loanKit.brand);
 
   const priceList = [2, 1, 1, 1];
   const timer = buildManualTimer(console.log);

--- a/packages/zoe/test/unitTests/contracts/loan/test-lend.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-lend.js
@@ -16,7 +16,7 @@ test('makeLendInvitation', async t => {
   const { zcf, zoe, loanKit } = await setupLoanUnitTest();
 
   const config = {
-    mmrRatio: makeRatio(150, loanKit.brand),
+    mmr: makeRatio(150, loanKit.brand),
   };
   const lendInvitation = makeLendInvitation(zcf, config);
 

--- a/packages/zoe/test/unitTests/contracts/loan/test-lend.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-lend.js
@@ -10,11 +10,14 @@ import { E } from '@agoric/eventual-send';
 import { setupLoanUnitTest, checkDescription } from './helpers';
 
 import { makeLendInvitation } from '../../../../src/contracts/loan/lend';
+import { makeRatio } from '../../../../src/contractSupport';
 
 test('makeLendInvitation', async t => {
   const { zcf, zoe, loanKit } = await setupLoanUnitTest();
 
-  const config = {};
+  const config = {
+    mmrRatio: makeRatio(150, loanKit.brand),
+  };
   const lendInvitation = makeLendInvitation(zcf, config);
 
   await checkDescription(t, zoe, lendInvitation, 'lend');

--- a/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
@@ -60,7 +60,7 @@ test('loan - lend - exit before borrow', async t => {
   const { notifier: periodNotifier } = makeNotifierKit();
 
   const terms = {
-    mmrRatio: makeRatio(150, loanKit.brand),
+    mmr: makeRatio(150, loanKit.brand),
     autoswapInstance,
     priceAuthority,
     periodNotifier,

--- a/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
@@ -14,7 +14,7 @@ import { checkDetails, checkPayout } from './helpers';
 import { setup } from '../../setupBasicMints';
 import { makeFakePriceAuthority } from '../../../../tools/fakePriceAuthority';
 import buildManualTimer from '../../../../tools/manualTimer';
-import { makePercent } from '../../../../src/contractSupport/percentMath';
+import { makeRatio } from '../../../../src/contractSupport';
 
 const loanRoot = `${__dirname}/../../../../src/contracts/loan/`;
 const autoswapRoot = `${__dirname}/../../../../src/contracts/autoswap`;
@@ -60,7 +60,7 @@ test('loan - lend - exit before borrow', async t => {
   const { notifier: periodNotifier } = makeNotifierKit();
 
   const terms = {
-    mmr: makePercent(150, loanKit.amountMath),
+    mmrRatio: makeRatio(150, loanKit.brand),
     autoswapInstance,
     priceAuthority,
     periodNotifier,

--- a/packages/zoe/test/unitTests/contracts/loan/test-updateDebt.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-updateDebt.js
@@ -8,10 +8,17 @@ import '@agoric/install-ses';
 import test from 'ava';
 
 import { calculateInterest } from '../../../../src/contracts/loan/updateDebt';
+import { makeRatio } from '../../../../src/contractSupport';
+
+const FAKE_BRAND = 'FAKE';
 
 test('test calculateInterest', async t => {
   const testCalculateInterest = ([oldDebt, interestRate, expected]) => {
-    t.is(calculateInterest(oldDebt, interestRate), expected);
+    const debt = { brand: FAKE_BRAND, value: oldDebt };
+    const interestRateRatio = makeRatio(interestRate, FAKE_BRAND, 10000);
+    const interest = calculateInterest(debt, interestRateRatio);
+    t.is(interest.value, expected);
+    t.is(interest.brand, FAKE_BRAND);
   };
 
   const expectations = [

--- a/packages/zoe/test/unitTests/contracts/loan/test-updateDebt.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-updateDebt.js
@@ -9,16 +9,17 @@ import test from 'ava';
 
 import { calculateInterest } from '../../../../src/contracts/loan/updateDebt';
 import { makeRatio } from '../../../../src/contractSupport';
-
-const FAKE_BRAND = 'FAKE';
+import { setup } from '../../setupBasicMints';
 
 test('test calculateInterest', async t => {
+  const { brands } = setup();
+  const brand = brands.get('moola');
   const testCalculateInterest = ([oldDebt, interestRate, expected]) => {
-    const debt = { brand: FAKE_BRAND, value: oldDebt };
-    const interestRateRatio = makeRatio(interestRate, FAKE_BRAND, 10000);
+    const debt = { brand, value: oldDebt };
+    const interestRateRatio = makeRatio(interestRate, brand, 10000);
     const interest = calculateInterest(debt, interestRateRatio);
     t.is(interest.value, expected);
-    t.is(interest.brand, FAKE_BRAND);
+    t.is(interest.brand, brand);
   };
 
   const expectations = [

--- a/packages/zoe/test/unitTests/contracts/test-callSpread-calculation.js
+++ b/packages/zoe/test/unitTests/contracts/test-callSpread-calculation.js
@@ -6,75 +6,98 @@ import '../../../exported';
 
 import { setup } from '../setupBasicMints';
 import { calculateShares } from '../../../src/contracts/callSpread/calculateShares';
-import { makeAll, makeNone } from '../../../src/contractSupport/percentMath';
+import { multiplyBy } from '../../../src/contractSupport';
+import {
+  make0Percent,
+  make100Percent,
+} from '../../../src/contracts/callSpread/percent';
 
-function compareSharePercents(t, expected, actual, amount) {
-  t.deepEqual(expected.longShare.scale(amount), actual.longShare.scale(amount));
+function compareShareRatios(t, expected, actual, amount) {
   t.deepEqual(
-    expected.shortShare.scale(amount),
-    actual.shortShare.scale(amount),
+    multiplyBy(amount, expected.longShare),
+    multiplyBy(amount, actual.longShare),
+  );
+  t.deepEqual(
+    multiplyBy(amount, expected.shortShare),
+    multiplyBy(amount, actual.shortShare),
   );
 }
 
 test('callSpread-calculation, at lower bound', async t => {
-  const { moola, amountMaths, bucks } = setup();
+  const { moola, amountMaths, bucks, brands } = setup();
   const moolaMath = amountMaths.get('moola');
   const bucksMath = amountMaths.get('bucks');
+  const bucksBrand = brands.get('bucks');
 
   const strike1 = moola(20);
   const strike2 = moola(70);
   const price = moola(20);
-  compareSharePercents(
+  compareShareRatios(
     t,
-    { longShare: makeNone(bucksMath), shortShare: makeAll(bucksMath) },
+    {
+      longShare: make0Percent(bucksBrand),
+      shortShare: make100Percent(bucksBrand),
+    },
     calculateShares(moolaMath, bucksMath, price, strike1, strike2),
     bucks(1000),
   );
 });
 
 test('callSpread-calculation, at upper bound', async t => {
-  const { moola, amountMaths, bucks } = setup();
+  const { moola, amountMaths, bucks, brands } = setup();
   const moolaMath = amountMaths.get('moola');
   const bucksMath = amountMaths.get('bucks');
+  const bucksBrand = brands.get('bucks');
 
   const strike1 = moola(20);
   const strike2 = moola(55);
   const price = moola(55);
-  compareSharePercents(
+  compareShareRatios(
     t,
-    { longShare: makeAll(bucksMath), shortShare: makeNone(bucksMath) },
+    {
+      longShare: make100Percent(bucksBrand),
+      shortShare: make0Percent(bucksBrand),
+    },
     calculateShares(moolaMath, bucksMath, price, strike1, strike2),
     bucks(1000),
   );
 });
 
 test('callSpread-calculation, below lower bound', async t => {
-  const { moola, amountMaths, bucks } = setup();
+  const { moola, amountMaths, bucks, brands } = setup();
   const moolaMath = amountMaths.get('moola');
   const bucksMath = amountMaths.get('bucks');
+  const bucksBrand = brands.get('bucks');
 
   const strike1 = moola(15);
   const strike2 = moola(55);
   const price = moola(0);
-  compareSharePercents(
+  compareShareRatios(
     t,
-    { longShare: makeNone(bucksMath), shortShare: makeAll(bucksMath) },
+    {
+      longShare: make0Percent(bucksBrand),
+      shortShare: make100Percent(bucksBrand),
+    },
     calculateShares(moolaMath, bucksMath, price, strike1, strike2),
     bucks(1000),
   );
 });
 
 test('callSpread-calculation, above upper bound', async t => {
-  const { moola, amountMaths, bucks } = setup();
+  const { moola, amountMaths, bucks, brands } = setup();
   const moolaMath = amountMaths.get('moola');
   const bucksMath = amountMaths.get('bucks');
+  const bucksBrand = brands.get('bucks');
 
   const strike1 = moola(15);
   const strike2 = moola(55);
   const price = moola(60);
-  compareSharePercents(
+  compareShareRatios(
     t,
-    { longShare: makeAll(bucksMath), shortShare: makeNone(bucksMath) },
+    {
+      longShare: make100Percent(bucksBrand),
+      shortShare: make0Percent(bucksBrand),
+    },
     calculateShares(moolaMath, bucksMath, price, strike1, strike2),
     bucks(1000),
   );
@@ -95,37 +118,45 @@ test('callSpread-calculation, mid-way', async t => {
     strike1,
     strike2,
   );
-  t.deepEqual(bucks(833), longShare.scale(bucks(1000)));
-  t.deepEqual(bucks(166), shortShare.scale(bucks(1000)));
+  t.deepEqual(bucks(833), multiplyBy(bucks(1000), longShare));
+  t.deepEqual(bucks(166), multiplyBy(bucks(1000), shortShare));
 });
 
 test('callSpread-calculation, zero', async t => {
-  const { moola, amountMaths, bucks } = setup();
+  const { moola, amountMaths, bucks, brands } = setup();
   const moolaMath = amountMaths.get('moola');
   const bucksMath = amountMaths.get('bucks');
+  const bucksBrand = brands.get('bucks');
 
   const strike1 = moola(15);
   const strike2 = moola(45);
   const price = moola(0);
-  compareSharePercents(
+  compareShareRatios(
     t,
-    { longShare: makeNone(bucksMath), shortShare: makeAll(bucksMath) },
+    {
+      longShare: make0Percent(bucksBrand),
+      shortShare: make100Percent(bucksBrand),
+    },
     calculateShares(moolaMath, bucksMath, price, strike1, strike2),
     bucks(1000),
   );
 });
 
 test('callSpread-calculation, large', async t => {
-  const { moola, amountMaths, bucks } = setup();
+  const { moola, amountMaths, bucks, brands } = setup();
   const moolaMath = amountMaths.get('moola');
   const bucksMath = amountMaths.get('bucks');
+  const bucksBrand = brands.get('bucks');
 
   const strike1 = moola(15);
   const strike2 = moola(45);
   const price = moola(10000000000);
-  compareSharePercents(
+  compareShareRatios(
     t,
-    { longShare: makeAll(bucksMath), shortShare: makeNone(bucksMath) },
+    {
+      longShare: make100Percent(bucksBrand),
+      shortShare: make0Percent(bucksBrand),
+    },
     calculateShares(moolaMath, bucksMath, price, strike1, strike2),
     bucks(1000),
   );


### PR DESCRIPTION
Use Ratios in Loan and callSpread contracts.

The loan has support for backward compatibility, since the MMR was visible in the terms as a Percent.

#documentation-branch: ratios