### PR TITLE
feat(assert)!: RESM to NESM

### DIFF
--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -2,9 +2,7 @@
   "name": "@agoric/assert",
   "version": "0.2.12",
   "description": "Assert expression support that protects sensitive data",
-  "parsers": {
-    "js": "mjs"
-  },
+  "type": "module",
   "main": "src/assert.js",
   "engines": {
     "node": ">=11.0"
@@ -36,8 +34,7 @@
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "devDependencies": {
     "@agoric/install-ses": "^0.5.13",
-    "ava": "^3.12.1",
-    "esm": "agoric-labs/esm#Agoric-built"
+    "ava": "^3.12.1"
   },
   "files": [
     "src/",
@@ -47,9 +44,6 @@
   "ava": {
     "files": [
       "test/**/test-*.js"
-    ],
-    "require": [
-      "esm"
     ]
   },
   "eslintConfig": {


### PR DESCRIPTION
refs: #527

## Description

BREAKING CHANGE: Converts `@agoric/assert` from emulated ESM with `node -r esm` to Node.js ESM proper.

### Documentation Considerations

From a documentation perspective, we must emphasize that we only work with our patched version of RESM: `agoric-labs/esm#Agoric-built` and this change is part of an effort to relax the dependency on ESM emulation going forward. This means that our modules will work more in accordance with the evolution of the JavaScript community and eventually be able to downgrade to CommonJS gracefully for broader adoption. For now, `agoric install` and our project scaffolds and scaffolded applications will continue to work without modification.
