### PR TITLE
Distribute fees from the Treasury via the bank

### DIFF
--- a/packages/vats/jsconfig.json
+++ b/packages/vats/jsconfig.json
@@ -14,5 +14,5 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
-  "include": ["**/*.js", "globals.d.ts"],
+  "include": ["src/**/*.js", "globals.d.ts"],
 }

--- a/packages/vats/src/distributeFees.js
+++ b/packages/vats/src/distributeFees.js
@@ -1,0 +1,108 @@
+// @ts-check
+
+import { observeNotifier } from '@agoric/notifier';
+import { E } from '@agoric/eventual-send';
+import { natSafeMath } from '@agoric/zoe/src/contractSupport';
+import { amountMath } from '@agoric/ertp';
+import { Far } from '@agoric/marshal';
+
+const { add, subtract, multiply, floorDivide } = natSafeMath;
+
+// wrapper to take the treasury's creatorFacet, and make a function that will
+// request an invitation and return a promise for a payment.
+export function makeTreasuryFeeCollector(zoe, treasuryCreatorFacet) {
+  /** @type FeeCollector */
+  return Far('collectFees', {
+    collectFees: () => {
+      const invitation = E(treasuryCreatorFacet).makeCollectFeesInvitation();
+      const collectFeesSeat = zoe.offer(invitation, undefined, undefined);
+      return E(collectFeesSeat).getPayout('RUN');
+    },
+  });
+}
+
+// A distributor of fees from treasury to the Bank module, which has a mapping
+// from accounts to purses. Each time the epochTimer signals the end of an
+// Epoch, it will ask the bank's notifier for a fresh list of accounts and ask
+// the treasury for the fees that have been collected to date. It will then
+// divide the funds evenly amount the accounts, and send payments in batches of
+// depositsPerUpdate every updateInterval. When the payment doesn't divide
+// evenly among the accounts, it holds the remainder till the next epoch.
+
+/** @type {BuildFeeDistributor} */
+export function buildDistributor(treasury, bank, epochTimer, timer, params) {
+  const {
+    depositsPerUpdate,
+    updateInterval,
+    epochInterval,
+    runIssuer,
+    runBrand,
+  } = params;
+  const accountsNotifier = bank.getAccountsNotifier();
+  let leftOverPayment;
+  let leftOverValue = 0n;
+  const queuedAccounts = [];
+  const queuedPayments = [];
+  let lastWallTimeUpdate;
+  const timerNotifier = timer.makeNotifier(0n, updateInterval);
+
+  async function scheduleDeposits() {
+    if (!queuedPayments.length) {
+      return;
+    }
+
+    ({ updateCount: lastWallTimeUpdate } = await timerNotifier.getUpdateSince(
+      lastWallTimeUpdate,
+    ));
+
+    bank.depositMultiple(
+      queuedAccounts.splice(0, depositsPerUpdate),
+      queuedPayments.splice(0, depositsPerUpdate),
+    );
+
+    scheduleDeposits();
+  }
+
+  async function schedulePayments() {
+    let payment = E(treasury).collectFees();
+    const [amount, { value: accounts }] = await Promise.all([
+      E(runIssuer).getAmountOf(payment),
+      accountsNotifier.getUpdateSince(),
+    ]);
+    const totalValue = add(leftOverValue, amount.value);
+    const valuePerAccount = floorDivide(totalValue, accounts.length);
+
+    const amounts = Array(accounts.length).fill(
+      amountMath.make(runBrand, valuePerAccount),
+    );
+    if (leftOverValue) {
+      payment = E(runIssuer).combine([payment, leftOverPayment]);
+    }
+    leftOverValue = subtract(
+      totalValue,
+      multiply(accounts.length, valuePerAccount),
+    );
+    amounts.push(amountMath.make(runBrand, leftOverValue));
+
+    const manyPayments = await E(runIssuer).splitMany(payment, amounts);
+    // manyPayments is hardened, so we can't use pop()
+    leftOverPayment = manyPayments[manyPayments.length - 1];
+    queuedPayments.push(...manyPayments.slice(0, manyPayments.length - 1));
+    queuedAccounts.push(...accounts);
+
+    scheduleDeposits();
+  }
+
+  const timeObserver = {
+    updateState: _ => schedulePayments(),
+    fail: reason => {
+      throw Error(`Treasury timer failed: ${reason}`);
+    },
+    finish: done => {
+      throw Error(`Treasury timer died: ${done}`);
+    },
+  };
+
+  const epochNotifier = epochTimer.makeNotifier(0n, epochInterval);
+  observeNotifier(epochNotifier, timeObserver);
+}

