### PR TITLE
prepare for GC: several kernel refactorings

### DIFF
--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -593,7 +593,9 @@ export default function buildKernel(
       terminationTrigger = null;
       if (message.type === 'send') {
         kernelKeeper.decrementRefCount(message.target, `deq|msg|t`);
-        kernelKeeper.decrementRefCount(message.msg.result, `deq|msg|r`);
+        if (message.msg.result) {
+          kernelKeeper.decrementRefCount(message.msg.result, `deq|msg|r`);
+        }
         let idx = 0;
         for (const argSlot of message.msg.args.slots) {
           kernelKeeper.decrementRefCount(argSlot, `deq|msg|s${idx}`);

--- a/packages/SwingSet/src/kernel/kernelSyscall.js
+++ b/packages/SwingSet/src/kernel/kernelSyscall.js
@@ -11,7 +11,9 @@ export function doSend(kernelKeeper, target, msg) {
   insistMessage(msg);
   const m = harden({ type: 'send', target, msg });
   kernelKeeper.incrementRefCount(target, `enq|msg|t`);
-  kernelKeeper.incrementRefCount(msg.result, `enq|msg|r`);
+  if (msg.result) {
+    kernelKeeper.incrementRefCount(msg.result, `enq|msg|r`);
+  }
   kernelKeeper.incStat('syscalls');
   kernelKeeper.incStat('syscallSend');
   let idx = 0;

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -788,6 +788,22 @@ export default function makeKernelKeeper(kvStore, streamStore, kernelSlog) {
     return harden(deviceIDs);
   }
 
+  function getImporters(koid) {
+    // TODO maintain an index instead of scanning every single vat
+    const importers = [];
+    function doesImport(vatID) {
+      return getVatKeeper(vatID).importsKernelSlot(koid);
+    }
+    importers.push(...getDynamicVats().filter(doesImport));
+    importers.push(
+      ...getStaticVats()
+        .map(nameAndVatID => nameAndVatID[1])
+        .filter(doesImport),
+    );
+    importers.sort();
+    return importers;
+  }
+
   // used for debugging, and tests. This returns a JSON-serializable object.
   // It includes references to live (mutable) kernel state, so don't mutate
   // the pieces, and be sure to serialize/deserialize before passing it
@@ -891,6 +907,7 @@ export default function makeKernelKeeper(kvStore, streamStore, kernelSlog) {
     addKernelObject,
     ownerOfKernelObject,
     ownerOfKernelDevice,
+    getImporters,
     deleteKernelObject,
 
     addKernelPromise,

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -2,6 +2,7 @@ import { Nat } from '@agoric/nat';
 import { assert, details as X } from '@agoric/assert';
 import { initializeVatState, makeVatKeeper } from './vatKeeper';
 import { initializeDeviceState, makeDeviceKeeper } from './deviceKeeper';
+import { parseReachableAndVatSlot } from './reachable';
 import { insistEnhancedStorageAPI } from '../../storageAPI';
 import {
   insistKernelType,
@@ -246,6 +247,11 @@ export default function makeKernelKeeper(kvStore, streamStore, kernelSlog) {
       actions.add(action);
     }
     setGCActions(actions);
+  }
+
+  function getReachableAndVatSlot(vatID, kernelSlot) {
+    const kernelKey = `${vatID}.c.${kernelSlot}`;
+    return parseReachableAndVatSlot(kvStore.get(kernelKey));
   }
 
   function addKernelObject(ownerID) {
@@ -707,6 +713,7 @@ export default function makeKernelKeeper(kvStore, streamStore, kernelSlog) {
       addKernelPromiseForVat,
       incrementRefCount,
       decrementRefCount,
+      getReachableAndVatSlot,
       incStat,
       decStat,
       getCrankNumber,

--- a/packages/SwingSet/src/kernel/state/reachable.js
+++ b/packages/SwingSet/src/kernel/state/reachable.js
@@ -1,0 +1,23 @@
+import { assert, details as X } from '@agoric/assert';
+
+export function parseReachableAndVatSlot(value) {
+  assert.typeof(value, 'string', X`non-string value: ${value}`);
+  const flag = value.slice(0, 1);
+  assert.equal(value.slice(1, 2), ' ');
+  const vatSlot = value.slice(2);
+  let isReachable;
+  if (flag === 'R') {
+    isReachable = true;
+  } else if (flag === '_') {
+    isReachable = false;
+  } else {
+    assert(`flag (${flag}) must be 'R' or '_'`);
+  }
+  return { isReachable, vatSlot };
+}
+harden(parseReachableAndVatSlot);
+
+export function buildReachableAndVatSlot(isReachable, vatSlot) {
+  return `${isReachable ? 'R' : '_'} ${vatSlot}`;
+}
+harden(buildReachableAndVatSlot);

--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -8,6 +8,10 @@ import { parseKernelSlot } from '../parseKernelSlots';
 import { makeVatSlot, parseVatSlot } from '../../parseVatSlots';
 import { insistVatID } from '../id';
 import { kdebug } from '../kdebug';
+import {
+  parseReachableAndVatSlot,
+  buildReachableAndVatSlot,
+} from './reachable';
 
 // makeVatKeeper is a pure function: all state is kept in the argument object
 
@@ -47,6 +51,7 @@ export function initializeVatState(kvStore, streamStore, vatID) {
  * kernel's mapping tables.
  * @param {*} incrementRefCount
  * @param {*} decrementRefCount
+ * @param {(vatID: string, kernelSlot: string) => {reachable: boolean, vatSlot: string}} getReachableAndVatSlot
  * @param {*} incStat
  * @param {*} decStat
  * @param {*} getCrankNumber
@@ -61,6 +66,7 @@ export function makeVatKeeper(
   addKernelPromiseForVat,
   incrementRefCount,
   decrementRefCount,
+  getReachableAndVatSlot,
   incStat,
   decStat,
   getCrankNumber,
@@ -84,40 +90,31 @@ export function makeVatKeeper(
     return harden({ source, options });
   }
 
-  function parseReachableAndVatSlot(value) {
-    assert.typeof(value, 'string', X`non-string value: ${value}`);
-    const flag = value.slice(0, 1);
-    assert.equal(value.slice(1, 2), ' ');
-    const vatSlot = value.slice(2);
-    let reachable;
-    if (flag === 'R') {
-      reachable = true;
-    } else if (flag === '_') {
-      reachable = false;
-    } else {
-      assert(`flag (${flag}) must be 'R' or '_'`);
-    }
-    return { reachable, vatSlot };
-  }
-
-  function buildReachableAndVatSlot(reachable, vatSlot) {
-    return `${reachable ? 'R' : '_'} ${vatSlot}`;
-  }
-
-  function getReachableAndVatSlot(kernelSlot) {
+  function getReachableFlag(kernelSlot) {
     const kernelKey = `${vatID}.c.${kernelSlot}`;
-    return parseReachableAndVatSlot(kvStore.get(kernelKey));
+    const data = kvStore.get(kernelKey);
+    const { isReachable } = parseReachableAndVatSlot(data);
+    return isReachable;
+  }
+
+  function insistNotReachable(kernelSlot) {
+    const isReachable = getReachableFlag(kernelSlot);
+    assert.equal(isReachable, false, X`${kernelSlot} was reachable, oops`);
   }
 
   function setReachableFlag(kernelSlot) {
+    // const { type } = parseKernelSlot(kernelSlot);
     const kernelKey = `${vatID}.c.${kernelSlot}`;
     const { vatSlot } = parseReachableAndVatSlot(kvStore.get(kernelKey));
+    // const { allocatedByVat } = parseVatSlot(vatSlot);
     kvStore.set(kernelKey, buildReachableAndVatSlot(true, vatSlot));
   }
 
   function clearReachableFlag(kernelSlot) {
+    // const { type } = parseKernelSlot(kernelSlot);
     const kernelKey = `${vatID}.c.${kernelSlot}`;
     const { vatSlot } = parseReachableAndVatSlot(kvStore.get(kernelKey));
+    // const { allocatedByVat } = parseVatSlot(vatSlot);
     kvStore.set(kernelKey, buildReachableAndVatSlot(false, vatSlot));
   }
 
@@ -181,8 +178,8 @@ export function makeVatKeeper(
         setReachableFlag(kernelSlot);
       } else {
         // imports must be reachable
-        const { reachable } = getReachableAndVatSlot(kernelSlot);
-        assert(reachable, X`vat tried to access unreachable import`);
+        const { isReachable } = getReachableAndVatSlot(vatID, kernelSlot);
+        assert(isReachable, X`vat tried to access unreachable import`);
       }
     }
     return kernelSlot;
@@ -235,7 +232,7 @@ export function makeVatKeeper(
       kdebug(`Add mapping k->v ${kernelKey}<=>${vatKey}`);
     }
 
-    const { reachable, vatSlot } = getReachableAndVatSlot(kernelSlot);
+    const { isReachable, vatSlot } = getReachableAndVatSlot(vatID, kernelSlot);
     const { allocatedByVat } = parseVatSlot(vatSlot);
     if (setReachable) {
       if (!allocatedByVat) {
@@ -244,7 +241,7 @@ export function makeVatKeeper(
       } else {
         // if the kernel is sending non-reachable exports back into
         // exporting vat, that's a kernel bug
-        assert(reachable, X`kernel sent unreachable export`);
+        assert(isReachable, X`kernel sent unreachable export ${kernelSlot}`);
       }
     }
     return vatSlot;
@@ -383,6 +380,8 @@ export function makeVatKeeper(
     getSourceAndOptions,
     mapVatSlotToKernelSlot,
     mapKernelSlotToVatSlot,
+    getReachableFlag,
+    insistNotReachable,
     setReachableFlag,
     clearReachableFlag,
     hasCListEntry,

--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -118,6 +118,19 @@ export function makeVatKeeper(
     kvStore.set(kernelKey, buildReachableAndVatSlot(false, vatSlot));
   }
 
+  function importsKernelSlot(kernelSlot) {
+    const kernelKey = `${vatID}.c.${kernelSlot}`;
+    const data = kvStore.get(kernelKey);
+    if (data) {
+      const { vatSlot } = parseReachableAndVatSlot(data);
+      const { allocatedByVat } = parseVatSlot(vatSlot);
+      if (!allocatedByVat) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /**
    * Provide the kernel slot corresponding to a given vat slot, allocating a
    * new one (for exports only) if it doesn't already exist. If we're allowed
@@ -378,6 +391,7 @@ export function makeVatKeeper(
   return harden({
     setSourceAndOptions,
     getSourceAndOptions,
+    importsKernelSlot,
     mapVatSlotToKernelSlot,
     mapKernelSlotToVatSlot,
     getReachableFlag,

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -314,7 +314,10 @@ test('bootstrap export', async t => {
     'right.obj0.bar 2 true',
   ]);
 
+  // that pushes several higher-priority GC dropExports onto the queue as
+  // everything gets dropped
+  await c.run();
+
   removeTriple(kt, barP, leftVatID, 'p+5'); // pruned promise
   checkKT(t, c, kt);
-  t.deepEqual(c.dump().runQueue, []);
 });

--- a/packages/SwingSet/test/test-devices.js
+++ b/packages/SwingSet/test/test-devices.js
@@ -162,7 +162,7 @@ async function test2(t, mode) {
       'method4',
       'ret method4 done',
     ]);
-    await c.step();
+    await c.run();
     t.deepEqual(c.dump().log, [
       'calling d2.method4',
       'method4',

--- a/packages/SwingSet/test/test-state.js
+++ b/packages/SwingSet/test/test-state.js
@@ -622,7 +622,7 @@ test('vatKeeper', async t => {
   t.is(vk2.mapVatSlotToKernelSlot(vatExport1), kernelExport1);
   t.is(vk2.mapKernelSlotToVatSlot(kernelExport1), vatExport1);
 
-  const kernelImport2 = 'ko25';
+  const kernelImport2 = k.addKernelObject('v1', 25);
   const vatImport2 = vk.mapKernelSlotToVatSlot(kernelImport2);
   t.is(vatImport2, 'o-50');
   t.is(vk.mapKernelSlotToVatSlot(kernelImport2), vatImport2);

--- a/packages/SwingSet/test/timer-device/test-device.js
+++ b/packages/SwingSet/test/timer-device/test-device.js
@@ -33,9 +33,9 @@ test('wake', async t => {
   await initializeSwingset(timerConfig, ['timer'], hostStorage);
   const c = await makeSwingsetController(hostStorage, deviceEndowments);
   timer.poll(1);
-  await c.step();
+  await c.run();
   timer.poll(5);
-  await c.step();
+  await c.run();
   t.deepEqual(c.dump().log, ['starting wake test', 'handler.wake()']);
 });
 
@@ -49,9 +49,9 @@ test('repeater', async t => {
   await initializeSwingset(timerConfig, ['repeater', 3, 2], hostStorage);
   const c = await makeSwingsetController(hostStorage, deviceEndowments);
   timer.poll(1);
-  await c.step();
+  await c.run();
   timer.poll(5);
-  await c.step();
+  await c.run();
   t.deepEqual(c.dump().log, [
     'starting repeater test',
     'next scheduled time: 3',
@@ -69,11 +69,11 @@ test('repeater2', async t => {
   await initializeSwingset(timerConfig, ['repeater', 3, 2], hostStorage);
   const c = await makeSwingsetController(hostStorage, deviceEndowments);
   timer.poll(1n);
-  await c.step();
+  await c.run();
   timer.poll(5n);
-  await c.step();
+  await c.run();
   timer.poll(8n);
-  await c.step();
+  await c.run();
   t.deepEqual(c.dump().log, [
     'starting repeater test',
     'next scheduled time: 3',
@@ -92,25 +92,25 @@ test('repeaterZero', async t => {
   await initializeSwingset(timerConfig, ['repeater', 0, 3], hostStorage);
   const c = await makeSwingsetController(hostStorage, deviceEndowments);
   timer.poll(1);
-  await c.step();
+  await c.run();
   timer.poll(2);
-  await c.step();
+  await c.run();
   timer.poll(3);
-  await c.step();
+  await c.run();
   timer.poll(4);
-  await c.step();
+  await c.run();
   timer.poll(5);
-  await c.step();
+  await c.run();
   timer.poll(6);
-  await c.step();
+  await c.run();
   timer.poll(7);
-  await c.step();
+  await c.run();
   timer.poll(8);
-  await c.step();
+  await c.run();
   timer.poll(9);
-  await c.step();
+  await c.run();
   timer.poll(10);
-  await c.step();
+  await c.run();
   t.deepEqual(c.dump().log, [
     'starting repeater test',
     'next scheduled time: 3',


### PR DESCRIPTION
This refactors a number of kernel pieces in preparation for landing GC features. I recommend reviewing this one commit at a time.

* tolerate missing result promise: don't `decrementRefCount` a message result promise if we know the value is `undefined`
* factor out the parsing and creation of the "reachable+vatSlot" string used as the value of kernelDB c-list kernel-to-vat entries
* improve `addKernelObject` for unit tests, and add `deleteKernelObject`
* add an admittedly lazy+inefficient implementation of `kernelKeeper.getImporters` (#3223 is the plan to make it better, but I think with <30 vats it's probably sufficient for the next few weeks)
* refactor `kernel.run()`/`step()` to use a new `getNextMessage()`, in preparation for executing GC actions before anything on the run-queue

refs #3106 
