### PR TITLE
feat: change distribution interval from 1 second to 5 seconds.

### DIFF
--- a/packages/vats/src/bootstrap.js
+++ b/packages/vats/src/bootstrap.js
@@ -165,7 +165,7 @@ export function buildRootObject(vatPowers, vatParameters) {
     const epochTimerService = chainTimerService;
     const distributorParams = {
       depositsPerUpdate: 51,
-      updateInterval: 1n, // 1 second
+      updateInterval: 5n, // 5 seconds
       epochInterval: 60n * 60n, // 1 hour
       runIssuer: centralIssuer,
       runBrand: centralBrand,


### PR DESCRIPTION
block time is currently 5s, so requests for more frequent updates are
equivalent to 5s.