### PR TITLE
fix refcounts during comms addEgress

### DIFF
--- a/packages/SwingSet/src/vats/comms/clist-inbound.js
+++ b/packages/SwingSet/src/vats/comms/clist-inbound.js
@@ -121,8 +121,8 @@ export function makeInbound(state) {
       const doSetReachable = !allocatedByRecipient;
       if (doSetReachable) {
         // the remote is exporting, not importing
-        const isImport = false;
-        remote.setReachable(lref, isImport);
+        const isImportFromComms = false;
+        remote.setReachable(lref, isImportFromComms);
       }
       assert(remote.isReachable(lref), `remote using unreachable ${lref}`);
     }

--- a/packages/SwingSet/src/vats/comms/clist-kernel.js
+++ b/packages/SwingSet/src/vats/comms/clist-kernel.js
@@ -60,8 +60,8 @@ export function makeKernel(state, syscall) {
       const doSetReachable = allocatedByVat;
       if (doSetReachable) {
         // the kernel is an importer in this case
-        const isImport = true;
-        setReachable(lref, isImport);
+        const isImportFromComms = true;
+        setReachable(lref, isImportFromComms);
       }
       assert(isReachable(lref), X`comms sending unreachable ${lref}`);
     }
@@ -166,8 +166,8 @@ export function makeKernel(state, syscall) {
       const doSetReachable = !allocatedByVat;
       if (doSetReachable) {
         // the kernel is an exporter in this case
-        const isImport = false;
-        setReachable(lref, isImport);
+        const isImportFromComms = false;
+        setReachable(lref, isImportFromComms);
       }
       assert(isReachable(lref), `kernel using unreachable ${lref}`);
     }

