### PR TITLE
fix(xsnap)!: avoid O(n^2) Array, Map, Set growth

### DIFF
--- a/packages/xsnap/api.js
+++ b/packages/xsnap/api.js
@@ -3,7 +3,7 @@
 /** The version identifier for our meter type.
  * TODO Bump this whenever there's a change to metering semantics.
  */
-export const METER_TYPE = 'xs-meter-8';
+export const METER_TYPE = 'xs-meter-9';
 
 export const ExitCode = {
   E_UNKNOWN_ERROR: -1,

--- a/packages/xsnap/src/xsnap.c
+++ b/packages/xsnap/src/xsnap.c
@@ -213,7 +213,7 @@ typedef enum {
 	E_TOO_MUCH_COMPUTATION = 17,
 } ExitCode;
 
-ExitCode main(int argc, char* argv[])
+int main(int argc, char* argv[])
 {
 	int argi;
 	int argr = 0;
@@ -827,14 +827,10 @@ void fxFreezeBuiltIns(txMachine* the)
 	mxFreezeBuiltInCall; mxPush(mxGeneratorPrototype); mxFreezeBuiltInRun;
 	mxFreezeBuiltInCall; mxPush(mxHostPrototype); mxFreezeBuiltInRun;
 	mxFreezeBuiltInCall; mxPush(mxIteratorPrototype); mxFreezeBuiltInRun;
-	mxFreezeBuiltInCall; mxPush(mxMapEntriesIteratorPrototype); mxFreezeBuiltInRun;
-	mxFreezeBuiltInCall; mxPush(mxMapKeysIteratorPrototype); mxFreezeBuiltInRun;
-	mxFreezeBuiltInCall; mxPush(mxMapValuesIteratorPrototype); mxFreezeBuiltInRun;
+	mxFreezeBuiltInCall; mxPush(mxMapIteratorPrototype); mxFreezeBuiltInRun;
 	mxFreezeBuiltInCall; mxPush(mxModulePrototype); mxFreezeBuiltInRun;
 	mxFreezeBuiltInCall; mxPush(mxRegExpStringIteratorPrototype); mxFreezeBuiltInRun;
-	mxFreezeBuiltInCall; mxPush(mxSetEntriesIteratorPrototype); mxFreezeBuiltInRun;
-	mxFreezeBuiltInCall; mxPush(mxSetKeysIteratorPrototype); mxFreezeBuiltInRun;
-	mxFreezeBuiltInCall; mxPush(mxSetValuesIteratorPrototype); mxFreezeBuiltInRun;
+	mxFreezeBuiltInCall; mxPush(mxSetIteratorPrototype); mxFreezeBuiltInRun;
 	mxFreezeBuiltInCall; mxPush(mxStringIteratorPrototype); mxFreezeBuiltInRun;
 	mxFreezeBuiltInCall; mxPush(mxTransferPrototype); mxFreezeBuiltInRun;
 	mxFreezeBuiltInCall; mxPush(mxTypedArrayPrototype); mxFreezeBuiltInRun;


### PR DESCRIPTION
TODO:
 - [x] tests to verify performance improvements

*BREAKING CHANGE:* xs-meter-9 represents XS Map/Set optimizations

see also https://github.com/agoric-labs/moddable/tree/ag-testnet-5 ; this time, I merged Moddable's `public` branch into our "vendor branch" rather than rebasing.

commit 437261727 is work that we would have gotten for free if we had integrated Moddable's refactor of `xsnap.c` into platform and application. https://github.com/endojs/endo/issues/681

fixes #3012