### PR TITLE
fix(swingset): fix GC handling of orphaned objects

### DIFF
--- a/packages/SwingSet/test/gc-dead-vat/bootstrap.js
+++ b/packages/SwingSet/test/gc-dead-vat/bootstrap.js
@@ -1,25 +1,55 @@
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
+import { makePromiseKit } from '@agoric/promise-kit';
 
-async function sendExport(root) {
+async function sendExport(doomedRoot) {
   const exportToDoomed = Far('exportToDoomed', {});
-  const fromDoomed = await E(root).accept(exportToDoomed);
-  return fromDoomed;
+  await E(doomedRoot).accept(exportToDoomed);
 }
 
 export function buildRootObject() {
   let vat;
+  let doomedRoot;
   const pin = [];
+  const pk1 = makePromiseKit();
   return Far('root', {
     async bootstrap(vats, devices) {
       const vatMaker = E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
       vat = await E(vatMaker).createVatByName('doomed', { metered: false });
-      const fromDoomed = await sendExport(vat.root);
-      pin.push(fromDoomed);
+      doomedRoot = vat.root;
+      await sendExport(doomedRoot);
+      const doomedExport1Presence = await E(doomedRoot).getDoomedExport1();
+      pin.push(doomedExport1Presence);
+    },
+    async stash() {
+      // Give vat-doomed a target that doesn't resolve one() right away.
+      // vat-doomed will send doomedExport2 to the result of target~.one(),
+      // which means doomedExport2 will be held in the kernel's promise-queue
+      // entry until we resolve pk1.promise
+      const target = Far('target', {
+        one() {
+          return pk1.promise;
+        },
+      });
+      await E(doomedRoot).stashDoomedExport2(target);
     },
     async startTerminate() {
       await E(vat.root).terminate();
       await E(vat.done);
+    },
+    callOrphan() {
+      // the object is gone, so hello() ought to reject
+      const p = E(pin[0]).hello();
+      return p.then(
+        _res => {
+          throw Error('what??');
+        },
+        _err => 'good',
+      );
+    },
+    async drop() {
+      pin.splice(0);
+      pk1.reject(0);
     },
   });
 }

--- a/packages/SwingSet/test/gc-dead-vat/vat-doomed.js
+++ b/packages/SwingSet/test/gc-dead-vat/vat-doomed.js
@@ -1,12 +1,19 @@
+import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 
 export function buildRootObject(vatPowers) {
   const pin = [];
-  const exportedRemotable = Far('exported', {});
+  const doomedExport1 = Far('doomedExport1', {});
+  const doomedExport2 = Far('doomedExport2', {});
   return Far('root', {
-    accept(args) {
-      pin.push(args);
-      return exportedRemotable;
+    accept(exportToDoomedPresence) {
+      pin.push(exportToDoomedPresence);
+    },
+    getDoomedExport1() {
+      return doomedExport1;
+    },
+    stashDoomedExport2(target) {
+      E(E(target).one()).neverCalled(doomedExport2);
     },
     terminate() {
       vatPowers.exitVat('completion');


### PR DESCRIPTION
There were two bugs in the kernel's garbage-collection handling of orphaned
objects (exports of a vat which is later terminated).

* Sending a message to an orphaned vat caused the object's refcount to be
incremented, but never decremented again, preventing it from being collected.
The root cause was `kernelKeeper.kernelObjectExists` using `.owner` to decide
whether the object still exists. Orphaned objects have a `.refcount` but no
`.owner`. The fix is to  just test `.refcount` instead of `.owner`. #3376
* `kernelKeeper.processRefcounts()` wants to check the `isReachable` flag of
the exporting vat, to know whether they need a dropExport message, but
orphaned objects have no exporting vat anymore. The check crashed the kernel
when it attempted to get a vatKeeper for `undefined`. The immediate fix is to
skip this check for orphaned objects, which avoids the crash (#3377). But we
still need a fix to delete the refcount=0,0 entry (#3378).

closes #3376
closes #3377
refs #3378