### PR TITLE
feat(cosmic-swingset): add swingset 'crankhash' to state vector

### DIFF
--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -209,6 +209,14 @@ export default async function main(progname, args, { env, homedir, agcc }) {
       },
       exportMailbox,
     );
+    function setActivityhash(activityhash) {
+      const msg = stringify({
+        method: 'set',
+        key: 'activityhash',
+        value: activityhash,
+      });
+      chainSend(portNums.storage, msg);
+    }
     function doOutboundBridge(dstID, obj) {
       const portNum = portNums[dstID];
       if (portNum === undefined) {
@@ -245,6 +253,7 @@ export default async function main(progname, args, { env, homedir, agcc }) {
     const s = await launch(
       stateDBDir,
       mailboxStorage,
+      setActivityhash,
       doOutboundBridge,
       vatconfig,
       argv,

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -219,6 +219,9 @@ export async function launch(
       type: 'cosmic-swingset-bootstrap-block-finish',
       blockTime,
     });
+    if (setActivityhash) {
+      setActivityhash(controller.getActivityhash());
+    }
   }
 
   async function endBlock(blockHeight, blockTime) {

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -126,6 +126,7 @@ function neverStop() {
 export async function launch(
   kernelStateDBDir,
   mailboxStorage,
+  setActivityhash,
   bridgeOutbound,
   vatconfig,
   argv,
@@ -232,6 +233,9 @@ export async function launch(
       blockHeight,
       blockTime,
     });
+    if (setActivityhash) {
+      setActivityhash(controller.getActivityhash());
+    }
   }
 
   async function saveChainState() {

--- a/packages/cosmic-swingset/src/sim-chain.js
+++ b/packages/cosmic-swingset/src/sim-chain.js
@@ -77,6 +77,7 @@ export async function connectToFakeChain(basedir, GCI, delay, inbound) {
     stateDBdir,
     mailboxStorage,
     undefined,
+    undefined,
     vatconfig,
     argv,
     GCI, // debugName


### PR DESCRIPTION
This 'crankhash' covers all kernel state changes, so if any two validators
diverge, their crankhashes should diverge too. By storing them into the
cosmos-sdk state vector, the AppHashes will diverage as well, causing at
least one of them to fall out of consensus. This should let us catch
divergence as soon as possible.

closes #3442