### PR TITLE
fix(cosmic-swingset): apply Far/Data everywhere I could think of

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/vats/bridge.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bridge.js
@@ -3,6 +3,7 @@
 import makeStore from '@agoric/store';
 import '@agoric/store/exported';
 import { assert, details as X } from '@agoric/assert';
+import { Far } from '@agoric/marshal';
 
 /**
  * @template T
@@ -53,7 +54,7 @@ export function makeBridgeManager(E, D, bridgeDevice) {
     // No return value.
   }
 
-  const bridgeHandler = harden({ inbound: bridgeInbound });
+  const bridgeHandler = Far('bridgeHandler', { inbound: bridgeInbound });
 
   function callOutbound(dstID, obj) {
     assert(bridgeDevice, X`bridge device not yet connected`);
@@ -70,7 +71,7 @@ export function makeBridgeManager(E, D, bridgeDevice) {
   // We now manage the device.
   D(bridgeDevice).registerInboundHandler(bridgeHandler);
 
-  return harden({
+  return Far('bridgeManager', {
     toBridge(dstID, obj) {
       return callOutbound(dstID, obj);
     },

--- a/packages/cosmic-swingset/lib/ag-solo/vats/captp.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/captp.js
@@ -2,6 +2,7 @@
 // in its own makeHardener, etc.
 import { makeCapTP } from '@agoric/captp/lib/captp';
 import { E } from '@agoric/eventual-send';
+import { Data } from '@agoric/marshal';
 
 export const getCapTPHandler = (
   send,
@@ -11,7 +12,7 @@ export const getCapTPHandler = (
   const chans = new Map();
   const doFallback = async (method, ...args) => {
     if (!fallback) {
-      return {};
+      return Data({});
     }
     return E(fallback)[method](...args);
   };

--- a/packages/cosmic-swingset/lib/ag-solo/vats/ibc.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/ibc.js
@@ -8,6 +8,7 @@ import {
 import makeStore from '@agoric/store';
 import { makePromiseKit } from '@agoric/promise-kit';
 import { assert, details as X } from '@agoric/assert';
+import { Far } from '@agoric/marshal';
 
 import '@agoric/store/exported';
 import '@agoric/swingset-vat/src/vats/network/types';
@@ -176,7 +177,7 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
       onReceive = withChannelReceiveQueue(onReceive);
     }
 
-    return harden({
+    return Far('IBCConnectionHandler', {
       async onOpen(conn, localAddr, remoteAddr, _handler) {
         console.debug(
           'onOpen Remote IBC Connection',
@@ -244,7 +245,7 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
   /**
    * @type {ProtocolHandler}
    */
