### PR TITLE
various comms-GC-related cleanups

### DIFF
--- a/packages/SwingSet/src/vats/comms/clist-inbound.js
+++ b/packages/SwingSet/src/vats/comms/clist-inbound.js
@@ -35,7 +35,6 @@ export function makeInbound(state) {
     insistRemoteType('promise', rpid);
     const remote = state.getRemote(remoteID);
     const lpid = remote.mapFromRemote(flipRemoteSlot(rpid));
-    remote.deleteToRemoteMapping(lpid);
     remote.enqueueRetirement(rpid);
     cdebug(`comms begin retiring ${remoteID} ${rpid} ${lpid}`);
   }

--- a/packages/SwingSet/src/vats/comms/clist-inbound.js
+++ b/packages/SwingSet/src/vats/comms/clist-inbound.js
@@ -27,7 +27,7 @@ export function makeInbound(state) {
       subscribers.indexOf(remoteID) === -1,
       X`attempt to retire remote ${remoteID} subscribed promise ${rpid}`,
     );
-    remote.deleteRemoteMapping(rpid, lpid);
+    remote.deleteRemoteMapping(lpid);
     cdebug(`comms delete mapping r<->k ${remoteID} {rpid}<=>${lpid}`);
   }
 

--- a/packages/SwingSet/src/vats/comms/clist-kernel.js
+++ b/packages/SwingSet/src/vats/comms/clist-kernel.js
@@ -72,7 +72,7 @@ export function makeKernel(state, syscall) {
       !kernelIsSubscribed,
       X`attempt to retire subscribed promise ${kfpid}`,
     );
-    state.deleteKernelMapping(kfpid, lpid);
+    state.deleteKernelMapping(lpid);
     cdebug(`comms delete mapping l<->k ${kfpid}<=>${lpid}`);
   }
 

--- a/packages/SwingSet/src/vats/comms/delivery.js
+++ b/packages/SwingSet/src/vats/comms/delivery.js
@@ -147,10 +147,7 @@ export function makeDeliveryKit(state, syscall, transmit, clistKit) {
       delim2 >= 0,
       X`received message ${message} lacks ackSeqNum delimiter`,
     );
-    const ackSeqNum = Number.parseInt(
-      message.substring(delim1 + 1, delim2),
-      10,
-    );
+    const ackSeqNum = parseInt(message.substring(delim1 + 1, delim2), 10);
     handleAckFromRemote(remoteID, ackSeqNum);
 
     const msgBody = message.substring(delim2 + 1);

