### PR TITLE
fix(cosmos): ensure simulated transactions can't trigger SwingSet

### DIFF
--- a/golang/cosmos/vm/controller.go
+++ b/golang/cosmos/vm/controller.go
@@ -25,6 +25,8 @@ var nameToPort = make(map[string]int)
 var lastPort = 0
 
 func SetControllerContext(ctx sdk.Context) func() {
+	// We are only called by the controller, so we assume that it is billing its
+	// own meter usage.
 	controllerContext.Context = ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
 	return func() {
 		controllerContext.Context = sdk.Context{}

--- a/golang/cosmos/x/swingset/abci.go
+++ b/golang/cosmos/x/swingset/abci.go
@@ -49,7 +49,7 @@ func BeginBlock(ctx sdk.Context, req abci.RequestBeginBlock, keeper Keeper) erro
 		return sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
-	_, err = keeper.CallToController(ctx, string(b))
+	_, err = keeper.CallToController(ctx, string(b), "")
 
 	// fmt.Fprintln(os.Stderr, "Returned from SwingSet", out, err)
 	return err
@@ -71,7 +71,7 @@ func EndBlock(ctx sdk.Context, req abci.RequestEndBlock, keeper Keeper) ([]abci.
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
-	_, err = keeper.CallToController(ctx, string(b))
+	_, err = keeper.CallToController(ctx, string(b), "")
 
 	// fmt.Fprintln(os.Stderr, "Returned from SwingSet", out, err)
 	if err != nil {
@@ -102,7 +102,7 @@ func CommitBlock(keeper Keeper) error {
 		return sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
-	_, err = keeper.CallToController(sdk.Context{}, string(b))
+	_, err = keeper.CallToController(sdk.Context{}, string(b), "")
 
 	// fmt.Fprintln(os.Stderr, "Returned from SwingSet", out, err)
 	if err != nil {

--- a/golang/cosmos/x/swingset/genesis.go
+++ b/golang/cosmos/x/swingset/genesis.go
@@ -53,7 +53,7 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, data *types.GenesisState) []abc
 		panic(err)
 	}
 
-	_, err = keeper.CallToController(ctx, string(b))
+	_, err = keeper.CallToController(ctx, string(b), "")
 
 	if err != nil {
 		// NOTE: A failed BOOTSTRAP_BLOCK means that the SwingSet state is inconsistent.

--- a/golang/cosmos/x/swingset/handler.go
+++ b/golang/cosmos/x/swingset/handler.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Agoric/agoric-sdk/golang/cosmos/vm"
 	"github.com/Agoric/agoric-sdk/golang/cosmos/x/swingset/keeper"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -17,14 +16,6 @@ func NewHandler(k Keeper) sdk.Handler {
 	msgServer := keeper.NewMsgServerImpl(k)
 
 	return func(ctx sdk.Context, msg sdk.Msg) (*sdk.Result, error) {
-		if vm.IsSimulation(ctx) {
-			// We don't support simulation.
-			return &sdk.Result{}, nil
-		} else {
-			// The simulation was done, so now allow infinite gas.
-			ctx = ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
-		}
-
 		ctx = ctx.WithEventManager(sdk.NewEventManager())
 
 		switch msg := msg.(type) {

--- a/golang/cosmos/x/swingset/keeper/keeper.go
+++ b/golang/cosmos/x/swingset/keeper/keeper.go
@@ -26,7 +26,7 @@ type Keeper struct {
 	bankKeeper    bankkeeper.Keeper
 
 	// CallToController dispatches a message to the controlling process
-	CallToController func(ctx sdk.Context, str string) (string, error)
+	CallToController func(ctx sdk.Context, str, simReturn string) (string, error)
 }
 
 // A prefix of bytes, since KVStores can't handle empty slices as keys.
@@ -48,7 +48,7 @@ func stringToKey(keyStr string) []byte {
 func NewKeeper(
 	cdc codec.Codec, key sdk.StoreKey,
 	accountKeeper authkeeper.AccountKeeper, bankKeeper bankkeeper.Keeper,
-	callToController func(ctx sdk.Context, str string) (string, error),
+	callToController func(ctx sdk.Context, str, simReturn string) (string, error),
 ) Keeper {
 
 	return Keeper{

--- a/golang/cosmos/x/swingset/keeper/msg_server.go
+++ b/golang/cosmos/x/swingset/keeper/msg_server.go
@@ -58,7 +58,7 @@ func (keeper msgServer) DeliverInbound(goCtx context.Context, msg *types.MsgDeli
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
-	_, err = keeper.CallToController(ctx, string(b))
+	_, err = keeper.CallToController(ctx, string(b), "")
 	// fmt.Fprintln(os.Stderr, "Returned from SwingSet", out, err)
 	if err != nil {
 		return nil, err
@@ -104,7 +104,7 @@ func (keeper msgServer) Provision(goCtx context.Context, msg *types.MsgProvision
 		return nil, err
 	}
 
-	_, err = keeper.CallToController(ctx, string(b))
+	_, err = keeper.CallToController(ctx, string(b), "")
 	// fmt.Fprintln(os.Stderr, "Returned from SwingSet", out, err)
 	if err != nil {
 		return nil, err

--- a/golang/cosmos/x/vbank/handler.go
+++ b/golang/cosmos/x/vbank/handler.go
@@ -3,7 +3,6 @@ package vbank
 import (
 	"fmt"
 
-	"github.com/Agoric/agoric-sdk/golang/cosmos/vm"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
@@ -11,14 +10,6 @@ import (
 // NewHandler returns a handler for "vbank" type messages.
 func NewHandler(keeper Keeper) sdk.Handler {
 	return func(ctx sdk.Context, msg sdk.Msg) (*sdk.Result, error) {
-		if vm.IsSimulation(ctx) {
-			// We don't support simulation.
-			return &sdk.Result{}, nil
-		} else {
-			// The simulation was done, so now allow infinite gas.
-			ctx = ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
-		}
-
 		switch msg := msg.(type) {
 		default:
 			errMsg := fmt.Sprintf("Unrecognized vbank Msg type: %T", msg)

--- a/golang/cosmos/x/vbank/keeper/keeper.go
+++ b/golang/cosmos/x/vbank/keeper/keeper.go
@@ -20,7 +20,7 @@ type Keeper struct {
 	bankKeeper       types.BankKeeper
 	feeCollectorName string
 	// CallToController dispatches a message to the controlling process
-	CallToController func(ctx sdk.Context, str string) (string, error)
+	CallToController func(ctx sdk.Context, str, simReturn string) (string, error)
 }
 
 // NewKeeper creates a new vbank Keeper instance
@@ -28,7 +28,7 @@ func NewKeeper(
 	cdc codec.Codec, key sdk.StoreKey, paramSpace paramtypes.Subspace,
 	bankKeeper types.BankKeeper,
 	feeCollectorName string,
-	callToController func(ctx sdk.Context, str string) (string, error),
+	callToController func(ctx sdk.Context, str, simReturn string) (string, error),
 ) Keeper {
 
 	// set KeyTable if it has not already been set

--- a/golang/cosmos/x/vbank/module.go
+++ b/golang/cosmos/x/vbank/module.go
@@ -192,7 +192,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) []abci.V
 		panic(err)
 	}
 	if bz != nil {
-		_, err := am.CallToController(ctx, string(bz))
+		_, err := am.CallToController(ctx, string(bz), "")
 		if err != nil {
 			panic(err)
 		}

--- a/golang/cosmos/x/vbank/vbank.go
+++ b/golang/cosmos/x/vbank/vbank.go
@@ -227,9 +227,9 @@ func (ch portHandler) Receive(ctx *vm.ControllerContext, str string) (ret string
 	return
 }
 
-func (am AppModule) CallToController(ctx sdk.Context, send string) (string, error) {
+func (am AppModule) CallToController(ctx sdk.Context, send, simReturn string) (string, error) {
 	// fmt.Println("vbank.go upcall", send)
-	reply, err := am.keeper.CallToController(ctx, send)
+	reply, err := am.keeper.CallToController(ctx, send, simReturn)
 	// fmt.Println("vbank.go upcall reply", reply, err)
 	return reply, err
 }

--- a/golang/cosmos/x/vbank/vbank_test.go
+++ b/golang/cosmos/x/vbank/vbank_test.go
@@ -229,8 +229,8 @@ func (b *mockBank) SendCoinsFromModuleToModule(ctx sdk.Context, senderModule, re
 func makeTestKit(bank types.BankKeeper) (Keeper, sdk.Context) {
 	encodingConfig := params.MakeEncodingConfig()
 	cdc := encodingConfig.Marshaller
-	callToController := func(ctx sdk.Context, str string) (string, error) {
-		return "", nil
+	callToController := func(ctx sdk.Context, str, simReturn string) (string, error) {
+		return simReturn, nil
 	}
 
 	paramsTStoreKey := sdk.NewTransientStoreKey(paramstypes.TStoreKey)
@@ -472,9 +472,9 @@ func Test_EndBlock_Events(t *testing.T) {
 	}}
 	keeper, ctx := makeTestKit(bank)
 	msgsSent := []string{}
-	keeper.CallToController = func(ctx sdk.Context, str string) (string, error) {
+	keeper.CallToController = func(ctx sdk.Context, str, simReturn string) (string, error) {
 		msgsSent = append(msgsSent, str)
-		return "", nil
+		return simReturn, nil
 	}
 	am := NewAppModule(keeper)
 
@@ -546,9 +546,9 @@ func Test_EndBlock_Rewards(t *testing.T) {
 	}
 	keeper, ctx := makeTestKit(bank)
 	msgsSent := []string{}
-	keeper.CallToController = func(ctx sdk.Context, str string) (string, error) {
+	keeper.CallToController = func(ctx sdk.Context, str, simReturn string) (string, error) {
 		msgsSent = append(msgsSent, str)
-		return "", nil
+		return simReturn, nil
 	}
 	am := NewAppModule(keeper)
 

--- a/golang/cosmos/x/vibc/handler.go
+++ b/golang/cosmos/x/vibc/handler.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/Agoric/agoric-sdk/golang/cosmos/vm"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
@@ -12,14 +11,6 @@ import (
 // NewHandler returns a handler for "vibc" type messages.
 func NewHandler(keeper Keeper) sdk.Handler {
 	return func(ctx sdk.Context, msg sdk.Msg) (*sdk.Result, error) {
-		if vm.IsSimulation(ctx) {
-			// We don't support simulation.
-			return &sdk.Result{}, nil
-		} else {
-			// The simulation was done, so now allow infinite gas.
-			ctx = ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
-		}
-
 		switch msg := msg.(type) {
 		case *MsgSendPacket:
 			return handleMsgSendPacket(ctx, keeper, msg)
@@ -62,7 +53,7 @@ func handleMsgSendPacket(ctx sdk.Context, keeper Keeper, msg *MsgSendPacket) (*s
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
-	_, err = keeper.CallToController(ctx, string(b))
+	_, err = keeper.CallToController(ctx, string(b), "")
 	// fmt.Fprintln(os.Stderr, "Returned from SwingSet", out, err)
 	if err != nil {
 		return nil, err

--- a/golang/cosmos/x/vibc/keeper/keeper.go
+++ b/golang/cosmos/x/vibc/keeper/keeper.go
@@ -28,7 +28,7 @@ type Keeper struct {
 	bankKeeper    bankkeeper.Keeper
 
 	// CallToController dispatches a message to the controlling process
-	CallToController func(ctx sdk.Context, str string) (string, error)
+	CallToController func(ctx sdk.Context, str, simReturn string) (string, error)
 }
 
 // NewKeeper creates a new dIBC Keeper instance
@@ -37,7 +37,7 @@ func NewKeeper(
 	channelKeeper types.ChannelKeeper, portKeeper types.PortKeeper,
 	bankKeeper bankkeeper.Keeper,
 	scopedKeeper capabilitykeeper.ScopedKeeper,
-	callToController func(ctx sdk.Context, str string) (string, error),
+	callToController func(ctx sdk.Context, str, simReturn string) (string, error),
 ) Keeper {
 
 	return Keeper{


### PR DESCRIPTION
Closes #3739

The former pattern of `vm.IsSimulation` was too brittle to handle
our migration to the GRPC-based transaction handlers.  Instead,
intercept the actual invocation of CallToController and prevent
it from running anything in SwingSet if in simulation mode.

Also, make sure our InfiniteGasMeter is only assigned once, so
that if we ever do Cosmos-level metering of SwingSet downcalls,
there is only one place to adjust.