### PR TITLE
Virtual purse balance updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,9 +31,8 @@ replace google.golang.org/grpc => google.golang.org/grpc v1.33.2
 // https://github.com/tendermint/tendermint/pull/6204.
 // replace github.com/tendermint/tendermint => github.com/agoric-labs/tendermint v0.33.1-dev2.0.20210310191408-9156bacf449c
 
-// At least until https://github.com/cosmos/cosmos-sdk/issues/8478 is solved and
-// released.
-// replace github.com/cosmos/cosmos-sdk => github.com/agoric-labs/cosmos-sdk v0.34.4-0.20210129184725-f1afab29a888
+// At least until GetABCIEventHistory() is implemented and released.
+replace github.com/cosmos/cosmos-sdk => github.com/agoric-labs/cosmos-sdk v0.34.4-0.20210504041254-7cead73a2b33
 
 // For testing against a local cosmos-sdk or tendermint
 // replace github.com/cosmos/cosmos-sdk => ../forks/cosmos-sdk

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/agoric-labs/cosmos-sdk v0.34.4-0.20201011165527-9684bf64c2db h1:UqImt
 github.com/agoric-labs/cosmos-sdk v0.34.4-0.20201011165527-9684bf64c2db/go.mod h1:YZcO00Tq/qqj4ncsfn+PobyTelsot7wEMGPpxEbEAT0=
 github.com/agoric-labs/cosmos-sdk v0.34.4-0.20210129184725-f1afab29a888 h1:0be7uMLEqiZ4Bqp2VD8agsf7DmJEFNdKrRBRIYKAb5s=
 github.com/agoric-labs/cosmos-sdk v0.34.4-0.20210129184725-f1afab29a888/go.mod h1:vlgqdPpUGSxgqSbZea6fjszoLkPKwCuiqSBySLlv4ro=
+github.com/agoric-labs/cosmos-sdk v0.34.4-0.20210504041254-7cead73a2b33 h1:ED86oqboGopyS7PIkdsgScbCax8+Fbn0Y4UVDnu1Za0=
+github.com/agoric-labs/cosmos-sdk v0.34.4-0.20210504041254-7cead73a2b33/go.mod h1:I1Zw1zmU4rA/NITaakTb71pXQnQrWyFBhqo3WSeg0vA=
 github.com/agoric-labs/tendermint v0.33.1-dev2.0.20210122151802-a81eb67c924d h1:/4mrvbNZs/K6ZDppuy0/Drm9Yb/dr5j+15Y6n2x4pVY=
 github.com/agoric-labs/tendermint v0.33.1-dev2.0.20210122151802-a81eb67c924d/go.mod h1:FxbRbTEQsxz1LUmY4cVFFcjcdNT6VwVm7Ajw5HQmf04=
 github.com/agoric-labs/tendermint v0.33.1-dev2.0.20210126214117-87803b32fbb4 h1:oHNB57wl8KSb6oo1w32FW19PdB5uFfPjfnFYX6/pbn8=

--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -369,7 +369,7 @@ func NewAgoricApp(
 		callToController,
 	)
 	vpurseModule := vpurse.NewAppModule(app.VpurseKeeper)
-	app.vpursePort = swingset.RegisterPortHandler("bank", vpurse.NewPortHandler(app.VpurseKeeper))
+	app.vpursePort = swingset.RegisterPortHandler("bank", vpurse.NewPortHandler(vpurseModule, app.VpurseKeeper))
 
 	// create evidence keeper with router
 	evidenceKeeper := evidencekeeper.NewKeeper(

--- a/golang/cosmos/x/vpurse/keeper/keeper.go
+++ b/golang/cosmos/x/vpurse/keeper/keeper.go
@@ -54,6 +54,10 @@ func (k Keeper) GetBalance(ctx sdk.Context, addr sdk.AccAddress, denom string) s
 	return k.bankKeeper.GetBalance(ctx, addr, denom)
 }
 
