### PR TITLE
refactor(ertp): Rename identity to additiveIdentity

### DIFF
--- a/packages/ERTP/src/mathHelpers/natMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/natMathHelpers.js
@@ -4,7 +4,7 @@ import { Nat } from '@agoric/nat';
 
 import '../types.js';
 
-const identity = 0n;
+const empty = 0n;
 
 /**
  * Fungible digital assets use the natMathHelpers to manage balances -
@@ -20,8 +20,8 @@ const identity = 0n;
  */
 const natMathHelpers = {
   doCoerce: Nat,
-  doMakeEmpty: () => identity,
-  doIsEmpty: nat => nat === identity,
+  doMakeEmpty: () => empty,
+  doIsEmpty: nat => nat === empty,
   doIsGTE: (left, right) => left >= right,
   doIsEqual: (left, right) => left === right,
   // BigInts don't observably overflow

--- a/packages/ERTP/src/mathHelpers/setMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/setMathHelpers.js
@@ -9,7 +9,7 @@ import '../types.js';
 // Operations for arrays with unique objects identifying and providing
 // information about digital assets. Used for Zoe invites.
 /** @type {SetValue} */
-const identity = harden([]);
+const empty = harden([]);
 
 /**
  * @param {Object} record
@@ -120,7 +120,7 @@ const setMathHelpers = harden({
     checkForDupes(makeBuckets(list));
     return list;
   },
-  doMakeEmpty: () => identity,
+  doMakeEmpty: () => empty,
   doIsEmpty: list => passStyleOf(list) === 'copyArray' && list.length === 0,
   doIsGTE: (left, right) => {
     const leftBuckets = makeBuckets(left);


### PR DESCRIPTION
Fixes #3587

This is an exceedingly, almost inappropriately pedantic narrowing of the meaning of identity to specifically additive identity, as distinguished from multiplicative identity.

This is stacked on #3592 