### PR TITLE
chore(swingset): add GC Actions

### DIFF
--- a/packages/SwingSet/src/kernel/gc-actions.js
+++ b/packages/SwingSet/src/kernel/gc-actions.js
@@ -1,0 +1,85 @@
+import { assert } from '@agoric/assert';
+import { insistKernelType } from './parseKernelSlots';
+import { insistVatID } from './id';
+
+const typePriority = ['dropExport', 'retireExport', 'retireImport'];
+
+function parseAction(s) {
+  const [vatID, type, kref] = s.split(' ');
+  insistVatID(vatID);
+  assert(typePriority.includes(type), `unknown type ${type}`);
+  insistKernelType('object', kref);
+  return { vatID, type, kref };
+}
+
+export function processNextGCAction(kernelKeeper) {
+  const allActionsSet = kernelKeeper.getGCActions();
+
+  function getRefCount(kref) {
+    // When we check for a re-exported kref, if it's entirely missing, that
+    // qualifies (to us) as a zero refcount.
+    const owner = kernelKeeper.ownerOfKernelObject(kref);
+    if (owner) {
+      return kernelKeeper.getObjectRefCount(kref);
+    }
+    return { reachable: 0, recognizable: 0 };
+  }
+
+  function filterActions(groupedActions) {
+    const krefs = [];
+    const actions = [];
+    for (const action of groupedActions) {
+      const { type, kref } = parseAction(action);
+      const { reachable, recognizable } = getRefCount(kref);
+      // negate actions on re-exported krefs, and don't treat as work to do
+      if (reachable || (type === 'retireExport' && recognizable)) {
+        allActionsSet.delete(action);
+      } else {
+        krefs.push(kref);
+        actions.push(action);
+      }
+    }
+    for (const action of actions) {
+      allActionsSet.delete(action);
+    }
+    return krefs;
+  }
+
+  const grouped = new Map(); // grouped.get(vatID).get(type) = krefs to process
+  for (const action of allActionsSet) {
+    const { vatID, type } = parseAction(action);
+    if (!grouped.has(vatID)) {
+      grouped.set(vatID, new Map());
+    }
+    const forVat = grouped.get(vatID);
+    if (!forVat.has(type)) {
+      forVat.set(type, []);
+    }
+    forVat.get(type).push(action);
+  }
+  // console.log(`grouped:`, grouped);
+
+  const vatIDs = Array.from(grouped.keys());
+  vatIDs.sort();
+  for (const vatID of vatIDs) {
+    const forVat = grouped.get(vatID);
+    // find the highest-priority type of work to do within this vat
+    for (const type of typePriority) {
+      if (forVat.has(type)) {
+        const actions = forVat.get(type);
+        const krefs = filterActions(actions);
+        if (krefs.length) {
+          // at last, we act
+          krefs.sort();
+          // remove the work we're about to do from the durable set
+          kernelKeeper.setGCActions(allActionsSet);
+          return harden({ type: `${type}s`, vatID, krefs });
+        }
+      }
+    }
+  }
+  // remove negated items from the durable set
+  kernelKeeper.setGCActions(allActionsSet);
+  return undefined; // no GC work to do
+}
+harden(processNextGCAction);

