### PR TITLE
chore: add issuers notifier to wallet bridge API

### DIFF
--- a/packages/dapp-svelte-wallet/api/src/types.js
+++ b/packages/dapp-svelte-wallet/api/src/types.js
@@ -60,6 +60,8 @@
  * return the board ID to use to receive payments of the specified brand.
  * @property {() => Promise<Notifier<Array<PursesJSONState>>>} getPursesNotifier
  * Follow changes to the purses.
+ * @property {() => Promise<Notifier<Array<[Petname, BrandRecord]>>>} getIssuersNotifier
+ * Follow changes to the issuers
  * @property {() => Promise<Notifier<Array<OfferState>>>} getOffersNotifier
  * Follow changes to the offers.
  * @property {(petname: Petname, issuerBoardId: string) => Promise<void>}

--- a/packages/dapp-svelte-wallet/api/src/wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/wallet.js
@@ -117,6 +117,10 @@ export function buildRootObject(_vatPowers) {
         observeIteration(makeApprovedNotifier(pursesNotifier), updater);
         return notifier;
       },
+      async getIssuersNotifier() {
+        await approve();
+        return walletAdmin.getIssuersNotifier();
+      },
       async addOffer(offer) {
         await approve();
         return walletAdmin.addOffer(offer, { ...meta, dappOrigin });
@@ -218,6 +222,9 @@ export function buildRootObject(_vatPowers) {
     },
     async getPursesNotifier() {
       return walletAdmin.getAttenuatedPursesNotifier();
+    },
+    async getIssuersNotifier() {
+      return walletAdmin.getIssuersNotifier();
     },
     suggestInstallation(petname, installationBoardId) {
       return walletAdmin.suggestInstallation(petname, installationBoardId);


### PR DESCRIPTION
make the issuers notifier available to dapps so that dapps can get the latest petnames