### PR TITLE
chore: add attestation contract

### DIFF
--- a/packages/zoe/src/contracts/attestation/attMaker.js
+++ b/packages/zoe/src/contracts/attestation/attMaker.js
@@ -1,0 +1,24 @@
+// @ts-check
+
+import { makeStore } from '@agoric/store';
+
+const makeGetAttMaker = makeAttMaker => {
+  /** @type {WeakStore<Address, AttMaker>} */
+  const addressToAttMaker = makeStore('address');
+
+  /** @type {GetAttMaker} */
+  const getAttMaker = address => {
+    assert.typeof(address, 'string');
+    if (addressToAttMaker.has(address)) {
+      return addressToAttMaker.get(address);
+    }
+    const attMaker = makeAttMaker(address);
+    addressToAttMaker.init(address, attMaker);
+    return attMaker;
+  };
+
+  harden(getAttMaker);
+  return getAttMaker;
+};
+harden(makeGetAttMaker);
+export { makeGetAttMaker };

--- a/packages/zoe/src/contracts/attestation/attMaker.js
+++ b/packages/zoe/src/contracts/attestation/attMaker.js
@@ -3,7 +3,7 @@
 import { makeStore } from '@agoric/store';
 
 const makeGetAttMaker = makeAttMaker => {
-  /** @type {WeakStore<Address, AttMaker>} */
+  /** @type {Store<Address, AttMaker>} */
   const addressToAttMaker = makeStore('address');
 
   /** @type {GetAttMaker} */

--- a/packages/zoe/src/contracts/attestation/attestation.js
+++ b/packages/zoe/src/contracts/attestation/attestation.js
@@ -124,14 +124,14 @@ const start = async zcf => {
     makeExtendAttInvitation,
     getIssuers: () => {
       return harden({
-        returnable: returnableAttManager.issuer,
-        expiring: expiringAttManager.issuer,
+        returnable: returnableAttManager.getIssuer(),
+        expiring: expiringAttManager.getIssuer(),
       });
     },
     getBrands: () => {
       return harden({
-        returnable: returnableAttManager.brand,
-        expiring: expiringAttManager.brand,
+        returnable: returnableAttManager.getBrand(),
+        expiring: expiringAttManager.getBrand(),
       });
     },
   });

--- a/packages/zoe/src/contracts/attestation/attestation.js
+++ b/packages/zoe/src/contracts/attestation/attestation.js
@@ -13,6 +13,8 @@ import { max } from './helpers';
 import { assertPrerequisites } from './prerequisites';
 import { makeGetAttMaker } from './attMaker';
 
+const { details: X } = assert;
+
 /**
  * @type {ContractStartFn}
  */
@@ -53,7 +55,7 @@ const start = async zcf => {
   const getLiened = (address, currentTime, brand) => {
     assert(
       brand === underlyingBrand,
-      `This contract can only make attestations for ${brand}`,
+      X`This contract can only make attestations for ${brand}`,
     );
     storedTime.updateTime(currentTime);
     const expiringLienAmount = expiringAttManager.getLienAmount(

--- a/packages/zoe/src/contracts/attestation/attestation.js
+++ b/packages/zoe/src/contracts/attestation/attestation.js
@@ -83,6 +83,12 @@ const start = async zcf => {
       storedTime.getTime(),
     );
 
+  // IMPORTANT: only expose this function to the owner of the address.
+  // This request *must* come from the owner of the address. Merely
+  // verifying that the address *could* add a lien is not sufficient.
+  // The owner must consent to adding a lien, and non-owners must not
+  // be able to initiate a lien for another account.
+
   /** @type {MakeAttestationsInternal} */
   const makeAttestationsInternal = async (
     address,
@@ -135,6 +141,10 @@ const start = async zcf => {
       });
     },
   });
+
+  // IMPORTANT: The AttMaker should only be given to the owner of the
+  // address. Only the owner should be able to create attestations and
+  // the resulting liens on their underlying tokens.
 
   /** @type {MakeAttMaker} */
   const makeAttMaker = address => {

--- a/packages/zoe/src/contracts/attestation/attestation.js
+++ b/packages/zoe/src/contracts/attestation/attestation.js
@@ -119,7 +119,7 @@ const start = async zcf => {
     });
   };
 
