### PR TITLE
refactor(marshal): Convert RESM to NESM

### DIFF
--- a/packages/assert/exported.js
+++ b/packages/assert/exported.js
@@ -1,1 +1,1 @@
-import './src/types';
+import './src/types.js';

--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -18,7 +18,7 @@
 // is a record of a failed attempt to remove '.types'.
 // To satisfy CI, not only do we need to keep the file,
 // but we need to import it here as well.
-import './types';
+import './types.js';
 
 const { freeze } = Object;
 

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -2,9 +2,7 @@
   "name": "@agoric/marshal",
   "version": "0.4.19",
   "description": "marshal",
-  "parsers": {
-    "js": "mjs"
-  },
+  "type": "module",
   "main": "index.js",
   "directories": {
     "test": "test"
@@ -43,8 +41,9 @@
   "devDependencies": {
     "@agoric/install-ses": "^0.5.20",
     "@agoric/swingset-vat": "^0.18.6",
+    "@endo/ses-ava": "^0.2.4",
     "ava": "^3.12.1",
-    "esm": "agoric-labs/esm#Agoric-built"
+    "ses": "^0.13.4"
   },
   "files": [
     "src/",
@@ -66,9 +65,6 @@
   "ava": {
     "files": [
       "test/**/test-*.js"
-    ],
-    "require": [
-      "esm"
     ],
     "timeout": "2m"
   }

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
+    "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
     "pretty-fix": "prettier --write '**/*.js'",
     "pretty-check": "prettier --check '**/*.js'",
@@ -43,6 +44,7 @@
     "@agoric/swingset-vat": "^0.18.6",
     "@endo/ses-ava": "^0.2.4",
     "ava": "^3.12.1",
+    "c8": "^7.7.2",
     "ses": "^0.13.4"
   },
   "files": [

--- a/packages/marshal/test/lockdown.js
+++ b/packages/marshal/test/lockdown.js
@@ -1,0 +1,66 @@
+// This is like `@agoric/install-ses` but sacrificing safety to optimize
+// for debugging and testing. The difference is only the lockdown options.
+// The setting below are *unsafe* and should not be used in contact with
+// genuinely malicious code.
+
+// See
+// https://github.com/endojs/endo/blob/master/packages/ses/lockdown-options.md
+// for more explanation of these lockdown options.
+
+lockdown({
+  // The default `{errorTaming: 'safe'}` setting, if possible, redacts the
+  // stack trace info from the error instances, so that it is not available
+  // merely by saying `errorInstance.stack`. However, some tools, such as
+  // Ava, will look for the stack there and become much less useful if it is
+  // missing.
+  //
+  // NOTE TO REVIEWERS: If you see the following line commented out,
+  // this may be a development accident that should be fixed before merging.
+  //
+  errorTaming: 'unsafe',
+
+  // The default `{stackFiltering: 'concise'}` setting usually makes for a
+  // better debugging experience, by severely reducing the noisy distractions
+  // of the normal verbose stack traces. Which is why you may want to comment
+  // out the `'verbose'` setting is commented out below. However, some
+  // tools, such as Ava, look for the full filename that it expects in order
+  // to fetch the source text for diagnostics, which is why this file
+  // sets it to `'verbose'`.
+  //
+  // Another reason for not commenting it out: The cause
+  // of the bug may be anywhere, so the `'noise'` thrown out by the default
+  // `'concise'` setting may also contain the signal you need. To see it,
+  // uncomment out the following line. But please do not commit it in that
+  // state.
+  //
+  // NOTE TO REVIEWERS: If you see the following line commented out,
+  // this may be a development accident that should be fixed before merging.
+  //
+  stackFiltering: 'verbose',
+
+  // The default `{overrideTaming: 'moderate'}` setting does not hurt the
+  // debugging experience much. But it will introduce noise into, for example,
+  // the vscode debugger's object inspector. During debug and test, if you can
+  // avoid legacy code that needs the `'moderate'` setting, then the `'min'`
+  // setting reduces debugging noise yet further, by turning fewer inherited
+  // properties into accessors.
+  //
+  // NOTE TO REVIEWERS: If you see the following line commented out,
+  // this may be a development accident that should be fixed before merging.
+  //
+  overrideTaming: 'min',
+
+  // The default `{consoleTaming: 'safe'}` setting usually makes for a
+  // better debugging experience, by wrapping the original `console` with
+  // the SES replacement `console` that provides more information about
+  // errors, expecially those thrown by the `assert` system. However,
+  // in case the SES `console` is getting in the way, we provide the
+  // `'unsafe'` option for leaving the original `console` in place.
+  //
+  // NOTE TO REVIEWERS: If you see the following line *not* commented out,
+  // this may be a development accident that should be fixed before merging.
+  //
+  // consoleTaming: 'unsafe',
+});
+
+Error.stackTraceLimit = Infinity;

--- a/packages/marshal/test/prepare-test-env-ava.js
+++ b/packages/marshal/test/prepare-test-env-ava.js
@@ -1,0 +1,8 @@
+import 'ses';
+import './lockdown.js';
+
+import { wrapTest } from '@endo/ses-ava';
+import rawTest from 'ava';
+
+/** @type {typeof rawTest} */
+export const test = wrapTest(rawTest);

--- a/packages/marshal/test/test-marshal-far-function.js
+++ b/packages/marshal/test/test-marshal-far-function.js
@@ -1,7 +1,6 @@
 // @ts-check
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+import { test } from './prepare-test-env-ava.js';
 
 import { Far } from '../src/marshal.js';
 import { getInterfaceOf, passStyleOf } from '../src/passStyleOf.js';

--- a/packages/marshal/test/test-marshal-far-obj.js
+++ b/packages/marshal/test/test-marshal-far-obj.js
@@ -1,7 +1,6 @@
 // @ts-check
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+import { test } from './prepare-test-env-ava.js';
 
 import {
   getInterfaceOf,

--- a/packages/marshal/test/test-marshal-justin.js
+++ b/packages/marshal/test/test-marshal-justin.js
@@ -1,7 +1,6 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+import { test } from './prepare-test-env-ava.js';
 
-import { makeMarshal, Remotable } from '../src/marshal';
+import { makeMarshal, Remotable } from '../src/marshal.js';
 import { decodeToJustin } from '../src/marshal-justin.js';
 
 // this only includes the tests that do not use liveSlots

--- a/packages/marshal/test/test-marshal-stringify.js
+++ b/packages/marshal/test/test-marshal-stringify.js
@@ -1,5 +1,4 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+import { test } from './prepare-test-env-ava.js';
 
 import { Far } from '../src/marshal.js';
 import { stringify, parse } from '../src/marshal-stringify.js';

--- a/packages/marshal/test/test-marshal.js
+++ b/packages/marshal/test/test-marshal.js
@@ -1,7 +1,6 @@
 // @ts-check
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+import { test } from './prepare-test-env-ava.js';
 
 import { passStyleOf } from '../src/passStyleOf.js';
 


### PR DESCRIPTION
This required an incidental bufix in `assert`, and also incidentally adds a coverage script.