### PR TITLE
Demonstrate disappearing deep stacks

### DIFF
--- a/packages/eventual-send/test/test-await-no-deep-stacks.js
+++ b/packages/eventual-send/test/test-await-no-deep-stacks.js
@@ -5,17 +5,19 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
 
-import { E } from './get-hp';
-
-test('deep-stacks when', t => {
+test('no-deep-stacks then', t => {
   let r;
   const p = new Promise(res => (r = res));
-  const q = E.when(p, v1 => E.when(v1 + 1, v2 => assert.equal(v2, 22)));
+  const q = (async () => assert.equal(await ((await p) + 1), 22))();
   r(33);
-  return q.catch(reason => {
-    t.assert(reason instanceof Error);
-    console.log('expected failure', reason);
-  });
+  return (async () => {
+    try {
+      await q;
+    } catch (reason) {
+      t.assert(reason instanceof Error);
+      console.log('expected failure', reason);
+    }
+  })();
 });
 
 /*
@@ -28,26 +30,18 @@ paths. See
 https://github.com/endojs/endo/blob/master/packages/ses/lockdown-options.md
 
 ```
-$ ava test/test-deep-stacks.js
+$ ava test/test-await-no-deep-stacks.js
 
 expected failure (RangeError#1)
 RangeError#1: Expected 34 is same as 22
-  at packages/eventual-send/test/test-deep-stacks.js:13:57
-
-RangeError#1 ERROR_NOTE: Thrown from: (Error#2) : 2 . 0
-RangeError#1 ERROR_NOTE: Rejection from: (Error#3) : 1 . 1
-Nested 2 errors under RangeError#1
-  Error#2: Event: 1.1
-    at packages/eventual-send/test/test-deep-stacks.js:13:31
-
-  Error#2 ERROR_NOTE: Caused by: (Error#3)
-  Nested error under Error#2
-    Error#3: Event: 0.1
-      at packages/eventual-send/test/test-deep-stacks.js:13:15
-      at async Promise.all (index 0)
+  at packages/eventual-send/test/test-await-no-deep-stacks.js:11:33
+  at async packages/eventual-send/test/test-await-no-deep-stacks.js:15:7
 ```
 
 If you're in a shell or IDE that supports it, try clicking (or command-clicking
-or something) on the file paths for test-deep-stacks.js You should see that there
-are three invocations that were spread over three turns.
+or something) on the file paths for test-await-no-deep-stacks.js You should see
+one invocation and one await together in one stack as if they occurred in the
+same turn. No other turns are visible. Compare with
+test-deep-send.js or test-deep-stacks.js to see the debugging advantage of using
+eventual-send (`E`) or `E.when` instead.
 */

--- a/packages/eventual-send/test/test-deep-send.js
+++ b/packages/eventual-send/test/test-deep-send.js
@@ -1,4 +1,4 @@
-// This file does not start with "test-" because it is useful as an
+// This file is not very useful as an
 // automated test. Rather, its purpose is just to run it to see what a
 // deep stack looks like.
 
@@ -28,3 +28,38 @@ test('deep-stacks E', t => {
     console.log('expected failure', reason);
   });
 });
