### PR TITLE
DO NOT MERGE Demonstrate how to get deep await stacks

### DIFF
--- a/packages/zoe/test/autoswapJig.js
+++ b/packages/zoe/test/autoswapJig.js
@@ -185,7 +185,13 @@ export const makeTrader = async (purses, zoe, publicFacet, centralIssuer) => {
           : [secondaryIssuer, secondary, centralIssuer, central];
       const { In: refund, Out: payout } = await seat.getPayouts();
       assertPayoutAmount(t, outIssuer, payout, out(outExpected), 'trade out');
-      assertPayoutAmount(t, inIssuer, refund, inMath(inExpected), 'trade in');
+      await assertPayoutAmount(
+        t,
+        inIssuer,
+        refund,
+        inMath(inExpected),
+        'trade in',
+      );
 
       const poolPost = await getPoolAllocation(secondaryIssuer);
       t.deepEqual(poolPost.Central, central(cPost), `central after swap`);

--- a/packages/zoe/test/zoeTestHelpers.js
+++ b/packages/zoe/test/zoeTestHelpers.js
@@ -41,7 +41,7 @@ export const assertPayoutAmount = async (
   label = '',
 ) => {
   const amount = await issuer.getAmountOf(payout);
-  assertAmountsEqual(t, amount, expectedAmount, label);
+  await assertAmountsEqual(t, amount, expectedAmount, label);
 };
 
 // Returns a promise that can be awaited in tests to ensure the check completes.


### PR DESCRIPTION
@Chris-Hibbert reported a weakness in our error reporting observed with https://github.com/Agoric/agoric-sdk/pull/2966/files#diff-ef3d02b0104386935d4a26278647b501b495f2a9283fb5173a2b2f18f79cf672R975 , where test/unitTests/contracts/newSwap/test-newSwap-swap.js would report puny stacks. This was due to two problems.

(TODO cite @Chris-Hibbert 's bug here)

One is that the test reported failure by calling `t.fail`, which uses only ava's pseudo-console, bypassing our console completely. This is addressed by https://github.com/endojs/endo/pull/701 for the methods `t.fail`, `t.notThrows`, and `t.notThrowsAsync`. Tested against Chris' bug, that PR does also output using our console.

The other problem is that the glue holding the turns together is use of `await`, which our deep stack mechanisms have no ability to follow. However, there is some good news and some bad news on that front, specific to v8 and node. With adequate chaining of `await`s, the v8 builtin stacks will actually be deep through `awaits`. But only if more `await`s are used than is normally healthy. In any case, this PR adds those awaits needed so this one case reports the deep stack that it should.

These awaits are unreasonable and exist only to document this discovery. So this PR should ***NOT BE MERGED***.