### PR TITLE
On-chain naming hubs

### DIFF
--- a/packages/cosmic-swingset/README-telemetry.md
+++ b/packages/cosmic-swingset/README-telemetry.md
@@ -53,13 +53,13 @@ enable = true
 address = "tcp://0.0.0.0:1317"
 ```
 
-If the API server is enabled, then this will export metrics at
+If the API server is enabled, then this will export Cosmos SDK metrics at
 http://0.0.0.0:1317/metrics?format=prometheus (at your enabled API server port).
 The metrics will also be exported at the Tendermint Prometheus port if enabled
 in the next section.
 
 The exported metrics are listed at:
-https://docs.cosmos.network/v0.40/core/telemetry.html
+https://docs.cosmos.network/v0.42/core/telemetry.html
 
 ## Tendermint metrics
 

--- a/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
@@ -210,6 +210,10 @@ export function buildRootObject(vatPowers, vatParameters) {
     );
 
     const {
+      nameHub: agoricNames,
+      nameAdmin: agoricNamesAdmin,
+    } = makeNameHubKit();
+    const {
       nameHub: namesByAddress,
       nameAdmin: namesByAddressAdmin,
     } = makeNameHubKit();
@@ -231,6 +235,9 @@ export function buildRootObject(vatPowers, vatParameters) {
         }
         if (powerFlags && powerFlags.includes('agoric.priceAuthorityAdmin')) {
           additionalPowers.priceAuthorityAdmin = priceAuthorityAdmin;
+        }
+        if (powerFlags && powerFlags.includes('agoric.agoricNamesAdmin')) {
+          additionalPowers.agoricNamesAdmin = agoricNamesAdmin;
         }
 
         const payments = await E(vats.mints).mintInitialPayments(
@@ -264,6 +271,7 @@ export function buildRootObject(vatPowers, vatParameters) {
 
         const bundle = harden({
           ...additionalPowers,
+          agoricNames,
           chainTimerService,
           sharingService,
           contractHost,
@@ -526,6 +534,7 @@ export function buildRootObject(vatPowers, vatParameters) {
                 // to give capabilities to all clients (since we are running
                 // locally with the `--give-me-all-the-agoric-powers` flag).
                 return chainBundler.createUserBundle(nickname, 'demo', [
+                  'agoric.agoricNamesAdmin',
                   'agoric.priceAuthorityAdmin',
                   'agoric.vattp',
                 ]);

--- a/packages/cosmic-swingset/lib/ag-solo/vats/nameHub.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/nameHub.js
@@ -1,0 +1,82 @@
+// @ts-check
+
+import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
+import { makePromiseKit } from '@agoric/promise-kit';
+import { makeStore } from '@agoric/store';
+
+import './types.js';
+
+/**
+ * @returns {NameHubKit}
+ */
+export const makeNameHubKit = () => {
+  /** @typedef {Partial<PromiseRecord<unknown> & { value: unknown }>} NameRecord */
+  /** @type {Store<unknown, NameRecord>} */
+  const keyToRecord = makeStore('nameKey');
+
+  /** @type {NameHub} */
+  const nameHub = {
+    async lookup(...path) {
+      if (path.length === 0) {
+        return nameHub;
+      }
+      const [first, ...remaining] = path;
+      const record = keyToRecord.get(first);
+      /** @type {any} */
+      const firstValue = record.promise || record.value;
+      if (remaining.length === 0) {
+        return firstValue;
+      }
+      return E(firstValue).lookup(...remaining);
+    },
+  };
+
+  /** @type {NameAdmin} */
+  const nameAdmin = {
+    reserve(key) {
+      if (keyToRecord.has(key)) {
+        // If we already have a promise, don't use a new one.
+        if (keyToRecord.get(key).promise) {
+          return;
+        }
+        keyToRecord.set(key, makePromiseKit());
+      } else {
+        keyToRecord.init(key, makePromiseKit());
+      }
+    },
+    update(key, newValue) {
+      const record = harden({ value: newValue });
+      if (keyToRecord.has(key)) {
+        const old = keyToRecord.get(key);
+        if (old.resolve) {
+          old.resolve(newValue);
+        }
+        keyToRecord.set(key, record);
+      } else {
+        keyToRecord.init(key, record);
+      }
+    },
+    delete(key) {
+      if (keyToRecord.has(key)) {
+        // Reject only if already exists.
+        const old = keyToRecord.get(key);
+        if (old.reject) {
+          old.reject(Error(`Value has been deleted`));
+          // Silence unhandled rejections.
+          old.promise && old.promise.catch(_ => {});
+        }
+      }
+      // This delete may throw.  Reflect it to callers.
+      keyToRecord.delete(key);
+    },
+  };
+
+  const nameHubKit = {
+    nameHub: Far('nameHub', nameHub),
+    nameAdmin: Far('nameAdmin', nameAdmin),
+  };
+
+  harden(nameHubKit);
+  return nameHubKit;
+};

--- a/packages/cosmic-swingset/lib/ag-solo/vats/nameHub.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/nameHub.js
@@ -5,7 +5,7 @@ import { Far } from '@agoric/marshal';
 import { makePromiseKit } from '@agoric/promise-kit';
 import { makeStore } from '@agoric/store';
 
-import './types.js';
+// import './types.js';
 
 /**
  * @returns {NameHubKit}

--- a/packages/cosmic-swingset/lib/ag-solo/vats/nameHub.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/nameHub.js
@@ -5,7 +5,7 @@ import { Far } from '@agoric/marshal';
 import { makePromiseKit } from '@agoric/promise-kit';
 import { makeStore } from '@agoric/store';
 
-// import './types.js';
+import './types.js';
 
 /**
  * @returns {NameHubKit}

--- a/packages/cosmic-swingset/lib/ag-solo/vats/types.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/types.js
@@ -1,7 +1,34 @@
+// @ts-check
+
 /**
  * @typedef {Object} Board
  * @property {(id: string) => any} getValue
  * @property {(value: any) => string} getId
  * @property {(value: any) => boolean} has
  * @property {() => string[]} ids
+ */
+
+/**
+ * @typedef {Object} NameHub
+ * @property {(...path: Array<unknown>) => Promise<unknown>} lookup Look up a
+ * path of keys starting from the current NameHub.
+ */
+
+/**
+ * @typedef {Object} NameAdmin
+ * @property {(key: unknown) => void} reserve Mark a key as reserved; will
+ * return a promise that is fulfilled when the key is updated (or rejected when
+ * deleted).
+ * @property {(key: unknown, newValue: unknown) => void} update Fulfill an
+ * outstanding reserved promise (if any) to the newValue and set the key to the
+ * newValue.
+ * @property {(key: unknown) => void} delete Delete a value and reject an
+ * outstanding reserved promise (if any).
+ */
+
+/**
+ * @typedef {Object} NameHubKit A kit of a NameHub and its corresponding
+ * NameAdmin.
+ * @property {NameHub} nameHub
+ * @property {NameAdmin} nameAdmin
  */

--- a/packages/cosmic-swingset/lib/ag-solo/vats/types.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/types.js
@@ -11,7 +11,8 @@
 /**
  * @typedef {Object} NameHub
  * @property {(...path: Array<unknown>) => Promise<unknown>} lookup Look up a
- * path of keys starting from the current NameHub.
+ * path of keys starting from the current NameHub.  Wait on any reserved
+ * promises.
  */
 
 /**

--- a/packages/cosmic-swingset/lib/ag-solo/vats/vat-provisioning.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/vat-provisioning.js
@@ -15,7 +15,7 @@ export function buildRootObject(_vatPowers) {
     vattp = v;
   }
 
-  async function pleaseProvision(nickname, pubkey, powerFlags) {
+  async function pleaseProvision(nickname, address, powerFlags) {
     let chainBundle;
     const fetch = Far('fetch', {
       getDemoBundle() {
@@ -24,15 +24,19 @@ export function buildRootObject(_vatPowers) {
     });
 
     // Add a remote and egress for the pubkey.
-    const { transmitter, setReceiver } = await E(vattp).addRemote(pubkey);
-    await E(comms).addRemote(pubkey, transmitter, setReceiver);
+    const { transmitter, setReceiver } = await E(vattp).addRemote(address);
+    await E(comms).addRemote(address, transmitter, setReceiver);
 
     const INDEX = 1;
-    await E(comms).addEgress(pubkey, INDEX, fetch);
+    await E(comms).addEgress(address, INDEX, fetch);
 
     // Do this here so that any side-effects don't happen unless
     // the egress has been successfully added.
-    chainBundle = E(bundler).createUserBundle(nickname, powerFlags || []);
+    chainBundle = E(bundler).createUserBundle(
+      nickname,
+      address,
+      powerFlags || [],
+    );
     return { ingressIndex: INDEX };
   }
 

--- a/packages/cosmic-swingset/test/unitTests/test-name-hub.js
+++ b/packages/cosmic-swingset/test/unitTests/test-name-hub.js
@@ -1,0 +1,53 @@
+import '@agoric/install-ses';
+import test from 'ava';
+
+import { makeNameHubKit } from '../../lib/ag-solo/vats/nameHub';
+
+test('makeNameHubKit - reserve and update', async t => {
+  const { nameAdmin, nameHub } = makeNameHubKit();
+
+  await t.throwsAsync(() => nameHub.lookup('hello'), {
+    message: '"nameKey" not found: (a string)',
+  });
+
+  // Try reserving and looking up.
+  nameAdmin.reserve('hello');
+
+  let lookedUpHello = false;
+  const lookupHelloP = nameHub
+    .lookup('hello')
+    .finally(() => (lookedUpHello = true));
+
+  t.falsy(lookedUpHello);
+  nameAdmin.update('hello', 'foo');
+  t.is(await lookupHelloP, 'foo');
+  t.truthy(lookedUpHello);
+
+  nameAdmin.update('hello', 'foo2');
+  t.is(await nameHub.lookup('hello'), 'foo2');
+});
+
+test('makeNameHubKit - reserve and delete', async t => {
+  const { nameAdmin, nameHub } = makeNameHubKit();
+
+  await t.throwsAsync(() => nameHub.lookup('goodbye'), {
+    message: '"nameKey" not found: (a string)',
+  });
+
+  nameAdmin.reserve('goodbye');
+  let lookedUpGoodbye = false;
+  const lookupGoodbyeP = nameHub
+    .lookup('bar')
+    .finally(() => (lookedUpGoodbye = true));
+
+  t.falsy(lookedUpGoodbye);
+  nameAdmin.delete('goodbye');
+  await t.throwsAsync(lookupGoodbyeP, {
+    message: '"nameKey" not found: (a string)',
+  });
+  t.truthy(lookedUpGoodbye);
+
+  await t.throwsAsync(() => nameHub.lookup('goodbye'), {
+    message: '"nameKey" not found: (a string)',
+  });
+});

--- a/packages/cosmic-swingset/test/unitTests/test-name-hub.js
+++ b/packages/cosmic-swingset/test/unitTests/test-name-hub.js
@@ -3,6 +3,27 @@ import test from 'ava';
 
 import { makeNameHubKit } from '../../lib/ag-solo/vats/nameHub';
 
+test('makeNameHubKit - lookup paths', async t => {
+  const { nameAdmin: na1, nameHub: nh1 } = makeNameHubKit();
+  const { nameAdmin: na2, nameHub: nh2 } = makeNameHubKit();
+  const { nameAdmin: na3, nameHub: nh3 } = makeNameHubKit();
+
+  na1.update('path1', nh2);
+  t.is(await nh1.lookup('path1'), nh2);
+  na2.update('path2', nh3);
+  t.is(await nh2.lookup('path2'), nh3);
+  na3.update('path3', 'finish');
+  t.is(await nh3.lookup('path3'), 'finish');
+
+  t.is(await nh1.lookup(), nh1);
+  t.is(await nh1.lookup('path1'), nh2);
+  t.is(await nh1.lookup('path1', 'path2'), nh3);
+  t.is(await nh1.lookup('path1', 'path2', 'path3'), 'finish');
+  await t.throwsAsync(() => nh1.lookup('path1', 'path2', 'path3', 'path4'), {
+    message: /^target has no method "lookup", has/,
+  });
+});
+
 test('makeNameHubKit - reserve and update', async t => {
   const { nameAdmin, nameHub } = makeNameHubKit();
 

--- a/packages/dapp-svelte-wallet/api/deploy.js
+++ b/packages/dapp-svelte-wallet/api/deploy.js
@@ -13,7 +13,7 @@ export default async function deployWallet(
   const home = await homePromise;
   // console.log('have home', home);
   const {
-    agoric: { board, faucet, zoe },
+    agoric: { agoricNames, namesByAddress, board, faucet, zoe },
     local: { http, spawner, wallet: oldWallet },
   } = home;
 
@@ -25,6 +25,8 @@ export default async function deployWallet(
 
   // Wallet for both end-user client and dapp dev client
   const walletVat = await E(walletInstall).spawn({
+    agoricNames,
+    namesByAddress,
     zoe,
     board,
     faucet,

--- a/packages/dapp-svelte-wallet/api/src/lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-wallet.js
@@ -53,6 +53,8 @@ const cmp = (a, b) => {
  * @typedef {Object} MakeWalletParams
  * @property {ZoeService} zoe
  * @property {Board} board
+ * @property {NameHub} agoricNames
+ * @property {NameHub} namesByAddress
  * @property {(state: any) => void} [pursesStateChangeHandler=noActionStateChangeHandler]
  * @property {(state: any) => void} [inboxStateChangeHandler=noActionStateChangeHandler]
  * @param {MakeWalletParams} param0
@@ -60,6 +62,8 @@ const cmp = (a, b) => {
 export function makeWallet({
   zoe,
   board,
+  agoricNames,
+  namesByAddress,
   pursesStateChangeHandler = noActionStateChangeHandler,
   inboxStateChangeHandler = noActionStateChangeHandler,
 }) {
@@ -1471,6 +1475,12 @@ export function makeWallet({
     },
     getBoard() {
       return board;
+    },
+    getAgoricNames(...path) {
+      return E(agoricNames).lookup(...path);
+    },
+    getNamesByAddress(...path) {
+      return E(namesByAddress).lookup(...path);
     },
   });
 

--- a/packages/dapp-svelte-wallet/api/src/lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-wallet.js
@@ -53,8 +53,8 @@ const cmp = (a, b) => {
  * @typedef {Object} MakeWalletParams
  * @property {ZoeService} zoe
  * @property {Board} board
- * @property {NameHub} agoricNames
- * @property {NameHub} namesByAddress
+ * @property {NameHub} [agoricNames]
+ * @property {NameHub} [namesByAddress]
  * @property {(state: any) => void} [pursesStateChangeHandler=noActionStateChangeHandler]
  * @property {(state: any) => void} [inboxStateChangeHandler=noActionStateChangeHandler]
  * @param {MakeWalletParams} param0
@@ -1477,9 +1477,14 @@ export function makeWallet({
       return board;
     },
     getAgoricNames(...path) {
+      assert(agoricNames, X`agoricNames was not supplied to the wallet maker`);
       return E(agoricNames).lookup(...path);
     },
     getNamesByAddress(...path) {
+      assert(
+        namesByAddress,
+        X`namesByAddress was not supplied to the wallet maker`,
+      );
       return E(namesByAddress).lookup(...path);
     },
   });

--- a/packages/dapp-svelte-wallet/api/src/types.js
+++ b/packages/dapp-svelte-wallet/api/src/types.js
@@ -4,14 +4,6 @@
  */
 
 /**
- * @typedef {import('@agoric/cosmic-swingset/lib/ag-solo/vats/lib-board').Board} Board
- */
-
-/**
- * @typedef {import('@agoric/cosmic-swingset/lib/ag-solo/vats/types').NameHub} NameHub
- */
-
-/**
  * @typedef {string | string[]} Petname A petname can either be a plain string
  * or a path for which the first element is a petname for the origin, and the
  * rest of the elements are a snapshot of the names that were first given by that

--- a/packages/dapp-svelte-wallet/api/src/types.js
+++ b/packages/dapp-svelte-wallet/api/src/types.js
@@ -8,6 +8,10 @@
  */
 
 /**
+ * @typedef {import('@agoric/cosmic-swingset/lib/ag-solo/vats/types').NameHub} NameHub
+ */
+
+/**
  * @typedef {string | string[]} Petname A petname can either be a plain string
  * or a path for which the first element is a petname for the origin, and the
  * rest of the elements are a snapshot of the names that were first given by that
@@ -83,6 +87,10 @@
  * Get the Zoe Service
  * @property {() => Promise<Board>} getBoard
  * Get the Board
+ * @property {(...path: Array<unknown>) => Promise<unknown>} getAgoricNames
+ * Get the curated Agoric public naming hub
+ * @property {(...path: Array<unknown>) => Promise<unknown>} getNamesByAddress
+ * Get the Agoric address mapped to its public naming hub
  * @property {(brands: Array<Brand>) => Promise<Array<Petname>>}
  * getBrandPetnames
  * Get the petnames for the brands that are passed in

--- a/packages/dapp-svelte-wallet/api/src/wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/wallet.js
@@ -75,8 +75,10 @@ export function buildRootObject(_vatPowers) {
     },
   });
 
-  async function startup({ zoe, board }) {
+  async function startup({ zoe, board, agoricNames, namesByAddress }) {
     const w = makeWallet({
+      agoricNames,
+      namesByAddress,
       zoe,
       board,
       pursesStateChangeHandler: pursesPublish,
@@ -178,6 +180,14 @@ export function buildRootObject(_vatPowers) {
         await approve();
         return walletAdmin.getBoard();
       },
+      async getAgoricNames(...path) {
+        await approve();
+        return walletAdmin.getAgoricNames(...path);
+      },
+      async getNamesByAddress(...path) {
+        await approve();
+        return walletAdmin.getNamesByAddress(...path);
+      },
       async getBrandPetnames(brands) {
         await approve();
         return walletAdmin.getBrandPetnames(brands);
@@ -226,6 +236,12 @@ export function buildRootObject(_vatPowers) {
     },
     async getBoard() {
       return walletAdmin.getBoard();
+    },
+    async getAgoricNames(...path) {
+      return walletAdmin.getAgoricNames(...path);
+    },
+    async getNamesByAddress(...path) {
+      return walletAdmin.getNamesByAddress(...path);
     },
     async getBrandPetnames(brands) {
       return walletAdmin.getBrandPetnames(brands);


### PR DESCRIPTION
Closes #2721 

Implements `home.agoricNames` and `home.namesByAddress`, which are controlled by (privileged, granted by the `agoric.agoricNamesAdmin` provisioning powerFlag) `home.agoricNamesAdmin` and (permissionless) `home.myAddressNameAdmin`.

These are also exposed by the wallet bridge's `getAgoricNames(...path)` and `getNamesByAddress(...path)`.