--- a/packages/SwingSet/src/vats/comms/dispatch.js
+++ b/packages/SwingSet/src/vats/comms/dispatch.js
@@ -143,13 +143,13 @@ export function buildCommsDispatch(
 
   function deliver(target, method, args, resultP) {
     const result = doDeliver(target, method, args, resultP);
-    state.purgeDeadLocalPromises();
+    state.processMaybeFree();
     return result;
   }
 
   function notify(resolutions) {
     resolveFromKernel(resolutions);
-    state.purgeDeadLocalPromises();
+    state.processMaybeFree();
   }
 
   function dropExports(vrefs) {

--- a/packages/SwingSet/src/vats/comms/dispatch.js
+++ b/packages/SwingSet/src/vats/comms/dispatch.js
@@ -132,7 +132,7 @@ export function buildCommsDispatch(
     // crank).  The resulting abrupt comms vat termination should serve as a
     // diagnostic signal that we have a bug that must be corrected.
 
-    args.slots.map(s =>
+    args.slots.forEach(s =>
       assert(
         !state.hasMetaObject(s),
         X`comms meta-object ${s} not allowed in message args`,

--- a/packages/SwingSet/src/vats/comms/remote.js
+++ b/packages/SwingSet/src/vats/comms/remote.js
@@ -67,10 +67,6 @@ export function makeRemote(state, store, remoteID) {
     state.decrementRefCount(lref, `{rref}|${remoteID}|clist`);
   }
 
-  function deleteToRemoteMapping(lref) {
-    store.delete(`${remoteID}.c.${lref}`);
-  }
-
   function nextSendSeqNum() {
     return Number(store.getRequired(`${remoteID}.sendSeq`));
   }
@@ -150,7 +146,6 @@ export function makeRemote(state, store, remoteID) {
     mapToRemote,
     addRemoteMapping,
     deleteRemoteMapping,
-    deleteToRemoteMapping,
     allocateRemoteObject,
     skipRemoteObjectID,
     allocateRemotePromise,

--- a/packages/SwingSet/src/vats/comms/remote.js
+++ b/packages/SwingSet/src/vats/comms/remote.js
@@ -70,22 +70,22 @@ export function makeRemote(state, store, remoteID) {
   }
 
   function nextSendSeqNum() {
-    return Number(store.getRequired(`${remoteID}.sendSeq`));
+    return parseInt(store.getRequired(`${remoteID}.sendSeq`), 10);
   }
 
   function advanceSendSeqNum() {
     const key = `${remoteID}.sendSeq`;
-    const seqNum = Number(store.getRequired(key));
+    const seqNum = parseInt(store.getRequired(key), 10);
     store.set(key, `${seqNum + 1}`);
   }
 
   function lastReceivedSeqNum() {
-    return Number(store.getRequired(`${remoteID}.recvSeq`));
+    return parseInt(store.getRequired(`${remoteID}.recvSeq`), 10);
   }
 
   function advanceReceivedSeqNum() {
     const key = `${remoteID}.recvSeq`;
-    let seqNum = Number(store.getRequired(key));
+    let seqNum = parseInt(store.getRequired(key), 10);
     seqNum += 1;
     store.set(key, `${seqNum}`);
     return seqNum;

--- a/packages/SwingSet/src/vats/comms/remote.js
+++ b/packages/SwingSet/src/vats/comms/remote.js
@@ -61,8 +61,10 @@ export function makeRemote(state, store, remoteID) {
     state.incrementRefCount(lref, `{rref}|${remoteID}|clist`);
   }
 
-  function deleteRemoteMapping(rref, lref) {
-    store.delete(`${remoteID}.c.${rref}`);
+  function deleteRemoteMapping(lref) {
+    const rrefOutbound = store.get(`${remoteID}.c.${lref}`);
+    const rrefInbound = flipRemoteSlot(rrefOutbound);
+    store.delete(`${remoteID}.c.${rrefInbound}`);
     store.delete(`${remoteID}.c.${lref}`);
     state.decrementRefCount(lref, `{rref}|${remoteID}|clist`);
   }

--- a/packages/SwingSet/src/vats/comms/state.js
+++ b/packages/SwingSet/src/vats/comms/state.js
@@ -168,7 +168,8 @@ export function makeState(syscall, identifierBase = 0) {
    * @param {string} _tag  Descriptive label for use in diagnostics
    */
   function incrementRefCount(lref, _tag) {
-    if (lref && parseLocalSlot(lref).type === 'promise') {
+    const { type } = parseLocalSlot(lref);
+    if (type === 'promise') {
       const refCount = Number(store.get(`${lref}.refCount`)) + 1;
       // cdebug(`++ ${lref}  ${tag} ${refCount}`);
       if (refCount === 1 && deadLocalPromises.has(lref)) {
@@ -192,7 +193,8 @@ export function makeState(syscall, identifierBase = 0) {
    * @throws if this tries to decrement the reference count below zero.
    */
   function decrementRefCount(lref, tag) {
-    if (lref && parseLocalSlot(lref).type === 'promise') {
+    const { type } = parseLocalSlot(lref);
+    if (type === 'promise') {
       let refCount = Number(store.get(`${lref}.refCount`));
       assert(refCount > 0n, X`refCount underflow {lref} ${tag}`);
       refCount -= 1;

--- a/packages/SwingSet/src/vats/comms/state.js
+++ b/packages/SwingSet/src/vats/comms/state.js
@@ -188,9 +188,7 @@ export function makeState(syscall, identifierBase = 0) {
    *
    * @param {string} lref  Ref of the local object whose refcount is to be decremented.
    * @param {string} tag  Descriptive label for use in diagnostics
-   * @returns {boolean} true if the reference count has been decremented to
-   *    zero, false if it is still non-zero
-   * @throws if this tries to decrement the reference count below zero.
+   * @throws if this tries to decrement a reference count below zero.
    */
   function decrementRefCount(lref, tag) {
     const { type } = parseLocalSlot(lref);
@@ -212,10 +210,8 @@ export function makeState(syscall, identifierBase = 0) {
         // dispatch is complete and any ancillary promises are safely referenced
         // by their subscribers clists.
         deadLocalPromises.add(lref);
-        return true;
       }
     }
-    return false;
   }
 
   /**

--- a/packages/SwingSet/src/vats/comms/state.js
+++ b/packages/SwingSet/src/vats/comms/state.js
@@ -174,7 +174,7 @@ export function makeState(syscall, identifierBase = 0) {
   function incrementRefCount(lref, _tag) {
     const { type } = parseLocalSlot(lref);
     if (type === 'promise') {
-      const refCount = Number(store.get(`${lref}.refCount`)) + 1;
+      const refCount = parseInt(store.get(`${lref}.refCount`), 10) + 1;
       // cdebug(`++ ${lref}  ${tag} ${refCount}`);
       store.set(`${lref}.refCount`, `${refCount}`);
     }
@@ -193,7 +193,7 @@ export function makeState(syscall, identifierBase = 0) {
   function decrementRefCount(lref, tag) {
     const { type } = parseLocalSlot(lref);
     if (type === 'promise') {
-      let refCount = Number(store.get(`${lref}.refCount`));
+      let refCount = parseInt(store.get(`${lref}.refCount`), 10);
       assert(refCount > 0n, X`refCount underflow {lref} ${tag}`);
       refCount -= 1;
       // cdebug(`-- ${lref}  ${tag} ${refCount}`);
@@ -235,7 +235,7 @@ export function makeState(syscall, identifierBase = 0) {
         if (type === 'promise' && enableLocalPromiseGC) {
           const s = store.get(`${lref}.refCount`);
           if (s) {
-            const refCount = Number(s);
+            const refCount = parseInt(s, 10);
             // refCount>0 means they were saved from near-certain death
             if (!refCount) {
               let idx = 0;
@@ -469,10 +469,10 @@ export function makeState(syscall, identifierBase = 0) {
     insistVatType('object', transmitterID);
     addMetaObject(transmitterID);
 
-    const index = Number(store.getRequired('r.nextID'));
+    const index = parseInt(store.getRequired('r.nextID'), 10);
     store.set('r.nextID', `${index + 1}`);
     const remoteID = `r${index}`;
-    const idBase = Number(store.get('identifierBase'));
+    const idBase = parseInt(store.get('identifierBase'), 10);
     store.set('identifierBase', `${idBase + 1000}`);
     initializeRemoteState(store, remoteID, idBase, name, transmitterID);
     store.set(nameKey, remoteID);

--- a/packages/SwingSet/src/vats/comms/state.js
+++ b/packages/SwingSet/src/vats/comms/state.js
@@ -268,7 +268,8 @@ export function makeState(syscall, identifierBase = 0) {
     incrementRefCount(lref, `{kfref}|k|clist`);
   }
 
-  function deleteKernelMapping(kfref, lref) {
+  function deleteKernelMapping(lref) {
+    const kfref = store.get(`c.${lref}`);
     store.delete(`c.${kfref}`);
     store.delete(`c.${lref}`);
     decrementRefCount(lref, `{kfref}|k|clist`);

--- a/packages/SwingSet/test/test-comms.js
+++ b/packages/SwingSet/test/test-comms.js
@@ -426,12 +426,12 @@ test('retire result promise on inbound message', t => {
   _('k>r', [pResult, false, 42]);
   _('a<r', [paResult, false, 42]);
 
-  // Now the kernel c-list entries and the outbound remote c-list entry should
-  // be gone but the inbound remote c-list entry should still be there.  The
-  // result promise should also still be there, but be in a resolved state.
+  // Now the kernel c-list entries should be gone but the inbound/outbound
+  // remote c-list entries should still be there. The result promise should
+  // also still be there, but be in a resolved state.
   t.falsy(state.mapFromKernel(refOf(pResult)));
   t.falsy(state.mapToKernel(plResult));
-  t.falsy(remoteA.mapToRemote(plResult));
+  t.truthy(remoteA.mapToRemote(plResult));
   t.truthy(remoteA.mapFromRemote(refOf(paResult)));
   t.is(state.getPromiseStatus(plResult), 'fulfilled');
 
@@ -439,8 +439,8 @@ test('retire result promise on inbound message', t => {
   _('a>m', oaLarry, 'more', undefined);
   _('k<m', oLarry, 'more', undefined);
 
-  // And now the inbound remote c-list entry and the promise itself should be
-  // gone too.
+  // And now the remote c-list entries and the promise itself should be gone
+  t.falsy(remoteA.mapToRemote(plResult));
   t.falsy(remoteA.mapFromRemote(refOf(paResult)));
   t.is(state.getPromiseStatus(plResult), undefined);
 
@@ -555,16 +555,16 @@ test('retire outbound promises', t => {
   _('k>r', [pPromise1, false, [pPromise2]], [pPromise2, false, [pPromise1]]);
   _('a<r', [paPromise1, false, [paPromise2]], [paPromise2, false, [paPromise1]]);
 
-  // Now the kernel c-list entries and the outbound remote c-list entries should
-  // be gone but the inbound remote c-list entries should still be there
+  // Now the kernel c-list entries should be gone, but the inbound/outgoung
+  // remote c-list entries should still be there
   t.falsy(state.mapFromKernel(refOf(pPromise1)));
   t.falsy(state.mapToKernel(plPromise1));
-  t.falsy(remoteA.mapToRemote(plPromise1));
+  t.truthy(remoteA.mapToRemote(plPromise1));
   t.truthy(remoteA.mapFromRemote(refOf(paPromise1)));
 
   t.falsy(state.mapFromKernel(refOf(pPromise2)));
   t.falsy(state.mapToKernel(plPromise2));
-  t.falsy(remoteA.mapToRemote(plPromise2));
+  t.truthy(remoteA.mapToRemote(plPromise2));
   t.truthy(remoteA.mapFromRemote(refOf(paPromise2)));
 
   // Then the remote sends some traffic, which will contain an ack
@@ -572,7 +572,9 @@ test('retire outbound promises', t => {
   _('k<m', oLarry, 'more', undefined);
 
   // And now the inbound remote c-list entries should be gone too.
+  t.falsy(remoteA.mapToRemote(plPromise1));
   t.falsy(remoteA.mapFromRemote(refOf(paPromise1)));
+  t.falsy(remoteA.mapToRemote(plPromise2));
   t.falsy(remoteA.mapFromRemote(refOf(paPromise2)));
 
   done();


### PR DESCRIPTION
These commits smooth the way for the upcoming GC-over-comms branch. Mostly refactorings, although the `processMaybeFree` rearrangement has the potential to slightly modify the behavior (hopefully in a good way).

refs #3306 
