### PR TITLE
fix(swingset): force vattp to run on worker=local for now

### DIFF
--- a/packages/SwingSet/src/initializeSwingset.js
+++ b/packages/SwingSet/src/initializeSwingset.js
@@ -297,6 +297,11 @@ export async function initializeSwingset(
   // it to comms
   config.vats.vattp = {
     bundle: kernelBundles.vattp,
+    creationOptions: {
+      // we saw evidence of vattp dropping messages, and out of caution,
+      // we're keeping it on an in-kernel worker for now. See #3039.
+      managerType: 'local',
+    },
   };
 
   // timer wrapper vat is added automatically, but TODO: bootstraps must


### PR DESCRIPTION
We're seeing something weird, where vattp is dropping messages randomly,
which could cause a consensus failure. So we're going to pin it to a local
worker for now, instead of letting it run on XS.

refs #3039