### PR TITLE
refactor(zoe): rename addSeat to handleOffer

### DIFF
--- a/packages/zoe/docs/zoe-zcf.puml
+++ b/packages/zoe/docs/zoe-zcf.puml
@@ -30,7 +30,7 @@ end note
 Zoe --\\ Zcf : <font color=gray><size:12> invitation
 Zcf --\\ contract : <font color=gray><size:12> invitation
 contract --\\ Zcf : <font color=gray><size:12> {creatorFacet, creatorInvitation, publicFacet }
-Zcf --\\ Zoe : <font color=gray><size:12> {creatorFacet, creatorInvitation, addSeatObj}
+Zcf --\\ Zoe : <font color=gray><size:12> {creatorFacet, creatorInvitation, handleOfferObj}
 Alice //-- Zoe : <font color=gray><size:12> {creatorFacet, creatorInvitation}
 
 ====
@@ -38,7 +38,7 @@ Alice //-- Zoe : <font color=gray><size:12> {creatorFacet, creatorInvitation}
 Alice -> Zoe : offer(invitation...)
 Zoe -> Zoe : makeUserSeat
 Zoe -> Alice : <font color=gray><size:12> userSeat
-Zoe -> Zcf : addSeat
+Zoe -> Zcf : handleOffer
 note left
 deposit payments
 end note

--- a/packages/zoe/src/contractFacet/contractFacet.js
+++ b/packages/zoe/src/contractFacet/contractFacet.js
@@ -299,11 +299,11 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
       },
     });
 
-    // addSeatObject gives Zoe the ability to notify ZCF when a new seat is
+    // handleOfferObject gives Zoe the ability to notify ZCF when a new seat is
     // added in offer(). ZCF responds with the exitObj and offerResult.
-    /** @type {AddSeatObj} */
-    const addSeatObj = Far('addSeatObj', {
-      addSeat: (invitationHandle, zoeSeatAdmin, seatData) => {
+    /** @type {HandleOfferObj} */
+    const handleOfferObj = Far('handleOfferObj', {
+      handleOffer: (invitationHandle, zoeSeatAdmin, seatData) => {
         const zcfSeat = makeZCFSeat(zoeSeatAdmin, seatData);
         const offerHandler = invitationHandleToHandler.get(invitationHandle);
         const offerResultP = E(offerHandler)(zcfSeat).catch(reason => {
@@ -316,7 +316,7 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
           throw zcfSeat.fail(reason);
         });
         const exitObj = makeExitObj(seatData.proposal, zcfSeat);
-        /** @type {AddSeatResult} */
+        /** @type {HandleOfferResult} */
         return harden({ offerResultP, exitObj });
       },
     });
@@ -341,7 +341,7 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
             creatorFacet,
             publicFacet,
             creatorInvitation,
-            addSeatObj,
+            handleOfferObj,
           });
         },
       );

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -62,7 +62,7 @@
  */
 
 /**
- * @typedef {Object} AddSeatResult
+ * @typedef {Object} HandleOfferResult
  * @property {Promise<any>} offerResultP
  * @property {Object} exitObj
  */
@@ -93,11 +93,11 @@
  * depending on whether the seat comes from a normal offer or a
  * request by the contract for an "empty" seat.
  *
- * @typedef {Object} AddSeatObj
+ * @typedef {Object} HandleOfferObj
  * @property {(invitationHandle: InvitationHandle,
  *             zoeSeatAdmin: ZoeSeatAdmin,
  *             seatData: SeatData,
- *            ) => AddSeatResult} addSeat
+ *            ) => HandleOfferResult} handleOffer
  */
 
 /**
@@ -169,7 +169,7 @@
  * @property {Object} creatorFacet
  * @property {Promise<Invitation>} creatorInvitation
  * @property {Object} publicFacet
- * @property {AddSeatObj} addSeatObj
+ * @property {HandleOfferObj} handleOfferObj
  *
  *
  * @callback ExecuteContract

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -111,11 +111,11 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
       /** @type {ZCFRoot} */
       const zcfRoot = root;
 
-      /** @type {PromiseRecord<AddSeatObj>} */
-      const addSeatObjPromiseKit = makePromiseKit();
+      /** @type {PromiseRecord<HandleOfferObj>} */
+      const handleOfferObjPromiseKit = makePromiseKit();
       // Don't trigger Node.js's UnhandledPromiseRejectionWarning.
       // This does not suppress any error messages.
-      addSeatObjPromiseKit.promise.catch(_ => {});
+      handleOfferObjPromiseKit.promise.catch(_ => {});
       const publicFacetPromiseKit = makePromiseKit();
       // Don't trigger Node.js's UnhandledPromiseRejectionWarning.
       // This does not suppress any error messages.
@@ -183,8 +183,8 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
 
             zoeSeatAdmins.add(zoeSeatAdmin);
 
-            E(addSeatObjPromiseKit.promise)
-              .addSeat(invitationHandle, zoeSeatAdmin, seatData)
+            E(handleOfferObjPromiseKit.promise)
+              .handleOffer(invitationHandle, zoeSeatAdmin, seatData)
               .then(({ offerResultP, exitObj }) => {
                 offerResultPromiseKit.resolve(offerResultP);
                 exitObjPromiseKit.resolve(exitObj);
@@ -272,7 +272,7 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
         creatorFacet = Far('emptyCreatorFacet', {}),
         publicFacet = Far('emptyPublicFacet', {}),
         creatorInvitation: creatorInvitationP,
-        addSeatObj,
+        handleOfferObj,
       } = await E(zcfRoot).executeContract(
         bundle,
         zoeService,
@@ -282,7 +282,7 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
         exportIssuerStorage(),
       );
 
-      addSeatObjPromiseKit.resolve(addSeatObj);
+      handleOfferObjPromiseKit.resolve(handleOfferObj);
       publicFacetPromiseKit.resolve(publicFacet);
 
       // creatorInvitation can be undefined, but if it is defined,


### PR DESCRIPTION
This PR renames `AddSeatObj` and the `addSeat` method to `HandleOfferObj` and `handleOffer` respectively.