### PR TITLE
fix(xsnap): tame XS deep freeze in SES workers

### DIFF
--- a/packages/xsnap/lib/deep-freeze-tame.js
+++ b/packages/xsnap/lib/deep-freeze-tame.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const { freeze } = Object;
+
+/**
+ * Tame XS's deep freeze by ignoring any additional arguments.
+ *
+ * @param {unknown} o
+ */
+Object.freeze = o => freeze(o);

--- a/packages/xsnap/lib/ses-boot-debug.js
+++ b/packages/xsnap/lib/ses-boot-debug.js
@@ -1,6 +1,7 @@
 import './console-shim.js';
 import './text-shim.js';
 import '@agoric/eventual-send/shim.js';
+import './deep-freeze-tame.js';
 import './lockdown-shim-debug.js';
 
 harden(console);

--- a/packages/xsnap/lib/ses-boot.js
+++ b/packages/xsnap/lib/ses-boot.js
@@ -1,3 +1,4 @@
+import './deep-freeze-tame.js';
 import './console-shim.js';
 import './text-shim.js';
 import '@agoric/eventual-send/shim.js';


### PR DESCRIPTION
This adds an extra function call for every `Object.freeze()` call. I'm not sure we want that, given @phoddie 's offer to make deep-freeze a compile-time opt-out feature.

Meanwhile, testing that this feature is not available to contract code seems worthwhile.
fixes #1058

@erights I gave just a little thought to how to do this in SES... would you want the extra function call on all platforms? Or do feature detection? I'm not sure.

So this represents something that I know how to do. I'm interested in feedback on which alternative(s) we should pursue.
