### PR TITLE
schedule vat creation on the run-queue

### DIFF
--- a/packages/SwingSet/src/kernel/vatAdmin/vatAdmin-src.js
+++ b/packages/SwingSet/src/kernel/vatAdmin/vatAdmin-src.js
@@ -21,7 +21,7 @@ import { Far } from '@agoric/marshal';
 
 export function buildRootDeviceNode({ endowments, serialize }) {
   const {
-    create: kernelVatCreationFn,
+    pushCreateVatEvent,
     stats: kernelVatStatsFn,
     terminate: kernelTerminateVatFn,
   } = endowments;
@@ -31,12 +31,12 @@ export function buildRootDeviceNode({ endowments, serialize }) {
     // Called by the wrapper vat to create a new vat. Gets a new ID from the
     // kernel's vat creator fn. Remember that the root object will arrive
     // separately. Clean up the outgoing and incoming arguments.
-    create(bundle, options) {
-      const vatID = kernelVatCreationFn({ bundle }, options);
+    create(bundle, options = {}) {
+      const vatID = pushCreateVatEvent({ bundle }, options);
       return vatID;
     },
-    createByName(bundleName, options) {
-      const vatID = kernelVatCreationFn({ bundleName }, options);
+    createByName(bundleName, options = {}) {
+      const vatID = pushCreateVatEvent({ bundleName }, options);
       return vatID;
     },
     terminateWithFailure(vatID, reason) {


### PR DESCRIPTION
This handles properly async vat creation, such as the process used by
subprocess-xsnap, in which the vat isn't ready for use right away.
Previously, we queued the "vat ready" message (to vatAdmin) at a random time,
which was both non-deterministic, and it left the run-queue empty, making
tests and certain runtime configurations think the kernel was idle, exiting
too early.

Now, when the vatAdminVat uses its device node to create a dynamic vat, we
merely queue a new create-vat event on the run-queue. Later, when this
arrives at the front of the queue, we perform a crank which starts the vat
manager and waits for it to complete. Any state changes that result from this
process (such as queueing the vat-is-ready message) get committed as a part
of this crank.

closes #2911