### PR TITLE
fix(deploy-script-support): Relax constraint on repository clone path

### DIFF
--- a/packages/deploy-script-support/test/unitTests/test-resolvePathForPackagedContract.js
+++ b/packages/deploy-script-support/test/unitTests/test-resolvePathForPackagedContract.js
@@ -12,7 +12,5 @@ test('resolvePathForPackagedContract', async t => {
 
   const result = resolvePathForPackagedContract(path);
 
-  t.truthy(
-    result.includes('agoric-sdk/packages/zoe/src/contracts/automaticRefund.js'),
-  );
+  t.truthy(result.includes('packages/zoe/src/contracts/automaticRefund.js'));
 });


### PR DESCRIPTION
This relaxes a test constraint that requires the repository to be cloned with the name `agoric-sdk`. This is inconvenient for alternate workspaces.
