### PR TITLE
feat(swingset): drop Presences, trigger `syscall.dropImports`

### DIFF
--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -20,6 +20,7 @@ import { xsnap, makeSnapstore } from '@agoric/xsnap';
 import { WeakRef, FinalizationRegistry } from './weakref';
 import { startSubprocessWorker } from './spawnSubprocessWorker';
 import { waitUntilQuiescent } from './waitUntilQuiescent';
+import { gcAndFinalize } from './gc';
 import { insistStorageAPI } from './storageAPI';
 import { insistCapData } from './capdata';
 import { parseVatSlot } from './parseVatSlots';
@@ -271,7 +272,8 @@ export async function makeSwingsetController(
     const supercode = require.resolve(
       './kernel/vatManager/supervisor-subprocess-node.js',
     );
-    return startSubprocessWorker(process.execPath, ['-r', 'esm', supercode]);
+    const args = ['--expose-gc', '-r', 'esm', supercode];
+    return startSubprocessWorker(process.execPath, args);
   }
 
   const bundles = [
@@ -297,6 +299,7 @@ export async function makeSwingsetController(
     writeSlogObject,
     WeakRef,
     FinalizationRegistry,
+    gcAndFinalize,
   };
 
   const kernelOptions = { verbose };

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -105,6 +105,7 @@ export default function buildKernel(
     writeSlogObject,
     WeakRef,
     FinalizationRegistry,
+    gcAndFinalize,
   } = kernelEndowments;
   deviceEndowments = { ...deviceEndowments }; // copy so we can modify
   const { verbose, defaultManagerType = 'local' } = kernelOptions;
@@ -631,7 +632,12 @@ export default function buildKernel(
     }
   }
 
