### PR TITLE
Fix chain again

### DIFF
--- a/golang/cosmos/x/swingset/keeper/keeper_test.go
+++ b/golang/cosmos/x/swingset/keeper/keeper_test.go
@@ -1,0 +1,46 @@
+package keeper
+
+import (
+	"bytes"
+	"testing"
+)
+
+func Test_Key_Encoding(t *testing.T) {
+	tests := []struct {
+		name   string
+		keyStr string
+		key    []byte
+	}{
+		{
+			name:   "empty key matches prefix",
+			keyStr: "",
+			key:    keyPrefix,
+		},
+		{
+			name:   "empty key string (actual)",
+			keyStr: "",
+			key:    []byte{':'},
+		},
+		{
+			name:   "some key string",
+			keyStr: "some",
+			key:    []byte{':', 's', 'o', 'm', 'e'},
+		},
+		{
+			name:   "key prefix immutable",
+			keyStr: "",
+			key:    keyPrefix,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if key := stringToKey(tt.keyStr); !bytes.Equal(key, tt.key) {
+				t.Errorf("stringToKey(%q) = %v, want %v", tt.keyStr, key, tt.key)
+			}
+			if keyStr := keyToString(tt.key); keyStr != tt.keyStr {
+				t.Errorf("keyToString(%v) = %q, want %q", tt.key, keyStr, tt.keyStr)
+			}
+		})
+	}
+}

--- a/golang/cosmos/x/swingset/keeper/querier.go
+++ b/golang/cosmos/x/swingset/keeper/querier.go
@@ -68,7 +68,7 @@ func queryStorage(ctx sdk.Context, path string, req abci.RequestQuery, keeper Ke
 		return []byte{}, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, "could not get storage")
 	}
 
-	bz, err2 := codec.MarshalJSONIndent(legacyQuerierCdc, types.Storage{value})
+	bz, err2 := codec.MarshalJSONIndent(legacyQuerierCdc, types.Storage{Value: value})
 	if err2 != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err2.Error())
 	}
@@ -82,10 +82,10 @@ func queryKeys(ctx sdk.Context, path string, req abci.RequestQuery, keeper Keepe
 	klist := keys.Keys
 
 	if klist == nil {
-		return []byte{}, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, "could not get keys")
+		klist = []string{}
 	}
 
-	bz, err2 := codec.MarshalJSONIndent(legacyQuerierCdc, types.Keys{klist})
+	bz, err2 := codec.MarshalJSONIndent(legacyQuerierCdc, types.Keys{Keys: klist})
 	if err2 != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err2.Error())
 	}

--- a/packages/agoric-cli/jsconfig.json
+++ b/packages/agoric-cli/jsconfig.json
@@ -1,0 +1,19 @@
+// This file can contain .js-specific Typescript compiler config.
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+
+    "noEmit": true,
+/*
+    // The following flags are for creating .d.ts files:
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+*/
+    "downlevelIteration": true,
+    "strictNullChecks": true,
+    "moduleResolution": "node",
+  },
+  "include": ["src/**/*.js", "lib/**/*.js", "exported.js"],
+}