--- a/packages/vats/src/distributeFees.js
+++ b/packages/vats/src/distributeFees.js
@@ -15,7 +15,7 @@ export function makeTreasuryFeeCollector(zoe, treasuryCreatorFacet) {
   return Far('collectFees', {
     collectFees: () => {
       const invitation = E(treasuryCreatorFacet).makeCollectFeesInvitation();
-      const collectFeesSeat = zoe.offer(invitation, undefined, undefined);
+      const collectFeesSeat = E(zoe).offer(invitation, undefined, undefined);
       return E(collectFeesSeat).getPayout('RUN');
     },
   });

--- a/packages/vats/src/types.js
+++ b/packages/vats/src/types.js
@@ -43,3 +43,44 @@
  * @property {NameHub} nameHub
  * @property {NameAdmin} nameAdmin
  */
+
+/**
+ * @typedef {Object} FeeCollector
+ *
+ * @property {() => ERef<Payment>} collectFees
+ */
+
+/**
+ * @typedef {Object} Bank
+ *
+ * @property {(accounts: string[], payments: Payment[]) => void} depositMultiple
+ * @property {() => Notifier<string[]>} getAccountsNotifier
+ */
+
+/**
+ * @typedef {Object} DistributorParams
+ *
+ * @property {number} depositsPerUpdate - (number) how many payments should be
+ *  sent to the Bank interface per updateInterval
+ * @property {bigint} updateInterval - (bigint) parameter to the timer
+ *  controlling the interval at which deposits are sent to the Bank API
+ * @property {bigint} epochInterval - parameter to the epochTimer controlling
+ *  the interval at which rewards should be sent to the bank.
+ * @property {Issuer} runIssuer
+ * @property {Brand} runBrand
+ */
+
+/**
+ * @callback BuildFeeDistributor
+ *
+ * @param {FeeCollector} treasuryCollector - an object with a collectFees()
+ *  method, which will return a payment. can be populated with
+ *  makeTreasuryFeeCollector(zoe, treasuryCreatorFacet)
+ * @param {Bank} bank - object with getAccountsNotifier() and depositMultiple()
+ * @param {TimerService} epochTimer - timer that notifies at the end of each
+ *  Epoch. The epochInterval parameter controls the interval.
+ * @param {TimerService} timer - timer controlling frequency at which batches
+ *  of payments are sent to the bank for processing. The parameter updateInterval
+ *  specifies the interval at which updates are sent.
+ * @param {DistributorParams} params
+ */

--- a/packages/vats/src/types.js
+++ b/packages/vats/src/types.js
@@ -51,7 +51,7 @@
  */
 
 /**
- * @typedef {Object} Bank
+ * @typedef {Object} BankDepositFacet
  *
  * @property {(accounts: string[], payments: Payment[]) => void} depositMultiple
  * @property {() => Notifier<string[]>} getAccountsNotifier
@@ -64,8 +64,8 @@
  *  sent to the Bank interface per updateInterval
  * @property {bigint} updateInterval - (bigint) parameter to the timer
  *  controlling the interval at which deposits are sent to the Bank API
- * @property {bigint} epochInterval - parameter to the epochTimer controlling
- *  the interval at which rewards should be sent to the bank.
+ * @property {bigint} [epochInterval=1n] - parameter to the epochTimer
+ *  controlling the interval at which rewards should be sent to the bank.
  * @property {Issuer} runIssuer
  * @property {Brand} runBrand
  */
@@ -76,11 +76,12 @@
  * @param {FeeCollector} treasuryCollector - an object with a collectFees()
  *  method, which will return a payment. can be populated with
  *  makeTreasuryFeeCollector(zoe, treasuryCreatorFacet)
- * @param {Bank} bank - object with getAccountsNotifier() and depositMultiple()
- * @param {TimerService} epochTimer - timer that notifies at the end of each
- *  Epoch. The epochInterval parameter controls the interval.
- * @param {TimerService} timer - timer controlling frequency at which batches
- *  of payments are sent to the bank for processing. The parameter updateInterval
- *  specifies the interval at which updates are sent.
+ * @param {ERef<BankDepositFacet>} bank - object with getAccountsNotifier() and
+ *  depositMultiple() @param {ERef<TimerService>} epochTimer - timer that
+ *  notifies at the end of each Epoch. The epochInterval parameter controls the
+ *  interval.
+ * @param {ERef<TimerService>} timer - timer controlling frequency at which
+ *  batches of payments are sent to the bank for processing. The parameter
+ *  updateInterval specifies the interval at which updates are sent.
  * @param {DistributorParams} params
  */

--- a/packages/vats/src/types.js
+++ b/packages/vats/src/types.js
@@ -73,8 +73,8 @@
 /**
  * @callback BuildFeeDistributor
  *
- * @param {FeeCollector} treasuryCollector - an object with a collectFees()
- *  method, which will return a payment. can be populated with
+ * @param {ERef<FeeCollector>} treasuryCollector - an object with a
+ *  collectFees() method, which will return a payment. can be populated with
  *  makeTreasuryFeeCollector(zoe, treasuryCreatorFacet)
  * @param {ERef<BankDepositFacet>} bank - object with getAccountsNotifier() and
  *  depositMultiple() @param {ERef<TimerService>} epochTimer - timer that

--- a/packages/vats/src/vat-distributeFees.js
+++ b/packages/vats/src/vat-distributeFees.js
@@ -1,0 +1,6 @@
+import { Far } from '@agoric/marshal';
+import { buildDistributor } from './distributeFees';
+
+export function buildRootObject(_vatPowers) {
+  return Far('feeDistributor', { buildDistributor });
+}

--- a/packages/vats/test/test-distributeFees.js
+++ b/packages/vats/test/test-distributeFees.js
@@ -1,0 +1,164 @@
+// @ts-check
+
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
+
+import { amountMath } from '@agoric/ertp';
+import { makeNotifierKit } from '@agoric/notifier';
+import buildManualTimer from '@agoric/zoe/tools/manualTimer';
+import { setup } from '@agoric/zoe/test/unitTests/setupBasicMints';
+
+import { makePromiseKit } from '@agoric/promise-kit';
+import { assertPayoutAmount } from '@agoric/zoe/test/zoeTestHelpers';
+import { buildDistributor } from '../src/distributeFees';
+
+// Some notifier updates aren't propogating sufficiently quickly for the tests.
+// This invocation (thanks to Warner) waits for all promises that can fire to
+// have all their callbacks run
+async function waitForPromisesToSettle() {
+  const pk = makePromiseKit();
+  // eslint-disable-next-line no-undef
+  setImmediate(pk.resolve);
+  return pk.promise;
+}
+
+function makeFakeBank() {
+  const depositAccounts = [];
+  const depositPayments = [];
+  const { notifier, updater } = makeNotifierKit();
+
+  return {
+    getAccountsNotifier: () => notifier,
+    depositMultiple: (a, p) => {
+      depositAccounts.push(a);
+      depositPayments.push(p);
+    },
+
+    // tools for the fake:
+    getUpdater: _ => updater,
+    getAccounts: _ => depositAccounts,
+    getPayments: _ => depositPayments,
+  };
+}
+
+function makeFakeTreasury() {
+  const feePayments = [];
+  return {
+    collectFees: () => feePayments.pop(),
+
+    // tools for the fake:
+    pushFees: payment => feePayments.push(payment),
+  };
+}
+
+function assertPaymentArray(t, payments, count, value, issuer, brand) {
+  for (let i = 0; i < count; i += 1) {
+    assertPayoutAmount(t, issuer, payments[i], amountMath.make(brand, value));
+  }
+}
+
+test('fee distribution', async t => {
+  const { brands, moolaIssuer: issuer, moolaMint: runMint } = setup();
+  const brand = brands.get('moola');
+  const bank = makeFakeBank();
+  const bankUpdater = bank.getUpdater();
+  const treasury = makeFakeTreasury();
+  const epochTimer = buildManualTimer(console.log);
+  const wallTimer = buildManualTimer(console.log);
+  const distributorParams = {
+    depositsPerUpdate: 2,
+    updateInterval: 1n,
+    epochInterval: 1n,
+    runIssuer: issuer,
+    runBrand: brand,
+  };
+  buildDistributor(treasury, bank, epochTimer, wallTimer, distributorParams);
+
+  treasury.pushFees(runMint.mintPayment(amountMath.make(brand, 500)));
+  bankUpdater.updateState(['a37', 'a2389', 'a274', 'a16', 'a1772']);
+
+  t.deepEqual(bank.getAccounts(), []);
+  t.deepEqual(bank.getPayments(), []);
+
+  await epochTimer.tick();
+  await waitForPromisesToSettle();
+
+  t.deepEqual(bank.getAccounts(), [['a37', 'a2389']]);
+  assertPaymentArray(t, bank.getPayments()[0], 2, 100, issuer, brand);
+
+  await wallTimer.tick();
+  waitForPromisesToSettle();
+
+  t.deepEqual(bank.getAccounts(), [
+    ['a37', 'a2389'],
+    ['a274', 'a16'],
+  ]);
+  assertPaymentArray(t, bank.getPayments()[1], 2, 100, issuer, brand);
+
+  await wallTimer.tick();
+  waitForPromisesToSettle();
+
+  t.deepEqual(bank.getAccounts(), [
+    ['a37', 'a2389'],
+    ['a274', 'a16'],
+    ['a1772'],
+  ]);
+  assertPaymentArray(t, bank.getPayments()[2], 1, 100, issuer, brand);
+
+  await wallTimer.tick();
+  waitForPromisesToSettle();
+
+  t.deepEqual(bank.getAccounts(), [
+    ['a37', 'a2389'],
+    ['a274', 'a16'],
+    ['a1772'],
+  ]);
+});
+
+test('fee distribution, leftovers', async t => {
+  const { brands, moolaIssuer: issuer, moolaMint: runMint } = setup();
+  const brand = brands.get('moola');
+  const bank = makeFakeBank();
+  const bankUpdater = bank.getUpdater();
+  const treasury = makeFakeTreasury();
+  const epochTimer = buildManualTimer(console.log);
+  const wallTimer = buildManualTimer(console.log);
+  const distributorParams = {
+    depositsPerUpdate: 7,
+    updateInterval: 1n,
+    epochInterval: 1n,
+    runIssuer: issuer,
+    runBrand: brand,
+  };
+  buildDistributor(treasury, bank, epochTimer, wallTimer, distributorParams);
+
+  treasury.pushFees(runMint.mintPayment(amountMath.make(brand, 12)));
+  bankUpdater.updateState(['a37', 'a2389', 'a274', 'a16', 'a1772']);
+
+  t.deepEqual(bank.getAccounts(), []);
+  t.deepEqual(bank.getPayments(), []);
+
+  await epochTimer.tick();
+  await waitForPromisesToSettle();
+
+  t.deepEqual(bank.getAccounts(), [['a37', 'a2389', 'a274', 'a16', 'a1772']]);
+  assertPaymentArray(t, bank.getPayments()[0], 5, 2, issuer, brand);
+
+  await wallTimer.tick();
+  waitForPromisesToSettle();
+
+  // Pay them again
+  treasury.pushFees(runMint.mintPayment(amountMath.make(brand, 13)));
+  await wallTimer.tick();
+
+  await epochTimer.tick();
+  await waitForPromisesToSettle();
+
+  await wallTimer.tick();
+  waitForPromisesToSettle();
+
+  t.deepEqual(bank.getAccounts(), [
+    ['a37', 'a2389', 'a274', 'a16', 'a1772'],
+    ['a37', 'a2389', 'a274', 'a16', 'a1772'],
+  ]);
+  assertPaymentArray(t, bank.getPayments()[1], 5, 3, issuer, brand);
+});


### PR DESCRIPTION
Every epoch, collect fees from the treasury and get a list of accounts
from the bank. split the collected fees evenly among the accounts,
batching the payments according to parameters.

closes: #3001

See also: #2931 