### PR TITLE
Only use ABCI write lock when persistent data changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,11 +32,10 @@ replace google.golang.org/grpc => google.golang.org/grpc v1.33.2
 
 // At least until post-v0.34.12 is released with
 // https://github.com/tendermint/tendermint/issue/6899 resolved.
-replace github.com/tendermint/tendermint => github.com/agoric-labs/tendermint v0.34.12-alpha.agoric.1
+replace github.com/tendermint/tendermint => github.com/agoric-labs/tendermint v0.34.12-alpha.agoric.8
  
-// At least until GetABCIEventHistory() is implemented and released.
-// And also until the above tendermint issue is released.
-replace github.com/cosmos/cosmos-sdk => github.com/agoric-labs/cosmos-sdk v0.44.0-alpha.agoric.2
+// We need a fork of cosmos-sdk until all of the differences are merged.
+replace github.com/cosmos/cosmos-sdk => github.com/agoric-labs/cosmos-sdk v0.44.0-alpha.agoric.5
 
 // For testing against a local cosmos-sdk or tendermint
 // replace github.com/cosmos/cosmos-sdk => ../forks/cosmos-sdk

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,12 @@ github.com/agoric-labs/cosmos-sdk v0.44.0-alpha.agoric h1:X5D4QHvjlhq5CntQR1jlVd
 github.com/agoric-labs/cosmos-sdk v0.44.0-alpha.agoric/go.mod h1:ENm1b98MKZzKfYKbWwpVNfjcTZToveK+IDhHa2WRNQo=
 github.com/agoric-labs/cosmos-sdk v0.44.0-alpha.agoric.2 h1:s9vdQixPCD5qGY6MubGypDkjpikkIcmUuSZQYwUaFjI=
 github.com/agoric-labs/cosmos-sdk v0.44.0-alpha.agoric.2/go.mod h1:ENm1b98MKZzKfYKbWwpVNfjcTZToveK+IDhHa2WRNQo=
+github.com/agoric-labs/cosmos-sdk v0.44.0-alpha.agoric.5 h1:6gI2FSFqnTcYO7ZBfHm1wlOjSG2tooWfYRyNW9UjENk=
+github.com/agoric-labs/cosmos-sdk v0.44.0-alpha.agoric.5/go.mod h1:wvjoIRARpPFK8Xrrj11cexWRA1oBbvlBO3zbIIsmDls=
 github.com/agoric-labs/tendermint v0.34.12-alpha.agoric.1 h1:N6qCgZLeSa2CzmNnjxmxoxY7r7rZGtY5vCtoHrauOSo=
 github.com/agoric-labs/tendermint v0.34.12-alpha.agoric.1/go.mod h1:aeHL7alPh4uTBIJQ8mgFEE8VwJLXI1VD3rVOmH2Mcy0=
+github.com/agoric-labs/tendermint v0.34.12-alpha.agoric.8 h1:Enx/u3VEVSuTySMyUVSIWlQRHAbQHrHTnDRSHKJS2Po=
+github.com/agoric-labs/tendermint v0.34.12-alpha.agoric.8/go.mod h1:aeHL7alPh4uTBIJQ8mgFEE8VwJLXI1VD3rVOmH2Mcy0=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/packages/cosmic-swingset/perf.sh
+++ b/packages/cosmic-swingset/perf.sh
@@ -1,0 +1,27 @@
+#! /bin/bash
+set -ex
+
+# Get the height parameter from the command line argument.
+height=${1-0}
+
+addr=$(cat t1/8000/ag-cosmos-helper-address)
+hex=$(ag-cosmos-helper keys parse $addr --output=json | jq -r '.bytes')
+b64=$(echo $hex | xxd -r -p | base64 | tr '+/' '-_')
+# echo $b64
+
+# Query the bank balance of (potentially) an empty account
+server=http://localhost:1317
+url="$server/bank/balances/$addr?height=$height"
+#url="$server/agoric/swingset/egress/$b64"
+#url=$server/agoric/swingset/storage/data/activityhash
+
+# Display the output of a single request:
+curl "$url"
+
+# Run the Apache Benchmark:
+ab -n 16000 -c 5 "$url"
+
+{ sleep 1; : NOTE: This will time out because of rate limiting; } &
+# This one hangs (because of rate limiting at around 16350 requests since the
+# last one started):
+ab -n 3000 -c 5 "$url"


### PR DESCRIPTION
Follow up with tendermint/tendermint#6899

Not only are the changes to Tendermint and Cosmos-SDK better-factored, this implementation answers up to 5,500 queries per second (a 1k qps improvement).
