### PR TITLE
Make powerful globals explicit

### DIFF
--- a/golang/cosmos/src/index.js
+++ b/golang/cosmos/src/index.js
@@ -1,1 +1,2 @@
+/* global module require */
 module.exports = require('bindings')('agcosmosdaemon.node');

--- a/packages/ERTP/test/swingsetTests/splitPayments/test-splitPayments.js
+++ b/packages/ERTP/test/swingsetTests/splitPayments/test-splitPayments.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import test from 'ava';
 import { loadBasedir, buildVatController } from '@agoric/swingset-vat';
 import path from 'path';

--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -1,3 +1,4 @@
+/* global require */
 import fs from 'fs';
 import process from 'process';
 import re2 from 're2';

--- a/packages/SwingSet/src/devices/bridge.js
+++ b/packages/SwingSet/src/devices/bridge.js
@@ -1,3 +1,4 @@
+/* global require */
 /*
   The 'bridge' devices provides bidirectional function calls between objects
   on the host and code within a swingset.

--- a/packages/SwingSet/src/devices/command.js
+++ b/packages/SwingSet/src/devices/command.js
@@ -1,3 +1,4 @@
+/* global require */
 import { makePromiseKit } from '@agoric/promise-kit';
 import { Nat } from '@agoric/nat';
 

