### PR TITLE
feat(swingset): Thread dev and format options thru SwingsetConfig

### DIFF
--- a/packages/SwingSet/src/initializeSwingset.js
+++ b/packages/SwingSet/src/initializeSwingset.js
@@ -70,7 +70,8 @@ function byName(a, b) {
  * 'bootstrap.js'.
  *
  * @param {string} basedir  The directory to scan
- *
+ * @param {Object} [options]
+ * @param {boolean} [options.dev] whether to include devDependencies
  * @returns {SwingSetConfig} a swingset config object: {
  *   bootstrap: "bootstrap",
  *   vats: {
@@ -87,7 +88,8 @@ function byName(a, b) {
  *
  * Swingsets defined by scanning a directory in this manner define no devices.
  */
-export function loadBasedir(basedir) {
+export function loadBasedir(basedir, options = {}) {
+  const { dev = false } = options;
   /** @type { SwingSetConfigDescriptor } */
   const vats = {};
   const subs = fs.readdirSync(basedir, { withFileTypes: true });
@@ -120,7 +122,7 @@ export function loadBasedir(basedir) {
     // scanning thing is something we decide we want to have long term.
     bootstrapPath = undefined;
   }
-  const config = { vats };
+  const config = { vats, dev };
   if (bootstrapPath) {
     vats.bootstrap = {
       sourceSpec: bootstrapPath,
@@ -385,7 +387,9 @@ export async function initializeSwingset(
         validateBundleDescriptor(desc, groupName, name);
         if (desc.sourceSpec) {
           names.push(name);
-          presumptiveBundles.push(bundleSource(desc.sourceSpec));
+          presumptiveBundles.push(
+            bundleSource(desc.sourceSpec, { dev: config.dev }),
+          );
         } else if (desc.bundleSpec) {
           names.push(name);
           presumptiveBundles.push(fs.readFileSync(desc.bundleSpec));

--- a/packages/SwingSet/src/initializeSwingset.js
+++ b/packages/SwingSet/src/initializeSwingset.js
@@ -30,13 +30,23 @@ const allValues = async obj =>
 
 /**
  * Build the source bundles for the kernel and xsnap vat worker.
+ *
+ * @param {Object} [options]
+ * @param {ModuleFormat} [options.bundleFormat]
  */
-export async function buildKernelBundles() {
+export async function buildKernelBundles(options = {}) {
   // this takes 2.7s on my computer
 
-  const src = rel => bundleSource(new URL(rel, import.meta.url).pathname);
+  const { bundleFormat = undefined } = options;
+
+  const src = rel =>
+    bundleSource(new URL(rel, import.meta.url).pathname, {
+      format: bundleFormat,
+    });
   const srcGE = rel =>
-    bundleSource(new URL(rel, import.meta.url).pathname, 'getExport');
+    bundleSource(new URL(rel, import.meta.url).pathname, {
+      format: 'getExport',
+    });
 
   const bundles = await allValues({
     kernel: src('./kernel/kernel.js'),
@@ -71,7 +81,8 @@ function byName(a, b) {
  *
  * @param {string} basedir  The directory to scan
  * @param {Object} [options]
- * @param {boolean} [options.dev] whether to include devDependencies
+ * @param {boolean} [options.includeDevDependencies] whether to include devDependencies
+ * @param {ModuleFormat} [options.bundleFormat] the bundle format to use
  * @returns {SwingSetConfig} a swingset config object: {
  *   bootstrap: "bootstrap",
  *   vats: {
@@ -89,7 +100,7 @@ function byName(a, b) {
  * Swingsets defined by scanning a directory in this manner define no devices.
  */
 export function loadBasedir(basedir, options = {}) {
-  const { dev = false } = options;
+  const { includeDevDependencies = false, bundleFormat = undefined } = options;
   /** @type { SwingSetConfigDescriptor } */
   const vats = {};
   const subs = fs.readdirSync(basedir, { withFileTypes: true });
@@ -122,7 +133,7 @@ export function loadBasedir(basedir, options = {}) {
     // scanning thing is something we decide we want to have long term.
     bootstrapPath = undefined;
   }
-  const config = { vats, dev };
+  const config = { vats, includeDevDependencies, format: bundleFormat };
   if (bootstrapPath) {
     vats.bootstrap = {
       sourceSpec: bootstrapPath,
@@ -284,7 +295,9 @@ export async function initializeSwingset(
   }
 
   const {
-    kernelBundles = await buildKernelBundles(),
+    kernelBundles = await buildKernelBundles({
+      bundleFormat: config.bundleFormat,
+    }),
     verbose,
   } = initializationOptions;
 
@@ -388,7 +401,10 @@ export async function initializeSwingset(
         if (desc.sourceSpec) {
           names.push(name);
           presumptiveBundles.push(
-            bundleSource(desc.sourceSpec, { dev: config.dev }),
+            bundleSource(desc.sourceSpec, {
+              dev: config.includeDevDependencies,
+              format: config.bundleFormat,
+            }),
           );
         } else if (desc.bundleSpec) {
           names.push(name);

--- a/packages/SwingSet/src/types.js
+++ b/packages/SwingSet/src/types.js
@@ -163,6 +163,8 @@
 /**
  * @typedef {Object} SwingSetConfig a swingset config object
  * @property {string} [bootstrap]
+ * @property {boolean} [dev] indicates that `devDependencies` of the
+ * surrounding `package.json` should be accessible to bundles.
  * @property { ManagerType } [defaultManagerType]
  * @property {SwingSetConfigDescriptor} [vats]
  * @property {SwingSetConfigDescriptor} [bundles]

--- a/packages/SwingSet/src/types.js
+++ b/packages/SwingSet/src/types.js
@@ -3,6 +3,10 @@
 // import '@agoric/marshal/src/types.js';
 
 /**
+ * @typedef {'getExport' | 'nestedEvaluate' | 'endoZipBase64'} BundleFormat
+ */
+
+/**
  * @typedef {CapData<string>} SwingSetCapData
  */
 
@@ -163,11 +167,14 @@
 /**
  * @typedef {Object} SwingSetConfig a swingset config object
  * @property {string} [bootstrap]
- * @property {boolean} [dev] indicates that `devDependencies` of the
- * surrounding `package.json` should be accessible to bundles.
+ * @property {boolean} [includeDevDependencies] indicates that
+ * `devDependencies` of the surrounding `package.json` should be accessible to
+ * bundles.
  * @property { ManagerType } [defaultManagerType]
  * @property {SwingSetConfigDescriptor} [vats]
  * @property {SwingSetConfigDescriptor} [bundles]
+ * @property {BundleFormat} [bundleFormat] the bundle source / import bundle
+ * format.
  * @property {*} [devices]
  *
  * Swingsets defined by scanning a directory in this manner define no devices.

--- a/packages/sharing-service/test/swingsetTests/sharingService/test-sharing.js
+++ b/packages/sharing-service/test/swingsetTests/sharingService/test-sharing.js
@@ -10,7 +10,7 @@ const dirname = path.dirname(filename);
 
 async function main(basedir, argv) {
   const dir = path.resolve(`${dirname}/..`, basedir);
-  const config = await loadBasedir(dir);
+  const config = await loadBasedir(dir, { dev: true });
   config.defaultManagerType = 'xs-worker';
   const controller = await buildVatController(config, argv);
   await controller.run();

--- a/packages/sharing-service/test/swingsetTests/sharingService/test-sharing.js
+++ b/packages/sharing-service/test/swingsetTests/sharingService/test-sharing.js
@@ -10,7 +10,7 @@ const dirname = path.dirname(filename);
 
 async function main(basedir, argv) {
   const dir = path.resolve(`${dirname}/..`, basedir);
-  const config = await loadBasedir(dir, { dev: true });
+  const config = await loadBasedir(dir, { includeDevDependencies: true });
   config.defaultManagerType = 'xs-worker';
   const controller = await buildVatController(config, argv);
   await controller.run();


### PR DESCRIPTION
Refs: #2684

This change threads two options through `loadBasedir` and the returned `SwingsetConfig` into `initializeSwingset`. This allows for future work to isolate scenarios that do or do not work with the new Zip file archive format, and to enable `devDependencies` to be explicitly allowed for certain bundles, generally only for bundles generated for testing purposes.

Test plan forthcoming presently…