### PR TITLE
exclude liveslots deserialization code from metering

### DIFF
--- a/packages/SwingSet/src/kernel/dummyMeterControl.js
+++ b/packages/SwingSet/src/kernel/dummyMeterControl.js
@@ -1,0 +1,55 @@
+// @ts-check
+import { assert } from '@agoric/assert';
+
+export function makeDummyMeterControl() {
+  let meteringDisabled = 0;
+
+  function isMeteringDisabled() {
+    return !!meteringDisabled;
+  }
+
+  function assertIsMetered(msg) {
+    assert(!meteringDisabled, msg);
+  }
+
+  function assertNotMetered(msg) {
+    assert(!!meteringDisabled, msg);
+  }
+
+  function runWithoutMetering(thunk) {
+    meteringDisabled += 1;
+    try {
+      return thunk();
+    } finally {
+      meteringDisabled -= 1;
+    }
+  }
+
+  async function runWithoutMeteringAsync(thunk) {
+    meteringDisabled += 1;
+    try {
+      return await thunk();
+    } finally {
+      meteringDisabled -= 1;
+    }
+  }
+
+  // return a version of f that runs outside metering
+  function unmetered(f) {
+    function wrapped(...args) {
+      return runWithoutMetering(() => f(...args));
+    }
+    return harden(wrapped);
+  }
+
+  /** @type { MeterControl } */
+  const meterControl = {
+    isMeteringDisabled,
+    assertIsMetered,
+    assertNotMetered,
+    runWithoutMetering,
+    runWithoutMeteringAsync,
+    unmetered,
+  };
+  return harden(meterControl);
+}

