### PR TITLE
Fixes for bootstrap tokens

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Save Git revision
-      run: git rev-parse HEAD > packages/cosmic-swingset/lib/git-revision.txt
+      run: echo "GIT_REVISION=$(git rev-parse HEAD)" >> $GITHUB_ENV
     - name: Save SDK_VERSION
       run: echo "SDK_VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
     - name: Save MODDABLE_COMMIT_HASH
@@ -23,7 +23,7 @@ jobs:
       with:
         name: agoric/agoric-sdk
         dockerfile: packages/deployment/Dockerfile.sdk
-        buildargs: MODDABLE_COMMIT_HASH
+        buildargs: MODDABLE_COMMIT_HASH,GIT_REVISION
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         snapshot: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,8 +59,8 @@ jobs:
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: agoric/cosmic-swingset-solo
-        dockerfile: packages/cosmic-swingset/lib/ag-solo/Dockerfile
-        context: packages/cosmic-swingset/lib/ag-solo
+        dockerfile: packages/solo/Dockerfile
+        context: packages/solo
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         snapshot: true

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -358,6 +358,7 @@ jobs:
     # END-RESTORE-BOILERPLATE
 
     - name: yarn test (solo)
+      timeout-minutes: 20
       run: cd packages/solo && yarn test
       env:
         ESM_DISABLE_CACHE: true

--- a/docker/ag-setup-solo
+++ b/docker/ag-setup-solo
@@ -21,7 +21,7 @@ else
 fi
 exec docker run \
   -p127.0.0.1:$HOST_PORT:$PORT \
-  --volume=ag-solo-state:/agoric/solo \
+  --volume=ag-solo-state:/data/solo \
   --volume=$HOME/.agoric:/root/.agoric \
   -eAG_SOLO_BASEDIR="$SOLO_HOME" \
   --rm -it $FLAGS \

--- a/docker/ag-solo
+++ b/docker/ag-solo
@@ -19,7 +19,7 @@ else
   FLAGS=-p127.0.0.1:$HOST_PORT:$PORT
 fi
 exec docker run \
-  --volume=ag-solo-state:/agoric/solo \
+  --volume=ag-solo-state:/data/solo \
   --volume=$HOME/.agoric:/root/.agoric \
   -eAG_SOLO_BASEDIR="$SOLO_HOME" \
   --rm -it $FLAGS \

--- a/golang/cosmos/.gitignore
+++ b/golang/cosmos/.gitignore
@@ -85,7 +85,6 @@ typings/
 
 # next.js build output
 .next
-lib/git-revision.txt
 /binding.gyp
 *-stamp
 build/

--- a/packages/agoric-cli/lib/chain-config.js
+++ b/packages/agoric-cli/lib/chain-config.js
@@ -5,6 +5,9 @@ export const MINT_DENOM = 'ubld';
 export const STAKING_DENOM = 'ubld';
 export const STAKING_MAX_VALIDATORS = 150;
 
+export const DEFAULT_BOOTSTRAP_VALUE = 50000n * 10n ** 6n;
+export const DEFAULT_DONATION_VALUE = 5n * 10n ** 6n;
+
 export const GOV_DEPOSIT_COINS = [{ amount: '1000000', denom: MINT_DENOM }];
 
 // Can't beat the speed of light, we need 600ms round trip time for the other
