### PR TITLE
refactor(ERTP): Convert RESM to NESM

### DIFF
--- a/packages/ERTP/exported.js
+++ b/packages/ERTP/exported.js
@@ -1,1 +1,1 @@
-import './src/types';
+import './src/types.js';

--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -2,9 +2,7 @@
   "name": "@agoric/ertp",
   "version": "0.11.11",
   "description": "Electronic Rights Transfer Protocol (ERTP). A smart contract framework for exchanging electronic rights",
-  "parsers": {
-    "js": "mjs"
-  },
+  "type": "module",
   "main": "src/index.js",
   "engines": {
     "node": ">=11.0"
@@ -54,8 +52,7 @@
     "@agoric/bundle-source": "^1.4.5",
     "@agoric/install-ses": "^0.5.21",
     "@agoric/swingset-vat": "^0.19.0",
-    "ava": "^3.12.1",
-    "esm": "agoric-labs/esm#Agoric-built"
+    "ava": "^3.12.1"
   },
   "files": [
     "src",
@@ -68,9 +65,6 @@
   "ava": {
     "files": [
       "test/**/test-*.js"
-    ],
-    "require": [
-      "esm"
     ],
     "timeout": "2m"
   },

--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -3,15 +3,15 @@
 import { assert, details as X } from '@agoric/assert';
 import { mustBeComparable } from '@agoric/same-structure';
 
-import './types';
-import natMathHelpers from './mathHelpers/natMathHelpers';
-import setMathHelpers from './mathHelpers/setMathHelpers';
+import './types.js';
+import natMathHelpers from './mathHelpers/natMathHelpers.js';
+import setMathHelpers from './mathHelpers/setMathHelpers.js';
 import {
   looksLikeSetValue,
   looksLikeNatValue,
   looksLikeValue,
   looksLikeBrand,
-} from './typeGuards';
+} from './typeGuards.js';
 
 // We want an enum, but narrowed to the AssetKind type.
 /**

--- a/packages/ERTP/src/index.js
+++ b/packages/ERTP/src/index.js
@@ -1,5 +1,5 @@
 // @ts-check
 
-export * from './amountMath';
-export * from './issuerKit';
-export * from './typeGuards';
+export * from './amountMath.js';
+export * from './issuerKit.js';
+export * from './typeGuards.js';

--- a/packages/ERTP/src/issuerKit.js
+++ b/packages/ERTP/src/issuerKit.js
@@ -3,12 +3,12 @@
 
 import { assert, details as X } from '@agoric/assert';
 
-import { AssetKind } from './amountMath';
-import { coerceDisplayInfo } from './displayInfo';
-import { makeBrand } from './brand';
-import { makePaymentLedger } from './paymentLedger';
+import { AssetKind } from './amountMath.js';
+import { coerceDisplayInfo } from './displayInfo.js';
+import { makeBrand } from './brand.js';
+import { makePaymentLedger } from './paymentLedger.js';
 
-import './types';
+import './types.js';
 
 /**
  * @type {MakeIssuerKit}

--- a/packages/ERTP/src/mathHelpers/natMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/natMathHelpers.js
@@ -2,7 +2,7 @@
 
 import { Nat } from '@agoric/nat';
 
-import '../types';
+import '../types.js';
 
 const identity = 0n;
 

--- a/packages/ERTP/src/mathHelpers/setMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/setMathHelpers.js
@@ -4,7 +4,7 @@ import { passStyleOf } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
 import { mustBeComparable, sameStructure } from '@agoric/same-structure';
 
-import '../types';
+import '../types.js';
 
 // Operations for arrays with unique objects identifying and providing
 // information about digital assets. Used for Zoe invites.

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -6,11 +6,11 @@ import { isPromise } from '@agoric/promise-kit';
 import { Far } from '@agoric/marshal';
 import { makeWeakStore } from '@agoric/store';
 
-import { AmountMath } from './amountMath';
-import { makePayment } from './payment';
-import { makePurse } from './purse';
+import { AmountMath } from './amountMath.js';
+import { makePayment } from './payment.js';
+import { makePurse } from './purse.js';
 
-import '@agoric/store/exported';
+import '@agoric/store/exported.js';
 
 /**
  * Make the paymentLedger, the source of truth for the balances of

--- a/packages/ERTP/src/purse.js
+++ b/packages/ERTP/src/purse.js
@@ -1,6 +1,6 @@
 import { makeNotifierKit } from '@agoric/notifier';
 import { Far } from '@agoric/marshal';
-import { AmountMath } from './amountMath';
+import { AmountMath } from './amountMath.js';
 
 export const makePurse = (allegedName, assetKind, brand, purseMethods) => {
   let currentBalance = AmountMath.makeEmpty(brand, assetKind);

--- a/packages/ERTP/test/swingsetTests/basicFunctionality/bootstrap.js
+++ b/packages/ERTP/test/swingsetTests/basicFunctionality/bootstrap.js
@@ -1,7 +1,7 @@
 import { E } from '@agoric/eventual-send';
 import { assert, details as X } from '@agoric/assert';
 import { Far } from '@agoric/marshal';
-import { makeIssuerKit, AmountMath } from '../../../src';
+import { makeIssuerKit, AmountMath } from '../../../src/index.js';
 
 export function buildRootObject(vatPowers, vatParameters) {
   const arg0 = vatParameters.argv[0];

--- a/packages/ERTP/test/swingsetTests/basicFunctionality/test-basicFunctionality.js
+++ b/packages/ERTP/test/swingsetTests/basicFunctionality/test-basicFunctionality.js
@@ -1,14 +1,12 @@
 // @ts-check
-/* global __dirname */
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { loadBasedir, buildVatController } from '@agoric/swingset-vat';
-import path from 'path';
 
 async function main(basedir, argv) {
-  const dir = path.resolve(`${__dirname}/..`, basedir);
+  const dir = new URL(`../${basedir}`, import.meta.url).pathname;
   const config = await loadBasedir(dir);
   config.defaultManagerType = 'xs-worker';
   const controller = await buildVatController(config, argv);

--- a/packages/ERTP/test/swingsetTests/basicFunctionality/vat-alice.js
+++ b/packages/ERTP/test/swingsetTests/basicFunctionality/vat-alice.js
@@ -1,6 +1,6 @@
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
-import { AmountMath } from '../../../src';
+import { AmountMath } from '../../../src/index.js';
 
 function makeAliceMaker(log) {
   return Far('aliceMaker', {

--- a/packages/ERTP/test/swingsetTests/splitPayments/bootstrap.js
+++ b/packages/ERTP/test/swingsetTests/splitPayments/bootstrap.js
@@ -3,7 +3,7 @@
 import { E } from '@agoric/eventual-send';
 import { assert, details as X } from '@agoric/assert';
 import { Far } from '@agoric/marshal';
-import { makeIssuerKit, AmountMath } from '../../../src';
+import { makeIssuerKit, AmountMath } from '../../../src/index.js';
 
 export function buildRootObject(vatPowers, vatParameters) {
   const arg0 = vatParameters.argv[0];

--- a/packages/ERTP/test/swingsetTests/splitPayments/test-splitPayments.js
+++ b/packages/ERTP/test/swingsetTests/splitPayments/test-splitPayments.js
@@ -1,14 +1,12 @@
-/* global __dirname */
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { loadBasedir, buildVatController } from '@agoric/swingset-vat';
-import path from 'path';
 
 async function main(basedir, argv) {
-  const dir = path.resolve(`${__dirname}/..`, basedir);
+  const dir = new URL(`../${basedir}/`, import.meta.url).pathname;
   const config = await loadBasedir(dir);
   config.defaultManagerType = 'xs-worker';
   const controller = await buildVatController(config, argv);

--- a/packages/ERTP/test/swingsetTests/splitPayments/vat-alice.js
+++ b/packages/ERTP/test/swingsetTests/splitPayments/vat-alice.js
@@ -2,7 +2,7 @@
 
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
-import { AmountMath } from '../../../src';
+import { AmountMath } from '../../../src/index.js';
 
 function makeAliceMaker(log) {
   return Far('aliceMaker', {

--- a/packages/ERTP/test/unitTests/mathHelpers/mockBrand.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/mockBrand.js
@@ -1,5 +1,5 @@
 import { Far } from '@agoric/marshal';
-import { AssetKind } from '../../../src';
+import { AssetKind } from '../../../src/index.js';
 
 /** @type {Brand} */
 export const mockBrand = Far('brand', {

--- a/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-natMathHelpers.js
@@ -1,10 +1,10 @@
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import { Far } from '@agoric/marshal';
-import { AmountMath as m, AssetKind } from '../../../src';
-import { mockBrand } from './mockBrand';
+import { AmountMath as m, AssetKind } from '../../../src/index.js';
+import { mockBrand } from './mockBrand.js';
 
 // The "unit tests" for MathHelpers actually make the calls through
 // AmountMath so that we can test that any duplication is handled

--- a/packages/ERTP/test/unitTests/mathHelpers/test-setMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-setMathHelpers.js
@@ -1,11 +1,11 @@
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import { Far } from '@agoric/marshal';
 
-import { AmountMath as m, AssetKind } from '../../../src';
-import { mockBrand } from './mockBrand';
+import { AmountMath as m, AssetKind } from '../../../src/index.js';
+import { mockBrand } from './mockBrand.js';
 
 // The "unit tests" for MathHelpers actually make the calls through
 // AmountMath so that we can test that any duplication is handled

--- a/packages/ERTP/test/unitTests/mathHelpers/test-strSetMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-strSetMathHelpers.js
@@ -1,9 +1,9 @@
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
-import { AmountMath as m, AssetKind } from '../../../src';
-import { mockBrand } from './mockBrand';
+import { AmountMath as m, AssetKind } from '../../../src/index.js';
+import { mockBrand } from './mockBrand.js';
 
 // The "unit tests" for MathHelpers actually make the calls through
 // AmountMath so that we can test that any duplication is handled

--- a/packages/ERTP/test/unitTests/test-interfaces.js
+++ b/packages/ERTP/test/unitTests/test-interfaces.js
@@ -1,9 +1,9 @@
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import { getInterfaceOf } from '@agoric/marshal';
-import { makeIssuerKit, AmountMath } from '../../src';
+import { makeIssuerKit, AmountMath } from '../../src/index.js';
 
 test('interfaces - particular implementation', t => {
   const allegedName = 'bucks';

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -1,9 +1,9 @@
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import { E } from '@agoric/eventual-send';
-import { AssetKind, makeIssuerKit, AmountMath } from '../../src';
+import { AssetKind, makeIssuerKit, AmountMath } from '../../src/index.js';
 
 test('issuer.getBrand, brand.isMyIssuer', t => {
   const { issuer, brand } = makeIssuerKit('fungible');

--- a/packages/ERTP/test/unitTests/test-mintObj.js
+++ b/packages/ERTP/test/unitTests/test-mintObj.js
@@ -1,12 +1,12 @@
 // @ts-check
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import { Far } from '@agoric/marshal';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { assert } from '@agoric/assert';
 
-import { makeIssuerKit, AssetKind, AmountMath } from '../../src';
+import { makeIssuerKit, AssetKind, AmountMath } from '../../src/index.js';
 
 test('mint.getIssuer', t => {
   const { mint, issuer } = makeIssuerKit('fungible');

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -3,8 +3,7 @@
   "version": "0.19.0",
   "description": "Vat/Container Launcher",
   "type": "module",
-  "main": "src/main.js",
-  "module": "src/index.js",
+  "main": "src/index.js",
   "engines": {
     "node": ">=11.0"
   },

--- a/packages/SwingSet/src/main.js
+++ b/packages/SwingSet/src/main.js
@@ -1,2 +1,0 @@
-/* global module require */
-module.exports = require('./index.js');

--- a/packages/same-structure/index.js
+++ b/packages/same-structure/index.js
@@ -4,4 +4,4 @@ export {
   sameStructure,
   mustBeSameStructure,
   mustBeComparable,
-} from './src/sameStructure';
+} from './src/sameStructure.js';

--- a/packages/xsnap/src/avaXS.js
+++ b/packages/xsnap/src/avaXS.js
@@ -270,7 +270,7 @@ async function avaConfig(args, options, { glob, readFile }) {
   if (unsupported.length > 0) {
     console.warn(X`ava-xs does not support ava options: ${q(unsupported)}`);
   }
-  const { files: filePatterns, require } = pkgMeta.ava;
+  const { files: filePatterns, require = [] } = pkgMeta.ava;
   let { exclude } = pkgMeta['ava-xs'] || {};
   if (typeof exclude === 'string') {
     exclude = [exclude];


### PR DESCRIPTION
This makes the changes necessary for ERTP to run on Node.js’s own ESM loader implementation.

This subsumes minor patches for same-structure and swingset to finish their conversion, making them available for use with NESM from an importing package.