### PR TITLE
fix(ui-components): add dummy test:xs target

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "test": "BABEL_ENV='test' ava",
+    "test:xs": "exit 0",
     "build:tests": "rm -rf compiled && BABEL_ENV='test' ./node_modules/.bin/babel test/components --out-dir compiled/test/components",
     "build:src": "rm -rf dist && BABEL_ENV='test' ./node_modules/.bin/babel src --out-dir dist",
     "build": "yarn build:src && yarn build:tests",


### PR DESCRIPTION
This should allow the CI test to resume passing. It isn't blocking PRs because it's marked as ignored.