### PR TITLE
chore: clean up yarn.lock

### DIFF
--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@agoric/assert": "^0.3.6",
     "@agoric/babel-standalone": "^7.14.3",
-    "@endo/ses-ava": "0.2.4",
+    "@endo/ses-ava": "^0.2.4",
     "ava": "^3.12.1",
     "c8": "^7.7.2",
     "ses": "^0.13.4"


### PR DESCRIPTION
Currently, `yarn install` on master isn't clean. It produces a change to yarn.lock. Rather than checking in the change to yarn.lock, it looks to me that a caret was missing and the caret should be included. 

<img width="382" alt="Screen Shot 2021-07-26 at 4 35 42 PM" src="https://user-images.githubusercontent.com/2441069/127072432-5277f0a8-05d8-42b9-8d9b-cd383d18b261.png">
