### PR TITLE
fix: Remove superfluous -S for env in shebangs

### DIFF
--- a/packages/SwingSet/tools/rekernelize.js
+++ b/packages/SwingSet/tools/rekernelize.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node
+#!/usr/bin/env node
 
 import 'node-lmdb';
 import '@agoric/babel-standalone';

--- a/packages/agoric-cli/lib/entrypoint.js
+++ b/packages/agoric-cli/lib/entrypoint.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node
+#!/usr/bin/env node
 
 /* global process */
 // TODO Remove babel-standalone and esm preinitialization

--- a/packages/swingset-runner/src/graphDisk.js
+++ b/packages/swingset-runner/src/graphDisk.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node
+#!/usr/bin/env node
 
 import { dataGraphApp } from './dataGraphApp.js';
 

--- a/packages/swingset-runner/src/graphMem.js
+++ b/packages/swingset-runner/src/graphMem.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node
+#!/usr/bin/env node
 
 import { dataGraphApp } from './dataGraphApp.js';
 

--- a/packages/swingset-runner/src/graphStats.js
+++ b/packages/swingset-runner/src/graphStats.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node
+#!/usr/bin/env node
 
 import { dataGraphApp } from './dataGraphApp.js';
 

--- a/packages/swingset-runner/src/graphTime.js
+++ b/packages/swingset-runner/src/graphTime.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node
+#!/usr/bin/env node
 
 import { dataGraphApp } from './dataGraphApp.js';
 

--- a/packages/swingset-runner/src/kerneldump-entrypoint.js
+++ b/packages/swingset-runner/src/kerneldump-entrypoint.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node
+#!/usr/bin/env node
 
 /**
  * Simple boilerplate program providing linkage to launch an application written using modules within the

--- a/packages/swingset-runner/src/runner-entrypoint.js
+++ b/packages/swingset-runner/src/runner-entrypoint.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node
+#!/usr/bin/env node
 
 // #!/usr/bin/env -S node --inspect-brk
 

--- a/packages/swingset-runner/src/slogulator-entrypoint.js
+++ b/packages/swingset-runner/src/slogulator-entrypoint.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node
+#!/usr/bin/env node
 
 /**
  * Simple boilerplate program providing linkage to launch an application written using modules within the


### PR DESCRIPTION
## Description

The `-S` flag on `/usr/bin/env` in `#!` lines is necessary when using extra command line flags like `-r esm` or `--inspect-brk`, but not portable to Linux. This change does not completely remove these lines but does remove all of the flags that are not necessary, and probably are vestiges of former use of `-r esm`.
