### PR TITLE
fix: snapStore tmp files were kept for debugging

### DIFF
--- a/packages/xsnap/src/snapStore.js
+++ b/packages/xsnap/src/snapStore.js
@@ -109,8 +109,6 @@ export function makeSnapStore(
       await atomicWrite(`${h}.gz`, gztmp =>
         filter(snapFile, createGzip(), gztmp),
       );
-      const basename = snapFile.split('/').slice(-1)[0]; // @@WIP
-      await rename(snapFile, resolve(root, `${h}-${basename}`)); // @@WIP
       return h;
     }, 'save-raw');
   }


### PR DESCRIPTION
fixes #3419
