### PR TITLE
chore(swingset): when a vat is terminated, log the problem to stdout

### DIFF
--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -387,6 +387,8 @@ export default function buildKernel(
       finish(deliveryResult);
       const [status, problem] = deliveryResult;
       if (status !== 'ok') {
+        // probably a metering fault, or a bug in the vat's dispatch()
+        console.log(`delivery problem, terminating vat ${vatID}`, problem);
         setTerminationTrigger(vatID, true, true, makeError(problem));
       }
     } catch (e) {


### PR DESCRIPTION
A vat getting terminated is somewhat surprising, so be more noisy about it.