### PR TITLE
BREAKING CHANGE: move fakeVatAdmin into @agoric/zoe/tools/

### DIFF
--- a/packages/zoe/src/contractFacet/fakeVatAdmin.js
+++ b/packages/zoe/src/contractFacet/fakeVatAdmin.js
@@ -1,3 +1,0 @@
-// @ts-check
-
-export { makeFakeVatAdmin } from '../../tools/fakeVatAdmin';


### PR DESCRIPTION
Removes fakeVatAdmin.js from `contractFacet/`. This is a breaking change, but the dapps have already been moved over using fakeVatAdmin.js from 'tools/'. This PR will be merged into zoe-beta-1 so that the breaking changes are all merged at once.