### PR TITLE
fix: Revert eslint to @agoric

### DIFF
--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -76,7 +76,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "prettier": {

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -81,7 +81,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "ava": {

--- a/packages/access-token/package.json
+++ b/packages/access-token/package.json
@@ -37,7 +37,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "prettier": {

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -57,7 +57,7 @@
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "ava": {

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -48,7 +48,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "eslintIgnore": [

--- a/packages/bundle-source/package.json
+++ b/packages/bundle-source/package.json
@@ -63,7 +63,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "prettier": {

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -62,7 +62,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "prettier": {

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -50,7 +50,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "prettier": {

--- a/packages/dapp-svelte-wallet/package.json
+++ b/packages/dapp-svelte-wallet/package.json
@@ -34,7 +34,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "prettier": {

--- a/packages/deploy-script-support/package.json
+++ b/packages/deploy-script-support/package.json
@@ -74,7 +74,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "prettier": {

--- a/packages/deployment/package.json
+++ b/packages/deployment/package.json
@@ -40,7 +40,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "prettier": {

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -43,7 +43,7 @@
   ],
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "prettier": {

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -46,7 +46,7 @@
   "homepage": "https://github.com/Agoric/agoric-sdk/packages/import-bundle",
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "prettier": {

--- a/packages/import-manager/package.json
+++ b/packages/import-manager/package.json
@@ -50,7 +50,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "eslintIgnore": [

--- a/packages/install-metering-and-ses/package.json
+++ b/packages/install-metering-and-ses/package.json
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "eslintIgnore": [

--- a/packages/install-ses/package.json
+++ b/packages/install-ses/package.json
@@ -45,7 +45,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "eslintIgnore": [

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -53,7 +53,7 @@
   ],
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "prettier": {

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -51,7 +51,7 @@
   ],
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "eslintIgnore": [

--- a/packages/pegasus/package.json
+++ b/packages/pegasus/package.json
@@ -69,7 +69,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "eslintIgnore": [

--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -45,7 +45,7 @@
   ],
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "eslintIgnore": [

--- a/packages/same-structure/package.json
+++ b/packages/same-structure/package.json
@@ -46,7 +46,7 @@
   ],
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "eslintIgnore": [

--- a/packages/sharing-service/package.json
+++ b/packages/sharing-service/package.json
@@ -45,7 +45,7 @@
   ],
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "eslintIgnore": [

--- a/packages/solo/package.json
+++ b/packages/solo/package.json
@@ -60,7 +60,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "prettier": {

--- a/packages/sparse-ints/package.json
+++ b/packages/sparse-ints/package.json
@@ -46,7 +46,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "eslintIgnore": [

--- a/packages/spawner/package.json
+++ b/packages/spawner/package.json
@@ -52,7 +52,7 @@
   ],
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "eslintIgnore": [

--- a/packages/stat-logger/package.json
+++ b/packages/stat-logger/package.json
@@ -40,7 +40,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "prettier": {

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -49,7 +49,7 @@
   ],
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "eslintIgnore": [

--- a/packages/swing-store-lmdb/package.json
+++ b/packages/swing-store-lmdb/package.json
@@ -44,7 +44,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "prettier": {

--- a/packages/swing-store-simple/package.json
+++ b/packages/swing-store-simple/package.json
@@ -42,7 +42,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "prettier": {

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -45,7 +45,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "prettier": {

--- a/packages/tame-metering/package.json
+++ b/packages/tame-metering/package.json
@@ -41,7 +41,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "prettier": {

--- a/packages/transform-metering/package.json
+++ b/packages/transform-metering/package.json
@@ -56,7 +56,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "prettier": {

--- a/packages/treasury/package.json
+++ b/packages/treasury/package.json
@@ -69,7 +69,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "eslintIgnore": [

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -32,7 +32,7 @@
   "eslintConfig": {
     "extends": [
       "react-app",
-      "@endo"
+      "@agoric"
     ],
     "rules": {
       "no-use-before-define": "off",

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -50,7 +50,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "prettier": {

--- a/packages/xsnap/package.json
+++ b/packages/xsnap/package.json
@@ -52,7 +52,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ],
     "ignorePatterns": [
       "examples/**/*.js"

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -87,7 +87,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "@endo"
+      "@agoric"
     ]
   },
   "eslintIgnore": [


### PR DESCRIPTION
ESlint no longer works in VS Code, though it works fine as a build step and in CI. This reverts the migration from `@agoric/eslint*` to `@endo/*` until we can make VS Code work recognize the version installed in `node_modules`.
