### PR TITLE
New SES typings

### DIFF
--- a/packages/ERTP/jsconfig.json
+++ b/packages/ERTP/jsconfig.json
@@ -1,7 +1,7 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "esnext",
 
     "noEmit": true,
 /*

--- a/packages/SwingSet/jsconfig.json
+++ b/packages/SwingSet/jsconfig.json
@@ -1,7 +1,7 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "esnext",
 
     "noEmit": true,
 /*

--- a/packages/assert/jsconfig.json
+++ b/packages/assert/jsconfig.json
@@ -1,7 +1,7 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "esnext",
 
     "noEmit": true,
 /*

--- a/packages/cosmic-swingset/jsconfig.json
+++ b/packages/cosmic-swingset/jsconfig.json
@@ -1,7 +1,7 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "esnext",
 
     "noEmit": true,
 /*

--- a/packages/dapp-svelte-wallet/api/jsconfig.json
+++ b/packages/dapp-svelte-wallet/api/jsconfig.json
@@ -1,7 +1,7 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "esnext",
 
     "noEmit": true,
 /*

--- a/packages/deploy-script-support/jsconfig.json
+++ b/packages/deploy-script-support/jsconfig.json
@@ -1,7 +1,7 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "esnext",
 
     "noEmit": true,
 /*

--- a/packages/marshal/jsconfig.json
+++ b/packages/marshal/jsconfig.json
@@ -1,7 +1,7 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "esnext",
 
     "noEmit": true,
 /*

--- a/packages/notifier/jsconfig.json
+++ b/packages/notifier/jsconfig.json
@@ -1,7 +1,7 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "esnext",
 
     "noEmit": true,
 /*

--- a/packages/promise-kit/jsconfig.json
+++ b/packages/promise-kit/jsconfig.json
@@ -1,7 +1,7 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "esnext",
 
     "noEmit": true,
 /*

--- a/packages/store/jsconfig.json
+++ b/packages/store/jsconfig.json
@@ -1,7 +1,7 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "esnext",
 
     "noEmit": true,
 /*

--- a/packages/store/src/types.js
+++ b/packages/store/src/types.js
@@ -1,3 +1,6 @@
+// eslint-disable-next-line spaced-comment
+/// <reference types="ses"/>
+
 /**
  * @typedef {Record<string, Function>} ExternalInstance
  */


### PR DESCRIPTION
Closes #2498 

We require Agoric/SES-shim#585 to land and a newer SES release to be used in agoric-sdk at the same time as these changes are made.

Fix typing problems found while testing against the latest SES.

We standardize on `"target": "esnext"` since we are anticipating the future standards.
