### PR TITLE
chore: remove amountMathKind from issuerKit

### DIFF
--- a/packages/ERTP/src/issuer.js
+++ b/packages/ERTP/src/issuer.js
@@ -285,7 +285,6 @@ function makeIssuerKit(
     issuer,
     amountMath: makeAmountMath(brand, amountMathKind),
     brand,
-    amountMathKind,
   });
 }
 

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -310,7 +310,6 @@
  * @property {Issuer} issuer
  * @property {DeprecatedAmountMath} amountMath
  * @property {Brand} brand
- * @property {AmountMathKind} amountMathKind
  */
 
 /**


### PR DESCRIPTION
I believe that the `amountMathKind` was made part of the issuerKit before we could determine the `amountMathKind` from the values themselves. I was thinking we should remove it for clarity, since it is not be used or tested anywhere :/ 