### PR TITLE
'use jessie' detection with eslint and prettier

### DIFF
--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -23,9 +23,7 @@
     "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint:eslint": "eslint '**/*.js'",
-    "lint:types": "tsc -p jsconfig.json",
-    "lint-fix-jessie": "eslint -c '.eslintrc-jessie.js' --fix '**/*.js'",
-    "lint-check-jessie": "eslint -c '.eslintrc-jessie.js' '**/*.js'"
+    "lint:types": "tsc -p jsconfig.json"
   },
   "repository": {
     "type": "git",

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -16,9 +16,7 @@
     "test": "ava --config .ava-unit-test.config.js",
     "integration-test": "ava --config .ava-integration-test.config.js",
     "lint-check": "eslint '**/*.{js,jsx}'",
-    "lint-fix": "eslint --fix '**/*.{js,jsx}'",
-    "lint-fix-jessie": "eslint -c '.eslintrc-jessie.js' --fix '**/*.{js,jsx}'",
-    "lint-check-jessie": "eslint -c '.eslintrc-jessie.js' '**/*.{js,jsx}'"
+    "lint-fix": "eslint --fix '**/*.{js,jsx}'"
   },
   "devDependencies": {
     "ava": "^3.12.1",

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -17,9 +17,7 @@
     "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint:eslint": "eslint '**/*.js'",
-    "lint:types": "tsc -p jsconfig.json",
-    "lint-fix-jessie": "eslint -c '.eslintrc-jessie.js' --fix '**/*.js'",
-    "lint-check-jessie": "eslint -c '.eslintrc-jessie.js' '**/*.js'"
+    "lint:types": "tsc -p jsconfig.json"
   },
   "repository": {
     "type": "git",

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -31,9 +31,7 @@
     "test": "ava",
     "test:nyc": "nyc ava",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint-check": "eslint 'lib/*.js'",
-    "lint-fix-jessie": "eslint -c '.eslintrc-jessie.js' --fix '**/*.js'",
-    "lint-check-jessie": "eslint -c '.eslintrc-jessie.js' '**/*.js'"
+    "lint-check": "eslint 'lib/*.js'"
   },
   "devDependencies": {
     "@agoric/install-ses": "^0.5.2",

--- a/packages/dapp-svelte-wallet/api/package.json
+++ b/packages/dapp-svelte-wallet/api/package.json
@@ -10,9 +10,7 @@
     "lint-fix": "yarn lint --fix",
     "lint-check": "yarn lint",
     "lint:types": "tsc -p jsconfig.json",
-    "lint:eslint": "eslint '**/*.js'",
-    "lint-fix-jessie": "eslint -c '.eslintrc-jessie.js' --fix '**/*.{js,jsx}'",
-    "lint-check-jessie": "eslint -c '.eslintrc-jessie.js' '**/*.{js,jsx}'"
+    "lint:eslint": "eslint '**/*.js'"
   },
   "devDependencies": {
     "@agoric/bundle-source": "^1.2.2",

--- a/packages/deploy-script-support/package.json
+++ b/packages/deploy-script-support/package.json
@@ -19,9 +19,7 @@
     "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint:eslint": "eslint '**/*.js'",
-    "lint:types": "tsc -p jsconfig.json",
-    "lint-fix-jessie": "eslint -c '.eslintrc-jessie.js' --fix '**/*.js'",
-    "lint-check-jessie": "eslint -c '.eslintrc-jessie.js' '**/*.js'"
+    "lint:types": "tsc -p jsconfig.json"
   },
   "repository": {
     "type": "git",

--- a/packages/eslint-config/eslint-config.json
+++ b/packages/eslint-config/eslint-config.json
@@ -6,6 +6,7 @@
     "plugin:@agoric/recommended"
   ],
   "parser": "@typescript-eslint/parser",
