### PR TITLE
Utility to replace kernel bundle in kernel DB

### DIFF
--- a/packages/SwingSet/bin/rekernelize.js
+++ b/packages/SwingSet/bin/rekernelize.js
@@ -6,24 +6,58 @@ import 'node-lmdb';
 import '@agoric/babel-standalone';
 import '@agoric/install-ses';
 
+import fs from 'fs';
 import path from 'path';
 import process from 'process';
 
 import bundleSource from '@agoric/bundle-source';
 import { openLMDBSwingStore } from '@agoric/swing-store-lmdb';
 
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function dirContains(dirpath, suffix) {
+  try {
+    const files = fs.readdirSync(dirpath);
+    for (const file of files) {
+      if (file.endsWith(suffix)) {
+        return true;
+      }
+    }
+    return false;
+  } catch (e) {
+    return false;
+  }
+}
+
 async function main() {
   const argv = process.argv.slice(2);
 
   let dbDir = '.';
   if (argv.length > 1) {
-    console.error('usage: rekernelize [DBDIR]');
-    process.exit(1);
+    fail('usage: rekernelize [DBDIR_OR_FILE]');
   } else if (argv[0]) {
     dbDir = argv[0];
   }
 
-  const kernelStateDBDir = path.join(dbDir, 'swingset-kernel-state');
+  let kernelStateDBDir;
+  const dbSuffix = '.mdb';
+  if (dbDir.endsWith(dbSuffix)) {
+    kernelStateDBDir = path.dirname(dbDir);
+  } else if (dirContains(dbDir, dbSuffix)) {
+    kernelStateDBDir = dbDir;
+  } else {
+    kernelStateDBDir = path.join(dbDir, 'swingset-kernel-state');
+    if (!dirContains(kernelStateDBDir, dbSuffix)) {
+      kernelStateDBDir = null;
+    }
+  }
+  if (!kernelStateDBDir) {
+    fail(`can't find a database at ${dbDir}`);
+  }
+
   const swingStore = openLMDBSwingStore(kernelStateDBDir);
   const kvStore = swingStore.kvStore;
   assert(kvStore.get('initialized'), 'kernel store not initialized');

--- a/packages/SwingSet/bin/rekernelize.js
+++ b/packages/SwingSet/bin/rekernelize.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env -S node -r esm
+
+/* global require */
+
+import 'node-lmdb';
+import '@agoric/babel-standalone';
+import '@agoric/install-ses';
+
+import path from 'path';
+import process from 'process';
+
+import bundleSource from '@agoric/bundle-source';
+import { openLMDBSwingStore } from '@agoric/swing-store-lmdb';
+
+async function main() {
+  const argv = process.argv.slice(2);
+
+  let dbDir = '.';
+  if (argv.length > 1) {
+    console.error('usage: rekernelize [DBDIR]');
+    process.exit(1);
+  } else if (argv[0]) {
+    dbDir = argv[0];
+  }
+
+  const kernelStateDBDir = path.join(dbDir, 'swingset-kernel-state');
+  const swingStore = openLMDBSwingStore(kernelStateDBDir);
+  const kvStore = swingStore.kvStore;
+  assert(kvStore.get('initialized'), 'kernel store not initialized');
+
+  const kernelBundle = await bundleSource(
+    require.resolve('../src/kernel/kernel.js'),
+  );
+
+  kvStore.set('kernelBundle', JSON.stringify(kernelBundle));
+  swingStore.commit();
+  swingStore.close();
+}
+
+main().then(
+  () => 0,
+  e => console.error(`${e}`, e),
+);


### PR DESCRIPTION
Utility to replace the kernel bundle in a kernel database with whatever the kernel bundle would be if you started a new swingset right now.

Usage:
```rekernelize.js [PATH]```

where `PATH` is the path to the directory where the kernel DB lives (defaults to current working directory).