### PR TITLE
feat: Add script for syncing versions

### DIFF
--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -44,7 +44,7 @@
     "@agoric/notifier": "^0.3.14",
     "@agoric/promise-kit": "^0.2.13",
     "@agoric/store": "^0.4.14",
-    "@agoric/swing-store-lmdb": "^0.4.11",
+    "@agoric/swing-store-lmdb": "^0.4.12",
     "@agoric/swing-store-simple": "^0.3.9",
     "@agoric/tame-metering": "^1.3.9",
     "@agoric/transform-metering": "^1.4.12",

--- a/scripts/get-versions.sh
+++ b/scripts/get-versions.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -ueo pipefail
+
+# Gather a map of the versions from this or another workspace.
+WORKDIR=${1:-.}
+
+cd -- "$WORKDIR"
+yarn workspaces --json info |
+jq -r '.data | fromjson | .[].location | "\(.)/package.json"' |
+xargs jq '{key: .name, value: "^\(.version)"}' |
+jq --slurp from_entries

--- a/scripts/set-versions.sh
+++ b/scripts/set-versions.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -ueo pipefail
+
+# Accepts a dependency version map on stdin and updates all of the
+# package.jsons in this workspace such that, if they depend on one of the named
+# dependencies, it uses the version from the map.
+# This is useful for consistent bulk updates over all packages.
+
+DIR=$(dirname -- "${BASH_SOURCE[0]}")
+VERSIONSHASH=$(git hash-object -w --stdin)
+
+cd -- "$DIR/.."
+
+yarn workspaces --json info |
+jq -r '.data | fromjson | .[].location | "\(.)/package.json"' |
+while read PACKAGEJSON; do
+  PACKAGEJSONHASH=$(
+    jq --argfile versions <(git cat-file blob "$VERSIONSHASH") '
+      def update(name): if .[name] then {
+        (name): [
+          .[name] |
+          to_entries[] |
+          {
+            key: .key,
+            value: ($versions[.key] // .value)
+          }
+        ] | from_entries
+      } else {} end;
+
+      . +
+      update("dependencies") +
+      update("devDependencies") +
+      update("peerDependencies")
+    ' "$PACKAGEJSON" |
+    git hash-object -w --stdin
+  )
+  git cat-file blob "$PACKAGEJSONHASH" > "$PACKAGEJSON"
+done

--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -ueo pipefail
+
+# Synchronizes dependencies from this workspace with the last-published
+# versions of this or another workspace, designated by the path to the work of
+# that workspace.
+# This is specifically useful for syncing the versions published from the
+# Endo workspace repository.
+
+DIR=$(dirname -- "${BASH_SOURCE[0]}")
+
+"$DIR/get-versions.sh" "$@" | "$DIR/set-versions.sh"


### PR DESCRIPTION
- A `sync-versions.sh` script that updates all `dependencies`, `devDependencies`, and `peerDependencies` in this workspace with the versions published by this workspace or the workspace at the specified directory, e.g., `./scripts/sync-versions.sh` makes all local versions consistent and `./scripts/sync-versions.sh ../endo` syncs the versions published by the Endo repository. Uses `get-versions.sh` piped to `set-versions.sh`.
- `get-versions.sh` builds a JSON mapping of all packages and their versions in this workspace or in another at the specified directory.
- `set-versions.sh` reads a JSON version map and applies it to every package in this workspace. This can also be used to surgically update a particular package e.g., `npx shon [ --esm agoric-labs/esm#Agoric-built ] | ./scripts/set-packages.sh` to pin esm in every package.

The second commit applies `sync-package.sh` locally and fixes one inconsistency.