### PR TITLE
fix(spawner): add enough Far/Data to pass tests

### DIFF
--- a/packages/spawner/package.json
+++ b/packages/spawner/package.json
@@ -36,6 +36,7 @@
     "@agoric/ertp": "^0.9.2",
     "@agoric/eventual-send": "^0.13.2",
     "@agoric/import-bundle": "^0.2.2",
+    "@agoric/marshal": "^0.3.2",
     "@agoric/nat": "^4.0.0",
     "@agoric/promise-kit": "^0.2.2",
     "@agoric/same-structure": "^0.1.2",

--- a/packages/spawner/src/contractHost.js
+++ b/packages/spawner/src/contractHost.js
@@ -4,6 +4,7 @@ import { importBundle } from '@agoric/import-bundle';
 import { makeWeakStore } from '@agoric/store';
 import { assert, details as X } from '@agoric/assert';
 import { allComparable } from '@agoric/same-structure';
+import { Far } from '@agoric/marshal';
 import { makeIssuerKit } from '@agoric/ertp';
 
 export { makeCollect } from './makeCollect';
@@ -59,7 +60,7 @@ function makeContractHost(vatPowers, additionalEndowments = {}) {
   // installation, which may die forever.
 
   /** The contract host is designed to have a long-lived credible identity. */
-  const contractHost = harden({
+  const contractHost = Far('contractHost', {
     getInvitationIssuer() {
       return inviteIssuer;
     },
@@ -136,7 +137,7 @@ function makeContractHost(vatPowers, additionalEndowments = {}) {
         const startFn = ns.default;
 
         return Promise.resolve(allComparable(termsP)).then(terms => {
-          const inviteMaker = harden({
+          const inviteMaker = Far('inviteMaker', {
             // Used by the contract to make invites for credibly
             // participating in the contract. The returned invite
             // can be redeemed for this seat. The inviteMaker
@@ -146,7 +147,7 @@ function makeContractHost(vatPowers, additionalEndowments = {}) {
             // accurate. The seatDesc is according to that
             // contractSrc code.
             make(seatDesc, seat) {
-              const seatIdentity = harden({});
+              const seatIdentity = Far('seat', {});
               const seatDescription = harden([
                 {
                   installation,
@@ -170,7 +171,7 @@ function makeContractHost(vatPowers, additionalEndowments = {}) {
       }
 
       installation.spawn = spawn;
-      harden(installation);
+      Far('installation', installation);
       installationSourceBundles.init(installation, contractBundle);
       return installation;
     },

--- a/packages/spawner/test/swingsetTests/contractHost/bootstrap.js
+++ b/packages/spawner/test/swingsetTests/contractHost/bootstrap.js
@@ -3,6 +3,7 @@
 import { E } from '@agoric/eventual-send';
 import { makeLocalAmountMath } from '@agoric/ertp';
 import { assert, details as X } from '@agoric/assert';
+import { Far } from '@agoric/marshal';
 import { bundleFunction } from '../../make-function-bundle';
 
 import { escrowExchangeSrcs } from '../../../src/escrow';
@@ -34,7 +35,7 @@ export function buildRootObject(vatPowers, vatParameters) {
     ]);
   }
 
-  const fakeNeverTimer = harden({
+  const fakeNeverTimer = Far('fakeNeverTimer', {
     setWakeup(deadline, _resolution = undefined) {
       log(`Pretend ${deadline} never happens`);
       return deadline;
@@ -354,7 +355,7 @@ export function buildRootObject(vatPowers, vatParameters) {
     });
   }
 
-  const obj0 = {
+  return Far('root', {
     async bootstrap(vats) {
       switch (vatParameters.argv[0]) {
         case 'trivial-oldformat': {
@@ -415,6 +416,5 @@ export function buildRootObject(vatPowers, vatParameters) {
         }
       }
     },
-  };
-  return harden(obj0);
+  });
 }

--- a/packages/spawner/test/swingsetTests/contractHost/vat-alice.js
+++ b/packages/spawner/test/swingsetTests/contractHost/vat-alice.js
@@ -1,6 +1,7 @@
 // Copyright (C) 2018 Agoric, under Apache License 2.0
 
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 import { allComparable } from '@agoric/same-structure';
 import { makeLocalAmountMath } from '@agoric/ertp';
 
@@ -21,7 +22,7 @@ function makeAliceMaker(host, log) {
     });
   }
 
-  return harden({
+  return Far('aliceMaker', {
     async make(
       escrowExchangeInstallationP,
       coveredCallInstallationP,
@@ -38,7 +39,7 @@ function makeAliceMaker(host, log) {
       const moneyMath = await makeLocalAmountMath(moneyIssuerP);
       const stockMath = await makeLocalAmountMath(stockIssuerP);
 
-      const alice = harden({
+      const alice = Far('alice', {
         payBobWell(bob) {
           log('++ alice.payBobWell starting');
           const paymentP = E(myMoneyPurseP).withdraw(moneyMath.make(10));
@@ -188,9 +189,9 @@ function makeAliceMaker(host, log) {
 }
 
 export function buildRootObject(vatPowers) {
-  return harden({
+  return Far('root', {
     makeAliceMaker(host) {
-      return harden(makeAliceMaker(host, vatPowers.log));
+      return makeAliceMaker(host, vatPowers.log);
     },
   });
 }

--- a/packages/spawner/test/swingsetTests/contractHost/vat-bob.js
+++ b/packages/spawner/test/swingsetTests/contractHost/vat-bob.js
@@ -2,6 +2,7 @@
 // Copyright (C) 2018 Agoric, under Apache License 2.0
 
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 import { makeLocalAmountMath } from '@agoric/ertp';
 
 import { assert, details as X } from '@agoric/assert';
@@ -10,7 +11,7 @@ import { makeCollect } from '../../../src/makeCollect';
 function makeBobMaker(host, log) {
   const collect = makeCollect(E, log);
 
-  return harden({
+  return Far('bobMaker', {
     async make(
       escrowExchangeInstallationP,
       coveredCallInstallationP,
@@ -26,7 +27,7 @@ function makeBobMaker(host, log) {
       const moneyNeeded = moneyMath.make(10);
       const stockNeeded = stockMath.make(7);
 
-      const bob = harden({
+      const bob = Far('bob', {
         /*
          * This is not an imperative to Bob to buy something but rather
          * the opposite. It is a request by a client to buy something from
@@ -109,9 +110,9 @@ function makeBobMaker(host, log) {
 }
 
 export function buildRootObject(vatPowers) {
-  return harden({
+  return Far('root', {
     makeBobMaker(host) {
-      return harden(makeBobMaker(host, vatPowers.log));
+      return makeBobMaker(host, vatPowers.log);
     },
   });
 }

--- a/packages/spawner/test/swingsetTests/contractHost/vat-fred.js
+++ b/packages/spawner/test/swingsetTests/contractHost/vat-fred.js
@@ -2,6 +2,7 @@
 // Copyright (C) 2018 Agoric, under Apache License 2.0
 
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 import { makeLocalAmountMath } from '@agoric/ertp';
 import { allComparable } from '@agoric/same-structure';
 
@@ -10,7 +11,7 @@ import { makeCollect } from '../../../src/makeCollect';
 function makeFredMaker(host, log) {
   const collect = makeCollect(E, log);
 
-  return harden({
+  return Far('fredMaker', {
     async make(
       escrowExchangeInstallationP,
       coveredCallInstallationP,
@@ -37,7 +38,7 @@ function makeFredMaker(host, log) {
       const wonka7 = stockMath.make(7);
       const fin55 = finMath.make(55);
 
-      const fred = harden({
+      const fred = Far('fred', {
         acceptOptionOffer(allegedSaleInvitePaymentP) {
           log('++ fred.acceptOptionOffer starting');
 
@@ -97,9 +98,9 @@ function makeFredMaker(host, log) {
 }
 
 export function buildRootObject(vatPowers) {
-  return harden({
+  return Far('root', {
     makeFredMaker(host) {
-      return harden(makeFredMaker(host, vatPowers.log));
+      return makeFredMaker(host, vatPowers.log);
     },
   });
 }

--- a/packages/spawner/test/swingsetTests/contractHost/vat-host.js
+++ b/packages/spawner/test/swingsetTests/contractHost/vat-host.js
@@ -1,11 +1,12 @@
 // Copyright (C) 2018 Agoric, under Apache License 2.0
 
+import { Far } from '@agoric/marshal';
 import { makeContractHost } from '../../../src/contractHost';
 
 export function buildRootObject(vatPowers) {
-  return harden({
+  return Far('root', {
     makeHost() {
-      return harden(makeContractHost(vatPowers));
+      return makeContractHost(vatPowers);
     },
   });
 }

--- a/packages/spawner/test/swingsetTests/contractHost/vat-mint.js
+++ b/packages/spawner/test/swingsetTests/contractHost/vat-mint.js
@@ -1,7 +1,8 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
+import { Far } from '@agoric/marshal';
 import { makeIssuerKit } from '@agoric/ertp';
 
 export function buildRootObject(_vatPowers) {
-  return harden({ makeIssuerKit });
+  return Far('root', { makeIssuerKit });
 }


### PR DESCRIPTION
I'm pretty sure this is incomplete: coveredCall.js and escrow.js lack Far()
calls around clearly pass-by-reference objects. It's not obvious how to add
them, because the functions therein are turned into source strings with plain
toString (backticks), so any reference to Far will result in an
undefined-global TypeError when the string is evaluated. To include Far
properly, these need to be sent through bundleSource() instead of a simple
toString.

But this doesn't seem to cause the unit tests to break, probably because 10
of the 14 tests are marked as test.skip. I'm going to PR this anyways,
because I think spawner is vestigal and is likely to be deleted entirely
before those tests are ever re-enabled.

refs #2018