### PR TITLE
Load virtual objects when accessed, not when deserialized

### DIFF
--- a/packages/SwingSet/test/virtualObjects/test-representatives.js
+++ b/packages/SwingSet/test/virtualObjects/test-representatives.js
@@ -1,9 +1,15 @@
 /* global __dirname */
+// eslint-disable-next-line import/order
 import { test } from '../../tools/prepare-test-env-ava';
 
-// eslint-disable-next-line import/order
 import path from 'path';
-import { buildVatController } from '../../src/index';
+
+import { initSwingStore } from '@agoric/swing-store-simple';
+import {
+  buildVatController,
+  initializeSwingset,
+  makeSwingsetController,
+} from '../../src/index';
 import makeNextLog from '../make-nextlog';
 
 function capdata(body, slots = []) {
@@ -34,7 +40,7 @@ test('virtual object representatives', async t => {
     },
   };
 
-  const c = await buildVatController(config);
+  const c = await buildVatController(config, []);
   const nextLog = makeNextLog(c);
 
   await c.run();
@@ -150,4 +156,179 @@ test('virtual object representatives', async t => {
     'testCacheOverflow catches Error: cache overflowed with objects being initialized',
   ]);
   t.deepEqual(c.kpResolution(rz2), capdata('"overflow"'));
+});
+
+test('exercise cache', async t => {
+  const config = {
+    bootstrap: 'bootstrap',
+    vats: {
+      bootstrap: {
+        sourceSpec: path.resolve(__dirname, 'vat-representative-bootstrap.js'),
+        creationOptions: {
+          virtualObjectCacheSize: 3,
+        },
+      },
+    },
+  };
+
+  const log = [];
+
+  const storage = initSwingStore().storage;
+  function vsKey(key) {
+    return key.match(/^\w+\.vs\./);
+  }
+  const loggingStorage = {
+    has: key => storage.has(key),
+    getKeys: (start, end) => storage.getKeys(start, end),
+    get(key) {
+      const result = storage.get(key);
+      if (vsKey(key)) {
+        log.push(['get', key, result]);
+      }
+      return result;
+    },
+    set(key, value) {
+      if (vsKey(key)) {
+        log.push(['set', key, value]);
+      }
+      storage.set(key, value);
+    },
+    delete(key) {
+      if (vsKey(key)) {
+        log.push(['delete', key]);
+      }
+      storage.delete(key);
+    },
+  };
+
+  const bootstrapResult = await initializeSwingset(config, [], loggingStorage);
+  const c = await makeSwingsetController(loggingStorage, {});
+
+  const nextLog = makeNextLog(c);
+
+  await c.run();
+  t.deepEqual(c.kpResolution(bootstrapResult), capargs('bootstrap done'));
+
+  async function doSimple(method, what, ...args) {
+    let sendArgs;
+    if (what) {
+      const whatArg = {
+        '@qclass': 'slot',
+        iface: 'Alleged: thing',
+        index: 0,
+      };
+      sendArgs = capargs([whatArg, ...args], [what]);
+    } else {
+      sendArgs = capargs(args);
+    }
+    const r = c.queueToVatExport('bootstrap', 'o+0', method, sendArgs);
+    await c.run();
+    t.is(c.kpStatus(r), 'fulfilled');
+    t.deepEqual(nextLog(), []);
+    return r;
+  }
+
+  async function make(name, holdIt, expect) {
+    const r = await doSimple('makeThing', null, name, holdIt);
+    const result = c.kpResolution(r);
+    t.deepEqual(result, slot0('thing', expect));
+    return result.slots[0];
+  }
+  async function read(what, expect) {
+    const r = await doSimple('readThing', what);
+    t.deepEqual(c.kpResolution(r), capargs(expect));
+  }
+  async function readHeld(expect) {
+    const r = await doSimple('readHeldThing', null);
+    t.deepEqual(c.kpResolution(r), capargs(expect));
+  }
+  async function write(what, newName) {
+    await doSimple('writeThing', what, newName);
+  }
+  async function writeHeld(newName) {
+    await doSimple('writeHeldThing', null, newName);
+  }
+  async function forgetHeld() {
+    await doSimple('forgetHeldThing', null);
+  }
+  async function hold(what) {
+    await doSimple('holdThing', what);
+  }
+  function thingID(num) {
+    return `v1.vs.o+1/${num}`;
+  }
+  function thingVal(name) {
+    return JSON.stringify({
+      name: capdata(JSON.stringify(name)),
+    });
+  }
+
+  // expected kernel object ID allocations
+  const T1 = 'ko25';
+  const T2 = 'ko26';
+  const T3 = 'ko27';
+  const T4 = 'ko28';
+  const T5 = 'ko29';
+  const T6 = 'ko30';
+  const T7 = 'ko31';
+  const T8 = 'ko32';
+
+  // init cache - []
+  await make('thing1', true, T1); // make t1 - [t1]
+  await make('thing2', false, T2); // make t2 - [t2 t1]
+  await read(T1, 'thing1'); // refresh t1 - [t1 t2]
+  await read(T2, 'thing2'); // refresh t2 - [t2 t1]
+  await readHeld('thing1'); // cache unchanged - [t2 t1]
+
+  await make('thing3', false, T3); // make t3 - [t3 t2 t1]
+  await make('thing4', false, T4); // make t4 - [t4 t3 t2 t1]
+  t.deepEqual(log, []);
+  await make('thing5', false, T5); // evict t1, make t5 - [t5 t4 t3 t2] t1
+  t.deepEqual(log.shift(), ['set', thingID(1), thingVal('thing1')]);
+  await make('thing6', false, T6); // evict t2, make t6 - [t6 t5 t4 t3] t2
+  t.deepEqual(log.shift(), ['set', thingID(2), thingVal('thing2')]);
+  await make('thing7', false, T7); // evict t3, make t7 - [t7 t6 t5 t4]
+  t.deepEqual(log.shift(), ['set', thingID(3), thingVal('thing3')]);
+  await make('thing8', false, T8); // evict t4, make t8 - [t8 t7 t6 t5]
+  t.deepEqual(log.shift(), ['set', thingID(4), thingVal('thing4')]);
+
+  await read(T2, 'thing2'); // reanimate t2, evict t5 - [t2 t8 t7 t6]
+  t.deepEqual(log.shift(), ['get', thingID(2), thingVal('thing2')]);
+  t.deepEqual(log.shift(), ['set', thingID(5), thingVal('thing5')]);
+  await readHeld('thing1'); // reanimate t1, evict t6 - [t1 t2 t8 t7]
+  t.deepEqual(log.shift(), ['get', thingID(1), thingVal('thing1')]);
+  t.deepEqual(log.shift(), ['set', thingID(6), thingVal('thing6')]);
+
+  await write(T2, 'thing2 updated'); // refresh t2 - [t2 t1 t8 t7]
+  await writeHeld('thing1 updated'); // cache unchanged - [t2 t1 t8 t7]
+
+  await read(T8, 'thing8'); // refresh t8 - [t8 t2 t1 t7]
+  await read(T7, 'thing7'); // refresh t7 - [t7 t8 t2 t1]
+  t.deepEqual(log, []);
+  await read(T6, 'thing6'); // reanimate t6, evict t1 - [t6 t7 t8 t2]
+  t.deepEqual(log.shift(), ['get', thingID(6), thingVal('thing6')]);
+  t.deepEqual(log.shift(), ['set', thingID(1), thingVal('thing1 updated')]);
+  await read(T5, 'thing5'); // reanimate t5, evict t2 - [t5 t6 t7 t8]
+  t.deepEqual(log.shift(), ['get', thingID(5), thingVal('thing5')]);
+  t.deepEqual(log.shift(), ['set', thingID(2), thingVal('thing2 updated')]);
+  await read(T4, 'thing4'); // reanimate t4, evict t8 - [t4 t5 t6 t7]
+  t.deepEqual(log.shift(), ['get', thingID(4), thingVal('thing4')]);
+  t.deepEqual(log.shift(), ['set', thingID(8), thingVal('thing8')]);
+  await read(T3, 'thing3'); // reanimate t3, evict t7 - [t3 t4 t5 t6]
+  t.deepEqual(log.shift(), ['get', thingID(3), thingVal('thing3')]);
+  t.deepEqual(log.shift(), ['set', thingID(7), thingVal('thing7')]);
+
+  await read(T2, 'thing2 updated'); // reanimate t2, evict t6 - [t2 t3 t4 t5]
+  t.deepEqual(log.shift(), ['get', thingID(2), thingVal('thing2 updated')]);
+  await readHeld('thing1 updated'); // reanimate t1, evict t5 - [t1 t2 t3 t4]
+  t.deepEqual(log.shift(), ['get', thingID(1), thingVal('thing1 updated')]);
+
+  await forgetHeld(); // cache unchanged - [t1 t2 t3 t4]
+  await hold(T8); // cache unchanged - [t1 t2 t3 t4]
+  t.deepEqual(log, []);
+  await read(T7, 'thing7'); // reanimate t7, evict t4 - [t7 t1 t2 t3]
+  t.deepEqual(log.shift(), ['get', thingID(7), thingVal('thing7')]);
+  await writeHeld('thing8 updated'); // reanimate t8, evict t3 - [t8 t7 t1 t2]
+  t.deepEqual(log.shift(), ['get', thingID(8), thingVal('thing8')]);
+  t.deepEqual(log, []);
 });

