### PR TITLE
drop support for Node 12

### DIFF
--- a/.github/workflows/ag-solo-xs.yml.DISABLED
+++ b/.github/workflows/ag-solo-xs.yml.DISABLED
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
-        node-version: '12.x'
+        node-version: '14.x'
     - name: cache node modules
       uses: actions/cache@v1
       with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,7 +17,7 @@ jobs:
 
     - uses: actions/setup-node@v1
       with:
-        node-version: '12.x'
+        node-version: '14.x'
     - name: cache node modules
       uses: actions/cache@v1
       with:

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -14,7 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['12.x', '14.x']
+        # TODO: ['14.x', '16.x']
+        node-version: ['14.x']
     steps:
     - uses: actions/checkout@v2
       with:
@@ -51,7 +52,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['12.x']
+        # note: only use one node-version
+        node-version: ['14.x']
     steps:
     - uses: actions/setup-node@v1
       with:
@@ -83,6 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        # note: only use one node-version
         node-version: ['14.x']
     if: ${{github.event_name == 'push' && github.ref == 'refs/heads/master'}}
     steps:
@@ -122,6 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        # note: only use one node-version
         node-version: ['14.x']
     if: ${{github.event_name == 'push' && github.ref == 'refs/heads/master'}}
     steps:
@@ -177,7 +181,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['12.x', '14.x']
+        # TODO: ['14.x', '16.x']
+        node-version: ['14.x']
     steps:
     - uses: actions/setup-node@v1
       with:
@@ -306,7 +311,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['12.x', '14.x']
+        # TODO: ['14.x', '16.x']
+        node-version: ['14.x']
     steps:
     - uses: actions/setup-node@v1
       with:
@@ -372,7 +378,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['12.x', '14.x']
+        # TODO: ['14.x', '16.x']
+        node-version: ['14.x']
     steps:
     - uses: actions/setup-node@v1
       with:
@@ -410,7 +417,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['12.x', '14.x']
+        # TODO: ['14.x', '16.x']
+        node-version: ['14.x']
     steps:
     - uses: actions/setup-node@v1
       with:
@@ -457,7 +465,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['12.x', '14.x']
+        # TODO: ['14.x', '16.x']
+        node-version: ['14.x']
     steps:
     - uses: actions/setup-node@v1
       with:
@@ -502,7 +511,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['12.x', '14.x']
+        # TODO: ['14.x', '16.x']
+        node-version: ['14.x']
     steps:
     - uses: actions/setup-node@v1
       with:
@@ -540,6 +550,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        # note: only use one node-version, maybe
         node-version: ['14.x']
     steps:
     - uses: actions/setup-node@v1

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ to use.
 ## Prerequisites
 
 * Git
-* Node.js (version 12.14.1 or higher)
+* Node.js LTS (version 14.15.0 or higher)
+  * we generally support the latest LTS release: use [nvm](https://github.com/nvm-sh/nvm) to keep your local system up-to-date
 * Yarn (`npm install -g yarn`)
 
 Any version of Yarn will do: the `.yarnrc` file should ensure that all

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "typescript": "^4.2.3"
   },
   "engines": {
-    "node": ">=12.14.1"
+    "node": ">=14.15.0"
   },
   "scripts": {
     "OFF-clean": "yarn workspaces run clean",


### PR DESCRIPTION
This removes the CI jobs that tested everything against Node 12, leaving only Node 14. It updates the top-level README to indicate the new requirement, and sets the top-level `package.json` to require `node: ">=14.15.0"`, which covers the 14 LTS releases.

It also changes all the individual package `package.json` to require `>= 14.15.0`. I'm less confident about this change. It's in a separate commit to make it easy to remove if reviewers say so.
