### PR TITLE
refactor(zoe): separate out the invitationKit

### DIFF
--- a/packages/zoe/src/zoeService/makeInvitation.js
+++ b/packages/zoe/src/zoeService/makeInvitation.js
@@ -26,6 +26,13 @@ export const createInvitationKit = () => {
         'string',
         X`The description ${description} must be a string`,
       );
+      // If the contract-provided customProperties include the
+      // properties 'description', 'handle', 'instance' and
+      // 'installation', their corresponding values will be
+      // overwritten with the actual values. For example, the value
+      // for `instance` will always be the actual instance for the
+      // contract, even if customProperties includes a property called
+      // `instance`.
       const invitationAmount = AmountMath.make(invitationKit.brand, [
         {
           ...customProperties,


### PR DESCRIPTION
This PR attenuates the power to create invitations and separates this logic into a separate file. 

Stacked on #3179 