### PR TITLE
chore: don't change tests, just split up into unit and swingset tests in CI

### DIFF
--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -505,7 +505,7 @@ jobs:
       env:
         ESM_DISABLE_CACHE: true
 
-  test-zoe:
+  test-zoe-unit:
     # BEGIN-TEST-BOILERPLATE
     needs: build
     runs-on: ubuntu-latest
@@ -539,7 +539,45 @@ jobs:
 
     - name: yarn test (zoe)
       timeout-minutes: 30
-      run: cd packages/zoe && yarn test
+      run: cd packages/zoe && yarn test:unit
+      env:
+        ESM_DISABLE_CACHE: true
+
+  test-zoe-swingset:
+    # BEGIN-TEST-BOILERPLATE
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # TODO: ['14.x', '16.x']
+        node-version: ['14.x']
+    steps:
+    - uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    # END-TEST-BOILERPLATE
+    # BEGIN-RESTORE-BOILERPLATE
+    - name: restore built files
+      id: built
+      uses: actions/cache@v1
+      with:
+        path: .
+        key: ${{ runner.os }}-${{ matrix.node-version }}-built-${{ github.sha }}
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'true'
+      if: steps.built.outputs.cache-hit != 'true'
+    - name: yarn install
+      run: yarn install
+      if: steps.built.outputs.cache-hit != 'true'
+    - name: yarn build
+      run: yarn build
+      if: steps.built.outputs.cache-hit != 'true'
+    # END-RESTORE-BOILERPLATE
+
+    - name: yarn test (zoe)
+      timeout-minutes: 30
+      run: cd packages/zoe && yarn test:swingset
       env:
         ESM_DISABLE_CACHE: true
 

--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -14,7 +14,7 @@
     "test": "ava",
     "test:xs": "yarn test:xs-unit && yarn test:xs-worker",
     "test:xs-unit": "ava-xs",
-    "test:xs-worker": "SWINGSET_WORKER_TYPE=xs-worker ava -c 2 test/swingsetTests/**/test-*.js",
+    "test:xs-worker": "SWINGSET_WORKER_TYPE=xs-worker ava -c 2 'test/swingsetTests/**/test-*.js'",
     "pretty-fix": "prettier --write '**/*.js'",
     "pretty-check": "prettier --check '**/*.js'",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -11,11 +11,11 @@
   },
   "scripts": {
     "build": "yarn build-zcfBundle",
-    "test": "ava",
-    "test:unit": "ava 'test/unitTests/**/test-*.js' -T 1m",
-    "test:swingset": "ava 'test/swingsetTests/**/test-*.js' -T 10m",
+    "test": "ava --verbose",
+    "test:unit": "ava 'test/unitTests/**/test-*.js' -T 1m --verbose",
+    "test:swingset": "ava 'test/swingsetTests/**/test-*.js' -T 10m --verbose",
     "test:xs": "yarn test:xs-unit",
-    "test:xs-unit": "ava-xs",
+    "test:xs-unit": "ava-xs --verbose",
     "test:xs-worker": "SWINGSET_WORKER_TYPE=xs-worker ava -c 2 'test/swingsetTests/**/test-*.js'",
     "build-zcfBundle": "node -r esm scripts/build-zcfBundle.js",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
@@ -85,7 +85,7 @@
     "require": [
       "esm"
     ],
-    "timeout": "10m"
+    "timeout": "20m"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -11,10 +11,12 @@
   },
   "scripts": {
     "build": "yarn build-zcfBundle",
-    "test": "ava --verbose",
+    "test": "ava",
+    "test:unit": "ava 'test/unitTests/**/test-*.js' -T 1m",
+    "test:swingset": "ava 'test/swingsetTests/**/test-*.js' -T 10m",
     "test:xs": "yarn test:xs-unit",
-    "test:xs-unit": "ava-xs --verbose",
-    "test:xs-worker": "SWINGSET_WORKER_TYPE=xs-worker ava -c 2 test/swingsetTests/**/test-*.js",
+    "test:xs-unit": "ava-xs",
+    "test:xs-worker": "SWINGSET_WORKER_TYPE=xs-worker ava -c 2 'test/swingsetTests/**/test-*.js'",
     "build-zcfBundle": "node -r esm scripts/build-zcfBundle.js",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint-check": "yarn lint",
@@ -83,7 +85,7 @@
     "require": [
       "esm"
     ],
-    "timeout": "20m"
+    "timeout": "10m"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
This is a much lighter version of https://github.com/Agoric/agoric-sdk/pull/3384/. This PR only splits up the unit and swingset tests. It does not edit the swingset tests. 

(Note that this PR adds quotes around any globstar usage in npm scripts.)

New yarn commands within Zoe:
`yarn test:unit`
`yarn test:swingset`