--- a/packages/SwingSet/test/test-gc-actions.js
+++ b/packages/SwingSet/test/test-gc-actions.js
@@ -1,0 +1,152 @@
+// eslint-disable-next-line import/order
+import { test } from '../tools/prepare-test-env-ava';
+
+import { processNextGCAction } from '../src/kernel/gc-actions';
+
+test('gc actions', t => {
+  let rc = {};
+  let actions = [];
+  let newActions;
+  let msg;
+  function setActions(a) {
+    actions = a;
+    newActions = Array.from(a);
+  }
+  const kernelKeeper = {
+    getGCActions() {
+      return new Set(actions);
+    },
+    setGCActions(a) {
+      newActions = Array.from(a);
+      newActions.sort();
+    },
+    ownerOfKernelObject(kref) {
+      return rc[kref] ? 'vatX' : undefined;
+    },
+    getObjectRefCount(kref) {
+      const [reachable, recognizable] = rc[kref];
+      return { reachable, recognizable };
+    },
+  };
+  function process() {
+    return processNextGCAction(kernelKeeper);
+  }
+
+  function make(type, vatID, ...krefs) {
+    return { type, vatID, krefs };
+  }
+
+  // idle
+  setActions([]);
+  rc = {};
+  msg = process();
+  t.deepEqual(msg, undefined);
+  t.deepEqual(newActions, []);
+
+  // fully dropped. the dropExport takes priority
+  setActions(['v1 dropExport ko1', 'v1 retireExport ko1']);
+  rc = { ko1: [0, 0] };
+  msg = process();
+  t.deepEqual(msg, make('dropExports', 'v1', 'ko1'));
+  t.deepEqual(newActions, ['v1 retireExport ko1']);
+  // then the retireExport
+  setActions(['v1 retireExport ko1']);
+  rc = { ko1: [0, 0] };
+  msg = process();
+  t.deepEqual(msg, make('retireExports', 'v1', 'ko1'));
+  t.deepEqual(newActions, []);
+
+  // fully dropped, then fully re-reachable before dropExports: both negated
+  setActions(['v1 dropExport ko1', 'v1 retireExport ko1']);
+  rc = { ko1: [1, 1] }; // re-exported, still reachable+recognizable
+  msg = process();
+  t.deepEqual(msg, undefined);
+  t.deepEqual(newActions, []);
+
+  // fully dropped, dropExport happens, then fully re-reachable: retire negated
+  setActions(['v1 dropExport ko1', 'v1 retireExport ko1']);
+  rc = { ko1: [0, 0] };
+  msg = process();
+  t.deepEqual(msg, make('dropExports', 'v1', 'ko1'));
+  t.deepEqual(newActions, ['v1 retireExport ko1']);
+  setActions(['v1 retireExport ko1']);
+  rc = { ko1: [1, 1] };
+  msg = process();
+  t.deepEqual(msg, undefined);
+  t.deepEqual(newActions, []);
+
+  // fully dropped, re-reachable, partial drop, then dropExport
+  rc = { ko1: [0, 0] };
+  setActions(['v1 dropExport ko1', 'v1 retireExport ko1']);
+  rc = { ko1: [1, 1] };
+  rc = { ko1: [0, 1] };
+  msg = process();
+  t.deepEqual(msg, make('dropExports', 'v1', 'ko1'));
+  t.deepEqual(newActions, ['v1 retireExport ko1']);
+  // the retire is left pending because we ignore lower-prority types
+  setActions(['v1 retireExport ko1']);
+  rc = { ko1: [0, 1] };
+  msg = process();
+  t.deepEqual(msg, undefined);
+  t.deepEqual(newActions, []);
+
+  // fully dropped, dropExports happens, re-reachable, partial drop: retire
+  // negated
+  setActions(['v1 dropExport ko1', 'v1 retireExport ko1']);
+  rc = { ko1: [0, 0] };
+  msg = process();
+  t.deepEqual(msg, make('dropExports', 'v1', 'ko1'));
+  t.deepEqual(newActions, ['v1 retireExport ko1']);
+  setActions(['v1 retireExport ko1']);
+  rc = { ko1: [0, 1] };
+  msg = process();
+  t.deepEqual(msg, undefined);
+  t.deepEqual(newActions, []);
+
+  // partially dropped: recognizable but not reachable
+  setActions(['v1 dropExport ko1']);
+  rc = { ko1: [0, 1] }; // recognizable, not reachable
+  msg = process();
+  t.deepEqual(msg, make('dropExports', 'v1', 'ko1'));
+  t.deepEqual(newActions, []);
+
+  // partially dropped, re-reachable: negate dropExports
+  setActions(['v1 dropExport ko1']);
+  rc = { ko1: [1, 1] };
+  msg = process();
+  t.deepEqual(msg, undefined);
+  t.deepEqual(newActions, []);
+
+  // priority order: retireImports is last
+  setActions(['v1 dropExport ko1', 'v1 retireImport ko2']);
+  rc = { ko1: [0, 0], ko2: [0, 0] };
+  msg = process();
+  t.deepEqual(msg, make('dropExports', 'v1', 'ko1'));
+  t.deepEqual(newActions, ['v1 retireImport ko2']);
+
+  setActions(['v1 retireExport ko1', 'v1 retireImport ko2']);
+  rc = { ko1: [0, 0], ko2: [0, 0] };
+  msg = process();
+  t.deepEqual(msg, make('retireExports', 'v1', 'ko1'));
+  t.deepEqual(newActions, ['v1 retireImport ko2']);
+
+  setActions(['v1 retireImport ko2']);
+  rc = { ko1: [0, 0], ko2: [0, 0] };
+  msg = process();
+  t.deepEqual(msg, make('retireImports', 'v1', 'ko2'));
+  t.deepEqual(newActions, []);
+
+  // multiple vats: process in sorted order
+  setActions(['v1 dropExport ko1', 'v2 dropExport ko2']);
+  rc = { ko1: [0, 0], ko2: [0, 0] };
+  msg = process();
+  t.deepEqual(msg, make('dropExports', 'v1', 'ko1'));
+  t.deepEqual(newActions, ['v2 dropExport ko2']);
+
+  // multiple vats: vatID is major sort order, type is minor
+  setActions(['v1 retireExport ko1', 'v2 dropExport ko2']);
+  rc = { ko1: [0, 0], ko2: [0, 0] };
+  msg = process();
+  t.deepEqual(msg, make('retireExports', 'v1', 'ko1'));
+  t.deepEqual(newActions, ['v2 dropExport ko2']);
+});

