### PR TITLE
Use prepare-test-env and ses-ava in SwingSet where possible

### DIFF
--- a/packages/ERTP/test/swingsetTests/basicFunctionality/test-basicFunctionality.js
+++ b/packages/ERTP/test/swingsetTests/basicFunctionality/test-basicFunctionality.js
@@ -2,7 +2,7 @@
 /* global __dirname */
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/swingset-vat/tools/prepare-test-env';
+import '@agoric/swingset-vat/tools/prepare-test-env-ava';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';

--- a/packages/ERTP/test/swingsetTests/splitPayments/test-splitPayments.js
+++ b/packages/ERTP/test/swingsetTests/splitPayments/test-splitPayments.js
@@ -2,7 +2,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/swingset-vat/tools/prepare-test-env';
+import '@agoric/swingset-vat/tools/prepare-test-env-ava';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';

--- a/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/swingset-vat/tools/prepare-test-env';
+import '@agoric/swingset-vat/tools/prepare-test-env-ava';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';

--- a/packages/ERTP/test/unitTests/mathHelpers/test-setMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-setMathHelpers.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/swingset-vat/tools/prepare-test-env';
+import '@agoric/swingset-vat/tools/prepare-test-env-ava';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';

--- a/packages/ERTP/test/unitTests/mathHelpers/test-strSetMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-strSetMathHelpers.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/swingset-vat/tools/prepare-test-env';
+import '@agoric/swingset-vat/tools/prepare-test-env-ava';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';

--- a/packages/ERTP/test/unitTests/test-interfaces.js
+++ b/packages/ERTP/test/unitTests/test-interfaces.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/swingset-vat/tools/prepare-test-env';
+import '@agoric/swingset-vat/tools/prepare-test-env-ava';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/swingset-vat/tools/prepare-test-env';
+import '@agoric/swingset-vat/tools/prepare-test-env-ava';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';

--- a/packages/ERTP/test/unitTests/test-mintObj.js
+++ b/packages/ERTP/test/unitTests/test-mintObj.js
@@ -1,6 +1,6 @@
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/swingset-vat/tools/prepare-test-env';
+import '@agoric/swingset-vat/tools/prepare-test-env-ava';
 
 import { Far } from '@agoric/marshal';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/SwingSet/test/definition/test-vat-definition.js
+++ b/packages/SwingSet/test/definition/test-vat-definition.js
@@ -1,6 +1,6 @@
 /* global require */
-import '@agoric/install-ses';
-import test from 'ava';
+import { test } from '../../tools/prepare-test-env-ava';
+
 import { buildVatController } from '../../src/index';
 
 const mUndefined = { '@qclass': 'undefined' };

--- a/packages/SwingSet/test/test-comms.js
+++ b/packages/SwingSet/test/test-comms.js
@@ -1,14 +1,11 @@
-import { wrapTest } from '@agoric/ses-ava';
-import '@agoric/install-ses';
-import rawTest from 'ava';
+import { test } from '../tools/prepare-test-env-ava';
+
 import buildCommsDispatch from '../src/vats/comms';
 import { flipRemoteSlot } from '../src/vats/comms/parseRemoteSlot';
 import { makeState, makeStateKit } from '../src/vats/comms/state';
 import { makeCListKit } from '../src/vats/comms/clist';
 import { addRemote } from '../src/vats/comms/remote';
 import { debugState } from '../src/vats/comms/dispatch';
