### PR TITLE
fix(swingset): only mark refs for processing if refcount hits zero

### DIFF
--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -853,7 +853,9 @@ export default function makeKernelKeeper(kvStore, streamStore, kernelSlog) {
         reachable -= 1;
       }
       recognizable -= 1;
-      maybeFreeKrefs.add(kernelSlot);
+      if (!reachable || !recognizable) {
+        maybeFreeKrefs.add(kernelSlot);
+      }
       setObjectRefCount(kernelSlot, { reachable, recognizable });
     }
 

--- a/packages/SwingSet/test/gc-dead-vat/bootstrap.js
+++ b/packages/SwingSet/test/gc-dead-vat/bootstrap.js
@@ -1,25 +1,55 @@
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
+import { makePromiseKit } from '@agoric/promise-kit';
 
-async function sendExport(root) {
+async function sendExport(doomedRoot) {
   const exportToDoomed = Far('exportToDoomed', {});
-  const fromDoomed = await E(root).accept(exportToDoomed);
-  return fromDoomed;
+  await E(doomedRoot).accept(exportToDoomed);
 }
 
 export function buildRootObject() {
   let vat;
+  let doomedRoot;
   const pin = [];
+  const pk1 = makePromiseKit();
   return Far('root', {
     async bootstrap(vats, devices) {
       const vatMaker = E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
       vat = await E(vatMaker).createVatByName('doomed', { metered: false });
-      const fromDoomed = await sendExport(vat.root);
-      pin.push(fromDoomed);
+      doomedRoot = vat.root;
+      await sendExport(doomedRoot);
+      const doomedExport1Presence = await E(doomedRoot).getDoomedExport1();
+      pin.push(doomedExport1Presence);
+    },
+    async stash() {
+      // Give vat-doomed a target that doesn't resolve one() right away.
+      // vat-doomed will send doomedExport2 to the result of target~.one(),
+      // which means doomedExport2 will be held in the kernel's promise-queue
+      // entry until we resolve pk1.promise
+      const target = Far('target', {
+        one() {
+          return pk1.promise;
+        },
+      });
+      await E(doomedRoot).stashDoomedExport2(target);
     },
     async startTerminate() {
       await E(vat.root).terminate();
       await E(vat.done);
+    },
+    callOrphan() {
+      // the object is gone, so hello() ought to reject
+      const p = E(pin[0]).hello();
+      return p.then(
+        _res => {
+          throw Error('what??');
+        },
+        _err => 'good',
+      );
+    },
+    async drop() {
+      pin.splice(0);
+      pk1.reject(0);
     },
   });
 }

--- a/packages/SwingSet/test/gc-dead-vat/vat-doomed.js
+++ b/packages/SwingSet/test/gc-dead-vat/vat-doomed.js
@@ -1,12 +1,19 @@
+import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 
 export function buildRootObject(vatPowers) {
   const pin = [];
-  const exportedRemotable = Far('exported', {});
+  const doomedExport1 = Far('doomedExport1', {});
+  const doomedExport2 = Far('doomedExport2', {});
   return Far('root', {
-    accept(args) {
-      pin.push(args);
-      return exportedRemotable;
+    accept(exportToDoomedPresence) {
+      pin.push(exportToDoomedPresence);
+    },
+    getDoomedExport1() {
+      return doomedExport1;
+    },
+    stashDoomedExport2(target) {
+      E(E(target).one()).neverCalled(doomedExport2);
     },
     terminate() {
       vatPowers.exitVat('completion');


### PR DESCRIPTION
This should remove some unnecessary work done by `processRefcounts` on
objects which have lost one reference, but not all of them.

refs #3106