### PR TITLE
chore(swingset): add tool to measure+display metering usage

### DIFF
--- a/packages/SwingSet/tools/measure-metering/measure.js
+++ b/packages/SwingSet/tools/measure-metering/measure.js
@@ -1,0 +1,148 @@
+// run as `node tools/measure-metering/measure.js`
+
+// eslint-disable-next-line import/order
+import '../prepare-test-env.js';
+
+// eslint-disable-next-line import/order
+import bundleSource from '@agoric/bundle-source';
+import { xsnap } from '@agoric/xsnap';
+import * as proc from 'child_process';
+import * as os from 'os';
+import { buildVatController } from '../../src/index.js';
+import { capargs } from '../../test/util.js';
+
+function countingPolicy() {
+  let computrons = 0n;
+  const policy = harden({
+    vatCreated() {
+      return true;
+    },
+    crankComplete(details = {}) {
+      // console.log(`crankComplete`, details);
+      assert.typeof(details, 'object');
+      if (details.computrons) {
+        assert.typeof(details.computrons, 'bigint');
+        computrons += details.computrons;
+      }
+      return true;
+    },
+    crankFailed() {
+      return true;
+    },
+
+    counted() {
+      return computrons;
+    },
+  });
+  return policy;
+}
+
+async function run() {
+  const x = xsnap({ os: os.type(), spawn: proc.spawn });
+  const res = await x.evaluate('4');
+  const { meterType } = res.meterUsage;
+  console.log(`meterType: ${meterType}`);
+  await x.terminate();
+
+  const bootFn = new URL('measurement-bootstrap.js', import.meta.url).pathname;
+  const targetFn = new URL('measurement-target.js', import.meta.url).pathname;
+  const zoeFn = new URL('measurement-zoe.js', import.meta.url).pathname;
+  // const treasuryFn = new URL('measurement-zoe.js', import.meta.url).pathname;
+  const autoswapFn = new URL(
+    '../../../zoe/src/contracts/newSwap/multipoolAutoswap.js',
+    import.meta.url,
+  ).pathname;
+  const autoswapBundle = await bundleSource(autoswapFn);
+  const config = {
+    defaultManagerType: 'xs-worker',
+    bootstrap: 'bootstrap',
+    vats: {
+      bootstrap: {
+        sourceSpec: bootFn,
+      },
+      zoe: {
+        sourceSpec: zoeFn,
+      },
+    },
+    bundles: {
+      target: {
+        sourceSpec: targetFn,
+      },
+    },
+  };
+
+  const c = await buildVatController(config);
+  c.pinVatRoot('bootstrap');
+
+  await c.run();
+
+  async function runOneMode(mode) {
+    const kp = c.queueToVatRoot('bootstrap', 'measure', capargs([mode]));
+    await c.run();
+    const cd = c.kpResolution(kp);
+    const used = JSON.parse(cd.body);
+    assert.typeof(used, 'number');
+    return used;
+  }
+
+  // discard the first message, which for some reason uses ~350 more
+  await runOneMode('empty');
+  const empty = await runOneMode('empty');
+  console.log(`empty (baseline): ${empty}`);
+
+  const asyncEmpty = await runOneMode('asyncEmpty');
+  console.log(` add async: ${asyncEmpty - empty}`);
+  const init = await runOneMode('init');
+  console.log(`"let i = 1": ${init - empty}`);
+  const add = await runOneMode('add');
+  console.log(`"i += 2": ${add - init}`);
+  const loop100 = await runOneMode('loop100');
+  console.log(
+    `"let sum; for (let i=0; i<100; i++) { sum += i; }": ${loop100 - empty}`,
+  );
+  const loop1000 = await runOneMode('loop1000');
+  console.log(`  same but to 1000: ${loop1000 - empty}`);
+
+  const makeCounter = await runOneMode('makeCounter');
+  console.log(`define Far add/read counter object: ${makeCounter - empty}`);
+  const counterAdd = await runOneMode('counterAdd');
+  console.log(`  "counter.add(1)": ${counterAdd - empty}`);
+
+  const log = await runOneMode('log');
+  console.log(`"console.log('')": ${log - empty}`);
+
+  const makeIssuer = await runOneMode('makeIssuer');
+  console.log(`makeIssuerKit: ${makeIssuer - empty}`);
+  const getBrand = await runOneMode('getBrand');
+  console.log(`getBrand: ${getBrand - empty}`);
+  const getCurrentAmount = await runOneMode('getCurrentAmount');
+  console.log(`getCurrentAmount: ${getCurrentAmount - empty}`);
+  const deposit = await runOneMode('deposit');
+  console.log(`deposit: ${deposit - empty}`);
+  const getUpdateSince = await runOneMode('getUpdateSince');
+  console.log(`getUpdateSince: ${getUpdateSince - empty}`);
+
+  // Zoe is in a static vat, so to measure Zoe's usage, we ask the runPolicy
+  // how many computrons it was asked about, rather than following the Meter
+  // of the target vat.
+
+  async function doCounted(method, args = []) {
+    const kp = c.queueToVatRoot('bootstrap', method, capargs(args));
+    const p = countingPolicy();
+    await c.run(p);
+    c.kpResolution(kp);
+    const counted = p.counted();
+    return Number(counted);
+  }
+  const zoeInstallTreasury = await doCounted('zoeInstallTreasury');
+  console.log(`zoe install (treasury): ${zoeInstallTreasury}`);
+
+  const zoeInstallAMM = await doCounted('zoeInstallBundle', [autoswapBundle]);
+  console.log(`zoe install (AMM): ${zoeInstallAMM}`);
+  const zoeInstantiate = await doCounted('zoeInstantiate');
+  console.log(`zoe instantiate (AMM): ${zoeInstantiate}`);
+
+  await c.shutdown();
+}
+
+run().catch(err => console.log('error in run:', err));

