### PR TITLE
add "run policy" object to controller.run()

### DIFF
--- a/packages/SwingSet/docs/run-policy.md
+++ b/packages/SwingSet/docs/run-policy.md
@@ -1,0 +1,135 @@
+# The Run Policy
+
+The SwingSet kernel maintains a queue of pending operations to execute: mostly deliveries to vats and promise resolution notifications. This queue may be sizable, and each operation may provoke more work to be added to the list.
+
+SwingSet manages its own prioritization and scheduling for this workload, but it does not get to decide how much work should be done at a time. The host applications breaks this work up into "blocks". We colloquially describe this as the "block size": in the SwingSet context this refers to the number of deliveries ("cranks") performed before declaring the block to be finished, rather than measuring the number of bytes in some host application consensus data structure.
+
+The host is responsible for committing the SwingSet state to durable storage (i.e. `swingstore.commit()`) at the end of a block. Outbound messages are embargoed until after this commit point, to prevent "hangover inconsistency" from revealing state that might still get unwound. Large block sizes are generally more efficient, however 1: they increase latency, because outbound reply messages cannot be delivered until the end of the block, and 2: they increase the likelihood of losing progress because of a crash or other interrupt during the block. Depending upon the application, it may be appropriate to limit blocks to 5-10 seconds of computation.
+
+To impose this limit, the host application has two choices. The first is to call `controller.step()` many times, until the limit is reached. Each invocation performs one delivery to one vat, and returns `true` if there is more work left on the run-queue, or `false` if the queue is empty. Applications could use this method if they want to impose a wallclock limit on the block (keep calling `step()` until 5 seconds have passed or it returns `false`).
+
+But the more sophisticated approach is to call `controller.run(policy)`, with a "Run Policy" object that knows when the block should end. The policy object will get detailed information about each delivery, including the metering results (how many low-level JS engine operations were performed), and can use this to guide the block size.
+
+## Cranks
+
+The kernel maintains two queues. The highest priority queue contains "GC Actions", which are messages to vats that indicate an object has been garbage collected and can now be freed. These are provoked by reference-counting operations that occur as a side-effect of GC syscalls, as well as vat termination events. Each GC Action counts as a "crank", and is reported to the policy object. The policy may end a block while there is still GC Action work to do, in which case the kernel will pick it back up again when the next block begins.
+
+If the GC Action queue is entirely empty, the kernel will look for regular work to do. This consists of the following event types:
+
+* message deliveries to vats (provoked by `syscall.send`, delivered as `dispatch.deliver`)
+* promise resolution notifications (provoked by `syscall.resolve`, delivered as `dispatch.notify`)
+* vat creation
+
+Each message delivery and resolution notification causes (at most) one vat to execute one "crank" (it might not execute any crank, e.g. when a message is delivered to an unresolved promise, it just gets added to the promise's queue). This crank gives the vat some amount of time to process the delivery, during which it may invoke any number of syscalls. The crank might cause the vat to be terminated, either because of an error, or because it took too much CPU and exceeded its Meter's allowance. Each crank yields a "delivery results object", which indicates the success or failure of the delivery.
+
+When run in a suitable vat worker (`managerType: 'xs-worker'`), the delivery results also include the number of "computrons" consumed, as counted by the JS engine. Computrons are vaguely correlated to CPU cycles (despite being much larger) and thus some correspondence to wallclock time. A Run Policy which wishes to limit wallclock time in a consensus-base manner should pay attention to the cumulative computron count, and end the block after some experimentally-determined limit.
+
+Vat creation also gives a single vat (the brand new one) time to run the top-level forms of its source bundle, as well as the invocation of its `buildRootObject()` method. This typically takes considerably longer than the subsequent messages, and is not currently metered.
+
+## Run Policy
+
+The kernel will invoke the following methods on the policy object (so all must exist, even if they're empty):
+
+* `policy.vatCreated()`
+* `policy.crankComplete({ computrons })`
+* `policy.crankFailed()`
+
+All methods should return `true` if the kernel should keep running, or `false` if it should stop.
+
+The `computrons` argument may be `undefined` (e.g. if the crank was delivered to a non-`xs worker`-based vat, such as the comms vat). The policy should probably treat this as equivalent to some "typical" number of computrons.
+
+`crankFailed` indicates the vat suffered an error during crank delivery, such as a metering fault, memory allocation fault, or fatal syscall. We do not currently have a way to measure the computron usage of failed cranks (many of the error cases are signaled by the worker process exiting with a distinctive status code, which does not give it an opportunity to report back detailed metering data). The run policy should assume the worst.
+
+More arguments may be added in the future, such as:
+* `vatCreated:` the size of the source bundle
+* `crankComplete`: the number of syscalls that were made
+* `crankComplete`: the aggregate size of the delivery/notification arguments
+  * (the first message delivered to each ZCF contract vat contains a very large contract source bundle, and takes considerable time to execute, and this would let the policy treat these cranks accordingly)
+* `crankFailed`: the number of computrons consumed before the failure
+* `crankFailed`: the nature of the failure (we might be able to distinguish between 1: per-crank metering limit exceeded, 2: allocation limit exceed, 3: fatal syscall, 4: Meter exhausted)
+
+The run policy should be provided as the first argument to `controller.run()`. If omitted, the kernel defaults to `forever`, a policy that runs until the queue is empty.
+
+## Typical Run Policies
+
+A basic policy might simply limit the block to 100 cranks and two vat creations:
+
+```js
+function make100CrankPolicy() {
+  let cranks = 0;
+  let vats = 0;
+  const policy = harden({
+    vatCreated() {
+      vats += 1;
+      return (vats < 2);
+    },
+    crankComplete(details) {
+      cranks += 1;
+      return (cranks < 100);
+    },
+    crankFailed() {
+      cranks += 1;
+      return (cranks < 100);
+    },
+  });
+}
+```
+
+and would be supplied like:
+
+```js
+while(1) {
+  processInboundIO();
+  const policy = make100CrankPolicy();
+  await controller.run(policy);
+  commit();
+  processOutboundIO();
+}
+```
+
+Note that a new policy object should be provided for each call to `run()`.
+
+A more sophisticated one would count computrons. Suppose that experiments suggest that one million computrons take about 5 seconds to execute. The policy would look like:
+
+
+```js
+function makeComputronCounterPolicy(limit) {
+  let total = 0;
+  const policy = harden({
+    vatCreated() {
+      total += 100000; // pretend vat creation takes 100k computrons
+      return (total < limit);
+    },
+    crankComplete(details) {
+      const { computrons } = details;
+      total += computrons;
+      return (total < limit);
+    },
+    crankFailed() {
+      total += 1000000; // who knows, 1M is as good as anything
+      return (total < limit);
+    },
+  });
+}
+```
+
+See `src/runPolicies.js` for examples.
+
+## Non-Consensus Wallclock Limits
+
+If the SwingSet kernel is not being operated in consensus mode, then it is safe to use wallclock time as a block limit:
+
+```js
+function makeWallclockPolicy(seconds) {
+  let timeout = Date.now() + 1000*seconds;
+  const policy = harden({
+    vatCreated: () => Date.now() < timeout,
+    crankComplete: () => Date.now() < timeout,
+    crankFailed: () => Date.now() < timeout,
+  });
+}
+```
+
+The kernel does not know (ahead of time) how long the last crank will take, so this will ensure the N-1 initial cranks take less than `seconds` time.
+
+The kernel knows nothing of time, because the kernel is specifically deterministic. If you want to use wallclock time (which is inherently non-deterministic across the separate nodes of a consensus machine), the run policy is responsible for bringing its own source of nondeterminism.

--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -330,6 +330,7 @@ export async function makeSwingsetController(
       const vatID = kernel.vatNameToID(vatName);
       const kref = kernel.getRootObject(vatID);
       kernel.pinObject(kref);
+      return kref;
     },
 
     // these are for tests

--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -306,8 +306,8 @@ export async function makeSwingsetController(
       kernel.kdebugEnable(flag);
     },
 
-    async run() {
-      return kernel.run();
+    async run(policy) {
+      return kernel.run(policy);
     },
 
     async step() {

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -70,6 +70,7 @@ const enableKernelGC = true;
 // d$NN.source = JSON({ bundle }) or JSON({ bundleName })
 // d$NN.options = JSON
 
+// crankNumber = $NN
 // runQueue = JSON(runQueue) // usually empty on disk
 // gcActions = JSON(gcActions) // usually empty on disk
 // pinnedObjects = ko$NN[,ko$NN..]

--- a/packages/SwingSet/src/runPolicies.js
+++ b/packages/SwingSet/src/runPolicies.js
@@ -1,0 +1,75 @@
+// @ts-check
+
+import { assert } from '@agoric/assert';
+
+export function foreverPolicy() {
+  /** @type { RunPolicy } */
+  return harden({
+    vatCreated(_details) {
+      return true;
+    },
+    crankComplete(_details) {
+      return true;
+    },
+    crankFailed(_details) {
+      return true;
+    },
+  });
+}
+
+export function crankCounter(maxCranks, maxCreateVats) {
+  let cranks = 0;
+  let vats = 0;
+  /** @type { RunPolicy } */
+  const policy = harden({
+    vatCreated() {
+      vats += 1;
+      return vats < maxCreateVats;
+    },
+    crankComplete(_details) {
+      cranks += 1;
+      return cranks < maxCranks;
+    },
+    crankFailed() {
+      cranks += 1;
+      return cranks < maxCranks;
+    },
+  });
+  return policy;
+}
+
+export function computronCounter(limit) {
+  assert.typeof(limit, 'bigint');
+  let total = 0n;
+  /** @type { RunPolicy } */
+  const policy = harden({
+    vatCreated() {
+      total += 100000n; // pretend vat creation takes 100k computrons
+      return total < limit;
+    },
+    crankComplete(details = {}) {
+      assert.typeof(details, 'object');
+      if (details.computrons) {
+        assert.typeof(details.computrons, 'bigint');
+        total += details.computrons;
+      }
+      return total < limit;
+    },
+    crankFailed() {
+      total += 1000000n; // who knows, 1M is as good as anything
+      return total < limit;
+    },
+  });
+  return policy;
+}
+
+export function wallClockWaiter(seconds) {
+  const timeout = Date.now() + 1000 * seconds;
+  /** @type { RunPolicy } */
+  const policy = harden({
+    vatCreated: () => Date.now() < timeout,
+    crankComplete: () => Date.now() < timeout,
+    crankFailed: () => Date.now() < timeout,
+  });
+  return policy;
+}

--- a/packages/SwingSet/src/types.js
+++ b/packages/SwingSet/src/types.js
@@ -188,3 +188,16 @@
  *
  * @typedef { ReturnType<typeof import('./kernel/state/storageWrapper').addHelpers> } KVStorePlus
  */
+
+/**
+ * @typedef { [tag: 'none'] } PolicyInputNone
+ * @typedef { [tag: 'create-vat', details: {} ]} PolicyInputCreateVat
+ * @typedef { [tag: 'crank', details: { computrons?: bigint }] } PolicyInputCrankComplete
+ * @typedef { [tag: 'crank-failed', details: {}]} PolicyInputCrankFailed
+ * @typedef { PolicyInputNone | PolicyInputCreateVat | PolicyInputCrankComplete | PolicyInputCrankFailed } PolicyInput
+ * @typedef { boolean } PolicyOutput
+ * @typedef { { vatCreated: (details: {}) => PolicyOutput,
+ *              crankComplete: (details: { computrons?: bigint }) => PolicyOutput,
+ *              crankFailed: (details: {}) => PolicyOutput,
+ *             } } RunPolicy
+ */

--- a/packages/SwingSet/test/run-policy/test-run-policy.js
+++ b/packages/SwingSet/test/run-policy/test-run-policy.js
@@ -1,0 +1,115 @@
+/* global __dirname */
+import { test } from '../../tools/prepare-test-env-ava.js';
+
+// eslint-disable-next-line import/order
+import path from 'path';
+import { provideHostStorage } from '../../src/hostStorage.js';
+import { initializeSwingset, makeSwingsetController } from '../../src/index.js';
+import { capargsOneSlot, capSlot, capargs } from '../util.js';
+import {
+  crankCounter,
+  computronCounter,
+  wallClockWaiter,
+} from '../../src/runPolicies.js';
+
+async function testCranks(t, mode) {
+  const config = {
+    vats: {
+      left: {
+        sourceSpec: path.join(__dirname, 'vat-policy-left.js'),
+      },
+      right: {
+        sourceSpec: path.join(__dirname, 'vat-policy-right.js'),
+        creationOptions: {
+          enableVatstore: true,
+        },
+      },
+    },
+    defaultManagerType: 'xs-worker',
+  };
+  const hostStorage = provideHostStorage();
+  await initializeSwingset(config, [], hostStorage);
+  const c = await makeSwingsetController(hostStorage);
+  c.pinVatRoot('left');
+  const rightKref = c.pinVatRoot('right');
+  const rightID = c.vatNameToID('right');
+  t.teardown(c.shutdown);
+
+  if (mode === 'messages' || mode === 'wallclock') {
+    // The 'message' mode sends doMessage() to left, which makes left send
+    // doMessage() to right, which makes right send doMessage() to left, etc.
+    // This uses four cranks per cycle, since each doMessage() also has a
+    // return promise that must be resolved.
+    const args = capargs([capSlot(0), 'disabled'], [rightKref]);
+    c.queueToVatRoot('left', 'doMessage', args);
+  } else if (mode === 'resolutions') {
+    // This triggers a back-and-forth cycle of promise resolution, which uses
+    // two cranks per cycle. The setup takes three cranks.
+    const args = capargsOneSlot(rightKref);
+    c.queueToVatRoot('left', 'startPromise', args);
+  } else if (mode === 'computrons') {
+    // Use doMessage() like above, but once every 10 cycles, do enough extra
+    // CPU to trigger a computron-limiting policy.
+    const args = capargs([capSlot(0), 0], [rightKref]);
+    c.queueToVatRoot('left', 'doMessage', args);
+  } else {
+    throw Error(`unknown mode ${mode}`);
+  }
+
+  let oldCrankNum = parseInt(hostStorage.kvStore.get('crankNumber'), 10);
+  function elapsedCranks() {
+    const newCrankNum = parseInt(hostStorage.kvStore.get('crankNumber'), 10);
+    const elapsed = newCrankNum - oldCrankNum;
+    oldCrankNum = newCrankNum;
+    return elapsed;
+  }
+
+  let more;
+
+  if (mode === 'messages' || mode === 'resolutions') {
+    more = await c.run(crankCounter(7, 0));
+    t.truthy(more, 'vat was supposed to run forever');
+    t.is(elapsedCranks(), 7);
+
+    more = await c.run(crankCounter(1, 0));
+    t.truthy(more, 'vat was supposed to run forever');
+    t.is(elapsedCranks(), 1);
+
+    more = await c.run(crankCounter(8, 0));
+    t.truthy(more, 'vat was supposed to run forever');
+    t.is(elapsedCranks(), 8);
+  } else if (mode === 'computrons') {
+    // the doMessage cycle has four steps:
+    // 1: normal delivery (122k-134k computrons)
+    // 2: notify (22k computrons)
+    // 3: normal delivery
+    // 4: notify
+
+    // and takes about 300k per cycle. But every 5th time we do step 3, it
+    // does an extra 5.7M computrons. The cumulative computron count just
+    // before that point should be about 1.3M, and after should be 7M, so by
+    // setting a threshold of 4M, we should finish c.run() just after that
+    // extra-compute step.
+    await c.run(computronCounter(4_000_000n));
+    t.is(elapsedCranks(), 17);
+    const ckey = `${rightID}.vs.vvs.seqnum`;
+    const seqnum = parseInt(hostStorage.kvStore.get(ckey), 10);
+    t.is(seqnum, 5);
+  } else if (mode === 'wallclock') {
+    const startMS = Date.now();
+    // On an idle system, this does about 120 cranks per second when run
+    // alone. When the rest of test-run-policy.js is running in parallel, it
+    // does about 100 cps.
+    more = await c.run(wallClockWaiter(1.0));
+    t.truthy(more, 'vat was supposed to run forever');
+    const elapsedMS = Date.now() - startMS;
+    const elapsed = elapsedMS / 1000;
+    // console.log(`elapsed`, elapsed, more);
+    t.true(elapsed < 200.0, `time distort: ${elapsed} >= 200.0s`);
+  }
+}
+
+test('run policy - cranks - messages', t => testCranks(t, 'messages'));
+test('run policy - cranks - resolutions', t => testCranks(t, 'resolutions'));
+test('run policy - computrons', t => testCranks(t, 'computrons'));
+test('run policy - wallclock', t => testCranks(t, 'wallclock'));

--- a/packages/SwingSet/test/run-policy/vat-policy-left.js
+++ b/packages/SwingSet/test/run-policy/vat-policy-left.js
@@ -1,0 +1,32 @@
+import { Far } from '@agoric/marshal';
+import { E } from '@agoric/eventual-send';
+import { makePromiseKit } from '@agoric/promise-kit';
+
+export function buildRootObject() {
+  let nextPK;
+  function doPromise(args) {
+    args[0]
+      .then(doPromise)
+      .catch(err => console.log(`left doPromise err`, err));
+    const oldPK = nextPK;
+    nextPK = makePromiseKit();
+    oldPK.resolve([nextPK.promise]);
+  }
+
+  const left = Far('left', {
+    doMessage(right, seqnum) {
+      E(right).doMessage(left, seqnum);
+    },
+
+    startPromise(right) {
+      nextPK = makePromiseKit();
+      E(right)
+        .startPromise([nextPK.promise])
+        .then(args => {
+          doPromise(args);
+        })
+        .catch(err => console.log(`left startPromise err`, err));
+    },
+  });
+  return left;
+}

--- a/packages/SwingSet/test/run-policy/vat-policy-right.js
+++ b/packages/SwingSet/test/run-policy/vat-policy-right.js
@@ -1,0 +1,63 @@
+import { Far } from '@agoric/marshal';
+import { E } from '@agoric/eventual-send';
+import { makePromiseKit } from '@agoric/promise-kit';
+
+// this takes about 5.7M computrons
+function consumeCPU() {
+  const a = new Array(100);
+  for (let i = 0; i < a.length; i += 1) {
+    a[i] = i;
+  }
+  for (let i = 0; i < 200; i += 1) {
+    a.sort((first, second) => first - second);
+    a.sort((first, second) => second - first);
+  }
+}
+
+export function buildRootObject(vatPowers) {
+  const vatstore = vatPowers.vatstore;
+  let counter = 0;
+  // we cannot perform syscalls during startup, only during deliveries, so we
+  // can't pre-initialize this
+  // vatstore.set('counter', `${counter}`);
+  function increment() {
+    counter += 1;
+    vatstore.set('counter', `${counter}`);
+  }
+
+  let nextPKR;
+  function doPromise(args) {
+    increment();
+    args[0]
+      .then(doPromise)
+      .catch(err => console.log(`right doPromise err`, err));
+    const oldPK = nextPKR;
+    nextPKR = makePromiseKit();
+    oldPK.resolve([nextPKR.promise]);
+  }
+
+  const right = Far('right', {
+    doMessage(left, seqnum) {
+      increment();
+      if (seqnum !== 'disabled') {
+        // if enbled, do extra work once every 5 cranks, to exercise the
+        // limited-computron policy
+        seqnum += 1;
+        vatstore.set('seqnum', `${seqnum}`);
+        if (seqnum % 5 === 0) {
+          consumeCPU();
+        }
+      }
+      E(left).doMessage(right, seqnum);
+    },
+
+    startPromise(args) {
+      nextPKR = makePromiseKit();
+      args[0]
+        .then(doPromise)
+        .catch(err => console.log(`right startPromise err`, err));
+      return harden([nextPKR.promise]);
+    },
+  });
+  return right;
+}

--- a/packages/SwingSet/test/util.js
+++ b/packages/SwingSet/test/util.js
@@ -100,6 +100,10 @@ export function capargs(args, slots = []) {
   return capdata(JSON.stringify(args, marshalBigIntReplacer), slots);
 }
 
+export function capSlot(index) {
+  return { '@qclass': 'slot', iface: 'Alleged: export', index };
+}
+
 export function capdataOneSlot(slot) {
   return capargs({ '@qclass': 'slot', iface: 'Alleged: export', index: 0 }, [
     slot,


### PR DESCRIPTION
This allows the host application to control how much work `c.run()` does
before it returns. Depending upon the policy chosen, this can be a count of
cranks, or cumulative computrons used, with more details to be added in the
future.

closes #3460
