### PR TITLE
Switch to ses-ava

### DIFF
--- a/packages/ERTP/test/swingsetTests/basicFunctionality/test-basicFunctionality.js
+++ b/packages/ERTP/test/swingsetTests/basicFunctionality/test-basicFunctionality.js
@@ -1,11 +1,8 @@
 // @ts-check
 /* global __dirname */
-
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/swingset-vat/tools/prepare-test-env-ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { loadBasedir, buildVatController } from '@agoric/swingset-vat';
 import path from 'path';

--- a/packages/ERTP/test/swingsetTests/splitPayments/test-splitPayments.js
+++ b/packages/ERTP/test/swingsetTests/splitPayments/test-splitPayments.js
@@ -1,11 +1,7 @@
 /* global __dirname */
 // @ts-check
-
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/swingset-vat/tools/prepare-test-env-ava';
-
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { loadBasedir, buildVatController } from '@agoric/swingset-vat';

--- a/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
@@ -1,10 +1,7 @@
 // @ts-check
-
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/swingset-vat/tools/prepare-test-env-ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
 import { Far } from '@agoric/marshal';
 import { amountMath as m, MathKind } from '../../../src';
 import { mockBrand } from './mockBrand';

--- a/packages/ERTP/test/unitTests/mathHelpers/test-setMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-setMathHelpers.js
@@ -1,10 +1,6 @@
 // @ts-check
-
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/swingset-vat/tools/prepare-test-env-ava';
-
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
 
 import { Far } from '@agoric/marshal';
 

--- a/packages/ERTP/test/unitTests/mathHelpers/test-strSetMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-strSetMathHelpers.js
@@ -1,10 +1,7 @@
 // @ts-check
-
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/swingset-vat/tools/prepare-test-env-ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
 import { amountMath as m, MathKind } from '../../../src';
 import { mockBrand } from './mockBrand';
 

--- a/packages/ERTP/test/unitTests/test-interfaces.js
+++ b/packages/ERTP/test/unitTests/test-interfaces.js
@@ -1,10 +1,7 @@
 // @ts-check
-
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/swingset-vat/tools/prepare-test-env-ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
 import { getInterfaceOf } from '@agoric/marshal';
 import { makeIssuerKit, amountMath } from '../../src';
 import { ERTPKind, makeInterface } from '../../src/interfaces';

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -1,10 +1,7 @@
 // @ts-check
-
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/swingset-vat/tools/prepare-test-env-ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
 import { E } from '@agoric/eventual-send';
 import { MathKind, makeIssuerKit, amountMath } from '../../src';
 

--- a/packages/ERTP/test/unitTests/test-mintObj.js
+++ b/packages/ERTP/test/unitTests/test-mintObj.js
@@ -1,12 +1,10 @@
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/swingset-vat/tools/prepare-test-env-ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
 
 import { Far } from '@agoric/marshal';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { assert } from '@agoric/assert';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
 
 import { makeIssuerKit, MathKind, amountMath } from '../../src';
 

--- a/packages/dapp-svelte-wallet/api/test/test-getPursesNotifier.js
+++ b/packages/dapp-svelte-wallet/api/test/test-getPursesNotifier.js
@@ -1,8 +1,5 @@
 // @ts-check
-// eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava'; // calls lockdown()
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava'; // calls lockdown()
 
 import { makeIssuerKit } from '@agoric/ertp';
 import { makeZoe } from '@agoric/zoe';

--- a/packages/dapp-svelte-wallet/api/test/test-lib-dehydrate.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-dehydrate.js
@@ -1,6 +1,5 @@
-import '@agoric/zoe/tools/prepare-test-env-ava'; // calls lockdown()
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava'; // calls lockdown()
+
 import { Far } from '@agoric/marshal';
 
 import { makeDehydrator } from '../src/lib-dehydrate';

--- a/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
@@ -1,9 +1,7 @@
 /* global require */
 // @ts-check
-// eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava'; // calls lockdown()
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava'; // calls lockdown()
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import bundleSource from '@agoric/bundle-source';
 import { makeIssuerKit, makeLocalAmountMath } from '@agoric/ertp';

--- a/packages/deploy-script-support/test/unitTests/test-assertOfferResult.js
+++ b/packages/deploy-script-support/test/unitTests/test-assertOfferResult.js
@@ -1,8 +1,6 @@
 // @ts-check
 
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
 import { assertOfferResult } from '../../src/assertOfferResult';
 

