### PR TITLE
refactor(ERTP): use jessie in issuer.js

### DIFF
--- a/packages/ERTP/src/collections.js
+++ b/packages/ERTP/src/collections.js
@@ -1,0 +1,11 @@
+// @ts-check
+
+/**
+ * TODO: move to https://github.com/Agoric/readonly-collections-shim ?
+ *
+ * @returns {Set<T>}
+ * @template T
+ */
+export function makeFlexSet() {
+  return new Set();
+}

--- a/packages/ERTP/src/issuer.js
+++ b/packages/ERTP/src/issuer.js
@@ -1,6 +1,8 @@
 // @ts-check
 /* global makeWeakStore */
 
+'use jessie';
+
 import { assert, details as X } from '@agoric/assert';
 import { makeExternalStore } from '@agoric/store';
 import { E } from '@agoric/eventual-send';
@@ -97,7 +99,7 @@ function makeIssuerKit(
     const purse = Far(makeFarName(allegedName, ERTPKind.PURSE), {
       deposit: (srcPayment, optAmount = undefined) => {
         if (isPromise(srcPayment)) {
-          throw new TypeError(
+          throw TypeError(
             `deposit does not accept promises as first argument. Instead of passing the promise (deposit(paymentPromise)), consider unwrapping the promise first: paymentPromise.then(actualPayment => deposit(actualPayment))`,
           );
         }
@@ -160,11 +162,10 @@ function makeIssuerKit(
     // other uses.
 
     if (payments.length > 1) {
-      // TODO: replace with a Set that understands virtual objects
       const antiAliasingStore = makeWeakStore('payment');
       payments.forEach(payment => {
         if (antiAliasingStore.has(payment)) {
-          throw new Error('same payment seen twice');
+          throw Error('same payment seen twice');
         }
         antiAliasingStore.init(payment, undefined);
       });


### PR DESCRIPTION
I experimented with `'use jessie'` from #2595; it worked well enough that perhaps the results are worth keeping?

I found it surprising that the eslint processor doesn't notice `'use jessie'` after `import` statements. Then I found it surprising that putting it _before_ `import` statements isn't a JS syntax error.