### PR TITLE
feat(swingset)!: make dynamic vats unmetered by default

### DIFF
--- a/packages/SwingSet/src/kernel/loadVat.js
+++ b/packages/SwingSet/src/kernel/loadVat.js
@@ -138,7 +138,7 @@ export function makeVatLoader(stuff) {
    *        the amount of computation and allocation that can occur during any
    *        given crank. Stack frames are limited as well. The meter is refilled
    *        between cranks, but if the meter ever underflows, the vat is
-   *        terminated. If false, the vat is unmetered.  Defaults to true for
+   *        terminated. If false, the vat is unmetered.  Defaults to false for
    *        dynamic vats; static vats may not be metered.
    *
    * @param {Record<string, unknown>} [options.vatParameters] provides
@@ -199,7 +199,7 @@ export function makeVatLoader(stuff) {
       isDynamic ? allowedDynamicOptions : allowedStaticOptions,
     );
     const {
-      metered = isDynamic,
+      metered = false,
       vatParameters = {},
       managerType,
       enableSetup = false,

--- a/packages/SwingSet/test/metering/test-dynamic-vat-metered.js
+++ b/packages/SwingSet/test/metering/test-dynamic-vat-metered.js
@@ -57,11 +57,9 @@ async function runOneTest(t, explosion, managerType) {
   await c.run();
 
   // 'createVat' will import the bundle
-  c.queueToVatRoot(
-    'bootstrap',
-    'createVat',
-    capargs([dynamicVatBundle, { managerType }]),
-  );
+  const cvopts = { managerType, metered: true };
+  const cvargs = capargs([dynamicVatBundle, cvopts]);
+  c.queueToVatRoot('bootstrap', 'createVat', cvargs);
   await c.run();
   t.deepEqual(nextLog(), ['created'], 'first create');
 

--- a/packages/SwingSet/test/metering/test-dynamic-vat-subcompartment.js
+++ b/packages/SwingSet/test/metering/test-dynamic-vat-subcompartment.js
@@ -43,7 +43,9 @@ test('metering dynamic vat which imports bundle', async t => {
   );
 
   // 'createVat' will import the bundle
-  c.queueToVatRoot('bootstrap', 'createVat', capargs([dynamicVatBundle]));
+  const cvopts = { metered: true };
+  const cvargs = capargs([dynamicVatBundle, cvopts]);
+  c.queueToVatRoot('bootstrap', 'createVat', cvargs);
   await c.run();
   t.deepEqual(nextLog(), ['created'], 'first create');
 


### PR DESCRIPTION
When #3308 lands, the definition of "metering" will change. Previously, a
"metered dynamic vat" just meant that 1: each crank was limited to some fixed
amount of computrons, and 2: the low-level `deliveryResult` included the
number of computrons consumed by that delivery (but nobody paid attention to
the value).

In the new system, metering requires a Meter: an object with a `remaining`
capacity, which is deducted by the consumption of each delivery. Each metered
vat is associated with (exactly one) Meter. The presence of a Meter still
implies a per-crank limit: unmetered vats do not have a per-crank limit
either.

Previously, all dynamic vats were metered by default. Since the new metering
needs a Meter, it would be awkward to retain this default: we'd have to
allocate a new Meter during `createVat` without the caller's awareness, and
then there would be nobody to pay attention to it (or refill it when it runs
low).

So this commit changes the default to "false". Dynamic vats will be
unmetered (neither per-crank limits nor cumulative limits) by default.
Callers who want to retain the per-crank limits should add `metered: true` to
their `createVat` options. Such callers will need to create a Meter object
once #3308 is done.

The commit also updates swingset metering tests to add `metered: true`.

refs #3308