### PR TITLE
store: refuse keys that are empty pass-by-copy objects

### DIFF
--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -32,7 +32,8 @@
   },
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "dependencies": {
-    "@agoric/assert": "^0.2.2"
+    "@agoric/assert": "^0.2.2",
+    "@agoric/marshal": "^0.3.2"
   },
   "devDependencies": {
     "@agoric/install-ses": "^0.5.2",

--- a/packages/store/src/helpers.js
+++ b/packages/store/src/helpers.js
@@ -1,0 +1,21 @@
+// @ts-check
+
+import { getInterfaceOf } from '@agoric/marshal';
+
+/**
+ * Helper function to reject keys which are empty objects but not marked as
+ * Remotable. This is intended to catch code which uses harden({}) (which
+ * will become pass-by-copy, see #2018) as a "handle" or "marker object"
+ * when they should have used Far().
+ *
+ * @param { unknown } key
+ */
+export function isEmptyNonRemotableObject(key) {
+  return (
+    typeof key === 'object' &&
+    key !== null &&
+    Reflect.ownKeys(key).length === 0 &&
+    getInterfaceOf(key) === undefined
+  );
+}
+harden(isEmptyNonRemotableObject);

--- a/packages/store/src/store.js
+++ b/packages/store/src/store.js
@@ -3,6 +3,7 @@
 // @ts-check
 
 import { assert, details as X, q } from '@agoric/assert';
+import { isEmptyNonRemotableObject } from './helpers';
 
 /**
  * Distinguishes between adding a new key (init) and updating or
@@ -21,21 +22,30 @@ export function makeStore(keyName = 'key') {
     assert(!store.has(key), X`${q(keyName)} already registered: ${key}`);
   const assertKeyExists = key =>
     assert(store.has(key), X`${q(keyName)} not found: ${key}`);
+  const assertNotBadKey = key =>
+    assert(!isEmptyNonRemotableObject(key), X`${q(keyName)} bad key: ${key}`);
   return harden({
-    has: key => store.has(key),
+    has: key => {
+      assertNotBadKey(key);
+      return store.has(key);
+    },
     init: (key, value) => {
+      assertNotBadKey(key);
       assertKeyDoesNotExist(key);
       store.set(key, value);
     },
     get: key => {
+      assertNotBadKey(key);
       assertKeyExists(key);
       return store.get(key);
     },
     set: (key, value) => {
+      assertNotBadKey(key);
       assertKeyExists(key);
       store.set(key, value);
     },
     delete: key => {
+      assertNotBadKey(key);
       assertKeyExists(key);
       store.delete(key);
     },

--- a/packages/store/src/weak-store.js
+++ b/packages/store/src/weak-store.js
@@ -3,6 +3,7 @@
 // @ts-check
 
 import { assert, details as X, q } from '@agoric/assert';
+import { isEmptyNonRemotableObject } from './helpers';
 import './types';
 
 /**
@@ -17,21 +18,30 @@ export function makeWeakStore(keyName = 'key') {
     assert(!wm.has(key), X`${q(keyName)} already registered: ${key}`);
   const assertKeyExists = key =>
     assert(wm.has(key), X`${q(keyName)} not found: ${key}`);
+  const assertNotBadKey = key =>
+    assert(!isEmptyNonRemotableObject(key), X`${q(keyName)} bad key: ${key}`);
   return harden({
-    has: key => wm.has(key),
+    has: key => {
+      assertNotBadKey(key);
+      return wm.has(key);
+    },
     init: (key, value) => {
+      assertNotBadKey(key);
       assertKeyDoesNotExist(key);
       wm.set(key, value);
     },
     get: key => {
+      assertNotBadKey(key);
       assertKeyExists(key);
       return wm.get(key);
     },
     set: (key, value) => {
+      assertNotBadKey(key);
       assertKeyExists(key);
       wm.set(key, value);
     },
     delete: key => {
+      assertNotBadKey(key);
       assertKeyExists(key);
       wm.delete(key);
     },

--- a/packages/store/test/test-store.js
+++ b/packages/store/test/test-store.js
@@ -1,0 +1,85 @@
+// @ts-check
+/* eslint-disable no-use-before-define */
+import '@agoric/install-ses';
+import test from 'ava';
+import { makeStore, makeWeakStore } from '../src/index';
+import '../src/types';
+
+function check(t, mode, objMaker) {
+  // Check the full API, and make sure object identity isn't a problem by
+  // creating two potentially-similar things for use as keys.
+  let s;
+  if (mode === 'strong') {
+    s = makeStore('store1');
+  } else if (mode === 'weak') {
+    s = makeWeakStore('store1');
+  } else {
+    throw Error(`unknown mode ${mode}`);
+  }
+  const k1 = objMaker(1);
+  const k2 = objMaker(2);
+
+  function checkEntries(entries) {
+    if (mode === 'strong') {
+      t.deepEqual(new Set(s.keys()), new Set(entries.map(([k, _v]) => k)));
+      t.deepEqual(new Set(s.values()), new Set(entries.map(([_k, v]) => v)));
+      t.deepEqual(new Set(s.entries()), new Set(entries));
+    }
+  }
+
+  checkEntries([]);
+
+  s.init(k1, 'one');
+  t.truthy(s.has(k1));
+  t.is(s.get(k1), 'one');
+  t.falsy(s.has(k2));
+  checkEntries([[k1, 'one']]);
+
+  t.throws(() => s.init(k1, 'other'), {
+    message: /"store1" already registered:/,
+  });
+  t.throws(() => s.get(k2), { message: /"store1" not found:/ });
+  t.throws(() => s.set(k2, 'other'), { message: /"store1" not found:/ });
+  t.throws(() => s.delete(k2), { message: /"store1" not found:/ });
+
+  s.init(k2, 'two');
+  t.truthy(s.has(k1));
+  t.truthy(s.has(k2));
+  t.is(s.get(k1), 'one');
+  t.is(s.get(k2), 'two');
+  checkEntries([
+    [k1, 'one'],
+    [k2, 'two'],
+  ]);
+
+  s.set(k1, 'oneplus');
+  t.truthy(s.has(k1));
+  t.truthy(s.has(k2));
+  t.is(s.get(k1), 'oneplus');
+  t.is(s.get(k2), 'two');
+  checkEntries([
+    [k1, 'oneplus'],
+    [k2, 'two'],
+  ]);
+
+  s.delete(k1);
+  t.falsy(s.has(k1));
+  t.truthy(s.has(k2));
+  t.is(s.get(k2), 'two');
+  checkEntries([[k2, 'two']]);
+
+  s.delete(k2);
+  t.falsy(s.has(k1));
+  t.falsy(s.has(k2));
+  checkEntries([]);
+}
+
+test('store', t => {
+  // makeStore
+  check(t, 'strong', count => count); // simple numeric keys
+  check(t, 'strong', count => `${count}`); // simple strings
+  check(t, 'strong', () => harden({}));
+
+  // makeWeakStore
+  check(t, 'weak', () => harden({}));
+});


### PR DESCRIPTION
To protect against surprises when we change `harden({})` from pass-by-reference to pass-by-copy (#2018), @michaelfig and I figured that the simplest safety measure would be to have `store`/`weakstore` refuse such keys.

This branch adds these checks, as well as a bunch of unit tests (it appeared to have none before).

I could use some help from a TypeScript guru, I can't seem to find a way to satisfy the signature of the helper function.
