### PR TITLE
chore: rename invitation descriptions

### DIFF
--- a/packages/treasury/src/liquidateMinimum.js
+++ b/packages/treasury/src/liquidateMinimum.js
@@ -90,7 +90,7 @@ export async function start(zcf) {
 
   const creatorFacet = {
     makeDebtorInvitation: runDebt =>
-      zcf.makeInvitation(makeDebtorHook(runDebt), 'liquidate'),
+      zcf.makeInvitation(makeDebtorHook(runDebt), 'Liquidate'),
   };
 
   return harden({ creatorFacet });

--- a/packages/treasury/src/make-empty.js
+++ b/packages/treasury/src/make-empty.js
@@ -6,7 +6,7 @@ import { E } from '@agoric/eventual-send';
  * @param { ContractFacet } zcf
  */
 export function makeEmptyOfferWithResult(zcf) {
-  const invitation = zcf.makeInvitation(_ => undefined, 'empty offer');
+  const invitation = zcf.makeInvitation(_ => undefined, 'EmptyOffer');
   const zoe = zcf.getZoeService();
   return E(zoe).offer(invitation); // Promise<OfferResultRecord>,
 }

--- a/packages/treasury/src/stablecoinMachine.js
+++ b/packages/treasury/src/stablecoinMachine.js
@@ -207,10 +207,7 @@ export async function start(zcf) {
       return vm;
     }
 
-    return zcf.makeInvitation(
-      addTypeHook,
-      'add a new kind of collateral to the machine',
-    );
+    return zcf.makeInvitation(addTypeHook, 'AddCollateralType');
   }
 
   /**
@@ -238,7 +235,7 @@ export async function start(zcf) {
       return mgr.makeLoanKit(seat);
     }
 
-    return zcf.makeInvitation(makeLoanHook, 'make a loan');
+    return zcf.makeInvitation(makeLoanHook, 'MakeLoan');
   }
 
   zcf.setTestJig(() => ({

--- a/packages/treasury/src/vault.js
+++ b/packages/treasury/src/vault.js
@@ -188,7 +188,7 @@ export function makeVaultKit(
 
   function makeCloseInvitation() {
     assertVaultIsOpen();
-    return zcf.makeInvitation(closeHook, 'pay off entire loan and close Vault');
+    return zcf.makeInvitation(closeHook, 'CloseVault');
   }
 
   // The proposal is not allowed to include any keys other than these,
@@ -366,7 +366,7 @@ export function makeVaultKit(
 
   function makeAdjustBalancesInvitation() {
     assertVaultIsOpen();
-    return zcf.makeInvitation(adjustBalancesHook, 'adjustBalances');
+    return zcf.makeInvitation(adjustBalancesHook, 'AdjustBalances');
   }
 
   async function openLoan(seat) {

--- a/packages/treasury/src/vaultManager.js
+++ b/packages/treasury/src/vaultManager.js
@@ -229,6 +229,10 @@ export function makeVaultManager(
     // the payout object
     return harden({
       uiNotifier: notifier,
+      invitationMakers: {
+        AdjustBalances: vault.makeAdjustBalancesInvitation,
+        CloseVault: vault.makeCloseInvitation,
+      },
       vault,
       liquidationPayout: collateralPayoutP,
     });


### PR DESCRIPTION
chore: rename invitation descriptions to meet the requirements for continuing invitations (must be ASCII and capitalized). Also, a invitationsMaker property is required on the `offerResult`

Fixes https://github.com/Agoric/dapp-token-economy/issues/255