### PR TITLE
chore: Start Charging for Execution

### DIFF
--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -227,6 +227,13 @@
  */
 
 /**
+ * @typedef RootAndAdminNodeAndMeter
+ * @property {Object} root
+ * @property {AdminNode} adminNode
+ * @property {Meter} meter
+ */
+
+/**
  * @typedef {Object} AdminNode
  * A powerful object that can be used to terminate the vat in which a contract
  * is running, to get statistics, or to be notified when it terminates.

--- a/packages/zoe/src/zoeService/chargeForComputrons.js
+++ b/packages/zoe/src/zoeService/chargeForComputrons.js
@@ -5,7 +5,14 @@ import { natSafeMath } from '../contractSupport/index.js';
 
 const { multiply, ceilDivide } = natSafeMath;
 
+/**
+ * @param {MeteringConfig} meteringConfig
+ * @param {Brand} feeBrand
+ * @param {ChargeZoeFee} chargeZoeFee
+ * @returns {ChargeForComputrons}
+ */
 const makeChargeForComputrons = (meteringConfig, feeBrand, chargeZoeFee) => {
+  /** @type {ChargeForComputrons} */
   const chargeForComputrons = async feePurse => {
     const feeValue = ceilDivide(
       multiply(meteringConfig.incrementBy, meteringConfig.price.feeNumerator),

--- a/packages/zoe/src/zoeService/chargeForComputrons.js
+++ b/packages/zoe/src/zoeService/chargeForComputrons.js
@@ -14,6 +14,7 @@ const { multiply, ceilDivide } = natSafeMath;
 const makeChargeForComputrons = (meteringConfig, feeBrand, chargeZoeFee) => {
   /** @type {ChargeForComputrons} */
   const chargeForComputrons = async feePurse => {
+    // Round on the side of charging higher fees
     const feeValue = ceilDivide(
       multiply(meteringConfig.incrementBy, meteringConfig.price.feeNumerator),
       meteringConfig.price.computronDenominator,

--- a/packages/zoe/src/zoeService/chargeForComputrons.js
+++ b/packages/zoe/src/zoeService/chargeForComputrons.js
@@ -1,0 +1,23 @@
+// @ts-check
+
+import { AmountMath } from '@agoric/ertp';
+import { natSafeMath } from '../contractSupport/index.js';
+
+const { multiply, ceilDivide } = natSafeMath;
+
+const makeChargeForComputrons = (meteringConfig, feeBrand, chargeZoeFee) => {
+  const chargeForComputrons = async feePurse => {
+    const feeValue = ceilDivide(
+      multiply(meteringConfig.incrementBy, meteringConfig.price.feeNumerator),
+      meteringConfig.price.computronDenominator,
+    );
+    const feeToCharge = AmountMath.make(feeBrand, feeValue);
+    await chargeZoeFee(feePurse, feeToCharge);
+    return meteringConfig.incrementBy;
+  };
+  harden(chargeForComputrons);
+  return chargeForComputrons;
+};
+
+harden(makeChargeForComputrons);
+export { makeChargeForComputrons };

--- a/packages/zoe/src/zoeService/createZCFVat.js
+++ b/packages/zoe/src/zoeService/createZCFVat.js
@@ -7,16 +7,26 @@ import zcfContractBundle from '../../bundles/bundle-contractFacet.js';
  * ZCF Vats can be created.
  *
  * @param {VatAdminSvc} vatAdminSvc
+ * @param {bigint} initial
+ * @param {bigint} threshold
  * @param {string=} zcfBundleName
  * @returns {CreateZCFVat}
  */
-export const setupCreateZCFVat = (vatAdminSvc, zcfBundleName = undefined) => {
+export const setupCreateZCFVat = (
+  vatAdminSvc,
+  initial,
+  threshold,
+  zcfBundleName = undefined,
+) => {
   /** @type {CreateZCFVat} */
   const createZCFVat = async () => {
-    const meter = await E(vatAdminSvc).createUnlimitedMeter();
-    return typeof zcfBundleName === 'string'
-      ? E(vatAdminSvc).createVatByName(zcfBundleName, { meter })
-      : E(vatAdminSvc).createVat(zcfContractBundle, { meter });
+    const meter = await E(vatAdminSvc).createMeter(initial, threshold);
+    const rootAndAdminNodeP =
+      typeof zcfBundleName === 'string'
+        ? E(vatAdminSvc).createVatByName(zcfBundleName, { meter })
+        : E(vatAdminSvc).createVat(zcfContractBundle, { meter });
+    const rootAndAdminNode = await rootAndAdminNodeP;
+    return harden({ meter, ...rootAndAdminNode });
   };
   return createZCFVat;
 };

--- a/packages/zoe/src/zoeService/createZCFVat.js
+++ b/packages/zoe/src/zoeService/createZCFVat.js
@@ -7,8 +7,8 @@ import zcfContractBundle from '../../bundles/bundle-contractFacet.js';
  * ZCF Vats can be created.
  *
  * @param {VatAdminSvc} vatAdminSvc
- * @param {bigint} initial
- * @param {bigint} threshold
+ * @param {Computrons} initial
+ * @param {Computrons} threshold
  * @param {string=} zcfBundleName
  * @returns {CreateZCFVat}
  */

--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -98,6 +98,7 @@
  * @param {Object} customTerms
  * @param {IssuerKeywordRecord} uncleanIssuerKeywordRecord
  * @param {Instance} instance
+ * @param {ERef<FeePurse>} feePurse
  * @returns {ZoeInstanceStorageManager}
  */
 
@@ -122,7 +123,7 @@
  * ZCF bundle
  *
  * @callback CreateZCFVat
- * @returns {Promise<RootAndAdminNode>}
+ * @returns {Promise<RootAndAdminNodeAndMeter>}
  */
 
 /**
@@ -143,4 +144,20 @@
  */
 
 /**
+ * @typedef {Object} Meter
+ * @property {(delta: bigint) => void} addRemaining
+ * @property {(newThreshold: bigint) => void} setThreshold
+ * @property {() => bigint} get
+ * @property {() => Notifier<bigint>} getNotifier
+ */
+
+/**
+ * @callback ChargeForComputrons
+ *
+ * Charges the feePurse argument for a set number of computrons (This
+ * number is returned by the function and can now be added to the
+ * meter).
+ *
+ * @param {ERef<FeePurse>} feePurse
+ * @returns {Promise<bigint>}
  */

--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -144,11 +144,18 @@
  */
 
 /**
+ * @typedef {bigint} Computrons
+ */
+
+/**
  * @typedef {Object} Meter
- * @property {(delta: bigint) => void} addRemaining
- * @property {(newThreshold: bigint) => void} setThreshold
- * @property {() => bigint} get
- * @property {() => Notifier<bigint>} getNotifier
+ *
+ * All `bigint` units here are in computrons.
+ *
+ * @property {(delta: Computrons) => void} addRemaining
+ * @property {(newThreshold: Computrons) => void} setThreshold
+ * @property {() => Computrons} get
+ * @property {() => Notifier<Computrons>} getNotifier
  */
 
 /**

--- a/packages/zoe/src/zoeService/refillMeter.js
+++ b/packages/zoe/src/zoeService/refillMeter.js
@@ -1,0 +1,21 @@
+// @ts-check
+
+import { E } from '@agoric/eventual-send';
+import { makeAsyncIterableFromNotifier as iterateNotifier } from '@agoric/notifier';
+
+/**
+ * @param {Meter} meter
+ * @param {ChargeForComputrons} chargeForComputrons
+ * @param {ERef<FeePurse>} feePurse
+ */
+const refillMeter = async (meter, chargeForComputrons, feePurse) => {
+  const meterNotifier = E(meter).getNotifier();
+
+  for await (const value of iterateNotifier(meterNotifier)) {
+    console.log('NOTIFIED', value);
+    const incrementBy = await chargeForComputrons(feePurse);
+    await E(meter).addRemaining(incrementBy); // will notify at the same threshold as before
+  }
+};
+harden(refillMeter);
+export { refillMeter };

--- a/packages/zoe/src/zoeService/refillMeter.js
+++ b/packages/zoe/src/zoeService/refillMeter.js
@@ -11,9 +11,11 @@ import { makeAsyncIterableFromNotifier as iterateNotifier } from '@agoric/notifi
 const refillMeter = async (meter, chargeForComputrons, feePurse) => {
   const meterNotifier = E(meter).getNotifier();
 
-  for await (const value of iterateNotifier(meterNotifier)) {
-    console.log('NOTIFIED', value);
+  for await (const remaining of iterateNotifier(meterNotifier)) {
     const incrementBy = await chargeForComputrons(feePurse);
+    console.log(
+      `Meter down to ${remaining}. Refilling to ${remaining + incrementBy}`,
+    );
     await E(meter).addRemaining(incrementBy); // will notify at the same threshold as before
   }
 };

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -57,6 +57,7 @@ export const makeStartInstance = (
       customTerms,
       uncleanIssuerKeywordRecord,
       instance,
+      feePurse,
     );
     // AWAIT ///
 

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -387,11 +387,11 @@
 
 /**
  * @typedef {Object} MeteringConfig
- * @property {bigint} initial - the amount of computrons a meter
+ * @property {Computrons} initial - the amount of computrons a meter
  * starts with
- * @property {bigint} incrementBy - when a meter is refilled, this
+ * @property {Computrons} incrementBy - when a meter is refilled, this
  * amount will be added
- * @property {bigint} threshold - Zoe will be notified when the meter
+ * @property {Computrons} threshold - Zoe will be notified when the meter
  * drops below this amount
  * @property {{ feeNumerator: bigint, computronDenominator: bigint }}
  * price - the price of computrons in RUN

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -384,3 +384,15 @@
  * @property {NatValue} startInstanceFee
  * @property {NatValue} offerFee
  */
+
+/**
+ * @typedef {Object} MeteringConfig
+ * @property {bigint} initial - the amount of computrons a meter
+ * starts with
+ * @property {bigint} incrementBy - when a meter is refilled, this
+ * amount will be added
+ * @property {bigint} threshold - Zoe will be notified when the meter
+ * drops below this amount
+ * @property {{ feeNumerator: bigint, computronDenominator: bigint }}
+ * price - the price of computrons in RUN
+ */

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -26,7 +26,7 @@ import { makeInvitationQueryFns } from './invitationQueries.js';
 import { setupCreateZCFVat } from './createZCFVat.js';
 import { createFeeMint } from './feeMint.js';
 import { bindDefaultFeePurse, setupMakeFeePurse } from './feePurse.js';
-import { natSafeMath } from '../contractSupport/index.js';
+import { makeChargeForComputrons } from './chargeForComputrons.js';
 
 /**
  * Create an instance of Zoe.
@@ -113,18 +113,6 @@ const makeZoeKit = (
     feeIssuer,
   );
 
-  const { multiply, ceilDivide } = natSafeMath;
-
-  const chargeForComputrons = async feePurse => {
-    const feeValue = ceilDivide(
-      multiply(meteringConfig.incrementBy, meteringConfig.price.feeNumerator),
-      meteringConfig.price.computronDenominator,
-    );
-    const feeToCharge = AmountMath.make(feeBrand, feeValue);
-    await chargeZoeFee(feePurse, feeToCharge);
-    return meteringConfig.incrementBy;
-  };
-
   // This method contains the power to create a new ZCF Vat, and must
   // be closely held. vatAdminSvc is even more powerful - any vat can
   // be created. We severely restrict access to vatAdminSvc for this reason.
@@ -133,6 +121,12 @@ const makeZoeKit = (
     meteringConfig.initial,
     meteringConfig.threshold,
     zcfBundleName,
+  );
+
+  const chargeForComputrons = makeChargeForComputrons(
+    meteringConfig,
+    feeBrand,
+    chargeZoeFee,
   );
 
   // The ZoeStorageManager composes and consolidates capabilities

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -13,6 +13,7 @@ import { makeEscrowStorage } from './escrowStorage.js';
 import { createInvitationKit } from './makeInvitation.js';
 import { makeInstanceAdminStorage } from './instanceAdminStorage.js';
 import { makeInstallationStorage } from './installationStorage.js';
+import { refillMeter } from './refillMeter.js';
 
 /**
  * The Zoe Storage Manager encapsulates and composes important
@@ -31,6 +32,7 @@ import { makeInstallationStorage } from './installationStorage.js';
  * @param {ChargeZoeFee} chargeZoeFee
  * @param {Amount} getPublicFacetFeeAmount
  * @param {Amount} installFeeAmount
+ * @param {ChargeForComputrons} chargeForComputrons
  * @returns {ZoeStorageManager}
  */
 export const makeZoeStorageManager = (
@@ -40,6 +42,7 @@ export const makeZoeStorageManager = (
   chargeZoeFee,
   getPublicFacetFeeAmount,
   installFeeAmount,
+  chargeForComputrons,
 ) => {
   // issuerStorage contains the issuers that the ZoeService knows
   // about, as well as information about them such as their brand,
@@ -88,6 +91,7 @@ export const makeZoeStorageManager = (
     customTerms,
     uncleanIssuerKeywordRecord,
     instance,
+    feePurse,
   ) => {
     // Clean the issuerKeywordRecord we receive in `startInstance`
     // from the user, and save the issuers in Zoe if they are not
@@ -205,7 +209,9 @@ export const makeZoeStorageManager = (
 
     const makeInvitation = setupMakeInvitation(instance, installation);
 
-    const { root, adminNode } = await createZCFVat();
+    const { root, adminNode, meter } = await createZCFVat();
+
+    refillMeter(meter, chargeForComputrons, feePurse);
 
     return harden({
       getTerms: instanceRecordManager.getTerms,

--- a/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
@@ -137,28 +137,28 @@ test.skip('ZCF metering crash in API call', async t => {
   t.deepEqual(dump.log, meteringExceededInAPILog);
 });
 
-const meteringExceptionInMakeContractILog = [
+const meteringExceptionInStartILog = [
   '=> alice is set up',
-  '=> alice.doMeterExceptionInMakeContract called',
+  '=> alice.doMeterExceptionInStart called',
   'contract creation failed: RangeError: Allocate meter exceeded',
   'newCounter: 2',
 ];
 // TODO: Unskip. See https://github.com/Agoric/agoric-sdk/issues/1625
-test.skip('ZCF metering crash in makeContract call', async t => {
-  const dump = await main(['meterInMakeContract', [3, 0, 0]]);
-  t.deepEqual(dump.log, meteringExceptionInMakeContractILog);
+test.skip('ZCF metering crash in `start` call', async t => {
+  const dump = await main(['meterInStart', [3, 0, 0]]);
+  t.deepEqual(dump.log, meteringExceptionInStartILog);
 });
 
-const thrownExceptionInMakeContractILog = [
+const thrownExceptionInStartILog = [
   '=> alice is set up',
-  '=> alice.doThrowInMakeContract called',
+  '=> alice.doThrowInStart called',
   'contract creation failed: Error: blowup in makeContract',
   'newCounter: 2',
 ];
 
 test('throw in makeContract call', async t => {
-  const dump = await main(['throwInMakeContract', [3, 0, 0]]);
-  t.deepEqual(dump.log, thrownExceptionInMakeContractILog);
+  const dump = await main(['throwInStart', [3, 0, 0]]);
+  t.deepEqual(dump.log, thrownExceptionInStartILog);
 });
 
 const happyTerminationLog = [

--- a/packages/zoe/test/swingsetTests/brokenContracts/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/vat-alice.js
@@ -423,8 +423,8 @@ const build = async (log, zoe, issuers, payments, installations) => {
     log(`newCounter: ${await E(publicFacet2).getOffersCount()}`);
   };
 
-  const doMeterExceptionInMakeContract = async () => {
-    log(`=> alice.doMeterExceptionInMakeContract called`);
+  const doMeterExceptionInStart = async () => {
+    log(`=> alice.doMeterExceptionInStart called`);
     const installId = installations.crashAutoRefund;
 
     const issuerKeywordRecord = harden({
@@ -446,8 +446,8 @@ const build = async (log, zoe, issuers, payments, installations) => {
     log(`newCounter: ${await E(publicFacet2).getOffersCount()}`);
   };
 
-  const doThrowInMakeContract = async () => {
-    log(`=> alice.doThrowInMakeContract called`);
+  const doThrowInStart = async () => {
+    log(`=> alice.doThrowInStart called`);
     const installId = installations.crashAutoRefund;
 
     const issuerKeywordRecord = harden({
@@ -642,11 +642,11 @@ const build = async (log, zoe, issuers, payments, installations) => {
         case 'meterInApiCall': {
           return doMeterExceptionInApiCall();
         }
-        case 'throwInMakeContract': {
-          return doThrowInMakeContract();
+        case 'throwInStart': {
+          return doThrowInStart();
         }
-        case 'meterInMakeContract': {
-          return doMeterExceptionInMakeContract();
+        case 'meterInStart': {
+          return doMeterExceptionInStart();
         }
         case 'happyTermination': {
           return doHappyTermination();

--- a/packages/zoe/test/swingsetTests/refillMeter/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/refillMeter/bootstrap.js
@@ -1,0 +1,136 @@
+import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
+import { AssetKind } from '@agoric/ertp';
+/* eslint-disable import/extensions, import/no-unresolved */
+import refillMeterBundle from './bundle-refillMeterContract.js';
+/* eslint-enable import/extensions, import/no-unresolved */
+
+export function buildRootObject(vatPowers) {
+  const log = vatPowers.testLog;
+  return Far('root', {
+    async bootstrap(vats, devices) {
+      const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
+        devices.vatAdmin,
+      );
+
+      const feeIssuerConfig = {
+        name: 'RUN',
+        assetKind: AssetKind.NAT,
+        displayInfo: { decimalPlaces: 6, assetKind: AssetKind.NAT },
+        initialFunds: 5_275_000n,
+      };
+      const zoeFeesConfig = {
+        getPublicFacetFee: 0n,
+        installFee: 65_000n,
+        startInstanceFee: 5_000_000n,
+        offerFee: 0n,
+      };
+      const meteringConfig = {
+        incrementBy: 70_000n,
+        initial: 4_396_000n, // startInstance seems to take around this much
+        threshold: 70_000,
+        price: {
+          feeNumerator: 1n,
+          computronDenominator: 1n, // default is just one-to-one
+        },
+      };
+
+      const { zoe, feePurse } = await E(vats.zoe).buildZoe(
+        vatAdminSvc,
+        feeIssuerConfig,
+        zoeFeesConfig,
+        meteringConfig,
+      );
+
+      const preInstallationAmount = await E(feePurse).getCurrentAmount();
+      let expected = feeIssuerConfig.initialFunds;
+      log(
+        'pre-installation ',
+        preInstallationAmount.value,
+        '. Equals expected: ',
+        preInstallationAmount.value === expected,
+      );
+
+      const installation = await E(zoe).install(refillMeterBundle.bundle);
+
+      const postInstallationAmount = await E(feePurse).getCurrentAmount();
+      expected -= zoeFeesConfig.installFee;
+
+      log(
+        'post-installation ',
+        postInstallationAmount.value,
+        '. Equals expected: ',
+        postInstallationAmount.value === expected,
+      );
+
+      const { publicFacet } = await E(zoe).startInstance(installation);
+
+      const postStartInstanceAmount = await E(feePurse).getCurrentAmount();
+      expected -= zoeFeesConfig.startInstanceFee;
+
+      // Meter was refilled
+      // Meter down to 48873. Refilling to 118873
+      expected -= meteringConfig.incrementBy;
+
+      log(
+        'post-startInstance ',
+        postStartInstanceAmount.value,
+        '. Equals expected: ',
+        postStartInstanceAmount.value === expected,
+      );
+
+      log('if the above is true, meter was refilled once');
+
+      // 1
+      await E(publicFacet).smallComputation();
+
+      const postSmallComputation1 = await E(feePurse).getCurrentAmount();
+
+      log(
+        'post-smallComputation1 ',
+        postSmallComputation1.value,
+        '. Equals expected: ',
+        postSmallComputation1.value === expected,
+      );
+
+      // Note meter does not refill here
+      log('meter does not refill here');
+
+      // 2
+      await E(publicFacet).smallComputation();
+
+      const postSmallComputation2 = await E(feePurse).getCurrentAmount();
+      expected -= meteringConfig.incrementBy;
+
+      log(
+        'post-smallComputation2 ',
+        postSmallComputation2.value,
+        '. Equals expected: ',
+        postSmallComputation2.value === expected,
+      );
+
+      // 3
+      await E(publicFacet).smallComputation();
+
+      const postSmallComputation3 = await E(feePurse).getCurrentAmount();
+      expected -= meteringConfig.incrementBy;
+
+      log(
+        'post-smallComputation3 ',
+        postSmallComputation3.value,
+        '. Equals expected: ',
+        postSmallComputation3.value === expected,
+      );
+
+      // 4 + 5
+      // Note: a fifth time should kill the vat due to lack of funds
+      // in the fee purse
+      await E(publicFacet).smallComputation();
+      await E(publicFacet)
+        .smallComputation()
+        .catch(e => {
+          log(`error: ${e}`);
+        });
+    },
+  });
+}

--- a/packages/zoe/test/swingsetTests/refillMeter/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/refillMeter/bootstrap.js
@@ -17,17 +17,17 @@ export function buildRootObject(vatPowers) {
         name: 'RUN',
         assetKind: AssetKind.NAT,
         displayInfo: { decimalPlaces: 6, assetKind: AssetKind.NAT },
-        initialFunds: 5_275_000n,
+        initialFunds: 4_470_000n,
       };
       const zoeFeesConfig = {
         getPublicFacetFee: 0n,
         installFee: 65_000n,
-        startInstanceFee: 5_000_000n,
+        startInstanceFee: 4_200_000n,
         offerFee: 0n,
       };
       const meteringConfig = {
         incrementBy: 70_000n,
-        initial: 4_396_000n, // startInstance seems to take around this much
+        initial: 4_200_000n, // startInstance seems to take around this much
         threshold: 70_000,
         price: {
           feeNumerator: 1n,
@@ -45,9 +45,7 @@ export function buildRootObject(vatPowers) {
       const preInstallationAmount = await E(feePurse).getCurrentAmount();
       let expected = feeIssuerConfig.initialFunds;
       log(
-        'pre-installation ',
-        preInstallationAmount.value,
-        '. Equals expected: ',
+        'pre-installation equals expected: ',
         preInstallationAmount.value === expected,
       );
 
@@ -57,9 +55,7 @@ export function buildRootObject(vatPowers) {
       expected -= zoeFeesConfig.installFee;
 
       log(
-        'post-installation ',
-        postInstallationAmount.value,
-        '. Equals expected: ',
+        'post-installation equals expected: ',
         postInstallationAmount.value === expected,
       );
 
@@ -69,17 +65,12 @@ export function buildRootObject(vatPowers) {
       expected -= zoeFeesConfig.startInstanceFee;
 
       // Meter was refilled
-      // Meter down to 48873. Refilling to 118873
       expected -= meteringConfig.incrementBy;
 
       log(
-        'post-startInstance ',
-        postStartInstanceAmount.value,
-        '. Equals expected: ',
+        'post-startInstance equals expected: ',
         postStartInstanceAmount.value === expected,
       );
-
-      log('if the above is true, meter was refilled once');
 
       // 1
       await E(publicFacet).smallComputation();
@@ -87,25 +78,18 @@ export function buildRootObject(vatPowers) {
       const postSmallComputation1 = await E(feePurse).getCurrentAmount();
 
       log(
-        'post-smallComputation1 ',
-        postSmallComputation1.value,
-        '. Equals expected: ',
+        'post-smallComputation1 equals expected: ',
         postSmallComputation1.value === expected,
       );
-
-      // Note meter does not refill here
-      log('meter does not refill here');
 
       // 2
       await E(publicFacet).smallComputation();
 
       const postSmallComputation2 = await E(feePurse).getCurrentAmount();
-      expected -= meteringConfig.incrementBy;
+      // No refill
 
       log(
-        'post-smallComputation2 ',
-        postSmallComputation2.value,
-        '. Equals expected: ',
+        'post-smallComputation2 equals expected: ',
         postSmallComputation2.value === expected,
       );
 
@@ -116,15 +100,13 @@ export function buildRootObject(vatPowers) {
       expected -= meteringConfig.incrementBy;
 
       log(
-        'post-smallComputation3 ',
-        postSmallComputation3.value,
-        '. Equals expected: ',
+        'post-smallComputation3 equals expected: ',
         postSmallComputation3.value === expected,
       );
 
-      // 4 + 5
-      // Note: a fifth time should kill the vat due to lack of funds
+      // This should kill the vat due to lack of funds
       // in the fee purse
+      await E(publicFacet).smallComputation();
       await E(publicFacet).smallComputation();
       await E(publicFacet)
         .smallComputation()

--- a/packages/zoe/test/swingsetTests/refillMeter/refillMeterContract.js
+++ b/packages/zoe/test/swingsetTests/refillMeter/refillMeterContract.js
@@ -1,0 +1,11 @@
+// @ts-check
+import { Far } from '@agoric/marshal';
+
+const start = () => {
+  const publicFacet = Far('publicFacet', {
+    smallComputation: () => {},
+  });
+  return harden({ publicFacet });
+};
+harden(start);
+export { start };

--- a/packages/zoe/test/swingsetTests/refillMeter/test-refillMeter.js
+++ b/packages/zoe/test/swingsetTests/refillMeter/test-refillMeter.js
@@ -1,0 +1,52 @@
+// TODO Remove babel-standalone preinitialization
+// https://github.com/endojs/endo/issues/768
+import '@agoric/babel-standalone';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@agoric/install-ses';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import test from 'ava';
+import { loadBasedir, buildVatController } from '@agoric/swingset-vat';
+import fs from 'fs';
+import path from 'path';
+import bundleSource from '@agoric/bundle-source';
+
+const filename = new URL(import.meta.url).pathname;
+const dirname = path.dirname(filename);
+
+const CONTRACT_FILES = ['refillMeterContract'];
+const generateBundlesP = Promise.all(
+  CONTRACT_FILES.map(async contract => {
+    const bundle = await bundleSource(`${dirname}/${contract}`);
+    const obj = { bundle, contract };
+    fs.writeFileSync(
+      `${dirname}/bundle-${contract}.js`,
+      `export default ${JSON.stringify(obj)};`,
+    );
+  }),
+);
+
+async function main(argv) {
+  const config = await loadBasedir(dirname);
+  config.defaultManagerType = 'xs-worker';
+  await generateBundlesP;
+  const controller = await buildVatController(config, argv);
+  await controller.run();
+  return controller.dump();
+}
+
+const refillMeterLog = [
+  'pre-installation 5275000. Equals expected: true',
+  'post-installation 5210000. Equals expected: true',
+  'post-startInstance 140000. Equals expected: true',
+  'if the above is true, meter was refilled once',
+  'post-smallComputation1 140000. Equals expected: true',
+  'meter does not refill here',
+  'post-smallComputation2 70000. Equals expected: true',
+  'post-smallComputation3 0. Equals expected: true',
+  'error: Error: vat terminated',
+];
+
+test('zoe - metering - refill meter', async t => {
+  const dump = await main(['refillMeter']);
+  t.deepEqual(dump.log, refillMeterLog, 'log is correct');
+});

--- a/packages/zoe/test/swingsetTests/refillMeter/test-refillMeter.js
+++ b/packages/zoe/test/swingsetTests/refillMeter/test-refillMeter.js
@@ -10,6 +10,8 @@ import fs from 'fs';
 import path from 'path';
 import bundleSource from '@agoric/bundle-source';
 
+import { METER_TYPE } from '../../../../xsnap/api.js';
+
 const filename = new URL(import.meta.url).pathname;
 const dirname = path.dirname(filename);
 
@@ -35,18 +37,21 @@ async function main(argv) {
 }
 
 const refillMeterLog = [
-  'pre-installation 5275000. Equals expected: true',
-  'post-installation 5210000. Equals expected: true',
-  'post-startInstance 140000. Equals expected: true',
-  'if the above is true, meter was refilled once',
-  'post-smallComputation1 140000. Equals expected: true',
-  'meter does not refill here',
-  'post-smallComputation2 70000. Equals expected: true',
-  'post-smallComputation3 0. Equals expected: true',
+  'pre-installation equals expected: true',
+  'post-installation equals expected: true',
+  'post-startInstance equals expected: true',
+  'post-smallComputation1 equals expected: true',
+  'post-smallComputation2 equals expected: true',
+  'post-smallComputation3 equals expected: true',
   'error: Error: vat terminated',
 ];
 
 test('zoe - metering - refill meter', async t => {
+  // If this assertion fails, please update this test with the new
+  // computron values. This test aims to be resilient to changes in
+  // computron values for particular actions but a significant change
+  // may break the test.
+  assert(METER_TYPE === 'xs-meter-10');
   const dump = await main(['refillMeter']);
   t.deepEqual(dump.log, refillMeterLog, 'log is correct');
 });

--- a/packages/zoe/test/swingsetTests/refillMeter/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/refillMeter/vat-zoe.js
@@ -1,0 +1,34 @@
+// @ts-check
+
+import { Far } from '@agoric/marshal';
+
+// noinspection ES6PreferShortImport
+import { E } from '@agoric/eventual-send';
+import { makeZoeKit } from '../../../src/zoeService/zoe.js';
+
+export function buildRootObject(vatPowers) {
+  return Far('root', {
+    buildZoe: async (
+      vatAdminSvc,
+      feeIssuerConfig,
+      zoeFeesConfig,
+      meteringConfig,
+    ) => {
+      const shutdownZoeVat = vatPowers.exitVatWithFailure;
+      const { zoeService, initialFeeFunds } = makeZoeKit(
+        vatAdminSvc,
+        shutdownZoeVat,
+        feeIssuerConfig,
+        zoeFeesConfig,
+        meteringConfig,
+      );
+      const feePurse = E(zoeService).makeFeePurse();
+      const zoe = E(zoeService).bindDefaultFeePurse(feePurse);
+      await E(feePurse).deposit(initialFeeFunds);
+      return harden({
+        zoe,
+        feePurse,
+      });
+    },
+  });
+}

--- a/packages/zoe/test/swingsetTests/zoe-metering/test-zoe-metering.js
+++ b/packages/zoe/test/swingsetTests/zoe-metering/test-zoe-metering.js
@@ -42,10 +42,10 @@ async function main(argv) {
 const infiniteInstallLoopLog = [
   'installing infiniteInstallLoop',
   'instantiating infiniteInstallLoop',
-  'error: RangeError: Compute meter exceeded',
+  'error: Error: vat terminated',
 ];
-// TODO: Unskip. See https://github.com/Agoric/agoric-sdk/issues/1625
-test.skip('zoe - metering - infinite loop in installation', async t => {
+
+test('zoe - metering - infinite loop in installation', async t => {
   const dump = await main(['infiniteInstallLoop']);
   t.deepEqual(dump.log, infiniteInstallLoopLog, 'log is correct');
 });
@@ -53,10 +53,10 @@ test.skip('zoe - metering - infinite loop in installation', async t => {
 const infiniteInstanceLoopLog = [
   'installing infiniteInstanceLoop',
   'instantiating infiniteInstanceLoop',
-  'error: RangeError: Compute meter exceeded',
+  'error: Error: vat terminated',
 ];
-// TODO: Unskip. See https://github.com/Agoric/agoric-sdk/issues/1625
-test.skip('zoe - metering - infinite loop in instantiation', async t => {
+
+test('zoe - metering - infinite loop in instantiation', async t => {
   const dump = await main(['infiniteInstanceLoop']);
   t.deepEqual(dump.log, infiniteInstanceLoopLog, 'log is correct');
 });
@@ -65,10 +65,10 @@ const infiniteTestLoopLog = [
   'installing infiniteTestLoop',
   'instantiating infiniteTestLoop',
   'invoking infiniteTestLoop.doTest()',
-  'error: RangeError: Compute meter exceeded',
+  'error: Error: vat terminated',
 ];
-// TODO: Unskip. See https://github.com/Agoric/agoric-sdk/issues/1625
-test.skip('zoe - metering - infinite loop in contract method', async t => {
+
+test('zoe - metering - infinite loop in contract method', async t => {
   const dump = await main(['infiniteTestLoop']);
   t.deepEqual(dump.log, infiniteTestLoopLog, 'log is correct');
 });
@@ -77,10 +77,10 @@ const testBuiltinsLog = [
   'installing testBuiltins',
   'instantiating testBuiltins',
   'invoking testBuiltins.doTest()',
-  'error: RangeError: Allocate meter exceeded',
+  'error: Error: vat terminated',
 ];
-// TODO: Unskip. See https://github.com/Agoric/agoric-sdk/issues/1625
-test.skip('zoe - metering - expensive builtins in contract method', async t => {
+
+test('zoe - metering - expensive builtins in contract method', async t => {
   const dump = await main(['testBuiltins']);
   t.deepEqual(dump.log, testBuiltinsLog, 'log is correct');
 });

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregatorChainlink.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregatorChainlink.js
@@ -11,7 +11,7 @@ import { Far } from '@agoric/marshal';
 import { makeIssuerKit, AssetKind, AmountMath } from '@agoric/ertp';
 
 import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
-import { makeZoe } from '../../../src/zoeService/zoe.js';
+import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import buildManualTimer from '../../../tools/manualTimer.js';
 
 import '../../../exported.js';
@@ -46,7 +46,9 @@ test.before(
   /** @param {ExecutionContext} ot */ async ot => {
     // Outside of tests, we should use the long-lived Zoe on the
     // testnet. In this test, we must create a new Zoe.
-    const zoe = makeZoe(makeFakeVatAdmin().admin);
+    const { zoeService } = makeZoeKit(makeFakeVatAdmin().admin);
+    const feePurse = E(zoeService).makeFeePurse();
+    const zoe = E(zoeService).bindDefaultFeePurse(feePurse);
 
     // Pack the contracts.
     const oracleBundle = await bundleSource(oraclePath);

--- a/packages/zoe/test/unitTests/zoe/test-chargeForComputrons.js
+++ b/packages/zoe/test/unitTests/zoe/test-chargeForComputrons.js
@@ -1,0 +1,37 @@
+// @ts-check
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+
+import { Far } from '@agoric/marshal';
+
+import { makeChargeForComputrons } from '../../../src/zoeService/chargeForComputrons.js';
+import { natSafeMath } from '../../../src/contractSupport/index.js';
+
+const { multiply, ceilDivide } = natSafeMath;
+
+test('chargeForComputrons', async t => {
+  const meteringConfig = {
+    incrementBy: 50n,
+    price: { feeNumerator: 5n, computronDenominator: 3n },
+  };
+
+  const feeBrand = Far('brand', {});
+
+  const feesCharged = [];
+
+  const chargeZoeFee = async (_purse, feeToCharge) => {
+    feesCharged.push(feeToCharge.value);
+  };
+
+  const chargeForComputrons = makeChargeForComputrons(
+    meteringConfig,
+    feeBrand,
+    chargeZoeFee,
+  );
+
+  t.deepEqual(feesCharged, []);
+  await chargeForComputrons('feePurse');
+  // 50 computrons * (5 RUN per 3 computrons or about 1.666) = 84 RUN
+  t.deepEqual(feesCharged, [ceilDivide(multiply(50n, 5n), 3n)]);
+});

--- a/packages/zoe/test/unitTests/zoe/test-createZCFVat.js
+++ b/packages/zoe/test/unitTests/zoe/test-createZCFVat.js
@@ -14,12 +14,24 @@ test('setupCreateZCFVat', async t => {
   const fakeVatAdminSvc = Far('fakeVatAdminSvc', {
     createMeter: () => {},
     createUnlimitedMeter: () => {},
-    createVatByName: name => name,
-    createVat: _bundle => 'zcfBundle',
+    createVatByName: _name => {
+      return harden({ adminNode: undefined, root: undefined });
+    },
+    createVat: _bundle => {
+      return harden({ adminNode: undefined, root: undefined });
+    },
   });
 
   // @ts-ignore fakeVatAdminSvc is mocked
-  t.is(await setupCreateZCFVat(fakeVatAdminSvc, undefined)(), 'zcfBundle');
+  t.deepEqual(await setupCreateZCFVat(fakeVatAdminSvc, undefined)(), {
+    meter: undefined,
+    adminNode: undefined,
+    root: undefined,
+  });
   // @ts-ignore fakeVatAdminSvc is mocked
-  t.is(await setupCreateZCFVat(fakeVatAdminSvc, 'myVat')(), 'myVat');
+  t.deepEqual(await setupCreateZCFVat(fakeVatAdminSvc, 'myVat')(), {
+    meter: undefined,
+    adminNode: undefined,
+    root: undefined,
+  });
 });

--- a/packages/zoe/test/unitTests/zoe/test-refillMeter.js
+++ b/packages/zoe/test/unitTests/zoe/test-refillMeter.js
@@ -1,0 +1,26 @@
+// @ts-check
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+
+import { Far } from '@agoric/marshal';
+import { makeNotifierKit } from '@agoric/notifier';
+import { makePromiseKit } from '@agoric/promise-kit';
+
+import { refillMeter } from '../../../src/zoeService/refillMeter.js';
+
+test('refillMeter', async t => {
+  const feePurse = /** @type {FeePurse} */ (Far('feePurse', {}));
+  const chargeForComputrons = async _feePurse => 10n;
+  const notifierKit = makeNotifierKit();
+  const deltaPromiseKit = makePromiseKit();
+  const meter = Far('meter', {
+    getNotifier: () => notifierKit.notifier,
+    addRemaining: delta => deltaPromiseKit.resolve(delta),
+  });
+  // @ts-ignore Mocked for testing
+  refillMeter(meter, chargeForComputrons, feePurse);
+  notifierKit.updater.updateState('first');
+  const delta = await deltaPromiseKit.promise;
+  t.is(delta, 10n);
+});

--- a/packages/zoe/tools/fakeVatAdmin.js
+++ b/packages/zoe/tools/fakeVatAdmin.js
@@ -3,6 +3,7 @@
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
 import { Far } from '@agoric/marshal';
+import { makeNotifierKit } from '@agoric/notifier';
 
 import { assert, details as X } from '@agoric/assert';
 import { evalContractBundle } from '../src/contractFacet/evalContractCode.js';
@@ -31,8 +32,14 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
   // test-only state can be provided from contracts
   // to their tests.
   const admin = Far('vatAdmin', {
-    createMeter: () => {},
-    createUnlimitedMeter: () => {},
+    createMeter: () => {
+      const notifierKit = makeNotifierKit();
+      return harden({ getNotifier: () => notifierKit.notifier });
+    },
+    createUnlimitedMeter: () => {
+      const notifierKit = makeNotifierKit();
+      return harden({ getNotifier: () => notifierKit.notifier });
+    },
     createVat: bundle => {
       return harden({
         root: makeRemote(


### PR DESCRIPTION
Closes #3685 

Stacked on #3319 

This PR charges for execution and refills the meter. Note that the Zoe configuration still allows for a lot of flexibility in terms of our economic decision of how much to charge. For instance, the `startInstanceFee` should probably be enough to cover the execution of a large contract, but this PR leaves the default as 0n. We will need to think more about how we want the configurations to work.