@@ -93,7 +96,13 @@ export function finishTendermintConfig({
 }
 
 // Rewrite/import the genesis.json.
-export function finishCosmosGenesis({ genesisJson, exportedGenesisJson }) {
+export function finishCosmosGenesis({
+  genesisJson,
+  exportedGenesisJson,
+  bootstrapAddress,
+  bootstrapValue,
+  donationValue,
+}) {
   const genesis = JSON.parse(genesisJson);
   const exported = exportedGenesisJson ? JSON.parse(exportedGenesisJson) : {};
 
@@ -124,20 +133,11 @@ export function finishCosmosGenesis({ genesisJson, exportedGenesisJson }) {
   genesis.app_state.mint.params.inflation_rate_change = '0.0';
   genesis.app_state.mint.params.inflation_min = '0.0';
 
-  /*
-		FIXME: Allow these to be configurable.
-		- name: faucet
-		  type: local
-		  address: agoric1hr29lkgsdzdr0jdpa0tfzjgrm0vnd339qde52l
-		  pubkey: agoricpub1addwnpepqw0aeejelzrmy9wn0tp9zcs70jf2d0jw0ycyt6pc4a92fmss9uv4g5e0n9y
-		  mnemonic: ""
-		  threshold: 0
-		  pubkeys: []
-	*/
-  genesis.app_state.vpurse.bootstrap_address =
-    'agoric1hr29lkgsdzdr0jdpa0tfzjgrm0vnd339qde52l';
-  genesis.app_state.vpurse.bootstrap_value = `${50000n * 10n ** 6n}`;
-  genesis.app_state.vpurse.donation_value = `${5n * 10n ** 6n}`;
+  genesis.app_state.vpurse.bootstrap_address = bootstrapAddress;
+  genesis.app_state.vpurse.bootstrap_value = `${bootstrapValue ||
+    DEFAULT_BOOTSTRAP_VALUE}`;
+  genesis.app_state.vpurse.donation_value = `${donationValue ||
+    DEFAULT_DONATION_VALUE}`;
 
   // Set the denomination for different modules.
   genesis.app_state.mint.params.mint_denom = MINT_DENOM;

--- a/packages/agoric-cli/lib/set-defaults.js
+++ b/packages/agoric-cli/lib/set-defaults.js
@@ -17,6 +17,18 @@ export default async function setDefaultsMain(progname, rawArgs, powers, opts) {
     X`<prog> must currently be 'ag-chain-cosmos'`,
   );
 
+  const { bootstrapAddress, bootstrapValue, donationValue } = opts;
+
+  console.log(bootstrapAddress, bootstrapValue, donationValue);
+  assert(
+    bootstrapAddress || !bootstrapValue,
+    X`must set bootstrap-address if bootstrap-value is set`,
+  );
+  assert(
+    bootstrapAddress || !donationValue,
+    X`must set bootstrap-address if donation-value is set`,
+  );
+
   const { exportMetrics } = opts;
 
   let appFile;
@@ -82,6 +94,9 @@ export default async function setDefaultsMain(progname, rawArgs, powers, opts) {
     const newGenesisJson = finishCosmosGenesis({
       genesisJson,
       exportedGenesisJson,
+      bootstrapAddress,
+      bootstrapValue,
+      donationValue,
     });
 
     await create(genesisFile, newGenesisJson);

--- a/packages/agoric-cli/lib/start.js
+++ b/packages/agoric-cli/lib/start.js
@@ -5,7 +5,6 @@ import { createHash } from 'crypto';
 
 import {
   STAKING_DENOM,
-  MINT_DENOM,
   finishTendermintConfig,
   finishCosmosGenesis,
   finishCosmosApp,
@@ -13,7 +12,7 @@ import {
 
 import { makePspawn } from './helpers';
 
-const PROVISION_COINS = `100000000${STAKING_DENOM},100000000${MINT_DENOM},100provisionpass,100sendpacketpass`;
+const PROVISION_COINS = `100000000${STAKING_DENOM},100provisionpass,100sendpacketpass`;
 const DELEGATE0_COINS = `50000000${STAKING_DENOM}`;
 const CHAIN_ID = 'agoric';
 
@@ -312,6 +311,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
     ]);
     const newGenesisJson = finishCosmosGenesis({
       genesisJson,
+      bootstrapAddress: addrs.provision,
     });
     const newConfigToml = finishTendermintConfig({
       configToml,

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -30,6 +30,7 @@
     "@agoric/bundle-source": "^1.3.4",
     "@agoric/captp": "^1.7.10",
     "@agoric/install-ses": "^0.5.10",
+    "@agoric/nat": "^4.0.0",
     "@agoric/promise-kit": "^0.2.10",
     "@agoric/swing-store-simple": "^0.3.6",
     "@iarna/toml": "^2.2.3",

--- a/packages/cosmic-swingset/.dockerignore
+++ b/packages/cosmic-swingset/.dockerignore
@@ -8,10 +8,6 @@ provisioning-server
 solo
 build
 node_modules
-lib/ag-solo/ui/node_modules
-lib/ag-solo/ui/build
-lib/lib*.h
-lib/lib*.so
 ve[0-9]
 t[0-9]
 binding.gyp

--- a/packages/cosmic-swingset/.gitignore
+++ b/packages/cosmic-swingset/.gitignore
@@ -86,6 +86,3 @@ typings/
 
 # next.js build output
 .next
-lib/git-revision.txt
-/binding.gyp
-*-stamp

--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -66,7 +66,7 @@ scenario2-setup-nobuild:
 	$(AGCH) --home=t1/n0 --keyring-dir=t1/bootstrap gentx --keyring-backend=test bootstrap 73000000ubld --chain-id=$(CHAIN_ID)
 	$(AGCH) --home=t1/n0 collect-gentxs
 	$(AGCH) --home=t1/n0 validate-genesis
-	../agoric-cli/bin/agoric set-defaults --export-metrics ag-chain-cosmos t1/n0/config
+	../agoric-cli/bin/agoric set-defaults --export-metrics --bootstrap-address=`cat t1/bootstrap-address` ag-chain-cosmos t1/n0/config
 	# Set the chain address in all the ag-solos.
 	jq '. + { genesis_time: "$(GENESIS_TIME)", initial_height: "$(INITIAL_HEIGHT)" }' t1/n0/config/genesis.json > t1/n0/config/genesis2.json
 	mv t1/n0/config/genesis2.json t1/n0/config/genesis.json

--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -1,6 +1,5 @@
 REPOSITORY = agoric/cosmic-swingset
 CHAIN_ID = agoric
-INITIAL_TOKENS = 1000000000000urun
 INITIAL_HEIGHT = 17
 GENESIS_TIME = $(shell TZ=UTC date +%Y-%m-%dT%H:%M:%SZ)
 

--- a/packages/cosmic-swingset/bin/ag-nchainz
+++ b/packages/cosmic-swingset/bin/ag-nchainz
@@ -22,7 +22,7 @@ thisdir=$(cd "$(dirname -- "$real0")" && pwd -P)
 PATHCONFIG=nchainz/config/paths
 CLI=ag-cosmos-helper
 DAEMON=ag-chain-cosmos
-SOLO=$thisdir/ag-solo
+SOLO=$thisdir/../solo/bin/ag-solo
 SKIP=no
 COMMAND=
 

--- a/packages/cosmic-swingset/bin/ag-nchainz
+++ b/packages/cosmic-swingset/bin/ag-nchainz
@@ -55,7 +55,6 @@ testnet)
   portstart=$(( $BASE_PORT + $i * $NUM_SOLOS ))
   portend=$(( $portstart + $NUM_SOLOS - 1 ))
   SOLO_ADDRS=()
-  SOLO_NAMES=()
   POWER_FLAGS='[\"agoric.vattp\"]'
   egresses=
   sep=''
@@ -64,6 +63,7 @@ testnet)
     echo "Initializing ag-solo in $solo"
 		$SOLO init $solo --webport=$port
     addr=$(cat $solo/ag-cosmos-helper-address)
+    SOLO_ADDRS+=( "$addr" )
 		$DAEMON add-genesis-account --home=$n0d \
       $($CLI --home=$solo/$CLI-statedir --keyring-backend=test keys show -a ag-solo) \
       1000urun,1provisionpass
@@ -73,7 +73,8 @@ testnet)
 	done
   for node in `ls -d $chainid/n* 2>/dev/null || true`; do
     [[ "$node/$DAEMON" == $n0d ]] || cp $n0d/config/genesis.json $node/$DAEMON/config/genesis.json
-	  "$thisdir/../../agoric-cli/bin/agoric" set-defaults ag-chain-cosmos $node/$DAEMON/config
+	  "$thisdir/../../agoric-cli/bin/agoric" set-defaults --bootstrap-address=${SOLO_ADDRS[0]} \
+      ag-chain-cosmos $node/$DAEMON/config
     cp "$node/$DAEMON/config/genesis.json" "$node/$DAEMON/config/genesis-orig.json"
     # Append the egresses to the genesis and reset bond_denom.
     jq ".*{app_state:{staking:{params:{bond_denom:\"stake\"}},swingset:{storage:{$egresses}}}}" \

--- a/packages/cosmic-swingset/scripts/single-node.sh
+++ b/packages/cosmic-swingset/scripts/single-node.sh
@@ -44,7 +44,7 @@ case $DAEMON in
 ag-chain-cosmos)
   # For Agoric
   DIR=$(dirname -- "${BASH_SOURCE[0]}")
-  "$DIR/../../agoric-cli/bin/agoric" set-defaults ag-chain-cosmos ~/.$DAEMON/config
+  "$DIR/../../agoric-cli/bin/agoric" set-defaults --bootstrap-address=$GENACCT ag-chain-cosmos ~/.$DAEMON/config
   ;;
 esac
 

--- a/packages/cosmic-swingset/scripts/single-node.sh
+++ b/packages/cosmic-swingset/scripts/single-node.sh
@@ -5,7 +5,7 @@ set -e
 DAEMON=${DAEMON-gaiad}
 CLI=${CLI-gaiacli}
 STAKE=${STAKE-10000000000stake}
-coins="${STAKE},100000000000samoleans,1000000000urun,100provisionpass"
+coins="${STAKE},100000000000samoleans,1000000000ubld,100provisionpass"
 
 CHAINID=$1
 GENACCT=$2

--- a/packages/deployment/Dockerfile
+++ b/packages/deployment/Dockerfile
@@ -31,10 +31,7 @@ RUN ln -sf $PWD/ag-setup-cosmos /usr/local/bin/
 COPY package*.json .
 RUN npm install --production
 
-# Add the ag-solo, so we can deploy it via Ansible.
-COPY --from=agoric/cosmic-swingset-solo /usr/src/agoric-sdk/packages/cosmic-swingset/lib/ag-solo/ /usr/src/agoric-sdk/packages/cosmic-swingset/lib/ag-solo/
-
 COPY . .
-WORKDIR /agoric/chains
+WORKDIR /data/chains
 
 ENTRYPOINT [ "ag-setup-cosmos" ]

--- a/packages/deployment/Dockerfile
+++ b/packages/deployment/Dockerfile
@@ -28,10 +28,7 @@ RUN echo 'deb http://ppa.launchpad.net/ansible/ansible/ubuntu trusty main' >> /e
 
 WORKDIR /usr/src/agoric-sdk/packages/deployment
 RUN ln -sf $PWD/ag-setup-cosmos /usr/local/bin/
-COPY package*.json .
-RUN npm install --production
 
-COPY . .
 WORKDIR /data/chains
 
 ENTRYPOINT [ "ag-setup-cosmos" ]

--- a/packages/deployment/Dockerfile.sdk
+++ b/packages/deployment/Dockerfile.sdk
@@ -47,6 +47,9 @@ WORKDIR /usr/src
 COPY --from=build-js /usr/src/agoric-sdk agoric-sdk
 COPY --from=build-js /root/go/bin/ag-cosmos-helper /usr/local/bin/
 RUN ln -s /usr/src/agoric-sdk/packages/cosmic-swingset/bin/ag-chain-cosmos /usr/local/bin/
+RUN ln -s /usr/src/agoric-sdk/packages/solo/bin/ag-solo /usr/local/bin/
+RUN ln -s /usr/src/agoric-sdk/packages/agoric-cli/bin/agoric /usr/local/bin/
+COPY . lib/ag-solo/
 
 # By default, run the daemon with specified arguments.
 WORKDIR /root

--- a/packages/deployment/Dockerfile.sdk
+++ b/packages/deployment/Dockerfile.sdk
@@ -54,6 +54,11 @@ COPY . lib/ag-solo/
 ARG GIT_REVISION=unknown
 RUN echo "$GIT_REVISION" > /usr/src/agoric-sdk/packages/solo/public/git-revision.txt
 
+# Compatibility links for older containers.
+RUN ln -s /data /agoric
+RUN ln -s /data/solo /usr/src/agoric-sdk/packages/cosmic-swingset/solo
+RUN ln -s /data/chains /usr/src/agoric-sdk/packages/cosmic-swingset/chains
+
 # By default, run the daemon with specified arguments.
 WORKDIR /root
 EXPOSE 1317 9090 26657

--- a/packages/deployment/Dockerfile.sdk
+++ b/packages/deployment/Dockerfile.sdk
@@ -8,8 +8,8 @@ RUN go mod download
 
 COPY golang/cosmos ./
 
-COPY packages/cosmic-swingset/lib/*.txt ./
-RUN make MOD_READONLY= compile-go
+ARG GIT_REVISION
+RUN make GIT_REVISION="$GIT_REVISION" MOD_READONLY= compile-go
 
 ###############################
 # The js build container
@@ -50,6 +50,9 @@ RUN ln -s /usr/src/agoric-sdk/packages/cosmic-swingset/bin/ag-chain-cosmos /usr/
 RUN ln -s /usr/src/agoric-sdk/packages/solo/bin/ag-solo /usr/local/bin/
 RUN ln -s /usr/src/agoric-sdk/packages/agoric-cli/bin/agoric /usr/local/bin/
 COPY . lib/ag-solo/
+
+ARG GIT_REVISION=unknown
+RUN echo "$GIT_REVISION" > /usr/src/agoric-sdk/packages/solo/public/git-revision.txt
 
 # By default, run the daemon with specified arguments.
 WORKDIR /root

--- a/packages/deployment/Makefile
+++ b/packages/deployment/Makefile
@@ -6,6 +6,9 @@ VERSION := $(shell node -e 'console.log(require("../../package.json").version)' 
 TAG := $(if $(VERSION),$(VERSION),latest)
 MODDABLE_COMMIT_HASH := $(shell git submodule status ../xsnap/moddable | \
 	sed -ne 's/^.\([^ ]*\).*/\1/p')
+GIT_REVISION := $(shell hash=$$(git rev-parse --short HEAD); \
+	dirty=`git diff --quiet || echo -dirty`; \
+	echo "$$hash$$dirty")
 
 # Don't push alpha tags as ":$(TAG)".
 ifeq ($(TAG),latest)
@@ -22,10 +25,8 @@ docker-build: docker-build-sdk docker-build-solo \
 	docker-build-setup docker-build-deployment
 
 docker-build-sdk:
-	hash=`git rev-parse --short HEAD`; \
-	  dirty=`git diff --quiet || echo -dirty`; \
-	  echo "$$hash$$dirty" > $(SS)lib/git-revision.txt
 	docker build --build-arg=MODDABLE_COMMIT_HASH=$(MODDABLE_COMMIT_HASH) \
+		--build-arg=GIT_REVISION=$(GIT_REVISION) \
 		-t $(REPOSITORY_SDK):$(TAG) --file=Dockerfile.sdk ../..
 	docker tag $(REPOSITORY_SDK):$(TAG) $(REPOSITORY_SDK):latest
 

--- a/packages/deployment/Makefile
+++ b/packages/deployment/Makefile
@@ -34,7 +34,7 @@ docker-build-setup:
 	docker tag $(REPOSITORY)-setup:$(TAG) $(REPOSITORY)-setup:latest
 
 docker-build-solo:
-	docker build --build-arg=TAG=$(TAG) -t $(REPOSITORY)-solo:$(TAG) $(SS)lib/ag-solo
+	docker build --build-arg=TAG=$(TAG) -t $(REPOSITORY)-solo:$(TAG) ../solo
 	docker tag $(REPOSITORY)-solo:$(TAG) $(REPOSITORY)-solo:latest
 
 docker-build-deployment:

--- a/packages/deployment/ansible/cosmos-genesis.yml
+++ b/packages/deployment/ansible/cosmos-genesis.yml
@@ -6,12 +6,12 @@
   vars:
     - data: "{{ SETUP_HOME }}/{{ service }}/data"
     - service: ag-chain-cosmos
-    - BOOTSTRAP_TOKENS: "{{ lookup('file', SETUP_HOME + '/boot-tokens.txt') }},100provisionpass"
+    - BOOTSTRAP_TOKENS: 100provisionpass
     - CHAIN_NAME: "{{ lookup('file', SETUP_HOME + '/ag-chain-cosmos/chain-name.txt') }}"
     - NETWORK_CONFIG_URL: https://testnet.agoric.com/network-config
     - STAKER: ag-staker
     - STAKER_TOKENS: 10000000000000000000000000ubld
-    - STAKER_INIT_COINS: 62000000ubld,93000000urun
+    - STAKER_INIT_COINS: 62000000ubld
     - STAKER_SELF_DELEGATION: 50000000ubld
     - STAKER_NODE: validator0
   roles:

--- a/packages/deployment/ansible/cosmos-validators.yml
+++ b/packages/deployment/ansible/cosmos-validators.yml
@@ -11,7 +11,7 @@
     - CHAIN_NAME: "{{ lookup('file', SETUP_HOME + '/' + service + '/chain-name.txt') }}"
     - STAKER: ag-staker
     - STAKER_NODE: validator0
-    - STAKER_INIT_COINS: 62000000ubld,93000000urun
+    - STAKER_INIT_COINS: 62000000ubld
     - STAKER_SELF_DELEGATION: 50000000ubld
   roles:
     - cosmos-validators

--- a/packages/deployment/ansible/install-cosmos.yml
+++ b/packages/deployment/ansible/install-cosmos.yml
@@ -8,7 +8,7 @@
   vars:
     - service: ag-chain-cosmos
     - data: "{{ SETUP_HOME }}/{{ service }}/data"
-    - execline: "/usr/src/cosmic-swingset/bin/ag-chain-cosmos start"
+    - execline: "/usr/local/bin/ag-chain-cosmos start"
     - PERSISTENT_PEERS: "{{ lookup('file', SETUP_HOME + '/' + service + '/data/peers.txt') }}"
     - NUM_FILE_DESCRIPTORS: 2048
     - BLOCK_CADENCE: 2s

--- a/packages/deployment/ansible/prepare-cosmos.yml
+++ b/packages/deployment/ansible/prepare-cosmos.yml
@@ -8,10 +8,9 @@
   vars:
     - service: ag-chain-cosmos
     - data: "{{ SETUP_HOME }}/{{ service }}/data"
-    - BOOTSTRAP_TOKENS: "{{ lookup('file', SETUP_HOME + '/boot-tokens.txt') }}"
     - CHAIN_NAME: "{{ lookup('file', SETUP_HOME + '/' + service + '/chain-name.txt') }}"
     - STAKER: ag-staker
-    - STAKER_INIT_COINS: 62000000ubld,93000000urun
+    - STAKER_INIT_COINS: 62000000ubld
     - STAKER_SELF_DELEGATION: 50000000ubld
     - HELPER_BINARY: "{{lookup('env', 'GOPATH') or '/usr/local'}}/bin/ag-cosmos-helper"
     - APPDIR: "{{lookup('pipe', 'pwd')}}/../.."

--- a/packages/deployment/ansible/roles/copy/tasks/main.yml
+++ b/packages/deployment/ansible/roles/copy/tasks/main.yml
@@ -7,30 +7,6 @@
     mode: push
   when: HELPER_BINARY is defined
 
-- name: Agoric SDK exists
-  delegate_to: localhost
-  stat:
-    path: "/usr/src/agoric-sdk"
-  register: ws
-
-- name: "Synchronize install directory {{APPDIR}}"
-  synchronize:
-    src: "{{APPDIR}}/"
-    dest: "/usr/src/cosmic-swingset/"
-    dirs: yes
-    delete: yes
-    checksum: yes
-    mode: push
-    rsync_opts:
-    - "--exclude=.git"
-    - "--exclude=setup"
-    - "--exclude=.vscode"
-    - "--exclude=chains"
-    - "--exclude=x"
-    - "--exclude=t[0-9]*"
-    - "--exclude=provisioning-server"
-  when: not ws.stat.exists
-
 - name: Synchronize Agoric SDK
   synchronize:
     src: "/usr/src/agoric-sdk/"
@@ -39,35 +15,15 @@
     delete: yes
     checksum: yes
     mode: push
-  when: ws.stat.exists
-
-- name: Remove cosmic-swingset to prepare for linking
-  file:
-    path: /usr/src/cosmic-swingset
-    state: absent
-  when: ws.stat.exists
-
-- name: Symlink cosmic-swingset
-  file:
-    src: /usr/src/agoric-sdk/packages/cosmic-swingset
-    dest: /usr/src/cosmic-swingset
-    state: link
-  when: ws.stat.exists
 
 - name: "Symlink ag-chain-cosmos"
   file:
-    src: "/usr/src/cosmic-swingset/bin/ag-chain-cosmos"
+    src: "/usr/src/agoric-sdk/packages/cosmic-swingset/bin/ag-chain-cosmos"
     dest: "/usr/local/bin/ag-chain-cosmos"
     state: link
 
-- name: "Symlink /usr/src/ag-solo"
+- name: "Symlink ag-solo"
   file:
-    src: "/usr/src/cosmic-swingset"
-    dest: /usr/src/ag-solo
-    state: link
-
-- name: "Symlink /usr/local/bin/ag-solo"
-  file:
-    src: "/usr/src/cosmic-swingset/bin/ag-solo"
+    src: "/usr/src/agoric-sdk/packages/solo/bin/ag-solo"
     dest: "/usr/local/bin/ag-solo"
     state: link

--- a/packages/deployment/ansible/roles/cosmos-genesis/files/faucet-helper.sh
+++ b/packages/deployment/ansible/roles/cosmos-genesis/files/faucet-helper.sh
@@ -10,6 +10,16 @@ DELEGATE_COINS=62000000ubld,93000000urun
 OP=$1
 shift
 
+case $OP in
+show-faucet-address)
+  exec ag-cosmos-helper --home=$FAUCET_HOME \
+    keys show -a \
+    --keyring-backend=test \
+    -- faucet
+  exit $?
+  ;;
+done
+
 chainName=$(cat "$thisdir/ag-chain-cosmos/chain-name.txt")
 IFS=, read -r -a origRpcAddrs <<<"$(AG_SETUP_COSMOS_HOME=$thisdir ag-setup-cosmos show-rpcaddrs)"
 

--- a/packages/deployment/ansible/roles/cosmos-genesis/files/faucet-helper.sh
+++ b/packages/deployment/ansible/roles/cosmos-genesis/files/faucet-helper.sh
@@ -18,7 +18,7 @@ show-faucet-address)
     -- faucet
   exit $?
   ;;
-done
+esac
 
 chainName=$(cat "$thisdir/ag-chain-cosmos/chain-name.txt")
 IFS=, read -r -a origRpcAddrs <<<"$(AG_SETUP_COSMOS_HOME=$thisdir ag-setup-cosmos show-rpcaddrs)"

--- a/packages/deployment/ansible/roles/cosmos-genesis/tasks/main.yml
+++ b/packages/deployment/ansible/roles/cosmos-genesis/tasks/main.yml
@@ -15,9 +15,8 @@
 
 - name: "Extract faucet address"
   delegate_to: localhost
-  shell: "ag-cosmos-helper --home={{ SETUP_HOME + '/../faucet' }} \
-    --keyring-backend=test \
-    keys show -a faucet > {{ SETUP_HOME + '/../faucet/address.txt' }}"
+  shell: "{{ SETUP_HOME + '/faucet-helper.sh' }} show-faucet-address \
+    > {{ SETUP_HOME + '/../faucet/address.txt' }}"
   when: not faucet
 
 - set_fact:

--- a/packages/deployment/bigdipper/settings.json
+++ b/packages/deployment/bigdipper/settings.json
@@ -18,14 +18,14 @@
       "coins": [
           {
               "denom": "ubld",
-              "displayName": "AGSTAKE",
-              "displayNamePlural": "AGSTAKES",
+              "displayName": "BLD",
+              "displayNamePlural": "BLDS",
               "fraction": 1000000
           },
      {
    "denom": "urun",
-   "displayName": "AG",
-   "displayNamePlural": "AGS",
+   "displayName": "RUN",
+   "displayNamePlural": "RUNS",
    "fraction": 1000000
      }
 

--- a/packages/deployment/docker/ag-setup-cosmos
+++ b/packages/deployment/docker/ag-setup-cosmos
@@ -22,7 +22,7 @@ show-*)
   ;;
 esac
 exec docker run --rm $TTY $FLAGS \
-  --volume=ag-setup-cosmos-chains:/agoric/chains \
+  --volume=ag-setup-cosmos-chains:/data/chains \
   --volume=ag-chain-cosmos-state:/root/.ag-chain-cosmos \
   --volume=/var/run/docker.sock:/var/run/docker.sock \
   --env AG_SETUP_COSMOS_NAME=$NETWORK_NAME \

--- a/packages/deployment/main.js
+++ b/packages/deployment/main.js
@@ -390,7 +390,7 @@ show-config      display the client connection parameters
               agoricCli,
               `set-defaults`,
               `ag-chain-cosmos`,
-              `--bootstrap-address=${faucetAddress}`,
+              `--bootstrap-address=${faucetAddress.trimRight()}`,
               `--persistent-peers=${peers}`,
               `--seeds=${seeds}`,
               `--unconditional-peer-ids=${allIds}`,
@@ -434,7 +434,7 @@ show-config      display the client connection parameters
           'play',
           'install',
           `-eexecline=${shellEscape(
-            '/usr/src/cosmic-swingset/bin/ag-chain-cosmos start --log_level=warn',
+            '/usr/local/bin/ag-chain-cosmos start --log_level=warn',
           )}`,
           ...agChainCosmosEnvironment,
         ]),

