### PR TITLE
Audit refcounts

### DIFF
--- a/packages/SwingSet/src/initializeSwingset.js
+++ b/packages/SwingSet/src/initializeSwingset.js
@@ -9,6 +9,7 @@ import bundleSource from '@agoric/bundle-source';
 import './types.js';
 import { insistStorageAPI } from './storageAPI.js';
 import { initializeKernel } from './kernel/initializeKernel.js';
+import { kdebugEnable } from './kernel/kdebug.js';
 
 /**
  * @param {X[]} xs
@@ -218,7 +219,7 @@ export function swingsetIsInitialized(hostStorage) {
  * @param {SwingSetConfig} config
  * @param {string[]} argv
  * @param {HostStore} hostStorage
- * @param {{ kernelBundles?: Record<string, string> }} initializationOptions
+ * @param {{ kernelBundles?: Record<string, string>, verbose?: boolean }} initializationOptions
  * @param {{ env?: Record<string, string | undefined > }} runtimeOptions
  */
 export async function initializeSwingset(
@@ -266,7 +267,10 @@ export async function initializeSwingset(
       assert.fail(X`unknown manager type ${defaultManagerType}`);
   }
 
-  const { kernelBundles = await buildKernelBundles() } = initializationOptions;
+  const {
+    kernelBundles = await buildKernelBundles(),
+    verbose,
+  } = initializationOptions;
 
   kvStore.set('kernelBundle', JSON.stringify(kernelBundles.kernel));
   kvStore.set('lockdownBundle', JSON.stringify(kernelBundles.lockdown));
@@ -386,5 +390,8 @@ export async function initializeSwingset(
   await bundleBundles(config.vats, 'vats');
   await bundleBundles(config.devices, 'devices');
 
+  if (verbose) {
+    kdebugEnable(true);
+  }
   return initializeKernel(config, hostStorage);
 }

--- a/packages/SwingSet/src/kernel/initializeKernel.js
+++ b/packages/SwingSet/src/kernel/initializeKernel.js
@@ -8,7 +8,7 @@ import { makeVatSlot } from '../parseVatSlots';
 import { insistStorageAPI } from '../storageAPI';
 import { wrapStorage } from './state/storageWrapper';
 import makeKernelKeeper from './state/kernelKeeper';
-import { doAddExport, doQueueToKref } from './kernel';
+import { exportRootObject, doQueueToKref } from './kernel';
 
 function makeVatRootObjectSlot() {
   return makeVatSlot('object', true, 0);
@@ -82,11 +82,10 @@ export function initializeKernel(config, hostStorage, verbose = false) {
       vatKeeper.setSourceAndOptions({ bundle, bundleName }, creationOptions);
       if (name === 'vatAdmin') {
         // Create a kref for the vatAdmin root, so the kernel can tell it
-        // about creation/termination of dynamic vats. doAddExport will
-        // increment the refcount so it won't go away, despite being
-        // unreferenced by any other vat.
-        const rootVref = makeVatRootObjectSlot();
-        const kref = doAddExport(kernelKeeper, vatID, rootVref);
+        // about creation/termination of dynamic vats.
+        const kref = exportRootObject(kernelKeeper, vatID);
+        // Pin, to prevent it being GC'd when only the kvStore points to it
+        kernelKeeper.pinObject(kref);
         kvStore.set('vatAdminRootKref', kref);
         gotVatAdminRootKref = true;
       }
@@ -193,8 +192,7 @@ export function initializeKernel(config, hostStorage, verbose = false) {
     });
     const args = harden([vatObj0s, deviceObj0s]);
     // doQueueToKref() takes kernel-refs (ko+NN, kd+NN) in s.slots
-    const rootVref = makeVatRootObjectSlot();
-    const rootKref = doAddExport(kernelKeeper, bootstrapVatID, rootVref);
+    const rootKref = exportRootObject(kernelKeeper, bootstrapVatID);
     const resultKpid = doQueueToKref(
       kernelKeeper,
       rootKref,

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -818,6 +818,7 @@ export default function makeKernelKeeper(
         reachable += 1;
       }
       recognizable += 1;
+      // kdebug(`++ ${kernelSlot}  ${tag} ${reachable},${recognizable}`);
       setObjectRefCount(kernelSlot, { reachable, recognizable });
     }
   }
@@ -860,6 +861,7 @@ export default function makeKernelKeeper(
         reachable -= 1;
       }
       recognizable -= 1;
+      // kdebug(`-- ${kernelSlot}  ${tag} ${reachable},${recognizable}`);
       if (!reachable || !recognizable) {
         maybeFreeKrefs.add(kernelSlot);
       }

--- a/packages/SwingSet/src/kernel/vatTranslator.js
+++ b/packages/SwingSet/src/kernel/vatTranslator.js
@@ -89,7 +89,7 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
     const vrefs = krefs.map(kref =>
       mapKernelSlotToVatSlot(kref, gcDeliveryMapOpts),
     );
-    krefs.map(vatKeeper.clearReachableFlag);
+    krefs.map(kref => vatKeeper.clearReachableFlag(kref, 'dropE'));
     const vatDelivery = harden(['dropExports', vrefs]);
     return vatDelivery;
   }
