### PR TITLE
fix(swingset): let command device pass BigInt args/responses/broadcasts

### DIFF
--- a/packages/SwingSet/src/devices/command-src.js
+++ b/packages/SwingSet/src/devices/command-src.js
@@ -1,5 +1,5 @@
 import { Nat } from '@agoric/nat';
-import { Far } from '@agoric/marshal';
+import { Far, parse, stringify } from '@agoric/marshal';
 
 import { assert, details as X } from '@agoric/assert';
 
@@ -19,7 +19,7 @@ export function buildRootDeviceNode(tools) {
       );
     }
     try {
-      const body = JSON.parse(`${bodyString}`);
+      const body = parse(`${bodyString}`);
       SO(inboundHandler).inbound(Nat(count), body);
     } catch (e) {
       console.error(`error during inboundCallback:`, e);
@@ -35,7 +35,7 @@ export function buildRootDeviceNode(tools) {
 
     sendResponse(count, isReject, obj) {
       try {
-        deliverResponse(count, isReject, JSON.stringify(obj));
+        deliverResponse(count, isReject, stringify(obj));
       } catch (e) {
         console.error(`error during sendResponse:`, e);
       }
@@ -43,7 +43,7 @@ export function buildRootDeviceNode(tools) {
 
     sendBroadcast(obj) {
       try {
-        sendBroadcast(JSON.stringify(obj));
+        sendBroadcast(stringify(obj));
       } catch (e) {
         console.error(`error during sendBroadcast:`, e);
       }

--- a/packages/SwingSet/src/devices/command.js
+++ b/packages/SwingSet/src/devices/command.js
@@ -1,5 +1,6 @@
 import { makePromiseKit } from '@agoric/promise-kit';
 import { Nat } from '@agoric/nat';
+import { parse, stringify } from '@agoric/marshal';
 
 import { assert, details as X } from '@agoric/assert';
 
@@ -20,7 +21,7 @@ export default function buildCommand(broadcastCallback) {
     responses.set(count, { resolve, reject });
     assert(inboundCallback, X`inboundCommand before registerInboundCallback`);
     try {
-      inboundCallback(count, JSON.stringify(obj));
+      inboundCallback(count, stringify(obj));
     } catch (e) {
       console.error(`error running inboundCallback:`, e);
     }
@@ -28,7 +29,7 @@ export default function buildCommand(broadcastCallback) {
   }
 
   function sendBroadcast(kBodyString) {
-    const obj = JSON.parse(`${kBodyString}`);
+    const obj = parse(`${kBodyString}`);
     broadcastCallback(obj);
   }
 
@@ -40,12 +41,7 @@ export default function buildCommand(broadcastCallback) {
   function deliverResponse(kCount, kIsReject, kResponseString) {
     const count = Nat(kCount);
     const isReject = Boolean(kIsReject);
-    let obj;
-    // TODO: is this safe against kernel-realm trickery? It's awfully handy
-    // to let the kernel-side result be 'undefined'
-    if (kResponseString !== undefined) {
-      obj = JSON.parse(`${kResponseString}`);
-    }
+    const obj = parse(`${kResponseString}`);
     // TODO this might not qualify as an error, it needs more thought
     // See https://github.com/Agoric/agoric-sdk/pull/2406#discussion_r575561554
     assert(responses.has(count), X`unknown response index ${count}`);

--- a/packages/SwingSet/test/files-devices/bootstrap-2.js
+++ b/packages/SwingSet/test/files-devices/bootstrap-2.js
@@ -74,14 +74,21 @@ export function buildRootObject(vatPowers, vatParameters) {
         });
         D(devices.mailbox).registerInboundHandler(handler);
       } else if (argv[0] === 'command1') {
-        D(devices.command).sendBroadcast({ hello: 'everybody' });
+        D(devices.command).sendBroadcast(
+          harden({ hello: 'everybody', big: BigInt(1) }),
+        );
       } else if (argv[0] === 'command2') {
         const handler = Far('handler', {
           inbound(count, body) {
-            log(`handle-${count}-${body.piece}`);
-            D(devices.command).sendResponse(count, body.doReject, {
-              response: 'body',
-            });
+            log(`handle-${count}-${body.piece}-${body.big}`);
+            D(devices.command).sendResponse(
+              count,
+              body.doReject,
+              harden({
+                response: 'body',
+                big: BigInt(4),
+              }),
+            );
           },
         });
         D(devices.command).registerInboundHandler(handler);

--- a/packages/SwingSet/test/test-devices.js
+++ b/packages/SwingSet/test/test-devices.js
@@ -433,7 +433,7 @@ test.serial('command broadcast', async t => {
   await initializeSwingset(config, ['command1'], hostStorage, t.context.data);
   const c = await makeSwingsetController(hostStorage, deviceEndowments);
   await c.run();
-  t.deepEqual(broadcasts, [{ hello: 'everybody' }]);
+  t.deepEqual(broadcasts, [{ hello: 'everybody', big: BigInt(1) }]);
 });
 
 test.serial('command deliver', async t => {
@@ -461,21 +461,25 @@ test.serial('command deliver', async t => {
   await c.run();
 
   t.deepEqual(c.dump().log.length, 0);
-  const p1 = cm.inboundCommand({ piece: 'missing', doReject: false });
+  const p1 = cm.inboundCommand(
+    harden({ piece: 'missing', doReject: false, big: BigInt(2) }),
+  );
   await c.run();
   const r1 = await p1;
-  t.deepEqual(r1, { response: 'body' });
-  t.deepEqual(c.dump().log, ['handle-0-missing']);
+  t.deepEqual(r1, { response: 'body', big: BigInt(4) });
+  t.deepEqual(c.dump().log, ['handle-0-missing-2']);
 
-  const p2 = cm.inboundCommand({ piece: 'errory', doReject: true });
+  const p2 = cm.inboundCommand(
+    harden({ piece: 'errory', doReject: true, big: 3 }),
+  );
   let rejection;
   p2.then(
     res => t.fail(`expected to reject, but got ${res}`),
     rej => (rejection = rej),
   );
   await c.run();
-  t.deepEqual(c.dump().log, ['handle-0-missing', 'handle-1-errory']);
-  t.deepEqual(rejection, { response: 'body' });
+  t.deepEqual(c.dump().log, ['handle-0-missing-2', 'handle-1-errory-3']);
+  t.deepEqual(rejection, { response: 'body', big: BigInt(4) });
 });
 
 test.serial('liveslots throws when D() gets promise', async t => {


### PR DESCRIPTION
Previously the "command device" used JSON.stringify/parse to pass data across
the kernel/host boundary. This could not handle `undefined`, BigInts, and
other interesting pass-by-copy datatypes.

With this change, we use `marshal` stringify/parse instead of plain JSON,
which can handle a wider variety of JavaScript datatypes. This is nearly a
superset of JSON, with the unfortunate exception of empty objects, which will
not be handled quite right until #2018 is finished. Such objects will arrive
as empty Presences (with an unusual prototype and an unenumerable
Symbol-named property), or will be rejected during serialization (because
they lack a Data or Far marker), or will cause a warning but arrive properly,
depending upon what phase of the #2018 transition we're in at the time.

The one visible limitation of using `marshal` stringify/parse is that the
data you feed to it must be `harden`ed: the command device will throw an
exception if given unhardened data. The previous JSON approach did not
require this.

refs #2559