### PR TITLE
Stop trusting untrustable toString

### DIFF
--- a/packages/SwingSet/test/message-patterns.js
+++ b/packages/SwingSet/test/message-patterns.js
@@ -136,7 +136,7 @@ export function buildPatterns(log) {
       log(`match: ${b20amy === data}`);
     };
   }
-  out.a20 = ['b20 got [Alleged: amy]', 'match: true', 'a20 done'];
+  out.a20 = ['b20 got [object Alleged: amy]', 'match: true', 'a20 done'];
   test('a20');
 
   // bob!x({key: amy})
@@ -155,7 +155,7 @@ export function buildPatterns(log) {
       log(`match: ${b21amy === data.key2}`);
     };
   }
-  out.a21 = ['b21 got [Alleged: amy]', 'match: true', 'a21 done'];
+  out.a21 = ['b21 got [object Alleged: amy]', 'match: true', 'a21 done'];
   test('a21');
 
   // bob!x(bob)
@@ -233,7 +233,7 @@ export function buildPatterns(log) {
       return b.bill;
     };
   }
-  out.a42 = ['a42 done, [Alleged: bill] match true'];
+  out.a42 = ['a42 done, [object Alleged: bill] match true'];
   test('a42');
 
   // bob!x() -> <nada> // rejection
@@ -309,7 +309,7 @@ export function buildPatterns(log) {
     };
   }
   // TODO https://github.com/Agoric/agoric-sdk/issues/1631
-  out.a51 = ['a51 done, got [Alleged: bert], match true true'];
+  out.a51 = ['a51 done, got [object Alleged: bert], match true true'];
   test('a51');
 
   // bob!x() -> P(bill) // new reference
@@ -330,7 +330,7 @@ export function buildPatterns(log) {
       return b.bill;
     };
   }
-  out.a52 = ['a52 done, got [Alleged: bill], match true'];
+  out.a52 = ['a52 done, got [object Alleged: bill], match true'];
   test('a52');
 
   // bob!x(amy) -> P(amy) // new to bob
@@ -398,7 +398,7 @@ export function buildPatterns(log) {
       p1.resolve(b.bill);
     };
   }
-  out.a62 = ['a62 done, got [Alleged: bill]'];
+  out.a62 = ['a62 done, got [object Alleged: bill]'];
   test('a62');
 
   // bob!x(amy) -> P(amy) // resolve after receipt

--- a/packages/SwingSet/test/test-marshal.js
+++ b/packages/SwingSet/test/test-marshal.js
@@ -52,7 +52,7 @@ test('deserialize imports', async t => {
     slots: ['o-1'],
   });
   // a should be a proxy/presence. For now these are obvious.
-  t.is(a.toString(), '[Alleged: presence o-1]');
+  t.is(a.toString(), '[object Alleged: presence o-1]');
   t.truthy(Object.isFrozen(a));
 
   // m now remembers the proxy

