### PR TITLE
Settle REMOTE_STYLE name

### DIFF
--- a/packages/ERTP/src/displayInfo.js
+++ b/packages/ERTP/src/displayInfo.js
@@ -1,12 +1,7 @@
 // @ts-check
 
 import { assert, details as X, q } from '@agoric/assert';
-import {
-  pureCopy,
-  passStyleOf,
-  REMOTE_STYLE,
-  getInterfaceOf,
-} from '@agoric/marshal';
+import { pureCopy, passStyleOf } from '@agoric/marshal';
 
 // TODO: assertSubset and assertKeysAllowed are copied from Zoe. Move
 // this code to a location where it can be used by ERTP and Zoe
@@ -45,26 +40,15 @@ export const assertDisplayInfo = allegedDisplayInfo => {
   if (allegedDisplayInfo === undefined) {
     return;
   }
+  assert(
+    passStyleOf(allegedDisplayInfo) === 'copyRecord',
+    X`A displayInfo can only be a pass-by-copy record: ${allegedDisplayInfo}`,
+  );
   const displayInfoKeys = harden(['decimalPlaces']);
   assertKeysAllowed(displayInfoKeys, allegedDisplayInfo);
 };
 
 export const coerceDisplayInfo = allegedDisplayInfo => {
-  if (passStyleOf(allegedDisplayInfo) === REMOTE_STYLE) {
-    // These condition together try to ensure that `allegedDisplayInfo`
-    // is a plain empty object. It will accept all plain empty objects
-    // that it should. It will reject most things we want to reject including
-    // remotables that are explicitly declared `Remotable`. But a normal
-    // HandledPromise presence not explicitly declared `Remotable` will
-    // be mistaken for a plain empty object. Even in this case, the copy
-    // has a new identity, so the only danger is that we didn't reject
-    // with a diagnostic, potentially masking a programmer error.
-    assert(Object.isFrozen(allegedDisplayInfo));
-    assert.equal(Reflect.ownKeys(allegedDisplayInfo).length, 0);
-    assert.equal(Object.getPrototypeOf(allegedDisplayInfo), Object.prototype);
-    assert.equal(getInterfaceOf(allegedDisplayInfo), undefined);
-    return harden({});
-  }
   allegedDisplayInfo = pureCopy(allegedDisplayInfo);
   assertDisplayInfo(allegedDisplayInfo);
   return allegedDisplayInfo;

--- a/packages/ERTP/src/mathHelpers/setMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/setMathHelpers.js
@@ -29,7 +29,7 @@ const hashBadly = thing => {
   if (allowableNonObjectValues.includes(type)) {
     return thing;
   }
-  if (passStyleOf(thing) === 'presence') {
+  if (passStyleOf(thing) === 'remotable') {
     return thing;
   }
   if (passStyleOf(thing) === 'copyRecord') {

--- a/packages/ERTP/src/typeGuards.js
+++ b/packages/ERTP/src/typeGuards.js
@@ -1,5 +1,5 @@
 import { isNat } from '@agoric/nat';
-import { passStyleOf, REMOTE_STYLE } from '@agoric/marshal';
+import { passStyleOf } from '@agoric/marshal';
 
 const { isFrozen } = Object;
 
@@ -61,4 +61,4 @@ export const looksLikeValue = value =>
  * @returns {brand is Brand}
  */
 export const looksLikeBrand = brand =>
-  isFrozen(brand) && passStyleOf(brand) === REMOTE_STYLE;
+  isFrozen(brand) && passStyleOf(brand) === 'remotable';

--- a/packages/SwingSet/src/kernel/deviceSlots.js
+++ b/packages/SwingSet/src/kernel/deviceSlots.js
@@ -1,9 +1,4 @@
-import {
-  Remotable,
-  passStyleOf,
-  REMOTE_STYLE,
-  makeMarshal,
-} from '@agoric/marshal';
+import { Remotable, passStyleOf, makeMarshal } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
 import { insistVatType, makeVatSlot, parseVatSlot } from '../parseVatSlots';
 import { insistCapData } from '../capdata';
@@ -72,7 +67,7 @@ export function makeDeviceSlots(
     if (!valToSlot.has(val)) {
       // must be a new export
       // lsdebug('must be a new export', JSON.stringify(val));
-      assert.equal(passStyleOf(val), REMOTE_STYLE);
+      assert.equal(passStyleOf(val), 'remotable');
       const slot = exportPassByPresence();
       parseVatSlot(slot); // assertion
       valToSlot.set(val, slot);
@@ -175,7 +170,7 @@ export function makeDeviceSlots(
     deviceParameters,
     serialize: m.serialize, // We deliberately do not provide m.deserialize
   });
-  assert.equal(passStyleOf(rootObject), REMOTE_STYLE);
+  assert.equal(passStyleOf(rootObject), 'remotable');
 
   const rootSlot = makeVatSlot('device', true, 0n);
   valToSlot.set(rootObject, rootSlot);

--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -1,11 +1,6 @@
 /* global HandledPromise */
 
-import {
-  Remotable,
-  passStyleOf,
-  REMOTE_STYLE,
-  makeMarshal,
-} from '@agoric/marshal';
+import { Remotable, passStyleOf, makeMarshal } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
 import { isPromise } from '@agoric/promise-kit';
 import { insistVatType, makeVatSlot, parseVatSlot } from '../parseVatSlots';
@@ -379,7 +374,7 @@ function build(
           exitVatWithFailure(disavowalError);
           throw disavowalError; // cannot reference a disavowed object
         }
-        assert.equal(passStyleOf(val), REMOTE_STYLE);
+        assert.equal(passStyleOf(val), 'remotable');
         slot = exportPassByPresence();
       }
       parseVatSlot(slot); // assertion
@@ -798,7 +793,7 @@ function build(
 
     // here we finally invoke the vat code, and get back the root object
     const rootObject = buildRootObject(harden(vpow), harden(vatParameters));
-    assert.equal(passStyleOf(rootObject), REMOTE_STYLE);
+    assert.equal(passStyleOf(rootObject), 'remotable');
 
     const rootSlot = makeVatSlot('object', true, BigInt(0));
     valToSlot.set(rootObject, rootSlot);

--- a/packages/deploy-script-support/src/startInstance.js
+++ b/packages/deploy-script-support/src/startInstance.js
@@ -65,7 +65,7 @@ export const makeStartInstance = (
     console.log(`-- Registering Contract Instance: ${instancePetname}`);
     await E(instanceManager).add(instancePetname, instance);
 
-    if (passStyleOf(creatorInvitation) === 'presence') {
+    if (passStyleOf(creatorInvitation) === 'remotable') {
       assert(
         creatorInvitation,
         `creatorInvitation must be defined to be deposited`,

--- a/packages/marshal/index.js
+++ b/packages/marshal/index.js
@@ -1,5 +1,4 @@
 export {
-  REMOTE_STYLE,
   getInterfaceOf,
   getErrorConstructor,
   passStyleOf,

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -8,7 +8,6 @@ import { assert, details as X, q } from '@agoric/assert';
 import { makeReplacerIbidTable, makeReviverIbidTable } from './ibidTables';
 import {
   PASS_STYLE,
-  REMOTE_STYLE,
   passStyleOf,
   getInterfaceOf,
   getErrorConstructor,
@@ -98,7 +97,7 @@ function pureCopy(val, already = new WeakMap()) {
       return /** @type {T} */ (unk2);
     }
 
-    case REMOTE_STYLE: {
+    case 'remotable': {
       assert.fail(
         X`Input value ${q(
           passStyle,
@@ -130,7 +129,7 @@ const makeRemotableProto = (oldProto, allegedName) => {
   const toString = () => `[${allegedName}]`;
   return harden(
     create(oldProto, {
-      [PASS_STYLE]: { value: REMOTE_STYLE },
+      [PASS_STYLE]: { value: 'remotable' },
       toString: { value: toString },
       [Symbol.toStringTag]: { value: allegedName },
     }),
@@ -252,7 +251,7 @@ ${q(body2)}
         slotMap.set(val, slotIndex);
 
         /*
-        if (iface === undefined && passStyleOf(val) === REMOTE_STYLE) {
+        if (iface === undefined && passStyleOf(val) === 'remotable') {
           // iface = `Alleged: remotable at slot ${slotIndex}`;
           if (
             getPrototypeOf(val) === objectPrototype &&
@@ -425,7 +424,7 @@ ${q(body2)}
                 });
               }
             }
-            case REMOTE_STYLE: {
+            case 'remotable': {
               ibidTable.leaf(val);
               const iface = getInterfaceOf(val);
               // console.log(`serializeSlot: ${val}`);

--- a/packages/marshal/src/passStyleOf.js
+++ b/packages/marshal/src/passStyleOf.js
@@ -17,9 +17,6 @@ const {
 
 const { ownKeys } = Reflect;
 
-// TODO: Use just 'remote' when we're willing to make a breaking change.
-export const REMOTE_STYLE = 'presence';
-
 export const PASS_STYLE = Symbol.for('passStyle');
 
 /** @type {MarshalGetInterfaceOf} */
@@ -27,7 +24,7 @@ export function getInterfaceOf(val) {
   if (typeof val !== 'object' || val === null) {
     return undefined;
   }
-  if (val[PASS_STYLE] !== REMOTE_STYLE) {
+  if (val[PASS_STYLE] !== 'remotable') {
     return undefined;
   }
   assert(isFrozen(val), X`Remotable ${val} must be frozen`, TypeError);
@@ -225,8 +222,8 @@ const assertRemotableProto = val => {
     X`Unexpect properties on Remotable Proto ${ownKeys(rest)}`,
   );
   assert(
-    passStyleValue === REMOTE_STYLE,
-    X`Expected ${q(REMOTE_STYLE)}, not ${q(passStyleValue)}`,
+    passStyleValue === 'remotable',
+    X`Expected 'remotable', not ${q(passStyleValue)}`,
   );
   assert.typeof(toStringValue, 'function', X`toString must be a function`);
   assert.typeof(toStringTagValue, 'string', X`@@toStringTag must be a string`);
@@ -306,7 +303,7 @@ function assertRemotable(val) {
  *   * 'copyRecord' for non-empty records with only data properties
  *   * 'copyArray' for arrays with only data properties
  *   * 'copyError' for instances of Error with only data properties
- *   * REMOTE_STYLE for non-array objects with only method properties
+ *   * 'remotable' for non-array objects with only method properties
  *   * 'promise' for genuine promises only
  *   * throwing an error on anything else, including thenables.
  * We export passStyleOf so other algorithms can use this module's
@@ -320,7 +317,7 @@ export function passStyleOf(val) {
   switch (typestr) {
     case 'object': {
       if (getInterfaceOf(val)) {
-        return REMOTE_STYLE;
+        return 'remotable';
       }
       if (val === null) {
         return 'null';
@@ -348,7 +345,7 @@ export function passStyleOf(val) {
       assertRemotable(val);
       // console.log(`--- @@marshal: pass-by-ref object without Far/Remotable`);
       // assert.fail(X`pass-by-ref object without Far/Remotable`);
-      return REMOTE_STYLE;
+      return 'remotable';
     }
     case 'function': {
       assert.fail(X`Bare functions like ${val} are disabled for now`);

--- a/packages/marshal/src/types.js
+++ b/packages/marshal/src/types.js
@@ -2,9 +2,7 @@
 /// <reference path="extra-types.d.ts" />
 
 /**
- * @typedef { "bigint" | "boolean" | "null" | "number" | "string" | "symbol" | "undefined" | "copyArray" | "copyRecord" | "copyError" | "promise" | "presence" } PassStyle
- * TODO "presence" above should indirect through REMOTE_STYLE to prepare
- * for changing it to "remotable"
+ * @typedef { "bigint" | "boolean" | "null" | "number" | "string" | "symbol" | "undefined" | "copyArray" | "copyRecord" | "copyError" | "promise" | "remotable" } PassStyle
  */
 
 // TODO declare more precise types throughout this file, so the type system

--- a/packages/same-structure/src/sameStructure.js
+++ b/packages/same-structure/src/sameStructure.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { passStyleOf, REMOTE_STYLE } from '@agoric/marshal';
+import { passStyleOf } from '@agoric/marshal';
 import { assert, details as X, q } from '@agoric/assert';
 
 const {
@@ -89,7 +89,7 @@ function allComparable(passable) {
     case 'boolean':
     case 'number':
     case 'bigint':
-    case REMOTE_STYLE:
+    case 'remotable':
     case 'copyError': {
       return passable;
     }
@@ -149,7 +149,7 @@ function sameStructure(left, right) {
     case 'boolean':
     case 'number':
     case 'bigint':
-    case REMOTE_STYLE: {
+    case 'remotable': {
       return sameValueZero(left, right);
     }
     case 'copyRecord':
@@ -227,7 +227,7 @@ function mustBeSameStructureInternal(left, right, message, path) {
     case 'boolean':
     case 'number':
     case 'bigint':
-    case REMOTE_STYLE: {
+    case 'remotable': {
       if (!sameValueZero(left, right)) {
         complain('different');
       }

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -5,7 +5,7 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
-import { passStyleOf, REMOTE_STYLE } from '@agoric/marshal';
+import { passStyleOf } from '@agoric/marshal';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import bundleSource from '@agoric/bundle-source';
@@ -60,7 +60,7 @@ test(`zoe.startInstance bad installation`, async t => {
 });
 
 function isEmptyFacet(t, facet) {
-  t.is(passStyleOf(facet), REMOTE_STYLE);
+  t.is(passStyleOf(facet), 'remotable');
   t.deepEqual(Object.getOwnPropertyNames(facet), []);
 }
 


### PR DESCRIPTION
Long ago, @michaelfig and I settled on terminology such that `'presence'` is a name at the eventual-send/handled-promise layer of abstraction and `'remotable'` is a name at the marshal/passStyleOf level of abstraction. However, at that time, for remotables, `passStyleOf` was already returning `'presence'`. To ease the transition from `'presence'` to `'remotable'` we introduced the constant name `REMOTE_STYLE`.

We recently revisited the naming at https://github.com/Agoric/documentation/issues/456#issuecomment-820646550 . Although some of our other preferred name choices changed, this overriding one has remained stable. This PR changes the concrete `passStyleOf` answer for those cases from `'presence'` to `'remotable'` and also replaces all uses of `REMOTE_STYLE` with `'remotable'`. It deletes the constant name `REMOTE_STYLE`.

In addition, while doing these substitutions, I noticed that `coerceDisplayInfo` was still trying to cope with a simple empty object being treated as a remotable, which is an irregularity we fixed long ago.

As with #2898 there is a potential cross-version compat issue we need to think about before merging. However, this string shows up only in local APIs. It is never sent as part of a protocol and so is much less likely to cause any actual incompat issues.