### PR TITLE
Allow for genesis to start at an arbitrary height

### DIFF
--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -65,6 +65,8 @@ scenario2-setup-nobuild:
 	$(AGCH) --home=t1/n0 validate-genesis
 	../agoric-cli/bin/agoric set-defaults --export-metrics ag-chain-cosmos t1/n0/config
 	# Set the chain address in all the ag-solos.
+	jq '. + { initial_height: "17" }' t1/n0/config/genesis.json > t1/n0/config/genesis2.json
+	mv t1/n0/config/genesis2.json t1/n0/config/genesis.json
 	$(MAKE) set-local-gci-ingress
 
 scenario2-run-chain:

--- a/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
+++ b/packages/cosmic-swingset/lib/ag-solo/fake-chain.js
@@ -95,9 +95,6 @@ export async function connectToFakeChain(basedir, GCI, delay, inbound) {
       thisBlock.push(...intoChain);
       intoChain = [];
 
-      blockTime += PRETEND_BLOCK_DELAY;
-      blockHeight += 1;
-
       await blockManager(
         { type: 'BEGIN_BLOCK', blockHeight, blockTime },
         savedChainSends,
@@ -126,8 +123,12 @@ export async function connectToFakeChain(basedir, GCI, delay, inbound) {
         { type: 'COMMIT_BLOCK', blockHeight, blockTime },
         savedChainSends,
       );
+
+      // We now advance to the next block.
       thisBlock = [];
-      blockTime += scaleBlockTime(Date.now() - actualStart);
+      blockTime +=
+        scaleBlockTime(Date.now() - actualStart) + PRETEND_BLOCK_DELAY;
+      blockHeight += 1;
 
       clearTimeout(nextBlockTimeout);
       // eslint-disable-next-line no-use-before-define
@@ -159,7 +160,10 @@ export async function connectToFakeChain(basedir, GCI, delay, inbound) {
   }
 
   // The first block is special... do it now.
-  await simulateBlock();
+  await blockManager(
+    { type: 'END_BLOCK', blockHeight, blockTime },
+    savedChainSends,
+  );
 
   // Start the first pretend block.
   nextBlockTimeout = setTimeout(simulateBlock, maximumDelay);

--- a/packages/cosmic-swingset/lib/block-manager.js
+++ b/packages/cosmic-swingset/lib/block-manager.js
@@ -23,7 +23,7 @@ export default function makeBlockManager({
   savedHeight,
   verboseBlocks = false,
 }) {
-  let computedHeight = savedHeight;
+  let computedHeight = savedHeight === 0 ? undefined : savedHeight;
   let runTime = 0;
 
   async function kernelPerformAction(action) {
@@ -84,7 +84,10 @@ export default function makeBlockManager({
     switch (action.type) {
       case COMMIT_BLOCK: {
         verboseBlocks && log.info('block', action.blockHeight, 'commit');
-        if (action.blockHeight !== computedHeight) {
+        if (
+          computedHeight !== undefined &&
+          action.blockHeight !== computedHeight
+        ) {
           throw Error(
             `Committed height ${action.blockHeight} does not match computed height ${computedHeight}`,
           );
@@ -124,7 +127,10 @@ export default function makeBlockManager({
           const restoreHeight = action.blockHeight - 1;
           // We can reset from -1 or 0 to anything, since that's what happens
           // when genesis.initial_height !== "1".
-          if (computedHeight > 0 && restoreHeight !== computedHeight) {
+          if (
+            computedHeight !== undefined &&
+            restoreHeight !== computedHeight
+          ) {
             // Keep throwing forever.
             decohered = Error(
               // TODO unimplemented
@@ -166,13 +172,18 @@ export default function makeBlockManager({
 
           // Advance our saved state variables.
           savedActions = currentActions;
-          computedHeight = action.blockHeight;
+          if (computedHeight === undefined) {
+            // Genesis height is the same as the first block, so we
+            // need to adjust.
+            computedHeight = action.blockHeight - 1;
+          } else {
+            computedHeight = action.blockHeight;
+          }
 
           // Save the kernel's computed state so that we can recover if we ever
           // reset before Cosmos SDK commit.
           const start2 = Date.now();
           await saveOutsideState(computedHeight, savedActions, savedChainSends);
-          savedHeight = computedHeight;
 
           const saveTime = Date.now() - start2;
 

--- a/packages/cosmic-swingset/lib/launch-chain.js
+++ b/packages/cosmic-swingset/lib/launch-chain.js
@@ -201,9 +201,9 @@ export async function launch(
   }
 
   const [savedHeight, savedActions, savedChainSends] = JSON.parse(
-    storage.get(SWING_STORE_META_KEY) || '[-1, [], []]',
+    storage.get(SWING_STORE_META_KEY) || '[0, [], []]',
   );
-  firstBlock = savedHeight < 0;
+  firstBlock = savedHeight === 0;
 
   return {
     deliverInbound,


### PR DESCRIPTION
This PR brings the fake chain and ag-chain-cosmos back into line with the following features:

1. allow the genesis `initial_height >= "1"`
2. run and commit the genesis transactions and chain bootstrap before opening for business
3. the genesis transaction context's block height is the same as the first block
