### PR TITLE
Only format /dev/sda if we are deploying to DigitalOcean

### DIFF
--- a/packages/deployment/ansible/roles/prereq/tasks/main.yml
+++ b/packages/deployment/ansible/roles/prereq/tasks/main.yml
@@ -20,25 +20,30 @@
     - xfsprogs
     - "nodejs={{ NODEJS_VERSION }}.*"
 
-- name: Stat /dev/sda
-  stat:
-    path: /dev/sda
-  register: sda
+- name: Default home_dev for DigitalOcean
+  set_fact:
+    home_dev: /dev/sda
+  when: "home_dev is not defined and provider is defined and provider.startswith('digitalocean')"
 
-- name: Create /dev/sda with XFS
+- name: "Stat {{ home_dev }}"
+  stat:
+    path: "{{ home_dev | default('/nonexistent') }}"
+  register: hdev
+
+- name: "Format {{ home_dev }} with XFS"
   filesystem:
     fstype: xfs
-    dev: /dev/sda
-  when: sda.stat.exists
+    dev: "{{ home_dev }}"
+  when: hdev.stat.exists
 
-- name: Mount /dev/sda
+- name: "Mount {{ home_dev }}"
   mount:
     path: /home
-    src: /dev/sda
+    src: "{{ home_dev }}"
     fstype: auto
     state: mounted
-  when: sda.stat.exists
+  when: hdev.stat.exists
 
 - name: Resize /home with XFS
   shell: "xfs_growfs -n /home"
-  when: sda.stat.exists
+  when: hdev.stat.exists

--- a/packages/deployment/src/main.js
+++ b/packages/deployment/src/main.js
@@ -918,11 +918,12 @@ ${name}:
             // These are the validator params.
             roleParams = `
   moniker: Agoric${offset + instance}
-  website: https://testnet.agoric.com
+  website: https://testnet.agoric.net
   identity: https://keybase.io/team/agoric.testnet.validators`;
           }
           const host = `\
 ${node}:${roleParams}
+  provider: ${provider}
   ansible_host: ${ip}
   ansible_ssh_user: root
   ansible_ssh_private_key_file: '${keyFile}'

--- a/packages/deployment/src/main.js
+++ b/packages/deployment/src/main.js
@@ -85,7 +85,7 @@ const waitForStatus = ({ setup, running }) => async (
 };
 
 const provisionOutput = async ({ rd, wr, running }) => {
-  const jsonFile = `${PROVISION_DIR}/terraform.json`;
+  const jsonFile = `${PROVISION_DIR}/terraform-output.json`;
   await makeGuardFile({ rd, wr })(jsonFile, async makeFile => {
     const json = await running.needBacktick(`terraform output -json`);
     await makeFile(json);
@@ -859,11 +859,15 @@ ${chalk.yellow.bold(`ag-setup-solo --netconfig='${dwebHost}/network-config'`)}
 
     case 'provision': {
       await inited();
-      if (!(await rd.exists('.terraform'))) {
-        await needDoRun(['terraform', 'init']);
-      }
+
+      // Remove everything that provisioning affects.
+      await needDoRun(['rm', '-rf', PROVISION_DIR]);
+
+      // It is always safe to init.
+      await needDoRun(['terraform', 'init']);
+
+      // Apply the provisioning plan.
       await needDoRun(['terraform', 'apply', ...args.slice(1)]);
-      await needDoRun(['rm', '-f', `${PROVISION_DIR}/*.stamp`]);
       break;
     }
 


### PR DESCRIPTION
This fixes an overzealous `ag-setup-cosmos` script that would reformat and mount `/dev/sda` even if not on a terraformed DigitalOcean instance as intended.

The surprise was fortunately not fatal to @dckc's Docker host but was unnecessarily nerve-wracking.

Also tweak `ag-setup-cosmos provision` to properly update terraform and clear/rebuild derived state.
