### PR TITLE
fix: make separate 'test:xs' target, remove XS from 'test' target

### DIFF
--- a/golang/cosmos/package.json
+++ b/golang/cosmos/package.json
@@ -15,6 +15,7 @@
     "build:gyp": "make compile-gyp",
     "build:gyp-debug": "make compile-gyp GYP_DEBUG=--debug",
     "test:nyc": "nyc ava",
+    "test:xs": "exit 0",
     "build": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint-check": "eslint '**/*.js'"

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "lint-check": "yarn workspaces run lint-check",
     "lint": "yarn workspaces run lint-check",
     "test": "yarn workspaces run test",
+    "test:xs": "yarn workspaces run test:xs",
     "build": "yarn workspaces run build",
     "postinstall": "patch-package",
     "patch-package": "patch-package",

--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -11,8 +11,7 @@
   },
   "scripts": {
     "build": "exit 0",
-    "test": "yarn test:node && yarn test:xs",
-    "test:node": "ava",
+    "test": "ava",
     "test:xs": "yarn test:xs-unit && yarn test:xs-worker",
     "test:xs-unit": "ava-xs",
     "test:xs-worker": "WORKER_TYPE=xs-worker ava",

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
+    "test:xs": "exit 0",
     "test:xs-worker": "ava test/workers/test-worker.js -m 'xs vat manager'",
     "pretty-fix": "prettier --write '**/*.js'",
     "pretty-check": "prettier --check '**/*.js'",

--- a/packages/acorn-eventual-send/package.json
+++ b/packages/acorn-eventual-send/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
+    "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint-check": "eslint '**/*.js'"
   },

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava --config .ava-unit-test.config.js",
+    "test:xs": "exit 0",
     "integration-test": "ava --config .ava-integration-test.config.js",
     "lint-check": "eslint '**/*.{js,jsx}'",
     "lint-fix": "eslint --fix '**/*.{js,jsx}'"

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -13,6 +13,7 @@
     "build": "exit 0",
     "test": "exit 0",
     "test:nyc": "exit 0",
+    "test:xs": "exit 0",
     "lint-fix": "yarn lint --fix",
     "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",

--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -28,7 +28,8 @@
     "lint-fix": "eslint --fix '**/*.js'",
     "prepublish": "yarn clean && yarn build",
     "test": "ava",
-    "test:nyc": "nyc ava"
+    "test:nyc": "nyc ava",
+    "test:xs": "exit 0"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^6.1.0",

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -10,6 +10,7 @@
     "build": "exit 0",
     "test": "ava",
     "test:nyc": "nyc ava",
+    "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint-check": "eslint '**/*.js'",
     "lint-fix-jessie": "eslint -c '.eslintrc-jessie.js' --fix '**/*.js'",

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -30,6 +30,7 @@
     "build": "exit 0",
     "test": "ava",
     "test:nyc": "nyc ava",
+    "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint-check": "eslint 'lib/*.js'"
   },

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -11,6 +11,7 @@
     "build": "exit 0",
     "test": "ava",
     "test:nyc": "nyc ava",
+    "test:xs": "exit 0",
     "pretty-fix": "prettier --write '**/*.js'",
     "pretty-check": "prettier --check '**/*.js'",
     "lint-fix": "yarn lint --fix",

--- a/packages/dapp-svelte-wallet/api/package.json
+++ b/packages/dapp-svelte-wallet/api/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
+    "test:xs": "exit 0",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint-fix": "yarn lint --fix",
     "lint-check": "yarn lint",

--- a/packages/dapp-svelte-wallet/package.json
+++ b/packages/dapp-svelte-wallet/package.json
@@ -20,6 +20,7 @@
     "lint-fix": "exit 0",
     "lint-check": "exit 0",
     "test": "exit 0",
