### PR TITLE
refactor(zoe): severely restrict access to vatAdminSvc

### DIFF
--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -36,7 +36,7 @@
  * @property {(completion: Completion) => void} shutdown
  * @property {(reason: TerminationReason) => void} shutdownWithFailure
  * @property {Assert} assert
- * @property {() => ZoeService} getZoeService
+ * @property {() => ERef<ZoeService>} getZoeService
  * @property {() => Issuer} getInvitationIssuer
  * @property {() => Terms} getTerms
  * @property {(issuer: Issuer) => Brand} getBrandForIssuer

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -174,7 +174,7 @@
  *
  * @callback ExecuteContract
  * @param {SourceBundle} bundle
- * @param {ZoeService} zoeService
+ * @param {Promise<ZoeService>} zoeServicePromise
  * @param {Issuer} invitationIssuer
  * @param {ZoeInstanceAdmin} zoeInstanceAdmin
  * @param {InstanceRecord} instanceRecord

--- a/packages/zoe/src/zoeService/createZCFVat.js
+++ b/packages/zoe/src/zoeService/createZCFVat.js
@@ -1,0 +1,20 @@
+import { E } from '@agoric/eventual-send';
+
+import zcfContractBundle from '../../bundles/bundle-contractFacet';
+
+/**
+ * Attenuate the power of vatAdminSvc by restricting it such that only
+ * ZCF Vats can be created.
+ *
+ * @param {VatAdminSvc} vatAdminSvc
+ * @param {string=} zcfBundleName
+ * @returns {CreateZCFVat}
+ */
+export const setupCreateZCFVat = (vatAdminSvc, zcfBundleName) => {
+  /** @type {CreateZCFVat} */
+  const createZCFVat = () =>
+    zcfBundleName
+      ? E(vatAdminSvc).createVatByName(zcfBundleName)
+      : E(vatAdminSvc).createVat(zcfContractBundle);
+  return createZCFVat;
+};

--- a/packages/zoe/src/zoeService/createZCFVat.js
+++ b/packages/zoe/src/zoeService/createZCFVat.js
@@ -10,10 +10,10 @@ import zcfContractBundle from '../../bundles/bundle-contractFacet';
  * @param {string=} zcfBundleName
  * @returns {CreateZCFVat}
  */