+func (k Keeper) GetAllBalances(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins {
+	return k.bankKeeper.GetAllBalances(ctx, addr)
+}
+
 func (k Keeper) SendCoins(ctx sdk.Context, addr sdk.AccAddress, amt sdk.Coins) error {
 	if err := k.bankKeeper.MintCoins(ctx, types.ModuleName, amt); err != nil {
 		return err

--- a/golang/cosmos/x/vpurse/module.go
+++ b/golang/cosmos/x/vpurse/module.go
@@ -114,6 +114,9 @@ func (am AppModule) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) []abci.V
 	}
 
 	/* Scan for all the events matching (taken from cosmos-sdk/x/bank/spec/04_events.md):
+
+	### MsgSend
+
 	| Type     | Attribute Key | Attribute Value    |
 	| -------- | ------------- | ------------------ |
 	| transfer | recipient     | {recipientAddress} |
@@ -151,7 +154,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) []abci.V
 	}
 
 	// Dump all the addressToBalances entries to SwingSet.
-	bz, err := marshalBalanceUpdate(ctx, addressToBalance)
+	bz, err := marshalBalanceUpdate(addressToBalance)
 	if err != nil {
 		panic(err)
 	}

--- a/golang/cosmos/x/vpurse/module.go
+++ b/golang/cosmos/x/vpurse/module.go
@@ -97,6 +97,70 @@ func (am AppModule) BeginBlock(ctx sdk.Context, req abci.RequestBeginBlock) {
 
 // EndBlock implements the AppModule interface
 func (am AppModule) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) []abci.ValidatorUpdate {
+	events := ctx.EventManager().GetABCIEventHistory()
+	addressToBalance := make(map[string]sdk.Coins, len(events)*2)
+
+	ensureBalanceIsPresent := func(address string) error {
+		if _, ok := addressToBalance[address]; ok {
+			return nil
+		}
+		account, err := sdk.AccAddressFromBech32(address)
+		if err != nil {
+			return err
+		}
+		coins := am.keeper.GetAllBalances(ctx, account)
+		addressToBalance[address] = coins
+		return nil
+	}
+
+	/* Scan for all the events matching (taken from cosmos-sdk/x/bank/spec/04_events.md):
+	| Type     | Attribute Key | Attribute Value    |
+	| -------- | ------------- | ------------------ |
+	| transfer | recipient     | {recipientAddress} |
+	| transfer | sender        | {senderAddress}    |
+	| transfer | amount        | {amount}           |
+	| message  | module        | bank               |
+	| message  | action        | send               |
+	| message  | sender        | {senderAddress}    |
+
+	### MsgMultiSend
+
+	| Type     | Attribute Key | Attribute Value    |
+	| -------- | ------------- | ------------------ |
+	| transfer | recipient     | {recipientAddress} |
+	| transfer | sender        | {senderAddress}    |
+	| transfer | amount        | {amount}           |
+	| message  | module        | bank               |
+	| message  | action        | multisend          |
+	| message  | sender        | {senderAddress}    |
+	*/
+	// fmt.Printf("have vpurse events: %+v\n", events)
+	for _, event := range events {
+		switch event.Type {
+		case "transfer":
+			for _, attr := range event.Attributes {
+				// fmt.Println("have transfer attr", string(attr.GetKey()), string(attr.GetValue()))
+				switch string(attr.GetKey()) {
+				case "recipient":
+				case "sender":
+					address := string(attr.GetValue())
+					ensureBalanceIsPresent(address)
+				}
+			}
+		}
+	}
+
+	// Dump all the addressToBalances entries to SwingSet.
+	bz, err := marshalBalanceUpdate(ctx, addressToBalance)
+	if err != nil {
+		panic(err)
+	}
+	if bz != nil {
+		if _, err := am.CallToController(ctx, string(bz)); err != nil {
+			panic(err)
+		}
+	}
+
 	return []abci.ValidatorUpdate{}
 }
 

