### PR TITLE
Variation of ses-ava test with deep stacks

### DIFF
--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@agoric/assert": "^0.2.2",
     "@agoric/install-ses": "^0.5.2",
+    "@agoric/ses-ava": "^0.1.0+1-dev",
     "ava": "^3.12.1",
     "esm": "^3.2.7",
     "nyc": "^15.1.0",

--- a/packages/eventual-send/test/test-ses-ava-reject-deep-stacks.js
+++ b/packages/eventual-send/test/test-ses-ava-reject-deep-stacks.js
@@ -1,0 +1,69 @@
+import { wrapTest } from '@agoric/ses-ava';
+import '@agoric/install-ses';
+import rawTest from 'ava';
+// import { E } from './get-hp';
+
+// This file is a variation of the `test-ses-ava-reject` from the
+// `@agoric/ses-ava` package. The difference is that this test
+// uses `E.when` rather than `then` to demonstrate deep stacks.
+
+const test = wrapTest(rawTest);
+
+test('ses-ava reject console output', t => {
+  t.assert(true);
+  // Uncomment this to see something like the text in the extended comment below
+
+  /*
+  return E.when(Promise.resolve(null), v1 =>
+    E.when(v1, v2 =>
+      E.when(v2, _ => {
+        assert.typeof(88, 'string', assert.details`msg ${'NOTICE ME'}`);
+      }),
+    ),
+  );
+  */
+});
+
+/*
+Uncommenting the test code above should produce something like the following.
+Some of this output still comes from ava. The stack-like display comes from
+the SES `console`, which shows the detailed error message including the
+redacted `'NOTICE ME'` that ava has no access to.
+```
+REJECTED from ava test: (TypeError#1)
+TypeError#1: msg NOTICE ME
+  at packages/eventual-send/test/test-ses-ava-reject-deep-stacks.js:29:22
+
+TypeError#1 ERROR_NOTE: Thrown from: (Error#2) : 3 . 0
+TypeError#1 ERROR_NOTE: Rejection from: (Error#3) : 2 . 1
+TypeError#1 ERROR_NOTE: Rejection from: (Error#4) : 1 . 1
+Nested 3 errors under TypeError#1
+  Error#2: Event: 2.1
+    at packages/eventual-send/test/test-ses-ava-reject-deep-stacks.js:28:9
+
+  Error#2 ERROR_NOTE: Caused by: (Error#3)
+  Nested error under Error#2
+    Error#3: Event: 1.1
+      at packages/eventual-send/test/test-ses-ava-reject-deep-stacks.js:27:7
+
+    Error#3 ERROR_NOTE: Caused by: (Error#4)
+    Nested error under Error#3
+      Error#4: Event: 0.1
+        at packages/eventual-send/test/test-ses-ava-reject-deep-stacks.js:26:12
+        at async Promise.all (index 0)
+
+  ses-ava reject console output
+
+  Rejected promise returned by test. Reason:
+
+  TypeError {
+    message: 'msg (a string)',
+  }
+
+  › packages/eventual-send/test/test-ses-ava-reject-deep-stacks.js:29:22
+
+  ─
+
+  1 test failed
+```
+*/

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,6 +29,13 @@
   resolved "https://registry.yarnpkg.com/@agoric/nat/-/nat-4.0.0.tgz#330dcde37fcf8882dbc5012a3b2c4c135eee4930"
   integrity sha512-zlTe14g0PGfONO0+TdhLv8k4IZH040ojvBZuNrcQSV+l8HlFTZ/IKzI5HorlCVDDBU7riykAb/6MaTgMRbYp3w==
 
+"@agoric/ses-ava@^0.1.0+1-dev":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@agoric/ses-ava/-/ses-ava-0.1.0.tgz#e6e905167379b42ed6926b7f5bb9f64713c3a436"
+  integrity sha512-uQcXariKortUFD6AOb2LD5riJW2J1KLFuoIOtXgQcI4aVv33Q33WajNWr5HsY0stGvaqoDvfQ5heGjc3lovIbw==
+  dependencies:
+    ses "^0.12.3"
+
 "@agoric/transform-module@^0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@agoric/transform-module/-/transform-module-0.4.1.tgz#9fb152364faf372e1bda535cb4ef89717724f57c"


### PR DESCRIPTION
Modeled on https://github.com/endojs/endo/blob/master/packages/ses-ava/test/test-ses-ava-reject.js but with `E.when` rather than `.then` in order to show deep stacks.

Until https://github.com/Agoric/SES-shim/issues/579 is fixed, both comment out the code being tested because when it is not commented out it causes the ava failure that is the point of the test, but this means that `yarn test` fails and therefore that CI fails.