### PR TITLE
use metered=true on all dynamic vats, xs-worker on all swingset tests

### DIFF
--- a/packages/ERTP/test/swingsetTests/basicFunctionality/test-basicFunctionality.js
+++ b/packages/ERTP/test/swingsetTests/basicFunctionality/test-basicFunctionality.js
@@ -10,6 +10,7 @@ import path from 'path';
 async function main(basedir, argv) {
   const dir = path.resolve(`${__dirname}/..`, basedir);
   const config = await loadBasedir(dir);
+  config.defaultManagerType = 'xs-worker';
   const controller = await buildVatController(config, argv);
   await controller.run();
   return controller.dump();

--- a/packages/ERTP/test/swingsetTests/splitPayments/test-splitPayments.js
+++ b/packages/ERTP/test/swingsetTests/splitPayments/test-splitPayments.js
@@ -10,6 +10,7 @@ import path from 'path';
 async function main(basedir, argv) {
   const dir = path.resolve(`${__dirname}/..`, basedir);
   const config = await loadBasedir(dir);
+  config.defaultManagerType = 'xs-worker';
   const controller = await buildVatController(config, argv);
   await controller.run();
   return controller.dump();

--- a/packages/governance/test/swingsetTests/committeeBinary/test-committee.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/test-committee.js
@@ -51,6 +51,7 @@ test.before(async t => {
     parameters: { contractBundles }, // argv will be added to this
   };
   const config = { bootstrap: 'bootstrap', vats };
+  config.defaultManagerType = 'xs-worker';
 
   const step4 = Date.now();
   const ktime = `${(step2 - start) / 1000}s kernel`;

--- a/packages/sharing-service/test/swingsetTests/sharingService/test-sharing.js
+++ b/packages/sharing-service/test/swingsetTests/sharingService/test-sharing.js
@@ -9,6 +9,7 @@ import { buildVatController, loadBasedir } from '@agoric/swingset-vat';
 async function main(basedir, argv) {
   const dir = path.resolve(`${__dirname}/..`, basedir);
   const config = await loadBasedir(dir);
+  config.defaultManagerType = 'xs-worker';
   const controller = await buildVatController(config, argv);
   await controller.run();
   return controller.dump();

--- a/packages/spawner/src/contractHost.js
+++ b/packages/spawner/src/contractHost.js
@@ -13,7 +13,8 @@ function makeSpawner(vatAdminSvc) {
       assert(!oldModuleFormat, 'oldModuleFormat not supported');
       return Far('installer', {
         async spawn(argsP) {
-          const { root } = await E(vatAdminSvc).createVat(spawnBundle);
+          const opts = { metered: true };
+          const { root } = await E(vatAdminSvc).createVat(spawnBundle, opts);
           return E(E(root).loadBundle(bundle)).start(argsP);
         },
       });

--- a/packages/spawner/test/swingsetTests/contractHost/test-contractHost.js
+++ b/packages/spawner/test/swingsetTests/contractHost/test-contractHost.js
@@ -19,9 +19,9 @@ test.before(async t => {
   t.context.data = { kernelBundles, trivialBundle };
 });
 
-async function main(t, mode, defaultManagerType = 'local') {
+async function main(t, mode) {
   const config = await loadBasedir(__dirname);
-  config.defaultManagerType = defaultManagerType;
+  config.defaultManagerType = 'xs-worker';
   const { kernelBundles, trivialBundle } = t.context.data;
   const argv = [mode, trivialBundle];
   const controller = await buildVatController(config, argv, { kernelBundles });
@@ -48,6 +48,6 @@ const contractExhaustedGolden = [
 ];
 
 test('exhaustion', async t => {
-  const dump = await main(t, 'exhaust', 'xs-worker');
+  const dump = await main(t, 'exhaust');
   t.deepEqual(dump.log, contractExhaustedGolden);
 });

--- a/packages/treasury/test/swingsetTests/test-treasury.js
+++ b/packages/treasury/test/swingsetTests/test-treasury.js
@@ -52,6 +52,7 @@ test.before(async t => {
   vats.bootstrap.parameters = { contractBundles };
 
   const config = { bootstrap: 'bootstrap', vats };
+  config.defaultManagerType = 'xs-worker';
 
   t.context.data = { kernelBundles, config };
 });

--- a/packages/zoe/src/zoeService/createZCFVat.js
+++ b/packages/zoe/src/zoeService/createZCFVat.js
@@ -14,7 +14,7 @@ export const setupCreateZCFVat = (vatAdminSvc, zcfBundleName = undefined) => {
   /** @type {CreateZCFVat} */
   const createZCFVat = () =>
     typeof zcfBundleName === 'string'
-      ? E(vatAdminSvc).createVatByName(zcfBundleName)
-      : E(vatAdminSvc).createVat(zcfContractBundle);
+      ? E(vatAdminSvc).createVatByName(zcfBundleName, { metered: true })
+      : E(vatAdminSvc).createVat(zcfContractBundle, { metered: true });
   return createZCFVat;
 };

--- a/packages/zoe/test/swingsetTests/makeKind/test-makeKind.js
+++ b/packages/zoe/test/swingsetTests/makeKind/test-makeKind.js
@@ -49,6 +49,7 @@ test.before(async t => {
     parameters: { contractBundles }, // argv will be added to this
   };
   const config = { bootstrap: 'bootstrap', vats };
+  config.defaultManagerType = 'xs-worker';
 
   const step4 = Date.now();
   const ktime = `${(step2 - start) / 1000}s kernel`;

--- a/packages/zoe/test/swingsetTests/zoe/test-zoe.js
+++ b/packages/zoe/test/swingsetTests/zoe/test-zoe.js
@@ -63,6 +63,7 @@ test.before(async t => {
     parameters: { contractBundles }, // argv will be added to this
   };
   const config = { bootstrap: 'bootstrap', vats };
+  config.defaultManagerType = 'xs-worker';
 
   const step4 = Date.now();
   const ktime = `${(step2 - start) / 1000}s kernel`;


### PR DESCRIPTION
Swingset will soon change from "all dynamic vats are metered" to "dynamic vats are unmetered by default", so set "metered: true" to retain the current behavior for ZCF vats.

In addition, metering is going to be removed from the "local" (Node.js) vat-worker, so "metered: true" will require "xs-worker" (xsnap) instead. This changes the `tests/swingsetTests` runners to use xs-worker.

Note that this upcoming change means any application which uses Zoe to spawn ZCF vats must run with `config.defaultManagerType='xs-worker'`, otherwise vat creation will fail when Zoe asks for a metered vat. Our two primary applications (the chain and the solo machine) both do this already.

refs #3518
refs #3308