--- a/golang/cosmos/x/vpurse/vpurse.go
+++ b/golang/cosmos/x/vpurse/vpurse.go
@@ -44,7 +44,7 @@ type vpurseBalanceUpdate struct {
 
 var nonce uint64
 
-func marshalBalanceUpdate(ctx sdk.Context, addressToBalance map[string]sdk.Coins) ([]byte, error) {
+func marshalBalanceUpdate(addressToBalance map[string]sdk.Coins) ([]byte, error) {
 	nentries := len(addressToBalance)
 	if nentries == 0 {
 		return nil, nil
@@ -110,7 +110,7 @@ func (ch portHandler) Receive(ctx *swingset.ControllerContext, str string) (ret 
 		}
 		addressToBalances := make(map[string]sdk.Coins, 1)
 		addressToBalances[msg.Sender] = sdk.NewCoins(keeper.GetBalance(ctx.Context, addr, msg.Denom))
-		bz, err := marshalBalanceUpdate(ctx.Context, addressToBalances)
+		bz, err := marshalBalanceUpdate(addressToBalances)
 		if err != nil {
 			return "", err
 		}
@@ -134,7 +134,7 @@ func (ch portHandler) Receive(ctx *swingset.ControllerContext, str string) (ret 
 		}
 		addressToBalances := make(map[string]sdk.Coins, 1)
 		addressToBalances[msg.Recipient] = sdk.NewCoins(keeper.GetBalance(ctx.Context, addr, msg.Denom))
-		bz, err := marshalBalanceUpdate(ctx.Context, addressToBalances)
+		bz, err := marshalBalanceUpdate(addressToBalances)
 		if err != nil {
 			return "", err
 		}

--- a/golang/cosmos/x/vpurse/vpurse.go
+++ b/golang/cosmos/x/vpurse/vpurse.go
@@ -10,6 +10,7 @@ import (
 )
 
 type portHandler struct {
+	am     AppModule
 	keeper Keeper
 }
 
@@ -22,10 +23,51 @@ type portMessage struct { // comes from swingset's vat-bank
 	Amount    string `json:"amount"`
 }
 
-func NewPortHandler(keeper Keeper) portHandler {
+func NewPortHandler(am AppModule, keeper Keeper) portHandler {
 	return portHandler{
+		am:     am,
 		keeper: keeper,
 	}
+}
+
+type vpurseSingleBalanceUpdate struct {
+	Address string `json:"address"`
+	Denom   string `json:"denom"`
+	Amount  string `json:"amount"`
+}
+
+type vpurseBalanceUpdate struct {
+	Nonce   uint64                      `json:"nonce"`
+	Type    string                      `json:"type"`
+	Updated []vpurseSingleBalanceUpdate `json:"updated"`
+}
+
+var nonce uint64
+
+func marshalBalanceUpdate(ctx sdk.Context, addressToBalance map[string]sdk.Coins) ([]byte, error) {
+	nentries := len(addressToBalance)
+	if nentries == 0 {
+		return nil, nil
+	}
+
+	nonce += 1
+	event := vpurseBalanceUpdate{
+		Type:    "VPURSE_BALANCE_UPDATE",
+		Nonce:   nonce,
+		Updated: make([]vpurseSingleBalanceUpdate, 0, nentries),
+	}
+	for address, coins := range addressToBalance {
+		for _, coin := range coins {
+			update := vpurseSingleBalanceUpdate{
+				Address: address,
+				Amount:  coin.Amount.String(),
+				Denom:   coin.Denom,
+			}
+			event.Updated = append(event.Updated, update)
+		}
+	}
+
+	return json.Marshal(&event)
 }
 
 func (ch portHandler) Receive(ctx *swingset.ControllerContext, str string) (ret string, err error) {
@@ -66,7 +108,16 @@ func (ch portHandler) Receive(ctx *swingset.ControllerContext, str string) (ret 
 		if err := keeper.GrabCoins(ctx.Context, addr, coins); err != nil {
 			return "", fmt.Errorf("cannot grab %s coins: %w", coins.Sort().String(), err)
 		}
-		ret = "true"
+		addressToBalances := make(map[string]sdk.Coins, 1)
+		addressToBalances[msg.Sender] = sdk.NewCoins(keeper.GetBalance(ctx.Context, addr, msg.Denom))
+		bz, err := marshalBalanceUpdate(ctx.Context, addressToBalances)
+		if err != nil {
+			return "", err
+		}
+		if bz == nil {
+			ret = "true"
+		}
+		ret = string(bz)
 
 	case "VPURSE_GIVE":
 		addr, err := sdk.AccAddressFromBech32(msg.Recipient)
@@ -81,7 +132,16 @@ func (ch portHandler) Receive(ctx *swingset.ControllerContext, str string) (ret 
 		if err := keeper.SendCoins(ctx.Context, addr, coins); err != nil {
 			return "", fmt.Errorf("cannot give %s coins: %w", coins.Sort().String(), err)
 		}
-		ret = "true"
+		addressToBalances := make(map[string]sdk.Coins, 1)
+		addressToBalances[msg.Recipient] = sdk.NewCoins(keeper.GetBalance(ctx.Context, addr, msg.Denom))
+		bz, err := marshalBalanceUpdate(ctx.Context, addressToBalances)
+		if err != nil {
+			return "", err
+		}
+		if bz == nil {
+			ret = "true"
+		}
+		ret = string(bz)
 
 	default:
 		err = fmt.Errorf("unrecognized type %s", msg.Type)

--- a/packages/cosmic-swingset/src/block-manager.js
+++ b/packages/cosmic-swingset/src/block-manager.js
@@ -10,6 +10,7 @@ const END_BLOCK = 'END_BLOCK';
 const COMMIT_BLOCK = 'COMMIT_BLOCK';
 const IBC_EVENT = 'IBC_EVENT';
 const PLEASE_PROVISION = 'PLEASE_PROVISION';
+const VPURSE_BALANCE_UPDATE = 'VPURSE_BALANCE_UPDATE';
 
 export default function makeBlockManager({
   deliverInbound,
@@ -51,6 +52,11 @@ export default function makeBlockManager({
           action.blockTime,
         );
         break;
+
+      case VPURSE_BALANCE_UPDATE: {
+        p = doBridgeInbound('bank', action);
+        break;
+      }
 
       case IBC_EVENT: {
         p = doBridgeInbound('dibc', action);

--- a/packages/vats/src/bridge.js
+++ b/packages/vats/src/bridge.js
@@ -21,7 +21,7 @@ import { Far } from '@agoric/marshal';
  * @property {(srcId: string, obj: any) => Promise<any>} fromBridge Handle an inbound message
  *
  * @typedef {Object} BridgeManager The object to manage this bridge
- * @property {(dstID: string, obj: any) => void} toBridge
+ * @property {(dstID: string, obj: any) => any} toBridge
  * @property {(srcID: string, handler: BridgeHandler) => void} register
  * @property {(srcID: string, handler: BridgeHandler) => void} unregister
  */

--- a/packages/vats/src/issuers.js
+++ b/packages/vats/src/issuers.js
@@ -77,7 +77,7 @@ const fromCosmosIssuerEntries = [
       bankPurse: 'Agoric staking token',
       collateralConfig: {
         keyword: 'BLD',
-        collateralValue: scaleMicro(1000000n),
+        collateralValue: scaleMicro(2000000n),
         initialMarginPercent: 150n,
         liquidationMarginPercent: 125n,
         interestRateBasis: 250n,


### PR DESCRIPTION
Closes #2960

This has been tested against all combinations of virtual purse withdrawals/deposits and Cosmos-SDK-level transfers.

Unfortunately, it requires a patch to cosmos-sdk to enable modules to observe the events that were raised earlier in the block.  The PR will be forthcoming, once there is more discussion around the design.

@katelynsills, as usual, please review the JS for semantics.
@JimLarson, @kriskowal, again, please sanity-check the Golang.
