### PR TITLE
feat(xsnap): refined metering: stack, arrays

### DIFF
--- a/packages/xsnap/api.js
+++ b/packages/xsnap/api.js
@@ -3,7 +3,7 @@
 /** The version identifier for our meter type.
  * TODO Bump this whenever there's a change to metering semantics.
  */
-export const METER_TYPE = 'xs-meter-6';
+export const METER_TYPE = 'xs-meter-7';
 
 export const ExitCode = {
   E_UNKNOWN_ERROR: -1,

--- a/packages/xsnap/test/test-xs-perf.js
+++ b/packages/xsnap/test/test-xs-perf.js
@@ -23,6 +23,10 @@ export function options() {
   return { ...xsnapOptions, handleCommand, messages };
 }
 
+const { entries, fromEntries } = Object;
+
+const shape = obj => fromEntries(entries(obj).map(([p, v]) => [p, typeof v]));
+
 test('meter details', async t => {
   const opts = options();
   const vat = xsnap(opts);
@@ -42,9 +46,16 @@ test('meter details', async t => {
   const {
     meterUsage: { meterType, ...meters },
   } = result;
+
+  t.like(
+    meters,
+    { compute: 1_260_073, allocate: 42_074_144 },
+    'compute, allocate meters should be stable; update METER_TYPE?',
+  );
+
   t.log(meters);
-  const { entries, fromEntries } = Object;
   t.deepEqual(
+    shape(meters),
     {
       compute: 'number',
       allocate: 'number',
@@ -55,9 +66,9 @@ test('meter details', async t => {
       mapSetRemoveCount: 'number',
       maxBucketSize: 'number',
     },
-    fromEntries(entries(meters).map(([p, v]) => [p, typeof v])),
+    'auxiliary (non-consensus) meters are available',
   );
-  t.is(meterType, 'xs-meter-6');
+  t.is(meterType, 'xs-meter-7');
 });
 
 test('high resolution timer', async t => {

--- a/packages/xsnap/test/test-xsnap.js
+++ b/packages/xsnap/test/test-xsnap.js
@@ -460,8 +460,8 @@ test('property name space exhaustion: orderly fail-stop', async t => {
     ]) {
       test(`parser buffer size ${parserBufferSize ||
         'default'}k; rep ${qty}; debug ${debug}`, async t => {
-        const opts = options();
-        const vat = xsnap({ ...opts, debug, parserBufferSize });
+        const opts = { ...options(), meteringLimit: 1e8, debug };
+        const vat = xsnap({ ...opts, parserBufferSize });
         t.teardown(() => vat.terminate());
         const expected = failure ? [failure] : [qty * 4 + 2];
         // eslint-disable-next-line no-await-in-loop


### PR DESCRIPTION
This brings in Moddable's May 8 metering improvements.

refs #2322
depends on https://github.com/agoric-labs/moddable/pull/6

can't say "fixes" because regexps are still outstanding