--- a/packages/SwingSet/src/devices/loopbox.js
+++ b/packages/SwingSet/src/devices/loopbox.js
@@ -1,3 +1,4 @@
+/* global require */
 import { assert, details as X } from '@agoric/assert';
 
 /*

--- a/packages/SwingSet/src/devices/mailbox.js
+++ b/packages/SwingSet/src/devices/mailbox.js
@@ -1,3 +1,4 @@
+/* global require */
 /*
   The 'mailbox' device helps manage bidirectional communication with a number
   of 'peers'. Each peer is identified with a string. We exchange ordered

--- a/packages/SwingSet/src/devices/plugin.js
+++ b/packages/SwingSet/src/devices/plugin.js
@@ -1,3 +1,4 @@
+/* global require */
 export function buildPlugin(pluginDir, pluginRequire, queueThunkForKernel) {
   const srcPath = require.resolve('./plugin-src');
   let resetter;

--- a/packages/SwingSet/src/devices/timer.js
+++ b/packages/SwingSet/src/devices/timer.js
@@ -1,3 +1,4 @@
+/* global require */
 import { Nat } from '@agoric/nat';
 
 import { assert, details as X } from '@agoric/assert';

--- a/packages/SwingSet/src/initializeSwingset.js
+++ b/packages/SwingSet/src/initializeSwingset.js
@@ -1,3 +1,4 @@
+/* global require */
 import fs from 'fs';
 import path from 'path';
 

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-nodeworker-cjs.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-nodeworker-cjs.js
@@ -1,3 +1,4 @@
+/* global module require */
 // `tap` and `node -r esm` were able to allow the swingset process to create
 // a thread (`new Worker()`) from the (ESM) supervisor file without problems,
 // but for some reason AVA cannot. The file loaded into the new thread

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
@@ -1,3 +1,4 @@
+/* global globalThis */
 // @ts-check
 import { assert, details as X } from '@agoric/assert';
 import { importBundle } from '@agoric/import-bundle';

--- a/packages/SwingSet/src/main.js
+++ b/packages/SwingSet/src/main.js
@@ -1,1 +1,2 @@
+/* global module require */
 module.exports = require('./index.js');

--- a/packages/SwingSet/src/netstring.js
+++ b/packages/SwingSet/src/netstring.js
@@ -1,3 +1,4 @@
+/* global require Buffer */
 import { assert, details as X } from '@agoric/assert';
 
 // adapted from 'netstring-stream', https://github.com/tlivings/netstring-stream/

--- a/packages/SwingSet/src/waitUntilQuiescent.js
+++ b/packages/SwingSet/src/waitUntilQuiescent.js
@@ -1,3 +1,4 @@
+/* global setImmediate */
 import { makePromiseKit } from '@agoric/promise-kit';
 
 // This can only be imported from the Start Compartment, where 'setImmediate'

--- a/packages/SwingSet/src/weakref.js
+++ b/packages/SwingSet/src/weakref.js
@@ -1,3 +1,4 @@
+/* global globalThis */
 import { assert, details as X } from '@agoric/assert';
 
 const { defineProperties } = Object;

--- a/packages/SwingSet/src/worker-protocol.js
+++ b/packages/SwingSet/src/worker-protocol.js
@@ -1,3 +1,4 @@
+/* global Buffer */
 import { Transform } from 'stream';
 
 // Transform objects which convert from hardened Arrays of JSON-serializable

--- a/packages/SwingSet/test/definition/test-vat-definition.js
+++ b/packages/SwingSet/test/definition/test-vat-definition.js
@@ -1,3 +1,4 @@
+/* global require */
 import '@agoric/install-ses';
 import test from 'ava';
 import { buildVatController } from '../../src/index';

--- a/packages/SwingSet/test/device-plugin/test-device.js
+++ b/packages/SwingSet/test/device-plugin/test-device.js
@@ -1,3 +1,4 @@
+/* global require __dirname */
 import '@agoric/install-ses';
 import test from 'ava';
 import { initSwingStore } from '@agoric/swing-store-simple';

--- a/packages/SwingSet/test/metering/test-dynamic-vat-metered.js
+++ b/packages/SwingSet/test/metering/test-dynamic-vat-metered.js
@@ -1,3 +1,4 @@
+/* global require */
 import '@agoric/install-metering-and-ses';
 import bundleSource from '@agoric/bundle-source';
 import { initSwingStore } from '@agoric/swing-store-simple';

--- a/packages/SwingSet/test/metering/test-dynamic-vat-subcompartment.js
+++ b/packages/SwingSet/test/metering/test-dynamic-vat-subcompartment.js
@@ -1,3 +1,4 @@
+/* global require */
 import '@agoric/install-metering-and-ses';
 import bundleSource from '@agoric/bundle-source';
 import test from 'ava';

--- a/packages/SwingSet/test/metering/test-dynamic-vat-unmetered.js
+++ b/packages/SwingSet/test/metering/test-dynamic-vat-unmetered.js
@@ -1,3 +1,4 @@
+/* global require */
 import '@agoric/install-metering-and-ses';
 import bundleSource from '@agoric/bundle-source';
 import test from 'ava';

--- a/packages/SwingSet/test/metering/test-metering.js
+++ b/packages/SwingSet/test/metering/test-metering.js
@@ -1,3 +1,4 @@
+/* global require */
 // eslint-disable-next-line import/order
 import { replaceGlobalMeter } from './install-global-metering';
 import '@agoric/install-ses';

--- a/packages/SwingSet/test/metering/test-within-vat.js
+++ b/packages/SwingSet/test/metering/test-within-vat.js
@@ -1,3 +1,4 @@
+/* global require */
 import '@agoric/install-metering-and-ses';
 import bundleSource from '@agoric/bundle-source';
 import test from 'ava';

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -1,3 +1,4 @@
+/* global require __dirname */
 import '@agoric/install-ses';
 import test from 'ava';
 import path from 'path';

--- a/packages/SwingSet/test/test-demos-comms.js
+++ b/packages/SwingSet/test/test-demos-comms.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import '@agoric/install-ses';
 import { initSwingStore } from '@agoric/swing-store-simple';
 import test from 'ava';

--- a/packages/SwingSet/test/test-demos.js
+++ b/packages/SwingSet/test/test-demos.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import '@agoric/install-ses';
 import { initSwingStore } from '@agoric/swing-store-simple';
 import test from 'ava';

--- a/packages/SwingSet/test/test-device-bridge.js
+++ b/packages/SwingSet/test/test-device-bridge.js
@@ -1,3 +1,4 @@
+/* global require */
 import '@agoric/install-ses';
 import test from 'ava';
 import { initSwingStore } from '@agoric/swing-store-simple';

--- a/packages/SwingSet/test/test-devices.js
+++ b/packages/SwingSet/test/test-devices.js
@@ -1,3 +1,4 @@
+/* global require */
 import '@agoric/install-ses';
 import test from 'ava';
 import bundleSource from '@agoric/bundle-source';

--- a/packages/SwingSet/test/test-exomessages.js
+++ b/packages/SwingSet/test/test-exomessages.js
@@ -1,3 +1,4 @@
+/* global require */
 import '@agoric/install-ses';
 import test from 'ava';
 import { buildVatController } from '../src/index';

--- a/packages/SwingSet/test/test-marshal.js
+++ b/packages/SwingSet/test/test-marshal.js
@@ -1,3 +1,4 @@
+/* global setImmediate */
 import '@agoric/install-ses';
 import { Far } from '@agoric/marshal';
 import test from 'ava';

--- a/packages/SwingSet/test/test-message-patterns.js
+++ b/packages/SwingSet/test/test-message-patterns.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 /* eslint no-await-in-loop: "off" */
 /* eslint dot-notation: "off" */
 /* eslint object-shorthand: "off" */

--- a/packages/SwingSet/test/test-netstring.js
+++ b/packages/SwingSet/test/test-netstring.js
@@ -1,3 +1,4 @@
+/* global Buffer */
 import '@agoric/install-ses'; // adds 'harden' to global
 
 import test from 'ava';

--- a/packages/SwingSet/test/test-promises.js
+++ b/packages/SwingSet/test/test-promises.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import '@agoric/install-ses';
 import test from 'ava';
 import path from 'path';

--- a/packages/SwingSet/test/test-syscall-failure.js
+++ b/packages/SwingSet/test/test-syscall-failure.js
@@ -1,3 +1,4 @@
+/* global require */
 import '@agoric/install-ses';
 import test from 'ava';
 import { initSwingStore } from '@agoric/swing-store-simple';

--- a/packages/SwingSet/test/test-tildot.js
+++ b/packages/SwingSet/test/test-tildot.js
@@ -1,3 +1,4 @@
+/* global require */
 import '@agoric/install-ses';
 import test from 'ava';
 import { buildVatController } from '../src/index';

--- a/packages/SwingSet/test/test-transcript-light.js
+++ b/packages/SwingSet/test/test-transcript-light.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import '@agoric/install-ses';
 import test from 'ava';
 import path from 'path';

--- a/packages/SwingSet/test/test-transcript.js
+++ b/packages/SwingSet/test/test-transcript.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import '@agoric/install-ses';
 import test from 'ava';
 import path from 'path';

--- a/packages/SwingSet/test/test-vattp.js
+++ b/packages/SwingSet/test/test-vattp.js
@@ -1,3 +1,4 @@
+/* global require */
 import '@agoric/install-ses';
 import test from 'ava';
 import { initSwingStore } from '@agoric/swing-store-simple';

--- a/packages/SwingSet/test/test-worker-protocol.js
+++ b/packages/SwingSet/test/test-worker-protocol.js
@@ -1,3 +1,4 @@
+/* global Buffer */
 import '@agoric/install-ses'; // adds 'harden' to global
 
 import test from 'ava';

--- a/packages/SwingSet/test/timer-device/test-device.js
+++ b/packages/SwingSet/test/timer-device/test-device.js
@@ -1,3 +1,4 @@
+/* global require */
 import '@agoric/install-ses';
 import test from 'ava';
 import { initSwingStore } from '@agoric/swing-store-simple';

--- a/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
+++ b/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import '@agoric/install-ses';
 import path from 'path';
 import test from 'ava';

--- a/packages/SwingSet/test/vat-admin/test-innerVat.js
+++ b/packages/SwingSet/test/vat-admin/test-innerVat.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import '@agoric/install-metering-and-ses';
 import path from 'path';
 import test from 'ava';

--- a/packages/SwingSet/test/vat-admin/test-replay.js
+++ b/packages/SwingSet/test/vat-admin/test-replay.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import '@agoric/install-metering-and-ses';
 import path from 'path';
 import test from 'ava';

--- a/packages/SwingSet/test/virtualObjects/test-representatives.js
+++ b/packages/SwingSet/test/virtualObjects/test-representatives.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import '@agoric/install-ses';
 import path from 'path';
 import test from 'ava';

--- a/packages/SwingSet/test/workers/test-worker.js
+++ b/packages/SwingSet/test/workers/test-worker.js
@@ -1,3 +1,4 @@
+/* global require __dirname */
 import '@agoric/install-ses';
 import test from 'ava';
 import { loadBasedir, buildVatController } from '../../src/index';

--- a/packages/SwingSet/tools/prepare-test-env.js
+++ b/packages/SwingSet/tools/prepare-test-env.js
@@ -1,3 +1,4 @@
+/* global globalThis */
 /**
  * Prepare Agoric SwingSet vat global environment for testing.
  *

--- a/packages/acorn-eventual-send/index.js
+++ b/packages/acorn-eventual-send/index.js
@@ -1,3 +1,4 @@
+/* global module */
 const tilde = '~'.charCodeAt(0);
 const dot = '.'.charCodeAt(0);
 const zero = '0'.charCodeAt(0);

--- a/packages/acorn-eventual-send/test/test-rollup.js
+++ b/packages/acorn-eventual-send/test/test-rollup.js
@@ -1,3 +1,4 @@
+/* global require */
 import test from 'ava';
 import { rollup } from 'rollup/dist/rollup.es';
 import * as acorn from 'acorn';

--- a/packages/agoric-cli/integration-tests/test-workflow.js
+++ b/packages/agoric-cli/integration-tests/test-workflow.js
@@ -1,3 +1,4 @@
+/* global __dirname process setTimeout clearTimeout setInterval clearInterval */
 /* eslint-disable import/no-extraneous-dependencies */
 import '@agoric/install-ses';
 import test from 'ava';

--- a/packages/agoric-cli/lib/anylogger-agoric.js
+++ b/packages/agoric-cli/lib/anylogger-agoric.js
@@ -1,3 +1,4 @@
+/* global process */
 import anylogger from 'anylogger';
 import chalk from 'chalk';
 

--- a/packages/agoric-cli/lib/deploy.js
+++ b/packages/agoric-cli/lib/deploy.js
@@ -1,3 +1,4 @@
+/* global require process setTimeout setInterval clearInterval */
 /* eslint-disable no-await-in-loop */
 import { E, makeCapTP } from '@agoric/captp';
 import { makePromiseKit } from '@agoric/promise-kit';

--- a/packages/agoric-cli/lib/entrypoint.js
+++ b/packages/agoric-cli/lib/entrypoint.js
@@ -1,3 +1,4 @@
+/* global process */
 import '@agoric/install-ses';
 
 import path from 'path';

--- a/packages/agoric-cli/lib/helpers.js
+++ b/packages/agoric-cli/lib/helpers.js
@@ -1,3 +1,4 @@
+/* global process */
 // @ts-check
 
 /** @typedef {import('child_process').ChildProcess} ChildProcess */

--- a/packages/agoric-cli/lib/install.js
+++ b/packages/agoric-cli/lib/install.js
@@ -1,3 +1,4 @@
+/* global __dirname process */
 import path from 'path';
 import chalk from 'chalk';
 import { makePspawn } from './helpers';

--- a/packages/agoric-cli/lib/main.js
+++ b/packages/agoric-cli/lib/main.js
@@ -1,3 +1,4 @@
+/* global __dirname process */
 import { Command } from 'commander';
 
 import { assert, details as X } from '@agoric/assert';

--- a/packages/agoric-cli/lib/open.js
+++ b/packages/agoric-cli/lib/open.js
@@ -1,3 +1,4 @@
+/* global process setInterval clearInterval */
 import { promises as defaultFs } from 'fs';
 import opener from 'opener';
 import crypto from 'crypto';

--- a/packages/agoric-cli/lib/start.js
+++ b/packages/agoric-cli/lib/start.js
@@ -1,3 +1,4 @@
+/* global __dirname process setTimeout */
 import path from 'path';
 import chalk from 'chalk';
 import { createHash } from 'crypto';

--- a/packages/agoric-cli/test/test-main.js
+++ b/packages/agoric-cli/test/test-main.js
@@ -1,3 +1,4 @@
+/* global globalThis */
 import test from 'ava';
 import '@agoric/install-ses';
 import fs from 'fs';

--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -1,3 +1,4 @@
+/* global globalThis */
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 // @ts-check
 

--- a/packages/bundle-source/demo/dir1/sub/more.js
+++ b/packages/bundle-source/demo/dir1/sub/more.js
@@ -1,3 +1,4 @@
+/* global exports require */
 const things = require('./things.js');
 
 exports.more = `have more ${things.description}`;

--- a/packages/bundle-source/demo/dir1/sub/things.js
+++ b/packages/bundle-source/demo/dir1/sub/things.js
@@ -1,1 +1,2 @@
+/* global exports */
 exports.description = 'many different things';

--- a/packages/bundle-source/src/index.js
+++ b/packages/bundle-source/src/index.js
@@ -1,3 +1,4 @@
+/* global process */
 import fs from 'fs';
 import { rollup as rollup0 } from 'rollup';
 import path from 'path';

--- a/packages/bundle-source/test/sanity.js
+++ b/packages/bundle-source/test/sanity.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 // 'lockdown' appears on the global as a side-effect of importing 'ses'
 import 'ses';
 

--- a/packages/bundle-source/test/test-bigint-transform.js
+++ b/packages/bundle-source/test/test-bigint-transform.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import '@agoric/install-ses';
 import test from 'ava';
 import bundleSource from '..';

--- a/packages/bundle-source/test/test-circular.js
+++ b/packages/bundle-source/test/test-circular.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import '@agoric/install-ses';
 import test from 'ava';
 import bundleSource from '..';

--- a/packages/bundle-source/test/test-comment.js
+++ b/packages/bundle-source/test/test-comment.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import '@agoric/install-ses';
 import test from 'ava';
 import bundleSource from '..';

--- a/packages/bundle-source/test/test-external-fs.js
+++ b/packages/bundle-source/test/test-external-fs.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import '@agoric/install-ses';
 import test from 'ava';
 import bundleSource from '..';

--- a/packages/bundle-source/test/test-tildot-transform.js
+++ b/packages/bundle-source/test/test-tildot-transform.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import '@agoric/install-ses';
 import test from 'ava';
 import bundleSource from '..';

--- a/packages/cosmic-swingset/calc-gci.js
+++ b/packages/cosmic-swingset/calc-gci.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* global require */
 
 const fs = require('fs');
 const djson = require('deterministic-json');

--- a/packages/cosmic-swingset/calc-rpcport.js
+++ b/packages/cosmic-swingset/calc-rpcport.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* global require */
 
 // NOTE: Runs outside SES
 

--- a/packages/cosmic-swingset/lib/ag-solo/add-chain.js
+++ b/packages/cosmic-swingset/lib/ag-solo/add-chain.js
@@ -1,3 +1,4 @@
+/* global process */
 import fetch from 'node-fetch';
 import crypto from 'crypto';
 import djson from 'deterministic-json';

--- a/packages/cosmic-swingset/lib/ag-solo/batched-deliver.js
+++ b/packages/cosmic-swingset/lib/ag-solo/batched-deliver.js
@@ -1,3 +1,4 @@
+/* global setTimeout clearTimeout */
 const DEFAULT_BATCH_TIMEOUT_MS = 1000;
 
 export function makeBatchedDeliver(

--- a/packages/cosmic-swingset/lib/ag-solo/chain-cosmos-sdk.js
+++ b/packages/cosmic-swingset/lib/ag-solo/chain-cosmos-sdk.js
@@ -1,3 +1,4 @@
+/* global setTimeout */
 import path from 'path';
 import fs from 'fs';
 import { execFile } from 'child_process';

--- a/packages/cosmic-swingset/lib/ag-solo/entrypoint.js
+++ b/packages/cosmic-swingset/lib/ag-solo/entrypoint.js
@@ -1,4 +1,5 @@
 #! /usr/bin/env node
+/* global module require */
 
 const esmRequire = require('esm')(module);
 

--- a/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
+++ b/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
@@ -1,3 +1,4 @@
+/* global process setTimeout clearTimeout */
 /* eslint-disable no-await-in-loop */
 import path from 'path';
 import fs from 'fs';

--- a/packages/cosmic-swingset/lib/ag-solo/html/main.js
+++ b/packages/cosmic-swingset/lib/ag-solo/html/main.js
@@ -1,3 +1,4 @@
+/* global setTimeout */
 // NOTE: Runs outside SES
 
 /* global WebSocket fetch document window walletFrame localStorage */

--- a/packages/cosmic-swingset/lib/ag-solo/init-basedir.js
+++ b/packages/cosmic-swingset/lib/ag-solo/init-basedir.js
@@ -1,3 +1,4 @@
+/* global __dirname Buffer */
 import fs from 'fs';
 import path from 'path';
 import { execFileSync } from 'child_process';

--- a/packages/cosmic-swingset/lib/ag-solo/main.js
+++ b/packages/cosmic-swingset/lib/ag-solo/main.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import fs from 'fs';
 import path from 'path';
 import parseArgs from 'minimist';

--- a/packages/cosmic-swingset/lib/ag-solo/start.js
+++ b/packages/cosmic-swingset/lib/ag-solo/start.js
@@ -1,3 +1,4 @@
+/* global require process setTimeout */
 import fs from 'fs';
 import path from 'path';
 import temp from 'temp';

--- a/packages/cosmic-swingset/lib/ag-solo/web.js
+++ b/packages/cosmic-swingset/lib/ag-solo/web.js
@@ -1,3 +1,4 @@
+/* global require setTimeout clearTimeout setInterval clearInterval */
 // Start a network service
 import path from 'path';
 import http from 'http';

--- a/packages/cosmic-swingset/lib/anylogger-agoric.js
+++ b/packages/cosmic-swingset/lib/anylogger-agoric.js
@@ -1,3 +1,4 @@
+/* global process */
 import anylogger from 'anylogger';
 
 // Turn on debugging output with DEBUG=agoric

--- a/packages/cosmic-swingset/lib/chain-entrypoint.js
+++ b/packages/cosmic-swingset/lib/chain-entrypoint.js
@@ -1,4 +1,5 @@
 #! /usr/bin/env node
+/* global module require process */
 
 const esmRequire = require('esm')(module);
 

--- a/packages/cosmic-swingset/lib/chain-main.js
+++ b/packages/cosmic-swingset/lib/chain-main.js
@@ -1,3 +1,4 @@
+/* global __dirname setInterval */
 import stringify from '@agoric/swingset-vat/src/kernel/json-stable-stringify';
 import {
   importMailbox,

--- a/packages/cosmic-swingset/test/captp-fixture.js
+++ b/packages/cosmic-swingset/test/captp-fixture.js
@@ -1,3 +1,4 @@
+/* global __dirname process setTimeout */
 import { spawn } from 'child_process';
 import WebSocket from 'ws';
 import { makeCapTP, E } from '@agoric/captp';

--- a/packages/cosmic-swingset/test/test-home.js
+++ b/packages/cosmic-swingset/test/test-home.js
@@ -1,3 +1,4 @@
+/* global require */
 import '@agoric/install-ses';
 import test from 'ava';
 import bundleSource from '@agoric/bundle-source';

--- a/packages/cosmic-swingset/test/test-home.js
+++ b/packages/cosmic-swingset/test/test-home.js
@@ -1,4 +1,4 @@
-/* global require */
+/* global require process */
 import '@agoric/install-ses';
 import test from 'ava';
 import bundleSource from '@agoric/bundle-source';

--- a/packages/cosmic-swingset/test/test-make.js
+++ b/packages/cosmic-swingset/test/test-make.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import test from 'ava';
 import { spawn } from 'child_process';
 

--- a/packages/dapp-svelte-wallet/api/deploy.js
+++ b/packages/dapp-svelte-wallet/api/deploy.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 // @ts-nocheck
 // Agoric wallet deployment script.
 // FIXME: This is just hacked together for the legacy wallet.

--- a/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
@@ -1,3 +1,4 @@
+/* global require */
 // @ts-check
 import '@agoric/install-ses'; // calls lockdown()
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/deploy-script-support/src/helpers.js
+++ b/packages/deploy-script-support/src/helpers.js
@@ -1,3 +1,4 @@
+/* global require */
 // @ts-check
 import '@agoric/zoe/exported';
 import { E } from '@agoric/eventual-send';

--- a/packages/deploy-script-support/test/unitTests/test-install.js
+++ b/packages/deploy-script-support/test/unitTests/test-install.js
@@ -1,3 +1,4 @@
+/* global require */
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/deploy-script-support/test/unitTests/test-offer.js
+++ b/packages/deploy-script-support/test/unitTests/test-offer.js
@@ -1,3 +1,4 @@
+/* global require */
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/deploy-script-support/test/unitTests/test-resolvePathForLocalContract.js
+++ b/packages/deploy-script-support/test/unitTests/test-resolvePathForLocalContract.js
@@ -1,3 +1,4 @@
+/* global require */
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/deploy-script-support/test/unitTests/test-resolvePathForPackagedContract.js
+++ b/packages/deploy-script-support/test/unitTests/test-resolvePathForPackagedContract.js
@@ -1,3 +1,4 @@
+/* global require */
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/deploy-script-support/test/unitTests/test-startInstance.js
+++ b/packages/deploy-script-support/test/unitTests/test-startInstance.js
@@ -1,3 +1,4 @@
+/* global require */
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/deployment/init.js
+++ b/packages/deployment/init.js
@@ -1,3 +1,4 @@
+/* global process */
 import fetch from 'node-fetch';
 import inquirer from 'inquirer';
 import { assert, details as X } from '@agoric/assert';

--- a/packages/deployment/main.js
+++ b/packages/deployment/main.js
@@ -1,3 +1,4 @@
+/* global __dirname process */
 /* eslint-disable no-await-in-loop */
 import inquirer from 'inquirer';
 import djson from 'deterministic-json';

--- a/packages/deployment/run.js
+++ b/packages/deployment/run.js
@@ -1,3 +1,4 @@
+/* global process */
 import { exec as rawExec, spawn } from 'child_process';
 import { Writable } from 'stream';
 

--- a/packages/deployment/setup.js
+++ b/packages/deployment/setup.js
@@ -1,3 +1,4 @@
+/* global __dirname process setInterval */
 import chalk from 'chalk';
 import { resolve } from './files';
 

--- a/packages/eslint-config/eslint-config.json
+++ b/packages/eslint-config/eslint-config.json
@@ -7,16 +7,23 @@
   ],
   "parser": "@typescript-eslint/parser",
   "env": {
-    "es6": true
+    "es6": true,
+    "node": false,
+    "commonjs": false
   },
   "globals": {
     "globalThis": "readonly",
     "BigInt": "readonly",
     "assert": "readonly",
+    "console": "readonly",
     "harden": "readonly",
     "lockdown": "readonly",
     "Compartment": "readonly",
-    "StaticModuleRecord": "readonly"
+    "StaticModuleRecord": "readonly",
+    "TextDecoder": "readonly",
+    "TextEncoder": "readonly",
+    "URL": "readonly",
+    "URLSearchParams": "readonly"
   },
   "rules": {
     "quotes": [

--- a/packages/eslint-config/eslint-config.json
+++ b/packages/eslint-config/eslint-config.json
@@ -12,7 +12,6 @@
     "commonjs": false
   },
   "globals": {
-    "globalThis": "readonly",
     "BigInt": "readonly",
     "assert": "readonly",
     "console": "readonly",

--- a/packages/eventual-send/integration-test/pre-release-browser-tests/rollup/rollup.config.test.js
+++ b/packages/eventual-send/integration-test/pre-release-browser-tests/rollup/rollup.config.test.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import path from 'path';
 
 /* eslint-disable-next-line import/no-unresolved */

--- a/packages/eventual-send/integration-test/pre-release-browser-tests/webpack/webpack.config.js
+++ b/packages/eventual-send/integration-test/pre-release-browser-tests/webpack/webpack.config.js
@@ -1,3 +1,4 @@
+/* global __dirname module require */
 const path = require('path');
 
 module.exports = {

--- a/packages/eventual-send/integration-test/test/utility/test-bundler.js
+++ b/packages/eventual-send/integration-test/test/utility/test-bundler.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 /* eslint-disable-next-line import/no-unresolved, import/no-extraneous-dependencies */
 import puppeteer from 'puppeteer';
 /* eslint-disable-next-line import/no-unresolved, import/no-extraneous-dependencies */

--- a/packages/eventual-send/integration-test/transform-tests/config/rollup.config.no-lib.js
+++ b/packages/eventual-send/integration-test/transform-tests/config/rollup.config.no-lib.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 /* eslint-disable-next-line import/no-unresolved */
 import replace from 'rollup-plugin-replace';
 import path from 'path';

--- a/packages/eventual-send/shim.js
+++ b/packages/eventual-send/shim.js
@@ -1,3 +1,4 @@
+/* global globalThis */
 import { makeHandledPromise } from './src/index';
 
 if (typeof HandledPromise === 'undefined') {

--- a/packages/eventual-send/src/track-turns.js
+++ b/packages/eventual-send/src/track-turns.js
@@ -1,3 +1,4 @@
+/* global globalThis */
 // @ts-nocheck
 
 // NOTE: We can't import these because they're not in scope before lockdown.

--- a/packages/eventual-send/test/test-eventual-send.js
+++ b/packages/eventual-send/test/test-eventual-send.js
@@ -1,3 +1,4 @@
+/* global setTimeout */
 import '@agoric/install-ses';
 import test from 'ava';
 import { assert, details as X } from '@agoric/assert';

--- a/packages/import-bundle/test/bundle1.js
+++ b/packages/import-bundle/test/bundle1.js
@@ -1,4 +1,4 @@
-/* global endow1 */
+/* global globalThis endow1 */
 
 import { bundle2Add, bundle2Transform, bundle2ReadGlobal } from './bundle2.js';
 

--- a/packages/import-bundle/test/bundle2.js
+++ b/packages/import-bundle/test/bundle2.js
@@ -1,3 +1,4 @@
+/* global globalThis */
 export function bundle2Add(a) {
   return a + 2;
 }

--- a/packages/import-bundle/test/test-import-bundle.js
+++ b/packages/import-bundle/test/test-import-bundle.js
@@ -1,3 +1,4 @@
+/* global require */
 import '@agoric/install-ses';
 import { encodeBase64 } from '@agoric/base64';
 import * as fs from 'fs';

--- a/packages/promise-kit/src/promiseKit.js
+++ b/packages/promise-kit/src/promiseKit.js
@@ -1,3 +1,4 @@
+/* global globalThis */
 // @ts-check
 
 // eslint-disable-next-line spaced-comment

--- a/packages/sharing-service/test/swingsetTests/sharingService/test-sharing.js
+++ b/packages/sharing-service/test/swingsetTests/sharingService/test-sharing.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import '@agoric/install-ses';
 import test from 'ava';
 import path from 'path';

--- a/packages/spawner/test/swingsetTests/contractHost/test-contractHost.js
+++ b/packages/spawner/test/swingsetTests/contractHost/test-contractHost.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import '@agoric/install-metering-and-ses';
 import test from 'ava';
 import path from 'path';

--- a/packages/spawner/test/swingsetTests/escrow/test-escrow.js
+++ b/packages/spawner/test/swingsetTests/escrow/test-escrow.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import '@agoric/install-ses';
 import test from 'ava';
 import { buildVatController, loadBasedir } from '@agoric/swingset-vat';

--- a/packages/stat-logger/src/statGraph.js
+++ b/packages/stat-logger/src/statGraph.js
@@ -1,3 +1,4 @@
+/* global process */
 import fs from 'fs';
 import path from 'path';
 import * as vega from 'vega';

--- a/packages/swingset-runner/demo/exchangeBenchmark/prepareContracts.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/prepareContracts.js
@@ -1,3 +1,4 @@
+/* global require __dirname */
 import '@agoric/install-ses';
 import bundleSource from '@agoric/bundle-source';
 

--- a/packages/swingset-runner/demo/swapBenchmark/prepareContracts.js
+++ b/packages/swingset-runner/demo/swapBenchmark/prepareContracts.js
@@ -1,3 +1,4 @@
+/* global require __dirname */
 import '@agoric/install-ses';
 import bundleSource from '@agoric/bundle-source';
 

--- a/packages/swingset-runner/demo/zoeTests/prepareContracts.js
+++ b/packages/swingset-runner/demo/zoeTests/prepareContracts.js
@@ -1,3 +1,4 @@
+/* global require __dirname */
 import '@agoric/install-ses';
 import bundleSource from '@agoric/bundle-source';
 

--- a/packages/swingset-runner/src/main.js
+++ b/packages/swingset-runner/src/main.js
@@ -1,4 +1,4 @@
-/* global __dirname */
+/* global globalThis __dirname */
 import path from 'path';
 import fs from 'fs';
 import process from 'process';

--- a/packages/swingset-runner/src/main.js
+++ b/packages/swingset-runner/src/main.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import path from 'path';
 import fs from 'fs';
 import process from 'process';
@@ -307,7 +308,7 @@ export async function main() {
   }
 
   if (forceGC) {
-    if (!global.gc) {
+    if (!globalThis.gc) {
       fail(
         'To use --forcegc you must start node with the --expose-gc command line option',
       );
@@ -590,7 +591,7 @@ export async function main() {
     }
     const blockEndTime = readClock();
     if (forceGC) {
-      global.gc();
+      globalThis.gc();
     }
     if (statLogger) {
       blockNumber += 1;

--- a/packages/swingset-runner/src/push-metrics.js
+++ b/packages/swingset-runner/src/push-metrics.js
@@ -1,3 +1,4 @@
+/* global process */
 import { KERNEL_STATS_METRICS } from '@agoric/swingset-vat/src/kernel/metrics';
 import { spawnSync } from 'child_process';
 import fs from 'fs';

--- a/packages/swingset-runner/test/test-demo.js
+++ b/packages/swingset-runner/test/test-demo.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import test from 'ava';
 import { spawn } from 'child_process';
 import fs from 'fs';

--- a/packages/tame-metering/src/tame.js
+++ b/packages/tame-metering/src/tame.js
@@ -1,3 +1,4 @@
+/* global globalThis */
 import * as c from './constants';
 
 let replaceGlobalMeter;

--- a/packages/transform-metering/src/transform.js
+++ b/packages/transform-metering/src/transform.js
@@ -1,3 +1,4 @@
+/* global require */
 import * as c from './constants';
 
 // We'd like to import this, but RE2 is cjs

--- a/packages/transform-metering/test/test-transform.js
+++ b/packages/transform-metering/test/test-transform.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 /* eslint-disable no-await-in-loop */
 import test from 'ava';
 import * as babelCore from '@babel/core';

--- a/packages/transform-metering/test/test-zzz-eval.js
+++ b/packages/transform-metering/test/test-zzz-eval.js
@@ -1,3 +1,4 @@
+/* global process setTimeout */
 // eslint-disable-next-line import/order
 import { replaceGlobalMeter } from './install-metering';
 import '@agoric/install-ses'; // calls lockdown()

--- a/packages/xsnap/lib/console-shim.js
+++ b/packages/xsnap/lib/console-shim.js
@@ -1,3 +1,4 @@
+/* global globalThis */
 function tryPrint(...args) {
   try {
     // eslint-disable-next-line

--- a/packages/xsnap/lib/text-shim.js
+++ b/packages/xsnap/lib/text-shim.js
@@ -1,3 +1,4 @@
+/* global globalThis */
 /* eslint-disable max-classes-per-file */
 /* eslint-disable class-methods-use-this */
 

--- a/packages/xsnap/src/avaAssertXS.js
+++ b/packages/xsnap/src/avaAssertXS.js
@@ -1,3 +1,4 @@
+/* global globalThis */
 /* eslint-disable no-await-in-loop */
 // @ts-check
 

--- a/packages/xsnap/src/avaHandler.js
+++ b/packages/xsnap/src/avaHandler.js
@@ -1,4 +1,4 @@
-/* global __dirname __filename */
+/* global globalThis __dirname __filename */
 /* set up globalThis.handleCommand for running test scripts
 
 See avaXS.js for the way this is run inside an xsnap process.

--- a/packages/xsnap/src/avaHandler.js
+++ b/packages/xsnap/src/avaHandler.js
@@ -1,3 +1,4 @@
+/* global __dirname __filename */
 /* set up globalThis.handleCommand for running test scripts
 
 See avaXS.js for the way this is run inside an xsnap process.

--- a/packages/xsnap/src/avaXS.js
+++ b/packages/xsnap/src/avaXS.js
@@ -1,3 +1,4 @@
+/* global module require process __filename */
 /* avaXS - ava style test runner for XS
 
 Usage:

--- a/packages/xsnap/src/build.js
+++ b/packages/xsnap/src/build.js
@@ -1,3 +1,4 @@
+/* global __dirname process */
 import * as childProcess from 'child_process';
 import { existsSync, readFileSync } from 'fs';
 import os from 'os';

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -1,3 +1,4 @@
+/* global __filename */
 // @ts-check
 /* eslint no-await-in-loop: ["off"] */
 

--- a/packages/xsnap/src/xsrepl.js
+++ b/packages/xsnap/src/xsrepl.js
@@ -1,3 +1,4 @@
+/* global process */
 // @ts-check
 /* eslint no-await-in-loop: ["off"] */
 

--- a/packages/zoe/scripts/build-zcfBundle.js
+++ b/packages/zoe/scripts/build-zcfBundle.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import 'ses';
 import fs from 'fs';
 import process from 'process';

--- a/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import '@agoric/install-metering-and-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';

--- a/packages/zoe/test/swingsetTests/zoe-metering/test-zoe-metering.js
+++ b/packages/zoe/test/swingsetTests/zoe-metering/test-zoe-metering.js
@@ -1,3 +1,4 @@
+/* global process __dirname */
 import '@agoric/install-metering-and-ses';
 import test from 'ava';
 import { loadBasedir, buildVatController } from '@agoric/swingset-vat';

--- a/packages/zoe/test/swingsetTests/zoe/test-zoe.js
+++ b/packages/zoe/test/swingsetTests/zoe/test-zoe.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-metering-and-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contractSupport/test-depositTo.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-depositTo.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/loan/helpers.js
+++ b/packages/zoe/test/unitTests/contracts/loan/helpers.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import '../../../../exported';
 
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 // ts-check
 import '../../../../exported';
 

--- a/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
+++ b/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
+++ b/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/test-autoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-autoswap.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/test-barter.js
+++ b/packages/zoe/test/unitTests/contracts/test-barter.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/test-brokenContract.js
+++ b/packages/zoe/test/unitTests/contracts/test-brokenContract.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';

--- a/packages/zoe/test/unitTests/contracts/test-callSpread.js
+++ b/packages/zoe/test/unitTests/contracts/test-callSpread.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/test-coveredCall.js
+++ b/packages/zoe/test/unitTests/contracts/test-coveredCall.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';

--- a/packages/zoe/test/unitTests/contracts/test-mintPayments.js
+++ b/packages/zoe/test/unitTests/contracts/test-mintPayments.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';

--- a/packages/zoe/test/unitTests/contracts/test-oracle.js
+++ b/packages/zoe/test/unitTests/contracts/test-oracle.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';

--- a/packages/zoe/test/unitTests/contracts/test-otcDesk.js
+++ b/packages/zoe/test/unitTests/contracts/test-otcDesk.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';

--- a/packages/zoe/test/unitTests/contracts/test-secondPriceAuction.js
+++ b/packages/zoe/test/unitTests/contracts/test-secondPriceAuction.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/test-sellTickets.js
+++ b/packages/zoe/test/unitTests/contracts/test-sellTickets.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
+++ b/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 

--- a/packages/zoe/test/unitTests/contracts/test-throwInOfferHandler.js
+++ b/packages/zoe/test/unitTests/contracts/test-throwInOfferHandler.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/test-useObj.js
+++ b/packages/zoe/test/unitTests/contracts/test-useObj.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/test-scriptedOracle.js
+++ b/packages/zoe/test/unitTests/test-scriptedOracle.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';

--- a/packages/zoe/test/unitTests/zcf/setupZcfTest.js
+++ b/packages/zoe/test/unitTests/zcf/setupZcfTest.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 import { E } from '@agoric/eventual-send';
 import bundleSource from '@agoric/bundle-source';
 

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies


### PR DESCRIPTION
Mitigates https://github.com/Agoric/agoric-sdk/issues/2160

First, thanks to @michaelfig for figuring out how to tell eslint to stop whitelisting dangerous globals.

Changes eslint-config to stop assuming either the node globals or the browser globals. Then added back in the globals that are harmless such as `URL` and those that are harmless enough such as `console`. All those on the expanded list can be used without further ceremony without provoking and eslint warning.

For the rest, I went through the lint warnings produced by doing a `yarn lint` at the top and added an explicit
```js
/* global ...stuff... */
```
to the top of each of those files. There is only one code change. A use of the non-standard global variable `global` was changed to the standard name `globalThis`. 

This PR *does not* reduce our excess authority problem at all! However, it does make the ambient authority assumed from global variables explicit. The first step for a file to fix a problem is for the file to admit it has a problem.