### PR TITLE
Cosmos upgrade to v0.43.0-rc2.agoric

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ replace google.golang.org/grpc => google.golang.org/grpc v1.33.2
 
 // At least until GetABCIEventHistory() is implemented and released.
 // And also `gentx --keyring-dir=...`
-replace github.com/cosmos/cosmos-sdk => github.com/agoric-labs/cosmos-sdk v0.43.0-rc0.agoric
+replace github.com/cosmos/cosmos-sdk => github.com/agoric-labs/cosmos-sdk v0.43.0-rc2.agoric
 
 // For testing against a local cosmos-sdk or tendermint
 // replace github.com/cosmos/cosmos-sdk => ../forks/cosmos-sdk

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/agoric-labs/cosmos-sdk v0.43.0-beta1.0.20210623214818-65f9554e0ddf h1
 github.com/agoric-labs/cosmos-sdk v0.43.0-beta1.0.20210623214818-65f9554e0ddf/go.mod h1:R2Rl4vquyMn0d88HFmyeEoY2W7Tvyze0yiaFGqYnleE=
 github.com/agoric-labs/cosmos-sdk v0.43.0-rc0.agoric h1:FEAGSUalJkM3aJ79+Y87VsUybGGLc44SMDqgQDVFyc4=
 github.com/agoric-labs/cosmos-sdk v0.43.0-rc0.agoric/go.mod h1:ctcrTEAhei9s8O3KSNvL0dxe+fVQGp07QyRb/7H9JYE=
+github.com/agoric-labs/cosmos-sdk v0.43.0-rc2.agoric h1:amg+qkeKS3g4oU/jcGmzuz3rwud1y2pY0S0yCodwVu0=
+github.com/agoric-labs/cosmos-sdk v0.43.0-rc2.agoric/go.mod h1:ctcrTEAhei9s8O3KSNvL0dxe+fVQGp07QyRb/7H9JYE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/packages/access-token/src/json-store.js
+++ b/packages/access-token/src/json-store.js
@@ -1,6 +1,7 @@
 // @ts-check
 import fs from 'fs';
 import path from 'path';
+import process from 'process';
 import Readlines from 'n-readlines';
 
 // TODO: Update this when we make a breaking change.
@@ -198,7 +199,7 @@ function makeJSONStore(dirPath, forceReset = false) {
    */
   function commit() {
     if (dirPath) {
-      const tempFile = `${storeFile}.tmp`;
+      const tempFile = `${storeFile}-${process.pid}.tmp`;
       const fd = fs.openSync(tempFile, 'w');
 
       for (const [key, value] of state.entries()) {

--- a/packages/solo/src/entrypoint.js
+++ b/packages/solo/src/entrypoint.js
@@ -22,9 +22,7 @@ const baseprog = path.basename(process.argv[1]);
 solo(baseprog, process.argv.slice(2)).then(
   res => process.exit(res || 0),
   reason => {
-    console.log(`error running ag-solo:`, reason);
-    console.error(`\
-Maybe the chain has bumped and you need to rerun ag-setup-solo?`);
+    console.error(`error running ag-solo:`, reason);
     process.exit(1);
   },
 );


### PR DESCRIPTION
Take most recent cosmos-sdk with our changes.  These ones include @zmanian and @JimLarson changes to vesting, as well as the most recent v0.43.0-rc2 changes from cosmos-sdk.  We want eventually to be on the v0.43.x official release when it is available.

Also, two minor cleanups in ag-solo.
