### PR TITLE
Provide StreamStore implementations

### DIFF
--- a/packages/swing-store-lmdb/test/test-state.js
+++ b/packages/swing-store-lmdb/test/test-state.js
@@ -71,72 +71,37 @@ test('streamStore read/write', t => {
   t.is(isSwingStore(dbDir), false);
   const { streamStore, commit, close } = initSwingStore(dbDir);
 
-  let s1pos = streamStore.STREAM_START;
-  const writer1 = streamStore.openWriteStream('st1');
-  s1pos = writer1('first', s1pos);
-  s1pos = writer1('second', s1pos);
+  const start = streamStore.STREAM_START;
+  let s1pos = start;
+  s1pos = streamStore.writeStreamItem('st1', 'first', s1pos);
+  s1pos = streamStore.writeStreamItem('st1', 'second', s1pos);
   const s1posAlt = { ...s1pos };
-  const writer2 = streamStore.openWriteStream('st2');
-  s1pos = writer1('third', s1pos);
+  s1pos = streamStore.writeStreamItem('st1', 'third', s1pos);
   let s2pos = streamStore.STREAM_START;
-  s2pos = writer2('oneth', s2pos);
-  s1pos = writer1('fourth', s1pos);
-  s2pos = writer2('twoth', s2pos);
+  s2pos = streamStore.writeStreamItem('st2', 'oneth', s2pos);
+  s1pos = streamStore.writeStreamItem('st1', 'fourth', s1pos);
+  s2pos = streamStore.writeStreamItem('st2', 'twoth', s2pos);
   const s2posAlt = { ...s2pos };
-  s2pos = writer2('threeth', s2pos);
-  s2pos = writer2('fourst', s2pos);
+  s2pos = streamStore.writeStreamItem('st2', 'threeth', s2pos);
+  s2pos = streamStore.writeStreamItem('st2', 'fourst', s2pos);
   streamStore.closeStream('st1');
   streamStore.closeStream('st2');
-  const reader1 = streamStore.openReadStream(
-    'st1',
-    streamStore.STREAM_START,
-    s1pos,
-  );
-  const reads1 = [];
-  for (const item of reader1) {
-    reads1.push(item);
-  }
-  t.deepEqual(reads1, ['first', 'second', 'third', 'fourth']);
-  const writer2alt = streamStore.openWriteStream('st2');
-  s2pos = writer2alt('re3', s2posAlt);
+  const reader1 = streamStore.readStream('st1', start, s1pos);
+  t.deepEqual(Array.from(reader1), ['first', 'second', 'third', 'fourth']);
+  s2pos = streamStore.writeStreamItem('st2', 're3', s2posAlt);
   streamStore.closeStream('st2');
-  const reader2 = streamStore.openReadStream(
-    'st2',
-    streamStore.STREAM_START,
-    s2pos,
-  );
-  const reads2 = [];
-  for (const item of reader2) {
-    reads2.push(item);
-  }
-  t.deepEqual(reads2, ['oneth', 'twoth', 're3']);
+  const reader2 = streamStore.readStream('st2', start, s2pos);
+  t.deepEqual(Array.from(reader2), ['oneth', 'twoth', 're3']);
 
-  const reader1alt = streamStore.openReadStream('st1', s1posAlt, s1pos);
-  const reads1alt = [];
-  for (const item of reader1alt) {
-    reads1alt.push(item);
-  }
-  t.deepEqual(reads1alt, ['third', 'fourth']);
+  const reader1alt = streamStore.readStream('st1', s1posAlt, s1pos);
+  t.deepEqual(Array.from(reader1alt), ['third', 'fourth']);
 
-  const writerEmpty = streamStore.openWriteStream('empty');
-  const emptyPos = writerEmpty('filler', streamStore.STREAM_START);
+  const emptyPos = streamStore.writeStreamItem('empty', 'filler', start);
   streamStore.closeStream('empty');
-  const readerEmpty = streamStore.openReadStream('empty', emptyPos, emptyPos);
-  const readsEmpty = [];
-  for (const item of readerEmpty) {
-    readsEmpty.push(item);
-  }
-  t.deepEqual(readsEmpty, []);
-  const readerEmpty2 = streamStore.openReadStream(
-    'empty',
-    streamStore.STREAM_START,
-    streamStore.STREAM_START,
-  );
-  const readsEmpty2 = [];
-  for (const item of readerEmpty2) {
-    readsEmpty2.push(item);
-  }
-  t.deepEqual(readsEmpty2, []);
+  const readerEmpty = streamStore.readStream('empty', emptyPos, emptyPos);
+  t.deepEqual(Array.from(readerEmpty), []);
+  const readerEmpty2 = streamStore.readStream('empty', start, start);
+  t.deepEqual(Array.from(readerEmpty2), []);
 
   commit();
   close();
@@ -148,35 +113,20 @@ test('streamStore mode interlock', t => {
   fs.rmdirSync(dbDir, { recursive: true });
   t.is(isSwingStore(dbDir), false);
   const { streamStore, commit, close } = initSwingStore(dbDir);
+  const start = streamStore.STREAM_START;
 
-  const writer = streamStore.openWriteStream('st1');
-  const s1pos = writer('first', streamStore.STREAM_START);
-  t.throws(
-    () => streamStore.openReadStream('st1', streamStore.STREAM_START, s1pos),
-    {
-      message: `can't read stream "st1" because it's already in use`,
-    },
-  );
-  t.throws(() => streamStore.openWriteStream('st1', s1pos), {
-    message: `can't write stream "st1" because it's already in use`,
+  const s1pos = streamStore.writeStreamItem('st1', 'first', start);
+
+  t.throws(() => streamStore.readStream('st1', start, s1pos), {
+    message: `can't read stream "st1" because it's already in use`,
   });
   streamStore.closeStream('st1');
-  t.throws(() => writer('second', streamStore.STREAM_START), {
-    message: `can't write to closed stream "st1"`,
-  });
 
-  const reader = streamStore.openReadStream(
-    'st1',
-    streamStore.STREAM_START,
-    s1pos,
-  );
-  t.throws(
-    () => streamStore.openReadStream('st1', streamStore.STREAM_START, s1pos),
-    {
-      message: `can't read stream "st1" because it's already in use`,
-    },
-  );
-  t.throws(() => streamStore.openWriteStream('st1'), {
+  const reader = streamStore.readStream('st1', start, s1pos);
+  t.throws(() => streamStore.readStream('st1', start, s1pos), {
+    message: `can't read stream "st1" because it's already in use`,
+  });
+  t.throws(() => streamStore.writeStreamItem('st1', start, s1pos), {
     message: `can't write stream "st1" because it's already in use`,
   });
   streamStore.closeStream('st1');

--- a/packages/swing-store-lmdb/test/test-state.js
+++ b/packages/swing-store-lmdb/test/test-state.js
@@ -15,7 +15,7 @@ import {
   isSwingStore,
 } from '../src/lmdbSwingStore';
 
-function testStorage(t, kvStore) {
+function testKVStore(t, kvStore) {
   t.falsy(kvStore.has('missing'));
   t.is(kvStore.get('missing'), undefined);
 
@@ -52,15 +52,91 @@ test('storageInLMDB under SES', t => {
   fs.rmdirSync(dbDir, { recursive: true });
   t.is(isSwingStore(dbDir), false);
   const { kvStore, commit, close } = initSwingStore(dbDir);
-  testStorage(t, kvStore);
+  testKVStore(t, kvStore);
   commit();
   const before = getAllState(kvStore);
   close();
   t.is(isSwingStore(dbDir), true);
 
-  const { kvStore: after } = openSwingStore(dbDir);
+  const { kvStore: after, close: close2 } = openSwingStore(dbDir);
   t.deepEqual(getAllState(after), before, 'check state after reread');
   t.is(isSwingStore(dbDir), true);
+  close2();
+});
+
+test('streamStore read/write', t => {
+  const dbDir = 'testdb';
+  t.teardown(() => fs.rmdirSync(dbDir, { recursive: true }));
+  fs.rmdirSync(dbDir, { recursive: true });
+  t.is(isSwingStore(dbDir), false);
+  const { streamStore, commit, close } = initSwingStore(dbDir);
+
+  let s1pos;
+  const writer1 = streamStore.openWriteStream('st1');
+  s1pos = writer1('first', s1pos);
+  s1pos = writer1('second', s1pos);
+  const s1posAlt = { ...s1pos };
+  const writer2 = streamStore.openWriteStream('st2');
+  s1pos = writer1('third', s1pos);
+  let s2pos = { offset: 0, itemCount: 0 };
+  s2pos = writer2('oneth', s2pos);
+  s1pos = writer1('fourth', s1pos);
+  s2pos = writer2('twoth', s2pos);
+  const s2posAlt = { ...s2pos };
+  s2pos = writer2('threeth', s2pos);
+  s2pos = writer2('fourst', s2pos);
+  streamStore.closeStream('st1');
+  streamStore.closeStream('st2');
+  const reader1 = streamStore.openReadStream('st1', s1pos);
+  const reads1 = [];
+  for (const item of reader1) {
+    reads1.push(item);
+  }
+  t.deepEqual(reads1, ['first', 'second', 'third', 'fourth']);
+  const writer2alt = streamStore.openWriteStream('st2');
+  s2pos = writer2alt('re3', s2posAlt);
+  streamStore.closeStream('st2');
+  const reader2 = streamStore.openReadStream('st2', s2pos);
+  const reads2 = [];
+  for (const item of reader2) {
+    reads2.push(item);
+  }
+  t.deepEqual(reads2, ['oneth', 'twoth', 're3']);
+
+  const reader1alt = streamStore.openReadStream('st1', s1pos, s1posAlt);
+  const reads1alt = [];
+  for (const item of reader1alt) {
+    reads1alt.push(item);
+  }
+  t.deepEqual(reads1alt, ['third', 'fourth']);
+
+  commit();
+  close();
+});
+
+test('streamStore mode interlock', t => {
+  const dbDir = 'testdb';
+  t.teardown(() => fs.rmdirSync(dbDir, { recursive: true }));
+  fs.rmdirSync(dbDir, { recursive: true });
+  t.is(isSwingStore(dbDir), false);
+  const { streamStore, commit, close } = initSwingStore(dbDir);
+
+  const writer1 = streamStore.openWriteStream('st1');
+  const s1pos = writer1('first');
+  const reader1 = streamStore.openReadStream('st1', s1pos);
+  t.throws(() => reader1.next(), {
+    message: `can't read stream "st1" because it's already being used for "write"`,
+  });
+  streamStore.closeStream('st1');
+
+  const reader1a = streamStore.openReadStream('st1', s1pos);
+  reader1a.next();
+  t.throws(() => streamStore.openWriteStream('st1'), {
+    message: `can't write stream "st1" because it's already being used for "read"`,
+  });
+
+  commit();
+  close();
 });
 
 test('rejectSimple under SES', t => {

--- a/packages/swing-store-lmdb/test/test-state.js
+++ b/packages/swing-store-lmdb/test/test-state.js
@@ -71,14 +71,14 @@ test('streamStore read/write', t => {
   t.is(isSwingStore(dbDir), false);
   const { streamStore, commit, close } = initSwingStore(dbDir);
 
-  let s1pos;
+  let s1pos = streamStore.STREAM_START;
   const writer1 = streamStore.openWriteStream('st1');
   s1pos = writer1('first', s1pos);
   s1pos = writer1('second', s1pos);
   const s1posAlt = { ...s1pos };
   const writer2 = streamStore.openWriteStream('st2');
   s1pos = writer1('third', s1pos);
-  let s2pos = { offset: 0, itemCount: 0 };
+  let s2pos = streamStore.STREAM_START;
   s2pos = writer2('oneth', s2pos);
   s1pos = writer1('fourth', s1pos);
   s2pos = writer2('twoth', s2pos);
@@ -87,7 +87,11 @@ test('streamStore read/write', t => {
   s2pos = writer2('fourst', s2pos);
   streamStore.closeStream('st1');
   streamStore.closeStream('st2');
-  const reader1 = streamStore.openReadStream('st1', s1pos);
+  const reader1 = streamStore.openReadStream(
+    'st1',
+    streamStore.STREAM_START,
+    s1pos,
+  );
   const reads1 = [];
   for (const item of reader1) {
     reads1.push(item);
@@ -96,14 +100,18 @@ test('streamStore read/write', t => {
   const writer2alt = streamStore.openWriteStream('st2');
   s2pos = writer2alt('re3', s2posAlt);
   streamStore.closeStream('st2');
-  const reader2 = streamStore.openReadStream('st2', s2pos);
+  const reader2 = streamStore.openReadStream(
+    'st2',
+    streamStore.STREAM_START,
+    s2pos,
+  );
   const reads2 = [];
   for (const item of reader2) {
     reads2.push(item);
   }
   t.deepEqual(reads2, ['oneth', 'twoth', 're3']);
 
-  const reader1alt = streamStore.openReadStream('st1', s1pos, s1posAlt);
+  const reader1alt = streamStore.openReadStream('st1', s1posAlt, s1pos);
   const reads1alt = [];
   for (const item of reader1alt) {
     reads1alt.push(item);
@@ -111,7 +119,7 @@ test('streamStore read/write', t => {
   t.deepEqual(reads1alt, ['third', 'fourth']);
 
   const writerEmpty = streamStore.openWriteStream('empty');
-  const emptyPos = writerEmpty('filler');
+  const emptyPos = writerEmpty('filler', streamStore.STREAM_START);
   streamStore.closeStream('empty');
   const readerEmpty = streamStore.openReadStream('empty', emptyPos, emptyPos);
   const readsEmpty = [];
@@ -121,6 +129,7 @@ test('streamStore read/write', t => {
   t.deepEqual(readsEmpty, []);
   const readerEmpty2 = streamStore.openReadStream(
     'empty',
+    streamStore.STREAM_START,
     streamStore.STREAM_START,
   );
   const readsEmpty2 = [];
@@ -141,22 +150,32 @@ test('streamStore mode interlock', t => {
   const { streamStore, commit, close } = initSwingStore(dbDir);
 
   const writer = streamStore.openWriteStream('st1');
-  const s1pos = writer('first');
-  t.throws(() => streamStore.openReadStream('st1', s1pos), {
-    message: `can't read stream "st1" because it's already in use`,
-  });
+  const s1pos = writer('first', streamStore.STREAM_START);
+  t.throws(
+    () => streamStore.openReadStream('st1', streamStore.STREAM_START, s1pos),
+    {
+      message: `can't read stream "st1" because it's already in use`,
+    },
+  );
   t.throws(() => streamStore.openWriteStream('st1', s1pos), {
     message: `can't write stream "st1" because it's already in use`,
   });
   streamStore.closeStream('st1');
-  t.throws(() => writer('second'), {
+  t.throws(() => writer('second', streamStore.STREAM_START), {
     message: `can't write to closed stream "st1"`,
   });
 
-  const reader = streamStore.openReadStream('st1', s1pos);
-  t.throws(() => streamStore.openReadStream('st1', s1pos), {
-    message: `can't read stream "st1" because it's already in use`,
-  });
+  const reader = streamStore.openReadStream(
+    'st1',
+    streamStore.STREAM_START,
+    s1pos,
+  );
+  t.throws(
+    () => streamStore.openReadStream('st1', streamStore.STREAM_START, s1pos),
+    {
+      message: `can't read stream "st1" because it's already in use`,
+    },
+  );
   t.throws(() => streamStore.openWriteStream('st1'), {
     message: `can't write stream "st1" because it's already in use`,
   });
@@ -164,6 +183,8 @@ test('streamStore mode interlock', t => {
   t.throws(() => reader.next(), {
     message: `can't read stream "st1", it's been closed`,
   });
+
+  streamStore.closeStream('nonexistent');
 
   commit();
   close();

--- a/packages/swing-store-simple/test/test-state.js
+++ b/packages/swing-store-simple/test/test-state.js
@@ -11,7 +11,7 @@ import {
   isSwingStore,
 } from '../src/simpleSwingStore';
 
-function testStorage(t, kvStore) {
+function testKVStore(t, kvStore) {
   t.falsy(kvStore.has('missing'));
   t.is(kvStore.get('missing'), undefined);
 
@@ -44,7 +44,7 @@ function testStorage(t, kvStore) {
 
 test('storageInMemory', t => {
   const { kvStore } = initSwingStore();
-  testStorage(t, kvStore);
+  testKVStore(t, kvStore);
 });
 
 test('storageInFile', t => {
@@ -53,7 +53,7 @@ test('storageInFile', t => {
   fs.rmdirSync(dbDir, { recursive: true });
   t.is(isSwingStore(dbDir), false);
   const { kvStore, commit, close } = initSwingStore(dbDir);
-  testStorage(t, kvStore);
+  testKVStore(t, kvStore);
   commit();
   const before = getAllState(kvStore);
   close();
@@ -71,4 +71,71 @@ test('rejectLMDB', t => {
   fs.writeFileSync(path.resolve(notSimpleDir, 'data.mdb'), 'some data\n');
   fs.writeFileSync(path.resolve(notSimpleDir, 'lock.mdb'), 'lock stuff\n');
   t.is(isSwingStore(notSimpleDir), false);
+});
+
+test('streamStore read/write', t => {
+  const { streamStore, commit, close } = initSwingStore();
+
+  let s1pos;
+  const writer1 = streamStore.openWriteStream('st1');
+  s1pos = writer1('first', s1pos);
+  s1pos = writer1('second', s1pos);
+  const s1posAlt = { ...s1pos };
+  const writer2 = streamStore.openWriteStream('st2');
+  s1pos = writer1('third', s1pos);
+  let s2pos = { itemCount: 0 };
+  s2pos = writer2('oneth', s2pos);
+  s1pos = writer1('fourth', s1pos);
+  s2pos = writer2('twoth', s2pos);
+  const s2posAlt = { ...s2pos };
+  s2pos = writer2('threeth', s2pos);
+  s2pos = writer2('fourst', s2pos);
+  streamStore.closeStream('st1');
+  streamStore.closeStream('st2');
+  const reader1 = streamStore.openReadStream('st1', s1pos);
+  const reads1 = [];
+  for (const item of reader1) {
+    reads1.push(item);
+  }
+  t.deepEqual(reads1, ['first', 'second', 'third', 'fourth']);
+  const writer2alt = streamStore.openWriteStream('st2');
+  s2pos = writer2alt('re3', s2posAlt);
+  streamStore.closeStream('st2');
+  const reader2 = streamStore.openReadStream('st2', s2pos);
+  const reads2 = [];
+  for (const item of reader2) {
+    reads2.push(item);
+  }
+  t.deepEqual(reads2, ['oneth', 'twoth', 're3']);
+
+  const reader1alt = streamStore.openReadStream('st1', s1pos, s1posAlt);
+  const reads1alt = [];
+  for (const item of reader1alt) {
+    reads1alt.push(item);
+  }
+  t.deepEqual(reads1alt, ['third', 'fourth']);
+
+  commit();
+  close();
+});
+
+test('streamStore mode interlock', t => {
+  const { streamStore, commit, close } = initSwingStore();
+
+  const writer1 = streamStore.openWriteStream('st1');
+  const s1pos = writer1('first');
+  const reader1 = streamStore.openReadStream('st1', s1pos);
+  t.throws(() => reader1.next(), {
+    message: `can't read stream "st1" because it's already being used for "write"`,
+  });
+  streamStore.closeStream('st1');
+
+  const reader1a = streamStore.openReadStream('st1', s1pos);
+  reader1a.next();
+  t.throws(() => streamStore.openWriteStream('st1'), {
+    message: `can't write stream "st1" because it's already being used for "read"`,
+  });
+
+  commit();
+  close();
 });

--- a/packages/swing-store-simple/test/test-state.js
+++ b/packages/swing-store-simple/test/test-state.js
@@ -115,6 +115,25 @@ test('streamStore read/write', t => {
   }
   t.deepEqual(reads1alt, ['third', 'fourth']);
 
+  const writerEmpty = streamStore.openWriteStream('empty');
+  const emptyPos = writerEmpty('filler');
+  streamStore.closeStream('empty');
+  const readerEmpty = streamStore.openReadStream('empty', emptyPos, emptyPos);
+  const readsEmpty = [];
+  for (const item of readerEmpty) {
+    readsEmpty.push(item);
+  }
+  t.deepEqual(readsEmpty, []);
+  const readerEmpty2 = streamStore.openReadStream(
+    'empty',
+    streamStore.STREAM_START,
+  );
+  const readsEmpty2 = [];
+  for (const item of readerEmpty2) {
+    readsEmpty2.push(item);
+  }
+  t.deepEqual(readsEmpty2, []);
+
   commit();
   close();
 });
@@ -122,18 +141,29 @@ test('streamStore read/write', t => {
 test('streamStore mode interlock', t => {
   const { streamStore, commit, close } = initSwingStore();
 
-  const writer1 = streamStore.openWriteStream('st1');
-  const s1pos = writer1('first');
-  const reader1 = streamStore.openReadStream('st1', s1pos);
-  t.throws(() => reader1.next(), {
-    message: `can't read stream "st1" because it's already being used for "write"`,
+  const writer = streamStore.openWriteStream('st1');
+  const s1pos = writer('first');
+  t.throws(() => streamStore.openReadStream('st1', s1pos), {
+    message: `can't read stream "st1" because it's already in use`,
+  });
+  t.throws(() => streamStore.openWriteStream('st1', s1pos), {
+    message: `can't write stream "st1" because it's already in use`,
   });
   streamStore.closeStream('st1');
+  t.throws(() => writer('second'), {
+    message: `can't write to closed stream "st1"`,
+  });
 
-  const reader1a = streamStore.openReadStream('st1', s1pos);
-  reader1a.next();
+  const reader = streamStore.openReadStream('st1', s1pos);
+  t.throws(() => streamStore.openReadStream('st1', s1pos), {
+    message: `can't read stream "st1" because it's already in use`,
+  });
   t.throws(() => streamStore.openWriteStream('st1'), {
-    message: `can't write stream "st1" because it's already being used for "read"`,
+    message: `can't write stream "st1" because it's already in use`,
+  });
+  streamStore.closeStream('st1');
+  t.throws(() => reader.next(), {
+    message: `can't read stream "st1", it's been closed`,
   });
 
   commit();


### PR DESCRIPTION
Define the StreamStore API and provide on-disk and in-memory implementations, marching towards moving the transcripts out of the kernel key-value DB.

API:

```
StreamStore:
  openWriteStream(streamName: string): StreamWriter
  openReadStream(streamName: string, endPosition: StreamPosition, startPosition?: StreamPosition: Iterable<string>
  closeStream(streamName: string)

StreamWriter:
  (item: string, position: StreamPosition|null) => StreamPosition
```

Starting to read takes an end position, which defines the end of the stream, and optionally a start position, which says where to begin reading.  Items are returned sequentially by an iterator.

Each act of writing takes a position to write to and returns a new position (nominally for the next write).  A write position of `null` signals the beginning of a stream.

`StreamPosition` is an opaque object from the perspective of API clients, but is serializable.
