### PR TITLE
Use WeakRefs to ensure virtual objects have at most one representative

### DIFF
--- a/packages/SwingSet/docs/virtual-objects.md
+++ b/packages/SwingSet/docs/virtual-objects.md
@@ -94,9 +94,7 @@ Additional important details:
 
 - A virtual object's state may include references to other virtual objects. The latter objects will be persisted separately and only deserialized as needed, so "swapping in" a virtual object that references other virtual objects does not entail swapping in the entire associated object graph.
 
-- The in-memory manifestations of a virtual object (which we call its "representatives") are not necessarily (or even usually) `===` to each other, even when they represent the same object, since a new representative is created for each act of deserialization.  (Note: future implementations may remove this limitation by having at most one representative in memory for any given virtual object, at which point object identity, i.e., `===`, _will_ be usable for comparison.)  All representatives for a given object do, however, operate on the same underlying state, so changes to the state made by a method call to one representative will be visible to the other representatives.
-
-- The `self` object returned by the `instanceKitMaker` function _is_ the representative, so you can capture it inside any of the body methods (as well as the `init` function) in order to pass the virtual object to somebody else.  So you can write things like the following:
+- The `self` object returned by the `instanceKitMaker` function _is_ the in-memory representation of the virtual object, so you can capture it inside any of the body methods (as well as the `init` function) in order to pass the virtual object to somebody else.  So you can write things like the following:
 
 ```javascript
   function thingKitMaker(state) {
@@ -124,10 +122,10 @@ to obtain a new weak store instance, which you can then access using the `has`, 
 
 However, the vat secondary storage system's `makeWeakStore` augments the one provided by the `@agoric/store` package in two important ways:
 
-- Weak store operations may use virtual object representatives as keys, and if you do this the corresponding underlying virtual object instance identities will be used for indexing rather than the object identities of the representative objects (i.e., two different representives for the same underlying virtual object will operate on the same weak store entry).
+- Weak store operations may use virtual objects as keys, and if you do this the corresponding underlying virtual object instance identities will be used for indexing rather than the current in-memory object identities of the objects.
 
 - The values set for weak store entries will be saved persistently to secondary storage.  This means that such weak stores can grow to be very large without impacting the vat's memory footprint.
 
 Since weak store values are saved persistently, they must be serializable and will be hardened as soon as they are set.
 
-An important caveat is that the latter entries are currently not actually weak, in the sense that if a virtual object becomes unreferenced, any corresponding weak store entries will not go away.  This is not semantically visible to vat code, but does impact the disk storage footprint of the vat.  Since virtual object representatives may come and go depending on the working state of the vat, there is no graceful way to garbage collect the underlying objects or corresponding weak store entries; a future system which can do robust distributed garbage collection should eventually rectify this, but for now you should not rely on any such garbage collection happening.
+An important caveat is that the latter entries are currently not actually weak, in the sense that if a virtual object becomes unreferenced, any corresponding weak store entries will not go away.  This is not semantically visible to vat code, but does impact the disk storage footprint of the vat.  Since the in-memory representations of virtual objects may come and go depending on the working state of the vat, there is no graceful way to garbage collect the underlying objects or corresponding weak store entries; a future system which can do robust distributed garbage collection should eventually rectify this, but for now you should not rely on any such garbage collection happening.

--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -27,7 +27,7 @@ const DEFAULT_VIRTUAL_OBJECT_CACHE_SIZE = 3; // XXX ridiculously small value to 
  * @param {*} vatParameters
  * @param {*} gcTools { WeakRef, FinalizationRegistry, waitUntilQuiescent }
  * @param {Console} console
- * @returns {*} { vatGlobals, inescapableGlobalLexicals, dispatch, setBuildRootObject }
+ * @returns {*} { vatGlobals, inescapableGlobalProperties, dispatch, setBuildRootObject }
  *
  * setBuildRootObject should be called, once, with a function that will
  * create a root object for the new vat The caller provided buildRootObject
@@ -803,7 +803,7 @@ function build(
     makeKind,
   });
 
-  const inescapableGlobalLexicals = harden({
+  const inescapableGlobalProperties = harden({
     WeakMap: RepairedWeakMap,
     WeakSet: RepairedWeakSet,
   });
@@ -901,7 +901,7 @@ function build(
   // we return 'deadSet' for unit tests
   return harden({
     vatGlobals,
-    inescapableGlobalLexicals,
+    inescapableGlobalProperties,
     setBuildRootObject,
     dispatch,
     m,
@@ -921,7 +921,7 @@ function build(
  * @param {boolean} enableDisavow
  * @param {*} gcTools { WeakRef, FinalizationRegistry, waitUntilQuiescent }
  * @param {Console} [liveSlotsConsole]
- * @returns {*} { vatGlobals, inescapableGlobalLexicals, dispatch, setBuildRootObject }
+ * @returns {*} { vatGlobals, inescapableGlobalProperties, dispatch, setBuildRootObject }
  *
  * setBuildRootObject should be called, once, with a function that will
  * create a root object for the new vat The caller provided buildRootObject
@@ -971,14 +971,14 @@ export function makeLiveSlots(
   );
   const {
     vatGlobals,
-    inescapableGlobalLexicals,
+    inescapableGlobalProperties,
     dispatch,
     setBuildRootObject,
     deadSet,
   } = r; // omit 'm'
   return harden({
     vatGlobals,
-    inescapableGlobalLexicals,
+    inescapableGlobalProperties,
     dispatch,
     setBuildRootObject,
     deadSet,

--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -346,6 +346,8 @@ function build(
     syscall,
     allocateExportID,
     valToSlot,
+    // eslint-disable-next-line no-use-before-define
+    registerValue,
     m,
     cacheSize,
   );
@@ -397,7 +399,7 @@ function build(
   }
 
   function registerValue(slot, val) {
-    const { type } = parseVatSlot(slot);
+    const { type, virtual } = parseVatSlot(slot);
     slotToVal.set(slot, new WeakRef(val));
     valToSlot.set(val, slot);
     if (type === 'object' || type === 'device') {
@@ -414,7 +416,9 @@ function build(
     // that test-liveslots.js test('dropImports') passes despite this,
     // because it uses a fake WeakRef that doesn't care about the strong
     // reference.
-    safetyPins.add(val);
+    if (!virtual) {
+      safetyPins.add(val);
+    }
   }
 
   function convertSlotToVal(slot, iface = undefined) {
@@ -459,8 +463,8 @@ function build(
       } else {
         assert.fail(X`unrecognized slot type '${type}'`);
       }
-      registerValue(slot, val);
     }
+    registerValue(slot, val);
     return val;
   }
 

--- a/packages/SwingSet/src/kernel/vatManager/manager-local.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-local.js
@@ -129,7 +129,7 @@ export function makeLocalVatManagerFactory(tools) {
       assert,
     });
     const inescapableTransforms = [];
-    const inescapableGlobalLexicals = {};
+    const inescapableGlobalLexicals = { ...ls.inescapableGlobalLexicals };
     if (metered) {
       const getMeter = meterRecord.getMeter;
       inescapableTransforms.push(src => transformMetering(src, getMeter));

--- a/packages/SwingSet/src/kernel/vatManager/manager-local.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-local.js
@@ -129,7 +129,8 @@ export function makeLocalVatManagerFactory(tools) {
       assert,
     });
     const inescapableTransforms = [];
-    const inescapableGlobalLexicals = { ...ls.inescapableGlobalLexicals };
+    const inescapableGlobalProperties = { ...ls.inescapableGlobalProperties };
+    const inescapableGlobalLexicals = {};
     if (metered) {
       const getMeter = meterRecord.getMeter;
       inescapableTransforms.push(src => transformMetering(src, getMeter));
@@ -141,6 +142,7 @@ export function makeLocalVatManagerFactory(tools) {
       endowments,
       inescapableTransforms,
       inescapableGlobalLexicals,
+      inescapableGlobalProperties,
     });
 
     let dispatch;

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-nodeworker.js
@@ -95,14 +95,18 @@ parentPort.on('message', ([type, ...margs]) => {
       assert,
     };
 
-    importBundle(bundle, { endowments }).then(vatNS => {
-      workerLog(`got vatNS:`, Object.keys(vatNS).join(','));
-      sendUplink(['gotBundle']);
-      ls.setBuildRootObject(vatNS.buildRootObject);
-      dispatch = makeSupervisorDispatch(ls.dispatch, waitUntilQuiescent);
-      workerLog(`got dispatch:`, Object.keys(dispatch).join(','));
-      sendUplink(['dispatchReady']);
-    });
+    const inescapableGlobalProperties = { ...ls.inescapableGlobalProperties };
+
+    importBundle(bundle, { endowments, inescapableGlobalProperties }).then(
+      vatNS => {
+        workerLog(`got vatNS:`, Object.keys(vatNS).join(','));
+        sendUplink(['gotBundle']);
+        ls.setBuildRootObject(vatNS.buildRootObject);
+        dispatch = makeSupervisorDispatch(ls.dispatch, waitUntilQuiescent);
+        workerLog(`got dispatch:`, Object.keys(dispatch).join(','));
+        sendUplink(['dispatchReady']);
+      },
+    );
   } else if (type === 'deliver') {
     if (!dispatch) {
       workerLog(`error: deliver before dispatchReady`);

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-node.js
@@ -108,14 +108,18 @@ fromParent.on('data', ([type, ...margs]) => {
       assert,
     };
 
-    importBundle(bundle, { endowments }).then(vatNS => {
-      workerLog(`got vatNS:`, Object.keys(vatNS).join(','));
-      sendUplink(['gotBundle']);
-      ls.setBuildRootObject(vatNS.buildRootObject);
-      dispatch = makeSupervisorDispatch(ls.dispatch, waitUntilQuiescent);
-      workerLog(`got dispatch:`, Object.keys(dispatch).join(','));
-      sendUplink(['dispatchReady']);
-    });
+    const inescapableGlobalProperties = { ...ls.inescapableGlobalProperties };
+
+    importBundle(bundle, { endowments, inescapableGlobalProperties }).then(
+      vatNS => {
+        workerLog(`got vatNS:`, Object.keys(vatNS).join(','));
+        sendUplink(['gotBundle']);
+        ls.setBuildRootObject(vatNS.buildRootObject);
+        dispatch = makeSupervisorDispatch(ls.dispatch, waitUntilQuiescent);
+        workerLog(`got dispatch:`, Object.keys(dispatch).join(','));
+        sendUplink(['dispatchReady']);
+      },
+    );
   } else if (type === 'deliver') {
     if (!dispatch) {
       workerLog(`error: deliver before dispatchReady`);

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
@@ -203,7 +203,13 @@ function makeWorker(port) {
       // bootstrap provides HandledPromise
       HandledPromise: globalThis.HandledPromise,
     };
-    const vatNS = await importBundle(bundle, { endowments });
+
+    const inescapableGlobalProperties = { ...ls.inescapableGlobalProperties };
+
+    const vatNS = await importBundle(bundle, {
+      endowments,
+      inescapableGlobalProperties,
+    });
     workerLog(`got vatNS:`, Object.keys(vatNS).join(','));
     ls.setBuildRootObject(vatNS.buildRootObject);
     assert(ls.dispatch);

--- a/packages/SwingSet/src/kernel/virtualObjectManager.js
+++ b/packages/SwingSet/src/kernel/virtualObjectManager.js
@@ -447,7 +447,10 @@ export function makeVirtualObjectManager(
 
     function reanimate(vobjID) {
       // kdebug(`vo reanimate ${vobjID}`);
-      return makeRepresentative(cache.lookup(vobjID, false), false).self;
+      const innerSelf = cache.lookup(vobjID, false);
+      const representative = makeRepresentative(innerSelf, false).self;
+      innerSelf.representative = representative;
+      return representative;
     }
     kindTable.set(kindID, reanimate);
 
@@ -465,6 +468,7 @@ export function makeVirtualObjectManager(
       if (init) {
         init(...args);
       }
+      innerSelf.representative = initialRepresentative;
       registerValue(vobjID, initialRepresentative);
       initializationsInProgress.delete(initialData);
       const rawData = {};

--- a/packages/SwingSet/src/kernel/virtualObjectManager.js
+++ b/packages/SwingSet/src/kernel/virtualObjectManager.js
@@ -436,12 +436,12 @@ export function makeVirtualObjectManager(
       if (initializing) {
         innerSelf.wrapData = wrapData;
         instanceKit = harden(instanceKitMaker(innerSelf.rawData));
+        cache.remember(innerSelf);
       } else {
         const activeData = {};
         wrapData(activeData);
         instanceKit = harden(instanceKitMaker(activeData));
       }
-      cache.remember(innerSelf);
       return instanceKit;
     }
 

--- a/packages/SwingSet/src/kernel/virtualObjectManager.js
+++ b/packages/SwingSet/src/kernel/virtualObjectManager.js
@@ -250,16 +250,13 @@ export function makeVirtualObjectManager(
 
     function virtualObjectKey(key) {
       const vobjID = valToSlot.get(key);
-      if (!vobjID) {
-        return undefined;
-      } else {
+      if (vobjID) {
         const { type, virtual } = parseVatSlot(vobjID);
         if (type === 'object' && virtual) {
           return `ws${storeID}.${vobjID}`;
-        } else {
-          return undefined;
         }
       }
+      return undefined;
     }
 
     return harden({
@@ -317,6 +314,118 @@ export function makeVirtualObjectManager(
       },
     });
   }
+
+  function vrefKey(value) {
+    const vobjID = valToSlot.get(value);
+    if (vobjID) {
+      const { type, virtual } = parseVatSlot(vobjID);
+      if (type === 'object' && virtual) {
+        return vobjID;
+      }
+    }
+    return undefined;
+  }
+
+  /* eslint max-classes-per-file: ["error", 2] */
+
+  const actualWeakMaps = new WeakMap();
+  const virtualObjectMaps = new WeakMap();
+
+  class RepairedWeakMap {
+    constructor() {
+      actualWeakMaps.set(this, new WeakMap());
+      virtualObjectMaps.set(this, new Map());
+    }
+
+    has(key) {
+      const vkey = vrefKey(key);
+      if (vkey) {
+        return virtualObjectMaps.get(this).has(vkey);
+      } else {
+        return actualWeakMaps.get(this).has(key);
+      }
+    }
+
+    get(key) {
+      const vkey = vrefKey(key);
+      if (vkey) {
+        return virtualObjectMaps.get(this).get(vkey);
+      } else {
+        return actualWeakMaps.get(this).get(key);
+      }
+    }
+
+    set(key, value) {
+      const vkey = vrefKey(key);
+      if (vkey) {
+        virtualObjectMaps.get(this).set(vkey, value);
+      } else {
+        actualWeakMaps.get(this).set(key, value);
+      }
+      return this;
+    }
+
+    delete(key) {
+      const vkey = vrefKey(key);
+      if (vkey) {
+        return virtualObjectMaps.get(this).delete(vkey);
+      } else {
+        return actualWeakMaps.get(this).delete(key);
+      }
+    }
+  }
+
+  Object.defineProperty(RepairedWeakMap, Symbol.toStringTag, {
+    value: 'WeakMap',
+    writable: false,
+    enumerable: false,
+    configurable: true,
+  });
+
+  const actualWeakSets = new WeakMap();
+  const virtualObjectSets = new WeakMap();
+
+  class RepairedWeakSet {
+    constructor() {
+      actualWeakSets.set(this, new WeakSet());
+      virtualObjectSets.set(this, new Set());
+    }
+
+    has(value) {
+      const vkey = vrefKey(value);
+      if (vkey) {
+        return virtualObjectSets.get(this).has(vkey);
+      } else {
+        return actualWeakSets.get(this).has(value);
+      }
+    }
+
+    add(value) {
+      const vkey = vrefKey(value);
+      if (vkey) {
+        virtualObjectSets.get(this).add(vkey);
+      } else {
+        actualWeakSets.get(this).add(value);
+      }
+      return this;
+    }
+
+    delete(value) {
+      const vkey = vrefKey(value);
+      if (vkey) {
+        return virtualObjectSets.get(this).delete(vkey);
+      } else {
+        return actualWeakSets.get(this).delete(value);
+      }
+    }
+  }
+
+  Object.defineProperty(RepairedWeakSet, Symbol.toStringTag, {
+    value: 'WeakSet',
+    writable: false,
+    enumerable: false,
+    configurable: true,
+  });
 
   /**
    * Define a new kind of virtual object.
@@ -495,6 +604,8 @@ export function makeVirtualObjectManager(
   return harden({
     makeWeakStore,
     makeKind,
+    RepairedWeakMap,
+    RepairedWeakSet,
     flushCache: cache.flush,
     makeVirtualObjectRepresentative,
   });

--- a/packages/SwingSet/src/weakref.js
+++ b/packages/SwingSet/src/weakref.js
@@ -6,7 +6,7 @@ const { defineProperties } = Object;
 /*
  * We retain a measure of compatibility with Node.js v12, which does not
  * expose WeakRef or FinalizationRegistry (there is a --flag for it, but it's
- * * not clear how stable it is). When running on a platform without these *
+ * not clear how stable it is). When running on a platform without these
  * tools, vats cannot do GC, and the tools they get will be no-ops. WeakRef
  * instances will hold a strong reference, and the FinalizationRegistry will
  * never invoke the callbacks.

--- a/packages/SwingSet/test/virtualObjects/test-virtualObjectManager.js
+++ b/packages/SwingSet/test/virtualObjects/test-virtualObjectManager.js
@@ -241,3 +241,76 @@ test('weak store operations', t => {
   ws1.set(nv2, 'non-virtual object #2 revised');
   t.is(ws1.get(nv2), 'non-virtual object #2 revised');
 });
+
+test('virtualized weak collection operations', t => {
+  // TODO: don't yet have a way to test the weakness of the virtualized weak
+  // collections
+
+  const {
+    RepairedWeakMap,
+    RepairedWeakSet,
+    makeKind,
+  } = makeFakeVirtualObjectManager(3);
+
+  const thingMaker = makeKind(makeThingInstance);
+  const zotMaker = makeKind(makeZotInstance);
+
+  const thing1 = thingMaker('t1');
+  const thing2 = thingMaker('t2');
+
+  const zot1 = zotMaker(1, 'z1');
+  const zot2 = zotMaker(2, 'z2');
+  const zot3 = zotMaker(3, 'z3');
+  const zot4 = zotMaker(4, 'z4');
+
+  const wm1 = new RepairedWeakMap();
+  const wm2 = new RepairedWeakMap();
+  const nv1 = {};
+  const nv2 = { a: 47 };
+  wm1.set(zot1, 'zot #1');
+  wm2.set(zot2, 'zot #2');
+  wm1.set(zot3, 'zot #3');
+  wm2.set(zot4, 'zot #4');
+  wm1.set(thing1, 'thing #1');
+  wm2.set(thing2, 'thing #2');
+  wm1.set(nv1, 'non-virtual object #1');
+  wm1.set(nv2, 'non-virtual object #2');
+  t.is(wm1.get(zot1), 'zot #1');
+  t.is(wm1.has(zot1), true);
+  t.is(wm2.has(zot1), false);
+  wm1.set(zot3, 'zot #3 revised');
+  wm2.delete(zot4);
+  t.is(wm1.get(nv1), 'non-virtual object #1');
+  t.is(wm1.get(nv2), 'non-virtual object #2');
+  t.is(wm2.has(zot4), false);
+  t.is(wm1.get(zot3), 'zot #3 revised');
+  wm1.delete(nv1);
+  t.is(wm1.has(nv1), false);
+  wm1.set(nv2, 'non-virtual object #2 revised');
+  t.is(wm1.get(nv2), 'non-virtual object #2 revised');
+
+  const ws1 = new RepairedWeakSet();
+  const ws2 = new RepairedWeakSet();
+  ws1.add(zot1);
+  ws2.add(zot2);
+  ws1.add(zot3);
+  ws2.add(zot4);
+  ws1.add(thing1);
+  ws2.add(thing2);
+  ws1.add(nv1);
+  ws1.add(nv2);
+  t.is(ws1.has(zot1), true);
+  t.is(ws2.has(zot1), false);
+  ws1.add(zot3);
+  ws2.delete(zot4);
+  t.is(ws1.has(nv1), true);
+  t.is(ws1.has(nv2), true);
+  t.is(ws2.has(nv1), false);
+  t.is(ws2.has(nv2), false);
+  t.is(ws2.has(zot4), false);
+  t.is(ws1.has(zot3), true);
+  ws1.delete(nv1);
+  t.is(ws1.has(nv1), false);
+  ws1.add(nv2);
+  t.is(ws1.has(nv2), true);
+});

--- a/packages/SwingSet/test/virtualObjects/test-virtualObjectManager.js
+++ b/packages/SwingSet/test/virtualObjects/test-virtualObjectManager.js
@@ -81,8 +81,10 @@ function zotVal(arbitrary, name, tag, count) {
   });
 }
 
+// prettier-ignore
 test('virtual object operations', t => {
-  const { makeKind, flushCache, dumpStore } = makeFakeVirtualObjectManager(3);
+  const log = [];
+  const { makeKind, flushCache, dumpStore } = makeFakeVirtualObjectManager(3, log);
 
   const thingMaker = makeKind(makeThingInstance);
   const zotMaker = makeKind(makeZotInstance);
@@ -99,44 +101,88 @@ test('virtual object operations', t => {
   // t3-0: 'thing-3' 200 0
   const thing4 = thingMaker('thing-4', 300); // [t4-0 t3-0 t2-0 t1-0]
   // t4-0: 'thing-4' 300 0
+  t.deepEqual(log, []);
 
   const zot1 = zotMaker(23, 'Alice', 'is this on?'); // [z1-0 t4-0 t3-0 t2-0] evict t1-0
   // z1-0: 23 'Alice' 'is this on?' 0
+  t.is(log.shift(), `set o+1/1 ${thingVal(0, 'thing-1', 0)}`); // evict t1-0
+  t.deepEqual(log, []);
+
   const zot2 = zotMaker(29, 'Bob', 'what are you saying?'); // [z2-0 z1-0 t4-0 t3-0] evict t2-0
   // z2-0: 29 'Bob' 'what are you saying?' 0
+  t.is(log.shift(), `set o+1/2 ${thingVal(100, 'thing-2', 0)}`); // evict t2-0
+  t.deepEqual(log, []);
+
   const zot3 = zotMaker(47, 'Carol', 'as if...'); // [z3-0 z2-0 z1-0 t4-0] evict t3-0
   // z3-0: 47 'Carol' 'as if...' 0
+  t.is(log.shift(), `set o+1/3 ${thingVal(200, 'thing-3', 0)}`); // evict t3-0
+  t.deepEqual(log, []);
+
   const zot4 = zotMaker(66, 'Dave', 'you and what army?'); // [z4-0 z3-0 z2-0 z1-0] evict t4-0
   // z4-0: 66 'Dave' 'you and what army?' 0
+  t.is(log.shift(), `set o+1/4 ${thingVal(300, 'thing-4', 0)}`); // evict t4-0
+  t.deepEqual(log, []);
 
   t.deepEqual(dumpStore(), [
-    ['o+1/1', thingVal(0, 'thing-1', 0)], // t1-0
-    ['o+1/2', thingVal(100, 'thing-2', 0)], // t2-0
-    ['o+1/3', thingVal(200, 'thing-3', 0)], // t3-0
-    ['o+1/4', thingVal(300, 'thing-4', 0)], // t4-0
+    ['o+1/1', thingVal(0, 'thing-1', 0)], // =t1-0
+    ['o+1/2', thingVal(100, 'thing-2', 0)], // =t2-0
+    ['o+1/3', thingVal(200, 'thing-3', 0)], // =t3-0
+    ['o+1/4', thingVal(300, 'thing-4', 0)], // =t4-0
   ]);
 
   // phase 2: first batch-o-stuff
   t.is(thing1.inc(), 1); // [t1-1 z4-0 z3-0 z2-0] evict z1-0
+  t.is(log.shift(), `set o+2/1 ${zotVal(23, 'Alice', 'is this on?', 0)}`); // evict z1-0
+  t.is(log.shift(), `get o+1/1 => ${thingVal(0, 'thing-1', 0)}`); // load t1-0
+  t.deepEqual(log, []);
+
   // t1-1: 'thing-1' 1 0
   t.is(zot1.sayHello('hello'), 'hello Alice'); // [z1-1 t1-1 z4-0 z3-0] evict z2-0
+  t.is(log.shift(), `set o+2/2 ${zotVal(29, 'Bob', 'what are you saying?', 0)}`); // evict z2-0
+  t.is(log.shift(), `get o+2/1 => ${zotVal(23, 'Alice', 'is this on?', 0)}`); // load z1-0
+  t.deepEqual(log, []);
+
   // z1-1: 23 'Alice' 'is this on?' 1
   t.is(thing1.inc(), 2); // [t1-2 z1-1 z4-0 z3-0]
+  t.deepEqual(log, []);
+
   // t1-2: 'thing-1' 2 0
   t.is(zot2.sayHello('hi'), 'hi Bob'); // [z2-1 t1-2 z1-1 z4-0] evict z3-0
+  t.is(log.shift(), `set o+2/3 ${zotVal(47, 'Carol', 'as if...', 0)}`); // evict z3-0
+  t.is(log.shift(), `get o+2/2 => ${zotVal(29, 'Bob', 'what are you saying?', 0)}`); // load z2-0
+  t.deepEqual(log, []);
+
   // z2-1: 29 'Bob' 'what are you saying?' 1
   t.is(thing1.inc(), 3); // [t1-3 z2-1 z1-1 z4-0]
+  t.deepEqual(log, []);
+
   // t1-3: 'thing-1' 3 0
   t.is(zot3.sayHello('aloha'), 'aloha Carol'); // [z3-1 t1-3 z2-1 z1-1] evict z4-0
+  t.is(log.shift(), `set o+2/4 ${zotVal(66, 'Dave', 'you and what army?', 0)}`); // evict z4-0
+  t.is(log.shift(), `get o+2/3 => ${zotVal(47, 'Carol', 'as if...', 0)}`); // load z3-0
+  t.deepEqual(log, []);
+
   // z3-1: 47 'Carol' 'as if...' 1
   t.is(zot4.sayHello('bonjour'), 'bonjour Dave'); // [z4-1 z3-1 t1-3 z2-1] evict z1-1
+  t.is(log.shift(), `set o+2/1 ${zotVal(23, 'Alice', 'is this on?', 1)}`); // evict z1-1
+  t.is(log.shift(), `get o+2/4 => ${zotVal(66, 'Dave', 'you and what army?', 0)}`); // load z4-0
+  t.deepEqual(log, []);
+
   // z4-1: 66 'Dave' 'you and what army?' 1
   t.is(zot1.sayHello('hello again'), 'hello again Alice'); // [z1-2 z4-1 z3-1 t1-3] evict z2-1
+  t.is(log.shift(), `set o+2/2 ${zotVal(29, 'Bob', 'what are you saying?', 1)}`); // evict z2-1
+  t.is(log.shift(), `get o+2/1 => ${zotVal(23, 'Alice', 'is this on?', 1)}`); // get z1-1
+  t.deepEqual(log, []);
+
   // z1-2: 23 'Alice' 'is this on?' 2
   t.is(
     thing2.describe(), // [t2-0 z1-2 z4-1 z3-1] evict t1-3
     'thing-2 counter has been reset 0 times and is now 100',
   );
+  t.is(log.shift(), `set o+1/1 ${thingVal(3, 'thing-1', 0)}`); // evict t1-3
+  t.is(log.shift(), `get o+1/2 => ${thingVal(100, 'thing-2', 0)}`); // load t2-0
+  t.deepEqual(log, []);
+
   t.deepEqual(dumpStore(), [
     ['o+1/1', thingVal(3, 'thing-1', 0)], // =t1-3
     ['o+1/2', thingVal(100, 'thing-2', 0)], // =t2-0
@@ -150,30 +196,70 @@ test('virtual object operations', t => {
 
   // phase 3: second batch-o-stuff
   t.is(thing1.get(), 3); // [t1-3 t2-0 z1-2 z4-1] evict z3-1
+  t.is(log.shift(), `set o+2/3 ${zotVal(47, 'Carol', 'as if...', 1)}`); // evict z3-1
+  t.is(log.shift(), `get o+1/1 => ${thingVal(3, 'thing-1', 0)}`); // load t1-3
+  t.deepEqual(log, []);
+
   t.is(thing1.inc(), 4); // [t1-4 t2-0 z1-2 z4-1]
+  t.deepEqual(log, []);
+
   // t1-4: 'thing-1' 4 0
   t.is(thing4.reset(1000), 1); // [t4-1 t1-4 t2-0 z1-2] evict z4-1
+  t.is(log.shift(), `set o+2/4 ${zotVal(66, 'Dave', 'you and what army?', 1)}`); // evict z4-1
+  t.is(log.shift(), `get o+1/4 => ${thingVal(300, 'thing-4', 0)}`); // load t4-0
+  t.deepEqual(log, []);
+
   // t4-1: 'thing-4' 1000 1
   t.is(zot3.rename('Chester'), 'Chester'); // [z3-2 t4-1 t1-4 t2-0] evict z1-2
+  t.is(log.shift(), `set o+2/1 ${zotVal(23, 'Alice', 'is this on?', 2)}`); // evict z1-2
+  t.is(log.shift(), `get o+2/3 => ${zotVal(47, 'Carol', 'as if...', 1)}`); // load z3-1
+  t.deepEqual(log, []);
+
   // z3-2: 47 'Chester' 'as if...' 2
   t.is(zot1.getInfo(), 'zot Alice tag=is this on? count=3 arbitrary=23'); // [z1-3 z3-2 t4-1 t1-4] evict t2-0
+  // evict t2-0 does nothing because t2 is not dirty
+  t.is(log.shift(), `get o+2/1 => ${zotVal(23, 'Alice', 'is this on?', 2)}`); // load z1-2
+  t.deepEqual(log, []);
+
   // z1-3: 23 'Alice' 'is this on?' 3
   t.is(zot2.getInfo(), 'zot Bob tag=what are you saying? count=2 arbitrary=29'); // [z2-2 z1-3 z3-2 t4-1] evict t1-4
+  t.is(log.shift(), `set o+1/1 ${thingVal(4, 'thing-1', 0)}`); // evict t1-4
+  t.is(log.shift(), `get o+2/2 => ${zotVal(29, 'Bob', 'what are you saying?', 1)}`); // load z2-1
+  t.deepEqual(log, []);
+
   // z2-2: 29 'Bob' 'what are you saying?' 1
   t.is(
-    thing2.describe(), // [t1-4 z2-2 z1-3 z3-2] evict t4-1
+    thing2.describe(), // [t2-0 z2-2 z1-3 z3-2] evict t4-1
     'thing-2 counter has been reset 0 times and is now 100',
   );
-  t.is(zot3.getInfo(), 'zot Chester tag=as if... count=3 arbitrary=47'); // [z3-3 t1-4 z2-2 z1-3]
+  t.is(log.shift(), `set o+1/4 ${thingVal(1000, 'thing-4', 1)}`); // evict t4-1
+  t.is(log.shift(), `get o+1/2 => ${thingVal(100, 'thing-2', 0)}`); // load t2-0
+  t.deepEqual(log, []);
+
+  t.is(zot3.getInfo(), 'zot Chester tag=as if... count=3 arbitrary=47'); // [z3-3 t2-0 z2-2 z1-3]
+  t.deepEqual(log, []);
+
   // z3-3: 47 'Chester' 'as if...' 3
-  t.is(zot4.getInfo(), 'zot Dave tag=you and what army? count=2 arbitrary=66'); // [z4-1 z3-3 t1-4 z2-2] evict z1-3
+  t.is(zot4.getInfo(), 'zot Dave tag=you and what army? count=2 arbitrary=66'); // [z4-1 z3-3 t2-0 z2-2] evict z1-3
+  t.is(log.shift(), `set o+2/1 ${zotVal(23, 'Alice', 'is this on?', 3)}`); // evict z1-3
+  t.is(log.shift(), `get o+2/4 => ${zotVal(66, 'Dave', 'you and what army?', 1)}`); // load z4-1
+  t.deepEqual(log, []);
+
   // z4-2: 66 'Dave' 'you and what army?' 2
-  t.is(thing3.inc(), 201); // [t3-0 z4-2 z3-3 t1-4] evict z2-2
+  t.is(thing3.inc(), 201); // [t3-1 z4-2 z3-3 t2-0] evict z2-2
+  t.is(log.shift(), `set o+2/2 ${zotVal(29, 'Bob', 'what are you saying?', 2)}`); // evict z2-2
+  t.is(log.shift(), `get o+1/3 => ${thingVal(200, 'thing-3', 0)}`); // load t3-0
+  t.deepEqual(log, []);
+
   // t3-1: 'thing-3' 201 0
   t.is(
-    thing4.describe(), // [t4-1 t3-0 z4-2 z3-3] evict t1-4
+    thing4.describe(), // [t4-1 t3-1 z4-2 z3-3] evict t2-0
     'thing-4 counter has been reset 1 times and is now 1000',
   );
+  // evict t2-0 does nothing because t2 is not dirty
+  t.is(log.shift(), `get o+1/4 => ${thingVal(1000, 'thing-4', 1)}`); // load t4-1
+  t.deepEqual(log, []);
+
   t.deepEqual(dumpStore(), [
     ['o+1/1', thingVal(4, 'thing-1', 0)], // =t1-4
     ['o+1/2', thingVal(100, 'thing-2', 0)], // =t2-0
@@ -186,13 +272,23 @@ test('virtual object operations', t => {
   ]);
 
   // phase 4: flush test
-  t.is(thing1.inc(), 5); // [t1-5 t4-1 t3-0 z4-2] evict z3-3
+  t.is(thing1.inc(), 5); // [t1-5 t4-1 t3-1 z4-2] evict z3-3
+  t.is(log.shift(), `set o+2/3 ${zotVal(47, 'Chester', 'as if...', 3)}`); // evict z3-3
+  t.is(log.shift(), `get o+1/1 => ${thingVal(4, 'thing-1', 0)}`); // load t1-4
+  t.deepEqual(log, []);
+
   // t1-5: 'thing-1' 5 0
-  flushCache(); // [] evict z4-2 t3-0 t4-1 t1-5
+  flushCache(); // [] evict z4-2 t3-1 t4-1 t1-5
+  t.is(log.shift(), `set o+2/4 ${zotVal(66, 'Dave', 'you and what army?', 2)}`); // evict z4-2
+  t.is(log.shift(), `set o+1/3 ${thingVal(201, 'thing-3', 0)}`); // evict t3-1
+  // evict t4-1 does nothing because t4 is not dirty
+  t.is(log.shift(), `set o+1/1 ${thingVal(5, 'thing-1', 0)}`); // evict t1-5
+  t.deepEqual(log, []);
+
   t.deepEqual(dumpStore(), [
     ['o+1/1', thingVal(5, 'thing-1', 0)], // =t1-5
     ['o+1/2', thingVal(100, 'thing-2', 0)], // =t2-0
-    ['o+1/3', thingVal(201, 'thing-3', 0)], // =t3-0
+    ['o+1/3', thingVal(201, 'thing-3', 0)], // =t3-1
     ['o+1/4', thingVal(1000, 'thing-4', 1)], // =t4-1
     ['o+2/1', zotVal(23, 'Alice', 'is this on?', 3)], // =z1-3
     ['o+2/2', zotVal(29, 'Bob', 'what are you saying?', 2)], // =z2-2

--- a/packages/SwingSet/tools/fakeVirtualObjectManager.js
+++ b/packages/SwingSet/tools/fakeVirtualObjectManager.js
@@ -4,7 +4,7 @@ import { parseVatSlot } from '../src/parseVatSlots';
 
 import { makeVirtualObjectManager } from '../src/kernel/virtualObjectManager';
 
-export function makeFakeVirtualObjectManager(cacheSize = 100) {
+export function makeFakeVirtualObjectManager(cacheSize = 100, log) {
   const fakeStore = new Map();
 
   function dumpStore() {
@@ -17,9 +17,25 @@ export function makeFakeVirtualObjectManager(cacheSize = 100) {
   }
 
   const fakeSyscall = {
-    vatstoreGet: key => fakeStore.get(key),
-    vatstoreSet: (key, value) => fakeStore.set(key, value),
-    vatstoreDelete: key => fakeStore.delete(key),
+    vatstoreGet(key) {
+      const result = fakeStore.get(key);
+      if (log) {
+        log.push(`get ${key} => ${result}`);
+      }
+      return result;
+    },
+    vatstoreSet(key, value) {
+      if (log) {
+        log.push(`set ${key} ${value}`);
+      }
+      fakeStore.set(key, value);
+    },
+    vatstoreDelete(key) {
+      if (log) {
+        log.push(`delete ${key}`);
+      }
+      fakeStore.delete(key);
+    },
   };
 
   let nextExportID = 1;

--- a/packages/SwingSet/tools/fakeVirtualObjectManager.js
+++ b/packages/SwingSet/tools/fakeVirtualObjectManager.js
@@ -64,6 +64,8 @@ export function makeFakeVirtualObjectManager(cacheSize = 100) {
     makeVirtualObjectRepresentative,
     makeWeakStore,
     makeKind,
+    RepairedWeakMap,
+    RepairedWeakSet,
     flushCache,
   } = makeVirtualObjectManager(
     fakeSyscall,
@@ -77,6 +79,8 @@ export function makeFakeVirtualObjectManager(cacheSize = 100) {
   return {
     makeKind,
     makeWeakStore,
+    RepairedWeakMap,
+    RepairedWeakSet,
     flushCache,
     dumpStore,
   };

--- a/packages/SwingSet/tools/fakeVirtualObjectManager.js
+++ b/packages/SwingSet/tools/fakeVirtualObjectManager.js
@@ -55,6 +55,11 @@ export function makeFakeVirtualObjectManager(cacheSize = 100) {
   // eslint-disable-next-line no-use-before-define
   const fakeMarshal = makeMarshal(fakeConvertValToSlot, fakeConvertSlotToVal);
 
+  function fakeRegisterValue(slot, val) {
+    slotToVal.set(slot, val);
+    valToSlot.set(val, slot);
+  }
+
   const {
     makeVirtualObjectRepresentative,
     makeWeakStore,
@@ -64,6 +69,7 @@ export function makeFakeVirtualObjectManager(cacheSize = 100) {
     fakeSyscall,
     fakeAllocateExportID,
     valToSlot,
+    fakeRegisterValue,
     fakeMarshal,
     cacheSize,
   );

--- a/packages/import-bundle/src/compartment-wrapper.js
+++ b/packages/import-bundle/src/compartment-wrapper.js
@@ -2,6 +2,7 @@ export function wrapInescapableCompartment(
   OldCompartment,
   inescapableTransforms,
   inescapableGlobalLexicals,
+  inescapableGlobalProperties,
 ) {
   // This is the new Compartment constructor. We name it `Compartment` so
   // that it's .name property is correct, but we hold it in 'NewCompartment'
@@ -50,6 +51,15 @@ export function wrapInescapableCompartment(
     // like c.globalThis.Compartment = wrap(c.globalThis.Compartment), but
     // there are details to work out.
     c.globalThis.Compartment = NewCompartment;
+
+    for (const prop of Object.keys(inescapableGlobalProperties)) {
+      Object.defineProperty(c.globalThis, prop, {
+        value: inescapableGlobalProperties[prop],
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      });
+    }
 
     return c;
   };

--- a/packages/import-bundle/src/index.js
+++ b/packages/import-bundle/src/index.js
@@ -16,6 +16,7 @@ export async function importBundle(bundle, options = {}) {
     transforms = [],
     inescapableTransforms = [],
     inescapableGlobalLexicals = {},
+    inescapableGlobalProperties = {},
   } = options;
   const endowments = {
     TextEncoder,
@@ -26,12 +27,14 @@ export async function importBundle(bundle, options = {}) {
   let CompartmentToUse = Compartment;
   if (
     inescapableTransforms.length ||
-    Object.keys(inescapableGlobalLexicals).length
+    Object.keys(inescapableGlobalLexicals).length ||
+    Object.keys(inescapableGlobalProperties).length
   ) {
     CompartmentToUse = wrapInescapableCompartment(
       Compartment,
       inescapableTransforms,
       inescapableGlobalLexicals,
+      inescapableGlobalProperties,
     );
   }
 

--- a/packages/import-bundle/test/test-compartment-wrapper.js
+++ b/packages/import-bundle/test/test-compartment-wrapper.js
@@ -121,6 +121,8 @@ function check(t, c, odometer, n) {
     { message: /Not available/ },
     `${n} .constructor is tamed`,
   );
+
+  t.is(c.evaluate('WeakMap'), 'replaced');
 }
 
 test('wrap', t => {
@@ -131,10 +133,12 @@ test('wrap', t => {
 
   const inescapableTransforms = [milageTransform];
   const inescapableGlobalLexicals = { getOdometer };
+  const inescapableGlobalProperties = { WeakMap: 'replaced' };
   const WrappedCompartment = wrapInescapableCompartment(
     Compartment,
     inescapableTransforms,
     inescapableGlobalLexicals,
+    inescapableGlobalProperties,
   );
   const endowments = { console };
   const c1 = new WrappedCompartment(endowments);

--- a/packages/import-bundle/test/test-compartment-wrapper.js
+++ b/packages/import-bundle/test/test-compartment-wrapper.js
@@ -123,6 +123,7 @@ function check(t, c, odometer, n) {
   );
 
   t.is(c.evaluate('WeakMap'), 'replaced');
+  t.is(c.evaluate('globalThis.WeakMap'), 'replaced');
 }
 
 test('wrap', t => {


### PR DESCRIPTION
Further work towards completing #1968.  The weakref-based virtual object mechanism is now entirely working, but we still expose non-determinism via stock WeakMaps and WeakSets, hence this PR is currently a draft per our plan of 4/27.  Also, the unification of representatives with inner selves which this enables has not yet been done.