### PR TITLE
refactor!: new reallocate API to assist with reviewing conservation of rights

### DIFF
--- a/packages/pegasus/src/pegasus.js
+++ b/packages/pegasus/src/pegasus.js
@@ -7,7 +7,6 @@ import { E } from '@agoric/eventual-send';
 import { Nat } from '@agoric/nat';
 import { parse as parseMultiaddr } from '@agoric/swingset-vat/src/vats/network/multiaddr';
 import { assertProposalShape } from '@agoric/zoe/src/contractSupport';
-import { AmountMath } from '@agoric/ertp';
 
 import '@agoric/notifier/exported';
 import '@agoric/vats/exported';
@@ -498,16 +497,9 @@ const makePegasus = (zcf, board, namesByAddress) => {
         winner,
       ) => {
         // Transfer the amount to our backing seat.
-        const currentLoser = loser.getAmountAllocated(loserKeyword, localBrand);
-        const currentWinner = winner.getAmountAllocated(
-          winnerKeyword,
-          localBrand,
-        );
-        const newLoser = AmountMath.subtract(currentLoser, amount);
-        const newWinner = AmountMath.add(currentWinner, amount);
-        const loserStage = loser.stage({ [loserKeyword]: newLoser });
-        const winnerStage = winner.stage({ [winnerKeyword]: newWinner });
-        zcf.reallocate(loserStage, winnerStage);
+        loser.decrementBy({ [loserKeyword]: amount });
+        winner.incrementBy({ [winnerKeyword]: amount });
+        zcf.reallocate(loser, winner);
       };
 
       // Describe how to retain/redeem real local erights.

--- a/packages/treasury/src/collectRewardFees.js
+++ b/packages/treasury/src/collectRewardFees.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-import { AmountMath } from '@agoric/ertp';
 import { offerTo } from '@agoric/zoe/src/contractSupport';
 import { E } from '@agoric/eventual-send';
 
