### PR TITLE
fix: properly pin the Moddable SDK version

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,11 +14,14 @@ jobs:
       run: git rev-parse HEAD > packages/cosmic-swingset/lib/git-revision.txt
     - name: Save SDK_VERSION
       run: echo "SDK_VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
+    - name: Save MODDABLE_COMMIT_HASH
+      run: set $(git submodule status); echo "MODDABLE_COMMIT_HASH=$1" >> $GITHUB_ENV
     - name: Build SDK image
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: agoric/agoric-sdk
         dockerfile: packages/deployment/Dockerfile.sdk
+        buildargs: MODDABLE_COMMIT_HASH
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         snapshot: true

--- a/packages/deployment/Dockerfile.sdk
+++ b/packages/deployment/Dockerfile.sdk
@@ -14,6 +14,7 @@ RUN make MOD_READONLY= compile-go
 ###############################
 # The js build container
 FROM node:12-buster AS build-js
+ARG MODDABLE_COMMIT_HASH
 
 WORKDIR /usr/src/agoric-sdk
 COPY . .
@@ -28,7 +29,8 @@ RUN cd golang/cosmos && yarn build:gyp
 # Install the entry points in the path.
 RUN cd packages/cosmic-swingset && make install install-helper
 
-RUN yarn build
+# Check out the specified Moddable SDK version.
+RUN MODDABLE_COMMIT_HASH="$MODDABLE_COMMIT_HASH" yarn build
 
 # Remove dev dependencies.
 RUN rm -rf packages/xsnap/moddable

--- a/packages/deployment/Makefile
+++ b/packages/deployment/Makefile
@@ -4,6 +4,7 @@ SS := ../cosmic-swingset/
 VERSION := $(shell node -e 'console.log(require("../../package.json").version)' 2>/dev/null)
 
 TAG := $(if $(VERSION),$(VERSION),latest)
+MODDABLE_COMMIT_HASH := $(firstword $(shell git submodule status ../xsnap/moddable))
 
 # Don't push alpha tags as ":$(TAG)".
 ifeq ($(TAG),latest)
@@ -22,8 +23,9 @@ docker-build: docker-build-sdk docker-build-solo \
 docker-build-sdk:
 	hash=`git rev-parse --short HEAD`; \
 	  dirty=`git diff --quiet || echo -dirty`; \
-	  echo "$$hash$$dirty" > $(SS)lib/git-revision.txt && \
-		docker build -t $(REPOSITORY_SDK):$(TAG) --file=Dockerfile.sdk ../..
+	  echo "$$hash$$dirty" > $(SS)lib/git-revision.txt
+	docker build --build-arg=MODDABLE_COMMIT_HASH=$(MODDABLE_COMMIT_HASH) \
+		-t $(REPOSITORY_SDK):$(TAG) --file=Dockerfile.sdk ../..
 	docker tag $(REPOSITORY_SDK):$(TAG) $(REPOSITORY_SDK):latest
 
 docker-build-setup:
@@ -47,7 +49,7 @@ docker-push: docker-push-base docker-push-solo docker-push-setup \
 
 # ./docker is an emptyish directory.
 docker-build-ibc-alpha:
-	docker build --build-arg=SDK_TAG=$(TAG) -t $(REPOSITORY_SDK):ibc-alpha --file=Dockerfile.ibc-alpha ./docker
+	docker build --build-arg=MODDABLE_COMMIT_HASH=--build-arg=SDK_TAG=$(TAG) -t $(REPOSITORY_SDK):ibc-alpha --file=Dockerfile.ibc-alpha ./docker
 
 docker-push-ibc-alpha: docker-build-ibc-alpha
 	docker push $(REPOSITORY_SDK):ibc-alpha

--- a/packages/xsnap/src/build.js
+++ b/packages/xsnap/src/build.js
@@ -37,7 +37,7 @@ function exec(command, cwd, args = []) {
     }
     await exec('git', 'moddable', ['checkout', moddableCommitHash]);
   } else {
-    await exec('git', '.', ['submodule', 'update']);
+    await exec('git', '.', ['submodule', 'update', '--init', '--checkout']);
   }
 
   const pjson = readFileSync(`${__dirname}/../package.json`, 'utf-8');


### PR DESCRIPTION
Use only `git submodule update` (no `--init`) to avoid changes
to the SDK version we're using.  This should prevent spurious
differences after running a build.

We also use the $MODDABLE_COMMIT_HASH environment variable to
control what version gets checked out from a Docker build.

fixes #2457 