### PR TITLE
chore(assert): point to upstream sources

### DIFF
--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -11,6 +11,9 @@
 // To the extent that this `console` is considered a resource,
 // this module must be considered a resource module.
 
+// The assertions re-exported here are defined in
+// https://github.com/endojs/endo/blob/master/packages/ses/src/error/assert.js
+
 import './types';
 
 const { freeze } = Object;


### PR DESCRIPTION
Add a pointer to the SES-shim (now `endojs`) code which defines `assert`, and the interesting properties on it like `assert.typeof`. I keep forgetting what the API is, and when I follow the `import { assert } from '@agoric/assert'` line to find the definition, the trail goes cold (because `assert` is actually a global, added by the SES shim). This pointer might help me or others in the future.
