### PR TITLE
chore: update moddable submodule for XS finalization GC fix f3e7535

### DIFF
--- a/packages/xsnap/test/test-xsnap.js
+++ b/packages/xsnap/test/test-xsnap.js
@@ -160,6 +160,19 @@ test('bigint map key', async t => {
   t.deepEqual(opts.messages, ['"abc"']);
 });
 
+test('bigint toString', async t => {
+  const opts = options();
+  const vat = xsnap(opts);
+  t.teardown(() => vat.terminate());
+  await vat.evaluate(`
+    const send = it => issueCommand(ArrayBuffer.fromString(JSON.stringify(it)));
+    const txt = \`number: 1 2 3 bigint: \${0n} \${1n} \${BigInt(2)} \${BigInt(3)} .\`;
+    send(txt)
+  `);
+  t.deepEqual(opts.messages, ['"number: 1 2 3 bigint: 0 1 2 3 ."']);
+});
+
+
 test('keyword in destructuring', async t => {
   const opts = options();
   const vat = xsnap(opts);


### PR DESCRIPTION
fixes #3085 by way of https://github.com/agoric-labs/moddable/commit/f3e75356b1bb50c9d6f12226191f25d1f73218d5

In an [ag-3085-rebase branch in agoric-labs/moddable](https://github.com/agoric-labs/moddable/tree/ag-3085-rebase), I rebased our instrumentation tweaks on top of current moddable:

 * feat(xsnap): count additions and removals from maps, sets
 * feat: maintain garbageCollectionCount for xsnap
