### PR TITLE
refactor(zoe): lockdown errorTrapping redundancy

### DIFF
--- a/packages/zoe/test/swingsetTests/zoe-metering/test-zoe-metering.js
+++ b/packages/zoe/test/swingsetTests/zoe-metering/test-zoe-metering.js
@@ -1,5 +1,3 @@
-/* global process */
-
 // TODO Remove babel-standalone preinitialization
 // https://github.com/endojs/endo/issues/768
 import '@agoric/babel-standalone';
@@ -11,9 +9,6 @@ import { loadBasedir, buildVatController } from '@agoric/swingset-vat';
 import fs from 'fs';
 import path from 'path';
 import bundleSource from '@agoric/bundle-source';
-
-// Don't let unhandled promises crash our process.
-process.on('unhandledRejection', e => console.log('unhandled rejection', e));
 
 const filename = new URL(import.meta.url).pathname;
 const dirname = path.dirname(filename);


### PR DESCRIPTION
SES 0.14 adds an `errorTrapping` behavior that obviates the practice of trapping uncaught exceptions to log them. These are logged by default, including their original stack traces.

This is stacked on #3591 