### PR TITLE
More verbose kernel crashes

### DIFF
--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -639,10 +639,9 @@ func (app *GaiaApp) InitChainer(ctx sdk.Context, req abci.RequestInitChain) abci
 
 // Commit tells the controller that the block is commited
 func (app *GaiaApp) Commit() abci.ResponseCommit {
-	// Wrap the BaseApp's Commit method
-	res := app.BaseApp.Commit()
+	// Frontrun the BaseApp's Commit method
 	swingset.CommitBlock(app.SwingSetKeeper)
-	return res
+	return app.BaseApp.Commit()
 }
 
 // LoadHeight loads a particular height

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -410,7 +410,9 @@ export default function buildKernel(
     kernelKeeper.incStat('dispatchDeliver');
     // eslint-disable-next-line no-use-before-define
     if (!vatWarehouse.lookup(vatID)) {
-      resolveToError(msg.result, VAT_TERMINATION_ERROR);
+      if (msg.result) {
+        resolveToError(msg.result, VAT_TERMINATION_ERROR);
+      }
     } else {
       const kd = harden(['message', target, msg]);
       // eslint-disable-next-line no-use-before-define
@@ -445,7 +447,7 @@ export default function buildKernel(
       const vatID = kernelKeeper.ownerOfKernelObject(target);
       if (vatID) {
         await deliverToVat(vatID, target, msg);
-      } else {
+      } else if (msg.result) {
         resolveToError(msg.result, VAT_TERMINATION_ERROR);
       }
     } else if (type === 'promise') {
@@ -483,7 +485,7 @@ export default function buildKernel(
             } else {
               kernelKeeper.addMessageToPromiseQueue(target, msg);
             }
-          } else {
+          } else if (msg.result) {
             resolveToError(msg.result, VAT_TERMINATION_ERROR);
           }
         }

--- a/packages/cosmic-swingset/src/sim-chain.js
+++ b/packages/cosmic-swingset/src/sim-chain.js
@@ -149,8 +149,7 @@ export async function connectToFakeChain(basedir, GCI, delay, inbound) {
   );
 
   const simulateBlock = () =>
-    unhandledSimulateBlock().catch(e => {
-      console.error(e);
+    unhandledSimulateBlock().catch(_ => {
       process.exit(1);
     });
 


### PR DESCRIPTION
This PR guards some cases where SwingSet wasn't checking for null kpids.  It also logs kernel errors at the block-manager level, to make them easier to understand.

However, the following error still remains after killing off all the `xsnap` processes for a running SwingSet (`scenario3` works just as well/badly as `scenario2` in that case):

```
END_BLOCK error: (Error#1)
Error#1: ' undefined is not a 'vNN'-style VatID: (TypeError#2)

  at meteredConstructor.insistVatID (packages/SwingSet/src/kernel/id.js:30:19)
  at provideVatKeeper (packages/SwingSet/src/kernel/state/kernelKeeper.js:913:8)
  at meteredConstructor.processRefcounts (packages/SwingSet/src/kernel/state/kernelKeeper.js:893:31)
  at processQueueMessage (packages/SwingSet/src/kernel/kernel.js:672:24)
  at async meteredConstructor.step (packages/SwingSet/src/kernel/kernel.js:949:7)
  at async crankScheduler (packages/cosmic-swingset/src/launch-chain.js:152:17)
  at async endBlock (packages/cosmic-swingset/src/launch-chain.js:174:5)

```

Restarting after that kind of crash seems to work (given the error resolver patch in this PR), but the SwingSet state doesn't appear correct, as it won't respond to future messages as expected.  I've verified that once the SwingSet rejects a promise, the solo or chain doesn't commit any additional state.  The invalid committed state seems to occur earlier, before the kernel crash.

@warner, please review, and I hope to merge, but we also need to do an audit to fix the remaining inconsistencies in what to do when workers die unexpectedly.
