### PR TITLE
chore(swingset): hush vat-warehouse announcement of vat load

### DIFF
--- a/packages/SwingSet/src/kernel/vatManager/vat-warehouse.js
+++ b/packages/SwingSet/src/kernel/vatManager/vat-warehouse.js
@@ -130,7 +130,7 @@ export function makeVatWarehouse(kernelKeeper, vatLoader, policyOptions) {
     const { enablePipelining = false } = options;
 
     const lastSnapshot = vatKeeper.getLastSnapshot();
-    const entriesReplayed = await manager.replayTranscript(
+    await manager.replayTranscript(
       lastSnapshot ? lastSnapshot.startPos : undefined,
     );
 
@@ -140,14 +140,14 @@ export function makeVatWarehouse(kernelKeeper, vatLoader, policyOptions) {
       enablePipelining,
       options,
     };
-    console.info(
-      vatID,
-      'online:',
-      options.managerType,
-      options.description || '',
-      'transcript entries replayed:',
-      entriesReplayed,
-    );
+    // console.info(
+    //   vatID,
+    //   'online:',
+    //   options.managerType,
+    //   options.description || '',
+    //   'transcript entries replayed:',
+    //   entriesReplayed, // retval of replayTranscript() above
+    // );
     ephemeral.vats.set(vatID, result);
     // eslint-disable-next-line no-use-before-define
     await applyAvailabilityPolicy(vatID);


### PR DESCRIPTION
This causes swingset tests to be pretty noisy, as well as chain/solo startup.

fixes #3412