### PR TITLE
Clean up handling of RUN bank purses

### DIFF
--- a/golang/cosmos/Makefile
+++ b/golang/cosmos/Makefile
@@ -90,7 +90,7 @@ proto-check-breaking: proto-tools
 	buf check breaking --against-input '.git#branch=master'
 
 TMVER = v0.34.3
-COSMOSVER = v0.41.0
+COSMOSVER = v0.42.4
 
 TM_URL           = https://raw.githubusercontent.com/tendermint/tendermint/$(TMVER)/proto/tendermint
 GOGO_PROTO_URL   = https://raw.githubusercontent.com/regen-network/protobuf/cosmos

--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -503,14 +503,12 @@ func NewAgoricApp(
 }
 
 type cosmosInitAction struct {
-	Type             string `json:"type"`
-	IBCPort          int    `json:"ibcPort"`
-	StoragePort      int    `json:"storagePort"`
-	VPursePort       int    `json:"vpursePort"`
-	ChainID          string `json:"chainID"`
-	BootstrapAddress string `json:"bootstrapAddress"`
-	BootstrapValue   string `json:"bootstrapValue"`
-	DonationValue    string `json:"donationValue"`
+	Type        string    `json:"type"`
+	ChainID     string    `json:"chainID"`
+	IBCPort     int       `json:"ibcPort"`
+	StoragePort int       `json:"storagePort"`
+	SupplyCoins sdk.Coins `json:"supplyCoins"`
+	VPursePort  int       `json:"vpursePort"`
 }
 
 // MakeCodecs constructs the *std.Codec and *codec.LegacyAmino instances used by
@@ -530,27 +528,14 @@ func (app *GaiaApp) MustInitController(ctx sdk.Context) {
 	}
 	app.controllerInited = true
 