--- a/packages/SwingSet/test/test-state.js
+++ b/packages/SwingSet/test/test-state.js
@@ -283,6 +283,7 @@ test('kernel state', async t => {
   checkState(t, getState, [
     ['crankNumber', '0'],
     ['initialized', 'true'],
+    ['gcActions', '[]'],
     ['runQueue', '[]'],
     ['vat.nextID', '1'],
     ['vat.names', '[]'],
@@ -314,6 +315,7 @@ test('kernelKeeper vat names', async t => {
   commitCrank();
   checkState(t, getState, [
     ['crankNumber', '0'],
+    ['gcActions', '[]'],
     ['runQueue', '[]'],
     ['vat.nextID', '3'],
     ['vat.names', JSON.stringify(['vatname5', 'Frank'])],
@@ -361,6 +363,7 @@ test('kernelKeeper device names', async t => {
   commitCrank();
   checkState(t, getState, [
     ['crankNumber', '0'],
+    ['gcActions', '[]'],
     ['runQueue', '[]'],
     ['vat.nextID', '1'],
     ['vat.names', '[]'],
@@ -539,6 +542,7 @@ test('kernelKeeper promises', async t => {
     ['vat.names', '[]'],
     ['vat.dynamicIDs', '[]'],
     ['device.names', '[]'],
+    ['gcActions', '[]'],
     ['runQueue', '[]'],
     ['kd.nextID', '30'],
     ['ko.nextID', '20'],


### PR DESCRIPTION
This is a relatively independent portion of the kernel-side GC work. "GC
Actions" are generated by the upcoming `processRefcounts()` function that the
kernel will run after each delivery is complete. For example, if the kernel
observes an object's "reachable" refcount drop to 0 during a crank, and the
count is still zero when `processRefcounts()` runs, it will push a
`dropExports` action (for the exporting vat and dropped kref) into the GC
Actions set.

The GC Actions set is stored durably in the kernelDB, and consulted by a call
to `processNextGCAction()` just before pulling anything else off the
run-queue. This call must select the highest-priority action to take, and
check to see if the kref in question has been re-exported since the action
was enqueued (removing it from the queue if so). It then returns the action
to take, or `undefined` if there are none.

This commit adds the implementation of `processNextGCAction()`, and the unit
test which exercises its various possibilities.

It also adds a new key to the kernelDB (named `gcActions`) which holds the
durable set, and several new kernelKeeper methods to manipulate it, including
`get`, a simple `add` function, and a `get` to replace the set
wholesale (since `processRefcounts` can be more efficient if it updates the
durable set in a single operation rather than a long sequence of adds).

It does not change the behavior of the kernel: nothing yet adds GC
Actions (this will happen in `processRefcounts()`, nor does anything example
the durable set to act upon any queued actions (this will happen in
`getNextMessage()`).

refs #3109