@@ -239,7 +239,7 @@ function makeTranslateVatSyscallToKernelSyscall(vatID, kernelKeeper) {
       const kref = mapVatSlotToKernelSlot(vref, gcSyscallMapOpts);
       // and we clear the reachable flag, which might the decrement the
       // reachable refcount, which might tag the kref for processing
-      clearReachableFlag(kref);
+      clearReachableFlag(kref, 'dropI');
       return kref;
     });
     kdebug(`syscall[${vatID}].dropImports(${krefs.join(' ')})`);

--- a/packages/SwingSet/test/definition/test-vat-definition.js
+++ b/packages/SwingSet/test/definition/test-vat-definition.js
@@ -25,13 +25,15 @@ test('create with setup and buildRootObject', async t => {
     },
   };
   const c = await buildVatController(config, []);
-  let r = c.queueToVatExport('setup', 'o+0', 'increment', capargs([]), 'panic');
+  c.pinVatRoot('setup');
+  c.pinVatRoot('liveslots');
+  let r = c.queueToVatRoot('setup', 'increment', capargs([]), 'panic');
   await c.run();
   t.deepEqual(c.kpResolution(r), capargs(mUndefined), 'setup incr');
-  r = c.queueToVatExport('setup', 'o+0', 'read', capargs([]), 'panic');
+  r = c.queueToVatRoot('setup', 'read', capargs([]), 'panic');
   await c.run();
   t.deepEqual(c.kpResolution(r), capargs(1), 'setup read');
