### PR TITLE
fix(SwingSet): improve slogging during replay

### DIFF
--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -140,6 +140,7 @@ export default function buildKernel(
 
   const vatAdminRootKref = hostStorage.kvStore.get('vatAdminRootKref');
 
+  /** @type { KernelSlog } */
   const kernelSlog = writeSlogObject
     ? makeSlogger(slogCallbacks, writeSlogObject)
     : makeDummySlogger(slogCallbacks, makeConsole);
@@ -430,8 +431,7 @@ export default function buildKernel(
     const crankNum = kernelKeeper.getCrankNumber();
     const deliveryNum = vatKeeper.nextDeliveryNum(); // increments
     const { meterID } = vatKeeper.getOptions();
-    /** @typedef { any } FinishFunction TODO: static types for slog? */
-    /** @type { FinishFunction } */
+    /** @type { SlogFinishDelivery } */
     const finish = kernelSlog.delivery(vatID, crankNum, deliveryNum, kd, vd);
     // Ensure that the vatSlogger is available before clist translation.
     kernelSlog.provideVatSlogger(vatID);
@@ -872,7 +872,7 @@ export default function buildKernel(
         // we leave this catch() with ksc=undefined, so no doKernelSyscall()
       }
 
-      /** @type { FinishFunction } */
+      /** @type { SlogFinishSyscall } */
       const finish = kernelSlog.syscall(vatID, ksc, vatSyscallObject);
 
       if (ksc) {

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -854,6 +854,9 @@ export default function buildKernel(
         return harden(['error', problem]);
       }
       let ksc;
+      let kres;
+      let vres;
+
       try {
         // This can fail if the vat asks for something not on their clist, or
         // their syscall doesn't make sense in some other way, or due to a
@@ -865,34 +868,39 @@ export default function buildKernel(
         console.log(`error during syscall translation:`, vaterr);
         const problem = 'syscall translation error: prepare to die';
         setTerminationTrigger(vatID, true, true, makeError(problem));
-        return harden(['error', problem]);
+        vres = harden(['error', problem]);
+        // we leave this catch() with ksc=undefined, so no doKernelSyscall()
       }
 
       /** @type { FinishFunction } */
       const finish = kernelSlog.syscall(vatID, ksc, vatSyscallObject);
-      let vres;
-      try {
-        // this can fail if kernel or device code is buggy
-        const kres = kernelSyscallHandler.doKernelSyscall(ksc);
-        // kres is a KernelResult ([successFlag, value]), but since errors
-        // here are signalled with exceptions, kres is ['ok', value]. Vats
-        // (liveslots) record the response in the transcript (which is why we
-        // use 'null' instead of 'undefined', TODO clean this up), but otherwise
-        // most syscalls ignore it. The one syscall that pays attention is
-        // callNow(), which assumes it's capdata.
-        vres = translators.kernelSyscallResultToVatSyscallResult(ksc[0], kres);
-        // here, vres is either ['ok', null] or ['ok', capdata]
-        finish(kres, vres); // TODO call meaningfully on failure too?
-      } catch (err) {
-        // kernel/device errors cause a kernel panic
-        panic(`error during syscall/device.invoke: ${err}`, err);
-        // the kernel is now in a shutdown state, but it may take a while to
-        // grind to a halt
-        const problem = 'you killed my kernel. prepare to die';
-        setTerminationTrigger(vatID, true, true, makeError(problem));
-        return harden(['error', problem]);
-      }
 
+      if (ksc) {
+        try {
+          // this can fail if kernel or device code is buggy
+          kres = kernelSyscallHandler.doKernelSyscall(ksc);
+          // kres is a KernelResult ([successFlag, value]), but since errors
+          // here are signalled with exceptions, kres is ['ok', value]. Vats
+          // (liveslots) record the response in the transcript (which is why we
+          // use 'null' instead of 'undefined', TODO clean this up), but otherwise
+          // most syscalls ignore it. The one syscall that pays attention is
+          // callNow(), which assumes it's capdata.
+          vres = translators.kernelSyscallResultToVatSyscallResult(
+            ksc[0],
+            kres,
+          );
+          // here, vres is either ['ok', null] or ['ok', capdata]
+        } catch (err) {
+          // kernel/device errors cause a kernel panic
+          panic(`error during syscall/device.invoke: ${err}`, err);
+          // the kernel is now in a shutdown state, but it may take a while to
+          // grind to a halt
+          const problem = 'you killed my kernel. prepare to die';
+          setTerminationTrigger(vatID, true, true, makeError(problem));
+          vres = harden(['error', problem]);
+        }
+      }
+      finish(kres, vres);
       return vres;
     }
     return vatSyscallHandler;

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -428,18 +428,13 @@ export default function buildKernel(
     // eslint-disable-next-line no-use-before-define
     assert(vatWarehouse.lookup(vatID));
     const vatKeeper = kernelKeeper.provideVatKeeper(vatID);
-    const crankNum = kernelKeeper.getCrankNumber();
-    const deliveryNum = vatKeeper.nextDeliveryNum(); // increments
     const { meterID } = vatKeeper.getOptions();
-    /** @type { SlogFinishDelivery } */
-    const finish = kernelSlog.delivery(vatID, crankNum, deliveryNum, kd, vd);
     // Ensure that the vatSlogger is available before clist translation.
-    kernelSlog.provideVatSlogger(vatID);
+    const vs = kernelSlog.provideVatSlogger(vatID).vatSlog;
     try {
       // eslint-disable-next-line no-use-before-define
-      const deliveryResult = await vatWarehouse.deliverToVat(vatID, vd);
+      const deliveryResult = await vatWarehouse.deliverToVat(vatID, kd, vd, vs);
       insistVatDeliveryResult(deliveryResult);
-      finish(deliveryResult);
       const [status, problem] = deliveryResult;
       if (status !== 'ok') {
         // probably a metering fault, or a bug in the vat's dispatch()

--- a/packages/SwingSet/src/kernel/slogger.js
+++ b/packages/SwingSet/src/kernel/slogger.js
@@ -137,12 +137,12 @@ export function makeSlogger(slogCallbacks, writeObj) {
     }
 
     // kd: kernelDelivery, vd: vatDelivery
-    function delivery(newCrankNum, newDeliveryNum, kd, vd) {
+    function delivery(newCrankNum, newDeliveryNum, kd, vd, replay = false) {
       assertOldState(IDLE, 'reentrant delivery?');
       state = DELIVERY;
       crankNum = newCrankNum;
       deliveryNum = newDeliveryNum;
-      const when = { crankNum, vatID, deliveryNum };
+      const when = { crankNum, vatID, deliveryNum, replay };
       write({ type: 'deliver', ...when, kd, vd });
       syscallNum = 0;
 

--- a/packages/SwingSet/src/kernel/slogger.js
+++ b/packages/SwingSet/src/kernel/slogger.js
@@ -77,6 +77,12 @@ function makeCallbackRegistry(callbacks) {
   });
 }
 
+/**
+ *
+ * @param {*} slogCallbacks
+ * @param {*} makeConsole
+ * @returns { KernelSlog }
+ */
 export function makeDummySlogger(slogCallbacks, makeConsole) {
   const { registerCallback: reg, doneRegistering } = makeCallbackRegistry(
     slogCallbacks,
@@ -96,6 +102,12 @@ export function makeDummySlogger(slogCallbacks, makeConsole) {
   return dummySlogger;
 }
 
+/**
+ *
+ * @param {*} slogCallbacks
+ * @param {*} writeObj
+ * @returns { KernelSlog }
+ */
 export function makeSlogger(slogCallbacks, writeObj) {
   const write = writeObj ? e => writeObj(e) : () => 0;
 

--- a/packages/SwingSet/src/kernel/slogger.js
+++ b/packages/SwingSet/src/kernel/slogger.js
@@ -88,7 +88,13 @@ export function makeDummySlogger(slogCallbacks, makeConsole) {
     slogCallbacks,
   );
   const dummySlogger = harden({
-    provideVatSlogger: reg('provideVatSlogger', () => 0),
+    provideVatSlogger: reg('provideVatSlogger', () =>
+      harden({
+        vatSlog: {
+          delivery: () => () => 0,
+        },
+      }),
+    ),
     vatConsole: reg('vatConsole', () => makeConsole('disabled slogger')),
     startup: reg('startup', () => () => 0), // returns nop finish() function
     replayVatTranscript: reg('replayVatTranscript', () => () => 0),

--- a/packages/SwingSet/src/types.js
+++ b/packages/SwingSet/src/types.js
@@ -98,8 +98,8 @@
  * @typedef { [tag: 'send', target: string, msg: Message] } VatSyscallSend
  * @typedef { [tag: 'callNow', target: string, method: string, args: SwingSetCapData]} VatSyscallCallNow
  * @typedef { [tag: 'subscribe', vpid: string ]} VatSyscallSubscribe
- * @typedef { [ vpid: string, rejected: boolean, data: SwingSetCapData ]} Resolutions
- * @typedef { [tag: 'resolve', resolutions: Resolutions ]} VatSyscallResolve
+ * @typedef { [ vpid: string, rejected: boolean, data: SwingSetCapData ]} VatResolutions
+ * @typedef { [tag: 'resolve', resolutions: VatResolutions ]} VatSyscallResolve
  * @typedef { [tag: 'vatstoreGet', key: string ]} VatSyscallVatstoreGet
  * @typedef { [tag: 'vatstoreSet', key: string, data: string ]} VatSyscallVatstoreSet
  * @typedef { [tag: 'vatstoreDelete', key: string ]} VatSyscallVatstoreDelete
@@ -118,13 +118,61 @@
  * @typedef { VatSyscallResultOk | VatSyscallResultError } VatSyscallResult
  * @typedef { (vso: VatSyscallObject) => VatSyscallResult } VatSyscaller
  *
+ * @typedef { [tag: 'message', target: string, msg: Message]} KernelDeliveryMessage
+ * @typedef { [tag: 'notify', resolutions: string[] ]} KernelDeliveryNotify
+ * @typedef { [tag: 'dropExports', krefs: string[] ]} KernelDeliveryDropExports
+ * @typedef { [tag: 'retireExports', krefs: string[] ]} KernelDeliveryRetireExports
+ * @typedef { [tag: 'retireImports', krefs: string[] ]} KernelDeliveryRetireImports
+ * @typedef { KernelDeliveryMessage | KernelDeliveryNotify | KernelDeliveryDropExports
+ *            | KernelDeliveryRetireExports | KernelDeliveryRetireImports
+ *          } KernelDeliveryObject
+ * @typedef { [tag: 'send', target: string, msg: Message] } KernelSyscallSend
+ * @typedef { [tag: 'callNow', target: string, method: string, args: SwingSetCapData]} KernelSyscallCallNow
+ * @typedef { [tag: 'subscribe', kpid: string ]} KernelSyscallSubscribe
+ * @typedef { [ kpid: string, rejected: boolean, data: SwingSetCapData ]} KernelResolutions
+ * @typedef { [tag: 'resolve', resolutions: KernelResolutions ]} KernelSyscallResolve
+ * @typedef { [tag: 'vatstoreGet', key: string ]} KernelSyscallVatstoreGet
+ * @typedef { [tag: 'vatstoreSet', key: string, data: string ]} KernelSyscallVatstoreSet
+ * @typedef { [tag: 'vatstoreDelete', key: string ]} KernelSyscallVatstoreDelete
+ * @typedef { [tag: 'dropImports', krefs: string[] ]} KernelSyscallDropImports
+ * @typedef { [tag: 'retireImports', krefs: string[] ]} KernelSyscallRetireImports
+ * @typedef { [tag: 'retireExports', krefs: string[] ]} KernelSyscallRetireExports
+ *
+ * @typedef { KernelSyscallSend | KernelSyscallCallNow | KernelSyscallSubscribe
+ *    | KernelSyscallResolve | KernelSyscallVatstoreGet | KernelSyscallVatstoreSet
+ *    | KernelSyscallVatstoreDelete | KernelSyscallDropImports
+ *    | KernelSyscallRetireImports | KernelSyscallRetireExports
+ * } KernelSyscallObject
+ * @typedef { [tag: 'ok', data: SwingSetCapData | string | null ]} KernelSyscallResultOk
+ * @typedef { [tag: 'error', err: string ] } KernelSyscallResultError
+ * @typedef { KernelSyscallResultOk | KernelSyscallResultError } KernelSyscallResult
+ *
  * @typedef { { d: VatDeliveryObject, syscalls: VatSyscallObject[] } } TranscriptEntry
  * @typedef { { transcriptCount: number } } VatStats
  * @typedef { ReturnType<typeof import('./kernel/state/vatKeeper').makeVatKeeper> } VatKeeper
  * @typedef { ReturnType<typeof import('./kernel/state/kernelKeeper').default> } KernelKeeper
  * @typedef { ReturnType<typeof import('@agoric/xsnap').xsnap> } XSnap
+ * @typedef { (dr: VatDeliveryResult) => void } SlogFinishDelivery
+ * @typedef { (ksr: KernelSyscallResult, vsr: VatSyscallResult) => void } SlogFinishSyscall
  * @typedef { { write: ({}) => void,
+ *              vatConsole: (vatID: string, origConsole: {}) => {},
+ *              delivery: (vatID: string,
+ *                         newCrankNum: BigInt, newDeliveryNum: BigInt,
+ *                         kd: KernelDeliveryObject, vd: VatDeliveryObject,
+ *                         replay?: boolean) => SlogFinishDelivery,
+ *              syscall: (vatID: string,
+ *                        ksc: KernelSyscallObject | undefined,
+ *                        vsc: VatSyscallObject) => SlogFinishSyscall,
+ *              provideVatSlogger: (vatID: string,
+ *                                  dynamic?: boolean,
+ *                                  description?: string,
+ *                                  name?: string,
+ *                                  vatSourceBundle?: *,
+ *                                  managerType?: string,
+ *                                  vatParameters?: *) => VatSlog,
+ *              terminateVat: (vatID: string, shouldReject: boolean, info: SwingSetCapData) => void,
  *             } } KernelSlog
+ * @typedef { * } VatSlog
  *
  * @typedef { { createFromBundle: (vatID: string,
  *                                 bundle: Bundle,


### PR DESCRIPTION
* during transcript replay, record (simulated) syscalls and delivery results
in the slog
  * previously we only recorded deliveries
  * this captures GC syscalls, to investigate divergence bugs
  * it also records metering results for the delivery, for the same reason
* during normal delivery, record syscall data even if the syscall fails
  * vat-fatal syscall errors, like dropping an object that was already
    retired, now capture the vat's attempted syscall, even if the translation
    into kernelspace failed, or the kernelSyscallHandler invocation failed
  * previously we lost all record of these syscall attempts, making it hard
    to debug the reason for vat termination
* slog entries for replayed deliveries/syscalls look just like the normal
  ones, but now have a `replay` boolean to distinguish the two
  * replayed deliveries do not have a `crankNum`, since we deliberately do
    not record that in the transcript, so we don't know the value during replay
* we compute a `deliveryNum` for each replayed message from the transcript
  position offset, which ought to match the original. This might need some
  refactoring to make fewer (or more) assumptions about the shape of a
  StreamPosition.

refs #3428 (not as a fix, but as a critical debugging tool)

