### PR TITLE
Missing comma. Fix changes error message

### DIFF
--- a/packages/zoe/src/contracts/callSpread/percent.js
+++ b/packages/zoe/src/contracts/callSpread/percent.js
@@ -12,11 +12,11 @@ const BASIS_POINTS = 10000n;
 
 // If ratio is between 0 and 1, subtract from 1.
 export function oneMinus(ratio) {
+  assertIsRatio(ratio);
   assert(
     ratio.numerator.brand === ratio.denominator.brand,
     X`oneMinus only supports ratios with a single brand, but ${ratio.numerator.brand} doesn't match ${ratio.denominator.brand}`,
   );
-  assertIsRatio(ratio);
   assert(
     ratio.numerator.value <= ratio.denominator.value,
     X`Parameter must be less than or equal to 1: ${ratio.numerator.value}/${ratio.denominator.value}`,

--- a/packages/zoe/test/unitTests/contractSupport/test-percentSupport.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-percentSupport.js
@@ -68,7 +68,7 @@ test('ratio - complement', t => {
   amountsEqual(t, multiplyBy(moe(100000), twoThirds), moe(66666), brand);
 
   t.throws(() => oneMinus(moe(3)), {
-    message: /Cannot read property 'brand' of undefined/,
+    message: /Parameter must be a Ratio record, but \(an object\) has "brand"/,
   });
   t.throws(() => oneMinus(makeRatioFromAmounts(moe(30), moe(20))), {
     message: 'Parameter must be less than or equal to 1: (a bigint)/(a bigint)',

--- a/packages/zoe/test/unitTests/contractSupport/test-percentSupport.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-percentSupport.js
@@ -67,11 +67,9 @@ test('ratio - complement', t => {
   amountsEqual(t, multiplyBy(moe(100000), oneThird), moe(33333), brand);
   amountsEqual(t, multiplyBy(moe(100000), twoThirds), moe(66666), brand);
 
-  t.throws(() =>
-    oneMinus(moe(3), {
-      message: 'Ratio must be a record with 4 fields',
-    }),
-  );
+  t.throws(() => oneMinus(moe(3)), {
+    message: /Cannot read property 'brand' of undefined/,
+  });
   t.throws(() => oneMinus(makeRatioFromAmounts(moe(30), moe(20))), {
     message: 'Parameter must be less than or equal to 1: (a bigint)/(a bigint)',
   });


### PR DESCRIPTION
Test case had missing comma. Once fixed, the error message was different than the test expected.

Note to reviewers: Please check the difference in error message and let me know if this change makes sense, or is itself the symptom of a problem. Thanks.