### PR TITLE
refactor(zoe): create helper for preventing the UnhandledPromiseRejectionWarning

### DIFF
--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -24,6 +24,7 @@ import { makeIssuerStorage } from '../issuerStorage';
 import { makeIssuerRecord } from '../issuerRecord';
 import { createSeatManager } from './zcfSeat';
 import { makeInstanceRecordStorage } from '../instanceRecordStorage';
+import { handlePWarning, handlePKitWarning } from '../handleWarning';
 
 import '../../exported';
 import '../internal-types';
@@ -73,13 +74,9 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
       const { notifier, updater } = makeNotifierKit();
       /** @type {PromiseRecord<ZoeSeatAdmin>} */
       const zoeSeatAdminPromiseKit = makePromiseKit();
-      // Don't trigger Node.js's UnhandledPromiseRejectionWarning.
-      // This does not suppress any error messages.
-      zoeSeatAdminPromiseKit.promise.catch(_ => {});
+      handlePKitWarning(zoeSeatAdminPromiseKit);
       const userSeatPromiseKit = makePromiseKit();
-      // Don't trigger Node.js's UnhandledPromiseRejectionWarning.
-      // This does not suppress any error messages.
-      userSeatPromiseKit.promise.catch(_ => {});
+      handlePKitWarning(userSeatPromiseKit);
       const seatHandle = makeHandle('SeatHandle');
 
       const seatData = harden({
@@ -323,9 +320,7 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
 
     // First, evaluate the contract code bundle.
     const contractCode = evalContractBundle(bundle);
-    // Don't trigger Node.js's UnhandledPromiseRejectionWarning.
-    // This does not suppress any error messages.
-    contractCode.catch(() => {});
+    handlePWarning(contractCode);
 
     // Next, execute the contract code, passing in zcf
     /** @type {Promise<ExecuteContractResult>} */
@@ -345,9 +340,7 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
           });
         },
       );
-    // Don't trigger Node.js's UnhandledPromiseRejectionWarning.
-    // This does not suppress any error messages.
-    result.catch(() => {});
+    handlePWarning(result);
     return result;
   };
 

--- a/packages/zoe/src/contractFacet/evalContractCode.js
+++ b/packages/zoe/src/contractFacet/evalContractCode.js
@@ -4,6 +4,7 @@
 
 import { importBundle } from '@agoric/import-bundle';
 import { assert } from '@agoric/assert';
