### PR TITLE
refactor!(zoe): handle subtracting empty in a less fragile way

### DIFF
--- a/packages/zoe/src/contractFacet/allocationMath.js
+++ b/packages/zoe/src/contractFacet/allocationMath.js
@@ -25,11 +25,17 @@ import { AmountMath } from '@agoric/ertp';
  */
 const doOperation = (allocation, amountKeywordRecord, operationFn) => {
   const allKeywords = Object.keys({ ...allocation, ...amountKeywordRecord });
-  
-  const entries = allKeywords.map(keyword => {
-      const result = operationFn(allocation[keyword], amountKeywordRecord[keyword], keyword);
-      return [ keyword, result];
-    }).filter(([_keyword, result]) => result !== undefined);
+
+  const entries = allKeywords
+    .map(keyword => {
+      const result = operationFn(
+        allocation[keyword],
+        amountKeywordRecord[keyword],
+        keyword,
+      );
+      return [keyword, result];
+    })
+    .filter(([_keyword, result]) => result !== undefined);
 
   return Object.fromEntries(entries);
 };
@@ -48,7 +54,10 @@ const add = (amount, amountToAdd, _keyword) => {
 /** @type {Operation} */
 const subtract = (amount, amountToSubtract, keyword) => {
   // if amountToSubtract is undefined OR is defined, but empty
-  if (amountToSubtract === undefined || (amountToSubtract !== undefined && AmountMath.isEmpty(amountToSubtract))) {
+  if (
+    amountToSubtract === undefined ||
+    (amountToSubtract !== undefined && AmountMath.isEmpty(amountToSubtract))
+  ) {
     // Subtracting undefined is equivalent to subtracting empty, so in
     // both cases we can return the original amount. If the original
     // amount is undefined, it is filtered out in doOperation.

--- a/packages/zoe/src/contractFacet/allocationMath.js
+++ b/packages/zoe/src/contractFacet/allocationMath.js
@@ -54,10 +54,7 @@ const add = (amount, amountToAdd, _keyword) => {
 /** @type {Operation} */
 const subtract = (amount, amountToSubtract, keyword) => {
   // if amountToSubtract is undefined OR is defined, but empty
-  if (
-    amountToSubtract === undefined ||
-    (amountToSubtract !== undefined && AmountMath.isEmpty(amountToSubtract))
-  ) {
+  if (amountToSubtract === undefined || AmountMath.isEmpty(amountToSubtract)) {
     // Subtracting undefined is equivalent to subtracting empty, so in
     // both cases we can return the original amount. If the original
     // amount is undefined, it is filtered out in doOperation.

--- a/packages/zoe/src/contracts/newSwap/collectFees.js
+++ b/packages/zoe/src/contracts/newSwap/collectFees.js
@@ -1,7 +1,5 @@
 // @ts-check
 
-import { AmountMath } from '@agoric/ertp';
-
 export const makeMakeCollectFeesInvitation = (zcf, feeSeat, centralBrand) => {
   const collectFees = seat => {
     const amount = feeSeat.getAmountAllocated('RUN', centralBrand);

--- a/packages/zoe/src/contracts/newSwap/collectFees.js
+++ b/packages/zoe/src/contracts/newSwap/collectFees.js
@@ -4,10 +4,7 @@ import { AmountMath } from '@agoric/ertp';
 
 export const makeMakeCollectFeesInvitation = (zcf, feeSeat, centralBrand) => {
   const collectFees = seat => {
-    // Ensure that the feeSeat has a stagedAllocation with a RUN keyword
-    feeSeat.incrementBy({ RUN: AmountMath.makeEmpty(centralBrand) });
     const amount = feeSeat.getAmountAllocated('RUN', centralBrand);
-
     seat.incrementBy(feeSeat.decrementBy({ RUN: amount }));
     zcf.reallocate(seat, feeSeat);
 

--- a/packages/zoe/test/unitTests/zcf/test-reallocate-empty.js
+++ b/packages/zoe/test/unitTests/zcf/test-reallocate-empty.js
@@ -19,11 +19,9 @@ test(`zcf.reallocate introducing new empty amount`, async t => {
 
   const empty = AmountMath.makeEmpty(brand, AssetKind.NAT);
 
-  // decrementBy empty
-  t.throws(() => zcfSeat1.decrementBy({ RUN: empty }), {
-    message:
-      'The amount could not be subtracted from the allocation because the allocation did not have an amount under the keyword "RUN".',
-  });
+  // decrementBy empty does not throw, and does not add a keyword
+  zcfSeat1.decrementBy({ RUN: empty });
+  t.deepEqual(zcfSeat1.getStagedAllocation(), {});
 
   // Try to incrementBy empty. This succeeds, and the keyword is added
   // with an empty amount.


### PR DESCRIPTION
Closes #3335 

#3184 required contracts to ensure that a keyword is specified before subtracting from the amount at that keyword. For instance:

https://github.com/Agoric/agoric-sdk/blob/eba3074241e901f14443d30074cb45c66d63c573/packages/zoe/src/contracts/newSwap/collectFees.js#L6-L13

On second thought, this is way too fragile, and too much to require of contract developers. 

This PR changes Zoe such that subtracting an empty amount, even from a keyword that does not exist, will not error. This will resolve the bug in #3335 in a way that handles the edge case for developers rather than requiring them to anticipate it.