### PR TITLE
gc-related cleanups

### DIFF
--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -382,7 +382,9 @@ export async function makeSwingsetController(
       insistCapData(args);
       const kref = kernel.addExport(vatID, exportID);
       const kpid = kernel.queueToKref(kref, method, args, resultPolicy);
-      kernel.kpRegisterInterest(kpid);
+      if (kpid) {
+        kernel.kpRegisterInterest(kpid);
+      }
       return kpid;
     },
   });

--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -408,6 +408,7 @@ export async function makeSwingsetController(
  *   testTrackDecref?: unknown,
  *   snapstorePath?: string,
  *   warehousePolicy?: { maxVatsOnline?: number },
+ *   slogFile?: string,
  * }} runtimeOptions
  * @typedef { import('@agoric/swing-store-simple').KVStore } KVStore
  */
@@ -424,6 +425,7 @@ export async function buildVatController(
     slogCallbacks,
     snapstorePath,
     warehousePolicy,
+    slogFile,
   } = runtimeOptions;
   const actualRuntimeOptions = {
     verbose,
@@ -431,6 +433,7 @@ export async function buildVatController(
     slogCallbacks,
     snapstorePath,
     warehousePolicy,
+    slogFile,
   };
   const initializationOptions = { verbose, kernelBundles };
   let bootstrapResult;

--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -463,7 +463,7 @@ function build(
       slotToVal.set(slot, new WeakRef(val));
       if (type === 'object') {
         deadSet.delete(slot);
-        droppedRegistry.register(val, slot);
+        droppedRegistry.register(val, slot, val);
       }
     }
     return valToSlot.get(val);
@@ -486,7 +486,7 @@ function build(
     // we don't dropImports on promises, to avoid interaction with retire
     if (type === 'object') {
       deadSet.delete(slot); // might have been FINALIZED before, no longer
-      droppedRegistry.register(val, slot);
+      droppedRegistry.register(val, slot, val);
     }
   }
 

--- a/packages/SwingSet/src/kernel/slogger.js
+++ b/packages/SwingSet/src/kernel/slogger.js
@@ -235,23 +235,23 @@ export function makeSlogger(slogCallbacks, writeObj) {
   const slogger = harden({
     provideVatSlogger: reg('provideVatSlogger', provideVatSlogger),
     vatConsole: reg('vatConsole', (vatID, ...args) =>
-      vatSlogs.get(vatID).vatConsole(...args),
+      provideVatSlogger(vatID).vatSlog.vatConsole(...args),
     ),
     startup: reg('startup', (vatID, ...args) =>
-      vatSlogs.get(vatID).startup(...args),
+      provideVatSlogger(vatID).vatSlog.startup(...args),
     ),
     replayVatTranscript,
     delivery: reg('delivery', (vatID, ...args) =>
-      vatSlogs.get(vatID).delivery(...args),
+      provideVatSlogger(vatID).vatSlog.delivery(...args),
     ),
     syscall: reg('syscall', (vatID, ...args) =>
-      vatSlogs.get(vatID).syscall(...args),
+      provideVatSlogger(vatID).vatSlog.syscall(...args),
     ),
     changeCList: reg('changeCList', (vatID, ...args) =>
-      vatSlogs.get(vatID).changeCList(...args),
+      provideVatSlogger(vatID).vatSlog.changeCList(...args),
     ),
     terminateVat: reg('terminateVat', (vatID, ...args) =>
-      vatSlogs.get(vatID).terminateVat(...args),
+      provideVatSlogger(vatID).vatSlog.terminateVat(...args),
     ),
     write,
   });

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-helper.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-helper.js
@@ -35,7 +35,7 @@ function makeSupervisorDispatch(dispatch) {
         () => harden(['ok', null, null]),
         err => {
           // TODO react more thoughtfully, maybe terminate the vat
-          console.log(`error ${err} during vat dispatch of ${delivery}`);
+          console.log(`error ${err} during vat dispatch() of ${delivery}`);
           return harden(['error', `${err.message}`, null]);
         },
       );

--- a/packages/SwingSet/src/vats/comms/dispatch.js
+++ b/packages/SwingSet/src/vats/comms/dispatch.js
@@ -152,21 +152,21 @@ export function buildCommsDispatch(
     assert(Array.isArray(vrefs));
     vrefs.map(vref => insistVatType('object', vref));
     vrefs.map(vref => assert(parseVatSlot(vref).allocatedByVat));
-    console.log(`-- comms ignoring dropExports`);
+    // console.log(`-- comms ignoring dropExports`);
   }
 
   function retireExports(vrefs) {
     assert(Array.isArray(vrefs));
     vrefs.map(vref => insistVatType('object', vref));
     vrefs.map(vref => assert(parseVatSlot(vref).allocatedByVat));
-    console.log(`-- comms ignoring retireExports`);
+    // console.log(`-- comms ignoring retireExports`);
   }
 
   function retireImports(vrefs) {
     assert(Array.isArray(vrefs));
     vrefs.map(vref => insistVatType('object', vref));
     vrefs.map(vref => assert(!parseVatSlot(vref).allocatedByVat));
-    console.log(`-- comms ignoring retireImports`);
+    // console.log(`-- comms ignoring retireImports`);
   }
 
   function dispatch(vatDeliveryObject) {


### PR DESCRIPTION
This makes a number of small cleanups in preparation for landing larger GC work.

* update docs/garbage-collection.md with a new algorithm
* add `slogFile` option to `buildVatController()`
* use `provideVatSlogger` within the slogger
* tolerate `policy='none'` in `queueToVatExport`
* log message tweaks
* enable `unregister()` in the liveslots FinalizationRegistry
* comment out GC debug prints in the comms vat

I'd recommend reviewing each commit separately, they're pretty small and non-overlapping.

refs #3106 
