### PR TITLE
refactor(zoe): create instanceAdminStorage and move it into the zoeStorageManager

### DIFF
--- a/packages/zoe/src/instanceRecordStorage.js
+++ b/packages/zoe/src/instanceRecordStorage.js
@@ -59,8 +59,8 @@ export const makeInstanceRecordStorage = () => {
     };
   };
 
-  /** @type {ExportInstanceRecord} */
-  const exportInstanceRecord = () => {
+  /** @type {GetInstanceRecord} */
+  const getInstanceRecord = () => {
     assertInstantiated();
     return harden(instanceRecord);
   };
@@ -96,7 +96,7 @@ export const makeInstanceRecordStorage = () => {
 
   return harden({
     addIssuerToInstanceRecord,
-    exportInstanceRecord,
+    getInstanceRecord,
     getTerms,
     getIssuers,
     getBrands,

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -178,7 +178,7 @@
  * @param {Issuer} invitationIssuer
  * @param {ZoeInstanceAdmin} zoeInstanceAdmin
  * @param {InstanceRecord} instanceRecord
- * @param {ExportedIssuerStorage} issuerStorageFromZoe
+ * @param {IssuerRecords} issuerStorageFromZoe
  * @returns {Promise<ExecuteContractResult>}
  *
  */
@@ -232,7 +232,7 @@
  */
 
 /**
- * @typedef {Array<IssuerRecord>} ExportedIssuerStorage
+ * @typedef {Array<IssuerRecord>} IssuerRecords
  */
 
 /**
@@ -257,13 +257,13 @@
  */
 
 /**
- * 
+ *
  * @callback CreateSeatManager
  * The SeatManager holds the active zcfSeats and seatStagings and can
  * reallocate and make new zcfSeats.
  *
- * @param {ZoeInstanceAdmin} zoeInstanceAdmin 
- * @param {GetAssetKindByBrand} getAssetKindByBrand 
+ * @param {ZoeInstanceAdmin} zoeInstanceAdmin
+ * @param {GetAssetKindByBrand} getAssetKindByBrand
  * @returns {{ makeZCFSeat: MakeZCFSeat,
     reallocate: Reallocate,
     reallocateInternal: ReallocateInternal,
@@ -288,7 +288,7 @@
 /**
  * @typedef {Object} InstanceRecordManager
  * @property {AddIssuerToInstanceRecord} addIssuerToInstanceRecord
- * @property {ExportInstanceRecord} exportInstanceRecord
+ * @property {GetInstanceRecord} getInstanceRecord
  * @property {InstanceRecordManagerGetTerms} getTerms
  * @property {InstanceRecordGetIssuers} getIssuers
  * @property {InstanceRecordGetBrands} getBrands
@@ -297,12 +297,12 @@
  */
 
 /**
- * @callback ExportInstanceRecord
+ * @callback GetInstanceRecord
  * @returns {InstanceRecord}
  */
 
 /**
- * @callback IssuerStorageExportIssuerStorage
+ * @callback IssuerStorageGetIssuerRecords
  * @param {Issuer[]} issuers
- * @returns {ExportedIssuerStorage}
+ * @returns {IssuerRecords}
  */

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -302,7 +302,7 @@
  */
 
 /**
- * @callback ExportIssuerStorage
+ * @callback IssuerStorageExportIssuerStorage
  * @param {Issuer[]} issuers
  * @returns {ExportedIssuerStorage}
  */

--- a/packages/zoe/src/issuerStorage.js
+++ b/packages/zoe/src/issuerStorage.js
@@ -175,7 +175,7 @@ export const makeIssuerStorage = () => {
     return brandToIssuerRecord.get(brand).issuer;
   };
 
-  /** @type {ExportIssuerStorage} */
+  /** @type {IssuerStorageExportIssuerStorage} */
   const exportIssuerStorage = issuers => {
     assertInstantiated();
     return issuers.map(issuerToIssuerRecord.get);

--- a/packages/zoe/src/issuerStorage.js
+++ b/packages/zoe/src/issuerStorage.js
@@ -175,19 +175,19 @@ export const makeIssuerStorage = () => {
     return brandToIssuerRecord.get(brand).issuer;
   };
 
-  /** @type {IssuerStorageExportIssuerStorage} */
-  const exportIssuerStorage = issuers => {
+  /** @type {IssuerStorageGetIssuerRecords} */
+  const getIssuerRecords = issuers => {
     assertInstantiated();
     return issuers.map(issuerToIssuerRecord.get);
   };
 
-  const instantiate = (exportedIssuerStorage = []) => {
+  const instantiate = (issuerRecords = []) => {
     assert(
       instantiated === false,
       X`issuerStorage can only be instantiated once`,
     );
     instantiated = true;
-    exportedIssuerStorage.forEach(storeIssuerRecord);
+    issuerRecords.forEach(storeIssuerRecord);
   };
 
   return {
@@ -197,7 +197,7 @@ export const makeIssuerStorage = () => {
     getAssetKindByBrand,
     getBrandForIssuer,
     getIssuerForBrand,
-    exportIssuerStorage,
+    getIssuerRecords,
     instantiate,
   };
 };

--- a/packages/zoe/src/zoeService/instanceAdminStorage.js
+++ b/packages/zoe/src/zoeService/instanceAdminStorage.js
@@ -1,0 +1,33 @@
+// @ts-check
+
+import { makeWeakStore as makeNonVOWeakStore } from '@agoric/store';
+
+export const makeInstanceAdminStorage = () => {
+  /** @type {WeakStore<Instance,InstanceAdmin>} */
+  const instanceToInstanceAdmin = makeNonVOWeakStore('instance');
+
+  /** @type {GetPublicFacet} */
+  const getPublicFacet = instance =>
+    instanceToInstanceAdmin.get(instance).getPublicFacet();
+
+  /** @type {GetBrands} */
+  const getBrands = instance =>
+    instanceToInstanceAdmin.get(instance).getBrands();
+
+  /** @type {GetIssuers} */
+  const getIssuers = instance =>
+    instanceToInstanceAdmin.get(instance).getIssuers();
+
+  /** @type {GetTerms} */
+  const getTerms = instance => instanceToInstanceAdmin.get(instance).getTerms();
+
+  return harden({
+    getPublicFacet,
+    getBrands,
+    getIssuers,
+    getTerms,
+    getInstanceAdmin: instanceToInstanceAdmin.get,
+    initInstanceAdmin: instanceToInstanceAdmin.init,
+    deleteInstanceAdmin: instanceToInstanceAdmin.delete,
+  });
+};

--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -27,3 +27,80 @@
  * @param {PaymentPKeywordRecord} payments
  * @returns {Promise<Allocation>}
  */
+
+/**
+ * @callback InitInstanceAdmin
+ * @param {Instance} instance
+ * @param {InstanceAdmin} InstanceAdmin
+ * @returns {void}
+ */
+
+/**
+ * @callback GetInstanceAdmin
+ * @param {Instance} instance
+ * @returns {InstanceAdmin}
+ */
+
+/**
+ * @callback DeleteInstanceAdmin
+ * @param {Instance} instance
+ * @returns {void}
+ */
+
+/**
+ * @callback UnwrapInstallation
+ *
+ * Assert the installation is known, and return the bundle and
+ * installation
+ *
+ * @param {ERef<Installation>} installationP
+ * @returns {Promise<{ bundle: SourceBundle, installation:
+ * Installation }>}
+ */
+
+/**
+ * @callback ExportIssuerStorage
+ * @returns {ExportedIssuerStorage}
+ */
+
+/**
+ * @typedef {Object} ZoeInstanceStorageManager
+ * @property {InstanceRecordManagerGetTerms} getTerms
+ * @property {InstanceRecordGetIssuers} getIssuers
+ * @property {InstanceRecordGetBrands} getBrands
+ * @property {SaveIssuer} saveIssuer
+ * @property {MakeZoeMint} makeZoeMint
+ * @property {ExportInstanceRecord} exportInstanceRecord
+ * @property {ExportIssuerStorage} exportIssuerStorage
+ * @property {WithdrawPayments} withdrawPayments
+ * @property {InitInstanceAdmin} initInstanceAdmin
+ * @property {DeleteInstanceAdmin} deleteInstanceAdmin
+ */
+
+/**
+ * Create a storage manager for a particular contract instance. The
+ * ZoeInstanceStorageManager encapsulates access to the
+ * issuerStorage and escrowStorage from Zoe, and stores the
+ * instance-specific terms
+ *
+ * @callback MakeZoeInstanceStorageManager
+ * @param {Installation} installation
+ * @param {Object} customTerms
+ * @param {IssuerKeywordRecord} uncleanIssuerKeywordRecord
+ * @param {Instance} instance
+ * @returns {ZoeInstanceStorageManager}
+ */
+
+/**
+ * @typedef ZoeStorageManager
+ * @property {MakeZoeInstanceStorageManager} makeZoeInstanceStorageManager
+ * @property {GetAssetKindByBrand} getAssetKindByBrand
+ * @property {DepositPayments} depositPayments
+ * @property {Install} install
+ * @property {GetPublicFacet} getPublicFacet
+ * @property {GetBrands} getBrands
+ * @property {GetIssuers} getIssuers
+ * @property {GetTerms} getTerms
+ * @property {GetInstanceAdmin} getInstanceAdmin
+ * @property {UnwrapInstallation} unwrapInstallation
+ */

--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -59,8 +59,8 @@
  */
 
 /**
- * @callback ExportIssuerStorage
- * @returns {ExportedIssuerStorage}
+ * @callback GetIssuerRecords
+ * @returns {IssuerRecords}
  */
 
 /**
@@ -70,8 +70,8 @@
  * @property {InstanceRecordGetBrands} getBrands
  * @property {SaveIssuer} saveIssuer
  * @property {MakeZoeMint} makeZoeMint
- * @property {ExportInstanceRecord} exportInstanceRecord
- * @property {ExportIssuerStorage} exportIssuerStorage
+ * @property {GetInstanceRecord} getInstanceRecord
+ * @property {GetIssuerRecords} getIssuerRecords
  * @property {WithdrawPayments} withdrawPayments
  * @property {InitInstanceAdmin} initInstanceAdmin
  * @property {DeleteInstanceAdmin} deleteInstanceAdmin

--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -54,8 +54,10 @@
  * installation
  *
  * @param {ERef<Installation>} installationP
- * @returns {Promise<{ bundle: SourceBundle, installation:
- * Installation }>}
+ * @returns {Promise<{
+ *   bundle: SourceBundle,
+ *   installation:Installation
+ * }>}
  */
 
 /**

--- a/packages/zoe/src/zoeService/offer/offer.js
+++ b/packages/zoe/src/zoeService/offer/offer.js
@@ -10,14 +10,14 @@ import '../internal-types';
 
 /**
  * @param {Issuer} invitationIssuer
- * @param {WeakStore<Instance,InstanceAdmin>} instanceToInstanceAdmin
+ * @param {GetInstanceAdmin} getInstanceAdmin
  * @param {DepositPayments} depositPayments
  * @param {GetAssetKindByBrand} getAssetKindByBrand
  * @returns {Offer}
  */
 export const makeOffer = (
   invitationIssuer,
-  instanceToInstanceAdmin,
+  getInstanceAdmin,
   depositPayments,
   getAssetKindByBrand,
 ) => {
@@ -32,7 +32,7 @@ export const makeOffer = (
       invitation,
     );
     // AWAIT ///
-    const instanceAdmin = instanceToInstanceAdmin.get(instanceHandle);
+    const instanceAdmin = getInstanceAdmin(instanceHandle);
     instanceAdmin.assertAcceptingOffers();
 
     const proposal = cleanProposal(uncleanProposal, getAssetKindByBrand);

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -95,8 +95,8 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
         getBrands: getInstanceBrands,
         saveIssuer,
         makeZoeMint,
-        exportInstanceRecord,
-        exportIssuerStorage,
+        getInstanceRecord,
+        getIssuerRecords,
         withdrawPayments,
         initInstanceAdmin,
       } = await makeZoeInstanceStorageManager(
@@ -273,8 +273,8 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
         zoeService,
         invitationIssuer,
         zoeInstanceAdminForZcf,
-        exportInstanceRecord(),
-        exportIssuerStorage(),
+        getInstanceRecord(),
+        getIssuerRecords(),
       );
 
       handleOfferObjPromiseKit.resolve(handleOfferObj);

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -138,16 +138,14 @@ export const makeZoeStorageManager = () => {
       return zoeMint;
     };
 
-    /** @type {ExportIssuerStorage} */
-    const exportIssuerStorage = () =>
-      issuerStorage.exportIssuerStorage(
+    /** @type {GetIssuerRecords} */
+    const getIssuerRecords = () =>
+      issuerStorage.getIssuerRecords(
         // the issuerStorage is a weakStore, so we cannot iterate over
         // it directly. Additionally, we only want to export the
         // issuers used in this contract instance specifically, not
         // all issuers.
-        Object.values(
-          instanceRecordManager.exportInstanceRecord().terms.issuers,
-        ),
+        Object.values(instanceRecordManager.getInstanceRecord().terms.issuers),
       );
 
     return harden({
@@ -156,8 +154,8 @@ export const makeZoeStorageManager = () => {
       getBrands: instanceRecordManager.getBrands,
       saveIssuer,
       makeZoeMint,
-      exportInstanceRecord: instanceRecordManager.exportInstanceRecord,
-      exportIssuerStorage,
+      getInstanceRecord: instanceRecordManager.getInstanceRecord,
+      getIssuerRecords,
       withdrawPayments: escrowStorage.withdrawPayments,
       initInstanceAdmin,
       deleteInstanceAdmin,

--- a/packages/zoe/test/unitTests/test-instanceStorage.js
+++ b/packages/zoe/test/unitTests/test-instanceStorage.js
@@ -41,7 +41,7 @@ test('makeAndStoreInstanceRecord', async t => {
   });
   const {
     addIssuerToInstanceRecord,
-    exportInstanceRecord,
+    getInstanceRecord,
     getTerms,
     getIssuers,
     getBrands,
@@ -53,7 +53,7 @@ test('makeAndStoreInstanceRecord', async t => {
     brands,
   );
 
-  t.deepEqual(exportInstanceRecord(), {
+  t.deepEqual(getInstanceRecord(), {
     installation: fakeInstallation,
     terms: { time: 2n, issuers, brands },
   });
@@ -92,7 +92,7 @@ test('makeInstanceRecordStorage', async t => {
   });
   const {
     addIssuerToInstanceRecord,
-    exportInstanceRecord,
+    getInstanceRecord,
     getTerms,
     getIssuers,
     getBrands,
@@ -104,7 +104,7 @@ test('makeInstanceRecordStorage', async t => {
     terms: { time: 2n, issuers, brands },
   });
 
-  t.deepEqual(exportInstanceRecord(), {
+  t.deepEqual(getInstanceRecord(), {
     installation: fakeInstallation,
     terms: { time: 2n, issuers, brands },
   });

--- a/packages/zoe/test/unitTests/test-issuerStorage.js
+++ b/packages/zoe/test/unitTests/test-issuerStorage.js
@@ -177,8 +177,8 @@ test('getIssuerForBrand', async t => {
   t.is(currencyKit.issuer, getIssuerForBrand(currencyKit.brand));
 });
 
-test('exportIssuerStorage', async t => {
-  const { storeIssuer, exportIssuerStorage, instantiate } = makeIssuerStorage();
+test('getIssuerRecords', async t => {
+  const { storeIssuer, getIssuerRecords, instantiate } = makeIssuerStorage();
   instantiate();
   const { currencyKit, ticketKit } = setupIssuersForTest();
 
@@ -186,13 +186,13 @@ test('exportIssuerStorage', async t => {
   await storeIssuer(ticketKit.issuer);
 
   // Note that only the currencyIssuer is going to be exported
-  const exportedIssuerStorage = exportIssuerStorage([currencyKit.issuer]);
+  const issuerRecords = getIssuerRecords([currencyKit.issuer]);
 
-  t.deepEqual(exportedIssuerStorage, [currencyIssuerRecord]);
+  t.deepEqual(issuerRecords, [currencyIssuerRecord]);
 });
 
-test('use exportedIssuerStorage', async t => {
-  const { storeIssuer, exportIssuerStorage, instantiate } = makeIssuerStorage();
+test('use issuerRecords', async t => {
+  const { storeIssuer, getIssuerRecords, instantiate } = makeIssuerStorage();
   instantiate();
   const { currencyKit, ticketKit } = setupIssuersForTest();
 
@@ -200,17 +200,17 @@ test('use exportedIssuerStorage', async t => {
   await storeIssuer(ticketKit.issuer);
 
   // Note that only the currencyIssuer is going to be exported
-  const exportedIssuerStorage = exportIssuerStorage([currencyKit.issuer]);
+  const issuerRecords = getIssuerRecords([currencyKit.issuer]);
 
-  t.deepEqual(exportedIssuerStorage, [currencyIssuerRecord]);
+  t.deepEqual(issuerRecords, [currencyIssuerRecord]);
 
   // SecondIssuerStorage
   const {
-    exportIssuerStorage: exportIssuerStorage2,
+    getIssuerRecords: getIssuerRecords2,
     instantiate: instantiate2,
   } = makeIssuerStorage();
-  instantiate2(exportedIssuerStorage);
+  instantiate2(issuerRecords);
 
-  const exportedIssuerStorage2 = exportIssuerStorage2([currencyKit.issuer]);
+  const exportedIssuerStorage2 = getIssuerRecords2([currencyKit.issuer]);
   t.deepEqual(exportedIssuerStorage2, [currencyIssuerRecord]);
 });

--- a/packages/zoe/test/unitTests/zoe/test-instanceAdminStorage.js
+++ b/packages/zoe/test/unitTests/zoe/test-instanceAdminStorage.js
@@ -1,0 +1,85 @@
+// @ts-check
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+
+import { Far } from '@agoric/marshal';
+
+import { makeInstanceAdminStorage } from '../../../src/zoeService/instanceAdminStorage';
+
+test('makeInstanceAdminStorage', async t => {
+  const {
+    getPublicFacet,
+    getBrands,
+    getIssuers,
+    getTerms,
+    getInstanceAdmin,
+    initInstanceAdmin,
+    deleteInstanceAdmin,
+  } = makeInstanceAdminStorage();
+
+  const mockInstance1 = Far('mockInstance1', {});
+  const mockInstance2 = Far('mockInstance2', {});
+  const mockInstanceAdmin1 = Far('mockInstanceAdmin1', {
+    getPublicFacet: () => 'publicFacet1',
+    getBrands: () => 'brands1',
+    getIssuers: () => 'issuers1',
+    getTerms: () => 'terms1',
+  });
+  const mockInstanceAdmin2 = Far('mockInstanceAdmin2', {
+    getPublicFacet: () => 'publicFacet2',
+    getBrands: () => 'brands2',
+    getIssuers: () => 'issuers2',
+    getTerms: () => 'terms2',
+  });
+
+  // @ts-ignore instance is mocked
+  initInstanceAdmin(mockInstance1, mockInstanceAdmin1);
+
+  // @ts-ignore instance is mocked
+  initInstanceAdmin(mockInstance2, mockInstanceAdmin2);
+
+  // @ts-ignore instance is mocked
+  t.is(getInstanceAdmin(mockInstance1), mockInstanceAdmin1);
+
+  // @ts-ignore instance is mocked
+  t.is(getPublicFacet(mockInstance1), 'publicFacet1');
+
+  // @ts-ignore instance is mocked
+  t.is(getBrands(mockInstance2), 'brands2');
+
+  // @ts-ignore instance is mocked
+  t.is(getIssuers(mockInstance1), 'issuers1');
+
+  // @ts-ignore instance is mocked
+  t.is(getTerms(mockInstance1), 'terms1');
+
+  // @ts-ignore instance is mocked
+  deleteInstanceAdmin(mockInstance2);
+
+  // @ts-ignore instance is mocked
+  t.throws(() => getInstanceAdmin(mockInstance2), {
+    message: '"instance" not found: "[Alleged: mockInstance2]"',
+  });
+
+  // @ts-ignore instance is mocked
+  t.throws(() => getPublicFacet(mockInstance2), {
+    message: '"instance" not found: "[Alleged: mockInstance2]"',
+  });
+});
+
+test('add another instance admin for same instance', async t => {
+  const { initInstanceAdmin } = makeInstanceAdminStorage();
+
+  const mockInstance1 = Far('mockInstance1', {});
+  const mockInstanceAdmin1 = Far('mockInstanceAdmin1', {});
+  const mockInstanceAdmin2 = Far('mockInstanceAdmin2', {});
+
+  // @ts-ignore instance is mocked
+  initInstanceAdmin(mockInstance1, mockInstanceAdmin1);
+
+  // @ts-ignore instance is mocked
+  t.throws(() => initInstanceAdmin(mockInstance1, mockInstanceAdmin2), {
+    message: '"instance" already registered: "[Alleged: mockInstance1]"',
+  });
+});


### PR DESCRIPTION
This is a small PR that moves the logic of storing instanceAdmins to a separate file. The payoff for this will come later, when we move the `startInstance` method code to a different file and zoe.js is very short and clean. 

Also added comments and more types.