### PR TITLE
cleanups in preparation for Meters

### DIFF
--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -695,11 +695,11 @@ export default function buildKernel(
         kdebug(`vat terminated: ${JSON.stringify(info)}`);
       }
       if (!didAbort) {
-        kernelKeeper.processRefcounts();
-        kernelKeeper.saveStats();
         // eslint-disable-next-line no-use-before-define
         await vatWarehouse.maybeSaveSnapshot();
       }
+      kernelKeeper.processRefcounts();
+      kernelKeeper.saveStats();
       commitCrank();
       kernelKeeper.incrementCrankNumber();
     } finally {


### PR DESCRIPTION
These commits perform some cleanups and refactorings to make the upcoming Meter PR easier to review.

* rearrange the way we react to deliveries that cause state to be unwound

refs #3308

