### PR TITLE
Extract a closureFacet for testing

### DIFF
--- a/packages/governance/src/binaryBallotCounter.js
+++ b/packages/governance/src/binaryBallotCounter.js
@@ -6,7 +6,7 @@ import { makePromiseKit } from '@agoric/promise-kit';
 import { Far } from '@agoric/marshal';
 
 import { ChoiceMethod, buildBallot } from './ballotBuilder';
-import { scheduleClose } from './closure';
+import { scheduleClose } from './closingRule';
 
 const makeWeightedBallot = (ballot, shares) => ({ ballot, shares });
 
@@ -28,7 +28,7 @@ const makeBinaryBallotCounter = (
   positions,
   threshold,
   tieOutcome = undefined,
-  closureRule,
+  closingRule,
 ) => {
   assert(
     positions.length === 2,
@@ -126,7 +126,7 @@ const makeBinaryBallotCounter = (
   const sharedFacet = {
     getBallotTemplate: () => template,
     isOpen: () => isOpen,
-    getClosureRule: () => closureRule,
+    getClosingRule: () => closingRule,
   };
 
   /** @type {VoterFacet} */
@@ -136,7 +136,7 @@ const makeBinaryBallotCounter = (
   });
 
   // exposed for testing. In contracts, shouldn't be released.
-  const closeFacet = Far('', { closeVoting });
+  const closeFacet = Far('closeFacet', { closeVoting });
 
   /** @type {BallotCounterCreatorFacet} */
   const creatorFacet = Far('adminFacet', {
@@ -164,7 +164,7 @@ const start = zcf => {
     positions,
     quorumThreshold,
     tieOutcome,
-    closureRule,
+    closingRule,
   } = zcf.getTerms();
 
   // The closeFacet is exposed for testing, but doesn't escape from a contract
@@ -173,10 +173,10 @@ const start = zcf => {
     positions,
     quorumThreshold,
     tieOutcome,
-    closureRule,
+    closingRule,
   );
 
-  scheduleClose(closureRule, closeFacet.closeVoting);
+  scheduleClose(closingRule, closeFacet.closeVoting);
 
   return { publicFacet, creatorFacet };
 };

--- a/packages/governance/src/binaryBallotCounter.js
+++ b/packages/governance/src/binaryBallotCounter.js
@@ -6,6 +6,7 @@ import { makePromiseKit } from '@agoric/promise-kit';
 import { Far } from '@agoric/marshal';
 
 import { ChoiceMethod, buildBallot } from './ballotBuilder';
+import { scheduleClose } from './closure';
 
 const makeWeightedBallot = (ballot, shares) => ({ ballot, shares });
 
@@ -27,14 +28,15 @@ const makeBinaryBallotCounter = (
   positions,
   threshold,
   tieOutcome = undefined,
+  closureRule,
 ) => {
   assert(
     positions.length === 2,
     X`Binary ballots must have exactly two positions. had ${positions.length}: ${positions}`,
   );
+  assert.typeof(question, 'string');
   assert.typeof(positions[0], 'string');
   assert.typeof(positions[1], 'string');
-  assert.typeof(question, 'string');
   if (tieOutcome) {
     assert(
       positions.includes(tieOutcome),
@@ -116,23 +118,29 @@ const makeBinaryBallotCounter = (
     }
   };
 
+  const closeVoting = () => {
+    isOpen = false;
+    countVotes();
+  };
+
   const sharedFacet = {
     getBallotTemplate: () => template,
     isOpen: () => isOpen,
+    getClosureRule: () => closureRule,
   };
 
   /** @type {VoterFacet} */
   const voterFacet = Far('voterFacet', {
+    ...sharedFacet,
     submitVote: recordBallot,
   });
+
+  // exposed for testing. In contracts, shouldn't be released.
+  const closeFacet = Far('', { closeVoting });
 
   /** @type {BallotCounterCreatorFacet} */
   const creatorFacet = Far('adminFacet', {
     ...sharedFacet,
-    closeVoting: () => {
-      isOpen = false;
-      countVotes();
-    },
     getVoterFacet: () => voterFacet,
   });
 
@@ -142,7 +150,7 @@ const makeBinaryBallotCounter = (
     getOutcome: () => outcomePromise.promise,
     getStats: () => tallyPromise.promise,
   });
-  return { publicFacet, creatorFacet };
+  return { publicFacet, creatorFacet, closeFacet };
 };
 
 const start = zcf => {
@@ -151,8 +159,26 @@ const start = zcf => {
   // discount abstentions, we could refactor to provide the quorumCounter as a
   // component.
   // TODO(hibbert) checking the quorum should be pluggable and legible.
-  const { question, positions, quorumThreshold } = zcf.getTerms();
-  return makeBinaryBallotCounter(question, positions, quorumThreshold);
+  const {
+    question,
+    positions,
+    quorumThreshold,
+    tieOutcome,
+    closureRule,
+  } = zcf.getTerms();
+
+  // The closeFacet is exposed for testing, but doesn't escape from a contract
+  const { publicFacet, creatorFacet, closeFacet } = makeBinaryBallotCounter(
+    question,
+    positions,
+    quorumThreshold,
+    tieOutcome,
+    closureRule,
+  );
+
+  scheduleClose(closureRule, closeFacet.closeVoting);
+
+  return { publicFacet, creatorFacet };
 };
 
 harden(start);

--- a/packages/governance/src/closingRule.js
+++ b/packages/governance/src/closingRule.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-// Standard closure rule is a deadline and Timer. An alternative might allow for
+// Standard closing rule is a deadline and Timer. An alternative might allow for
 // emergency votes that can close as soon as a quorum or other threshold is
 // reached.
 
@@ -8,12 +8,12 @@ import { Far } from '@agoric/marshal';
 import { E } from '@agoric/eventual-send';
 
 /** @type {CloseVoting} */
-export const scheduleClose = (closureRule, closeVoting) => {
-  const { timer, deadline } = closureRule;
+export const scheduleClose = (closingRule, closeVoting) => {
+  const { timer, deadline } = closingRule;
   E(timer).setWakeup(
     deadline,
     Far('close voting', {
-      wake: () => closeVoting(),
+      wake: closeVoting,
     }),
   );
 };

--- a/packages/governance/src/closure.js
+++ b/packages/governance/src/closure.js
@@ -1,0 +1,19 @@
+// @ts-check
+
+// Standard closure rule is a deadline and Timer. An alternative might allow for
+// emergency votes that can close as soon as a quorum or other threshold is
+// reached.
+
+import { Far } from '@agoric/marshal';
+import { E } from '@agoric/eventual-send';
+
+/** @type {CloseVoting} */
+export const scheduleClose = (closureRule, closeVoting) => {
+  const { timer, deadline } = closureRule;
+  E(timer).setWakeup(
+    deadline,
+    Far('close voting', {
+      wake: () => closeVoting(),
+    }),
+  );
+};

--- a/packages/governance/src/types.js
+++ b/packages/governance/src/types.js
@@ -82,7 +82,6 @@
  * @typedef {Object} BallotCounterCreatorFacet
  * @property {() => boolean} isOpen
  * @property {() => Ballot} getBallotTemplate
- * @property {() => void} closeVoting
  * @property {() => VoterFacet} getVoterFacet
  */
 
@@ -92,6 +91,12 @@
  * @property {() => Ballot} getBallotTemplate
  * @property {() => Promise<string>} getOutcome
  * @property {() => Promise<VoteStatistics>} getStats
+ */
+
+/**
+ * @typedef {Object} BallotCounterCloseFacet
+ *   TEST ONLY: Should not be allowed to escape from contracts
+ * @property {() => void} closeVoting
  */
 
 /**
@@ -128,4 +133,16 @@
 /**
  * @typedef {Object} VoterFacet
  * @property {SubmitVote} submitVote
+ */
+
+/**
+ * @typedef {Object} ClosureRule
+ * @property {Timer} timer
+ * @property {Timestamp} deadline
+ */
+
+/**
+ * @callback CloseVoting
+ * @param {ClosureRule} closureRule
+ * @param {() => void} closeVoting
  */

--- a/packages/governance/src/types.js
+++ b/packages/governance/src/types.js
@@ -136,13 +136,13 @@
  */
 
 /**
- * @typedef {Object} ClosureRule
+ * @typedef {Object} ClosingRule
  * @property {Timer} timer
  * @property {Timestamp} deadline
  */
 
 /**
  * @callback CloseVoting
- * @param {ClosureRule} closureRule
+ * @param {ClosingRule} closingRule
  * @param {() => void} closeVoting
  */

--- a/packages/governance/test/unitTests/test-ballotCount.js
+++ b/packages/governance/test/unitTests/test-ballotCount.js
@@ -12,7 +12,7 @@ const FISH = 'Fish';
 const BAIT = 'Cut Bait';
 
 test('binary ballot', async t => {
-  const { publicFacet, creatorFacet } = makeBinaryBallotCounter(
+  const { publicFacet, creatorFacet, closeFacet } = makeBinaryBallotCounter(
     QUESTION,
     [FISH, BAIT],
     1n,
@@ -28,7 +28,7 @@ test('binary ballot', async t => {
     aliceSeat,
     aliceTemplate.choose([alicePositions[0]]),
   );
-  creatorFacet.closeVoting();
+  closeFacet.closeVoting();
   const outcome = await E(publicFacet).getOutcome();
   t.deepEqual(outcome, FISH);
 });
@@ -59,7 +59,7 @@ test('binary spoiled', async t => {
 });
 
 test('binary tied', async t => {
-  const { publicFacet, creatorFacet } = makeBinaryBallotCounter(
+  const { publicFacet, creatorFacet, closeFacet } = makeBinaryBallotCounter(
     QUESTION,
     [FISH, BAIT],
     2n,
@@ -72,13 +72,13 @@ test('binary tied', async t => {
   const positions = aliceTemplate.getDetails().positions;
   E(voterFacet).submitVote(aliceSeat, aliceTemplate.choose([positions[0]]));
   await E(voterFacet).submitVote(bobSeat, aliceTemplate.choose([positions[1]]));
-  creatorFacet.closeVoting();
+  closeFacet.closeVoting();
   const outcome = await E(publicFacet).getOutcome();
   t.deepEqual(outcome, undefined);
 });
 
 test('binary tied w/fallback', async t => {
-  const { publicFacet, creatorFacet } = makeBinaryBallotCounter(
+  const { publicFacet, creatorFacet, closeFacet } = makeBinaryBallotCounter(
     QUESTION,
     [FISH, BAIT],
     2n,
@@ -92,7 +92,7 @@ test('binary tied w/fallback', async t => {
   const positions = aliceTemplate.getDetails().positions;
   E(voterFacet).submitVote(aliceSeat, aliceTemplate.choose([positions[0]]));
   await E(voterFacet).submitVote(bobSeat, aliceTemplate.choose([positions[1]]));
-  creatorFacet.closeVoting();
+  closeFacet.closeVoting();
   const outcome = await E(publicFacet).getOutcome();
   t.deepEqual(outcome, BAIT);
 });
@@ -145,19 +145,19 @@ test('binary counter does not match ballot', async t => {
 });
 
 test('binary no votes', async t => {
-  const { publicFacet, creatorFacet } = makeBinaryBallotCounter(
+  const { publicFacet, closeFacet } = makeBinaryBallotCounter(
     QUESTION,
     [FISH, BAIT],
     0n,
   );
 
-  creatorFacet.closeVoting();
+  closeFacet.closeVoting();
   const outcome = await E(publicFacet).getOutcome();
   t.deepEqual(outcome, undefined);
 });
 
 test('binary varying share weights', async t => {
-  const { publicFacet, creatorFacet } = makeBinaryBallotCounter(
+  const { publicFacet, creatorFacet, closeFacet } = makeBinaryBallotCounter(
     QUESTION,
     [FISH, BAIT],
     1n,
@@ -172,13 +172,13 @@ test('binary varying share weights', async t => {
   await E(voterFacet).submitVote(austinSeat, template.choose([BAIT]), 24n);
   await E(voterFacet).submitVote(saraSeat, template.choose([BAIT]), 11n);
 
-  creatorFacet.closeVoting();
+  closeFacet.closeVoting();
   const outcome = await E(publicFacet).getOutcome();
   t.deepEqual(outcome, 'Fish');
 });
 
 test('binary contested', async t => {
-  const { publicFacet, creatorFacet } = makeBinaryBallotCounter(
+  const { publicFacet, creatorFacet, closeFacet } = makeBinaryBallotCounter(
     QUESTION,
     [FISH, BAIT],
     3n,
@@ -193,14 +193,14 @@ test('binary contested', async t => {
 
   E(voterFacet).submitVote(aliceSeat, template.choose([positions[0]]), 23n);
   await E(voterFacet).submitVote(bobSeat, template.choose([positions[1]]), 47n);
-  creatorFacet.closeVoting();
+  closeFacet.closeVoting();
 
   const outcome = await E(publicFacet).getOutcome();
   t.deepEqual(outcome, BAIT);
 });
 
 test('binary revote', async t => {
-  const { publicFacet, creatorFacet } = makeBinaryBallotCounter(
+  const { publicFacet, creatorFacet, closeFacet } = makeBinaryBallotCounter(
     QUESTION,
     [FISH, BAIT],
     5n,
@@ -216,7 +216,7 @@ test('binary revote', async t => {
   E(voterFacet).submitVote(aliceSeat, template.choose([positions[0]]), 23n);
   E(voterFacet).submitVote(bobSeat, template.choose([positions[1]]), 47n);
   await E(voterFacet).submitVote(bobSeat, template.choose([positions[1]]), 15n);
-  creatorFacet.closeVoting();
+  closeFacet.closeVoting();
 
   const outcome = await E(publicFacet).getOutcome();
   t.deepEqual(outcome, FISH);
@@ -243,7 +243,7 @@ test('binary ballot too many', async t => {
 });
 
 test('binary no quorum', async t => {
-  const { publicFacet, creatorFacet } = makeBinaryBallotCounter(
+  const { publicFacet, creatorFacet, closeFacet } = makeBinaryBallotCounter(
     QUESTION,
     [FISH, BAIT],
     2n,
@@ -257,7 +257,7 @@ test('binary no quorum', async t => {
     aliceSeat,
     aliceTemplate.choose([positions[0]]),
   );
-  creatorFacet.closeVoting();
+  closeFacet.closeVoting();
   await E(publicFacet)
     .getOutcome()
     .then(o => t.fail(`expected to reject, not ${o}`))


### PR DESCRIPTION
The closureFacet is exposed for testing when binaryBallotBuilder is
imported. When used as a contract, ClosureRules have to be specified
in the terms, and are carried out outside the testable internal function.