--- a/packages/deploy-script-support/test/unitTests/test-depositInvitation.js
+++ b/packages/deploy-script-support/test/unitTests/test-depositInvitation.js
@@ -1,8 +1,7 @@
 // @ts-check
 
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+
 import { makeIssuerKit, MathKind } from '@agoric/ertp';
 
 import '../../exported';

--- a/packages/deploy-script-support/test/unitTests/test-findInvitationAmount.js
+++ b/packages/deploy-script-support/test/unitTests/test-findInvitationAmount.js
@@ -1,8 +1,7 @@
 // @ts-check
 
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+
 import { makeIssuerKit, MathKind } from '@agoric/ertp';
 
 import '../../exported';

--- a/packages/deploy-script-support/test/unitTests/test-install.js
+++ b/packages/deploy-script-support/test/unitTests/test-install.js
@@ -1,9 +1,8 @@
 /* global require */
 // @ts-check
 
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+
 import { makeZoe } from '@agoric/zoe';
 import fakeVatAdmin from '@agoric/zoe/src/contractFacet/fakeVatAdmin';
 import { makeBoard } from '@agoric/cosmic-swingset/lib/ag-solo/vats/lib-board';

--- a/packages/deploy-script-support/test/unitTests/test-offer.js
+++ b/packages/deploy-script-support/test/unitTests/test-offer.js
@@ -1,9 +1,8 @@
 /* global require */
 // @ts-check
 
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+
 import { makeZoe } from '@agoric/zoe';
 import fakeVatAdmin from '@agoric/zoe/src/contractFacet/fakeVatAdmin';
 import bundleSource from '@agoric/bundle-source';

--- a/packages/deploy-script-support/test/unitTests/test-resolvePathForLocalContract.js
+++ b/packages/deploy-script-support/test/unitTests/test-resolvePathForLocalContract.js
@@ -1,9 +1,7 @@
 /* global require */
 // @ts-check
 
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
 import { makeResolvePaths } from '../../src/resolvePath';
 

--- a/packages/deploy-script-support/test/unitTests/test-resolvePathForPackagedContract.js
+++ b/packages/deploy-script-support/test/unitTests/test-resolvePathForPackagedContract.js
@@ -1,9 +1,7 @@
 /* global require */
 // @ts-check
 
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
 import { makeResolvePaths } from '../../src/resolvePath';
 

--- a/packages/deploy-script-support/test/unitTests/test-saveLocalAmountMaths.js
+++ b/packages/deploy-script-support/test/unitTests/test-saveLocalAmountMaths.js
@@ -1,8 +1,6 @@
 // @ts-check
 
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
 import { makeIssuerKit } from '@agoric/ertp';
 

--- a/packages/deploy-script-support/test/unitTests/test-startInstance.js
+++ b/packages/deploy-script-support/test/unitTests/test-startInstance.js
@@ -1,9 +1,8 @@
 /* global require */
 // @ts-check
 
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+
 import { makeZoe } from '@agoric/zoe';
 import fakeVatAdmin from '@agoric/zoe/src/contractFacet/fakeVatAdmin';
 import bundleSource from '@agoric/bundle-source';

