### PR TITLE
liveslots: don't pin the interior queueMessage promise

### DIFF
--- a/packages/SwingSet/test/gc/bootstrap.js
+++ b/packages/SwingSet/test/gc/bootstrap.js
@@ -5,10 +5,12 @@ export function buildRootObject() {
   let A = Far('A', { hello() {} });
   let B = Far('B', { hello() {} });
   let target;
+  let zoe;
 
   return Far('root', {
     async bootstrap(vats) {
       target = vats.target;
+      zoe = vats.zoe;
     },
     async one() {
       await E(target).two(A, B);
@@ -16,6 +18,10 @@ export function buildRootObject() {
     drop() {
       A = null;
       B = null;
+    },
+
+    async makeInvitation0() {
+      await E(target).makeInvitationTarget(zoe);
     },
   });
 }

--- a/packages/SwingSet/test/gc/vat-fake-zoe.js
+++ b/packages/SwingSet/test/gc/vat-fake-zoe.js
@@ -1,0 +1,10 @@
+import { Far } from '@agoric/marshal';
+
+export function buildRootObject() {
+  const C = Far('Zoe Invitation payment', { hello() {} });
+  return Far('root', {
+    async makeInvitationZoe() {
+      return C;
+    },
+  });
+}

--- a/packages/SwingSet/test/gc/vat-target.js
+++ b/packages/SwingSet/test/gc/vat-target.js
@@ -7,5 +7,9 @@ export function buildRootObject() {
       // A=ko26 B=ko27
       await E(A).hello(B);
     },
+
+    makeInvitationTarget(zoe) {
+      return E(zoe).makeInvitationZoe();
+    },
   });
 }

--- a/packages/SwingSet/test/vat-controller-1.js
+++ b/packages/SwingSet/test/vat-controller-1.js
@@ -3,8 +3,10 @@ import { extractMessage } from './util';
 
 export default function setup(syscall, _state, _helpers, vatPowers) {
   function dispatch(vatDeliverObject) {
-    const { facetID, method, args } = extractMessage(vatDeliverObject);
-    vatPowers.testLog(JSON.stringify({ target: facetID, method, args }));
+    if (vatDeliverObject[0] === 'message') {
+      const { facetID, method, args } = extractMessage(vatDeliverObject);
+      vatPowers.testLog(JSON.stringify({ target: facetID, method, args }));
+    }
   }
   return dispatch;
 }


### PR DESCRIPTION
'makeImportedPromise' was originally just for imported promises, but was soon
recruited to supply the result promises that come back from E() eventual-send
operations too. During this transition, the responsibility for registering
and retaining the returned Promise got fuzzy. When slotToVal was changed to
use a WeakRef instead of a strong reference, the `pendingPromises` set was
[introduced](fe93b3dba3b023e0d8255584add3aabaf11dfea1) to keep these alive
until they got resolved.

During that process, I went too far and changed `queueMessage` to stash its
interior `p` Promise in `pendingPromises`. This is the HandledPromise that
enables messages to be pipelined to the future result of the `queueMessage`
invocation, but it is *not* the one provided to userspace (HP's handlers are
invoked a turn later, to prevent a reentrancy hazard, so the
userspace-visible Promise has come and gone by the time `queueMessage` runs).
That userspace promise is registered under the result vpid, and kept alive
with `pendingPromises`, and resolved when a `dispatch.notify` arrives, but
the interior `p` promise needs none of those things.

By adding `p` to `pendingPromises` but not registering it for processing
during `dispatch.notify`, it was kept alive forever, even after being
resolved. And a resolved Promise necessarily keeps its resolution value
alive. The consequence was that any Presence returned through the result of
off-vat E() call was kept alive forever, and never made available for garbage
collection.

The fix is to refactor the code slightly. We rename `makeImportedPromise` to
`makePipelinablePromise` to make it clear that the function is not only for
promise imports. We stop using `pendingPromises` to pin the return value of
`makePipelinablePromise`, and leave that up to the caller. When that caller
is `convertValToSlot` (the original imported promise case), we add a
`pendingPromises.add` to pin those promises. When the caller is
`queueMessage`, we continue to not pin the interior `p`.

This was a liveslots bug, and not specific to XS or V8.

fixes #3482
