### PR TITLE
Clean up SwingStore constructor APIs

### DIFF
--- a/packages/SwingSet/src/hostStorage.js
+++ b/packages/SwingSet/src/hostStorage.js
@@ -1,8 +1,8 @@
 // @ts-check
-import { initSwingStore as initSimpleSwingStore } from '@agoric/swing-store-simple';
+import { initSimpleSwingStore } from '@agoric/swing-store-simple';
 import {
-  initSwingStore as initLMDBSwingStore,
-  openSwingStore as openLMDBSwingStore,
+  initLMDBSwingStore,
+  openLMDBSwingStore,
 } from '@agoric/swing-store-lmdb';
 
 import { assert, details as X } from '@agoric/assert';

--- a/packages/SwingSet/test/test-clist.js
+++ b/packages/SwingSet/test/test-clist.js
@@ -1,14 +1,14 @@
 import { test } from '../tools/prepare-test-env-ava';
 
 // eslint-disable-next-line import/order
-import { initSwingStore } from '@agoric/swing-store-simple';
+import { initSimpleSwingStore } from '@agoric/swing-store-simple';
 import { makeDummySlogger } from '../src/kernel/slogger';
 import makeKernelKeeper from '../src/kernel/state/kernelKeeper';
 import { wrapStorage } from '../src/kernel/state/storageWrapper';
 
 test(`clist reachability`, async t => {
   const slog = makeDummySlogger({});
-  const hostStorage = initSwingStore();
+  const hostStorage = initSimpleSwingStore();
   const { enhancedCrankBuffer: s } = wrapStorage(hostStorage.kvStore);
 
   const kk = makeKernelKeeper(s, hostStorage.streamStore, slog);

--- a/packages/SwingSet/test/test-state.js
+++ b/packages/SwingSet/test/test-state.js
@@ -2,7 +2,7 @@ import { test } from '../tools/prepare-test-env-ava';
 
 // eslint-disable-next-line import/order
 import {
-  initSwingStore,
+  initSimpleSwingStore,
   getAllState,
   setAllState,
 } from '@agoric/swing-store-simple';
@@ -68,12 +68,12 @@ function testStorage(t, s, getState, commit) {
 }
 
 test('storageInMemory', t => {
-  const store = initSwingStore();
+  const store = initSimpleSwingStore();
   testStorage(t, store.kvStore, () => getAllState(store).kvStuff, null);
 });
 
 function buildHostDBAndGetState() {
-  const store = initSwingStore();
+  const store = initSimpleSwingStore();
   const hostDB = buildHostDBInMemory(store.kvStore);
   return { hostDB, getState: () => getAllState(store).kvStuff };
 }
@@ -119,13 +119,13 @@ test('blockBuffer fulfills storage API', t => {
 });
 
 test('guardStorage fulfills storage API', t => {
-  const store = initSwingStore();
+  const store = initSimpleSwingStore();
   const guardedHostStorage = guardStorage(store.kvStore);
   testStorage(t, guardedHostStorage, () => getAllState(store).kvStuff, null);
 });
 
 test('crankBuffer fulfills storage API', t => {
-  const store = initSwingStore();
+  const store = initSimpleSwingStore();
   const { crankBuffer, commitCrank } = buildCrankBuffer(store.kvStore);
   testStorage(t, crankBuffer, () => getAllState(store).kvStuff, commitCrank);
 });
@@ -186,7 +186,7 @@ test('crankBuffer can abortCrank', t => {
 });
 
 test('storage helpers', t => {
-  const store = initSwingStore();
+  const store = initSimpleSwingStore();
   const s = addHelpers(store.kvStore);
 
   s.set('foo.0', 'f0');
@@ -236,7 +236,7 @@ test('storage helpers', t => {
 });
 
 function buildKeeperStorageInMemory() {
-  const store = initSwingStore();
+  const store = initSimpleSwingStore();
   const { kvStore, streamStore } = store;
   const { enhancedCrankBuffer, commitCrank } = wrapStorage(kvStore);
   return {
@@ -248,7 +248,7 @@ function buildKeeperStorageInMemory() {
 }
 
 function duplicateKeeper(getState) {
-  const store = initSwingStore();
+  const store = initSimpleSwingStore();
   const { kvStore, streamStore } = store;
   setAllState(store, { kvStuff: getState(), streamStuff: new Map() });
   const { enhancedCrankBuffer } = wrapStorage(kvStore);

--- a/packages/SwingSet/tools/db-delete.js
+++ b/packages/SwingSet/tools/db-delete.js
@@ -2,7 +2,7 @@
 
 import '@agoric/install-ses';
 import process from 'process';
-import { openSwingStore } from '@agoric/swing-store-lmdb';
+import { openLMDBSwingStore } from '@agoric/swing-store-lmdb';
 
 const log = console.log;
 
@@ -47,7 +47,7 @@ function run() {
   const stateDBDir = argv.shift();
   const key = argv.shift();
 
-  const { kvStore, commit } = openSwingStore(stateDBDir);
+  const { kvStore, commit } = openLMDBSwingStore(stateDBDir);
 
   if (range) {
     for (const k of kvStore.getKeys(`${key}.`, `${key}/`)) {

--- a/packages/SwingSet/tools/db-get.js
+++ b/packages/SwingSet/tools/db-get.js
@@ -2,7 +2,7 @@
 
 import '@agoric/install-ses';
 import process from 'process';
-import { openSwingStore } from '@agoric/swing-store-lmdb';
+import { openLMDBSwingStore } from '@agoric/swing-store-lmdb';
 
 const log = console.log;
 
@@ -58,7 +58,7 @@ function run() {
   const stateDBDir = argv.shift();
   const key = argv.shift();
 
-  const { kvStore } = openSwingStore(stateDBDir);
+  const { kvStore } = openLMDBSwingStore(stateDBDir);
 
   function pkv(k) {
     const value = kvStore.get(k);

--- a/packages/SwingSet/tools/db-set.js
+++ b/packages/SwingSet/tools/db-set.js
@@ -2,7 +2,7 @@
 
 import '@agoric/install-ses';
 import process from 'process';
-import { openSwingStore } from '@agoric/swing-store-lmdb';
+import { openLMDBSwingStore } from '@agoric/swing-store-lmdb';
 
 const log = console.log;
 
@@ -33,7 +33,7 @@ function run() {
   const key = argv.shift();
   const value = argv.shift();
 
-  const { kvStore, commit } = openSwingStore(stateDBDir);
+  const { kvStore, commit } = openLMDBSwingStore(stateDBDir);
 
   kvStore.set(key, value);
   commit();

--- a/packages/SwingSet/tools/replace-bundle.js
+++ b/packages/SwingSet/tools/replace-bundle.js
@@ -2,7 +2,7 @@
 
 import '@agoric/install-ses';
 import process from 'process';
-import { openSwingStore } from '@agoric/swing-store-lmdb';
+import { openLMDBSwingStore } from '@agoric/swing-store-lmdb';
 import bundleSource from '@agoric/bundle-source';
 
 const log = console.log;
@@ -35,7 +35,7 @@ async function run() {
   const stateDBDir = argv.shift();
   const srcPath = argv.shift();
 
-  const { kvStore, commit } = openSwingStore(stateDBDir);
+  const { kvStore, commit } = openLMDBSwingStore(stateDBDir);
   log(`will use ${srcPath} in ${stateDBDir} for ${bundleName}`);
 
   if (bundleName === 'kernel') {

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -12,7 +12,7 @@ import {
   loadSwingsetConfigFile,
 } from '@agoric/swingset-vat';
 import { assert, details as X } from '@agoric/assert';
-import { openSwingStore } from '@agoric/swing-store-lmdb';
+import { openLMDBSwingStore } from '@agoric/swing-store-lmdb';
 import {
   DEFAULT_METER_PROVIDER,
   exportKernelStats,
@@ -97,7 +97,7 @@ export async function launch(
 ) {
   console.info('Launching SwingSet kernel');
 
-  const { kvStore, streamStore, commit } = openSwingStore(kernelStateDBDir);
+  const { kvStore, streamStore, commit } = openLMDBSwingStore(kernelStateDBDir);
   const hostStorage = {
     kvStore,
     streamStore,

--- a/packages/solo/src/reset-state.js
+++ b/packages/solo/src/reset-state.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 
-import { initSwingStore } from '@agoric/swing-store-lmdb';
+import { initLMDBSwingStore } from '@agoric/swing-store-lmdb';
 
 export default async function resetState(basedir) {
   const mailboxStateFile = path.resolve(
@@ -10,7 +10,7 @@ export default async function resetState(basedir) {
   );
   fs.writeFileSync(mailboxStateFile, `{}\n`);
   const kernelStateDBDir = path.join(basedir, 'swingset-kernel-state');
-  const { commit, close } = initSwingStore(kernelStateDBDir);
+  const { commit, close } = initLMDBSwingStore(kernelStateDBDir);
   commit();
   close();
 }

--- a/packages/solo/src/start.js
+++ b/packages/solo/src/start.js
@@ -23,7 +23,7 @@ import {
   buildPlugin,
   buildTimer,
 } from '@agoric/swingset-vat';
-import { openSwingStore } from '@agoric/swing-store-lmdb';
+import { openLMDBSwingStore } from '@agoric/swing-store-lmdb';
 import { connectToFakeChain } from '@agoric/cosmic-swingset/src/sim-chain';
 import { makeWithQueue } from '@agoric/vats/src/queue';
 
@@ -134,7 +134,7 @@ async function buildSwingset(
     plugin: { ...plugin.endowments },
   };
 
-  const { kvStore, streamStore, commit } = openSwingStore(kernelStateDBDir);
+  const { kvStore, streamStore, commit } = openLMDBSwingStore(kernelStateDBDir);
   const hostStorage = {
     kvStore,
     streamStore,

--- a/packages/swing-store-lmdb/src/lmdbSwingStore.js
+++ b/packages/swing-store-lmdb/src/lmdbSwingStore.js
@@ -19,14 +19,15 @@ const encoder = new util.TextEncoder();
  */
 
 /**
- * Do the work of `initSwingStore` and `openSwingStore`.
+ * Do the work of `initLMDBSwingStore` and `openLMDBSwingStore`.
  *
  * @param {string} dirPath  Path to a directory in which database files may be kept.
  * @param {boolean} forceReset  If true, initialize the database to an empty state
+ * @param {Object} options  Configuration options
  *
  * @returns {SwingStore}
  */
-function makeSwingStore(dirPath, forceReset = false) {
+function makeLMDBSwingStore(dirPath, forceReset, options) {
   let txn = null;
 
   if (forceReset) {
@@ -34,10 +35,11 @@ function makeSwingStore(dirPath, forceReset = false) {
   }
   fs.mkdirSync(`${dirPath}/streams`, { recursive: true });
 
+  const { mapSize = 2 * 1024 * 1024 * 1024 } = options;
   let lmdbEnv = new lmdb.Env();
   lmdbEnv.open({
     path: dirPath,
-    mapSize: 2 * 1024 * 1024 * 1024, // XXX need to tune this
+    mapSize,
     // Turn off useWritemap on the Mac.  The userWritemap option is currently
     // required for LMDB to function correctly on Linux running under WSL, but
     // we don't yet have a convenient recipe to probe our environment at
@@ -406,12 +408,13 @@ function makeSwingStore(dirPath, forceReset = false) {
  *   This directory need not actually exist yet (if it doesn't it will be
  *   created) but it is reserved (by the caller) for the exclusive use of this
  *   swing store instance.
+ * @param {Object?} options  Optional configuration options
  *
  * @returns {SwingStore}
  */
-export function initSwingStore(dirPath) {
+export function initLMDBSwingStore(dirPath, options = {}) {
   assert.typeof(dirPath, 'string');
-  return makeSwingStore(dirPath, true);
+  return makeLMDBSwingStore(dirPath, true, options);
 }
 
 /**
@@ -422,12 +425,13 @@ export function initSwingStore(dirPath) {
  *   This directory need not actually exist yet (if it doesn't it will be
  *   created) but it is reserved (by the caller) for the exclusive use of this
  *   swing store instance.
+ * @param {Object?} options  Optional configuration options
  *
  * @returns {SwingStore}
  */
-export function openSwingStore(dirPath) {
+export function openLMDBSwingStore(dirPath, options = {}) {
   assert.typeof(dirPath, 'string');
-  return makeSwingStore(dirPath, false);
+  return makeLMDBSwingStore(dirPath, false, options);
 }
 
 /**
@@ -437,8 +441,8 @@ export function openSwingStore(dirPath) {
  *   This directory need not actually exist
  *
  * @returns {boolean}
- *   If the directory is present and contains the files created by initSwingStore
- *   or openSwingStore, returns true. Else returns false.
+ *   If the directory is present and contains the files created by initLMDBSwingStore
+ *   or openLMDBSwingStore, returns true. Else returns false.
  *
  */
 export function isSwingStore(dirPath) {

--- a/packages/swing-store-lmdb/test/test-state.js
+++ b/packages/swing-store-lmdb/test/test-state.js
@@ -9,8 +9,8 @@ import test from 'ava';
 import { getAllState } from '@agoric/swing-store-simple';
 
 import {
-  initSwingStore,
-  openSwingStore,
+  initLMDBSwingStore,
+  openLMDBSwingStore,
   isSwingStore,
 } from '../src/lmdbSwingStore';
 
@@ -54,7 +54,7 @@ test('storageInLMDB under SES', t => {
   t.teardown(() => fs.rmdirSync(dbDir, { recursive: true }));
   fs.rmdirSync(dbDir, { recursive: true });
   t.is(isSwingStore(dbDir), false);
-  const store = initSwingStore(dbDir);
+  const store = initLMDBSwingStore(dbDir);
   const { commit, close } = store;
   testKVStore(t, store);
   commit();
@@ -62,7 +62,7 @@ test('storageInLMDB under SES', t => {
   close();
   t.is(isSwingStore(dbDir), true);
 
-  const store2 = openSwingStore(dbDir);
+  const store2 = openLMDBSwingStore(dbDir);
   const { close: close2 } = store2;
   t.deepEqual(getAllState(store2), before, 'check state after reread');
   t.is(isSwingStore(dbDir), true);
@@ -74,7 +74,7 @@ test('streamStore read/write', t => {
   t.teardown(() => fs.rmdirSync(dbDir, { recursive: true }));
   fs.rmdirSync(dbDir, { recursive: true });
   t.is(isSwingStore(dbDir), false);
-  const { streamStore, commit, close } = initSwingStore(dbDir);
+  const { streamStore, commit, close } = initLMDBSwingStore(dbDir);
 
   const start = streamStore.STREAM_START;
   let s1pos = start;
@@ -117,7 +117,7 @@ test('streamStore mode interlock', t => {
   t.teardown(() => fs.rmdirSync(dbDir, { recursive: true }));
   fs.rmdirSync(dbDir, { recursive: true });
   t.is(isSwingStore(dbDir), false);
-  const { streamStore, commit, close } = initSwingStore(dbDir);
+  const { streamStore, commit, close } = initLMDBSwingStore(dbDir);
   const start = streamStore.STREAM_START;
 
   const s1pos = streamStore.writeStreamItem('st1', 'first', start);

--- a/packages/swing-store-simple/src/simpleSwingStore.js
+++ b/packages/swing-store-simple/src/simpleSwingStore.js
@@ -34,11 +34,11 @@ import { assert, details as X, q } from '@agoric/assert';
 const streamPeek = new WeakMap(); // for tests to get raw access to the streams
 
 /**
- * Do the work of `initSwingStore` and `openSwingStore`.
+ * Create a swingset store that based on an in-memory map.
  *
  * @returns {SwingStore}
  */
-function makeSwingStore() {
+export function initSimpleSwingStore() {
   const state = new Map();
 
   /**
@@ -270,54 +270,6 @@ function makeSwingStore() {
   streamPeek.set(streamStore, streams);
 
   return harden({ kvStore, streamStore, commit, close });
-}
-
-/**
- * Create a swingset store that is an in-memory map.
- *
- * @param {string=} dirPath  Optional path to a directory in which database files
- *   might be kept, if this were a persistent form of swingset store.  If a path
- *   is provided, a warning will be output to the console.  This parameter is
- *   provided so that the in-memory store may be substituted for a persistent
- *   store for testing or debugging purposes without needing to change the
- *   client.
- *
- * @returns {SwingStore}
- */
-export function initSwingStore(dirPath) {
-  if (dirPath) {
-    console.error(
-      Error(
-        `Warning: initSwingStore ignoring dirPath, simpleStore is memory only`,
-      ),
-    );
-  }
-  return makeSwingStore();
-}
-
-/**
- * Open a swingset store that is an in-memory map.  Note that "open" is a
- * misnomer here, because you will always get a fresh, empty store.  This entry
- * point is provided for testing purposes only.
- *
- * @param {string=} dirPath  Optional path to a directory in which database files
- *   might be kept, if this were a persistent form of swingset store.  If a path
- *   is provided, a warning will be output to the console.  This parameter is
- *   provided so that the in-memory store may be substituted for a persistent
- *   store for testing or debugging purposes without needing to change the
- *   client.
- *
- * @returns {SwingStore}
- */
-export function openSwingStore(dirPath) {
-  if (dirPath) {
-    console.error(
-      Error(
-        `Warning: initSwingStore ignoring dirPath, simpleStore is memory only`,
-      ),
-    );
-  }
-  return makeSwingStore();
 }
 
 /**

--- a/packages/swing-store-simple/test/test-state.js
+++ b/packages/swing-store-simple/test/test-state.js
@@ -1,10 +1,10 @@
 import '@agoric/install-ses';
 
 import test from 'ava';
-import { initSwingStore, getAllState } from '../src/simpleSwingStore';
+import { initSimpleSwingStore, getAllState } from '../src/simpleSwingStore';
 
 test('kvStore read/write', t => {
-  const store = initSwingStore();
+  const store = initSimpleSwingStore();
   const kvStore = store.kvStore;
 
   t.falsy(kvStore.has('missing'));
@@ -41,7 +41,7 @@ test('kvStore read/write', t => {
 });
 
 test('streamStore read/write', t => {
-  const { streamStore, commit, close } = initSwingStore();
+  const { streamStore, commit, close } = initSimpleSwingStore();
 
   const start = streamStore.STREAM_START;
   let s1pos = start;
@@ -80,7 +80,7 @@ test('streamStore read/write', t => {
 });
 
 test('streamStore mode interlock', t => {
-  const { streamStore, commit, close } = initSwingStore();
+  const { streamStore, commit, close } = initSimpleSwingStore();
   const start = streamStore.STREAM_START;
 
   const s1pos = streamStore.writeStreamItem('st1', 'first', start);

--- a/packages/swingset-runner/src/kerneldump.js
+++ b/packages/swingset-runner/src/kerneldump.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import process from 'process';
 
-import { openSwingStore } from '@agoric/swing-store-lmdb';
+import { openLMDBSwingStore } from '@agoric/swing-store-lmdb';
 
 import { dumpStore } from './dumpstore';
 import { auditRefCounts } from './auditstore';
@@ -106,7 +106,7 @@ export function main() {
   if (!kernelStateDBDir) {
     fail(`can't find a database at ${target}`, false);
   }
-  const swingStore = openSwingStore(kernelStateDBDir);
+  const swingStore = openLMDBSwingStore(kernelStateDBDir);
   if (justStats) {
     const rawStats = JSON.parse(swingStore.kvStore.get('kernelStats'));
     const cranks = Number(swingStore.kvStore.get('crankNumber'));

--- a/packages/swingset-runner/src/main.js
+++ b/packages/swingset-runner/src/main.js
@@ -15,10 +15,10 @@ import {
 import { buildLoopbox } from '@agoric/swingset-vat/src/devices/loopbox';
 import engineGC from '@agoric/swingset-vat/src/engine-gc';
 
-import { initSwingStore as initSimpleSwingStore } from '@agoric/swing-store-simple';
+import { initSimpleSwingStore } from '@agoric/swing-store-simple';
 import {
-  initSwingStore as initLMDBSwingStore,
-  openSwingStore as openLMDBSwingStore,
+  initLMDBSwingStore,
+  openLMDBSwingStore,
 } from '@agoric/swing-store-lmdb';
 
 import { dumpStore } from './dumpstore';


### PR DESCRIPTION
* Add an options bag parameter to the LMDB SwingStore constructors with an optional `maxSize` property to allow the configuration of the LMDB database size limit.  If not configured, it defaults to 2Gb, which is what it was previously hardcoded to be.

* Rename and refactor SwingStore constructors to acknowledge the reality that they are no longer polymorphic and should not be used as if they are (nobody was doing that, but this makes it official).  This includes updating all the places these constructors are called to reflect the new names (in many cases this simply involved getting rid of renamings that were already being done on `import`).

Closes #3073 
