### PR TITLE
Reconcile some types and their implementation

### DIFF
--- a/packages/ERTP/src/displayInfo.js
+++ b/packages/ERTP/src/displayInfo.js
@@ -37,9 +37,6 @@ export const assertKeysAllowed = (allowedKeys, record) => {
 };
 
 export const assertDisplayInfo = allegedDisplayInfo => {
-  if (allegedDisplayInfo === undefined) {
-    return;
-  }
   assert(
     passStyleOf(allegedDisplayInfo) === 'copyRecord',
     X`A displayInfo can only be a pass-by-copy record: ${allegedDisplayInfo}`,
@@ -48,7 +45,11 @@ export const assertDisplayInfo = allegedDisplayInfo => {
   assertKeysAllowed(displayInfoKeys, allegedDisplayInfo);
 };
 
-export const coerceDisplayInfo = allegedDisplayInfo => {
+/**
+ * @param {any} [allegedDisplayInfo={}]
+ * @returns {DisplayInfo}
+ */
+export const coerceDisplayInfo = (allegedDisplayInfo = {}) => {
   allegedDisplayInfo = pureCopy(allegedDisplayInfo);
   assertDisplayInfo(allegedDisplayInfo);
   return allegedDisplayInfo;

--- a/packages/ERTP/src/displayInfo.js
+++ b/packages/ERTP/src/displayInfo.js
@@ -36,21 +36,27 @@ export const assertKeysAllowed = (allowedKeys, record) => {
   );
 };
 
-export const assertDisplayInfo = allegedDisplayInfo => {
+// eslint-disable-next-line jsdoc/require-returns-check
+/**
+ * @param {DisplayInfo} allegedDisplayInfo
+ * @returns {asserts allegedDisplayInfo is DisplayInfo}
+ */
+function assertDisplayInfo(allegedDisplayInfo) {
   assert(
     passStyleOf(allegedDisplayInfo) === 'copyRecord',
     X`A displayInfo can only be a pass-by-copy record: ${allegedDisplayInfo}`,
   );
   const displayInfoKeys = harden(['decimalPlaces']);
   assertKeysAllowed(displayInfoKeys, allegedDisplayInfo);
-};
+}
+export { assertDisplayInfo };
 
 /**
- * @param {any} [allegedDisplayInfo={}]
+ * @param {DisplayInfo} [allegedDisplayInfo={}]
  * @returns {DisplayInfo}
  */
 export const coerceDisplayInfo = (allegedDisplayInfo = {}) => {
-  allegedDisplayInfo = pureCopy(allegedDisplayInfo);
-  assertDisplayInfo(allegedDisplayInfo);
-  return allegedDisplayInfo;
+  const copyDisplayInfo = pureCopy(allegedDisplayInfo);
+  assertDisplayInfo(copyDisplayInfo);
+  return copyDisplayInfo;
 };

--- a/packages/ERTP/src/issuer.js
+++ b/packages/ERTP/src/issuer.js
@@ -22,10 +22,10 @@ import './types';
 function makeIssuerKit(
   allegedName,
   amountMathKind = MathKind.NAT,
-  displayInfo = undefined,
+  rawDisplayInfo = harden({}),
 ) {
   assert.typeof(allegedName, 'string');
-  displayInfo = coerceDisplayInfo(displayInfo);
+  const displayInfo = coerceDisplayInfo(rawDisplayInfo);
 
   /** @type {Brand} */
   const brand = Far(makeFarName(allegedName, ERTPKind.BRAND), {

--- a/packages/ERTP/src/issuer.js
+++ b/packages/ERTP/src/issuer.js
@@ -22,10 +22,10 @@ import './types';
 function makeIssuerKit(
   allegedName,
   amountMathKind = MathKind.NAT,
-  rawDisplayInfo = harden({}),
+  displayInfo = harden({}),
 ) {
   assert.typeof(allegedName, 'string');
-  const displayInfo = coerceDisplayInfo(rawDisplayInfo);
+  displayInfo = coerceDisplayInfo(displayInfo);
 
   /** @type {Brand} */
   const brand = Far(makeFarName(allegedName, ERTPKind.BRAND), {

--- a/packages/ERTP/src/issuer.js
+++ b/packages/ERTP/src/issuer.js
@@ -27,6 +27,7 @@ function makeIssuerKit(
   assert.typeof(allegedName, 'string');
   displayInfo = coerceDisplayInfo(displayInfo);
 
+  /** @type {Brand} */
   const brand = Far(makeFarName(allegedName, ERTPKind.BRAND), {
     isMyIssuer: allegedIssuerP => {
       return E.when(allegedIssuerP, allegedIssuer => {

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -289,7 +289,7 @@
  * @callback MakeIssuerKit
  * @param {string} allegedName
  * @param {AmountMathKind} [amountMathKind=MathKind.NAT]
- * @param {DisplayInfo=} [displayInfo=undefined]
+ * @param {DisplayInfo} [displayInfo={}]
  * @returns {IssuerKit}
  *
  * The allegedName becomes part of the brand in asset descriptions. The

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -16,7 +16,7 @@ test('issuer.getBrand, brand.isMyIssuer', t => {
   );
   t.is(issuer.getAllegedName(), myBrand.getAllegedName());
   t.is(issuer.getAllegedName(), 'fungible');
-  t.is(brand.getDisplayInfo(), undefined);
+  t.deepEqual(brand.getDisplayInfo(), {});
 });
 
 test('brand.getDisplayInfo()', t => {

--- a/packages/SwingSet/src/vats/network/types.js
+++ b/packages/SwingSet/src/vats/network/types.js
@@ -31,7 +31,7 @@
  * @typedef {Object} ListenHandler A handler for incoming connections
  * @property {(port: Port, l: ListenHandler) => Promise<void>} [onListen] The listener has been registered
  * @property {(port: Port, localAddr: Endpoint, remoteAddr: Endpoint, l: ListenHandler) => Promise<ConnectionHandler>} onAccept A new connection is incoming
- * @property {(port: Port, localAddr: Endpoint, remoteAddr: Endpoint, l: ListenHandler) => Promise<void>} onReject The connection was rejected
+ * @property {(port: Port, localAddr: Endpoint, remoteAddr: Endpoint, l: ListenHandler) => Promise<void>} [onReject] The connection was rejected
  * @property {(port: Port, rej: any, l: ListenHandler) => Promise<void>} [onError] There was an error while listening
  * @property {(port: Port, l: ListenHandler) => Promise<void>} [onRemove] The listener has been removed
  */

--- a/packages/assert/exported.js
+++ b/packages/assert/exported.js
@@ -1,0 +1,1 @@
+import './src/types';

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -42,6 +42,7 @@
   },
   "files": [
     "src/",
+    "exported.js",
     "NEWS.md"
   ],
   "ava": {

--- a/packages/dapp-svelte-wallet/api/src/internal-types.js
+++ b/packages/dapp-svelte-wallet/api/src/internal-types.js
@@ -12,8 +12,8 @@
 /**
  * @typedef {Object} PurseActions
  * @property {(receiverP: ERef<{ receive: (payment: Payment) => void }>, valueToSend: Value) => Promise<void>} send
- * @property {(payment: Payment) => Promise<Value>} receive
- * @property {(payment: Payment, amount: Amount=) => Promise<Value>} deposit
+ * @property {(payment: Payment) => Promise<Amount>} receive
+ * @property {(payment: Payment, amount: Amount=) => Promise<Amount>} deposit
  */
 
 /**

--- a/packages/eventual-send/src/index.d.ts
+++ b/packages/eventual-send/src/index.d.ts
@@ -6,6 +6,14 @@ type Property = string | number;
 
 type ERef<T> = PromiseLike<T> | T;
 
+// Type for an object that must only be invoked with E.  It supports a given
+// interface but declares all the functions as asyncable.
+export type EOnly<T> = T extends (...args: infer P) => infer R ?
+  (...args: P) => ERef<R> | EOnly<R>
+  : T extends Record<string | number | symbol, Function> ? ERef<{
+  [K in keyof T]: EOnly<T[K]>
+}> : ERef<T>;
+
 type Unpromise<T> = T extends ERef<infer U> ? U : T;
 
 type Parameters<T> = T extends (...args: infer T) => any ? T : any;

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -684,13 +684,16 @@ export { Remotable };
 /**
  * A concise convenience for the most common `Remotable` use.
  *
+ * @template T
  * @param {string} farName This name will be prepended with `Alleged: `
  * for now to form the `Remotable` `iface` argument.
- * @param {object} [remotable={}] The object used as the remotable
- * @returns {object} remotable, modified for debuggability
+ * @param {T|undefined} [remotable={}] The object used as the remotable
+ * @returns {T} remotable, modified for debuggability
  */
-const Far = (farName, remotable = {}) =>
-  Remotable(`Alleged: ${farName}`, undefined, remotable);
+const Far = (farName, remotable = undefined) => {
+  const r = remotable === undefined ? {} : remotable;
+  return Remotable(`Alleged: ${farName}`, undefined, r);
+};
 
 harden(Far);
 export { Far };

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -35,10 +35,10 @@ const { ownKeys } = Reflect;
  * The resulting copy is guaranteed to be pure data, as well as hardened.
  * Such a hardened, pure copy cannot be used as a communications path.
  *
- * @template T
- * @param {T & OnlyData} val input value.  NOTE: Must be hardened!
+ * @template {OnlyData} T
+ * @param {T} val input value.  NOTE: Must be hardened!
  * @param {WeakMap<any,any>} [already=new WeakMap()]
- * @returns {T & PureData} pure, hardened copy
+ * @returns {T} pure, hardened copy
  */
 function pureCopy(val, already = new WeakMap()) {
   // eslint-disable-next-line no-use-before-define

--- a/packages/marshal/src/passStyleOf.js
+++ b/packages/marshal/src/passStyleOf.js
@@ -7,6 +7,7 @@ import { assert, details as X, q } from '@agoric/assert';
 import { isPromise } from '@agoric/promise-kit';
 
 import './types';
+import '@agoric/assert/exported';
 
 // Setting this flag to true is what allows objects with `null` or
 // `Object.prototype` prototypes to be treated as remotable.  Setting to `false`
@@ -189,7 +190,7 @@ function isPassByCopyRecord(val) {
 /**
  * @callback Checker
  * @param {boolean} cond
- * @param {Parameters<typeof assert>[1]} details
+ * @param {Details=} details
  * @returns {boolean}
  */
 

--- a/packages/notifier/src/notifier.js
+++ b/packages/notifier/src/notifier.js
@@ -12,6 +12,11 @@ import {
 
 import './types';
 
+/**
+ * @template T
+ * @param {BaseNotifier<T>} baseNotifierP
+ * @returns {AsyncIterable<T> & SharableNotifier}
+ */
 export const makeNotifier = baseNotifierP => {
   const asyncIterable = makeAsyncIterableFromNotifier(baseNotifierP);
 

--- a/packages/notifier/src/types.js
+++ b/packages/notifier/src/types.js
@@ -66,9 +66,12 @@
 
 /**
  * @template T
- * @typedef {BaseNotifier<T> & AsyncIterable<T>} Notifier<T> an object that can
+ * @typedef {BaseNotifier<T> & AsyncIterable<T> & SharableNotifier} Notifier<T> an object that can
  * be used to get the current state or updates
- *
+ */
+
+/**
+ * @typedef {Object} SharableNotifier
  * @property {() => NotifierInternals} getSharableNotifierInternals
  * Used to replicate the multicast values at other sites. To manually create a
  * local representative of a Notification, do
@@ -103,9 +106,12 @@
 
 /**
  * @template T
- * @typedef {BaseSubscription<T> & AsyncIterable<T>} Subscription<T>
+ * @typedef {BaseSubscription<T> & AsyncIterable<T> & SharableSubscription} Subscription<T>
  * A form of AsyncIterable supporting distributed and multicast usage.
- *
+ */
+
+/**
+ * @typedef {Object} SharableSubscription
  * @property {() => SubscriptionInternals} getSharableSubscriptionInternals
  * Used to replicate the multicast values at other sites. To manually create a
  * local representative of a Subscription, do

--- a/packages/notifier/src/types.js
+++ b/packages/notifier/src/types.js
@@ -92,7 +92,7 @@
 // eslint-disable-next-line jsdoc/require-property
 /**
  * @template T
- * @typedef {Object} BaseSubscription<T>
+ * @typedef {{}} BaseSubscription<T>
  */
 
 /**

--- a/packages/vats/src/bootstrap.js
+++ b/packages/vats/src/bootstrap.js
@@ -538,7 +538,7 @@ export function buildRootObject(vatPowers, vatParameters) {
           return harden(makeEchoConnectionHandler());
         },
         async onListen(port, _listenHandler) {
-          console.debug(`listening on port: ${port}`);
+          console.debug(`listening on echo port: ${port}`);
         },
       }),
     );

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -85,7 +85,7 @@
     "require": [
       "esm"
     ],
-    "timeout": "10m"
+    "timeout": "20m"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/zoe/src/contracts/multipoolAutoswap/types.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/types.js
@@ -23,8 +23,6 @@
  * using makeSwapOutInvitation at the current price
  * @property {() => Record<string, Amount>} getPoolAllocation get an
  * AmountKeywordRecord showing the current balances in the pool.
- * @property {() => Array<Brand>} getAllPoolBrands get a list of all the brands
- * that have associated pools.
  */
 
 /**
@@ -88,7 +86,7 @@
  * AmountKeywordRecord showing the current balances in the pool for brand.
  * @property {() => Issuer} getQuoteIssuer - get the Issuer that attests to
  * the prices in the priceQuotes issued by the PriceAuthorities
- * @property {(brand: Brand) => {toCentral: PriceAuthority, fromCentral: PriceAuthority}}} getPriceAuthorities
+ * @property {(brand: Brand) => {toCentral: PriceAuthority, fromCentral: PriceAuthority}} getPriceAuthorities
  * get a pair of PriceAuthorities { toCentral, fromCentral } for requesting
  * Prices and notifications about changing prices.
  */

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -97,11 +97,8 @@
  * @property {() => void} assertAcceptingOffers
  * @property {(invitationHandle: InvitationHandle,
  *     initialAllocation: Allocation,
- *     proposal: ProposalRecord) => Promise<UserSeat> } makeUserSeat
- * @property {(initialAllocation: Allocation,
- *     proposal: ProposalRecord,
- *     exitObj: ExitObj,
- *     seatHandle: SeatHandle) => foo } makeNoEscrowSeat
+ *     proposal: ProposalRecord) => UserSeat } makeUserSeat
+ * @property {MakeNoEscrowSeat} makeNoEscrowSeat
  * @property {() => Instance} getInstance
  * @property {() => Object} getPublicFacet
  * @property {() => IssuerKeywordRecord} getIssuers

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -96,14 +96,17 @@
  * @typedef {Object} InstanceAdmin
  * @property {() => void} assertAcceptingOffers
  * @property {(invitationHandle: InvitationHandle,
-      initialAllocation: Allocation,
-      proposal: ProposalRecord) => UserSeat } makeUserSeat
+ *     initialAllocation: Allocation,
+ *     proposal: ProposalRecord) => Promise<UserSeat> } makeUserSeat
+ * @property {(initialAllocation: Allocation,
+ *     proposal: ProposalRecord,
+ *     exitObj: ExitObj,
+ *     seatHandle: SeatHandle) => foo } makeNoEscrowSeat
  * @property {() => Instance} getInstance
  * @property {() => Object} getPublicFacet
  * @property {() => IssuerKeywordRecord} getIssuers
  * @property {() => BrandKeywordRecord} getBrands
  * @property {() => Object} getTerms
- * @property {() => boolean} acceptingOffers
  * @property {(completion: Completion) => void} exitAllSeats
  * @property {(reason: TerminationReason) => void} failAllSeats
  * @property {() => void} stopAcceptingOffers

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -218,11 +218,7 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
             zoeSeatAdmins.forEach(zoeSeatAdmin => zoeSeatAdmin.fail(reason));
           },
           stopAcceptingOffers: () => (acceptingOffers = false),
-          makeUserSeat: async (
-            invitationHandle,
-            initialAllocation,
-            proposal,
-          ) => {
+          makeUserSeat: (invitationHandle, initialAllocation, proposal) => {
             const offerResultPromiseKit = makePromiseKit();
             // Don't trigger Node.js's UnhandledPromiseRejectionWarning.
             // This does not suppress any error messages.

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -198,7 +198,7 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
         const hasExited = zoeSeatAdmin => !zoeSeatAdmins.has(zoeSeatAdmin);
 
         /** @type {InstanceAdmin} */
-        return Far('instanceAdmin', {
+        const instanceAdmin = Far('instanceAdmin', {
           getPublicFacet: () => publicFacetPromiseKit.promise,
           getTerms,
           getIssuers,
@@ -278,6 +278,7 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
             return { userSeat, notifier, zoeSeatAdmin };
           },
         });
+        return instanceAdmin;
       };
 
       const instanceAdmin = makeInstanceAdmin();

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
@@ -133,7 +133,10 @@ test('median aggregator', /** @param {ExecutionContext} t */ async t => {
 
   // TODO: Port this to makeQuoteNotifier(amountIn, brandOut)
   // @ts-ignore fix needed
-  const notifier = E(pa).getPriceNotifier(brandIn, brandOut);
+  const notifier = E(pa).makeQuoteNotifier(
+    amountMath.make(brandIn, 1n),
+    brandOut,
+  );
   await E(aggregator.creatorFacet).initOracle(price1000.instance, {
     increment: 10n,
   });

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -378,7 +378,7 @@ test(`zcf.makeZCFMint - NAT`, async t => {
   };
   await testTerms(t, zcf, expected);
   t.is(issuerRecord.mathKind, MathKind.NAT);
-  t.is(issuerRecord.brand.getDisplayInfo(), undefined);
+  t.deepEqual(issuerRecord.brand.getDisplayInfo(), {});
 });
 
 test(`zcf.makeZCFMint - SET`, async t => {

--- a/packages/zoe/tools/types.js
+++ b/packages/zoe/tools/types.js
@@ -44,8 +44,8 @@
 
 /**
  * @typedef {Object} MutableQuote
- * @property {() => void} cancel
- * @property {() => void} updateLevel
+ * @property {(reason?: any) => void} cancel
+ * @property {(amountIn: Amount, amountOut: Amount) => void} updateLevel
  * @property {() => ERef<PriceQuote>} getPromise
  */
 


### PR DESCRIPTION
Clear up some potential oversights where types were broken.  I updated the types where the implementation had drifted, and the following are changes to the implementation where the types were clearly better than the code:

- @katelynsills `makeIssuerKit` allowed DisplayInfo to be `undefined`, but `Brand` typing said it was never `undefined`.  I changed `makeIssuerKit` to disallow `undefined`, and default to `{}`.
- @Chris-Hibbert `packages/zoe/src/contractSupport/priceAuthority.js` had drifted from the desired type; it didn't implement the new-style `makeQuoteNotifier`, so I took a stab at it.  We should probably have tests for the implementation.
