### PR TITLE
refactor(deployment): Convert RESM to NESM

### DIFF
--- a/packages/deployment/package.json
+++ b/packages/deployment/package.json
@@ -2,13 +2,11 @@
   "name": "@agoric/deployment",
   "version": "1.28.7",
   "description": "Set up Agoric public chain nodes",
-  "parsers": {
-    "js": "mjs"
-  },
+  "type": "module",
   "private": true,
   "main": "src/main.js",
   "bin": {
-    "ag-setup-cosmos": "src/entrypoint.cjs"
+    "ag-setup-cosmos": "src/entrypoint.js"
   },
   "scripts": {
     "test": "exit 0",
@@ -26,7 +24,6 @@
     "@agoric/install-ses": "^0.5.21",
     "chalk": "^2.4.2",
     "deterministic-json": "^1.0.5",
-    "esm": "agoric-labs/esm#Agoric-built",
     "inquirer": "^6.3.1",
     "minimist": "^1.2.0",
     "node-fetch": "^2.6.0",

--- a/packages/deployment/src/entrypoint.cjs
+++ b/packages/deployment/src/entrypoint.cjs
@@ -1,3 +1,0 @@
-#! /usr/bin/env node
-/* global require module */
-require('esm')(module)('./entrypoint.js');

--- a/packages/deployment/src/entrypoint.js
+++ b/packages/deployment/src/entrypoint.js
@@ -11,9 +11,9 @@ import { exec, spawn } from 'child_process';
 import inquirer from 'inquirer';
 import fetch from 'node-fetch';
 
-import { running } from './run';
-import { setup } from './setup';
-import * as files from './files';
+import { running } from './run.js';
+import { setup } from './setup.js';
+import * as files from './files.js';
 import deploy from './main.js';
 
 process.on('SIGINT', () => process.exit(-1));

--- a/packages/deployment/src/init.js
+++ b/packages/deployment/src/init.js
@@ -1,8 +1,8 @@
 // @ts-check
 
 import { assert, details as X } from '@agoric/assert';
-import { PLAYBOOK_WRAPPER, SSH_TYPE } from './setup';
-import { shellEscape } from './run';
+import { PLAYBOOK_WRAPPER, SSH_TYPE } from './setup.js';
+import { shellEscape } from './run.js';
 
 export const AVAILABLE_ROLES = ['validator', 'peer', 'seed'];
 

--- a/packages/deployment/src/main.js
+++ b/packages/deployment/src/main.js
@@ -1,15 +1,13 @@
-/* global __dirname */
 /* eslint-disable no-await-in-loop */
 import djson from 'deterministic-json';
 import { createHash } from 'crypto';
 import chalk from 'chalk';
 import parseArgs from 'minimist';
 import { assert, details as X } from '@agoric/assert';
-import { dirname, basename } from 'path';
-import { doInit } from './init';
-import { shellMetaRegexp, shellEscape } from './run';
-import { streamFromString } from './files';
-import { SSH_TYPE, DEFAULT_BOOT_TOKENS } from './setup';
+import { doInit } from './init.js';
+import { shellMetaRegexp, shellEscape } from './run.js';
+import { streamFromString } from './files.js';
+import { SSH_TYPE, DEFAULT_BOOT_TOKENS } from './setup.js';
 
 const PROVISION_DIR = 'provision';
 const COSMOS_DIR = 'ag-chain-cosmos';
@@ -29,6 +27,8 @@ const isPublicRpc = (roles, cluster) => {
   return roles[cluster] === 'validator';
 };
 const isPersistentPeer = isPublicRpc;
+
+const dirname = new URL('./', import.meta.url).pathname;
 
 const makeGuardFile = ({ rd, wr }) => async (file, maker) => {
   if (await rd.exists(file)) {
@@ -402,7 +402,7 @@ show-config      display the client connection parameters
       await guardFile(`${COSMOS_DIR}/set-defaults.stamp`, async () => {
         await needReMain(['play', 'cosmos-clone-config']);
 
-        const agoricCli = rd.resolve(__dirname, `../../agoric-cli/bin/agoric`);
+        const agoricCli = rd.resolve(dirname, `../../agoric-cli/bin/agoric`);
 
         // Apply the Agoric set-defaults to all the .dst dirs.
         const files = await rd.readdir(`${COSMOS_DIR}/data`);
@@ -911,8 +911,8 @@ ${name}:
           addRole[role] = makeGroup(role, 4);
         }
         const keyFile = rd.resolve(
-          dirname(SSH_PRIVATE_KEY_FILE),
-          `${provider}-${basename(SSH_PRIVATE_KEY_FILE)}`,
+          rd.dirname(SSH_PRIVATE_KEY_FILE),
+          `${provider}-${rd.basename(SSH_PRIVATE_KEY_FILE)}`,
         );
         for (let instance = 0; instance < ips.length; instance += 1) {
           const ip = ips[instance];

--- a/packages/deployment/src/setup.js
+++ b/packages/deployment/src/setup.js
@@ -1,4 +1,3 @@
-/* global __dirname */
 import chalk from 'chalk';
 
 export const ACCOUNT_JSON = `account.json`;
@@ -6,10 +5,12 @@ export const DEFAULT_BOOT_TOKENS = `1000000000000000ubld,100000000000urun`;
 export const PLAYBOOK_WRAPPER = `./ansible-playbook.sh`;
 export const SSH_TYPE = 'ecdsa';
 
+const dirname = new URL('./', import.meta.url).pathname;
+
 export const setup = ({ resolve, env, setInterval }) => {
   const it = harden({
-    AGORIC_SDK: resolve(__dirname, '../../..'),
-    SETUP_DIR: resolve(__dirname, '..'),
+    AGORIC_SDK: resolve(dirname, '../../..'),
+    SETUP_DIR: resolve(dirname, '..'),
     SETUP_HOME: env.AG_SETUP_COSMOS_HOME
       ? resolve(env.AG_SETUP_COSMOS_HOME)
       : resolve('.'),


### PR DESCRIPTION
This change also incidentally removes a dependency on path in favor of using the thread read powers. This frees up the name dirname in module scope for our adapter to import.module.url.

Refs #527