### PR TITLE
chore: Upgrade to nat@4.1.0

### DIFF
--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -44,7 +44,7 @@
     "@agoric/assert": "^0.2.12",
     "@agoric/eventual-send": "^0.13.14",
     "@agoric/marshal": "^0.4.11",
-    "@agoric/nat": "^4.0.0",
+    "@agoric/nat": "^4.1.0",
     "@agoric/notifier": "^0.3.14",
     "@agoric/promise-kit": "^0.2.13",
     "@agoric/same-structure": "^0.1.13",

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -41,7 +41,7 @@
     "@agoric/import-bundle": "^0.2.14",
     "@agoric/install-ses": "^0.5.13",
     "@agoric/marshal": "^0.4.11",
-    "@agoric/nat": "^4.0.0",
+    "@agoric/nat": "^4.1.0",
     "@agoric/notifier": "^0.3.14",
     "@agoric/promise-kit": "^0.2.13",
     "@agoric/store": "^0.4.14",

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -31,7 +31,7 @@
     "@agoric/bundle-source": "^1.3.7",
     "@agoric/captp": "^1.7.13",
     "@agoric/install-ses": "^0.5.13",
-    "@agoric/nat": "^4.0.0",
+    "@agoric/nat": "^4.1.0",
     "@agoric/promise-kit": "^0.2.13",
     "@iarna/toml": "^2.2.3",
     "anylogger": "^0.21.0",

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@agoric/eventual-send": "^0.13.14",
     "@agoric/marshal": "^0.4.11",
-    "@agoric/nat": "^4.0.0",
+    "@agoric/nat": "^4.1.0",
     "@agoric/promise-kit": "^0.2.13",
     "esm": "agoric-labs/esm#Agoric-built"
   },

--- a/packages/deploy-script-support/package.json
+++ b/packages/deploy-script-support/package.json
@@ -45,7 +45,7 @@
     "@agoric/eventual-send": "^0.13.14",
     "@agoric/import-manager": "^0.2.14",
     "@agoric/marshal": "^0.4.11",
-    "@agoric/nat": "^4.0.0",
+    "@agoric/nat": "^4.1.0",
     "@agoric/notifier": "^0.3.14",
     "@agoric/promise-kit": "^0.2.13",
     "@agoric/same-structure": "^0.1.13",

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@agoric/assert": "^0.2.12",
     "@agoric/eventual-send": "^0.13.14",
-    "@agoric/nat": "^4.0.0",
+    "@agoric/nat": "^4.1.0",
     "@agoric/promise-kit": "^0.2.13"
   },
   "devDependencies": {

--- a/packages/pegasus/package.json
+++ b/packages/pegasus/package.json
@@ -38,7 +38,7 @@
     "@agoric/ertp": "^0.11.2",
     "@agoric/eventual-send": "^0.13.14",
     "@agoric/marshal": "^0.4.11",
-    "@agoric/nat": "^4.0.0",
+    "@agoric/nat": "^4.1.0",
     "@agoric/notifier": "^0.3.14",
     "@agoric/promise-kit": "^0.2.13",
     "@agoric/store": "^0.4.14",

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -27,7 +27,7 @@
     "@agoric/eventual-send": "^0.13.14",
     "@agoric/install-ses": "^0.5.13",
     "@agoric/marshal": "^0.4.11",
-    "@agoric/nat": "^4.0.0",
+    "@agoric/nat": "^4.1.0",
     "@agoric/same-structure": "^0.1.13",
     "@agoric/stat-logger": "^0.4.9",
     "@agoric/swing-store-lmdb": "^0.4.12",

--- a/packages/transform-metering/package.json
+++ b/packages/transform-metering/package.json
@@ -19,7 +19,7 @@
     "esm": "agoric-labs/esm#Agoric-built"
   },
   "dependencies": {
-    "@agoric/nat": "^4.0.0",
+    "@agoric/nat": "^4.1.0",
     "@agoric/tame-metering": "^1.3.9",
     "@babel/parser": "^7.14.2",
     "@babel/types": "^7.14.2",

--- a/packages/treasury/package.json
+++ b/packages/treasury/package.json
@@ -38,7 +38,7 @@
     "@agoric/ertp": "^0.11.2",
     "@agoric/eventual-send": "^0.13.14",
     "@agoric/marshal": "^0.4.11",
-    "@agoric/nat": "^4.0.0",
+    "@agoric/nat": "^4.1.0",
     "@agoric/notifier": "^0.3.14",
     "@agoric/promise-kit": "^0.2.13",
     "@agoric/store": "^0.4.14",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -8,7 +8,7 @@
     "@agoric/ertp": "^0.11.2",
     "@agoric/eventual-send": "^0.13.14",
     "@agoric/install-ses": "^0.5.13",
-    "@agoric/nat": "^4.0.0",
+    "@agoric/nat": "^4.1.0",
     "@agoric/zoe": "^0.15.7",
     "clsx": "^1.1.1"
   },

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -30,7 +30,7 @@
     "@agoric/import-bundle": "^0.2.14",
     "@agoric/install-ses": "^0.5.13",
     "@agoric/marshal": "^0.4.11",
-    "@agoric/nat": "^4.0.0",
+    "@agoric/nat": "^4.1.0",
     "@agoric/notifier": "^0.3.14",
     "@agoric/pegasus": "^0.2.7",
     "@agoric/promise-kit": "^0.2.13",

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -46,7 +46,7 @@
     "@agoric/eventual-send": "^0.13.14",
     "@agoric/import-bundle": "^0.2.14",
     "@agoric/marshal": "^0.4.11",
-    "@agoric/nat": "^4.0.0",
+    "@agoric/nat": "^4.1.0",
     "@agoric/notifier": "^0.3.14",
     "@agoric/promise-kit": "^0.2.13",
     "@agoric/same-structure": "^0.1.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,10 +12,10 @@
   resolved "https://registry.yarnpkg.com/@agoric/babel-standalone/-/babel-standalone-7.14.3.tgz#1bf201417481d37d2797dd3283590dcbef775b4d"
   integrity sha512-Rdlxts19kvxHsqTjTrhGJv0yKgCyjCSVgXoLBZf9dZ7lyo/j+6xFQBiWjP03bXve3X74wUvA1QU55wVey8DEiQ==
 
-"@agoric/nat@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@agoric/nat/-/nat-4.0.0.tgz#330dcde37fcf8882dbc5012a3b2c4c135eee4930"
-  integrity sha512-zlTe14g0PGfONO0+TdhLv8k4IZH040ojvBZuNrcQSV+l8HlFTZ/IKzI5HorlCVDDBU7riykAb/6MaTgMRbYp3w==
+"@agoric/nat@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@agoric/nat/-/nat-4.1.0.tgz#102794e033ffc183a20b0f86031a2e76d204b9f6"
+  integrity sha512-2oMoh3DMn0Fx8HChPPiH8irBNdT/33ttxAZJohhd3nU3gyBRQ1u+eEoOQWfSkrE6M02iMkQM7GE9MzGmjQ6bHg==
 
 "@babel/cli@^7.12.13":
   version "7.13.10"


### PR DESCRIPTION
This upgrades `nat` to a version that can be bundled by Endo while maintaining compatibility with `node -r esm`.

Refs #2684