### PR TITLE
refactor!(zoe): add method zcf.getInstance()

### DIFF
--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -56,6 +56,7 @@ export const makeZCFZygote = (
     addIssuerToInstanceRecord,
     getTerms,
     assertUniqueKeyword,
+    getInstanceRecord,
     instantiate: instantiateInstanceRecordStorage,
   } = makeInstanceRecordStorage();
 
@@ -243,6 +244,7 @@ export const makeZCFZygote = (
         testJigSetter({ ...testFn(), zcf });
       }
     },
+    getInstance: () => getInstanceRecord().instance,
   });
 
   // handleOfferObject gives Zoe the ability to notify ZCF when a new seat is

--- a/packages/zoe/src/instanceRecordStorage.js
+++ b/packages/zoe/src/instanceRecordStorage.js
@@ -109,6 +109,7 @@ export const makeInstanceRecordStorage = () => {
  * Put together the instance record
  *
  * @param {Installation} installation
+ * @param {Instance} instance
  * @param {Object} customTerms
  * @param {IssuerKeywordRecord} issuers
  * @param {BrandKeywordRecord} brands
@@ -116,12 +117,14 @@ export const makeInstanceRecordStorage = () => {
  */
 export const makeAndStoreInstanceRecord = (
   installation,
+  instance,
   customTerms,
   issuers,
   brands,
 ) => {
   const instanceRecord = harden({
     installation,
+    instance,
     terms: {
       ...customTerms,
       issuers,

--- a/packages/zoe/src/types.js
+++ b/packages/zoe/src/types.js
@@ -28,6 +28,7 @@
  *
  * @typedef {object} InstanceRecord
  * @property {Installation} installation
+ * @property {Instance} instance
  * @property {Terms} terms - contract parameters
  
  *

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -91,6 +91,7 @@ export const makeZoeStorageManager = createZCFVat => {
     // capabilities from the ZCF side.
     const instanceRecordManager = makeAndStoreInstanceRecord(
       installation,
+      instance,
       customTerms,
       issuers,
       brands,

--- a/packages/zoe/test/unitTests/test-instanceStorage.js
+++ b/packages/zoe/test/unitTests/test-instanceStorage.js
@@ -30,6 +30,7 @@ test('makeAndStoreInstanceRecord', async t => {
   const { currencyKit, ticketKit } = setupIssuersForTest();
   const bundle = await bundleSource(root);
   const fakeInstallation = { getBundle: () => bundle };
+  const fakeInstance = /** @type {Instance} */ ({});
   const customTerms = harden({ time: 2n });
   const issuers = harden({
     Currency: currencyKit.issuer,
@@ -48,6 +49,7 @@ test('makeAndStoreInstanceRecord', async t => {
     assertUniqueKeyword,
   } = makeAndStoreInstanceRecord(
     fakeInstallation,
+    fakeInstance,
     customTerms,
     issuers,
     brands,
@@ -55,6 +57,7 @@ test('makeAndStoreInstanceRecord', async t => {
 
   t.deepEqual(getInstanceRecord(), {
     installation: fakeInstallation,
+    instance: fakeInstance,
     terms: { time: 2n, issuers, brands },
   });
 
@@ -70,7 +73,8 @@ test('makeAndStoreInstanceRecord', async t => {
   // Add currency again, but call it "money"
   addIssuerToInstanceRecord(
     'Money',
-    makeIssuerRecord(currencyKit.brand, currencyKit.issuer, AssetKind.NAT, {
+    makeIssuerRecord(currencyKit.brand, currencyKit.issuer, {
+      assetKind: AssetKind.NAT,
       decimalPlaces: 18,
     }),
   );
@@ -82,6 +86,7 @@ test('makeInstanceRecordStorage', async t => {
   const { currencyKit, ticketKit } = setupIssuersForTest();
   const bundle = await bundleSource(root);
   const fakeInstallation = { getBundle: () => bundle };
+  const fakeInstance = /** @type {Instance} */ ({});
   const issuers = harden({
     Currency: currencyKit.issuer,
     Ticket: ticketKit.issuer,
@@ -101,11 +106,13 @@ test('makeInstanceRecordStorage', async t => {
   } = makeInstanceRecordStorage();
   instantiate({
     installation: fakeInstallation,
+    instance: fakeInstance,
     terms: { time: 2n, issuers, brands },
   });
 
   t.deepEqual(getInstanceRecord(), {
     installation: fakeInstallation,
+    instance: fakeInstance,
     terms: { time: 2n, issuers, brands },
   });
 
@@ -121,7 +128,8 @@ test('makeInstanceRecordStorage', async t => {
   // Add currency again, but call it "money"
   addIssuerToInstanceRecord(
     'Money',
-    makeIssuerRecord(currencyKit.brand, currencyKit.issuer, AssetKind.NAT, {
+    makeIssuerRecord(currencyKit.brand, currencyKit.issuer, {
+      assetKind: AssetKind.NAT, 
       decimalPlaces: 18,
     }),
   );

--- a/packages/zoe/test/unitTests/test-instanceStorage.js
+++ b/packages/zoe/test/unitTests/test-instanceStorage.js
@@ -129,7 +129,7 @@ test('makeInstanceRecordStorage', async t => {
   addIssuerToInstanceRecord(
     'Money',
     makeIssuerRecord(currencyKit.brand, currencyKit.issuer, {
-      assetKind: AssetKind.NAT, 
+      assetKind: AssetKind.NAT,
       decimalPlaces: 18,
     }),
   );

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -19,6 +19,12 @@ test(`zcf.getZoeService`, async t => {
   t.is(await zoeService, zoe);
 });
 
+test(`zcf.getInstance`, async t => {
+  const { zcf, instance } = await setupZCFTest();
+  const instanceFromZCF = zcf.getInstance();
+  t.is(instance, instanceFromZCF);
+});
+
 test(`zcf.getInvitationIssuer`, async t => {
   const { zoe, zcf } = await setupZCFTest();
   const zcfInvitationIssuer = zcf.getInvitationIssuer();


### PR DESCRIPTION
Closes #3330 

Adds a method to zcf: `getInstance()`. This allows the contract code to easily get its own instance, in order to send elsewhere. 