### PR TITLE
fix(swingset): remove Far/Remotable/getInterfaceOf from vatPowers

### DIFF
--- a/packages/SwingSet/docs/static-vats.md
+++ b/packages/SwingSet/docs/static-vats.md
@@ -63,8 +63,6 @@ A few vats do not use liveslots. The main one is the "comms vat", which performs
 
 Static vats currently receive the following objects in their `buildRootObject()`'s sole `vatPowers` argument:
 
-* `Remotable`
-* `getInterfaceOf`
 * `makeGetMeter`
 * `transformMetering`
 * `transformTildot`
@@ -72,14 +70,6 @@ Static vats currently receive the following objects in their `buildRootObject()`
 * `exitVatWithFailure`
 
 (dynamic vats do not get `makeGetMeter` or `transformMetering`)
-
-### marshalling: `Remotable` and `getInterfaceOf`
-
-Messages sent between vats include arguments (and return values) which are serialized with `@agoric/marshal`. This marshalling library makes a distinction between plain data, and "remotable objects". Data is merely copied, but remotables arrive as a *Presence*, to which messages can be sent, with e.g. `counter~.increment()`.
-
-Objects which are frozen, and whose enumerable properties are all functions, will automatically qualify as remotable. In addition, vats can use `Remotable()` to create new remotable objects with a particular "interface" name, as well as other properties. The interface name can be retrieved with `getInterfaceOf`.
-
-This functionality is still in development. See https://github.com/Agoric/agoric-sdk/issues/804 for details.
 
 ### metering: `makeGetMeter`, `transformMetering`
 

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -1,4 +1,3 @@
-import { Remotable, getInterfaceOf } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
 import { importBundle } from '@agoric/import-bundle';
 import { assertKnownOptions } from '../assertOptions';
