### PR TITLE
Have `yarn lint-fix` run ESLint --fix before Typescript checks

### DIFF
--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -18,7 +18,7 @@
     "test:nyc": "nyc ava",
     "pretty-fix": "prettier --write '**/*.js'",
     "pretty-check": "prettier --check '**/*.js'",
-    "lint-fix": "yarn lint --fix",
+    "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint:eslint": "eslint '**/*.js'",

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -20,7 +20,7 @@
     "test:xs-worker": "ava test/workers/test-worker.js -m 'xs vat manager'",
     "pretty-fix": "prettier --write '**/*.js'",
     "pretty-check": "prettier --check '**/*.js'",
-    "lint-fix": "yarn lint --fix",
+    "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint-check": "yarn lint",
     "lint": "yarn lint:types&&yarn lint:eslint",
     "lint:types": "tsc -p jsconfig.json",

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -14,7 +14,7 @@
     "test": "exit 0",
     "test:nyc": "exit 0",
     "test:xs": "exit 0",
-    "lint-fix": "yarn lint --fix",
+    "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint:eslint": "eslint '**/*.js'",

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -14,7 +14,7 @@
     "test:xs": "exit 0",
     "pretty-fix": "prettier --write '**/*.js'",
     "pretty-check": "prettier --check '**/*.js'",
-    "lint-fix": "yarn lint --fix",
+    "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint:types": "tsc -p jsconfig.json",

--- a/packages/dapp-svelte-wallet/api/package.json
+++ b/packages/dapp-svelte-wallet/api/package.json
@@ -8,7 +8,7 @@
     "test": "ava",
     "test:xs": "exit 0",
     "lint": "yarn lint:types && yarn lint:eslint",
-    "lint-fix": "yarn lint --fix",
+    "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint-check": "yarn lint",
     "lint:types": "tsc -p jsconfig.json",
     "lint:eslint": "eslint '**/*.js'"

--- a/packages/dapp-svelte-wallet/ui/package.json
+++ b/packages/dapp-svelte-wallet/ui/package.json
@@ -8,8 +8,9 @@
     "dev": "rollup -c -w",
     "start": "sirv public",
     "lint-check": "yarn lint",
-    "lint-fix": "exit 0",
-    "lint": "exit 0",
+    "lint-fix": "yarn lint:eslint --fix",
+    "lint": "yarn lint:eslint",
+    "lint:eslint": "eslint 'src/*.js'",
     "test": "exit 0",
     "test:xs": "exit 0"
   },

--- a/packages/dapp-svelte-wallet/ui/package.json
+++ b/packages/dapp-svelte-wallet/ui/package.json
@@ -31,6 +31,17 @@
     "svelte-awesome": "^2.3.0",
     "svelte-themer": "^0.1.4"
   },
+  "eslintConfig": {
+    "extends": [
+      "@agoric"
+    ],
+    "env": {
+      "browser": true
+    },
+    "rules": {
+      "import/no-extraneous-dependencies": "off"
+    }
+  },
   "files": [
     "public"
   ],

