### PR TITLE
chore: update moddable to get snapshot fixes

### DIFF
--- a/packages/xsnap/api.js
+++ b/packages/xsnap/api.js
@@ -3,7 +3,7 @@
 /** The version identifier for our meter type.
  * TODO Bump this whenever there's a change to metering semantics.
  */
-export const METER_TYPE = 'xs-meter-7';
+export const METER_TYPE = 'xs-meter-8';
 
 export const ExitCode = {
   E_UNKNOWN_ERROR: -1,

--- a/packages/xsnap/src/xsnap.c
+++ b/packages/xsnap/src/xsnap.c
@@ -83,15 +83,13 @@ static char* fxWriteNetStringError(int code);
 // The order of the callbacks materially affects how they are introduced to
 // code that runs from a snapshot, so must be consistent in the face of
 // upgrade.
-#define mxSnapshotCallbackCount 6
+#define mxSnapshotCallbackCount 5
 txCallback gxSnapshotCallbacks[mxSnapshotCallbackCount] = {
 	fx_issueCommand, // 0
-	// fx_Array_prototype_meter, // 1
-	NULL, // 1
-	fx_print, // 2
-	fx_setImmediate, // 3
-	fx_gc, // 4
-	fx_performance_now, // 5
+	fx_print, // 1
+	fx_setImmediate, // 2
+	fx_gc, // 3
+	fx_performance_now, // 4
 	// fx_evalScript,
 	// fx_isPromiseJobQueueEmpty,
 	// fx_setInterval,

--- a/packages/xsnap/src/xsnap.c
+++ b/packages/xsnap/src/xsnap.c
@@ -46,13 +46,9 @@ static void fxCheckAliasesError(txMachine* the, txAliasIDList* list, txFlag flag
 static void fxCheckEnvironmentAliases(txMachine* the, txSlot* environment, txAliasIDList* list);
 static void fxCheckInstanceAliases(txMachine* the, txSlot* instance, txAliasIDList* list);
 static void fxFreezeBuiltIns(txMachine* the);
-static void fxPatchBuiltIns(txMachine* the);
 static void fxPrintUsage();
 
 static void fx_issueCommand(xsMachine *the);
-#if 0
-static void fx_Array_prototype_meter(xsMachine* the);
-#endif
 
 extern void fx_clearTimer(txMachine* the);
 static void fx_destroyTimer(void* data);
@@ -335,7 +331,6 @@ ExitCode main(int argc, char* argv[])
 	else {
 		machine = xsCreateMachine(creation, "xsnap", NULL);
 		fxBuildAgent(machine);
-		fxPatchBuiltIns(machine);
 	}
 	if (freeze) {
 		fxFreezeBuiltIns(machine);
@@ -858,33 +853,6 @@ void fxFreezeBuiltIns(txMachine* the)
 	mxFreezeBuiltInCall; mxPush(mxHosts); mxFreezeBuiltInRun; //@@
 
 	mxPop();
-}
-
-#if 0
-void fx_Array_prototype_meter(xsMachine* the)
-{
-	xsIntegerValue length = xsToInteger(xsGet(xsThis, xsID("length")));
-	xsMeterHostFunction(length);
-}
-#endif
-
-void fxPatchBuiltIns(txMachine* machine)
-{
-	// FIXME: This function is disabled because it caused failures.
-	// https://github.com/Moddable-OpenSource/moddable/issues/550
-
-	// TODO: Provide complete metering of builtins and operators.
-#if 0
-	xsBeginHost(machine);
-	xsVars(2);
-	xsVar(0) = xsGet(xsGlobal, xsID("Array"));
-	xsVar(0) = xsGet(xsVar(0), xsID("prototype"));
-	xsVar(1) = xsGet(xsVar(0), xsID("reverse"));
-	xsPatchHostFunction(xsVar(1), fx_Array_prototype_meter);
-	xsVar(1) = xsGet(xsVar(0), xsID("sort"));
-	xsPatchHostFunction(xsVar(1), fx_Array_prototype_meter);
-	xsEndHost(machine);
-#endif
 }
 
 void fxPrintUsage()

--- a/packages/xsnap/src/xsnap.c
+++ b/packages/xsnap/src/xsnap.c
@@ -50,7 +50,9 @@ static void fxPatchBuiltIns(txMachine* the);
 static void fxPrintUsage();
 
 static void fx_issueCommand(xsMachine *the);
+#if 0
 static void fx_Array_prototype_meter(xsMachine* the);
+#endif
 
 extern void fx_clearTimer(txMachine* the);
 static void fx_destroyTimer(void* data);
@@ -84,7 +86,8 @@ static char* fxWriteNetStringError(int code);
 #define mxSnapshotCallbackCount 6
 txCallback gxSnapshotCallbacks[mxSnapshotCallbackCount] = {
 	fx_issueCommand, // 0
-	fx_Array_prototype_meter, // 1
+	// fx_Array_prototype_meter, // 1
+	NULL, // 1
 	fx_print, // 2
 	fx_setImmediate, // 3
 	fx_gc, // 4
@@ -859,11 +862,13 @@ void fxFreezeBuiltIns(txMachine* the)
 	mxPop();
 }
 
+#if 0
 void fx_Array_prototype_meter(xsMachine* the)
 {
 	xsIntegerValue length = xsToInteger(xsGet(xsThis, xsID("length")));
 	xsMeterHostFunction(length);
 }
+#endif
 
 void fxPatchBuiltIns(txMachine* machine)
 {

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -17,7 +17,7 @@ import * as netstring from './netstring.js';
 import * as node from './node-stream.js';
 
 // This will need adjustment, but seems to be fine for a start.
-export const DEFAULT_CRANK_METERING_LIMIT = 1e7;
+export const DEFAULT_CRANK_METERING_LIMIT = 1e8;
 
 const OK = '.'.charCodeAt(0);
 const ERROR = '!'.charCodeAt(0);

--- a/packages/xsnap/test/test-replay.js
+++ b/packages/xsnap/test/test-replay.js
@@ -15,7 +15,7 @@ const io = { spawn: proc.spawn, os: os.type() }; // WARNING: ambient
 const transcript1 = [
   [
     '/xsnap-tests/00000-options.json',
-    '{"os":"Linux","name":"xsnap test worker","debug":false,"meteringLimit":10000000}',
+    '{"os":"Linux","name":"xsnap test worker","debug":false,"meteringLimit":100000000}',
   ],
   [
     '/xsnap-tests/00001-evaluate.dat',

--- a/packages/xsnap/test/test-xs-perf.js
+++ b/packages/xsnap/test/test-xs-perf.js
@@ -63,6 +63,8 @@ test('meter details', async t => {
     },
     'auxiliary (non-consensus) meters are available',
   );
+  // @ts-ignore extra meters not declared on RunResult (yet?)
+  t.true(meters.mapSetAddCount > 20000);
   t.is(meterType, 'xs-meter-8');
 });
 

--- a/packages/xsnap/test/test-xs-perf.js
+++ b/packages/xsnap/test/test-xs-perf.js
@@ -63,7 +63,7 @@ test('meter details', async t => {
     },
     'auxiliary (non-consensus) meters are available',
   );
-  // @ts-ignore extra meters not declared on RunResult (yet?)
+  // @ts-ignore extra meters not declared on RunResult (TODO: #3139)
   t.true(meters.mapSetAddCount > 20000);
   t.is(meterType, 'xs-meter-8');
 });


### PR DESCRIPTION
fixes #3350
fixes #2322
ref https://github.com/agoric-labs/moddable/tree/ag-testnet-4

We were previously at a97e1fb60dde. Moddable released the fixes re #3350 as well as metering for bigint, regex for #2322. Here we add test and bump the metering version. In the moddable repo, the top two commits (20ec3085, 29b71e09) are our metering tweaks, rebased. 2602c98c is the latest change from moddable that affects XS.

```
moddable/xs$ git log --graph --pretty=format:'%ad %h %s' --abbrev-commit --date=short a97e1.. .
* 2021-05-02 29b71e09 feat(xsnap): count additions and removals from maps, sets
* 2021-05-01 20ec3085 feat: maintain garbageCollectionCount for xsnap
* 2021-06-20 2602c98c quick change to preflight keys needed by mod
* 2021-06-19 71b46945 XS: too many mod keys will abort later
* 2021-06-19 2572a7bc XS snapshot missing bound functions callback
* 2021-06-18 fd6dcf52 XS: safer capture error stack
* 2021-06-17 028fcd45 XS snapshot: cleanup chunks after wrtiting
* 2021-06-15 969ba224 XS metering string from/to number conversions
* 2021-06-14 274c545f XS: metering bigint
* 2021-06-14 a14a5c03 XS: metering regexp
* 2021-06-14 b594c62a XS: metering changes
* 2021-06-09 b99a8268 add ArrayBuffer.fromBigInt

moddable/xs$ git diff -w --stat a97e1fb60dde.. .
 xs/includes/xs.d.ts       |  1 +
 xs/platforms/esp/xsHost.c |  8 ++++++++
 xs/sources/xsAPI.c        | 35 +++++++++++++++++++++++++++++++++--
 xs/sources/xsAll.h        |  3 +--
 xs/sources/xsBigInt.c     | 65 ++++++++++++++++++++++++++++++++++++++++++++++-------------------
 xs/sources/xsError.c      |  8 ++++++--
 xs/sources/xsFunction.c   | 35 -----------------------------------
 xs/sources/xsRun.c        | 20 +++++++++++++++-----
 xs/sources/xsSnapshot.c   | 21 ++++++++++++++++++++-
 xs/sources/xsre.c         | 19 +++++++++++++++++--
 10 files changed, 147 insertions(+), 68 deletions(-)

```

