### PR TITLE
Skip flaky metering test

### DIFF
--- a/packages/SwingSet/test/metering/test-dynamic-vat-metered.js
+++ b/packages/SwingSet/test/metering/test-dynamic-vat-metered.js
@@ -192,7 +192,8 @@ test('exceed stack', t => {
   return overflowCrank(t, 'stack');
 });
 
-test('meter decrements', async t => {
+// See the TODO comment below about `test.skip`.
+test.skip('meter decrements', async t => {
   const managerType = 'xs-worker';
   const { kernelBundles, dynamicVatBundle, bootstrapBundle } = t.context.data;
   const config = {
@@ -290,8 +291,12 @@ test('meter decrements', async t => {
   remaining = await getMeter();
   console.log(remaining);
 
-  // It looks like #3499 might reduce this to two, in which case comment out
-  // the following three lines.
+  // It looks like #3499 has made this flaky, reducing it to two on
+  // my (markm) local development env but not under CI. Locally, if
+  // I comment out the following three lines, it passes locally
+  // but not under CI. Leaving them uncommented passes on CI but
+  // not locally.
+  // TODO Marking this `test.skip` until this flakiness is cleared up.
   await consume(true);
   remaining = await getMeter();
   console.log(remaining);

--- a/packages/SwingSet/test/metering/test-dynamic-vat-metered.js
+++ b/packages/SwingSet/test/metering/test-dynamic-vat-metered.js
@@ -297,6 +297,7 @@ test.skip('meter decrements', async t => {
   // but not under CI. Leaving them uncommented passes on CI but
   // not locally.
   // TODO Marking this `test.skip` until this flakiness is cleared up.
+  // See https://github.com/Agoric/agoric-sdk/issues/3538
   await consume(true);
   remaining = await getMeter();
   console.log(remaining);


### PR DESCRIPTION
From the change:

```js
  // It looks like #3499 has made this flaky, reducing it to two on
  // my (markm) local development env but not under CI. Locally, if
  // I comment out the following three lines, it passes locally
  // but not under CI. Leaving them uncommented passes on CI but
  // not locally.
  // TODO Marking this `test.skip` until this flakiness is cleared up.
```

See https://github.com/Agoric/agoric-sdk/issues/3538
