### PR TITLE
Remove incorrect assertion in multipoolAutoSwap priceAuthority

### DIFF
--- a/packages/zoe/src/contracts/multipoolAutoswap/priceAuthority.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/priceAuthority.js
@@ -4,7 +4,6 @@ import { amountMath } from '@agoric/ertp';
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 import { observeNotifier } from '@agoric/notifier';
-import { assert, details as X } from '@agoric/assert';
 
 import { makeOnewayPriceAuthorityKit } from '../../contractSupport';
 
@@ -39,7 +38,9 @@ export const makePriceAuthority = (
    */
   function createQuote(priceQuery) {
     const quote = priceQuery(calcAmountOut, calcAmountIn);
-    assert(quote, X`priceQuery must return a quote`);
+    if (!quote) {
+      return undefined;
+    }
 
     const { amountIn, amountOut } = quote;
     return E(timer)

--- a/packages/zoe/test/unitTests/contracts/test-multipoolPriceAuthority.js
+++ b/packages/zoe/test/unitTests/contracts/test-multipoolPriceAuthority.js
@@ -1,0 +1,62 @@
+// @ts-check
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+import { makeNotifierKit } from '@agoric/notifier';
+import { makeIssuerKit, amountMath, MathKind } from '@agoric/ertp';
+import { makePriceAuthority } from '../../../src/contracts/multipoolAutoswap/priceAuthority';
+import { setup } from '../setupBasicMints';
+import buildManualTimer from '../../../tools/manualTimer';
+
+test('multipoolAutoSwap PriceAuthority exception path', async t => {
+  const { moolaR, simoleanR } = setup();
+  const timer = buildManualTimer(console.log, 0n);
+  const { notifier, updater } = makeNotifierKit();
+
+  const quoteKit = makeIssuerKit('quoteIssuer', MathKind.SET);
+
+  function ersatzQuote(moolaIn, simoleansOut) {
+    return {
+      amountIn: amountMath.make(moolaR.brand, moolaIn),
+      amountOut: amountMath.make(simoleanR.brand, simoleansOut),
+    };
+  }
+
+  const priceAuthority = makePriceAuthority(
+    () => ersatzQuote(3, 25),
+    () => ersatzQuote(18, 5),
+    moolaR.brand,
+    simoleanR.brand,
+    timer,
+    null,
+    notifier,
+    quoteKit,
+  );
+
+  const triggerDoesNot = priceAuthority.quoteWhenLT(
+    amountMath.make(moolaR.brand, 10),
+    amountMath.make(simoleanR.brand, 20),
+  );
+
+  triggerDoesNot.then(
+    quote => t.fail(` wasn't expecting a call with a quote ${quote}`),
+    e => t.fail(` wasn't expecting ${e}`),
+  );
+
+  const trigger = priceAuthority.quoteWhenLT(
+    amountMath.make(moolaR.brand, 10),
+    amountMath.make(simoleanR.brand, 30),
+  );
+
+  trigger.then(
+    quote => {
+      t.deepEqual(quote.quoteAmount.brand, quoteKit.brand);
+      t.truthy(quote.quoteAmount.value);
+      t.truthy(quote.quotePayment);
+    },
+    e => t.fail(` wasn't expecting ${e}`),
+  );
+
+  await updater.updateState(true);
+  await timer.tick();
+});


### PR DESCRIPTION
fixes #2831

priceAggregator shows that when priceQuery() returns a falsy value, createQuote()
is expected to return undefined. This happens when the comparefunction returns
false, so the promise isn't resolved.

I added a test of the priceAuthority in multipoolAutoSwap. The test fails before
the change (The first trigger gets false on the comparison)  and passes afterward.