### PR TITLE
fix for a bug in newSwap calculations

### DIFF
--- a/packages/zoe/src/contracts/newSwap/getCurrentPrice.js
+++ b/packages/zoe/src/contracts/newSwap/getCurrentPrice.js
@@ -61,6 +61,7 @@ export const makeGetCurrentPrice = (
         centralBrand,
         add(BASIS_POINTS, protocolFeeBP),
       );
+      // TODO(hibbert): use a multiplyBy that rounds up when we have one.
       const protocolFee = multiplyBy(amountIn, feeOverOnePlusFee);
       const poolAmountIn = AmountMath.subtract(amountIn, protocolFee);
       const price = getPool(brandOut).getPriceGivenAvailableInput(
@@ -90,6 +91,7 @@ export const makeGetCurrentPrice = (
       const { amountOut: noFeeDeltaX } = getPool(
         brandIn,
       ).getPriceGivenAvailableInput(amountIn, brandOut, 0n);
+      // TODO(hibbert): use a multiplyBy that rounds up when we have one.
       const protocolFee = multiplyBy(noFeeDeltaX, protocolFeeRatio);
       const amountOutFinal = AmountMath.subtract(price.amountOut, protocolFee);
 
@@ -143,6 +145,7 @@ export const makeGetCurrentPrice = (
       // Now we know the amountOut that the user will receive, and can ask
       // whether it can be obtained for less.
 
+      // TODO(hibbert): use a multiplyBy that rounds up when we have one.
       const actualFee = multiplyBy(reducedCentralAmount, protocolFeeRatio);
       const reducedCentralPlusFee = AmountMath.add(
         reducedCentralAmount,
@@ -187,6 +190,7 @@ export const makeGetCurrentPrice = (
         poolFeeBP,
       );
 
+      // TODO(hibbert): use a multiplyBy that rounds up when we have one.
       const protocolFee = multiplyBy(price.amountIn, protocolFeeRatio);
       return {
         amountIn: AmountMath.add(price.amountIn, protocolFee),
@@ -207,6 +211,7 @@ export const makeGetCurrentPrice = (
         centralBrand,
         subtract(BASIS_POINTS, protocolFeeBP),
       );
+      // TODO(hibbert): use a multiplyBy that rounds up when we have one.
       const protocolFee = multiplyBy(amountOut, protocolFeeMultiplier);
 
       const price = getPool(brandIn).getPriceGivenRequiredOutput(
@@ -260,6 +265,7 @@ export const makeGetCurrentPrice = (
       );
 
       // propagate improved prices
+      // TODO(hibbert): use a multiplyBy that rounds up when we have one.
       const protocolFee = multiplyBy(
         finalCentralAmountWithFee,
         protocolFeeRatio,

--- a/packages/zoe/src/contracts/newSwap/swap.js
+++ b/packages/zoe/src/contracts/newSwap/swap.js
@@ -125,7 +125,9 @@ export const makeMakeSwapInvitation = (
     // central to secondary, secondary to central, or secondary to secondary
     const pools = [];
     if (isCentral(brandIn) && isSecondary(brandOut)) {
-      stagings.push(poolStagingFromCentral(amountIn, amountOut, protocolFee));
+      stagings.push(
+        poolStagingFromCentral(reducedAmountIn, amountOut, protocolFee),
+      );
       pools.push(getPool(brandOut));
     } else if (isSecondary(brandIn) && isCentral(brandOut)) {
       stagings.push(

--- a/packages/zoe/test/unitTests/contracts/newSwap/test-newSwap-swap.js
+++ b/packages/zoe/test/unitTests/contracts/newSwap/test-newSwap-swap.js
@@ -991,22 +991,33 @@ test('newSwap jig - breaking scenario', async t => {
 
   t.deepEqual(await E(publicFacet).getProtocolPoolBalance(), {});
 
-  const priceQuote = await E(publicFacet).getPriceGivenAvailableInput(
+  const quoteFromRun = await E(publicFacet).getPriceGivenAvailableInput(
     centralTokens(73000000n),
     moolaR.brand,
   );
-  t.deepEqual(priceQuote, {
+  t.deepEqual(quoteFromRun, {
     amountIn: centralTokens(72999997n),
     amountOut: moola(3145007n),
   });
 
-  const newPriceQuote = await E(publicFacet).getPriceGivenAvailableInput(
-    priceQuote.amountIn,
+  const newQuoteFromRun = await E(publicFacet).getPriceGivenAvailableInput(
+    quoteFromRun.amountIn,
     moolaR.brand,
   );
 
-  t.truthy(amountMath.isGTE(priceQuote.amountIn, newPriceQuote.amountIn));
-  t.truthy(amountMath.isGTE(newPriceQuote.amountOut, priceQuote.amountOut));
+  t.truthy(amountMath.isGTE(quoteFromRun.amountIn, newQuoteFromRun.amountIn));
+  t.truthy(amountMath.isGTE(newQuoteFromRun.amountOut, quoteFromRun.amountOut));
+
+  const quoteToRun = await E(publicFacet).getPriceGivenRequiredOutput(
+    moolaR.brand,
+    centralTokens(370000000n),
+  );
+  const newQuoteToRun = await E(publicFacet).getPriceGivenRequiredOutput(
+    moolaR.brand,
+    quoteToRun.amountOut,
+  );
+  t.deepEqual(quoteToRun.amountIn, newQuoteToRun.amountIn);
+  t.deepEqual(newQuoteToRun.amountOut, quoteToRun.amountOut);
 });
 
 // This demonstrates that we've worked around

--- a/packages/zoe/test/unitTests/contracts/newSwap/test-newswap-bug.js
+++ b/packages/zoe/test/unitTests/contracts/newSwap/test-newswap-bug.js
@@ -10,11 +10,13 @@ import fakeVatAdmin from '../../../../tools/fakeVatAdmin';
 
 import { makeZoe } from '../../../../src/zoeService/zoe';
 import buildManualTimer from '../../../../tools/manualTimer';
+import { makeRatio, multiplyBy } from '../../../../src/contractSupport';
 
 const multipoolAutoswapRoot = `${__dirname}/../../../../src/contracts/newSwap/multipoolAutoswap.js`;
 
 const DEFAULT_POOL_FEE = 24n;
 const DEFAULT_PROTOCOL_FEE = 6n;
+const BASIS_POINTS = 10000n;
 
 test('test bug scenario', async t => {
   const runKit = makeIssuerKit(
@@ -33,7 +35,6 @@ test('test bug scenario', async t => {
   const bundle = await bundleSource(multipoolAutoswapRoot);
 
   const installation = await zoe.install(bundle);
-  // This timer is only used to build quotes. Let's make it non-zero
   const fakeTimer = buildManualTimer(console.log, 30n);
   const { publicFacet } = await zoe.startInstance(
     installation,
@@ -54,9 +55,6 @@ test('test bug scenario', async t => {
   const bldPoolAllocation = amountMath.make(bldKit.brand, 2196247730468n);
   const runPoolAllocation = amountMath.make(runKit.brand, 50825056949339n);
 
-  // Alice adds liquidity
-  // 10 moola = 5 central tokens at the time of the liquidity adding
-  // aka 2 moola = 1 central token
   const aliceProposal = harden({
     give: {
       Secondary: bldPoolAllocation,
@@ -104,4 +102,120 @@ test('test bug scenario', async t => {
   const offerResult = await E(seatP).getOfferResult();
 
   console.log(offerResult);
+});
+
+// 30n/10000n = 0.003 or 0.3%
+const conductTrade = async (t, reduceWantOutBP = 30n) => {
+  const runKit = makeIssuerKit(
+    'RUN',
+    MathKind.NAT,
+    harden({ decimalPlaces: 6 }),
+  );
+  const bldKit = makeIssuerKit(
+    'BLD',
+    MathKind.NAT,
+    harden({ decimalPlaces: 6 }),
+  );
+  const zoe = makeZoe(fakeVatAdmin);
+
+  // Pack the contract.
+  const bundle = await bundleSource(multipoolAutoswapRoot);
+
+  const installation = await zoe.install(bundle);
+  const fakeTimer = buildManualTimer(console.log, 30n);
+  const { publicFacet } = await zoe.startInstance(
+    installation,
+    harden({ Central: runKit.issuer }),
+    {
+      timer: fakeTimer,
+      poolFee: DEFAULT_POOL_FEE,
+      protocolFee: DEFAULT_PROTOCOL_FEE,
+    },
+  );
+  const aliceAddLiquidityInvitation = E(
+    publicFacet,
+  ).makeAddLiquidityInvitation();
+
+  const bldLiquidityIssuer = await E(publicFacet).addPool(bldKit.issuer, 'BLD');
+  const bldLiquidityBrand = await E(bldLiquidityIssuer).getBrand();
+
+  const bldPoolAllocation = amountMath.make(bldKit.brand, 2196247730468n);
+  const runPoolAllocation = amountMath.make(runKit.brand, 50825056949339n);
+
+  const aliceProposal = harden({
+    give: {
+      Secondary: bldPoolAllocation,
+      Central: runPoolAllocation,
+    },
+    want: { Liquidity: amountMath.make(bldLiquidityBrand, 0n) },
+  });
+
+  const alicePayments = {
+    Secondary: bldKit.mint.mintPayment(bldPoolAllocation),
+    Central: runKit.mint.mintPayment(runPoolAllocation),
+  };
+
+  const addLiquiditySeat = await zoe.offer(
+    aliceAddLiquidityInvitation,
+    aliceProposal,
+    alicePayments,
+  );
+
+  t.is(
+    await E(addLiquiditySeat).getOfferResult(),
+    'Added liquidity.',
+    `Alice added bld and run liquidity`,
+  );
+
+  await addLiquiditySeat.getPayout('Liquidity');
+
+  const priceQuote = await E(publicFacet).getPriceGivenAvailableInput(
+    amountMath.make(runKit.brand, 73000000n),
+    bldKit.brand,
+  );
+
+  console.log('price quote', priceQuote);
+
+  const percentToReduceBy = makeRatio(
+    reduceWantOutBP,
+    priceQuote.amountOut.brand,
+    BASIS_POINTS,
+  );
+  const wantOutReduced = amountMath.subtract(
+    priceQuote.amountOut,
+    multiplyBy(priceQuote.amountOut, percentToReduceBy),
+  );
+
+  const proposal = harden({
+    give: { In: priceQuote.amountIn },
+    want: { Out: wantOutReduced },
+  });
+
+  const payment = harden({ In: runKit.mint.mintPayment(priceQuote.amountIn) });
+
+  const seatP = E(zoe).offer(
+    E(publicFacet).makeSwapInInvitation(),
+    proposal,
+    payment,
+  );
+
+  const offerResult = await E(seatP).getOfferResult();
+
+  console.log(offerResult);
+};
+
+test('test bug scenario with 0% reduction in want', async t => {
+  await conductTrade(t, 0n);
+});
+
+test('test bug scenario with 0.2% reduction in want', async t => {
+  await conductTrade(t, 20n);
+});
+
+test('test bug scenario with 0.3% reduction in want', async t => {
+  await conductTrade(t, 30n);
+});
+
+test('test bug scenario with 3% reduction in want', async t => {
+  await conductTrade(t, 300n);
 });

--- a/packages/zoe/test/unitTests/contracts/newSwap/test-newswap-bug.js
+++ b/packages/zoe/test/unitTests/contracts/newSwap/test-newswap-bug.js
@@ -1,0 +1,107 @@
+/* global __dirname */
+// @ts-check
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+
+import bundleSource from '@agoric/bundle-source';
+import { makeIssuerKit, amountMath, MathKind } from '@agoric/ertp';
+import { E } from '@agoric/eventual-send';
+import fakeVatAdmin from '../../../../tools/fakeVatAdmin';
+
+import { makeZoe } from '../../../../src/zoeService/zoe';
+import buildManualTimer from '../../../../tools/manualTimer';
+
+const multipoolAutoswapRoot = `${__dirname}/../../../../src/contracts/newSwap/multipoolAutoswap.js`;
+
+const DEFAULT_POOL_FEE = 24n;
+const DEFAULT_PROTOCOL_FEE = 6n;
+
+test('test bug scenario', async t => {
+  const runKit = makeIssuerKit(
+    'RUN',
+    MathKind.NAT,
+    harden({ decimalPlaces: 6 }),
+  );
+  const bldKit = makeIssuerKit(
+    'BLD',
+    MathKind.NAT,
+    harden({ decimalPlaces: 6 }),
+  );
+  const zoe = makeZoe(fakeVatAdmin);
+
+  // Pack the contract.
+  const bundle = await bundleSource(multipoolAutoswapRoot);
+
+  const installation = await zoe.install(bundle);
+  // This timer is only used to build quotes. Let's make it non-zero
+  const fakeTimer = buildManualTimer(console.log, 30n);
+  const { publicFacet } = await zoe.startInstance(
+    installation,
+    harden({ Central: runKit.issuer }),
+    {
+      timer: fakeTimer,
+      poolFee: DEFAULT_POOL_FEE,
+      protocolFee: DEFAULT_PROTOCOL_FEE,
+    },
+  );
+  const aliceAddLiquidityInvitation = E(
+    publicFacet,
+  ).makeAddLiquidityInvitation();
+
+  const bldLiquidityIssuer = await E(publicFacet).addPool(bldKit.issuer, 'BLD');
+  const bldLiquidityBrand = await E(bldLiquidityIssuer).getBrand();
+
+  const bldPoolAllocation = amountMath.make(bldKit.brand, 2196247730468n);
+  const runPoolAllocation = amountMath.make(runKit.brand, 50825056949339n);
+
+  // Alice adds liquidity
+  // 10 moola = 5 central tokens at the time of the liquidity adding
+  // aka 2 moola = 1 central token
+  const aliceProposal = harden({
+    give: {
+      Secondary: bldPoolAllocation,
+      Central: runPoolAllocation,
+    },
+    want: { Liquidity: amountMath.make(bldLiquidityBrand, 0n) },
+  });
+
+  const alicePayments = {
+    Secondary: bldKit.mint.mintPayment(bldPoolAllocation),
+    Central: runKit.mint.mintPayment(runPoolAllocation),
+  };
+
+  const addLiquiditySeat = await zoe.offer(
+    aliceAddLiquidityInvitation,
+    aliceProposal,
+    alicePayments,
+  );
+
+  t.is(
+    await E(addLiquiditySeat).getOfferResult(),
+    'Added liquidity.',
+    `Alice added bld and run liquidity`,
+  );
+
+  const priceQuote = await E(publicFacet).getPriceGivenAvailableInput(
+    amountMath.make(runKit.brand, 73000000n),
+    bldKit.brand,
+  );
+
+  console.log('price quote', priceQuote);
+
+  const proposal = harden({
+    give: { In: priceQuote.amountIn },
+    want: { Out: priceQuote.amountOut },
+  });
+  const payment = harden({ In: runKit.mint.mintPayment(priceQuote.amountIn) });
+
+  const seatP = E(zoe).offer(
+    E(publicFacet).makeSwapInInvitation(),
+    proposal,
+    payment,
+  );
+
+  const offerResult = await E(seatP).getOfferResult();
+
+  console.log(offerResult);
+});

--- a/packages/zoe/test/unitTests/contracts/newSwap/test-newswap-bug.js
+++ b/packages/zoe/test/unitTests/contracts/newSwap/test-newswap-bug.js
@@ -4,7 +4,7 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
 import bundleSource from '@agoric/bundle-source';
-import { makeIssuerKit, amountMath, MathKind } from '@agoric/ertp';
+import { makeIssuerKit, AmountMath, AssetKind } from '@agoric/ertp';
 import { E } from '@agoric/eventual-send';
 import fakeVatAdmin from '../../../../tools/fakeVatAdmin';
 
@@ -21,12 +21,12 @@ const BASIS_POINTS = 10000n;
 test('test bug scenario', async t => {
   const runKit = makeIssuerKit(
     'RUN',
-    MathKind.NAT,
+    AssetKind.NAT,
     harden({ decimalPlaces: 6 }),
   );
   const bldKit = makeIssuerKit(
     'BLD',
-    MathKind.NAT,
+    AssetKind.NAT,
     harden({ decimalPlaces: 6 }),
   );
   const zoe = makeZoe(fakeVatAdmin);
@@ -52,15 +52,15 @@ test('test bug scenario', async t => {
   const bldLiquidityIssuer = await E(publicFacet).addPool(bldKit.issuer, 'BLD');
   const bldLiquidityBrand = await E(bldLiquidityIssuer).getBrand();
 
-  const bldPoolAllocation = amountMath.make(bldKit.brand, 2196247730468n);
-  const runPoolAllocation = amountMath.make(runKit.brand, 50825056949339n);
+  const bldPoolAllocation = AmountMath.make(bldKit.brand, 2196247730468n);
+  const runPoolAllocation = AmountMath.make(runKit.brand, 50825056949339n);
 
   const aliceProposal = harden({
     give: {
       Secondary: bldPoolAllocation,
       Central: runPoolAllocation,
     },
-    want: { Liquidity: amountMath.make(bldLiquidityBrand, 0n) },
+    want: { Liquidity: AmountMath.make(bldLiquidityBrand, 0n) },
   });
 
   const alicePayments = {
@@ -81,7 +81,7 @@ test('test bug scenario', async t => {
   );
 
   const priceQuote = await E(publicFacet).getPriceGivenAvailableInput(
-    amountMath.make(runKit.brand, 73000000n),
+    AmountMath.make(runKit.brand, 73000000n),
     bldKit.brand,
   );
 
@@ -108,12 +108,12 @@ test('test bug scenario', async t => {
 const conductTrade = async (t, reduceWantOutBP = 30n) => {
   const runKit = makeIssuerKit(
     'RUN',
-    MathKind.NAT,
+    AssetKind.NAT,
     harden({ decimalPlaces: 6 }),
   );
   const bldKit = makeIssuerKit(
     'BLD',
-    MathKind.NAT,
+    AssetKind.NAT,
     harden({ decimalPlaces: 6 }),
   );
   const zoe = makeZoe(fakeVatAdmin);
@@ -139,15 +139,15 @@ const conductTrade = async (t, reduceWantOutBP = 30n) => {
   const bldLiquidityIssuer = await E(publicFacet).addPool(bldKit.issuer, 'BLD');
   const bldLiquidityBrand = await E(bldLiquidityIssuer).getBrand();
 
-  const bldPoolAllocation = amountMath.make(bldKit.brand, 2196247730468n);
-  const runPoolAllocation = amountMath.make(runKit.brand, 50825056949339n);
+  const bldPoolAllocation = AmountMath.make(bldKit.brand, 2196247730468n);
+  const runPoolAllocation = AmountMath.make(runKit.brand, 50825056949339n);
 
   const aliceProposal = harden({
     give: {
       Secondary: bldPoolAllocation,
       Central: runPoolAllocation,
     },
-    want: { Liquidity: amountMath.make(bldLiquidityBrand, 0n) },
+    want: { Liquidity: AmountMath.make(bldLiquidityBrand, 0n) },
   });
 
   const alicePayments = {
@@ -170,7 +170,7 @@ const conductTrade = async (t, reduceWantOutBP = 30n) => {
   await addLiquiditySeat.getPayout('Liquidity');
 
   const priceQuote = await E(publicFacet).getPriceGivenAvailableInput(
-    amountMath.make(runKit.brand, 73000000n),
+    AmountMath.make(runKit.brand, 73000000n),
     bldKit.brand,
   );
 
@@ -181,7 +181,7 @@ const conductTrade = async (t, reduceWantOutBP = 30n) => {
     priceQuote.amountOut.brand,
     BASIS_POINTS,
   );
-  const wantOutReduced = amountMath.subtract(
+  const wantOutReduced = AmountMath.subtract(
     priceQuote.amountOut,
     multiplyBy(priceQuote.amountOut, percentToReduceBy),
   );

--- a/packages/zoe/test/unitTests/contracts/newSwap/test-newswap-bug.js
+++ b/packages/zoe/test/unitTests/contracts/newSwap/test-newswap-bug.js
@@ -207,15 +207,3 @@ const conductTrade = async (t, reduceWantOutBP = 30n) => {
 test('test bug scenario with 0% reduction in want', async t => {
   await conductTrade(t, 0n);
 });
-
-test('test bug scenario with 0.2% reduction in want', async t => {
-  await conductTrade(t, 20n);
-});
-
-test('test bug scenario with 0.3% reduction in want', async t => {
-  await conductTrade(t, 30n);
-});
-
-test('test bug scenario with 3% reduction in want', async t => {
-  await conductTrade(t, 300n);
-});


### PR DESCRIPTION
The old code was calculating the protocol fee (in two cases) by
successive approximations, but a closed form solution is available (it
took me a while to realize what it was.)