### PR TITLE
WIP Protect atomic actions after commit points

### DIFF
--- a/packages/ERTP/src/issuerKit.js
+++ b/packages/ERTP/src/issuerKit.js
@@ -17,6 +17,7 @@ const makeIssuerKit = (
   allegedName,
   assetKind = AssetKind.NAT,
   displayInfo = harden({}),
+  atomic = assert.atomic,
 ) => {
   assert.typeof(allegedName, 'string');
   assert(
@@ -46,6 +47,7 @@ const makeIssuerKit = (
     brand,
     assetKind,
     cleanDisplayInfo,
+    atomic,
   );
 
   return harden({

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -317,6 +317,7 @@
  * @param {string} allegedName
  * @param {AssetKind} [assetKind=AssetKind.NAT]
  * @param {AdditionalDisplayInfo} [displayInfo={}]
+ * @param {Atomic=} atomic
  * @returns {IssuerKit}
  *
  * The allegedName becomes part of the brand in asset descriptions. The

--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -32,6 +32,7 @@ if (globalAssert === undefined) {
 }
 
 const missing = [
+  'error',
   'fail',
   'equal',
   'typeof',
@@ -40,6 +41,7 @@ const missing = [
   'details',
   'quote',
   'makeAssert',
+  'atomic',
 ].filter(name => globalAssert[name] === undefined);
 if (missing.length > 0) {
   throw new Error(

--- a/packages/assert/src/types.js
+++ b/packages/assert/src/types.js
@@ -122,7 +122,15 @@
 /**
  * The `assert.typeof` method
  *
- * @typedef {AssertTypeofBigint & AssertTypeofBoolean & AssertTypeofFunction & AssertTypeofNumber & AssertTypeofObject & AssertTypeofString & AssertTypeofSymbol & AssertTypeofUndefined} AssertTypeof
+ * @typedef { AssertTypeofBigint &
+ *   AssertTypeofBoolean &
+ *   AssertTypeofFunction &
+ *   AssertTypeofNumber &
+ *   AssertTypeofObject &
+ *   AssertTypeofString &
+ *   AssertTypeofSymbol &
+ *   AssertTypeofUndefined
+ * } AssertTypeof
  */
 
 /**
@@ -148,6 +156,33 @@
  * @param {Error} error
  * @param {Details} detailsNote
  * @returns {void}
+ */
+
+/**
+ * @callback Commit
+ */
+
+/**
+ * @callback AtomicAction
+ * @param {Commit} commit
+ */
+
+/**
+ * The `assert.atomic` method
+ *
+ * @callback Atomic
+ * Calls back to `action` once, passing it a no-argument `commit` function
+ * which `action` should call to mark its *commit point*. If `action` returns
+ * or throws before the commit point, that outcome is just propagated (with
+ * an added error note on a throw). If `action` returns after the commit
+ * point, that returned value is just propagated.
+ *
+ * However, if `action` throws after that commit point, that becomes an
+ * `assert.fail` for this `assert` instance, terminating / abandoning whatever
+ * unit of computation this `assert` instance does on failure. For example,
+ * `zcf.assert.atomic(f)` will immediately shut down that `zcf`'s contract
+ * if `f` throws after the commit point.
+ * @param {AtomicAction} action
  */
 
 // /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Use https://github.com/endojs/endo/pull/733 to protect against atomicity failures after commit points in ERTP.

This is necessarily a WIP draft until we can depend on https://github.com/endojs/endo/pull/733 . Thus, this PR is also expected to fail under CI until that dependency can be satisfied.