### PR TITLE
fix(repl): render the unjsonable things described in #2278

### DIFF
--- a/packages/dapp-svelte-wallet/ui/lib/Debug.svelte
+++ b/packages/dapp-svelte-wallet/ui/lib/Debug.svelte
@@ -5,11 +5,11 @@
   import Dialog from "smelte/src/components/Dialog";
   import Button from "smelte/src/components/Button";
   import CancelButton from './CancelButton.svelte';
-  import { stringify } from './helpers';
+  import { dump } from './helpers';
 
   export let title = "Debug Info";
   export let target;
-  $: display = stringify(target, 2);
+  $: display = dump(target, 2);
 
   let showModal = false;
 </script>

--- a/packages/dapp-svelte-wallet/ui/lib/helpers.js
+++ b/packages/dapp-svelte-wallet/ui/lib/helpers.js
@@ -1,1 +1,1 @@
-export { stringify } from '@agoric/vats/src/repl';
+export { dump } from '@agoric/vats/src/repl';

--- a/packages/vats/src/repl.js
+++ b/packages/vats/src/repl.js
@@ -12,14 +12,6 @@ const UNJSONABLES = new Map([
   [undefined, 'undefined'],
 ]);
 
-for (const [name, { value }] of Object.entries(
-  Object.getOwnPropertyDescriptors(Symbol),
-)) {
-  if (typeof value === 'symbol' && typeof name === 'string') {
-    UNJSONABLES.set(value, `Symbol(Symbol.${name})`);
-  }
-}
-
 // A REPL-specific JSON stringify.
 export function stringify(
   value,
@@ -32,12 +24,12 @@ export function stringify(
     if (typeof value === 'bigint') {
       return `${value}n`;
     }
+    if (typeof value === 'symbol') {
+      return String(value);
+    }
     const rawString = UNJSONABLES.get(value);
     if (rawString) {
       return rawString;
-    }
-    if (typeof value === 'symbol') {
-      return `Symbol(?)`;
     }
     return JSON.stringify(value, null, spaces);
   }

--- a/packages/vats/test/test-dump.js
+++ b/packages/vats/test/test-dump.js
@@ -1,0 +1,65 @@
+import '@agoric/install-ses';
+import test from 'ava';
+
+import { dump } from '../src/repl';
+
+// Taken from https://github.com/endojs/endo/tree/main/packages/ses/test/error/test-assert-log.js#L414
+test('dump: the @erights challenge', async t => {
+  const superTagged = { [Symbol.toStringTag]: 'Tagged' };
+  const subTagged = { __proto__: superTagged };
+  const subTaggedNonEmpty = { __proto__: superTagged, foo: 'x' };
+
+  const challenges = [
+    Promise.resolve('x'),
+    function foo() {},
+    '[hilbert]',
+    undefined,
+    'undefined',
+    URIError('wut?'),
+    [33n, Symbol('foo'), Symbol.for('bar'), Symbol.asyncIterator],
+    {
+      NaN,
+      Infinity,
+      neg: -Infinity,
+    },
+    2 ** 54,
+    { superTagged, subTagged, subTaggedNonEmpty },
+  ];
+  t.is(
+    dump(challenges),
+    '[[Promise],[Function foo],"[hilbert]",undefined,"undefined",[URIError: wut?],[33n,Symbol(foo),Symbol(bar),Symbol(Symbol.asyncIterator)],{"NaN":NaN,"Infinity":Infinity,"neg":-Infinity},18014398509481984,{"superTagged":{[Symbol(Symbol.toStringTag)]:"Tagged"},"subTagged":[Object Tagged]{},"subTaggedNonEmpty":[Object Tagged]{"foo":"x"}}]',
+  );
+  t.is(
+    dump(challenges, '  '),
+    `\
+[
+  [Promise],
+  [Function foo],
+  "[hilbert]",
+  undefined,
+  "undefined",
+  [URIError: wut?],
+  [
+    33n,
+    Symbol(foo),
+    Symbol(bar),
+    Symbol(Symbol.asyncIterator)
+  ],
+  {
+    "NaN": NaN,
+    "Infinity": Infinity,
+    "neg": -Infinity
+  },
+  18014398509481984,
+  {
+    "superTagged": {
+      [Symbol(Symbol.toStringTag)]: "Tagged"
+    },
+    "subTagged": [Object Tagged] {},
+    "subTaggedNonEmpty": [Object Tagged] {
+      "foo": "x"
+    }
+  }
+]`,
+  );
+});

--- a/packages/vats/test/test-repl.js
+++ b/packages/vats/test/test-repl.js
@@ -91,9 +91,16 @@ test('repl: Symbols', async t => {
   let m = sentMessages.shift();
 
   let histnum = 0;
-  for (const expr of ['asyncIterator', 'toStringTag', 'hasInstance'].map(
-    name => `Symbol.${name}`,
-  )) {
+  const exprDisplays = [
+    'asyncIterator',
+    'toStringTag',
+    'hasInstance',
+  ].map(name => [`Symbol.${name}`, `Symbol(Symbol.${name})`]);
+  exprDisplays.push(
+    [`Symbol.for('foo')`, `Symbol(foo)`],
+    [`Symbol('foo')`, `Symbol(foo)`],
+  );
+  for (const [expr, display] of exprDisplays) {
     t.deepEqual(doEval(histnum, expr), {});
     m = sentMessages.shift();
     t.deepEqual(m.type, 'updateHistory');
@@ -104,23 +111,7 @@ test('repl: Symbols', async t => {
     m = sentMessages.shift();
     t.is(m.type, 'updateHistory');
     t.is(m.histnum, histnum);
-    t.is(m.display, `Symbol(${expr})`);
-    t.deepEqual(sentMessages, []);
-    histnum += 1;
-  }
-
-  for (const expr of [`Symbol.for('foo')`, `Symbol('foo')`]) {
-    t.deepEqual(doEval(histnum, expr), {});
-    m = sentMessages.shift();
-    t.deepEqual(m.type, 'updateHistory');
-    t.is(sentMessages.length, 1);
-
-    t.is(m.histnum, histnum);
-    t.is(m.display, `working on eval(${expr})`);
-    m = sentMessages.shift();
-    t.is(m.type, 'updateHistory');
-    t.is(m.histnum, histnum);
-    t.is(m.display, `Symbol(?)`);
+    t.is(m.display, display);
     t.deepEqual(sentMessages, []);
     histnum += 1;
   }


### PR DESCRIPTION
Closes #2278 

This uses a map to keep track of the names for unjsonable things, with some special handling for symbols.
