### PR TITLE
fix(cosmic-swingset): use BOOTSTRAP_BLOCK to avoid slog confusion

### DIFF
--- a/golang/cosmos/x/swingset/genesis.go
+++ b/golang/cosmos/x/swingset/genesis.go
@@ -2,8 +2,10 @@ package swingset
 
 import (
 	// "fmt"
+	"encoding/json"
 	stdlog "log"
 
+	"github.com/Agoric/agoric-sdk/golang/cosmos/vm"
 	"github.com/Agoric/agoric-sdk/golang/cosmos/x/swingset/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -24,6 +26,12 @@ func DefaultGenesisState() *types.GenesisState {
 	return gs
 }
 
+type bootstrapBlockAction struct {
+	Type        string `json:"type"`
+	BlockTime   int64  `json:"blockTime"`
+	StoragePort int    `json:"storagePort"`
+}
+
 func InitGenesis(ctx sdk.Context, keeper Keeper, data *types.GenesisState) []abci.ValidatorUpdate {
 	var storage types.Storage
 	for key, value := range data.Storage {
@@ -34,13 +42,25 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, data *types.GenesisState) []abc
 	// Just run the SwingSet kernel to finish bootstrap and get ready to open for
 	// business.
 	stdlog.Println("Running SwingSet until bootstrap is ready")
-	bootstrapBlock := abci.RequestEndBlock{Height: ctx.BlockHeight()}
-	valUpdate, err := EndBlock(ctx, bootstrapBlock, keeper)
+	action := &bootstrapBlockAction{
+		Type:        "BOOTSTRAP_BLOCK",
+		BlockTime:   ctx.BlockTime().Unix(),
+		StoragePort: vm.GetPort("storage"),
+	}
+	b, err := json.Marshal(action)
 	if err != nil {
-		// Errors here are fatal.
 		panic(err)
 	}
-	return valUpdate
+
+	_, err = keeper.CallToController(ctx, string(b))
+
+	if err != nil {
+		// NOTE: A failed BOOTSTRAP_BLOCK means that the SwingSet state is inconsistent.
+		// Panic here, in the hopes that a replay from scratch will fix the problem.
+		panic(err)
+	}
+
+	return []abci.ValidatorUpdate{}
 }
 
 func ExportGenesis(ctx sdk.Context, k Keeper) *types.GenesisState {

--- a/packages/agoric-cli/lib/start.js
+++ b/packages/agoric-cli/lib/start.js
@@ -313,7 +313,6 @@ export default async function startMain(progname, rawArgs, powers, opts) {
     ]);
     const newGenesisJson = finishCosmosGenesis({
       genesisJson,
-      bootstrapAddress: addrs.provision,
     });
     const newConfigToml = finishTendermintConfig({
       configToml,

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -184,7 +184,7 @@ export async function launch(
     // entire bootstrap before opening for business.
     await crankScheduler(Infinity);
     controller.writeSlogObject({
-      type: 'cosmic-swingset-bootstrap-block-end',
+      type: 'cosmic-swingset-bootstrap-block-finish',
       blockTime,
     });
   }

--- a/packages/cosmic-swingset/src/sim-chain.js
+++ b/packages/cosmic-swingset/src/sim-chain.js
@@ -45,7 +45,7 @@ async function makeMapStorage(file) {
 }
 
 export async function connectToFakeChain(basedir, GCI, delay, inbound) {
-  const initialHeight = 1;
+  const initialHeight = 0;
   const mailboxFile = path.join(basedir, `fake-chain-${GCI}-mailbox.json`);
   const bootAddress = `${GCI}-client`;
 
@@ -58,9 +58,7 @@ export async function connectToFakeChain(basedir, GCI, delay, inbound) {
     hardcodedClientAddresses: [bootAddress],
     noFakeCurrencies: process.env.NO_FAKE_CURRENCIES,
     bootMsg: {
-      bootstrapAddress: 'agoric1simboot',
-      bootstrapValue: `${50000n * 10n ** 6n}`,
-      donationValue: `${5n * 10n ** 6n}`,
+      supplyCoins: [{ denom: 'ubld', amount: `${50000n * 10n ** 6n}` }],
     },
   };
   const stateDBdir = path.join(basedir, `fake-chain-${GCI}-state`);
@@ -149,7 +147,8 @@ export async function connectToFakeChain(basedir, GCI, delay, inbound) {
   );
 
   const simulateBlock = () =>
-    unhandledSimulateBlock().catch(_ => {
+    unhandledSimulateBlock().catch(e => {
+      console.error(e);
       process.exit(1);
     });
 
@@ -166,16 +165,14 @@ export async function connectToFakeChain(basedir, GCI, delay, inbound) {
   }
 
   let genesisBlockP;
-  if (blockHeight < 0) {
+  if (!blockHeight) {
     // The before-first-block is special... do it now.
-    // This emulates what x/swingset does to run an END_BLOCK
-    // with block 1 and genesis transactions before continuing with the real
-    // block 1.
-    blockHeight = initialHeight;
+    // This emulates what x/swingset does to run a BOOTSTRAP_BLOCK
+    // before continuing with the real initialHeight.
     genesisBlockP = blockManager(
-      { type: 'END_BLOCK', blockHeight, blockTime },
+      { type: 'BOOTSTRAP_BLOCK', blockTime },
       savedChainSends,
-    );
+    ).then(() => (blockHeight = initialHeight));
   }
   await genesisBlockP;
 

--- a/packages/solo/src/start.js
+++ b/packages/solo/src/start.js
@@ -444,8 +444,12 @@ export default async function start(basedir, argv) {
       if (err) {
         console.error(err);
       }
+      // eslint-disable-next-line no-use-before-define
+      process.off('exit', killDeployment);
     },
   );
+  const killDeployment = () => cp.kill('SIGINT');
+  process.on('exit', killDeployment);
 
   return whenHellFreezesOver.then(() => cp.kill('SIGINT'));
 }


### PR DESCRIPTION
Fixes #3470

This should clear up the slogging of the bootstrap work that is run before the chain starts producing blocks.

Rather than running this work under a fake `END_BLOCK` message, use `BOOTSTRAP_BLOCK` instead.
