### PR TITLE
Update kerneldump to work with SES

### DIFF
--- a/packages/swingset-runner/bin/kerneldump
+++ b/packages/swingset-runner/bin/kerneldump
@@ -4,5 +4,12 @@
  * Simple boilerplate program providing linkage to launch an application written using modules within the
  * as yet not-entirely-ESM-supporting version of NodeJS.
  */
+
+// LMDB bindings need to be imported before lockdown.
+import 'node-lmdb';
+
+// Now do lockdown.
+import '@agoric/install-ses';
 import { main } from '../src/kerneldump.js';
+
 main();


### PR DESCRIPTION
Kerneldump uses LMDB, which has gone and gotten itself all entangled with SES, so the startup needed a tweak.