### PR TITLE
feat: allow users to pass offerArgs with their offer

### DIFF
--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -202,6 +202,7 @@
 /**
  * @callback OfferHandler
  * @param {ZCFSeat} seat
+ * @param {Object=} offerArgs
  * @returns {any}
  */
 

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -264,15 +264,17 @@ export const makeZCFZygote = (
     handleOffer: (invitationHandle, zoeSeatAdmin, seatData) => {
       const zcfSeat = makeZCFSeat(zoeSeatAdmin, seatData);
       const offerHandler = takeOfferHandler(invitationHandle);
-      const offerResultP = E(offerHandler)(zcfSeat).catch(reason => {
-        if (reason === undefined) {
-          const newErr = new Error(
-            `If an offerHandler throws, it must provide a reason of type Error, but the reason was undefined. Please fix the contract code to specify a reason for throwing.`,
-          );
-          throw zcfSeat.fail(newErr);
-        }
-        throw zcfSeat.fail(reason);
-      });
+      const offerResultP = E(offerHandler)(zcfSeat, seatData.offerArgs).catch(
+        reason => {
+          if (reason === undefined) {
+            const newErr = new Error(
+              `If an offerHandler throws, it must provide a reason of type Error, but the reason was undefined. Please fix the contract code to specify a reason for throwing.`,
+            );
+            throw zcfSeat.fail(newErr);
+          }
+          throw zcfSeat.fail(reason);
+        },
+      );
       const exitObj = makeExitObj(seatData.proposal, zcfSeat);
       /** @type {HandleOfferResult} */
       return harden({ offerResultP, exitObj });

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -14,6 +14,7 @@
  * @property {Notifier<Allocation>} notifier
  * @property {Allocation} initialAllocation
  * @property {SeatHandle} seatHandle
+ * @property {Object=} offerArgs
  */
 
 /**
@@ -75,7 +76,9 @@
  * @property {() => void} assertAcceptingOffers
  * @property {(invitationHandle: InvitationHandle,
  *     initialAllocation: Allocation,
- *     proposal: ProposalRecord) => UserSeat } makeUserSeat
+ *     proposal: ProposalRecord,
+ *     offerArgs: Object=,
+ * ) => UserSeat } makeUserSeat
  * @property {MakeNoEscrowSeat} makeNoEscrowSeat
  * @property {() => Instance} getInstance
  * @property {() => Object} getPublicFacet

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -96,7 +96,7 @@ export const makeStartInstance = (
           invitationHandle,
           initialAllocation,
           proposal,
-          offerArgs,
+          offerArgs = undefined,
         ) => {
           const offerResultPromiseKit = makePromiseKit();
           handlePKitWarning(offerResultPromiseKit);

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -92,7 +92,12 @@ export const makeStartInstance = (
           zoeSeatAdmins.forEach(zoeSeatAdmin => zoeSeatAdmin.fail(reason));
         },
         stopAcceptingOffers: () => (acceptingOffers = false),
-        makeUserSeat: (invitationHandle, initialAllocation, proposal) => {
+        makeUserSeat: (
+          invitationHandle,
+          initialAllocation,
+          proposal,
+          offerArgs,
+        ) => {
           const offerResultPromiseKit = makePromiseKit();
           handlePKitWarning(offerResultPromiseKit);
           const exitObjPromiseKit = makePromiseKit();
@@ -116,6 +121,7 @@ export const makeStartInstance = (
             initialAllocation,
             notifier,
             seatHandle,
+            offerArgs,
           });
 
           zoeSeatAdmins.add(zoeSeatAdmin);

--- a/packages/zoe/test/offerArgsUsageContract.js
+++ b/packages/zoe/test/offerArgsUsageContract.js
@@ -1,0 +1,14 @@
+// @ts-check
+
+/** @type {ContractStartFn} */
+const start = zcf => {
+  /** @type {OfferHandler} */
+  const handler = (_seat, offerArgs) => {
+    assert.typeof(offerArgs.myArg, 'string');
+    return offerArgs.myArg;
+  };
+  const creatorInvitation = zcf.makeInvitation(handler, 'creatorInvitation');
+  return harden({ creatorInvitation });
+};
+harden(start);
+export { start };

--- a/packages/zoe/test/swingsetTests/offerArgs/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/offerArgs/bootstrap.js
@@ -1,0 +1,20 @@
+import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
+
+export function buildRootObject(vatPowers, vatParameters) {
+  const { contractBundles: cb } = vatParameters;
+  return Far('root', {
+    async bootstrap(vats, devices) {
+      const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
+        devices.vatAdmin,
+      );
+      const zoe = await E(vats.zoe).buildZoe(vatAdminSvc);
+      const installations = {
+        offerArgsUsageContract: await E(zoe).install(cb.offerArgsUsageContract),
+      };
+
+      const aliceP = E(vats.alice).build(zoe, installations);
+      await E(aliceP).offerArgsUsageTest();
+    },
+  });
+}

--- a/packages/zoe/test/swingsetTests/offerArgs/test-offerArgs.js
+++ b/packages/zoe/test/swingsetTests/offerArgs/test-offerArgs.js
@@ -1,0 +1,76 @@
+/* global __dirname */
+
+// TODO Remove babel-standalone preinitialization
+// https://github.com/endojs/endo/issues/768
+import '@agoric/babel-standalone';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@agoric/install-ses';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import test from 'ava';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { buildVatController, buildKernelBundles } from '@agoric/swingset-vat';
+import bundleSource from '@agoric/bundle-source';
+
+const CONTRACT_FILES = ['offerArgsUsageContract'];
+
+test.before(async t => {
+  const start = Date.now();
+  const kernelBundles = await buildKernelBundles();
+  const step2 = Date.now();
+  const contractBundles = {};
+  await Promise.all(
+    CONTRACT_FILES.map(async settings => {
+      let bundleName;
+      let contractPath;
+      if (typeof settings === 'string') {
+        bundleName = settings;
+        contractPath = settings;
+      } else {
+        ({ bundleName, contractPath } = settings);
+      }
+      const source = `${__dirname}/../../${contractPath}`;
+      const bundle = await bundleSource(source);
+      contractBundles[bundleName] = bundle;
+    }),
+  );
+  const step3 = Date.now();
+
+  const vats = {};
+  await Promise.all(
+    ['alice', 'zoe'].map(async name => {
+      const source = `${__dirname}/vat-${name}.js`;
+      const bundle = await bundleSource(source);
+      vats[name] = { bundle };
+    }),
+  );
+  const bootstrapSource = `${__dirname}/bootstrap.js`;
+  vats.bootstrap = {
+    bundle: await bundleSource(bootstrapSource),
+    parameters: { contractBundles }, // argv will be added to this
+  };
+  const config = { bootstrap: 'bootstrap', vats };
+  config.defaultManagerType = 'xs-worker';
+
+  const step4 = Date.now();
+  const ktime = `${(step2 - start) / 1000}s kernel`;
+  const ctime = `${(step3 - step2) / 1000}s contracts`;
+  const vtime = `${(step4 - step3) / 1000}s vats`;
+  const ttime = `${(step4 - start) / 1000}s total`;
+  console.log(`bundling: ${ktime}, ${ctime}, ${vtime}, ${ttime}`);
+
+  t.context.data = { kernelBundles, config };
+});
+
+async function main(t, argv) {
+  const { kernelBundles, config } = t.context.data;
+  const controller = await buildVatController(config, argv, { kernelBundles });
+  await controller.run();
+  return controller.dump();
+}
+
+const expected = ['offerArgs.myArg was accessed in the contract'];
+
+test.serial('private args usage', async t => {
+  const dump = await main(t);
+  t.deepEqual(dump.log, expected);
+});

--- a/packages/zoe/test/swingsetTests/offerArgs/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/offerArgs/vat-alice.js
@@ -1,0 +1,31 @@
+import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
+
+const build = async (log, zoe, installations) => {
+  return Far('build', {
+    offerArgsUsageTest: async () => {
+      const { creatorInvitation } = await E(zoe).startInstance(
+        installations.offerArgsUsageContract,
+      );
+
+      const offerArgs = harden({
+        myArg: 'offerArgs.myArg was accessed in the contract',
+      });
+
+      const userSeat = await E(zoe).offer(
+        creatorInvitation,
+        undefined,
+        undefined,
+        offerArgs,
+      );
+      const offerResult = await E(userSeat).getOfferResult();
+      log(offerResult);
+    },
+  });
+};
+
+export function buildRootObject(vatPowers) {
+  return Far('root', {
+    build: (...args) => build(vatPowers.testLog, ...args),
+  });
+}

--- a/packages/zoe/test/swingsetTests/offerArgs/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/offerArgs/vat-zoe.js
@@ -1,0 +1,10 @@
+import { Far } from '@agoric/marshal';
+
+// noinspection ES6PreferShortImport
+import { makeZoe } from '../../../src/zoeService/zoe';
+
+export function buildRootObject(_vatPowers) {
+  return Far('root', {
+    buildZoe: vatAdminSvc => makeZoe(vatAdminSvc),
+  });
+}


### PR DESCRIPTION
Changes `E(zoe).offer` to take an optional `offerArgs` object. The `offerArgs` are passed through Zoe to the offerHandler in the ZCFVat. The contract code can chose to validate and use or drop the object.

This gives the user a way to communicate preferences to the contract outside of the proposal. 

closes #3574