### PR TITLE
fix(swingset): require.resolve paths typo, plus @ts-check

### DIFF
--- a/packages/SwingSet/src/initializeSwingset.js
+++ b/packages/SwingSet/src/initializeSwingset.js
@@ -151,7 +151,7 @@ export function loadBasedir(basedir) {
  */
 function resolveSpecFromConfig(dirname, specPath) {
   try {
-    return require.resolve(specPath, { path: [dirname] });
+    return require.resolve(specPath, { paths: [dirname] });
   } catch (e) {
     if (e.code !== 'MODULE_NOT_FOUND') {
       throw e;

--- a/packages/swing-store-simple/simpleSwingStore.js
+++ b/packages/swing-store-simple/simpleSwingStore.js
@@ -220,7 +220,7 @@ function makeSwingStore(dirPath, forceReset = false) {
  * serialized to a text file.  If there is an existing store at the given
  * `dirPath`, it will be reinitialized to an empty state.
  *
- * @param {string} dirPath  Path to a directory in which database files may be kept.
+ * @param {string=} dirPath  Path to a directory in which database files may be kept.
  *   This directory need not actually exist yet (if it doesn't it will be
  *   created) but it is reserved (by the caller) for the exclusive use of this
  *   swing store instance.  If this is nullish, the swing store created will


### PR DESCRIPTION
While adding `defaultManagerType` to swingset `config` in #2676, I added `@ts-check` to `initializeSwingset.js` to get some help from the machine. In the course of cleaning up a few things that failed to check, I found a typo in a `require.resolve` call.
