### PR TITLE
refactor virtual object manager

### DIFF
--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -338,6 +338,15 @@ function build(
       console.info('Logging sent error stack', err),
   });
 
+  function getSlotForVal(val) {
+    return valToSlot.get(val);
+  }
+
+  function getValForSlot(slot) {
+    const wr = slotToVal.get(slot);
+    return wr && wr.deref();
+  }
+
   const {
     makeVirtualObjectRepresentative,
     makeWeakStore,
@@ -347,7 +356,8 @@ function build(
   } = makeVirtualObjectManager(
     syscall,
     allocateExportID,
-    valToSlot,
+    getSlotForVal,
+    getValForSlot,
     // eslint-disable-next-line no-use-before-define
     registerValue,
     m,

--- a/packages/SwingSet/test/virtualObjects/test-virtualObjectManager.js
+++ b/packages/SwingSet/test/virtualObjects/test-virtualObjectManager.js
@@ -84,7 +84,7 @@ function zotVal(arbitrary, name, tag, count) {
 // prettier-ignore
 test('virtual object operations', t => {
   const log = [];
-  const { makeKind, flushCache, dumpStore } = makeFakeVirtualObjectManager(3, log);
+  const { makeKind, flushCache, dumpStore } = makeFakeVirtualObjectManager({ cacheSize: 3, log });
 
   const thingMaker = makeKind(makeThingInstance);
   const zotMaker = makeKind(makeZotInstance);
@@ -298,7 +298,9 @@ test('virtual object operations', t => {
 });
 
 test('weak store operations', t => {
-  const { makeWeakStore, makeKind } = makeFakeVirtualObjectManager(3);
+  const { makeWeakStore, makeKind } = makeFakeVirtualObjectManager({
+    cacheSize: 3,
+  });
 
   const thingMaker = makeKind(makeThingInstance);
   const zotMaker = makeKind(makeZotInstance);
@@ -346,7 +348,7 @@ test('virtualized weak collection operations', t => {
     VirtualObjectAwareWeakMap,
     VirtualObjectAwareWeakSet,
     makeKind,
-  } = makeFakeVirtualObjectManager(3);
+  } = makeFakeVirtualObjectManager({ cacheSize: 3 });
 
   const thingMaker = makeKind(makeThingInstance);
   const zotMaker = makeKind(makeZotInstance);

--- a/packages/SwingSet/test/virtualObjects/test-weakcollections.js
+++ b/packages/SwingSet/test/virtualObjects/test-weakcollections.js
@@ -91,18 +91,16 @@ test('weakMap vref handling', async t => {
   const {
     VirtualObjectAwareWeakMap,
     VirtualObjectAwareWeakSet,
-    valToSlot,
-    slotToVal,
+    registerEntry,
+    deleteEntry,
   } = makeFakeVirtualObjectManager({ cacheSize: 3, log });
 
   function addCListEntry(slot, val) {
-    slotToVal.set(slot, val);
-    valToSlot.set(val, slot);
+    registerEntry(slot, val);
   }
 
   function removeCListEntry(slot, val) {
-    slotToVal.delete(slot);
-    valToSlot.delete(val);
+    deleteEntry(slot, val);
   }
 
   const weakMap = new VirtualObjectAwareWeakMap();

--- a/packages/SwingSet/test/virtualObjects/test-weakcollections.js
+++ b/packages/SwingSet/test/virtualObjects/test-weakcollections.js
@@ -93,7 +93,7 @@ test('weakMap vref handling', async t => {
     VirtualObjectAwareWeakSet,
     valToSlot,
     slotToVal,
-  } = makeFakeVirtualObjectManager(3, log);
+  } = makeFakeVirtualObjectManager({ cacheSize: 3, log });
 
   function addCListEntry(slot, val) {
     slotToVal.set(slot, val);

--- a/packages/SwingSet/tools/fakeVirtualObjectManager.js
+++ b/packages/SwingSet/tools/fakeVirtualObjectManager.js
@@ -4,7 +4,8 @@ import { parseVatSlot } from '../src/parseVatSlots';
 
 import { makeVirtualObjectManager } from '../src/kernel/virtualObjectManager';
 
-export function makeFakeVirtualObjectManager(cacheSize = 100, log) {
+export function makeFakeVirtualObjectManager(options = {}) {
+  const { cacheSize = 100, log } = options;
   const fakeStore = new Map();
 
   function dumpStore() {

--- a/packages/SwingSet/tools/prepare-test-env.js
+++ b/packages/SwingSet/tools/prepare-test-env.js
@@ -9,7 +9,9 @@
 import './install-ses-debug';
 import { makeFakeVirtualObjectManager } from './fakeVirtualObjectManager';
 
-const { makeKind, makeWeakStore } = makeFakeVirtualObjectManager(3);
+const { makeKind, makeWeakStore } = makeFakeVirtualObjectManager({
+  cacheSize: 3,
+});
 
 globalThis.makeKind = makeKind;
 globalThis.makeWeakStore = makeWeakStore;


### PR DESCRIPTION
This rearranges the virtual object manager, especially `makeFakeVirtualObjectManager`, to facilitate upcoming tests:

* take an options bag, to make it easier to add new options
* take functions to manipulate the liveslots `slotToVal` and `valToSlot` tables, rather than the tables directly, to reduce coupling
* return some additional debug hooks from the fake version
* add a `weak: true` mode to make the fake version's `slotToVal` table use WeakRefs, just like liveslots does

The last part is important to allow the upcoming #3132 tests to work correctly. Without a WeakRef, the fake version would hold onto the Remotable with a strong reference, preventing us from checking whether or not the VOM is also holding a strong reference (it would cause a false positive).
