### PR TITLE
refactor(notifier): Convert RESM to NESM

### DIFF
--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -2,9 +2,7 @@
   "name": "@agoric/notifier",
   "version": "0.3.22",
   "description": "Notifier allows services to update clients about state changes using a stream of promises",
-  "parsers": {
-    "js": "mjs"
-  },
+  "type": "module",
   "main": "src/index.js",
   "engines": {
     "node": ">=11.0"
@@ -41,8 +39,9 @@
   "devDependencies": {
     "@agoric/install-ses": "^0.5.20",
     "@agoric/swingset-vat": "^0.18.6",
+    "@endo/ses-ava": "^0.2.4",
     "ava": "^3.12.1",
-    "esm": "agoric-labs/esm#Agoric-built"
+    "ses": "^0.13.4"
   },
   "files": [
     "src/",
@@ -67,9 +66,6 @@
   "ava": {
     "files": [
       "test/**/test-*.js"
-    ],
-    "require": [
-      "esm"
     ],
     "timeout": "2m"
   }

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
+    "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint-check": "yarn lint",
@@ -41,6 +42,7 @@
     "@agoric/swingset-vat": "^0.18.6",
     "@endo/ses-ava": "^0.2.4",
     "ava": "^3.12.1",
+    "c8": "^7.7.2",
     "ses": "^0.13.4"
   },
   "files": [

--- a/packages/notifier/test/iterable-testing-tools.js
+++ b/packages/notifier/test/iterable-testing-tools.js
@@ -1,5 +1,4 @@
 // @ts-check
-import '@agoric/install-ses';
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
 import { observeIteration, observeIterator } from '../src/index.js';

--- a/packages/notifier/test/lockdown.js
+++ b/packages/notifier/test/lockdown.js
@@ -1,0 +1,66 @@
+// This is like `@agoric/install-ses` but sacrificing safety to optimize
+// for debugging and testing. The difference is only the lockdown options.
+// The setting below are *unsafe* and should not be used in contact with
+// genuinely malicious code.
+
+// See
+// https://github.com/endojs/endo/blob/master/packages/ses/lockdown-options.md
+// for more explanation of these lockdown options.
+
+lockdown({
+  // The default `{errorTaming: 'safe'}` setting, if possible, redacts the
+  // stack trace info from the error instances, so that it is not available
+  // merely by saying `errorInstance.stack`. However, some tools, such as
+  // Ava, will look for the stack there and become much less useful if it is
+  // missing.
+  //
+  // NOTE TO REVIEWERS: If you see the following line commented out,
+  // this may be a development accident that should be fixed before merging.
+  //
+  errorTaming: 'unsafe',
+
+  // The default `{stackFiltering: 'concise'}` setting usually makes for a
+  // better debugging experience, by severely reducing the noisy distractions
+  // of the normal verbose stack traces. Which is why you may want to comment
+  // out the `'verbose'` setting is commented out below. However, some
+  // tools, such as Ava, look for the full filename that it expects in order
+  // to fetch the source text for diagnostics, which is why this file
+  // sets it to `'verbose'`.
+  //
+  // Another reason for not commenting it out: The cause
+  // of the bug may be anywhere, so the `'noise'` thrown out by the default
+  // `'concise'` setting may also contain the signal you need. To see it,
+  // uncomment out the following line. But please do not commit it in that
+  // state.
+  //
+  // NOTE TO REVIEWERS: If you see the following line commented out,
+  // this may be a development accident that should be fixed before merging.
+  //
+  stackFiltering: 'verbose',
+
+  // The default `{overrideTaming: 'moderate'}` setting does not hurt the
+  // debugging experience much. But it will introduce noise into, for example,
+  // the vscode debugger's object inspector. During debug and test, if you can
+  // avoid legacy code that needs the `'moderate'` setting, then the `'min'`
+  // setting reduces debugging noise yet further, by turning fewer inherited
+  // properties into accessors.
+  //
+  // NOTE TO REVIEWERS: If you see the following line commented out,
+  // this may be a development accident that should be fixed before merging.
+  //
+  overrideTaming: 'min',
+
+  // The default `{consoleTaming: 'safe'}` setting usually makes for a
+  // better debugging experience, by wrapping the original `console` with
+  // the SES replacement `console` that provides more information about
+  // errors, expecially those thrown by the `assert` system. However,
+  // in case the SES `console` is getting in the way, we provide the
+  // `'unsafe'` option for leaving the original `console` in place.
+  //
+  // NOTE TO REVIEWERS: If you see the following line *not* commented out,
+  // this may be a development accident that should be fixed before merging.
+  //
+  // consoleTaming: 'unsafe',
+});
+
+Error.stackTraceLimit = Infinity;

--- a/packages/notifier/test/prepare-test-env-ava.js
+++ b/packages/notifier/test/prepare-test-env-ava.js
@@ -1,0 +1,10 @@
+// @ts-check
+import '@agoric/eventual-send/shim.js';
+import 'ses';
+import './lockdown.js';
+
+import { wrapTest } from '@endo/ses-ava';
+import rawTest from 'ava';
+
+/** @type {typeof rawTest} */
+export const test = wrapTest(rawTest);

--- a/packages/notifier/test/test-notifier-adaptor.js
+++ b/packages/notifier/test/test-notifier-adaptor.js
@@ -1,6 +1,6 @@
 // @ts-check
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+
+import { test } from './prepare-test-env-ava.js';
 
 import {
   makeAsyncIterableFromNotifier,

--- a/packages/notifier/test/test-notifier-examples.js
+++ b/packages/notifier/test/test-notifier-examples.js
@@ -1,7 +1,9 @@
 // @ts-check
-import '@agoric/install-ses';
+
+import { test } from './prepare-test-env-ava.js';
+
+// eslint-disable-next-line import/order
 import { E } from '@agoric/eventual-send';
-import test from 'ava';
 import {
   observeIteration,
   makeNotifierKit,

--- a/packages/notifier/test/test-notifier.js
+++ b/packages/notifier/test/test-notifier.js
@@ -1,9 +1,7 @@
 // @ts-check
-import '@agoric/install-ses';
 
-import test from 'ava';
+import { test } from './prepare-test-env-ava.js';
 import { makeNotifierKit } from '../src/index.js';
-
 import '../src/types.js';
 
 test('notifier - initial state', async t => {

--- a/packages/notifier/test/test-subscriber-examples.js
+++ b/packages/notifier/test/test-subscriber-examples.js
@@ -1,7 +1,9 @@
 // @ts-check
-import '@agoric/install-ses';
+
+import { test } from './prepare-test-env-ava.js';
+
+// eslint-disable-next-line import/order
 import { E } from '@agoric/eventual-send';
-import test from 'ava';
 import {
   observeIteration,
   makeSubscriptionKit,


### PR DESCRIPTION
This also adds a test:c8 script for coverage.

Reviewers will note that I’m copying `lockdown.js` up from lower layers of the onion—this might factor into a utility package and I’m hoping the extent of that change will be obvious when more of the packages have converted to NESM. `ses-install` introduces a dependency cycle at these layers . To avoid an upward-dependency on SwingSet, each of these conversions also creates a version of `prepare-test-ava`, each of which is actually varies depending on the layers beneath it and wouldn’t package well.