-	var bootstrapAddr sdk.AccAddress
-	gs := app.VpurseKeeper.GetGenesis(ctx)
-	if len(gs.BootstrapAddress) > 0 {
-		ba, err := sdk.AccAddressFromBech32(gs.BootstrapAddress)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "Cannot get bootstrap addr", err)
-			os.Exit(1)
-		}
-		bootstrapAddr = ba
-	}
-
 	// Begin initializing the controller here.
 	action := &cosmosInitAction{
-		Type:             "AG_COSMOS_INIT",
-		VPursePort:       app.vpursePort,
-		IBCPort:          app.ibcPort,
-		StoragePort:      swingset.GetPort("storage"),
-		ChainID:          ctx.ChainID(),
-		BootstrapAddress: bootstrapAddr.String(),
-		BootstrapValue:   gs.BootstrapValue.String(),
-		DonationValue:    gs.DonationValue.String(),
+		Type:        "AG_COSMOS_INIT",
+		ChainID:     ctx.ChainID(),
+		IBCPort:     app.ibcPort,
+		StoragePort: swingset.GetPort("storage"),
+		SupplyCoins: app.BankKeeper.GetSupply(ctx).GetTotal(),
+		VPursePort:  app.vpursePort,
 	}
 	bz, err := json.Marshal(action)
 	if err == nil {

--- a/golang/cosmos/proto/agoric/vpurse/genesis.proto
+++ b/golang/cosmos/proto/agoric/vpurse/genesis.proto
@@ -8,21 +8,4 @@ option go_package = "github.com/Agoric/agoric-sdk/golang/cosmos/x/vpurse/types";
 message GenesisState {
     option (gogoproto.equal) = false;
 
-    // These are passed as part of the AG_COSMOS_INIT message.
-    // They are plumbed through to configure the bootstrap of the treasury:
-    
-    // Cosmos-SDK layer bech32 address to receive bootstrap_value urun.
-    string bootstrap_address = 1;
-
-    // Number of urun to have the treasury send to bootstrap_address.
-    string bootstrap_value = 2 [
-        (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Int",
-        (gogoproto.nullable)   = false
-    ];
-
-    // Number of urun to send from bootstrap_address to new ag-solo clients.
-    string donation_value = 3 [
-        (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Int",
-        (gogoproto.nullable)   = false
-    ];
 }

--- a/golang/cosmos/x/vpurse/genesis.go
+++ b/golang/cosmos/x/vpurse/genesis.go
@@ -11,51 +11,27 @@ import (
 )
 
 func NewGenesisState() *types.GenesisState {
-	return &types.GenesisState{
-		BootstrapAddress: "",
-		BootstrapValue:   sdk.NewInt(0),
-		DonationValue:    sdk.NewInt(0),
-	}
+	return &types.GenesisState{}
 }
 
 func ValidateGenesis(data *types.GenesisState) error {
 	if data == nil {
 		return fmt.Errorf("vpurse genesis data cannot be nil")
 	}
-	if len(data.BootstrapAddress) > 0 {
-		if _, err := sdk.AccAddressFromBech32(data.BootstrapAddress); err != nil {
-			return fmt.Errorf("vpurse genesis invalid bootstrapAdddress %s: %w", data.BootstrapAddress, err)
-		}
-	}
-	if data.BootstrapValue.IsNil() {
-		return fmt.Errorf("vpurse genesis bootstrapValue cannot be nil")
-	}
-	if data.BootstrapValue.IsNegative() {
-		return fmt.Errorf("vpurse genesis bootstrapValue %s cannot be negative", data.DonationValue.String())
-	}
-	if data.DonationValue.IsNil() {
-		return fmt.Errorf("vpurse genesis donationValue cannot be nil")
-	}
-	if data.DonationValue.IsNegative() {
-		return fmt.Errorf("vpurse genesis donationValue %s cannot be negative", data.DonationValue.String())
-	}
 	return nil
 }
 
 func DefaultGenesisState() *types.GenesisState {
 	gs := NewGenesisState()
-	fmt.Println("default gen", gs)
 	return gs
 }
 
 func InitGenesis(ctx sdk.Context, keeper Keeper, data *types.GenesisState) []abci.ValidatorUpdate {
 	keeper.SetGenesis(ctx, *data)
-	fmt.Println("initialising gen", *data)
 	return []abci.ValidatorUpdate{}
 }
 
 func ExportGenesis(ctx sdk.Context, k Keeper) *types.GenesisState {
 	gs := k.GetGenesis(ctx)
-	fmt.Println("exporting gen", gs)
 	return &gs
 }

--- a/golang/cosmos/x/vpurse/types/genesis.pb.go
+++ b/golang/cosmos/x/vpurse/types/genesis.pb.go
@@ -5,7 +5,6 @@ package types
 
 import (
 	fmt "fmt"
-	github_com_cosmos_cosmos_sdk_types "github.com/cosmos/cosmos-sdk/types"
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
@@ -25,12 +24,6 @@ var _ = math.Inf
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type GenesisState struct {
-	// Cosmos-SDK layer bech32 address to receive bootstrap_value urun.
-	BootstrapAddress string `protobuf:"bytes,1,opt,name=bootstrap_address,json=bootstrapAddress,proto3" json:"bootstrap_address,omitempty"`
-	// Number of urun to have the treasury send to bootstrap_address.
-	BootstrapValue github_com_cosmos_cosmos_sdk_types.Int `protobuf:"bytes,2,opt,name=bootstrap_value,json=bootstrapValue,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Int" json:"bootstrap_value"`
-	// Number of urun to send from bootstrap_address to new ag-solo clients.
-	DonationValue github_com_cosmos_cosmos_sdk_types.Int `protobuf:"bytes,3,opt,name=donation_value,json=donationValue,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Int" json:"donation_value"`
 }
 
 func (m *GenesisState) Reset()         { *m = GenesisState{} }
@@ -66,13 +59,6 @@ func (m *GenesisState) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_GenesisState proto.InternalMessageInfo
 
-func (m *GenesisState) GetBootstrapAddress() string {
-	if m != nil {
-		return m.BootstrapAddress
-	}
-	return ""
-}
-
 func init() {
 	proto.RegisterType((*GenesisState)(nil), "agoric.vpurse.GenesisState")
 }
@@ -80,24 +66,18 @@ func init() {
 func init() { proto.RegisterFile("agoric/vpurse/genesis.proto", fileDescriptor_5640d8342a3d07c5) }
 
 var fileDescriptor_5640d8342a3d07c5 = []byte{
-	// 272 bytes of a gzipped FileDescriptorProto
+	// 169 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x4e, 0x4c, 0xcf, 0x2f,
 	0xca, 0x4c, 0xd6, 0x2f, 0x2b, 0x28, 0x2d, 0x2a, 0x4e, 0xd5, 0x4f, 0x4f, 0xcd, 0x4b, 0x2d, 0xce,
 	0x2c, 0xd6, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0xe2, 0x85, 0x48, 0xea, 0x41, 0x24, 0xa5, 0x44,
-	0xd2, 0xf3, 0xd3, 0xf3, 0xc1, 0x32, 0xfa, 0x20, 0x16, 0x44, 0x91, 0xd2, 0x47, 0x46, 0x2e, 0x1e,
-	0x77, 0x88, 0xb6, 0xe0, 0x92, 0xc4, 0x92, 0x54, 0x21, 0x6d, 0x2e, 0xc1, 0xa4, 0xfc, 0xfc, 0x92,
-	0xe2, 0x92, 0xa2, 0xc4, 0x82, 0xf8, 0xc4, 0x94, 0x94, 0xa2, 0xd4, 0xe2, 0x62, 0x09, 0x46, 0x05,
-	0x46, 0x0d, 0xce, 0x20, 0x01, 0xb8, 0x84, 0x23, 0x44, 0x5c, 0x28, 0x9c, 0x8b, 0x1f, 0xa1, 0xb8,
-	0x2c, 0x31, 0xa7, 0x34, 0x55, 0x82, 0x09, 0xa4, 0xd4, 0x49, 0xef, 0xc4, 0x3d, 0x79, 0x86, 0x5b,
-	0xf7, 0xe4, 0xd5, 0xd2, 0x33, 0x4b, 0x32, 0x4a, 0x93, 0xf4, 0x92, 0xf3, 0x73, 0xf5, 0x93, 0xf3,
-	0x8b, 0x73, 0xf3, 0x8b, 0xa1, 0x94, 0x6e, 0x71, 0x4a, 0xb6, 0x7e, 0x49, 0x65, 0x41, 0x6a, 0xb1,
-	0x9e, 0x67, 0x5e, 0x49, 0x10, 0x1f, 0xdc, 0x98, 0x30, 0x90, 0x29, 0x42, 0xa1, 0x5c, 0x7c, 0x29,
-	0xf9, 0x79, 0x89, 0x25, 0x99, 0xf9, 0x79, 0x50, 0x73, 0x99, 0xc9, 0x32, 0x97, 0x17, 0x66, 0x0a,
-	0xd8, 0x58, 0x2b, 0x96, 0x17, 0x0b, 0xe4, 0x19, 0x9c, 0x82, 0x4f, 0x3c, 0x92, 0x63, 0xbc, 0xf0,
-	0x48, 0x8e, 0xf1, 0xc1, 0x23, 0x39, 0xc6, 0x09, 0x8f, 0xe5, 0x18, 0x2e, 0x3c, 0x96, 0x63, 0xb8,
-	0xf1, 0x58, 0x8e, 0x21, 0xca, 0x12, 0xc9, 0x58, 0x47, 0x48, 0xd0, 0x42, 0x02, 0x11, 0x6c, 0x6c,
-	0x7a, 0x7e, 0x4e, 0x62, 0x5e, 0x3a, 0xcc, 0xbe, 0x0a, 0x58, 0xa8, 0x83, 0x6d, 0x4b, 0x62, 0x03,
-	0x87, 0xa7, 0x31, 0x20, 0x00, 0x00, 0xff, 0xff, 0x41, 0xba, 0x27, 0x6a, 0x93, 0x01, 0x00, 0x00,
+	0xd2, 0xf3, 0xd3, 0xf3, 0xc1, 0x32, 0xfa, 0x20, 0x16, 0x44, 0x91, 0x92, 0x08, 0x17, 0x8f, 0x3b,
+	0x44, 0x57, 0x70, 0x49, 0x62, 0x49, 0xaa, 0x15, 0xcb, 0x8b, 0x05, 0xf2, 0x0c, 0x4e, 0xc1, 0x27,
+	0x1e, 0xc9, 0x31, 0x5e, 0x78, 0x24, 0xc7, 0xf8, 0xe0, 0x91, 0x1c, 0xe3, 0x84, 0xc7, 0x72, 0x0c,
+	0x17, 0x1e, 0xcb, 0x31, 0xdc, 0x78, 0x2c, 0xc7, 0x10, 0x65, 0x99, 0x9e, 0x59, 0x92, 0x51, 0x9a,
+	0xa4, 0x97, 0x9c, 0x9f, 0xab, 0xef, 0x08, 0xb1, 0x1c, 0x62, 0x8d, 0x6e, 0x71, 0x4a, 0xb6, 0x7e,
+	0x7a, 0x7e, 0x4e, 0x62, 0x5e, 0xba, 0x7e, 0x72, 0x7e, 0x71, 0x6e, 0x7e, 0xb1, 0x7e, 0x05, 0xcc,
+	0x5d, 0x25, 0x95, 0x05, 0xa9, 0xc5, 0x49, 0x6c, 0x60, 0x1b, 0x8d, 0x01, 0x01, 0x00, 0x00, 0xff,
+	0xff, 0x06, 0x16, 0xf7, 0xbe, 0xb5, 0x00, 0x00, 0x00,
 }
 
 func (m *GenesisState) Marshal() (dAtA []byte, err error) {
@@ -120,33 +100,6 @@ func (m *GenesisState) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	{
-		size := m.DonationValue.Size()
-		i -= size
-		if _, err := m.DonationValue.MarshalTo(dAtA[i:]); err != nil {
-			return 0, err
-		}
-		i = encodeVarintGenesis(dAtA, i, uint64(size))
-	}
-	i--
-	dAtA[i] = 0x1a
-	{
-		size := m.BootstrapValue.Size()
-		i -= size
-		if _, err := m.BootstrapValue.MarshalTo(dAtA[i:]); err != nil {
-			return 0, err
-		}
-		i = encodeVarintGenesis(dAtA, i, uint64(size))
-	}
-	i--
-	dAtA[i] = 0x12
-	if len(m.BootstrapAddress) > 0 {
-		i -= len(m.BootstrapAddress)
-		copy(dAtA[i:], m.BootstrapAddress)
-		i = encodeVarintGenesis(dAtA, i, uint64(len(m.BootstrapAddress)))
-		i--
-		dAtA[i] = 0xa
-	}
 	return len(dAtA) - i, nil
 }
 
@@ -167,14 +120,6 @@ func (m *GenesisState) Size() (n int) {
 	}
 	var l int
 	_ = l
-	l = len(m.BootstrapAddress)
-	if l > 0 {
-		n += 1 + l + sovGenesis(uint64(l))
-	}
-	l = m.BootstrapValue.Size()
-	n += 1 + l + sovGenesis(uint64(l))
-	l = m.DonationValue.Size()
-	n += 1 + l + sovGenesis(uint64(l))
 	return n
 }
 
@@ -213,106 +158,6 @@ func (m *GenesisState) Unmarshal(dAtA []byte) error {
 			return fmt.Errorf("proto: GenesisState: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
-		case 1:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field BootstrapAddress", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowGenesis
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthGenesis
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return ErrInvalidLengthGenesis
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.BootstrapAddress = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
-		case 2:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field BootstrapValue", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowGenesis
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthGenesis
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return ErrInvalidLengthGenesis
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if err := m.BootstrapValue.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
-		case 3:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field DonationValue", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowGenesis
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthGenesis
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return ErrInvalidLengthGenesis
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if err := m.DonationValue.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipGenesis(dAtA[iNdEx:])

--- a/packages/SwingSet/src/gc-and-finalize.js
+++ b/packages/SwingSet/src/gc-and-finalize.js
@@ -63,11 +63,18 @@
  * dummy pre-resolved Promise.
  */
 
+let alreadyWarned = false;
 export async function gcAndFinalize() {
   if (typeof gc !== 'function') {
-    console.log(`unable to gc(), skipping`);
+    if (!alreadyWarned) {
+      alreadyWarned = true;
+      console.warn(
+        Error(`no gc() function; disabling deterministic finalizers`),
+      );
+    }
     return;
   }
+
   // on Node.js, GC seems to work better if the promise queue is empty first
   await new Promise(setImmediate);
   // on xsnap, we must do it twice for some reason

--- a/packages/agoric-cli/lib/chain-config.js
+++ b/packages/agoric-cli/lib/chain-config.js
@@ -1,12 +1,10 @@
 import djson from 'deterministic-json';
 import TOML from '@iarna/toml';
 
+export const CENTRAL_DENOM = 'urun';
 export const MINT_DENOM = 'ubld';
 export const STAKING_DENOM = 'ubld';
 export const STAKING_MAX_VALIDATORS = 150;
-
-export const DEFAULT_BOOTSTRAP_VALUE = 50000n * 10n ** 6n;
-export const DEFAULT_DONATION_VALUE = 5n * 10n ** 6n;
 
 export const GOV_DEPOSIT_COINS = [{ amount: '1000000', denom: MINT_DENOM }];
 
@@ -96,13 +94,7 @@ export function finishTendermintConfig({
 }
 
 // Rewrite/import the genesis.json.
-export function finishCosmosGenesis({
-  genesisJson,
-  exportedGenesisJson,
-  bootstrapAddress,
-  bootstrapValue,
-  donationValue,
-}) {
+export function finishCosmosGenesis({ genesisJson, exportedGenesisJson }) {
   const genesis = JSON.parse(genesisJson);
   const exported = exportedGenesisJson ? JSON.parse(exportedGenesisJson) : {};
 
@@ -132,12 +124,6 @@ export function finishCosmosGenesis({
   genesis.app_state.mint.minter.inflation = '0.0';
   genesis.app_state.mint.params.inflation_rate_change = '0.0';
   genesis.app_state.mint.params.inflation_min = '0.0';
-
-  genesis.app_state.vpurse.bootstrap_address = bootstrapAddress;
-  genesis.app_state.vpurse.bootstrap_value = `${bootstrapValue ||
-    DEFAULT_BOOTSTRAP_VALUE}`;
-  genesis.app_state.vpurse.donation_value = `${donationValue ||
-    DEFAULT_DONATION_VALUE}`;
 
   // Set the denomination for different modules.
   genesis.app_state.mint.params.mint_denom = MINT_DENOM;

--- a/packages/agoric-cli/lib/main.js
+++ b/packages/agoric-cli/lib/main.js
@@ -1,8 +1,7 @@
 /* global __dirname process */
 import { Command } from 'commander';
 
-import { assert, details as X, quote as q } from '@agoric/assert';
-import { Nat } from '@agoric/nat';
+import { assert, details as X } from '@agoric/assert';
 import cosmosMain from './cosmos';
 import deployMain from './deploy';
 import initMain from './init';
@@ -32,15 +31,6 @@ const main = async (progname, rawArgs, powers) => {
     }
     return true;
   }
-
-  const makeParseNatValue = flag => value => {
-    try {
-      const bi = BigInt(value);
-      return Nat(bi);
-    } catch (e) {
-      assert.fail(X`${q(flag)} must be a natural number, not ${value}; ${e}`);
-    }
-  };
 
   function subMain(fn, args, options) {
     return fn(progname, args, powers, options).then(
@@ -121,23 +111,6 @@ const main = async (progname, rawArgs, powers) => {
   program
     .command('set-defaults <program> <config-dir>')
     .description('update the configuration files for <program> in <config-dir>')
-    .option(
-      '--bootstrap-address <bech32>',
-      'the chain address which should receive urun',
-      '',
-    )
-    .option(
-      '--bootstrap-value <number>',
-      'the amount of urun to give to bootstrap-address',
-      makeParseNatValue('bootstrap-value'),
-      0n,
-    )
-    .option(
-      '--donation-value <number>',
-      'the amount of urun to transfer from bootsrtap-address to each client',
-      makeParseNatValue('donation-value'),
-      0n,
-    )
     .option(
       '--export-metrics',
       'open ports to export Prometheus metrics',

--- a/packages/agoric-cli/lib/set-defaults.js
+++ b/packages/agoric-cli/lib/set-defaults.js
@@ -17,18 +17,6 @@ export default async function setDefaultsMain(progname, rawArgs, powers, opts) {
     X`<prog> must currently be 'ag-chain-cosmos'`,
   );
 
-  const { bootstrapAddress, bootstrapValue, donationValue } = opts;
-
-  console.log(bootstrapAddress, bootstrapValue, donationValue);
-  assert(
-    bootstrapAddress || !bootstrapValue,
-    X`must set bootstrap-address if bootstrap-value is set`,
-  );
-  assert(
-    bootstrapAddress || !donationValue,
-    X`must set bootstrap-address if donation-value is set`,
-  );
-
   const { exportMetrics } = opts;
 
   let appFile;
@@ -94,9 +82,6 @@ export default async function setDefaultsMain(progname, rawArgs, powers, opts) {
     const newGenesisJson = finishCosmosGenesis({
       genesisJson,
       exportedGenesisJson,
-      bootstrapAddress,
-      bootstrapValue,
-      donationValue,
     });
 
     await create(genesisFile, newGenesisJson);

--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -62,12 +62,12 @@ scenario2-setup-nobuild:
 	# Create the bootstrap account.
 	$(AGCH) --home=t1/bootstrap keys add bootstrap --keyring-backend=test
 	$(AGCH) --home=t1/bootstrap keys show -a bootstrap --keyring-backend=test > t1/bootstrap-address
-	$(AGCH) --home=t1/n0 add-genesis-account `cat t1/bootstrap-address` 1000000000000000ubld,100provisionpass,100sendpacketpass
+	$(AGCH) --home=t1/n0 add-genesis-account `cat t1/bootstrap-address` 1000000000000000ubld,50000000000urun,100provisionpass,100sendpacketpass
 	# Create the (singleton) chain node.
 	$(AGCH) --home=t1/n0 --keyring-dir=t1/bootstrap gentx --keyring-backend=test bootstrap 73000000ubld --chain-id=$(CHAIN_ID)
 	$(AGCH) --home=t1/n0 collect-gentxs
 	$(AGCH) --home=t1/n0 validate-genesis
-	../agoric-cli/bin/agoric set-defaults --export-metrics --bootstrap-address=`cat t1/bootstrap-address` ag-chain-cosmos t1/n0/config
+	../agoric-cli/bin/agoric set-defaults --export-metrics ag-chain-cosmos t1/n0/config
 	# Set the chain address in all the ag-solos.
 	jq '. + { genesis_time: "$(GENESIS_TIME)", initial_height: "$(INITIAL_HEIGHT)" }' t1/n0/config/genesis.json > t1/n0/config/genesis2.json
 	mv t1/n0/config/genesis2.json t1/n0/config/genesis.json
@@ -87,8 +87,8 @@ scenario2-reset-client:
 scenario2-run-client: t1-provision-one-with-powers t1-start-ag-solo
 
 # Provision the ag-solo from an provisionpass-holding address (idempotent).
-AGORIC_POWERS = agoric.bankManager,agoric.agoricNamesAdmin,agoric.pegasusConnections,agoric.priceAuthorityAdmin,agoric.treasuryCreator,agoric.vattp
-SOLO_COINS = 13000000ubld
+AGORIC_POWERS = agoric.ALL_THE_POWERS
+SOLO_COINS = 13000000ubld,5000000urun
 COSMOS_RPC_HOST = localhost
 COSMOS_RPC_PORT = 26657
 wait-for-cosmos:
@@ -106,7 +106,7 @@ t1-provision-one-with-powers: wait-for-cosmos
 	  $(AGCH) --home=t1/bootstrap query swingset egress $$addr --chain-id=$(CHAIN_ID) || \
 		{ $(AGCH) --home=t1/bootstrap tx bank send --keyring-backend=test --from=bootstrap \
 		  --gas=auto --gas-adjustment=1.2 --broadcast-mode=block --yes --chain-id=$(CHAIN_ID) \
-			bootstrap $$addr $(SOLO_COINS); \
+			bootstrap $$addr $(SOLO_COINS) && \
 	  $(AGCH) --home=t1/bootstrap tx swingset provision-one --keyring-backend=test --from=bootstrap \
 		  --gas=auto --gas-adjustment=1.2 --broadcast-mode=block --yes --chain-id=$(CHAIN_ID) \
 		  t1/$(BASE_PORT) $$addr $(AGORIC_POWERS) | tee /dev/stderr | grep -q '"code":0'; }
@@ -116,7 +116,7 @@ t1-provision-one: wait-for-cosmos
 	  $(AGCH) --home=t1/bootstrap query swingset egress $$addr --chain-id=$(CHAIN_ID) || \
 		{ $(AGCH) --home=t1/bootstrap tx bank send --keyring-backend=test --from=bootstrap \
 		  --gas=auto --gas-adjustment=1.2 --broadcast-mode=block --yes --chain-id=$(CHAIN_ID) \
-			bootstrap $$addr $(SOLO_COINS); \
+			bootstrap $$addr $(SOLO_COINS) && \
 	  $(AGCH) --home=t1/bootstrap tx swingset provision-one --keyring-backend=test --from=bootstrap \
 		  --gas=auto --gas-adjustment=1.2 --broadcast-mode=block --yes --chain-id=$(CHAIN_ID) \
 		  t1/$(BASE_PORT) $$addr | tee /dev/stderr | grep -q '"code":0'; }

--- a/packages/xsnap/test/gc.js
+++ b/packages/xsnap/test/gc.js
@@ -68,9 +68,15 @@
  * dummy pre-resolved Promise.
  */
 
+let alreadyWarned = false;
 export async function gcAndFinalize() {
   if (typeof gc !== 'function') {
-    console.log(`unable to gc(), skipping`);
+    if (!alreadyWarned) {
+      alreadyWarned = true;
+      console.warn(
+        Error(`no gc() function; disabling deterministic finalizers`),
+      );
+    }
     return;
   }
   // on Node.js, GC seems to work better if the promise queue is empty first


### PR DESCRIPTION
Closes #3068 
Fixes #3120

@JimLarson This PR removes the potentially out-of-sync `urun` parameters from the `x/vpurse` module's `genesis.json` parameters.  Instead, the total fungible coins supply is calculated and sent to JS in the `AG_COSMOS_INIT` call.  The treasury-minted RUN corresponding to the `urun` supply allocated in the genesis.json is not sent to a special "bootstrap" account, it is instead deposited in a RUN-urun escrow purse to back the `urun` bank purse supply with actual RUN.

Additionally, the bootstrap per-provision RUN donation was removed, in favour of just using `tx bank send` to transfer `urun` to the provisioned address.  Since that is now simpler, #3120 was easy to fix, and now `agoric start local-chain` and `agoric start local-solo` give the solo wallets 5 RUN and 13 BLD.  @dckc I updated the on-chain faucet to do the same.

@warner In testing these changes, I cleared up the `unable to gc(), skipping` message to make it more explicit and non-repetitive.  ~~I also gave the `$SWINGSET_WORKER_TYPE` setting precedence over the config file, to help me diagnose some error stacks on the chain without using xsnap.~~
