### PR TITLE
feat: for Keplr support (and presumably other wallets) we need CORS

### DIFF
--- a/packages/agoric-cli/lib/main.js
+++ b/packages/agoric-cli/lib/main.js
@@ -112,6 +112,11 @@ const main = async (progname, rawArgs, powers) => {
     .command('set-defaults <program> <config-dir>')
     .description('update the configuration files for <program> in <config-dir>')
     .option(
+      '--enable-cors',
+      'open RPC and API endpoints to all cross-origin requests',
+      false,
+    )
+    .option(
       '--export-metrics',
       'open ports to export Prometheus metrics',
       false,

--- a/packages/agoric-cli/lib/set-defaults.js
+++ b/packages/agoric-cli/lib/set-defaults.js
@@ -17,7 +17,7 @@ export default async function setDefaultsMain(progname, rawArgs, powers, opts) {
     X`<prog> must currently be 'ag-chain-cosmos'`,
   );
 
-  const { exportMetrics } = opts;
+  const { exportMetrics, enableCors } = opts;
 
   let appFile;
   let configFile;
@@ -51,6 +51,7 @@ export default async function setDefaultsMain(progname, rawArgs, powers, opts) {
 
     const newAppToml = finishCosmosApp({
       appToml,
+      enableCors,
       exportMetrics,
     });
     await create(appFile, newAppToml);
@@ -63,6 +64,7 @@ export default async function setDefaultsMain(progname, rawArgs, powers, opts) {
 
     const newConfigToml = finishTendermintConfig({
       configToml,
+      enableCors,
       persistentPeers,
       seeds,
       unconditionalPeerIds,


### PR DESCRIPTION
A small tweak to allow easily toggling the CORS Access-Control-Allow-Origin header to `"*"` for deployed "peer" machines, or if there are none, for deployed "validator" machines.

This is needed for the Keplr integration.