--- a/packages/SwingSet/test/test-vpid-liveslots.js
+++ b/packages/SwingSet/test/test-vpid-liveslots.js
@@ -473,7 +473,7 @@ async function doVatResolveCase23(t, which, mode, stalls) {
 
   // assert that the vat saw the local promise being resolved too
   if (mode === 'presence') {
-    t.is(resolutionOfP1.toString(), `[Alleged: presence ${target2}]`);
+    t.is(resolutionOfP1.toString(), `[object Alleged: presence ${target2}]`);
   } else if (mode === 'data') {
     t.is(resolutionOfP1, 4);
   } else if (mode === 'promise-data') {

--- a/packages/SwingSet/test/virtualObjects/test-weakcollections.js
+++ b/packages/SwingSet/test/virtualObjects/test-weakcollections.js
@@ -54,11 +54,11 @@ test('weakMap in vat', async t => {
   t.deepEqual(nextLog(), [
     'probe of sample-object returns imported item #0',
     'probe of [object Promise] returns imported item #1',
-    'probe of [Alleged: remember-exp] returns mer',
-    'probe of [Alleged: holder-vo] returns mevo',
+    'probe of [object Alleged: remember-exp] returns mer',
+    'probe of [object Alleged: holder-vo] returns mevo',
     'probe of [object Promise] returns mep',
-    'probe of [Alleged: forget-exp] returns fer',
-    'probe of [Alleged: holder-vo] returns fevo',
+    'probe of [object Alleged: forget-exp] returns fer',
+    'probe of [object Alleged: holder-vo] returns fevo',
     'probe of [object Promise] returns fep',
   ]);
   await doSimple('betweenProbes');
@@ -68,11 +68,11 @@ test('weakMap in vat', async t => {
   t.deepEqual(nextLog(), [
     'probe of sample-object returns imported item #0',
     'probe of [object Promise] returns undefined',
-    'probe of [Alleged: remember-exp] returns mer',
-    'probe of [Alleged: holder-vo] returns mevo',
+    'probe of [object Alleged: remember-exp] returns mer',
+    'probe of [object Alleged: holder-vo] returns mevo',
     'probe of [object Promise] returns mep',
-    'probe of [Alleged: forget-exp] returns fer',
-    'probe of [Alleged: holder-vo] returns fevo',
+    'probe of [object Alleged: forget-exp] returns fer',
+    'probe of [object Alleged: holder-vo] returns fevo',
     'probe of [object Promise] returns fep',
   ]);
 });

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -140,12 +140,9 @@ const makeRemotableProto = (remotable, iface) => {
   } else {
     assert.fail(X`unrecognized typeof ${remotable}`);
   }
-  // Assign the arrow function to a variable to set its .name.
-  const toString = () => `[${iface}]`;
   return harden(
     create(oldProto, {
       [PASS_STYLE]: { value: 'remotable' },
-      toString: { value: toString },
       [Symbol.toStringTag]: { value: iface },
     }),
   );

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -120,18 +120,29 @@ export const pureCopy = val => {
 harden(pureCopy);
 
 /**
+ * Now that the remotableProto does not provide its own `toString` method,
+ * ensure it always inherits from something. The original prototype of
+ * `remotable` if there was one, or `Object.prototype` otherwise.
+ *
  * @param {Object} remotable
  * @param {InterfaceSpec} iface
  * @returns {Object}
  */
 const makeRemotableProto = (remotable, iface) => {
-  const oldProto = getPrototypeOf(remotable);
+  let oldProto = getPrototypeOf(remotable);
   if (typeof remotable === 'object') {
+    if (oldProto === null) {
+      oldProto = objectPrototype;
+    }
     assert(
       oldProto === objectPrototype || oldProto === null,
       X`For now, remotables cannot inherit from anything unusual, in ${remotable}`,
     );
   } else if (typeof remotable === 'function') {
+    assert(
+      oldProto !== null,
+      X`Original function must not inherit from null: ${remotable}`,
+    );
     assert(
       oldProto === functionPrototype ||
         getPrototypeOf(oldProto) === functionPrototype,

--- a/packages/marshal/src/passStyleOf.js
+++ b/packages/marshal/src/passStyleOf.js
@@ -261,7 +261,6 @@ const checkRemotableProtoOf = (original, check = x => x) => {
    *
    * @type {{ [PASS_STYLE]: string,
    *          [Symbol.toStringTag]: string,
-   *          toString: () => void
    *        }}
    */
   const proto = getPrototypeOf(original);
@@ -317,7 +316,6 @@ const checkRemotableProtoOf = (original, check = x => x) => {
 
   const {
     [PASS_STYLE]: passStyleDesc,
-    toString: toStringDesc,
     // @ts-ignore https://github.com/microsoft/TypeScript/issues/1863
     [Symbol.toStringTag]: ifaceDesc,
     ...rest
@@ -332,10 +330,6 @@ const checkRemotableProtoOf = (original, check = x => x) => {
     check(
       passStyleDesc.value === 'remotable',
       X`Expected 'remotable', not ${q(passStyleDesc.value)}`,
-    ) &&
-    check(
-      typeof toStringDesc.value === 'function',
-      X`toString must be a function`,
     ) &&
     checkIface(ifaceDesc && ifaceDesc.value, check)
   );

--- a/packages/marshal/test/test-marshal-far-function.js
+++ b/packages/marshal/test/test-marshal-far-function.js
@@ -5,7 +5,7 @@ import { test } from './prepare-test-env-ava.js';
 import { Far } from '../src/marshal.js';
 import { getInterfaceOf, passStyleOf } from '../src/passStyleOf.js';
 
-const { freeze } = Object;
+const { freeze, getPrototypeOf, setPrototypeOf } = Object;
 
 test('Far functions', t => {
   t.notThrows(() => Far('arrow', a => a + 1), 'Far function');
@@ -57,5 +57,13 @@ test('Data can contain far functions', t => {
   const mightBeMethod = a => a + 1;
   t.throws(() => passStyleOf(freeze({ x: 8, foo: mightBeMethod })), {
     message: /Remotables with non-methods like "x" /,
+  });
+});
+
+test('function without prototype', t => {
+  const arrow = a => a;
+  setPrototypeOf(arrow, null);
+  t.throws(() => Far('arrow', arrow), {
+    message: /must not inherit from null/,
   });
 });

--- a/packages/marshal/test/test-marshal-far-function.js
+++ b/packages/marshal/test/test-marshal-far-function.js
@@ -5,7 +5,7 @@ import { test } from './prepare-test-env-ava.js';
 import { Far } from '../src/marshal.js';
 import { getInterfaceOf, passStyleOf } from '../src/passStyleOf.js';
 
-const { freeze, getPrototypeOf, setPrototypeOf } = Object;
+const { freeze, setPrototypeOf } = Object;
 
 test('Far functions', t => {
   t.notThrows(() => Far('arrow', a => a + 1), 'Far function');

--- a/packages/marshal/test/test-marshal-far-obj.js
+++ b/packages/marshal/test/test-marshal-far-obj.js
@@ -10,6 +10,7 @@ import {
 
 import { Remotable, Far, makeMarshal } from '../src/marshal.js';
 
+const { quote: q } = assert;
 const { create, prototype: objectPrototype } = Object;
 
 // this only includes the tests that do not use liveSlots
@@ -40,8 +41,9 @@ test('Remotable/getInterfaceOf', t => {
   const p = Far('MyHandle');
   harden(p);
   // console.log(p);
-  t.is(getInterfaceOf(p), 'Alleged: MyHandle', `interface is MyHandle`);
-  t.is(`${p}`, '[Alleged: MyHandle]', 'stringify is [MyHandle]');
+  t.is(getInterfaceOf(p), 'Alleged: MyHandle', `interface MyHandle`);
+  t.is(`${p}`, '[object Alleged: MyHandle]', 'stringify [MyHandle]');
+  t.is(`${q(p)}`, '"[Alleged: MyHandle]"', 'quotify [MyHandle]');
 
   const p2 = Far('Thing', {
     name() {
@@ -75,28 +77,24 @@ const BAD_PASS_STYLE = Symbol('passStyle');
 
 const goodRemotableProto = harden({
   [GOOD_PASS_STYLE]: 'remotable',
-  toString: Object, // Any function will do
   [Symbol.toStringTag]: 'Alleged: Good remotable proto',
 });
 
 const badRemotableProto1 = harden({
   [BAD_PASS_STYLE]: 'remotable',
-  toString: Object, // Any function will do
   [Symbol.toStringTag]: 'Alleged: Good remotable proto',
 });
 const badRemotableProto2 = harden({
   [GOOD_PASS_STYLE]: 'string',
-  toString: Object, // Any function will do
   [Symbol.toStringTag]: 'Alleged: Good remotable proto',
 });
 const badRemotableProto3 = harden({
   [GOOD_PASS_STYLE]: 'remotable',
-  toString: {}, // Any function will do
+  toString: Object, // Any function will do
   [Symbol.toStringTag]: 'Alleged: Good remotable proto',
 });
 const badRemotableProto4 = harden({
   [GOOD_PASS_STYLE]: 'remotable',
-  toString: Object, // Any function will do
   [Symbol.toStringTag]: 'Bad remotable proto',
 });
 
@@ -122,9 +120,6 @@ test('getInterfaceOf validation', t => {
 const NON_METHOD = {
   message: /cannot serialize Remotables with non-methods like .* in .*/,
 };
-const TO_STRING_NONFUNC = {
-  message: /toString must be a function/,
-};
 const IFACE_ALLEGED = {
   message: /For now, iface "Bad remotable proto" must be "Remotable" or begin with "Alleged: "; unimplemented/,
 };
@@ -147,7 +142,7 @@ test('passStyleOf validation of remotables', t => {
   t.is(passStyleOf(sub(goodRemotableProto)), 'remotable');
   t.throws(() => passStyleOf(sub(badRemotableProto1)), UNEXPECTED_PROPS);
   t.throws(() => passStyleOf(sub(badRemotableProto2)), EXPECTED_PRESENCE);
-  t.throws(() => passStyleOf(sub(badRemotableProto3)), TO_STRING_NONFUNC);
+  t.throws(() => passStyleOf(sub(badRemotableProto3)), UNEXPECTED_PROPS);
   t.throws(() => passStyleOf(sub(badRemotableProto4)), IFACE_ALLEGED);
 });
 

--- a/packages/marshal/test/test-marshal-far-obj.js
+++ b/packages/marshal/test/test-marshal-far-obj.js
@@ -11,7 +11,7 @@ import {
 import { Remotable, Far, makeMarshal } from '../src/marshal.js';
 
 const { quote: q } = assert;
-const { create, prototype: objectPrototype } = Object;
+const { create, getPrototypeOf, prototype: objectPrototype } = Object;
 
 // this only includes the tests that do not use liveSlots
 
@@ -276,4 +276,9 @@ test('transitional remotables', t => {
 
   // anything with non-enumerable properties is rejected
   shouldThrow(['nonenumStringData', 'enumStringFunc'], FAR_ONLYMETH);
+});
+
+test('object without prototype', t => {
+  const base = Far('base', { __proto__: null });
+  t.is(getPrototypeOf(getPrototypeOf(base)), Object.prototype);
 });

--- a/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
@@ -53,7 +53,7 @@ test.skip('ZCF metering crash on invitation exercise', async t => {
 const meterExceededInSecondOfferLog = [
   '=> alice is set up',
   '=> alice.doMeterExceptionInHook called',
-  'Swap outcome resolves to an invitation: [Alleged: presence o-73]',
+  'Swap outcome resolves to an invitation: [object Alleged: presence o-73]',
   'aliceMoolaPurse: balance {"brand":{},"value":0}',
   'aliceSimoleanPurse: balance {"brand":{},"value":0}',
   'aliceMoolaPurse: balance {"brand":{},"value":5}',

--- a/packages/zoe/test/unitTests/test-testHelpers.js
+++ b/packages/zoe/test/unitTests/test-testHelpers.js
@@ -102,7 +102,7 @@ test('assertAmountsEqual - brand mismatch', t => {
   assertAmountsEqual(fakeT, moola(0), bucks(0));
   t.is(
     fakeT.getError(),
-    'brand ([Alleged: moola brand]) expected to equal [Alleged: bucks brand]',
+    'brand ([object Alleged: moola brand]) expected to equal [object Alleged: bucks brand]',
   );
 });
 


### PR DESCRIPTION
Because we cannot rely on a weakmap to validate that something was correct by construction, and functions are encapsulated, we cannot validate that this is a correct or even pure `toString` function. It was only there to make debugging marginally more pleasant anyway. Without it, the inherited `Object.prototype.toString` function gets what it needs from the `[Symbol.toStringTag]` property, costing only the stift from `'[Alleged: foo]'` to `[object Alleged: foo]'`. The `q` function was already getting what it needed from the `[Symbol.toStringTag]` property, rendering as `'"[Alleged: foo]"'` both before and after this PR.