-  r = c.queueToVatExport('setup', 'o+0', 'remotable', capargs([]), 'panic');
+  r = c.queueToVatRoot('setup', 'remotable', capargs([]), 'panic');
   await c.run();
   t.deepEqual(
     c.kpResolution(r),
@@ -39,13 +41,13 @@ test('create with setup and buildRootObject', async t => {
     'setup Remotable/getInterfaceOf',
   );
 
-  r = c.queueToVatExport('liveslots', 'o+0', 'increment', capargs([]), 'panic');
+  r = c.queueToVatRoot('liveslots', 'increment', capargs([]), 'panic');
   await c.run();
   t.deepEqual(c.kpResolution(r), capargs(mUndefined), 'ls incr');
-  r = c.queueToVatExport('liveslots', 'o+0', 'read', capargs([]), 'panic');
+  r = c.queueToVatRoot('liveslots', 'read', capargs([]), 'panic');
   await c.run();
   t.deepEqual(c.kpResolution(r), capargs(1), 'ls read');
-  r = c.queueToVatExport('liveslots', 'o+0', 'remotable', capargs([]), 'panic');
+  r = c.queueToVatRoot('liveslots', 'remotable', capargs([]), 'panic');
   await c.run();
   t.deepEqual(
     c.kpResolution(r),

--- a/packages/SwingSet/test/gc/test-gc-vat.js
+++ b/packages/SwingSet/test/gc/test-gc-vat.js
@@ -32,13 +32,14 @@ async function dropPresence(t, dropExport) {
   const hostStorage = provideHostStorage();
   await initializeSwingset(config, [], hostStorage);
   const c = await makeSwingsetController(hostStorage);
+  c.pinVatRoot('bootstrap');
   t.teardown(c.shutdown);
   await c.run();
 
   const bootstrapID = c.vatNameToID('bootstrap');
-  c.queueToVatExport('bootstrap', 'o+0', 'one', capargs([]));
+  c.queueToVatRoot('bootstrap', 'one', capargs([]));
   if (dropExport) {
-    c.queueToVatExport('bootstrap', 'o+0', 'drop', capargs([]));
+    c.queueToVatRoot('bootstrap', 'drop', capargs([]));
     await c.step();
   }
   await c.step();

--- a/packages/SwingSet/test/metering/test-dynamic-vat-metered.js
+++ b/packages/SwingSet/test/metering/test-dynamic-vat-metered.js
@@ -50,15 +50,15 @@ async function runOneTest(t, explosion, managerType) {
     hostStorage,
     kernelBundles,
   });
+  c.pinVatRoot('bootstrap');
   const nextLog = makeNextLog(c);
 
   // let the vatAdminService get wired up before we create any new vats
   await c.run();
 
   // 'createVat' will import the bundle
-  c.queueToVatExport(
+  c.queueToVatRoot(
     'bootstrap',
-    'o+0',
     'createVat',
     capargs([dynamicVatBundle, { managerType }]),
   );
@@ -73,13 +73,13 @@ async function runOneTest(t, explosion, managerType) {
   const root = kvStore.get(`${vatID}.c.o+0`);
 
   // and grab a kpid that won't be resolved until the vat dies
-  const r = c.queueToVatExport('bootstrap', 'o+0', 'getNever', capargs([]));
+  const r = c.queueToVatRoot('bootstrap', 'getNever', capargs([]));
   await c.run();
   const neverArgs = c.kpResolution(r);
   const neverKPID = neverArgs.slots[0];
 
   // First, send a message to the dynamic vat that runs normally
-  c.queueToVatExport('bootstrap', 'o+0', 'run', capargs([]));
+  c.queueToVatRoot('bootstrap', 'run', capargs([]));
   await c.run();
   t.is(JSON.parse(kvStore.get('vat.dynamicIDs')).length, 1);
   t.is(kvStore.get(`${root}.owner`), vatID);
@@ -93,7 +93,7 @@ async function runOneTest(t, explosion, managerType) {
   // message result promise should be rejected, and the control facet should
   // report the vat's demise.  Remnants of the killed vat should be gone
   // from the kernel state store.
-  c.queueToVatExport('bootstrap', 'o+0', 'explode', capargs([explosion]));
+  c.queueToVatRoot('bootstrap', 'explode', capargs([explosion]));
   await c.run();
   t.is(JSON.parse(kvStore.get('vat.dynamicIDs')).length, 0);
   t.is(kvStore.get(`${root}.owner`), undefined);
@@ -128,7 +128,7 @@ async function runOneTest(t, explosion, managerType) {
   );
 
   // the dead vat should stay dead
-  c.queueToVatExport('bootstrap', 'o+0', 'run', capargs([]));
+  c.queueToVatRoot('bootstrap', 'run', capargs([]));
   await c.run();
   t.deepEqual(nextLog(), ['run exploded: Error: vat terminated'], 'stay dead');
 }

--- a/packages/SwingSet/test/metering/test-dynamic-vat-subcompartment.js
+++ b/packages/SwingSet/test/metering/test-dynamic-vat-subcompartment.js
@@ -30,6 +30,7 @@ test('metering dynamic vat which imports bundle', async t => {
     },
   };
   const c = await buildVatController(config, []);
+  c.pinVatRoot('bootstrap');
   const nextLog = makeNextLog(c);
 
   // let the vatAdminService get wired up before we create any new vats
@@ -42,12 +43,7 @@ test('metering dynamic vat which imports bundle', async t => {
   );
 
   // 'createVat' will import the bundle
-  c.queueToVatExport(
-    'bootstrap',
-    'o+0',
-    'createVat',
-    capargs([dynamicVatBundle]),
-  );
+  c.queueToVatRoot('bootstrap', 'createVat', capargs([dynamicVatBundle]));
   await c.run();
   t.deepEqual(nextLog(), ['created'], 'first create');
 
@@ -55,17 +51,12 @@ test('metering dynamic vat which imports bundle', async t => {
   const grandchildBundle = await bundleSource(
     require.resolve('./grandchild.js'),
   );
-  const r = c.queueToVatExport(
-    'bootstrap',
-    'o+0',
-    'load',
-    capargs([grandchildBundle]),
-  );
+  const r = c.queueToVatRoot('bootstrap', 'load', capargs([grandchildBundle]));
   await c.run();
   t.deepEqual(c.kpResolution(r), capargs('ok'));
 
   // First, send a message to the grandchild that runs normally
-  c.queueToVatExport('bootstrap', 'o+0', 'bundleRun', capargs([]));
+  c.queueToVatRoot('bootstrap', 'bundleRun', capargs([]));
   await c.run();
 
   t.deepEqual(nextLog(), ['did run'], 'first run ok');
@@ -73,12 +64,7 @@ test('metering dynamic vat which imports bundle', async t => {
   // Now tell the grandchild to exhaust the dynamic vat's meter. The message
   // result promise should be rejected, and the control facet should report
   // the vat's demise
-  c.queueToVatExport(
-    'bootstrap',
-    'o+0',
-    'bundleExplode',
-    capargs(['allocate']),
-  );
+  c.queueToVatRoot('bootstrap', 'bundleExplode', capargs(['allocate']));
   await c.run();
 
   t.deepEqual(
@@ -91,7 +77,7 @@ test('metering dynamic vat which imports bundle', async t => {
   );
 
   // the whole vat should be dead (we use 'run' instead of 'bundleRun')
-  c.queueToVatExport('bootstrap', 'o+0', 'run', capargs([]));
+  c.queueToVatRoot('bootstrap', 'run', capargs([]));
   await c.run();
   t.deepEqual(
     nextLog(),

--- a/packages/SwingSet/test/metering/test-dynamic-vat-unmetered.js
+++ b/packages/SwingSet/test/metering/test-dynamic-vat-unmetered.js
@@ -31,6 +31,7 @@ test('unmetered dynamic vat', async t => {
     },
   };
   const c = await buildVatController(config, []);
+  c.pinVatRoot('bootstrap');
   const nextLog = makeNextLog(c);
 
   // let the vatAdminService get wired up before we create any new vats
@@ -43,9 +44,8 @@ test('unmetered dynamic vat', async t => {
   );
 
   // 'createVat' will import the bundle
-  c.queueToVatExport(
+  c.queueToVatRoot(
     'bootstrap',
-    'o+0',
     'createVat',
     capargs([dynamicVatBundle, { metered: false }]),
     'panic',
@@ -54,7 +54,7 @@ test('unmetered dynamic vat', async t => {
   t.deepEqual(nextLog(), ['created'], 'first create');
 
   // First, send a message to the dynamic vat that runs normally
-  c.queueToVatExport('bootstrap', 'o+0', 'run', capargs([]), 'panic');
+  c.queueToVatRoot('bootstrap', 'run', capargs([]), 'panic');
   await c.run();
 
   t.deepEqual(nextLog(), ['did run'], 'first run ok');
@@ -62,13 +62,7 @@ test('unmetered dynamic vat', async t => {
   // Tell the dynamic vat to call `Array(4e9)`. If metering was in place,
   // this would be rejected. Without metering, it's harmless (Arrays are
   // lazy).
-  c.queueToVatExport(
-    'bootstrap',
-    'o+0',
-    'explode',
-    capargs(['allocate']),
-    'panic',
-  );
+  c.queueToVatRoot('bootstrap', 'explode', capargs(['allocate']), 'panic');
   await c.run();
   t.deepEqual(nextLog(), ['failed to explode'], 'metering disabled');
 });

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -66,7 +66,7 @@ async function simpleCall(t) {
   t.deepEqual(data.kernelTable, [vatAdminRoot]);
 
   // vat1:o+1 will map to ko21
-  controller.queueToVatExport('vat1', 'o+1', 'foo', capdata('args'));
+  controller.queueToVatRoot('vat1', 'foo', capdata('args'));
   t.deepEqual(controller.dump().runQueue, [
     {
       msg: {
@@ -80,7 +80,7 @@ async function simpleCall(t) {
   ]);
   await controller.run();
   t.deepEqual(JSON.parse(controller.dump().log[0]), {
-    target: 'o+1',
+    target: 'o+0',
     method: 'foo',
     args: capdata('args'),
   });
@@ -161,6 +161,7 @@ test('bootstrap export', async t => {
     path.resolve(__dirname, 'basedir-controller-3'),
   );
   const c = await buildVatController(config);
+  c.pinVatRoot('bootstrap');
   const vatAdminVatID = c.vatNameToID('vatAdmin');
   const vatAdminDevID = c.deviceNameToID('vatAdmin');
   const commsVatID = c.vatNameToID('comms');

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -65,7 +65,7 @@ async function simpleCall(t) {
   const vatAdminRoot = ['ko20', adminVatID, 'o+0'];
   t.deepEqual(data.kernelTable, [vatAdminRoot]);
 
-  // vat1:o+1 will map to ko21
+  // vat1:o+0 will map to ko21
   controller.queueToVatRoot('vat1', 'foo', capdata('args'));
   t.deepEqual(controller.dump().runQueue, [
     {

--- a/packages/SwingSet/test/test-devices.js
+++ b/packages/SwingSet/test/test-devices.js
@@ -113,7 +113,7 @@ test.serial('d1', async t => {
   await initializeSwingset(config, [], hostStorage, t.context.data);
   const c = await makeSwingsetController(hostStorage, deviceEndowments);
   await c.step();
-  c.queueToVatExport('bootstrap', 'o+0', 'step1', capargs([]));
+  c.queueToVatRoot('bootstrap', 'step1', capargs([]));
   await c.step();
   t.deepEqual(c.dump().log, [
     'callNow',
@@ -144,6 +144,7 @@ async function test2(t, mode) {
   const hostStorage = provideHostStorage();
   await initializeSwingset(config, [mode], hostStorage, t.context.data);
   const c = await makeSwingsetController(hostStorage, {});
+  c.pinVatRoot('bootstrap');
   await c.step();
   if (mode === '1') {
     t.deepEqual(c.dump().log, ['calling d2.method1', 'method1 hello', 'done']);
@@ -510,8 +511,8 @@ test.serial('liveslots throws when D() gets promise', async t => {
   // If that isn't working as expected, and the promise makes it to
   // syscall.callNow, the translator will notice and kill the vat. We send a
   // ping() to it to make sure it's still alive. If the vat were dead,
-  // queueToVatExport would throw because the vat was deleted.
-  c.queueToVatExport('bootstrap', 'o+0', 'ping', capargs([]), 'panic');
+  // queueToVatRoot would throw because the vat was deleted.
+  c.queueToVatRoot('bootstrap', 'ping', capargs([]), 'panic');
   await c.run();
 
   // If the translator doesn't catch the promise and it makes it to the device,
@@ -543,7 +544,7 @@ test.serial('syscall.callNow(promise) is vat-fatal', async t => {
   t.deepEqual(c.dump().log, ['sending Promise', 'good: callNow failed']);
   // now check that the vat was terminated: this should throw an exception
   // because the entire bootstrap vat was deleted
-  t.throws(() => c.queueToVatExport('bootstrap', 'o+0', 'ping', capargs([])), {
+  t.throws(() => c.queueToVatRoot('bootstrap', 'ping', capargs([])), {
     message: /vat name .* must exist, but doesn't/,
   });
 });

--- a/packages/SwingSet/test/test-exomessages.js
+++ b/packages/SwingSet/test/test-exomessages.js
@@ -77,11 +77,11 @@ test('bootstrap failure', async t => {
 
 async function extraMessage(t, mode, status, body, slots) {
   const controller = await beginning(t, 'data');
+  controller.pinVatRoot('bootstrap');
   await controller.run();
   const args = { body: `["${mode}"]`, slots: [] };
-  const extraResult = controller.queueToVatExport(
+  const extraResult = controller.queueToVatRoot(
     'bootstrap',
-    'o+0',
     'extra',
     args,
     'ignore',

--- a/packages/SwingSet/test/test-promises.js
+++ b/packages/SwingSet/test/test-promises.js
@@ -173,6 +173,7 @@ test('refcount while queued', async t => {
     path.resolve(__dirname, 'basedir-promises-3'),
   );
   const c = await buildVatController(config, [], t.context.data);
+  c.pinVatRoot('bootstrap');
 
   // bootstrap() sets up an unresolved promise (p2, the result promise of
   // right~.one()) with vat-right as the decider, and enqueues a message
@@ -180,7 +181,7 @@ test('refcount while queued', async t => {
   await c.run();
 
   // then we tell that vat to resolve pk1 to a value (4)
-  c.queueToVatExport('bootstrap', 'o+0', 'two', capargs([]), 'ignore');
+  c.queueToVatRoot('bootstrap', 'two', capargs([]), 'ignore');
   await c.run();
 
   // Now we have a resolved promise 'pk1' whose only reference is the
@@ -192,13 +193,7 @@ test('refcount while queued', async t => {
   // tell vat-right to resolve p2, which should transfer the 'four' message
   // from the p2 promise queue to the run-queue for vat-right. That message
   // will be delivered, with a new promise that is promptly resolved to '3'.
-  const kpid4 = c.queueToVatExport(
-    'right',
-    'o+0',
-    'three',
-    capargs([]),
-    'ignore',
-  );
+  const kpid4 = c.queueToVatRoot('right', 'three', capargs([]), 'ignore');
   await c.run();
   t.deepEqual(c.kpResolution(kpid4), capargs([true, 3]));
 });

--- a/packages/SwingSet/test/test-transcriptlessness.js
+++ b/packages/SwingSet/test/test-transcriptlessness.js
@@ -29,7 +29,7 @@ async function testTranscriptlessness(t, useTranscript) {
   const c2 = await buildVatController(config, [], {
     hostStorage,
   });
-  c2.queueToVatExport('bootstrap', 'o+0', 'go', capargs([]), 'panic');
+  c2.queueToVatRoot('bootstrap', 'go', capargs([]), 'panic');
   await c2.run();
   if (useTranscript) {
     t.deepEqual(c2.dump().log, [

--- a/packages/SwingSet/test/test-vatstore.js
+++ b/packages/SwingSet/test/test-vatstore.js
@@ -22,9 +22,10 @@ test('vatstore', async t => {
   const c = await buildVatController(config, [], {
     hostStorage,
   });
+  c.pinVatRoot('bootstrap');
 
   function send(msg, ...args) {
-    c.queueToVatExport('bootstrap', 'o+0', msg, capargs(args));
+    c.queueToVatRoot('bootstrap', msg, capargs(args));
   }
 
   send('get', 'zot');

--- a/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
+++ b/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
@@ -126,6 +126,7 @@ test('dispatches to the dead do not harm kernel', async t => {
       hostStorage: hostStorage1,
       kernelBundles: t.context.data.kernelBundles,
     });
+    c1.pinVatRoot('bootstrap');
     await c1.run();
     t.deepEqual(c1.kpResolution(c1.bootstrapResult), capargs('bootstrap done'));
     t.deepEqual(c1.dump().log, [
@@ -145,9 +146,8 @@ test('dispatches to the dead do not harm kernel', async t => {
       hostStorage: hostStorage2,
       kernelBundles: t.context.data.kernelBundles,
     });
-    const r2 = c2.queueToVatExport(
+    const r2 = c2.queueToVatRoot(
       'bootstrap',
-      'o+0',
       'speakAgain',
       capargs([]),
       'panic',
@@ -203,6 +203,7 @@ test('dead vat state removed', async t => {
     hostStorage,
     kernelBundles: t.context.data.kernelBundles,
   });
+  controller.pinVatRoot('bootstrap');
   await controller.run();
   t.deepEqual(
     controller.kpResolution(controller.bootstrapResult),
@@ -213,7 +214,7 @@ test('dead vat state removed', async t => {
   t.is(kvStore.get('ko26.owner'), 'v6');
   t.is(Array.from(kvStore.getKeys('v6.', 'v6/')).length, 9);
 
-  controller.queueToVatExport('bootstrap', 'o+0', 'phase2', capargs([]));
+  controller.queueToVatRoot('bootstrap', 'phase2', capargs([]));
   await controller.run();
   t.is(kvStore.get('vat.dynamicIDs'), '[]');
   t.is(kvStore.get('ko26.owner'), undefined);

--- a/packages/SwingSet/test/vat-admin/test-replay.js
+++ b/packages/SwingSet/test/vat-admin/test-replay.js
@@ -48,9 +48,9 @@ test('replay bundleSource-based dynamic vat', async t => {
       hostStorage: hostStorage1,
       kernelBundles: t.context.data.kernelBundles,
     });
-    const r1 = c1.queueToVatExport(
+    c1.pinVatRoot('bootstrap');
+    const r1 = c1.queueToVatRoot(
       'bootstrap',
-      'o+0',
       'createBundle',
       capargs([]),
       'panic',
@@ -70,13 +70,7 @@ test('replay bundleSource-based dynamic vat', async t => {
     const c2 = await buildVatController(copy(config), [], {
       hostStorage: hostStorage2,
     });
-    const r2 = c2.queueToVatExport(
-      'bootstrap',
-      'o+0',
-      'check',
-      capargs([]),
-      'panic',
-    );
+    const r2 = c2.queueToVatRoot('bootstrap', 'check', capargs([]), 'panic');
     await c2.run();
     t.deepEqual(c2.kpResolution(r2), capargs('ok'));
   }
@@ -100,9 +94,9 @@ test('replay bundleName-based dynamic vat', async t => {
       hostStorage: hostStorage1,
       kernelBundles: t.context.data.kernelBundles,
     });
-    const r1 = c1.queueToVatExport(
+    c1.pinVatRoot('bootstrap');
+    const r1 = c1.queueToVatRoot(
       'bootstrap',
-      'o+0',
       'createNamed',
       capargs([]),
       'panic',
@@ -118,13 +112,7 @@ test('replay bundleName-based dynamic vat', async t => {
     const c2 = await buildVatController(copy(config), [], {
       hostStorage: hostStorage2,
     });
-    const r2 = c2.queueToVatExport(
-      'bootstrap',
-      'o+0',
-      'check',
-      capargs([]),
-      'panic',
-    );
+    const r2 = c2.queueToVatRoot('bootstrap', 'check', capargs([]), 'panic');
     await c2.run();
     t.deepEqual(c2.kpResolution(r2), capargs('ok'));
   }

--- a/packages/SwingSet/test/vat-warehouse/test-reload-snapshot.js
+++ b/packages/SwingSet/test/vat-warehouse/test-reload-snapshot.js
@@ -44,6 +44,7 @@ test('vat reload from snapshot', async t => {
   const c1 = await makeSwingsetController(hostStorage, null, {
     warehousePolicy: { initialSnapshot: 2, snapshotInterval: 5 },
   });
+  c1.pinVatRoot('target');
   const vatID = c1.vatNameToID('target');
 
   function getPositions() {
@@ -57,14 +58,14 @@ test('vat reload from snapshot', async t => {
   }
 
   const expected1 = [];
-  c1.queueToVatExport('target', 'o+0', 'count', capargs([]));
+  c1.queueToVatRoot('target', 'count', capargs([]));
   expected1.push(`count = 0`);
   await c1.run();
   t.deepEqual(c1.dump().log, expected1);
   t.deepEqual(getPositions(), [0, 1]);
 
   for (let i = 1; i < 11; i += 1) {
-    c1.queueToVatExport('target', 'o+0', 'count', capargs([]));
+    c1.queueToVatRoot('target', 'count', capargs([]));
     expected1.push(`count = ${i}`);
   }
   await c1.run();
@@ -75,7 +76,7 @@ test('vat reload from snapshot', async t => {
   const c2 = await makeSwingsetController(hostStorage);
   const expected2 = [`count = 7`, `count = 8`, `count = 9`, `count = 10`];
   t.deepEqual(c2.dump().log, expected2); // replayed 4 deliveries
-  c2.queueToVatExport('target', 'o+0', 'count', capargs([]));
+  c2.queueToVatRoot('target', 'count', capargs([]));
   expected2.push(`count = 11`);
   await c2.run();
   t.deepEqual(c2.dump().log, expected2); // note: *not* 0-11

--- a/packages/SwingSet/test/vat-warehouse/test-warehouse.js
+++ b/packages/SwingSet/test/vat-warehouse/test-warehouse.js
@@ -18,6 +18,7 @@ async function makeController(managerType, runtimeOptions) {
   config.vats.target3 = config.vats.target;
   config.vats.target4 = config.vats.target;
   const c = await buildVatController(config, [], runtimeOptions);
+  c.pinVatRoot('bootstrap');
   return c;
 }
 
@@ -78,7 +79,7 @@ async function runSteps(c, t) {
   await c.run();
   for (const { vat, online } of steps) {
     t.log('sending to vat', vat);
-    c.queueToVatExport(vat, 'o+0', 'append', capargs([1]));
+    c.queueToVatRoot(vat, 'append', capargs([1]));
     // eslint-disable-next-line no-await-in-loop
     await c.run();
     t.log(

--- a/packages/SwingSet/test/virtualObjects/test-representatives.js
+++ b/packages/SwingSet/test/virtualObjects/test-representatives.js
@@ -41,15 +41,15 @@ test('virtual object representatives', async t => {
   };
 
   const c = await buildVatController(config, []);
+  c.pinVatRoot('bootstrap');
   const nextLog = makeNextLog(c);
 
   await c.run();
   t.deepEqual(c.kpResolution(c.bootstrapResult), capargs('bootstrap done'));
 
   async function doTestA(mode, result) {
-    const r = c.queueToVatExport(
+    const r = c.queueToVatRoot(
       'bootstrap',
-      'o+0',
       'testA',
       capargs([`thing${mode}`, mode]),
     );
@@ -62,9 +62,8 @@ test('virtual object representatives', async t => {
   await doTestA(2, 'ko26');
 
   async function doTestB(mode, result) {
-    const r = c.queueToVatExport(
+    const r = c.queueToVatRoot(
       'bootstrap',
-      'o+0',
       'testB',
       capargs([`thing${mode}`, mode]),
     );
@@ -84,9 +83,8 @@ test('virtual object representatives', async t => {
   await doTestB(6, 'ko30');
 
   async function doTestC(mode) {
-    const r = c.queueToVatExport(
+    const r = c.queueToVatRoot(
       'bootstrap',
-      'o+0',
       'testC',
       capargs([`thing${mode}`, mode]),
     );
@@ -100,9 +98,8 @@ test('virtual object representatives', async t => {
   await doTestC(10);
 
   async function doTestD(mode) {
-    const r = c.queueToVatExport(
+    const r = c.queueToVatRoot(
       'bootstrap',
-      'o+0',
       'testD',
       capargs([`thing${mode}`, mode]),
     );
@@ -114,9 +111,8 @@ test('virtual object representatives', async t => {
   await doTestD(12);
 
   async function doTestE(mode) {
-    const r = c.queueToVatExport(
+    const r = c.queueToVatRoot(
       'bootstrap',
-      'o+0',
       'testE',
       capargs([`thing${mode}`, mode]),
     );
@@ -133,9 +129,8 @@ test('virtual object representatives', async t => {
   await doTestE(19);
   await doTestE(20);
 
-  const rz1 = c.queueToVatExport(
+  const rz1 = c.queueToVatRoot(
     'bootstrap',
-    'o+0',
     'testCacheOverflow',
     capargs([`zot1`, false]),
   );
@@ -144,9 +139,8 @@ test('virtual object representatives', async t => {
   t.deepEqual(nextLog(), []);
   t.deepEqual(c.kpResolution(rz1), slot0('zot', 'ko31'));
 
-  const rz2 = c.queueToVatExport(
+  const rz2 = c.queueToVatRoot(
     'bootstrap',
-    'o+0',
     'testCacheOverflow',
     capargs([`zot2`, true]),
   );
@@ -212,6 +206,7 @@ test('exercise cache', async t => {
     loggingHostStorage,
   );
   const c = await makeSwingsetController(loggingHostStorage, {});
+  c.pinVatRoot('bootstrap');
 
   const nextLog = makeNextLog(c);
 
@@ -230,7 +225,7 @@ test('exercise cache', async t => {
     } else {
       sendArgs = capargs(args);
     }
-    const r = c.queueToVatExport('bootstrap', 'o+0', method, sendArgs);
+    const r = c.queueToVatRoot('bootstrap', method, sendArgs);
     await c.run();
     t.is(c.kpStatus(r), 'fulfilled');
     t.deepEqual(nextLog(), []);

--- a/packages/SwingSet/test/virtualObjects/test-weakcollections.js
+++ b/packages/SwingSet/test/virtualObjects/test-weakcollections.js
@@ -35,6 +35,7 @@ test('weakMap in vat', async t => {
   const hostStorage = provideHostStorage();
   const bootstrapResult = await initializeSwingset(config, [], hostStorage);
   const c = await makeSwingsetController(hostStorage, {});
+  c.pinVatRoot('bootstrap');
   const nextLog = makeNextLog(c);
 
   await c.run();
@@ -42,7 +43,7 @@ test('weakMap in vat', async t => {
 
   async function doSimple(method) {
     const sendArgs = capargs([], []);
-    const r = c.queueToVatExport('bootstrap', 'o+0', method, sendArgs);
+    const r = c.queueToVatRoot('bootstrap', method, sendArgs);
     await c.run();
     t.is(c.kpStatus(r), 'fulfilled');
     return c.kpResolution(r);

--- a/packages/swingset-runner/.gitignore
+++ b/packages/swingset-runner/.gitignore
@@ -3,6 +3,7 @@
 *.sss
 *.jsonlines
 *.naive
+*.sqlite
 slog
 vslog
 vlog

--- a/packages/swingset-runner/src/dumpstore.js
+++ b/packages/swingset-runner/src/dumpstore.js
@@ -45,6 +45,7 @@ export function dumpStore(swingStore, outfile, rawMode) {
 
   popt('crankNumber');
   popt('kernel.defaultManagerType');
+  popt('pinnedObjects');
   popt('vatAdminRootKref');
   popt('gcActions');
   popt('kernelStats');
@@ -77,12 +78,23 @@ export function dumpStore(swingStore, outfile, rawMode) {
   pgroup('kd');
   gap();
 
+  let starting = true;
   for (const [dn, d] of devs.entries()) {
+    if (starting) {
+      starting = false;
+    } else {
+      gap();
+    }
     p(`// device ${d} (${dn})`);
     popt(`${d}.options`);
     poptBig('bundle', `${d}.source`);
     popt(`${d}.o.nextID`);
+    popt(`${d}.deviceState`);
     for (const key of groupKeys(`${d}.c.kd`)) {
+      const val = popt(key);
+      popt(`${d}.c.${val}`);
+    }
+    for (const key of groupKeys(`${d}.c.ko`)) {
       const val = popt(key);
       popt(`${d}.c.${val}`);
     }
@@ -121,7 +133,7 @@ export function dumpStore(swingStore, outfile, rawMode) {
   gap();
 
   const vatInfo = [];
-  let starting = true;
+  starting = true;
   for (const [vn, v] of vats.entries()) {
     if (starting) {
       starting = false;

--- a/packages/swingset-runner/src/kerneldump.js
+++ b/packages/swingset-runner/src/kerneldump.js
@@ -17,6 +17,7 @@ FLAGS may be:
   --raw       - dump the kernel state database as key/value pairs,
                 alphabetically without annotation
   --refcounts - audit kernel promise reference counts
+  --refdump   - dump reference count analysis
   --auditonly - only audit, don't dump
   --help      - print this helpful usage information
   --out PATH  - output dump to PATH ("-" indicates stdout, the default)
@@ -56,6 +57,7 @@ export function main() {
   let refCounts = false;
   let justStats = false;
   let doDump = true;
+  let refDump = false;
   let outfile;
   while (argv[0] && argv[0].startsWith('-')) {
     const flag = argv.shift();
@@ -68,7 +70,13 @@ export function main() {
         refCounts = true;
         break;
       case '--auditonly':
+        refCounts = true;
         doDump = false;
+        break;
+      case '--refdump':
+        refCounts = true;
+        doDump = false;
+        refDump = true;
         break;
       case '--stats':
         justStats = true;
@@ -116,7 +124,7 @@ export function main() {
       dumpStore(swingStore, outfile, rawMode);
     }
     if (refCounts) {
-      auditRefCounts(swingStore.kvStore);
+      auditRefCounts(swingStore.kvStore, refDump, doDump);
     }
   }
 }

--- a/packages/swingset-runner/src/main.js
+++ b/packages/swingset-runner/src/main.js
@@ -411,6 +411,7 @@ export async function main() {
       config,
       bootstrapArgv,
       hostStorage,
+      { verbose },
       runtimeOptions,
     );
     swingStore.commit();
@@ -424,6 +425,11 @@ export async function main() {
     deviceEndowments,
     runtimeOptions,
   );
+  if (benchmarkRounds > 0) {
+    // Pin the vat root that will run benchmark rounds so it'll still be there
+    // when it comes time to run them.
+    controller.pinVatRoot(launchIndirectly ? 'launcher' : 'bootstrap');
+  }
 
   let blockNumber = 0;
   let statLogger = null;
@@ -560,9 +566,8 @@ export async function main() {
     let totalSteps = 0;
     let totalDeltaT = 0n;
     for (let i = 0; i < rounds; i += 1) {
-      const roundResult = controller.queueToVatExport(
+      const roundResult = controller.queueToVatRoot(
         launchIndirectly ? 'launcher' : 'bootstrap',
-        'o+0',
         'runBenchmarkRound',
         args,
         'ignore',


### PR DESCRIPTION
Implements #3445 

The `kerneldump` utility's refcount auditing feature now understands object reference counts in addition to the promise reference counts that it previously dealt with.

This change ended up drawing in several other groups of changes in its train, which are included here as individual commits for the benefit of reviewers.

- The logging messages used to trace reference count increments and decrements had not been updated to incorporate the reference counts now associated with objects.  Now they have been.
- There was a bug such that if you turned on verbose logging it would not take effect until part of the way through swingset initialization, causing some messages pertinent to debugging refcounts to be elided.  This is now fixed, though the handling of swingset options (in particular, "initialization options" vs. "runtime options") could still benefit from refactoring and cleanup, for which issue #3307 is relevant; a comment has been added to that issue accordingly.
- The mechanism by which objects exported outside the swingset got "pinned" by having their reference counts artificially incremented was kind of a mess.  This mess has been cleaned up, resulting in some changes to the controller API.
- Things that used said controller API (mostly notably tests, but also swingset-runner) have been updated to reflect this New World Order.
- Finally, refcount auditing itself: this has been run over all the examples I could find and so far no issues have emerged that weren't issues with the audit logic itself or one of the above mentioned bits of grunge that have now been dealt with.  I pronounce @warner's GC efforts in this area to be Good.