### PR TITLE
chore(swingset): remove decref support

### DIFF
--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -112,7 +112,6 @@ export async function makeSwingsetController(
     debugPrefix = '',
     slogCallbacks,
     slogFile,
-    testTrackDecref,
     snapstorePath,
   } = runtimeOptions;
   if (typeof Compartment === 'undefined') {
@@ -275,7 +274,7 @@ export async function makeSwingsetController(
     FinalizationRegistry,
   };
 
-  const kernelOptions = { verbose, testTrackDecref };
+  const kernelOptions = { verbose };
   const kernel = buildKernel(kernelEndowments, deviceEndowments, kernelOptions);
 
   if (runtimeOptions.verbose) {
@@ -368,13 +367,11 @@ export async function buildVatController(
     kernelBundles,
     debugPrefix,
     slogCallbacks,
-    testTrackDecref,
     snapstorePath,
   } = runtimeOptions;
   const actualRuntimeOptions = {
     verbose,
     debugPrefix,
-    testTrackDecref,
     slogCallbacks,
     snapstorePath,
   };

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -107,11 +107,7 @@ export default function buildKernel(
     FinalizationRegistry,
   } = kernelEndowments;
   deviceEndowments = { ...deviceEndowments }; // copy so we can modify
-  const {
-    verbose,
-    testTrackDecref = false,
-    defaultManagerType = 'local',
-  } = kernelOptions;
+  const { verbose, defaultManagerType = 'local' } = kernelOptions;
   const logStartup = verbose ? console.debug : () => 0;
 
   insistStorageAPI(hostStorage);
@@ -156,17 +152,6 @@ export default function buildKernel(
       return origConsole;
     }
     return kernelSlog.vatConsole(vatID, origConsole);
-  }
-
-  const pendingDecrefs = [];
-  function decref(vatID, vref, count) {
-    assert(ephemeral.vats.has(vatID), X`unknown vatID ${vatID}`);
-    assert(count > 0, X`bad count ${count}`);
-    // TODO: decrement the clist import counter by 'count', then GC if zero
-    if (testTrackDecref) {
-      console.log(`kernel decref [${vatID}].${vref} -= ${count}`);
-      pendingDecrefs.push({ vatID, vref, count });
-    }
   }
 
   // runQueue entries are {type, vatID, more..}. 'more' depends on type:
@@ -587,7 +572,7 @@ export default function buildKernel(
     }
   }
 
