### PR TITLE
chore: Migrate eslint to endo packages

### DIFF
--- a/golang/cosmos/package.json
+++ b/golang/cosmos/package.json
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/Agoric/agoric-sdk/packages/connector-cosmos",
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "timeout": "30m"
   },
   "dependencies": {
+    "@endo/eslint-config": "^0.3.9",
     "patch-package": "^6.2.2"
   }
 }

--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -76,7 +76,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "prettier": {

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -81,7 +81,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "ava": {

--- a/packages/access-token/package.json
+++ b/packages/access-token/package.json
@@ -36,7 +36,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "prettier": {

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -56,7 +56,7 @@
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "ava": {

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -48,7 +48,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "eslintIgnore": [

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -62,7 +62,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "prettier": {

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -61,7 +61,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "prettier": {

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -50,7 +50,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "prettier": {

--- a/packages/dapp-svelte-wallet/api/package.json
+++ b/packages/dapp-svelte-wallet/api/package.json
@@ -33,7 +33,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "prettier": {

--- a/packages/dapp-svelte-wallet/package.json
+++ b/packages/dapp-svelte-wallet/package.json
@@ -33,7 +33,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "prettier": {

--- a/packages/dapp-svelte-wallet/ui/package.json
+++ b/packages/dapp-svelte-wallet/ui/package.json
@@ -33,7 +33,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ],
     "env": {
       "browser": true

--- a/packages/deploy-script-support/package.json
+++ b/packages/deploy-script-support/package.json
@@ -74,7 +74,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "prettier": {

--- a/packages/deployment/package.json
+++ b/packages/deployment/package.json
@@ -39,7 +39,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "prettier": {

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -42,7 +42,7 @@
   ],
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "prettier": {

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -45,7 +45,7 @@
   "homepage": "https://github.com/Agoric/agoric-sdk/packages/import-bundle",
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "prettier": {

--- a/packages/import-manager/package.json
+++ b/packages/import-manager/package.json
@@ -49,7 +49,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "eslintIgnore": [

--- a/packages/install-metering-and-ses/package.json
+++ b/packages/install-metering-and-ses/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "eslintIgnore": [

--- a/packages/install-ses/package.json
+++ b/packages/install-ses/package.json
@@ -44,7 +44,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "eslintIgnore": [

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -53,7 +53,7 @@
   ],
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "prettier": {

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -51,7 +51,7 @@
   ],
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "eslintIgnore": [

--- a/packages/pegasus/package.json
+++ b/packages/pegasus/package.json
@@ -69,7 +69,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "eslintIgnore": [

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -45,7 +45,7 @@
   ],
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "eslintIgnore": [

--- a/packages/same-structure/package.json
+++ b/packages/same-structure/package.json
@@ -45,7 +45,7 @@
   ],
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "eslintIgnore": [

--- a/packages/sharing-service/package.json
+++ b/packages/sharing-service/package.json
@@ -44,7 +44,7 @@
   ],
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "eslintIgnore": [

--- a/packages/solo/package.json
+++ b/packages/solo/package.json
@@ -60,7 +60,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "prettier": {

--- a/packages/sparse-ints/package.json
+++ b/packages/sparse-ints/package.json
@@ -45,7 +45,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "eslintIgnore": [

--- a/packages/spawner/package.json
+++ b/packages/spawner/package.json
@@ -51,7 +51,7 @@
   ],
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "eslintIgnore": [

--- a/packages/stat-logger/package.json
+++ b/packages/stat-logger/package.json
@@ -39,7 +39,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "prettier": {

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -49,7 +49,7 @@
   ],
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "eslintIgnore": [

--- a/packages/swing-store-lmdb/package.json
+++ b/packages/swing-store-lmdb/package.json
@@ -44,7 +44,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "prettier": {

--- a/packages/swing-store-simple/package.json
+++ b/packages/swing-store-simple/package.json
@@ -42,7 +42,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "prettier": {

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -45,7 +45,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "prettier": {

--- a/packages/tame-metering/package.json
+++ b/packages/tame-metering/package.json
@@ -40,7 +40,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "prettier": {

--- a/packages/transform-metering/package.json
+++ b/packages/transform-metering/package.json
@@ -55,7 +55,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "prettier": {

--- a/packages/treasury/package.json
+++ b/packages/treasury/package.json
@@ -69,7 +69,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "eslintIgnore": [

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -32,7 +32,7 @@
   "eslintConfig": {
     "extends": [
       "react-app",
-      "@agoric"
+      "@endo"
     ],
     "rules": {
       "no-use-before-define": "off",

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -50,7 +50,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "prettier": {

--- a/packages/xsnap/package.json
+++ b/packages/xsnap/package.json
@@ -52,7 +52,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ],
     "ignorePatterns": [
       "examples/**/*.js"

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -87,7 +87,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@agoric"
+      "@endo"
     ]
   },
   "eslintIgnore": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1279,6 +1279,20 @@
     "@endo/zip" "^0.2.2"
     ses "^0.13.2"
 
+"@endo/eslint-config@^0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@endo/eslint-config/-/eslint-config-0.3.9.tgz#157ab2e64ddca73c65c7cf0762cfb04c573c3722"
+  integrity sha512-nL3y1ncAC52PGLaZDr2u+/r5jjiLZ295wWGNpa+g0yOhzOuAaZ6PvEs8r7qIXJ7YrzdzRKJcEdC+RBjRLRo8Tg==
+  dependencies:
+    "@endo/eslint-plugin" "^0.3.5"
+
+"@endo/eslint-plugin@^0.3.5":
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/@endo/eslint-plugin/-/eslint-plugin-0.3.5.tgz#13c9c5e3f11ee147698af4f81b0cf03cea155bb1"
+  integrity sha512-qmkCgasPlzQhY/1gstz67RnakLmjc/MRSyNFzmvCmLw9NOCP4DEtsq9O6Af4wimfeqGwYOBvGOGT/FzfydQvlA==
+  dependencies:
+    requireindex "~1.1.0"
+
 "@endo/ses-ava@^0.2.2":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@endo/ses-ava/-/ses-ava-0.2.2.tgz#44fc4f1c25575346f43b03d4e944931e53d81f3d"


### PR DESCRIPTION
Refs: https://github.com/endojs/endo/issues/696

Our lint rules currently exist independently in agoric and endo repositories. They are in sync at the moment, but have drifted in the past. Since then, we have published the versions from the endo repository. This change subscribes to those versions and deletes the variant so further drift does not occur.

- chore: Switch eslint to Endo published version
- chore: Update yarn.lock
- ~chore: Remove eslint packages from workspace~
