### PR TITLE
ci: correctly handle the case of no coverage data

### DIFF
--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -154,7 +154,7 @@ jobs:
     - name: generate coverage for all tests
       run: 'yarn test:c8-all || :'
     - name: generate coverage/html reports
-      run: yarn c8 report --reporter=html-spa --reports-dir=coverage/html --temp-directory=coverage/tmp
+      run: mkdir -p coverage/tmp && yarn c8 report --reporter=html-spa --reports-dir=coverage/html --temp-directory=coverage/tmp
     - uses: actions/upload-artifact@v2
       with:
         name: coverage


### PR DESCRIPTION
Handle the case where there is no generated coverage data, so that the `master` branch doesn't fail CI.

A future PR will add some actual `test:c8` targets as specified in `COVERAGE.md`.
