### PR TITLE
refactor(cosmic-swingset): Convert RESM to NESM

### DIFF
--- a/packages/cosmic-swingset/bin/ag-chain-cosmos
+++ b/packages/cosmic-swingset/bin/ag-chain-cosmos
@@ -1,2 +1,1 @@
-#! /usr/bin/env node
-require('../src/entrypoint.cjs');
+../src/entrypoint.js

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
+    "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
     "pretty-fix": "prettier --write '**/*.js'",
     "pretty-check": "prettier --check '**/*.js'",
@@ -46,7 +47,8 @@
     "tmp": "^0.2.1"
   },
   "devDependencies": {
-    "ava": "^3.12.1"
+    "ava": "^3.12.1",
+    "c8": "^7.7.2"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -2,11 +2,9 @@
   "name": "@agoric/cosmic-swingset",
   "version": "0.31.10",
   "description": "Agoric's Cosmos blockchain integration",
-  "parsers": {
-    "js": "mjs"
-  },
+  "type": "module",
   "bin": {
-    "ag-chain-cosmos": "./src/entrypoint.cjs"
+    "ag-chain-cosmos": "./src/entrypoint.js"
   },
   "main": "src/chain-main.js",
   "repository": "https://github.com/Agoric/agoric-sdk",
@@ -43,7 +41,7 @@
     "agoric": "^0.13.11",
     "anylogger": "^0.21.0",
     "deterministic-json": "^1.0.5",
-    "esm": "agoric-labs/esm#Agoric-built",
+    "import-meta-resolve": "^1.1.1",
     "node-lmdb": "^0.9.4",
     "tmp": "^0.2.1"
   },
@@ -68,9 +66,6 @@
   "ava": {
     "files": [
       "test/**/test-*.js"
-    ],
-    "require": [
-      "esm"
     ],
     "timeout": "20m"
   }

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -1,15 +1,16 @@
-/* global require setInterval */
-import stringify from '@agoric/swingset-vat/src/kernel/json-stable-stringify';
+/* global setInterval */
+import { resolve as importMetaResolve } from 'import-meta-resolve';
+import stringify from '@agoric/swingset-vat/src/kernel/json-stable-stringify.js';
 import {
   importMailbox,
   exportMailbox,
-} from '@agoric/swingset-vat/src/devices/mailbox';
+} from '@agoric/swingset-vat/src/devices/mailbox.js';
 
 import { assert, details as X } from '@agoric/assert';
 
-import { launch } from './launch-chain';
-import makeBlockManager from './block-manager';
-import { getMeterProvider } from './kernel-stats';
+import { launch } from './launch-chain.js';
+import makeBlockManager from './block-manager.js';
+import { getMeterProvider } from './kernel-stats.js';
 
 const AG_COSMOS_INIT = 'AG_COSMOS_INIT';
 
@@ -227,7 +228,12 @@ export default async function main(progname, args, { env, homedir, agcc }) {
       }
     }
 
-    const vatconfig = require.resolve('@agoric/vats/decentral-config.json');
+    const vatconfig = new URL(
+      await importMetaResolve(
+        '@agoric/vats/decentral-config.json',
+        import.meta.url,
+      ),
+    ).pathname;
     const argv = {
       ROLE: 'chain',
       noFakeCurrencies: env.NO_FAKE_CURRENCIES,

--- a/packages/cosmic-swingset/src/entrypoint.cjs
+++ b/packages/cosmic-swingset/src/entrypoint.cjs
@@ -1,3 +1,0 @@
-#! /usr/bin/env node
-/* global require module */
-require('esm')(module)('./entrypoint.js');

--- a/packages/cosmic-swingset/src/entrypoint.js
+++ b/packages/cosmic-swingset/src/entrypoint.js
@@ -17,7 +17,7 @@ import os from 'os';
 import path from 'path';
 import process from 'process';
 
-import './anylogger-agoric';
+import './anylogger-agoric.js';
 import anylogger from 'anylogger';
 import main from './chain-main.js';
 

--- a/packages/cosmic-swingset/src/kernel-stats.js
+++ b/packages/cosmic-swingset/src/kernel-stats.js
@@ -6,7 +6,7 @@ import { makeLegacyMap } from '@agoric/store';
 import {
   KERNEL_STATS_SUM_METRICS,
   KERNEL_STATS_UPDOWN_METRICS,
-} from '@agoric/swingset-vat/src/kernel/metrics';
+} from '@agoric/swingset-vat/src/kernel/metrics.js';
 
 /**
  * TODO Would be nice somehow to label the vats individually, but it's too

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -17,7 +17,7 @@ import {
   DEFAULT_METER_PROVIDER,
   exportKernelStats,
   makeSlogCallbacks,
-} from './kernel-stats';
+} from './kernel-stats.js';
 
 const console = anylogger('launch-chain');
 

--- a/packages/cosmic-swingset/src/sim-chain.js
+++ b/packages/cosmic-swingset/src/sim-chain.js
@@ -1,21 +1,22 @@
-/* global require process setTimeout clearTimeout */
+/* global process setTimeout clearTimeout */
 /* eslint-disable no-await-in-loop */
 import path from 'path';
 import fs from 'fs';
