### PR TITLE
fix(swingset): fix refcounts for messages queued to a promise

### DIFF
--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -136,9 +136,9 @@ export default function makeKernelKeeper(kvStore, streamStore, kernelSlog) {
     kernelStats[`${key}Max`] = 0;
   });
 
-  function incStat(stat) {
+  function incStat(stat, delta = 1) {
     assert.typeof(kernelStats[stat], 'number');
-    kernelStats[stat] += 1;
+    kernelStats[stat] += delta;
     const maxStat = `${stat}Max`;
     if (
       kernelStats[maxStat] !== undefined &&
@@ -148,7 +148,7 @@ export default function makeKernelKeeper(kvStore, streamStore, kernelSlog) {
     }
     const upStat = `${stat}Up`;
     if (kernelStats[upStat] !== undefined) {
-      kernelStats[upStat] += 1;
+      kernelStats[upStat] += delta;
     }
   }
 

--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -234,7 +234,7 @@ export function makeVatKeeper(
       } else {
         assert.fail(X`unknown type ${type}`);
       }
-      incrementRefCount(kernelSlot, `${vatID}[kv|clist`);
+      incrementRefCount(kernelSlot, `${vatID}|kv|clist`);
       const vatSlot = makeVatSlot(type, false, id);
 
       const vatKey = `${vatID}.c.${vatSlot}`;

--- a/packages/SwingSet/test/basedir-promises-3/bootstrap.js
+++ b/packages/SwingSet/test/basedir-promises-3/bootstrap.js
@@ -1,0 +1,20 @@
+import { E } from '@agoric/eventual-send';
+import { makePromiseKit } from '@agoric/promise-kit';
+import { Far } from '@agoric/marshal';
+
+export function buildRootObject() {
+  const pk1 = makePromiseKit();
+  return Far('root', {
+    bootstrap(vats) {
+      const p2 = E(vats.right).one(); // p2 is kp41
+      E(p2).four(pk1.promise);
+      // that puts an unresolved promise in the arguments of the promise
+      // queue for p2
+    },
+    two() {
+      pk1.resolve(3);
+      // The promise is resolved and retired from our clist, the only
+      // remaining reference is from the p2 promise queue
+    },
+  });
+}

--- a/packages/SwingSet/test/basedir-promises-3/vat-right.js
+++ b/packages/SwingSet/test/basedir-promises-3/vat-right.js
@@ -1,0 +1,25 @@
+import { Far } from '@agoric/marshal';
+import { makePromiseKit } from '@agoric/promise-kit';
+
+export function buildRootObject() {
+  const pk3 = makePromiseKit();
+  const pk4 = makePromiseKit();
+  const t2 = Far('t2', {
+    four(arg) {
+      // arg should be a Promise that promptly resolves to 4
+      const argP = Promise.resolve(arg);
+      const wasP = argP === arg;
+      argP.then(newArg => pk4.resolve([wasP, newArg]));
+    },
+  });
+
+  return Far('root', {
+    one() {
+      return pk3.promise;
+    },
+    three() {
+      pk3.resolve(t2);
+      return pk4.promise;
+    },
+  });
+}

--- a/packages/SwingSet/test/test-kernel.js
+++ b/packages/SwingSet/test/test-kernel.js
@@ -1097,7 +1097,7 @@ test('non-pipelined promise queueing', async t => {
       id: p1ForKernel,
       state: 'unresolved',
       policy: 'ignore',
-      refCount: 2,
+      refCount: 3,
       decider: vatB,
       subscribers: [],
       queue: [
@@ -1112,7 +1112,7 @@ test('non-pipelined promise queueing', async t => {
       id: p2ForKernel,
       state: 'unresolved',
       policy: 'ignore',
-      refCount: 1,
+      refCount: 3,
       decider: undefined,
       subscribers: [],
       queue: [
@@ -1127,7 +1127,7 @@ test('non-pipelined promise queueing', async t => {
       id: p3ForKernel,
       state: 'unresolved',
       policy: 'ignore',
-      refCount: 1,
+      refCount: 2,
       decider: undefined,
       subscribers: [],
       queue: [],

--- a/packages/SwingSet/test/test-promises.js
+++ b/packages/SwingSet/test/test-promises.js
@@ -8,6 +8,7 @@ import {
   loadBasedir,
   buildKernelBundles,
 } from '../src/index';
+import { capargs } from './util';
 
 test.before(async t => {
   const kernelBundles = await buildKernelBundles();
@@ -165,4 +166,39 @@ test('circular promise resolution data', async t => {
     },
   ];
   t.deepEqual(c.dump().promises, expectedPromises);
+});
+
+test('refcount while queued', async t => {
+  const config = await loadBasedir(
+    path.resolve(__dirname, 'basedir-promises-3'),
+  );
+  const c = await buildVatController(config, [], t.context.data);
+
+  // bootstrap() sets up an unresolved promise (p2, the result promise of
+  // right~.one()) with vat-right as the decider, and enqueues a message
+  // (p2~.four(pk)) which contains a second unresolved promise 'pk1'
+  await c.run();
+
+  // then we tell that vat to resolve pk1 to a value (4)
+  c.queueToVatExport('bootstrap', 'o+0', 'two', capargs([]), 'ignore');
+  await c.run();
+
+  // Now we have a resolved promise 'pk1' whose only reference is the
+  // arguments of a message queued to a promise. We're exercising the promise
+  // retirement reference counting: if it allows the 'pk1' refcount to reach
+  // zero, the promise will be collected, and an error will occur when 'p2'
+  // is resolved.
+
+  // tell vat-right to resolve p2, which should transfer the 'four' message
+  // from the p2 promise queue to the run-queue for vat-right. That message
+  // will be delivered, with a new promise that is promptly resolved to '3'.
+  const kpid4 = c.queueToVatExport(
+    'right',
+    'o+0',
+    'three',
+    capargs([]),
+    'ignore',
+  );
+  await c.run();
+  t.deepEqual(c.kpResolution(kpid4), capargs([true, 3]));
 });


### PR DESCRIPTION
As described in #3264, we were not maintaining correct reference counts when
messages get queued to an unresolved promise.

In the new approach, the lifetime of a message is:

* all krefs (target, args, and optional result) of a message are increfed
  during `doSend`, as before
  * this adds a `type: 'send'` event to the run-queue
* when the `send` event is pulled off the run-queue, all krefs are
  decrefed (as before)
* if the event is delivered to a vat, great
* if the event is delivered to a promise,
  `kernelKeeper.addMessageToPromiseQueue` increfs all krefs
  * (this is new: previously `addMessageToPromiseQueue` did not change the
    refcounts)
* later, if/when the promise is resolved, the messages are transferred
  laterally from the promise queue to `send` events on the run-queue, without
  changing their refcounts
  * (this is new: previously the transfer was done with `doSend`, which
    incremented the refcounts)
  * the counts are decremented when the `send` event is removed from the
    run-queue, as usual

The result is the same number of increments and decrements as before, but the
increment is done earlier, so messages on a promise queue will maintain a
refcount on all their krefs (target, args, and any result). This protects
objects and promises which would otherwise have been eligible for collection
while they sat on the promise queue.

Strictly speaking we don't need to maintain a refcount on the target (which
is also kind of redundant: everything on the queue for promise `kp1`
obviously has `target: 'kp1'`), since that will always be additionally held
by the c-list of the decider (at least). But by making all promise queues do
the same thing as the main run-queue, we can laterally transfer messages from
promise- to run-queue without DB churn (decrementing then immediately
incrementing the counts).

This change moves the responsibility for the lateral transfer from
`notifySubscribersAndQueue` in kernel.js to
`kernelKeeper.resolveKernelPromise()`, deleting the former entirely and
merging the subscription loop into `doResolve`.

closes #3264

(reviewer note: consider examining each commit separately; they don't overlap much, but are logically separate)