### PR TITLE
chore(swingset): addMessageToPromiseQueue requires a message

### DIFF
--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -10,6 +10,7 @@ import {
   parseKernelSlot,
 } from '../parseKernelSlots';
 import { insistCapData } from '../../capdata';
+import { insistMessage } from '../../message';
 import { insistDeviceID, insistVatID, makeDeviceID, makeVatID } from '../id';
 import { kdebug } from '../kdebug';
 import {
@@ -510,6 +511,7 @@ export default function makeKernelKeeper(kvStore, streamStore, kernelSlog) {
 
   function addMessageToPromiseQueue(kernelSlot, msg) {
     insistKernelType('promise', kernelSlot);
+    insistMessage(msg);
 
     const p = getKernelPromise(kernelSlot);
     assert(


### PR DESCRIPTION
Add more type assertions to kernelKeeper.addMessageToPromiseQueue(), which is
defined to take a Message (with method, result, and args capdata).

test-state was giving it the wrong things (run-queue events, which include
both 'send' for messages, and 'notify' for promise resolution notifications).
Promise queue entries are only ever message sends, never anything else. I
clean up test-state to only queue messages, and to track a few more values
that will be meaningful when the refcounts and queue handling change soon.

I also changed the resolution tests to use properly-allocated objects, rather
than arbitrarily-chosen object references. This doesn't matter now, but when
the upcoming refcount improvements are made,
`kernelKeeper.resolveKernelPromise` will need the capdata to reference real
objects with real refcounts that can be modified.

refs #3264 (prep/cleanup)