### PR TITLE
implement dispatch.retireExports for Remotables

### DIFF
--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -849,11 +849,50 @@ function build(
     }
   }
 
+  function retireOneExport(vref) {
+    insistVatType('object', vref);
+    const { virtual, allocatedByVat, type } = parseVatSlot(vref);
+    assert(allocatedByVat);
+    assert.equal(type, 'object');
+    if (virtual) {
+      // virtual object: ignore for now, but TODO we must still not make
+      // syscall.retireExport for vrefs that were already retired by the
+      // kernel
+      // console.log(`-- liveslots ignoring retireExports ${vref}`);
+    } else {
+      // Remotable
+      // console.log(`-- liveslots acting on retireExports ${vref}`);
+      const wr = slotToVal.get(vref);
+      if (wr) {
+        const val = wr.deref();
+        if (val) {
+          // it's fine to still have a value, that just means the kernel
+          // (and other vats) have completely forgotten about this, but we
+          // still know about it
+
+          if (exportedRemotables.has(val)) {
+            // however this is weird: we still think the Remotable is
+            // reachable, otherwise we would have removed it from
+            // exportedRemotables. The kernel was supposed to send
+            // dispatch.dropExports first.
+            console.log(`err: kernel retired undropped ${vref}`);
+            // TODO: find a way to make this more severe, it's cause for
+            // panicing the kernel, except that vats don't have that
+            // authority. It's *not* cause for terminating the vat, since
+            // it wasn't necessarily our fault.
+            return;
+          }
+          valToSlot.delete(val);
+          droppedRegistry.unregister(val);
+        }
+        slotToVal.delete(vref);
+      }
+    }
+  }
+
   function retireExports(vrefs) {
     assert(Array.isArray(vrefs));
-    vrefs.map(vref => insistVatType('object', vref));
-    vrefs.map(vref => assert(parseVatSlot(vref).allocatedByVat));
-    console.log(`-- liveslots ignoring retireExports`);
+    vrefs.forEach(retireOneExport);
   }
 
   function retireImports(vrefs) {

--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -839,7 +839,7 @@ function build(
     assert(Array.isArray(vrefs));
     vrefs.map(vref => insistVatType('object', vref));
     vrefs.map(vref => assert(parseVatSlot(vref).allocatedByVat));
-    console.log(`-- liveslots acting upon dropExports`);
+    // console.log(`-- liveslots acting upon dropExports ${vrefs.join(',')}`);
     for (const vref of vrefs) {
       const wr = slotToVal.get(vref);
       const o = wr && wr.deref();
@@ -899,7 +899,7 @@ function build(
     assert(Array.isArray(vrefs));
     vrefs.map(vref => insistVatType('object', vref));
     vrefs.map(vref => assert(!parseVatSlot(vref).allocatedByVat));
-    console.log(`-- liveslots ignoring retireImports`);
+    // console.log(`-- liveslots ignoring retireImports ${vrefs.join(',')}`);
   }
 
   // TODO: when we add notifyForward, guard against cycles


### PR DESCRIPTION
fix(swingset): implement dispatch.retireExports for Remotables

This updates liveslots to implement kernel-delivered
`dispatch.retireExports`, but only when the object being retired is a
Remotable (virtual objects are left alone for now).

Retiring an exported Remotable means we remove it from the `slotToVal` and
`valToSlot` tables, and unregister it from the `droppedRegistry`. At this
point, vat code might still hold a strong reference to the Remoteable, but
liveslots is unaware of it. If the vat re-exports the object, it will get a
new vref.

This also comments out some debug messages.

refs #3106 