--- a/packages/ui-components/test/display/natValue/test-captureNum.js
+++ b/packages/ui-components/test/display/natValue/test-captureNum.js
@@ -1,7 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+
 import { captureNum } from '../../../src/display/natValue/helpers/captureNum';
 
 test('captureNum', t => {

--- a/packages/ui-components/test/display/natValue/test-parseAsNat.js
+++ b/packages/ui-components/test/display/natValue/test-parseAsNat.js
@@ -1,9 +1,8 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+
 import { parseAsNat } from '../../../src/display/natValue/parseAsNat';
 
 test('parseAsNat dollars to cents', t => {

--- a/packages/ui-components/test/display/natValue/test-roundToDecimalPlaces.js
+++ b/packages/ui-components/test/display/natValue/test-roundToDecimalPlaces.js
@@ -1,7 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+
 import { roundToDecimalPlaces as round } from '../../../src/display/natValue/helpers/roundToDecimalPlaces';
 
 test('roundToDecimalPlaces', t => {

--- a/packages/ui-components/test/display/natValue/test-stringifyNat.js
+++ b/packages/ui-components/test/display/natValue/test-stringifyNat.js
@@ -1,7 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+
 import { stringifyNat } from '../../../src/display/natValue/stringifyNat';
 
 test('stringifyNat cents to dollars', t => {

--- a/packages/ui-components/test/display/natValue/test-stringifyRatio.js
+++ b/packages/ui-components/test/display/natValue/test-stringifyRatio.js
@@ -1,9 +1,6 @@
 // @ts-check
-
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
 import { makeRatio } from '@agoric/zoe/src/contractSupport';
 import { makeIssuerKit, MathKind } from '@agoric/ertp';

--- a/packages/ui-components/test/display/setValue/test-parseAsSet.js
+++ b/packages/ui-components/test/display/setValue/test-parseAsSet.js
@@ -1,7 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+
 import { parseAsSet } from '../../../src/display/setValue/parseAsSet';
 
 test('parseSet', t => {

--- a/packages/ui-components/test/display/setValue/test-stringifySet.js
+++ b/packages/ui-components/test/display/setValue/test-stringifySet.js
@@ -1,7 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+
 import { stringifySet } from '../../../src/display/setValue/stringifySet';
 
 test('stringifySet', t => {

--- a/packages/ui-components/test/display/test-display.js
+++ b/packages/ui-components/test/display/test-display.js
@@ -1,7 +1,8 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import test from 'ava'; // TODO ses-ava doesn't yet have test.todo
+
 import { parseAsValue } from '../../src/display/display';
 
 test('parseAsValue', t => {

--- a/packages/zoe/test/unitTests/contractSupport/test-bondingCurves.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-bondingCurves.js
@@ -1,9 +1,6 @@
 // @ts-check
-
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
 import {
   getInputPrice,

--- a/packages/zoe/test/unitTests/contractSupport/test-depositTo.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-depositTo.js
@@ -1,10 +1,7 @@
 /* global __dirname */
 // @ts-check
-
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
 import { E } from '@agoric/eventual-send';
 import bundleSource from '@agoric/bundle-source';

--- a/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
@@ -1,10 +1,7 @@
 /* global __dirname */
 // @ts-check
-
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
 import { E } from '@agoric/eventual-send';
 import bundleSource from '@agoric/bundle-source';

--- a/packages/zoe/test/unitTests/contractSupport/test-percentMath.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-percentMath.js
@@ -1,9 +1,6 @@
 // @ts-check
-
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
 import '../../../exported';
 

--- a/packages/zoe/test/unitTests/contractSupport/test-percentSupport.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-percentSupport.js
@@ -1,9 +1,7 @@
 // @ts-check
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
 import { makeIssuerKit, amountMath } from '@agoric/ertp';
 
 import { multiplyBy, makeRatioFromAmounts } from '../../../src/contractSupport';

--- a/packages/zoe/test/unitTests/contractSupport/test-ratio.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-ratio.js
@@ -1,9 +1,7 @@
 // @ts-check
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
 import '../../../src/contractSupport/types';
 
 import { makeIssuerKit, amountMath } from '@agoric/ertp';

--- a/packages/zoe/test/unitTests/contractSupport/test-stateMachine.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-stateMachine.js
@@ -1,8 +1,6 @@
 // @ts-check
-
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
 import { makeStateMachine } from '../../../src/contractSupport';
 

--- a/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
@@ -1,10 +1,7 @@
 /* global __dirname */
 // @ts-check
-
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
 import { E } from '@agoric/eventual-send';
 import bundleSource from '@agoric/bundle-source';

--- a/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
@@ -1,9 +1,6 @@
 // @ts-check
-
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 import { Far } from '@agoric/marshal';
 
 import makeStore from '@agoric/store';

--- a/packages/zoe/test/unitTests/contracts/loan/helpers.js
+++ b/packages/zoe/test/unitTests/contracts/loan/helpers.js
@@ -1,10 +1,10 @@
 /* global __dirname */
 // @ts-check
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@agoric/zoe/tools/prepare-test-env';
 
 import '../../../../exported';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
 import { E } from '@agoric/eventual-send';
 import bundleSource from '@agoric/bundle-source';
 import { amountMath } from '@agoric/ertp';

--- a/packages/zoe/test/unitTests/contracts/loan/test-addCollateral.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-addCollateral.js
@@ -1,11 +1,9 @@
 // @ts-check
-
-import '../../../../exported';
-
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import test from 'ava'; // TODO ses-ava doesn't yet have test.todo
+import '../../../../exported';
 
 import { amountMath } from '@agoric/ertp';
 

--- a/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
@@ -1,11 +1,9 @@
 // @ts-check
-
-import '../../../../exported';
-
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import test from 'ava'; // TODO ses-ava doesn't yet have test.todo
+import '../../../../exported';
 
 import { amountMath } from '@agoric/ertp';
 import { E } from '@agoric/eventual-send';

--- a/packages/zoe/test/unitTests/contracts/loan/test-close.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-close.js
@@ -1,10 +1,10 @@
 // @ts-check
-import '../../../../exported';
-
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import test from 'ava'; // TODO ses-ava doesn't yet have test.todo
+import '../../../../exported';
+
 import { E } from '@agoric/eventual-send';
 import { amountMath } from '@agoric/ertp';
 

--- a/packages/zoe/test/unitTests/contracts/loan/test-lend.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-lend.js
@@ -1,10 +1,8 @@
 // @ts-check
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 import '../../../../exported';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
 import { E } from '@agoric/eventual-send';
 import { amountMath } from '@agoric/ertp';
 

--- a/packages/zoe/test/unitTests/contracts/loan/test-liquidate.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-liquidate.js
@@ -1,11 +1,7 @@
 // @ts-check
-
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 import '../../../../exported';
-
-// eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
 
 import { amountMath } from '@agoric/ertp';
 

--- a/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
@@ -1,11 +1,11 @@
 /* global __dirname */
 // @ts-check
-import '../../../../exported';
-
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@agoric/zoe/tools/prepare-test-env-ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import test from 'ava'; // TODO ses-ava doesn't yet have test.todo
+import '../../../../exported';
+
 import { E } from '@agoric/eventual-send';
 import { amountMath } from '@agoric/ertp';
 import bundleSource from '@agoric/bundle-source';

--- a/packages/zoe/test/unitTests/contracts/loan/test-updateDebt.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-updateDebt.js
@@ -1,11 +1,7 @@
 // @ts-check
-
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 import '../../../../exported';
-
-// eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
 
 import { calculateInterest } from '../../../../src/contracts/loan/updateDebt';
 import { makeRatio } from '../../../../src/contractSupport';

--- a/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
+++ b/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
@@ -1,11 +1,8 @@
 /* global __dirname */
-
 // @ts-check
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
 import bundleSource from '@agoric/bundle-source';
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';

--- a/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
+++ b/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
@@ -1,11 +1,8 @@
 /* global __dirname */
-
 // @ts-check
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
 import bundleSource from '@agoric/bundle-source';
 import { E } from '@agoric/eventual-send';
 

--- a/packages/zoe/test/unitTests/contracts/test-autoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-autoswap.js
@@ -1,10 +1,8 @@
 /* global __dirname */
 // @ts-check
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
 import { E } from '@agoric/eventual-send';
 import { amountMath } from '@agoric/ertp';
 import {

--- a/packages/zoe/test/unitTests/contracts/test-autoswapPool.js
+++ b/packages/zoe/test/unitTests/contracts/test-autoswapPool.js
@@ -3,9 +3,7 @@
 // isolated unit test of price calculations in pool in multipoolAutoswap
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
 import { E } from '@agoric/eventual-send';
 import { setupZCFTest } from '../zcf/setupZcfTest';

--- a/packages/zoe/test/unitTests/contracts/test-barter.js
+++ b/packages/zoe/test/unitTests/contracts/test-barter.js
@@ -1,10 +1,8 @@
 /* global __dirname */
 // @ts-check
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
 import { E } from '@agoric/eventual-send';
 import { amountMath } from '@agoric/ertp';
 

--- a/packages/zoe/test/unitTests/contracts/test-brokenContract.js
+++ b/packages/zoe/test/unitTests/contracts/test-brokenContract.js
@@ -1,9 +1,8 @@
 /* global __dirname */
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import bundleSource from '@agoric/bundle-source';
 

--- a/packages/zoe/test/unitTests/contracts/test-callSpread-calculation.js
+++ b/packages/zoe/test/unitTests/contracts/test-callSpread-calculation.js
@@ -1,9 +1,7 @@
 // @ts-check
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
 import '../../../exported';
 
 import { setup } from '../setupBasicMints';

--- a/packages/zoe/test/unitTests/contracts/test-callSpread.js
+++ b/packages/zoe/test/unitTests/contracts/test-callSpread.js
@@ -1,11 +1,8 @@
 /* global __dirname */
-
 // @ts-check
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
 import { E } from '@agoric/eventual-send';
 import '../../../exported';
 import buildManualTimer from '../../../tools/manualTimer';

--- a/packages/zoe/test/unitTests/contracts/test-coveredCall.js
+++ b/packages/zoe/test/unitTests/contracts/test-coveredCall.js
@@ -1,11 +1,8 @@
 /* global __dirname */
-
 // @ts-check
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
 import bundleSource from '@agoric/bundle-source';
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';

--- a/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
@@ -1,9 +1,8 @@
 /* global __dirname */
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import bundleSource from '@agoric/bundle-source';
 import { E } from '@agoric/eventual-send';

--- a/packages/zoe/test/unitTests/contracts/test-mintPayments.js
+++ b/packages/zoe/test/unitTests/contracts/test-mintPayments.js
@@ -1,11 +1,7 @@
 /* global __dirname */
-
 // @ts-check
-
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
 import bundleSource from '@agoric/bundle-source';
 import { E } from '@agoric/eventual-send';

--- a/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-multipoolAutoswap.js
@@ -1,9 +1,7 @@
 /* global __dirname */
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
 import bundleSource from '@agoric/bundle-source';
 import { makeIssuerKit, amountMath } from '@agoric/ertp';

--- a/packages/zoe/test/unitTests/contracts/test-oracle.js
+++ b/packages/zoe/test/unitTests/contracts/test-oracle.js
@@ -1,10 +1,8 @@
 /* global __dirname */
 // @ts-check
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import anyTest from 'ava';
 import bundleSource from '@agoric/bundle-source';
 
 import { makeIssuerKit, MathKind, amountMath } from '@agoric/ertp';
@@ -29,8 +27,6 @@ import '../../../src/contracts/exported';
  */
 
 const contractPath = `${__dirname}/../../../src/contracts/oracle`;
-
-const test = /** @type {import('ava').TestInterface<TestContext>} */ (anyTest);
 
 test.before(
   'setup oracle',

--- a/packages/zoe/test/unitTests/contracts/test-otcDesk.js
+++ b/packages/zoe/test/unitTests/contracts/test-otcDesk.js
@@ -1,10 +1,8 @@
 /* global __dirname */
 // @ts-check
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import bundleSource from '@agoric/bundle-source';
 import { E } from '@agoric/eventual-send';

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
@@ -1,10 +1,8 @@
 /* global __dirname */
 // @ts-check
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import anyTest from 'ava';
 import bundleSource from '@agoric/bundle-source';
 
 import { E } from '@agoric/eventual-send';
@@ -40,8 +38,6 @@ import '../../../src/contracts/exported';
 
 const oraclePath = `${__dirname}/../../../src/contracts/oracle`;
 const aggregatorPath = `${__dirname}/../../../src/contracts/priceAggregator`;
-
-const test = /** @type {import('ava').TestInterface<TestContext>} */ (anyTest);
 
 test.before(
   'setup aggregator and oracles',

--- a/packages/zoe/test/unitTests/contracts/test-secondPriceAuction.js
+++ b/packages/zoe/test/unitTests/contracts/test-secondPriceAuction.js
@@ -1,10 +1,8 @@
 /* global __dirname */
 // @ts-check
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
 import bundleSource from '@agoric/bundle-source';
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';

--- a/packages/zoe/test/unitTests/contracts/test-sellTickets.js
+++ b/packages/zoe/test/unitTests/contracts/test-sellTickets.js
@@ -1,10 +1,7 @@
 /* global __dirname */
 // @ts-check
-
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
 import { assert } from '@agoric/assert';
 import bundleSource from '@agoric/bundle-source';

--- a/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
+++ b/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
@@ -1,11 +1,8 @@
 /* global __dirname */
 // @ts-check
-
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { E } from '@agoric/eventual-send';
 

--- a/packages/zoe/test/unitTests/contracts/test-throwInOfferHandler.js
+++ b/packages/zoe/test/unitTests/contracts/test-throwInOfferHandler.js
@@ -1,10 +1,7 @@
 /* global __dirname */
 // @ts-check
-
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
 import bundleSource from '@agoric/bundle-source';
 

--- a/packages/zoe/test/unitTests/contracts/test-useObj.js
+++ b/packages/zoe/test/unitTests/contracts/test-useObj.js
@@ -1,10 +1,7 @@
 /* global __dirname */
 // @ts-check
-
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
 import bundleSource from '@agoric/bundle-source';
 

--- a/packages/zoe/test/unitTests/test-cleanProposal.js
+++ b/packages/zoe/test/unitTests/test-cleanProposal.js
@@ -1,9 +1,6 @@
 // @ts-check
-
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
 import { MathKind } from '@agoric/ertp/src/deprecatedAmountMath';
 import { cleanProposal } from '../../src/cleanProposal';

--- a/packages/zoe/test/unitTests/test-fakePriceAuthority.js
+++ b/packages/zoe/test/unitTests/test-fakePriceAuthority.js
@@ -1,8 +1,7 @@
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+
 import { E } from '@agoric/eventual-send';
 import { assert } from '@agoric/assert';
 import buildManualTimer from '../../tools/manualTimer';

--- a/packages/zoe/test/unitTests/test-makeKind.js
+++ b/packages/zoe/test/unitTests/test-makeKind.js
@@ -1,10 +1,8 @@
 // @ts-check
 /* global __dirname makeKind makeWeakStore */
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
 import bundleSource from '@agoric/bundle-source';
 
 import { E } from '@agoric/eventual-send';

--- a/packages/zoe/test/unitTests/test-manualTimer.js
+++ b/packages/zoe/test/unitTests/test-manualTimer.js
@@ -1,10 +1,7 @@
 // @ts-check
-
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
 import { E } from '@agoric/eventual-send';
 import buildManualTimer from '../../tools/manualTimer';
 

--- a/packages/zoe/test/unitTests/test-objArrayConversion.js
+++ b/packages/zoe/test/unitTests/test-objArrayConversion.js
@@ -1,9 +1,6 @@
 // @ts-check
-
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
 import { arrayToObj } from '../../src/objArrayConversion';
 

--- a/packages/zoe/test/unitTests/test-offerSafety.js
+++ b/packages/zoe/test/unitTests/test-offerSafety.js
@@ -1,8 +1,6 @@
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
 import { isOfferSafe } from '../../src/contractFacet/offerSafety';
 import { setup } from './setupBasicMints';

--- a/packages/zoe/test/unitTests/test-rightsConservation.js
+++ b/packages/zoe/test/unitTests/test-rightsConservation.js
@@ -1,9 +1,7 @@
 // @ts-check
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
 import { amountMath, makeIssuerKit } from '@agoric/ertp';
 import { assertRightsConserved } from '../../src/contractFacet/rightsConservation';

--- a/packages/zoe/test/unitTests/test-scriptedOracle.js
+++ b/packages/zoe/test/unitTests/test-scriptedOracle.js
@@ -1,9 +1,8 @@
 /* global __dirname */
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import anyTest from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+
 import bundleSource from '@agoric/bundle-source';
 
 import { E } from '@agoric/eventual-send';
@@ -35,8 +34,6 @@ const bountyContractPath = `${__dirname}/bounty`;
  *
  * @typedef {import('ava').ExecutionContext<TestContext>} ExecutionContext
  */
-
-const test = /** @type {import('ava').TestInterface<TestContext>} */ (anyTest);
 
 test.before(
   'setup oracle',

--- a/packages/zoe/test/unitTests/test-zoe-env.js
+++ b/packages/zoe/test/unitTests/test-zoe-env.js
@@ -1,10 +1,7 @@
 // @ts-check
-
-// eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
 /* global makeKind, makeWeakStore */
 // eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
 test('harden from SES is in the zoe contract environment', t => {
   // @ts-ignore testing existence of function only

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -1,9 +1,7 @@
 /* global __dirname */
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -1,8 +1,6 @@
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
 import { MathKind, amountMath } from '@agoric/ertp';
 import { E } from '@agoric/eventual-send';

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
@@ -1,11 +1,7 @@
 /* global __dirname */
-
 // @ts-check
-
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
 import { E } from '@agoric/eventual-send';
 import bundleSource from '@agoric/bundle-source';

--- a/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
@@ -1,9 +1,6 @@
 // @ts-check
-
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/zoe/tools/prepare-test-env-ava';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import test from 'ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
 import { MathKind, makeIssuerKit } from '@agoric/ertp';
 import { setup } from '../setupBasicMints';

--- a/packages/zoe/tools/prepare-test-env-ava.js
+++ b/packages/zoe/tools/prepare-test-env-ava.js
@@ -7,4 +7,4 @@
  * the same as the SwingSet vat environment.
  */
 
-import '@agoric/swingset-vat/tools/prepare-test-env-ava';
+export { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';


### PR DESCRIPTION
Everywhere we're already importing `prepare-test-env-ava`, import `test` from there rather than `ava`.

Except where we use `test.todo` which ses-ava does not yet support.