### PR TITLE
chore: Add brand to purse notifier data

### DIFF
--- a/packages/dapp-svelte-wallet/api/src/lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-wallet.js
@@ -244,6 +244,7 @@ export function makeWallet({
      * @type {PursesJSONState}
      */
     const jstate = {
+      brand,
       brandBoardId,
       ...(depositBoardId && { depositBoardId }),
       brandPetname,

--- a/packages/dapp-svelte-wallet/api/src/lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-wallet.js
@@ -168,6 +168,7 @@ export function makeWallet({
      * @returns {PursesJSONState}
      */
     const innerFilter = ({
+      brand,
       brandBoardId,
       depositBoardId,
       brandPetname,
@@ -178,6 +179,7 @@ export function makeWallet({
       currentAmount,
     }) =>
       harden({
+        brand,
         brandBoardId,
         ...(depositBoardId && { depositBoardId }),
         brandPetname,

--- a/packages/dapp-svelte-wallet/api/src/types.js
+++ b/packages/dapp-svelte-wallet/api/src/types.js
@@ -90,6 +90,7 @@
 
 /**
  * @typedef {Object} PursesJSONState
+ * @property {Brand} brand
  * @property {string} brandBoardId  the board ID for this purse's brand
  * @property {string=} depositBoardId the board ID for the deposit-only facet of
  * this purse

--- a/packages/dapp-svelte-wallet/api/test/test-getPursesNotifier.js
+++ b/packages/dapp-svelte-wallet/api/test/test-getPursesNotifier.js
@@ -79,7 +79,7 @@ test('getPursesNotifier', async t => {
 });
 
 test('getAttenuatedPursesNotifier', async t => {
-  const { wallet, MOOLA_ISSUER_PETNAME, MOOLA_PURSE_PETNAME } = await setup();
+  const { wallet, MOOLA_ISSUER_PETNAME, MOOLA_PURSE_PETNAME, moolaKit } = await setup();
   const pursesNotifier = wallet.getAttenuatedPursesNotifier();
   const update = await pursesNotifier.getUpdateSince();
   t.is(update.updateCount, 7);
@@ -87,7 +87,7 @@ test('getAttenuatedPursesNotifier', async t => {
   t.is(update.value.length, 2);
   const moolaPurseInfo = update.value[1];
   t.false('actions' in moolaPurseInfo);
-  t.false('brand' in moolaPurseInfo);
+  t.is(moolaPurseInfo.brand, moolaKit.brand);
   t.is(moolaPurseInfo.brandBoardId, '1532665031');
   t.is(moolaPurseInfo.brandPetname, MOOLA_ISSUER_PETNAME);
   t.deepEqual(moolaPurseInfo.currentAmount, {

--- a/packages/dapp-svelte-wallet/api/test/test-getPursesNotifier.js
+++ b/packages/dapp-svelte-wallet/api/test/test-getPursesNotifier.js
@@ -79,7 +79,12 @@ test('getPursesNotifier', async t => {
 });
 
 test('getAttenuatedPursesNotifier', async t => {
-  const { wallet, MOOLA_ISSUER_PETNAME, MOOLA_PURSE_PETNAME, moolaKit } = await setup();
+  const {
+    wallet,
+    MOOLA_ISSUER_PETNAME,
+    MOOLA_PURSE_PETNAME,
+    moolaKit,
+  } = await setup();
   const pursesNotifier = wallet.getAttenuatedPursesNotifier();
   const update = await pursesNotifier.getUpdateSince();
   t.is(update.updateCount, 7);

--- a/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
@@ -183,10 +183,14 @@ test('lib-wallet issuer and purse methods', async t => {
     `deposit successful`,
   );
   t.is(pursesStateChangeLog.length, 6, `pursesStateChangeLog length`);
+  const purseLog = JSON.parse(
+    pursesStateChangeLog[pursesStateChangeLog.length - 1],
+  );
   t.deepEqual(
-    JSON.parse(pursesStateChangeLog[pursesStateChangeLog.length - 1]),
+    purseLog,
     [
       {
+        brand: purseLog[0].brand,
         brandBoardId: '1667979430',
         depositBoardId: '604346717',
         displayInfo: {
@@ -206,6 +210,7 @@ test('lib-wallet issuer and purse methods', async t => {
         },
       },
       {
+        brand: purseLog[1].brand,
         brandBoardId: '727995140',
         brandPetname: 'moola',
         displayInfo: {
@@ -319,6 +324,7 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
   t.deepEqual(
     zoeInvitePurseState[0],
     {
+      brand: zoeInvitePurseState[0].brand,
       brandBoardId: '1667979430',
       depositBoardId: '604346717',
       displayInfo: {
@@ -402,6 +408,7 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
   t.deepEqual(
     zoeInvitePurseState2,
     {
+      brand: zoeInvitePurseState2.brand,
       brandBoardId: '1667979430',
       depositBoardId: '604346717',
       displayInfo: {
@@ -502,6 +509,7 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
   t.deepEqual(
     zoeInvitePurseState3,
     {
+      brand: zoeInvitePurseState3.brand,
       brandBoardId: '1667979430',
       depositBoardId: '604346717',
       displayInfo: {
@@ -681,6 +689,7 @@ test('lib-wallet offer methods', async t => {
   t.deepEqual(
     zoeInvitePurseState,
     {
+      brand: zoeInvitePurseState.brand,
       brandBoardId: '1667979430',
       depositBoardId: '604346717',
       brandPetname: 'zoe invite',
@@ -704,6 +713,7 @@ test('lib-wallet offer methods', async t => {
   t.deepEqual(
     moolaPurseState,
     {
+      brand: moolaPurseState.brand,
       brandBoardId: '1532665031',
       brandPetname: 'moola',
       displayInfo: {


### PR DESCRIPTION
The brand object wasn't being given in the purse notifier state, because of needing the result to be JSON compatible. Now that we are no longer JSON compatible (BigInts!) we should include it so that we can filter purses by brand.

I need to see what dapps this might break...