### PR TITLE
Implement less solo overhead, part 1

### DIFF
--- a/golang/cosmos/x/swingset/keeper/keeper.go
+++ b/golang/cosmos/x/swingset/keeper/keeper.go
@@ -170,6 +170,10 @@ func (k Keeper) SetStorage(ctx sdk.Context, path string, storage *types.Storage)
 		dataStore.Set(pathKey, k.cdc.MustMarshalLengthPrefixed(storage))
 	}
 
+	ctx.EventManager().EmitEvent(
+		types.NewStorageEvent(path, storage.Value),
+	)
+
 	// Update the parent keys.
 	pathComponents := strings.Split(path, ".")
 	for i := len(pathComponents) - 1; i >= 0; i-- {

--- a/golang/cosmos/x/swingset/keeper/querier.go
+++ b/golang/cosmos/x/swingset/keeper/querier.go
@@ -65,7 +65,7 @@ func queryStorage(ctx sdk.Context, path string, req abci.RequestQuery, keeper Ke
 	value := storage.Value
 
 	if value == "" {
-		return []byte{}, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, "could not get storage")
+		return []byte{}, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "could not get storage %+v", path)
 	}
 
 	bz, err2 := codec.MarshalJSONIndent(legacyQuerierCdc, types.Storage{Value: value})

--- a/golang/cosmos/x/swingset/types/events.go
+++ b/golang/cosmos/x/swingset/types/events.go
@@ -1,0 +1,25 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// swingset module event types
+const (
+	EventTypeStorage = "storage"
+
+	AttributeKeyPath  = "path"
+	AttributeKeyValue = "value"
+
+	AttributeValueCategory = ModuleName
+)
+
+// NewStorageSetEvent constructs a new storage change sdk.Event
+// nolint: interfacer
+func NewStorageEvent(path, value string) sdk.Event {
+	return sdk.NewEvent(
+		EventTypeStorage,
+		sdk.NewAttribute(AttributeKeyPath, path),
+		sdk.NewAttribute(AttributeKeyValue, value),
+	)
+}