--- a/packages/SwingSet/src/kernel/dummyMeterControl.js
+++ b/packages/SwingSet/src/kernel/dummyMeterControl.js
@@ -27,11 +27,11 @@ export function makeDummyMeterControl() {
 
   async function runWithoutMeteringAsync(thunk) {
     meteringDisabled += 1;
-    try {
-      return await thunk();
-    } finally {
-      meteringDisabled -= 1;
-    }
+    return Promise.resolve()
+      .then(() => thunk())
+      .finally(() => {
+        meteringDisabled -= 1;
+      });
   }
 
   // return a version of f that runs outside metering

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -16,6 +16,7 @@ import { insistMessage, insistVatDeliveryResult } from '../message.js';
 import { insistDeviceID, insistVatID } from './id.js';
 import { makeKernelSyscallHandler, doSend } from './kernelSyscall.js';
 import { makeSlogger, makeDummySlogger } from './slogger.js';
+import { makeDummyMeterControl } from './dummyMeterControl.js';
 import { getKpidsToRetire } from './cleanup.js';
 import { processNextGCAction } from './gc-actions.js';
 
@@ -812,6 +813,7 @@ export default function buildKernel(
     FinalizationRegistry,
     waitUntilQuiescent,
     gcAndFinalize,
+    meterControl: makeDummyMeterControl(),
   });
   const vatManagerFactory = makeVatManagerFactory({
     allVatPowers,

--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -465,7 +465,8 @@ function build(
       if (type === 'object') {
         // Set.delete() metering seems unaffected by presence/absence, but it
         // doesn't matter anyway because deadSet.add only happens when
-        // finializers run, which happens deterministically
+        // finializers run, and we wrote xsnap.c to ensure they only run
+        // deterministically (during gcAndFinalize)
         deadSet.delete(slot);
         droppedRegistry.register(val, slot, val);
       }

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-nodeworker.js
@@ -13,6 +13,7 @@ import engineGC from '../../engine-gc.js';
 import { WeakRef, FinalizationRegistry } from '../../weakref.js';
 import { makeGcAndFinalize } from '../../gc-and-finalize.js';
 import { waitUntilQuiescent } from '../../waitUntilQuiescent.js';
+import { makeDummyMeterControl } from '../dummyMeterControl.js';
 import { makeLiveSlots } from '../liveSlots.js';
 import {
   makeSupervisorDispatch,
@@ -70,11 +71,13 @@ parentPort.on('message', ([type, ...margs]) => {
       makeMarshal,
       testLog,
     };
+
     const gcTools = harden({
       WeakRef,
       FinalizationRegistry,
       waitUntilQuiescent,
       gcAndFinalize: makeGcAndFinalize(engineGC),
+      meterControl: makeDummyMeterControl(),
     });
     const ls = makeLiveSlots(
       syscall,

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-node.js
@@ -10,6 +10,7 @@ import { makeMarshal } from '@agoric/marshal';
 import engineGC from '../../engine-gc.js';
 import { WeakRef, FinalizationRegistry } from '../../weakref.js';
 import { makeGcAndFinalize } from '../../gc-and-finalize.js';
+import { makeDummyMeterControl } from '../dummyMeterControl.js';
 import {
   arrayEncoderStream,
   arrayDecoderStream,
@@ -86,11 +87,13 @@ fromParent.on('data', ([type, ...margs]) => {
       makeMarshal,
       testLog,
     };
+
     const gcTools = harden({
       WeakRef,
       FinalizationRegistry,
       waitUntilQuiescent,
       gcAndFinalize: makeGcAndFinalize(engineGC),
+      meterControl: makeDummyMeterControl(),
     });
     const ls = makeLiveSlots(
       syscall,

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-subprocess-xsnap.js
@@ -60,12 +60,12 @@ function makeMeterControl() {
     const limit = globalThis.currentMeterLimit();
     const before = globalThis.resetMeter(0, 0);
     meteringDisabled += 1;
-    try {
-      return await thunk();
-    } finally {
-      globalThis.resetMeter(limit, before);
-      meteringDisabled -= 1;
-    }
+    return Promise.resolve()
+      .then(() => thunk())
+      .finally(() => {
+        globalThis.resetMeter(limit, before);
+        meteringDisabled -= 1;
+      });
   }
 
   // return a version of f that runs outside metering

--- a/packages/SwingSet/src/types.js
+++ b/packages/SwingSet/src/types.js
@@ -201,3 +201,20 @@
  *              crankFailed: (details: {}) => PolicyOutput,
  *             } } RunPolicy
  */
+
+/**
+ * The MeterControl object gives liveslots a mechanism to disable metering for certain GC-sensitive
+ * regions of code. Only the XS worker can actually do metering, but we track the enabled/disabled
+ * status on all workers, so that the assertions can be exercised more thoroughly (via non-XS unit
+ * tests). MeterControl.isMeteringDisabled()===false does not mean metering is happening, it just
+ * means that MeterControl isn't disabling it.
+ *
+ * @typedef {Object} MeterControl
+ * @property {() => boolean} isMeteringDisabled Ask whether metering is currently disabled.
+ * @property {*} assertIsMetered
+ * @property {*} assertNotMetered
+ * @property {*} runWithoutMetering Run a callback outside metering
+ * @property {*} runWithoutMeteringAsync Run an async callback outside metering
+ * @property {*} unmetered Wrap a callback with runWithoutMetering
+ *
+ */

--- a/packages/SwingSet/test/liveslots-helpers.js
+++ b/packages/SwingSet/test/liveslots-helpers.js
@@ -3,6 +3,7 @@ import engineGC from '../src/engine-gc.js';
 import { WeakRef, FinalizationRegistry } from '../src/weakref.js';
 import { waitUntilQuiescent } from '../src/waitUntilQuiescent.js';
 import { makeGcAndFinalize } from '../src/gc-and-finalize.js';
+import { makeDummyMeterControl } from '../src/kernel/dummyMeterControl.js';
 import { makeLiveSlots } from '../src/kernel/liveSlots.js';
 
 export function buildSyscall() {
@@ -46,6 +47,7 @@ export function makeDispatch(
     FinalizationRegistry,
     waitUntilQuiescent,
     gcAndFinalize: makeGcAndFinalize(engineGC),
+    meterControl: makeDummyMeterControl(),
   });
   const { setBuildRootObject, dispatch } = makeLiveSlots(
     syscall,

--- a/packages/SwingSet/test/test-liveslots.js
+++ b/packages/SwingSet/test/test-liveslots.js
@@ -9,6 +9,7 @@ import { assert, details as X } from '@agoric/assert';
 import engineGC from '../src/engine-gc.js';
 import { waitUntilQuiescent } from '../src/waitUntilQuiescent.js';
 import { makeGcAndFinalize } from '../src/gc-and-finalize.js';
+import { makeDummyMeterControl } from '../src/kernel/dummyMeterControl.js';
 import { makeLiveSlots } from '../src/kernel/liveSlots.js';
 import { buildSyscall, makeDispatch } from './liveslots-helpers.js';
 import {
@@ -906,6 +907,7 @@ function makeMockGC() {
     getAllFRs,
     waitUntilQuiescent,
     gcAndFinalize: mockGCAndFinalize,
+    meterControl: makeDummyMeterControl(),
   });
 }
 

--- a/packages/SwingSet/test/test-marshal.js
+++ b/packages/SwingSet/test/test-marshal.js
@@ -9,8 +9,6 @@ import { WeakRef, FinalizationRegistry } from '../src/weakref.js';
 import { makeDummyMeterControl } from '../src/kernel/dummyMeterControl.js';
 import { makeMarshaller } from '../src/kernel/liveSlots.js';
 
-import { buildVatController } from '../src/index.js';
-
 const gcTools = harden({
   WeakRef,
   FinalizationRegistry,
@@ -21,12 +19,6 @@ function makeUnmeteredMarshaller(syscall) {
   const { m } = makeMarshaller(syscall, gcTools);
   const unmeteredUnserialize = gcTools.meterControl.unmetered(m.unserialize);
   return { m, unmeteredUnserialize };
-}
-
-async function prep() {
-  const config = {};
-  const controller = await buildVatController(config);
-  await controller.run();
 }
 
 test('serialize exports', t => {
@@ -56,7 +48,6 @@ test('serialize exports', t => {
 });
 
 test('deserialize imports', async t => {
-  await prep();
   const { unmeteredUnserialize } = makeUnmeteredMarshaller(undefined);
   const a = unmeteredUnserialize({
     body: '{"@qclass":"slot","index":0}',
@@ -93,7 +84,6 @@ test('deserialize exports', t => {
 });
 
 test('serialize imports', async t => {
-  await prep();
   const { m, unmeteredUnserialize } = makeUnmeteredMarshaller(undefined);
   const a = unmeteredUnserialize({
     body: '{"@qclass":"slot","index":0}',
@@ -144,7 +134,6 @@ test('serialize promise', async t => {
 });
 
 test('unserialize promise', async t => {
-  await prep();
   const log = [];
   const syscall = {
     subscribe(promiseID) {

--- a/packages/SwingSet/test/test-marshal.js
+++ b/packages/SwingSet/test/test-marshal.js
@@ -6,11 +6,16 @@ import { Far } from '@agoric/marshal';
 import { makePromiseKit } from '@agoric/promise-kit';
 
 import { WeakRef, FinalizationRegistry } from '../src/weakref.js';
+import { makeDummyMeterControl } from '../src/kernel/dummyMeterControl.js';
 import { makeMarshaller } from '../src/kernel/liveSlots.js';
 
 import { buildVatController } from '../src/index.js';
 
-const gcTools = harden({ WeakRef, FinalizationRegistry });
+const gcTools = harden({
+  WeakRef,
+  FinalizationRegistry,
+  meterControl: makeDummyMeterControl(),
+});
 
 async function prep() {
   const config = {};

--- a/packages/SwingSet/test/test-metering-control.js
+++ b/packages/SwingSet/test/test-metering-control.js
@@ -1,0 +1,23 @@
+// eslint-disable-next-line import/order
+import { test } from '../tools/prepare-test-env-ava.js';
+
+import { makeDummyMeterControl } from '../src/kernel/dummyMeterControl.js';
+
+test('dummy meter control', async t => {
+  const mc = makeDummyMeterControl();
+  t.false(mc.isMeteringDisabled());
+  t.throws(mc.assertNotMetered);
+  mc.runWithoutMetering(mc.assertNotMetered);
+  let x = 0;
+  mc.runWithoutMetering(() => (x = 1));
+  t.is(x, 1);
+  await mc.runWithoutMeteringAsync(() => (x = 2));
+  t.is(x, 2);
+  function set(y) {
+    x = y;
+    return 'yes';
+  }
+  const unmeteredSet = mc.unmetered(set);
+  t.is(unmeteredSet(3), 'yes');
+  t.is(x, 3);
+});


### PR DESCRIPTION
We're trying to hedge against XS not necessarily performing
"organic" (non-forced) GC at exactly the same across all members (validators)
of a consensus machine, especially when some members have reloaded a vat from
snapshot (i.e. restarted) recently and others have not. We rely upon
finalizer callbacks only running at explicitly-deterministic times, but we
must still guard against objects becoming collected spontaneously, which will
cause a WeakRef to become "dead" (`wr.deref() === undefined`) at a random
point in the middle of a turn. Any code which calls `wr.deref`, or is
conditionally executed/skipped according to the results, is "GC-sensitive".
This includes `convertSlotToVal`, and therefore `m.unserialize`.

We cannot allow metering results to diverge between validators, because:

* 1: it might make the difference between the crank completing successfully,
and the vat being terminated for a per-crank metering fault
* 2: it will change the large-scale Meter value, which is reported to
userspace
* 3: it might cause the runPolicy to finish the block earlier on one
validator than on others

all of which would cause a consensus failure.

To prevent this, we run most of the "inbound" side of liveslots without
metering. This includes the first turn of all `dispatch.*` methods, which
runs entirely within liveslots:

* `dispatch.deliver` performs argument deserialization in the first turn,
  then executes user code in the second and subsequent turns
* `dispatch.notify` does the same
* the GC deliveries (`dispatch.dropExport`, etc) only use one turn

We also disable metering when deserializing the return value from
a (synchronous) device call, and when retiring a promise ID (which touches
`slotToVal`).

Finally, we disable metering for all turns of the post-crank GC `finish()`
call. This excludes all invocations of the finalizer callbacks, as well as
all the `processDeadSet` code which is highly sensitive to the results.

closes #3458
