### PR TITLE
chore(CI): increase test-xs timeout from 20min to 30min

### DIFF
--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -452,7 +452,7 @@ jobs:
     # END-RESTORE-BOILERPLATE
 
     - name: yarn test (xs)
-      timeout-minutes: 20
+      timeout-minutes: 30
       run: yarn test:xs
       env:
         ESM_DISABLE_CACHE: true


### PR DESCRIPTION
It looks like this takes 24min to complete, ugh. Most `test-xs` jobs were failing at the 20min mark, but since XS is disabled, this was ignored.