### PR TITLE
fix: Patch external-editor constructor override error

### DIFF
--- a/patches/external-editor+3.1.0.patch
+++ b/patches/external-editor+3.1.0.patch
@@ -38,3 +38,51 @@ index 85a164e..217f192 100644
          d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
      };
  })();
+diff --git a/node_modules/external-editor/main/errors/ReadFileError.js b/node_modules/external-editor/main/errors/ReadFileError.js
+index 69e0513..e53e584 100644
+--- a/node_modules/external-editor/main/errors/ReadFileError.js
++++ b/node_modules/external-editor/main/errors/ReadFileError.js
+@@ -14,7 +14,18 @@ var __extends = (this && this.__extends) || (function () {
+     };
+     return function (d, b) {
+         extendStatics(d, b);
+-        function __() { this.constructor = d; }
++        function __() {
++          if (Object.defineProperty) {
++            Object.defineProperty(this, 'constructor', {
++              value: d,
++              writable: true,
++              configurable: true,
++              enumerable: true,
++            });
++          } else {
++            this.constructor = d;
++          }
++        }
+         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+     };
+ })();
+diff --git a/node_modules/external-editor/main/errors/RemoveFileError.js b/node_modules/external-editor/main/errors/RemoveFileError.js
+index 23d266f..86e228e 100644
+--- a/node_modules/external-editor/main/errors/RemoveFileError.js
++++ b/node_modules/external-editor/main/errors/RemoveFileError.js
+@@ -14,7 +14,18 @@ var __extends = (this && this.__extends) || (function () {
+     };
+     return function (d, b) {
+         extendStatics(d, b);
+-        function __() { this.constructor = d; }
++        function __() {
++          if (Object.defineProperty) {
++            Object.defineProperty(this, 'constructor', {
++              value: d,
++              writable: true,
++              configurable: true,
++              enumerable: true,
++            });
++          } else {
++            this.constructor = d;
++          }
++        }
+         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+     };
+ })();


### PR DESCRIPTION
refs: This is necessary to unblock the addition of Zip archive bundles #3273

One transitive dependency of Agoric SDK is a module called `external-editor` that trips the prototype property override hazard after lockdown.  This includes a patch to that module that fixes the property override using `defineProperty`.