-  const gcTools = harden({ WeakRef, FinalizationRegistry, decref });
+  const gcTools = harden({ WeakRef, FinalizationRegistry });
   const vatManagerFactory = makeVatManagerFactory({
     allVatPowers,
     kernelKeeper,
@@ -998,7 +983,7 @@ export default function buildKernel(
       // a time, so any log() calls that were interleaved during their
       // original execution will be sorted by vat in the replace). Logs are
       // not kept in the persistent state, only in ephemeral state.
-      return { log: ephemeral.log, pendingDecrefs, ...kernelKeeper.dump() };
+      return { log: ephemeral.log, ...kernelKeeper.dump() };
     },
     kdebugEnable,
 

--- a/packages/SwingSet/src/kernel/vatManager/factory.js
+++ b/packages/SwingSet/src/kernel/vatManager/factory.js
@@ -34,14 +34,12 @@ export function makeVatManagerFactory({
     makeNodeWorker,
     kernelKeeper,
     testLog: allVatPowers.testLog,
-    decref: gcTools.decref,
   });
 
   const nodeSubprocessFactory = makeNodeSubprocessFactory({
     startSubprocessWorker: startSubprocessWorkerNode,
     kernelKeeper,
     testLog: allVatPowers.testLog,
-    decref: gcTools.decref,
   });
 
   const xsWorkerFactory = makeXsSubprocessFactory({
@@ -49,7 +47,6 @@ export function makeVatManagerFactory({
     kernelKeeper,
     allVatPowers,
     testLog: allVatPowers.testLog,
-    decref: gcTools.decref,
   });
 
   function validateManagerOptions(managerOptions) {

--- a/packages/SwingSet/src/kernel/vatManager/manager-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-nodeworker.js
@@ -23,7 +23,7 @@ function parentLog(first, ...args) {
 }
 
 export function makeNodeWorkerVatManagerFactory(tools) {
-  const { makeNodeWorker, kernelKeeper, testLog, decref } = tools;
+  const { makeNodeWorker, kernelKeeper, testLog } = tools;
 
   function createFromBundle(vatID, bundle, managerOptions) {
     const {
@@ -71,10 +71,6 @@ export function makeNodeWorkerVatManagerFactory(tools) {
       doSyscall(vatSyscallObject);
     }
 
-    function vatDecref(vref, count) {
-      decref(vatID, vref, count);
-    }
-
     // start the worker and establish a connection
 
     const { promise: workerP, resolve: gotWorker } = makePromiseKit();
@@ -114,9 +110,6 @@ export function makeNodeWorkerVatManagerFactory(tools) {
           const deliveryResult = args;
           resolve(deliveryResult);
         }
-      } else if (type === 'decref') {
-        const [vref, count] = args;
-        vatDecref(vref, count);
       } else {
         parentLog(`unrecognized uplink message ${type}`);
       }

--- a/packages/SwingSet/src/kernel/vatManager/manager-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-subprocess-node.js
@@ -24,7 +24,7 @@ function parentLog(first, ...args) {
 }
 
 export function makeNodeSubprocessFactory(tools) {
-  const { startSubprocessWorker, kernelKeeper, testLog, decref } = tools;
+  const { startSubprocessWorker, kernelKeeper, testLog } = tools;
 
   function createFromBundle(vatID, bundle, managerOptions) {
     const {
@@ -74,10 +74,6 @@ export function makeNodeSubprocessFactory(tools) {
       doSyscall(vatSyscallObject);
     }
 
-    function vatDecref(vref, count) {
-      decref(vatID, vref, count);
-    }
-
     // start the worker and establish a connection
     const { fromChild, toChild, terminate, done } = startSubprocessWorker();
 
@@ -116,9 +112,6 @@ export function makeNodeSubprocessFactory(tools) {
           const deliveryResult = args;
           resolve(deliveryResult);
         }
-      } else if (type === 'decref') {
-        const [vref, count] = args;
-        vatDecref(vref, count);
       } else {
         parentLog(`unrecognized uplink message ${type}`);
       }

--- a/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
@@ -20,7 +20,6 @@ const decoder = new TextDecoder();
  *   kernelKeeper: KernelKeeper,
  *   startXSnap: (name: string, handleCommand: SyncHandler) => Promise<XSnap>,
  *   testLog: (...args: unknown[]) => void,
- *   decref: (vatID: unknown, vref: unknown, count: number) => void,
  * }} tools
  * @returns { VatManagerFactory }
  *
@@ -35,7 +34,6 @@ export function makeXsSubprocessFactory({
   kernelKeeper,
   startXSnap,
   testLog,
-  decref,
 }) {
   /**
    * @param { unknown } vatID
@@ -73,11 +71,6 @@ export function makeXsSubprocessFactory({
       return doSyscall(vatSyscallObject);
     }
 
-    /** @type { (vref: unknown, count: number) => void } */
-    function vatDecref(vref, count) {
-      decref(vatID, vref, count);
-    }
-
     /** @type { (item: Tagged) => unknown } */
     function handleUpstream([type, ...args]) {
       parentLog(vatID, `handleUpstream`, type, args.length);
@@ -99,12 +92,6 @@ export function makeXsSubprocessFactory({
         case 'testLog':
           testLog(...args);
           return ['OK'];
-        case 'decref': {
-          const [vref, count] = args;
-          assert(typeof count === 'number');
-          vatDecref(vref, count);
-          return ['OK'];
-        }
         case 'transformTildot': {
           const [extjs] = args;
           try {


### PR DESCRIPTION
This was a false start on the GC task. Previously we thought vat-side
finalizers would call a vat-specific `decref` function at spontaneous times,
and the kernel would accumulate the dropped references for later processing.
Now we have liveslots collect the finalizer results and perform a
non-transcript-enforced syscall.dropImports at the end of crank.

This removes `testTrackDecref` from `kernelOptions`.