### PR TITLE
Cosmos bootstrap block is not a simulation

### DIFF
--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -358,10 +358,10 @@ func NewAgoricApp(
 	)
 
 	// This function is tricky to get right, so we build it ourselves.
-	callToController := func(ctx sdk.Context, str, simReturn string) (string, error) {
+	callToController := func(ctx sdk.Context, str string) (string, error) {
 		if vm.IsSimulation(ctx) {
-			// Just return the simReturn, since the message is being simulated.
-			return simReturn, nil
+			// Just return empty, since the message is being simulated.
+			return "", nil
 		}
 		// We use SwingSet-level metering to charge the user for the call.
 		app.MustInitController(ctx)
@@ -570,7 +570,7 @@ func (app *GaiaApp) MustInitController(ctx sdk.Context) {
 	}
 	bz, err := json.Marshal(action)
 	if err == nil {
-		_, err = app.SwingSetKeeper.CallToController(ctx, string(bz), "")
+		_, err = app.SwingSetKeeper.CallToController(ctx, string(bz))
 	}
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Cannot initialize Controller", err)

--- a/golang/cosmos/vm/height.go
+++ b/golang/cosmos/vm/height.go
@@ -8,6 +8,11 @@ var committedHeight int64 = 0
 
 // IsSimulation tells if we are simulating the transaction
 func IsSimulation(ctx sdk.Context) bool {
+	// If we haven't committed yet, we're still in bootstrap.
+	if committedHeight == 0 {
+		return false
+	}
+	// Otherwise, if we already committed this block, we're in simulation.
 	return committedHeight == ctx.BlockHeight()
 }
 

--- a/golang/cosmos/x/swingset/abci.go
+++ b/golang/cosmos/x/swingset/abci.go
@@ -49,7 +49,7 @@ func BeginBlock(ctx sdk.Context, req abci.RequestBeginBlock, keeper Keeper) erro
 		return sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
-	_, err = keeper.CallToController(ctx, string(b), "")
+	_, err = keeper.CallToController(ctx, string(b))
 
 	// fmt.Fprintln(os.Stderr, "Returned from SwingSet", out, err)
 	return err
@@ -71,7 +71,7 @@ func EndBlock(ctx sdk.Context, req abci.RequestEndBlock, keeper Keeper) ([]abci.
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
-	_, err = keeper.CallToController(ctx, string(b), "")
+	_, err = keeper.CallToController(ctx, string(b))
 
 	// fmt.Fprintln(os.Stderr, "Returned from SwingSet", out, err)
 	if err != nil {
@@ -102,7 +102,7 @@ func CommitBlock(keeper Keeper) error {
 		return sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
-	_, err = keeper.CallToController(sdk.Context{}, string(b), "")
+	_, err = keeper.CallToController(sdk.Context{}, string(b))
 
 	// fmt.Fprintln(os.Stderr, "Returned from SwingSet", out, err)
 	if err != nil {

--- a/golang/cosmos/x/swingset/genesis.go
+++ b/golang/cosmos/x/swingset/genesis.go
@@ -53,7 +53,7 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, data *types.GenesisState) []abc
 		panic(err)
 	}
 
-	_, err = keeper.CallToController(ctx, string(b), "")
+	_, err = keeper.CallToController(ctx, string(b))
 
 	if err != nil {
 		// NOTE: A failed BOOTSTRAP_BLOCK means that the SwingSet state is inconsistent.

--- a/golang/cosmos/x/swingset/keeper/keeper.go
+++ b/golang/cosmos/x/swingset/keeper/keeper.go
@@ -26,7 +26,7 @@ type Keeper struct {
 	bankKeeper    bankkeeper.Keeper
 
 	// CallToController dispatches a message to the controlling process
-	CallToController func(ctx sdk.Context, str, simReturn string) (string, error)
+	CallToController func(ctx sdk.Context, str string) (string, error)
 }
 
 // A prefix of bytes, since KVStores can't handle empty slices as keys.
@@ -48,7 +48,7 @@ func stringToKey(keyStr string) []byte {
 func NewKeeper(
 	cdc codec.Codec, key sdk.StoreKey,
 	accountKeeper authkeeper.AccountKeeper, bankKeeper bankkeeper.Keeper,
-	callToController func(ctx sdk.Context, str, simReturn string) (string, error),
+	callToController func(ctx sdk.Context, str string) (string, error),
 ) Keeper {
 
 	return Keeper{

--- a/golang/cosmos/x/swingset/keeper/msg_server.go
+++ b/golang/cosmos/x/swingset/keeper/msg_server.go
@@ -58,7 +58,7 @@ func (keeper msgServer) DeliverInbound(goCtx context.Context, msg *types.MsgDeli
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
-	_, err = keeper.CallToController(ctx, string(b), "")
+	_, err = keeper.CallToController(ctx, string(b))
 	// fmt.Fprintln(os.Stderr, "Returned from SwingSet", out, err)
 	if err != nil {
 		return nil, err
@@ -104,7 +104,7 @@ func (keeper msgServer) Provision(goCtx context.Context, msg *types.MsgProvision
 		return nil, err
 	}
 
-	_, err = keeper.CallToController(ctx, string(b), "")
+	_, err = keeper.CallToController(ctx, string(b))
 	// fmt.Fprintln(os.Stderr, "Returned from SwingSet", out, err)
 	if err != nil {
 		return nil, err

--- a/golang/cosmos/x/vbank/keeper/keeper.go
+++ b/golang/cosmos/x/vbank/keeper/keeper.go
@@ -20,7 +20,7 @@ type Keeper struct {
 	bankKeeper       types.BankKeeper
 	feeCollectorName string
 	// CallToController dispatches a message to the controlling process
-	CallToController func(ctx sdk.Context, str, simReturn string) (string, error)
+	CallToController func(ctx sdk.Context, str string) (string, error)
 }
 
 // NewKeeper creates a new vbank Keeper instance
@@ -28,7 +28,7 @@ func NewKeeper(
 	cdc codec.Codec, key sdk.StoreKey, paramSpace paramtypes.Subspace,
 	bankKeeper types.BankKeeper,
 	feeCollectorName string,
-	callToController func(ctx sdk.Context, str, simReturn string) (string, error),
+	callToController func(ctx sdk.Context, str string) (string, error),
 ) Keeper {
 
 	// set KeyTable if it has not already been set

--- a/golang/cosmos/x/vbank/module.go
+++ b/golang/cosmos/x/vbank/module.go
@@ -192,7 +192,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) []abci.V
 		panic(err)
 	}
 	if bz != nil {
-		_, err := am.CallToController(ctx, string(bz), "")
+		_, err := am.CallToController(ctx, string(bz))
 		if err != nil {
 			panic(err)
 		}

--- a/golang/cosmos/x/vbank/vbank.go
+++ b/golang/cosmos/x/vbank/vbank.go
@@ -227,9 +227,9 @@ func (ch portHandler) Receive(ctx *vm.ControllerContext, str string) (ret string
 	return
 }
 
-func (am AppModule) CallToController(ctx sdk.Context, send, simReturn string) (string, error) {
+func (am AppModule) CallToController(ctx sdk.Context, send string) (string, error) {
 	// fmt.Println("vbank.go upcall", send)
-	reply, err := am.keeper.CallToController(ctx, send, simReturn)
+	reply, err := am.keeper.CallToController(ctx, send)
 	// fmt.Println("vbank.go upcall reply", reply, err)
 	return reply, err
 }

--- a/golang/cosmos/x/vbank/vbank_test.go
+++ b/golang/cosmos/x/vbank/vbank_test.go
@@ -229,8 +229,8 @@ func (b *mockBank) SendCoinsFromModuleToModule(ctx sdk.Context, senderModule, re
 func makeTestKit(bank types.BankKeeper) (Keeper, sdk.Context) {
 	encodingConfig := params.MakeEncodingConfig()
 	cdc := encodingConfig.Marshaller
-	callToController := func(ctx sdk.Context, str, simReturn string) (string, error) {
-		return simReturn, nil
+	callToController := func(ctx sdk.Context, str string) (string, error) {
+		return "", nil
 	}
 
 	paramsTStoreKey := sdk.NewTransientStoreKey(paramstypes.TStoreKey)
@@ -472,9 +472,9 @@ func Test_EndBlock_Events(t *testing.T) {
 	}}
 	keeper, ctx := makeTestKit(bank)
 	msgsSent := []string{}
-	keeper.CallToController = func(ctx sdk.Context, str, simReturn string) (string, error) {
+	keeper.CallToController = func(ctx sdk.Context, str string) (string, error) {
 		msgsSent = append(msgsSent, str)
-		return simReturn, nil
+		return "", nil
 	}
 	am := NewAppModule(keeper)
 
@@ -546,9 +546,9 @@ func Test_EndBlock_Rewards(t *testing.T) {
 	}
 	keeper, ctx := makeTestKit(bank)
 	msgsSent := []string{}
-	keeper.CallToController = func(ctx sdk.Context, str, simReturn string) (string, error) {
+	keeper.CallToController = func(ctx sdk.Context, str string) (string, error) {
 		msgsSent = append(msgsSent, str)
-		return simReturn, nil
+		return "", nil
 	}
 	am := NewAppModule(keeper)
 

--- a/golang/cosmos/x/vibc/handler.go
+++ b/golang/cosmos/x/vibc/handler.go
@@ -53,7 +53,7 @@ func handleMsgSendPacket(ctx sdk.Context, keeper Keeper, msg *MsgSendPacket) (*s
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
-	_, err = keeper.CallToController(ctx, string(b), "")
+	_, err = keeper.CallToController(ctx, string(b))
 	// fmt.Fprintln(os.Stderr, "Returned from SwingSet", out, err)
 	if err != nil {
 		return nil, err

--- a/golang/cosmos/x/vibc/ibc.go
+++ b/golang/cosmos/x/vibc/ibc.go
@@ -172,9 +172,9 @@ func (ch portHandler) Receive(ctx *vm.ControllerContext, str string) (ret string
 	return
 }
 
-func (am AppModule) CallToController(ctx sdk.Context, send, simReturn string) (string, error) {
+func (am AppModule) CallToController(ctx sdk.Context, send string) (string, error) {
 	// fmt.Println("ibc.go upcall", send)
-	reply, err := am.keeper.CallToController(ctx, send, simReturn)
+	reply, err := am.keeper.CallToController(ctx, send)
 	// fmt.Println("ibc.go upcall reply", reply, err)
 	return reply, err
 }
@@ -221,7 +221,7 @@ func (am AppModule) OnChanOpenInit(
 		return err
 	}
 
-	_, err = am.CallToController(ctx, string(bytes), "")
+	_, err = am.CallToController(ctx, string(bytes))
 	if err != nil {
 		return err
 	}
@@ -278,7 +278,7 @@ func (am AppModule) OnChanOpenTry(
 		return err
 	}
 
-	_, err = am.CallToController(ctx, string(bytes), "")
+	_, err = am.CallToController(ctx, string(bytes))
 	if err != nil {
 		return err
 	}
@@ -328,7 +328,7 @@ func (am AppModule) OnChanOpenAck(
 		return err
 	}
 
-	_, err = am.CallToController(ctx, string(bytes), "")
+	_, err = am.CallToController(ctx, string(bytes))
 	return err
 }
 
@@ -360,7 +360,7 @@ func (am AppModule) OnChanOpenConfirm(
 		return err
 	}
 
-	_, err = am.CallToController(ctx, string(bytes), "")
+	_, err = am.CallToController(ctx, string(bytes))
 	return err
 }
 
@@ -392,7 +392,7 @@ func (am AppModule) OnChanCloseInit(
 		return err
 	}
 
-	_, err = am.CallToController(ctx, string(bytes), "")
+	_, err = am.CallToController(ctx, string(bytes))
 	return err
 }
 
@@ -424,7 +424,7 @@ func (am AppModule) OnChanCloseConfirm(
 		return err
 	}
 
-	_, err = am.CallToController(ctx, string(bytes), "")
+	_, err = am.CallToController(ctx, string(bytes))
 	return err
 }
 
@@ -461,7 +461,7 @@ func (am AppModule) OnRecvPacket(
 		return channeltypes.NewErrorAcknowledgement(err.Error())
 	}
 
-	_, err = am.CallToController(ctx, string(bytes), "")
+	_, err = am.CallToController(ctx, string(bytes))
 	if err != nil {
 		return channeltypes.NewErrorAcknowledgement(err.Error())
 	}
@@ -497,7 +497,7 @@ func (am AppModule) OnAcknowledgementPacket(
 		return nil, err
 	}
 
-	_, err = am.CallToController(ctx, string(bytes), "")
+	_, err = am.CallToController(ctx, string(bytes))
 	if err != nil {
 		return nil, err
 	}
@@ -532,7 +532,7 @@ func (am AppModule) OnTimeoutPacket(
 		return nil, err
 	}
 
-	_, err = am.CallToController(ctx, string(bytes), "")
+	_, err = am.CallToController(ctx, string(bytes))
 	if err != nil {
 		return nil, err
 	}

--- a/golang/cosmos/x/vibc/keeper/keeper.go
+++ b/golang/cosmos/x/vibc/keeper/keeper.go
@@ -28,7 +28,7 @@ type Keeper struct {
 	bankKeeper    bankkeeper.Keeper
 
 	// CallToController dispatches a message to the controlling process
-	CallToController func(ctx sdk.Context, str, simReturn string) (string, error)
+	CallToController func(ctx sdk.Context, str string) (string, error)
 }
 
 // NewKeeper creates a new dIBC Keeper instance
@@ -37,7 +37,7 @@ func NewKeeper(
 	channelKeeper types.ChannelKeeper, portKeeper types.PortKeeper,
 	bankKeeper bankkeeper.Keeper,
 	scopedKeeper capabilitykeeper.ScopedKeeper,
-	callToController func(ctx sdk.Context, str, simReturn string) (string, error),
+	callToController func(ctx sdk.Context, str string) (string, error),
 ) Keeper {
 
 	return Keeper{


### PR DESCRIPTION
Fix an initialisation error with `vm.IsSimulation`.  Any block that happens before the first commit is definitely a bootstrap block, not a simulation.

Also refactor back to the original `CallToController` arguments; we can use `""` as a sentinel for a simulated block instead of having the caller pass it in every time.
