### PR TITLE
fix(xsnap): tolerate Symbols in console.log() arguments

### DIFF
--- a/packages/xsnap/lib/console-shim.js
+++ b/packages/xsnap/lib/console-shim.js
@@ -2,10 +2,14 @@
 function tryPrint(...args) {
   try {
     // eslint-disable-next-line
-    print(...args);
+    print(...args.map(arg => typeof arg === 'symbol' ? arg.toString() : arg));
   } catch (err) {
     // eslint-disable-next-line
     print('cannot print:', err.message);
+    args.forEach((a, i) => {
+      // eslint-disable-next-line
+      print(` ${i}:`, a.toString ? a.toString() : '<no .toString>', typeof a);
+    });
   }
 }
 


### PR DESCRIPTION
The xsnap `print()` doesn't know how to print a Symbol, so until that's
fixed, here's a workaround in our `tryPrint()` function. This is the backend
of all console.log calls within the XS process.

refs https://github.com/Moddable-OpenSource/moddable/issues/679