### PR TITLE
refactor(import-manager): Convert RESM to NESM

### DIFF
--- a/packages/import-manager/package.json
+++ b/packages/import-manager/package.json
@@ -2,10 +2,8 @@
   "name": "@agoric/import-manager",
   "version": "0.2.23",
   "description": "Share code across vat boundaries",
-  "parsers": {
-    "js": "mjs"
-  },
-  "main": "src/importManager.js",
+  "type": "module",
+  "main": "./src/importManager.js",
   "engines": {
     "node": ">=11.0"
   },
@@ -33,8 +31,7 @@
   "devDependencies": {
     "@agoric/install-ses": "^0.5.21",
     "@agoric/swingset-vat": "^0.19.0",
-    "ava": "^3.12.1",
-    "esm": "agoric-labs/esm#Agoric-built"
+    "ava": "^3.12.1"
   },
   "files": [
     "src/",
@@ -43,9 +40,6 @@
   "ava": {
     "files": [
       "test/**/test-*.js"
-    ],
-    "require": [
-      "esm"
     ]
   },
   "eslintConfig": {

--- a/packages/import-manager/package.json
+++ b/packages/import-manager/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
+    "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint-check": "yarn lint",
@@ -31,7 +32,8 @@
   "devDependencies": {
     "@agoric/install-ses": "^0.5.21",
     "@agoric/swingset-vat": "^0.19.0",
-    "ava": "^3.12.1"
+    "ava": "^3.12.1",
+    "c8": "^7.7.2"
   },
   "files": [
     "src/",

--- a/packages/import-manager/test/unitTests/badImports.js
+++ b/packages/import-manager/test/unitTests/badImports.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
-import { importManager } from '../../src/importManager';
-import { listIsEmpty, numIsEmpty } from './valueOps';
+import { importManager } from '../../src/importManager.js';
+import { listIsEmpty, numIsEmpty } from './valueOps.js';
 
 function makeBadImportManager() {
   const mgr = importManager();

--- a/packages/import-manager/test/unitTests/goodImports.js
+++ b/packages/import-manager/test/unitTests/goodImports.js
@@ -1,7 +1,7 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
-import { numIsEmpty, listIsEmpty } from './valueOps';
-import { importManager } from '../../src/importManager';
+import { numIsEmpty, listIsEmpty } from './valueOps.js';
+import { importManager } from '../../src/importManager.js';
 
 // This file models the way a module could export functionality to be run
 // locally within a vat, but with the behavior determined by remote objects.

--- a/packages/import-manager/test/unitTests/test-importsA.js
+++ b/packages/import-manager/test/unitTests/test-importsA.js
@@ -1,8 +1,8 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava';
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
-import { makeGoodImportManager } from './goodImports';
+import { makeGoodImportManager } from './goodImports.js';
 
 test('import num is not empty', t => {
   const importer = makeGoodImportManager();


### PR DESCRIPTION
Converts the import-manager package to use Node.js ESM instead of -r esm emulation.

Refs #527