--- a/packages/deployment/main.js
+++ b/packages/deployment/main.js
@@ -380,6 +380,9 @@ show-config      display the client connection parameters
         const allIds = await needBacktick(
           `${shellEscape(progname)} show-all-ids`,
         );
+        const faucetAddress = await needBacktick(
+          `${shellEscape(progname)} show-faucet-address`,
+        );
         await Promise.all(
           dsts.map(async (dst, i) => {
             // Update the config.toml and genesis.json.
@@ -387,6 +390,7 @@ show-config      display the client connection parameters
               agoricCli,
               `set-defaults`,
               `ag-chain-cosmos`,
+              `--bootstrap-address=${faucetAddress}`,
               `--persistent-peers=${peers}`,
               `--seeds=${seeds}`,
               `--unconditional-peer-ids=${allIds}`,
@@ -514,6 +518,7 @@ ${chalk.yellow.bold(`ag-setup-solo --netconfig='${dwebHost}/network-config'`)}
       break;
     }
 
+    case 'show-faucet-address':
     case 'add-egress':
     case 'add-delegate': {
       await inited();

--- a/packages/solo/Dockerfile
+++ b/packages/solo/Dockerfile
@@ -1,10 +1,7 @@
 ARG TAG=latest
 FROM agoric/agoric-sdk:$TAG
 
-WORKDIR /usr/src/agoric-sdk/packages/cosmic-swingset
-RUN ln -sf $PWD/bin/ag-solo $PWD/node_modules/.bin/agoric /usr/local/bin/
-COPY . lib/ag-solo/
-WORKDIR /agoric/solo
+WORKDIR /data/solo
 
 EXPOSE 8000
 ENTRYPOINT [ "ag-solo", "--webhost=0.0.0.0", "--webport=8000" ]

--- a/packages/solo/bin/ag-solo
+++ b/packages/solo/bin/ag-solo
@@ -1,13 +1,2 @@
-#! /bin/bash
-real0=$(readlink "${BASH_SOURCE[0]}" || echo "${BASH_SOURCE[0]}")
-thisdir=$(cd "$(dirname -- "$real0")" > /dev/null && pwd -P)
-nodeFlags=()
-while test $# -gt 0; do
-  case "$1" in
-  --inspect*) nodeFlags+=( "$1" ) ;;
-  *) break ;;
-  esac
-  shift
-done
-
-exec node ${nodeFlags[@]} "$thisdir/../src/entrypoint.cjs" ${1+"$@"}
+#! /usr/bin/env node
+require('../src/entrypoint.cjs');

--- a/packages/solo/package.json
+++ b/packages/solo/package.json
@@ -6,7 +6,7 @@
     "js": "mjs"
   },
   "bin": {
-    "ag-solo": "./src/entrypoint.cjs"
+    "ag-solo": "bin/ag-solo"
   },
   "main": "src/main.js",
   "repository": "https://github.com/Agoric/agoric-sdk",

