### PR TITLE
Tooling cleanup

### DIFF
--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -45,6 +45,7 @@
     "@agoric/notifier": "^0.3.14",
     "@agoric/promise-kit": "^0.2.13",
     "@agoric/store": "^0.4.14",
+    "@agoric/swing-store-lmdb": "^0.4.11",
     "@agoric/swing-store-simple": "^0.3.9",
     "@agoric/tame-metering": "^1.3.9",
     "@agoric/transform-metering": "^1.4.12",

--- a/packages/SwingSet/src/kernel/slogger.js
+++ b/packages/SwingSet/src/kernel/slogger.js
@@ -143,13 +143,13 @@ export function makeSlogger(slogCallbacks, writeObj) {
       crankNum = newCrankNum;
       const when = { crankNum, vatID, deliveryNum };
       write({ type: 'deliver', ...when, kd, vd });
-      deliveryNum += 1;
       syscallNum = 0;
 
       // dr: deliveryResult
       function finish(dr) {
         assertOldState(DELIVERY, 'delivery-finish called twice?');
         write({ type: 'deliver-result', ...when, dr });
+        deliveryNum += 1;
         state = IDLE;
       }
       return harden(finish);

--- a/packages/SwingSet/src/kernel/vatManager/manager-helper.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-helper.js
@@ -164,6 +164,7 @@ function makeManagerKit(
       });
       // eslint-disable-next-line no-await-in-loop
       await deliver(t.d);
+      transcriptManager.finishReplayDelivery();
       kernelSlog.write({ type: 'finish-replay-delivery', vatID, deliveryNum });
       deliveryNum += 1;
     }

--- a/packages/SwingSet/src/kernel/vatManager/transcript.js
+++ b/packages/SwingSet/src/kernel/vatManager/transcript.js
@@ -59,6 +59,22 @@ export function makeTranscriptManager(vatKeeper, vatID) {
     return s.response;
   }
 
