### PR TITLE
chore: upgrade to Typescript 4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "packages/deploy-script-support"
   ],
   "devDependencies": {
-    "@typescript-eslint/parser": "^4.1.0",
+    "@typescript-eslint/parser": "^4.18.0",
     "ava": "^3.12.1",
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.0.0",
@@ -59,7 +59,7 @@
     "lerna": "^3.20.2",
     "nyc": "^15.1.0",
     "prettier": "^1.18.2",
-    "typescript": "~4.0.0"
+    "typescript": "^4.2.3"
   },
   "engines": {
     "node": ">=12.14.1"

--- a/packages/SwingSet/src/capdata.js
+++ b/packages/SwingSet/src/capdata.js
@@ -1,6 +1,6 @@
 import { assert, details as X } from '@agoric/assert';
 
-/* eslint-disable jsdoc/valid-types,jsdoc/require-returns-check */
+/* eslint-disable jsdoc/require-returns-check */
 /**
  * Assert function to ensure that something expected to be a capdata object
  * actually is.  A capdata object should have a .body property that's a string

--- a/packages/SwingSet/src/vats/network/router.js
+++ b/packages/SwingSet/src/vats/network/router.js
@@ -104,9 +104,7 @@ export function makeRouterProtocol(E = defaultE) {
     protocolHandlers.delete(prefix);
   }
 
-  /* eslint-disable jsdoc/valid-types */
   /** @type {Protocol['bind']} */
-  /* eslint-enable jsdoc/valid-types */
   async function bind(localAddr) {
     const [route] = router.getRoutes(localAddr);
     assert(

--- a/packages/SwingSet/src/vats/network/types.js
+++ b/packages/SwingSet/src/vats/network/types.js
@@ -18,7 +18,6 @@
  * @property {(prefix: Endpoint) => Promise<Port>} bind Claim a port, or if ending in ENDPOINT_SEPARATOR, a fresh name
  */
 
-/* eslint-disable jsdoc/valid-types */
 /**
  * @typedef {Object} Port A port that has been bound to a protocol
  * @property {() => Endpoint} getLocalAddress Get the locally bound name of this port
@@ -27,7 +26,6 @@
  * @property {(acceptHandler: ListenHandler) => Promise<void>} removeListener Remove the currently-bound listener
  * @property {() => void} revoke Deallocate the port entirely, removing all listeners and closing all active connections
  */
-/* eslint-enable jsdoc/valid-types */
 
 /**
  * @typedef {Object} ListenHandler A handler for incoming connections
@@ -47,7 +45,6 @@
  * @property {() => Endpoint} getRemoteAddress Get the name of the counterparty
  */
 
-/* eslint-disable jsdoc/valid-types */
 /**
  * @typedef {Object} ConnectionHandler A handler for a given Connection
  * @property {(connection: Connection, localAddr: Endpoint, remoteAddr: Endpoint, c: ConnectionHandler) => void} [onOpen] The connection has been opened
@@ -56,7 +53,6 @@
  *
  * @typedef {any?} CloseReason The reason a connection was closed
  */
-/* eslint-enable jsdoc/valid-types */
 
 /**
  * @typedef {Object} ProtocolHandler A handler for things the protocol implementation will invoke

--- a/packages/SwingSet/src/vats/plugin-manager.js
+++ b/packages/SwingSet/src/vats/plugin-manager.js
@@ -56,7 +56,6 @@ const DEFAULT_WALKER = Far('walker', { walk: pluginRootP => pluginRootP });
  * @property {() => string} getPluginDir
  */
 
-/* eslint-disable jsdoc/valid-types */
 /**
  * Create a handler that manages a promise interface to external modules.
  *
@@ -64,7 +63,6 @@ const DEFAULT_WALKER = Far('walker', { walk: pluginRootP => pluginRootP });
  * @param {{ [prop: string]: any, D: <T>(target: Device<T>) => T}} param1
  * @returns {PluginManager} admin facet for this handler
  */
-/* eslint-enable jsdoc/valid-types */
 export function makePluginManager(pluginDevice, { D, ...vatPowers }) {
   /**
    * @typedef {Object} AbortDispatch

--- a/packages/captp/lib/captp.js
+++ b/packages/captp/lib/captp.js
@@ -50,11 +50,7 @@ export function makeCapTP(ourId, rawSend, bootstrapObj = undefined, opts = {}) {
   /** @type {any} */
   let unplug = false;
   async function quietReject(reason = undefined, returnIt = true) {
-    if (
-      onReject &&
-      (unplug === false || reason !== unplug) &&
-      reason !== undefined
-    ) {
+    if ((unplug === false || reason !== unplug) && reason !== undefined) {
       onReject(reason);
     }
     if (!returnIt) {

--- a/packages/cosmic-swingset/lib/ag-solo/vats/bridge.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bridge.js
@@ -17,7 +17,6 @@ import { Far } from '@agoric/marshal';
  */
 
 /**
- *
  * @typedef {Object} BridgeHandler An object that can receive messages from the bridge device
  * @property {(srcId: string, obj: any) => Promise<void>} fromBridge Handle an inbound message
  *
@@ -27,7 +26,6 @@ import { Far } from '@agoric/marshal';
  * @property {(srcID: string, handler: BridgeHandler) => void} unregister
  */
 
-/* eslint-disable jsdoc/valid-types */
 /**
  * Create a handler that demuxes/muxes the bridge device by its first argument.
  *
@@ -36,7 +34,6 @@ import { Far } from '@agoric/marshal';
  * @param {Device<BridgeDevice>} bridgeDevice The bridge to manage
  * @returns {BridgeManager} admin facet for this handler
  */
-/* eslint-enable jsdoc/valid-types */
 export function makeBridgeManager(E, D, bridgeDevice) {
   /**
    * @type {Store<string, BridgeHandler>}

--- a/packages/cosmic-swingset/lib/ag-solo/vats/ui-agent.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/ui-agent.js
@@ -10,14 +10,12 @@
  * @property {typeof console} console
  */
 
-/* eslint-disable jsdoc/valid-types */
 /**
  * Create a set of UI agent makers.
  *
  * @param {UIAgentEndowments} param0
  * @returns {{[maker: string]: (petname: string, ext = {}) => UIAgent}}
  */
-/* eslint-enable jsdoc/valid-types */
 export default function makeAgentMakers({ console: agentConsole }) {
   return harden({
     /**

--- a/packages/dapp-svelte-wallet/api/src/internal-types.js
+++ b/packages/dapp-svelte-wallet/api/src/internal-types.js
@@ -79,7 +79,6 @@
  * @property {() => Promise<boolean>} getAmountOf
  */
 
-/* eslint-disable jsdoc/valid-types */
 /**
  * We obtain the WalletAdminFacet from its implementation.  Ideally this facet
  * would not be necessary.  Once we have clarified and standardized its APIs we

--- a/packages/dapp-svelte-wallet/api/src/lib-dehydrate.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-dehydrate.js
@@ -4,14 +4,12 @@ import { makeMarshal } from '@agoric/marshal';
 import makeStore from '@agoric/store';
 import { assert, details as X, q } from '@agoric/assert';
 
-/* eslint-disable jsdoc/valid-types */
 /**
  * @typedef {string[]} Path
  * @typedef {{} & 'Strongname'} Strongname
  * @param {any} x
  * @returns {x is Path}
  */
-/* eslint-enable jsdoc/valid-types */
 export const isPath = x => {
   if (!Array.isArray(x)) {
     return false;

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@agoric/eslint-plugin": "^0.2.0",
-    "@typescript-eslint/parser": "^4.1.0",
+    "@typescript-eslint/parser": "^4.18.0",
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-config-jessie": "^0.0.4",

--- a/packages/promise-kit/src/promiseKit.js
+++ b/packages/promise-kit/src/promiseKit.js
@@ -68,14 +68,12 @@ export function makePromiseKit() {
 }
 harden(makePromiseKit);
 
-/* eslint-disable jsdoc/valid-types */
 /**
  * Determine if the argument is a Promise.
  *
  * @param {any} maybePromise The value to examine
  * @returns {maybePromise is Promise} Whether it is a promise
  */
-/* eslint-enable jsdoc/valid-types */
 export function isPromise(maybePromise) {
   return Promise.resolve(maybePromise) === maybePromise;
 }

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -270,14 +270,12 @@ export const swapExact = (
   return defaultAcceptanceMsg;
 };
 
-/* eslint-disable jsdoc/valid-types */
 /**
  * @typedef ExpectedRecord
  * @property {Record<Keyword, null>} [want]
  * @property {Record<Keyword, null>} [give]
  * @property {Partial<Record<keyof ProposalRecord['exit'], null>>} [exit]
  */
-/* eslint-enable jsdoc/valid-types */
 
 /**
  * Check the seat's proposal against an `expected` record that says

--- a/packages/zoe/src/objArrayConversion.js
+++ b/packages/zoe/src/objArrayConversion.js
@@ -81,12 +81,12 @@ export const assertSubset = (whole, part) => {
  *
  * @template T, U
  * @template {keyof T} K
- * @param {Record<K, T>} original
- * @param {(pair: [K, T]) => [K, U]} mapPairFn
+ * @param {{ [K2 in keyof T]: T[K2] }} original
+ * @param {(pair: [K, T[K]]) => [K, U]} mapPairFn
  * @returns {Record<K, U>}
  */
 export const objectMap = (original, mapPairFn) => {
-  const ents = /** @type {[K, T][]} */ (Object.entries(original));
+  const ents = /** @type {[K, T[K]][]} */ (Object.entries(original));
   const mapEnts = ents.map(ent => mapPairFn(ent));
   return /** @type {Record<K, U>} */ (Data(Object.fromEntries(mapEnts)));
 };

--- a/packages/zoe/src/types.js
+++ b/packages/zoe/src/types.js
@@ -1,7 +1,6 @@
 // eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
-// eslint-disable-next-line jsdoc/valid-types
 /**
  * @template {string} H - the name of the handle
  * @typedef {H & {}} Handle A type constructor for an opaque type
@@ -15,7 +14,7 @@
  * @typedef {Handle<'Invitation'>} InvitationHandle - an opaque handle for an invitation
  * @typedef {Record<Keyword,Issuer>} IssuerKeywordRecord
  * @typedef {Record<Keyword,Brand>} BrandKeywordRecord
- * @typedef {Record<Keyword, DeprecatedAmountMath} DeprecatedAmountMathKeywordRecord
+ * @typedef {Record<Keyword, DeprecatedAmountMath>} DeprecatedAmountMathKeywordRecord
  */
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1572,49 +1572,48 @@
   dependencies:
     "@types/node" "*"
 
-"@typescript-eslint/parser@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.1.0.tgz#9b0409411725f14cd7faa81a664e5051225961db"
-  integrity sha512-hM/WNCQTzDHgS0Ke3cR9zPndL3OTKr9OoN9CL3UqulsAjYDrglSwIIgswSmHBcSbOzLmgaMARwrQEbIumIglvQ==
+"@typescript-eslint/parser@^4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.18.0.tgz#a211edb14a69fc5177054bec04c95b185b4dde21"
+  integrity sha512-W3z5S0ZbecwX3PhJEAnq4mnjK5JJXvXUDBYIYGoweCyWyuvAKfGHvzmpUzgB5L4cRBb+cTu9U/ro66dx7dIimA==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.1.0"
-    "@typescript-eslint/types" "4.1.0"
-    "@typescript-eslint/typescript-estree" "4.1.0"
+    "@typescript-eslint/scope-manager" "4.18.0"
+    "@typescript-eslint/types" "4.18.0"
+    "@typescript-eslint/typescript-estree" "4.18.0"
     debug "^4.1.1"
 
-"@typescript-eslint/scope-manager@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.1.0.tgz#9e389745ee9cfe12252ed1e9958808abd6b3a683"
-  integrity sha512-HD1/u8vFNnxwiHqlWKC/Pigdn0Mvxi84Y6GzbZ5f5sbLrFKu0al02573Er+D63Sw67IffVUXR0uR8rpdfdk+vA==
+"@typescript-eslint/scope-manager@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.18.0.tgz#d75b55234c35d2ff6ac945758d6d9e53be84a427"
+  integrity sha512-olX4yN6rvHR2eyFOcb6E4vmhDPsfdMyfQ3qR+oQNkAv8emKKlfxTWUXU5Mqxs2Fwe3Pf1BoPvrwZtwngxDzYzQ==
   dependencies:
-    "@typescript-eslint/types" "4.1.0"
-    "@typescript-eslint/visitor-keys" "4.1.0"
+    "@typescript-eslint/types" "4.18.0"
+    "@typescript-eslint/visitor-keys" "4.18.0"
 
-"@typescript-eslint/types@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.1.0.tgz#edbd3fec346f34e13ce7aa176b03b497a32c496a"
-  integrity sha512-rkBqWsO7m01XckP9R2YHVN8mySOKKY2cophGM8K5uDK89ArCgahItQYdbg/3n8xMxzu2elss+an1TphlUpDuJw==
+"@typescript-eslint/types@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.18.0.tgz#bebe323f81f2a7e2e320fac9415e60856267584a"
+  integrity sha512-/BRociARpj5E+9yQ7cwCF/SNOWwXJ3qhjurMuK2hIFUbr9vTuDeu476Zpu+ptxY2kSxUHDGLLKy+qGq2sOg37A==
 
-"@typescript-eslint/typescript-estree@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.1.0.tgz#394046ead25164494218c0e3d6b960695ea967f6"
-  integrity sha512-r6et57qqKAWU173nWyw31x7OfgmKfMEcjJl9vlJEzS+kf9uKNRr4AVTRXfTCwebr7bdiVEkfRY5xGnpPaNPe4Q==
+"@typescript-eslint/typescript-estree@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.18.0.tgz#756d3e61da8c16ab99185532c44872f4cd5538cb"
+  integrity sha512-wt4xvF6vvJI7epz+rEqxmoNQ4ZADArGQO9gDU+cM0U5fdVv7N+IAuVoVAoZSOZxzGHBfvE3XQMLdy+scsqFfeg==
   dependencies:
-    "@typescript-eslint/types" "4.1.0"
-    "@typescript-eslint/visitor-keys" "4.1.0"
+    "@typescript-eslint/types" "4.18.0"
+    "@typescript-eslint/visitor-keys" "4.18.0"
     debug "^4.1.1"
     globby "^11.0.1"
     is-glob "^4.0.1"
-    lodash "^4.17.15"
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/visitor-keys@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.1.0.tgz#b2d528c9484e7eda1aa4f86ccf0432fb16e4d545"
-  integrity sha512-+taO0IZGCtCEsuNTTF2Q/5o8+fHrlml8i9YsZt2AiDCdYEJzYlsmRY991l/6f3jNXFyAWepdQj7n8Na6URiDRQ==
+"@typescript-eslint/visitor-keys@4.18.0":
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.18.0.tgz#4e6fe2a175ee33418318a029610845a81e2ff7b6"
+  integrity sha512-Q9t90JCvfYaN0OfFUgaLqByOfz8yPeTAdotn/XYNm5q9eHax90gzdb+RJ6E9T5s97Kv/UHWKERTmqA0jTKAEHw==
   dependencies:
-    "@typescript-eslint/types" "4.1.0"
+    "@typescript-eslint/types" "4.18.0"
     eslint-visitor-keys "^2.0.0"
 
 "@yarnpkg/lockfile@^1.1.0":
@@ -10333,10 +10332,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.0.5, typescript@~4.0.0:
+typescript@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
   integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
+
+typescript@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
+  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
 
 uglify-js@^3.1.4:
   version "3.8.0"


### PR DESCRIPTION
Remove many extraneous eslint-ignores since our eslint-config
package already accommodates.

For @warner to use with `WeakRef`.
