### PR TITLE
WIP Suggestion for #3117: Lexical capture makes state redundant

### DIFF
--- a/packages/ERTP/src/payment.js
+++ b/packages/ERTP/src/payment.js
@@ -4,18 +4,16 @@
 import { Far } from '@agoric/marshal';
 
 export const makePaymentMaker = (allegedName, brand) => {
-  const paymentVOFactory = state => {
+  const paymentVOFactory = _state => {
     return {
-      init: b => (state.brand = b),
+      init: () => {},
       self: Far(`${allegedName} payment`, {
-        getAllegedBrand: () => state.brand,
+        getAllegedBrand: () => brand,
       }),
     };
   };
 
-  const paymentMaker = makeKind(paymentVOFactory);
-
-  const makePayment = () => paymentMaker(brand);
+  const makePayment = makeKind(paymentVOFactory);
 
   return makePayment;
 };


### PR DESCRIPTION
Since we already have a `paymentMaker` per brand, we don't need to redundantly store the brand into the virtual object state made by that `paymentMaker`. This works for the same reason that this code already does not store the `allegedName` into the virtual object state.