### PR TITLE
fix(swingset): comms initialization check must be deterministic

### DIFF
--- a/packages/SwingSet/src/vats/comms/dispatch.js
+++ b/packages/SwingSet/src/vats/comms/dispatch.js
@@ -8,7 +8,6 @@ import { insistCapData } from '../../capdata.js';
 import { makeCListKit } from './clist.js';
 import { makeDeliveryKit } from './delivery.js';
 import { makeGCKit } from './gc-comms.js';
-import { cdebug } from './cdebug.js';
 
 export const debugState = new WeakMap();
 
@@ -52,19 +51,12 @@ export function buildCommsDispatch(
   // our root object (o+0) is the Comms Controller
   const controller = makeVatSlot('object', true, 0);
 
-  let needToInitializeState = true;
-
-  function initializeState() {
-    state.initialize();
-    state.addMetaObject(controller);
-    cdebug(`comms controller is ${controller}`);
-    needToInitializeState = false;
+  function maybeInitializeState() {
+    state.maybeInitialize(controller);
   }
 
   function doDeliver(target, method, args, result) {
-    if (needToInitializeState) {
-      initializeState();
-    }
+    maybeInitializeState();
     // console.debug(`comms.deliver ${target} r=${result}`);
     insistCapData(args);
 

--- a/packages/SwingSet/src/vats/comms/state.js
+++ b/packages/SwingSet/src/vats/comms/state.js
@@ -131,7 +131,7 @@ export function makeState(syscall, identifierBase = 0) {
   }
   const store = makeSyscallStore(syscall);
 
-  function initialize() {
+  function maybeInitialize(controller) {
     if (!store.get('initialized')) {
       store.set('identifierBase', `${identifierBase}`);
       store.set('lo.nextID', `${identifierBase + 10}`);
@@ -140,6 +140,11 @@ export function makeState(syscall, identifierBase = 0) {
       store.set('p.nextID', `${identifierBase + 40}`);
       store.set('r.nextID', '1');
       store.set('initialized', 'true');
+      if (controller) {
+        // eslint-disable-next-line no-use-before-define
+        addMetaObject(controller);
+        cdebug(`comms controller is ${controller}`);
+      }
     }
   }
 
@@ -725,7 +730,7 @@ export function makeState(syscall, identifierBase = 0) {
   }
 
   const state = harden({
-    initialize,
+    maybeInitialize,
 
     mapFromKernel,
     mapToKernel,

--- a/packages/SwingSet/test/test-comms.js
+++ b/packages/SwingSet/test/test-comms.js
@@ -16,7 +16,7 @@ import { commsVatDriver } from './commsVatDriver.js';
 
 test('translation', t => {
   const s = makeState(null, 0);
-  s.initialize();
+  s.maybeInitialize();
   const fakeSyscall = {};
   const clistKit = makeCListKit(s, fakeSyscall);
   const { provideRemoteForLocal, provideLocalForRemote } = clistKit;
@@ -128,7 +128,7 @@ test('transmit', t => {
   const { syscall, sends } = mockSyscall();
   const dispatch = buildCommsDispatch(syscall, 'fakestate', 'fakehelpers');
   const { state, clistKit } = debugState.get(dispatch);
-  state.initialize();
+  state.maybeInitialize();
   const {
     provideKernelForLocal,
     provideLocalForKernel,
@@ -203,7 +203,7 @@ test('receive', t => {
   const { syscall, sends, gcs } = mockSyscall();
   const dispatch = buildCommsDispatch(syscall, 'fakestate', 'fakehelpers');
   const { state, clistKit } = debugState.get(dispatch);
-  state.initialize();
+  state.maybeInitialize();
   const {
     provideLocalForKernel,
     getKernelForLocal,
@@ -349,7 +349,7 @@ test('addEgress', t => {
   const { syscall } = mockSyscall();
   const dispatch = buildCommsDispatch(syscall, 'fakestate', 'fakehelpers');
   const { state, clistKit } = debugState.get(dispatch);
-  state.initialize();
+  state.maybeInitialize();
   const { getLocalForKernel, getRemoteForLocal } = clistKit;
   const transmitterID = 'o-1';
   const remoteName = 'remote1';
@@ -382,7 +382,7 @@ test('addIngress', t => {
   const { syscall, resolves } = mockSyscall();
   const dispatch = buildCommsDispatch(syscall, 'fakestate', 'fakehelpers');
   const { state, clistKit } = debugState.get(dispatch);
-  state.initialize();
+  state.maybeInitialize();
   const { getLocalForKernel, getRemoteForLocal } = clistKit;
   const transmitterID = 'o-1';
   const remoteName = 'remote1';
@@ -416,7 +416,7 @@ test('comms gc', t => {
   const { syscall, sends, gcs } = mockSyscall();
   const dispatch = buildCommsDispatch(syscall, 'fakestate', 'fakehelpers');
   const { state, clistKit: ck } = debugState.get(dispatch);
-  state.initialize();
+  state.maybeInitialize();
   const transmitterID = 'o-1'; // vat-tp target for B
   const { remoteID, receiverID } = state.addRemote('B', transmitterID);
   function didTx(exp) {

--- a/packages/SwingSet/test/vat-activityhash-comms.js
+++ b/packages/SwingSet/test/vat-activityhash-comms.js
@@ -1,0 +1,24 @@
+import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
+
+export function buildRootObject(_vatPowers) {
+  let comms;
+
+  async function addNewRemote(name) {
+    const transmitter = Far('tx', {});
+    const setReceiver = Far('sr', {
+      setReceiver() {},
+    });
+    await E(comms).addRemote(name, transmitter, setReceiver);
+  }
+
+  return Far('root', {
+    async bootstrap(vats) {
+      comms = vats.comms;
+      await addNewRemote('remote1');
+    },
+    async addRemote(name) {
+      await addNewRemote(name);
+    },
+  });
+}


### PR DESCRIPTION
The comms vat has a bunch of counters that need to be initialized exactly
once in the lifetime of the vat's durable state. There is a DB flag named
`initialize` to track whether this has happened already or not. Since vats
can only do syscalls during deliveries, not startup (see #2910), the comms
vat must read this flag on every delivery, just in case this is the very
first one, and the DB needs initialization.

The comms vat was using an in-RAM flag (`needToInitializeState`) to cache the
result, to avoid a DB read for every single delivery. However this caused the
syscall behavior to change for the first delivery after a kernel restart.
There were two extra syscalls taking place: a `vatstoreGet('initialized')`,
and a `vatstoreSet('meta.o+0', 'true')`. The `vatstoreSet` was causing a DB
change, which was picked up by the new kernel activityhash, and caused a
consensus failure on the first post-restart comms message.

This changes the comms vat to always read the DB flag, on every delivery,
making its behavior consistent and independent of kernel restarts. It also
moves the `vatstoreSet` to be guarded by the results of the `initialized`
check, so it only happens once in the lifetime of the vat.

To remove the need for the `vatstoreGet` on each delivery, we'll need to
enhance the way `setup()` is called, to provide an external flag that tells
the vat whether this is the very first time ever, or if it's merely a kernel
restart that required the vat's `dispatch` object to be reconstructed.

fixes #3726