### PR TITLE
Integrate Pegasus on-chain

### DIFF
--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -328,6 +328,10 @@ jobs:
       run: cd packages/treasury && yarn test
       env:
         ESM_DISABLE_CACHE: true
+    - name: yarn test (pegasus)
+      run: cd packages/pegasus && yarn test
+      env:
+        ESM_DISABLE_CACHE: true
     - name: yarn test (cosmic-swingset)
       run: cd packages/cosmic-swingset && yarn test
       env:

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "packages/dapp-svelte-wallet/api",
     "packages/dapp-svelte-wallet",
     "packages/treasury",
+    "packages/pegasus",
     "packages/cosmic-swingset",
     "packages/agoric-cli",
     "packages/deployment",

--- a/packages/SwingSet/src/vats/network/types.js
+++ b/packages/SwingSet/src/vats/network/types.js
@@ -30,7 +30,6 @@
 /**
  * @typedef {Object} ListenHandler A handler for incoming connections
  * @property {(port: Port, l: ListenHandler) => Promise<void>} [onListen] The listener has been registered
- * @property {(port: Port, listenAddr: Endpoint, remoteAddr: Endpoint, l: ListenHandler) => Promise<Endpoint>} [onInbound] Return metadata for inbound connection attempt
  * @property {(port: Port, localAddr: Endpoint, remoteAddr: Endpoint, l: ListenHandler) => Promise<ConnectionHandler>} onAccept A new connection is incoming
  * @property {(port: Port, localAddr: Endpoint, remoteAddr: Endpoint, l: ListenHandler) => Promise<void>} onReject The connection was rejected
  * @property {(port: Port, rej: any, l: ListenHandler) => Promise<void>} [onError] There was an error while listening
@@ -61,6 +60,8 @@
  * @property {(port: Port, localAddr: Endpoint, p: ProtocolHandler) => Promise<void>} onBind A port will be bound
  * @property {(port: Port, localAddr: Endpoint, listenHandler: ListenHandler, p: ProtocolHandler) => Promise<void>} onListen A port was listening
  * @property {(port: Port, localAddr: Endpoint, listenHandler: ListenHandler, p: ProtocolHandler) => Promise<void>} onListenRemove A port listener has been reset
+ * @property {(port: Port, listenAddr: Endpoint, remoteAddr: Endpoint, l: ListenHandler, p: ProtocolHandler) => Promise<Endpoint>} [onInbound] Return suffix for
+ * inbound connection attempt
  * @property {(port: Port, localAddr: Endpoint, remote: Endpoint, c: ConnectionHandler, p: ProtocolHandler) => Promise<[Endpoint, ConnectionHandler]>} onConnect A port initiates an outbound connection
  * @property {(port: Port, localAddr: Endpoint, p: ProtocolHandler) => Promise<void>} onRevoke The port is being completely destroyed
  *

--- a/packages/SwingSet/src/vats/network/types.js
+++ b/packages/SwingSet/src/vats/network/types.js
@@ -60,8 +60,8 @@
  * @property {(port: Port, localAddr: Endpoint, p: ProtocolHandler) => Promise<void>} onBind A port will be bound
  * @property {(port: Port, localAddr: Endpoint, listenHandler: ListenHandler, p: ProtocolHandler) => Promise<void>} onListen A port was listening
  * @property {(port: Port, localAddr: Endpoint, listenHandler: ListenHandler, p: ProtocolHandler) => Promise<void>} onListenRemove A port listener has been reset
- * @property {(port: Port, listenAddr: Endpoint, remoteAddr: Endpoint, l: ListenHandler, p: ProtocolHandler) => Promise<Endpoint>} [onInbound] Return suffix for
- * inbound connection attempt
+ * @property {(port: Port, localAddr: Endpoint, remote: Endpoint, p: ProtocolHandler) => Promise<Endpoint>} [onInstantiate] Return unique suffix for
+ * local address
  * @property {(port: Port, localAddr: Endpoint, remote: Endpoint, c: ConnectionHandler, p: ProtocolHandler) => Promise<[Endpoint, ConnectionHandler]>} onConnect A port initiates an outbound connection
  * @property {(port: Port, localAddr: Endpoint, p: ProtocolHandler) => Promise<void>} onRevoke The port is being completely destroyed
  *

--- a/packages/SwingSet/test/test-network.js
+++ b/packages/SwingSet/test/test-network.js
@@ -81,7 +81,9 @@ test('handled protocol', async t => {
   await port.connect(
     '/ibc/*/ordered/echo',
     harden({
-      async onOpen(connection, _localAddr, _remoteAddr) {
+      async onOpen(connection, localAddr, remoteAddr) {
+        t.is(localAddr, '/ibc/*/ordered');
+        t.is(remoteAddr, '/ibc/*/ordered/echo');
         const ack = await connection.send('ping');
         // log(ack);
         t.is(`${ack}`, 'ping', 'received pong');
@@ -213,8 +215,11 @@ test('loopback protocol', async t => {
   await port2.connect(
     port.getLocalAddress(),
     harden({
-      async onOpen(c, _localAddr, _remoteAddr, _connectionHandler) {
-        t.is(`${await c.send('ping')}`, 'pingack', 'expected pingack');
+      async onOpen(c, localAddr, remoteAddr, _connectionHandler) {
+        t.is(localAddr, '/loopback/bar/nonce/1');
+        t.is(remoteAddr, '/loopback/foo/nonce/2');
+        const pingack = await c.send('ping');
+        t.is(pingack, 'pingack', 'expected pingack');
         closed.resolve();
       },
     }),

--- a/packages/SwingSet/tools/prepare-test-env-ava.js
+++ b/packages/SwingSet/tools/prepare-test-env-ava.js
@@ -15,4 +15,5 @@ import './prepare-test-env';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import rawTest from 'ava';
 
+/** @type {typeof rawTest} */
 export const test = wrapTest(rawTest);

--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -75,12 +75,13 @@ scenario2-run-chain:
 scenario2-run-client: t1-provision-one-with-powers t1-start-ag-solo
 
 # Provision the ag-solo from an provisionpass-holding address (idempotent).
+AGORIC_POWERS = agoric.agoricNamesAdmin,agoric.pegasusConnections,agoric.priceAuthorityAdmin,agoric.treasuryCreator,agoric.vattp
 t1-provision-one-with-powers:
 	addr=$$(cat t1/$(BASE_PORT)/ag-cosmos-helper-address); \
 	  $(AGCH) --home=t1/bootstrap query swingset egress $$addr --chain-id=$(CHAIN_ID) || \
 	  $(AGCH) --home=t1/bootstrap tx swingset provision-one --keyring-backend=test --from=bootstrap \
 		  --gas=auto --gas-adjustment=1.2 --broadcast-mode=block --yes --chain-id=$(CHAIN_ID) \
-		  t1/$(BASE_PORT) $$addr agoric.vattp | tee /dev/stderr | grep -q '"code":0'
+		  t1/$(BASE_PORT) $$addr $(AGORIC_POWERS) | tee /dev/stderr | grep -q '"code":0'
 
 t1-provision-one:
 	addr=$$(cat t1/$(BASE_PORT)/ag-cosmos-helper-address); \

--- a/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
+++ b/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
@@ -58,10 +58,6 @@ export async function connectToFakeChain(basedir, GCI, delay, inbound) {
     noFakeCurrencies: process.env.NO_FAKE_CURRENCIES,
   };
   const stateDBdir = path.join(basedir, `fake-chain-${GCI}-state`);
-  function doOutboundBridge(dstID, _obj) {
-    // console.error('received', dstID, obj);
-    return `Bridge device (${dstID}) not implemented for fake-chain`;
-  }
   function flushChainSends(replay) {
     assert(!replay, X`Replay not implemented`);
   }
@@ -70,7 +66,7 @@ export async function connectToFakeChain(basedir, GCI, delay, inbound) {
   const s = await launch(
     stateDBdir,
     mailboxStorage,
-    doOutboundBridge,
+    undefined,
     vatsdir,
     argv,
     GCI, // debugName

--- a/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
@@ -1,8 +1,9 @@
-// @ts-nocheck
+// @ts-check
 import { allComparable } from '@agoric/same-structure';
 import {
   makeLoopbackProtocolHandler,
   makeEchoConnectionHandler,
+  makeNonceMaker,
 } from '@agoric/swingset-vat/src/vats/network';
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
@@ -55,6 +56,7 @@ export function buildRootObject(vatPowers, vatParameters) {
   // Make services that are provided on the real or virtual chain side
   async function makeChainBundler(
     vats,
+    bridgeManager,
     timerDevice,
     vatAdminSvc,
     noFakeCurrencies,
@@ -73,7 +75,7 @@ export function buildRootObject(vatPowers, vatParameters) {
       E(vats.registrar).getSharedRegistrar(),
       E(vats.board).getBoard(),
       E(vats.timer).createTimerService(timerDevice),
-      /** @type {ZoeService} */ (E(vats.zoe).buildZoe(vatAdminSvc)),
+      /** @type {ERef<ZoeService>} */ (E(vats.zoe).buildZoe(vatAdminSvc)),
       E(vats.host).makeHost(),
       E(vats.priceAuthority).makePriceAuthority(),
     ]);
@@ -85,6 +87,10 @@ export function buildRootObject(vatPowers, vatParameters) {
     const {
       nameHub: namesByAddress,
       nameAdmin: namesByAddressAdmin,
+    } = makeNameHubKit();
+    const {
+      nameHub: pegasusConnections,
+      nameAdmin: pegasusConnectionsAdmin,
     } = makeNameHubKit();
 
     async function installEconomy() {
@@ -130,14 +136,19 @@ export function buildRootObject(vatPowers, vatParameters) {
 
     // Now we can bootstrap the economy!
     const treasuryCreator = await installEconomy();
-    const [centralIssuer, centralBrand, ammInstance] = await Promise.all([
-      ...['issuer', 'brand'].map(hub =>
-        E(agoricNames).lookup(hub, CENTRAL_ISSUER_NAME),
-      ),
+    const [
+      centralIssuer,
+      centralBrand,
+      ammInstance,
+      pegasusInstance,
+    ] = await Promise.all([
+      E(agoricNames).lookup('issuer', CENTRAL_ISSUER_NAME),
+      E(agoricNames).lookup('brand', CENTRAL_ISSUER_NAME),
       E(agoricNames).lookup('instance', 'autoswap'),
+      E(agoricNames).lookup('instance', 'Pegasus'),
     ]);
 
-    // [string, import('./issuers').IssuerInitializationRecord]
+    /** @type {[string, import('./issuers').IssuerInitializationRecord]} */
     const CENTRAL_ISSUER_ENTRY = [
       CENTRAL_ISSUER_NAME,
       {
@@ -232,6 +243,7 @@ export function buildRootObject(vatPowers, vatParameters) {
           );
           const payment = E.get(payments)[0];
 
+          assert(record.issuer);
           const amount = await E(record.issuer).getAmountOf(payment);
           const proposal = harden({
             give: {
@@ -255,14 +267,13 @@ export function buildRootObject(vatPowers, vatParameters) {
         }),
       );
     }
-    // await addAllCollateral();
 
     /**
      * @param {ERef<Issuer>} issuerIn
      * @param {ERef<Issuer>} issuerOut
      * @param {ERef<Brand>} brandIn
      * @param {ERef<Brand>} brandOut
-     * @param {Array<[number, number]>} tradeList
+     * @param {Array<[bigint | number, bigint | number]>} tradeList
      */
     const makeFakePriceAuthority = (
       issuerIn,
@@ -281,7 +292,11 @@ export function buildRootObject(vatPowers, vatParameters) {
         quoteInterval: QUOTE_INTERVAL,
       });
 
-    const ammPublicFacet = E(zoe).getPublicFacet(ammInstance);
+    const [ammPublicFacet, pegasus] = await Promise.all(
+      [ammInstance, pegasusInstance].map(instance =>
+        E(zoe).getPublicFacet(instance),
+      ),
+    );
     await addAllCollateral();
 
     await Promise.all(
@@ -293,6 +308,7 @@ export function buildRootObject(vatPowers, vatParameters) {
         assert(record);
         const { tradesGivenCentral, issuer } = record;
 
+        assert(issuer);
         const brand = await E(issuer).getBrand();
         let { toCentral, fromCentral } = await E(ammPublicFacet)
           .getPriceAuthorities(brand)
@@ -322,6 +338,7 @@ export function buildRootObject(vatPowers, vatParameters) {
           console.log(
             `Making fake price authority for ${issuerName}-${CENTRAL_ISSUER_NAME}`,
           );
+          /** @type {Array<[bigint | number, bigint | number]>} */
           const tradesGivenOther = tradesGivenCentral.map(
             ([valueCentral, valueOther]) => [valueOther, valueCentral],
           );
@@ -354,6 +371,17 @@ export function buildRootObject(vatPowers, vatParameters) {
       }),
     );
 
+    // This needs to happen after creating all the services.
+    // eslint-disable-next-line no-use-before-define
+    await registerNetworkProtocols(
+      vats,
+      bridgeManager,
+      pegasus,
+      pegasusConnectionsAdmin,
+    );
+
+    /** @type {ERef<Protocol>} */
+    const network = vats.network;
     return Far('chainBundler', {
       async createUserBundle(_nickname, address, powerFlags = []) {
         // Bind to some fresh ports (unspecified name) on the IBC implementation
@@ -361,22 +389,26 @@ export function buildRootObject(vatPowers, vatParameters) {
         const ibcport = [];
         for (let i = 0; i < NUM_IBC_PORTS; i += 1) {
           // eslint-disable-next-line no-await-in-loop
-          ibcport.push(await E(vats.network).bind('/ibc-port/'));
+          const port = await E(network).bind('/ibc-port/');
+          ibcport.push(port);
         }
 
         const additionalPowers = {};
-        if (powerFlags && powerFlags.includes('agoric.vattp')) {
-          // Give the authority to create a new host for vattp to share objects with.
-          additionalPowers.vattp = makeVattpFrom(vats);
+        if (powerFlags && powerFlags.includes('agoric.agoricNamesAdmin')) {
+          additionalPowers.agoricNamesAdmin = agoricNamesAdmin;
+        }
+        if (powerFlags && powerFlags.includes('agoric.pegasusConnections')) {
+          additionalPowers.pegasusConnections = pegasusConnections;
         }
         if (powerFlags && powerFlags.includes('agoric.priceAuthorityAdmin')) {
           additionalPowers.priceAuthorityAdmin = priceAuthorityAdmin;
         }
-        if (powerFlags && powerFlags.includes('agoric.agoricNamesAdmin')) {
-          additionalPowers.agoricNamesAdmin = agoricNamesAdmin;
-        }
         if (powerFlags && powerFlags.includes('agoric.treasuryCreator')) {
           additionalPowers.treasuryCreator = treasuryCreator;
+        }
+        if (powerFlags && powerFlags.includes('agoric.vattp')) {
+          // Give the authority to create a new host for vattp to share objects with.
+          additionalPowers.vattp = makeVattpFrom(vats);
         }
 
         const mintIssuerNames = [];
@@ -450,7 +482,14 @@ export function buildRootObject(vatPowers, vatParameters) {
     });
   }
 
-  async function registerNetworkProtocols(vats, bridgeMgr) {
+  async function registerNetworkProtocols(
+    vats,
+    bridgeMgr,
+    pegasus,
+    pegasusConnectionsAdmin,
+  ) {
+    /** @type {ERef<Protocol>} */
+    const network = vats.network;
     const ps = [];
     // Every vat has a loopback device.
     ps.push(
@@ -479,20 +518,57 @@ export function buildRootObject(vatPowers, vatParameters) {
         ),
       );
     } else {
-      const loHandler = makeLoopbackProtocolHandler(E);
+      const loHandler = makeLoopbackProtocolHandler(
+        makeNonceMaker('ibc-channel/channel-'),
+      );
       ps.push(
         E(vats.network).registerProtocolHandler(['/ibc-port'], loHandler),
       );
     }
     await Promise.all(ps);
 
-    if (bridgeMgr) {
-      // Add an echo listener on our ibc-port network.
-      const port = await E(vats.network).bind('/ibc-port/echo');
+    // Add an echo listener on our ibc-port network (whether real or virtual).
+    const echoPort = await E(network).bind('/ibc-port/echo');
+    E(echoPort).addListener(
+      Far('listener', {
+        async onAccept(_port, _localAddr, _remoteAddr, _listenHandler) {
+          return harden(makeEchoConnectionHandler());
+        },
+      }),
+    );
+
+    if (pegasus) {
+      // Add the Pegasus transfer port.
+      const port = await E(network).bind('/ibc-port/pegasus');
       E(port).addListener(
         Far('listener', {
           async onAccept(_port, _localAddr, _remoteAddr, _listenHandler) {
-            return harden(makeEchoConnectionHandler());
+            const chandlerP = E(pegasus).makePegConnectionHandler();
+            const proxyMethod = name => (...args) =>
+              E(chandlerP)[name](...args);
+            const onOpen = proxyMethod('onOpen');
+            const onClose = proxyMethod('onClose');
+
+            let localAddr;
+            return Far('pegasusConnectionHandler', {
+              onOpen(c, actualLocalAddr, ...args) {
+                localAddr = actualLocalAddr;
+                if (pegasusConnectionsAdmin) {
+                  pegasusConnectionsAdmin.update(localAddr, c);
+                }
+                return onOpen(c, ...args);
+              },
+              onReceive: proxyMethod('onReceive'),
+              onClose(c, ...args) {
+                try {
+                  return onClose(c, ...args);
+                } finally {
+                  if (pegasusConnectionsAdmin) {
+                    pegasusConnectionsAdmin.delete(localAddr, c);
+                  }
+                }
+              },
+            });
           },
         }),
       );
@@ -616,19 +692,18 @@ export function buildRootObject(vatPowers, vatParameters) {
         case 'chain': {
           // provisioning vat can ask the demo server for bundles, and can
           // register client pubkeys with comms
+          const chainBundler = await makeChainBundler(
+            vats,
+            bridgeManager,
+            devices.timer,
+            vatAdminSvc,
+            noFakeCurrencies,
+          );
           await E(vats.provisioning).register(
-            await makeChainBundler(
-              vats,
-              devices.timer,
-              vatAdminSvc,
-              noFakeCurrencies,
-            ),
+            chainBundler,
             vats.comms,
             vats.vattp,
           );
-
-          // Must occur after makeChainBundler.
-          await registerNetworkProtocols(vats, bridgeManager);
           break;
         }
 
@@ -639,7 +714,7 @@ export function buildRootObject(vatPowers, vatParameters) {
           const localTimerService = await E(vats.timer).createTimerService(
             devices.timer,
           );
-          await registerNetworkProtocols(vats, bridgeManager);
+          await registerNetworkProtocols(vats, bridgeManager, null);
 
           await setupCommandDevice(vats.http, devices.command, {
             client: true,
@@ -663,6 +738,7 @@ export function buildRootObject(vatPowers, vatParameters) {
         case 'sim-chain': {
           const chainBundler = await makeChainBundler(
             vats,
+            bridgeManager,
             devices.timer,
             vatAdminSvc,
             noFakeCurrencies,
@@ -674,8 +750,6 @@ export function buildRootObject(vatPowers, vatParameters) {
             vats.comms,
             vats.vattp,
           );
-
-          await registerNetworkProtocols(vats, bridgeManager);
 
           // Allow some hardcoded client address connections into the chain.
           // This is necessary for fake-chain, which does not have Cosmos SDK
@@ -694,6 +768,7 @@ export function buildRootObject(vatPowers, vatParameters) {
                   `agoric1admin${nonce}`,
                   [
                     'agoric.agoricNamesAdmin',
+                    'agoric.pegasusConnections',
                     'agoric.priceAuthorityAdmin',
                     'agoric.treasuryCreator',
                     'agoric.vattp',

--- a/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/bootstrap.js
@@ -7,7 +7,8 @@ import {
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 import { makeStore } from '@agoric/store';
-import { installOnChain as installEconomyOnChain } from '@agoric/treasury/bundles/install-on-chain';
+import { installOnChain as installTreasuryOnChain } from '@agoric/treasury/bundles/install-on-chain';
+import { installOnChain as installPegasusOnChain } from '@agoric/pegasus/bundles/install-on-chain';
 
 // this will return { undefined } until `ag-solo set-gci-ingress`
 // has been run to update gci.js
@@ -105,16 +106,26 @@ export function buildRootObject(vatPowers, vatParameters) {
         ),
       );
 
-      // Install the economy, giving it access to the name admins we made.
-      return installEconomyOnChain({
-        agoricNames,
-        board,
-        centralName: CENTRAL_ISSUER_NAME,
-        chainTimerService,
-        nameAdmins,
-        priceAuthority,
-        zoe,
-      });
+      // Install the economy, giving the components access to the name admins we made.
+      const [treasuryCreator] = await Promise.all([
+        installTreasuryOnChain({
+          agoricNames,
+          board,
+          centralName: CENTRAL_ISSUER_NAME,
+          chainTimerService,
+          nameAdmins,
+          priceAuthority,
+          zoe,
+        }),
+        installPegasusOnChain({
+          agoricNames,
+          board,
+          nameAdmins,
+          namesByAddress,
+          zoe,
+        }),
+      ]);
+      return treasuryCreator;
     }
 
     // Now we can bootstrap the economy!

--- a/packages/cosmic-swingset/lib/ag-solo/vats/ibc.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/ibc.js
@@ -266,13 +266,7 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
       };
       return callIBCDevice('bindPort', { packet });
     },
-    async onInbound(
-      _port,
-      _listenAddr,
-      remoteAddr,
-      _lhandler,
-      _protocolHandler,
-    ) {
+    async onInstantiate(_port, _localAddr, remoteAddr, _protocolHandler) {
       // we can take advantage of the fact that remoteAddrs are unique (they
       // have their own channelID).
       return remoteAddrToLocalSuffix.get(remoteAddr);

--- a/packages/cosmic-swingset/lib/ag-solo/vats/ibc.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/ibc.js
@@ -242,6 +242,9 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
    */
   const portToPendingConns = makeStore('Port');
 
+  /** @type {Store<Endpoint, Endpoint>} */
+  const remoteAddrToLocalSuffix = makeStore();
+
   /**
    * @type {ProtocolHandler}
    */
@@ -262,6 +265,17 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
         source_port: portID,
       };
       return callIBCDevice('bindPort', { packet });
+    },
+    async onInbound(
+      _port,
+      _listenAddr,
+      remoteAddr,
+      _lhandler,
+      _protocolHandler,
+    ) {
+      // we can take advantage of the fact that remoteAddrs are unique (they
+      // have their own channelID).
+      return remoteAddrToLocalSuffix.get(remoteAddr);
     },
     async onConnect(port, localAddr, remoteAddr, chandler, _protocolHandler) {
       console.debug('IBC onConnect', localAddr, remoteAddr);
@@ -451,11 +465,18 @@ EOF
           const ibcHops = hops.map(hop => `/ibc-hop/${hop}`).join('/');
           const remoteAddr = `${ibcHops}/ibc-port/${rPortID}/${order.toLowerCase()}/${rVersion}/ibc-channel/${rChannelID}`;
 
-          // See if we allow an inbound attempt for this address pair (without rejecting).
+          // See if we allow an inbound attempt for this address pair (without
+          // rejecting).
+          remoteAddrToLocalSuffix.init(remoteAddr, `ibc-channel/${channelID}`);
           const attemptP = E(protocolImpl).inbound(localAddr, remoteAddr);
 
           // Tell what version string we negotiated.
-          const attemptedLocal = await E(attemptP).getLocalAddress();
+          const attemptedLocal = await E(attemptP)
+            .getLocalAddress()
+            .finally(() => {
+              // No matter what, delete the temporary mapping.
+              remoteAddrToLocalSuffix.delete(remoteAddr);
+            });
           const match = attemptedLocal.match(
             // Match:  ... /ORDER/VERSION ...
             new RegExp('^(/[^/]+/[^/]+)*/(ordered|unordered)/([^/]+)(/|$)'),

--- a/packages/cosmic-swingset/lib/ag-solo/vats/types.js
+++ b/packages/cosmic-swingset/lib/ag-solo/vats/types.js
@@ -10,20 +10,26 @@
 
 /**
  * @typedef {Object} NameHub
- * @property {(...path: Array<unknown>) => Promise<unknown>} lookup Look up a
+ * @property {(...path: Array<string>) => Promise<any>} lookup Look up a
  * path of keys starting from the current NameHub.  Wait on any reserved
  * promises.
+ * @property {() => Array<[string, unknown]>} entries get all the entries
+ * available in the current NameHub
+ * @property {() => Array<string>} keys get all names available in the current
+ * NameHub
+ * @property {() => Array<unknown>} values get all values available in the
+ * current NameHub
  */
 
 /**
  * @typedef {Object} NameAdmin
- * @property {(key: unknown) => void} reserve Mark a key as reserved; will
+ * @property {(key: string) => void} reserve Mark a key as reserved; will
  * return a promise that is fulfilled when the key is updated (or rejected when
  * deleted).
- * @property {(key: unknown, newValue: unknown) => void} update Fulfill an
+ * @property {(key: string, newValue: unknown) => void} update Fulfill an
  * outstanding reserved promise (if any) to the newValue and set the key to the
  * newValue.
- * @property {(key: unknown) => void} delete Delete a value and reject an
+ * @property {(key: string) => void} delete Delete a value and reject an
  * outstanding reserved promise (if any).
  */
 

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -38,6 +38,7 @@
     "@agoric/marshal": "^0.4.3",
     "@agoric/nat": "^4.0.0",
     "@agoric/notifier": "^0.3.6",
+    "@agoric/pegasus": "^0.1.0",
     "@agoric/promise-kit": "^0.2.6",
     "@agoric/registrar": "^0.2.6",
     "@agoric/same-structure": "^0.1.6",

--- a/packages/cosmic-swingset/test/unitTests/test-name-hub.js
+++ b/packages/cosmic-swingset/test/unitTests/test-name-hub.js
@@ -7,12 +7,32 @@ test('makeNameHubKit - lookup paths', async t => {
   const { nameAdmin: na2, nameHub: nh2 } = makeNameHubKit();
   const { nameAdmin: na3, nameHub: nh3 } = makeNameHubKit();
 
+  t.deepEqual(nh1.keys(), []);
+  t.deepEqual(nh1.values(), []);
+  t.deepEqual(nh1.entries(), []);
+  t.deepEqual(nh2.keys(), []);
+  t.deepEqual(nh2.values(), []);
+  t.deepEqual(nh2.entries(), []);
+  t.deepEqual(nh3.keys(), []);
+  t.deepEqual(nh3.values(), []);
+  t.deepEqual(nh3.entries(), []);
+
   na1.update('path1', nh2);
   t.is(await nh1.lookup('path1'), nh2);
   na2.update('path2', nh3);
   t.is(await nh2.lookup('path2'), nh3);
   na3.update('path3', 'finish');
   t.is(await nh3.lookup('path3'), 'finish');
+
+  t.deepEqual(nh1.keys(), ['path1']);
+  t.deepEqual(nh1.values(), [nh2]);
+  t.deepEqual(nh1.entries(), [['path1', nh2]]);
+  t.deepEqual(nh2.keys(), ['path2']);
+  t.deepEqual(nh2.values(), [nh3]);
+  t.deepEqual(nh2.entries(), [['path2', nh3]]);
+  t.deepEqual(nh3.keys(), ['path3']);
+  t.deepEqual(nh3.values(), ['finish']);
+  t.deepEqual(nh3.entries(), [['path3', 'finish']]);
 
   t.is(await nh1.lookup(), nh1);
   t.is(await nh1.lookup('path1'), nh2);
@@ -30,6 +50,10 @@ test('makeNameHubKit - reserve and update', async t => {
     message: /"nameKey" not found: .*/,
   });
 
+  t.deepEqual(nameHub.keys(), []);
+  t.deepEqual(nameHub.values(), []);
+  t.deepEqual(nameHub.entries(), []);
+
   // Try reserving and looking up.
   nameAdmin.reserve('hello');
 
@@ -37,9 +61,16 @@ test('makeNameHubKit - reserve and update', async t => {
   const lookupHelloP = nameHub
     .lookup('hello')
     .finally(() => (lookedUpHello = true));
+  t.deepEqual(nameHub.keys(), ['hello']);
+  const helloP = nameHub.values()[0];
+  t.assert(helloP instanceof Promise);
+  t.deepEqual(nameHub.entries(), [['hello', helloP]]);
 
   t.falsy(lookedUpHello);
   nameAdmin.update('hello', 'foo');
+  t.deepEqual(nameHub.keys(), ['hello']);
+  t.deepEqual(nameHub.values(), ['foo']);
+  t.deepEqual(nameHub.entries(), [['hello', 'foo']]);
   t.is(await lookupHelloP, 'foo');
   t.truthy(lookedUpHello);
 
@@ -54,6 +85,10 @@ test('makeNameHubKit - reserve and delete', async t => {
     message: /"nameKey" not found: .*/,
   });
 
+  t.deepEqual(nameHub.keys(), []);
+  t.deepEqual(nameHub.values(), []);
+  t.deepEqual(nameHub.entries(), []);
+
   nameAdmin.reserve('goodbye');
   let lookedUpGoodbye = false;
   const lookupGoodbyeP = nameHub
@@ -61,7 +96,15 @@ test('makeNameHubKit - reserve and delete', async t => {
     .finally(() => (lookedUpGoodbye = true));
 
   t.falsy(lookedUpGoodbye);
+  t.deepEqual(nameHub.keys(), ['goodbye']);
+  const goodbyeP = nameHub.values()[0];
+  t.assert(goodbyeP instanceof Promise);
+  t.deepEqual(nameHub.entries(), [['goodbye', goodbyeP]]);
+
   nameAdmin.delete('goodbye');
+  t.deepEqual(nameHub.keys(), []);
+  t.deepEqual(nameHub.values(), []);
+  t.deepEqual(nameHub.entries(), []);
   await t.throwsAsync(lookupGoodbyeP, {
     message: /"nameKey" not found: .*/,
   });

--- a/packages/dapp-svelte-wallet/api/src/pubsub.js
+++ b/packages/dapp-svelte-wallet/api/src/pubsub.js
@@ -1,4 +1,4 @@
-export default function(E) {
+export default function makePubsub(E) {
   let lastPublished;
   const subscribers = [];
 

--- a/packages/pegasus/bundles/install-on-chain.js
+++ b/packages/pegasus/bundles/install-on-chain.js
@@ -1,0 +1,76 @@
+// @ts-check
+import { E } from '@agoric/eventual-send';
+
+import pegasusBundle from './bundle-pegasus';
+
+/**
+ * @param {Object} param0
+ * @param {ERef<NameHub>} param0.agoricNames
+ * @param {ERef<Board>} param0.board
+ * @param {Store<NameHub, NameAdmin>} param0.nameAdmins
+ * @param {NameHub} param0.namesByAddress
+ * @param {ERef<ZoeService>} param0.zoe
+ */
+export async function installOnChain({ agoricNames, board, nameAdmins, namesByAddress, zoe }) {
+  // Fetch the nameAdmins we need.
+  const [installAdmin, instanceAdmin, uiConfigAdmin] = await Promise.all(
+    ['installation', 'instance', 'uiConfig'].map(async edge => {
+      const hub = /** @type {NameHub} */ (await E(agoricNames).lookup(edge));
+      return nameAdmins.get(hub);
+    }),
+  );
+
+  /** @type {Array<[string, SourceBundle]>} */
+  const nameBundles = [['pegasus', pegasusBundle]];
+  const [pegasusInstall] = await Promise.all(
+    nameBundles.map(async ([name, bundle]) => {
+      // Install the bundle in Zoe.
+      const install = await E(zoe).install(bundle);
+      // Advertise the installation in agoricNames.
+      await E(installAdmin).update(name, install);
+      // Return for variable assignment.
+      return install;
+    }),
+  );
+
+  const terms = harden({
+    board,
+    namesByAddress,
+  });
+
+  const { instance, creatorFacet } = await E(zoe).startInstance(pegasusInstall, undefined, terms);
+ 
+  const pegasusUiDefaults = {
+    CONTRACT_NAME: 'Pegasus',
+    BRIDGE_URL: 'http://127.0.0.1:8000',
+    // Avoid setting API_URL, so that the UI uses the same origin it came from,
+    // if it has an api server.
+    // API_URL: 'http://127.0.0.1:8000',
+  };
+
+  // Look up all the board IDs.
+  const boardIdValue = [
+    ['INSTANCE_BOARD_ID', instance],
+  ];
+  await Promise.all(boardIdValue.map(async ([key, valP]) => {
+    const val = await valP;
+    const boardId = await E(board).getId(val);
+    pegasusUiDefaults[key] = boardId;
+  }));
+
+  // Stash the defaults where the UI can find them.
+  harden(pegasusUiDefaults);
+
+  // Install the names in agoricNames.
+  /** @type {Array<[NameAdmin, string, unknown]>} */
+  const nameAdminUpdates = [
+    [uiConfigAdmin, pegasusUiDefaults.CONTRACT_NAME, pegasusUiDefaults],
+    [installAdmin, pegasusUiDefaults.CONTRACT_NAME, pegasusInstall],
+    [instanceAdmin, pegasusUiDefaults.CONTRACT_NAME, instance],
+  ];
+  await Promise.all(
+    nameAdminUpdates.map(([nameAdmin, name, value]) => E(nameAdmin).update(name, value)),
+  );
+
+  return creatorFacet;
+}

--- a/packages/pegasus/exported.js
+++ b/packages/pegasus/exported.js
@@ -1,0 +1,5 @@
+import './src/types';
+import '@agoric/notifier/exported';
+import '@agoric/ertp/exported';
+import '@agoric/store/exported';
+import '@agoric/swingset-vat/exported';

--- a/packages/pegasus/globals.d.ts
+++ b/packages/pegasus/globals.d.ts
@@ -1,0 +1,2 @@
+declare var makeKind: function;
+declare var makeWeakStore: function;

--- a/packages/pegasus/jsconfig.json
+++ b/packages/pegasus/jsconfig.json
@@ -1,0 +1,18 @@
+// This file can contain .js-specific Typescript compiler config.
+{
+  "compilerOptions": {
+    "target": "esnext",
+
+    "noEmit": true,
+/*
+    // The following flags are for creating .d.ts files:
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+*/
+    "downlevelIteration": true,
+    "strictNullChecks": true,
+    "moduleResolution": "node",
+  },
+  "include": ["src/**/*.js", "exported.js", "globals.d.ts"],
+}

--- a/packages/pegasus/package.json
+++ b/packages/pegasus/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agoric/treasury",
+  "name": "@agoric/pegasus",
   "version": "0.2.1",
   "description": "Core cryptoeconomy contracts",
   "parsers": {
@@ -34,6 +34,7 @@
   "dependencies": {
     "@agoric/assert": "^0.2.6",
     "@agoric/bundle-source": "^1.3.1",
+    "@agoric/cosmic-swingset": "^0.28.1",
     "@agoric/captp": "^1.7.6",
     "@agoric/deploy-script-support": "^0.2.1",
     "@agoric/ertp": "^0.10.3",

--- a/packages/pegasus/package.json
+++ b/packages/pegasus/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@agoric/pegasus",
-  "version": "0.2.1",
-  "description": "Core cryptoeconomy contracts",
+  "version": "0.1.0",
+  "description": "Peg-as-us contract",
   "parsers": {
     "js": "mjs"
   },
-  "main": "src/stablecoinMachine.js",
+  "main": "src/pegasus.js",
   "engines": {
     "node": ">=11.0"
   },

--- a/packages/pegasus/scripts/build-bundles.js
+++ b/packages/pegasus/scripts/build-bundles.js
@@ -1,0 +1,41 @@
+/* global __dirname require */
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import 'ses';
+import fs from 'fs';
+import process from 'process';
+import bundleSource from '@agoric/bundle-source';
+
+const srcDir = `${__dirname}/../src`;
+const bundlesDir = `${__dirname}/../bundles`;
+
+async function writeSourceBundle(contractFilename, outputPath) {
+  const path = require.resolve(contractFilename);
+  await bundleSource(path).then(bundle => {
+    // TODO: fix
+    // @ts-ignore mkdirSync believes it only accepts 2 arguments.
+    fs.mkdirSync(bundlesDir, { recursive: true }, err => {
+      if (err) throw err;
+    });
+    fs.writeFileSync(outputPath, `export default ${JSON.stringify(bundle)};`);
+  });
+}
+
+async function main() {
+  const contractOutputs = [
+    [`${srcDir}/pegasus.js`, `${bundlesDir}/bundle-pegasus.js`],
+  ];
+  for (const [contractFilename, outputPath] of contractOutputs) {
+    // eslint-disable-next-line no-await-in-loop
+    await writeSourceBundle(contractFilename, outputPath);
+  }
+}
+
+main().then(
+  _ => process.exit(0),
+  err => {
+    console.log('error creating contract bundles:');
+    console.log(err);
+    process.exit(1);
+  },
+);

--- a/packages/pegasus/src/pegasus.js
+++ b/packages/pegasus/src/pegasus.js
@@ -1,0 +1,616 @@
+// @ts-check
+
+import { assert, details, q } from '@agoric/assert';
+import { makeNotifierKit } from '@agoric/notifier';
+import { makeStore, makeWeakStore } from '@agoric/store';
+import { E } from '@agoric/eventual-send';
+import { Nat } from '@agoric/nat';
+import { parse as parseMultiaddr } from '@agoric/swingset-vat/src/vats/network/multiaddr';
+import { assertProposalShape } from '@agoric/zoe/src/contractSupport';
+
+import '@agoric/notifier/exported';
+import '@agoric/cosmic-swingset/exported';
+import '@agoric/swingset-vat/src/vats/network/types';
+import '@agoric/zoe/exported';
+import '../exported';
+
+const DEFAULT_AMOUNT_MATH_KIND = 'nat';
+const DEFAULT_PROTOCOL = 'ics20-1';
+
+const TRANSFER_PROPOSAL_SHAPE = {
+  give: {
+    Transfer: null,
+  },
+};
+
+/**
+ * Get the denomination combined with the network address.
+ *
+ * @param {ERef<Endpoint>} endpointP network connection address
+ * @param {Denom} denom denomination
+ * @param {TransferProtocol} [protocol=DEFAULT_PROTOCOL] the protocol to use
+ * @returns {Promise<string>} denomination URI scoped to endpoint
+ */
+async function makeDenomUri(endpointP, denom, protocol = DEFAULT_PROTOCOL) {
+  switch (protocol) {
+    case 'ics20-1': {
+      return E.when(endpointP, endpoint => {
+        // Deconstruct IBC endpoints to use ICS-20 conventions.
+        // IBC endpoint: `/ibc-hop/gaia/ibc-port/transfer/ordered/ics20-1/ibc-channel/chtedite`
+        const pairs = parseMultiaddr(endpoint);
+
+        const protoPort = pairs.find(([proto]) => proto === 'ibc-port');
+        assert(protoPort, details`Cannot find IBC port in ${endpoint}`);
+
+        // FIXME: We really should get this from the actual endpoint.
+        const FIXME_FAKE_CHANNEL = ['ibc-channel', 'transfer'];
+        const protoChannel =
+          pairs.find(([proto]) => proto === 'ibc-channel') ||
+          FIXME_FAKE_CHANNEL;
+        assert(protoChannel, details`Cannot find IBC channel in ${endpoint}`);
+
+        const port = protoPort[1];
+        const channel = protoChannel[1];
+        return `${protocol}:${port}/${channel}/${denom}`;
+      });
+    }
+
+    default:
+      throw assert.fail(details`Invalid denomination protocol ${protocol}`);
+  }
+}
+
+/**
+ * Translate to and from local tokens.
+ *
+ * @param {Brand} localBrand
+ * @param {string} prefixedDenom
+ */
+function makeICS20Converter(localBrand, prefixedDenom) {
+  /**
+   * Convert an inbound packet to a local amount.
+   *
+   * @param {FungibleTransferPacket} packet
+   * @returns {Amount}
+   */
+  function packetToLocalAmount(packet) {
+    // packet.amount is a string in JSON.
+    const bigValue = BigInt(packet.amount);
+
+    // If we overflow, or don't have a non-negative integer, throw an exception!
+    const value = Nat(bigValue);
+
+    return harden({
+      brand: localBrand,
+      value,
+    });
+  }
+
+  /**
+   * Convert the amount to a packet to send.
+   *
+   * @param {Amount} amount
+   * @param {DepositAddress} depositAddress
+   * @returns {FungibleTransferPacket}
+   */
+  function localAmountToPacket(amount, depositAddress) {
+    const { brand, value } = amount;
+    assert(
+      brand === localBrand,
+      details`Brand must our local issuer's, not ${q(brand)}`,
+    );
+    // We're using Nat as a dynamic check in a way that tsc doesn't grok.
+    // Should Nat's parameter type be `unknown`?
+    // @ts-ignore
+    const stringValue = String(Nat(value));
+
+    // Generate the ics20-1 packet.
+    return harden({
+      amount: stringValue,
+      denomination: prefixedDenom,
+      receiver: depositAddress,
+    });
+  }
+
+  return { localAmountToPacket, packetToLocalAmount };
+}
+
+/**
+ * Send the transfer packet and return a status.
+ *
+ * @param {Connection} c
+ * @param {FungibleTransferPacket} packet
+ * @returns {Promise<void>}
+ */
+const sendTransferPacket = async (c, packet) => {
+  const packetBytes = JSON.stringify(packet);
+  return E(c)
+    .send(packetBytes)
+    .then(ack => {
+      // We got a response, so possible success.
+      const { success, error } = JSON.parse(ack);
+      if (!success) {
+        // Let the next catch handle this error.
+        throw error;
+      }
+    });
+};
+
+/**
+ * Create the [send, receive] pair.
+ *
+ * @typedef {Object} CourierArgs
+ * @property {ContractFacet} zcf
+ * @property {Connection} connection
+ * @property {BoardDepositFacet} board
+ * @property {NameHub} namesByAddress
+ * @property {DenomUri} denomUri
+ * @property {Brand} localBrand
+ * @property {(zcfSeat: ZCFSeat, amounts: AmountKeywordRecord) => void} retain
+ * @property {(zcfSeat: ZCFSeat, amounts: AmountKeywordRecord) => void} redeem
+ * @param {CourierArgs} arg0
+ * @returns {Courier}
+ */
+const makeCourier = ({
+  zcf,
+  connection,
+  board,
+  namesByAddress,
+  denomUri,
+  localBrand,
+  retain,
+  redeem,
+}) => {
+  const uriMatch = denomUri.match(/^[^:]+:(.*)$/);
+  assert(uriMatch, details`denomUri ${q(denomUri)} does not look like a URI`);
+  const prefixedDenom = uriMatch[1];
+
+  const { localAmountToPacket, packetToLocalAmount } = makeICS20Converter(
+    localBrand,
+    prefixedDenom,
+  );
+
+  /** @type {Sender} */
+  const send = async (zcfSeat, depositAddress) => {
+    const tryToSend = async () => {
+      const amount = zcfSeat.getAmountAllocated('Transfer', localBrand);
+      const packet = localAmountToPacket(amount, depositAddress);
+
+      // Retain the payment.  We must not proceed on failure.
+      retain(zcfSeat, { Transfer: amount });
+
+      // The payment is already escrowed, and proposed to retain, so try sending.
+      return sendTransferPacket(connection, packet).then(
+        _ => zcfSeat.exit(),
+        reason => {
+          // Return the payment to the seat, if possible.
+          redeem(zcfSeat, { Transfer: amount });
+          throw reason;
+        },
+      );
+    };
+
+    // Reflect any error back to the seat.
+    return tryToSend().catch(reason => {
+      zcfSeat.kickOut(reason);
+    });
+  };
+
+  /** @type {Receiver} */
+  const receive = async packet => {
+    // Look up the deposit facet for this board address, if there is one.
+    const depositAddress = packet.receiver;
+    /** @type {DepositFacet} */
+    const depositFacet = await E(board)
+      .getValue(depositAddress)
+      .catch(_ => E(namesByAddress).lookup(depositAddress, 'depositFacet'));
+    const localAmount = packetToLocalAmount(packet);
+
+    const { userSeat, zcfSeat } = zcf.makeEmptySeatKit();
+
+    // Redeem the backing payment.
+    try {
+      redeem(zcfSeat, { Transfer: localAmount });
+      zcfSeat.exit();
+    } catch (e) {
+      zcfSeat.kickOut(e);
+      throw e;
+    }
+
+    // Once we've gotten to this point, their payment is committed and
+    // won't be refunded on a failed receive.
+    const payout = await E(userSeat).getPayout('Transfer');
+
+    // Send the payout promise to the deposit facet.
+    E(depositFacet)
+      .receive(payout)
+      .catch(_ => {});
+
+    // We don't want to wait for the depositFacet to return, so that
+    // it can't hang up (i.e. DoS) an ordered channel, which relies on
+    // us returning promptly.
+    return undefined;
+  };
+
+  return { send, receive };
+};
+
+/**
+ * Make a Pegasus public API.
+ *
+ * @param {ContractFacet} zcf the Zoe Contract Facet
+ * @param {BoardDepositFacet} board where to find depositFacets by boardID
+ * @param {NameHub} namesByAddress where to find depositFacets by bech32
+ */
+const makePegasus = (zcf, board, namesByAddress) => {
+  /** @type {NotifierRecord<Peg[]>} */
+  const { notifier, updater } = makeNotifierKit([]);
+
+  /**
+   * @typedef {Object} LocalDenomState
+   * @property {Store<DenomUri, Courier>} denomUriToCourier
+   * @property {Set<Peg>} pegs
+   * @property {number} lastDenomNonce
+   */
+
+  /**
+   * @type {WeakStore<Connection, LocalDenomState>}
+   */
+  const connectionToLocalDenomState = makeWeakStore('Connection');
+
+  let lastLocalIssuerNonce = 0;
+  /**
+   * Create a new issuer keyword (based on Local + nonce)
+   *
+   * @returns {string}
+   */
+  const createLocalIssuerKeyword = () => {
+    lastLocalIssuerNonce += 1;
+    return `Local${lastLocalIssuerNonce}`;
+  };
+
+  /**
+   * @type {Store<Peg, Connection>}
+   */
+  const pegToConnection = makeStore('Peg');
+
+  /**
+   * Create a fresh Peg associated with a descriptor.
+   *
+   * @typedef {Object} PegDescriptor
+   * @property {Brand} localBrand
+   * @property {DenomUri} denomUri
+   * @property {string} allegedName
+   *
+   * @param {Connection} c
+   * @param {PegDescriptor} desc
+   * @param {Set<Peg>} pegs
+   * @returns {Peg}
+   */
+  const makePeg = (c, desc, pegs) => {
+    /** @type {Peg} */
+    const peg = harden({
+      getAllegedName() {
+        return desc.allegedName;
+      },
+      getLocalBrand() {
+        return desc.localBrand;
+      },
+      getDenomUri() {
+        return desc.denomUri;
+      },
+    });
+
+    pegs.add(peg);
+    pegToConnection.init(peg, c);
+    updater.updateState([...pegToConnection.keys()]);
+    return peg;
+  };
+
+  return harden({
+    makeDenomUri,
+    /**
+     * Return a handler that can be used with the Network API.
+     *
+     * @returns {ConnectionHandler}
+     */
+    makePegConnectionHandler() {
+      /**
+       * @type {Store<DenomUri, Courier>}
+       */
+      const denomUriToCourier = makeStore('Denomination');
+      /**
+       * @type {Set<Peg>}
+       */
+      const pegs = new Set();
+      return {
+        async onOpen(c) {
+          // Register C with the table of Peg receivers.
+          connectionToLocalDenomState.init(c, {
+            denomUriToCourier,
+            pegs,
+            lastDenomNonce: 0,
+          });
+        },
+        async onReceive(c, packetBytes) {
+          // Dispatch the packet to the appropriate Peg for this connection.
+          /**
+           * @type {FungibleTransferPacket}
+           */
+          const packet = JSON.parse(packetBytes);
+          const denomUri = `ics20-1:${packet.denomination}`;
+          const { receive } = denomUriToCourier.get(denomUri);
+          return receive(packet)
+            .then(_ => {
+              const ack = { success: true };
+              return JSON.stringify(ack);
+            })
+            .catch(error => {
+              // On failure, just return the stringified error.
+              const nack = { success: false, error: `${error}` };
+              return JSON.stringify(nack);
+            });
+        },
+        async onClose(c) {
+          // Unregister C.  Pending transfers will be rejected by the Network API.
+          connectionToLocalDenomState.delete(c);
+          for (const peg of pegs.keys()) {
+            pegToConnection.delete(peg);
+          }
+          updater.updateState([...pegToConnection.keys()]);
+        },
+      };
+    },
+    /**
+     * Peg a remote asset over a network connection.
+     *
+     * @param {string} allegedName
+     * @param {ERef<Connection>} connectionP The network connection (such as IBC
+     * channel) to communicate over
+     * @param {Denom} remoteDenom Remote denomination
+     * @param {string} [amountMathKind=DEFAULT_AMOUNT_MATH_KIND] The kind of
+     * amount math for the pegged values
+     * @param {TransferProtocol} [protocol=DEFAULT_PROTOCOL]
+     * @returns {Promise<Peg>}
+     */
+    async pegRemote(
+      allegedName,
+      connectionP,
+      remoteDenom,
+      amountMathKind = DEFAULT_AMOUNT_MATH_KIND,
+      protocol = DEFAULT_PROTOCOL,
+    ) {
+      // Assertions
+      assert(
+        // TODO: Find the exact restrictions on Cosmos denoms.
+        remoteDenom.match(/^[a-z][a-z0-9]*$/),
+        details`Invalid ics20-1 remoteDenom ${q(
+          remoteDenom,
+        )}; need Cosmos denomination format`,
+      );
+      assert(
+        amountMathKind === 'nat',
+        details`Unimplemented amountMathKind ${q(amountMathKind)}; need "nat"`,
+      );
+      assert(
+        protocol === 'ics20-1',
+        details`Unimplemented protocol ${q(protocol)}; need "ics20-1"`,
+      );
+
+      const c = await connectionP;
+      assert(
+        connectionToLocalDenomState.has(c),
+        details`The connection must use .createPegConnectionHandler()`,
+      );
+
+      // Find our data elements.
+      const allegedLocalAddress = await E(c).getLocalAddress();
+      const denomUri = await makeDenomUri(
+        allegedLocalAddress,
+        remoteDenom,
+        protocol,
+      );
+
+      // Create the issuer for the local erights corresponding to the remote values.
+      const localKeyword = createLocalIssuerKeyword();
+      const zcfMint = await zcf.makeZCFMint(localKeyword, amountMathKind);
+      const { brand: localBrand } = zcfMint.getIssuerRecord();
+
+      // Describe how to retain/redeem pegged shadow erights.
+      const courier = makeCourier({
+        zcf,
+        connection: c,
+        localBrand,
+        board,
+        namesByAddress,
+        denomUri,
+        retain: (zcfSeat, amounts) => zcfMint.burnLosses(amounts, zcfSeat),
+        redeem: (zcfSeat, amounts) => {
+          zcfMint.mintGains(amounts, zcfSeat);
+        },
+      });
+
+      const { denomUriToCourier, pegs } = connectionToLocalDenomState.get(c);
+      denomUriToCourier.init(denomUri, courier);
+
+      return makePeg(c, { localBrand, denomUri, allegedName }, pegs);
+    },
+
+    /**
+     * Peg a local asset over a network connection.
+     *
+     * @param {string} allegedName
+     * @param {ERef<Connection>} connectionP The network connection (such as IBC
+     * channel) to communicate over
+     * @param {Issuer} localIssuer Local ERTP issuer whose assets should be
+     * pegged to the connection
+     * @param {TransferProtocol} [protocol=DEFAULT_PROTOCOL] Protocol to speak
+     * on the connection
+     * @returns {Promise<Peg>}
+     */
+    async pegLocal(
+      allegedName,
+      connectionP,
+      localIssuer,
+      protocol = DEFAULT_PROTOCOL,
+    ) {
+      // Assertions
+      assert(
+        protocol === 'ics20-1',
+        details`Unimplemented protocol ${q(protocol)}; need "ics20-1"`,
+      );
+
+      const c = await connectionP;
+      assert(
+        connectionToLocalDenomState.has(c),
+        details`The connection must use .createPegConnectionHandler()`,
+      );
+
+      // We need the last nonce for our denom name.
+      const localDenomState = connectionToLocalDenomState.get(c);
+      localDenomState.lastDenomNonce += 1;
+      const denom = `pegasus${localDenomState.lastDenomNonce}`;
+
+      // Find our data elements.
+      const allegedLocalAddress = await E(c).getLocalAddress();
+      const denomUri = await makeDenomUri(allegedLocalAddress, denom, protocol);
+
+      // Create a seat in which to keep our denomination.
+      const { zcfSeat: poolSeat } = zcf.makeEmptySeatKit();
+
+      // Ensure the issuer can be used in Zoe offers.
+      const localKeyword = createLocalIssuerKeyword();
+      const {
+        brand: localBrand,
+        amountMath: localAmountMath,
+      } = await zcf.saveIssuer(localIssuer, localKeyword);
+
+      /**
+       * Transfer amount (of localBrand and localAmountMath) from loser to winner seats.
+       *
+       * @param {Amount} amount amount to transfer
+       * @param {Keyword} loserKeyword the keyword to take from the loser
+       * @param {ZCFSeat} loser seat to transfer from
+       * @param {Keyword} winnerKeyword the keyword to give to the winner
+       * @param {ZCFSeat} winner seat to transfer to
+       */
+      const transferAmountFrom = (
+        amount,
+        loserKeyword,
+        loser,
+        winnerKeyword,
+        winner,
+      ) => {
+        // Transfer the amount to our backing seat.
+        const currentLoser = loser.getAmountAllocated(loserKeyword, localBrand);
+        const currentWinner = winner.getAmountAllocated(
+          winnerKeyword,
+          localBrand,
+        );
+        const newLoser = localAmountMath.subtract(currentLoser, amount);
+        const newWinner = localAmountMath.add(currentWinner, amount);
+        const loserStage = loser.stage({ [loserKeyword]: newLoser });
+        const winnerStage = winner.stage({ [winnerKeyword]: newWinner });
+        zcf.reallocate(loserStage, winnerStage);
+      };
+
+      // Describe how to retain/redeem real local erights.
+      const courier = makeCourier({
+        zcf,
+        connection: c,
+        board,
+        namesByAddress,
+        denomUri,
+        localBrand,
+        retain: (transferSeat, amounts) =>
+          transferAmountFrom(
+            amounts.Transfer,
+            'Transfer',
+            transferSeat,
+            'Pool',
+            poolSeat,
+          ),
+        redeem: (transferSeat, amounts) =>
+          transferAmountFrom(
+            amounts.Transfer,
+            'Pool',
+            poolSeat,
+            'Transfer',
+            transferSeat,
+          ),
+      });
+
+      const { denomUriToCourier, pegs } = localDenomState;
+      denomUriToCourier.init(denomUri, courier);
+
+      return makePeg(c, { localBrand, denomUri, allegedName }, pegs);
+    },
+
+    /**
+     * Find one of our registered issuers.
+     *
+     * @param {Brand} localBrand
+     * @returns {Promise<Issuer>}
+     */
+    async getLocalIssuer(localBrand) {
+      return zcf.getIssuerForBrand(localBrand);
+    },
+
+    /**
+     * Get all the created pegs.
+     */
+    async getNotifier() {
+      return notifier;
+    },
+
+    /**
+     * Create a Zoe invitation to transfer assets over network to a deposit address.
+     *
+     * @param {ERef<Peg>} pegP the peg over which to transfer
+     * @param {DepositAddress} depositAddress the remote receiver's address
+     * @returns {Promise<Invitation>} to transfer, make an offer of { give: { Transfer: pegAmount } } to this invitation
+     */
+    async makeInvitationToTransfer(pegP, depositAddress) {
+      // Verify the peg.
+      const peg = await pegP;
+      const c = pegToConnection.get(peg);
+
+      // Get details from the peg.
+      const denomUri = await E(peg).getDenomUri();
+      const { denomUriToCourier } = connectionToLocalDenomState.get(c);
+      const { send } = denomUriToCourier.get(denomUri);
+
+      /**
+       * Attempt the transfer, returning a refund if failed.
+       *
+       * @type {OfferHandler}
+       */
+      const offerHandler = zcfSeat => {
+        assertProposalShape(zcfSeat, TRANSFER_PROPOSAL_SHAPE);
+        send(zcfSeat, depositAddress);
+      };
+
+      return zcf.makeInvitation(offerHandler, 'pegasus transfer');
+    },
+  });
+};
+
+/**
+ * @typedef {ReturnType<typeof makePegasus>} Pegasus
+ */
+
+/**
+ * @type {ContractStartFn}
+ */
+const start = zcf => {
+  const { board, namesByAddress } = zcf.getTerms();
+
+  return {
+    publicFacet: makePegasus(zcf, board, namesByAddress),
+  };
+};
+
+harden(makeDenomUri);
+harden(start);
+harden(makePegasus);
+export { start, makePegasus, makeDenomUri };

--- a/packages/pegasus/src/types.js
+++ b/packages/pegasus/src/types.js
@@ -1,0 +1,36 @@
+// eslint-disable-next-line spaced-comment
+/// <reference types="ses"/>
+
+/**
+ * @typedef {string} DenomUri
+ * @typedef {string} Denom
+ * @typedef {string} DepositAddress
+ * @typedef {string} TransferProtocol
+ *
+ * @typedef {Object} Peg
+ * @property {() => string} getAllegedName get the debug name
+ * @property {() => Brand} getLocalBrand get the brand associated with the peg
+ * @property {() => DenomUri} getDenomUri get the denomination identifier
+ */
+
+/**
+ * @typedef {Object} BoardDepositFacet a registry for depositAddresses
+ * @property {(id: string) => any} getValue return the corresponding DepositFacet
+ */
+
+/**
+ * @typedef {Object} FungibleTransferPacket
+ * @property {string} amount The extent of the amount
+ * @property {Denom} denomination The denomination of the amount
+ * @property {string} [sender] The sender address
+ * @property {DepositAddress} receiver The receiver deposit address
+ */
+
+/**
+ * @typedef {(zcfSeat: ZCFSeat, depositAddress: DepositAddress) => Promise<void>} Sender
+ * Successive transfers are not guaranteed to be processed in the order in which they were sent.
+ * @typedef {(packet: FungibleTransferPacket) => Promise<void>} Receiver
+ * @typedef {Object} Courier
+ * @property {Sender} send
+ * @property {Receiver} receive
+ */

--- a/packages/pegasus/test/fakeVatAdmin.js
+++ b/packages/pegasus/test/fakeVatAdmin.js
@@ -1,0 +1,22 @@
+import { E } from '@agoric/eventual-send';
+import { makePromiseKit } from '@agoric/promise-kit';
+
+import { evalContractBundle } from '@agoric/zoe/src/contractFacet/evalContractCode';
+
+export default harden({
+  createVat: bundle => {
+    return harden({
+      root: E(evalContractBundle(bundle)).buildRootObject(),
+      adminNode: {
+        done: () => {
+          return makePromiseKit().promise;
+        },
+        terminate: () => {},
+        adminData: () => ({}),
+      },
+    });
+  },
+  createVatByName: _name => {
+    throw Error(`createVatByName not supported in fake mode`);
+  },
+});

--- a/packages/pegasus/test/test-peg.js
+++ b/packages/pegasus/test/test-peg.js
@@ -59,7 +59,7 @@ async function testRemotePeg(t) {
    * @type {import('../src/pegasus').Pegasus}
    */
   const pegasus = publicAPI;
-  const network = makeNetworkProtocol(makeLoopbackProtocolHandler(E));
+  const network = makeNetworkProtocol(makeLoopbackProtocolHandler());
 
   const portP = E(network).bind('/ibc-channel/chanabc/ibc-port/portdef');
   const portName = await E(portP).getLocalAddress();

--- a/packages/pegasus/test/test-peg.js
+++ b/packages/pegasus/test/test-peg.js
@@ -1,0 +1,179 @@
+/* global __dirname */
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
+
+import { E } from '@agoric/eventual-send';
+import {
+  makeNetworkProtocol,
+  makeLoopbackProtocolHandler,
+} from '@agoric/swingset-vat/src/vats/network';
+
+import bundleSource from '@agoric/bundle-source';
+import { amountMath } from '@agoric/ertp';
+import { makeZoe } from '@agoric/zoe';
+
+import fakeVatAdmin from '@agoric/zoe/src/contractFacet/fakeVatAdmin';
+
+const contractPath = `${__dirname}/../src/pegasus`;
+
+/**
+ * @param {import('tape-promise/tape').Test} t
+ */
+async function testRemotePeg(t) {
+  t.plan(13);
+
+  /**
+   * @type {import('@agoric/ertp').DepositFacet?}
+   */
+  let localDepositFacet;
+  const fakeBoard = harden({
+    getValue(id) {
+      if (id === '0x1234') {
+        return localDepositFacet;
+      }
+      t.is(id, 'agoric1234567', 'tried bech32 first in board');
+      throw Error(`unrecognized board id ${id}`);
+    },
+  });
+  const fakeNamesByAddress = harden({
+    lookup(...keys) {
+      t.is(keys[0], 'agoric1234567', 'unrecognized fakeNamesByAddress');
+      t.is(keys[1], 'depositFacet', 'lookup not for the depositFacet');
+      t.is(keys.length, 2);
+      return localDepositFacet;
+    },
+  });
+
+  const zoe = makeZoe(fakeVatAdmin);
+
+  // Pack the contract.
+  const contractBundle = await bundleSource(contractPath);
+  const installationHandle = await E(zoe).install(contractBundle);
+
+  const { publicFacet: publicAPI } = await E(zoe).startInstance(
+    installationHandle,
+    {},
+    { board: fakeBoard, namesByAddress: fakeNamesByAddress },
+  );
+
+  /**
+   * @type {import('../src/pegasus').Pegasus}
+   */
+  const pegasus = publicAPI;
+  const network = makeNetworkProtocol(makeLoopbackProtocolHandler(E));
+
+  const portP = E(network).bind('/ibc-channel/chanabc/ibc-port/portdef');
+  const portName = await E(portP).getLocalAddress();
+
+  /**
+   * Pretend we're Gaia.
+   *
+   * @type {import('@agoric/swingset-vat/src/vats/network').Connection?}
+   */
+  let gaiaConnection;
+  E(portP).addListener({
+    async onAccept(_p, _localAddr, _remoteAddr) {
+      return harden({
+        async onOpen(c) {
+          gaiaConnection = c;
+        },
+        async onReceive(_c, packetBytes) {
+          const packet = JSON.parse(packetBytes);
+          t.deepEqual(
+            packet,
+            {
+              amount: '100000000000000000001',
+              denomination: 'portdef/chanabc/uatom',
+              receiver: 'markaccount',
+            },
+            'expected transfer packet',
+          );
+          return JSON.stringify({ success: true });
+        },
+      });
+    },
+  });
+
+  // Pretend we're Agoric.
+  const chandler = E(pegasus).makePegConnectionHandler();
+  const connP = E(portP).connect(portName, chandler);
+
+  const pegP = await E(pegasus).pegRemote('Gaia', connP, 'uatom');
+  const localBrand = await E(pegP).getLocalBrand();
+  const localIssuer = await E(pegasus).getLocalIssuer(localBrand);
+
+  const localPurseP = E(localIssuer).makeEmptyPurse();
+  localDepositFacet = await E(localPurseP).getDepositFacet();
+
+  // Get some local Atoms.
+  const sendPacket = {
+    amount: '100000000000000000001',
+    denomination: 'portdef/chanabc/uatom',
+    receiver: '0x1234',
+    sender: 'FIXME:sender',
+  };
+
+  const sendAckData = await E(gaiaConnection).send(JSON.stringify(sendPacket));
+  const sendAck = JSON.parse(sendAckData);
+  t.deepEqual(sendAck, { success: true }, 'Gaia sent the atoms');
+  if (!sendAck.success) {
+    console.log(sendAckData, sendAck.error);
+  }
+
+  const localAtomsAmount = await E(localPurseP).getCurrentAmount();
+  t.deepEqual(
+    localAtomsAmount,
+    { brand: localBrand, value: 100000000000000000001n },
+    'we received the shadow atoms',
+  );
+
+  const sendPacket2 = {
+    amount: '170',
+    denomination: 'portdef/chanabc/uatom',
+    receiver: 'agoric1234567',
+    sender: 'FIXME:sender2',
+  };
+
+  const sendAckData2 = await E(gaiaConnection).send(JSON.stringify(sendPacket2));
+  const sendAck2 = JSON.parse(sendAckData2);
+  t.deepEqual(sendAck2, { success: true }, 'Gaia sent more atoms');
+  if (!sendAck2.success) {
+    console.log(sendAckData2, sendAck2.error);
+  }
+
+  const localAtomsAmount2 = await E(localPurseP).getCurrentAmount();
+  t.deepEqual(
+    localAtomsAmount2,
+    { brand: localBrand, value: 100000000000000000171n },
+    'we received more shadow atoms',
+  );
+
+  const localAtoms = await E(localPurseP).withdraw(localAtomsAmount);
+
+  const allegedName = await E(pegP).getAllegedName();
+  t.is(allegedName, 'Gaia', 'alleged peg name is equal');
+  const transferInvitation = await E(pegasus).makeInvitationToTransfer(
+    pegP,
+    'markaccount',
+  );
+  const seat = await E(zoe).offer(
+    transferInvitation,
+    harden({
+      give: { Transfer: localAtomsAmount },
+    }),
+    harden({ Transfer: localAtoms }),
+  );
+  const outcome = await seat.getOfferResult();
+  t.is(outcome, undefined, 'transfer is successful');
+
+  const paymentPs = await seat.getPayouts();
+  const refundAmount = await E(localIssuer).getAmountOf(paymentPs.Transfer);
+
+  const isEmptyRefund = amountMath.isEmpty(refundAmount, localBrand);
+  t.assert(isEmptyRefund, 'no refund from success');
+
+  const stillIsLive = await E(localIssuer).isLive(localAtoms);
+  t.assert(!stillIsLive, 'payment is consumed');
+}
+
+test('remote peg', t =>
+  testRemotePeg(t).catch(err => t.not(err, err, 'unexpected exception')));

--- a/packages/pegasus/test/test-peg.js
+++ b/packages/pegasus/test/test-peg.js
@@ -133,7 +133,9 @@ async function testRemotePeg(t) {
     sender: 'FIXME:sender2',
   };
 
-  const sendAckData2 = await E(gaiaConnection).send(JSON.stringify(sendPacket2));
+  const sendAckData2 = await E(gaiaConnection).send(
+    JSON.stringify(sendPacket2),
+  );
   const sendAck2 = JSON.parse(sendAckData2);
   t.deepEqual(sendAck2, { success: true }, 'Gaia sent more atoms');
   if (!sendAck2.success) {

--- a/packages/zoe/src/contractSupport/ratio.js
+++ b/packages/zoe/src/contractSupport/ratio.js
@@ -44,9 +44,9 @@ export const assertIsRatio = ratio => {
 };
 
 /**
- * @param {NatValue} numerator
+ * @param {bigint | number} numerator
  * @param {Brand} numeratorBrand
- * @param {NatValue} denominator
+ * @param {bigint | number} denominator
  * @param {Brand} denominatorBrand
  * @returns {Ratio}
  */


### PR DESCRIPTION
Get Pegasus working on-chain:

- move the Pegasus contract to the SDK (will repoint from `dapp-pegasus` later)
- install Pegasus on chain bootstrap
- finish work on `protocolHandler.onInbound` to properly append unique connection allocation information (such as `ibc-channel/channel-321`) to the local address
- implement nameHub `.keys()`, `.values()` and `.entries()`.
- don't use the bridge when on the sim-chain
- expose connections to Pegasus in the `home.pegasusConnections` nameHub.  This, combined with the Pegasus instance, is enough authority to be able to install pegged collateral types in the Treasury.