@@ -188,17 +187,13 @@ export default function buildKernel(
 
   // These will eventually be provided by the in-worker supervisor instead.
 
-  // We need to give the vat the correct Remotable and getKernelPromise so
-  // that they can access our own @agoric/marshal, not a separate instance in
-  // a bundle. TODO: ideally the powerless ones (Remotable, getInterfaceOf,
-  // maybe transformMetering) are imported by the vat, not passed in an
-  // argument. The powerful one (makeGetMeter) should only be given to the
-  // root object, to share with (or withhold from) other objects as it sees
-  // fit. TODO: makeGetMeter and transformMetering will go away
+  // TODO: ideally the powerless ones (maybe transformMetering) are imported
+  // by the vat, not passed in an argument. The powerful one (makeGetMeter)
+  // should only be given to the root object, to share with (or withhold
+  // from) other objects as it sees fit. TODO: makeGetMeter and
+  // transformMetering will go away
 
   const allVatPowers = harden({
-    Remotable,
-    getInterfaceOf,
     makeGetMeter: meterManager.makeGetMeter,
     transformMetering: (...args) =>
       meterManager.runWithoutGlobalMeter(transformMetering, ...args),

--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -2,8 +2,6 @@
 
 import {
   Remotable,
-  Far,
-  getInterfaceOf,
   passStyleOf,
   REMOTE_STYLE,
   makeMarshal,
@@ -669,9 +667,6 @@ export function makeLiveSlots(
 ) {
   const allVatPowers = {
     ...vatPowers,
-    getInterfaceOf,
-    Remotable,
-    Far,
     makeMarshal,
   };
   const r = build(syscall, forVatID, cacheSize, allVatPowers, vatParameters);

--- a/packages/SwingSet/src/kernel/vatManager/manager-local.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-local.js
@@ -19,8 +19,6 @@ export function makeLocalVatManagerFactory(tools) {
   const { makeGetMeter, refillAllMeters, stopGlobalMeter } = meterManager;
   const { WeakRef, FinalizationRegistry } = gcTools;
   const baseVP = {
-    Remotable: allVatPowers.Remotable,
-    getInterfaceOf: allVatPowers.getInterfaceOf,
     makeMarshal: allVatPowers.makeMarshal,
     transformTildot: allVatPowers.transformTildot,
   };

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-nodeworker.js
@@ -6,7 +6,7 @@ import anylogger from 'anylogger';
 
 import { assert, details as X } from '@agoric/assert';
 import { importBundle } from '@agoric/import-bundle';
-import { Remotable, getInterfaceOf, makeMarshal } from '@agoric/marshal';
+import { makeMarshal } from '@agoric/marshal';
 import { WeakRef, FinalizationRegistry } from '../../weakref';
 import { waitUntilQuiescent } from '../../waitUntilQuiescent';
 import { makeLiveSlots } from '../liveSlots';
@@ -95,8 +95,6 @@ parentPort.on('message', ([type, ...margs]) => {
     // transformTildot should be async and outsourced to the kernel
     // process/thread.
     const vatPowers = {
-      Remotable,
-      getInterfaceOf,
       makeMarshal,
       testLog,
     };

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-node.js
@@ -6,7 +6,7 @@ import fs from 'fs';
 
 import { assert, details as X } from '@agoric/assert';
 import { importBundle } from '@agoric/import-bundle';
-import { Remotable, getInterfaceOf, makeMarshal } from '@agoric/marshal';
+import { makeMarshal } from '@agoric/marshal';
 import { WeakRef, FinalizationRegistry } from '../../weakref';
 import { arrayEncoderStream, arrayDecoderStream } from '../../worker-protocol';
 import {
@@ -115,8 +115,6 @@ fromParent.on('data', ([type, ...margs]) => {
     // transformTildot should be async and outsourced to the kernel
     // process/thread.
     const vatPowers = {
-      Remotable,
-      getInterfaceOf,
       makeMarshal,
       testLog,
     };

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
@@ -2,7 +2,7 @@
 // @ts-check
 import { assert, details as X } from '@agoric/assert';
 import { importBundle } from '@agoric/import-bundle';
-import { Remotable, getInterfaceOf, makeMarshal } from '@agoric/marshal';
+import { makeMarshal } from '@agoric/marshal';
 // grumble... waitUntilQuiescent is exported and closes over ambient authority
 import { waitUntilQuiescent } from '../../waitUntilQuiescent';
 
@@ -210,8 +210,6 @@ function makeWorker(port) {
     });
 
     const vatPowers = {
-      Remotable,
-      getInterfaceOf,
       makeMarshal,
       transformTildot,
       testLog: (...args) =>

--- a/packages/cosmic-swingset/lib/ag-solo/vats/repl.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/repl.js
@@ -1,5 +1,6 @@
 import { isPromise } from '@agoric/promise-kit';
 import { E } from '@agoric/eventual-send';
+import { getInterfaceOf, Remotable, Far } from '@agoric/marshal';
 
 import { Nat } from '@agoric/nat';
 import makeUIAgentMakers from './ui-agent';
@@ -8,7 +9,7 @@ import makeUIAgentMakers from './ui-agent';
 export function stringify(
   value,
   spaces,
-  getInterfaceOf,
+  gio = getInterfaceOf,
   inProgress = new WeakSet(),
   depth = 0,
 ) {
@@ -41,7 +42,7 @@ export function stringify(
 
   let ret = '';
   const spcs = spaces === undefined ? '' : ' '.repeat(spaces);
-  if (getInterfaceOf && getInterfaceOf(value) !== undefined) {
+  if (gio && gio(value) !== undefined) {
     ret += `${value}`;
   } else if (Array.isArray(value)) {
     ret += `[`;
@@ -52,7 +53,7 @@ export function stringify(
       if (spcs !== '') {
         ret += `\n${spcs.repeat(depth + 1)}`;
       }
-      ret += stringify(value[i], spaces, getInterfaceOf, inProgress, depth + 1);
+      ret += stringify(value[i], spaces, gio, inProgress, depth + 1);
       sep = ',';
     }
     if (sep !== '' && spcs !== '') {
@@ -70,7 +71,7 @@ export function stringify(
       ret += `\n${spcs.repeat(depth + 1)}`;
     }
     ret += `${JSON.stringify(key)}:${spaces > 0 ? ' ' : ''}`;
-    ret += stringify(value[key], spaces, getInterfaceOf, inProgress, depth + 1);
+    ret += stringify(value[key], spaces, gio, inProgress, depth + 1);
     sep = ',';
   }
   if (sep !== '' && spcs !== '') {
@@ -82,10 +83,10 @@ export function stringify(
 }
 
 export function getReplHandler(replObjects, send, vatPowers) {
-  // We use getInterfaceOf locally, and transformTildot is baked into the
-  // Compartment we use to evaluate REPL inputs. We provide getInterfaceOf
-  // and Remotable to REPL input code.
-  const { getInterfaceOf, Remotable, Far, transformTildot } = vatPowers;
+  // transformTildot is baked into the Compartment we use to evaluate REPL
+  // inputs. We provide getInterfaceOf and Remotable to REPL input code., but
+  // import them from @agoric/marshal directly
+  const { transformTildot } = vatPowers;
   let highestHistory = -1;
   const commands = {
     [highestHistory]: '',


### PR DESCRIPTION
Vat code should import these three from `@agoric/marshal` rather than pulling
them from `vatPowers`.

closes #2637

This needs to land on top of #2638 , which removes the last customer of these `vatPowers` properties (as far as I can tell).