--- a/packages/solo/src/entrypoint.cjs
+++ b/packages/solo/src/entrypoint.cjs
@@ -11,12 +11,14 @@ require('node-lmdb');
 esmRequire('@agoric/install-metering-and-ses');
 
 const process = require('process');
+const path = require('path');
 
 // Configure logs.
 esmRequire('@agoric/cosmic-swingset/src/anylogger-agoric.js');
 const solo = esmRequire('./main.js').default;
 
-solo(process.argv[1], process.argv.splice(2)).then(
+const baseprog = path.basename(process.argv[1]);
+solo(baseprog, process.argv.slice(2)).then(
   _res => 0,
   reason => {
     console.log(`error running ag-solo:`, reason);

--- a/packages/solo/src/entrypoint.cjs
+++ b/packages/solo/src/entrypoint.cjs
@@ -19,7 +19,7 @@ const solo = esmRequire('./main.js').default;
 
 const baseprog = path.basename(process.argv[1]);
 solo(baseprog, process.argv.slice(2)).then(
-  _res => 0,
+  res => process.exit(res || 0),
   reason => {
     console.log(`error running ag-solo:`, reason);
     console.error(`\

--- a/packages/solo/src/init-basedir.js
+++ b/packages/solo/src/init-basedir.js
@@ -50,11 +50,11 @@ export default function initBasedir(
 
   // Save our version codes.
   const pj = 'package.json';
-  fs.copyFileSync(path.join(`${here}/..`, pj), path.join(dstHtmldir, pj));
+  fs.copyFileSync(path.join(here, '..', pj), path.join(dstHtmldir, pj));
   const gr = 'git-revision.txt';
   try {
     fs.copyFileSync(
-      path.join(`${here}/../public`, gr),
+      path.join(here, '../public', gr),
       path.join(dstHtmldir, gr),
     );
   } catch (e) {

--- a/packages/solo/src/init-basedir.js
+++ b/packages/solo/src/init-basedir.js
@@ -53,7 +53,10 @@ export default function initBasedir(
   fs.copyFileSync(path.join(`${here}/..`, pj), path.join(dstHtmldir, pj));
   const gr = 'git-revision.txt';
   try {
-    fs.copyFileSync(path.join(`${here}/..`, gr), path.join(dstHtmldir, gr));
+    fs.copyFileSync(
+      path.join(`${here}/../public`, gr),
+      path.join(dstHtmldir, gr),
+    );
   } catch (e) {
     let revision;
     try {

--- a/packages/solo/src/main.js
+++ b/packages/solo/src/main.js
@@ -62,7 +62,7 @@ start
       const { netconfig } = parseArgs(argv.slice(1));
       if (!AG_SOLO_BASEDIR) {
         console.error(`setup: you must set $AG_SOLO_BASEDIR`);
-        return;
+        return 1;
       }
       if (!fs.existsSync(AG_SOLO_BASEDIR)) {
         await solo(progname, ['init', AG_SOLO_BASEDIR, ...argv.slice(1)]);
@@ -145,11 +145,13 @@ start
       const cp = spawnSync(`${__dirname}/../../${argv[0]}.js`, argv.slice(1), {
         stdio: 'inherit',
       });
-      process.exit(cp.status);
+      return cp.status;
     }
     default: {
       log.error(`unrecognized command ${argv[0]}`);
       log.error(`try one of: init, set-gci-ingress, start`);
+      return 1;
     }
   }
+  return 0;
 }

--- a/packages/solo/src/main.js
+++ b/packages/solo/src/main.js
@@ -49,7 +49,7 @@ export default async function solo(progname, rawArgv) {
 
   if (opts.help) {
     process.stdout.write(`\
-Usage: ${rawArgv[0]} COMMAND [OPTIONS...]
+Usage: ${progname} COMMAND [OPTIONS...]
 
 init
 set-gci-ingress
@@ -146,7 +146,6 @@ start
         stdio: 'inherit',
       });
       process.exit(cp.status);
-      break;
     }
     default: {
       log.error(`unrecognized command ${argv[0]}`);

--- a/packages/solo/src/start.js
+++ b/packages/solo/src/start.js
@@ -385,8 +385,9 @@ export default async function start(basedir, argv) {
   swingSetRunning = true;
   deliverOutbound();
 
+  const afterHellFreezesOver = new Promise(() => {});
   if (!hostport) {
-    return;
+    return afterHellFreezesOver;
   }
 
   const deploys = typeof deploy === 'string' ? [deploy] : deploy;
@@ -410,7 +411,7 @@ export default async function start(basedir, argv) {
   // Launch the agoric wallet deploys (if any).  The assumption is that the CLI
   // runs correctly under the same version of the JS engine we're currently
   // using.
-  fork(
+  const cp = fork(
     agoricCli,
     [
       `deploy`,
@@ -426,4 +427,6 @@ export default async function start(basedir, argv) {
       }
     },
   );
+
+  return afterHellFreezesOver.then(() => cp.kill('SIGINT'));
 }

--- a/packages/solo/src/start.js
+++ b/packages/solo/src/start.js
@@ -385,9 +385,9 @@ export default async function start(basedir, argv) {
   swingSetRunning = true;
   deliverOutbound();
 
-  const afterHellFreezesOver = new Promise(() => {});
+  const whenHellFreezesOver = new Promise(() => {});
   if (!hostport) {
-    return afterHellFreezesOver;
+    return whenHellFreezesOver;
   }
 
   const deploys = typeof deploy === 'string' ? [deploy] : deploy;
@@ -428,5 +428,5 @@ export default async function start(basedir, argv) {
     },
   );
 
-  return afterHellFreezesOver.then(() => cp.kill('SIGINT'));
+  return whenHellFreezesOver.then(() => cp.kill('SIGINT'));
 }

--- a/packages/solo/test/startsolo.sh
+++ b/packages/solo/test/startsolo.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
 set -e
 PORT=${PORT-8000}
-AG_SOLO=$(cd ../src && pwd)/entrypoint.cjs
+AG_SOLO=$(cd .. && pwd)/bin/ag-solo
 
 TDIR="${TMPDIR-/tmp}/startsolo.$$"
 trap 'rm -rf "$TDIR"' EXIT


### PR DESCRIPTION
- Don't hardcode bootstrap params in `chain-config.js`; use `--bootstrap-address`, `--bootstrap-value` and `--donation-value` refs #2974 
- Update deployment process to avoid creating genesis accounts with `urun` on the cosmos-sdk side, just get it from the Agoric VM's bootstrap address
- Fix Docker build (includes moving saved state to `/data` for Rosetta compat and leaving behind forwarding symlinks).
