### PR TITLE
Ambidextrous amountMath

### DIFF
--- a/packages/ERTP/src/typeGuards.js
+++ b/packages/ERTP/src/typeGuards.js
@@ -1,7 +1,23 @@
 import { isNat } from '@agoric/nat';
+import { passStyleOf, REMOTE_STYLE } from '@agoric/marshal';
+
+const { isFrozen } = Object;
+
+// A type guard predicate named `looksLikeFoo` tests that something seems to be
+// a
+// Foo, produces static type info on the truthy path alleging that it is a Foo,
+// but does not validate that it is a well formed Foo. Names like `isFoo` should
+// be reserved for predicates that actually validate objects coming from
+// untrusted callers.
+//
+// The corresponding assertions would be `assertLooksLikeFoo` and `assertFoo`.
+// These
+// produce the same static type info, but on the success path rather than the
+// truthy path.
 
 /**
- * Type guard for SetValue
+ * Non-validating type guard for SetValue
+ *
  * Used as a pre-validation check to select which validator
  * (mathHelpers) to use, and also used with assert to satisfy
  * Typescript checking
@@ -9,10 +25,11 @@ import { isNat } from '@agoric/nat';
  * @param {Value} value
  * @returns {value is SetValue}
  */
-export const isSetValue = value => Array.isArray(value);
+export const looksLikeSetValue = value => Array.isArray(value);
 
 /**
- * Type guard for NatValue.
+ * Non-validating type guard for NatValue.
+ *
  * Used as a pre-validation check to select which validator
  * (mathHelpers) to use, and also used with assert to satisfy
  * Typescript checking
@@ -20,4 +37,30 @@ export const isSetValue = value => Array.isArray(value);
  * @param {Value} value
  * @returns {value is NatValue}
  */
-export const isNatValue = value => isNat(value);
+export const looksLikeNatValue = value => isNat(value);
+
+/**
+ * Call this for a validated answer (that in this case happens to be the same).
+ *
+ * @param {Value} value
+ * @returns {value is NatValue}
+ */
+export const isNatValue = looksLikeNatValue;
+
+/**
+ * Non-validating type guard for Value.
+ *
+ * @param {Value} value
+ * @returns {value is Value}
+ */
+export const looksLikeValue = value =>
+  looksLikeSetValue(value) || looksLikeNatValue(value);
+
+/**
+ * Non-validating type guard for Brand.
+ *
+ * @param {Brand} brand
+ * @returns {brand is Brand}
+ */
+export const looksLikeBrand = brand =>
+  isFrozen(brand) && passStyleOf(brand) === REMOTE_STYLE;

--- a/packages/ERTP/src/typeGuards.js
+++ b/packages/ERTP/src/typeGuards.js
@@ -4,16 +4,14 @@ import { passStyleOf, REMOTE_STYLE } from '@agoric/marshal';
 const { isFrozen } = Object;
 
 // A type guard predicate named `looksLikeFoo` tests that something seems to be
-// a
-// Foo, produces static type info on the truthy path alleging that it is a Foo,
-// but does not validate that it is a well formed Foo. Names like `isFoo` should
-// be reserved for predicates that actually validate objects coming from
+// a Foo, produces static type info on the truthy path alleging that it is a
+// Foo, but does not validate that it is a well formed Foo. Names like `isFoo`
+// should be reserved for predicates that actually validate objects coming from
 // untrusted callers.
 //
 // The corresponding assertions would be `assertLooksLikeFoo` and `assertFoo`.
