### PR TITLE
feat(SwingSet): add "reachable" flag to clist entries

### DIFF
--- a/packages/SwingSet/src/blockBuffer.js
+++ b/packages/SwingSet/src/blockBuffer.js
@@ -43,7 +43,7 @@ export function buildBlockBuffer(hostDB) {
         keys.delete(k);
       }
       for (const k of Array.from(keys).sort()) {
-        if (start <= k && k < end) {
+        if ((start === '' || start <= k) && (end === '' || k < end)) {
           yield k;
         }
       }

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -42,7 +42,9 @@ const enableKernelPromiseGC = true;
 // v$NN.o.nextID = $NN
 // v$NN.p.nextID = $NN
 // v$NN.d.nextID = $NN
-// v$NN.c.$kernelSlot = $vatSlot = o+$NN/o-$NN/p+$NN/p-$NN/d+$NN/d-$NN
+// v$NN.c.$kernelSlot = '$R $vatSlot'
+//   $R is 'R' when reachable, '_' when merely recognizable
+//   $vatSlot is one of: o+$NN/o-$NN/p+$NN/p-$NN/d+$NN/d-$NN
 // v$NN.c.$vatSlot = $kernelSlot = ko$NN/kp$NN/kd$NN
 // v$NN.t.$NN = JSON(transcript entry)
 // v$NN.t.nextID = $NN

--- a/packages/SwingSet/src/kernel/state/storageWrapper.js
+++ b/packages/SwingSet/src/kernel/state/storageWrapper.js
@@ -121,6 +121,8 @@ export function buildCrankBuffer(kvStore) {
     },
 
     *getKeys(start, end) {
+      assert.typeof(start, 'string');
+      assert.typeof(end, 'string');
       const keys = new Set(kvStore.getKeys(start, end));
       for (const k of additions.keys()) {
         keys.add(k);
@@ -129,13 +131,14 @@ export function buildCrankBuffer(kvStore) {
         keys.delete(k);
       }
       for (const k of Array.from(keys).sort()) {
-        if (start <= k && k < end) {
+        if ((start === '' || start <= k) && (end === '' || k < end)) {
           yield k;
         }
       }
     },
 
     get(key) {
+      assert.typeof(key, 'string');
       if (additions.has(key)) {
         return additions.get(key);
       }
@@ -146,11 +149,14 @@ export function buildCrankBuffer(kvStore) {
     },
 
     set(key, value) {
+      assert.typeof(key, 'string');
+      assert.typeof(value, 'string');
       additions.set(key, value);
       deletions.delete(key);
     },
 
     delete(key) {
+      assert.typeof(key, 'string');
       additions.delete(key);
       deletions.add(key);
     },

--- a/packages/SwingSet/test/test-clist.js
+++ b/packages/SwingSet/test/test-clist.js
@@ -1,0 +1,89 @@
+import { test } from '../tools/prepare-test-env-ava';
+
+// eslint-disable-next-line import/order
+import { initSwingStore } from '@agoric/swing-store-simple';
+import { makeDummySlogger } from '../src/kernel/slogger';
+import makeKernelKeeper from '../src/kernel/state/kernelKeeper';
+import { wrapStorage } from '../src/kernel/state/storageWrapper';
+
+test(`clist reachability`, async t => {
+  const slog = makeDummySlogger({});
+  const { enhancedCrankBuffer: s } = wrapStorage(initSwingStore().kvStore);
+
+  const kk = makeKernelKeeper(s, slog);
+  kk.createStartingKernelState('local');
+  const vatID = kk.allocateUnusedVatID();
+  const vk = kk.allocateVatKeeper(vatID);
+
+  t.is(vk.mapKernelSlotToVatSlot('ko1'), 'o-50');
+  t.is(vk.mapKernelSlotToVatSlot('ko2'), 'o-51');
+  t.is(vk.mapKernelSlotToVatSlot('ko1'), 'o-50');
+
+  t.is(vk.mapVatSlotToKernelSlot('o+1'), 'ko20');
+  t.is(vk.mapVatSlotToKernelSlot('o+2'), 'ko21');
+  t.is(vk.mapVatSlotToKernelSlot('o+1'), 'ko20');
+
+  t.is(s.get(`${vatID}.c.o+1`), `ko20`);
+  t.is(s.get(`${vatID}.c.ko20`), 'R o+1');
+
+  // newly allocated imports are marked as reachable
+  t.is(s.get(`${vatID}.c.ko1`), 'R o-50');
+  // now pretend that the vat drops its o-50 import: the syscall.dropImport
+  // will cause the kernel to clear the reachability flag
+  vk.clearReachableFlag('ko1');
+  t.is(s.get(`${vatID}.c.ko1`), '_ o-50');
+  // while dropped, the vat may not access the import
+  t.throws(() => vk.mapVatSlotToKernelSlot('o-50'), {
+    message: /vat tried to access unreachable import/,
+  });
+
+  // now the kernel sends a new message that references ko1, causing a
+  // re-import
+  vk.setReachableFlag('ko1');
+  t.is(s.get(`${vatID}.c.ko1`), 'R o-50');
+  // re-import without intervening dropImport is idempotent
+  vk.setReachableFlag('ko1');
+  t.is(s.get(`${vatID}.c.ko1`), 'R o-50');
+
+  // test the same thing for exports
+  t.is(s.get(`${vatID}.c.ko20`), 'R o+1');
+  // kernel tells vat that kernel is dropping the export, clearing the
+  // reachability flag
+  vk.clearReachableFlag('ko20');
+  t.is(s.get(`${vatID}.c.ko20`), '_ o+1');
+  // while dropped, access by the kernel indicates a bug
+  t.throws(() => vk.mapKernelSlotToVatSlot('ko20'), {
+    message: /kernel sent unreachable export/,
+  });
+
+  // vat re-exports o+1
+  vk.setReachableFlag('ko20');
+  t.is(s.get(`${vatID}.c.ko20`), 'R o+1');
+  // re-export without intervening dropExport is idempotent
+  vk.setReachableFlag('ko20');
+  t.is(s.get(`${vatID}.c.ko20`), 'R o+1');
+
+  // test setReachable=false, used by handlers for GC operations like
+  // syscall.dropImport to talk about an import without claiming it's
+  // reachable or causing it to become reachable
+
+  t.is(vk.mapKernelSlotToVatSlot('ko3'), 'o-52');
+  vk.clearReachableFlag('ko3');
+  t.is(s.get(`${vatID}.c.ko3`), '_ o-52');
+  t.throws(() => vk.mapVatSlotToKernelSlot('o-52'), {
+    message: /vat tried to access unreachable import/,
+  });
+  t.is(vk.mapVatSlotToKernelSlot('o-52', false), 'ko3');
+  t.is(vk.mapKernelSlotToVatSlot('ko3', false), 'o-52');
+  t.is(s.get(`${vatID}.c.ko3`), '_ o-52');
+
+  t.is(vk.mapVatSlotToKernelSlot('o+3'), 'ko22');
+  vk.clearReachableFlag('ko22');
+  t.is(s.get(`${vatID}.c.ko22`), '_ o+3');
+  t.throws(() => vk.mapKernelSlotToVatSlot('ko22'), {
+    message: /kernel sent unreachable export/,
+  });
+  t.is(vk.mapKernelSlotToVatSlot('ko22', false), 'o+3');
+  t.is(vk.mapVatSlotToKernelSlot('o+3', false), 'ko22');
+  t.is(s.get(`${vatID}.c.ko22`), '_ o+3');
+});

--- a/packages/SwingSet/test/test-state.js
+++ b/packages/SwingSet/test/test-state.js
@@ -47,6 +47,9 @@ function testStorage(t, s, getState, commit) {
   s.set('foo3', 'f3');
   t.deepEqual(Array.from(s.getKeys('foo1', 'foo3')), ['foo1', 'foo2']);
   t.deepEqual(Array.from(s.getKeys('foo1', 'foo4')), ['foo1', 'foo2', 'foo3']);
+  t.deepEqual(Array.from(s.getKeys('', '')), ['foo', 'foo1', 'foo2', 'foo3']);
+  t.deepEqual(Array.from(s.getKeys('foo1', '')), ['foo1', 'foo2', 'foo3']);
+  t.deepEqual(Array.from(s.getKeys('', 'foo2')), ['foo', 'foo1']);
 
   s.delete('foo2');
   t.falsy(s.has('foo2'));
@@ -250,21 +253,15 @@ function duplicateKeeper(getState) {
 }
 
 test('hostStorage param guards', async t => {
-  const { kstorage, commitCrank } = buildKeeperStorageInMemory();
-  kstorage.set('foo', true);
-  t.throws(commitCrank, { message: /must be a string/ });
-  kstorage.set(true, 'foo');
-  t.throws(commitCrank, { message: /must be a string/ });
-  kstorage.has(true);
-  t.throws(commitCrank, { message: /must be a string/ });
-  kstorage.getKeys('foo', true);
-  t.throws(commitCrank, { message: /must be a string/ });
-  kstorage.getKeys(true, 'foo');
-  t.throws(commitCrank, { message: /must be a string/ });
-  kstorage.get(true);
-  t.throws(commitCrank, { message: /must be a string/ });
-  kstorage.delete(true);
-  t.throws(commitCrank, { message: /must be a string/ });
+  const { kstorage } = buildKeeperStorageInMemory();
+  const exp = { message: /true must be a string/ };
+  t.throws(() => kstorage.set('foo', true), exp);
+  t.throws(() => kstorage.set(true, 'foo'), exp);
+  t.throws(() => kstorage.has(true), exp);
+  t.throws(() => Array.from(kstorage.getKeys('foo', true)), exp);
+  t.throws(() => Array.from(kstorage.getKeys(true, 'foo')), exp);
+  t.throws(() => kstorage.get(true), exp);
+  t.throws(() => kstorage.delete(true), exp);
 });
 
 test('kernel state', async t => {


### PR DESCRIPTION
The kernel-to-vat clist entry for `kref` is stored in the kernelDB under a
key of `${vatID}.c.${kref}` . This changes the value at that key from
`${vref}` to `${flag} ${vref}`, where `flag` is either `R` (for "reachable
and recognizable") or `_` (for "recognizable but not reachable). The "neither
reachable nor recognizable" state simply deletes the clist entry altogether.

This adds vatKeeper methods to set and clear the flag on a given kref. These
will be used by the GC syscall handlers for dropImport and friends.

It also cleans up some inconsistencies in the wrappers we put around the HostStorage API.

closes #3108