-  const protocol = harden({
+  const protocol = Far('ProtocolHandler', {
     async onCreate(impl, _protocolHandler) {
       console.debug('IBC onCreate');
       protocolImpl = impl;
@@ -378,7 +379,7 @@ EOF
     },
   });
 
-  return harden({
+  return Far('IBCProtocolHandler', {
     ...protocol,
     async fromBridge(srcID, obj) {
       console.info('IBC fromBridge', srcID, obj);

--- a/packages/cosmic-swingset/lib/ag-solo/vats/lib-board.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/lib-board.js
@@ -2,6 +2,7 @@
 
 import { generateSparseInts } from '@agoric/sparse-ints';
 import { assert, details as X, q } from '@agoric/assert';
+import { Far } from '@agoric/marshal';
 import makeStore from '@agoric/store';
 import { models as crcmodels } from 'polycrc';
 
@@ -40,7 +41,7 @@ function makeBoard(seed = 0) {
   const sparseInts = generateSparseInts(seed);
 
   /** @type {Board} */
-  const board = harden({
+  const board = Far('Board', {
     // Add if not already present
     getId: value => {
       if (!valToId.has(value)) {

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-board.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-board.js
@@ -1,6 +1,7 @@
+import { Far } from '@agoric/marshal';
 import { makeBoard } from './lib-board';
 
 export function buildRootObject(_vatPowers) {
   const board = makeBoard();
-  return harden({ getBoard: () => board });
+  return Far('board', { getBoard: () => board });
 }

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-host.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-host.js
@@ -1,11 +1,12 @@
 // Copyright (C) 2018 Agoric, under Apache License 2.0
 
+import { Far } from '@agoric/marshal';
 import { makeContractHost } from '@agoric/spawner';
 
 export function buildRootObject(vatPowers) {
-  return harden({
+  return Far('root', {
     makeHost() {
-      return harden(makeContractHost(vatPowers));
+      return makeContractHost(vatPowers);
     },
   });
 }

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-http.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-http.js
@@ -1,5 +1,6 @@
 import { makeNotifierKit } from '@agoric/notifier';
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
 import { getReplHandler } from './repl';
 import { getCapTPHandler } from './captp';
@@ -71,7 +72,7 @@ export function buildRootObject(vatPowers) {
     urlToHandler.set(url, commandHandler);
   }
 
-  return harden({
+  return Far('root', {
     setCommandDevice(d) {
       commandDevice = d;
 
@@ -79,7 +80,7 @@ export function buildRootObject(vatPowers) {
       registerURLHandler(replHandler, '/private/repl');
 
       // Assign the captp handler.
-      const captpHandler = harden({
+      const captpHandler = Far('captpHandler', {
         getBootstrap(_otherSide, _meta) {
           // Harden only our exported objects, and fetch them afresh each time.
           return harden(exportedToCapTP);
@@ -113,7 +114,7 @@ export function buildRootObject(vatPowers) {
         ...decentralObjects, // TODO: Remove; replaced by .agoric
         ...privateObjects, // TODO: Remove; replaced by .local
         ...handyObjects,
-        agoric: { ...decentralObjects },
+        agoric: { ...decentralObjects }, // TODO: maybe needs Data()???
         local: { ...privateObjects },
       };
 
@@ -161,7 +162,7 @@ export function buildRootObject(vatPowers) {
       try {
         let channelHandle = channelIdToHandle.get(rawChannelID);
         if (dispatcher === 'onOpen') {
-          channelHandle = harden({});
+          channelHandle = Far('channelHandle');
           channelIdToHandle.set(rawChannelID, channelHandle);
           channelHandleToId.set(channelHandle, rawChannelID);
         } else if (dispatcher === 'onClose') {

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-ibc.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-ibc.js
@@ -1,3 +1,4 @@
+import { Far } from '@agoric/marshal';
 import { E } from '@agoric/eventual-send';
 import { makeIBCProtocolHandler } from './ibc';
 
@@ -10,7 +11,7 @@ export function buildRootObject(_vatPowers) {
     );
     return harden(ibcHandler);
   }
-  return harden({
+  return Far('root', {
     createInstance,
   });
 }

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-mints.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-mints.js
@@ -1,3 +1,4 @@
+import { Far } from '@agoric/marshal';
 import { makeIssuerKit } from '@agoric/ertp';
 
 import makeStore from '@agoric/store';
@@ -8,7 +9,7 @@ import makeStore from '@agoric/store';
 export function buildRootObject(_vatPowers) {
   const mintsAndMath = makeStore('issuerName');
 
-  const api = harden({
+  const api = Far('api', {
     getAllIssuerNames: () => mintsAndMath.keys(),
     getIssuer: issuerName => {
       const mint = mintsAndMath.get(issuerName);

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-network.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-network.js
@@ -3,5 +3,5 @@ import { E } from '@agoric/eventual-send';
 import { makeRouterProtocol } from '@agoric/swingset-vat/src/vats/network/router';
 
 export function buildRootObject(_vatPowers) {
-  return harden(makeRouterProtocol(E));
+  return makeRouterProtocol(E); // already Far('Router')
 }

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-priceAuthority.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-priceAuthority.js
@@ -1,9 +1,10 @@
+import { Far } from '@agoric/marshal';
 import { makePriceAuthorityRegistry } from '@agoric/zoe/tools/priceAuthorityRegistry';
 import { makeFakePriceAuthority } from '@agoric/zoe/tools/fakePriceAuthority';
 import { makeLocalAmountMath } from '@agoric/ertp';
 
 export function buildRootObject(_vatPowers) {
-  return harden({
+  return Far('root', {
     makePriceAuthority: makePriceAuthorityRegistry,
     async makeFakePriceAuthority(options) {
       const { issuerIn, issuerOut } = options;

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-provisioning.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-provisioning.js
@@ -1,4 +1,5 @@
 import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
 
 // This vat contains the controller-side provisioning service. To enable local
 // testing, it is loaded by both the controller and other ag-solo vat machines.
@@ -16,7 +17,7 @@ export function buildRootObject(_vatPowers) {
 
   async function pleaseProvision(nickname, pubkey, powerFlags) {
     let chainBundle;
-    const fetch = harden({
+    const fetch = Far('fetch', {
       getDemoBundle() {
         return chainBundle;
       },
@@ -35,5 +36,5 @@ export function buildRootObject(_vatPowers) {
     return { ingressIndex: INDEX };
   }
 
-  return harden({ register, pleaseProvision });
+  return Far('root', { register, pleaseProvision });
 }

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-registrar.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-registrar.js
@@ -1,3 +1,4 @@
+import { Far } from '@agoric/marshal';
 import { makeRegistrar } from '@agoric/registrar';
 
 // This vat contains the registrar for the demo.
@@ -9,5 +10,5 @@ export function buildRootObject(_vatPowers) {
     return sharedRegistrar;
   }
 
-  return harden({ getSharedRegistrar });
+  return Far('root', { getSharedRegistrar });
 }

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-sharing.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-sharing.js
@@ -1,3 +1,4 @@
+import { Far } from '@agoric/marshal';
 import { makeSharingService } from '@agoric/sharing-service';
 
 // This vat contains the sharing service for the demo.
@@ -9,5 +10,5 @@ export function buildRootObject(_vatPowers) {
     return sharingService;
   }
 
-  return harden({ getSharingService });
+  return Far('root', { getSharingService });
 }

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-uploads.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-uploads.js
@@ -1,3 +1,4 @@
+import { Far } from '@agoric/marshal';
 import makeScratchPad from './scratch';
 
 // This vat contains the private upload scratch pad.
@@ -9,5 +10,5 @@ export function buildRootObject(_vatPowers) {
     return uploads;
   }
 
-  return harden({ getUploads });
+  return Far('root', { getUploads });
 }

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-zoe.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-zoe.js
@@ -1,7 +1,8 @@
+import { Far } from '@agoric/marshal';
 import { makeZoe } from '@agoric/zoe';
 
 export function buildRootObject(_vatPowers, vatParameters) {
-  return harden({
+  return Far('root', {
     buildZoe: adminVat => makeZoe(adminVat, vatParameters.zcfBundleName),
   });
 }

--- a/packages/cosmic-swingset/test/test-home.js
+++ b/packages/cosmic-swingset/test/test-home.js
@@ -2,6 +2,7 @@
 import '@agoric/install-ses';
 import test from 'ava';
 import bundleSource from '@agoric/bundle-source';
+import { Far } from '@agoric/marshal';
 
 import { makeFixture, E } from './captp-fixture';
 
@@ -44,7 +45,7 @@ test.serial('home.board', async t => {
     `using a non-verified id throws`,
   );
 
-  const myValue = {};
+  const myValue = Far('myValue', {});
   const myId = await E(board).getId(myValue);
   t.is(typeof myId, 'string', `board key is string`);
 

--- a/packages/cosmic-swingset/test/unitTests/test-lib-board.js
+++ b/packages/cosmic-swingset/test/unitTests/test-lib-board.js
@@ -3,13 +3,14 @@
 import '@agoric/install-ses';
 import test from 'ava';
 
+import { Far } from '@agoric/marshal';
 import { makeBoard } from '../../lib/ag-solo/vats/lib-board';
 
 test('makeBoard', async t => {
   const board = makeBoard();
 
-  const obj1 = harden({});
-  const obj2 = harden({});
+  const obj1 = Far('obj1', {});
+  const obj2 = Far('obj2', {});
 
   t.deepEqual(board.ids(), [], `board is empty to start`);
 


### PR DESCRIPTION
@michaelfig I added Far/Data everywhere I could think of, but the cosmic-swingset tests are still failing (with `marshal.js`'s throw-on-unmarked-empty-objects asserts uncommented). I think you can probably spot the problem faster than me, also I think there's a lot of code that isn't covered by the tests that I'd probably miss. Can you move this forward?

Switch to this branch, then apply the following patch to marshal.js:

```diff
diff --git a/packages/marshal/src/marshal.js b/packages/marshal/src/marshal.js
index 1cb78971..6b58d3f8 100644
--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -293,8 +293,8 @@ function isPassByCopyRecord(val) {
   // error, then (TODO) it will go back to pass-by-copy.
   // See https://github.com/Agoric/agoric-sdk/issues/2018
   if (descKeys.length === 0 && proto === objectPrototype) {
-    // console.log(`--- @@marshal: empty object without Data/Far/Remotable`);
-    // assert.fail(X`empty object without Data/Far/Remotable`);
+    console.log(`--- @@marshal: empty object without Data/Far/Remotable`);
+    assert.fail(X`empty object without Data/Far/Remotable`);
     return false;
   }
   for (const descKey of descKeys) {
@@ -512,8 +512,9 @@ export function passStyleOf(val) {
         return 'copyRecord';
       }
       assertRemotable(val);
-      // console.log(`--- @@marshal: pass-by-ref object without Far/Remotable`);
-      // assert.fail(X`pass-by-ref object without Far/Remotable`);
+      const desc = Object.entries(val).map(([k,v]) => `[${k}]=${v}`).concat(' , ');
+      console.log(`--- @@marshal: pass-by-ref [${desc}] object without Far/Remotable`, Error());
+      assert.fail(X`pass-by-ref object without Far/Remotable`);
       return REMOTE_STYLE;
     }
     case 'function': {
```

I've experimented with commenting out the asserts but leaving the logs in place, and then grepping the output. Let me know if I can help out, happy to pair on this.
