### PR TITLE
DO NOT MERGE with private instance variables

### DIFF
--- a/packages/SwingSet/docs/virtual-objects.md
+++ b/packages/SwingSet/docs/virtual-objects.md
@@ -94,9 +94,7 @@ Additional important details:
 
 - A virtual object's state may include references to other virtual objects. The latter objects will be persisted separately and only deserialized as needed, so "swapping in" a virtual object that references other virtual objects does not entail swapping in the entire associated object graph.
 
-- The in-memory manifestations of a virtual object (which we call its "representatives") are not necessarily (or even usually) `===` to each other, even when they represent the same object, since a new representative is created for each act of deserialization.  (Note: future implementations may remove this limitation by having at most one representative in memory for any given virtual object, at which point object identity, i.e., `===`, _will_ be usable for comparison.)  All representatives for a given object do, however, operate on the same underlying state, so changes to the state made by a method call to one representative will be visible to the other representatives.
-
-- The `self` object returned by the `instanceKitMaker` function _is_ the representative, so you can capture it inside any of the body methods (as well as the `init` function) in order to pass the virtual object to somebody else.  So you can write things like the following:
+- The `self` object returned by the `instanceKitMaker` function _is_ the in-memory representation of the virtual object, so you can capture it inside any of the body methods (as well as the `init` function) in order to pass the virtual object to somebody else.  So you can write things like the following:
 
 ```javascript
   function thingKitMaker(state) {
@@ -124,10 +122,10 @@ to obtain a new weak store instance, which you can then access using the `has`, 
 
 However, the vat secondary storage system's `makeWeakStore` augments the one provided by the `@agoric/store` package in two important ways:
 
-- Weak store operations may use virtual object representatives as keys, and if you do this the corresponding underlying virtual object instance identities will be used for indexing rather than the object identities of the representative objects (i.e., two different representives for the same underlying virtual object will operate on the same weak store entry).
+- Weak store operations may use virtual objects as keys, and if you do this the corresponding underlying virtual object instance identities will be used for indexing rather than the current in-memory object identities of the objects.
 
 - The values set for weak store entries will be saved persistently to secondary storage.  This means that such weak stores can grow to be very large without impacting the vat's memory footprint.
 
 Since weak store values are saved persistently, they must be serializable and will be hardened as soon as they are set.
 
-An important caveat is that the latter entries are currently not actually weak, in the sense that if a virtual object becomes unreferenced, any corresponding weak store entries will not go away.  This is not semantically visible to vat code, but does impact the disk storage footprint of the vat.  Since virtual object representatives may come and go depending on the working state of the vat, there is no graceful way to garbage collect the underlying objects or corresponding weak store entries; a future system which can do robust distributed garbage collection should eventually rectify this, but for now you should not rely on any such garbage collection happening.
+An important caveat is that the latter entries are currently not actually weak, in the sense that if a virtual object becomes unreferenced, any corresponding weak store entries will not go away.  This is not semantically visible to vat code, but does impact the disk storage footprint of the vat.  Since the in-memory representations of virtual objects may come and go depending on the working state of the vat, there is no graceful way to garbage collect the underlying objects or corresponding weak store entries; a future system which can do robust distributed garbage collection should eventually rectify this, but for now you should not rely on any such garbage collection happening.

--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -27,7 +27,7 @@ const DEFAULT_VIRTUAL_OBJECT_CACHE_SIZE = 3; // XXX ridiculously small value to 
  * @param {*} vatParameters
  * @param {*} gcTools { WeakRef, FinalizationRegistry, waitUntilQuiescent }
  * @param {Console} console
- * @returns {*} { vatGlobals, dispatch, setBuildRootObject }
+ * @returns {*} { vatGlobals, inescapableGlobalLexicals, dispatch, setBuildRootObject }
  *
  * setBuildRootObject should be called, once, with a function that will
  * create a root object for the new vat The caller provided buildRootObject
@@ -342,6 +342,8 @@ function build(
     makeVirtualObjectRepresentative,
     makeWeakStore,
     makeKind,
+    VirtualizedWeakMap,
+    VirtualizedWeakSet,
   } = makeVirtualObjectManager(
     syscall,
     allocateExportID,
@@ -804,6 +806,11 @@ function build(
     makeKind,
   });
 
+  const inescapableGlobalLexicals = harden({
+    WeakMap: VirtualizedWeakMap,
+    WeakSet: VirtualizedWeakSet,
+  });
+
   function setBuildRootObject(buildRootObject) {
     assert(!didRoot);
     didRoot = true;
@@ -894,7 +901,14 @@ function build(
   harden(dispatch);
 
   // we return 'deadSet' for unit tests
-  return harden({ vatGlobals, setBuildRootObject, dispatch, m, deadSet });
+  return harden({
+    vatGlobals,
+    inescapableGlobalLexicals,
+    setBuildRootObject,
+    dispatch,
+    m,
+    deadSet,
+  });
 }
 
 /**
@@ -909,7 +923,7 @@ function build(
  * @param {boolean} enableDisavow
  * @param {*} gcTools { WeakRef, FinalizationRegistry, waitUntilQuiescent }
  * @param {Console} [liveSlotsConsole]
- * @returns {*} { vatGlobals, dispatch, setBuildRootObject }
+ * @returns {*} { vatGlobals, inescapableGlobalLexicals, dispatch, setBuildRootObject }
  *
  * setBuildRootObject should be called, once, with a function that will
  * create a root object for the new vat The caller provided buildRootObject
@@ -957,8 +971,20 @@ export function makeLiveSlots(
     gcTools,
     liveSlotsConsole,
   );
-  const { vatGlobals, dispatch, setBuildRootObject, deadSet } = r; // omit 'm'
-  return harden({ vatGlobals, dispatch, setBuildRootObject, deadSet });
+  const {
+    vatGlobals,
+    inescapableGlobalLexicals,
+    dispatch,
+    setBuildRootObject,
+    deadSet,
+  } = r; // omit 'm'
+  return harden({
+    vatGlobals,
+    inescapableGlobalLexicals,
+    dispatch,
+    setBuildRootObject,
+    deadSet,
+  });
 }
 
 // for tests

--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -346,6 +346,8 @@ function build(
     syscall,
     allocateExportID,
     valToSlot,
+    // eslint-disable-next-line no-use-before-define
+    registerValue,
     m,
     cacheSize,
   );
@@ -397,7 +399,7 @@ function build(
   }
 
   function registerValue(slot, val) {
-    const { type } = parseVatSlot(slot);
+    const { type, virtual } = parseVatSlot(slot);
     slotToVal.set(slot, new WeakRef(val));
     valToSlot.set(val, slot);
     if (type === 'object' || type === 'device') {
@@ -414,7 +416,9 @@ function build(
     // that test-liveslots.js test('dropImports') passes despite this,
     // because it uses a fake WeakRef that doesn't care about the strong
     // reference.
-    safetyPins.add(val);
+    if (!virtual) {
+      safetyPins.add(val);
+    }
   }
 
   function convertSlotToVal(slot, iface = undefined) {
@@ -459,8 +463,8 @@ function build(
       } else {
         assert.fail(X`unrecognized slot type '${type}'`);
       }
-      registerValue(slot, val);
     }
+    registerValue(slot, val);
     return val;
   }
 

--- a/packages/SwingSet/src/kernel/vatManager/manager-local.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-local.js
@@ -129,7 +129,7 @@ export function makeLocalVatManagerFactory(tools) {
       assert,
     });
     const inescapableTransforms = [];
-    const inescapableGlobalLexicals = {};
+    const inescapableGlobalLexicals = { ...ls.inescapableGlobalLexicals };
     if (metered) {
       const getMeter = meterRecord.getMeter;
       inescapableTransforms.push(src => transformMetering(src, getMeter));

--- a/packages/SwingSet/src/kernel/virtualObjectManager.js
+++ b/packages/SwingSet/src/kernel/virtualObjectManager.js
@@ -447,7 +447,10 @@ export function makeVirtualObjectManager(
 
     function reanimate(vobjID) {
       // kdebug(`vo reanimate ${vobjID}`);
-      return makeRepresentative(cache.lookup(vobjID, false), false).self;
+      const innerSelf = cache.lookup(vobjID, false);
+      const representative = makeRepresentative(innerSelf, false).self;
+      innerSelf.representative = representative;
+      return representative;
     }
     kindTable.set(kindID, reanimate);
 
@@ -465,6 +468,7 @@ export function makeVirtualObjectManager(
       if (init) {
         init(...args);
       }
+      innerSelf.representative = initialRepresentative;
       registerValue(vobjID, initialRepresentative);
       initializationsInProgress.delete(initialData);
       const rawData = {};

--- a/packages/SwingSet/src/kernel/virtualObjectManager.js
+++ b/packages/SwingSet/src/kernel/virtualObjectManager.js
@@ -436,12 +436,12 @@ export function makeVirtualObjectManager(
       if (initializing) {
         innerSelf.wrapData = wrapData;
         instanceKit = harden(instanceKitMaker(innerSelf.rawData));
+        cache.remember(innerSelf);
       } else {
         const activeData = {};
         wrapData(activeData);
         instanceKit = harden(instanceKitMaker(activeData));
       }
-      cache.remember(innerSelf);
       return instanceKit;
     }
 

--- a/packages/SwingSet/src/kernel/virtualObjectManager.js
+++ b/packages/SwingSet/src/kernel/virtualObjectManager.js
@@ -328,39 +328,40 @@ export function makeVirtualObjectManager(
 
   /* eslint max-classes-per-file: ["error", 2] */
 
-  const actualWeakMaps = new WeakMap();
-  const virtualObjectMaps = new WeakMap();
-
   class VirtualizedWeakMap {
+    #actual;
+
+    #virtual;
+
     constructor() {
-      actualWeakMaps.set(this, new WeakMap());
-      virtualObjectMaps.set(this, new Map());
+      this.#actual = new WeakMap();
+      this.#virtual = new Map();
     }
 
     has(key) {
       const vkey = vrefKey(key);
       if (vkey) {
-        return virtualObjectMaps.get(this).has(vkey);
+        return this.#virtual.has(vkey);
       } else {
-        return actualWeakMaps.get(this).has(key);
+        return this.#actual.has(key);
       }
     }
 
     get(key) {
       const vkey = vrefKey(key);
       if (vkey) {
-        return virtualObjectMaps.get(this).get(vkey);
+        return this.#virtual.get(vkey);
       } else {
-        return actualWeakMaps.get(this).get(key);
+        return this.#actual.get(key);
       }
     }
 
     set(key, value) {
       const vkey = vrefKey(key);
       if (vkey) {
-        virtualObjectMaps.get(this).set(vkey, value);
+        this.#virtual.set(vkey, value);
       } else {
-        actualWeakMaps.get(this).set(key, value);
+        this.#actual.set(key, value);
       }
       return this;
     }
@@ -368,9 +369,9 @@ export function makeVirtualObjectManager(
     delete(key) {
       const vkey = vrefKey(key);
       if (vkey) {
-        return virtualObjectMaps.get(this).delete(vkey);
+        return this.#virtual.delete(vkey);
       } else {
-        return actualWeakMaps.get(this).delete(key);
+        return this.#actual.delete(key);
       }
     }
   }

--- a/packages/SwingSet/src/weakref.js
+++ b/packages/SwingSet/src/weakref.js
@@ -6,7 +6,7 @@ const { defineProperties } = Object;
 /*
  * We retain a measure of compatibility with Node.js v12, which does not
  * expose WeakRef or FinalizationRegistry (there is a --flag for it, but it's
- * * not clear how stable it is). When running on a platform without these *
+ * not clear how stable it is). When running on a platform without these
  * tools, vats cannot do GC, and the tools they get will be no-ops. WeakRef
  * instances will hold a strong reference, and the FinalizationRegistry will
  * never invoke the callbacks.

--- a/packages/SwingSet/test/virtualObjects/test-virtualObjectManager.js
+++ b/packages/SwingSet/test/virtualObjects/test-virtualObjectManager.js
@@ -241,3 +241,76 @@ test('weak store operations', t => {
   ws1.set(nv2, 'non-virtual object #2 revised');
   t.is(ws1.get(nv2), 'non-virtual object #2 revised');
 });
+
+test('virtualized weak collection operations', t => {
+  // TODO: don't yet have a way to test the weakness of the virtualized weak
+  // collections
+
+  const {
+    VirtualizedWeakMap,
+    VirtualizedWeakSet,
+    makeKind,
+  } = makeFakeVirtualObjectManager(3);
+
+  const thingMaker = makeKind(makeThingInstance);
+  const zotMaker = makeKind(makeZotInstance);
+
+  const thing1 = thingMaker('t1');
+  const thing2 = thingMaker('t2');
+
+  const zot1 = zotMaker(1, 'z1');
+  const zot2 = zotMaker(2, 'z2');
+  const zot3 = zotMaker(3, 'z3');
+  const zot4 = zotMaker(4, 'z4');
+
+  const wm1 = new VirtualizedWeakMap();
+  const wm2 = new VirtualizedWeakMap();
+  const nv1 = {};
+  const nv2 = { a: 47 };
+  wm1.set(zot1, 'zot #1');
+  wm2.set(zot2, 'zot #2');
+  wm1.set(zot3, 'zot #3');
+  wm2.set(zot4, 'zot #4');
+  wm1.set(thing1, 'thing #1');
+  wm2.set(thing2, 'thing #2');
+  wm1.set(nv1, 'non-virtual object #1');
+  wm1.set(nv2, 'non-virtual object #2');
+  t.is(wm1.get(zot1), 'zot #1');
+  t.is(wm1.has(zot1), true);
+  t.is(wm2.has(zot1), false);
+  wm1.set(zot3, 'zot #3 revised');
+  wm2.delete(zot4);
+  t.is(wm1.get(nv1), 'non-virtual object #1');
+  t.is(wm1.get(nv2), 'non-virtual object #2');
+  t.is(wm2.has(zot4), false);
+  t.is(wm1.get(zot3), 'zot #3 revised');
+  wm1.delete(nv1);
+  t.is(wm1.has(nv1), false);
+  wm1.set(nv2, 'non-virtual object #2 revised');
+  t.is(wm1.get(nv2), 'non-virtual object #2 revised');
+
+  const ws1 = new VirtualizedWeakSet();
+  const ws2 = new VirtualizedWeakSet();
+  ws1.add(zot1);
+  ws2.add(zot2);
+  ws1.add(zot3);
+  ws2.add(zot4);
+  ws1.add(thing1);
+  ws2.add(thing2);
+  ws1.add(nv1);
+  ws1.add(nv2);
+  t.is(ws1.has(zot1), true);
+  t.is(ws2.has(zot1), false);
+  ws1.add(zot3);
+  ws2.delete(zot4);
+  t.is(ws1.has(nv1), true);
+  t.is(ws1.has(nv2), true);
+  t.is(ws2.has(nv1), false);
+  t.is(ws2.has(nv2), false);
+  t.is(ws2.has(zot4), false);
+  t.is(ws1.has(zot3), true);
+  ws1.delete(nv1);
+  t.is(ws1.has(nv1), false);
+  ws1.add(nv2);
+  t.is(ws1.has(nv2), true);
+});

--- a/packages/SwingSet/tools/fakeVirtualObjectManager.js
+++ b/packages/SwingSet/tools/fakeVirtualObjectManager.js
@@ -64,6 +64,8 @@ export function makeFakeVirtualObjectManager(cacheSize = 100) {
     makeVirtualObjectRepresentative,
     makeWeakStore,
     makeKind,
+    VirtualizedWeakMap,
+    VirtualizedWeakSet,
     flushCache,
   } = makeVirtualObjectManager(
     fakeSyscall,
@@ -77,6 +79,8 @@ export function makeFakeVirtualObjectManager(cacheSize = 100) {
   return {
     makeKind,
     makeWeakStore,
+    VirtualizedWeakMap,
+    VirtualizedWeakSet,
     flushCache,
     dumpStore,
   };

--- a/packages/SwingSet/tools/fakeVirtualObjectManager.js
+++ b/packages/SwingSet/tools/fakeVirtualObjectManager.js
@@ -55,6 +55,11 @@ export function makeFakeVirtualObjectManager(cacheSize = 100) {
   // eslint-disable-next-line no-use-before-define
   const fakeMarshal = makeMarshal(fakeConvertValToSlot, fakeConvertSlotToVal);
 
+  function fakeRegisterValue(slot, val) {
+    slotToVal.set(slot, val);
+    valToSlot.set(val, slot);
+  }
+
   const {
     makeVirtualObjectRepresentative,
     makeWeakStore,
@@ -64,6 +69,7 @@ export function makeFakeVirtualObjectManager(cacheSize = 100) {
     fakeSyscall,
     fakeAllocateExportID,
     valToSlot,
+    fakeRegisterValue,
     fakeMarshal,
     cacheSize,
   );


### PR DESCRIPTION
Your class looks much better with the newfangled private instance variables. Should make no semantic difference, nor even a performance difference on engines using the transposed representation of weakmaps. IOW, no speedup expected on XS. Better GC performance on, for example, v8.

But DO NOT MERGE because our tool support is not up to it. Our bundle-source calls rollup which calls acorn to parse the file. The version of acorn it uses doesn't understand that newfangled syntax. But want to get this out there for future reference.