### PR TITLE
chore: charge fees as per zoeFeesConfig. Add tests to confirm fees charged

### DIFF
--- a/packages/zoe/src/zoeService/feeMint.js
+++ b/packages/zoe/src/zoeService/feeMint.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { makeIssuerKit } from '@agoric/ertp';
+import { makeIssuerKit, AmountMath } from '@agoric/ertp';
 
 import { makeHandle } from '../makeHandle.js';
 
@@ -11,7 +11,10 @@ const { details: X } = assert;
  * @returns {{
  *    feeMintAccess: FeeMintAccess,
  *    getFeeIssuerKit: GetFeeIssuerKit,
- *    feeIssuer: Issuer }}
+ *    feeIssuer: Issuer,
+ *    feeBrand: Brand,
+ *    initialFeeFunds: Payment,
+ * }}
  */
 const createFeeMint = (feeIssuerConfig, shutdownZoeVat) => {
   /** @type {IssuerKit} */
@@ -34,10 +37,16 @@ const createFeeMint = (feeIssuerConfig, shutdownZoeVat) => {
     return feeIssuerKit;
   };
 
+  const initialFeeFunds = feeIssuerKit.mint.mintPayment(
+    AmountMath.make(feeIssuerKit.brand, feeIssuerConfig.initialFunds),
+  );
+
   return harden({
     feeMintAccess,
     getFeeIssuerKit,
     feeIssuer: feeIssuerKit.issuer,
+    feeBrand: feeIssuerKit.brand,
+    initialFeeFunds,
   });
 };
 

