### PR TITLE
chore(swingset): track vat deliveryNum persistently

### DIFF
--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -372,12 +372,15 @@ export default function buildKernel(
   async function deliverAndLogToVat(vatID, kernelDelivery, vatDelivery) {
     const vat = ephemeral.vats.get(vatID);
     assert(vat);
+    const vatKeeper = kernelKeeper.getVatKeeper(vatID);
     const crankNum = kernelKeeper.getCrankNumber();
+    const deliveryNum = vatKeeper.nextDeliveryNum(); // increments
     /** @typedef { any } FinishFunction TODO: static types for slog? */
     /** @type { FinishFunction } */
     const finish = kernelSlog.delivery(
       vatID,
       crankNum,
+      deliveryNum,
       kernelDelivery,
       vatDelivery,
     );

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -47,6 +47,7 @@ const enableKernelPromiseGC = true;
 //   $R is 'R' when reachable, '_' when merely recognizable
 //   $vatSlot is one of: o+$NN/o-$NN/p+$NN/p-$NN/d+$NN/d-$NN
 // v$NN.c.$vatSlot = $kernelSlot = ko$NN/kp$NN/kd$NN
+// v$NN.nextDeliveryNum = $NN
 // v$NN.t.endPosition = $NN
 // v$NN.vs.$key = string
 

--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -32,6 +32,7 @@ export function initializeVatState(kvStore, streamStore, vatID) {
   kvStore.set(`${vatID}.o.nextID`, `${FIRST_OBJECT_ID}`);
   kvStore.set(`${vatID}.p.nextID`, `${FIRST_PROMISE_ID}`);
   kvStore.set(`${vatID}.d.nextID`, `${FIRST_DEVICE_ID}`);
+  kvStore.set(`${vatID}.nextDeliveryNum`, `0`);
   kvStore.set(
     `${vatID}.t.endPosition`,
     `${JSON.stringify(streamStore.STREAM_START)}`,
@@ -88,6 +89,12 @@ export function makeVatKeeper(
     const source = JSON.parse(kvStore.get(`${vatID}.source`));
     const options = JSON.parse(kvStore.get(`${vatID}.options`));
     return harden({ source, options });
+  }
+
+  function nextDeliveryNum() {
+    const num = Nat(BigInt(kvStore.get(`${vatID}.nextDeliveryNum`)));
+    kvStore.set(`${vatID}.nextDeliveryNum`, `${num + 1n}`);
+    return num;
   }
 
   function getReachableFlag(kernelSlot) {
@@ -391,6 +398,7 @@ export function makeVatKeeper(
   return harden({
     setSourceAndOptions,
     getSourceAndOptions,
+    nextDeliveryNum,
     importsKernelSlot,
     mapVatSlotToKernelSlot,
     mapKernelSlotToVatSlot,

--- a/packages/SwingSet/test/metering/test-dynamic-vat-metered.js
+++ b/packages/SwingSet/test/metering/test-dynamic-vat-metered.js
@@ -80,7 +80,7 @@ async function runOneTest(t, explosion, managerType) {
   await c.run();
   t.is(JSON.parse(kvStore.get('vat.dynamicIDs')).length, 1);
   t.is(kvStore.get(`${root}.owner`), vatID);
-  t.is(Array.from(kvStore.getKeys(`${vatID}`, `${vatID}/`)).length, 10);
+  t.is(Array.from(kvStore.getKeys(`${vatID}`, `${vatID}/`)).length, 11);
   // neverKPID should still be unresolved
   t.is(kvStore.get(`${neverKPID}.state`), 'unresolved');
 

--- a/packages/SwingSet/test/test-state.js
+++ b/packages/SwingSet/test/test-state.js
@@ -616,11 +616,15 @@ test('vatKeeper', async t => {
   t.is(kernelExport1, 'ko20');
   t.is(vk.mapVatSlotToKernelSlot(vatExport1), kernelExport1);
   t.is(vk.mapKernelSlotToVatSlot(kernelExport1), vatExport1);
+  t.is(vk.nextDeliveryNum(), 0n);
+  t.is(vk.nextDeliveryNum(), 1n);
 
   commitCrank();
   let vk2 = duplicateKeeper(getState).allocateVatKeeper(v1);
   t.is(vk2.mapVatSlotToKernelSlot(vatExport1), kernelExport1);
   t.is(vk2.mapKernelSlotToVatSlot(kernelExport1), vatExport1);
+  t.is(vk2.nextDeliveryNum(), 2n);
+  t.is(vk2.nextDeliveryNum(), 3n);
 
   const kernelImport2 = k.addKernelObject('v1', 25);
   const vatImport2 = vk.mapKernelSlotToVatSlot(kernelImport2);

--- a/packages/SwingSet/test/test-syscall-failure.js
+++ b/packages/SwingSet/test/test-syscall-failure.js
@@ -40,7 +40,7 @@ async function vatSyscallFailure(t, beDynamic) {
       '["bootstrap","badvatStatic","vatAdmin","comms","vattp","timer"]',
     );
     t.is(kvStore.get(`${badVatRootObject}.owner`), badVatID);
-    t.is(Array.from(kvStore.getKeys(`${badVatID}.`, `${badVatID}/`)).length, 8);
+    t.is(Array.from(kvStore.getKeys(`${badVatID}.`, `${badVatID}/`)).length, 9);
     t.is(kvStore.get('vat.name.badvatStatic'), badVatID);
   }
   await controller.run();

--- a/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
+++ b/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
@@ -208,7 +208,7 @@ test('dead vat state removed', async t => {
   const kvStore = hostStorage.kvStore;
   t.is(kvStore.get('vat.dynamicIDs'), '["v6"]');
   t.is(kvStore.get('ko26.owner'), 'v6');
-  t.is(Array.from(kvStore.getKeys('v6.', 'v6/')).length, 8);
+  t.is(Array.from(kvStore.getKeys('v6.', 'v6/')).length, 9);
 
   controller.queueToVatExport('bootstrap', 'o+0', 'phase2', capargs([]));
   await controller.run();


### PR DESCRIPTION
Previously, the concept of "deliveryNum" (a counter of how many deliveries
have been made to any particular vat) only existed within the slogger, which
used an internal (ephemeral) counter, and attached the count to each slogfile
delivery record. That meant two successive slogfiles, created by two
successive launches of the same kernel (one building upon the saved state of
the other), would get overlapping delivery numbers. The problem would get
worse with the #2277 VatWarehouse, which will create a new `vatSlogger` each
time the vat is paged in (multiple times per kernel process).

This moves the `deliveryNum` counter into the kernelDB's durable `kvStore`,
in a new `$vatID.nextDeliveryNum` key. It is incremented for each delivery by
`deliverAndLogToVat()`. The slogger simply receives and remembers
`deliveryNum` (just like what it's always done with `crankNum`), and no
longer attempts to increment a counter itself.

closes #3254