--- a/packages/dapp-svelte-wallet/ui/src/display.js
+++ b/packages/dapp-svelte-wallet/ui/src/display.js
@@ -47,7 +47,8 @@ export function parseValue(str, displayInfo) {
  * @returns {string}
  */
 export function stringifyValue(value, displayInfo = undefined) {
-  const { amountMathKind = MathKind.NAT, decimalPlaces = 0 } = displayInfo || {};
+  const { amountMathKind = MathKind.NAT, decimalPlaces = 0 } =
+    displayInfo || {};
 
   if (amountMathKind !== MathKind.NAT) {
     // Just return the size of the set.
@@ -66,7 +67,7 @@ export function stringifyValue(value, displayInfo = undefined) {
   const unitstr = `${bValue / bScale}`;
 
   // Find the remainder of the value divided by the scale.
-  const bDecimals = BigInt(bValue % bScale)
+  const bDecimals = BigInt(bValue % bScale);
 
   // Create the decimal string.
   const decstr = `${bDecimals}`

--- a/packages/dapp-svelte-wallet/ui/src/main.js
+++ b/packages/dapp-svelte-wallet/ui/src/main.js
@@ -3,8 +3,8 @@ import './tailwind.css';
 import App from './App.svelte';
 
 const app = new App({
-	target: document.body,
-	props: {}
+  target: document.body,
+  props: {},
 });
 
 export default app;

--- a/packages/dapp-svelte-wallet/ui/src/websocket.js
+++ b/packages/dapp-svelte-wallet/ui/src/websocket.js
@@ -7,7 +7,8 @@ function makeReadable(value, start = undefined) {
 }
 
 // Find a default url if we are running in dev mode.  FIXME: Make better.
-const base = location.port === '5000' ? 'http://localhost:8000' : location;
+const base =
+  window.location.port === '5000' ? 'http://localhost:8000' : window.location;
 
 export function makeWebSocket(path, { onOpen, onMessage, onClose }) {
   const [connected, setConnected] = makeReadable(false);
@@ -23,6 +24,7 @@ export function makeWebSocket(path, { onOpen, onMessage, onClose }) {
   let reopenTimeout;
   function reopen() {
     console.log(`Reconnecting in ${RECONNECT_BACKOFF_SECONDS} seconds`);
+    // eslint-disable-next-line no-use-before-define
     reopenTimeout = setTimeout(openSocket, RECONNECT_BACKOFF_SECONDS * 1000);
   }
 
@@ -69,7 +71,7 @@ export function makeWebSocket(path, { onOpen, onMessage, onClose }) {
     }
   }
 
-  const sendMessage = (obj) => {
+  const sendMessage = obj => {
     if (socket && socket.readyState <= 1) {
       socket.send(JSON.stringify(obj));
     }

--- a/packages/deploy-script-support/package.json
+++ b/packages/deploy-script-support/package.json
@@ -16,7 +16,7 @@
     "test:xs": "exit 0",
     "pretty-fix": "prettier --write '**/*.js'",
     "pretty-check": "prettier --check '**/*.js'",
-    "lint-fix": "yarn lint --fix",
+    "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint:eslint": "eslint '**/*.js'",

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -16,7 +16,7 @@
     "test:xs": "exit 0",
     "pretty-fix": "prettier --write '**/*.js'",
     "pretty-check": "prettier --check '**/*.js'",
-    "lint-fix": "yarn lint --fix",
+    "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint:types": "tsc -p jsconfig.json",

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -14,7 +14,7 @@
     "test": "ava",
     "test:nyc": "nyc ava",
     "test:xs": "exit 0",
-    "lint-fix": "yarn lint --fix",
+    "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint:eslint": "eslint '**/*.js'",

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -13,7 +13,7 @@
     "build": "exit 0",
     "test": "exit 0",
     "test:xs": "exit 0",
-    "lint-fix": "yarn lint --fix",
+    "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint:eslint": "eslint '**/*.js'",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -13,7 +13,7 @@
     "build": "exit 0",
     "test": "ava",
     "test:xs": "exit 0",
-    "lint-fix": "yarn lint --fix",
+    "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint:types": "tsc -p jsconfig.json",

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -18,7 +18,7 @@
     "test:xs-unit-debug": "ava-xs --debug",
     "test:xs-worker": "WORKER_TYPE=xs-worker ava",
     "build-zcfBundle": "node -r esm scripts/build-zcfBundle.js",
-    "lint-fix": "yarn lint --fix",
+    "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint:eslint": "eslint '**/*.js'",


### PR DESCRIPTION
Closes #1745

Just use `yarn lint-fix` to fix the lint (which then automatically runs extra typing checks on the results).

Also Closes #2419 by adding some linting to `@agoric/dapp-svelte-wallet-ui`.
