### PR TITLE
feat(tame-metering)!: RESM to NESM

### DIFF
--- a/packages/SwingSet/bin/replay-transcript.js
+++ b/packages/SwingSet/bin/replay-transcript.js
@@ -1,19 +1,19 @@
 /* global WeakRef FinalizationRegistry require */
 // import '@agoric/install-ses';
-import '../tools/install-ses-debug';
+import '../tools/install-ses-debug.js';
 import fs from 'fs';
 import zlib from 'zlib';
 import readline from 'readline';
 import process from 'process';
 import { spawn } from 'child_process';
 import bundleSource from '@agoric/bundle-source';
-import { waitUntilQuiescent } from '../src/waitUntilQuiescent';
-import { makeStartXSnap } from '../src/controller';
-import { makeXsSubprocessFactory } from '../src/kernel/vatManager/manager-subprocess-xsnap';
-import { makeLocalVatManagerFactory } from '../src/kernel/vatManager/manager-local';
-import { makeNodeSubprocessFactory } from '../src/kernel/vatManager/manager-subprocess-node';
-import { startSubprocessWorker } from '../src/spawnSubprocessWorker';
-import { requireIdentical } from '../src/kernel/vatManager/transcript';
+import { waitUntilQuiescent } from '../src/waitUntilQuiescent.js';
+import { makeStartXSnap } from '../src/controller.js';
+import { makeXsSubprocessFactory } from '../src/kernel/vatManager/manager-subprocess-xsnap.js';
+import { makeLocalVatManagerFactory } from '../src/kernel/vatManager/manager-local.js';
+import { makeNodeSubprocessFactory } from '../src/kernel/vatManager/manager-subprocess-node.js';
+import { startSubprocessWorker } from '../src/spawnSubprocessWorker.js';
+import { requireIdentical } from '../src/kernel/vatManager/transcript.js';
 
 async function makeBundles() {
   const srcGE = rel => bundleSource(require.resolve(rel), 'getExport');

--- a/packages/SwingSet/demo/encouragementBotComms/vat-botcomms.js
+++ b/packages/SwingSet/demo/encouragementBotComms/vat-botcomms.js
@@ -1,4 +1,4 @@
-import buildCommsDispatch from '../../src/vats/comms';
+import buildCommsDispatch from '../../src/vats/comms/index.js';
 
 export default function setup(syscall, _state, _helpers, _vatPowers) {
   return buildCommsDispatch(syscall);

--- a/packages/SwingSet/demo/encouragementBotComms/vat-botvattp.js
+++ b/packages/SwingSet/demo/encouragementBotComms/vat-botvattp.js
@@ -1,1 +1,1 @@
-export { buildRootObject } from '../../src/vats/vat-tp';
+export { buildRootObject } from '../../src/vats/vat-tp.js';

--- a/packages/SwingSet/demo/encouragementBotComms/vat-usercomms.js
+++ b/packages/SwingSet/demo/encouragementBotComms/vat-usercomms.js
@@ -1,4 +1,4 @@
-import buildCommsDispatch from '../../src/vats/comms';
+import buildCommsDispatch from '../../src/vats/comms/index.js';
 
 export default function setup(syscall, _state, _helpers, _vatPowers) {
   return buildCommsDispatch(syscall);

--- a/packages/SwingSet/demo/encouragementBotComms/vat-uservattp.js
+++ b/packages/SwingSet/demo/encouragementBotComms/vat-uservattp.js
@@ -1,1 +1,1 @@
-export { buildRootObject } from '../../src/vats/vat-tp';
+export { buildRootObject } from '../../src/vats/vat-tp.js';

--- a/packages/SwingSet/exported.js
+++ b/packages/SwingSet/exported.js
@@ -1,1 +1,1 @@
-import './src/vats/types';
+import './src/vats/types.js';

--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -17,19 +17,19 @@ import { importBundle } from '@agoric/import-bundle';
 import { makeMeteringTransformer } from '@agoric/transform-metering';
 import { xsnap, makeSnapstore } from '@agoric/xsnap';
 
-import engineGC from './engine-gc';
-import { WeakRef, FinalizationRegistry } from './weakref';
-import { startSubprocessWorker } from './spawnSubprocessWorker';
-import { waitUntilQuiescent } from './waitUntilQuiescent';
-import { makeGcAndFinalize } from './gc-and-finalize';
-import { insistStorageAPI } from './storageAPI';
-import { insistCapData } from './capdata';
-import { parseVatSlot } from './parseVatSlots';
-import { provideHostStorage } from './hostStorage';
+import engineGC from './engine-gc.js';
+import { WeakRef, FinalizationRegistry } from './weakref.js';
+import { startSubprocessWorker } from './spawnSubprocessWorker.js';
+import { waitUntilQuiescent } from './waitUntilQuiescent.js';
+import { makeGcAndFinalize } from './gc-and-finalize.js';
+import { insistStorageAPI } from './storageAPI.js';
+import { insistCapData } from './capdata.js';
+import { parseVatSlot } from './parseVatSlots.js';
+import { provideHostStorage } from './hostStorage.js';
 import {
   swingsetIsInitialized,
   initializeSwingset,
-} from './initializeSwingset';
+} from './initializeSwingset.js';
 
 /** @param {string} tag */
 function makeConsole(tag) {

--- a/packages/SwingSet/src/index.js
+++ b/packages/SwingSet/src/index.js
@@ -1,14 +1,14 @@
-export { buildVatController, makeSwingsetController } from './controller';
+export { buildVatController, makeSwingsetController } from './controller.js';
 export {
   swingsetIsInitialized,
   initializeSwingset,
   buildKernelBundles,
   loadBasedir,
   loadSwingsetConfigFile,
-} from './initializeSwingset';
+} from './initializeSwingset.js';
 
-export { buildMailboxStateMap, buildMailbox } from './devices/mailbox';
-export { buildTimer } from './devices/timer';
-export { buildBridge } from './devices/bridge';
-export { default as buildCommand } from './devices/command';
-export { buildPlugin } from './devices/plugin';
+export { buildMailboxStateMap, buildMailbox } from './devices/mailbox.js';
+export { buildTimer } from './devices/timer.js';
+export { buildBridge } from './devices/bridge.js';
+export { default as buildCommand } from './devices/command.js';
+export { buildPlugin } from './devices/plugin.js';

--- a/packages/SwingSet/src/initializeSwingset.js
+++ b/packages/SwingSet/src/initializeSwingset.js
@@ -6,9 +6,9 @@ import path from 'path';
 import { assert, details as X } from '@agoric/assert';
 import bundleSource from '@agoric/bundle-source';
 
-import './types';
-import { insistStorageAPI } from './storageAPI';
-import { initializeKernel } from './kernel/initializeKernel';
+import './types.js';
+import { insistStorageAPI } from './storageAPI.js';
+import { initializeKernel } from './kernel/initializeKernel.js';
 
 const zip = (xs, ys) => xs.map((x, i) => [x, ys[i]]);
 const { keys, values, fromEntries } = Object;

--- a/packages/SwingSet/src/kernel/cleanup.js
+++ b/packages/SwingSet/src/kernel/cleanup.js
@@ -1,5 +1,5 @@
-// import { kdebug } from './kdebug';
-import { parseKernelSlot } from './parseKernelSlots';
+// import { kdebug } from './kdebug.js';
+import { parseKernelSlot } from './parseKernelSlots.js';
 
 export function getKpidsToRetire(kernelKeeper, rootKPID, rootKernelData) {
   const seen = new Set();

--- a/packages/SwingSet/src/kernel/deviceManager.js
+++ b/packages/SwingSet/src/kernel/deviceManager.js
@@ -1,8 +1,8 @@
 import { assert } from '@agoric/assert';
-import { makeDeviceSlots } from './deviceSlots';
-import { insistCapData } from '../capdata';
+import { makeDeviceSlots } from './deviceSlots.js';
+import { insistCapData } from '../capdata.js';
 
-import '../types';
+import '../types.js';
 
 /* The DeviceManager is much simpler than the VatManager, because the feature
  * set is smaller:

--- a/packages/SwingSet/src/kernel/deviceSlots.js
+++ b/packages/SwingSet/src/kernel/deviceSlots.js
@@ -1,7 +1,7 @@
 import { Remotable, passStyleOf, makeMarshal } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
-import { insistVatType, makeVatSlot, parseVatSlot } from '../parseVatSlots';
-import { insistCapData } from '../capdata';
+import { insistVatType, makeVatSlot, parseVatSlot } from '../parseVatSlots.js';
+import { insistCapData } from '../capdata.js';
 
 // 'makeDeviceSlots' is a subset of makeLiveSlots, for device code
 

--- a/packages/SwingSet/src/kernel/gc-actions.js
+++ b/packages/SwingSet/src/kernel/gc-actions.js
@@ -1,6 +1,6 @@
 import { assert } from '@agoric/assert';
-import { insistKernelType } from './parseKernelSlots';
-import { insistVatID } from './id';
+import { insistKernelType } from './parseKernelSlots.js';
+import { insistVatID } from './id.js';
 
 const typePriority = ['dropExport', 'retireExport', 'retireImport'];
 

--- a/packages/SwingSet/src/kernel/index.js
+++ b/packages/SwingSet/src/kernel/index.js
@@ -1,3 +1,3 @@
-import buildKernel from './kernel';
+import buildKernel from './kernel.js';
 
 export default buildKernel;

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -1,27 +1,27 @@
 // @ts-check
 import { assert, details as X } from '@agoric/assert';
 import { importBundle } from '@agoric/import-bundle';
-import { assertKnownOptions } from '../assertOptions';
-import { makeVatManagerFactory } from './vatManager/factory';
-import { makeVatWarehouse } from './vatManager/vat-warehouse';
-import makeDeviceManager from './deviceManager';
-import { wrapStorage } from './state/storageWrapper';
-import makeKernelKeeper from './state/kernelKeeper';
-import { kdebug, kdebugEnable, legibilizeMessageArgs } from './kdebug';
-import { insistKernelType, parseKernelSlot } from './parseKernelSlots';
-import { parseVatSlot } from '../parseVatSlots';
-import { insistStorageAPI } from '../storageAPI';
-import { insistCapData } from '../capdata';
-import { insistMessage, insistVatDeliveryResult } from '../message';
-import { insistDeviceID, insistVatID } from './id';
-import { makeMeterManager } from './metering';
-import { makeKernelSyscallHandler, doSend } from './kernelSyscall';
-import { makeSlogger, makeDummySlogger } from './slogger';
-import { getKpidsToRetire } from './cleanup';
+import { assertKnownOptions } from '../assertOptions.js';
+import { makeVatManagerFactory } from './vatManager/factory.js';
+import { makeVatWarehouse } from './vatManager/vat-warehouse.js';
+import makeDeviceManager from './deviceManager.js';
+import { wrapStorage } from './state/storageWrapper.js';
+import makeKernelKeeper from './state/kernelKeeper.js';
+import { kdebug, kdebugEnable, legibilizeMessageArgs } from './kdebug.js';
+import { insistKernelType, parseKernelSlot } from './parseKernelSlots.js';
+import { parseVatSlot } from '../parseVatSlots.js';
+import { insistStorageAPI } from '../storageAPI.js';
+import { insistCapData } from '../capdata.js';
+import { insistMessage, insistVatDeliveryResult } from '../message.js';
+import { insistDeviceID, insistVatID } from './id.js';
+import { makeMeterManager } from './metering.js';
+import { makeKernelSyscallHandler, doSend } from './kernelSyscall.js';
+import { makeSlogger, makeDummySlogger } from './slogger.js';
+import { getKpidsToRetire } from './cleanup.js';
 
-import { makeVatRootObjectSlot, makeVatLoader } from './loadVat';
-import { makeDeviceTranslators } from './deviceTranslator';
-import { notifyTermination } from './notifyTermination';
+import { makeVatRootObjectSlot, makeVatLoader } from './loadVat.js';
+import { makeDeviceTranslators } from './deviceTranslator.js';
+import { notifyTermination } from './notifyTermination.js';
 
 function abbreviateReplacer(_, arg) {
   if (typeof arg === 'bigint') {

--- a/packages/SwingSet/src/kernel/kernelSyscall.js
+++ b/packages/SwingSet/src/kernel/kernelSyscall.js
@@ -1,8 +1,8 @@
 import { assert, details as X } from '@agoric/assert';
-import { insistKernelType, parseKernelSlot } from './parseKernelSlots';
-import { insistMessage } from '../message';
-import { insistCapData } from '../capdata';
-import { insistDeviceID, insistVatID } from './id';
+import { insistKernelType, parseKernelSlot } from './parseKernelSlots.js';
+import { insistMessage } from '../message.js';
+import { insistCapData } from '../capdata.js';
+import { insistDeviceID, insistVatID } from './id.js';
 
 const OKNULL = harden(['ok', null]);
 

--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -3,10 +3,10 @@
 import { Remotable, passStyleOf, makeMarshal } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
 import { isPromise } from '@agoric/promise-kit';
-import { insistVatType, makeVatSlot, parseVatSlot } from '../parseVatSlots';
-import { insistCapData } from '../capdata';
-import { insistMessage } from '../message';
-import { makeVirtualObjectManager } from './virtualObjectManager';
+import { insistVatType, makeVatSlot, parseVatSlot } from '../parseVatSlots.js';
+import { insistCapData } from '../capdata.js';
+import { insistMessage } from '../message.js';
+import { makeVirtualObjectManager } from './virtualObjectManager.js';
 
 const DEFAULT_VIRTUAL_OBJECT_CACHE_SIZE = 3; // XXX ridiculously small value to force churn for testing
 

--- a/packages/SwingSet/src/kernel/notifyTermination.js
+++ b/packages/SwingSet/src/kernel/notifyTermination.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { insistCapData } from '../capdata';
+import { insistCapData } from '../capdata.js';
 
 /**
  * @param {string} vatID

--- a/packages/SwingSet/src/kernel/state/deviceKeeper.js
+++ b/packages/SwingSet/src/kernel/state/deviceKeeper.js
@@ -4,9 +4,9 @@
 
 import { Nat } from '@agoric/nat';
 import { assert, details as X } from '@agoric/assert';
-import { parseKernelSlot } from '../parseKernelSlots';
-import { makeVatSlot, parseVatSlot } from '../../parseVatSlots';
-import { insistDeviceID } from '../id';
+import { parseKernelSlot } from '../parseKernelSlots.js';
+import { makeVatSlot, parseVatSlot } from '../../parseVatSlots.js';
+import { insistDeviceID } from '../id.js';
 
 const FIRST_DEVICE_STATE_ID = 10n;
 

--- a/packages/SwingSet/src/kernel/vatManager/factory.js
+++ b/packages/SwingSet/src/kernel/vatManager/factory.js
@@ -1,9 +1,9 @@
 import { assert, details as X } from '@agoric/assert';
-import { assertKnownOptions } from '../../assertOptions';
-import { makeLocalVatManagerFactory } from './manager-local';
-import { makeNodeWorkerVatManagerFactory } from './manager-nodeworker';
-import { makeNodeSubprocessFactory } from './manager-subprocess-node';
-import { makeXsSubprocessFactory } from './manager-subprocess-xsnap';
+import { assertKnownOptions } from '../../assertOptions.js';
+import { makeLocalVatManagerFactory } from './manager-local.js';
+import { makeNodeWorkerVatManagerFactory } from './manager-nodeworker.js';
+import { makeNodeSubprocessFactory } from './manager-subprocess-node.js';
+import { makeXsSubprocessFactory } from './manager-subprocess-xsnap.js';
 
 export function makeVatManagerFactory({
   allVatPowers,

--- a/packages/SwingSet/src/kernel/vatManager/lockdown-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/lockdown-subprocess-xsnap.js
@@ -1,1 +1,1 @@
-import '@agoric/xsnap/lib/ses-boot';
+import '@agoric/xsnap/lib/ses-boot.js';

--- a/packages/SwingSet/src/kernel/vatManager/manager-helper.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-helper.js
@@ -1,8 +1,8 @@
 // @ts-check
 import { assert } from '@agoric/assert';
-import '../../types';
-import { insistVatDeliveryResult } from '../../message';
-import { makeTranscriptManager } from './transcript';
+import '../../types.js';
+import { insistVatDeliveryResult } from '../../message.js';
+import { makeTranscriptManager } from './transcript.js';
 
 // We use vat-centric terminology here, so "inbound" means "into a vat",
 // always from the kernel. Conversely "outbound" means "out of a vat", into

--- a/packages/SwingSet/src/kernel/vatManager/manager-local.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-local.js
@@ -1,13 +1,13 @@
 // @ts-check
 import { assert, details as X } from '@agoric/assert';
 import { importBundle } from '@agoric/import-bundle';
-import { makeLiveSlots } from '../liveSlots';
-import { makeManagerKit } from './manager-helper';
+import { makeLiveSlots } from '../liveSlots.js';
+import { makeManagerKit } from './manager-helper.js';
 import {
   makeSupervisorDispatch,
   makeMeteredDispatch,
   makeSupervisorSyscall,
-} from './supervisor-helper';
+} from './supervisor-helper.js';
 
 export function makeLocalVatManagerFactory(tools) {
   const {

--- a/packages/SwingSet/src/kernel/vatManager/manager-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-nodeworker.js
@@ -2,7 +2,7 @@
 // import { Worker } from 'worker_threads'; // not from a Compartment
 import { assert, details as X } from '@agoric/assert';
 import { makePromiseKit } from '@agoric/promise-kit';
-import { makeManagerKit } from './manager-helper';
+import { makeManagerKit } from './manager-helper.js';
 
 // start a "Worker" (Node's tool for starting new threads) and load a bundle
 // into it

--- a/packages/SwingSet/src/kernel/vatManager/manager-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-subprocess-node.js
@@ -2,7 +2,7 @@
 
 import { assert, details as X } from '@agoric/assert';
 import { makePromiseKit } from '@agoric/promise-kit';
-import { makeManagerKit } from './manager-helper';
+import { makeManagerKit } from './manager-helper.js';
 
 // start a "Worker" (Node's tool for starting new threads) and load a bundle
 // into it

--- a/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
@@ -1,11 +1,14 @@
 // @ts-check
 import { assert, details as X, q } from '@agoric/assert';
-import { ExitCode } from '@agoric/xsnap/api';
-import { makeManagerKit } from './manager-helper';
+import { ExitCode } from '@agoric/xsnap/api.js';
+import { makeManagerKit } from './manager-helper.js';
 
-import { insistVatSyscallObject, insistVatDeliveryResult } from '../../message';
-import '../../types';
-import './types';
+import {
+  insistVatSyscallObject,
+  insistVatDeliveryResult,
+} from '../../message.js';
+import '../../types.js';
+import './types.js';
 
 // eslint-disable-next-line no-unused-vars
 function parentLog(first, ...args) {

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-helper.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-helper.js
@@ -1,7 +1,10 @@
 // @ts-check
 import { assert } from '@agoric/assert';
-import { insistVatSyscallObject, insistVatSyscallResult } from '../../message';
-import '../../types';
+import {
+  insistVatSyscallObject,
+  insistVatSyscallResult,
+} from '../../message.js';
+import '../../types.js';
 
 /**
  * @typedef { (delivery: VatDeliveryObject) => (VatDeliveryResult | Promise<VatDeliveryResult>) } VatDispatcherSyncAsync

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-nodeworker-cjs.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-nodeworker-cjs.js
@@ -10,4 +10,4 @@
 
 // eslint-disable-next-line no-global-assign
 require = require('esm')(module);
-module.exports = require('./supervisor-nodeworker');
+module.exports = require('./supervisor-nodeworker.js');

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-nodeworker.js
@@ -5,19 +5,19 @@ import '@agoric/install-ses';
 import { parentPort } from 'worker_threads';
 import anylogger from 'anylogger';
 
-import '../../types';
+import '../../types.js';
 import { assert, details as X } from '@agoric/assert';
 import { importBundle } from '@agoric/import-bundle';
 import { makeMarshal } from '@agoric/marshal';
-import engineGC from '../../engine-gc';
-import { WeakRef, FinalizationRegistry } from '../../weakref';
-import { makeGcAndFinalize } from '../../gc-and-finalize';
-import { waitUntilQuiescent } from '../../waitUntilQuiescent';
-import { makeLiveSlots } from '../liveSlots';
+import engineGC from '../../engine-gc.js';
+import { WeakRef, FinalizationRegistry } from '../../weakref.js';
+import { makeGcAndFinalize } from '../../gc-and-finalize.js';
+import { waitUntilQuiescent } from '../../waitUntilQuiescent.js';
+import { makeLiveSlots } from '../liveSlots.js';
 import {
   makeSupervisorDispatch,
   makeSupervisorSyscall,
-} from './supervisor-helper';
+} from './supervisor-helper.js';
 
 assert(parentPort, 'parentPort somehow missing, am I not a Worker?');
 

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-node.js
@@ -7,20 +7,23 @@ import fs from 'fs';
 import { assert, details as X } from '@agoric/assert';
 import { importBundle } from '@agoric/import-bundle';
 import { makeMarshal } from '@agoric/marshal';
-import engineGC from '../../engine-gc';
-import { WeakRef, FinalizationRegistry } from '../../weakref';
-import { makeGcAndFinalize } from '../../gc-and-finalize';
-import { arrayEncoderStream, arrayDecoderStream } from '../../worker-protocol';
+import engineGC from '../../engine-gc.js';
+import { WeakRef, FinalizationRegistry } from '../../weakref.js';
+import { makeGcAndFinalize } from '../../gc-and-finalize.js';
+import {
+  arrayEncoderStream,
+  arrayDecoderStream,
+} from '../../worker-protocol.js';
 import {
   netstringEncoderStream,
   netstringDecoderStream,
-} from '../../netstring';
-import { waitUntilQuiescent } from '../../waitUntilQuiescent';
-import { makeLiveSlots } from '../liveSlots';
+} from '../../netstring.js';
+import { waitUntilQuiescent } from '../../waitUntilQuiescent.js';
+import { makeLiveSlots } from '../liveSlots.js';
 import {
   makeSupervisorDispatch,
   makeSupervisorSyscall,
-} from './supervisor-helper';
+} from './supervisor-helper.js';
 
 // eslint-disable-next-line no-unused-vars
 function workerLog(first, ...args) {

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
@@ -3,17 +3,20 @@
 import { assert, details as X, q } from '@agoric/assert';
 import { importBundle } from '@agoric/import-bundle';
 import { makeMarshal } from '@agoric/marshal';
-import '../../types';
+import '../../types.js';
 // grumble... waitUntilQuiescent is exported and closes over ambient authority
-import { waitUntilQuiescent } from '../../waitUntilQuiescent';
-import { makeGcAndFinalize } from '../../gc-and-finalize';
-import { insistVatDeliveryObject, insistVatSyscallResult } from '../../message';
+import { waitUntilQuiescent } from '../../waitUntilQuiescent.js';
+import { makeGcAndFinalize } from '../../gc-and-finalize.js';
+import {
+  insistVatDeliveryObject,
+  insistVatSyscallResult,
+} from '../../message.js';
 
-import { makeLiveSlots } from '../liveSlots';
+import { makeLiveSlots } from '../liveSlots.js';
 import {
   makeSupervisorDispatch,
   makeSupervisorSyscall,
-} from './supervisor-helper';
+} from './supervisor-helper.js';
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();

--- a/packages/SwingSet/src/kernel/vatManager/transcript.js
+++ b/packages/SwingSet/src/kernel/vatManager/transcript.js
@@ -1,4 +1,4 @@
-import djson from '../djson';
+import djson from '../djson.js';
 
 export function requireIdentical(vatID, originalSyscall, newSyscall) {
   if (djson.stringify(originalSyscall) !== djson.stringify(newSyscall)) {

--- a/packages/SwingSet/src/kernel/vatManager/vat-warehouse.js
+++ b/packages/SwingSet/src/kernel/vatManager/vat-warehouse.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from '@agoric/assert';
-import { makeVatTranslators } from '../vatTranslator';
+import { makeVatTranslators } from '../vatTranslator.js';
 
 /**
  * @param { ReturnType<typeof import('../state/kernelKeeper').default> } kernelKeeper

--- a/packages/SwingSet/src/kernel/virtualObjectManager.js
+++ b/packages/SwingSet/src/kernel/virtualObjectManager.js
@@ -1,6 +1,6 @@
 import { assert, details as X, quote as q } from '@agoric/assert';
-import { parseVatSlot } from '../parseVatSlots';
-// import { kdebug } from './kdebug';
+import { parseVatSlot } from '../parseVatSlots.js';
+// import { kdebug } from './kdebug.js';
 
 const initializationsInProgress = new WeakSet();
 

--- a/packages/SwingSet/src/message.js
+++ b/packages/SwingSet/src/message.js
@@ -1,5 +1,5 @@
 import { assert, details as X } from '@agoric/assert';
-import { insistCapData } from './capdata';
+import { insistCapData } from './capdata.js';
 
 /**
  * Assert function to ensure that something expected to be a message object

--- a/packages/SwingSet/src/spawnSubprocessWorker.js
+++ b/packages/SwingSet/src/spawnSubprocessWorker.js
@@ -1,8 +1,8 @@
 // this file is loaded by the controller, in the start compartment
 import { spawn } from 'child_process';
 import { makePromiseKit } from '@agoric/promise-kit';
-import { arrayEncoderStream, arrayDecoderStream } from './worker-protocol';
-import { netstringEncoderStream, netstringDecoderStream } from './netstring';
+import { arrayEncoderStream, arrayDecoderStream } from './worker-protocol.js';
+import { netstringEncoderStream, netstringDecoderStream } from './netstring.js';
 
 // Start a subprocess from a given executable, and arrange a bidirectional
 // message channel with a "supervisor" within that process. Return a {

--- a/packages/SwingSet/src/types.js
+++ b/packages/SwingSet/src/types.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-// import '@agoric/marshal/src/types';
+// import '@agoric/marshal/src/types.js';
 
 /**
  * @typedef {CapData<string>} SwingSetCapData

--- a/packages/SwingSet/src/vats/comms/clist-inbound.js
+++ b/packages/SwingSet/src/vats/comms/clist-inbound.js
@@ -3,8 +3,8 @@ import {
   flipRemoteSlot,
   insistRemoteType,
   parseRemoteSlot,
-} from './parseRemoteSlot';
-import { cdebug } from './cdebug';
+} from './parseRemoteSlot.js';
+import { cdebug } from './cdebug.js';
 
 function rname(remote) {
   return `${remote.remoteID()} (${remote.name()})`;

--- a/packages/SwingSet/src/vats/comms/clist-kernel.js
+++ b/packages/SwingSet/src/vats/comms/clist-kernel.js
@@ -1,7 +1,7 @@
 import { assert, details as X } from '@agoric/assert';
-import { parseVatSlot, insistVatType } from '../../parseVatSlots';
-import { parseLocalSlot } from './parseLocalSlots';
-import { cdebug } from './cdebug';
+import { parseVatSlot, insistVatType } from '../../parseVatSlots.js';
+import { parseLocalSlot } from './parseLocalSlots.js';
+import { cdebug } from './cdebug.js';
 
 export function makeKernel(state, syscall) {
   // *-KernelForLocal: comms vat sending out to kernel

--- a/packages/SwingSet/src/vats/comms/clist-outbound.js
+++ b/packages/SwingSet/src/vats/comms/clist-outbound.js
@@ -1,7 +1,7 @@
 import { assert, details as X } from '@agoric/assert';
-import { parseLocalSlot, insistLocalType } from './parseLocalSlots';
-import { flipRemoteSlot, insistRemoteType } from './parseRemoteSlot';
-import { cdebug } from './cdebug';
+import { parseLocalSlot, insistLocalType } from './parseLocalSlots.js';
+import { flipRemoteSlot, insistRemoteType } from './parseRemoteSlot.js';
+import { cdebug } from './cdebug.js';
 
 function rname(remote) {
   return `${remote.remoteID()} (${remote.name()})`;

--- a/packages/SwingSet/src/vats/comms/clist-xgress.js
+++ b/packages/SwingSet/src/vats/comms/clist-xgress.js
@@ -1,7 +1,7 @@
 import { Nat } from '@agoric/nat';
-import { insistLocalType } from './parseLocalSlots';
-import { makeRemoteSlot } from './parseRemoteSlot';
-import { cdebug } from './cdebug';
+import { insistLocalType } from './parseLocalSlots.js';
+import { makeRemoteSlot } from './parseRemoteSlot.js';
+import { cdebug } from './cdebug.js';
 
 export function makeIngressEgress(state, provideLocalForRemote) {
   function addEgress(remoteID, remoteRefID, loid) {

--- a/packages/SwingSet/src/vats/comms/clist.js
+++ b/packages/SwingSet/src/vats/comms/clist.js
@@ -1,7 +1,7 @@
-import { makeInbound } from './clist-inbound';
-import { makeOutbound } from './clist-outbound';
-import { makeKernel } from './clist-kernel';
-import { makeIngressEgress } from './clist-xgress';
+import { makeInbound } from './clist-inbound.js';
+import { makeOutbound } from './clist-outbound.js';
+import { makeKernel } from './clist-kernel.js';
+import { makeIngressEgress } from './clist-xgress.js';
 
 // get-*: the entry must be present
 // add-*: the entry must not be present. add one.

--- a/packages/SwingSet/src/vats/comms/delivery.js
+++ b/packages/SwingSet/src/vats/comms/delivery.js
@@ -2,11 +2,11 @@
 /* eslint-disable no-use-before-define */
 
 import { assert, details as X } from '@agoric/assert';
-import { parseLocalSlot, insistLocalType } from './parseLocalSlots';
-import { makeUndeliverableError } from '../../makeUndeliverableError';
-import { insistCapData } from '../../capdata';
-import { insistRemoteType } from './parseRemoteSlot';
-import { insistRemoteID } from './remote';
+import { parseLocalSlot, insistLocalType } from './parseLocalSlots.js';
+import { makeUndeliverableError } from '../../makeUndeliverableError.js';
+import { insistCapData } from '../../capdata.js';
+import { insistRemoteType } from './parseRemoteSlot.js';
+import { insistRemoteID } from './remote.js';
 
 const UNDEFINED = harden({
   body: JSON.stringify({ '@qclass': 'undefined' }),

--- a/packages/SwingSet/src/vats/comms/dispatch.js
+++ b/packages/SwingSet/src/vats/comms/dispatch.js
@@ -1,13 +1,17 @@
 import { assert, details as X } from '@agoric/assert';
-import { makeVatSlot, insistVatType, parseVatSlot } from '../../parseVatSlots';
-import { insistMessage } from '../../message';
-import { makeState } from './state';
-import { deliverToController } from './controller';
-import { insistCapData } from '../../capdata';
+import {
+  makeVatSlot,
+  insistVatType,
+  parseVatSlot,
+} from '../../parseVatSlots.js';
+import { insistMessage } from '../../message.js';
+import { makeState } from './state.js';
+import { deliverToController } from './controller.js';
+import { insistCapData } from '../../capdata.js';
 
-import { makeCListKit } from './clist';
-import { makeDeliveryKit } from './delivery';
-import { cdebug } from './cdebug';
+import { makeCListKit } from './clist.js';
+import { makeDeliveryKit } from './delivery.js';
+import { cdebug } from './cdebug.js';
 
 export const debugState = new WeakMap();
 

--- a/packages/SwingSet/src/vats/comms/index.js
+++ b/packages/SwingSet/src/vats/comms/index.js
@@ -1,3 +1,3 @@
-import { buildCommsDispatch } from './dispatch';
+import { buildCommsDispatch } from './dispatch.js';
 
 export default buildCommsDispatch;

--- a/packages/SwingSet/src/vats/comms/remote.js
+++ b/packages/SwingSet/src/vats/comms/remote.js
@@ -1,6 +1,6 @@
 import { Nat } from '@agoric/nat';
 import { assert, details as X } from '@agoric/assert';
-import { makeRemoteSlot, flipRemoteSlot } from './parseRemoteSlot';
+import { makeRemoteSlot, flipRemoteSlot } from './parseRemoteSlot.js';
 
 export function insistRemoteID(remoteID) {
   assert(/^r\d+$/.test(remoteID), X`not a remoteID: ${remoteID}`);

--- a/packages/SwingSet/src/vats/comms/state.js
+++ b/packages/SwingSet/src/vats/comms/state.js
@@ -1,10 +1,10 @@
 import { Nat } from '@agoric/nat';
 import { assert, details as X } from '@agoric/assert';
-import { insistCapData } from '../../capdata';
-import { makeVatSlot, insistVatType } from '../../parseVatSlots';
-import { makeLocalSlot, parseLocalSlot } from './parseLocalSlots';
-import { initializeRemoteState, makeRemote, insistRemoteID } from './remote';
-import { cdebug } from './cdebug';
+import { insistCapData } from '../../capdata.js';
+import { makeVatSlot, insistVatType } from '../../parseVatSlots.js';
+import { makeLocalSlot, parseLocalSlot } from './parseLocalSlots.js';
+import { initializeRemoteState, makeRemote, insistRemoteID } from './remote.js';
+import { cdebug } from './cdebug.js';
 
 const COMMS = 'comms';
 const KERNEL = 'kernel';

--- a/packages/SwingSet/src/vats/network/bytes.js
+++ b/packages/SwingSet/src/vats/network/bytes.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import './types';
+import './types.js';
 import { encodeBase64, decodeBase64 } from '@endo/base64';
 
 /* eslint-disable no-bitwise */

--- a/packages/SwingSet/src/vats/network/index.js
+++ b/packages/SwingSet/src/vats/network/index.js
@@ -1,4 +1,4 @@
-export * from './network';
-export { default as makeRouter } from './router';
-export * from './multiaddr';
-export * from './bytes';
+export * from './network.js';
+export { default as makeRouter } from './router.js';
+export * from './multiaddr.js';
+export * from './bytes.js';

--- a/packages/SwingSet/src/vats/network/network.js
+++ b/packages/SwingSet/src/vats/network/network.js
@@ -5,11 +5,11 @@ import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 import { makePromiseKit } from '@agoric/promise-kit';
 import { assert, details as X } from '@agoric/assert';
-import { toBytes } from './bytes';
+import { toBytes } from './bytes.js';
 
-import '@agoric/store/exported';
-import './types';
-import './internal-types';
+import '@agoric/store/exported.js';
+import './types.js';
+import './internal-types.js';
 
 /**
  * Compatibility note: this must match what our peers use,

--- a/packages/SwingSet/src/vats/network/router.js
+++ b/packages/SwingSet/src/vats/network/router.js
@@ -4,11 +4,11 @@ import { E as defaultE } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 import makeStore from '@agoric/store';
 import { assert, details as X } from '@agoric/assert';
-import { makeNetworkProtocol, ENDPOINT_SEPARATOR } from './network';
+import { makeNetworkProtocol, ENDPOINT_SEPARATOR } from './network.js';
 
-import '@agoric/store/exported';
-import './types';
-import './internal-types';
+import '@agoric/store/exported.js';
+import './types.js';
+import './internal-types.js';
 
 /**
  * @typedef {Object} Router A delimited string router implementation

--- a/packages/SwingSet/src/vats/plugin-manager.js
+++ b/packages/SwingSet/src/vats/plugin-manager.js
@@ -6,7 +6,7 @@ import { makePromiseKit } from '@agoric/promise-kit';
 import { E, HandledPromise } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 
-import '@agoric/store/exported';
+import '@agoric/store/exported.js';
 
 /**
  * @template T

--- a/packages/SwingSet/test/basedir-message-patterns/vat-a.js
+++ b/packages/SwingSet/test/basedir-message-patterns/vat-a.js
@@ -1,5 +1,5 @@
 import { Far } from '@agoric/marshal';
-import { buildPatterns } from '../message-patterns';
+import { buildPatterns } from '../message-patterns.js';
 
 export function buildRootObject(vatPowers) {
   const amy = Far('amy', {});

--- a/packages/SwingSet/test/basedir-message-patterns/vat-b.js
+++ b/packages/SwingSet/test/basedir-message-patterns/vat-b.js
@@ -1,5 +1,5 @@
 import { Far } from '@agoric/marshal';
-import { buildPatterns } from '../message-patterns';
+import { buildPatterns } from '../message-patterns.js';
 
 export function buildRootObject(vatPowers) {
   const bert = Far('bert', {

--- a/packages/SwingSet/test/basedir-message-patterns/vat-c.js
+++ b/packages/SwingSet/test/basedir-message-patterns/vat-c.js
@@ -1,5 +1,5 @@
 import { Far } from '@agoric/marshal';
-import { buildPatterns } from '../message-patterns';
+import { buildPatterns } from '../message-patterns.js';
 
 export function buildRootObject(vatPowers) {
   const root = Far('root', {

--- a/packages/SwingSet/test/commsVatDriver.js
+++ b/packages/SwingSet/test/commsVatDriver.js
@@ -1,8 +1,8 @@
 import { assert, details as X } from '@agoric/assert';
-import buildCommsDispatch from '../src/vats/comms';
-import { debugState } from '../src/vats/comms/dispatch';
-import { flipRemoteSlot } from '../src/vats/comms/parseRemoteSlot';
-import { makeMessage, makeResolutions } from './util';
+import buildCommsDispatch from '../src/vats/comms/index.js';
+import { debugState } from '../src/vats/comms/dispatch.js';
+import { flipRemoteSlot } from '../src/vats/comms/parseRemoteSlot.js';
+import { makeMessage, makeResolutions } from './util.js';
 
 // This module provides a power tool for testing the comms vat implementation.
 // It provides support for injecting events into the comms vat and observing

--- a/packages/SwingSet/test/definition/test-vat-definition.js
+++ b/packages/SwingSet/test/definition/test-vat-definition.js
@@ -1,7 +1,7 @@
 /* global require */
-import { test } from '../../tools/prepare-test-env-ava';
+import { test } from '../../tools/prepare-test-env-ava.js';
 
-import { buildVatController } from '../../src/index';
+import { buildVatController } from '../../src/index.js';
 
 const mUndefined = { '@qclass': 'undefined' };
 

--- a/packages/SwingSet/test/device-plugin/bootstrap.js
+++ b/packages/SwingSet/test/device-plugin/bootstrap.js
@@ -1,7 +1,7 @@
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
-import { makePluginManager } from '../../src/vats/plugin-manager';
+import { makePluginManager } from '../../src/vats/plugin-manager.js';
 
 export function buildRootObject(vatPowers, vatParameters) {
   const { D } = vatPowers;

--- a/packages/SwingSet/test/device-plugin/test-device.js
+++ b/packages/SwingSet/test/device-plugin/test-device.js
@@ -1,16 +1,16 @@
 /* global require __dirname */
-import { test } from '../../tools/prepare-test-env-ava';
+import { test } from '../../tools/prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
-import { provideHostStorage } from '../../src/hostStorage';
+import { provideHostStorage } from '../../src/hostStorage.js';
 
 import {
   swingsetIsInitialized,
   initializeSwingset,
   makeSwingsetController,
-} from '../../src/index';
-import { buildBridge } from '../../src/devices/bridge';
-import { buildPlugin } from '../../src/devices/plugin';
+} from '../../src/index.js';
+import { buildBridge } from '../../src/devices/bridge.js';
+import { buildPlugin } from '../../src/devices/plugin.js';
 
 test.before('initialize storage', t => {
   t.context.hostStorage = provideHostStorage();

--- a/packages/SwingSet/test/files-devices/bootstrap-0.js
+++ b/packages/SwingSet/test/files-devices/bootstrap-0.js
@@ -1,4 +1,4 @@
-import { extractMessage } from '../util';
+import { extractMessage } from '../util.js';
 
 export default function setup(syscall, state, _helpers, vatPowers) {
   function dispatch(vatDeliverObject) {

--- a/packages/SwingSet/test/files-devices/bootstrap-1.js
+++ b/packages/SwingSet/test/files-devices/bootstrap-1.js
@@ -1,5 +1,5 @@
 import { assert, details as X } from '@agoric/assert';
-import { extractMessage } from '../util';
+import { extractMessage } from '../util.js';
 
 export default function setup(syscall, state, _helpers, vatPowers) {
   const { testLog } = vatPowers;

--- a/packages/SwingSet/test/files-devices/bootstrap-4.js
+++ b/packages/SwingSet/test/files-devices/bootstrap-4.js
@@ -1,7 +1,7 @@
 import { assert } from '@agoric/assert';
 import { QCLASS } from '@agoric/marshal';
-import { insistVatType } from '../../src/parseVatSlots';
-import { extractMessage } from '../util';
+import { insistVatType } from '../../src/parseVatSlots.js';
+import { extractMessage } from '../util.js';
 
 // to exercise the error we get when syscall.callNow() is given a promise
 // identifier, we must bypass liveslots, which would otherwise protect us

--- a/packages/SwingSet/test/liveslots-helpers.js
+++ b/packages/SwingSet/test/liveslots-helpers.js
@@ -1,9 +1,9 @@
-import engineGC from '../src/engine-gc';
+import engineGC from '../src/engine-gc.js';
 
-import { WeakRef, FinalizationRegistry } from '../src/weakref';
-import { waitUntilQuiescent } from '../src/waitUntilQuiescent';
-import { makeGcAndFinalize } from '../src/gc-and-finalize';
-import { makeLiveSlots } from '../src/kernel/liveSlots';
+import { WeakRef, FinalizationRegistry } from '../src/weakref.js';
+import { waitUntilQuiescent } from '../src/waitUntilQuiescent.js';
+import { makeGcAndFinalize } from '../src/gc-and-finalize.js';
+import { makeLiveSlots } from '../src/kernel/liveSlots.js';
 
 export function buildSyscall() {
   const log = [];

--- a/packages/SwingSet/test/message-patterns.js
+++ b/packages/SwingSet/test/message-patterns.js
@@ -7,7 +7,7 @@ import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
 import { quote as q } from '@agoric/assert';
 import { Far } from '@agoric/marshal';
-import { ignore } from './util';
+import { ignore } from './util.js';
 
 // Exercise a set of increasingly complex object-capability message patterns,
 // for testing.

--- a/packages/SwingSet/test/metering/grandchild.js
+++ b/packages/SwingSet/test/metering/grandchild.js
@@ -1,4 +1,4 @@
-import { meterMe } from './metered-code';
+import { meterMe } from './metered-code.js';
 
 export function meterThem(explode) {
   const log2 = [];

--- a/packages/SwingSet/test/metering/metered-dynamic-vat.js
+++ b/packages/SwingSet/test/metering/metered-dynamic-vat.js
@@ -2,7 +2,7 @@ import { assert } from '@agoric/assert';
 import { importBundle } from '@agoric/import-bundle';
 import { makePromiseKit } from '@agoric/promise-kit';
 import { Far } from '@agoric/marshal';
-import { meterMe } from './metered-code';
+import { meterMe } from './metered-code.js';
 
 export function buildRootObject(_dynamicVatPowers) {
   let grandchildNS;

--- a/packages/SwingSet/test/metering/test-dynamic-vat-metered.js
+++ b/packages/SwingSet/test/metering/test-dynamic-vat-metered.js
@@ -5,9 +5,9 @@ import '@agoric/babel-standalone';
 import '@agoric/install-metering-and-ses';
 import bundleSource from '@agoric/bundle-source';
 import test from 'ava';
-import { provideHostStorage } from '../../src/hostStorage';
-import { buildKernelBundles, buildVatController } from '../../src/index';
-import makeNextLog from '../make-nextlog';
+import { provideHostStorage } from '../../src/hostStorage.js';
+import { buildKernelBundles, buildVatController } from '../../src/index.js';
+import makeNextLog from '../make-nextlog.js';
 
 function capdata(body, slots = []) {
   return harden({ body, slots });

--- a/packages/SwingSet/test/metering/test-dynamic-vat-subcompartment.js
+++ b/packages/SwingSet/test/metering/test-dynamic-vat-subcompartment.js
@@ -5,8 +5,8 @@ import '@agoric/babel-standalone';
 import '@agoric/install-metering-and-ses';
 import bundleSource from '@agoric/bundle-source';
 import test from 'ava';
-import { buildVatController } from '../../src/index';
-import makeNextLog from '../make-nextlog';
+import { buildVatController } from '../../src/index.js';
+import makeNextLog from '../make-nextlog.js';
 
 function capdata(body, slots = []) {
   return harden({ body, slots });

--- a/packages/SwingSet/test/metering/test-dynamic-vat-unmetered.js
+++ b/packages/SwingSet/test/metering/test-dynamic-vat-unmetered.js
@@ -5,8 +5,8 @@ import '@agoric/babel-standalone';
 import '@agoric/install-metering-and-ses';
 import bundleSource from '@agoric/bundle-source';
 import test from 'ava';
-import { buildVatController } from '../../src/index';
-import makeNextLog from '../make-nextlog';
+import { buildVatController } from '../../src/index.js';
+import makeNextLog from '../make-nextlog.js';
 
 function capdata(body, slots = []) {
   return harden({ body, slots });

--- a/packages/SwingSet/test/metering/test-metering.js
+++ b/packages/SwingSet/test/metering/test-metering.js
@@ -1,6 +1,6 @@
 /* global require */
 // eslint-disable-next-line import/order
-import { replaceGlobalMeter } from './install-global-metering';
+import { replaceGlobalMeter } from './install-global-metering.js';
 // TODO Remove babel-standalone preinitialization
 // https://github.com/endojs/endo/issues/768
 import '@agoric/babel-standalone';
@@ -11,7 +11,7 @@ import { importBundle } from '@agoric/import-bundle';
 import { makeMeter, makeMeteringTransformer } from '@agoric/transform-metering';
 import re2 from 're2';
 import test from 'ava';
-import { waitUntilQuiescent } from '../../src/waitUntilQuiescent';
+import { waitUntilQuiescent } from '../../src/waitUntilQuiescent.js';
 
 // Run a function under the control of a meter. The function must not have
 // access to the timer queue (setImmediate or setInterval). Returns a Promise

--- a/packages/SwingSet/test/test-clist.js
+++ b/packages/SwingSet/test/test-clist.js
@@ -1,10 +1,10 @@
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
 import { initSimpleSwingStore } from '@agoric/swing-store-simple';
-import { makeDummySlogger } from '../src/kernel/slogger';
-import makeKernelKeeper from '../src/kernel/state/kernelKeeper';
-import { wrapStorage } from '../src/kernel/state/storageWrapper';
+import { makeDummySlogger } from '../src/kernel/slogger.js';
+import makeKernelKeeper from '../src/kernel/state/kernelKeeper.js';
+import { wrapStorage } from '../src/kernel/state/storageWrapper.js';
 
 test(`clist reachability`, async t => {
   const slog = makeDummySlogger({});

--- a/packages/SwingSet/test/test-comms.js
+++ b/packages/SwingSet/test/test-comms.js
@@ -1,17 +1,17 @@
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
-import buildCommsDispatch from '../src/vats/comms';
-import { flipRemoteSlot } from '../src/vats/comms/parseRemoteSlot';
-import { makeState } from '../src/vats/comms/state';
-import { makeCListKit } from '../src/vats/comms/clist';
-import { debugState } from '../src/vats/comms/dispatch';
+import buildCommsDispatch from '../src/vats/comms/index.js';
+import { flipRemoteSlot } from '../src/vats/comms/parseRemoteSlot.js';
+import { makeState } from '../src/vats/comms/state.js';
+import { makeCListKit } from '../src/vats/comms/clist.js';
+import { debugState } from '../src/vats/comms/dispatch.js';
 import {
   makeMessage,
   makeDropExports,
   makeRetireExports,
   makeRetireImports,
-} from './util';
-import { commsVatDriver } from './commsVatDriver';
+} from './util.js';
+import { commsVatDriver } from './commsVatDriver.js';
 
 test('provideRemoteForLocal', t => {
   const s = makeState(null, 0);

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -1,17 +1,17 @@
 /* global require __dirname */
 // eslint-disable-next-line import/order
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
 import path from 'path';
 import { spawn } from 'child_process';
-import { provideHostStorage } from '../src/hostStorage';
+import { provideHostStorage } from '../src/hostStorage.js';
 import {
   buildVatController,
   loadBasedir,
   initializeSwingset,
   makeSwingsetController,
-} from '../src/index';
-import { checkKT } from './util';
+} from '../src/index.js';
+import { checkKT } from './util.js';
 
 function capdata(body, slots = []) {
   return harden({ body, slots });

--- a/packages/SwingSet/test/test-demos-comms.js
+++ b/packages/SwingSet/test/test-demos-comms.js
@@ -1,15 +1,15 @@
 /* global __dirname */
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
 import path from 'path';
-import { provideHostStorage } from '../src/hostStorage';
-import { buildLoopbox } from '../src/devices/loopbox';
+import { provideHostStorage } from '../src/hostStorage.js';
+import { buildLoopbox } from '../src/devices/loopbox.js';
 import {
   loadBasedir,
   initializeSwingset,
   makeSwingsetController,
-} from '../src/index';
+} from '../src/index.js';
 
 async function main(basedir, argv) {
   const config = await loadBasedir(basedir);

--- a/packages/SwingSet/test/test-demos.js
+++ b/packages/SwingSet/test/test-demos.js
@@ -1,15 +1,15 @@
 /* global __dirname */
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
 import path from 'path';
-import { provideHostStorage } from '../src/hostStorage';
-import { buildLoopbox } from '../src/devices/loopbox';
+import { provideHostStorage } from '../src/hostStorage.js';
+import { buildLoopbox } from '../src/devices/loopbox.js';
 import {
   loadBasedir,
   initializeSwingset,
   makeSwingsetController,
-} from '../src/index';
+} from '../src/index.js';
 
 async function main(basedir, argv) {
   const config = await loadBasedir(basedir);

--- a/packages/SwingSet/test/test-device-bridge.js
+++ b/packages/SwingSet/test/test-device-bridge.js
@@ -1,14 +1,14 @@
 /* global require */
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
-import { provideHostStorage } from '../src/hostStorage';
+import { provideHostStorage } from '../src/hostStorage.js';
 
 import {
   initializeSwingset,
   makeSwingsetController,
   buildBridge,
-} from '../src/index';
+} from '../src/index.js';
 
 test('bridge device', async t => {
   const outboundLog = [];

--- a/packages/SwingSet/test/test-devices.js
+++ b/packages/SwingSet/test/test-devices.js
@@ -1,18 +1,18 @@
 /* global require */
 // eslint-disable-next-line import/order
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
 import bundleSource from '@agoric/bundle-source';
 import { getAllState } from '@agoric/swing-store-simple';
-import { provideHostStorage } from '../src/hostStorage';
+import { provideHostStorage } from '../src/hostStorage.js';
 
 import {
   initializeSwingset,
   makeSwingsetController,
   buildKernelBundles,
-} from '../src/index';
-import { buildMailboxStateMap, buildMailbox } from '../src/devices/mailbox';
-import buildCommand from '../src/devices/command';
+} from '../src/index.js';
+import { buildMailboxStateMap, buildMailbox } from '../src/devices/mailbox.js';
+import buildCommand from '../src/devices/command.js';
 
 function capdata(body, slots = []) {
   return harden({ body, slots });

--- a/packages/SwingSet/test/test-exomessages.js
+++ b/packages/SwingSet/test/test-exomessages.js
@@ -1,7 +1,7 @@
 /* global require */
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
-import { buildVatController } from '../src/index';
+import { buildVatController } from '../src/index.js';
 
 async function beginning(t, mode) {
   const config = {

--- a/packages/SwingSet/test/test-fake-weakref.js
+++ b/packages/SwingSet/test/test-fake-weakref.js
@@ -1,6 +1,6 @@
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
-import { WeakRef, FinalizationRegistry } from '../src/weakref';
+import { WeakRef, FinalizationRegistry } from '../src/weakref.js';
 
 // We don't test that WeakRefs actually work, we only make sure we can
 // interact with them without crashing. This exercises the fake no-op WeakRef

--- a/packages/SwingSet/test/test-gc-actions.js
+++ b/packages/SwingSet/test/test-gc-actions.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/order
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
-import { processNextGCAction } from '../src/kernel/gc-actions';
+import { processNextGCAction } from '../src/kernel/gc-actions.js';
 
 test('gc actions', t => {
   let rc = {};

--- a/packages/SwingSet/test/test-gc-and-finalize.js
+++ b/packages/SwingSet/test/test-gc-and-finalize.js
@@ -1,12 +1,12 @@
 /* global FinalizationRegistry WeakRef */
 // eslint-disable-next-line import/order
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
 import * as childProcess from 'child_process';
 import * as os from 'os';
 import { xsnap } from '@agoric/xsnap';
-import engineGC from '../src/engine-gc';
-import { makeGcAndFinalize } from '../src/gc-and-finalize';
+import engineGC from '../src/engine-gc.js';
+import { makeGcAndFinalize } from '../src/gc-and-finalize.js';
 
 function makeVictim() {
   const victim = { doomed: 'oh no' };

--- a/packages/SwingSet/test/test-gc-transcript.js
+++ b/packages/SwingSet/test/test-gc-transcript.js
@@ -1,8 +1,8 @@
 // eslint-disable-next-line import/order
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
-import { makeDummySlogger } from '../src/kernel/slogger';
-import { makeManagerKit } from '../src/kernel/vatManager/manager-helper';
+import { makeDummySlogger } from '../src/kernel/slogger.js';
+import { makeManagerKit } from '../src/kernel/vatManager/manager-helper.js';
 
 const m1 = ['message', { method: 'foo', args: { body: '', slots: [] } }];
 

--- a/packages/SwingSet/test/test-kernel.js
+++ b/packages/SwingSet/test/test-kernel.js
@@ -1,16 +1,16 @@
 // eslint-disable-next-line import/order
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
 import anylogger from 'anylogger';
 import { assert, details as X } from '@agoric/assert';
-import { WeakRef, FinalizationRegistry } from '../src/weakref';
-import { waitUntilQuiescent } from '../src/waitUntilQuiescent';
+import { WeakRef, FinalizationRegistry } from '../src/weakref.js';
+import { waitUntilQuiescent } from '../src/waitUntilQuiescent.js';
 
-import buildKernel from '../src/kernel/index';
-import { initializeKernel } from '../src/kernel/initializeKernel';
-import { makeVatSlot } from '../src/parseVatSlots';
-import { provideHostStorage } from '../src/hostStorage';
-import { checkKT, extractMessage } from './util';
+import buildKernel from '../src/kernel/index.js';
+import { initializeKernel } from '../src/kernel/initializeKernel.js';
+import { makeVatSlot } from '../src/parseVatSlots.js';
+import { provideHostStorage } from '../src/hostStorage.js';
+import { checkKT, extractMessage } from './util.js';
 
 function capdata(body, slots = []) {
   return harden({ body, slots });

--- a/packages/SwingSet/test/test-liveslots.js
+++ b/packages/SwingSet/test/test-liveslots.js
@@ -6,11 +6,11 @@ import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 import { makePromiseKit } from '@agoric/promise-kit';
 import { assert, details as X } from '@agoric/assert';
-import engineGC from '../src/engine-gc';
-import { waitUntilQuiescent } from '../src/waitUntilQuiescent';
-import { makeGcAndFinalize } from '../src/gc-and-finalize';
-import { makeLiveSlots } from '../src/kernel/liveSlots';
-import { buildSyscall, makeDispatch } from './liveslots-helpers';
+import engineGC from '../src/engine-gc.js';
+import { waitUntilQuiescent } from '../src/waitUntilQuiescent.js';
+import { makeGcAndFinalize } from '../src/gc-and-finalize.js';
+import { makeLiveSlots } from '../src/kernel/liveSlots.js';
+import { buildSyscall, makeDispatch } from './liveslots-helpers.js';
 import {
   capargs,
   capargsOneSlot,

--- a/packages/SwingSet/test/test-marshal.js
+++ b/packages/SwingSet/test/test-marshal.js
@@ -1,14 +1,14 @@
 /* global setImmediate */
 // eslint-disable-next-line import/order
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
 import { Far } from '@agoric/marshal';
 import { makePromiseKit } from '@agoric/promise-kit';
 
-import { WeakRef, FinalizationRegistry } from '../src/weakref';
-import { makeMarshaller } from '../src/kernel/liveSlots';
+import { WeakRef, FinalizationRegistry } from '../src/weakref.js';
+import { makeMarshaller } from '../src/kernel/liveSlots.js';
 
-import { buildVatController } from '../src/index';
+import { buildVatController } from '../src/index.js';
 
 const gcTools = harden({ WeakRef, FinalizationRegistry });
 

--- a/packages/SwingSet/test/test-message-patterns.js
+++ b/packages/SwingSet/test/test-message-patterns.js
@@ -6,22 +6,22 @@
 // `test.serial` does not yet seem compatible with ses-ava
 // See https://github.com/endojs/endo/issues/647
 // TODO restore
-// import { test } from '../tools/prepare-test-env-ava';
-import '../tools/prepare-test-env';
+// import { test } from '../tools/prepare-test-env-ava.js';
+import '../tools/prepare-test-env.js';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 
 import path from 'path';
 import bundleSource from '@agoric/bundle-source';
-import { provideHostStorage } from '../src/hostStorage';
+import { provideHostStorage } from '../src/hostStorage.js';
 import {
   initializeSwingset,
   makeSwingsetController,
   buildVatController,
   buildKernelBundles,
-} from '../src/index';
-import { buildLoopbox } from '../src/devices/loopbox';
-import { buildPatterns } from './message-patterns';
+} from '../src/index.js';
+import { buildLoopbox } from '../src/devices/loopbox.js';
+import { buildPatterns } from './message-patterns.js';
 
 // This exercises all the patterns in 'message-patterns.js' twice (once with
 // vatA/vatB connected directly through the kernel, and a second time with

--- a/packages/SwingSet/test/test-netstring.js
+++ b/packages/SwingSet/test/test-netstring.js
@@ -1,12 +1,12 @@
 /* global Buffer */
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
 import {
   encode,
   decode,
   netstringEncoderStream,
   netstringDecoderStream,
-} from '../src/netstring';
+} from '../src/netstring.js';
 
 const umlaut = 'ümlaut';
 const umlautBuffer = Buffer.from(umlaut, 'utf-8');

--- a/packages/SwingSet/test/test-network.js
+++ b/packages/SwingSet/test/test-network.js
@@ -1,4 +1,4 @@
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
 import { makePromiseKit } from '@agoric/promise-kit';
@@ -10,7 +10,7 @@ import {
   makeLoopbackProtocolHandler,
   makeNetworkProtocol,
   makeRouter,
-} from '../src/vats/network';
+} from '../src/vats/network/index.js';
 
 // eslint-disable-next-line no-constant-condition
 const log = false ? console.log : () => {};

--- a/packages/SwingSet/test/test-node-version.js
+++ b/packages/SwingSet/test/test-node-version.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line no-redeclare
 /* global process */
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
 import semver from 'semver';

--- a/packages/SwingSet/test/test-promises.js
+++ b/packages/SwingSet/test/test-promises.js
@@ -1,5 +1,5 @@
 /* global __dirname */
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
 import path from 'path';
@@ -7,8 +7,8 @@ import {
   buildVatController,
   loadBasedir,
   buildKernelBundles,
-} from '../src/index';
-import { capargs } from './util';
+} from '../src/index.js';
+import { capargs } from './util.js';
 
 test.before(async t => {
   const kernelBundles = await buildKernelBundles();

--- a/packages/SwingSet/test/test-queue-priority.js
+++ b/packages/SwingSet/test/test-queue-priority.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line no-redeclare
 /* global setImmediate setTimeout */
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
 test('Promise queue should be higher priority than IO/timer queue', async t => {
   const log = [];

--- a/packages/SwingSet/test/test-state.js
+++ b/packages/SwingSet/test/test-state.js
@@ -1,4 +1,4 @@
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
 import {
@@ -6,14 +6,14 @@ import {
   getAllState,
   setAllState,
 } from '@agoric/swing-store-simple';
-import { buildHostDBInMemory } from '../src/hostStorage';
-import { buildBlockBuffer } from '../src/blockBuffer';
-import makeKernelKeeper from '../src/kernel/state/kernelKeeper';
+import { buildHostDBInMemory } from '../src/hostStorage.js';
+import { buildBlockBuffer } from '../src/blockBuffer.js';
+import makeKernelKeeper from '../src/kernel/state/kernelKeeper.js';
 import {
   buildCrankBuffer,
   addHelpers,
   wrapStorage,
-} from '../src/kernel/state/storageWrapper';
+} from '../src/kernel/state/storageWrapper.js';
 
 function checkState(t, getState, expected) {
   const state = getState();

--- a/packages/SwingSet/test/test-syscall-failure.js
+++ b/packages/SwingSet/test/test-syscall-failure.js
@@ -1,9 +1,9 @@
 /* global require */
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
-import { provideHostStorage } from '../src/hostStorage';
-import { buildVatController } from '../src';
+import { provideHostStorage } from '../src/hostStorage.js';
+import { buildVatController } from '../src/index.js';
 
 async function vatSyscallFailure(t, beDynamic) {
   const config = {

--- a/packages/SwingSet/test/test-timer-device.js
+++ b/packages/SwingSet/test/test-timer-device.js
@@ -1,6 +1,6 @@
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
-import { makeTimerMap, curryPollFn } from '../src/devices/timer-src';
+import { makeTimerMap, curryPollFn } from '../src/devices/timer-src.js';
 
 test('multiMap multi store', t => {
   const mm = makeTimerMap();

--- a/packages/SwingSet/test/test-transcript-light.js
+++ b/packages/SwingSet/test/test-transcript-light.js
@@ -1,11 +1,11 @@
 /* global __dirname */
 // eslint-disable-next-line import/order
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
 import path from 'path';
 import { getAllState, setAllState } from '@agoric/swing-store-simple';
-import { provideHostStorage } from '../src/hostStorage';
-import { buildVatController, loadBasedir } from '../src/index';
+import { provideHostStorage } from '../src/hostStorage.js';
+import { buildVatController, loadBasedir } from '../src/index.js';
 
 test('transcript-light load', async t => {
   const config = await loadBasedir(

--- a/packages/SwingSet/test/test-transcript.js
+++ b/packages/SwingSet/test/test-transcript.js
@@ -1,12 +1,12 @@
 /* global __dirname */
 // eslint-disable-next-line import/order
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
 import path from 'path';
 // import fs from 'fs';
 import { getAllState, setAllState } from '@agoric/swing-store-simple';
-import { provideHostStorage } from '../src/hostStorage';
-import { buildVatController, loadBasedir } from '../src/index';
+import { provideHostStorage } from '../src/hostStorage.js';
+import { buildVatController, loadBasedir } from '../src/index.js';
 
 async function buildTrace(c, storage) {
   const states = [];

--- a/packages/SwingSet/test/test-transcriptlessness.js
+++ b/packages/SwingSet/test/test-transcriptlessness.js
@@ -1,9 +1,9 @@
 /* global require */
 // eslint-disable-next-line import/order
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
-import { provideHostStorage } from '../src/hostStorage';
-import { buildVatController } from '../src/index';
+import { provideHostStorage } from '../src/hostStorage.js';
+import { buildVatController } from '../src/index.js';
 import { capargs } from './util.js';
 
 async function testTranscriptlessness(t, useTranscript) {

--- a/packages/SwingSet/test/test-vat-env.js
+++ b/packages/SwingSet/test/test-vat-env.js
@@ -1,4 +1,4 @@
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
 import { Far } from '@agoric/marshal';

--- a/packages/SwingSet/test/test-vatstore.js
+++ b/packages/SwingSet/test/test-vatstore.js
@@ -1,9 +1,9 @@
 /* global require */
 // eslint-disable-next-line import/order
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
-import { provideHostStorage } from '../src/hostStorage';
-import { buildVatController } from '../src/index';
+import { provideHostStorage } from '../src/hostStorage.js';
+import { buildVatController } from '../src/index.js';
 import { capargs } from './util.js';
 
 test('vatstore', async t => {

--- a/packages/SwingSet/test/test-vattp.js
+++ b/packages/SwingSet/test/test-vattp.js
@@ -1,10 +1,10 @@
 /* global require */
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
-import { provideHostStorage } from '../src/hostStorage';
-import { initializeSwingset, makeSwingsetController } from '../src/index';
-import { buildMailboxStateMap, buildMailbox } from '../src/devices/mailbox';
+import { provideHostStorage } from '../src/hostStorage.js';
+import { initializeSwingset, makeSwingsetController } from '../src/index.js';
+import { buildMailboxStateMap, buildMailbox } from '../src/devices/mailbox.js';
 
 test('vattp', async t => {
   const s = buildMailboxStateMap();

--- a/packages/SwingSet/test/test-vpid-kernel.js
+++ b/packages/SwingSet/test/test-vpid-kernel.js
@@ -1,16 +1,16 @@
 // eslint-disable-next-line import/order
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
 import anylogger from 'anylogger';
 import { assert, details as X } from '@agoric/assert';
-import { WeakRef, FinalizationRegistry } from '../src/weakref';
-import { waitUntilQuiescent } from '../src/waitUntilQuiescent';
-import { provideHostStorage } from '../src/hostStorage';
+import { WeakRef, FinalizationRegistry } from '../src/weakref.js';
+import { waitUntilQuiescent } from '../src/waitUntilQuiescent.js';
+import { provideHostStorage } from '../src/hostStorage.js';
 
-import buildKernel from '../src/kernel/index';
-import { initializeKernel } from '../src/kernel/initializeKernel';
+import buildKernel from '../src/kernel/index.js';
+import { initializeKernel } from '../src/kernel/initializeKernel.js';
 
-import { buildDispatch } from './util';
+import { buildDispatch } from './util.js';
 
 function capdata(body, slots = []) {
   return harden({ body, slots });

--- a/packages/SwingSet/test/test-vpid-liveslots.js
+++ b/packages/SwingSet/test/test-vpid-liveslots.js
@@ -1,12 +1,12 @@
 // eslint-disable-next-line import/order
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
 import { assert, details as X } from '@agoric/assert';
 import { Far } from '@agoric/marshal';
-import { buildSyscall, makeDispatch } from './liveslots-helpers';
-import { makeMessage, makeResolve, makeReject, capargs } from './util';
+import { buildSyscall, makeDispatch } from './liveslots-helpers.js';
+import { makeMessage, makeResolve, makeReject, capargs } from './util.js';
 
 function hush(p) {
   p.then(

--- a/packages/SwingSet/test/test-worker-protocol.js
+++ b/packages/SwingSet/test/test-worker-protocol.js
@@ -1,12 +1,15 @@
 /* global Buffer */
-import { test } from '../tools/prepare-test-env-ava';
+import { test } from '../tools/prepare-test-env-ava.js';
 
-import { arrayEncoderStream, arrayDecoderStream } from '../src/worker-protocol';
+import {
+  arrayEncoderStream,
+  arrayDecoderStream,
+} from '../src/worker-protocol.js';
 import {
   encode,
   netstringEncoderStream,
   netstringDecoderStream,
-} from '../src/netstring';
+} from '../src/netstring.js';
 
 test('arrayEncoderStream', async t => {
   const e = arrayEncoderStream();

--- a/packages/SwingSet/test/timer-device/device-timer.js
+++ b/packages/SwingSet/test/timer-device/device-timer.js
@@ -1,3 +1,3 @@
-import setup from '../../src/devices/timer-src';
+import setup from '../../src/devices/timer-src.js';
 
 export { setup };

--- a/packages/SwingSet/test/timer-device/test-device.js
+++ b/packages/SwingSet/test/timer-device/test-device.js
@@ -1,13 +1,13 @@
 /* global require */
-import { test } from '../../tools/prepare-test-env-ava';
+import { test } from '../../tools/prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
-import { provideHostStorage } from '../../src/hostStorage';
+import { provideHostStorage } from '../../src/hostStorage.js';
 
-import { initializeSwingset, makeSwingsetController } from '../../src/index';
-import { buildTimer } from '../../src/devices/timer';
+import { initializeSwingset, makeSwingsetController } from '../../src/index.js';
+import { buildTimer } from '../../src/devices/timer.js';
 
-const TimerSrc = require.resolve('../../src/devices/timer-src');
+const TimerSrc = require.resolve('../../src/devices/timer-src.js');
 
 const timerConfig = {
   bootstrap: 'bootstrap',

--- a/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
+++ b/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
@@ -6,7 +6,7 @@ import '@agoric/install-ses';
 import path from 'path';
 import test from 'ava';
 import { getAllState, setAllState } from '@agoric/swing-store-simple';
-import { provideHostStorage } from '../../../src/hostStorage';
+import { provideHostStorage } from '../../../src/hostStorage.js';
 
 import {
   buildVatController,

--- a/packages/SwingSet/test/vat-admin/test-innerVat.js
+++ b/packages/SwingSet/test/vat-admin/test-innerVat.js
@@ -6,7 +6,11 @@ import '@agoric/install-metering-and-ses';
 import path from 'path';
 import test from 'ava';
 import bundleSource from '@agoric/bundle-source';
-import { buildKernelBundles, buildVatController, loadBasedir } from '../../src';
+import {
+  buildKernelBundles,
+  buildVatController,
+  loadBasedir,
+} from '../../src/index.js';
 
 function nonBundleFunction(_E) {
   return {};

--- a/packages/SwingSet/test/vat-admin/test-replay.js
+++ b/packages/SwingSet/test/vat-admin/test-replay.js
@@ -7,8 +7,8 @@ import path from 'path';
 import test from 'ava';
 import bundleSource from '@agoric/bundle-source';
 import { getAllState, setAllState } from '@agoric/swing-store-simple';
-import { provideHostStorage } from '../../src/hostStorage';
-import { buildKernelBundles, buildVatController } from '../../src';
+import { provideHostStorage } from '../../src/hostStorage.js';
+import { buildKernelBundles, buildVatController } from '../../src/index.js';
 
 function capdata(body, slots = []) {
   return harden({ body, slots });

--- a/packages/SwingSet/test/vat-syscall-failure.js
+++ b/packages/SwingSet/test/vat-syscall-failure.js
@@ -1,4 +1,4 @@
-import { extractMessage } from './util';
+import { extractMessage } from './util.js';
 
 function capdata(body, slots = []) {
   return harden({ body, slots });

--- a/packages/SwingSet/test/virtualObjects/test-reachable-vrefs.js
+++ b/packages/SwingSet/test/virtualObjects/test-reachable-vrefs.js
@@ -1,10 +1,10 @@
-import { test } from '../../tools/prepare-test-env-ava';
+import { test } from '../../tools/prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
 import { Far, Remotable } from '@agoric/marshal';
 
-import { makeVatSlot } from '../../src/parseVatSlots';
-import { makeFakeVirtualObjectManager } from '../../tools/fakeVirtualObjectManager';
+import { makeVatSlot } from '../../src/parseVatSlots.js';
+import { makeFakeVirtualObjectManager } from '../../tools/fakeVirtualObjectManager.js';
 
 // empty object, used as makeWeakStore() key
 function makeKeyInstance(_state) {

--- a/packages/SwingSet/test/virtualObjects/test-representatives.js
+++ b/packages/SwingSet/test/virtualObjects/test-representatives.js
@@ -1,16 +1,16 @@
 /* global __dirname */
-import { test } from '../../tools/prepare-test-env-ava';
+import { test } from '../../tools/prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
 import path from 'path';
 
-import { provideHostStorage } from '../../src/hostStorage';
+import { provideHostStorage } from '../../src/hostStorage.js';
 import {
   buildVatController,
   initializeSwingset,
   makeSwingsetController,
-} from '../../src/index';
-import makeNextLog from '../make-nextlog';
+} from '../../src/index.js';
+import makeNextLog from '../make-nextlog.js';
 
 function capdata(body, slots = []) {
   return harden({ body, slots });

--- a/packages/SwingSet/test/virtualObjects/test-retain-remotable.js
+++ b/packages/SwingSet/test/virtualObjects/test-retain-remotable.js
@@ -1,12 +1,12 @@
 /* global WeakRef */
-import { test } from '../../tools/prepare-test-env-ava';
+import { test } from '../../tools/prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
 import { Far } from '@agoric/marshal';
 
-import engineGC from '../../src/engine-gc';
-import { makeGcAndFinalize } from '../../src/gc-and-finalize';
-import { makeFakeVirtualObjectManager } from '../../tools/fakeVirtualObjectManager';
+import engineGC from '../../src/engine-gc.js';
+import { makeGcAndFinalize } from '../../src/gc-and-finalize.js';
+import { makeFakeVirtualObjectManager } from '../../tools/fakeVirtualObjectManager.js';
 
 // empty object, used as makeWeakStore() key
 function makeKeyInstance(_state) {

--- a/packages/SwingSet/test/virtualObjects/test-virtualObjectCache.js
+++ b/packages/SwingSet/test/virtualObjects/test-virtualObjectCache.js
@@ -1,6 +1,6 @@
-import { test } from '../../tools/prepare-test-env-ava';
+import { test } from '../../tools/prepare-test-env-ava.js';
 
-import { makeCache } from '../../src/kernel/virtualObjectManager';
+import { makeCache } from '../../src/kernel/virtualObjectManager.js';
 
 function makeFakeStore() {
   const backing = new Map();

--- a/packages/SwingSet/test/virtualObjects/test-virtualObjectManager.js
+++ b/packages/SwingSet/test/virtualObjects/test-virtualObjectManager.js
@@ -1,8 +1,8 @@
-import { test } from '../../tools/prepare-test-env-ava';
+import { test } from '../../tools/prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
 import { Far } from '@agoric/marshal';
-import { makeFakeVirtualObjectManager } from '../../tools/fakeVirtualObjectManager';
+import { makeFakeVirtualObjectManager } from '../../tools/fakeVirtualObjectManager.js';
 
 function capdata(body, slots = []) {
   return harden({ body, slots });

--- a/packages/SwingSet/test/virtualObjects/test-weakcollections.js
+++ b/packages/SwingSet/test/virtualObjects/test-weakcollections.js
@@ -1,14 +1,14 @@
 /* global __dirname */
-import { test } from '../../tools/prepare-test-env-ava';
+import { test } from '../../tools/prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
 import path from 'path';
 
-import engineGC from '../../src/engine-gc';
-import { provideHostStorage } from '../../src/hostStorage';
-import { initializeSwingset, makeSwingsetController } from '../../src/index';
-import { makeFakeVirtualObjectManager } from '../../tools/fakeVirtualObjectManager';
-import makeNextLog from '../make-nextlog';
+import engineGC from '../../src/engine-gc.js';
+import { provideHostStorage } from '../../src/hostStorage.js';
+import { initializeSwingset, makeSwingsetController } from '../../src/index.js';
+import { makeFakeVirtualObjectManager } from '../../tools/fakeVirtualObjectManager.js';
+import makeNextLog from '../make-nextlog.js';
 
 function capdata(body, slots = []) {
   return harden({ body, slots });

--- a/packages/SwingSet/test/warehouse/test-warehouse.js
+++ b/packages/SwingSet/test/warehouse/test-warehouse.js
@@ -1,9 +1,9 @@
 /* global __dirname */
 // @ts-check
 
-import { test } from '../../tools/prepare-test-env-ava';
+import { test } from '../../tools/prepare-test-env-ava.js';
 
-import { loadBasedir, buildVatController } from '../../src/index';
+import { loadBasedir, buildVatController } from '../../src/index.js';
 
 async function makeController(managerType, maxVatsOnline) {
   const config = await loadBasedir(__dirname);

--- a/packages/SwingSet/test/workers/test-worker.js
+++ b/packages/SwingSet/test/workers/test-worker.js
@@ -1,7 +1,7 @@
 /* global require __dirname */
-import { test } from '../../tools/prepare-test-env-ava';
+import { test } from '../../tools/prepare-test-env-ava.js';
 
-import { loadBasedir, buildVatController } from '../../src/index';
+import { loadBasedir, buildVatController } from '../../src/index.js';
 
 const expected = [['B good', 'C good', 'F good', 'three good'], 'rp3 good'];
 

--- a/packages/SwingSet/tools/fakeVirtualObjectManager.js
+++ b/packages/SwingSet/tools/fakeVirtualObjectManager.js
@@ -1,9 +1,9 @@
 /* global WeakRef */
 import { makeMarshal } from '@agoric/marshal';
 import { assert } from '@agoric/assert';
-import { parseVatSlot } from '../src/parseVatSlots';
+import { parseVatSlot } from '../src/parseVatSlots.js';
 
-import { makeVirtualObjectManager } from '../src/kernel/virtualObjectManager';
+import { makeVirtualObjectManager } from '../src/kernel/virtualObjectManager.js';
 
 export function makeFakeVirtualObjectManager(options = {}) {
   const { cacheSize = 100, log, weak = false } = options;

--- a/packages/SwingSet/tools/install-ses-debug.js
+++ b/packages/SwingSet/tools/install-ses-debug.js
@@ -8,7 +8,7 @@
 // for more explanation of these lockdown options.
 
 import 'ses';
-import '@agoric/eventual-send/shim';
+import '@agoric/eventual-send/shim.js';
 // TODO Remove babel-standalone preinitialization
 // https://github.com/endojs/endo/issues/768
 import '@agoric/babel-standalone';

--- a/packages/SwingSet/tools/prepare-test-env-ava.js
+++ b/packages/SwingSet/tools/prepare-test-env-ava.js
@@ -15,7 +15,7 @@ import '@agoric/babel-standalone';
 //
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { wrapTest } from '@endo/ses-ava';
-import './prepare-test-env';
+import './prepare-test-env.js';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import rawTest from 'ava';
 

--- a/packages/SwingSet/tools/prepare-test-env.js
+++ b/packages/SwingSet/tools/prepare-test-env.js
@@ -10,7 +10,7 @@
 // https://github.com/endojs/endo/issues/768
 import '@agoric/babel-standalone';
 
-import './install-ses-debug';
+import './install-ses-debug.js';
 import { makeFakeVirtualObjectManager } from './fakeVirtualObjectManager';
 
 const { makeKind, makeWeakStore } = makeFakeVirtualObjectManager({

--- a/packages/bundle-source/demo/circular/a.js
+++ b/packages/bundle-source/demo/circular/a.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-cycle
-import { bar } from './b';
+import { bar } from './b.js';
 
 /**
  * @type {import('./b').Bar}

--- a/packages/bundle-source/demo/circular/b.js
+++ b/packages/bundle-source/demo/circular/b.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-cycle
-import { foo } from './a';
+import { foo } from './a.js';
 
 /*
  * --------->

--- a/packages/bundle-source/demo/dir1/index.js
+++ b/packages/bundle-source/demo/dir1/index.js
@@ -1,5 +1,5 @@
-import { encourage, makeError } from './encourage';
-import more from './sub/more';
+import { encourage, makeError } from './encourage.js';
+import more from './sub/more.js';
 
 export default function makeEncourager() {
   return harden({

--- a/packages/bundle-source/exported.js
+++ b/packages/bundle-source/exported.js
@@ -1,1 +1,1 @@
-import './src/types';
+import './src/types.js';

--- a/packages/bundle-source/src/index.js
+++ b/packages/bundle-source/src/index.js
@@ -12,7 +12,7 @@ import { encodeBase64 } from '@endo/base64';
 
 import { SourceMapConsumer } from 'source-map';
 
-import './types';
+import './types.js';
 
 const DEFAULT_MODULE_FORMAT = 'nestedEvaluate';
 const DEFAULT_FILE_PREFIX = '/bundled-source/...';

--- a/packages/bundle-source/test/sanity.js
+++ b/packages/bundle-source/test/sanity.js
@@ -5,7 +5,7 @@ import 'ses';
 import { decodeBase64 } from '@endo/base64';
 import { parseArchive } from '@endo/compartment-mapper/import-archive.js';
 import test from 'ava';
-import bundleSource from '..';
+import bundleSource from '../src/index.js';
 
 function evaluate(src, endowments) {
   const c = new Compartment(endowments, {}, {});

--- a/packages/bundle-source/test/test-bigint-transform.js
+++ b/packages/bundle-source/test/test-bigint-transform.js
@@ -4,7 +4,7 @@
 import '@agoric/babel-standalone';
 import '@agoric/install-ses';
 import test from 'ava';
-import bundleSource from '..';
+import bundleSource from '../src/index.js';
 
 test('bigint transform', async t => {
   const bundle = await bundleSource(`${__dirname}/../demo/bigint`, 'getExport');

--- a/packages/bundle-source/test/test-circular.js
+++ b/packages/bundle-source/test/test-circular.js
@@ -4,7 +4,7 @@
 import '@agoric/babel-standalone';
 import '@agoric/install-ses';
 import test from 'ava';
-import bundleSource from '..';
+import bundleSource from '../src/index.js';
 
 function evaluate(src, endowments) {
   const c = new Compartment(endowments, {}, {});

--- a/packages/bundle-source/test/test-comment.js
+++ b/packages/bundle-source/test/test-comment.js
@@ -6,7 +6,7 @@ import '@agoric/install-ses';
 import test from 'ava';
 import { decodeBase64 } from '@endo/base64';
 import { parseArchive } from '@endo/compartment-mapper/import-archive.js';
-import bundleSource from '..';
+import bundleSource from '../src/index.js';
 
 function evaluate(src, endowments) {
   const c = new Compartment(endowments, {}, {});

--- a/packages/bundle-source/test/test-explicit.js
+++ b/packages/bundle-source/test/test-explicit.js
@@ -7,7 +7,7 @@ import test from 'ava';
 import { rollup } from 'rollup';
 import { resolve as pathResolve } from 'path';
 import resolvePlugin from '@rollup/plugin-node-resolve';
-import bundleSource from '..';
+import bundleSource from '../src/index.js';
 
 test('explicit authority', async t => {
   const { moduleFormat } = await bundleSource(

--- a/packages/bundle-source/test/test-external-fs.js
+++ b/packages/bundle-source/test/test-external-fs.js
@@ -4,7 +4,7 @@
 import '@agoric/babel-standalone';
 import '@agoric/install-ses';
 import test from 'ava';
-import bundleSource from '..';
+import bundleSource from '../src/index.js';
 
 function evaluate(src, endowments) {
   const c = new Compartment(endowments, {}, {});

--- a/packages/bundle-source/test/test-sanity-unfiltered.js
+++ b/packages/bundle-source/test/test-sanity-unfiltered.js
@@ -1,4 +1,4 @@
 // Like test-sanity.js but with { stackFiltering: 'verbose' }
-import { makeSanityTests } from './sanity';
+import { makeSanityTests } from './sanity.js';
 
 makeSanityTests('verbose');

--- a/packages/bundle-source/test/test-sanity.js
+++ b/packages/bundle-source/test/test-sanity.js
@@ -1,5 +1,5 @@
 // Like test-sanity-unfiltered.js but with { stackFiltering: 'concise' }
-import { makeSanityTests } from './sanity';
+import { makeSanityTests } from './sanity.js';
 
 // 'concise' is currently the default. But the purpose of this
 // test is not to test what choice is the default. Since the behavior

--- a/packages/captp/lib/index.js
+++ b/packages/captp/lib/index.js
@@ -2,5 +2,5 @@ import { Nat } from '@agoric/nat';
 
 export * from '@agoric/marshal';
 
-export * from './captp';
+export * from './captp.js';
 export { Nat };

--- a/packages/captp/test/test-crosstalk.js
+++ b/packages/captp/test/test-crosstalk.js
@@ -1,7 +1,7 @@
 import '@agoric/install-ses';
 import { Far } from '@agoric/marshal';
 import test from 'ava';
-import { makeLoopback, E } from '../lib/captp';
+import { makeLoopback, E } from '../lib/captp.js';
 
 test('prevent crosstalk', async t => {
   const { makeFar } = makeLoopback('alice');

--- a/packages/captp/test/test-disco.js
+++ b/packages/captp/test/test-disco.js
@@ -1,7 +1,7 @@
 import '@agoric/install-ses';
 import { Far } from '@agoric/marshal';
 import test from 'ava';
-import { E, makeCapTP } from '../lib/captp';
+import { E, makeCapTP } from '../lib/captp.js';
 
 test('try disconnecting captp', async t => {
   const objs = [];

--- a/packages/captp/test/test-loopback.js
+++ b/packages/captp/test/test-loopback.js
@@ -2,7 +2,7 @@
 import '@agoric/install-ses';
 import { Far } from '@agoric/marshal';
 import test from 'ava';
-import { E, makeLoopback } from '../lib/captp';
+import { E, makeLoopback } from '../lib/captp.js';
 
 test('try loopback captp', async t => {
   const pr = {};

--- a/packages/eventual-send/integration-test/test/test-post-release.js
+++ b/packages/eventual-send/integration-test/test/test-post-release.js
@@ -1,4 +1,4 @@
-import testBundler from './utility/test-bundler';
+import testBundler from './utility/test-bundler.js';
 
 testBundler(
   'unpkg umd',

--- a/packages/eventual-send/integration-test/test/test-pre-release.js
+++ b/packages/eventual-send/integration-test/test/test-pre-release.js
@@ -1,4 +1,4 @@
-import testBundler from './utility/test-bundler';
+import testBundler from './utility/test-bundler.js';
 
 testBundler(
   'mock unpkg umd',

--- a/packages/eventual-send/shim.js
+++ b/packages/eventual-send/shim.js
@@ -1,5 +1,5 @@
 /* global globalThis */
-import { makeHandledPromise } from './src/index';
+import { makeHandledPromise } from './src/index.js';
 
 if (typeof HandledPromise === 'undefined') {
   globalThis.HandledPromise = makeHandledPromise();

--- a/packages/eventual-send/src/E.js
+++ b/packages/eventual-send/src/E.js
@@ -1,4 +1,4 @@
-import { trackTurns } from './track-turns';
+import { trackTurns } from './track-turns.js';
 
 // eslint-disable-next-line spaced-comment
 /// <reference path="index.d.ts" />

--- a/packages/eventual-send/src/index.js
+++ b/packages/eventual-send/src/index.js
@@ -1,4 +1,4 @@
-import { trackTurns } from './track-turns';
+import { trackTurns } from './track-turns.js';
 
 const {
   defineProperties,

--- a/packages/eventual-send/src/no-shim.js
+++ b/packages/eventual-send/src/no-shim.js
@@ -1,5 +1,5 @@
 /* global HandledPromise */
-import makeE from './E';
+import makeE from './E.js';
 
 const hp = HandledPromise;
 export const E = makeE(HandledPromise);

--- a/packages/eventual-send/test/get-hp.js
+++ b/packages/eventual-send/test/get-hp.js
@@ -1,5 +1,5 @@
-import makeE from '../src/E';
-import { makeHandledPromise } from '../src/index';
+import makeE from '../src/E.js';
+import { makeHandledPromise } from '../src/index.js';
 
 export const HandledPromise = makeHandledPromise(Promise);
 export const E = makeE(HandledPromise);

--- a/packages/eventual-send/test/test-deep-send.js
+++ b/packages/eventual-send/test/test-deep-send.js
@@ -3,9 +3,9 @@
 // deep stack looks like.
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
-import { E } from './get-hp';
+import { E } from './get-hp.js';
 
 const { freeze } = Object;
 

--- a/packages/eventual-send/test/test-deep-stacks.js
+++ b/packages/eventual-send/test/test-deep-stacks.js
@@ -3,9 +3,9 @@
 // deep stack looks like.
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
-import { E } from './get-hp';
+import { E } from './get-hp.js';
 
 test('deep-stacks when', t => {
   let r;

--- a/packages/eventual-send/test/test-e.js
+++ b/packages/eventual-send/test/test-e.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
-import { E, HandledPromise } from './get-hp';
+import { E, HandledPromise } from './get-hp.js';
 
 test('E reexports', async t => {
   t.is(E.resolve, HandledPromise.resolve, 'E reexports resolve');

--- a/packages/eventual-send/test/test-eventual-send.js
+++ b/packages/eventual-send/test/test-eventual-send.js
@@ -1,8 +1,8 @@
 /* global setTimeout */
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
-import { HandledPromise } from './get-hp';
+import { HandledPromise } from './get-hp.js';
 
 const { getPrototypeOf } = Object;
 const { details: X } = assert;

--- a/packages/eventual-send/test/test-hp.js
+++ b/packages/eventual-send/test/test-hp.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
-import { HandledPromise } from './get-hp';
+import { HandledPromise } from './get-hp.js';
 
 test('chained properties', async t => {
   const pr = {};

--- a/packages/eventual-send/test/test-proxy.js
+++ b/packages/eventual-send/test/test-proxy.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
-import { HandledPromise } from './get-hp';
+import { HandledPromise } from './get-hp.js';
 
 test('resolveWithPresence with proxy options', async t => {
   const l = t.log; // decomment this line for debug aid

--- a/packages/eventual-send/test/test-thenable.js
+++ b/packages/eventual-send/test/test-thenable.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
-import { E, HandledPromise } from './get-hp';
+import { E, HandledPromise } from './get-hp.js';
 
 test('E.resolve is always asynchronous', async t => {
   const p = new Promise(_ => {});

--- a/packages/import-bundle/src/index.js
+++ b/packages/import-bundle/src/index.js
@@ -1,7 +1,7 @@
 import { parseArchive } from '@endo/compartment-mapper/import-archive.js';
 import { decodeBase64 } from '@endo/base64';
 import { assert, details as X } from '@agoric/assert';
-import { wrapInescapableCompartment } from './compartment-wrapper';
+import { wrapInescapableCompartment } from './compartment-wrapper.js';
 
 // importBundle takes the output of bundle-source, and returns a namespace
 // object (with .default, and maybe other properties for named exports)

--- a/packages/import-bundle/test/test-compartment-wrapper.js
+++ b/packages/import-bundle/test/test-compartment-wrapper.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import { assert, details as X } from '@agoric/assert';
 import { wrapInescapableCompartment } from '../src/compartment-wrapper.js';

--- a/packages/install-ses/install-ses.js
+++ b/packages/install-ses/install-ses.js
@@ -3,7 +3,7 @@
 import 'ses';
 
 // Install our HandledPromise global.
-import '@agoric/eventual-send/shim';
+import '@agoric/eventual-send/shim.js';
 
 // For testing under Ava, and also sometimes for testing and debugging in
 // general, when safety is not needed, you perhaps want to use

--- a/packages/install-ses/test/test-install-ses.js
+++ b/packages/install-ses/test/test-install-ses.js
@@ -1,4 +1,4 @@
-import '../install-ses';
+import '../install-ses.js';
 import test from 'ava';
 
 test('globals are present', t => {

--- a/packages/marshal/exported.js
+++ b/packages/marshal/exported.js
@@ -1,1 +1,1 @@
-import './src/types';
+import './src/types.js';

--- a/packages/marshal/index.js
+++ b/packages/marshal/index.js
@@ -2,8 +2,14 @@ export {
   getInterfaceOf,
   getErrorConstructor,
   passStyleOf,
-} from './src/passStyleOf';
+} from './src/passStyleOf.js';
 
-export { pureCopy, QCLASS, makeMarshal, Remotable, Far } from './src/marshal';
+export {
+  pureCopy,
+  QCLASS,
+  makeMarshal,
+  Remotable,
+  Far,
+} from './src/marshal.js';
 
-export { stringify, parse } from './src/marshal-stringify';
+export { stringify, parse } from './src/marshal-stringify.js';

--- a/packages/marshal/src/marshal-justin.js
+++ b/packages/marshal/src/marshal-justin.js
@@ -5,10 +5,10 @@
 
 import { Nat } from '@agoric/nat';
 import { assert, details as X, q } from '@agoric/assert';
-import { getErrorConstructor } from './passStyleOf';
-import { QCLASS } from './marshal';
+import { getErrorConstructor } from './passStyleOf.js';
+import { QCLASS } from './marshal.js';
 
-import './types';
+import './types.js';
 
 const { ownKeys } = Reflect;
 

--- a/packages/marshal/src/marshal-stringify.js
+++ b/packages/marshal/src/marshal-stringify.js
@@ -1,9 +1,9 @@
 // @ts-check
 
 import { assert, details as X } from '@agoric/assert';
-import { makeMarshal } from './marshal';
+import { makeMarshal } from './marshal.js';
 
-import './types';
+import './types.js';
 
 /** @type {ConvertValToSlot<any>} */
 const doNotConvertValToSlot = val =>

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -12,9 +12,9 @@ import {
   getErrorConstructor,
   assertCanBeRemotable,
   assertIface,
-} from './passStyleOf';
+} from './passStyleOf.js';
 
-import './types';
+import './types.js';
 
 const {
   getPrototypeOf,

--- a/packages/marshal/src/passStyleOf.js
+++ b/packages/marshal/src/passStyleOf.js
@@ -6,8 +6,8 @@
 import { assert, details as X, q } from '@agoric/assert';
 import { isPromise } from '@agoric/promise-kit';
 
-import './types';
-import '@agoric/assert/exported';
+import './types.js';
+import '@agoric/assert/exported.js';
 
 // Setting this flag to true is what allows objects with `null` or
 // `Object.prototype` prototypes to be treated as remotable.  Setting to `false`

--- a/packages/marshal/test/test-marshal-justin.js
+++ b/packages/marshal/test/test-marshal-justin.js
@@ -1,8 +1,8 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import { makeMarshal, Remotable } from '../src/marshal';
-import { decodeToJustin } from '../src/marshal-justin';
+import { decodeToJustin } from '../src/marshal-justin.js';
 
 // this only includes the tests that do not use liveSlots
 

--- a/packages/marshal/test/test-marshal-stringify.js
+++ b/packages/marshal/test/test-marshal-stringify.js
@@ -1,9 +1,9 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
-import { Far } from '../src/marshal';
-import { stringify, parse } from '../src/marshal-stringify';
-import { roundTripPairs } from './test-marshal';
+import { Far } from '../src/marshal.js';
+import { stringify, parse } from '../src/marshal-stringify.js';
+import { roundTripPairs } from './test-marshal.js';
 
 const { isFrozen } = Object;
 

--- a/packages/marshal/test/test-marshal.js
+++ b/packages/marshal/test/test-marshal.js
@@ -1,9 +1,9 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
-import { getInterfaceOf, passStyleOf } from '../src/passStyleOf';
+import { getInterfaceOf, passStyleOf } from '../src/passStyleOf.js';
 
-import { Remotable, Far, makeMarshal } from '../src/marshal';
+import { Remotable, Far, makeMarshal } from '../src/marshal.js';
 
 const { freeze, isFrozen, create, prototype: objectPrototype } = Object;
 

--- a/packages/notifier/exported.js
+++ b/packages/notifier/exported.js
@@ -1,1 +1,1 @@
-import './src/types';
+import './src/types.js';

--- a/packages/notifier/exports.js
+++ b/packages/notifier/exports.js
@@ -1,5 +1,5 @@
 // TODO: Remove this file when all our clients are known to be updated.
-export * from './exported';
+export * from './exported.js';
 console.warn(
-  `DEPRECATION: '@agoric/notifier/exports' is deprecated in favour of '@agoric/notifier/exported'`,
+  `DEPRECATION: '@agoric/notifier/exports' is deprecated in favour of '@agoric/notifier/exported.js'`,
 );

--- a/packages/notifier/src/asyncIterableAdaptor.js
+++ b/packages/notifier/src/asyncIterableAdaptor.js
@@ -4,7 +4,7 @@
 
 import { E } from '@agoric/eventual-send';
 
-import './types';
+import './types.js';
 
 /**
  * Adaptor from a notifierP to an async iterable.

--- a/packages/notifier/src/index.js
+++ b/packages/notifier/src/index.js
@@ -2,8 +2,8 @@ export {
   makeNotifier,
   makeNotifierKit,
   makeNotifierFromAsyncIterable,
-} from './notifier';
-export { makeSubscription, makeSubscriptionKit } from './subscriber';
+} from './notifier.js';
+export { makeSubscription, makeSubscriptionKit } from './subscriber.js';
 export {
   observeNotifier,
   observeIterator,
@@ -13,4 +13,4 @@ export {
   updateFromNotifier,
   // Consider deprecating or not reexporting
   makeAsyncIterableFromNotifier,
-} from './asyncIterableAdaptor';
+} from './asyncIterableAdaptor.js';

--- a/packages/notifier/src/notifier.js
+++ b/packages/notifier/src/notifier.js
@@ -8,9 +8,9 @@ import { Far } from '@agoric/marshal';
 import {
   makeAsyncIterableFromNotifier,
   observeIteration,
-} from './asyncIterableAdaptor';
+} from './asyncIterableAdaptor.js';
 
-import './types';
+import './types.js';
 
 /**
  * @template T

--- a/packages/notifier/src/subscriber.js
+++ b/packages/notifier/src/subscriber.js
@@ -6,7 +6,7 @@ import { HandledPromise, E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 import { makePromiseKit } from '@agoric/promise-kit';
 
-import './types';
+import './types.js';
 
 /**
  * @template T

--- a/packages/notifier/test/iterable-testing-tools.js
+++ b/packages/notifier/test/iterable-testing-tools.js
@@ -2,10 +2,10 @@
 import '@agoric/install-ses';
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
-import { observeIteration, observeIterator } from '../src/index';
+import { observeIteration, observeIterator } from '../src/index.js';
 
-import '@agoric/marshal/exported';
-import '../src/types';
+import '@agoric/marshal/exported.js';
+import '../src/types.js';
 
 const obj = harden({});
 const unresP = new Promise(_ => {});

--- a/packages/notifier/test/map-unum.js
+++ b/packages/notifier/test/map-unum.js
@@ -13,7 +13,7 @@ import {
   makeNotifierKit,
   makeSubscriptionKit,
   observeIteration,
-} from '../src/index';
+} from '../src/index.js';
 
 export const makeMapLeader = initialEntries => {
   let m = new Map(initialEntries);

--- a/packages/notifier/test/test-notifier-adaptor.js
+++ b/packages/notifier/test/test-notifier-adaptor.js
@@ -1,13 +1,13 @@
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import {
   makeAsyncIterableFromNotifier,
   makeNotifierFromAsyncIterable,
   observeIteration,
   observeNotifier,
-} from '../src/index';
+} from '../src/index.js';
 import {
   finiteStream,
   explodingStream,
@@ -15,7 +15,7 @@ import {
   testManualConsumer,
   testAutoConsumer,
   makeTestIterationObserver,
-} from './iterable-testing-tools';
+} from './iterable-testing-tools.js';
 
 // /////////////// Self test the testing tools for consistency /////////////////
 

--- a/packages/notifier/test/test-notifier-examples.js
+++ b/packages/notifier/test/test-notifier-examples.js
@@ -2,10 +2,14 @@
 import '@agoric/install-ses';
 import { E } from '@agoric/eventual-send';
 import test from 'ava';
-import { observeIteration, makeNotifierKit, makeNotifier } from '../src/index';
-import { paula, alice, bob } from './iterable-testing-tools';
+import {
+  observeIteration,
+  makeNotifierKit,
+  makeNotifier,
+} from '../src/index.js';
+import { paula, alice, bob } from './iterable-testing-tools.js';
 
-import '../src/types';
+import '../src/types.js';
 
 const last = array => array[array.length - 1];
 

--- a/packages/notifier/test/test-notifier.js
+++ b/packages/notifier/test/test-notifier.js
@@ -2,9 +2,9 @@
 import '@agoric/install-ses';
 
 import test from 'ava';
-import { makeNotifierKit } from '../src/index';
+import { makeNotifierKit } from '../src/index.js';
 
-import '../src/types';
+import '../src/types.js';
 
 test('notifier - initial state', async t => {
   /** @type {NotifierRecord<1>} */

--- a/packages/notifier/test/test-subscriber-examples.js
+++ b/packages/notifier/test/test-subscriber-examples.js
@@ -6,10 +6,10 @@ import {
   observeIteration,
   makeSubscriptionKit,
   makeSubscription,
-} from '../src/index';
-import { paula, alice, bob, carol } from './iterable-testing-tools';
+} from '../src/index.js';
+import { paula, alice, bob, carol } from './iterable-testing-tools.js';
 
-import '../src/types';
+import '../src/types.js';
 
 test('subscription for-await-of success example', async t => {
   const { publication, subscription } = makeSubscriptionKit();

--- a/packages/store/exported.js
+++ b/packages/store/exported.js
@@ -1,1 +1,1 @@
-import './src/types';
+import './src/types.js';

--- a/packages/store/src/external/default.js
+++ b/packages/store/src/external/default.js
@@ -2,7 +2,7 @@
 
 // @ts-check
 
-import '../types';
-import { makeMemoryExternalStore } from './memory';
+import '../types.js';
+import { makeMemoryExternalStore } from './memory.js';
 
 export const makeExternalStore = makeMemoryExternalStore;

--- a/packages/store/src/external/hydrate.js
+++ b/packages/store/src/external/hydrate.js
@@ -1,9 +1,9 @@
 // @ts-check
 
-import '../types';
+import '../types.js';
 
-import { makeWeakStore } from '../weak-store';
-import { makeStore } from '../store';
+import { makeWeakStore } from '../weak-store.js';
+import { makeStore } from '../store.js';
 
 /**
  * @callback MakeBackingStore

--- a/packages/store/src/external/memory.js
+++ b/packages/store/src/external/memory.js
@@ -1,8 +1,8 @@
 // Copyright (C) 2019-20 Agoric, under Apache license 2.0
 
 // @ts-check
-import { makeWeakStore } from '../weak-store';
-import '../types';
+import { makeWeakStore } from '../weak-store.js';
+import '../types.js';
 
 /**
  * Create a completely in-memory "external" store.  This store will be

--- a/packages/store/src/index.js
+++ b/packages/store/src/index.js
@@ -1,8 +1,8 @@
-export { makeStore } from './store';
-export { makeWeakStore } from './weak-store';
-export { makeExternalStore } from './external/default';
-export { makeMemoryExternalStore } from './external/memory';
-export { makeHydrateExternalStoreMaker } from './external/hydrate';
+export { makeStore } from './store.js';
+export { makeWeakStore } from './weak-store.js';
+export { makeExternalStore } from './external/default.js';
+export { makeMemoryExternalStore } from './external/memory.js';
+export { makeHydrateExternalStoreMaker } from './external/hydrate.js';
 
 // Backward compatibility.
-export { makeStore as default } from './store';
+export { makeStore as default } from './store.js';

--- a/packages/store/src/store.js
+++ b/packages/store/src/store.js
@@ -3,7 +3,7 @@
 // @ts-check
 
 import { assert, details as X, q } from '@agoric/assert';
-import { isEmptyNonRemotableObject } from './helpers';
+import { isEmptyNonRemotableObject } from './helpers.js';
 
 /**
  * Distinguishes between adding a new key (init) and updating or

--- a/packages/store/src/weak-store.js
+++ b/packages/store/src/weak-store.js
@@ -3,8 +3,8 @@
 // @ts-check
 
 import { assert, details as X, q } from '@agoric/assert';
-import { isEmptyNonRemotableObject } from './helpers';
-import './types';
+import { isEmptyNonRemotableObject } from './helpers.js';
+import './types.js';
 
 /**
  * @template {Record<any, any>} K

--- a/packages/store/test/test-external-store.js
+++ b/packages/store/test/test-external-store.js
@@ -1,16 +1,16 @@
 // @ts-check
 /* eslint-disable no-use-before-define */
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import {
   makeStore,
   makeExternalStore,
   makeHydrateExternalStoreMaker,
   makeWeakStore,
-} from '../src/index';
+} from '../src/index.js';
 
-import '../src/types';
+import '../src/types.js';
 
 const moduleLevel = 'module-level';
 

--- a/packages/store/test/test-store.js
+++ b/packages/store/test/test-store.js
@@ -4,9 +4,9 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
 
 import { Far } from '@agoric/marshal';
-import { makeStore, makeWeakStore } from '../src/index';
-import { isEmptyNonRemotableObject } from '../src/helpers';
-import '../src/types';
+import { makeStore, makeWeakStore } from '../src/index.js';
+import { isEmptyNonRemotableObject } from '../src/helpers.js';
+import '../src/types.js';
 
 test('empty object check', t => {
   const f = isEmptyNonRemotableObject;

--- a/packages/swing-store-lmdb/test/test-state.js
+++ b/packages/swing-store-lmdb/test/test-state.js
@@ -12,7 +12,7 @@ import {
   initLMDBSwingStore,
   openLMDBSwingStore,
   isSwingStore,
-} from '../src/lmdbSwingStore';
+} from '../src/lmdbSwingStore.js';
 
 function testKVStore(t, store) {
   const kvStore = store.kvStore;

--- a/packages/swing-store-simple/test/test-state.js
+++ b/packages/swing-store-simple/test/test-state.js
@@ -1,7 +1,7 @@
 import '@agoric/install-ses';
 
 import test from 'ava';
-import { initSimpleSwingStore, getAllState } from '../src/simpleSwingStore';
+import { initSimpleSwingStore, getAllState } from '../src/simpleSwingStore.js';
 
 test('kvStore read/write', t => {
   const store = initSimpleSwingStore();

--- a/packages/tame-metering/package.json
+++ b/packages/tame-metering/package.json
@@ -2,9 +2,7 @@
   "name": "@agoric/tame-metering",
   "version": "1.3.9",
   "description": "tame-metering",
-  "parsers": {
-    "js": "mjs"
-  },
+  "type": "module",
   "main": "src/index.js",
   "scripts": {
     "test": "ava",
@@ -12,9 +10,6 @@
     "lint-fix": "eslint --fix '**/*.{js,jsx}'",
     "lint-check": "eslint '**/*.{js,jsx}'",
     "build": "exit 0"
-  },
-  "dependencies": {
-    "esm": "agoric-labs/esm#Agoric-built"
   },
   "devDependencies": {
     "ava": "^3.12.1"
@@ -40,9 +35,6 @@
   "ava": {
     "files": [
       "test/**/test-*.js"
-    ],
-    "require": [
-      "esm"
     ],
     "timeout": "2m"
   },

--- a/packages/tame-metering/src/index.js
+++ b/packages/tame-metering/src/index.js
@@ -1,1 +1,1 @@
-export { tameMetering, isTamed } from './tame';
+export { tameMetering, isTamed } from './tame.js';

--- a/packages/tame-metering/src/install-global-metering.js
+++ b/packages/tame-metering/src/install-global-metering.js
@@ -1,3 +1,3 @@
-import { tameMetering } from './tame';
+import { tameMetering } from './tame.js';
 
 export default tameMetering();

--- a/packages/tame-metering/src/tame.js
+++ b/packages/tame-metering/src/tame.js
@@ -1,5 +1,5 @@
 /* global globalThis */
-import * as c from './constants';
+import * as c from './constants.js';
 
 let replaceGlobalMeter;
 

--- a/packages/tame-metering/test/test-istamed.js
+++ b/packages/tame-metering/test/test-istamed.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { isTamed, tameMetering } from '../src/index';
+import { isTamed, tameMetering } from '../src/index.js';
 
 test('isTamed', t => {
   t.is(isTamed(), false, 'isTamed() is false in a new untamed realm');

--- a/packages/tame-metering/test/test-sanity.js
+++ b/packages/tame-metering/test/test-sanity.js
@@ -1,4 +1,4 @@
-import '../src/install-global-metering';
+import '../src/install-global-metering.js';
 import test from 'ava';
 
 test('symbol properties', t => {

--- a/packages/transform-metering/src/constants.js
+++ b/packages/transform-metering/src/constants.js
@@ -1,5 +1,5 @@
 // These are the meter members of the meterId.
-export * from '@agoric/tame-metering/src/constants';
+export * from '@agoric/tame-metering/src/constants.js';
 export const METER_COMBINED = '*';
 
 export const DEFAULT_METER_ID = '$h\u200d_meter';

--- a/packages/transform-metering/src/evaluator.js
+++ b/packages/transform-metering/src/evaluator.js
@@ -1,4 +1,4 @@
-import { makeMeteringTransformer } from './transform';
+import { makeMeteringTransformer } from './transform.js';
 
 export function makeMeteredEvaluator({
   replaceGlobalMeter,

--- a/packages/transform-metering/src/index.js
+++ b/packages/transform-metering/src/index.js
@@ -1,4 +1,4 @@
-export { makeMeteredEvaluator } from './evaluator';
-export { makeMeter } from './meter';
-export { makeMeteringTransformer } from './transform';
-export { makeWithMeter } from './with';
+export { makeMeteredEvaluator } from './evaluator.js';
+export { makeMeter } from './meter.js';
+export { makeMeteringTransformer } from './transform.js';
+export { makeWithMeter } from './with.js';

--- a/packages/transform-metering/src/meter.js
+++ b/packages/transform-metering/src/meter.js
@@ -1,4 +1,4 @@
-import * as c from './constants';
+import * as c from './constants.js';
 
 const { isArray } = Array;
 const { getOwnPropertyDescriptors } = Object;

--- a/packages/transform-metering/src/transform.js
+++ b/packages/transform-metering/src/transform.js
@@ -1,6 +1,6 @@
 /* global require */
-import * as c from './constants';
-import { makePureBabelCore } from './pure-babel-core';
+import * as c from './constants.js';
+import { makePureBabelCore } from './pure-babel-core.js';
 
 // We'd like to import this, but RE2 is cjs
 const RE2 = require('re2');

--- a/packages/transform-metering/test/test-meter.js
+++ b/packages/transform-metering/test/test-meter.js
@@ -1,8 +1,8 @@
 /* eslint-disable no-await-in-loop */
 import test from 'ava';
 
-import { makeMeter } from '../src/index';
-import * as c from '../src/constants';
+import { makeMeter } from '../src/index.js';
+import * as c from '../src/constants.js';
 
 const testAllExhausted = (t, meter, desc) => {
   t.throws(

--- a/packages/transform-metering/test/test-tame.js
+++ b/packages/transform-metering/test/test-tame.js
@@ -1,10 +1,10 @@
 /* eslint-disable no-await-in-loop */
-import replaceGlobalMeter from '@agoric/tame-metering/src/install-global-metering';
+import replaceGlobalMeter from '@agoric/tame-metering/src/install-global-metering.js';
 
 // eslint-disable-next-line import/order
 import test from 'ava';
 
-import { makeMeter, makeWithMeter } from '../src/index';
+import { makeMeter, makeWithMeter } from '../src/index.js';
 
 test('meter running', async t => {
   const { meter, refillFacet } = makeMeter({ budgetCombined: 10 });

--- a/packages/transform-metering/test/test-transform.js
+++ b/packages/transform-metering/test/test-transform.js
@@ -3,8 +3,8 @@
 import test from 'ava';
 import fs from 'fs';
 
-import { makeMeteringTransformer } from '../src/index';
-import * as c from '../src/constants';
+import { makeMeteringTransformer } from '../src/index.js';
+import * as c from '../src/constants.js';
 
 test('meter transform', async t => {
   let getMeter;

--- a/packages/transform-metering/test/test-zzz-eval.js
+++ b/packages/transform-metering/test/test-zzz-eval.js
@@ -1,11 +1,11 @@
 /* global process setTimeout */
-import { replaceGlobalMeter } from './install-metering';
+import { replaceGlobalMeter } from './install-metering.js';
 import '@agoric/install-ses'; // calls lockdown()
 
 // eslint-disable-next-line import/order
 import test from 'ava';
 
-import { makeMeter, makeMeteredEvaluator } from '../src/index';
+import { makeMeter, makeMeteredEvaluator } from '../src/index.js';
 
 // 'May be blocked by https://github.com/Agoric/SES-beta/issues/8',
 

--- a/packages/xsnap/lib/ses-boot-debug.js
+++ b/packages/xsnap/lib/ses-boot-debug.js
@@ -1,6 +1,6 @@
-import './console-shim';
-import './text-shim';
-import '@agoric/eventual-send/shim';
-import './lockdown-shim-debug';
+import './console-shim.js';
+import './text-shim.js';
+import '@agoric/eventual-send/shim.js';
+import './lockdown-shim-debug.js';
 
 harden(console);

--- a/packages/xsnap/lib/ses-boot.js
+++ b/packages/xsnap/lib/ses-boot.js
@@ -1,6 +1,6 @@
-import './console-shim';
-import './text-shim';
-import '@agoric/eventual-send/shim';
-import './lockdown-shim';
+import './console-shim.js';
+import './text-shim.js';
+import '@agoric/eventual-send/shim.js';
+import './lockdown-shim.js';
 
 harden(console);

--- a/packages/xsnap/src/ava-xs.js
+++ b/packages/xsnap/src/ava-xs.js
@@ -20,7 +20,7 @@ const path = require('path');
 const glob = require('glob');
 const bundleSource = require('@agoric/bundle-source').default;
 
-const { main, makeBundleResolve } = require('./avaXS');
+const { main, makeBundleResolve } = require('./avaXS.js');
 
 Promise.resolve()
   .then(_ =>

--- a/packages/xsnap/src/avaXS.js
+++ b/packages/xsnap/src/avaXS.js
@@ -15,7 +15,7 @@ import '@agoric/babel-standalone';
 /* eslint-disable no-await-in-loop */
 import '@agoric/install-ses';
 import { assert, details as X, q } from '@agoric/assert';
-import { xsnap } from './xsnap';
+import { xsnap } from './xsnap.js';
 
 // scripts for use in xsnap subprocesses
 const SESboot = `../dist/bundle-ses-boot-debug.umd.js`;

--- a/packages/xsnap/src/index.js
+++ b/packages/xsnap/src/index.js
@@ -1,9 +1,9 @@
-export { xsnap } from './xsnap';
+export { xsnap } from './xsnap.js';
 export {
   ExitCode,
   ErrorMessage,
   ErrorCode,
   ErrorSignal,
   METER_TYPE,
-} from '../api';
-export { makeSnapstore } from './snapStore';
+} from '../api.js';
+export { makeSnapstore } from './snapStore.js';

--- a/packages/xsnap/src/node-stream.js
+++ b/packages/xsnap/src/node-stream.js
@@ -11,7 +11,7 @@
  * @template T
  * @typedef {import('./defer.js').Deferred<T>} Deferred
  */
-import { defer } from './defer';
+import { defer } from './defer.js';
 
 const continues = { value: undefined };
 

--- a/packages/xsnap/src/stream.js
+++ b/packages/xsnap/src/stream.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { defer } from './defer';
+import { defer } from './defer.js';
 
 /**
  * @template T

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -11,10 +11,10 @@
  * @typedef {import('./defer').Deferred<T>} Deferred
  */
 
-import { ErrorCode, ErrorSignal, ErrorMessage, METER_TYPE } from '../api';
-import { defer } from './defer';
-import * as netstring from './netstring';
-import * as node from './node-stream';
+import { ErrorCode, ErrorSignal, ErrorMessage, METER_TYPE } from '../api.js';
+import { defer } from './defer.js';
+import * as netstring from './netstring.js';
+import * as node from './node-stream.js';
 
 // This will need adjustment, but seems to be fine for a start.
 const DEFAULT_CRANK_METERING_LIMIT = 1e7;

--- a/packages/xsnap/src/xsrepl.js
+++ b/packages/xsnap/src/xsrepl.js
@@ -9,8 +9,8 @@
 import * as childProcess from 'child_process';
 import * as os from 'os';
 import * as readline from 'readline';
-import { xsnap } from './xsnap';
-import { defer } from './defer';
+import { xsnap } from './xsnap.js';
+import { defer } from './defer.js';
 
 const decoder = new TextDecoder();
 

--- a/packages/xsnap/test/test-boot-lockdown.js
+++ b/packages/xsnap/test/test-boot-lockdown.js
@@ -3,7 +3,7 @@ import * as childProcess from 'child_process';
 import * as os from 'os';
 import * as fs from 'fs';
 import * as path from 'path';
-import { xsnap } from '../src/xsnap';
+import { xsnap } from '../src/xsnap.js';
 
 const importModuleUrl = `file://${__filename}`;
 

--- a/packages/xsnap/test/test-gc.js
+++ b/packages/xsnap/test/test-gc.js
@@ -3,8 +3,8 @@ import test from 'ava';
 
 import * as childProcess from 'child_process';
 import * as os from 'os';
-import { xsnap } from '../src/xsnap';
-import { makeGcAndFinalize } from './gc';
+import { xsnap } from '../src/xsnap.js';
+import { makeGcAndFinalize } from './gc.js';
 
 function makeVictim() {
   const victim = { doomed: 'oh no' };

--- a/packages/xsnap/test/test-netstring.js
+++ b/packages/xsnap/test/test-netstring.js
@@ -1,6 +1,6 @@
 import test from 'ava';
-import * as netstring from '../src/netstring';
-import { pipe } from '../src/stream';
+import * as netstring from '../src/netstring.js';
+import { pipe } from '../src/stream.js';
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();

--- a/packages/xsnap/test/test-snapstore.js
+++ b/packages/xsnap/test/test-snapstore.js
@@ -12,8 +12,8 @@ import zlib from 'zlib';
 import test from 'ava';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import tmp from 'tmp';
-import { xsnap } from '../src/xsnap';
-import { makeSnapstore } from '../src/snapStore';
+import { xsnap } from '../src/xsnap.js';
+import { makeSnapstore } from '../src/snapStore.js';
 
 const importMetaUrl = new URL(`file://${__filename}`);
 

--- a/packages/xsnap/test/test-xs-perf.js
+++ b/packages/xsnap/test/test-xs-perf.js
@@ -2,7 +2,7 @@
 import test from 'ava';
 import * as childProcess from 'child_process';
 import * as os from 'os';
-import { xsnap } from '../src/xsnap';
+import { xsnap } from '../src/xsnap.js';
 
 const decoder = new TextDecoder();
 

--- a/packages/xsnap/test/test-xsnap.js
+++ b/packages/xsnap/test/test-xsnap.js
@@ -5,8 +5,8 @@ import * as childProcess from 'child_process';
 import * as os from 'os';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import tmp from 'tmp';
-import { xsnap } from '../src/xsnap';
-import { ExitCode, ErrorCode } from '../api';
+import { xsnap } from '../src/xsnap.js';
+import { ExitCode, ErrorCode } from '../api.js';
 
 const importMetaUrl = `file://${__filename}`;
 


### PR DESCRIPTION
BREAKING CHANGE: Converts `@agoric/tame-metering` from emulated ESM with `node -r esm` to Node.js ESM proper.

Refs: #527