--- a/packages/agoric-cli/lib/cosmos.js
+++ b/packages/agoric-cli/lib/cosmos.js
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { makePspawn } from './helpers.js';
+import { makePspawn, getSDKBinaries } from './helpers.js';
 
 export default async function cosmosMain(progname, rawArgs, powers, opts) {
   const IMAGE = `agoric/agoric-sdk`;
@@ -21,7 +21,8 @@ export default async function cosmosMain(progname, rawArgs, powers, opts) {
 
   function helper(args, hopts = undefined) {
     if (opts.sdk) {
-      return pspawn('ag-cosmos-helper', args, hopts);
+      const { cosmosHelper } = getSDKBinaries();
+      return pspawn(cosmosHelper, args, hopts);
     }
 
     // Don't allocate a TTY if we're not talking to one.

--- a/packages/agoric-cli/lib/helpers.js
+++ b/packages/agoric-cli/lib/helpers.js
@@ -3,11 +3,24 @@
 
 /** @typedef {import('child_process').ChildProcess} ChildProcess */
 
+export const getSDKBinaries = () => {
+  const myUrl = import.meta.url;
+  return {
+    agSolo: new URL('../../solo/src/entrypoint.js', myUrl).pathname,
+    cosmosChain: new URL('../../cosmic-swingset/bin/ag-chain-cosmos', myUrl)
+      .pathname,
+    cosmosHelper: new URL(
+      '../../../golang/cosmos/build/ag-cosmos-helper',
+      myUrl,
+    ).pathname,
+  };
+};
+
 /**
  * Create a promisified spawn function with the following built-in parameters.
  *
  * @param {Object} param0
- * @param {Record<string, string>} [param0.env] the default environment
+ * @param {Record<string, string | undefined>} [param0.env] the default environment
  * @param {*} [param0.chalk] a colorizer
  * @param {Console} [param0.log] a console object
  * @param {(cmd: string, cargs: Array<string>, opts: any) => ChildProcess}param0.spawn the spawn function
@@ -26,7 +39,7 @@ export const makePspawn = ({
    * @param {Object} param2
    * @param {string | [string, string, string]} [param2.stdio] standard IO
    * specification
-   * @param {Record<string, string>} [param2.env] environment
+   * @param {Record<string, string | undefined>} [param2.env] environment
    * @returns {Promise<number> & { childProcess: ChildProcess }}} promise for
    * exit status. The return result has a `childProcess` property to obtain
    * control over the running process

--- a/packages/agoric-cli/package.json
+++ b/packages/agoric-cli/package.json
@@ -15,9 +15,11 @@
     "test:c8": "c8 $C8_OPTIONS ava --config=ava-nesm.config.js",
     "test:xs": "exit 0",
     "integration-test": "ava --config .ava-integration-test.config.js",
+    "lint-fix": "yarn lint:eslint --fix && yarn lint:types",
     "lint-check": "yarn lint",
-    "lint-fix": "eslint --fix '**/*.{js,jsx}'",
-    "lint": "eslint '**/*.{js,jsx}'"
+    "lint": "yarn lint:types && yarn lint:eslint",
+    "lint:types": "tsc -p jsconfig.json",
+    "lint:eslint": "eslint '**/*.js'"
   },
   "devDependencies": {
     "@agoric/swingset-vat": "^0.20.0",

--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -17,11 +17,7 @@ BASE_PORT?=8000
 
 OTEL_EXPORTER_PROMETHEUS_PORT = 9461
 
-# On a host machine.  Stay here.
-INSPECT_ADDRESS = 127.0.0.1
-
-BREAK_CHAIN = false
-NODE_DEBUG = node --inspect-port=$(INSPECT_ADDRESS):9229
+AGC_START_ARGS =
 
 BIN := $(shell echo $${GOBIN-$${GOPATH-$$HOME/go}/bin})
 
@@ -47,8 +43,8 @@ scenario1-run-chain:
 scenario1-run-client:
 	AG_SOLO_BASEDIR=$$PWD/t9/$(BASE_PORT) $(AG_SOLO) setup --network-config=http://localhost:8001/network-config --webport=$(BASE_PORT)
 
-AGC = ./bin/ag-chain-cosmos
-AGCH = ag-cosmos-helper
+AGC = DEBUG=SwingSet:ls,SwingSet:vat ./bin/ag-chain-cosmos
+AGCH = $(GOSRC)/build/ag-cosmos-helper
 scenario2-setup: all scenario2-setup-nobuild
 scenario2-setup-nobuild:
 	rm -rf t1
@@ -75,8 +71,12 @@ scenario2-setup-nobuild:
 
 scenario2-run-chain:
 	OTEL_EXPORTER_PROMETHEUS_PORT=$(OTEL_EXPORTER_PROMETHEUS_PORT) \
-		DEBUG=SwingSet:ls,SwingSet:vat \
-		$(AGC) `$(BREAK_CHAIN) && echo --inspect-brk` --home=t1/n0 start --log_level=warn
+		$(AGC) --home=t1/n0 start --log_level=warn $(AGC_START_ARGS)
+
+# Run a chain with an explicit halt.
+scenario2-run-chain-to-halt:
+	$(AGC) --home=t1/n0 start --log_level=warn --halt-height=$$(($(INITIAL_HEIGHT) + 3)); \
+		test "$$?" -eq 98
 
 # Blow away all client state to try again without resetting the chain.
 scenario2-reset-client:

--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -129,7 +129,7 @@ t1-provision-one-with-powers: wait-for-cosmos
 			bootstrap $$addr $(SOLO_COINS) && \
 	  $(AGCH) --home=t1/bootstrap tx swingset provision-one --keyring-backend=test --from=bootstrap \
 		  --gas=auto --gas-adjustment=1.2 --broadcast-mode=block --yes --chain-id=$(CHAIN_ID) \
-		  t1/$(BASE_PORT) $$addr $(AGORIC_POWERS) | tee /dev/stderr | grep -q '"code":0'; }
+		  t1/$(BASE_PORT) $$addr $(AGORIC_POWERS) -ojson | tee /dev/stderr | grep -q '"code":0'; }
 	
 
 t1-provision-one: wait-for-cosmos
@@ -142,7 +142,7 @@ t1-provision-one: wait-for-cosmos
 			bootstrap $$addr $(SOLO_COINS) && \
 	  $(AGCH) --home=t1/bootstrap tx swingset provision-one --keyring-backend=test --from=bootstrap \
 		  --gas=auto --gas-adjustment=1.2 --broadcast-mode=block --yes --chain-id=$(CHAIN_ID) \
-		  t1/$(BASE_PORT) $$addr | tee /dev/stderr | grep -q '"code":0'; }
+		  t1/$(BASE_PORT) $$addr -ojson | tee /dev/stderr | grep -q '"code":0'; }
 
 t1/$(BASE_PORT)/cosmos-client-account.setup:
 	test ! -f t1/$(BASE_PORT)/cosmos-client-account || \

