### PR TITLE
provide 'gcTools' consistently across all vat worker types

### DIFF
--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -634,13 +634,14 @@ function build(syscall, forVatID, cacheSize, vatPowers, vatParameters) {
  * @param {*} vatPowers
  * @param {*} vatParameters
  * @param {number} cacheSize  Upper bound on virtual object cache size
+ * @param {*} _gcTools
  * @returns {*} { vatGlobals, dispatch, setBuildRootObject }
  *
  * setBuildRootObject should be called, once, with a function that will
  * create a root object for the new vat The caller provided buildRootObject
  * function produces and returns the new vat's root object:
  *
- *     buildRootObject(vatPowers, vatParameters)
+ * buildRootObject(vatPowers, vatParameters)
  *
  * Within the vat, `import { E } from '@agoric/eventual-send'` will
  * provide the E wrapper. For any object x, E(x) returns a proxy object
@@ -664,6 +665,7 @@ export function makeLiveSlots(
   vatPowers = harden({}),
   vatParameters = harden({}),
   cacheSize = DEFAULT_VIRTUAL_OBJECT_CACHE_SIZE,
+  _gcTools,
 ) {
   const allVatPowers = {
     ...vatPowers,

--- a/packages/SwingSet/src/kernel/vatManager/manager-local.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-local.js
@@ -17,7 +17,6 @@ export function makeLocalVatManagerFactory(tools) {
   } = tools;
 
   const { makeGetMeter, refillAllMeters, stopGlobalMeter } = meterManager;
-  const { WeakRef, FinalizationRegistry } = gcTools;
   const baseVP = {
     makeMarshal: allVatPowers.makeMarshal,
     transformTildot: allVatPowers.transformTildot,
@@ -101,10 +100,6 @@ export function makeLocalVatManagerFactory(tools) {
       vatParameters,
       testLog: allVatPowers.testLog,
     });
-    function vatDecref(vref, count) {
-      gcTools.decref(vatID, vref, count);
-    }
-    const lsgc = harden({ WeakRef, FinalizationRegistry, vatDecref });
 
     // we might or might not use this, depending upon whether the vat exports
     // 'buildRootObject' or a default 'setup' function
@@ -114,7 +109,7 @@ export function makeLocalVatManagerFactory(tools) {
       vatPowers,
       vatParameters,
       virtualObjectCacheSize,
-      lsgc,
+      gcTools,
     );
 
     let meterRecord = null;

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
@@ -229,13 +229,15 @@ function makeWorker(port) {
         ? virtualObjectCacheSize
         : undefined;
 
+    const gcTools = {}; // future expansion
+
     const ls = makeLiveSlots(
       syscall,
       vatID,
       vatPowers,
       vatParameters,
       cacheSize,
-      // TODO: lsgc? API drift?
+      gcTools,
     );
 
     const endowments = {


### PR DESCRIPTION
This cleans up a "huh?" that @dckc noticed in `supervisor-subprocess-xsnap.js`. The `gcTools` argument isn't used by liveslots yet, but will as we get more of #2615 implemented.

This should land after #2639 does, just because that's the order in which I've done my local development. If that gets stalled for some reason, I could rebase this to land separately.. I don't think it overlaps significantly.