+  "processor": "@agoric/use-jessie",
   "env": {
     "es6": true,
     "node": false,

--- a/packages/eslint-plugin/lib/index.js
+++ b/packages/eslint-plugin/lib/index.js
@@ -18,3 +18,4 @@ var requireIndex = require("requireindex");
 // import all rules in lib/rules
 module.exports.rules = requireIndex(__dirname + "/rules");
 module.exports.configs = requireIndex(__dirname + "/configs");
+module.exports.processors = requireIndex(__dirname + "/processors");

--- a/packages/eslint-plugin/lib/processors/use-jessie.js
+++ b/packages/eslint-plugin/lib/processors/use-jessie.js
@@ -1,0 +1,171 @@
+'use strict';
+
+// This is all one line so that we don't mess up
+// eslint's error locations.
+//
+// TODO: Generate this from a data structure.
+const jessieRulesOneLine = `\
+/* eslint\
+ curly: ['error', 'all']\
+,eqeqeq: ['error', 'always']\
+,no-bitwise: ['error']\
+,no-fallthrough: ['error', { commentPattern: 'fallthrough is not allowed' }]\
+,no-plusplus: ['error']\
+,no-restricted-globals: ['error', 'RegExp', 'Date']\
+,no-restricted-syntax: ['error', \
+{\
+  selector: "BinaryExpression[operator='in']",\
+  message: "'in' is not allowed.",\
+},\
+{\
+  selector: "BinaryExpression[operator='instanceof']",\
+  message: "'instanceof' is not allowed.",\
+},\
+{\
+  selector: 'NewExpression',\
+  message: "'new' is not allowed.",\
+},\
+{\
+  selector: 'FunctionDeclaration[generator=true]',\
+  message: 'generators are not allowed.',\
+},\
+{\
+  selector: 'FunctionDeclaration[async=true]',\
+  message: 'async functions are not allowed.',\
+},\
+{\
+  selector: 'FunctionExpression[async=true]',\
+  message: 'async functions are not allowed.',\
+},\
+{\
+  selector: 'ArrowFunctionExpression[async=true]',\
+  message: 'async functions are not allowed.',\
+},\
+{\
+  selector: 'DoWhileStatement',\
+  message: 'do/while statements are not allowed.',\
+},\
+{\
+  selector: 'ThisExpression',\
+  message: "'this' not allowed.",\
+},\
+{\
+  selector: "UnaryExpression[operator='delete']",\
+  message: "'delete' not allowed.",\
+},\
+{\
+  selector: 'ForInStatement',\
+  message: 'for/in statements are not allowed; use for/of Object.keys(val).',\
+},\
+{\
+  selector: 'MemberExpression[computed=true]',\
+  message: 'computed property names are not allowed.',\
+},\
+{\
+  selector: 'Super',\
+  message: "'super' is not allowed.",\
+},\
+{\
+  selector: 'MetaProperty',\
+  message: "'MetaProperty' is not allowed.",\
+},\
+{\
+  selector: 'ClassExpression',\
+  message: "'ClassExpression' is not allowed.",\
+},\
+{\
+  selector: "CallExpression[callee.name='eval']",\
+  message: "'eval' is not allowed.",\
+},\
+{\
+  selector: 'Literal[regex]',\
+  message: 'regexp literal syntax is not allowed.',\
+}\
+]\
+,no-ternary: ['error']\
+,no-var: ['error']\
+,guard-for-in: 'off'\
+,semi: ['error', 'always']\
+ */ \
+`;
+
+function indexOfFirstStatement(text) {
+  let i = 0;
+  let slashStarComment = false;
+
+  while (i < text.length) {
+    let s = text.substr(i);
+    if (slashStarComment) {
+      const endComment = s.match(/^.*?\*\//s);
+      if (endComment) {
+        slashStarComment = false;
+        i += endComment[0].length;
+      } else {
+        return -1;
+      }
+    } else {
+      const ws = s.match(/^\s+/);
+      if (ws) {
+        i += ws[0].length;
+        s = text.substr(i);
+      }
+
+      const multilineComment = s.match(/^\/\*/);
+      if (multilineComment) {
+        slashStarComment = true;
+        i += multilineComment[0].length;
+      } else {
+        const lineComment = s.match(/^\/\/.*/);
+        if (lineComment) {
+          i += lineComment[0].length;
+        } else {
+          // No comments, no whitespace.
+          return i;
+        }
+      }
+    }
+  }
+  return -1;
+}
+
+function isJessie(text) {
+  const pos = indexOfFirstStatement(text);
+  if (pos >= 0) {
+    for (const jessieToken of ['"use jessie";', "'use jessie';"]) {
+      if (text.substr(pos, jessieToken.length) === jessieToken) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+const filenameIsJessie = new Set();
+module.exports = {
+  preprocess(text, filename) {
+    if (isJessie(text)) {
+      filenameIsJessie.add(filename);
+      return [
+        `${jessieRulesOneLine}${text}`
+      ];
+    }
+    filenameIsJessie.delete(filename);
+    return [text];
+  },
+  postprocess(messages, filename) {
+    if (!filenameIsJessie.has(filename)) {
+      return [].concat(...messages);
+    }
+    const rewritten = messages.flatMap(errors => errors.map(err => {
+      if ('fix' in err) {
+        // Remove the bytes we inserted.
+        const range = err.fix.range.map(offset => offset > jessieRulesOneLine.length ? offset - jessieRulesOneLine.length : offset);
+        return { ...err, fix: { ...err.fix, range }};
+      }
+      return err;
+    }));
+    // console.error('have rewritten', require('util').inspect(rewritten, undefined, Infinity))
+    return rewritten;
+  },
+  supportsAutofix: true,
+};

--- a/packages/import-manager/package.json
+++ b/packages/import-manager/package.json
@@ -13,9 +13,7 @@
     "build": "exit 0",
     "test": "ava",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint-check": "eslint '**/*.js'",
-    "lint-fix-jessie": "eslint -c '.eslintrc-jessie.js' --fix '**/*.js'",
-    "lint-check-jessie": "eslint -c '.eslintrc-jessie.js' '**/*.js'"
+    "lint-check": "eslint '**/*.js'"
   },
   "repository": {
     "type": "git",

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -17,9 +17,7 @@
     "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint:eslint": "eslint '**/*.js'",
-    "lint:types": "tsc -p jsconfig.json",
-    "lint-fix-jessie": "eslint -c '.eslintrc-jessie.js' --fix '**/*.js'",
-    "lint-check-jessie": "eslint -c '.eslintrc-jessie.js' '**/*.js'"
+    "lint:types": "tsc -p jsconfig.json"
   },
   "repository": {
     "type": "git",

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -16,9 +16,7 @@
     "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint:eslint": "eslint '**/*.js'",
-    "lint:types": "tsc -p jsconfig.json",
-    "lint-fix-jessie": "eslint -c '.eslintrc-jessie.js' --fix '**/*.js'",
-    "lint-check-jessie": "eslint -c '.eslintrc-jessie.js' '**/*.js'"
+    "lint:types": "tsc -p jsconfig.json"
   },
   "repository": {
     "type": "git",

--- a/packages/registrar/package.json
+++ b/packages/registrar/package.json
@@ -14,9 +14,7 @@
     "test": "ava",
     "test:nyc": "nyc ava",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint-check": "eslint '**/*.js'",
-    "lint-fix-jessie": "eslint -c '.eslintrc-jessie.js' --fix '**/*.js'",
-    "lint-check-jessie": "eslint -c '.eslintrc-jessie.js' '**/*.js'"
+    "lint-check": "eslint '**/*.js'"
   },
   "repository": {
     "type": "git",

--- a/packages/same-structure/package.json
+++ b/packages/same-structure/package.json
@@ -13,9 +13,7 @@
     "build": "exit 0",
     "test": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint-check": "eslint '**/*.js'",
-    "lint-fix-jessie": "eslint -c '.eslintrc-jessie.js' --fix '**/*.js'",
-    "lint-check-jessie": "eslint -c '.eslintrc-jessie.js' '**/*.js'"
+    "lint-check": "eslint '**/*.js'"
   },
   "repository": {
     "type": "git",

--- a/packages/sharing-service/package.json
+++ b/packages/sharing-service/package.json
@@ -14,9 +14,7 @@
     "test": "ava",
     "test:nyc": "nyc ava",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint-check": "eslint '**/*.js'",
-    "lint-fix-jessie": "eslint -c '.eslintrc-jessie.js' --fix '**/*.js'",
-    "lint-check-jessie": "eslint -c '.eslintrc-jessie.js' '**/*.js'"
+    "lint-check": "eslint '**/*.js'"
   },
   "repository": {
     "type": "git",

--- a/packages/sparse-ints/package.json
+++ b/packages/sparse-ints/package.json
@@ -13,9 +13,7 @@
     "build": "exit 0",
     "test": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint-check": "eslint '**/*.js'",
-    "lint-fix-jessie": "eslint -c '.eslintrc-jessie.js' --fix '**/*.js'",
-    "lint-check-jessie": "eslint -c '.eslintrc-jessie.js' '**/*.js'"
+    "lint-check": "eslint '**/*.js'"
   },
   "repository": {
     "type": "git",

--- a/packages/spawner/package.json
+++ b/packages/spawner/package.json
@@ -14,9 +14,7 @@
     "test": "ava",
     "test:nyc": "nyc ava",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint-check": "eslint '**/*.js'",
-    "lint-fix-jessie": "eslint -c '.eslintrc-jessie.js' --fix '**/*.js'",
-    "lint-check-jessie": "eslint -c '.eslintrc-jessie.js' '**/*.js'"
+    "lint-check": "eslint '**/*.js'"
   },
   "repository": {
     "type": "git",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -14,10 +14,9 @@
     "test": "ava",
     "lint-fix": "yarn lint --fix",
     "lint-check": "yarn lint",
-    "lint": "yarn lint:types && eslint '**/*.js'",
+    "lint": "yarn lint:types && yarn lint:eslint",
     "lint:types": "tsc -p jsconfig.json",
-    "lint-fix-jessie": "eslint -c '.eslintrc-jessie.js' --fix '**/*.js'",
-    "lint-check-jessie": "eslint -c '.eslintrc-jessie.js' '**/*.js'"
+    "lint:eslint": "eslint '**/*.js'"
   },
   "repository": {
     "type": "git",

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -18,9 +18,7 @@
     "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint:eslint": "eslint '**/*.js'",
-    "lint:types": "tsc -p jsconfig.json",
-    "lint-fix-jessie": "eslint -c '.eslintrc-jessie.js' --fix '**/*.js'",
-    "lint-check-jessie": "eslint -c '.eslintrc-jessie.js' '**/*.js'"
+    "lint:types": "tsc -p jsconfig.json"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Refs #456 

This PR goes a lot further than our former support, and uses an eslint "processor" to detect `'use jessie';` or `"use jessie";` at the beginning of a file, then apply a set of additional rules to it.  Unfortunately, I couldn't find a way to reuse the exsting `eslint-config-jessie` package yet, but I think we could snarf the rules from it, then apply them as a single-line comment added to the beginning of the file.

Unlike prior attempts, this does not need any different CLI arguments, configuration files, nor does it interfere with Prettier or other ESLint fix requests.

Landing this just to ensure we don't break anything, but it can definitely be improved.  The general approach is the only one I found that would work within the constraints.
