### PR TITLE
fix(vats): vat-ibc must use LegacyMap, not Store, to hold a Set

### DIFF
--- a/packages/SwingSet/src/vats/network/router.js
+++ b/packages/SwingSet/src/vats/network/router.js
@@ -65,8 +65,9 @@ export default function makeRouter() {
   });
 }
 /**
- * @typedef {Protocol} RouterProtocol
- * @property {(prefix: string, protocolHandler: ProtocolHandler) => void} registerProtocolHandler
+ * @typedef {Object} RouterProtocol
+ * @property {(prefix: string) => Promise<Port>} bind
+ * @property {(paths: string[], protocolHandler: ProtocolHandler) => void} registerProtocolHandler
  * @property {(prefix: string, protocolHandler: ProtocolHandler) => void} unregisterProtocolHandler
  */
 

--- a/packages/vats/src/ibc.js
+++ b/packages/vats/src/ibc.js
@@ -5,7 +5,7 @@ import {
   dataToBase64,
   base64ToBytes,
 } from '@agoric/swingset-vat/src/vats/network';
-import { makeStore } from '@agoric/store';
+import { makeStore, makeLegacyMap } from '@agoric/store';
 import { makePromiseKit } from '@agoric/promise-kit';
 import { assert, details as X } from '@agoric/assert';
 import { Far } from '@agoric/marshal';
@@ -240,7 +240,7 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
   /**
    * @type {Store<Port, Set<PromiseRecord<ConnectionHandler>>>}
    */
-  const portToPendingConns = makeStore('Port');
+  const portToPendingConns = makeLegacyMap('Port');
 
   /** @type {Store<Endpoint, Endpoint>} */
   const remoteAddrToLocalSuffix = makeStore('endpoint');

--- a/packages/vats/src/ibc.js
+++ b/packages/vats/src/ibc.js
@@ -240,6 +240,7 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
   /**
    * @type {Store<Port, Set<PromiseRecord<ConnectionHandler>>>}
    */
+  // Legacy because it holds a raw JavaScript Set
   const portToPendingConns = makeLegacyMap('Port');
 
   /** @type {Store<Endpoint, Endpoint>} */

--- a/packages/vats/test/test-network.js
+++ b/packages/vats/test/test-network.js
@@ -1,0 +1,33 @@
+// @ts-check
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
+
+import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
+
+import { buildRootObject as ibcBuildRootObject } from '../src/vat-ibc.js';
+import { buildRootObject as networkBuildRootObject } from '../src/vat-network.js';
+
+test('network - ibc', async t => {
+  t.plan(2);
+
+  const networkVat = E(networkBuildRootObject)();
+  const ibcVat = E(ibcBuildRootObject)();
+
+  const callbacks = Far('ibcCallbacks', {
+    downcall: (method, params) => {
+      t.is(method, 'bindPort');
+      t.deepEqual(params, { packet: { source_port: 'port-1' } });
+    },
+  });
+
+  const ibcHandler = await E(ibcVat).createInstance(callbacks);
+  await E(networkVat).registerProtocolHandler(
+    ['/ibc-port', '/ibc-hop'],
+    ibcHandler,
+  );
+
+  // Actually test the ibc port binding.
+  // TODO: Do more tests on the returned Port object.
+  await E(networkVat).bind('/ibc-port/');
+});


### PR DESCRIPTION
The recent change to make Stores accept only "Passable" objects means that
you can't put a Set in one anymore. The IBC code was holding Sets of Promises
in a Store, and that now fails. This caused the chain to halt at startup,
during initialization and bootstrap.

The fix is to use a "LegacyMap" instead of a "Store".

fixes #3621