### PR TITLE
Experiment: #3448 without paramType

### DIFF
--- a/packages/governance/src/ballotBuilder.js
+++ b/packages/governance/src/ballotBuilder.js
@@ -6,7 +6,7 @@ import { sameStructure } from '@agoric/same-structure';
 import { makeHandle } from '@agoric/zoe/src/makeHandle.js';
 import { Nat } from '@agoric/nat';
 
-import { assertType, ParamType } from './paramManager.js';
+import { looksLikeParam } from './paramManager.js';
 
 /**
  * @type {{
@@ -65,7 +65,7 @@ const looksLikeParamChangeQuestion = question => {
     X`Question ("${question}") must be a record with paramSpec: anObject`,
   );
   assert(question.proposedValue);
-  assertType(ParamType.INSTANCE, question.contract, 'contract');
+  looksLikeParam(question.contract, 'contract');
 };
 
 /** @type {LooksLikeQuestionForType} */

--- a/packages/governance/src/governParam.js
+++ b/packages/governance/src/governParam.js
@@ -12,7 +12,7 @@ import {
   ElectionType,
   looksLikeBallotSpec,
 } from './ballotBuilder.js';
-import { assertType } from './paramManager.js';
+import { looksLikeParam } from './paramManager.js';
 
 /** @type {MakeParamChangePositions} */
 const makeParamChangePositions = (paramSpec, proposedValue) => {
@@ -74,8 +74,7 @@ const setupGovernance = async (
   ) => {
     const paramMgr = E(paramManagerAccessor).get(paramSpec);
     const paramName = paramSpec.parameterName;
-    const param = await E(paramMgr).getParam(paramName);
-    assertType(param.type, proposedValue, paramName);
+    looksLikeParam(proposedValue, paramName);
     const outcomeOfUpdateP = makePromiseKit();
 
     const { positive, negative } = makeParamChangePositions(

--- a/packages/governance/src/paramManager.js
+++ b/packages/governance/src/paramManager.js
@@ -1,120 +1,49 @@
 // @ts-check
 
 import { assert, details as X } from '@agoric/assert';
-import { assertIsRatio } from '@agoric/zoe/src/contractSupport/index.js';
-import { AmountMath, looksLikeBrand } from '@agoric/ertp';
 import { Far } from '@agoric/marshal';
 import { assertKeywordName } from '@agoric/zoe/src/cleanProposal.js';
-import { Nat } from '@agoric/nat';
-
-/**
- * @type {{
- *  AMOUNT: 'amount',
- *  BRAND: 'brand',
- *  INSTANCE: 'instance',
- *  INSTALLATION: 'installation',
- *  NAT: 'nat',
- *  RATIO: 'ratio',
- *  STRING: 'string',
- *  UNKNOWN: 'unknown',
- * }}
- *
- * UNKNOWN is an escape hatch for types we haven't added yet. If you are
- * developing a new contract and use UNKNOWN, please also file an issue to ask
- * us to support the new type.
- */
-const ParamType = {
-  AMOUNT: 'amount',
-  BRAND: 'brand',
-  INSTANCE: 'instance',
-  INSTALLATION: 'installation',
-  NAT: 'nat',
-  RATIO: 'ratio',
-  STRING: 'string',
-  UNKNOWN: 'unknown',
-};
+import { mustBeComparable } from '@agoric/same-structure';
 
 /** @type {AssertParamManagerType} */
-const assertType = (type, value, name) => {
-  switch (type) {
-    case ParamType.AMOUNT:
-      // It would be nice to have a clean way to assert something is an amount.
-      // @ts-ignore value is undifferentiated to this point
-      AmountMath.coerce(value.brand, value);
-      break;
-    case ParamType.BRAND:
-      assert(
-        // @ts-ignore value is undifferentiated to this point
-        looksLikeBrand(value),
-        X`value for ${name} must be a brand, was ${value}`,
-      );
-      break;
-    case ParamType.INSTALLATION:
-      // TODO(3344): add a better assertion once Zoe validates installations
-      assert(
-        typeof value === 'object' &&
-          Object.getOwnPropertyNames(value).length === 1,
-        X`value for ${name} must be an Installation, was ${value}`,
-      );
-      break;
-    case ParamType.INSTANCE:
-      // TODO(3344): add a better assertion once Zoe validates instances
-      assert(
-        typeof value === 'object' && !Object.getOwnPropertyNames(value).length,
-        X`value for ${name} must be an Instance, was ${value}`,
-      );
-      break;
-    case ParamType.NAT:
-      assert.typeof(value, 'bigint');
-      Nat(value);
-      break;
-    case ParamType.RATIO:
-      assertIsRatio(value);
-      break;
-    case ParamType.STRING:
-      assert.typeof(value, 'string');
-      break;
-    case ParamType.UNKNOWN:
-      break;
-    default:
-      assert.fail(X`unrecognized type ${type}`);
-  }
+const looksLikeParam = (value, name) => {
+  assert.typeof(name, 'string');
+  mustBeComparable(value);
 };
 
 /** @type {BuildParamManager} */
 const buildParamManager = paramDescriptions => {
-  const typesAndValues = {};
+  const paramValues = {};
   // updateFns will have updateFoo() for each Foo param.
   const updateFns = {};
 
-  paramDescriptions.forEach(({ name, value, type }) => {
+  paramDescriptions.forEach(({ name, value }) => {
     // we want to create function names like updateFeeRatio(), so we insist that
     // the name has Keyword-nature.
     assertKeywordName(name);
 
     assert(
-      !typesAndValues[name],
+      !paramValues[name],
       X`each parameter name must be unique: ${name} duplicated`,
     );
-    assertType(type, value, name);
+    looksLikeParam(value, name);
 
-    typesAndValues[name] = { type, value };
+    paramValues[name] = { value };
     updateFns[`update${name}`] = newValue => {
-      assertType(type, newValue, name);
-      typesAndValues[name].value = newValue;
+      looksLikeParam(newValue, name);
+      paramValues[name].value = newValue;
       return newValue;
     };
   });
 
   const makeDescription = name => ({
     name,
-    type: typesAndValues[name].type,
-    value: typesAndValues[name].value,
+    value: paramValues[name].value,
   });
   const getParams = () => {
     /** @type {Record<Keyword,ParamDescription>} */
     const descriptions = {};
-    Object.getOwnPropertyNames(typesAndValues).forEach(name => {
+    Object.getOwnPropertyNames(paramValues).forEach(name => {
       descriptions[name] = makeDescription(name);
     });
     return harden(descriptions);
@@ -131,7 +60,6 @@ const buildParamManager = paramDescriptions => {
   });
 };
 
-harden(ParamType);
 harden(buildParamManager);
-harden(assertType);
-export { ParamType, buildParamManager, assertType };
+harden(looksLikeParam);
+export { buildParamManager, looksLikeParam };

--- a/packages/governance/src/types.js
+++ b/packages/governance/src/types.js
@@ -20,11 +20,6 @@
  */
 
 /**
- * @typedef { 'amount' | 'brand' | 'instance' | 'installation' | 'nat' |
- * 'ratio' | 'string' | 'unknown' } ParamType
- */
-
-/**
  * @typedef { 'majority' | 'all' | 'no_quorum' } QuorumRule
  */
 
@@ -39,20 +34,9 @@
  */
 
 /**
- * @template T
- * @typedef {{ type: T, name: string }} ParamRecord
- */
-
-/**
- * @typedef {ParamRecord<'amount'> & { value: Amount } |
- *   ParamRecord<'brand'> & { value: Brand } |
- *   ParamRecord<'installation'> & { value: Installation } |
- *   ParamRecord<'instance'> & { value: Instance } |
- *   ParamRecord<'nat'> & { value: bigint } |
- *   ParamRecord<'ratio'> & { value: Ratio } |
- *   ParamRecord<'string'> & { value: string } |
- *   ParamRecord<'unknown'> & { value: unknown }
- * } ParamDescription
+ * @typedef {Object} ParamDescription
+ * @property {string} name
+ * @property {ParamValue} value
  */
 
 /**
@@ -363,7 +347,6 @@
 
 /**
  * @callback AssertParamManagerType
- * @param {ParamType} type
  * @param {ParamValue} value
  * @param {string} name
  */

--- a/packages/governance/src/types.js
+++ b/packages/governance/src/types.js
@@ -29,8 +29,7 @@
  */
 
 /**
- * @typedef { Amount | Brand | Installation | Instance | bigint |
- *   Ratio | string | unknown } ParamValue
+ * @typedef {Comparable} ParamValue
  */
 
 /**

--- a/packages/governance/test/swingsetTests/contractGovernor/governedContract.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/governedContract.js
@@ -4,7 +4,7 @@ import { assert, details as X } from '@agoric/assert';
 import { Far } from '@agoric/marshal';
 import { sameStructure } from '@agoric/same-structure';
 
-import { buildParamManager, ParamType } from '../../../src/paramManager.js';
+import { buildParamManager } from '../../../src/paramManager.js';
 
 const MALLEABLE_NUMBER = 'MalleableNumber';
 
@@ -18,7 +18,6 @@ const governedParameterInitialValues = [
   {
     name: MALLEABLE_NUMBER,
     value: 602214090000000000000000n,
-    type: ParamType.NAT,
   },
 ];
 harden(governedParameterTerms);

--- a/packages/governance/test/unitTests/test-param-manager.js
+++ b/packages/governance/test/unitTests/test-param-manager.js
@@ -7,7 +7,7 @@ import { makeRatio } from '@agoric/zoe/src/contractSupport/index.js';
 
 import { makeHandle } from '@agoric/zoe/src/makeHandle.js';
 import { Far } from '@agoric/marshal';
-import { buildParamManager, ParamType } from '../../src/paramManager.js';
+import { buildParamManager } from '../../src/paramManager.js';
 import { makeParamChangePositions } from '../../src/governParam.js';
 
 const BASIS_POINTS = 10_000n;
@@ -17,27 +17,11 @@ test('params one Nat', async t => {
   const numberDescription = {
     name: numberKey,
     value: 13n,
-    type: ParamType.NAT,
   };
   const { getParam, updateNumber } = buildParamManager([numberDescription]);
   t.deepEqual(getParam(numberKey), numberDescription);
   updateNumber(42n);
   t.deepEqual(getParam(numberKey).value, 42n);
-
-  t.throws(
-    () => updateNumber(18.1),
-    {
-      message: '18.1 must be a bigint',
-    },
-    'value should be a nat',
-  );
-  t.throws(
-    () => updateNumber(13),
-    {
-      message: '13 must be a bigint',
-    },
-    'must be bigint',
-  );
 });
 
 test('params one String', async t => {
@@ -45,20 +29,11 @@ test('params one String', async t => {
   const stringDescription = {
     name: stringKey,
     value: 'foo',
-    type: ParamType.STRING,
   };
   const { getParam, updateString } = buildParamManager([stringDescription]);
   t.deepEqual(getParam(stringKey), stringDescription);
   updateString('bar');
   t.deepEqual(getParam(stringKey).value, 'bar');
-
-  t.throws(
-    () => updateString(18.1),
-    {
-      message: '18.1 must be a string',
-    },
-    'value should be a string',
-  );
 });
 
 test('params one Amount', async t => {
@@ -67,20 +42,11 @@ test('params one Amount', async t => {
   const amountDescription = {
     name: amountKey,
     value: AmountMath.makeEmpty(brand),
-    type: ParamType.AMOUNT,
   };
   const { getParam, updateAmount } = buildParamManager([amountDescription]);
   t.deepEqual(getParam(amountKey), amountDescription);
   updateAmount(AmountMath.make(brand, [13]));
   t.deepEqual(getParam(amountKey).value, AmountMath.make(brand, [13]));
-
-  t.throws(
-    () => updateAmount(18.1),
-    {
-      message: 'The brand "[undefined]" doesn\'t look like a brand.',
-    },
-    'value should be a amount',
-  );
 });
 
 test('params one BigInt', async t => {
@@ -88,27 +54,11 @@ test('params one BigInt', async t => {
   const bigIntDescription = {
     name: bigintKey,
     value: 314159n,
-    type: ParamType.NAT,
   };
   const { getParam, updateBigint } = buildParamManager([bigIntDescription]);
   t.deepEqual(getParam(bigintKey), bigIntDescription);
   updateBigint(271828182845904523536n);
   t.deepEqual(getParam(bigintKey).value, 271828182845904523536n);
-
-  t.throws(
-    () => updateBigint(18.1),
-    {
-      message: '18.1 must be a bigint',
-    },
-    'value should be a bigint',
-  );
-  t.throws(
-    () => updateBigint(-1000n),
-    {
-      message: '-1000 is negative',
-    },
-    'NAT params must be positive',
-  );
 });
 
 test('params one ratio', async t => {
@@ -117,7 +67,6 @@ test('params one ratio', async t => {
   const ratioDescription = {
     name: ratioKey,
     value: makeRatio(7n, brand),
-    type: ParamType.RATIO,
   };
 
   const { getParam, getParams, updateRatio } = buildParamManager([
@@ -130,14 +79,6 @@ test('params one ratio', async t => {
     getParams()[ratioKey].value,
     makeRatio(701n, brand, BASIS_POINTS),
   );
-
-  t.throws(
-    () => updateRatio(18.1),
-    {
-      message: 'Expected "number" is same as "copyRecord"',
-    },
-    'value should be a ratio',
-  );
 });
 
 test('params one brand', async t => {
@@ -147,20 +88,11 @@ test('params one brand', async t => {
   const brandDescription = {
     name: brandKey,
     value: roseBrand,
-    type: ParamType.BRAND,
   };
   const { getParam, updateBrand } = buildParamManager([brandDescription]);
   t.deepEqual(getParam(brandKey), brandDescription);
   updateBrand(thornBrand);
   t.deepEqual(getParam(brandKey).value, thornBrand);
-
-  t.throws(
-    () => updateBrand(18.1),
-    {
-      message: 'value for "Brand" must be a brand, was 18.1',
-    },
-    'value should be a brand',
-  );
 });
 
 test('params one unknown', async t => {
@@ -169,7 +101,6 @@ test('params one unknown', async t => {
   const stuffDescription = {
     name: stuffKey,
     value: stiltonBrand,
-    type: ParamType.UNKNOWN,
   };
   const { getParam, updateStuff } = buildParamManager([stuffDescription]);
   t.deepEqual(getParam(stuffKey), stuffDescription);
@@ -185,17 +116,9 @@ test('params one instance', async t => {
   const instanceDescription = {
     name: instanceKey,
     value: instanceHandle,
-    type: ParamType.INSTANCE,
   };
   const { getParam, updateInstance } = buildParamManager([instanceDescription]);
   t.deepEqual(getParam(instanceKey), instanceDescription);
-  t.throws(
-    () => updateInstance(18.1),
-    {
-      message: 'value for "Instance" must be an Instance, was 18.1',
-    },
-    'value should be an Instance',
-  );
   const handle2 = makeHandle('another Instance');
   updateInstance(handle2);
   t.deepEqual(getParam(instanceKey).value, handle2);
@@ -211,19 +134,11 @@ test('params one installation', async t => {
   const installationDescription = {
     name: installationKey,
     value: installationHandle,
-    type: ParamType.INSTALLATION,
   };
   const { getParam, updateInstallation } = buildParamManager([
     installationDescription,
   ]);
   t.deepEqual(getParam(installationKey), installationDescription);
-  t.throws(
-    () => updateInstallation(18.1),
-    {
-      message: 'value for "Installation" must be an Installation, was 18.1',
-    },
-    'value should be an installation',
-  );
   const handle2 = Far('another fake Installation', {
     getBundle: () => ({ condensed: '() => {})' }),
   });
@@ -240,31 +155,16 @@ test('params duplicate entry', async t => {
         {
           name: stuffKey,
           value: 37n,
-          type: ParamType.NAT,
         },
         {
           name: stuffKey,
           value: stiltonBrand,
-          type: ParamType.UNKNOWN,
         },
       ]),
     {
       message: `each parameter name must be unique: "Stuff" duplicated`,
     },
   );
-});
-
-test('params unknown type', async t => {
-  const stuffKey = 'Stuff';
-  const stuffDescription = {
-    name: stuffKey,
-    value: 'It was the best of times, it was the worst of times',
-    type: 'quote',
-  };
-  // @ts-ignore  illegal value for testing
-  t.throws(() => buildParamManager([stuffDescription]), {
-    message: 'unrecognized type "quote"',
-  });
 });
 
 test('params multiple values', t => {
@@ -274,12 +174,10 @@ test('params multiple values', t => {
   const cheeseDescription = {
     name: stuffKey,
     value: parmesanBrand,
-    type: ParamType.UNKNOWN,
   };
   const constantDescription = {
     name: natKey,
     value: 602214076000000000000000n,
-    type: ParamType.NAT,
   };
   const { getParams, getParam, updateNat, updateStuff } = buildParamManager([
     cheeseDescription,
@@ -290,7 +188,6 @@ test('params multiple values', t => {
   const floatDescription = {
     name: stuffKey,
     value: 18.1,
-    type: ParamType.UNKNOWN,
   };
   t.deepEqual(getParam(stuffKey), floatDescription);
   t.deepEqual(getParam(natKey), constantDescription);

--- a/packages/governance/test/unitTests/test-paramGovernance.js
+++ b/packages/governance/test/unitTests/test-paramGovernance.js
@@ -89,7 +89,6 @@ test('governParam happy path with fakes', async t => {
   t.deepEqual(governedFacets.publicFacet.getState(), {
     MalleableNumber: {
       name: MALLEABLE_NUMBER,
-      type: 'nat',
       value: 25n,
     },
   });
@@ -155,7 +154,6 @@ test('governParam no votes', async t => {
   t.deepEqual(governedFacets.publicFacet.getState(), {
     MalleableNumber: {
       name: MALLEABLE_NUMBER,
-      type: 'nat',
       value: 602214090000000000000000n,
     },
   });
@@ -177,7 +175,7 @@ test('governParam bad update', async t => {
   );
   const brokenParamMgr = Far('broken ParamMgr', {
     getParam: () => {
-      return harden({ type: 'nat' });
+      return harden({});
     },
   });
   const accessor = Far('param accessor', {
@@ -228,7 +226,6 @@ test('governParam bad update', async t => {
   t.deepEqual(governedFacets.publicFacet.getState(), {
     MalleableNumber: {
       name: MALLEABLE_NUMBER,
-      type: 'nat',
       value: 602214090000000000000000n,
     },
   });


### PR DESCRIPTION
experimental variations on #3448 

Reviewing #3448 , I couldn't figure out why it was enumerating the possible types of params, rather than allowing any Comparable value to be a param value. The type distinctions #3448 makes includes, for example, between Brand and Instance, but it cannot locally check that anyway, so what's the point in declaring it?

I understand that #3448 is the base for a bunch of later PRs, so perhaps there's an answer there? Or perhaps it drive the UI for participating in governance? Not knowing, this is only an experiment, to see if we can both simplify and make the code more generic by being parametric over all possible Comparables as parameter values.