+
+/*
+prepare-test-env-ava sets the `"stackFiltering"` option to `lockdown` to
+`"verbose"`. For expository purposes, if the `"stackFiltering"` option to
+`lockdown` is set to `"concise"` you should see something like the
+following. What you should actually see with `"verbose"` is like this, but with
+much extraneous information --- infrastructure stack frames and longer file
+paths. See
+https://github.com/endojs/endo/blob/master/packages/ses/lockdown-options.md
+
+```
+$ ava test/test-deep-send.js
+
+expected failure (Error#1)
+Error#1: Wut?
+  at Object.bar (packages/eventual-send/test/test-deep-send.js:13:21)
+
+Error#1 ERROR_NOTE: Thrown from: (Error#2) : 2 . 0
+Error#1 ERROR_NOTE: Rejection from: (Error#3) : 1 . 1
+Nested 2 errors under Error#1
+  Error#2: Event: 1.1
+    at Object.foo (packages/eventual-send/test/test-deep-send.js:17:28)
+
+  Error#2 ERROR_NOTE: Caused by: (Error#3)
+  Nested error under Error#2
+    Error#3: Event: 0.1
+      at Object.test (packages/eventual-send/test/test-deep-send.js:21:22)
+      at packages/eventual-send/test/test-deep-send.js:25:19
+      at async Promise.all (index 0)
+```
+
+If you're in a shell or IDE that supports it, try clicking (or command-clicking
+or something) on the file paths for test-deep-send.js You should see that there
+are four invocations that were spread over three turns.
+*/

--- a/packages/eventual-send/test/test-then-no-deep-stacks.js
+++ b/packages/eventual-send/test/test-then-no-deep-stacks.js
@@ -5,12 +5,12 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
 
-import { E } from './get-hp';
-
-test('deep-stacks when', t => {
+test('no-deep-stacks then', t => {
   let r;
   const p = new Promise(res => (r = res));
-  const q = E.when(p, v1 => E.when(v1 + 1, v2 => assert.equal(v2, 22)));
+  const q = p.then(v1 =>
+    Promise.resolve(v1 + 1).then(v2 => assert.equal(v2, 22)),
+  );
   r(33);
   return q.catch(reason => {
     t.assert(reason instanceof Error);
@@ -28,26 +28,16 @@ paths. See
 https://github.com/endojs/endo/blob/master/packages/ses/lockdown-options.md
 
 ```
-$ ava test/test-deep-stacks.js
+$ ava test/test-then-no-deep-stacks.js
 
 expected failure (RangeError#1)
 RangeError#1: Expected 34 is same as 22
-  at packages/eventual-send/test/test-deep-stacks.js:13:57
-
-RangeError#1 ERROR_NOTE: Thrown from: (Error#2) : 2 . 0
-RangeError#1 ERROR_NOTE: Rejection from: (Error#3) : 1 . 1
-Nested 2 errors under RangeError#1
-  Error#2: Event: 1.1
-    at packages/eventual-send/test/test-deep-stacks.js:13:31
-
-  Error#2 ERROR_NOTE: Caused by: (Error#3)
-  Nested error under Error#2
-    Error#3: Event: 0.1
-      at packages/eventual-send/test/test-deep-stacks.js:13:15
-      at async Promise.all (index 0)
+  at packages/eventual-send/test/test-then-no-deep-stacks.js:12:47
 ```
 
 If you're in a shell or IDE that supports it, try clicking (or command-clicking
-or something) on the file paths for test-deep-stacks.js You should see that there
-are three invocations that were spread over three turns.
+or something) on the file path for test-then-no-deep-stacks.js You should see
+only the last invocation with its stack from that one last turn. Compare with
+test-deep-send.js or test-deep-stacks.js to see the debugging advantage of using
+eventual-send (`E`) or `E.when` instead.
 */


### PR DESCRIPTION
We have instrumented eventual-send (`E`) and `E.when` to give us deep stacks. However, for understandable reasons, our code uses a tremendous number of `.then(`s and `await`s. The `await`s we cannot instrument without an invasive rewrite. The `.then(`s we cannot instrument without an invasive monkey patch that would miss implicit `.then(` equivalents. This PR adds tests to make these differences clear, so we can make better informed tradeoffs between these options. There will remain good reason to use `await` in a disciplined manner in many places. However, we should generally be able to substitute `E.when(` for almost all `.then(`s.

An inventory of the `.then(`s in our main repositories:

![Screen Shot 2021-04-14 at 4 07 04 PM](https://user-images.githubusercontent.com/273868/114797010-1249d700-9d47-11eb-8cdb-bbc38dfc5ee5.png)
