### PR TITLE
error plumbing: test-innerVat.js

### DIFF
--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -519,8 +519,20 @@ export default function buildKernel(
     function makeErrorResponse(error) {
       // delete partial vat state
       kernelKeeper.cleanupAfterTerminatedVat(vatID);
+      console.log('makeErrorResponse@@', error);
+      console.log('makeErrorResponse@@ done');
       return {
-        body: JSON.stringify([vatID, { error: `${error}` }]),
+        body: JSON.stringify([
+          vatID,
+          {
+            error: {
+              '@qclass': 'error',
+              message: error.message,
+              name: error.name,
+              errorId: 'BOB@@',
+            },
+          },
+        ]),
         slots: [],
       };
     }

--- a/packages/SwingSet/src/kernel/vatAdmin/vatAdminWrapper.js
+++ b/packages/SwingSet/src/kernel/vatAdmin/vatAdminWrapper.js
@@ -5,6 +5,7 @@
  * must ensure that only data goes in and out. It's also responsible for turning
  * device affordances into objects that can be used by code in other vats.
  */
+import { details as X } from '@agoric/assert';
 import { makePromiseKit } from '@agoric/promise-kit';
 import { Far } from '@agoric/marshal';
 
@@ -62,7 +63,8 @@ export function buildRootObject(vatPowers) {
     if (results.rootObject) {
       resolve(results.rootObject);
     } else {
-      reject(Error(`Vat Creation Error: ${results.error}`));
+      debugger;
+      reject(assert.error(X`Vat Creation Error: ${results.error}`));
     }
   }
 

--- a/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { assert, details as X } from '@agoric/assert';
+import { assert, details as X, q } from '@agoric/assert';
 import { ExitCode } from '@agoric/xsnap/api';
 import { makeManagerKit } from './manager-helper';
 
@@ -125,7 +125,8 @@ export function makeXsSubprocessFactory({
     if (bundleReply[0] === 'dispatchReady') {
       parentLog(vatID, `bundle loaded. dispatch ready.`);
     } else {
-      assert.fail(X`failed to setBundle: ${bundleReply}`);
+      const [_tag, errName, message] = bundleReply;
+      assert.fail(X`setBundle failed: ${q(errName)}: ${q(message)}`);
     }
 
     /**

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
@@ -16,6 +16,10 @@ import {
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
+const marshal = makeMarshal(undefined, undefined, {
+  // don't scare the validators with errors they don't know what to do with.
+  marshalSaveError: () => {},
+});
 
 // eslint-disable-next-line no-unused-vars
 function workerLog(first, ...args) {
@@ -36,7 +40,7 @@ function managerPort(issueCommand) {
   const encode = item => {
     let txt;
     try {
-      txt = JSON.stringify(item);
+      txt = marshal.serialize(harden(item)).body;
     } catch (nope) {
       workerLog(nope.message, item);
       throw nope;
@@ -83,7 +87,7 @@ function managerPort(issueCommand) {
             report.result = encode(item);
           })
           .catch(err => {
-            report.result = encode(['err', err.name, err.message]);
+            report.result = encode(['err', err]);
           })
           .catch(_err => {
             report.result = lastResort;

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
@@ -83,7 +83,7 @@ function managerPort(issueCommand) {
             report.result = encode(item);
           })
           .catch(err => {
-            report.result = encode(['err', f.name, err.message]);
+            report.result = encode(['err', err.name, err.message]);
           })
           .catch(_err => {
             report.result = lastResort;

--- a/packages/SwingSet/test/vat-admin/test-innerVat.js
+++ b/packages/SwingSet/test/vat-admin/test-innerVat.js
@@ -45,10 +45,13 @@ test('VatAdmin counter test', async t => {
 test('VatAdmin broken vat creation', async t => {
   const c = await doTestSetup(t, 'brokenVat');
   await c.run();
-  t.deepEqual(c.dump().log, [
-    'starting brokenVat test',
-    'yay, rejected: Error: Vat Creation Error: ReferenceError: missing is not defined',
-  ]);
+  const { log } = c.dump();
+  t.is(log.length, 2);
+  t.is(log[0], 'starting brokenVat test');
+  t.regex(
+    log[1],
+    /^yay, rejected: Error: Vat Creation Error:.*ReferenceError.*missing/,
+  );
 });
 
 test('error creating vat from non-bundle', async t => {

--- a/packages/solo/solo-config.json
+++ b/packages/solo/solo-config.json
@@ -1,5 +1,6 @@
 {
   "bootstrap": "bootstrap",
+  "defaultManagerType": "xs-worker",
   "vats": {
     "spawner": {
       "sourceSpec": "./src/vat-spawner.js"

--- a/packages/vats/decentral-config.json
+++ b/packages/vats/decentral-config.json
@@ -5,6 +5,7 @@
       "sourceSpec": "@agoric/zoe/contractFacet"
     }
   },
+  "defaultManagerType": "xs-worker",
   "vats": {
     "board": {
       "sourceSpec": "./src/vat-board.js"

--- a/packages/xsnap/lib/console-shim.js
+++ b/packages/xsnap/lib/console-shim.js
@@ -1,8 +1,9 @@
 /* global globalThis */
 function tryPrint(...args) {
+  debugger;
   try {
     // eslint-disable-next-line
-    print(...args);
+    print('FRED THE FRIENDLY CONSOLE@@', ...args);
   } catch (err) {
     // eslint-disable-next-line
     print('cannot print:', err.message);


### PR DESCRIPTION
@erights to reproduce, check out this branch, `yarn; yarn build` as usual, then:

```
~/projects/agoric/agoric-sdk/packages/SwingSet
17:53 connolly@jambox$ XSNAP_DEBUG=1 SWINGSET_WORKER_TYPE=xs-worker yarn test test/vat-admin/test-innerVat.js  -m 'VatAdmin broken vat creation'
```

see [installing the Moddable SDK on a mac](https://github.com/Moddable-OpenSource/moddable/blob/public/documentation/Moddable%20SDK%20-%20Getting%20Started.md#mac-instructions) if you have not already done that. Then you can run `xsbug` too.
