### PR TITLE
Some release tweaks

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,8 +16,8 @@ jobs:
       run: echo "SDK_VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
     - name: Save MODDABLE_COMMIT_HASH
       run: |
-        set $(git submodule status packages/xsnap/moddable)
-        echo "MODDABLE_COMMIT_HASH=$1" >> $GITHUB_ENV
+        git submodule status packages/xsnap/moddable | \
+        sed -ne 's/^.\([^ ]*\).*/MODDABLE_COMMIT_HASH=\1/p' >> $GITHUB_ENV
     - name: Build SDK image
       uses: elgohr/Publish-Docker-Github-Action@master
       with:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,8 @@
 version: "2.2"
 services:
   ag-solo:
-    image: agoric/cosmic-swingset-solo:${SDK_TAG:-latest}
+    # This tag needs to be the SDK used by the $NETCONFIG_URL
+    image: agoric/cosmic-swingset-solo:${SDK_TAG:-2.14.0}
     # ISSUE: 127.0.0.1? not a docker network?
     ports:
       - "${HOST_PORT:-8000}:${PORT:-8000}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/sdk",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "private": true,
   "useWorkspaces": true,
   "workspaces": [

--- a/packages/agoric-cli/lib/chain-config.js
+++ b/packages/agoric-cli/lib/chain-config.js
@@ -3,6 +3,8 @@ import TOML from '@iarna/toml';
 
 export const MINT_DENOM = 'uag';
 export const STAKING_DENOM = 'uagstake';
+export const STAKING_MAX_VALIDATORS = 150;
+
 export const GOV_DEPOSIT_COINS = [{ amount: '10000000', denom: MINT_DENOM }];
 
 // Can't beat the speed of light, we need 600ms round trip time for the other
@@ -108,6 +110,7 @@ export function finishCosmosGenesis({ genesisJson, exportedGenesisJson }) {
   genesis.app_state.ibc = initState.ibc;
 
   genesis.app_state.staking.params.bond_denom = STAKING_DENOM;
+  genesis.app_state.staking.params.max_validators = STAKING_MAX_VALIDATORS;
 
   // We scale this parameter according to our own block cadence, so
   // that we tolerate the same downtime as the old genesis.

--- a/packages/deployment/Makefile
+++ b/packages/deployment/Makefile
@@ -4,7 +4,8 @@ SS := ../cosmic-swingset/
 VERSION := $(shell node -e 'console.log(require("../../package.json").version)' 2>/dev/null)
 
 TAG := $(if $(VERSION),$(VERSION),latest)
-MODDABLE_COMMIT_HASH := $(firstword $(shell git submodule status ../xsnap/moddable))
+MODDABLE_COMMIT_HASH := $(shell git submodule status ../xsnap/moddable | \
+	sed -ne 's/^.\([^ ]*\).*/\1/p')
 
 # Don't push alpha tags as ":$(TAG)".
 ifeq ($(TAG),latest)


### PR DESCRIPTION
These are last-minute changes to:
- fix the Docker builds to be tolerant if submodules were not already initialised
- bump the default genesis.json max validators to 150
- default docker client to the actual devnet SDK version
