### PR TITLE
fix: deploy-script-support tests

### DIFF
--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -271,6 +271,10 @@ jobs:
       run: cd packages/transform-metering && yarn test
       env:
         ESM_DISABLE_CACHE: true
+    - name: yarn test (deploy-script-support)
+      run: cd packages/deploy-script-support && yarn test
+      env:
+        ESM_DISABLE_CACHE: true
 
 ##############
 # Long-running tests are executed individually.

--- a/packages/deploy-script-support/test/unitTests/test-assertOfferResult.js
+++ b/packages/deploy-script-support/test/unitTests/test-assertOfferResult.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/deploy-script-support/test/unitTests/test-depositInvitation.js
+++ b/packages/deploy-script-support/test/unitTests/test-depositInvitation.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { makeIssuerKit, MathKind } from '@agoric/ertp';

--- a/packages/deploy-script-support/test/unitTests/test-findInvitationAmount.js
+++ b/packages/deploy-script-support/test/unitTests/test-findInvitationAmount.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { makeIssuerKit, MathKind } from '@agoric/ertp';

--- a/packages/deploy-script-support/test/unitTests/test-install.js
+++ b/packages/deploy-script-support/test/unitTests/test-install.js
@@ -1,6 +1,7 @@
 /* global require */
 // @ts-check
 
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { makeZoe } from '@agoric/zoe';

--- a/packages/deploy-script-support/test/unitTests/test-offer.js
+++ b/packages/deploy-script-support/test/unitTests/test-offer.js
@@ -1,6 +1,7 @@
 /* global require */
 // @ts-check
 
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { makeZoe } from '@agoric/zoe';

--- a/packages/deploy-script-support/test/unitTests/test-resolvePathForLocalContract.js
+++ b/packages/deploy-script-support/test/unitTests/test-resolvePathForLocalContract.js
@@ -1,6 +1,7 @@
 /* global require */
 // @ts-check
 
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/deploy-script-support/test/unitTests/test-resolvePathForPackagedContract.js
+++ b/packages/deploy-script-support/test/unitTests/test-resolvePathForPackagedContract.js
@@ -1,6 +1,7 @@
 /* global require */
 // @ts-check
 
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/deploy-script-support/test/unitTests/test-saveLocalAmountMaths.js
+++ b/packages/deploy-script-support/test/unitTests/test-saveLocalAmountMaths.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/deploy-script-support/test/unitTests/test-startInstance.js
+++ b/packages/deploy-script-support/test/unitTests/test-startInstance.js
@@ -1,6 +1,7 @@
 /* global require */
 // @ts-check
 
+import '@agoric/zoe/tools/prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { makeZoe } from '@agoric/zoe';


### PR DESCRIPTION
Fixes the errors in deploy-script-support tests and adds deploy-script-support to the Github workflow.

Note that `yarn test` locally failed for me, but in cosmic-swingset, unrelated to this PR.