### PR TITLE
fix: Remove remaining uses of -r esm

### DIFF
--- a/packages/SwingSet/docs/how-to-replay.md
+++ b/packages/SwingSet/docs/how-to-replay.md
@@ -23,7 +23,7 @@ By modifying the replay tool, you can control how the replay is performed:
 Suppose you have an agoric chain node (validator or non-voting fullnode) that keeps its state in `~/.ag-chain-cosmos/`. After stopping the node (so the database is not being modified during read), the following invocation will extract a list of vatIDs to choose from:
 
 ```
-$ node -r esm extract-transcript-from-kerneldb.js ~/.ag-chain-cosmos/data/ag-cosmos-chain-state
+$ node extract-transcript-from-kerneldb.js ~/.ag-chain-cosmos/data/ag-cosmos-chain-state
 
 all vats:
 v1 : bank       (26464 deliveries)
@@ -55,7 +55,7 @@ v24 : (dynamic) {"managerType":"xs-worker"}    (1 deliveries)
 To replay the "zoe" vat, first extract the transcript:
 
 ```
-$ node -r esm extract-transcript-from-kerneldb.js ~/.ag-chain-cosmos/data/ag-cosmos-chain-state zoe
+$ node extract-transcript-from-kerneldb.js ~/.ag-chain-cosmos/data/ag-cosmos-chain-state zoe
 
 extracting transcript for vat v11 into transcript-v11.sst
 29905 transcript entries

--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -227,8 +227,6 @@ export async function makeSwingsetController(
 
   // this launches a worker in a Node.js thread (aka "Worker")
   function makeNodeWorker() {
-    // TODO: after we move away from `-r esm` and use real ES6 modules, point
-    // this at nodeWorkerSupervisor.js instead of the CJS intermediate
     const supercode = new URL(
       'kernel/vatManager/supervisor-nodeworker.js',
       import.meta.url,
@@ -242,7 +240,7 @@ export async function makeSwingsetController(
       'kernel/vatManager/supervisor-subprocess-node.js',
       import.meta.url,
     ).pathname;
-    const args = ['-r', 'esm', supercode];
+    const args = [supercode];
     return startSubprocessWorker(process.execPath, args);
   }
 

--- a/packages/SwingSet/tools/db-delete.js
+++ b/packages/SwingSet/tools/db-delete.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node -r esm
+#!/usr/bin/env node
 
 import '@agoric/install-ses';
 import process from 'process';

--- a/packages/SwingSet/tools/db-get.js
+++ b/packages/SwingSet/tools/db-get.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node -r esm
+#!/usr/bin/env node
 
 import '@agoric/install-ses';
 import process from 'process';

--- a/packages/SwingSet/tools/db-set.js
+++ b/packages/SwingSet/tools/db-set.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node -r esm
+#!/usr/bin/env node
 
 import '@agoric/install-ses';
 import process from 'process';

--- a/packages/SwingSet/tools/replace-bundle.js
+++ b/packages/SwingSet/tools/replace-bundle.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node -r esm
+#!/usr/bin/env node
 
 import '@agoric/install-ses';
 import process from 'process';

--- a/packages/eventual-send/integration-test/package.json
+++ b/packages/eventual-send/integration-test/package.json
@@ -5,14 +5,14 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "test": "tape -r esm test/*.js",
+    "test": "tape test/*.js",
     "create-test-file-no-lib-cjs": "rollup -c transform-tests/config/rollup.config.no-lib.js",
-    "test:pre-release": "tape -r esm test/test-pre-release.js",
-    "test:post-release": "tape -r esm test/test-post-release.js",
+    "test:pre-release": "tape test/test-pre-release.js",
+    "test:post-release": "tape test/test-post-release.js",
     "create-test-file-esm": "rollup -c transform-tests/config/rollup.config.esm.js",
     "create-test-file-cjs": "rollup -c transform-tests/config/rollup.config.cjs.js",
     "create-test-file-browserified-tape": "browserify transform-tests/output/test.no-lib.cjs.js > transform-tests/output/test.tape-no-lib.js --exclude @agoric/eventual-send",
-    "build:webpack": "webpack -r esm --display-error-details --config pre-release-browser-tests/webpack/webpack.config.js",
+    "build:webpack": "webpack --display-error-details --config pre-release-browser-tests/webpack/webpack.config.js",
     "build:browserify": "browserify transform-tests/output/test.cjs.js > bundles/browserify.js",
     "build:rollup": "rollup -c pre-release-browser-tests/rollup/rollup.config.test.js",
     "build:parcel": "parcel build pre-release-browser-tests/parcel/index.html --public-url ./ -d bundles/parcel"

--- a/packages/xsnap/src/replay.js
+++ b/packages/xsnap/src/replay.js
@@ -1,6 +1,6 @@
 /**
  * Replay usage:
- *   node -r esm replay.js <folder>...
+ *   node replay.js <folder>...
  *
  * In case of more than one folder:
  *  1. Spawn based on 00000-options.json in the first folder
@@ -10,6 +10,9 @@
  */
 // @ts-check
 
+import childProcessPowers from 'child_process';
+import osPowers from 'os';
+import fsPowers from 'fs';
 import { xsnap, DEFAULT_CRANK_METERING_LIMIT } from './xsnap.js';
 import { queue } from './stream.js';
 
@@ -293,17 +296,13 @@ export async function main(argv, { spawn, osType, readdirSync, readFileSync }) {
   await replayXSnap(options, folders, { readdirSync, readFileSync });
 }
 
-/* global require, module, process, require */
-if (typeof require !== 'undefined' && require.main === module) {
+/* global process */
+if (process.argv[1] === new URL(import.meta.url).pathname) {
   main([...process.argv.slice(2)], {
-    // eslint-disable-next-line global-require
-    spawn: require('child_process').spawn,
-    // eslint-disable-next-line global-require
-    osType: require('os').type,
-    // eslint-disable-next-line global-require
-    readdirSync: require('fs').readdirSync,
-    // eslint-disable-next-line global-require
-    readFileSync: require('fs').readFileSync,
+    spawn: childProcessPowers.spawn,
+    osType: osPowers.type,
+    readdirSync: fsPowers.readdirSync,
+    readFileSync: fsPowers.readFileSync,
   }).catch(err => {
     console.error(err);
     process.exit(err.code || 1);

--- a/packages/xsnap/src/xsrepl
+++ b/packages/xsnap/src/xsrepl
@@ -1,4 +1,4 @@
 #!/bin/bash
 real0=$(readlink "${BASH_SOURCE[0]}" || echo "${BASH_SOURCE[0]}")
 thisdir=$(cd "$(dirname -- "$real0")" > /dev/null && pwd -P)
-node -r esm "$thisdir/xsrepl.js" "$*"
+node "$thisdir/xsrepl.js" "$*"


### PR DESCRIPTION
This change follows #527 to erase some remaining evidence of -r esm in shebangs and incidentally also follows #3708 removing the env -S flag that does not work on Linux for these cases.