### PR TITLE
Patch vega d3 fix fixme

### DIFF
--- a/packages/swingset-runner/bin/runner
+++ b/packages/swingset-runner/bin/runner
@@ -10,14 +10,6 @@
 // LMDB bindings need to be imported before lockdown.
 import 'node-lmdb';
 
-// FIXME: Without importing vega ahead of lockdown,
-// node -r esm bin/runner --init --memdb run demo/encouragementBot
-// exits with error code 1, just printing `{}`.
-//
-// Since this started with ses@0.12.3 we suspect vega is somehow
-// hitting the override mistake with `constructor`.
-import 'vega';
-
 // Now do lockdown.
 import '../src/install-optional-metering-and-ses';
 import { main } from '../src/main.js';

--- a/patches/d3-color+2.0.0.patch
+++ b/patches/d3-color+2.0.0.patch
@@ -1,0 +1,18 @@
+diff --git a/node_modules/d3-color/dist/d3-color.js b/node_modules/d3-color/dist/d3-color.js
+index ba46026..5742b8c 100644
+--- a/node_modules/d3-color/dist/d3-color.js
++++ b/node_modules/d3-color/dist/d3-color.js
+@@ -7,7 +7,12 @@ typeof define === 'function' && define.amd ? define(['exports'], factory) :
+ 
+ function define(constructor, factory, prototype) {
+   constructor.prototype = factory.prototype = prototype;
+-  prototype.constructor = constructor;
++  Object.defineProperty(prototype, 'constructor', {
++    value: constructor,
++    writable: true,
++    enumerable: true,
++    configurable: true
++  });
+ }
+ 
+ function extend(parent, definition) {

--- a/patches/express+4.17.1.patch
+++ b/patches/express+4.17.1.patch
@@ -1,0 +1,28 @@
+diff --git a/node_modules/express/lib/router/index.js b/node_modules/express/lib/router/index.js
+index 69e6d38..085e61e 100644
+--- a/node_modules/express/lib/router/index.js
++++ b/node_modules/express/lib/router/index.js
+@@ -504,12 +504,17 @@ proto.route = function route(path) {
+ };
+ 
+ // create Router#VERB functions
+-methods.concat('all').forEach(function(method){
+-  proto[method] = function(path){
+-    var route = this.route(path)
+-    route[method].apply(route, slice.call(arguments, 1));
+-    return this;
+-  };
++methods.concat('all').forEach(function (method) {
++  Object.defineProperty(proto, method, {
++    value: function (path) {
++      var route = this.route(path)
++      route[method].apply(route, slice.call(arguments, 1));
++      return this;
++    },
++    writable: true,
++    enumerable: true,
++    configurable: true
++  });
+ });
+ 
+ // append methods to a list of methods

--- a/patches/external-editor+3.1.0.patch
+++ b/patches/external-editor+3.1.0.patch
@@ -1,0 +1,20 @@
+diff --git a/node_modules/external-editor/main/errors/CreateFileError.js b/node_modules/external-editor/main/errors/CreateFileError.js
+index 7faa34c..6686f9a 100644
+--- a/node_modules/external-editor/main/errors/CreateFileError.js
++++ b/node_modules/external-editor/main/errors/CreateFileError.js
+@@ -14,7 +14,14 @@ var __extends = (this && this.__extends) || (function () {
+     };
+     return function (d, b) {
+         extendStatics(d, b);
+-        function __() { this.constructor = d; }
++        function __() {
++          Object.defineProperty(this, 'constructor', {
++            value: d,
++            writable: true,
++            enumerable: true,
++            configurable: true
++          });
++        }
+         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+     };
+ })();

--- a/patches/external-editor+3.1.0.patch
+++ b/patches/external-editor+3.1.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/external-editor/main/errors/CreateFileError.js b/node_modules/external-editor/main/errors/CreateFileError.js
-index 7faa34c..6686f9a 100644
+index 7faa34c..7b49f68 100644
 --- a/node_modules/external-editor/main/errors/CreateFileError.js
 +++ b/node_modules/external-editor/main/errors/CreateFileError.js
 @@ -14,7 +14,14 @@ var __extends = (this && this.__extends) || (function () {
@@ -8,12 +8,32 @@ index 7faa34c..6686f9a 100644
          extendStatics(d, b);
 -        function __() { this.constructor = d; }
 +        function __() {
-+          Object.defineProperty(this, 'constructor', {
-+            value: d,
-+            writable: true,
-+            enumerable: true,
-+            configurable: true
-+          });
++            Object.defineProperty(this, 'constructor', {
++                value: d,
++                writable: true,
++                enumerable: true,
++                configurable: true
++            });
++        }
+         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+     };
+ })();
+diff --git a/node_modules/external-editor/main/errors/LaunchEditorError.js b/node_modules/external-editor/main/errors/LaunchEditorError.js
+index 85a164e..217f192 100644
+--- a/node_modules/external-editor/main/errors/LaunchEditorError.js
++++ b/node_modules/external-editor/main/errors/LaunchEditorError.js
+@@ -14,7 +14,14 @@ var __extends = (this && this.__extends) || (function () {
+     };
+     return function (d, b) {
+         extendStatics(d, b);
+-        function __() { this.constructor = d; }
++        function __() {
++            Object.defineProperty(this, 'constructor', {
++                value: d,
++                writable: true,
++                enumerable: true,
++                configurable: true
++            });
 +        }
          d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
      };

--- a/patches/node-fetch+2.6.1.patch
+++ b/patches/node-fetch+2.6.1.patch
@@ -1,15 +1,15 @@
 diff --git a/node_modules/node-fetch/lib/index.js b/node_modules/node-fetch/lib/index.js
-index 4b241bf..786320b 100644
+index 4b241bf..c5f1165 100644
 --- a/node_modules/node-fetch/lib/index.js
 +++ b/node_modules/node-fetch/lib/index.js
-@@ -153,9 +153,17 @@ function FetchError(message, type, systemError) {
+@@ -153,9 +153,23 @@ function FetchError(message, type, systemError) {
    Error.captureStackTrace(this, this.constructor);
  }
  
 -FetchError.prototype = Object.create(Error.prototype);
 -FetchError.prototype.constructor = FetchError;
 -FetchError.prototype.name = 'FetchError';
-+function makeErrorish(errorConstructor) {
++function makeErrorish(errorConstructor, name) {
 +  errorConstructor.prototype = Object.create(Error.prototype, {
 +    constructor: {
 +      value: errorConstructor,
@@ -17,13 +17,19 @@ index 4b241bf..786320b 100644
 +      enumerable: true,
 +      configurable: true
 +    },
++    name: {
++      value: name,
++      writable: true,
++      enumerable: true,
++      configurable: true
++    },
 +  });
 +}
-+makeErrorish(FetchError);
++makeErrorish(FetchError, 'FetchError');
  
  let convert;
  try {
-@@ -1378,10 +1386,7 @@ function AbortError(message) {
+@@ -1378,10 +1392,7 @@ function AbortError(message) {
    // hide custom error implementation details from end-users
    Error.captureStackTrace(this, this.constructor);
  }
@@ -31,7 +37,7 @@ index 4b241bf..786320b 100644
 -AbortError.prototype = Object.create(Error.prototype);
 -AbortError.prototype.constructor = AbortError;
 -AbortError.prototype.name = 'AbortError';
-+makeErrorish(AbortError);
++makeErrorish(AbortError, 'AbortError');
  
  // fix an issue where "PassThrough", "resolve" aren't a named export for node <10
  const PassThrough$1 = Stream.PassThrough;

--- a/patches/node-fetch+2.6.1.patch
+++ b/patches/node-fetch+2.6.1.patch
@@ -1,0 +1,37 @@
+diff --git a/node_modules/node-fetch/lib/index.js b/node_modules/node-fetch/lib/index.js
+index 4b241bf..786320b 100644
+--- a/node_modules/node-fetch/lib/index.js
++++ b/node_modules/node-fetch/lib/index.js
+@@ -153,9 +153,17 @@ function FetchError(message, type, systemError) {
+   Error.captureStackTrace(this, this.constructor);
+ }
+ 
+-FetchError.prototype = Object.create(Error.prototype);
+-FetchError.prototype.constructor = FetchError;
+-FetchError.prototype.name = 'FetchError';
++function makeErrorish(errorConstructor) {
++  errorConstructor.prototype = Object.create(Error.prototype, {
++    constructor: {
++      value: errorConstructor,
++      writable: true,
++      enumerable: true,
++      configurable: true
++    },
++  });
++}
++makeErrorish(FetchError);
+ 
+ let convert;
+ try {
+@@ -1378,10 +1386,7 @@ function AbortError(message) {
+   // hide custom error implementation details from end-users
+   Error.captureStackTrace(this, this.constructor);
+ }
+-
+-AbortError.prototype = Object.create(Error.prototype);
+-AbortError.prototype.constructor = AbortError;
+-AbortError.prototype.name = 'AbortError';
++makeErrorish(AbortError);
+ 
+ // fix an issue where "PassThrough", "resolve" aren't a named export for node <10
+ const PassThrough$1 = Stream.PassThrough;

--- a/patches/vega-util+1.16.0.patch
+++ b/patches/vega-util+1.16.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/vega-util/build/vega-util.js b/node_modules/vega-util/build/vega-util.js
-index 0b40c91..4e8694f 100644
+index 0b40c91..bd0a2e4 100644
 --- a/node_modules/vega-util/build/vega-util.js
 +++ b/node_modules/vega-util/build/vega-util.js
 @@ -611,7 +611,12 @@
@@ -37,7 +37,7 @@ index 0b40c91..4e8694f 100644
    exports.zoomSymlog = zoomSymlog;
  
 +  Object.defineProperties(exports, {
-+    hasOwnProperties: {
++    hasOwnProperty: {
 +      value: has,
 +      writable: true,
 +      enumerable: true,

--- a/patches/vega-util+1.16.0.patch
+++ b/patches/vega-util+1.16.0.patch
@@ -1,0 +1,56 @@
+diff --git a/node_modules/vega-util/build/vega-util.js b/node_modules/vega-util/build/vega-util.js
+index 0b40c91..4e8694f 100644
+--- a/node_modules/vega-util/build/vega-util.js
++++ b/node_modules/vega-util/build/vega-util.js
+@@ -611,7 +611,12 @@
+ 
+   function inherits (child, parent, members) {
+     const proto = child.prototype = Object.create(parent.prototype);
+-    proto.constructor = child;
++    Object.defineProperty(proto, 'constructor', {
++      value: child,
++      writable: true,
++      enumerable: true,
++      configurable: true
++    });
+     return extend(proto, members);
+   }
+ 
+@@ -859,7 +864,6 @@
+   exports.fastmap = fastmap;
+   exports.field = field;
+   exports.flush = flush;
+-  exports.hasOwnProperty = has;
+   exports.id = id;
+   exports.identity = identity;
+   exports.inherits = inherits;
+@@ -895,7 +899,6 @@
+   exports.toDate = toDate;
+   exports.toNumber = toNumber;
+   exports.toSet = toSet;
+-  exports.toString = toString;
+   exports.truncate = truncate;
+   exports.truthy = truthy;
+   exports.utcquarter = utcquarter;
+@@ -907,6 +910,21 @@
+   exports.zoomPow = zoomPow;
+   exports.zoomSymlog = zoomSymlog;
+ 
++  Object.defineProperties(exports, {
++    hasOwnProperties: {
++      value: has,
++      writable: true,
++      enumerable: true,
++      configurable: true
++    },
++    toString: {
++      value: toString,
++      writable: true,
++      enumerable: true,
++      configurable: true
++    }
++  });
++
+   Object.defineProperty(exports, '__esModule', { value: true });
+ 
+ })));


### PR DESCRIPTION
Found and patched where vega-util was overriding `Object.constructor` by assignment.
Fixing that uncovered same problem with d3-color. Same patch.

vega-util was also overriding two other frozen primordial properties by assignment, `hasOwnProperties` and `toString`. Patched both, although `toString` is a hopeless cause. But fixing `hasOwnProperties` means SES can stop enabling it, further reducing vscode debugger's object inspector noise.

Fixes #2556 

Fixes the FIXME kludge added to bin/runner at 
https://github.com/Agoric/agoric-sdk/pull/2552/files/84f9ccf388e6aeb71b5aabb2a552e5ec36d4fa9f#r585869497

See 
https://github.com/vega/vega/issues/3075
https://github.com/Agoric/SES-shim/issues/576