### PR TITLE
Suggestion for the #3117 review

### DIFF
--- a/packages/ERTP/src/brand.js
+++ b/packages/ERTP/src/brand.js
@@ -5,21 +5,15 @@ import { markBrand } from './markObjects.js';
 
 /**
  * @param {string} allegedName
- * @param {Promise<Issuer>} issuerP
+ * @param {(allegedIssuer: Issuer) => boolean} isMyIssuerNow
  * @param {DisplayInfo} displayInfo
  * @returns {Brand}
  */
-export const makeBrand = (allegedName, issuerP, displayInfo) => {
+export const makeBrand = (allegedName, isMyIssuerNow, displayInfo) => {
   /** @type {Brand} */
   const brand = markBrand(allegedName, {
-    isMyIssuer: allegedIssuerP => {
-      return E.when(
-        Promise.all([allegedIssuerP, issuerP]),
-        ([allegedIssuer, issuer]) => {
-          return allegedIssuer === issuer;
-        },
-      );
-    },
+    isMyIssuer: allegedIssuerP => E.when(allegedIssuerP, isMyIssuerNow),
+
     getAllegedName: () => allegedName,
 
     // Give information to UI on how to display the amount.

--- a/packages/ERTP/src/issuerKit.js
+++ b/packages/ERTP/src/issuerKit.js
@@ -31,11 +31,10 @@ const makeIssuerKit = (
   /** @type {PromiseRecord<Issuer>} */
   const issuerPromiseKit = makePromiseKit();
 
-  const brand = makeBrand(
-    allegedName,
-    issuerPromiseKit.promise,
-    cleanDisplayInfo,
-  );
+  // eslint-disable-next-line no-use-before-define
+  const isMyIssuerNow = allegedIssuer => allegedIssuer === issuer;
+
+  const brand = makeBrand(allegedName, isMyIssuerNow, cleanDisplayInfo);
 
   // Attenuate the powerful authority to mint and change balances
   const { issuer, mint } = makePaymentLedger(

--- a/packages/ERTP/src/issuerKit.js
+++ b/packages/ERTP/src/issuerKit.js
@@ -31,6 +31,14 @@ const makeIssuerKit = (
   /** @type {PromiseRecord<Issuer>} */
   const issuerPromiseKit = makePromiseKit();
 
+  /**
+   * We can define this function to use the in-scope `issuer` variable
+   * before that variable is initialized, as long as the variable is
+   * initialized before the function is called.
+   *
+   * @param {Issuer} allegedIssuer
+   * @returns {boolean}
+   */
   // eslint-disable-next-line no-use-before-define
   const isMyIssuerNow = allegedIssuer => allegedIssuer === issuer;
 

--- a/packages/ERTP/src/issuerKit.js
+++ b/packages/ERTP/src/issuerKit.js
@@ -2,7 +2,6 @@
 // @jessie-check
 
 import { assert, details as X } from '@agoric/assert';
-import { makePromiseKit } from '@agoric/promise-kit';
 
 import { AssetKind } from './amountMath';
 import { coerceDisplayInfo } from './displayInfo';
@@ -28,9 +27,6 @@ const makeIssuerKit = (
   // Add assetKind to displayInfo, or override if present
   const cleanDisplayInfo = coerceDisplayInfo(displayInfo, assetKind);
 
-  /** @type {PromiseRecord<Issuer>} */
-  const issuerPromiseKit = makePromiseKit();
-
   /**
    * We can define this function to use the in-scope `issuer` variable
    * before that variable is initialized, as long as the variable is
@@ -51,8 +47,6 @@ const makeIssuerKit = (
     assetKind,
     cleanDisplayInfo,
   );
-
-  issuerPromiseKit.resolve(issuer);
 
   return harden({
     brand,


### PR DESCRIPTION
Suggestion for the #3117 review

This is arguably simpler. I found it awkward that the brand only had a promise for its issuer even though they were created together. When we call `makeBrand` we'd like to give it the issuer, but it hasn't been created yet. In E, the promise would have been exactly the right answer because once it is resolved it becomes a direct reference. However, here it led to the brand doing a `Promise.all`. Instead, we can define a function that uses the in scope `issuer` variable before that variable is initialized, as long as the variable is initialized before the function is called.

