### PR TITLE
Further minor improvements to swingset-runner

### DIFF
--- a/packages/SwingSet/test/test-state.js
+++ b/packages/SwingSet/test/test-state.js
@@ -10,7 +10,6 @@ import { buildHostDBInMemory } from '../src/hostStorage';
 import { buildBlockBuffer } from '../src/blockBuffer';
 import makeKernelKeeper from '../src/kernel/state/kernelKeeper';
 import {
-  guardStorage,
   buildCrankBuffer,
   addHelpers,
   wrapStorage,
@@ -116,12 +115,6 @@ test('blockBuffer fulfills storage API', t => {
   const { hostDB, getState } = buildHostDBAndGetState();
   const { blockBuffer, commitBlock } = buildBlockBuffer(hostDB);
   testStorage(t, blockBuffer, getState, commitBlock);
-});
-
-test('guardStorage fulfills storage API', t => {
-  const store = initSimpleSwingStore();
-  const guardedHostStorage = guardStorage(store.kvStore);
-  testStorage(t, guardedHostStorage, () => getAllState(store).kvStuff, null);
 });
 
 test('crankBuffer fulfills storage API', t => {

--- a/packages/swingset-runner/demo/encouragementBotComms/runnerArgs
+++ b/packages/swingset-runner/demo/encouragementBotComms/runnerArgs
@@ -1,1 +1,0 @@
---loopbox

--- a/packages/swingset-runner/src/dumpstore.js
+++ b/packages/swingset-runner/src/dumpstore.js
@@ -45,6 +45,8 @@ export function dumpStore(swingStore, outfile, rawMode) {
 
   popt('crankNumber');
   popt('kernel.defaultManagerType');
+  popt('vatAdminRootKref');
+  popt('gcActions');
   popt('kernelStats');
   gap();
 
@@ -132,6 +134,7 @@ export function dumpStore(swingStore, outfile, rawMode) {
     popt(`${v}.d.nextID`);
     popt(`${v}.o.nextID`);
     popt(`${v}.p.nextID`);
+    popt(`${v}.nextDeliveryNum`);
     const endPos = JSON.parse(popt(`${v}.t.endPosition`));
     vatInfo.push([v, vn, endPos]);
     for (const key of groupKeys(`${v}.c.kd`)) {

--- a/packages/swingset-runner/src/main.js
+++ b/packages/swingset-runner/src/main.js
@@ -413,8 +413,8 @@ export async function main() {
       hostStorage,
       runtimeOptions,
     );
+    swingStore.commit();
     if (initOnly) {
-      swingStore.commit();
       swingStore.close();
       return;
     }

--- a/packages/swingset-runner/src/main.js
+++ b/packages/swingset-runner/src/main.js
@@ -459,10 +459,14 @@ export async function main() {
       break;
     }
     case 'step': {
-      const steps = await controller.step();
-      swingStore.commit();
-      swingStore.close();
-      log(`runner stepped ${steps} crank${steps === 1 ? '' : 's'}`);
+      try {
+        const steps = await controller.step();
+        swingStore.commit();
+        swingStore.close();
+        log(`runner stepped ${steps} crank${steps === 1 ? '' : 's'}`);
+      } catch (err) {
+        kernelFailure(err);
+      }
       break;
     }
     case 'shell': {
@@ -522,9 +526,13 @@ export async function main() {
       cli.defineCommand('step', {
         help: 'Step the swingset one crank, without commit',
         action: async () => {
-          const steps = await controller.step();
-          log(steps ? 'stepped one crank' : "didn't step, queue is empty");
-          cli.displayPrompt();
+          try {
+            const steps = await controller.step();
+            log(steps ? 'stepped one crank' : "didn't step, queue is empty");
+            cli.displayPrompt();
+          } catch (err) {
+            kernelFailure(err);
+          }
         },
       });
       break;
@@ -591,13 +599,17 @@ export async function main() {
     }
     while (requestedSteps > 0) {
       requestedSteps -= 1;
-      // eslint-disable-next-line no-await-in-loop
-      const stepped = await controller.step();
-      if (stepped < 1) {
-        break;
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const stepped = await controller.step();
+        if (stepped < 1) {
+          break;
+        }
+        crankNumber += stepped;
+        actualSteps += stepped;
+      } catch (err) {
+        kernelFailure(err);
       }
-      crankNumber += stepped;
-      actualSteps += stepped;
       if (doDumps) {
         kernelStateDump();
       }
@@ -656,6 +668,11 @@ export async function main() {
       stepLimit -= steps;
     } while ((runAll || stepLimit > 0) && steps >= blockSize);
     return [totalSteps, readClock() - startTime];
+  }
+
+  function kernelFailure(err) {
+    log(`kernel failure in crank ${crankNumber}: ${err}`, err);
+    process.exit(1);
   }
 
   async function commandRun(stepLimit, runInBlockMode) {

--- a/packages/swingset-runner/src/main.js
+++ b/packages/swingset-runner/src/main.js
@@ -77,7 +77,6 @@ FLAGS may be:
   --globalmetering - install metering on global objects
   --meter          - run metered vats (implies --globalmetering and --indirect)
   --config FILE    - read swingset config from FILE instead of inferring it
-  --loopbox        - make the loopbox device available to the bootstrap vat
 
 CMD is one of:
   help   - print this helpful usage information
@@ -185,7 +184,6 @@ export async function main() {
   let dbDir = null;
   let dbSize = 0;
   let initOnly = false;
-  let loopbox = false;
 
   while (argv[0] && argv[0].startsWith('-')) {
     const flag = argv.shift();
@@ -287,9 +285,6 @@ export async function main() {
       case '--lmdb':
         dbMode = flag;
         break;
-      case '--loopbox':
-        loopbox = true;
-        break;
       case '-v':
       case '--verbose':
         verbose = true;
@@ -340,7 +335,7 @@ export async function main() {
     config = loadBasedir(basedir);
   }
   const deviceEndowments = {};
-  if (loopbox) {
+  if (config.loopboxSenders) {
     const { loopboxSrcPath, loopboxEndowments } = buildLoopbox('immediate');
     config.devices = {
       loopbox: {


### PR DESCRIPTION
Four small adjustments to swingset-runner and one to SwingSet.  These are all in service of #3238.

* Get rid of the `--loopbox` command line flag.  Since the loopbox, if used, now _must_ be preconfigured with the sender names, and we get these from the config file so the command line flag only provides confusion and errors.
* Always checkpoint the kernel database after initialization.
* Intercept exceptions thrown by `controller.step()` and exit gracefully if they happen.
* The `kerneldump` utility has been updated to understand the most recent changes to the kernel DB schema.
* Remove nugatory (and noise generating) error wrappers in `guardStorage`

Each is a separate commit for your reviewing convenience.