### PR TITLE
refactor(ERTP): no implicit `any` types in ERTP/src

### DIFF
--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -186,6 +186,7 @@ const coerceLR = (h, leftAmount, rightAmount) => {
 /** @type {AmountMath} */
 const AmountMath = {
   // TODO: remove when the deprecated order is no longer allowed.
+  // https://github.com/Agoric/agoric-sdk/issues/3202
   // @ts-ignore The brand can be the second argument, but this is deprecated
   make: (brand, allegedValue) => {
     if (looksLikeBrand(allegedValue)) {
@@ -200,6 +201,7 @@ const AmountMath = {
     return harden({ brand, value });
   },
   // TODO: remove when the deprecated order is no longer allowed.
+  // https://github.com/Agoric/agoric-sdk/issues/3202
   // @ts-ignore The brand can be the second argument, but this is deprecated
   coerce: (brand, allegedAmount) => {
     if (looksLikeBrand(allegedAmount)) {
@@ -217,6 +219,7 @@ const AmountMath = {
     return AmountMath.make(brand, allegedAmount.value);
   },
   // TODO: remove when the deprecated order is no longer allowed.
+  // https://github.com/Agoric/agoric-sdk/issues/3202
   // @ts-ignore The brand can be the second argument, but this is deprecated
   getValue: (brand, amount) => AmountMath.coerce(brand, amount).value,
   makeEmpty: (brand, assetKind = AssetKind.NAT) => {

--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -154,6 +154,12 @@ const assertLooksLikeAmount = amount => {
   assertLooksLikeValue(amount.value);
 };
 
+/**
+ * @param {Amount} leftAmount
+ * @param {Amount} rightAmount
+ * @param {Brand | undefined} brand
+ * @returns {NatMathHelpers | SetMathHelpers }
+ */
 const checkLRAndGetHelpers = (leftAmount, rightAmount, brand = undefined) => {
   assertLooksLikeAmount(leftAmount);
   assertLooksLikeAmount(rightAmount);
@@ -167,12 +173,20 @@ const checkLRAndGetHelpers = (leftAmount, rightAmount, brand = undefined) => {
   return getHelpers(leftAmount, rightAmount);
 };
 
+/**
+ * @param {MathHelpers<Value>} h
+ * @param {Amount} leftAmount
+ * @param {Amount} rightAmount
+ * @returns {[Value, Value]}
+ */
 const coerceLR = (h, leftAmount, rightAmount) => {
   return [h.doCoerce(leftAmount.value), h.doCoerce(rightAmount.value)];
 };
 
 /** @type {AmountMath} */
 const AmountMath = {
+  // TODO: remove when the deprecated order is no longer allowed.
+  // @ts-ignore The brand can be the second argument, but this is deprecated
   make: (brand, allegedValue) => {
     if (looksLikeBrand(allegedValue)) {
       // Swap to support deprecated reverse argument order
@@ -185,6 +199,8 @@ const AmountMath = {
     const value = getHelpersFromValue(allegedValue).doCoerce(allegedValue);
     return harden({ brand, value });
   },
+  // TODO: remove when the deprecated order is no longer allowed.
+  // @ts-ignore The brand can be the second argument, but this is deprecated
   coerce: (brand, allegedAmount) => {
     if (looksLikeBrand(allegedAmount)) {
       // Swap to support deprecated reverse argument order
@@ -200,6 +216,8 @@ const AmountMath = {
     // Will throw on inappropriate value
     return AmountMath.make(brand, allegedAmount.value);
   },
+  // TODO: remove when the deprecated order is no longer allowed.
+  // @ts-ignore The brand can be the second argument, but this is deprecated
   getValue: (brand, amount) => AmountMath.coerce(brand, amount).value,
   makeEmpty: (brand, assetKind = AssetKind.NAT) => {
     assert(

--- a/packages/ERTP/src/displayInfo.js
+++ b/packages/ERTP/src/displayInfo.js
@@ -23,9 +23,14 @@ export const assertSubset = (whole, part) => {
   });
 };
 
-// Assert that the keys of `record` are all in `allowedKeys`. If a key
-// of `record` is not in `allowedKeys`, throw an error. If a key in
-// `allowedKeys` is not a key of record, we do not throw an error.
+/**
+ * Assert that the keys of `record` are all in `allowedKeys`. If a key
+ * of `record` is not in `allowedKeys`, throw an error. If a key in
+ * `allowedKeys` is not a key of record, we do not throw an error.
+ *
+ * @param {string[]} allowedKeys
+ * @param {Object} record
+ */
 export const assertKeysAllowed = (allowedKeys, record) => {
   const keys = Object.getOwnPropertyNames(record);
   assertSubset(allowedKeys, keys);

--- a/packages/ERTP/src/mathHelpers/natMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/natMathHelpers.js
@@ -20,7 +20,7 @@ const identity = 0n;
  */
 const natMathHelpers = {
   doCoerce: Nat,
-  doMakeEmpty: _ => identity,
+  doMakeEmpty: () => identity,
   doIsEmpty: nat => nat === identity,
   doIsGTE: (left, right) => left >= right,
   doIsEqual: (left, right) => left === right,

--- a/packages/ERTP/src/mathHelpers/setMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/setMathHelpers.js
@@ -8,8 +8,13 @@ import '../types';
 
 // Operations for arrays with unique objects identifying and providing
 // information about digital assets. Used for Zoe invites.
+/** @type {SetValue} */
 const identity = harden([]);
 
+/**
+ * @param {Object} record
+ * @returns {string}
+ */
 const getKeyForRecord = record => {
   const keys = Object.getOwnPropertyNames(record);
   keys.sort();
@@ -20,9 +25,14 @@ const getKeyForRecord = record => {
   return [...keys, ...values].join();
 };
 
-// Cut down the number of sameStructure comparisons to only the ones
-// that don't fail basic equality tests
-// TODO: better name?
+/**
+ * Cut down the number of sameStructure comparisons to only the ones
+ * that don't fail basic equality tests
+ * TODO: better name?
+ *
+ * @param {SetValueElem} thing
+ * @returns {SetValueElem}
+ */
 const hashBadly = thing => {
   const type = typeof thing;
   const allowableNonObjectValues = ['string', 'number', 'bigint', 'boolean'];
@@ -40,6 +50,14 @@ const hashBadly = thing => {
   );
 };
 
+/**
+ * @typedef {Map<SetValueElem, SetValueElem[]>} Buckets
+ */
+
+/**
+ * @param {SetValueElem[]} list
+ * @returns {Buckets}
+ */
 const makeBuckets = list => {
   const buckets = new Map();
   list.forEach(elem => {
@@ -53,7 +71,11 @@ const makeBuckets = list => {
   return buckets;
 };
 
-// Based on bucket sort
+/**
+ * Based on bucket sort
+ *
+ * @param {Buckets} buckets
+ */
 const checkForDupes = buckets => {
   for (const maybeMatches of buckets.values()) {
     for (let i = 0; i < maybeMatches.length; i += 1) {
@@ -67,12 +89,19 @@ const checkForDupes = buckets => {
   }
 };
 
+/**
+ *
+ * @param {Buckets} buckets
+ * @param {SetValueElem} elem
+ * @returns {boolean}
+ */
 const hasElement = (buckets, elem) => {
   const badHash = hashBadly(elem);
   if (!buckets.has(badHash)) {
     return false;
   }
   const maybeMatches = buckets.get(badHash);
+  assert(maybeMatches);
   return maybeMatches.some(maybeMatch => sameStructure(maybeMatch, elem));
 };
 
@@ -91,7 +120,7 @@ const setMathHelpers = harden({
     checkForDupes(makeBuckets(list));
     return list;
   },
-  doMakeEmpty: _ => identity,
+  doMakeEmpty: () => identity,
   doIsEmpty: list => passStyleOf(list) === 'copyArray' && list.length === 0,
   doIsGTE: (left, right) => {
     const leftBuckets = makeBuckets(left);
@@ -114,6 +143,10 @@ const setMathHelpers = harden({
         X`right element ${rightElem} was not in left`,
       );
     });
+    /**
+     * @param {SetValueElem} leftElem
+     * @returns {boolean}
+     */
     const leftElemNotInRight = leftElem => !hasElement(rightBuckets, leftElem);
     return harden(left.filter(leftElemNotInRight));
   },

--- a/packages/ERTP/src/payment.js
+++ b/packages/ERTP/src/payment.js
@@ -3,8 +3,13 @@
 
 import { Far } from '@agoric/marshal';
 
+/**
+ * @param {string} allegedName
+ * @param {Brand} brand
+ * @returns {() => Payment}
+ */
 export const makePaymentMaker = (allegedName, brand) => {
-  const paymentVOFactory = _state => {
+  const paymentVOFactory = () => {
     return {
       init: () => {},
       self: Far(`${allegedName} payment`, {


### PR DESCRIPTION
This PR adds types to ERTP/src where otherwise there would be an implicit `any`. 

Ideally, we would want to set `noImplicitAny: true` in the jsconfig.json, but the tests have a lot of implicit `any`s so this is the next best thing, to turn it on and fix the `src/` directory, then turn it off again. 