### PR TITLE
fix(bundleSource): patch acorn with defineProperty to avoid override mistake

### DIFF
--- a/patches/acorn+7.1.1.patch
+++ b/patches/acorn+7.1.1.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/acorn/dist/acorn.js b/node_modules/acorn/dist/acorn.js
+index e2b3317..bc1c4d3 100644
+--- a/node_modules/acorn/dist/acorn.js
++++ b/node_modules/acorn/dist/acorn.js
+@@ -1811,7 +1811,7 @@
+       if (checkClashes) {
+         if (has(checkClashes, expr.name))
+           { this.raiseRecoverable(expr.start, "Argument name clash"); }
+-        checkClashes[expr.name] = true;
++        Object.defineProperty(checkClashes, expr.name, { configurable: true, enumerable: true, value: true });
+       }
+       if (bindingType !== BIND_NONE && bindingType !== BIND_OUTSIDE) { this.declareName(expr.name, bindingType, expr.start); }
+       break


### PR DESCRIPTION
This avoids the `.constructor` assignment that prevents us from cleaning up the console noise.

fixes #2324 