### PR TITLE
chore: some type fixes made when type checking Zoe

### DIFF
--- a/packages/SwingSet/src/kernel/virtualObjectManager.js
+++ b/packages/SwingSet/src/kernel/virtualObjectManager.js
@@ -397,11 +397,15 @@ export function makeVirtualObjectManager(
         for (const prop of Object.getOwnPropertyNames(innerSelf.rawData)) {
           Object.defineProperty(target, prop, {
             get: () => {
+              // TODO: ensureState has no arg
+              // @ts-ignore
               ensureState(innerSelf);
               return m.unserialize(innerSelf.rawData[prop]);
             },
             set: value => {
               const serializedValue = m.serialize(value);
+              // TODO: ensureState has no arg
+              // @ts-ignore
               ensureState(innerSelf);
               innerSelf.rawData[prop] = serializedValue;
               innerSelf.dirty = true;

--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -45,7 +45,7 @@
     "prettier": "^1.19.1",
     "rollup": "1.31.0",
     "rollup-plugin-terser": "^5.1.3",
-    "typescript": "^4.0.5"
+    "typescript": "^4.2.3"
   },
   "files": [
     "LICENSE*",

--- a/packages/marshal/src/types.js
+++ b/packages/marshal/src/types.js
@@ -146,8 +146,8 @@
 /**
  * @template Slot
  * @typedef Marshal
- * @property {Serialize} serialize
- * @property {Unserialize} unserialize
+ * @property {Serialize<Slot>} serialize
+ * @property {Unserialize<Slot>} unserialize
  */
 
 /**

--- a/packages/notifier/src/types.js
+++ b/packages/notifier/src/types.js
@@ -59,7 +59,7 @@
  */
 
 /**
- * @typedef NotifierInternals Purposely opaque. Will be shared between
+ * @typedef {any} NotifierInternals Purposely opaque. Will be shared between
  * machines, so it must be same to expose. But other software should avoid
  * depending on its internal structure.
  */
@@ -96,7 +96,7 @@
  */
 
 /**
- * @typedef SubscriptionInternals Purposely opaque. Will be shared between
+ * @typedef {any} SubscriptionInternals Purposely opaque. Will be shared between
  * machines, so it must be same to expose. But other software should avoid
  * depending on its internal structure.
  */

--- a/yarn.lock
+++ b/yarn.lock
@@ -10332,11 +10332,6 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
-  integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
-
 typescript@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"


### PR DESCRIPTION
When I turned on the full typechecking for Zoe, it found these errors in other packages, so I thought I would check in these fixes. 