### PR TITLE
Move transcripts out of key-value store and into stream stores

### DIFF
--- a/packages/SwingSet/bin/extract-transcript-from-kerneldb.js
+++ b/packages/SwingSet/bin/extract-transcript-from-kerneldb.js
@@ -1,3 +1,5 @@
+// XXX this is wrong; it needs to use the swingstore instead of opening the LMDB
+// file directly, then use stream store reads to get the transcript entries.
 import lmdb from 'node-lmdb';
 import process from 'process';
 import fs from 'fs';

--- a/packages/SwingSet/src/kernel/initializeKernel.js
+++ b/packages/SwingSet/src/kernel/initializeKernel.js
@@ -17,11 +17,11 @@ function makeVatRootObjectSlot() {
 export function initializeKernel(config, hostStorage, verbose = false) {
   const logStartup = verbose ? console.debug : () => 0;
 
-  const { kvStore } = hostStorage;
+  const { kvStore, streamStore } = hostStorage;
   insistStorageAPI(kvStore);
   const { enhancedCrankBuffer, commitCrank } = wrapStorage(kvStore);
 
-  const kernelKeeper = makeKernelKeeper(enhancedCrankBuffer);
+  const kernelKeeper = makeKernelKeeper(enhancedCrankBuffer, streamStore);
 
   const wasInitialized = kernelKeeper.getInitialized();
   assert(!wasInitialized);

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -111,7 +111,7 @@ export default function buildKernel(
   const { verbose, defaultManagerType = 'local' } = kernelOptions;
   const logStartup = verbose ? console.debug : () => 0;
 
-  const { kvStore } = hostStorage;
+  const { kvStore, streamStore } = hostStorage;
   insistStorageAPI(kvStore);
   const { enhancedCrankBuffer, abortCrank, commitCrank } = wrapStorage(kvStore);
 
@@ -119,7 +119,11 @@ export default function buildKernel(
     ? makeSlogger(slogCallbacks, writeSlogObject)
     : makeDummySlogger(slogCallbacks, makeConsole);
 
-  const kernelKeeper = makeKernelKeeper(enhancedCrankBuffer, kernelSlog);
+  const kernelKeeper = makeKernelKeeper(
+    enhancedCrankBuffer,
+    streamStore,
+    kernelSlog,
+  );
 
   const meterManager = makeMeterManager(replaceGlobalMeter);
 

--- a/packages/SwingSet/src/types.js
+++ b/packages/SwingSet/src/types.js
@@ -103,7 +103,7 @@
  *
  * @typedef { { d: VatDeliveryObject, syscalls: VatSyscallObject[] } } TranscriptEntry
  * @typedef { { transcriptCount: number } } VatStats
- * @typedef { { getTranscript: () => TranscriptEntry[],
+ * @typedef { { getTranscript: (startPos?: Object) => TranscriptEntry[],
  *              vatStats: () => VatStats,
  *             } } VatKeeper
  * @typedef { { getVatKeeper: (vatID: string) => VatKeeper } } KernelKeeper

--- a/packages/SwingSet/test/metering/test-dynamic-vat-metered.js
+++ b/packages/SwingSet/test/metering/test-dynamic-vat-metered.js
@@ -80,7 +80,7 @@ async function runOneTest(t, explosion, managerType) {
   await c.run();
   t.is(JSON.parse(kvStore.get('vat.dynamicIDs')).length, 1);
   t.is(kvStore.get(`${root}.owner`), vatID);
-  t.is(Array.from(kvStore.getKeys(`${vatID}`, `${vatID}/`)).length, 12);
+  t.is(Array.from(kvStore.getKeys(`${vatID}`, `${vatID}/`)).length, 10);
   // neverKPID should still be unresolved
   t.is(kvStore.get(`${neverKPID}.state`), 'unresolved');
 

--- a/packages/SwingSet/test/test-clist.js
+++ b/packages/SwingSet/test/test-clist.js
@@ -8,9 +8,10 @@ import { wrapStorage } from '../src/kernel/state/storageWrapper';
 
 test(`clist reachability`, async t => {
   const slog = makeDummySlogger({});
-  const { enhancedCrankBuffer: s } = wrapStorage(initSwingStore().kvStore);
+  const hostStorage = initSwingStore();
+  const { enhancedCrankBuffer: s } = wrapStorage(hostStorage.kvStore);
 
-  const kk = makeKernelKeeper(s, slog);
+  const kk = makeKernelKeeper(s, hostStorage.streamStore, slog);
   kk.createStartingKernelState('local');
   const vatID = kk.allocateUnusedVatID();
   const vk = kk.allocateVatKeeper(vatID);

--- a/packages/SwingSet/test/test-devices.js
+++ b/packages/SwingSet/test/test-devices.js
@@ -237,7 +237,7 @@ test.serial('device state', async t => {
   const d3 = c1.deviceNameToID('d3');
   await c1.run();
   t.deepEqual(c1.dump().log, ['undefined', 'w+r', 'called', 'got {"s":"new"}']);
-  const s = getAllState(hostStorage.kvStore);
+  const s = getAllState(hostStorage).kvStuff;
   t.deepEqual(JSON.parse(s[`${d3}.deviceState`]), capargs({ s: 'new' }));
   t.deepEqual(JSON.parse(s[`${d3}.o.nextID`]), 10);
 });

--- a/packages/SwingSet/test/test-gc-transcript.js
+++ b/packages/SwingSet/test/test-gc-transcript.js
@@ -20,6 +20,7 @@ function setup(storedTranscript = []) {
     getTranscript() {
       return storedTranscript;
     },
+    closeTranscript() {},
   };
   const kernelKeeper = {
     getVatKeeper() {

--- a/packages/SwingSet/test/test-transcript-light.js
+++ b/packages/SwingSet/test/test-transcript-light.js
@@ -13,95 +13,90 @@ test('transcript-light load', async t => {
   );
   const hostStorage = provideHostStorage();
   const c = await buildVatController(config, ['one'], { hostStorage });
-  const kvStore = hostStorage.kvStore;
-  const state0 = getAllState(kvStore);
-  t.is(state0.initialized, 'true');
-  t.not(state0.runQueue, '[]');
+  const state0 = getAllState(hostStorage);
+  t.is(state0.kvStuff.initialized, 'true');
+  t.not(state0.kvStuff.runQueue, '[]');
 
   await c.step();
-  const state1 = getAllState(kvStore);
+  const state1 = getAllState(hostStorage);
 
   await c.step();
-  const state2 = getAllState(kvStore);
+  const state2 = getAllState(hostStorage);
 
   await c.step();
-  const state3 = getAllState(kvStore);
+  const state3 = getAllState(hostStorage);
 
   await c.step();
-  const state4 = getAllState(kvStore);
+  const state4 = getAllState(hostStorage);
 
   await c.step();
-  const state5 = getAllState(kvStore);
+  const state5 = getAllState(hostStorage);
 
   // build from loaded state
   // Step 0
 
   const cfg0 = await loadBasedir(path.resolve(__dirname, 'basedir-transcript'));
   const hostStorage0 = provideHostStorage();
-  const kvStore0 = hostStorage0.kvStore;
-  // XXX TODO copy transcripts
-  setAllState(kvStore0, state0);
+  setAllState(hostStorage0, state0);
   const c0 = await buildVatController(cfg0, ['one'], {
     hostStorage: hostStorage0,
   });
 
   await c0.step();
-  t.deepEqual(state1, getAllState(kvStore0), `p1`);
+  t.deepEqual(state1, getAllState(hostStorage0), `p1`);
 
   await c0.step();
-  t.deepEqual(state2, getAllState(kvStore0), `p2`);
+  t.deepEqual(state2, getAllState(hostStorage0), `p2`);
 
   await c0.step();
-  t.deepEqual(state3, getAllState(kvStore0), `p3`);
+  t.deepEqual(state3, getAllState(hostStorage0), `p3`);
 
   await c0.step();
-  t.deepEqual(state4, getAllState(kvStore0), `p4`);
+  t.deepEqual(state4, getAllState(hostStorage0), `p4`);
 
   await c0.step();
-  t.deepEqual(state5, getAllState(kvStore0), `p5`);
+  t.deepEqual(state5, getAllState(hostStorage0), `p5`);
 
   // Step 1
 
   const cfg1 = await loadBasedir(path.resolve(__dirname, 'basedir-transcript'));
   const hostStorage1 = provideHostStorage();
-  const kvStore1 = hostStorage1.kvStore;
-  setAllState(kvStore1, state1);
+  setAllState(hostStorage1, state1);
   const c1 = await buildVatController(cfg1, ['one'], {
     hostStorage: hostStorage1,
   });
 
-  t.deepEqual(state1, getAllState(kvStore1), `p6`); // actual, expected
+  t.deepEqual(state1, getAllState(hostStorage1), `p6`); // actual, expected
 
   await c1.step();
-  t.deepEqual(state2, getAllState(kvStore1), `p7`);
+  t.deepEqual(state2, getAllState(hostStorage1), `p7`);
 
   await c1.step();
-  t.deepEqual(state3, getAllState(kvStore1), `p8`);
+  t.deepEqual(state3, getAllState(hostStorage1), `p8`);
 
   await c1.step();
-  t.deepEqual(state4, getAllState(kvStore1), `p9`);
+  t.deepEqual(state4, getAllState(hostStorage1), `p9`);
 
   await c1.step();
-  t.deepEqual(state5, getAllState(kvStore1), `p10`);
+  t.deepEqual(state5, getAllState(hostStorage1), `p10`);
 
   // Step 2
 
   const cfg2 = await loadBasedir(path.resolve(__dirname, 'basedir-transcript'));
   const hostStorage2 = provideHostStorage();
-  const kvStore2 = hostStorage2.kvStore;
-  setAllState(kvStore2, state2);
+  setAllState(hostStorage2, state2);
   const c2 = await buildVatController(cfg2, ['one'], {
     hostStorage: hostStorage2,
   });
 
-  t.deepEqual(state2, getAllState(kvStore2), `p11`);
+  t.deepEqual(state2, getAllState(hostStorage2), `p11`);
 
   await c2.step();
-  t.deepEqual(state3, getAllState(kvStore2), `p12`);
+  t.deepEqual(state3, getAllState(hostStorage2), `p12`);
 
   await c2.step();
-  t.deepEqual(state4, getAllState(kvStore2), `p13`);
+  t.deepEqual(state4, getAllState(hostStorage2), `p13`);
 
   await c2.step();
-  t.deepEqual(state5, getAllState(kvStore2), `p14`);
+  t.deepEqual(state5, getAllState(hostStorage2), `p14`);
 });

--- a/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
+++ b/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
@@ -133,10 +133,10 @@ test('dispatches to the dead do not harm kernel', async t => {
       'done: Error: arbitrary reason',
     ]);
   }
-  const state1 = getAllState(hostStorage1.kvStore);
+  const state1 = getAllState(hostStorage1);
   const hostStorage2 = provideHostStorage();
   // XXX TODO also copy transcripts
-  setAllState(hostStorage2.kvStore, state1);
+  setAllState(hostStorage2, state1);
   {
     const c2 = await buildVatController(config, [], {
       hostStorage: hostStorage2,
@@ -176,10 +176,10 @@ test('replay does not resurrect dead vat', async t => {
     t.deepEqual(c1.dump().log, [`w: I ate'nt dead`]);
   }
 
-  const state1 = getAllState(hostStorage1.kvStore);
+  const state1 = getAllState(hostStorage1);
   const hostStorage2 = provideHostStorage();
   // XXX TODO also copy transcripts
-  setAllState(hostStorage2.kvStore, state1);
+  setAllState(hostStorage2, state1);
   {
     const c2 = await buildVatController(config, [], {
       hostStorage: hostStorage2,
@@ -208,7 +208,7 @@ test('dead vat state removed', async t => {
   const kvStore = hostStorage.kvStore;
   t.is(kvStore.get('vat.dynamicIDs'), '["v6"]');
   t.is(kvStore.get('ko26.owner'), 'v6');
-  t.is(Array.from(kvStore.getKeys('v6.', 'v6/')).length, 9);
+  t.is(Array.from(kvStore.getKeys('v6.', 'v6/')).length, 8);
 
   controller.queueToVatExport('bootstrap', 'o+0', 'phase2', capargs([]));
   await controller.run();

--- a/packages/SwingSet/test/vat-admin/test-replay.js
+++ b/packages/SwingSet/test/vat-admin/test-replay.js
@@ -60,9 +60,9 @@ test('replay bundleSource-based dynamic vat', async t => {
   // we could re-use the Storage object, but I'll be paranoid and create a
   // new one.
 
-  const state1 = getAllState(hostStorage1.kvStore);
+  const state1 = getAllState(hostStorage1);
   const hostStorage2 = provideHostStorage();
-  setAllState(hostStorage2.kvStore, state1);
+  setAllState(hostStorage2, state1);
   {
     const c2 = await buildVatController(copy(config), [], {
       hostStorage: hostStorage2,
@@ -108,9 +108,9 @@ test('replay bundleName-based dynamic vat', async t => {
     t.deepEqual(c1.kpResolution(r1), capargs('created'));
   }
 
-  const state1 = getAllState(hostStorage1.kvStore);
+  const state1 = getAllState(hostStorage1);
   const hostStorage2 = provideHostStorage();
-  setAllState(hostStorage2.kvStore, state1);
+  setAllState(hostStorage2, state1);
   {
     const c2 = await buildVatController(copy(config), [], {
       hostStorage: hostStorage2,

--- a/packages/swingset-runner/.gitignore
+++ b/packages/swingset-runner/.gitignore
@@ -1,5 +1,6 @@
 # swingset persistence data
 *.mdb
+*.sss
 *.jsonlines
 *.naive
 slog

--- a/packages/swingset-runner/src/kerneldump.js
+++ b/packages/swingset-runner/src/kerneldump.js
@@ -135,7 +135,7 @@ export function main() {
     printMainStats(organizeMainStats(rawStats, cranks));
   } else {
     if (doDump) {
-      dumpStore(swingStore.kvStore, outfile, rawMode);
+      dumpStore(swingStore, outfile, rawMode);
     }
     if (refCounts) {
       auditRefCounts(swingStore.kvStore);

--- a/packages/swingset-runner/src/main.js
+++ b/packages/swingset-runner/src/main.js
@@ -531,7 +531,7 @@ export async function main() {
 
   function kernelStateDump() {
     const dumpPath = `${dumpDir}/${dumpTag}${crankNumber}`;
-    dumpStore(swingStore.kvStore, dumpPath, rawMode);
+    dumpStore(swingStore, dumpPath, rawMode);
   }
 
   async function runBenchmark(rounds) {


### PR DESCRIPTION
These changes actually realize the goal of ceasing to store vat transcripts in the kernel LMDB database, instead streaming them to files outside the database, all managed by the new SwingStore streamStore abstraction.

Closes #3065