### PR TITLE
fix(swingset): activate `dispatch.dropExports`

### DIFF
--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -837,7 +837,14 @@ function build(
     assert(Array.isArray(vrefs));
     vrefs.map(vref => insistVatType('object', vref));
     vrefs.map(vref => assert(parseVatSlot(vref).allocatedByVat));
-    console.log(`-- liveslots ignoring dropExports`);
+    console.log(`-- liveslots acting upon dropExports`);
+    for (const vref of vrefs) {
+      const wr = slotToVal.get(vref);
+      const o = wr && wr.deref();
+      if (o) {
+        exportedRemotables.delete(o);
+      }
+    }
   }
 
   function retireExports(vrefs) {


### PR DESCRIPTION
Liveslots now reacts to dispatch.dropExports by dropping the strong
`exportedRemotables` reference, possibly allowing the Remotable to be
collected.

closes #3137