### PR TITLE
chore(cosmic-swingset): repl.js imports getInterfaceOf/etc

### DIFF
--- a/packages/cosmic-swingset/lib/ag-solo/vats/repl.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/repl.js
@@ -1,5 +1,6 @@
 import { isPromise } from '@agoric/promise-kit';
 import { E } from '@agoric/eventual-send';
+import { getInterfaceOf, Remotable, Far } from '@agoric/marshal';
 
 import { Nat } from '@agoric/nat';
 import makeUIAgentMakers from './ui-agent';
@@ -8,7 +9,7 @@ import makeUIAgentMakers from './ui-agent';
 export function stringify(
   value,
   spaces,
-  getInterfaceOf,
+  gio = getInterfaceOf,
   inProgress = new WeakSet(),
   depth = 0,
 ) {
@@ -41,7 +42,7 @@ export function stringify(
 
   let ret = '';
   const spcs = spaces === undefined ? '' : ' '.repeat(spaces);
-  if (getInterfaceOf && getInterfaceOf(value) !== undefined) {
+  if (gio && gio(value) !== undefined) {
     ret += `${value}`;
   } else if (Array.isArray(value)) {
     ret += `[`;
@@ -52,7 +53,7 @@ export function stringify(
       if (spcs !== '') {
         ret += `\n${spcs.repeat(depth + 1)}`;
       }
-      ret += stringify(value[i], spaces, getInterfaceOf, inProgress, depth + 1);
+      ret += stringify(value[i], spaces, gio, inProgress, depth + 1);
       sep = ',';
     }
     if (sep !== '' && spcs !== '') {
@@ -70,7 +71,7 @@ export function stringify(
       ret += `\n${spcs.repeat(depth + 1)}`;
     }
     ret += `${JSON.stringify(key)}:${spaces > 0 ? ' ' : ''}`;
-    ret += stringify(value[key], spaces, getInterfaceOf, inProgress, depth + 1);
+    ret += stringify(value[key], spaces, gio, inProgress, depth + 1);
     sep = ',';
   }
   if (sep !== '' && spcs !== '') {
@@ -82,10 +83,10 @@ export function stringify(
 }
 
 export function getReplHandler(replObjects, send, vatPowers) {
-  // We use getInterfaceOf locally, and transformTildot is baked into the
-  // Compartment we use to evaluate REPL inputs. We provide getInterfaceOf
-  // and Remotable to REPL input code.
-  const { getInterfaceOf, Remotable, Far, transformTildot } = vatPowers;
+  // transformTildot is baked into the Compartment we use to evaluate REPL
+  // inputs. We provide getInterfaceOf and Remotable to REPL input code., but
+  // import them from @agoric/marshal directly
+  const { transformTildot } = vatPowers;
   let highestHistory = -1;
   const commands = {
     [highestHistory]: '',


### PR DESCRIPTION
.. rather than being given them on `vatPowers`, since those are going away.

refs #2637

@michaelfig I changed `stringify` to stop accepting a `getInterfaceOf` argument because eslint complained about the shadowed name. I didn't see any external importers of the file within `cosmic-swingset/`, so I removed the `export`. If there *are* any external importers of this file, they'll need to be updated for the new signature (I removed the argument from the middle, which is always troublesome). I figured a "cannot import" error would be more obvious than whatever would happen when one argument gets confused for another. As part of your review, please think about whether there are any other importers.
