### PR TITLE
Protect atomic actions

### DIFF
--- a/packages/ERTP/src/issuerKit.js
+++ b/packages/ERTP/src/issuerKit.js
@@ -17,6 +17,7 @@ const makeIssuerKit = (
   allegedName,
   assetKind = AssetKind.NAT,
   displayInfo = harden({}),
+  fatalAssert = assert,
 ) => {
   assert.typeof(allegedName, 'string');
   assert(
@@ -46,6 +47,7 @@ const makeIssuerKit = (
     brand,
     assetKind,
     cleanDisplayInfo,
+    fatalAssert,
   );
 
   return harden({

--- a/packages/ERTP/src/issuerKit.js
+++ b/packages/ERTP/src/issuerKit.js
@@ -17,7 +17,7 @@ const makeIssuerKit = (
   allegedName,
   assetKind = AssetKind.NAT,
   displayInfo = harden({}),
-  optTerminateWithFailure = undefined,
+  optShutdownWithFailure = undefined,
 ) => {
   assert.typeof(allegedName, 'string');
   assert(
@@ -47,7 +47,7 @@ const makeIssuerKit = (
     brand,
     assetKind,
     cleanDisplayInfo,
-    optTerminateWithFailure,
+    optShutdownWithFailure,
   );
 
   return harden({

--- a/packages/ERTP/src/issuerKit.js
+++ b/packages/ERTP/src/issuerKit.js
@@ -17,7 +17,7 @@ const makeIssuerKit = (
   allegedName,
   assetKind = AssetKind.NAT,
   displayInfo = harden({}),
-  fatalAssert = assert,
+  optAbandonWithFailure = undefined,
 ) => {
   assert.typeof(allegedName, 'string');
   assert(
@@ -47,7 +47,7 @@ const makeIssuerKit = (
     brand,
     assetKind,
     cleanDisplayInfo,
-    fatalAssert,
+    optAbandonWithFailure,
   );
 
   return harden({

--- a/packages/ERTP/src/issuerKit.js
+++ b/packages/ERTP/src/issuerKit.js
@@ -17,7 +17,7 @@ const makeIssuerKit = (
   allegedName,
   assetKind = AssetKind.NAT,
   displayInfo = harden({}),
-  optAbandonWithFailure = undefined,
+  optTerminateWithFailure = undefined,
 ) => {
   assert.typeof(allegedName, 'string');
   assert(
@@ -47,7 +47,7 @@ const makeIssuerKit = (
     brand,
     assetKind,
     cleanDisplayInfo,
-    optAbandonWithFailure,
+    optTerminateWithFailure,
   );
 
   return harden({

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -20,7 +20,7 @@ import '@agoric/store/exported';
  * @param {Brand} brand
  * @param {AssetKind} assetKind
  * @param {DisplayInfo} displayInfo
- * @param {((reason: Error) => void)=} optTerminateWithFailure
+ * @param {ShutdownWithFailure=} optTerminateWithFailure
  * @returns {{ issuer: Issuer, mint: Mint }}
  */
 export const makePaymentLedger = (
@@ -30,6 +30,7 @@ export const makePaymentLedger = (
   displayInfo,
   optTerminateWithFailure = undefined,
 ) => {
+  /** @type {ShutdownWithFailure} */
   const destroyLedgerWithFailure = reason => {
     // TODO destroy ledger state.
     // We need to defensively destroy the ledger state because:

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { assert, details as X } from '@agoric/assert';
+import { assert, details as X, fatalRaise } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
 import { isPromise } from '@agoric/promise-kit';
 import { Far } from '@agoric/marshal';
@@ -124,7 +124,9 @@ export const makePaymentLedger = (
         return newPayment;
       });
     } catch (err) {
-      fatalAssert.fail(X`fatal ${err}`);
+      // For some unknown reason, the '@returns {never}` on `fatalRaise`
+      // was not sufficient to make TypeScript happy, so we added the `throw`.
+      throw fatalRaise(fatalAssert, err);
     }
     return harden(newPayments);
   };
@@ -154,7 +156,7 @@ export const makePaymentLedger = (
         // COMMIT POINT.
         paymentLedger.delete(payment);
       } catch (err) {
-        fatalAssert.fail(X`fatal ${err}`);
+        fatalRaise(fatalAssert, err);
       }
       return paymentBalance;
     });
@@ -258,7 +260,7 @@ export const makePaymentLedger = (
       paymentLedger.delete(srcPayment);
       updatePurseBalance(newPurseBalance);
     } catch (err) {
-      fatalAssert.fail(X`fatal ${err}`);
+      fatalRaise(fatalAssert, err);
     }
     return srcPaymentBalance;
   };
@@ -284,7 +286,7 @@ export const makePaymentLedger = (
       updatePurseBalance(newPurseBalance);
       paymentLedger.init(payment, amount);
     } catch (err) {
-      fatalAssert.fail(X`fatal ${err}`);
+      fatalRaise(fatalAssert, err);
     }
     return payment;
   };

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -33,6 +33,7 @@ export const makePaymentLedger = (
   /** @type {ShutdownWithFailure} */
   const destroyLedgerWithFailure = reason => {
     // TODO destroy ledger state.
+    // https://github.com/Agoric/agoric-sdk/issues/3434
     // We need to defensively destroy the ledger state because:
     // If the `optTerminateWithFailure` is absent or returns,
     // the most violent termination we can fall back to is to throw. However,

--- a/packages/ERTP/src/purse.js
+++ b/packages/ERTP/src/purse.js
@@ -19,6 +19,7 @@ export const makePurse = (allegedName, assetKind, brand, purseMethods) => {
   /** @type {Purse} */
   const purse = Far(`${allegedName} purse`, {
     deposit: (srcPayment, optAmount = undefined) => {
+      // Note COMMIT POINT within deposit.
       return purseMethods.deposit(
         currentBalance,
         updatePurseBalance,
@@ -27,6 +28,7 @@ export const makePurse = (allegedName, assetKind, brand, purseMethods) => {
       );
     },
     withdraw: amount =>
+      // Note COMMIT POINT within withdraw.
       purseMethods.withdraw(currentBalance, updatePurseBalance, amount),
     getCurrentAmount: () => currentBalance,
     getCurrentAmountNotifier: () => balanceNotifier,

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -360,6 +360,7 @@
  * @param {string} allegedName
  * @param {AssetKind} [assetKind=AssetKind.NAT]
  * @param {AdditionalDisplayInfo} [displayInfo={}]
+ * @param {Assert=} fatalAssert
  * @returns {IssuerKit}
  *
  * The allegedName becomes part of the brand in asset descriptions. The

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -360,7 +360,7 @@
  * @param {string} allegedName
  * @param {AssetKind} [assetKind=AssetKind.NAT]
  * @param {AdditionalDisplayInfo} [displayInfo={}]
- * @param {Assert=} fatalAssert
+ * @param {Raise=} optAbandonWithFailure
  * @returns {IssuerKit}
  *
  * The allegedName becomes part of the brand in asset descriptions. The

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -373,7 +373,13 @@
  * @param {string} allegedName
  * @param {AssetKind} [assetKind=AssetKind.NAT]
  * @param {AdditionalDisplayInfo} [displayInfo={}]
- * @param {ShutdownWithFailure=} optTerminateWithFailure
+ * @param {ShutdownWithFailure=} optShutdownWithFailure If this issuer fails
+ * in the middle of an atomic action (which btw should never happen), it
+ * potentially leaves its ledger in a corrupted state. If this function was
+ * provided, then it the failed atomic action will call it, so that some
+ * larger unit of computation, like the enclosing vat, can be shutdown
+ * before anything else is corrupted by that corrupted state.
+ * See https://github.com/Agoric/agoric-sdk/issues/3434
  * @returns {IssuerKit}
  *
  * The allegedName becomes part of the brand in asset descriptions. The

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -360,7 +360,7 @@
  * @param {string} allegedName
  * @param {AssetKind} [assetKind=AssetKind.NAT]
  * @param {AdditionalDisplayInfo} [displayInfo={}]
- * @param {Raise=} optAbandonWithFailure
+ * @param {((reason: Error) => void)=} optTerminateWithFailure
  * @returns {IssuerKit}
  *
  * The allegedName becomes part of the brand in asset descriptions. The

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -356,11 +356,24 @@
  */
 
 /**
+ * @callback ShutdownWithFailure
+ * Called to shut something down because something went wrong, where the reason
+ * is supposed to be an Error that describes what went wrong. Some valid
+ * implementations of `ShutdownWithFailure` will never return, either
+ * because they throw or because they immediately shutdown the enclosing unit
+ * of computation. However, they also might return, so the caller should
+ * follow this call by their own defensive `throw reason;` if appropriate.
+ *
+ * @param {Error} reason
+ * @returns {void}
+ */
+
+/**
  * @callback MakeIssuerKit
  * @param {string} allegedName
  * @param {AssetKind} [assetKind=AssetKind.NAT]
  * @param {AdditionalDisplayInfo} [displayInfo={}]
- * @param {((reason: Error) => void)=} optTerminateWithFailure
+ * @param {ShutdownWithFailure=} optTerminateWithFailure
  * @returns {IssuerKit}
  *
  * The allegedName becomes part of the brand in asset descriptions. The

--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -74,3 +74,33 @@ function an(str) {
 }
 freeze(an);
 export { an };
+
+// eslint-disable-next-line jsdoc/require-returns-check
+/**
+ * This `fatalRaise` helper function is needed only until we can depend on
+ * https://github.com/endojs/endo/pull/796 . In anticipation, it feature tests
+ * for `fatalAssert.raise`. If absent it fails back to a more awkward use of
+ * `fatalAssert.fail`.
+ *
+ * @deprecated
+ * @param {Assert} fatalAssert
+ * @param {Error} reason
+ * @returns {never}
+ */
+const fatalRaise = (fatalAssert, reason) => {
+  // In order to feature test for a future feature, we must temporarily
+  // ignore that feature's absence from current types.
+  // @ts-ignore
+  if (typeof fatalAssert.raise === 'function') {
+    // Once we can depend on https://github.com/endojs/endo/pull/796 we
+    // should replace all calls to this function with the following line.
+    // The `throw` below is because we don't yet statically know that
+    // `fatalAssert.raise` never returns.
+    // @ts-ignore
+    throw fatalAssert.raise(reason);
+  } else {
+    fatalAssert.fail(details`Terminating due to ${reason}`);
+  }
+};
+freeze(fatalRaise);
+export { fatalRaise };

--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -40,8 +40,6 @@ const missing = [
   'details',
   'quote',
   'makeAssert',
-  'notThrows',
-  'atomic',
 ].filter(name => globalAssert[name] === undefined);
 if (missing.length > 0) {
   throw new Error(

--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -74,33 +74,3 @@ function an(str) {
 }
 freeze(an);
 export { an };
-
-// eslint-disable-next-line jsdoc/require-returns-check
-/**
- * This `fatalRaise` helper function is needed only until we can depend on
- * https://github.com/endojs/endo/pull/796 . In anticipation, it feature tests
- * for `fatalAssert.raise`. If absent it fails back to a more awkward use of
- * `fatalAssert.fail`.
- *
- * @deprecated
- * @param {Assert} fatalAssert
- * @param {Error} reason
- * @returns {never}
- */
-const fatalRaise = (fatalAssert, reason) => {
-  // In order to feature test for a future feature, we must temporarily
-  // ignore that feature's absence from current types.
-  // @ts-ignore
-  if (typeof fatalAssert.raise === 'function') {
-    // Once we can depend on https://github.com/endojs/endo/pull/796 we
-    // should replace all calls to this function with the following line.
-    // The `throw` below is because we don't yet statically know that
-    // `fatalAssert.raise` never returns.
-    // @ts-ignore
-    throw fatalAssert.raise(reason);
-  } else {
-    fatalAssert.fail(details`Terminating due to ${reason}`);
-  }
-};
-freeze(fatalRaise);
-export { fatalRaise };

--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -40,6 +40,8 @@ const missing = [
   'details',
   'quote',
   'makeAssert',
+  'notThrows',
+  'atomic',
 ].filter(name => globalAssert[name] === undefined);
 if (missing.length > 0) {
   throw new Error(

--- a/packages/treasury/src/vaultManager.js
+++ b/packages/treasury/src/vaultManager.js
@@ -18,6 +18,8 @@ import { makePrioritizedVaults } from './prioritizedVaults';
 import { liquidate } from './liquidation';
 import { makeTracer } from './makeTracer';
 
+const { details: X } = assert;
+
 const trace = makeTracer(' VM ');
 
 // Each VaultManager manages a single collateralType. It owns an autoswap
@@ -182,10 +184,14 @@ export function makeVaultManager(
     updateState: updateTime =>
       chargeAllVaults(updateTime, poolIncrementSeat).catch(_ => {}),
     fail: reason => {
-      zcf.shutdownWithFailure(`Unable to continue without a timer: ${reason}`);
+      zcf.shutdownWithFailure(
+        assert.error(X`Unable to continue without a timer: ${reason}`),
+      );
     },
     finish: done => {
-      zcf.shutdownWithFailure(`Unable to continue without a timer: ${done}`);
+      zcf.shutdownWithFailure(
+        assert.error(X`Unable to continue without a timer: ${done}`),
+      );
     },
   };
 

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -4,10 +4,6 @@
 /**
  * @typedef {any} Completion
  * Any passable non-thenable. Often an explanatory string.
- *
- * @typedef {Error|any} TerminationReason
- * Something provided as an explanation to a termination request. Usually an
- * Error but not required to be so.
  */
 
 /**
@@ -34,7 +30,7 @@
  * saving
  * @property {MakeInvitation} makeInvitation
  * @property {(completion: Completion) => void} shutdown
- * @property {(reason: TerminationReason) => void} shutdownWithFailure
+ * @property {ShutdownWithFailure} shutdownWithFailure
  * @property {Assert} assert
  * @property {() => ERef<ZoeService>} getZoeService
  * @property {() => Issuer} getInvitationIssuer

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { assert, details as X } from '@agoric/assert';
+import { assert, details as X, fatalRaise } from '@agoric/assert';
 import {
   makeWeakStore as makeNonVOWeakStore,
   makeStore as makeNonVOStore,
@@ -173,7 +173,7 @@ export const createSeatManager = (
 
       E(zoeInstanceAdmin).replaceAllocations(seatHandleAllocations);
     } catch (err) {
-      zcfAssert.fail(X`fatal ${err}`);
+      fatalRaise(zcfAssert, err);
     }
   };
 

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -17,7 +17,7 @@ import { addToAllocation, subtractFromAllocation } from './allocationMath';
 export const createSeatManager = (
   zoeInstanceAdmin,
   getAssetKindByBrand,
-  abandonContractWithFailure,
+  shutdownWithFailure,
 ) => {
   /** @type {WeakStore<ZCFSeat, Allocation>}  */
   let activeZCFSeats = makeNonVOWeakStore('zcfSeat');
@@ -173,7 +173,7 @@ export const createSeatManager = (
 
       E(zoeInstanceAdmin).replaceAllocations(seatHandleAllocations);
     } catch (err) {
-      abandonContractWithFailure(err);
+      shutdownWithFailure(err);
       throw err;
     }
   };

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -150,7 +150,7 @@ export const createSeatManager = (
       X`At least one seat has a staged allocation but was not included in the call to reallocate`,
     );
 
-    zcfAssert.notThrows(() => {
+    try {
       // No side effects above. All conditions checked which could have
       // caused us to reject this reallocation.
       // COMMIT POINT
@@ -172,7 +172,9 @@ export const createSeatManager = (
       });
 
       E(zoeInstanceAdmin).replaceAllocations(seatHandleAllocations);
-    });
+    } catch (err) {
+      zcfAssert.fail(X`fatal ${err}`);
+    }
   };
 
   const reallocate = (/** @type {ZCFSeat[]} */ ...seats) => {

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { assert, details as X, fatalRaise } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import {
   makeWeakStore as makeNonVOWeakStore,
   makeStore as makeNonVOStore,
@@ -17,7 +17,7 @@ import { addToAllocation, subtractFromAllocation } from './allocationMath';
 export const createSeatManager = (
   zoeInstanceAdmin,
   getAssetKindByBrand,
-  zcfAssert,
+  abandonContractWithFailure,
 ) => {
   /** @type {WeakStore<ZCFSeat, Allocation>}  */
   let activeZCFSeats = makeNonVOWeakStore('zcfSeat');
@@ -173,7 +173,8 @@ export const createSeatManager = (
 
       E(zoeInstanceAdmin).replaceAllocations(seatHandleAllocations);
     } catch (err) {
-      fatalRaise(zcfAssert, err);
+      abandonContractWithFailure(err);
+      throw err;
     }
   };
 

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -42,6 +42,9 @@ export const makeZCFZygote = (
     instantiate: instantiateIssuerStorage,
   } = makeIssuerStorage();
 
+  /**
+   * @param {Error} reason
+   */
   const shutdownWithFailure = reason => {
     E(zoeInstanceAdmin).failAllSeats(reason);
     // eslint-disable-next-line no-use-before-define
@@ -49,11 +52,6 @@ export const makeZCFZygote = (
     // @ts-ignore powers is not typed correctly:
     // https://github.com/Agoric/agoric-sdk/issues/3239
     powers.exitVatWithFailure(reason);
-  };
-
-  const abandonContractWithFailure = reason => {
-    shutdownWithFailure(reason);
-    throw reason;
   };
 
   const {
@@ -64,7 +62,7 @@ export const makeZCFZygote = (
   } = createSeatManager(
     zoeInstanceAdmin,
     getAssetKindByBrand,
-    abandonContractWithFailure,
+    shutdownWithFailure,
   );
 
   const { storeOfferHandler, takeOfferHandler } = makeOfferHandlerStorage();
@@ -239,7 +237,7 @@ export const makeZCFZygote = (
       powers.exitVat(completion);
     },
     shutdownWithFailure,
-    assert: makeAssert(abandonContractWithFailure),
+    assert: makeAssert(shutdownWithFailure),
     stopAcceptingOffers: () => E(zoeInstanceAdmin).stopAcceptingOffers(),
     makeZCFMint,
     makeEmptySeatKit,

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -42,9 +42,7 @@ export const makeZCFZygote = (
     instantiate: instantiateIssuerStorage,
   } = makeIssuerStorage();
 
-  /**
-   * @param {Error} reason
-   */
+  /** @type {ShutdownWithFailure} */
   const shutdownWithFailure = reason => {
     E(zoeInstanceAdmin).failAllSeats(reason);
     // eslint-disable-next-line no-use-before-define

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -51,14 +51,21 @@ export const makeZCFZygote = (
     powers.exitVatWithFailure(reason);
   };
 
-  const zcfAssert = makeAssert(shutdownWithFailure);
+  const abandonContractWithFailure = reason => {
+    shutdownWithFailure(reason);
+    throw reason;
+  };
 
   const {
     makeZCFSeat,
     reallocate,
     reallocateInternal,
     dropAllReferences,
-  } = createSeatManager(zoeInstanceAdmin, getAssetKindByBrand, zcfAssert);
+  } = createSeatManager(
+    zoeInstanceAdmin,
+    getAssetKindByBrand,
+    abandonContractWithFailure,
+  );
 
   const { storeOfferHandler, takeOfferHandler } = makeOfferHandlerStorage();
 
@@ -232,7 +239,7 @@ export const makeZCFZygote = (
       powers.exitVat(completion);
     },
     shutdownWithFailure,
-    assert: zcfAssert,
+    assert: makeAssert(abandonContractWithFailure),
     stopAcceptingOffers: () => E(zoeInstanceAdmin).stopAcceptingOffers(),
     makeZCFMint,
     makeEmptySeatKit,

--- a/packages/zoe/src/contracts/loan/liquidate.js
+++ b/packages/zoe/src/contracts/loan/liquidate.js
@@ -41,6 +41,7 @@ export const doLiquidation = async (
     zcf.shutdown('your loan had to be liquidated');
   };
 
+  /** @type {ShutdownWithFailure} */
   const closeWithFailure = err => {
     lenderSeat.fail(err);
     collateralSeat.fail(err);

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -255,13 +255,14 @@
 
 /**
  *
- * @callback CreateSeatManager 
+ * @callback CreateSeatManager
  *
  * The SeatManager holds the active zcfSeats and can reallocate and
  * make new zcfSeats.
  *
  * @param {ERef<ZoeInstanceAdmin>} zoeInstanceAdmin
  * @param {GetAssetKindByBrand} getAssetKindByBrand
+ * @param {Assert} zcfAssert
  * @returns {{ makeZCFSeat: MakeZCFSeat,
     reallocate: Reallocate,
     reallocateInternal: ReallocateInternal,

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -52,7 +52,7 @@
  * @typedef {Object} ZoeSeatAdmin
  * @property {(allocation: Allocation) => void} replaceAllocation
  * @property {ZoeSeatAdminExit} exit
- * @property {(reason: TerminationReason) => void} fail called with the reason
+ * @property {ShutdownWithFailure} fail called with the reason
  * for calling fail on this seat, where reason is normally an instanceof Error.
  */
 
@@ -83,7 +83,7 @@
  * @property {() => BrandKeywordRecord} getBrands
  * @property {() => Object} getTerms
  * @property {(completion: Completion) => void} exitAllSeats
- * @property {(reason: TerminationReason) => void} failAllSeats
+ * @property {ShutdownWithFailure} failAllSeats
  * @property {() => void} stopAcceptingOffers
  */
 
@@ -117,7 +117,7 @@
  * @property {MakeNoEscrowSeat} makeNoEscrowSeat
  * @property {ReplaceAllocations} replaceAllocations
  * @property {(completion: Completion) => void} exitAllSeats
- * @property {(reason: TerminationReason) => void} failAllSeats
+ * @property {ShutdownWithFailure} failAllSeats
  * @property {() => void} stopAcceptingOffers
  */
 
@@ -214,7 +214,7 @@
  * terminated. If the contract terminates with a failure, the promise will be
  * rejected with the reason. If the contract terminates successfully, the
  * promise will fulfill to the completion value.
- * @property {(reason: TerminationReason) => void} terminateWithFailure
+ * @property {ShutdownWithFailure} terminateWithFailure
  * Terminate the vat in which the contract is running as a failure.
  */
 

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -262,7 +262,7 @@
  *
  * @param {ERef<ZoeInstanceAdmin>} zoeInstanceAdmin
  * @param {GetAssetKindByBrand} getAssetKindByBrand
- * @param {Assert} zcfAssert
+ * @param {Raise} abandonContractWithFailure
  * @returns {{ makeZCFSeat: MakeZCFSeat,
     reallocate: Reallocate,
     reallocateInternal: ReallocateInternal,

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -262,7 +262,7 @@
  *
  * @param {ERef<ZoeInstanceAdmin>} zoeInstanceAdmin
  * @param {GetAssetKindByBrand} getAssetKindByBrand
- * @param {(reason: Error) => void} shutdownWithFailure
+ * @param {ShutdownWithFailure} shutdownWithFailure
  * @returns {{ makeZCFSeat: MakeZCFSeat,
     reallocate: Reallocate,
     reallocateInternal: ReallocateInternal,

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -262,7 +262,7 @@
  *
  * @param {ERef<ZoeInstanceAdmin>} zoeInstanceAdmin
  * @param {GetAssetKindByBrand} getAssetKindByBrand
- * @param {Raise} abandonContractWithFailure
+ * @param {(reason: Error) => void} shutdownWithFailure
  * @returns {{ makeZCFSeat: MakeZCFSeat,
     reallocate: Reallocate,
     reallocateInternal: ReallocateInternal,

--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Create a purse for a new issuer
  *
@@ -81,6 +83,7 @@
  * @property {Issuer} invitationIssuer
  * @property {Object} root of a RootAndAdminNode
  * @property {AdminNode} adminNode of a RootAndAdminNode
+ * @property {Assert} zcfAssert
  */
 
 /**

--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -83,7 +83,6 @@
  * @property {Issuer} invitationIssuer
  * @property {Object} root of a RootAndAdminNode
  * @property {AdminNode} adminNode of a RootAndAdminNode
- * @property {Assert} zcfAssert
  */
 
 /**

--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -77,9 +77,10 @@
  * @property {WithdrawPayments} withdrawPayments
  * @property {InitInstanceAdmin} initInstanceAdmin
  * @property {DeleteInstanceAdmin} deleteInstanceAdmin
- * @property {CreateZCFVat} createZCFVat
  * @property {ZoeInstanceAdminMakeInvitation} makeInvitation
  * @property {Issuer} invitationIssuer
+ * @property {Object} root of a RootAndAdminNode
+ * @property {AdminNode} adminNode of a RootAndAdminNode
  */
 
 /**

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { assert, details as X, fatalRaise } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
 import { makeWeakStore as makeNonVOWeakStore } from '@agoric/store';
@@ -43,7 +43,7 @@ export const makeStartInstance = (
     );
     // AWAIT ///
 
-    const { adminNode, root, zcfAssert } = await zoeInstanceStorageManager;
+    const { adminNode, root } = await zoeInstanceStorageManager;
     /** @type {ZCFRoot} */
     const zcfRoot = root;
 
@@ -168,7 +168,8 @@ export const makeStartInstance = (
             zoeSeatAdmin.replaceAllocation(allocation);
           });
         } catch (err) {
-          fatalRaise(zcfAssert, err);
+          adminNode.terminateWithFailure(err);
+          throw err;
         }
       },
       stopAcceptingOffers: () => instanceAdmin.stopAcceptingOffers(),

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -43,7 +43,7 @@ export const makeStartInstance = (
     );
     // AWAIT ///
 
-    const { adminNode, root } = await zoeInstanceStorageManager;
+    const { adminNode, root } = zoeInstanceStorageManager;
     /** @type {ZCFRoot} */
     const zcfRoot = root;
 

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -43,7 +43,7 @@ export const makeStartInstance = (
     );
     // AWAIT ///
 
-    const { adminNode, root } = await zoeInstanceStorageManager;
+    const { adminNode, root, zcfAssert } = await zoeInstanceStorageManager;
     /** @type {ZCFRoot} */
     const zcfRoot = root;
 
@@ -162,10 +162,14 @@ export const makeStartInstance = (
       failAllSeats: reason => instanceAdmin.failAllSeats(reason),
       makeZoeMint: zoeInstanceStorageManager.makeZoeMint,
       replaceAllocations: seatHandleAllocations => {
-        seatHandleAllocations.forEach(({ seatHandle, allocation }) => {
-          const zoeSeatAdmin = seatHandleToZoeSeatAdmin.get(seatHandle);
-          zoeSeatAdmin.replaceAllocation(allocation);
-        });
+        try {
+          seatHandleAllocations.forEach(({ seatHandle, allocation }) => {
+            const zoeSeatAdmin = seatHandleToZoeSeatAdmin.get(seatHandle);
+            zoeSeatAdmin.replaceAllocation(allocation);
+          });
+        } catch (err) {
+          zcfAssert.fail(X`fatal ${err}`);
+        }
       },
       stopAcceptingOffers: () => instanceAdmin.stopAcceptingOffers(),
     });

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { assert, details as X } from '@agoric/assert';
+import { assert, details as X, fatalRaise } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
 import { makeWeakStore as makeNonVOWeakStore } from '@agoric/store';
@@ -168,7 +168,7 @@ export const makeStartInstance = (
             zoeSeatAdmin.replaceAllocation(allocation);
           });
         } catch (err) {
-          zcfAssert.fail(X`fatal ${err}`);
+          fatalRaise(zcfAssert, err);
         }
       },
       stopAcceptingOffers: () => instanceAdmin.stopAcceptingOffers(),

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -43,7 +43,7 @@ export const makeStartInstance = (
     );
     // AWAIT ///
 
-    const { adminNode, root } = await zoeInstanceStorageManager.createZCFVat();
+    const { adminNode, root } = await zoeInstanceStorageManager;
     /** @type {ZCFRoot} */
     const zcfRoot = root;
 

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-import { assert, fatalRaise } from '@agoric/assert';
 import { AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { Far } from '@agoric/marshal';
 
@@ -116,7 +115,13 @@ export const makeZoeStorageManager = createZCFVat => {
         brand: localBrand,
         displayInfo: localDisplayInfo,
         // eslint-disable-next-line no-use-before-define
-      } = makeIssuerKit(keyword, assetKind, displayInfo, zcfAssert);
+      } = makeIssuerKit(
+        keyword,
+        assetKind,
+        displayInfo,
+        // eslint-disable-next-line no-use-before-define
+        abandonZcfVatWithFailure,
+      );
       const localIssuerRecord = makeIssuerRecord(
         localBrand,
         localIssuer,
@@ -150,7 +155,8 @@ export const makeZoeStorageManager = createZCFVat => {
             localIssuer.burn(payment, totalToBurn);
           } catch (err) {
             // eslint-disable-next-line no-use-before-define
-            fatalRaise(zcfAssert, err);
+            abandonZcfVatWithFailure(err);
+            throw err;
           }
         },
       });
@@ -171,7 +177,10 @@ export const makeZoeStorageManager = createZCFVat => {
 
     const { root, adminNode } = await createZCFVat();
 
-    const zcfAssert = assert.makeAssert(adminNode.terminateWithFailure);
+    const abandonZcfVatWithFailure = reason => {
+      adminNode.terminateWithFailure(reason);
+      throw reason;
+    };
 
     return harden({
       getTerms: instanceRecordManager.getTerms,
@@ -188,7 +197,6 @@ export const makeZoeStorageManager = createZCFVat => {
       invitationIssuer,
       root,
       adminNode,
-      zcfAssert,
     });
   };
 

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { assert, details as X } from '@agoric/assert';
+import { assert, fatalRaise } from '@agoric/assert';
 import { AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { Far } from '@agoric/marshal';
 
@@ -150,7 +150,7 @@ export const makeZoeStorageManager = createZCFVat => {
             localIssuer.burn(payment, totalToBurn);
           } catch (err) {
             // eslint-disable-next-line no-use-before-define
-            zcfAssert.fail(X`fatal ${err}`);
+            fatalRaise(zcfAssert, err);
           }
         },
       });

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -120,7 +120,7 @@ export const makeZoeStorageManager = createZCFVat => {
         assetKind,
         displayInfo,
         // eslint-disable-next-line no-use-before-define
-        abandonZcfVatWithFailure,
+        adminNode.terminateWithFailure,
       );
       const localIssuerRecord = makeIssuerRecord(
         localBrand,
@@ -155,7 +155,7 @@ export const makeZoeStorageManager = createZCFVat => {
             localIssuer.burn(payment, totalToBurn);
           } catch (err) {
             // eslint-disable-next-line no-use-before-define
-            abandonZcfVatWithFailure(err);
+            adminNode.terminateWithFailure(err);
             throw err;
           }
         },
@@ -176,11 +176,6 @@ export const makeZoeStorageManager = createZCFVat => {
     const makeInvitation = setupMakeInvitation(instance, installation);
 
     const { root, adminNode } = await createZCFVat();
-
-    const abandonZcfVatWithFailure = reason => {
-      adminNode.terminateWithFailure(reason);
-      throw reason;
-    };
 
     return harden({
       getTerms: instanceRecordManager.getTerms,

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { assert } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import { AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { Far } from '@agoric/marshal';
 
@@ -143,12 +143,15 @@ export const makeZoeStorageManager = createZCFVat => {
         },
         withdrawAndBurn: totalToBurn => {
           // eslint-disable-next-line no-use-before-define
-          zcfAssert.notThrows(() => {
+          try {
             // COMMIT POINT
             const payment = localPooledPurse.withdraw(totalToBurn);
             // Note redundant COMMIT POINT within burn.
             localIssuer.burn(payment, totalToBurn);
-          });
+          } catch (err) {
+            // eslint-disable-next-line no-use-before-define
+            zcfAssert.fail(X`fatal ${err}`);
+          }
         },
       });
       return zoeMint;

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -188,6 +188,7 @@ export const makeZoeStorageManager = createZCFVat => {
       invitationIssuer,
       root,
       adminNode,
+      zcfAssert,
     });
   };
 

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -114,7 +114,6 @@ export const makeZoeStorageManager = createZCFVat => {
         issuer: localIssuer,
         brand: localBrand,
         displayInfo: localDisplayInfo,
-        // eslint-disable-next-line no-use-before-define
       } = makeIssuerKit(
         keyword,
         assetKind,

--- a/packages/zoe/test/swingsetTests/brokenContracts/crashingAutoRefund.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/crashingAutoRefund.js
@@ -71,6 +71,7 @@ const start = zcf => {
   };
 
   const zcfShutdown = completion => zcf.shutdown(completion);
+  /** @type {ShutdownWithFailure} */
   const zcfShutdownWithFailure = reason => zcf.shutdownWithFailure(reason);
 
   const makeSwapInvitation = () =>


### PR DESCRIPTION
An atomic action is some set of operations, where either all or none of them should happen. Our style is to test everything that could cause any of the individual operations before the commit point, and then do all the actions, now that it is impossible for any of these actions to fail. However, we might have missed a reason why it might fail anyway. This PR puts `try`/`catch` blocks around the atomic actions we've identified. If the try block exits by throwing, then the catch block terminates some appropriate unit of computation, like the contract or the vat.

Replaces #3144 
