### PR TITLE
refactor(xsnap): Revert externalize netstring IO dependency

### DIFF
--- a/packages/xsnap/package.json
+++ b/packages/xsnap/package.json
@@ -31,7 +31,6 @@
     "@agoric/bundle-source": "^1.4.5",
     "@agoric/eventual-send": "^0.13.23",
     "@agoric/install-ses": "^0.5.21",
-    "@endo/netstring": "^0.2.5",
     "glob": "^7.1.6",
     "ses": "^0.14.0"
   },

--- a/packages/xsnap/src/netstring.js
+++ b/packages/xsnap/src/netstring.js
@@ -1,0 +1,118 @@
+// @ts-check
+
+/**
+ * @template T
+ * @template U
+ * @template V
+ * @typedef {import('./stream.js').Stream<T, U, V>} Stream
+ */
+
+const COLON = ':'.charCodeAt(0);
+const COMMA = ','.charCodeAt(0);
+
+const decoder = new TextDecoder();
+const encoder = new TextEncoder();
+
+/**
+ * @param {AsyncIterable<Uint8Array>} input
+ * @param {string=} name
+ * @param {number=} capacity
+ * @returns {AsyncGenerator<Uint8Array, Uint8Array, unknown>} input
+ */
+export async function* reader(input, name = '<unknown>', capacity = 1024) {
+  let length = 0;
+  let buffer = new Uint8Array(capacity);
+  let offset = 0;
+
+  for await (const chunk of input) {
+    if (length + chunk.byteLength >= capacity) {
+      while (length + chunk.byteLength >= capacity) {
+        capacity *= 2;
+      }
+      const replacement = new Uint8Array(capacity);
+      replacement.set(buffer, 0);
+      buffer = replacement;
+    }
+    buffer.set(chunk, length);
+    length += chunk.byteLength;
+
+    let drained = false;
+    while (!drained && length > 0) {
+      const colon = buffer.indexOf(COLON);
+      if (colon === 0) {
+        throw new Error(
+          `Expected number before colon at offset ${offset} of ${name}`,
+        );
+      } else if (colon > 0) {
+        const prefixBytes = buffer.subarray(0, colon);
+        const prefixString = decoder.decode(prefixBytes);
+        const contentLength = +prefixString;
+        if (Number.isNaN(contentLength)) {
+          throw new Error(
+            `Invalid netstring prefix length ${prefixString} at offset ${offset} of ${name}`,
+          );
+        }
+        const messageLength = colon + contentLength + 2;
+        if (messageLength <= length) {
+          yield buffer.subarray(colon + 1, colon + 1 + contentLength);
+          buffer.copyWithin(0, messageLength);
+          length -= messageLength;
+          offset += messageLength;
+        } else {
+          drained = true;
+        }
+      } else {
+        drained = true;
+      }
+    }
+  }
+
+  if (length > 0) {
+    throw new Error(
+      `Unexpected dangling message at offset ${offset} of ${name}`,
+    );
+  }
+  return new Uint8Array(0);
+}
+
+/**
+ * @param {Stream<void, Uint8Array, void>} output
+ * @returns {Stream<void, Uint8Array, void>}
+ */
+export function writer(output) {
+  const scratch = new Uint8Array(8);
+
+  return {
+    async next(message) {
+      const { written: length = 0 } = encoder.encodeInto(
+        `${message.byteLength}`,
+        scratch,
+      );
+      scratch[length] = COLON;
+
+      const { done: done1 } = await output.next(
+        scratch.subarray(0, length + 1),
+      );
+      if (done1) {
+        return output.return();
+      }
+
+      const { done: done2 } = await output.next(message);
+      if (done2) {
+        return output.return();
+      }
+
+      scratch[0] = COMMA;
+      return output.next(scratch.subarray(0, 1));
+    },
+    async return() {
+      return output.return();
+    },
+    async throw(error) {
+      return output.throw(error);
+    },
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+  };
+}

--- a/packages/xsnap/src/xsnap.js
+++ b/packages/xsnap/src/xsnap.js
@@ -13,7 +13,7 @@
 
 import { ErrorCode, ErrorSignal, ErrorMessage, METER_TYPE } from '../api.js';
 import { defer } from './defer.js';
-import { netstringReader, netstringWriter } from '@endo/netstring';
+import * as netstring from './netstring.js';
 import * as node from './node-stream.js';
 
 // This will need adjustment, but seems to be fine for a start.
