### PR TITLE
expose hash of kernel state changes as "activityhash"

### DIFF
--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -12,6 +12,7 @@ import { assert, details as X } from '@agoric/assert';
 import { importBundle } from '@agoric/import-bundle';
 import { xsnap, recordXSnap } from '@agoric/xsnap';
 
+import { createSHA256 } from './hasher.js';
 import engineGC from './engine-gc.js';
 import { WeakRef, FinalizationRegistry } from './weakref.js';
 import { startSubprocessWorker } from './spawnSubprocessWorker.js';
@@ -271,6 +272,7 @@ export async function makeSwingsetController(
     WeakRef,
     FinalizationRegistry,
     gcAndFinalize: makeGcAndFinalize(engineGC),
+    createSHA256,
   };
 
   const kernelOptions = { verbose, warehousePolicy, overrideVatManagerOptions };
@@ -325,6 +327,10 @@ export async function makeSwingsetController(
 
     getStatus() {
       return defensiveCopy(kernel.getStatus());
+    },
+
+    getActivityhash() {
+      return kernel.getActivityhash();
     },
 
     pinVatRoot(vatName) {

--- a/packages/SwingSet/src/hasher.js
+++ b/packages/SwingSet/src/hasher.js
@@ -1,0 +1,32 @@
+import { assert } from '@agoric/assert';
+
+import { createHash } from 'crypto';
+
+/**
+ * @typedef { (initial: string?) => {
+ *             add: (more: string) => void,
+ *             finish: () => string,
+ *            }
+ *          } CreateSHA256
+ */
+
+/** @type { CreateSHA256 } */
+function createSHA256(initial = undefined) {
+  const hash = createHash('sha256');
+  let done = false;
+  function add(more) {
+    assert(!done);
+    hash.update(more);
+  }
+  function finish() {
+    assert(!done);
+    done = true;
+    return hash.digest('hex');
+  }
+  if (initial) {
+    add(initial);
+  }
+  return harden({ add, finish });
+}
+harden(createSHA256);
+export { createSHA256 };

--- a/packages/SwingSet/src/kernel/initializeKernel.js
+++ b/packages/SwingSet/src/kernel/initializeKernel.js
@@ -2,6 +2,7 @@
 
 import { makeMarshal, Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
+import { createSHA256 } from '../hasher.js';
 import { assertKnownOptions } from '../assertOptions.js';
 import { insistVatID } from './id.js';
 import { makeVatSlot } from '../parseVatSlots.js';
@@ -17,7 +18,8 @@ export function initializeKernel(config, hostStorage, verbose = false) {
   const logStartup = verbose ? console.debug : () => 0;
   insistStorageAPI(hostStorage.kvStore);
 
-  const kernelKeeper = makeKernelKeeper(hostStorage);
+  const kernelSlog = null;
+  const kernelKeeper = makeKernelKeeper(hostStorage, kernelSlog, createSHA256);
 
   const wasInitialized = kernelKeeper.getInitialized();
   assert(!wasInitialized);

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -126,6 +126,7 @@ export default function buildKernel(
     WeakRef,
     FinalizationRegistry,
     gcAndFinalize,
+    createSHA256,
   } = kernelEndowments;
   deviceEndowments = { ...deviceEndowments }; // copy so we can modify
   const {
@@ -142,7 +143,7 @@ export default function buildKernel(
     ? makeSlogger(slogCallbacks, writeSlogObject)
     : makeDummySlogger(slogCallbacks, makeConsole);
 
-  const kernelKeeper = makeKernelKeeper(hostStorage, kernelSlog);
+  const kernelKeeper = makeKernelKeeper(hostStorage, kernelSlog, createSHA256);
 
   let started = false;
 
@@ -1204,6 +1205,10 @@ export default function buildKernel(
       return harden({
         activeVats: vatWarehouse.activeVatsInfo(),
       });
+    },
+
+    getActivityhash() {
+      return kernelKeeper.getActivityhash();
     },
 
     dump() {

--- a/packages/SwingSet/src/kernel/kernelSyscall.js
+++ b/packages/SwingSet/src/kernel/kernelSyscall.js
@@ -28,12 +28,13 @@ export function doSend(kernelKeeper, target, msg) {
 export function makeKernelSyscallHandler(tools) {
   const {
     kernelKeeper,
-    kvStore,
     ephemeral,
     notify,
     doResolve,
     setTerminationTrigger,
   } = tools;
+
+  const { kvStore } = kernelKeeper;
 
   function send(target, msg) {
     return doSend(kernelKeeper, target, msg);

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -70,6 +70,7 @@ const enableKernelGC = true;
 
 // exclude from consensus
 // local.snapshot.$id = [vatID, ...]
+// local.kernelStats // JSON(various kernel stats)
 
 // d$NN.o.nextID = $NN
 // d$NN.c.$kernelSlot = $deviceSlot = o-$NN/d+$NN/d-$NN
@@ -208,11 +209,14 @@ export default function makeKernelKeeper(hostStorage, kernelSlog) {
   }
 
   function saveStats() {
-    kvStore.set('kernelStats', JSON.stringify(kernelStats));
+    kvStore.set('local.kernelStats', JSON.stringify(kernelStats));
   }
 
   function loadStats() {
-    kernelStats = { ...kernelStats, ...JSON.parse(getRequired('kernelStats')) };
+    kernelStats = {
+      ...kernelStats,
+      ...JSON.parse(getRequired('local.kernelStats')),
+    };
   }
 
   function getStats() {

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -31,6 +31,10 @@ const enableKernelGC = true;
 // "prefix." and "prefix/", which avoids including anything using an
 // extension of the prefix (e.g. [vat1.foo, vat1.bar, vat15.baz]).
 //
+// The 'local.' namespace is excluded from the kernel activity hash, and is
+// allowed to vary between instances in a consensus machine. Everything else
+// is required to be deterministic.
+//
 // The schema is:
 //
 // vat.names = JSON([names..])
@@ -59,13 +63,13 @@ const enableKernelGC = true;
 // v$NN.vs.$key = string
 // v$NN.meter = m$NN
 // exclude from consensus
-// v$NN.lastSnapshot = JSON({ snapshotID, startPos })
+// local.v$NN.lastSnapshot = JSON({ snapshotID, startPos })
 
 // m$NN.remaining = $NN // remaining capacity (in computrons) or 'unlimited'
 // m$NN.threshold = $NN // notify when .remaining first drops below this
 
 // exclude from consensus
-// snapshot.$id = [vatID, ...]
+// local.snapshot.$id = [vatID, ...]
 
 // d$NN.o.nextID = $NN
 // d$NN.c.$kernelSlot = $deviceSlot = o-$NN/d+$NN/d-$NN

--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -445,7 +445,7 @@ export function makeVatKeeper(
    * @returns {{ snapshotID: string, startPos: StreamPosition } | undefined}
    */
   function getLastSnapshot() {
-    const notation = kvStore.get(`${vatID}.lastSnapshot`);
+    const notation = kvStore.get(`local.${vatID}.lastSnapshot`);
     if (!notation) {
       return undefined;
     }
@@ -470,7 +470,7 @@ export function makeVatKeeper(
    * @param {string} snapshotID
    */
   function addToSnapshot(snapshotID) {
-    const key = `snapshot.${snapshotID}`;
+    const key = `local.snapshot.${snapshotID}`;
     const consumers = JSON.parse(kvStore.get(key) || '[]');
     assert(Array.isArray(consumers));
 
@@ -493,7 +493,7 @@ export function makeVatKeeper(
    * @param {string} snapshotID
    */
   function removeFromSnapshot(snapshotID) {
-    const key = `snapshot.${snapshotID}`;
+    const key = `local.snapshot.${snapshotID}`;
     const consumersJSON = kvStore.get(key);
     assert(consumersJSON, X`cannot remove ${vatID}: ${key} key not defined`);
     const consumers = JSON.parse(consumersJSON);
@@ -526,7 +526,7 @@ export function makeVatKeeper(
     }
     const endPosition = getTranscriptEndPosition();
     kvStore.set(
-      `${vatID}.lastSnapshot`,
+      `local.${vatID}.lastSnapshot`,
       JSON.stringify({ snapshotID, startPos: endPosition }),
     );
     addToSnapshot(snapshotID);

--- a/packages/SwingSet/test/test-clist.js
+++ b/packages/SwingSet/test/test-clist.js
@@ -4,14 +4,12 @@ import { test } from '../tools/prepare-test-env-ava.js';
 import { initSimpleSwingStore } from '@agoric/swing-store-simple';
 import { makeDummySlogger } from '../src/kernel/slogger.js';
 import makeKernelKeeper from '../src/kernel/state/kernelKeeper.js';
-import { wrapStorage } from '../src/kernel/state/storageWrapper.js';
 
 test(`clist reachability`, async t => {
   const slog = makeDummySlogger({});
   const hostStorage = initSimpleSwingStore();
-  const { enhancedCrankBuffer: s } = wrapStorage(hostStorage.kvStore);
-
-  const kk = makeKernelKeeper(s, hostStorage.streamStore, slog);
+  const kk = makeKernelKeeper(hostStorage, slog);
+  const s = kk.kvStore;
   kk.createStartingKernelState('local');
   const vatID = kk.allocateUnusedVatID();
   const vk = kk.provideVatKeeper(vatID);
@@ -95,9 +93,8 @@ test(`clist reachability`, async t => {
 test('getImporters', async t => {
   const slog = makeDummySlogger({});
   const hostStorage = initSimpleSwingStore();
-  const { enhancedCrankBuffer: s } = wrapStorage(hostStorage.kvStore);
+  const kk = makeKernelKeeper(hostStorage, slog);
 
-  const kk = makeKernelKeeper(s, hostStorage.streamStore, slog);
   kk.createStartingKernelState('local');
   const vatID1 = kk.allocateUnusedVatID();
   kk.addDynamicVatID(vatID1);

--- a/packages/SwingSet/test/test-clist.js
+++ b/packages/SwingSet/test/test-clist.js
@@ -2,13 +2,14 @@ import { test } from '../tools/prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
 import { initSimpleSwingStore } from '@agoric/swing-store-simple';
+import { createSHA256 } from '../src/hasher.js';
 import { makeDummySlogger } from '../src/kernel/slogger.js';
 import makeKernelKeeper from '../src/kernel/state/kernelKeeper.js';
 
 test(`clist reachability`, async t => {
   const slog = makeDummySlogger({});
   const hostStorage = initSimpleSwingStore();
-  const kk = makeKernelKeeper(hostStorage, slog);
+  const kk = makeKernelKeeper(hostStorage, slog, createSHA256);
   const s = kk.kvStore;
   kk.createStartingKernelState('local');
   const vatID = kk.allocateUnusedVatID();
@@ -93,7 +94,7 @@ test(`clist reachability`, async t => {
 test('getImporters', async t => {
   const slog = makeDummySlogger({});
   const hostStorage = initSimpleSwingStore();
-  const kk = makeKernelKeeper(hostStorage, slog);
+  const kk = makeKernelKeeper(hostStorage, slog, createSHA256);
 
   kk.createStartingKernelState('local');
   const vatID1 = kk.allocateUnusedVatID();

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -42,7 +42,8 @@ async function simpleCall(t) {
       },
     },
   };
-  const controller = await buildVatController(config);
+  const hostStorage = provideHostStorage();
+  const controller = await buildVatController(config, [], { hostStorage });
   const data = controller.dump();
   // note: data.vatTables is sorted by vatID, but we have no particular
   // reason to believe that vat1 will get a lower ID than vatAdmin, because
@@ -86,6 +87,18 @@ async function simpleCall(t) {
 
   controller.log('2');
   t.is(controller.dump().log[1], '2');
+
+  // hash determined experimentally: will change if the initial kernel state
+  // ever changes. "h1" is what we get when defaultManagerType is "local"
+  const h1 = 'ff9faf10b93a1b5905e00a3343ce58b5ce2c83ed771ff8b619260f6c49c14d15';
+  // "h2" is for "xs-worker", when $SWINGSET_WORKER_TYPE=xs-worker
+  const h2 = 'd794586f99118a2bc00c32ffd5a1a1e698260ba18c6f7aeb5c73b7e798ca8445';
+  const type = hostStorage.kvStore.get('kernel.defaultManagerType');
+  if (type === 'local') {
+    t.is(controller.getActivityhash(), h1);
+  } else if (type === 'xs-worker') {
+    t.is(controller.getActivityhash(), h2);
+  }
 }
 
 test('simple call', async t => {

--- a/packages/SwingSet/test/test-gc-kernel.js
+++ b/packages/SwingSet/test/test-gc-kernel.js
@@ -4,6 +4,7 @@ import { test } from '../tools/prepare-test-env-ava.js';
 
 import { WeakRef, FinalizationRegistry } from '../src/weakref.js';
 import { waitUntilQuiescent } from '../src/waitUntilQuiescent.js';
+import { createSHA256 } from '../src/hasher.js';
 
 import buildKernel from '../src/kernel/index.js';
 import { initializeKernel } from '../src/kernel/initializeKernel.js';
@@ -51,6 +52,7 @@ function makeEndowments() {
     writeSlogObject,
     WeakRef,
     FinalizationRegistry,
+    createSHA256,
   };
 }
 

--- a/packages/SwingSet/test/test-hasher.js
+++ b/packages/SwingSet/test/test-hasher.js
@@ -1,0 +1,36 @@
+import { test } from '../tools/prepare-test-env-ava.js';
+
+// eslint-disable-next-line import/order
+import { createSHA256 } from '../src/hasher.js';
+
+test('createSHA256', t => {
+  t.is(
+    createSHA256().finish(),
+    'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+  );
+
+  const h1 = createSHA256('a');
+  t.is(
+    h1.finish(),
+    'ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb',
+  );
+
+  const h2 = createSHA256();
+  h2.add('a');
+  t.is(
+    h2.finish(),
+    'ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb',
+  );
+
+  const h3 = createSHA256('a');
+  h3.add('b');
+  t.is(
+    h3.finish(),
+    'fb8e20fc2e4c3f248c60c39bd652f3c1347298bb977b8b4d5903b85055620603',
+  );
+
+  const h4 = createSHA256();
+  h4.finish();
+  t.throws(h4.add);
+  t.throws(h4.finish);
+});

--- a/packages/SwingSet/test/test-kernel.js
+++ b/packages/SwingSet/test/test-kernel.js
@@ -5,6 +5,7 @@ import anylogger from 'anylogger';
 import { assert, details as X } from '@agoric/assert';
 import { WeakRef, FinalizationRegistry } from '../src/weakref.js';
 import { waitUntilQuiescent } from '../src/waitUntilQuiescent.js';
+import { createSHA256 } from '../src/hasher.js';
 
 import buildKernel from '../src/kernel/index.js';
 import { initializeKernel } from '../src/kernel/initializeKernel.js';
@@ -62,6 +63,7 @@ function makeEndowments() {
     makeConsole,
     WeakRef,
     FinalizationRegistry,
+    createSHA256,
   };
 }
 

--- a/packages/SwingSet/test/test-state.js
+++ b/packages/SwingSet/test/test-state.js
@@ -1,11 +1,14 @@
-import { test } from '../tools/prepare-test-env-ava.js';
-
+/* eslint-disable no-useless-concat */
 // eslint-disable-next-line import/order
+import { test } from '../tools/prepare-test-env-ava.js';
+// eslint-disable-next-line import/order
+import { createHash } from 'crypto';
 import {
   initSimpleSwingStore,
   getAllState,
   setAllState,
 } from '@agoric/swing-store-simple';
+import { createSHA256 } from '../src/hasher.js';
 import { buildHostDBInMemory } from '../src/hostStorage.js';
 import { buildBlockBuffer } from '../src/blockBuffer.js';
 import makeKernelKeeper from '../src/kernel/state/kernelKeeper.js';
@@ -18,7 +21,10 @@ function checkState(t, getState, expected) {
   const state = getState();
   const got = [];
   for (const key of Object.getOwnPropertyNames(state)) {
-    got.push([key, state[key]]);
+    if (key !== 'activityhash') {
+      // the hash is just too annoying to compare against
+      got.push([key, state[key]]);
+    }
   }
   function compareStrings(a, b) {
     if (a > b) {
@@ -118,7 +124,10 @@ test('blockBuffer fulfills storage API', t => {
 
 test('crankBuffer fulfills storage API', t => {
   const store = initSimpleSwingStore();
-  const { crankBuffer, commitCrank } = buildCrankBuffer(store.kvStore);
+  const { crankBuffer, commitCrank } = buildCrankBuffer(
+    store.kvStore,
+    createSHA256,
+  );
   testStorage(t, crankBuffer, () => getAllState(store).kvStuff, commitCrank);
 });
 
@@ -127,6 +136,7 @@ test('crankBuffer can abortCrank', t => {
   const { blockBuffer, commitBlock } = buildBlockBuffer(hostDB);
   const { crankBuffer: s, commitCrank, abortCrank } = buildCrankBuffer(
     blockBuffer,
+    createSHA256,
   );
 
   s.set('foo', 'f');
@@ -235,7 +245,7 @@ function buildKeeperStorageInMemory() {
 function duplicateKeeper(getState) {
   const store = initSimpleSwingStore();
   setAllState(store, { kvStuff: getState(), streamStuff: new Map() });
-  return makeKernelKeeper(store);
+  return makeKernelKeeper(store, null, createSHA256);
 }
 
 test('hostStorage param guards', async t => {
@@ -253,7 +263,7 @@ test('hostStorage param guards', async t => {
 test('kernel state', async t => {
   const store = buildKeeperStorageInMemory();
   const { getState } = store;
-  const k = makeKernelKeeper(store);
+  const k = makeKernelKeeper(store, null, createSHA256);
   t.truthy(!k.getInitialized());
   k.createStartingKernelState('local');
   k.setInitialized();
@@ -280,7 +290,7 @@ test('kernel state', async t => {
 test('kernelKeeper vat names', async t => {
   const store = buildKeeperStorageInMemory();
   const { getState } = store;
-  const k = makeKernelKeeper(store);
+  const k = makeKernelKeeper(store, null, createSHA256);
   k.createStartingKernelState('local');
 
   const v1 = k.allocateVatIDForNameIfNeeded('vatname5');
@@ -325,7 +335,7 @@ test('kernelKeeper vat names', async t => {
 test('kernelKeeper device names', async t => {
   const store = buildKeeperStorageInMemory();
   const { getState } = store;
-  const k = makeKernelKeeper(store);
+  const k = makeKernelKeeper(store, null, createSHA256);
   k.createStartingKernelState('local');
 
   const d7 = k.allocateDeviceIDForNameIfNeeded('devicename5');
@@ -370,7 +380,7 @@ test('kernelKeeper device names', async t => {
 test('kernelKeeper runQueue', async t => {
   const store = buildKeeperStorageInMemory();
   const { getState } = store;
-  const k = makeKernelKeeper(store);
+  const k = makeKernelKeeper(store, null, createSHA256);
   k.createStartingKernelState('local');
 
   t.truthy(k.isRunQueueEmpty());
@@ -407,7 +417,7 @@ test('kernelKeeper runQueue', async t => {
 test('kernelKeeper promises', async t => {
   const store = buildKeeperStorageInMemory();
   const { getState } = store;
-  const k = makeKernelKeeper(store);
+  const k = makeKernelKeeper(store, null, createSHA256);
   k.createStartingKernelState('local');
 
   const p1 = k.addKernelPromiseForVat('v4');
@@ -529,7 +539,7 @@ test('kernelKeeper promises', async t => {
 
 test('kernelKeeper promise resolveToData', async t => {
   const store = buildKeeperStorageInMemory();
-  const k = makeKernelKeeper(store);
+  const k = makeKernelKeeper(store, null, createSHA256);
   k.createStartingKernelState('local');
 
   const p1 = k.addKernelPromiseForVat('v4');
@@ -551,7 +561,7 @@ test('kernelKeeper promise resolveToData', async t => {
 
 test('kernelKeeper promise reject', async t => {
   const store = buildKeeperStorageInMemory();
-  const k = makeKernelKeeper(store);
+  const k = makeKernelKeeper(store, null, createSHA256);
   k.createStartingKernelState('local');
 
   const p1 = k.addKernelPromiseForVat('v4');
@@ -574,7 +584,7 @@ test('kernelKeeper promise reject', async t => {
 test('vatKeeper', async t => {
   const store = buildKeeperStorageInMemory();
   const { getState } = store;
-  const k = makeKernelKeeper(store);
+  const k = makeKernelKeeper(store, null, createSHA256);
   k.createStartingKernelState('local');
 
   const v1 = k.allocateVatIDForNameIfNeeded('name1');
@@ -611,7 +621,7 @@ test('vatKeeper', async t => {
 
 test('vatKeeper.getOptions', async t => {
   const store = buildKeeperStorageInMemory();
-  const k = makeKernelKeeper(store);
+  const k = makeKernelKeeper(store, null, createSHA256);
   k.createStartingKernelState('local');
 
   const v1 = k.allocateVatIDForNameIfNeeded('name1');
@@ -629,14 +639,14 @@ test('vatKeeper.getOptions', async t => {
 
 test('XS vatKeeper defaultManagerType', async t => {
   const store = buildKeeperStorageInMemory();
-  const k = makeKernelKeeper(store);
+  const k = makeKernelKeeper(store, null, createSHA256);
   k.createStartingKernelState('xs-worker');
   t.is(k.getDefaultManagerType(), 'xs-worker');
 });
 
 test('meters', async t => {
   const store = buildKeeperStorageInMemory();
-  const k = makeKernelKeeper(store);
+  const k = makeKernelKeeper(store, null, createSHA256);
   k.createStartingKernelState('local');
   const m1 = k.allocateMeter(100n, 10n);
   const m2 = k.allocateMeter(200n, 150n);
@@ -672,4 +682,121 @@ test('meters', async t => {
   t.deepEqual(k.getMeter(m3), { remaining: 'unlimited', threshold: 5n });
   t.deepEqual(k.deductMeter(m3, 1000n), { underflow: false, notify: false });
   t.deepEqual(k.getMeter(m3), { remaining: 'unlimited', threshold: 5n });
+});
+
+test('crankhash', t => {
+  const store = buildKeeperStorageInMemory();
+  const k = makeKernelKeeper(store, null, createSHA256);
+  k.createStartingKernelState('local');
+  k.commitCrank();
+  // the initial state additions happen to hash to this:
+  const oldActivityhash =
+    '2062d4a479c62d3f83b7ca654f911fdd5320609e003deb0a0396872639d170a1';
+  t.is(store.kvStore.get('activityhash'), oldActivityhash);
+
+  k.kvStore.set('one', '1');
+  let h = createHash('sha256');
+  h.update('add\n' + 'one\n' + '1\n');
+  const expCrankhash = h.digest('hex');
+  t.is(
+    expCrankhash,
+    '29dedad4ccd119b6f7d80109590cc357c69eb4f03210cdbc9b1c982cd228fd8b',
+  );
+
+  h = createHash('sha256');
+  h.update('activityhash\n');
+  h.update(`${oldActivityhash}\n${expCrankhash}\n`);
+  const expActivityhash = h.digest('hex');
+  t.is(
+    expActivityhash,
+    '3c963c0082282e486edfcb62d31322e72f5e0c2c9f296ea61f613eeea23b8770',
+  );
+
+  const { crankhash, activityhash } = k.commitCrank();
+  t.is(crankhash, expCrankhash);
+  t.is(activityhash, expActivityhash);
+  t.is(store.kvStore.get('activityhash'), expActivityhash);
+});
+
+test('crankhash - skip keys', t => {
+  const store = buildKeeperStorageInMemory();
+  const k = makeKernelKeeper(store, null, createSHA256);
+  k.createStartingKernelState('local');
+  k.commitCrank();
+
+  k.kvStore.set('one', '1');
+  const h = createHash('sha256');
+  h.update('add\n' + 'one\n' + '1\n');
+  const expCrankhash = h.digest('hex');
+  t.is(
+    expCrankhash,
+    '29dedad4ccd119b6f7d80109590cc357c69eb4f03210cdbc9b1c982cd228fd8b',
+  );
+  t.is(k.commitCrank().crankhash, expCrankhash);
+
+  // certain local keys are excluded from consensus, and should not affect
+  // the hash
+  k.kvStore.set('one', '1');
+  k.kvStore.set('local.snapshot.XYZ', '["vat1234"]');
+  k.kvStore.set(
+    'local.v1234.lastSnapshot',
+    '{"snapshotID":"XYZ","startPos":4}',
+  );
+  t.is(k.commitCrank().crankhash, expCrankhash);
+});
+
+test('crankhash - duplicate set', t => {
+  // setting the same key multiple times counts as divergence, because we
+  // hash as we add/delete, not just the accumulated additions/deletions set
+
+  const store = buildKeeperStorageInMemory();
+  const k = makeKernelKeeper(store, null, createSHA256);
+  k.createStartingKernelState('local');
+  k.commitCrank();
+
+  k.kvStore.set('one', '1');
+  const h = createHash('sha256');
+  h.update('add\n' + 'one\n' + '1\n');
+  const expCrankhash = h.digest('hex');
+  t.is(
+    expCrankhash,
+    '29dedad4ccd119b6f7d80109590cc357c69eb4f03210cdbc9b1c982cd228fd8b',
+  );
+  t.is(k.commitCrank().crankhash, expCrankhash);
+
+  k.kvStore.set('one', '1');
+  k.kvStore.set('one', '1');
+  const h2 = createHash('sha256');
+  h2.update('add\n' + 'one\n' + '1\n');
+  h2.update('add\n' + 'one\n' + '1\n');
+  const expCrankhash2 = h2.digest('hex');
+  t.is(
+    expCrankhash2,
+    '6e82c45c44062ceb71cf242a79aa76578a2dd3002e0b76d756790418914ccc34',
+  );
+  t.is(k.commitCrank().crankhash, expCrankhash2);
+});
+
+test('crankhash - set and delete', t => {
+  // setting and deleting a key is different than never setting it
+
+  const store = buildKeeperStorageInMemory();
+  const k = makeKernelKeeper(store, null, createSHA256);
+  k.createStartingKernelState('local');
+  k.commitCrank();
+
+  const h1 = createHash('sha256');
+  const expCrankhash1 = h1.digest('hex');
+  t.is(k.commitCrank().crankhash, expCrankhash1); // empty
+
+  const h2 = createHash('sha256');
+  h2.update('add\n' + 'one\n' + '1\n');
+  h2.update('delete\n' + 'one\n');
+  const expCrankhash2 = h2.digest('hex');
+
+  k.kvStore.set('one', '1');
+  k.kvStore.delete('one');
+  t.is(k.commitCrank().crankhash, expCrankhash2);
+
+  t.not(expCrankhash1, expCrankhash2);
 });

--- a/packages/SwingSet/test/test-vpid-kernel.js
+++ b/packages/SwingSet/test/test-vpid-kernel.js
@@ -5,6 +5,7 @@ import anylogger from 'anylogger';
 import { assert, details as X } from '@agoric/assert';
 import { WeakRef, FinalizationRegistry } from '../src/weakref.js';
 import { waitUntilQuiescent } from '../src/waitUntilQuiescent.js';
+import { createSHA256 } from '../src/hasher.js';
 import { provideHostStorage } from '../src/hostStorage.js';
 
 import buildKernel from '../src/kernel/index.js';
@@ -41,6 +42,7 @@ function makeEndowments() {
     makeConsole,
     WeakRef,
     FinalizationRegistry,
+    createSHA256,
   };
 }
 

--- a/packages/SwingSet/test/vat-warehouse/test-reload-snapshot.js
+++ b/packages/SwingSet/test/vat-warehouse/test-reload-snapshot.js
@@ -33,7 +33,7 @@ test('vat reload from snapshot', async t => {
   const vatID = c1.vatNameToID('target');
 
   function getPositions() {
-    const lastSnapshot = hostStorage.kvStore.get(`${vatID}.lastSnapshot`);
+    const lastSnapshot = hostStorage.kvStore.get(`local.${vatID}.lastSnapshot`);
     const start = lastSnapshot
       ? JSON.parse(lastSnapshot).startPos.itemCount
       : 0;

--- a/packages/SwingSet/test/vat-warehouse/test-warehouse.js
+++ b/packages/SwingSet/test/vat-warehouse/test-warehouse.js
@@ -103,10 +103,10 @@ test('4 vats in warehouse with 2 online', async t => {
 
 function unusedSnapshotsOnDisk(kvStore, snapstorePath) {
   const inUse = [];
-  for (const k of kvStore.getKeys(`snapshot.`, `snapshot/`)) {
+  for (const k of kvStore.getKeys(`local.snapshot.`, `local.snapshot/`)) {
     const consumers = JSON.parse(kvStore.get(k));
     if (consumers.length > 0) {
-      const id = k.slice(`snapshot.`.length);
+      const id = k.slice(`local.snapshot.`.length);
       inUse.push(id);
     }
   }


### PR DESCRIPTION
The multiple members of a consensus machine are supposed to perform
identical exection of every crank. To detect any possible divergence as
quickly as possible, the kernel maintains the "crankhash": a
constantly-updated string which incorporates (by SHA256 hash) a copy of every
DB write and delete.

`controller.getCrankHash()` can be run after one or more cranks have
finished, and the resulting hex string can be e.g. stored in a host
application consensus state vector. If two members diverge in a way that
causes their swingset state to differ, they will have different crankhashes,
and the consensus state vectors will diverge. This should cause at least one
of them to fall out of consensus.

Some keys are excluded from consensus: currently just those involving vat
snapshots and the truncation (non-initial starting point) of the transcript.

refs #3442 
