### PR TITLE
Start phasing out ibids. Other marshal improvements

### DIFF
--- a/packages/SwingSet/test/test-marshal.js
+++ b/packages/SwingSet/test/test-marshal.js
@@ -20,7 +20,7 @@ async function prep() {
 
 test('serialize exports', t => {
   const { m } = makeMarshaller(undefined, gcTools);
-  const ser = val => m.serialize(val);
+  const ser = m.serialize;
   const o1 = Far('o1', {});
   const o2 = Far('o2', {
     meth1() {
@@ -33,6 +33,11 @@ test('serialize exports', t => {
   });
   // m now remembers that o1 is exported as 1
   t.deepEqual(ser(harden([o1, o1])), {
+    body:
+      '[{"@qclass":"slot","iface":"Alleged: o1","index":0},{"@qclass":"slot","index":0}]',
+    slots: ['o+1'],
+  });
+  t.deepEqual(ser(harden([o1, o1]), 'forbidCycles'), {
     body:
       '[{"@qclass":"slot","iface":"Alleged: o1","index":0},{"@qclass":"ibid","index":1}]',
     slots: ['o+1'],

--- a/packages/marshal/src/ibidTables.js
+++ b/packages/marshal/src/ibidTables.js
@@ -9,37 +9,77 @@ import { assert, details as X, q } from '@agoric/assert';
 import './types';
 
 /**
+ * @typedef {Object} ReplacerIbidTable
+ * @property {(obj: Passable) => boolean} has
+ * @property {(obj: Passable) => (number | undefined)} get
+ * @property {(obj: Passable) => void} leaf
+ * @property {(obj: Passable) => Passable} start
+ * @property {(obj: Passable, result: Encoding) => Encoding} finish
+ */
+
+/**
  * The ibid logic relies on
  *    * JSON.stringify on an array visiting array indexes from 0 to
  *      arr.length -1 in order, and not visiting anything else.
  *    * JSON.parse of a record (a plain object) creating an object on
  *      which a getOwnPropertyNames will enumerate properties in the
  *      same order in which they appeared in the parsed JSON string.
+ *
+ * @param {CyclePolicy} cyclePolicy
+ * @returns {ReplacerIbidTable}
  */
-const makeReplacerIbidTable = () => {
-  /** @type {Map<object, number>} */
+const makeReplacerIbidTable = cyclePolicy => {
+  /** @type {Map<Passable, number>} */
   const ibidMap = new Map();
   let ibidCount = 0;
+  /** @type {WeakSet<Passable>} */
+  const unfinishedIbids = new WeakSet();
 
   return harden({
-    /**
-     * @param {object} obj
-     */
-    has(obj) {
-      return ibidMap.has(obj);
+    has: obj => {
+      if (!ibidMap.has(obj)) {
+        return false;
+      }
+      const index = ibidMap.get(obj);
+      const inCycle = unfinishedIbids.has(obj);
+      switch (cyclePolicy) {
+        case 'allowCycles': {
+          return true;
+        }
+        case 'warnOfCycles': {
+          console.log(`Warning: ibid cycle at ${index}`);
+          return true;
+        }
+        case 'forbidCycles': {
+          assert(!inCycle, X`Cannot encode cycles at ${index}`, TypeError);
+          return true;
+        }
+        case 'noIbids': {
+          assert(!inCycle, X`Cannot encode cycles at ${index}`, TypeError);
+          return false;
+        }
+        default: {
+          assert.fail(
+            X`Unrecognized cycle policy: ${q(cyclePolicy)}`,
+            TypeError,
+          );
+        }
+      }
     },
-    /**
-     * @param {object} obj
-     */
-    get(obj) {
-      return ibidMap.get(obj);
-    },
-    /**
-     * @param {object} obj
-     */
-    add(obj) {
+    get: obj => ibidMap.get(obj),
+    leaf: obj => {
       ibidMap.set(obj, ibidCount);
       ibidCount += 1;
+    },
+    start: obj => {
+      ibidMap.set(obj, ibidCount);
+      ibidCount += 1;
+      unfinishedIbids.add(obj);
+      return obj;
+    },
+    finish: (obj, result) => {
+      unfinishedIbids.delete(obj);
+      return result;
     },
   });
 };
@@ -47,18 +87,38 @@ harden(makeReplacerIbidTable);
 export { makeReplacerIbidTable };
 
 /**
+ * @template T
+ * @typedef {Object} ReviverIbidTable
+ * @property {(allegedIndex: number) => T} get
+ * @property {(obj: T) => T} leaf
+ * @property {(obj: T) => T} start
+ * @property {(obj: T) => T} finish
+ */
+
+/**
+ * @template T
  * @param {CyclePolicy} cyclePolicy
+ * @returns {ReviverIbidTable<T>}
  */
 const makeReviverIbidTable = cyclePolicy => {
+  if (cyclePolicy === 'noIbids') {
+    return harden({
+      get: _allegedIndex => {
+        assert.fail(X`Ibids not accepted`, TypeError);
+      },
+      leaf: obj => obj,
+      start: obj => obj,
+      finish: obj => obj,
+    });
+  }
+
+  /** @type {Passable[]} */
   const ibids = [];
+  /** @type {WeakSet<Passable>} */
   const unfinishedIbids = new WeakSet();
 
   return harden({
-    /**
-     * @param {number} allegedIndex
-     * @returns {object}
-     */
-    get(allegedIndex) {
+    get: allegedIndex => {
       const index = Number(Nat(allegedIndex));
       assert(index < ibids.length, X`ibid out of range: ${index}`, RangeError);
       const result = ibids[index];
@@ -84,25 +144,16 @@ const makeReviverIbidTable = cyclePolicy => {
       }
       return result;
     },
-    /**
-     * @param {object} obj
-     */
-    register(obj) {
+    leaf: obj => {
       ibids.push(obj);
       return obj;
     },
-    /**
-     * @param {object} obj
-     */
-    start(obj) {
+    start: obj => {
       ibids.push(obj);
       unfinishedIbids.add(obj);
       return obj;
     },
-    /**
-     * @param {object} obj
-     */
-    finish(obj) {
+    finish: obj => {
       unfinishedIbids.delete(obj);
       return obj;
     },

--- a/packages/marshal/src/marshal-justin.js
+++ b/packages/marshal/src/marshal-justin.js
@@ -119,6 +119,8 @@ const identPattern = /^[a-zA-Z]\w*$/;
  * @returns {string}
  */
 const decodeToJustin = (encoding, shouldIndent = false) => {
+  // TODO How do I avoid these imports in types?
+  /** @type {import('./ibidTables').ReviverIbidTable<Encoding>} */
   const ibidTable = makeReviverIbidTable('forbidCycles');
   const ibidMap = new Map();
 
@@ -174,7 +176,7 @@ const decodeToJustin = (encoding, shouldIndent = false) => {
           return;
         }
         case 'error': {
-          ibidTable.register(rawTree);
+          ibidTable.leaf(rawTree);
           const { name, message } = rawTree;
           assert.typeof(
             name,
@@ -193,7 +195,7 @@ const decodeToJustin = (encoding, shouldIndent = false) => {
           return;
         }
         case 'slot': {
-          ibidTable.register(rawTree);
+          ibidTable.leaf(rawTree);
           const { index, iface } = rawTree;
           assert.typeof(index, 'number');
           Nat(index);

--- a/packages/marshal/src/types.js
+++ b/packages/marshal/src/types.js
@@ -120,7 +120,7 @@
 /**
  * @template Slot
  * @typedef CapData
- * @property {Encoding} body
+ * @property {string} body A JSON.stringify of an Encoding
  * @property {Slot[]} slots
  */
 
@@ -128,11 +128,12 @@
  * @template Slot
  * @callback Serialize
  * @param {Passable} val
+ * @param {CyclePolicy=} cyclePolicy
  * @returns {CapData<Slot>}
  */
 
 /**
- * @typedef {"allowCycles" | "warnOfCycles" | "forbidCycles"} CyclePolicy
+ * @typedef {"allowCycles" | "warnOfCycles" | "forbidCycles" | "noIbids"} CyclePolicy
  */
 
 /**

--- a/packages/marshal/test/test-marshal-justin.js
+++ b/packages/marshal/test/test-marshal-justin.js
@@ -56,7 +56,14 @@ export const jsonPairs = harden([
     '{"@qclass":"hilbert","original":{"@qclass":"hilbert","original":8,"rest":{"foo":"foo1"}},"rest":{"bar":{"@qclass":"hilbert","original":{"@qclass":"undefined"}}}}',
     '{"@qclass":{"@qclass":8,foo:"foo1"},bar:{"@qclass":undefined}}',
   ],
+  // ibids and slots
+  [
+    '[{"@qclass":"slot","iface":"Alleged: for testing Justin","index":0}]',
+    '[getSlotVal(0,"Alleged: for testing Justin")]',
+  ],
+]);
 
+const jsonIbidPairs = harden([
   // ibids and slots
   [
     '[{"foo":8},{"@qclass":"ibid","index":1}]',
@@ -94,6 +101,23 @@ test('serialize decodeToJustin eval round trip pairs', t => {
     t.is(justinExpr, justinSrc);
     const value = harden(c.evaluate(`(${justinExpr})`));
     const { body: newBody } = serialize(value);
+    t.is(newBody, body);
+  }
+});
+
+test('serialize decodeToJustin eval round trip ibid pairs', t => {
+  const { serialize } = makeMarshal(undefined, undefined, {
+    // We're turning `errorTagging`` off only for the round trip tests, not in
+    // general.
+    errorTagging: 'off',
+  });
+  for (const [body, justinSrc] of jsonIbidPairs) {
+    const c = fakeJustinCompartment();
+    const encoding = JSON.parse(body);
+    const justinExpr = decodeToJustin(encoding);
+    t.is(justinExpr, justinSrc);
+    const value = harden(c.evaluate(`(${justinExpr})`));
+    const { body: newBody } = serialize(value, 'forbidCycles');
     t.is(newBody, body);
   }
 });

--- a/packages/marshal/test/test-marshal.js
+++ b/packages/marshal/test/test-marshal.js
@@ -234,7 +234,7 @@ test('unserialize errors', t => {
 
 test('serialize ibid cycle', t => {
   const m = makeMarshal();
-  const ser = val => m.serialize(val);
+  const ser = val => m.serialize(val, 'allowCycles');
   const cycle = ['a', 'x', 'c'];
   cycle[1] = cycle;
   harden(cycle);
@@ -247,7 +247,7 @@ test('serialize ibid cycle', t => {
 
 test('forbid ibid cycle', t => {
   const m = makeMarshal();
-  const uns = body => m.unserialize({ body, slots: [] });
+  const uns = body => m.unserialize({ body, slots: [] }, 'forbidCycles');
   t.throws(() => uns('["a",{"@qclass":"ibid","index":0},"c"]'), {
     message: /Ibid cycle at 0/,
   });
@@ -262,7 +262,7 @@ test('unserialize ibid cycle', t => {
 
 test('serialize marshal ibids', t => {
   const m = makeMarshal();
-  const ser = val => m.serialize(val);
+  const ser = val => m.serialize(val, 'allowCycles');
 
   const cycle1 = {};
   cycle1['@qclass'] = cycle1;


### PR DESCRIPTION
Turning on the commented out instrumentation and running `yarn test` over all of `agoric-sdk` there is only this one case where the output without ibids is larger than the output with ibids. It seems to be from one of the swingset tests but I'm not sure which. Even in this unusual case, the expansion is less than 2x.

```
Expansion 478 / 262 = 1.8244274809160306 }
 [{"@qclass":"slot","index":0},[{"brand":{"@qclass":"slot","iface":"Alleged: moola brand","index":1},"value":{"@qclass":"bigint","digits":"200"}},{"brand":{"@qclass":"slot","index":1},"value":{"@qclass":"bigint","digits":"200"}},{"brand":{"@qclass":"slot","index":1},"value":{"@qclass":"bigint","digits":"200"}},{"brand":{"@qclass":"slot","index":1},"value":{"@qclass":"bigint","digits":"200"}},{"brand":{"@qclass":"slot","index":1},"value":{"@qclass":"bigint","digits":"200"}}]] 
 [{"@qclass":"slot","index":0},[{"brand":{"@qclass":"slot","iface":"Alleged: moola brand","index":1},"value":{"@qclass":"bigint","digits":"200"}},{"@qclass":"ibid","index":3},{"@qclass":"ibid","index":3},{"@qclass":"ibid","index":3},{"@qclass":"ibid","index":3}]] 
```

This PR adds a new `cyclePolicy` of `'noIbids'`. Serialization is now also parameterized by a `cyclePolicy` in addition to unserialization. The default unserialization policy remains `'forbidCycles'`. The default serialization policy is `'noIbids'` which never encodes and ibid, but does detect and reject cycles during serialization, preventing unbounded recursion.

`marshal` now deals with `convertSlotToVal` more like the way it has always dealt with `convertValToSlot` --- it uses its own internal bookkeeping to avoid asking these external functions redundant questions. Previously, if a slot would have been repeated, the serialization side would instead encode it with an ibid. But the unserialization side did not insist on that. If the same slot number appeared in the encoding multiple times, the unserialization would call `convertSlotToVal` redundantly, possibly producing different vals for different occurrences of the same slot number. This PR eliminates that hazard.

Without ibids, we should now have the invariant that `sameStructure(x, y)` implies that
`serialize(x).body === serialize(y).body`. In other word, with respect to the `sameStructure` equivalence class, `serialize` should now be canonical. Our pass-by-copy superstructure cannot have cycles. And it always has tree semantics whether it is originally a DAG or not. It will always unserialize to a tree.

This PR expands complexity a bit in order to deal with the transition to an ibid-less world without breaking anything. Once we're on the other side of that, a lot of this will become simpler.

Attn @cwebber 