--- a/packages/SwingSet/test/virtualObjects/test-virtualObjectCache.js
+++ b/packages/SwingSet/test/virtualObjects/test-virtualObjectCache.js
@@ -72,23 +72,18 @@ test('cache overflow and refresh', t => {
 
   // lookup that has no effect
   things[0] = cache.lookup('t0'); // cache: t0, t2, t5, t4
+  things[0].rawData = 'changed thing #0';
   things[0].dirty = true; // pretend we changed it
-  t.is(things[0].rawData, 'thing #0');
+  t.is(things[0].rawData, 'changed thing #0');
   t.is(things[3].rawData, null);
-  t.deepEqual(store.getLog(), [
-    ['fetch', 't0', 'thing #0'],
-    ['store', 't3', 'thing #3'],
-  ]);
+  t.deepEqual(store.getLog(), [['store', 't3', 'thing #3']]);
 
   // verify refresh
   cache.refresh(things[4]); // cache: t4, t0, t2, t5
   things[1] = cache.lookup('t1'); // cache: t1, t4, t0, t2
-  t.is(things[1].rawData, 'thing #1');
+  t.is(things[1].rawData, null);
   t.is(things[5].rawData, null);
-  t.deepEqual(store.getLog(), [
-    ['fetch', 't1', 'thing #1'],
-    ['store', 't5', 'thing #5'],
-  ]);
+  t.deepEqual(store.getLog(), [['store', 't5', 'thing #5']]);
 
   // verify that everything is there
   cache.flush(); // cache: empty
@@ -100,11 +95,11 @@ test('cache overflow and refresh', t => {
   t.is(things[5].rawData, null);
   t.deepEqual(store.getLog(), [
     ['store', 't2', 'thing #2'],
-    ['store', 't0', 'thing #0'],
+    ['store', 't0', 'changed thing #0'],
     ['store', 't4', 'thing #4'],
   ]);
   t.deepEqual(store.dump(), [
-    ['t0', 'thing #0'],
+    ['t0', 'changed thing #0'],
     ['t1', 'thing #1'],
     ['t2', 'thing #2'],
     ['t3', 'thing #3'],
@@ -134,13 +129,7 @@ test('cache overflow and refresh', t => {
   t.is(things[0].rawData, null);
   t.is(things[5].rawData, 'new thing #5');
   t.deepEqual(store.getLog(), [
-    ['fetch', 't0', 'thing #0'],
-    ['fetch', 't1', 'thing #1'],
-    ['fetch', 't2', 'thing #2'],
-    ['fetch', 't3', 'thing #3'],
-    ['fetch', 't4', 'thing #4'],
     ['store', 't0', 'new thing #0'],
-    ['fetch', 't5', 'thing #5'],
     ['store', 't1', 'new thing #1'],
   ]);
   t.deepEqual(store.dump(), [

--- a/packages/SwingSet/test/virtualObjects/test-virtualObjectManager.js
+++ b/packages/SwingSet/test/virtualObjects/test-virtualObjectManager.js
@@ -7,7 +7,6 @@ import { makeFakeVirtualObjectManager } from '../../tools/fakeVirtualObjectManag
 function capdata(body, slots = []) {
   return harden({ body, slots });
 }
-const s = JSON.stringify;
 
 function makeThingInstance(state) {
   return {
@@ -39,6 +38,14 @@ function makeThingInstance(state) {
   };
 }
 
+function thingVal(counter, label, resetCounter) {
+  return JSON.stringify({
+    counter: capdata(JSON.stringify(counter)),
+    label: capdata(JSON.stringify(label)),
+    resetCounter: capdata(JSON.stringify(resetCounter)),
+  });
+}
+
 function makeZotInstance(state) {
   return {
     init(arbitrary = 47, name = 'Bob', tag = 'say what?') {
@@ -65,6 +72,15 @@ function makeZotInstance(state) {
   };
 }
 
+function zotVal(arbitrary, name, tag, count) {
+  return JSON.stringify({
+    arbitrary: capdata(JSON.stringify(arbitrary)),
+    name: capdata(JSON.stringify(name)),
+    tag: capdata(JSON.stringify(tag)),
+    count: capdata(JSON.stringify(count)),
+  });
+}
+
 test('virtual object operations', t => {
   const { makeKind, flushCache, dumpStore } = makeFakeVirtualObjectManager(3);
 
@@ -85,12 +101,11 @@ test('virtual object operations', t => {
   const zot3 = zotMaker(47, 'Carol', 'as if...');
   const zot4 = zotMaker(66, 'Dave', 'you and what army?');
 
-  // prettier-ignore
   t.deepEqual(dumpStore(), [
-    ['o+1/1', s({counter:capdata('0'),label:capdata('"thing-1"'),resetCounter:capdata('0')})],
-    ['o+1/2', s({counter:capdata('100'),label:capdata('"thing-2"'),resetCounter:capdata('0')})],
-    ['o+1/3', s({counter:capdata('200'),label:capdata('"thing-3"'),resetCounter:capdata('0')})],
-    ['o+1/4', s({counter:capdata('300'),label:capdata('"thing-4"'),resetCounter:capdata('0')})],
+    ['o+1/1', thingVal(0, 'thing-1', 0)],
+    ['o+1/2', thingVal(100, 'thing-2', 0)],
+    ['o+1/3', thingVal(200, 'thing-3', 0)],
+    ['o+1/4', thingVal(300, 'thing-4', 0)],
   ]);
 
   // phase 2: first batch-o-stuff
@@ -106,16 +121,15 @@ test('virtual object operations', t => {
     thing2.describe(),
     'thing-2 counter has been reset 0 times and is now 100',
   );
-  // prettier-ignore
   t.deepEqual(dumpStore(), [
-    ['o+1/1', s({counter:capdata('3'),label:capdata('"thing-1"'),resetCounter:capdata('0')})],
-    ['o+1/2', s({counter:capdata('100'),label:capdata('"thing-2"'),resetCounter:capdata('0')})],
-    ['o+1/3', s({counter:capdata('200'),label:capdata('"thing-3"'),resetCounter:capdata('0')})],
-    ['o+1/4', s({counter:capdata('300'),label:capdata('"thing-4"'),resetCounter:capdata('0')})],
-    ['o+2/1', s({arbitrary:capdata('23'),name:capdata('"Alice"'),tag:capdata('"is this on?"'),count:capdata('2')})],
-    ['o+2/2', s({arbitrary:capdata('29'),name:capdata('"Bob"'),tag:capdata('"what are you saying?"'),count:capdata('0')})],
-    ['o+2/3', s({arbitrary:capdata('47'),name:capdata('"Carol"'),tag:capdata('"as if..."'),count:capdata('0')})],
-    ['o+2/4', s({arbitrary:capdata('66'),name:capdata('"Dave"'),tag:capdata('"you and what army?"'),count:capdata('0')})],
+    ['o+1/1', thingVal(3, 'thing-1', 0)],
+    ['o+1/2', thingVal(100, 'thing-2', 0)],
+    ['o+1/3', thingVal(200, 'thing-3', 0)],
+    ['o+1/4', thingVal(300, 'thing-4', 0)],
+    ['o+2/1', zotVal(23, 'Alice', 'is this on?', 2)],
+    ['o+2/2', zotVal(29, 'Bob', 'what are you saying?', 0)],
+    ['o+2/3', zotVal(47, 'Carol', 'as if...', 0)],
+    ['o+2/4', zotVal(66, 'Dave', 'you and what army?', 0)],
   ]);
 
   // phase 3: second batch-o-stuff
@@ -136,31 +150,29 @@ test('virtual object operations', t => {
     thing4.describe(),
     'thing-4 counter has been reset 1 times and is now 1000',
   );
-  // prettier-ignore
   t.deepEqual(dumpStore(), [
-    ['o+1/1', s({counter:capdata('4'),label:capdata('"thing-1"'),resetCounter:capdata('0')})],
-    ['o+1/2', s({counter:capdata('100'),label:capdata('"thing-2"'),resetCounter:capdata('0')})],
-    ['o+1/3', s({counter:capdata('200'),label:capdata('"thing-3"'),resetCounter:capdata('0')})],
-    ['o+1/4', s({counter:capdata('1000'),label:capdata('"thing-4"'),resetCounter:capdata('1')})],
-    ['o+2/1', s({arbitrary:capdata('23'),name:capdata('"Alice"'),tag:capdata('"is this on?"'),count:capdata('3')})],
-    ['o+2/2', s({arbitrary:capdata('29'),name:capdata('"Bob"'),tag:capdata('"what are you saying?"'),count:capdata('2')})],
-    ['o+2/3', s({arbitrary:capdata('47'),name:capdata('"Chester"'),tag:capdata('"as if..."'),count:capdata('3')})],
-    ['o+2/4', s({arbitrary:capdata('66'),name:capdata('"Dave"'),tag:capdata('"you and what army?"'),count:capdata('1')})],
+    ['o+1/1', thingVal(4, 'thing-1', 0)],
+    ['o+1/2', thingVal(100, 'thing-2', 0)],
+    ['o+1/3', thingVal(200, 'thing-3', 0)],
+    ['o+1/4', thingVal(1000, 'thing-4', 1)],
+    ['o+2/1', zotVal(23, 'Alice', 'is this on?', 3)],
+    ['o+2/2', zotVal(29, 'Bob', 'what are you saying?', 2)],
+    ['o+2/3', zotVal(47, 'Chester', 'as if...', 3)],
+    ['o+2/4', zotVal(66, 'Dave', 'you and what army?', 1)],
   ]);
 
   // phase 4: flush test
   t.is(thing1.inc(), 5);
   flushCache();
-  // prettier-ignore
   t.deepEqual(dumpStore(), [
-    ['o+1/1', s({counter:capdata('5'),label:capdata('"thing-1"'),resetCounter:capdata('0')})],
-    ['o+1/2', s({counter:capdata('100'),label:capdata('"thing-2"'),resetCounter:capdata('0')})],
-    ['o+1/3', s({counter:capdata('201'),label:capdata('"thing-3"'),resetCounter:capdata('0')})],
-    ['o+1/4', s({counter:capdata('1000'),label:capdata('"thing-4"'),resetCounter:capdata('1')})],
-    ['o+2/1', s({arbitrary:capdata('23'),name:capdata('"Alice"'),tag:capdata('"is this on?"'),count:capdata('3')})],
-    ['o+2/2', s({arbitrary:capdata('29'),name:capdata('"Bob"'),tag:capdata('"what are you saying?"'),count:capdata('2')})],
-    ['o+2/3', s({arbitrary:capdata('47'),name:capdata('"Chester"'),tag:capdata('"as if..."'),count:capdata('3')})],
-    ['o+2/4', s({arbitrary:capdata('66'),name:capdata('"Dave"'),tag:capdata('"you and what army?"'),count:capdata('2')})],
+    ['o+1/1', thingVal(5, 'thing-1', 0)],
+    ['o+1/2', thingVal(100, 'thing-2', 0)],
+    ['o+1/3', thingVal(201, 'thing-3', 0)],
+    ['o+1/4', thingVal(1000, 'thing-4', 1)],
+    ['o+2/1', zotVal(23, 'Alice', 'is this on?', 3)],
+    ['o+2/2', zotVal(29, 'Bob', 'what are you saying?', 2)],
+    ['o+2/3', zotVal(47, 'Chester', 'as if...', 3)],
+    ['o+2/4', zotVal(66, 'Dave', 'you and what army?', 2)],
   ]);
 });
 

--- a/packages/SwingSet/test/virtualObjects/vat-representative-bootstrap.js
+++ b/packages/SwingSet/test/virtualObjects/vat-representative-bootstrap.js
@@ -54,11 +54,46 @@ const zotMaker = makeKind(makeZotInstance);
 
 export function buildRootObject(vatPowers) {
   const { testLog } = vatPowers;
+  let heldThing;
 
   return Far('root', {
     bootstrap() {
       return 'bootstrap done';
     },
+    makeThing(name, hold) {
+      const thing = thingMaker(name);
+      if (hold) {
+        heldThing = thing;
+      }
+      return thing;
+    },
+    readThing(what) {
+      return what.getName();
+    },
+    readHeldThing() {
+      if (heldThing) {
+        return heldThing.getName();
+      } else {
+        throw Error('no held thing');
+      }
+    },
+    writeThing(what, newName) {
+      what.rename(newName);
+    },
+    writeHeldThing(newName) {
+      if (heldThing) {
+        heldThing.rename(newName);
+      } else {
+        throw Error('no held thing');
+      }
+    },
+    holdThing(what) {
+      heldThing = what;
+    },
+    forgetHeldThing() {
+      heldThing = null;
+    },
+
     testA(name, mode) {
       // mode 1: make thing, return thing
       // mode 2: make thing, return initial self


### PR DESCRIPTION
This is a step towards making virtual object references comparable with `===` by managing representatives using weak refs (see #1968)