### PR TITLE
chore: create the RUN Mint within Zoe but Treasury can make an RUN ZCFMint

### DIFF
--- a/packages/dapp-svelte-wallet/api/test/test-getPursesNotifier.js
+++ b/packages/dapp-svelte-wallet/api/test/test-getPursesNotifier.js
@@ -2,7 +2,7 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { makeIssuerKit } from '@agoric/ertp';
-import { makeZoe } from '@agoric/zoe';
+import { makeZoeKit } from '@agoric/zoe';
 import fakeVatAdmin from '@agoric/zoe/tools/fakeVatAdmin.js';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { makeBoard } from '@agoric/vats/src/lib-board.js';
@@ -24,7 +24,7 @@ function makeFakeMyAddressNameAdmin() {
 }
 
 const setup = async () => {
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
   const board = makeBoard();
 
   const pursesStateChangeHandler = _data => {};

--- a/packages/dapp-svelte-wallet/api/test/test-getPursesNotifier.js
+++ b/packages/dapp-svelte-wallet/api/test/test-getPursesNotifier.js
@@ -24,7 +24,7 @@ function makeFakeMyAddressNameAdmin() {
 }
 
 const setup = async () => {
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
   const board = makeBoard();
 
   const pursesStateChangeHandler = _data => {};

--- a/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
@@ -45,7 +45,7 @@ async function setupTest() {
   const moolaBundle = makeIssuerKit('moola');
   const simoleanBundle = makeIssuerKit('simolean');
   const rpgBundle = makeIssuerKit('rpg', AssetKind.SET);
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
   const board = makeBoard();
 
   // Create AutomaticRefund instance
@@ -1193,7 +1193,7 @@ test('addOffer offer.invitation', async t => {
 });
 
 test('addOffer makeContinuingInvitation', async t => {
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
   const board = makeBoard();
 
   // Create ContinuingInvitationExample instance
@@ -1275,7 +1275,7 @@ test('addOffer makeContinuingInvitation', async t => {
 });
 
 test('getZoe, getBoard', async t => {
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
   const board = makeBoard();
 
   const pursesStateChangeHandler = _data => {};

--- a/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
@@ -5,7 +5,7 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import bundleSource from '@agoric/bundle-source';
 import { makeIssuerKit, AmountMath, AssetKind } from '@agoric/ertp';
 
-import { makeZoe } from '@agoric/zoe';
+import { makeZoeKit } from '@agoric/zoe';
 import fakeVatAdmin from '@agoric/zoe/tools/fakeVatAdmin.js';
 
 import { assert } from '@agoric/assert';
@@ -45,7 +45,7 @@ async function setupTest() {
   const moolaBundle = makeIssuerKit('moola');
   const simoleanBundle = makeIssuerKit('simolean');
   const rpgBundle = makeIssuerKit('rpg', AssetKind.SET);
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
   const board = makeBoard();
 
   // Create AutomaticRefund instance
@@ -1193,7 +1193,7 @@ test('addOffer offer.invitation', async t => {
 });
 
 test('addOffer makeContinuingInvitation', async t => {
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
   const board = makeBoard();
 
   // Create ContinuingInvitationExample instance
@@ -1275,7 +1275,7 @@ test('addOffer makeContinuingInvitation', async t => {
 });
 
 test('getZoe, getBoard', async t => {
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
   const board = makeBoard();
 
   const pursesStateChangeHandler = _data => {};

--- a/packages/deploy-script-support/test/unitTests/test-install.js
+++ b/packages/deploy-script-support/test/unitTests/test-install.js
@@ -12,7 +12,7 @@ import '../../exported.js';
 import { makeInstall } from '../../src/install.js';
 
 test('install', async t => {
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
 
   let addedInstallation;
 

--- a/packages/deploy-script-support/test/unitTests/test-install.js
+++ b/packages/deploy-script-support/test/unitTests/test-install.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import { makeZoe } from '@agoric/zoe';
+import { makeZoeKit } from '@agoric/zoe';
 import fakeVatAdmin from '@agoric/zoe/tools/fakeVatAdmin.js';
 import { makeBoard } from '@agoric/vats/src/lib-board.js';
 import bundleSource from '@agoric/bundle-source';
@@ -12,7 +12,7 @@ import '../../exported.js';
 import { makeInstall } from '../../src/install.js';
 
 test('install', async t => {
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   let addedInstallation;
 

--- a/packages/deploy-script-support/test/unitTests/test-offer.js
+++ b/packages/deploy-script-support/test/unitTests/test-offer.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import { makeZoe } from '@agoric/zoe';
+import { makeZoeKit } from '@agoric/zoe';
 import fakeVatAdmin from '@agoric/zoe/tools/fakeVatAdmin.js';
 import bundleSource from '@agoric/bundle-source';
 import { makeIssuerKit, AmountMath } from '@agoric/ertp';
@@ -37,7 +37,7 @@ test('offer', async t => {
     },
     saveOfferResult: () => {},
   };
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   const bundleUrl = await importMetaResolve(
     '@agoric/zoe/src/contracts/automaticRefund.js',

--- a/packages/deploy-script-support/test/unitTests/test-offer.js
+++ b/packages/deploy-script-support/test/unitTests/test-offer.js
@@ -37,7 +37,7 @@ test('offer', async t => {
     },
     saveOfferResult: () => {},
   };
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
 
   const bundleUrl = await importMetaResolve(
     '@agoric/zoe/src/contracts/automaticRefund.js',

--- a/packages/deploy-script-support/test/unitTests/test-startInstance.js
+++ b/packages/deploy-script-support/test/unitTests/test-startInstance.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
-import { makeZoe } from '@agoric/zoe';
+import { makeZoeKit } from '@agoric/zoe';
 import fakeVatAdmin from '@agoric/zoe/tools/fakeVatAdmin.js';
 import bundleSource from '@agoric/bundle-source';
 import { makeIssuerKit } from '@agoric/ertp';
@@ -19,7 +19,7 @@ test('startInstance', async t => {
   const moolaKit = makeIssuerKit('moola');
   const usdKit = makeIssuerKit('usd');
 
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   const bundleUrl = new URL(
     await importMetaResolve(

--- a/packages/deploy-script-support/test/unitTests/test-startInstance.js
+++ b/packages/deploy-script-support/test/unitTests/test-startInstance.js
@@ -19,7 +19,7 @@ test('startInstance', async t => {
   const moolaKit = makeIssuerKit('moola');
   const usdKit = makeIssuerKit('usd');
 
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
 
   const bundleUrl = new URL(
     await importMetaResolve(

--- a/packages/governance/test/swingsetTests/committeeBinary/vat-zoe.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/vat-zoe.js
@@ -2,12 +2,12 @@
 
 import { Far } from '@agoric/marshal';
 
-import { makeZoe } from '@agoric/zoe';
+import { makeZoeKit } from '@agoric/zoe';
 
 export function buildRootObject(_vatPowers) {
   return Far('root', {
     buildZoe: vatAdminSvc => {
-      const { zoeService: zoe } = makeZoe(vatAdminSvc);
+      const { zoeService: zoe } = makeZoeKit(vatAdminSvc);
       return zoe;
     },
   });

--- a/packages/governance/test/swingsetTests/committeeBinary/vat-zoe.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/vat-zoe.js
@@ -6,6 +6,9 @@ import { makeZoe } from '@agoric/zoe';
 
 export function buildRootObject(_vatPowers) {
   return Far('root', {
-    buildZoe: vatAdminSvc => makeZoe(vatAdminSvc),
+    buildZoe: vatAdminSvc => {
+      const { zoeService: zoe } = makeZoe(vatAdminSvc);
+      return zoe;
+    },
   });
 }

--- a/packages/governance/test/swingsetTests/committeeBinary/vat-zoe.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/vat-zoe.js
@@ -4,10 +4,11 @@ import { Far } from '@agoric/marshal';
 
 import { makeZoeKit } from '@agoric/zoe';
 
-export function buildRootObject(_vatPowers) {
+export function buildRootObject(vatPowers) {
   return Far('root', {
     buildZoe: vatAdminSvc => {
-      const { zoeService: zoe } = makeZoeKit(vatAdminSvc);
+      const shutdownZoeVat = vatPowers.exitVatWithFailure;
+      const { zoeService: zoe } = makeZoeKit(vatAdminSvc, shutdownZoeVat);
       return zoe;
     },
   });

--- a/packages/governance/test/unitTests/test-committee.js
+++ b/packages/governance/test/unitTests/test-committee.js
@@ -6,7 +6,7 @@ import '@agoric/zoe/exported.js';
 
 import path from 'path';
 import { E } from '@agoric/eventual-send';
-import { makeZoe } from '@agoric/zoe';
+import { makeZoeKit } from '@agoric/zoe';
 import fakeVatAdmin from '@agoric/zoe/tools/fakeVatAdmin.js';
 import bundleSource from '@agoric/bundle-source';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
@@ -20,7 +20,7 @@ const registrarRoot = `${dirname}/../../src/committeeRegistrar.js`;
 const counterRoot = `${dirname}/../../src/binaryBallotCounter.js`;
 
 async function setupContract() {
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   // pack the contract
   const [registrarBundle, counterBundle] = await Promise.all([

--- a/packages/governance/test/unitTests/test-committee.js
+++ b/packages/governance/test/unitTests/test-committee.js
@@ -20,7 +20,7 @@ const registrarRoot = `${dirname}/../../src/committeeRegistrar.js`;
 const counterRoot = `${dirname}/../../src/binaryBallotCounter.js`;
 
 async function setupContract() {
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
 
   // pack the contract
   const [registrarBundle, counterBundle] = await Promise.all([

--- a/packages/pegasus/bundles/install-on-chain.js
+++ b/packages/pegasus/bundles/install-on-chain.js
@@ -11,7 +11,13 @@ import pegasusBundle from './bundle-pegasus.js';
  * @param {NameHub} param0.namesByAddress
  * @param {ERef<ZoeService>} param0.zoe
  */
-export async function installOnChain({ agoricNames, board, nameAdmins, namesByAddress, zoe }) {
+export async function installOnChain({
+  agoricNames,
+  board,
+  nameAdmins,
+  namesByAddress,
+  zoe,
+}) {
   // Fetch the nameAdmins we need.
   const [installAdmin, instanceAdmin, uiConfigAdmin] = await Promise.all(
     ['installation', 'instance', 'uiConfig'].map(async edge => {
@@ -38,8 +44,12 @@ export async function installOnChain({ agoricNames, board, nameAdmins, namesByAd
     namesByAddress,
   });
 
-  const { instance, creatorFacet } = await E(zoe).startInstance(pegasusInstall, undefined, terms);
- 
+  const { instance, creatorFacet } = await E(zoe).startInstance(
+    pegasusInstall,
+    undefined,
+    terms,
+  );
+
   const pegasusUiDefaults = {
     CONTRACT_NAME: 'Pegasus',
     BRIDGE_URL: 'http://127.0.0.1:8000',
@@ -49,14 +59,14 @@ export async function installOnChain({ agoricNames, board, nameAdmins, namesByAd
   };
 
   // Look up all the board IDs.
-  const boardIdValue = [
-    ['INSTANCE_BOARD_ID', instance],
-  ];
-  await Promise.all(boardIdValue.map(async ([key, valP]) => {
-    const val = await valP;
-    const boardId = await E(board).getId(val);
-    pegasusUiDefaults[key] = boardId;
-  }));
+  const boardIdValue = [['INSTANCE_BOARD_ID', instance]];
+  await Promise.all(
+    boardIdValue.map(async ([key, valP]) => {
+      const val = await valP;
+      const boardId = await E(board).getId(val);
+      pegasusUiDefaults[key] = boardId;
+    }),
+  );
 
   // Stash the defaults where the UI can find them.
   harden(pegasusUiDefaults);
@@ -69,7 +79,9 @@ export async function installOnChain({ agoricNames, board, nameAdmins, namesByAd
     [instanceAdmin, pegasusUiDefaults.CONTRACT_NAME, instance],
   ];
   await Promise.all(
-    nameAdminUpdates.map(([nameAdmin, name, value]) => E(nameAdmin).update(name, value)),
+    nameAdminUpdates.map(([nameAdmin, name, value]) =>
+      E(nameAdmin).update(name, value),
+    ),
   );
 
   return creatorFacet;

--- a/packages/pegasus/test/test-peg.js
+++ b/packages/pegasus/test/test-peg.js
@@ -9,7 +9,7 @@ import {
 
 import bundleSource from '@agoric/bundle-source';
 import { AmountMath } from '@agoric/ertp';
-import { makeZoe } from '@agoric/zoe';
+import { makeZoeKit } from '@agoric/zoe';
 
 import fakeVatAdmin from '@agoric/zoe/tools/fakeVatAdmin.js';
 import { Far } from '@agoric/marshal';
@@ -47,7 +47,7 @@ async function testRemotePeg(t) {
     },
   });
 
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   // Pack the contract.
   const contractBundle = await bundleSource(contractPath);

--- a/packages/pegasus/test/test-peg.js
+++ b/packages/pegasus/test/test-peg.js
@@ -47,7 +47,7 @@ async function testRemotePeg(t) {
     },
   });
 
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
 
   // Pack the contract.
   const contractBundle = await bundleSource(contractPath);

--- a/packages/swingset-runner/demo/exchangeBenchmark/vat-zoe.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/vat-zoe.js
@@ -1,10 +1,10 @@
-import { makeZoe } from '@agoric/zoe';
+import { makeZoeKit } from '@agoric/zoe';
 import { Far } from '@agoric/marshal';
 
 export function buildRootObject(_vatPowers, vatParameters) {
   return Far('root', {
     buildZoe: vatAdminSvc => {
-      const { zoeService: zoe } = makeZoe(
+      const { zoeService: zoe } = makeZoeKit(
         vatAdminSvc,
         vatParameters.zcfBundleName,
       );

--- a/packages/swingset-runner/demo/exchangeBenchmark/vat-zoe.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/vat-zoe.js
@@ -3,6 +3,12 @@ import { Far } from '@agoric/marshal';
 
 export function buildRootObject(_vatPowers, vatParameters) {
   return Far('root', {
-    buildZoe: vatAdminSvc => makeZoe(vatAdminSvc, vatParameters.zcfBundleName),
+    buildZoe: vatAdminSvc => {
+      const { zoeService: zoe } = makeZoe(
+        vatAdminSvc,
+        vatParameters.zcfBundleName,
+      );
+      return zoe;
+    },
   });
 }

--- a/packages/swingset-runner/demo/exchangeBenchmark/vat-zoe.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/vat-zoe.js
@@ -1,11 +1,16 @@
-import { makeZoeKit } from '@agoric/zoe';
+// @ts-check
+
 import { Far } from '@agoric/marshal';
 
-export function buildRootObject(_vatPowers, vatParameters) {
+import { makeZoeKit } from '@agoric/zoe';
+
+export function buildRootObject(vatPowers, vatParameters) {
   return Far('root', {
     buildZoe: vatAdminSvc => {
+      const shutdownZoeVat = vatPowers.exitVatWithFailure;
       const { zoeService: zoe } = makeZoeKit(
         vatAdminSvc,
+        shutdownZoeVat,
         vatParameters.zcfBundleName,
       );
       return zoe;

--- a/packages/swingset-runner/demo/swapBenchmark/vat-zoe.js
+++ b/packages/swingset-runner/demo/swapBenchmark/vat-zoe.js
@@ -1,10 +1,10 @@
-import { makeZoe } from '@agoric/zoe';
+import { makeZoeKit } from '@agoric/zoe';
 import { Far } from '@agoric/marshal';
 
 export function buildRootObject(_vatPowers, vatParameters) {
   return Far('root', {
     buildZoe: vatAdminSvc => {
-      const { zoeService: zoe } = makeZoe(
+      const { zoeService: zoe } = makeZoeKit(
         vatAdminSvc,
         vatParameters.zcfBundleName,
       );

--- a/packages/swingset-runner/demo/swapBenchmark/vat-zoe.js
+++ b/packages/swingset-runner/demo/swapBenchmark/vat-zoe.js
@@ -3,6 +3,12 @@ import { Far } from '@agoric/marshal';
 
 export function buildRootObject(_vatPowers, vatParameters) {
   return Far('root', {
-    buildZoe: vatAdminSvc => makeZoe(vatAdminSvc, vatParameters.zcfBundleName),
+    buildZoe: vatAdminSvc => {
+      const { zoeService: zoe } = makeZoe(
+        vatAdminSvc,
+        vatParameters.zcfBundleName,
+      );
+      return zoe;
+    },
   });
 }

--- a/packages/swingset-runner/demo/swapBenchmark/vat-zoe.js
+++ b/packages/swingset-runner/demo/swapBenchmark/vat-zoe.js
@@ -1,11 +1,16 @@
-import { makeZoeKit } from '@agoric/zoe';
+// @ts-check
+
 import { Far } from '@agoric/marshal';
 
-export function buildRootObject(_vatPowers, vatParameters) {
+import { makeZoeKit } from '@agoric/zoe';
+
+export function buildRootObject(vatPowers, vatParameters) {
   return Far('root', {
     buildZoe: vatAdminSvc => {
+      const shutdownZoeVat = vatPowers.exitVatWithFailure;
       const { zoeService: zoe } = makeZoeKit(
         vatAdminSvc,
+        shutdownZoeVat,
         vatParameters.zcfBundleName,
       );
       return zoe;

--- a/packages/swingset-runner/demo/zoeTests/vat-zoe.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-zoe.js
@@ -4,6 +4,12 @@ import { Far } from '@agoric/marshal';
 
 export function buildRootObject(_vatPowers, vatParameters) {
   return Far('root', {
-    buildZoe: vatAdminSvc => makeZoe(vatAdminSvc, vatParameters.zcfBundleName),
+    buildZoe: vatAdminSvc => {
+      const { zoeService: zoe } = makeZoe(
+        vatAdminSvc,
+        vatParameters.zcfBundleName,
+      );
+      return zoe;
+    },
   });
 }

--- a/packages/swingset-runner/demo/zoeTests/vat-zoe.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-zoe.js
@@ -1,11 +1,11 @@
 // noinspection ES6PreferShortImport
-import { makeZoe } from '@agoric/zoe';
+import { makeZoeKit } from '@agoric/zoe';
 import { Far } from '@agoric/marshal';
 
 export function buildRootObject(_vatPowers, vatParameters) {
   return Far('root', {
     buildZoe: vatAdminSvc => {
-      const { zoeService: zoe } = makeZoe(
+      const { zoeService: zoe } = makeZoeKit(
         vatAdminSvc,
         vatParameters.zcfBundleName,
       );

--- a/packages/swingset-runner/demo/zoeTests/vat-zoe.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-zoe.js
@@ -1,12 +1,16 @@
-// noinspection ES6PreferShortImport
-import { makeZoeKit } from '@agoric/zoe';
+// @ts-check
+
 import { Far } from '@agoric/marshal';
 
-export function buildRootObject(_vatPowers, vatParameters) {
+import { makeZoeKit } from '@agoric/zoe';
+
+export function buildRootObject(vatPowers, vatParameters) {
   return Far('root', {
     buildZoe: vatAdminSvc => {
+      const shutdownZoeVat = vatPowers.exitVatWithFailure;
       const { zoeService: zoe } = makeZoeKit(
         vatAdminSvc,
+        shutdownZoeVat,
         vatParameters.zcfBundleName,
       );
       return zoe;

--- a/packages/treasury/bundles/install-on-chain.js
+++ b/packages/treasury/bundles/install-on-chain.js
@@ -20,11 +20,12 @@ const DEFAULT_PROTOCOL_FEE = 6n;
  * @param {Store<NameHub, NameAdmin>} param0.nameAdmins
  * @param {ERef<PriceAuthority>} param0.priceAuthority
  * @param {ERef<ZoeService>} param0.zoe
+ * @param {Handle<'feeMintAccess'>} param0.feeMintAccess
  * @param {NatValue} param0.bootstrapPaymentValue
  * @param {NatValue} [param0.poolFee]
  * @param {NatValue} [param0.protocolFee]
  */
-export async function installOnChain({ agoricNames, board, centralName, chainTimerService, nameAdmins, priceAuthority, zoe, bootstrapPaymentValue, poolFee = DEFAULT_POOL_FEE, protocolFee = DEFAULT_PROTOCOL_FEE }) {
+export async function installOnChain({ agoricNames, board, centralName, chainTimerService, nameAdmins, priceAuthority, zoe, feeMintAccess, bootstrapPaymentValue, poolFee = DEFAULT_POOL_FEE, protocolFee = DEFAULT_PROTOCOL_FEE }) {
   // Fetch the nameAdmins we need.
   const [brandAdmin, installAdmin, instanceAdmin, issuerAdmin, uiConfigAdmin] = await Promise.all(
     ['brand', 'installation', 'instance', 'issuer', 'uiConfig'].map(async edge => {
@@ -62,7 +63,9 @@ export async function installOnChain({ agoricNames, board, centralName, chainTim
     bootstrapPaymentValue,
   });
 
-  const { instance, creatorFacet } = await E(zoe).startInstance(stablecoinMachineInstall, undefined, terms);
+  const privateArgs = harden({ feeMintAccess });
+
+  const { instance, creatorFacet } = await E(zoe).startInstance(stablecoinMachineInstall, undefined, terms, privateArgs);
  
   const [
     ammInstance,

--- a/packages/treasury/src/stablecoinMachine.js
+++ b/packages/treasury/src/stablecoinMachine.js
@@ -41,7 +41,7 @@ import { makeMakeCollectFeesInvitation } from './collectRewardFees.js';
 const trace = makeTracer('ST');
 
 /** @type {ContractStartFn} */
-export async function start(zcf) {
+export async function start(zcf, privateArgs) {
   // loanParams has time limits for charging interest
   const {
     autoswapInstall,
@@ -51,6 +51,8 @@ export async function start(zcf) {
     liquidationInstall,
     bootstrapPaymentValue = 0n,
   } = zcf.getTerms();
+
+  const { feeMintAccess } = privateArgs;
 
   assert.typeof(
     loanParams.chargingPeriod,
@@ -66,7 +68,7 @@ export async function start(zcf) {
   );
 
   const [runMint, govMint] = await Promise.all([
-    zcf.makeZCFMint('RUN', undefined, harden({ decimalPlaces: 6 })),
+    zcf.registerFeeMint('RUN', feeMintAccess),
     zcf.makeZCFMint('Governance', undefined, harden({ decimalPlaces: 6 })),
   ]);
   const { issuer: runIssuer, brand: runBrand } = runMint.getIssuerRecord();

--- a/packages/treasury/test/swingsetTests/bootstrap.js
+++ b/packages/treasury/test/swingsetTests/bootstrap.js
@@ -20,7 +20,14 @@ const setupBasicMints = () => {
   });
 };
 
-const makeVats = (log, vats, zoe, installations, startingValues) => {
+const makeVats = (
+  log,
+  vats,
+  zoe,
+  installations,
+  startingValues,
+  feeMintAccess,
+) => {
   const timer = buildManualTimer(console.log, 0n, ONE_DAY);
   const { mints, issuers, brands } = setupBasicMints();
   const makePayments = values =>
@@ -46,6 +53,7 @@ const makeVats = (log, vats, zoe, installations, startingValues) => {
     installations,
     timer,
     vats.priceAuthority,
+    feeMintAccess,
   );
 
   const result = { aliceP, treasuryPublicFacet };
@@ -59,7 +67,9 @@ function makeBootstrap(argv, cb, vatPowers) {
     const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
       devices.vatAdmin,
     );
-    const zoe = E(vats.zoe).buildZoe(vatAdminSvc);
+    const { zoeService: zoe, feeMintAccess } = await E(vats.zoe).buildZoe(
+      vatAdminSvc,
+    );
     const [liquidateMinimum, autoswap, treasury] = await Promise.all([
       E(zoe).install(cb.liquidateMinimum),
       E(zoe).install(cb.autoswap),
@@ -75,6 +85,7 @@ function makeBootstrap(argv, cb, vatPowers) {
       zoe,
       installations,
       startingValues,
+      feeMintAccess,
     );
 
     await E(aliceP).startTest(testName, treasuryPublicFacet);

--- a/packages/treasury/test/swingsetTests/vat-owner.js
+++ b/packages/treasury/test/swingsetTests/vat-owner.js
@@ -20,6 +20,7 @@ const build = async (
   installations,
   timer,
   priceAuthorityVat,
+  feeMintAccess,
 ) => {
   const [moolaBrand] = brands;
   const [moolaPayment] = payments;
@@ -45,6 +46,7 @@ const build = async (
     installations.treasury,
     undefined,
     terms,
+    harden({ feeMintAccess }),
   );
 
   const {

--- a/packages/treasury/test/swingsetTests/vat-zoe.js
+++ b/packages/treasury/test/swingsetTests/vat-zoe.js
@@ -2,10 +2,10 @@
 
 import { Far } from '@agoric/marshal';
 
-import { makeZoe } from '@agoric/zoe';
+import { makeZoeKit } from '@agoric/zoe';
 
 export function buildRootObject(_vatPowers) {
   return Far('root', {
-    buildZoe: vatAdminSvc => makeZoe(vatAdminSvc),
+    buildZoe: vatAdminSvc => makeZoeKit(vatAdminSvc),
   });
 }

--- a/packages/treasury/test/swingsetTests/vat-zoe.js
+++ b/packages/treasury/test/swingsetTests/vat-zoe.js
@@ -4,8 +4,11 @@ import { Far } from '@agoric/marshal';
 
 import { makeZoeKit } from '@agoric/zoe';
 
-export function buildRootObject(_vatPowers) {
+export function buildRootObject(vatPowers) {
   return Far('root', {
-    buildZoe: vatAdminSvc => makeZoeKit(vatAdminSvc),
+    buildZoe: vatAdminSvc => {
+      const shutdownZoeVat = vatPowers.exitVatWithFailure;
+      return makeZoeKit(vatAdminSvc, shutdownZoeVat);
+    },
   });
 }

--- a/packages/treasury/test/test-bootstrapPayment.js
+++ b/packages/treasury/test/test-bootstrapPayment.js
@@ -33,7 +33,7 @@ const makeInstall = async (root, zoe) => {
 };
 
 test('bootstrap payment', async t => {
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe, feeMintAccess } = makeZoe(fakeVatAdmin);
   const autoswapRoot = await autoswapRootP;
   const autoswapInstall = await makeInstall(autoswapRoot, zoe);
   const stablecoinInstall = await makeInstall(stablecoinRoot, zoe);
@@ -61,6 +61,7 @@ test('bootstrap payment', async t => {
 
       bootstrapPaymentValue,
     },
+    harden({ feeMintAccess }),
   );
 
   const issuers = await E(zoe).getIssuers(instance);
@@ -80,7 +81,7 @@ test('bootstrap payment', async t => {
 });
 
 test('bootstrap payment - only minted once', async t => {
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe, feeMintAccess } = makeZoe(fakeVatAdmin);
   const autoswapRoot = await autoswapRootP;
   const autoswapInstall = await makeInstall(autoswapRoot, zoe);
   const stablecoinInstall = await makeInstall(stablecoinRoot, zoe);
@@ -108,6 +109,7 @@ test('bootstrap payment - only minted once', async t => {
 
       bootstrapPaymentValue,
     },
+    harden({ feeMintAccess }),
   );
 
   const issuers = await E(zoe).getIssuers(instance);
@@ -136,7 +138,7 @@ test('bootstrap payment - only minted once', async t => {
 });
 
 test('bootstrap payment - default value is 0n', async t => {
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe, feeMintAccess } = makeZoe(fakeVatAdmin);
   const autoswapRoot = await autoswapRootP;
   const autoswapInstall = await makeInstall(autoswapRoot, zoe);
   const stablecoinInstall = await makeInstall(stablecoinRoot, zoe);
@@ -159,6 +161,7 @@ test('bootstrap payment - default value is 0n', async t => {
       timerService: manualTimer,
       liquidationInstall,
     },
+    harden({ feeMintAccess }),
   );
 
   const issuers = await E(zoe).getIssuers(instance);

--- a/packages/treasury/test/test-bootstrapPayment.js
+++ b/packages/treasury/test/test-bootstrapPayment.js
@@ -9,7 +9,7 @@ import path from 'path';
 import { E } from '@agoric/eventual-send';
 import bundleSource from '@agoric/bundle-source';
 import fakeVatAdmin from '@agoric/zoe/tools/fakeVatAdmin.js';
-import { makeZoe } from '@agoric/zoe';
+import { makeZoeKit } from '@agoric/zoe';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import { AmountMath } from '@agoric/ertp';
 import { resolve as importMetaResolve } from 'import-meta-resolve';
@@ -33,7 +33,7 @@ const makeInstall = async (root, zoe) => {
 };
 
 test('bootstrap payment', async t => {
-  const { zoeService: zoe, feeMintAccess } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe, feeMintAccess } = makeZoeKit(fakeVatAdmin);
   const autoswapRoot = await autoswapRootP;
   const autoswapInstall = await makeInstall(autoswapRoot, zoe);
   const stablecoinInstall = await makeInstall(stablecoinRoot, zoe);
@@ -81,7 +81,7 @@ test('bootstrap payment', async t => {
 });
 
 test('bootstrap payment - only minted once', async t => {
-  const { zoeService: zoe, feeMintAccess } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe, feeMintAccess } = makeZoeKit(fakeVatAdmin);
   const autoswapRoot = await autoswapRootP;
   const autoswapInstall = await makeInstall(autoswapRoot, zoe);
   const stablecoinInstall = await makeInstall(stablecoinRoot, zoe);
@@ -138,7 +138,7 @@ test('bootstrap payment - only minted once', async t => {
 });
 
 test('bootstrap payment - default value is 0n', async t => {
-  const { zoeService: zoe, feeMintAccess } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe, feeMintAccess } = makeZoeKit(fakeVatAdmin);
   const autoswapRoot = await autoswapRootP;
   const autoswapInstall = await makeInstall(autoswapRoot, zoe);
   const stablecoinInstall = await makeInstall(stablecoinRoot, zoe);

--- a/packages/treasury/test/test-stablecoin.js
+++ b/packages/treasury/test/test-stablecoin.js
@@ -12,7 +12,7 @@ import { resolve as importMetaResolve } from 'import-meta-resolve';
 import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import { makeLoopback } from '@agoric/captp';
 
-import { makeZoe } from '@agoric/zoe';
+import { makeZoeKit } from '@agoric/zoe';
 import { makeIssuerKit, AssetKind, AmountMath } from '@agoric/ertp';
 
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
@@ -55,7 +55,7 @@ const setUpZoeForTest = async setJig => {
    * @property {ERef<MultipoolAutoswapPublicFacet>} autoswap
    */
 
-  const { zoeService, feeMintAccess: nonFarFeeMintAccess } = makeZoe(
+  const { zoeService, feeMintAccess: nonFarFeeMintAccess } = makeZoeKit(
     makeFakeVatAdmin(setJig, makeRemote).admin,
   );
   /** @type {ERef<ZoeService>} */

--- a/packages/treasury/test/test-stablecoin.js
+++ b/packages/treasury/test/test-stablecoin.js
@@ -35,7 +35,7 @@ const trace = makeTracer('TestST');
 const BASIS_POINTS = 10000n;
 const PERCENT = 100n;
 
-function setUpZoeForTest(setJig) {
+const setUpZoeForTest = async setJig => {
   const { makeFar, makeNear } = makeLoopback('zoeTest');
   let isFirst = true;
   function makeRemote(arg) {
@@ -46,7 +46,7 @@ function setUpZoeForTest(setJig) {
   }
 
   /**
-   * These properties will be asssigned by `setJig` in the contract.
+   * These properties will be assigned by `setJig` in the contract.
    *
    * @typedef {Object} TestContext
    * @property {ContractFacet} zcf
@@ -55,11 +55,18 @@ function setUpZoeForTest(setJig) {
    * @property {ERef<MultipoolAutoswapPublicFacet>} autoswap
    */
 
+  const { zoeService, feeMintAccess: nonFarFeeMintAccess } = makeZoe(
+    makeFakeVatAdmin(setJig, makeRemote).admin,
+  );
   /** @type {ERef<ZoeService>} */
-  const zoe = makeFar(makeZoe(makeFakeVatAdmin(setJig, makeRemote).admin));
+  const zoe = makeFar(zoeService);
   trace('makeZoe');
-  return zoe;
-}
+  const feeMintAccess = await makeFar(nonFarFeeMintAccess);
+  return {
+    zoe,
+    feeMintAccess,
+  };
+};
 
 async function makeInstall(sourceRoot, zoe) {
   const url = await importMetaResolve(sourceRoot, import.meta.url);
@@ -133,7 +140,7 @@ test('first', async t => {
   const setJig = jig => {
     testJig = jig;
   };
-  const zoe = setUpZoeForTest(setJig);
+  const { zoe, feeMintAccess } = await setUpZoeForTest(setJig);
 
   const autoswapInstall = await makeInstall(autoswapRoot, zoe);
   const stablecoinInstall = await makeInstall(stablecoinRoot, zoe);
@@ -164,6 +171,7 @@ test('first', async t => {
       timerService: manualTimer,
       liquidationInstall,
     },
+    harden({ feeMintAccess }),
   );
 
   const { runIssuerRecord, govIssuerRecord, autoswap: _autoswapAPI } = testJig;
@@ -294,7 +302,7 @@ test('price drop', async t => {
   const setJig = jig => {
     testJig = jig;
   };
-  const zoe = setUpZoeForTest(setJig);
+  const { zoe, feeMintAccess } = await setUpZoeForTest(setJig);
 
   const autoswapInstall = await makeInstall(autoswapRoot, zoe);
   const stablecoinInstall = await makeInstall(stablecoinRoot, zoe);
@@ -329,6 +337,7 @@ test('price drop', async t => {
       timerService: manualTimer,
       liquidationInstall,
     },
+    harden({ feeMintAccess }),
   );
 
   const { runIssuerRecord, govIssuerRecord } = testJig;
@@ -447,7 +456,7 @@ test('price falls precipitously', async t => {
   const setJig = jig => {
     testJig = jig;
   };
-  const zoe = setUpZoeForTest(setJig);
+  const { zoe, feeMintAccess } = await setUpZoeForTest(setJig);
 
   const autoswapInstall = await makeInstall(autoswapRoot, zoe);
   const stablecoinInstall = await makeInstall(stablecoinRoot, zoe);
@@ -487,6 +496,7 @@ test('price falls precipitously', async t => {
       timerService: manualTimer,
       liquidationInstall,
     },
+    harden({ feeMintAccess }),
   );
 
   const { runIssuerRecord, govIssuerRecord, autoswap: autoswapAPI } = testJig;
@@ -603,7 +613,7 @@ test('stablecoin display collateral', async t => {
   const setJig = jig => {
     testJig = jig;
   };
-  const zoe = setUpZoeForTest(setJig);
+  const { zoe, feeMintAccess } = await setUpZoeForTest(setJig);
 
   const autoswapInstall = await makeInstall(autoswapRoot, zoe);
   const stablecoinInstall = await makeInstall(stablecoinRoot, zoe);
@@ -632,6 +642,7 @@ test('stablecoin display collateral', async t => {
       timerService: manualTimer,
       liquidationInstall,
     },
+    harden({ feeMintAccess }),
   );
 
   const { runIssuerRecord, govIssuerRecord, autoswap: _autoswapAPI } = testJig;
@@ -691,7 +702,7 @@ test('interest on multiple vaults', async t => {
   const setJig = jig => {
     testJig = jig;
   };
-  const zoe = setUpZoeForTest(setJig);
+  const { zoe, feeMintAccess } = await setUpZoeForTest(setJig);
 
   const autoswapInstall = await makeInstall(autoswapRoot, zoe);
   const stablecoinInstall = await makeInstall(stablecoinRoot, zoe);
@@ -724,6 +735,7 @@ test('interest on multiple vaults', async t => {
       timerService: manualTimer,
       liquidationInstall,
     },
+    harden({ feeMintAccess }),
   );
 
   const { runIssuerRecord, govIssuerRecord, autoswap: _autoswapAPI } = testJig;
@@ -898,7 +910,7 @@ test('adjust balances', async t => {
   const setJig = jig => {
     testJig = jig;
   };
-  const zoe = setUpZoeForTest(setJig);
+  const { zoe, feeMintAccess } = await setUpZoeForTest(setJig);
 
   const autoswapInstall = await makeInstall(autoswapRoot, zoe);
   const stablecoinInstall = await makeInstall(stablecoinRoot, zoe);
@@ -929,6 +941,7 @@ test('adjust balances', async t => {
       timerService: manualTimer,
       liquidationInstall,
     },
+    harden({ feeMintAccess }),
   );
 
   const { runIssuerRecord, govIssuerRecord } = testJig;
@@ -1200,7 +1213,7 @@ test('overdeposit', async t => {
   const setJig = jig => {
     testJig = jig;
   };
-  const zoe = setUpZoeForTest(setJig);
+  const { zoe, feeMintAccess } = await setUpZoeForTest(setJig);
 
   const autoswapInstall = await makeInstall(autoswapRoot, zoe);
   const stablecoinInstall = await makeInstall(stablecoinRoot, zoe);
@@ -1231,6 +1244,7 @@ test('overdeposit', async t => {
       timerService: manualTimer,
       liquidationInstall,
     },
+    harden({ feeMintAccess }),
   );
 
   const { runIssuerRecord, govIssuerRecord } = testJig;
@@ -1393,7 +1407,7 @@ test('mutable liquidity triggers and interest', async t => {
   const setJig = jig => {
     testJig = jig;
   };
-  const zoe = setUpZoeForTest(setJig);
+  const { zoe, feeMintAccess } = await setUpZoeForTest(setJig);
 
   const autoswapInstall = await makeInstall(autoswapRoot, zoe);
   const stablecoinInstall = await makeInstall(stablecoinRoot, zoe);
@@ -1427,6 +1441,7 @@ test('mutable liquidity triggers and interest', async t => {
       timerService: manualTimer,
       liquidationInstall,
     },
+    harden({ feeMintAccess }),
   );
 
   const { runIssuerRecord, govIssuerRecord } = testJig;
@@ -1620,7 +1635,7 @@ test('mutable liquidity triggers and interest', async t => {
 test('bad chargingPeriod', async t => {
   /* @type {TestContext} */
   const setJig = () => {};
-  const zoe = setUpZoeForTest(setJig);
+  const { zoe, feeMintAccess } = await setUpZoeForTest(setJig);
 
   const autoswapInstall = await makeInstall(autoswapRoot, zoe);
   const stablecoinInstall = await makeInstall(stablecoinRoot, zoe);
@@ -1648,6 +1663,7 @@ test('bad chargingPeriod', async t => {
           timerService: manualTimer,
           liquidationInstall,
         },
+        harden({ feeMintAccess }),
       ),
     { message: 'chargingPeriod (2) must be a BigInt' },
   );
@@ -1659,7 +1675,7 @@ test('coll fees from loan and AMM', async t => {
   const setJig = jig => {
     testJig = jig;
   };
-  const zoe = setUpZoeForTest(setJig);
+  const { zoe, feeMintAccess } = await setUpZoeForTest(setJig);
 
   const autoswapInstall = await makeInstall(autoswapRoot, zoe);
   const stablecoinInstall = await makeInstall(stablecoinRoot, zoe);
@@ -1690,6 +1706,7 @@ test('coll fees from loan and AMM', async t => {
       timerService: manualTimer,
       liquidationInstall,
     },
+    harden({ feeMintAccess }),
   );
 
   const { runIssuerRecord, govIssuerRecord, autoswap: _autoswapAPI } = testJig;
@@ -1796,7 +1813,7 @@ test('close loan', async t => {
   const setJig = jig => {
     testJig = jig;
   };
-  const zoe = setUpZoeForTest(setJig);
+  const { zoe, feeMintAccess } = await setUpZoeForTest(setJig);
 
   const autoswapInstall = await makeInstall(autoswapRoot, zoe);
   const stablecoinInstall = await makeInstall(stablecoinRoot, zoe);
@@ -1827,6 +1844,7 @@ test('close loan', async t => {
       timerService: manualTimer,
       liquidationInstall,
     },
+    harden({ feeMintAccess }),
   );
   const { runIssuerRecord, govIssuerRecord } = testJig;
   const { issuer: runIssuer, brand: runBrand } = runIssuerRecord;

--- a/packages/treasury/test/test-vault-interest.js
+++ b/packages/treasury/test/test-vault-interest.js
@@ -5,7 +5,7 @@ import '@agoric/zoe/exported.js';
 import { E } from '@agoric/eventual-send';
 import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import { makeLoopback } from '@agoric/captp';
-import { makeZoe } from '@agoric/zoe';
+import { makeZoeKit } from '@agoric/zoe';
 import bundleSource from '@agoric/bundle-source';
 import { resolve as importMetaResolve } from 'import-meta-resolve';
 
@@ -39,7 +39,7 @@ const setJig = jig => {
 
 const { makeFar, makeNear: makeRemote } = makeLoopback('zoeTest');
 
-const { zoeService, feeMintAccess: nonFarFeeMintAccess } = makeZoe(
+const { zoeService, feeMintAccess: nonFarFeeMintAccess } = makeZoeKit(
   makeFakeVatAdmin(setJig, makeRemote).admin,
 );
 /** @type {ERef<ZoeService>} */

--- a/packages/treasury/test/test-vault-interest.js
+++ b/packages/treasury/test/test-vault-interest.js
@@ -39,9 +39,13 @@ const setJig = jig => {
 
 const { makeFar, makeNear: makeRemote } = makeLoopback('zoeTest');
 
+const { zoeService, feeMintAccess: nonFarFeeMintAccess } = makeZoe(
+  makeFakeVatAdmin(setJig, makeRemote).admin,
+);
 /** @type {ERef<ZoeService>} */
-const zoe = makeFar(makeZoe(makeFakeVatAdmin(setJig, makeRemote).admin));
+const zoe = makeFar(zoeService);
 trace('makeZoe');
+const feeMintAccessP = makeFar(nonFarFeeMintAccess);
 
 /**
  * @param {ERef<ZoeService>} zoeP
@@ -52,9 +56,15 @@ async function launch(zoeP, sourceRoot) {
   const contractPath = new URL(contractUrl).pathname;
   const contractBundle = await bundleSource(contractPath);
   const installation = await E(zoeP).install(contractBundle);
+  const feeMintAccess = await feeMintAccessP;
   const { creatorInvitation, creatorFacet, instance } = await E(
     zoeP,
-  ).startInstance(installation);
+  ).startInstance(
+    installation,
+    undefined,
+    undefined,
+    harden({ feeMintAccess }),
+  );
   const {
     runMint,
     collateralKit: { mint: collateralMint, brand: collaterlBrand },

--- a/packages/treasury/test/test-vault.js
+++ b/packages/treasury/test/test-vault.js
@@ -37,9 +37,13 @@ const setJig = jig => {
 
 const { makeFar, makeNear: makeRemote } = makeLoopback('zoeTest');
 
+const { zoeService, feeMintAccess: nonFarFeeMintAccess } = makeZoe(
+  makeFakeVatAdmin(setJig, makeRemote).admin,
+);
 /** @type {ERef<ZoeService>} */
-const zoe = makeFar(makeZoe(makeFakeVatAdmin(setJig, makeRemote).admin));
+const zoe = makeFar(zoeService);
 trace('makeZoe');
+const feeMintAccessP = makeFar(nonFarFeeMintAccess);
 
 /**
  * @param {ERef<ZoeService>} zoeP
@@ -50,9 +54,15 @@ async function launch(zoeP, sourceRoot) {
   const contractPath = new URL(contractUrl).pathname;
   const contractBundle = await bundleSource(contractPath);
   const installation = await E(zoeP).install(contractBundle);
+  const feeMintAccess = await feeMintAccessP;
   const { creatorInvitation, creatorFacet, instance } = await E(
     zoeP,
-  ).startInstance(installation);
+  ).startInstance(
+    installation,
+    undefined,
+    undefined,
+    harden({ feeMintAccess }),
+  );
   const {
     runMint,
     collateralKit: { mint: collateralMint, brand: collaterlBrand },

--- a/packages/treasury/test/test-vault.js
+++ b/packages/treasury/test/test-vault.js
@@ -6,7 +6,7 @@ import '@agoric/zoe/exported.js';
 import { E } from '@agoric/eventual-send';
 import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import { makeLoopback } from '@agoric/captp';
-import { makeZoe } from '@agoric/zoe';
+import { makeZoeKit } from '@agoric/zoe';
 import bundleSource from '@agoric/bundle-source';
 import { resolve as importMetaResolve } from 'import-meta-resolve';
 
@@ -37,7 +37,7 @@ const setJig = jig => {
 
 const { makeFar, makeNear: makeRemote } = makeLoopback('zoeTest');
 
-const { zoeService, feeMintAccess: nonFarFeeMintAccess } = makeZoe(
+const { zoeService, feeMintAccess: nonFarFeeMintAccess } = makeZoeKit(
   makeFakeVatAdmin(setJig, makeRemote).admin,
 );
 /** @type {ERef<ZoeService>} */

--- a/packages/treasury/test/vault-contract-wrapper.js
+++ b/packages/treasury/test/vault-contract-wrapper.js
@@ -17,15 +17,16 @@ import { SECONDS_PER_YEAR } from '../src/interest.js';
 
 const BASIS_POINTS = 10000n;
 
-/** @param {ContractFacet} zcf */
-export async function start(zcf) {
+/** @type {ContractStartFn} */
+export async function start(zcf, privateArgs) {
   console.log(`contract started`);
+  assert.typeof(privateArgs.feeMintAccess, 'object');
 
   const collateralKit = makeIssuerKit('Collateral');
   const { brand: collateralBrand } = collateralKit;
   await zcf.saveIssuer(collateralKit.issuer, 'Collateral'); // todo: CollateralETH, etc
 
-  const runMint = await zcf.makeZCFMint('RUN');
+  const runMint = await zcf.registerFeeMint('RUN', privateArgs.feeMintAccess);
   const { brand: runBrand } = runMint.getIssuerRecord();
 
   const { zcfSeat: _collateralSt, userSeat: liqSeat } = zcf.makeEmptySeatKit();

--- a/packages/vats/src/bootstrap.js
+++ b/packages/vats/src/bootstrap.js
@@ -75,14 +75,16 @@ export function buildRootObject(vatPowers, vatParameters) {
       sharingService,
       board,
       chainTimerService,
-      zoe,
+      { zoeService: zoe, feeMintAccess },
       { priceAuthority, adminFacet: priceAuthorityAdmin },
     ] = await Promise.all([
       E(bankVat).makeBankManager(bankBridgeManager),
       E(vats.sharing).getSharingService(),
       E(vats.board).getBoard(),
       E(vats.timer).createTimerService(timerDevice),
-      /** @type {ERef<ZoeService>} */ (E(vats.zoe).buildZoe(vatAdminSvc)),
+      /** @type {Promise<{ zoeService: ZoeService, feeMintAccess: FeeMintAccess }>} */ (E(
+        vats.zoe,
+      ).buildZoe(vatAdminSvc)),
       E(vats.priceAuthority).makePriceAuthority(),
     ]);
 
@@ -129,6 +131,7 @@ export function buildRootObject(vatPowers, vatParameters) {
           priceAuthority,
           zoe,
           bootstrapPaymentValue,
+          feeMintAccess,
         }),
         installPegasusOnChain({
           agoricNames,

--- a/packages/vats/src/vat-zoe.js
+++ b/packages/vats/src/vat-zoe.js
@@ -1,8 +1,8 @@
 import { Far } from '@agoric/marshal';
-import { makeZoe } from '@agoric/zoe';
+import { makeZoeKit } from '@agoric/zoe';
 
 export function buildRootObject(_vatPowers, vatParameters) {
   return Far('root', {
-    buildZoe: adminVat => makeZoe(adminVat, vatParameters.zcfBundleName),
+    buildZoe: adminVat => makeZoeKit(adminVat, vatParameters.zcfBundleName),
   });
 }

--- a/packages/vats/src/vat-zoe.js
+++ b/packages/vats/src/vat-zoe.js
@@ -1,8 +1,11 @@
 import { Far } from '@agoric/marshal';
 import { makeZoeKit } from '@agoric/zoe';
 
-export function buildRootObject(_vatPowers, vatParameters) {
+export function buildRootObject(vatPowers, vatParameters) {
   return Far('root', {
-    buildZoe: adminVat => makeZoeKit(adminVat, vatParameters.zcfBundleName),
+    buildZoe: adminVat => {
+      const shutdownZoeVat = vatPowers.exitVatWithFailure;
+      makeZoeKit(adminVat, shutdownZoeVat, vatParameters.zcfBundleName);
+    },
   });
 }

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -39,9 +39,11 @@
  * @property {(brand: Brand) => Issuer} getIssuerForBrand
  * @property {GetAssetKindByBrand} getAssetKind
  * @property {MakeZCFMint} makeZCFMint
+ * @property {ZCFRegisterFeeMint} registerFeeMint
  * @property {ZCFMakeEmptySeatKit} makeEmptySeatKit
  * @property {SetTestJig} setTestJig
  * @property {() => void} stopAcceptingOffers
+ * @property {() => Instance} getInstance
  */
 
 /**
@@ -105,6 +107,14 @@
  * @param {AssetKind=} assetKind
  * @param {AdditionalDisplayInfo=} displayInfo
  * @returns {Promise<ZCFMint>}
+ */
+
+/**
+ * @callback ZCFRegisterFeeMint
+ * @param {Keyword} keyword
+ * @param {FeeMintAccess} allegedFeeMintAccess - an object that
+ * purports to be the object that grants access to the fee mint
+ * @returns {Promise<ZCFMint>
  */
 
 /**

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -120,19 +120,8 @@ export const makeZCFZygote = (
     assert(amountKeywordRecord !== null, X`${name} cannot be null`);
   };
 
-  /** @type {MakeZCFMint} */
-  const makeZCFMint = async (
-    keyword,
-    assetKind = AssetKind.NAT,
-    displayInfo,
-  ) => {
-    assertUniqueKeyword(keyword);
-
-    const zoeMintP = E(zoeInstanceAdmin).makeZoeMint(
-      keyword,
-      assetKind,
-      displayInfo,
-    );
+  // A helper for the code shared between MakeZCFMint and RegisterZCFMint
+  const doMakeZCFMint = async (keyword, zoeMintP) => {
     const {
       brand: mintyBrand,
       issuer: mintyIssuer,
@@ -146,7 +135,7 @@ export const makeZCFZygote = (
     );
     recordIssuer(keyword, mintyIssuerRecord);
 
-    const empty = AmountMath.makeEmpty(mintyBrand, assetKind);
+    const empty = AmountMath.makeEmpty(mintyBrand, mintyDisplayInfo.assetKind);
     const add = (total, amountToAdd) => {
       return AmountMath.add(total, amountToAdd, mintyBrand);
     };
@@ -191,6 +180,34 @@ export const makeZCFZygote = (
       },
     });
     return zcfMint;
+  };
+
+  /** @type {MakeZCFMint} */
+  const makeZCFMint = async (
+    keyword,
+    assetKind = AssetKind.NAT,
+    displayInfo,
+  ) => {
+    assertUniqueKeyword(keyword);
+
+    const zoeMintP = E(zoeInstanceAdmin).makeZoeMint(
+      keyword,
+      assetKind,
+      displayInfo,
+    );
+
+    return doMakeZCFMint(keyword, zoeMintP);
+  };
+
+  /** @type {ZCFRegisterFeeMint} */
+  const registerFeeMint = async (keyword, feeMintAccess) => {
+    assertUniqueKeyword(keyword);
+
+    const zoeMintP = E(zoeInstanceAdmin).registerFeeMint(
+      keyword,
+      feeMintAccess,
+    );
+    return doMakeZCFMint(keyword, zoeMintP);
   };
 
   /** @type {ContractFacet} */
@@ -238,6 +255,7 @@ export const makeZCFZygote = (
     assert: makeAssert(shutdownWithFailure),
     stopAcceptingOffers: () => E(zoeInstanceAdmin).stopAcceptingOffers(),
     makeZCFMint,
+    registerFeeMint,
     makeEmptySeatKit,
 
     // The methods below are pure and have no side-effects //

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -118,11 +118,27 @@
  *             keyword: Keyword
  *            ) => Promise<IssuerRecord>} saveIssuer
  * @property {MakeZoeMint} makeZoeMint
+ * @property {RegisterFeeMint} registerFeeMint
  * @property {MakeNoEscrowSeat} makeNoEscrowSeat
  * @property {ReplaceAllocations} replaceAllocations
  * @property {(completion: Completion) => void} exitAllSeats
  * @property {ShutdownWithFailure} failAllSeats
  * @property {() => void} stopAcceptingOffers
+ */
+
+/**
+ * @callback RegisterFeeMint
+ * @param {Keyword} keyword - the keyword to use for the issuer
+ * @param {FeeMintAccess} allegedFeeMintAccess - an object that
+ * purports to be the object that allows access to the feeMint
+ * @returns {ZoeMint}
+ */
+
+/**
+ * @callback MakeZoeMintPremadeKit
+ * @param {Keyword} keyword - the keyword to use for the issuer
+ * @param {IssuerKit} localIssuerKit - an issuer kit that originates
+ * within Zoe
  */
 
 /**

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -135,7 +135,7 @@
  */
 
 /**
- * @callback MakeZoeMintPremadeKit
+ * @callback WrapIssuerKitWithZoeMint
  * @param {Keyword} keyword - the keyword to use for the issuer
  * @param {IssuerKit} localIssuerKit - an issuer kit that originates
  * within Zoe

--- a/packages/zoe/src/zoeService/feeMint.js
+++ b/packages/zoe/src/zoeService/feeMint.js
@@ -1,0 +1,42 @@
+// @ts-check
+
+import { makeIssuerKit } from '@agoric/ertp';
+
+import { makeHandle } from '../makeHandle.js';
+
+const { details: X } = assert;
+/**
+ * @param {FeeIssuerConfig} feeIssuerConfig
+ * @returns {{
+ *    feeMintAccess: FeeMintAccess,
+ *    getFeeIssuerKit: GetFeeIssuerKit,
+ *    feeIssuer: Issuer }}
+ */
+const createFeeMint = feeIssuerConfig => {
+  /** @type {IssuerKit} */
+  const feeIssuerKit = makeIssuerKit(
+    feeIssuerConfig.name,
+    feeIssuerConfig.assetKind,
+    feeIssuerConfig.displayInfo,
+  );
+
+  /** @type {FeeMintAccess} */
+  const feeMintAccess = makeHandle('feeMintAccess');
+
+  /** @type {GetFeeIssuerKit} */
+  const getFeeIssuerKit = allegedFeeMintAccess => {
+    assert(
+      feeMintAccess === allegedFeeMintAccess,
+      X`The object representing access to the fee brand mint was not provided`,
+    );
+    return feeIssuerKit;
+  };
+
+  return harden({
+    feeMintAccess,
+    getFeeIssuerKit,
+    feeIssuer: feeIssuerKit.issuer,
+  });
+};
+
+export { createFeeMint };

--- a/packages/zoe/src/zoeService/feeMint.js
+++ b/packages/zoe/src/zoeService/feeMint.js
@@ -7,17 +7,19 @@ import { makeHandle } from '../makeHandle.js';
 const { details: X } = assert;
 /**
  * @param {FeeIssuerConfig} feeIssuerConfig
+ * @param {ShutdownWithFailure} shutdownZoeVat
  * @returns {{
  *    feeMintAccess: FeeMintAccess,
  *    getFeeIssuerKit: GetFeeIssuerKit,
  *    feeIssuer: Issuer }}
  */
-const createFeeMint = feeIssuerConfig => {
+const createFeeMint = (feeIssuerConfig, shutdownZoeVat) => {
   /** @type {IssuerKit} */
   const feeIssuerKit = makeIssuerKit(
     feeIssuerConfig.name,
     feeIssuerConfig.assetKind,
     feeIssuerConfig.displayInfo,
+    shutdownZoeVat,
   );
 
   /** @type {FeeMintAccess} */

--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -75,6 +75,7 @@
  * @property {InstanceRecordGetBrands} getBrands
  * @property {SaveIssuer} saveIssuer
  * @property {MakeZoeMint} makeZoeMint
+ * @property {RegisterFeeMint} registerFeeMint
  * @property {GetInstanceRecord} getInstanceRecord
  * @property {GetIssuerRecords} getIssuerRecords
  * @property {WithdrawPayments} withdrawPayments
@@ -122,4 +123,14 @@
  *
  * @callback CreateZCFVat
  * @returns {Promise<RootAndAdminNode>}
+ */
+
+/**
+ * @typedef {Handle<'feeMintAccess'>} FeeMintAccess
+ */
+
+/**
+ * @callback GetFeeIssuerKit
+ * @param {FeeMintAccess} feeMintAccess
+ * @returns {IssuerKit}
  */

--- a/packages/zoe/src/zoeService/makeInvitation.js
+++ b/packages/zoe/src/zoeService/makeInvitation.js
@@ -2,8 +2,13 @@
 import { assert, details as X } from '@agoric/assert';
 import { AmountMath, makeIssuerKit, AssetKind } from '@agoric/ertp';
 
-export const createInvitationKit = () => {
-  const invitationKit = makeIssuerKit('Zoe Invitation', AssetKind.SET);
+export const createInvitationKit = shutdownZoeVat => {
+  const invitationKit = makeIssuerKit(
+    'Zoe Invitation',
+    AssetKind.SET,
+    undefined,
+    shutdownZoeVat,
+  );
 
   /**
    * @param {Instance} instance

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -180,6 +180,7 @@ export const makeStartInstance = (
       exitAllSeats: completion => instanceAdmin.exitAllSeats(completion),
       failAllSeats: reason => instanceAdmin.failAllSeats(reason),
       makeZoeMint: zoeInstanceStorageManager.makeZoeMint,
+      registerFeeMint: zoeInstanceStorageManager.registerFeeMint,
       replaceAllocations: seatHandleAllocations => {
         try {
           seatHandleAllocations.forEach(({ seatHandle, allocation }) => {

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -38,6 +38,12 @@
  * @property {GetInvitationDetails} getInvitationDetails - return an
  * object with the instance, installation, description, invitation
  * handle, and any custom properties specific to the contract.
+ * @property {GetFeeIssuer} getFeeIssuer
+ */
+
+/**
+ * @callback GetFeeIssuer
+ * @returns {Issuer}
  */
 
 /**
@@ -268,4 +274,11 @@
 /**
  * @typedef {Object} Installation
  * @property {() => SourceBundle} getBundle
+ */
+
+/**
+ * @typedef {Object} FeeIssuerConfig
+ * @property {string} name
+ * @property {AssetKind} assetKind
+ * @property {DisplayInfo} displayInfo
  */

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -17,6 +17,7 @@ import '../internal-types.js';
 
 import { Far } from '@agoric/marshal';
 import { makePromiseKit } from '@agoric/promise-kit';
+import { AssetKind } from '@agoric/ertp';
 
 import { makeZoeStorageManager } from './zoeStorageManager.js';
 import { makeStartInstance } from './startInstance.js';
@@ -24,7 +25,6 @@ import { makeOffer } from './offer/offer.js';
 import { makeInvitationQueryFns } from './invitationQueries.js';
 import { setupCreateZCFVat } from './createZCFVat.js';
 import { createFeeMint } from './feeMint.js';
-import { AssetKind } from '../../../ERTP/src/amountMath.js';
 
 /**
  * Create an instance of Zoe.
@@ -33,7 +33,7 @@ import { AssetKind } from '../../../ERTP/src/amountMath.js';
  * to create a new vat.
  * @param {FeeIssuerConfig} feeIssuerConfig
  * @param {string} [zcfBundleName] - The name of the contract facet bundle.
- * @returns {{ zoeService: ZoeService, feeMintAccess: Handle<'feeMintAccess'> }} The created Zoe service.
+ * @returns {{ zoeService: ZoeService, feeMintAccess: FeeMintAccess }}
  */
 const makeZoe = (
   vatAdminSvc,

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -35,7 +35,7 @@ import { createFeeMint } from './feeMint.js';
  * @param {string} [zcfBundleName] - The name of the contract facet bundle.
  * @returns {{ zoeService: ZoeService, feeMintAccess: FeeMintAccess }}
  */
-const makeZoe = (
+const makeZoeKit = (
   vatAdminSvc,
   feeIssuerConfig = {
     name: 'RUN',
@@ -126,4 +126,4 @@ const makeZoe = (
   return harden({ zoeService, feeMintAccess });
 };
 
-export { makeZoe };
+export { makeZoeKit };

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -31,12 +31,16 @@ import { createFeeMint } from './feeMint.js';
  *
  * @param {VatAdminSvc} vatAdminSvc - The vatAdmin Service, which carries the power
  * to create a new vat.
+ * @param {ShutdownWithFailure} shutdownZoeVat - a function to
+ * shutdown the Zoe Vat. This function needs to use the vatPowers
+ * available to a vat.
  * @param {FeeIssuerConfig} feeIssuerConfig
  * @param {string} [zcfBundleName] - The name of the contract facet bundle.
  * @returns {{ zoeService: ZoeService, feeMintAccess: FeeMintAccess }}
  */
 const makeZoeKit = (
   vatAdminSvc,
+  shutdownZoeVat = () => {},
   feeIssuerConfig = {
     name: 'RUN',
     assetKind: AssetKind.NAT,
@@ -51,6 +55,7 @@ const makeZoeKit = (
 
   const { feeMintAccess, getFeeIssuerKit, feeIssuer } = createFeeMint(
     feeIssuerConfig,
+    shutdownZoeVat,
   );
 
   // This method contains the power to create a new ZCF Vat, and must
@@ -73,7 +78,7 @@ const makeZoeKit = (
     getInstallationForInstance,
     getInstanceAdmin,
     invitationIssuer,
-  } = makeZoeStorageManager(createZCFVat, getFeeIssuerKit);
+  } = makeZoeStorageManager(createZCFVat, getFeeIssuerKit, shutdownZoeVat);
 
   // Pass the capabilities necessary to create zoe.startInstance
   const startInstance = makeStartInstance(

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -107,8 +107,8 @@ export const makeZoeStorageManager = (createZCFVat, getFeeIssuerKit) => {
       return issuerRecord;
     };
 
-    /** @type {MakeZoeMintPremadeKit} */
-    const makeZoeMintPremadeKit = (keyword, localIssuerKit) => {
+    /** @type {WrapIssuerKitWithZoeMint} */
+    const wrapIssuerKitWithZoeMint = (keyword, localIssuerKit) => {
       const {
         mint: localMint,
         issuer: localIssuer,
@@ -168,13 +168,13 @@ export const makeZoeStorageManager = (createZCFVat, getFeeIssuerKit) => {
         // eslint-disable-next-line no-use-before-define
         adminNode.terminateWithFailure,
       );
-      return makeZoeMintPremadeKit(keyword, localIssuerKit);
+      return wrapIssuerKitWithZoeMint(keyword, localIssuerKit);
     };
 
     /** @type {RegisterFeeMint} */
     const registerFeeMint = (keyword, allegedFeeMintAccess) => {
       const feeIssuerKit = getFeeIssuerKit(allegedFeeMintAccess);
-      return makeZoeMintPremadeKit(keyword, feeIssuerKit);
+      return wrapIssuerKitWithZoeMint(keyword, feeIssuerKit);
     };
 
     /** @type {GetIssuerRecords} */

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -27,9 +27,14 @@ import { makeInstallationStorage } from './installationStorage.js';
  * @param {CreateZCFVat} createZCFVat - the ability to create a new
  * ZCF Vat
  * @param {GetFeeIssuerKit} getFeeIssuerKit
+ * @param {ShutdownWithFailure} shutdownZoeVat
  * @returns {ZoeStorageManager}
  */
-export const makeZoeStorageManager = (createZCFVat, getFeeIssuerKit) => {
+export const makeZoeStorageManager = (
+  createZCFVat,
+  getFeeIssuerKit,
+  shutdownZoeVat,
+) => {
   // issuerStorage contains the issuers that the ZoeService knows
   // about, as well as information about them such as their brand,
   // assetKind, and displayInfo
@@ -44,7 +49,9 @@ export const makeZoeStorageManager = (createZCFVat, getFeeIssuerKit) => {
   // In order to participate in a contract, users must have
   // invitations, which are ERTP payments made by Zoe. This code
   // contains the mint capability for invitations.
-  const { setupMakeInvitation, invitationIssuer } = createInvitationKit();
+  const { setupMakeInvitation, invitationIssuer } = createInvitationKit(
+    shutdownZoeVat,
+  );
 
   // Every new instance of a contract creates a corresponding
   // "zoeInstanceAdmin" - an admin facet within the Zoe Service for

--- a/packages/zoe/test/swingsetTests/brokenContracts/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/vat-zoe.js
@@ -7,6 +7,9 @@ import { makeZoe } from '../../../src/zoeService/zoe.js';
 
 export function buildRootObject(_vatPowers) {
   return Far('root', {
-    buildZoe: vatAdminSvc => makeZoe(vatAdminSvc),
+    buildZoe: vatAdminSvc => {
+      const { zoeService: zoe } = makeZoe(vatAdminSvc);
+      return zoe;
+    },
   });
 }

--- a/packages/zoe/test/swingsetTests/brokenContracts/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/vat-zoe.js
@@ -3,12 +3,12 @@
 import { Far } from '@agoric/marshal';
 
 // noinspection ES6PreferShortImport
-import { makeZoe } from '../../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 
 export function buildRootObject(_vatPowers) {
   return Far('root', {
     buildZoe: vatAdminSvc => {
-      const { zoeService: zoe } = makeZoe(vatAdminSvc);
+      const { zoeService: zoe } = makeZoeKit(vatAdminSvc);
       return zoe;
     },
   });

--- a/packages/zoe/test/swingsetTests/brokenContracts/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/vat-zoe.js
@@ -5,10 +5,11 @@ import { Far } from '@agoric/marshal';
 // noinspection ES6PreferShortImport
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 
-export function buildRootObject(_vatPowers) {
+export function buildRootObject(vatPowers) {
   return Far('root', {
     buildZoe: vatAdminSvc => {
-      const { zoeService: zoe } = makeZoeKit(vatAdminSvc);
+      const shutdownZoeVat = vatPowers.exitVatWithFailure;
+      const { zoeService: zoe } = makeZoeKit(vatAdminSvc, shutdownZoeVat);
       return zoe;
     },
   });

--- a/packages/zoe/test/swingsetTests/makeKind/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/makeKind/vat-zoe.js
@@ -1,12 +1,12 @@
 import { Far } from '@agoric/marshal';
 
 // noinspection ES6PreferShortImport
-import { makeZoe } from '../../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 
 export function buildRootObject(_vatPowers) {
   return Far('root', {
     buildZoe: vatAdminSvc => {
-      const { zoeService: zoe } = makeZoe(vatAdminSvc);
+      const { zoeService: zoe } = makeZoeKit(vatAdminSvc);
       return zoe;
     },
   });

--- a/packages/zoe/test/swingsetTests/makeKind/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/makeKind/vat-zoe.js
@@ -5,6 +5,9 @@ import { makeZoe } from '../../../src/zoeService/zoe.js';
 
 export function buildRootObject(_vatPowers) {
   return Far('root', {
-    buildZoe: vatAdminSvc => makeZoe(vatAdminSvc),
+    buildZoe: vatAdminSvc => {
+      const { zoeService: zoe } = makeZoe(vatAdminSvc);
+      return zoe;
+    },
   });
 }

--- a/packages/zoe/test/swingsetTests/makeKind/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/makeKind/vat-zoe.js
@@ -1,12 +1,15 @@
+// @ts-check
+
 import { Far } from '@agoric/marshal';
 
 // noinspection ES6PreferShortImport
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 
-export function buildRootObject(_vatPowers) {
+export function buildRootObject(vatPowers) {
   return Far('root', {
     buildZoe: vatAdminSvc => {
-      const { zoeService: zoe } = makeZoeKit(vatAdminSvc);
+      const shutdownZoeVat = vatPowers.exitVatWithFailure;
+      const { zoeService: zoe } = makeZoeKit(vatAdminSvc, shutdownZoeVat);
       return zoe;
     },
   });

--- a/packages/zoe/test/swingsetTests/offerArgs/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/offerArgs/vat-zoe.js
@@ -1,12 +1,12 @@
 import { Far } from '@agoric/marshal';
 
 // noinspection ES6PreferShortImport
-import { makeZoe } from '../../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 
 export function buildRootObject(_vatPowers) {
   return Far('root', {
     buildZoe: vatAdminSvc => {
-      const { zoeService: zoe } = makeZoe(vatAdminSvc);
+      const { zoeService: zoe } = makeZoeKit(vatAdminSvc);
       return zoe;
     },
   });

--- a/packages/zoe/test/swingsetTests/offerArgs/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/offerArgs/vat-zoe.js
@@ -5,6 +5,9 @@ import { makeZoe } from '../../../src/zoeService/zoe.js';
 
 export function buildRootObject(_vatPowers) {
   return Far('root', {
-    buildZoe: vatAdminSvc => makeZoe(vatAdminSvc),
+    buildZoe: vatAdminSvc => {
+      const { zoeService: zoe } = makeZoe(vatAdminSvc);
+      return zoe;
+    },
   });
 }

--- a/packages/zoe/test/swingsetTests/offerArgs/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/offerArgs/vat-zoe.js
@@ -1,12 +1,15 @@
+// @ts-check
+
 import { Far } from '@agoric/marshal';
 
 // noinspection ES6PreferShortImport
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 
-export function buildRootObject(_vatPowers) {
+export function buildRootObject(vatPowers) {
   return Far('root', {
     buildZoe: vatAdminSvc => {
-      const { zoeService: zoe } = makeZoeKit(vatAdminSvc);
+      const shutdownZoeVat = vatPowers.exitVatWithFailure;
+      const { zoeService: zoe } = makeZoeKit(vatAdminSvc, shutdownZoeVat);
       return zoe;
     },
   });

--- a/packages/zoe/test/swingsetTests/privateArgs/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/privateArgs/vat-zoe.js
@@ -1,12 +1,12 @@
 import { Far } from '@agoric/marshal';
 
 // noinspection ES6PreferShortImport
-import { makeZoe } from '../../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 
 export function buildRootObject(_vatPowers) {
   return Far('root', {
     buildZoe: vatAdminSvc => {
-      const { zoeService: zoe } = makeZoe(vatAdminSvc);
+      const { zoeService: zoe } = makeZoeKit(vatAdminSvc);
       return zoe;
     },
   });

--- a/packages/zoe/test/swingsetTests/privateArgs/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/privateArgs/vat-zoe.js
@@ -5,6 +5,9 @@ import { makeZoe } from '../../../src/zoeService/zoe.js';
 
 export function buildRootObject(_vatPowers) {
   return Far('root', {
-    buildZoe: vatAdminSvc => makeZoe(vatAdminSvc),
+    buildZoe: vatAdminSvc => {
+      const { zoeService: zoe } = makeZoe(vatAdminSvc);
+      return zoe;
+    },
   });
 }

--- a/packages/zoe/test/swingsetTests/privateArgs/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/privateArgs/vat-zoe.js
@@ -1,12 +1,15 @@
+// @ts-check
+
 import { Far } from '@agoric/marshal';
 
 // noinspection ES6PreferShortImport
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 
-export function buildRootObject(_vatPowers) {
+export function buildRootObject(vatPowers) {
   return Far('root', {
     buildZoe: vatAdminSvc => {
-      const { zoeService: zoe } = makeZoeKit(vatAdminSvc);
+      const shutdownZoeVat = vatPowers.exitVatWithFailure;
+      const { zoeService: zoe } = makeZoeKit(vatAdminSvc, shutdownZoeVat);
       return zoe;
     },
   });

--- a/packages/zoe/test/swingsetTests/zoe-metering/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/zoe-metering/vat-zoe.js
@@ -1,12 +1,12 @@
 import { Far } from '@agoric/marshal';
 
 // noinspection ES6PreferShortImport
-import { makeZoe } from '../../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 
 export function buildRootObject(_vatPowers) {
   return Far('root', {
     buildZoe: vatAdminSvc => {
-      const { zoeService: zoe } = makeZoe(vatAdminSvc);
+      const { zoeService: zoe } = makeZoeKit(vatAdminSvc);
       return zoe;
     },
   });

--- a/packages/zoe/test/swingsetTests/zoe-metering/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/zoe-metering/vat-zoe.js
@@ -5,6 +5,9 @@ import { makeZoe } from '../../../src/zoeService/zoe.js';
 
 export function buildRootObject(_vatPowers) {
   return Far('root', {
-    buildZoe: vatAdminSvc => makeZoe(vatAdminSvc),
+    buildZoe: vatAdminSvc => {
+      const { zoeService: zoe } = makeZoe(vatAdminSvc);
+      return zoe;
+    },
   });
 }

--- a/packages/zoe/test/swingsetTests/zoe-metering/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/zoe-metering/vat-zoe.js
@@ -1,12 +1,15 @@
+// @ts-check
+
 import { Far } from '@agoric/marshal';
 
 // noinspection ES6PreferShortImport
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 
-export function buildRootObject(_vatPowers) {
+export function buildRootObject(vatPowers) {
   return Far('root', {
     buildZoe: vatAdminSvc => {
-      const { zoeService: zoe } = makeZoeKit(vatAdminSvc);
+      const shutdownZoeVat = vatPowers.exitVatWithFailure;
+      const { zoeService: zoe } = makeZoeKit(vatAdminSvc, shutdownZoeVat);
       return zoe;
     },
   });

--- a/packages/zoe/test/swingsetTests/zoe/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-zoe.js
@@ -7,6 +7,9 @@ import { makeZoe } from '../../../src/zoeService/zoe.js';
 
 export function buildRootObject(_vatPowers) {
   return Far('root', {
-    buildZoe: vatAdminSvc => makeZoe(vatAdminSvc),
+    buildZoe: vatAdminSvc => {
+      const { zoeService: zoe } = makeZoe(vatAdminSvc);
+      return zoe;
+    },
   });
 }

--- a/packages/zoe/test/swingsetTests/zoe/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-zoe.js
@@ -3,12 +3,12 @@
 import { Far } from '@agoric/marshal';
 
 // noinspection ES6PreferShortImport
-import { makeZoe } from '../../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 
 export function buildRootObject(_vatPowers) {
   return Far('root', {
     buildZoe: vatAdminSvc => {
-      const { zoeService: zoe } = makeZoe(vatAdminSvc);
+      const { zoeService: zoe } = makeZoeKit(vatAdminSvc);
       return zoe;
     },
   });

--- a/packages/zoe/test/swingsetTests/zoe/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-zoe.js
@@ -5,10 +5,11 @@ import { Far } from '@agoric/marshal';
 // noinspection ES6PreferShortImport
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 
-export function buildRootObject(_vatPowers) {
+export function buildRootObject(vatPowers) {
   return Far('root', {
     buildZoe: vatAdminSvc => {
-      const { zoeService: zoe } = makeZoeKit(vatAdminSvc);
+      const shutdownZoeVat = vatPowers.exitVatWithFailure;
+      const { zoeService: zoe } = makeZoeKit(vatAdminSvc, shutdownZoeVat);
       return zoe;
     },
   });

--- a/packages/zoe/test/unitTests/contractSupport/test-depositTo.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-depositTo.js
@@ -8,7 +8,7 @@ import { E } from '@agoric/eventual-send';
 import bundleSource from '@agoric/bundle-source';
 
 import { setup } from '../setupBasicMints.js';
-import { makeZoe } from '../../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
 import { depositToSeat } from '../../../src/contractSupport/zoeHelpers.js';
 import { makeOffer } from '../makeOffer.js';
@@ -23,7 +23,7 @@ async function setupContract(moolaIssuer, bucksIssuer) {
   const setJig = jig => {
     testJig = jig;
   };
-  const { zoeService: zoe } = makeZoe(makeFakeVatAdmin(setJig).admin);
+  const { zoeService: zoe } = makeZoeKit(makeFakeVatAdmin(setJig).admin);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/contractSupport/test-depositTo.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-depositTo.js
@@ -23,7 +23,7 @@ async function setupContract(moolaIssuer, bucksIssuer) {
   const setJig = jig => {
     testJig = jig;
   };
-  const zoe = makeZoe(makeFakeVatAdmin(setJig).admin);
+  const { zoeService: zoe } = makeZoe(makeFakeVatAdmin(setJig).admin);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
@@ -27,7 +27,7 @@ const setupContract = async (moolaIssuer, bucksIssuer) => {
   const setJig = jig => {
     instanceToZCF.set(jig.instance, jig.zcf);
   };
-  const zoe = makeZoe(makeFakeVatAdmin(setJig).admin);
+  const { zoeService: zoe } = makeZoe(makeFakeVatAdmin(setJig).admin);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
@@ -8,7 +8,7 @@ import { E } from '@agoric/eventual-send';
 import bundleSource from '@agoric/bundle-source';
 
 import { setup } from '../setupBasicMints.js';
-import { makeZoe } from '../../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
 import {
   offerTo,
@@ -27,7 +27,7 @@ const setupContract = async (moolaIssuer, bucksIssuer) => {
   const setJig = jig => {
     instanceToZCF.set(jig.instance, jig.zcf);
   };
-  const { zoeService: zoe } = makeZoe(makeFakeVatAdmin(setJig).admin);
+  const { zoeService: zoe } = makeZoeKit(makeFakeVatAdmin(setJig).admin);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
@@ -8,7 +8,7 @@ import { E } from '@agoric/eventual-send';
 import bundleSource from '@agoric/bundle-source';
 
 import { setup } from '../setupBasicMints.js';
-import { makeZoe } from '../../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
 import {
   depositToSeat,
@@ -27,7 +27,7 @@ async function setupContract(moolaIssuer, bucksIssuer) {
   const setJig = jig => {
     testJig = jig;
   };
-  const { zoeService: zoe } = makeZoe(makeFakeVatAdmin(setJig).admin);
+  const { zoeService: zoe } = makeZoeKit(makeFakeVatAdmin(setJig).admin);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
@@ -27,7 +27,7 @@ async function setupContract(moolaIssuer, bucksIssuer) {
   const setJig = jig => {
     testJig = jig;
   };
-  const zoe = makeZoe(makeFakeVatAdmin(setJig).admin);
+  const { zoeService: zoe } = makeZoe(makeFakeVatAdmin(setJig).admin);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/contracts/attestation/test-attestation.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/test-attestation.js
@@ -11,7 +11,7 @@ import { Far } from '@agoric/marshal';
 import bundleSource from '@agoric/bundle-source';
 import { E } from '@agoric/eventual-send';
 
-import { makeZoe } from '../../../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../../../src/zoeService/zoe.js';
 import fakeVatAdmin from '../../../../tools/fakeVatAdmin.js';
 
 const filename = new URL(import.meta.url).pathname;
@@ -22,7 +22,7 @@ const attestationRoot = `${dirname}/../../../../src/contracts/attestation/attest
 test('attestation contract basic tests', async t => {
   const bundle = await bundleSource(attestationRoot);
 
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
   const installation = await E(zoe).install(bundle);
 
   const bldIssuerKit = makeIssuerKit('BLD', AssetKind.NAT, {

--- a/packages/zoe/test/unitTests/contracts/attestation/test-attestation.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/test-attestation.js
@@ -22,7 +22,7 @@ const attestationRoot = `${dirname}/../../../../src/contracts/attestation/attest
 test('attestation contract basic tests', async t => {
   const bundle = await bundleSource(attestationRoot);
 
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
   const installation = await E(zoe).install(bundle);
 
   const bldIssuerKit = makeIssuerKit('BLD', AssetKind.NAT, {

--- a/packages/zoe/test/unitTests/contracts/attestation/test-exampleVotingUsage.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/test-exampleVotingUsage.js
@@ -23,7 +23,7 @@ const exampleVotingUsageRoot = `${dirname}/exampleVotingUsage.js`;
 test('exampleVotingUsage', async t => {
   const bundle = await bundleSource(exampleVotingUsageRoot);
 
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
   const installation = await E(zoe).install(bundle);
 
   const bldIssuerKit = makeIssuerKit('BLD', AssetKind.NAT, {

--- a/packages/zoe/test/unitTests/contracts/attestation/test-exampleVotingUsage.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/test-exampleVotingUsage.js
@@ -10,7 +10,7 @@ import { makeIssuerKit, AssetKind, AmountMath } from '@agoric/ertp';
 import bundleSource from '@agoric/bundle-source';
 import { E } from '@agoric/eventual-send';
 
-import { makeZoe } from '../../../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../../../src/zoeService/zoe.js';
 import fakeVatAdmin from '../../../../tools/fakeVatAdmin.js';
 import { makeAttestationElem } from '../../../../src/contracts/attestation/expiring/expiringHelpers.js';
 import { makeHandle } from '../../../../src/makeHandle.js';
@@ -23,7 +23,7 @@ const exampleVotingUsageRoot = `${dirname}/exampleVotingUsage.js`;
 test('exampleVotingUsage', async t => {
   const bundle = await bundleSource(exampleVotingUsageRoot);
 
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
   const installation = await E(zoe).install(bundle);
 
   const bldIssuerKit = makeIssuerKit('BLD', AssetKind.NAT, {

--- a/packages/zoe/test/unitTests/contracts/multipoolAutoswap/test-multipoolAutoswap.js
+++ b/packages/zoe/test/unitTests/contracts/multipoolAutoswap/test-multipoolAutoswap.js
@@ -33,7 +33,7 @@ const multipoolAutoswapRoot = `${dirname}/../../../../src/contracts/multipoolAut
 
 test('multipoolAutoSwap with valid offers', async t => {
   const { moolaR, simoleanR, moola, simoleans } = setup();
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
   const invitationIssuer = zoe.getInvitationIssuer();
   const invitationBrand = await E(invitationIssuer).getBrand();
 
@@ -546,7 +546,7 @@ test('multipoolAutoSwap with valid offers', async t => {
 
 test('multipoolAutoSwap get detailed prices', async t => {
   const { moolaR, simoleanR, moola, simoleans } = setup();
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
   const invitationIssuer = zoe.getInvitationIssuer();
   const invitationBrand = await E(invitationIssuer).getBrand();
 
@@ -728,7 +728,7 @@ test('multipoolAutoSwap get detailed prices', async t => {
 
 test('multipoolAutoSwap with some invalid offers', async t => {
   const { moolaR, moola } = setup();
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
   const invitationIssuer = zoe.getInvitationIssuer();
 
   // Set up central token
@@ -789,7 +789,7 @@ test('multipoolAutoSwap with some invalid offers', async t => {
 
 test('multipoolAutoSwap jig - addLiquidity', async t => {
   const { moolaR, moola } = setup();
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
 
   // Pack the contract.
   const bundle = await bundleSource(multipoolAutoswapRoot);
@@ -923,7 +923,7 @@ test('multipoolAutoSwap jig - addLiquidity', async t => {
 
 test('multipoolAutoSwap jig - check liquidity', async t => {
   const { moolaR, moola } = setup();
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
 
   // Pack the contract.
   const bundle = await bundleSource(multipoolAutoswapRoot);
@@ -1058,7 +1058,7 @@ test('multipoolAutoSwap jig - check liquidity', async t => {
 
 test('multipoolAutoSwap jig - swapOut', async t => {
   const { moolaR, moola, simoleanR, simoleans } = setup();
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
 
   // Pack the contract.
   const bundle = await bundleSource(multipoolAutoswapRoot);
@@ -1270,7 +1270,7 @@ test('multipoolAutoSwap jig - swapOut', async t => {
 
 test('multipoolAutoSwap jig - swapOut uneven', async t => {
   const { moolaR, moola, simoleanR, simoleans } = setup();
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
 
   // Pack the contract.
   const bundle = await bundleSource(multipoolAutoswapRoot);
@@ -1452,7 +1452,7 @@ test('multipoolAutoSwap jig - swapOut uneven', async t => {
 
 test('multipoolAutoSwap jig - removeLiquidity', async t => {
   const { moolaR, moola } = setup();
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
 
   // Pack the contract.
   const bundle = await bundleSource(multipoolAutoswapRoot);
@@ -1564,7 +1564,7 @@ test('multipoolAutoSwap jig - removeLiquidity', async t => {
 
 test('multipoolAutoSwap jig - removeLiquidity ask for too much', async t => {
   const { moolaR, moola } = setup();
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
 
   // Pack the contract.
   const bundle = await bundleSource(multipoolAutoswapRoot);
@@ -1660,7 +1660,7 @@ test('multipoolAutoSwap jig - removeLiquidity ask for too much', async t => {
 
 test('multipoolAutoSwap jig - remove all liquidity', async t => {
   const { moolaR, moola } = setup();
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
 
   // Pack the contract.
   const bundle = await bundleSource(multipoolAutoswapRoot);
@@ -1755,7 +1755,7 @@ test('multipoolAutoSwap jig - remove all liquidity', async t => {
 
 test('multipoolAutoSwap jig - insufficient', async t => {
   const { moolaR, moola } = setup();
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
 
   // Pack the contract.
   const bundle = await bundleSource(multipoolAutoswapRoot);
@@ -1849,7 +1849,7 @@ test('multipoolAutoSwap jig - insufficient', async t => {
 });
 
 test('multipoolAutoSwap collect empty fees', async t => {
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
   const centralR = makeIssuerKit('central');
   const centralTokens = value => AmountMath.make(value, centralR.brand);
 
@@ -1881,7 +1881,7 @@ test('multipoolAutoSwap collect empty fees', async t => {
 
 test('multipoolAutoSwap swapout secondary to secondary', async t => {
   const { moolaR, simoleanR, moola, simoleans } = setup();
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
   const invitationIssuer = zoe.getInvitationIssuer();
   const invitationBrand = await E(invitationIssuer).getBrand();
 

--- a/packages/zoe/test/unitTests/contracts/multipoolAutoswap/test-multipoolAutoswap.js
+++ b/packages/zoe/test/unitTests/contracts/multipoolAutoswap/test-multipoolAutoswap.js
@@ -10,7 +10,7 @@ import { E } from '@agoric/eventual-send';
 import fakeVatAdmin from '../../../../tools/fakeVatAdmin.js';
 
 // noinspection ES6PreferShortImport
-import { makeZoe } from '../../../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../../../src/zoeService/zoe.js';
 import { setup } from '../../setupBasicMints.js';
 import {
   makeTrader,
@@ -33,7 +33,7 @@ const multipoolAutoswapRoot = `${dirname}/../../../../src/contracts/multipoolAut
 
 test('multipoolAutoSwap with valid offers', async t => {
   const { moolaR, simoleanR, moola, simoleans } = setup();
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
   const invitationIssuer = zoe.getInvitationIssuer();
   const invitationBrand = await E(invitationIssuer).getBrand();
 
@@ -546,7 +546,7 @@ test('multipoolAutoSwap with valid offers', async t => {
 
 test('multipoolAutoSwap get detailed prices', async t => {
   const { moolaR, simoleanR, moola, simoleans } = setup();
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
   const invitationIssuer = zoe.getInvitationIssuer();
   const invitationBrand = await E(invitationIssuer).getBrand();
 
@@ -728,7 +728,7 @@ test('multipoolAutoSwap get detailed prices', async t => {
 
 test('multipoolAutoSwap with some invalid offers', async t => {
   const { moolaR, moola } = setup();
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
   const invitationIssuer = zoe.getInvitationIssuer();
 
   // Set up central token
@@ -789,7 +789,7 @@ test('multipoolAutoSwap with some invalid offers', async t => {
 
 test('multipoolAutoSwap jig - addLiquidity', async t => {
   const { moolaR, moola } = setup();
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   // Pack the contract.
   const bundle = await bundleSource(multipoolAutoswapRoot);
@@ -923,7 +923,7 @@ test('multipoolAutoSwap jig - addLiquidity', async t => {
 
 test('multipoolAutoSwap jig - check liquidity', async t => {
   const { moolaR, moola } = setup();
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   // Pack the contract.
   const bundle = await bundleSource(multipoolAutoswapRoot);
@@ -1058,7 +1058,7 @@ test('multipoolAutoSwap jig - check liquidity', async t => {
 
 test('multipoolAutoSwap jig - swapOut', async t => {
   const { moolaR, moola, simoleanR, simoleans } = setup();
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   // Pack the contract.
   const bundle = await bundleSource(multipoolAutoswapRoot);
@@ -1270,7 +1270,7 @@ test('multipoolAutoSwap jig - swapOut', async t => {
 
 test('multipoolAutoSwap jig - swapOut uneven', async t => {
   const { moolaR, moola, simoleanR, simoleans } = setup();
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   // Pack the contract.
   const bundle = await bundleSource(multipoolAutoswapRoot);
@@ -1452,7 +1452,7 @@ test('multipoolAutoSwap jig - swapOut uneven', async t => {
 
 test('multipoolAutoSwap jig - removeLiquidity', async t => {
   const { moolaR, moola } = setup();
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   // Pack the contract.
   const bundle = await bundleSource(multipoolAutoswapRoot);
@@ -1564,7 +1564,7 @@ test('multipoolAutoSwap jig - removeLiquidity', async t => {
 
 test('multipoolAutoSwap jig - removeLiquidity ask for too much', async t => {
   const { moolaR, moola } = setup();
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   // Pack the contract.
   const bundle = await bundleSource(multipoolAutoswapRoot);
@@ -1660,7 +1660,7 @@ test('multipoolAutoSwap jig - removeLiquidity ask for too much', async t => {
 
 test('multipoolAutoSwap jig - remove all liquidity', async t => {
   const { moolaR, moola } = setup();
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   // Pack the contract.
   const bundle = await bundleSource(multipoolAutoswapRoot);
@@ -1755,7 +1755,7 @@ test('multipoolAutoSwap jig - remove all liquidity', async t => {
 
 test('multipoolAutoSwap jig - insufficient', async t => {
   const { moolaR, moola } = setup();
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   // Pack the contract.
   const bundle = await bundleSource(multipoolAutoswapRoot);
@@ -1849,7 +1849,7 @@ test('multipoolAutoSwap jig - insufficient', async t => {
 });
 
 test('multipoolAutoSwap collect empty fees', async t => {
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
   const centralR = makeIssuerKit('central');
   const centralTokens = value => AmountMath.make(value, centralR.brand);
 
@@ -1881,7 +1881,7 @@ test('multipoolAutoSwap collect empty fees', async t => {
 
 test('multipoolAutoSwap swapout secondary to secondary', async t => {
   const { moolaR, simoleanR, moola, simoleans } = setup();
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
   const invitationIssuer = zoe.getInvitationIssuer();
   const invitationBrand = await E(invitationIssuer).getBrand();
 

--- a/packages/zoe/test/unitTests/contracts/newSwap/test-newSwap-swap.js
+++ b/packages/zoe/test/unitTests/contracts/newSwap/test-newSwap-swap.js
@@ -11,7 +11,7 @@ import { assert, q } from '@agoric/assert';
 import fakeVatAdmin from '../../../../tools/fakeVatAdmin.js';
 
 // noinspection ES6PreferShortImport
-import { makeZoe } from '../../../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../../../src/zoeService/zoe.js';
 import { setup } from '../../setupBasicMints.js';
 import {
   makeTrader,
@@ -37,7 +37,7 @@ const newSwapRoot = `${dirname}/../../../../src/contracts/newSwap/multipoolAutos
 
 test('newSwap with valid offers', async t => {
   const { moolaR, simoleanR, moola, simoleans } = setup();
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
   const invitationIssuer = zoe.getInvitationIssuer();
   const invitationBrand = await E(invitationIssuer).getBrand();
 
@@ -390,7 +390,7 @@ test('newSwap with valid offers', async t => {
 
 test('newSwap doubleSwap', async t => {
   const { moolaR, simoleanR, moola, simoleans } = setup();
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   // Set up central token
   const centralR = makeIssuerKit('central');
@@ -611,7 +611,7 @@ test('newSwap doubleSwap', async t => {
 
 test('newSwap with some invalid offers', async t => {
   const { moolaR, moola } = setup();
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
   const invitationIssuer = zoe.getInvitationIssuer();
 
   // Set up central token
@@ -674,7 +674,7 @@ test('newSwap with some invalid offers', async t => {
 
 test('newSwap jig - swapOut uneven', async t => {
   const { moolaR, moola, simoleanR, simoleans } = setup();
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   // Pack the contract.
   const bundle = await bundleSource(newSwapRoot);
@@ -911,7 +911,7 @@ test('newSwap jig - swapOut uneven', async t => {
 
 test('newSwap jig - breaking scenario', async t => {
   const { moolaR, moola, simoleanR } = setup();
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   // Pack the contract.
   const bundle = await bundleSource(newSwapRoot);
@@ -1028,7 +1028,7 @@ test('newSwap jig - breaking scenario', async t => {
 // This demonstrates that Zoe can reallocate empty amounts. i.e. that
 // https://github.com/Agoric/agoric-sdk/issues/3033 stays fixed
 test('zoe allow empty reallocations', async t => {
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   // Set up central token
   const { issuer, brand } = makeIssuerKit('central');

--- a/packages/zoe/test/unitTests/contracts/newSwap/test-newSwap-swap.js
+++ b/packages/zoe/test/unitTests/contracts/newSwap/test-newSwap-swap.js
@@ -37,7 +37,7 @@ const newSwapRoot = `${dirname}/../../../../src/contracts/newSwap/multipoolAutos
 
 test('newSwap with valid offers', async t => {
   const { moolaR, simoleanR, moola, simoleans } = setup();
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
   const invitationIssuer = zoe.getInvitationIssuer();
   const invitationBrand = await E(invitationIssuer).getBrand();
 
@@ -390,7 +390,7 @@ test('newSwap with valid offers', async t => {
 
 test('newSwap doubleSwap', async t => {
   const { moolaR, simoleanR, moola, simoleans } = setup();
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
 
   // Set up central token
   const centralR = makeIssuerKit('central');
@@ -611,7 +611,7 @@ test('newSwap doubleSwap', async t => {
 
 test('newSwap with some invalid offers', async t => {
   const { moolaR, moola } = setup();
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
   const invitationIssuer = zoe.getInvitationIssuer();
 
   // Set up central token
@@ -674,7 +674,7 @@ test('newSwap with some invalid offers', async t => {
 
 test('newSwap jig - swapOut uneven', async t => {
   const { moolaR, moola, simoleanR, simoleans } = setup();
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
 
   // Pack the contract.
   const bundle = await bundleSource(newSwapRoot);
@@ -911,7 +911,7 @@ test('newSwap jig - swapOut uneven', async t => {
 
 test('newSwap jig - breaking scenario', async t => {
   const { moolaR, moola, simoleanR } = setup();
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
 
   // Pack the contract.
   const bundle = await bundleSource(newSwapRoot);
@@ -1028,7 +1028,7 @@ test('newSwap jig - breaking scenario', async t => {
 // This demonstrates that Zoe can reallocate empty amounts. i.e. that
 // https://github.com/Agoric/agoric-sdk/issues/3033 stays fixed
 test('zoe allow empty reallocations', async t => {
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
 
   // Set up central token
   const { issuer, brand } = makeIssuerKit('central');

--- a/packages/zoe/test/unitTests/contracts/newSwap/test-newswap-bug.js
+++ b/packages/zoe/test/unitTests/contracts/newSwap/test-newswap-bug.js
@@ -36,7 +36,7 @@ test('test bug scenario', async t => {
     AssetKind.NAT,
     harden({ decimalPlaces: 6 }),
   );
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
 
   // Pack the contract.
   const bundle = await bundleSource(multipoolAutoswapRoot);
@@ -123,7 +123,7 @@ const conductTrade = async (t, reduceWantOutBP = 30n) => {
     AssetKind.NAT,
     harden({ decimalPlaces: 6 }),
   );
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
 
   // Pack the contract.
   const bundle = await bundleSource(multipoolAutoswapRoot);

--- a/packages/zoe/test/unitTests/contracts/newSwap/test-newswap-bug.js
+++ b/packages/zoe/test/unitTests/contracts/newSwap/test-newswap-bug.js
@@ -9,7 +9,7 @@ import { makeIssuerKit, AmountMath, AssetKind } from '@agoric/ertp';
 import { E } from '@agoric/eventual-send';
 import fakeVatAdmin from '../../../../tools/fakeVatAdmin.js';
 
-import { makeZoe } from '../../../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../../../src/zoeService/zoe.js';
 import buildManualTimer from '../../../../tools/manualTimer.js';
 import {
   makeRatio,
@@ -36,7 +36,7 @@ test('test bug scenario', async t => {
     AssetKind.NAT,
     harden({ decimalPlaces: 6 }),
   );
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   // Pack the contract.
   const bundle = await bundleSource(multipoolAutoswapRoot);
@@ -123,7 +123,7 @@ const conductTrade = async (t, reduceWantOutBP = 30n) => {
     AssetKind.NAT,
     harden({ decimalPlaces: 6 }),
   );
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   // Pack the contract.
   const bundle = await bundleSource(multipoolAutoswapRoot);

--- a/packages/zoe/test/unitTests/contracts/test-brokenContract.js
+++ b/packages/zoe/test/unitTests/contracts/test-brokenContract.js
@@ -8,7 +8,7 @@ import path from 'path';
 import bundleSource from '@agoric/bundle-source';
 
 // noinspection ES6PreferShortImport
-import { makeZoe } from '../../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import { setup } from '../setupBasicMints.js';
 import fakeVatAdmin from '../../../tools/fakeVatAdmin.js';
 
@@ -21,7 +21,7 @@ test('zoe - brokenAutomaticRefund', async t => {
   t.plan(1);
   // Setup zoe and mints
   const { moolaR } = setup();
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
   // Pack the contract.
   const bundle = await bundleSource(automaticRefundRoot);
   const installation = await zoe.install(bundle);

--- a/packages/zoe/test/unitTests/contracts/test-brokenContract.js
+++ b/packages/zoe/test/unitTests/contracts/test-brokenContract.js
@@ -21,7 +21,7 @@ test('zoe - brokenAutomaticRefund', async t => {
   t.plan(1);
   // Setup zoe and mints
   const { moolaR } = setup();
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
   // Pack the contract.
   const bundle = await bundleSource(automaticRefundRoot);
   const installation = await zoe.install(bundle);

--- a/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
@@ -8,7 +8,7 @@ import path from 'path';
 import bundleSource from '@agoric/bundle-source';
 import { E } from '@agoric/eventual-send';
 
-import { makeZoe } from '../../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import { setup } from '../setupBasicMints.js';
 import fakeVatAdmin from '../../../tools/fakeVatAdmin.js';
 
@@ -20,7 +20,7 @@ const contractRoot = `${dirname}/escrowToVote.js`;
 test('zoe - escrowToVote', async t => {
   t.plan(14);
   const { moolaIssuer, moolaMint, moola } = setup();
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
@@ -20,7 +20,7 @@ const contractRoot = `${dirname}/escrowToVote.js`;
 test('zoe - escrowToVote', async t => {
   t.plan(14);
   const { moolaIssuer, moolaMint, moola } = setup();
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/contracts/test-mintPayments.js
+++ b/packages/zoe/test/unitTests/contracts/test-mintPayments.js
@@ -19,7 +19,7 @@ const mintPaymentsRoot = `${dirname}/../../../src/contracts/mintPayments.js`;
 
 test('zoe - mint payments', async t => {
   t.plan(2);
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
 
   const makeAlice = () => {
     return {
@@ -87,7 +87,7 @@ test('zoe - mint payments', async t => {
 
 test('zoe - mint payments with unrelated give and want', async t => {
   t.plan(3);
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
   const moolaKit = makeIssuerKit('moola');
   const simoleanKit = makeIssuerKit('simolean');
 

--- a/packages/zoe/test/unitTests/contracts/test-mintPayments.js
+++ b/packages/zoe/test/unitTests/contracts/test-mintPayments.js
@@ -10,7 +10,7 @@ import { makeIssuerKit, AmountMath } from '@agoric/ertp';
 import fakeVatAdmin from '../../../tools/fakeVatAdmin.js';
 
 // noinspection ES6PreferShortImport
-import { makeZoe } from '../../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 
 const filename = new URL(import.meta.url).pathname;
 const dirname = path.dirname(filename);
@@ -19,7 +19,7 @@ const mintPaymentsRoot = `${dirname}/../../../src/contracts/mintPayments.js`;
 
 test('zoe - mint payments', async t => {
   t.plan(2);
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   const makeAlice = () => {
     return {
@@ -87,7 +87,7 @@ test('zoe - mint payments', async t => {
 
 test('zoe - mint payments with unrelated give and want', async t => {
   t.plan(3);
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
   const moolaKit = makeIssuerKit('moola');
   const simoleanKit = makeIssuerKit('simolean');
 

--- a/packages/zoe/test/unitTests/contracts/test-oracle.js
+++ b/packages/zoe/test/unitTests/contracts/test-oracle.js
@@ -12,7 +12,7 @@ import { assert, details as X } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
 
 import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
-import { makeZoe } from '../../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 
 import '../../../exported.js';
 import '../../../src/contracts/exported.js';
@@ -37,7 +37,7 @@ test.before(
   /** @param {ExecutionContext} ot */ async ot => {
     // Outside of tests, we should use the long-lived Zoe on the
     // testnet. In this test, we must create a new Zoe.
-    const { zoeService: zoe } = makeZoe(makeFakeVatAdmin().admin);
+    const { zoeService: zoe } = makeZoeKit(makeFakeVatAdmin().admin);
 
     // Pack the contract.
     const contractBundle = await bundleSource(contractPath);

--- a/packages/zoe/test/unitTests/contracts/test-oracle.js
+++ b/packages/zoe/test/unitTests/contracts/test-oracle.js
@@ -37,7 +37,7 @@ test.before(
   /** @param {ExecutionContext} ot */ async ot => {
     // Outside of tests, we should use the long-lived Zoe on the
     // testnet. In this test, we must create a new Zoe.
-    const zoe = makeZoe(makeFakeVatAdmin().admin);
+    const { zoeService: zoe } = makeZoe(makeFakeVatAdmin().admin);
 
     // Pack the contract.
     const contractBundle = await bundleSource(contractPath);

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
@@ -13,7 +13,7 @@ import { makePromiseKit } from '@agoric/promise-kit';
 
 import { assert } from '@agoric/assert';
 import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
-import { makeZoe } from '../../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import buildManualTimer from '../../../tools/manualTimer.js';
 
 import '../../../exported.js';
@@ -48,7 +48,7 @@ test.before(
   /** @param {ExecutionContext} ot */ async ot => {
     // Outside of tests, we should use the long-lived Zoe on the
     // testnet. In this test, we must create a new Zoe.
-    const { zoeService: zoe } = makeZoe(makeFakeVatAdmin().admin);
+    const { zoeService: zoe } = makeZoeKit(makeFakeVatAdmin().admin);
 
     // Pack the contracts.
     const oracleBundle = await bundleSource(oraclePath);

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
@@ -48,7 +48,7 @@ test.before(
   /** @param {ExecutionContext} ot */ async ot => {
     // Outside of tests, we should use the long-lived Zoe on the
     // testnet. In this test, we must create a new Zoe.
-    const zoe = makeZoe(makeFakeVatAdmin().admin);
+    const { zoeService: zoe } = makeZoe(makeFakeVatAdmin().admin);
 
     // Pack the contracts.
     const oracleBundle = await bundleSource(oraclePath);

--- a/packages/zoe/test/unitTests/contracts/test-secondPriceAuction.js
+++ b/packages/zoe/test/unitTests/contracts/test-secondPriceAuction.js
@@ -245,7 +245,7 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
 test('zoe - secondPriceAuction - alice tries to exit', async t => {
   t.plan(12);
   const { moolaR, simoleanR, moola, simoleans } = setup();
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
 
   // Setup Alice
   const aliceMoolaPayment = moolaR.mint.mintPayment(moola(1));

--- a/packages/zoe/test/unitTests/contracts/test-secondPriceAuction.js
+++ b/packages/zoe/test/unitTests/contracts/test-secondPriceAuction.js
@@ -9,7 +9,7 @@ import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 
 // noinspection ES6PreferShortImport
-import { makeZoe } from '../../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import buildManualTimer from '../../../tools/manualTimer.js';
 import { setup } from '../setupBasicMints.js';
 import { setupMixed } from '../setupMixedMints.js';
@@ -245,7 +245,7 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
 test('zoe - secondPriceAuction - alice tries to exit', async t => {
   t.plan(12);
   const { moolaR, simoleanR, moola, simoleans } = setup();
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   // Setup Alice
   const aliceMoolaPayment = moolaR.mint.mintPayment(moola(1));

--- a/packages/zoe/test/unitTests/contracts/test-sellTickets.js
+++ b/packages/zoe/test/unitTests/contracts/test-sellTickets.js
@@ -12,7 +12,7 @@ import { E } from '@agoric/eventual-send';
 import fakeVatAdmin from '../../../tools/fakeVatAdmin.js';
 
 // noinspection ES6PreferShortImport
-import { makeZoe } from '../../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import { defaultAcceptanceMsg } from '../../../src/contractSupport/index.js';
 
 const filename = new URL(import.meta.url).pathname;
@@ -23,7 +23,7 @@ const sellItemsRoot = `${dirname}/../../../src/contracts/sellItems.js`;
 
 test(`mint and sell tickets for multiple shows`, async t => {
   // Setup initial conditions
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   const mintAndSellNFTBundle = await bundleSource(mintAndSellNFTRoot);
   const mintAndSellNFTInstallation = await E(zoe).install(mintAndSellNFTBundle);
@@ -147,7 +147,7 @@ test(`mint and sell opera tickets`, async t => {
 
   const moola = value => AmountMath.make(value, moolaBrand);
 
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   const mintAndSellNFTBundle = await bundleSource(mintAndSellNFTRoot);
   const mintAndSellNFTInstallation = await E(zoe).install(mintAndSellNFTBundle);
@@ -541,7 +541,7 @@ test(`mint and sell opera tickets`, async t => {
 //
 test('Testing publicFacet.getAvailableItemsNotifier()', async t => {
   // Setup initial conditions
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   const mintAndSellNFTBundle = await bundleSource(mintAndSellNFTRoot);
   const mintAndSellNFTInstallation = await E(zoe).install(mintAndSellNFTBundle);

--- a/packages/zoe/test/unitTests/contracts/test-sellTickets.js
+++ b/packages/zoe/test/unitTests/contracts/test-sellTickets.js
@@ -23,7 +23,7 @@ const sellItemsRoot = `${dirname}/../../../src/contracts/sellItems.js`;
 
 test(`mint and sell tickets for multiple shows`, async t => {
   // Setup initial conditions
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
 
   const mintAndSellNFTBundle = await bundleSource(mintAndSellNFTRoot);
   const mintAndSellNFTInstallation = await E(zoe).install(mintAndSellNFTBundle);
@@ -147,7 +147,7 @@ test(`mint and sell opera tickets`, async t => {
 
   const moola = value => AmountMath.make(value, moolaBrand);
 
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
 
   const mintAndSellNFTBundle = await bundleSource(mintAndSellNFTRoot);
   const mintAndSellNFTInstallation = await E(zoe).install(mintAndSellNFTBundle);
@@ -541,7 +541,7 @@ test(`mint and sell opera tickets`, async t => {
 //
 test('Testing publicFacet.getAvailableItemsNotifier()', async t => {
   // Setup initial conditions
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
 
   const mintAndSellNFTBundle = await bundleSource(mintAndSellNFTRoot);
   const mintAndSellNFTInstallation = await E(zoe).install(mintAndSellNFTBundle);

--- a/packages/zoe/test/unitTests/contracts/test-throwInOfferHandler.js
+++ b/packages/zoe/test/unitTests/contracts/test-throwInOfferHandler.js
@@ -7,7 +7,7 @@ import path from 'path';
 import bundleSource from '@agoric/bundle-source';
 
 import { E } from '@agoric/eventual-send';
-import { makeZoe } from '../../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import fakeVatAdmin from '../../../tools/fakeVatAdmin.js';
 
 const filename = new URL(import.meta.url).pathname;
@@ -16,7 +16,7 @@ const dirname = path.dirname(filename);
 const contractRoot = `${dirname}/throwInOfferHandler.js`;
 
 test('throw in offerHandler', async t => {
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/contracts/test-throwInOfferHandler.js
+++ b/packages/zoe/test/unitTests/contracts/test-throwInOfferHandler.js
@@ -16,7 +16,7 @@ const dirname = path.dirname(filename);
 const contractRoot = `${dirname}/throwInOfferHandler.js`;
 
 test('throw in offerHandler', async t => {
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/contracts/test-useObj.js
+++ b/packages/zoe/test/unitTests/contracts/test-useObj.js
@@ -20,7 +20,7 @@ const contractRoot = `${dirname}/useObjExample.js`;
 test('zoe - useObj', async t => {
   t.plan(3);
   const { moolaIssuer, moolaMint, moola } = setup();
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/contracts/test-useObj.js
+++ b/packages/zoe/test/unitTests/contracts/test-useObj.js
@@ -8,7 +8,7 @@ import bundleSource from '@agoric/bundle-source';
 
 // noinspection ES6PreferShortImport
 import { E } from '@agoric/eventual-send';
-import { makeZoe } from '../../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import { setup } from '../setupBasicMints.js';
 import fakeVatAdmin from '../../../tools/fakeVatAdmin.js';
 
@@ -20,7 +20,7 @@ const contractRoot = `${dirname}/useObjExample.js`;
 test('zoe - useObj', async t => {
   t.plan(3);
   const { moolaIssuer, moolaMint, moola } = setup();
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/setupBasicMints.js
+++ b/packages/zoe/test/unitTests/setupBasicMints.js
@@ -2,7 +2,7 @@
 
 import { makeIssuerKit, AmountMath } from '@agoric/ertp';
 import { makeStore } from '@agoric/store';
-import { makeZoe } from '../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../src/zoeService/zoe.js';
 import fakeVatAdmin from '../../tools/fakeVatAdmin.js';
 
 const setup = () => {
@@ -21,7 +21,7 @@ const setup = () => {
     brands.init(k, allBundles[k].brand);
   }
 
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   const makeSimpleMake = brand => value => AmountMath.make(value, brand);
 

--- a/packages/zoe/test/unitTests/setupBasicMints.js
+++ b/packages/zoe/test/unitTests/setupBasicMints.js
@@ -21,7 +21,7 @@ const setup = () => {
     brands.init(k, allBundles[k].brand);
   }
 
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
 
   const makeSimpleMake = brand => value => AmountMath.make(value, brand);
 

--- a/packages/zoe/test/unitTests/setupMixedMints.js
+++ b/packages/zoe/test/unitTests/setupMixedMints.js
@@ -25,7 +25,7 @@ const setupMixed = () => {
   const cryptoCats = value => AmountMath.make(value, allBundles.cc.brand);
   const moola = value => AmountMath.make(value, allBundles.moola.brand);
 
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
   return {
     zoe,
     ccIssuer,

--- a/packages/zoe/test/unitTests/setupMixedMints.js
+++ b/packages/zoe/test/unitTests/setupMixedMints.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { makeIssuerKit, AmountMath, AssetKind } from '@agoric/ertp';
-import { makeZoe } from '../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../src/zoeService/zoe.js';
 import fakeVatAdmin from '../../tools/fakeVatAdmin.js';
 
 const setupMixed = () => {
@@ -25,7 +25,7 @@ const setupMixed = () => {
   const cryptoCats = value => AmountMath.make(value, allBundles.cc.brand);
   const moola = value => AmountMath.make(value, allBundles.moola.brand);
 
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
   return {
     zoe,
     ccIssuer,

--- a/packages/zoe/test/unitTests/setupNonFungibleMints.js
+++ b/packages/zoe/test/unitTests/setupNonFungibleMints.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { makeIssuerKit, AmountMath, AssetKind } from '@agoric/ertp';
-import { makeZoe } from '../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../src/zoeService/zoe.js';
 import fakeVatAdmin from '../../tools/fakeVatAdmin.js';
 
 const setupNonFungible = () => {
@@ -21,7 +21,7 @@ const setupNonFungible = () => {
   function createRpgItem(name, power, desc = undefined) {
     return harden([{ name, description: desc || name, power }]);
   }
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   const ccIssuer = issuers.get('cc');
   const rpgIssuer = issuers.get('rpg');

--- a/packages/zoe/test/unitTests/setupNonFungibleMints.js
+++ b/packages/zoe/test/unitTests/setupNonFungibleMints.js
@@ -21,7 +21,7 @@ const setupNonFungible = () => {
   function createRpgItem(name, power, desc = undefined) {
     return harden([{ name, description: desc || name, power }]);
   }
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
 
   const ccIssuer = issuers.get('cc');
   const rpgIssuer = issuers.get('rpg');

--- a/packages/zoe/test/unitTests/test-makeKind.js
+++ b/packages/zoe/test/unitTests/test-makeKind.js
@@ -18,7 +18,7 @@ const root = `${dirname}/../minimalMakeKindContract.js`;
 
 test('makeKind non-swingset', async t => {
   const bundle = await bundleSource(root);
-  const zoe = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
   const installation = await E(zoe).install(bundle);
   t.notThrows(() => makeKind());
   t.notThrows(() => makeVirtualScalarWeakMap());

--- a/packages/zoe/test/unitTests/test-makeKind.js
+++ b/packages/zoe/test/unitTests/test-makeKind.js
@@ -8,7 +8,7 @@ import path from 'path';
 import bundleSource from '@agoric/bundle-source';
 
 import { E } from '@agoric/eventual-send';
-import { makeZoe } from '../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../src/zoeService/zoe.js';
 import fakeVatAdmin from '../../tools/fakeVatAdmin.js';
 
 const filename = new URL(import.meta.url).pathname;
@@ -18,7 +18,7 @@ const root = `${dirname}/../minimalMakeKindContract.js`;
 
 test('makeKind non-swingset', async t => {
   const bundle = await bundleSource(root);
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
   const installation = await E(zoe).install(bundle);
   t.notThrows(() => makeKind());
   t.notThrows(() => makeVirtualScalarWeakMap());

--- a/packages/zoe/test/unitTests/test-scriptedOracle.js
+++ b/packages/zoe/test/unitTests/test-scriptedOracle.js
@@ -44,7 +44,7 @@ test.before(
   /** @param {ExecutionContext} ot */ async ot => {
     // Outside of tests, we should use the long-lived Zoe on the
     // testnet. In this test, we must create a new Zoe.
-    const zoe = makeZoe(makeFakeVatAdmin().admin);
+    const { zoeService: zoe } = makeZoe(makeFakeVatAdmin().admin);
 
     const oracleContractBundle = await bundleSource(oracleContractPath);
     const bountyContractBundle = await bundleSource(bountyContractPath);

--- a/packages/zoe/test/unitTests/test-scriptedOracle.js
+++ b/packages/zoe/test/unitTests/test-scriptedOracle.js
@@ -10,7 +10,7 @@ import { E } from '@agoric/eventual-send';
 
 import { assert } from '@agoric/assert';
 import { makeFakeVatAdmin } from '../../tools/fakeVatAdmin.js';
-import { makeZoe } from '../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../src/zoeService/zoe.js';
 
 import '../../exported.js';
 import '../../src/contracts/exported.js';
@@ -44,7 +44,7 @@ test.before(
   /** @param {ExecutionContext} ot */ async ot => {
     // Outside of tests, we should use the long-lived Zoe on the
     // testnet. In this test, we must create a new Zoe.
-    const { zoeService: zoe } = makeZoe(makeFakeVatAdmin().admin);
+    const { zoeService: zoe } = makeZoeKit(makeFakeVatAdmin().admin);
 
     const oracleContractBundle = await bundleSource(oracleContractPath);
     const bountyContractBundle = await bundleSource(bountyContractPath);

--- a/packages/zoe/test/unitTests/zcf/registerFeeMintContract.js
+++ b/packages/zoe/test/unitTests/zcf/registerFeeMintContract.js
@@ -1,0 +1,41 @@
+// @ts-check
+
+import { AmountMath } from '@agoric/ertp';
+import { E } from '@agoric/eventual-send';
+
+/**
+ * Tests zcf.registerFeeMint
+ *
+ * @type {ContractStartFn}
+ */
+const start = async (zcf, privateArgs) => {
+  // make the `zcf` and `instance` available to the tests
+  const instance = zcf.getInstance();
+  zcf.setTestJig(() => harden({ instance }));
+
+  const RUNZCFMint = await zcf.registerFeeMint(
+    'RUN',
+    privateArgs.feeMintAccess,
+  );
+  const { brand: RUNBrand } = RUNZCFMint.getIssuerRecord();
+  const { zcfSeat, userSeat } = zcf.makeEmptySeatKit();
+  RUNZCFMint.mintGains(
+    {
+      Winnings: AmountMath.make(RUNBrand, 10n),
+    },
+    zcfSeat,
+  );
+
+  const creatorFacet = harden({
+    getMintedAmount: () => zcfSeat.getAmountAllocated('Winnings'),
+    getMintedPayout: () => {
+      zcfSeat.exit();
+      return E(userSeat).getPayout('Winnings');
+    },
+  });
+
+  return harden({ creatorFacet });
+};
+
+harden(start);
+export { start };

--- a/packages/zoe/test/unitTests/zcf/setupZcfTest.js
+++ b/packages/zoe/test/unitTests/zcf/setupZcfTest.js
@@ -23,7 +23,7 @@ export const setupZCFTest = async (issuerKeywordRecord, terms) => {
   };
   // The contract provides the `zcf` via `setTestJig` upon `start`.
   const fakeVatAdmin = makeFakeVatAdmin(setZCF);
-  const zoe = makeZoe(fakeVatAdmin.admin);
+  const { zoeService: zoe } = makeZoe(fakeVatAdmin.admin);
   const bundle = await bundleSource(contractRoot);
   const installation = await E(zoe).install(bundle);
   const { creatorFacet, instance } = await E(zoe).startInstance(

--- a/packages/zoe/test/unitTests/zcf/setupZcfTest.js
+++ b/packages/zoe/test/unitTests/zcf/setupZcfTest.js
@@ -7,7 +7,7 @@ import { assert } from '@agoric/assert';
 import path from 'path';
 
 // noinspection ES6PreferShortImport
-import { makeZoe } from '../../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
 
 const filename = new URL(import.meta.url).pathname;
@@ -23,7 +23,7 @@ export const setupZCFTest = async (issuerKeywordRecord, terms) => {
   };
   // The contract provides the `zcf` via `setTestJig` upon `start`.
   const fakeVatAdmin = makeFakeVatAdmin(setZCF);
-  const { zoeService: zoe } = makeZoe(fakeVatAdmin.admin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin.admin);
   const bundle = await bundleSource(contractRoot);
   const installation = await E(zoe).install(bundle);
   const { creatorFacet, instance } = await E(zoe).startInstance(

--- a/packages/zoe/test/unitTests/zcf/test-feeMintAccess.js
+++ b/packages/zoe/test/unitTests/zcf/test-feeMintAccess.js
@@ -11,7 +11,7 @@ import { AmountMath } from '@agoric/ertp';
 import bundleSource from '@agoric/bundle-source';
 
 // noinspection ES6PreferShortImport
-import { makeZoe } from '../../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import fakeVatAdmin from '../../../tools/fakeVatAdmin.js';
 
 const filename = new URL(import.meta.url).pathname;
@@ -20,7 +20,7 @@ const dirname = path.dirname(filename);
 const contractRoot = `${dirname}/registerFeeMintContract.js`;
 
 test(`feeMintAccess`, async t => {
-  const { zoeService: zoe, feeMintAccess } = makeZoe(fakeVatAdmin);
+  const { zoeService: zoe, feeMintAccess } = makeZoeKit(fakeVatAdmin);
   const bundle = await bundleSource(contractRoot);
   const installation = await E(zoe).install(bundle);
   const { creatorFacet } = await E(zoe).startInstance(

--- a/packages/zoe/test/unitTests/zcf/test-feeMintAccess.js
+++ b/packages/zoe/test/unitTests/zcf/test-feeMintAccess.js
@@ -1,0 +1,41 @@
+// @ts-check
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+
+import path from 'path';
+
+import { E } from '@agoric/eventual-send';
+import { AmountMath } from '@agoric/ertp';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import bundleSource from '@agoric/bundle-source';
+
+// noinspection ES6PreferShortImport
+import { makeZoe } from '../../../src/zoeService/zoe.js';
+import fakeVatAdmin from '../../../tools/fakeVatAdmin.js';
+
+const filename = new URL(import.meta.url).pathname;
+const dirname = path.dirname(filename);
+
+const contractRoot = `${dirname}/registerFeeMintContract.js`;
+
+test(`feeMintAccess`, async t => {
+  const { zoeService: zoe, feeMintAccess } = makeZoe(fakeVatAdmin);
+  const bundle = await bundleSource(contractRoot);
+  const installation = await E(zoe).install(bundle);
+  const { creatorFacet } = await E(zoe).startInstance(
+    installation,
+    undefined,
+    undefined,
+    harden({ feeMintAccess }),
+  );
+  const mintedAmount = await E(creatorFacet).getMintedAmount();
+  const feeIssuer = E(zoe).getFeeIssuer();
+  const feeBrand = await E(feeIssuer).getBrand();
+  t.true(AmountMath.isEqual(mintedAmount, AmountMath.make(feeBrand, 10n)));
+
+  const mintedPayment = await E(creatorFacet).getMintedPayout();
+  const mintedAmount2 = await E(feeIssuer).getAmountOf(mintedPayment);
+
+  t.true(AmountMath.isEqual(mintedAmount2, AmountMath.make(feeBrand, 10n)));
+});

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat-exit.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat-exit.js
@@ -29,7 +29,7 @@ test(`zoe - wrongly throw zcfSeat.exit()`, async t => {
     testJig = jig;
   };
   const { admin: fakeVatAdminSvc, vatAdminState } = makeFakeVatAdmin(setJig);
-  const zoe = makeZoe(fakeVatAdminSvc);
+  const { zoeService: zoe } = makeZoe(fakeVatAdminSvc);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat-exit.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat-exit.js
@@ -8,7 +8,7 @@ import { E } from '@agoric/eventual-send';
 import bundleSource from '@agoric/bundle-source';
 
 // noinspection ES6PreferShortImport
-import { makeZoe } from '../../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import { setup } from '../setupBasicMints.js';
 import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
 
@@ -29,7 +29,7 @@ test(`zoe - wrongly throw zcfSeat.exit()`, async t => {
     testJig = jig;
   };
   const { admin: fakeVatAdminSvc, vatAdminState } = makeFakeVatAdmin(setJig);
-  const { zoeService: zoe } = makeZoe(fakeVatAdminSvc);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdminSvc);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
@@ -26,7 +26,7 @@ test(`zoe - zcfSeat.fail() doesn't throw`, async t => {
     testJig = jig;
   };
   const { admin: fakeVatAdminSvc, vatAdminState } = makeFakeVatAdmin(setJig);
-  const zoe = makeZoe(fakeVatAdminSvc);
+  const { zoeService: zoe } = makeZoe(fakeVatAdminSvc);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
@@ -8,7 +8,7 @@ import { E } from '@agoric/eventual-send';
 import bundleSource from '@agoric/bundle-source';
 
 // noinspection ES6PreferShortImport
-import { makeZoe } from '../../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import { setup } from '../setupBasicMints.js';
 import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
 
@@ -26,7 +26,7 @@ test(`zoe - zcfSeat.fail() doesn't throw`, async t => {
     testJig = jig;
   };
   const { admin: fakeVatAdminSvc, vatAdminState } = makeFakeVatAdmin(setJig);
-  const { zoeService: zoe } = makeZoe(fakeVatAdminSvc);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdminSvc);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/zcf/zcfTesterContract.js
+++ b/packages/zoe/test/unitTests/zcf/zcfTesterContract.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-import { E } from '@agoric/eventual-send';
 import '../../../exported.js';
 
 /**
@@ -10,10 +9,9 @@ import '../../../exported.js';
  */
 const start = async zcf => {
   // make the `zcf` and `instance` available to the tests
-  const invitation = zcf.makeInvitation(() => {}, 'test');
-  const zoe = zcf.getZoeService();
-  const { instance } = await E(zoe).getInvitationDetails(invitation);
+  const instance = zcf.getInstance();
   zcf.setTestJig(() => harden({ instance }));
+
   return {};
 };
 


### PR DESCRIPTION
This PR creates the RUN issuerKit within Zoe instead of the Treasury contract. `makeZoe` returns the Zoe Service and a handle that can be passed into a contract, to register a ZCFMint for RUN. This is to give the Treasury access to a ZCFMint for the RUN Mint, without actually exposing the RUN Mint. 

Note that a method had to be added to `zcf`: `registerFeeMint`. 

Closes #3520 

Stacked on #3319. 