### PR TITLE
Use priceAuthority's mutable trigger points in Treasury

### DIFF
--- a/packages/treasury/src/liquidateMinimum.js
+++ b/packages/treasury/src/liquidateMinimum.js
@@ -45,7 +45,7 @@ export async function start(zcf) {
       const { deposited, userSeatPromise: liqSeat } = await offerTo(
         zcf,
         swapInvitation,
-        undefined,
+        undefined, // The keywords were mapped already
         liqProposal,
         debtorSeat,
       );
@@ -65,7 +65,7 @@ export async function start(zcf) {
         } = await offerTo(
           zcf,
           strategy.makeInvitation(),
-          strategy.keywordMapping(),
+          undefined, // The keywords were mapped already
           strategy.makeProposal(amountIn, amountMath.makeEmpty(runBrand)),
           debtorSeat,
         );

--- a/packages/treasury/src/vaultManager.js
+++ b/packages/treasury/src/vaultManager.js
@@ -72,8 +72,7 @@ export function makeVaultManager(
   // better performance, use virtual objects.)
   // eslint-disable-next-line no-use-before-define
   const sortedVaultKits = makePrioritizedVaults(reschedulePriceCheck);
-  // The highest debt ratio for which we have a request outstanding
-  let highestDebtRatio = sortedVaultKits.highestRatio();
+  let outstandingQuote;
 
   // When any Vault's debt ratio is higher than the current high-water level,
   // call reschedulePriceCheck() to request a fresh notification from the
@@ -84,41 +83,51 @@ export function makeVaultManager(
   // when a priceQuote is received, we'll only reschedule if the high-water
   // level when the request was made matches the current high-water level.
   async function reschedulePriceCheck() {
-    const highestRatioWhenScheduled = sortedVaultKits.highestRatio();
-    if (!highestRatioWhenScheduled) {
+    const highestDebtRatio = sortedVaultKits.highestRatio();
+    if (!highestDebtRatio) {
       // if there aren't any open vaults, we don't need an outstanding RFQ.
       return;
     }
 
-    highestDebtRatio = highestRatioWhenScheduled;
     const liquidationMargin = shared.getLiquidationMargin();
 
-    // We ask to be alerted when the price level falls enough that the vault
+    // ask to be alerted when the price level falls enough that the vault
     // with the highest debt to collateral ratio will no longer be valued at the
     // liquidationMargin above its debt.
     const triggerPoint = multiplyBy(
-      highestRatioWhenScheduled.numerator,
+      highestDebtRatio.numerator,
       liquidationMargin,
     );
-    // Notice that this is scheduleing a callback for later (possibly much
-    // later). Callers shouldn't be expecting a response from this function.
-    const quote = await E(priceAuthority).quoteWhenLT(
-      highestRatioWhenScheduled.denominator,
+
+    // if there's an outstanding quote, reset the level. If there's no current
+    // quote (because this is the first loan, or because a quote just resolved)
+    // then make a new request to the priceAuthority, and when it resolves,
+    // liquidate anything that's above the price level.
+    if (outstandingQuote) {
+      E(outstandingQuote).updateLevel(
+        highestDebtRatio.denominator,
+        triggerPoint,
+      );
+      return;
+    }
+
+    outstandingQuote = await E(priceAuthority).mutableQuoteWhenLT(
+      highestDebtRatio.denominator,
       triggerPoint,
     );
 
+    // There are two awaits in a row here. The first gets a mutableQuote object
+    // relatively quickly from the PriceAuthority. The second schedules a
+    // callback that may not fire until much later.
+    // Callers shouldn't expect a response from this function.
+    const quote = await E(outstandingQuote).getPromise();
+    // When we receive a quote, we liquidate all the vaults that don't have
+    // sufficient collateral, (even if the trigger was set for a different
+    // level) because we use the actual price ratio plus margin here.
     const quoteRatioPlusMargin = makeRatioFromAmounts(
       divideBy(getAmountOut(quote), liquidationMargin),
       getAmountIn(quote),
     );
-
-    // Since we can't cancel outstanding quote requests when balances change,
-    // we may receive alerts that don't match the current high-water mark. When
-    // we receive a quote, we liquidate all the vaults that don't have
-    // sufficient collateral, (even if the trigger was set for a different
-    // level) because we use the actual price ratio plus margin here. We
-    // only reschedule if the high-water mark matches to prevent creating too
-    // many extra requests.
 
     sortedVaultKits.forEachRatioGTE(quoteRatioPlusMargin, ({ vaultKit }) => {
       trace('liquidating', vaultKit.vaultSeat.getProposal());
@@ -131,9 +140,8 @@ export function makeVaultManager(
         collateralBrand,
       );
     });
-    if (highestRatioWhenScheduled === highestDebtRatio) {
-      reschedulePriceCheck();
-    }
+    outstandingQuote = undefined;
+    reschedulePriceCheck();
   }
 
   function liquidateAll() {
@@ -158,6 +166,8 @@ export function makeVaultManager(
         ),
       amountMath.makeEmpty(runBrand),
     );
+    sortedVaultKits.updateAllDebts();
+    reschedulePriceCheck();
     runMint.mintGains({ RUN: poolIncrement }, poolIncrementSeat);
     const poolStage = poolIncrementSeat.stage({
       RUN: amountMath.makeEmpty(runBrand),

--- a/packages/treasury/test/test-prioritizedVaults.js
+++ b/packages/treasury/test/test-prioritizedVaults.js
@@ -52,7 +52,7 @@ function makeRescheduler() {
 
 function makeFakeVaultKit(
   initDebt,
-  initCollateral = amountMath.make(100n, initDebt.brand),
+  initCollateral = amountMath.make(initDebt.brand, 100n),
 ) {
   let debt = initDebt;
   let collateral = initCollateral;
@@ -73,7 +73,7 @@ test('add to vault', async t => {
 
   const rescheduler = makeRescheduler();
   const vaults = makePrioritizedVaults(rescheduler.fakeReschedule);
-  const fakeVaultKit = makeFakeVaultKit(amountMath.make(130n, brand));
+  const fakeVaultKit = makeFakeVaultKit(amountMath.make(brand, 130n));
   const { notifier } = makeNotifierKit();
   vaults.addVaultKit(fakeVaultKit, notifier);
   const collector = makeCollector();
@@ -92,17 +92,17 @@ test('updates', async t => {
   const rescheduler = makeRescheduler();
   const vaults = makePrioritizedVaults(rescheduler.fakeReschedule);
 
-  const fakeVault1 = makeFakeVaultKit(amountMath.make(120n, brand));
+  const fakeVault1 = makeFakeVaultKit(amountMath.make(brand, 120n));
   const { updater: updater1, notifier: notifier1 } = makeNotifierKit();
   vaults.addVaultKit(fakeVault1, notifier1);
 
-  const fakeVault2 = makeFakeVaultKit(amountMath.make(180n, brand));
+  const fakeVault2 = makeFakeVaultKit(amountMath.make(brand, 180n));
   const { updater: updater2, notifier: notifier2 } = makeNotifierKit();
   vaults.addVaultKit(fakeVault2, notifier2);
 
   // prioritizedVaults doesn't care what the update contains
-  updater1.updateState({});
-  updater2.updateState({});
+  updater1.updateState({ locked: amountMath.make(brand, 300n) });
+  updater2.updateState({ locked: amountMath.make(brand, 300n) });
   await waitForPromisesToSettle();
 
   const collector = makeCollector();
@@ -122,24 +122,24 @@ test('update changes ratio', async t => {
   const rescheduler = makeRescheduler();
   const vaults = makePrioritizedVaults(rescheduler.fakeReschedule);
 
-  const fakeVault1 = makeFakeVaultKit(amountMath.make(120n, brand));
+  const fakeVault1 = makeFakeVaultKit(amountMath.make(brand, 120n));
   const { updater: updater1, notifier: notifier1 } = makeNotifierKit();
   vaults.addVaultKit(fakeVault1, notifier1);
 
-  const fakeVault2 = makeFakeVaultKit(amountMath.make(180n, brand));
+  const fakeVault2 = makeFakeVaultKit(amountMath.make(brand, 180n));
   const { updater: updater2, notifier: notifier2 } = makeNotifierKit();
   vaults.addVaultKit(fakeVault2, notifier2);
 
   // prioritizedVaults doesn't care what the update contains
-  updater1.updateState({});
-  updater2.updateState({});
+  updater1.updateState({ locked: amountMath.make(brand, 300n) });
+  updater2.updateState({ locked: amountMath.make(brand, 300n) });
   await waitForPromisesToSettle();
 
   const ratio180 = makeRatio(180n, brand, 100n);
   t.deepEqual(vaults.highestRatio(), ratio180);
 
   fakeVault1.vault.setDebt(amountMath.make(200n, brand));
-  updater1.updateState({});
+  updater1.updateState({ locked: amountMath.make(brand, 300n) });
   await waitForPromisesToSettle();
   t.deepEqual(vaults.highestRatio(), makeRatio(200n, brand, 100n));
 
@@ -159,17 +159,17 @@ test('removals', async t => {
   const rescheduler = makeRescheduler();
   const vaults = makePrioritizedVaults(rescheduler.fakeReschedule);
 
-  const fakeVault1 = makeFakeVaultKit(amountMath.make(150n, brand));
+  const fakeVault1 = makeFakeVaultKit(amountMath.make(brand, 150n));
   const { notifier: notifier1 } = makeNotifierKit();
   vaults.addVaultKit(fakeVault1, notifier1);
   const ratio150 = makeRatio(150n, brand);
 
-  const fakeVault2 = makeFakeVaultKit(amountMath.make(130n, brand));
+  const fakeVault2 = makeFakeVaultKit(amountMath.make(brand, 130n));
   const { notifier: notifier2 } = makeNotifierKit();
   vaults.addVaultKit(fakeVault2, notifier2);
   const ratio130 = makeRatio(130n, brand);
 
-  const fakeVault3 = makeFakeVaultKit(amountMath.make(140n, brand));
+  const fakeVault3 = makeFakeVaultKit(amountMath.make(brand, 140n));
   const { notifier: notifier3 } = makeNotifierKit();
   vaults.addVaultKit(fakeVault3, notifier3);
 
@@ -189,11 +189,11 @@ test('chargeInterest', async t => {
   const rescheduler = makeRescheduler();
   const vaults = makePrioritizedVaults(rescheduler.fakeReschedule);
 
-  const fakeVault1 = makeFakeVaultKit(amountMath.make(130n, brand));
+  const fakeVault1 = makeFakeVaultKit(amountMath.make(brand, 130n));
   const { notifier: notifier1 } = makeNotifierKit();
   vaults.addVaultKit(fakeVault1, notifier1);
 
-  const fakeVault2 = makeFakeVaultKit(amountMath.make(150n, brand));
+  const fakeVault2 = makeFakeVaultKit(amountMath.make(brand, 150n));
   const { notifier: notifier2 } = makeNotifierKit();
   vaults.addVaultKit(fakeVault2, notifier2);
 
@@ -220,16 +220,16 @@ test('liquidation', async t => {
   const reschedulePriceCheck = makeRescheduler();
   const vaults = makePrioritizedVaults(reschedulePriceCheck.fakeReschedule);
 
-  const fakeVault1 = makeFakeVaultKit(amountMath.make(130n, brand));
+  const fakeVault1 = makeFakeVaultKit(amountMath.make(brand, 130n));
   const { notifier: notifier1 } = makeNotifierKit();
   vaults.addVaultKit(fakeVault1, notifier1);
 
-  const fakeVault2 = makeFakeVaultKit(amountMath.make(150n, brand));
+  const fakeVault2 = makeFakeVaultKit(amountMath.make(brand, 150n));
   const { notifier: notifier2 } = makeNotifierKit();
   vaults.addVaultKit(fakeVault2, notifier2);
   const cr2 = makeRatio(150n, brand);
 
-  const fakeVault3 = makeFakeVaultKit(amountMath.make(140n, brand));
+  const fakeVault3 = makeFakeVaultKit(amountMath.make(brand, 140n));
   const { notifier: notifier3 } = makeNotifierKit();
   vaults.addVaultKit(fakeVault3, notifier3);
   const cr3 = makeRatio(140n, brand);
@@ -250,19 +250,19 @@ test('highestRatio ', async t => {
   const reschedulePriceCheck = makeRescheduler();
   const vaults = makePrioritizedVaults(reschedulePriceCheck.fakeReschedule);
 
-  const fakeVault1 = makeFakeVaultKit(amountMath.make(130n, brand));
+  const fakeVault1 = makeFakeVaultKit(amountMath.make(brand, 130n));
   const { notifier: notifier2 } = makeNotifierKit();
   vaults.addVaultKit(fakeVault1, notifier2);
   const cr1 = makeRatio(130n, brand);
   t.deepEqual(vaults.highestRatio(), cr1);
 
-  const fakeVault6 = makeFakeVaultKit(amountMath.make(150n, brand));
+  const fakeVault6 = makeFakeVaultKit(amountMath.make(brand, 150n));
   const { notifier: notifier1 } = makeNotifierKit();
   vaults.addVaultKit(fakeVault6, notifier1);
   const cr6 = makeRatio(150n, brand);
   t.deepEqual(vaults.highestRatio(), cr6);
 
-  const fakeVault3 = makeFakeVaultKit(amountMath.make(140n, brand));
+  const fakeVault3 = makeFakeVaultKit(amountMath.make(brand, 140n));
   const { notifier: notifier3 } = makeNotifierKit();
   vaults.addVaultKit(fakeVault3, notifier3);
   const cr3 = makeRatio(140n, brand);
@@ -285,18 +285,18 @@ test('removal by notification', async t => {
   const reschedulePriceCheck = makeRescheduler();
   const vaults = makePrioritizedVaults(reschedulePriceCheck.fakeReschedule);
 
-  const fakeVault1 = makeFakeVaultKit(amountMath.make(150n, brand));
+  const fakeVault1 = makeFakeVaultKit(amountMath.make(brand, 150n));
   const { updater: updater1, notifier: notifier1 } = makeNotifierKit();
   vaults.addVaultKit(fakeVault1, notifier1);
   const cr1 = makeRatio(150n, brand);
   t.deepEqual(vaults.highestRatio(), cr1);
 
-  const fakeVault2 = makeFakeVaultKit(amountMath.make(130n, brand));
+  const fakeVault2 = makeFakeVaultKit(amountMath.make(brand, 130n));
   const { notifier: notifier2 } = makeNotifierKit();
   vaults.addVaultKit(fakeVault2, notifier2);
   t.deepEqual(vaults.highestRatio(), cr1, 'should be new highest');
 
-  const fakeVault3 = makeFakeVaultKit(amountMath.make(140n, brand));
+  const fakeVault3 = makeFakeVaultKit(amountMath.make(brand, 140n));
   const { notifier: notifier3 } = makeNotifierKit();
   vaults.addVaultKit(fakeVault3, notifier3);
   const cr3 = makeRatio(140n, brand);

--- a/packages/treasury/test/test-stablecoin.js
+++ b/packages/treasury/test/test-stablecoin.js
@@ -17,8 +17,8 @@ import buildManualTimer from '@agoric/zoe/tools/manualTimer';
 import { makeRatio, multiplyBy } from '@agoric/zoe/src/contractSupport/ratio';
 import { makePromiseKit } from '@agoric/promise-kit';
 
+import { makeScriptedPriceAuthority } from '@agoric/zoe/tools/scriptedPriceAuthority';
 import { makeTracer } from '../src/makeTracer';
-import { makeScriptedPriceAuthority } from '../../zoe/test/unitTests/contracts/scriptedPriceAuthority';
 
 const stablecoinRoot = '../src/stablecoinMachine.js';
 const liquidationRoot = '../src/liquidateMinimum.js';

--- a/packages/zoe/src/contracts/multipoolAutoswap/priceAuthority.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/priceAuthority.js
@@ -38,7 +38,6 @@ export const makePriceAuthority = (
    * @returns {ERef<PriceQuote>=}
    */
   function createQuote(priceQuery) {
-    // calcAmountIn is not used, but required by typescript
     const quote = priceQuery(calcAmountOut, calcAmountIn);
     assert(quote, X`priceQuery must return a quote`);
 

--- a/packages/zoe/test/unitTests/contracts/scriptedPriceAuthority.js
+++ b/packages/zoe/test/unitTests/contracts/scriptedPriceAuthority.js
@@ -1,0 +1,94 @@
+// @ts-check
+
+import { amountMath, makeIssuerKit, MathKind } from '@agoric/ertp';
+import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
+import { observeNotifier } from '@agoric/notifier';
+import {
+  natSafeMath,
+  makeOnewayPriceAuthorityKit,
+} from '../../../src/contractSupport';
+
+export function makeScriptedPriceAuthority(options) {
+  const {
+    actualBrandIn,
+    actualBrandOut,
+    priceList,
+    timer,
+    unitAmountIn = amountMath.make(1n, actualBrandIn),
+    quoteInterval = 1n,
+    quoteIssuerKit = makeIssuerKit('quote', MathKind.SET),
+  } = options;
+  const { brand, issuer: quoteIssuer, mint: quoteMint } = quoteIssuerKit;
+  let currentPrice;
+
+  /** @param {PriceQuoteValue} quote */
+  const authenticateQuote = quote => {
+    const quoteAmount = amountMath.make(quote, brand);
+    const quotePayment = quoteMint.mintPayment(quoteAmount);
+    return harden({ quoteAmount, quotePayment });
+  };
+
+  const calcAmountOut = amountIn => {
+    amountMath.coerce(actualBrandIn, amountIn);
+
+    return amountMath.make(
+      natSafeMath.floorDivide(
+        natSafeMath.multiply(currentPrice, amountIn.value),
+        unitAmountIn.value,
+      ),
+      actualBrandOut,
+    );
+  };
+  const calcAmountIn = amountOut => {
+    amountMath.coerce(actualBrandOut, amountOut);
+    return amountMath.make(
+      natSafeMath.floorDivide(
+        natSafeMath.multiply(unitAmountIn.value, amountOut.value),
+        currentPrice,
+      ),
+      actualBrandOut,
+    );
+  };
+
+  function createQuote(priceQuery) {
+    const quote = priceQuery(calcAmountOut, calcAmountIn);
+    if (!quote) {
+      return undefined;
+    }
+
+    const { amountIn, amountOut } = quote;
+    return E(timer)
+      .getCurrentTimestamp()
+      .then(now =>
+        authenticateQuote([{ amountIn, amountOut, timer, timestamp: now }]),
+      );
+  }
+
+  const notifier = timer.makeNotifier(0n, 1n);
+
+  const priceAuthorityOptions = harden({
+    timer,
+    createQuote,
+    actualBrandIn,
+    actualBrandOut,
+    quoteIssuer,
+    notifier,
+  });
+
+  const {
+    priceAuthority,
+    adminFacet: { fireTriggers },
+  } = makeOnewayPriceAuthorityKit(priceAuthorityOptions);
+
+  const priceObserver = Far('priceObserver', {
+    updateState: t => {
+      currentPrice = priceList[t % (BigInt(priceList.length) * quoteInterval)];
+
+      fireTriggers(createQuote);
+    },
+  });
+  observeNotifier(notifier, priceObserver);
+
+  return priceAuthority;
+}

--- a/packages/zoe/tools/fakePriceAuthority.js
+++ b/packages/zoe/tools/fakePriceAuthority.js
@@ -293,6 +293,18 @@ export async function makeFakePriceAuthority(options) {
       const compareLT = amount => !amountMath.isGTE(amount, amountOutLimit);
       return resolveQuoteWhen(compareLT, amountIn, amountOutLimit);
     },
+    mutableQuoteWhenLT: () => {
+      throw Error('use ScriptedPriceAuthority');
+    },
+    mutableQuoteWhenLTE: () => {
+      throw Error('use ScriptedPriceAuthority');
+    },
+    mutableQuoteWhenGT: () => {
+      throw Error('use ScriptedPriceAuthority');
+    },
+    mutableQuoteWhenGTE: () => {
+      throw Error('use ScriptedPriceAuthority');
+    },
   };
   return priceAuthority;
 }

--- a/packages/zoe/tools/priceAuthorityRegistry.js
+++ b/packages/zoe/tools/priceAuthorityRegistry.js
@@ -72,6 +72,25 @@ export const makePriceAuthorityRegistry = () => {
     };
 
   /**
+   * Create a mutableQuoteWhen* method for the given condition.
+   *
+   * @param {'LT' | 'LTE' | 'GTE' | 'GT'} relation
+   */
+  const makeMutableQuoteWhen = relation =>
+    /**
+     * Return a mutable quote when relation is true of the arguments.
+     *
+     * @param {Amount} amountIn monitor the amountOut corresponding to this amountIn
+     * @param {Amount} amountOutLimit the value to compare with the monitored amountOut
+     * @returns {Promise<MutableQuote>} resolve with a quote when `amountOut
+     * relation amountOutLimit` is true
+     */
+    async function mutableQuoteWhenRelation(amountIn, amountOutLimit) {
+      const pa = paFor(amountIn.brand, amountOutLimit.brand);
+      return E(pa)[`mutableQuoteWhen${relation}`](amountIn, amountOutLimit);
+    };
+
+  /**
    * This PriceAuthority is just a wrapper for multiple registered
    * PriceAuthorities.
    *
@@ -107,6 +126,10 @@ export const makePriceAuthorityRegistry = () => {
     quoteWhenLTE: makeQuoteWhen('LTE'),
     quoteWhenGTE: makeQuoteWhen('GTE'),
     quoteWhenGT: makeQuoteWhen('GT'),
+    mutableQuoteWhenLT: makeMutableQuoteWhen('LT'),
+    mutableQuoteWhenLTE: makeMutableQuoteWhen('LTE'),
+    mutableQuoteWhenGTE: makeMutableQuoteWhen('GTE'),
+    mutableQuoteWhenGT: makeMutableQuoteWhen('GT'),
   };
 
   /** @type {PriceAuthorityRegistryAdmin} */

--- a/packages/zoe/tools/scriptedPriceAuthority.js
+++ b/packages/zoe/tools/scriptedPriceAuthority.js
@@ -7,7 +7,7 @@ import { observeNotifier } from '@agoric/notifier';
 import {
   natSafeMath,
   makeOnewayPriceAuthorityKit,
-} from '../../../src/contractSupport';
+} from '../src/contractSupport';
 
 export function makeScriptedPriceAuthority(options) {
   const {
@@ -20,7 +20,7 @@ export function makeScriptedPriceAuthority(options) {
     quoteIssuerKit = makeIssuerKit('quote', MathKind.SET),
   } = options;
   const { brand, issuer: quoteIssuer, mint: quoteMint } = quoteIssuerKit;
-  let currentPrice;
+  let currentPrice = priceList[0];
 
   /** @param {PriceQuoteValue} quote */
   const authenticateQuote = quote => {
@@ -83,7 +83,8 @@ export function makeScriptedPriceAuthority(options) {
 
   const priceObserver = Far('priceObserver', {
     updateState: t => {
-      currentPrice = priceList[t % (BigInt(priceList.length) * quoteInterval)];
+      currentPrice =
+        priceList[Number(t) % (priceList.length * Number(quoteInterval))];
 
       fireTriggers(createQuote);
     },

--- a/packages/zoe/tools/types.js
+++ b/packages/zoe/tools/types.js
@@ -43,6 +43,13 @@
  */
 
 /**
+ * @typedef {Object} MutableQuote
+ * @property {() => void} cancel
+ * @property {() => void} updateLevel
+ * @property {() => ERef<PriceQuote>} getPromise
+ */
+
+/**
  * @typedef {Object} PriceAuthority An object that mints PriceQuotes and handles
  * triggers and notifiers for changes in the price
  *
@@ -81,6 +88,21 @@
  *
  * @property {(amountIn: Amount, amountOutLimit: Amount) => Promise<PriceQuote>}
  * quoteWhenLT Resolve when the price quote of `amountIn` drops below
+ * `amountOutLimit`
+ *
+ * @property {(amountIn: Amount, amountOutLimit: Amount) => ERef<MutableQuote>}
+ * mutableQuoteWhenGT Resolve when a price quote of `amountIn` exceeds `amountOutLimit`
+ *
+ * @property {(amountIn: Amount, amountOutLimit: Amount) => ERef<MutableQuote>}
+ * mutableQuoteWhenGTE Resolve when a price quote of `amountIn` reaches or exceeds
+ * `amountOutLimit`
+ *
+ * @property {(amountIn: Amount, amountOutLimit: Amount) => ERef<MutableQuote>}
+ * mutableQuoteWhenLTE Resolve when a price quote of `amountIn` reaches or drops below
+ * `amountOutLimit`
+ *
+ * @property {(amountIn: Amount, amountOutLimit: Amount) => ERef<MutableQuote>}
+ * mutableQuoteWhenLT Resolve when the price quote of `amountIn` drops below
  * `amountOutLimit`
  */
 


### PR DESCRIPTION
repaired a discovered ommission: liquidate after charging interest when needed

Add a ScriptedPriceAuthority, which uses the priceAuthority so it doesn't need to repeat the code.

fixes: #2785