### PR TITLE
refactor: Regularize lint scripts

### DIFF
--- a/packages/access-token/package.json
+++ b/packages/access-token/package.json
@@ -10,8 +10,9 @@
     "build": "exit 0",
     "test": "ava",
     "test:xs": "exit 0",
+    "lint-check": "yarn lint",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint-check": "eslint '**/*.js'"
+    "lint": "eslint '**/*.js'"
   },
   "dependencies": {
     "@agoric/assert": "^0.3.1",

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -16,8 +16,9 @@
     "test": "ava",
     "test:xs": "exit 0",
     "integration-test": "ava --config .ava-integration-test.config.js",
-    "lint-check": "eslint '**/*.{js,jsx}'",
-    "lint-fix": "eslint --fix '**/*.{js,jsx}'"
+    "lint-check": "yarn lint",
+    "lint-fix": "eslint --fix '**/*.{js,jsx}'",
+    "lint": "eslint '**/*.{js,jsx}'"
   },
   "devDependencies": {
     "@agoric/swingset-vat": "^0.18.0",

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -11,9 +11,10 @@
     "test": "ava",
     "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint-check": "eslint '**/*.js'",
+    "lint-check": "yarn lint",
     "lint-fix-jessie": "eslint -c '.eslintrc-jessie.js' --fix '**/*.js'",
-    "lint-check-jessie": "eslint -c '.eslintrc-jessie.js' '**/*.js'"
+    "lint-check-jessie": "eslint -c '.eslintrc-jessie.js' '**/*.js'",
+    "lint": "eslint '**/*.js'"
   },
   "devDependencies": {
     "@agoric/install-ses": "^0.5.15",

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -30,8 +30,9 @@
     "build": "exit 0",
     "test": "ava",
     "test:xs": "exit 0",
+    "lint-check": "yarn lint",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint-check": "eslint 'lib/*.js'"
+    "lint": "eslint 'lib/*.js'"
   },
   "devDependencies": {
     "@agoric/install-ses": "^0.5.15",

--- a/packages/dapp-svelte-wallet/package.json
+++ b/packages/dapp-svelte-wallet/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "lint-fix": "exit 0",
     "lint-check": "exit 0",
+    "lint": "exit 0",
     "test": "exit 0",
     "test:xs": "exit 0",
     "build": "exit 0"

--- a/packages/deploy-script-support/package.json
+++ b/packages/deploy-script-support/package.json
@@ -17,9 +17,9 @@
     "pretty-check": "prettier --check '**/*.js'",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint-check": "yarn lint",
-    "lint": "yarn lint:types && yarn lint:eslint",
     "lint:eslint": "eslint '**/*.js'",
-    "lint:types": "tsc -p jsconfig.json"
+    "lint:types": "tsc -p jsconfig.json",
+    "lint": "yarn lint:types && yarn lint:eslint"
   },
   "repository": {
     "type": "git",

--- a/packages/deployment/package.json
+++ b/packages/deployment/package.json
@@ -14,8 +14,9 @@
     "test": "exit 0",
     "test:xs": "exit 0",
     "build": "exit 0",
+    "lint-check": "yarn lint",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint-check": "eslint '**/*.js'"
+    "lint": "eslint '**/*.js'"
   },
   "repository": "https://github.com/Agoric/agoric-sdk",
   "author": "Agoric",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -18,8 +18,9 @@
     "test:nyc": "exit 0",
     "test:xs": "exit 0",
     "build": "exit 0",
+    "lint-check": "exit 0",
     "lint-fix": "exit 0",
