### PR TITLE
feat(swingset): vatKeeper.getOptions() avoids loading source

### DIFF
--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -91,6 +91,11 @@ export function makeVatKeeper(
     return harden({ source, options });
   }
 
+  function getOptions() {
+    const options = JSON.parse(kvStore.get(`${vatID}.options`));
+    return harden(options);
+  }
+
   function nextDeliveryNum() {
     const num = Nat(BigInt(kvStore.get(`${vatID}.nextDeliveryNum`)));
     kvStore.set(`${vatID}.nextDeliveryNum`, `${num + 1n}`);
@@ -398,6 +403,7 @@ export function makeVatKeeper(
   return harden({
     setSourceAndOptions,
     getSourceAndOptions,
+    getOptions,
     nextDeliveryNum,
     importsKernelSlot,
     mapVatSlotToKernelSlot,

--- a/packages/SwingSet/src/kernel/vatManager/vat-warehouse.js
+++ b/packages/SwingSet/src/kernel/vatManager/vat-warehouse.js
@@ -135,9 +135,7 @@ export function makeVatWarehouse(kernelKeeper, vatLoader, policyOptions) {
     }
     const vatKeeper = kernelKeeper.getVatKeeper(vatID);
     if (vatKeeper) {
-      const {
-        options: { enablePipelining },
-      } = vatKeeper.getSourceAndOptions();
+      const { enablePipelining } = vatKeeper.getOptions();
       return { enablePipelining };
     }
     return undefined;

--- a/packages/SwingSet/test/test-state.js
+++ b/packages/SwingSet/test/test-state.js
@@ -642,6 +642,24 @@ test('vatKeeper', async t => {
   t.is(vk2.mapVatSlotToKernelSlot(vatImport2), kernelImport2);
 });
 
+test('vatKeeper.getOptions', async t => {
+  const { kvStore, streamStore } = buildKeeperStorageInMemory();
+  const k = makeKernelKeeper(kvStore, streamStore);
+  k.createStartingKernelState('local');
+
+  const v1 = k.allocateVatIDForNameIfNeeded('name1');
+  const vk = k.allocateVatKeeper(v1);
+  vk.setSourceAndOptions(
+    { bundleName: 'vattp' },
+    {
+      managerType: 'local',
+      name: 'fred',
+    },
+  );
+  const { name } = vk.getOptions();
+  t.is(name, 'fred');
+});
+
 test('XS vatKeeper defaultManagerType', async t => {
   const { kvStore, streamStore } = buildKeeperStorageInMemory();
   const k = makeKernelKeeper(kvStore, streamStore);


### PR DESCRIPTION
fixes #3280