### PR TITLE
feat: add collateralConfig to issuer entries and enact

### DIFF
--- a/packages/agoric-cli/integration-tests/test-workflow.js
+++ b/packages/agoric-cli/integration-tests/test-workflow.js
@@ -12,7 +12,7 @@ import { spawn } from 'child_process';
 
 import { makePspawn } from '../lib/helpers';
 
-const TIMEOUT_SECONDS = 2 * 60;
+const TIMEOUT_SECONDS = 8 * 60;
 
 // To keep in sync with https://agoric.com/documentation/getting-started/
 

--- a/packages/cosmic-swingset/lib/ag-solo/vats/issuers.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/issuers.js
@@ -2,56 +2,99 @@
 
 export const CENTRAL_ISSUER_NAME = 'MOE';
 
+/** @typedef {number | bigint} Bigish */
+
+/**
+ * @typedef {Object} CollateralConfig
+ * @property {string} keyword
+ * @property {Bigish} collateralValue
+ * @property {bigint} initialPricePercent
+ * @property {bigint} initialMarginPercent
+ * @property {bigint} liquidationMarginPercent
+ * @property {bigint} interestRateBasis
+ * @property {bigint} loanFeeBasis
+ */
+
 /**
  * @typedef {Object} IssuerInitializationRecord
  * @property {Issuer} [issuer]
+ * @property {Brand} [brand]
  * @property {Array<any>} [issuerArgs]
+ * @property {CollateralConfig} [collateralConfig]
  * @property {string} pursePetname
- * @property {number} mintValue
- * @property {Array<[number, number]>} [fakeTradesGivenCentral]
+ * @property {Bigish} mintValue
+ * @property {Array<[Bigish, Bigish]>} [fakeTradesGivenCentral]
  */
 
-/** @type {Map<string, IssuerInitializationRecord>} */
-export const fakeIssuerNameToRecord = new Map(
-  harden([
-    [
-      '$LINK',
-      {
-        issuerArgs: [undefined, { decimalPlaces: 6 }],
-        mintValue: 7 * 10 ** 6,
-        pursePetname: 'Oracle fee',
-        fakeTradesGivenCentral: [
-          [1000, 3000000],
-          [1000, 2500000],
-          [1000, 2750000],
-        ],
+/** @type {Array<[string, IssuerInitializationRecord]>} */
+const fakeIssuerEntries = [
+  [
+    '$LINK',
+    {
+      issuerArgs: [undefined, { decimalPlaces: 18 }],
+      mintValue: 7n * 10n ** 18n,
+      collateralConfig: {
+        keyword: 'LINK',
+        collateralValue: 6000n * 10n ** 18n,
+        initialPricePercent: 125n,
+        initialMarginPercent: 150n,
+        liquidationMarginPercent: 125n,
+        interestRateBasis: 250n,
+        loanFeeBasis: 50n,
       },
-    ],
-    [
-      'moola',
-      {
-        mintValue: 1900,
-        pursePetname: 'Fun budget',
-        fakeTradesGivenCentral: [
-          [10, 1],
-          [13, 1],
-          [12, 1],
-          [18, 1],
-          [15, 1],
-        ],
+      pursePetname: 'Oracle fee',
+      fakeTradesGivenCentral: [
+        [1000, 3000n * 10n ** 15n],
+        [1000, 2500n * 10n ** 15n],
+        [1000, 2750n * 10n ** 15n],
+      ],
+    },
+  ],
+  [
+    'moola',
+    {
+      mintValue: 1900,
+      collateralConfig: {
+        collateralValue: 74000,
+        keyword: 'Moola',
+        initialPricePercent: 150n,
+        initialMarginPercent: 150n,
+        liquidationMarginPercent: 120n,
+        interestRateBasis: 200n,
+        loanFeeBasis: 150n,
       },
-    ],
-    [
-      'simolean',
-      {
-        mintValue: 1900,
-        pursePetname: 'Nest egg',
-        fakeTradesGivenCentral: [
-          [2135, 50],
-          [2172, 50],
-          [2124, 50],
-        ],
+      pursePetname: 'Fun budget',
+      fakeTradesGivenCentral: [
+        [10, 1],
+        [13, 1],
+        [12, 1],
+        [18, 1],
+        [15, 1],
+      ],
+    },
+  ],
+  [
+    'simolean',
+    {
+      mintValue: 1900,
+      collateralConfig: {
+        collateralValue: 96800,
+        keyword: 'Simolean',
+        initialPricePercent: 110n,
+        initialMarginPercent: 120n,
+        liquidationMarginPercent: 105n,
+        interestRateBasis: 100n,
+        loanFeeBasis: 225n,
       },
-    ],
-  ]),
-);
+      pursePetname: 'Nest egg',
+      fakeTradesGivenCentral: [
+        [2135, 50],
+        [2172, 50],
+        [2124, 50],
+      ],
+    },
+  ],
+];
+
+harden(fakeIssuerEntries);
+export { fakeIssuerEntries };

--- a/packages/treasury/bundles/install-on-chain.js
+++ b/packages/treasury/bundles/install-on-chain.js
@@ -106,4 +106,6 @@ export async function installOnChain({ agoricNames, board, chainTimerService, na
   await Promise.all(
     nameAdminUpdates.map(([nameAdmin, name, value]) => E(nameAdmin).update(name, value)),
   );
+
+  return creatorFacet;
 }


### PR DESCRIPTION
This has the configuration of fake collateral in `packages/cosmic-swingset/lib/ag-solo/vats/issuers.js`.  The fake collateral (like the fake issuers) go away when `process.env.NO_FAKE_CURRENCIES` is set.
