### PR TITLE
fix(swingset): recreateDynamicVat() waits for vat creation

### DIFF
--- a/packages/SwingSet/src/kernel/loadVat.js
+++ b/packages/SwingSet/src/kernel/loadVat.js
@@ -55,13 +55,11 @@ export function makeVatLoader(stuff) {
    * @param {*} source  The source object implementing the vat
    * @param {*} dynamicOptions  Options bag governing vat creation
    *
-   * @returns {string}  The vatID of the vat
+   * @returns {Promise<void>} fires when the vat is ready for messages
    */
   function recreateDynamicVat(vatID, source, dynamicOptions) {
     // eslint-disable-next-line no-use-before-define
-    create(vatID, source, dynamicOptions, false, true);
-    // again we ignore create()'s Promise
-    return vatID;
+    return create(vatID, source, dynamicOptions, false, true);
   }
 
   /**


### PR DESCRIPTION
This changes `recreateDynamicVat` to return the same sort of Promise that `recreateStaticVat` does, to make the reloading of dynamic vats run sequentially, not (accidentally) in parallel. See #2871 for details.