-export const setupCreateZCFVat = (vatAdminSvc, zcfBundleName) => {
+export const setupCreateZCFVat = (vatAdminSvc, zcfBundleName = undefined) => {
   /** @type {CreateZCFVat} */
   const createZCFVat = () =>
-    zcfBundleName
+    typeof zcfBundleName === 'string'
       ? E(vatAdminSvc).createVatByName(zcfBundleName)
       : E(vatAdminSvc).createVat(zcfContractBundle);
   return createZCFVat;

--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -77,6 +77,7 @@
  * @property {WithdrawPayments} withdrawPayments
  * @property {InitInstanceAdmin} initInstanceAdmin
  * @property {DeleteInstanceAdmin} deleteInstanceAdmin
+ * @property {CreateZCFVat} createZCFVat
  */
 
 /**

--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -78,6 +78,8 @@
  * @property {InitInstanceAdmin} initInstanceAdmin
  * @property {DeleteInstanceAdmin} deleteInstanceAdmin
  * @property {CreateZCFVat} createZCFVat
+ * @property {ZoeInstanceAdminMakeInvitation} makeInvitation
+ * @property {Issuer} invitationIssuer
  */
 
 /**
@@ -99,6 +101,7 @@
  * @property {MakeZoeInstanceStorageManager} makeZoeInstanceStorageManager
  * @property {GetAssetKindByBrand} getAssetKindByBrand
  * @property {DepositPayments} depositPayments
+ * @property {Issuer} invitationIssuer
  * @property {Install} install
  * @property {GetPublicFacet} getPublicFacet
  * @property {GetBrands} getBrands

--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -106,3 +106,11 @@
  * @property {GetInstanceAdmin} getInstanceAdmin
  * @property {UnwrapInstallation} unwrapInstallation
  */
+
+/**
+ * Use VatAdminSvc to create a new vat, but only with the code of the
+ * ZCF bundle
+ *
+ * @callback CreateZCFVat
+ * @returns {Promise<RootAndAdminNode>}
+ */

--- a/packages/zoe/src/zoeService/makeInvitation.js
+++ b/packages/zoe/src/zoeService/makeInvitation.js
@@ -26,6 +26,13 @@ export const createInvitationKit = () => {
         'string',
         X`The description ${description} must be a string`,
       );
+      // If the contract-provided customProperties include the
+      // properties 'description', 'handle', 'instance' and
+      // 'installation', their corresponding values will be
+      // overwritten with the actual values. For example, the value
+      // for `instance` will always be the actual instance for the
+      // contract, even if customProperties includes a property called
+      // `instance`.
       const invitationAmount = AmountMath.make(invitationKit.brand, [
         {
           ...customProperties,

--- a/packages/zoe/src/zoeService/makeInvitation.js
+++ b/packages/zoe/src/zoeService/makeInvitation.js
@@ -1,0 +1,47 @@
+// @ts-check
+import { assert, details as X } from '@agoric/assert';
+import { AmountMath, makeIssuerKit, AssetKind } from '@agoric/ertp';
+
+export const createInvitationKit = () => {
+  const invitationKit = makeIssuerKit('Zoe Invitation', AssetKind.SET);
+
+  /**
+   * @param {Instance} instance
+   * @param {Installation} installation
+   * @returns {ZoeInstanceAdminMakeInvitation}
+   */
+  const setupMakeInvitation = (instance, installation) => {
+    assert.typeof(instance, 'object');
+    assert.typeof(installation, 'object');
+
+    /** @type {ZoeInstanceAdminMakeInvitation} */
+    const makeInvitation = (
+      invitationHandle,
+      description,
+      customProperties,
+    ) => {
+      assert.typeof(invitationHandle, 'object');
+      assert.typeof(
+        description,
+        'string',
+        X`The description ${description} must be a string`,
+      );
+      const invitationAmount = AmountMath.make(invitationKit.brand, [
+        {
+          ...customProperties,
+          description,
+          handle: invitationHandle,
+          instance,
+          installation,
+        },
+      ]);
+      return invitationKit.mint.mintPayment(invitationAmount);
+    };
+    return makeInvitation;
+  };
+
+  return harden({
+    setupMakeInvitation,
+    invitationIssuer: invitationKit.issuer,
+  });
+};

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -1,0 +1,225 @@
+// @ts-check
+
+import { assert, details as X } from '@agoric/assert';
+import { E } from '@agoric/eventual-send';
+import { makePromiseKit } from '@agoric/promise-kit';
+import { makeWeakStore as makeNonVOWeakStore } from '@agoric/store';
+import { Far } from '@agoric/marshal';
+
+import { makeZoeSeatAdminKit } from './zoeSeat';
+import { makeHandle } from '../makeHandle';
+import { handlePKitWarning } from '../handleWarning';
+
+/**
+ * @param {Promise<ZoeService>} zoeServicePromise
+ * @param {MakeZoeInstanceStorageManager} makeZoeInstanceStorageManager
+ * @param {UnwrapInstallation} unwrapInstallation
+ * @returns {StartInstance}
+ */
+export const makeStartInstance = (
+  zoeServicePromise,
+  makeZoeInstanceStorageManager,
+  unwrapInstallation,
+) => {
+  /** @type {StartInstance} */
+  const startInstance = async (
+    installationP,
+    uncleanIssuerKeywordRecord = harden({}),
+    customTerms = harden({}),
+  ) => {
+    /** @type {WeakStore<SeatHandle, ZoeSeatAdmin>} */
+    const seatHandleToZoeSeatAdmin = makeNonVOWeakStore('seatHandle');
+
+    const { installation, bundle } = await unwrapInstallation(installationP);
+    // AWAIT ///
+
+    const instance = makeHandle('Instance');
+
+    const zoeInstanceStorageManager = await makeZoeInstanceStorageManager(
+      installation,
+      customTerms,
+      uncleanIssuerKeywordRecord,
+      instance,
+    );
+    // AWAIT ///
+
+    const { adminNode, root } = await zoeInstanceStorageManager.createZCFVat();
+    /** @type {ZCFRoot} */
+    const zcfRoot = root;
+
+    /** @type {PromiseRecord<HandleOfferObj>} */
+    const handleOfferObjPromiseKit = makePromiseKit();
+    handlePKitWarning(handleOfferObjPromiseKit);
+    const publicFacetPromiseKit = makePromiseKit();
+    handlePKitWarning(publicFacetPromiseKit);
+
+    const makeInstanceAdmin = () => {
+      /** @type {Set<ZoeSeatAdmin>} */
+      const zoeSeatAdmins = new Set();
+      let acceptingOffers = true;
+
+      const exitZoeSeatAdmin = zoeSeatAdmin =>
+        zoeSeatAdmins.delete(zoeSeatAdmin);
+      const hasExited = zoeSeatAdmin => !zoeSeatAdmins.has(zoeSeatAdmin);
+
+      /** @type {InstanceAdmin} */
+      const instanceAdmin = Far('instanceAdmin', {
+        getPublicFacet: () => publicFacetPromiseKit.promise,
+        getTerms: zoeInstanceStorageManager.getTerms,
+        getIssuers: zoeInstanceStorageManager.getIssuers,
+        getBrands: zoeInstanceStorageManager.getBrands,
+        getInstance: () => instance,
+        assertAcceptingOffers: () => {
+          assert(acceptingOffers, `No further offers are accepted`);
+        },
+        exitAllSeats: completion => {
+          acceptingOffers = false;
+          zoeSeatAdmins.forEach(zoeSeatAdmin => zoeSeatAdmin.exit(completion));
+        },
+        failAllSeats: reason => {
+          acceptingOffers = false;
+          zoeSeatAdmins.forEach(zoeSeatAdmin => zoeSeatAdmin.fail(reason));
+        },
+        stopAcceptingOffers: () => (acceptingOffers = false),
+        makeUserSeat: (invitationHandle, initialAllocation, proposal) => {
+          const offerResultPromiseKit = makePromiseKit();
+          handlePKitWarning(offerResultPromiseKit);
+          const exitObjPromiseKit = makePromiseKit();
+          handlePKitWarning(exitObjPromiseKit);
+          const seatHandle = makeHandle('SeatHandle');
+
+          const { userSeat, notifier, zoeSeatAdmin } = makeZoeSeatAdminKit(
+            initialAllocation,
+            exitZoeSeatAdmin,
+            hasExited,
+            proposal,
+            zoeInstanceStorageManager.withdrawPayments,
+            exitObjPromiseKit.promise,
+            offerResultPromiseKit.promise,
+          );
+
+          seatHandleToZoeSeatAdmin.init(seatHandle, zoeSeatAdmin);
+
+          const seatData = harden({
+            proposal,
+            initialAllocation,
+            notifier,
+            seatHandle,
+          });
+
+          zoeSeatAdmins.add(zoeSeatAdmin);
+
+          E(handleOfferObjPromiseKit.promise)
+            .handleOffer(invitationHandle, zoeSeatAdmin, seatData)
+            .then(({ offerResultP, exitObj }) => {
+              offerResultPromiseKit.resolve(offerResultP);
+              exitObjPromiseKit.resolve(exitObj);
+            });
+
+          // return the userSeat before the offerHandler is called
+          return userSeat;
+        },
+        makeNoEscrowSeat: (
+          initialAllocation,
+          proposal,
+          exitObj,
+          seatHandle,
+        ) => {
+          const { userSeat, notifier, zoeSeatAdmin } = makeZoeSeatAdminKit(
+            initialAllocation,
+            exitZoeSeatAdmin,
+            hasExited,
+            proposal,
+            zoeInstanceStorageManager.withdrawPayments,
+            exitObj,
+          );
+          zoeSeatAdmins.add(zoeSeatAdmin);
+          seatHandleToZoeSeatAdmin.init(seatHandle, zoeSeatAdmin);
+          return { userSeat, notifier, zoeSeatAdmin };
+        },
+      });
+      return instanceAdmin;
+    };
+
+    const instanceAdmin = makeInstanceAdmin();
+    zoeInstanceStorageManager.initInstanceAdmin(instance, instanceAdmin);
+
+    E(adminNode)
+      .done()
+      .then(
+        completion => instanceAdmin.exitAllSeats(completion),
+        reason => instanceAdmin.failAllSeats(reason),
+      );
+
+    /** @type {ZoeInstanceAdmin} */
+    const zoeInstanceAdminForZcf = Far('zoeInstanceAdminForZcf', {
+      makeInvitation: zoeInstanceStorageManager.makeInvitation,
+      // checks of keyword done on zcf side
+      saveIssuer: zoeInstanceStorageManager.saveIssuer,
+      // A Seat requested by the contract without any payments to escrow
+      makeNoEscrowSeat: instanceAdmin.makeNoEscrowSeat,
+      exitAllSeats: completion => instanceAdmin.exitAllSeats(completion),
+      failAllSeats: reason => instanceAdmin.failAllSeats(reason),
+      makeZoeMint: zoeInstanceStorageManager.makeZoeMint,
+      replaceAllocations: seatHandleAllocations => {
+        seatHandleAllocations.forEach(({ seatHandle, allocation }) => {
+          const zoeSeatAdmin = seatHandleToZoeSeatAdmin.get(seatHandle);
+          zoeSeatAdmin.replaceAllocation(allocation);
+        });
+      },
+      stopAcceptingOffers: () => instanceAdmin.stopAcceptingOffers(),
+    });
+
+    // At this point, the contract will start executing. All must be
+    // ready
+
+    const {
+      creatorFacet = Far('emptyCreatorFacet', {}),
+      publicFacet = Far('emptyPublicFacet', {}),
+      creatorInvitation: creatorInvitationP,
+      handleOfferObj,
+    } = await E(zcfRoot).executeContract(
+      bundle,
+      zoeServicePromise,
+      zoeInstanceStorageManager.invitationIssuer,
+      zoeInstanceAdminForZcf,
+      zoeInstanceStorageManager.getInstanceRecord(),
+      zoeInstanceStorageManager.getIssuerRecords(),
+    );
+
+    handleOfferObjPromiseKit.resolve(handleOfferObj);
+    publicFacetPromiseKit.resolve(publicFacet);
+
+    // creatorInvitation can be undefined, but if it is defined,
+    // let's make sure it is an invitation.
+    return Promise.allSettled([
+      creatorInvitationP,
+      zoeInstanceStorageManager.invitationIssuer.isLive(creatorInvitationP),
+    ]).then(([invitationResult, isLiveResult]) => {
+      let creatorInvitation;
+      if (invitationResult.status === 'fulfilled') {
+        creatorInvitation = invitationResult.value;
+      }
+      if (creatorInvitation !== undefined) {
+        assert(
+          isLiveResult.status === 'fulfilled' && isLiveResult.value,
+          X`The contract did not correctly return a creatorInvitation`,
+        );
+      }
+      const adminFacet = Far('adminFacet', {
+        getVatShutdownPromise: () => E(adminNode).done(),
+        getVatStats: () => E(adminNode).adminData(),
+      });
+
+      // Actually returned to the user.
+      return {
+        creatorFacet,
+        creatorInvitation,
+        instance,
+        publicFacet,
+        adminFacet,
+      };
+    });
+  };
+  return startInstance;
+};

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -1,16 +1,13 @@
 // @ts-check
-import { makeWeakStore as makeNonVOWeakStore } from '@agoric/store';
-import { assert, details as X } from '@agoric/assert';
-import { E } from '@agoric/eventual-send';
-import { makePromiseKit } from '@agoric/promise-kit';
 
 /**
  * Zoe uses ERTP, the Electronic Rights Transfer Protocol
  *
- * Within Zoe, the assetKind of validated amounts must be consistent
- * with the brand's assetKind. This is stricter than the validation
- * provided by AmountMath currently. When the brand has a
- * assetKind itself, AmountMath will validate that.
+ * A note about ERTP AssetKinds: Within Zoe, the assetKind of
+ * validated amounts must be consistent with the brand's assetKind.
+ * This is stricter than the validation provided by AmountMath
+ * currently. When the brand has a assetKind itself, AmountMath will
+ * validate that.
  */
 import '@agoric/ertp/exported';
 import '@agoric/store/exported';
@@ -19,12 +16,12 @@ import '../../exported';
 import '../internal-types';
 
 import { Far } from '@agoric/marshal';
-import { makeZoeSeatAdminKit } from './zoeSeat';
-import { makeHandle } from '../makeHandle';
+import { makePromiseKit } from '@agoric/promise-kit';
+
 import { makeZoeStorageManager } from './zoeStorageManager';
+import { makeStartInstance } from './startInstance';
 import { makeOffer } from './offer/offer';
 import { makeInvitationQueryFns } from './invitationQueries';
-import { handlePKitWarning } from '../handleWarning';
 import { setupCreateZCFVat } from './createZCFVat';
 
 /**
@@ -35,15 +32,19 @@ import { setupCreateZCFVat } from './createZCFVat';
  * @param {string} [zcfBundleName] - The name of the contract facet bundle.
  * @returns {ZoeService} The created Zoe service.
  */
-function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
-  /** @type {WeakStore<SeatHandle, ZoeSeatAdmin>} */
-  const seatHandleToZoeSeatAdmin = makeNonVOWeakStore('seatHandle');
+const makeZoe = (vatAdminSvc, zcfBundleName = undefined) => {
+  // We must use the ZoeService before it is defined. See below where
+  // the promise is resolved.
+  /** @type {PromiseRecord<ZoeService>} */
+  const zoeServicePromiseKit = makePromiseKit();
 
   // This method contains the power to create a new ZCF Vat, and must
   // be closely held. vatAdminSvc is even more powerful - any vat can
   // be created. We severely restrict access to vatAdminSvc for this reason.
   const createZCFVat = setupCreateZCFVat(vatAdminSvc, zcfBundleName);
 
+  // The ZoeStorageManager composes and consolidates capabilities
+  // needed by Zoe according to POLA.
   const {
     depositPayments,
     getAssetKindByBrand,
@@ -58,12 +59,14 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
     invitationIssuer,
   } = makeZoeStorageManager(createZCFVat);
 
-  const {
-    getInstance,
-    getInstallation,
-    getInvitationDetails,
-  } = makeInvitationQueryFns(invitationIssuer);
+  // Pass the capabilities necessary to create zoe.startInstance
+  const startInstance = makeStartInstance(
+    zoeServicePromiseKit.promise,
+    makeZoeInstanceStorageManager,
+    unwrapInstallation,
+  );
 
+  // Pass the capabilities necessary to create zoe.offer
   const offer = makeOffer(
     invitationIssuer,
     getInstanceAdmin,
@@ -71,10 +74,23 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
     getAssetKindByBrand,
   );
 
+  // Make the methods that allow users to easily and credibly get
+  // information about their invitations.
+  const {
+    getInstance,
+    getInstallation,
+    getInvitationDetails,
+  } = makeInvitationQueryFns(invitationIssuer);
+
   /** @type {ZoeService} */
   const zoeService = Far('zoeService', {
-    getInvitationIssuer: () => invitationIssuer,
     install,
+    startInstance,
+    offer,
+
+    // The functions below are getters only and have no impact on
+    // state within Zoe
+    getInvitationIssuer: () => invitationIssuer,
     getPublicFacet,
     getBrands,
     getIssuers,
@@ -82,211 +98,14 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
     getInstance,
     getInstallation,
     getInvitationDetails,
-    startInstance: async (
-      installationP,
-      uncleanIssuerKeywordRecord = harden({}),
-      customTerms = harden({}),
-    ) => {
-      const { installation, bundle } = await unwrapInstallation(installationP);
-      // AWAIT ///
-
-      const instance = makeHandle('Instance');
-
-      const zoeInstanceStorageManager = await makeZoeInstanceStorageManager(
-        installation,
-        customTerms,
-        uncleanIssuerKeywordRecord,
-        instance,
-      );
-      // AWAIT ///
-
-      const {
-        adminNode,
-        root,
-      } = await zoeInstanceStorageManager.createZCFVat();
-      /** @type {ZCFRoot} */
-      const zcfRoot = root;
-
-      /** @type {PromiseRecord<HandleOfferObj>} */
-      const handleOfferObjPromiseKit = makePromiseKit();
-      handlePKitWarning(handleOfferObjPromiseKit);
-      const publicFacetPromiseKit = makePromiseKit();
-      handlePKitWarning(publicFacetPromiseKit);
-
-      const makeInstanceAdmin = () => {
-        /** @type {Set<ZoeSeatAdmin>} */
-        const zoeSeatAdmins = new Set();
-        let acceptingOffers = true;
-
-        const exitZoeSeatAdmin = zoeSeatAdmin =>
-          zoeSeatAdmins.delete(zoeSeatAdmin);
-        const hasExited = zoeSeatAdmin => !zoeSeatAdmins.has(zoeSeatAdmin);
-
-        /** @type {InstanceAdmin} */
-        const instanceAdmin = Far('instanceAdmin', {
-          getPublicFacet: () => publicFacetPromiseKit.promise,
-          getTerms: zoeInstanceStorageManager.getTerms,
-          getIssuers: zoeInstanceStorageManager.getIssuers,
-          getBrands: zoeInstanceStorageManager.getBrands,
-          getInstance: () => instance,
-          assertAcceptingOffers: () => {
-            assert(acceptingOffers, `No further offers are accepted`);
-          },
-          exitAllSeats: completion => {
-            acceptingOffers = false;
-            zoeSeatAdmins.forEach(zoeSeatAdmin =>
-              zoeSeatAdmin.exit(completion),
-            );
-          },
-          failAllSeats: reason => {
-            acceptingOffers = false;
-            zoeSeatAdmins.forEach(zoeSeatAdmin => zoeSeatAdmin.fail(reason));
-          },
-          stopAcceptingOffers: () => (acceptingOffers = false),
-          makeUserSeat: (invitationHandle, initialAllocation, proposal) => {
-            const offerResultPromiseKit = makePromiseKit();
-            handlePKitWarning(offerResultPromiseKit);
-            const exitObjPromiseKit = makePromiseKit();
-            handlePKitWarning(exitObjPromiseKit);
-            const seatHandle = makeHandle('SeatHandle');
-
-            const { userSeat, notifier, zoeSeatAdmin } = makeZoeSeatAdminKit(
-              initialAllocation,
-              exitZoeSeatAdmin,
-              hasExited,
-              proposal,
-              zoeInstanceStorageManager.withdrawPayments,
-              exitObjPromiseKit.promise,
-              offerResultPromiseKit.promise,
-            );
-
-            seatHandleToZoeSeatAdmin.init(seatHandle, zoeSeatAdmin);
-
-            const seatData = harden({
-              proposal,
-              initialAllocation,
-              notifier,
-              seatHandle,
-            });
-
-            zoeSeatAdmins.add(zoeSeatAdmin);
-
-            E(handleOfferObjPromiseKit.promise)
-              .handleOffer(invitationHandle, zoeSeatAdmin, seatData)
-              .then(({ offerResultP, exitObj }) => {
-                offerResultPromiseKit.resolve(offerResultP);
-                exitObjPromiseKit.resolve(exitObj);
-              });
-
-            // return the userSeat before the offerHandler is called
-            return userSeat;
-          },
-          makeNoEscrowSeat: (
-            initialAllocation,
-            proposal,
-            exitObj,
-            seatHandle,
-          ) => {
-            const { userSeat, notifier, zoeSeatAdmin } = makeZoeSeatAdminKit(
-              initialAllocation,
-              exitZoeSeatAdmin,
-              hasExited,
-              proposal,
-              zoeInstanceStorageManager.withdrawPayments,
-              exitObj,
-            );
-            zoeSeatAdmins.add(zoeSeatAdmin);
-            seatHandleToZoeSeatAdmin.init(seatHandle, zoeSeatAdmin);
-            return { userSeat, notifier, zoeSeatAdmin };
-          },
-        });
-        return instanceAdmin;
-      };
-
-      const instanceAdmin = makeInstanceAdmin();
-      zoeInstanceStorageManager.initInstanceAdmin(instance, instanceAdmin);
-
-      E(adminNode)
-        .done()
-        .then(
-          completion => instanceAdmin.exitAllSeats(completion),
-          reason => instanceAdmin.failAllSeats(reason),
-        );
-
-      /** @type {ZoeInstanceAdmin} */
-      const zoeInstanceAdminForZcf = Far('zoeInstanceAdminForZcf', {
-        makeInvitation: zoeInstanceStorageManager.makeInvitation,
-        // checks of keyword done on zcf side
-        saveIssuer: zoeInstanceStorageManager.saveIssuer,
-        // A Seat requested by the contract without any payments to escrow
-        makeNoEscrowSeat: instanceAdmin.makeNoEscrowSeat,
-        exitAllSeats: completion => instanceAdmin.exitAllSeats(completion),
-        failAllSeats: reason => instanceAdmin.failAllSeats(reason),
-        makeZoeMint: zoeInstanceStorageManager.makeZoeMint,
-        replaceAllocations: seatHandleAllocations => {
-          seatHandleAllocations.forEach(({ seatHandle, allocation }) => {
-            const zoeSeatAdmin = seatHandleToZoeSeatAdmin.get(seatHandle);
-            zoeSeatAdmin.replaceAllocation(allocation);
-          });
-        },
-        stopAcceptingOffers: () => instanceAdmin.stopAcceptingOffers(),
-      });
-
-      // At this point, the contract will start executing. All must be
-      // ready
-
-      const {
-        creatorFacet = Far('emptyCreatorFacet', {}),
-        publicFacet = Far('emptyPublicFacet', {}),
-        creatorInvitation: creatorInvitationP,
-        handleOfferObj,
-      } = await E(zcfRoot).executeContract(
-        bundle,
-        zoeService,
-        invitationIssuer,
-        zoeInstanceAdminForZcf,
-        zoeInstanceStorageManager.getInstanceRecord(),
-        zoeInstanceStorageManager.getIssuerRecords(),
-      );
-
-      handleOfferObjPromiseKit.resolve(handleOfferObj);
-      publicFacetPromiseKit.resolve(publicFacet);
-
-      // creatorInvitation can be undefined, but if it is defined,
-      // let's make sure it is an invitation.
-      return Promise.allSettled([
-        creatorInvitationP,
-        invitationIssuer.isLive(creatorInvitationP),
-      ]).then(([invitationResult, isLiveResult]) => {
-        let creatorInvitation;
-        if (invitationResult.status === 'fulfilled') {
-          creatorInvitation = invitationResult.value;
-        }
-        if (creatorInvitation !== undefined) {
-          assert(
-            isLiveResult.status === 'fulfilled' && isLiveResult.value,
-            X`The contract did not correctly return a creatorInvitation`,
-          );
-        }
-        const adminFacet = Far('adminFacet', {
-          getVatShutdownPromise: () => E(adminNode).done(),
-          getVatStats: () => E(adminNode).adminData(),
-        });
-
-        // Actually returned to the user.
-        return {
-          creatorFacet,
-          creatorInvitation,
-          instance,
-          publicFacet,
-          adminFacet,
-        };
-      });
-    },
-    offer,
   });
 
+  // startInstance must pass the ZoeService to the newly recreated ZCF
+  // vat, but the zoeService is not yet defined when startInstance is
+  // defined. So, we pass a promise and then resolve the promise here.
+  zoeServicePromiseKit.resolve(zoeService);
+
   return zoeService;
-}
+};
 
 export { makeZoe };

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -6,7 +6,7 @@
  * A note about ERTP AssetKinds: Within Zoe, the assetKind of
  * validated amounts must be consistent with the brand's assetKind.
  * This is stricter than the validation provided by AmountMath
- * currently. When the brand has a assetKind itself, AmountMath will
+ * currently. When the brand has an assetKind itself, AmountMath will
  * validate that.
  */
 import '@agoric/ertp/exported';

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -33,8 +33,8 @@ import { setupCreateZCFVat } from './createZCFVat';
  * @returns {ZoeService} The created Zoe service.
  */
 const makeZoe = (vatAdminSvc, zcfBundleName = undefined) => {
-  // We must use the ZoeService before it is defined. See below where
-  // the promise is resolved.
+  // We must pass the ZoeService to `makeStartInstance` before it is
+  // defined. See below where the promise is resolved.
   /** @type {PromiseRecord<ZoeService>} */
   const zoeServicePromiseKit = makePromiseKit();
 
@@ -100,7 +100,7 @@ const makeZoe = (vatAdminSvc, zcfBundleName = undefined) => {
     getInvitationDetails,
   });
 
-  // startInstance must pass the ZoeService to the newly recreated ZCF
+  // startInstance must pass the ZoeService to the newly created ZCF
   // vat, but the zoeService is not yet defined when startInstance is
   // defined. So, we pass a promise and then resolve the promise here.
   zoeServicePromiseKit.resolve(zoeService);

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -102,7 +102,10 @@ function makeZoe(vatAdminSvc, zcfBundleName = undefined) {
       );
       // AWAIT ///
 
-      const { adminNode, root } = await createZCFVat();
+      const {
+        adminNode,
+        root,
+      } = await zoeInstanceStorageManager.createZCFVat();
       /** @type {ZCFRoot} */
       const zcfRoot = root;
 

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -22,12 +22,12 @@ import { makeInstallationStorage } from './installationStorage';
  * Manager divides up the resulting capabilities between those needed
  * by a new contract instance (returned as the result of
  * `makeZoeInstanceStorageManager`) and those needed for other purposes.
- */
-
-/**
+ *
+ * @param {CreateZCFVat} createZCFVat - the ability to create a new
+ * ZCF Vat
  * @returns {ZoeStorageManager}
  */
-export const makeZoeStorageManager = () => {
+export const makeZoeStorageManager = createZCFVat => {
   // issuerStorage contains the issuers that the ZoeService knows
   // about, as well as information about them such as their brand,
   // mathKind, and displayInfo
@@ -159,6 +159,7 @@ export const makeZoeStorageManager = () => {
       withdrawPayments: escrowStorage.withdrawPayments,
       initInstanceAdmin,
       deleteInstanceAdmin,
+      createZCFVat,
     });
   };
 

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -16,7 +16,7 @@ import { assertAmountsEqual } from '../../zoeTestHelpers';
 test(`zcf.getZoeService`, async t => {
   const { zoe, zcf } = await setupZCFTest();
   const zoeService = zcf.getZoeService();
-  t.is(zoeService, zoe);
+  t.is(await zoeService, zoe);
 });
 
 test(`zcf.getInvitationIssuer`, async t => {

--- a/packages/zoe/test/unitTests/zoe/test-createZCFVat.js
+++ b/packages/zoe/test/unitTests/zoe/test-createZCFVat.js
@@ -1,0 +1,23 @@
+// @ts-check
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+
+import { Far } from '@agoric/marshal';
+
+import { setupCreateZCFVat } from '../../../src/zoeService/createZCFVat';
+
+test('setupCreateZCFVat', async t => {
+  // This is difficult to unit test, since the real functionality
+  // creates a new vat
+
+  const fakeVatAdminSvc = Far('fakeVatAdminSvc', {
+    createVatByName: name => name,
+    createVat: _bundle => 'zcfBundle',
+  });
+
+  // @ts-ignore fakeVatAdminSvc is mocked
+  t.is(await setupCreateZCFVat(fakeVatAdminSvc, undefined)(), 'zcfBundle');
+  // @ts-ignore fakeVatAdminSvc is mocked
+  t.is(await setupCreateZCFVat(fakeVatAdminSvc, 'myVat')(), 'myVat');
+});

--- a/packages/zoe/test/unitTests/zoe/test-makeInvitation.js
+++ b/packages/zoe/test/unitTests/zoe/test-makeInvitation.js
@@ -1,0 +1,108 @@
+// @ts-check
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+import { amountMath } from '@agoric/ertp';
+
+import { E } from '@agoric/eventual-send';
+import { createInvitationKit } from '../../../src/zoeService/makeInvitation';
+
+test('createInvitationKit', async t => {
+  const { setupMakeInvitation, invitationIssuer } = createInvitationKit();
+
+  const mockInstance = harden({});
+  const mockInstallation = harden({});
+
+  // @ts-ignore mockInstance is mocked
+  const makeInvitation = setupMakeInvitation(mockInstance, mockInstallation);
+
+  const mockInvitationHandle = harden({});
+  const description = 'myInvitation';
+  const customProperties = harden({
+    fruit: 'apple',
+  });
+
+  const invitation = makeInvitation(
+    // @ts-ignore mockInvitationHandle is mocked
+    mockInvitationHandle,
+    description,
+    customProperties,
+  );
+
+  const amount = await E(invitationIssuer).getAmountOf(invitation);
+  const invitationBrand = await E(invitationIssuer).getBrand();
+
+  t.deepEqual(
+    amount,
+    amountMath.make(invitationBrand, [
+      {
+        description: 'myInvitation',
+        fruit: 'apple',
+        handle: mockInvitationHandle,
+        installation: mockInstallation,
+        instance: mockInstance,
+      },
+    ]),
+  );
+});
+
+test('description is omitted, wrongly', async t => {
+  const { setupMakeInvitation } = createInvitationKit();
+
+  const mockInstance = harden({});
+  const mockInstallation = harden({});
+
+  // @ts-ignore mockInstance is mocked
+  const makeInvitation = setupMakeInvitation(mockInstance, mockInstallation);
+
+  const mockInvitationHandle = harden({});
+  const description = undefined;
+  const customProperties = harden({
+    fruit: 'apple',
+  });
+
+  t.throws(
+    () =>
+      makeInvitation(
+        // @ts-ignore mockInvitationHandle is mocked
+        mockInvitationHandle,
+        description,
+        customProperties,
+      ),
+    { message: `The description "[undefined]" must be a string` },
+  );
+});
+
+test('customProperties ok to omit', async t => {
+  const { setupMakeInvitation, invitationIssuer } = createInvitationKit();
+
+  const mockInstance = harden({});
+  const mockInstallation = harden({});
+
+  // @ts-ignore mockInstance is mocked
+  const makeInvitation = setupMakeInvitation(mockInstance, mockInstallation);
+
+  const mockInvitationHandle = harden({});
+  const description = 'myInvitation';
+
+  const invitation = makeInvitation(
+    // @ts-ignore mockInvitationHandle is mocked
+    mockInvitationHandle,
+    description,
+  );
+
+  const amount = await E(invitationIssuer).getAmountOf(invitation);
+  const invitationBrand = await E(invitationIssuer).getBrand();
+
+  t.deepEqual(
+    amount,
+    amountMath.make(invitationBrand, [
+      {
+        description: 'myInvitation',
+        handle: mockInvitationHandle,
+        installation: mockInstallation,
+        instance: mockInstance,
+      },
+    ]),
+  );
+});


### PR DESCRIPTION
Attenuate `vatAdminSvc`. This will become more useful when the `startInstance` function is moved to another file. 

Includes changes from the PRs that were stacked on top of this, so there is less traffic going onto master:

https://github.com/Agoric/agoric-sdk/pull/3181
https://github.com/Agoric/agoric-sdk/pull/3182