### PR TITLE
Have prepare-test-env.js provide unsafe debug settings

### DIFF
--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -59,6 +59,7 @@
     "rollup": "^1.23.1",
     "rollup-plugin-node-resolve": "^5.2.0",
     "semver": "^6.3.0",
+    "ses": "^0.12.3",
     "yargs": "^14.2.0"
   },
   "files": [

--- a/packages/SwingSet/tools/install-ses-debug.js
+++ b/packages/SwingSet/tools/install-ses-debug.js
@@ -1,0 +1,57 @@
+// This is like `@agoric/install-ses` but sacrificing safety to optimize
+// for debugging and testing. The difference is only the lockdown options.
+// The setting below are *unsafe* and should not be used in contact with
+// genuinely malicious code.
+
+// See
+// https://github.com/endojs/endo/blob/master/packages/ses/lockdown-options.md
+// for more explanation of these lockdown options.
+
+import 'ses';
+import '@agoric/eventual-send/shim';
+
+lockdown({
+  // The default `{errorTaming: 'safe'}` setting, if possible, redacts the
+  // stack trace info from the error instances, so that it is not available
+  // merely by saying `errorInstance.stack`. However, some tools will look
+  // for the stack there and become much less useful if it is missing.
+  //
+  errorTaming: 'unsafe',
+
+  // The default `{overrideTaming: 'moderate'}` setting does not hurt the
+  // debugging experience much. But it will introduce noise into, for example,
+  // the vscode debugger's object inspector. During debug and test, if you can
+  // avoid legacy code that needs the `'moderate'` setting, then the `'min'`
+  // setting reduces debugging noise yet further, by turning fewer inherited
+  // properties into accessors.
+  //
+  overrideTaming: 'min',
+
+  // The default `{stackFiltering: 'concise'}` setting usually makes for a
+  // better debugging experience, but severely reducing the noisy distractions
+  // of the normal verbose stack traces. Which is why the alternative
+  // `'verbose'` setting is commented out below. However, the actual cause
+  // of the bug may be anywhere, so the `'noise'` thrown out by the default
+  // `'concise'` setting may also contain the signal you need. To see it,
+  // uncomment out the following line. But please do not commit it in that
+  // state.
+  //
+  // NOTE TO REVIEWERS: If you see the following line *not* commented out,
+  // this may be a development accident that should be fixed before merging.
+  //
+  // stackFiltering: 'verbose',
+
+  // The default `{consoleTaming: 'safe'}` setting usually makes for a
+  // better debugging experience, by wrapping the original `console` with
+  // the SES replacement `console` that provides more information about
+  // errors, expecially those thrown by the `assert` system. However,
+  // in case the SES `console` is getting in the way, we provide the
+  // `'unsafe'` option for leaving the original `console` in place.
+  //
+  // consoleTaming: 'unsafe',
+});
+
+Error.stackTraceLimit = Infinity;
+
+harden(TextEncoder);
+harden(TextDecoder);

--- a/packages/SwingSet/tools/install-ses-debug.js
+++ b/packages/SwingSet/tools/install-ses-debug.js
@@ -13,10 +13,33 @@ import '@agoric/eventual-send/shim';
 lockdown({
   // The default `{errorTaming: 'safe'}` setting, if possible, redacts the
   // stack trace info from the error instances, so that it is not available
-  // merely by saying `errorInstance.stack`. However, some tools will look
-  // for the stack there and become much less useful if it is missing.
+  // merely by saying `errorInstance.stack`. However, some tools, such as
+  // Ava, will look for the stack there and become much less useful if it is
+  // missing.
+  //
+  // NOTE TO REVIEWERS: If you see the following line commented out,
+  // this may be a development accident that should be fixed before merging.
   //
   errorTaming: 'unsafe',
+
+  // The default `{stackFiltering: 'concise'}` setting usually makes for a
+  // better debugging experience, by severely reducing the noisy distractions
+  // of the normal verbose stack traces. Which is why you may want to comment
+  // out the `'verbose'` setting is commented out below. However, some
+  // tools, such as Ava, look for the full filename that it expects in order
+  // to fetch the source text for diagnostics, which is why this file
+  // sets it to `'verbose'`.
+  //
+  // Another reason for not commenting it out: The cause
+  // of the bug may be anywhere, so the `'noise'` thrown out by the default
+  // `'concise'` setting may also contain the signal you need. To see it,
+  // uncomment out the following line. But please do not commit it in that
+  // state.
+  //
+  // NOTE TO REVIEWERS: If you see the following line commented out,
+  // this may be a development accident that should be fixed before merging.
+  //
+  stackFiltering: 'verbose',
 
   // The default `{overrideTaming: 'moderate'}` setting does not hurt the
   // debugging experience much. But it will introduce noise into, for example,
@@ -25,21 +48,10 @@ lockdown({
   // setting reduces debugging noise yet further, by turning fewer inherited
   // properties into accessors.
   //
-  overrideTaming: 'min',
-
-  // The default `{stackFiltering: 'concise'}` setting usually makes for a
-  // better debugging experience, but severely reducing the noisy distractions
-  // of the normal verbose stack traces. Which is why the alternative
-  // `'verbose'` setting is commented out below. However, the actual cause
-  // of the bug may be anywhere, so the `'noise'` thrown out by the default
-  // `'concise'` setting may also contain the signal you need. To see it,
-  // uncomment out the following line. But please do not commit it in that
-  // state.
-  //
-  // NOTE TO REVIEWERS: If you see the following line *not* commented out,
+  // NOTE TO REVIEWERS: If you see the following line commented out,
   // this may be a development accident that should be fixed before merging.
   //
-  // stackFiltering: 'verbose',
+  overrideTaming: 'min',
 
   // The default `{consoleTaming: 'safe'}` setting usually makes for a
   // better debugging experience, by wrapping the original `console` with
@@ -47,6 +59,9 @@ lockdown({
   // errors, expecially those thrown by the `assert` system. However,
   // in case the SES `console` is getting in the way, we provide the
   // `'unsafe'` option for leaving the original `console` in place.
+  //
+  // NOTE TO REVIEWERS: If you see the following line *not* commented out,
+  // this may be a development accident that should be fixed before merging.
   //
   // consoleTaming: 'unsafe',
 });

--- a/packages/SwingSet/tools/prepare-test-env.js
+++ b/packages/SwingSet/tools/prepare-test-env.js
@@ -6,7 +6,7 @@
  * for virtual objects: makeKind, makeWeakStore
  */
 
-import '@agoric/install-ses';
+import './install-ses-debug';
 import { makeFakeVirtualObjectManager } from './fakeVirtualObjectManager';
 
 const { makeKind, makeWeakStore } = makeFakeVirtualObjectManager(3);

--- a/packages/deploy-script-support/package.json
+++ b/packages/deploy-script-support/package.json
@@ -71,8 +71,7 @@
       "test/**/test-*.js"
     ],
     "require": [
-      "esm",
-      "@agoric/install-ses"
+      "esm"
     ]
   },
   "eslintConfig": {

--- a/packages/install-ses/install-ses.js
+++ b/packages/install-ses/install-ses.js
@@ -4,7 +4,72 @@ import 'ses';
 // Install our HandledPromise global.
 import '@agoric/eventual-send/shim';
 
-lockdown();
+// For testing under Ava, and also sometimes for testing and debugging in
+// general, when safety is not needed, you perhaps want to use
+// packages/SwingSet/tools/install-ses-debug.js instead of this one.
+// If you're using a prepare-test-env.js, it is probably already doing that
+// for you.
+
+lockdown({
+  // The default `{errorTaming: 'safe'}` setting, if possible, redacts the
+  // stack trace info from the error instances, so that it is not available
+  // merely by saying `errorInstance.stack`. However, some tools
+  // will look for the stack there and become much less useful if it is
+  // missing. In production, the settings in this file need to preserve
+  // security, so the 'unsafe' setting below MUST always be commented out
+  // except during private development.
+  //
+  // NOTE TO REVIEWERS: If you see the following line *not* commented out,
+  // this may be a development accident that MUST be fixed before merging.
+  //
+  // errorTaming: 'unsafe',
+  //
+  //
+  // The default `{stackFiltering: 'concise'}` setting usually makes for a
+  // better debugging experience, by severely reducing the noisy distractions
+  // of the normal verbose stack traces. Which is why we comment
+  // out the `'verbose'` setting is commented out below. However, some
+  // tools look for the full filename that it expects in order
+  // to fetch the source text for diagnostics,
+  //
+  // Another reason for not commenting it out: The cause
+  // of the bug may be anywhere, so the `'noise'` thrown out by the default
+  // `'concise'` setting may also contain the signal you need. To see it,
+  // uncomment out the following line. But please do not commit it in that
+  // state.
+  //
+  // NOTE TO REVIEWERS: If you see the following line *not* commented out,
+  // this may be a development accident that MUST be fixed before merging.
+  //
+  // stackFiltering: 'verbose',
+  //
+  //
+  // The default `{overrideTaming: 'moderate'}` setting does not hurt the
+  // debugging experience much. But it will introduce noise into, for example,
+  // the vscode debugger's object inspector. During debug and test, if you can
+  // avoid legacy code that needs the `'moderate'` setting, then the `'min'`
+  // setting reduces debugging noise yet further, by turning fewer inherited
+  // properties into accessors.
+  //
+  // NOTE TO REVIEWERS: If you see the following line *not* commented out,
+  // this may be a development accident that MUST be fixed before merging.
+  //
+  // overrideTaming: 'min',
+  //
+  //
+  // The default `{consoleTaming: 'safe'}` setting usually makes for a
+  // better debugging experience, by wrapping the original `console` with
+  // the SES replacement `console` that provides more information about
+  // errors, expecially those thrown by the `assert` system. However,
+  // in case the SES `console` is getting in the way, we provide the
+  // `'unsafe'` option for leaving the original `console` in place.
+  //
+  // NOTE TO REVIEWERS: If you see the following line *not* commented out,
+  // this may be a development accident that MUST be fixed before merging.
+  //
+  // consoleTaming: 'unsafe',
+});
+
 // We are now in the "Start Compartment". Our global has all the same
 // powerful things it had before, but the primordials have changed to make
 // them safe to use in the arguments of API calls we make into more limited


### PR DESCRIPTION
prepare-test-env optimizes for debugging and testing at the expense of safety.

Progress on #2662 but does not yet close it.