### PR TITLE
Ignore an xsnap build output

### DIFF
--- a/packages/xsnap/test/.gitignore
+++ b/packages/xsnap/test/.gitignore
@@ -1,1 +1,2 @@
 fixture-snapshot.xss
+fixture-snap-pool


### PR DESCRIPTION
After doing the normal installing building and testing, a `git status` was bugging me about an untracked `fixture-snap-pool`. It seemed harmless, so I am optimistically adding it to the closest `.gitignore`. With that, `git status` is clean again.