### PR TITLE
fix liveslots object retention

### DIFF
--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -97,6 +97,7 @@ function build(
   const slotToVal = new Map(); // vref -> WeakRef(object)
   const exportedRemotables = new Set(); // objects
   const pendingPromises = new Set(); // Promises
+  const importedDevices = new Set(); // device nodes
   const safetyPins = new Set(); // temporary
   const deadSet = new Set(); // vrefs that are finalized but not yet reported
 
@@ -487,6 +488,7 @@ function build(
         }
       } else if (type === 'device') {
         val = makeDeviceNode(slot, iface);
+        importedDevices.add(val);
       } else {
         assert.fail(X`unrecognized slot type '${type}'`);
       }

--- a/packages/SwingSet/test/test-liveslots.js
+++ b/packages/SwingSet/test/test-liveslots.js
@@ -1,10 +1,13 @@
+/* global WeakRef */
 // eslint-disable-next-line import/order
 import { test } from '../tools/prepare-test-env-ava';
 
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
+import { makePromiseKit } from '@agoric/promise-kit';
 import { assert, details as X } from '@agoric/assert';
 import { waitUntilQuiescent } from '../src/waitUntilQuiescent';
+import { gcAndFinalize } from '../src/gc';
 import { makeLiveSlots } from '../src/kernel/liveSlots';
 import { buildSyscall, makeDispatch } from './liveslots-helpers';
 import {
@@ -317,6 +320,43 @@ test('liveslots retires outbound promise IDs after resolve to data', async t => 
 
 test('liveslots retires outbound promise IDs after reject', async t => {
   await doOutboundPromise(t, 'reject');
+});
+
+test('liveslots retains pending exported promise', async t => {
+  const { log, syscall } = buildSyscall();
+  let watch;
+  const success = [];
+  function build(_vatPowers) {
+    const root = Far('root', {
+      make() {
+        const pk = makePromiseKit();
+        watch = new WeakRef(pk.promise);
+        // we export the Promise, but do not retain resolve/reject
+        return [pk.promise];
+      },
+      // if liveslots fails to keep a strongref to the Promise, it will have
+      // been collected by now, and calling check() will fail, because
+      // liveslots can't create a new Promise import when the allocatedByVat
+      // says it was an export
+      check(_p) {
+        success.push('yes');
+      },
+    });
+    return root;
+  }
+
+  const dispatch = makeDispatch(syscall, build);
+  const rootA = 'o+0';
+  const resultP = 'p-1';
+  await dispatch(makeMessage(rootA, 'make', capargs([]), resultP));
+  await gcAndFinalize();
+  t.truthy(watch.deref(), 'Promise not retained');
+  t.is(log[0].type, 'resolve');
+  const res0 = log[0].resolutions[0];
+  t.is(res0[0], resultP);
+  const exportedVPID = res0[2].slots[0]; // currently p+5
+  await dispatch(makeMessage(rootA, 'check', capargsOneSlot(exportedVPID)));
+  t.deepEqual(success, ['yes']);
 });
 
 function hush(p) {


### PR DESCRIPTION
These three commits improve the way liveslots keeps strong references to:

* Promises, while unresolved
* Remotables, either because they've been exported into the kernel, or used from virtualized data
* Device nodes, forever

They ought to make it safe to remove the "safety pins" that have been protecting JS `Objects` and `Promises` against surprising garbage collection.

refs #3106 
