### PR TITLE
refactor: remove vestigial bundle-source thunk

### DIFF
--- a/packages/zoe/test/bundle-source.js
+++ b/packages/zoe/test/bundle-source.js
@@ -1,6 +1,0 @@
-// @ts-check
-
-import bundleSource from '@agoric/bundle-source';
-
-// Use the new format.
-export default src => bundleSource(src, 'nestedEvaluate');

--- a/packages/zoe/test/swingsetTests/zoe-metering/test-zoe-metering.js
+++ b/packages/zoe/test/swingsetTests/zoe-metering/test-zoe-metering.js
@@ -9,7 +9,7 @@ import '@agoric/install-ses';
 import test from 'ava';
 import { loadBasedir, buildVatController } from '@agoric/swingset-vat';
 import fs from 'fs';
-import bundleSource from '../../bundle-source';
+import bundleSource from '@agoric/bundle-source';
 
 // Don't let unhandled promises crash our process.
 process.on('unhandledRejection', e => console.log('unhandled rejection', e));


### PR DESCRIPTION
This is a minor refactor that blocks nothing. There is an unnecessary bundle-source thunk in Zoe tests, used once. This appears to be a tool for consolidating common options for bundleSource in the context of Zoe tests, but looks forgotten.
