### PR TITLE
test(cosmic-swingset): more robustness around termination

### DIFF
--- a/packages/cosmic-swingset/test/captp-fixture.js
+++ b/packages/cosmic-swingset/test/captp-fixture.js
@@ -9,8 +9,7 @@ const PORT = 7999;
 // Ensure we're all using the same HandledPromise.
 export { E };
 
-export async function makeFixture() {
-  const noisy = process.env.NOISY;
+export async function makeFixture(noisy = false) {
   const accessToken = await getAccessToken(PORT);
 
   let expectedToExit = false;

--- a/packages/cosmic-swingset/test/test-home.js
+++ b/packages/cosmic-swingset/test/test-home.js
@@ -8,7 +8,7 @@ import { makeFixture, E } from './captp-fixture';
 let home;
 let teardown;
 test.before('setup', async t => {
-  const { homeP, kill } = await makeFixture();
+  const { homeP, kill } = await makeFixture(process.env.NOISY);
   teardown = kill;
   home = await homeP;
   t.truthy('ready');


### PR DESCRIPTION
Closes #2581

Help ensure old ag-solos aren't left running if tests are interrupted.
