### PR TITLE
Add more typing to @agoric/marshal

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "packages/agoric-cli",
     "packages/deployment",
     "packages/notifier",
-    "packages/xs-vat-worker",
     "packages/xsnap",
     "packages/deploy-script-support"
   ],

--- a/packages/assert/src/types.js
+++ b/packages/assert/src/types.js
@@ -90,7 +90,7 @@
  * @param {any} specimen
  * @param {'object'} typename
  * @param {Details=} optDetails
- * @returns {asserts specimen is object}
+ * @returns {asserts specimen is Record<any, any> | null}
  *
  * @callback AssertTypeofString
  * @param {any} specimen

--- a/packages/marshal/src/extra-types.d.ts
+++ b/packages/marshal/src/extra-types.d.ts
@@ -1,0 +1,3 @@
+// This type cannot be declared in pure JSDoc.
+// It's a recursive array type.
+declare type NestedArray<T> = Array<T | NestedArray<T>>;

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -1018,7 +1018,11 @@ export function makeMarshal(
             );
             const result = ibidTable.start({});
             result[QCLASS] = fullRevive(rawTree.original);
-            if (rawTree.rest !== undefined) {
+            if ('rest' in rawTree) {
+              assert(
+                rawTree.rest !== undefined,
+                X`Rest encoding must not be undefined`,
+              );
               const rest = fullRevive(rawTree.rest);
               // TODO really should assert that `passStyleOf(rest)` is
               // `'copyRecord'` but we'd have to harden it and it is too

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -404,6 +404,7 @@ function assertCanBeRemotable(val) {
       X`cannot serialize objects with getters like ${q(String(key))} in ${val}`,
     );
     assert.typeof(
+      // @ts-ignore https://github.com/microsoft/TypeScript/issues/1863
       val[key],
       'function',
       X`cannot serialize objects with non-methods like ${q(
@@ -658,6 +659,7 @@ export function makeMarshal(
     let slotIndex;
     if (slotMap.has(val)) {
       slotIndex = slotMap.get(val);
+      assert.typeof(slotIndex, 'number');
     } else {
       const slot = convertValToSlot(val);
 
@@ -708,12 +710,6 @@ export function makeMarshal(
     const ibidTable = makeReplacerIbidTable();
 
     /**
-     * Just consists of data that rounds trips to plain data.
-     *
-     * @typedef {any} PlainJSONData
-     */
-
-    /**
      * Must encode `val` into plain JSON data *canonically*, such that
      * `sameStructure(v1, v2)` implies
      * `JSON.stringify(encode(v1)) === JSON.stringify(encode(v2))`
@@ -724,7 +720,7 @@ export function makeMarshal(
      * a canonical-json stringify of the encoded form.
      *
      * @param {Passable} val
-     * @returns {PlainJSONData}
+     * @returns {Encoding}
      */
     const encode = val => {
       // First we handle all primitives. Some can be represented directly as

--- a/packages/marshal/src/types.js
+++ b/packages/marshal/src/types.js
@@ -55,7 +55,7 @@
  */
 
 /**
- * @typedef {SOMETHING} Remotable
+ * @typedef {*} Remotable
  * Might be an object explicitly deemed to be `Remotable`, an object inferred
  * to be Remotable, or a remote presence of a Remotable.
  */
@@ -83,27 +83,35 @@
  */
 
 /**
- * @typedef Encoding
+ * @template T
+ * @typedef {{ '@qclass': T }} QCLASS
+ */
+
+/**
+ * @typedef {QCLASS<'NaN'> |
+ * QCLASS<'undefined'> |
+ * QCLASS<'Infinity'> |
+ * QCLASS<'-Infinity'> |
+ * QCLASS<'bigint'> & { digits: string } |
+ * QCLASS<'@@asyncIterator'> |
+ * QCLASS<'ibid'> & { index: number } |
+ * QCLASS<'error'> & { name: string, message: string, errorId?: string } |
+ * QCLASS<'slot'> & { index: number, iface?: InterfaceSpec } |
+ * QCLASS<'hilbert'> & { original: Encoding, rest?: Encoding } |
+ * null | string | boolean | number | EncodingRecord} EncodingElement
+ * @typedef {{ [index: string]: Encoding | undefined, '@qclass'?: undefined }} EncodingRecord
+ * We exclude '@qclass' as a property in encoding records.
+ */
+
+/**
+ * @template T
+ * @typedef {Array<T | NestedArray<T>>} NestedArray Helper type to produce
+ * recursive arrays
+ */
+
+/**
+ * @typedef {EncodingElement | NestedArray<EncodingElement>} Encoding
  * The JSON structure that the data portion of a Passable serializes to.
- *
- * TODO turn into a discriminated union type
- *   { [QCLASS]: 'undefined' }
- * | { [QCLASS]: 'NaN' }
- * | { [QCLASS]: 'Infinity' }
- * | { [QCLASS]: '-Infinity' }
- * | { [QCLASS]: 'bigint', digits: string }
- *   // Likely to generalize to more symbols
- * | { [QCLASS]: '@@asyncIterator' }
- *   // Should be path rather than index
- * | { [QCLASS]: 'ibid', index: number }
- * | { [QCLASS]: 'error', name: string, message: string, errorId? string }
- * | { [QCLASS]: 'slot', index: number, iface? InterfaceSpec }
- * | { [QCLASS]: 'hilbert', original: Encoding, rest? Record<string, Encoding> }
- *   // Primitive values directly encodable in JSON
- * | null | string | boolean | number
- * | Encoding[]
- *   // excluding QCLASS as a property name
- * | Record<string, Encoding>
  *
  * The QCLASS 'hilbert' is a reference to the Hilbert Hotel
  * of https://www.ias.edu/ideas/2016/pires-hilbert-hotel

--- a/packages/marshal/src/types.js
+++ b/packages/marshal/src/types.js
@@ -1,3 +1,6 @@
+// eslint-disable-next-line spaced-comment
+/// <reference path="extra-types.d.ts" />
+
 /**
  * @typedef { "bigint" | "boolean" | "null" | "number" | "string" | "symbol" | "undefined" | "copyArray" | "copyRecord" | "copyError" | "promise" | "presence" } PassStyle
  * TODO "presence" above should indirect through REMOTE_STYLE to prepare
@@ -101,12 +104,6 @@
  * @typedef {{ [index: string]: Encoding, '@qclass'?: undefined }} EncodingRecord
  * We exclude '@qclass' as a property in encoding records.
  * @typedef {EncodingUnion | null | string | boolean | number | EncodingRecord} EncodingElement
- */
-
-/**
- * @template T
- * @typedef {Array<T | NestedArray<T>>} NestedArray Helper type to produce
- * recursive arrays
  */
 
 /**

--- a/packages/marshal/src/types.js
+++ b/packages/marshal/src/types.js
@@ -84,23 +84,23 @@
 
 /**
  * @template T
- * @typedef {{ '@qclass': T }} QCLASS
+ * @typedef {{ '@qclass': T }} EncodingClass
  */
 
 /**
- * @typedef {QCLASS<'NaN'> |
- * QCLASS<'undefined'> |
- * QCLASS<'Infinity'> |
- * QCLASS<'-Infinity'> |
- * QCLASS<'bigint'> & { digits: string } |
- * QCLASS<'@@asyncIterator'> |
- * QCLASS<'ibid'> & { index: number } |
- * QCLASS<'error'> & { name: string, message: string, errorId?: string } |
- * QCLASS<'slot'> & { index: number, iface?: InterfaceSpec } |
- * QCLASS<'hilbert'> & { original: Encoding, rest?: Encoding } |
- * null | string | boolean | number | EncodingRecord} EncodingElement
- * @typedef {{ [index: string]: Encoding | undefined, '@qclass'?: undefined }} EncodingRecord
+ * @typedef {EncodingClass<'NaN'> |
+ * EncodingClass<'undefined'> |
+ * EncodingClass<'Infinity'> |
+ * EncodingClass<'-Infinity'> |
+ * EncodingClass<'bigint'> & { digits: string } |
+ * EncodingClass<'@@asyncIterator'> |
+ * EncodingClass<'ibid'> & { index: number } |
+ * EncodingClass<'error'> & { name: string, message: string, errorId?: string } |
+ * EncodingClass<'slot'> & { index: number, iface?: InterfaceSpec } |
+ * EncodingClass<'hilbert'> & { original: Encoding, rest?: Encoding }} EncodingUnion
+ * @typedef {{ [index: string]: Encoding, '@qclass'?: undefined }} EncodingRecord
  * We exclude '@qclass' as a property in encoding records.
+ * @typedef {EncodingUnion | null | string | boolean | number | EncodingRecord} EncodingElement
  */
 
 /**

--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -233,6 +233,7 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
             'object',
             X`gains ${gains} must be an amountKeywordRecord`,
           );
+          assert(gains !== null, X`gains cannot be null`);
           if (zcfSeat === undefined) {
             zcfSeat = makeEmptySeatKit().zcfSeat;
           }
@@ -271,6 +272,7 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
             'object',
             X`losses ${losses} must be an amountKeywordRecord`,
           );
+          assert(losses !== null, X`losses cannot be null`);
           let totalToBurn = mintyAmountMath.getEmpty();
           const oldAllocation = zcfSeat.getCurrentAllocation();
           const updates = objectMap(


### PR DESCRIPTION
Fully type the return value of marshal's encode.

This also fixes the typing of `assert.typeof(xxx, 'object')`, which revealed a few minor not-null assumptions in Zoe.
