### PR TITLE
feat: push metrics from autobench

### DIFF
--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -109,6 +109,8 @@ jobs:
     # END-RESTORE-BOILERPLATE
 
     - name: benchmark changes
+      env:
+        AUTOBENCH_METRICS_URL: ${{ secrets.AUTOBENCH_METRICS_URL }}
       run: cd packages/swingset-runner && yarn ci:autobench
     - uses: actions/upload-artifact@v2
       with:

--- a/packages/SwingSet/src/kernel/metrics.js
+++ b/packages/SwingSet/src/kernel/metrics.js
@@ -1,0 +1,91 @@
+// All the kernel metrics we are prepared for.
+export const KERNEL_STATS_SUM_METRICS = [
+  {
+    key: 'syscalls',
+    name: 'swingset_syscall_total',
+    description: 'Total number of SwingSet kernel calls',
+  },
+  {
+    key: 'syscallSend',
+    name: 'swingset_syscall_send_total',
+    description: 'Total number of SwingSet message send kernel calls',
+  },
+  {
+    key: 'syscallCallNow',
+    name: 'swingset_syscall_call_now_total',
+    description: 'Total number of SwingSet synchronous device kernel calls',
+  },
+  {
+    key: 'syscallSubscribe',
+    name: 'swingset_syscall_subscribe_total',
+    description: 'Total number of SwingSet promise subscription kernel calls',
+  },
+  {
+    key: 'syscallResolve',
+    name: 'swingset_syscall_resolve_total',
+    description: 'Total number of SwingSet promise resolution kernel calls',
+  },
+  {
+    key: 'dispatches',
+    name: 'swingset_dispatch_total',
+    description: 'Total number of SwingSet vat calls',
+  },
+  {
+    key: 'dispatchDeliver',
+    name: 'swingset_dispatch_deliver_total',
+    description: 'Total number of SwingSet vat message deliveries',
+  },
+  {
+    key: 'dispatchNotify',
+    name: 'swingset_dispatch_notify_total',
+    description: 'Total number of SwingSet vat promise notifications',
+  },
+];
+
+export const KERNEL_STATS_UPDOWN_METRICS = [
+  {
+    key: 'kernelObjects',
+    name: 'swingset_kernel_objects',
+    description: 'Active kernel objects',
+  },
+  {
+    key: 'kernelDevices',
+    name: 'swingset_kernel_devices',
+    description: 'Active kernel devices',
+  },
+  {
+    key: 'kernelPromises',
+    name: 'swingset_kernel_promises',
+    description: 'Active kernel promises',
+  },
+  {
+    key: 'kpUnresolved',
+    name: 'swingset_unresolved_kernel_promises',
+    description: 'Unresolved kernel promises',
+  },
+  {
+    key: 'kpFulfilled',
+    name: 'swingset_fulfilled_kernel_promises',
+    description: 'Fulfilled kernel promises',
+  },
+  {
+    key: 'kpRejected',
+    name: 'swingset_rejected_kernel_promises',
+    description: 'Rejected kernel promises',
+  },
+  {
+    key: 'runQueueLength',
+    name: 'swingset_run_queue_length',
+    description: 'Length of the kernel run queue',
+  },
+  {
+    key: 'clistEntries',
+    name: 'swingset_clist_entries',
+    description: 'Number of entries in the kernel c-list',
+  },
+];
+
+export const KERNEL_STATS_METRICS = [
+  ...KERNEL_STATS_SUM_METRICS.map(m => ({ ...m, metricType: 'counter' })),
+  ...KERNEL_STATS_UPDOWN_METRICS.map(m => ({ ...m, metricType: 'gauge' })),
+];

--- a/packages/cosmic-swingset/lib/kernel-stats.js
+++ b/packages/cosmic-swingset/lib/kernel-stats.js
@@ -1,92 +1,10 @@
 import { MeterProvider } from '@opentelemetry/metrics';
 import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
 
