### PR TITLE
fix(swingset): don't perturb XS heap state when loading snapshot

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -293,6 +293,7 @@ github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
+github.com/golang/mock v1.5.0 h1:jlYHihg//f7RRwuPfptm04yp4s7O6Kw8EZiVYIGcH0g=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.0/go.mod h1:Qd/q+1AKNOZr9uGQzbzCmRO6sUih6GTPZv6a1/R87v0=

--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -93,7 +93,7 @@ export function makeStartXSnap(bundles, { snapStore, env, spawn }) {
       // console.log('startXSnap from', { snapshotHash });
       return snapStore.load(snapshotHash, async snapshot => {
         const xs = doXSnap({ snapshot, name, handleCommand, ...xsnapOpts });
-        await xs.evaluate('null'); // ensure that spawn is done
+        await xs.isReady();
         return xs;
       });
     }

--- a/packages/xsnap/src/replay.js
+++ b/packages/xsnap/src/replay.js
@@ -130,6 +130,10 @@ export function recordXSnap(options, folderPath, { writeFileSync }) {
   const it = xsnap({ ...options, handleCommand });
 
   return freeze({
+    isReady: async () => {
+      nextFile('isReady');
+      return it.isReady();
+    },
     /** @param { Uint8Array } msg */
     issueCommand: async msg => {
       nextFile('issueCommand').put(msg);
@@ -215,6 +219,10 @@ export async function replayXSnap(
       }
       const file = rd.file(step);
       switch (kind) {
+        case 'isReady':
+          // eslint-disable-next-line no-await-in-loop
+          await it.isReady();
+          break;
         case 'evaluate':
           running = it.evaluate(file.getText());
           break;

--- a/packages/xsnap/src/xsnap.c
+++ b/packages/xsnap/src/xsnap.c
@@ -370,6 +370,9 @@ ExitCode main(int argc, char* argv[])
 			char command = *nsbuf;
 			// fprintf(stderr, "command: len %d %c arg: %s\n", nslen, command, nsbuf + 1);
 			switch(command) {
+			case 'R': // isReady
+				fxWriteNetString(toParent, ".", "", 0);
+				break;
 			case '?':
 			case 'e':
 				xsBeginCrank(machine, gxCrankMeteringLimit);

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -239,6 +239,18 @@ export function xsnap(options) {
   }
 
   /**
+   * @returns {Promise<void>}
+   */
+  async function isReady() {
+    const result = baton.then(async () => {
+      await messagesToXsnap.next(encoder.encode(`R`));
+      await runToIdle();
+    });
+    baton = result.catch(() => {});
+    return Promise.race([vatCancelled, result]);
+  }
+
+  /**
    * @param {Uint8Array} message
    * @returns {Promise<RunResult<Uint8Array>>}
    */
@@ -305,6 +317,7 @@ export function xsnap(options) {
   return freeze({
     issueCommand,
     issueStringCommand,
+    isReady,
     close,
     terminate,
     evaluate,

--- a/packages/xsnap/test/test-snapstore.js
+++ b/packages/xsnap/test/test-snapstore.js
@@ -163,7 +163,7 @@ test('create SES worker, save, restore, resume', async t => {
 
   const worker = await store.load(h, async snapshot => {
     const xs = xsnap({ name: 'ses-resume', snapshot, os: osType(), spawn });
-    await xs.evaluate('0');
+    await xs.isReady();
     return xs;
   });
   t.teardown(() => worker.close());

--- a/packages/xsnap/test/test-xs-perf.js
+++ b/packages/xsnap/test/test-xs-perf.js
@@ -68,6 +68,27 @@ test('meter details', async t => {
   t.is(meterType, 'xs-meter-8');
 });
 
+test('isReady does not compute / allocate', async t => {
+  const opts = options(io);
+  const vat1 = xsnap(opts);
+  t.teardown(() => vat1.terminate());
+  const vat2 = xsnap(opts);
+  t.teardown(() => vat2.terminate());
+
+  await vat1.evaluate('null');
+  const { meterUsage: m1 } = await vat1.evaluate('null');
+  t.log(m1);
+
+  await vat2.evaluate('null');
+  await vat2.isReady();
+  const { meterUsage: m2 } = await vat2.evaluate('null');
+
+  t.log(m2);
+
+  t.is(m1.compute, m2.compute);
+  t.is(m1.allocate, m2.allocate);
+});
+
 test('metering regex - REDOS', async t => {
   const opts = options(io);
   const vat = xsnap(opts);


### PR DESCRIPTION
fixes #3428
fixes #3429

the xsnap API feature is tested a little bit, but, we have yet to...
  - create a test that creates a vat, runs it long enough to trigger a snapshot, runs it longer still to trigger GC, then stops the kernel and reloads.
    - postponed; see #3428

### validator testing?

If any validator wants to test this, it would be something like:

```
cd agoric-sdk
git fetch --all
git checkout xsnap-isready
yarn
yarn build
# then restart your validator
```

**Do not** restart your validator node with the older code. The older code had a bug with restarting (#3428).
