### PR TITLE
refactor(zoe): separate offerHandlerStorage and delete entry after use

### DIFF
--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -55,7 +55,7 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
       dropAllReferences,
     } = createSeatManager(zoeInstanceAdmin, getAssetKindByBrand);
 
-    const { storeOfferHandler, getOfferHandler } = makeOfferHandlerStorage();
+    const { storeOfferHandler, takeOfferHandler } = makeOfferHandlerStorage();
 
     // Make the instanceRecord
     const {
@@ -304,7 +304,7 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
     const handleOfferObj = Far('handleOfferObj', {
       handleOffer: (invitationHandle, zoeSeatAdmin, seatData) => {
         const zcfSeat = makeZCFSeat(zoeSeatAdmin, seatData);
-        const offerHandler = getOfferHandler(invitationHandle);
+        const offerHandler = takeOfferHandler(invitationHandle);
         const offerResultP = E(offerHandler)(zcfSeat).catch(reason => {
           if (reason === undefined) {
             const newErr = new Error(

--- a/packages/zoe/src/contractFacet/offerHandlerStorage.js
+++ b/packages/zoe/src/contractFacet/offerHandlerStorage.js
@@ -1,9 +1,11 @@
+// @ts-check
+
 import { makeWeakStore as makeNonVOWeakStore } from '@agoric/store';
 
 import { makeHandle } from '../makeHandle';
 
 export const makeOfferHandlerStorage = () => {
-  /** @type {WeakStore<InvitationHandle, (seat: ZCFSeat) => unknown>} */
+  /** @type {WeakStore<InvitationHandle, OfferHandler>} */
   const invitationHandleToHandler = makeNonVOWeakStore('invitationHandle');
 
   /** @type {(offerHandler: OfferHandler) => InvitationHandle} */

--- a/packages/zoe/src/contractFacet/offerHandlerStorage.js
+++ b/packages/zoe/src/contractFacet/offerHandlerStorage.js
@@ -16,7 +16,7 @@ export const makeOfferHandlerStorage = () => {
   };
 
   /** @type {(invitationHandle: InvitationHandle) => OfferHandler} */
-  const getOfferHandler = invitationHandle => {
+  const takeOfferHandler = invitationHandle => {
     const offerHandler = invitationHandleToHandler.get(invitationHandle);
     invitationHandleToHandler.delete(invitationHandle);
     return offerHandler;
@@ -24,6 +24,6 @@ export const makeOfferHandlerStorage = () => {
 
   return harden({
     storeOfferHandler,
-    getOfferHandler,
+    takeOfferHandler,
   });
 };

--- a/packages/zoe/src/contractFacet/offerHandlerStorage.js
+++ b/packages/zoe/src/contractFacet/offerHandlerStorage.js
@@ -1,0 +1,27 @@
+import { makeWeakStore as makeNonVOWeakStore } from '@agoric/store';
+
+import { makeHandle } from '../makeHandle';
+
+export const makeOfferHandlerStorage = () => {
+  /** @type {WeakStore<InvitationHandle, (seat: ZCFSeat) => unknown>} */
+  const invitationHandleToHandler = makeNonVOWeakStore('invitationHandle');
+
+  /** @type {(offerHandler: OfferHandler) => InvitationHandle} */
+  const storeOfferHandler = offerHandler => {
+    const invitationHandle = makeHandle('Invitation');
+    invitationHandleToHandler.init(invitationHandle, offerHandler);
+    return invitationHandle;
+  };
+
+  /** @type {(invitationHandle: InvitationHandle) => OfferHandler} */
+  const getOfferHandler = invitationHandle => {
+    const offerHandler = invitationHandleToHandler.get(invitationHandle);
+    invitationHandleToHandler.delete(invitationHandle);
+    return offerHandler;
+  };
+
+  return harden({
+    storeOfferHandler,
+    getOfferHandler,
+  });
+};

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -191,7 +191,7 @@
 /**
  * @callback OfferHandler
  * @param {ZCFSeat} seat
- * @returns {unknown}
+ * @returns {any}
  */
 
 /**

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -191,7 +191,7 @@
 /**
  * @callback OfferHandler
  * @param {ZCFSeat} seat
- * @returns any
+ * @returns {unknown}
  */
 
 /**

--- a/packages/zoe/test/unitTests/zcf/test-offerHandlerStorage.js
+++ b/packages/zoe/test/unitTests/zcf/test-offerHandlerStorage.js
@@ -1,0 +1,20 @@
+// @ts-check
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+
+import { makeOfferHandlerStorage } from '../../../src/contractFacet/offerHandlerStorage';
+
+test('offerHandlerStorage', async t => {
+  const { storeOfferHandler, getOfferHandler } = makeOfferHandlerStorage();
+
+  const offerHandler = () => {};
+  const invitationHandle = storeOfferHandler(offerHandler);
+  t.is(getOfferHandler(invitationHandle), offerHandler);
+
+  // Getting the offerHandler also deletes it for explicit GC, so trying to get it
+  // twice errors.
+  t.throws(() => getOfferHandler(invitationHandle), {
+    message: '"invitationHandle" not found: "[Alleged: InvitationHandle]"',
+  });
+});

--- a/packages/zoe/test/unitTests/zcf/test-offerHandlerStorage.js
+++ b/packages/zoe/test/unitTests/zcf/test-offerHandlerStorage.js
@@ -6,15 +6,15 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 import { makeOfferHandlerStorage } from '../../../src/contractFacet/offerHandlerStorage';
 
 test('offerHandlerStorage', async t => {
-  const { storeOfferHandler, getOfferHandler } = makeOfferHandlerStorage();
+  const { storeOfferHandler, takeOfferHandler } = makeOfferHandlerStorage();
 
   const offerHandler = () => {};
   const invitationHandle = storeOfferHandler(offerHandler);
-  t.is(getOfferHandler(invitationHandle), offerHandler);
+  t.is(takeOfferHandler(invitationHandle), offerHandler);
 
   // Getting the offerHandler also deletes it for explicit GC, so trying to get it
   // twice errors.
-  t.throws(() => getOfferHandler(invitationHandle), {
+  t.throws(() => takeOfferHandler(invitationHandle), {
     message: '"invitationHandle" not found: "[Alleged: InvitationHandle]"',
   });
 });


### PR DESCRIPTION
This PR is very small. It moves the details of storing the offerHandler to a separate file. Importantly, now the offerHandler entry is dropped after use.