### PR TITLE
add block events to the slogfile

### DIFF
--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -315,6 +315,8 @@ export async function makeSwingsetController(
       kernel.log(str);
     },
 
+    writeSlogObject,
+
     dump() {
       return JSON.parse(JSON.stringify(kernel.dump()));
     },

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -161,7 +161,12 @@ export async function launch(
   }
 
   let bootstrapBlock;
-  async function endBlock(_blockHeight, _blockTime) {
+  async function endBlock(blockHeight, blockTime) {
+    controller.writeSlogObject({
+      type: 'cosmic-swingset-end-block-start',
+      blockHeight,
+      blockTime,
+    });
     let numCranks = FIXME_MAX_CRANKS_PER_BLOCK;
     if (bootstrapBlock) {
       // This is the initial block, we need to finish processing the entire
@@ -170,6 +175,11 @@ export async function launch(
       bootstrapBlock = false;
     }
     await crankScheduler(numCranks);
+    controller.writeSlogObject({
+      type: 'cosmic-swingset-end-block-finish',
+      blockHeight,
+      blockTime,
+    });
   }
 
   async function saveChainState() {
@@ -187,6 +197,11 @@ export async function launch(
 
   async function deliverInbound(sender, messages, ack) {
     assert(Array.isArray(messages), X`inbound given non-Array: ${messages}`);
+    controller.writeSlogObject({
+      type: 'cosmic-swingset-deliver-inbound',
+      sender,
+      count: messages.length,
+    });
     if (!mb.deliverInbound(sender, messages, ack)) {
       return;
     }
@@ -194,6 +209,10 @@ export async function launch(
   }
 
   async function doBridgeInbound(source, body) {
+    controller.writeSlogObject({
+      type: 'cosmic-swingset-bridge-inbound',
+      source,
+    });
     // console.log(`doBridgeInbound`);
     // the inbound bridge will push messages onto the kernel run-queue for
     // delivery+dispatch to some handler vat
@@ -201,6 +220,11 @@ export async function launch(
   }
 
   async function beginBlock(blockHeight, blockTime) {
+    controller.writeSlogObject({
+      type: 'cosmic-swingset-begin-block',
+      blockHeight,
+      blockTime,
+    });
     const addedToQueue = timer.poll(blockTime);
     console.debug(
       `polled; blockTime:${blockTime}, h:${blockHeight}; ADDED =`,


### PR DESCRIPTION
This adds several cosmic-swingset block-related events into the slogfile, which helps to correlate swingset cranks with cosmos/tendermint blocks.
