### PR TITLE
annotate zoe with Far/Data

### DIFF
--- a/packages/zoe/src/cleanProposal.js
+++ b/packages/zoe/src/cleanProposal.js
@@ -1,6 +1,7 @@
 import { assert, details as X, q } from '@agoric/assert';
 import { mustBeComparable } from '@agoric/same-structure';
 import { isNat } from '@agoric/nat';
+import { Data } from '@agoric/marshal';
 
 import '../exported';
 import './internal-types';
@@ -110,7 +111,7 @@ export const cleanProposal = (getAmountMath, proposal) => {
   assertKeysAllowed(rootKeysAllowed, proposal);
 
   // We fill in the default values if the keys are undefined.
-  let { want = harden({}), give = harden({}) } = proposal;
+  let { want = Data({}), give = Data({}) } = proposal;
   const { exit = harden({ onDemand: null }) } = proposal;
 
   want = coerceAmountKeywordRecord(getAmountMath, want);

--- a/packages/zoe/src/contractFacet/exit.js
+++ b/packages/zoe/src/contractFacet/exit.js
@@ -1,5 +1,6 @@
 import { assert, details as X, q } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 /**
  * Makes the appropriate exitObj, which runs in ZCF and allows the seat's owner
@@ -11,7 +12,7 @@ export const makeExitObj = (proposal, zoeSeatAdmin, zcfSeatAdmin) => {
   const [exitKind] = Object.getOwnPropertyNames(proposal.exit);
 
   /** @type {ExitObj} */
-  let exitObj = harden({
+  let exitObj = Far('exitObj', {
     exit: () => {
       throw new Error(
         `Only seats with the exit rule "onDemand" can exit at will`,
@@ -29,7 +30,7 @@ export const makeExitObj = (proposal, zoeSeatAdmin, zcfSeatAdmin) => {
     E(proposal.exit.afterDeadline.timer)
       .setWakeup(
         proposal.exit.afterDeadline.deadline,
-        harden({
+        Far('wakeObj', {
           wake: exitFn,
         }),
       )
@@ -48,9 +49,9 @@ export const makeExitObj = (proposal, zoeSeatAdmin, zcfSeatAdmin) => {
     // only allows two kinds of objects: records (no methods and only
     // data) and presences (local proxies for objects that may have
     // methods).
-    exitObj = {
+    exitObj = Far('exitObj', {
       exit: exitFn,
-    };
+    });
   } else {
     // if exitKind is 'waived' the user has no ability to exit their seat
     // on demand

--- a/packages/zoe/src/contractFacet/fakeVatAdmin.js
+++ b/packages/zoe/src/contractFacet/fakeVatAdmin.js
@@ -1,5 +1,6 @@
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
+import { Far } from '@agoric/marshal';
 
 import { assert, details as X } from '@agoric/assert';
 import { evalContractBundle } from './evalContractCode';
@@ -26,7 +27,7 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
   // This is explicitly intended to be mutable so that
   // test-only state can be provided from contracts
   // to their tests.
-  const admin = harden({
+  const admin = Far('vatAdmin', {
     createVat: bundle => {
       return harden({
         root: makeRemote(
@@ -36,7 +37,7 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
             testContextSetter,
           ),
         ),
-        adminNode: {
+        adminNode: Far('adminNode', {
           done: () => {
             const kit = makePromiseKit();
             // Don't trigger Node.js's UnhandledPromiseRejectionWarning.
@@ -46,7 +47,7 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
           },
           terminateWithFailure: () => {},
           adminData: () => {},
-        },
+        }),
       });
     },
     createVatByName: _name => {

--- a/packages/zoe/src/contractFacet/seat.js
+++ b/packages/zoe/src/contractFacet/seat.js
@@ -2,7 +2,7 @@
 
 import { E } from '@agoric/eventual-send';
 import { assert, details as X } from '@agoric/assert';
-import { Far } from '@agoric/marshal';
+import { Data, Far } from '@agoric/marshal';
 
 import { isOfferSafe } from './offerSafety';
 
@@ -26,7 +26,7 @@ export const makeZcfSeatAdminKit = (
   const assertExitedFalse = () => assert(!exited, X`seat has been exited`);
 
   /** @type {ZCFSeatAdmin} */
-  const zcfSeatAdmin = harden({
+  const zcfSeatAdmin = Far('zcfSeatAdmin', {
     // Updates the currentAllocation of the seat, using the allocation
     // from seatStaging.
     commit: seatStaging => {
@@ -88,7 +88,7 @@ export const makeZcfSeatAdminKit = (
     },
     isOfferSafe: newAllocation => {
       assertExitedFalse();
-      const reallocation = harden({
+      const reallocation = Data({
         ...currentAllocation,
         ...newAllocation,
       });
@@ -98,7 +98,7 @@ export const makeZcfSeatAdminKit = (
     stage: newAllocation => {
       assertExitedFalse();
       // Check offer safety.
-      const allocation = harden({
+      const allocation = Data({
         ...currentAllocation,
         ...newAllocation,
       });

--- a/packages/zoe/src/contractSupport/percentMath.js
+++ b/packages/zoe/src/contractSupport/percentMath.js
@@ -2,6 +2,7 @@
 
 import './types';
 import { assert, details as X } from '@agoric/assert';
+import { Far } from '@agoric/marshal';
 import { Nat } from '@agoric/nat';
 import { natSafeMath } from './safeMath';
 import { makeRatio } from './ratio';
@@ -27,7 +28,7 @@ const { multiply, floorDivide } = natSafeMath;
  */
 function makePercent(value, amountMath, base = 100n) {
   Nat(value);
-  return harden({
+  return Far('percent', {
     scale: amount => {
       assert(
         amountMath.getBrand() === amount.brand,

--- a/packages/zoe/src/contractSupport/priceAuthority.js
+++ b/packages/zoe/src/contractSupport/priceAuthority.js
@@ -1,4 +1,5 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
 import { makePromiseKit } from '@agoric/promise-kit';
 
@@ -151,7 +152,7 @@ export function makeOnewayPriceAuthorityKit(opts) {
   };
 
   /** @type {PriceAuthority} */
-  const priceAuthority = {
+  const priceAuthority = Far('PriceAuthority', {
     getQuoteIssuer(brandIn, brandOut) {
       assertBrands(brandIn, brandOut);
       return quoteIssuer;
@@ -200,7 +201,7 @@ export function makeOnewayPriceAuthorityKit(opts) {
       const quotePK = makePromiseKit();
       await E(timer).setWakeup(
         deadline,
-        harden({
+        Far('wakeObj', {
           async wake(timestamp) {
             try {
               const quoteP = createQuote(calcAmountOut => ({
@@ -227,8 +228,7 @@ export function makeOnewayPriceAuthorityKit(opts) {
     quoteWhenLTE: makeQuoteWhenOut(isLTE),
     quoteWhenGTE: makeQuoteWhenOut(isGTE),
     quoteWhenGT: makeQuoteWhenOut(isGT),
-  };
-  harden(priceAuthority);
+  });
 
   return { priceAuthority, adminFacet: { fireTriggers } };
 }

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -7,6 +7,7 @@ import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
 
 import { MathKind } from '@agoric/ertp';
+import { Data } from '@agoric/marshal';
 import { satisfiesWant } from '../contractFacet/offerSafety';
 import { objectMap } from '../objArrayConversion';
 
@@ -408,7 +409,7 @@ export async function withdrawFromSeat(zcf, seat, amounts) {
  * @param {IssuerKeywordRecord} issuerKeywordRecord Issuers to save to
  * ZCF
  */
-export async function saveAllIssuers(zcf, issuerKeywordRecord = {}) {
+export async function saveAllIssuers(zcf, issuerKeywordRecord = Data({})) {
   const { issuers } = zcf.getTerms();
   const issuersPSaved = Object.entries(issuerKeywordRecord).map(
     ([keyword, issuer]) => {

--- a/packages/zoe/src/contracts/auction/secondPriceAuction.js
+++ b/packages/zoe/src/contracts/auction/secondPriceAuction.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 // Eventually will be importable from '@agoric/zoe-contract-support'
 import {
@@ -46,7 +47,9 @@ const start = zcf => {
   E(timeAuthority)
     .setWakeup(
       closesAfter,
-      harden({ wake: () => calcWinnerAndClose(zcf, sellSeat, bidSeats) }),
+      Far('wakeObj', {
+        wake: () => calcWinnerAndClose(zcf, sellSeat, bidSeats),
+      }),
     )
     .catch(err => {
       console.error(
@@ -91,7 +94,7 @@ const start = zcf => {
 
     // The bid invitations can only be sent out after the assets to be
     // auctioned are escrowed.
-    return harden({ makeBidInvitation });
+    return Far('offerResult', { makeBidInvitation });
   };
 
   const creatorInvitation = zcf.makeInvitation(sell, 'sellAssets');

--- a/packages/zoe/src/contracts/automaticRefund.js
+++ b/packages/zoe/src/contracts/automaticRefund.js
@@ -1,5 +1,7 @@
 // @ts-check
 
+import { Far } from '@agoric/marshal';
+
 import '../../exported';
 
 /**
@@ -29,7 +31,7 @@ const start = zcf => {
   const makeRefundInvitation = () => zcf.makeInvitation(refund, 'getRefund');
 
   /** @type {AutomaticRefundPublicFacet} */
-  const publicFacet = harden({
+  const publicFacet = Far('publicFacet', {
     getOffersCount: () => offersCount,
     makeInvitation: makeRefundInvitation,
   });

--- a/packages/zoe/src/contracts/autoswap.js
+++ b/packages/zoe/src/contracts/autoswap.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { Far } from '@agoric/marshal';
 import { assert } from '@agoric/assert';
 
 // Eventually will be importable from '@agoric/zoe-contract-support'
@@ -360,7 +361,7 @@ const start = async zcf => {
   const getPoolAllocation = poolSeat.getCurrentAllocation;
 
   /** @type {AutoswapPublicFacet} */
-  const publicFacet = harden({
+  const publicFacet = Far('publicFacet', {
     getInputPrice: getOutputForGivenInput,
     getOutputPrice: getInputForGivenOutput,
     getLiquidityIssuer: () => liquidityIssuer,

--- a/packages/zoe/src/contracts/barterExchange.js
+++ b/packages/zoe/src/contracts/barterExchange.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { Far } from '@agoric/marshal';
 import makeStore from '@agoric/store';
 import '../../exported';
 
@@ -126,7 +127,7 @@ const start = zcf => {
     return 'Trade completed.';
   };
 
-  const publicFacet = harden({
+  const publicFacet = Far('publicFacet', {
     makeInvitation: () => zcf.makeInvitation(exchangeOfferHandler, 'exchange'),
   });
 

--- a/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
@@ -5,6 +5,7 @@ import './types';
 import { assert, details as X } from '@agoric/assert';
 import { makePromiseKit } from '@agoric/promise-kit';
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 import {
   assertProposalShape,
   depositToSeat,
@@ -168,7 +169,7 @@ const start = zcf => {
     return { longInvitation, shortInvitation };
   }
 
-  const creatorFacet = harden({ makeInvitationPair });
+  const creatorFacet = Far('creatorFacet', { makeInvitationPair });
   return harden({ creatorFacet });
 };
 

--- a/packages/zoe/src/contracts/loan/borrow.js
+++ b/packages/zoe/src/contracts/loan/borrow.js
@@ -3,6 +3,7 @@ import '../../../exported';
 
 import { assert, details as X } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 import { makePromiseKit } from '@agoric/promise-kit';
 
 import {
@@ -147,7 +148,7 @@ export const makeBorrowInvitation = (zcf, config) => {
     // TODO: Add ability to repay partially
 
     /** @type {BorrowFacet} */
-    const borrowFacet = {
+    const borrowFacet = Far('borrowFacet', {
       makeCloseLoanInvitation: () =>
         makeCloseLoanInvitation(zcf, configWithBorrower),
       makeAddCollateralInvitation: () =>
@@ -157,9 +158,9 @@ export const makeBorrowInvitation = (zcf, config) => {
       getLastCalculationTimestamp,
       getRecentCollateralAmount: () =>
         collateralSeat.getAmountAllocated('Collateral'),
-    };
+    });
 
-    return harden(borrowFacet);
+    return borrowFacet;
   };
 
   const customBorrowProps = harden({ maxLoan });

--- a/packages/zoe/src/contracts/loan/updateDebt.js
+++ b/packages/zoe/src/contracts/loan/updateDebt.js
@@ -3,6 +3,7 @@
 import '../../../exported';
 import { makeNotifierKit } from '@agoric/notifier';
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 import { scheduleLiquidation } from './scheduleLiquidation';
 import { makeRatio, multiplyBy } from '../../contractSupport';
@@ -107,7 +108,7 @@ export const makeDebtCalculator = debtCalculatorConfig => {
 
   debtNotifierUpdater.updateState(debt);
 
-  return harden({
+  return Far('debtCalculator', {
     getDebt,
     getLastCalculationTimestamp: _ => lastCalculationTimestamp,
     getDebtNotifier: _ => debtNotifier,

--- a/packages/zoe/src/contracts/mintAndSellNFT.js
+++ b/packages/zoe/src/contracts/mintAndSellNFT.js
@@ -2,6 +2,7 @@
 
 import { makeIssuerKit, MathKind } from '@agoric/ertp';
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 import '../../exported';
 import { assert } from '@agoric/assert';
@@ -109,7 +110,10 @@ const start = zcf => {
   };
 
   /** @type {MintAndSellNFTCreatorFacet} */
-  const creatorFacet = harden({ sellTokens, getIssuer: () => issuer });
+  const creatorFacet = Far('creatorFacet', {
+    sellTokens,
+    getIssuer: () => issuer,
+  });
 
   return harden({ creatorFacet });
 };

--- a/packages/zoe/src/contracts/mintPayments.js
+++ b/packages/zoe/src/contracts/mintPayments.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-use-before-define */
 // @ts-check
 
+import { Far } from '@agoric/marshal';
+
 import '../../exported';
 
 /**
@@ -39,19 +41,19 @@ const start = async zcf => {
     return 'Offer completed. You should receive a payment from Zoe';
   };
 
-  const creatorFacet = {
+  const creatorFacet = Far('creatorFacet', {
     // The creator of the instance can send invitations to anyone
     // they wish to.
     makeInvitation: (extent = 1000) =>
       zcf.makeInvitation(mintPayment(extent), 'mint a payment'),
     getTokenIssuer: () => issuer,
-  };
+  });
 
-  const publicFacet = {
+  const publicFacet = Far('publicFacet', {
     // Make the token issuer public. Note that only the mint can
     // make new digital assets. The issuer is ok to make public.
     getTokenIssuer: () => issuer,
-  };
+  });
 
   // Return the creatorFacet to the creator, so they can make
   // invitations for others to get payments of tokens. Publish the

--- a/packages/zoe/src/contracts/multipoolAutoswap/multipoolAutoswap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/multipoolAutoswap.js
@@ -2,6 +2,7 @@
 
 import { assert, details as X } from '@agoric/assert';
 import { makeWeakStore } from '@agoric/store';
+import { Far } from '@agoric/marshal';
 
 import { assertIssuerKeywords } from '../../contractSupport';
 import { makeAddPool } from './pool';
@@ -124,7 +125,7 @@ const start = zcf => {
   );
 
   /** @type {MultipoolAutoswapPublicFacet} */
-  const publicFacet = {
+  const publicFacet = Far('MultipoolAutoswapPublicFacet', {
     addPool,
     getPoolAllocation,
     getLiquidityIssuer,
@@ -138,7 +139,7 @@ const start = zcf => {
     makeSwapOutInvitation,
     makeAddLiquidityInvitation,
     makeRemoveLiquidityInvitation,
-  };
+  });
 
   return harden({ publicFacet });
 };

--- a/packages/zoe/src/contracts/oracle.js
+++ b/packages/zoe/src/contracts/oracle.js
@@ -1,5 +1,7 @@
 // @ts-check
 import { assert, details as X } from '@agoric/assert';
+import { Far } from '@agoric/marshal';
+
 import '../../exported';
 
 import { E } from '@agoric/eventual-send';
@@ -53,14 +55,14 @@ const start = async zcf => {
     },
   };
 
-  const creatorFacet = {
+  const creatorFacet = Far('creatorFacet', {
     initialize(privateParams) {
       ({ oracleHandler: handler } = privateParams);
       return realCreatorFacet;
     },
-  };
+  });
 
-  const publicFacet = {
+  const publicFacet = Far('publicFacet', {
     async query(query) {
       try {
         assert(!revoked, revokedMsg);
@@ -99,7 +101,7 @@ const start = async zcf => {
       };
       return zcf.makeInvitation(doQuery, 'oracle query', { query });
     },
-  };
+  });
 
   return harden({ creatorFacet, publicFacet });
 };

--- a/packages/zoe/src/contracts/otcDesk.js
+++ b/packages/zoe/src/contracts/otcDesk.js
@@ -2,6 +2,7 @@
 
 import { E } from '@agoric/eventual-send';
 import { assert } from '@agoric/assert';
+import { Data, Far } from '@agoric/marshal';
 import {
   trade,
   offerTo,
@@ -116,7 +117,7 @@ const start = zcf => {
     return 'Inventory removed';
   };
 
-  const creatorFacet = {
+  const creatorFacet = Far('creatorFacet', {
     /**
      * The inventory can be added in bulk before any quotes are made
      * or can be added immediately before a quote.
@@ -124,7 +125,7 @@ const start = zcf => {
      * @param {IssuerKeywordRecord=} issuerKeywordRecord
      * @returns {Promise<Payment>}
      */
-    makeAddInventoryInvitation: async (issuerKeywordRecord = {}) => {
+    makeAddInventoryInvitation: async (issuerKeywordRecord = Data({})) => {
       await saveAllIssuers(zcf, issuerKeywordRecord);
       return zcf.makeInvitation(addInventory, 'addInventory');
     },
@@ -139,7 +140,7 @@ const start = zcf => {
       return zcf.makeInvitation(removeInventory, 'removeInventory');
     },
     makeQuote,
-  };
+  });
 
   return harden({ creatorFacet });
 };

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -1,5 +1,6 @@
 // @ts-check
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 import { makeNotifierKit } from '@agoric/notifier';
 import makeStore from '@agoric/store';
 import { Nat, isNat } from '@agoric/nat';
@@ -203,7 +204,7 @@ const start = async zcf => {
   };
 
   /** @type {PriceAggregatorCreatorFacet} */
-  const creatorFacet = harden({
+  const creatorFacet = Far('PriceAggregatorCreatorFacet', {
     async initializeQuoteMint(quoteMint) {
       const quoteIssuerRecord = await zcf.saveIssuer(
         E(quoteMint).getIssuer(),
@@ -317,11 +318,11 @@ const start = async zcf => {
     },
   });
 
-  const publicFacet = {
+  const publicFacet = Far('publicFacet', {
     getPriceAuthority() {
       return priceAuthority;
     },
-  };
+  });
 
   return harden({ creatorFacet, publicFacet });
 };

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -2,6 +2,7 @@
 // @ts-check
 
 import { assert, details as X } from '@agoric/assert';
+import { Far } from '@agoric/marshal';
 import { Nat } from '@agoric/nat';
 import {
   assertIssuerKeywords,
@@ -53,13 +54,13 @@ const start = zcf => {
   };
 
   /** @type {SellItemsPublicFacet} */
-  const publicFacet = {
+  const publicFacet = Far('SellItemsPublicFacet', {
     getAvailableItems: () => {
       assert(sellerSeat && !sellerSeat.hasExited(), X`no items are for sale`);
       return sellerSeat.getAmountAllocated('Items');
     },
     getItemsIssuer: () => issuers.Items,
-  };
+  });
 
   const buy = buyerSeat => {
     assertProposalShape(buyerSeat, {
@@ -110,7 +111,7 @@ const start = zcf => {
   };
 
   /** @type {SellItemsCreatorFacet} */
-  const creatorFacet = {
+  const creatorFacet = Far('SellItemsCreatorFacet', {
     makeBuyerInvitation: () => {
       const itemsAmount = sellerSeat.getAmountAllocated('Items');
       assert(
@@ -121,7 +122,7 @@ const start = zcf => {
     },
     getAvailableItems: publicFacet.getAvailableItems,
     getItemsIssuer: publicFacet.getItemsIssuer,
-  };
+  });
 
   const creatorInvitation = zcf.makeInvitation(sell, 'seller');
 

--- a/packages/zoe/src/contracts/simpleExchange.js
+++ b/packages/zoe/src/contracts/simpleExchange.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import { makeNotifierKit } from '@agoric/notifier';
+import { Far } from '@agoric/marshal';
 
 import '../../exported';
 import {
@@ -134,7 +135,7 @@ const start = zcf => {
     zcf.makeInvitation(exchangeOfferHandler, 'exchange');
 
   /** @type {SimpleExchangePublicFacet} */
-  const publicFacet = harden({
+  const publicFacet = Far('SimpleExchangePublicFacet', {
     makeInvitation: makeExchangeInvitation,
     getNotifier: () => notifier,
   });

--- a/packages/zoe/src/objArrayConversion.js
+++ b/packages/zoe/src/objArrayConversion.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { Data } from '@agoric/marshal';
 import { assert, details as X, q } from '@agoric/assert';
 
 /**
@@ -22,7 +23,7 @@ export const arrayToObj = (array, keys) => {
     /** @type {Record<U, T>} */
     ({});
   keys.forEach((key, i) => (obj[key] = array[i]));
-  return obj;
+  return Data(obj);
 };
 
 /**
@@ -87,5 +88,5 @@ export const assertSubset = (whole, part) => {
 export const objectMap = (original, mapPairFn) => {
   const ents = /** @type {[K, T][]} */ (Object.entries(original));
   const mapEnts = ents.map(ent => mapPairFn(ent));
-  return /** @type {Record<K, U>} */ (Object.fromEntries(mapEnts));
+  return /** @type {Record<K, U>} */ (Data(Object.fromEntries(mapEnts)));
 };

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -14,7 +14,7 @@ import { makeIssuerKit, MathKind } from '@agoric/ertp';
 import '../../exported';
 import '../internal-types';
 
-import { Far } from '@agoric/marshal';
+import { Data, Far } from '@agoric/marshal';
 import { makeIssuerTable } from '../issuerTable';
 import { makeZoeSeatAdminKit } from './zoeSeat';
 import zcfContractBundle from '../../bundles/bundle-contractFacet';
@@ -61,7 +61,6 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
     const installation = Far('Installation', {
       getBundle: () => bundle,
     });
-    harden(installation);
     installations.add(installation);
     return installation;
   };
@@ -98,8 +97,8 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
     },
     startInstance: async (
       installationP,
-      uncleanIssuerKeywordRecord = harden({}),
-      customTerms = harden({}),
+      uncleanIssuerKeywordRecord = Data({}),
+      customTerms = Data({}),
     ) => {
       /** @param {Issuer[]} issuers */
       const initIssuers = issuers =>
@@ -204,7 +203,7 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
         brandToPurse.init(localBrand, localPooledPurse);
 
         /** @type {ZoeMint} */
-        const zoeMint = harden({
+        const zoeMint = Far('ZoeMint', {
           getIssuerRecord: () => {
             return localIssuerRecord;
           },
@@ -348,8 +347,8 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
       // ready
 
       const {
-        creatorFacet = {},
-        publicFacet = {},
+        creatorFacet = Far('emptyCreatorFacet', {}),
+        publicFacet = Far('emptyPublicFacet', {}),
         creatorInvitation: creatorInvitationP,
         addSeatObj,
       } = await E(zcfRoot).executeContract(
@@ -357,7 +356,7 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
         zoeService,
         invitationIssuer,
         zoeInstanceAdminForZcf,
-        harden({ ...instanceRecord }),
+        Data({ ...instanceRecord }),
       );
 
       addSeatObjPromiseKit.resolve(addSeatObj);
@@ -379,7 +378,7 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
             X`The contract did not correctly return a creatorInvitation`,
           );
         }
-        const adminFacet = harden({
+        const adminFacet = Far('adminFacet', {
           getVatShutdownPromise: () => E(adminNode).done(),
           getVatStats: () => E(adminNode).adminData(),
         });
@@ -396,8 +395,8 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
     },
     offer: async (
       invitation,
-      uncleanProposal = harden({}),
-      paymentKeywordRecord = harden({}),
+      uncleanProposal = Data({}),
+      paymentKeywordRecord = Data({}),
     ) => {
       return invitationKit.issuer.burn(invitation).then(
         invitationAmount => {
@@ -490,7 +489,6 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
       );
     },
   });
-  harden(zoeService);
 
   return zoeService;
 }

--- a/packages/zoe/test/autoswapJig.js
+++ b/packages/zoe/test/autoswapJig.js
@@ -1,4 +1,5 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 import { makeLocalAmountMath } from '@agoric/ertp';
 import { natSafeMath } from '../src/contractSupport';
 
@@ -121,7 +122,7 @@ export const makeTrader = async (purses, zoe, publicFacet, centralIssuer) => {
   const getPoolAllocation = issuer =>
     E(publicFacet).getPoolAllocation(issuer.getBrand());
 
-  const trader = harden({
+  const trader = Far('trader', {
     offerAndTrade: async (outAmount, inAmount, swapIn) => {
       const proposal = harden({
         want: { Out: outAmount },

--- a/packages/zoe/test/swingsetTests/brokenContracts/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/bootstrap.js
@@ -1,4 +1,5 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 import { makeIssuerKit } from '@agoric/ertp';
 /* eslint-disable import/extensions, import/no-unresolved */
 import crashingAutoRefund from './bundle-crashingAutoRefund';
@@ -38,7 +39,7 @@ const makeVats = (log, vats, zoe, installations, startingValues) => {
 };
 
 export function buildRootObject(vatPowers, vatParameters) {
-  const obj0 = {
+  return Far('root', {
     async bootstrap(vats, devices) {
       const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
         devices.vatAdmin,
@@ -59,6 +60,5 @@ export function buildRootObject(vatPowers, vatParameters) {
       );
       await E(aliceP).startTest(testName);
     },
-  };
-  return harden(obj0);
+  });
 }

--- a/packages/zoe/test/swingsetTests/brokenContracts/crashingAutoRefund.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/crashingAutoRefund.js
@@ -1,5 +1,7 @@
 // @ts-check
 
+import { Far } from '@agoric/marshal';
+
 import {
   swap,
   assertIssuerKeywords,
@@ -75,7 +77,7 @@ const start = zcf => {
     zcf.makeInvitation(makeMatchingInvitation, 'firstOffer');
 
   offersCount += 1n;
-  const publicFacet = harden({
+  const publicFacet = Far('publicFacet', {
     getOffersCount: () => {
       offersCount += 1n;
       return offersCount;

--- a/packages/zoe/test/swingsetTests/brokenContracts/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/vat-alice.js
@@ -1,4 +1,5 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
 import { showPurseBalance, setupIssuers } from '../helpers';
 
@@ -620,7 +621,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
     E(publicFacet).zcfShutdownWithFailure('Sadness');
   };
 
-  return harden({
+  return Far('build', {
     startTest: async testName => {
       switch (testName) {
         case 'meterInOfferHook': {
@@ -665,7 +666,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
 };
 
 export function buildRootObject(vatPowers) {
-  return harden({
+  return Far('root', {
     build: (...args) => build(vatPowers.testLog, ...args),
   });
 }

--- a/packages/zoe/test/swingsetTests/brokenContracts/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/vat-zoe.js
@@ -1,8 +1,10 @@
+import { Far } from '@agoric/marshal';
+
 // noinspection ES6PreferShortImport
 import { makeZoe } from '../../../src/zoeService/zoe';
 
 export function buildRootObject(_vatPowers) {
-  return harden({
+  return Far('root', {
     buildZoe: vatAdminSvc => makeZoe(vatAdminSvc),
   });
 }

--- a/packages/zoe/test/swingsetTests/zoe-metering/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/zoe-metering/bootstrap.js
@@ -1,4 +1,5 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 /* eslint-disable import/extensions, import/no-unresolved */
 import infiniteInstallLoopBundle from './bundle-infiniteInstallLoop';
 import infiniteInstanceLoopBundle from './bundle-infiniteInstanceLoop';
@@ -8,7 +9,7 @@ import testBuiltinsBundle from './bundle-testBuiltins';
 
 export function buildRootObject(vatPowers, vatParameters) {
   const log = vatPowers.testLog;
-  const obj0 = {
+  return Far('root', {
     async bootstrap(vats, devices) {
       const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
         devices.vatAdmin,
@@ -44,6 +45,5 @@ export function buildRootObject(vatPowers, vatParameters) {
         log(`error: ${e}`);
       }
     },
-  };
-  return harden(obj0);
+  });
 }

--- a/packages/zoe/test/swingsetTests/zoe-metering/infiniteTestLoop.js
+++ b/packages/zoe/test/swingsetTests/zoe-metering/infiniteTestLoop.js
@@ -1,5 +1,7 @@
+import { Far } from '@agoric/marshal';
+
 export const start = _zcf => {
-  const publicFacet = harden({
+  const publicFacet = Far('publicFacet', {
     doTest: () => {
       for (;;) {
         // Nothing

--- a/packages/zoe/test/swingsetTests/zoe-metering/testBuiltins.js
+++ b/packages/zoe/test/swingsetTests/zoe-metering/testBuiltins.js
@@ -1,5 +1,7 @@
+import { Far } from '@agoric/marshal';
+
 export const start = _zcf => {
-  const publicFacet = harden({
+  const publicFacet = Far('publicFacet', {
     doTest: () => {
       new Array(1e9).map(Object.create);
     },

--- a/packages/zoe/test/swingsetTests/zoe-metering/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/zoe-metering/vat-zoe.js
@@ -1,8 +1,10 @@
+import { Far } from '@agoric/marshal';
+
 // noinspection ES6PreferShortImport
 import { makeZoe } from '../../../src/zoeService/zoe';
 
 export function buildRootObject(_vatPowers) {
-  return harden({
+  return Far('root', {
     buildZoe: vatAdminSvc => makeZoe(vatAdminSvc),
   });
 }

--- a/packages/zoe/test/swingsetTests/zoe/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/zoe/bootstrap.js
@@ -1,4 +1,5 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 import { makeIssuerKit } from '@agoric/ertp';
 import buildManualTimer from '../../../tools/manualTimer';
 
@@ -77,7 +78,7 @@ const makeVats = (log, vats, zoe, installations, startingValues) => {
 
 export function buildRootObject(vatPowers, vatParameters) {
   const { argv, contractBundles: cb } = vatParameters;
-  const obj0 = {
+  return Far('root', {
     async bootstrap(vats, devices) {
       const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
         devices.vatAdmin,
@@ -106,6 +107,5 @@ export function buildRootObject(vatPowers, vatParameters) {
       );
       await E(aliceP).startTest(testName, bobP, carolP, daveP);
     },
-  };
-  return harden(obj0);
+  });
 }

--- a/packages/zoe/test/swingsetTests/zoe/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-alice.js
@@ -1,4 +1,5 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 import { makeLocalAmountMath } from '@agoric/ertp';
 import { assert, details as X } from '@agoric/assert';
 import { showPurseBalance, setupIssuers } from '../helpers';
@@ -504,7 +505,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     const proposal = harden({
       give: { UnderlyingAsset: moola(3) },
       want: { StrikePrice: simoleans(7) },
-      exit: { afterDeadline: { timer: {}, deadline: 1n } },
+      exit: { afterDeadline: { timer: Far({}), deadline: 1n } },
     });
 
     const paymentKeywordRecord = { UnderlyingAsset: moolaPayment };
@@ -532,7 +533,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     await showPurseBalance(simoleanPurseP, 'aliceSimoleanPurse', log);
   };
 
-  return harden({
+  return Far('build', {
     startTest: async (testName, bobP, carolP, daveP) => {
       switch (testName) {
         case 'automaticRefundOk': {
@@ -577,7 +578,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 };
 
 export function buildRootObject(vatPowers) {
-  return harden({
+  return Far('root', {
     build: (...args) => build(vatPowers.testLog, ...args),
   });
 }

--- a/packages/zoe/test/swingsetTests/zoe/vat-bob.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-bob.js
@@ -1,4 +1,5 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
 import { sameStructure } from '@agoric/same-structure';
 import { makeLocalAmountMath } from '@agoric/ertp';
@@ -20,7 +21,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
   let secondPriceAuctionSeatP;
 
-  return harden({
+  return Far('build', {
     doAutomaticRefund: async invitation => {
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
@@ -563,7 +564,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 };
 
 export function buildRootObject(vatPowers) {
-  return harden({
+  return Far('root', {
     build: (...args) => build(vatPowers.testLog, ...args),
   });
 }

--- a/packages/zoe/test/swingsetTests/zoe/vat-carol.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-carol.js
@@ -1,4 +1,5 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
 import { sameStructure } from '@agoric/same-structure';
 import { showPurseBalance, setupIssuers } from '../helpers';
@@ -12,7 +13,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
 
   let secondPriceAuctionSeatP;
 
-  return harden({
+  return Far('build', {
     doSecondPriceAuctionBid: async invitationP => {
       const invitation = await E(invitationIssuer).claim(invitationP);
       const instance = await E(zoe).getInstance(invitation);
@@ -64,7 +65,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
 };
 
 export function buildRootObject(vatPowers) {
-  return harden({
+  return Far('root', {
     build: (...args) => build(vatPowers.testLog, ...args),
   });
 }

--- a/packages/zoe/test/swingsetTests/zoe/vat-dave.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-dave.js
@@ -1,4 +1,5 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
 import { sameStructure } from '@agoric/same-structure';
 import { showPurseBalance, setupIssuers } from '../helpers';
@@ -19,7 +20,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
   let secondPriceAuctionSeatP;
 
-  return harden({
+  return Far('build', {
     doSecondPriceAuctionBid: async invitation => {
       const instance = await E(zoe).getInstance(invitation);
       const installation = await E(zoe).getInstallation(invitation);
@@ -181,7 +182,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 };
 
 export function buildRootObject(vatPowers) {
-  return harden({
+  return Far('root', {
     build: (...args) => build(vatPowers.testLog, ...args),
   });
 }

--- a/packages/zoe/test/swingsetTests/zoe/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-zoe.js
@@ -1,8 +1,10 @@
+import { Far } from '@agoric/marshal';
+
 // noinspection ES6PreferShortImport
 import { makeZoe } from '../../../src/zoeService/zoe';
 
 export function buildRootObject(_vatPowers) {
-  return harden({
+  return Far('root', {
     buildZoe: vatAdminSvc => makeZoe(vatAdminSvc),
   });
 }

--- a/packages/zoe/test/unitTests/bounty.js
+++ b/packages/zoe/test/unitTests/bounty.js
@@ -1,4 +1,5 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
 
 /**
@@ -60,7 +61,7 @@ const start = async zcf => {
         bountySeat.stage({ Fee: feeMath.getEmpty() }),
       );
 
-      const wakeHandler = harden({
+      const wakeHandler = Far('wakeHandler', {
         wake: async () => {
           const reply = await E(oracle).query('state');
           if (reply.event === condition) {

--- a/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
@@ -6,6 +6,7 @@ import '@agoric/install-ses';
 import test from 'ava';
 
 import { E } from '@agoric/eventual-send';
+import { Data } from '@agoric/marshal';
 import bundleSource from '@agoric/bundle-source';
 
 import { setup } from '../setupBasicMints';
@@ -96,7 +97,7 @@ test(`offerTo - basic usage`, async t => {
   const { zcfSeat: fromSeatContractA } = await makeOffer(
     zoe,
     zcfA,
-    harden({ want: {}, give: { TokenK: bucks(5) } }),
+    harden({ want: Data({}), give: { TokenK: bucks(5) } }),
     harden({ TokenK: bucksMint.mintPayment(bucks(5)) }),
   );
 

--- a/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
@@ -2,7 +2,7 @@
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
-import { Far } from '@agoric/marshal';
+import { Far, Data } from '@agoric/marshal';
 
 import makeStore from '@agoric/store';
 import { setup } from '../setupBasicMints';
@@ -27,13 +27,13 @@ function makeMockTradingZcfBuilder() {
   const amountMathToBrand = makeStore('amountMath');
   const reallocatedStagings = [];
 
-  return harden({
+  return Far('mockTradingZcfBuilder', {
     addOffer: (keyword, offer) => offers.init(keyword, offer),
     addAllocation: (keyword, alloc) => allocs.init(keyword, alloc),
     addBrand: issuerRecord =>
       amountMathToBrand.init(issuerRecord.brand, issuerRecord.amountMath),
     build: () =>
-      harden({
+      Far('mockZCF', {
         getAmountMath: amountMath => amountMathToBrand.get(amountMath),
         getZoeService: () => {},
         reallocate: (...seatStagings) => {
@@ -48,7 +48,7 @@ test('ZoeHelpers satisfies blank proposal', t => {
   const { moolaR, moola } = setup();
   const fakeZcfSeat = Far('fakeZcfSeat', {
     getCurrentAllocation: () => harden({ Asset: moola(10) }),
-    getProposal: () => harden({}),
+    getProposal: () => Data({}),
   });
   const mockZCFBuilder = makeMockTradingZcfBuilder();
   mockZCFBuilder.addBrand(moolaR);
@@ -122,7 +122,7 @@ test('ZoeHelpers satisfies() with give', t => {
 
 const makeMockZcfSeatAdmin = (proposal, initialAllocation, getAmountMath) => {
   const allSeatStagings = new WeakSet();
-  const mockZoeSeatAdmin = harden({});
+  const mockZoeSeatAdmin = Far('mockZoeSeatAdmin', {});
   const { zcfSeat: actual } = makeZcfSeatAdminKit(
     allSeatStagings,
     mockZoeSeatAdmin,

--- a/packages/zoe/test/unitTests/contracts/escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/escrowToVote.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import { assert, details as X, q } from '@agoric/assert';
+import { Far } from '@agoric/marshal';
 import makeStore from '@agoric/store';
 // Eventually will be importable from '@agoric/zoe-contract-support'
 import {
@@ -50,7 +51,7 @@ const start = zcf => {
     assertProposalShape(voterSeat, {
       give: { Assets: null },
     });
-    const voter = harden({
+    const voter = Far('voter', {
       /**
        * Vote on a particular issue
        *
@@ -75,7 +76,7 @@ const start = zcf => {
     return voter;
   };
 
-  const creatorFacet = harden({
+  const creatorFacet = Far('creatorFacet', {
     closeElection: () => {
       assert(electionOpen, 'the election is already closed');
       // YES | NO to Nat

--- a/packages/zoe/test/unitTests/contracts/loan/test-liquidate.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-liquidate.js
@@ -7,6 +7,7 @@ import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 
+import { Data } from '@agoric/marshal';
 import { doLiquidation } from '../../../../src/contracts/loan/liquidate';
 
 import {
@@ -23,8 +24,8 @@ test('test doLiquidation with mocked autoswap', async t => {
   // Set up the lender seat. At this point the lender has nothing.
   const { zcfSeat: lenderSeat, userSeat: lenderUserSeat } = await makeSeatKit(
     zcf,
-    { give: {} },
-    {},
+    { give: Data({}) },
+    Data({}),
   );
 
   const collateral = collateralKit.amountMath.make(10);
@@ -112,8 +113,8 @@ test('test with malfunctioning autoswap', async t => {
   // Set up the lender seat. At this point the lender has nothing.
   const { zcfSeat: lenderSeat, userSeat: lenderUserSeat } = await makeSeatKit(
     zcf,
-    { give: {} },
-    {},
+    { give: Data({}) },
+    Data({}),
   );
 
   const collateral = collateralKit.amountMath.make(10);

--- a/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
+++ b/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
@@ -5,6 +5,7 @@ import test from 'ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import bundleSource from '@agoric/bundle-source';
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 import { setup } from '../setupBasicMints';
 import { setupNonFungible } from '../setupNonFungibleMints';
@@ -78,7 +79,7 @@ test('zoe - atomicSwap', async t => {
   const makeBob = (installation, simoleanPayment) => {
     const moolaPurse = moolaKit.issuer.makeEmptyPurse();
     const simoleanPurse = simoleanKit.issuer.makeEmptyPurse();
-    return harden({
+    return Far('bob', {
       offer: async untrustedInvitation => {
         const invitationIssuer = await E(zoe).getInvitationIssuer();
 
@@ -237,7 +238,7 @@ test('zoe - non-fungible atomicSwap', async t => {
   };
 
   const makeBob = (installation, rpgPayment) => {
-    return harden({
+    return Far('bob', {
       offer: async (untrustedInvitation, calico37Amount, vorpalAmount) => {
         const ccPurse = ccIssuer.makeEmptyPurse();
         const rpgPurse = rpgIssuer.makeEmptyPurse();

--- a/packages/zoe/test/unitTests/contracts/test-coveredCall.js
+++ b/packages/zoe/test/unitTests/contracts/test-coveredCall.js
@@ -4,6 +4,7 @@ import '@agoric/install-ses';
 import test from 'ava';
 import bundleSource from '@agoric/bundle-source';
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 import { sameStructure } from '@agoric/same-structure';
 import { makeLocalAmountMath } from '@agoric/ertp';
@@ -109,7 +110,7 @@ test('zoe - coveredCall', async t => {
     const moolaPurse = moolaKit.issuer.makeEmptyPurse();
     const simoleanPurse = simoleanKit.issuer.makeEmptyPurse();
     const bucksPurse = bucksKit.issuer.makeEmptyPurse();
-    return harden({
+    return Far('bob', {
       offer: async untrustedInvitation => {
         const invitationIssuer = await E(zoe).getInvitationIssuer();
 

--- a/packages/zoe/test/unitTests/contracts/test-oracle.js
+++ b/packages/zoe/test/unitTests/contracts/test-oracle.js
@@ -6,6 +6,7 @@ import anyTest from 'ava';
 import bundleSource from '@agoric/bundle-source';
 
 import { makeIssuerKit, MathKind } from '@agoric/ertp';
+import { Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
 
@@ -55,7 +56,7 @@ test.before(
      */
     const makePingOracle = async _t => {
       /** @type {OracleHandler} */
-      const oracleHandler = harden({
+      const oracleHandler = Far('OracleHandler', {
         async onQuery(query, fee) {
           let requiredFee;
           if (query.kind === 'Paid') {

--- a/packages/zoe/test/unitTests/contracts/test-otcDesk.js
+++ b/packages/zoe/test/unitTests/contracts/test-otcDesk.js
@@ -5,6 +5,7 @@ import test from 'ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import bundleSource from '@agoric/bundle-source';
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 import { setup } from '../setupBasicMints';
 import buildManualTimer from '../../../tools/manualTimer';
@@ -124,7 +125,7 @@ const makeBob = (
   moolaPurse.deposit(moolaPayment);
   simoleanPurse.deposit(simoleanPayment);
   bucksPurse.deposit(bucksPayment);
-  return harden({
+  return Far('Bob', {
     offerOk: async untrustedInvitation => {
       const invitationIssuer = await E(zoe).getInvitationIssuer();
       const invitation = await invitationIssuer.claim(untrustedInvitation);

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
@@ -6,6 +6,7 @@ import anyTest from 'ava';
 import bundleSource from '@agoric/bundle-source';
 
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 import { makeIssuerKit, MathKind } from '@agoric/ertp';
 import { makePromiseKit } from '@agoric/promise-kit';
 
@@ -65,7 +66,7 @@ test.before(
     /** @type {MakeFakePriceOracle} */
     const makeFakePriceOracle = async (t, valueOut = undefined) => {
       /** @type {OracleHandler} */
-      const oracleHandler = harden({
+      const oracleHandler = Far('OracleHandler', {
         async onQuery({ increment }, _fee) {
           valueOut += increment;
           return harden({

--- a/packages/zoe/test/unitTests/contracts/test-secondPriceAuction.js
+++ b/packages/zoe/test/unitTests/contracts/test-secondPriceAuction.js
@@ -4,6 +4,7 @@ import '@agoric/install-ses';
 import test from 'ava';
 import bundleSource from '@agoric/bundle-source';
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 // noinspection ES6PreferShortImport
 import { makeZoe } from '../../../src/zoeService/zoe';
@@ -85,7 +86,7 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
   const makeBob = (installation, simoleanPayment) => {
     const moolaPurse = moolaKit.issuer.makeEmptyPurse();
     const simoleanPurse = simoleanKit.issuer.makeEmptyPurse();
-    return harden({
+    return Far('bob', {
       offer: async untrustedInvitation => {
         const invitationIssuer = await E(zoe).getInvitationIssuer();
 
@@ -157,7 +158,7 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
   const makeLosingBidder = (bidAmount, simoleanPayment) => {
     const moolaPurse = moolaKit.issuer.makeEmptyPurse();
     const simoleanPurse = simoleanKit.issuer.makeEmptyPurse();
-    return harden({
+    return Far('losing bidder', {
       offer: async untrustedInvitation => {
         const invitationIssuer = await E(zoe).getInvitationIssuer();
         const invitation = await invitationIssuer.claim(untrustedInvitation);

--- a/packages/zoe/test/unitTests/contracts/throwInOfferHandler.js
+++ b/packages/zoe/test/unitTests/contracts/throwInOfferHandler.js
@@ -2,6 +2,7 @@
 import '../../../exported';
 
 import { makeIssuerKit } from '@agoric/ertp';
+import { Far } from '@agoric/marshal';
 
 import { depositToSeat } from '../../../src/contractSupport';
 
@@ -31,10 +32,10 @@ const start = zcf => {
   const makeThrowInDepositToSeatInvitation = () =>
     zcf.makeInvitation(throwInDepositToSeat, 'throwInDepositToSeat');
 
-  const creatorFacet = {
+  const creatorFacet = Far('creatorFacet', {
     makeThrowInOfferHandlerInvitation,
     makeThrowInDepositToSeatInvitation,
-  };
+  });
   return harden({ creatorFacet });
 };
 

--- a/packages/zoe/test/unitTests/contracts/useObjExample.js
+++ b/packages/zoe/test/unitTests/contracts/useObjExample.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import { assert, details as X } from '@agoric/assert';
+import { Far } from '@agoric/marshal';
 // Eventually will be importable from '@agoric/zoe-contract-support'
 import {
   assertIssuerKeywords,
@@ -23,7 +24,7 @@ const start = zcf => {
     assertProposalShape(seat, {
       give: { Pixels: null },
     });
-    const useObj = harden({
+    const useObj = Far('useObj', {
       /**
        * (Pretend to) color some pixels.
        *
@@ -54,10 +55,10 @@ const start = zcf => {
     return useObj;
   };
 
-  const publicFacet = {
+  const publicFacet = Far('publicFacet', {
     // The only publicFacet method is to make an invitation.
     makeInvitation: () => zcf.makeInvitation(makeUseObj, 'use object'),
-  };
+  });
 
   return harden({ publicFacet });
 };

--- a/packages/zoe/test/unitTests/test-cleanProposal.js
+++ b/packages/zoe/test/unitTests/test-cleanProposal.js
@@ -3,6 +3,7 @@ import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { makeWeakStore } from '@agoric/store';
+import { Data } from '@agoric/marshal';
 import { cleanProposal } from '../../src/cleanProposal';
 import { setup } from './setupBasicMints';
 import buildManualTimer from '../../tools/manualTimer';
@@ -44,14 +45,14 @@ test('cleanProposal - all empty', t => {
   const getAmountMathForBrand = brandToAmountMath.get;
 
   const proposal = harden({
-    give: {},
-    want: {},
+    give: Data({}),
+    want: Data({}),
     exit: { waived: null },
   });
 
   const expected = harden({
-    give: {},
-    want: {},
+    give: Data({}),
+    want: Data({}),
     exit: { waived: null },
   });
 

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -6,6 +6,7 @@ import test from 'ava';
 
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
+import { passStyleOf, REMOTE_STYLE } from '@agoric/marshal';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import bundleSource from '@agoric/bundle-source';
@@ -53,6 +54,11 @@ test(`zoe.startInstance bad installation`, async t => {
   });
 });
 
+function isEmptyFacet(t, facet) {
+  t.is(passStyleOf(facet), REMOTE_STYLE);
+  t.deepEqual(Object.getOwnPropertyNames(facet), []);
+}
+
 test(`zoe.startInstance no issuerKeywordRecord, no terms`, async t => {
   const { zoe, installation } = await setupZCFTest();
   const result = await E(zoe).startInstance(installation);
@@ -64,9 +70,9 @@ test(`zoe.startInstance no issuerKeywordRecord, no terms`, async t => {
     'instance',
     'publicFacet',
   ]);
-  t.deepEqual(result.creatorFacet, {});
+  isEmptyFacet(t, result.creatorFacet);
   t.deepEqual(result.creatorInvitation, undefined);
-  t.deepEqual(result.publicFacet, {});
+  isEmptyFacet(t, result.publicFacet);
   t.deepEqual(Object.getOwnPropertyNames(result.adminFacet).sort(), [
     'getVatShutdownPromise',
     'getVatStats',
@@ -92,9 +98,9 @@ test(`zoe.startInstance promise for installation`, async t => {
     'instance',
     'publicFacet',
   ]);
-  t.deepEqual(result.creatorFacet, {});
+  isEmptyFacet(t, result.creatorFacet);
   t.deepEqual(result.creatorInvitation, undefined);
-  t.deepEqual(result.publicFacet, {});
+  isEmptyFacet(t, result.publicFacet);
   t.deepEqual(Object.getOwnPropertyNames(result.adminFacet).sort(), [
     'getVatShutdownPromise',
     'getVatStats',

--- a/packages/zoe/tools/manualTimer.js
+++ b/packages/zoe/tools/manualTimer.js
@@ -4,6 +4,7 @@ import { E } from '@agoric/eventual-send';
 import { makeStore } from '@agoric/store';
 import { assert, details as X } from '@agoric/assert';
 import { Nat } from '@agoric/nat';
+import { Far } from '@agoric/marshal';
 
 import './types';
 import './internal-types';
@@ -43,7 +44,7 @@ export default function buildManualTimer(log, startValue = 0n) {
     };
 
     /** @type {TimerRepeater} */
-    const repeater = {
+    const repeater = Far('TimerRepeater', {
       schedule(waker) {
         assert(wakers, X`Cannot schedule on a disabled repeater`);
         wakers.push(waker);
@@ -53,15 +54,14 @@ export default function buildManualTimer(log, startValue = 0n) {
         wakers = null;
         timer.removeWakeup(repeaterWaker);
       },
-    };
-    harden(repeater);
+    });
     nextWakeup = ticks + delaySecs;
     timer.setWakeup(nextWakeup, repeaterWaker);
     return repeater;
   };
 
   /** @type {ManualTimer} */
-  const timer = {
+  const timer = Far('ManualTimer', {
     // This function will only be called in testing code to advance the clock.
     async tick(msg) {
       ticks += 1n;
@@ -134,7 +134,6 @@ export default function buildManualTimer(log, startValue = 0n) {
       timer.setWakeup(ticks + delaySecs, repeaterWaker);
       return notifier;
     },
-  };
-  harden(timer);
+  });
   return timer;
 }


### PR DESCRIPTION
This isn't ready yet, but I wanted to get it checked in so @katelynsills or @Chris-Hibbert could get a head start on reviewing it.

I walked through all files and added Far/Data annotations wherever it seemed appropriate. There are also some random debug messages and comments-to-self (in separate commits); I'll remove those before seeking a proper review.

All test pass when the extra asserts in `marshal.js` are left commented out.

When the extra asserts are enabled, the plain `unitTests/` pass, but the `swingsetTests/` do not. I'm starting with `test-zoe.js`. Something is sneaking an empty unmarked object through. It might involve code in `contracts/automaticRefund.js > makeRefundInvitation` or `zcf.makeInvitation`, but that might also be a red herring.

refs #2018 
