### PR TITLE
refactor: Omnibus RESM to NESM conversions

### DIFF
--- a/packages/install-ses/package.json
+++ b/packages/install-ses/package.json
@@ -2,9 +2,7 @@
   "name": "@agoric/install-ses",
   "version": "0.5.21",
   "description": "install SES at import time",
-  "parsers": {
-    "js": "mjs"
-  },
+  "type": "module",
   "main": "install-ses.js",
   "scripts": {
     "build": "exit 0",
@@ -15,8 +13,7 @@
     "lint": "eslint '**/*.js'"
   },
   "devDependencies": {
-    "ava": "^3.12.1",
-    "esm": "agoric-labs/esm#Agoric-built"
+    "ava": "^3.12.1"
   },
   "dependencies": {
     "@agoric/eventual-send": "^0.13.23",
@@ -38,9 +35,6 @@
   "ava": {
     "files": [
       "test/**/test-*.js"
-    ],
-    "require": [
-      "esm"
     ]
   },
   "eslintConfig": {

--- a/packages/swing-store-lmdb/package.json
+++ b/packages/swing-store-lmdb/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
+    "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint-check": "yarn lint",
@@ -26,7 +27,8 @@
   "devDependencies": {
     "@agoric/install-ses": "^0.5.21",
     "@agoric/swing-store-simple": "^0.4.7",
-    "ava": "^3.12.1"
+    "ava": "^3.12.1",
+    "c8": "^7.7.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/swing-store-lmdb/package.json
+++ b/packages/swing-store-lmdb/package.json
@@ -2,9 +2,7 @@
   "name": "@agoric/swing-store-lmdb",
   "version": "0.5.7",
   "description": "Persistent storage for SwingSet, based on an LMDB key-value database",
-  "parsers": {
-    "js": "mjs"
-  },
+  "type": "module",
   "main": "src/lmdbSwingStore.js",
   "repository": "https://github.com/Agoric/agoric-sdk",
   "author": "Agoric",
@@ -28,8 +26,7 @@
   "devDependencies": {
     "@agoric/install-ses": "^0.5.21",
     "@agoric/swing-store-simple": "^0.4.7",
-    "ava": "^3.12.1",
-    "esm": "agoric-labs/esm#Agoric-built"
+    "ava": "^3.12.1"
   },
   "publishConfig": {
     "access": "public"
@@ -37,9 +34,6 @@
   "ava": {
     "files": [
       "test/**/test-*.js"
-    ],
-    "require": [
-      "esm"
     ],
     "timeout": "2m"
   },

--- a/packages/swing-store-simple/package.json
+++ b/packages/swing-store-simple/package.json
@@ -2,9 +2,7 @@
   "name": "@agoric/swing-store-simple",
   "version": "0.4.7",
   "description": "Persistent storage for SwingSet, based on a Map, optionally backed by a simple JSON file",
-  "parsers": {
-    "js": "mjs"
-  },
+  "type": "module",
   "main": "src/simpleSwingStore.js",
   "repository": "https://github.com/Agoric/agoric-sdk",
   "author": "Agoric",
@@ -25,8 +23,7 @@
   },
   "devDependencies": {
     "@agoric/install-ses": "^0.5.21",
-    "ava": "^3.12.1",
-    "esm": "agoric-labs/esm#Agoric-built"
+    "ava": "^3.12.1"
   },
   "publishConfig": {
     "access": "public"
@@ -34,9 +31,6 @@
   "ava": {
     "files": [
       "test/**/test-*.js"
-    ],
-    "require": [
-      "esm"
     ],
     "timeout": "2m"
   },

--- a/packages/swing-store-simple/package.json
+++ b/packages/swing-store-simple/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
+    "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint-check": "yarn lint",
@@ -23,7 +24,8 @@
   },
   "devDependencies": {
     "@agoric/install-ses": "^0.5.21",
-    "ava": "^3.12.1"
+    "ava": "^3.12.1",
+    "c8": "^7.7.2"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
These RESM to NESM migrations are presented as a single PR since they’re individually trivial.

- install-ses
- swing-store-simple
- swing-store-lmdb

Each of these that has tests has an accompanying commit to add a test:c8 coverage script.