### PR TITLE
chore: update to adhere better to conventional-commits

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,8 @@
     "version": {
       "message": "chore(release): publish",
       "conventionalCommits": true,
-      "preid": "dev"
+      "preid": "dev",
+      "changelogPreset": "conventionalcommits"
     }
   },
   "packages": [

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@typescript-eslint/parser": "^4.18.0",
     "ava": "^3.12.1",
     "c8": "^7.7.2",
+    "conventional-changelog-conventionalcommits": "^4.6.0",
     "eslint": "^7.23.0",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-config-jessie": "^0.0.4",

--- a/patches/@lerna+conventional-commits+3.18.5.patch
+++ b/patches/@lerna+conventional-commits+3.18.5.patch
@@ -1,0 +1,22 @@
+diff --git a/node_modules/@lerna/conventional-commits/lib/recommend-version.js b/node_modules/@lerna/conventional-commits/lib/recommend-version.js
+index f13ae56..ae5a449 100644
+--- a/node_modules/@lerna/conventional-commits/lib/recommend-version.js
++++ b/node_modules/@lerna/conventional-commits/lib/recommend-version.js
+@@ -51,7 +51,16 @@ function recommendVersion(pkg, type, { changelogPreset, rootPath, tagPrefix, pre
+ 
+         // result might be undefined because some presets are not consistent with angular
+         // we still need to bump _something_ because lerna saw a change here
+-        const releaseType = data.releaseType || "patch";
++        let releaseType = data.releaseType || "patch";
++        
++        // Don't gratuitously break compatibility with clients using `^0.x.y`.
++        if (semver.major(pkg.version) === 0) {
++          if (releaseType === "major") {
++            releaseType = "minor";
++          } else if (releaseType === "minor") {
++            releaseType = "patch";
++          }
++        }
+ 
+         if (prereleaseId) {
+           const shouldBump = shouldBumpPrerelease(releaseType, pkg.version);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4130,6 +4130,14 @@ compare-func@^1.3.1:
     array-ify "^1.0.0"
     dot-prop "^3.0.0"
 
+compare-func@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/compare-func/-/compare-func-2.0.0.tgz#fb65e75edbddfd2e568554e8b5b05fff7a51fcb3"
+  integrity sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==
+  dependencies:
+    array-ify "^1.0.0"
+    dot-prop "^5.1.0"
+
 component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
@@ -4244,6 +4252,15 @@ conventional-changelog-angular@^5.0.3:
   integrity sha512-QDEmLa+7qdhVIv8sFZfVxU1VSyVvnXPsxq8Vam49mKUcO1Z8VTLEJk9uI21uiJUsnmm0I4Hrsdc9TgkOQo9WSA==
   dependencies:
     compare-func "^1.3.1"
+    q "^1.5.1"
+
+conventional-changelog-conventionalcommits@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.0.tgz#7fc17211dbca160acf24687bd2fdd5fd767750eb"
+  integrity sha512-sj9tj3z5cnHaSJCYObA9nISf7eq/YjscLPoq6nmew4SiOjxqL2KRpK20fjnjVbpNDjJ2HR3MoVcWKXwbVvzS0A==
+  dependencies:
+    compare-func "^2.0.0"
+    lodash "^4.17.15"
     q "^1.5.1"
 
 conventional-changelog-core@^3.1.6:
@@ -5134,6 +5151,13 @@ dot-prop@^4.2.0:
   integrity sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==
   dependencies:
     is-obj "^1.0.0"
+
+dot-prop@^5.1.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.3.0.tgz#90ccce708cd9cd82cc4dc8c3ddd9abdd55b20e88"
+  integrity sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==
+  dependencies:
+    is-obj "^2.0.0"
 
 dot-prop@^5.2.0:
   version "5.2.0"


### PR DESCRIPTION
As noted in https://github.com/lerna/lerna/issues/2668#issuecomment-708632441  This honours either or both of the `!:` or `BREAKING CHANGE:` mechanisms to specify a breaking change.

Also, we patch Lerna to version pre-1.0.0 packages better (make `minor` bumps of `0.x.y` result in `0.x.(y+1)`).