-// All the kernel metrics we are prepared for.
-const KERNEL_STATS_SUM_METRICS = [
-  {
-    key: 'syscalls',
-    name: 'swingset_syscall_total',
-    description: 'Total number of SwingSet kernel calls',
-  },
-  {
-    key: 'syscallSend',
-    name: 'swingset_syscall_send_total',
-    description: 'Total number of SwingSet message send kernel calls',
-  },
-  {
-    key: 'syscallCallNow',
-    name: 'swingset_syscall_call_now_total',
-    description: 'Total number of SwingSet synchronous device kernel calls',
-  },
-  {
-    key: 'syscallSubscribe',
-    name: 'swingset_syscall_subscribe_total',
-    description: 'Total number of SwingSet promise subscription kernel calls',
-  },
-  {
-    key: 'syscallResolve',
-    name: 'swingset_syscall_resolve_total',
-    description: 'Total number of SwingSet promise resolution kernel calls',
-  },
-  {
-    key: 'dispatches',
-    name: 'swingset_dispatch_total',
-    description: 'Total number of SwingSet vat calls',
-  },
-  {
-    key: 'dispatchDeliver',
-    name: 'swingset_dispatch_deliver_total',
-    description: 'Total number of SwingSet vat message deliveries',
-  },
-  {
-    key: 'dispatchNotify',
-    name: 'swingset_dispatch_notify_total',
-    description: 'Total number of SwingSet vat promise notifications',
-  },
-];
-
-const KERNEL_STATS_UPDOWN_METRICS = [
-  {
-    key: 'kernelObjects',
-    name: 'swingset_kernel_objects',
-    description: 'Active kernel objects',
-  },
-  {
-    key: 'kernelDevices',
-    name: 'swingset_kernel_devices',
-    description: 'Active kernel devices',
-  },
-  {
-    key: 'kernelPromises',
-    name: 'swingset_kernel_promises',
-    description: 'Active kernel promises',
-  },
-  {
-    key: 'kpUnresolved',
-    name: 'swingset_unresolved_kernel_promises',
-    description: 'Unresolved kernel promises',
-  },
-  {
-    key: 'kpFulfilled',
-    name: 'swingset_fulfilled_kernel_promises',
-    description: 'Fulfilled kernel promises',
-  },
-  {
-    key: 'kpRejected',
-    name: 'swingset_rejected_kernel_promises',
-    description: 'Rejected kernel promises',
-  },
-  {
-    key: 'runQueueLength',
-    name: 'swingset_run_queue_length',
-    description: 'Length of the kernel run queue',
-  },
-  {
-    key: 'clistEntries',
-    name: 'swingset_clist_entries',
-    description: 'Number of entries in the kernel c-list',
-  },
-];
+import {
+  KERNEL_STATS_SUM_METRICS,
+  KERNEL_STATS_UPDOWN_METRICS,
+} from '@agoric/swingset-vat/src/kernel/metrics';
 
 /**
  * @param {Object} param0

--- a/packages/deployment/main.js
+++ b/packages/deployment/main.js
@@ -39,6 +39,7 @@ const PROVISIONER_NODE = 'node0'; // FIXME: Allow configuration.
 const COSMOS_DIR = 'ag-chain-cosmos';
 const DWEB_DIR = 'dweb';
 const SECONDS_BETWEEN_BLOCKS = 5;
+const DEFAULT_SWINGSET_PROMETHEUS_PORT = 9464;
 
 // This is needed for hyphenated group names not to trigger Ansible.
 process.env.ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS = 'ignore';
@@ -405,6 +406,17 @@ show-config      display the client connection parameters
         needReMain(['play', 'install-cosmos']),
       );
 
+      let SWINGSET_PROMETHEUS_PORT;
+      if (await exists(`prometheus-tendermint.txt`)) {
+        SWINGSET_PROMETHEUS_PORT = DEFAULT_SWINGSET_PROMETHEUS_PORT;
+      }
+      const agChainCosmosEnvironment = SWINGSET_PROMETHEUS_PORT
+        ? [
+            `-eserviceLines=${shellEscape(
+              `Environment="OTEL_EXPORTER_PROMETHEUS_PORT=${SWINGSET_PROMETHEUS_PORT}"`,
+            )}`,
+          ]
+        : [];
       await guardFile(`${COSMOS_DIR}/service.stamp`, () =>
         needReMain([
           'play',
@@ -412,6 +424,7 @@ show-config      display the client connection parameters
           `-eexecline=${shellEscape(
             '/usr/src/cosmic-swingset/bin/ag-chain-cosmos start --log_level=warn',
           )}`,
+          ...agChainCosmosEnvironment,
         ]),
       );
 

--- a/packages/swingset-runner/autobench
+++ b/packages/swingset-runner/autobench
@@ -1,7 +1,9 @@
 #!/bin/sh
 set -e
 for suite in exchangeBenchmark; do
-  test ! -f demo/$suite/prepareContracts || node -r esm demo/$suite/prepareContracts.js
+  echo "Autobenching suite $suite ..."
+  test ! -f demo/$suite/prepareContracts.js || node -r esm demo/$suite/prepareContracts.js
   node --expose-gc -r esm bin/runner --init --benchmark 100 --statsfile benchstats.json --config demo/$suite/swingset.json run -- --quiet --prime
   node -r esm src/push-metrics.js $suite benchstats.json
 done
+echo "Done!"

--- a/packages/swingset-runner/autobench
+++ b/packages/swingset-runner/autobench
@@ -1,3 +1,7 @@
 #!/bin/sh
-node -r esm demo/exchangeBenchmark/prepareContracts.js
-node --expose-gc -r esm bin/runner --init --benchmark 100 --statsfile benchstats.json --config demo/exchangeBenchmark/swingset.json run -- --quiet --prime
+set -e
+for suite in exchangeBenchmark; do
+  test ! -f demo/$suite/prepareContracts || node -r esm demo/$suite/prepareContracts.js
+  node --expose-gc -r esm bin/runner --init --benchmark 100 --statsfile benchstats.json --config demo/$suite/swingset.json run -- --quiet --prime
+  node -r esm src/push-metrics.js $suite benchstats.json
+done

--- a/packages/swingset-runner/src/push-metrics.js
+++ b/packages/swingset-runner/src/push-metrics.js
@@ -1,0 +1,199 @@
+import { KERNEL_STATS_METRICS } from '@agoric/swingset-vat/src/kernel/metrics';
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+
+const AUTOBENCH_METRICS_URL = process.env.AUTOBENCH_METRICS_URL;
+
+const AUTOBENCH_METRICS = [
+  {
+    key: 'cranks',
+    metricType: 'count',
+    name: 'autobench_cranks_total',
+    description: 'Total number of cranks',
+  },
+  {
+    key: 'rounds',
+    metricType: 'count',
+    name: 'autobench_rounds_total',
+    description: 'Total number of rounds',
+  },
+  {
+    key: 'cranksPerRound',
+    metricType: 'gauge',
+    name: 'autobench_cranks_per_round',
+    description: 'Number of cranks per round',
+  },
+];
+
+const [suite, benchStatsFile] = process.argv.slice(2);
+if (!benchStatsFile) {
+  console.error(`Usage: push-metrics.js SUITE benchStats.json`);
+  process.exit(1);
+}
+
+function promHeader(name, metricType, help = undefined) {
+  let hdr = '';
+  if (help !== undefined) {
+    hdr += `\
+# HELP ${name} ${help}
+`;
+  }
+  hdr += `\
+# TYPE ${name} ${metricType}
+`;
+  return hdr;
+}
+
+function promValue(name, value, labels = []) {
+  let sep = '{';
+  let labelstr = '';
+
+  for (const [key, value] of labels) {
+    labelstr += `${sep}${key}=${JSON.stringify(value)}`;
+    sep = ',';
+  }
+
+  if (sep === ',') {
+    labelstr += '}';
+  }
+
+  return `\
+${name}${labelstr} ${value}
+`;
+}
+
+function generateCommonMetrics(obj, phaseLabels) {
+  let metrics = '';
+  for (const { key, metricType, name, description } of AUTOBENCH_METRICS) {
+    let hdr = promHeader(name, metricType, description);
+    for (const phase of Object.keys(phaseLabels)) {
+      if (obj[phase] && key in obj[phase]) {
+        // Only write the header once.
+        metrics += hdr;
+        hdr = '';
+        metrics += promValue(cranks, obj[phase][key], phaseLabels[phase]);
+      }
+    }
+  }
+  return metrics;
+}
+
+function generateMetricsFromBenchStats(benchStats) {
+  const obj = JSON.parse(benchStats);
+  const mainLabels = [['phase', 'prime']];
+  const benchmarkLabels = [['phase', 'bench']];
+  let metrics = generateCommonMetrics(benchStats, { main: mainLabels, benchmark: benchmarkLabels });
+  if (obj.main) {
+    metrics += generateMetricsFromPrimeData(obj.main.data, mainLabels);
+  }
+  if (obj.benchmark) {
+    metrics += generateMetricsFromBenchmarkData(obj.benchmark.data, benchmarkLabels);
+  }
+  return metrics; 
+}
+
+function generateMetricsFromPrimeData(data, labels = undefined) {
+  let metrics = '';
+  const todo = new Set(Object.keys(data));
+  for (const { metricType, key, name, description } of KERNEL_STATS_METRICS) {
+    if (!(key in data)) {
+      continue;
+    }
+    todo.delete(key);
+    if ('value' in data[key]) {
+      metrics += promHeader(name, metricType, description);
+      metrics += promValue(name, data[key].value, labels);
+    }
+    if ('up' in data[key]) {
+      const nm = `${name}_up`;
+      metrics += promHeader(nm, 'counter', `${description} (number of increments)`);
+      metrics += promValue(nm, data[key].up, labels);
+    }
+    if ('down' in data[key]) {
+      const nm = `${name}_down`;
+      metrics += promHeader(nm, 'counter', `${description} (number of decrements)`);
+      metrics += promValue(nm, data[key].down, labels);
+    }
+    if ('max' in data[key]) {
+      const nm = `${name}_max`;
+      metrics += promHeader(nm, 'gauge', `${description} (maximum value)`);
+      metrics += promValue(nm, data[key].max, labels);
+    }
+    if ('perCrank' in data[key]) {
+      const nm = `${name}_per_crank`;
+      metrics += promHeader(nm, 'gauge', `${description} (value per crank)`);
+      metrics += promValue(nm, data[key].perCrank, labels);
+    }
+  }
+
+  for (const key of todo.keys()) {
+    console.warn(`Unrecognized prime data property ${key}`);
+  }
+  return metrics;
+}
+
+function generateMetricsFromBenchmarkData(data, labels = undefined) {
+  let metrics = '';
+  const todo = new Set(Object.keys(data));
+  for (const { key, name, description } of KERNEL_STATS_METRICS) {
+    if (!(key in data)) {
+      continue;
+    }
+    todo.delete(key);
+    if ('delta' in data[key]) {
+      const nm = `${name}_delta`;
+      metrics += promHeader(nm, 'gauge', `${description} benchmark delta`);
+      metrics += promValue(nm, data[key].delta, labels);
+    }
+    if ('deltaPerRound' in data[key]) {
+      const nm = `${name}_delta_per_round`;
+      metrics += promHeader(nm, 'gauge', `${description} benchmark delta per round`);
+      metrics += promValue(nm, data[key].deltaPerRound, labels);
+    }
+  }
+
+  for (const key of todo.keys()) {
+    console.warn(`Unrecognized benchmark data property ${key}`);
+  }
+  return metrics;
+}
+
+const benchStats = fs.readFileSync(benchStatsFile, 'utf-8');
+const metrics = generateMetricsFromBenchStats(benchStats);
+
+const metricsFile = benchStatsFile.replace(/(\.json)?$/, '.txt');
+fs.writeFileSync(metricsFile, metrics);
+
+if (!AUTOBENCH_METRICS_URL) {
+  console.warn('$AUTOBENCH_METRICS_URL is not set; skipping');
+  process.exit(0);
+}
+
+// We get the commit id to post.
+const gitCp = spawnSync('git', ['rev-parse', 'HEAD'], {
+  stdio: ['inherit', 'pipe', 'inherit'],
+  encoding: 'utf-8',
+});
+const revision = gitCp.stdout.trimRight();
+
+const labels = [['revision', revision], ['suite', suite]];
+
+// This setting of metricsGroup ensures the history is kept for other git
+// commits, but reset for previous uploads of this same gitCommit or suite.
+const metricsGroup = '/' + labels.flatMap((kv) => kv.map(encodeURIComponent)).join('/');
+
+const curlCp = spawnSync(
+  'curl',
+  [
+    '--data-binary',
+    `@${metricsFile}`,
+    '-X',
+    'PUT',
+    `${AUTOBENCH_METRICS_URL}${metricsGroup}`,
+  ],
+  {
+    stdio: 'inherit',
+  },
+);
+
+process.exit(curlCp.status);

--- a/packages/swingset-runner/src/push-metrics.js
+++ b/packages/swingset-runner/src/push-metrics.js
@@ -7,13 +7,13 @@ const AUTOBENCH_METRICS_URL = process.env.AUTOBENCH_METRICS_URL;
 const AUTOBENCH_METRICS = [
   {
     key: 'cranks',
-    metricType: 'count',
+    metricType: 'counter',
     name: 'autobench_cranks_total',
     description: 'Total number of cranks',
   },
   {
     key: 'rounds',
-    metricType: 'count',
+    metricType: 'counter',
     name: 'autobench_rounds_total',
     description: 'Total number of rounds',
   },
@@ -162,7 +162,7 @@ function generateMetricsFromBenchStats(benchStats) {
   const obj = JSON.parse(benchStats);
   const mainLabels = [['phase', 'prime']];
   const benchmarkLabels = [['phase', 'bench']];
-  let metrics = generateCommonMetrics(benchStats, {
+  let metrics = generateCommonMetrics(obj, {
     main: mainLabels,
     benchmark: benchmarkLabels,
   });

--- a/packages/swingset-runner/src/push-metrics.js
+++ b/packages/swingset-runner/src/push-metrics.js
@@ -4,23 +4,25 @@ import fs from 'fs';
 
 const AUTOBENCH_METRICS_URL = process.env.AUTOBENCH_METRICS_URL;
 
+const NAME_PREFIX = 'autobench_';
+
 const AUTOBENCH_METRICS = [
   {
     key: 'cranks',
     metricType: 'counter',
-    name: 'autobench_cranks_total',
+    name: 'cranks_total',
     description: 'Total number of cranks',
   },
   {
     key: 'rounds',
     metricType: 'counter',
-    name: 'autobench_rounds_total',
+    name: 'rounds_total',
     description: 'Total number of rounds',
   },
   {
     key: 'cranksPerRound',
     metricType: 'gauge',
-    name: 'autobench_cranks_per_round',
+    name: 'cranks_per_round',
     description: 'Number of cranks per round',
   },
 ];
@@ -35,11 +37,11 @@ function promHeader(name, metricType, help = undefined) {
   let hdr = '';
   if (help !== undefined) {
     hdr += `\
-# HELP ${name} ${help}
+# HELP ${NAME_PREFIX}${name} ${help}
 `;
   }
   hdr += `\
-# TYPE ${name} ${metricType}
+# TYPE ${NAME_PREFIX}${name} ${metricType}
 `;
   return hdr;
 }
@@ -58,7 +60,7 @@ function promValue(name, value, labels = []) {
   }
 
   return `\
-${name}${labelstr} ${value}
+${NAME_PREFIX}${name}${labelstr} ${value}
 `;
 }
 


### PR DESCRIPTION
Refs #2398 

This does part of the job by pushing the stats to a [Prometheus Push Gateway](https://github.com/prometheus/pushgateway#readme).  I've configured the Github secret to point to Agoric's private server and verified that it works.  The task of analysing the stats there (and ideally setting some alerts if performance seems to regress) is left for the future.

Also, move the kernel metrics descriptions into `@agoric/swingset-vat/src/kernel/metrics`, and ensure the descriptions don't drift from actual kernel stats usage.

Bonus change: enable Prometheus SwingSet scraping when deploying validators to a network.

<details>
<summary>Sample of the benchstats.json</summary>

```json
{
  "main": {
    "cranks": 240,
    "data": {
      "kernelObjects": {
        "value": 84,
        "up": 84,
        "down": 0,
        "max": 84,
        "perCrank": 0.35
      },
      "kernelDevices": {
        "value": 1,
        "up": 1,
        "down": 0,
        "max": 1,
        "perCrank": 0.004166666666666667
      },
      "kernelPromises": {
        "value": 2,
        "up": 124,
        "down": 122,
        "max": 13,
        "perCrank": 0.008333333333333333
      },
      "kpUnresolved": {
        "value": 1,
        "up": 124,
        "down": 123,
        "max": 12,
        "perCrank": 0.004166666666666667
      },
      "kpFulfilled": {
        "value": 1,
        "up": 123,
        "down": 122,
        "max": 8,
        "perCrank": 0.004166666666666667
      },
      "kpRejected": {
        "value": 0,
        "up": 0,
        "down": 0,
        "max": 0,
        "perCrank": 0
      },
      "runQueueLength": {
        "value": 0,
        "up": 240,
        "max": 9,
        "perCrank": 0
      },
      "syscalls": {
        "value": 365,
        "perCrank": 1.5208333333333333
      },
      "syscallSend": {
        "value": 120,
        "perCrank": 0.5
      },
      "syscallSubscribe": {
        "value": 121,
        "perCrank": 0.5041666666666667
      },
      "syscallResolve": {
        "value": 123,
        "perCrank": 0.5125
      },
      "syscallCallNow": {
        "value": 1,
        "perCrank": 0.004166666666666667
      },
      "dispatches": {
        "value": 239,
        "perCrank": 0.9958333333333333
      },
      "dispatchDeliver": {
        "value": 119,
        "perCrank": 0.49583333333333335
      },
      "dispatchNotify": {
        "value": 120,
        "perCrank": 0.5
      },
      "clistEntries": {
        "value": 214,
        "up": 469,
        "down": 255,
        "max": 222,
        "perCrank": 0.8916666666666667
      }
    }
  },
  "benchmark": {
    "cranks": 7500,
    "rounds": 100,
    "cranksPerRound": 75,
    "data": {
      "kernelObjects": {
        "delta": 2300,
        "deltaPerRound": 23
      },
      "kernelDevices": {
        "delta": 0,
        "deltaPerRound": 0
      },
      "kernelPromises": {
        "delta": 1,
        "deltaPerRound": 0.01
      },
      "kpUnresolved": {
        "delta": 0,
        "deltaPerRound": 0
      },
      "kpFulfilled": {
        "delta": 1,
        "deltaPerRound": 0.01
      },
      "kpRejected": {
        "delta": 0,
        "deltaPerRound": 0
      },
      "runQueueLength": {
        "delta": 0,
        "deltaPerRound": 0
      },
      "syscalls": {
        "delta": 11500,
        "deltaPerRound": 115
      },
      "syscallSend": {
        "delta": 3700,
        "deltaPerRound": 37
      },
      "syscallSubscribe": {
        "delta": 3800,
        "deltaPerRound": 38
      },
      "syscallResolve": {
        "delta": 4000,
        "deltaPerRound": 40
      },
      "syscallCallNow": {
        "delta": 0,
        "deltaPerRound": 0
      },
      "dispatches": {
        "delta": 7500,
        "deltaPerRound": 75
      },
      "dispatchDeliver": {
        "delta": 3700,
        "deltaPerRound": 37
      },
      "dispatchNotify": {
        "delta": 3800,
        "deltaPerRound": 38
      },
      "clistEntries": {
        "delta": 5500,
        "deltaPerRound": 55
      }
    }
  }
}
```
</details>

<details>
<summary>And the generated benchstats.txt</summary>

```
# HELP autobench_cranks_total Total number of cranks
# TYPE autobench_cranks_total counter
autobench_cranks_total{phase="prime"} 240
autobench_cranks_total{phase="bench"} 7500
# HELP autobench_rounds_total Total number of rounds
# TYPE autobench_rounds_total counter
autobench_rounds_total{phase="bench"} 100
# HELP autobench_cranks_per_round Number of cranks per round
# TYPE autobench_cranks_per_round gauge
autobench_cranks_per_round{phase="bench"} 75
# HELP autobench_swingset_syscall_total Total number of SwingSet kernel calls
# TYPE autobench_swingset_syscall_total counter
autobench_swingset_syscall_total{phase="prime"} 365
# HELP autobench_swingset_syscall_total_per_crank Total number of SwingSet kernel calls (value per crank)
# TYPE autobench_swingset_syscall_total_per_crank gauge
autobench_swingset_syscall_total_per_crank{phase="prime"} 1.5208333333333333
# HELP autobench_swingset_syscall_send_total Total number of SwingSet message send kernel calls
# TYPE autobench_swingset_syscall_send_total counter
autobench_swingset_syscall_send_total{phase="prime"} 120
# HELP autobench_swingset_syscall_send_total_per_crank Total number of SwingSet message send kernel calls (value per crank)
# TYPE autobench_swingset_syscall_send_total_per_crank gauge
autobench_swingset_syscall_send_total_per_crank{phase="prime"} 0.5
# HELP autobench_swingset_syscall_call_now_total Total number of SwingSet synchronous device kernel calls
# TYPE autobench_swingset_syscall_call_now_total counter
autobench_swingset_syscall_call_now_total{phase="prime"} 1
# HELP autobench_swingset_syscall_call_now_total_per_crank Total number of SwingSet synchronous device kernel calls (value per crank)
# TYPE autobench_swingset_syscall_call_now_total_per_crank gauge
autobench_swingset_syscall_call_now_total_per_crank{phase="prime"} 0.004166666666666667
# HELP autobench_swingset_syscall_subscribe_total Total number of SwingSet promise subscription kernel calls
# TYPE autobench_swingset_syscall_subscribe_total counter
autobench_swingset_syscall_subscribe_total{phase="prime"} 121
# HELP autobench_swingset_syscall_subscribe_total_per_crank Total number of SwingSet promise subscription kernel calls (value per crank)
# TYPE autobench_swingset_syscall_subscribe_total_per_crank gauge
autobench_swingset_syscall_subscribe_total_per_crank{phase="prime"} 0.5041666666666667
# HELP autobench_swingset_syscall_resolve_total Total number of SwingSet promise resolution kernel calls
# TYPE autobench_swingset_syscall_resolve_total counter
autobench_swingset_syscall_resolve_total{phase="prime"} 123
# HELP autobench_swingset_syscall_resolve_total_per_crank Total number of SwingSet promise resolution kernel calls (value per crank)
# TYPE autobench_swingset_syscall_resolve_total_per_crank gauge
autobench_swingset_syscall_resolve_total_per_crank{phase="prime"} 0.5125
# HELP autobench_swingset_dispatch_total Total number of SwingSet vat calls
# TYPE autobench_swingset_dispatch_total counter
autobench_swingset_dispatch_total{phase="prime"} 239
# HELP autobench_swingset_dispatch_total_per_crank Total number of SwingSet vat calls (value per crank)
# TYPE autobench_swingset_dispatch_total_per_crank gauge
autobench_swingset_dispatch_total_per_crank{phase="prime"} 0.9958333333333333
# HELP autobench_swingset_dispatch_deliver_total Total number of SwingSet vat message deliveries
# TYPE autobench_swingset_dispatch_deliver_total counter
autobench_swingset_dispatch_deliver_total{phase="prime"} 119
# HELP autobench_swingset_dispatch_deliver_total_per_crank Total number of SwingSet vat message deliveries (value per crank)
# TYPE autobench_swingset_dispatch_deliver_total_per_crank gauge
autobench_swingset_dispatch_deliver_total_per_crank{phase="prime"} 0.49583333333333335
# HELP autobench_swingset_dispatch_notify_total Total number of SwingSet vat promise notifications
# TYPE autobench_swingset_dispatch_notify_total counter
autobench_swingset_dispatch_notify_total{phase="prime"} 120
# HELP autobench_swingset_dispatch_notify_total_per_crank Total number of SwingSet vat promise notifications (value per crank)
# TYPE autobench_swingset_dispatch_notify_total_per_crank gauge
autobench_swingset_dispatch_notify_total_per_crank{phase="prime"} 0.5
# HELP autobench_swingset_kernel_objects Active kernel objects
# TYPE autobench_swingset_kernel_objects gauge
autobench_swingset_kernel_objects{phase="prime"} 84
# HELP autobench_swingset_kernel_objects_up Active kernel objects (number of increments)
# TYPE autobench_swingset_kernel_objects_up counter
autobench_swingset_kernel_objects_up{phase="prime"} 84
# HELP autobench_swingset_kernel_objects_down Active kernel objects (number of decrements)
# TYPE autobench_swingset_kernel_objects_down counter
autobench_swingset_kernel_objects_down{phase="prime"} 0
# HELP autobench_swingset_kernel_objects_max Active kernel objects (maximum value)
# TYPE autobench_swingset_kernel_objects_max gauge
autobench_swingset_kernel_objects_max{phase="prime"} 84
# HELP autobench_swingset_kernel_objects_per_crank Active kernel objects (value per crank)
# TYPE autobench_swingset_kernel_objects_per_crank gauge
autobench_swingset_kernel_objects_per_crank{phase="prime"} 0.35
# HELP autobench_swingset_kernel_devices Active kernel devices
# TYPE autobench_swingset_kernel_devices gauge
autobench_swingset_kernel_devices{phase="prime"} 1
# HELP autobench_swingset_kernel_devices_up Active kernel devices (number of increments)
# TYPE autobench_swingset_kernel_devices_up counter
autobench_swingset_kernel_devices_up{phase="prime"} 1
# HELP autobench_swingset_kernel_devices_down Active kernel devices (number of decrements)
# TYPE autobench_swingset_kernel_devices_down counter
autobench_swingset_kernel_devices_down{phase="prime"} 0
# HELP autobench_swingset_kernel_devices_max Active kernel devices (maximum value)
# TYPE autobench_swingset_kernel_devices_max gauge
autobench_swingset_kernel_devices_max{phase="prime"} 1
# HELP autobench_swingset_kernel_devices_per_crank Active kernel devices (value per crank)
# TYPE autobench_swingset_kernel_devices_per_crank gauge
autobench_swingset_kernel_devices_per_crank{phase="prime"} 0.004166666666666667
# HELP autobench_swingset_kernel_promises Active kernel promises
# TYPE autobench_swingset_kernel_promises gauge
autobench_swingset_kernel_promises{phase="prime"} 2
# HELP autobench_swingset_kernel_promises_up Active kernel promises (number of increments)
# TYPE autobench_swingset_kernel_promises_up counter
autobench_swingset_kernel_promises_up{phase="prime"} 124
# HELP autobench_swingset_kernel_promises_down Active kernel promises (number of decrements)
# TYPE autobench_swingset_kernel_promises_down counter
autobench_swingset_kernel_promises_down{phase="prime"} 122
# HELP autobench_swingset_kernel_promises_max Active kernel promises (maximum value)
# TYPE autobench_swingset_kernel_promises_max gauge
autobench_swingset_kernel_promises_max{phase="prime"} 13
# HELP autobench_swingset_kernel_promises_per_crank Active kernel promises (value per crank)
# TYPE autobench_swingset_kernel_promises_per_crank gauge
autobench_swingset_kernel_promises_per_crank{phase="prime"} 0.008333333333333333
# HELP autobench_swingset_unresolved_kernel_promises Unresolved kernel promises
# TYPE autobench_swingset_unresolved_kernel_promises gauge
autobench_swingset_unresolved_kernel_promises{phase="prime"} 1
# HELP autobench_swingset_unresolved_kernel_promises_up Unresolved kernel promises (number of increments)
# TYPE autobench_swingset_unresolved_kernel_promises_up counter
autobench_swingset_unresolved_kernel_promises_up{phase="prime"} 124
# HELP autobench_swingset_unresolved_kernel_promises_down Unresolved kernel promises (number of decrements)
# TYPE autobench_swingset_unresolved_kernel_promises_down counter
autobench_swingset_unresolved_kernel_promises_down{phase="prime"} 123
# HELP autobench_swingset_unresolved_kernel_promises_max Unresolved kernel promises (maximum value)
# TYPE autobench_swingset_unresolved_kernel_promises_max gauge
autobench_swingset_unresolved_kernel_promises_max{phase="prime"} 12
# HELP autobench_swingset_unresolved_kernel_promises_per_crank Unresolved kernel promises (value per crank)
# TYPE autobench_swingset_unresolved_kernel_promises_per_crank gauge
autobench_swingset_unresolved_kernel_promises_per_crank{phase="prime"} 0.004166666666666667
# HELP autobench_swingset_fulfilled_kernel_promises Fulfilled kernel promises
# TYPE autobench_swingset_fulfilled_kernel_promises gauge
autobench_swingset_fulfilled_kernel_promises{phase="prime"} 1
# HELP autobench_swingset_fulfilled_kernel_promises_up Fulfilled kernel promises (number of increments)
# TYPE autobench_swingset_fulfilled_kernel_promises_up counter
autobench_swingset_fulfilled_kernel_promises_up{phase="prime"} 123
# HELP autobench_swingset_fulfilled_kernel_promises_down Fulfilled kernel promises (number of decrements)
# TYPE autobench_swingset_fulfilled_kernel_promises_down counter
autobench_swingset_fulfilled_kernel_promises_down{phase="prime"} 122
# HELP autobench_swingset_fulfilled_kernel_promises_max Fulfilled kernel promises (maximum value)
# TYPE autobench_swingset_fulfilled_kernel_promises_max gauge
autobench_swingset_fulfilled_kernel_promises_max{phase="prime"} 8
# HELP autobench_swingset_fulfilled_kernel_promises_per_crank Fulfilled kernel promises (value per crank)
# TYPE autobench_swingset_fulfilled_kernel_promises_per_crank gauge
autobench_swingset_fulfilled_kernel_promises_per_crank{phase="prime"} 0.004166666666666667
# HELP autobench_swingset_rejected_kernel_promises Rejected kernel promises
# TYPE autobench_swingset_rejected_kernel_promises gauge
autobench_swingset_rejected_kernel_promises{phase="prime"} 0
# HELP autobench_swingset_rejected_kernel_promises_up Rejected kernel promises (number of increments)
# TYPE autobench_swingset_rejected_kernel_promises_up counter
autobench_swingset_rejected_kernel_promises_up{phase="prime"} 0
# HELP autobench_swingset_rejected_kernel_promises_down Rejected kernel promises (number of decrements)
# TYPE autobench_swingset_rejected_kernel_promises_down counter
autobench_swingset_rejected_kernel_promises_down{phase="prime"} 0
# HELP autobench_swingset_rejected_kernel_promises_max Rejected kernel promises (maximum value)
# TYPE autobench_swingset_rejected_kernel_promises_max gauge
autobench_swingset_rejected_kernel_promises_max{phase="prime"} 0
# HELP autobench_swingset_rejected_kernel_promises_per_crank Rejected kernel promises (value per crank)
# TYPE autobench_swingset_rejected_kernel_promises_per_crank gauge
autobench_swingset_rejected_kernel_promises_per_crank{phase="prime"} 0
# HELP autobench_swingset_run_queue_length Length of the kernel run queue
# TYPE autobench_swingset_run_queue_length gauge
autobench_swingset_run_queue_length{phase="prime"} 0
# HELP autobench_swingset_run_queue_length_up Length of the kernel run queue (number of increments)
# TYPE autobench_swingset_run_queue_length_up counter
autobench_swingset_run_queue_length_up{phase="prime"} 240
# HELP autobench_swingset_run_queue_length_max Length of the kernel run queue (maximum value)
# TYPE autobench_swingset_run_queue_length_max gauge
autobench_swingset_run_queue_length_max{phase="prime"} 9
# HELP autobench_swingset_run_queue_length_per_crank Length of the kernel run queue (value per crank)
# TYPE autobench_swingset_run_queue_length_per_crank gauge
autobench_swingset_run_queue_length_per_crank{phase="prime"} 0
# HELP autobench_swingset_clist_entries Number of entries in the kernel c-list
# TYPE autobench_swingset_clist_entries gauge
autobench_swingset_clist_entries{phase="prime"} 214
# HELP autobench_swingset_clist_entries_up Number of entries in the kernel c-list (number of increments)
# TYPE autobench_swingset_clist_entries_up counter
autobench_swingset_clist_entries_up{phase="prime"} 469
# HELP autobench_swingset_clist_entries_down Number of entries in the kernel c-list (number of decrements)
# TYPE autobench_swingset_clist_entries_down counter
autobench_swingset_clist_entries_down{phase="prime"} 255
# HELP autobench_swingset_clist_entries_max Number of entries in the kernel c-list (maximum value)
# TYPE autobench_swingset_clist_entries_max gauge
autobench_swingset_clist_entries_max{phase="prime"} 222
# HELP autobench_swingset_clist_entries_per_crank Number of entries in the kernel c-list (value per crank)
# TYPE autobench_swingset_clist_entries_per_crank gauge
autobench_swingset_clist_entries_per_crank{phase="prime"} 0.8916666666666667
# HELP autobench_swingset_syscall_total_delta Total number of SwingSet kernel calls benchmark delta
# TYPE autobench_swingset_syscall_total_delta gauge
autobench_swingset_syscall_total_delta{phase="bench"} 11500
# HELP autobench_swingset_syscall_total_delta_per_round Total number of SwingSet kernel calls benchmark delta per round
# TYPE autobench_swingset_syscall_total_delta_per_round gauge
autobench_swingset_syscall_total_delta_per_round{phase="bench"} 115
# HELP autobench_swingset_syscall_send_total_delta Total number of SwingSet message send kernel calls benchmark delta
# TYPE autobench_swingset_syscall_send_total_delta gauge
autobench_swingset_syscall_send_total_delta{phase="bench"} 3700
# HELP autobench_swingset_syscall_send_total_delta_per_round Total number of SwingSet message send kernel calls benchmark delta per round
# TYPE autobench_swingset_syscall_send_total_delta_per_round gauge
autobench_swingset_syscall_send_total_delta_per_round{phase="bench"} 37
# HELP autobench_swingset_syscall_call_now_total_delta Total number of SwingSet synchronous device kernel calls benchmark delta
# TYPE autobench_swingset_syscall_call_now_total_delta gauge
autobench_swingset_syscall_call_now_total_delta{phase="bench"} 0
# HELP autobench_swingset_syscall_call_now_total_delta_per_round Total number of SwingSet synchronous device kernel calls benchmark delta per round
# TYPE autobench_swingset_syscall_call_now_total_delta_per_round gauge
autobench_swingset_syscall_call_now_total_delta_per_round{phase="bench"} 0
# HELP autobench_swingset_syscall_subscribe_total_delta Total number of SwingSet promise subscription kernel calls benchmark delta
# TYPE autobench_swingset_syscall_subscribe_total_delta gauge
autobench_swingset_syscall_subscribe_total_delta{phase="bench"} 3800
# HELP autobench_swingset_syscall_subscribe_total_delta_per_round Total number of SwingSet promise subscription kernel calls benchmark delta per round
# TYPE autobench_swingset_syscall_subscribe_total_delta_per_round gauge
autobench_swingset_syscall_subscribe_total_delta_per_round{phase="bench"} 38
# HELP autobench_swingset_syscall_resolve_total_delta Total number of SwingSet promise resolution kernel calls benchmark delta
# TYPE autobench_swingset_syscall_resolve_total_delta gauge
autobench_swingset_syscall_resolve_total_delta{phase="bench"} 4000
# HELP autobench_swingset_syscall_resolve_total_delta_per_round Total number of SwingSet promise resolution kernel calls benchmark delta per round
# TYPE autobench_swingset_syscall_resolve_total_delta_per_round gauge
autobench_swingset_syscall_resolve_total_delta_per_round{phase="bench"} 40
# HELP autobench_swingset_dispatch_total_delta Total number of SwingSet vat calls benchmark delta
# TYPE autobench_swingset_dispatch_total_delta gauge
autobench_swingset_dispatch_total_delta{phase="bench"} 7500
# HELP autobench_swingset_dispatch_total_delta_per_round Total number of SwingSet vat calls benchmark delta per round
# TYPE autobench_swingset_dispatch_total_delta_per_round gauge
autobench_swingset_dispatch_total_delta_per_round{phase="bench"} 75
# HELP autobench_swingset_dispatch_deliver_total_delta Total number of SwingSet vat message deliveries benchmark delta
# TYPE autobench_swingset_dispatch_deliver_total_delta gauge
autobench_swingset_dispatch_deliver_total_delta{phase="bench"} 3700
# HELP autobench_swingset_dispatch_deliver_total_delta_per_round Total number of SwingSet vat message deliveries benchmark delta per round
# TYPE autobench_swingset_dispatch_deliver_total_delta_per_round gauge
autobench_swingset_dispatch_deliver_total_delta_per_round{phase="bench"} 37
# HELP autobench_swingset_dispatch_notify_total_delta Total number of SwingSet vat promise notifications benchmark delta
# TYPE autobench_swingset_dispatch_notify_total_delta gauge
autobench_swingset_dispatch_notify_total_delta{phase="bench"} 3800
# HELP autobench_swingset_dispatch_notify_total_delta_per_round Total number of SwingSet vat promise notifications benchmark delta per round
# TYPE autobench_swingset_dispatch_notify_total_delta_per_round gauge
autobench_swingset_dispatch_notify_total_delta_per_round{phase="bench"} 38
# HELP autobench_swingset_kernel_objects_delta Active kernel objects benchmark delta
# TYPE autobench_swingset_kernel_objects_delta gauge
autobench_swingset_kernel_objects_delta{phase="bench"} 2300
# HELP autobench_swingset_kernel_objects_delta_per_round Active kernel objects benchmark delta per round
# TYPE autobench_swingset_kernel_objects_delta_per_round gauge
autobench_swingset_kernel_objects_delta_per_round{phase="bench"} 23
# HELP autobench_swingset_kernel_devices_delta Active kernel devices benchmark delta
# TYPE autobench_swingset_kernel_devices_delta gauge
autobench_swingset_kernel_devices_delta{phase="bench"} 0
# HELP autobench_swingset_kernel_devices_delta_per_round Active kernel devices benchmark delta per round
# TYPE autobench_swingset_kernel_devices_delta_per_round gauge
autobench_swingset_kernel_devices_delta_per_round{phase="bench"} 0
# HELP autobench_swingset_kernel_promises_delta Active kernel promises benchmark delta
# TYPE autobench_swingset_kernel_promises_delta gauge
autobench_swingset_kernel_promises_delta{phase="bench"} 1
# HELP autobench_swingset_kernel_promises_delta_per_round Active kernel promises benchmark delta per round
# TYPE autobench_swingset_kernel_promises_delta_per_round gauge
autobench_swingset_kernel_promises_delta_per_round{phase="bench"} 0.01
# HELP autobench_swingset_unresolved_kernel_promises_delta Unresolved kernel promises benchmark delta
# TYPE autobench_swingset_unresolved_kernel_promises_delta gauge
autobench_swingset_unresolved_kernel_promises_delta{phase="bench"} 0
# HELP autobench_swingset_unresolved_kernel_promises_delta_per_round Unresolved kernel promises benchmark delta per round
# TYPE autobench_swingset_unresolved_kernel_promises_delta_per_round gauge
autobench_swingset_unresolved_kernel_promises_delta_per_round{phase="bench"} 0
# HELP autobench_swingset_fulfilled_kernel_promises_delta Fulfilled kernel promises benchmark delta
# TYPE autobench_swingset_fulfilled_kernel_promises_delta gauge
autobench_swingset_fulfilled_kernel_promises_delta{phase="bench"} 1
# HELP autobench_swingset_fulfilled_kernel_promises_delta_per_round Fulfilled kernel promises benchmark delta per round
# TYPE autobench_swingset_fulfilled_kernel_promises_delta_per_round gauge
autobench_swingset_fulfilled_kernel_promises_delta_per_round{phase="bench"} 0.01
# HELP autobench_swingset_rejected_kernel_promises_delta Rejected kernel promises benchmark delta
# TYPE autobench_swingset_rejected_kernel_promises_delta gauge
autobench_swingset_rejected_kernel_promises_delta{phase="bench"} 0
# HELP autobench_swingset_rejected_kernel_promises_delta_per_round Rejected kernel promises benchmark delta per round
# TYPE autobench_swingset_rejected_kernel_promises_delta_per_round gauge
autobench_swingset_rejected_kernel_promises_delta_per_round{phase="bench"} 0
# HELP autobench_swingset_run_queue_length_delta Length of the kernel run queue benchmark delta
# TYPE autobench_swingset_run_queue_length_delta gauge
autobench_swingset_run_queue_length_delta{phase="bench"} 0
# HELP autobench_swingset_run_queue_length_delta_per_round Length of the kernel run queue benchmark delta per round
# TYPE autobench_swingset_run_queue_length_delta_per_round gauge
autobench_swingset_run_queue_length_delta_per_round{phase="bench"} 0
# HELP autobench_swingset_clist_entries_delta Number of entries in the kernel c-list benchmark delta
# TYPE autobench_swingset_clist_entries_delta gauge
autobench_swingset_clist_entries_delta{phase="bench"} 5500
# HELP autobench_swingset_clist_entries_delta_per_round Number of entries in the kernel c-list benchmark delta per round
# TYPE autobench_swingset_clist_entries_delta_per_round gauge
autobench_swingset_clist_entries_delta_per_round{phase="bench"} 55
```
</details>