### PR TITLE
The beginnings of SwingSet consensus mode

### DIFF
--- a/golang/cosmos/x/vbank/vbank.go
+++ b/golang/cosmos/x/vbank/vbank.go
@@ -121,7 +121,7 @@ func rewardRate(pool sdk.Coins, blocks int64) sdk.Coins {
 }
 
 func (ch portHandler) Receive(ctx *vm.ControllerContext, str string) (ret string, err error) {
-	fmt.Println("vbank.go downcall", str)
+	// fmt.Println("vbank.go downcall", str)
 	keeper := ch.keeper
 
 	var msg portMessage
@@ -223,13 +223,13 @@ func (ch portHandler) Receive(ctx *vm.ControllerContext, str string) (ret string
 		err = fmt.Errorf("unrecognized type %s", msg.Type)
 	}
 
-	fmt.Println("vbank.go downcall reply", ret, err)
+	// fmt.Println("vbank.go downcall reply", ret, err)
 	return
 }
 
 func (am AppModule) CallToController(ctx sdk.Context, send string) (string, error) {
-	// fmt.Println("ibc.go upcall", send)
+	// fmt.Println("vbank.go upcall", send)
 	reply, err := am.keeper.CallToController(ctx, send)
-	// fmt.Println("ibc.go upcall reply", reply, err)
+	// fmt.Println("vbank.go upcall reply", reply, err)
 	return reply, err
 }

--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -123,7 +123,7 @@ export function makeStartXSnap(bundles, { snapStore, env, spawn }) {
  *   slogCallbacks?: unknown,
  *   slogFile?: string,
  *   testTrackDecref?: unknown,
- *   warehousePolicy?: { maxVatsOnline?: number },
+ *   warehousePolicy?: { maxVatsOnline?: number, consensusMode?: boolean },
  *   spawn?: typeof import('child_process').spawn,
  *   env?: Record<string, string | undefined>
  * }} runtimeOptions
@@ -420,7 +420,7 @@ export async function makeSwingsetController(
  *   debugPrefix?: string,
  *   slogCallbacks?: unknown,
  *   testTrackDecref?: unknown,
- *   warehousePolicy?: { maxVatsOnline?: number },
+ *   warehousePolicy?: { maxVatsOnline?: number, consensusMode?: boolean },
  *   slogFile?: string,
  * }} runtimeOptions
  * @typedef { import('@agoric/swing-store-simple').KVStore } KVStore

--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -123,7 +123,8 @@ export function makeStartXSnap(bundles, { snapStore, env, spawn }) {
  *   slogCallbacks?: unknown,
  *   slogFile?: string,
  *   testTrackDecref?: unknown,
- *   warehousePolicy?: { maxVatsOnline?: number, consensusMode?: boolean },
+ *   warehousePolicy?: { maxVatsOnline?: number },
+ *   overrideVatManagerOptions?: { consensusMode?: boolean },
  *   spawn?: typeof import('child_process').spawn,
  *   env?: Record<string, string | undefined>
  * }} runtimeOptions
@@ -147,6 +148,7 @@ export async function makeSwingsetController(
     slogFile,
     spawn = ambientSpawn,
     warehousePolicy = {},
+    overrideVatManagerOptions = {},
   } = runtimeOptions;
   if (typeof Compartment === 'undefined') {
     throw Error('SES must be installed before calling makeSwingsetController');
@@ -306,7 +308,7 @@ export async function makeSwingsetController(
     gcAndFinalize: makeGcAndFinalize(engineGC),
   };
 
-  const kernelOptions = { verbose, warehousePolicy };
+  const kernelOptions = { verbose, warehousePolicy, overrideVatManagerOptions };
   /** @type { ReturnType<typeof import('./kernel').default> } */
   const kernel = buildKernel(kernelEndowments, deviceEndowments, kernelOptions);
 
@@ -420,7 +422,8 @@ export async function makeSwingsetController(
  *   debugPrefix?: string,
  *   slogCallbacks?: unknown,
  *   testTrackDecref?: unknown,
- *   warehousePolicy?: { maxVatsOnline?: number, consensusMode?: boolean },
+ *   warehousePolicy?: { maxVatsOnline?: number },
+ *   overrideVatManagerOptions?: { consensusMode?: boolean },
  *   slogFile?: string,
  * }} runtimeOptions
  * @typedef { import('@agoric/swing-store-simple').KVStore } KVStore

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -135,6 +135,7 @@ export default function buildKernel(
     verbose,
     defaultManagerType = 'local',
     warehousePolicy,
+    overrideVatManagerOptions = {},
   } = kernelOptions;
   const logStartup = verbose ? console.debug : () => 0;
 