--- a/packages/SwingSet/tools/measure-metering/measurement-bootstrap.js
+++ b/packages/SwingSet/tools/measure-metering/measurement-bootstrap.js
@@ -1,0 +1,48 @@
+/* eslint-disable import/no-extraneous-dependencies,no-unused-vars,no-empty-function */
+import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
+import stablecoinBundle from '@agoric/treasury/bundles/bundle-stablecoinMachine.js';
+import { makeIssuerKit, AmountMath } from '@agoric/ertp';
+
+export function buildRootObject() {
+  let control;
+  let meter;
+  let zoe;
+  let installation;
+
+  return Far('root', {
+    async bootstrap(vats, devices) {
+      const service = await E(vats.vatAdmin).createVatAdminService(
+        devices.vatAdmin,
+      );
+      zoe = await E(vats.zoe).buildZoe(service);
+      const lots = 1_000_000_000n;
+      meter = await E(service).createMeter(lots, 0n);
+      const opts = { managerType: 'xs-worker', meter };
+      control = await E(service).createVatByName('target', opts);
+      await E(control.root).setZoe(zoe);
+    },
+
+    async measure(mode) {
+      const start = await E(meter).get();
+      await E(control.root)[mode]();
+      const finish = await E(meter).get();
+      return Number(start.remaining - finish.remaining);
+    },
+
+    async zoeInstallTreasury() {
+      installation = await E(zoe).install(stablecoinBundle);
+    },
+    async zoeInstallBundle(bundle) {
+      installation = await E(zoe).install(bundle);
+    },
+
+    async zoeInstantiate() {
+      const ik = makeIssuerKit('tokens');
+      await E(zoe).startInstance(installation, harden({ Central: ik.issuer }), {
+        poolFee: 24n,
+        protocolFee: 6n,
+      });
+    },
+  });
+}

--- a/packages/SwingSet/tools/measure-metering/measurement-target.js
+++ b/packages/SwingSet/tools/measure-metering/measurement-target.js
@@ -1,0 +1,71 @@
+/* eslint-disable import/no-extraneous-dependencies,no-unused-vars,no-empty-function */
+import { Far } from '@agoric/marshal';
+import { makeIssuerKit, AmountMath } from '@agoric/ertp';
+
+export function buildRootObject(vatPowers) {
+  function makeCounter() {
+    let count = 0;
+    return Far('counter', {
+      add(delta) {
+        count += delta;
+      },
+      read() {
+        return count;
+      },
+    });
+  }
+  const counter = makeCounter();
+  const ik = makeIssuerKit('tokens');
+  const purse = ik.issuer.makeEmptyPurse();
+  const notifier = purse.getCurrentAmountNotifier();
+  const brand = ik.issuer.getBrand();
+  const payment = ik.mint.mintPayment(AmountMath.make(brand, 100n));
+
+  let zoe;
+  return Far('root', {
+    setZoe(z) {
+      zoe = z;
+    },
+    empty() {},
+    async asyncEmpty() {},
+    init() {
+      const i = 1;
+    },
+    add() {
+      let i = 1;
+      i += 2;
+    },
+    loop100() {
+      let sum;
+      for (let i = 0; i < 100; i += 1) {
+        sum += 1;
+      }
+    },
+    loop1000() {
+      let sum;
+      for (let i = 0; i < 1000; i += 1) {
+        sum += 1;
+      }
+    },
+    makeCounter,
+    counterAdd: counter.add,
+    log() {
+      console.log('');
+    },
+    makeIssuer() {
+      makeIssuerKit('tokens');
+    },
+    getBrand() {
+      ik.issuer.getBrand();
+    },
+    getCurrentAmount() {
+      purse.getCurrentAmount();
+    },
+    deposit() {
+      purse.deposit(payment);
+    },
+    getUpdateSince() {
+      notifier.getUpdateSince();
+    },
+  });
+}

--- a/packages/SwingSet/tools/measure-metering/measurement-zoe.js
+++ b/packages/SwingSet/tools/measure-metering/measurement-zoe.js
@@ -1,0 +1,9 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { Far } from '@agoric/marshal';
+import { makeZoe } from '@agoric/zoe';
+
+export function buildRootObject(_vatPowers, vatParameters) {
+  return Far('root', {
+    buildZoe: adminVat => makeZoe(adminVat, vatParameters.zcfBundleName),
+  });
+}


### PR DESCRIPTION
Run `cd packages/SwingSet && node test/measure-metering/measure.js` to get
the report.

This doesn't change the swingset code, it's just a tool that lives in the swingset `test/` directory (but isn't run as part of the tests).

cc @katelynsills 
