### PR TITLE
fix(swingset): create dynamic vats with the right options

### DIFF
--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -538,7 +538,7 @@ export default function buildKernel(
     }
 
     // eslint-disable-next-line no-use-before-define
-    return createVatDynamically(vatID, source, dynamicOptions)
+    return createVatDynamically(vatID, source, options)
       .then(makeSuccessResponse, makeErrorResponse)
       .then(sendResponse)
       .catch(err => console.error(`error in vat creation`, err));


### PR DESCRIPTION
A cut-and-paste error was omitting `defaultManagerType` from the options sent
to `createVatDynamically`, causing all dynamic vats to be created with the
"local" (Node.js same-process) worker, even if the default settings asked for
"xs-worker" (xsnap subprocess).