### PR TITLE
Markm's suggestions for #3578 

### DIFF
--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -261,10 +261,10 @@ export const makeZCFZygote = (
   // added in offer(). ZCF responds with the exitObj and offerResult.
   /** @type {HandleOfferObj} */
   const handleOfferObj = Far('handleOfferObj', {
-    handleOffer: (invitationHandle, zoeSeatAdmin, seatData) => {
+    handleOffer: (invitationHandle, zoeSeatAdmin, seatData, offerArgs) => {
       const zcfSeat = makeZCFSeat(zoeSeatAdmin, seatData);
       const offerHandler = takeOfferHandler(invitationHandle);
-      const offerResultP = E(offerHandler)(zcfSeat, seatData.offerArgs).catch(
+      const offerResultP = E(offerHandler)(zcfSeat, offerArgs).catch(
         reason => {
           if (reason === undefined) {
             const newErr = new Error(

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -14,7 +14,6 @@
  * @property {Notifier<Allocation>} notifier
  * @property {Allocation} initialAllocation
  * @property {SeatHandle} seatHandle
- * @property {Object=} offerArgs
  */
 
 /**
@@ -99,6 +98,7 @@
  * @property {(invitationHandle: InvitationHandle,
  *             zoeSeatAdmin: ZoeSeatAdmin,
  *             seatData: SeatData,
+ *             offerArgs: Object=
  *            ) => HandleOfferResult} handleOffer
  */
 

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -121,13 +121,12 @@ export const makeStartInstance = (
             initialAllocation,
             notifier,
             seatHandle,
-            offerArgs,
           });
 
           zoeSeatAdmins.add(zoeSeatAdmin);
 
           E(handleOfferObjPromiseKit.promise)
-            .handleOffer(invitationHandle, zoeSeatAdmin, seatData)
+            .handleOffer(invitationHandle, zoeSeatAdmin, seatData, offerArgs)
             .then(({ offerResultP, exitObj }) => {
               offerResultPromiseKit.resolve(offerResultP);
               exitObjPromiseKit.resolve(exitObj);


### PR DESCRIPTION
This PR is a review comment on #3578 . However, for reasons I do *not* understand, it causes a SwingSet kernel panic. (@warner , if a change like this in user code can cause a kernel panic, that's a SwingSet bug, right?)

The issue is that the offerArgs are only used once, to pass to the offerHandler, which is as it should be. But to get them there, #3578 puts them in the seatData, where they remain. Since they are only used dynamically during the activity caused by the `offer`, it should ideally only exist in parameters, or ephemeral data at most, not stored in long lived data.