### PR TITLE
fix: use --expose-gc for top-level 'yarn test'

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,9 @@
     "files": [
       "packages/*/test/**/test-*.js"
     ],
+    "nodeArguments": [
+      "--expose-gc"
+    ],
     "require": [
       "esm"
     ],


### PR DESCRIPTION
I added this to SwingSet/package.json in commit
d4bc61724365ae7eefb64459c7aefb5f2189e4b1 (PR #3136). However I overlooked the
fact that #3100 had already landed, which changed the top-level `yarn test`
from one that just did a (sequential) `yarn workspaces test`, testing one
package at a time with whatever the local `package.json` said to do, to one
that does a (parallel) `ava` invocation, which does all packages at the same
time but ignores the local `package.json` settings.

We need to include `--expose-gc` in the `nodeArguments` in the top-level
package.json to make sure the parallel form give the correct arguments when
SwingSet's turn comes around (as well as other packages which benefit from
enabling GC but don't have tests which directly assert that it can be done).

Running a top-level `yarn test` on agoric-sdk trunk is currrently broken because of this.
