### PR TITLE
fix(swingset): xs-worker confused meter exhaustion with process fail

### DIFF
--- a/packages/SwingSet/src/kernel/vatManager/manager-helper.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-helper.js
@@ -139,16 +139,19 @@ function makeManagerKit(
   /**
    *
    * @param { VatDeliveryObject } delivery
-   * @returns { Promise<VatDeliveryResult> }
+   * @returns { Promise<VatDeliveryResult> } // or Error
    */
   async function deliver(delivery) {
     if (transcriptManager) {
       transcriptManager.startDispatch(delivery);
     }
+    // metering faults (or other reasons why the vat should be
+    // deterministically terminated) are reported with status= ['error',
+    // err.message, null]. Any non-deterministic error (unexpected worker
+    // termination) is reported by rejection, causing an Error to bubble all
+    // the way up to controller.step/run.
     /** @type { VatDeliveryResult } */
-    const status = await deliverToWorker(delivery).catch(err =>
-      harden(['error', err.message, null]),
-    );
+    const status = await deliverToWorker(delivery);
     insistVatDeliveryResult(status);
     // TODO: if the dispatch failed for whatever reason, and we choose to
     // destroy the vat, change what we do with the transcript here.

--- a/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
@@ -161,7 +161,8 @@ export function makeXsSubprocessFactory({
             message = 'Allocate meter exceeded';
             break;
           default:
-            message = err.message;
+            // non-metering failure. crash.
+            throw err;
         }
         return harden(['error', message, null]);
       }

--- a/packages/SwingSet/test/test-xsnap-errors.js
+++ b/packages/SwingSet/test/test-xsnap-errors.js
@@ -3,7 +3,7 @@
 // eslint-disable-next-line import/order
 import { test } from '../tools/prepare-test-env-ava.js';
 import path from 'path';
-import spawn from 'child_process';
+import { spawn } from 'child_process';
 import bundleSource from '@agoric/bundle-source';
 
 import { makeXsSubprocessFactory } from '../src/kernel/vatManager/manager-subprocess-xsnap.js';
@@ -24,8 +24,10 @@ test('child termination during crank', async t => {
   const env = {};
 
   const startXSnap = makeStartXSnap(bundles, { snapstorePath, env, spawn });
-  const kernelKeeper = {}; // add just enough methods to not crash
   /** @type { KernelKeeper } */
+  const kernelKeeper = {
+    provideVatKeeper: () => null,
+  }; // add just enough methods to not crash
   /** @type { KernelSlog } */
   const kernelSlog = {}; // same
   /** @type { VatPowers } */

--- a/packages/SwingSet/test/test-xsnap-errors.js
+++ b/packages/SwingSet/test/test-xsnap-errors.js
@@ -1,4 +1,5 @@
 /* global require */
+// @ts-check
 // eslint-disable-next-line import/order
 import { test } from '../tools/prepare-test-env-ava.js';
 import path from 'path';
@@ -19,11 +20,15 @@ test('child termination during crank', async t => {
   );
   const bundles = [lockdown, supervisor];
   const snapstorePath = undefined; // good enough?
+  /** @type { Record<string, string> } */
   const env = {};
 
   const startXSnap = makeStartXSnap(bundles, { snapstorePath, env, spawn });
   const kernelKeeper = {}; // add just enough methods to not crash
+  /** @type { KernelKeeper } */
+  /** @type { KernelSlog } */
   const kernelSlog = {}; // same
+  /** @type { VatPowers } */
   const allVatPowers = {}; // probably safe to leave empty
   const xsWorkerFactory = makeXsSubprocessFactory({
     startXSnap,
@@ -36,11 +41,13 @@ test('child termination during crank', async t => {
   const vatID = 'v1';
   const fn = path.join(__dirname, 'vat-xsnap-hang.js');
   const bundle = await bundleSource(fn);
+  /** @type { ManagerOptions } */
   const managerOptions = {};
   const schandler = _vso => ['ok', null];
   const m = xsWorkerFactory.createFromBundle('v1', bundle, {}, schandler);
 
   const msg = { method: 'hang', args: capargs([]) };
+  /** @type { VatDeliveryObject } */
   const delivery = ['message', 'o+0', msg];
 
   // TODO: disable metering limit

--- a/packages/SwingSet/test/test-xsnap-errors.js
+++ b/packages/SwingSet/test/test-xsnap-errors.js
@@ -1,3 +1,5 @@
+/* global require */
+// eslint-disable-next-line import/order
 import { test } from '../tools/prepare-test-env-ava.js';
 import path from 'path';
 import spawn from 'child_process';
@@ -9,9 +11,13 @@ import { capargs } from './util.js';
 
 test('child termination during crank', async t => {
   const makeb = rel => bundleSource(require.resolve(rel), 'getExport');
-  const lockdown = await makeb('../src/kernel/vatManager/lockdown-subprocess-xsnap.js');
-  const supervisor = await makeb('../src/kernel/vatManager/supervisor-subprocess-xsnap.js');
-  const bundles = [ lockdown, supervisor ];
+  const lockdown = await makeb(
+    '../src/kernel/vatManager/lockdown-subprocess-xsnap.js',
+  );
+  const supervisor = await makeb(
+    '../src/kernel/vatManager/supervisor-subprocess-xsnap.js',
+  );
+  const bundles = [lockdown, supervisor];
   const snapstorePath = undefined; // good enough?
   const env = {};
 
@@ -31,9 +37,9 @@ test('child termination during crank', async t => {
   const fn = path.join(__dirname, 'vat-xsnap-hang.js');
   const bundle = await bundleSource(fn);
   const managerOptions = {};
-  const schandler = vso => ['ok', null];
+  const schandler = _vso => ['ok', null];
   const m = xsWorkerFactory.createFromBundle('v1', bundle, {}, schandler);
-  
+
   const msg = { method: 'hang', args: capargs([]) };
   const delivery = ['message', 'o+0', msg];
 
@@ -45,6 +51,4 @@ test('child termination during crank', async t => {
     instanceOf: Error,
     message: 'something about termination',
   });
-
-
 });

--- a/packages/SwingSet/test/test-xsnap-errors.js
+++ b/packages/SwingSet/test/test-xsnap-errors.js
@@ -1,4 +1,4 @@
-/* global require */
+/* global require, __dirname */
 // @ts-check
 // eslint-disable-next-line import/order
 import { test } from '../tools/prepare-test-env-ava.js';

--- a/packages/SwingSet/test/test-xsnap-errors.js
+++ b/packages/SwingSet/test/test-xsnap-errors.js
@@ -76,8 +76,9 @@ test('child termination during crank', async t => {
 
   t.throwsAsync(p, {
     instanceOf: Error,
-    message: 'something about termination',
+    code: 'SIGTERM',
+    message: 'v1:undefined exited due to signal SIGTERM',
   });
 
-  await p;
+  await p.catch(() => {});
 });

--- a/packages/SwingSet/test/test-xsnap-errors.js
+++ b/packages/SwingSet/test/test-xsnap-errors.js
@@ -1,0 +1,50 @@
+import { test } from '../tools/prepare-test-env-ava.js';
+import path from 'path';
+import spawn from 'child_process';
+import bundleSource from '@agoric/bundle-source';
+
+import { makeXsSubprocessFactory } from '../src/kernel/vatManager/manager-subprocess-xsnap.js';
+import { makeStartXSnap } from '../src/controller.js';
+import { capargs } from './util.js';
+
+test('child termination during crank', async t => {
+  const makeb = rel => bundleSource(require.resolve(rel), 'getExport');
+  const lockdown = await makeb('../src/kernel/vatManager/lockdown-subprocess-xsnap.js');
+  const supervisor = await makeb('../src/kernel/vatManager/supervisor-subprocess-xsnap.js');
+  const bundles = [ lockdown, supervisor ];
+  const snapstorePath = undefined; // good enough?
+  const env = {};
+
+  const startXSnap = makeStartXSnap(bundles, { snapstorePath, env, spawn });
+  const kernelKeeper = {}; // add just enough methods to not crash
+  const kernelSlog = {}; // same
+  const allVatPowers = {}; // probably safe to leave empty
+  const xsWorkerFactory = makeXsSubprocessFactory({
+    startXSnap,
+    kernelKeeper,
+    kernelSlog,
+    allVatPowers,
+    testLog: allVatPowers.testLog,
+  });
+
+  const vatID = 'v1';
+  const fn = path.join(__dirname, 'vat-xsnap-hang.js');
+  const bundle = await bundleSource(fn);
+  const managerOptions = {};
+  const schandler = vso => ['ok', null];
+  const m = xsWorkerFactory.createFromBundle('v1', bundle, {}, schandler);
+  
+  const msg = { method: 'hang', args: capargs([]) };
+  const delivery = ['message', 'o+0', msg];
+
+  // TODO: disable metering limit
+  const p = m.deliver(delivery); // won't resolve until child dies
+  // TODO: somehow kill the child process
+
+  const hang = t.throwsAsync(_ => p, {
+    instanceOf: Error,
+    message: 'something about termination',
+  });
+
+
+});

--- a/packages/SwingSet/test/vat-xsnap-hang.js
+++ b/packages/SwingSet/test/vat-xsnap-hang.js
@@ -1,7 +1,10 @@
 import { Far } from '@agoric/marshal';
 
-export function buildRootObject(vatPowers) {
+export function buildRootObject(_vatPowers) {
   return Far('root', {
-    hang() { for (;;) {} },
+    hang() {
+      // eslint-disable-next-line no-empty
+      for (;;) {}
+    },
   });
 }

--- a/packages/SwingSet/test/vat-xsnap-hang.js
+++ b/packages/SwingSet/test/vat-xsnap-hang.js
@@ -1,0 +1,7 @@
+import { Far } from '@agoric/marshal';
+
+export function buildRootObject(vatPowers) {
+  return Far('root', {
+    hang() { for (;;) {} },
+  });
+}


### PR DESCRIPTION
fixes #3394

separate commits are not worth keeping after review; let's squash.
