### PR TITLE
chore(vats): downgrade "cannot create fee collector" error message

### DIFF
--- a/packages/vats/src/bootstrap.js
+++ b/packages/vats/src/bootstrap.js
@@ -171,7 +171,7 @@ export function buildRootObject(vatPowers, vatParameters) {
         brand: centralBrand,
       })
       .catch(e => {
-        console.error('Cannot create fee collector', e);
+        console.log('Cannot create fee collector', e);
         return undefined;
       });
     if (feeCollectorDepositFacet) {


### PR DESCRIPTION
@michaelfig suggested that I downgrade the "Cannot create fee collector"
error message from `console.error` to `console.log`. It happens just after
the Bank vat throws a "Bank doesn't implement fee collectors" Error when its
`getFeeCollectorDepositFacet()` method is invoked. The Error is written to
stdio as soon as it's serialized (xsnap/SES does that with everything), and
we aren't changing that. This patch only changes a `console.error` that sat
in the `.catch()` clause on that message. But at least it removes one of the
15 lines from the log.