### PR TITLE
remove install-metering-and-ses from apps and most unit tests

### DIFF
--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -31,7 +31,7 @@
     "@agoric/cosmos": "^0.26.4",
     "@agoric/dapp-svelte-wallet": "^0.10.4",
     "@agoric/import-bundle": "^0.2.16",
-    "@agoric/install-metering-and-ses": "^0.2.15",
+    "@agoric/install-ses": "^0.5.15",
     "@agoric/store": "^0.4.16",
     "@agoric/swing-store-lmdb": "^0.5.1",
     "@agoric/swingset-vat": "^0.18.0",

--- a/packages/cosmic-swingset/src/entrypoint.js
+++ b/packages/cosmic-swingset/src/entrypoint.js
@@ -11,7 +11,7 @@ import '@agoric/babel-standalone';
 
 // we need to enable Math.random as a workaround for 'brace-expansion' module
 // (dep chain: temp->glob->minimatch->brace-expansion)
-import '@agoric/install-metering-and-ses';
+import '@agoric/install-ses';
 
 import os from 'os';
 import path from 'path';

--- a/packages/solo/package.json
+++ b/packages/solo/package.json
@@ -34,7 +34,7 @@
     "@agoric/dapp-svelte-wallet": "^0.10.4",
     "@agoric/eventual-send": "^0.13.16",
     "@agoric/import-bundle": "^0.2.16",
-    "@agoric/install-metering-and-ses": "^0.2.15",
+    "@agoric/install-ses": "^0.5.15",
     "@agoric/marshal": "^0.4.13",
     "@agoric/notifier": "^0.3.16",
     "@agoric/promise-kit": "^0.2.15",

