### PR TITLE
refactor(install-metering-and-ses): Convert RESM to NESM

### DIFF
--- a/packages/install-metering-and-ses/install-metering-and-ses.js
+++ b/packages/install-metering-and-ses/install-metering-and-ses.js
@@ -1,3 +1,3 @@
-import '@agoric/eventual-send/shim';
-import './install-global-metering';
+import '@agoric/eventual-send/shim.js';
+import './install-global-metering.js';
 import '@agoric/install-ses';

--- a/packages/install-metering-and-ses/package.json
+++ b/packages/install-metering-and-ses/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "exit 0",
     "test": "ava",
+    "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
     "lint-check": "yarn lint",
     "lint-fix": "eslint --fix '**/*.js'",
@@ -14,7 +15,8 @@
   },
   "devDependencies": {
     "@agoric/transform-metering": "^1.4.20",
-    "ava": "^3.12.1"
+    "ava": "^3.12.1",
+    "c8": "^7.7.2"
   },
   "dependencies": {
     "@agoric/eventual-send": "^0.13.23",

--- a/packages/install-metering-and-ses/package.json
+++ b/packages/install-metering-and-ses/package.json
@@ -2,9 +2,7 @@
   "name": "@agoric/install-metering-and-ses",
   "version": "0.2.21",
   "description": "tame metering and install SES at import time",
-  "parsers": {
-    "js": "mjs"
-  },
+  "type": "module",
   "main": "install-metering-and-ses.js",
   "scripts": {
     "build": "exit 0",
@@ -16,8 +14,7 @@
   },
   "devDependencies": {
     "@agoric/transform-metering": "^1.4.20",
-    "ava": "^3.12.1",
-    "esm": "agoric-labs/esm#Agoric-built"
+    "ava": "^3.12.1"
   },
   "dependencies": {
     "@agoric/eventual-send": "^0.13.23",
@@ -55,9 +52,6 @@
   "ava": {
     "files": [
       "test/**/test-*.js"
-    ],
-    "require": [
-      "esm"
     ],
     "timeout": "2m"
   }

--- a/packages/install-metering-and-ses/test/test-install-metering-and-ses.js
+++ b/packages/install-metering-and-ses/test/test-install-metering-and-ses.js
@@ -1,4 +1,4 @@
-import '../install-metering-and-ses';
+import '../install-metering-and-ses.js';
 import test from 'ava';
 import { makeMeter } from '@agoric/transform-metering';
 


### PR DESCRIPTION
Converts the transform-metering package to use Node.js ESM instead of -r esm emulation.

Refs #527