### PR TITLE
fix(swingset): stop rejecting metered=true for xs-worker

### DIFF
--- a/packages/SwingSet/src/kernel/vatManager/factory.js
+++ b/packages/SwingSet/src/kernel/vatManager/factory.js
@@ -87,7 +87,7 @@ export function makeVatManagerFactory({
       enableSetup,
     } = managerOptions;
 
-    if (metered && managerType !== 'local') {
+    if (metered && managerType !== 'local' && managerType !== 'xs-worker') {
       console.warn(
         `TODO: support metered with ${managerType}; using local as work-around`,
       );
@@ -97,7 +97,7 @@ export function makeVatManagerFactory({
         `TODO: stop using setup() with ${managerType}; using local as work-around`,
       );
     }
-    if (managerType === 'local' || metered || enableSetup) {
+    if (managerType === 'local' || enableSetup) {
       if (setup) {
         return localFactory.createFromSetup(
           vatID,

--- a/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
@@ -53,7 +53,6 @@ export function makeXsSubprocessFactory({
       enableDisavow,
       name,
     } = managerOptions;
-    assert(!managerOptions.metered, 'xs-worker: metered not supported yet');
     assert(
       !managerOptions.enableSetup,
       'xs-worker: enableSetup not supported at all',


### PR DESCRIPTION
Previously, any vat which wanted metering was forced to use worker=local,
even if they asked for something different. And worker=xs asserted that
metering was not requested. This removes both checks.

refs #2868