### PR TITLE
fix(wallet): Nat values are now BigInts, so fix the parse output

### DIFF
--- a/packages/dapp-svelte-wallet/ui/src/display.js
+++ b/packages/dapp-svelte-wallet/ui/src/display.js
@@ -36,7 +36,7 @@ export function parseValue(str, displayInfo) {
     X`${str} exceeds ${decimalPlaces} decimal places`,
   );
 
-  return parseInt(`${unitstr}${dec0str0}`, 10);
+  return BigInt(`${unitstr}${dec0str0}`);
 }
 
 /**


### PR DESCRIPTION
Closes #3367, Closes #3368

After searching for `parseInt` and finding only this occurrence, I changed it to use `BigInt`.  I remember specifically when I had forked this code from my earlier work that did use BigInts, it was just never updated when ERTP changed to use them.

I lacked the confidence to migrate the wallet to use the new `ui-components/src/display/display.js` library since we are still considering rewriting the wallet.  I tested that this change (and a `yarn build`) solves the problem.
