### PR TITLE
fix(dapp-svelte-wallet): add Far/Data annotations

### DIFF
--- a/packages/dapp-svelte-wallet/api/src/lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-wallet.js
@@ -255,7 +255,7 @@ export function makeWallet({
         ...jstate,
         purse,
         brand,
-        actions: Far('actions', {
+        actions: Far('purse.actions', {
           // Send a value from this purse.
           async send(receiverP, sendValue) {
             const { amountMath } = brandTable.getByBrand(brand);
@@ -776,7 +776,7 @@ export function makeWallet({
         origin,
         approvalP,
         enable: false,
-        actions: Far('actions', {
+        actions: Far('dapp.actions', {
           setPetname(petname) {
             if (dappRecord.petname === petname) {
               return dappRecord.actions;

--- a/packages/dapp-svelte-wallet/api/src/lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-wallet.js
@@ -17,7 +17,7 @@ import { makeIssuerTable } from '@agoric/zoe/src/issuerTable';
 
 import { E } from '@agoric/eventual-send';
 
-import { makeMarshal, passStyleOf } from '@agoric/marshal';
+import { makeMarshal, passStyleOf, Far, Data } from '@agoric/marshal';
 import { makeNotifierKit, observeNotifier } from '@agoric/notifier';
 import { makePromiseKit } from '@agoric/promise-kit';
 
@@ -184,7 +184,7 @@ export function makeWallet({
         currentAmount,
       });
     const filter = state => state.map(innerFilter);
-    const pu = harden({
+    const pu = Far('pursesUpdater', {
       updateState: newState => {
         ipu.updateState(newState);
         apu.updateState(filter(newState));
@@ -255,7 +255,7 @@ export function makeWallet({
         ...jstate,
         purse,
         brand,
-        actions: {
+        actions: Far('actions', {
           // Send a value from this purse.
           async send(receiverP, sendValue) {
             const { amountMath } = brandTable.getByBrand(brand);
@@ -276,7 +276,7 @@ export function makeWallet({
           deposit(payment, amount = undefined) {
             return E(purse).deposit(payment, amount);
           },
-        },
+        }),
       }),
     );
     pursesUpdater.updateState([...pursesFullState.values()]);
@@ -470,7 +470,7 @@ export function makeWallet({
     // Payments are made for the keywords in proposal.give.
     const keywords = [];
 
-    const paymentPs = Object.entries(proposal.give || {}).map(
+    const paymentPs = Object.entries(proposal.give || Data({})).map(
       ([keyword, amount]) => {
         const purse = purseKeywordRecord[keyword];
         assert(
@@ -491,15 +491,11 @@ export function makeWallet({
     // for the offer.
     const payments = await Promise.all(paymentPs);
 
-    const paymentKeywordRecord = Object.fromEntries(
-      keywords.map((keyword, i) => [keyword, payments[i]]),
+    const paymentKeywordRecord = Data(
+      Object.fromEntries(keywords.map((keyword, i) => [keyword, payments[i]])),
     );
 
-    const seat = E(zoe).offer(
-      inviteP,
-      harden(proposal),
-      harden(paymentKeywordRecord),
-    );
+    const seat = E(zoe).offer(inviteP, harden(proposal), paymentKeywordRecord);
 
     // We'll resolve when deposited.
     const depositedP = E(seat)
@@ -586,7 +582,7 @@ export function makeWallet({
     if (already) {
       depositFacet = actions;
     } else {
-      depositFacet = harden({
+      depositFacet = Far('depositFacet', {
         receive(paymentP) {
           return E(actions).receive(paymentP);
         },
@@ -684,26 +680,28 @@ export function makeWallet({
 
   const compileProposal = proposalTemplate => {
     const {
-      want = {},
-      give = {},
+      want = Data({}),
+      give = Data({}),
       exit = { onDemand: null },
     } = proposalTemplate;
 
     const purseKeywordRecord = {};
 
     const compile = amountKeywordRecord => {
-      return Object.fromEntries(
-        Object.entries(amountKeywordRecord).map(
-          ([keyword, { pursePetname, value }]) => {
-            const purse = getPurse(pursePetname);
-            purseKeywordRecord[keyword] = purse;
-            const brand = purseToBrand.get(purse);
-            const amount = {
-              brand,
-              value,
-            };
-            return [keyword, amount];
-          },
+      return Data(
+        Object.fromEntries(
+          Object.entries(amountKeywordRecord).map(
+            ([keyword, { pursePetname, value }]) => {
+              const purse = getPurse(pursePetname);
+              purseKeywordRecord[keyword] = purse;
+              const brand = purseToBrand.get(purse);
+              const amount = {
+                brand,
+                value,
+              };
+              return [keyword, amount];
+            },
+          ),
         ),
       );
     };
@@ -778,7 +776,7 @@ export function makeWallet({
         origin,
         approvalP,
         enable: false,
-        actions: {
+        actions: Far('actions', {
           setPetname(petname) {
             if (dappRecord.petname === petname) {
               return dappRecord.actions;
@@ -824,7 +822,7 @@ export function makeWallet({
             updateDapp(dappRecord);
             return dappRecord.actions;
           },
-        },
+        }),
       };
 
       // Prepare the table entry to be updated.
@@ -1138,11 +1136,14 @@ export function makeWallet({
   };
 
   // Allow people to send us payments.
-  const selfContact = addContact('Self', {
-    receive(payment) {
-      return addPayment(payment);
-    },
-  });
+  const selfContact = addContact(
+    'Self',
+    Far('contact', {
+      receive(payment) {
+        return addPayment(payment);
+      },
+    }),
+  );
   async function getDepositFacetId(_brandBoardId) {
     // Always return the generic deposit facet.
     return E.G(selfContact).depositBoardId;
@@ -1278,8 +1279,8 @@ export function makeWallet({
     return selfContact;
   }
 
-  const makeManager = petnameMapping => {
-    const manager = {
+  const makeManager = (petnameMapping, managerType) => {
+    const manager = Far(managerType, {
       rename: async (petname, thing) => {
         petnameMapping.renamePetname(petname, thing);
         await updateAllState();
@@ -1290,18 +1291,21 @@ export function makeWallet({
         petnameMapping.suggestPetname(petname, thing);
         await updateAllState();
       },
-    };
-    return harden(manager);
+    });
+    return manager;
   };
 
   /** @type {InstallationManager} */
-  const installationManager = makeManager(installationMapping);
+  const installationManager = makeManager(
+    installationMapping,
+    'InstallationManager',
+  );
 
   /** @type {InstanceManager} */
-  const instanceManager = makeManager(instanceMapping);
+  const instanceManager = makeManager(instanceMapping, 'InstanceManager');
 
   /** @type {IssuerManager} */
-  const issuerManager = {
+  const issuerManager = Far('IssuerManager', {
     rename: async (petname, issuer) => {
       assert(
         brandTable.hasByIssuer(issuer),
@@ -1330,8 +1334,7 @@ export function makeWallet({
       brandMapping.suggestPetname(petname, brand);
       await updateAllIssuersState();
     },
-  };
-  harden(issuerManager);
+  });
 
   function getInstallationManager() {
     return installationManager;
@@ -1364,7 +1367,7 @@ export function makeWallet({
     return offerResult.uiNotifier;
   }
 
-  const wallet = harden({
+  const wallet = Far('wallet', {
     saveOfferResult,
     getOfferResult,
     waitForDappApproval,

--- a/packages/dapp-svelte-wallet/api/test/test-lib-dehydrate.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-dehydrate.js
@@ -11,9 +11,9 @@ test('makeDehydrator', async t => {
   const instanceHandleMapping = makeMapping('instanceHandle');
   const brandMapping = makeMapping('brand');
 
-  const handle1 = harden({});
-  const handle2 = harden({});
-  const handle3 = harden({});
+  const handle1 = Far('handle1');
+  const handle2 = Far('handle2');
+  const handle3 = Far('handle3');
   instanceHandleMapping.addPetname('simpleExchange', handle1);
   instanceHandleMapping.addPetname('atomicSwap', handle2);
   instanceHandleMapping.addPetname('automaticRefund', handle3);
@@ -21,7 +21,11 @@ test('makeDehydrator', async t => {
     message: /val \(an object\) already has a petname/,
   });
   t.throws(
-    () => instanceHandleMapping.addPetname('simpleExchange', harden({})),
+    () =>
+      instanceHandleMapping.addPetname(
+        'simpleExchange',
+        Far('simpleExchangeHandle'),
+      ),
     { message: /petname \(a string\) is already in use/ },
   );
 
@@ -38,7 +42,7 @@ test('makeDehydrator', async t => {
     `renaming is successful going from val to petname`,
   );
   t.throws(
-    () => instanceHandleMapping.renamePetname('new value', harden({})),
+    () => instanceHandleMapping.renamePetname('new value', Far('newHandle')),
     {
       message: /has not been previously named, would you like to add it instead\?/,
     },
@@ -58,7 +62,7 @@ test('makeDehydrator', async t => {
   );
 
   // Test deletion.
-  const temp = harden({});
+  const temp = Far('temp');
   instanceHandleMapping.addPetname('to be deleted', temp);
   t.is(
     instanceHandleMapping.valToPetname.get(temp),
@@ -67,7 +71,7 @@ test('makeDehydrator', async t => {
   );
   t.deepEqual(
     instanceHandleMapping.petnameToVal.get('to be deleted'),
-    handle1,
+    temp,
     `'to be deleted' present going from val to petname`,
   );
   instanceHandleMapping.deletePetname('to be deleted');
@@ -99,7 +103,8 @@ test('makeDehydrator', async t => {
   t.deepEqual(
     dehydrate(harden({ handle: handle1 })),
     {
-      body: '{"handle":{"@qclass":"slot","index":0}}',
+      body:
+        '{"handle":{"@qclass":"slot","iface":"Alleged: handle1","index":0}}',
       slots: [{ kind: 'instanceHandle', petname: 'simpleExchange' }],
     },
     `serialize val with petname`,
@@ -148,7 +153,7 @@ test('makeDehydrator', async t => {
     },
     exit: {
       afterDeadline: {
-        timer: {},
+        timer: Far('timer', {}),
         deadline: 55,
       },
     },
@@ -157,7 +162,7 @@ test('makeDehydrator', async t => {
     dehydrate(proposal),
     {
       body:
-        '{"exit":{"afterDeadline":{"deadline":55,"timer":{"@qclass":"slot","index":0}}},"give":{"Price":{"brand":{"@qclass":"slot","iface":"Alleged: mock brand","index":1},"value":3}},"want":{"Asset1":{"brand":{"@qclass":"slot","iface":"Alleged: mock brand","index":2},"value":60},"Asset2":{"brand":{"@qclass":"slot","iface":"Alleged: mock brand","index":3},"value":{"instanceHandle":{"@qclass":"slot","index":4}}}}}',
+        '{"exit":{"afterDeadline":{"deadline":55,"timer":{"@qclass":"slot","iface":"Alleged: timer","index":0}}},"give":{"Price":{"brand":{"@qclass":"slot","iface":"Alleged: mock brand","index":1},"value":3}},"want":{"Asset1":{"brand":{"@qclass":"slot","iface":"Alleged: mock brand","index":2},"value":60},"Asset2":{"brand":{"@qclass":"slot","iface":"Alleged: mock brand","index":3},"value":{"instanceHandle":{"@qclass":"slot","iface":"Alleged: handle3","index":4}}}}}',
       slots: [
         { kind: 'unnamed', petname: 'unnamed-1' },
         { kind: 'brand', petname: 'simolean' },
@@ -185,11 +190,12 @@ test('makeDehydrator', async t => {
     proposal,
     `hydrated proposal`,
   );
-  const handle4 = harden({});
+  const handle4 = Far('handle4');
   t.deepEqual(
     dehydrate(harden({ handle: handle4 })),
     {
-      body: '{"handle":{"@qclass":"slot","index":0}}',
+      body:
+        '{"handle":{"@qclass":"slot","iface":"Alleged: handle4","index":0}}',
       slots: [{ kind: 'unnamed', petname: 'unnamed-2' }],
     },
     `serialize val with no petname`,
@@ -209,7 +215,8 @@ test('makeDehydrator', async t => {
   t.deepEqual(
     dehydrate(harden({ handle: handle4 })),
     {
-      body: '{"handle":{"@qclass":"slot","index":0}}',
+      body:
+        '{"handle":{"@qclass":"slot","iface":"Alleged: handle4","index":0}}',
       slots: [{ kind: 'instanceHandle', petname: 'autoswap' }],
     },
     `serialize val with new petname`,

--- a/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
@@ -4,6 +4,7 @@ import '@agoric/install-ses'; // calls lockdown()
 import test from 'ava';
 import bundleSource from '@agoric/bundle-source';
 import { makeIssuerKit, makeLocalAmountMath } from '@agoric/ertp';
+import { Data } from '@agoric/marshal';
 
 import { makeZoe } from '@agoric/zoe';
 import fakeVatAdmin from '@agoric/zoe/src/contractFacet/fakeVatAdmin';
@@ -269,7 +270,7 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
 
       inviteHandleBoardId,
 
-      proposalTemplate: {},
+      proposalTemplate: Data({}),
     });
 
   const rawId = '1588645041696';
@@ -1190,7 +1191,7 @@ test('addOffer makeContinuingInvitation', async t => {
       instance,
       description: 'FirstThing',
     },
-    proposalTemplate: {},
+    proposalTemplate: Data({}),
   };
 
   await wallet.addOffer(offer);
@@ -1213,7 +1214,7 @@ test('addOffer makeContinuingInvitation', async t => {
       priorOfferId: rawId,
       description: 'SecondThing',
     },
-    proposalTemplate: {},
+    proposalTemplate: Data({}),
   };
 
   await wallet.addOffer(offer2);


### PR DESCRIPTION
I'm not sure this catches everything, but it allows the API unit tests to pass (while the `marshal.js` asserts are enabled).

refs #2018