### PR TITLE
Suggestion for 3184 -- decrement first

### DIFF
--- a/packages/treasury/src/collectRewardFees.js
+++ b/packages/treasury/src/collectRewardFees.js
@@ -16,11 +16,9 @@ export const makeMakeCollectFeesInvitation = (
     const { zcfSeat: transferSeat } = zcf.makeEmptySeatKit();
     await E.get(offerTo(zcf, invitation, {}, {}, transferSeat)).deposited;
 
-    feeSeat.decrementBy(
-      seat.incrementBy({ RUN: feeSeat.getAmountAllocated('RUN', runBrand) }),
+    seat.incrementBy(feeSeat.decrementBy({ RUN: feeSeat.getAmountAllocated('RUN', runBrand) }),
     );
-    transferSeat.decrementBy(
-      seat.incrementBy({
+    seat.incrementBy(transferSeat.decrementBy({
         RUN: transferSeat.getAmountAllocated('RUN', runBrand),
       }),
     );

--- a/packages/treasury/src/collectRewardFees.js
+++ b/packages/treasury/src/collectRewardFees.js
@@ -16,9 +16,11 @@ export const makeMakeCollectFeesInvitation = (
     const { zcfSeat: transferSeat } = zcf.makeEmptySeatKit();
     await E.get(offerTo(zcf, invitation, {}, {}, transferSeat)).deposited;
 
-    seat.incrementBy(feeSeat.decrementBy({ RUN: feeSeat.getAmountAllocated('RUN', runBrand) }),
+    seat.incrementBy(
+      feeSeat.decrementBy({ RUN: feeSeat.getAmountAllocated('RUN', runBrand) }),
     );
-    seat.incrementBy(transferSeat.decrementBy({
+    seat.incrementBy(
+      transferSeat.decrementBy({
         RUN: transferSeat.getAmountAllocated('RUN', runBrand),
       }),
     );

--- a/packages/treasury/src/stablecoinMachine.js
+++ b/packages/treasury/src/stablecoinMachine.js
@@ -83,8 +83,7 @@ export async function start(zcf) {
    * @type {TransferReward}
    */
   function transferReward(amount, fromSeat) {
-    fromSeat.decrementBy(
-      rewardPoolSeat.incrementBy({
+    rewardPoolSeat.incrementBy(fromSeat.decrementBy({
         RUN: amount,
       }),
     );
@@ -159,7 +158,7 @@ export async function start(zcf) {
 
       // trade the governance tokens for collateral, putting the
       // collateral on Secondary to be positioned for Autoswap
-      govSeat.decrementBy(seat.incrementBy({ Governance: govAmount }));
+      seat.incrementBy(govSeat.decrementBy({ Governance: govAmount }));
       govSeat.incrementBy({ Secondary: collateralIn });
       seat.decrementBy({ Collateral: collateralIn });
 

--- a/packages/treasury/src/stablecoinMachine.js
+++ b/packages/treasury/src/stablecoinMachine.js
@@ -83,7 +83,8 @@ export async function start(zcf) {
    * @type {TransferReward}
    */
   function transferReward(amount, fromSeat) {
-    rewardPoolSeat.incrementBy(fromSeat.decrementBy({
+    rewardPoolSeat.incrementBy(
+      fromSeat.decrementBy({
         RUN: amount,
       }),
     );

--- a/packages/treasury/src/vault.js
+++ b/packages/treasury/src/vault.js
@@ -165,9 +165,8 @@ export function makeVaultKit(
     assert(AmountMath.isGTE(runReturned, runDebt));
 
     // Return any overpayment
-    seat.decrementBy(vaultSeat.incrementBy({ RUN: runDebt }));
-    vaultSeat.decrementBy(
-      seat.incrementBy({ Collateral: getCollateralAllocated(vaultSeat) }),
+    vaultSeat.incrementBy(seat.decrementBy({ RUN: runDebt }));
+    seat.incrementBy(vaultSeat.decrementBy({ Collateral: getCollateralAllocated(vaultSeat) }),
     );
     zcf.reallocate(seat, vaultSeat);
 
@@ -236,12 +235,10 @@ export function makeVaultKit(
   function stageCollateral(seat) {
     const proposal = seat.getProposal();
     if (proposal.want.Collateral) {
-      vaultSeat.decrementBy(
-        seat.incrementBy({ Collateral: proposal.want.Collateral }),
+      seat.incrementBy(vaultSeat.decrementBy({ Collateral: proposal.want.Collateral }),
       );
     } else if (proposal.give.Collateral) {
-      seat.decrementBy(
-        vaultSeat.incrementBy({ Collateral: proposal.give.Collateral }),
+      vaultSeat.incrementBy(seat.decrementBy({ Collateral: proposal.give.Collateral }),
       );
     }
   }
@@ -282,14 +279,14 @@ export function makeVaultKit(
   function stageRun(seat) {
     const proposal = seat.getProposal();
     if (proposal.want.RUN) {
-      vaultSeat.decrementBy(seat.incrementBy({ RUN: proposal.want.RUN }));
+      seat.incrementBy(vaultSeat.decrementBy({ RUN: proposal.want.RUN }));
     } else if (proposal.give.RUN) {
       // We don't allow runDebt to be negative, so we'll refund overpayments
       const acceptedRun = AmountMath.isGTE(proposal.give.RUN, runDebt)
         ? runDebt
         : proposal.give.RUN;
 
-      seat.decrementBy(vaultSeat.incrementBy({ RUN: acceptedRun }));
+      vaultSeat.incrementBy(seat.decrementBy({ RUN: acceptedRun }));
     }
   }
 
@@ -411,8 +408,8 @@ export function makeVaultKit(
 
     runMint.mintGains({ RUN: runDebt }, vaultSeat);
 
-    vaultSeat.decrementBy(seat.incrementBy({ RUN: wantedRun }));
-    seat.decrementBy(vaultSeat.incrementBy({ Collateral: collateralAmount }));
+    seat.incrementBy(vaultSeat.decrementBy({ RUN: wantedRun }));
+    vaultSeat.incrementBy(seat.decrementBy({ Collateral: collateralAmount }));
     zcf.reallocate(vaultSeat, seat);
     manager.transferReward(fee, vaultSeat);
 

--- a/packages/treasury/src/vault.js
+++ b/packages/treasury/src/vault.js
@@ -166,7 +166,8 @@ export function makeVaultKit(
 
     // Return any overpayment
     vaultSeat.incrementBy(seat.decrementBy({ RUN: runDebt }));
-    seat.incrementBy(vaultSeat.decrementBy({ Collateral: getCollateralAllocated(vaultSeat) }),
+    seat.incrementBy(
+      vaultSeat.decrementBy({ Collateral: getCollateralAllocated(vaultSeat) }),
     );
     zcf.reallocate(seat, vaultSeat);
 
@@ -235,10 +236,12 @@ export function makeVaultKit(
   function stageCollateral(seat) {
     const proposal = seat.getProposal();
     if (proposal.want.Collateral) {
-      seat.incrementBy(vaultSeat.decrementBy({ Collateral: proposal.want.Collateral }),
+      seat.incrementBy(
+        vaultSeat.decrementBy({ Collateral: proposal.want.Collateral }),
       );
     } else if (proposal.give.Collateral) {
-      vaultSeat.incrementBy(seat.decrementBy({ Collateral: proposal.give.Collateral }),
+      vaultSeat.incrementBy(
+        seat.decrementBy({ Collateral: proposal.give.Collateral }),
       );
     }
   }

--- a/packages/treasury/test/vault-contract-wrapper.js
+++ b/packages/treasury/test/vault-contract-wrapper.js
@@ -40,8 +40,7 @@ export async function start(zcf) {
   };
 
   function transferReward(amount, fromSeat) {
-    fromSeat.decrementBy(
-      stableCoinSeat.incrementBy({
+    stableCoinSeat.incrementBy(fromSeat.decrementBy({
         RUN: amount,
       }),
     );

--- a/packages/treasury/test/vault-contract-wrapper.js
+++ b/packages/treasury/test/vault-contract-wrapper.js
@@ -40,7 +40,8 @@ export async function start(zcf) {
   };
 
   function transferReward(amount, fromSeat) {
-    stableCoinSeat.incrementBy(fromSeat.decrementBy({
+    stableCoinSeat.incrementBy(
+      fromSeat.decrementBy({
         RUN: amount,
       }),
     );

--- a/packages/zoe/src/contracts/autoswap.js
+++ b/packages/zoe/src/contracts/autoswap.js
@@ -294,7 +294,8 @@ const start = async zcf => {
       Secondary: newUserSecondaryAmount,
     };
 
-    poolSeat.incrementBy(removeLiqSeat.decrementBy({ Liquidity: userAllocation.Liquidity }),
+    poolSeat.incrementBy(
+      removeLiqSeat.decrementBy({ Liquidity: userAllocation.Liquidity }),
     );
 
     removeLiqSeat.incrementBy(poolSeat.decrementBy(liquidityRemoved));

--- a/packages/zoe/src/contracts/autoswap.js
+++ b/packages/zoe/src/contracts/autoswap.js
@@ -197,8 +197,8 @@ const start = async zcf => {
       Central: AmountMath.make(centralIn, brands.Central),
       Secondary: secondaryAmount,
     };
-    seat.decrementBy(poolSeat.incrementBy(liquidityDeposited));
-    poolSeat.decrementBy(seat.incrementBy({ Liquidity: liquidityAmountOut }));
+    poolSeat.incrementBy(seat.decrementBy(liquidityDeposited));
+    seat.incrementBy(poolSeat.decrementBy({ Liquidity: liquidityAmountOut }));
 
     zcf.reallocate(poolSeat, seat);
 
@@ -294,11 +294,10 @@ const start = async zcf => {
       Secondary: newUserSecondaryAmount,
     };
 
-    removeLiqSeat.decrementBy(
-      poolSeat.incrementBy({ Liquidity: userAllocation.Liquidity }),
+    poolSeat.incrementBy(removeLiqSeat.decrementBy({ Liquidity: userAllocation.Liquidity }),
     );
 
-    poolSeat.decrementBy(removeLiqSeat.incrementBy(liquidityRemoved));
+    removeLiqSeat.incrementBy(poolSeat.decrementBy(liquidityRemoved));
 
     zcf.reallocate(poolSeat, removeLiqSeat);
 

--- a/packages/zoe/src/contracts/callSpread/fundedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/fundedCallSpread.js
@@ -110,11 +110,9 @@ const start = async zcf => {
         give: { Collateral: null },
         want: { LongOption: null, ShortOption: null },
       });
-      creatorSeat.decrementBy(
-        collateralSeat.incrementBy({ Collateral: settlementAmount }),
+      collateralSeat.incrementBy(creatorSeat.decrementBy({ Collateral: settlementAmount }),
       );
-      collateralSeat.decrementBy(
-        creatorSeat.incrementBy({
+      creatorSeat.incrementBy(collateralSeat.decrementBy({
           LongOption: longAmount,
           ShortOption: shortAmount,
         }),

--- a/packages/zoe/src/contracts/callSpread/fundedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/fundedCallSpread.js
@@ -110,9 +110,11 @@ const start = async zcf => {
         give: { Collateral: null },
         want: { LongOption: null, ShortOption: null },
       });
-      collateralSeat.incrementBy(creatorSeat.decrementBy({ Collateral: settlementAmount }),
+      collateralSeat.incrementBy(
+        creatorSeat.decrementBy({ Collateral: settlementAmount }),
       );
-      creatorSeat.incrementBy(collateralSeat.decrementBy({
+      creatorSeat.incrementBy(
+        collateralSeat.decrementBy({
           LongOption: longAmount,
           ShortOption: shortAmount,
         }),

--- a/packages/zoe/src/contracts/callSpread/payoffHandler.js
+++ b/packages/zoe/src/contracts/callSpread/payoffHandler.js
@@ -38,7 +38,7 @@ function makePayoffHandler(zcf, seatPromiseKits, collateralSeat) {
     seatPromise.then(seat => {
       const totalCollateral = terms.settlementAmount;
       const seatPortion = multiplyBy(totalCollateral, sharePercent);
-      collateralSeat.decrementBy(seat.incrementBy({ Collateral: seatPortion }));
+      seat.incrementBy(collateralSeat.decrementBy({ Collateral: seatPortion }));
       zcf.reallocate(seat, collateralSeat);
       seat.exit();
       seatsExited += 1;

--- a/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
@@ -134,9 +134,8 @@ const start = zcf => {
         X`wanted option not a match`,
       );
 
-      collateralSeat.decrementBy(depositSeat.incrementBy(spreadAmount));
-      depositSeat.decrementBy(
-        collateralSeat.incrementBy({ Collateral: newCollateral }),
+      depositSeat.incrementBy(collateralSeat.decrementBy(spreadAmount));
+      collateralSeat.incrementBy(depositSeat.decrementBy({ Collateral: newCollateral }),
       );
 
       zcf.reallocate(collateralSeat, depositSeat);

--- a/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
@@ -135,7 +135,8 @@ const start = zcf => {
       );
 
       depositSeat.incrementBy(collateralSeat.decrementBy(spreadAmount));
-      collateralSeat.incrementBy(depositSeat.decrementBy({ Collateral: newCollateral }),
+      collateralSeat.incrementBy(
+        depositSeat.decrementBy({ Collateral: newCollateral }),
       );
 
       zcf.reallocate(collateralSeat, depositSeat);

--- a/packages/zoe/src/contracts/loan/addCollateral.js
+++ b/packages/zoe/src/contracts/loan/addCollateral.js
@@ -20,7 +20,8 @@ export const makeAddCollateralInvitation = (zcf, config) => {
       want: {},
     });
 
-    collateralSeat.incrementBy(addCollateralSeat.decrementBy({
+    collateralSeat.incrementBy(
+      addCollateralSeat.decrementBy({
         Collateral: addCollateralSeat.getAmountAllocated('Collateral'),
       }),
     );

--- a/packages/zoe/src/contracts/loan/addCollateral.js
+++ b/packages/zoe/src/contracts/loan/addCollateral.js
@@ -20,8 +20,7 @@ export const makeAddCollateralInvitation = (zcf, config) => {
       want: {},
     });
 
-    addCollateralSeat.decrementBy(
-      collateralSeat.incrementBy({
+    collateralSeat.incrementBy(addCollateralSeat.decrementBy({
         Collateral: addCollateralSeat.getAmountAllocated('Collateral'),
       }),
     );

--- a/packages/zoe/src/contracts/loan/borrow.js
+++ b/packages/zoe/src/contracts/loan/borrow.js
@@ -80,11 +80,10 @@ export const makeBorrowInvitation = (zcf, config) => {
     const { zcfSeat: collateralSeat } = zcf.makeEmptySeatKit();
 
     // Transfer the wanted Loan amount to the borrower
-    lenderSeat.decrementBy(borrowerSeat.incrementBy({ Loan: loanWanted }));
+    borrowerSeat.incrementBy(lenderSeat.decrementBy({ Loan: loanWanted }));
 
     // Transfer *all* collateral to the collateral seat.
-    borrowerSeat.decrementBy(
-      collateralSeat.incrementBy({ Collateral: collateralGiven }),
+    collateralSeat.incrementBy(borrowerSeat.decrementBy({ Collateral: collateralGiven }),
     );
     zcf.reallocate(lenderSeat, borrowerSeat, collateralSeat);
 

--- a/packages/zoe/src/contracts/loan/borrow.js
+++ b/packages/zoe/src/contracts/loan/borrow.js
@@ -83,7 +83,8 @@ export const makeBorrowInvitation = (zcf, config) => {
     borrowerSeat.incrementBy(lenderSeat.decrementBy({ Loan: loanWanted }));
 
     // Transfer *all* collateral to the collateral seat.
-    collateralSeat.incrementBy(borrowerSeat.decrementBy({ Collateral: collateralGiven }),
+    collateralSeat.incrementBy(
+      borrowerSeat.decrementBy({ Collateral: collateralGiven }),
     );
     zcf.reallocate(lenderSeat, borrowerSeat, collateralSeat);
 

--- a/packages/zoe/src/contracts/loan/close.js
+++ b/packages/zoe/src/contracts/loan/close.js
@@ -42,8 +42,7 @@ export const makeCloseLoanInvitation = (zcf, config) => {
     // required Loan amount. Any excess Loan amount is kept by the repaySeat.
     // Transfer the repaid loan amount to the lender
 
-    collateralSeat.decrementBy(
-      repaySeat.incrementBy({
+    repaySeat.incrementBy(collateralSeat.decrementBy({
         Collateral: collateralSeat.getAmountAllocated(
           'Collateral',
           collateralBrand,

--- a/packages/zoe/src/contracts/loan/close.js
+++ b/packages/zoe/src/contracts/loan/close.js
@@ -42,7 +42,8 @@ export const makeCloseLoanInvitation = (zcf, config) => {
     // required Loan amount. Any excess Loan amount is kept by the repaySeat.
     // Transfer the repaid loan amount to the lender
 
-    repaySeat.incrementBy(collateralSeat.decrementBy({
+    repaySeat.incrementBy(
+      collateralSeat.decrementBy({
         Collateral: collateralSeat.getAmountAllocated(
           'Collateral',
           collateralBrand,

--- a/packages/zoe/src/contracts/loan/scheduleLiquidation.js
+++ b/packages/zoe/src/contracts/loan/scheduleLiquidation.js
@@ -55,7 +55,8 @@ export const scheduleLiquidation = (zcf, configWithBorrower) => {
       // collateral is on the collateral seat. If an error occurs, we
       // reallocate the collateral to the lender and shutdown the
       // contract, kicking out any remaining seats.
-      lenderSeat.incrementBy(collateralSeat.decrementBy({ Collateral: allCollateral }),
+      lenderSeat.incrementBy(
+        collateralSeat.decrementBy({ Collateral: allCollateral }),
       );
       zcf.reallocate(lenderSeat, collateralSeat);
       zcf.shutdownWithFailure(err);

--- a/packages/zoe/src/contracts/loan/scheduleLiquidation.js
+++ b/packages/zoe/src/contracts/loan/scheduleLiquidation.js
@@ -55,8 +55,7 @@ export const scheduleLiquidation = (zcf, configWithBorrower) => {
       // collateral is on the collateral seat. If an error occurs, we
       // reallocate the collateral to the lender and shutdown the
       // contract, kicking out any remaining seats.
-      collateralSeat.decrementBy(
-        lenderSeat.incrementBy({ Collateral: allCollateral }),
+      lenderSeat.incrementBy(collateralSeat.decrementBy({ Collateral: allCollateral }),
       );
       zcf.reallocate(lenderSeat, collateralSeat);
       zcf.shutdownWithFailure(err);

--- a/packages/zoe/src/contracts/multipoolAutoswap/pool.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/pool.js
@@ -62,13 +62,15 @@ export const makeAddPool = (
       liquidityZcfMint.mintGains({ Liquidity: liquidityAmountOut }, poolSeat);
       liqTokenSupply += liquidityValueOut;
 
-      poolSeat.incrementBy(zcfSeat.decrementBy({
+      poolSeat.incrementBy(
+        zcfSeat.decrementBy({
           Central: zcfSeat.getCurrentAllocation().Central,
           Secondary: secondaryAmount,
         }),
       );
 
-      zcfSeat.incrementBy(poolSeat.decrementBy({ Liquidity: liquidityAmountOut }),
+      zcfSeat.incrementBy(
+        poolSeat.decrementBy({ Liquidity: liquidityAmountOut }),
       );
       zcf.reallocate(poolSeat, zcfSeat);
       zcfSeat.exit();
@@ -247,7 +249,8 @@ export const makeAddPool = (
         liqTokenSupply -= liquidityValueIn;
 
         poolSeat.incrementBy(userSeat.decrementBy({ Liquidity: liquidityIn }));
-        userSeat.incrementBy(poolSeat.decrementBy({
+        userSeat.incrementBy(
+          poolSeat.decrementBy({
             Central: centralTokenAmountOut,
             Secondary: tokenKeywordAmountOut,
           }),

--- a/packages/zoe/src/contracts/multipoolAutoswap/pool.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/pool.js
@@ -62,15 +62,13 @@ export const makeAddPool = (
       liquidityZcfMint.mintGains({ Liquidity: liquidityAmountOut }, poolSeat);
       liqTokenSupply += liquidityValueOut;
 
-      zcfSeat.decrementBy(
-        poolSeat.incrementBy({
+      poolSeat.incrementBy(zcfSeat.decrementBy({
           Central: zcfSeat.getCurrentAllocation().Central,
           Secondary: secondaryAmount,
         }),
       );
 
-      poolSeat.decrementBy(
-        zcfSeat.incrementBy({ Liquidity: liquidityAmountOut }),
+      zcfSeat.incrementBy(poolSeat.decrementBy({ Liquidity: liquidityAmountOut }),
       );
       zcf.reallocate(poolSeat, zcfSeat);
       zcfSeat.exit();
@@ -248,9 +246,8 @@ export const makeAddPool = (
 
         liqTokenSupply -= liquidityValueIn;
 
-        userSeat.decrementBy(poolSeat.incrementBy({ Liquidity: liquidityIn }));
-        poolSeat.decrementBy(
-          userSeat.incrementBy({
+        poolSeat.incrementBy(userSeat.decrementBy({ Liquidity: liquidityIn }));
+        userSeat.incrementBy(poolSeat.decrementBy({
             Central: centralTokenAmountOut,
             Secondary: tokenKeywordAmountOut,
           }),

--- a/packages/zoe/src/contracts/oracle.js
+++ b/packages/zoe/src/contracts/oracle.js
@@ -34,7 +34,7 @@ const start = async zcf => {
           ? feeSeat.getCurrentAllocation()
           : seat.getProposal().want;
 
-        feeSeat.decrementBy(seat.incrementBy(gains));
+        seat.incrementBy(feeSeat.decrementBy(gains));
         zcf.reallocate(seat, feeSeat);
         seat.exit();
         return 'Successfully withdrawn';
@@ -46,7 +46,7 @@ const start = async zcf => {
     makeShutdownInvitation: () => {
       const shutdown = seat => {
         revoked = true;
-        feeSeat.decrementBy(seat.incrementBy(feeSeat.getCurrentAllocation()));
+        seat.incrementBy(feeSeat.decrementBy(feeSeat.getCurrentAllocation()));
         zcf.reallocate(seat, feeSeat);
         zcf.shutdown(revokedMsg);
       };
@@ -84,7 +84,7 @@ const start = async zcf => {
           const fee = querySeat.getAmountAllocated('Fee', feeBrand);
           const { requiredFee, reply } = await E(handler).onQuery(query, fee);
           if (requiredFee) {
-            querySeat.decrementBy(feeSeat.incrementBy({ Fee: requiredFee }));
+            feeSeat.incrementBy(querySeat.decrementBy({ Fee: requiredFee }));
             zcf.reallocate(feeSeat, querySeat);
           }
           querySeat.exit();

--- a/packages/zoe/src/contracts/otcDesk.js
+++ b/packages/zoe/src/contracts/otcDesk.js
@@ -99,7 +99,7 @@ const start = zcf => {
   const addInventory = seat => {
     assertProposalShape(seat, { want: {} });
     // Take everything in this seat and add it to the marketMakerSeat
-    seat.decrementBy(marketMakerSeat.incrementBy(seat.getCurrentAllocation()));
+    marketMakerSeat.incrementBy(seat.decrementBy(seat.getCurrentAllocation()));
     zcf.reallocate(marketMakerSeat, seat);
     seat.exit();
     return 'Inventory added';
@@ -108,7 +108,7 @@ const start = zcf => {
   const removeInventory = seat => {
     assertProposalShape(seat, { give: {} });
     const { want } = seat.getProposal();
-    marketMakerSeat.decrementBy(seat.incrementBy(want));
+    seat.incrementBy(marketMakerSeat.decrementBy(want));
     zcf.reallocate(marketMakerSeat, seat);
     seat.exit();
     return 'Inventory removed';

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -108,8 +108,8 @@ const start = zcf => {
     );
 
     // Reallocate.
-    buyerSeat.decrementBy(sellerSeat.incrementBy({ Money: providedMoney }));
-    sellerSeat.decrementBy(buyerSeat.incrementBy({ Items: wantedItems }));
+    sellerSeat.incrementBy(buyerSeat.decrementBy({ Money: providedMoney }));
+    buyerSeat.incrementBy(sellerSeat.decrementBy({ Items: wantedItems }));
     zcf.reallocate(buyerSeat, sellerSeat);
 
     // The buyer's offer has been processed.

--- a/packages/zoe/test/unitTests/bounty.js
+++ b/packages/zoe/test/unitTests/bounty.js
@@ -27,8 +27,7 @@ const start = async zcf => {
     assertProposalShape(funderSeat, endowBounty);
 
     function payOffBounty(seat) {
-      funderSeat.decrementBy(
-        seat.incrementBy({ Bounty: funderSeat.getCurrentAllocation().Bounty }),
+      seat.incrementBy(funderSeat.decrementBy({ Bounty: funderSeat.getCurrentAllocation().Bounty }),
       );
 
       zcf.reallocate(funderSeat, seat);
@@ -57,7 +56,7 @@ const start = async zcf => {
       );
 
       // The funder gets the fee regardless of the outcome.
-      bountySeat.decrementBy(funderSeat.incrementBy({ Fee: feeAmount }));
+      funderSeat.incrementBy(bountySeat.decrementBy({ Fee: feeAmount }));
       zcf.reallocate(funderSeat, bountySeat);
 
       const wakeHandler = Far('wakeHandler', {

--- a/packages/zoe/test/unitTests/bounty.js
+++ b/packages/zoe/test/unitTests/bounty.js
@@ -27,7 +27,10 @@ const start = async zcf => {
     assertProposalShape(funderSeat, endowBounty);
 
     function payOffBounty(seat) {
-      seat.incrementBy(funderSeat.decrementBy({ Bounty: funderSeat.getCurrentAllocation().Bounty }),
+      seat.incrementBy(
+        funderSeat.decrementBy({
+          Bounty: funderSeat.getCurrentAllocation().Bounty,
+        }),
       );
 
       zcf.reallocate(funderSeat, seat);


### PR DESCRIPTION
Where the increment was nested inside the decrement in #3184, swap them.

For cases like this, I think it is more intuitive to put the decrement on the inside. It fits with our physical conservation intuitions: The amounts in the decrement's return value are the amounts extracted from the decremented seat's allocation. That amount in turn is used to increment the allocation of the outer seat.