### PR TITLE
chore(zoe): prune obsolete test:xs-unit-debug package script

### DIFF
--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -15,7 +15,6 @@
     "test:nyc": "nyc ava",
     "test:xs": "yarn test:xs-unit",
     "test:xs-unit": "ava-xs --verbose",
-    "test:xs-unit-debug": "ava-xs --debug",
     "test:xs-worker": "SWINGSET_WORKER_TYPE=xs-worker ava -c 2 test/swingsetTests/**/test-*.js",
     "build-zcfBundle": "node -r esm scripts/build-zcfBundle.js",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",


### PR DESCRIPTION
The `test:xs-unit-deb` package script was motivated by limitations
on ava-xs's argument parsing that were fixed around Mar 9 e89f1e1b71 .

fixes #2650