### PR TITLE
fix: upgrade to allow `gentx --keyring-dir=...`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,8 @@ replace google.golang.org/grpc => google.golang.org/grpc v1.33.2
 // replace github.com/tendermint/tendermint => github.com/agoric-labs/tendermint v0.33.1-dev2.0.20210310191408-9156bacf449c
 
 // At least until GetABCIEventHistory() is implemented and released.
-replace github.com/cosmos/cosmos-sdk => github.com/agoric-labs/cosmos-sdk v0.43.0-beta1.0.20210607203003-f9d4f60682f2
+// And also `gentx --keyring-dir=...`
+replace github.com/cosmos/cosmos-sdk => github.com/agoric-labs/cosmos-sdk v0.43.0-beta1.0.20210623214818-65f9554e0ddf
 
 // For testing against a local cosmos-sdk or tendermint
 // replace github.com/cosmos/cosmos-sdk => ../forks/cosmos-sdk


### PR DESCRIPTION
Fixes Agoric/testnet-notes#10

The actual fix is at cosmos/cosmos-sdk#9574 but I've implemented it in our Agoric-specific fork https://github.com/agoric-labs/cosmos-sdk/tree/Agoric .
