### PR TITLE
refactor dispatch to be a function, not an object

### DIFF
--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -58,7 +58,6 @@ export async function makeSwingsetController(
     debugPrefix = '',
     slogCallbacks,
     slogFile,
-    testTrackDecref,
     defaultManagerType = env.WORKER_TYPE || 'local',
   } = runtimeOptions;
   if (typeof Compartment === 'undefined') {
@@ -230,7 +229,7 @@ export async function makeSwingsetController(
     FinalizationRegistry,
   };
 
-  const kernelOptions = { verbose, testTrackDecref, defaultManagerType };
+  const kernelOptions = { verbose, defaultManagerType };
   const kernel = buildKernel(kernelEndowments, deviceEndowments, kernelOptions);
 
   if (runtimeOptions.verbose) {
@@ -323,13 +322,11 @@ export async function buildVatController(
     kernelBundles,
     debugPrefix,
     slogCallbacks,
-    testTrackDecref,
     defaultManagerType,
   } = runtimeOptions;
   const actualRuntimeOptions = {
     verbose,
     debugPrefix,
-    testTrackDecref,
     slogCallbacks,
     defaultManagerType,
   };

--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -29,7 +29,7 @@ const DEFAULT_VIRTUAL_OBJECT_CACHE_SIZE = 3; // XXX ridiculously small value to 
  * @param {boolean} enableDisavow
  * @param {*} vatPowers
  * @param {*} vatParameters
- * @param {*} gcTools { WeakRef, FinalizationRegistry, vatDecref }
+ * @param {*} gcTools { WeakRef, FinalizationRegistry }
  * @param {Console} console
  * @returns {*} { vatGlobals, dispatch, setBuildRootObject }
  *

--- a/packages/SwingSet/src/kernel/vatManager/factory.js
+++ b/packages/SwingSet/src/kernel/vatManager/factory.js
@@ -32,14 +32,12 @@ export function makeVatManagerFactory({
     makeNodeWorker,
     kernelKeeper,
     testLog: allVatPowers.testLog,
-    decref: gcTools.decref,
   });
 
   const nodeSubprocessFactory = makeNodeSubprocessFactory({
     startSubprocessWorker: startSubprocessWorkerNode,
     kernelKeeper,
     testLog: allVatPowers.testLog,
-    decref: gcTools.decref,
   });
 
   const xsWorkerFactory = makeXsSubprocessFactory({
@@ -47,7 +45,6 @@ export function makeVatManagerFactory({
     kernelKeeper,
     allVatPowers,
     testLog: allVatPowers.testLog,
-    decref: gcTools.decref,
   });
 
   function validateManagerOptions(managerOptions) {

--- a/packages/SwingSet/src/kernel/vatManager/manager-local.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-local.js
@@ -32,9 +32,10 @@ export function makeLocalVatManagerFactory(tools) {
     const transcriptManager = makeTranscriptManager(vatKeeper, vatID);
     const { syscall, setVatSyscallHandler } = createSyscall(transcriptManager);
     function finish(dispatch, meterRecord) {
-      assert(
-        dispatch && dispatch.deliver,
-        `vat failed to return a 'dispatch' with .deliver: ${dispatch}`,
+      assert.equal(
+        typeof dispatch,
+        'function',
+        `vat failed to return a 'dispatch' function: ${dispatch}`,
       );
       const { deliver, replayTranscript } = makeDeliver(
         {

--- a/packages/SwingSet/src/kernel/vatManager/manager-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-nodeworker.js
@@ -107,8 +107,8 @@ export function makeNodeWorkerVatManagerFactory(tools) {
         if (waiting) {
           const resolve = waiting;
           waiting = null;
-          const deliveryResult = args;
-          resolve(deliveryResult);
+          const [vatDeliveryResults] = args;
+          resolve(vatDeliveryResults);
         }
       } else {
         parentLog(`unrecognized uplink message ${type}`);

--- a/packages/SwingSet/src/kernel/vatManager/manager-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-nodeworker.js
@@ -98,7 +98,7 @@ export function makeNodeWorkerVatManagerFactory(tools) {
         dispatchIsReady();
       } else if (type === 'syscall') {
         parentLog(`syscall`, args);
-        const vatSyscallObject = args;
+        const [vatSyscallObject] = args;
         handleSyscall(vatSyscallObject);
       } else if (type === 'testLog') {
         testLog(...args);

--- a/packages/SwingSet/src/kernel/vatManager/manager-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-nodeworker.js
@@ -132,9 +132,13 @@ export function makeNodeWorkerVatManagerFactory(tools) {
       parentLog(`sending delivery`, vatDeliveryObject);
       assert(!waiting, X`already waiting for delivery`);
       const pr = makePromiseKit();
+      transcriptManager.startDispatch(vatDeliveryObject);
       waiting = pr.resolve;
       sendToWorker(['deliver', vatDeliveryObject]);
-      return pr.promise;
+      return pr.promise.then(vatDeliveryResults => {
+        transcriptManager.finishDispatch();
+        return vatDeliveryResults;
+      });
     }
 
     async function replayTranscript() {

--- a/packages/SwingSet/src/kernel/vatManager/manager-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-nodeworker.js
@@ -23,7 +23,7 @@ function parentLog(first, ...args) {
 }
 
 export function makeNodeWorkerVatManagerFactory(tools) {
-  const { makeNodeWorker, kernelKeeper, testLog, decref } = tools;
+  const { makeNodeWorker, kernelKeeper, testLog } = tools;
 
   function createFromBundle(vatID, bundle, managerOptions) {
     const {
@@ -71,10 +71,6 @@ export function makeNodeWorkerVatManagerFactory(tools) {
       doSyscall(vatSyscallObject);
     }
 
-    function vatDecref(vref, count) {
-      decref(vatID, vref, count);
-    }
-
     // start the worker and establish a connection
 
     const { promise: workerP, resolve: gotWorker } = makePromiseKit();
@@ -114,9 +110,6 @@ export function makeNodeWorkerVatManagerFactory(tools) {
           const deliveryResult = args;
           resolve(deliveryResult);
         }
-      } else if (type === 'decref') {
-        const [vref, count] = args;
-        vatDecref(vref, count);
       } else {
         parentLog(`unrecognized uplink message ${type}`);
       }

--- a/packages/SwingSet/src/kernel/vatManager/manager-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-nodeworker.js
@@ -128,12 +128,12 @@ export function makeNodeWorkerVatManagerFactory(tools) {
       enableDisavow,
     ]);
 
-    function deliver(delivery) {
-      parentLog(`sending delivery`, delivery);
+    function deliver(vatDeliveryObject) {
+      parentLog(`sending delivery`, vatDeliveryObject);
       assert(!waiting, X`already waiting for delivery`);
       const pr = makePromiseKit();
       waiting = pr.resolve;
-      sendToWorker(['deliver', ...delivery]);
+      sendToWorker(['deliver', vatDeliveryObject]);
       return pr.promise;
     }
 

--- a/packages/SwingSet/src/kernel/vatManager/manager-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-subprocess-node.js
@@ -24,7 +24,7 @@ function parentLog(first, ...args) {
 }
 
 export function makeNodeSubprocessFactory(tools) {
-  const { startSubprocessWorker, kernelKeeper, testLog, decref } = tools;
+  const { startSubprocessWorker, kernelKeeper, testLog } = tools;
 
   function createFromBundle(vatID, bundle, managerOptions) {
     const {
@@ -74,10 +74,6 @@ export function makeNodeSubprocessFactory(tools) {
       doSyscall(vatSyscallObject);
     }
 
-    function vatDecref(vref, count) {
-      decref(vatID, vref, count);
-    }
-
     // start the worker and establish a connection
     const { fromChild, toChild, terminate, done } = startSubprocessWorker();
 
@@ -116,9 +112,6 @@ export function makeNodeSubprocessFactory(tools) {
           const deliveryResult = args;
           resolve(deliveryResult);
         }
-      } else if (type === 'decref') {
-        const [vref, count] = args;
-        vatDecref(vref, count);
       } else {
         parentLog(`unrecognized uplink message ${type}`);
       }

--- a/packages/SwingSet/src/kernel/vatManager/manager-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-subprocess-node.js
@@ -109,8 +109,8 @@ export function makeNodeSubprocessFactory(tools) {
         if (waiting) {
           const resolve = waiting;
           waiting = null;
-          const deliveryResult = args;
-          resolve(deliveryResult);
+          const [vatDeliveryResults] = args;
+          resolve(vatDeliveryResults);
         }
       } else {
         parentLog(`unrecognized uplink message ${type}`);

--- a/packages/SwingSet/src/kernel/vatManager/manager-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-subprocess-node.js
@@ -128,12 +128,12 @@ export function makeNodeSubprocessFactory(tools) {
       enableDisavow,
     ]);
 
-    function deliver(delivery) {
-      parentLog(`sending delivery`, delivery);
+    function deliver(vatDeliveryObject) {
+      parentLog(`sending delivery`, vatDeliveryObject);
       assert(!waiting, X`already waiting for delivery`);
       const pr = makePromiseKit();
       waiting = pr.resolve;
-      sendToWorker(['deliver', ...delivery]);
+      sendToWorker(['deliver', vatDeliveryObject]);
       return pr.promise;
     }
 

--- a/packages/SwingSet/src/kernel/vatManager/manager-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-subprocess-node.js
@@ -132,9 +132,13 @@ export function makeNodeSubprocessFactory(tools) {
       parentLog(`sending delivery`, vatDeliveryObject);
       assert(!waiting, X`already waiting for delivery`);
       const pr = makePromiseKit();
+      transcriptManager.startDispatch(vatDeliveryObject);
       waiting = pr.resolve;
       sendToWorker(['deliver', vatDeliveryObject]);
-      return pr.promise;
+      return pr.promise.then(vatDeliveryResults => {
+        transcriptManager.finishDispatch();
+        return vatDeliveryResults;
+      });
     }
 
     async function replayTranscript() {

--- a/packages/SwingSet/src/kernel/vatManager/manager-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-subprocess-node.js
@@ -100,7 +100,7 @@ export function makeNodeSubprocessFactory(tools) {
         dispatchIsReady();
       } else if (type === 'syscall') {
         parentLog(`syscall`, args);
-        const vatSyscallObject = args;
+        const [vatSyscallObject] = args;
         handleSyscall(vatSyscallObject);
       } else if (type === 'testLog') {
         testLog(...args);

--- a/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
@@ -20,7 +20,6 @@ const decoder = new TextDecoder();
  *   kernelKeeper: KernelKeeper,
  *   startXSnap: (name: string, handleCommand: SyncHandler) => { worker: XSnap, bundles: Record<string, ExportBundle> },
  *   testLog: (...args: unknown[]) => void,
- *   decref: (vatID: unknown, vref: unknown, count: number) => void,
  * }} tools
  * @returns { VatManagerFactory }
  *
@@ -35,7 +34,6 @@ export function makeXsSubprocessFactory({
   kernelKeeper,
   startXSnap,
   testLog,
-  decref,
 }) {
   /**
    * @param { unknown } vatID
@@ -72,11 +70,6 @@ export function makeXsSubprocessFactory({
       return doSyscall(vatSyscallObject);
     }
 
-    /** @type { (vref: unknown, count: number) => void } */
-    function vatDecref(vref, count) {
-      decref(vatID, vref, count);
-    }
-
     /** @type { (item: Tagged) => unknown } */
     function handleUpstream([type, ...args]) {
       parentLog(vatID, `handleUpstream`, type, args.length);
@@ -98,12 +91,6 @@ export function makeXsSubprocessFactory({
         case 'testLog':
           testLog(...args);
           return ['OK'];
-        case 'decref': {
-          const [vref, count] = args;
-          assert(typeof count === 'number');
-          vatDecref(vref, count);
-          return ['OK'];
-        }
         case 'transformTildot': {
           const [extjs] = args;
           try {

--- a/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
@@ -152,11 +152,11 @@ export function makeXsSubprocessFactory({
       assert.fail(X`failed to setBundle: ${bundleReply}`);
     }
 
-    /** @type { (item: Tagged) => Promise<Tagged> } */
-    async function deliver(delivery) {
-      parentLog(vatID, `sending delivery`, delivery);
-      transcriptManager.startDispatch(delivery);
-      const result = await issueTagged(['deliver', ...delivery]);
+    /** @type { (delivery: VatDeliveryObject) => Promise<Tagged> } */
+    async function deliver(vatDeliveryObject) {
+      parentLog(vatID, `sending delivery`, vatDeliveryObject);
+      transcriptManager.startDispatch(vatDeliveryObject);
+      const result = await issueTagged(['deliver', vatDeliveryObject]);
       parentLog(vatID, `deliverDone`, result.reply[0], result.reply.length);
       transcriptManager.finishDispatch();
 

--- a/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
@@ -76,8 +76,11 @@ export function makeXsSubprocessFactory({
       switch (type) {
         case 'syscall': {
           parentLog(vatID, `syscall`, args[0], args.length);
-          const [scTag, ...vatSyscallArgs] = args;
-          return handleSyscall([scTag, ...vatSyscallArgs]);
+          assert(Array.isArray(args[0]));
+          const [scTag, ...vatSyscallArgs] = args[0];
+          /** @type { Tagged } */
+          const vatSyscallObject = [scTag, ...vatSyscallArgs];
+          return handleSyscall(vatSyscallObject);
         }
         case 'console': {
           const [level, tag, ...rest] = args;

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-nodeworker.js
@@ -143,7 +143,7 @@ parentPort.on('message', ([type, ...margs]) => {
       workerLog(`error: deliver before dispatchReady`);
       return;
     }
-    const [dtype, ...dargs] = margs;
+    const [[dtype, ...dargs]] = margs;
     if (dtype === 'message') {
       doMessage(...dargs).then(res => sendUplink(['deliverDone', ...res]));
     } else if (dtype === 'notify') {

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-nodeworker.js
@@ -88,7 +88,7 @@ parentPort.on('message', ([type, ...margs]) => {
     }
 
     function doSyscall(vatSyscallObject) {
-      sendUplink(['syscall', ...vatSyscallObject]);
+      sendUplink(['syscall', vatSyscallObject]);
     }
     const syscall = harden({
       send: (...args) => doSyscall(['send', ...args]),

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-nodeworker.js
@@ -10,6 +10,7 @@ import { makeMarshal } from '@agoric/marshal';
 import { WeakRef, FinalizationRegistry } from '../../weakref';
 import { waitUntilQuiescent } from '../../waitUntilQuiescent';
 import { makeLiveSlots } from '../liveSlots';
+import { summarizeDelivery } from './deliver';
 
 // eslint-disable-next-line no-unused-vars
 function workerLog(first, ...args) {
@@ -41,32 +42,13 @@ function sendUplink(msg) {
 
 let dispatch;
 
-async function doProcess(dispatchRecord, errmsg) {
-  const dispatchOp = dispatchRecord[0];
-  const dispatchArgs = dispatchRecord.slice(1);
+async function deliver(vatDeliveryObject) {
   workerLog(`runAndWait`);
-  await runAndWait(() => dispatch[dispatchOp](...dispatchArgs), errmsg);
+  const errmsg = summarizeDelivery(vatDeliveryObject);
+  await runAndWait(() => dispatch(vatDeliveryObject), errmsg);
   workerLog(`doProcess done`);
   const vatDeliveryResults = harden(['ok']);
   return vatDeliveryResults;
-}
-
-function doMessage(targetSlot, msg) {
-  const errmsg = `vat[${targetSlot}].${msg.method} dispatch failed`;
-  return doProcess(
-    ['deliver', targetSlot, msg.method, msg.args, msg.result],
-    errmsg,
-  );
-}
-
-function doNotify(resolutions) {
-  const errmsg = `vat.notify failed`;
-  return doProcess(['notify', resolutions], errmsg);
-}
-
-function doDropExports(vrefs) {
-  const errmsg = `vat.doDropExport failed`;
-  return doProcess(['dropExports', vrefs], errmsg);
 }
 
 parentPort.on('message', ([type, ...margs]) => {
@@ -143,22 +125,10 @@ parentPort.on('message', ([type, ...margs]) => {
       workerLog(`error: deliver before dispatchReady`);
       return;
     }
-    const [[dtype, ...dargs]] = margs;
-    if (dtype === 'message') {
-      doMessage(...dargs).then(vatDeliveryResults =>
-        sendUplink(['deliverDone', vatDeliveryResults]),
-      );
-    } else if (dtype === 'notify') {
-      doNotify(...dargs).then(vatDeliveryResults =>
-        sendUplink(['deliverDone', vatDeliveryResults]),
-      );
-    } else if (dtype === 'dropExports') {
-      doDropExports(...dargs).then(vatDeliveryResults =>
-        sendUplink(['deliverDone', vatDeliveryResults]),
-      );
-    } else {
-      assert.fail(X`bad delivery type ${dtype}`);
-    }
+    const [vatDeliveryObject] = margs;
+    deliver(vatDeliveryObject).then(vatDeliveryResults =>
+      sendUplink(['deliverDone', vatDeliveryResults]),
+    );
   } else {
     workerLog(`unrecognized downlink message ${type}`);
   }

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-nodeworker.js
@@ -145,11 +145,17 @@ parentPort.on('message', ([type, ...margs]) => {
     }
     const [[dtype, ...dargs]] = margs;
     if (dtype === 'message') {
-      doMessage(...dargs).then(res => sendUplink(['deliverDone', ...res]));
+      doMessage(...dargs).then(vatDeliveryResults =>
+        sendUplink(['deliverDone', vatDeliveryResults]),
+      );
     } else if (dtype === 'notify') {
-      doNotify(...dargs).then(res => sendUplink(['deliverDone', ...res]));
+      doNotify(...dargs).then(vatDeliveryResults =>
+        sendUplink(['deliverDone', vatDeliveryResults]),
+      );
     } else if (dtype === 'dropExports') {
-      doDropExports(...dargs).then(res => sendUplink(['deliverDone', ...res]));
+      doDropExports(...dargs).then(vatDeliveryResults =>
+        sendUplink(['deliverDone', vatDeliveryResults]),
+      );
     } else {
       assert.fail(X`bad delivery type ${dtype}`);
     }

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-node.js
@@ -163,7 +163,7 @@ fromParent.on('data', ([type, ...margs]) => {
       workerLog(`error: deliver before dispatchReady`);
       return;
     }
-    const [dtype, ...dargs] = margs;
+    const [[dtype, ...dargs]] = margs;
     if (dtype === 'message') {
       doMessage(...dargs).then(res => sendUplink(['deliverDone', ...res]));
     } else if (dtype === 'notify') {

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-node.js
@@ -165,11 +165,17 @@ fromParent.on('data', ([type, ...margs]) => {
     }
     const [[dtype, ...dargs]] = margs;
     if (dtype === 'message') {
-      doMessage(...dargs).then(res => sendUplink(['deliverDone', ...res]));
+      doMessage(...dargs).then(vatDeliveryResults =>
+        sendUplink(['deliverDone', vatDeliveryResults]),
+      );
     } else if (dtype === 'notify') {
-      doNotify(...dargs).then(res => sendUplink(['deliverDone', ...res]));
+      doNotify(...dargs).then(vatDeliveryResults =>
+        sendUplink(['deliverDone', vatDeliveryResults]),
+      );
     } else if (dtype === 'dropExports') {
-      doDropExports(...dargs).then(res => sendUplink(['deliverDone', ...res]));
+      doDropExports(...dargs).then(vatDeliveryResults =>
+        sendUplink(['deliverDone', vatDeliveryResults]),
+      );
     } else {
       assert.fail(X`bad delivery type ${dtype}`);
     }

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-node.js
@@ -108,7 +108,7 @@ fromParent.on('data', ([type, ...margs]) => {
     }
 
     function doSyscall(vatSyscallObject) {
-      sendUplink(['syscall', ...vatSyscallObject]);
+      sendUplink(['syscall', vatSyscallObject]);
     }
     const syscall = harden({
       send: (...args) => doSyscall(['send', ...args]),

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
@@ -199,10 +199,10 @@ function makeWorker(port) {
     virtualObjectCacheSize,
     enableDisavow,
   ) {
-    /** @type { (item: Tagged) => unknown } */
+    /** @type { (vso: Tagged) => unknown } */
     function doSyscall(vatSyscallObject) {
       workerLog('doSyscall', vatSyscallObject);
-      const result = port.call(['syscall', ...vatSyscallObject]);
+      const result = port.call(['syscall', vatSyscallObject]);
       workerLog(' ... syscall result:', result);
       return result;
     }

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
@@ -277,7 +277,8 @@ function makeWorker(port) {
       }
       case 'deliver': {
         assert(dispatch, 'cannot deliver before setBundle');
-        const [dtype, ...dargs] = args;
+        assert(Array.isArray(args[0]));
+        const [[dtype, ...dargs]] = args;
         switch (dtype) {
           case 'message':
             return doMessage(dargs[0], dargs[1]);

--- a/packages/SwingSet/src/message.js
+++ b/packages/SwingSet/src/message.js
@@ -7,12 +7,12 @@ import { insistCapData } from './capdata';
  * string, a .args property that's a capdata object, and optionally a .result
  * property that, if present, must be a string.
  *
- * @param {any} message  The object to be tested
+ * @param {unknown} message  The object to be tested
  *
  * @throws {Error} if, upon inspection, the parameter does not satisfy the above
  *   criteria.
  *
- * @returns {void}
+ * @returns { asserts message is Message }
  */
 export function insistMessage(message) {
   assert.typeof(
@@ -28,4 +28,110 @@ export function insistMessage(message) {
       X`message has non-string non-null .result ${message.result}`,
     );
   }
+  return undefined;
+}
+
+/**
+ * @param {unknown} vdo
+ * @returns { asserts vdo is VatDeliveryObject }
+ */
+export function insistVatDeliveryObject(vdo) {
+  assert(Array.isArray(vdo));
+  const [type, ...rest] = vdo;
+  switch (type) {
+    case 'message': {
+      const [target, msg] = rest;
+      assert.typeof(target, 'string');
+      insistMessage(msg);
+      break;
+    }
+    case 'notify': {
+      const [resolutions] = rest;
+      assert(Array.isArray(resolutions));
+      for (const [vpid, rejected, data] of resolutions) {
+        assert.typeof(vpid, 'string');
+        assert.typeof(rejected, 'boolean');
+        insistCapData(data);
+      }
+      break;
+    }
+    case 'dropExports': {
+      const [slots] = rest;
+      assert(Array.isArray(slots));
+      for (const slot of slots) {
+        assert.typeof(slot, 'string');
+      }
+      break;
+    }
+    default:
+      assert.fail(`unknown syscall type ${type}`);
+  }
+  return undefined;
+}
+
+/**
+ *
+ * @param {unknown} vso
+ * @returns { asserts vso is VatSyscallObject }
+ */
+export function insistVatSyscallObject(vso) {
+  assert(Array.isArray(vso));
+  const [type, ...rest] = vso;
+  switch (type) {
+    case 'send': {
+      const [target, msg] = rest;
+      assert.typeof(target, 'string');
+      insistMessage(msg);
+      break;
+    }
+    case 'callNow': {
+      const [target, method, args] = rest;
+      assert.typeof(target, 'string');
+      assert.typeof(method, 'string');
+      insistCapData(args);
+      break;
+    }
+    case 'subscribe': {
+      const [vpid] = rest;
+      assert.typeof(vpid, 'string');
+      break;
+    }
+    case 'resolve': {
+      const [resolutions] = rest;
+      assert(Array.isArray(resolutions));
+      for (const [vpid, rejected, data] of resolutions) {
+        assert.typeof(vpid, 'string');
+        assert.typeof(rejected, 'boolean');
+        insistCapData(data);
+      }
+      break;
+    }
+    case 'vatstoreGet': {
+      const [key] = rest;
+      assert.typeof(key, 'string');
+      break;
+    }
+    case 'vatstoreSet': {
+      const [key, data] = rest;
+      assert.typeof(key, 'string');
+      assert.typeof(data, 'string');
+      break;
+    }
+    case 'vatstoreDelete': {
+      const [key] = rest;
+      assert.typeof(key, 'string');
+      break;
+    }
+    case 'dropImports': {
+      const [slots] = rest;
+      assert(Array.isArray(slots));
+      for (const slot of slots) {
+        assert.typeof(slot, 'string');
+      }
+      break;
+    }
+    default:
+      assert.fail(`unknown syscall type ${type}`);
+  }
+  return undefined;
 }

--- a/packages/SwingSet/src/types.js
+++ b/packages/SwingSet/src/types.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @typedef {CapData<string>} CapDataS
+ * @typedef {CapData<string>} SwingSetCapData
  */
 
 /**
@@ -52,4 +52,40 @@
  *   exitVat: unknown,
  *   exitVatWithFailure: unknown,
  * }} TerminationVatPowers
+ */
+
+/*
+ * `['message', targetSlot, msg]`
+ * msg is `{ method, args, result }`
+ * `['notify', resolutions]`
+ * `['dropExports', vrefs]`
+ */
+
+/**
+ * @typedef {{
+ * method: string,
+ * args: SwingSetCapData,
+ * result?: string,
+ * }} Message
+ *
+ * @typedef { [tag: 'message', target: string, msg: Message]} VatDeliveryMessage
+ * @typedef { [tag: 'notify', resolutions: string[] ]} VatDeliveryNotify
+ * @typedef { [tag: 'dropExports', vrefs: string[] ]} VatDeliveryDropExports
+ * @typedef { VatDeliveryMessage | VatDeliveryNotify | VatDeliveryDropExports } VatDeliveryObject
+ *
+ * @typedef { [tag: 'send', target: string, msg: Message] } VatSyscallSend
+ * @typedef { [tag: 'callNow', target: string, method: string, args: SwingSetCapData]} VatSyscallCallNow
+ * @typedef { [tag: 'subscribe', vpid: string ]} VatSyscallSubscribe
+ * @typedef { [ vpid: string, rejected: boolean, data: SwingSetCapData ]} Resolutions
+ * @typedef { [tag: 'resolve', resolutions: Resolutions ]} VatSyscallResolve
+ * @typedef { [tag: 'vatstoreGet', key: string ]} VatSyscallVatstoreGet
+ * @typedef { [tag: 'vatstoreSet', key: string, data: string ]} VatSyscallVatstoreSet
+ * @typedef { [tag: 'vatstoreDelete', key: string ]} VatSyscallVatstoreDelete
+ * @typedef { [tag: 'dropImports', slots: string[] ]} VatSyscallDropImports
+ *
+ * @typedef { VatSyscallSend | VatSyscallCallNow | VatSyscallSubscribe
+ *    | VatSyscallResolve | VatSyscallVatstoreGet | VatSyscallVatstoreSet
+ *    | VatSyscallVatstoreDelete | VatSyscallDropImports
+ * } VatSyscallObject
+ *
  */

--- a/packages/SwingSet/test/files-devices/bootstrap-0.js
+++ b/packages/SwingSet/test/files-devices/bootstrap-0.js
@@ -1,9 +1,10 @@
+import { extractMessage } from '../util';
+
 export default function setup(syscall, state, _helpers, vatPowers) {
-  const dispatch = harden({
-    deliver(facetid, method, args, _result) {
-      vatPowers.testLog(args.body);
-      vatPowers.testLog(JSON.stringify(args.slots));
-    },
-  });
+  function dispatch(vatDeliverObject) {
+    const { args } = extractMessage(vatDeliverObject);
+    vatPowers.testLog(args.body);
+    vatPowers.testLog(JSON.stringify(args.slots));
+  }
   return dispatch;
 }

--- a/packages/SwingSet/test/files-devices/bootstrap-1.js
+++ b/packages/SwingSet/test/files-devices/bootstrap-1.js
@@ -1,22 +1,22 @@
 import { assert, details as X } from '@agoric/assert';
+import { extractMessage } from '../util';
 
 export default function setup(syscall, state, _helpers, vatPowers) {
   const { testLog } = vatPowers;
   let deviceRef;
-  const dispatch = harden({
-    deliver(facetid, method, args, _result) {
-      if (method === 'bootstrap') {
-        const argb = JSON.parse(args.body);
-        const deviceIndex = argb[1].d1.index;
-        deviceRef = args.slots[deviceIndex];
-        assert(deviceRef === 'd-70', X`bad deviceRef ${deviceRef}`);
-      } else if (method === 'step1') {
-        testLog(`callNow`);
-        const setArgs = harden({ body: JSON.stringify([1, 2]), slots: [] });
-        const ret = syscall.callNow(deviceRef, 'set', setArgs);
-        testLog(JSON.stringify(ret));
-      }
-    },
-  });
+  function dispatch(vatDeliverObject) {
+    const { method, args } = extractMessage(vatDeliverObject);
+    if (method === 'bootstrap') {
+      const argb = JSON.parse(args.body);
+      const deviceIndex = argb[1].d1.index;
+      deviceRef = args.slots[deviceIndex];
+      assert(deviceRef === 'd-70', X`bad deviceRef ${deviceRef}`);
+    } else if (method === 'step1') {
+      testLog(`callNow`);
+      const setArgs = harden({ body: JSON.stringify([1, 2]), slots: [] });
+      const ret = syscall.callNow(deviceRef, 'set', setArgs);
+      testLog(JSON.stringify(ret));
+    }
+  }
   return dispatch;
 }

--- a/packages/SwingSet/test/files-devices/bootstrap-4.js
+++ b/packages/SwingSet/test/files-devices/bootstrap-4.js
@@ -1,6 +1,7 @@
 import { assert } from '@agoric/assert';
 import { QCLASS } from '@agoric/marshal';
 import { insistVatType } from '../../src/parseVatSlots';
+import { extractMessage } from '../util';
 
 // to exercise the error we get when syscall.callNow() is given a promise
 // identifier, we must bypass liveslots, which would otherwise protect us
@@ -17,32 +18,31 @@ function capargs(args, slots = []) {
 export default function setup(syscall, state, _helpers, vatPowers) {
   const { callNow } = syscall;
   const { testLog } = vatPowers;
-  const dispatch = harden({
-    deliver(facetid, method, args, _result) {
-      if (method === 'bootstrap') {
-        // find the device slot
-        const [_vats, devices] = JSON.parse(args.body);
-        const qnode = devices.d0;
-        assert.equal(qnode[QCLASS], 'slot');
-        const slot = args.slots[qnode.index];
-        insistVatType('device', slot);
+  function dispatch(vatDeliverObject) {
+    const { method, args } = extractMessage(vatDeliverObject);
+    if (method === 'bootstrap') {
+      // find the device slot
+      const [_vats, devices] = JSON.parse(args.body);
+      const qnode = devices.d0;
+      assert.equal(qnode[QCLASS], 'slot');
+      const slot = args.slots[qnode.index];
+      insistVatType('device', slot);
 
-        const vpid = 'p+1'; // pretend we're exporting a promise
-        const pnode = { [QCLASS]: 'slot', index: 0 };
-        const callNowArgs = capargs([pnode], [vpid]);
+      const vpid = 'p+1'; // pretend we're exporting a promise
+      const pnode = { [QCLASS]: 'slot', index: 0 };
+      const callNowArgs = capargs([pnode], [vpid]);
 
-        testLog('sending Promise');
-        try {
-          // this will throw an exception, but is also (eventually) vat-fatal
-          callNow(slot, 'send', callNowArgs);
-          testLog('oops: survived sending Promise');
-        } catch (e) {
-          testLog('good: callNow failed');
-        }
-      } else if (method === 'ping') {
-        testLog('oops: still alive');
+      testLog('sending Promise');
+      try {
+        // this will throw an exception, but is also (eventually) vat-fatal
+        callNow(slot, 'send', callNowArgs);
+        testLog('oops: survived sending Promise');
+      } catch (e) {
+        testLog('good: callNow failed');
       }
-    },
-  });
+    } else if (method === 'ping') {
+      testLog('oops: still alive');
+    }
+  }
   return dispatch;
 }

--- a/packages/SwingSet/test/liveslots-helpers.js
+++ b/packages/SwingSet/test/liveslots-helpers.js
@@ -1,0 +1,46 @@
+import { WeakRef, FinalizationRegistry } from '../src/weakref';
+import { makeLiveSlots } from '../src/kernel/liveSlots';
+
+export function buildSyscall() {
+  const log = [];
+
+  const syscall = {
+    send(targetSlot, method, args, resultSlot) {
+      log.push({ type: 'send', targetSlot, method, args, resultSlot });
+    },
+    subscribe(target) {
+      log.push({ type: 'subscribe', target });
+    },
+    resolve(resolutions) {
+      log.push({ type: 'resolve', resolutions });
+    },
+    dropImports(slots) {
+      log.push({ type: 'dropImports', slots });
+    },
+    exit(isFailure, info) {
+      log.push({ type: 'exit', isFailure, info });
+    },
+  };
+
+  return { log, syscall };
+}
+
+export function makeDispatch(
+  syscall,
+  build,
+  vatID = 'vatA',
+  enableDisavow = false,
+) {
+  const gcTools = harden({ WeakRef, FinalizationRegistry });
+  const { setBuildRootObject, dispatch } = makeLiveSlots(
+    syscall,
+    vatID,
+    {},
+    {},
+    undefined,
+    enableDisavow,
+    gcTools,
+  );
+  setBuildRootObject(build);
+  return dispatch;
+}

--- a/packages/SwingSet/test/test-comms.js
+++ b/packages/SwingSet/test/test-comms.js
@@ -7,6 +7,7 @@ import { makeState, makeStateKit } from '../src/vats/comms/state';
 import { makeCListKit } from '../src/vats/comms/clist';
 import { addRemote } from '../src/vats/comms/remote';
 import { debugState } from '../src/vats/comms/dispatch';
+import { makeMessage, makeDropExports } from './util';
 
 const test = wrapTest(rawTest);
 
@@ -49,8 +50,8 @@ test('transmit', t => {
   // look at machine A, on which some local vat is sending messages to a
   // remote 'bob' on machine B
   const { syscall, sends } = mockSyscall();
-  const d = buildCommsDispatch(syscall, 'fakestate', 'fakehelpers');
-  const { state, clistKit } = debugState.get(d);
+  const dispatch = buildCommsDispatch(syscall, 'fakestate', 'fakehelpers');
+  const { state, clistKit } = debugState.get(dispatch);
   const {
     provideKernelForLocal,
     provideLocalForKernel,
@@ -67,7 +68,7 @@ test('transmit', t => {
 
   // now tell the comms vat to send a message to a remote machine, the
   // equivalent of bob!foo()
-  d.deliver(bobKernel, 'foo', capdata('argsbytes', []), null);
+  dispatch(makeMessage(bobKernel, 'foo', capdata('argsbytes', [])));
   t.deepEqual(sends.shift(), [
     transmitterID,
     'transmit',
@@ -75,11 +76,12 @@ test('transmit', t => {
   ]);
 
   // bob!bar(alice, bob)
-  d.deliver(
-    bobKernel,
-    'bar',
-    capdata('argsbytes', [aliceKernel, bobKernel]),
-    null,
+  dispatch(
+    makeMessage(
+      bobKernel,
+      'bar',
+      capdata('argsbytes', [aliceKernel, bobKernel]),
+    ),
   );
   t.deepEqual(sends.shift(), [
     transmitterID,
@@ -89,11 +91,12 @@ test('transmit', t => {
   // the outbound ro-20 should match an inbound ro+20, both represent 'alice'
   t.is(getLocalForRemote(remoteID, 'ro+20'), aliceLocal);
   // do it again, should use same values
-  d.deliver(
-    bobKernel,
-    'bar',
-    capdata('argsbytes', [aliceKernel, bobKernel]),
-    null,
+  dispatch(
+    makeMessage(
+      bobKernel,
+      'bar',
+      capdata('argsbytes', [aliceKernel, bobKernel]),
+    ),
   );
   t.deepEqual(sends.shift(), [
     transmitterID,
@@ -102,12 +105,13 @@ test('transmit', t => {
   ]);
 
   // bob!cat(alice, bob, ayana)
-  const ayana = 'o-11';
-  d.deliver(
-    bobKernel,
-    'cat',
-    capdata('argsbytes', [aliceKernel, bobKernel, ayana]),
-    null,
+  const ayanaKernel = 'o-11';
+  dispatch(
+    makeMessage(
+      bobKernel,
+      'cat',
+      capdata('argsbytes', [aliceKernel, bobKernel, ayanaKernel]),
+    ),
   );
   t.deepEqual(sends.shift(), [
     transmitterID,
@@ -120,8 +124,8 @@ test('receive', t => {
   // look at machine B, which is receiving remote messages aimed at a local
   // vat's object 'bob'
   const { syscall, sends } = mockSyscall();
-  const d = buildCommsDispatch(syscall, 'fakestate', 'fakehelpers');
-  const { state, clistKit } = debugState.get(d);
+  const dispatch = buildCommsDispatch(syscall, 'fakestate', 'fakehelpers');
+  const { state, clistKit } = debugState.get(dispatch);
   const {
     provideLocalForKernel,
     getKernelForLocal,
@@ -140,20 +144,22 @@ test('receive', t => {
 
   // now pretend the transport layer received a message from remote1, as if
   // the remote machine had performed bob!foo()
-  d.deliver(
-    receiverID,
-    'receive',
-    encodeArgs(`1:deliver:${bobRemote}:foo:;argsbytes`),
-    null,
+  dispatch(
+    makeMessage(
+      receiverID,
+      'receive',
+      encodeArgs(`1:deliver:${bobRemote}:foo:;argsbytes`),
+    ),
   );
   t.deepEqual(sends.shift(), [bobKernel, 'foo', capdata('argsbytes')]);
 
   // bob!bar(alice, bob)
-  d.deliver(
-    receiverID,
-    'receive',
-    encodeArgs(`2:deliver:${bobRemote}:bar::ro-20:${bobRemote};argsbytes`),
-    null,
+  dispatch(
+    makeMessage(
+      receiverID,
+      'receive',
+      encodeArgs(`2:deliver:${bobRemote}:bar::ro-20:${bobRemote};argsbytes`),
+    ),
   );
   const expectedAliceKernel = 'o+31';
   t.deepEqual(sends.shift(), [
@@ -169,11 +175,12 @@ test('receive', t => {
 
   // bob!bar(alice, bob), again, to test stability
   // also test absent sequence number
-  d.deliver(
-    receiverID,
-    'receive',
-    encodeArgs(`:deliver:${bobRemote}:bar::ro-20:${bobRemote};argsbytes`),
-    null,
+  dispatch(
+    makeMessage(
+      receiverID,
+      'receive',
+      encodeArgs(`:deliver:${bobRemote}:bar::ro-20:${bobRemote};argsbytes`),
+    ),
   );
   t.deepEqual(sends.shift(), [
     bobKernel,
@@ -183,13 +190,14 @@ test('receive', t => {
 
   // bob!cat(alice, bob, ayana)
   const expectedAyanaKernel = 'o+32';
-  d.deliver(
-    receiverID,
-    'receive',
-    encodeArgs(
-      `4:deliver:${bobRemote}:cat::ro-20:${bobRemote}:ro-21;argsbytes`,
+  dispatch(
+    makeMessage(
+      receiverID,
+      'receive',
+      encodeArgs(
+        `4:deliver:${bobRemote}:cat::ro-20:${bobRemote}:ro-21;argsbytes`,
+      ),
     ),
-    null,
   );
   t.deepEqual(sends.shift(), [
     bobKernel,
@@ -200,15 +208,18 @@ test('receive', t => {
   // react to bad sequence number
   t.throws(
     () =>
-      d.deliver(
-        receiverID,
-        'receive',
-        encodeArgs(`47:deliver:${bobRemote}:bar::ro-20:${bobRemote};argsbytes`),
-        null,
+      dispatch(
+        makeMessage(
+          receiverID,
+          'receive',
+          encodeArgs(
+            `47:deliver:${bobRemote}:bar::ro-20:${bobRemote};argsbytes`,
+          ),
+        ),
       ),
     { message: /unexpected recv seqNum \(a string\)/ },
   );
 
   // make sure comms can tolerate dropExports, even if it's a no-op
-  d.dropExports([expectedAliceKernel, expectedAyanaKernel]);
+  dispatch(makeDropExports(expectedAliceKernel, expectedAyanaKernel));
 });

--- a/packages/SwingSet/test/vat-controller-1
+++ b/packages/SwingSet/test/vat-controller-1
@@ -1,7 +1,9 @@
 // -*- js -*-
+import { extractMessage } from './util';
 export default function setup(syscall, _state, _helpers, vatPowers) {
-  function deliver(target, method, args) {
-    vatPowers.testLog(JSON.stringify({ target, method, args }));
+  function dispatch(vatDeliverObject) {
+    const { facetID, method, args } = extractMessage(vatDeliverObject);
+    vatPowers.testLog(JSON.stringify({ target: facetID, method, args }));
   }
-  return { deliver };
+  return dispatch;
 }

--- a/packages/SwingSet/test/vat-syscall-failure.js
+++ b/packages/SwingSet/test/vat-syscall-failure.js
@@ -1,3 +1,5 @@
+import { extractMessage } from './util';
+
 function capdata(body, slots = []) {
   return harden({ body, slots });
 }
@@ -7,10 +9,11 @@ function capargs(args, slots = []) {
 }
 
 export default function setup(syscall, _state, _helpers, vatPowers) {
-  function deliver(target, method, args) {
+  function dispatch(vatDeliverObject) {
+    const { method, args } = extractMessage(vatDeliverObject);
     vatPowers.testLog(`${method}`);
     const thing = method === 'begood' ? args.slots[0] : 'o-3414159';
     syscall.send(thing, 'pretendToBeAThing', capargs([method]));
   }
-  return { deliver };
+  return dispatch;
 }


### PR DESCRIPTION
Previously, the low-level vat interface was defined by a `dispatch` *object*,
with methods like `.deliver` and `.notify`. Now, it is defined by a
`dispatch()` *function*, which takes a `vatDeliveryObject` that has the exact
same form as the data sent in the kernel-vat protocol.

This reduces the size of the manager/supervisor code and reduces the
redundancy somewhat.

refs #2671
