### PR TITLE
fix(swingset)!: remove stats from vatAdmin API

### DIFF
--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -866,12 +866,6 @@ export default function buildKernel(
     });
   }
 
-  function collectVatStats(vatID) {
-    insistVatID(vatID);
-    const vatKeeper = kernelKeeper.provideVatKeeper(vatID);
-    return vatKeeper.vatStats();
-  }
-
   async function start() {
     if (started) {
       throw Error('kernel.start already called');
@@ -891,7 +885,6 @@ export default function buildKernel(
         // later when it is created and a root object is available
         return vatID;
       },
-      stats: collectVatStats,
       terminate: (vatID, reason) => terminateVat(vatID, true, reason),
     };
 

--- a/packages/SwingSet/src/kernel/vatAdmin/vatAdmin-src.js
+++ b/packages/SwingSet/src/kernel/vatAdmin/vatAdmin-src.js
@@ -20,11 +20,7 @@
 import { Far } from '@agoric/marshal';
 
 export function buildRootDeviceNode({ endowments, serialize }) {
-  const {
-    pushCreateVatEvent,
-    stats: kernelVatStatsFn,
-    terminate: kernelTerminateVatFn,
-  } = endowments;
+  const { pushCreateVatEvent, terminate: kernelTerminateVatFn } = endowments;
 
   // The Root Device Node.
   return Far('root', {
@@ -41,11 +37,6 @@ export function buildRootDeviceNode({ endowments, serialize }) {
     },
     terminateWithFailure(vatID, reason) {
       kernelTerminateVatFn(vatID, serialize(reason));
-    },
-    // Call the registered kernel function to request vat stats. Clean up the
-    // outgoing and incoming arguments.
-    adminStats(vatID) {
-      return kernelVatStatsFn(`${vatID}`);
     },
   });
 }

--- a/packages/SwingSet/src/kernel/vatAdmin/vatAdminWrapper.js
+++ b/packages/SwingSet/src/kernel/vatAdmin/vatAdminWrapper.js
@@ -30,9 +30,6 @@ export function buildRootObject(vatPowers) {
       terminateWithFailure(reason) {
         D(vatAdminNode).terminateWithFailure(vatID, reason);
       },
-      adminData() {
-        return D(vatAdminNode).adminStats(vatID);
-      },
       done() {
         return doneP;
       },

--- a/packages/SwingSet/test/vat-admin/bootstrap.js
+++ b/packages/SwingSet/test/vat-admin/bootstrap.js
@@ -51,17 +51,6 @@ export function buildRootObject(vatPowers, vatParameters) {
             );
           return;
         }
-        case 'vatStats': {
-          log(`starting stats test`);
-          const { root, adminNode } = await E(vatAdminSvc).createVat(
-            bundles.newVatBundle,
-          );
-          log(await E(adminNode).adminData());
-          const c = E(root).createRcvr(1);
-          log(await E(c).increment(3));
-          log(await E(adminNode).adminData());
-          return;
-        }
         default:
           assert.fail(X`unknown argv mode '${argv[0]}'`);
       }

--- a/packages/SwingSet/test/vat-admin/test-innerVat.js
+++ b/packages/SwingSet/test/vat-admin/test-innerVat.js
@@ -70,15 +70,3 @@ test('error creating vat from non-bundle', async t => {
   ]);
   await c.run();
 });
-
-test('VatAdmin get vat stats', async t => {
-  const c = await doTestSetup(t, 'vatStats');
-  await c.run();
-  t.deepEqual(c.dump().log, [
-    'starting stats test',
-    '{"deviceCount":0,"objectCount":0,"promiseCount":0,"transcriptCount":0}',
-    '4',
-    '{"deviceCount":0,"objectCount":0,"promiseCount":2,"transcriptCount":2}',
-  ]);
-  await c.run();
-});

--- a/packages/deploy-script-support/test/unitTests/test-startInstance.js
+++ b/packages/deploy-script-support/test/unitTests/test-startInstance.js
@@ -67,7 +67,6 @@ test('startInstance', async t => {
     creatorFacet,
     publicFacet,
     instance,
-    adminFacet,
     creatorInvitationDetails,
   } = await startInstance(startInstanceConfig);
 
@@ -75,5 +74,4 @@ test('startInstance', async t => {
   t.truthy(creatorFacet);
   t.is(await E(zoe).getPublicFacet(instance), publicFacet);
   t.is(creatorInvitationDetails.description, 'getRefund');
-  t.is(await E(adminFacet).getVatStats(), undefined);
 });

--- a/packages/pegasus/test/fakeVatAdmin.js
+++ b/packages/pegasus/test/fakeVatAdmin.js
@@ -12,7 +12,6 @@ export default harden({
           return makePromiseKit().promise;
         },
         terminate: () => {},
-        adminData: () => ({}),
       },
     });
   },

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -216,8 +216,6 @@
  * promise will fulfill to the completion value.
  * @property {(reason: TerminationReason) => void} terminateWithFailure
  * Terminate the vat in which the contract is running as a failure.
- * @property {() => Object} adminData
- * returns some statistics about the vat in which the contract is running.
  */
 
 /**

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -208,7 +208,6 @@ export const makeStartInstance = (
       }
       const adminFacet = Far('adminFacet', {
         getVatShutdownPromise: () => E(adminNode).done(),
-        getVatStats: () => E(adminNode).adminData(),
       });
 
       // Actually returned to the user.

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -156,7 +156,6 @@
 /**
  * @typedef {Object} AdminFacet
  * @property {() => Promise<Completion>} getVatShutdownPromise
- * @property {() => any} getVatStats
  */
 
 /**

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -80,7 +80,6 @@ test(`zoe.startInstance no issuerKeywordRecord, no terms`, async t => {
   isEmptyFacet(t, result.publicFacet);
   t.deepEqual(Object.getOwnPropertyNames(result.adminFacet).sort(), [
     'getVatShutdownPromise',
-    'getVatStats',
   ]);
 });
 
@@ -108,7 +107,6 @@ test(`zoe.startInstance promise for installation`, async t => {
   isEmptyFacet(t, result.publicFacet);
   t.deepEqual(Object.getOwnPropertyNames(result.adminFacet).sort(), [
     'getVatShutdownPromise',
-    'getVatStats',
   ]);
 });
 

--- a/packages/zoe/tools/fakeVatAdmin.js
+++ b/packages/zoe/tools/fakeVatAdmin.js
@@ -47,7 +47,6 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
             return kit.promise;
           },
           terminateWithFailure: () => {},
-          adminData: () => {},
         }),
       });
     },


### PR DESCRIPTION
The "Admin Node" returned by `vatAdmin~.createVatDynamically()` had a method
named `adminData()`, which returned some statistics like the number of
objects imported into the vat. This wasn't super-useful and exposes a little
too much information about the kernel's internals, especially as GC starts to
get more interesting. So we've decided to remove this API.

closes #3331
