### PR TITLE
refactor(governance): Convert RESM to NESM

### DIFF
--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -2,9 +2,7 @@
   "name": "@agoric/governance",
   "version": "0.1.7",
   "description": "Core governance support",
-  "parsers": {
-    "js": "mjs"
-  },
+  "type": "module",
   "main": "src/paramManager.js",
   "engines": {
     "node": ">=14.15.0"
@@ -48,7 +46,6 @@
     "@agoric/install-ses": "^0.5.21",
     "@agoric/swingset-vat": "^0.19.0",
     "ava": "^3.12.1",
-    "esm": "agoric-labs/esm#Agoric-built",
     "ses": "^0.14.0"
   },
   "files": [
@@ -58,9 +55,6 @@
   "ava": {
     "files": [
       "test/**/test-*.js"
-    ],
-    "require": [
-      "esm"
     ],
     "timeout": "10m"
   },

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
+    "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint-check": "yarn lint",
@@ -46,6 +47,7 @@
     "@agoric/install-ses": "^0.5.21",
     "@agoric/swingset-vat": "^0.19.0",
     "ava": "^3.12.1",
+    "c8": "^7.7.2",
     "ses": "^0.14.0"
   },
   "files": [

--- a/packages/governance/src/binaryBallotCounter.js
+++ b/packages/governance/src/binaryBallotCounter.js
@@ -6,8 +6,8 @@ import { makePromiseKit } from '@agoric/promise-kit';
 import { Far } from '@agoric/marshal';
 
 import { E } from '@agoric/eventual-send';
-import { ChoiceMethod, buildBallot } from './ballotBuilder';
-import { scheduleClose } from './closingRule';
+import { ChoiceMethod, buildBallot } from './ballotBuilder.js';
+import { scheduleClose } from './closingRule.js';
 
 const makeWeightedBallot = (ballot, shares) => harden({ ballot, shares });
 

--- a/packages/governance/src/paramManager.js
+++ b/packages/governance/src/paramManager.js
@@ -1,10 +1,10 @@
 // @ts-check
 
 import { assert, details as X } from '@agoric/assert';
-import { assertIsRatio } from '@agoric/zoe/src/contractSupport';
+import { assertIsRatio } from '@agoric/zoe/src/contractSupport/index.js';
 import { AmountMath, looksLikeBrand } from '@agoric/ertp';
 import { Far } from '@agoric/marshal';
-import { assertKeywordName } from '@agoric/zoe/src/cleanProposal';
+import { assertKeywordName } from '@agoric/zoe/src/cleanProposal.js';
 import { Nat } from '@agoric/nat';
 
 /**

--- a/packages/governance/test/swingsetTests/committeeBinary/bootstrap.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/bootstrap.js
@@ -2,7 +2,7 @@
 
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer';
+import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 
 const makeVoterVat = async (log, vats, zoe) => {
   const voterCreator = E(vats.voter).build(zoe);

--- a/packages/governance/test/swingsetTests/committeeBinary/test-committee.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/test-committee.js
@@ -1,5 +1,3 @@
-/* global __dirname */
-
 // @ts-check
 
 // TODO Remove babel-standalone preinitialization
@@ -12,8 +10,12 @@ import '@agoric/install-ses';
 import test from 'ava';
 import { buildVatController, buildKernelBundles } from '@agoric/swingset-vat';
 import bundleSource from '@agoric/bundle-source';
+import path from 'path';
 
 const CONTRACT_FILES = ['committeeRegistrar', 'binaryBallotCounter'];
+
+const filename = new URL(import.meta.url).pathname;
+const dirname = path.dirname(filename);
 
 test.before(async t => {
   const start = Date.now();
@@ -30,7 +32,7 @@ test.before(async t => {
       } else {
         ({ bundleName, contractPath } = settings);
       }
-      const source = `${__dirname}/../../../src/${contractPath}`;
+      const source = `${dirname}/../../../src/${contractPath}`;
       const bundle = await bundleSource(source);
       contractBundles[bundleName] = bundle;
     }),
@@ -40,12 +42,12 @@ test.before(async t => {
   const vats = {};
   await Promise.all(
     ['voter', 'zoe'].map(async name => {
-      const source = `${__dirname}/vat-${name}.js`;
+      const source = `${dirname}/vat-${name}.js`;
       const bundle = await bundleSource(source);
       vats[name] = { bundle };
     }),
   );
-  const bootstrapSource = `${__dirname}/bootstrap.js`;
+  const bootstrapSource = `${dirname}/bootstrap.js`;
   vats.bootstrap = {
     bundle: await bundleSource(bootstrapSource),
     parameters: { contractBundles }, // argv will be added to this

--- a/packages/governance/test/test-param-manager.js
+++ b/packages/governance/test/test-param-manager.js
@@ -1,12 +1,12 @@
 // @ts-check
 
-import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
-import '@agoric/zoe/exported';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import '@agoric/zoe/exported.js';
 import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
-import { makeRatio } from '@agoric/zoe/src/contractSupport';
+import { makeRatio } from '@agoric/zoe/src/contractSupport/index.js';
 
-import { makeHandle } from '@agoric/zoe/src/makeHandle';
-import { buildParamManager, ParamType } from '../src/paramManager';
+import { makeHandle } from '@agoric/zoe/src/makeHandle.js';
+import { buildParamManager, ParamType } from '../src/paramManager.js';
 
 const BASIS_POINTS = 10_000;
 

--- a/packages/governance/test/unitTests/test-ballotCount.js
+++ b/packages/governance/test/unitTests/test-ballotCount.js
@@ -1,11 +1,11 @@
 // @ts-check
 
-import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
-import '@agoric/zoe/exported';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import '@agoric/zoe/exported.js';
 import { E } from '@agoric/eventual-send';
 
-import { makeHandle } from '@agoric/zoe/src/makeHandle';
-import { makeBinaryBallotCounter } from '../../src/binaryBallotCounter';
+import { makeHandle } from '@agoric/zoe/src/makeHandle.js';
+import { makeBinaryBallotCounter } from '../../src/binaryBallotCounter.js';
 
 const QUESTION = 'Fish or cut bait?';
 const FISH = 'Fish';

--- a/packages/governance/test/unitTests/test-committee.js
+++ b/packages/governance/test/unitTests/test-committee.js
@@ -1,20 +1,23 @@
-/* global __dirname */
 // @ts-check
 
-import { test } from '@agoric/zoe/tools/prepare-test-env-ava';
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import '@agoric/zoe/exported';
+import '@agoric/zoe/exported.js';
 
+import path from 'path';
 import { E } from '@agoric/eventual-send';
 import { makeZoe } from '@agoric/zoe';
-import fakeVatAdmin from '@agoric/zoe/tools/fakeVatAdmin';
+import fakeVatAdmin from '@agoric/zoe/tools/fakeVatAdmin.js';
 import bundleSource from '@agoric/bundle-source';
-import buildManualTimer from '@agoric/zoe/tools/manualTimer';
+import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 
-import { ChoiceMethod } from '../../src/ballotBuilder';
+import { ChoiceMethod } from '../../src/ballotBuilder.js';
 
-const registrarRoot = `${__dirname}/../../src/committeeRegistrar`;
-const counterRoot = `${__dirname}/../../src/binaryBallotCounter`;
+const filename = new URL(import.meta.url).pathname;
+const dirname = path.dirname(filename);
+
+const registrarRoot = `${dirname}/../../src/committeeRegistrar.js`;
+const counterRoot = `${dirname}/../../src/binaryBallotCounter.js`;
 
 async function setupContract() {
   const zoe = makeZoe(fakeVatAdmin);


### PR DESCRIPTION
This changes the governance package to use Node.js ESM instead of -r esm emulation as described in #527. A second commit adds a script for measuring test coverage.

Refs #527