### PR TITLE
Silence validator vats

### DIFF
--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -74,7 +74,8 @@
     ],
     "require": [
       "esm"
-    ]
+    ],
+    "timeout": "2m"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -146,8 +146,14 @@ export default function buildKernel(
   }
   harden(testLog);
 
-  function makeVatConsole(vatID) {
-    const origConsole = makeConsole(`${debugPrefix}SwingSet:${vatID}`);
+  function makeVatConsole(kind, vatID) {
+    const origConsole = makeConsole(`${debugPrefix}SwingSet:${kind}:${vatID}`);
+    if (kind === 'ls') {
+      // LiveSlots is not recorded to kernelSlog.
+      // The slog captures 1: what a vat is told to do, and
+      // 2: what a vat says about its activities
+      return origConsole;
+    }
     return kernelSlog.vatConsole(vatID, origConsole);
   }
 

--- a/packages/SwingSet/src/kernel/loadVat.js
+++ b/packages/SwingSet/src/kernel/loadVat.js
@@ -209,7 +209,8 @@ export function makeVatLoader(stuff) {
         enablePipelining,
         enableInternalMetering: !isDynamic,
         notifyTermination,
-        vatConsole: makeVatConsole(vatID),
+        vatConsole: makeVatConsole('vat', vatID),
+        liveSlotsConsole: makeVatConsole('ls', vatID),
         vatParameters,
         virtualObjectCacheSize,
       };

--- a/packages/SwingSet/src/kernel/vatManager/factory.js
+++ b/packages/SwingSet/src/kernel/vatManager/factory.js
@@ -59,6 +59,7 @@ export function makeVatManagerFactory({
       'metered',
       'enableSetup',
       'enableInternalMetering',
+      'liveSlotsConsole',
       'notifyTermination',
       'virtualObjectCacheSize',
       'vatParameters',

--- a/packages/SwingSet/src/kernel/vatManager/manager-local.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-local.js
@@ -88,6 +88,7 @@ export function makeLocalVatManagerFactory(tools) {
       enableInternalMetering = false,
       vatParameters = {},
       vatConsole,
+      liveSlotsConsole,
       virtualObjectCacheSize,
     } = managerOptions;
     assert(vatConsole, 'vats need managerOptions.vatConsole');
@@ -110,6 +111,7 @@ export function makeLocalVatManagerFactory(tools) {
       vatParameters,
       virtualObjectCacheSize,
       gcTools,
+      liveSlotsConsole,
     );
 
     let meterRecord = null;

--- a/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
+++ b/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
@@ -17,7 +17,7 @@ import { makeWithQueue } from './vats/queue';
 import { makeBatchedDeliver } from './batched-deliver';
 import { getMeterProvider } from '../kernel-stats';
 
-const log = anylogger('fake-chain');
+const console = anylogger('fake-chain');
 
 const PRETEND_BLOCK_DELAY = 5;
 const scaleBlockTime = ms => Math.floor(ms / 1000);
@@ -66,7 +66,7 @@ export async function connectToFakeChain(basedir, GCI, delay, inbound) {
     assert(!replay, X`Replay not implemented`);
   }
 
-  const meterProvider = getMeterProvider(log, process.env);
+  const meterProvider = getMeterProvider(console, process.env);
   const s = await launch(
     stateDBdir,
     mailboxStorage,
@@ -133,7 +133,7 @@ export async function connectToFakeChain(basedir, GCI, delay, inbound) {
       thisBlock = [];
       blockTime += scaleBlockTime(Date.now() - actualStart);
     } catch (e) {
-      log.error(`error fake processing`, e);
+      console.error(`error fake processing`, e);
     }
 
     clearTimeout(nextBlockTimeout);
@@ -148,7 +148,7 @@ export async function connectToFakeChain(basedir, GCI, delay, inbound) {
   let totalDeliveries = 0;
   async function deliver(newMessages, acknum) {
     totalDeliveries += 1;
-    console.log(`delivering to ${GCI} (trips=${totalDeliveries})`);
+    console.info(`delivering to ${GCI} (trips=${totalDeliveries})`);
 
     intoChain.push([newMessages, acknum]);
     if (!delay) {

--- a/packages/cosmic-swingset/lib/anylogger-agoric.js
+++ b/packages/cosmic-swingset/lib/anylogger-agoric.js
@@ -4,15 +4,24 @@ import anylogger from 'anylogger';
 // Turn on debugging output with DEBUG=agoric
 
 let debugging;
+const filterOutPrefixes = [];
 if (process.env.DEBUG === undefined) {
   // DEBUG not set, default to log level.
   debugging = 'log';
-} else if (process.env.DEBUG.includes('agoric')) {
-  // DEBUG set and we're enabled; verbose.
-  debugging = 'debug';
 } else {
-  // DEBUG set but we're not enabled; quieter than normal.
-  debugging = 'info';
+  if (!process.env.DEBUG.includes('SwingSet:vat')) {
+    filterOutPrefixes.push('SwingSet:vat:');
+  }
+  if (!process.env.DEBUG.includes('SwingSet:ls')) {
+    filterOutPrefixes.push('SwingSet:ls:');
+  }
+  if (process.env.DEBUG.includes('agoric')) {
+    // DEBUG set and we're enabled; verbose.
+    debugging = 'debug';
+  } else {
+    // DEBUG set but we're not enabled; quieter than normal.
+    debugging = 'info';
+  }
 }
 const defaultLevel = anylogger.levels[debugging];
 
@@ -22,8 +31,9 @@ anylogger.ext = (l, o) => {
   l.enabledFor = lvl => defaultLevel >= anylogger.levels[lvl];
 
   const prefix = l.name.replace(/:/g, ': ');
+  const filteredOut = filterOutPrefixes.find(pfx => l.name.startsWith(pfx));
   for (const [level, code] of Object.entries(anylogger.levels)) {
-    if (code > defaultLevel) {
+    if (filteredOut || code > defaultLevel) {
       // Disable printing.
       l[level] = () => {};
     } else {

--- a/packages/cosmic-swingset/lib/chain-entrypoint.js
+++ b/packages/cosmic-swingset/lib/chain-entrypoint.js
@@ -12,6 +12,11 @@ const agcc = require('@agoric/cosmos');
 // (dep chain: temp->glob->minimatch->brace-expansion)
 esmRequire('@agoric/install-metering-and-ses');
 
+if (!process.env.DEBUG) {
+  // By default, disable debugging.
+  process.env.DEBUG = '';
+}
+
 const path = require('path');
 const os = require('os');
 

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -551,7 +551,14 @@ const defaultSlotToValFn = (x, _) => x;
 export function makeMarshal(
   convertValToSlot = defaultValToSlotFn,
   convertSlotToVal = defaultSlotToValFn,
-  { marshalName = 'anon-marshal', errorTagging = 'on' } = {},
+  {
+    marshalName = 'anon-marshal',
+    errorTagging = 'on',
+    // We prefer that the caller instead log to somewhere hidden
+    // to be revealed when correlating with the received error.
+    marshalSaveError = err =>
+      console.log('Temporary logging of sent error', err),
+  } = {},
 ) {
   assert.typeof(marshalName, 'string');
   assert(
@@ -743,12 +750,7 @@ export function makeMarshal(
               if (errorTagging === 'on') {
                 const errorId = nextErrorId();
                 assert.note(val, X`Sent as ${errorId}`);
-                // TODO we need to instead log to somewhere hidden
-                // to be revealed when correlating with the received error.
-                // By sending this to `console.log`, under swingset this is
-                // enabled by `agoric start --reset -v` and not enabled without
-                // the `-v` flag.
-                console.log('Temporary logging of sent error', val);
+                marshalSaveError(val);
                 return harden({
                   [QCLASS]: 'error',
                   errorId,

--- a/packages/marshal/src/types.js
+++ b/packages/marshal/src/types.js
@@ -162,7 +162,8 @@
 /**
  * @typedef MakeMarshalOptions
  * @property {string=} marshalName
- * @property {('on'|'off')=} errorTagging
+ * @property {'on'|'off'=} errorTagging
+ * @property {(err: Error) => void=} marshalSaveError
  */
 
 // /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
We don't want to scare away validators with error messages that are unrelated to the correct functioning of their node.

So, we disable vats' and liveslots' `console.*` when running `ag-chain-cosmos start` unless `DEBUG=SwingSet:vat,SwingSet:ls`.  The current vat logging doesn't change for `agoric start` or for `ag-solo`.
