### PR TITLE
feat(agoric-cli): Support Node.js ESM deploy scripts

### DIFF
--- a/packages/agoric-cli/lib/init.js
+++ b/packages/agoric-cli/lib/init.js
@@ -29,10 +29,19 @@ export default async function initMain(_progname, rawArgs, priv, opts) {
 
   const pspawn = makePspawn({ log, chalk, spawn });
 
+  let dappBranch = [];
+  if (opts.dappBranch) {
+    dappBranch = ['-b', opts.dappBranch];
+  }
+
   if (
-    await pspawn('git', ['clone', '--origin=upstream', dappURL, DIR], {
-      stdio: 'inherit',
-    })
+    await pspawn(
+      'git',
+      ['clone', '--origin=upstream', dappURL, DIR, ...dappBranch],
+      {
+        stdio: 'inherit',
+      },
+    )
   ) {
     throw Error('cannot clone');
   }

--- a/packages/agoric-cli/lib/main.js
+++ b/packages/agoric-cli/lib/main.js
@@ -12,6 +12,7 @@ import walletMain from './open.js';
 
 const DEFAULT_DAPP_TEMPLATE = 'dapp-fungible-faucet';
 const DEFAULT_DAPP_URL_BASE = 'git://github.com/Agoric/';
+const DEFAULT_DAPP_BRANCH = undefined;
 
 const STAMP = '_agstate';
 
@@ -105,6 +106,11 @@ const main = async (progname, rawArgs, powers) => {
       '--dapp-base <base-url>',
       'find the template relative to <base-url>',
       DEFAULT_DAPP_URL_BASE,
+    )
+    .option(
+      '--dapp-branch <branch>',
+      'use this branch instead of the repository HEAD',
+      DEFAULT_DAPP_BRANCH,
     )
     .action(async (project, cmd) => {
       const opts = { ...program.opts(), ...cmd.opts() };

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -36,6 +36,7 @@
     "@agoric/install-ses": "^0.5.23",
     "@agoric/nat": "^4.1.0",
     "@agoric/promise-kit": "^0.2.23",
+    "@endo/compartment-mapper": "^0.5.1",
     "@iarna/toml": "^2.2.3",
     "anylogger": "^0.21.0",
     "chalk": "^2.4.2",


### PR DESCRIPTION
refs: #527

This adds support for Node.js ESM deploy scripts, allowing dapps to be created
or refactored using Node.js ESM instead of the `standardthings/esm` emulation.

To test this feature, I created a `nesm` branch of the `dapp-fungible-faucet`
dapp that was converted to Node.js ESM with `"type": "module"` in
`package.json` and verified through a console log that `agoric deploy` chose to
use the Node.js ESM implementation. For good measure, I added a temporary
useless reference to `import.meta.url`, which is not properly emulated by `-r
esm`. 

This necessitated an additional feature to `agoric init`, to specify the
branch to use from the template dapp.
