### PR TITLE
fix(liveslots): low-level vat dispatch() is now async

### DIFF
--- a/packages/SwingSet/src/kernel/vatManager/supervisor-helper.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-helper.js
@@ -29,15 +29,18 @@ function makeSupervisorDispatch(dispatch, waitUntilQuiescent) {
    *
    */
   async function dispatchToVat(delivery) {
-    // the (low-level) vat is not currently responsible for giving up agency:
-    // we enforce that ourselves for now
-    Promise.resolve(delivery)
+    // the (low-level) vat is responsible for giving up agency, but we still
+    // protect against exceptions
+    return Promise.resolve(delivery)
       .then(dispatch)
-      .catch(err =>
-        console.log(`error ${err} during vat dispatch of ${delivery}`),
+      .then(
+        () => harden(['ok', null, null]),
+        err => {
+          // TODO react more thoughtfully, maybe terminate the vat
+          console.log(`error ${err} during vat dispatch of ${delivery}`);
+          return harden(['error', `${err.message}`, null]);
+        },
       );
-    await waitUntilQuiescent();
-    return harden(['ok', null, null]);
   }
 
   return harden(dispatchToVat);

--- a/packages/SwingSet/test/liveslots-helpers.js
+++ b/packages/SwingSet/test/liveslots-helpers.js
@@ -1,4 +1,5 @@
 import { WeakRef, FinalizationRegistry } from '../src/weakref';
+import { waitUntilQuiescent } from '../src/waitUntilQuiescent';
 import { makeLiveSlots } from '../src/kernel/liveSlots';
 
 export function buildSyscall() {
@@ -37,7 +38,7 @@ export function makeDispatch(
   vatID = 'vatA',
   enableDisavow = false,
 ) {
-  const gcTools = harden({ WeakRef, FinalizationRegistry });
+  const gcTools = harden({ WeakRef, FinalizationRegistry, waitUntilQuiescent });
   const { setBuildRootObject, dispatch } = makeLiveSlots(
     syscall,
     vatID,


### PR DESCRIPTION
`dispatch()`, the low-level interface to each vat (generally provided by
liveslots), is now async. Vats are responsible for not resolving the promise
returned by `dispatch()` until the user-level code has finished running and
the crank is complete. Vats are given `waitUntilQuiescent` in their `gcTools`
argument to facilitate this.

This will make it possible for liveslots to run `gc()` and wait long enough
to give finalizers a chance to run (and then call `dropImports`) before the
crank is considered complete.

closes #2671
refs #2660