### PR TITLE
refactor: Zoe uses new AmountMath

### DIFF
--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -183,7 +183,7 @@ const amountMath = {
   make: (allegedValue, brand) => {
     assertLooksLikeBrand(brand);
     assertLooksLikeValue(allegedValue);
-    // @ts-ignore
+    // @ts-ignore Needs better typing to express Value to Helpers relationship
     const value = getHelpersFromValue(allegedValue).doCoerce(allegedValue);
     return harden({ brand, value });
   },
@@ -212,23 +212,23 @@ const amountMath = {
     assertLooksLikeAmount(amount);
     optionalBrandCheck(amount, brand);
     const h = getHelpersFromAmount(amount);
-    // @ts-ignore
+    // @ts-ignore Needs better typing to express Value to Helpers relationship
     return h.doIsEmpty(h.doCoerce(amount.value));
   },
   isGTE: (leftAmount, rightAmount, brand = undefined) => {
     const h = checkLRAndGetHelpers(leftAmount, rightAmount, brand);
-    // @ts-ignore
+    // @ts-ignore Needs better typing to express Value to Helpers relationship
     return h.doIsGTE(...coerceLR(h, leftAmount, rightAmount));
   },
   isEqual: (leftAmount, rightAmount, brand = undefined) => {
     const h = checkLRAndGetHelpers(leftAmount, rightAmount, brand);
-    // @ts-ignore
+    // @ts-ignore Needs better typing to express Value to Helpers relationship
     return h.doIsEqual(...coerceLR(h, leftAmount, rightAmount));
   },
   add: (leftAmount, rightAmount, brand = undefined) => {
     const h = checkLRAndGetHelpers(leftAmount, rightAmount, brand);
     return noCoerceMake(
-      // @ts-ignore
+      // @ts-ignore Needs better typing to express Value to Helpers relationship
       h.doAdd(...coerceLR(h, leftAmount, rightAmount)),
       leftAmount.brand,
     );
@@ -236,7 +236,7 @@ const amountMath = {
   subtract: (leftAmount, rightAmount, brand = undefined) => {
     const h = checkLRAndGetHelpers(leftAmount, rightAmount, brand);
     return noCoerceMake(
-      // @ts-ignore
+      // @ts-ignore Needs better typing to express Value to Helpers relationship
       h.doSubtract(...coerceLR(h, leftAmount, rightAmount)),
       leftAmount.brand,
     );

--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -3,12 +3,13 @@
 import { assert, details as X } from '@agoric/assert';
 import { mustBeComparable } from '@agoric/same-structure';
 import { passStyleOf, REMOTE_STYLE } from '@agoric/marshal';
-import { Nat, isNat } from '@agoric/nat';
+import { isNat } from '@agoric/nat';
 
 import './types';
 import natMathHelpers from './mathHelpers/natMathHelpers';
 import setMathHelpers from './mathHelpers/setMathHelpers';
 import { makeAmountMath } from './deprecatedAmountMath';
+import { isSetValue, isNatValue } from './typeGuards';
 
 // We want an enum, but narrowed to the AmountMathKind type.
 /**
@@ -68,22 +69,34 @@ const helpers = {
 };
 
 /**
- * @type {(value: NatValue | SetValue) => SetMathHelpers | NatMathHelpers }
+ * @param {Value} value
+ * @returns {NatMathHelpers | SetMathHelpers}
  */
 const getHelpersFromValue = value => {
-  if (Array.isArray(value)) {
+  if (isSetValue(value)) {
     return setMathHelpers;
   }
-  assert(
-    typeof Nat(value) === 'bigint',
-    X`value ${value} must be a bigint or an array`,
-  );
-  return natMathHelpers;
+  if (isNatValue(value)) {
+    return natMathHelpers;
+  }
+  assert.fail(X`value ${value} must be a bigint or an array`);
 };
 
-/** @type {(amount: Amount ) => NatMathHelpers | SetMathHelpers} */
+/** @type {(amount: Amount) => AmountMathKind} */
+const getMathKind = amount => {
+  if (isSetValue(amount.value)) {
+    return 'set';
+  }
+  if (isNatValue(amount.value)) {
+    return 'nat';
+  }
+  assert.fail(X`value ${amount.value} must be a bigint or an array`);
+};
+
+/**
+ * @type {(amount: Amount ) => NatMathHelpers | SetMathHelpers }
+ */
 const getHelpersFromAmount = amount => {
-  // @ts-ignore
   return getHelpersFromValue(amount.value);
 };
 
@@ -122,16 +135,8 @@ const assertLooksLikeValue = value => {
   );
 };
 
-const brandMethods = ['isMyIssuer', 'getAllegedName', 'getDisplayInfo'];
-
 const checkBrand = (brand, msg) => {
   assert(passStyleOf(brand) === REMOTE_STYLE, msg);
-  const ownKeys = Reflect.ownKeys(brand);
-  const inBrandMethods = key => brandMethods.includes(key);
-  assert(
-    ownKeys.every(inBrandMethods),
-    X`The brand ${brand} doesn't look like a brand. It has these keys: ${ownKeys}`,
-  );
 };
 
 /** @type {(brand: Brand) => void} */
@@ -193,7 +198,7 @@ const amountMath = {
     return amountMath.make(allegedAmount.value, brand);
   },
   getValue: (amount, brand) => amountMath.coerce(amount, brand).value,
-  makeEmpty: (mathKind, brand) => {
+  makeEmpty: (brand, mathKind = MathKind.NAT) => {
     assert(
       helpers[mathKind],
       X`${mathKind} must be MathKind.NAT or MathKind.SET. MathKind.STRING_SET is accepted but deprecated`,
@@ -201,6 +206,8 @@ const amountMath = {
     assertLooksLikeBrand(brand);
     return noCoerceMake(helpers[mathKind].doMakeEmpty(), brand);
   },
+  makeEmptyFromAmount: amount =>
+    amountMath.makeEmpty(amount.brand, getMathKind(amount)),
   isEmpty: (amount, brand = undefined) => {
     assertLooksLikeAmount(amount);
     optionalBrandCheck(amount, brand);
@@ -237,4 +244,4 @@ const amountMath = {
 };
 harden(amountMath);
 
-export { amountMath, MathKind, makeAmountMath };
+export { amountMath, MathKind, getMathKind, makeAmountMath };

--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -20,6 +20,7 @@ import { isSetValue, isNatValue } from './typeGuards';
 const MathKind = {
   NAT: 'nat',
   SET: 'set',
+  // Deprecated, to be removed in Beta
   STRING_SET: 'strSet',
 };
 harden(MathKind);
@@ -135,14 +136,14 @@ const assertLooksLikeValue = value => {
   );
 };
 
-const checkBrand = (brand, msg) => {
+const assertBrand = (brand, msg) => {
   assert(passStyleOf(brand) === REMOTE_STYLE, msg);
 };
 
 /** @type {(brand: Brand) => void} */
 const assertLooksLikeBrand = brand => {
   const msg = X`The brand ${brand} doesn't look like a brand.`;
-  checkBrand(brand, msg);
+  assertBrand(brand, msg);
 };
 
 /**
@@ -153,7 +154,7 @@ const assertLooksLikeBrand = brand => {
  */
 const assertLooksLikeAmountBrand = amount => {
   const msg = X`The amount ${amount} doesn't look like an amount. Did you pass a value instead?`;
-  checkBrand(amount.brand, msg);
+  assertBrand(amount.brand, msg);
 };
 
 const assertLooksLikeAmount = amount => {

--- a/packages/ERTP/src/index.js
+++ b/packages/ERTP/src/index.js
@@ -3,3 +3,4 @@
 export * from './amountMath';
 export * from './issuer';
 export * from './localAmountMath';
+export * from './typeGuards';

--- a/packages/ERTP/src/issuer.js
+++ b/packages/ERTP/src/issuer.js
@@ -52,7 +52,7 @@ function makeIssuerKit(
   const isEqual = (left, right) => amountMath.isEqual(left, right, brand);
 
   /** @type {Amount} */
-  const emptyAmount = amountMath.makeEmpty(amountMathKind, brand);
+  const emptyAmount = amountMath.makeEmpty(brand, amountMathKind);
 
   const makePayment = makePaymentMaker(allegedName, brand);
 
@@ -285,6 +285,7 @@ function makeIssuerKit(
     issuer,
     amountMath: makeAmountMath(brand, amountMathKind),
     brand,
+    amountMathKind,
   });
 }
 

--- a/packages/ERTP/src/mathHelpers/setMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/setMathHelpers.js
@@ -2,7 +2,7 @@
 
 import { passStyleOf } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
-import { sameStructure } from '@agoric/same-structure';
+import { mustBeComparable, sameStructure } from '@agoric/same-structure';
 
 import '../types';
 
@@ -86,6 +86,7 @@ const hasElement = (buckets, elem) => {
 const setMathHelpers = harden({
   doCoerce: list => {
     harden(list);
+    mustBeComparable(list);
     assert(passStyleOf(list) === 'copyArray', 'list must be an array');
     checkForDupes(makeBuckets(list));
     return list;

--- a/packages/ERTP/src/typeGuards.js
+++ b/packages/ERTP/src/typeGuards.js
@@ -1,0 +1,51 @@
+import { assert } from '@agoric/assert';
+import { Nat } from '@agoric/nat';
+
+/**
+ * Type guard for SetValue
+ *
+ * @param {Value} value
+ * @returns {value is SetValue}
+ */
+export const isSetValue = value => Array.isArray(value);
+
+/**
+ * Type guard for NatValue
+ *
+ * @param {Value} value
+ * @returns {value is NatValue}
+ */
+export const isNatValue = value => {
+  if (isSetValue(value)) {
+    return false;
+  }
+  return typeof Nat(value) === 'bigint';
+};
+
+/**
+ * @param {NatMathHelpers | SetMathHelpers } mathHelpers
+ * @returns {mathHelpers is SetMathHelpers}
+ */
+export const isSetMathHelpers = mathHelpers =>
+  isSetValue(mathHelpers.doMakeEmpty());
+
+/**
+ * @param {NatMathHelpers | SetMathHelpers } mathHelpers
+ * @returns {mathHelpers is NatMathHelpers}
+ */
+export const isNatMathHelpers = mathHelpers =>
+  isNatValue(mathHelpers.doMakeEmpty());
+
+/**
+ * @param {Value} value
+ * @returns {asserts SetValue}
+ */
+export const assertSetValue = value =>
+  assert(isSetValue(value), `Must be a SetValue`);
+
+/**
+ * @param {Value} value
+ * @returns {asserts NatValue}
+ */
+export const assertNatValue = value =>
+  assert(isNatValue(value), `Must be a NatValue`);

--- a/packages/ERTP/src/typeGuards.js
+++ b/packages/ERTP/src/typeGuards.js
@@ -1,4 +1,3 @@
-import { assert } from '@agoric/assert';
 import { isNat } from '@agoric/nat';
 
 /**

--- a/packages/ERTP/src/typeGuards.js
+++ b/packages/ERTP/src/typeGuards.js
@@ -3,6 +3,9 @@ import { isNat } from '@agoric/nat';
 
 /**
  * Type guard for SetValue
+ * Used as a pre-validation check to select which validator
+ * (mathHelpers) to use, and also used with assert to satisfy
+ * Typescript checking
  *
  * @param {Value} value
  * @returns {value is SetValue}
@@ -10,23 +13,12 @@ import { isNat } from '@agoric/nat';
 export const isSetValue = value => Array.isArray(value);
 
 /**
- * Type guard for NatValue
+ * Type guard for NatValue.
+ * Used as a pre-validation check to select which validator
+ * (mathHelpers) to use, and also used with assert to satisfy
+ * Typescript checking
  *
  * @param {Value} value
  * @returns {value is NatValue}
  */
 export const isNatValue = value => isNat(value);
-
-/**
- * @param {Value} value
- * @returns {asserts SetValue}
- */
-export const assertSetValue = value =>
-  assert(isSetValue(value), `Must be a SetValue`);
-
-/**
- * @param {Value} value
- * @returns {asserts NatValue}
- */
-export const assertNatValue = value =>
-  assert(isNatValue(value), `Must be a NatValue`);

--- a/packages/ERTP/src/typeGuards.js
+++ b/packages/ERTP/src/typeGuards.js
@@ -1,5 +1,5 @@
 import { assert } from '@agoric/assert';
-import { isNat, Nat } from '@agoric/nat';
+import { isNat } from '@agoric/nat';
 
 /**
  * Type guard for SetValue

--- a/packages/ERTP/src/typeGuards.js
+++ b/packages/ERTP/src/typeGuards.js
@@ -1,5 +1,5 @@
 import { assert } from '@agoric/assert';
-import { Nat } from '@agoric/nat';
+import { isNat, Nat } from '@agoric/nat';
 
 /**
  * Type guard for SetValue
@@ -15,26 +15,7 @@ export const isSetValue = value => Array.isArray(value);
  * @param {Value} value
  * @returns {value is NatValue}
  */
-export const isNatValue = value => {
-  if (isSetValue(value)) {
-    return false;
-  }
-  return typeof Nat(value) === 'bigint';
-};
-
-/**
- * @param {NatMathHelpers | SetMathHelpers } mathHelpers
- * @returns {mathHelpers is SetMathHelpers}
- */
-export const isSetMathHelpers = mathHelpers =>
-  isSetValue(mathHelpers.doMakeEmpty());
-
-/**
- * @param {NatMathHelpers | SetMathHelpers } mathHelpers
- * @returns {mathHelpers is NatMathHelpers}
- */
-export const isNatMathHelpers = mathHelpers =>
-  isNatValue(mathHelpers.doMakeEmpty());
+export const isNatValue = value => isNat(value);
 
 /**
  * @param {Value} value

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -41,6 +41,13 @@
  */
 
 /**
+ * @callback MakeEmpty
+ * @param {Brand} brand
+ * @param {AmountMathKind=} mathKind
+ * @returns {Amount}
+ */
+
+/**
  * @typedef {Object} AmountMath
  * Logic for manipulating amounts.
  *
@@ -58,9 +65,13 @@
  * @property {(amount: Amount, brand: Brand) => Value} getValue
  * Extract and return the value.
  *
- * @property {(string: mathKind, brand: Brand) => Amount} makeEmpty
+ * @property {MakeEmpty} makeEmpty
  * Return the amount representing an empty amount. This is the
  * identity element for MathHelpers.add and MatHelpers.subtract.
+ *
+ * @property {(amount: Amount) => Amount} makeEmptyFromAmount
+ * Return the amount representing an empty amount, using another
+ * amount as the template for the brand and mathKind.
  *
  * @property {(amount: Amount, brand?: Brand) => boolean} isEmpty
  * Return true if the Amount is empty. Otherwise false.
@@ -130,6 +141,20 @@
  */
 
 /**
+ * @callback IssuerBurn
+ * @param {PaymentP} payment
+ * @param {Amount=} optAmount
+ * @returns {Promise<Amount>}
+ */
+
+/**
+ * @callback IssuerClaim
+ * @param {PaymentP} payment
+ * @param {Amount=} optAmount
+ * @returns {Promise<Payment>}
+ */
+
+/**
  * @typedef {Object} Issuer
  * The issuer cannot mint a new amount, but it can create empty purses and
  * payments. The issuer can also transform payments (splitting payments,
@@ -160,7 +185,7 @@
  *
  * If the payment is a promise, the operation will proceed upon resolution.
  *
- * @property {(payment: PaymentP, optAmount: Amount=) => Promise<Amount>} burn
+ * @property {IssuerBurn} burn
  * Burn all of the digital assets in the payment. `optAmount` is optional.
  * If `optAmount` is present, the code will insist that the amount of
  * the digital assets in the payment is equal to `optAmount`, to
@@ -168,7 +193,7 @@
  *
  * If the payment is a promise, the operation will proceed upon resolution.
  *
- * @property {(payment: PaymentP, optAmount: Amount=) => Promise<Payment>} claim
+ * @property {IssuerClaim} claim
  * Transfer all digital assets from the payment to a new payment and
  * delete the original. `optAmount` is optional.
  * If `optAmount` is present, the code will insist that the amount of
@@ -221,6 +246,7 @@
  * @property {Issuer} issuer
  * @property {DeprecatedAmountMath} amountMath
  * @property {Brand} brand
+ * @property {AmountMathKind} amountMathKind
  */
 
 /**
@@ -234,13 +260,27 @@
  */
 
 /**
+ * @callback DepositFacetReceive
+ * @param {Payment} payment
+ * @param {Amount=} optAmount
+ * @returns {Amount}
+ */
+
+/**
  * @typedef {Object} DepositFacet
- * @property {(payment: Payment, optAmount: Amount=) => Amount} receive
+ * @property {DepositFacetReceive} receive
  * Deposit all the contents of payment into the purse that made this facet,
  * returning the amount. If the optional argument `optAmount` does not equal the
  * amount of digital assets in the payment, throw an error.
  *
  * If payment is a promise, throw an error.
+ */
+
+/**
+ * @callback PurseDeposit
+ * @param {Payment} payment
+ * @param {Amount=} optAmount
+ * @returns {Amount}
  */
 
 /**
@@ -262,7 +302,7 @@
  * @property {() => Notifier<Amount>} getCurrentAmountNotifier
  * Get a lossy notifier for changes to this purse's balance.
  *
- * @property {(payment: Payment, optAmount: Amount=) => Amount} deposit
+ * @property {PurseDeposit} deposit
  * Deposit all the contents of payment into this purse, returning the
  * amount. If the optional argument `optAmount` does not equal the
  * amount of digital assets in the payment, throw an error.
@@ -300,7 +340,7 @@
 
 /**
  * @template V
- * @typedef {Object} MathHelpers<T>
+ * @typedef {Object} MathHelpers<V>
  * All of the difference in how digital asset amount are manipulated can be reduced to
  * the behavior of the math on values. We extract this
  * custom logic into mathHelpers. MathHelpers are about value

--- a/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
@@ -106,7 +106,7 @@ test('natMathHelpers getValue no brand', t => {
 test('natMathHelpers makeEmpty', t => {
   const empty = m.make(0n, mockBrand);
 
-  t.deepEqual(m.makeEmpty(MathKind.NAT, mockBrand), empty, `empty is 0`);
+  t.deepEqual(m.makeEmpty(mockBrand), empty, `empty is 0`);
 });
 
 test('natMathHelpers makeEmpty no brand', t => {
@@ -114,9 +114,9 @@ test('natMathHelpers makeEmpty no brand', t => {
     // @ts-ignore
     () => m.makeEmpty(MathKind.NAT),
     {
-      message: "The brand (an undefined) doesn't look like a brand.",
+      message: "The brand (a string) doesn't look like a brand.",
     },
-    `brand is required in coerce`,
+    `make empty no brand`,
   );
 });
 

--- a/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
@@ -78,7 +78,7 @@ test('natMathHelpers coerce', t => {
 
 test('natMathHelpers coerce no brand', t => {
   t.throws(
-    // @ts-ignore
+    // @ts-ignore deliberate invalid arguments for testing
     () => m.coerce(m.make(4n, mockBrand)),
     {
       message: "The brand (an undefined) doesn't look like a brand.",
@@ -94,7 +94,7 @@ test('natMathHelpers getValue', t => {
 
 test('natMathHelpers getValue no brand', t => {
   t.throws(
-    // @ts-ignore
+    // @ts-ignore deliberate invalid arguments for testing
     () => m.getValue(m.make(4n, mockBrand)),
     {
       message: "The brand (an undefined) doesn't look like a brand.",
@@ -111,7 +111,7 @@ test('natMathHelpers makeEmpty', t => {
 
 test('natMathHelpers makeEmpty no brand', t => {
   t.throws(
-    // @ts-ignore
+    // @ts-ignore deliberate invalid arguments for testing
     () => m.makeEmpty(MathKind.NAT),
     {
       message: "The brand (a string) doesn't look like a brand.",

--- a/packages/ERTP/test/unitTests/mathHelpers/test-setMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-setMathHelpers.js
@@ -107,7 +107,7 @@ const runSetMathHelpersTests = (t, [a, b, c], a2 = undefined) => {
 
   // makeEmpty
   t.deepEqual(
-    m.makeEmpty(MathKind.SET, mockBrand),
+    m.makeEmpty(mockBrand, MathKind.SET),
     { brand: mockBrand, value: [] },
     `empty is []`,
   );

--- a/packages/ERTP/test/unitTests/mathHelpers/test-strSetMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-strSetMathHelpers.js
@@ -59,7 +59,7 @@ test('set with strings getValue', t => {
 
 test('set with strings makeEmpty', t => {
   t.deepEqual(
-    m.makeEmpty(MathKind.SET, mockBrand),
+    m.makeEmpty(mockBrand, MathKind.SET),
     { brand: mockBrand, value: [] },
     `empty is []`,
   );

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -79,10 +79,7 @@ test('issuer.makeEmptyPurse', async t => {
   };
 
   t.assert(
-    amountMath.isEqual(
-      purse.getCurrentAmount(),
-      amountMath.makeEmpty(MathKind.NAT, brand),
-    ),
+    amountMath.isEqual(purse.getCurrentAmount(), amountMath.makeEmpty(brand)),
     `empty purse is empty`,
   );
   await checkNotifier();
@@ -111,10 +108,7 @@ test('issuer.makeEmptyPurse', async t => {
       );
     });
     t.assert(
-      amountMath.isEqual(
-        purse.getCurrentAmount(),
-        amountMath.makeEmpty(MathKind.NAT, brand),
-      ),
+      amountMath.isEqual(purse.getCurrentAmount(), amountMath.makeEmpty(brand)),
       `the purse is empty again`,
     );
     await checkNotifier();
@@ -130,7 +124,7 @@ test('issuer.makeEmptyPurse', async t => {
 test('purse.deposit', async t => {
   t.plan(7);
   const { issuer, mint, brand } = makeIssuerKit('fungible');
-  const fungible0 = amountMath.makeEmpty(MathKind.NAT, brand);
+  const fungible0 = amountMath.makeEmpty(brand);
   const fungible17 = amountMath.make(17n, brand);
   const fungible25 = amountMath.make(25n, brand);
   const fungibleSum = amountMath.add(fungible17, fungible25);

--- a/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
@@ -164,17 +164,19 @@ export function buildRootObject(vatPowers, vatParameters) {
      * @param {Array<[number, number]>} tradeList
      */
     const makeFakePriceAuthority = async (issuerIn, issuerOut, tradeList) => {
-      const [brandIn, brandOut, pa] = await Promise.all([
+      const [brandIn, brandOut] = await Promise.all([
         E(issuerIn).getBrand(),
         E(issuerOut).getBrand(),
-        E(vats.priceAuthority).makeFakePriceAuthority({
-          issuerIn,
-          issuerOut,
-          tradeList,
-          timer: chainTimerService,
-          quoteInterval: QUOTE_INTERVAL,
-        }),
       ]);
+      const pa = await E(vats.priceAuthority).makeFakePriceAuthority({
+        issuerIn,
+        issuerOut,
+        actualBrandIn: brandIn,
+        actualBrandOut: brandOut,
+        tradeList,
+        timer: chainTimerService,
+        quoteInterval: QUOTE_INTERVAL,
+      });
       return E(priceAuthorityAdmin).registerPriceAuthority(
         pa,
         brandIn,

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-priceAuthority.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-priceAuthority.js
@@ -1,18 +1,12 @@
 import { Far } from '@agoric/marshal';
 import { makePriceAuthorityRegistry } from '@agoric/zoe/tools/priceAuthorityRegistry';
 import { makeFakePriceAuthority } from '@agoric/zoe/tools/fakePriceAuthority';
-import { makeLocalAmountMath } from '@agoric/ertp';
 
 export function buildRootObject(_vatPowers) {
   return Far('root', {
     makePriceAuthority: makePriceAuthorityRegistry,
     async makeFakePriceAuthority(options) {
-      const { issuerIn, issuerOut } = options;
-      const [mathIn, mathOut] = await Promise.all([
-        makeLocalAmountMath(issuerIn),
-        makeLocalAmountMath(issuerOut),
-      ]);
-      return makeFakePriceAuthority({ ...options, mathIn, mathOut });
+      return makeFakePriceAuthority({ ...options });
     },
   });
 }

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-priceAuthority.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-priceAuthority.js
@@ -5,8 +5,6 @@ import { makeFakePriceAuthority } from '@agoric/zoe/tools/fakePriceAuthority';
 export function buildRootObject(_vatPowers) {
   return Far('root', {
     makePriceAuthority: makePriceAuthorityRegistry,
-    async makeFakePriceAuthority(options) {
-      return makeFakePriceAuthority({ ...options });
-    },
+    makeFakePriceAuthority: async options => makeFakePriceAuthority(options),
   });
 }

--- a/packages/zoe/scripts/build-zcfBundle.js
+++ b/packages/zoe/scripts/build-zcfBundle.js
@@ -1,4 +1,6 @@
 /* global __dirname */
+
+// eslint-disable-next-line import/no-extraneous-dependencies
 import 'ses';
 import fs from 'fs';
 import process from 'process';
@@ -6,6 +8,7 @@ import bundleSource from '@agoric/bundle-source';
 
 async function writeSourceBundle(contractFilename, outputPath) {
   await bundleSource(contractFilename).then(bundle => {
+    // @ts-ignore
     fs.mkdirSync(`${__dirname}/../bundles`, { recursive: true }, err => {
       if (err) throw err;
     });

--- a/packages/zoe/scripts/build-zcfBundle.js
+++ b/packages/zoe/scripts/build-zcfBundle.js
@@ -8,7 +8,8 @@ import bundleSource from '@agoric/bundle-source';
 
 async function writeSourceBundle(contractFilename, outputPath) {
   await bundleSource(contractFilename).then(bundle => {
-    // @ts-ignore
+    // TODO: fix
+    // @ts-ignore mkdirSync believes it only accepts 2 arguments.
     fs.mkdirSync(`${__dirname}/../bundles`, { recursive: true }, err => {
       if (err) throw err;
     });

--- a/packages/zoe/src/cleanProposal.js
+++ b/packages/zoe/src/cleanProposal.js
@@ -14,6 +14,7 @@ import '../exported';
 import './internal-types';
 
 import { arrayToObj, assertSubset } from './objArrayConversion';
+import { MathKind } from '@agoric/ertp/src/deprecatedAmountMath';
 
 const firstCapASCII = /^[A-Z][a-zA-Z0-9_$]*$/;
 
@@ -73,8 +74,14 @@ const coerceAmountKeywordRecord = (
   // indicated by brand. `AmountMath.coerce` throws if coercion fails.
   const coercedAmounts = amounts.map(amount => {
     const brandMathKind = getMathKindByBrand(amount.brand);
+    const amountMathKind = getMathKind(amount);
+    // TODO: replace this assertion with a check of the mathKind
+    // property on the brand, when that exists. Additionally, remove
+    // the deprecated STRING_SET
     assert(
-      getMathKind(amount) === brandMathKind,
+      amountMathKind === brandMathKind ||
+        (brandMathKind === MathKind.STRING_SET &&
+          amountMathKind === MathKind.SET),
       X`The amount ${amount} did not have the mathKind of the brand ${brandMathKind}`,
     );
     return amountMath.coerce(amount, amount.brand);

--- a/packages/zoe/src/cleanProposal.js
+++ b/packages/zoe/src/cleanProposal.js
@@ -61,7 +61,7 @@ const cleanKeys = (allowedKeys, record) => {
 export const getKeywords = keywordRecord =>
   harden(Object.getOwnPropertyNames(keywordRecord));
 
-export const coerceAmountKeywordRecord = allegedAmountKeywordRecord => {
+const coerceAmountKeywordRecord = allegedAmountKeywordRecord => {
   const keywords = getKeywords(allegedAmountKeywordRecord);
   keywords.forEach(assertKeywordName);
 

--- a/packages/zoe/src/cleanProposal.js
+++ b/packages/zoe/src/cleanProposal.js
@@ -102,8 +102,9 @@ export const cleanKeywords = keywordRecord => {
   return keywords;
 };
 
+const expectedAfterDeadlineKeys = harden(['timer', 'deadline']);
+
 const assertAfterDeadlineExitRule = exit => {
-  const expectedAfterDeadlineKeys = ['timer', 'deadline'];
   assertKeysAllowed(expectedAfterDeadlineKeys, exit.afterDeadline);
   assert(exit.afterDeadline.timer !== undefined, X`timer must be defined`);
   assert(
@@ -116,13 +117,15 @@ const assertAfterDeadlineExitRule = exit => {
 const assertExitValueNull = (exit, exitKey) =>
   assert(exit[exitKey] === null, `exit value must be null for key ${exitKey}`);
 
+// We expect the single exit key to be one of the following:
+const allowedExitKeys = harden(['onDemand', 'afterDeadline', 'waived']);
+
 const assertExit = exit => {
   assert(
     Object.getOwnPropertyNames(exit).length === 1,
     X`exit ${exit} should only have one key`,
   );
-  // We expect the single exit key to be one of the following:
-  const allowedExitKeys = ['onDemand', 'afterDeadline', 'waived'];
+
   const [exitKey] = cleanKeys(allowedExitKeys, exit);
   if (isOnDemandExitRule(exit) || isWaivedExitRule(exit)) {
     assertExitValueNull(exit, exitKey);

--- a/packages/zoe/src/cleanProposal.js
+++ b/packages/zoe/src/cleanProposal.js
@@ -15,6 +15,8 @@ import './internal-types';
 
 import { arrayToObj, assertSubset } from './objArrayConversion';
 
+const firstCapASCII = /^[A-Z][a-zA-Z0-9_$]*$/;
+
 // We adopt simple requirements on keywords so that they do not accidentally
 // conflict with existing property names.
 // We require keywords to be strings, ascii identifiers beginning with an
@@ -26,7 +28,6 @@ import { arrayToObj, assertSubset } from './objArrayConversion';
 // lookup a keyword-named property no matter what `i` is.
 export const assertKeywordName = keyword => {
   assert.typeof(keyword, 'string');
-  const firstCapASCII = /^[A-Z][a-zA-Z0-9_$]*$/;
   assert(
     firstCapASCII.test(keyword),
     X`keyword ${q(
@@ -54,7 +55,7 @@ const assertKeysAllowed = (allowedKeys, record) => {
 
 const cleanKeys = (allowedKeys, record) => {
   assertKeysAllowed(allowedKeys, record);
-  return Object.getOwnPropertyNames(record);
+  return harden(Object.getOwnPropertyNames(record));
 };
 
 export const getKeywords = keywordRecord =>
@@ -103,9 +104,6 @@ const assertAfterDeadlineExitRule = exit => {
       isNat(exit.afterDeadline.deadline),
     X`deadline must be a Nat BigInt`,
   );
-  // timers must have a 'setWakeup' function which takes a deadline
-  // and an object as arguments.
-  // TODO: how to check methods on presences?
 };
 
 const assertExitValueNull = (exit, exitKey) =>
@@ -145,6 +143,8 @@ const assertKeywordNotInBoth = (want, give) => {
   });
 };
 
+const rootKeysAllowed = harden(['want', 'give', 'exit']);
+
 /**
  * cleanProposal checks the keys and values of the proposal, including
  * the keys and values of the internal objects. The proposal may have
@@ -161,7 +161,6 @@ const assertKeywordNotInBoth = (want, give) => {
  * @returns {ProposalRecord}
  */
 export const cleanProposal = proposal => {
-  const rootKeysAllowed = ['want', 'give', 'exit'];
   mustBeComparable(proposal);
   assertKeysAllowed(rootKeysAllowed, proposal);
 

--- a/packages/zoe/src/cleanProposal.js
+++ b/packages/zoe/src/cleanProposal.js
@@ -3,7 +3,7 @@
 import { assert, details as X, q } from '@agoric/assert';
 import { mustBeComparable } from '@agoric/same-structure';
 import { isNat } from '@agoric/nat';
-import { amountMath, getMathKind } from '@agoric/ertp';
+import { amountMath, getMathKind, MathKind } from '@agoric/ertp';
 import {
   isOnDemandExitRule,
   isWaivedExitRule,
@@ -14,7 +14,6 @@ import '../exported';
 import './internal-types';
 
 import { arrayToObj, assertSubset } from './objArrayConversion';
-import { MathKind } from '@agoric/ertp/src/deprecatedAmountMath';
 
 const firstCapASCII = /^[A-Z][a-zA-Z0-9_$]*$/;
 

--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -153,7 +153,7 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
 
     const makeEmptySeatKit = (exit = undefined) => {
       const initialAllocation = harden({});
-      const proposal = cleanProposal(harden({ exit }));
+      const proposal = cleanProposal(harden({ exit }), getMathKindByBrand);
       const { notifier, updater } = makeNotifierKit();
       /** @type {PromiseRecord<ZoeSeatAdmin>} */
       const zoeSeatAdminPromiseKit = makePromiseKit();

--- a/packages/zoe/src/contractFacet/exit.js
+++ b/packages/zoe/src/contractFacet/exit.js
@@ -1,6 +1,14 @@
+// @ts-check
+
 import { assert, details as X, q } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
+
+import {
+  isOnDemandExitRule,
+  isAfterDeadlineExitRule,
+  isWaivedExitRule,
+} from '../typeGuards';
 
 /**
  * Makes the appropriate exitObj, which runs in ZCF and allows the seat's owner
@@ -9,56 +17,56 @@ import { Far } from '@agoric/marshal';
 
 /** @type {MakeExitObj} */
 export const makeExitObj = (proposal, zoeSeatAdmin, zcfSeatAdmin) => {
-  const [exitKind] = Object.getOwnPropertyNames(proposal.exit);
+  const { exit } = proposal;
 
-  /** @type {ExitObj} */
-  let exitObj = Far('exitObj', {
-    exit: () => {
-      throw new Error(
-        `Only seats with the exit rule "onDemand" can exit at will`,
-      );
-    },
-  });
-
-  const exitFn = () => {
+  const reusedExitFn = () => {
     zcfSeatAdmin.updateHasExited();
     return E(zoeSeatAdmin).exit();
   };
 
-  if (exitKind === 'afterDeadline') {
+  if (isOnDemandExitRule(exit)) {
+    // Allow the user to exit their seat on demand. Note: we must wrap
+    // it in an object to send it back to Zoe because our marshalling layer
+    // only allows two kinds of objects: records (no methods and only
+    // data) and presences (local proxies for objects that may have
+    // methods).
+    return Far('exitObj', {
+      exit: reusedExitFn,
+    });
+  }
+
+  if (isAfterDeadlineExitRule(exit)) {
     // Automatically exit the seat after deadline.
-    E(proposal.exit.afterDeadline.timer)
+    E(exit.afterDeadline.timer)
       .setWakeup(
-        proposal.exit.afterDeadline.deadline,
+        exit.afterDeadline.deadline,
         Far('wakeObj', {
-          wake: exitFn,
+          wake: reusedExitFn,
         }),
       )
       .catch(reason => {
         console.error(
-          `The seat could not be made with the provided timer ${proposal.exit.afterDeadline.timer} and deadline ${proposal.exit.afterDeadline.deadline}`,
+          `The seat could not be made with the provided timer ${exit.afterDeadline.timer} and deadline ${exit.afterDeadline.deadline}`,
         );
         console.error(reason);
         zcfSeatAdmin.updateHasExited();
         E(zoeSeatAdmin).fail(reason);
         throw reason;
       });
-  } else if (exitKind === 'onDemand') {
-    // Allow the user to exit their seat on demand. Note: we must wrap
-    // it in an object to send it back to Zoe because our marshalling layer
-    // only allows two kinds of objects: records (no methods and only
-    // data) and presences (local proxies for objects that may have
-    // methods).
-    exitObj = Far('exitObj', {
-      exit: exitFn,
-    });
-  } else {
-    // if exitKind is 'waived' the user has no ability to exit their seat
-    // on demand
-    assert(
-      exitKind === 'waived',
-      X`exit kind was not recognized: ${q(exitKind)}`,
-    );
   }
-  return exitObj;
+
+  if (isWaivedExitRule(exit) || isAfterDeadlineExitRule(exit)) {
+    /** @type {ExitObj} */
+    return Far('exitObj', {
+      exit: () => {
+        // if exitKind is 'waived' the user has no ability to exit their seat
+        // on demand
+        throw Error(
+          `Only seats with the exit rule "onDemand" can exit at will`,
+        );
+      },
+    });
+  }
+
+  assert.fail(X`exit kind was not recognized: ${q(exit)}`);
 };

--- a/packages/zoe/src/contractFacet/fakeVatAdmin.js
+++ b/packages/zoe/src/contractFacet/fakeVatAdmin.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
 import { Far } from '@agoric/marshal';

--- a/packages/zoe/src/contractFacet/offerSafety.js
+++ b/packages/zoe/src/contractFacet/offerSafety.js
@@ -1,22 +1,22 @@
 // @ts-check
 
+import { amountMath } from '@agoric/ertp';
+
 /**
  * Helper to perform satisfiesWant and satisfiesGive. Is
  * allocationAmount greater than or equal to requiredAmount for every
  * keyword of giveOrWant?
  *
- * @param {(brand: Brand) => DeprecatedAmountMath} getAmountMath
  * @param {AmountKeywordRecord} giveOrWant
  * @param {AmountKeywordRecord} allocation
  */
-const satisfiesInternal = (getAmountMath, giveOrWant = {}, allocation) => {
+const satisfiesInternal = (giveOrWant = {}, allocation) => {
   const isGTEByKeyword = ([keyword, requiredAmount]) => {
     // If there is no allocation for a keyword, we know the giveOrWant
     // is not satisfied without checking further.
     if (allocation[keyword] === undefined) {
       return false;
     }
-    const amountMath = getAmountMath(requiredAmount.brand);
     const allocationAmount = allocation[keyword];
     return amountMath.isGTE(allocationAmount, requiredAmount);
   };
@@ -27,32 +27,24 @@ const satisfiesInternal = (getAmountMath, giveOrWant = {}, allocation) => {
  * For this allocation to satisfy what the user wanted, their
  * allocated amounts must be greater than or equal to proposal.want.
  *
- * @param {(brand: Brand) => DeprecatedAmountMath} getAmountMath - a
- * function that takes a brand and returns the appropriate amountMath.
- * The function must have an amountMath for every brand in
- * proposal.want.
- * @param  {ProposalRecord} proposal - the rules that accompanied the
+ * @param {ProposalRecord} proposal - the rules that accompanied the
  * escrow of payments that dictate what the user expected to get back
  * from Zoe. A proposal is a record with keys `give`, `want`, and
  * `exit`. `give` and `want` are records with keywords as keys and
  * amounts as values. The proposal is a user's understanding of the
  * contract that they are entering when they make an offer.
- * @param  {AmountKeywordRecord} allocation - a record with keywords
+ * @param {AmountKeywordRecord} allocation - a record with keywords
  * as keys and amounts as values. These amounts are the reallocation
  * to be given to a user.
  */
-const satisfiesWant = (getAmountMath, proposal, allocation) =>
-  satisfiesInternal(getAmountMath, proposal.want, allocation);
+const satisfiesWant = (proposal, allocation) =>
+  satisfiesInternal(proposal.want, allocation);
 
 /**
  * For this allocation to count as a full refund, the allocated
  * amounts must be greater than or equal to what was originally
  * offered (proposal.give).
  *
- * @param {(brand: Brand) => DeprecatedAmountMath} getAmountMath - a
- * function that takes a brand and returns the appropriate amountMath.
- * The function must have an amountMath for every brand in
- * proposal.give.
  * @param  {ProposalRecord} proposal - the rules that accompanied the
  * escrow of payments that dictate what the user expected to get back
  * from Zoe. A proposal is a record with keys `give`, `want`, and
@@ -63,8 +55,8 @@ const satisfiesWant = (getAmountMath, proposal, allocation) =>
  * as keys and amounts as values. These amounts are the reallocation
  * to be given to a user.
  */
-const satisfiesGive = (getAmountMath, proposal, allocation) =>
-  satisfiesInternal(getAmountMath, proposal.give, allocation);
+const satisfiesGive = (proposal, allocation) =>
+  satisfiesInternal(proposal.give, allocation);
 
 /**
  * `isOfferSafe` checks offer safety for a single offer.
@@ -73,10 +65,6 @@ const satisfiesGive = (getAmountMath, proposal, allocation) =>
  * `proposal.give` (giving a refund) or whether we fully satisfy
  * `proposal.want`. Both can be fully satisfied.
  *
- * @param {(brand: Brand) => DeprecatedAmountMath} getAmountMath - a
- * function that takes a brand and returns the appropriate amountMath.
- * The function must have an amountMath for every brand in
- * proposal.want and proposal.give.
  * @param  {ProposalRecord} proposal - the rules that accompanied the
  * escrow of payments that dictate what the user expected to get back
  * from Zoe. A proposal is a record with keys `give`, `want`, and
@@ -87,10 +75,9 @@ const satisfiesGive = (getAmountMath, proposal, allocation) =>
  * as keys and amounts as values. These amounts are the reallocation
  * to be given to a user.
  */
-function isOfferSafe(getAmountMath, proposal, allocation) {
+function isOfferSafe(proposal, allocation) {
   return (
-    satisfiesGive(getAmountMath, proposal, allocation) ||
-    satisfiesWant(getAmountMath, proposal, allocation)
+    satisfiesGive(proposal, allocation) || satisfiesWant(proposal, allocation)
   );
 }
 

--- a/packages/zoe/src/contractFacet/rightsConservation.js
+++ b/packages/zoe/src/contractFacet/rightsConservation.js
@@ -2,6 +2,7 @@
 
 import makeStore from '@agoric/store';
 import { assert, details as X } from '@agoric/assert';
+import { amountMath } from '@agoric/ertp';
 
 import '../../exported';
 import '../internal-types';
@@ -10,22 +11,20 @@ import '../internal-types';
  * Iterate over the amounts and sum, storing the sums in a
  * map by brand.
  *
- * @param {(brand: Brand) => DeprecatedAmountMath} getAmountMath - a function
- * to get amountMath given a brand.
  * @param  {Amount[]} amounts - an array of amounts
  * @returns {Store<Brand, Amount>} sumsByBrand - a map of Brand keys and
  * Amount values. The amounts are the sums.
  */
-const sumByBrand = (getAmountMath, amounts) => {
+const sumByBrand = amounts => {
   const sumsByBrand = makeStore('brand');
   amounts.forEach(amount => {
     const { brand } = amount;
-    const amountMath = getAmountMath(brand);
     if (!sumsByBrand.has(brand)) {
-      sumsByBrand.init(brand, amountMath.getEmpty());
+      sumsByBrand.init(brand, amount);
+    } else {
+      const sumSoFar = sumsByBrand.get(brand);
+      sumsByBrand.set(brand, amountMath.add(sumSoFar, amount));
     }
-    const sumSoFar = sumsByBrand.get(brand);
-    sumsByBrand.set(brand, amountMath.add(sumSoFar, amount));
   });
   return sumsByBrand;
 };
@@ -33,17 +32,11 @@ const sumByBrand = (getAmountMath, amounts) => {
 /**
  * Assert that the left sums by brand equal the right sums by brand
  *
- * @param {(brand: Brand) => DeprecatedAmountMath} getAmountMath - a function
- * to get amountMath given a brand.
  * @param  {Store<Brand, Amount>} leftSumsByBrand - a map of brands to sums
  * @param  {Store<Brand, Amount>} rightSumsByBrand - a map of brands to sums
  * indexed by issuer
  */
-const assertEqualPerBrand = (
-  getAmountMath,
-  leftSumsByBrand,
-  rightSumsByBrand,
-) => {
+const assertEqualPerBrand = (leftSumsByBrand, rightSumsByBrand) => {
   const leftKeys = leftSumsByBrand.keys();
   const rightKeys = rightSumsByBrand.keys();
   assert.equal(
@@ -55,7 +48,7 @@ const assertEqualPerBrand = (
     .keys()
     .forEach(brand =>
       assert(
-        getAmountMath(brand).isEqual(
+        amountMath.isEqual(
           leftSumsByBrand.get(brand),
           rightSumsByBrand.get(brand),
         ),
@@ -68,19 +61,16 @@ const assertEqualPerBrand = (
  * `assertRightsConserved` checks that the total amount per brand is
  * equal to the total amount per brand in the proposed reallocation
  *
- * @param {(brand: Brand) => DeprecatedAmountMath} getAmountMath - a function
- * to get amountMath given a brand.
- * @param  {Amount[]} previousAmounts - an array of the amounts before the
+ * @param {Amount[]} previousAmounts - an array of the amounts before the
  * proposed reallocation
- * @param  {Amount[]} newAmounts - an array of the amounts in the
+ * @param {Amount[]} newAmounts - an array of the amounts in the
  * proposed reallocation
- *
  * @returns {void}
  */
-function assertRightsConserved(getAmountMath, previousAmounts, newAmounts) {
-  const sumsPrevAmounts = sumByBrand(getAmountMath, previousAmounts);
-  const sumsNewAmounts = sumByBrand(getAmountMath, newAmounts);
-  assertEqualPerBrand(getAmountMath, sumsPrevAmounts, sumsNewAmounts);
+function assertRightsConserved(previousAmounts, newAmounts) {
+  const sumsPrevAmounts = sumByBrand(previousAmounts);
+  const sumsNewAmounts = sumByBrand(newAmounts);
+  assertEqualPerBrand(sumsPrevAmounts, sumsNewAmounts);
 }
 
 export { assertRightsConserved };

--- a/packages/zoe/src/contractFacet/seat.js
+++ b/packages/zoe/src/contractFacet/seat.js
@@ -3,6 +3,7 @@
 import { E } from '@agoric/eventual-send';
 import { assert, details as X } from '@agoric/assert';
 import { Far } from '@agoric/marshal';
+import { amountMath } from '@agoric/ertp';
 
 import { isOfferSafe } from './offerSafety';
 
@@ -14,7 +15,7 @@ export const makeZcfSeatAdminKit = (
   allSeatStagings,
   zoeSeatAdmin,
   seatData,
-  getAmountMath,
+  getMathKindByBrand,
 ) => {
   // The proposal and notifier are not reassigned.
   const { proposal, notifier } = seatData;
@@ -80,7 +81,8 @@ export const makeZcfSeatAdminKit = (
         brand,
         X`A brand must be supplied when the keyword is not defined`,
       );
-      return getAmountMath(brand).getEmpty();
+      const mathKind = getMathKindByBrand(brand);
+      return amountMath.makeEmpty(brand, mathKind);
     },
     getCurrentAllocation: () => {
       assertExitedFalse();
@@ -93,7 +95,7 @@ export const makeZcfSeatAdminKit = (
         ...newAllocation,
       });
 
-      return isOfferSafe(getAmountMath, proposal, reallocation);
+      return isOfferSafe(proposal, reallocation);
     },
     stage: newAllocation => {
       assertExitedFalse();
@@ -104,7 +106,7 @@ export const makeZcfSeatAdminKit = (
       });
 
       assert(
-        isOfferSafe(getAmountMath, proposal, allocation),
+        isOfferSafe(proposal, allocation),
         X`The reallocation was not offer safe`,
       );
 

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -11,6 +11,12 @@
  */
 
 /**
+ * @callback ZCFMakeEmptySeatKit
+ * @param {ExitRule=} exit
+ * @returns {ZCFSeatKit}
+ */
+
+/**
  * @typedef {Object} ContractFacet
  *
  * The Zoe interface specific to a contract instance. The Zoe Contract
@@ -36,8 +42,9 @@
  * @property {(issuer: Issuer) => Brand} getBrandForIssuer
  * @property {(brand: Brand) => Issuer} getIssuerForBrand
  * @property {GetAmountMath} getAmountMath
+ * @property {(brand: Brand) => AmountMathKind} getMathKind
  * @property {MakeZCFMint} makeZCFMint
- * @property {(exit: ExitRule=) => ZcfSeatKit} makeEmptySeatKit
+ * @property {ZCFMakeEmptySeatKit} makeEmptySeatKit
  * @property {SetTestJig} setTestJig
  * @property {() => void} stopAcceptingOffers
  */
@@ -61,11 +68,11 @@
  * change, overall rights will be unchanged, and a reallocation can
  * only effect offer safety for seats whose allocations change.
  *
- * @param  {SeatStaging} seatStaging
- * @param {SeatStaging} seatStaging
- * @param {SeatStaging=} seatStaging
- * @param {SeatStaging=} seatStaging
- * @param {SeatStaging=} seatStaging
+ * @param  {SeatStaging} seatStaging1
+ * @param {SeatStaging} seatStaging2
+ * @param {SeatStaging=} seatStaging3
+ * @param {SeatStaging=} seatStaging4
+ * @param {SeatStaging=} seatStaging5
  * @returns {void}
  */
 
@@ -100,12 +107,6 @@
  */
 
 /**
- * @callback GetAmountMath
- * @param {Brand} brand
- * @returns {DeprecatedAmountMath}
- */
-
-/**
  * @callback MakeZCFMint
  * @param {Keyword} keyword
  * @param {AmountMathKind=} amountMathKind
@@ -120,11 +121,16 @@
  */
 
 /**
+ * @callback ZCFMintMintGains
+ * @param {AmountKeywordRecord} mintGains
+ * @param {ZCFSeat=} zcfSeat
+ * @returns {ZCFSeat}
+ */
+
+/**
  * @typedef {Object} ZCFMint
  * @property {() => IssuerRecord} getIssuerRecord
- * @property {(gains: AmountKeywordRecord,
- *             zcfSeat: ZCFSeat=,
- *            ) => ZCFSeat} mintGains
+ * @property {ZCFMintMintGains} mintGains
  * All the amounts in gains must be of this ZCFMint's brand.
  * The gains' keywords are in the namespace of that seat.
  * Add the gains to that seat's allocation.
@@ -149,19 +155,41 @@
  */
 
 /**
+ * @callback ZCFSeatFail
+ *
+ * fail called with the reason for this failure, where reason is
+ * normally an instanceof Error.
+ * @param {Error=} reason
+ * @returns {Error}
+ */
+/**
+ * @callback ZCFSeatKickOut
+ *
+ * called with the reason for this failure,
+ * where reason is normally an instanceof Error. This method is
+ * deprecated as of 0.9.1-dev.3 in favor of fail().
+ * @param {Error=} reason
+ * @returns {Error}
+ */
+
+/**
+ * @callback ZCFGetAmountAllocated
+ * The brand is used for filling in an empty amount if the `keyword`
+ * is not present in the allocation
+ * @param {Keyword} keyword
+ * @param {Brand=} brand
+ * @returns {Amount}
+ */
+
+/**
  * @typedef {Object} ZCFSeat
  * @property {() => void} exit
- * @property {(reason: Error=) => Error} fail called with the reason for this
- * failure, where reason is normally an instanceof Error.
- * @property {(reason: Error=) => Error} kickOut called with the reason for
- * this failure, where reason is normally an instanceof Error. This method
- * is deprecated as of 0.9.1-dev.3 in favor of fail().
+ * @property {ZCFSeatFail} fail
+ * @property {ZCFSeatKickOut} kickOut
  * @property {() => Notifier<Allocation>} getNotifier
  * @property {() => boolean} hasExited
  * @property {() => ProposalRecord} getProposal
- * @property {(keyword: Keyword, brand: Brand=) => Amount} getAmountAllocated
- * The brand is used for filling in an empty amount if the `keyword`
- * is not present in the allocation
+ * @property {ZCFGetAmountAllocated} getAmountAllocated
  * @property {() => Allocation} getCurrentAllocation
  * @property {(newAllocation: Allocation) => boolean} isOfferSafe
  * @property {(newAllocation: Allocation) => SeatStaging} stage

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -68,7 +68,7 @@
  * change, overall rights will be unchanged, and a reallocation can
  * only effect offer safety for seats whose allocations change.
  *
- * @param  {SeatStaging} seatStaging1
+ * @param {SeatStaging} seatStaging1
  * @param {SeatStaging} seatStaging2
  * @param {SeatStaging=} seatStaging3
  * @param {SeatStaging=} seatStaging4
@@ -91,13 +91,13 @@
  * @callback MakeInvitation
  *
  * Make a credible Zoe invitation for a particular smart contract
- * indicated by the `instance` in the extent of the invitation. Zoe
- * also puts the `installation` and a unique `handle` in the extent of
+ * indicated by the `instance` in the details of the invitation. Zoe
+ * also puts the `installation` and a unique `handle` in the details of
  * the invitation. The contract must provide a `description` for the
  * invitation and should include whatever information is
  * necessary for a potential buyer of the invitation to know what they are
  * getting in the `customProperties`. `customProperties` will be
- * placed in the extent of the invitation.
+ * placed in the details of the invitation.
  *
  * @param {OfferHandler=} offerHandler - a contract specific function
  * that handles the offer, such as saving it or performing a trade
@@ -122,7 +122,7 @@
 
 /**
  * @callback ZCFMintMintGains
- * @param {AmountKeywordRecord} mintGains
+ * @param {AmountKeywordRecord} gains
  * @param {ZCFSeat=} zcfSeat
  * @returns {ZCFSeat}
  */

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -50,7 +50,8 @@
  */
 
 /**
- * @callback Reallocate
+ * @typedef {(seatStaging1: SeatStaging, seatStaging2: SeatStaging,
+ * ...seatStagingRest: Array<SeatStaging>) => void} Reallocate
  *
  * The contract can reallocate over seatStagings, which are
  * associations of seats with reallocations.
@@ -67,13 +68,6 @@
  * whose allocations will change. Since rights are conserved for the
  * change, overall rights will be unchanged, and a reallocation can
  * only effect offer safety for seats whose allocations change.
- *
- * @param {SeatStaging} seatStaging1
- * @param {SeatStaging} seatStaging2
- * @param {SeatStaging=} seatStaging3
- * @param {SeatStaging=} seatStaging4
- * @param {SeatStaging=} seatStaging5
- * @returns {void}
  */
 
 /**

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -17,6 +17,12 @@
  */
 
 /**
+ * @callback GetAmountMath
+ * @param {Brand} brand
+ * @returns {DeprecatedAmountMath}
+ */
+
+/**
  * @typedef {Object} ContractFacet
  *
  * The Zoe interface specific to a contract instance. The Zoe Contract

--- a/packages/zoe/src/contractSupport/bondingCurves.js
+++ b/packages/zoe/src/contractSupport/bondingCurves.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { assert, details as X } from '@agoric/assert';
 import { Nat } from '@agoric/nat';
 import { natSafeMath } from './safeMath';
@@ -19,16 +21,16 @@ const BASIS_POINTS = 10000n; // TODO change to 10_000n once tooling copes.
  * request, and to do the actual reallocation after an offer has
  * been made.
  *
- * @param {Value} inputValue - the value of the asset sent
+ * @param {NatValue} inputValue - the value of the asset sent
  * in to be swapped
- * @param {Value} inputReserve - the value in the liquidity
+ * @param {NatValue} inputReserve - the value in the liquidity
  * pool of the kind of asset sent in
- * @param {Value} outputReserve - the value in the liquidity
+ * @param {NatValue} outputReserve - the value in the liquidity
  * pool of the kind of asset to be sent out
  * @param {bigint} [feeBasisPoints=30n] - the fee taken in
  * basis points. The default is 0.3% or 30 basis points. The fee
  * is taken from inputValue
- * @returns {Value} outputValue - the current price, in value form
+ * @returns {NatValue} outputValue - the current price, in value form
  */
 export const getInputPrice = (
   inputValue,
@@ -61,16 +63,16 @@ export const getInputPrice = (
  * request, and to do the actual reallocation after an offer has
  * been made.
  *
- * @param {Value} outputValue - the value of the asset the user wants
+ * @param {NatValue} outputValue - the value of the asset the user wants
  * to get
- * @param {Value} inputReserve - the value in the liquidity
+ * @param {NatValue} inputReserve - the value in the liquidity
  * pool of the asset being spent
- * @param {Value} outputReserve - the value in the liquidity
+ * @param {NatValue} outputReserve - the value in the liquidity
  * pool of the kind of asset to be sent out
  * @param {bigint} [feeBasisPoints=30n] - the fee taken in
  * basis points. The default is 0.3% or 30 basis points. The fee is taken from
  * outputValue
- * @returns {bigint} inputValue - the value of input required to purchase output
+ * @returns {NatValue} inputValue - the value of input required to purchase output
  */
 export const getOutputPrice = (
   outputValue,
@@ -125,12 +127,12 @@ export const calcLiqValueToMint = (
  * adding liquidity. We require that the deposited ratio of central to secondary
  * match the current ratio of holdings in the pool.
  *
- * @param {Value} centralIn - The value of central assets being deposited
- * @param {Value} centralPool - The value of central assets in the pool
- * @param {Value} secondaryPool - The value of secondary assets in the pool
- * @param {Value} secondaryIn - The value of secondary assets provided. If
+ * @param {NatValue} centralIn - The value of central assets being deposited
+ * @param {NatValue} centralPool - The value of central assets in the pool
+ * @param {NatValue} secondaryPool - The value of secondary assets in the pool
+ * @param {NatValue} secondaryIn - The value of secondary assets provided. If
  * the pool is empty, the entire amount will be accepted
- * @returns {bigint} - the amount of secondary required
+ * @returns {NatValue} - the amount of secondary required
  */
 export const calcSecondaryRequired = (
   centralIn,
@@ -138,10 +140,6 @@ export const calcSecondaryRequired = (
   secondaryPool,
   secondaryIn,
 ) => {
-  Nat(centralIn);
-  Nat(centralPool);
-  Nat(secondaryPool);
-  Nat(secondaryIn);
   if (centralPool === 0n || secondaryPool === 0n) {
     return secondaryIn;
   }

--- a/packages/zoe/src/contractSupport/bondingCurves.js
+++ b/packages/zoe/src/contractSupport/bondingCurves.js
@@ -38,9 +38,9 @@ export const getInputPrice = (
   outputReserve,
   feeBasisPoints = 30n,
 ) => {
-  Nat(inputValue);
-  Nat(inputReserve);
-  Nat(outputReserve);
+  inputValue = Nat(inputValue);
+  inputReserve = Nat(inputReserve);
+  outputReserve = Nat(outputReserve);
   assert(inputValue > 0n, X`inputValue ${inputValue} must be positive`);
   assert(inputReserve > 0n, X`inputReserve ${inputReserve} must be positive`);
   assert(
@@ -80,9 +80,10 @@ export const getOutputPrice = (
   outputReserve,
   feeBasisPoints = 30n,
 ) => {
-  Nat(outputValue);
-  Nat(inputReserve);
-  Nat(outputReserve);
+  outputValue = Nat(outputValue);
+  inputReserve = Nat(inputReserve);
+  outputReserve = Nat(outputReserve);
+
   assert(inputReserve > 0n, X`inputReserve ${inputReserve} must be positive`);
   assert(
     outputReserve > 0n,
@@ -112,9 +113,9 @@ export const calcLiqValueToMint = (
   inputValue,
   inputReserve,
 ) => {
-  Nat(liqTokenSupply);
-  Nat(inputValue);
-  Nat(inputReserve);
+  liqTokenSupply = Nat(liqTokenSupply);
+  inputValue = Nat(inputValue);
+  inputReserve = Nat(inputReserve);
 
   if (liqTokenSupply === 0n) {
     return inputValue;
@@ -140,6 +141,11 @@ export const calcSecondaryRequired = (
   secondaryPool,
   secondaryIn,
 ) => {
+  centralIn = Nat(centralIn);
+  centralPool = Nat(centralPool);
+  secondaryPool = Nat(secondaryPool);
+  secondaryIn = Nat(secondaryIn);
+
   if (centralPool === 0n || secondaryPool === 0n) {
     return secondaryIn;
   }
@@ -164,9 +170,9 @@ export const calcValueToRemove = (
   poolValue,
   liquidityValueIn,
 ) => {
-  Nat(liqTokenSupply);
-  Nat(liquidityValueIn);
-  Nat(poolValue);
+  liqTokenSupply = Nat(liqTokenSupply);
+  liquidityValueIn = Nat(liquidityValueIn);
+  poolValue = Nat(poolValue);
 
   return floorDivide(multiply(liquidityValueIn, poolValue), liqTokenSupply);
 };

--- a/packages/zoe/src/contractSupport/index.js
+++ b/packages/zoe/src/contractSupport/index.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 export {
   getInputPrice,
   getOutputPrice,

--- a/packages/zoe/src/contractSupport/priceAuthority.js
+++ b/packages/zoe/src/contractSupport/priceAuthority.js
@@ -58,9 +58,6 @@ export function makeOnewayPriceAuthorityKit(opts) {
     notifier,
   } = opts;
 
-  const paBrandIn = actualBrandIn;
-  const paBrandOut = actualBrandOut;
-
   let haveFirstQuote = false;
   notifier.getUpdateSince().then(_ => (haveFirstQuote = true));
 
@@ -150,13 +147,13 @@ export function makeOnewayPriceAuthorityKit(opts) {
   const assertBrands = (brandIn, brandOut) => {
     assert.equal(
       brandIn,
-      paBrandIn,
-      X`Desired brandIn ${brandIn} must match ${paBrandIn}`,
+      actualBrandIn,
+      X`Desired brandIn ${brandIn} must match ${actualBrandIn}`,
     );
     assert.equal(
       brandOut,
-      paBrandOut,
-      X`Desired brandOut ${brandOut} must match ${paBrandOut}`,
+      actualBrandOut,
+      X`Desired brandOut ${brandOut} must match ${actualBrandOut}`,
     );
   };
 

--- a/packages/zoe/src/contractSupport/priceAuthority.js
+++ b/packages/zoe/src/contractSupport/priceAuthority.js
@@ -1,44 +1,46 @@
+// @ts-check
+
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
 import { makePromiseKit } from '@agoric/promise-kit';
+import { amountMath } from '@agoric/ertp';
 
 import '../../exported';
 
 /**
  * @callback CompareAmount
- * @param {DeprecatedAmountMath} math
  * @param {Amount} amount
  * @param {Amount} amountLimit
  * @returns {boolean}
  */
 
 /** @type {CompareAmount} */
-const isLT = (math, amountOut, amountLimit) =>
-  !math.isGTE(amountOut, amountLimit);
+const isLT = (amountOut, amountLimit) =>
+  !amountMath.isGTE(amountOut, amountLimit);
 
 /** @type {CompareAmount} */
-const isLTE = (math, amount, amountLimit) => math.isGTE(amountLimit, amount);
+const isLTE = (amount, amountLimit) => amountMath.isGTE(amountLimit, amount);
 
 /** @type {CompareAmount} */
-const isGTE = (math, amount, amountLimit) => math.isGTE(amount, amountLimit);
+const isGTE = (amount, amountLimit) => amountMath.isGTE(amount, amountLimit);
 
 /** @type {CompareAmount} */
-const isGT = (math, amount, amountLimit) => !math.isGTE(amountLimit, amount);
+const isGT = (amount, amountLimit) => !amountMath.isGTE(amountLimit, amount);
 
 /**
  * @typedef {Object} OnewayPriceAuthorityOptions
  * @property {Issuer} quoteIssuer
- * @property {DeprecatedAmountMath} mathIn
- * @property {DeprecatedAmountMath} mathOut
  * @property {Notifier<PriceQuote>} notifier
  * @property {TimerService} timer
  * @property {PriceQuoteCreate} createQuote
+ * @property {Brand} actualBrandIn
+ * @property {Brand} actualBrandOut
  */
 
 /**
  * @callback Trigger
- * @param {Timestamp} timestamp
+ * @param {Function} createInstantQuote
  * @returns {Promise<void>}
  */
 
@@ -47,10 +49,17 @@ const isGT = (math, amount, amountLimit) => !math.isGTE(amountLimit, amount);
  * @returns {PriceAuthorityKit}
  */
 export function makeOnewayPriceAuthorityKit(opts) {
-  const { timer, createQuote, mathIn, mathOut, quoteIssuer, notifier } = opts;
+  const {
+    timer,
+    createQuote,
+    actualBrandIn,
+    actualBrandOut,
+    quoteIssuer,
+    notifier,
+  } = opts;
 
-  const paBrandIn = mathIn.getBrand();
-  const paBrandOut = mathOut.getBrand();
+  const paBrandIn = actualBrandIn;
+  const paBrandOut = actualBrandOut;
 
   let haveFirstQuote = false;
   notifier.getUpdateSince().then(_ => (haveFirstQuote = true));
@@ -85,8 +94,8 @@ export function makeOnewayPriceAuthorityKit(opts) {
      * of calcAmountTrigger
      */
     async function quoteWhenOutTrigger(amountIn, amountOutLimit) {
-      mathIn.coerce(amountIn);
-      mathOut.coerce(amountOutLimit);
+      amountMath.coerce(amountIn, actualBrandIn);
+      amountMath.coerce(amountOutLimit, actualBrandOut);
 
       /** @type {PromiseRecord<PriceQuote>} */
       const triggerPK = makePromiseKit();
@@ -101,7 +110,7 @@ export function makeOnewayPriceAuthorityKit(opts) {
             }
             const amountOut = calcAmountOut(amountIn);
 
-            if (!compareAmount(mathOut, amountOut, amountOutLimit)) {
+            if (!compareAmount(amountOut, amountOutLimit)) {
               // Don't fire the trigger yet.
               return undefined;
             }
@@ -166,7 +175,7 @@ export function makeOnewayPriceAuthorityKit(opts) {
       return notifier;
     },
     async quoteGiven(amountIn, brandOut) {
-      mathIn.coerce(amountIn);
+      amountMath.coerce(amountIn, actualBrandIn);
       assertBrands(amountIn.brand, brandOut);
 
       await notifier.getUpdateSince();
@@ -176,7 +185,7 @@ export function makeOnewayPriceAuthorityKit(opts) {
       }));
     },
     async quoteWanted(brandIn, amountOut) {
-      mathOut.coerce(amountOut);
+      amountMath.coerce(amountOut, actualBrandOut);
       assertBrands(brandIn, amountOut.brand);
 
       await notifier.getUpdateSince();
@@ -186,7 +195,7 @@ export function makeOnewayPriceAuthorityKit(opts) {
         const actualAmountOut = calcAmountOut(amountIn);
 
         assert(
-          mathOut.isGTE(actualAmountOut, amountOut),
+          amountMath.isGTE(actualAmountOut, amountOut),
           X`Calculation of ${actualAmountOut} didn't cover expected ${amountOut}`,
         );
         return { amountIn, amountOut };
@@ -194,7 +203,7 @@ export function makeOnewayPriceAuthorityKit(opts) {
     },
     async quoteAtTime(deadline, amountIn, brandOut) {
       assert.typeof(deadline, 'bigint');
-      mathIn.coerce(amountIn);
+      amountMath.coerce(amountIn, actualBrandIn);
       assertBrands(amountIn.brand, brandOut);
 
       await notifier.getUpdateSince();

--- a/packages/zoe/src/contractSupport/priceAuthority.js
+++ b/packages/zoe/src/contractSupport/priceAuthority.js
@@ -40,7 +40,7 @@ const isGT = (amount, amountLimit) => !amountMath.isGTE(amountLimit, amount);
 
 /**
  * @callback Trigger
- * @param {Function} createInstantQuote
+ * @param {PriceQuoteCreate} createInstantQuote
  * @returns {Promise<void>}
  */
 

--- a/packages/zoe/src/contractSupport/ratio.js
+++ b/packages/zoe/src/contractSupport/ratio.js
@@ -43,6 +43,13 @@ export const assertIsRatio = ratio => {
   Nat(ratio.denominator.value);
 };
 
+/**
+ * @param {NatValue} numerator
+ * @param {Brand} numeratorBrand
+ * @param {NatValue} denominator
+ * @param {Brand} denominatorBrand
+ * @returns {Ratio}
+ */
 export const makeRatio = (
   numerator,
   numeratorBrand,
@@ -51,7 +58,7 @@ export const makeRatio = (
 ) => {
   assert(
     denominator > 0n,
-    X`No infinite ratios! Denoninator was 0/${q(denominatorBrand)}`,
+    X`No infinite ratios! Denominator was 0/${q(denominatorBrand)}`,
   );
 
   // TODO(https://github.com/Agoric/agoric-sdk/pull/2310) after the refactoring

--- a/packages/zoe/src/contractSupport/safeMath.js
+++ b/packages/zoe/src/contractSupport/safeMath.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { Nat } from '@agoric/nat';
 
 /**

--- a/packages/zoe/src/contractSupport/stateMachine.js
+++ b/packages/zoe/src/contractSupport/stateMachine.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { assert } from '@agoric/assert';
 
 /* allowedTransitions is an array of arrays which gets turned into a

--- a/packages/zoe/src/contractSupport/statistics.js
+++ b/packages/zoe/src/contractSupport/statistics.js
@@ -38,5 +38,6 @@ export const calculateMedian = (samples, math) => {
   const secondIndex = sorted.length / 2;
   const sum = math.add(sorted[secondIndex - 1], sorted[secondIndex]);
 
+  // @ts-ignore
   return math.divide(sum, 2);
 };

--- a/packages/zoe/src/contractSupport/statistics.js
+++ b/packages/zoe/src/contractSupport/statistics.js
@@ -37,7 +37,5 @@ export const calculateMedian = (samples, math) => {
   // Even length, take the mean of the two middle values.
   const secondIndex = sorted.length / 2;
   const sum = math.add(sorted[secondIndex - 1], sorted[secondIndex]);
-
-  // @ts-ignore
   return math.divide(sum, 2);
 };

--- a/packages/zoe/src/contracts/auction/assertBidSeat.js
+++ b/packages/zoe/src/contracts/auction/assertBidSeat.js
@@ -1,19 +1,19 @@
+// @ts-check
+
 import { assert, details as X } from '@agoric/assert';
+import { amountMath } from '@agoric/ertp';
 
 export const assertBidSeat = (zcf, sellSeat, bidSeat) => {
-  const {
-    maths: { Ask: bidMath, Asset: assetMath },
-  } = zcf.getTerms();
   const minBid = sellSeat.getProposal().want.Ask;
   const bid = bidSeat.getAmountAllocated('Bid', minBid.brand);
   assert(
-    bidMath.isGTE(bid, minBid),
+    amountMath.isGTE(bid, minBid),
     X`bid ${bid} is under the minimum bid ${minBid}`,
   );
   const assetAtAuction = sellSeat.getProposal().give.Asset;
   const assetWanted = bidSeat.getAmountAllocated('Asset', assetAtAuction.brand);
   assert(
-    assetMath.isGTE(assetAtAuction, assetWanted),
+    amountMath.isGTE(assetAtAuction, assetWanted),
     X`more assets were wanted ${assetWanted} than were available ${assetAtAuction}`,
   );
 };

--- a/packages/zoe/src/contracts/auction/secondPriceLogic.js
+++ b/packages/zoe/src/contracts/auction/secondPriceLogic.js
@@ -2,6 +2,11 @@
 
 import { amountMath } from '@agoric/ertp';
 
+/**
+ * @param {ContractFacet} zcf
+ * @param {ZCFSeat} sellSeat
+ * @param {Array<ZCFSeat>} bidSeats
+ */
 export const calcWinnerAndClose = (zcf, sellSeat, bidSeats) => {
   const {
     give: { Asset: assetAmount },

--- a/packages/zoe/src/contracts/auction/secondPriceLogic.js
+++ b/packages/zoe/src/contracts/auction/secondPriceLogic.js
@@ -1,26 +1,31 @@
+// @ts-check
+
+import { amountMath } from '@agoric/ertp';
+
 export const calcWinnerAndClose = (zcf, sellSeat, bidSeats) => {
   const {
     give: { Asset: assetAmount },
     want: { Ask: minBid },
   } = sellSeat.getProposal();
-  const bidMath = zcf.getAmountMath(minBid.brand);
-  const assetMath = zcf.getAmountMath(assetAmount.brand);
 
-  let highestBid = bidMath.getEmpty();
-  let secondHighestBid = bidMath.getEmpty();
+  const bidBrand = minBid.brand;
+  const emptyBid = amountMath.makeEmpty(bidBrand);
+
+  let highestBid = emptyBid;
+  let secondHighestBid = emptyBid;
   let highestBidSeat = bidSeats[0];
   let activeBidsCount = 0n;
 
   bidSeats.forEach(bidSeat => {
     if (!bidSeat.hasExited()) {
       activeBidsCount += 1n;
-      const bid = bidSeat.getAmountAllocated('Bid', highestBid.brand);
+      const bid = bidSeat.getAmountAllocated('Bid', bidBrand);
       // If the bid is greater than the highestBid, it's the new highestBid
-      if (bidMath.isGTE(bid, highestBid)) {
+      if (amountMath.isGTE(bid, highestBid, bidBrand)) {
         secondHighestBid = highestBid;
         highestBid = bid;
         highestBidSeat = bidSeat;
-      } else if (bidMath.isGTE(bid, secondHighestBid)) {
+      } else if (amountMath.isGTE(bid, secondHighestBid, bidBrand)) {
         // If the bid is not greater than the highest bid, but is greater
         // than the second highest bid, it is the new second highest bid.
         secondHighestBid = bid;
@@ -38,13 +43,17 @@ export const calcWinnerAndClose = (zcf, sellSeat, bidSeats) => {
     secondHighestBid = highestBid;
   }
 
-  const winnerRefund = bidMath.subtract(highestBid, secondHighestBid);
+  const winnerRefund = amountMath.subtract(
+    highestBid,
+    secondHighestBid,
+    bidBrand,
+  );
 
   // Everyone else gets a refund so their values remain the
   // same.
   zcf.reallocate(
     sellSeat.stage({
-      Asset: assetMath.getEmpty(),
+      Asset: amountMath.makeEmptyFromAmount(assetAmount),
       Ask: secondHighestBid,
     }),
     highestBidSeat.stage({ Asset: assetAmount, Bid: winnerRefund }),

--- a/packages/zoe/src/contracts/autoswap.js
+++ b/packages/zoe/src/contracts/autoswap.js
@@ -2,7 +2,7 @@
 
 import { Far } from '@agoric/marshal';
 import { assert } from '@agoric/assert';
-import { amountMath } from '@agoric/ertp';
+import { amountMath, isNatValue } from '@agoric/ertp';
 
 // Eventually will be importable from '@agoric/zoe-contract-support'
 import {
@@ -142,7 +142,7 @@ const start = async zcf => {
       want: { Out: wantedAmountOut },
     } = swapSeat.getProposal();
 
-    assert.typeof(amountIn.value, 'bigint');
+    assert(isNatValue(amountIn.value));
 
     const outputValue = getInputPrice(
       amountIn.value,
@@ -172,7 +172,7 @@ const start = async zcf => {
       want: { Out: wantedAmountOut },
     } = swapSeat.getProposal();
 
-    assert.typeof(wantedAmountOut.value, 'bigint');
+    assert(isNatValue(wantedAmountOut.value));
 
     const tradePrice = getOutputPrice(
       wantedAmountOut.value,
@@ -246,8 +246,8 @@ const start = async zcf => {
     const userAllocation = liqSeat.getCurrentAllocation();
     const secondaryIn = userAllocation.Secondary;
 
-    assert.typeof(userAllocation.Central.value, 'bigint');
-    assert.typeof(secondaryIn.value, 'bigint');
+    assert(isNatValue(userAllocation.Central.value));
+    assert(isNatValue(secondaryIn.value));
 
     // To calculate liquidity, we'll need to calculate alpha from the primary
     // token's value before, and the value that will be added to the pool
@@ -279,7 +279,7 @@ const start = async zcf => {
     // TODO (hibbert) should we burn tokens?
     const userAllocation = removeLiqSeat.getCurrentAllocation();
     const liquidityValueIn = userAllocation.Liquidity.value;
-    assert.typeof(liquidityValueIn, 'bigint');
+    assert(isNatValue(liquidityValueIn));
 
     const newUserCentralAmount = amountMath.make(
       calcValueToRemove(
@@ -342,7 +342,7 @@ const start = async zcf => {
   const getOutputForGivenInput = (amountIn, brandOut) => {
     const inputReserve = getPoolAmount(amountIn.brand).value;
     const outputReserve = getPoolAmount(brandOut).value;
-    assert.typeof(amountIn.value, 'bigint');
+    assert(isNatValue(amountIn.value));
     const outputValue = getInputPrice(
       amountIn.value,
       inputReserve,
@@ -361,7 +361,7 @@ const start = async zcf => {
   const getInputForGivenOutput = (amountOut, brandIn) => {
     const inputReserve = getPoolAmount(brandIn).value;
     const outputReserve = getPoolAmount(amountOut.brand).value;
-    assert.typeof(amountOut.value, 'bigint');
+    assert(isNatValue(amountOut.value));
     const outputValue = getOutputPrice(
       amountOut.value,
       inputReserve,

--- a/packages/zoe/src/contracts/callSpread/calculateShares.js
+++ b/packages/zoe/src/contracts/callSpread/calculateShares.js
@@ -3,6 +3,7 @@
 import '../../../exported';
 import './types';
 
+import { isNat } from '@agoric/nat';
 import { amountMath } from '@agoric/ertp';
 import { assert } from '@agoric/assert';
 import { makeRatio } from '../../contractSupport';
@@ -29,7 +30,7 @@ function calculateShares(collateralBrand, price, strikePrice1, strikePrice2) {
 
   const denominator = amountMath.subtract(strikePrice2, strikePrice1);
   const numerator = amountMath.subtract(price, strikePrice1);
-  assert.typeof(numerator.value, 'bigint');
+  assert(isNat(numerator.value));
   assert.typeof(denominator.value, 'bigint');
   const longShare = makeRatio(
     numerator.value,

--- a/packages/zoe/src/contracts/callSpread/calculateShares.js
+++ b/packages/zoe/src/contracts/callSpread/calculateShares.js
@@ -3,7 +3,6 @@
 import '../../../exported';
 import './types';
 
-import { isNat } from '@agoric/nat';
 import { amountMath } from '@agoric/ertp';
 import { assert } from '@agoric/assert';
 import { makeRatio } from '../../contractSupport';

--- a/packages/zoe/src/contracts/callSpread/calculateShares.js
+++ b/packages/zoe/src/contracts/callSpread/calculateShares.js
@@ -30,7 +30,7 @@ function calculateShares(collateralBrand, price, strikePrice1, strikePrice2) {
 
   const denominator = amountMath.subtract(strikePrice2, strikePrice1);
   const numerator = amountMath.subtract(price, strikePrice1);
-  assert(isNat(numerator.value));
+  assert.typeof(numerator.value, 'bigint');
   assert.typeof(denominator.value, 'bigint');
   const longShare = makeRatio(
     numerator.value,

--- a/packages/zoe/src/contracts/callSpread/calculateShares.js
+++ b/packages/zoe/src/contracts/callSpread/calculateShares.js
@@ -1,7 +1,9 @@
 // @ts-check
+
 import '../../../exported';
 import './types';
 
+import { amountMath } from '@agoric/ertp';
 import { assert } from '@agoric/assert';
 import { makeRatio } from '../../contractSupport';
 import { oneMinus, make100Percent, make0Percent } from './percent';
@@ -12,28 +14,22 @@ import { oneMinus, make100Percent, make0Percent } from './percent';
  * of the underlying asset at closing that determines the payouts to the parties
  *
  * @type {CalculateShares} */
-function calculateShares(
-  strikeMath,
-  collateralMath,
-  price,
-  strikePrice1,
-  strikePrice2,
-) {
-  const collateralBrand = collateralMath.getBrand();
-  if (strikeMath.isGTE(strikePrice1, price)) {
+function calculateShares(collateralBrand, price, strikePrice1, strikePrice2) {
+  if (amountMath.isGTE(strikePrice1, price)) {
     return {
       longShare: make0Percent(collateralBrand),
       shortShare: make100Percent(collateralBrand),
     };
-  } else if (strikeMath.isGTE(price, strikePrice2)) {
+  } else if (amountMath.isGTE(price, strikePrice2)) {
     return {
       longShare: make100Percent(collateralBrand),
       shortShare: make0Percent(collateralBrand),
     };
   }
 
-  const denominator = strikeMath.subtract(strikePrice2, strikePrice1);
-  const numerator = strikeMath.subtract(price, strikePrice1);
+  const denominator = amountMath.subtract(strikePrice2, strikePrice1);
+  const numerator = amountMath.subtract(price, strikePrice1);
+  assert.typeof(numerator.value, 'bigint');
   assert.typeof(denominator.value, 'bigint');
   const longShare = makeRatio(
     numerator.value,

--- a/packages/zoe/src/contracts/callSpread/calculateShares.js
+++ b/packages/zoe/src/contracts/callSpread/calculateShares.js
@@ -3,7 +3,7 @@
 import '../../../exported';
 import './types';
 
-import { amountMath } from '@agoric/ertp';
+import { amountMath, isNatValue } from '@agoric/ertp';
 import { assert } from '@agoric/assert';
 import { makeRatio } from '../../contractSupport';
 import { oneMinus, make100Percent, make0Percent } from './percent';
@@ -29,8 +29,8 @@ function calculateShares(collateralBrand, price, strikePrice1, strikePrice2) {
 
   const denominator = amountMath.subtract(strikePrice2, strikePrice1);
   const numerator = amountMath.subtract(price, strikePrice1);
-  assert.typeof(numerator.value, 'bigint');
-  assert.typeof(denominator.value, 'bigint');
+  assert(isNatValue(numerator.value));
+  assert(isNatValue(denominator.value));
   const longShare = makeRatio(
     numerator.value,
     collateralBrand,

--- a/packages/zoe/src/contracts/callSpread/fundedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/fundedCallSpread.js
@@ -1,10 +1,12 @@
 // @ts-check
+
 import '../../../exported';
 import './types';
 
 import { assert, details as X } from '@agoric/assert';
 import { makePromiseKit } from '@agoric/promise-kit';
 import { E } from '@agoric/eventual-send';
+import { amountMath } from '@agoric/ertp';
 import {
   assertProposalShape,
   depositToSeat,
@@ -56,16 +58,18 @@ import { Position } from './position';
 
 /** @type {ContractStartFn} */
 const start = async zcf => {
-  const terms = zcf.getTerms();
   const {
-    maths: { Collateral: collateralMath, Strike: strikeMath },
-  } = terms;
-  assertUsesNatMath(zcf, collateralMath.getBrand());
-  assertUsesNatMath(zcf, strikeMath.getBrand());
+    brands,
+    strikePrice1,
+    strikePrice2,
+    settlementAmount,
+  } = zcf.getTerms();
+  assertUsesNatMath(zcf, brands.Collateral);
+  assertUsesNatMath(zcf, brands.Strike);
   // notice that we don't assert that the Underlying is fungible.
 
   assert(
-    strikeMath.isGTE(terms.strikePrice2, terms.strikePrice1),
+    amountMath.isGTE(strikePrice2, strikePrice1),
     X`strikePrice2 must be greater than strikePrice1`,
   );
 
@@ -112,7 +116,7 @@ const start = async zcf => {
         zcf,
         {
           seat: collateralSeat,
-          gains: { Collateral: terms.settlementAmount },
+          gains: { Collateral: settlementAmount },
         },
         {
           seat: creatorSeat,

--- a/packages/zoe/src/contracts/callSpread/payoffHandler.js
+++ b/packages/zoe/src/contracts/callSpread/payoffHandler.js
@@ -1,8 +1,10 @@
 // @ts-check
+
 import '../../../exported';
 import './types';
 
 import { E } from '@agoric/eventual-send';
+import { amountMath } from '@agoric/ertp';
 import { trade, getAmountOut, multiplyBy } from '../../contractSupport';
 import { Position } from './position';
 import { calculateShares } from './calculateShares';
@@ -16,8 +18,7 @@ import { calculateShares } from './calculateShares';
 function makePayoffHandler(zcf, seatPromiseKits, collateralSeat) {
   const terms = zcf.getTerms();
   const {
-    maths: { Collateral: collateralMath, Strike: strikeMath },
-    brands: { Strike: strikeBrand },
+    brands: { Strike: strikeBrand, Collateral: collateralBrand },
   } = terms;
   let seatsExited = 0;
 
@@ -45,7 +46,7 @@ function makePayoffHandler(zcf, seatPromiseKits, collateralSeat) {
       seat.exit();
       seatsExited += 1;
       const remainder = collateralSeat.getAmountAllocated('Collateral');
-      if (collateralMath.isEmpty(remainder) && seatsExited === 2) {
+      if (amountMath.isEmpty(remainder, collateralBrand) && seatsExited === 2) {
         zcf.shutdown('contract has been settled');
       }
     });
@@ -55,8 +56,7 @@ function makePayoffHandler(zcf, seatPromiseKits, collateralSeat) {
     const strike1 = terms.strikePrice1;
     const strike2 = terms.strikePrice2;
     const { longShare, shortShare } = calculateShares(
-      strikeMath,
-      collateralMath,
+      collateralBrand,
       quoteAmount,
       strike1,
       strike2,

--- a/packages/zoe/src/contracts/callSpread/percent.js
+++ b/packages/zoe/src/contracts/callSpread/percent.js
@@ -34,5 +34,5 @@ export function make100Percent(brand) {
 }
 
 export function make0Percent(brand) {
-  return makeRatio(0, brand);
+  return makeRatio(0n, brand);
 }

--- a/packages/zoe/src/contracts/callSpread/position.js
+++ b/packages/zoe/src/contracts/callSpread/position.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Constants for long and short positions.
  *

--- a/packages/zoe/src/contracts/callSpread/types.js
+++ b/packages/zoe/src/contracts/callSpread/types.js
@@ -31,14 +31,14 @@
 /**
  * @callback MakePercent
  * @param {bigint} value
- * @param {DeprecatedAmountMath} amountMath
+ * @param {Brand} brand
  * @param {bigint=} base
  * @returns {Percent}
  */
 
 /**
  * @callback MakeCanonicalPercent
- * @param {DeprecatedAmountMath} amountMath
+ * @param {Brand} brand
  * @returns {Percent}
  */
 
@@ -46,7 +46,6 @@
  * @callback CalculatePercent
  * @param {Amount} numerator
  * @param {Amount} denominator
- * @param {DeprecatedAmountMath} amountMath
  * @param {bigint=} base
  * @returns {Percent}
  */
@@ -78,12 +77,11 @@
  * Otherwise return longShare and shortShare representing ratios between 0% and
  * 100% reflecting the position of the price in the range from strikePrice1 to
  * strikePrice2.
- * @param {DeprecatedAmountMath} strikeMath
- * @param {DeprecatedAmountMath} collateralMath
+ * @param {Brand} collateralBrand
  * @param {Amount} price
  * @param {Amount} strikePrice1
  * @param {Amount} strikePrice2
- * @returns {CalculateSharesReturn  }
+ * @returns {CalculateSharesReturn}
  */
 
 /**

--- a/packages/zoe/src/contracts/coveredCall.js
+++ b/packages/zoe/src/contracts/coveredCall.js
@@ -1,4 +1,5 @@
 // @ts-check
+
 import '../../exported';
 
 // Eventually will be importable from '@agoric/zoe-contract-support'

--- a/packages/zoe/src/contracts/loan/borrow.js
+++ b/packages/zoe/src/contracts/loan/borrow.js
@@ -1,10 +1,12 @@
 // @ts-check
+
 import '../../../exported';
 
 import { assert, details as X } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 import { makePromiseKit } from '@agoric/promise-kit';
+import { amountMath } from '@agoric/ertp';
 
 import {
   assertProposalShape,
@@ -43,8 +45,6 @@ export const makeBorrowInvitation = (zcf, config) => {
     const collateralGiven = borrowerSeat.getAmountAllocated('Collateral');
     const loanWanted = borrowerSeat.getProposal().want.Loan;
     const loanBrand = zcf.getTerms().brands.Loan;
-    const loanMath = zcf.getTerms().maths.Loan;
-    const collateralMath = zcf.getTerms().maths.Collateral;
 
     // The value of the collateral in the Loan brand
     const quote = await E(priceAuthority).quoteGiven(
@@ -57,7 +57,7 @@ export const makeBorrowInvitation = (zcf, config) => {
     // Assert the required collateral was escrowed.
     const requiredMargin = multiplyBy(loanWanted, mmr);
     assert(
-      loanMath.isGTE(collateralPriceInLoanBrand, requiredMargin),
+      amountMath.isGTE(collateralPriceInLoanBrand, requiredMargin),
       X`The required margin is ${requiredMargin.value}% but collateral only had value of ${collateralPriceInLoanBrand.value}`,
     );
 
@@ -65,7 +65,7 @@ export const makeBorrowInvitation = (zcf, config) => {
 
     // Assert that the collateralGiven has not changed after the AWAIT
     assert(
-      collateralMath.isEqual(
+      amountMath.isEqual(
         collateralGiven,
         borrowerSeat.getAmountAllocated('Collateral'),
       ),
@@ -74,7 +74,7 @@ export const makeBorrowInvitation = (zcf, config) => {
 
     // Assert that loanWanted <= maxLoan
     assert(
-      loanMath.isGTE(maxLoan, loanWanted),
+      amountMath.isGTE(maxLoan, loanWanted),
       X`The wanted loan ${loanWanted} must be below or equal to the maximum possible loan ${maxLoan}`,
     );
 
@@ -112,7 +112,6 @@ export const makeBorrowInvitation = (zcf, config) => {
     const debtCalculatorConfig = {
       calcInterestFn: calculateInterest,
       originalDebt: loanWanted,
-      loanMath,
       periodNotifier,
       interestRate,
       interestPeriod,

--- a/packages/zoe/src/contracts/loan/close.js
+++ b/packages/zoe/src/contracts/loan/close.js
@@ -3,6 +3,7 @@
 import './types';
 
 import { assert, details as X } from '@agoric/assert';
+import { amountMath } from '@agoric/ertp';
 
 import { assertProposalShape, trade } from '../../contractSupport';
 
@@ -22,7 +23,6 @@ export const makeCloseLoanInvitation = (zcf, config) => {
       want: { Collateral: null },
     });
 
-    const loanMath = zcf.getTerms().maths.Loan;
     const loanBrand = zcf.getTerms().brands.Loan;
     const collateralBrand = zcf.getTerms().brands.Collateral;
 
@@ -34,7 +34,7 @@ export const makeCloseLoanInvitation = (zcf, config) => {
 
     // All debt must be repaid.
     assert(
-      loanMath.isGTE(repaid, debt),
+      amountMath.isGTE(repaid, debt),
       X`Not enough Loan assets have been repaid.  ${debt} is required, but only ${repaid} was repaid.`,
     );
 

--- a/packages/zoe/src/contracts/loan/index.js
+++ b/packages/zoe/src/contracts/loan/index.js
@@ -1,4 +1,5 @@
 // @ts-check
+
 import '../../../exported';
 
 import { assert, details as X } from '@agoric/assert';
@@ -55,18 +56,18 @@ import { makeLendInvitation } from './lend';
  */
 const start = async zcf => {
   assertIssuerKeywords(zcf, harden(['Collateral', 'Loan']));
-  const loanMath = zcf.getTerms().maths.Loan;
 
   // Rather than grabbing the terms each time we use them, let's set
   // some defaults and add them to a contract-wide config.
 
   const {
-    mmr = makeRatio(150n, loanMath), // Maintenance Margin Requirement
     autoswapInstance,
     priceAuthority,
     periodNotifier,
     interestRate,
     interestPeriod,
+    brands: { Loan: loanBrand, Collateral: collateralBrand },
+    mmr = makeRatio(150n, loanBrand), // Maintenance Margin Requirement
   } = zcf.getTerms();
 
   assert(autoswapInstance, X`autoswapInstance must be provided`);
@@ -82,6 +83,8 @@ const start = async zcf => {
     periodNotifier,
     interestRate,
     interestPeriod,
+    loanBrand,
+    collateralBrand,
   };
 
   const creatorInvitation = makeLendInvitation(zcf, harden(config));

--- a/packages/zoe/src/contracts/loan/lend.js
+++ b/packages/zoe/src/contracts/loan/lend.js
@@ -1,4 +1,5 @@
 // @ts-check
+
 import '../../../exported';
 
 import { assertProposalShape } from '../../contractSupport';

--- a/packages/zoe/src/contracts/loan/liquidate.js
+++ b/packages/zoe/src/contracts/loan/liquidate.js
@@ -1,7 +1,9 @@
 // @ts-check
+
 import '../../../exported';
 
 import { E } from '@agoric/eventual-send';
+import { amountMath } from '@agoric/ertp';
 
 import { offerTo } from '../../contractSupport/zoeHelpers';
 
@@ -10,20 +12,15 @@ export const doLiquidation = async (
   collateralSeat,
   autoswapPublicFacetP,
   lenderSeat,
+  loanBrand,
 ) => {
-  const loanMath = zcf.getTerms().maths.Loan;
-
   const allCollateral = collateralSeat.getAmountAllocated('Collateral');
-
   const swapInvitation = E(autoswapPublicFacetP).makeSwapInInvitation();
-
   const toAmounts = harden({ In: allCollateral });
-
   const proposal = harden({
     give: toAmounts,
-    want: { Out: loanMath.getEmpty() },
+    want: { Out: amountMath.makeEmpty(loanBrand) },
   });
-
   const keywordMapping = harden({
     Collateral: 'In',
     Loan: 'Out',
@@ -68,12 +65,18 @@ export const doLiquidation = async (
  * @type {Liquidate}
  */
 export const liquidate = async (zcf, config) => {
-  const { collateralSeat, autoswapInstance, lenderSeat } = config;
+  const { collateralSeat, autoswapInstance, lenderSeat, loanBrand } = config;
 
   const zoeService = zcf.getZoeService();
 
   const autoswapPublicFacetP = E(zoeService).getPublicFacet(autoswapInstance);
 
   // For testing purposes, make it easier to mock the autoswap public facet.
-  return doLiquidation(zcf, collateralSeat, autoswapPublicFacetP, lenderSeat);
+  return doLiquidation(
+    zcf,
+    collateralSeat,
+    autoswapPublicFacetP,
+    lenderSeat,
+    loanBrand,
+  );
 };

--- a/packages/zoe/src/contracts/loan/scheduleLiquidation.js
+++ b/packages/zoe/src/contracts/loan/scheduleLiquidation.js
@@ -1,8 +1,9 @@
-// ts-check
+// @ts-check
 
 import '../../../exported';
 
 import { E } from '@agoric/eventual-send';
+import { amountMath } from '@agoric/ertp';
 
 import { liquidate } from './liquidate';
 import { getAmountIn, multiplyBy } from '../../contractSupport';
@@ -25,8 +26,6 @@ export const scheduleLiquidation = (zcf, configWithBorrower) => {
   // Formula: liquidationTriggerValue = (currentDebt * mmr)
   const liquidationTriggerValue = multiplyBy(currentDebt, mmr);
 
-  const collateralMath = zcf.getTerms().maths.Collateral;
-
   const allCollateral = collateralSeat.getAmountAllocated('Collateral');
 
   const internalLiquidationPromise = E(priceAuthority).quoteWhenLT(
@@ -42,7 +41,7 @@ export const scheduleLiquidation = (zcf, configWithBorrower) => {
       // collateral. If the amount is wrong, we will have already
       // scheduled another liquidation for the right amount.
       const currentCollateral = collateralSeat.getAmountAllocated('Collateral');
-      if (collateralMath.isEqual(amountIn, currentCollateral)) {
+      if (amountMath.isEqual(amountIn, currentCollateral)) {
         liquidationPromiseKit.resolve(priceQuote);
         liquidate(zcf, configWithBorrower);
       }

--- a/packages/zoe/src/contracts/loan/types.js
+++ b/packages/zoe/src/contracts/loan/types.js
@@ -34,8 +34,11 @@
  * @property {Ratio} interestRate
  *   The rate in basis points that will be multiplied with the debt on
  *   every period to compound interest.
- 
+ *
  * @property {RelativeTime} interestPeriod
+ *
+ * @property {Brand} loanBrand
+ * @property {Brand} collateralBrand
  */
 
 /**
@@ -63,7 +66,7 @@
  *
  *   A function to get the current debt
  *
- * @property {PromiseKit} liquidationPromiseKit
+ * @property {PromiseRecord<PriceQuote>} liquidationPromiseKit
  *
  *   PromiseKit that includes a promise that resolves to a PriceQuote
  *   when liquidation is triggered
@@ -77,7 +80,7 @@
  *   The ZCFSeat holding the collateral in escrow after the borrower
  *   escrows it
  *
- * @property {PromiseKit} liquidationPromiseKit
+ * @property {PromiseRecord<PriceQuote>} liquidationPromiseKit
  *
  *   PromiseKit that includes a promise that resolves to a PriceQuote
  *   when liquidation is triggered
@@ -161,10 +164,6 @@
  *
  *   The debt at the start of the loan, in Loan brand
  *
- * @property {DeprecatedAmountMath} loanMath
- *
- *   AmountMath for the loan brand
- *
  * @property {PeriodNotifier} periodNotifier
  *
  *   The AsyncIterable to notify when a period has occurred
@@ -186,7 +185,7 @@
  * @property {ZCFSeat} collateralSeat
  * @property {PromiseRecord<any>} liquidationPromiseKit
  * @property {bigint} [mmr]
- * @property {InstanceHandle} autoswapInstance
+ * @property {Handle<'Instance'>} autoswapInstance
  * @property {PriceAuthority} priceAuthority
  * @property {PeriodNotifier} periodNotifier
  * @property {bigint} interestRate

--- a/packages/zoe/src/contracts/loan/updateDebt.js
+++ b/packages/zoe/src/contracts/loan/updateDebt.js
@@ -4,6 +4,7 @@ import '../../../exported';
 import { Far } from '@agoric/marshal';
 import { makeNotifierKit, observeNotifier } from '@agoric/notifier';
 import { assert, details as X } from '@agoric/assert';
+import { amountMath } from '@agoric/ertp';
 
 import { scheduleLiquidation } from './scheduleLiquidation';
 import { multiplyBy } from '../../contractSupport';
@@ -26,7 +27,6 @@ export const makeDebtCalculator = debtCalculatorConfig => {
   const {
     calcInterestFn = calculateInterest,
     originalDebt,
-    loanMath,
     periodNotifier,
     interestRate,
     interestPeriod,
@@ -56,7 +56,7 @@ export const makeDebtCalculator = debtCalculatorConfig => {
       while (lastCalculationTimestamp + interestPeriod <= timestamp) {
         lastCalculationTimestamp += interestPeriod;
         const interest = calcInterestFn(debt, interestRate);
-        debt = loanMath.add(debt, interest);
+        debt = amountMath.add(debt, interest);
         updatedLoan = true;
       }
       if (updatedLoan) {

--- a/packages/zoe/src/contracts/mintPayments.js
+++ b/packages/zoe/src/contracts/mintPayments.js
@@ -1,7 +1,7 @@
-/* eslint-disable no-use-before-define */
 // @ts-check
 
 import { Far } from '@agoric/marshal';
+import { amountMath } from '@agoric/ertp';
 
 import '../../exported';
 
@@ -28,10 +28,10 @@ const start = async zcf => {
 
   // Now that ZCF has saved the issuer, brand, and local amountMath, they
   // can be accessed synchronously.
-  const { amountMath, issuer } = zcfMint.getIssuerRecord();
+  const { issuer, brand } = zcfMint.getIssuerRecord();
 
-  const mintPayment = extent => seat => {
-    const amount = amountMath.make(extent);
+  const mintPayment = value => seat => {
+    const amount = amountMath.make(value, brand);
     // Synchronously mint and allocate amount to seat.
     zcfMint.mintGains({ Token: amount }, seat);
     // Exit the seat so that the user gets a payout.
@@ -44,8 +44,8 @@ const start = async zcf => {
   const creatorFacet = Far('creatorFacet', {
     // The creator of the instance can send invitations to anyone
     // they wish to.
-    makeInvitation: (extent = 1000) =>
-      zcf.makeInvitation(mintPayment(extent), 'mint a payment'),
+    makeInvitation: (value = 1000) =>
+      zcf.makeInvitation(mintPayment(value), 'mint a payment'),
     getTokenIssuer: () => issuer,
   });
 

--- a/packages/zoe/src/contracts/multipoolAutoswap/addLiquidity.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/addLiquidity.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { assertProposalShape } from '../../contractSupport';
 
 import '../../../exported';

--- a/packages/zoe/src/contracts/multipoolAutoswap/getCurrentPrice.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/getCurrentPrice.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import '../../../exported';
 
 import { assert, details as X } from '@agoric/assert';

--- a/packages/zoe/src/contracts/multipoolAutoswap/pool.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/pool.js
@@ -2,7 +2,7 @@
 
 import { E } from '@agoric/eventual-send';
 import { assert, details as X } from '@agoric/assert';
-import { MathKind, amountMath } from '@agoric/ertp/src/amountMath';
+import { MathKind, amountMath, isNatValue } from '@agoric/ertp/';
 
 import {
   getInputPrice,
@@ -102,7 +102,7 @@ export const makeAddPool = (zcf, isSecondary, initPool, centralBrand) => {
           inputAmount.brand,
           outputBrand,
         );
-        assert.typeof(inputAmount.value, 'bigint');
+        assert(isNatValue(inputAmount.value));
         const valueOut = getInputPrice(
           inputAmount.value,
           inputReserve,
@@ -125,7 +125,7 @@ export const makeAddPool = (zcf, isSecondary, initPool, centralBrand) => {
           inputBrand,
           outputAmount.brand,
         );
-        assert.typeof(outputAmount.value, 'bigint');
+        assert(isNatValue(outputAmount.value));
         const valueIn = getOutputPrice(
           outputAmount.value,
           inputReserve,
@@ -147,10 +147,10 @@ export const makeAddPool = (zcf, isSecondary, initPool, centralBrand) => {
         const secondaryIn = userAllocation.Secondary;
         const centralAmount = pool.getCentralAmount();
         const secondaryAmount = pool.getSecondaryAmount();
-        assert.typeof(userAllocation.Central.value, 'bigint');
-        assert.typeof(centralAmount.value, 'bigint');
-        assert.typeof(secondaryAmount.value, 'bigint');
-        assert.typeof(secondaryIn.value, 'bigint');
+        assert(isNatValue(userAllocation.Central.value));
+        assert(isNatValue(centralAmount.value));
+        assert(isNatValue(secondaryAmount.value));
+        assert(isNatValue(secondaryIn.value));
 
         // To calculate liquidity, we'll need to calculate alpha from the primary
         // token's value before, and the value that will be added to the pool
@@ -178,7 +178,7 @@ export const makeAddPool = (zcf, isSecondary, initPool, centralBrand) => {
           liquidityBrand,
         );
         const liquidityValueIn = liquidityIn.value;
-        assert.typeof(liquidityValueIn, 'bigint');
+        assert(isNatValue(liquidityValueIn));
         const centralTokenAmountOut = amountMath.make(
           calcValueToRemove(
             liqTokenSupply,

--- a/packages/zoe/src/contracts/multipoolAutoswap/removeLiquidity.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/removeLiquidity.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { assertProposalShape } from '../../contractSupport';
 
 import '../../../exported';

--- a/packages/zoe/src/contracts/multipoolAutoswap/swap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/swap.js
@@ -97,7 +97,7 @@ export const makeMakeSwapInvitation = (
         amountIn: reducedAmountIn,
         amountOut,
         // TODO: determine whether centralAmount will always exist
-        // @ts-ignore
+        // @ts-ignore If has Central, should not be typed as PriceAmountPair
         centralAmount: reducedCentralAmount,
       } = getPriceGivenAvailableInput(amountIn, brandOut);
 
@@ -212,7 +212,7 @@ export const makeMakeSwapInvitation = (
         amountIn,
         amountOut: improvedAmountOut,
         // TODO: determine whether centralAmount will always exist
-        // @ts-ignore
+        // @ts-ignore If has Central, should not be typed as PriceAmountPair
         centralAmount: improvedCentralAmount,
       } = getPriceGivenRequiredOutput(brandIn, amountOut);
       const brandInPool = getPool(brandIn);

--- a/packages/zoe/src/contracts/multipoolAutoswap/types.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/types.js
@@ -26,7 +26,7 @@
  */
 
 /**
- * typedef {Object} PriceAmountPair
+ * @typedef {Object} PriceAmountPair
  *
  * @property {Amount} amountOut
  * @property {Amount} amountIn
@@ -41,9 +41,6 @@
  * @property {(seat: ZCFSeat) => string} addLiquidity
  * @property {(seat: ZCFSeat) => string} removeLiquidity
  * @property {() => ZCFSeat} getPoolSeat
- * @property {() => DeprecatedAmountMath} getAmountMath - get the amountMath for this
- * pool's secondary brand
- * @property {() => DeprecatedAmountMath} getCentralAmountMath
  * @property {() => Amount} getSecondaryAmount
  * @property {() => Amount} getCentralAmount
  */

--- a/packages/zoe/src/contracts/oracle.js
+++ b/packages/zoe/src/contracts/oracle.js
@@ -1,6 +1,8 @@
 // @ts-check
+
 import { assert, details as X } from '@agoric/assert';
 import { Far } from '@agoric/marshal';
+import { amountMath } from '@agoric/ertp';
 
 import '../../exported';
 
@@ -15,7 +17,6 @@ import { trade } from '../contractSupport';
  */
 const start = async zcf => {
   const feeBrand = zcf.getTerms().brands.Fee;
-  const feeMath = zcf.getTerms().maths.Fee;
 
   /** @type {OracleHandler} */
   let handler;
@@ -66,10 +67,10 @@ const start = async zcf => {
     async query(query) {
       try {
         assert(!revoked, revokedMsg);
-        const noFee = feeMath.getEmpty();
+        const noFee = amountMath.makeEmpty(feeBrand);
         const { requiredFee, reply } = await E(handler).onQuery(query, noFee);
         assert(
-          !requiredFee || feeMath.isGTE(noFee, requiredFee),
+          !requiredFee || amountMath.isGTE(noFee, requiredFee),
           X`Oracle required a fee but the query had none`,
         );
         return reply;

--- a/packages/zoe/src/contracts/priceAggregatorTypes.js
+++ b/packages/zoe/src/contracts/priceAggregatorTypes.js
@@ -6,9 +6,16 @@
  */
 
 /**
+ * @callback PriceAggregatorCreatorFacetInitOracle
+ * @param {Instance} oracleInstance
+ * @param {unknown=} query
+ * @returns {Promise<OracleAdmin>}
+ */
+
+/**
  * @typedef {Object} PriceAggregatorCreatorFacet
  * @property {(quoteMint: Mint) => Promise<void>} initializeQuoteMint
- * @property {(oracleInstance: Instance, query: any=) => Promise<OracleAdmin>} initOracle
+ * @property {PriceAggregatorCreatorFacetInitOracle} initOracle
  */
 
 /**
@@ -31,11 +38,17 @@
  */
 
 /**
+ * @callback OracleCreatorFacetMakeWithdrawInvitation
+ * @param {boolean=} total
+ * @returns {ERef<Invitation>}
+ */
+
+/**
  * @typedef {Object} OracleCreatorFacet the private methods accessible from the
  * contract instance
  * @property {() => AmountKeywordRecord} getCurrentFees get the current
  * fee amounts
- * @property {(total: boolean=) => ERef<Invitation>}
+ * @property {OracleCreatorFacetMakeWithdrawInvitation}
  * makeWithdrawInvitation create an invitation to withdraw fees
  * @property {() => Promise<Invitation>} makeShutdownInvitation
  *   Make an invitation to withdraw all fees and shutdown

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -122,7 +122,7 @@
  * @param invitationHandle: InvitationHandle,
  * @param description: string,
  * @param customProperties: Record<string, any>=,
- * @returns {Payment} payment
+ * @returns {Payment}
  */
 
 /**

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -19,7 +19,7 @@
  * @typedef {Object} ZoeSeatAdminKit
  * @property {UserSeat} userSeat
  * @property {ZoeSeatAdmin} zoeSeatAdmin
- * @property {Notifier} notifier
+ * @property {Notifier<Allocation>} notifier
  *
  * @callback MakeZoeSeatAdminKit
  * Make the Zoe seat admin, user seat and a notifier
@@ -30,13 +30,25 @@
  * @param {ERef<ExitObj>} exitObj
  * @param {ERef<OfferResult>=} offerResult
  * @returns {ZoeSeatAdminKit}
- *
+ */
+
+/**
+ * @callback ZoeSeatAdminExit
+ * @param {Completion=} completion
+ * @returns {void}
+ */
+
+/**
  * @typedef {Object} ZoeSeatAdmin
  * @property {(allocation: Allocation) => void} replaceAllocation
- * @property {(completion: Completion) => void} exit
+ * @property {ZoeSeatAdminExit} exit
  * @property {(reason: TerminationReason) => void} fail called with the reason
  * for calling fail on this seat, where reason is normally an instanceof Error.
  * @property {() => Allocation} getCurrentAllocation
+ */
+
+/**
+ * @callback {(brand: Brand) => AmountMathKind} GetMathKind
  */
 
 /**
@@ -48,7 +60,7 @@
  * - a presence from Zoe such that ZCF can tell Zoe
  * about seat events
  * @param {SeatData} seatData - pass-by-copy data to use to make the seat
- * @param {GetAmountMath} getAmountMath
+ * @param {GetMathKind} getMathKind - get the mathKind given the brand
  * @returns {ZcfSeatAdminKit}
  */
 
@@ -106,11 +118,16 @@
  */
 
 /**
+ * @callback ZoeInstanceAdminMakeInvitation
+ * @param invitationHandle: InvitationHandle,
+ * @param description: string,
+ * @param customProperties: Record<string, any>=,
+ * @returns {Payment} payment
+ */
+
+/**
  * @typedef {Object} ZoeInstanceAdmin
- * @property {(invitationHandle: InvitationHandle,
- *             description: string,
- *             customProperties: Record<string, any>=,
- *            ) => Payment} makeInvitation
+ * @property {ZoeInstanceAdminMakeInvitation} makeInvitation
  * @property {(issuerP: ERef<Issuer>,
  *             keyword: Keyword
  *            ) => Promise<void>} saveIssuer

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -271,3 +271,13 @@
  * @param {(amount: Amount) => any} onFulfilled
  * @returns {any} the result of `onFulfilled`
  */
+
+/**
+ * @callback GetMathKindByBrand
+ * Get the mathKind for a brand known by Zoe
+ *
+ * To be deleted when brands have a property for mathKind
+ *
+ * @param {Brand} brand
+ * @returns {AmountMathKind}
+ */

--- a/packages/zoe/src/issuerTable.js
+++ b/packages/zoe/src/issuerTable.js
@@ -68,6 +68,7 @@ const makeIssuerTable = () => {
         brand,
         issuer,
         amountMath,
+        mathKind: amountMathKind,
         displayInfo: { ...displayInfo, amountMathKind },
       });
       return issuerTable.getByBrand(brand);

--- a/packages/zoe/src/makeHandle.js
+++ b/packages/zoe/src/makeHandle.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { assert } from '@agoric/assert';
 import { Far } from '@agoric/marshal';
 

--- a/packages/zoe/src/typeGuards.js
+++ b/packages/zoe/src/typeGuards.js
@@ -1,0 +1,28 @@
+// @ts-check
+
+/**
+ * @param {ExitRule} exit
+ * @returns {exit is OnDemandExitRule}
+ */
+export const isOnDemandExitRule = exit => {
+  const [exitKey] = Object.getOwnPropertyNames(exit);
+  return exitKey === 'onDemand';
+};
+
+/**
+ * @param {ExitRule} exit
+ * @returns {exit is WaivedExitRule}
+ */
+export const isWaivedExitRule = exit => {
+  const [exitKey] = Object.getOwnPropertyNames(exit);
+  return exitKey === 'waived';
+};
+
+/**
+ * @param {ExitRule} exit
+ * @returns {exit is AfterDeadlineExitRule}
+ */
+export const isAfterDeadlineExitRule = exit => {
+  const [exitKey] = Object.getOwnPropertyNames(exit);
+  return exitKey === 'afterDeadline';
+};

--- a/packages/zoe/src/types.js
+++ b/packages/zoe/src/types.js
@@ -37,6 +37,7 @@
  * @property {Brand} brand
  * @property {Issuer} issuer
  * @property {DeprecatedAmountMath} amountMath
+ * @property {AmountMathKind} mathKind
  * @property {any} [displayInfo]
  *
  * @typedef {AmountKeywordRecord} Allocation

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -105,7 +105,7 @@
  * @property {() => Promise<OfferResult>} getOfferResult
  * @property {() => void=} tryExit
  * @property {() => Promise<boolean>} hasExited
- * @property {() => Promise<Notifier>} getNotifier
+ * @property {() => Promise<Notifier<Allocation>>} getNotifier
  */
 
 /**
@@ -140,7 +140,8 @@
  * @typedef {Record<Keyword,Amount>} AmountKeywordRecord
  *
  * The keys are keywords, and the values are amounts. For example:
- * { Asset: amountMath.make(5), Price: amountMath.make(9) }
+ * { Asset: amountMath.make(5n, assetBrand), Price:
+ * amountMath.make(9n, priceBrand) }
  */
 
 /**
@@ -158,10 +159,22 @@
  */
 
 /**
- * @typedef {Object} ExitRule
- * @property {null=} onDemand
- * @property {null=} waived
- * @property {{timer:Timer, deadline:Deadline}=} afterDeadline
+ * @typedef {Object} OnDemandExitRule
+ * @property {null} onDemand
+ */
+
+/**
+ * @typedef {Object} WaivedExitRule
+ * @property {null} waived
+ */
+
+/**
+ * @typedef {Object} AfterDeadlineExitRule
+ * @property {{timer:Timer, deadline:Deadline}} afterDeadline
+ */
+
+/**
+ * @typedef {OnDemandExitRule | WaivedExitRule | AfterDeadlineExitRule} ExitRule
  *
  * The possible keys are 'waived', 'onDemand', and 'afterDeadline'.
  * `timer` and `deadline` only are used for the `afterDeadline` key.

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -137,6 +137,10 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
         issuerRecords.map(record => record.brand),
         keywords,
       );
+      const maths = arrayToObj(
+        issuerRecords.map(record => record.amountMath),
+        keywords,
+      );
 
       let instanceRecord = {
         installation,
@@ -144,6 +148,7 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
           ...customTerms,
           issuers,
           brands,
+          maths,
         },
       };
 
@@ -166,6 +171,10 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
             brands: {
               ...instanceRecord.terms.brands,
               [keyword]: issuerRecord.brand,
+            },
+            maths: {
+              ...instanceRecord.terms.maths,
+              [keyword]: issuerRecord.amountMath,
             },
           },
         };

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -52,6 +52,9 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
   /** @type {WeakStore<SeatHandle, ZoeSeatAdmin>} */
   const seatHandleToZoeSeatAdmin = makeNonVOWeakStore('seatHandle');
 
+  /** @type {GetMathKindByBrand} */
+  const getMathKindByBrand = brand => issuerTable.getByBrand(brand).mathKind;
+
   /**
    * Create an installation by permanently storing the bundle. It will be
    * evaluated each time it is used to make a new instance of a contract.
@@ -416,7 +419,7 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
             `No further offers are accepted`,
           );
 
-          const proposal = cleanProposal(uncleanProposal);
+          const proposal = cleanProposal(uncleanProposal, getMathKindByBrand);
           const { give, want } = proposal;
           const giveKeywords = Object.keys(give);
           const wantKeywords = Object.keys(want);

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -6,6 +6,11 @@ import { makePromiseKit } from '@agoric/promise-kit';
 
 /**
  * Zoe uses ERTP, the Electronic Rights Transfer Protocol
+ *
+ * Within Zoe, the mathKind of validated amounts must be consistent
+ * with the brand's mathKind. This is stricter than the validation
+ * provided by amountMath currently. When the brand has a
+ * mathKind itself, amountMath will validate that.
  */
 import '@agoric/ertp/exported';
 import '@agoric/store/exported';

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -45,6 +45,7 @@ export const makeZoeSeatAdminKit = (
     /** @type {PaymentPKeywordRecord} */
     const payout = objectMap(currentAllocation, ([keyword, payoutAmount]) => {
       const purse = brandToPurse.get(payoutAmount.brand);
+      // TODO: fix types of ObjectMap
       // @ts-ignore
       return [keyword, E(purse).withdraw(payoutAmount)];
     });

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -45,6 +45,7 @@ export const makeZoeSeatAdminKit = (
     /** @type {PaymentPKeywordRecord} */
     const payout = objectMap(currentAllocation, ([keyword, payoutAmount]) => {
       const purse = brandToPurse.get(payoutAmount.brand);
+      // @ts-ignore
       return [keyword, E(purse).withdraw(payoutAmount)];
     });
     harden(payout);

--- a/packages/zoe/test/autoswapJig.js
+++ b/packages/zoe/test/autoswapJig.js
@@ -1,8 +1,10 @@
+// @ts-check
+
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
-import { makeLocalAmountMath } from '@agoric/ertp';
-import { natSafeMath } from '../src/contractSupport';
+import { amountMath } from '@agoric/ertp';
 
+import { natSafeMath } from '../src/contractSupport';
 import { assertOfferResult, assertPayoutAmount } from './zoeTestHelpers';
 
 const { add, subtract, multiply, floorDivide } = natSafeMath;
@@ -144,8 +146,6 @@ export const makeTrader = async (purses, zoe, publicFacet, centralIssuer) => {
       expected,
       { Secondary: secondaryIssuer },
     ) => {
-      const { make: central } = await makeLocalAmountMath(centralIssuer);
-      const { make: secondary } = await makeLocalAmountMath(secondaryIssuer);
       // just check that the trade went through, and the results are as stated.
       // The test will declare fees, refunds, and figure out when the trade
       // gets less than requested
@@ -161,6 +161,11 @@ export const makeTrader = async (purses, zoe, publicFacet, centralIssuer) => {
         in: inExpected,
         out: outExpected,
       } = expected;
+
+      const centralBrand = await E(centralIssuer).getBrand();
+      const secondaryBrand = await E(secondaryIssuer).getBrand();
+      const central = value => amountMath.make(value, centralBrand);
+      const secondary = value => amountMath.make(value, secondaryBrand);
 
       const poolPre = await getPoolAllocation(secondaryIssuer);
       t.deepEqual(poolPre.Central, central(cPoolPre), `central before swap`);
@@ -199,12 +204,17 @@ export const makeTrader = async (purses, zoe, publicFacet, centralIssuer) => {
       expected,
       { Liquidity: liquidityIssuer, Secondary: secondaryIssuer },
     ) => {
-      const { make: central } = await makeLocalAmountMath(centralIssuer);
-      const { make: secondary } = await makeLocalAmountMath(secondaryIssuer);
-      const { make: liquidity } = await makeLocalAmountMath(liquidityIssuer);
       // just check that it went through, and the results are as stated.
       // The test will declare fees, refunds, and figure out when the trade
       // gets less than requested
+
+      const centralBrand = await E(centralIssuer).getBrand();
+      const secondaryBrand = await E(secondaryIssuer).getBrand();
+      const liquidityBrand = await E(liquidityIssuer).getBrand();
+      const central = value => amountMath.make(value, centralBrand);
+      const secondary = value => amountMath.make(value, secondaryBrand);
+      const liquidity = value => amountMath.make(value, liquidityBrand);
+
       const { c: cPre, s: sPre, l: lPre, k: kPre } = priorPoolState;
       const { cAmount, sAmount, lAmount = liquidity(0) } = details;
       const {
@@ -281,9 +291,13 @@ export const makeTrader = async (purses, zoe, publicFacet, centralIssuer) => {
       expected,
       { Liquidity: liquidityIssuer, Secondary: secondaryIssuer },
     ) => {
-      const { make: central } = await makeLocalAmountMath(centralIssuer);
-      const { make: secondary } = await makeLocalAmountMath(secondaryIssuer);
-      const { make: liquidity } = await makeLocalAmountMath(liquidityIssuer);
+      const centralBrand = await E(centralIssuer).getBrand();
+      const secondaryBrand = await E(secondaryIssuer).getBrand();
+      const liquidityBrand = await E(liquidityIssuer).getBrand();
+      const central = value => amountMath.make(value, centralBrand);
+      const secondary = value => amountMath.make(value, secondaryBrand);
+      const liquidity = value => amountMath.make(value, liquidityBrand);
+
       const { c: cPre, s: sPre, l: lPre, k: kPre } = priorPoolState;
       const { cAmount, sAmount, lAmount = liquidity(0) } = details;
       const {
@@ -344,13 +358,17 @@ export const makeTrader = async (purses, zoe, publicFacet, centralIssuer) => {
       expected,
       { Liquidity: liquidityIssuer, Secondary: secondaryIssuer },
     ) => {
-      const { make: central } = await makeLocalAmountMath(centralIssuer);
-      const { make: secondary } = await makeLocalAmountMath(secondaryIssuer);
-      const { make: liquidity } = await makeLocalAmountMath(liquidityIssuer);
-
       // just check that it went through, and the results are as stated.
       // The test will declare fees, refunds, and figure out when the trade
       // gets less than requested
+
+      const centralBrand = await E(centralIssuer).getBrand();
+      const secondaryBrand = await E(secondaryIssuer).getBrand();
+      const liquidityBrand = await E(liquidityIssuer).getBrand();
+      const central = value => amountMath.make(value, centralBrand);
+      const secondary = value => amountMath.make(value, secondaryBrand);
+      const liquidity = value => amountMath.make(value, liquidityBrand);
+
       const { c: cPre, s: sPre, l: lPre, k: kPre } = priorPoolState;
       const { cAmount, sAmount, lAmount = liquidity(0) } = details;
       const {

--- a/packages/zoe/test/bundle-source.js
+++ b/packages/zoe/test/bundle-source.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import bundleSource from '@agoric/bundle-source';
 
 // Use the new format.

--- a/packages/zoe/test/swingsetTests/brokenContracts/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/bootstrap.js
@@ -1,6 +1,8 @@
+// @ts-check
+
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
-import { makeIssuerKit } from '@agoric/ertp';
+import { makeIssuerKit, amountMath } from '@agoric/ertp';
 /* eslint-disable import/extensions, import/no-unresolved */
 import crashingAutoRefund from './bundle-crashingAutoRefund';
 /* eslint-enable import/extensions, import/no-unresolved */
@@ -13,25 +15,24 @@ const setupBasicMints = () => {
   ];
   const mints = all.map(objs => objs.mint);
   const issuers = all.map(objs => objs.issuer);
-  const amountMaths = all.map(objs => objs.amountMath);
+  const brands = all.map(objs => objs.brand);
 
   return harden({
     mints,
     issuers,
-    amountMaths,
+    brands,
   });
 };
 
 const makeVats = (log, vats, zoe, installations, startingValues) => {
-  const { mints, issuers, amountMaths } = setupBasicMints();
+  const { mints, issuers, brands } = setupBasicMints();
   const makePayments = values =>
     mints.map((mint, i) => {
-      return mint.mintPayment(amountMaths[i].make(values[i]));
+      return mint.mintPayment(amountMath.make(values[i], brands[i]));
     });
 
   // Setup Alice
   const alicePayment = makePayments(startingValues);
-  // const alicePayment = mints[0].mintPayment(amountMaths[0].make(3));
   const aliceP = E(vats.alice).build(zoe, issuers, alicePayment, installations);
 
   log(`=> alice is set up`);

--- a/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
@@ -1,10 +1,12 @@
 /* global __dirname */
+// @ts-check
+
+// eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-metering-and-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
+
 import { loadBasedir, buildVatController } from '@agoric/swingset-vat';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import bundleSource from '@agoric/bundle-source';
 
 import fs from 'fs';

--- a/packages/zoe/test/swingsetTests/brokenContracts/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/vat-alice.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
@@ -335,6 +337,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
       exit: { onDemand: null },
     });
     const aliceSwapTwoPayments = { Price: simoleansPayment };
+    // @ts-ignore
     const swapSeatTwo = await E(zoe).offer(
       swapInvitationTwo,
       swapTwoProposal,

--- a/packages/zoe/test/swingsetTests/brokenContracts/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/vat-alice.js
@@ -336,8 +336,8 @@ const build = async (log, zoe, issuers, payments, installations) => {
       want: { Asset: moola(2) },
       exit: { onDemand: null },
     });
+    assert(swapInvitationTwo);
     const aliceSwapTwoPayments = { Price: simoleansPayment };
-    // @ts-ignore
     const swapSeatTwo = await E(zoe).offer(
       swapInvitationTwo,
       swapTwoProposal,

--- a/packages/zoe/test/swingsetTests/brokenContracts/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/vat-zoe.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { Far } from '@agoric/marshal';
 
 // noinspection ES6PreferShortImport

--- a/packages/zoe/test/swingsetTests/helpers.js
+++ b/packages/zoe/test/swingsetTests/helpers.js
@@ -1,5 +1,7 @@
+// @ts-check
+
 import { E } from '@agoric/eventual-send';
-import { makeLocalAmountMath } from '@agoric/ertp';
+import { amountMath } from '@agoric/ertp';
 
 export const showPurseBalance = async (purseP, name, log) => {
   try {
@@ -14,14 +16,13 @@ export const setupIssuers = async (zoe, issuers) => {
   const purses = issuers.map(issuer => E(issuer).makeEmptyPurse());
   const invitationIssuer = await E(zoe).getInvitationIssuer();
   const [moolaIssuer, simoleanIssuer, bucksIssuer] = issuers;
+  const [moolaBrand, simoleanBrand, bucksBrand] = await Promise.all(
+    issuers.map(issuer => E(issuer).getBrand()),
+  );
 
-  const moolaAmountMath = await makeLocalAmountMath(moolaIssuer);
-  const simoleanAmountMath = await makeLocalAmountMath(simoleanIssuer);
-  const bucksAmountMath = await makeLocalAmountMath(bucksIssuer);
-
-  const moola = moolaAmountMath.make;
-  const simoleans = simoleanAmountMath.make;
-  const bucks = bucksAmountMath.make;
+  const moola = value => amountMath.make(value, moolaBrand);
+  const simoleans = value => amountMath.make(value, simoleanBrand);
+  const bucks = value => amountMath.make(value, bucksBrand);
 
   return harden({
     issuers: harden([moolaIssuer, simoleanIssuer]),
@@ -29,9 +30,6 @@ export const setupIssuers = async (zoe, issuers) => {
     moolaIssuer,
     simoleanIssuer,
     bucksIssuer,
-    moolaAmountMath,
-    simoleanAmountMath,
-    bucksAmountMath,
     moola,
     simoleans,
     bucks,

--- a/packages/zoe/test/swingsetTests/zoe-metering/test-zoe-metering.js
+++ b/packages/zoe/test/swingsetTests/zoe-metering/test-zoe-metering.js
@@ -1,5 +1,8 @@
 /* global process __dirname */
+
+// eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-metering-and-ses';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { loadBasedir, buildVatController } from '@agoric/swingset-vat';
 import fs from 'fs';

--- a/packages/zoe/test/swingsetTests/zoe/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/zoe/bootstrap.js
@@ -1,6 +1,8 @@
+// @ts-check
+
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
-import { makeIssuerKit } from '@agoric/ertp';
+import { makeIssuerKit, amountMath } from '@agoric/ertp';
 import buildManualTimer from '../../../tools/manualTimer';
 
 const setupBasicMints = () => {
@@ -11,20 +13,22 @@ const setupBasicMints = () => {
   ];
   const mints = all.map(objs => objs.mint);
   const issuers = all.map(objs => objs.issuer);
-  const amountMaths = all.map(objs => objs.amountMath);
+  const brands = all.map(objs => objs.brand);
 
   return harden({
     mints,
     issuers,
-    amountMaths,
+    brands,
   });
 };
 
 const makeVats = (log, vats, zoe, installations, startingValues) => {
   const timer = buildManualTimer(log);
-  const { mints, issuers, amountMaths } = setupBasicMints();
+  const { mints, issuers, brands } = setupBasicMints();
   const makePayments = values =>
-    mints.map((mint, i) => mint.mintPayment(amountMaths[i].make(values[i])));
+    mints.map((mint, i) =>
+      mint.mintPayment(amountMath.make(values[i], brands[i])),
+    );
   const [aliceValues, bobValues, carolValues, daveValues] = startingValues;
 
   // Setup Alice

--- a/packages/zoe/test/swingsetTests/zoe/test-zoe.js
+++ b/packages/zoe/test/swingsetTests/zoe/test-zoe.js
@@ -1,9 +1,11 @@
 /* global __dirname */
+
+// @ts-check
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/install-metering-and-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { buildVatController, buildKernelBundles } from '@agoric/swingset-vat';
 import bundleSource from '@agoric/bundle-source';
 

--- a/packages/zoe/test/swingsetTests/zoe/vat-bob.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-bob.js
@@ -5,7 +5,7 @@ import { Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
 import { sameStructure } from '@agoric/same-structure';
 import { amountMath } from '@agoric/ertp';
-import { assertSetValue } from '@agoric/ertp/src/typeGuards';
+import { isSetValue } from '@agoric/ertp/src/typeGuards';
 
 import { showPurseBalance, setupIssuers } from '../helpers';
 
@@ -508,7 +508,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const availableTickets = await E(publicFacet).getAvailableItems();
       log('availableTickets: ', availableTickets);
       // find the value corresponding to ticket #1
-      assertSetValue(availableTickets.value);
+      assert(isSetValue(availableTickets.value));
       const ticket1Value = availableTickets.value.find(
         ticket => ticket.number === 1,
       );

--- a/packages/zoe/test/swingsetTests/zoe/vat-carol.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-carol.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';

--- a/packages/zoe/test/swingsetTests/zoe/vat-dave.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-dave.js
@@ -1,18 +1,14 @@
+// @ts-check
+
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
 import { sameStructure } from '@agoric/same-structure';
+import { amountMath } from '@agoric/ertp';
 import { showPurseBalance, setupIssuers } from '../helpers';
 
 const build = async (log, zoe, issuers, payments, installations, timer) => {
-  const {
-    moola,
-    simoleans,
-    bucks,
-    purses,
-    moolaAmountMath,
-    simoleanAmountMath,
-  } = await setupIssuers(zoe, issuers);
+  const { moola, simoleans, bucks, purses } = await setupIssuers(zoe, issuers);
   const [moolaPurseP, simoleanPurseP, bucksPurseP] = purses;
   const [_moolaPayment, simoleanPayment, bucksPayment] = payments;
   const [moolaIssuer, simoleanIssuer, bucksIssuer] = issuers;
@@ -118,14 +114,14 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         X`wrong invitation`,
       );
       assert(
-        moolaAmountMath.isEqual(
+        amountMath.isEqual(
           optionValue[0].underlyingAssets.UnderlyingAsset,
           moola(3),
         ),
         X`wrong underlying asset`,
       );
       assert(
-        simoleanAmountMath.isEqual(
+        amountMath.isEqual(
           optionValue[0].strikePrice.StrikePrice,
           simoleans(7),
         ),

--- a/packages/zoe/test/swingsetTests/zoe/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-zoe.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { Far } from '@agoric/marshal';
 
 // noinspection ES6PreferShortImport

--- a/packages/zoe/test/unitTests/contractSupport/test-bondingCurves.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-bondingCurves.js
@@ -1,5 +1,8 @@
+// @ts-check
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 
 import {

--- a/packages/zoe/test/unitTests/contractSupport/test-depositTo.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-depositTo.js
@@ -1,4 +1,6 @@
 /* global __dirname */
+// @ts-check
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -11,18 +13,9 @@ import { setup } from '../setupBasicMints';
 import { makeZoe } from '../../..';
 import { makeFakeVatAdmin } from '../../../src/contractFacet/fakeVatAdmin';
 import { depositToSeat } from '../../../src/contractSupport/zoeHelpers';
+import { makeOffer } from '../makeOffer';
 
 const contractRoot = `${__dirname}/../zcf/zcfTesterContract`;
-
-const makeOffer = async (zoe, zcf, proposal, payments) => {
-  let zcfSeat;
-  const getSeat = seat => {
-    zcfSeat = seat;
-  };
-  const invitation = await zcf.makeInvitation(getSeat, 'seat');
-  const userSeat = await E(zoe).offer(invitation, proposal, payments);
-  return { zcfSeat, userSeat };
-};
 
 async function setupContract(moolaIssuer, bucksIssuer) {
   let testJig;
@@ -63,7 +56,7 @@ test(`depositToSeat - groundZero`, async t => {
   await depositToSeat(zcf, zcfSeat, { B: bucks(2) }, { B: newBucks });
   t.deepEqual(
     zcfSeat.getCurrentAllocation(),
-    { A: moola(0), B: bucks(7) },
+    { A: moola(0n), B: bucks(7n) },
     'should add deposit',
   );
 });
@@ -82,7 +75,7 @@ test(`depositToSeat - keyword variations`, async t => {
   await depositToSeat(zcf, zcfSeat, { C: bucks(2) }, { C: newBucks });
   t.deepEqual(
     zcfSeat.getCurrentAllocation(),
-    { A: moola(0), B: bucks(5), C: bucks(2) },
+    { A: moola(0n), B: bucks(5), C: bucks(2) },
     'should add deposit',
   );
 });
@@ -107,7 +100,7 @@ test(`depositToSeat - mismatched keywords`, async t => {
   );
   t.deepEqual(
     zcfSeat.getCurrentAllocation(),
-    { A: moola(0), B: bucks(5) },
+    { A: moola(0n), B: bucks(5) },
     'should add deposit',
   );
 });

--- a/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
@@ -17,18 +17,9 @@ import {
   assertProposalShape,
   swapExact,
 } from '../../../src/contractSupport/zoeHelpers';
+import { makeOffer } from '../makeOffer';
 
 const contractRoot = `${__dirname}/../zcf/zcfTesterContract`;
-
-const makeOffer = async (zoe, zcf, proposal, payments) => {
-  let zcfSeat;
-  const getSeat = seat => {
-    zcfSeat = seat;
-  };
-  const invitation = await zcf.makeInvitation(getSeat, 'seat');
-  const userSeat = await E(zoe).offer(invitation, proposal, payments);
-  return { zcfSeat, userSeat };
-};
 
 const setupContract = async (moolaIssuer, bucksIssuer) => {
   const instanceToZCF = new Map();
@@ -240,7 +231,7 @@ test(`offerTo - violates offer safety of fromSeat`, async t => {
   );
 
   t.deepEqual(fromSeatContractA.getCurrentAllocation(), {
-    TokenJ: moola(0),
+    TokenJ: moola(0n),
     TokenK: bucks(5),
   });
   t.falsy(fromSeatContractA.hasExited());

--- a/packages/zoe/test/unitTests/contractSupport/test-percentMath.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-percentMath.js
@@ -7,7 +7,7 @@ import test from 'ava';
 
 import '../../../exported';
 
-import { makeIssuerKit } from '@agoric/ertp';
+import { makeIssuerKit, amountMath } from '@agoric/ertp';
 import {
   makePercent,
   calculatePercent,
@@ -16,107 +16,118 @@ import {
 } from '../../../src/contractSupport/percentMath';
 
 test('percentMath - basic', t => {
-  const { amountMath } = makeIssuerKit('moe');
-  const moe = amountMath.make;
+  const { brand } = makeIssuerKit('moe');
+  /** @param {bigint} value */
+  const moe = value => amountMath.make(value, brand);
 
-  const halfDefault = makePercent(50n, amountMath);
-  const halfPrecise = makePercent(5000n, amountMath, 10000n);
+  const halfDefault = makePercent(50n, brand);
+  const halfPrecise = makePercent(5000n, brand, 10000n);
 
-  t.deepEqual(moe(666), halfDefault.scale(moe(1333)));
-  t.deepEqual(moe(6666666), halfDefault.scale(moe(13333333)));
-  t.deepEqual(moe(666), halfPrecise.scale(moe(1333)));
-  t.deepEqual(moe(6666666), halfPrecise.scale(moe(13333333)));
+  t.deepEqual(moe(666n), halfDefault.scale(moe(1333n)));
+  t.deepEqual(moe(666666n), halfDefault.scale(moe(1333333n)));
+  t.deepEqual(moe(666n), halfPrecise.scale(moe(1333n)));
+  t.deepEqual(moe(6666666n), halfPrecise.scale(moe(13333333n)));
 });
 
 test('percentMath - onethird', t => {
-  const { amountMath } = makeIssuerKit('moe');
-  const moe = amountMath.make;
+  const { brand } = makeIssuerKit('moe');
+  /** @param {bigint} value */
+  const moe = value => amountMath.make(value, brand);
 
-  const oneThirdDefault = calculatePercent(moe(1), moe(3), amountMath);
-  const oneThirdPrecise = calculatePercent(moe(1), moe(3), amountMath, 10000);
+  const oneThirdDefault = calculatePercent(moe(1n), moe(3n));
+  const oneThirdPrecise = calculatePercent(moe(1n), moe(3n), 10000n);
 
-  t.deepEqual(moe(33000), oneThirdDefault.scale(moe(100000)));
-  t.deepEqual(moe(33330), oneThirdPrecise.scale(moe(100000)));
+  t.deepEqual(moe(33000n), oneThirdDefault.scale(moe(100000n)));
+  t.deepEqual(moe(33330n), oneThirdPrecise.scale(moe(100000n)));
 });
 
 test('percentMath - brand mismatch', t => {
-  const { amountMath } = makeIssuerKit('moe');
-  const { amountMath: astAmountMath } = makeIssuerKit('ast');
-  const moe = amountMath.make;
+  const { brand } = makeIssuerKit('moe');
+  /** @param {bigint} value */
+  const moe = value => amountMath.make(value, brand);
 
-  const oneThirdDefault = calculatePercent(moe(1), moe(3), amountMath);
+  const { brand: astBrand } = makeIssuerKit('ast');
+
+  const oneThirdDefault = calculatePercent(moe(1n), moe(3n));
   t.throws(
-    () => calculatePercent(moe(1), amountMath, astAmountMath.make(3), 10000n),
+    () => calculatePercent(moe(1n), amountMath.make(3n, astBrand), 10000n),
     {
       message: `Dividing amounts of different brands doesn't produce a percent.`,
     },
   );
 
-  t.throws(() => oneThirdDefault.scale(astAmountMath.make(100000)), {
-    message: `amountMath must have the same brand as amount`,
+  t.throws(() => oneThirdDefault.scale(amountMath.make(100000n, astBrand)), {
+    message: `amount must have the same brand as the percent`,
   });
 });
 
 test('percentMath - ALL', t => {
-  const { amountMath } = makeIssuerKit('moe');
-  const moe = amountMath.make;
+  const { brand } = makeIssuerKit('moe');
+  /** @param {bigint} value */
+  const moe = value => amountMath.make(value, brand);
 
-  t.deepEqual(moe(100000), makeAll(amountMath).scale(moe(100000)));
+  t.deepEqual(moe(100000n), makeAll(brand).scale(moe(100000n)));
 });
 
 test('percentMath - NONE', t => {
-  const { amountMath } = makeIssuerKit('moe');
-  const moe = amountMath.make;
+  const { brand } = makeIssuerKit('moe');
+  /** @param {bigint} value */
+  const moe = value => amountMath.make(value, brand);
 
-  t.deepEqual(amountMath.getEmpty(), makeNone(amountMath).scale(moe(100000)));
+  t.deepEqual(amountMath.makeEmpty(brand), makeNone(brand).scale(moe(100000n)));
 });
 
 test('percentMath - complement', t => {
-  const { amountMath } = makeIssuerKit('moe');
-  const moe = amountMath.make;
+  const { brand } = makeIssuerKit('moe');
+  /** @param {bigint} value */
+  const moe = value => amountMath.make(value, brand);
 
-  const oneThirdDefault = calculatePercent(moe(1), moe(3), amountMath);
+  const oneThirdDefault = calculatePercent(moe(1n), moe(3n));
   const twoThirdsDefault = oneThirdDefault.complement();
-  const oneThirdPrecise = calculatePercent(moe(1), moe(3), amountMath, 10000n);
+  const oneThirdPrecise = calculatePercent(moe(1n), moe(3n), 10000n);
   const twoThirdsPrecise = oneThirdPrecise.complement();
 
-  t.deepEqual(moe(33000), oneThirdDefault.scale(moe(100000)));
-  t.deepEqual(moe(67000), twoThirdsDefault.scale(moe(100000)));
-  t.deepEqual(moe(66670), twoThirdsPrecise.scale(moe(100000)));
+  t.deepEqual(moe(33000n), oneThirdDefault.scale(moe(100000n)));
+  t.deepEqual(moe(67000n), twoThirdsDefault.scale(moe(100000n)));
+  t.deepEqual(moe(66670n), twoThirdsPrecise.scale(moe(100000n)));
 });
 
 test('percentMath - non-standard thirds', t => {
-  const { amountMath } = makeIssuerKit('moe');
-  const moe = amountMath.make;
+  const { brand } = makeIssuerKit('moe');
+  /** @param {bigint} value */
+  const moe = value => amountMath.make(value, brand);
 
-  const oneThirdDefault = calculatePercent(moe(1), moe(3), amountMath);
-  const oneThirdBetter = calculatePercent(moe(1), moe(3), amountMath, 1000n);
-  const oneThirdPrecise = makePercent(1n, amountMath, 3n);
+  const oneThirdDefault = calculatePercent(moe(1n), moe(3n));
+  const oneThirdBetter = calculatePercent(moe(1n), moe(3n), 1000n);
+  const oneThirdPrecise = makePercent(1n, brand, 3n);
 
-  t.deepEqual(moe(2970), oneThirdDefault.scale(moe(9000)));
-  t.deepEqual(moe(2997), oneThirdBetter.scale(moe(9000)));
-  t.deepEqual(moe(3000), oneThirdPrecise.scale(moe(9000)));
+  t.deepEqual(moe(2970n), oneThirdDefault.scale(moe(9000n)));
+  t.deepEqual(moe(2997n), oneThirdBetter.scale(moe(9000n)));
+  t.deepEqual(moe(3000n), oneThirdPrecise.scale(moe(9000n)));
 });
 
 test('percentMath - larger than 100%', t => {
-  const { amountMath } = makeIssuerKit('moe');
-  const moe = amountMath.make;
+  const { brand } = makeIssuerKit('moe');
+  /** @param {bigint} value */
+  const moe = value => amountMath.make(value, brand);
 
-  const oneFiftyDefault = calculatePercent(moe(5), moe(3), amountMath);
-  const oneFiftyBetter = calculatePercent(moe(5), moe(3), amountMath, 1000n);
+  const oneFiftyDefault = calculatePercent(moe(5n), moe(3n));
+  const oneFiftyBetter = calculatePercent(moe(5n), moe(3n), 1000n);
 
   // 1.66 * 7777
-  t.deepEqual(moe(12909), oneFiftyDefault.scale(moe(7777)));
+  t.deepEqual(moe(12909n), oneFiftyDefault.scale(moe(7777n)));
   // 1.666 * 7777
-  t.deepEqual(moe(12956), oneFiftyBetter.scale(moe(7777)));
+  t.deepEqual(moe(12956n), oneFiftyBetter.scale(moe(7777n)));
 });
 
 test('percentMath - Nats only', t => {
-  const { amountMath } = makeIssuerKit('moe');
+  const { brand } = makeIssuerKit('moe');
 
-  t.throws(() => makePercent(10.1, amountMath), {
+  // @ts-ignore
+  t.throws(() => makePercent(10.1, brand), {
     message: '10.1 not a safe integer',
   });
 
-  t.notThrows(() => makePercent(47n, amountMath));
+  // @ts-ignore
+  t.notThrows(() => makePercent(47, brand));
 });

--- a/packages/zoe/test/unitTests/contractSupport/test-percentMath.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-percentMath.js
@@ -123,11 +123,11 @@ test('percentMath - larger than 100%', t => {
 test('percentMath - Nats only', t => {
   const { brand } = makeIssuerKit('moe');
 
-  // @ts-ignore
+  // @ts-ignore invalid arguments for testing
   t.throws(() => makePercent(10.1, brand), {
     message: '10.1 not a safe integer',
   });
 
-  // @ts-ignore
+  // @ts-ignore test with number even though deprecated
   t.notThrows(() => makePercent(47, brand));
 });

--- a/packages/zoe/test/unitTests/contractSupport/test-percentSupport.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-percentSupport.js
@@ -4,7 +4,7 @@
 import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
-import { makeIssuerKit } from '@agoric/ertp';
+import { makeIssuerKit, amountMath } from '@agoric/ertp';
 
 import { multiplyBy, makeRatioFromAmounts } from '../../../src/contractSupport';
 import {
@@ -34,8 +34,8 @@ function amountsEqual(t, a1, a2, brand) {
 }
 
 test('ratio - ALL', t => {
-  const { amountMath, brand } = makeIssuerKit('moe');
-  const moe = amountMath.make;
+  const { brand } = makeIssuerKit('moe');
+  const moe = value => amountMath.make(value, brand);
 
   amountsEqual(
     t,
@@ -46,20 +46,20 @@ test('ratio - ALL', t => {
 });
 
 test('ratio - NONE', t => {
-  const { amountMath, brand } = makeIssuerKit('moe');
-  const moe = amountMath.make;
+  const { brand } = makeIssuerKit('moe');
+  const moe = value => amountMath.make(value, brand);
 
   amountsEqual(
     t,
-    amountMath.getEmpty(),
+    amountMath.makeEmpty(brand),
     multiplyBy(moe(100000), make0Percent(brand)),
     brand,
   );
 });
 
 test('ratio - complement', t => {
-  const { amountMath, brand } = makeIssuerKit('moe');
-  const moe = amountMath.make;
+  const { brand } = makeIssuerKit('moe');
+  const moe = value => amountMath.make(value, brand);
 
   const oneThird = makeRatioFromAmounts(moe(1), moe(3));
   const twoThirds = oneMinus(oneThird);

--- a/packages/zoe/test/unitTests/contractSupport/test-ratio.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-ratio.js
@@ -6,7 +6,7 @@ import '@agoric/zoe/tools/prepare-test-env';
 import test from 'ava';
 import '../../../src/contractSupport/types';
 
-import { makeIssuerKit } from '@agoric/ertp';
+import { makeIssuerKit, amountMath } from '@agoric/ertp';
 import {
   makeRatio,
   makeRatioFromAmounts,
@@ -35,17 +35,28 @@ function amountsEqual(t, a1, a2, brand) {
 }
 
 test('ratio - basic', t => {
-  const { amountMath, brand } = makeIssuerKit('moe');
-  const moe = amountMath.make;
+  const { brand } = makeIssuerKit('moe');
+  /** @param {bigint} value */
+  const moe = value => amountMath.make(value, brand);
 
-  const halfDefault = makeRatio(50, brand);
-  const halfPrecise = makeRatio(5000, brand, 10000);
+  const halfDefault = makeRatio(50n, brand);
+  const halfPrecise = makeRatio(5000n, brand, 10000n);
 
-  amountsEqual(t, multiplyBy(moe(1333), halfDefault), moe(666), brand);
-  amountsEqual(t, multiplyBy(moe(13333333), halfDefault), moe(6666666), brand);
-  amountsEqual(t, multiplyBy(moe(1333), halfPrecise), moe(666), brand);
-  amountsEqual(t, multiplyBy(moe(13333333), halfPrecise), moe(6666666), brand);
-  amountsEqual(t, multiplyBy(moe(0), halfPrecise), moe(0), brand);
+  amountsEqual(t, multiplyBy(moe(1333n), halfDefault), moe(666n), brand);
+  amountsEqual(
+    t,
+    multiplyBy(moe(13333333n), halfDefault),
+    moe(6666666n),
+    brand,
+  );
+  amountsEqual(t, multiplyBy(moe(1333n), halfPrecise), moe(666n), brand);
+  amountsEqual(
+    t,
+    multiplyBy(moe(13333333n), halfPrecise),
+    moe(6666666n),
+    brand,
+  );
+  amountsEqual(t, multiplyBy(moe(0n), halfPrecise), moe(0n), brand);
 });
 
 test('ratio - multiplyBy non Amount', t => {
@@ -55,141 +66,165 @@ test('ratio - multiplyBy non Amount', t => {
     value: 3.5,
     brand,
   });
-  t.throws(() => multiplyBy(badAmount, makeRatio(25, brand)), {
+  t.throws(() => multiplyBy(badAmount, makeRatio(25n, brand)), {
     message: '3.5 not a safe integer',
   });
-  t.throws(() => divideBy(badAmount, makeRatio(25, brand)), {
+  t.throws(() => divideBy(badAmount, makeRatio(25n, brand)), {
     message: '3.5 not a safe integer',
   });
 });
 
 test('ratio - onethird', t => {
-  const { amountMath, brand } = makeIssuerKit('moe');
-  const moe = amountMath.make;
+  const { brand } = makeIssuerKit('moe');
+  /** @param {bigint} value */
+  const moe = value => amountMath.make(value, brand);
 
-  const oneThird = makeRatioFromAmounts(moe(1), moe(3));
+  const oneThird = makeRatioFromAmounts(moe(1n), moe(3n));
 
-  amountsEqual(t, multiplyBy(moe(100000), oneThird), moe(33333), brand);
+  amountsEqual(t, multiplyBy(moe(100000n), oneThird), moe(33333n), brand);
 });
 
 test('ratio - different brands', t => {
-  const { amountMath, brand: moeBrand } = makeIssuerKit('moe');
-  const { amountMath: astAmountMath } = makeIssuerKit('ast');
-  const moe = amountMath.make;
-  const ast = astAmountMath.make;
+  const { brand } = makeIssuerKit('moe');
+  /** @param {bigint} value */
+  const moe = value => amountMath.make(value, brand);
+  const { brand: astBrand } = makeIssuerKit('ast');
+  /** @param {bigint} value */
+  const ast = value => amountMath.make(value, astBrand);
 
-  const convertToMoe = makeRatioFromAmounts(moe(1), astAmountMath.make(3));
-  amountsEqual(t, multiplyBy(ast(10000), convertToMoe), moe(3333), moeBrand);
+  const convertToMoe = makeRatioFromAmounts(
+    moe(1n),
+    amountMath.make(3n, astBrand),
+  );
+  amountsEqual(t, multiplyBy(ast(10000n), convertToMoe), moe(3333n), brand);
 });
 
 test('ratio - brand mismatch', t => {
-  const { amountMath } = makeIssuerKit('moe');
-  const { amountMath: astAmountMath } = makeIssuerKit('ast');
-  const moe = amountMath.make;
-  const ast = astAmountMath.make;
+  const { brand } = makeIssuerKit('moe');
+  /** @param {bigint} value */
+  const moe = value => amountMath.make(value, brand);
+  const { brand: astBrand } = makeIssuerKit('ast');
+  /** @param {bigint} value */
+  const ast = value => amountMath.make(value, astBrand);
 
-  const convertToMoe = makeRatioFromAmounts(moe(1), astAmountMath.make(3));
-  t.throws(() => divideBy(ast(10000), convertToMoe), {
+  const convertToMoe = makeRatioFromAmounts(
+    moe(1n),
+    amountMath.make(3n, astBrand),
+  );
+  t.throws(() => divideBy(ast(10000n), convertToMoe), {
     message: /amount's brand .* must match ratio's numerator .*/,
   });
-  t.throws(() => multiplyBy(moe(10000), convertToMoe), {
+  t.throws(() => multiplyBy(moe(10000n), convertToMoe), {
     message: /amount's brand .* must match ratio's denominator .*/,
   });
 });
 
 test.failing('ratio - brand mismatch & details', t => {
-  const { amountMath } = makeIssuerKit('moe');
-  const { amountMath: astAmountMath } = makeIssuerKit('ast');
-  const moe = amountMath.make;
-  const ast = astAmountMath.make;
+  const { brand } = makeIssuerKit('moe');
+  /** @param {bigint} value */
+  const moe = value => amountMath.make(value, brand);
+  const { brand: astBrand } = makeIssuerKit('ast');
+  /** @param {bigint} value */
+  const ast = value => amountMath.make(value, astBrand);
 
-  const convertToMoe = makeRatioFromAmounts(moe(1), astAmountMath.make(3));
-  t.throws(() => divideBy(ast(10000), convertToMoe), {
+  const convertToMoe = makeRatioFromAmounts(
+    moe(1n),
+    amountMath.make(3n, astBrand),
+  );
+  t.throws(() => divideBy(ast(10000n), convertToMoe), {
     message: `amount's brand "ast" must match ratio's numerator "moe"`,
   });
-  t.throws(() => multiplyBy(moe(10000), convertToMoe), {
+  t.throws(() => multiplyBy(moe(10000n), convertToMoe), {
     message: `amount's brand "moe" must match ratio's denominator "ast"`,
   });
 });
 
 test('ratio - larger than 100%', t => {
-  const { amountMath, brand } = makeIssuerKit('moe');
-  const moe = amountMath.make;
+  const { brand } = makeIssuerKit('moe');
+  /** @param {bigint} value */
+  const moe = value => amountMath.make(value, brand);
 
-  const fiveThirds = makeRatioFromAmounts(moe(5), moe(3));
+  const fiveThirds = makeRatioFromAmounts(moe(5n), moe(3n));
 
   // 5/3 * 7777
-  amountsEqual(t, multiplyBy(moe(7777), fiveThirds), moe(12961), brand);
+  amountsEqual(t, multiplyBy(moe(7777n), fiveThirds), moe(12961n), brand);
 });
 
 test('ratio - Nats', t => {
   const { brand } = makeIssuerKit('moe');
 
+  // @ts-ignore
   t.throws(() => makeRatio(10.1, brand), {
     message: '10.1 not a safe integer',
   });
 });
 
 test('ratio division', t => {
-  const { amountMath, brand: moeBrand } = makeIssuerKit('moe');
-  const moe = amountMath.make;
+  const { brand } = makeIssuerKit('moe');
+  /** @param {bigint} value */
+  const moe = value => amountMath.make(value, brand);
 
-  const twoFifths = makeRatioFromAmounts(moe(2), moe(5));
-  amountsEqual(t, divideBy(moe(100), twoFifths), moe(250), moeBrand);
-  amountsEqual(t, multiplyBy(moe(100), twoFifths), moe(40), moeBrand);
-  amountsEqual(t, divideBy(moe(0), twoFifths), moe(0), moeBrand);
+  const twoFifths = makeRatioFromAmounts(moe(2n), moe(5n));
+  amountsEqual(t, divideBy(moe(100n), twoFifths), moe(250n), brand);
+  amountsEqual(t, multiplyBy(moe(100n), twoFifths), moe(40n), brand);
+  amountsEqual(t, divideBy(moe(0n), twoFifths), moe(0n), brand);
 });
 
 test('ratio inverse', t => {
-  const { amountMath, brand: moeBrand } = makeIssuerKit('moe');
-  const moe = amountMath.make;
+  const { brand } = makeIssuerKit('moe');
+  /** @param {bigint} value */
+  const moe = value => amountMath.make(value, brand);
 
-  const twoFifths = makeRatioFromAmounts(moe(2), moe(5));
+  const twoFifths = makeRatioFromAmounts(moe(2n), moe(5n));
   const fiveHalves = invertRatio(twoFifths);
 
-  amountsEqual(t, divideBy(moe(100), fiveHalves), moe(40), moeBrand);
-  amountsEqual(t, multiplyBy(moe(100), fiveHalves), moe(250), moeBrand);
+  amountsEqual(t, divideBy(moe(100n), fiveHalves), moe(40n), brand);
+  amountsEqual(t, multiplyBy(moe(100n), fiveHalves), moe(250n), brand);
 });
 
 test('ratio bad inputs', t => {
-  const { amountMath, brand: moeBrand } = makeIssuerKit('moe');
-  const moe = amountMath.make;
-  t.throws(() => makeRatio(-3, moeBrand), {
+  const { brand } = makeIssuerKit('moe');
+  /** @param {bigint} value */
+  const moe = value => amountMath.make(value, brand);
+  // @ts-ignore
+  t.throws(() => makeRatio(-3, brand), {
     message: '-3 is negative',
   });
-  t.throws(() => makeRatio(3, moeBrand, 100.5), {
+  // @ts-ignore
+  t.throws(() => makeRatio(3n, brand, 100.5), {
     message: '100.5 not a safe integer',
   });
-  t.throws(() => makeRatioFromAmounts(3, moe(30)), {
+  t.throws(() => makeRatioFromAmounts(3n, moe(30n)), {
     message: 'undefined is a undefined but must be a bigint or a number',
   });
-  t.throws(() => multiplyBy(37, makeRatioFromAmounts(moe(3), moe(5))), {
+  t.throws(() => multiplyBy(37, makeRatioFromAmounts(moe(3n), moe(5n))), {
     message: 'Expected an amount: (a number)',
   });
-  t.throws(() => divideBy(makeRatioFromAmounts(moe(3), moe(5)), 37), {
+  t.throws(() => divideBy(makeRatioFromAmounts(moe(3n), moe(5n)), 37), {
     message: `Expected an amount: (an object)`,
   });
-  t.throws(() => makeRatio(3, moeBrand, 0), {
-    message: /No infinite ratios! Denoninator was 0/,
+  t.throws(() => makeRatio(3n, brand, 0n), {
+    message: /No infinite ratios! Denominator was 0/,
   });
-  t.throws(() => makeRatioFromAmounts(moe(37), moe(0)), {
-    message: /No infinite ratios! Denoninator was 0/,
+  t.throws(() => makeRatioFromAmounts(moe(37n), moe(0n)), {
+    message: /No infinite ratios! Denominator was 0/,
   });
-  t.throws(() => makeRatioFromAmounts(moe(37), moe(0)), {
-    message: /No infinite ratios! Denoninator was 0/,
+  t.throws(() => makeRatioFromAmounts(moe(37n), moe(0n)), {
+    message: /No infinite ratios! Denominator was 0/,
   });
 });
 
 test.failing('ratio bad inputs w/brand names', t => {
-  const { amountMath, brand: moeBrand } = makeIssuerKit('moe');
-  const moe = amountMath.make;
-  t.throws(() => makeRatio(3, moeBrand, 0), {
-    message: 'No infinite ratios! Denoninator was 0/"moe"',
+  const { brand } = makeIssuerKit('moe');
+  /** @param {bigint} value */
+  const moe = value => amountMath.make(value, brand);
+  t.throws(() => makeRatio(3n, brand, 0n), {
+    message: 'No infinite ratios! Denonimator was 0/"moe"',
   });
-  t.throws(() => makeRatioFromAmounts(moe(37), moe(0)), {
-    message: 'No infinite ratios! Denoninator was 0/"moe"',
+  t.throws(() => makeRatioFromAmounts(moe(37n), moe(0n)), {
+    message: 'No infinite ratios! Denonimator was 0/"moe"',
   });
-  t.throws(() => makeRatioFromAmounts(moe(37), moe(0)), {
-    message: 'No infinite ratios! Denoninator was 0/"moe"',
+  t.throws(() => makeRatioFromAmounts(moe(37n), moe(0n)), {
+    message: 'No infinite ratios! Denonimator was 0/"moe"',
   });
 });

--- a/packages/zoe/test/unitTests/contractSupport/test-ratio.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-ratio.js
@@ -153,7 +153,7 @@ test('ratio - larger than 100%', t => {
 test('ratio - Nats', t => {
   const { brand } = makeIssuerKit('moe');
 
-  // @ts-ignore
+  // @ts-ignore invalid arguments for testing
   t.throws(() => makeRatio(10.1, brand), {
     message: '10.1 not a safe integer',
   });
@@ -186,11 +186,11 @@ test('ratio bad inputs', t => {
   const { brand } = makeIssuerKit('moe');
   /** @param {bigint} value */
   const moe = value => amountMath.make(value, brand);
-  // @ts-ignore
+  // @ts-ignore invalid arguments for testing
   t.throws(() => makeRatio(-3, brand), {
     message: '-3 is negative',
   });
-  // @ts-ignore
+  // @ts-ignore invalid arguments for testing
   t.throws(() => makeRatio(3n, brand, 100.5), {
     message: '100.5 not a safe integer',
   });

--- a/packages/zoe/test/unitTests/contractSupport/test-stateMachine.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-stateMachine.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env';
 import test from 'ava';

--- a/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
@@ -1,4 +1,6 @@
 /* global __dirname */
+// @ts-check
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -12,18 +14,9 @@ import { makeZoe } from '../../..';
 import { makeFakeVatAdmin } from '../../../src/contractFacet/fakeVatAdmin';
 import { depositToSeat, withdrawFromSeat } from '../../../src/contractSupport';
 import { assertPayoutAmount } from '../../zoeTestHelpers';
+import { makeOffer } from '../makeOffer';
 
 const contractRoot = `${__dirname}/../zcf/zcfTesterContract`;
-
-const makeOffer = async (zoe, zcf, proposal, payments) => {
-  let zcfSeat;
-  const getSeat = seat => {
-    zcfSeat = seat;
-  };
-  const invitation = await zcf.makeInvitation(getSeat, 'seat');
-  const userSeat = await E(zoe).offer(invitation, proposal, payments);
-  return { zcfSeat, userSeat };
-};
 
 async function setupContract(moolaIssuer, bucksIssuer) {
   let testJig;
@@ -83,7 +76,7 @@ test(`withdrawFromSeat - violates offerSafety`, async t => {
   await depositToSeat(zcf, zcfSeat, { B: bucks(2) }, { B: newBucks });
   t.deepEqual(
     zcfSeat.getCurrentAllocation(),
-    { A: moola(0), B: bucks(7) },
+    { A: moola(0n), B: bucks(7n) },
     'should add deposit',
   );
   await t.throwsAsync(
@@ -97,7 +90,7 @@ test(`withdrawFromSeat - violates offerSafety`, async t => {
 
   t.deepEqual(
     zcfSeat.getCurrentAllocation(),
-    { A: moola(0), B: bucks(7) },
+    { A: moola(0n), B: bucks(7n) },
     'bad withdraw should leave allocations unchanged',
   );
 });

--- a/packages/zoe/test/unitTests/contracts/brokenAutoRefund.js
+++ b/packages/zoe/test/unitTests/contracts/brokenAutoRefund.js
@@ -13,7 +13,7 @@ const start = zcf => {
   const makeRefundInvitation = () => zcf.makeInvitation(refund, 'getRefund');
   // should be makeRefundInvitation(). Intentionally wrong to provoke
   // an error.
-  // @ts-ignore
+  // @ts-ignore invalid arguments for testing
   return { creatorInvitation: makeRefundInvitation };
 };
 

--- a/packages/zoe/test/unitTests/contracts/brokenAutoRefund.js
+++ b/packages/zoe/test/unitTests/contracts/brokenAutoRefund.js
@@ -11,7 +11,9 @@ const start = zcf => {
     return `The offer was accepted`;
   };
   const makeRefundInvitation = () => zcf.makeInvitation(refund, 'getRefund');
-  // should be makeRefundInvitation(). Intentionally wrong to provoke an error.
+  // should be makeRefundInvitation(). Intentionally wrong to provoke
+  // an error.
+  // @ts-ignore
   return { creatorInvitation: makeRefundInvitation };
 };
 

--- a/packages/zoe/test/unitTests/contracts/escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/escrowToVote.js
@@ -3,6 +3,7 @@
 import { assert, details as X, q } from '@agoric/assert';
 import { Far } from '@agoric/marshal';
 import makeStore from '@agoric/store';
+import { amountMath } from '@agoric/ertp';
 // Eventually will be importable from '@agoric/zoe-contract-support'
 import {
   assertIssuerKeywords,
@@ -28,7 +29,6 @@ const start = zcf => {
   const {
     question,
     brands: { Assets: assetsBrand },
-    maths: { Assets: amountMath },
   } = zcf.getTerms();
   let electionOpen = true;
   assertIssuerKeywords(zcf, harden(['Assets']));
@@ -81,8 +81,8 @@ const start = zcf => {
       assert(electionOpen, 'the election is already closed');
       // YES | NO to Nat
       const tally = new Map();
-      tally.set('YES', amountMath.getEmpty());
-      tally.set('NO', amountMath.getEmpty());
+      tally.set('YES', amountMath.makeEmpty(assetsBrand));
+      tally.set('NO', amountMath.makeEmpty(assetsBrand));
 
       for (const [seat, response] of seatToResponse.entries()) {
         if (!seat.hasExited()) {

--- a/packages/zoe/test/unitTests/contracts/loan/test-addCollateral.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-addCollateral.js
@@ -1,4 +1,4 @@
-// ts-check
+// @ts-check
 
 import '../../../../exported';
 
@@ -6,6 +6,8 @@ import '../../../../exported';
 import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
+
+import { amountMath } from '@agoric/ertp';
 
 import { makeAddCollateralInvitation } from '../../../../src/contracts/loan/addCollateral';
 import { makeFakePriceAuthority } from '../../../../tools/fakePriceAuthority';
@@ -23,7 +25,7 @@ test.todo('makeAddCollateralInvitation - test bad proposal');
 test('makeAddCollateralInvitation', async t => {
   const { zcf, zoe, collateralKit, loanKit } = await setupLoanUnitTest();
 
-  const collateral = collateralKit.amountMath.make(10);
+  const collateral = amountMath.make(10n, collateralKit.brand);
 
   // Set up the collateral seat
   const { zcfSeat: collateralSeat } = await makeSeatKit(
@@ -39,14 +41,14 @@ test('makeAddCollateralInvitation', async t => {
   const timer = buildManualTimer(console.log);
 
   const priceAuthority = makeFakePriceAuthority({
-    mathIn: collateralKit.amountMath,
-    mathOut: loanKit.amountMath,
     priceList: [],
     timer,
+    actualBrandIn: collateralKit.brand,
+    actualBrandOut: loanKit.brand,
   });
 
   const autoswapInstance = {};
-  const getDebt = () => loanKit.amountMath.make(100);
+  const getDebt = () => amountMath.make(100n, loanKit.brand);
 
   const config = {
     collateralSeat,
@@ -54,11 +56,12 @@ test('makeAddCollateralInvitation', async t => {
     autoswapInstance,
     priceAuthority,
     getDebt,
-    mmr: makeRatio(150, loanKit.brand),
+    mmr: makeRatio(150n, loanKit.brand),
+    loanBrand: loanKit.brand,
   };
   const addCollateralInvitation = makeAddCollateralInvitation(zcf, config);
 
-  const addedAmount = collateralKit.amountMath.make(3);
+  const addedAmount = amountMath.make(3n, collateralKit.brand);
 
   await performAddCollateral(
     t,
@@ -72,6 +75,6 @@ test('makeAddCollateralInvitation', async t => {
   // Ensure the collSeat gets the added collateral
 
   t.deepEqual(collateralSeat.getCurrentAllocation(), {
-    Collateral: collateralKit.amountMath.add(collateral, addedAmount),
+    Collateral: amountMath.add(collateral, addedAmount),
   });
 });

--- a/packages/zoe/test/unitTests/contracts/loan/test-close.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-close.js
@@ -1,4 +1,4 @@
-// ts-check
+// @ts-check
 import '../../../../exported';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -6,6 +6,7 @@ import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { E } from '@agoric/eventual-send';
+import { amountMath } from '@agoric/ertp';
 
 import {
   setupLoanUnitTest,
@@ -25,7 +26,7 @@ test.todo(`repay - request too much collateral`);
 test('makeCloseLoanInvitation repay all', async t => {
   const { zcf, zoe, collateralKit, loanKit } = await setupLoanUnitTest();
 
-  const collateral = collateralKit.amountMath.make(10);
+  const collateral = amountMath.make(10n, collateralKit.brand);
 
   // Set up the collateral seat
   const { zcfSeat: collateralSeat } = await makeSeatKit(
@@ -42,9 +43,9 @@ test('makeCloseLoanInvitation repay all', async t => {
     userSeat: lenderUserSeatP,
   } = zcf.makeEmptySeatKit();
 
-  const borrowedAmount = loanKit.amountMath.make(20);
-  const interest = loanKit.amountMath.make(3);
-  const required = loanKit.amountMath.add(borrowedAmount, interest);
+  const borrowedAmount = amountMath.make(20n, loanKit.brand);
+  const interest = amountMath.make(3n, loanKit.brand);
+  const required = amountMath.add(borrowedAmount, interest);
   const getDebt = () => required;
 
   const config = {
@@ -59,7 +60,7 @@ test('makeCloseLoanInvitation repay all', async t => {
 
   const proposal = harden({
     give: { Loan: required },
-    want: { Collateral: collateralKit.amountMath.make(10) },
+    want: { Collateral: amountMath.make(10n, collateralKit.brand) },
   });
 
   const payments = harden({
@@ -78,8 +79,8 @@ test('makeCloseLoanInvitation repay all', async t => {
     seat,
     { Loan: loanKit, Collateral: collateralKit },
     {
-      Loan: loanKit.amountMath.getEmpty(),
-      Collateral: collateralKit.amountMath.make(10),
+      Loan: amountMath.makeEmpty(loanKit.brand),
+      Collateral: amountMath.make(10n, collateralKit.brand),
     },
     'repaySeat',
   );
@@ -95,7 +96,7 @@ test('makeCloseLoanInvitation repay all', async t => {
     { Loan: loanKit, Collateral: collateralKit },
     {
       Loan: required,
-      Collateral: collateralKit.amountMath.getEmpty(),
+      Collateral: amountMath.makeEmpty(collateralKit.brand),
     },
     'lenderSeat',
   );

--- a/packages/zoe/test/unitTests/contracts/loan/test-lend.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-lend.js
@@ -1,4 +1,4 @@
-// ts-check
+// @ts-check
 import '../../../../exported';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -6,6 +6,7 @@ import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { E } from '@agoric/eventual-send';
+import { amountMath } from '@agoric/ertp';
 
 import { setupLoanUnitTest, checkDescription } from './helpers';
 
@@ -16,13 +17,13 @@ test('makeLendInvitation', async t => {
   const { zcf, zoe, loanKit } = await setupLoanUnitTest();
 
   const config = {
-    mmr: makeRatio(150, loanKit.brand),
+    mmr: makeRatio(150n, loanKit.brand),
   };
   const lendInvitation = makeLendInvitation(zcf, config);
 
   await checkDescription(t, zoe, lendInvitation, 'lend');
 
-  const maxLoan = loanKit.amountMath.make(1000);
+  const maxLoan = amountMath.make(1000n, loanKit.brand);
 
   const proposal = harden({
     give: { Loan: maxLoan },

--- a/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
@@ -1,5 +1,5 @@
 /* global __dirname */
-// ts-check
+// @ts-check
 import '../../../../exported';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -7,7 +7,7 @@ import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { E } from '@agoric/eventual-send';
-
+import { amountMath } from '@agoric/ertp';
 import bundleSource from '@agoric/bundle-source';
 import { makeNotifierKit } from '@agoric/notifier';
 
@@ -52,28 +52,28 @@ test('loan - lend - exit before borrow', async t => {
   const timer = buildManualTimer(console.log);
 
   const priceAuthority = makeFakePriceAuthority({
-    mathIn: collateralKit.amountMath,
-    mathOut: loanKit.amountMath,
     priceList: [],
     timer,
+    actualBrandIn: collateralKit.brand,
+    actualBrandOut: loanKit.brand,
   });
 
   const { notifier: periodNotifier } = makeNotifierKit();
 
   const terms = {
-    mmr: makeRatio(150, loanKit.brand),
+    mmr: makeRatio(150n, loanKit.brand),
     autoswapInstance,
     priceAuthority,
     periodNotifier,
-    interestRate: 5,
-    interestPeriod: 10,
+    interestRate: 5n,
+    interestPeriod: 10n,
   };
 
   const { creatorInvitation: lendInvitation, instance } = await E(
     zoe,
   ).startInstance(installation, issuerKeywordRecord, terms);
 
-  const maxLoan = loanKit.amountMath.make(1000);
+  const maxLoan = amountMath.make(1000n, loanKit.brand);
 
   // Alice is willing to lend Loan tokens
   const proposal = harden({

--- a/packages/zoe/test/unitTests/contracts/loan/test-updateDebt.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-updateDebt.js
@@ -1,4 +1,4 @@
-// ts-check
+// @ts-check
 
 import '../../../../exported';
 
@@ -16,7 +16,7 @@ test('test calculateInterest', async t => {
   const brand = brands.get('moola');
   const testCalculateInterest = ([oldDebt, interestRate, expected]) => {
     const debt = { brand, value: oldDebt };
-    const interestRateRatio = makeRatio(interestRate, brand, 10000);
+    const interestRateRatio = makeRatio(interestRate, brand, 10000n);
     const interest = calculateInterest(debt, interestRateRatio);
     t.is(interest.value, expected);
     t.is(interest.brand, brand);

--- a/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
+++ b/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
@@ -1,9 +1,11 @@
 /* global __dirname */
+
+// @ts-check
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import bundleSource from '@agoric/bundle-source';
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
@@ -58,7 +60,7 @@ test('zoe - atomicSwap', async t => {
           .then(amountDeposited =>
             t.deepEqual(
               amountDeposited,
-              moola(0),
+              moola(0n),
               `Alice didn't get any of what she put in`,
             ),
           );
@@ -425,7 +427,7 @@ test('zoe - atomicSwap like-for-like', async t => {
   );
 
   // Alice didn't get any of what Alice put in
-  t.deepEqual(await moolaIssuer.getAmountOf(aliceAssetPayout), moola(0));
+  t.deepEqual(await moolaIssuer.getAmountOf(aliceAssetPayout), moola(0n));
 
   // Alice deposits her payout to ensure she can
   const aliceAssetAmount = await aliceMoolaPurse.deposit(aliceAssetPayout);

--- a/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
+++ b/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
@@ -1,4 +1,7 @@
 /* global __dirname */
+
+// @ts-check
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/test-autoswapPool.js
+++ b/packages/zoe/test/unitTests/contracts/test-autoswapPool.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // isolated unit test of price calculations in pool in multipoolAutoswap
 
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/test-barter.js
+++ b/packages/zoe/test/unitTests/contracts/test-barter.js
@@ -1,9 +1,12 @@
 /* global __dirname */
+// @ts-check
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { E } from '@agoric/eventual-send';
+import { amountMath } from '@agoric/ertp';
 
 import { setup } from '../setupBasicMints';
 import { installationPFromSource } from '../installFromSource';
@@ -18,7 +21,6 @@ test('barter with valid offers', async t => {
     simoleanIssuer,
     moolaMint,
     simoleanMint,
-    amountMaths,
     moola,
     simoleans,
     zoe,
@@ -103,20 +105,18 @@ test('barter with valid offers', async t => {
 
   // Alice gets paid at least what she wanted
   t.truthy(
-    amountMaths
-      .get('simoleans')
-      .isGTE(
-        await simoleanIssuer.getAmountOf(aliceSimoleanPayout),
-        aliceSellOrderProposal.want.Out,
-      ),
+    amountMath.isGTE(
+      await simoleanIssuer.getAmountOf(aliceSimoleanPayout),
+      aliceSellOrderProposal.want.Out,
+    ),
   );
 
   // Alice sold all of her moola
-  t.deepEqual(await moolaIssuer.getAmountOf(aliceMoolaPayout), moola(0));
+  t.deepEqual(await moolaIssuer.getAmountOf(aliceMoolaPayout), moola(0n));
 
   await Promise.all([
     // Alice had 0 moola and 4 simoleans.
-    assertPayoutAmount(t, moolaIssuer, aliceMoolaPayout, moola(0)),
+    assertPayoutAmount(t, moolaIssuer, aliceMoolaPayout, moola(0n)),
     assertPayoutAmount(t, simoleanIssuer, aliceSimoleanPayout, simoleans(4)),
 
     // Bob had 3 moola and 3 simoleans.

--- a/packages/zoe/test/unitTests/contracts/test-brokenContract.js
+++ b/packages/zoe/test/unitTests/contracts/test-brokenContract.js
@@ -1,4 +1,5 @@
 /* global __dirname */
+// @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/test-callSpread-calculation.js
+++ b/packages/zoe/test/unitTests/contracts/test-callSpread-calculation.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -24,9 +26,7 @@ function compareShareRatios(t, expected, actual, amount) {
 }
 
 test('callSpread-calculation, at lower bound', async t => {
-  const { moola, amountMaths, bucks, brands } = setup();
-  const moolaMath = amountMaths.get('moola');
-  const bucksMath = amountMaths.get('bucks');
+  const { moola, bucks, brands } = setup();
   const bucksBrand = brands.get('bucks');
 
   const strike1 = moola(20);
@@ -38,15 +38,13 @@ test('callSpread-calculation, at lower bound', async t => {
       longShare: make0Percent(bucksBrand),
       shortShare: make100Percent(bucksBrand),
     },
-    calculateShares(moolaMath, bucksMath, price, strike1, strike2),
+    calculateShares(bucksBrand, price, strike1, strike2),
     bucks(1000),
   );
 });
 
 test('callSpread-calculation, at upper bound', async t => {
-  const { moola, amountMaths, bucks, brands } = setup();
-  const moolaMath = amountMaths.get('moola');
-  const bucksMath = amountMaths.get('bucks');
+  const { moola, bucks, brands } = setup();
   const bucksBrand = brands.get('bucks');
 
   const strike1 = moola(20);
@@ -58,35 +56,32 @@ test('callSpread-calculation, at upper bound', async t => {
       longShare: make100Percent(bucksBrand),
       shortShare: make0Percent(bucksBrand),
     },
-    calculateShares(moolaMath, bucksMath, price, strike1, strike2),
+    calculateShares(bucksBrand, price, strike1, strike2),
     bucks(1000),
   );
 });
 
 test('callSpread-calculation, below lower bound', async t => {
-  const { moola, amountMaths, bucks, brands } = setup();
-  const moolaMath = amountMaths.get('moola');
-  const bucksMath = amountMaths.get('bucks');
+  const { moola, bucks, brands } = setup();
   const bucksBrand = brands.get('bucks');
 
   const strike1 = moola(15);
   const strike2 = moola(55);
-  const price = moola(0);
+  const price = moola(0n);
   compareShareRatios(
     t,
     {
       longShare: make0Percent(bucksBrand),
       shortShare: make100Percent(bucksBrand),
     },
-    calculateShares(moolaMath, bucksMath, price, strike1, strike2),
+    calculateShares(bucksBrand, price, strike1, strike2),
     bucks(1000),
   );
 });
 
 test('callSpread-calculation, above upper bound', async t => {
-  const { moola, amountMaths, bucks, brands } = setup();
-  const moolaMath = amountMaths.get('moola');
-  const bucksMath = amountMaths.get('bucks');
+  const { moola, bucks, brands } = setup();
+
   const bucksBrand = brands.get('bucks');
 
   const strike1 = moola(15);
@@ -98,22 +93,20 @@ test('callSpread-calculation, above upper bound', async t => {
       longShare: make100Percent(bucksBrand),
       shortShare: make0Percent(bucksBrand),
     },
-    calculateShares(moolaMath, bucksMath, price, strike1, strike2),
+    calculateShares(bucksBrand, price, strike1, strike2),
     bucks(1000),
   );
 });
 
 test('callSpread-calculation, mid-way', async t => {
-  const { moola, amountMaths, bucks } = setup();
-  const moolaMath = amountMaths.get('moola');
-  const bucksMath = amountMaths.get('bucks');
+  const { moola, bucks, brands } = setup();
+  const bucksBrand = brands.get('bucks');
 
   const strike1 = moola(15);
   const strike2 = moola(45);
   const price = moola(40);
   const { longShare, shortShare } = calculateShares(
-    moolaMath,
-    bucksMath,
+    bucksBrand,
     price,
     strike1,
     strike2,
@@ -123,29 +116,25 @@ test('callSpread-calculation, mid-way', async t => {
 });
 
 test('callSpread-calculation, zero', async t => {
-  const { moola, amountMaths, bucks, brands } = setup();
-  const moolaMath = amountMaths.get('moola');
-  const bucksMath = amountMaths.get('bucks');
+  const { moola, bucks, brands } = setup();
   const bucksBrand = brands.get('bucks');
 
   const strike1 = moola(15);
   const strike2 = moola(45);
-  const price = moola(0);
+  const price = moola(0n);
   compareShareRatios(
     t,
     {
       longShare: make0Percent(bucksBrand),
       shortShare: make100Percent(bucksBrand),
     },
-    calculateShares(moolaMath, bucksMath, price, strike1, strike2),
+    calculateShares(bucksBrand, price, strike1, strike2),
     bucks(1000),
   );
 });
 
 test('callSpread-calculation, large', async t => {
-  const { moola, amountMaths, bucks, brands } = setup();
-  const moolaMath = amountMaths.get('moola');
-  const bucksMath = amountMaths.get('bucks');
+  const { moola, bucks, brands } = setup();
   const bucksBrand = brands.get('bucks');
 
   const strike1 = moola(15);
@@ -157,7 +146,7 @@ test('callSpread-calculation, large', async t => {
       longShare: make100Percent(bucksBrand),
       shortShare: make0Percent(bucksBrand),
     },
-    calculateShares(moolaMath, bucksMath, price, strike1, strike2),
+    calculateShares(bucksBrand, price, strike1, strike2),
     bucks(1000),
   );
 });

--- a/packages/zoe/test/unitTests/contracts/test-callSpread.js
+++ b/packages/zoe/test/unitTests/contracts/test-callSpread.js
@@ -1,4 +1,7 @@
 /* global __dirname */
+
+// @ts-check
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -16,10 +19,10 @@ const fundedCallSpread = `${__dirname}/../../../src/contracts/callSpread/fundedC
 const pricedCallSpread = `${__dirname}/../../../src/contracts/callSpread/pricedCallSpread`;
 const simpleExchange = `${__dirname}/../../../src/contracts/simpleExchange`;
 
-const makeTestPriceAuthority = (amountMaths, priceList, timer) =>
+const makeTestPriceAuthority = (brands, priceList, timer) =>
   makeFakePriceAuthority({
-    mathIn: amountMaths.get('simoleans'),
-    mathOut: amountMaths.get('moola'),
+    actualBrandIn: brands.get('simoleans'),
+    actualBrandOut: brands.get('moola'),
     priceList,
     timer,
   });
@@ -37,7 +40,6 @@ test('fundedCallSpread below Strike1', async t => {
     bucksMint,
     bucks,
     zoe,
-    amountMaths,
     brands,
   } = setup();
   const installation = await installationPFromSource(zoe, fundedCallSpread);
@@ -55,7 +57,7 @@ test('fundedCallSpread below Strike1', async t => {
 
   const manualTimer = buildManualTimer(console.log, 0n);
   const priceAuthority = makeTestPriceAuthority(
-    amountMaths,
+    brands,
     [54, 20, 35, 15, 28],
     manualTimer,
   );
@@ -136,7 +138,7 @@ test('fundedCallSpread above Strike2', async t => {
     bucksMint,
     bucks,
     zoe,
-    amountMaths,
+    brands,
   } = setup();
   const installation = await installationPFromSource(zoe, fundedCallSpread);
 
@@ -152,11 +154,7 @@ test('fundedCallSpread above Strike2', async t => {
   const carolBucksPurse = bucksIssuer.makeEmptyPurse();
 
   const manualTimer = buildManualTimer(console.log, 0n);
-  const priceAuthority = makeTestPriceAuthority(
-    amountMaths,
-    [20, 55],
-    manualTimer,
-  );
+  const priceAuthority = makeTestPriceAuthority(brands, [20, 55], manualTimer);
   // underlying is 2 Simoleans, strike range is 30-50 (doubled)
   const terms = harden({
     expiration: 3n,
@@ -236,7 +234,7 @@ test('fundedCallSpread, mid-strike', async t => {
     bucksMint,
     bucks,
     zoe,
-    amountMaths,
+    brands,
   } = setup();
   const installation = await installationPFromSource(zoe, fundedCallSpread);
 
@@ -252,11 +250,7 @@ test('fundedCallSpread, mid-strike', async t => {
   const carolBucksPurse = bucksIssuer.makeEmptyPurse();
 
   const manualTimer = buildManualTimer(console.log, 0n);
-  const priceAuthority = makeTestPriceAuthority(
-    amountMaths,
-    [20, 45],
-    manualTimer,
-  );
+  const priceAuthority = makeTestPriceAuthority(brands, [20, 45], manualTimer);
   // underlying is 2 Simoleans, strike range is 30-50 (doubled)
   const terms = harden({
     expiration: 3n,
@@ -335,7 +329,7 @@ test('fundedCallSpread, late exercise', async t => {
     bucksMint,
     bucks,
     zoe,
-    amountMaths,
+    brands,
   } = setup();
   const installation = await installationPFromSource(zoe, fundedCallSpread);
 
@@ -351,11 +345,7 @@ test('fundedCallSpread, late exercise', async t => {
   const carolBucksPurse = bucksIssuer.makeEmptyPurse();
 
   const manualTimer = buildManualTimer(console.log, 0n);
-  const priceAuthority = makeTestPriceAuthority(
-    amountMaths,
-    [20, 45],
-    manualTimer,
-  );
+  const priceAuthority = makeTestPriceAuthority(brands, [20, 45], manualTimer);
   // underlying is 2 Simoleans, strike range is 30-50 (doubled)
   const terms = harden({
     expiration: 3n,
@@ -434,7 +424,7 @@ test('fundedCallSpread, sell options', async t => {
     bucksMint,
     bucks,
     zoe,
-    amountMaths,
+    brands,
   } = setup();
   const installation = await installationPFromSource(zoe, fundedCallSpread);
   const invitationIssuer = await E(zoe).getInvitationIssuer();
@@ -454,11 +444,7 @@ test('fundedCallSpread, sell options', async t => {
   const carolBucksPayment = bucksMint.mintPayment(bucks(100));
 
   const manualTimer = buildManualTimer(console.log, 0n);
-  const priceAuthority = makeTestPriceAuthority(
-    amountMaths,
-    [20, 45],
-    manualTimer,
-  );
+  const priceAuthority = makeTestPriceAuthority(brands, [20, 45], manualTimer);
   // underlying is 2 Simoleans, strike range is 30-50 (doubled)
   const terms = harden({
     expiration: 3n,
@@ -613,7 +599,7 @@ test('pricedCallSpread, mid-strike', async t => {
     bucksMint,
     bucks,
     zoe,
-    amountMaths,
+    brands,
   } = setup();
   const installation = await installationPFromSource(zoe, pricedCallSpread);
 
@@ -631,7 +617,7 @@ test('pricedCallSpread, mid-strike', async t => {
 
   const manualTimer = buildManualTimer(console.log, 0n);
   const priceAuthority = await makeTestPriceAuthority(
-    amountMaths,
+    brands,
     [20, 45, 45, 45, 45, 45, 45],
     manualTimer,
   );

--- a/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
@@ -1,4 +1,5 @@
 /* global __dirname */
+// @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/test-mintPayments.js
+++ b/packages/zoe/test/unitTests/contracts/test-mintPayments.js
@@ -1,13 +1,15 @@
 /* global __dirname */
+
+// @ts-check
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 
 import bundleSource from '@agoric/bundle-source';
-
 import { E } from '@agoric/eventual-send';
-import { makeIssuerKit, makeLocalAmountMath } from '@agoric/ertp';
+import { makeIssuerKit, amountMath } from '@agoric/ertp';
 import fakeVatAdmin from '../../../src/contractFacet/fakeVatAdmin';
 
 // noinspection ES6PreferShortImport
@@ -61,9 +63,9 @@ test('zoe - mint payments', async t => {
         // what we get as our payout
         const publicFacet = await E(zoe).getPublicFacet(instance);
         const tokenIssuer = await E(publicFacet).getTokenIssuer();
-        const amountMath = await makeLocalAmountMath(tokenIssuer);
+        const tokenBrand = await E(tokenIssuer).getBrand();
 
-        const tokens1000 = await E(amountMath).make(1000);
+        const tokens1000 = await amountMath.make(1000n, tokenBrand);
         const tokenPayoutAmount = await E(tokenIssuer).getAmountOf(paymentP);
 
         // Bob got 1000 tokens
@@ -131,8 +133,8 @@ test('zoe - mint payments with unrelated give and want', async t => {
         const { instance } = invitationValue;
 
         const proposal = harden({
-          give: { Asset: moolaKit.amountMath.make(10) },
-          want: { Price: simoleanKit.amountMath.make(100) },
+          give: { Asset: amountMath.make(10n, moolaKit.brand) },
+          want: { Price: amountMath.make(100n, simoleanKit.brand) },
         });
         const paymentKeywordRecord = harden({
           Asset: moolaPayment,
@@ -150,9 +152,9 @@ test('zoe - mint payments with unrelated give and want', async t => {
         // what we get as our payout
         const publicFacet = await E(zoe).getPublicFacet(instance);
         const tokenIssuer = await E(publicFacet).getTokenIssuer();
-        const amountMath = await makeLocalAmountMath(tokenIssuer);
+        const tokenBrand = await E(tokenIssuer).getBrand();
 
-        const tokens1000 = await E(amountMath).make(1000);
+        const tokens1000 = await amountMath.make(1000n, tokenBrand);
         const tokenPayoutAmount = await E(tokenIssuer).getAmountOf(
           tokenPaymentP,
         );
@@ -163,7 +165,7 @@ test('zoe - mint payments with unrelated give and want', async t => {
         // Got refunded all the moola given
         t.deepEqual(
           await E(moolaKit.issuer).getAmountOf(moolaRefundP),
-          moolaKit.amountMath.make(10),
+          amountMath.make(10n, moolaKit.brand),
         );
       },
     };
@@ -178,7 +180,7 @@ test('zoe - mint payments with unrelated give and want', async t => {
   // Setup Bob
   const bob = makeBob(
     installation,
-    moolaKit.mint.mintPayment(moolaKit.amountMath.make(10)),
+    moolaKit.mint.mintPayment(amountMath.make(10n, moolaKit.brand)),
   );
   await bob.offer(invitation);
 });

--- a/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
@@ -1,12 +1,12 @@
 /* global __dirname */
+// @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import bundleSource from '@agoric/bundle-source';
 
-import { makeIssuerKit, makeLocalAmountMath } from '@agoric/ertp';
+import bundleSource from '@agoric/bundle-source';
+import { makeIssuerKit, amountMath } from '@agoric/ertp';
 import { E } from '@agoric/eventual-send';
 import fakeVatAdmin from '../../../src/contractFacet/fakeVatAdmin';
 
@@ -28,10 +28,11 @@ test('multipoolAutoSwap with valid offers', async t => {
   const { moolaR, simoleanR, moola, simoleans } = setup();
   const zoe = makeZoe(fakeVatAdmin);
   const invitationIssuer = zoe.getInvitationIssuer();
+  const invitationBrand = await E(invitationIssuer).getBrand();
 
   // Set up central token
   const centralR = makeIssuerKit('central');
-  const centralTokens = centralR.amountMath.make;
+  const centralTokens = value => amountMath.make(value, centralR.brand);
 
   // Setup Alice
   const aliceMoolaPayment = moolaR.mint.mintPayment(moola(100));
@@ -57,21 +58,21 @@ test('multipoolAutoSwap with valid offers', async t => {
     publicFacet,
   ).makeAddLiquidityInvitation();
 
-  const invitationAmountMath = await makeLocalAmountMath(invitationIssuer);
   const aliceInvitationAmount = await invitationIssuer.getAmountOf(
     aliceAddLiquidityInvitation,
   );
   t.deepEqual(
     aliceInvitationAmount,
-    invitationAmountMath.make(
-      harden([
+    amountMath.make(
+      [
         {
           description: 'multipool autoswap add liquidity',
           instance,
           installation,
           handle: aliceInvitationAmount.value[0].handle,
         },
-      ]),
+      ],
+      invitationBrand,
     ),
     `invitation value is as expected`,
   );
@@ -80,19 +81,17 @@ test('multipoolAutoSwap with valid offers', async t => {
     moolaR.issuer,
     'Moola',
   );
-  const moolaLiquidityAmountMath = await makeLocalAmountMath(
-    moolaLiquidityIssuer,
-  );
-  const moolaLiquidity = moolaLiquidityAmountMath.make;
+  const moolaLiquidityBrand = await E(moolaLiquidityIssuer).getBrand();
+  const moolaLiquidity = value => amountMath.make(value, moolaLiquidityBrand);
 
   const simoleanLiquidityIssuer = await E(publicFacet).addPool(
     simoleanR.issuer,
     'Simoleans',
   );
-  const simoleanLiquidityAmountMath = await makeLocalAmountMath(
-    simoleanLiquidityIssuer,
-  );
-  const simoleanLiquidity = simoleanLiquidityAmountMath.make;
+
+  const simoleanLiquidityBrand = await E(simoleanLiquidityIssuer).getBrand();
+  const simoleanLiquidity = value =>
+    amountMath.make(value, simoleanLiquidityBrand);
 
   const issuerKeywordRecord = zoe.getIssuers(instance);
   t.deepEqual(
@@ -202,7 +201,7 @@ test('multipoolAutoSwap with valid offers', async t => {
 
   t.deepEqual(
     await moolaR.issuer.getAmountOf(bobMoolaPayout1),
-    moola(0),
+    moola(0n),
     `bob gets no moola back`,
   );
   t.deepEqual(
@@ -457,7 +456,7 @@ test('multipoolAutoSwap with valid offers', async t => {
   t.deepEqual(
     await E(bobPublicFacet).getPoolAllocation(moolaR.brand),
     harden({
-      Secondary: moola(0),
+      Secondary: moola(0n),
       Central: centralTokens(0),
       Liquidity: moolaLiquidity(50),
     }),
@@ -469,10 +468,11 @@ test('multipoolAutoSwap get detailed prices', async t => {
   const { moolaR, simoleanR, moola, simoleans } = setup();
   const zoe = makeZoe(fakeVatAdmin);
   const invitationIssuer = zoe.getInvitationIssuer();
+  const invitationBrand = await E(invitationIssuer).getBrand();
 
   // Set up central token
   const centralR = makeIssuerKit('central');
-  const centralTokens = centralR.amountMath.make;
+  const centralTokens = value => amountMath.make(value, centralR.brand);
 
   // Setup Alice
   const aliceMoolaPayment = moolaR.mint.mintPayment(moola(1000));
@@ -494,21 +494,21 @@ test('multipoolAutoSwap get detailed prices', async t => {
     publicFacet,
   ).makeAddLiquidityInvitation();
 
-  const invitationAmountMath = await makeLocalAmountMath(invitationIssuer);
   const aliceInvitationAmount = await invitationIssuer.getAmountOf(
     aliceAddLiquidityInvitation,
   );
   t.deepEqual(
     aliceInvitationAmount,
-    invitationAmountMath.make(
-      harden([
+    amountMath.make(
+      [
         {
           description: 'multipool autoswap add liquidity',
           instance,
           installation,
           handle: aliceInvitationAmount.value[0].handle,
         },
-      ]),
+      ],
+      invitationBrand,
     ),
     `invitation value is as expected`,
   );
@@ -517,19 +517,17 @@ test('multipoolAutoSwap get detailed prices', async t => {
     moolaR.issuer,
     'Moola',
   );
-  const moolaLiquidityAmountMath = await makeLocalAmountMath(
-    moolaLiquidityIssuer,
-  );
-  const moolaLiquidity = moolaLiquidityAmountMath.make;
+  const moolaLiquidityBrand = await E(moolaLiquidityIssuer).getBrand();
+  const moolaLiquidity = value => amountMath.make(value, moolaLiquidityBrand);
 
   const simoleanLiquidityIssuer = await E(publicFacet).addPool(
     simoleanR.issuer,
     'Simoleans',
   );
-  const simoleanLiquidityAmountMath = await makeLocalAmountMath(
-    simoleanLiquidityIssuer,
-  );
-  const simoleanLiquidity = simoleanLiquidityAmountMath.make;
+
+  const simoleanLiquidityBrand = await E(simoleanLiquidityIssuer).getBrand();
+  const simoleanLiquidity = value =>
+    amountMath.make(value, simoleanLiquidityBrand);
 
   // Alice adds liquidity to the moola pool
   // 10 moola = 5 central tokens at the time of the liquidity adding
@@ -650,7 +648,7 @@ test('multipoolAutoSwap with some invalid offers', async t => {
 
   // Set up central token
   const centralR = makeIssuerKit('central');
-  const centralTokens = centralR.amountMath.make;
+  const centralTokens = value => amountMath.make(value, centralR.brand);
 
   // Setup Bob
   const bobMoolaPayment = moolaR.mint.mintPayment(moola(17));
@@ -712,7 +710,7 @@ test('multipoolAutoSwap jig - addLiquidity', async t => {
 
   // Set up central token
   const centralR = makeIssuerKit('central');
-  const centralTokens = centralR.amountMath.make;
+  const centralTokens = value => amountMath.make(value, centralR.brand);
 
   // set up purses
   const centralPayment = centralR.mint.mintPayment(centralTokens(20000));
@@ -732,11 +730,9 @@ test('multipoolAutoSwap jig - addLiquidity', async t => {
     moolaR.issuer,
     'Moola',
   );
-  const moolaLiquidityAmountMath = await makeLocalAmountMath(
-    moolaLiquidityIssuer,
-  );
+  const moolaLiquidityBrand = await E(moolaLiquidityIssuer).getBrand();
+  const moolaLiquidity = value => amountMath.make(value, moolaLiquidityBrand);
 
-  const moolaLiquidity = moolaLiquidityAmountMath.make;
   const issuerKeywordRecord = {
     Central: centralR.issuer,
     Secondary: moolaR.issuer,
@@ -801,7 +797,7 @@ test('multipoolAutoSwap jig - addLiquidity', async t => {
   // Alice adds liquidity with an out-of-balance offer -- too much moola
   const liqDetails2 = {
     cAmount: centralTokens(100),
-    sAmount: moola(200),
+    sAmount: moola(200n),
     lAmount: moolaLiquidity(100),
   };
 
@@ -846,7 +842,7 @@ test('multipoolAutoSwap jig - check liquidity', async t => {
 
   // Set up central token
   const centralR = makeIssuerKit('central');
-  const centralTokens = centralR.amountMath.make;
+  const centralTokens = value => amountMath.make(value, centralR.brand);
 
   // set up purses
   const centralPayment = centralR.mint.mintPayment(centralTokens(20000));
@@ -859,17 +855,18 @@ test('multipoolAutoSwap jig - check liquidity', async t => {
     installation,
     harden({ Central: centralR.issuer }),
   );
-  /** @type {MultipoolAutoswapPublicFacet} */
-  const { publicFacet } = startRecord;
+
+  const {
+    /** @type {MultipoolAutoswapPublicFacet} */ publicFacet,
+  } = startRecord;
   const moolaLiquidityIssuer = await E(publicFacet).addPool(
     moolaR.issuer,
     'Moola',
   );
-  const moolaLiquidityAmountMath = await makeLocalAmountMath(
-    moolaLiquidityIssuer,
-  );
 
-  const moolaLiquidity = moolaLiquidityAmountMath.make;
+  const moolaLiquidityBrand = await E(moolaLiquidityIssuer).getBrand();
+  const moolaLiquidity = value => amountMath.make(value, moolaLiquidityBrand);
+
   const issuerKeywordRecord = {
     Central: centralR.issuer,
     Secondary: moolaR.issuer,
@@ -916,7 +913,7 @@ test('multipoolAutoSwap jig - check liquidity', async t => {
   );
   moolaPoolState = updatePoolState(moolaPoolState, initLiquidityExpected);
   assertPayoutDeposit(t, centralP, centralPurse, centralTokens(0));
-  assertPayoutDeposit(t, secondaryP, moolaPurse, moola(0));
+  assertPayoutDeposit(t, secondaryP, moolaPurse, moola(0n));
   assertPayoutDeposit(t, liquidityP, purses[1], moolaLiquidity(10000));
 
   const liquidityIssuer = await E(publicFacet).getLiquidityIssuer(moolaR.brand);
@@ -978,7 +975,7 @@ test('multipoolAutoSwap jig - swapOut', async t => {
 
   // Set up central token
   const centralR = makeIssuerKit('central');
-  const centralTokens = centralR.amountMath.make;
+  const centralTokens = value => amountMath.make(value, centralR.brand);
 
   // set up purses
   const centralPayment = centralR.mint.mintPayment(centralTokens(30000));
@@ -993,25 +990,25 @@ test('multipoolAutoSwap jig - swapOut', async t => {
     installation,
     harden({ Central: centralR.issuer }),
   );
-  /** @type {MultipoolAutoswapPublicFacet} */
-  const { publicFacet } = startRecord;
+
+  const {
+    /** @type {MultipoolAutoswapPublicFacet} */ publicFacet,
+  } = startRecord;
   const moolaLiquidityIssuer = await E(publicFacet).addPool(
     moolaR.issuer,
     'Moola',
   );
-  const moolaLiquidityAmountMath = await makeLocalAmountMath(
-    moolaLiquidityIssuer,
-  );
+  const moolaLiquidityBrand = await E(moolaLiquidityIssuer).getBrand();
+  const moolaLiquidity = value => amountMath.make(value, moolaLiquidityBrand);
+
   const simoleanLiquidityIssuer = await E(publicFacet).addPool(
     simoleanR.issuer,
-    'Simolean',
-  );
-  const simoleanLiquidityAmountMath = await makeLocalAmountMath(
-    simoleanLiquidityIssuer,
+    'Simoleans',
   );
 
-  const moolaLiquidity = moolaLiquidityAmountMath.make;
-  const simoleanLiquidity = simoleanLiquidityAmountMath.make;
+  const simoleanLiquidityBrand = await E(simoleanLiquidityIssuer).getBrand();
+  const simoleanLiquidity = value =>
+    amountMath.make(value, simoleanLiquidityBrand);
   const mIssuerKeywordRecord = {
     Secondary: moolaR.issuer,
     Liquidity: moolaLiquidityIssuer,
@@ -1183,7 +1180,7 @@ test('multipoolAutoSwap jig - swapOut uneven', async t => {
 
   // Set up central token
   const centralR = makeIssuerKit('central');
-  const centralTokens = centralR.amountMath.make;
+  const centralTokens = value => amountMath.make(value, centralR.brand);
 
   // set up purses
   const centralPayment = centralR.mint.mintPayment(centralTokens(30000));
@@ -1206,19 +1203,17 @@ test('multipoolAutoSwap jig - swapOut uneven', async t => {
     moolaR.issuer,
     'Moola',
   );
-  const moolaLiquidityAmountMath = await makeLocalAmountMath(
-    moolaLiquidityIssuer,
-  );
+  const moolaLiquidityBrand = await E(moolaLiquidityIssuer).getBrand();
+  const moolaLiquidity = value => amountMath.make(value, moolaLiquidityBrand);
+
   const simoleanLiquidityIssuer = await E(publicFacet).addPool(
     simoleanR.issuer,
-    'Simolean',
-  );
-  const simoleanLiquidityAmountMath = await makeLocalAmountMath(
-    simoleanLiquidityIssuer,
+    'Simoleans',
   );
 
-  const moolaLiquidity = moolaLiquidityAmountMath.make;
-  const simoleanLiquidity = simoleanLiquidityAmountMath.make;
+  const simoleanLiquidityBrand = await E(simoleanLiquidityIssuer).getBrand();
+  const simoleanLiquidity = value =>
+    amountMath.make(value, simoleanLiquidityBrand);
   const mIssuerKeywordRecord = {
     Secondary: moolaR.issuer,
     Liquidity: moolaLiquidityIssuer,
@@ -1367,7 +1362,7 @@ test('multipoolAutoSwap jig - removeLiquidity', async t => {
 
   // Set up central token
   const centralR = makeIssuerKit('central');
-  const centralTokens = centralR.amountMath.make;
+  const centralTokens = value => amountMath.make(value, centralR.brand);
 
   // set up purses
   const centralPayment = centralR.mint.mintPayment(centralTokens(20000));
@@ -1388,11 +1383,9 @@ test('multipoolAutoSwap jig - removeLiquidity', async t => {
     moolaR.issuer,
     'Moola',
   );
-  const moolaLiquidityAmountMath = await makeLocalAmountMath(
-    moolaLiquidityIssuer,
-  );
+  const moolaLiquidityBrand = await E(moolaLiquidityIssuer).getBrand();
+  const moolaLiquidity = value => amountMath.make(value, moolaLiquidityBrand);
 
-  const moolaLiquidity = moolaLiquidityAmountMath.make;
   const issuerKeywordRecord = {
     Central: centralR.issuer,
     Secondary: moolaR.issuer,
@@ -1481,7 +1474,7 @@ test('multipoolAutoSwap jig - removeLiquidity ask for too much', async t => {
 
   // Set up central token
   const centralR = makeIssuerKit('central');
-  const centralTokens = centralR.amountMath.make;
+  const centralTokens = value => amountMath.make(value, centralR.brand);
 
   // set up purses
   const centralPayment = centralR.mint.mintPayment(centralTokens(20000));
@@ -1502,11 +1495,9 @@ test('multipoolAutoSwap jig - removeLiquidity ask for too much', async t => {
     moolaR.issuer,
     'Moola',
   );
-  const moolaLiquidityAmountMath = await makeLocalAmountMath(
-    moolaLiquidityIssuer,
-  );
+  const moolaLiquidityBrand = await E(moolaLiquidityIssuer).getBrand();
+  const moolaLiquidity = value => amountMath.make(value, moolaLiquidityBrand);
 
-  const moolaLiquidity = moolaLiquidityAmountMath.make;
   const issuerKeywordRecord = {
     Central: centralR.issuer,
     Secondary: moolaR.issuer,
@@ -1580,7 +1571,7 @@ test('multipoolAutoSwap jig - remove all liquidity', async t => {
 
   // Set up central token
   const centralR = makeIssuerKit('central');
-  const centralTokens = centralR.amountMath.make;
+  const centralTokens = value => amountMath.make(value, centralR.brand);
 
   // set up purses
   const centralPayment = centralR.mint.mintPayment(centralTokens(20000));
@@ -1601,11 +1592,9 @@ test('multipoolAutoSwap jig - remove all liquidity', async t => {
     moolaR.issuer,
     'Moola',
   );
-  const moolaLiquidityAmountMath = await makeLocalAmountMath(
-    moolaLiquidityIssuer,
-  );
+  const moolaLiquidityBrand = await E(moolaLiquidityIssuer).getBrand();
+  const moolaLiquidity = value => amountMath.make(value, moolaLiquidityBrand);
 
-  const moolaLiquidity = moolaLiquidityAmountMath.make;
   const issuerKeywordRecord = {
     Central: centralR.issuer,
     Secondary: moolaR.issuer,
@@ -1677,7 +1666,7 @@ test('multipoolAutoSwap jig - insufficient', async t => {
 
   // Set up central token
   const centralR = makeIssuerKit('central');
-  const centralTokens = centralR.amountMath.make;
+  const centralTokens = value => amountMath.make(value, centralR.brand);
 
   // set up purses
   const centralPayment = centralR.mint.mintPayment(centralTokens(30000));
@@ -1698,11 +1687,9 @@ test('multipoolAutoSwap jig - insufficient', async t => {
     moolaR.issuer,
     'Moola',
   );
-  const moolaLiquidityAmountMath = await makeLocalAmountMath(
-    moolaLiquidityIssuer,
-  );
+  const moolaLiquidityBrand = await E(moolaLiquidityIssuer).getBrand();
 
-  const moolaLiquidity = moolaLiquidityAmountMath.make;
+  const moolaLiquidity = value => amountMath.make(value, moolaLiquidityBrand);
   const mIssuerKeywordRecord = {
     Secondary: moolaR.issuer,
     Liquidity: moolaLiquidityIssuer,
@@ -1751,7 +1738,7 @@ test('multipoolAutoSwap jig - insufficient', async t => {
   // provide insufficient moola; trade fails
   const seat = await alice.offerAndTrade(
     centralTokens(gain),
-    moola(200),
+    moola(200n),
     false,
   );
   await t.throwsAsync(
@@ -1760,6 +1747,6 @@ test('multipoolAutoSwap jig - insufficient', async t => {
     `shouldn't have been able to trade`,
   );
   const { In: refund, Out: payout } = await seat.getPayouts();
-  t.deepEqual(await moolaR.issuer.getAmountOf(refund), moola(200));
+  t.deepEqual(await moolaR.issuer.getAmountOf(refund), moola(200n));
   t.deepEqual(await centralR.issuer.getAmountOf(payout), centralTokens(0));
 });

--- a/packages/zoe/test/unitTests/contracts/test-otcDesk.js
+++ b/packages/zoe/test/unitTests/contracts/test-otcDesk.js
@@ -1,4 +1,6 @@
 /* global __dirname */
+// @ts-check
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -217,7 +219,7 @@ const makeBob = (
         t,
         moolaIssuer,
         E(offerExpiredSeat).getPayout('Whatever2'),
-        moola(0),
+        moola(0n),
         'bob moola',
       );
       await assertPayoutAmount(

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
@@ -136,7 +136,7 @@ test('median aggregator', /** @param {ExecutionContext} t */ async t => {
   const pa = E(aggregator.publicFacet).getPriceAuthority();
 
   // TODO: Port this to makeQuoteNotifier(amountIn, brandOut)
-  // @ts-ignore
+  // @ts-ignore fix needed
   const notifier = E(pa).getPriceNotifier(brandIn, brandOut);
   await E(aggregator.creatorFacet).initOracle(price1000.instance, {
     increment: 10n,

--- a/packages/zoe/test/unitTests/contracts/test-secondPriceAuction.js
+++ b/packages/zoe/test/unitTests/contracts/test-secondPriceAuction.js
@@ -1,4 +1,6 @@
 /* global __dirname */
+// @ts-check
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -65,7 +67,7 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
           .then(amountDeposited =>
             t.deepEqual(
               amountDeposited,
-              moola(0),
+              moola(0n),
               `Alice didn't get any of what she put in`,
             ),
           );
@@ -183,7 +185,7 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
           .getPayout('Asset')
           .then(moolaPurse.deposit)
           .then(amountDeposited =>
-            t.deepEqual(amountDeposited, moola(0), `didn't win the auction`),
+            t.deepEqual(amountDeposited, moola(0n), `didn't win the auction`),
           );
 
         await E(seat)
@@ -347,7 +349,7 @@ test('zoe - secondPriceAuction - alice tries to exit', async t => {
   // carol gets the assets.
   t.deepEqual(
     await moolaR.issuer.getAmountOf(aliceMoolaPayout),
-    moola(0),
+    moola(0n),
     `alice has no moola`,
   );
 
@@ -362,7 +364,7 @@ test('zoe - secondPriceAuction - alice tries to exit', async t => {
   await aliceSimoleanPurse.deposit(aliceSimoleanPayout);
 
   // Bob gets a refund
-  t.deepEqual(await moolaR.issuer.getAmountOf(bobMoolaPayout), moola(0));
+  t.deepEqual(await moolaR.issuer.getAmountOf(bobMoolaPayout), moola(0n));
   t.deepEqual(
     await simoleanR.issuer.getAmountOf(bobSimoleanPayout),
     bobProposal.give.Bid,

--- a/packages/zoe/test/unitTests/contracts/test-sellTickets.js
+++ b/packages/zoe/test/unitTests/contracts/test-sellTickets.js
@@ -6,9 +6,10 @@ import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 
+import { assert } from '@agoric/assert';
 import bundleSource from '@agoric/bundle-source';
 import { makeIssuerKit, amountMath } from '@agoric/ertp';
-import { assertSetValue } from '@agoric/ertp/src/typeGuards';
+import { isSetValue } from '@agoric/ertp/src/typeGuards';
 import { E } from '@agoric/eventual-send';
 import fakeVatAdmin from '../../../src/contractFacet/fakeVatAdmin';
 
@@ -213,7 +214,7 @@ test(`mint and sell opera tickets`, async t => {
       3,
       'Alice should see 3 available tickets',
     );
-    assertSetValue(availableTickets.value);
+    assert(isSetValue(availableTickets.value));
     t.truthy(
       availableTickets.value.find(ticket => ticket.number === 1),
       `availableTickets contains ticket number 1`,
@@ -437,7 +438,7 @@ test(`mint and sell opera tickets`, async t => {
       ticketSalesPublicFacet,
     ).getAvailableItems();
 
-    assertSetValue(availableTickets.value);
+    assert(isSetValue(availableTickets.value));
     // Bob sees the currently available tickets
     t.is(
       availableTickets.value.length,

--- a/packages/zoe/test/unitTests/contracts/test-throwInOfferHandler.js
+++ b/packages/zoe/test/unitTests/contracts/test-throwInOfferHandler.js
@@ -1,4 +1,6 @@
 /* global __dirname */
+// @ts-check
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/test-useObj.js
+++ b/packages/zoe/test/unitTests/contracts/test-useObj.js
@@ -1,4 +1,6 @@
 /* global __dirname */
+// @ts-check
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/throwInOfferHandler.js
+++ b/packages/zoe/test/unitTests/contracts/throwInOfferHandler.js
@@ -1,7 +1,7 @@
 // @ts-check
 import '../../../exported';
 
-import { makeIssuerKit } from '@agoric/ertp';
+import { makeIssuerKit, amountMath } from '@agoric/ertp';
 import { Far } from '@agoric/marshal';
 
 import { depositToSeat } from '../../../src/contractSupport';
@@ -19,7 +19,7 @@ const start = zcf => {
 
   const throwInDepositToSeat = async seat => {
     const issuerKit = makeIssuerKit('token');
-    const tokens10 = issuerKit.amountMath.make(10);
+    const tokens10 = amountMath.make(10n, issuerKit.brand);
     const payment = issuerKit.mint.mintPayment(tokens10);
     const amounts = harden({ Token: tokens10 });
     const payments = harden({ Tokens: payment });

--- a/packages/zoe/test/unitTests/contracts/useObjExample.js
+++ b/packages/zoe/test/unitTests/contracts/useObjExample.js
@@ -2,6 +2,8 @@
 
 import { assert, details as X } from '@agoric/assert';
 import { Far } from '@agoric/marshal';
+import { amountMath } from '@agoric/ertp';
+
 // Eventually will be importable from '@agoric/zoe-contract-support'
 import {
   assertIssuerKeywords,
@@ -18,7 +20,6 @@ const start = zcf => {
     brands: { Pixels: pixelBrand },
   } = zcf.getTerms();
   assertIssuerKeywords(zcf, harden(['Pixels']));
-  const amountMath = zcf.getAmountMath(pixelBrand);
 
   const makeUseObj = seat => {
     assertProposalShape(seat, {
@@ -29,7 +30,7 @@ const start = zcf => {
        * (Pretend to) color some pixels.
        *
        * @param {string} color
-       * @param {Amount} amountToColor
+       * @param {Amount=} amountToColor
        */
       colorPixels: (color, amountToColor = undefined) => {
         // Throw if the offer is no longer active, i.e. the user has
@@ -41,6 +42,7 @@ const start = zcf => {
         if (amountToColor === undefined) {
           amountToColor = escrowedAmount;
         }
+        assert(amountToColor);
         // Ensure that the amount of pixels that we want to color is
         // covered by what is actually escrowed.
         assert(

--- a/packages/zoe/test/unitTests/installFromSource.js
+++ b/packages/zoe/test/unitTests/installFromSource.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import bundleSource from '@agoric/bundle-source';
 
 /**

--- a/packages/zoe/test/unitTests/makeOffer.js
+++ b/packages/zoe/test/unitTests/makeOffer.js
@@ -1,0 +1,22 @@
+// @ts-check
+
+import { E } from '@agoric/eventual-send';
+import { assert } from '@agoric/assert';
+
+/**
+ * @param {ZoeService} zoe
+ * @param {ContractFacet} zcf
+ * @param {Proposal=} proposal
+ * @param {PaymentPKeywordRecord=} payments
+ * @returns {Promise<{zcfSeat: ZCFSeat, userSeat: UserSeat}>}
+ */
+export const makeOffer = async (zoe, zcf, proposal, payments) => {
+  let zcfSeat;
+  const getSeat = seat => {
+    zcfSeat = seat;
+  };
+  const invitation = await zcf.makeInvitation(getSeat, 'seat');
+  const userSeat = await E(zoe).offer(invitation, proposal, payments);
+  assert(zcfSeat);
+  return { zcfSeat, userSeat };
+};

--- a/packages/zoe/test/unitTests/setupBasicMints.js
+++ b/packages/zoe/test/unitTests/setupBasicMints.js
@@ -1,4 +1,6 @@
-import { makeIssuerKit } from '@agoric/ertp';
+// @ts-check
+
+import { makeIssuerKit, amountMath } from '@agoric/ertp';
 import { makeZoe } from '../../src/zoeService/zoe';
 import fakeVatAdmin from '../../src/contractFacet/fakeVatAdmin';
 
@@ -11,17 +13,40 @@ const setup = () => {
     simoleans: simoleanBundle,
     bucks: bucksBundle,
   };
-  const amountMaths = new Map();
+  /** @type {Map<string, Brand>} */
   const brands = new Map();
 
   for (const k of Object.getOwnPropertyNames(allBundles)) {
-    amountMaths.set(k, allBundles[k].amountMath);
     brands.set(k, allBundles[k].brand);
   }
 
   const zoe = makeZoe(fakeVatAdmin);
 
-  return harden({
+  const makeSimpleMake = brand => value => amountMath.make(value, brand);
+
+  /**
+   * @typedef {Object} BasicMints
+   * @property {Issuer} moolaIssuer
+   * @property {Mint} moolaMint
+   * @property {IssuerKit} moolaR
+   * @property {IssuerKit} moolaKit
+   * @property {Issuer} simoleanIssuer
+   * @property {Mint} simoleanMint
+   * @property {IssuerKit} simoleanR
+   * @property {IssuerKit} simoleanKit
+   * @property {Issuer} bucksIssuer
+   * @property {Mint} bucksMint
+   * @property {IssuerKit} bucksR
+   * @property {IssuerKit} bucksKit
+   * @property {Map<string, Brand>} brands
+   * @property {(value: any) => Amount} moola
+   * @property {(value: any) => Amount} simoleans
+   * @property {(value: any) => Amount} bucks
+   * @property {ZoeService} zoe
+   */
+
+  /** @type {BasicMints} */
+  const result = {
     moolaIssuer: moolaBundle.issuer,
     moolaMint: moolaBundle.mint,
     moolaR: moolaBundle,
@@ -34,13 +59,14 @@ const setup = () => {
     bucksMint: bucksBundle.mint,
     bucksR: bucksBundle,
     bucksKit: bucksBundle,
-    amountMaths,
     brands,
-    moola: moolaBundle.amountMath.make,
-    simoleans: simoleanBundle.amountMath.make,
-    bucks: bucksBundle.amountMath.make,
+    moola: makeSimpleMake(moolaBundle.brand),
+    simoleans: makeSimpleMake(simoleanBundle.brand),
+    bucks: makeSimpleMake(bucksBundle.brand),
     zoe,
-  });
+  };
+  harden(result);
+  return result;
 };
 harden(setup);
 export { setup };

--- a/packages/zoe/test/unitTests/setupMixedMints.js
+++ b/packages/zoe/test/unitTests/setupMixedMints.js
@@ -1,20 +1,20 @@
-import { makeIssuerKit } from '@agoric/ertp';
+// @ts-check
+
+import { makeIssuerKit, amountMath, MathKind } from '@agoric/ertp';
 import { makeZoe } from '../../src/zoeService/zoe';
 import fakeVatAdmin from '../../src/contractFacet/fakeVatAdmin';
 
 const setupMixed = () => {
-  const ccBundle = makeIssuerKit('CryptoCats', 'strSet');
+  const ccBundle = makeIssuerKit('CryptoCats', MathKind.SET);
   const moolaBundle = makeIssuerKit('moola');
   const allBundles = { cc: ccBundle, moola: moolaBundle };
   const mints = new Map();
   const issuers = new Map();
-  const amountMaths = new Map();
   const brands = new Map();
 
   for (const k of Object.getOwnPropertyNames(allBundles)) {
     mints.set(k, allBundles[k].mint);
     issuers.set(k, allBundles[k].issuer);
-    amountMaths.set(k, allBundles[k].amountMath);
     brands.set(k, allBundles[k].brand);
   }
 
@@ -22,8 +22,8 @@ const setupMixed = () => {
   const moolaIssuer = issuers.get('moola');
   const ccMint = mints.get('cc');
   const moolaMint = mints.get('moola');
-  const cryptoCats = allBundles.cc.amountMath.make;
-  const moola = allBundles.moola.amountMath.make;
+  const cryptoCats = value => amountMath.make(value, allBundles.cc.brand);
+  const moola = value => amountMath.make(value, allBundles.moola.brand);
 
   const zoe = makeZoe(fakeVatAdmin);
   return {
@@ -34,7 +34,6 @@ const setupMixed = () => {
     moolaMint,
     cryptoCats,
     moola,
-    amountMaths,
     brands,
   };
 };

--- a/packages/zoe/test/unitTests/setupNonFungibleMints.js
+++ b/packages/zoe/test/unitTests/setupNonFungibleMints.js
@@ -1,20 +1,20 @@
-import { makeIssuerKit } from '@agoric/ertp';
+// @ts-check
+
+import { makeIssuerKit, amountMath, MathKind } from '@agoric/ertp';
 import { makeZoe } from '../../src/zoeService/zoe';
 import fakeVatAdmin from '../../src/contractFacet/fakeVatAdmin';
 
 const setupNonFungible = () => {
-  const ccBundle = makeIssuerKit('CryptoCats', 'strSet');
-  const rpgBundle = makeIssuerKit('MMORPG Items', 'set');
+  const ccBundle = makeIssuerKit('CryptoCats', MathKind.SET);
+  const rpgBundle = makeIssuerKit('MMORPG Items', MathKind.SET);
   const allBundles = { cc: ccBundle, rpg: rpgBundle };
   const mints = new Map();
   const issuers = new Map();
-  const amountMaths = new Map();
   const brands = new Map();
 
   for (const k of Object.getOwnPropertyNames(allBundles)) {
     mints.set(k, allBundles[k].mint);
     issuers.set(k, allBundles[k].issuer);
-    amountMaths.set(k, allBundles[k].amountMath);
     brands.set(k, allBundles[k].brand);
   }
 
@@ -27,8 +27,8 @@ const setupNonFungible = () => {
   const rpgIssuer = issuers.get('rpg');
   const ccMint = mints.get('cc');
   const rpgMint = mints.get('rpg');
-  const cryptoCats = allBundles.cc.amountMath.make;
-  const rpgItems = allBundles.rpg.amountMath.make;
+  const cryptoCats = value => amountMath.make(value, allBundles.cc.brand);
+  const rpgItems = value => amountMath.make(value, allBundles.rpg.brand);
   return {
     ccIssuer,
     rpgIssuer,
@@ -36,7 +36,6 @@ const setupNonFungible = () => {
     rpgMint,
     cryptoCats,
     rpgItems,
-    amountMaths,
     brands,
     createRpgItem,
     zoe,

--- a/packages/zoe/test/unitTests/test-cleanProposal.js
+++ b/packages/zoe/test/unitTests/test-cleanProposal.js
@@ -1,21 +1,16 @@
+// @ts-check
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
-import { makeWeakStore } from '@agoric/store';
+
 import { cleanProposal } from '../../src/cleanProposal';
 import { setup } from './setupBasicMints';
 import buildManualTimer from '../../tools/manualTimer';
 
 test('cleanProposal test', t => {
-  const { simoleanR, moolaR, bucksR, moola, simoleans } = setup();
-
-  const brandToAmountMath = makeWeakStore('brand');
-  brandToAmountMath.init(moolaR.brand, moolaR.amountMath);
-  brandToAmountMath.init(simoleanR.brand, simoleanR.amountMath);
-  brandToAmountMath.init(bucksR.brand, bucksR.amountMath);
-
-  const getAmountMathForBrand = brandToAmountMath.get;
+  const { moola, simoleans } = setup();
 
   const proposal = harden({
     give: { Asset: simoleans(1) },
@@ -28,21 +23,12 @@ test('cleanProposal test', t => {
     exit: { onDemand: null },
   });
 
-  const actual = cleanProposal(getAmountMathForBrand, proposal);
+  const actual = cleanProposal(proposal);
 
   t.deepEqual(actual, expected);
 });
 
 test('cleanProposal - all empty', t => {
-  const { simoleanR, moolaR, bucksR } = setup();
-
-  const brandToAmountMath = makeWeakStore('brand');
-  brandToAmountMath.init(moolaR.brand, moolaR.amountMath);
-  brandToAmountMath.init(simoleanR.brand, simoleanR.amountMath);
-  brandToAmountMath.init(bucksR.brand, bucksR.amountMath);
-
-  const getAmountMathForBrand = brandToAmountMath.get;
-
   const proposal = harden({
     give: harden({}),
     want: harden({}),
@@ -56,19 +42,12 @@ test('cleanProposal - all empty', t => {
   });
 
   // cleanProposal no longer fills in empty keywords
-  t.deepEqual(cleanProposal(getAmountMathForBrand, proposal), expected);
+  t.deepEqual(cleanProposal(proposal), expected);
 });
 
 test('cleanProposal - repeated brands', t => {
   t.plan(3);
-  const { simoleanR, moolaR, bucksR, moola, simoleans } = setup();
-
-  const brandToAmountMath = makeWeakStore('brand');
-  brandToAmountMath.init(moolaR.brand, moolaR.amountMath);
-  brandToAmountMath.init(simoleanR.brand, simoleanR.amountMath);
-  brandToAmountMath.init(bucksR.brand, bucksR.amountMath);
-
-  const getAmountMathForBrand = brandToAmountMath.get;
+  const { moola, simoleans } = setup();
   const timer = buildManualTimer(console.log);
 
   const proposal = harden({
@@ -85,7 +64,7 @@ test('cleanProposal - repeated brands', t => {
     exit: { afterDeadline: { timer, deadline: 100n } },
   });
   // cleanProposal no longer fills in empty keywords
-  const actual = cleanProposal(getAmountMathForBrand, proposal);
+  const actual = cleanProposal(proposal);
   t.deepEqual(actual.want, expected.want);
   t.deepEqual(actual.give, expected.give);
   t.deepEqual(actual.exit, expected.exit);

--- a/packages/zoe/test/unitTests/test-fakePriceAuthority.js
+++ b/packages/zoe/test/unitTests/test-fakePriceAuthority.js
@@ -4,6 +4,7 @@ import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { E } from '@agoric/eventual-send';
+import { assert } from '@agoric/assert';
 import buildManualTimer from '../../tools/manualTimer';
 
 import { setup } from './setupBasicMints';
@@ -15,20 +16,21 @@ import {
   getQuoteValues,
 } from '../../src/contractSupport';
 
-const makeTestPriceAuthority = (amountMaths, priceList, timer) =>
+const makeTestPriceAuthority = (brands, priceList, timer) =>
   makeFakePriceAuthority({
-    mathIn: amountMaths.get('moola'),
-    mathOut: amountMaths.get('bucks'),
+    actualBrandIn: brands.get('moola'),
+    actualBrandOut: brands.get('bucks'),
     priceList,
     timer,
   });
 
 test('priceAuthority quoteAtTime', async t => {
-  const { moola, bucks, amountMaths, brands } = setup();
+  const { moola, bucks, brands } = setup();
   const bucksBrand = brands.get('bucks');
+  assert(bucksBrand);
   const manualTimer = buildManualTimer(console.log, 0n);
   const priceAuthority = await makeTestPriceAuthority(
-    amountMaths,
+    brands,
     [20, 55],
     manualTimer,
   );
@@ -49,11 +51,12 @@ test('priceAuthority quoteAtTime', async t => {
 });
 
 test('priceAuthority quoteGiven', async t => {
-  const { moola, amountMaths, brands, bucks } = setup();
+  const { moola, brands, bucks } = setup();
   const bucksBrand = brands.get('bucks');
+  assert(bucksBrand);
   const manualTimer = buildManualTimer(console.log, 0n);
   const priceAuthority = await makeTestPriceAuthority(
-    amountMaths,
+    brands,
     [20, 55],
     manualTimer,
   );
@@ -66,11 +69,12 @@ test('priceAuthority quoteGiven', async t => {
 });
 
 test('priceAuthority quoteWanted', async t => {
-  const { moola, bucks, amountMaths, brands } = setup();
+  const { moola, bucks, brands } = setup();
   const moolaBrand = brands.get('moola');
+  assert(moolaBrand);
   const manualTimer = buildManualTimer(console.log, 0n);
   const priceAuthority = await makeTestPriceAuthority(
-    amountMaths,
+    brands,
     [20, 55],
     manualTimer,
   );
@@ -84,12 +88,14 @@ test('priceAuthority quoteWanted', async t => {
 });
 
 test('priceAuthority paired quotes', async t => {
-  const { moola, bucks, amountMaths, brands } = setup();
+  const { moola, bucks, brands } = setup();
   const moolaBrand = brands.get('moola');
+  assert(moolaBrand);
   const bucksBrand = brands.get('bucks');
+  assert(bucksBrand);
   const manualTimer = buildManualTimer(console.log, 0n);
   const priceAuthority = await makeTestPriceAuthority(
-    amountMaths,
+    brands,
     [20, 55],
     manualTimer,
   );
@@ -110,10 +116,10 @@ test('priceAuthority paired quotes', async t => {
 });
 
 test('priceAuthority quoteWhenGTE', async t => {
-  const { moola, bucks, amountMaths } = setup();
+  const { moola, bucks, brands } = setup();
   const manualTimer = buildManualTimer(console.log, 0n);
   const priceAuthority = await makeTestPriceAuthority(
-    amountMaths,
+    brands,
     [20, 30, 25, 40],
     manualTimer,
   );
@@ -136,10 +142,10 @@ test('priceAuthority quoteWhenGTE', async t => {
 });
 
 test('priceAuthority quoteWhenLT', async t => {
-  const { moola, bucks, amountMaths } = setup();
+  const { moola, bucks, brands } = setup();
   const manualTimer = buildManualTimer(console.log, 0n);
   const priceAuthority = await makeTestPriceAuthority(
-    amountMaths,
+    brands,
     [40, 30, 29],
     manualTimer,
   );
@@ -161,10 +167,10 @@ test('priceAuthority quoteWhenLT', async t => {
 });
 
 test('priceAuthority quoteWhenGT', async t => {
-  const { moola, bucks, amountMaths } = setup();
+  const { moola, bucks, brands } = setup();
   const manualTimer = buildManualTimer(console.log, 0n);
   const priceAuthority = await makeTestPriceAuthority(
-    amountMaths,
+    brands,
     [40, 30, 41],
     manualTimer,
   );
@@ -186,10 +192,10 @@ test('priceAuthority quoteWhenGT', async t => {
 });
 
 test('priceAuthority quoteWhenLTE', async t => {
-  const { moola, bucks, amountMaths } = setup();
+  const { moola, bucks, brands } = setup();
   const manualTimer = buildManualTimer(console.log, 0n);
   const priceAuthority = await makeTestPriceAuthority(
-    amountMaths,
+    brands,
     [40, 26, 50, 25],
     manualTimer,
   );

--- a/packages/zoe/test/unitTests/test-objArrayConversion.js
+++ b/packages/zoe/test/unitTests/test-objArrayConversion.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/test-offerSafety.js
+++ b/packages/zoe/test/unitTests/test-offerSafety.js
@@ -1,3 +1,4 @@
+// @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -5,11 +6,6 @@ import test from 'ava';
 
 import { isOfferSafe } from '../../src/contractFacet/offerSafety';
 import { setup } from './setupBasicMints';
-
-function makeGetAmountMath(mapping) {
-  const brandToAmountMath = new Map(mapping);
-  return brand => brandToAmountMath.get(brand);
-}
 
 // Potential outcomes:
 // 1. Users can get what they wanted, get back what they gave, both, or
@@ -30,166 +26,125 @@ function makeGetAmountMath(mapping) {
 
 // more than want, more than give -> isOfferSafe() = true
 test('isOfferSafe - more than want, more than give', t => {
-  const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
-  const getAmountMath = makeGetAmountMath([
-    [moolaR.brand, moolaR.amountMath],
-    [simoleanR.brand, simoleanR.amountMath],
-    [bucksR.brand, bucksR.amountMath],
-  ]);
+  const { moola, simoleans, bucks } = setup();
   const proposal = harden({
     give: { A: moola(8) },
-    want: { B: simoleans(6), C: bucks(7) },
+    want: { B: simoleans(6), C: bucks(7n) },
+    exit: { waived: null },
   });
   const amounts = harden({ A: moola(10), B: simoleans(7), C: bucks(8) });
 
-  t.truthy(isOfferSafe(getAmountMath, proposal, amounts));
+  t.truthy(isOfferSafe(proposal, amounts));
 });
 
 // more than want, less than give -> true
 test('isOfferSafe - more than want, less than give', t => {
-  const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
-  const getAmountMath = makeGetAmountMath([
-    [moolaR.brand, moolaR.amountMath],
-    [simoleanR.brand, simoleanR.amountMath],
-    [bucksR.brand, bucksR.amountMath],
-  ]);
+  const { moola, simoleans, bucks } = setup();
   const proposal = harden({
     give: { A: moola(8) },
-    want: { B: simoleans(6), C: bucks(7) },
+    want: { B: simoleans(6), C: bucks(7n) },
+    exit: { waived: null },
   });
   const amounts = harden({ A: moola(1), B: simoleans(7), C: bucks(8) });
 
-  t.truthy(isOfferSafe(getAmountMath, proposal, amounts));
+  t.truthy(isOfferSafe(proposal, amounts));
 });
 
 // more than want, equal to give -> true
 test('isOfferSafe - more than want, equal to give', t => {
-  const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
-  const getAmountMath = makeGetAmountMath([
-    [moolaR.brand, moolaR.amountMath],
-    [simoleanR.brand, simoleanR.amountMath],
-    [bucksR.brand, bucksR.amountMath],
-  ]);
+  const { moola, simoleans, bucks } = setup();
   const proposal = harden({
     want: { A: moola(8) },
-    give: { B: simoleans(6), C: bucks(7) },
+    give: { B: simoleans(6), C: bucks(7n) },
+    exit: { waived: null },
   });
-  const amounts = harden({ A: moola(9), B: simoleans(6), C: bucks(7) });
+  const amounts = harden({ A: moola(9), B: simoleans(6), C: bucks(7n) });
 
-  t.truthy(isOfferSafe(getAmountMath, proposal, amounts));
+  t.truthy(isOfferSafe(proposal, amounts));
 });
 
 // less than want, more than give -> true
 test('isOfferSafe - less than want, more than give', t => {
-  const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
-  const getAmountMath = makeGetAmountMath([
-    [moolaR.brand, moolaR.amountMath],
-    [simoleanR.brand, simoleanR.amountMath],
-    [bucksR.brand, bucksR.amountMath],
-  ]);
+  const { moola, simoleans, bucks } = setup();
   const proposal = harden({
     want: { A: moola(8) },
-    give: { B: simoleans(6), C: bucks(7) },
+    give: { B: simoleans(6), C: bucks(7n) },
+    exit: { waived: null },
   });
   const amounts = harden({ A: moola(7), B: simoleans(9), C: bucks(19) });
 
-  t.truthy(isOfferSafe(getAmountMath, proposal, amounts));
+  t.truthy(isOfferSafe(proposal, amounts));
 });
 
 // less than want, less than give -> false
 test('isOfferSafe - less than want, less than give', t => {
-  const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
-  const getAmountMath = makeGetAmountMath([
-    [moolaR.brand, moolaR.amountMath],
-    [simoleanR.brand, simoleanR.amountMath],
-    [bucksR.brand, bucksR.amountMath],
-  ]);
+  const { moola, simoleans, bucks } = setup();
   const proposal = harden({
     want: { A: moola(8) },
-    give: { B: simoleans(6), C: bucks(7) },
+    give: { B: simoleans(6), C: bucks(7n) },
+    exit: { waived: null },
   });
   const amounts = harden({ A: moola(7), B: simoleans(5), C: bucks(6) });
 
-  t.falsy(isOfferSafe(getAmountMath, proposal, amounts));
+  t.falsy(isOfferSafe(proposal, amounts));
 });
 
 // less than want, equal to give -> true
 test('isOfferSafe - less than want, equal to give', t => {
-  const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
-  const getAmountMath = makeGetAmountMath([
-    [moolaR.brand, moolaR.amountMath],
-    [simoleanR.brand, simoleanR.amountMath],
-    [bucksR.brand, bucksR.amountMath],
-  ]);
+  const { moola, simoleans, bucks } = setup();
   const proposal = harden({
     want: { B: simoleans(6) },
-    give: { A: moola(1), C: bucks(7) },
+    give: { A: moola(1), C: bucks(7n) },
+    exit: { waived: null },
   });
-  const amounts = harden({ A: moola(1), B: simoleans(5), C: bucks(7) });
+  const amounts = harden({ A: moola(1), B: simoleans(5), C: bucks(7n) });
 
-  t.truthy(isOfferSafe(getAmountMath, proposal, amounts));
+  t.truthy(isOfferSafe(proposal, amounts));
 });
 
 // equal to want, more than give -> true
 test('isOfferSafe - equal to want, more than give', t => {
-  const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
-  const getAmountMath = makeGetAmountMath([
-    [moolaR.brand, moolaR.amountMath],
-    [simoleanR.brand, simoleanR.amountMath],
-    [bucksR.brand, bucksR.amountMath],
-  ]);
+  const { moola, simoleans, bucks } = setup();
   const proposal = harden({
     want: { B: simoleans(6) },
-    give: { A: moola(1), C: bucks(7) },
+    give: { A: moola(1), C: bucks(7n) },
+    exit: { waived: null },
   });
   const amounts = harden({ A: moola(2), B: simoleans(6), C: bucks(8) });
 
-  t.truthy(isOfferSafe(getAmountMath, proposal, amounts));
+  t.truthy(isOfferSafe(proposal, amounts));
 });
 
 // equal to want, less than give -> true
 test('isOfferSafe - equal to want, less than give', t => {
-  const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
-  const getAmountMath = makeGetAmountMath([
-    [moolaR.brand, moolaR.amountMath],
-    [simoleanR.brand, simoleanR.amountMath],
-    [bucksR.brand, bucksR.amountMath],
-  ]);
+  const { moola, simoleans, bucks } = setup();
   const proposal = harden({
     want: { B: simoleans(6) },
-    give: { A: moola(1), C: bucks(7) },
+    give: { A: moola(1), C: bucks(7n) },
+    exit: { waived: null },
   });
-  const amounts = harden({ A: moola(0), B: simoleans(6), C: bucks(0) });
+  const amounts = harden({ A: moola(0n), B: simoleans(6), C: bucks(0) });
 
-  t.truthy(isOfferSafe(getAmountMath, proposal, amounts));
+  t.truthy(isOfferSafe(proposal, amounts));
 });
 
 // equal to want, equal to give -> true
 test('isOfferSafe - equal to want, equal to give', t => {
-  const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
-  const getAmountMath = makeGetAmountMath([
-    [moolaR.brand, moolaR.amountMath],
-    [simoleanR.brand, simoleanR.amountMath],
-    [bucksR.brand, bucksR.amountMath],
-  ]);
+  const { moola, simoleans, bucks } = setup();
   const proposal = harden({
     want: { B: simoleans(6) },
-    give: { A: moola(1), C: bucks(7) },
+    give: { A: moola(1), C: bucks(7n) },
+    exit: { waived: null },
   });
-  const amounts = harden({ A: moola(1), B: simoleans(6), C: bucks(7) });
+  const amounts = harden({ A: moola(1), B: simoleans(6), C: bucks(7n) });
 
-  t.truthy(isOfferSafe(getAmountMath, proposal, amounts));
+  t.truthy(isOfferSafe(proposal, amounts));
 });
 
 test('isOfferSafe - empty proposal', t => {
-  const { moolaR, simoleanR, bucksR, moola, simoleans, bucks } = setup();
-  const getAmountMath = makeGetAmountMath([
-    [moolaR.brand, moolaR.amountMath],
-    [simoleanR.brand, simoleanR.amountMath],
-    [bucksR.brand, bucksR.amountMath],
-  ]);
-  const proposal = harden({ give: {}, want: {} });
-  const amounts = harden({ A: moola(1), B: simoleans(6), C: bucks(7) });
+  const { moola, simoleans, bucks } = setup();
+  const proposal = harden({ give: {}, want: {}, exit: { waived: null } });
+  const amounts = harden({ A: moola(1), B: simoleans(6), C: bucks(7n) });
 
-  t.truthy(isOfferSafe(getAmountMath, proposal, amounts));
+  t.truthy(isOfferSafe(proposal, amounts));
 });

--- a/packages/zoe/test/unitTests/test-rightsConservation.js
+++ b/packages/zoe/test/unitTests/test-rightsConservation.js
@@ -1,36 +1,31 @@
+// @ts-check
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 
-import { makeWeakStore } from '@agoric/store';
-import { makeIssuerKit } from '@agoric/ertp';
+import { amountMath, makeIssuerKit } from '@agoric/ertp';
 import { assertRightsConserved } from '../../src/contractFacet/rightsConservation';
 
-const setupAmountMaths = () => {
+const setupBrands = () => {
   const moolaIssuerResults = makeIssuerKit('moola');
   const simoleanIssuerResults = makeIssuerKit('simoleans');
   const bucksIssuerResults = makeIssuerKit('bucks');
 
   const all = [moolaIssuerResults, simoleanIssuerResults, bucksIssuerResults];
-  const amountMathArray = all.map(objs => objs.amountMath);
-  const brandToAmountMath = makeWeakStore('brand');
-  all.forEach(bundle =>
-    brandToAmountMath.init(bundle.brand, bundle.amountMath),
-  );
-  const getAmountMathForBrand = brandToAmountMath.get;
-  return {
-    amountMathArray,
-    getAmountMathForBrand,
-  };
+  const brands = all.map(record => record.brand);
+  return brands;
 };
 
-const makeAmountMatrix = (amountMathArray, valueMatrix) =>
-  valueMatrix.map(row => row.map((value, i) => amountMathArray[i].make(value)));
+const makeAmountMatrix = (brands, valueMatrix) =>
+  valueMatrix.map(row =>
+    row.map((value, i) => amountMath.make(value, brands[i])),
+  );
 
 // rights are conserved for amount with Nat values
 test(`assertRightsConserved - true for amount with nat values`, t => {
-  const { amountMathArray, getAmountMathForBrand } = setupAmountMaths();
+  const brands = setupBrands();
   const previousValues = [
     [0, 1, 0],
     [4, 1, 0],
@@ -42,20 +37,15 @@ test(`assertRightsConserved - true for amount with nat values`, t => {
     [6, 2, 0],
   ];
 
-  const previousAmounts = makeAmountMatrix(
-    amountMathArray,
-    previousValues,
-  ).flat();
-  const newAmounts = makeAmountMatrix(amountMathArray, newValues).flat();
+  const previousAmounts = makeAmountMatrix(brands, previousValues).flat();
+  const newAmounts = makeAmountMatrix(brands, newValues).flat();
 
-  t.notThrows(() =>
-    assertRightsConserved(getAmountMathForBrand, previousAmounts, newAmounts),
-  );
+  t.notThrows(() => assertRightsConserved(previousAmounts, newAmounts));
 });
 
 // rights are *not* conserved for amount with Nat values
 test(`assertRightsConserved - false for amount with Nat values`, t => {
-  const { amountMathArray, getAmountMathForBrand } = setupAmountMaths();
+  const brands = setupBrands();
   const oldValues = [
     [0, 1, 4],
     [4, 1, 0],
@@ -67,25 +57,22 @@ test(`assertRightsConserved - false for amount with Nat values`, t => {
     [6, 2, 0],
   ];
 
-  const oldAmounts = makeAmountMatrix(amountMathArray, oldValues).flat();
-  const newAmounts = makeAmountMatrix(amountMathArray, newValues).flat();
+  const oldAmounts = makeAmountMatrix(brands, oldValues).flat();
+  const newAmounts = makeAmountMatrix(brands, newValues).flat();
 
   console.log('ERROR EXPECTED: rights were not conserved for brand >>>');
   t.throws(
-    () => assertRightsConserved(getAmountMathForBrand, oldAmounts, newAmounts),
+    () => assertRightsConserved(oldAmounts, newAmounts),
     { message: /rights were not conserved for brand/ },
     `should throw if rights aren't conserved`,
   );
 });
 
 test(`assertRightsConserved - empty arrays`, t => {
-  const { getAmountMathForBrand } = setupAmountMaths();
   const oldAmounts = [];
   const newAmounts = [];
 
-  t.notThrows(() =>
-    assertRightsConserved(getAmountMathForBrand, oldAmounts, newAmounts),
-  );
+  t.notThrows(() => assertRightsConserved(oldAmounts, newAmounts));
 });
 
 // TODO: add tests for non-Nat values

--- a/packages/zoe/test/unitTests/test-scriptedOracle.js
+++ b/packages/zoe/test/unitTests/test-scriptedOracle.js
@@ -31,7 +31,7 @@ const bountyContractPath = `${__dirname}/bounty`;
  * @property {Installation} bountyInstallation
  * @property {Mint} moolaMint
  * @property {Issuer} moolaIssuer
- * @property {AmountMath['make']} moola
+ * @property {(value: Value) => Amount} moola
  *
  * @typedef {import('ava').ExecutionContext<TestContext>} ExecutionContext
  */
@@ -87,7 +87,7 @@ test('pay bounty', async t => {
       deadline: 3n,
       condition: 'Succeeded',
       timer,
-      fee: moola(50),
+      fee: moola(50n),
     },
   );
 
@@ -96,34 +96,34 @@ test('pay bounty', async t => {
   const funderSeat = await E(zoe).offer(
     funderInvitation,
     harden({
-      give: { Bounty: moola(200) },
-      want: { Fee: moola(0) },
+      give: { Bounty: moola(200n) },
+      want: { Fee: moola(0n) },
     }),
     harden({
-      Bounty: moolaMint.mintPayment(moola(200)),
+      Bounty: moolaMint.mintPayment(moola(200n)),
     }),
   );
   const bountyInvitation = await funderSeat.getOfferResult();
-  assertPayoutAmount(t, moolaIssuer, funderSeat.getPayout('Fee'), moola(50));
-  assertPayoutAmount(t, moolaIssuer, funderSeat.getPayout('Bounty'), moola(0));
+  assertPayoutAmount(t, moolaIssuer, funderSeat.getPayout('Fee'), moola(50n));
+  assertPayoutAmount(t, moolaIssuer, funderSeat.getPayout('Bounty'), moola(0n));
 
   // Bob buys the bounty invitation
   const bountySeat = await E(zoe).offer(
     bountyInvitation,
     harden({
-      give: { Fee: moola(50) },
-      want: { Bounty: moola(0) },
+      give: { Fee: moola(50n) },
+      want: { Bounty: moola(0n) },
     }),
     harden({
-      Fee: moolaMint.mintPayment(moola(50)),
+      Fee: moolaMint.mintPayment(moola(50n)),
     }),
   );
-  assertPayoutAmount(t, moolaIssuer, bountySeat.getPayout('Fee'), moola(0));
+  assertPayoutAmount(t, moolaIssuer, bountySeat.getPayout('Fee'), moola(0n));
   assertPayoutAmount(
     t,
     moolaIssuer,
     bountySeat.getPayout('Bounty'),
-    moola(200),
+    moola(200n),
   );
 
   await E(timer).tick();
@@ -156,7 +156,7 @@ test('pay no bounty', async t => {
       deadline: 3n,
       condition: 'Succeeded',
       timer,
-      fee: moola(50),
+      fee: moola(50n),
     },
   );
 
@@ -165,37 +165,37 @@ test('pay no bounty', async t => {
   const funderSeat = await E(zoe).offer(
     funderInvitation,
     harden({
-      give: { Bounty: moola(200) },
-      want: { Fee: moola(0) },
+      give: { Bounty: moola(200n) },
+      want: { Fee: moola(0n) },
     }),
     harden({
-      Bounty: moolaMint.mintPayment(moola(200)),
+      Bounty: moolaMint.mintPayment(moola(200n)),
     }),
   );
   const bountyInvitation = await funderSeat.getOfferResult();
-  assertPayoutAmount(t, moolaIssuer, funderSeat.getPayout('Fee'), moola(50));
+  assertPayoutAmount(t, moolaIssuer, funderSeat.getPayout('Fee'), moola(50n));
   // Alice gets the funds back.
   assertPayoutAmount(
     t,
     moolaIssuer,
     funderSeat.getPayout('Bounty'),
-    moola(200),
+    moola(200n),
   );
 
   // Bob buys the bounty invitation
   const bountySeat = await E(zoe).offer(
     bountyInvitation,
     harden({
-      give: { Fee: moola(50) },
-      want: { Bounty: moola(0) },
+      give: { Fee: moola(50n) },
+      want: { Bounty: moola(0n) },
     }),
     harden({
-      Fee: moolaMint.mintPayment(moola(50)),
+      Fee: moolaMint.mintPayment(moola(50n)),
     }),
   );
-  assertPayoutAmount(t, moolaIssuer, bountySeat.getPayout('Fee'), moola(0));
+  assertPayoutAmount(t, moolaIssuer, bountySeat.getPayout('Fee'), moola(0n));
   // Bob doesn't receive the bounty
-  assertPayoutAmount(t, moolaIssuer, bountySeat.getPayout('Bounty'), moola(0));
+  assertPayoutAmount(t, moolaIssuer, bountySeat.getPayout('Bounty'), moola(0n));
 
   await E(timer).tick();
   await E(timer).tick();

--- a/packages/zoe/test/unitTests/test-zoe-env.js
+++ b/packages/zoe/test/unitTests/test-zoe-env.js
@@ -7,16 +7,19 @@ import '@agoric/zoe/tools/prepare-test-env';
 import test from 'ava';
 
 test('harden from SES is in the zoe contract environment', t => {
+  // @ts-ignore
   harden();
   t.pass();
 });
 
 test('(mock) makeKind from SwingSet is in the zoe contract environment', t => {
+  // @ts-ignore
   makeKind();
   t.pass();
 });
 
 test('(mock) makeWeakStore from SwingSet is in the zoe contract environment', t => {
+  // @ts-ignore
   makeWeakStore();
   t.pass();
 });

--- a/packages/zoe/test/unitTests/test-zoe-env.js
+++ b/packages/zoe/test/unitTests/test-zoe-env.js
@@ -7,19 +7,19 @@ import '@agoric/zoe/tools/prepare-test-env';
 import test from 'ava';
 
 test('harden from SES is in the zoe contract environment', t => {
-  // @ts-ignore
+  // @ts-ignore testing existence of function only
   harden();
   t.pass();
 });
 
 test('(mock) makeKind from SwingSet is in the zoe contract environment', t => {
-  // @ts-ignore
+  // @ts-ignore testing existence of function only
   makeKind();
   t.pass();
 });
 
 test('(mock) makeWeakStore from SwingSet is in the zoe contract environment', t => {
-  // @ts-ignore
+  // @ts-ignore testing existence of function only
   makeWeakStore();
   t.pass();
 });

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -224,6 +224,7 @@ test(`zoe.getTerms - none`, async t => {
   t.deepEqual(await E(zoe).getTerms(instance), {
     brands: {},
     issuers: {},
+    maths: {},
   });
 });
 
@@ -251,10 +252,16 @@ test(`zoe.getTerms`, async t => {
     brands: {
       Moola: moolaKit.brand,
     },
+    maths: { Moola: moolaKit.amountMath },
     someTerm: 2,
   };
 
-  t.deepEqual(zoeTerms, expected);
+  t.deepEqual({ ...zoeTerms, maths: {} }, { ...expected, maths: {} });
+  t.is(
+    zoeTerms.maths.Moola.getAmountMathKind(),
+    moolaKit.amountMath.getAmountMathKind(),
+  );
+  t.is(zoeTerms.maths.Moola.getBrand(), moolaKit.amountMath.getBrand());
 });
 
 test(`zoe.getTerms - no instance`, async t => {

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -224,7 +224,6 @@ test(`zoe.getTerms - none`, async t => {
   t.deepEqual(await E(zoe).getTerms(instance), {
     brands: {},
     issuers: {},
-    maths: {},
   });
 });
 
@@ -252,16 +251,10 @@ test(`zoe.getTerms`, async t => {
     brands: {
       Moola: moolaKit.brand,
     },
-    maths: { Moola: moolaKit.amountMath },
     someTerm: 2,
   };
 
-  t.deepEqual({ ...zoeTerms, maths: {} }, { ...expected, maths: {} });
-  t.is(
-    zoeTerms.maths.Moola.getAmountMathKind(),
-    moolaKit.amountMath.getAmountMathKind(),
-  );
-  t.is(zoeTerms.maths.Moola.getBrand(), moolaKit.amountMath.getBrand());
+  t.deepEqual(zoeTerms, expected);
 });
 
 test(`zoe.getTerms - no instance`, async t => {

--- a/packages/zoe/test/unitTests/zcf/setupZcfTest.js
+++ b/packages/zoe/test/unitTests/zcf/setupZcfTest.js
@@ -28,7 +28,7 @@ export const setupZCFTest = async (issuerKeywordRecord, terms) => {
     terms,
   );
   const { vatAdminState } = fakeVatAdmin;
-  // @ts-ignore
+  // @ts-ignore fix types to understand that zcf is always defined
   assert(zcf !== undefined);
   return { zoe, zcf, instance, installation, creatorFacet, vatAdminState };
 };

--- a/packages/zoe/test/unitTests/zcf/setupZcfTest.js
+++ b/packages/zoe/test/unitTests/zcf/setupZcfTest.js
@@ -1,6 +1,9 @@
 /* global __dirname */
+// @ts-check
+
 import { E } from '@agoric/eventual-send';
 import bundleSource from '@agoric/bundle-source';
+import { assert } from '@agoric/assert';
 
 // noinspection ES6PreferShortImport
 import { makeZoe } from '../../../src/zoeService/zoe';
@@ -25,5 +28,7 @@ export const setupZCFTest = async (issuerKeywordRecord, terms) => {
     terms,
   );
   const { vatAdminState } = fakeVatAdmin;
+  // @ts-ignore
+  assert(zcf !== undefined);
   return { zoe, zcf, instance, installation, creatorFacet, vatAdminState };
 };

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
@@ -1,4 +1,7 @@
 /* global __dirname */
+
+// @ts-check
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
@@ -274,7 +274,7 @@ test(`zoeHelper with zcf - assertProposalShape`, async t => {
     { B: simoleanMint.mintPayment(simoleans(3)) },
   );
 
-  // @ts-ignore
+  // @ts-ignore invalid arguments for testing
   t.throws(() => assertProposalShape(zcfSeat, []), {
     message: 'Expected must be an non-array object',
   });
@@ -512,7 +512,7 @@ test(`zcf/zoeHelper - assertProposalShape w/bad Expected`, async t => {
     { B: simoleanMint.mintPayment(simoleans(3)) },
   );
 
-  // @ts-ignore
+  // @ts-ignore invalid arguments for testing
   t.throws(() => assertProposalShape(zcfSeat, { give: { B: moola(3) } }), {
     message: `The value of the expected record must be null but was (an object)`,
   });

--- a/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
@@ -1,6 +1,7 @@
+// @ts-check
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env';
-import { E } from '@agoric/eventual-send';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 
@@ -16,16 +17,7 @@ import {
 } from '../../../src/contractSupport';
 import { assertPayoutAmount } from '../../zoeTestHelpers';
 import { setupZCFTest } from './setupZcfTest';
-
-const makeOffer = async (zoe, zcf, proposal, payments) => {
-  let zcfSeat;
-  const getSeat = seat => {
-    zcfSeat = seat;
-  };
-  const invitation = await zcf.makeInvitation(getSeat, 'seat');
-  const userSeat = await E(zoe).offer(invitation, proposal, payments);
-  return { zcfSeat, userSeat };
-};
+import { makeOffer } from '../makeOffer';
 
 test(`zoeHelper with zcf - swap`, async t => {
   const {
@@ -96,7 +88,7 @@ test(`zoeHelper with zcf - swap no match`, async t => {
     },
     'mismatched offers',
   );
-  assertPayoutAmount(t, moolaIssuer, await aUserSeat.getPayout('A'), moola(0));
+  assertPayoutAmount(t, moolaIssuer, await aUserSeat.getPayout('A'), moola(0n));
   const seat1PayoutB = await aUserSeat.getPayout('B');
   assertPayoutAmount(t, simoleanIssuer, seat1PayoutB, simoleans(3));
   const seat2PayoutB = await bUserSeat.getPayout('B');
@@ -152,7 +144,7 @@ test(`zcf saveAllIssuers - multiple`, async t => {
   const { issuer: dIssuer, brand: dBrand } = makeIssuerKit('doubloons');
   const { issuer: pIssuer, brand: pBrand } = makeIssuerKit(
     'pieces of eight',
-    MathKind.STRING_SET,
+    MathKind.SET,
   );
 
   await saveAllIssuers(zcf, { G: gIssuer, D: dIssuer, P: pIssuer });
@@ -184,7 +176,7 @@ test(`zcf saveAllIssuers - duplicate keyword`, async t => {
 
   const { issuer: pIssuer, brand: pBrand } = makeIssuerKit(
     'pieces of eight',
-    MathKind.STRING_SET,
+    MathKind.SET,
   );
 
   await t.notThrowsAsync(
@@ -282,6 +274,7 @@ test(`zoeHelper with zcf - assertProposalShape`, async t => {
     { B: simoleanMint.mintPayment(simoleans(3)) },
   );
 
+  // @ts-ignore
   t.throws(() => assertProposalShape(zcfSeat, []), {
     message: 'Expected must be an non-array object',
   });
@@ -357,7 +350,7 @@ test(`zoeHelper w/zcf - swapExact`, async t => {
     await userSeatB.getPayout('C'),
     simoleans(3),
   );
-  assertPayoutAmount(t, moolaIssuer, await userSeatB.getPayout('D'), moola(0));
+  assertPayoutAmount(t, moolaIssuer, await userSeatB.getPayout('D'), moola(0n));
   t.deepEqual(Object.getOwnPropertyNames(await userSeatB.getPayouts()), [
     'D',
     'C',
@@ -393,7 +386,7 @@ test(`zoeHelper w/zcf - swapExact w/shortage`, async t => {
     message: 'The reallocation failed to conserve rights.',
   });
   t.truthy(zcfSeatA.hasExited(), 'fail right');
-  assertPayoutAmount(t, moolaIssuer, await userSeatA.getPayout('A'), moola(0));
+  assertPayoutAmount(t, moolaIssuer, await userSeatA.getPayout('A'), moola(0n));
   assertPayoutAmount(
     t,
     simoleanIssuer,
@@ -439,7 +432,7 @@ test(`zoeHelper w/zcf - swapExact w/excess`, async t => {
     message: 'The reallocation failed to conserve rights.',
   });
   t.truthy(zcfSeatA.hasExited(), 'fail right');
-  assertPayoutAmount(t, moolaIssuer, await userSeatA.getPayout('A'), moola(0));
+  assertPayoutAmount(t, moolaIssuer, await userSeatA.getPayout('A'), moola(0n));
   assertPayoutAmount(
     t,
     simoleanIssuer,
@@ -519,6 +512,7 @@ test(`zcf/zoeHelper - assertProposalShape w/bad Expected`, async t => {
     { B: simoleanMint.mintPayment(simoleans(3)) },
   );
 
+  // @ts-ignore
   t.throws(() => assertProposalShape(zcfSeat, { give: { B: moola(3) } }), {
     message: `The value of the expected record must be null but was (an object)`,
   });

--- a/packages/zoe/test/zoeTestHelpers.js
+++ b/packages/zoe/test/zoeTestHelpers.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { E } from '@agoric/eventual-send';
 
 import '../exported';


### PR DESCRIPTION
This PR changes Zoe to use the new AmountMath. The old amountMath is still available for now from ERTP and Zoe, but is deprecated.

The AmountMath API changed. The parameters are reversed in `makeEmpty` and a new function `makeEmptyFromAmount` was added. 

I used type checking to look for places where the amountMath needed to be updated, so I made the type-checking more expansive and fixed a number of small problems. Soon, we should be able to typecheck all of the Zoe package.

Note: In the more expansive checking I was doing locally, typescript didn't like for a function property to have potentially undefined parameters, so those got moved out into callback definitions instead.

Closes #2600 

#documentation-branch: 2600-new-amount-math-zoe