--- a/packages/cosmic-swingset/test/test-make.js
+++ b/packages/cosmic-swingset/test/test-make.js
@@ -7,11 +7,11 @@ const dirname = path.dirname(filename);
 
 test('make and exec', async t => {
   await new Promise(resolve =>
-    spawn('make', {
+    spawn('make', ['scenario2-setup'], {
       cwd: `${dirname}/..`,
       stdio: ['ignore', 'ignore', 'inherit'],
     }).addListener('exit', code => {
-      t.is(code, 0, 'make exits successfully');
+      t.is(code, 0, 'make scenario2-setup exits successfully');
       resolve();
     }),
   );
@@ -21,6 +21,15 @@ test('make and exec', async t => {
       stdio: ['ignore', 'ignore', 'inherit'],
     }).addListener('exit', code => {
       t.is(code, 0, 'exec exits successfully');
+      resolve();
+    }),
+  );
+  await new Promise(resolve =>
+    spawn('make', ['scenario2-run-chain-to-halt'], {
+      cwd: `${dirname}/..`,
+      stdio: ['ignore', 'ignore', 'inherit'],
+    }).addListener('exit', code => {
+      t.is(code, 0, 'make scenario2-run-chain-to-halt is successful');
       resolve();
     }),
   );

--- a/packages/solo/src/chain-cosmos-sdk.js
+++ b/packages/solo/src/chain-cosmos-sdk.js
@@ -18,7 +18,11 @@ import {
 
 const console = anylogger('chain-cosmos-sdk');
 
-const HELPER = 'ag-cosmos-helper';
+export const HELPER = new URL(
+  '../../../golang/cosmos/build/ag-cosmos-helper',
+  import.meta.url,
+).pathname;
+
 const FAUCET_ADDRESS =
   'the appropriate faucet channel on Discord (https://agoric.com/discord)';
 

--- a/packages/solo/src/init-basedir.js
+++ b/packages/solo/src/init-basedir.js
@@ -5,6 +5,7 @@ import { execFileSync } from 'child_process';
 
 import { assert, details as X } from '@agoric/assert';
 import anylogger from 'anylogger';
+import { HELPER } from './chain-cosmos-sdk.js';
 
 const log = anylogger('ag-solo:init');
 
@@ -75,12 +76,11 @@ export default function initBasedir(
     const agchServerDir = path.join(basedir, 'ag-cosmos-helper-statedir');
     if (!fs.existsSync(agchServerDir)) {
       fs.mkdirSync(agchServerDir);
-      // we assume 'ag-cosmos-helper' is on $PATH for now, see chain-cosmos-sdk.js
       const keyName = 'ag-solo';
       // we suppress stderr because it displays the mnemonic phrase, but
       // unfortunately that means errors are harder to diagnose
       execFileSync(
-        'ag-cosmos-helper',
+        HELPER,
         [
           'keys',
           'add',
@@ -96,7 +96,7 @@ export default function initBasedir(
       );
       log('key generated, now extracting address');
       const kout = execFileSync(
-        'ag-cosmos-helper',
+        HELPER,
         [
           'keys',
           'show',


### PR DESCRIPTION
In the absence of integration tests, I only notice these when I run `cd packages/cosmic-swingset && make scenario2-setup scenario2-run-chain`.

Minor but critical fixes.

- Properly use `-ojson` where it is required.
- Add an integration test to run the chain for a few blocks
- Fix x/swingset storage implementation to allow empty string in storage paths, **AND A NONDETERMINISM** (once again caused by `range(myMap)`)
- Remove dependency on `$PATH` within `solo`, `cosmic-swingset` and `agoric-cli`; use the SDK-relative filenames instead