--- a/packages/solo/solo-config.json
+++ b/packages/solo/solo-config.json
@@ -1,6 +1,6 @@
 {
   "bootstrap": "bootstrap",
-  "defaultManagerType": "local",
+  "defaultManagerType": "xs-worker",
   "vats": {
     "spawner": {
       "sourceSpec": "./src/vat-spawner.js"

--- a/packages/solo/src/entrypoint.js
+++ b/packages/solo/src/entrypoint.js
@@ -9,7 +9,7 @@ import '@agoric/babel-standalone';
 
 // we need to enable Math.random as a workaround for 'brace-expansion' module
 // (dep chain: temp->glob->minimatch->brace-expansion)
-import '@agoric/install-metering-and-ses';
+import '@agoric/install-ses';
 
 import process from 'process';
 import path from 'path';

--- a/packages/solo/src/init-basedir.js
+++ b/packages/solo/src/init-basedir.js
@@ -21,7 +21,7 @@ export default function initBasedir(
   const { env = process.environment } = opts;
   const {
     wallet = DEFAULT_WALLET,
-    defaultManagerType = env.SWINGSET_WORKER_TYPE || 'local',
+    defaultManagerType = env.SWINGSET_WORKER_TYPE || 'xs-worker',
     ...options
   } = opts;
   options.wallet = wallet;

--- a/packages/solo/src/main.js
+++ b/packages/solo/src/main.js
@@ -78,7 +78,7 @@ start
           webport: '8000',
           webhost: '127.0.0.1',
           egresses: DEFAULT_EGRESSES,
-          defaultManagerType: process.env.SWINGSET_WORKER_TYPE || 'local',
+          defaultManagerType: process.env.SWINGSET_WORKER_TYPE || 'xs-worker',
         },
       });
       const webport = Number(subOpts.webport);

--- a/packages/spawner/package.json
+++ b/packages/spawner/package.json
@@ -40,7 +40,6 @@
   "devDependencies": {
     "@agoric/babel-standalone": "^7.14.3",
     "@agoric/bundle-source": "^1.3.9",
-    "@agoric/install-metering-and-ses": "^0.2.15",
     "@agoric/install-ses": "^0.5.15",
     "@agoric/swingset-vat": "^0.18.0",
     "ava": "^3.12.1",

--- a/packages/spawner/test/swingsetTests/contractHost/test-contractHost.js
+++ b/packages/spawner/test/swingsetTests/contractHost/test-contractHost.js
@@ -2,7 +2,7 @@
 // TODO Remove babel-standalone preinitialization
 // https://github.com/endojs/endo/issues/768
 import '@agoric/babel-standalone';
-import '@agoric/install-metering-and-ses';
+import '@agoric/install-ses';
 import test from 'ava';
 import path from 'path';
 import bundleSource from '@agoric/bundle-source';
@@ -19,8 +19,9 @@ test.before(async t => {
   t.context.data = { kernelBundles, trivialBundle };
 });
 
-async function main(t, mode) {
+async function main(t, mode, defaultManagerType = 'local') {
   const config = await loadBasedir(__dirname);
+  config.defaultManagerType = defaultManagerType;
   const { kernelBundles, trivialBundle } = t.context.data;
   const argv = [mode, trivialBundle];
   const controller = await buildVatController(config, argv, { kernelBundles });
@@ -47,6 +48,6 @@ const contractExhaustedGolden = [
 ];
 
 test('exhaustion', async t => {
-  const dump = await main(t, 'exhaust');
+  const dump = await main(t, 'exhaust', 'xs-worker');
   t.deepEqual(dump.log, contractExhaustedGolden);
 });

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -58,7 +58,6 @@
   },
   "devDependencies": {
     "@agoric/babel-standalone": "^7.14.3",
-    "@agoric/install-metering-and-ses": "^0.2.15",
     "@agoric/install-ses": "^0.5.15",
     "ava": "^3.12.1",
     "esm": "agoric-labs/esm#Agoric-built",

--- a/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
@@ -5,7 +5,7 @@
 // https://github.com/endojs/endo/issues/768
 import '@agoric/babel-standalone';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-metering-and-ses';
+import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 
@@ -28,6 +28,7 @@ const generateBundlesP = Promise.all(
 
 async function main(argv) {
   const config = await loadBasedir(__dirname);
+  config.defaultManagerType = 'xs-worker';
   await generateBundlesP;
   const controller = await buildVatController(config, argv);
   await controller.run();

--- a/packages/zoe/test/swingsetTests/makeKind/test-makeKind.js
+++ b/packages/zoe/test/swingsetTests/makeKind/test-makeKind.js
@@ -4,7 +4,7 @@
 // https://github.com/endojs/endo/issues/768
 import '@agoric/babel-standalone';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-metering-and-ses';
+import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/zoe/test/swingsetTests/zoe-metering/test-zoe-metering.js
+++ b/packages/zoe/test/swingsetTests/zoe-metering/test-zoe-metering.js
@@ -4,7 +4,7 @@
 // https://github.com/endojs/endo/issues/768
 import '@agoric/babel-standalone';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-metering-and-ses';
+import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { loadBasedir, buildVatController } from '@agoric/swingset-vat';
@@ -33,6 +33,7 @@ const generateBundlesP = Promise.all(
 
 async function main(argv) {
   const config = await loadBasedir(__dirname);
+  config.defaultManagerType = 'xs-worker';
   await generateBundlesP;
   const controller = await buildVatController(config, argv);
   await controller.run();

--- a/packages/zoe/test/swingsetTests/zoe/test-zoe.js
+++ b/packages/zoe/test/swingsetTests/zoe/test-zoe.js
@@ -6,7 +6,7 @@
 // https://github.com/endojs/endo/issues/768
 import '@agoric/babel-standalone';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import '@agoric/install-metering-and-ses';
+import '@agoric/install-ses';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test from 'ava';
 import { buildVatController, buildKernelBundles } from '@agoric/swingset-vat';


### PR DESCRIPTION
At this point, any dynamic vats that need to be metered should be run under `xsnap`, not `local`, which means we no longer need to use `@agoric/install-metering-and-ses` to wrap the globals with metered versions. Those wrappers cause a significant slowdown in all Node.js-side code (like the kernel), even when metering is not enabled, so it's nice to remove them.

This changes `spawner` and `zoe` tests which need to exercise metering to use an `xsnap` worker. All instances of `import '@agoric/install-metering-and-ses'` have been changed to `import '@agoric/install-ses'`. This reduces the runtime of those tests by 4x-6x (in one case, Zoe's `test-crashingContract.js`, reducing it from 340s to 60s).

Most importantly, this changes our two main applications (`cosmic-swingset` and the `solo` node) in the same way. We don't have measurements on the performance changes, but we expect them to be noticeable.

refs #3373 

Probably doesn't close it yet, there are still some swingset internal tests that exercise that metering code which needs to be changed.
