### PR TITLE
refactor: pull out installation-related functionality 

### DIFF
--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -1,0 +1,52 @@
+// @ts-check
+
+import { assert, details as X } from '@agoric/assert';
+import { Far } from '@agoric/marshal';
+import { E } from '@agoric/eventual-send';
+
+export const makeInstallationStorage = () => {
+  /** @type {WeakSet<Installation>} */
+  const installations = new WeakSet();
+
+  /**
+   * Create an installation by permanently storing the bundle. It will be
+   * evaluated each time it is used to make a new instance of a contract.
+   */
+  /** @type {Install} */
+  const install = bundle => {
+    assert(bundle, X`a bundle must be provided`);
+    /** @type {Installation} */
+    const installation = Far('Installation', {
+      getBundle: () => bundle,
+    });
+    installations.add(installation);
+    return installation;
+  };
+
+  const assertInstallation = installation =>
+    assert(
+      installations.has(installation),
+      X`${installation} was not a valid installation`,
+    );
+
+  /**
+   *  Assert the installation is known, and return the bundle and
+   * installation
+   *
+   * @param {ERef<Installation>} installationP
+   * @returns {Promise<{ bundle: SourceBundle, installation:
+   * Installation }>}
+   */
+  const unwrapInstallation = installationP => {
+    return E.when(installationP, installation => {
+      assertInstallation(installation);
+      const bundle = installation.getBundle();
+      return { bundle, installation };
+    });
+  };
+
+  return harden({
+    install,
+    unwrapInstallation,
+  });
+};

--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -14,7 +14,7 @@ export const makeInstallationStorage = () => {
    */
   /** @type {Install} */
   const install = bundle => {
-    assert(bundle, X`a bundle must be provided`);
+    assert.typeof(bundle, 'object', X`a bundle must be provided`);
     /** @type {Installation} */
     const installation = Far('Installation', {
       getBundle: () => bundle,

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -47,7 +47,7 @@
  * registering it with Zoe. Returns an installation.
  *
  * @param {SourceBundle} bundle
- * @returns {Promise<Installation>}
+ * @returns {Installation}
  */
 
 /**

--- a/packages/zoe/test/unitTests/zoe/test-installationStorage.js
+++ b/packages/zoe/test/unitTests/zoe/test-installationStorage.js
@@ -1,0 +1,61 @@
+// @ts-check
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+
+import { makeInstallationStorage } from '../../../src/zoeService/installationStorage';
+
+test('install, unwrap installations', async t => {
+  const { install, unwrapInstallation } = makeInstallationStorage();
+  const fakeBundle = {};
+
+  const installation = install(fakeBundle);
+  const unwrapped = await unwrapInstallation(installation);
+  t.is(unwrapped.installation, installation);
+  t.is(unwrapped.bundle, fakeBundle);
+});
+
+test('unwrap promise for installation', async t => {
+  const { install, unwrapInstallation } = makeInstallationStorage();
+  const fakeBundle = {};
+
+  const installation = install(fakeBundle);
+  const unwrapped = await unwrapInstallation(Promise.resolve(installation));
+  t.is(unwrapped.installation, installation);
+  t.is(unwrapped.bundle, fakeBundle);
+});
+
+test('install several', async t => {
+  const { install, unwrapInstallation } = makeInstallationStorage();
+  const fakeBundle1 = {};
+  const fakeBundle2 = {};
+
+  const installation1 = install(fakeBundle1);
+  const unwrapped1 = await unwrapInstallation(installation1);
+  t.is(unwrapped1.installation, installation1);
+  t.is(unwrapped1.bundle, fakeBundle1);
+
+  const installation2 = install(fakeBundle2);
+  const unwrapped2 = await unwrapInstallation(installation2);
+  t.is(unwrapped2.installation, installation2);
+  t.is(unwrapped2.bundle, fakeBundle2);
+});
+
+test('install same twice', async t => {
+  const { install, unwrapInstallation } = makeInstallationStorage();
+  const fakeBundle1 = {};
+
+  const installation1 = install(fakeBundle1);
+  const unwrapped1 = await unwrapInstallation(installation1);
+  t.is(unwrapped1.installation, installation1);
+  t.is(unwrapped1.bundle, fakeBundle1);
+
+  // If the same bundle is installed twice, the bundle is the same,
+  // but the installation is different. Zoe does not currently care about
+  // duplicate bundles.
+  const installation2 = install(fakeBundle1);
+  const unwrapped2 = await unwrapInstallation(installation2);
+  t.is(unwrapped2.installation, installation2);
+  t.not(installation2, installation1);
+  t.is(unwrapped2.bundle, fakeBundle1);
+});


### PR DESCRIPTION
refactor: pull out installation-related functionality into separate file, add unit tests

Small part of #2860