--- a/packages/solo/src/chain-cosmos-sdk.js
+++ b/packages/solo/src/chain-cosmos-sdk.js
@@ -39,9 +39,27 @@ Send:
 
 to ${FAUCET_ADDRESS}`;
 
-const SEND_RETRY_DELAY_MS = Math.min(DEFAULT_BATCH_TIMEOUT_MS, 500);
+// Retry if our latest message failed.
+const SEND_RETRY_DELAY_MS = 1_000;
 
 const MAX_BUFFER_SIZE = 10 * 1024 * 1024;
+
+// Wait for at least this long between errors when initially polling mailbox.
+const MIN_MAILBOX_POLL_BACKOFF_MS = 1_000;
+
+// How much of each delay to leave to randomness.
+const RANDOM_SCALE = 0.1;
+
+// Tradeoff:
+// true: clear out messages from mailbox when we are waiting for more activity.
+// Costs an extra tx per string of messages.
+//
+// false: leave acknowledged messages in mailbox until we have something else to
+// send.  Costs more mailbox space over time.
+const SEND_EMPTY_ACKS = false;
+
+const randomizeDelay = delay =>
+  Math.ceil(delay + delay * RANDOM_SCALE * Math.random());
 
 const makeTempFile = async (prefix, contents) => {
   const tmpInfo = await new Promise((resolve, reject) => {
@@ -175,6 +193,7 @@ export async function connectToChain(
   }
 
   let goodRpcHref = rpcHrefs[0];
+  let pollMailboxBackoffMs = 0;
   const runHelper = (args, stdin = undefined) => {
     const fullArgs = [
       ...args,
@@ -290,7 +309,7 @@ ${chainID} chain does not yet know of address ${clientAddr}${adviseEgress(
    *
    * @returns {Notifier<any>}
    */
-  const getBlockNotifier = () => {
+  const getMailboxNotifier = () => {
     const { notifier, updater } = makeNotifierKit();
     retryRpcHref(async rpcHref => {
       // Every time we enter this function, we are establishing a
@@ -316,6 +335,8 @@ ${chainID} chain does not yet know of address ${clientAddr}${adviseEgress(
       // This magic identifier just distinguishes our subscription
       // from other noise on the Websocket, if there is any.
       const MAGIC_ID = 13254;
+      const mailboxPath = `mailbox.${clientAddr}`;
+      let firstUpdate = true;
       ws.addEventListener('open', _ => {
         // We send a message to subscribe to every
         // new block header.
@@ -327,25 +348,99 @@ ${chainID} chain does not yet know of address ${clientAddr}${adviseEgress(
           method: 'subscribe',
           params: {
             // Here is the Tendermint event for new blocks.
-            query: "tm.event = 'NewBlockHeader'",
+            // query: `tm.event = 'NewBlockHeader'`,
+
+            // This is the Cosmos event for activityhash changes.
+            // query: `storage.path = 'activityhash'`,
+
+            // This is the Cosmos event for our mailbox changes.
+            query: `storage.path = '${mailboxPath}'`,
           },
         };
         // Send that message, and wait for the subscription.
         ws.send(JSON.stringify(obj));
 
-        // Ensure our sender wakes up again.
-        // eslint-disable-next-line no-use-before-define
-        sendUpdater.updateState(true);
+        // Poll to establish our initial mailbox.
+        const pollMailboxWhileFirstUpdate = async () => {
+          if (!firstUpdate) {
+            // Already got the subscription.
+            return;
+          }
+          const mb = await getMailbox().then(
+            res => res,
+            e => {
+              console.error(`Cannot get first mailbox:`, e);
+            },
+          );
+          if (!firstUpdate) {
+            // Already got the subscription.
+            return;
+          }
+          console.error('got first mb', mb);
+          if (mb !== undefined) {
+            // Found the first mailbox.
+            // console.error('Updating in pollMailboxWhileFirstUpdate');
+            updater.updateState(mb);
+            firstUpdate = false;
+            return;
+          }
+
+          // Back off and try again.
+          pollMailboxBackoffMs = pollMailboxBackoffMs
+            ? pollMailboxBackoffMs * 2
+            : MIN_MAILBOX_POLL_BACKOFF_MS;
+          setTimeout(
+            pollMailboxWhileFirstUpdate,
+            randomizeDelay(pollMailboxBackoffMs),
+          );
+        };
+
+        // This is a new connection, so we have to poll again.
+        pollMailboxBackoffMs = 0;
+        pollMailboxWhileFirstUpdate().catch(e =>
+          console.error(
+            `Unexpected rejection while polling ${goodRpcHref} until first update:`,
+            e,
+          ),
+        );
       });
       ws.addEventListener('message', ev => {
         // We received a message.
+        // console.info('got message', ev.data);
         const obj = JSON.parse(ev.data);
-        if (obj.id === MAGIC_ID) {
-          // It matches our subscription, so notify.
-          updater.updateState(obj);
+        if (obj.id !== MAGIC_ID) {
+          return;
         }
+
+        // It matches our subscription, so maybe notify.
+        const events = obj.result.events;
+        if (!events) {
+          return;
+        }
+        const paths = events['storage.path'];
+        const values = events['storage.value'];
+
+        // Find only the latest value.
+        let latestValue;
+        paths.forEach((key, i) => {
+          if (key === mailboxPath) {
+            latestValue = values[i];
+          }
+        });
+        if (latestValue === undefined) {
+          return;
+        }
+
+        const mb = JSON.parse(latestValue);
+
+        // Update our notifier.
+        // console.error('Updating in ws.message');
+        updater.updateState(mb);
+        firstUpdate = false;
       });
       ws.addEventListener('close', _ => {
+        // Stop trying to poll.
+        firstUpdate = false;
         // The value `undefined` as the resolution of this retry
         // tells the caller to retry again with a different RPC server.
         retryPK.resolve(undefined);
@@ -358,8 +453,8 @@ ${chainID} chain does not yet know of address ${clientAddr}${adviseEgress(
     return notifier;
   };
 
-  // Begin the block notifier cycle.
-  const blockNotifier = getBlockNotifier();
+  // Begin the mailbox notifier cycle.
+  const mbNotifier = getMailboxNotifier();
 
   const { notifier: sendNotifier, updater: sendUpdater } = makeNotifierKit();
 
@@ -503,33 +598,32 @@ ${chainID} chain does not yet know of address ${clientAddr}${adviseEgress(
   };
 
   /**
-   * This function is entered at most the same number of times
-   * as the blockNotifier announces a new block.
+   * This function is entered at most the same number of times as the
+   * mailboxNotifier announces a new mailbox.
    *
-   * It then gets the mailbox.  There are no optimisations.
+   * It then delivers the mailbox to inbound.  There are no optimisations.
    *
-   * @param {number=} lastBlockUpdate
+   * @param {number=} lastMailboxUpdate
    */
-  const recurseEachNewBlock = async (lastBlockUpdate = undefined) => {
-    const { updateCount } = await blockNotifier.getUpdateSince(lastBlockUpdate);
-    console.debug(`new block on ${GCI}, fetching mailbox`);
+  const recurseEachMailboxUpdate = async (lastMailboxUpdate = undefined) => {
+    const { updateCount, value: mailbox } = await mbNotifier.getUpdateSince(
+      lastMailboxUpdate,
+    );
     assert(updateCount, X`${GCI} unexpectedly finished!`);
-    await getMailbox()
-      .then(ret => {
-        if (!ret) {
-          return;
-        }
-        const { outbox, ack } = ret;
-        // console.debug('have outbox', outbox, ack);
-        inbound(GCI, outbox, ack);
-        removeAckedFromMessagePool(ack);
-      })
-      .catch(e => console.error(`Failed to fetch ${GCI} mailbox:`, e));
-    recurseEachNewBlock(updateCount);
+    const { outbox, ack } = mailbox;
+    // console.info('have mailbox', mailbox);
+    inbound(GCI, outbox, ack);
+    removeAckedFromMessagePool(ack);
+
+    recurseEachMailboxUpdate(updateCount).catch(e =>
+      console.error(`Failed to fetch ${GCI} mailbox:`, e),
+    );
   };
 
-  // Begin the block consumer.
-  recurseEachNewBlock();
+  // Begin the mailbox consumer.
+  recurseEachMailboxUpdate().catch(e =>
+    console.error(`Failed to fetch first ${GCI} mailbox:`, e),
+  );
 
   // Retry sending, but no more than one pending retry at a time.
   let retryPending;
@@ -544,7 +638,7 @@ ${chainID} chain does not yet know of address ${clientAddr}${adviseEgress(
     retryPending = setTimeout(() => {
       retryPending = undefined;
       sendUpdater.updateState(true);
-    }, SEND_RETRY_DELAY_MS);
+    }, randomizeDelay(SEND_RETRY_DELAY_MS));
   };
 
   // This function ensures we only have one outgoing send operation at a time.
@@ -564,7 +658,9 @@ ${chainID} chain does not yet know of address ${clientAddr}${adviseEgress(
     let doSend = false;
     if (acknum > highestAck) {
       highestAck = acknum;
-      doSend = true;
+      // We never send just an ack without messages.  But if we did, the
+      // following line would do it:
+      doSend = SEND_EMPTY_ACKS;
     }
     if (newMessages.length) {
       addToMessagePool(newMessages);
@@ -578,5 +674,5 @@ ${chainID} chain does not yet know of address ${clientAddr}${adviseEgress(
 
   // Now that we've started consuming blocks, tell our caller how to deliver
   // messages.
-  return makeBatchedDeliver(deliver, SEND_RETRY_DELAY_MS);
+  return makeBatchedDeliver(deliver, Math.min(DEFAULT_BATCH_TIMEOUT_MS, 2000));
 }


### PR DESCRIPTION
Refs #3763 

Implemented thus far:
- query mailbox once at start via WebSocket
- watch for mailbox events instead of polling every block
- randomise retry delays

Not yet:
- decouple sending times from receiving times
- increase Nagle timer delay to 3 seconds
- impatience timer for mailbox update after submit
