### PR TITLE
refactor(promise-kit): Convert RESM to NESM

### DIFF
--- a/packages/promise-kit/package.json
+++ b/packages/promise-kit/package.json
@@ -2,9 +2,7 @@
   "name": "@agoric/promise-kit",
   "version": "0.2.20",
   "description": "Helper for making promises",
-  "parsers": {
-    "js": "mjs"
-  },
+  "type": "module",
   "main": "src/promiseKit.js",
   "engines": {
     "node": ">=11.0"
@@ -36,8 +34,7 @@
     "@agoric/eventual-send": "^0.13.22"
   },
   "devDependencies": {
-    "ava": "^3.12.1",
-    "esm": "agoric-labs/esm#Agoric-built"
+    "ava": "^3.12.1"
   },
   "files": [
     "src/",
@@ -61,9 +58,6 @@
   "ava": {
     "files": [
       "test/**/test-*.js"
-    ],
-    "require": [
-      "esm"
     ],
     "timeout": "2m"
   }


### PR DESCRIPTION
This migrates the package `promise-kit` from using `esm` (**RESM**) to Node.js ESM (**NESM**).

refs: #527
