### PR TITLE
Minor cleanups

### DIFF
--- a/golang/cosmos/daemon/main.go
+++ b/golang/cosmos/daemon/main.go
@@ -60,7 +60,7 @@ func RunWithController(sendToController cmd.Sender) {
 	// Exit on Control-C and kill.
 	// Without this explicitly, ag-chain-cosmos ignores them.
 	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(sigs, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-sigs
 		os.Exit(98)

--- a/packages/deployment/ansible/cosmos-genesis.yml
+++ b/packages/deployment/ansible/cosmos-genesis.yml
@@ -9,8 +9,8 @@
     - BOOTSTRAP_TOKENS: 100provisionpass
     - CHAIN_NAME: "{{ lookup('file', SETUP_HOME + '/ag-chain-cosmos/chain-name.txt') }}"
     - NETWORK_CONFIG_URL: https://testnet.agoric.com/network-config
+    - FAUCET_TOKENS: "{{ lookup('file', SETUP_HOME + '/boot-tokens.txt') }}"
     - STAKER: ag-staker
-    - STAKER_TOKENS: 10000000000000000000000000ubld
     - STAKER_INIT_COINS: 62000000ubld
     - STAKER_SELF_DELEGATION: 50000000ubld
     - STAKER_NODE: validator0

--- a/packages/deployment/ansible/roles/cosmos-genesis/files/faucet-helper.sh
+++ b/packages/deployment/ansible/roles/cosmos-genesis/files/faucet-helper.sh
@@ -93,6 +93,7 @@ while [[ ${#rpcAddrs[@]} -gt 0 ]]; do
         echo "$ADDR:$DELEGATE_COINS:$NAME" >> $thisdir/cosmos-delegates.txt
         exit 0
       fi
+      exit $?
       ;;
     *)
       echo 1>&2 "Unknown operation $OP"

--- a/packages/deployment/ansible/roles/cosmos-genesis/tasks/main.yml
+++ b/packages/deployment/ansible/roles/cosmos-genesis/tasks/main.yml
@@ -50,7 +50,7 @@
   become_user: "{{ service }}"
   shell: "\
     {{ service }} add-genesis-account \
-      {{ faucet }} {{ STAKER_TOKENS }},{{ BOOTSTRAP_TOKENS }}"
+      {{ faucet }} {{ FAUCET_TOKENS }},{{ BOOTSTRAP_TOKENS }}"
 
 - name: "Add {{ STAKER_INIT_COINS }} coins to {{ STAKER }}-{{ STAKER_NODE }}"
   become: yes

--- a/packages/xsnap/.gitignore
+++ b/packages/xsnap/.gitignore
@@ -1,2 +1,4 @@
 build
 dist
+test/fixture-snap-pool/
+test/fixture-snap-shot.xss


### PR DESCRIPTION
I noticed these minor problems, and bundled them up into a single PR:

- Golang abstracts away some signals under the name `os.Interrupt`, which we should also catch
- The faucet was not given `urun` when bootstrapping a new chain
- `faucet-helper.sh` was falling through and reporting a misleading error
- Add some leftovers from the XS snapshot tests to `.gitignore`.