--- a/packages/zoe/src/zoeService/feePurse.js
+++ b/packages/zoe/src/zoeService/feePurse.js
@@ -9,12 +9,15 @@ const { details: X } = assert;
  *
  * @param {Issuer} feeIssuer
  * @returns {{
- *   makeFeePurse: MakeFeePurse,
- *   assertFeePurse: AssertFeePurse,
+ *   makeFeePurse: MakeFeePurse
+ *   chargeZoeFee: ChargeZoeFee,
+ *   feeCollectionPurse: Purse,
  * }}
  */
 const setupMakeFeePurse = feeIssuer => {
   const feePurses = new WeakSet();
+
+  const feeCollectionPurse = feeIssuer.makeEmptyPurse();
 
   /** @type {MakeFeePurse} */
   const makeFeePurse = async () => {
@@ -29,18 +32,18 @@ const setupMakeFeePurse = feeIssuer => {
     return feePurse;
   };
 
-  /** @type {IsFeePurse} */
-  const isFeePurse = feePurse => E.when(feePurse, fp => feePurses.has(fp));
-
-  /** @type {AssertFeePurse} */
-  const assertFeePurse = async feePurse => {
-    const feePurseProvided = await isFeePurse(feePurse);
-    assert(feePurseProvided, X`A feePurse must be provided, not ${feePurse}`);
+  /** @type {ChargeZoeFee} */
+  const chargeZoeFee = (feePurse, feeAmount) => {
+    return E.when(feePurse, fp => {
+      assert(feePurses.has(fp), X`A feePurse must be provided, not ${fp}`);
+      feeCollectionPurse.deposit(fp.withdraw(feeAmount));
+    });
   };
 
   return {
     makeFeePurse,
-    assertFeePurse,
+    chargeZoeFee,
+    feeCollectionPurse,
   };
 };
 

--- a/packages/zoe/src/zoeService/feePurse.js
+++ b/packages/zoe/src/zoeService/feePurse.js
@@ -9,7 +9,7 @@ const { details: X } = assert;
  *
  * @param {Issuer} feeIssuer
  * @returns {{
- *   makeFeePurse: MakeFeePurse
+ *   makeFeePurse: MakeFeePurse,
  *   chargeZoeFee: ChargeZoeFee,
  *   feeCollectionPurse: Purse,
  * }}

--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -5,10 +5,10 @@ import { Far } from '@agoric/marshal';
 import { E } from '@agoric/eventual-send';
 
 /**
- * @param {AssertFeePurse} assertFeePurse
+ * @param {ChargeZoeFee} chargeZoeFee
+ * @param {Amount} installFeeAmount
  */
-
-export const makeInstallationStorage = assertFeePurse => {
+export const makeInstallationStorage = (chargeZoeFee, installFeeAmount) => {
   /** @type {WeakSet<Installation>} */
   const installations = new WeakSet();
 
@@ -19,7 +19,7 @@ export const makeInstallationStorage = assertFeePurse => {
   /** @type {InstallFeePurseRequired} */
   const install = async (bundle, feePurse) => {
     assert.typeof(bundle, 'object', X`a bundle must be provided`);
-    await assertFeePurse(feePurse);
+    await chargeZoeFee(feePurse, installFeeAmount);
     /** @type {Installation} */
     const installation = Far('Installation', {
       getBundle: () => bundle,

--- a/packages/zoe/src/zoeService/instanceAdminStorage.js
+++ b/packages/zoe/src/zoeService/instanceAdminStorage.js
@@ -3,16 +3,19 @@
 import { makeWeakStore } from '@agoric/store';
 
 /**
- * @param {AssertFeePurse} assertFeePurse
+ * @param {ChargeZoeFee} chargeZoeFee
+ * @param {Amount} getPublicFacetFeeAmount
  */
-
-export const makeInstanceAdminStorage = assertFeePurse => {
+export const makeInstanceAdminStorage = (
+  chargeZoeFee,
+  getPublicFacetFeeAmount,
+) => {
   /** @type {WeakStore<Instance,InstanceAdmin>} */
   const instanceToInstanceAdmin = makeWeakStore('instance');
 
   /** @type {GetPublicFacetFeePurseRequired} */
   const getPublicFacet = async (instance, feePurse) => {
-    await assertFeePurse(feePurse);
+    await chargeZoeFee(feePurse, getPublicFacetFeeAmount);
     return instanceToInstanceAdmin.get(instance).getPublicFacet();
   };
 

--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -136,13 +136,11 @@
  */
 
 /**
- * @callback IsFeePurse
- * @param {ERef<FeePurse>} feePurse
- * @returns {Promise<boolean>}
+ * @callback ChargeZoeFee
+ * @param {ERef<Purse>} feePurse
+ * @param {Amount} feeAmount
+ * @returns {Promise<void>}
  */
 
 /**
- * @callback AssertFeePurse
- * @param {ERef<FeePurse>} feePurse
- * @returns {Promise<void>}
  */

--- a/packages/zoe/src/zoeService/offer/offer.js
+++ b/packages/zoe/src/zoeService/offer/offer.js
@@ -16,7 +16,8 @@ const { details: X, quote: q } = assert;
  * @param {GetInstanceAdmin} getInstanceAdmin
  * @param {DepositPayments} depositPayments
  * @param {GetAssetKindByBrand} getAssetKindByBrand
- * @param {AssertFeePurse} assertFeePurse
+ * @param {ChargeZoeFee} chargeZoeFee
+ * @param {Amount} offerFeeAmount
  * @returns {Offer}
  */
 export const makeOffer = (
@@ -24,7 +25,8 @@ export const makeOffer = (
   getInstanceAdmin,
   depositPayments,
   getAssetKindByBrand,
-  assertFeePurse,
+  chargeZoeFee,
+  offerFeeAmount,
 ) => {
   /** @type {OfferFeePurseRequired} */
   const offer = async (
@@ -40,7 +42,7 @@ export const makeOffer = (
     );
     // AWAIT ///
 
-    await assertFeePurse(feePurse);
+    await chargeZoeFee(feePurse, offerFeeAmount);
 
     const instanceAdmin = getInstanceAdmin(instanceHandle);
     instanceAdmin.assertAcceptingOffers();

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -14,14 +14,16 @@ import { handlePKitWarning } from '../handleWarning.js';
  * @param {Promise<ZoeService>} zoeServicePromise
  * @param {MakeZoeInstanceStorageManager} makeZoeInstanceStorageManager
  * @param {UnwrapInstallation} unwrapInstallation
- * @param {AssertFeePurse} assertFeePurse
+ * @param {ChargeZoeFee} chargeZoeFee
+ * @param {Amount} startInstanceFeeAmount
  * @returns {StartInstance}
  */
 export const makeStartInstance = (
   zoeServicePromise,
   makeZoeInstanceStorageManager,
   unwrapInstallation,
-  assertFeePurse,
+  chargeZoeFee,
+  startInstanceFeeAmount,
 ) => {
   /** @type {StartInstanceFeePurseRequired} */
   const startInstance = async (
@@ -31,8 +33,7 @@ export const makeStartInstance = (
     privateArgs = undefined,
     feePurse,
   ) => {
-    await assertFeePurse(feePurse);
-
+    await chargeZoeFee(feePurse, startInstanceFeeAmount);
     /** @type {WeakStore<SeatHandle, ZoeSeatAdmin>} */
     const seatHandleToZoeSeatAdmin = makeWeakStore('seatHandle');
 

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -352,6 +352,7 @@
  * @property {string} name
  * @property {AssetKind} assetKind
  * @property {DisplayInfo} displayInfo
+ * @property {Value} initialFunds
  */
 
 /**
@@ -374,4 +375,12 @@
  * @property {GetFeeIssuer} getFeeIssuer
  * @property {MakeFeePurse} makeFeePurse
  * @property {BindDefaultFeePurse} bindDefaultFeePurse
+ */
+
+/**
+ * @typedef {Object} ZoeFeesConfig
+ * @property {NatValue} getPublicFacetFee
+ * @property {NatValue} installFee
+ * @property {NatValue} startInstanceFee
+ * @property {NatValue} offerFee
  */

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -15,9 +15,9 @@ import '@agoric/store/exported.js';
 import '../../exported.js';
 import '../internal-types.js';
 
+import { AmountMath, AssetKind } from '@agoric/ertp';
 import { Far } from '@agoric/marshal';
 import { makePromiseKit } from '@agoric/promise-kit';
-import { AssetKind } from '@agoric/ertp';
 
 import { makeZoeStorageManager } from './zoeStorageManager.js';
 import { makeStartInstance } from './startInstance.js';
@@ -36,8 +36,14 @@ import { bindDefaultFeePurse, setupMakeFeePurse } from './feePurse.js';
  * shutdown the Zoe Vat. This function needs to use the vatPowers
  * available to a vat.
  * @param {FeeIssuerConfig} feeIssuerConfig
+ * @param {ZoeFeesConfig} zoeFees
  * @param {string} [zcfBundleName] - The name of the contract facet bundle.
- * @returns {{ zoeService: ZoeService, feeMintAccess: FeeMintAccess }}
+ * @returns {{
+ *   zoeService: ZoeService,
+ *   feeMintAccess: FeeMintAccess,
+ *   initialFeeFunds: Payment,
+ *   feeCollectionPurse: Purse,
+ * }}
  */
 const makeZoeKit = (
   vatAdminSvc,
@@ -46,6 +52,13 @@ const makeZoeKit = (
     name: 'RUN',
     assetKind: AssetKind.NAT,
     displayInfo: { decimalPlaces: 6, assetKind: AssetKind.NAT },
+    initialFunds: 0n,
+  },
+  zoeFees = {
+    getPublicFacetFee: 0n,
+    installFee: 0n,
+    startInstanceFee: 0n,
+    offerFee: 0n,
   },
   zcfBundleName = undefined,
 ) => {
@@ -54,12 +67,40 @@ const makeZoeKit = (
   /** @type {PromiseRecord<ZoeService>} */
   const zoeServicePromiseKit = makePromiseKit();
 
-  const { feeMintAccess, getFeeIssuerKit, feeIssuer } = createFeeMint(
-    feeIssuerConfig,
-    shutdownZoeVat,
+  const {
+    feeMintAccess,
+    getFeeIssuerKit,
+    feeIssuer,
+    feeBrand,
+    initialFeeFunds,
+  } = createFeeMint(feeIssuerConfig, shutdownZoeVat);
+
+  // The initial funds should be enough to pay for launching the
+  // Agoric economy.
+  assert(
+    AmountMath.isGTE(
+      AmountMath.make(feeBrand, feeIssuerConfig.initialFunds),
+      AmountMath.add(
+        AmountMath.make(feeBrand, zoeFees.installFee),
+        AmountMath.make(feeBrand, zoeFees.startInstanceFee),
+      ),
+    ),
   );
 
-  const { makeFeePurse, assertFeePurse } = setupMakeFeePurse(feeIssuer);
+  const getPublicFacetFeeAmount = AmountMath.make(
+    feeBrand,
+    zoeFees.getPublicFacetFee,
+  );
+  const installFeeAmount = AmountMath.make(feeBrand, zoeFees.installFee);
+  const startInstanceFeeAmount = AmountMath.make(
+    feeBrand,
+    zoeFees.startInstanceFee,
+  );
+  const offerFeeAmount = AmountMath.make(feeBrand, zoeFees.offerFee);
+
+  const { makeFeePurse, chargeZoeFee, feeCollectionPurse } = setupMakeFeePurse(
+    feeIssuer,
+  );
 
   // This method contains the power to create a new ZCF Vat, and must
   // be closely held. vatAdminSvc is even more powerful - any vat can
@@ -85,7 +126,9 @@ const makeZoeKit = (
     createZCFVat,
     getFeeIssuerKit,
     shutdownZoeVat,
-    assertFeePurse,
+    chargeZoeFee,
+    getPublicFacetFeeAmount,
+    installFeeAmount,
   );
 
   // Pass the capabilities necessary to create E(zoe).startInstance
@@ -93,7 +136,8 @@ const makeZoeKit = (
     zoeServicePromiseKit.promise,
     makeZoeInstanceStorageManager,
     unwrapInstallation,
-    assertFeePurse,
+    chargeZoeFee,
+    startInstanceFeeAmount,
   );
 
   // Pass the capabilities necessary to create E(zoe).offer
@@ -102,7 +146,8 @@ const makeZoeKit = (
     getInstanceAdmin,
     depositPayments,
     getAssetKindByBrand,
-    assertFeePurse,
+    chargeZoeFee,
+    offerFeeAmount,
   );
 
   // Make the methods that allow users to easily and credibly get
@@ -141,7 +186,12 @@ const makeZoeKit = (
   // defined. So, we pass a promise and then resolve the promise here.
   zoeServicePromiseKit.resolve(zoeService);
 
-  return harden({ zoeService, feeMintAccess });
+  return harden({
+    zoeService,
+    feeMintAccess,
+    initialFeeFunds,
+    feeCollectionPurse,
+  });
 };
 
 export { makeZoeKit };

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -28,14 +28,18 @@ import { makeInstallationStorage } from './installationStorage.js';
  * ZCF Vat
  * @param {GetFeeIssuerKit} getFeeIssuerKit
  * @param {ShutdownWithFailure} shutdownZoeVat
- * @param {AssertFeePurse} assertFeePurse
+ * @param {ChargeZoeFee} chargeZoeFee
+ * @param {Amount} getPublicFacetFeeAmount
+ * @param {Amount} installFeeAmount
  * @returns {ZoeStorageManager}
  */
 export const makeZoeStorageManager = (
   createZCFVat,
   getFeeIssuerKit,
   shutdownZoeVat,
-  assertFeePurse,
+  chargeZoeFee,
+  getPublicFacetFeeAmount,
+  installFeeAmount,
 ) => {
   // issuerStorage contains the issuers that the ZoeService knows
   // about, as well as information about them such as their brand,
@@ -68,13 +72,14 @@ export const makeZoeStorageManager = (
     getInstanceAdmin,
     initInstanceAdmin,
     deleteInstanceAdmin,
-  } = makeInstanceAdminStorage(assertFeePurse);
+  } = makeInstanceAdminStorage(chargeZoeFee, getPublicFacetFeeAmount);
 
   // Zoe stores "installations" - identifiable bundles of contract
   // code that can be reused again and again to create new contract
   // instances
   const { install, unwrapInstallation } = makeInstallationStorage(
-    assertFeePurse,
+    chargeZoeFee,
+    installFeeAmount,
   );
 
   /** @type {MakeZoeInstanceStorageManager} */

--- a/packages/zoe/test/unitTests/test-feesCharged.js
+++ b/packages/zoe/test/unitTests/test-feesCharged.js
@@ -1,0 +1,120 @@
+// @ts-check
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+
+import path from 'path';
+
+import { AmountMath, AssetKind } from '@agoric/ertp';
+import { E } from '@agoric/eventual-send';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import bundleSource from '@agoric/bundle-source';
+
+// noinspection ES6PreferShortImport
+import { makeZoeKit } from '../../src/zoeService/zoe.js';
+import { makeFakeVatAdmin } from '../../tools/fakeVatAdmin.js';
+
+const filename = new URL(import.meta.url).pathname;
+const dirname = path.dirname(filename);
+
+const contractRoot = `${dirname}/zcf/zcfTesterContract.js`;
+
+test(`fee charged for install, startInstance, offer, getPublicFacet`, async t => {
+  /** @type {ContractFacet} */
+  let zcf;
+  const setZCF = jig => {
+    zcf = jig.zcf;
+  };
+  // The contract provides the `zcf` via `setTestJig` upon `start`.
+  const fakeVatAdmin = makeFakeVatAdmin(setZCF);
+  const zoeFeesConfig = harden({
+    getPublicFacetFee: 1n,
+    installFee: 2n,
+    startInstanceFee: 100n,
+    offerFee: 5n,
+  });
+
+  const feeIssuerConfig = {
+    name: 'RUN',
+    assetKind: AssetKind.NAT,
+    displayInfo: { decimalPlaces: 6, assetKind: AssetKind.NAT },
+    initialFunds: 200n,
+  };
+
+  const { zoeService, initialFeeFunds, feeCollectionPurse } = makeZoeKit(
+    fakeVatAdmin.admin,
+    undefined,
+    feeIssuerConfig,
+    zoeFeesConfig,
+  );
+  const feePurse = E(zoeService).makeFeePurse();
+  const zoe = E(zoeService).bindDefaultFeePurse(feePurse);
+  const feeIssuer = E(zoe).getFeeIssuer();
+  const feeBrand = await E(feeIssuer).getBrand();
+
+  let expectedBalance = AmountMath.make(feeBrand, feeIssuerConfig.initialFunds);
+
+  await E(feePurse).deposit(initialFeeFunds);
+
+  const bundle = await bundleSource(contractRoot);
+
+  t.true(
+    AmountMath.isEqual(await E(feePurse).getCurrentAmount(), expectedBalance),
+  );
+
+  const installation = await E(zoe).install(bundle);
+
+  expectedBalance = AmountMath.subtract(
+    expectedBalance,
+    AmountMath.make(feeBrand, zoeFeesConfig.installFee),
+  );
+
+  t.true(
+    AmountMath.isEqual(await E(feePurse).getCurrentAmount(), expectedBalance),
+  );
+
+  const { instance } = await E(zoe).startInstance(installation);
+
+  expectedBalance = AmountMath.subtract(
+    expectedBalance,
+    AmountMath.make(feeBrand, zoeFeesConfig.startInstanceFee),
+  );
+
+  t.true(
+    AmountMath.isEqual(await E(feePurse).getCurrentAmount(), expectedBalance),
+  );
+
+  const invitation = zcf.makeInvitation(() => {}, 'invitation');
+  await E(zoe).offer(invitation);
+
+  expectedBalance = AmountMath.subtract(
+    expectedBalance,
+    AmountMath.make(feeBrand, zoeFeesConfig.offerFee),
+  );
+
+  t.true(
+    AmountMath.isEqual(await E(feePurse).getCurrentAmount(), expectedBalance),
+  );
+
+  await E(zoe).getPublicFacet(instance);
+
+  expectedBalance = AmountMath.subtract(
+    expectedBalance,
+    AmountMath.make(feeBrand, zoeFeesConfig.getPublicFacetFee),
+  );
+
+  t.true(
+    AmountMath.isEqual(await E(feePurse).getCurrentAmount(), expectedBalance),
+  );
+
+  const allFees = AmountMath.make(
+    feeBrand,
+    zoeFeesConfig.installFee +
+      zoeFeesConfig.startInstanceFee +
+      zoeFeesConfig.offerFee +
+      zoeFeesConfig.getPublicFacetFee,
+  );
+  t.true(
+    AmountMath.isEqual(await E(feeCollectionPurse).getCurrentAmount(), allFees),
+  );
+});

--- a/packages/zoe/test/unitTests/zoe/test-feePurse.js
+++ b/packages/zoe/test/unitTests/zoe/test-feePurse.js
@@ -11,10 +11,8 @@ const setup = () => {
   const runIssuerKit = makeIssuerKit('RUN', AssetKind.NAT, {
     decimalPlaces: 6,
   });
-  const { makeFeePurse, assertFeePurse } = setupMakeFeePurse(
-    runIssuerKit.issuer,
-  );
-  return { makeFeePurse, assertFeePurse, runIssuerKit };
+  const { makeFeePurse, chargeZoeFee } = setupMakeFeePurse(runIssuerKit.issuer);
+  return { makeFeePurse, chargeZoeFee, runIssuerKit };
 };
 
 test('feePurse starts empty', async t => {
@@ -39,9 +37,15 @@ test('depositing into and withdrawing from feePurse', async t => {
   t.true(AmountMath.isEmpty(feePurse.getCurrentAmount()));
 });
 
-test('assertFeePurse', async t => {
-  const { makeFeePurse, assertFeePurse } = setup();
+test('chargeZoeFee', async t => {
+  const { makeFeePurse, chargeZoeFee, runIssuerKit } = setup();
   const feePurse = await makeFeePurse();
 
-  t.is(await assertFeePurse(feePurse), undefined);
+  const run1000 = AmountMath.make(runIssuerKit.brand, 1000n);
+  const payment = runIssuerKit.mint.mintPayment(run1000);
+  feePurse.deposit(payment);
+
+  await chargeZoeFee(feePurse, run1000);
+
+  t.true(AmountMath.isEmpty(feePurse.getCurrentAmount()));
 });

--- a/packages/zoe/test/unitTests/zoe/test-installationStorage.js
+++ b/packages/zoe/test/unitTests/zoe/test-installationStorage.js
@@ -5,12 +5,9 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { makeInstallationStorage } from '../../../src/zoeService/installationStorage.js';
 
-const assertFeePurse = () => {};
-
 test('install, unwrap installations', async t => {
-  const { install, unwrapInstallation } = makeInstallationStorage(
-    assertFeePurse,
-  );
+  const chargeZoeFee = () => true;
+  const { install, unwrapInstallation } = makeInstallationStorage(chargeZoeFee);
   const fakeBundle = {};
   const feePurse = /** @type {FeePurse} */ ({});
 
@@ -21,9 +18,8 @@ test('install, unwrap installations', async t => {
 });
 
 test('unwrap promise for installation', async t => {
-  const { install, unwrapInstallation } = makeInstallationStorage(
-    assertFeePurse,
-  );
+  const chargeZoeFee = () => true;
+  const { install, unwrapInstallation } = makeInstallationStorage(chargeZoeFee);
   const fakeBundle = {};
   const feePurse = /** @type {FeePurse} */ ({});
 
@@ -34,9 +30,8 @@ test('unwrap promise for installation', async t => {
 });
 
 test('install several', async t => {
-  const { install, unwrapInstallation } = makeInstallationStorage(
-    assertFeePurse,
-  );
+  const chargeZoeFee = () => true;
+  const { install, unwrapInstallation } = makeInstallationStorage(chargeZoeFee);
   const fakeBundle1 = {};
   const fakeBundle2 = {};
   const feePurse = /** @type {FeePurse} */ ({});
@@ -53,9 +48,8 @@ test('install several', async t => {
 });
 
 test('install same twice', async t => {
-  const { install, unwrapInstallation } = makeInstallationStorage(
-    assertFeePurse,
-  );
+  const chargeZoeFee = () => true;
+  const { install, unwrapInstallation } = makeInstallationStorage(chargeZoeFee);
   const fakeBundle1 = {};
   const feePurse = /** @type {FeePurse} */ ({});
 

--- a/packages/zoe/test/unitTests/zoe/test-instanceAdminStorage.js
+++ b/packages/zoe/test/unitTests/zoe/test-instanceAdminStorage.js
@@ -7,9 +7,9 @@ import { Far } from '@agoric/marshal';
 
 import { makeInstanceAdminStorage } from '../../../src/zoeService/instanceAdminStorage.js';
 
-const assertFeePurse = () => {};
-
 test('makeInstanceAdminStorage', async t => {
+  const chargeZoeFee = () => {};
+
   const {
     getPublicFacet,
     getBrands,
@@ -19,7 +19,7 @@ test('makeInstanceAdminStorage', async t => {
     getInstanceAdmin,
     initInstanceAdmin,
     deleteInstanceAdmin,
-  } = makeInstanceAdminStorage(assertFeePurse);
+  } = makeInstanceAdminStorage(chargeZoeFee);
 
   const mockInstance1 = Far('mockInstance1', {});
   const mockInstance2 = Far('mockInstance2', {});
@@ -77,7 +77,8 @@ test('makeInstanceAdminStorage', async t => {
 });
 
 test('add another instance admin for same instance', async t => {
-  const { initInstanceAdmin } = makeInstanceAdminStorage(assertFeePurse);
+  const chargeZoeFee = () => {};
+  const { initInstanceAdmin } = makeInstanceAdminStorage(chargeZoeFee);
 
   const mockInstance1 = Far('mockInstance1', {});
   const mockInstanceAdmin1 = Far('mockInstanceAdmin1', {});


### PR DESCRIPTION
Closes #3682 

Stacked on #3663 

Actually charges fees for using expensive Zoe methods: install, startInstance, offer, getPublicFacet. In order to do this, the signature of `makeZoeKit` changed. A new parameter `zoeFeesConfig` was added. Also, the return type of `makeZoeKit` changed to return two new things:

* initialFeeFunds - this is used in the bootstrap process to create the Treasury contract prior to any ZCFMint. This can also be used for the funds to give to users at startup.
* feeCollectionPurse - a purse with all of the fees that Zoe charged to pay for its own execution (not the ZCFVat execution charges that will come in a later PR). This is returned to the caller of `makeZoeKit`. We will need to decide how to allocate this at some point in the future, but this is not needed for the Testnet phase.