### PR TITLE
fix(swingset): add exit/vatstore syscalls to non-local vat workers

### DIFF
--- a/packages/SwingSet/src/kernel/vatManager/supervisor-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-nodeworker.js
@@ -87,6 +87,10 @@ parentPort.on('message', ([type, ...margs]) => {
       },
       subscribe: (...args) => doSyscall(['subscribe', ...args]),
       resolve: (...args) => doSyscall(['resolve', ...args]),
+      exit: (...args) => doSyscall(['exit', ...args]),
+      vatstoreGet: (...args) => doSyscall(['vatstoreGet', ...args]),
+      vatstoreSet: (...args) => doSyscall(['vatstoreSet', ...args]),
+      vatstoreDelete: (...args) => doSyscall(['vatstoreDelete', ...args]),
     });
 
     const vatID = 'demo-vatID';

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-node.js
@@ -107,6 +107,10 @@ fromParent.on('data', ([type, ...margs]) => {
       },
       subscribe: (...args) => doSyscall(['subscribe', ...args]),
       resolve: (...args) => doSyscall(['resolve', ...args]),
+      exit: (...args) => doSyscall(['exit', ...args]),
+      vatstoreGet: (...args) => doSyscall(['vatstoreGet', ...args]),
+      vatstoreSet: (...args) => doSyscall(['vatstoreSet', ...args]),
+      vatstoreDelete: (...args) => doSyscall(['vatstoreDelete', ...args]),
     });
 
     const vatID = 'demo-vatID';

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
@@ -204,6 +204,7 @@ function makeWorker(port) {
       callNow: (...args) => doSyscall(['callNow', ...args]),
       subscribe: (...args) => doSyscall(['subscribe', ...args]),
       resolve: (...args) => doSyscall(['resolve', ...args]),
+      exit: (...args) => doSyscall(['exit', ...args]),
       vatstoreGet: (...args) => doSyscall(['vatstoreGet', ...args]),
       vatstoreSet: (...args) => doSyscall(['vatstoreSet', ...args]),
       vatstoreDelete: (...args) => doSyscall(['vatstoreDelete', ...args]),


### PR DESCRIPTION
Some unfortunate code duplication meant the nodeworker/subprocess-node
workers were lacking vatstoreGet, vatstoreSet, and vatstoreDelete. And
everything but the local worker was lacking syscall.exit.

refs #2643 , but doesn't close it because I want to (eventually) write proper
tests for this

cc @dckc just so you know this is getting addressed :)
