### PR TITLE
fix(assert): Improve diagnostic for missing assert global

### DIFF
--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -27,7 +27,7 @@ const globalAssert = globalThis.assert;
 
 if (globalAssert === undefined) {
   throw new Error(
-    `Cannot initialize @agoric/assert, missing globalThis.assert`,
+    `Cannot initialize @agoric/assert, missing globalThis.assert, import 'ses' before '@agoric/assert'`,
   );
 }
 


### PR DESCRIPTION
This improves the error diagnostic when the assert module fails to obtain the assert global that SES installs.
