### PR TITLE
fix(promise-kit): make strict typing compliant

### DIFF
--- a/packages/promise-kit/src/promiseKit.js
+++ b/packages/promise-kit/src/promiseKit.js
@@ -4,6 +4,7 @@
 // eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
+/** @type {import('@agoric/eventual-send').HandledPromiseConstructor | PromiseConstructor} */
 const BestPipelinablePromise = globalThis.HandledPromise || Promise;
 
 /**
@@ -26,7 +27,7 @@ const BestPipelinablePromise = globalThis.HandledPromise || Promise;
 /**
  * Needed to prevent type errors where functions are detected to be undefined.
  */
-const NOOP_INITIALIZER = harden(_ => {});
+const NOOP_INITIALIZER = harden(() => {});
 
 /**
  * makePromiseKit() builds a Promise object, and returns a record
@@ -37,7 +38,7 @@ const NOOP_INITIALIZER = harden(_ => {});
  * @returns {PromiseRecord<T>}
  */
 export function makePromiseKit() {
-  /** @type {(value: T) => void} */
+  /** @type {(value: ERef<T>) => void} */
   let res = NOOP_INITIALIZER;
   /** @type {(reason: any) => void} */
   let rej = NOOP_INITIALIZER;
@@ -49,19 +50,20 @@ export function makePromiseKit() {
   // Node.js adds the `domain` property which is not a standard
   // property on Promise. Because we do not know it to be ocap-safe,
   // we remove it.
-  if (p.domain) {
+  if ('domain' in p) {
     // deleting p.domain may break functionality. To retain current
     // functionality at the expense of safety, set unsafe to true.
     const unsafe = false;
     if (unsafe) {
-      const originalDomain = p.domain;
+      const originalDomain = /** @type {*} */ (p).domain;
       Object.defineProperty(p, 'domain', {
         get() {
           return originalDomain;
         },
       });
     } else {
-      delete p.domain;
+      // prettier-ignore
+      delete /** @type {*} */ (p).domain;
     }
   }
   return harden({ promise: p, resolve: res, reject: rej });

--- a/packages/promise-kit/src/promiseKit.js
+++ b/packages/promise-kit/src/promiseKit.js
@@ -43,6 +43,7 @@ export function makePromiseKit() {
   /** @type {(reason: any) => void} */
   let rej = NOOP_INITIALIZER;
 
+  /** @type {Promise<any> & {domain?: unknown}} */
   const p = new BestPipelinablePromise((resolve, reject) => {
     res = resolve;
     rej = reject;
@@ -55,15 +56,14 @@ export function makePromiseKit() {
     // functionality at the expense of safety, set unsafe to true.
     const unsafe = false;
     if (unsafe) {
-      const originalDomain = /** @type {*} */ (p).domain;
+      const originalDomain = p.domain;
       Object.defineProperty(p, 'domain', {
         get() {
           return originalDomain;
         },
       });
     } else {
-      // prettier-ignore
-      delete /** @type {*} */ (p).domain;
+      delete p.domain;
     }
   }
   return harden({ promise: p, resolve: res, reject: rej });


### PR DESCRIPTION
## Description

`@agoric/promise-kit` doesn't specify a `types` entry in its `package.json` causing `tsc` to parse its `.js` source to extract jsdoc typing. This parsing would also validate this internal implementation, which would raise errors when the consumer of the package is in `strict` mode (mostly `noImplicitAny`).

### Security Considerations

There is a single runtime change from `p.domain` to `'domain' in p` which is actually more correct.

### Documentation Considerations

N/A

### Testing Considerations

We should enable `"strict": true` for this package's `jsconfig.json` but that currently isn't possible because `global.HandledPromise` is only declared in `@agoric/eventual-send` which is not imported directly by `promise-kit`.