--- a/packages/SwingSet/src/vats/comms/clist-outbound.js
+++ b/packages/SwingSet/src/vats/comms/clist-outbound.js
@@ -82,8 +82,8 @@ export function makeOutbound(state) {
       const doSetReachable = !allocatedByRecipient;
       if (doSetReachable) {
         // the remote is always importing it
-        const isImport = true;
-        remote.setReachable(lref, isImport);
+        const isImportFromComms = true;
+        remote.setReachable(lref, isImportFromComms);
         // This provideRemoteForLocal was called as part of translating a
         // message to send (either a delivery, in `sendToRemote()`, or a
         // resolution notification, in `resolveToRemote`). Both cases finish

--- a/packages/SwingSet/src/vats/comms/clist-xgress.js
+++ b/packages/SwingSet/src/vats/comms/clist-xgress.js
@@ -16,7 +16,7 @@ export function makeIngressEgress(state, provideLocalForRemote) {
     const inboundRRef = makeRemoteSlot('object', true, remoteRefID);
     remote.addRemoteMapping(inboundRRef, loid);
     remote.skipRemoteObjectID(remoteRefID);
-    const isImportFromComms = false; // bug 3483: this should be 'true'
+    const isImportFromComms = true;
     remote.setReachable(loid, isImportFromComms);
 
     // prettier-ignore

--- a/packages/SwingSet/src/vats/comms/clist-xgress.js
+++ b/packages/SwingSet/src/vats/comms/clist-xgress.js
@@ -16,8 +16,8 @@ export function makeIngressEgress(state, provideLocalForRemote) {
     const inboundRRef = makeRemoteSlot('object', true, remoteRefID);
     remote.addRemoteMapping(inboundRRef, loid);
     remote.skipRemoteObjectID(remoteRefID);
-    const isCommsImport = false;
-    remote.setReachable(loid, isCommsImport);
+    const isImportFromComms = false; // bug 3483: this should be 'true'
+    remote.setReachable(loid, isImportFromComms);
 
     // prettier-ignore
     cdebug(`comms add egress ${loid} to ${remoteID} in ${inboundRRef}`);

--- a/packages/SwingSet/src/vats/comms/gc-comms.js
+++ b/packages/SwingSet/src/vats/comms/gc-comms.js
@@ -110,8 +110,8 @@ function makeGCKit(state, syscall, transmit) {
       // kernel shouldn't double-drop
       assert(state.isReachableByKernel(lref), lref);
       // allocatedByVat means kernel is importing from comms
-      const isImport = true;
-      state.clearReachableByKernel(lref, isImport);
+      const isImportFromComms = true;
+      state.clearReachableByKernel(lref, isImportFromComms);
     }
     for (const kfref of retireExports) {
       const lref = checkFromKernel(kfref, true);
@@ -173,8 +173,8 @@ function makeGCKit(state, syscall, transmit) {
       const { lref, informed } = checkFromRemote(remote, ackSeqNum, rref);
       if (informed) {
         assert(remote.isReachable(lref)); // no double-drop
-        const isImport = true;
-        remote.clearReachable(lref, isImport);
+        const isImportFromComms = true;
+        remote.clearReachable(lref, isImportFromComms);
       }
     }
     for (const rref of retireExports) {
@@ -202,8 +202,9 @@ function makeGCKit(state, syscall, transmit) {
     let kfrefs = [];
     for (const lref of dropExports) {
       assert(state.isReachableByKernel(lref));
-      const isImport = false; // when we drop, kernel is always the exporter
-      state.clearReachableByKernel(lref, isImport);
+      // when we drop, kernel is always the exporter
+      const isImportFromComms = false;
+      state.clearReachableByKernel(lref, isImportFromComms);
       const kfref = state.mapToKernel(lref);
       assert(kfref);
       kfrefs.push(kfref);
@@ -246,8 +247,8 @@ function makeGCKit(state, syscall, transmit) {
 
     for (const lref of dropExports) {
       assert(r.isReachable(lref));
-      const isImport = false; // we send drops to the exporter
-      r.clearReachable(lref, isImport);
+      const isImportFromComms = false; // we send drops to the exporter
+      r.clearReachable(lref, isImportFromComms);
       const rref = r.mapToRemote(lref);
       assert(rref);
       msgs.push(`gc:dropExport:${rref}`);

--- a/packages/SwingSet/src/vats/comms/state.js
+++ b/packages/SwingSet/src/vats/comms/state.js
@@ -227,14 +227,14 @@ export function makeState(syscall, identifierBase = 0) {
   function changeRecognizable(lref, delta) {
     const key = `${lref}.recognizable`;
     const recognizable = Nat(BigInt(store.getRequired(key))) + delta;
-    store.set(key, `${recognizable}`);
+    store.set(key, `${Nat(recognizable)}`);
     return recognizable;
   }
 
   function changeReachable(lref, delta) {
     const key = `${lref}.reachable`;
     const reachable = Nat(BigInt(store.getRequired(key))) + delta;
-    store.set(key, `${reachable}`);
+    store.set(key, `${Nat(reachable)}`);
     return reachable;
   }
 
@@ -260,7 +260,7 @@ export function makeState(syscall, identifierBase = 0) {
     if (type === 'promise') {
       const refCount = parseInt(store.get(`${lref}.refCount`), 10) + 1;
       // cdebug(`++ ${lref}  ${tag} ${refCount}`);
-      store.set(`${lref}.refCount`, `${refCount}`);
+      store.set(`${lref}.refCount`, `${Nat(refCount)}`);
     }
     if (type === 'object') {
       if (mode === 'clist-import' || mode === 'data') {
@@ -288,7 +288,7 @@ export function makeState(syscall, identifierBase = 0) {
       assert(refCount > 0n, X`refCount underflow {lref} ${tag}`);
       refCount -= 1;
       // cdebug(`-- ${lref}  ${tag} ${refCount}`);
-      store.set(`${lref}.refCount`, `${refCount}`);
+      store.set(`${lref}.refCount`, `${Nat(refCount)}`);
       if (refCount === 0) {
         // If we are still in the middle of a resolve operation, and this lref
         // is an ancillary promise that was briefly added to the decider's

--- a/packages/SwingSet/src/vats/comms/state.js
+++ b/packages/SwingSet/src/vats/comms/state.js
@@ -319,6 +319,14 @@ export function makeState(syscall, identifierBase = 0) {
     }
   }
 
+  function getRefCounts(lref) {
+    const reaKey = `${lref}.reachable`;
+    const reachable = Nat(BigInt(store.getRequired(reaKey)));
+    const recKey = `${lref}.recognizable`;
+    const recognizable = Nat(BigInt(store.getRequired(recKey)));
+    return { reachable, recognizable };
+  }
+
   /**
    * Delete any local promises that have zero references. Return a list of
    * work for unreachable/unrecognizable objects.
@@ -748,6 +756,7 @@ export function makeState(syscall, identifierBase = 0) {
     lrefMightBeFree,
     incrementRefCount,
     decrementRefCount,
+    getRefCounts,
     processMaybeFree,
 
     deciderIsKernel,


### PR DESCRIPTION
The comms `addEgress` function was calling `setReachable` with the wrong value for `isImportFromComms`. When we add an egress, the kernel is exporting an object into comms, and comms is exporting that to the downstream machine. So the downstream machine is *importing* it from comms (which means the `isReachable` flag causes the `reachable` refcount to be increased, something that only happens on imports, not on the export).

This caused the object being exported through `addEgress` to have a zero refcount. If/when the downstream machine ever dropped it, the refcount would go negative, causing an error.

fixes #3483

I recommend reviewing this one commit at a time. The second commit is a non-behavior-changing renaming which would distract from the important changes.