+  function finishReplayDelivery() {
+    if (playbackSyscalls.length !== 0) {
+      console.log(`anachrophobia strikes vat ${vatID}`);
+      console.log(
+        `delivery completed with ${playbackSyscalls.length} expected syscalls remaining`,
+      );
+      for (const s of playbackSyscalls) {
+        console.log(`expected:`, djson.stringify(s.d));
+      }
+      if (!replayError) {
+        replayError = new Error(`historical inaccuracy in replay of ${vatID}`);
+      }
+      throw replayError;
+    }
+  }
+
   function checkReplayError() {
     if (replayError) {
       throw replayError;
@@ -73,6 +89,7 @@ export function makeTranscriptManager(vatKeeper, vatID) {
     startReplayDelivery,
     finishReplay,
     simulateSyscall,
+    finishReplayDelivery,
     checkReplayError,
     inReplay,
   });

--- a/packages/SwingSet/test/test-devices.js
+++ b/packages/SwingSet/test/test-devices.js
@@ -136,6 +136,7 @@ async function test2(t, mode) {
     devices: {
       d2: {
         sourceSpec: require.resolve('./files-devices/device-2'),
+        creationOptions: { unendowed: true },
       },
     },
   };
@@ -223,6 +224,7 @@ test.serial('device state', async t => {
     devices: {
       d3: {
         sourceSpec: require.resolve('./files-devices/device-3'),
+        creationOptions: { unendowed: true },
       },
     },
   };
@@ -492,12 +494,13 @@ test.serial('liveslots throws when D() gets promise', async t => {
     devices: {
       d0: {
         sourceSpec: require.resolve('./files-devices/device-0'),
+        creationOptions: { unendowed: true },
       },
     },
   };
   const storage = initSwingStore().storage;
   await initializeSwingset(config, ['promise1'], storage, t.context.data);
-  const c = await makeSwingsetController(storage, { d0: {} });
+  const c = await makeSwingsetController(storage, {});
   await c.step();
   // When liveslots catches an attempt to send a promise into D(), it throws
   // a regular error, which the vat can catch.
@@ -527,12 +530,13 @@ test.serial('syscall.callNow(promise) is vat-fatal', async t => {
     devices: {
       d0: {
         sourceSpec: require.resolve('./files-devices/device-0'),
+        creationOptions: { unendowed: true },
       },
     },
   };
   const storage = initSwingStore().storage;
   await initializeSwingset(config, [], storage, t.context.data);
-  const c = await makeSwingsetController(storage, { d0: {} });
+  const c = await makeSwingsetController(storage, {});
   await c.step();
   // if the kernel paniced, that c.step() will reject, and the await will throw
   t.deepEqual(c.dump().log, ['sending Promise', 'good: callNow failed']);

--- a/packages/SwingSet/test/workers/test-worker.js
+++ b/packages/SwingSet/test/workers/test-worker.js
@@ -13,6 +13,9 @@ async function makeController(managerType) {
   config.devices = {
     add: {
       sourceSpec: require.resolve('./device-add.js'),
+      creationOptions: {
+        unendowed: true,
+      },
     },
   };
   const c = await buildVatController(config, []);

--- a/packages/SwingSet/tools/db-delete.js
+++ b/packages/SwingSet/tools/db-delete.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env -S node -r esm
+
+import '@agoric/install-ses';
+import process from 'process';
+import { openSwingStore } from '@agoric/swing-store-lmdb';
+
+const log = console.log;
+
+function usage() {
+  log(`
+Command line:
+  db-delete-key.js [FLAGS] STATEDIR KEY
+
+FLAGS may be:
+  --range - delete all keys starting with \`\${KEY}.\`
+`);
+}
+
+function fail(message, printUsage) {
+  if (message) {
+    log(message);
+  }
+  if (printUsage) {
+    usage();
+  }
+  process.exit(1);
+}
+
+function run() {
+  const argv = process.argv.slice(2);
+
+  let range = false;
+  while (argv[0] && argv[0].startsWith('-')) {
+    const flag = argv.shift();
+    switch (flag) {
+      case '--range':
+        range = true;
+        break;
+      default:
+        fail(`invalid flag ${flag}`, true);
+        break;
+    }
+  }
+  if (argv.length !== 2) {
+    fail('wrong number of args', true);
+  }
+  const stateDBDir = argv.shift();
+  const key = argv.shift();
+
+  const { storage, commit } = openSwingStore(stateDBDir);
+
+  if (range) {
+    for (const k of storage.getKeys(`${key}.`, `${key}/`)) {
+      storage.delete(k);
+    }
+  } else {
+    storage.delete(key);
+  }
+  commit();
+}
+
+run();

--- a/packages/SwingSet/tools/db-get.js
+++ b/packages/SwingSet/tools/db-get.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env -S node -r esm
+
+import '@agoric/install-ses';
+import process from 'process';
+import { openSwingStore } from '@agoric/swing-store-lmdb';
+
+const log = console.log;
+
+const out = process.stdout;
+function p(str) {
+  out.write(str);
+  out.write('\n');
+}
+
+function usage() {
+  log(`
+Command line:
+  db-get-key.js [FLAGS] STATEDIR KEY
+
+FLAGS may be:
+  --raw   - just output the value(s) without adornment or key info
+  --range - output values for all keys starting with \`\${KEY}.\`
+`);
+}
+
+function fail(message, printUsage) {
+  if (message) {
+    log(message);
+  }
+  if (printUsage) {
+    usage();
+  }
+  process.exit(1);
+}
+
+function run() {
+  const argv = process.argv.slice(2);
+
+  let raw = false;
+  let range = false;
+  while (argv[0] && argv[0].startsWith('-')) {
+    const flag = argv.shift();
+    switch (flag) {
+      case '--raw':
+        raw = true;
+        break;
+      case '--range':
+        range = true;
+        break;
+      default:
+        fail(`invalid flag ${flag}`, true);
+        break;
+    }
+  }
+  if (argv.length !== 2) {
+    fail('wrong number of args', true);
+  }
+  const stateDBDir = argv.shift();
+  const key = argv.shift();
+
+  const { storage } = openSwingStore(stateDBDir);
+
+  function pkv(k) {
+    const value = storage.get(k);
+    if (raw) {
+      p(value);
+    } else {
+      p(`${k} :: ${value}`);
+    }
+  }
+
+  if (range) {
+    for (const k of storage.getKeys(`${key}.`, `${key}/`)) {
+      pkv(k);
+    }
+  } else {
+    pkv(key);
+  }
+}
+
+run();

--- a/packages/SwingSet/tools/db-set.js
+++ b/packages/SwingSet/tools/db-set.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env -S node -r esm
+
+import '@agoric/install-ses';
+import process from 'process';
+import { openSwingStore } from '@agoric/swing-store-lmdb';
+
+const log = console.log;
+
+function usage() {
+  log(`
+Command line:
+  db-set-key.js STATEDIR KEY VALUE
+`);
+}
+
+function fail(message, printUsage) {
+  if (message) {
+    log(message);
+  }
+  if (printUsage) {
+    usage();
+  }
+  process.exit(1);
+}
+
+function run() {
+  const argv = process.argv.slice(2);
+
+  if (argv.length !== 3) {
+    fail('wrong number of args', true);
+  }
+  const stateDBDir = argv.shift();
+  const key = argv.shift();
+  const value = argv.shift();
+
+  const { storage, commit } = openSwingStore(stateDBDir);
+
+  storage.set(key, value);
+  commit();
+}
+
+run();

--- a/packages/SwingSet/tools/replace-bundle.js
+++ b/packages/SwingSet/tools/replace-bundle.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env -S node -r esm
+
+import '@agoric/install-ses';
+import process from 'process';
+import { openSwingStore } from '@agoric/swing-store-lmdb';
+import bundleSource from '@agoric/bundle-source';
+
+const log = console.log;
+
+function usage() {
+  log(`
+Command line:
+  replace-bundle.js BUNDLEORVATNAME STATEDIR SOURCEPATH
+`);
+}
+
+function fail(message, printUsage) {
+  if (message) {
+    log(message);
+  }
+  if (printUsage) {
+    usage();
+  }
+  process.exit(1);
+}
+
+async function run() {
+  const argv = process.argv.slice(2);
+  if (argv.length !== 3) {
+    fail('wrong number of args', true);
+  }
+
+  let bundleName = argv.shift();
+  let bundleBundle = true;
+  const stateDBDir = argv.shift();
+  const srcPath = argv.shift();
+
+  const { storage, commit } = openSwingStore(stateDBDir);
+  log(`will use ${srcPath} in ${stateDBDir} for ${bundleName}`);
+
+  if (bundleName === 'kernel') {
+    bundleName = 'kernelBundle';
+  } else {
+    const vatID = storage.get(`vat.name.${bundleName}`);
+    if (vatID) {
+      bundleName = `${vatID}.source`;
+    }
+  }
+  if (bundleName === 'kernelBundle') {
+    bundleBundle = false;
+  }
+
+  const oldBundleStr = storage.get(bundleName);
+  log(`old bundle is ${oldBundleStr.length} bytes`);
+  let bundle = await bundleSource(srcPath);
+  if (bundleBundle) {
+    bundle = { bundle };
+  }
+  const newBundleStr = JSON.stringify(bundle);
+  log(`new bundle is ${newBundleStr.length} bytes`);
+  storage.set(bundleName, newBundleStr);
+  commit();
+  log(`bundle ${bundleName} replaced`);
+}
+
+run().catch(console.error);

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -16,7 +16,8 @@
     "test:nyc": "nyc ava",
     "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint-check": "eslint '**/*.js'",
+    "lint-check": "yarn lint",
+    "lint": "eslint '**/*.js'",
     "ci:autobench": "./autobench"
   },
   "dependencies": {

--- a/packages/swingset-runner/src/dataGraphApp.js
+++ b/packages/swingset-runner/src/dataGraphApp.js
@@ -61,7 +61,7 @@ function fail(message, printUsage, showFields) {
 }
 
 export async function dataGraphApp(xField, xLabel, yField, yLabel, fields) {
-  const argv = process.argv.splice(2);
+  const argv = process.argv.slice(2);
 
   let outfile = null;
   const datafiles = [];

--- a/packages/swingset-runner/src/dumpstore.js
+++ b/packages/swingset-runner/src/dumpstore.js
@@ -43,11 +43,14 @@ export function dumpStore(store, outfile, rawMode) {
   }
 
   popt('crankNumber');
+  popt('kernel.defaultManagerType');
   popt('kernelStats');
   gap();
 
   p('// bundles');
   poptBig('bundle', 'kernelBundle');
+  poptBig('bundle', 'lockdownBundle');
+  poptBig('bundle', 'supervisorBundle');
   for (const key of groupKeys('bundle.')) {
     poptBig('bundle', key);
   }

--- a/packages/swingset-runner/src/kerneldump.js
+++ b/packages/swingset-runner/src/kerneldump.js
@@ -54,7 +54,7 @@ function dirContains(dirpath, suffix) {
 }
 
 export function main() {
-  const argv = process.argv.splice(2);
+  const argv = process.argv.slice(2);
   let rawMode = false;
   let refCounts = false;
   let justStats = false;

--- a/packages/swingset-runner/src/main.js
+++ b/packages/swingset-runner/src/main.js
@@ -157,7 +157,7 @@ function generateIndirectConfig(baseConfig) {
  * Command line utility to run a swingset for development and testing purposes.
  */
 export async function main() {
-  const argv = process.argv.splice(2);
+  const argv = process.argv.slice(2);
 
   let forceReset = false;
   let dbMode = '--lmdb';


### PR DESCRIPTION
This PR is a grab-bag of small housecleaning fixes and improvements with respect to kernel tooling.  Each thing is its own commit for the benefit of review and posterity.

Fixes issues #3022, #3035, and #3043.

To summarize:
- Unendowed devices are not loaded unless they are explicitly given an empty endowments object or marked with the new boolean creation option `unendowed`.  This allows tools like swingset-runner to replay from transcripts when devices' endowments are not present.
- Replay now checks for excess syscalls as well as checking to see if the syscalls it sees match the transcript (issue #3043)
- A bunch of tools for fiddling with the kernel database have been added to the `SwingSet/tools` directory.
- A couple of minor slogger glitches (#3022 and #3035) have been fixed.
- Slogulator has been updated to encompass several new slog record types that have been added since the last time it was updated.
- The swingset-runner package now understands `yarn lint`
- Several command line tools that when parsing the command line mistakenly called `splice` when they should have been calling `slice` have been fixed.
