### PR TITLE
fix: repair stream store self-interference problem

### DIFF
--- a/packages/swing-store-lmdb/src/sqlStreamStore.js
+++ b/packages/swing-store-lmdb/src/sqlStreamStore.js
@@ -113,10 +113,9 @@ export function sqlStreamStore(dbDir, io) {
     insistStreamPosition(position);
 
     assert(
-      [undefined, 'writing'].includes(streamStatus.get(streamName)),
+      !streamStatus.get(streamName),
       X`can't write stream ${q(streamName)} because it's already in use`,
     );
-    streamStatus.set(streamName, 'writing');
 
     db.prepare(
       `

--- a/packages/swing-store-lmdb/test/test-state.js
+++ b/packages/swing-store-lmdb/test/test-state.js
@@ -121,10 +121,6 @@ test('streamStore mode interlock', t => {
   const start = streamStore.STREAM_START;
 
   const s1pos = streamStore.writeStreamItem('st1', 'first', start);
-
-  t.throws(() => streamStore.readStream('st1', start, s1pos), {
-    message: `can't read stream "st1" because it's already in use`,
-  });
   streamStore.closeStream('st1');
 
   const reader = streamStore.readStream('st1', start, s1pos);

--- a/packages/swing-store-simple/src/simpleSwingStore.js
+++ b/packages/swing-store-simple/src/simpleSwingStore.js
@@ -228,18 +228,12 @@ export function initSimpleSwingStore() {
     let stream = streams.get(streamName);
     if (!stream) {
       stream = [];
-      streamStatus.set(streamName, 'write');
       streams.set(streamName, stream);
     } else {
-      const status = streamStatus.get(streamName);
-      if (!status) {
-        streamStatus.set(streamName, 'write');
-      } else {
-        assert(
-          status === 'write',
-          X`can't write stream ${q(streamName)} because it's already in use`,
-        );
-      }
+      assert(
+        !streamStatus.get(streamName),
+        X`can't write stream ${q(streamName)} because it's already in use`,
+      );
     }
     stream[position.itemCount] = item;
     return harden({ itemCount: position.itemCount + 1 });

--- a/packages/swing-store-simple/test/test-state.js
+++ b/packages/swing-store-simple/test/test-state.js
@@ -85,9 +85,6 @@ test('streamStore mode interlock', t => {
 
   const s1pos = streamStore.writeStreamItem('st1', 'first', start);
 
-  t.throws(() => streamStore.readStream('st1', start, s1pos), {
-    message: `can't read stream "st1" because it's already in use`,
-  });
   streamStore.closeStream('st1');
 
   const reader = streamStore.readStream('st1', start, s1pos);


### PR DESCRIPTION
The stream store API evolved since the read/write mode interlock logic was originally coded, such each write has become a singular, stand-alone operation. The read/write mode interlock logic was thus overly aggressive in the face of read-after-write use cases, breaking some uses, notably the problem raised in issue #3437 as well as the swingset-runner "dump after each crank" debug feature.  This fixes that.

@warner I'm not 100% prepared to assert that this absolutely fixes the problem you identified in #3437, since there might be additional subtleties implicated in that, but please check.