### PR TITLE
Reference count virtual object property references for GC

### DIFF
--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -69,12 +69,12 @@ function build(
    * Translation and tracking tables to map in-vat object/promise references
    * to/from vat-format slot strings.
    *
-   * Exports: pass-by-presence objects (Remotables) in the vat are exported
-   * as o+NN slots, as are "virtual object" exports. Promises are exported as
-   * p+NN slots. We retain a strong reference to all exports via the
-   * `exportedRemotables` Set until (TODO) the kernel tells us all external
-   * references have been dropped via dispatch.dropExports, or by some
-   * unilateral revoke-object operation executed by our user-level code.
+   * Exports: pass-by-presence objects (Remotables) in the vat are exported as
+   * o+NN slots, as are "virtual object" exports. Promises are exported as p+NN
+   * slots. We retain a strong reference to all exports via the
+   * `exportedRemotables` Set until the kernel tells us all external references
+   * have been dropped via dispatch.dropExports, or by some unilateral
+   * revoke-object operation executed by our user-level code.
    *
    * Imports: o-NN slots are represented as a Presence. p-NN slots are
    * represented as an imported Promise, with the resolver held in an
@@ -217,7 +217,9 @@ function build(
     }
     possiblyRetiredSet.clear();
 
-    for (const vref of deadSet) {
+    const deadVrefs = Array.from(deadSet);
+    deadVrefs.sort();
+    for (const vref of deadVrefs) {
       const { virtual, allocatedByVat, type } = parseVatSlot(vref);
       assert(type === 'object', `unprepared to track ${type}`);
       if (virtual) {
@@ -256,9 +258,8 @@ function build(
       syscall.retireExports(exportsToRetire);
     }
 
-    // TODO: doMore=true when we've done something that might free more local
-    // objects, which probably won't happen until we sense entire WeakMaps
-    // going away or something involving virtual collections
+    // TODO: possibly the doMore flag is never going to become relevant;
+    // investigate.
     return doMore;
   }
 

--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -53,13 +53,7 @@ function build(
   gcTools,
   console,
 ) {
-  const {
-    WeakRef,
-    FinalizationRegistry,
-    meterControl,
-    waitUntilQuiescent,
-    gcAndFinalize,
-  } = gcTools;
+  const { WeakRef, FinalizationRegistry, meterControl } = gcTools;
   const enableLSDebug = false;
   function lsdebug(...args) {
     if (enableLSDebug) {
@@ -110,7 +104,7 @@ function build(
   const valToSlot = new WeakMap(); // object -> vref
   const slotToVal = new Map(); // vref -> WeakRef(object)
   const exportedRemotables = new Set(); // objects
-  const unretiredKernelRecognizableRemotables = new Set(); // vrefs
+  const kernelRecognizableRemotables = new Set(); // vrefs
   const pendingPromises = new Set(); // Promises
   const importedDevices = new Set(); // device nodes
   const possiblyDeadSet = new Set(); // vrefs that need to be checked for being dead
@@ -128,7 +122,7 @@ function build(
         // eslint-disable-next-line no-use-before-define
         const remotable = requiredValForSlot(vref);
         exportedRemotables.add(remotable);
-        unretiredKernelRecognizableRemotables.add(vref);
+        kernelRecognizableRemotables.add(vref);
       }
     }
   }
@@ -204,27 +198,27 @@ function build(
   const droppedRegistry = new FinalizationRegistry(finalizeDroppedImport);
 
   async function scanForDeadObjects() {
+    // `possiblyDeadSet` accumulates vrefs which have lost a supporting
+    // pillar (in-memory, export, or virtualized data refcount) since the
+    // last call to scanForDeadObjects. The vref might still be supported
+    // by a remaining pillar, or the pillar which was dropped might be back
+    // (e.g., given a new in-memory manifestation).
+
     const [importsToDrop, importsToRetire, exportsToRetire] = [[], [], []];
     let doMore;
     do {
-      // `possiblyDeadSet` has accumulated vrefs which were at one point dead
-      // from the perspective of the garbage collector, i.e., the in-memory
-      // object the vref referred to was garbage collected and finalized.
-      // However, the object might have been resurrected (i.e., given a new
-      // in-memory manifestation) in the meantime, so we can't take the GC's
-      // opinion as dispositive.  `deadSet` will be used to accumulate a set of
-      // those vrefs from `possiblyDeadSet` which *right now* have no in-memory
-      // manifestation.  These might then still be considered live because they
-      // are being sustained by references from virtual objects or other vats,
-      // which we will now have to check after having weeded out the
-      // resurrections.
-      const deadSet = new Set();
+      doMore = false;
+
       // Yes, we know this is an await inside a loop.  Too bad.  (Also, it's a
       // `do {} while` loop, which means there's no conditional bypass of the
       // await.)
       // eslint-disable-next-line no-await-in-loop
-      await gcAndFinalize();
-      doMore = false;
+      await gcTools.gcAndFinalize();
+
+      // `deadSet` is the subset of those vrefs which lack an in-memory
+      // manifestation *right now* (i.e. the non-resurrected ones), for which
+      // we must check the remaining pillars.
+      const deadSet = new Set();
       for (const vref of possiblyDeadSet) {
         // eslint-disable-next-line no-use-before-define
         if (!slotToVal.has(vref)) {
@@ -261,8 +255,8 @@ function build(
           doMore = doMore || gcAgain;
         } else if (allocatedByVat) {
           // Remotable: send retireExport
-          if (unretiredKernelRecognizableRemotables.has(vref)) {
-            unretiredKernelRecognizableRemotables.delete(vref);
+          if (kernelRecognizableRemotables.has(vref)) {
+            kernelRecognizableRemotables.delete(vref);
             exportsToRetire.push(vref);
           }
         } else {
@@ -979,7 +973,7 @@ function build(
           valToSlot.delete(val);
           droppedRegistry.unregister(val);
         }
-        unretiredKernelRecognizableRemotables.delete(vref);
+        kernelRecognizableRemotables.delete(vref);
         slotToVal.delete(vref);
       }
     }
@@ -1046,7 +1040,11 @@ function build(
     assert(!didRoot);
     didRoot = true;
 
-    // vats which use D are: (bootstrap, bridge, vat-http), swingset
+    // Build the `vatPowers` provided to `buildRootObject`. We include
+    // vatGlobals and inescapableGlobalProperties to make it easier to write
+    // unit tests that share their vatPowers with the test program, for
+    // direct manipulation). 'D' is used by only a few vats: (bootstrap,
+    // bridge, vat-http).
     const vpow = {
       D,
       exitVat,
@@ -1160,7 +1158,7 @@ function build(
 
     // Instead, we wait for userspace to become idle by draining the promise
     // queue.
-    await waitUntilQuiescent();
+    await gcTools.waitUntilQuiescent();
     // Userspace will not get control again within this crank.
 
     // Now that userspace is idle, we can drive GC until we think we've

--- a/packages/SwingSet/src/kernel/virtualObjectManager.js
+++ b/packages/SwingSet/src/kernel/virtualObjectManager.js
@@ -220,8 +220,9 @@ export function makeVirtualObjectManager(
    *  - any virtual references to it (if so, it will have a refcount > 0)
    *  - being exported (if so, its export flag will be set)
    *
-   * This function is called by code that removes one of these three legs, to see
-   * if the other two legs are now gone also.
+   * This function is called after a leg has been reported missing, and only
+   * if the memory (Representative) leg is currently missing, to see if the
+   * other two legs are now gone also.
    *
    * Deletion consists of removing the vatstore entries that describe its state
    * and track its refcount status.  In addition, when a virtual object is

--- a/packages/SwingSet/test/test-device-bridge.js
+++ b/packages/SwingSet/test/test-device-bridge.js
@@ -21,6 +21,7 @@ test('bridge device', async t => {
   const hostStorage = provideHostStorage();
   const config = {
     bootstrap: 'bootstrap',
+    defaultManagerType: 'xs-worker',
     vats: {
       bootstrap: {
         sourceSpec: new URL('device-bridge-bootstrap.js', import.meta.url)

--- a/packages/SwingSet/test/test-liveslots.js
+++ b/packages/SwingSet/test/test-liveslots.js
@@ -730,17 +730,24 @@ test('GC syscall.dropImports', async t => {
   // the presence itself should be gone
   t.falsy(wr.deref());
 
-  // since nothing else is holding onto it, the vat should emit a dropImports
+  // first it will check that there are no VO's holding onto it
   const l2 = log.shift();
   t.deepEqual(l2, {
+    type: 'vatstoreGet',
+    key: 'vom.rc.o-1',
+  });
+
+  // since nothing else is holding onto it, the vat should emit a dropImports
+  const l3 = log.shift();
+  t.deepEqual(l3, {
     type: 'dropImports',
     slots: [arg],
   });
 
   // and since the vat never used the Presence in a WeakMap/WeakSet, they
   // cannot recognize it either, and will emit retireImports
-  const l3 = log.shift();
-  t.deepEqual(l3, {
+  const l4 = log.shift();
+  t.deepEqual(l4, {
     type: 'retireImports',
     slots: [arg],
   });

--- a/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
+++ b/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
@@ -114,7 +114,7 @@ test('exit with presence', async t => {
   ]);
 });
 
-test('dispatches to the dead do not harm kernel', async t => {
+test.serial('dispatches to the dead do not harm kernel', async t => {
   const configPath = new URL('swingset-speak-to-dead.json', import.meta.url)
     .pathname;
   const config = await loadSwingsetConfigFile(configPath);
@@ -162,7 +162,7 @@ test('dispatches to the dead do not harm kernel', async t => {
   }
 });
 
-test('replay does not resurrect dead vat', async t => {
+test.serial('replay does not resurrect dead vat', async t => {
   const configPath = new URL('swingset-no-zombies.json', import.meta.url)
     .pathname;
   const config = await loadSwingsetConfigFile(configPath);

--- a/packages/SwingSet/test/vat-admin/test-replay.js
+++ b/packages/SwingSet/test/vat-admin/test-replay.js
@@ -26,7 +26,7 @@ test.before(async t => {
   t.context.data = { kernelBundles, dynamicBundle };
 });
 
-test('replay bundleSource-based dynamic vat', async t => {
+test.serial('replay bundleSource-based dynamic vat', async t => {
   const config = {
     vats: {
       bootstrap: {
@@ -72,7 +72,7 @@ test('replay bundleSource-based dynamic vat', async t => {
   }
 });
 
-test('replay bundleName-based dynamic vat', async t => {
+test.serial('replay bundleName-based dynamic vat', async t => {
   const config = {
     vats: {
       bootstrap: {

--- a/packages/SwingSet/test/virtualObjects/test-representatives.js
+++ b/packages/SwingSet/test/virtualObjects/test-representatives.js
@@ -150,7 +150,7 @@ test('virtual object representatives', async t => {
   t.deepEqual(c.kpResolution(rz2), capdata('"overflow"'));
 });
 
-test('exercise cache', async t => {
+test.serial('exercise cache', async t => {
   const config = {
     bootstrap: 'bootstrap',
     vats: {

--- a/packages/SwingSet/test/virtualObjects/test-representatives.js
+++ b/packages/SwingSet/test/virtualObjects/test-representatives.js
@@ -284,6 +284,10 @@ test('exercise cache', async t => {
 
   // init cache - []
   await make('thing1', true, T1); // make t1 - [t1]
+  t.deepEqual(log.shift(), ['get', 'v1.vs.vom.rc.o-50', undefined]);
+  t.deepEqual(log.shift(), ['get', 'v1.vs.vom.rc.o-51', undefined]);
+  t.deepEqual(log.shift(), ['get', 'v1.vs.vom.rc.o-52', undefined]);
+  t.deepEqual(log.shift(), ['get', 'v1.vs.vom.rc.o-53', undefined]);
   t.deepEqual(log.shift(), ['set', esKey(1), '1']);
   t.deepEqual(log, []);
 

--- a/packages/SwingSet/test/virtualObjects/test-virtualObjectGC.js
+++ b/packages/SwingSet/test/virtualObjects/test-virtualObjectGC.js
@@ -1065,7 +1065,6 @@ test.serial('remotable refcount management 1', async t => {
   validate(v, matchVatstoreSet('vom.o+2/4', heldThingValue(null)));
   validate(v, matchVatstoreGet('vom.o+1/1'));
   validateReturned(v, rp);
-  validate(v, matchRetireExports('o+3'));
   validateDone(v);
 });
 
@@ -1095,7 +1094,6 @@ test.serial('remotable refcount management 2', async t => {
   validateDelete(v, 'o+2/3');
   validateStatusCheck(v, 'o+2/4');
   validateDelete(v, 'o+2/4');
-  validate(v, matchRetireExports('o+3'));
   validateDone(v);
 });
 

--- a/packages/SwingSet/test/virtualObjects/test-virtualObjectGC.js
+++ b/packages/SwingSet/test/virtualObjects/test-virtualObjectGC.js
@@ -1095,10 +1095,6 @@ test.serial('remotable refcount management 2', async t => {
   validateDelete(v, 'o+2/3');
   validateStatusCheck(v, 'o+2/4');
   validateDelete(v, 'o+2/4');
-  validateDone(v);
-
-  rp = await dispatchMessage('noOp');
-  validateReturned(v, rp);
   validate(v, matchRetireExports('o+3'));
   validateDone(v);
 });

--- a/packages/SwingSet/test/virtualObjects/test-virtualObjectManager.js
+++ b/packages/SwingSet/test/virtualObjects/test-virtualObjectManager.js
@@ -379,6 +379,7 @@ test('virtual object gc', t => {
   pretendGC('o+1/1');
   t.is(log.shift(), `get vom.rc.o+1/1 => undefined`);
   t.is(log.shift(), `get vom.es.o+1/1 => 0`);
+  t.is(log.shift(), `get vom.o+1/1 => ${thingVal(0, 'thing #1', 0)}`);
   t.is(log.shift(), `delete vom.o+1/1`);
   t.is(log.shift(), `delete vom.rc.o+1/1`);
   t.is(log.shift(), `delete vom.es.o+1/1`);
@@ -411,6 +412,7 @@ test('virtual object gc', t => {
   pretendGC('o+1/2');
   t.is(log.shift(), `get vom.rc.o+1/2 => undefined`);
   t.is(log.shift(), `get vom.es.o+1/2 => 0`);
+  t.is(log.shift(), `get vom.o+1/2 => ${thingVal(0, 'thing #2', 0)}`);
   t.is(log.shift(), `delete vom.o+1/2`);
   t.is(log.shift(), `delete vom.rc.o+1/2`);
   t.is(log.shift(), `delete vom.es.o+1/2`);
@@ -426,6 +428,7 @@ test('virtual object gc', t => {
   pretendGC('o+1/3');
   t.is(log.shift(), `get vom.rc.o+1/3 => undefined`);
   t.is(log.shift(), `get vom.es.o+1/3 => undefined`);
+  t.is(log.shift(), `get vom.o+1/3 => ${thingVal(0, 'thing #3', 0)}`);
   t.is(log.shift(), `delete vom.o+1/3`);
   t.is(log.shift(), `delete vom.rc.o+1/3`);
   t.is(log.shift(), `delete vom.es.o+1/3`);


### PR DESCRIPTION
Previously we treated any reference to an object in the value of a virtual object property as a permanent reference to that object, preventing its garbage collection forever.  With this set of changes, these references are now counted, and any unreferenced objects become eligible for garbage collection, regardless of whether the reference is to a virtual object, a presence or a local (remotable) object.