### PR TITLE
feat(solo): accept $SOLO_SLOGFILE to write a slogfile

### DIFF
--- a/packages/solo/src/start.js
+++ b/packages/solo/src/start.js
@@ -150,9 +150,11 @@ async function buildSwingset(
     }
     await initializeSwingset(config, argv, hostStorage);
   }
+  const slogFile = process.env.SOLO_SLOGFILE;
   const controller = await makeSwingsetController(
     hostStorage,
     deviceEndowments,
+    { slogFile },
   );
 
   async function saveState() {


### PR DESCRIPTION
cosmic-swingset can be run with e.g. `SLOGFILE=chain.slog agoric start
local-chain` to make it write out a slogfile during execution.

This brings this same functionality to the solo node, e.g.
`SOLO_SLOGFILE=client.slog agoric start local-solo`.