### PR TITLE
Unserialized errors are remote

### DIFF
--- a/packages/SwingSet/src/kernel/deviceSlots.js
+++ b/packages/SwingSet/src/kernel/deviceSlots.js
@@ -104,6 +104,9 @@ export function makeDeviceSlots(
 
   const m = makeMarshal(convertValToSlot, convertSlotToVal, {
     marshalName: `device:${forDeviceName}`,
+    // TODO Temporary hack.
+    // See https://github.com/Agoric/agoric-sdk/issues/2780
+    errorIdNum: 50000,
   });
 
   function PresenceHandler(importSlot) {

--- a/packages/SwingSet/src/kernel/initializeKernel.js
+++ b/packages/SwingSet/src/kernel/initializeKernel.js
@@ -172,6 +172,9 @@ export function initializeKernel(config, hostStorage, verbose = false) {
 
     const m = makeMarshal(convertValToSlot, undefined, {
       marshalName: 'kernel:bootstrap',
+      // TODO Temporary hack.
+      // See https://github.com/Agoric/agoric-sdk/issues/2780
+      errorIdNum: 60000,
     });
     const args = harden([vatObj0s, deviceObj0s]);
     // queueToExport() takes kernel-refs (ko+NN, kd+NN) in s.slots

--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -234,6 +234,9 @@ function build(
   // eslint-disable-next-line no-use-before-define
   const m = makeMarshal(convertValToSlot, convertSlotToVal, {
     marshalName: `liveSlots:${forVatID}`,
+    // TODO Temporary hack.
+    // See https://github.com/Agoric/agoric-sdk/issues/2780
+    errorIdNum: 70000,
     marshalSaveError: err =>
       // By sending this to `console.log`, under cosmic-swingset this is
       // controlled by the `console` option given to makeLiveSlots.  For Agoric,

--- a/packages/SwingSet/test/test-exomessages.js
+++ b/packages/SwingSet/test/test-exomessages.js
@@ -59,14 +59,14 @@ async function testFailure(t) {
     failureHappened = true;
     t.is(
       e.message,
-      'kernel panic kp40.policy panic: rejected {"body":"{\\"@qclass\\":\\"error\\",\\"errorId\\":\\"error:liveSlots:v1#10001\\",\\"message\\":\\"gratuitous error\\",\\"name\\":\\"Error\\"}","slots":[]}',
+      'kernel panic kp40.policy panic: rejected {"body":"{\\"@qclass\\":\\"error\\",\\"errorId\\":\\"error:liveSlots:v1#70001\\",\\"message\\":\\"gratuitous error\\",\\"name\\":\\"Error\\"}","slots":[]}',
     );
   }
   t.truthy(failureHappened);
   t.is(controller.kpStatus(controller.bootstrapResult), 'rejected');
   t.deepEqual(controller.kpResolution(controller.bootstrapResult), {
     body:
-      '{"@qclass":"error","errorId":"error:liveSlots:v1#10001","message":"gratuitous error","name":"Error"}',
+      '{"@qclass":"error","errorId":"error:liveSlots:v1#70001","message":"gratuitous error","name":"Error"}',
     slots: [],
   });
 }
@@ -124,7 +124,7 @@ test('extra message rejects', async t => {
     t,
     'reject',
     'rejected',
-    '{"@qclass":"error","errorId":"error:liveSlots:v1#10001","message":"gratuitous error","name":"Error"}',
+    '{"@qclass":"error","errorId":"error:liveSlots:v1#70001","message":"gratuitous error","name":"Error"}',
     [],
   );
 });

--- a/packages/SwingSet/test/test-exomessages.js
+++ b/packages/SwingSet/test/test-exomessages.js
@@ -59,14 +59,14 @@ async function testFailure(t) {
     failureHappened = true;
     t.is(
       e.message,
-      'kernel panic kp40.policy panic: rejected {"body":"{\\"@qclass\\":\\"error\\",\\"errorId\\":\\"error:liveSlots:v1#1\\",\\"message\\":\\"gratuitous error\\",\\"name\\":\\"Error\\"}","slots":[]}',
+      'kernel panic kp40.policy panic: rejected {"body":"{\\"@qclass\\":\\"error\\",\\"errorId\\":\\"error:liveSlots:v1#10001\\",\\"message\\":\\"gratuitous error\\",\\"name\\":\\"Error\\"}","slots":[]}',
     );
   }
   t.truthy(failureHappened);
   t.is(controller.kpStatus(controller.bootstrapResult), 'rejected');
   t.deepEqual(controller.kpResolution(controller.bootstrapResult), {
     body:
-      '{"@qclass":"error","errorId":"error:liveSlots:v1#1","message":"gratuitous error","name":"Error"}',
+      '{"@qclass":"error","errorId":"error:liveSlots:v1#10001","message":"gratuitous error","name":"Error"}',
     slots: [],
   });
 }
@@ -124,7 +124,7 @@ test('extra message rejects', async t => {
     t,
     'reject',
     'rejected',
-    '{"@qclass":"error","errorId":"error:liveSlots:v1#1","message":"gratuitous error","name":"Error"}',
+    '{"@qclass":"error","errorId":"error:liveSlots:v1#10001","message":"gratuitous error","name":"Error"}',
     [],
   );
 });

--- a/packages/SwingSet/test/test-liveslots.js
+++ b/packages/SwingSet/test/test-liveslots.js
@@ -557,7 +557,7 @@ test('liveslots vs symbols', async t => {
   const rp2 = 'p-2';
   const expErr = {
     '@qclass': 'error',
-    errorId: 'error:liveSlots:vatA#10001',
+    errorId: 'error:liveSlots:vatA#70001',
     message: 'arbitrary Symbols cannot be used as method names',
     name: 'Error',
   };
@@ -671,7 +671,7 @@ test('disavow', async t => {
     info: {
       body: JSON.stringify({
         '@qclass': 'error',
-        errorId: 'error:liveSlots:vatA#10001',
+        errorId: 'error:liveSlots:vatA#70001',
         message: 'this Presence has been disavowed',
         name: 'Error',
       }),

--- a/packages/SwingSet/test/test-liveslots.js
+++ b/packages/SwingSet/test/test-liveslots.js
@@ -557,7 +557,7 @@ test('liveslots vs symbols', async t => {
   const rp2 = 'p-2';
   const expErr = {
     '@qclass': 'error',
-    errorId: 'error:liveSlots:vatA#1',
+    errorId: 'error:liveSlots:vatA#10001',
     message: 'arbitrary Symbols cannot be used as method names',
     name: 'Error',
   };
@@ -671,7 +671,7 @@ test('disavow', async t => {
     info: {
       body: JSON.stringify({
         '@qclass': 'error',
-        errorId: 'error:liveSlots:vatA#1',
+        errorId: 'error:liveSlots:vatA#10001',
         message: 'this Presence has been disavowed',
         name: 'Error',
       }),

--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -14,6 +14,10 @@
 // The assertions re-exported here are defined in
 // https://github.com/endojs/endo/blob/master/packages/ses/src/error/assert.js
 
+// At https://github.com/Agoric/agoric-sdk/issues/2774
+// is a record of a failed attempt to remove '.types'.
+// To satisfy CI, not only do we need to keep the file,
+// but we need to import it here as well.
 import './types';
 
 const { freeze } = Object;

--- a/packages/assert/src/types.js
+++ b/packages/assert/src/types.js
@@ -5,6 +5,8 @@
 // Based on
 // https://github.com/Agoric/SES-shim/blob/master/packages/ses/src/error/types.js
 // Coordinate edits until we refactor to avoid this duplication
+// At https://github.com/Agoric/agoric-sdk/issues/2774
+// is a record of a failed attempt to remove this duplication.
 
 /**
  * @callback BaseAssert

--- a/packages/assert/src/types.js
+++ b/packages/assert/src/types.js
@@ -26,6 +26,7 @@
  * @param {Details=} optDetails The details of what was asserted
  * @param {ErrorConstructor=} ErrorConstructor An optional alternate error
  * constructor to use.
+ * @param {string=} optErrorName
  * @returns {Error}
  */
 
@@ -182,10 +183,10 @@
  * );
  * ```
  *
- * The normal convention is to locally rename `details` to `X` and import `q`
- * and `assert` unmodified.
+ * The normal convention is to locally rename `quote` to `q` and
+ * `details` to `X`
  * ```js
- * import { assert, details as X, q } from \'@agoric/assert\';
+ * const { details: X, quote: q } = assert;
  * ```
  * so the above example would then be
  * ```js
@@ -198,6 +199,7 @@
  *
  * @callback AssertQuote
  * @param {*} payload What to declassify
+ * @param {(string|number)=} spaces
  * @returns {StringablePayload} The declassified payload
  */
 
@@ -231,6 +233,7 @@
  * `optRaise(reason)` would still happen.
  *
  * @param {Raise=} optRaise
+ * @param {boolean=} unredacted
  * @returns {Assert}
  */
 

--- a/packages/assert/src/types.js
+++ b/packages/assert/src/types.js
@@ -20,6 +20,11 @@
  */
 
 /**
+ * @typedef {Object} AssertMakeErrorOptions
+ * @property {string=} errorName
+ */
+
+/**
  * @callback AssertMakeError
  *
  * The `assert.error` method, recording details for the console.
@@ -28,7 +33,7 @@
  * @param {Details=} optDetails The details of what was asserted
  * @param {ErrorConstructor=} ErrorConstructor An optional alternate error
  * constructor to use.
- * @param {string=} optErrorName
+ * @param {AssertMakeErrorOptions=} options
  * @returns {Error}
  */
 

--- a/packages/captp/lib/captp.js
+++ b/packages/captp/lib/captp.js
@@ -84,7 +84,12 @@ export function makeCapTP(ourId, rawSend, bootstrapObj = undefined, opts = {}) {
     convertValToSlot,
     // eslint-disable-next-line no-use-before-define
     convertSlotToVal,
-    { marshalName: `captp:${ourId}` },
+    {
+      marshalName: `captp:${ourId}`,
+      // TODO Temporary hack.
+      // See https://github.com/Agoric/agoric-sdk/issues/2780
+      errorIdNum: 20000,
+    },
   );
 
   const valToSlot = new WeakMap(); // exports looked up by val

--- a/packages/dapp-svelte-wallet/api/src/lib-dehydrate.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-dehydrate.js
@@ -341,6 +341,9 @@ export const makeDehydrator = (initialUnnamedCount = 0) => {
     convertNameToVal,
     {
       marshalName: 'hydration',
+      // TODO Temporary hack.
+      // See https://github.com/Agoric/agoric-sdk/issues/2780
+      errorIdNum: 30000,
     },
   );
   return harden({

--- a/packages/dapp-svelte-wallet/api/src/lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-wallet.js
@@ -149,6 +149,9 @@ export function makeWallet({
   // @qclass is lost.
   const { unserialize: fillInSlots } = makeMarshal(noOp, identitySlotToValFn, {
     marshalName: 'wallet',
+    // TODO Temporary hack.
+    // See https://github.com/Agoric/agoric-sdk/issues/2780
+    errorIdNum: 40000,
   });
 
   /** @type {NotifierRecord<OfferState[]>} */

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -866,16 +866,12 @@ export function makeMarshal(
               X`invalid error message typeof ${q(typeof message)}`,
             );
             const EC = getErrorConstructor(`${name}`) || Error;
-            let error;
-            if (typeof errorId === 'string') {
-              const errorName = `Remote${EC.name}(${errorId})`;
-              error = assert.error(`${message}`, EC, { errorName });
-              assert.note(error, X`Received as ${errorId}`);
-            } else {
-              // errorId is a late addition so be tolerant of its absence.
-              const errorName = `Remote${EC.name}`;
-              error = assert.error(`${message}`, EC, { errorName });
-            }
+            // errorId is a late addition so be tolerant of its absence.
+            const errorName =
+              errorId === undefined
+                ? `Remote${EC.name}`
+                : `Remote${EC.name}(${errorId})`;
+            const error = assert.error(`${message}`, EC, { errorName });
             ibidTable.register(error);
             return error;
           }

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -538,7 +538,7 @@ export function makeMarshal(
   );
   // Ascending numbers identifying the sending of errors relative to this
   // marshal instance.
-  let errorCount = 0;
+  let errorCount = 10000;
   const nextErrorId = () => {
     errorCount += 1;
     return `error:${marshalName}#${errorCount}`;
@@ -872,11 +872,11 @@ export function makeMarshal(
               error = assert.error(
                 `${message}`,
                 EC,
-                `Remote ${EC.name}#${errorId}`,
+                `Remote${EC.name}(${errorId})`,
               );
               assert.note(error, X`Received as ${errorId}`);
             } else {
-              error = assert.error(`${message}`, EC);
+              error = assert.error(`${message}`, EC, `Remote${EC.name}`);
             }
             ibidTable.register(error);
             return error;

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -538,10 +538,10 @@ export function makeMarshal(
   );
   // Ascending numbers identifying the sending of errors relative to this
   // marshal instance.
-  let errorCount = 10000;
+  let errorIdNum = 10000;
   const nextErrorId = () => {
-    errorCount += 1;
-    return `error:${marshalName}#${errorCount}`;
+    errorIdNum += 1;
+    return `error:${marshalName}#${errorIdNum}`;
   };
 
   /**

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -868,15 +868,13 @@ export function makeMarshal(
             const EC = getErrorConstructor(`${name}`) || Error;
             let error;
             if (typeof errorId === 'string') {
-              // errorId is a late addition so be tolerant of its absence.
-              error = assert.error(
-                `${message}`,
-                EC,
-                `Remote${EC.name}(${errorId})`,
-              );
+              const errorName = `Remote${EC.name}(${errorId})`;
+              error = assert.error(`${message}`, EC, { errorName });
               assert.note(error, X`Received as ${errorId}`);
             } else {
-              error = assert.error(`${message}`, EC, `Remote${EC.name}`);
+              // errorId is a late addition so be tolerant of its absence.
+              const errorName = `Remote${EC.name}`;
+              error = assert.error(`${message}`, EC, { errorName });
             }
             ibidTable.register(error);
             return error;

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -523,8 +523,11 @@ export function makeMarshal(
   convertValToSlot = defaultValToSlotFn,
   convertSlotToVal = defaultSlotToValFn,
   {
-    marshalName = 'anon-marshal',
     errorTagging = 'on',
+    marshalName = 'anon-marshal',
+    // TODO Temporary hack.
+    // See https://github.com/Agoric/agoric-sdk/issues/2780
+    errorIdNum = 10000,
     // We prefer that the caller instead log to somewhere hidden
     // to be revealed when correlating with the received error.
     marshalSaveError = err =>
@@ -536,9 +539,6 @@ export function makeMarshal(
     errorTagging === 'on' || errorTagging === 'off',
     X`The errorTagging option can only be "on" or "off" ${errorTagging}`,
   );
-  // Ascending numbers identifying the sending of errors relative to this
-  // marshal instance.
-  let errorIdNum = 10000;
   const nextErrorId = () => {
     errorIdNum += 1;
     return `error:${marshalName}#${errorIdNum}`;

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -866,12 +866,19 @@ export function makeMarshal(
               X`invalid error message typeof ${q(typeof message)}`,
             );
             const EC = getErrorConstructor(`${name}`) || Error;
-            const error = harden(new EC(`${message}`));
-            ibidTable.register(error);
+            let error;
             if (typeof errorId === 'string') {
               // errorId is a late addition so be tolerant of its absence.
+              error = assert.error(
+                `${message}`,
+                EC,
+                `Remote ${EC.name}#${errorId}`,
+              );
               assert.note(error, X`Received as ${errorId}`);
+            } else {
+              error = assert.error(`${message}`, EC);
             }
+            ibidTable.register(error);
             return error;
           }
 

--- a/packages/marshal/src/types.js
+++ b/packages/marshal/src/types.js
@@ -161,9 +161,20 @@
 
 /**
  * @typedef MakeMarshalOptions
- * @property {string=} marshalName
- * @property {'on'|'off'=} errorTagging
- * @property {(err: Error) => void=} marshalSaveError
+ * @property {'on'|'off'=} errorTagging controls whether serialized errors
+ * also carry tagging information, made from `marshalName` and numbers
+ * generated (currently by counting) starting at `errorIdNum`. The
+ * `errorTagging` option defaults to `'on'`. Serialized
+ * errors are also logged to `marshalSaveError` only if tagging is `'on'`.
+ * @property {string=} marshalName Used to identify sent errors.
+ * @property {number=} errorIdNum Ascending numbers staring from here
+ * identify the sending of errors relative to this marshal instance.
+ * @property {(err: Error) => void=} marshalSaveError If `errorTagging` is
+ * `'on'`, then errors serialized by this marshal instance are also
+ * logged by calling `marshalSaveError` *after* `assert.note` associated
+ * that error with its errorId. Thus, if `marshalSaveError` in turn logs
+ * to the normal console, which is the default, then the console will
+ * show that note showing the associated errorId.
  */
 
 // /////////////////////////////////////////////////////////////////////////////

--- a/packages/marshal/test/test-marshal.js
+++ b/packages/marshal/test/test-marshal.js
@@ -180,13 +180,13 @@ test('serialize errors', t => {
 
   t.deepEqual(ser(harden(Error())), {
     body:
-      '{"@qclass":"error","errorId":"error:anon-marshal#1","message":"","name":"Error"}',
+      '{"@qclass":"error","errorId":"error:anon-marshal#10001","message":"","name":"Error"}',
     slots: [],
   });
 
   t.deepEqual(ser(harden(ReferenceError('msg'))), {
     body:
-      '{"@qclass":"error","errorId":"error:anon-marshal#2","message":"msg","name":"ReferenceError"}',
+      '{"@qclass":"error","errorId":"error:anon-marshal#10002","message":"msg","name":"ReferenceError"}',
     slots: [],
   });
 
@@ -201,7 +201,7 @@ test('serialize errors', t => {
   t.falsy(isFrozen(errExtra.foo));
   t.deepEqual(ser(errExtra), {
     body:
-      '{"@qclass":"error","errorId":"error:anon-marshal#3","message":"has extra properties","name":"Error"}',
+      '{"@qclass":"error","errorId":"error:anon-marshal#10003","message":"has extra properties","name":"Error"}',
     slots: [],
   });
   t.falsy(isFrozen(errExtra.foo));
@@ -211,7 +211,7 @@ test('serialize errors', t => {
   const nonError1 = { __proto__: nonErrorProto1, message: [] };
   t.deepEqual(ser(harden(nonError1)), {
     body:
-      '{"@qclass":"error","errorId":"error:anon-marshal#4","message":"","name":"included"}',
+      '{"@qclass":"error","errorId":"error:anon-marshal#10004","message":"","name":"included"}',
     slots: [],
   });
 });


### PR DESCRIPTION
If linked with https://github.com/endojs/endo/pull/649 , then `marshal` will cause unserialized errors to be identified as such when shown on the console. This tagging is invisible to unprivileged code.

If linked before that PR, then this PR has no effect. Thus, it can be merged before a SES containing that other PR is released.

Well, almost no effect. As a place holder for @dtribble's better pseudo-pseudo-random-number-generator, the remote error tagging simply starts the counter at 10000 instead of 0. This will help a bit but will still be confusing.