### PR TITLE
fix(xsnap): Account for TypedArray and subarrays in Text shim

### DIFF
--- a/packages/xsnap/lib/text-shim.js
+++ b/packages/xsnap/lib/text-shim.js
@@ -13,8 +13,16 @@ class TextEncoder {
 }
 
 class TextDecoder {
-  decode(bs) {
-    return fromArrayBuffer(bs);
+  decode(bytes) {
+    // TODO: the following condition can be removed in a future update of XS.
+    // https://github.com/Agoric/agoric-sdk/issues/3362
+    if (ArrayBuffer.isView(bytes)) {
+      bytes = bytes.buffer.slice(
+        bytes.byteOffset,
+        bytes.byteOffset + bytes.byteLength,
+      );
+    }
+    return fromArrayBuffer(bytes);
   }
 }
 

--- a/packages/xsnap/lib/text-shim.js
+++ b/packages/xsnap/lib/text-shim.js
@@ -7,8 +7,8 @@ const { fromString } = ArrayBuffer;
 const { fromArrayBuffer } = String;
 
 class TextEncoder {
-  encode(s) {
-    return new Uint8Array(fromString(s));
+  encode(text) {
+    return new Uint8Array(fromString(text));
   }
 }
 


### PR DESCRIPTION
refs: This change is necessary for integration of Zip archives #3346

At this time, XS does not provide a node-nor-web-compatible `TextEncoder` or `TextDecoder` so `xsnap` provides a shim. The shim is written in terms of XS's proprietary `String.fromArrayBuffer` and `ArrayBuffer.fromString` which do not yet take into account TypedArrays (only accepting ArrayBuffer, strictly) and do not account for subarray views that are not aligned at byteOffset zero. This change adds a test, and a temporary fix. When we next update Moddable/XS, the fix can be removed.

Caveat: the underlying XS API still truncates strings at the first encountered C null terminator which is necessary for continued compatibility with other tools in the Moddable ecosystem. Moddable may mitigate this by adding a module for a web-and-node-compatible `TextEncoder` and `TextDecoder` in a future version, but the limitation is currently bearable.