+import { handlePWarning } from '../handleWarning';
 
 const evalContractBundle = (bundle, additionalEndowments = {}) => {
   // Make the console more verbose.
@@ -30,9 +31,7 @@ const evalContractBundle = (bundle, additionalEndowments = {}) => {
   const installation = importBundle(bundle, {
     endowments: fullEndowments,
   });
-  // Don't trigger Node.js's UnhandledPromiseRejectionWarning.
-  // This does not suppress any error messages.
-  installation.catch(() => {});
+  handlePWarning(installation);
   return installation;
 };
 

--- a/packages/zoe/src/handleWarning.js
+++ b/packages/zoe/src/handleWarning.js
@@ -1,0 +1,23 @@
+// @ts-check
+
+/**
+ * Don't trigger Node.js's UnhandledPromiseRejectionWarning.
+ * This does not suppress any error messages.
+ *
+ * @param {Promise<any>} promise
+ * @returns {void}
+ */
+export const handlePWarning = promise => {
+  promise.catch(() => {});
+};
+
+/**
+ * Don't trigger Node.js's UnhandledPromiseRejectionWarning.
+ * This does not suppress any error messages.
+ *
+ * @param {PromiseRecord<any>} promiseKit
+ * @returns {void}
+ */
+export const handlePKitWarning = promiseKit => {
+  handlePWarning(promiseKit.promise);
+};

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -27,6 +27,7 @@ import { makeInstallationStorage } from './installationStorage';
 import { makeZoeStorageManager } from './zoeStorageManager';
 import { makeOffer } from './offer/offer';
 import { makeInvitationQueryFns } from './invitationQueries';
+import { handlePKitWarning } from '../handleWarning';
 
 /**
  * Create an instance of Zoe.
@@ -113,13 +114,9 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
 
       /** @type {PromiseRecord<HandleOfferObj>} */
       const handleOfferObjPromiseKit = makePromiseKit();
-      // Don't trigger Node.js's UnhandledPromiseRejectionWarning.
-      // This does not suppress any error messages.
-      handleOfferObjPromiseKit.promise.catch(_ => {});
+      handlePKitWarning(handleOfferObjPromiseKit);
       const publicFacetPromiseKit = makePromiseKit();
-      // Don't trigger Node.js's UnhandledPromiseRejectionWarning.
-      // This does not suppress any error messages.
-      publicFacetPromiseKit.promise.catch(_ => {});
+      handlePKitWarning(publicFacetPromiseKit);
 
       const makeInstanceAdmin = () => {
         /** @type {Set<ZoeSeatAdmin>} */
@@ -153,13 +150,9 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
           stopAcceptingOffers: () => (acceptingOffers = false),
           makeUserSeat: (invitationHandle, initialAllocation, proposal) => {
             const offerResultPromiseKit = makePromiseKit();
-            // Don't trigger Node.js's UnhandledPromiseRejectionWarning.
-            // This does not suppress any error messages.
-            offerResultPromiseKit.promise.catch(_ => {});
+            handlePKitWarning(offerResultPromiseKit);
             const exitObjPromiseKit = makePromiseKit();
-            // Don't trigger Node.js's UnhandledPromiseRejectionWarning.
-            // This does not suppress any error messages.
-            exitObjPromiseKit.promise.catch(_ => {});
+            handlePKitWarning(exitObjPromiseKit);
             const seatHandle = makeHandle('SeatHandle');
 
             const { userSeat, notifier, zoeSeatAdmin } = makeZoeSeatAdminKit(

--- a/packages/zoe/src/zoeService/zoeSeat.js
+++ b/packages/zoe/src/zoeService/zoeSeat.js
@@ -6,6 +6,8 @@ import { assert } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 
+import { handlePKitWarning } from '../handleWarning';
+
 import '../types';
 import '../internal-types';
 
@@ -32,9 +34,7 @@ export const makeZoeSeatAdminKit = (
   offerResult,
 ) => {
   const payoutPromiseKit = makePromiseKit();
-  // Don't trigger Node.js's UnhandledPromiseRejectionWarning.
-  // This does not suppress any error messages.
-  payoutPromiseKit.promise.catch(_ => {});
+  handlePKitWarning(payoutPromiseKit);
   const { notifier, updater } = makeNotifierKit();
 
   let currentAllocation = initialAllocation;

--- a/packages/zoe/tools/fakeVatAdmin.js
+++ b/packages/zoe/tools/fakeVatAdmin.js
@@ -6,6 +6,7 @@ import { Far } from '@agoric/marshal';
 
 import { assert, details as X } from '@agoric/assert';
 import { evalContractBundle } from '../src/contractFacet/evalContractCode';
+import { handlePKitWarning } from '../src/handleWarning';
 
 function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
   // FakeVatPowers isn't intended to support testing of vat termination, it is
@@ -42,9 +43,7 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
         adminNode: Far('adminNode', {
           done: () => {
             const kit = makePromiseKit();
-            // Don't trigger Node.js's UnhandledPromiseRejectionWarning.
-            // This does not suppress any error messages.
-            kit.promise.catch(_ => {});
+            handlePKitWarning(kit);
             return kit.promise;
           },
           terminateWithFailure: () => {},


### PR DESCRIPTION
This PR is very small. It creates a helper for preventing the UnhandledPromiseRejectionWarning that AVA can't tolerate. This helper is used throughout the Zoe code.