-    "lint-check": "exit 0"
+    "lint": "exit 0"
   },
   "files": [
     "eslint-config.json"

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -14,7 +14,8 @@
     "test:xs": "exit 0",
     "build": "exit 0",
     "lint-fix": "exit 0",
-    "lint-check": "exit 0"
+    "lint-check": "exit 0",
+    "lint": "exit 0"
   },
   "dependencies": {
     "requireindex": "~1.1.0"

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -11,8 +11,9 @@
     "test": "ava",
     "test:xs": "exit 0",
     "build": "exit 0",
+    "lint-check": "yarn lint",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint-check": "eslint '**/*.js'"
+    "lint": "eslint '**/*.js'"
   },
   "repository": {
     "type": "git",

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -14,8 +14,9 @@
     "test": "ava",
     "test:xs": "exit 0",
     "build": "exit 0",
+    "lint-check": "yarn lint",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint-check": "eslint '**/*.js'"
+    "lint": "eslint '**/*.js'"
   },
   "dependencies": {
     "@agoric/assert": "^0.3.1",

--- a/packages/import-manager/package.json
+++ b/packages/import-manager/package.json
@@ -14,7 +14,8 @@
     "test": "ava",
     "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint-check": "eslint '**/*.js'"
+    "lint-check": "yarn lint",
+    "lint": "eslint '**/*.js'"
   },
   "repository": {
     "type": "git",

--- a/packages/install-metering-and-ses/package.json
+++ b/packages/install-metering-and-ses/package.json
@@ -10,8 +10,9 @@
     "build": "exit 0",
     "test": "ava",
     "test:xs": "exit 0",
+    "lint-check": "yarn lint",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint-check": "eslint '**/*.js'"
+    "lint": "eslint '**/*.js'"
   },
   "devDependencies": {
     "@agoric/transform-metering": "^1.4.14",

--- a/packages/install-ses/package.json
+++ b/packages/install-ses/package.json
@@ -10,8 +10,9 @@
     "build": "exit 0",
     "test": "ava",
     "test:xs": "exit 0",
+    "lint-check": "yarn lint",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint-check": "eslint '**/*.js'"
+    "lint": "eslint '**/*.js'"
   },
   "devDependencies": {
     "ava": "^3.12.1",

--- a/packages/same-structure/package.json
+++ b/packages/same-structure/package.json
@@ -13,8 +13,9 @@
     "build": "exit 0",
     "test": "exit 0",
     "test:xs": "exit 0",
+    "lint-check": "yarn lint",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint-check": "eslint '**/*.js'"
+    "lint": "eslint '**/*.js'"
   },
   "repository": {
     "type": "git",

--- a/packages/sharing-service/package.json
+++ b/packages/sharing-service/package.json
@@ -13,8 +13,9 @@
     "build": "exit 0",
     "test": "ava",
     "test:xs": "exit 0",
+    "lint-check": "yarn lint",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint-check": "eslint '**/*.js'"
+    "lint": "eslint '**/*.js'"
   },
   "repository": {
     "type": "git",

--- a/packages/sparse-ints/package.json
+++ b/packages/sparse-ints/package.json
@@ -13,8 +13,9 @@
     "build": "exit 0",
     "test": "exit 0",
     "test:xs": "exit 0",
+    "lint-check": "yarn lint",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint-check": "eslint '**/*.js'"
+    "lint": "eslint '**/*.js'"
   },
   "repository": {
     "type": "git",

--- a/packages/spawner/package.json
+++ b/packages/spawner/package.json
@@ -14,8 +14,9 @@
     "build-bundle-spawn": "node -r esm scripts/build-bundle-spawn.js",
     "test": "ava",
     "test:xs": "exit 0",
+    "lint-check": "yarn lint",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint-check": "eslint '**/*.js'"
+    "lint": "eslint '**/*.js'"
   },
   "repository": {
     "type": "git",

--- a/packages/stat-logger/package.json
+++ b/packages/stat-logger/package.json
@@ -13,8 +13,9 @@
     "build": "exit 0",
     "test": "exit 0",
     "test:xs": "exit 0",
+    "lint-check": "yarn lint",
     "lint-fix": "eslint --fix '**/*.js'",
-    "lint-check": "eslint '**/*.js'"
+    "lint": "eslint '**/*.js'"
   },
   "dependencies": {
     "canvas": "^2.6.1",

--- a/packages/tame-metering/package.json
+++ b/packages/tame-metering/package.json
@@ -7,8 +7,9 @@
   "scripts": {
     "test": "ava",
     "test:xs": "exit 0",
+    "lint-check": "yarn lint",
     "lint-fix": "eslint --fix '**/*.{js,jsx}'",
-    "lint-check": "eslint '**/*.{js,jsx}'",
+    "lint": "eslint '**/*.{js,jsx}'",
     "build": "exit 0"
   },
   "devDependencies": {

--- a/packages/transform-metering/package.json
+++ b/packages/transform-metering/package.json
@@ -9,8 +9,9 @@
   "scripts": {
     "test": "ava",
     "test:xs": "exit 0",
+    "lint-check": "yarn lint",
     "lint-fix": "eslint --fix '**/*.{js,jsx}'",
-    "lint-check": "eslint '**/*.{js,jsx}'",
+    "lint": "eslint '**/*.{js,jsx}'",
     "build": "exit 0"
   },
   "devDependencies": {

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -24,8 +24,8 @@
     "build:src": "rm -rf dist && BABEL_ENV='test' ./node_modules/.bin/babel src --out-dir dist",
     "build": "yarn build:src && yarn build:tests",
     "lint-fix": "yarn lint --fix",
-    "lint": "yarn lint:types && yarn lint:eslint",
     "lint-check": "yarn lint",
+    "lint": "yarn lint:types && yarn lint:eslint",
     "lint:eslint": "eslint '**/*.js'",
     "lint:types": "tsc -p jsconfig.json"
   },


### PR DESCRIPTION
A minor refactor that ensures that `yarn lint` will work in place of `yarn lint-fix` in any package.
