### PR TITLE
refactor(swingset-runner): Convert autobench from RESM to NESM

### DIFF
--- a/packages/swingset-runner/.gitignore
+++ b/packages/swingset-runner/.gitignore
@@ -8,3 +8,4 @@ slog
 vslog
 vlog
 vdump
+benchstats-*

--- a/packages/swingset-runner/autobench.js
+++ b/packages/swingset-runner/autobench.js
@@ -1,6 +1,7 @@
-#! /usr/bin/env node
-const { spawnSync } = require('child_process');
-const { existsSync, unlinkSync } = require('fs');
+#!/usr/bin/env node
+
+import { spawnSync } from 'child_process';
+import { existsSync, unlinkSync } from 'fs';
 
 const spawnNodeSync = args => spawnSync('node', args, { stdio: 'inherit' });
 const SUITES = ['exchangeBenchmark', 'pingPongBenchmark', 'swapBenchmark'];
@@ -20,7 +21,7 @@ for (const suite of SUITES) {
   }
   const ssjson = `demo/${suite}/swingset.json`;
   const configFlags = existsSync(ssjson) ? ['--config', ssjson] : [];
-  
+
   // Calculate how many rounds to run.
   let brounds;
   switch (suite) {
@@ -35,9 +36,17 @@ for (const suite of SUITES) {
     }
   }
   spawnNodeSync([
-    'bin/runner', '--init',
-    '--benchmark', brounds, '--statsfile', benchstats, ...configFlags,
-    'run', `demo/${suite}`, '--quiet', '--prime',
+    'bin/runner',
+    '--init',
+    '--benchmark',
+    brounds,
+    '--statsfile',
+    benchstats,
+    ...configFlags,
+    'run',
+    `demo/${suite}`,
+    '--quiet',
+    '--prime',
   ]);
   spawnNodeSync(['src/push-metrics.js', suite, benchstats]);
 }

--- a/packages/swingset-runner/demo/exchangeBenchmark/prepareContracts.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/prepareContracts.js
@@ -7,7 +7,7 @@ import { resolve as importMetaResolve } from 'import-meta-resolve';
 
 import fs from 'fs';
 
-const CONTRACT_FILES = ['simpleExchange'];
+const CONTRACT_FILES = ['simpleExchange.js'];
 
 const generateBundlesP = Promise.all(
   CONTRACT_FILES.map(async contract => {
@@ -19,7 +19,7 @@ const generateBundlesP = Promise.all(
     const bundle = await bundleSource(contractPath);
     const obj = { bundle, contract };
     fs.writeFileSync(
-      new URL(`bundle-${contract}.js`, import.meta.url).pathname,
+      new URL(`bundle-${contract}`, import.meta.url).pathname,
       `export default ${JSON.stringify(obj)};`,
     );
   }),

--- a/packages/swingset-runner/demo/swapBenchmark/prepareContracts.js
+++ b/packages/swingset-runner/demo/swapBenchmark/prepareContracts.js
@@ -7,7 +7,7 @@ import { resolve as importMetaResolve } from 'import-meta-resolve';
 
 import fs from 'fs';
 
-const CONTRACT_FILES = ['atomicSwap'];
+const CONTRACT_FILES = ['atomicSwap.js'];
 
 const generateBundlesP = Promise.all(
   CONTRACT_FILES.map(async contract => {

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -16,7 +16,7 @@
     "lint-fix": "eslint --fix '**/*.js'",
     "lint-check": "yarn lint",
     "lint": "eslint '**/*.js'",
-    "ci:autobench": "./autobench"
+    "ci:autobench": "./autobench.js"
   },
   "dependencies": {
     "@agoric/assert": "^0.3.9",


### PR DESCRIPTION
refs: #527

I missed this in the first pass at converting swingset-runner.

To test, run `yarn ci:autobench`.
