### PR TITLE
fix: Treasury burn debt repayment before zeroing the amount owed

### DIFF
--- a/packages/treasury/src/types.js
+++ b/packages/treasury/src/types.js
@@ -59,7 +59,7 @@
 
 /**
  * @typedef {Object} InnerVaultManager
- * @property {Brand} collateralBrand
+ * @property {() => Brand} getCollateralBrand
  * @property {() => Ratio} getLiquidationMargin
  * @property {() => Ratio} getLoanFee
  * @property {() => Promise<PriceQuote>} getCollateralQuote

--- a/packages/treasury/src/vaultManager.js
+++ b/packages/treasury/src/vaultManager.js
@@ -202,7 +202,7 @@ export function makeVaultManager(
   /** @type {InnerVaultManager} */
   const innerFacet = harden({
     ...shared,
-    collateralBrand,
+    getCollateralBrand: () => collateralBrand,
   });
 
   /** @param {ZCFSeat} seat */

--- a/packages/treasury/test/vault-contract-wrapper.js
+++ b/packages/treasury/test/vault-contract-wrapper.js
@@ -66,7 +66,9 @@ export async function start(zcf) {
     getInterestRate() {
       return makeRatio(5n, runBrand);
     },
-    // collateralBrand, // TODO not a method. How did this ever work?
+    getCollateralBrand() {
+      return collateralBrand;
+    },
     reallocateReward,
   });
 


### PR DESCRIPTION
fixes #3495

fixed getCollateralBrand in the innerFacet, which wasn't a method.
Moved a check for empty denominators to be after an await.
Added assertVaultHoldsNoRun() in close.
Added a test for closing a loan.