### PR TITLE
Integrate JS RUN fees with the x/distribution module

### DIFF
--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -365,7 +365,7 @@ func NewAgoricApp(
 
 	app.VpurseKeeper = vpurse.NewKeeper(
 		appCodec, keys[vpurse.StoreKey],
-		app.BankKeeper,
+		app.BankKeeper, authtypes.FeeCollectorName,
 		callToController,
 	)
 	vpurseModule := vpurse.NewAppModule(app.VpurseKeeper)

--- a/packages/vats/src/distributeFees.js
+++ b/packages/vats/src/distributeFees.js
@@ -2,11 +2,7 @@
 
 import { observeNotifier } from '@agoric/notifier';
 import { E } from '@agoric/eventual-send';
-import { natSafeMath } from '@agoric/zoe/src/contractSupport';
-import { AmountMath } from '@agoric/ertp';
 import { Far } from '@agoric/marshal';
-
-const { add, subtract, multiply, floorDivide } = natSafeMath;
 
 // wrapper to take the treasury's creatorFacet, and make a function that will
 // request an invitation and return a promise for a payment.
@@ -21,65 +17,35 @@ export function makeTreasuryFeeCollector(zoe, treasuryCreatorFacet) {
   });
 }
 
-// A distributor of fees from treasury to the Bank module, which has a mapping
-// from accounts to purses. Each time the epochTimer signals the end of an
-// Epoch, it will ask the bank's notifier for a fresh list of accounts and ask
-// the treasury for the fees that have been collected to date. It will then
-// divide the funds evenly among the accounts, and send payments.
-// When the payment doesn't divide evenly among the accounts, it holds the
-// remainder till the next epoch.
-
-/** @type {BuildFeeDistributor} */
-export function buildDistributor(treasury, bank, epochTimer, params) {
+/**
+ * A distributor of fees from treasury to the Bank module. Each time the
+ * epochTimer signals the end of an Epoch, it will ask the treasury for the fees
+ * that have been collected to date and send that payment to the depositFacet.
+ *
+ * @type {BuildFeeDistributor}
+ */
+export async function buildDistributor(
+  treasury,
+  feeDepositFacet,
+  epochTimer,
+  params,
+) {
   const {
     // By default, we assume the epochTimer fires once per epoch.
     epochInterval = 1n,
-    runIssuer,
-    runBrand,
   } = params;
-  const accountsNotifier = E(bank).getAccountsNotifier();
-  let leftOverPayment;
-  let leftOverValue = 0n;
 
   async function schedulePayments() {
-    let payment = E(treasury).collectFees();
-    const [amount, { value: accounts }] = await Promise.all([
-      E(runIssuer).getAmountOf(payment),
-      E(accountsNotifier).getUpdateSince(),
-    ]);
-    const totalValue = add(leftOverValue, amount.value);
-    const valuePerAccount = floorDivide(totalValue, accounts.length);
-
-    const amounts = Array(accounts.length).fill(
-      AmountMath.make(runBrand, valuePerAccount),
-    );
-    if (leftOverValue) {
-      payment = E(runIssuer).combine([payment, leftOverPayment]);
-    }
-    leftOverValue = subtract(
-      totalValue,
-      multiply(accounts.length, valuePerAccount),
-    );
-    amounts.push(AmountMath.make(runBrand, leftOverValue));
-
-    const manyPayments = await E(runIssuer).splitMany(payment, amounts);
-    // manyPayments is hardened, so we can't use pop()
-    leftOverPayment = manyPayments[manyPayments.length - 1];
-    const actualPayments = manyPayments.slice(0, manyPayments.length - 1);
-
-    // eslint-disable-next-line no-unused-vars
-    const settledResultsP = Promise.allSettled(
-      // The scheduler will decide how fast to process the deposits.
-      accounts.map((acct, i) =>
-        E(bank).deposit(runBrand, acct, actualPayments[i]),
-      ),
-    );
-
-    // TODO: examine settledResultsP for failures, and reclaim those payments.
+    const payment = await E(treasury).collectFees();
+    return E(feeDepositFacet).receive(payment);
   }
 
   const timeObserver = {
-    updateState: _ => schedulePayments(),
+    updateState: _ =>
+      schedulePayments().catch(e => {
+        console.error('failed with', e);
+        throw e;
+      }),
     fail: reason => {
       throw Error(`Treasury epoch timer failed: ${reason}`);
     },

--- a/packages/vats/src/types.js
+++ b/packages/vats/src/types.js
@@ -1,6 +1,11 @@
 // @ts-check
 
 /**
+ * @template T
+ * @typedef {import('@agoric/eventual-send').EOnly<T>} EOnly
+ */
+
+/**
  * @typedef {Object} Board
  * @property {(id: string) => any} getValue
  * @property {(value: any) => string} getId
@@ -51,19 +56,10 @@
  */
 
 /**
- * @typedef {Object} BankDepositFacet
- *
- * @property {(brand: Brand, account: string, payment: Payment) => Promise<Amount>} deposit
- * @property {() => Notifier<string[]>} getAccountsNotifier
- */
-
-/**
  * @typedef {Object} DistributorParams
  *
  * @property {bigint} [epochInterval=1n] - parameter to the epochTimer
  *  controlling the interval at which rewards should be sent to the bank.
- * @property {Issuer} runIssuer
- * @property {Brand} runBrand
  */
 
 /**
@@ -72,8 +68,7 @@
  * @param {ERef<FeeCollector>} treasuryCollector - an object with a
  *  collectFees() method, which will return a payment. can be populated with
  *  makeTreasuryFeeCollector(zoe, treasuryCreatorFacet)
- * @param {ERef<BankDepositFacet>} bank - object with getAccountsNotifier() and
- *  deposit()
+ * @param {EOnly<DepositFacet>} feeDepositFacet - object with receive()
  * @param {ERef<TimerService>} epochTimer - timer that notifies at the end of
  *  each Epoch. The epochInterval parameter controls the interval.
  * @param {DistributorParams} params


### PR DESCRIPTION
- [x] JS polls the AMM/Treasury every 1 hour
- [x] JS sends RUN to the vpurse module
- [ ] fees sent from JS accumulate in the reward holding pool
- [ ] have a `vpurse.epochDuration` genesis parameter,
- [ ] for each block since the last disbursal, calculate percentage of epochDuration, and give out that portion of the reward holding pool to the feeCollector
- [x] the RUN is distributed to validators/stakers