@@ -800,6 +801,7 @@ export default function buildKernel(
     panic,
     buildVatSyscallHandler,
     vatAdminRootKref,
+    overrideVatManagerOptions,
   });
 
   const vatWarehouse = makeVatWarehouse(

--- a/packages/SwingSet/src/kernel/loadVat.js
+++ b/packages/SwingSet/src/kernel/loadVat.js
@@ -85,6 +85,7 @@ export function makeVatLoader(stuff) {
   }
 
   const allowedDynamicOptions = [
+    'consensusMode',
     'description',
     'metered',
     'managerType', // TODO: not sure we want vats to be able to control this
@@ -97,6 +98,7 @@ export function makeVatLoader(stuff) {
   ];
 
   const allowedStaticOptions = [
+    'consensusMode',
     'description',
     'name',
     'vatParameters',
@@ -129,6 +131,9 @@ export function makeVatLoader(stuff) {
    * @param {Object} options  an options bag. These options are currently understood:
    *
    * @param {ManagerType} options.managerType
+   *
+   * @param {boolean} options.consensusMode if true,
+   *        turn off debugging features provided to a vat that may cause nondeterminism
    *
    * @param {number} options.virtualObjectCacheSize
    *
@@ -198,6 +203,7 @@ export function makeVatLoader(stuff) {
       isDynamic ? allowedDynamicOptions : allowedStaticOptions,
     );
     const {
+      consensusMode,
       metered = isDynamic,
       vatParameters = {},
       managerType,
@@ -228,6 +234,7 @@ export function makeVatLoader(stuff) {
     );
 
     const managerOptions = {
+      consensusMode,
       managerType,
       bundle: vatSourceBundle,
       metered,

--- a/packages/SwingSet/src/kernel/loadVat.js
+++ b/packages/SwingSet/src/kernel/loadVat.js
@@ -10,6 +10,7 @@ export function makeVatRootObjectSlot() {
 
 export function makeVatLoader(stuff) {
   const {
+    overrideVatManagerOptions = {},
     vatManagerFactory,
     kernelSlog,
     makeVatConsole,
@@ -85,7 +86,6 @@ export function makeVatLoader(stuff) {
   }
 
   const allowedDynamicOptions = [
-    'consensusMode',
     'description',
     'metered',
     'managerType', // TODO: not sure we want vats to be able to control this
@@ -98,7 +98,6 @@ export function makeVatLoader(stuff) {
   ];
 
   const allowedStaticOptions = [
-    'consensusMode',
     'description',
     'name',
     'vatParameters',
@@ -131,9 +130,6 @@ export function makeVatLoader(stuff) {
    * @param {Object} options  an options bag. These options are currently understood:
    *
    * @param {ManagerType} options.managerType
-   *
-   * @param {boolean} options.consensusMode if true,
-   *        turn off debugging features provided to a vat that may cause nondeterminism
    *
    * @param {number} options.virtualObjectCacheSize
    *
@@ -203,7 +199,6 @@ export function makeVatLoader(stuff) {
       isDynamic ? allowedDynamicOptions : allowedStaticOptions,
     );
     const {
-      consensusMode,
       metered = isDynamic,
       vatParameters = {},
       managerType,
@@ -234,7 +229,6 @@ export function makeVatLoader(stuff) {
     );
 
     const managerOptions = {
-      consensusMode,
       managerType,
       bundle: vatSourceBundle,
       metered,
@@ -248,6 +242,7 @@ export function makeVatLoader(stuff) {
       virtualObjectCacheSize,
       useTranscript,
       name,
+      ...overrideVatManagerOptions,
     };
 
     const vatSyscallHandler = buildVatSyscallHandler(vatID, translators);
@@ -269,6 +264,7 @@ export function makeVatLoader(stuff) {
       enableSetup: true,
       managerType: 'local',
       useTranscript: true,
+      ...overrideVatManagerOptions,
     };
     const translators = makeVatTranslators(vatID, kernelKeeper);
     const vatSyscallHandler = buildVatSyscallHandler(vatID, translators);

--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -95,10 +95,13 @@ export function makeVatKeeper(
     kvStore.set(`${vatID}.options`, JSON.stringify(options));
   }
 
-  function getSourceAndOptions() {
+  /**
+   * @param {boolean} consensusMode
+   */
+  function getSourceAndOptions(consensusMode) {
     const source = JSON.parse(kvStore.get(`${vatID}.source`));
     const options = JSON.parse(kvStore.get(`${vatID}.options`));
-    return harden({ source, options });
+    return harden({ source, options: { ...options, consensusMode } });
   }
 
   function getOptions() {

--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -95,13 +95,10 @@ export function makeVatKeeper(
     kvStore.set(`${vatID}.options`, JSON.stringify(options));
   }
 
-  /**
-   * @param {boolean} consensusMode
-   */
-  function getSourceAndOptions(consensusMode) {
+  function getSourceAndOptions() {
     const source = JSON.parse(kvStore.get(`${vatID}.source`));
     const options = JSON.parse(kvStore.get(`${vatID}.options`));
-    return harden({ source, options: { ...options, consensusMode } });
+    return harden({ source, options });
   }
 
   function getOptions() {

--- a/packages/SwingSet/src/kernel/vatManager/factory.js
+++ b/packages/SwingSet/src/kernel/vatManager/factory.js
@@ -52,6 +52,7 @@ export function makeVatManagerFactory({
 
   function validateManagerOptions(managerOptions) {
     assertKnownOptions(managerOptions, [
+      'consensusMode',
       'enablePipelining',
       'managerType',
       'gcEveryCrank',

--- a/packages/SwingSet/src/kernel/vatManager/manager-local.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-local.js
@@ -150,7 +150,9 @@ export function makeLocalVatManagerFactory(tools) {
     const endowments = harden({
       ...vatEndowments,
       ...ls.vatGlobals,
-      console: makeVatConsole(vatConsole, !consensusMode),
+      console: makeVatConsole(vatConsole, (logger, args) => {
+        consensusMode || logger(...args);
+      }),
       assert,
     });
     const inescapableTransforms = [];

--- a/packages/SwingSet/src/kernel/vatManager/manager-local.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-local.js
@@ -7,6 +7,7 @@ import {
   makeSupervisorDispatch,
   makeMeteredDispatch,
   makeSupervisorSyscall,
+  makeVatConsole,
 } from './supervisor-helper.js';
 
 export function makeLocalVatManagerFactory(tools) {
@@ -91,6 +92,7 @@ export function makeLocalVatManagerFactory(tools) {
     vatSyscallHandler,
   ) {
     const {
+      consensusMode,
       metered = false,
       enableDisavow = false,
       enableSetup = false,
@@ -148,7 +150,7 @@ export function makeLocalVatManagerFactory(tools) {
     const endowments = harden({
       ...vatEndowments,
       ...ls.vatGlobals,
-      console: vatConsole,
+      console: makeVatConsole(vatConsole, !consensusMode),
       assert,
     });
     const inescapableTransforms = [];

--- a/packages/SwingSet/src/kernel/vatManager/manager-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-nodeworker.js
@@ -37,6 +37,7 @@ export function makeNodeWorkerVatManagerFactory(tools) {
 
   function createFromBundle(vatID, bundle, managerOptions, vatSyscallHandler) {
     const {
+      consensusMode,
       vatParameters,
       virtualObjectCacheSize,
       enableDisavow,
@@ -116,6 +117,7 @@ export function makeNodeWorkerVatManagerFactory(tools) {
       virtualObjectCacheSize,
       enableDisavow,
       enableVatstore,
+      consensusMode,
     ]);
 
     function deliverToWorker(delivery) {

--- a/packages/SwingSet/src/kernel/vatManager/manager-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-subprocess-node.js
@@ -17,6 +17,7 @@ export function makeNodeSubprocessFactory(tools) {
 
   function createFromBundle(vatID, bundle, managerOptions, vatSyscallHandler) {
     const {
+      consensusMode,
       vatParameters,
       virtualObjectCacheSize,
       enableDisavow,
@@ -111,6 +112,7 @@ export function makeNodeSubprocessFactory(tools) {
       virtualObjectCacheSize,
       enableDisavow,
       enableVatstore,
+      consensusMode,
     ]);
 
     function shutdown() {

--- a/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-subprocess-xsnap.js
@@ -51,6 +51,7 @@ export function makeXsSubprocessFactory({
   ) {
     parentLog(vatID, 'createFromBundle', { vatID });
     const {
+      consensusMode,
       vatParameters,
       virtualObjectCacheSize,
       enableDisavow,
@@ -60,6 +61,7 @@ export function makeXsSubprocessFactory({
       metered,
       compareSyscalls,
       useTranscript,
+      vatConsole,
     } = managerOptions;
     assert(
       !managerOptions.enableSetup,
@@ -86,9 +88,9 @@ export function makeXsSubprocessFactory({
           return mk.syscallFromWorker(vso);
         }
         case 'console': {
-          const [level, tag, ...rest] = args;
-          if (typeof level === 'string' && level in console) {
-            console[level](tag, ...rest);
+          const [level, ...rest] = args;
+          if (typeof level === 'string' && level in vatConsole) {
+            vatConsole[level](...rest);
           } else {
             console.error('bad console level', level);
           }
@@ -142,6 +144,7 @@ export function makeXsSubprocessFactory({
         virtualObjectCacheSize,
         enableDisavow,
         enableVatstore,
+        consensusMode,
         gcEveryCrank,
       ]);
       if (bundleReply[0] === 'dispatchReady') {
@@ -160,7 +163,7 @@ export function makeXsSubprocessFactory({
       parentLog(vatID, `sending delivery`, delivery);
       let result;
       try {
-        result = await issueTagged(['deliver', delivery]);
+        result = await issueTagged(['deliver', delivery, consensusMode]);
       } catch (err) {
         parentLog('issueTagged error:', err.code, err.message);
         let message;

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-helper.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-helper.js
@@ -206,9 +206,7 @@ function makeVatConsole(logger, wrapper = true) {
   const cons = Object.fromEntries(
     ['debug', 'log', 'info', 'warn', 'error'].map(level => {
       if (wrapper === false) {
-        // Static wrapper that never enables.  We create unique no-op functions
-        // so that the different log methods cannot be compared to detect this
-        // mode.
+        // Static wrapper that never enables.
         return [level, () => {}];
       }
 

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-helper.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-helper.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { assert } from '@agoric/assert';
+import { assert, details as X } from '@agoric/assert';
 import {
   insistVatSyscallObject,
   insistVatSyscallResult,
@@ -191,3 +191,45 @@ function makeSupervisorSyscall(syscallToManager, workerCanBlock) {
 
 harden(makeSupervisorSyscall);
 export { makeSupervisorSyscall };
+
+/**
+ * Create a vat console, or a no-op if consensusMode is true.
+ *
+ * TODO: consider other methods per SES VirtualConsole.
+ * See https://github.com/Agoric/agoric-sdk/issues/2146
+ *
+ * @param {Record<'debug' | 'log' | 'info' | 'warn' | 'error', (...args: any[]) => void>} logger
+ * the backing log method
+ * @param {boolean | ((logger: any, args: any[]) => void)} [wrapper]
+ */
+function makeVatConsole(logger, wrapper = true) {
+  const cons = Object.fromEntries(
+    ['debug', 'log', 'info', 'warn', 'error'].map(level => {
+      if (wrapper === false) {
+        // Static wrapper that never enables.  We create unique no-op functions
+        // so that the different log methods cannot be compared to detect this
+        // mode.
+        return [level, () => {}];
+      }
+
+      const backingLog = logger[level];
+      if (wrapper === true) {
+        // Static wrapper that always enables.
+        return [level, backingLog];
+      }
+
+      // Dynamic wrapper that may change its mind.
+      assert.typeof(
+        wrapper,
+        'function',
+        X`Invalid VatConsole wrapper value ${wrapper}`,
+      );
+      return [level, (...args) => wrapper(backingLog, args)];
+    }),
+  );
+
+  return harden(cons);
+}
+
+harden(makeVatConsole);
+export { makeVatConsole };

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-nodeworker.js
@@ -91,7 +91,9 @@ parentPort.on('message', ([type, ...margs]) => {
       ...ls.vatGlobals,
       console: makeVatConsole(
         anylogger(`SwingSet:vat:${vatID}`),
-        !consensusMode,
+        (logger, args) => {
+          consensusMode || logger(...args);
+        },
       ),
       assert,
     };

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-node.js
@@ -108,7 +108,9 @@ fromParent.on('data', ([type, ...margs]) => {
       ...ls.vatGlobals,
       console: makeVatConsole(
         anylogger(`SwingSet:vat:${vatID}`),
-        !consensusMode,
+        (logger, args) => {
+          consensusMode || logger(...args);
+        },
       ),
       assert,
     };

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-node.js
@@ -23,6 +23,7 @@ import { makeLiveSlots } from '../liveSlots.js';
 import {
   makeSupervisorDispatch,
   makeSupervisorSyscall,
+  makeVatConsole,
 } from './supervisor-helper.js';
 
 // eslint-disable-next-line no-unused-vars
@@ -31,15 +32,6 @@ function workerLog(first, ...args) {
 }
 
 workerLog(`supervisor started`);
-
-function makeConsole(tag) {
-  const log = anylogger(tag);
-  const cons = {};
-  for (const level of ['debug', 'log', 'info', 'warn', 'error']) {
-    cons[level] = log[level];
-  }
-  return harden(cons);
-}
 
 let dispatch;
 
@@ -76,6 +68,7 @@ fromParent.on('data', ([type, ...margs]) => {
       virtualObjectCacheSize,
       enableDisavow,
       enableVatstore,
+      consensusMode,
     ] = margs;
 
     function testLog(...args) {
@@ -110,9 +103,13 @@ fromParent.on('data', ([type, ...margs]) => {
       gcTools,
     );
 
+    // Enable or disable the console accordingly.
     const endowments = {
       ...ls.vatGlobals,
-      console: makeConsole(`SwingSet:vatWorker`),
+      console: makeVatConsole(
+        anylogger(`SwingSet:vat:${vatID}`),
+        !consensusMode,
+      ),
       assert,
     };
 

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
@@ -200,7 +200,7 @@ function makeWorker(port) {
         port.send(['console', level, ...jsonSafeArgs]);
       };
     };
-    const logger = {
+    const forwardingLogger = {
       debug: makeLog('debug'),
       log: makeLog('log'),
       info: makeLog('info'),
@@ -213,13 +213,13 @@ function makeWorker(port) {
     const endowments = {
       ...ls.vatGlobals,
       console: makeVatConsole(
-        logger,
+        forwardingLogger,
         // We have to dynamically wrap the consensus mode so that it can change
         // during the lifetime of the supervisor (which when snapshotting, is
         // restored to its current heap across restarts, not actually stopping
         // until the vat is terminated).
-        (fn, args) => {
-          currentConsensusMode || fn(...args);
+        (logger, args) => {
+          currentConsensusMode || logger(...args);
         },
       ),
       assert,

--- a/packages/SwingSet/src/kernel/vatManager/vat-warehouse.js
+++ b/packages/SwingSet/src/kernel/vatManager/vat-warehouse.js
@@ -46,7 +46,6 @@ export const makeLRU = max => {
  * @param { KernelKeeper } kernelKeeper
  * @param { ReturnType<typeof import('../loadVat.js').makeVatLoader> } vatLoader
  * @param {{
- *   consensusMode: boolean,
  *   maxVatsOnline?: number,
  *   snapshotInitial?: number,
  *   snapshotInterval?: number,
@@ -59,8 +58,6 @@ export const makeLRU = max => {
  */
 export function makeVatWarehouse(kernelKeeper, vatLoader, policyOptions) {
   const {
-    // Whether to eliminate all vat nodeterminism.
-    consensusMode = false,
     maxVatsOnline = 50,
     // Often a large contract evaluation is among the first few deliveries,
     // so let's do a snapshot after just a few deliveries.
@@ -111,7 +108,7 @@ export function makeVatWarehouse(kernelKeeper, vatLoader, policyOptions) {
 
     assert(kernelKeeper.vatIsAlive(vatID), X`${q(vatID)}: not alive`);
     const vatKeeper = kernelKeeper.provideVatKeeper(vatID);
-    const { source, options } = vatKeeper.getSourceAndOptions(consensusMode);
+    const { source, options } = vatKeeper.getSourceAndOptions();
 
     const translators = provideTranslators(vatID);
 

--- a/packages/SwingSet/src/kernel/vatManager/vat-warehouse.js
+++ b/packages/SwingSet/src/kernel/vatManager/vat-warehouse.js
@@ -46,6 +46,7 @@ export const makeLRU = max => {
  * @param { KernelKeeper } kernelKeeper
  * @param { ReturnType<typeof import('../loadVat.js').makeVatLoader> } vatLoader
  * @param {{
+ *   consensusMode: boolean,
  *   maxVatsOnline?: number,
  *   snapshotInitial?: number,
  *   snapshotInterval?: number,
@@ -58,6 +59,8 @@ export const makeLRU = max => {
  */
 export function makeVatWarehouse(kernelKeeper, vatLoader, policyOptions) {
   const {
+    // Whether to eliminate all vat nodeterminism.
+    consensusMode = false,
     maxVatsOnline = 50,
     // Often a large contract evaluation is among the first few deliveries,
     // so let's do a snapshot after just a few deliveries.
@@ -108,7 +111,7 @@ export function makeVatWarehouse(kernelKeeper, vatLoader, policyOptions) {
 
     assert(kernelKeeper.vatIsAlive(vatID), X`${q(vatID)}: not alive`);
     const vatKeeper = kernelKeeper.provideVatKeeper(vatID);
-    const { source, options } = vatKeeper.getSourceAndOptions();
+    const { source, options } = vatKeeper.getSourceAndOptions(consensusMode);
 
     const translators = provideTranslators(vatID);
 
@@ -140,7 +143,7 @@ export function makeVatWarehouse(kernelKeeper, vatLoader, policyOptions) {
       enablePipelining,
       options,
     };
-    console.log(
+    console.info(
       vatID,
       'online:',
       options.managerType,

--- a/packages/SwingSet/src/types.js
+++ b/packages/SwingSet/src/types.js
@@ -23,6 +23,7 @@
  *
  * @typedef { 'local' | 'nodeWorker' | 'node-subprocess' | 'xs-worker' | 'xs-worker-no-gc' } ManagerType
  * @typedef {{
+ *   consensusMode: boolean,
  *   enablePipelining?: boolean,
  *   managerType: ManagerType,
  *   gcEveryCrank?: boolean,
@@ -34,7 +35,7 @@
  *   virtualObjectCacheSize: number,
  *   name: string,
  *   compareSyscalls?: (originalSyscall: {}, newSyscall: {}) => Error | undefined,
- *   vatConsole: unknown,
+ *   vatConsole: Console,
  *   liveSlotsConsole?: Console,
  * } & (HasBundle | HasSetup)} ManagerOptions
  */

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -115,7 +115,14 @@ export default async function main(progname, args, { env, homedir, agcc }) {
   function registerPortHandler(portHandler) {
     lastPort += 1;
     const port = lastPort;
-    portHandlers[port] = portHandler;
+    portHandlers[port] = async (...phArgs) => {
+      try {
+        return await portHandler(...phArgs);
+      } catch (e) {
+        console.error('portHandler threw', e);
+        throw e;
+      }
+    };
     return port;
   }
 
@@ -228,6 +235,7 @@ export default async function main(progname, args, { env, homedir, agcc }) {
     };
     const meterProvider = getMeterProvider(console, env);
     const slogFile = env.SLOGFILE;
+    const consensusMode = env.DEBUG === undefined;
     const s = await launch(
       stateDBDir,
       mailboxStorage,
@@ -237,6 +245,7 @@ export default async function main(progname, args, { env, homedir, agcc }) {
       undefined,
       meterProvider,
       slogFile,
+      consensusMode,
     );
     return s;
   }

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -37,7 +37,7 @@ async function buildSwingset(
   hostStorage,
   vatconfig,
   argv,
-  { debugName = undefined, slogCallbacks, slogFile },
+  { consensusMode, debugName = undefined, slogCallbacks, slogFile },
 ) {
   const debugPrefix = debugName === undefined ? '' : `${debugName}:`;
   let config = loadSwingsetConfigFile(vatconfig);
@@ -80,7 +80,7 @@ async function buildSwingset(
   const controller = await makeSwingsetController(
     hostStorage,
     deviceEndowments,
-    { slogCallbacks, slogFile },
+    { warehousePolicy: { consensusMode }, slogCallbacks, slogFile },
   );
 
   // We DON'T want to run the kernel yet, only when the application decides
@@ -98,6 +98,7 @@ export async function launch(
   debugName = undefined,
   meterProvider = DEFAULT_METER_PROVIDER,
   slogFile = undefined,
+  consensusMode = false,
 ) {
   console.info('Launching SwingSet kernel');
 
@@ -139,6 +140,7 @@ export async function launch(
       debugName,
       slogCallbacks,
       slogFile,
+      consensusMode,
     },
   );
 

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -80,7 +80,7 @@ async function buildSwingset(
   const controller = await makeSwingsetController(
     hostStorage,
     deviceEndowments,
-    { warehousePolicy: { consensusMode }, slogCallbacks, slogFile },
+    { overrideVatManagerOptions: { consensusMode }, slogCallbacks, slogFile },
   );
 
   // We DON'T want to run the kernel yet, only when the application decides


### PR DESCRIPTION
Refs #2519

This PR plumbs through a `consensusMode` kernel option that, when true, tries to eliminate observable nondeterminism from the perspective of user code in vats.  For this first cut, that means that console logging is stubbed out as close to the vat code as possible.

Consensus mode is the default when running `ag-chain-cosmos` without setting `$DEBUG`.  It is a dynamic setting, so to get debugging information, you can take an existing initdir and run `DEBUG=agoric ag-chain-cosmos start` to reenable debug output.  Note that this may result in writing nondeterministic effects to disk, so be sure to take a copy of the initdir so that you can continue the original in consensus mode.

To facilitate debugging, `ag-solo` does not use consensus mode, nor does its embedded sim-chain (which is also solo, not quorum nor genuine chain).
