### PR TITLE
fix: tolerate endo pre and post #822

### DIFF
--- a/packages/import-bundle/test/test-compartment-wrapper.js
+++ b/packages/import-bundle/test/test-compartment-wrapper.js
@@ -118,7 +118,12 @@ function check(t, c, odometer, n) {
   const Con = Object.getPrototypeOf(c.globalThis.Compartment).constructor;
   t.throws(
     () => new Con(),
-    { message: /Not available/ },
+    {
+      // Temporarily tolerate Endo behavior before and after
+      // https://github.com/endojs/endo/pull/822
+      // TODO Simplify once depending on SES post #822
+      message: /Not available|Function\.prototype\.constructor is not a valid constructor\./,
+    },
     `${n} .constructor is tamed`,
   );
 

--- a/packages/xsnap/test/test-boot-lockdown.js
+++ b/packages/xsnap/test/test-boot-lockdown.js
@@ -45,7 +45,17 @@ test('child compartment cannot access start powers', async t => {
   await vat.evaluate(script);
   await vat.close();
 
-  t.deepEqual(opts.messages, ['err was TypeError: Not available']);
+  // Temporarily tolerate Endo behavior before and after
+  // https://github.com/endojs/endo/pull/822
+  // TODO Simplify once depending on SES post #822
+  // t.deepEqual(opts.messages, [
+  //   'err was TypeError: Function.prototype.constructor is not a valid constructor.',
+  // ]);
+  t.assert(
+    opts.messages[0] === 'err was TypeError: Not available' ||
+      opts.messages[0] ===
+        'err was TypeError: Function.prototype.constructor is not a valid constructor.',
+  );
 });
 
 test('SES deep stacks work on xsnap', async t => {


### PR DESCRIPTION
Test was testing for error message before https://github.com/endojs/endo/pull/822 , which is not yet part of an endo release. In anticipation, and to aid development against endo master using `yarn link`, temporarily make it tolerate both the old and new error messages.

Question for reviewers: To what degree should tests be testing for the content of error messages anyway?