### PR TITLE
refactor(agoric): Convert RESM to NESM

### DIFF
--- a/packages/agoric-cli/bin/agoric
+++ b/packages/agoric-cli/bin/agoric
@@ -1,2 +1,1 @@
-#!/usr/bin/env node
-require('esm')(module)('../lib/entrypoint');
+../lib/entrypoint.js

--- a/packages/agoric-cli/integration-tests/test-workflow.js
+++ b/packages/agoric-cli/integration-tests/test-workflow.js
@@ -1,6 +1,6 @@
-/* global __dirname process setTimeout clearTimeout setInterval clearInterval */
+/* global process setTimeout clearTimeout setInterval clearInterval */
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import fs from 'fs';
 import path from 'path';
@@ -11,9 +11,11 @@ import { request } from 'http';
 
 import { spawn } from 'child_process';
 
-import { makePspawn } from '../lib/helpers';
+import { makePspawn } from '../lib/helpers.js';
 
 const TIMEOUT_SECONDS = 20 * 60;
+
+const dirname = new URL('./', import.meta.url).pathname;
 
 // To keep in sync with https://agoric.com/documentation/getting-started/
 
@@ -45,10 +47,10 @@ test('workflow', async t => {
   }
 
   // Run all main programs with the '--sdk' flag if we are in agoric-sdk.
-  const extraArgs = fs.existsSync(`${__dirname}/../../cosmic-swingset`)
+  const extraArgs = fs.existsSync(`${dirname}/../../cosmic-swingset`)
     ? ['--sdk']
     : [];
-  const agoricCli = path.join(__dirname, '..', 'bin', 'agoric');
+  const agoricCli = path.join(dirname, '..', 'bin', 'agoric');
   function myMain(args) {
     // console.error('running agoric-cli', ...extraArgs, ...args);
     return pspawnStdout(agoricCli, [...extraArgs, ...args], {

--- a/packages/agoric-cli/lib/cosmos.js
+++ b/packages/agoric-cli/lib/cosmos.js
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { makePspawn } from './helpers';
+import { makePspawn } from './helpers.js';
 
 export default async function cosmosMain(progname, rawArgs, powers, opts) {
   const IMAGE = `agoric/agoric-sdk`;

--- a/packages/agoric-cli/lib/deploy.js
+++ b/packages/agoric-cli/lib/deploy.js
@@ -1,12 +1,16 @@
-/* global require process setTimeout setInterval clearInterval */
+/* global process setTimeout setInterval clearInterval */
 /* eslint-disable no-await-in-loop */
+
 import { E, makeCapTP } from '@agoric/captp';
 import { makePromiseKit } from '@agoric/promise-kit';
 import bundleSource from '@agoric/bundle-source';
 import path from 'path';
 import inquirer from 'inquirer';
+import createRequire from 'esm';
 
 import { getAccessToken } from '@agoric/access-token';
+
+const require = createRequire({});
 
 // note: CapTP has its own HandledPromise instantiation, and the contract
 // must use the same one that CapTP uses. We achieve this by not bundling
@@ -220,8 +224,11 @@ export { bootPlugin } from ${JSON.stringify(absPath)};
           }
 
           // use a dynamic import to load the deploy script, it is unconfined
-          // eslint-disable-next-line import/no-dynamic-require,global-require
-          const mainNS = require(pathResolve(moduleFile));
+          // eslint-disable-next-line import/no-dynamic-require
+          const mainNS = require(moduleFile);
+          // TODO Node.js ESM support if package.json of template says "type":
+          // "module":
+          //   const mainNS = await import(pathResolve(moduleFile));
           const main = mainNS.default;
           if (typeof main !== 'function') {
             console.error(

--- a/packages/agoric-cli/lib/entrypoint.js
+++ b/packages/agoric-cli/lib/entrypoint.js
@@ -1,6 +1,9 @@
+#!/usr/bin/env -S node
+
 /* global process */
-// TODO Remove babel-standalone preinitialization
+// TODO Remove babel-standalone and esm preinitialization
 // https://github.com/endojs/endo/issues/768
+import 'esm';
 import '@agoric/babel-standalone';
 import '@agoric/install-ses';
 
@@ -11,10 +14,10 @@ import rawFs from 'fs';
 import os from 'os';
 
 // Configure logs.
-import './anylogger-agoric';
+import './anylogger-agoric.js';
 import anylogger from 'anylogger';
 
-import main from './main';
+import main from './main.js';
 
 const fs = rawFs.promises;
 const log = anylogger('agoric');

--- a/packages/agoric-cli/lib/init.js
+++ b/packages/agoric-cli/lib/init.js
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { makePspawn } from './helpers';
+import { makePspawn } from './helpers.js';
 
 // Use either an absolute template URL, or find it relative to DAPP_URL_BASE.
 const gitURL = (relativeOrAbsoluteURL, base) => {

--- a/packages/agoric-cli/lib/install.js
+++ b/packages/agoric-cli/lib/install.js
@@ -1,7 +1,10 @@
-/* global __dirname process Buffer */
+/* global process Buffer */
 import path from 'path';
 import chalk from 'chalk';
-import { makePspawn } from './helpers';
+import { makePspawn } from './helpers.js';
+
+const filename = new URL(import.meta.url).pathname;
+const dirname = path.dirname(filename);
 
 export default async function installMain(progname, rawArgs, powers, opts) {
   const { anylogger, fs, spawn } = powers;
@@ -63,7 +66,7 @@ export default async function installMain(progname, rawArgs, powers, opts) {
     log('removing', linkFolder);
     await rimraf(linkFolder);
 
-    const sdkRoot = path.resolve(__dirname, `../../..`);
+    const sdkRoot = path.resolve(dirname, `../../..`);
     const sdkDirs = await workspaceDirectories(sdkRoot);
     await Promise.all(
       sdkDirs.map(async location => {

--- a/packages/agoric-cli/lib/main.js
+++ b/packages/agoric-cli/lib/main.js
@@ -1,19 +1,22 @@
-/* global __dirname process */
+/* global process */
 import { Command } from 'commander';
-
+import path from 'path';
 import { assert, details as X } from '@agoric/assert';
-import cosmosMain from './cosmos';
-import deployMain from './deploy';
-import initMain from './init';
-import installMain from './install';
-import setDefaultsMain from './set-defaults';
-import startMain from './start';
-import walletMain from './open';
+import cosmosMain from './cosmos.js';
+import deployMain from './deploy.js';
+import initMain from './init.js';
+import installMain from './install.js';
+import setDefaultsMain from './set-defaults.js';
+import startMain from './start.js';
+import walletMain from './open.js';
 
 const DEFAULT_DAPP_TEMPLATE = 'dapp-fungible-faucet';
 const DEFAULT_DAPP_URL_BASE = 'git://github.com/Agoric/';
 
 const STAMP = '_agstate';
+
+const filename = new URL(import.meta.url).pathname;
+const dirname = path.dirname(filename);
 
 const main = async (progname, rawArgs, powers) => {
   const { anylogger, fs } = powers;
@@ -41,7 +44,7 @@ const main = async (progname, rawArgs, powers) => {
 
   program.storeOptionsAsProperties(false);
 
-  const pj = await fs.readFile(`${__dirname}/../package.json`);
+  const pj = await fs.readFile(`${dirname}/../package.json`);
   const pkg = JSON.parse(pj);
   program.name(pkg.name).version(pkg.version);
 

--- a/packages/agoric-cli/lib/set-defaults.js
+++ b/packages/agoric-cli/lib/set-defaults.js
@@ -4,7 +4,7 @@ import {
   finishCosmosApp,
   finishTendermintConfig,
   finishCosmosGenesis,
-} from './chain-config';
+} from './chain-config.js';
 
 export default async function setDefaultsMain(progname, rawArgs, powers, opts) {
   const { anylogger, fs } = powers;

--- a/packages/agoric-cli/lib/start.js
+++ b/packages/agoric-cli/lib/start.js
@@ -1,4 +1,4 @@
-/* global __dirname process setTimeout */
+/* global process setTimeout */
 import path from 'path';
 import chalk from 'chalk';
 import { createHash } from 'crypto';
@@ -9,9 +9,12 @@ import {
   finishTendermintConfig,
   finishCosmosGenesis,
   finishCosmosApp,
-} from './chain-config';
+} from './chain-config.js';
 
-import { makePspawn } from './helpers';
+import { makePspawn } from './helpers.js';
+
+const filename = new URL(import.meta.url).pathname;
+const dirname = path.dirname(filename);
 
 const PROVISION_COINS = `100000000${STAKING_DENOM},50000000000${CENTRAL_DENOM},100provisionpass,100sendpacketpass`;
 const DELEGATE0_COINS = `50000000${STAKING_DENOM}`;
@@ -113,7 +116,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
 
   let agSolo;
   if (opts.sdk) {
-    agSolo = path.resolve(__dirname, '../../solo/src/entrypoint.js');
+    agSolo = path.resolve(dirname, '../../solo/src/entrypoint.js');
   } else {
     agSolo = `ag-solo`;
   }

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
+    "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
     "integration-test": "ava --config .ava-integration-test.config.js",
     "lint-check": "yarn lint",
@@ -21,6 +22,7 @@
   "devDependencies": {
     "@agoric/swingset-vat": "^0.19.0",
     "ava": "^3.12.1",
+    "c8": "^7.7.2",
     "tmp": "^0.1.0"
   },
   "dependencies": {

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -2,9 +2,7 @@
   "name": "agoric",
   "version": "0.13.11",
   "description": "Manage the Agoric Javascript smart contract platform",
-  "parsers": {
-    "js": "mjs"
-  },
+  "type": "module",
   "main": "lib/main.js",
   "bin": "bin/agoric",
   "files": [
@@ -63,9 +61,6 @@
   "ava": {
     "files": [
       "test/**/test-*.js"
-    ],
-    "require": [
-      "esm"
     ],
     "timeout": "2m"
   },

--- a/packages/agoric-cli/test/test-main.js
+++ b/packages/agoric-cli/test/test-main.js
@@ -1,13 +1,14 @@
 /* global globalThis */
-// TODO Remove babel-standalone preinitialization
+// TODO Remove babel-standalone and esm preinitialization
 // https://github.com/endojs/endo/issues/768
+import 'esm';
 import '@agoric/babel-standalone';
 import '@agoric/install-ses';
 import test from 'ava';
 import fs from 'fs';
 import anylogger from 'anylogger';
 
-import main from '../lib/main';
+import main from '../lib/main.js';
 
 test('sanity', async t => {
   const stubAnylogger = () => {


### PR DESCRIPTION
This changes the agoric-cli package to use Node.js ESM instead of -r esm emulation.

Refs #527