### PR TITLE
refactor(swingset): replace queueToExport to queueToKref

### DIFF
--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -365,14 +365,8 @@ export async function makeSwingsetController(
       parseVatSlot(exportID);
       assert.typeof(method, 'string');
       insistCapData(args);
-      kernel.addExport(vatID, exportID);
-      const kpid = kernel.queueToExport(
-        vatID,
-        exportID,
-        method,
-        args,
-        resultPolicy,
-      );
+      const kref = kernel.addExport(vatID, exportID);
+      const kpid = kernel.queueToKref(kref, method, args, resultPolicy);
       kernel.kpRegisterInterest(kpid);
       return kpid;
     },

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -61,8 +61,11 @@ async function simpleCall(t) {
     { vatID: vattpVatID, state: { transcript: [] } },
     { vatID: timerVatID, state: { transcript: [] } },
   ]);
-  t.deepEqual(data.kernelTable, []);
+  // the vatAdmin root is pre-registered
+  const vatAdminRoot = ['ko20', adminVatID, 'o+0'];
+  t.deepEqual(data.kernelTable, [vatAdminRoot]);
 
+  // vat1:o+1 will map to ko21
   controller.queueToVatExport('vat1', 'o+1', 'foo', capdata('args'));
   t.deepEqual(controller.dump().runQueue, [
     {
@@ -71,7 +74,7 @@ async function simpleCall(t) {
         args: capdata('args'),
         result: 'kp40',
       },
-      target: 'ko20',
+      target: 'ko21',
       type: 'send',
     },
   ]);
@@ -175,12 +178,12 @@ test('bootstrap export', async t => {
   // better test, probably by sorting the list of vats by their vatID, and
   // then asserting that their root objects are assigned `koNN` numbers in
   // matching order.
-  const boot0 = 'ko20';
-  const comms0 = 'ko21';
-  const left0 = 'ko22';
-  const right0 = 'ko23';
-  const timer0 = 'ko24';
-  const vatAdminSvc = 'ko25';
+  const vatAdminSvc = 'ko20';
+  const boot0 = 'ko21';
+  const comms0 = 'ko22';
+  const left0 = 'ko23';
+  const right0 = 'ko24';
+  const timer0 = 'ko25';
   const vattp0 = 'ko26';
   const adminDev = 'kd30';
   const kt = [


### PR DESCRIPTION
The internal `kernel.queueToExport(vatID, vref, method, args)` method will
inject a message onto the run-queue from outside of any particular vat. It is
used by `initializeKernel.js` to enqueue the bootstrap message, and by the
vatAdmin device to notify the vatAdmin vat about vats finishing creation (and
being terminated). To specify the target, you give it a `vatID` and a vref,
and it pretends that that vat had exported the vref, returning the kref to
the caller.

This change replaces `queueToExport` with `queueToKref(kref, method, args)`,
which does not perform the pretend vat export. Instead, it requires the
caller to provide a pre-translated kref. You should use it in conjunction
with `kernel.addExport`, which does the same pretend export that
`queueToExport` used to do.

The benefit to splitting this up is that we want better control over the GC
reference count of the target. `addExport` may add an artificial "reachable"
count, to keep the target alive. But `queueToKref` will not.

To support this, we must stash the kref of the vatAdminRoot in the DB during
initialization (just after the vatAdmin vat is defined), so it will be
available without the (vatNameToID, `addExport`) lookup at runtime. Instead,
the kernel loads this kref from the DB during startup, and passes it through
to the vat loader which needs it. A handful of vatLoader endowments are no
longer necessary.

(note that storing this kref is optional, in that unit tests which don't
bother to define any vats won't have it, but any real usage of swingset will
require it to be in the DB as soon as the first dynamic vat is created)

The 'policy' argument tells the kernel what to do if/when the
automatically-added result promise is resolved. I added a `none` mode to
prevent the creation of a result promise at all, which should help declutter
a few unit tests.

We're slowly migrating our terminology from "kernelSlot" and "vatSlot" to
"kref" and "vref". I updated the functions that were touched in this work.