### PR TITLE
slog high-resolution timestamps, capture transcript replay timing

### DIFF
--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -172,6 +172,7 @@ export async function makeSwingsetController(
     }
   }
   const kernelBundle = JSON.parse(hostStorage.get('kernelBundle'));
+  writeSlogObject({ type: 'import-kernel-start' });
   const kernelNS = await importBundle(kernelBundle, {
     filePrefix: 'kernel/...',
     endowments: {
@@ -181,6 +182,7 @@ export async function makeSwingsetController(
     },
   });
   const buildKernel = kernelNS.default;
+  writeSlogObject({ type: 'import-kernel-finish' });
 
   // transformMetering() requires Babel, which imports 'fs' and 'path', so it
   // cannot be implemented within a non-start-Compartment. We build it out

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -883,8 +883,10 @@ export default function buildKernel(
       if (!vat) {
         logStartup(`skipping reload of dead vat ${vatID}`);
       } else {
+        const slogDone = kernelSlog.replayVatTranscript(vatID);
         // eslint-disable-next-line no-await-in-loop
         await vat.manager.replayTranscript();
+        slogDone();
         logStartup(`finished replaying vatID ${vatID} transcript `);
         const newLength = kernelKeeper.getRunQueueLength();
         if (newLength !== oldLength) {

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -601,6 +601,7 @@ export default function buildKernel(
     startXSnap,
     gcTools,
     defaultManagerType,
+    kernelSlog,
   });
 
   function buildVatSyscallHandler(vatID, translators) {

--- a/packages/SwingSet/src/kernel/vatManager/deliver.js
+++ b/packages/SwingSet/src/kernel/vatManager/deliver.js
@@ -10,6 +10,7 @@ export function makeDeliver(tools, dispatch) {
     vatID,
     vatKeeper,
     waitUntilQuiescent,
+    kernelSlog,
   } = tools;
 
   /**

--- a/packages/SwingSet/src/kernel/vatManager/factory.js
+++ b/packages/SwingSet/src/kernel/vatManager/factory.js
@@ -17,6 +17,7 @@ export function makeVatManagerFactory({
   startXSnap,
   gcTools,
   defaultManagerType,
+  kernelSlog,
 }) {
   const localFactory = makeLocalVatManagerFactory({
     allVatPowers,
@@ -26,6 +27,7 @@ export function makeVatManagerFactory({
     transformMetering,
     waitUntilQuiescent,
     gcTools,
+    kernelSlog,
   });
 
   const nodeWorkerFactory = makeNodeWorkerVatManagerFactory({

--- a/packages/SwingSet/src/kernel/vatManager/manager-local.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-local.js
@@ -14,6 +14,7 @@ export function makeLocalVatManagerFactory(tools) {
     transformMetering,
     waitUntilQuiescent,
     gcTools,
+    kernelSlog,
   } = tools;
 
   const { makeGetMeter, refillAllMeters, stopGlobalMeter } = meterManager;
@@ -45,6 +46,7 @@ export function makeLocalVatManagerFactory(tools) {
           transcriptManager,
           vatKeeper,
           waitUntilQuiescent,
+          kernelSlog,
         },
         dispatch,
       );


### PR DESCRIPTION
This adds high-resolution (nanosecond-ish) timestamps to each slog object. We add this in `controller.js`, which runs in the full-powered start compartment, in the `writeSlogObject` function it passes into the kernel compartment, so we aren't increasing the authority of the kernel, or increasing its access to non-determinism.

It also slogs more events than previously. In particular, it logs the beginning and ending of each delivery, both the first time around, and during transcript replay. It also records the delivery data itself, which should give us enough information to 1: identify the "large" deliveries like `executeContract`, and 2: correlate the replayed deliveries with the originals, to see how much faster it is to replay a delivery with a mock/unplugged `syscall`.

The extra slog traffic might make things slower when slogging is turned on. I don't think it will make a significant difference when slogging is turned off.