+    "test:xs": "exit 0",
     "build": "exit 0"
   },
   "dependencies": {

--- a/packages/dapp-svelte-wallet/ui/package.json
+++ b/packages/dapp-svelte-wallet/ui/package.json
@@ -10,7 +10,8 @@
     "lint-check": "yarn lint",
     "lint-fix": "exit 0",
     "lint": "exit 0",
-    "test": "exit 0"
+    "test": "exit 0",
+    "test:xs": "exit 0"
   },
   "devDependencies": {
     "@agoric/captp": "^1.7.2",

--- a/packages/deploy-script-support/package.json
+++ b/packages/deploy-script-support/package.json
@@ -13,6 +13,7 @@
     "build": "exit 0",
     "test": "ava",
     "test:nyc": "nyc ava",
+    "test:xs": "exit 0",
     "pretty-fix": "prettier --write '**/*.js'",
     "pretty-check": "prettier --check '**/*.js'",
     "lint-fix": "yarn lint --fix",

--- a/packages/deployment/package.json
+++ b/packages/deployment/package.json
@@ -9,6 +9,7 @@
   "main": "main.js",
   "scripts": {
     "test": "exit 0",
+    "test:xs": "exit 0",
     "build": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint-check": "eslint '**/*.js'"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "test": "exit 0",
     "test:nyc": "exit 0",
+    "test:xs": "exit 0",
     "build": "exit 0",
     "lint-fix": "exit 0",
     "lint-check": "exit 0"

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -11,6 +11,7 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "exit 0",
+    "test:xs": "exit 0",
     "build": "exit 0",
     "lint-fix": "exit 0",
     "lint-check": "exit 0"

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "test": "ava",
     "test:nyc": "nyc ava",
+    "test:xs": "exit 0",
     "build": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint-check": "eslint '**/*.js'"

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "test": "ava",
     "test:nyc": "nyc ava",
+    "test:xs": "exit 0",
     "build": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint-check": "eslint '**/*.js'"

--- a/packages/import-manager/package.json
+++ b/packages/import-manager/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
+    "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint-check": "eslint '**/*.js'"
   },

--- a/packages/install-metering-and-ses/package.json
+++ b/packages/install-metering-and-ses/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
+    "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint-check": "eslint '**/*.js'"
   },

--- a/packages/install-ses/package.json
+++ b/packages/install-ses/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
+    "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint-check": "eslint '**/*.js'"
   },

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -13,6 +13,7 @@
     "build": "exit 0",
     "test": "ava",
     "test:nyc": "nyc ava",
+    "test:xs": "exit 0",
     "pretty-fix": "prettier --write '**/*.js'",
     "pretty-check": "prettier --check '**/*.js'",
     "lint-fix": "yarn lint --fix",

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -13,6 +13,7 @@
     "build": "exit 0",
     "test": "ava",
     "test:nyc": "nyc ava",
+    "test:xs": "exit 0",
     "lint-fix": "yarn lint --fix",
     "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "exit 0",
+    "test:xs": "exit 0",
     "lint-fix": "yarn lint --fix",
     "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",

--- a/packages/registrar/package.json
+++ b/packages/registrar/package.json
@@ -13,6 +13,7 @@
     "build": "exit 0",
     "test": "ava",
     "test:nyc": "nyc ava",
+    "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint-check": "eslint '**/*.js'"
   },

--- a/packages/same-structure/package.json
+++ b/packages/same-structure/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "exit 0",
+    "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint-check": "eslint '**/*.js'"
   },

--- a/packages/sharing-service/package.json
+++ b/packages/sharing-service/package.json
@@ -13,6 +13,7 @@
     "build": "exit 0",
     "test": "ava",
     "test:nyc": "nyc ava",
+    "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint-check": "eslint '**/*.js'"
   },

--- a/packages/sparse-ints/package.json
+++ b/packages/sparse-ints/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "exit 0",
+    "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint-check": "eslint '**/*.js'"
   },

--- a/packages/spawner/package.json
+++ b/packages/spawner/package.json
@@ -13,6 +13,7 @@
     "build": "exit 0",
     "test": "ava",
     "test:nyc": "nyc ava",