-  const publicFacet = Far('publicFacet', {
+  const publicFacet = Far('attestation publicFacet', {
     makeReturnAttInvitation: returnableAttManager.makeReturnAttInvitation,
     makeExtendAttInvitation,
     getIssuers: () => {
@@ -152,7 +152,7 @@ const start = async zcf => {
   // The authority is used to confirm that the underlying assets are escrowed appropriately.
   const addAuthority = authority => authorityPromiseKit.resolve(authority);
 
-  const creatorFacet = Far('creatorFacet', {
+  const creatorFacet = Far('attestation creatorFacet', {
     getLiened,
     getAttMaker,
     slashed,

--- a/packages/zoe/src/contracts/attestation/attestation.js
+++ b/packages/zoe/src/contracts/attestation/attestation.js
@@ -100,8 +100,9 @@ const start = async zcf => {
     amountToLien = AmountMath.coerce(underlyingBrand, amountToLien);
     assert.typeof(expiration, 'bigint');
 
-    const currentTime = await assertPrerequisites(
+    await assertPrerequisites(
       authorityPromiseKit.promise,
+      storedTime,
       getLiened,
       underlyingBrand,
       address,
@@ -109,7 +110,6 @@ const start = async zcf => {
       expiration,
     );
     // AWAIT ///
-    storedTime.updateTime(currentTime);
 
     const expiringAttPayment = expiringAttManager.addExpiringLien(
       address,

--- a/packages/zoe/src/contracts/attestation/attestation.js
+++ b/packages/zoe/src/contracts/attestation/attestation.js
@@ -1,0 +1,153 @@
+// @ts-check
+
+import { AmountMath } from '@agoric/ertp';
+import { E } from '@agoric/eventual-send';
+
+import '../../../exported';
+import { setupAttestation as setupExpiringAttestation } from './expiring/expiringNFT';
+import { setupAttestation as setupReturnableAttestation } from './returnable/returnableNFT';
+import { makeStoredTime } from './storedTime';
+import { max } from './helpers';
+import { assertPrerequisites } from './prerequisites';
+import { makeGetAttMaker } from './attMaker';
+
+/**
+ * @type {ContractStartFn}
+ */
+const start = async zcf => {
+  const {
+    brands: { Underlying: underlyingBrand },
+    authority, // an object representing the authority that has the ability to confirm that the underlying amount is escrowed externally
+    expiringAttName,
+    returnableAttName,
+  } = zcf.getTerms();
+
+  const { assetKind: underlyingAssetKind } = await E(
+    underlyingBrand,
+  ).getDisplayInfo();
+  // AWAIT ///
+
+  const storedTime = makeStoredTime();
+  const empty = AmountMath.makeEmpty(underlyingBrand, underlyingAssetKind);
+
+  const expiringAttManagerP = setupExpiringAttestation(
+    expiringAttName, // e.g. 'BldAttGov'
+    empty,
+    zcf,
+  );
+  const returnableAttManagerP = setupReturnableAttestation(
+    returnableAttName, // e.g. 'BldAttLoc'
+    empty,
+    zcf,
+  );
+  const [expiringAttManager, returnableAttManager] = await Promise.all([
+    expiringAttManagerP,
+    returnableAttManagerP,
+  ]);
+  // AWAIT ///
+
+  /** @type {GetLienAmount} */
+  const getLienAmount = (address, currentTime) => {
+    const expiringLienAmount = expiringAttManager.getLienAmount(
+      address,
+      currentTime,
+    );
+    const returnableLienAmount = returnableAttManager.getLienAmount(address);
+    return max(expiringLienAmount, returnableLienAmount);
+  };
+
+  /** @type {GetLiened} */
+  const getLiened = (addresses, currentTime) => {
+    storedTime.updateTime(currentTime);
+    return addresses.map(address => getLienAmount(address, currentTime));
+  };
+
+  /** @type {Slashed} */
+  const slashed = (address, currentTime) => {
+    storedTime.updateTime(currentTime);
+    expiringAttManager.disallowExtensions(address);
+  };
+
+  /** @type {MakeExtendAttInvitation} */
+  const makeExtendAttInvitation = newExpiration =>
+    expiringAttManager.makeExtendAttInvitation(
+      newExpiration,
+      storedTime.getTime(),
+    );
+
+  /** @type {MakeAttestationsInternal} */
+  const makeAttestationsInternal = async (
+    address,
+    amountToLien,
+    expiration,
+  ) => {
+    amountToLien = AmountMath.coerce(underlyingBrand, amountToLien);
+    assert.typeof(expiration, 'bigint');
+
+    const currentTime = await assertPrerequisites(
+      authority,
+      getLienAmount,
+      underlyingBrand,
+      address,
+      amountToLien,
+      expiration,
+    );
+    // AWAIT ///
+    storedTime.updateTime(currentTime);
+
+    const expiringAttPayment = expiringAttManager.addExpiringLien(
+      address,
+      amountToLien,
+      expiration,
+    );
+    const returnableAttPayment = returnableAttManager.addReturnableLien(
+      address,
+      amountToLien,
+    );
+
+    return harden({
+      expiring: expiringAttPayment,
+      returnable: returnableAttPayment,
+    });
+  };
+
+  const publicFacet = {
+    makeReturnAttInvitation: returnableAttManager.makeReturnAttInvitation, // called by user/dapp/wallet, can also be called from the AttMaker
+    makeExtendAttInvitation, // called by user/dapp/wallet, can also be called from the AttMaker
+    getIssuers: () => {
+      return {
+        returnable: returnableAttManager.issuer,
+        expiring: expiringAttManager.issuer,
+      };
+    },
+    getBrands: () => {
+      return {
+        returnable: returnableAttManager.brand,
+        expiring: expiringAttManager.brand,
+      };
+    },
+  };
+
+  /** @type {MakeAttMaker} */
+  const makeAttMaker = address => {
+    /** @type {AttMaker} */
+    return harden({
+      makeAttestations: (amountToLien, expiration) =>
+        makeAttestationsInternal(address, amountToLien, expiration),
+      makeReturnAttInvitation: returnableAttManager.makeReturnAttInvitation,
+      makeExtendAttInvitation,
+    });
+  };
+
+  const getAttMaker = makeGetAttMaker(makeAttMaker);
+
+  const creatorFacet = {
+    getLiened, // called by cosmos
+    getAttMaker, // called by createUserBundle in bootstrap.js
+    slashed, // called by cosmos
+  };
+
+  return harden({ creatorFacet, publicFacet });
+};
+
+export { start };

--- a/packages/zoe/src/contracts/attestation/expiring/expiringHelpers.js
+++ b/packages/zoe/src/contracts/attestation/expiring/expiringHelpers.js
@@ -1,0 +1,57 @@
+// @ts-check
+
+/**
+ * Add a lien for a particular amount for an address, with an
+ * expiration date after which it is unliened (whether the
+ * expiration date has passed is only checked when `getLienAmount`
+ * is called)
+ *
+ * @param {Store<Address,Array<ExpiringAttElem>>} store
+ * @param {ExpiringAttElem} attestationElem
+ */
+const addToLiened = (store, attestationElem) => {
+  const { address } = attestationElem;
+  if (store.has(address)) {
+    const lienedSoFar = store.get(address);
+    lienedSoFar.push(attestationElem);
+    store.set(address, lienedSoFar);
+  } else {
+    store.init(address, [attestationElem]);
+  }
+};
+
+/**
+ * We should be as reluctant as possible to lift a lien, therefore,
+ * the expiration has only expired when the currentTime is past
+ * (greater than and not equal to) the expiration.
+ *
+ * @param {Timestamp} expiration
+ * @param {Timestamp} currentTime
+ * @returns {boolean}
+ */
+const hasExpired = (expiration, currentTime) => expiration < currentTime;
+
+/**
+ * Create a single element that will be used in the SetValue of attestations
+ *
+ * @param {Address} address
+ * @param {Amount} amountLiened - the amount of the underlying asset to put
+ * a lien on
+ * @param {Timestamp} expiration
+ * @param {Handle<'attestation'>} handle - the unique handle
+ * @returns {ExpiringAttElem}
+ */
+const makeAttestationElem = (address, amountLiened, expiration, handle) => {
+  return harden({
+    address,
+    amountLiened,
+    expiration,
+    handle,
+  });
+};
+
+harden(addToLiened);
+harden(hasExpired);
+harden(makeAttestationElem);
+
+export { addToLiened, hasExpired, makeAttestationElem };

--- a/packages/zoe/src/contracts/attestation/expiring/expiringNFT.js
+++ b/packages/zoe/src/contracts/attestation/expiring/expiringNFT.js
@@ -12,7 +12,7 @@ import {
   hasExpired,
 } from './expiringHelpers';
 import { updateLien } from './updateLien';
-import { unlienIfExpired } from './unlienIfExpired';
+import { unlienExpiredAmounts } from './unlienExpiredAmounts';
 import { extendExpiration as extendExpirationInternal } from './extendExpiration';
 
 // Adds an expiring lien to an amount in response to an incoming call.
@@ -27,7 +27,9 @@ const { quote: q } = assert;
  * BLD) that the attestation is about
  * @param {ContractFacet} zcf
  * @returns {Promise<{disallowExtensions: DisallowExtensions, addExpiringLien: AddExpiringLien, getLienAmount:
- * GetLienAmount, makeExtendAttInvitation: MakeExtendAttInvitationInternal, issuer: Issuer, brand: Brand}>}
+ * GetLienAmount, makeExtendAttInvitation:
+ * MakeExtendAttInvitationInternal, getIssuer: () => Issuer, getBrand:
+ * () => Brand}>}
  */
 const setupAttestation = async (attestationTokenName, empty, zcf) => {
   assert(AmountMath.isEmpty(empty), `empty ${q(empty)} was not empty`);
@@ -39,7 +41,7 @@ const setupAttestation = async (attestationTokenName, empty, zcf) => {
 
   const externalBrand = empty.brand;
 
-  // Note: `amountLiened` is of the brand `externalBrand`
+  // Note: `amountLiened` in ExpiringAttElem is of the brand `externalBrand`
 
   /** @type {Store<Address,Array<ExpiringAttElem>>} */
   const lienedAmounts = makeStore('address');
@@ -78,7 +80,7 @@ const setupAttestation = async (attestationTokenName, empty, zcf) => {
 
     // We should first unlien any amounts for which the lien has
     // expired, then return the total lien still remaining for the address
-    const totalStillLiened = unlienIfExpired(
+    const totalStillLiened = unlienExpiredAmounts(
       lienedAmounts,
       empty,
       address,
@@ -134,8 +136,8 @@ const setupAttestation = async (attestationTokenName, empty, zcf) => {
     addExpiringLien,
     getLienAmount,
     makeExtendAttInvitation, // choice by user to extend expiration
-    issuer: attestationIssuer,
-    brand: attestationBrand,
+    getIssuer: () => attestationIssuer,
+    getBrand: () => attestationBrand,
   });
 };
 

--- a/packages/zoe/src/contracts/attestation/expiring/expiringNFT.js
+++ b/packages/zoe/src/contracts/attestation/expiring/expiringNFT.js
@@ -46,6 +46,7 @@ const setupAttestation = async (attestationTokenName, empty, zcf) => {
 
   const cannotGetExtension = new Set();
 
+  // IMPORTANT: only expose this function to the owner of the address.
   // This request *must* come from the owner of the address. Merely
   // verifying that the address *could* add a lien is not sufficient.
   // The owner must consent to adding a lien, and non-owners must not

--- a/packages/zoe/src/contracts/attestation/expiring/expiringNFT.js
+++ b/packages/zoe/src/contracts/attestation/expiring/expiringNFT.js
@@ -96,7 +96,7 @@ const setupAttestation = async (attestationTokenName, empty, zcf) => {
   };
 
   const canExtend = address => !cannotGetExtension.has(address);
-  const updateLienedAmounts = newAttestationElem =>
+  const updateLienedAmount = newAttestationElem =>
     updateLien(lienedAmounts, newAttestationElem);
 
   /** @type {ExtendExpiration} */
@@ -105,7 +105,7 @@ const setupAttestation = async (attestationTokenName, empty, zcf) => {
       seat,
       zcfMint,
       canExtend,
-      updateLienedAmounts,
+      updateLienedAmount,
       attestationBrand,
       newExpiration,
     );

--- a/packages/zoe/src/contracts/attestation/expiring/expiringNFT.js
+++ b/packages/zoe/src/contracts/attestation/expiring/expiringNFT.js
@@ -15,6 +15,8 @@ import { updateLien } from './updateLien';
 import { unlienExpiredAmounts } from './unlienExpiredAmounts';
 import { extendExpiration as extendExpirationInternal } from './extendExpiration';
 
+const { details: X } = assert;
+
 // Adds an expiring lien to an amount in response to an incoming call.
 // Can be queried for the current liened amount for an address.
 
@@ -30,7 +32,7 @@ import { extendExpiration as extendExpirationInternal } from './extendExpiration
  * () => Brand}>}
  */
 const setupAttestation = async (attestationTokenName, empty, zcf) => {
-  assert(AmountMath.isEmpty(empty), `empty '${empty}' was not empty`);
+  assert(AmountMath.isEmpty(empty), X`empty ${empty} was not empty`);
   const zcfMint = await zcf.makeZCFMint(attestationTokenName, AssetKind.SET);
   const {
     brand: attestationBrand,
@@ -120,7 +122,7 @@ const setupAttestation = async (attestationTokenName, empty, zcf) => {
     // Fail-fast if the newExpiration is already out of date
     assert(
       !hasExpired(newExpiration, currentTime),
-      `The attestation could not be extended, as the new expiration '${newExpiration}' is in the past`,
+      X`The attestation could not be extended, as the new expiration ${newExpiration} is in the past`,
     );
     const offerHandler = seat => extendExpiration(seat, newExpiration);
     return zcf.makeInvitation(offerHandler, 'ExtendAtt', {

--- a/packages/zoe/src/contracts/attestation/expiring/expiringNFT.js
+++ b/packages/zoe/src/contracts/attestation/expiring/expiringNFT.js
@@ -18,8 +18,6 @@ import { extendExpiration as extendExpirationInternal } from './extendExpiration
 // Adds an expiring lien to an amount in response to an incoming call.
 // Can be queried for the current liened amount for an address.
 
-const { quote: q } = assert;
-
 /**
  * @param {string} attestationTokenName - the name for the attestation
  * token
@@ -32,7 +30,7 @@ const { quote: q } = assert;
  * () => Brand}>}
  */
 const setupAttestation = async (attestationTokenName, empty, zcf) => {
-  assert(AmountMath.isEmpty(empty), `empty ${q(empty)} was not empty`);
+  assert(AmountMath.isEmpty(empty), `empty '${empty}' was not empty`);
   const zcfMint = await zcf.makeZCFMint(attestationTokenName, AssetKind.SET);
   const {
     brand: attestationBrand,
@@ -121,9 +119,7 @@ const setupAttestation = async (attestationTokenName, empty, zcf) => {
     // Fail-fast if the newExpiration is already out of date
     assert(
       !hasExpired(newExpiration, currentTime),
-      `The attestation could not be extended, as the new expiration ${q(
-        newExpiration,
-      )} is in the past`,
+      `The attestation could not be extended, as the new expiration '${newExpiration}' is in the past`,
     );
     const offerHandler = seat => extendExpiration(seat, newExpiration);
     return zcf.makeInvitation(offerHandler, 'ExtendAtt', {

--- a/packages/zoe/src/contracts/attestation/expiring/expiringNFT.js
+++ b/packages/zoe/src/contracts/attestation/expiring/expiringNFT.js
@@ -76,7 +76,7 @@ const setupAttestation = async (attestationTokenName, empty, zcf) => {
     assert.typeof(address, 'string');
     assert.typeof(currentTime, 'bigint');
 
-    // We should first unlien any amounts for which the lien has
+    // We first unlien any amounts for which the lien has
     // expired, then return the total lien still remaining for the address
     const totalStillLiened = unlienExpiredAmounts(
       lienedAmounts,

--- a/packages/zoe/src/contracts/attestation/expiring/extendExpiration.js
+++ b/packages/zoe/src/contracts/attestation/expiring/extendExpiration.js
@@ -1,0 +1,81 @@
+// @ts-check
+
+import { AmountMath } from '@agoric/ertp';
+import { checkOfferShape } from '../helpers';
+
+import { makeAttestationElem } from './expiringHelpers';
+
+const { details: X, quote: q } = assert;
+
+/**
+ * A user makes a proposal with a `give` of { Attestation:
+ * attestationPayment }, and receives a payout of { Attestation:
+ * newAttestationPayment } where the new attestation has an expiration
+ * of `newExpiration`.
+ *
+ * @param {ZCFSeat} seat
+ * @param {ZCFMint} zcfMint
+ * @param {(address: Address) => boolean} canExtend
+ * @param {(newAttestationElem: ExpiringAttElem) => void} updateLienedAmounts
+ * @param {Brand} attestationBrand
+ * @param {Timestamp} newExpiration
+ * @returns {void}
+ */
+const extendExpiration = (
+  seat,
+  zcfMint,
+  canExtend,
+  updateLienedAmounts,
+  attestationBrand,
+  newExpiration,
+) => {
+  const oldAttestationAmount = checkOfferShape(seat, attestationBrand);
+
+  const attestationValue = /** @type {SetValue} */ (oldAttestationAmount.value);
+
+  // TODO: allow for multiple elements in the amount value to each
+  // be extended. Currently, we restrict the value to a single element.
+  assert(
+    attestationValue.length === 1,
+    X`We can currently only extend a single attestation element at a time, not ${attestationValue}`,
+  );
+  const {
+    expiration,
+    handle,
+    address,
+    amountLiened,
+  } = /** @type {ExpiringAttElem} */ (attestationValue[0]);
+
+  assert(
+    canExtend(address),
+    `The address ${q(address)} cannot extend the expiration for attestations`,
+  );
+
+  assert(
+    newExpiration > expiration,
+    `The new expiration ${q(
+      newExpiration,
+    )} must be later than the old expiration ${q(expiration)}`,
+  );
+  // Importantly, we cannot drop the uniqueHandle and make a new
+  // one, because that would allow someone to escrow the newly
+  // minted attestation in a contract and the contract would have no
+  // way of knowing it was representing the same value as before,
+  // allowing the user to misrepresent the liened amount as larger
+  // then it actually is.
+  const newAttestationElem = makeAttestationElem(
+    address,
+    amountLiened,
+    newExpiration,
+    handle,
+  );
+  const amountToMint = AmountMath.make(attestationBrand, [newAttestationElem]);
+
+  // commit point within updateLien
+  updateLienedAmounts(newAttestationElem);
+  zcfMint.burnLosses(seat.getCurrentAllocation(), seat);
+  zcfMint.mintGains({ Attestation: amountToMint }, seat);
+  seat.exit();
+};
+harden(extendExpiration);
+export { extendExpiration };

--- a/packages/zoe/src/contracts/attestation/expiring/extendExpiration.js
+++ b/packages/zoe/src/contracts/attestation/expiring/extendExpiration.js
@@ -5,7 +5,7 @@ import { checkOfferShape } from '../helpers';
 
 import { makeAttestationElem } from './expiringHelpers';
 
-const { details: X, quote: q } = assert;
+const { details: X } = assert;
 
 /**
  * A user makes a proposal with a `give` of { Attestation:
@@ -48,14 +48,12 @@ const extendExpiration = (
 
   assert(
     canExtend(address),
-    `The address ${q(address)} cannot extend the expiration for attestations`,
+    `The address '${address}' cannot extend the expiration for attestations`,
   );
 
   assert(
     newExpiration > expiration,
-    `The new expiration ${q(
-      newExpiration,
-    )} must be later than the old expiration ${q(expiration)}`,
+    `The new expiration '${newExpiration}' must be later than the old expiration '${expiration}'`,
   );
   // Importantly, we cannot drop the uniqueHandle and make a new
   // one, because that would allow someone to escrow the newly

--- a/packages/zoe/src/contracts/attestation/expiring/extendExpiration.js
+++ b/packages/zoe/src/contracts/attestation/expiring/extendExpiration.js
@@ -16,7 +16,7 @@ const { details: X } = assert;
  * @param {ZCFSeat} seat
  * @param {ZCFMint} zcfMint
  * @param {(address: Address) => boolean} canExtend
- * @param {(newAttestationElem: ExpiringAttElem) => void} updateLienedAmounts
+ * @param {(newAttestationElem: ExpiringAttElem) => void} updateLienedAmount
  * @param {Brand} attestationBrand
  * @param {Timestamp} newExpiration
  * @returns {void}
@@ -25,7 +25,7 @@ const extendExpiration = (
   seat,
   zcfMint,
   canExtend,
-  updateLienedAmounts,
+  updateLienedAmount,
   attestationBrand,
   newExpiration,
 ) => {
@@ -70,8 +70,8 @@ const extendExpiration = (
 
   const amountToMint = AmountMath.make(attestationBrand, valueToMint);
 
-  // commit point within updateLienedAmounts
-  valueToMint.forEach(updateLienedAmounts);
+  // commit point within updateLienedAmount
+  valueToMint.forEach(updateLienedAmount);
   zcfMint.burnLosses(seat.getCurrentAllocation(), seat);
   zcfMint.mintGains({ Attestation: amountToMint }, seat);
   seat.exit();

--- a/packages/zoe/src/contracts/attestation/expiring/extendExpiration.js
+++ b/packages/zoe/src/contracts/attestation/expiring/extendExpiration.js
@@ -33,44 +33,45 @@ const extendExpiration = (
 
   const attestationValue = /** @type {SetValue} */ (oldAttestationAmount.value);
 
-  // TODO: allow for multiple elements in the amount value to each
-  // be extended. Currently, we restrict the value to a single element.
-  assert(
-    attestationValue.length === 1,
-    X`We can currently only extend a single attestation element at a time, not ${attestationValue}`,
-  );
-  const {
-    expiration,
-    handle,
-    address,
-    amountLiened,
-  } = /** @type {ExpiringAttElem} */ (attestationValue[0]);
+  const makeNewAttestationElem = oldAttestationElem => {
+    const {
+      expiration,
+      handle,
+      address,
+      amountLiened,
+    } = /** @type {ExpiringAttElem} */ oldAttestationElem;
 
-  assert(
-    canExtend(address),
-    `The address '${address}' cannot extend the expiration for attestations`,
-  );
+    assert(
+      canExtend(address),
+      X`The address ${address} cannot extend the expiration for attestations`,
+    );
 
-  assert(
-    newExpiration > expiration,
-    `The new expiration '${newExpiration}' must be later than the old expiration '${expiration}'`,
-  );
-  // Importantly, we cannot drop the uniqueHandle and make a new
-  // one, because that would allow someone to escrow the newly
-  // minted attestation in a contract and the contract would have no
-  // way of knowing it was representing the same value as before,
-  // allowing the user to misrepresent the liened amount as larger
-  // then it actually is.
-  const newAttestationElem = makeAttestationElem(
-    address,
-    amountLiened,
-    newExpiration,
-    handle,
-  );
-  const amountToMint = AmountMath.make(attestationBrand, [newAttestationElem]);
+    assert(
+      newExpiration > expiration,
+      X`The new expiration ${newExpiration} must be later than the old expiration ${expiration}`,
+    );
+    // Importantly, we cannot drop the uniqueHandle and make a new
+    // one, because that would allow someone to escrow the newly
+    // minted attestation in a contract and the contract would have no
+    // way of knowing it was representing the same value as before,
+    // allowing the user to misrepresent the liened amount as larger
+    // then it actually is.
+    const newAttestationElem = makeAttestationElem(
+      address,
+      amountLiened,
+      newExpiration,
+      handle,
+    );
 
-  // commit point within updateLien
-  updateLienedAmounts(newAttestationElem);
+    return newAttestationElem;
+  };
+
+  const valueToMint = attestationValue.map(makeNewAttestationElem);
+
+  const amountToMint = AmountMath.make(attestationBrand, valueToMint);
+
+  // commit point within updateLienedAmounts
+  valueToMint.forEach(updateLienedAmounts);
   zcfMint.burnLosses(seat.getCurrentAllocation(), seat);
   zcfMint.mintGains({ Attestation: amountToMint }, seat);
   seat.exit();

--- a/packages/zoe/src/contracts/attestation/expiring/unlienExpiredAmounts.js
+++ b/packages/zoe/src/contracts/attestation/expiring/unlienExpiredAmounts.js
@@ -14,8 +14,6 @@ import { hasExpired } from './expiringHelpers';
  * @returns {Amount} amountLiened
  */
 const unlienExpiredAmounts = (store, empty, address, currentTime) => {
-  let totalStillLiened = empty;
-
   // It is possible that the address does not currently have any
   // lienedAmounts
   if (!store.has(address)) {
@@ -23,13 +21,16 @@ const unlienExpiredAmounts = (store, empty, address, currentTime) => {
   }
 
   const lienedAtStart = store.get(address);
-  const notExpired = lienedAtStart.filter(({ amountLiened, expiration }) => {
+  const notExpired = lienedAtStart.filter(({ expiration }) => {
     if (hasExpired(expiration, currentTime)) {
       return false;
     }
-    totalStillLiened = AmountMath.add(totalStillLiened, amountLiened);
     return true;
   });
+  const totalStillLiened = notExpired.reduce(
+    (soFar, { amountLiened }) => AmountMath.add(soFar, amountLiened),
+    empty,
+  );
   // commit point
 
   store.set(address, notExpired);

--- a/packages/zoe/src/contracts/attestation/expiring/unlienExpiredAmounts.js
+++ b/packages/zoe/src/contracts/attestation/expiring/unlienExpiredAmounts.js
@@ -13,7 +13,7 @@ import { hasExpired } from './expiringHelpers';
  * @param {Timestamp} currentTime
  * @returns {Amount} amountLiened
  */
-const unlienIfExpired = (store, empty, address, currentTime) => {
+const unlienExpiredAmounts = (store, empty, address, currentTime) => {
   let totalStillLiened = empty;
 
   // It is possible that the address does not currently have any
@@ -35,5 +35,5 @@ const unlienIfExpired = (store, empty, address, currentTime) => {
   store.set(address, notExpired);
   return totalStillLiened;
 };
-harden(unlienIfExpired);
-export { unlienIfExpired };
+harden(unlienExpiredAmounts);
+export { unlienExpiredAmounts };

--- a/packages/zoe/src/contracts/attestation/expiring/unlienExpiredAmounts.js
+++ b/packages/zoe/src/contracts/attestation/expiring/unlienExpiredAmounts.js
@@ -21,12 +21,9 @@ const unlienExpiredAmounts = (store, empty, address, currentTime) => {
   }
 
   const lienedAtStart = store.get(address);
-  const notExpired = lienedAtStart.filter(({ expiration }) => {
-    if (hasExpired(expiration, currentTime)) {
-      return false;
-    }
-    return true;
-  });
+  const notExpired = lienedAtStart.filter(
+    ({ expiration }) => !hasExpired(expiration, currentTime),
+  );
   const totalStillLiened = notExpired.reduce(
     (soFar, { amountLiened }) => AmountMath.add(soFar, amountLiened),
     empty,

--- a/packages/zoe/src/contracts/attestation/expiring/unlienIfExpired.js
+++ b/packages/zoe/src/contracts/attestation/expiring/unlienIfExpired.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { AmountMath } from '@agoric/ertp';
 import { hasExpired } from './expiringHelpers';
 

--- a/packages/zoe/src/contracts/attestation/expiring/unlienIfExpired.js
+++ b/packages/zoe/src/contracts/attestation/expiring/unlienIfExpired.js
@@ -1,0 +1,37 @@
+import { AmountMath } from '@agoric/ertp';
+import { hasExpired } from './expiringHelpers';
+
+/**
+ * Look at the amounts liened and their expiration and unlien anything
+ * that is expired.
+ *
+ * @param {Store<Address,Array<ExpiringAttElem>>} store
+ * @param {Amount} empty - an empty amount of the externalBrand
+ * @param {Address} address
+ * @param {Timestamp} currentTime
+ * @returns {Amount} amountLiened
+ */
+const unlienIfExpired = (store, empty, address, currentTime) => {
+  let totalStillLiened = empty;
+
+  // It is possible that the address does not currently have any
+  // lienedAmounts
+  if (!store.has(address)) {
+    return empty;
+  }
+
+  const lienedAtStart = store.get(address);
+  const notExpired = lienedAtStart.filter(({ amountLiened, expiration }) => {
+    if (hasExpired(expiration, currentTime)) {
+      return false;
+    }
+    totalStillLiened = AmountMath.add(totalStillLiened, amountLiened);
+    return true;
+  });
+  // commit point
+
+  store.set(address, notExpired);
+  return totalStillLiened;
+};
+harden(unlienIfExpired);
+export { unlienIfExpired };

--- a/packages/zoe/src/contracts/attestation/expiring/updateLien.js
+++ b/packages/zoe/src/contracts/attestation/expiring/updateLien.js
@@ -3,6 +3,8 @@
 // TODO: make more efficient. This will slow as the number of
 // ExpiringAttElem per address increases.
 
+const { details: X } = assert;
+
 /**
  * A helper to actually update the lien record when a lien expiration
  * is extended.
@@ -15,7 +17,7 @@ const updateLien = (store, newAttestationElem) => {
   const { address, handle } = newAttestationElem;
   assert(
     store.has(address),
-    `No previous lien was found for address '${address}'`,
+    X`No previous lien was found for address ${address}`,
   );
   const lienedSoFar = store.get(address);
   let foundOldRecord;
@@ -31,10 +33,20 @@ const updateLien = (store, newAttestationElem) => {
 
   assert(
     foundOldRecord,
-    `No previous lien was found for address '${address}' and attestation '${newAttestationElem}'`,
+    X`No previous lien was found for address ${address} and attestation ${newAttestationElem}`,
   );
 
   minusOldRecord.push(newAttestationElem);
+
+  // Ensure that the handles for this address remain unique. Note that
+  // handles are unique in the entire store due to their construction
+  // using `makeHandle`. This assertion guarantees that the invariant
+  // remains even after updating a lien.
+  const handles = new Set();
+  minusOldRecord.forEach(({ handle: attHandle }) => {
+    assert(!handles.has(attHandle), X`Attestation handles must be unique`);
+    handles.add(attHandle);
+  });
 
   // commit point
   store.set(address, minusOldRecord);

--- a/packages/zoe/src/contracts/attestation/expiring/updateLien.js
+++ b/packages/zoe/src/contracts/attestation/expiring/updateLien.js
@@ -3,8 +3,6 @@
 // TODO: make more efficient. This will slow as the number of
 // ExpiringAttElem per address increases.
 
-const { quote: q } = assert;
-
 /**
  * A helper to actually update the lien record when a lien expiration
  * is extended.
@@ -17,7 +15,7 @@ const updateLien = (store, newAttestationElem) => {
   const { address, handle } = newAttestationElem;
   assert(
     store.has(address),
-    `No previous lien was found for address ${q(address)}`,
+    `No previous lien was found for address '${address}'`,
   );
   const lienedSoFar = store.get(address);
   let foundOldRecord;
@@ -33,9 +31,7 @@ const updateLien = (store, newAttestationElem) => {
 
   assert(
     foundOldRecord,
-    `No previous lien was found for address ${q(address)} and attestation ${q(
-      newAttestationElem,
-    )}`,
+    `No previous lien was found for address '${address}' and attestation '${newAttestationElem}'`,
   );
 
   minusOldRecord.push(newAttestationElem);

--- a/packages/zoe/src/contracts/attestation/expiring/updateLien.js
+++ b/packages/zoe/src/contracts/attestation/expiring/updateLien.js
@@ -1,0 +1,47 @@
+// @ts-check
+
+// TODO: make more efficient. This will slow as the number of
+// ExpiringAttElem per address increases.
+
+const { quote: q } = assert;
+
+/**
+ * A helper to actually update the lien record when a lien expiration
+ * is extended.
+ *
+ * @param {Store<Address,Array<ExpiringAttElem>>} store
+ * @param {ExpiringAttElem} newAttestationElem
+ * @returns {void}
+ */
+const updateLien = (store, newAttestationElem) => {
+  const { address, handle } = newAttestationElem;
+  assert(
+    store.has(address),
+    `No previous lien was found for address ${q(address)}`,
+  );
+  const lienedSoFar = store.get(address);
+  let foundOldRecord;
+  // find and remove the old record
+  const minusOldRecord = lienedSoFar.filter(({ handle: oldRecordHandle }) => {
+    if (oldRecordHandle === handle) {
+      foundOldRecord = true;
+      return false;
+    } else {
+      return true;
+    }
+  });
+
+  assert(
+    foundOldRecord,
+    `No previous lien was found for address ${q(address)} and attestation ${q(
+      newAttestationElem,
+    )}`,
+  );
+
+  minusOldRecord.push(newAttestationElem);
+
+  // commit point
+  store.set(address, minusOldRecord);
+};
+harden(updateLien);
+export { updateLien };

--- a/packages/zoe/src/contracts/attestation/helpers.js
+++ b/packages/zoe/src/contracts/attestation/helpers.js
@@ -5,6 +5,8 @@ import { E } from '@agoric/eventual-send';
 
 import { assertProposalShape } from '../../contractSupport';
 
+const { details: X } = assert;
+
 /**
  * Validate that the address is a string and that the amount is a
  * valid Amount of the right brand. Coerce the amount and return it.
@@ -45,7 +47,7 @@ const checkOfferShape = (seat, attestationBrand) => {
   const attestationAmount = seat.getAmountAllocated('Attestation');
   assert(
     attestationAmount.brand === attestationBrand,
-    `The escrowed attestation ${attestationAmount} was not of the attestation brand${attestationBrand}`,
+    X`The escrowed attestation ${attestationAmount} was not of the attestation brand${attestationBrand}`,
   );
   return attestationAmount;
 };

--- a/packages/zoe/src/contracts/attestation/helpers.js
+++ b/packages/zoe/src/contracts/attestation/helpers.js
@@ -1,0 +1,76 @@
+// @ts-check
+
+import { AmountMath } from '@agoric/ertp';
+import { E } from '@agoric/eventual-send';
+
+import { assertProposalShape } from '../../contractSupport';
+
+/**
+ * Validate that the address is a string and that the amount is a
+ * valid Amount of the right brand. Coerce the amount and return it.
+ *
+ * @param {Brand} externalBrand
+ * @param {Address} address
+ * @param {Amount} amount
+ * @returns {Amount}
+ */
+const validateInputs = (externalBrand, address, amount) => {
+  assert.typeof(address, 'string');
+  // Will throw if amount is invalid
+  return AmountMath.coerce(externalBrand, amount);
+};
+harden(validateInputs);
+
+/**
+ * @param {ContractFacet} zcf
+ * @param {ZCFMint} zcfMint
+ * @param {Amount} amountToMint
+ * @returns {Promise<Payment>}
+ */
+const mintZCFMintPayment = (zcf, zcfMint, amountToMint) => {
+  const { userSeat, zcfSeat } = zcf.makeEmptySeatKit();
+  zcfMint.mintGains({ Attestation: amountToMint }, zcfSeat);
+  zcfSeat.exit();
+  return E(userSeat).getPayout('Attestation');
+};
+harden(mintZCFMintPayment);
+
+/**
+ * @param {ZCFSeat} seat
+ * @param {Brand} attestationBrand
+ * @returns {Amount}
+ */
+const checkOfferShape = (seat, attestationBrand) => {
+  assertProposalShape(seat, { give: { Attestation: null }, want: {} });
+  const attestationAmount = seat.getAmountAllocated('Attestation');
+  assert(
+    attestationAmount.brand === attestationBrand,
+    `The escrowed attestation ${attestationAmount} was not of the attestation brand${attestationBrand}`,
+  );
+  return attestationAmount;
+};
+harden(checkOfferShape);
+
+/** @type {Max} */
+const max = (x, y) => {
+  return AmountMath.isGTE(x, y) ? x : y;
+};
+harden(max);
+
+// If x is greater than or equal to y, subtract. If not, return empty.
+const subtractOrMakeEmpty = (x, y) => {
+  if (AmountMath.isGTE(x, y)) {
+    return AmountMath.subtract(x, y);
+  } else {
+    return AmountMath.makeEmptyFromAmount(x);
+  }
+};
+harden(subtractOrMakeEmpty);
+
+export {
+  validateInputs,
+  mintZCFMintPayment,
+  checkOfferShape,
+  max,
+  subtractOrMakeEmpty,
+};

--- a/packages/zoe/src/contracts/attestation/prerequisites.js
+++ b/packages/zoe/src/contracts/attestation/prerequisites.js
@@ -1,0 +1,93 @@
+// @ts-check
+
+import { AmountMath } from '@agoric/ertp';
+import { E } from '@agoric/eventual-send';
+
+import { subtractOrMakeEmpty } from './helpers';
+
+const { details: X, quote: q } = assert;
+
+// TODO: Make the attestation contract more generic by allowing this
+// to be parameterized
+
+/**
+ * Assert the cosmos-specific prerequisites
+ *
+ * @param {{getAccountState: (address: Address) => {total: Amount, bonded: Amount, locked: Amount,
+ * currentTime: Timestamp}}} cosmos
+ * @param {GetLienAmount} getLienAmount
+ * @param {Brand} underlyingBrand
+ * @param {Address} address
+ * @param {Amount} amountToLien
+ * @param {Timestamp} expiration
+ */
+const assertPrerequisites = async (
+  cosmos,
+  getLienAmount,
+  underlyingBrand,
+  address,
+  amountToLien,
+  expiration,
+) => {
+  const accountState = await E(cosmos).getAccountState(address);
+  // AWAIT ///
+
+  let { total, bonded, locked } = accountState;
+  const { currentTime } = accountState;
+  assert.typeof(currentTime, 'bigint');
+  assert(
+    expiration > currentTime,
+    `Expiration ${q(expiration)} must be after the current time ${q(
+      currentTime,
+    )}`,
+  );
+
+  total = AmountMath.coerce(underlyingBrand, total);
+  bonded = AmountMath.coerce(underlyingBrand, bonded);
+  locked = AmountMath.coerce(underlyingBrand, locked);
+
+  // The amount for the address that currently has attestations that
+  // create a lien.
+
+  // NOTE: the total (and other values in the accountState) may
+  // be less than the amount liened, due to slashing affecting the
+  // cosmos balances but not affecting the amount liened.
+  const liened = getLienAmount(address, currentTime);
+
+  const unliened = subtractOrMakeEmpty(total, liened);
+  const bondedAndUnliened = subtractOrMakeEmpty(bonded, liened);
+  const unlocked = subtractOrMakeEmpty(total, locked);
+  const unlockedAndUnliened = subtractOrMakeEmpty(unlocked, liened);
+
+  // Prerequisite: x <= Unliened
+  assert(
+    AmountMath.isGTE(unliened, amountToLien),
+    X`Only ${q(
+      unliened,
+    )} was unliened, but an attestation was attempted for ${q(amountToLien)}`,
+  );
+
+  // Prerequisite: x <= Bonded - Liened
+  assert(
+    AmountMath.isGTE(bondedAndUnliened, amountToLien),
+    X`Only ${q(
+      bondedAndUnliened,
+    )} was bonded and unliened, but an attestation was attempted for ${q(
+      amountToLien,
+    )}`,
+  );
+
+  // Prerequisite: x <= Unlocked - Liened
+  assert(
+    AmountMath.isGTE(unlockedAndUnliened, amountToLien),
+    X`Only ${q(
+      unlockedAndUnliened,
+    )} was unlocked and unliened, but an attestation was attempted for ${q(
+      amountToLien,
+    )}`,
+  );
+
+  return currentTime;
+};
+harden(assertPrerequisites);
+export { assertPrerequisites };

--- a/packages/zoe/src/contracts/attestation/prerequisites.js
+++ b/packages/zoe/src/contracts/attestation/prerequisites.js
@@ -15,6 +15,7 @@ const { details: X } = assert;
  *
  * @param {ERef<{getAccountState: (address: Address, brand: Brand) => {total: Amount, bonded: Amount, locked: Amount,
  * currentTime: Timestamp}}>} stakeReporter
+ * @param {StoredTime} storedTime
  * @param {GetLiened} getLiened
  * @param {Brand} underlyingBrand
  * @param {Address} address
@@ -23,6 +24,7 @@ const { details: X } = assert;
  */
 const assertPrerequisites = async (
   stakeReporter,
+  storedTime,
   getLiened,
   underlyingBrand,
   address,
@@ -38,6 +40,7 @@ const assertPrerequisites = async (
   let { total, bonded, locked } = accountState;
   const { currentTime } = accountState;
   assert.typeof(currentTime, 'bigint');
+  storedTime.updateTime(currentTime);
   assert(
     expiration > currentTime,
     X`Expiration ${expiration} must be after the current time ${currentTime}`,

--- a/packages/zoe/src/contracts/attestation/prerequisites.js
+++ b/packages/zoe/src/contracts/attestation/prerequisites.js
@@ -5,7 +5,7 @@ import { E } from '@agoric/eventual-send';
 
 import { subtractOrMakeEmpty } from './helpers';
 
-const { details: X, quote: q } = assert;
+const { details: X } = assert;
 
 // TODO: Make the attestation contract more generic by allowing this
 // to be parameterized
@@ -40,9 +40,7 @@ const assertPrerequisites = async (
   assert.typeof(currentTime, 'bigint');
   assert(
     expiration > currentTime,
-    `Expiration ${q(expiration)} must be after the current time ${q(
-      currentTime,
-    )}`,
+    `Expiration '${expiration}' must be after the current time '${currentTime}'`,
   );
 
   total = AmountMath.coerce(underlyingBrand, total);
@@ -65,29 +63,19 @@ const assertPrerequisites = async (
   // Prerequisite: x <= Unliened
   assert(
     AmountMath.isGTE(unliened, amountToLien),
-    X`Only ${q(
-      unliened,
-    )} was unliened, but an attestation was attempted for ${q(amountToLien)}`,
+    X`Only '${unliened}' was unliened, but an attestation was attempted for '${amountToLien}'`,
   );
 
   // Prerequisite: x <= Bonded - Liened
   assert(
     AmountMath.isGTE(bondedAndUnliened, amountToLien),
-    X`Only ${q(
-      bondedAndUnliened,
-    )} was bonded and unliened, but an attestation was attempted for ${q(
-      amountToLien,
-    )}`,
+    X`Only '${bondedAndUnliened}' was bonded and unliened, but an attestation was attempted for '${amountToLien}'`,
   );
 
   // Prerequisite: x <= Unlocked - Liened
   assert(
     AmountMath.isGTE(unlockedAndUnliened, amountToLien),
-    X`Only ${q(
-      unlockedAndUnliened,
-    )} was unlocked and unliened, but an attestation was attempted for ${q(
-      amountToLien,
-    )}`,
+    X`Only '${unlockedAndUnliened}' was unlocked and unliened, but an attestation was attempted for '${amountToLien}'`,
   );
 
   return currentTime;

--- a/packages/zoe/src/contracts/attestation/prerequisites.js
+++ b/packages/zoe/src/contracts/attestation/prerequisites.js
@@ -40,7 +40,7 @@ const assertPrerequisites = async (
   assert.typeof(currentTime, 'bigint');
   assert(
     expiration > currentTime,
-    `Expiration '${expiration}' must be after the current time '${currentTime}'`,
+    X`Expiration ${expiration} must be after the current time ${currentTime}`,
   );
 
   total = AmountMath.coerce(underlyingBrand, total);
@@ -63,19 +63,19 @@ const assertPrerequisites = async (
   // Prerequisite: x <= Unliened
   assert(
     AmountMath.isGTE(unliened, amountToLien),
-    X`Only '${unliened}' was unliened, but an attestation was attempted for '${amountToLien}'`,
+    X`Only ${unliened} was unliened, but an attestation was attempted for ${amountToLien}`,
   );
 
   // Prerequisite: x <= Bonded - Liened
   assert(
     AmountMath.isGTE(bondedAndUnliened, amountToLien),
-    X`Only '${bondedAndUnliened}' was bonded and unliened, but an attestation was attempted for '${amountToLien}'`,
+    X`Only ${bondedAndUnliened} was bonded and unliened, but an attestation was attempted for ${amountToLien}`,
   );
 
   // Prerequisite: x <= Unlocked - Liened
   assert(
     AmountMath.isGTE(unlockedAndUnliened, amountToLien),
-    X`Only '${unlockedAndUnliened}' was unlocked and unliened, but an attestation was attempted for '${amountToLien}'`,
+    X`Only ${unlockedAndUnliened} was unlocked and unliened, but an attestation was attempted for ${amountToLien}`,
   );
 
   return currentTime;

--- a/packages/zoe/src/contracts/attestation/prerequisites.js
+++ b/packages/zoe/src/contracts/attestation/prerequisites.js
@@ -13,23 +13,26 @@ const { details: X, quote: q } = assert;
 /**
  * Assert the cosmos-specific prerequisites
  *
- * @param {{getAccountState: (address: Address) => {total: Amount, bonded: Amount, locked: Amount,
- * currentTime: Timestamp}}} cosmos
- * @param {GetLienAmount} getLienAmount
+ * @param {{getAccountState: (address: Address, brand: Brand) => {total: Amount, bonded: Amount, locked: Amount,
+ * currentTime: Timestamp}}} stakeReporter
+ * @param {GetLiened} getLiened
  * @param {Brand} underlyingBrand
  * @param {Address} address
  * @param {Amount} amountToLien
  * @param {Timestamp} expiration
  */
 const assertPrerequisites = async (
-  cosmos,
-  getLienAmount,
+  stakeReporter,
+  getLiened,
   underlyingBrand,
   address,
   amountToLien,
   expiration,
 ) => {
-  const accountState = await E(cosmos).getAccountState(address);
+  const accountState = await E(stakeReporter).getAccountState(
+    address,
+    underlyingBrand,
+  );
   // AWAIT ///
 
   let { total, bonded, locked } = accountState;
@@ -52,7 +55,7 @@ const assertPrerequisites = async (
   // NOTE: the total (and other values in the accountState) may
   // be less than the amount liened, due to slashing affecting the
   // cosmos balances but not affecting the amount liened.
-  const liened = getLienAmount(address, currentTime);
+  const liened = getLiened(address, currentTime, underlyingBrand);
 
   const unliened = subtractOrMakeEmpty(total, liened);
   const bondedAndUnliened = subtractOrMakeEmpty(bonded, liened);

--- a/packages/zoe/src/contracts/attestation/prerequisites.js
+++ b/packages/zoe/src/contracts/attestation/prerequisites.js
@@ -13,8 +13,8 @@ const { details: X, quote: q } = assert;
 /**
  * Assert the cosmos-specific prerequisites
  *
- * @param {{getAccountState: (address: Address, brand: Brand) => {total: Amount, bonded: Amount, locked: Amount,
- * currentTime: Timestamp}}} stakeReporter
+ * @param {ERef<{getAccountState: (address: Address, brand: Brand) => {total: Amount, bonded: Amount, locked: Amount,
+ * currentTime: Timestamp}}>} stakeReporter
  * @param {GetLiened} getLiened
  * @param {Brand} underlyingBrand
  * @param {Address} address

--- a/packages/zoe/src/contracts/attestation/returnable/returnableHelpers.js
+++ b/packages/zoe/src/contracts/attestation/returnable/returnableHelpers.js
@@ -1,0 +1,21 @@
+// @ts-check
+
+import { AmountMath } from '@agoric/ertp';
+
+/**
+ * Add a lien to an amount for an address.
+ *
+ * @param {Store<Address,Amount>} store
+ * @param {Address} address
+ * @param {Amount} amountToLien
+ */
+const addToLiened = (store, address, amountToLien) => {
+  if (store.has(address)) {
+    const updated = AmountMath.add(store.get(address), amountToLien);
+    store.set(address, updated);
+  } else {
+    store.init(address, amountToLien);
+  }
+};
+harden(addToLiened);
+export { addToLiened };

--- a/packages/zoe/src/contracts/attestation/returnable/returnableNFT.js
+++ b/packages/zoe/src/contracts/attestation/returnable/returnableNFT.js
@@ -37,6 +37,12 @@ const setupAttestation = async (attestationTokenName, empty, zcf) => {
   /** @type {Store<Address,Amount>} */
   const lienedAmounts = makeStore('address');
 
+  // IMPORTANT: only expose this function to the owner of the address.
+  // This request *must* come from the owner of the address. Merely
+  // verifying that the address *could* add a lien is not sufficient.
+  // The owner must consent to adding a lien, and non-owners must not
+  // be able to initiate a lien for another account.
+
   /** @type {AddReturnableLien} */
   const addReturnableLien = (address, amount) => {
     const amountToLien = validateInputs(externalBrand, address, amount);

--- a/packages/zoe/src/contracts/attestation/returnable/returnableNFT.js
+++ b/packages/zoe/src/contracts/attestation/returnable/returnableNFT.js
@@ -1,0 +1,116 @@
+// @ts-check
+
+import { makeStore } from '@agoric/store';
+import { AmountMath, AssetKind } from '@agoric/ertp';
+
+import {
+  mintZCFMintPayment,
+  validateInputs,
+  checkOfferShape,
+} from '../helpers';
+import { addToLiened } from './returnableHelpers';
+
+const { details: X, quote: q } = assert;
+
+/**
+ * @param {string} attestationTokenName - the name for the attestation
+ * token
+ * @param {Amount} empty
+ * @param {ContractFacet} zcf
+ * @returns {Promise<{makeReturnAttInvitation:
+ * MakeReturnAttInvitation, addReturnableLien: AddReturnableLien,
+ * getLienAmount: GetReturnableLienAmount, issuer: Issuer, brand: Brand}>}
+ */
+const setupAttestation = async (attestationTokenName, empty, zcf) => {
+  assert(AmountMath.isEmpty(empty), `empty ${q(empty)} was not empty`);
+  const zcfMint = await zcf.makeZCFMint(attestationTokenName, AssetKind.SET);
+  const {
+    brand: attestationBrand,
+    issuer: attestationIssuer,
+  } = zcfMint.getIssuerRecord();
+
+  const { brand: externalBrand } = empty;
+
+  // Amount in `lienedAmounts` is of the brand `externalBrand`
+
+  /** @type {Store<Address,Amount>} */
+  const lienedAmounts = makeStore('address');
+
+  /** @type {AddReturnableLien} */
+  const addReturnableLien = (address, amount) => {
+    const amountToLien = validateInputs(externalBrand, address, amount);
+
+    addToLiened(lienedAmounts, address, amountToLien);
+    const amountToMint = AmountMath.make(attestationBrand, [
+      /** @type {ReturnableAttElem} */ ({
+        address,
+        amountLiened: amountToLien,
+      }),
+    ]);
+
+    return mintZCFMintPayment(zcf, zcfMint, amountToMint);
+  };
+
+  /** @type {ReturnAttestation} */
+  const returnAttestation = seat => {
+    const attestationAmount = checkOfferShape(seat, attestationBrand);
+
+    // Burn the escrowed attestation payment and exit the seat
+    zcfMint.burnLosses({ Attestation: attestationAmount }, seat);
+    seat.exit();
+
+    const attestationValue =
+      /** @type {Array<ReturnableAttElem>} */ (attestationAmount.value);
+
+    attestationValue.forEach(({ address, amountLiened: amountReturned }) => {
+      assert(
+        lienedAmounts.has(address),
+        X`We have no record of anything liened for address ${q(address)}`,
+      );
+      // No need to validate the address and amountLiened because we
+      // get the address and the amountLiened from the escrowed
+      // amount, which Zoe verifies is from a real attestation payment
+      const liened = lienedAmounts.get(address);
+      // This assertion should always be true.
+      // TODO: Escalate appropriately, such as shutting down the vat
+      // if false.
+      assert(
+        AmountMath.isGTE(liened, amountReturned),
+        X`The returned amount ${q(
+          amountReturned,
+        )} was greater than the amount liened ${q(
+          liened,
+        )}. Something very wrong occurred.`,
+      );
+      const updated = AmountMath.subtract(liened, amountReturned);
+      lienedAmounts.set(address, updated);
+    });
+  };
+
+  /** @type {GetReturnableLienAmount} */
+  const getLienAmount = address => {
+    assert.typeof(address, 'string');
+    if (lienedAmounts.has(address)) {
+      return lienedAmounts.get(address);
+    } else {
+      return empty;
+    }
+  };
+
+  /** @type {MakeReturnAttInvitation} */
+  const makeReturnAttInvitation = () =>
+    zcf.makeInvitation(returnAttestation, 'ReturnAtt', {
+      brand: attestationBrand,
+    });
+
+  return harden({
+    makeReturnAttInvitation,
+    addReturnableLien,
+    getLienAmount,
+    issuer: attestationIssuer,
+    brand: attestationBrand,
+  });
+};
+
+harden(setupAttestation);
+export { setupAttestation };

--- a/packages/zoe/src/contracts/attestation/returnable/returnableNFT.js
+++ b/packages/zoe/src/contracts/attestation/returnable/returnableNFT.js
@@ -23,7 +23,7 @@ const { details: X } = assert;
  * getBrand: () => Brand}>}
  */
 const setupAttestation = async (attestationTokenName, empty, zcf) => {
-  assert(AmountMath.isEmpty(empty), `empty '${empty}' was not empty`);
+  assert(AmountMath.isEmpty(empty), X`empty ${empty} was not empty`);
   const zcfMint = await zcf.makeZCFMint(attestationTokenName, AssetKind.SET);
   const {
     brand: attestationBrand,
@@ -72,7 +72,7 @@ const setupAttestation = async (attestationTokenName, empty, zcf) => {
     attestationValue.forEach(({ address, amountLiened: amountReturned }) => {
       assert(
         lienedAmounts.has(address),
-        X`We have no record of anything liened for address '${address}'`,
+        X`We have no record of anything liened for address ${address}`,
       );
       // No need to validate the address and amountLiened because we
       // get the address and the amountLiened from the escrowed
@@ -83,7 +83,7 @@ const setupAttestation = async (attestationTokenName, empty, zcf) => {
       // if false.
       assert(
         AmountMath.isGTE(liened, amountReturned),
-        X`The returned amount '${amountReturned}' was greater than the amount liened '${liened}'. Something very wrong occurred.`,
+        X`The returned amount ${amountReturned} was greater than the amount liened ${liened}. Something very wrong occurred.`,
       );
       const updated = AmountMath.subtract(liened, amountReturned);
       lienedAmounts.set(address, updated);

--- a/packages/zoe/src/contracts/attestation/returnable/returnableNFT.js
+++ b/packages/zoe/src/contracts/attestation/returnable/returnableNFT.js
@@ -10,7 +10,7 @@ import {
 } from '../helpers';
 import { addToLiened } from './returnableHelpers';
 
-const { details: X, quote: q } = assert;
+const { details: X } = assert;
 
 /**
  * @param {string} attestationTokenName - the name for the attestation
@@ -23,7 +23,7 @@ const { details: X, quote: q } = assert;
  * getBrand: () => Brand}>}
  */
 const setupAttestation = async (attestationTokenName, empty, zcf) => {
-  assert(AmountMath.isEmpty(empty), `empty ${q(empty)} was not empty`);
+  assert(AmountMath.isEmpty(empty), `empty '${empty}' was not empty`);
   const zcfMint = await zcf.makeZCFMint(attestationTokenName, AssetKind.SET);
   const {
     brand: attestationBrand,
@@ -66,7 +66,7 @@ const setupAttestation = async (attestationTokenName, empty, zcf) => {
     attestationValue.forEach(({ address, amountLiened: amountReturned }) => {
       assert(
         lienedAmounts.has(address),
-        X`We have no record of anything liened for address ${q(address)}`,
+        X`We have no record of anything liened for address '${address}'`,
       );
       // No need to validate the address and amountLiened because we
       // get the address and the amountLiened from the escrowed
@@ -77,11 +77,7 @@ const setupAttestation = async (attestationTokenName, empty, zcf) => {
       // if false.
       assert(
         AmountMath.isGTE(liened, amountReturned),
-        X`The returned amount ${q(
-          amountReturned,
-        )} was greater than the amount liened ${q(
-          liened,
-        )}. Something very wrong occurred.`,
+        X`The returned amount '${amountReturned}' was greater than the amount liened '${liened}'. Something very wrong occurred.`,
       );
       const updated = AmountMath.subtract(liened, amountReturned);
       lienedAmounts.set(address, updated);

--- a/packages/zoe/src/contracts/attestation/returnable/returnableNFT.js
+++ b/packages/zoe/src/contracts/attestation/returnable/returnableNFT.js
@@ -19,7 +19,8 @@ const { details: X, quote: q } = assert;
  * @param {ContractFacet} zcf
  * @returns {Promise<{makeReturnAttInvitation:
  * MakeReturnAttInvitation, addReturnableLien: AddReturnableLien,
- * getLienAmount: GetReturnableLienAmount, issuer: Issuer, brand: Brand}>}
+ * getLienAmount: GetReturnableLienAmount, getIssuer: () => Issuer,
+ * getBrand: () => Brand}>}
  */
 const setupAttestation = async (attestationTokenName, empty, zcf) => {
   assert(AmountMath.isEmpty(empty), `empty ${q(empty)} was not empty`);
@@ -107,8 +108,8 @@ const setupAttestation = async (attestationTokenName, empty, zcf) => {
     makeReturnAttInvitation,
     addReturnableLien,
     getLienAmount,
-    issuer: attestationIssuer,
-    brand: attestationBrand,
+    getIssuer: () => attestationIssuer,
+    getBrand: () => attestationBrand,
   });
 };
 

--- a/packages/zoe/src/contracts/attestation/storedTime.js
+++ b/packages/zoe/src/contracts/attestation/storedTime.js
@@ -12,6 +12,7 @@ const makeStoredTime = () => {
   const getTime = () => storedTime;
 
   const updateTime = currentTime => {
+    assert.typeof(currentTime, 'bigint');
     assert(
       currentTime >= storedTime,
       X`The currentTime ${q(

--- a/packages/zoe/src/contracts/attestation/storedTime.js
+++ b/packages/zoe/src/contracts/attestation/storedTime.js
@@ -1,7 +1,5 @@
 // @ts-check
 
-const { details: X, quote: q } = assert;
-
 /**
  * @returns {{getTime: () => Timestamp, updateTime: (currentTime:
  * Timestamp) => void}}
@@ -13,15 +11,9 @@ const makeStoredTime = () => {
 
   const updateTime = currentTime => {
     assert.typeof(currentTime, 'bigint');
-    assert(
-      currentTime >= storedTime,
-      X`The currentTime ${q(
-        currentTime,
-      )} must be greater than or equal to the last recorded time ${q(
-        storedTime,
-      )}`,
-    );
-    storedTime = currentTime;
+    if (currentTime > storedTime) {
+      storedTime = currentTime;
+    }
   };
 
   return harden({

--- a/packages/zoe/src/contracts/attestation/storedTime.js
+++ b/packages/zoe/src/contracts/attestation/storedTime.js
@@ -1,8 +1,7 @@
 // @ts-check
 
 /**
- * @returns {{getTime: () => Timestamp, updateTime: (currentTime:
- * Timestamp) => void}}
+ * @returns {StoredTime}
  */
 const makeStoredTime = () => {
   let storedTime = 0n;

--- a/packages/zoe/src/contracts/attestation/storedTime.js
+++ b/packages/zoe/src/contracts/attestation/storedTime.js
@@ -1,0 +1,32 @@
+// @ts-check
+
+const { details: X, quote: q } = assert;
+
+/**
+ * @returns {{getTime: () => Timestamp, updateTime: (currentTime:
+ * Timestamp) => void}}
+ */
+const makeStoredTime = () => {
+  let storedTime = 0n;
+
+  const getTime = () => storedTime;
+
+  const updateTime = currentTime => {
+    assert(
+      currentTime >= storedTime,
+      X`The currentTime ${q(
+        currentTime,
+      )} must be greater than or equal to the last recorded time ${q(
+        storedTime,
+      )}`,
+    );
+    storedTime = currentTime;
+  };
+
+  return harden({
+    getTime,
+    updateTime,
+  });
+};
+harden(makeStoredTime);
+export { makeStoredTime };

--- a/packages/zoe/src/contracts/attestation/types.js
+++ b/packages/zoe/src/contracts/attestation/types.js
@@ -1,0 +1,182 @@
+/**
+ * @typedef {string} Address
+ */
+
+/**
+ * @callback GetAttMaker
+ * @param {Address} address
+ * @returns {AttMaker}
+ */
+
+/**
+ * @typedef {Object} AttestationPair
+ * @property {Promise<Payment>} expiring
+ * @property {Promise<Payment>} returnable
+ */
+
+/**
+ * @typedef AttMaker
+ * @property {(amountToLien: Amount, expiration: Timestamp) => Promise<AttestationPair>} makeAttestations
+ * @property {MakeReturnAttInvitation} makeReturnAttInvitation
+ * @property {MakeExtendAttInvitation} makeExtendAttInvitation
+ */
+
+/**
+ * @callback MakeAttMaker
+ * @param {Address} address
+ * @returns {AttMaker}
+ */
+
+/**
+ * @callback MakeAttestationsInternal
+ * @param {Address} address
+ * @param {Amount} amountToLien
+ * @param {Timestamp} expiration
+ * @returns {Promise<AttestationPair>}
+ */
+
+/**
+ * @callback Max
+ * Return the greater of two Amounts.
+ *
+ * @param {Amount} x
+ * @param {Amount} y
+ * @returns {Amount}
+ */
+
+/**
+ * @callback GetLienAmount
+ *
+ * @param {Address} address
+ * @param {Timestamp} currentTime
+ * @returns {Amount}
+ */
+
+/**
+ * @callback GetReturnableLienAmount
+ *
+ * @param {Address} address
+ * @returns {Amount}
+ */
+
+/**
+ * @callback AddExpiringLien
+ *
+ * Given an address string and an Amount to add a lien on and the
+ * expiration, record that the amount is "liened", and mint an
+ * attestation payment for the amount. Return the payment.
+ *
+ * @param {Address} address
+ * @param {Amount} amount
+ * @param {Timestamp} expiration
+ * @returns {Promise<Payment>}
+ */
+
+/**
+ * @callback AddReturnableLien
+ *
+ * Given an address string and an Amount to put a lien on, record that
+ * the Amount is "liened", and mint an attestation payment for the
+ * amount liened. Return the payment.
+ *
+ * @param {Address} address
+ * @param {Amount} amount
+ * @returns {Promise<Payment>}
+ */
+
+/**
+ * @typedef {Object} ExpiringAttElem
+ * @property {Address} address
+ * @property {Amount} amountLiened
+ * @property {Timestamp} expiration
+ * @property {Handle<'attestation'>} handle
+ */
+
+/**
+ * @typedef {Object} ReturnableAttElem
+ * @property {Address} address
+ * @property {Amount} amountLiened
+ */
+
+/**
+ * @callback ReturnAttestation
+ * @param {ZCFSeat} seat
+ * @returns {void}
+ */
+
+/**
+ * @callback DisallowExtensions
+ * @param {Address} address
+ * @returns {void}
+ */
+
+/**
+ * @callback ExtendExpiration
+ *
+ * Scenario: I have a vote ongoing where I've escrowed a payment and
+ * gotten it back. I would like to participate in a second vote with
+ * the election closing after the expiration of my payment. I want to
+ * extend my payment's expiration to be after the second vote's
+ * closing. I must not be able to trick the first vote into escrowing
+ * my new payment and double-counting my influence.
+ *
+ * Only the owner of the liened tokens is allowed to extend the
+ * expiration. We will use the holder of the original attestation
+ * payment as the measure of this. We can only extend the expiration
+ * if we have not already dropped the lien. Therefore to extend, we
+ * must still have a record of the attestation (with the unique
+ * handle).
+ *
+ * @param {ZCFSeat} seat
+ * @param {Timestamp} newExpiration
+ * @returns {void}
+ */
+
+/**
+ * @callback Slashed
+ *
+ * On slashing, we disallow any extensions. We do not reduce the liens.
+ *
+ * @param {Address} address
+ * @param {Timestamp} currentTime
+ * @returns {void}
+ */
+
+/**
+ * @callback MakeReturnAttInvitation
+ *
+ * Make an invitation for returning a returnable attestation.
+ *
+ * @returns {Promise<Invitation>}
+ */
+
+/**
+ * @callback MakeExtendAttInvitationInternal
+ *
+ * Make an invitation for extending the expiration date of an expiring
+ * attestation. Internal because the currentTime must be passed in,
+ * and that can only come from a trusted source.
+ *
+ * @param {Timestamp} newExpiration
+ * @param {Timestamp} currentTime
+ * @returns {Promise<Invitation>}
+ */
+
+/**
+ * @callback MakeExtendAttInvitation
+ *
+ * Make an invitation for extending the expiration date of an expiring
+ * attestation.
+ *
+ * @param {Timestamp} newExpiration
+ * @returns {Promise<Invitation>}
+ */
+
+/**
+ * @callback GetLiened
+ * Get the amount currently liened per address.
+ *
+ * @param {Array<Address>} addresses
+ * @param {Timestamp} currentTime
+ * @returns {Array<Amount>}
+ */

--- a/packages/zoe/src/contracts/attestation/types.js
+++ b/packages/zoe/src/contracts/attestation/types.js
@@ -181,3 +181,8 @@
  * @param {Brand} brand
  * @returns {Amount}
  */
+
+/**
+ * @typedef {{getTime: () => Timestamp, updateTime: (currentTime:
+ * Timestamp) => void}} StoredTime
+ */

--- a/packages/zoe/src/contracts/attestation/types.js
+++ b/packages/zoe/src/contracts/attestation/types.js
@@ -137,7 +137,7 @@
  *
  * On slashing, we disallow any extensions. We do not reduce the liens.
  *
- * @param {Array<Address>} address
+ * @param {Array<Address>} addresses
  * @param {Timestamp} currentTime
  * @returns {void}
  */
@@ -174,7 +174,7 @@
 
 /**
  * @callback GetLiened
- * Get the amount currently liened per address.
+ * Get the amount currently liened for the address and brand.
  *
  * @param {Address} addresses
  * @param {Timestamp} currentTime

--- a/packages/zoe/src/contracts/attestation/types.js
+++ b/packages/zoe/src/contracts/attestation/types.js
@@ -137,7 +137,7 @@
  *
  * On slashing, we disallow any extensions. We do not reduce the liens.
  *
- * @param {Address} address
+ * @param {Array<Address>} address
  * @param {Timestamp} currentTime
  * @returns {void}
  */
@@ -176,7 +176,8 @@
  * @callback GetLiened
  * Get the amount currently liened per address.
  *
- * @param {Array<Address>} addresses
+ * @param {Address} addresses
  * @param {Timestamp} currentTime
- * @returns {Array<Amount>}
+ * @param {Brand} brand
+ * @returns {Amount}
  */

--- a/packages/zoe/test/unitTests/contracts/attestation/exampleLoanUsage.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/exampleLoanUsage.js
@@ -3,7 +3,7 @@
 /**
  * ** Create loan:
  *
- * requires an NFT attestation of brand BLD-ATT-LOC, and the amount of
+ * requires an NFT attestation of brand BldAttLoc, and the amount of
  * RUN that can be loaned is about 10% of the value of BLD represented
  * in the attestation value: amount.value[0].value. (We should allow
  * for multiple elements in the value array, not just one, so we need
@@ -11,7 +11,7 @@
  *
  * ** Add more collateral:
  *
- * Escrow more attestations of brand BLD-ATT-LOC. Contract must add
+ * Escrow more attestations of brand BldAttLoc. Contract must add
  * the internal BLD values (amount.value[0].value) together to get a
  * total sum of liened BLD.
  *

--- a/packages/zoe/test/unitTests/contracts/attestation/exampleLoanUsage.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/exampleLoanUsage.js
@@ -1,0 +1,48 @@
+// @ts-check
+
+/**
+ * ** Create loan:
+ *
+ * requires an NFT attestation of brand BLD-ATT-LOC, and the amount of
+ * RUN that can be loaned is about 10% of the value of BLD represented
+ * in the attestation value: amount.value[0].value. (We should allow
+ * for multiple elements in the value array, not just one, so we need
+ * to iterate through amount.value)
+ *
+ * ** Add more collateral:
+ *
+ * Escrow more attestations of brand BLD-ATT-LOC. Contract must add
+ * the internal BLD values (amount.value[0].value) together to get a
+ * total sum of liened BLD.
+ *
+ * ** Withdraw more RUN:
+ *
+ * Only allowed if more collateral has been added (see above) or the
+ * market value of the collateral has risen.
+ *
+ * ** Withdraw a partial amount of BLD attestation:
+ *
+ * Must have returned some RUN, or the market value of collateral has
+ * risen. Contract calls a publicFacet method in the attestation
+ * contract that allows it to split an attestation into multiple
+ * versions? Would require no offer safety for the collateral, but
+ * that would be true already
+ *
+ * ** Withdraw all BLD attestation:
+ *
+ * Must pay back the loan. User gets the bld attestation back, needs
+ * to make an offer to the attestation contract to turn it back in.
+ *
+ *
+ * ------
+ * A fungible BLD attestation would be better suited to the RUN LoC as
+ * we could just reuse vault code (after removing without
+ * liquidation). But that would require being incredibly careful to
+ * only allow redemptions of attestations to unlien tokens
+ * appropriately. In other words, we have to ensure total conservation
+ * of funds on the cosmos side (unliening can't create tokens), and we
+ * have to ensure at the very least, that if a fungible NFT
+ * attestation is transferred and another person returns it, they
+ * cannot unlien more than they liened, and the system should not
+ * error if that's the case, just disallow it.
+ */

--- a/packages/zoe/test/unitTests/contracts/attestation/exampleLoanUsage.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/exampleLoanUsage.js
@@ -23,10 +23,10 @@
  * ** Withdraw a partial amount of BLD attestation:
  *
  * Must have returned some RUN, or the market value of collateral has
- * risen. Contract calls a publicFacet method in the attestation
- * contract that allows it to split an attestation into multiple
- * versions? Would require no offer safety for the collateral, but
- * that would be true already
+ * risen, or the loan was overcollateralized to start. Contract calls
+ * a publicFacet method in the attestation contract that allows it to
+ * split an attestation into multiple versions? Would require no offer
+ * safety for the collateral, but that would be true already
  *
  * ** Withdraw all BLD attestation:
  *

--- a/packages/zoe/test/unitTests/contracts/attestation/exampleLoanUsage.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/exampleLoanUsage.js
@@ -11,9 +11,9 @@
  *
  * ** Add more collateral:
  *
- * Escrow more attestations of brand BldAttLoc. Contract must add
- * the internal BLD values (amount.value[0].value) together to get a
- * total sum of liened BLD.
+ * Escrow more attestations of brand BldAttLoc. Contract must add the
+ * internal BLD values (amount.value[0].value) together to get a total
+ * sum of liened BLD.
  *
  * ** Withdraw more RUN:
  *
@@ -45,4 +45,10 @@
  * attestation is transferred and another person returns it, they
  * cannot unlien more than they liened, and the system should not
  * error if that's the case, just disallow it.
+ *
+ * michaelfig identified an additional problem with fungible
+ * attestation tokens in which redeeming someone else's fungible
+ * tokens can make a user's own fungible attestations tokens
+ * unredeemable, but with no external indications of this new change
+ * in their functionality.
  */

--- a/packages/zoe/test/unitTests/contracts/attestation/exampleVotingUsage.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/exampleVotingUsage.js
@@ -37,7 +37,7 @@ const start = zcf => {
     const attestationValue = /** @type {SetValue} */ (attestation.value);
 
     attestationValue.forEach(
-      /** @type {ExpiringAttElem} */ attestationElem => {
+      /** @param {ExpiringAttElem} attestationElem */ attestationElem => {
         const { amountLiened, handle, expiration } = attestationElem;
         if (storedAttestations.has(handle)) {
           // We check the newly escrowed attestation against the one we

--- a/packages/zoe/test/unitTests/contracts/attestation/exampleVotingUsage.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/exampleVotingUsage.js
@@ -1,0 +1,136 @@
+// @ts-check
+import { Far } from '@agoric/marshal';
+import { AssetKind, AmountMath } from '@agoric/ertp';
+import { makeStore } from '@agoric/store';
+
+import '../../../../src/contracts/attestation/types';
+
+const { details: X } = assert;
+
+// This voting contract does not track addresses, and does not care if
+// one address has multiple seats with different votes. Seems like
+// trying to enforce one address/one vote would create an incentive
+// for users to create multiple accounts, which we don't want.
+
+/** @type {ContractStartFn} */
+const start = zcf => {
+  const {
+    brands: { Attestation: attestationBrand },
+  } = zcf.getTerms();
+
+  /** @type {Store<Handle<'attestation'>, { seat: ZCFSeat,
+   * expiration: Timestamp, amountLiened: Amount}>} */
+  const storedAttestations = makeStore();
+
+  /** @type {Store<ZCFSeat, string>} */
+  const recordedVotes = makeStore();
+
+  const empty = AmountMath.makeEmpty(attestationBrand, AssetKind.SET);
+
+  /** @type {OfferHandler} */
+  const vote = seat => {
+    const attestation = seat.getAmountAllocated('Attestation');
+    assert(
+      AmountMath.isGTE(attestation, empty, attestationBrand),
+      X`There was no attestation escrowed`,
+    );
+    const attestationValue = /** @type {SetValue} */ (attestation.value);
+
+    attestationValue.forEach(
+      /** @type {ExpiringAttElem} */ attestationElem => {
+        const { amountLiened, handle, expiration } = attestationElem;
+        if (storedAttestations.has(handle)) {
+          // We check the newly escrowed attestation against the one we
+          // have already stored. If the newly escrowed one has an
+          // earlier or equal expiration, it is old and we should keep
+          // the priorAttestation instead.
+          const priorAttestation = storedAttestations.get(handle);
+          if (expiration > priorAttestation.expiration) {
+            storedAttestations.set(
+              handle,
+              harden({ seat, expiration, amountLiened }),
+            );
+          }
+        } else {
+          storedAttestations.init(
+            handle,
+            harden({ seat, expiration, amountLiened }),
+          );
+        }
+      },
+    );
+
+    // Give the user their attestation payment back
+    seat.exit();
+
+    return Far('offerResult', {
+      /** @param {string} answer */
+      castVote: answer => {
+        if (recordedVotes.has(seat)) {
+          recordedVotes.set(seat, answer);
+        } else {
+          recordedVotes.init(seat, answer);
+        }
+      },
+    });
+  };
+
+  const publicFacet = Far('publicFacet', {
+    makeVoteInvitation: () => zcf.makeInvitation(vote, 'vote'),
+  });
+
+  const creatorFacet = Far('creatorFacet', {
+    closeVote: currentTime => {
+      // For each seat, sum the values in the attestations as long as
+      // the expiration is after the currentTime.
+
+      /** @type {Store<ZCFSeat, Amount>} */
+      const sumBySeat = makeStore();
+
+      storedAttestations
+        .values()
+        .forEach(({ seat, expiration, amountLiened }) => {
+          // Only add the weight if the expiration is later than the
+          // currentTime.
+          if (expiration > currentTime) {
+            const weight = amountLiened;
+            if (sumBySeat.has(seat)) {
+              const weightSoFar = sumBySeat.get(seat);
+              sumBySeat.set(seat, AmountMath.add(weightSoFar, weight));
+            } else {
+              sumBySeat.init(seat, weight);
+            }
+          }
+        });
+
+      /** @type {Store<string, Amount>} */
+      const weightedAnswers = makeStore('answers');
+
+      recordedVotes.entries().forEach(([seat, answer]) => {
+        // The seat may no longer have a weight if an extended
+        // expiration attestation was used that replaced a previous
+        // attestation
+        if (sumBySeat.has(seat)) {
+          const weight = sumBySeat.get(seat);
+          if (weightedAnswers.has(answer)) {
+            const weightSoFar = weightedAnswers.get(answer);
+            weightedAnswers.set(answer, AmountMath.add(weightSoFar, weight));
+          } else {
+            weightedAnswers.init(answer, weight);
+          }
+        }
+      });
+
+      return weightedAnswers
+        .entries()
+        .map(([answer, amount]) => [answer, amount.value]);
+    },
+  });
+
+  return harden({
+    publicFacet,
+    creatorFacet,
+  });
+};
+harden(start);
+export { start };

--- a/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-addToLiened.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-addToLiened.js
@@ -1,0 +1,65 @@
+// @ts-check
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+import { makeStore } from '@agoric/store';
+import { AmountMath, makeIssuerKit } from '@agoric/ertp';
+
+import { addToLiened } from '../../../../../src/contracts/attestation/expiring/expiringHelpers';
+import { makeHandle } from '../../../../../src/makeHandle';
+
+test('add for same address', async t => {
+  /** @type {Store<Address,Array<ExpiringAttElem>>} */
+  const store = makeStore('address');
+  const address = 'address1';
+  const handle1 = makeHandle('attestation');
+  const handle2 = makeHandle('attestation');
+
+  const { brand } = makeIssuerKit('external');
+  const amountLiened = AmountMath.make(brand, 0n);
+  const expiration = 0n;
+  const elem1 = {
+    address,
+    handle: handle1,
+    amountLiened,
+    expiration,
+  };
+  const elem2 = { address, handle: handle2, amountLiened, expiration };
+  addToLiened(store, elem1);
+  addToLiened(store, elem2);
+
+  // reuse the same handle. This should not happen, but note that the
+  // store does not do any checking of the handle's uniqueness
+  addToLiened(store, elem1);
+
+  t.deepEqual(store.get(address), [elem1, elem2, elem1]);
+});
+
+test('add for multiple addresses', async t => {
+  /** @type {Store<Address,Array<ExpiringAttElem>>} */
+  const store = makeStore('address');
+  const { brand } = makeIssuerKit('external');
+  const amountLiened = AmountMath.make(brand, 0n);
+  const expiration = 0n;
+  const address1 = 'address1';
+  const address2 = 'address2';
+  const handle1 = makeHandle('attestation');
+  const handle2 = makeHandle('attestation');
+  const elem1 = {
+    address: address1,
+    handle: handle1,
+    amountLiened,
+    expiration,
+  };
+  const elem2 = {
+    address: address2,
+    handle: handle2,
+    amountLiened,
+    expiration,
+  };
+  addToLiened(store, elem1);
+  addToLiened(store, elem2);
+
+  t.deepEqual(store.get(address1), [elem1]);
+  t.deepEqual(store.get(address2), [elem2]);
+});

--- a/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-extendExpiration.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-extendExpiration.js
@@ -1,0 +1,122 @@
+// @ts-check
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+import { AmountMath, makeIssuerKit, AssetKind } from '@agoric/ertp';
+import { extendExpiration } from '../../../../../src/contracts/attestation/expiring/extendExpiration';
+import { makeAttestationElem } from '../../../../../src/contracts/attestation/expiring/expiringHelpers';
+import { makeHandle } from '../../../../../src/makeHandle';
+
+const doTest = (
+  t,
+  newExpiration,
+  canExtend = _address => true,
+  escrowsNothing = false,
+  moreThanOneElem = false,
+) => {
+  const { brand: attestationBrand } = makeIssuerKit(
+    'attestation',
+    AssetKind.SET,
+  );
+
+  const { brand: externalBrand } = makeIssuerKit('external');
+
+  const amountLiened = AmountMath.make(externalBrand, 100n);
+  const elem = makeAttestationElem(
+    'address',
+    amountLiened,
+    4n,
+    makeHandle('attestation'),
+  );
+  const newElem = makeAttestationElem(
+    'address',
+    amountLiened,
+    newExpiration,
+    elem.handle,
+  );
+
+  let currentAllocation;
+
+  if (escrowsNothing) {
+    currentAllocation = {};
+  } else if (moreThanOneElem) {
+    currentAllocation = {
+      Attestation: AmountMath.make(attestationBrand, [elem, newElem]),
+    };
+  } else {
+    currentAllocation = {
+      Attestation: AmountMath.make(attestationBrand, [elem]),
+    };
+  }
+
+  let hasExited = false;
+
+  const zcfSeat = {
+    getAmountAllocated: keyword => currentAllocation[keyword],
+    getCurrentAllocation: () => currentAllocation,
+    exit: () => {
+      hasExited = true;
+    },
+    getProposal: () => {
+      return { want: {}, give: currentAllocation };
+    },
+  };
+  const zcfMint = {
+    burnLosses: (losses, seat) => {
+      t.deepEqual(losses, currentAllocation);
+      t.is(seat, zcfSeat);
+    },
+    mintGains: (gains, seat) => {
+      t.deepEqual(gains, {
+        Attestation: AmountMath.make(attestationBrand, [newElem]),
+      });
+      t.is(seat, zcfSeat);
+    },
+  };
+  const updateLienedAmounts = updated => {
+    t.deepEqual(updated, newElem);
+  };
+
+  extendExpiration(
+    // @ts-ignore ZCFSeat is mocked for testing
+    zcfSeat,
+    zcfMint,
+    canExtend,
+    updateLienedAmounts,
+    attestationBrand,
+    newExpiration,
+  );
+
+  t.true(hasExited);
+};
+
+test('happy path', async t => {
+  doTest(t, 5n);
+});
+
+test('bad newExpiration', async t => {
+  t.throws(() => doTest(t, 0n), {
+    message:
+      'The new expiration "[0n]" must be later than the old expiration "[4n]"',
+  });
+});
+
+test('nothing escrowed', async t => {
+  t.throws(() => doTest(t, 5n, undefined, true), {
+    message: 'actual {} did not match expected {"Attestation":null}',
+  });
+});
+
+test('more than one elem', async t => {
+  t.throws(() => doTest(t, 5n, undefined, false, true), {
+    message: /We can currently only extend a single attestation element at a time/,
+  });
+});
+
+test('cannot extend', async t => {
+  const canExtend = _address => false;
+  t.throws(() => doTest(t, 5n, canExtend), {
+    message:
+      'The address "address" cannot extend the expiration for attestations',
+  });
+});

--- a/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-extendExpiration.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-extendExpiration.js
@@ -96,8 +96,7 @@ test('happy path', async t => {
 
 test('bad newExpiration', async t => {
   t.throws(() => doTest(t, 0n), {
-    message:
-      'The new expiration "[0n]" must be later than the old expiration "[4n]"',
+    message: "The new expiration '0' must be later than the old expiration '4'",
   });
 });
 
@@ -117,6 +116,6 @@ test('cannot extend', async t => {
   const canExtend = _address => false;
   t.throws(() => doTest(t, 5n, canExtend), {
     message:
-      'The address "address" cannot extend the expiration for attestations',
+      "The address 'address' cannot extend the expiration for attestations",
   });
 });

--- a/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-extendExpiration.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-extendExpiration.js
@@ -93,7 +93,7 @@ const doTest = (
       t.is(seat, zcfSeat);
     },
   };
-  const updateLienedAmounts = updated => {
+  const updateLienedAmount = updated => {
     t.deepEqual(updated, newElem);
   };
 
@@ -102,7 +102,7 @@ const doTest = (
     zcfSeat,
     zcfMint,
     canExtend,
-    updateLienedAmounts,
+    updateLienedAmount,
     attestationBrand,
     newExpiration,
   );

--- a/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-hasExpired.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-hasExpired.js
@@ -1,0 +1,23 @@
+// @ts-check
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+import { hasExpired } from '../../../../../src/contracts/attestation/expiring/expiringHelpers';
+
+test('expiration before current time', async t => {
+  const expiration = 1n;
+  const currentTime = 2n;
+  t.true(hasExpired(expiration, currentTime));
+});
+
+test('expiration equals current time', async t => {
+  const expiration = 2n;
+  const currentTime = 2n;
+  t.false(hasExpired(expiration, currentTime));
+});
+
+test('expiration after current time', async t => {
+  const expiration = 3n;
+  const currentTime = 2n;
+  t.false(hasExpired(expiration, currentTime));
+});

--- a/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-unlienIfExpired.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-unlienIfExpired.js
@@ -1,0 +1,123 @@
+// @ts-check
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+import { makeStore } from '@agoric/store';
+import { AmountMath, makeIssuerKit } from '@agoric/ertp';
+
+import { unlienIfExpired } from '../../../../../src/contracts/attestation/expiring/unlienIfExpired';
+import { makeAttestationElem } from '../../../../../src/contracts/attestation/expiring/expiringHelpers';
+import { makeHandle } from '../../../../../src/makeHandle';
+
+test(`store doesn't have address`, async t => {
+  /** @type {Store<Address,Array<ExpiringAttElem>>} */
+  const store = makeStore('address');
+  const address = 'address';
+  const currentTime = 5n;
+  const { brand: externalBrand } = makeIssuerKit('external');
+  const empty = AmountMath.makeEmpty(externalBrand);
+
+  const result = unlienIfExpired(store, empty, address, currentTime);
+  t.true(AmountMath.isEmpty(result));
+  t.false(store.has(address));
+});
+
+test(`store has address with empty array value`, async t => {
+  /** @type {Store<Address,Array<ExpiringAttElem>>} */
+  const store = makeStore('address');
+  const address = 'address';
+  const currentTime = 5n;
+  const { brand: externalBrand } = makeIssuerKit('external');
+  const empty = AmountMath.makeEmpty(externalBrand);
+
+  store.init(address, []);
+
+  const result = unlienIfExpired(store, empty, address, currentTime);
+  t.true(AmountMath.isEmpty(result));
+  t.deepEqual(store.get(address), []);
+});
+
+test(`store has address with all non-expired values`, async t => {
+  /** @type {Store<Address,Array<ExpiringAttElem>>} */
+  const store = makeStore('address');
+  const address = 'address';
+  const currentTime = 5n;
+  const { brand: externalBrand } = makeIssuerKit('external');
+  const empty = AmountMath.makeEmpty(externalBrand);
+
+  const bld10 = AmountMath.make(externalBrand, 10n);
+  const bld20 = AmountMath.make(externalBrand, 20n);
+  const bld40 = AmountMath.make(externalBrand, 40n);
+
+  const elem1 = makeAttestationElem(
+    address,
+    bld10,
+    10n,
+    makeHandle('attestation'),
+  );
+
+  const elem2 = makeAttestationElem(
+    address,
+    bld20,
+    10n,
+    makeHandle('attestation'),
+  );
+
+  const elem3 = makeAttestationElem(
+    address,
+    bld40,
+    10n,
+    makeHandle('attestation'),
+  );
+
+  store.init(address, [elem1, elem2, elem3]);
+
+  const result = unlienIfExpired(store, empty, address, currentTime);
+  t.true(
+    AmountMath.isEqual(
+      result,
+      AmountMath.add(AmountMath.add(bld10, bld20), bld40),
+    ),
+  );
+  t.deepEqual(store.get(address), [elem1, elem2, elem3]);
+});
+
+test(`store has address with one expired`, async t => {
+  /** @type {Store<Address,Array<ExpiringAttElem>>} */
+  const store = makeStore('address');
+  const address = 'address';
+  const currentTime = 5n;
+  const { brand: externalBrand } = makeIssuerKit('external');
+  const empty = AmountMath.makeEmpty(externalBrand);
+
+  const bld10 = AmountMath.make(externalBrand, 10n);
+  const bld20 = AmountMath.make(externalBrand, 20n);
+  const bld40 = AmountMath.make(externalBrand, 40n);
+
+  const elem1 = makeAttestationElem(
+    address,
+    bld10,
+    1n,
+    makeHandle('attestation'),
+  );
+
+  const elem2 = makeAttestationElem(
+    address,
+    bld20,
+    10n,
+    makeHandle('attestation'),
+  );
+
+  const elem3 = makeAttestationElem(
+    address,
+    bld40,
+    10n,
+    makeHandle('attestation'),
+  );
+
+  store.init(address, [elem1, elem2, elem3]);
+
+  const result = unlienIfExpired(store, empty, address, currentTime);
+  t.true(AmountMath.isEqual(result, AmountMath.add(bld20, bld40)));
+  t.deepEqual(store.get(address), [elem2, elem3]);
+});

--- a/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-unlienIfExpired.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-unlienIfExpired.js
@@ -5,7 +5,7 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
 import { makeStore } from '@agoric/store';
 import { AmountMath, makeIssuerKit } from '@agoric/ertp';
 
-import { unlienIfExpired } from '../../../../../src/contracts/attestation/expiring/unlienIfExpired';
+import { unlienExpiredAmounts } from '../../../../../src/contracts/attestation/expiring/unlienExpiredAmounts';
 import { makeAttestationElem } from '../../../../../src/contracts/attestation/expiring/expiringHelpers';
 import { makeHandle } from '../../../../../src/makeHandle';
 
@@ -17,7 +17,7 @@ test(`store doesn't have address`, async t => {
   const { brand: externalBrand } = makeIssuerKit('external');
   const empty = AmountMath.makeEmpty(externalBrand);
 
-  const result = unlienIfExpired(store, empty, address, currentTime);
+  const result = unlienExpiredAmounts(store, empty, address, currentTime);
   t.true(AmountMath.isEmpty(result));
   t.false(store.has(address));
 });
@@ -32,7 +32,7 @@ test(`store has address with empty array value`, async t => {
 
   store.init(address, []);
 
-  const result = unlienIfExpired(store, empty, address, currentTime);
+  const result = unlienExpiredAmounts(store, empty, address, currentTime);
   t.true(AmountMath.isEmpty(result));
   t.deepEqual(store.get(address), []);
 });
@@ -72,7 +72,7 @@ test(`store has address with all non-expired values`, async t => {
 
   store.init(address, [elem1, elem2, elem3]);
 
-  const result = unlienIfExpired(store, empty, address, currentTime);
+  const result = unlienExpiredAmounts(store, empty, address, currentTime);
   t.true(
     AmountMath.isEqual(
       result,
@@ -117,7 +117,7 @@ test(`store has address with one expired`, async t => {
 
   store.init(address, [elem1, elem2, elem3]);
 
-  const result = unlienIfExpired(store, empty, address, currentTime);
+  const result = unlienExpiredAmounts(store, empty, address, currentTime);
   t.true(AmountMath.isEqual(result, AmountMath.add(bld20, bld40)));
   t.deepEqual(store.get(address), [elem2, elem3]);
 });

--- a/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-updateLien.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-updateLien.js
@@ -17,7 +17,7 @@ test(`store doesn't have address`, async t => {
   const newAttestationElem = makeAttestationElem('address');
 
   t.throws(() => updateLien(store, newAttestationElem), {
-    message: "No previous lien was found for address 'address'",
+    message: 'No previous lien was found for address "address"',
   });
 });
 

--- a/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-updateLien.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-updateLien.js
@@ -1,0 +1,107 @@
+// @ts-check
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+import { makeStore } from '@agoric/store';
+import { AmountMath, makeIssuerKit } from '@agoric/ertp';
+
+import { updateLien } from '../../../../../src/contracts/attestation/expiring/updateLien';
+import { makeAttestationElem } from '../../../../../src/contracts/attestation/expiring/expiringHelpers';
+import { makeHandle } from '../../../../../src/makeHandle';
+
+test(`store doesn't have address`, async t => {
+  /** @type {Store<Address,Array<ExpiringAttElem>>} */
+  const store = makeStore('address');
+
+  // @ts-ignore AttestationElem mocked for test
+  const newAttestationElem = makeAttestationElem('address');
+
+  t.throws(() => updateLien(store, newAttestationElem), {
+    message: 'No previous lien was found for address "address"',
+  });
+});
+
+test(`no old records`, async t => {
+  /** @type {Store<Address,Array<ExpiringAttElem>>} */
+  const store = makeStore('address');
+
+  const address = 'address';
+
+  store.init(address, []);
+
+  const { brand: externalBrand } = makeIssuerKit('external');
+  const amountLiened = AmountMath.make(externalBrand, 10n);
+
+  const newAttestationElem = makeAttestationElem(
+    address,
+    amountLiened,
+    1n,
+    makeHandle('attestation'),
+  );
+
+  t.throws(() => updateLien(store, newAttestationElem), {
+    message: /No previous lien was found for address/,
+  });
+});
+
+test(`old records don't match`, async t => {
+  /** @type {Store<Address,Array<ExpiringAttElem>>} */
+  const store = makeStore('address');
+
+  const address = 'address';
+  const handle = makeHandle('attestation');
+  const { brand: externalBrand } = makeIssuerKit('external');
+  const amountLiened = AmountMath.make(externalBrand, 10n);
+  const oldAttestation = makeAttestationElem(address, amountLiened, 1n, handle);
+
+  store.init(address, [oldAttestation]);
+
+  const newAttestationElem = makeAttestationElem(
+    address,
+    amountLiened,
+    5n,
+    makeHandle('attestation'),
+  );
+
+  t.throws(() => updateLien(store, newAttestationElem), {
+    message: /No previous lien was found for address/,
+  });
+});
+
+test(`happy path`, async t => {
+  /** @type {Store<Address,Array<ExpiringAttElem>>} */
+  const store = makeStore('address');
+
+  const address = 'address';
+  const handle = makeHandle('attestation');
+  const { brand: externalBrand } = makeIssuerKit('external');
+  const amountLiened = AmountMath.make(externalBrand, 10n);
+
+  const oldAttestation1 = makeAttestationElem(
+    address,
+    amountLiened,
+    1n,
+    handle,
+  );
+  const oldAttestation2 = makeAttestationElem(
+    address,
+    amountLiened,
+    1n,
+    makeHandle('attestation'),
+  );
+
+  store.init(address, [oldAttestation1, oldAttestation2]);
+
+  const newAttestationElem = makeAttestationElem(
+    address,
+    amountLiened,
+    5n,
+    handle,
+  );
+
+  updateLien(store, newAttestationElem);
+
+  // old record is subtracted
+  // new attestation is added
+  t.deepEqual(store.get(address), [oldAttestation2, newAttestationElem]);
+});

--- a/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-updateLien.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-updateLien.js
@@ -17,7 +17,7 @@ test(`store doesn't have address`, async t => {
   const newAttestationElem = makeAttestationElem('address');
 
   t.throws(() => updateLien(store, newAttestationElem), {
-    message: 'No previous lien was found for address "address"',
+    message: "No previous lien was found for address 'address'",
   });
 });
 

--- a/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-userFlow.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-userFlow.js
@@ -141,7 +141,7 @@ test(`typical flow`, async t => {
 
   await t.throwsAsync(() => E(userSeat).getOfferResult(), {
     message:
-      'The address "myaddress" cannot extend the expiration for attestations',
+      "The address 'myaddress' cannot extend the expiration for attestations",
   });
 
   // refundAttestation has the same value as the extendedAttestation.

--- a/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-userFlow.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-userFlow.js
@@ -68,9 +68,12 @@ test(`typical flow`, async t => {
     addExpiringLien,
     getLienAmount,
     makeExtendAttInvitation,
-    issuer: attestationIssuer,
-    brand: attestationBrand,
+    getIssuer,
+    getBrand,
   } = await setupAttestation(attestationTokenName, empty, zcf);
+
+  const attestationIssuer = getIssuer();
+  const attestationBrand = getBrand();
 
   const testAttestationAmount = makeTestAttestationAmount(
     t,

--- a/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-userFlow.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-userFlow.js
@@ -140,8 +140,7 @@ test(`typical flow`, async t => {
   );
 
   await t.throwsAsync(() => E(userSeat).getOfferResult(), {
-    message:
-      "The address 'myaddress' cannot extend the expiration for attestations",
+    message: `The address "myaddress" cannot extend the expiration for attestations`,
   });
 
   // refundAttestation has the same value as the extendedAttestation.

--- a/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-userFlow.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-userFlow.js
@@ -9,12 +9,10 @@ import { setupZCFTest } from '../../../zcf/setupZcfTest';
 
 import { setupAttestation } from '../../../../../src/contracts/attestation/expiring/expiringNFT';
 
-const makeDoExtendExpiration = (
-  zoe,
-  zcf,
-  issuer,
-  makeExtendAttInvitation,
-) => async (attestation, newExpiration) => {
+const makeDoExtendExpiration = (zoe, issuer, makeExtendAttInvitation) => async (
+  attestation,
+  newExpiration,
+) => {
   const invitation = makeExtendAttInvitation(newExpiration);
   const attestationAmount = await E(issuer).getAmountOf(attestation);
   const proposal = harden({ give: { Attestation: attestationAmount } });
@@ -84,7 +82,6 @@ test(`typical flow`, async t => {
 
   const doExtendExpiration = makeDoExtendExpiration(
     zoe,
-    zcf,
     attestationIssuer,
     makeExtendAttInvitation,
   );

--- a/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-userFlow.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-userFlow.js
@@ -1,0 +1,193 @@
+// @ts-check
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+import { AmountMath, makeIssuerKit } from '@agoric/ertp';
+import { E } from '@agoric/eventual-send';
+
+import { setupZCFTest } from '../../../zcf/setupZcfTest';
+
+import { setupAttestation } from '../../../../../src/contracts/attestation/expiring/expiringNFT';
+
+const makeDoExtendExpiration = (
+  zoe,
+  zcf,
+  issuer,
+  makeExtendAttInvitation,
+) => async (attestation, newExpiration) => {
+  const invitation = makeExtendAttInvitation(newExpiration);
+  const attestationAmount = await E(issuer).getAmountOf(attestation);
+  const proposal = harden({ give: { Attestation: attestationAmount } });
+  const payments = harden({ Attestation: attestation });
+  const userSeat = E(zoe).offer(invitation, proposal, payments);
+  const extendedAttestation = E(userSeat).getPayout('Attestation');
+  return harden({
+    attestation: extendedAttestation,
+    userSeat,
+  });
+};
+
+const makeTestAttestationAmount = (t, issuer, brand, address) => async (
+  attestation,
+  amountLiened,
+  expiration,
+  handle,
+) => {
+  const attestationAmount = await E(issuer).getAmountOf(attestation);
+  const attestationHandle = attestationAmount.value[0].handle;
+  const expectedHandle = handle !== undefined ? handle : attestationHandle;
+
+  t.deepEqual(attestationAmount.value, [
+    {
+      address,
+      amountLiened,
+      expiration,
+      handle: expectedHandle,
+    },
+  ]);
+  t.is(attestationAmount.brand, brand);
+  return attestationHandle;
+};
+
+const makeTestLienAmount = (t, getLienAmount, address) => (
+  currentTime,
+  expectedLien,
+) => {
+  t.deepEqual(getLienAmount(address, currentTime), expectedLien);
+};
+
+test(`typical flow`, async t => {
+  const attestationTokenName = 'Token';
+  const { brand: externalBrand } = makeIssuerKit('external');
+  const empty = AmountMath.makeEmpty(externalBrand);
+
+  const { zoe, zcf } = await setupZCFTest();
+
+  const address = 'myaddress';
+
+  const {
+    disallowExtensions,
+    addExpiringLien,
+    getLienAmount,
+    makeExtendAttInvitation,
+    issuer: attestationIssuer,
+    brand: attestationBrand,
+  } = await setupAttestation(attestationTokenName, empty, zcf);
+
+  const testAttestationAmount = makeTestAttestationAmount(
+    t,
+    attestationIssuer,
+    attestationBrand,
+    address,
+  );
+  const testLienAmount = makeTestLienAmount(t, getLienAmount, address);
+
+  const doExtendExpiration = makeDoExtendExpiration(
+    zoe,
+    zcf,
+    attestationIssuer,
+    makeExtendAttInvitation,
+  );
+
+  let currentTime = 0n;
+
+  // At 0n, the lien amount.value is 0n
+  testLienAmount(currentTime, AmountMath.makeEmpty(externalBrand));
+
+  // Add a lien of 100n that expires at 1n
+  const amountToLien = AmountMath.make(externalBrand, 100n);
+  const expiration = 1n;
+  const attestation = await addExpiringLien(address, amountToLien, expiration);
+
+  // At 0n (still), the lien amount.value is 100n
+  testLienAmount(currentTime, amountToLien);
+
+  // The attestation is for 100n and expires at 1n
+  const handle = await testAttestationAmount(
+    attestation,
+    amountToLien,
+    expiration,
+  );
+
+  const newExpiration = 2n;
+
+  // Extend the Expiration to 2n
+  const { attestation: extendedAttestation } = await doExtendExpiration(
+    attestation,
+    newExpiration,
+  );
+
+  // The extendedAttestation should have the same amountLiened and the
+  // same handle, but it should have the new expiration
+  await testAttestationAmount(
+    extendedAttestation,
+    amountToLien,
+    newExpiration,
+    handle,
+  );
+
+  // At 0n (still), the amountLiened is still 100n
+  testLienAmount(currentTime, amountToLien);
+
+  // Now let's disallow extensions and then try extending
+  disallowExtensions(address);
+
+  const newExpiration2 = 4n;
+
+  const { attestation: refundAttestation, userSeat } = await doExtendExpiration(
+    extendedAttestation,
+    newExpiration2,
+  );
+
+  await t.throwsAsync(() => E(userSeat).getOfferResult(), {
+    message:
+      'The address "myaddress" cannot extend the expiration for attestations',
+  });
+
+  // refundAttestation has the same value as the extendedAttestation.
+  // It does not have the expiration of "newExpiration2"
+  testAttestationAmount(refundAttestation, amountToLien, newExpiration, handle);
+
+  // At 0n (still), the amountLiened is still 100n
+  testLienAmount(currentTime, amountToLien);
+
+  // Finally, time passes and it is 5n.
+  // The attestation has expired at this point (1n attestation compared to 5n currentTime)
+  currentTime = 5n;
+
+  testLienAmount(currentTime, AmountMath.makeEmpty(externalBrand));
+
+  // Test that the address can extend attestation expirations
+  // again, after the "disallowExtensions" has been lifted due to the
+  // amountLiened reaching 0n.
+  const amountToLien2 = AmountMath.make(externalBrand, 250n);
+
+  const expiration10 = 10n;
+  const attestationAfterDisallow = await addExpiringLien(
+    address,
+    amountToLien2,
+    expiration10,
+  );
+
+  const afterDisallowHandle = await testAttestationAmount(
+    attestationAfterDisallow,
+    amountToLien2,
+    expiration10,
+  );
+
+  // At 5n (still), the amountLiened is 250n
+  testLienAmount(currentTime, amountToLien2);
+
+  const newExpiration20 = 20n;
+  const { attestation: extendedAfterDisallow } = await doExtendExpiration(
+    attestationAfterDisallow,
+    newExpiration20,
+  );
+
+  await testAttestationAmount(
+    extendedAfterDisallow,
+    amountToLien2,
+    newExpiration20,
+    afterDisallowHandle,
+  );
+});

--- a/packages/zoe/test/unitTests/contracts/attestation/returnableNFT/test-userFlow.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/returnableNFT/test-userFlow.js
@@ -1,0 +1,122 @@
+// @ts-check
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+import { AmountMath, makeIssuerKit } from '@agoric/ertp';
+import { E } from '@agoric/eventual-send';
+
+import { setupZCFTest } from '../../../zcf/setupZcfTest';
+
+import { setupAttestation } from '../../../../../src/contracts/attestation/returnable/returnableNFT';
+
+const makeDoReturnAttestation = (
+  zoe,
+  issuer,
+  makeReturnAttInvitation,
+) => async attestation => {
+  const invitation = makeReturnAttInvitation();
+  const attestationAmount = await E(issuer).getAmountOf(attestation);
+  const proposal = harden({ give: { Attestation: attestationAmount } });
+  const payments = harden({ Attestation: attestation });
+  const userSeat = E(zoe).offer(invitation, proposal, payments);
+  const payout = await E(userSeat).getPayouts();
+  const amounts = await Promise.all(
+    Object.values(payout).map(paymentP => E(issuer).getAmountOf(paymentP)),
+  );
+  return harden({
+    amounts,
+    userSeat,
+  });
+};
+
+const makeTestAttestationAmount = (t, issuer, brand, address) => async (
+  attestation,
+  amountLiened,
+) => {
+  const attestationAmount = await E(issuer).getAmountOf(attestation);
+
+  t.deepEqual(attestationAmount.value, [
+    {
+      address,
+      amountLiened,
+    },
+  ]);
+  t.is(attestationAmount.brand, brand);
+};
+
+const makeTestLienAmount = (t, getLienAmount, address) => expectedLien => {
+  t.deepEqual(getLienAmount(address), expectedLien);
+};
+
+test(`typical flow`, async t => {
+  const attestationTokenName = 'Token';
+  const { brand: externalBrand } = makeIssuerKit('external');
+  const empty = AmountMath.makeEmpty(externalBrand);
+
+  const { zoe, zcf } = await setupZCFTest();
+
+  const address = 'myaddress';
+
+  const {
+    makeReturnAttInvitation,
+    addReturnableLien,
+    getLienAmount,
+    issuer: attestationIssuer,
+    brand: attestationBrand,
+  } = await setupAttestation(attestationTokenName, empty, zcf);
+
+  const testAttestationAmount = makeTestAttestationAmount(
+    t,
+    attestationIssuer,
+    attestationBrand,
+    address,
+  );
+  const testLienAmount = makeTestLienAmount(t, getLienAmount, address);
+
+  const doReturnAttestation = makeDoReturnAttestation(
+    zoe,
+    attestationIssuer,
+    makeReturnAttInvitation,
+  );
+
+  // LienAmount starts at 0n
+  testLienAmount(AmountMath.makeEmpty(externalBrand));
+
+  // Add a lien of 100n
+  const amountToLien = AmountMath.make(externalBrand, 100n);
+  const attestation = await addReturnableLien(address, amountToLien);
+
+  // LienAmount is now 100n
+  testLienAmount(amountToLien);
+
+  // The attestation is for 100n
+  await testAttestationAmount(attestation, amountToLien);
+
+  // take out another expiration for 50n
+  const amountToLien2 = AmountMath.make(externalBrand, 50n);
+  const attestation2 = await addReturnableLien(address, amountToLien2);
+
+  // LienAmount is now 150n
+  testLienAmount(AmountMath.add(amountToLien, amountToLien2));
+
+  // The attestation is for 50n
+  await testAttestationAmount(attestation2, amountToLien2);
+
+  // return the attestation for 50n
+
+  const { amounts } = await doReturnAttestation(attestation2);
+  t.true(amounts.every(amount => AmountMath.isEmpty(amount, attestationBrand)));
+
+  // The attestation should have been deposited and used up
+  await t.throwsAsync(() => E(attestationIssuer).getAmountOf(attestation2), {
+    message: 'payment not found for "Token"',
+  });
+
+  // The amountLiened has been reduced by 50n to 100n
+  testLienAmount(amountToLien);
+
+  // Return the original attestation
+  await doReturnAttestation(attestation);
+
+  testLienAmount(AmountMath.makeEmpty(externalBrand));
+});

--- a/packages/zoe/test/unitTests/contracts/attestation/returnableNFT/test-userFlow.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/returnableNFT/test-userFlow.js
@@ -61,9 +61,12 @@ test(`typical flow`, async t => {
     makeReturnAttInvitation,
     addReturnableLien,
     getLienAmount,
-    issuer: attestationIssuer,
-    brand: attestationBrand,
+    getIssuer,
+    getBrand,
   } = await setupAttestation(attestationTokenName, empty, zcf);
+
+  const attestationIssuer = getIssuer();
+  const attestationBrand = getBrand();
 
   const testAttestationAmount = makeTestAttestationAmount(
     t,

--- a/packages/zoe/test/unitTests/contracts/attestation/test-attestation.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/test-attestation.js
@@ -1,0 +1,204 @@
+// @ts-check
+
+/* global __dirname */
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+import { makeIssuerKit, AssetKind, AmountMath } from '@agoric/ertp';
+import { Far } from '@agoric/marshal';
+
+import bundleSource from '@agoric/bundle-source';
+import { E } from '@agoric/eventual-send';
+
+import { makeZoe } from '../../../../src/zoeService/zoe';
+import fakeVatAdmin from '../../../../tools/fakeVatAdmin';
+
+const attestationRoot = `${__dirname}/../../../../src/contracts/attestation/attestation`;
+
+test('attestation contract basic test', async t => {
+  const bundle = await bundleSource(attestationRoot);
+
+  const zoe = makeZoe(fakeVatAdmin);
+  const installation = await E(zoe).install(bundle);
+
+  const bldIssuerKit = makeIssuerKit('BLD', AssetKind.NAT, {
+    decimalPlaces: 6,
+  });
+  const uBrand = bldIssuerKit.brand;
+  const uIssuer = bldIssuerKit.issuer;
+
+  const issuerKeywordRecord = harden({ Underlying: uIssuer });
+
+  const mockCosmos = Far(
+    'cosmos',
+    /** @type {{getAccountState: (address: Address) => {total: Amount,
+     * bonded: Amount, locked: Amount, currentTime: Timestamp}}} */ ({
+      getAccountState: () => {
+        return harden({
+          total: AmountMath.make(uBrand, 500n),
+          bonded: AmountMath.make(uBrand, 200n),
+          locked: AmountMath.make(uBrand, 10n),
+          currentTime: 10n,
+        });
+      },
+    }),
+  );
+
+  const customTerms = harden({
+    authority: mockCosmos,
+    expiringAttName: 'BldAttGov',
+    returnableAttName: 'BldAttLoc',
+  });
+
+  const { publicFacet, creatorFacet } = await E(zoe).startInstance(
+    installation,
+    issuerKeywordRecord,
+    customTerms,
+  );
+
+  const brands = await E(publicFacet).getBrands();
+  const issuers = await E(publicFacet).getIssuers();
+
+  const address1 = 'address1';
+
+  /** @type {AttMaker} */
+  const attMaker = await E(creatorFacet).getAttMaker(address1);
+
+  // Try to make a lien greater than the total
+  const largeAmount = AmountMath.make(uBrand, 1000n);
+  const longExpiration = 100n;
+  const shortExpiration = 15n;
+  await t.throwsAsync(
+    () => E(attMaker).makeAttestations(largeAmount, shortExpiration),
+    {
+      message:
+        'Only {"brand":"[Alleged: BLD brand]","value":"[500n]"} was unliened, but an attestation was attempted for {"brand":"[Alleged: BLD brand]","value":"[1000n]"}',
+    },
+  );
+
+  // Try to make a lien with an already expired expiration
+  const amount50 = AmountMath.make(uBrand, 50n);
+  const expiredExpiration = 1n;
+  await t.throwsAsync(
+    () => E(attMaker).makeAttestations(amount50, expiredExpiration),
+    { message: 'Expiration "[1n]" must be after the current time "[10n]"' },
+  );
+
+  // check that no lien was successful so far
+  const liened = await E(creatorFacet).getLiened(harden([address1]), 10n);
+  t.deepEqual(liened, [AmountMath.makeEmpty(uBrand)]);
+
+  // Make a normal lien
+  const { returnable: returnable1, expiring: expiring1 } = await E(
+    attMaker,
+  ).makeAttestations(amount50, shortExpiration);
+
+  t.deepEqual(
+    await E(issuers.returnable).getAmountOf(returnable1),
+    AmountMath.make(brands.returnable, [
+      {
+        address: 'address1',
+        amountLiened: amount50,
+      },
+    ]),
+  );
+  const expiring1Amount = await E(issuers.expiring).getAmountOf(expiring1);
+  t.deepEqual(
+    expiring1Amount,
+    AmountMath.make(brands.expiring, [
+      {
+        address: 'address1',
+        amountLiened: amount50,
+        expiration: shortExpiration,
+        handle: expiring1Amount.value[0].handle,
+      },
+    ]),
+  );
+
+  const liened2 = await E(creatorFacet).getLiened(harden([address1]), 10n);
+  t.deepEqual(liened2, [amount50]);
+
+  // Make another normal lien
+
+  const amount25 = AmountMath.make(uBrand, 25n);
+  const { returnable: returnable2, expiring: expiring2 } = await E(
+    attMaker,
+  ).makeAttestations(amount25, longExpiration);
+
+  t.deepEqual(
+    await E(issuers.returnable).getAmountOf(returnable2),
+    AmountMath.make(brands.returnable, [
+      {
+        address: 'address1',
+        amountLiened: amount25,
+      },
+    ]),
+  );
+  const expiring2Amount = await E(issuers.expiring).getAmountOf(expiring2);
+  t.deepEqual(
+    expiring2Amount,
+    AmountMath.make(brands.expiring, [
+      {
+        address: 'address1',
+        amountLiened: amount25,
+        expiration: longExpiration,
+        handle: expiring2Amount.value[0].handle,
+      },
+    ]),
+  );
+  t.not(expiring1Amount.value[0].handle, expiring2Amount.value[0].handle);
+
+  const liened3 = await E(creatorFacet).getLiened(harden([address1]), 10n);
+  t.deepEqual(liened3, [AmountMath.add(amount50, amount25)]);
+
+  const returnAttestation = async att => {
+    const invitation = E(publicFacet).makeReturnAttInvitation();
+    const attestationAmount = await E(issuers.returnable).getAmountOf(att);
+    const proposal = harden({ give: { Attestation: attestationAmount } });
+    const payments = harden({ Attestation: att });
+    const userSeat = E(zoe).offer(invitation, proposal, payments);
+    const payout = await E(userSeat).getPayouts();
+    const amounts = await Promise.all(
+      Object.values(payout).map(paymentP =>
+        E(issuers.returnable).getAmountOf(paymentP),
+      ),
+    );
+    t.true(
+      amounts.every(amount => AmountMath.isEmpty(amount, brands.returnable)),
+    );
+    return userSeat;
+  };
+
+  // Return returnable1 for 50 bld
+  await returnAttestation(returnable1);
+
+  // Total liened amount should not change because there are
+  // outstanding expiring attestations
+  const liened4 = await E(creatorFacet).getLiened(harden([address1]), 10n);
+  t.deepEqual(liened4, [AmountMath.add(amount50, amount25)]);
+
+  // Move the currentTime forward so the shortExpiration attestation
+  // expires (50 bld)
+  const liened5 = await E(creatorFacet).getLiened(harden([address1]), 16n);
+  t.deepEqual(liened5, [amount25]); // the amount50 lien expired, leaving 25
+
+  // Move the currentTime forward so the longExpiration attestation
+  // expires. This should not change the total liened because there is
+  // an outstanding returnable attestation
+  const liened6 = await E(creatorFacet).getLiened(harden([address1]), 101n);
+  t.deepEqual(liened6, [amount25]);
+
+  // Return the last returnable attestation for 25
+  await returnAttestation(returnable2);
+
+  // Now the liened Amount should be empty
+  const liened7 = await E(creatorFacet).getLiened(harden([address1]), 101n);
+  t.deepEqual(liened7, [AmountMath.makeEmpty(uBrand)]);
+});
+
+// TODO: test with various unexpected or strange values from
+// E(cosmos).getAccountState(). Possibly better suited as a unit test
+// with `assertPrerequisites`
+
+// TODO: test slashed from the creatorFacet
+// TODO: test extending the invitations from the creatorFacet

--- a/packages/zoe/test/unitTests/contracts/attestation/test-attestation.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/test-attestation.js
@@ -74,7 +74,7 @@ test('attestation contract basic tests', async t => {
     () => E(attMaker).makeAttestations(largeAmount, shortExpiration),
     {
       message:
-        'Only \'{"brand":"[Alleged: BLD brand]","value":"[500n]"}\' was unliened, but an attestation was attempted for \'{"brand":"[Alleged: BLD brand]","value":"[1000n]"}\'',
+        'Only {"brand":"[Alleged: BLD brand]","value":"[500n]"} was unliened, but an attestation was attempted for {"brand":"[Alleged: BLD brand]","value":"[1000n]"}',
     },
   );
 
@@ -83,7 +83,7 @@ test('attestation contract basic tests', async t => {
   const expiredExpiration = 1n;
   await t.throwsAsync(
     () => E(attMaker).makeAttestations(amount50, expiredExpiration),
-    { message: "Expiration '1' must be after the current time '10'" },
+    { message: 'Expiration "[1n]" must be after the current time "[10n]"' },
   );
 
   // check that no lien was successful so far
@@ -271,8 +271,7 @@ test('attestation contract basic tests', async t => {
   // Now try to extend the expiration. This will fail.
   const { userSeat } = await doExtendExpiration(expiring4, 105n);
   await t.throwsAsync(() => E(userSeat).getOfferResult(), {
-    message:
-      "The address 'address1' cannot extend the expiration for attestations",
+    message: `The address "address1" cannot extend the expiration for attestations`,
   });
 });
 

--- a/packages/zoe/test/unitTests/contracts/attestation/test-attestation.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/test-attestation.js
@@ -31,7 +31,7 @@ test('attestation contract basic tests', async t => {
 
   let currentTime = 10n;
 
-  const mockCosmos = Far(
+  const mockAuthority = Far(
     'stakeReporter',
     /** @type {{getAccountState: (address: Address, brand: Brand) => {total: Amount,
      * bonded: Amount, locked: Amount, currentTime: Timestamp}}} */ ({
@@ -47,7 +47,6 @@ test('attestation contract basic tests', async t => {
   );
 
   const customTerms = harden({
-    authority: mockCosmos,
     expiringAttName: 'BldAttGov',
     returnableAttName: 'BldAttLoc',
   });
@@ -58,6 +57,7 @@ test('attestation contract basic tests', async t => {
     customTerms,
   );
 
+  await E(creatorFacet).addAuthority(mockAuthority);
   const brands = await E(publicFacet).getBrands();
   const issuers = await E(publicFacet).getIssuers();
 

--- a/packages/zoe/test/unitTests/contracts/attestation/test-attestation.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/test-attestation.js
@@ -74,7 +74,7 @@ test('attestation contract basic tests', async t => {
     () => E(attMaker).makeAttestations(largeAmount, shortExpiration),
     {
       message:
-        'Only {"brand":"[Alleged: BLD brand]","value":"[500n]"} was unliened, but an attestation was attempted for {"brand":"[Alleged: BLD brand]","value":"[1000n]"}',
+        'Only \'{"brand":"[Alleged: BLD brand]","value":"[500n]"}\' was unliened, but an attestation was attempted for \'{"brand":"[Alleged: BLD brand]","value":"[1000n]"}\'',
     },
   );
 
@@ -83,7 +83,7 @@ test('attestation contract basic tests', async t => {
   const expiredExpiration = 1n;
   await t.throwsAsync(
     () => E(attMaker).makeAttestations(amount50, expiredExpiration),
-    { message: 'Expiration "[1n]" must be after the current time "[10n]"' },
+    { message: "Expiration '1' must be after the current time '10'" },
   );
 
   // check that no lien was successful so far
@@ -272,7 +272,7 @@ test('attestation contract basic tests', async t => {
   const { userSeat } = await doExtendExpiration(expiring4, 105n);
   await t.throwsAsync(() => E(userSeat).getOfferResult(), {
     message:
-      'The address "address1" cannot extend the expiration for attestations',
+      "The address 'address1' cannot extend the expiration for attestations",
   });
 });
 

--- a/packages/zoe/test/unitTests/contracts/attestation/test-exampleVotingUsage.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/test-exampleVotingUsage.js
@@ -1,0 +1,82 @@
+// @ts-check
+
+/* global __dirname */
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+import { makeIssuerKit, AssetKind, AmountMath } from '@agoric/ertp';
+
+import bundleSource from '@agoric/bundle-source';
+import { E } from '@agoric/eventual-send';
+
+import { makeZoe } from '../../../../src/zoeService/zoe';
+import fakeVatAdmin from '../../../../tools/fakeVatAdmin';
+import { makeAttestationElem } from '../../../../src/contracts/attestation/expiring/expiringHelpers';
+import { makeHandle } from '../../../../src/makeHandle';
+
+const exampleVotingUsageRoot = `${__dirname}/exampleVotingUsage`;
+
+test('exampleVotingUsage', async t => {
+  const bundle = await bundleSource(exampleVotingUsageRoot);
+
+  const zoe = makeZoe(fakeVatAdmin);
+  const installation = await E(zoe).install(bundle);
+
+  const bldIssuerKit = makeIssuerKit('BLD', AssetKind.NAT, {
+    decimalPlaces: 6,
+  });
+
+  const issuerKit = makeIssuerKit('BLD-ATT-GOV', AssetKind.SET);
+
+  const { creatorFacet, publicFacet } = await E(zoe).startInstance(
+    installation,
+    {
+      Attestation: issuerKit.issuer,
+    },
+  );
+
+  const doVote = (attAmount, answer) => {
+    const voteInvitation = E(publicFacet).makeVoteInvitation();
+
+    const proposal = harden({
+      give: { Attestation: attAmount },
+    });
+
+    const payments = harden({
+      Attestation: issuerKit.mint.mintPayment(attAmount),
+    });
+    const seat = E(zoe).offer(voteInvitation, proposal, payments);
+    const offerResult = E(seat).getOfferResult();
+    return E(offerResult).castVote(answer);
+  };
+
+  // A normal vote which is weighted at 40 tokens and expires at 5n
+  const firstHandle = makeHandle('attestation');
+  const bld40 = AmountMath.make(bldIssuerKit.brand, 40n);
+  const elem1 = makeAttestationElem('myaddress', bld40, 5n, firstHandle);
+  await doVote(AmountMath.make(issuerKit.brand, [elem1]), 'Yes');
+
+  // Another vote, but which expires at 1n
+  const secondHandle = makeHandle('attestation');
+  const bld3 = AmountMath.make(bldIssuerKit.brand, 3n);
+  const elem2 = makeAttestationElem('myaddress', bld3, 1n, secondHandle);
+  await doVote(AmountMath.make(issuerKit.brand, [elem2]), 'No');
+
+  // Let's decide to trade that attestation in for one with a longer
+  // expiration. Note that the handle and the value are the same.
+  const elem3 = makeAttestationElem('myaddress', bld3, 4n, secondHandle);
+  await doVote(AmountMath.make(issuerKit.brand, [elem3]), 'Maybe');
+
+  // This vote should not be counted as it is expired.
+  const thirdHandle = makeHandle('attestation');
+  const bld5 = AmountMath.make(bldIssuerKit.brand, 5n);
+  const elem4 = makeAttestationElem('myaddress', bld5, 1n, thirdHandle);
+  await doVote(AmountMath.make(issuerKit.brand, [elem4]), 'Should not count');
+
+  const result = await E(creatorFacet).closeVote(3n);
+
+  t.deepEqual(result, [
+    ['Yes', 40n],
+    ['Maybe', 3n],
+  ]);
+});

--- a/packages/zoe/test/unitTests/contracts/attestation/test-exampleVotingUsage.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/test-exampleVotingUsage.js
@@ -26,7 +26,7 @@ test('exampleVotingUsage', async t => {
     decimalPlaces: 6,
   });
 
-  const issuerKit = makeIssuerKit('BLD-ATT-GOV', AssetKind.SET);
+  const issuerKit = makeIssuerKit('BldAttGov', AssetKind.SET);
 
   const { creatorFacet, publicFacet } = await E(zoe).startInstance(
     installation,

--- a/packages/zoe/test/unitTests/contracts/escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/escrowToVote.js
@@ -70,7 +70,7 @@ const start = zcf => {
         } else {
           seatToResponse.init(voterSeat, response);
         }
-        return `Successfully voted ${response}`;
+        return `Successfully voted '${response}'`;
       },
     });
     return voter;

--- a/packages/zoe/test/unitTests/contracts/escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/escrowToVote.js
@@ -70,7 +70,7 @@ const start = zcf => {
         } else {
           seatToResponse.init(voterSeat, response);
         }
-        return `Successfully voted '${response}'`;
+        return `Successfully voted ${response}`;
       },
     });
     return voter;


### PR DESCRIPTION
TLDR: Adds an attestation contract that handles both expiring attestations and attestations that have to be returned for a lien to be lifted.

## Intended Usage
The attestation contract exports a `creatorFacet` and a `publicFacet`. The `creatorFacet` is intended to be used by bootstrap.js and whatever middleware we create to talk to cosmos. 

### CreatorFacet Usage
`E(creatorFacet).getAttMaker(address)` is intended to be called by `createUserBundle` to create an object (`attMaker`) for the user similar to the bank object. The `attMaker` allows a user to create attestations, therefore taking out a lien on a certain amount of underlying BLD. Two kinds of attestations are made at a time: an "expiring" attestation that can be used for weighting votes in governance contracts, and a "returnable" attestation that can be used as collateral. Each of these types is separately importable and tested extensively.

`slashed` and `getLiened` are intended to be called by the cosmos layer (or middleware on behalf of cosmos).

## PublicFacet Usage

The `publicFacet` is intended to be called by users generally. With the `publicFacet`, a user can only get the attestation brands and attestation issuers, or create an invitation for themselves. There are two kinds of invitations that can be made: one for extending an already existing expiring attestation, and another for returning a returnable attestation. Note that using these invitations requires that an attestation of the appropriate brand is escrowed in the offer.

## Usage in contracts

In this PR, there is an example voting contract that uses the expiring attestation, with tests. The use of the returnable attestation as collateral is outlined in comments, but no code or tests.

## Reusability

The attestation contract itself probably has limited reusability, given the specifics of cosmos prerequisites and that both kinds of attestations are returned. However, each kind of attestation is highly reusable and has been put into its own importable file and has unit tests.

TODO:

- [x] Further discussion
- [x] Tests of the contract
~~Integration with bootstrap.js, wallet, cosmos~~ Not in this PR

Closes #3282 