### PR TITLE
Virtual object garbage collection

### DIFF
--- a/packages/SwingSet/test/virtualObjects/test-representatives.js
+++ b/packages/SwingSet/test/virtualObjects/test-representatives.js
@@ -279,29 +279,67 @@ test('exercise cache', async t => {
 
   // init cache - []
   await make('thing1', true, T1); // make t1 - [t1]
+  t.deepEqual(log.shift(), ['get', `${thingID(1)}.refCount`, undefined]);
+  t.deepEqual(log.shift(), ['set', `${thingID(1)}.refCount`, '1 0']);
+  t.deepEqual(log, []);
+
   await make('thing2', false, T2); // make t2 - [t2 t1]
+  t.deepEqual(log.shift(), ['get', `${thingID(2)}.refCount`, undefined]);
+  t.deepEqual(log.shift(), ['set', `${thingID(2)}.refCount`, '1 0']);
+  t.deepEqual(log, []);
+
   await read(T1, 'thing1'); // refresh t1 - [t1 t2]
   await read(T2, 'thing2'); // refresh t2 - [t2 t1]
   await readHeld('thing1'); // refresh t1 - [t1 t2]
 
   await make('thing3', false, T3); // make t3 - [t3 t1 t2]
-  await make('thing4', false, T4); // make t4 - [t4 t3 t1 t2]
+  t.deepEqual(log.shift(), ['get', `${thingID(3)}.refCount`, undefined]);
+  t.deepEqual(log.shift(), ['set', `${thingID(3)}.refCount`, '1 0']);
   t.deepEqual(log, []);
+
+  await make('thing4', false, T4); // make t4 - [t4 t3 t1 t2]
+  t.deepEqual(log.shift(), ['get', `${thingID(4)}.refCount`, undefined]);
+  t.deepEqual(log.shift(), ['set', `${thingID(4)}.refCount`, '1 0']);
+  t.deepEqual(log, []);
+
   await make('thing5', false, T5); // evict t2, make t5 - [t5 t4 t3 t1]
+  t.deepEqual(log.shift(), ['get', `${thingID(5)}.refCount`, undefined]);
+  t.deepEqual(log.shift(), ['get', `${thingID(2)}.refCount`, '1 0']);
   t.deepEqual(log.shift(), ['set', thingID(2), thingVal('thing2')]);
+  t.deepEqual(log.shift(), ['set', `${thingID(5)}.refCount`, '1 0']);
+  t.deepEqual(log, []);
+
   await make('thing6', false, T6); // evict t1, make t6 - [t6 t5 t4 t3]
+  t.deepEqual(log.shift(), ['get', `${thingID(6)}.refCount`, undefined]);
   t.deepEqual(log.shift(), ['set', thingID(1), thingVal('thing1')]);
+  t.deepEqual(log.shift(), ['set', `${thingID(6)}.refCount`, '1 0']);
+  t.deepEqual(log, []);
+
   await make('thing7', false, T7); // evict t3, make t7 - [t7 t6 t5 t4]
+  t.deepEqual(log.shift(), ['get', `${thingID(7)}.refCount`, undefined]);
+  t.deepEqual(log.shift(), ['get', `${thingID(3)}.refCount`, '1 0']);
   t.deepEqual(log.shift(), ['set', thingID(3), thingVal('thing3')]);
+  t.deepEqual(log.shift(), ['set', `${thingID(7)}.refCount`, '1 0']);
+  t.deepEqual(log, []);
+
   await make('thing8', false, T8); // evict t4, make t8 - [t8 t7 t6 t5]
+  t.deepEqual(log.shift(), ['get', `${thingID(8)}.refCount`, undefined]);
+  t.deepEqual(log.shift(), ['get', `${thingID(4)}.refCount`, '1 0']);
   t.deepEqual(log.shift(), ['set', thingID(4), thingVal('thing4')]);
+  t.deepEqual(log.shift(), ['set', `${thingID(8)}.refCount`, '1 0']);
+  t.deepEqual(log, []);
 
   await read(T2, 'thing2'); // reanimate t2, evict t5 - [t2 t8 t7 t6]
   t.deepEqual(log.shift(), ['get', thingID(2), thingVal('thing2')]);
+  t.deepEqual(log.shift(), ['get', `${thingID(5)}.refCount`, '1 0']);
   t.deepEqual(log.shift(), ['set', thingID(5), thingVal('thing5')]);
+  t.deepEqual(log, []);
+
   await readHeld('thing1'); // reanimate t1, evict t6 - [t1 t2 t8 t7]
   t.deepEqual(log.shift(), ['get', thingID(1), thingVal('thing1')]);
+  t.deepEqual(log.shift(), ['get', `${thingID(6)}.refCount`, '1 0']);
   t.deepEqual(log.shift(), ['set', thingID(6), thingVal('thing6')]);
+  t.deepEqual(log, []);
 
   await write(T2, 'thing2 updated'); // refresh t2 - [t2 t1 t8 t7]
   await writeHeld('thing1 updated'); // refresh t1 - [t1 t2 t8 t7]
@@ -309,30 +347,94 @@ test('exercise cache', async t => {
   await read(T8, 'thing8'); // refresh t8 - [t8 t1 t2 t7]
   await read(T7, 'thing7'); // refresh t7 - [t7 t8 t1 t2]
   t.deepEqual(log, []);
+
   await read(T6, 'thing6'); // reanimate t6, evict t2 - [t6 t7 t8 t1]
   t.deepEqual(log.shift(), ['get', thingID(6), thingVal('thing6')]);
+  t.deepEqual(log.shift(), ['get', `${thingID(2)}.refCount`, '1 0']);
   t.deepEqual(log.shift(), ['set', thingID(2), thingVal('thing2 updated')]);
+  t.deepEqual(log, []);
+
   await read(T5, 'thing5'); // reanimate t5, evict t1 - [t5 t6 t7 t8]
   t.deepEqual(log.shift(), ['get', thingID(5), thingVal('thing5')]);
   t.deepEqual(log.shift(), ['set', thingID(1), thingVal('thing1 updated')]);
+  t.deepEqual(log, []);
+
   await read(T4, 'thing4'); // reanimate t4, evict t8 - [t4 t5 t6 t7]
   t.deepEqual(log.shift(), ['get', thingID(4), thingVal('thing4')]);
   t.deepEqual(log.shift(), ['set', thingID(8), thingVal('thing8')]);
+  t.deepEqual(log, []);
+
   await read(T3, 'thing3'); // reanimate t3, evict t7 - [t3 t4 t5 t6]
   t.deepEqual(log.shift(), ['get', thingID(3), thingVal('thing3')]);
+  t.deepEqual(log.shift(), ['get', `${thingID(7)}.refCount`, '1 0']);
   t.deepEqual(log.shift(), ['set', thingID(7), thingVal('thing7')]);
+  t.deepEqual(log, []);
 
   await read(T2, 'thing2 updated'); // reanimate t2, evict t6 - [t2 t3 t4 t5]
   t.deepEqual(log.shift(), ['get', thingID(2), thingVal('thing2 updated')]);
+  t.deepEqual(log.shift(), ['get', `${thingID(6)}.refCount`, '1 0']);
+  t.deepEqual(log, []);
+
   await readHeld('thing1 updated'); // reanimate t1, evict t5 - [t1 t2 t3 t4]
   t.deepEqual(log.shift(), ['get', thingID(1), thingVal('thing1 updated')]);
+  t.deepEqual(log.shift(), ['get', `${thingID(5)}.refCount`, '1 0']);
+  t.deepEqual(log, []);
 
   await forgetHeld(); // cache unchanged - [t1 t2 t3 t4]
-  await hold(T8); // cache unchanged - [t1 t2 t3 t4]
+  t.deepEqual(log.shift(), ['get', `${thingID(1)}.refCount`, '1 0']);
   t.deepEqual(log, []);
+
+  await hold(T8); // cache unchanged - [t1 t2 t3 t4]
+  t.deepEqual(log.shift(), ['get', `${thingID(4)}.refCount`, '1 0']);
+  t.deepEqual(log, []);
+
   await read(T7, 'thing7'); // reanimate t7, evict t4 - [t7 t1 t2 t3]
   t.deepEqual(log.shift(), ['get', thingID(7), thingVal('thing7')]);
+  t.deepEqual(log.shift(), ['get', `${thingID(3)}.refCount`, '1 0']);
+  t.deepEqual(log, []);
+
   await writeHeld('thing8 updated'); // reanimate t8, evict t3 - [t8 t7 t1 t2]
   t.deepEqual(log.shift(), ['get', thingID(8), thingVal('thing8')]);
   t.deepEqual(log, []);
+});
+
+test('virtual object gc', async t => {
+  const config = {
+    bootstrap: 'bootstrap',
+    defaultManagerType: 'xs-worker',
+    vats: {
+      bob: {
+        sourceSpec: path.resolve(__dirname, 'vat-vom-gc-bob.js'),
+        creationOptions: {
+          virtualObjectCacheSize: 3,
+        },
+      },
+      bootstrap: {
+        sourceSpec: path.resolve(__dirname, 'vat-vom-gc-bootstrap.js'),
+      },
+    },
+  };
+
+  const hostStorage = provideHostStorage();
+
+  const c = await buildVatController(config, [], { hostStorage });
+  c.pinVatRoot('bootstrap');
+
+  await c.run();
+  t.deepEqual(
+    c.kpResolution(c.bootstrapResult),
+    capargs({ '@qclass': 'undefined' }),
+  );
+  const remainingVOs = {};
+  for (const key of hostStorage.kvStore.getKeys('v1.vs.', 'v1.vs/')) {
+    remainingVOs[key] = hostStorage.kvStore.get(key);
+  }
+  t.deepEqual(remainingVOs, {
+    'v1.vs.vom.o+1/2': '{"label":{"body":"\\"thing #2\\"","slots":[]}}',
+    'v1.vs.vom.o+1/2.refCount': '0 0',
+    'v1.vs.vom.o+1/3': '{"label":{"body":"\\"thing #3\\"","slots":[]}}',
+    'v1.vs.vom.o+1/3.refCount': '1 0',
+    'v1.vs.vom.o+1/8': '{"label":{"body":"\\"thing #8\\"","slots":[]}}',
+    'v1.vs.vom.o+1/9': '{"label":{"body":"\\"thing #9\\"","slots":[]}}',
+  });
 });

--- a/packages/SwingSet/test/virtualObjects/vat-vom-gc-bob.js
+++ b/packages/SwingSet/test/virtualObjects/vat-vom-gc-bob.js
@@ -1,0 +1,59 @@
+/* global makeKind */
+import { E } from '@agoric/eventual-send';
+
+const things = [];
+
+export function buildRootObject(_vatPowers) {
+  function makeThingInstance(state) {
+    return {
+      init(label) {
+        state.label = label;
+      },
+      self: {
+        getLabel() {
+          return state.label;
+        },
+      },
+    };
+  }
+
+  const thingMaker = makeKind(makeThingInstance);
+  let nextThingNumber = 0;
+
+  return harden({
+    prepare() {
+      for (let i = 1; i <= 9; i += 1) {
+        things.push(thingMaker(`thing #${i}`));
+      }
+    },
+    getThing(forWhom) {
+      let thing;
+      do {
+        thing = things[nextThingNumber];
+        nextThingNumber += 1;
+      } while (!thing);
+
+      if (nextThingNumber === 2) {
+        thing.getLabel();
+        things[3].getLabel();
+        things[3] = null; // arbitrarily drop one before sending it, but don't drop the one we're sending
+      } else {
+        thing.getLabel();
+        things[nextThingNumber - 1] = null; // drop the one we're sending
+      }
+      E(forWhom).deliverThing(thing);
+      thing = null;
+    },
+    finish() {
+      while (nextThingNumber < 7) {
+        const deadThing = things[nextThingNumber];
+        if (deadThing) {
+          deadThing.getLabel();
+          things[nextThingNumber] = null;
+        }
+        nextThingNumber += 1;
+      }
+      console.log(`Bob finishing`);
+    },
+  });
+}

--- a/packages/SwingSet/test/virtualObjects/vat-vom-gc-bob.js
+++ b/packages/SwingSet/test/virtualObjects/vat-vom-gc-bob.js
@@ -22,6 +22,7 @@ export function buildRootObject(_vatPowers) {
 
   return harden({
     prepare() {
+      things.push(null);
       for (let i = 1; i <= 9; i += 1) {
         things.push(thingMaker(`thing #${i}`));
       }
@@ -33,10 +34,10 @@ export function buildRootObject(_vatPowers) {
         nextThingNumber += 1;
       } while (!thing);
 
-      if (nextThingNumber === 2) {
+      if (nextThingNumber === 3) {
         thing.getLabel();
-        things[3].getLabel();
-        things[3] = null; // arbitrarily drop one before sending it, but don't drop the one we're sending
+        things[4].getLabel();
+        things[4] = null; // arbitrarily drop one before sending it, but don't drop the one we're sending
       } else {
         thing.getLabel();
         things[nextThingNumber - 1] = null; // drop the one we're sending
@@ -45,7 +46,7 @@ export function buildRootObject(_vatPowers) {
       thing = null;
     },
     finish() {
-      while (nextThingNumber < 7) {
+      while (nextThingNumber < 8) {
         const deadThing = things[nextThingNumber];
         if (deadThing) {
           deadThing.getLabel();

--- a/packages/SwingSet/test/virtualObjects/vat-vom-gc-bootstrap.js
+++ b/packages/SwingSet/test/virtualObjects/vat-vom-gc-bootstrap.js
@@ -1,0 +1,30 @@
+import { E } from '@agoric/eventual-send';
+
+export function buildRootObject(_vatPowers) {
+  let other;
+  let bob;
+  let me;
+  let goCount = 3;
+  return harden({
+    async bootstrap(vats) {
+      me = vats.bootstrap;
+      bob = vats.bob;
+      E(bob).prepare();
+      await E(me).go();
+    },
+    go() {
+      if (goCount > 0) {
+        E(bob).getThing(me);
+      } else {
+        E(bob).finish();
+      }
+      goCount -= 1;
+    },
+    deliverThing(thing) {
+      // eslint thinks 'other' is unused, but eslint is wrong.
+      // eslint-disable-next-line no-unused-vars
+      other = thing;
+      E(me).go();
+    },
+  });
+}

--- a/packages/SwingSet/tools/fakeVirtualObjectManager.js
+++ b/packages/SwingSet/tools/fakeVirtualObjectManager.js
@@ -96,6 +96,9 @@ export function makeFakeVirtualObjectManager(options = {}) {
   }
 
   function deleteEntry(slot, val) {
+    if (!val) {
+      val = getValForSlot(slot);
+    }
     slotToVal.delete(slot);
     valToSlot.delete(val);
   }
@@ -107,6 +110,8 @@ export function makeFakeVirtualObjectManager(options = {}) {
     VirtualObjectAwareWeakMap,
     VirtualObjectAwareWeakSet,
     isVrefReachable,
+    setExported,
+    possibleVirtualObjectDeath,
     flushCache,
   } = makeVirtualObjectManager(
     fakeSyscall,
@@ -124,6 +129,8 @@ export function makeFakeVirtualObjectManager(options = {}) {
     VirtualObjectAwareWeakMap,
     VirtualObjectAwareWeakSet,
     isVrefReachable,
+    setExported,
+    possibleVirtualObjectDeath,
   };
 
   const debugTools = {

--- a/packages/swingset-runner/demo/vatStore3/bootstrap.js
+++ b/packages/swingset-runner/demo/vatStore3/bootstrap.js
@@ -1,0 +1,30 @@
+import { E } from '@agoric/eventual-send';
+
+export function buildRootObject(_vatPowers) {
+  let other;
+  let bob;
+  let me;
+  let goCount = 3;
+  return harden({
+    async bootstrap(vats) {
+      me = vats.bootstrap;
+      bob = vats.bob;
+      E(bob).prepare();
+      await E(me).go();
+    },
+    go() {
+      if (goCount > 0) {
+        E(bob).getThing(me);
+      } else {
+        E(bob).finish();
+      }
+      goCount -= 1;
+    },
+    deliverThing(thing) {
+      // eslint thinks 'other' is unused, but eslint is wrong.
+      // eslint-disable-next-line no-unused-vars
+      other = thing;
+      E(me).go();
+    },
+  });
+}

--- a/packages/swingset-runner/demo/vatStore3/vat-bob.js
+++ b/packages/swingset-runner/demo/vatStore3/vat-bob.js
@@ -1,0 +1,59 @@
+/* global makeKind */
+import { E } from '@agoric/eventual-send';
+
+const things = [];
+
+export function buildRootObject(_vatPowers) {
+  function makeThingInstance(state) {
+    return {
+      init(label) {
+        state.label = label;
+      },
+      self: {
+        getLabel() {
+          return state.label;
+        },
+      },
+    };
+  }
+
+  const thingMaker = makeKind(makeThingInstance);
+  let nextThingNumber = 0;
+
+  return harden({
+    prepare() {
+      for (let i = 1; i <= 9; i += 1) {
+        things.push(thingMaker(`thing #${i}`));
+      }
+    },
+    getThing(forWhom) {
+      let thing;
+      do {
+        thing = things[nextThingNumber];
+        nextThingNumber += 1;
+      } while (!thing);
+
+      if (nextThingNumber === 2) {
+        console.log(`not nulling ${thing.getLabel()}`);
+        console.log(`nulling ${things[3].getLabel()} instead`);
+        things[3] = null; // arbitrarily drop one before sending it, but don't drop the one we're sending
+      } else {
+        console.log(`nulling ${thing.getLabel()}`);
+        things[nextThingNumber - 1] = null; // drop the one we're sending
+      }
+      E(forWhom).deliverThing(thing);
+      thing = null;
+    },
+    finish() {
+      while (nextThingNumber < 7) {
+        const deadThing = things[nextThingNumber];
+        if (deadThing) {
+          console.log(`final nulling ${deadThing.getLabel()}`);
+          things[nextThingNumber] = null;
+        }
+        nextThingNumber += 1;
+      }
+      console.log(`Bob finishing`);
+    },
+  });
+}

--- a/packages/swingset-runner/src/main.js
+++ b/packages/swingset-runner/src/main.js
@@ -51,6 +51,7 @@ FLAGS may be:
   --initonly       - initialize the swingset but exit without running it
   --lmdb           - runs using LMDB as the data store (default)
   --memdb          - runs using the non-persistent in-memory data store
+  --usexs          - run vats using the the XS engine
   --dbdir DIR      - specify where the data store should go (default BASEDIR)
   --dbsize SIZE    - set the LMDB size limit to SIZE megabytes (default 2GB)
   --blockmode      - run in block mode (checkpoint every BLOCKSIZE blocks)
@@ -180,6 +181,7 @@ export async function main() {
   let dbDir = null;
   let dbSize = 0;
   let initOnly = false;
+  let useXS = false;
 
   while (argv[0] && argv[0].startsWith('-')) {
     const flag = argv.shift();
@@ -273,6 +275,10 @@ export async function main() {
       case '--lmdb':
         dbMode = flag;
         break;
+      case '--usexs':
+      case '--useXS':
+        useXS = true;
+        break;
       case '-v':
       case '--verbose':
         verbose = true;
@@ -331,6 +337,9 @@ export async function main() {
     };
     delete config.loopboxSenders;
     deviceEndowments.loopbox = { ...loopboxEndowments };
+  }
+  if (useXS) {
+    config.defaultManagerType = 'xs-worker';
   }
   if (launchIndirectly) {
     config = generateIndirectConfig(config);
@@ -530,6 +539,7 @@ export async function main() {
   if (statLogger) {
     statLogger.close();
   }
+  controller.shutdown();
 
   function getCrankNumber() {
     return Number(swingStore.kvStore.get('crankNumber'));

--- a/packages/swingset-runner/src/slogulator.js
+++ b/packages/swingset-runner/src/slogulator.js
@@ -371,6 +371,11 @@ export function main() {
     }
   }
 
+  function doDeliverDropRetire(delivery, prefix = '') {
+    // prettier-ignore
+    p(`${prefix}recv-${delivery[0]}: [${delivery[1].map(r => pref(r)).join(' ')}]`);
+  }
+
   function doDeliver(delivery, prefix) {
     switch (delivery[0]) {
       case 'message':
@@ -378,6 +383,11 @@ export function main() {
         break;
       case 'notify':
         doDeliverNotify(delivery, prefix);
+        break;
+      case 'dropExports':
+      case 'retireExports':
+      case 'retireImports':
+        doDeliverDropRetire(delivery, prefix);
         break;
       default:
         p(`deliver: unknown deliver type "${delivery[0]}"`);
@@ -456,6 +466,10 @@ export function main() {
     p(`${tag}: ${key} := '${value}'`);
   }
 
+  function doSyscallDropRetire(tag, entry) {
+    p(`send-${tag}: [${entry[1].map(r => pref(r)).join(' ')}]`);
+  }
+
   function doSyscallExit(tag, entry) {
     const failure = kernelSpace ? entry[2] : entry[1];
     const value = kernelSpace ? entry[3] : entry[2];
@@ -487,6 +501,11 @@ export function main() {
         break;
       case 'vatstoreSet':
         doSyscallVatstoreSet(tag, syscall);
+        break;
+      case 'dropImports':
+      case 'retireExports':
+      case 'retireImports':
+        doSyscallDropRetire(tag, syscall);
         break;
       default:
         p(`syscall: unknown syscall ${currentSyscallName}`);
@@ -617,6 +636,9 @@ export function main() {
       case 'subscribe':
       case 'vatstoreDelete':
       case 'vatstoreSet':
+      case 'dropImports':
+      case 'retireExports':
+      case 'retireImports':
         if (value !== null) {
           p(`${tag}: unexpected value ${value}`);
         }


### PR DESCRIPTION
This implements the first stage of VOM GC: garbage collection of virtual objects per se.

This does not yet deal with virtual objects (or any other kind of objects) that are referenced from virtual object properties -- these are still pinned using the mechanisms that we had in place for that purpose prior to this.  Nor does it implement GC of virtual object keyed entries in weak collections.  These will come in a later PR.

Commits are organized topically for ease of review.

Closes #3456 