-// These
-// produce the same static type info, but on the success path rather than the
-// truthy path.
+// These produce the same static type info, but on the success path rather than
+// the truthy path.
 
 /**
  * Non-validating type guard for SetValue

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -56,6 +56,9 @@
  * @param {Value} allegedValue
  * @returns {Amount}
  *
+ * TODO find out how to get this "deprecated" marking recognized,
+ * or remove it.
+ * @deprecated Use brand-first overload instead
  * @callback AmountMakeValueBrand
  * Please use the brand-first overload. The value-first overload
  * is deprecated and will go way.
@@ -70,6 +73,9 @@
  * @param {Amount} allegedAmount
  * @returns {Amount}
  *
+ * TODO find out how to get this "deprecated" marking recognized,
+ * or remove it.
+ * @deprecated Use brand-first overload instead
  * @callback AmountCoerceAmountBrand
  * Please use the brand-first overload. The amount-first overload
  * is deprecated and will go way.
@@ -84,6 +90,9 @@
  * @param {Amount} allegedAmount
  * @returns {Amount}
  *
+ * TODO find out how to get this "deprecated" marking recognized,
+ * or remove it.
+ * @deprecated Use brand-first overload instead
  * @callback AmountGetValueAmountBrand
  * Please use the brand-first overload. The amount-first overload
  * is deprecated and will go way.

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -48,22 +48,63 @@
  */
 
 /**
+ * This section blindly imitates what Endo's ses/src/error/types.js
+ * does to express type overloaded methods.
+ *
+ * @callback AmountMakeBrandValue
+ * @param {Brand} brand
+ * @param {Value} allegedValue
+ * @returns {Amount}
+ *
+ * @callback AmountMakeValueBrand
+ * Please use the brand-first overload. The value-first overload
+ * is deprecated and will go way.
+ * @param {Value} brand
+ * @param {Brand} allegedValue
+ * @returns {Amount}
+ *
+ * @typedef {AmountMakeBrandValue & AmountMakeValueBrand} AmountMake
+ *
+ * @callback AmountCoerceBrandAmount
+ * @param {Brand} brand
+ * @param {Amount} allegedAmount
+ * @returns {Amount}
+ *
+ * @callback AmountCoerceAmountBrand
+ * Please use the brand-first overload. The amount-first overload
+ * is deprecated and will go way.
+ * @param {Amount} brand
+ * @param {Brand} allegedAmount
+ * @returns {Amount}
+ *
+ * @typedef {AmountCoerceBrandAmount & AmountCoerceAmountBrand} AmountCoerce
+ */
+
+/**
  * @typedef {Object} AmountMath
  * Logic for manipulating amounts.
  *
  * Amounts are the canonical description of tradable goods. They are manipulated
- * by issuers and mints, and represent the goods and currency carried by purses and
+ * by issuers and mints, and represent the goods and currency carried by purses
+ * and
  * payments. They can be used to represent things like currency, stock, and the
  * abstract right to participate in a particular exchange.
  *
- * @property {(allegedValue: Value, brand: Brand) => Amount} make
+ * @property {AmountMake} make
  * Make an amount from a value by adding the brand.
+ * Please use the brand-first overload. The value-first overload
+ * is deprecated and will go way.
  *
- * @property {(allegedAmount: Amount, brand: Brand) => Amount} coerce
- * Make sure this amount is valid and return it if so.
+ * @property {AmountCoerce} coerce
+ * Make sure this amount is valid enough, and return a corresponding
+ * valid amount if so.
+ * Please use the brand-first overload. The amount-first overload
+ * is deprecated and will go way.
  *
- * @property {(amount: Amount, brand: Brand) => Value} getValue
+ * @property {AmountCoerce} getValue
  * Extract and return the value.
+ * Please use the brand-first overload. The amount-first overload
+ * is deprecated and will go way.
  *
  * @property {MakeEmpty} makeEmpty
  * Return the amount representing an empty amount. This is the

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -78,6 +78,20 @@
  * @returns {Amount}
  *
  * @typedef {AmountCoerceBrandAmount & AmountCoerceAmountBrand} AmountCoerce
+ *
+ * @callback AmountGetValueBrandAmount
+ * @param {Brand} brand
+ * @param {Amount} allegedAmount
+ * @returns {Amount}
+ *
+ * @callback AmountGetValueAmountBrand
+ * Please use the brand-first overload. The amount-first overload
+ * is deprecated and will go way.
+ * @param {Amount} brand
+ * @param {Brand} allegedAmount
+ * @returns {Amount}
+ *
+ * @typedef {AmountGetValueBrandAmount & AmountGetValueAmountBrand} AmountGetValue
  */
 
 /**
@@ -101,7 +115,7 @@
  * Please use the brand-first overload. The amount-first overload
  * is deprecated and will go way.
  *
- * @property {AmountCoerce} getValue
+ * @property {AmountGetValue} getValue
  * Extract and return the value.
  * Please use the brand-first overload. The amount-first overload
  * is deprecated and will go way.

--- a/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
@@ -31,7 +31,7 @@ test('natMathHelpers make no brand', t => {
   t.throws(
     () => m.make(4n),
     {
-      message: /The brand "\[undefined\]" doesn't look like a brand./,
+      message: /The brand "\[4n\]" doesn't look like a brand./,
     },
     `brand is required in make`,
   );
@@ -78,7 +78,7 @@ test('natMathHelpers coerce no brand', t => {
     // @ts-ignore deliberate invalid arguments for testing
     () => m.coerce(m.make(4n, mockBrand)),
     {
-      message: /The brand "\[undefined\]" doesn't look like a brand./,
+      message: /The brand {"brand":"\[Alleged: brand\]","value":"\[4n\]"} doesn't look like a brand./,
     },
     `brand is required in coerce`,
   );
@@ -94,7 +94,7 @@ test('natMathHelpers getValue no brand', t => {
     // @ts-ignore deliberate invalid arguments for testing
     () => m.getValue(m.make(4n, mockBrand)),
     {
-      message: /The brand "\[undefined\]" doesn't look like a brand./,
+      message: /The brand {"brand":"\[Alleged: brand\]","value":"\[4n\]"} doesn't look like a brand./,
     },
     `brand is required in getValue`,
   );

--- a/packages/zoe/test/swingsetTests/zoe/vat-bob.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-bob.js
@@ -5,7 +5,7 @@ import { Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
 import { sameStructure } from '@agoric/same-structure';
 import { amountMath } from '@agoric/ertp';
-import { isSetValue } from '@agoric/ertp/src/typeGuards';
+import { looksLikeSetValue } from '@agoric/ertp/src/typeGuards';
 
 import { showPurseBalance, setupIssuers } from '../helpers';
 
@@ -508,7 +508,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const availableTickets = await E(publicFacet).getAvailableItems();
       log('availableTickets: ', availableTickets);
       // find the value corresponding to ticket #1
-      assert(isSetValue(availableTickets.value));
+      assert(looksLikeSetValue(availableTickets.value));
       const ticket1Value = availableTickets.value.find(
         ticket => ticket.number === 1,
       );

--- a/packages/zoe/test/unitTests/contracts/test-sellTickets.js
+++ b/packages/zoe/test/unitTests/contracts/test-sellTickets.js
@@ -6,7 +6,7 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 import { assert } from '@agoric/assert';
 import bundleSource from '@agoric/bundle-source';
 import { makeIssuerKit, amountMath } from '@agoric/ertp';
-import { isSetValue } from '@agoric/ertp/src/typeGuards';
+import { looksLikeSetValue } from '@agoric/ertp/src/typeGuards';
 import { E } from '@agoric/eventual-send';
 import fakeVatAdmin from '../../../src/contractFacet/fakeVatAdmin';
 
@@ -211,7 +211,7 @@ test(`mint and sell opera tickets`, async t => {
       3,
       'Alice should see 3 available tickets',
     );
-    assert(isSetValue(availableTickets.value));
+    assert(looksLikeSetValue(availableTickets.value));
     t.truthy(
       availableTickets.value.find(ticket => ticket.number === 1),
       `availableTickets contains ticket number 1`,
@@ -435,7 +435,7 @@ test(`mint and sell opera tickets`, async t => {
       ticketSalesPublicFacet,
     ).getAvailableItems();
 
-    assert(isSetValue(availableTickets.value));
+    assert(looksLikeSetValue(availableTickets.value));
     // Bob sees the currently available tickets
     t.is(
       availableTickets.value.length,

--- a/packages/zoe/test/zoeTestHelpers.js
+++ b/packages/zoe/test/zoeTestHelpers.js
@@ -4,7 +4,7 @@ import { E } from '@agoric/eventual-send';
 
 import '../exported';
 import setMathHelpers from '@agoric/ertp/src/mathHelpers/setMathHelpers';
-import { amountMath, isSetValue, isNatValue } from '@agoric/ertp';
+import { amountMath, looksLikeSetValue, isNatValue } from '@agoric/ertp';
 
 import { q } from '@agoric/assert';
 
@@ -12,7 +12,7 @@ export const assertAmountsEqual = (t, amount, expected, label = '') => {
   const brandsEqual = amount.brand === expected.brand;
   const l = label ? `${label} ` : '';
   let valuesEqual;
-  if (isSetValue(expected.value)) {
+  if (looksLikeSetValue(expected.value)) {
     valuesEqual = setMathHelpers.doIsEqual(amount.value, expected.value);
   } else if (isNatValue(expected.value)) {
     valuesEqual = amount.value === expected.value;


### PR DESCRIPTION
Change `amountMath` methods `make`, `coerce`, and `getValue` so that they accept their two arguments in either order. But be clear in the code and type comments that the brand first order is preferred and the other order is deprecated.

@michaelfig I imitated your overload declarations for `assert.typeof` and worked almost perfectly. I did need to put in one `@ts-ignore` that I don't understand. It is clearly commented.