### PR TITLE
refactor(transform-metering): Convert RESM to NESM

### DIFF
--- a/packages/transform-metering/package.json
+++ b/packages/transform-metering/package.json
@@ -2,10 +2,8 @@
   "name": "@agoric/transform-metering",
   "version": "1.4.20",
   "description": "transform-metering",
-  "parsers": {
-    "js": "mjs"
-  },
-  "main": "src/index.js",
+  "type": "module",
+  "main": "./src/index.js",
   "scripts": {
     "test": "ava",
     "test:xs": "exit 0",
@@ -16,8 +14,7 @@
   },
   "devDependencies": {
     "@agoric/install-ses": "^0.5.21",
-    "ava": "^3.12.1",
-    "esm": "agoric-labs/esm#Agoric-built"
+    "ava": "^3.12.1"
   },
   "dependencies": {
     "@agoric/nat": "^4.1.0",
@@ -48,9 +45,6 @@
   "ava": {
     "files": [
       "test/**/test-*.js"
-    ],
-    "require": [
-      "esm"
     ],
     "timeout": "2m"
   },

--- a/packages/transform-metering/package.json
+++ b/packages/transform-metering/package.json
@@ -6,6 +6,7 @@
   "main": "./src/index.js",
   "scripts": {
     "test": "ava",
+    "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
     "lint-check": "yarn lint",
     "lint-fix": "eslint --fix '**/*.{js,jsx}'",
@@ -23,6 +24,7 @@
     "@babel/parser": "^7.14.2",
     "@babel/traverse": "^7.14.2",
     "@babel/types": "^7.14.2",
+    "c8": "^7.7.2",
     "re2": "^1.10.5"
   },
   "keywords": [],

--- a/packages/transform-metering/src/pure-babel-core.js
+++ b/packages/transform-metering/src/pure-babel-core.js
@@ -55,8 +55,8 @@ export function makePureBabelCore() {
       }
       const visitor = traverse.visitors.merge(visitors);
       const file = makePureFile({ ast, code });
-      traverse(file.ast, visitor);
-      return generator(ast, generatorOpts, code);
+      (traverse.default || traverse)(file.ast, visitor);
+      return (generator.default || generator)(ast, generatorOpts, code);
     },
   };
 }

--- a/packages/transform-metering/src/transform.js
+++ b/packages/transform-metering/src/transform.js
@@ -1,9 +1,6 @@
-/* global require */
+import RE2 from 're2';
 import * as c from './constants.js';
 import { makePureBabelCore } from './pure-babel-core.js';
-
-// We'd like to import this, but RE2 is cjs
-const RE2 = require('re2');
 
 const METER_GENERATED = Symbol('meter-generated');
 const getMeterId = 'getMeter';
@@ -28,6 +25,7 @@ export function makeMeteringTransformer(
   let regexpNumber = 0;
 
   const meteringPlugin = regexpList => ({ types: t }) => {
+    t = t.default || t;
     // const [[meterId]] = [[getMeterId]]();
     const getMeterDecl = () => {
       const emid = t.Identifier(getMeterId);

--- a/packages/transform-metering/test/test-transform.js
+++ b/packages/transform-metering/test/test-transform.js
@@ -1,10 +1,13 @@
-/* global __dirname */
 /* eslint-disable no-await-in-loop */
 import test from 'ava';
 import fs from 'fs';
+import path from 'path';
 
 import { makeMeteringTransformer } from '../src/index.js';
 import * as c from '../src/constants.js';
+
+const filename = new URL(import.meta.url).pathname;
+const dirname = path.dirname(filename);
 
 test('meter transform', async t => {
   let getMeter;
@@ -34,7 +37,7 @@ test('meter transform', async t => {
     'meterId cannot appear in source',
   );
 
-  const base = `${__dirname}/../testdata`;
+  const base = `${dirname}/../testdata`;
   const tests = await fs.promises.readdir(base);
   for (const testDir of tests) {
     const src = await fs.promises.readFile(


### PR DESCRIPTION
Converts the transform-metering package to use Node.js ESM instead of -r esm emulation.

Refs #527 