-
-const test = wrapTest(rawTest);
 
 test('provideRemoteForLocal', t => {
   const s = makeState(0);
@@ -206,7 +203,7 @@ test('receive', t => {
         encodeArgs(`47:deliver:${bobRemote}:bar::ro-20:${bobRemote};argsbytes`),
         null,
       ),
-    { message: /unexpected recv seqNum \(a string\)/ },
+    { message: /unexpected recv seqNum .*/ },
   );
 
   // make sure comms can tolerate dropExports, even if it's a no-op

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -1,6 +1,7 @@
 /* global require __dirname */
-import '@agoric/install-ses';
-import test from 'ava';
+import { test } from '../tools/prepare-test-env-ava';
+
+// eslint-disable-next-line import/order
 import path from 'path';
 import { buildVatController, loadBasedir } from '../src/index';
 import { checkKT } from './util';

--- a/packages/SwingSet/test/test-demos-comms.js
+++ b/packages/SwingSet/test/test-demos-comms.js
@@ -1,7 +1,8 @@
 /* global __dirname */
-import '@agoric/install-ses';
+// eslint-disable-next-line import/order
+import { test } from '../tools/prepare-test-env-ava';
+
 import { initSwingStore } from '@agoric/swing-store-simple';
-import test from 'ava';
 import path from 'path';
 import { buildLoopbox } from '../src/devices/loopbox';
 import {

--- a/packages/SwingSet/test/test-demos.js
+++ b/packages/SwingSet/test/test-demos.js
@@ -1,7 +1,8 @@
 /* global __dirname */
-import '@agoric/install-ses';
+// eslint-disable-next-line import/order
+import { test } from '../tools/prepare-test-env-ava';
+
 import { initSwingStore } from '@agoric/swing-store-simple';
-import test from 'ava';
 import path from 'path';
 import { buildLoopbox } from '../src/devices/loopbox';
 import {

--- a/packages/SwingSet/test/test-device-bridge.js
+++ b/packages/SwingSet/test/test-device-bridge.js
@@ -1,6 +1,7 @@
 /* global require */
-import '@agoric/install-ses';
-import test from 'ava';
+import { test } from '../tools/prepare-test-env-ava';
+
+// eslint-disable-next-line import/order
 import { initSwingStore } from '@agoric/swing-store-simple';
 
 import {

--- a/packages/SwingSet/test/test-exomessages.js
+++ b/packages/SwingSet/test/test-exomessages.js
@@ -1,6 +1,6 @@
 /* global require */
-import '@agoric/install-ses';
-import test from 'ava';
+import { test } from '../tools/prepare-test-env-ava';
+
 import { buildVatController } from '../src/index';
 
 async function beginning(t, mode) {

--- a/packages/SwingSet/test/test-fake-weakref.js
+++ b/packages/SwingSet/test/test-fake-weakref.js
@@ -1,5 +1,5 @@
-import '@agoric/install-ses';
-import test from 'ava';
+import { test } from '../tools/prepare-test-env-ava';
+
 import { WeakRef, FinalizationRegistry } from '../src/weakref';
 
 // We don't test that WeakRefs actually work, we only make sure we can

--- a/packages/SwingSet/test/test-kernel.js
+++ b/packages/SwingSet/test/test-kernel.js
@@ -1,5 +1,6 @@
-import '@agoric/install-ses';
-import test from 'ava';
+// eslint-disable-next-line import/order
+import { test } from '../tools/prepare-test-env-ava';
+
 import anylogger from 'anylogger';
 import { initSwingStore } from '@agoric/swing-store-simple';
 import { assert, details as X } from '@agoric/assert';

--- a/packages/SwingSet/test/test-liveslots.js
+++ b/packages/SwingSet/test/test-liveslots.js
@@ -1,5 +1,6 @@
-import '@agoric/install-ses';
-import test from 'ava';
+// eslint-disable-next-line import/order
+import { test } from '../tools/prepare-test-env-ava';
+
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';

--- a/packages/SwingSet/test/test-marshal.js
+++ b/packages/SwingSet/test/test-marshal.js
@@ -1,7 +1,8 @@
 /* global setImmediate */
-import '@agoric/install-ses';
+// eslint-disable-next-line import/order
+import { test } from '../tools/prepare-test-env-ava';
+
 import { Far } from '@agoric/marshal';
-import test from 'ava';
 import { makePromiseKit } from '@agoric/promise-kit';
 
 import { WeakRef, FinalizationRegistry } from '../src/weakref';

--- a/packages/SwingSet/test/test-netstring.js
+++ b/packages/SwingSet/test/test-netstring.js
@@ -1,7 +1,6 @@
 /* global Buffer */
-import '@agoric/install-ses'; // adds 'harden' to global
+import { test } from '../tools/prepare-test-env-ava';
 
-import test from 'ava';
 import {
   encode,
   decode,

--- a/packages/SwingSet/test/test-network.js
+++ b/packages/SwingSet/test/test-network.js
@@ -1,5 +1,6 @@
-import '@agoric/install-ses'; // adds 'harden' to global
-import test from 'ava';
+import { test } from '../tools/prepare-test-env-ava';
+
+// eslint-disable-next-line import/order
 import { makePromiseKit } from '@agoric/promise-kit';
 
 import {

--- a/packages/SwingSet/test/test-node-version.js
+++ b/packages/SwingSet/test/test-node-version.js
@@ -1,7 +1,9 @@
 // eslint-disable-next-line no-redeclare
 /* global process */
+import { test } from '../tools/prepare-test-env-ava';
+
+// eslint-disable-next-line import/order
 import semver from 'semver';
-import test from 'ava';
 
 test('Node version for IO queue priority', t => {
   t.true(

--- a/packages/SwingSet/test/test-promises.js
+++ b/packages/SwingSet/test/test-promises.js
@@ -1,6 +1,7 @@
 /* global __dirname */
-import '@agoric/install-ses';
-import test from 'ava';
+import { test } from '../tools/prepare-test-env-ava';
+
+// eslint-disable-next-line import/order
 import path from 'path';
 import {
   buildVatController,

--- a/packages/SwingSet/test/test-queue-priority.js
+++ b/packages/SwingSet/test/test-queue-priority.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line no-redeclare
 /* global setImmediate setTimeout */
-import test from 'ava';
+import { test } from '../tools/prepare-test-env-ava';
 
 test('Promise queue should be higher priority than IO/timer queue', async t => {
   const log = [];

--- a/packages/SwingSet/test/test-state.js
+++ b/packages/SwingSet/test/test-state.js
@@ -1,5 +1,6 @@
-import '@agoric/install-ses';
-import test from 'ava';
+import { test } from '../tools/prepare-test-env-ava';
+
+// eslint-disable-next-line import/order
 import {
   initSwingStore,
   getAllState,

--- a/packages/SwingSet/test/test-syscall-failure.js
+++ b/packages/SwingSet/test/test-syscall-failure.js
@@ -1,6 +1,7 @@
 /* global require */
-import '@agoric/install-ses';
-import test from 'ava';
+import { test } from '../tools/prepare-test-env-ava';
+
+// eslint-disable-next-line import/order
 import { initSwingStore } from '@agoric/swing-store-simple';
 import { buildVatController } from '../src';
 

--- a/packages/SwingSet/test/test-tildot.js
+++ b/packages/SwingSet/test/test-tildot.js
@@ -1,6 +1,6 @@
 /* global require */
-import '@agoric/install-ses';
-import test from 'ava';
+import { test } from '../tools/prepare-test-env-ava';
+
 import { buildVatController } from '../src/index';
 
 test('vat code can use tildot', async t => {

--- a/packages/SwingSet/test/test-timer-device.js
+++ b/packages/SwingSet/test/test-timer-device.js
@@ -1,5 +1,5 @@
-import '@agoric/install-ses';
-import test from 'ava';
+import { test } from '../tools/prepare-test-env-ava';
+
 import { makeTimerMap, curryPollFn } from '../src/devices/timer-src';
 
 test('multiMap multi store', t => {

--- a/packages/SwingSet/test/test-transcript-light.js
+++ b/packages/SwingSet/test/test-transcript-light.js
@@ -1,6 +1,7 @@
 /* global __dirname */
-import '@agoric/install-ses';
-import test from 'ava';
+// eslint-disable-next-line import/order
+import { test } from '../tools/prepare-test-env-ava';
+
 import path from 'path';
 import {
   initSwingStore,

--- a/packages/SwingSet/test/test-transcript.js
+++ b/packages/SwingSet/test/test-transcript.js
@@ -1,6 +1,7 @@
 /* global __dirname */
-import '@agoric/install-ses';
-import test from 'ava';
+// eslint-disable-next-line import/order
+import { test } from '../tools/prepare-test-env-ava';
+
 import path from 'path';
 // import fs from 'fs';
 import {

--- a/packages/SwingSet/test/test-vat-env.js
+++ b/packages/SwingSet/test/test-vat-env.js
@@ -1,8 +1,7 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/swingset-vat/tools/prepare-test-env';
+import { test } from '../tools/prepare-test-env-ava';
+
+// eslint-disable-next-line import/order
 import { Far } from '@agoric/marshal';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
 
 test('harden from SES is in the vat environment', t => {
   harden();

--- a/packages/SwingSet/test/test-vattp.js
+++ b/packages/SwingSet/test/test-vattp.js
@@ -1,6 +1,7 @@
 /* global require */
-import '@agoric/install-ses';
-import test from 'ava';
+import { test } from '../tools/prepare-test-env-ava';
+
+// eslint-disable-next-line import/order
 import { initSwingStore } from '@agoric/swing-store-simple';
 import { initializeSwingset, makeSwingsetController } from '../src/index';
 import { buildMailboxStateMap, buildMailbox } from '../src/devices/mailbox';

--- a/packages/SwingSet/test/test-vpid-kernel.js
+++ b/packages/SwingSet/test/test-vpid-kernel.js
@@ -1,5 +1,6 @@
-import '@agoric/install-ses';
-import test from 'ava';
+// eslint-disable-next-line import/order
+import { test } from '../tools/prepare-test-env-ava';
+
 import anylogger from 'anylogger';
 import { initSwingStore } from '@agoric/swing-store-simple';
 import { assert, details as X } from '@agoric/assert';

--- a/packages/SwingSet/test/test-vpid-liveslots.js
+++ b/packages/SwingSet/test/test-vpid-liveslots.js
@@ -1,8 +1,7 @@
 // eslint-disable-next-line no-redeclare
 /* global setImmediate */
-
-import '@agoric/install-ses';
-import test from 'ava';
+// eslint-disable-next-line import/order
+import { test } from '../tools/prepare-test-env-ava';
 
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';

--- a/packages/SwingSet/test/test-worker-protocol.js
+++ b/packages/SwingSet/test/test-worker-protocol.js
@@ -1,7 +1,6 @@
 /* global Buffer */
-import '@agoric/install-ses'; // adds 'harden' to global
+import { test } from '../tools/prepare-test-env-ava';
 
-import test from 'ava';
 import { arrayEncoderStream, arrayDecoderStream } from '../src/worker-protocol';
 import {
   encode,

--- a/packages/SwingSet/test/timer-device/test-device.js
+++ b/packages/SwingSet/test/timer-device/test-device.js
@@ -1,6 +1,7 @@
 /* global require */
-import '@agoric/install-ses';
-import test from 'ava';
+import { test } from '../../tools/prepare-test-env-ava';
+
+// eslint-disable-next-line import/order
 import { initSwingStore } from '@agoric/swing-store-simple';
 
 import { initializeSwingset, makeSwingsetController } from '../../src/index';

--- a/packages/SwingSet/test/virtualObjects/test-representatives.js
+++ b/packages/SwingSet/test/virtualObjects/test-representatives.js
@@ -1,7 +1,8 @@
 /* global __dirname */
-import '@agoric/install-ses';
+import { test } from '../../tools/prepare-test-env-ava';
+
+// eslint-disable-next-line import/order
 import path from 'path';
-import test from 'ava';
 import { buildVatController } from '../../src/index';
 import makeNextLog from '../make-nextlog';
 

--- a/packages/SwingSet/test/virtualObjects/test-virtualObjectCache.js
+++ b/packages/SwingSet/test/virtualObjects/test-virtualObjectCache.js
@@ -1,5 +1,5 @@
-import '@agoric/install-ses';
-import test from 'ava';
+import { test } from '../../tools/prepare-test-env-ava';
+
 import { makeCache } from '../../src/kernel/virtualObjectManager';
 
 function makeFakeStore() {

--- a/packages/SwingSet/test/virtualObjects/test-virtualObjectManager.js
+++ b/packages/SwingSet/test/virtualObjects/test-virtualObjectManager.js
@@ -1,5 +1,6 @@
-import '@agoric/install-ses';
-import test from 'ava';
+import { test } from '../../tools/prepare-test-env-ava';
+
+// eslint-disable-next-line import/order
 import { Far } from '@agoric/marshal';
 import { makeFakeVirtualObjectManager } from '../../tools/fakeVirtualObjectManager';
 

--- a/packages/SwingSet/test/workers/test-worker.js
+++ b/packages/SwingSet/test/workers/test-worker.js
@@ -1,6 +1,6 @@
 /* global require __dirname */
-import '@agoric/install-ses';
-import test from 'ava';
+import { test } from '../../tools/prepare-test-env-ava';
+
 import { loadBasedir, buildVatController } from '../../src/index';
 
 const expected = [['B good', 'C good', 'F good', 'three good'], 'rp3 good'];

--- a/packages/SwingSet/tools/prepare-test-env-ava.js
+++ b/packages/SwingSet/tools/prepare-test-env-ava.js
@@ -1,0 +1,18 @@
+/**
+ * Like prepare-test-env but also sets up ses-ava and provides
+ * the ses-ava `test` function to be used as if it is the ava
+ * `test` function.
+ */
+
+// eslint thinks these are extraneous dependencies because this file
+// is in the tools/ directory rather than the test/ directory.
+// TODO How do we tell eslint that tools/ is dev-only? Either
+// that, or should we just move tools/* into test/ ?
+//
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { wrapTest } from '@agoric/ses-ava';
+import './prepare-test-env';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import rawTest from 'ava';
+
+export const test = wrapTest(rawTest);

--- a/packages/dapp-svelte-wallet/api/test/test-getPursesNotifier.js
+++ b/packages/dapp-svelte-wallet/api/test/test-getPursesNotifier.js
@@ -1,6 +1,6 @@
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env'; // calls lockdown()
+import '@agoric/zoe/tools/prepare-test-env-ava'; // calls lockdown()
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/dapp-svelte-wallet/api/test/test-lib-dehydrate.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-dehydrate.js
@@ -1,4 +1,4 @@
-import '@agoric/zoe/tools/prepare-test-env'; // calls lockdown()
+import '@agoric/zoe/tools/prepare-test-env-ava'; // calls lockdown()
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { Far } from '@agoric/marshal';

--- a/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
@@ -1,7 +1,7 @@
 /* global require */
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env'; // calls lockdown()
+import '@agoric/zoe/tools/prepare-test-env-ava'; // calls lockdown()
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/deploy-script-support/test/unitTests/test-assertOfferResult.js
+++ b/packages/deploy-script-support/test/unitTests/test-assertOfferResult.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/deploy-script-support/test/unitTests/test-depositInvitation.js
+++ b/packages/deploy-script-support/test/unitTests/test-depositInvitation.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { makeIssuerKit, MathKind } from '@agoric/ertp';

--- a/packages/deploy-script-support/test/unitTests/test-findInvitationAmount.js
+++ b/packages/deploy-script-support/test/unitTests/test-findInvitationAmount.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { makeIssuerKit, MathKind } from '@agoric/ertp';

--- a/packages/deploy-script-support/test/unitTests/test-install.js
+++ b/packages/deploy-script-support/test/unitTests/test-install.js
@@ -1,7 +1,7 @@
 /* global require */
 // @ts-check
 
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { makeZoe } from '@agoric/zoe';

--- a/packages/deploy-script-support/test/unitTests/test-offer.js
+++ b/packages/deploy-script-support/test/unitTests/test-offer.js
@@ -1,7 +1,7 @@
 /* global require */
 // @ts-check
 
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { makeZoe } from '@agoric/zoe';

--- a/packages/deploy-script-support/test/unitTests/test-resolvePathForLocalContract.js
+++ b/packages/deploy-script-support/test/unitTests/test-resolvePathForLocalContract.js
@@ -1,7 +1,7 @@
 /* global require */
 // @ts-check
 
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/deploy-script-support/test/unitTests/test-resolvePathForPackagedContract.js
+++ b/packages/deploy-script-support/test/unitTests/test-resolvePathForPackagedContract.js
@@ -1,7 +1,7 @@
 /* global require */
 // @ts-check
 
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/deploy-script-support/test/unitTests/test-saveLocalAmountMaths.js
+++ b/packages/deploy-script-support/test/unitTests/test-saveLocalAmountMaths.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/deploy-script-support/test/unitTests/test-startInstance.js
+++ b/packages/deploy-script-support/test/unitTests/test-startInstance.js
@@ -1,7 +1,7 @@
 /* global require */
 // @ts-check
 
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { makeZoe } from '@agoric/zoe';

--- a/packages/install-ses/install-ses.js
+++ b/packages/install-ses/install-ses.js
@@ -7,7 +7,7 @@ import '@agoric/eventual-send/shim';
 // For testing under Ava, and also sometimes for testing and debugging in
 // general, when safety is not needed, you perhaps want to use
 // packages/SwingSet/tools/install-ses-debug.js instead of this one.
-// If you're using a prepare-test-env.js, it is probably already doing that
+// If you're using a prepare-test-env-ava.js, it is probably already doing that
 // for you.
 
 lockdown({

--- a/packages/ui-components/test/display/natValue/test-captureNum.js
+++ b/packages/ui-components/test/display/natValue/test-captureNum.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { captureNum } from '../../../src/display/natValue/helpers/captureNum';

--- a/packages/ui-components/test/display/natValue/test-parseAsNat.js
+++ b/packages/ui-components/test/display/natValue/test-parseAsNat.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { parseAsNat } from '../../../src/display/natValue/parseAsNat';

--- a/packages/ui-components/test/display/natValue/test-roundToDecimalPlaces.js
+++ b/packages/ui-components/test/display/natValue/test-roundToDecimalPlaces.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { roundToDecimalPlaces as round } from '../../../src/display/natValue/helpers/roundToDecimalPlaces';

--- a/packages/ui-components/test/display/natValue/test-stringifyNat.js
+++ b/packages/ui-components/test/display/natValue/test-stringifyNat.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { stringifyNat } from '../../../src/display/natValue/stringifyNat';

--- a/packages/ui-components/test/display/natValue/test-stringifyRatio.js
+++ b/packages/ui-components/test/display/natValue/test-stringifyRatio.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/ui-components/test/display/setValue/test-parseAsSet.js
+++ b/packages/ui-components/test/display/setValue/test-parseAsSet.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { parseAsSet } from '../../../src/display/setValue/parseAsSet';

--- a/packages/ui-components/test/display/setValue/test-stringifySet.js
+++ b/packages/ui-components/test/display/setValue/test-stringifySet.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { stringifySet } from '../../../src/display/setValue/stringifySet';

--- a/packages/ui-components/test/display/test-display.js
+++ b/packages/ui-components/test/display/test-display.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { parseAsValue } from '../../src/display/display';

--- a/packages/zoe/test/unitTests/contractSupport/test-bondingCurves.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-bondingCurves.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/contractSupport/test-depositTo.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-depositTo.js
@@ -2,7 +2,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
@@ -2,7 +2,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/contractSupport/test-percentMath.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-percentMath.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/contractSupport/test-percentSupport.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-percentSupport.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { makeIssuerKit, amountMath } from '@agoric/ertp';

--- a/packages/zoe/test/unitTests/contractSupport/test-ratio.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-ratio.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import '../../../src/contractSupport/types';

--- a/packages/zoe/test/unitTests/contractSupport/test-stateMachine.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-stateMachine.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 import test from 'ava';
 
 import { makeStateMachine } from '../../../src/contractSupport';

--- a/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
@@ -2,7 +2,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { Far } from '@agoric/marshal';

--- a/packages/zoe/test/unitTests/contracts/loan/helpers.js
+++ b/packages/zoe/test/unitTests/contracts/loan/helpers.js
@@ -4,7 +4,7 @@
 import '../../../../exported';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 import { E } from '@agoric/eventual-send';
 import bundleSource from '@agoric/bundle-source';
 import { amountMath } from '@agoric/ertp';

--- a/packages/zoe/test/unitTests/contracts/loan/test-addCollateral.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-addCollateral.js
@@ -3,7 +3,7 @@
 import '../../../../exported';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
@@ -3,7 +3,7 @@
 import '../../../../exported';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/contracts/loan/test-close.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-close.js
@@ -2,7 +2,7 @@
 import '../../../../exported';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { E } from '@agoric/eventual-send';

--- a/packages/zoe/test/unitTests/contracts/loan/test-lend.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-lend.js
@@ -2,7 +2,7 @@
 import '../../../../exported';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { E } from '@agoric/eventual-send';

--- a/packages/zoe/test/unitTests/contracts/loan/test-liquidate.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-liquidate.js
@@ -3,7 +3,7 @@
 import '../../../../exported';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
@@ -3,7 +3,7 @@
 import '../../../../exported';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { E } from '@agoric/eventual-send';

--- a/packages/zoe/test/unitTests/contracts/loan/test-updateDebt.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-updateDebt.js
@@ -3,7 +3,7 @@
 import '../../../../exported';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
+++ b/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
@@ -3,7 +3,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import bundleSource from '@agoric/bundle-source';

--- a/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
+++ b/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
@@ -3,7 +3,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import bundleSource from '@agoric/bundle-source';

--- a/packages/zoe/test/unitTests/contracts/test-autoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-autoswap.js
@@ -2,7 +2,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { E } from '@agoric/eventual-send';

--- a/packages/zoe/test/unitTests/contracts/test-autoswapPool.js
+++ b/packages/zoe/test/unitTests/contracts/test-autoswapPool.js
@@ -3,7 +3,7 @@
 // isolated unit test of price calculations in pool in multipoolAutoswap
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/contracts/test-barter.js
+++ b/packages/zoe/test/unitTests/contracts/test-barter.js
@@ -2,7 +2,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { E } from '@agoric/eventual-send';

--- a/packages/zoe/test/unitTests/contracts/test-brokenContract.js
+++ b/packages/zoe/test/unitTests/contracts/test-brokenContract.js
@@ -1,7 +1,7 @@
 /* global __dirname */
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/test-callSpread-calculation.js
+++ b/packages/zoe/test/unitTests/contracts/test-callSpread-calculation.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import '../../../exported';

--- a/packages/zoe/test/unitTests/contracts/test-callSpread.js
+++ b/packages/zoe/test/unitTests/contracts/test-callSpread.js
@@ -3,7 +3,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { E } from '@agoric/eventual-send';

--- a/packages/zoe/test/unitTests/contracts/test-coveredCall.js
+++ b/packages/zoe/test/unitTests/contracts/test-coveredCall.js
@@ -3,7 +3,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import bundleSource from '@agoric/bundle-source';

--- a/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
@@ -1,7 +1,7 @@
 /* global __dirname */
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/test-mintPayments.js
+++ b/packages/zoe/test/unitTests/contracts/test-mintPayments.js
@@ -3,7 +3,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
@@ -1,7 +1,7 @@
 /* global __dirname */
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/contracts/test-oracle.js
+++ b/packages/zoe/test/unitTests/contracts/test-oracle.js
@@ -2,7 +2,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import anyTest from 'ava';
 import bundleSource from '@agoric/bundle-source';

--- a/packages/zoe/test/unitTests/contracts/test-otcDesk.js
+++ b/packages/zoe/test/unitTests/contracts/test-otcDesk.js
@@ -2,7 +2,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
@@ -2,7 +2,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import anyTest from 'ava';
 import bundleSource from '@agoric/bundle-source';

--- a/packages/zoe/test/unitTests/contracts/test-secondPriceAuction.js
+++ b/packages/zoe/test/unitTests/contracts/test-secondPriceAuction.js
@@ -2,7 +2,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import bundleSource from '@agoric/bundle-source';

--- a/packages/zoe/test/unitTests/contracts/test-sellTickets.js
+++ b/packages/zoe/test/unitTests/contracts/test-sellTickets.js
@@ -2,7 +2,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
+++ b/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
@@ -2,7 +2,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';

--- a/packages/zoe/test/unitTests/contracts/test-throwInOfferHandler.js
+++ b/packages/zoe/test/unitTests/contracts/test-throwInOfferHandler.js
@@ -2,7 +2,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/contracts/test-useObj.js
+++ b/packages/zoe/test/unitTests/contracts/test-useObj.js
@@ -2,7 +2,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/test-cleanProposal.js
+++ b/packages/zoe/test/unitTests/test-cleanProposal.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/test-fakePriceAuthority.js
+++ b/packages/zoe/test/unitTests/test-fakePriceAuthority.js
@@ -1,6 +1,6 @@
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { E } from '@agoric/eventual-send';

--- a/packages/zoe/test/unitTests/test-makeKind.js
+++ b/packages/zoe/test/unitTests/test-makeKind.js
@@ -2,7 +2,7 @@
 /* global __dirname makeKind makeWeakStore */
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import bundleSource from '@agoric/bundle-source';

--- a/packages/zoe/test/unitTests/test-manualTimer.js
+++ b/packages/zoe/test/unitTests/test-manualTimer.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';

--- a/packages/zoe/test/unitTests/test-objArrayConversion.js
+++ b/packages/zoe/test/unitTests/test-objArrayConversion.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/test-offerSafety.js
+++ b/packages/zoe/test/unitTests/test-offerSafety.js
@@ -1,6 +1,6 @@
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/test-rightsConservation.js
+++ b/packages/zoe/test/unitTests/test-rightsConservation.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/test-scriptedOracle.js
+++ b/packages/zoe/test/unitTests/test-scriptedOracle.js
@@ -1,7 +1,7 @@
 /* global __dirname */
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import anyTest from 'ava';
 import bundleSource from '@agoric/bundle-source';

--- a/packages/zoe/test/unitTests/test-zoe-env.js
+++ b/packages/zoe/test/unitTests/test-zoe-env.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 /* global makeKind, makeWeakStore */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -1,7 +1,7 @@
 /* global __dirname */
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -1,6 +1,6 @@
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
@@ -3,7 +3,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env';
+import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 

--- a/packages/zoe/tools/prepare-test-env-ava.js
+++ b/packages/zoe/tools/prepare-test-env-ava.js
@@ -1,0 +1,10 @@
+// @ts-check
+
+/**
+ * Prepare global environment for zoe tests.
+ *
+ * Currently, the zoe contract environment is
+ * the same as the SwingSet vat environment.
+ */
+
+import '@agoric/swingset-vat/tools/prepare-test-env-ava';


### PR DESCRIPTION
Enhance prepare-test-env beyond #2703 to also bundle in ses-ava.

Use it in SwingSet tests where possible. This does not include the metering tests.

Progress on #2662 but does not yet close it.