@@ -131,13 +131,13 @@ export function xsnap(options) {
     throw Error(`${name} exited`);
   });
 
-  const messagesToXsnap = netstringWriter(
+  const messagesToXsnap = netstring.writer(
     node.writer(
       /** @type {NodeJS.WritableStream} */ (xsnapProcess.stdio[3]),
       `messages to ${name}`,
     ),
   );
-  const messagesFromXsnap = netstringReader(
+  const messagesFromXsnap = netstring.reader(
     /** @type {AsyncIterable<Uint8Array>} */ (xsnapProcess.stdio[4]),
   );
 

--- a/packages/xsnap/test/test-netstring.js
+++ b/packages/xsnap/test/test-netstring.js
@@ -1,0 +1,111 @@
+import test from 'ava';
+import * as netstring from '../src/netstring.js';
+import { pipe } from '../src/stream.js';
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+async function read(source) {
+  const array = [];
+  for await (const chunk of source) {
+    // Capture current state, allocating a copy.
+    array.push(chunk.slice());
+  }
+  return array;
+}
+
+test('read short messages', async t => {
+  const r = netstring.reader([encoder.encode('0:,1:A,')], '<unknown>', 1);
+  const array = await read(r);
+  t.deepEqual(
+    ['', 'A'],
+    array.map(chunk => decoder.decode(chunk)),
+  );
+});
+
+test('read messages divided over chunk boundaries', async t => {
+  const r = netstring.reader(
+    [encoder.encode('5:hel'), encoder.encode('lo,')],
+    '<unknown>',
+    1,
+  );
+  const array = await read(r);
+  t.deepEqual(
+    ['hello'],
+    array.map(chunk => decoder.decode(chunk)),
+  );
+});
+
+function delay(ms) {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}
+
+test('round-trip short messages', async t => {
+  const array = [];
+  const w = netstring.writer({
+    async next(value) {
+      // Provide some back pressure to give the producer an opportunity to make
+      // the mistake of overwriting the given slice.
+      await delay(10);
+      // slice to capture before yielding.
+      array.push(value.slice());
+      return { done: false };
+    },
+    async return() {
+      return { done: true };
+    },
+    async throw() {
+      return { done: true };
+    },
+  });
+  await w.next(encoder.encode(''));
+  await w.next(encoder.encode('A'));
+  await w.next(encoder.encode('hello'));
+  await w.return();
+
+  t.deepEqual(
+    [encoder.encode(''), encoder.encode('A'), encoder.encode('hello')],
+    await read(netstring.reader(array)),
+  );
+});
+
+test('round-trip varying messages', async t => {
+  const array = ['', 'A', 'hello'];
+
+  for (let i = 1020; i < 1030; i++) {
+    array.push(new Array(i).fill(':').join(''));
+  }
+  for (let i = 2040; i < 2050; i++) {
+    array.push(new Array(i).fill(':').join(''));
+  }
+
+  t.plan(array.length);
+
+  const [input, output] = pipe();
+
+  const producer = (async () => {
+    const w = netstring.writer(output);
+    for (let i = 0; i < array.length; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await w.next(encoder.encode(array[i]));
+      // eslint-disable-next-line no-await-in-loop
+      await delay(10);
+    }
+    await w.return();
+  })();
+
+  const consumer = (async () => {
+    const r = netstring.reader(input);
+    let i = 0;
+    for await (const message of r) {
+      await delay(10);
+      t.is(array[i], decoder.decode(message));
+      i += 1;
+    }
+    t.log('end');
+  })();
+
+  await Promise.all([producer, consumer]);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1293,11 +1293,6 @@
   dependencies:
     requireindex "~1.1.0"
 
-"@endo/netstring@^0.2.5":
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/@endo/netstring/-/netstring-0.2.5.tgz#4823fc515511fe527f635a9a71b49dce6aedc1db"
-  integrity sha512-Qtq/l5x/NneV03VPKDmuVBBApwyhT6CUrWQIruHnsMgDWqOa1wv3HCHSrQ/7HVa19biKuMEe669GiAd9kLaW9g==
-
 "@endo/ses-ava@^0.2.5":
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/@endo/ses-ava/-/ses-ava-0.2.5.tgz#0ecfe3394386245f03b231dec481865c11cb60b7"


### PR DESCRIPTION
Reverts Agoric/agoric-sdk#2978

The above change landed with auto-merge despite failing the lint check. The lint check in turn fails because of errors in the published version of netstring’s type definitions, to be remedied in the next version.