@@ -17,16 +16,17 @@ export const makeMakeCollectFeesInvitation = (
     const { zcfSeat: transferSeat } = zcf.makeEmptySeatKit();
     await E.get(offerTo(zcf, invitation, {}, {}, transferSeat)).deposited;
 
-    const totalTransferred = AmountMath.add(
-      feeSeat.getAmountAllocated('RUN', runBrand),
-      transferSeat.getAmountAllocated('RUN', runBrand),
+    seat.incrementBy(
+      feeSeat.decrementBy({ RUN: feeSeat.getAmountAllocated('RUN', runBrand) }),
     );
-    const emptyRunAllocation = { RUN: AmountMath.makeEmpty(runBrand) };
-    zcf.reallocate(
-      transferSeat.stage(emptyRunAllocation),
-      feeSeat.stage(emptyRunAllocation),
-      seat.stage({ RUN: totalTransferred }),
+    seat.incrementBy(
+      transferSeat.decrementBy({
+        RUN: transferSeat.getAmountAllocated('RUN', runBrand),
+      }),
     );
+    const totalTransferred = seat.getStagedAllocation().RUN;
+
+    zcf.reallocate(transferSeat, feeSeat, seat);
     seat.exit();
     transferSeat.exit();
 

--- a/packages/treasury/src/stablecoinMachine.js
+++ b/packages/treasury/src/stablecoinMachine.js
@@ -80,15 +80,19 @@ export async function start(zcf) {
    * We provide an easy way for the vaultManager and vaults to add rewards to
    * the rewardPoolSeat, without directly exposing the rewardPoolSeat to them.
    *
-   * @type {TransferReward}
+   * @type {ReallocateReward}
    */
-  function transferReward(amount, fromSeat) {
+  function reallocateReward(amount, fromSeat, otherSeat = undefined) {
     rewardPoolSeat.incrementBy(
       fromSeat.decrementBy({
         RUN: amount,
       }),
     );
-    zcf.reallocate(rewardPoolSeat, fromSeat);
+    if (otherSeat !== undefined) {
+      zcf.reallocate(rewardPoolSeat, fromSeat, otherSeat);
+    } else {
+      zcf.reallocate(rewardPoolSeat, fromSeat);
+    }
   }
 
   /** @type {Store<Brand,VaultManager>} */
@@ -220,7 +224,7 @@ export async function start(zcf) {
         collateralBrand,
         priceAuthority,
         rates,
-        transferReward,
+        reallocateReward,
         timerService,
         loanParams,
         liquidationStrategy,

--- a/packages/treasury/src/stablecoinMachine.js
+++ b/packages/treasury/src/stablecoinMachine.js
@@ -21,7 +21,6 @@ import { E } from '@agoric/eventual-send';
 import { assert, details, q } from '@agoric/assert';
 import makeStore from '@agoric/store';
 import {
-  trade,
   assertProposalShape,
   offerTo,
   getAmountOut,
@@ -77,13 +76,19 @@ export async function start(zcf) {
   // away fees so the tests show that the funds have been removed.
   const { zcfSeat: rewardPoolSeat } = zcf.makeEmptySeatKit();
 
-  // We provide an easy way for the vaultManager and vaults to add rewards to
-  // this seat, without directly exposing the seat to them.
-  function stageReward(amount) {
-    const priorReward = rewardPoolSeat.getAmountAllocated('RUN', runBrand);
-    return rewardPoolSeat.stage({
-      RUN: AmountMath.add(priorReward, amount, runBrand),
-    });
+  /**
+   * We provide an easy way for the vaultManager and vaults to add rewards to
+   * the rewardPoolSeat, without directly exposing the rewardPoolSeat to them.
+   *
+   * @type {TransferReward}
+   */
+  function transferReward(amount, fromSeat) {
+    rewardPoolSeat.incrementBy(
+      fromSeat.decrementBy({
+        RUN: amount,
+      }),
+    );
+    zcf.reallocate(rewardPoolSeat, fromSeat);
   }
 
   /** @type {Store<Brand,VaultManager>} */
@@ -154,15 +159,11 @@ export async function start(zcf) {
 
       // trade the governance tokens for collateral, putting the
       // collateral on Secondary to be positioned for Autoswap
-      trade(
-        zcf,
-        {
-          seat,
-          gains: { Governance: govAmount },
-          losses: { Collateral: collateralIn },
-        },
-        { seat: govSeat, gains: { Secondary: collateralIn } },
-      );
+      seat.incrementBy(govSeat.decrementBy({ Governance: govAmount }));
+      seat.decrementBy({ Collateral: collateralIn });
+      govSeat.incrementBy({ Secondary: collateralIn });
+
+      zcf.reallocate(govSeat, seat);
       // the collateral is now on the temporary seat
 
       // once we've done that, we can put both the collateral and the minted
@@ -219,7 +220,7 @@ export async function start(zcf) {
         collateralBrand,
         priceAuthority,
         rates,
-        stageReward,
+        transferReward,
         timerService,
         loanParams,
         liquidationStrategy,

--- a/packages/treasury/src/types.js
+++ b/packages/treasury/src/types.js
@@ -45,10 +45,11 @@
  */
 
 /**
- * @callback StageReward return a seat staging (for use in reallocate)
- * that will add the indicated amount to the stablecoin machine's reward pool.
+ * @callback TransferReward transfer the indicated amount to the
+ * stablecoin machine's reward pool, taken from the `fromSeat`.
  * @param {Amount} amount
- * @returns SeatStaging
+ * @param {ZCFSeat} fromSeat
+ * @returns {void}
  */
 
 /**
@@ -59,7 +60,7 @@
  * @property {() => Promise<PriceQuote>} getCollateralQuote
  * @property {() => Ratio} getInitialMargin
  * @property {() => Ratio} getInterestRate - The annual interest rate on a loan
- * @property {StageReward} stageReward
+ * @property {TransferReward} transferReward
  */
 
 /**

--- a/packages/treasury/src/types.js
+++ b/packages/treasury/src/types.js
@@ -45,10 +45,15 @@
  */
 
 /**
- * @callback TransferReward transfer the indicated amount to the
- * stablecoin machine's reward pool, taken from the `fromSeat`.
+ * @callback ReallocateReward
+ *
+ * Transfer the indicated amount to the stablecoin machine's reward
+ * pool, taken from the `fromSeat`. Then reallocate over all the seat
+ * arguments and the rewardPoolSeat.
+ *
  * @param {Amount} amount
  * @param {ZCFSeat} fromSeat
+ * @param {ZCFSeat=} otherSeat
  * @returns {void}
  */
 
@@ -60,7 +65,7 @@
  * @property {() => Promise<PriceQuote>} getCollateralQuote
  * @property {() => Ratio} getInitialMargin
  * @property {() => Ratio} getInterestRate - The annual interest rate on a loan
- * @property {TransferReward} transferReward
+ * @property {ReallocateReward} reallocateReward
  */
 
 /**

--- a/packages/treasury/src/vault.js
+++ b/packages/treasury/src/vault.js
@@ -233,7 +233,7 @@ export function makeVaultKit(
     }
   }
 
-  function stageCollateral(seat) {
+  function transferCollateral(seat) {
     const proposal = seat.getProposal();
     if (proposal.want.Collateral) {
       seat.incrementBy(
@@ -279,7 +279,7 @@ export function makeVaultKit(
     }
   }
 
-  function stageRun(seat) {
+  function transferRun(seat) {
     const proposal = seat.getProposal();
     if (proposal.want.RUN) {
       seat.incrementBy(vaultSeat.decrementBy({ RUN: proposal.want.RUN }));
@@ -364,10 +364,9 @@ export function makeVaultKit(
     // mint to vaultSeat, then reallocate to reward and client, then burn from
     // vaultSeat. Would using a separate seat clarify the accounting?
     runMint.mintGains({ RUN: toMint }, vaultSeat);
-    stageCollateral(clientSeat);
-    stageRun(clientSeat);
-    zcf.reallocate(vaultSeat, clientSeat);
-    manager.transferReward(fee, vaultSeat);
+    transferCollateral(clientSeat);
+    transferRun(clientSeat);
+    manager.reallocateReward(fee, vaultSeat, clientSeat);
 
     runDebt = newDebt;
     runMint.burnLosses({ RUN: runAfter.vault }, vaultSeat);
@@ -413,8 +412,7 @@ export function makeVaultKit(
 
     seat.incrementBy(vaultSeat.decrementBy({ RUN: wantedRun }));
     vaultSeat.incrementBy(seat.decrementBy({ Collateral: collateralAmount }));
-    zcf.reallocate(vaultSeat, seat);
-    manager.transferReward(fee, vaultSeat);
+    manager.reallocateReward(fee, vaultSeat, seat);
 
     updateUiState();
 

--- a/packages/treasury/src/vaultManager.js
+++ b/packages/treasury/src/vaultManager.js
@@ -33,7 +33,7 @@ export function makeVaultManager(
   collateralBrand,
   priceAuthority,
   rates,
-  transferReward,
+  reallocateReward,
   timerService,
   loanParams,
   liquidationStrategy,
@@ -64,7 +64,7 @@ export function makeVaultManager(
         runBrand,
       );
     },
-    transferReward,
+    reallocateReward,
   };
 
   // A Map from vaultKits to their most recent ratio of debt to
@@ -169,7 +169,7 @@ export function makeVaultManager(
     sortedVaultKits.updateAllDebts();
     reschedulePriceCheck();
     runMint.mintGains({ RUN: poolIncrement }, poolIncrementSeat);
-    transferReward(poolIncrement, poolIncrementSeat);
+    reallocateReward(poolIncrement, poolIncrementSeat);
   }
 
   const periodNotifier = E(timerService).makeNotifier(

--- a/packages/treasury/src/vaultManager.js
+++ b/packages/treasury/src/vaultManager.js
@@ -33,7 +33,7 @@ export function makeVaultManager(
   collateralBrand,
   priceAuthority,
   rates,
-  stageReward,
+  transferReward,
   timerService,
   loanParams,
   liquidationStrategy,
@@ -64,7 +64,7 @@ export function makeVaultManager(
         runBrand,
       );
     },
-    stageReward,
+    transferReward,
   };
 
   // A Map from vaultKits to their most recent ratio of debt to
@@ -169,11 +169,7 @@ export function makeVaultManager(
     sortedVaultKits.updateAllDebts();
     reschedulePriceCheck();
     runMint.mintGains({ RUN: poolIncrement }, poolIncrementSeat);
-    const poolStage = poolIncrementSeat.stage({
-      RUN: AmountMath.makeEmpty(runBrand),
-    });
-    const poolSeatStaging = stageReward(poolIncrement);
-    zcf.reallocate(poolStage, poolSeatStaging);
+    transferReward(poolIncrement, poolIncrementSeat);
   }
 
   const periodNotifier = E(timerService).makeNotifier(

--- a/packages/treasury/test/vault-contract-wrapper.js
+++ b/packages/treasury/test/vault-contract-wrapper.js
@@ -39,13 +39,17 @@ export async function start(zcf) {
     },
   };
 
-  function transferReward(amount, fromSeat) {
+  function reallocateReward(amount, fromSeat, otherSeat) {
     stableCoinSeat.incrementBy(
       fromSeat.decrementBy({
         RUN: amount,
       }),
     );
-    zcf.reallocate(stableCoinSeat, fromSeat);
+    if (otherSeat !== undefined) {
+      zcf.reallocate(stableCoinSeat, fromSeat, otherSeat);
+    } else {
+      zcf.reallocate(stableCoinSeat, fromSeat);
+    }
   }
 
   /** @type {InnerVaultManager} */
@@ -63,7 +67,7 @@ export async function start(zcf) {
       return makeRatio(5n, runBrand);
     },
     collateralBrand,
-    transferReward,
+    reallocateReward,
   };
 
   const SECONDS_PER_HOUR = SECONDS_PER_YEAR / 365n / 24n;

--- a/packages/treasury/test/vault-contract-wrapper.js
+++ b/packages/treasury/test/vault-contract-wrapper.js
@@ -39,11 +39,13 @@ export async function start(zcf) {
     },
   };
 
-  function stageReward(amount, _fromSeat) {
-    const priorReward = stableCoinSeat.getAmountAllocated('RUN', runBrand);
-    return stableCoinSeat.stage({
-      RUN: AmountMath.add(priorReward, amount),
-    });
+  function transferReward(amount, fromSeat) {
+    stableCoinSeat.incrementBy(
+      fromSeat.decrementBy({
+        RUN: amount,
+      }),
+    );
+    zcf.reallocate(stableCoinSeat, fromSeat);
   }
 
   /** @type {InnerVaultManager} */
@@ -61,7 +63,7 @@ export async function start(zcf) {
       return makeRatio(5n, runBrand);
     },
     collateralBrand,
-    stageReward,
+    transferReward,
   };
 
   const SECONDS_PER_HOUR = SECONDS_PER_YEAR / 365n / 24n;

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -49,24 +49,28 @@
  */
 
 /**
- * @typedef {(seatStaging1: SeatStaging, seatStaging2: SeatStaging,
- * ...seatStagingRest: Array<SeatStaging>) => void} Reallocate
+ * @typedef {(seat1: ZCFSeat, seat2: ZCFSeat, ...seatRest:
+ * Array<ZCFSeat>) => void} Reallocate
  *
- * The contract can reallocate over seatStagings, which are
- * associations of seats with reallocations.
+ * The contract can reallocate over seats, which commits the staged
+ * allocation for each seat. On commit, the staged allocation becomes
+ * the current allocation and the staged allocation is deleted.
  *
  * The reallocation will only succeed if the reallocation 1) conserves
  * rights (the amounts specified have the same total value as the
  * current total amount), and 2) is 'offer-safe' for all parties
- * involved. Offer safety is checked at the staging step.
+ * involved. All seats that have staged allocations must be included
+ * as arguments to `reallocate`, or an error is thrown. Additionally,
+ * an error is thrown if any seats included in `reallocate` do not
+ * have a staged allocation.
  *
  * The reallocation is partial, meaning that it applies only to the
- * seats associated with the seatStagings. By induction, if rights
- * conservation and offer safety hold before, they will hold after a
- * safe reallocation, even though we only re-validate for the seats
- * whose allocations will change. Since rights are conserved for the
- * change, overall rights will be unchanged, and a reallocation can
- * only effect offer safety for seats whose allocations change.
+ * seats passed in as arguments. By induction, if rights conservation
+ * and offer safety hold before, they will hold after a safe
+ * reallocation, even though we only re-validate for the seats whose
+ * allocations will change. Since rights are conserved for the change,
+ * overall rights will be unchanged, and a reallocation can only
+ * effect offer safety for seats whose allocations change.
  */
 
 /**
@@ -187,14 +191,12 @@
  * @property {() => ProposalRecord} getProposal
  * @property {ZCFGetAmountAllocated} getAmountAllocated
  * @property {() => Allocation} getCurrentAllocation
- * @property {(newAllocation: Allocation) => boolean} isOfferSafe
- * @property {(newAllocation: Allocation) => SeatStaging} stage
- */
-
-/**
- * @typedef {Object} SeatStaging
- * @property {() => ZCFSeat} getSeat
  * @property {() => Allocation} getStagedAllocation
+ * @property {() => boolean} hasStagedAllocation
+ * @property {(newAllocation: Allocation) => boolean} isOfferSafe
+ * @property {(amountKeywordRecord: AmountKeywordRecord) => AmountKeywordRecord} incrementBy
+ * @property {(amountKeywordRecord: AmountKeywordRecord) => AmountKeywordRecord} decrementBy
+ * @property {() => void} clear
  */
 
 /**

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -1,21 +1,27 @@
 // @ts-check
 
 import { assert, details as X } from '@agoric/assert';
-import { makeWeakStore as makeNonVOWeakStore } from '@agoric/store';
+import {
+  makeWeakStore as makeNonVOWeakStore,
+  makeStore as makeNonVOStore,
+} from '@agoric/store';
 import { E } from '@agoric/eventual-send';
 import { AmountMath } from '@agoric/ertp';
 import { Far } from '@agoric/marshal';
 
 import { isOfferSafe } from './offerSafety';
 import { assertRightsConserved } from './rightsConservation';
+import { addToAllocation, subtractFromAllocation } from './allocationMath';
 
 /** @type {CreateSeatManager} */
 export const createSeatManager = (zoeInstanceAdmin, getAssetKindByBrand) => {
   /** @type {WeakStore<ZCFSeat, Allocation>}  */
   let activeZCFSeats = makeNonVOWeakStore('zcfSeat');
+  /** @type {Store<ZCFSeat, Allocation>} */
+  const zcfSeatToStagedAllocations = makeNonVOStore('zcfSeat');
 
-  /** @type {WeakStore<SeatStaging, SeatHandle>} */
-  let seatStagingToSeatHandle = makeNonVOWeakStore('seatStaging');
+  /** @type {WeakStore<ZCFSeat, SeatHandle>} */
+  let zcfSeatToSeatHandle = makeNonVOWeakStore('zcfSeat');
 
   /** @type {(zcfSeat: ZCFSeat) => boolean} */
   const hasExited = zcfSeat => !activeZCFSeats.has(zcfSeat);
@@ -28,24 +34,76 @@ export const createSeatManager = (zoeInstanceAdmin, getAssetKindByBrand) => {
     assert(activeZCFSeats.has(zcfSeat), X`seat has been exited`);
   };
 
+  /**
+   * @param {ZCFSeat} zcfSeat
+   * @returns {void}
+   */
   const doExitSeat = zcfSeat => {
     assertActive(zcfSeat);
     activeZCFSeats.delete(zcfSeat);
   };
 
+  /**
+   * @param {ZCFSeat} zcfSeat
+   * @returns {Allocation}
+   */
   const getCurrentAllocation = zcfSeat => {
     assertActive(zcfSeat);
     return activeZCFSeats.get(zcfSeat);
   };
 
-  const commitSeatStaging = seatStaging => {
-    assert(
-      seatStagingToSeatHandle.has(seatStaging),
-      X`The seatStaging ${seatStaging} was not recognized`,
-    );
-    const zcfSeat = seatStaging.getSeat();
+  /**
+   * @param {ZCFSeat} zcfSeat
+   * @returns {void}
+   */
+  const commitStagedAllocation = zcfSeat => {
     assertActive(zcfSeat);
-    activeZCFSeats.set(zcfSeat, seatStaging.getStagedAllocation());
+    activeZCFSeats.set(zcfSeat, zcfSeat.getStagedAllocation());
+    zcfSeatToStagedAllocations.delete(zcfSeat);
+  };
+
+  /**
+   * @param {ZCFSeat} zcfSeat
+   * @returns {Allocation}
+   */
+  const hasStagedAllocation = zcfSeatToStagedAllocations.has;
+
+  /**
+   * Get the stagedAllocation. If one does not exist, return the
+   * currentAllocation. We return the currentAllocation in this case
+   * so that downstream users do not have to check whether the
+   * stagedAllocation is defined before adding to it or subtracting
+   * from it. To check whether a stagedAllocation exists, use
+   * `hasStagedAllocation`
+   *
+   * @param {ZCFSeat} zcfSeat
+   * @returns {Allocation}
+   */
+  const getStagedAllocation = zcfSeat => {
+    if (zcfSeatToStagedAllocations.has(zcfSeat)) {
+      return zcfSeatToStagedAllocations.get(zcfSeat);
+    } else {
+      return activeZCFSeats.get(zcfSeat);
+    }
+  };
+
+  const assertStagedAllocation = zcfSeat => {
+    assert(
+      hasStagedAllocation(zcfSeat),
+      X`Reallocate failed because a seat had no staged allocation. Please add or subtract from the seat and then reallocate.`,
+    );
+  };
+
+  const clear = zcfSeat => {
+    zcfSeatToStagedAllocations.delete(zcfSeat);
+  };
+
+  const setStagedAllocation = (zcfSeat, newStagedAllocation) => {
+    if (zcfSeatToStagedAllocations.has(zcfSeat)) {
+      zcfSeatToStagedAllocations.set(zcfSeat, newStagedAllocation);
+    } else {
+      zcfSeatToStagedAllocations.init(zcfSeat, newStagedAllocation);
+    }
   };
 
   /**
@@ -55,22 +113,30 @@ export const createSeatManager = (zoeInstanceAdmin, getAssetKindByBrand) => {
    *
    * @type {ReallocateInternal}
    */
-  const reallocateInternal = seatStagings => {
+  const reallocateInternal = seats => {
     // Keep track of seats used so far in this call, to prevent aliasing.
     const zcfSeatsSoFar = new WeakSet();
 
-    seatStagings.forEach(seatStaging => {
+    seats.forEach(seat => {
       assert(
-        seatStagingToSeatHandle.has(seatStaging),
-        X`The seatStaging ${seatStaging} was not recognized`,
+        zcfSeatToSeatHandle.has(seat),
+        X`The seat ${seat} was not recognized`,
       );
-      const zcfSeat = seatStaging.getSeat();
       assert(
-        !zcfSeatsSoFar.has(zcfSeat),
-        X`Seat (${zcfSeat}) was already an argument to reallocate`,
+        !zcfSeatsSoFar.has(seat),
+        X`Seat (${seat}) was already an argument to reallocate`,
       );
-      zcfSeatsSoFar.add(zcfSeat);
+      zcfSeatsSoFar.add(seat);
     });
+
+    // Ensure that all stagings are present in this reallocate call.
+    const allStagedSeatsUsed = zcfSeatToStagedAllocations
+      .keys()
+      .every(stagedSeat => zcfSeatsSoFar.has(stagedSeat));
+    assert(
+      allStagedSeatsUsed,
+      X`At least one seat has a staged allocation but was not included in the call to reallocate`,
+    );
 
     // No side effects above. All conditions checked which could have
     // caused us to reject this reallocation.
@@ -85,45 +151,47 @@ export const createSeatManager = (zoeInstanceAdmin, getAssetKindByBrand) => {
     // for each of the seats) and inform Zoe of the
     // newAllocation.
 
-    seatStagings.forEach(commitSeatStaging);
+    seats.forEach(commitStagedAllocation);
 
-    const seatHandleAllocations = seatStagings.map(seatStaging => {
-      const zcfSeat = seatStaging.getSeat();
-      const seatHandle = seatStagingToSeatHandle.get(seatStaging);
-      return { seatHandle, allocation: zcfSeat.getCurrentAllocation() };
+    const seatHandleAllocations = seats.map(seat => {
+      const seatHandle = zcfSeatToSeatHandle.get(seat);
+      return { seatHandle, allocation: seat.getCurrentAllocation() };
     });
-
-    seatStagings.forEach(seatStagingToSeatHandle.delete);
 
     E(zoeInstanceAdmin).replaceAllocations(seatHandleAllocations);
   };
 
-  const reallocate = (/** @type {SeatStaging[]} */ ...seatStagings) => {
+  const reallocate = (/** @type {ZCFSeat[]} */ ...seats) => {
     // We may want to handle this with static checking instead.
     // Discussion at: https://github.com/Agoric/agoric-sdk/issues/1017
     assert(
-      seatStagings.length >= 2,
+      seats.length >= 2,
       X`reallocating must be done over two or more seats`,
     );
 
-    // Ensure that rights are conserved overall. Offer safety was
-    // already checked when an allocation was staged for an individual seat.
+    seats.forEach(assertStagedAllocation);
+
+    // Ensure that rights are conserved overall.
     const flattenAllocations = allocations =>
       allocations.flatMap(Object.values);
 
-    const previousAllocations = seatStagings.map(seatStaging =>
-      seatStaging.getSeat().getCurrentAllocation(),
-    );
+    const previousAllocations = seats.map(seat => seat.getCurrentAllocation());
     const previousAmounts = flattenAllocations(previousAllocations);
 
-    const newAllocations = seatStagings.map(seatStaging =>
-      seatStaging.getStagedAllocation(),
-    );
+    const newAllocations = seats.map(seat => seat.getStagedAllocation());
     const newAmounts = flattenAllocations(newAllocations);
 
     assertRightsConserved(previousAmounts, newAmounts);
 
-    reallocateInternal(seatStagings);
+    // Ensure that offer safety holds.
+    seats.forEach(seat => {
+      assert(
+        isOfferSafe(seat.getProposal(), seat.getStagedAllocation()),
+        X`Offer safety was violated by the proposed allocation: ${seat.getStagedAllocation()}. Proposal was ${seat.getProposal()}`,
+      );
+    });
+
+    reallocateInternal(seats);
   };
 
   /** @type {MakeZCFSeat} */
@@ -131,11 +199,26 @@ export const createSeatManager = (zoeInstanceAdmin, getAssetKindByBrand) => {
     zoeSeatAdmin,
     { proposal, notifier, initialAllocation, seatHandle },
   ) => {
+    /**
+     * @param {ZCFSeat} zcfSeat
+     */
+    const assertNoStagedAllocation = zcfSeat => {
+      if (hasStagedAllocation(zcfSeat)) {
+        assert.fail(
+          X`The seat could not be exited with a staged but uncommitted allocation: ${getStagedAllocation(
+            zcfSeat,
+          )}. Please reallocate over this seat or clear the staged allocation.`,
+        );
+      }
+    };
+
     /** @type {ZCFSeat} */
     const zcfSeat = Far('zcfSeat', {
       getNotifier: () => notifier,
       getProposal: () => proposal,
       exit: completion => {
+        assertActive(zcfSeat);
+        assertNoStagedAllocation(zcfSeat);
         doExitSeat(zcfSeat);
         E(zoeSeatAdmin).exit(completion);
       },
@@ -173,6 +256,7 @@ export const createSeatManager = (zoeInstanceAdmin, getAssetKindByBrand) => {
         return AmountMath.makeEmpty(brand, assetKind);
       },
       getCurrentAllocation: () => getCurrentAllocation(zcfSeat),
+      getStagedAllocation: () => getStagedAllocation(zcfSeat),
       isOfferSafe: newAllocation => {
         assertActive(zcfSeat);
         const currentAllocation = getCurrentAllocation(zcfSeat);
@@ -183,30 +267,31 @@ export const createSeatManager = (zoeInstanceAdmin, getAssetKindByBrand) => {
 
         return isOfferSafe(proposal, reallocation);
       },
-      stage: newAllocation => {
+      incrementBy: amountKeywordRecord => {
         assertActive(zcfSeat);
-        const currentAllocation = getCurrentAllocation(zcfSeat);
-        // Check offer safety.
-        const allocation = harden({
-          ...currentAllocation,
-          ...newAllocation,
-        });
-
-        assert(
-          isOfferSafe(proposal, allocation),
-          X`The reallocation was not offer safe`,
+        setStagedAllocation(
+          zcfSeat,
+          addToAllocation(getStagedAllocation(zcfSeat), amountKeywordRecord),
         );
-
-        const seatStaging = {
-          getSeat: () => zcfSeat,
-          getStagedAllocation: () => allocation,
-        };
-        seatStagingToSeatHandle.init(seatStaging, seatHandle);
-        return seatStaging;
+        return amountKeywordRecord;
       },
+      decrementBy: amountKeywordRecord => {
+        assertActive(zcfSeat);
+        setStagedAllocation(
+          zcfSeat,
+          subtractFromAllocation(
+            getStagedAllocation(zcfSeat),
+            amountKeywordRecord,
+          ),
+        );
+        return amountKeywordRecord;
+      },
+      clear,
+      hasStagedAllocation: () => hasStagedAllocation(zcfSeat),
     });
 
     activeZCFSeats.init(zcfSeat, initialAllocation);
+    zcfSeatToSeatHandle.init(zcfSeat, seatHandle);
 
     return zcfSeat;
   };
@@ -214,7 +299,7 @@ export const createSeatManager = (zoeInstanceAdmin, getAssetKindByBrand) => {
   /** @type {DropAllReferences} */
   const dropAllReferences = () => {
     activeZCFSeats = makeNonVOWeakStore('zcfSeat');
-    seatStagingToSeatHandle = makeNonVOWeakStore('seatStaging');
+    zcfSeatToSeatHandle = makeNonVOWeakStore('zcfSeat');
   };
 
   return harden({

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -57,7 +57,8 @@ export const createSeatManager = (zoeInstanceAdmin, getAssetKindByBrand) => {
    * @returns {void}
    */
   const commitStagedAllocation = zcfSeat => {
-    assertActive(zcfSeat);
+    // By this point, we have checked that the zcfSeat is a key in
+    // activeZCFSeats and in zcfSeatToStagedAllocations.
     activeZCFSeats.set(zcfSeat, zcfSeat.getStagedAllocation());
     zcfSeatToStagedAllocations.delete(zcfSeat);
   };
@@ -114,6 +115,13 @@ export const createSeatManager = (zoeInstanceAdmin, getAssetKindByBrand) => {
    * @type {ReallocateInternal}
    */
   const reallocateInternal = seats => {
+    // This check was already done in `reallocate`, but
+    // zcfMint.mintGains and zcfMint.burnLosses call
+    // `reallocateInternal` directly without calling `reallocate`, so
+    // we must check here as well.
+    seats.forEach(assertActive);
+    seats.forEach(assertStagedAllocation);
+
     // Keep track of seats used so far in this call, to prevent aliasing.
     const zcfSeatsSoFar = new WeakSet();
 
@@ -169,6 +177,7 @@ export const createSeatManager = (zoeInstanceAdmin, getAssetKindByBrand) => {
       X`reallocating must be done over two or more seats`,
     );
 
+    seats.forEach(assertActive);
     seats.forEach(assertStagedAllocation);
 
     // Ensure that rights are conserved overall.

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -10,7 +10,6 @@ import { makePromiseKit } from '@agoric/promise-kit';
 import { cleanProposal } from '../cleanProposal';
 import { evalContractBundle } from './evalContractCode';
 import { makeExitObj } from './exit';
-import { objectMap } from '../objArrayConversion';
 import { makeHandle } from '../makeHandle';
 import { makeIssuerStorage } from '../issuerStorage';
 import { makeIssuerRecord } from '../issuerRecord';
@@ -97,6 +96,15 @@ export const makeZCFZygote = (
     return { zcfSeat, userSeat: userSeatPromiseKit.promise };
   };
 
+  const assertAmountKeywordRecord = (amountKeywordRecord, name) => {
+    assert.typeof(
+      amountKeywordRecord,
+      'object',
+      X`${name} ${amountKeywordRecord} must be an amountKeywordRecord`,
+    );
+    assert(amountKeywordRecord !== null, X`${name} cannot be null`);
+  };
+
   /** @type {MakeZCFMint} */
   const makeZCFMint = async (
     keyword,
@@ -123,80 +131,44 @@ export const makeZCFZygote = (
     );
     recordIssuer(keyword, mintyIssuerRecord);
 
+    const empty = AmountMath.makeEmpty(mintyBrand, assetKind);
+    const add = (total, amountToAdd) => {
+      return AmountMath.add(total, amountToAdd, mintyBrand);
+    };
+
     /** @type {ZCFMint} */
     const zcfMint = Far('zcfMint', {
       getIssuerRecord: () => {
         return mintyIssuerRecord;
       },
       mintGains: (gains, zcfSeat = undefined) => {
-        assert.typeof(
-          gains,
-          'object',
-          X`gains ${gains} must be an amountKeywordRecord`,
-        );
-        assert(gains !== null, X`gains cannot be null`);
+        assertAmountKeywordRecord(gains, 'gains');
         if (zcfSeat === undefined) {
           zcfSeat = makeEmptySeatKit().zcfSeat;
         }
-        let totalToMint = AmountMath.makeEmpty(mintyBrand, assetKind);
-        const oldAllocation = zcfSeat.getCurrentAllocation();
-        const updates = objectMap(gains, ([seatKeyword, amountToAdd]) => {
-          assert(
-            totalToMint.brand === amountToAdd.brand,
-            X`Only digital assets of brand ${totalToMint.brand} can be minted in this call. ${amountToAdd} has the wrong brand.`,
-          );
-          totalToMint = AmountMath.add(totalToMint, amountToAdd);
-          const oldAmount = oldAllocation[seatKeyword];
-          // oldAmount being absent is equivalent to empty.
-          const newAmount = oldAmount
-            ? AmountMath.add(oldAmount, amountToAdd)
-            : amountToAdd;
-          return [seatKeyword, newAmount];
-        });
-        const newAllocation = harden({
-          ...oldAllocation,
-          ...updates,
-        });
+        const totalToMint = Object.values(gains).reduce(add, empty);
+        zcfSeat.incrementBy(gains);
         // verifies offer safety
-        const seatStaging = zcfSeat.stage(newAllocation);
+        assert(zcfSeat.isOfferSafe(zcfSeat.getStagedAllocation()));
         // No effects above. COMMIT POINT. The following two steps
         // *should* be committed atomically, but it is not a
         // disaster if they are not. If we minted only, no one would
         // ever get those invisibly-minted assets.
         E(zoeMintP).mintAndEscrow(totalToMint);
-        reallocateInternal([seatStaging]);
+        reallocateInternal([zcfSeat]);
         return zcfSeat;
       },
       burnLosses: (losses, zcfSeat) => {
-        assert.typeof(
-          losses,
-          'object',
-          X`losses ${losses} must be an amountKeywordRecord`,
-        );
-        assert(losses !== null, X`losses cannot be null`);
-        let totalToBurn = AmountMath.makeEmpty(mintyBrand, assetKind);
-        const oldAllocation = zcfSeat.getCurrentAllocation();
-        const updates = objectMap(losses, ([seatKeyword, amountToSubtract]) => {
-          assert(
-            totalToBurn.brand === amountToSubtract.brand,
-            X`Only digital assets of brand ${totalToBurn.brand} can be burned in this call. ${amountToSubtract} has the wrong brand.`,
-          );
-          totalToBurn = AmountMath.add(totalToBurn, amountToSubtract);
-          const oldAmount = oldAllocation[seatKeyword];
-          const newAmount = AmountMath.subtract(oldAmount, amountToSubtract);
-          return [seatKeyword, newAmount];
-        });
-        const newAllocation = harden({
-          ...oldAllocation,
-          ...updates,
-        });
+        assertAmountKeywordRecord(losses, 'losses');
+        const totalToBurn = Object.values(losses).reduce(add, empty);
+        zcfSeat.decrementBy(losses);
         // verifies offer safety
-        const seatStaging = zcfSeat.stage(newAllocation);
+        assert(zcfSeat.isOfferSafe(zcfSeat.getStagedAllocation()));
         // No effects above. Commit point. The following two steps
-        // *should* be committed atomically, but it is not a
-        // disaster if they are not. If we only commit the staging,
-        // no one would ever get the unburned assets.
-        reallocateInternal([seatStaging]);
+        // *should* be committed atomically, but it is not a disaster
+        // if they are not. If we only commit the stagedAllocation no
+        // one would ever get the unburned assets.
+        reallocateInternal([zcfSeat]);
         E(zoeMintP).withdrawAndBurn(totalToBurn);
       },
     });

--- a/packages/zoe/src/contractSupport/index.js
+++ b/packages/zoe/src/contractSupport/index.js
@@ -25,7 +25,6 @@ export * from './statistics';
 
 export {
   defaultAcceptanceMsg,
-  trade,
   swap,
   assertProposalShape,
   assertIssuerKeywords,

--- a/packages/zoe/src/contractSupport/types.js
+++ b/packages/zoe/src/contractSupport/types.js
@@ -2,18 +2,6 @@
 /// <reference types="ses"/>
 
 /**
- * @callback Trade
- * Trade between left and right so that left and right end up with
- * the declared gains and losses.
- * @param {ContractFacet} zcf
- * @param {SeatGainsLossesRecord} left
- * @param {SeatGainsLossesRecord} right
- * @param {string} [leftHasExitedMsg] A custom error message if
- * the left seat has been exited already
- * @param {string} [rightHasExitedMsg] A custom error message if the
- * right seat has been exited already
- * @returns {void}
- *
  * @typedef {Object} SeatGainsLossesRecord
  * @property {ZCFSeat} seat
  * @property {AmountKeywordRecord} gains - what the seat will
@@ -34,10 +22,24 @@
  * gives 5 moola and seat B only wants 3 moola, seat A retains 2
  * moola.
  *
- * If leftSeat has exited already, both seats will fail
- * with an error message (provided by 'leftHasExitedMsg'). Similarly,
- * if rightSeat has exited already, both seats fail
- * with an error message (provided by 'rightHasExitedMsg').
+ * If the swap fails, no assets are transferred, both seats will fail,
+ * and the function throws.
+ *
+ * The keywords for both seats must match.
+ *
+ * @param {ContractFacet} zcf
+ * @param {ZCFSeat} leftSeat
+ * @param {ZCFSeat} rightSeat
+ * @returns {string}
+ */
+
+/**
+ * @callback SwapExact
+ *
+ * Swap such that both seats gain what they want and lose everything
+ * that they gave. Only good for exact and entire swaps where each
+ * seat wants everything that the other seat has. The benefit of using
+ * this method is that the keywords of each seat do not matter.
  *
  * If the swap fails, no assets are transferred, both seats will fail,
  * and the function throws.
@@ -45,8 +47,6 @@
  * @param {ContractFacet} zcf
  * @param {ZCFSeat} leftSeat
  * @param {ZCFSeat} rightSeat
- * @param {string} [leftHasExitedMsg]
- * @param {string} [rightHasExitedMsg]
  * @returns {string}
  */
 

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -6,73 +6,13 @@ import { sameStructure } from '@agoric/same-structure';
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
 
-import { AssetKind, AmountMath } from '@agoric/ertp';
+import { AssetKind } from '@agoric/ertp';
 import { satisfiesWant } from '../contractFacet/offerSafety';
-import { objectMap } from '../objArrayConversion';
 
 export const defaultAcceptanceMsg = `The offer has been accepted. Once the contract has been completed, please check your payout`;
 
 const getKeysSorted = obj =>
   harden(Object.getOwnPropertyNames(obj || {}).sort());
-
-/**
- * Given toGains (an AmountKeywordRecord), and allocations (a pair,
- * 'to' and 'from', of Allocations), all the entries in
- * toGains will be added to 'to'. If fromLosses is defined, all the
- * entries in fromLosses are subtracted from 'from'. (If fromLosses
- * is not defined, toGains is subtracted from 'from'.)
- *
- * @param {FromToAllocations} allocations - the 'to' and 'from'
- * allocations
- * @param {AmountKeywordRecord} toGains - what should be gained in
- * the 'to' allocation
- * @param {AmountKeywordRecord} [fromLosses=toGains] - what should be lost in
- * the 'from' allocation. If not defined, fromLosses is equal to
- * toGains. Note that the total amounts should always be equal; it
- * is the keywords that might be different.
- * @returns {FromToAllocations} allocations - new allocations
- *
- * @typedef FromToAllocations
- * @property {Allocation} from
- * @property {Allocation} to
- */
-const calcNewAllocations = (allocations, toGains, fromLosses = toGains) => {
-  const subtract = (amount, amountToSubtract) => {
-    if (amountToSubtract !== undefined) {
-      return AmountMath.subtract(amount, amountToSubtract);
-    }
-    return amount;
-  };
-
-  const add = (amount, amountToAdd) => {
-    if (amount && amountToAdd) {
-      return AmountMath.add(amount, amountToAdd);
-    }
-    return amount || amountToAdd;
-  };
-
-  const newFromAllocation = objectMap(
-    allocations.from,
-    ([keyword, allocAmount]) => [
-      keyword,
-      subtract(allocAmount, fromLosses[keyword]),
-    ],
-  );
-
-  const allToKeywords = Object.keys({ ...allocations.to, ...toGains });
-
-  const newToAllocation = Object.fromEntries(
-    allToKeywords.map(keyword => [
-      keyword,
-      add(allocations.to[keyword], toGains[keyword]),
-    ]),
-  );
-
-  return harden({
-    from: newFromAllocation,
-    to: newToAllocation,
-  });
-};
 
 export const assertIssuerKeywords = (zcf, expected) => {
   const { issuers } = zcf.getTerms();
@@ -111,100 +51,16 @@ export const satisfies = (zcf, seat, update) => {
   return satisfiesWant(proposal, newAllocation);
 };
 
-/** @type {Trade} */
-export const trade = (
-  zcf,
-  left,
-  right,
-  leftHasExitedMsg = 'the left seat has exited',
-  rightHasExitedMsg = 'the right seat has exited',
-) => {
-  assert(left.seat !== right.seat, X`a seat cannot trade with itself`);
-  assert(!left.seat.hasExited(), leftHasExitedMsg);
-  assert(!right.seat.hasExited(), rightHasExitedMsg);
-  let leftAllocation = left.seat.getCurrentAllocation();
-  let rightAllocation = right.seat.getCurrentAllocation();
-  try {
-    // for all the keywords and amounts in left.gains, transfer from
-    // right to left
-    ({ from: rightAllocation, to: leftAllocation } = calcNewAllocations(
-      { from: rightAllocation, to: leftAllocation },
-      left.gains,
-      right.losses,
-    ));
-    // For all the keywords and amounts in right.gains, transfer from
-    // left to right
-    ({ from: leftAllocation, to: rightAllocation } = calcNewAllocations(
-      { from: leftAllocation, to: rightAllocation },
-      right.gains,
-      left.losses,
-    ));
-  } catch (err) {
-    const newErr = new Error(
-      `The trade between left ${left} and right ${right} failed.`,
-    );
-    assert.note(newErr, X`due to ${err}`);
-    throw newErr;
-  }
-
-  // Check whether reallocate would error before calling. If
-  // it would error, log information and throw.
-  const offerSafeForLeft = left.seat.isOfferSafe(leftAllocation);
-  const offerSafeForRight = right.seat.isOfferSafe(rightAllocation);
-  if (!(offerSafeForLeft && offerSafeForRight)) {
-    console.log(`currentLeftAllocation`, left.seat.getCurrentAllocation());
-    console.log(`currentRightAllocation`, right.seat.getCurrentAllocation());
-    console.log(`proposed left reallocation`, leftAllocation);
-    console.log(`proposed right reallocation`, rightAllocation);
-    // show the constraints
-    console.log(`left want`, left.seat.getProposal().want);
-    console.log(`right want`, right.seat.getProposal().want);
-
-    if (!offerSafeForLeft) {
-      console.log(`offer not safe for left`);
-    }
-    if (!offerSafeForRight) {
-      console.log(`offer not safe for right`);
-    }
-    throw new Error(
-      `The trade between left ${left} and right ${right} failed offer safety. Please check the log for more information`,
-    );
-  }
-
-  try {
-    zcf.reallocate(
-      left.seat.stage(leftAllocation),
-      right.seat.stage(rightAllocation),
-    );
-  } catch (err) {
-    const newErr = Error(`The reallocation failed to conserve rights.`);
-    assert.note(newErr, X`due to ${err}`);
-    throw newErr;
-  }
-};
-
 /** @type {Swap} */
-export const swap = (
-  zcf,
-  leftSeat,
-  rightSeat,
-  leftHasExitedMsg = 'the left seat in swap() has exited',
-  rightHasExitedMsg = 'the right seat in swap() has exited',
-) => {
+export const swap = (zcf, leftSeat, rightSeat) => {
   try {
-    trade(
-      zcf,
-      {
-        seat: leftSeat,
-        gains: leftSeat.getProposal().want,
-      },
-      {
-        seat: rightSeat,
-        gains: rightSeat.getProposal().want,
-      },
-      leftHasExitedMsg,
-      rightHasExitedMsg,
-    );
+    rightSeat.decrementBy(leftSeat.getProposal().want);
+    leftSeat.incrementBy(leftSeat.getProposal().want);
+
+    leftSeat.decrementBy(rightSeat.getProposal().want);
+    rightSeat.incrementBy(rightSeat.getProposal().want);
+
+    zcf.reallocate(leftSeat, rightSeat);
   } catch (err) {
     leftSeat.fail(err);
     rightSeat.fail(err);
@@ -216,36 +72,16 @@ export const swap = (
   return defaultAcceptanceMsg;
 };
 
-/**
- * @type {Swap}
- * Swap such that both seats gain what they want and lose everything
- * that they gave. Only good for exact and entire swaps where each
- * seat wants everything that the other seat has. The benefit of using
- * this method is that the keywords of each seat do not matter.
- */
-export const swapExact = (
-  zcf,
-  leftSeat,
-  rightSeat,
-  leftHasExitedMsg = 'the left seat in swapExact() has exited',
-  rightHasExitedMsg = 'the right seat in swapExact() has exited',
-) => {
+/** @type {SwapExact} */
+export const swapExact = (zcf, leftSeat, rightSeat) => {
   try {
-    trade(
-      zcf,
-      {
-        seat: leftSeat,
-        gains: leftSeat.getProposal().want,
-        losses: leftSeat.getProposal().give,
-      },
-      {
-        seat: rightSeat,
-        gains: rightSeat.getProposal().want,
-        losses: rightSeat.getProposal().give,
-      },
-      leftHasExitedMsg,
-      rightHasExitedMsg,
-    );
+    rightSeat.decrementBy(rightSeat.getProposal().give);
+    leftSeat.incrementBy(leftSeat.getProposal().want);
+
+    leftSeat.decrementBy(leftSeat.getProposal().give);
+    rightSeat.incrementBy(rightSeat.getProposal().want);
+
+    zcf.reallocate(leftSeat, rightSeat);
   } catch (err) {
     leftSeat.fail(err);
     rightSeat.fail(err);
@@ -342,11 +178,9 @@ export async function depositToSeat(zcf, recipientSeat, amounts, payments) {
     // exit the temporary seat. Note that the offerResult is the return value of this
     // function, so this synchronous trade must happen before the
     // offerResult resolves.
-    trade(
-      zcf,
-      { seat: tempSeat, gains: {} },
-      { seat: recipientSeat, gains: amounts },
-    );
+    tempSeat.decrementBy(amounts);
+    recipientSeat.incrementBy(amounts);
+    zcf.reallocate(tempSeat, recipientSeat);
     tempSeat.exit();
     return depositToSeatSuccessMsg;
   }
@@ -379,7 +213,9 @@ export async function depositToSeat(zcf, recipientSeat, amounts, payments) {
 export async function withdrawFromSeat(zcf, seat, amounts) {
   assert(!seat.hasExited(), 'The seat cannot have exited.');
   const { zcfSeat: tempSeat, userSeat: tempUserSeatP } = zcf.makeEmptySeatKit();
-  trade(zcf, { seat: tempSeat, gains: amounts }, { seat, gains: {} });
+  seat.decrementBy(amounts);
+  tempSeat.incrementBy(amounts);
+  zcf.reallocate(tempSeat, seat);
   tempSeat.exit();
   return E(tempUserSeatP).getPayouts();
 }
@@ -482,17 +318,17 @@ export const offerTo = async (
  * before performing a reallocation.
  *
  * @param {ContractFacet} zcf
- * @param {(stagings: SeatStaging[]) => void} assertFn - an assertion
+ * @param {(seats: ZCFSeat[]) => void} assertFn - an assertion
  * that must be true for the reallocate to occur
  * @returns {ContractFacet}
  */
 export const checkZCF = (zcf, assertFn) => {
   const checkedZCF = harden({
     ...zcf,
-    reallocate: (...stagings) => {
-      assertFn(stagings);
+    reallocate: (...seats) => {
+      assertFn(seats);
       // @ts-ignore The types aren't right for spreading
-      zcf.reallocate(...stagings);
+      zcf.reallocate(...seats);
     },
   });
   return checkedZCF;

--- a/packages/zoe/src/contracts/auction/secondPriceLogic.js
+++ b/packages/zoe/src/contracts/auction/secondPriceLogic.js
@@ -48,21 +48,14 @@ export const calcWinnerAndClose = (zcf, sellSeat, bidSeats) => {
     secondHighestBid = highestBid;
   }
 
-  const winnerRefund = AmountMath.subtract(
-    highestBid,
-    secondHighestBid,
-    bidBrand,
-  );
+  // Everyone else gets a refund so their values remain the same.
+  highestBidSeat.decrementBy({ Bid: secondHighestBid });
+  sellSeat.incrementBy({ Ask: secondHighestBid });
 
-  // Everyone else gets a refund so their values remain the
-  // same.
-  zcf.reallocate(
-    sellSeat.stage({
-      Asset: AmountMath.makeEmptyFromAmount(assetAmount),
-      Ask: secondHighestBid,
-    }),
-    highestBidSeat.stage({ Asset: assetAmount, Bid: winnerRefund }),
-  );
+  sellSeat.decrementBy({ Asset: assetAmount });
+  highestBidSeat.incrementBy({ Asset: assetAmount });
+
+  zcf.reallocate(sellSeat, highestBidSeat);
   sellSeat.exit();
   bidSeats.forEach(bidSeat => {
     if (!bidSeat.hasExited()) {

--- a/packages/zoe/src/contracts/callSpread/fundedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/fundedCallSpread.js
@@ -10,7 +10,6 @@ import { AmountMath } from '@agoric/ertp';
 import {
   assertProposalShape,
   depositToSeat,
-  trade,
   assertNatAssetKind,
 } from '../../contractSupport';
 import { makePayoffHandler } from './payoffHandler';
@@ -111,18 +110,16 @@ const start = async zcf => {
         give: { Collateral: null },
         want: { LongOption: null, ShortOption: null },
       });
-
-      trade(
-        zcf,
-        {
-          seat: collateralSeat,
-          gains: { Collateral: settlementAmount },
-        },
-        {
-          seat: creatorSeat,
-          gains: { LongOption: longAmount, ShortOption: shortAmount },
-        },
+      collateralSeat.incrementBy(
+        creatorSeat.decrementBy({ Collateral: settlementAmount }),
       );
+      creatorSeat.incrementBy(
+        collateralSeat.decrementBy({
+          LongOption: longAmount,
+          ShortOption: shortAmount,
+        }),
+      );
+      zcf.reallocate(collateralSeat, creatorSeat);
       payoffHandler.schedulePayoffs();
       creatorSeat.exit();
     };

--- a/packages/zoe/src/contracts/callSpread/payoffHandler.js
+++ b/packages/zoe/src/contracts/callSpread/payoffHandler.js
@@ -5,7 +5,7 @@ import './types';
 
 import { E } from '@agoric/eventual-send';
 import { AmountMath } from '@agoric/ertp';
-import { trade, getAmountOut, multiplyBy } from '../../contractSupport';
+import { getAmountOut, multiplyBy } from '../../contractSupport';
 import { Position } from './position';
 import { calculateShares } from './calculateShares';
 
@@ -38,11 +38,8 @@ function makePayoffHandler(zcf, seatPromiseKits, collateralSeat) {
     seatPromise.then(seat => {
       const totalCollateral = terms.settlementAmount;
       const seatPortion = multiplyBy(totalCollateral, sharePercent);
-      trade(
-        zcf,
-        { seat, gains: { Collateral: seatPortion } },
-        { seat: collateralSeat, gains: {} },
-      );
+      seat.incrementBy(collateralSeat.decrementBy({ Collateral: seatPortion }));
+      zcf.reallocate(seat, collateralSeat);
       seat.exit();
       seatsExited += 1;
       const remainder = collateralSeat.getAmountAllocated('Collateral');

--- a/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
@@ -11,7 +11,6 @@ import { AmountMath } from '@agoric/ertp';
 import {
   assertProposalShape,
   depositToSeat,
-  trade,
   assertNatAssetKind,
   makeRatio,
   multiplyBy,
@@ -135,15 +134,12 @@ const start = zcf => {
         X`wanted option not a match`,
       );
 
-      trade(
-        zcf,
-        { seat: depositSeat, gains: spreadAmount },
-        {
-          seat: collateralSeat,
-          gains: { Collateral: newCollateral },
-          losses: spreadAmount,
-        },
+      depositSeat.incrementBy(collateralSeat.decrementBy(spreadAmount));
+      collateralSeat.incrementBy(
+        depositSeat.decrementBy({ Collateral: newCollateral }),
       );
+
+      zcf.reallocate(collateralSeat, depositSeat);
       depositSeat.exit();
     };
 

--- a/packages/zoe/src/contracts/loan/addCollateral.js
+++ b/packages/zoe/src/contracts/loan/addCollateral.js
@@ -2,7 +2,7 @@
 
 import '../../../exported';
 
-import { assertProposalShape, trade } from '../../contractSupport';
+import { assertProposalShape } from '../../contractSupport';
 
 import { scheduleLiquidation } from './scheduleLiquidation';
 
@@ -20,19 +20,13 @@ export const makeAddCollateralInvitation = (zcf, config) => {
       want: {},
     });
 
-    trade(
-      zcf,
-      {
-        seat: collateralSeat,
-        gains: {
-          Collateral: addCollateralSeat.getAmountAllocated('Collateral'),
-        },
-      },
-      {
-        seat: addCollateralSeat,
-        gains: {},
-      },
+    collateralSeat.incrementBy(
+      addCollateralSeat.decrementBy({
+        Collateral: addCollateralSeat.getAmountAllocated('Collateral'),
+      }),
     );
+
+    zcf.reallocate(collateralSeat, addCollateralSeat);
     addCollateralSeat.exit();
 
     // Schedule the new liquidation trigger. The old one will have an

--- a/packages/zoe/src/contracts/loan/borrow.js
+++ b/packages/zoe/src/contracts/loan/borrow.js
@@ -10,7 +10,6 @@ import { AmountMath } from '@agoric/ertp';
 
 import {
   assertProposalShape,
-  trade,
   getAmountOut,
   multiplyBy,
   getTimestamp,
@@ -80,26 +79,14 @@ export const makeBorrowInvitation = (zcf, config) => {
 
     const { zcfSeat: collateralSeat } = zcf.makeEmptySeatKit();
 
-    // Transfer the wanted Loan amount to the collateralSeat
-    trade(
-      zcf,
-      {
-        seat: lenderSeat,
-        gains: {},
-      },
-      { seat: collateralSeat, gains: { Loan: loanWanted } },
-    );
+    // Transfer the wanted Loan amount to the borrower
+    borrowerSeat.incrementBy(lenderSeat.decrementBy({ Loan: loanWanted }));
 
-    // Transfer *all* collateral to the collateral seat. Transfer the
-    // wanted Loan amount to the borrower.
-    trade(
-      zcf,
-      {
-        seat: collateralSeat,
-        gains: { Collateral: collateralGiven },
-      },
-      { seat: borrowerSeat, gains: { Loan: loanWanted } },
+    // Transfer *all* collateral to the collateral seat.
+    collateralSeat.incrementBy(
+      borrowerSeat.decrementBy({ Collateral: collateralGiven }),
     );
+    zcf.reallocate(lenderSeat, borrowerSeat, collateralSeat);
 
     // We now exit the borrower seat so that the borrower gets their
     // loan. However, the borrower gets an object as their offerResult

--- a/packages/zoe/src/contracts/loan/scheduleLiquidation.js
+++ b/packages/zoe/src/contracts/loan/scheduleLiquidation.js
@@ -55,10 +55,10 @@ export const scheduleLiquidation = (zcf, configWithBorrower) => {
       // collateral is on the collateral seat. If an error occurs, we
       // reallocate the collateral to the lender and shutdown the
       // contract, kicking out any remaining seats.
-      zcf.reallocate(
-        lenderSeat.stage({ Collateral: allCollateral }),
-        collateralSeat.stage({}),
+      lenderSeat.incrementBy(
+        collateralSeat.decrementBy({ Collateral: allCollateral }),
       );
+      zcf.reallocate(lenderSeat, collateralSeat);
       zcf.shutdownWithFailure(err);
       throw err;
     });

--- a/packages/zoe/src/contracts/multipoolAutoswap/constantProduct.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/constantProduct.js
@@ -18,17 +18,15 @@ const calcK = allocation => {
 
 /**
  *
- * @param {SeatStaging[]} stagings
+ * @param {ZCFSeat[]} seats
  */
-export const assertConstantProduct = stagings => {
-  stagings.forEach(seatStaging => {
-    const seat = seatStaging.getSeat();
+export const assertConstantProduct = seats => {
+  seats.forEach(seat => {
     const priorAllocation = seat.getCurrentAllocation();
-    const stagedAllocation = seatStaging.getStagedAllocation();
+    const stagedAllocation = seat.getStagedAllocation();
     if (isPoolSeat(stagedAllocation)) {
       const oldK = calcK(priorAllocation);
       const newK = calcK(stagedAllocation);
-      console.log('oldK', oldK, 'newK', newK);
       assert(
         newK >= oldK,
         X`the product of the pool tokens must not decrease as the result of a trade. ${oldK} decreased to ${newK}`,

--- a/packages/zoe/src/contracts/multipoolAutoswap/types.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/types.js
@@ -41,7 +41,6 @@
  * @property {(seat: ZCFSeat) => string} addLiquidity
  * @property {(seat: ZCFSeat) => string} removeLiquidity
  * @property {() => ZCFSeat} getPoolSeat
- * @property {(newAllocation: Allocation) => SeatStaging} stageSeat
  * @property {() => Amount} getSecondaryAmount
  * @property {() => Amount} getCentralAmount
  * @property {() => Notifier} getNotifier

--- a/packages/zoe/src/contracts/newSwap/collectFees.js
+++ b/packages/zoe/src/contracts/newSwap/collectFees.js
@@ -4,14 +4,15 @@ import { AmountMath } from '@agoric/ertp';
 
 export const makeMakeCollectFeesInvitation = (zcf, feeSeat, centralBrand) => {
   const collectFees = seat => {
-    const allocation = feeSeat.getAmountAllocated('RUN', centralBrand);
+    // Ensure that the feeSeat has a stagedAllocation with a RUN keyword
+    feeSeat.incrementBy({ RUN: AmountMath.makeEmpty(centralBrand) });
+    const amount = feeSeat.getAmountAllocated('RUN', centralBrand);
 
-    zcf.reallocate(
-      seat.stage({ RUN: allocation }),
-      feeSeat.stage({ RUN: AmountMath.makeEmpty(centralBrand) }),
-    );
+    seat.incrementBy(feeSeat.decrementBy({ RUN: amount }));
+    zcf.reallocate(seat, feeSeat);
+
     seat.exit();
-    return `paid out ${allocation.value}`;
+    return `paid out ${amount.value}`;
   };
 
   const makeCollectFeesInvitation = () =>

--- a/packages/zoe/src/contracts/newSwap/swap.js
+++ b/packages/zoe/src/contracts/newSwap/swap.js
@@ -75,9 +75,6 @@ export const makeMakeSwapInvitation = (
     seat.incrementBy({ Out: amountOut });
 
     // Transfer protocolFee
-    // TODO: this should be transferred directly from the user such
-    // that there's no way to accidentally take more than expected
-    // from the pool.
     poolSeat.decrementBy({ Central: protocolFee });
     protocolSeat.incrementBy({ RUN: protocolFee });
 
@@ -104,7 +101,12 @@ export const makeMakeSwapInvitation = (
     brandInPoolSeat.incrementBy({ Secondary: amountIn });
 
     // Transfer protocolFee from the brandInPool
-    // TODO: Why the brandInPool? Should this be split over both?
+
+    // Note: the protocolFee is effectively shared between the
+    // brandInPool and the brandOutPool. We subtract the protocolFee
+    // from brandInPool directly, and we subtract more value from
+    // brandOutPool than we otherwise would, thus taking part of the
+    // fee from brandOutPool too.
     brandInPoolSeat.decrementBy({ Central: protocolFee });
     protocolSeat.incrementBy({ RUN: protocolFee });
 

--- a/packages/zoe/src/contracts/newSwap/swap.js
+++ b/packages/zoe/src/contracts/newSwap/swap.js
@@ -27,199 +27,157 @@ export const makeMakeSwapInvitation = (
   getPriceGivenRequiredOutput,
   protocolSeat,
 ) => {
-  function stageProtocolSeatFee(protocolFee) {
-    const protocolStage = protocolSeat.stage({
-      RUN: AmountMath.add(
-        protocolSeat.getAmountAllocated('RUN', protocolFee.brand),
-        protocolFee,
-      ),
-    });
-    return protocolStage;
-  }
-
-  function poolStagingFromCentral(amountIn, amountOut, protocolFee) {
+  const reallocateCentralToSecondary = (
+    seat,
+    protocolFee,
+    amountIn,
+    amountOut,
+  ) => {
     const pool = getPool(amountOut.brand);
-    // gains (amountIn - protocolFee), loses amountOut
-    return pool.stageSeat({
-      Central: AmountMath.add(
-        pool.getCentralAmount(),
-        AmountMath.subtract(amountIn, protocolFee),
-      ),
-      Secondary: AmountMath.subtract(pool.getSecondaryAmount(), amountOut),
-    });
-  }
+    const poolSeat = pool.getPoolSeat();
 
-  function poolStagingToCentral(amountIn, amountOut, protocolFee) {
+    // Transfer amountIn from the user
+    seat.decrementBy({ In: amountIn });
+    poolSeat.incrementBy({ Central: amountIn });
+
+    // Transfer protocolFee
+
+    // TODO: this should be transferred directly from the user such
+    // that there's no way to accidentally take more than expected
+    // from the pool.
+    poolSeat.decrementBy({ Central: protocolFee });
+    protocolSeat.incrementBy({ RUN: protocolFee });
+
+    // Transfer amountOut from the pool
+    poolSeat.decrementBy({ Secondary: amountOut });
+    seat.incrementBy({ Out: amountOut });
+
+    zcf.reallocate(poolSeat, seat, protocolSeat);
+    seat.exit();
+    pool.updateState();
+  };
+
+  const reallocateSecondaryToCentral = (
+    seat,
+    protocolFee,
+    amountIn,
+    amountOut,
+  ) => {
     const pool = getPool(amountIn.brand);
-    // gains reducedAmountIn, loses (amountOut + protocolFee)
-    return pool.stageSeat({
-      Central: AmountMath.subtract(
-        pool.getCentralAmount(),
-        AmountMath.add(amountOut, protocolFee),
-      ),
-      Secondary: AmountMath.add(pool.getSecondaryAmount(), amountIn),
-    });
-  }
+    const poolSeat = pool.getPoolSeat();
 
-  function secondaryPoolStagings(
+    // Transfer amountIn from the user
+    seat.decrementBy({ In: amountIn });
+    poolSeat.incrementBy({ Secondary: amountIn });
+
+    // Transfer amountOut from the pool
+    poolSeat.decrementBy({ Central: amountOut });
+    seat.incrementBy({ Out: amountOut });
+
+    // Transfer protocolFee
+    // TODO: this should be transferred directly from the user such
+    // that there's no way to accidentally take more than expected
+    // from the pool.
+    poolSeat.decrementBy({ Central: protocolFee });
+    protocolSeat.incrementBy({ RUN: protocolFee });
+
+    zcf.reallocate(poolSeat, seat, protocolSeat);
+    seat.exit();
+    pool.updateState();
+  };
+
+  const reallocateSecondaryToSecondary = (
+    seat,
+    protocolFee,
     amountIn,
     amountOut,
     centralAmount,
-    protocolFee,
-  ) {
+  ) => {
     const brandInPool = getPool(amountIn.brand);
-    // gains reducedAmountIn, loses (centralAmount + protocolFee)
-    const brandInStaging = brandInPool.stageSeat({
-      Secondary: AmountMath.add(brandInPool.getSecondaryAmount(), amountIn),
-      Central: AmountMath.subtract(
-        brandInPool.getCentralAmount(),
-        AmountMath.add(centralAmount, protocolFee),
-      ),
-    });
+    const brandInPoolSeat = brandInPool.getPoolSeat();
 
     const brandOutPool = getPool(amountOut.brand);
-    // gains centralAmount, loses amountOut
-    const brandOutStaging = brandOutPool.stageSeat({
-      Central: AmountMath.add(brandOutPool.getCentralAmount(), centralAmount),
-      Secondary: AmountMath.subtract(
-        brandOutPool.getSecondaryAmount(),
-        amountOut,
-      ),
-    });
-    return [brandInStaging, brandOutStaging];
-  }
+    const brandOutPoolSeat = brandOutPool.getPoolSeat();
 
-  // trade with a stated amountIn.
-  const swapIn = seat => {
+    // Transfer amountIn from the user
+    seat.decrementBy({ In: amountIn });
+    brandInPoolSeat.incrementBy({ Secondary: amountIn });
+
+    // Transfer protocolFee from the brandInPool
+    // TODO: Why the brandInPool? Should this be split over both?
+    brandInPoolSeat.decrementBy({ Central: protocolFee });
+    protocolSeat.incrementBy({ RUN: protocolFee });
+
+    // Transfer Central between pools
+    brandInPoolSeat.decrementBy({ Central: centralAmount });
+    brandOutPoolSeat.incrementBy({ Central: centralAmount });
+
+    // Transfer amountOut from the pool
+    brandOutPoolSeat.decrementBy({ Secondary: amountOut });
+    seat.incrementBy({ Out: amountOut });
+
+    zcf.reallocate(brandInPoolSeat, brandOutPoolSeat, seat, protocolSeat);
+    seat.exit();
+    brandInPool.updateState();
+    brandOutPool.updateState();
+  };
+
+  const reallocate = (
+    seat,
+    { protocolFee, amountIn, amountOut, centralAmount },
+  ) => {
+    // central to secondary, secondary to central, or secondary to secondary
+    if (isCentral(amountIn.brand) && isSecondary(amountOut.brand)) {
+      reallocateCentralToSecondary(seat, protocolFee, amountIn, amountOut);
+    } else if (isSecondary(amountIn.brand) && isCentral(amountOut.brand)) {
+      reallocateSecondaryToCentral(seat, protocolFee, amountIn, amountOut);
+    } else if (isSecondary(amountIn.brand) && isSecondary(amountOut.brand)) {
+      reallocateSecondaryToSecondary(
+        seat,
+        protocolFee,
+        amountIn,
+        amountOut,
+        centralAmount,
+      );
+    } else {
+      assert.fail(X`brands were not recognized`);
+    }
+  };
+
+  const doSwap = (seat, getPriceFn) => {
     assertProposalShape(seat, {
       give: { In: null },
       want: { Out: null },
     });
     const {
       give: { In: amountIn },
-      want: {
-        Out: { brand: brandOut },
-      },
+      want: { Out: amountOut },
     } = seat.getProposal();
-    const { brand: brandIn } = amountIn;
 
-    const {
-      amountIn: reducedAmountIn,
-      amountOut,
-      protocolFee,
-      // @ts-ignore two pool version of getPrice returns central
-      centralAmount,
-    } = getPriceGivenAvailableInput(amountIn, brandOut);
+    const prices = getPriceFn(amountIn, amountOut);
 
-    const stagings = [];
-    stagings.push(stageProtocolSeatFee(protocolFee));
-    stagings.push(
-      seat.stage(
-        harden({
-          In: AmountMath.subtract(amountIn, reducedAmountIn),
-          Out: amountOut,
-        }),
-      ),
-    );
+    const amountInCoversCosts = AmountMath.isGTE(amountIn, prices.amountIn);
 
-    // central to secondary, secondary to central, or secondary to secondary
-    const pools = [];
-    if (isCentral(brandIn) && isSecondary(brandOut)) {
-      stagings.push(
-        poolStagingFromCentral(reducedAmountIn, amountOut, protocolFee),
-      );
-      pools.push(getPool(brandOut));
-    } else if (isSecondary(brandIn) && isCentral(brandOut)) {
-      stagings.push(
-        poolStagingToCentral(reducedAmountIn, amountOut, protocolFee),
-      );
-      pools.push(getPool(brandIn));
-    } else if (isSecondary(brandIn) && isSecondary(brandOut)) {
-      const secondaryStagings = secondaryPoolStagings(
-        reducedAmountIn,
-        amountOut,
-        centralAmount,
-        protocolFee,
-      );
-      stagings.push(...secondaryStagings);
-      pools.push(getPool(brandIn), getPool(brandOut));
-    } else {
-      assert.fail(X`brands were not recognized`);
+    if (!amountInCoversCosts) {
+      const reason = `offeredAmountIn ${amountIn} is insufficient to buy amountOut ${amountOut}. ${prices.amountIn} is required.`;
+      throw seat.fail(Error(reason));
     }
-
-    // @ts-ignore typescript can't tell that we started by adding two stagings
-    zcf.reallocate(...stagings);
-    seat.exit();
-    pools.forEach(p => p.updateState());
+    reallocate(seat, prices);
     return SUCCESS_STRING;
   };
 
-  // trade with a stated amount out.
+  const swapIn = seat => {
+    const getPriceFn = (amountIn, amountOut) => {
+      return getPriceGivenAvailableInput(amountIn, amountOut.brand);
+    };
+    return doSwap(seat, getPriceFn);
+  };
+
   const swapOut = seat => {
-    assertProposalShape(seat, {
-      give: { In: null },
-      want: { Out: null },
-    });
-    // The offer's amountOut is a minimum; the offeredAmountIn is a max.
-    const {
-      give: { In: offeredAmountIn },
-      want: { Out: amountOut },
-    } = seat.getProposal();
-    const { brand: brandOut } = amountOut;
-    const brandIn = offeredAmountIn.brand;
-
-    const {
-      amountIn,
-      amountOut: improvedAmountOut,
-      protocolFee,
-      // @ts-ignore two pool version of getPrice returns central
-      centralAmount,
-    } = getPriceGivenRequiredOutput(brandIn, amountOut);
-
-    if (!AmountMath.isGTE(offeredAmountIn, amountIn)) {
-      const reason = `offeredAmountIn ${offeredAmountIn} is insufficient to buy amountOut ${amountOut}`;
-      throw seat.fail(Error(reason));
-    }
-
-    const stagings = [];
-    stagings.push(stageProtocolSeatFee(protocolFee));
-    stagings.push(
-      seat.stage({
-        In: AmountMath.subtract(offeredAmountIn, amountIn),
-        Out: improvedAmountOut,
-      }),
-    );
-
-    // central to secondary, secondary to central, or secondary to secondary
-    const pools = [];
-    if (isCentral(brandOut) && isSecondary(brandIn)) {
-      stagings.push(
-        poolStagingToCentral(amountIn, improvedAmountOut, protocolFee),
-      );
-      pools.push(getPool(brandIn));
-    } else if (isSecondary(brandOut) && isCentral(brandIn)) {
-      stagings.push(
-        poolStagingFromCentral(amountIn, improvedAmountOut, protocolFee),
-      );
-      pools.push(getPool(brandOut));
-    } else if (isSecondary(brandOut) && isSecondary(brandIn)) {
-      const secondaryStagings = secondaryPoolStagings(
-        amountIn,
-        improvedAmountOut,
-        centralAmount,
-        protocolFee,
-      );
-      stagings.push(...secondaryStagings);
-      pools.push(getPool(brandIn), getPool(brandOut));
-    } else {
-      assert.fail(X`brands were not recognized`);
-    }
-
-    // @ts-ignore typescript can't tell that we started by adding two stagings
-    zcf.reallocate(...stagings);
-    seat.exit();
-    pools.forEach(p => p.updateState());
-    return SUCCESS_STRING;
+    const getPriceFn = (amountIn, amountOut) => {
+      return getPriceGivenRequiredOutput(amountIn.brand, amountOut);
+    };
+    return doSwap(seat, getPriceFn);
   };
 
   const makeSwapInInvitation = () =>

--- a/packages/zoe/src/contracts/otcDesk.js
+++ b/packages/zoe/src/contracts/otcDesk.js
@@ -4,7 +4,6 @@ import { E } from '@agoric/eventual-send';
 import { assert } from '@agoric/assert';
 import { Far } from '@agoric/marshal';
 import {
-  trade,
   offerTo,
   saveAllIssuers,
   assertProposalShape,
@@ -100,11 +99,8 @@ const start = zcf => {
   const addInventory = seat => {
     assertProposalShape(seat, { want: {} });
     // Take everything in this seat and add it to the marketMakerSeat
-    trade(
-      zcf,
-      { seat: marketMakerSeat, gains: seat.getCurrentAllocation() },
-      { seat, gains: {} },
-    );
+    marketMakerSeat.incrementBy(seat.decrementBy(seat.getCurrentAllocation()));
+    zcf.reallocate(marketMakerSeat, seat);
     seat.exit();
     return 'Inventory added';
   };
@@ -112,7 +108,8 @@ const start = zcf => {
   const removeInventory = seat => {
     assertProposalShape(seat, { give: {} });
     const { want } = seat.getProposal();
-    trade(zcf, { seat: marketMakerSeat, gains: {} }, { seat, gains: want });
+    seat.incrementBy(marketMakerSeat.decrementBy(want));
+    zcf.reallocate(marketMakerSeat, seat);
     seat.exit();
     return 'Inventory removed';
   };

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -7,7 +7,6 @@ import { AmountMath } from '@agoric/ertp';
 import { makeNotifierKit, observeNotifier } from '@agoric/notifier';
 import {
   assertIssuerKeywords,
-  trade,
   defaultAcceptanceMsg,
   assertProposalShape,
   assertNatAssetKind,
@@ -108,15 +107,10 @@ const start = zcf => {
       X`More money (${totalCost}) is required to buy these items`,
     );
 
-    // Reallocate. We are able to trade by only defining the gains
-    // (omitting the losses) because the keywords for both offers are
-    // the same, so the gains for one offer are the losses for the
-    // other.
-    trade(
-      zcf,
-      { seat: sellerSeat, gains: { Money: providedMoney } },
-      { seat: buyerSeat, gains: { Items: wantedItems } },
-    );
+    // Reallocate.
+    sellerSeat.incrementBy(buyerSeat.decrementBy({ Money: providedMoney }));
+    buyerSeat.incrementBy(sellerSeat.decrementBy({ Items: wantedItems }));
+    zcf.reallocate(buyerSeat, sellerSeat);
 
     // The buyer's offer has been processed.
     buyerSeat.exit();

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -251,15 +251,16 @@
 
 /**
  * @callback ReallocateInternal
- * @param {SeatStaging[]} seatStagings
+ * @param {ZCFSeat[]} seats
  * @returns {void}
  */
 
 /**
  *
- * @callback CreateSeatManager
- * The SeatManager holds the active zcfSeats and seatStagings and can
- * reallocate and make new zcfSeats.
+ * @callback CreateSeatManager 
+ *
+ * The SeatManager holds the active zcfSeats and can reallocate and
+ * make new zcfSeats.
  *
  * @param {ERef<ZoeInstanceAdmin>} zoeInstanceAdmin
  * @param {GetAssetKindByBrand} getAssetKindByBrand

--- a/packages/zoe/test/unitTests/bounty.js
+++ b/packages/zoe/test/unitTests/bounty.js
@@ -17,7 +17,7 @@ import { AmountMath } from '@agoric/ertp';
 import { assertProposalShape } from '../../src/contractSupport';
 
 const start = async zcf => {
-  const { oracle, deadline, condition, timer, fee, brands } = zcf.getTerms();
+  const { oracle, deadline, condition, timer, fee } = zcf.getTerms();
 
   /** @type {OfferHandler} */
   function funder(funderSeat) {
@@ -27,10 +27,13 @@ const start = async zcf => {
     assertProposalShape(funderSeat, endowBounty);
 
     function payOffBounty(seat) {
-      zcf.reallocate(
-        funderSeat.stage({ Bounty: AmountMath.makeEmpty(brands.Bounty) }),
-        seat.stage({ Bounty: funderSeat.getCurrentAllocation().Bounty }),
+      seat.incrementBy(
+        funderSeat.decrementBy({
+          Bounty: funderSeat.getCurrentAllocation().Bounty,
+        }),
       );
+
+      zcf.reallocate(funderSeat, seat);
       seat.exit();
       funderSeat.exit();
       zcf.shutdown('bounty was paid');
@@ -56,10 +59,8 @@ const start = async zcf => {
       );
 
       // The funder gets the fee regardless of the outcome.
-      zcf.reallocate(
-        funderSeat.stage({ Fee: feeAmount }),
-        bountySeat.stage({ Fee: AmountMath.makeEmpty(brands.Fee) }),
-      );
+      funderSeat.incrementBy(bountySeat.decrementBy({ Fee: feeAmount }));
+      zcf.reallocate(funderSeat, bountySeat);
 
       const wakeHandler = Far('wakeHandler', {
         wake: async () => {

--- a/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
@@ -223,7 +223,7 @@ test(`offerTo - violates offer safety of fromSeat`, async t => {
       ),
     {
       message:
-        'The trade between left [object Object] and right [object Object] failed offer safety. Please check the log for more information',
+        'Offer safety was violated by the proposed allocation: {"TokenK":{"brand":"[Alleged: bucks brand]","value":"[0n]"},"TokenJ":{"brand":"[Alleged: moola brand]","value":"[0n]"}}. Proposal was {"want":{"TokenJ":{"brand":"[Alleged: moola brand]","value":"[3n]"}},"give":{"TokenK":{"brand":"[Alleged: bucks brand]","value":"[5n]"}},"exit":{"onDemand":null}}',
     },
   );
 

--- a/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
@@ -79,8 +79,7 @@ test(`withdrawFromSeat - violates offerSafety`, async t => {
   await t.throwsAsync(
     withdrawFromSeat(zcf, zcfSeat, { B: bucks(4) }),
     {
-      message:
-        'The trade between left [object Object] and right [object Object] failed offer safety. Please check the log for more information',
+      message: /Offer safety was violated by the proposed allocation/,
     },
     `withdrawFrom can't violate offerSafety`,
   );

--- a/packages/zoe/test/unitTests/contracts/loan/helpers.js
+++ b/packages/zoe/test/unitTests/contracts/loan/helpers.js
@@ -126,6 +126,7 @@ export const checkNoNewOffers = async (t, zcf) => {
 };
 
 export const makeSeatKit = async (zcf, proposal, payments) => {
+  /** @type {ZCFSeat} */
   let zcfSeat;
   const invitation = zcf.makeInvitation(seat => {
     zcfSeat = seat;

--- a/packages/zoe/test/unitTests/contracts/multipoolAutoswap/test-constantProduct.js
+++ b/packages/zoe/test/unitTests/contracts/multipoolAutoswap/test-constantProduct.js
@@ -45,17 +45,14 @@ test('constantProduct invariant', async t => {
   // Let's give the swap user all the tokens and take
   // nothing, a clear violation of the constant product
   t.throws(
-    () =>
-      checkedZCF.reallocate(
-        poolSeat.stage({
-          Central: AmountMath.make(centralBrand, 0n),
-          Secondary: AmountMath.make(secondaryBrand, 0n),
-        }),
-        swapSeat.stage({
-          In: poolSeatAllocation.Central,
-          Out: poolSeatAllocation.Secondary,
-        }),
-      ),
+    () => {
+      poolSeat.decrementBy(poolSeatAllocation);
+      swapSeat.incrementBy({
+        In: poolSeatAllocation.Central,
+        Out: poolSeatAllocation.Secondary,
+      });
+      checkedZCF.reallocate(poolSeat, swapSeat);
+    },
     {
       message:
         'the product of the pool tokens must not decrease as the result of a trade. "[1000000000000n]" decreased to "[0n]"',

--- a/packages/zoe/test/unitTests/contracts/multipoolAutoswap/test-multipoolAutoswap.js
+++ b/packages/zoe/test/unitTests/contracts/multipoolAutoswap/test-multipoolAutoswap.js
@@ -1650,8 +1650,7 @@ test('multipoolAutoSwap jig - removeLiquidity ask for too much', async t => {
     payment,
   );
   await t.throwsAsync(() => seat.getOfferResult(), {
-    message:
-      'The trade between left [object Object] and right [object Object] failed offer safety. Please check the log for more information',
+    message: /Offer safety was violated by the proposed allocation/,
   });
 });
 

--- a/packages/zoe/test/unitTests/contracts/test-otcDesk.js
+++ b/packages/zoe/test/unitTests/contracts/test-otcDesk.js
@@ -264,7 +264,8 @@ const makeBob = (
       const seat = await zoe.offer(invitation, proposal, payments);
 
       await t.throwsAsync(() => E(seat).getOfferResult(), {
-        message: 'The reallocation failed to conserve rights.',
+        message:
+          'rights were not conserved for brand "[Alleged: simoleans brand]"',
       });
 
       await assertPayoutAmount(

--- a/packages/zoe/test/unitTests/test-scriptedOracle.js
+++ b/packages/zoe/test/unitTests/test-scriptedOracle.js
@@ -101,8 +101,18 @@ test('pay bounty', async t => {
     }),
   );
   const bountyInvitation = await funderSeat.getOfferResult();
-  assertPayoutAmount(t, moolaIssuer, funderSeat.getPayout('Fee'), moola(50n));
-  assertPayoutAmount(t, moolaIssuer, funderSeat.getPayout('Bounty'), moola(0n));
+  const promise1 = assertPayoutAmount(
+    t,
+    moolaIssuer,
+    funderSeat.getPayout('Fee'),
+    moola(50n),
+  );
+  const promise2 = assertPayoutAmount(
+    t,
+    moolaIssuer,
+    funderSeat.getPayout('Bounty'),
+    moola(0n),
+  );
 
   // Bob buys the bounty invitation
   const bountySeat = await E(zoe).offer(
@@ -115,8 +125,13 @@ test('pay bounty', async t => {
       Fee: moolaMint.mintPayment(moola(50n)),
     }),
   );
-  assertPayoutAmount(t, moolaIssuer, bountySeat.getPayout('Fee'), moola(0n));
-  assertPayoutAmount(
+  const promise3 = assertPayoutAmount(
+    t,
+    moolaIssuer,
+    bountySeat.getPayout('Fee'),
+    moola(0n),
+  );
+  const promise4 = assertPayoutAmount(
     t,
     moolaIssuer,
     bountySeat.getPayout('Bounty'),
@@ -127,6 +142,7 @@ test('pay bounty', async t => {
   await E(timer).tick();
   await E(timer).tick();
   await E(timer).tick();
+  await Promise.all([promise1, promise2, promise3, promise4]);
 });
 
 test('pay no bounty', async t => {

--- a/packages/zoe/test/unitTests/zcf/test-reallocate-empty.js
+++ b/packages/zoe/test/unitTests/zcf/test-reallocate-empty.js
@@ -39,3 +39,17 @@ test(`zcf.reallocate introducing new empty amount`, async t => {
     RUN: empty,
   });
 });
+
+test(`zcf.reallocate undefined`, async t => {
+  const { zcf } = await setupZCFTest();
+  const { zcfSeat: zcfSeat1 } = zcf.makeEmptySeatKit();
+  const { zcfSeat: zcfSeat2 } = zcf.makeEmptySeatKit();
+
+  // @ts-ignore Deliberate wrong type for testing
+  t.throws(() => zcf.reallocate(zcfSeat1, zcfSeat2, undefined), {
+    message:
+      // TODO: Improve error message if something other than a seat is
+      // passed.
+      'seat has been exited',
+  });
+});

--- a/packages/zoe/test/unitTests/zcf/test-reallocate-empty.js
+++ b/packages/zoe/test/unitTests/zcf/test-reallocate-empty.js
@@ -2,11 +2,11 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 
-import { AmountMath } from '@agoric/ertp';
+import { AmountMath, AssetKind } from '@agoric/ertp';
 
 import { setupZCFTest } from './setupZcfTest';
 
-test(`zcfSeat.stage, zcf.reallocate introducing new empty amount`, async t => {
+test(`zcf.reallocate introducing new empty amount`, async t => {
   const { zcf } = await setupZCFTest();
   const { zcfSeat: zcfSeat1 } = zcf.makeEmptySeatKit();
   const { zcfSeat: zcfSeat2 } = zcf.makeEmptySeatKit();
@@ -17,64 +17,25 @@ test(`zcfSeat.stage, zcf.reallocate introducing new empty amount`, async t => {
   const allocation = zcfSeat1.getAmountAllocated('RUN', brand);
   t.true(AmountMath.isEmpty(allocation));
 
-  // Stage zcfSeat2 with the allocation from zcfSeat1
-  const zcfSeat2Staging = zcfSeat2.stage({ RUN: allocation });
+  const empty = AmountMath.makeEmpty(brand, AssetKind.NAT);
 
-  // Stage zcfSeat1 with empty
-  const zcfSeat1Staging = zcfSeat1.stage({ RUN: AmountMath.makeEmpty(brand) });
-
-  zcf.reallocate(zcfSeat1Staging, zcfSeat2Staging);
-
-  t.deepEqual(zcfSeat1.getCurrentAllocation(), {
-    RUN: AmountMath.make(0n, brand),
-  });
-  t.deepEqual(zcfSeat2.getCurrentAllocation(), {
-    RUN: AmountMath.make(0n, brand),
-  });
-});
-
-test(`zcfSeat.stage, zcf.reallocate "dropping" empty amount`, async t => {
-  const { zcf } = await setupZCFTest();
-  const { zcfSeat: zcfSeat1 } = zcf.makeEmptySeatKit();
-  const { zcfSeat: zcfSeat2 } = zcf.makeEmptySeatKit();
-  const zcfMint = await zcf.makeZCFMint('RUN');
-  const { brand } = zcfMint.getIssuerRecord();
-
-  zcfMint.mintGains({ RUN: AmountMath.make(brand, 0n) }, zcfSeat1);
-  zcfMint.mintGains({ RUN: AmountMath.make(brand, 0n) }, zcfSeat2);
-
-  // Now zcfSeat1 and zcfSeat2 both have an empty allocation for RUN.
-  t.deepEqual(zcfSeat1.getCurrentAllocation(), {
-    RUN: AmountMath.make(0n, brand),
-  });
-  t.deepEqual(zcfSeat2.getCurrentAllocation(), {
-    RUN: AmountMath.make(0n, brand),
+  // decrementBy empty
+  t.throws(() => zcfSeat1.decrementBy({ RUN: empty }), {
+    message:
+      'The amount could not be subtracted from the allocation because the allocation did not have an amount under the keyword "RUN".',
   });
 
-  // Stage zcfSeat1 with an entirely empty allocation
-  const zcfSeat1Staging = zcfSeat2.stage({});
+  // Try to incrementBy empty. This succeeds, and the keyword is added
+  // with an empty amount.
+  zcfSeat1.incrementBy({ RUN: empty });
+  zcfSeat2.incrementBy({ RUN: empty });
 
-  // Stage zcfSeat2 with an entirely empty allocation
-  const zcfSeat2Staging = zcfSeat1.stage({});
+  zcf.reallocate(zcfSeat1, zcfSeat2);
 
-  // Because of how we merge staged allocations with the current
-  // allocation (we don't delete keys), the RUN keyword still remains:
-  t.deepEqual(zcfSeat1Staging.getStagedAllocation(), {
-    RUN: AmountMath.make(0n, brand),
+  t.deepEqual(zcfSeat1.getStagedAllocation(), {
+    RUN: empty,
   });
-  t.deepEqual(zcfSeat2Staging.getStagedAllocation(), {
-    RUN: AmountMath.make(0n, brand),
-  });
-
-  zcf.reallocate(zcfSeat1Staging, zcfSeat2Staging);
-
-  // The reallocation succeeds without error, but because of how we
-  // merge new allocations with old allocations (we don't delete
-  // keys), the RUN keyword still remains as is.
-  t.deepEqual(zcfSeat1.getCurrentAllocation(), {
-    RUN: AmountMath.make(0n, brand),
-  });
-  t.deepEqual(zcfSeat2.getCurrentAllocation(), {
-    RUN: AmountMath.make(0n, brand),
+  t.deepEqual(zcfSeat2.getStagedAllocation(), {
+    RUN: empty,
   });
 });

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -399,7 +399,7 @@ test(`zcf.makeZCFMint - mintGains - no args`, async t => {
   const zcfMint = await zcf.makeZCFMint('A', AssetKind.SET);
   // @ts-ignore deliberate invalid arguments for testing
   t.throws(() => zcfMint.mintGains(), {
-    message: /gains "\[undefined\]" must be an amountKeywordRecord/,
+    message: '"gains" "[undefined]" must be an amountKeywordRecord',
   });
 });
 
@@ -424,7 +424,7 @@ test(`zcf.makeZCFMint - mintGains - no gains`, async t => {
   // https://github.com/Agoric/agoric-sdk/issues/1696
   // @ts-ignore deliberate invalid arguments for testing
   t.throws(() => zcfMint.mintGains(undefined, zcfSeat), {
-    message: /gains "\[undefined\]" must be an amountKeywordRecord/,
+    message: '"gains" "[undefined]" must be an amountKeywordRecord',
   });
 });
 
@@ -433,7 +433,7 @@ test(`zcf.makeZCFMint - burnLosses - no args`, async t => {
   const zcfMint = await zcf.makeZCFMint('A', AssetKind.SET);
   // @ts-ignore deliberate invalid arguments for testing
   t.throws(() => zcfMint.burnLosses(), {
-    message: /losses "\[undefined\]" must be an amountKeywordRecord/,
+    message: '"losses" "[undefined]" must be an amountKeywordRecord',
   });
 });
 
@@ -443,7 +443,7 @@ test(`zcf.makeZCFMint - burnLosses - no losses`, async t => {
   const { zcfSeat } = zcf.makeEmptySeatKit();
   // @ts-ignore deliberate invalid arguments for testing
   t.throws(() => zcfMint.burnLosses(undefined, zcfSeat), {
-    message: /losses "\[undefined\]" must be an amountKeywordRecord/,
+    message: '"losses" "[undefined]" must be an amountKeywordRecord',
   });
 });
 
@@ -454,7 +454,7 @@ test(`zcf.makeZCFMint - mintGains - wrong brand`, async t => {
   const zcfMint = await zcf.makeZCFMint('A', AssetKind.SET);
   const { zcfSeat } = zcf.makeEmptySeatKit();
   t.throws(() => zcfMint.mintGains({ Moola: moola(3) }, zcfSeat), {
-    message: /Only digital assets of brand .* can be minted in this call. .* has the wrong brand./,
+    message: `amount's brand "[Alleged: moola brand]" did not match expected brand "[Alleged: A brand]"`,
   });
 });
 
@@ -465,7 +465,7 @@ test(`zcf.makeZCFMint - burnLosses - wrong brand`, async t => {
   const zcfMint = await zcf.makeZCFMint('A', AssetKind.SET);
   const { zcfSeat } = zcf.makeEmptySeatKit();
   t.throws(() => zcfMint.burnLosses({ Moola: moola(3) }, zcfSeat), {
-    message: /Only digital assets of brand .* can be burned in this call. .* has the wrong brand./,
+    message: `amount's brand "[Alleged: moola brand]" did not match expected brand "[Alleged: A brand]"`,
   });
 });
 
@@ -618,16 +618,20 @@ test(`zcfSeat from zcf.makeEmptySeatKit - only these properties exist`, async t 
     'fail',
     'getAmountAllocated',
     'getCurrentAllocation',
+    'getStagedAllocation',
     'getNotifier',
     'getProposal',
     'hasExited',
     'isOfferSafe',
-    'stage',
+    'incrementBy',
+    'decrementBy',
+    'clear',
+    'hasStagedAllocation',
   ];
   const { zcf } = await setupZCFTest();
   const makeZCFSeat = () => zcf.makeEmptySeatKit().zcfSeat;
   const seat = makeZCFSeat();
-  t.deepEqual(Object.getOwnPropertyNames(seat).sort(), expectedMethods);
+  t.deepEqual(Object.getOwnPropertyNames(seat).sort(), expectedMethods.sort());
 });
 
 test(`zcfSeat.getProposal from zcf.makeEmptySeatKit`, async t => {
@@ -805,20 +809,17 @@ test(`zcfSeat.getAmountAllocated from zcf.makeEmptySeatKit`, async t => {
   });
 });
 
-test(`zcfSeat.stage, zcf.reallocate from zcf.makeEmptySeatKit`, async t => {
+test(`zcfSeat.incrementBy, decrementBy, zcf.reallocate from zcf.makeEmptySeatKit`, async t => {
   const { zcf } = await setupZCFTest();
   const { zcfSeat: zcfSeat1 } = zcf.makeEmptySeatKit();
   const { zcfSeat: zcfSeat2 } = zcf.makeEmptySeatKit();
 
   const issuerRecord1 = await allocateEasy(zcf, 'Stuff', zcfSeat1, 'A', 6);
-  const staging1 = zcfSeat1.stage({
-    A: AmountMath.make(0n, issuerRecord1.brand),
-  });
-  const staging2 = zcfSeat2.stage({
-    B: AmountMath.make(6n, issuerRecord1.brand),
-  });
+  const six = AmountMath.make(6n, issuerRecord1.brand);
+  zcfSeat1.decrementBy({ A: six });
+  zcfSeat2.incrementBy({ B: six });
 
-  zcf.reallocate(staging1, staging2);
+  zcf.reallocate(zcfSeat1, zcfSeat2);
 
   t.deepEqual(zcfSeat1.getCurrentAllocation(), {
     A: AmountMath.make(0n, issuerRecord1.brand),
@@ -1088,23 +1089,14 @@ test(`zcf.reallocate 3 seats, rights conserved`, async t => {
       want: { Whatever: moola(1) },
     }),
   );
+  zcfSeat1.decrementBy({ B: moola(3n) });
+  zcfSeat3.incrementBy({ Whatever: moola(1) });
+  zcfSeat2.incrementBy({ Whatever: moola(2) });
 
-  const staging1 = zcfSeat1.stage({
-    A: simoleans(2),
-    B: moola(0n),
-  });
+  zcfSeat2.decrementBy({ Whatever2: simoleans(2) });
+  zcfSeat1.incrementBy({ A: simoleans(2) });
 
-  const staging2 = zcfSeat2.stage({
-    Whatever: moola(2),
-    Whatever2: simoleans(0),
-  });
-
-  const staging3 = zcfSeat3.stage({
-    Whatever: moola(1),
-    Whatever2: simoleans(0),
-  });
-
-  zcf.reallocate(staging1, staging2, staging3);
+  zcf.reallocate(zcfSeat1, zcfSeat2, zcfSeat3);
   t.deepEqual(zcfSeat1.getCurrentAllocation(), {
     A: simoleans(2),
     B: moola(0n),
@@ -1117,8 +1109,58 @@ test(`zcf.reallocate 3 seats, rights conserved`, async t => {
 
   t.deepEqual(zcfSeat3.getCurrentAllocation(), {
     Whatever: moola(1),
-    Whatever2: simoleans(0),
   });
+});
+
+test(`zcf.reallocate 3 seats, some not staged`, async t => {
+  const { moolaKit, simoleanKit, moola, simoleans } = setup();
+  const { zoe, zcf } = await setupZCFTest({
+    Moola: moolaKit.issuer,
+    Simoleans: simoleanKit.issuer,
+  });
+
+  const { zcfSeat: zcfSeat1 } = await makeOffer(
+    zoe,
+    zcf,
+    harden({ want: { A: simoleans(2) }, give: { B: moola(3) } }),
+    harden({ B: moolaKit.mint.mintPayment(moola(3)) }),
+  );
+  const { zcfSeat: zcfSeat2 } = await makeOffer(
+    zoe,
+    zcf,
+    harden({
+      want: { Whatever: moola(2) },
+      give: { Whatever2: simoleans(2) },
+    }),
+    harden({ Whatever2: simoleanKit.mint.mintPayment(simoleans(2)) }),
+  );
+
+  const { zcfSeat: zcfSeat3 } = await makeOffer(
+    zoe,
+    zcf,
+    harden({
+      want: { Whatever: moola(1) },
+    }),
+  );
+
+  zcfSeat1.incrementBy({
+    A: simoleans(100),
+  });
+
+  t.throws(() => zcf.reallocate(zcfSeat1, zcfSeat2, zcfSeat3), {
+    message:
+      'Reallocate failed because a seat had no staged allocation. Please add or subtract from the seat and then reallocate.',
+  });
+
+  t.deepEqual(zcfSeat1.getCurrentAllocation(), {
+    A: simoleans(0),
+    B: moola(3),
+  });
+  t.deepEqual(zcfSeat2.getCurrentAllocation(), {
+    Whatever: moola(0n),
+    Whatever2: simoleans(2),
+  });
+  t.deepEqual(zcfSeat3.getCurrentAllocation(), { Whatever: moola(0n) });
 });
 
 test(`zcf.reallocate 3 seats, rights NOT conserved`, async t => {
@@ -1152,22 +1194,14 @@ test(`zcf.reallocate 3 seats, rights NOT conserved`, async t => {
     }),
   );
 
-  const staging1 = zcfSeat1.stage({
+  zcfSeat2.decrementBy({ Whatever2: simoleans(2) });
+  // This does not conserve rights in the slightest
+  zcfSeat1.incrementBy({
     A: simoleans(100),
-    B: moola(0n),
   });
+  zcfSeat3.incrementBy({ Whatever: moola(1) });
 
-  const staging2 = zcfSeat2.stage({
-    Whatever: moola(2),
-    Whatever2: simoleans(0),
-  });
-
-  const staging3 = zcfSeat3.stage({
-    Whatever: moola(1),
-    Whatever2: simoleans(0),
-  });
-
-  t.throws(() => zcf.reallocate(staging1, staging2, staging3), {
+  t.throws(() => zcf.reallocate(zcfSeat1, zcfSeat2, zcfSeat3), {
     message: /rights were not conserved for brand .*/,
   });
 

--- a/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
@@ -81,7 +81,7 @@ test(`zoeHelper with zcf - swap no match`, async t => {
     () => swap(zcf, aZcfSeat, bZcfSeat),
     {
       message:
-        'The trade between left [object Object] and right [object Object] failed.',
+        'The amount to be subtracted {"brand":"[Alleged: moola brand]","value":"[20n]"} was greater than the allocation\'s amount {"brand":"[Alleged: moola brand]","value":"[5n]"} for the keyword "A"',
     },
     'mismatched offers',
   );
@@ -398,7 +398,7 @@ test(`zoeHelper w/zcf - swapExact w/shortage`, async t => {
   );
 
   t.throws(() => swapExact(zcf, zcfSeatA, zcfSeatB), {
-    message: 'The reallocation failed to conserve rights.',
+    message: 'rights were not conserved for brand "[Alleged: moola brand]"',
   });
   t.truthy(zcfSeatA.hasExited(), 'fail right');
   assertPayoutAmount(t, moolaIssuer, await userSeatA.getPayout('A'), moola(0n));
@@ -444,7 +444,7 @@ test(`zoeHelper w/zcf - swapExact w/excess`, async t => {
   );
 
   t.throws(() => swapExact(zcf, zcfSeatA, zcfSeatB), {
-    message: 'The reallocation failed to conserve rights.',
+    message: 'rights were not conserved for brand "[Alleged: moola brand]"',
   });
   t.truthy(zcfSeatA.hasExited(), 'fail right');
   assertPayoutAmount(t, moolaIssuer, await userSeatA.getPayout('A'), moola(0n));
@@ -490,7 +490,7 @@ test(`zoeHelper w/zcf - swapExact w/extra payments`, async t => {
   );
 
   t.throws(() => swapExact(zcf, zcfSeatA, zcfSeatB), {
-    message: 'The reallocation failed to conserve rights.',
+    message: 'rights were not conserved for brand "[Alleged: moola brand]"',
   });
   t.truthy(zcfSeatA.hasExited(), 'fail right');
   assertPayoutAmount(


### PR DESCRIPTION
**This PR makes a breaking change to `ZCFSeats`, `zoe.reallocate`, and the `trade`, `swap`, and `swapExact` helpers.**

`SeatStagings` and `zcfSeat.stage` no longer exist. Instead, amountKeywordRecords can be added or subtracted to a seat's allocation by calling methods directly on the `zcfSeat`:

`{(amountKeywordRecord: AmountKeywordRecord) => AmountKeywordRecord} incrementBy` - the amountKeywordRecord to be added to the seat's staged allocation
`{(amountKeywordRecord: AmountKeywordRecord) => AmountKeywordRecord} decrementBy` - the amountKeywordRecord to be subtracted from the seat's staged allocation
`{() => void} clear` - delete the staged allocation, if any
`{() => Allocation} getStagedAllocation` - get the stagedAllocation, the allocation that will be committed if the seat is reallocated over, if offer safety holds and rights are conserved
`{() => boolean} hasStagedAllocation` - whether there is a staged allocation, i.e. whether `incrementBy` or `decrementBy` has been called and `clear` has not.

Once a seat has a staged allocation, it can be reallocated over by calling `zcf.reallocate(zcfSeat1, zcfSeat2, ....)`. This commits the staged allocation, such it is now the current allocation for that seat. 

The `trade` helper no longer exists, and the `swap` and `swapExact` helpers no longer accept errorMsg arguments. 

Example usage:

```js
      seat.decrementBy({ In: reducedAmountIn });
      poolSeat.incrementBy({ Central: reducedAmountIn });

      poolSeat.decrementBy({ Secondary: amountOut });
      seat.incrementBy({ Out: amountOut });

      zcf.reallocate(poolSeat, seat);
      seat.exit();
```

Closes #3215 

#dapp-otc-branch: 3184-reallocate-api