### PR TITLE
refactor: restructure host store API

### DIFF
--- a/packages/SwingSet/src/initializeSwingset.js
+++ b/packages/SwingSet/src/initializeSwingset.js
@@ -5,7 +5,6 @@ import path from 'path';
 
 import { assert, details as X } from '@agoric/assert';
 import bundleSource from '@agoric/bundle-source';
-import { initSwingStore } from '@agoric/swing-store-simple';
 
 import './types';
 import { insistStorageAPI } from './storageAPI';
@@ -200,25 +199,26 @@ export function loadSwingsetConfigFile(configPath) {
   }
 }
 
-export function swingsetIsInitialized(storage) {
-  return !!storage.get('initialized');
+export function swingsetIsInitialized(hostStorage) {
+  return !!hostStorage.kvStore.get('initialized');
 }
 
 /**
  * @param {SwingSetConfig} config
  * @param {string[]} argv
- * @param {SwingStore} hostStorage
+ * @param {HostStore} hostStorage
  * @param {{ kernelBundles?: Record<string, string> }} initializationOptions
  * @param {{ env?: Record<string, string | undefined > }} runtimeOptions
  */
 export async function initializeSwingset(
   config,
   argv = [],
-  hostStorage = initSwingStore().storage,
+  hostStorage,
   initializationOptions = {},
   runtimeOptions = {},
 ) {
-  insistStorageAPI(hostStorage);
+  const kvStore = hostStorage.kvStore;
+  insistStorageAPI(kvStore);
 
   assert(
     !swingsetIsInitialized(hostStorage),
@@ -256,9 +256,9 @@ export async function initializeSwingset(
 
   const { kernelBundles = await buildKernelBundles() } = initializationOptions;
 
-  hostStorage.set('kernelBundle', JSON.stringify(kernelBundles.kernel));
-  hostStorage.set('lockdownBundle', JSON.stringify(kernelBundles.lockdown));
-  hostStorage.set('supervisorBundle', JSON.stringify(kernelBundles.supervisor));
+  kvStore.set('kernelBundle', JSON.stringify(kernelBundles.kernel));
+  kvStore.set('lockdownBundle', JSON.stringify(kernelBundles.lockdown));
+  kvStore.set('supervisorBundle', JSON.stringify(kernelBundles.supervisor));
 
   if (config.bootstrap && argv) {
     const bootConfig = config.vats[config.bootstrap];

--- a/packages/SwingSet/src/kernel/initializeKernel.js
+++ b/packages/SwingSet/src/kernel/initializeKernel.js
@@ -17,8 +17,9 @@ function makeVatRootObjectSlot() {
 export function initializeKernel(config, hostStorage, verbose = false) {
   const logStartup = verbose ? console.debug : () => 0;
 
-  insistStorageAPI(hostStorage);
-  const { enhancedCrankBuffer, commitCrank } = wrapStorage(hostStorage);
+  const { kvStore } = hostStorage;
+  insistStorageAPI(kvStore);
+  const { enhancedCrankBuffer, commitCrank } = wrapStorage(kvStore);
 
   const kernelKeeper = makeKernelKeeper(enhancedCrankBuffer);
 

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -110,10 +110,9 @@ export default function buildKernel(
   const { verbose, defaultManagerType = 'local' } = kernelOptions;
   const logStartup = verbose ? console.debug : () => 0;
 
-  insistStorageAPI(hostStorage);
-  const { enhancedCrankBuffer, abortCrank, commitCrank } = wrapStorage(
-    hostStorage,
-  );
+  const { kvStore } = hostStorage;
+  insistStorageAPI(kvStore);
+  const { enhancedCrankBuffer, abortCrank, commitCrank } = wrapStorage(kvStore);
 
   const kernelSlog = writeSlogObject
     ? makeSlogger(slogCallbacks, writeSlogObject)
@@ -230,7 +229,7 @@ export default function buildKernel(
 
   const kernelSyscallHandler = makeKernelSyscallHandler({
     kernelKeeper,
-    storage: enhancedCrankBuffer,
+    kvStore: enhancedCrankBuffer,
     ephemeral,
     // eslint-disable-next-line no-use-before-define
     notify,

--- a/packages/SwingSet/src/kernel/kernelSyscall.js
+++ b/packages/SwingSet/src/kernel/kernelSyscall.js
@@ -26,7 +26,7 @@ export function doSend(kernelKeeper, target, msg) {
 export function makeKernelSyscallHandler(tools) {
   const {
     kernelKeeper,
-    storage,
+    kvStore,
     ephemeral,
     notify,
     doResolve,
@@ -52,7 +52,7 @@ export function makeKernelSyscallHandler(tools) {
     const actualKey = vatstoreKeyKey(vatID, key);
     kernelKeeper.incStat('syscalls');
     kernelKeeper.incStat('syscallVatstoreGet');
-    const value = storage.get(actualKey);
+    const value = kvStore.get(actualKey);
     return harden(['ok', value || null]);
   }
 
@@ -60,7 +60,7 @@ export function makeKernelSyscallHandler(tools) {
     const actualKey = vatstoreKeyKey(vatID, key);
     kernelKeeper.incStat('syscalls');
     kernelKeeper.incStat('syscallVatstoreSet');
-    storage.set(actualKey, value);
+    kvStore.set(actualKey, value);
     return OKNULL;
   }
 
@@ -68,7 +68,7 @@ export function makeKernelSyscallHandler(tools) {
     const actualKey = vatstoreKeyKey(vatID, key);
     kernelKeeper.incStat('syscalls');
     kernelKeeper.incStat('syscallVatstoreDelete');
-    storage.delete(actualKey);
+    kvStore.delete(actualKey);
     return OKNULL;
   }
 

--- a/packages/SwingSet/src/kernel/state/storageWrapper.js
+++ b/packages/SwingSet/src/kernel/state/storageWrapper.js
@@ -20,15 +20,15 @@ import { insistStorageAPI } from '../../storageAPI';
  * thrown errors and ensures that any return values that are supposed to be
  * strings actually are.
  *
- * @param {*} hostStorage  Alleged host storage object to be wrapped this way.
+ * @param {*} kvStore  Alleged host storage object to be wrapped this way.
  *
- * @returns {*} a hardened version of hostStorage wrapped as described.
+ * @returns {*} a hardened version of kvStore wrapped as described.
  */
-export function guardStorage(hostStorage) {
-  insistStorageAPI(hostStorage);
+export function guardStorage(kvStore) {
+  insistStorageAPI(kvStore);
 
   function callAndWrapError(method, ...args) {
-    // This is based on the one in SES, but hostStorage is not supposed to
+    // This is based on the one in SES, but kvStore is not supposed to
     // throw any exceptions, so we don't need to retain error types or stack
     // traces: just log the full exception, and return a stripped down
     // kernel-realm Error to the caller.
@@ -37,10 +37,10 @@ export function guardStorage(hostStorage) {
     // exposing host-realm Error objects to kernel realm callers.
 
     try {
-      return hostStorage[method](...args);
+      return kvStore[method](...args);
     } catch (err) {
-      console.error(`error invoking hostStorage.${method}(${args})`, err);
-      assert.fail(X`error invoking hostStorage.${method}(${args}): ${err}`);
+      console.error(`error invoking kvStore.${method}(${args})`, err);
+      assert.fail(X`error invoking kvStore.${method}(${args}): ${err}`);
     }
   }
 
@@ -49,23 +49,20 @@ export function guardStorage(hostStorage) {
     return !!callAndWrapError('has', key);
   }
 
-  // hostStorage.getKeys returns a host-realm Generator, so we return a
+  // kvStore.getKeys returns a host-realm Generator, so we return a
   // kernel-realm wrapper generator that returns the same contents, and guard
   // against the host-realm Generator throwing any new errors as it runs
   function* getKeys(start, end) {
     assert.typeof(start, 'string');
     assert.typeof(end, 'string');
     try {
-      for (const key of hostStorage.getKeys(start, end)) {
+      for (const key of kvStore.getKeys(start, end)) {
         yield key;
       }
     } catch (err) {
-      console.error(
-        `error invoking hostStorage.getKeys(${start}, ${end})`,
-        err,
-      );
+      console.error(`error invoking kvStore.getKeys(${start}, ${end})`, err);
       throw new Error(
-        `error invoking hostStorage.getKeys(${start}, ${end}): ${err}`,
+        `error invoking kvStore.getKeys(${start}, ${end}): ${err}`,
       );
     }
   }
@@ -97,16 +94,16 @@ export function guardStorage(hostStorage) {
  * Create and return a crank buffer, which wraps a storage object with logic
  * that buffers any mutations until told to commit them.
  *
- * @param {*} storage  The storage object that this crank buffer will be based on.
+ * @param {*} kvStore  The storage object that this crank buffer will be based on.
  *
  * @returns {*} an object {
- *   crankBuffer,  // crank buffer as described, wrapping `storage`
- *   commitCrank,  // function to save buffered mutations to `storage`
+ *   crankBuffer,  // crank buffer as described, wrapping `kvStore`
+ *   commitCrank,  // function to save buffered mutations to `kvStore`
  *   abortCrank,   // function to discard buffered mutations
  * }
  */
-export function buildCrankBuffer(storage) {
-  insistStorageAPI(storage);
+export function buildCrankBuffer(kvStore) {
+  insistStorageAPI(kvStore);
 
   // to avoid confusion, additions and deletions should never share a key
   const additions = new Map();
@@ -120,11 +117,11 @@ export function buildCrankBuffer(storage) {
       if (deletions.has(key)) {
         return false;
       }
-      return storage.has(key);
+      return kvStore.has(key);
     },
 
     *getKeys(start, end) {
-      const keys = new Set(storage.getKeys(start, end));
+      const keys = new Set(kvStore.getKeys(start, end));
       for (const k of additions.keys()) {
         keys.add(k);
       }
@@ -145,7 +142,7 @@ export function buildCrankBuffer(storage) {
       if (deletions.has(key)) {
         return undefined;
       }
-      return storage.get(key);
+      return kvStore.get(key);
     },
 
     set(key, value) {
@@ -164,10 +161,10 @@ export function buildCrankBuffer(storage) {
    */
   function commitCrank() {
     for (const [key, value] of additions) {
-      storage.set(key, value);
+      kvStore.set(key, value);
     }
     for (const key of deletions) {
-      storage.delete(key);
+      kvStore.delete(key);
     }
     additions.clear();
     deletions.clear();
@@ -184,9 +181,9 @@ export function buildCrankBuffer(storage) {
   return harden({ crankBuffer, commitCrank, abortCrank });
 }
 
-export function addHelpers(storage) {
+export function addHelpers(kvStore) {
   // these functions are built on top of the DB interface
-  insistStorageAPI(storage);
+  insistStorageAPI(kvStore);
 
   // NOTE: awkward naming: the thing that returns a stream of keys is named
   // "enumerate..." while the thing that returns a stream of values is named
@@ -199,7 +196,7 @@ export function addHelpers(storage) {
     // incorrectly.
     for (let i = start; true; i += 1) {
       const key = `${prefix}${i}`;
-      if (storage.has(key)) {
+      if (kvStore.has(key)) {
         yield key;
       } else {
         return;
@@ -209,7 +206,7 @@ export function addHelpers(storage) {
 
   function* getPrefixedValues(prefix, start = 0) {
     for (const key of enumeratePrefixedKeys(prefix, start)) {
-      yield storage.get(key);
+      yield kvStore.get(key);
     }
   }
 
@@ -218,7 +215,7 @@ export function addHelpers(storage) {
     // efficiently without backend DB support because it only looks at
     // numeric suffixes, in sequential order.
     for (const key of enumeratePrefixedKeys(prefix, start)) {
-      storage.delete(key);
+      kvStore.delete(key);
     }
   }
 
@@ -226,7 +223,7 @@ export function addHelpers(storage) {
     enumeratePrefixedKeys,
     getPrefixedValues,
     deletePrefixedKeys,
-    ...storage,
+    ...kvStore,
   });
 }
 
@@ -237,10 +234,10 @@ export function addHelpers(storage) {
 // write-back buffer wrapper (the CrankBuffer), but the keeper is unaware of
 // that.
 
-export function wrapStorage(hostStorage) {
-  const guardedHostStorage = guardStorage(hostStorage);
+export function wrapStorage(kvStore) {
+  const guardedKVStore = guardStorage(kvStore);
   const { crankBuffer, commitCrank, abortCrank } = buildCrankBuffer(
-    guardedHostStorage,
+    guardedKVStore,
   );
   const enhancedCrankBuffer = addHelpers(crankBuffer);
   return { enhancedCrankBuffer, commitCrank, abortCrank };

--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -20,21 +20,21 @@ const FIRST_TRANSCRIPT_ID = 0n;
 /**
  * Establish a vat's state.
  *
- * @param {*} storage  The storage in which the persistent state will be kept
+ * @param {*} kvStore  The storage in which the persistent state will be kept
  * @param {string} vatID The vat ID string of the vat in question
  * TODO: consider making this part of makeVatKeeper
  */
-export function initializeVatState(storage, vatID) {
-  storage.set(`${vatID}.o.nextID`, `${FIRST_OBJECT_ID}`);
-  storage.set(`${vatID}.p.nextID`, `${FIRST_PROMISE_ID}`);
-  storage.set(`${vatID}.d.nextID`, `${FIRST_DEVICE_ID}`);
-  storage.set(`${vatID}.t.nextID`, `${FIRST_TRANSCRIPT_ID}`);
+export function initializeVatState(kvStore, vatID) {
+  kvStore.set(`${vatID}.o.nextID`, `${FIRST_OBJECT_ID}`);
+  kvStore.set(`${vatID}.p.nextID`, `${FIRST_PROMISE_ID}`);
+  kvStore.set(`${vatID}.d.nextID`, `${FIRST_DEVICE_ID}`);
+  kvStore.set(`${vatID}.t.nextID`, `${FIRST_TRANSCRIPT_ID}`);
 }
 
 /**
  * Produce a vat keeper for a vat.
  *
- * @param {*} storage  The storage in which the persistent state will be kept
+ * @param {*} kvStore  The storage in which the persistent state will be kept
  * @param {*} kernelSlog
  * @param {string} vatID  The vat ID string of the vat in question
  * @param {*} addKernelObject  Kernel function to add a new object to the kernel's
@@ -49,7 +49,7 @@ export function initializeVatState(storage, vatID) {
  * @returns {*} an object to hold and access the kernel's state for the given vat
  */
 export function makeVatKeeper(
-  storage,
+  kvStore,
   kernelSlog,
   vatID,
   addKernelObject,
@@ -68,13 +68,13 @@ export function makeVatKeeper(
     assert.typeof(source, 'object');
     assert(source.bundle || source.bundleName);
     assert.typeof(options, 'object');
-    storage.set(`${vatID}.source`, JSON.stringify(source));
-    storage.set(`${vatID}.options`, JSON.stringify(options));
+    kvStore.set(`${vatID}.source`, JSON.stringify(source));
+    kvStore.set(`${vatID}.options`, JSON.stringify(options));
   }
 
   function getSourceAndOptions() {
-    const source = JSON.parse(storage.get(`${vatID}.source`));
-    const options = JSON.parse(storage.get(`${vatID}.options`));
+    const source = JSON.parse(kvStore.get(`${vatID}.source`));
+    const options = JSON.parse(kvStore.get(`${vatID}.options`));
     return harden({ source, options });
   }
 
@@ -92,7 +92,7 @@ export function makeVatKeeper(
   function mapVatSlotToKernelSlot(vatSlot) {
     assert.typeof(vatSlot, 'string', X`non-string vatSlot: ${vatSlot}`);
     const vatKey = `${vatID}.c.${vatSlot}`;
-    if (!storage.has(vatKey)) {
+    if (!kvStore.has(vatKey)) {
       const { type, allocatedByVat } = parseVatSlot(vatSlot);
 
       if (allocatedByVat) {
@@ -109,8 +109,8 @@ export function makeVatKeeper(
         incrementRefCount(kernelSlot, `${vatID}|vk|clist`);
         const kernelKey = `${vatID}.c.${kernelSlot}`;
         incStat('clistEntries');
-        storage.set(kernelKey, vatSlot);
-        storage.set(vatKey, kernelSlot);
+        kvStore.set(kernelKey, vatSlot);
+        kvStore.set(vatKey, kernelSlot);
         kernelSlog &&
           kernelSlog.changeCList(
             vatID,
@@ -127,7 +127,7 @@ export function makeVatKeeper(
       }
     }
 
-    return storage.get(vatKey);
+    return kvStore.get(vatKey);
   }
 
   /**
@@ -144,19 +144,19 @@ export function makeVatKeeper(
   function mapKernelSlotToVatSlot(kernelSlot) {
     assert.typeof(kernelSlot, 'string', 'non-string kernelSlot');
     const kernelKey = `${vatID}.c.${kernelSlot}`;
-    if (!storage.has(kernelKey)) {
+    if (!kvStore.has(kernelKey)) {
       const { type } = parseKernelSlot(kernelSlot);
 
       let id;
       if (type === 'object') {
-        id = Nat(BigInt(storage.get(`${vatID}.o.nextID`)));
-        storage.set(`${vatID}.o.nextID`, `${id + 1n}`);
+        id = Nat(BigInt(kvStore.get(`${vatID}.o.nextID`)));
+        kvStore.set(`${vatID}.o.nextID`, `${id + 1n}`);
       } else if (type === 'device') {
-        id = Nat(BigInt(storage.get(`${vatID}.d.nextID`)));
-        storage.set(`${vatID}.d.nextID`, `${id + 1n}`);
+        id = Nat(BigInt(kvStore.get(`${vatID}.d.nextID`)));
+        kvStore.set(`${vatID}.d.nextID`, `${id + 1n}`);
       } else if (type === 'promise') {
-        id = Nat(BigInt(storage.get(`${vatID}.p.nextID`)));
-        storage.set(`${vatID}.p.nextID`, `${id + 1n}`);
+        id = Nat(BigInt(kvStore.get(`${vatID}.p.nextID`)));
+        kvStore.set(`${vatID}.p.nextID`, `${id + 1n}`);
       } else {
         assert.fail(X`unknown type ${type}`);
       }
@@ -165,8 +165,8 @@ export function makeVatKeeper(
 
       const vatKey = `${vatID}.c.${vatSlot}`;
       incStat('clistEntries');
-      storage.set(vatKey, kernelSlot);
-      storage.set(kernelKey, vatSlot);
+      kvStore.set(vatKey, kernelSlot);
+      kvStore.set(kernelKey, vatSlot);
       kernelSlog &&
         kernelSlog.changeCList(
           vatID,
@@ -178,7 +178,7 @@ export function makeVatKeeper(
       kdebug(`Add mapping k->v ${kernelKey}<=>${vatKey}`);
     }
 
-    return storage.get(kernelKey);
+    return kvStore.get(kernelKey);
   }
 
   /**
@@ -189,7 +189,7 @@ export function makeVatKeeper(
    * @returns {boolean} true iff this vat has a c-list entry mapping for `slot`.
    */
   function hasCListEntry(slot) {
-    return storage.has(`${vatID}.c.${slot}`);
+    return kvStore.has(`${vatID}.c.${slot}`);
   }
 
   /**
@@ -212,11 +212,11 @@ export function makeVatKeeper(
         kernelSlot,
         vatSlot,
       );
-    if (storage.has(kernelKey)) {
+    if (kvStore.has(kernelKey)) {
       decrementRefCount(kernelSlot, `${vatID}|del|clist`);
       decStat('clistEntries');
-      storage.delete(kernelKey);
-      storage.delete(vatKey);
+      kvStore.delete(kernelKey);
+      kvStore.delete(vatKey);
     }
   }
 
@@ -231,7 +231,7 @@ export function makeVatKeeper(
    * Generator function to return the vat's transcript, one entry at a time.
    */
   function* getTranscript() {
-    for (const value of storage.getPrefixedValues(`${vatID}.t.`)) {
+    for (const value of kvStore.getPrefixedValues(`${vatID}.t.`)) {
       yield JSON.parse(value);
     }
   }
@@ -242,14 +242,14 @@ export function makeVatKeeper(
    * @param {string} msg  The message to append.
    */
   function addToTranscript(msg) {
-    const id = Nat(BigInt(storage.get(`${vatID}.t.nextID`)));
-    storage.set(`${vatID}.t.nextID`, `${id + 1n}`);
-    storage.set(`${vatID}.t.${id}`, JSON.stringify(msg));
+    const id = Nat(BigInt(kvStore.get(`${vatID}.t.nextID`)));
+    kvStore.set(`${vatID}.t.nextID`, `${id + 1n}`);
+    kvStore.set(`${vatID}.t.${id}`, JSON.stringify(msg));
   }
 
   function vatStats() {
     function getCount(key, first) {
-      const id = Nat(BigInt(storage.get(key)));
+      const id = Nat(BigInt(kvStore.get(key)));
       return id - Nat(first);
     }
 
@@ -275,12 +275,12 @@ export function makeVatKeeper(
   function dumpState() {
     const res = [];
     const prefix = `${vatID}.c.`;
-    for (const k of storage.getKeys(prefix, `${vatID}.c/`)) {
+    for (const k of kvStore.getKeys(prefix, `${vatID}.c/`)) {
       if (k.startsWith(prefix)) {
         const slot = k.slice(prefix.length);
         if (!slot.startsWith('k')) {
           const vatSlot = slot;
-          const kernelSlot = storage.get(k);
+          const kernelSlot = kvStore.get(k);
           res.push([kernelSlot, vatID, vatSlot]);
         }
       }

--- a/packages/SwingSet/src/storageAPI.js
+++ b/packages/SwingSet/src/storageAPI.js
@@ -5,16 +5,16 @@ import { assert, details as X } from '@agoric/assert';
  * actually implements the storage API.  It should have methods `has`,
  * `getKeys`, `get`, `set`, and `delete`.
  *
- * @param {*} storage  The object to be tested
+ * @param {*} kvStore  The object to be tested
  *
  * @throws {Error} if, upon inspection, the parameter does not satisfy the above
  *   criteria.
  *
  * @returns {void}
  */
-export function insistStorageAPI(storage) {
+export function insistStorageAPI(kvStore) {
   for (const n of ['has', 'getKeys', 'get', 'set', 'delete']) {
-    assert(n in storage, X`storage.${n} is missing, cannot use`);
+    assert(n in kvStore, X`kvStore.${n} is missing, cannot use`);
   }
 }
 
@@ -24,20 +24,20 @@ export function insistStorageAPI(storage) {
  * object that additionally has the methods `enumeratePrefixedKeys`,
  * `getPrefixedValues`, and `deletePrefixedKeys`.
  *
- * @param {*} storage  The object to be tested
+ * @param {*} kvStore  The object to be tested
  *
  * @throws {Error} if, upon inspection, the parameter does not satisfy the above
  *   criteria.
  *
  * @returns {void}
  */
-export function insistEnhancedStorageAPI(storage) {
-  insistStorageAPI(storage);
+export function insistEnhancedStorageAPI(kvStore) {
+  insistStorageAPI(kvStore);
   for (const n of [
     'enumeratePrefixedKeys',
     'getPrefixedValues',
     'deletePrefixedKeys',
   ]) {
-    assert(n in storage, X`storage.${n} is missing, cannot use`);
+    assert(n in kvStore, X`kvStore.${n} is missing, cannot use`);
   }
 }

--- a/packages/SwingSet/src/types.js
+++ b/packages/SwingSet/src/types.js
@@ -120,7 +120,6 @@
  *              shutdown: () => Promise<void>,
  *            } } VatManager
  * @typedef { () => Promise<void> } WaitUntilQuiescent
- *
  */
 
 /**
@@ -159,5 +158,12 @@
  */
 
 /**
+ * @typedef { import('@agoric/swing-store-simple').KVStore } KVStore
+ * @typedef { import('@agoric/swing-store-simple').StreamStore } StreamStore
  * @typedef { import('@agoric/swing-store-simple').SwingStore } SwingStore
+ *
+ * @typedef {{
+ *   kvStore: KVStore,
+ *   streamStore: StreamStore,
+ * }} HostStore
  */

--- a/packages/SwingSet/test/device-plugin/test-device.js
+++ b/packages/SwingSet/test/device-plugin/test-device.js
@@ -2,7 +2,7 @@
 import { test } from '../../tools/prepare-test-env-ava';
 
 // eslint-disable-next-line import/order
-import { initSwingStore } from '@agoric/swing-store-simple';
+import { provideHostStorage } from '../../src/hostStorage';
 
 import {
   swingsetIsInitialized,
@@ -13,8 +13,7 @@ import { buildBridge } from '../../src/devices/bridge';
 import { buildPlugin } from '../../src/devices/plugin';
 
 test.before('initialize storage', t => {
-  const { storage } = initSwingStore(null);
-  t.context.storage = storage;
+  t.context.hostStorage = provideHostStorage();
 });
 
 async function setupVatController(t) {
@@ -35,7 +34,7 @@ async function setupVatController(t) {
     bridge: { ...bridge.endowments },
   };
 
-  if (!swingsetIsInitialized(t.context.storage)) {
+  if (!swingsetIsInitialized(t.context.hostStorage)) {
     const config = {
       bootstrap: 'bootstrap',
       vats: {
@@ -55,9 +54,12 @@ async function setupVatController(t) {
         },
       },
     };
-    await initializeSwingset(config, ['plugin'], t.context.storage);
+    await initializeSwingset(config, ['plugin'], t.context.hostStorage);
   }
-  const c = await makeSwingsetController(t.context.storage, deviceEndowments);
+  const c = await makeSwingsetController(
+    t.context.hostStorage,
+    deviceEndowments,
+  );
   const cycle = async () => {
     await c.run();
     while (inputQueue.length) {

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -4,13 +4,13 @@ import { test } from '../tools/prepare-test-env-ava';
 
 import path from 'path';
 import { spawn } from 'child_process';
-import { initSwingStore } from '@agoric/swing-store-simple';
+import { provideHostStorage } from '../src/hostStorage';
 import {
   buildVatController,
   loadBasedir,
+  initializeSwingset,
   makeSwingsetController,
 } from '../src/index';
-import { initializeSwingset } from '../src/initializeSwingset';
 import { checkKT } from './util';
 
 function capdata(body, slots = []) {
@@ -106,16 +106,16 @@ test('XS bootstrap', async t => {
     path.resolve(__dirname, 'basedir-controller-2'),
   );
   config.defaultManagerType = 'xs-worker';
-  const hostStorage = initSwingStore().storage;
+  const hostStorage = provideHostStorage();
   const c = await buildVatController(config, [], { hostStorage });
   t.deepEqual(c.dump().log, ['bootstrap called']);
   t.is(
-    hostStorage.get('kernel.defaultManagerType'),
+    hostStorage.kvStore.get('kernel.defaultManagerType'),
     'xs-worker',
     'defaultManagerType is saved by kernelKeeper',
   );
   const vatID = c.vatNameToID('bootstrap');
-  const options = JSON.parse(hostStorage.get(`${vatID}.options`));
+  const options = JSON.parse(hostStorage.kvStore.get(`${vatID}.options`));
   t.is(
     options.managerType,
     'xs-worker',
@@ -124,7 +124,7 @@ test('XS bootstrap', async t => {
 });
 
 test('static vats are unmetered on XS', async t => {
-  const hostStorage = initSwingStore().storage;
+  const hostStorage = provideHostStorage();
   const config = await loadBasedir(
     path.resolve(__dirname, 'basedir-controller-2'),
   );

--- a/packages/SwingSet/test/test-demos-comms.js
+++ b/packages/SwingSet/test/test-demos-comms.js
@@ -1,9 +1,9 @@
 /* global __dirname */
-// eslint-disable-next-line import/order
 import { test } from '../tools/prepare-test-env-ava';
 
-import { initSwingStore } from '@agoric/swing-store-simple';
+// eslint-disable-next-line import/order
 import path from 'path';
+import { provideHostStorage } from '../src/hostStorage';
 import { buildLoopbox } from '../src/devices/loopbox';
 import {
   loadBasedir,
@@ -30,9 +30,12 @@ async function main(basedir, argv) {
     loopbox: { ...loopboxEndowments },
   };
 
-  const storage = initSwingStore().storage;
-  await initializeSwingset(config, argv, storage);
-  const controller = await makeSwingsetController(storage, deviceEndowments);
+  const hostStorage = provideHostStorage();
+  await initializeSwingset(config, argv, hostStorage);
+  const controller = await makeSwingsetController(
+    hostStorage,
+    deviceEndowments,
+  );
 
   await controller.run();
   return controller.dump();

--- a/packages/SwingSet/test/test-demos.js
+++ b/packages/SwingSet/test/test-demos.js
@@ -1,9 +1,9 @@
 /* global __dirname */
-// eslint-disable-next-line import/order
 import { test } from '../tools/prepare-test-env-ava';
 
-import { initSwingStore } from '@agoric/swing-store-simple';
+// eslint-disable-next-line import/order
 import path from 'path';
+import { provideHostStorage } from '../src/hostStorage';
 import { buildLoopbox } from '../src/devices/loopbox';
 import {
   loadBasedir,
@@ -24,9 +24,12 @@ async function main(basedir, argv) {
     loopbox: { ...loopboxEndowments },
   };
 
-  const storage = initSwingStore().storage;
-  await initializeSwingset(config, argv, storage);
-  const controller = await makeSwingsetController(storage, deviceEndowments);
+  const hostStorage = provideHostStorage();
+  await initializeSwingset(config, argv, hostStorage);
+  const controller = await makeSwingsetController(
+    hostStorage,
+    deviceEndowments,
+  );
   await controller.run();
   return controller.dump();
 }

--- a/packages/SwingSet/test/test-device-bridge.js
+++ b/packages/SwingSet/test/test-device-bridge.js
@@ -2,7 +2,7 @@
 import { test } from '../tools/prepare-test-env-ava';
 
 // eslint-disable-next-line import/order
-import { initSwingStore } from '@agoric/swing-store-simple';
+import { provideHostStorage } from '../src/hostStorage';
 
 import {
   initializeSwingset,
@@ -19,7 +19,7 @@ test('bridge device', async t => {
   }
   const bd = buildBridge(outboundCallback);
 
-  const storage = initSwingStore();
+  const hostStorage = provideHostStorage();
   const config = {
     bootstrap: 'bootstrap',
     vats: {
@@ -41,8 +41,8 @@ test('bridge device', async t => {
   argv[0] = { hello: 'from' };
   argv[1] = ['swingset'];
 
-  await initializeSwingset(config, argv, storage.storage);
-  const c = await makeSwingsetController(storage.storage, deviceEndowments);
+  await initializeSwingset(config, argv, hostStorage);
+  const c = await makeSwingsetController(hostStorage, deviceEndowments);
   t.teardown(c.shutdown);
   await c.run();
 
@@ -79,7 +79,7 @@ test('bridge device', async t => {
     bridge: { ...bd2.endowments },
   };
 
-  const c2 = await makeSwingsetController(storage.storage, endowments2);
+  const c2 = await makeSwingsetController(hostStorage, endowments2);
   await c2.run();
   // The bootstrap is reloaded from transcript, which means it doesn't run
   // any syscalls (they are switched off during replay), so it won't re-run
@@ -122,7 +122,7 @@ test('bridge device can return undefined', async t => {
   }
   const bd = buildBridge(outboundCallback);
 
-  const storage = initSwingStore();
+  const hostStorage = provideHostStorage();
   const config = {
     bootstrap: 'bootstrap',
     defaultManagerType: 'local',
@@ -144,8 +144,8 @@ test('bridge device can return undefined', async t => {
   const argv = [];
   argv[0] = { hello: 'from' };
   argv[1] = ['swingset'];
-  await initializeSwingset(config, argv, storage.storage);
-  const c = await makeSwingsetController(storage.storage, deviceEndowments);
+  await initializeSwingset(config, argv, hostStorage);
+  const c = await makeSwingsetController(hostStorage, deviceEndowments);
   t.teardown(c.shutdown);
   await c.run();
 

--- a/packages/SwingSet/test/test-devices.js
+++ b/packages/SwingSet/test/test-devices.js
@@ -3,7 +3,8 @@
 import { test } from '../tools/prepare-test-env-ava';
 
 import bundleSource from '@agoric/bundle-source';
-import { initSwingStore, getAllState } from '@agoric/swing-store-simple';
+import { getAllState } from '@agoric/swing-store-simple';
+import { provideHostStorage } from '../src/hostStorage';
 
 import {
   initializeSwingset,
@@ -57,7 +58,7 @@ test.serial('d0', async t => {
       },
     },
   };
-  const hostStorage = initSwingStore().storage;
+  const hostStorage = provideHostStorage();
   await initializeSwingset(config, [], hostStorage);
   const c = await makeSwingsetController(hostStorage, {});
   await c.step();
@@ -108,7 +109,7 @@ test.serial('d1', async t => {
     },
   };
 
-  const hostStorage = initSwingStore().storage;
+  const hostStorage = provideHostStorage();
   await initializeSwingset(config, [], hostStorage, t.context.data);
   const c = await makeSwingsetController(hostStorage, deviceEndowments);
   await c.step();
@@ -140,7 +141,7 @@ async function test2(t, mode) {
       },
     },
   };
-  const hostStorage = initSwingStore().storage;
+  const hostStorage = provideHostStorage();
   await initializeSwingset(config, [mode], hostStorage, t.context.data);
   const c = await makeSwingsetController(hostStorage, {});
   await c.step();
@@ -213,7 +214,7 @@ test.serial('d2.5', async t => {
 });
 
 test.serial('device state', async t => {
-  const { storage } = initSwingStore();
+  const hostStorage = provideHostStorage();
   const config = {
     bootstrap: 'bootstrap',
     vats: {
@@ -231,12 +232,12 @@ test.serial('device state', async t => {
 
   // The initial state should be missing (null). Then we set it with the call
   // from bootstrap, and read it back.
-  await initializeSwingset(config, ['write+read'], storage, t.context.data);
-  const c1 = await makeSwingsetController(storage, {});
+  await initializeSwingset(config, ['write+read'], hostStorage, t.context.data);
+  const c1 = await makeSwingsetController(hostStorage, {});
   const d3 = c1.deviceNameToID('d3');
   await c1.run();
   t.deepEqual(c1.dump().log, ['undefined', 'w+r', 'called', 'got {"s":"new"}']);
-  const s = getAllState(storage);
+  const s = getAllState(hostStorage.kvStore);
   t.deepEqual(JSON.parse(s[`${d3}.deviceState`]), capargs({ s: 'new' }));
   t.deepEqual(JSON.parse(s[`${d3}.o.nextID`]), 10);
 });
@@ -261,7 +262,7 @@ test.serial('mailbox outbound', async t => {
     mailbox: { ...mb.endowments },
   };
 
-  const hostStorage = initSwingStore().storage;
+  const hostStorage = provideHostStorage();
   await initializeSwingset(config, ['mailbox1'], hostStorage, t.context.data);
   const c = await makeSwingsetController(hostStorage, deviceEndowments);
   await c.run();
@@ -311,7 +312,7 @@ test.serial('mailbox inbound', async t => {
 
   let rc;
 
-  const hostStorage = initSwingStore().storage;
+  const hostStorage = provideHostStorage();
   await initializeSwingset(config, ['mailbox2'], hostStorage, t.context.data);
   const c = await makeSwingsetController(hostStorage, deviceEndowments);
   await c.run();
@@ -433,7 +434,7 @@ test.serial('command broadcast', async t => {
     command: { ...cm.endowments },
   };
 
-  const hostStorage = initSwingStore().storage;
+  const hostStorage = provideHostStorage();
   await initializeSwingset(config, ['command1'], hostStorage, t.context.data);
   const c = await makeSwingsetController(hostStorage, deviceEndowments);
   await c.run();
@@ -459,7 +460,7 @@ test.serial('command deliver', async t => {
     command: { ...cm.endowments },
   };
 
-  const hostStorage = initSwingStore().storage;
+  const hostStorage = provideHostStorage();
   await initializeSwingset(config, ['command2'], hostStorage, t.context.data);
   const c = await makeSwingsetController(hostStorage, deviceEndowments);
   await c.run();
@@ -498,9 +499,9 @@ test.serial('liveslots throws when D() gets promise', async t => {
       },
     },
   };
-  const storage = initSwingStore().storage;
-  await initializeSwingset(config, ['promise1'], storage, t.context.data);
-  const c = await makeSwingsetController(storage, {});
+  const hostStorage = provideHostStorage();
+  await initializeSwingset(config, ['promise1'], hostStorage, t.context.data);
+  const c = await makeSwingsetController(hostStorage, {});
   await c.step();
   // When liveslots catches an attempt to send a promise into D(), it throws
   // a regular error, which the vat can catch.
@@ -534,9 +535,9 @@ test.serial('syscall.callNow(promise) is vat-fatal', async t => {
       },
     },
   };
-  const storage = initSwingStore().storage;
-  await initializeSwingset(config, [], storage, t.context.data);
-  const c = await makeSwingsetController(storage, {});
+  const hostStorage = provideHostStorage();
+  await initializeSwingset(config, [], hostStorage, t.context.data);
+  const c = await makeSwingsetController(hostStorage, {});
   await c.step();
   // if the kernel paniced, that c.step() will reject, and the await will throw
   t.deepEqual(c.dump().log, ['sending Promise', 'good: callNow failed']);

--- a/packages/SwingSet/test/test-kernel.js
+++ b/packages/SwingSet/test/test-kernel.js
@@ -2,7 +2,6 @@
 import { test } from '../tools/prepare-test-env-ava';
 
 import anylogger from 'anylogger';
-import { initSwingStore } from '@agoric/swing-store-simple';
 import { assert, details as X } from '@agoric/assert';
 import { WeakRef, FinalizationRegistry } from '../src/weakref';
 import { waitUntilQuiescent } from '../src/waitUntilQuiescent';
@@ -10,6 +9,7 @@ import { waitUntilQuiescent } from '../src/waitUntilQuiescent';
 import buildKernel from '../src/kernel/index';
 import { initializeKernel } from '../src/kernel/initializeKernel';
 import { makeVatSlot } from '../src/parseVatSlots';
+import { provideHostStorage } from '../src/hostStorage';
 import { checkKT, extractMessage } from './util';
 
 function capdata(body, slots = []) {
@@ -57,7 +57,7 @@ function makeConsole(tag) {
 function makeEndowments() {
   return {
     waitUntilQuiescent,
-    hostStorage: initSwingStore().storage,
+    hostStorage: provideHostStorage(),
     runEndOfCrank: () => {},
     makeConsole,
     WeakRef,
@@ -1257,7 +1257,7 @@ test('xs-worker default manager type', async t => {
   initializeKernel({ defaultManagerType: 'xs-worker' }, endowments.hostStorage);
   buildKernel(endowments, {}, {});
   t.deepEqual(
-    endowments.hostStorage.get('kernel.defaultManagerType'),
+    endowments.hostStorage.kvStore.get('kernel.defaultManagerType'),
     'xs-worker',
   );
 });

--- a/packages/SwingSet/test/test-message-patterns.js
+++ b/packages/SwingSet/test/test-message-patterns.js
@@ -13,7 +13,7 @@ import test from 'ava';
 
 import path from 'path';
 import bundleSource from '@agoric/bundle-source';
-import { initSwingStore } from '@agoric/swing-store-simple';
+import { provideHostStorage } from '../src/hostStorage';
 import {
   initializeSwingset,
   makeSwingsetController,
@@ -143,7 +143,7 @@ export async function runVatsInComms(t, name) {
   const deviceEndowments = {
     loopbox: { ...loopboxEndowments },
   };
-  const hostStorage = initSwingStore().storage;
+  const hostStorage = provideHostStorage();
   await initializeSwingset(config, [name], hostStorage, { kernelBundles });
   const c = await makeSwingsetController(hostStorage, deviceEndowments);
   t.teardown(c.shutdown);

--- a/packages/SwingSet/test/test-state.js
+++ b/packages/SwingSet/test/test-state.js
@@ -65,14 +65,14 @@ function testStorage(t, s, getState, commit) {
 }
 
 test('storageInMemory', t => {
-  const { storage } = initSwingStore();
-  testStorage(t, storage, () => getAllState(storage), null);
+  const { kvStore } = initSwingStore();
+  testStorage(t, kvStore, () => getAllState(kvStore), null);
 });
 
 function buildHostDBAndGetState() {
-  const { storage } = initSwingStore();
-  const hostDB = buildHostDBInMemory(storage);
-  return { hostDB, getState: () => getAllState(storage) };
+  const { kvStore } = initSwingStore();
+  const hostDB = buildHostDBInMemory(kvStore);
+  return { hostDB, getState: () => getAllState(kvStore) };
 }
 
 test('hostDBInMemory', t => {
@@ -116,15 +116,15 @@ test('blockBuffer fulfills storage API', t => {
 });
 
 test('guardStorage fulfills storage API', t => {
-  const { storage } = initSwingStore();
-  const guardedHostStorage = guardStorage(storage);
-  testStorage(t, guardedHostStorage, () => getAllState(storage), null);
+  const { kvStore } = initSwingStore();
+  const guardedHostStorage = guardStorage(kvStore);
+  testStorage(t, guardedHostStorage, () => getAllState(kvStore), null);
 });
 
 test('crankBuffer fulfills storage API', t => {
-  const { storage } = initSwingStore();
-  const { crankBuffer, commitCrank } = buildCrankBuffer(storage);
-  testStorage(t, crankBuffer, () => getAllState(storage), commitCrank);
+  const { kvStore } = initSwingStore();
+  const { crankBuffer, commitCrank } = buildCrankBuffer(kvStore);
+  testStorage(t, crankBuffer, () => getAllState(kvStore), commitCrank);
 });
 
 test('crankBuffer can abortCrank', t => {
@@ -183,8 +183,8 @@ test('crankBuffer can abortCrank', t => {
 });
 
 test('storage helpers', t => {
-  const { storage } = initSwingStore();
-  const s = addHelpers(storage);
+  const { kvStore } = initSwingStore();
+  const s = addHelpers(kvStore);
 
   s.set('foo.0', 'f0');
   s.set('foo.1', 'f1');
@@ -192,7 +192,7 @@ test('storage helpers', t => {
   s.set('foo.3', 'f3');
   // omit foo.4
   s.set('foo.5', 'f5');
-  checkState(t, () => getAllState(storage), [
+  checkState(t, () => getAllState(kvStore), [
     ['foo.0', 'f0'],
     ['foo.1', 'f1'],
     ['foo.2', 'f2'],
@@ -226,26 +226,26 @@ test('storage helpers', t => {
   t.falsy(s.has('foo.3'));
   t.falsy(s.has('foo.4'));
   t.truthy(s.has('foo.5'));
-  checkState(t, () => getAllState(storage), [
+  checkState(t, () => getAllState(kvStore), [
     ['foo.0', 'f0'],
     ['foo.5', 'f5'],
   ]);
 });
 
 function buildKeeperStorageInMemory() {
-  const { storage } = initSwingStore();
-  const { enhancedCrankBuffer, commitCrank } = wrapStorage(storage);
+  const { kvStore } = initSwingStore();
+  const { enhancedCrankBuffer, commitCrank } = wrapStorage(kvStore);
   return {
     kstorage: enhancedCrankBuffer,
-    getState: () => getAllState(storage),
+    getState: () => getAllState(kvStore),
     commitCrank,
   };
 }
 
 function duplicateKeeper(getState) {
-  const { storage } = initSwingStore();
-  setAllState(storage, getState());
-  const { enhancedCrankBuffer } = wrapStorage(storage);
+  const { kvStore } = initSwingStore();
+  setAllState(kvStore, getState());
+  const { enhancedCrankBuffer } = wrapStorage(kvStore);
   return makeKernelKeeper(enhancedCrankBuffer);
 }
 

--- a/packages/SwingSet/test/test-transcript-light.js
+++ b/packages/SwingSet/test/test-transcript-light.js
@@ -3,97 +3,105 @@
 import { test } from '../tools/prepare-test-env-ava';
 
 import path from 'path';
-import {
-  initSwingStore,
-  getAllState,
-  setAllState,
-} from '@agoric/swing-store-simple';
+import { getAllState, setAllState } from '@agoric/swing-store-simple';
+import { provideHostStorage } from '../src/hostStorage';
 import { buildVatController, loadBasedir } from '../src/index';
 
 test('transcript-light load', async t => {
   const config = await loadBasedir(
     path.resolve(__dirname, 'basedir-transcript'),
   );
-  const { storage } = initSwingStore();
-  const c = await buildVatController(config, ['one'], { hostStorage: storage });
-  const state0 = getAllState(storage);
+  const hostStorage = provideHostStorage();
+  const c = await buildVatController(config, ['one'], { hostStorage });
+  const kvStore = hostStorage.kvStore;
+  const state0 = getAllState(kvStore);
   t.is(state0.initialized, 'true');
   t.not(state0.runQueue, '[]');
 
   await c.step();
-  const state1 = getAllState(storage);
+  const state1 = getAllState(kvStore);
 
   await c.step();
-  const state2 = getAllState(storage);
+  const state2 = getAllState(kvStore);
 
   await c.step();
-  const state3 = getAllState(storage);
+  const state3 = getAllState(kvStore);
 
   await c.step();
-  const state4 = getAllState(storage);
+  const state4 = getAllState(kvStore);
 
   await c.step();
-  const state5 = getAllState(storage);
+  const state5 = getAllState(kvStore);
 
   // build from loaded state
   // Step 0
 
   const cfg0 = await loadBasedir(path.resolve(__dirname, 'basedir-transcript'));
-  const storage0 = initSwingStore().storage;
-  setAllState(storage0, state0);
-  const c0 = await buildVatController(cfg0, ['one'], { hostStorage: storage0 });
+  const hostStorage0 = provideHostStorage();
+  const kvStore0 = hostStorage0.kvStore;
+  // XXX TODO copy transcripts
+  setAllState(kvStore0, state0);
+  const c0 = await buildVatController(cfg0, ['one'], {
+    hostStorage: hostStorage0,
+  });
 
   await c0.step();
-  t.deepEqual(state1, getAllState(storage0), `p1`);
+  t.deepEqual(state1, getAllState(kvStore0), `p1`);
 
   await c0.step();
-  t.deepEqual(state2, getAllState(storage0), `p2`);
+  t.deepEqual(state2, getAllState(kvStore0), `p2`);
 
   await c0.step();
-  t.deepEqual(state3, getAllState(storage0), `p3`);
+  t.deepEqual(state3, getAllState(kvStore0), `p3`);
 
   await c0.step();
-  t.deepEqual(state4, getAllState(storage0), `p4`);
+  t.deepEqual(state4, getAllState(kvStore0), `p4`);
 
   await c0.step();
-  t.deepEqual(state5, getAllState(storage0), `p5`);
+  t.deepEqual(state5, getAllState(kvStore0), `p5`);
 
   // Step 1
 
   const cfg1 = await loadBasedir(path.resolve(__dirname, 'basedir-transcript'));
-  const storage1 = initSwingStore().storage;
-  setAllState(storage1, state1);
-  const c1 = await buildVatController(cfg1, ['one'], { hostStorage: storage1 });
+  const hostStorage1 = provideHostStorage();
+  const kvStore1 = hostStorage1.kvStore;
+  setAllState(kvStore1, state1);
+  const c1 = await buildVatController(cfg1, ['one'], {
+    hostStorage: hostStorage1,
+  });
 
-  t.deepEqual(state1, getAllState(storage1), `p6`); // actual, expected
-
-  await c1.step();
-  t.deepEqual(state2, getAllState(storage1), `p7`);
-
-  await c1.step();
-  t.deepEqual(state3, getAllState(storage1), `p8`);
+  t.deepEqual(state1, getAllState(kvStore1), `p6`); // actual, expected
 
   await c1.step();
-  t.deepEqual(state4, getAllState(storage1), `p9`);
+  t.deepEqual(state2, getAllState(kvStore1), `p7`);
 
   await c1.step();
-  t.deepEqual(state5, getAllState(storage1), `p10`);
+  t.deepEqual(state3, getAllState(kvStore1), `p8`);
+
+  await c1.step();
+  t.deepEqual(state4, getAllState(kvStore1), `p9`);
+
+  await c1.step();
+  t.deepEqual(state5, getAllState(kvStore1), `p10`);
 
   // Step 2
 
   const cfg2 = await loadBasedir(path.resolve(__dirname, 'basedir-transcript'));
-  const storage2 = initSwingStore().storage;
-  setAllState(storage2, state2);
-  const c2 = await buildVatController(cfg2, ['one'], { hostStorage: storage2 });
+  const hostStorage2 = provideHostStorage();
+  const kvStore2 = hostStorage2.kvStore;
+  setAllState(kvStore2, state2);
+  const c2 = await buildVatController(cfg2, ['one'], {
+    hostStorage: hostStorage2,
+  });
 
-  t.deepEqual(state2, getAllState(storage2), `p11`);
-
-  await c2.step();
-  t.deepEqual(state3, getAllState(storage2), `p12`);
-
-  await c2.step();
-  t.deepEqual(state4, getAllState(storage2), `p13`);
+  t.deepEqual(state2, getAllState(kvStore2), `p11`);
 
   await c2.step();
-  t.deepEqual(state5, getAllState(storage2), `p14`);
+  t.deepEqual(state3, getAllState(kvStore2), `p12`);
+
+  await c2.step();
+  t.deepEqual(state4, getAllState(kvStore2), `p13`);
+
+  await c2.step();
+  t.deepEqual(state5, getAllState(kvStore2), `p14`);
 });

--- a/packages/SwingSet/test/test-vattp.js
+++ b/packages/SwingSet/test/test-vattp.js
@@ -2,7 +2,7 @@
 import { test } from '../tools/prepare-test-env-ava';
 
 // eslint-disable-next-line import/order
-import { initSwingStore } from '@agoric/swing-store-simple';
+import { provideHostStorage } from '../src/hostStorage';
 import { initializeSwingset, makeSwingsetController } from '../src/index';
 import { buildMailboxStateMap, buildMailbox } from '../src/devices/mailbox';
 
@@ -25,7 +25,7 @@ test('vattp', async t => {
   const deviceEndowments = {
     mailbox: { ...mb.endowments },
   };
-  const hostStorage = initSwingStore().storage;
+  const hostStorage = provideHostStorage();
 
   await initializeSwingset(config, ['1'], hostStorage);
   const c = await makeSwingsetController(hostStorage, deviceEndowments);
@@ -85,7 +85,7 @@ test('vattp 2', async t => {
   const deviceEndowments = {
     mailbox: { ...mb.endowments },
   };
-  const hostStorage = initSwingStore().storage;
+  const hostStorage = provideHostStorage();
 
   await initializeSwingset(config, ['2'], hostStorage);
   const c = await makeSwingsetController(hostStorage, deviceEndowments);

--- a/packages/SwingSet/test/test-vpid-kernel.js
+++ b/packages/SwingSet/test/test-vpid-kernel.js
@@ -2,10 +2,10 @@
 import { test } from '../tools/prepare-test-env-ava';
 
 import anylogger from 'anylogger';
-import { initSwingStore } from '@agoric/swing-store-simple';
 import { assert, details as X } from '@agoric/assert';
 import { WeakRef, FinalizationRegistry } from '../src/weakref';
 import { waitUntilQuiescent } from '../src/waitUntilQuiescent';
+import { provideHostStorage } from '../src/hostStorage';
 
 import buildKernel from '../src/kernel/index';
 import { initializeKernel } from '../src/kernel/initializeKernel';
@@ -36,7 +36,7 @@ function makeConsole(tag) {
 function makeEndowments() {
   return {
     waitUntilQuiescent,
-    hostStorage: initSwingStore().storage,
+    hostStorage: provideHostStorage(),
     runEndOfCrank: () => {},
     makeConsole,
     WeakRef,

--- a/packages/SwingSet/test/timer-device/test-device.js
+++ b/packages/SwingSet/test/timer-device/test-device.js
@@ -2,7 +2,7 @@
 import { test } from '../../tools/prepare-test-env-ava';
 
 // eslint-disable-next-line import/order
-import { initSwingStore } from '@agoric/swing-store-simple';
+import { provideHostStorage } from '../../src/hostStorage';
 
 import { initializeSwingset, makeSwingsetController } from '../../src/index';
 import { buildTimer } from '../../src/devices/timer';
@@ -28,7 +28,7 @@ test('wake', async t => {
   const deviceEndowments = {
     timer: { ...timer.endowments },
   };
-  const hostStorage = initSwingStore().storage;
+  const hostStorage = provideHostStorage();
 
   await initializeSwingset(timerConfig, ['timer'], hostStorage);
   const c = await makeSwingsetController(hostStorage, deviceEndowments);
@@ -44,7 +44,7 @@ test('repeater', async t => {
   const deviceEndowments = {
     timer: { ...timer.endowments },
   };
-  const hostStorage = initSwingStore().storage;
+  const hostStorage = provideHostStorage();
 
   await initializeSwingset(timerConfig, ['repeater', 3, 2], hostStorage);
   const c = await makeSwingsetController(hostStorage, deviceEndowments);
@@ -64,7 +64,7 @@ test('repeater2', async t => {
   const deviceEndowments = {
     timer: { ...timer.endowments },
   };
-  const hostStorage = initSwingStore().storage;
+  const hostStorage = provideHostStorage();
 
   await initializeSwingset(timerConfig, ['repeater', 3, 2], hostStorage);
   const c = await makeSwingsetController(hostStorage, deviceEndowments);
@@ -87,7 +87,7 @@ test('repeaterZero', async t => {
   const deviceEndowments = {
     timer: { ...timer.endowments },
   };
-  const hostStorage = initSwingStore().storage;
+  const hostStorage = provideHostStorage();
 
   await initializeSwingset(timerConfig, ['repeater', 0, 3], hostStorage);
   const c = await makeSwingsetController(hostStorage, deviceEndowments);

--- a/packages/SwingSet/test/vat-admin/test-replay.js
+++ b/packages/SwingSet/test/vat-admin/test-replay.js
@@ -3,11 +3,8 @@ import '@agoric/install-metering-and-ses';
 import path from 'path';
 import test from 'ava';
 import bundleSource from '@agoric/bundle-source';
-import {
-  initSwingStore,
-  getAllState,
-  setAllState,
-} from '@agoric/swing-store-simple';
+import { getAllState, setAllState } from '@agoric/swing-store-simple';
+import { provideHostStorage } from '../../src/hostStorage';
 import { buildKernelBundles, buildVatController } from '../../src';
 
 function capdata(body, slots = []) {
@@ -41,10 +38,11 @@ test('replay bundleSource-based dynamic vat', async t => {
     bootstrap: 'bootstrap',
   };
 
-  const { storage: storage1 } = initSwingStore();
+  // XXX TODO: also copy and check transcripts
+  const hostStorage1 = provideHostStorage();
   {
     const c1 = await buildVatController(copy(config), [], {
-      hostStorage: storage1,
+      hostStorage: hostStorage1,
       kernelBundles: t.context.data.kernelBundles,
     });
     const r1 = c1.queueToVatExport(
@@ -62,12 +60,12 @@ test('replay bundleSource-based dynamic vat', async t => {
   // we could re-use the Storage object, but I'll be paranoid and create a
   // new one.
 
-  const state1 = getAllState(storage1);
-  const { storage: storage2 } = initSwingStore();
-  setAllState(storage2, state1);
+  const state1 = getAllState(hostStorage1.kvStore);
+  const hostStorage2 = provideHostStorage();
+  setAllState(hostStorage2.kvStore, state1);
   {
     const c2 = await buildVatController(copy(config), [], {
-      hostStorage: storage2,
+      hostStorage: hostStorage2,
     });
     const r2 = c2.queueToVatExport(
       'bootstrap',
@@ -92,10 +90,11 @@ test('replay bundleName-based dynamic vat', async t => {
     bootstrap: 'bootstrap',
   };
 
-  const { storage: storage1 } = initSwingStore();
+  // XXX TODO: also copy and check transcripts
+  const hostStorage1 = provideHostStorage();
   {
     const c1 = await buildVatController(copy(config), [], {
-      hostStorage: storage1,
+      hostStorage: hostStorage1,
       kernelBundles: t.context.data.kernelBundles,
     });
     const r1 = c1.queueToVatExport(
@@ -109,12 +108,12 @@ test('replay bundleName-based dynamic vat', async t => {
     t.deepEqual(c1.kpResolution(r1), capargs('created'));
   }
 
-  const state1 = getAllState(storage1);
-  const { storage: storage2 } = initSwingStore();
-  setAllState(storage2, state1);
+  const state1 = getAllState(hostStorage1.kvStore);
+  const hostStorage2 = provideHostStorage();
+  setAllState(hostStorage2.kvStore, state1);
   {
     const c2 = await buildVatController(copy(config), [], {
-      hostStorage: storage2,
+      hostStorage: hostStorage2,
     });
     const r2 = c2.queueToVatExport(
       'bootstrap',

--- a/packages/SwingSet/tools/db-delete.js
+++ b/packages/SwingSet/tools/db-delete.js
@@ -47,14 +47,14 @@ function run() {
   const stateDBDir = argv.shift();
   const key = argv.shift();
 
-  const { storage, commit } = openSwingStore(stateDBDir);
+  const { kvStore, commit } = openSwingStore(stateDBDir);
 
   if (range) {
-    for (const k of storage.getKeys(`${key}.`, `${key}/`)) {
-      storage.delete(k);
+    for (const k of kvStore.getKeys(`${key}.`, `${key}/`)) {
+      kvStore.delete(k);
     }
   } else {
-    storage.delete(key);
+    kvStore.delete(key);
   }
   commit();
 }

--- a/packages/SwingSet/tools/db-get.js
+++ b/packages/SwingSet/tools/db-get.js
@@ -58,10 +58,10 @@ function run() {
   const stateDBDir = argv.shift();
   const key = argv.shift();
 
-  const { storage } = openSwingStore(stateDBDir);
+  const { kvStore } = openSwingStore(stateDBDir);
 
   function pkv(k) {
-    const value = storage.get(k);
+    const value = kvStore.get(k);
     if (raw) {
       p(value);
     } else {
@@ -70,7 +70,7 @@ function run() {
   }
 
   if (range) {
-    for (const k of storage.getKeys(`${key}.`, `${key}/`)) {
+    for (const k of kvStore.getKeys(`${key}.`, `${key}/`)) {
       pkv(k);
     }
   } else {

--- a/packages/SwingSet/tools/db-set.js
+++ b/packages/SwingSet/tools/db-set.js
@@ -33,9 +33,9 @@ function run() {
   const key = argv.shift();
   const value = argv.shift();
 
-  const { storage, commit } = openSwingStore(stateDBDir);
+  const { kvStore, commit } = openSwingStore(stateDBDir);
 
-  storage.set(key, value);
+  kvStore.set(key, value);
   commit();
 }
 

--- a/packages/SwingSet/tools/replace-bundle.js
+++ b/packages/SwingSet/tools/replace-bundle.js
@@ -35,13 +35,13 @@ async function run() {
   const stateDBDir = argv.shift();
   const srcPath = argv.shift();
 
-  const { storage, commit } = openSwingStore(stateDBDir);
+  const { kvStore, commit } = openSwingStore(stateDBDir);
   log(`will use ${srcPath} in ${stateDBDir} for ${bundleName}`);
 
   if (bundleName === 'kernel') {
     bundleName = 'kernelBundle';
   } else {
-    const vatID = storage.get(`vat.name.${bundleName}`);
+    const vatID = kvStore.get(`vat.name.${bundleName}`);
     if (vatID) {
       bundleName = `${vatID}.source`;
     }
@@ -50,7 +50,7 @@ async function run() {
     bundleBundle = false;
   }
 
-  const oldBundleStr = storage.get(bundleName);
+  const oldBundleStr = kvStore.get(bundleName);
   log(`old bundle is ${oldBundleStr.length} bytes`);
   let bundle = await bundleSource(srcPath);
   if (bundleBundle) {
@@ -58,7 +58,7 @@ async function run() {
   }
   const newBundleStr = JSON.stringify(bundle);
   log(`new bundle is ${newBundleStr.length} bytes`);
-  storage.set(bundleName, newBundleStr);
+  kvStore.set(bundleName, newBundleStr);
   commit();
   log(`bundle ${bundleName} replaced`);
 }

--- a/packages/agoric-cli/lib/open.js
+++ b/packages/agoric-cli/lib/open.js
@@ -43,13 +43,13 @@ export async function getAccessToken(port, powers = {}) {
   await fs.mkdir(sharedStateDir, { mode: 0o700, recursive: true });
 
   // Ensure an access token exists.
-  const { storage, commit, close } = openSwingStore(sharedStateDir, 'state');
+  const { kvStore, commit, close } = openSwingStore(sharedStateDir, 'state');
   const accessTokenKey = `accessToken/${port}`;
-  if (!storage.has(accessTokenKey)) {
-    storage.set(accessTokenKey, await generateAccessToken());
+  if (!kvStore.has(accessTokenKey)) {
+    kvStore.set(accessTokenKey, await generateAccessToken());
     commit();
   }
-  const accessToken = storage.get(accessTokenKey);
+  const accessToken = kvStore.get(accessTokenKey);
   close();
   return accessToken;
 }

--- a/packages/cosmic-swingset/src/check-lmdb.js
+++ b/packages/cosmic-swingset/src/check-lmdb.js
@@ -30,13 +30,13 @@ export function getBestSwingStore(tempdir) {
 
   try {
     const tdb1 = openSwingStoreLMDB(tempdir);
-    tdb1.storage.set('test key', 'test value');
+    tdb1.kvStore.set('test key', 'test value');
     tdb1.commit();
     tdb1.close();
 
     const tdb2 = openSwingStoreLMDB(tempdir);
-    assert(tdb2.storage.has('test key'), X`LMDB test disavows test key`);
-    const val = tdb2.storage.get('test key');
+    assert(tdb2.kvStore.has('test key'), X`LMDB test disavows test key`);
+    const val = tdb2.kvStore.get('test key');
     assert(
       val === 'test value',
       X`LMDB test returned '${val}', not 'test value'`,
@@ -51,8 +51,8 @@ export function getBestSwingStore(tempdir) {
     console.log(`LMDB does not work, falling back to Simple DB`, e);
     // see https://github.com/Agoric/agoric-sdk/issues/950 for details
     return {
-      openSwingStore: openSwingStoreSimple,
-      initSwingStore: initSwingStoreSimple,
+      openSwingStore: () => openSwingStoreSimple(),
+      initSwingStore: () => initSwingStoreSimple(),
     };
   } finally {
     fs.rmdirSync(tempdir, { recursive: true });

--- a/packages/solo/src/access-token.js
+++ b/packages/solo/src/access-token.js
@@ -32,13 +32,13 @@ export async function getAccessToken(port) {
   await fs.promises.mkdir(sharedStateDir, { mode: 0o700, recursive: true });
 
   // Ensure an access token exists.
-  const { storage, commit, close } = openSwingStore(sharedStateDir, 'state');
+  const { kvStore, commit, close } = openSwingStore(sharedStateDir, 'state');
   const accessTokenKey = `accessToken/${port}`;
-  if (!storage.has(accessTokenKey)) {
-    storage.set(accessTokenKey, await generateAccessToken());
+  if (!kvStore.has(accessTokenKey)) {
+    kvStore.set(accessTokenKey, await generateAccessToken());
     commit();
   }
-  const accessToken = storage.get(accessTokenKey);
+  const accessToken = kvStore.get(accessTokenKey);
   close();
   return accessToken;
 }

--- a/packages/solo/src/start.js
+++ b/packages/solo/src/start.js
@@ -136,15 +136,22 @@ async function buildSwingset(
 
   const tempdir = path.resolve(kernelStateDBDir, 'check-lmdb-tempdir');
   const { openSwingStore } = getBestSwingStore(tempdir);
-  const { storage, commit } = openSwingStore(kernelStateDBDir);
+  const { kvStore, streamStore, commit } = openSwingStore(kernelStateDBDir);
+  const hostStorage = {
+    kvStore,
+    streamStore,
+  };
 
-  if (!swingsetIsInitialized(storage)) {
+  if (!swingsetIsInitialized(hostStorage)) {
     if (defaultManagerType && !config.defaultManagerType) {
       config.defaultManagerType = defaultManagerType;
     }
-    await initializeSwingset(config, argv, storage);
+    await initializeSwingset(config, argv, hostStorage);
   }
-  const controller = await makeSwingsetController(storage, deviceEndowments);
+  const controller = await makeSwingsetController(
+    hostStorage,
+    deviceEndowments,
+  );
 
   async function saveState() {
     const ms = JSON.stringify(mbs.exportToData());

--- a/packages/swing-store-lmdb/jsconfig.json
+++ b/packages/swing-store-lmdb/jsconfig.json
@@ -1,0 +1,17 @@
+// This file can contain .js-specific Typescript compiler config.
+{
+  "compilerOptions": {
+    "target": "esnext",
+
+    "noEmit": true,
+/*
+    // The following flags are for creating .d.ts files:
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+*/
+    "strictNullChecks": true,
+    "moduleResolution": "node",
+  },
+  "include": ["src/**/*.js", "exported.js"],
+}

--- a/packages/swing-store-lmdb/package.json
+++ b/packages/swing-store-lmdb/package.json
@@ -5,7 +5,7 @@
   "parsers": {
     "js": "mjs"
   },
-  "main": "lmdbSwingStore.js",
+  "main": "src/lmdbSwingStore.js",
   "repository": "https://github.com/Agoric/agoric-sdk",
   "author": "Agoric",
   "license": "Apache-2.0",
@@ -13,11 +13,16 @@
     "build": "exit 0",
     "test": "ava",
     "test:xs": "exit 0",
-    "lint-fix": "eslint --fix '**/*.js'",
-    "lint-check": "eslint '**/*.js'"
+    "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
+    "lint-check": "yarn lint",
+    "lint": "yarn lint:types && yarn lint:eslint",
+    "lint:types": "tsc -p jsconfig.json",
+    "lint:eslint": "eslint '**/*.js'"
   },
   "dependencies": {
-    "node-lmdb": "^0.9.4"
+    "@agoric/assert": "^0.2.12",
+    "node-lmdb": "^0.9.4",
+    "n-readlines": "^1.0.0"
   },
   "devDependencies": {
     "@agoric/install-ses": "^0.5.13",

--- a/packages/swing-store-lmdb/test/test-state.js
+++ b/packages/swing-store-lmdb/test/test-state.js
@@ -13,37 +13,37 @@ import {
   initSwingStore,
   openSwingStore,
   isSwingStore,
-} from '../lmdbSwingStore';
+} from '../src/lmdbSwingStore';
 
-function testStorage(t, storage) {
-  t.falsy(storage.has('missing'));
-  t.is(storage.get('missing'), undefined);
+function testStorage(t, kvStore) {
+  t.falsy(kvStore.has('missing'));
+  t.is(kvStore.get('missing'), undefined);
 
-  storage.set('foo', 'f');
-  t.truthy(storage.has('foo'));
-  t.is(storage.get('foo'), 'f');
+  kvStore.set('foo', 'f');
+  t.truthy(kvStore.has('foo'));
+  t.is(kvStore.get('foo'), 'f');
 
-  storage.set('foo2', 'f2');
-  storage.set('foo1', 'f1');
-  storage.set('foo3', 'f3');
-  t.deepEqual(Array.from(storage.getKeys('foo1', 'foo3')), ['foo1', 'foo2']);
-  t.deepEqual(Array.from(storage.getKeys('foo1', 'foo4')), [
+  kvStore.set('foo2', 'f2');
+  kvStore.set('foo1', 'f1');
+  kvStore.set('foo3', 'f3');
+  t.deepEqual(Array.from(kvStore.getKeys('foo1', 'foo3')), ['foo1', 'foo2']);
+  t.deepEqual(Array.from(kvStore.getKeys('foo1', 'foo4')), [
     'foo1',
     'foo2',
     'foo3',
   ]);
 
-  storage.delete('foo2');
-  t.falsy(storage.has('foo2'));
-  t.is(storage.get('foo2'), undefined);
-  t.deepEqual(Array.from(storage.getKeys('foo1', 'foo4')), ['foo1', 'foo3']);
+  kvStore.delete('foo2');
+  t.falsy(kvStore.has('foo2'));
+  t.is(kvStore.get('foo2'), undefined);
+  t.deepEqual(Array.from(kvStore.getKeys('foo1', 'foo4')), ['foo1', 'foo3']);
 
   const reference = {
     foo: 'f',
     foo1: 'f1',
     foo3: 'f3',
   };
-  t.deepEqual(getAllState(storage), reference, 'check state after changes');
+  t.deepEqual(getAllState(kvStore), reference, 'check state after changes');
 }
 
 test('storageInLMDB under SES', t => {
@@ -51,14 +51,14 @@ test('storageInLMDB under SES', t => {
   t.teardown(() => fs.rmdirSync(dbDir, { recursive: true }));
   fs.rmdirSync(dbDir, { recursive: true });
   t.is(isSwingStore(dbDir), false);
-  const { storage, commit, close } = initSwingStore(dbDir);
-  testStorage(t, storage);
+  const { kvStore, commit, close } = initSwingStore(dbDir);
+  testStorage(t, kvStore);
   commit();
-  const before = getAllState(storage);
+  const before = getAllState(kvStore);
   close();
   t.is(isSwingStore(dbDir), true);
 
-  const { storage: after } = openSwingStore(dbDir);
+  const { kvStore: after } = openSwingStore(dbDir);
   t.deepEqual(getAllState(after), before, 'check state after reread');
   t.is(isSwingStore(dbDir), true);
 });

--- a/packages/swing-store-simple/jsconfig.json
+++ b/packages/swing-store-simple/jsconfig.json
@@ -1,0 +1,17 @@
+// This file can contain .js-specific Typescript compiler config.
+{
+  "compilerOptions": {
+    "target": "esnext",
+
+    "noEmit": true,
+/*
+    // The following flags are for creating .d.ts files:
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+*/
+    "strictNullChecks": true,
+    "moduleResolution": "node",
+  },
+  "include": ["src/**/*.js", "exported.js"],
+}

--- a/packages/swing-store-simple/package.json
+++ b/packages/swing-store-simple/package.json
@@ -5,7 +5,6 @@
   "parsers": {
     "js": "mjs"
   },
-  "type": "module",
   "main": "src/simpleSwingStore.js",
   "repository": "https://github.com/Agoric/agoric-sdk",
   "author": "Agoric",
@@ -13,7 +12,6 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
-    "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint-check": "yarn lint",

--- a/packages/swing-store-simple/package.json
+++ b/packages/swing-store-simple/package.json
@@ -6,7 +6,7 @@
     "js": "mjs"
   },
   "type": "module",
-  "main": "simpleSwingStore.js",
+  "main": "src/simpleSwingStore.js",
   "repository": "https://github.com/Agoric/agoric-sdk",
   "author": "Agoric",
   "license": "Apache-2.0",
@@ -15,13 +15,18 @@
     "test": "ava",
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
-    "lint-fix": "eslint --fix '**/*.js'",
-    "lint-check": "eslint '**/*.js'"
+    "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
+    "lint-check": "yarn lint",
+    "lint": "yarn lint:types && yarn lint:eslint",
+    "lint:types": "tsc -p jsconfig.json",
+    "lint:eslint": "eslint '**/*.js'"
   },
   "dependencies": {
+    "@agoric/assert": "^0.2.12",
     "n-readlines": "^1.0.0"
   },
   "devDependencies": {
+    "@agoric/install-ses": "^0.5.13",
     "ava": "^3.12.1",
     "esm": "^3.2.25"
   },

--- a/packages/swing-store-simple/test/test-state.js
+++ b/packages/swing-store-simple/test/test-state.js
@@ -1,3 +1,5 @@
+import '@agoric/install-ses';
+
 import fs from 'fs';
 import path from 'path';
 
@@ -7,42 +9,42 @@ import {
   openSwingStore,
   getAllState,
   isSwingStore,
-} from '../simpleSwingStore.js';
+} from '../src/simpleSwingStore.js';
 
-function testStorage(t, storage) {
-  t.falsy(storage.has('missing'));
-  t.is(storage.get('missing'), undefined);
+function testStorage(t, kvStore) {
+  t.falsy(kvStore.has('missing'));
+  t.is(kvStore.get('missing'), undefined);
 
-  storage.set('foo', 'f');
-  t.truthy(storage.has('foo'));
-  t.is(storage.get('foo'), 'f');
+  kvStore.set('foo', 'f');
+  t.truthy(kvStore.has('foo'));
+  t.is(kvStore.get('foo'), 'f');
 
-  storage.set('foo2', 'f2');
-  storage.set('foo1', 'f1');
-  storage.set('foo3', 'f3');
-  t.deepEqual(Array.from(storage.getKeys('foo1', 'foo3')), ['foo1', 'foo2']);
-  t.deepEqual(Array.from(storage.getKeys('foo1', 'foo4')), [
+  kvStore.set('foo2', 'f2');
+  kvStore.set('foo1', 'f1');
+  kvStore.set('foo3', 'f3');
+  t.deepEqual(Array.from(kvStore.getKeys('foo1', 'foo3')), ['foo1', 'foo2']);
+  t.deepEqual(Array.from(kvStore.getKeys('foo1', 'foo4')), [
     'foo1',
     'foo2',
     'foo3',
   ]);
 
-  storage.delete('foo2');
-  t.falsy(storage.has('foo2'));
-  t.is(storage.get('foo2'), undefined);
-  t.deepEqual(Array.from(storage.getKeys('foo1', 'foo4')), ['foo1', 'foo3']);
+  kvStore.delete('foo2');
+  t.falsy(kvStore.has('foo2'));
+  t.is(kvStore.get('foo2'), undefined);
+  t.deepEqual(Array.from(kvStore.getKeys('foo1', 'foo4')), ['foo1', 'foo3']);
 
   const reference = {
     foo: 'f',
     foo1: 'f1',
     foo3: 'f3',
   };
-  t.deepEqual(getAllState(storage), reference, 'check state after changes');
+  t.deepEqual(getAllState(kvStore), reference, 'check state after changes');
 }
 
 test('storageInMemory', t => {
-  const { storage } = initSwingStore();
-  testStorage(t, storage);
+  const { kvStore } = initSwingStore();
+  testStorage(t, kvStore);
 });
 
 test('storageInFile', t => {
@@ -50,14 +52,14 @@ test('storageInFile', t => {
   t.teardown(() => fs.rmdirSync(dbDir, { recursive: true }));
   fs.rmdirSync(dbDir, { recursive: true });
   t.is(isSwingStore(dbDir), false);
-  const { storage, commit, close } = initSwingStore(dbDir);
-  testStorage(t, storage);
+  const { kvStore, commit, close } = initSwingStore(dbDir);
+  testStorage(t, kvStore);
   commit();
-  const before = getAllState(storage);
+  const before = getAllState(kvStore);
   close();
   t.is(isSwingStore(dbDir), true);
 
-  const { storage: after } = openSwingStore(dbDir);
+  const { kvStore: after } = openSwingStore(dbDir);
   t.deepEqual(getAllState(after), before, 'check state after reread');
   t.is(isSwingStore(dbDir), true);
 });

--- a/packages/swing-store-simple/test/test-state.js
+++ b/packages/swing-store-simple/test/test-state.js
@@ -9,7 +9,7 @@ import {
   openSwingStore,
   getAllState,
   isSwingStore,
-} from '../src/simpleSwingStore.js';
+} from '../src/simpleSwingStore';
 
 function testStorage(t, kvStore) {
   t.falsy(kvStore.has('missing'));

--- a/packages/swingset-runner/demo/encouragementBotComms/runnerArgs
+++ b/packages/swingset-runner/demo/encouragementBotComms/runnerArgs
@@ -1,0 +1,1 @@
+--loopbox

--- a/packages/swingset-runner/demo/vatFailure/vat-bad.js
+++ b/packages/swingset-runner/demo/vatFailure/vat-bad.js
@@ -1,3 +1,5 @@
+import { assert } from '@agoric/assert';
+
 function capdata(body, slots = []) {
   return harden({ body, slots });
 }
@@ -11,5 +13,18 @@ export default function setup(syscall, _state, _helpers, _vatPowers) {
     const thing = method === 'begood' ? args.slots[0] : 'o-3414159';
     syscall.send(thing, 'pretendToBeAThing', capargs([method]));
   }
-  return { deliver };
+  function dispatch(vatDeliveryObject) {
+    const [type, ...args] = vatDeliveryObject;
+    switch (type) {
+      case 'message': {
+        const [targetSlot, msg] = args;
+        deliver(targetSlot, msg.method, msg.args);
+        return;
+      }
+      default:
+        assert.fail(`we only do deliveries here`);
+    }
+  }
+  harden(dispatch);
+  return dispatch;
 }

--- a/packages/swingset-runner/demo/zoeTests/vat-alice.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-alice.js
@@ -55,14 +55,21 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       UnderlyingAsset: moolaIssuer,
       StrikePrice: simoleanIssuer,
     });
-    const { creatorInvitation: writeCallInvitation } = await E(
+    const { creatorInvitation: writeCallInvitation, adminFacet } = await E(
       zoe,
     ).startInstance(installation, issuerKeywordRecord);
+
+    E(adminFacet)
+      .getVatShutdownPromise()
+      .then(
+        completion => log(`covered call was shut down due to "${completion}"`),
+        reason => log(`covered call failed due to "${reason}"`),
+      );
 
     const proposal = harden({
       give: { UnderlyingAsset: moola(3) },
       want: { StrikePrice: simoleans(7) },
-      exit: { afterDeadline: { deadline: 1, timer } },
+      exit: { afterDeadline: { deadline: 1n, timer } },
     });
 
     const paymentKeywordRecord = { UnderlyingAsset: moolaPayment };
@@ -98,7 +105,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       want: { StrikePrice: simoleans(7) },
       exit: {
         afterDeadline: {
-          deadline: 100,
+          deadline: 100n,
           timer,
         },
       },
@@ -130,7 +137,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       Ask: simoleanIssuer,
     });
     const now = await E(timer).getCurrentTimestamp();
-    const terms = harden({ timeAuthority: timer, closesAfter: now + 1 });
+    const terms = harden({ timeAuthority: timer, closesAfter: now + 1n });
     const { creatorInvitation: sellAssetsInvitation } = await E(
       zoe,
     ).startInstance(
@@ -346,7 +353,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     // remove the liquidity
     const aliceRemoveLiquidityProposal = harden({
       give: { Liquidity: liquidity(10) },
-      want: { Central: moola(0), Secondary: simoleans(0) },
+      want: { Central: moola(0n), Secondary: simoleans(0) },
     });
 
     const liquidityTokenPayment = await E(liquidityTokenPurseP).withdraw(

--- a/packages/swingset-runner/demo/zoeTests/vat-bob.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-bob.js
@@ -99,7 +99,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
           simoleans(7),
         ),
       );
-      assert(optionValue[0].expirationDate === 1, X`wrong expirationDate`);
+      assert(optionValue[0].expirationDate === 1n, X`wrong expirationDate`);
       assert(optionValue[0].timeAuthority === timer, 'wrong timer');
       const { UnderlyingAsset, StrikePrice } = issuerKeywordRecord;
 
@@ -167,7 +167,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         ),
         X`wrong strike price`,
       );
-      assert(optionValue[0].expirationDate === 100, X`wrong expiration date`);
+      assert(optionValue[0].expirationDate === 100n, X`wrong expiration date`);
       assert(optionValue[0].timeAuthority === timer, X`wrong timer`);
       assert(
         UnderlyingAsset === moolaIssuer,
@@ -457,7 +457,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       // Bob looks up how much moola he can get for 3 simoleans. It's 5
       const moolaProceeds = await E(publicFacet).getInputPrice(
         simoleans(3),
-        moola(0).brand,
+        moola(0n).brand,
       );
       log(`moola proceeds `, moolaProceeds);
 

--- a/packages/swingset-runner/demo/zoeTests/vat-dave.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-dave.js
@@ -126,7 +126,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         ),
         X`wrong strike price`,
       );
-      assert(optionValue[0].expirationDate === 100, X`wrong expiration date`);
+      assert(optionValue[0].expirationDate === 100n, X`wrong expiration date`);
       assert(optionValue[0].timeAuthority === timer, X`wrong timer`);
 
       // Dave escrows his 1 buck with Zoe and forms his proposal

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -26,6 +26,7 @@
     "@agoric/eventual-send": "^0.13.14",
     "@agoric/install-ses": "^0.5.13",
     "@agoric/marshal": "^0.4.11",
+    "@agoric/nat": "^4.0.0",
     "@agoric/same-structure": "^0.1.13",
     "@agoric/stat-logger": "^0.4.9",
     "@agoric/swing-store-lmdb": "^0.4.12",

--- a/packages/swingset-runner/src/kerneldump.js
+++ b/packages/swingset-runner/src/kerneldump.js
@@ -118,27 +118,27 @@ export function main() {
   if (!kernelStateDBDir) {
     fail(`can't find a database at ${target}`, false);
   }
-  let store;
+  let swingStore;
   switch (dbMode) {
     case '--filedb':
-      store = openSimpleSwingStore(kernelStateDBDir);
+      swingStore = openSimpleSwingStore(kernelStateDBDir);
       break;
     case '--lmdb':
-      store = openLMDBSwingStore(kernelStateDBDir);
+      swingStore = openLMDBSwingStore(kernelStateDBDir);
       break;
     default:
       fail(`invalid database mode ${dbMode}`, true);
   }
   if (justStats) {
-    const rawStats = JSON.parse(store.storage.get('kernelStats'));
-    const cranks = Number(store.storage.get('crankNumber'));
+    const rawStats = JSON.parse(swingStore.kvStore.get('kernelStats'));
+    const cranks = Number(swingStore.kvStore.get('crankNumber'));
     printMainStats(organizeMainStats(rawStats, cranks));
   } else {
     if (doDump) {
-      dumpStore(store.storage, outfile, rawMode);
+      dumpStore(swingStore.kvStore, outfile, rawMode);
     }
     if (refCounts) {
-      auditRefCounts(store.storage);
+      auditRefCounts(swingStore.kvStore);
     }
   }
 }

--- a/packages/swingset-runner/test/test-demo.js
+++ b/packages/swingset-runner/test/test-demo.js
@@ -40,10 +40,6 @@ test('run encouragmentBot demo with memdb', async t => {
   await innerTest(t, '--memdb');
 });
 
-test('run encouragmentBot demo with filedb', async t => {
-  await innerTest(t, '--filedb', 'filetest');
-});
-
 test('run encouragmentBot demo with lmdb', async t => {
   await innerTest(t, '--lmdb', 'lmdbtest');
 });

--- a/packages/swingset-runner/trun
+++ b/packages/swingset-runner/trun
@@ -5,6 +5,9 @@
 # If a demo has a swingset config file, use that, else use the default config
 # loader.  If it has more than one config file, run each one in turn.
 #
+# If a demo directory contains a file `runnerArgs`, insert the contents of the file
+# into the command line prior 'run' command.
+#
 # If a demo directory contains a file `sampleArgs`, do a run for each line of
 # the file, applying the contents of each line in turn as the buildRootObject
 # vatParameters.argv value, else just run the demo once.
@@ -71,13 +74,17 @@ function rundemo {
 
 for demo in demo/*; do
   hadconf=0
+  runnerArgs=""
+  if [ -f ${demo}/runnerArgs ]; then
+    runnerArgs=`cat ${demo}/runnerArgs`
+  fi
   for conf in ${demo}/*.json; do
     if [ "$conf" != "${demo}/annot.json" ]; then
-      rundemo $demo "--config $conf run"
+      rundemo $demo "--config $conf $runnerArgs run"
       hadconf=1
     fi
   done
   if [ "$hadconf" == "0" ]; then
-    rundemo $demo "run $demo"
+    rundemo $demo "$runnerArgs run $demo"
   fi
 done


### PR DESCRIPTION
In preparation for moving the transcripts out of the kernel database, this set of changes breaks the host store into a key-value store and a store for streams.  The stream store will be used for transcripts, though in this set of changes it is unused (i.e., transcripts are for now still kept in the key-value store).  Since it is unused, the stream store stuff itself is only minimally tested; this will come in the next phase, where we actually use the stream store for transcripts, since part of that will necessarily include updating the tests which validate or fiddle with transcripts (e.g., replay tests).

Although the stream store is not yet used, the API changes slightly alter how the principal host application calls (`initializeSwingset` and `makeSwingsetController`) are used to set up swingsets for execution.  Although the associated changes to the host applications were minor, these API alterations ended up touching a *lot* of test code.

Along with this, I did a lot of tidying up the organization of the swingset storage code, especially rationalizing a lot of the naming of things which was particularly awkward and confusing.  These changes also drew several more swingset files under the TypeScript type checking umbrella.

@michaelfig I've added you to the reviewer list because I fiddled with stuff in cosmic-swingset and ag-solo and you'll want to make sure I didn't mess those up in some subtle way.

@dckc I've added you to the reviewer list since you are going to be dealing storage for snapshots and this may be helpful as a heads-up as to where the swing-store is going and also a chance to head off possible impedance mismatches at the pass.

