### PR TITLE
fix(swingset): when a static vat dies, tolerate lack of next-of-kin

### DIFF
--- a/packages/SwingSet/src/kernel/vatAdmin/vatAdminWrapper.js
+++ b/packages/SwingSet/src/kernel/vatAdmin/vatAdminWrapper.js
@@ -68,6 +68,13 @@ export function buildRootObject(vatPowers) {
 
   // the kernel sends this when the vat halts
   function vatTerminated(vatID, shouldReject, info) {
+    if (!running.has(vatID)) {
+      // a static vat terminated, so we have nobody to notify
+      console.log(`DANGER: static vat ${vatID} terminated`);
+      // TODO: consider halting the kernel if this happens, static vats
+      // aren't supposed to just keel over and die
+      return;
+    }
     const { resolve, reject } = running.get(vatID);
     running.delete(vatID);
     if (shouldReject) {


### PR DESCRIPTION
`vatTerminated()` was choking during test-syscall-failure.js, because it want
to find a Promise to resolve/reject, and static vats don't have a creator
waiting to be notified about their death.

This replaces the ugly internal error with a simple warning. The death of a
static vat means something has gone seriously wrong, and we should consider
halting the kernel, but this internal error was not the right way to display
it.