-import stringify from '@agoric/swingset-vat/src/kernel/json-stable-stringify';
+import stringify from '@agoric/swingset-vat/src/kernel/json-stable-stringify.js';
 import {
   importMailbox,
   exportMailbox,
-} from '@agoric/swingset-vat/src/devices/mailbox';
+} from '@agoric/swingset-vat/src/devices/mailbox.js';
 
 import anylogger from 'anylogger';
 
+import { resolve as importMetaResolve } from 'import-meta-resolve';
 import { assert, details as X } from '@agoric/assert';
-import { makeWithQueue } from '@agoric/vats/src/queue';
-import { makeBatchedDeliver } from '@agoric/vats/src/batched-deliver';
-import { launch } from './launch-chain';
-import makeBlockManager from './block-manager';
-import { getMeterProvider } from './kernel-stats';
+import { makeWithQueue } from '@agoric/vats/src/queue.js';
+import { makeBatchedDeliver } from '@agoric/vats/src/batched-deliver.js';
+import { launch } from './launch-chain.js';
+import makeBlockManager from './block-manager.js';
+import { getMeterProvider } from './kernel-stats.js';
 
 const console = anylogger('fake-chain');
 
@@ -51,7 +52,12 @@ export async function connectToFakeChain(basedir, GCI, delay, inbound) {
 
   const mailboxStorage = await makeMapStorage(mailboxFile);
 
-  const vatconfig = require.resolve('@agoric/vats/decentral-config.json');
+  const vatconfig = new URL(
+    await importMetaResolve(
+      '@agoric/vats/decentral-config.json',
+      import.meta.url,
+    ),
+  ).pathname;
   const argv = {
     ROLE: 'sim-chain',
     giveMeAllTheAgoricPowers: true,

--- a/packages/cosmic-swingset/test/test-make.js
+++ b/packages/cosmic-swingset/test/test-make.js
@@ -1,11 +1,14 @@
-/* global __dirname */
 import test from 'ava';
 import { spawn } from 'child_process';
+import path from 'path';
+
+const filename = new URL(import.meta.url).pathname;
+const dirname = path.dirname(filename);
 
 test('make and exec', async t => {
   await new Promise(resolve =>
     spawn('make', {
-      cwd: `${__dirname}/..`,
+      cwd: `${dirname}/..`,
       stdio: ['ignore', 'ignore', 'inherit'],
     }).addListener('exit', code => {
       t.is(code, 0, 'make exits successfully');
@@ -14,7 +17,7 @@ test('make and exec', async t => {
   );
   await new Promise(resolve =>
     spawn('bin/ag-chain-cosmos', {
-      cwd: `${__dirname}/..`,
+      cwd: `${dirname}/..`,
       stdio: ['ignore', 'ignore', 'inherit'],
     }).addListener('exit', code => {
       t.is(code, 0, 'exec exits successfully');


### PR DESCRIPTION
One wiggle in this migration is that I’ve replaced the bin with a symlink to the entrypoint.js file, instead of having a thunk that imports a RESM thunk in CJS format that imports entrypoint.js.