### PR TITLE
fix(ERTP): avoid jessie warning

### DIFF
--- a/packages/ERTP/src/issuer.js
+++ b/packages/ERTP/src/issuer.js
@@ -1,7 +1,8 @@
 // @ts-check
 /* global makeWeakStore */
 
-'use jessie';
+// Let's hold off on this until agoric-sdk/issues/2704 is addressed.
+// 'use jessie';
 
 import { assert, details as X } from '@agoric/assert';
 import { makeExternalStore } from '@agoric/store';


### PR DESCRIPTION
Let's hold off on `use jessie` until #2704 is addressed.