### PR TITLE
chore(zoe): relax createInvitationKit to take ERef<TimerService>

### DIFF
--- a/packages/zoe/src/zoeService/makeInvitation.js
+++ b/packages/zoe/src/zoeService/makeInvitation.js
@@ -4,13 +4,13 @@ import { AmountMath, makeIssuerKit, AssetKind } from '@agoric/ertp';
 
 /**
  * @param {ShutdownWithFailure | undefined} shutdownZoeVat
- * @param {TimerService | undefined} timeAuthority
+ * @param {ERef<TimerService> | undefined} timeAuthorityP
  * @param {TranslateFee | (() => undefined)} translateFee
  * @param {TranslateExpiry | (() => undefined)} translateExpiry
  */
 export const createInvitationKit = (
   shutdownZoeVat = undefined,
-  timeAuthority,
+  timeAuthorityP,
   translateFee = () => undefined,
   translateExpiry = () => undefined,
 ) => {
@@ -46,6 +46,7 @@ export const createInvitationKit = (
       );
       const absoluteFee = translateFee(relativeFee);
       const absoluteExpiry = await translateExpiry(relativeExpiry);
+      const timeAuthority = await timeAuthorityP;
 
       const feeInfo = {
         fee: absoluteFee,

--- a/packages/zoe/src/zoeService/offer/offer.js
+++ b/packages/zoe/src/zoeService/offer/offer.js
@@ -19,7 +19,7 @@ const { details: X, quote: q } = assert;
  * @param {GetAssetKindByBrand} getAssetKindByBrand
  * @param {ChargeZoeFee} chargeZoeFee
  * @param {Amount} offerFeeAmount
- * @param {TimerService | undefined} timeAuthority
+ * @param {ERef<TimerService> | undefined} timeAuthority
  * @returns {Offer}
  */
 export const makeOffer = (

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -399,7 +399,7 @@
  * @property {NatValue} installFee
  * @property {NatValue} startInstanceFee
  * @property {NatValue} offerFee
- * @property {TimerService | undefined} timeAuthority
+ * @property {ERef<TimerService> | undefined} timeAuthority
  * @property {bigint} highFee
  * @property {bigint} lowFee
  * @property {bigint} shortExp

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -33,7 +33,7 @@ import { refillMeter } from './refillMeter.js';
  * @param {Amount} getPublicFacetFeeAmount
  * @param {Amount} installFeeAmount
  * @param {ChargeForComputrons} chargeForComputrons
- * @param {TimerService | undefined} timeAuthority
+ * @param {ERef<TimerService> | undefined} timeAuthority
  * @param {TranslateFee} translateFee
  * @param {TranslateExpiry} translateExpiry
  * @returns {ZoeStorageManager}


### PR DESCRIPTION
bootstrap supplies a Promise; don't await until we need it to be present.

This deals with the one `solo` problem in ci, but local testing shows another problem before it.

https://github.com/Agoric/agoric-sdk/pull/3693/checks?check_run_id=3331441280

using `ses-boot-debug.js` I got a bit more detail than `(an object)`:

```
Error#1: kernel panic kp40.policy panic: rejected {"body":"{\"@qclass\":\"error\",\"errorId\":\"error:liveSlots:v11#70001\",\"message\":\"A Zoe invitation is required, not \\\"[Promise]\\\"\",\"name\":\"Error\"}","slots":[]}
```

After this fix, the next failure looks like:

```
CapTP test fixture exception: (RemoteError(error:captp:http://localhost:7999#20001)#1)
RemoteError(error:captp:http://localhost:7999#20001)#1: board does not have id: "14
```

cc @katelynsills 