-  const gcTools = harden({ WeakRef, FinalizationRegistry, waitUntilQuiescent });
+  const gcTools = harden({
+    WeakRef,
+    FinalizationRegistry,
+    waitUntilQuiescent,
+    gcAndFinalize,
+  });
   const vatManagerFactory = makeVatManagerFactory({
     allVatPowers,
     kernelKeeper,

--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -45,7 +45,7 @@ function build(
   gcTools,
   console,
 ) {
-  const { WeakRef, FinalizationRegistry, waitUntilQuiescent } = gcTools;
+  const { WeakRef, FinalizationRegistry } = gcTools;
   const enableLSDebug = false;
   function lsdebug(...args) {
     if (enableLSDebug) {
@@ -176,6 +176,58 @@ function build(
     }
   }
   const droppedRegistry = new FinalizationRegistry(finalizeDroppedImport);
+
+  function processDroppedRepresentative(_vref) {
+    // no-op, to be implemented by virtual object manager
+    return false;
+  }
+
+  function processDeadSet() {
+    let doMore = false;
+    const [importsToDrop, importsToRetire, exportsToRetire] = [[], [], []];
+
+    for (const vref of deadSet) {
+      const { virtual, allocatedByVat, type } = parseVatSlot(vref);
+      assert(type === 'object', `unprepared to track ${type}`);
+      if (virtual) {
+        // Representative: send nothing, but perform refcount checking
+        doMore = doMore || processDroppedRepresentative(vref);
+      } else if (allocatedByVat) {
+        // Remotable: send retireExport
+        exportsToRetire.push(vref);
+      } else {
+        // Presence: send dropImport unless reachable by VOM
+        // eslint-disable-next-line no-lonely-if, no-use-before-define
+        if (!isVrefReachable(vref)) {
+          importsToDrop.push(vref);
+          // and retireExport if unrecognizable (TODO: needs
+          // VOM.vrefIsRecognizable)
+          // if (!vrefIsRecognizable(vref)) {
+          //   importsToRetire.push(vref);
+          // }
+        }
+      }
+    }
+    deadSet.clear();
+
+    if (importsToDrop.length) {
+      importsToDrop.sort();
+      syscall.dropImports(importsToDrop);
+    }
+    if (importsToRetire.length) {
+      importsToRetire.sort();
+      syscall.retireImports(importsToRetire);
+    }
+    if (exportsToRetire.length) {
+      exportsToRetire.sort();
+      syscall.retireExports(exportsToRetire);
+    }
+
+    // TODO: doMore=true when we've done something that might free more local
+    // objects, which probably won't happen until we sense entire WeakMaps
+    // going away or something involving virtual collections
+    return doMore;
+  }
 
   /** Remember disavowed Presences which will kill the vat if you try to talk
    * to them */
@@ -366,6 +418,7 @@ function build(
     makeKind,
     VirtualObjectAwareWeakMap,
     VirtualObjectAwareWeakSet,
+    isVrefReachable,
   } = makeVirtualObjectManager(
     syscall,
     allocateExportID,
@@ -906,6 +959,8 @@ function build(
     }
   }
 
+  const { waitUntilQuiescent, gcAndFinalize } = gcTools;
+
   /**
    * This low-level liveslots code is responsible for deciding when userspace
    * is done with a crank. Userspace code can use Promises, so it can add as
@@ -926,9 +981,23 @@ function build(
       .catch(err =>
         console.log(`liveslots error ${err} during delivery ${delivery}`),
       );
+
     // Instead, we wait for userspace to become idle by draining the promise
     // queue.
-    return waitUntilQuiescent();
+    await waitUntilQuiescent();
+    // Userspace will not get control again within this crank.
+
+    // Now that userspace is idle, we can drive GC until we think we've
+    // stopped.
+    async function finish() {
+      await gcAndFinalize();
+      const doMore = processDeadSet();
+      if (doMore) {
+        return finish();
+      }
+      return undefined;
+    }
+    return finish();
   }
   harden(dispatch);
 

--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -25,7 +25,7 @@ const DEFAULT_VIRTUAL_OBJECT_CACHE_SIZE = 3; // XXX ridiculously small value to 
  * @param {boolean} enableDisavow
  * @param {*} vatPowers
  * @param {*} vatParameters
- * @param {*} gcTools { WeakRef, FinalizationRegistry, waitUntilQuiescent }
+ * @param {*} gcTools { WeakRef, FinalizationRegistry, waitUntilQuiescent, gcAndFinalize }
  * @param {Console} console
  * @returns {*} { vatGlobals, inescapableGlobalProperties, dispatch, setBuildRootObject }
  *

--- a/packages/SwingSet/src/kernel/vatManager/manager-local.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-local.js
@@ -20,7 +20,6 @@ export function makeLocalVatManagerFactory(tools) {
     kernelSlog,
   } = tools;
 
-  const { waitUntilQuiescent } = gcTools;
   const { makeGetMeter, refillAllMeters, stopGlobalMeter } = meterManager;
   const baseVP = {
     makeMarshal: allVatPowers.makeMarshal,
@@ -42,7 +41,7 @@ export function makeLocalVatManagerFactory(tools) {
       assert.typeof(dispatch, 'function');
       // this 'deliverToWorker' never throws, even if liveslots has an internal error
       const deliverToWorker = makeMeteredDispatch(
-        makeSupervisorDispatch(dispatch, waitUntilQuiescent),
+        makeSupervisorDispatch(dispatch),
         mtools,
       );
       mk.setDeliverToWorker(deliverToWorker);

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-helper.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-helper.js
@@ -18,11 +18,9 @@ import '../../types';
  * manager process.
  *
  * @param { VatDispatcherSyncAsync } dispatch
- * @param { WaitUntilQuiescent } waitUntilQuiescent
  * @returns { VatDispatcher }
  */
-function makeSupervisorDispatch(dispatch, waitUntilQuiescent) {
-  assert.typeof(waitUntilQuiescent, 'function');
+function makeSupervisorDispatch(dispatch) {
   /**
    * @param { VatDeliveryObject } delivery
    * @returns { Promise<VatDeliveryResult> }

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-nodeworker.js
@@ -10,6 +10,7 @@ import { assert, details as X } from '@agoric/assert';
 import { importBundle } from '@agoric/import-bundle';
 import { makeMarshal } from '@agoric/marshal';
 import { WeakRef, FinalizationRegistry } from '../../weakref';
+import { gcAndFinalize } from '../../gc';
 import { waitUntilQuiescent } from '../../waitUntilQuiescent';
 import { makeLiveSlots } from '../liveSlots';
 import {
@@ -78,6 +79,7 @@ parentPort.on('message', ([type, ...margs]) => {
       WeakRef,
       FinalizationRegistry,
       waitUntilQuiescent,
+      gcAndFinalize,
     });
     const ls = makeLiveSlots(
       syscall,
@@ -102,7 +104,7 @@ parentPort.on('message', ([type, ...margs]) => {
         workerLog(`got vatNS:`, Object.keys(vatNS).join(','));
         sendUplink(['gotBundle']);
         ls.setBuildRootObject(vatNS.buildRootObject);
-        dispatch = makeSupervisorDispatch(ls.dispatch, waitUntilQuiescent);
+        dispatch = makeSupervisorDispatch(ls.dispatch);
         workerLog(`got dispatch:`, Object.keys(dispatch).join(','));
         sendUplink(['dispatchReady']);
       },

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-node.js
@@ -8,6 +8,7 @@ import { assert, details as X } from '@agoric/assert';
 import { importBundle } from '@agoric/import-bundle';
 import { makeMarshal } from '@agoric/marshal';
 import { WeakRef, FinalizationRegistry } from '../../weakref';
+import { gcAndFinalize } from '../../gc';
 import { arrayEncoderStream, arrayDecoderStream } from '../../worker-protocol';
 import {
   netstringEncoderStream,
@@ -91,6 +92,7 @@ fromParent.on('data', ([type, ...margs]) => {
       WeakRef,
       FinalizationRegistry,
       waitUntilQuiescent,
+      gcAndFinalize,
     });
     const ls = makeLiveSlots(
       syscall,

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
@@ -6,6 +6,7 @@ import { makeMarshal } from '@agoric/marshal';
 import '../../types';
 // grumble... waitUntilQuiescent is exported and closes over ambient authority
 import { waitUntilQuiescent } from '../../waitUntilQuiescent';
+import { gcAndFinalize } from '../../gc';
 import { insistVatDeliveryObject, insistVatSyscallResult } from '../../message';
 
 import { makeLiveSlots } from '../liveSlots';
@@ -184,6 +185,7 @@ function makeWorker(port) {
       WeakRef,
       FinalizationRegistry,
       waitUntilQuiescent,
+      gcAndFinalize,
     });
 
     const ls = makeLiveSlots(
@@ -213,7 +215,7 @@ function makeWorker(port) {
     workerLog(`got vatNS:`, Object.keys(vatNS).join(','));
     ls.setBuildRootObject(vatNS.buildRootObject);
     assert(ls.dispatch);
-    dispatch = makeSupervisorDispatch(ls.dispatch, waitUntilQuiescent);
+    dispatch = makeSupervisorDispatch(ls.dispatch);
     workerLog(`got dispatch`);
     return ['dispatchReady'];
   }

--- a/packages/SwingSet/test/liveslots-helpers.js
+++ b/packages/SwingSet/test/liveslots-helpers.js
@@ -1,5 +1,6 @@
 import { WeakRef, FinalizationRegistry } from '../src/weakref';
 import { waitUntilQuiescent } from '../src/waitUntilQuiescent';
+import { gcAndFinalize } from '../src/gc';
 import { makeLiveSlots } from '../src/kernel/liveSlots';
 
 export function buildSyscall() {
@@ -38,7 +39,12 @@ export function makeDispatch(
   vatID = 'vatA',
   enableDisavow = false,
 ) {
-  const gcTools = harden({ WeakRef, FinalizationRegistry, waitUntilQuiescent });
+  const gcTools = harden({
+    WeakRef,
+    FinalizationRegistry,
+    waitUntilQuiescent,
+    gcAndFinalize,
+  });
   const { setBuildRootObject, dispatch } = makeLiveSlots(
     syscall,
     vatID,

--- a/packages/SwingSet/test/test-liveslots.js
+++ b/packages/SwingSet/test/test-liveslots.js
@@ -811,12 +811,15 @@ function makeMockGC() {
     return allFRs;
   }
 
+  function mockGCAndFinalize() {}
+
   return harden({
     WeakRef: mockWeakRef,
     FinalizationRegistry: mockFinalizationRegistry,
     kill,
     getAllFRs,
     waitUntilQuiescent,
+    gcAndFinalize: mockGCAndFinalize,
   });
 }
 


### PR DESCRIPTION
Change liveslots to provoke GC at mid-crank, then process the "dead set" and
emit `syscall.dropImports` for everything we can.

For now, we conservatively assume that everything remains recognizable, so we
do *not* emit `syscall.retireImport` for anything. The vref might be used as
a WeakMap/WeakSet key, and the VOM isn't yet tracking those. When #3161 is
done, we'll change liveslots to ask the VOM about each vref, and retire the
ones it does not know how to recognize (which will hopefully be the majority
of them).

closes #3147
refs #2615
closes #2660

also closes #2243
