### PR TITLE
Implement a mock virtual object manager to support unit tests outside SwingSet

### DIFF
--- a/packages/SwingSet/tools/fakeVirtualObjectManager.js
+++ b/packages/SwingSet/tools/fakeVirtualObjectManager.js
@@ -30,20 +30,26 @@ export function makeFakeVirtualObjectManager(cacheSize = 100) {
   }
 
   const valToSlot = new WeakMap();
+  const slotToVal = new Map();
 
   function fakeConvertValToSlot(val) {
+    if (!valToSlot.has(val)) {
+      const slot = `o+${fakeAllocateExportID()}`;
+      valToSlot.set(val, slot);
+      slotToVal.set(slot, val);
+    }
     return valToSlot.get(val);
   }
 
   function fakeConvertSlotToVal(slot) {
     const { type, virtual } = parseVatSlot(slot);
-    assert(
-      virtual,
-      'fakeConvertSlotToVal only works with virtual object references',
-    );
     assert.equal(type, 'object');
-    // eslint-disable-next-line no-use-before-define
-    return makeVirtualObjectRepresentative(slot);
+    if (virtual) {
+      // eslint-disable-next-line no-use-before-define
+      return makeVirtualObjectRepresentative(slot);
+    } else {
+      return slotToVal.get(slot);
+    }
   }
 
   // eslint-disable-next-line no-use-before-define

--- a/packages/SwingSet/tools/fakeVirtualObjectManager.js
+++ b/packages/SwingSet/tools/fakeVirtualObjectManager.js
@@ -1,0 +1,71 @@
+import { makeMarshal } from '@agoric/marshal';
+import { assert } from '@agoric/assert';
+import { parseVatSlot } from '../src/parseVatSlots';
+
+import { makeVirtualObjectManager } from '../src/kernel/virtualObjectManager';
+
+export function makeFakeVirtualObjectManager(cacheSize = 100) {
+  const fakeStore = new Map();
+
+  function dumpStore() {
+    const result = [];
+    for (const entry of fakeStore.entries()) {
+      result.push(entry);
+    }
+    result.sort((e1, e2) => e1[0].localeCompare(e2[0]));
+    return result;
+  }
+
+  const fakeSyscall = {
+    vatstoreGet: key => fakeStore.get(key),
+    vatstoreSet: (key, value) => fakeStore.set(key, value),
+    vatstoreDelete: key => fakeStore.delete(key),
+  };
+
+  let nextExportID = 1;
+  function fakeAllocateExportID() {
+    const exportID = nextExportID;
+    nextExportID += 1;
+    return exportID;
+  }
+
+  const valToSlot = new WeakMap();
+
+  function fakeConvertValToSlot(val) {
+    return valToSlot.get(val);
+  }
+
+  function fakeConvertSlotToVal(slot) {
+    const { type, virtual } = parseVatSlot(slot);
+    assert(
+      virtual,
+      'fakeConvertSlotToVal only works with virtual object references',
+    );
+    assert.equal(type, 'object');
+    // eslint-disable-next-line no-use-before-define
+    return makeVirtualObjectRepresentative(slot);
+  }
+
+  // eslint-disable-next-line no-use-before-define
+  const fakeMarshal = makeMarshal(fakeConvertValToSlot, fakeConvertSlotToVal);
+
+  const {
+    makeVirtualObjectRepresentative,
+    makeWeakStore,
+    makeKind,
+    flushCache,
+  } = makeVirtualObjectManager(
+    fakeSyscall,
+    fakeAllocateExportID,
+    valToSlot,
+    fakeMarshal,
+    cacheSize,
+  );
+
+  return {
+    makeKind,
+    makeWeakStore,
+    flushCache,
+    dumpStore,
+  };
+}


### PR DESCRIPTION
In support of #2534, implements a fake version of the SwingSet virtual object manager for unit tests that need to run outside the SwingSet environment.

Provides a function `makeFakeVirtualObjectManager(optionalCacheSize)` that returns a set of the virtual object functions that act like the real thing but which store stuff in an ephemeral in-memory map and don't pull in the rest of the SwingSet environment.  They do, however, do this via the actual SwingSet kernel virtual object manager code -- what we're faking out is the store and the functions given to the marshaler.

Usage:
```
import { makeFakeVirtualObjectManager } from '@agoric/swingset-vat/tools/fakeVirtualObjectManager';
...
const { makeKind, makeWeakStore } = makeFakeVirtualObjectManager();
```
(the return object also includes `dumpStore` and `flushCache` functions, but you shouldn't normally need to mess with those).

It turned out that the unit tests for the virtual object manager itself already contained 95% of what was needed, so this is mostly a repackaging of that machinery.  In order to test this I rewrote the virtual object manager unit tests in terms of it, so I'm reasonably sure the logic is correct.

One thing this code does not do, which was requested in the original ticket #2534, is mess with the global environment.  I'm going to guess that it may be sufficiently straightforward for unit test setup code to just do the import, call `makeFakeVirtualObjectManager`, and make the resulting virtual object functions available to the test code.  However, if messing with the global environment is truly called for, then somebody who actually understands whatever dance is required to do that will need to give me some help.
