### PR TITLE
Expose metrics via slogger

### DIFF
--- a/golang/cosmos/x/dibc/ibc.go
+++ b/golang/cosmos/x/dibc/ibc.go
@@ -68,7 +68,7 @@ func NewPortHandler(ibcModule porttypes.IBCModule, keeper Keeper) portHandler {
 }
 
 func (ch portHandler) Receive(ctx *swingset.ControllerContext, str string) (ret string, err error) {
-	fmt.Println("ibc.go downcall", str)
+	// fmt.Println("ibc.go downcall", str)
 	keeper := ch.keeper
 
 	msg := new(portMessage)
@@ -167,7 +167,7 @@ func (ch portHandler) Receive(ctx *swingset.ControllerContext, str string) (ret 
 		err = fmt.Errorf("unrecognized method %s", msg.Method)
 	}
 
-	fmt.Println("ibc.go downcall reply", ret, err)
+	// fmt.Println("ibc.go downcall reply", ret, err)
 	return
 }
 

--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -56,6 +56,7 @@ export async function makeSwingsetController(
   const {
     verbose,
     debugPrefix = '',
+    slogCallbacks,
     slogFile,
     testTrackDecref,
     defaultManagerType = env.WORKER_TYPE || 'local',
@@ -223,6 +224,7 @@ export async function makeSwingsetController(
     makeNodeWorker,
     startSubprocessWorkerNode,
     startXSnap,
+    slogCallbacks,
     writeSlogObject,
     WeakRef,
     FinalizationRegistry,
@@ -320,6 +322,7 @@ export async function buildVatController(
     verbose,
     kernelBundles,
     debugPrefix,
+    slogCallbacks,
     testTrackDecref,
     defaultManagerType,
   } = runtimeOptions;
@@ -327,6 +330,7 @@ export async function buildVatController(
     verbose,
     debugPrefix,
     testTrackDecref,
+    slogCallbacks,
     defaultManagerType,
   };
   const initializationOptions = { verbose, kernelBundles };

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -94,6 +94,7 @@ export default function buildKernel(
     hostStorage,
     debugPrefix,
     vatEndowments,
+    slogCallbacks = {},
     makeConsole,
     replaceGlobalMeter,
     transformMetering,
@@ -119,8 +120,8 @@ export default function buildKernel(
   );
 
   const kernelSlog = writeSlogObject
-    ? makeSlogger(writeSlogObject)
-    : makeDummySlogger(makeConsole);
+    ? makeSlogger(slogCallbacks, writeSlogObject)
+    : makeDummySlogger(slogCallbacks, makeConsole);
 
   const kernelKeeper = makeKernelKeeper(enhancedCrankBuffer, kernelSlog);
 

--- a/packages/SwingSet/src/kernel/metering.js
+++ b/packages/SwingSet/src/kernel/metering.js
@@ -39,17 +39,19 @@ export function makeMeterManager(replaceGlobalMeter) {
       // console.error(`-- METER REFILL`);
       // console.error(`   allocate used: ${FULL - refillFacet.getAllocateBalance()}`);
       // console.error(`   compute used : ${FULL - refillFacet.getComputeBalance()}`);
-      const used = harden({
+      const meterUsage = harden({
+        // TODO: Change this meterType whenever the semantics change.
+        meterType: 'tame-metering-1',
         allocate: FULL - refillFacet.getAllocateBalance(),
         compute: FULL - refillFacet.getComputeBalance(),
       });
       if (meter.isExhausted() && !refillIfExhausted) {
-        return used;
+        return meterUsage;
       }
       refillFacet.allocate();
       refillFacet.compute();
       refillFacet.stack();
-      return used;
+      return meterUsage;
     }
 
     if (refillEachCrank) {

--- a/packages/SwingSet/src/kernel/metrics.js
+++ b/packages/SwingSet/src/kernel/metrics.js
@@ -83,6 +83,11 @@ export const KERNEL_STATS_UPDOWN_METRICS = [
     name: 'swingset_clist_entries',
     description: 'Number of entries in the kernel c-list',
   },
+  {
+    key: 'vats',
+    name: 'swingset_vats',
+    description: 'Number of active vats',
+  },
 ];
 
 export const KERNEL_STATS_METRICS = [

--- a/packages/SwingSet/src/kernel/slogger.js
+++ b/packages/SwingSet/src/kernel/slogger.js
@@ -22,7 +22,7 @@ function makeCallbackRegistry(callbacks) {
       const cb = callbacks[method];
       if (!cb) {
         // No registered callback, just use the implementation directly.
-        console.error('no registered callback for', method);
+        // console.error('no registered callback for', method);
         return impl;
       }
 
@@ -143,9 +143,9 @@ export function makeSlogger(slogCallbacks, writeObj) {
       syscallNum = 0;
 
       // dr: deliveryResult
-      function finish(dr, stats) {
+      function finish(dr) {
         assertOldState(DELIVERY, 'delivery-finish called twice?');
-        write({ type: 'deliver-result', ...when, dr, stats });
+        write({ type: 'deliver-result', ...when, dr });
         state = IDLE;
       }
       return harden(finish);

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -457,6 +457,7 @@ export default function makeKernelKeeper(storage, kernelSlog) {
           break;
         }
       }
+      decStat('vats');
     }
 
     return kernelPromisesToReject;
@@ -543,6 +544,7 @@ export default function makeKernelKeeper(storage, kernelSlog) {
 
   function allocateUnusedVatID() {
     const nextID = Nat(BigInt(getRequired(`vat.nextID`)));
+    incStat('vats');
     storage.set(`vat.nextID`, `${nextID + 1n}`);
     return makeVatID(nextID);
   }

--- a/packages/SwingSet/src/kernel/vatManager/deliver.js
+++ b/packages/SwingSet/src/kernel/vatManager/deliver.js
@@ -1,7 +1,6 @@
 import { assert, details as X } from '@agoric/assert';
 import { insistMessage } from '../../message';
 
-const METER_TYPE = 'tame-metering-1';
 export function makeDeliver(tools, dispatch) {
   const {
     meterRecord,
@@ -56,11 +55,13 @@ export function makeDeliver(tools, dispatch) {
     // refill this vat's meter, if any, accumulating its usage for stats
     if (meterRecord) {
       // note that refill() won't actually refill an exhausted meter
-      status[2] = { ...meterRecord.refill(), meterType: METER_TYPE };
+      const meterUsage = meterRecord.refill();
       const exhaustionError = meterRecord.isExhausted();
       if (exhaustionError) {
-        status = ['error', exhaustionError.message, status[2]];
+        status = ['error', exhaustionError.message, meterUsage];
       } else {
+        // We will have ['ok', null, meterUsage]
+        status[2] = meterUsage;
         updateStats(status[2]);
       }
     }

--- a/packages/SwingSet/src/kernel/vatManager/deliver.js
+++ b/packages/SwingSet/src/kernel/vatManager/deliver.js
@@ -1,6 +1,7 @@
 import { assert, details as X } from '@agoric/assert';
 import { insistMessage } from '../../message';
 
+const METER_TYPE = 'tame-metering-1';
 export function makeDeliver(tools, dispatch) {
   const {
     meterRecord,
@@ -51,16 +52,16 @@ export function makeDeliver(tools, dispatch) {
     await runAndWait(() => dispatch[dispatchOp](...dispatchArgs), errmsg);
     stopGlobalMeter();
 
-    let status = ['ok'];
+    let status = ['ok', null, null];
     // refill this vat's meter, if any, accumulating its usage for stats
     if (meterRecord) {
       // note that refill() won't actually refill an exhausted meter
-      const used = meterRecord.refill();
+      status[2] = { ...meterRecord.refill(), meterType: METER_TYPE };
       const exhaustionError = meterRecord.isExhausted();
       if (exhaustionError) {
-        status = ['error', exhaustionError.message];
+        status = ['error', exhaustionError.message, status[2]];
       } else {
-        updateStats(used);
+        updateStats(status[2]);
       }
     }
 

--- a/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
@@ -170,12 +170,12 @@ export function makeXsSubprocessFactory({
       parentLog(vatID, `deliverDone`, result.reply[0], result.reply.length);
       transcriptManager.finishDispatch();
 
-      // Attach the crank stats to the deliver result.
+      // Attach the meterUsage to the deliver result.
       /** @type {Tagged} */
       const deliverResult = [
         result.reply[0], // 'ok' or 'error'
         result.reply[1] || null, // problem or null
-        result.crankStats || null, // meter usage statistics or null
+        result.meterUsage || null, // meter usage statistics or null
       ];
       return harden(deliverResult);
     }

--- a/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
@@ -169,7 +169,15 @@ export function makeXsSubprocessFactory({
       const result = await issueTagged(['deliver', ...delivery]);
       parentLog(vatID, `deliverDone`, result.reply[0], result.reply.length);
       transcriptManager.finishDispatch();
-      return result.reply;
+
+      // Attach the crank stats to the deliver result.
+      /** @type {Tagged} */
+      const deliverResult = [
+        result.reply[0], // 'ok' or 'error'
+        result.reply[1] || null, // problem or null
+        result.crankStats || null, // meter usage statistics or null
+      ];
+      return harden(deliverResult);
     }
 
     async function replayTranscript() {

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
@@ -109,7 +109,7 @@ function abbreviateReplacer(_, arg) {
 function runAndWait(f, errmsg) {
   Promise.resolve()
     .then(f)
-    .then(undefined, err => {
+    .catch(err => {
       workerLog(`doProcess: ${errmsg}:`, err.message);
     });
   return waitUntilQuiescent();

--- a/packages/SwingSet/src/kernel/vatManager/types.js
+++ b/packages/SwingSet/src/kernel/vatManager/types.js
@@ -1,6 +1,6 @@
 /**
  * @typedef { [unknown, ...unknown[]] } Tagged
  * @typedef { { meterType: string, allocate: number|null, compute: number|null } }
- * CrankStats
- * @typedef { { reply: Tagged, crankStats: CrankStats } } CrankResults
+ * MeterUsage
+ * @typedef { { reply: Tagged, meterUsage: MeterUsage } } CrankResults
  */

--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -11,6 +11,8 @@ FAKE_CHAIN_DELAY = 0
 NUM_SOLOS?=1
 BASE_PORT?=8000
 
+OTEL_EXPORTER_PROMETHEUS_PORT = 9461
+
 # On a host machine.  Stay here.
 INSPECT_ADDRESS = 127.0.0.1
 
@@ -66,7 +68,7 @@ scenario2-setup-nobuild:
 	$(MAKE) set-local-gci-ingress
 
 scenario2-run-chain:
-	OTEL_EXPORTER_PROMETHEUS_PORT=9464 \
+	OTEL_EXPORTER_PROMETHEUS_PORT=$(OTEL_EXPORTER_PROMETHEUS_PORT) \
 		$(AGC) `$(BREAK_CHAIN) && echo --inspect-brk` --home=t1/n0 start --log_level=warn
 
 # Provision and start a client.
@@ -108,9 +110,11 @@ scenario3-setup:
 scenario3-run-client: scenario3-run
 # Set the fake chain here in case the delay has changed.
 scenario3-run:
-	(cd t3 && \
-			../bin/ag-solo set-fake-chain --delay=$(FAKE_CHAIN_DELAY) mySimGCI)
-	cd t3 && OTEL_EXPORTER_PROMETHEUS_PORT=9464 ../bin/ag-solo start
+	cd t3 && \
+			../bin/ag-solo set-fake-chain --delay=$(FAKE_CHAIN_DELAY) mySimGCI
+	cd t3 && \
+		OTEL_EXPORTER_PROMETHEUS_PORT=$(OTEL_EXPORTER_PROMETHEUS_PORT) \
+		../bin/ag-solo start
 
 docker-pull:
 	for f in '' -setup -solo; do \

--- a/packages/cosmic-swingset/lib/kernel-stats.js
+++ b/packages/cosmic-swingset/lib/kernel-stats.js
@@ -1,10 +1,146 @@
 import { MeterProvider } from '@opentelemetry/metrics';
 import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
 
+import makeStore from '@agoric/store';
+
 import {
   KERNEL_STATS_SUM_METRICS,
   KERNEL_STATS_UPDOWN_METRICS,
 } from '@agoric/swingset-vat/src/kernel/metrics';
+
+export const DEFAULT_METER_PROVIDER = new MeterProvider();
+
+export const HISTOGRAM_SECONDS_LATENCY_BOUNDARIES = [
+  0.005,
+  0.01,
+  0.025,
+  0.05,
+  0.1,
+  0.25,
+  0.5,
+  1,
+  2.5,
+  5,
+  10,
+  Infinity,
+];
+
+const wrapDeltaMS = (finisher, useDeltaMS) => {
+  const startMS = Date.now();
+  return (...finishArgs) => {
+    try {
+      return finisher(...finishArgs);
+    } finally {
+      const deltaMS = Date.now() - startMS;
+      useDeltaMS(deltaMS, finishArgs);
+    }
+  };
+};
+
+const recordToKey = record =>
+  JSON.stringify(
+    Object.entries(record).sort(([ka], [kb]) => (ka < kb ? -1 : 1)),
+  );
+
+export function makeSlogCallbacks({ metricMeter, labels }) {
+  const nameToBaseMetric = makeStore('baseMetricName');
+  nameToBaseMetric.init(
+    'swingset_vat_startup',
+    metricMeter.createValueRecorder('swingset_vat_startup', {
+      description: 'Vat startup time (ms)',
+    }),
+  );
+  nameToBaseMetric.init(
+    'swingset_vat_delivery',
+    metricMeter.createValueRecorder('swingset_vat_delivery', {
+      description: 'Vat delivery time (ms)',
+    }),
+  );
+  nameToBaseMetric.init(
+    'swingset_meter_usage',
+    metricMeter.createValueRecorder('swingset_meter_usage', {
+      description: 'Vat meter usage',
+    }),
+  );
+  const groupToMetrics = makeStore('metricGroup');
+
+  /**
+   * This function reuses or creates per-group named metrics.
+   *
+   * @param {string} name name of the base metric
+   * @param {Record<string, string>} [group] the labels to associate with a group
+   * @param {Record<string, string>} [instance] the specific metric labels
+   * @returns {any} the labelled metric
+   */
+  const getGroupedMetric = (name, group = {}, instance = {}) => {
+    let nameToMetric;
+    const groupKey = recordToKey(group);
+    const instanceKey = recordToKey(instance);
+    if (groupToMetrics.has(groupKey)) {
+      let oldInstanceKey;
+      [nameToMetric, oldInstanceKey] = groupToMetrics.get(groupKey);
+      if (instanceKey !== oldInstanceKey) {
+        for (const metric of nameToMetric.values()) {
+          // FIXME: Delete all the metrics of the old instance.
+          metric;
+        }
+        // Refresh the metric group.
+        nameToMetric = makeStore('metricName');
+        groupToMetrics.set(groupKey, [nameToMetric, instanceKey]);
+      }
+    } else {
+      nameToMetric = makeStore('metricName');
+      groupToMetrics.init(groupKey, [nameToMetric, instanceKey]);
+    }
+
+    let metric;
+    if (nameToMetric.has(name)) {
+      metric = nameToMetric.get(name);
+    } else {
+      // Bind the base metric to the group and instance labels.
+      metric = nameToBaseMetric
+        .get(name)
+        .bind({ ...labels, ...group, ...instance });
+      nameToMetric.init(name, metric);
+    }
+    return metric;
+  };
+
+  /**
+   * Measure some interesting stats.  We currently do a per-vat recording of
+   * time spent in the vat for startup and delivery.
+   */
+  const slogCallbacks = {
+    startup(_method, [vatID], finisher) {
+      return wrapDeltaMS(finisher, deltaMS => {
+        getGroupedMetric('swingset_vat_startup', { vatID }).record(deltaMS);
+      });
+    },
+    delivery(_method, [vatID], finisher) {
+      return wrapDeltaMS(finisher, (deltaMS, [[_status, _problem, usage]]) => {
+        getGroupedMetric('swingset_vat_delivery', { vatID }).record(deltaMS);
+        if (usage) {
+          // Add to aggregated metering stats.
+          const group = { vatID };
+          for (const [key, value] of Object.entries(usage)) {
+            if (key === 'meterType') {
+              // eslint-disable-next-line no-continue
+              continue;
+            }
+            getGroupedMetric(`swingset_meter_usage`, group, {
+              // The meterType is an instance-specific label--a change in it
+              // will result in the old value being discarded.
+              ...(usage.meterType && { meterType: usage.meterType }),
+              stat: key,
+            }).record(value || 0);
+          }
+        }
+      });
+    },
+  };
+
+  return harden(slogCallbacks);
+}
 
 /**
  * @param {Object} param0
@@ -69,6 +205,22 @@ export function exportKernelStats({
     });
     batchObserverResult.observe(labels, observations);
   });
+
+  const schedulerCrankTimeHistogram = metricMeter
+    .createValueRecorder('swingset_crank_processing_time', {
+      description: 'Processing time per crank (ms)',
+      boundaries: [1, 11, 21, 31, 41, 51, 61, 71, 81, 91, Infinity],
+    })
+    .bind(labels);
+
+  const schedulerBlockTimeHistogram = metricMeter
+    .createValueRecorder('swingset_block_processing_seconds', {
+      description: 'Processing time per block',
+      boundaries: HISTOGRAM_SECONDS_LATENCY_BOUNDARIES,
+    })
+    .bind(labels);
+
+  return { schedulerCrankTimeHistogram, schedulerBlockTimeHistogram };
 }
 
 /**

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -122,7 +122,7 @@ export function xsnap(options) {
    * @template T
    * @typedef {Object} RunResult
    * @property {T} reply
-   * @property {{ meterType: string, allocate: number|null, compute: number|null }} crankStats
+   * @property {{ meterType: string, allocate: number|null, compute: number|null }} meterUsage
    */
 
   /**
@@ -150,17 +150,17 @@ export function xsnap(options) {
           // For now it is just a number for the used compute meter.
           compute = JSON.parse(decoder.decode(meterData));
         }
-        const crankStats = {
+        const meterUsage = {
           // The version identifier for our meter type.
           // TODO Bump this whenever there's a change to metering semantics.
           meterType: 'xs-meter-1',
           allocate: null, // No allocation meter yet.
           compute,
         };
-        // console.log('have crankStats', crankStats);
+        // console.log('have meterUsage', meterUsage);
         return {
           reply: message.subarray(meterSeparator < 0 ? 1 : meterSeparator + 1),
-          crankStats,
+          meterUsage,
         };
       } else if (message[0] === ERROR) {
         throw new Error(

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -18,10 +18,6 @@ import * as node from './node-stream';
 // This will need adjustment, but seems to be fine for a start.
 const DEFAULT_CRANK_METERING_LIMIT = 1e7;
 
-// The version identifier for our meter type.
-// TODO Bump this whenever there's a change to metering semantics.
-const METER_TYPE = 'xs-meter-1';
-
 const OK = '.'.charCodeAt(0);
 const ERROR = '!'.charCodeAt(0);
 const QUERY = '?'.charCodeAt(0);
@@ -155,7 +151,9 @@ export function xsnap(options) {
           compute = JSON.parse(decoder.decode(meterData));
         }
         const crankStats = {
-          meterType: METER_TYPE,
+          // The version identifier for our meter type.
+          // TODO Bump this whenever there's a change to metering semantics.
+          meterType: 'xs-meter-1',
           allocate: null, // No allocation meter yet.
           compute,
         };


### PR DESCRIPTION
Closes #2617

This PR takes the low road to exposing more SwingSet details via Prometheus metrics.  We add a `sloggerCallbacks` kernel option that contains methods that should be wrapped around the corresponding method on the SwingSet slogger.  This makes it possible to intercept interesting slog actions and have them trigger the metrics.

Additionally, we have the local and xsnap vat managers return a meter usage object at the end of the deliveryResults array.  This result is available to slog, and thus can be smuggled back to the host from the `sloggerCallbacks.deliver.finish` function, where with cosmic-swingset it is available to Prometheus.

I find this integration to be pleasing, as it doesn't introduce another code path for metrics, but continues to leverage the existing SwingSet kernelStats and slogger mechanisms.  I tried to make minimal changes.  When we have more work on the vatManagers and complete metering under XS we will probably find abstractions to clean up any untidy code.

<details><summary>Example of new metrics exposed on http://localhost:9461/metrics (please excuse the extra `le="+Inf"` data points.  I hope to expand them (probably too much load on Prometheus) or remove them (takes some https://opentelemetry.io work) sometime.</summary>

```
# HELP swingset_vat_startup Vat startup time (ms)
# TYPE swingset_vat_startup histogram
swingset_vat_startup_count{app="ag-chain-cosmos",vatID="v1"} 1 1616222257396
swingset_vat_startup_sum{app="ag-chain-cosmos",vatID="v1"} 16 1616222257396
swingset_vat_startup_bucket{app="ag-chain-cosmos",vatID="v1",le="+Inf"} 1 1616222257396
swingset_vat_startup_count{app="ag-chain-cosmos",vatID="v11"} 1 1616222257413
swingset_vat_startup_sum{app="ag-chain-cosmos",vatID="v11"} 14 1616222257413
swingset_vat_startup_bucket{app="ag-chain-cosmos",vatID="v11",le="+Inf"} 1 1616222257413
swingset_vat_startup_count{app="ag-chain-cosmos",vatID="v13"} 1 1616222257421
swingset_vat_startup_sum{app="ag-chain-cosmos",vatID="v13"} 7 1616222257421
swingset_vat_startup_bucket{app="ag-chain-cosmos",vatID="v13",le="+Inf"} 1 1616222257421
swingset_vat_startup_count{app="ag-chain-cosmos",vatID="v2"} 1 1616222257443
swingset_vat_startup_sum{app="ag-chain-cosmos",vatID="v2"} 20 1616222257443
swingset_vat_startup_bucket{app="ag-chain-cosmos",vatID="v2",le="+Inf"} 1 1616222257443
swingset_vat_startup_count{app="ag-chain-cosmos",vatID="v3"} 1 1616222257457
swingset_vat_startup_sum{app="ag-chain-cosmos",vatID="v3"} 12 1616222257457
swingset_vat_startup_bucket{app="ag-chain-cosmos",vatID="v3",le="+Inf"} 1 1616222257457
swingset_vat_startup_count{app="ag-chain-cosmos",vatID="v4"} 1 1616222257475
swingset_vat_startup_sum{app="ag-chain-cosmos",vatID="v4"} 17 1616222257475
swingset_vat_startup_bucket{app="ag-chain-cosmos",vatID="v4",le="+Inf"} 1 1616222257475
swingset_vat_startup_count{app="ag-chain-cosmos",vatID="v5"} 1 1616222257487
swingset_vat_startup_sum{app="ag-chain-cosmos",vatID="v5"} 10 1616222257487
swingset_vat_startup_bucket{app="ag-chain-cosmos",vatID="v5",le="+Inf"} 1 1616222257487
swingset_vat_startup_count{app="ag-chain-cosmos",vatID="v6"} 1 1616222257508
swingset_vat_startup_sum{app="ag-chain-cosmos",vatID="v6"} 19 1616222257508
swingset_vat_startup_bucket{app="ag-chain-cosmos",vatID="v6",le="+Inf"} 1 1616222257508
swingset_vat_startup_count{app="ag-chain-cosmos",vatID="v7"} 1 1616222257514
swingset_vat_startup_sum{app="ag-chain-cosmos",vatID="v7"} 5 1616222257514
swingset_vat_startup_bucket{app="ag-chain-cosmos",vatID="v7",le="+Inf"} 1 1616222257514
swingset_vat_startup_count{app="ag-chain-cosmos",vatID="v8"} 1 1616222257521
swingset_vat_startup_sum{app="ag-chain-cosmos",vatID="v8"} 6 1616222257521
swingset_vat_startup_bucket{app="ag-chain-cosmos",vatID="v8",le="+Inf"} 1 1616222257521
swingset_vat_startup_count{app="ag-chain-cosmos",vatID="v9"} 1 1616222257527
swingset_vat_startup_sum{app="ag-chain-cosmos",vatID="v9"} 5 1616222257527
swingset_vat_startup_bucket{app="ag-chain-cosmos",vatID="v9",le="+Inf"} 1 1616222257527
swingset_vat_startup_count{app="ag-chain-cosmos",vatID="v15"} 1 1616222257538
swingset_vat_startup_sum{app="ag-chain-cosmos",vatID="v15"} 10 1616222257538
swingset_vat_startup_bucket{app="ag-chain-cosmos",vatID="v15",le="+Inf"} 1 1616222257538
swingset_vat_startup_count{app="ag-chain-cosmos",vatID="v12"} 1 1616222257545
swingset_vat_startup_sum{app="ag-chain-cosmos",vatID="v12"} 6 1616222257545
swingset_vat_startup_bucket{app="ag-chain-cosmos",vatID="v12",le="+Inf"} 1 1616222257545
swingset_vat_startup_count{app="ag-chain-cosmos",vatID="v14"} 1 1616222257553
swingset_vat_startup_sum{app="ag-chain-cosmos",vatID="v14"} 6 1616222257553
swingset_vat_startup_bucket{app="ag-chain-cosmos",vatID="v14",le="+Inf"} 1 1616222257553
swingset_vat_startup_count{app="ag-chain-cosmos",vatID="v10"} 1 1616222257584
swingset_vat_startup_sum{app="ag-chain-cosmos",vatID="v10"} 26 1616222257584
swingset_vat_startup_bucket{app="ag-chain-cosmos",vatID="v10",le="+Inf"} 1 1616222257584
swingset_vat_startup_count{app="ag-chain-cosmos",vatID="v16"} 1 1616222296474
swingset_vat_startup_sum{app="ag-chain-cosmos",vatID="v16"} 10665 1616222296474
swingset_vat_startup_bucket{app="ag-chain-cosmos",vatID="v16",le="+Inf"} 1 1616222296474
# HELP swingset_vat_delivery Vat delivery time (ms)
# TYPE swingset_vat_delivery histogram
swingset_vat_delivery_count{app="ag-chain-cosmos",vatID="v11"} 72 1616222265842
swingset_vat_delivery_sum{app="ag-chain-cosmos",vatID="v11"} 119 1616222265842
swingset_vat_delivery_bucket{app="ag-chain-cosmos",vatID="v11",le="+Inf"} 72 1616222265842
swingset_vat_delivery_count{app="ag-chain-cosmos",vatID="v14"} 156 1616222300291
swingset_vat_delivery_sum{app="ag-chain-cosmos",vatID="v14"} 593 1616222300291
swingset_vat_delivery_bucket{app="ag-chain-cosmos",vatID="v14",le="+Inf"} 156 1616222300291
swingset_vat_delivery_count{app="ag-chain-cosmos",vatID="v12"} 4 1616222296513
swingset_vat_delivery_sum{app="ag-chain-cosmos",vatID="v12"} 10687 1616222296513
swingset_vat_delivery_bucket{app="ag-chain-cosmos",vatID="v12",le="+Inf"} 4 1616222296513
swingset_vat_delivery_count{app="ag-chain-cosmos",vatID="v9"} 1 1616222257638
swingset_vat_delivery_sum{app="ag-chain-cosmos",vatID="v9"} 1 1616222257638
swingset_vat_delivery_bucket{app="ag-chain-cosmos",vatID="v9",le="+Inf"} 1 1616222257638
swingset_vat_delivery_count{app="ag-chain-cosmos",vatID="v8"} 1 1616222257640
swingset_vat_delivery_sum{app="ag-chain-cosmos",vatID="v8"} 1 1616222257640
swingset_vat_delivery_bucket{app="ag-chain-cosmos",vatID="v8",le="+Inf"} 1 1616222257640
swingset_vat_delivery_count{app="ag-chain-cosmos",vatID="v1"} 30 1616222285605
swingset_vat_delivery_sum{app="ag-chain-cosmos",vatID="v1"} 32 1616222285605
swingset_vat_delivery_bucket{app="ag-chain-cosmos",vatID="v1",le="+Inf"} 30 1616222285605
swingset_vat_delivery_count{app="ag-chain-cosmos",vatID="v15"} 19 1616222258055
swingset_vat_delivery_sum{app="ag-chain-cosmos",vatID="v15"} 40 1616222258055
swingset_vat_delivery_bucket{app="ag-chain-cosmos",vatID="v15",le="+Inf"} 19 1616222258055
swingset_vat_delivery_count{app="ag-chain-cosmos",vatID="v10"} 27 1616222300266
swingset_vat_delivery_sum{app="ag-chain-cosmos",vatID="v10"} 57 1616222300266
swingset_vat_delivery_bucket{app="ag-chain-cosmos",vatID="v10",le="+Inf"} 27 1616222300266
swingset_vat_delivery_count{app="ag-chain-cosmos",vatID="v2"} 1 1616222257651
swingset_vat_delivery_sum{app="ag-chain-cosmos",vatID="v2"} 3 1616222257651
swingset_vat_delivery_bucket{app="ag-chain-cosmos",vatID="v2",le="+Inf"} 1 1616222257651
swingset_vat_delivery_count{app="ag-chain-cosmos",vatID="v6"} 118 1616222284954
swingset_vat_delivery_sum{app="ag-chain-cosmos",vatID="v6"} 199 1616222284954
swingset_vat_delivery_bucket{app="ag-chain-cosmos",vatID="v6",le="+Inf"} 118 1616222284954
swingset_vat_delivery_count{app="ag-chain-cosmos",vatID="v4"} 134 1616222296570
swingset_vat_delivery_sum{app="ag-chain-cosmos",vatID="v4"} 213 1616222296570
swingset_vat_delivery_bucket{app="ag-chain-cosmos",vatID="v4",le="+Inf"} 134 1616222296570
swingset_vat_delivery_count{app="ag-chain-cosmos",vatID="v7"} 1 1616222258137
swingset_vat_delivery_sum{app="ag-chain-cosmos",vatID="v7"} 1 1616222258137
swingset_vat_delivery_bucket{app="ag-chain-cosmos",vatID="v7",le="+Inf"} 1 1616222258137
swingset_vat_delivery_count{app="ag-chain-cosmos",vatID="v5"} 18 1616222258420
swingset_vat_delivery_sum{app="ag-chain-cosmos",vatID="v5"} 42 1616222258420
swingset_vat_delivery_bucket{app="ag-chain-cosmos",vatID="v5",le="+Inf"} 18 1616222258420
swingset_vat_delivery_count{app="ag-chain-cosmos",vatID="v3"} 14 1616222258418
swingset_vat_delivery_sum{app="ag-chain-cosmos",vatID="v3"} 21 1616222258418
swingset_vat_delivery_bucket{app="ag-chain-cosmos",vatID="v3",le="+Inf"} 14 1616222258418
swingset_vat_delivery_count{app="ag-chain-cosmos",vatID="v13"} 218 1616222300288
swingset_vat_delivery_sum{app="ag-chain-cosmos",vatID="v13"} 289 1616222300288
swingset_vat_delivery_bucket{app="ag-chain-cosmos",vatID="v13",le="+Inf"} 218 1616222300288
swingset_vat_delivery_count{app="ag-chain-cosmos",vatID="v16"} 8 1616222300270
swingset_vat_delivery_sum{app="ag-chain-cosmos",vatID="v16"} 3694 1616222300270
swingset_vat_delivery_bucket{app="ag-chain-cosmos",vatID="v16",le="+Inf"} 8 1616222300270
...
# HELP swingset_meter_usage Vat meter usage
# TYPE swingset_meter_usage histogram
swingset_meter_usage_count{app="ag-chain-cosmos",vatID="v16",meterType="tame-metering-1",stat="allocate"} 8 1616222300270
swingset_meter_usage_sum{app="ag-chain-cosmos",vatID="v16",meterType="tame-metering-1",stat="allocate"} 19318758 1616222300270
swingset_meter_usage_bucket{app="ag-chain-cosmos",vatID="v16",meterType="tame-metering-1",stat="allocate",le="+Inf"} 8 1616222300270
swingset_meter_usage_count{app="ag-chain-cosmos",vatID="v16",meterType="tame-metering-1",stat="compute"} 8 1616222300285
swingset_meter_usage_sum{app="ag-chain-cosmos",vatID="v16",meterType="tame-metering-1",stat="compute"} 16681529 1616222300285
swingset_meter_usage_bucket{app="ag-chain-cosmos",vatID="v16",meterType="tame-metering-1",stat="compute",le="+Inf"} 8 1616222300285
```
</details>

I can't wait to slice and dice this data from testing!
