### PR TITLE
refactor(zoe): add instantiation step to issuerStorage and instanceRecordStorage

### DIFF
--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -44,7 +44,9 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
       getAssetKindByBrand,
       getBrandForIssuer,
       getIssuerForBrand,
-    } = makeIssuerStorage(issuerStorageFromZoe);
+      instantiate: instantiateIssuerStorage,
+    } = makeIssuerStorage();
+    instantiateIssuerStorage(issuerStorageFromZoe);
 
     const {
       makeZCFSeat,
@@ -61,7 +63,9 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
       addIssuerToInstanceRecord,
       getTerms,
       assertUniqueKeyword,
-    } = makeInstanceRecordStorage(instanceRecordFromZoe);
+      instantiate: instantiateInstanceRecordStorage,
+    } = makeInstanceRecordStorage();
+    instantiateInstanceRecordStorage(instanceRecordFromZoe);
 
     const recordIssuer = (keyword, issuerRecord) => {
       addIssuerToInstanceRecord(keyword, issuerRecord);

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -269,3 +269,40 @@
     reallocateInternal: ReallocateInternal,
     dropAllReferences: DropAllReferences }}
  */
+
+/**
+ * @callback InstanceRecordManagerGetTerms
+ * @returns {Terms}
+ */
+
+/**
+ * @callback InstanceRecordGetIssuers
+ * @returns {IssuerKeywordRecord}
+ */
+
+/**
+ * @callback InstanceRecordGetBrands
+ * @returns {BrandKeywordRecord}
+ */
+
+/**
+ * @typedef {Object} InstanceRecordManager
+ * @property {AddIssuerToInstanceRecord} addIssuerToInstanceRecord
+ * @property {ExportInstanceRecord} exportInstanceRecord
+ * @property {InstanceRecordManagerGetTerms} getTerms
+ * @property {InstanceRecordGetIssuers} getIssuers
+ * @property {InstanceRecordGetBrands} getBrands
+ * @property {(keyword: Keyword) => void} assertUniqueKeyword
+ * @property {(startingInstanceRecord: InstanceRecord) => void} instantiate
+ */
+
+/**
+ * @callback ExportInstanceRecord
+ * @returns {InstanceRecord}
+ */
+
+/**
+ * @callback ExportIssuerStorage
+ * @param {Issuer[]} issuers
+ * @returns {ExportedIssuerStorage}
+ */

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -13,6 +13,7 @@ import { makeEscrowStorage } from './escrowStorage';
 
 export const makeZoeStorageManager = () => {
   const issuerStorage = makeIssuerStorage();
+  issuerStorage.instantiate();
   const escrowStorage = makeEscrowStorage();
 
   const makeZoeInstanceStorageManager = async (
@@ -86,7 +87,9 @@ export const makeZoeStorageManager = () => {
     /** @returns {ExportedIssuerStorage} */
     const exportIssuerStorage = () =>
       issuerStorage.exportIssuerStorage(
-        Object.values(instanceRecordManager.getInstanceRecord().terms.issuers),
+        Object.values(
+          instanceRecordManager.exportInstanceRecord().terms.issuers,
+        ),
       );
 
     return harden({
@@ -95,7 +98,7 @@ export const makeZoeStorageManager = () => {
       getBrands: instanceRecordManager.getBrands,
       saveIssuer,
       makeZoeMint,
-      exportInstanceRecord: instanceRecordManager.getInstanceRecord,
+      exportInstanceRecord: instanceRecordManager.exportInstanceRecord,
       exportIssuerStorage,
       withdrawPayments: escrowStorage.withdrawPayments,
     });

--- a/packages/zoe/test/unitTests/test-instanceStorage.js
+++ b/packages/zoe/test/unitTests/test-instanceStorage.js
@@ -41,7 +41,7 @@ test('makeAndStoreInstanceRecord', async t => {
   });
   const {
     addIssuerToInstanceRecord,
-    getInstanceRecord,
+    exportInstanceRecord,
     getTerms,
     getIssuers,
     getBrands,
@@ -53,7 +53,7 @@ test('makeAndStoreInstanceRecord', async t => {
     brands,
   );
 
-  t.deepEqual(getInstanceRecord(), {
+  t.deepEqual(exportInstanceRecord(), {
     installation: fakeInstallation,
     terms: { time: 2n, issuers, brands },
   });
@@ -92,17 +92,19 @@ test('makeInstanceRecordStorage', async t => {
   });
   const {
     addIssuerToInstanceRecord,
-    getInstanceRecord,
+    exportInstanceRecord,
     getTerms,
     getIssuers,
     getBrands,
     assertUniqueKeyword,
-  } = makeInstanceRecordStorage({
+    instantiate,
+  } = makeInstanceRecordStorage();
+  instantiate({
     installation: fakeInstallation,
     terms: { time: 2n, issuers, brands },
   });
 
-  t.deepEqual(getInstanceRecord(), {
+  t.deepEqual(exportInstanceRecord(), {
     installation: fakeInstallation,
     terms: { time: 2n, issuers, brands },
   });

--- a/packages/zoe/test/unitTests/test-issuerStorage.js
+++ b/packages/zoe/test/unitTests/test-issuerStorage.js
@@ -20,7 +20,8 @@ const setupIssuersForTest = () => {
 };
 
 test('storeIssuer, getAssetKindByBrand', async t => {
-  const { storeIssuer, getAssetKindByBrand } = makeIssuerStorage();
+  const { storeIssuer, getAssetKindByBrand, instantiate } = makeIssuerStorage();
+  instantiate();
   const { currencyKit, ticketKit } = setupIssuersForTest();
 
   const currencyIssuerRecord = await storeIssuer(currencyKit.issuer);
@@ -45,7 +46,8 @@ test('storeIssuer, getAssetKindByBrand', async t => {
 });
 
 test('storeIssuer, same issuer twice', async t => {
-  const { storeIssuer } = makeIssuerStorage();
+  const { storeIssuer, instantiate } = makeIssuerStorage();
+  instantiate();
   const { currencyKit } = setupIssuersForTest();
 
   const currencyIssuerRecord = await storeIssuer(currencyKit.issuer);
@@ -55,7 +57,8 @@ test('storeIssuer, same issuer twice', async t => {
 });
 
 test('storeIssuer, promise for issuer', async t => {
-  const { storeIssuer } = makeIssuerStorage();
+  const { storeIssuer, instantiate } = makeIssuerStorage();
+  instantiate();
   const { currencyKit } = setupIssuersForTest();
 
   const currencyIssuerRecord = await storeIssuer(
@@ -72,7 +75,8 @@ test('storeIssuer, promise for issuer', async t => {
 });
 
 test(`getAssetKindByBrand - brand isn't stored`, t => {
-  const { getAssetKindByBrand } = makeIssuerStorage();
+  const { getAssetKindByBrand, instantiate } = makeIssuerStorage();
+  instantiate();
   const { currencyKit } = setupIssuersForTest();
   t.throws(() => getAssetKindByBrand(currencyKit.brand), {
     message: '"brand" not found: "[Alleged: currency brand]"',
@@ -80,7 +84,8 @@ test(`getAssetKindByBrand - brand isn't stored`, t => {
 });
 
 test(`storeIssuerKeywordRecord, twice`, async t => {
-  const { storeIssuerKeywordRecord } = makeIssuerStorage();
+  const { storeIssuerKeywordRecord, instantiate } = makeIssuerStorage();
+  instantiate();
   const { currencyKit, ticketKit } = setupIssuersForTest();
 
   const issuerKeywordRecord = harden({
@@ -107,7 +112,12 @@ test(`storeIssuerKeywordRecord, twice`, async t => {
 });
 
 test(`storeIssuerRecord`, async t => {
-  const { storeIssuerRecord, getAssetKindByBrand } = makeIssuerStorage();
+  const {
+    storeIssuerRecord,
+    getAssetKindByBrand,
+    instantiate,
+  } = makeIssuerStorage();
+  instantiate();
   const { currencyKit } = setupIssuersForTest();
 
   const issuerRecord = makeIssuerRecord(currencyKit.brand, currencyKit.issuer, {
@@ -122,8 +132,34 @@ test(`storeIssuerRecord`, async t => {
   t.is(getAssetKindByBrand(currencyKit.brand), AssetKind.NAT);
 });
 
+test(`storeIssuerRecord twice`, async t => {
+  const {
+    storeIssuerRecord,
+    getAssetKindByBrand,
+    instantiate,
+  } = makeIssuerStorage();
+  instantiate();
+  const { currencyKit } = setupIssuersForTest();
+
+  const issuerRecord = makeIssuerRecord(currencyKit.brand, currencyKit.issuer, {
+    decimalPlaces: 18,
+    assetKind: AssetKind.NAT,
+  });
+
+  const returnedIssuerRecord = await storeIssuerRecord(issuerRecord);
+
+  t.deepEqual(returnedIssuerRecord, issuerRecord);
+
+  t.is(getAssetKindByBrand(currencyKit.brand), AssetKind.NAT);
+
+  const returnedIssuerRecord2 = await storeIssuerRecord(issuerRecord);
+
+  t.deepEqual(returnedIssuerRecord2, issuerRecord);
+});
+
 test('getBrandForIssuer', async t => {
-  const { storeIssuer, getBrandForIssuer } = makeIssuerStorage();
+  const { storeIssuer, getBrandForIssuer, instantiate } = makeIssuerStorage();
+  instantiate();
   const { currencyKit } = setupIssuersForTest();
 
   await storeIssuer(currencyKit.issuer);
@@ -132,7 +168,8 @@ test('getBrandForIssuer', async t => {
 });
 
 test('getIssuerForBrand', async t => {
-  const { storeIssuer, getIssuerForBrand } = makeIssuerStorage();
+  const { storeIssuer, getIssuerForBrand, instantiate } = makeIssuerStorage();
+  instantiate();
   const { currencyKit } = setupIssuersForTest();
 
   await storeIssuer(currencyKit.issuer);
@@ -141,7 +178,8 @@ test('getIssuerForBrand', async t => {
 });
 
 test('exportIssuerStorage', async t => {
-  const { storeIssuer, exportIssuerStorage } = makeIssuerStorage();
+  const { storeIssuer, exportIssuerStorage, instantiate } = makeIssuerStorage();
+  instantiate();
   const { currencyKit, ticketKit } = setupIssuersForTest();
 
   const currencyIssuerRecord = await storeIssuer(currencyKit.issuer);
@@ -154,7 +192,8 @@ test('exportIssuerStorage', async t => {
 });
 
 test('use exportedIssuerStorage', async t => {
-  const { storeIssuer, exportIssuerStorage } = makeIssuerStorage();
+  const { storeIssuer, exportIssuerStorage, instantiate } = makeIssuerStorage();
+  instantiate();
   const { currencyKit, ticketKit } = setupIssuersForTest();
 
   const currencyIssuerRecord = await storeIssuer(currencyKit.issuer);
@@ -166,9 +205,11 @@ test('use exportedIssuerStorage', async t => {
   t.deepEqual(exportedIssuerStorage, [currencyIssuerRecord]);
 
   // SecondIssuerStorage
-  const { exportIssuerStorage: exportIssuerStorage2 } = makeIssuerStorage(
-    exportedIssuerStorage,
-  );
+  const {
+    exportIssuerStorage: exportIssuerStorage2,
+    instantiate: instantiate2,
+  } = makeIssuerStorage();
+  instantiate2(exportedIssuerStorage);
 
   const exportedIssuerStorage2 = exportIssuerStorage2([currencyKit.issuer]);
   t.deepEqual(exportedIssuerStorage2, [currencyIssuerRecord]);


### PR DESCRIPTION
This PR is a very small PR that affects Zoe's `issuerStorage` and `instanceRecordStorage`. 

The [one big Zoe refactoring split ZCF into three parts](https://github.com/Agoric/agoric-sdk/blob/b001894a1767f59db324c4deb845d7328c21f457/packages/zoe/src/contractFacet/vatRoot.js) - creating a blank ZCF, evaluating contract code, and then providing the specific terms for that particular instance. 

In order for the terms to be provided *after* ZCF is created, we have to change how the initial data is provided to `issuerStorage` and `instanceRecordStorage`. In particular, there needs to a separate step to add data, after they have been created. Both now have `instantiate` methods that perform this function.

The instantiate step will seem unnecessary until a separate PR actually makes the three-part ZCF.