+    "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint-check": "eslint '**/*.js'"
   },

--- a/packages/stat-logger/package.json
+++ b/packages/stat-logger/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "exit 0",
+    "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint-check": "eslint '**/*.js'"
   },

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
+    "test:xs": "exit 0",
     "lint-fix": "yarn lint --fix",
     "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",

--- a/packages/swing-store-lmdb/package.json
+++ b/packages/swing-store-lmdb/package.json
@@ -13,6 +13,7 @@
     "build": "exit 0",
     "test": "ava",
     "test:nyc": "nyc ava",
+    "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint-check": "eslint '**/*.js'"
   },

--- a/packages/swing-store-simple/package.json
+++ b/packages/swing-store-simple/package.json
@@ -13,6 +13,7 @@
     "build": "exit 0",
     "test": "ava",
     "test:nyc": "nyc ava",
+    "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint-check": "eslint '**/*.js'"
   },

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -14,6 +14,7 @@
     "build": "exit 0",
     "test": "ava",
     "test:nyc": "nyc ava",
+    "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint-check": "eslint '**/*.js'",
     "ci:autobench": "./autobench"

--- a/packages/tame-metering/package.json
+++ b/packages/tame-metering/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "test": "ava",
     "test:nyc": "nyc ava",
+    "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.{js,jsx}'",
     "lint-check": "eslint '**/*.{js,jsx}'",
     "build": "exit 0"

--- a/packages/transform-eventual-send/package.json
+++ b/packages/transform-eventual-send/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "test": "ava",
     "test:nyc": "nyc ava",
+    "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint-check": "eslint '**/*.js'",
     "build": "exit 0"

--- a/packages/transform-metering/package.json
+++ b/packages/transform-metering/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "test": "ava",
     "test:nyc": "nyc ava",
+    "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.{js,jsx}'",
     "lint-check": "eslint '**/*.{js,jsx}'",
     "build": "exit 0"

--- a/packages/xsnap/package.json
+++ b/packages/xsnap/package.json
@@ -23,7 +23,8 @@
     "lint:types": "tsc -p jsconfig.json",
     "lint-fix": "eslint --fix 'src/**/*.js' 'lib/**/*.js'",
     "lint-check": "yarn lint",
-    "test": "ava"
+    "test": "ava",
+    "test:xs": "exit 0"
   },
   "dependencies": {
     "@agoric/assert": "^0.2.2-dev.0",

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -11,9 +11,9 @@
   },
   "scripts": {
     "build": "yarn build-zcfBundle",
-    "test": "yarn test:node && yarn test:xs-unit",
-    "test:node": "ava --verbose",
+    "test": "ava --verbose",
     "test:nyc": "nyc ava",
+    "test:xs": "yarn test:xs-unit",
     "test:xs-unit": "ava-xs --verbose",
     "test:xs-unit-debug": "ava-xs --debug",
     "test:xs-worker": "WORKER_TYPE=xs-worker ava",


### PR DESCRIPTION
Running `yarn test` from the top level causes `yarn test` to be
run in each workspace.

Previously, in some packages (zoe and ERTP in particular), the local `yarn
test` expanded into doing both `test:node` and `test:xs`.

This introduces a new top-level `yarn test:xs` target, which runs `yarn
test:xs` in each workspace. Zoe and ERTP's local `yarn test` was changed to
only run the node tests. Zoe and ERTP 's local `yarn test:xs` runs the unit
tests under XS. All other packages have a no-op `exit 0` in their `test:xs`
target, so the top-level target doesn't crash when it encounters a package
that doesn't have any XS-specific testing (which is most of them).

With this change, CI will stop testing XS on each run. We'll follow up with a
separate change that tells CI to do a top-level `yarn test:xs`, probably with
a flag that makes the success optional (don't flunk a PR if it fails the XS
tests, for now).

refs #2647