### PR TITLE
fix(swingset): allow Symbol.asyncIterator as a method name

### DIFF
--- a/packages/SwingSet/docs/liveslots.md
+++ b/packages/SwingSet/docs/liveslots.md
@@ -51,6 +51,8 @@ const p = E(target).foo('arg1');
 p.then(obj2 => E(obj2).bar('arg2'))
 ```
 
+The method name being invoked can be any string, or the special `Symbol.asyncIterator`. All other Symbol-named methods are currently rejected, but see #2612 for plans to accept anything that JavaScript will accept.
+
 All vats are subject to the "tildot transformation", which means these calls may also be written like:
 
 ```js

--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -360,6 +360,15 @@ function build(syscall, forVatID, cacheSize, vatPowers, vatParameters) {
   }
 
   function queueMessage(targetSlot, prop, args, returnedP) {
+    if (typeof prop === 'symbol') {
+      if (prop === Symbol.asyncIterator) {
+        // special-case this Symbol for now, will be replaced in #2481
+        prop = 'Symbol.asyncIterator';
+      } else {
+        throw Error(`arbitrary Symbols cannot be used as method names`);
+      }
+    }
+
     const serArgs = m.serialize(harden(args));
     const resultVPID = allocatePromiseID();
     lsdebug(`Promise allocation ${forVatID}:${resultVPID} in queueMessage`);
@@ -458,6 +467,10 @@ function build(syscall, forVatID, cacheSize, vatPowers, vatParameters) {
     // should error-check cases that the kernel shouldn't do, like getting
     // the same vpid as a result= twice, or getting a result= for an exported
     // promise (for which we were already the decider).
+
+    if (method === 'Symbol.asyncIterator') {
+      method = Symbol.asyncIterator;
+    }
 
     const args = m.unserialize(argsdata);
 


### PR DESCRIPTION
Liveslots special-cases this one symbol by converting it into a (string)
method name of `"Symbol.asyncIterator"` for `syscall.send`, and back again
during `dispatch.deliver`. This has several limitations:

* no other Symbols are accepted yet
* `E(target)[Symbol.asyncIterator](args)` and
`E[target]['Symbol.asyncIterator'](args)` will invoke the same target method,
which is clearly wrong
* a method named `'Symbol.asyncIterator'` (as a string) cannot be invoked
remotely

This should all be fixed someday by #2481.

closes #2619