### PR TITLE
test and workaround for a reallocate issue in zoe

### DIFF
--- a/packages/zoe/src/contracts/newSwap/collectFees.js
+++ b/packages/zoe/src/contracts/newSwap/collectFees.js
@@ -5,10 +5,17 @@ import { amountMath } from '@agoric/ertp';
 export const makeMakeCollectFeesInvitation = (zcf, feeSeat, centralBrand) => {
   const collectFees = seat => {
     const allocation = feeSeat.getAmountAllocated('RUN', centralBrand);
-    zcf.reallocate(
-      seat.stage({ RUN: allocation }),
-      feeSeat.stage({ RUN: amountMath.makeEmpty(centralBrand) }),
-    );
+
+    // This check works around
+    // https://github.com/Agoric/agoric-sdk/issues/3033
+    // when that bug is fixed, the reallocate can be moved outside the check and
+    // the check dropped.
+    if (!amountMath.isEmpty(allocation)) {
+      zcf.reallocate(
+        seat.stage({ RUN: allocation }),
+        feeSeat.stage({ RUN: amountMath.makeEmpty(centralBrand) }),
+      );
+    }
     seat.exit();
     return `paid out ${allocation.value}`;
   };


### PR DESCRIPTION
issue #3033 shows that reallocate fails unnecessarily if asked to
reallocate to seats that had no previous allocation, even if the new
allocations are empty.

This works around that for the collectFees contract until a fix can be prepared.