### PR TITLE
Implement Bring Out Your Dead as a kernel-driven operation

### DIFF
--- a/packages/SwingSet/src/initializeSwingset.js
+++ b/packages/SwingSet/src/initializeSwingset.js
@@ -339,6 +339,7 @@ export async function initializeSwingset(
       enableSetup: true,
       managerType: 'local',
       useTranscript: false,
+      boydFrequency: 'never',
     },
   };
 

--- a/packages/SwingSet/src/initializeSwingset.js
+++ b/packages/SwingSet/src/initializeSwingset.js
@@ -339,7 +339,7 @@ export async function initializeSwingset(
       enableSetup: true,
       managerType: 'local',
       useTranscript: false,
-      boydFrequency: 'never',
+      reapInterval: 'never',
     },
   };
 

--- a/packages/SwingSet/src/kernel/initializeKernel.js
+++ b/packages/SwingSet/src/kernel/initializeKernel.js
@@ -25,7 +25,7 @@ export function initializeKernel(config, hostStorage, verbose = false) {
   assert(!wasInitialized);
   kernelKeeper.createStartingKernelState(
     config.defaultManagerType || 'local',
-    config.defaultBoydFrequency || 1,
+    config.defaultReapInterval || 1,
   );
 
   if (config.bundles) {
@@ -69,7 +69,7 @@ export function initializeKernel(config, hostStorage, verbose = false) {
         'enableVatstore',
         'virtualObjectCacheSize',
         'useTranscript',
-        'boydFrequency',
+        'reapInterval',
       ]);
       creationOptions.vatParameters = vatParameters;
       creationOptions.description = `static name=${name}`;
@@ -77,15 +77,15 @@ export function initializeKernel(config, hostStorage, verbose = false) {
       if (!creationOptions.managerType) {
         creationOptions.managerType = kernelKeeper.getDefaultManagerType();
       }
-      if (!creationOptions.boydFrequency) {
-        creationOptions.boydFrequency = kernelKeeper.getDefaultBoydFrequency();
+      if (!creationOptions.reapInterval) {
+        creationOptions.reapInterval = kernelKeeper.getDefaultReapInterval();
       }
 
       const vatID = kernelKeeper.allocateVatIDForNameIfNeeded(name);
       logStartup(`assigned VatID ${vatID} for genesis vat ${name}`);
       const vatKeeper = kernelKeeper.provideVatKeeper(vatID);
       vatKeeper.setSourceAndOptions({ bundle, bundleName }, creationOptions);
-      vatKeeper.initializeBoydCountdown(creationOptions.boydFrequency);
+      vatKeeper.initializeReapCountdown(creationOptions.reapInterval);
       if (name === 'vatAdmin') {
         // Create a kref for the vatAdmin root, so the kernel can tell it
         // about creation/termination of dynamic vats.

--- a/packages/SwingSet/src/kernel/initializeKernel.js
+++ b/packages/SwingSet/src/kernel/initializeKernel.js
@@ -23,7 +23,10 @@ export function initializeKernel(config, hostStorage, verbose = false) {
 
   const wasInitialized = kernelKeeper.getInitialized();
   assert(!wasInitialized);
-  kernelKeeper.createStartingKernelState(config.defaultManagerType || 'local');
+  kernelKeeper.createStartingKernelState(
+    config.defaultManagerType || 'local',
+    config.defaultBoydFrequency || 1,
+  );
 
   if (config.bundles) {
     for (const name of Object.keys(config.bundles)) {
@@ -66,6 +69,7 @@ export function initializeKernel(config, hostStorage, verbose = false) {
         'enableVatstore',
         'virtualObjectCacheSize',
         'useTranscript',
+        'boydFrequency',
       ]);
       creationOptions.vatParameters = vatParameters;
       creationOptions.description = `static name=${name}`;
@@ -73,11 +77,15 @@ export function initializeKernel(config, hostStorage, verbose = false) {
       if (!creationOptions.managerType) {
         creationOptions.managerType = kernelKeeper.getDefaultManagerType();
       }
+      if (!creationOptions.boydFrequency) {
+        creationOptions.boydFrequency = kernelKeeper.getDefaultBoydFrequency();
+      }
 
       const vatID = kernelKeeper.allocateVatIDForNameIfNeeded(name);
       logStartup(`assigned VatID ${vatID} for genesis vat ${name}`);
       const vatKeeper = kernelKeeper.provideVatKeeper(vatID);
       vatKeeper.setSourceAndOptions({ bundle, bundleName }, creationOptions);
+      vatKeeper.initializeBoydCountdown(creationOptions.boydFrequency);
       if (name === 'vatAdmin') {
         // Create a kref for the vatAdmin root, so the kernel can tell it
         // about creation/termination of dynamic vats.

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -435,6 +435,11 @@ export default function buildKernel(
       // eslint-disable-next-line no-use-before-define
       const deliveryResult = await vatWarehouse.deliverToVat(vatID, kd, vd, vs);
       insistVatDeliveryResult(deliveryResult);
+      if (vd[0] !== 'bringOutYourDead') {
+        if (vatKeeper.boydCountdown()) {
+          kernelKeeper.scheduleBoyd(vatID);
+        }
+      }
       const [status, problem] = deliveryResult;
       if (status !== 'ok') {
         // probably a metering fault, or a bug in the vat's dispatch()
@@ -661,6 +666,28 @@ export default function buildKernel(
    * @param { * } message
    * @returns { Promise<PolicyInput> }
    */
+  async function processBringOutYourDead(message) {
+    /** @type { PolicyInput } */
+    let policyInput = ['none'];
+    const { type, vatID } = message;
+    // console.log(`-- processBringOutYourDead(${vatID})`);
+    insistVatID(vatID);
+    // eslint-disable-next-line no-use-before-define
+    if (!vatWarehouse.lookup(vatID)) {
+      return harden(policyInput); // can't collect from the dead
+    }
+    const kd = harden([type]);
+    // eslint-disable-next-line no-use-before-define
+    const vd = vatWarehouse.kernelDeliveryToVatDelivery(vatID, kd);
+    policyInput = await deliverAndLogToVat(vatID, kd, vd, false);
+    return harden(policyInput);
+  }
+
+  /**
+   *
+   * @param { * } message
+   * @returns { Promise<PolicyInput> }
+   */
   async function processCreateVat(message) {
     assert(vatAdminRootKref, `initializeKernel did not set vatAdminRootKref`);
     const { vatID, source, dynamicOptions } = message;
@@ -670,7 +697,11 @@ export default function buildKernel(
     if (!dynamicOptions.managerType) {
       options.managerType = kernelKeeper.getDefaultManagerType();
     }
+    if (!dynamicOptions.boydFrequency) {
+      options.boydFrequency = kernelKeeper.getDefaultBoydFrequency();
+    }
     vatKeeper.setSourceAndOptions(source, options);
+    vatKeeper.initializeBoydCountdown(options.boydFrequency);
 
     function makeSuccessResponse() {
       // build success message, giving admin vat access to the new vat's root
@@ -723,6 +754,8 @@ export default function buildKernel(
     } else if (gcMessages.includes(message.type)) {
       // prettier-ignore
       return `${message.type} ${message.vatID} ${message.krefs.map(e=>`@${e}`).join(' ')}`;
+    } else if (message.type === 'bringOutYourDead') {
+      return `${message.type} ${message.vatID}`;
     } else {
       return `unknown message type ${message.type}`;
     }
@@ -764,6 +797,8 @@ export default function buildKernel(
         policyInput = await processNotify(message);
       } else if (message.type === 'create-vat') {
         policyInput = await processCreateVat(message);
+      } else if (message.type === 'bringOutYourDead') {
+        policyInput = await processBringOutYourDead(message);
       } else if (gcMessages.includes(message.type)) {
         policyInput = await processGCMessage(message);
       } else {
@@ -948,13 +983,23 @@ export default function buildKernel(
       'function',
       X`setup is not a function, rather ${setup}`,
     );
-    assertKnownOptions(creationOptions, ['enablePipelining', 'metered']);
+    assertKnownOptions(creationOptions, [
+      'enablePipelining',
+      'metered',
+      'boydFrequency',
+    ]);
 
     assert(!kernelKeeper.hasVatWithName(name), X`vat ${name} already exists`);
     creationOptions.vatParameters = vatParameters;
 
     const vatID = kernelKeeper.allocateVatIDForNameIfNeeded(name);
     logStartup(`assigned VatID ${vatID} for test vat ${name}`);
+
+    if (!creationOptions.boydFrequency) {
+      creationOptions.boydFrequency = 'never';
+    }
+    const vatKeeper = kernelKeeper.provideVatKeeper(vatID);
+    vatKeeper.initializeBoydCountdown(creationOptions.boydFrequency);
 
     await vatWarehouse.loadTestVat(vatID, setup, creationOptions);
     return vatID;
@@ -1076,6 +1121,11 @@ export default function buildKernel(
     if (gcMessage) {
       return gcMessage;
     }
+    const boydMessage = kernelKeeper.nextBoydAction();
+    if (boydMessage) {
+      return boydMessage;
+    }
+
     if (!kernelKeeper.isRunQueueEmpty()) {
       return kernelKeeper.getNextMsg();
     }

--- a/packages/SwingSet/src/kernel/loadVat.js
+++ b/packages/SwingSet/src/kernel/loadVat.js
@@ -95,7 +95,7 @@ export function makeVatLoader(stuff) {
     'enableVatstore',
     'virtualObjectCacheSize',
     'useTranscript',
-    'boydFrequency',
+    'reapInterval',
   ];
 
   const allowedStaticOptions = [
@@ -109,7 +109,7 @@ export function makeVatLoader(stuff) {
     'enableVatstore',
     'virtualObjectCacheSize',
     'useTranscript',
-    'boydFrequency',
+    'reapInterval',
   ];
 
   /**
@@ -171,13 +171,13 @@ export function makeVatLoader(stuff) {
    *        internal state can be reconstructed via replay.  If false, no such
    *        record is kept.  Defaults to true.
    *
-   * @param {number|'never'} [options.boydFrequency] The frequency (measured
+   * @param {number|'never'} [options.reapInterval] The interval (measured
    *        in number of deliveries to the vat) after which the kernel will
    *        deliver the 'bringOutYourDead' directive to the vat.  If the value
    *        is 'never', 'bringOutYourDead' will never be delivered and the vat
    *        will be responsible for internally managing (in a deterministic
    *        manner) any visible effects of garbage collection.  Defaults to the
-   *        kernel's configured 'defaultBoydFrequency' value.
+   *        kernel's configured 'defaultReapInterval' value.
    *
    * @param {string} [options.name]
    * @param {string} [options.description]

--- a/packages/SwingSet/src/kernel/loadVat.js
+++ b/packages/SwingSet/src/kernel/loadVat.js
@@ -95,6 +95,7 @@ export function makeVatLoader(stuff) {
     'enableVatstore',
     'virtualObjectCacheSize',
     'useTranscript',
+    'boydFrequency',
   ];
 
   const allowedStaticOptions = [
@@ -108,6 +109,7 @@ export function makeVatLoader(stuff) {
     'enableVatstore',
     'virtualObjectCacheSize',
     'useTranscript',
+    'boydFrequency',
   ];
 
   /**
@@ -160,16 +162,22 @@ export function makeVatLoader(stuff) {
    *        without waiting for the promises to be resolved.  If false, such
    *        messages will be queued inside the kernel.  Defaults to false.
    *
-   * @param {boolean} [options.enableVatstore] If true,
-   *        the vat is provided with an object that allows
-   *        individual keyed access (in an insolated subset of the key space) to
-   *        the vatstore.  Defaults to false.
+   * @param {boolean} [options.enableVatstore] If true, the vat is provided with
+   *        an object that allows individual keyed access (in an insolated
+   *        subset of the key space) to the vatstore.  Defaults to false.
    *
-   * @param {boolean} [options.useTranscript] If true,
-   *        saves a transcript of a vat's inbound
-   *        deliveries and outbound syscalls so that the vat's internal state
-   *        can be reconstructed via replay.  If false, no such record is kept.
-   *        Defaults to true.
+   * @param {boolean} [options.useTranscript] If true, saves a transcript of a
+   *        vat's inbound deliveries and outbound syscalls so that the vat's
+   *        internal state can be reconstructed via replay.  If false, no such
+   *        record is kept.  Defaults to true.
+   *
+   * @param {number|'never'} [options.boydFrequency] The frequency (measured
+   *        in number of deliveries to the vat) after which the kernel will
+   *        deliver the 'bringOutYourDead' directive to the vat.  If the value
+   *        is 'never', 'bringOutYourDead' will never be delivered and the vat
+   *        will be responsible for internally managing (in a deterministic
+   *        manner) any visible effects of garbage collection.  Defaults to the
+   *        kernel's configured 'defaultBoydFrequency' value.
    *
    * @param {string} [options.name]
    * @param {string} [options.description]

--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -118,6 +118,30 @@ export function makeVatKeeper(
     return harden(options);
   }
 
+  function initializeBoydCountdown(count) {
+    kvStore.set(`${vatID}.boydFrequency`, `${count}`);
+    kvStore.set(`${vatID}.boydCountdown`, `${count}`);
+  }
+
+  function boydCountdown() {
+    const rawCount = getRequired(`${vatID}.boydCountdown`);
+    if (rawCount === 'never') {
+      return false;
+    } else {
+      const count = Number.parseInt(rawCount, 10);
+      if (count === 1) {
+        kvStore.set(
+          `${vatID}.boydCountdown`,
+          getRequired(`${vatID}.boydFrequency`),
+        );
+        return true;
+      } else {
+        kvStore.set(`${vatID}.boydCountdown`, `${count - 1}`);
+        return false;
+      }
+    }
+  }
+
   function nextDeliveryNum() {
     const num = Nat(BigInt(kvStore.get(`${vatID}.nextDeliveryNum`)));
     kvStore.set(`${vatID}.nextDeliveryNum`, `${num + 1n}`);
@@ -582,6 +606,8 @@ export function makeVatKeeper(
     setSourceAndOptions,
     getSourceAndOptions,
     getOptions,
+    initializeBoydCountdown,
+    boydCountdown,
     nextDeliveryNum,
     importsKernelSlot,
     mapVatSlotToKernelSlot,

--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -118,25 +118,25 @@ export function makeVatKeeper(
     return harden(options);
   }
 
-  function initializeBoydCountdown(count) {
-    kvStore.set(`${vatID}.boydFrequency`, `${count}`);
-    kvStore.set(`${vatID}.boydCountdown`, `${count}`);
+  function initializeReapCountdown(count) {
+    kvStore.set(`${vatID}.reapInterval`, `${count}`);
+    kvStore.set(`${vatID}.reapCountdown`, `${count}`);
   }
 
-  function boydCountdown() {
-    const rawCount = getRequired(`${vatID}.boydCountdown`);
+  function countdownToReap() {
+    const rawCount = getRequired(`${vatID}.reapCountdown`);
     if (rawCount === 'never') {
       return false;
     } else {
       const count = Number.parseInt(rawCount, 10);
       if (count === 1) {
         kvStore.set(
-          `${vatID}.boydCountdown`,
-          getRequired(`${vatID}.boydFrequency`),
+          `${vatID}.reapCountdown`,
+          getRequired(`${vatID}.reapInterval`),
         );
         return true;
       } else {
-        kvStore.set(`${vatID}.boydCountdown`, `${count - 1}`);
+        kvStore.set(`${vatID}.reapCountdown`, `${count - 1}`);
         return false;
       }
     }
@@ -606,8 +606,8 @@ export function makeVatKeeper(
     setSourceAndOptions,
     getSourceAndOptions,
     getOptions,
-    initializeBoydCountdown,
-    boydCountdown,
+    initializeReapCountdown,
+    countdownToReap,
     nextDeliveryNum,
     importsKernelSlot,
     mapVatSlotToKernelSlot,

--- a/packages/SwingSet/src/kernel/vatManager/factory.js
+++ b/packages/SwingSet/src/kernel/vatManager/factory.js
@@ -61,6 +61,7 @@ export function makeVatManagerFactory({
       'enableVatstore',
       'virtualObjectCacheSize',
       'useTranscript',
+      'boydFrequency',
       'vatParameters',
       'vatConsole',
       'name',

--- a/packages/SwingSet/src/kernel/vatManager/factory.js
+++ b/packages/SwingSet/src/kernel/vatManager/factory.js
@@ -61,7 +61,7 @@ export function makeVatManagerFactory({
       'enableVatstore',
       'virtualObjectCacheSize',
       'useTranscript',
-      'boydFrequency',
+      'reapInterval',
       'vatParameters',
       'vatConsole',
       'name',

--- a/packages/SwingSet/src/kernel/vatTranslator.js
+++ b/packages/SwingSet/src/kernel/vatTranslator.js
@@ -5,6 +5,8 @@ import { insistVatType, parseVatSlot } from '../parseVatSlots.js';
 import { insistCapData } from '../capdata.js';
 import { kdebug, legibilizeMessageArgs, legibilizeValue } from './kdebug.js';
 
+const reapMessageVatDelivery = harden(['bringOutYourDead']);
+
 /*
  * Return a function that converts KernelDelivery objects into VatDelivery
  * objects
@@ -117,8 +119,7 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
   }
 
   function translateBringOutYourDead() {
-    const vatDelivery = harden(['bringOutYourDead']);
-    return vatDelivery;
+    return reapMessageVatDelivery;
   }
 
   function kernelDeliveryToVatDelivery(kd) {

--- a/packages/SwingSet/src/kernel/vatTranslator.js
+++ b/packages/SwingSet/src/kernel/vatTranslator.js
@@ -116,6 +116,11 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
     return vatDelivery;
   }
 
+  function translateBringOutYourDead() {
+    const vatDelivery = harden(['bringOutYourDead']);
+    return vatDelivery;
+  }
+
   function kernelDeliveryToVatDelivery(kd) {
     const [type, ...args] = kd;
     switch (type) {
@@ -129,6 +134,8 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
         return translateRetireExports(...args);
       case 'retireImports':
         return translateRetireImports(...args);
+      case 'bringOutYourDead':
+        return translateBringOutYourDead(...args);
       default:
         assert.fail(X`unknown kernelDelivery.type ${type}`);
     }
@@ -138,6 +145,7 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
     //  ['dropExports', vrefs]
     //  ['retireExports', vrefs]
     //  ['retireImports', vrefs]
+    //  ['bringOutYourDead']
   }
 
   return kernelDeliveryToVatDelivery;

--- a/packages/SwingSet/src/message.js
+++ b/packages/SwingSet/src/message.js
@@ -65,6 +65,10 @@ export function insistVatDeliveryObject(vdo) {
       }
       break;
     }
+    case 'bringOutYourDead': {
+      assert(rest.length === 0);
+      break;
+    }
     default:
       assert.fail(`unknown delivery type ${type}`);
   }

--- a/packages/SwingSet/src/types.js
+++ b/packages/SwingSet/src/types.js
@@ -34,7 +34,7 @@
  *   metered?: boolean,
  *   enableDisavow?: boolean,
  *   useTranscript?: boolean,
- *   boydFrequency?: number | 'never',
+ *   reapInterval?: number | 'never',
  *   enableVatstore?: boolean,
  *   vatParameters: Record<string, unknown>,
  *   virtualObjectCacheSize: number,

--- a/packages/SwingSet/src/types.js
+++ b/packages/SwingSet/src/types.js
@@ -34,6 +34,7 @@
  *   metered?: boolean,
  *   enableDisavow?: boolean,
  *   useTranscript?: boolean,
+ *   boydFrequency?: number | 'never',
  *   enableVatstore?: boolean,
  *   vatParameters: Record<string, unknown>,
  *   virtualObjectCacheSize: number,
@@ -89,8 +90,9 @@
  * @typedef { [tag: 'dropExports', vrefs: string[] ]} VatDeliveryDropExports
  * @typedef { [tag: 'retireExports', vrefs: string[] ]} VatDeliveryRetireExports
  * @typedef { [tag: 'retireImports', vrefs: string[] ]} VatDeliveryRetireImports
+ * @typedef { [tag: 'bringOutYourDead' ]} VatDeliveryBringOutYourDead
  * @typedef { VatDeliveryMessage | VatDeliveryNotify | VatDeliveryDropExports
- *            | VatDeliveryRetireExports | VatDeliveryRetireImports
+ *            | VatDeliveryRetireExports | VatDeliveryRetireImports | VatDeliveryBringOutYourDead
  *          } VatDeliveryObject
  * @typedef { [tag: 'ok', message: null, usage: { compute: number } | null] |
  *            [tag: 'error', message: string, usage: unknown | null] } VatDeliveryResult

--- a/packages/SwingSet/test/gc/test-gc-vat.js
+++ b/packages/SwingSet/test/gc/test-gc-vat.js
@@ -52,9 +52,11 @@ async function dropPresence(t, dropExport) {
   c.queueToVatRoot('bootstrap', 'one', capargs([]));
   if (dropExport) {
     c.queueToVatRoot('bootstrap', 'drop', capargs([]));
-    await c.step();
+    await c.step(); // message
+    await c.step(); // BOYD
   }
-  await c.step();
+  await c.step(); // message
+  await c.step(); // BOYD
 
   // examine the run-queue to learn the krefs for objects A and B
   const rq = c.dump().runQueue;

--- a/packages/SwingSet/test/gc/test-gc-vat.js
+++ b/packages/SwingSet/test/gc/test-gc-vat.js
@@ -53,10 +53,10 @@ async function dropPresence(t, dropExport) {
   if (dropExport) {
     c.queueToVatRoot('bootstrap', 'drop', capargs([]));
     await c.step(); // message
-    await c.step(); // BOYD
+    await c.step(); // reap
   }
   await c.step(); // message
-  await c.step(); // BOYD
+  await c.step(); // reap
 
   // examine the run-queue to learn the krefs for objects A and B
   const rq = c.dump().runQueue;

--- a/packages/SwingSet/test/run-policy/test-run-policy.js
+++ b/packages/SwingSet/test/run-policy/test-run-policy.js
@@ -12,6 +12,7 @@ import {
 
 async function testCranks(t, mode) {
   const config = {
+    defaultBoydFrequency: 'never',
     vats: {
       left: {
         sourceSpec: new URL('vat-policy-left.js', import.meta.url).pathname,

--- a/packages/SwingSet/test/run-policy/test-run-policy.js
+++ b/packages/SwingSet/test/run-policy/test-run-policy.js
@@ -12,7 +12,7 @@ import {
 
 async function testCranks(t, mode) {
   const config = {
-    defaultBoydFrequency: 'never',
+    defaultReapInterval: 'never',
     vats: {
       left: {
         sourceSpec: new URL('vat-policy-left.js', import.meta.url).pathname,

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -247,7 +247,7 @@ test.serial('bootstrap export', async t => {
       // eslint-disable-next-line no-await-in-loop
       await c.step();
     }
-    while (c.dump().boydQueue.length) {
+    while (c.dump().reapQueue.length) {
       // eslint-disable-next-line no-await-in-loop
       await c.step();
     }

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -174,6 +174,7 @@ test.serial('bootstrap export', async t => {
   const config = await loadBasedir(
     new URL('basedir-controller-3', import.meta.url).pathname,
   );
+  config.defaultManagerType = 'xs-worker';
   const c = await buildVatController(config);
   c.pinVatRoot('bootstrap');
   const vatAdminVatID = c.vatNameToID('vatAdmin');
@@ -246,12 +247,16 @@ test.serial('bootstrap export', async t => {
       // eslint-disable-next-line no-await-in-loop
       await c.step();
     }
+    while (c.dump().boydQueue.length) {
+      // eslint-disable-next-line no-await-in-loop
+      await c.step();
+    }
     await c.step(); // the non- GC action
   }
 
   t.deepEqual(c.dump().log, []);
   // console.log('--- c.step() running bootstrap.obj0.bootstrap');
-  await stepGC();
+  await stepGC(); // message bootstrap
   // kernel promise for result of the foo() that bootstrap sends to vat-left
   const fooP = 'kp41';
   t.deepEqual(c.dump().log, ['bootstrap.obj0.bootstrap()']);
@@ -280,7 +285,8 @@ test.serial('bootstrap export', async t => {
     },
   ]);
 
-  await stepGC();
+  await stepGC(); // dropExports
+  await stepGC(); // message foo
   const barP = 'kp42';
   t.deepEqual(c.dump().log, ['bootstrap.obj0.bootstrap()', 'left.foo 1']);
   kt.push([right0, leftVatID, 'o-50']);
@@ -303,7 +309,7 @@ test.serial('bootstrap export', async t => {
     { type: 'notify', vatID: bootstrapVatID, kpid: fooP },
   ]);
 
-  await stepGC();
+  await stepGC(); // message bar
 
   t.deepEqual(c.dump().log, [
     'bootstrap.obj0.bootstrap()',
@@ -318,7 +324,7 @@ test.serial('bootstrap export', async t => {
     { type: 'notify', vatID: leftVatID, kpid: barP },
   ]);
 
-  await stepGC();
+  await stepGC(); // notify
 
   t.deepEqual(c.dump().log, [
     'bootstrap.obj0.bootstrap()',
@@ -340,7 +346,7 @@ test.serial('bootstrap export', async t => {
     { type: 'notify', vatID: leftVatID, kpid: barP },
   ]);
 
-  await stepGC();
+  await stepGC(); // notify
 
   t.deepEqual(c.dump().log, [
     'bootstrap.obj0.bootstrap()',

--- a/packages/SwingSet/test/test-demos-comms.js
+++ b/packages/SwingSet/test/test-demos-comms.js
@@ -12,6 +12,7 @@ import {
 async function main(basedir, argv) {
   const config = await loadBasedir(basedir);
   const enableSetup = true;
+  config.defaultBoydFrequency = 'never';
   if (config.vats.botcomms) {
     config.vats.botcomms.creationOptions = { enableSetup };
   }

--- a/packages/SwingSet/test/test-demos-comms.js
+++ b/packages/SwingSet/test/test-demos-comms.js
@@ -12,7 +12,7 @@ import {
 async function main(basedir, argv) {
   const config = await loadBasedir(basedir);
   const enableSetup = true;
-  config.defaultBoydFrequency = 'never';
+  config.defaultReapInterval = 'never';
   if (config.vats.botcomms) {
     config.vats.botcomms.creationOptions = { enableSetup };
   }

--- a/packages/SwingSet/test/test-devices.js
+++ b/packages/SwingSet/test/test-devices.js
@@ -89,7 +89,7 @@ test.serial('d1', async t => {
   const sharedArray = [];
   const config = {
     bootstrap: 'bootstrap',
-    defaultBoydFrequency: 'never',
+    defaultReapInterval: 'never',
     vats: {
       bootstrap: {
         bundle: t.context.data.bootstrap1,
@@ -125,7 +125,7 @@ test.serial('d1', async t => {
 async function test2(t, mode) {
   const config = {
     bootstrap: 'bootstrap',
-    defaultBoydFrequency: 'never',
+    defaultReapInterval: 'never',
     vats: {
       bootstrap: {
         bundle: t.context.data.bootstrap2,

--- a/packages/SwingSet/test/test-devices.js
+++ b/packages/SwingSet/test/test-devices.js
@@ -89,6 +89,7 @@ test.serial('d1', async t => {
   const sharedArray = [];
   const config = {
     bootstrap: 'bootstrap',
+    defaultBoydFrequency: 'never',
     vats: {
       bootstrap: {
         bundle: t.context.data.bootstrap1,
@@ -124,6 +125,7 @@ test.serial('d1', async t => {
 async function test2(t, mode) {
   const config = {
     bootstrap: 'bootstrap',
+    defaultBoydFrequency: 'never',
     vats: {
       bootstrap: {
         bundle: t.context.data.bootstrap2,

--- a/packages/SwingSet/test/test-kernel.js
+++ b/packages/SwingSet/test/test-kernel.js
@@ -1264,7 +1264,7 @@ test('xs-worker default manager type', async t => {
   );
 });
 
-async function boydTest(t, freq) {
+async function reapTest(t, freq) {
   const kernel = makeKernel();
   await kernel.start();
   const log = [];
@@ -1274,7 +1274,7 @@ async function boydTest(t, freq) {
     }
     return dispatch;
   }
-  await kernel.createTestVat('vat1', setup, {}, { boydFrequency: freq });
+  await kernel.createTestVat('vat1', setup, {}, { reapInterval: freq });
   const vat1 = kernel.vatNameToID('vat1');
   t.deepEqual(log, []);
 
@@ -1296,7 +1296,7 @@ async function boydTest(t, freq) {
       },
     ];
   }
-  function matchBoyd() {
+  function matchReap() {
     return ['bringOutYourDead'];
   }
 
@@ -1308,28 +1308,28 @@ async function boydTest(t, freq) {
   for (let i = 0; i < 100; i += 1) {
     t.deepEqual(log.shift(), matchMsg(i));
     if (freq !== 'never' && (i + 1) % freq === 0) {
-      t.deepEqual(log.shift(), matchBoyd());
+      t.deepEqual(log.shift(), matchReap());
     }
   }
   t.deepEqual(log, []);
 }
 
-test('boyd frequency 1', async t => {
-  await boydTest(t, 1);
+test('reap interval 1', async t => {
+  await reapTest(t, 1);
 });
 
-test('boyd frequency 2', async t => {
-  await boydTest(t, 2);
+test('reap interval 2', async t => {
+  await reapTest(t, 2);
 });
 
-test('boyd frequency 5', async t => {
-  await boydTest(t, 5);
+test('reap interval 5', async t => {
+  await reapTest(t, 5);
 });
 
-test('boyd frequency 17', async t => {
-  await boydTest(t, 17);
+test('reap interval 17', async t => {
+  await reapTest(t, 17);
 });
 
-test('boyd frequency never', async t => {
-  await boydTest(t, 'never');
+test('reap interval never', async t => {
+  await reapTest(t, 'never');
 });

--- a/packages/SwingSet/test/test-liveslots.js
+++ b/packages/SwingSet/test/test-liveslots.js
@@ -1063,6 +1063,7 @@ test('dropImports', async t => {
   t.is(FR.countCallbacks(), 0);
 
   await dispatch(makeMessage(rootA, 'hold', capargsOneSlot('o-6')));
+  await dispatch(makeBringOutYourDead());
   // back to REACHABLE, removed from possiblyDeadSet
   t.deepEqual(possiblyDeadSet, new Set());
   t.is(FR.countCallbacks(), 0);

--- a/packages/SwingSet/test/test-message-patterns.js
+++ b/packages/SwingSet/test/test-message-patterns.js
@@ -64,6 +64,7 @@ test.before(async t => {
   const bundleLocal = await bundleSource(bootstrapLocal);
   const localConfig = {
     bootstrap: 'bootstrap',
+    defaultBoydFrequency: 'never',
     vats: {
       bootstrap: { bundle: bundleLocal },
       a: { bundle: bundleA },
@@ -86,6 +87,7 @@ test.before(async t => {
   const moreVatTP = { bundle: kernelBundles.vattp };
   const commsConfig = {
     bootstrap: 'bootstrap',
+    defaultBoydFrequency: 'never',
     vats: {
       bootstrap: { bundle: bundleComms },
       a: { bundle: bundleA },

--- a/packages/SwingSet/test/test-message-patterns.js
+++ b/packages/SwingSet/test/test-message-patterns.js
@@ -64,7 +64,7 @@ test.before(async t => {
   const bundleLocal = await bundleSource(bootstrapLocal);
   const localConfig = {
     bootstrap: 'bootstrap',
-    defaultBoydFrequency: 'never',
+    defaultReapInterval: 'never',
     vats: {
       bootstrap: { bundle: bundleLocal },
       a: { bundle: bundleA },
@@ -87,7 +87,7 @@ test.before(async t => {
   const moreVatTP = { bundle: kernelBundles.vattp };
   const commsConfig = {
     bootstrap: 'bootstrap',
-    defaultBoydFrequency: 'never',
+    defaultReapInterval: 'never',
     vats: {
       bootstrap: { bundle: bundleComms },
       a: { bundle: bundleA },

--- a/packages/SwingSet/test/test-state.js
+++ b/packages/SwingSet/test/test-state.js
@@ -270,6 +270,7 @@ test('kernel state', async t => {
     ['initialized', 'true'],
     ['gcActions', '[]'],
     ['runQueue', '[]'],
+    ['boydQueue', '[]'],
     ['vat.nextID', '1'],
     ['vat.names', '[]'],
     ['vat.dynamicIDs', '[]'],
@@ -279,6 +280,7 @@ test('kernel state', async t => {
     ['kd.nextID', '30'],
     ['kp.nextID', '40'],
     ['kernel.defaultManagerType', 'local'],
+    ['kernel.defaultBoydFrequency', 'undefined'],
     ['meter.nextID', '1'],
   ]);
 });
@@ -299,6 +301,7 @@ test('kernelKeeper vat names', async t => {
     ['crankNumber', '0'],
     ['gcActions', '[]'],
     ['runQueue', '[]'],
+    ['boydQueue', '[]'],
     ['vat.nextID', '3'],
     ['vat.names', JSON.stringify(['vatname5', 'Frank'])],
     ['vat.dynamicIDs', '[]'],
@@ -310,6 +313,7 @@ test('kernelKeeper vat names', async t => {
     ['vat.name.vatname5', 'v1'],
     ['vat.name.Frank', 'v2'],
     ['kernel.defaultManagerType', 'local'],
+    ['kernel.defaultBoydFrequency', 'undefined'],
     ['meter.nextID', '1'],
   ]);
   t.deepEqual(k.getStaticVats(), [
@@ -344,6 +348,7 @@ test('kernelKeeper device names', async t => {
     ['crankNumber', '0'],
     ['gcActions', '[]'],
     ['runQueue', '[]'],
+    ['boydQueue', '[]'],
     ['vat.nextID', '1'],
     ['vat.names', '[]'],
     ['vat.dynamicIDs', '[]'],
@@ -355,6 +360,7 @@ test('kernelKeeper device names', async t => {
     ['device.name.devicename5', 'd7'],
     ['device.name.Frank', 'd8'],
     ['kernel.defaultManagerType', 'local'],
+    ['kernel.defaultBoydFrequency', 'undefined'],
     ['meter.nextID', '1'],
   ]);
   t.deepEqual(k.getDevices(), [
@@ -519,6 +525,7 @@ test('kernelKeeper promises', async t => {
     ['device.names', '[]'],
     ['gcActions', '[]'],
     ['runQueue', JSON.stringify(expectedRunqueue)],
+    ['boydQueue', '[]'],
     ['kd.nextID', '30'],
     ['ko.nextID', '21'],
     ['kp.nextID', '41'],
@@ -529,6 +536,7 @@ test('kernelKeeper promises', async t => {
     [`${ko}.owner`, 'v1'],
     [`${ko}.refCount`, '1,1'],
     ['kernel.defaultManagerType', 'local'],
+    ['kernel.defaultBoydFrequency', 'undefined'],
     ['meter.nextID', '1'],
   ]);
 });
@@ -687,7 +695,7 @@ test('crankhash', t => {
   k.commitCrank();
   // the initial state additions happen to hash to this:
   const oldActivityhash =
-    '2062d4a479c62d3f83b7ca654f911fdd5320609e003deb0a0396872639d170a1';
+    '668ec0ad794255845b124656da85f6e30a4bc32378ceb7bfb610bf2529e3196b';
   t.is(store.kvStore.get('activityhash'), oldActivityhash);
 
   k.kvStore.set('one', '1');
@@ -705,7 +713,7 @@ test('crankhash', t => {
   const expActivityhash = h.digest('hex');
   t.is(
     expActivityhash,
-    '3c963c0082282e486edfcb62d31322e72f5e0c2c9f296ea61f613eeea23b8770',
+    '8ba058e647d22eb503790f94212945f5e1085ad6142d168d37ad20b0e16f2df3',
   );
 
   const { crankhash, activityhash } = k.commitCrank();

--- a/packages/SwingSet/test/test-state.js
+++ b/packages/SwingSet/test/test-state.js
@@ -270,7 +270,7 @@ test('kernel state', async t => {
     ['initialized', 'true'],
     ['gcActions', '[]'],
     ['runQueue', '[]'],
-    ['boydQueue', '[]'],
+    ['reapQueue', '[]'],
     ['vat.nextID', '1'],
     ['vat.names', '[]'],
     ['vat.dynamicIDs', '[]'],
@@ -280,7 +280,7 @@ test('kernel state', async t => {
     ['kd.nextID', '30'],
     ['kp.nextID', '40'],
     ['kernel.defaultManagerType', 'local'],
-    ['kernel.defaultBoydFrequency', 'undefined'],
+    ['kernel.defaultReapInterval', 'undefined'],
     ['meter.nextID', '1'],
   ]);
 });
@@ -301,7 +301,7 @@ test('kernelKeeper vat names', async t => {
     ['crankNumber', '0'],
     ['gcActions', '[]'],
     ['runQueue', '[]'],
-    ['boydQueue', '[]'],
+    ['reapQueue', '[]'],
     ['vat.nextID', '3'],
     ['vat.names', JSON.stringify(['vatname5', 'Frank'])],
     ['vat.dynamicIDs', '[]'],
@@ -313,7 +313,7 @@ test('kernelKeeper vat names', async t => {
     ['vat.name.vatname5', 'v1'],
     ['vat.name.Frank', 'v2'],
     ['kernel.defaultManagerType', 'local'],
-    ['kernel.defaultBoydFrequency', 'undefined'],
+    ['kernel.defaultReapInterval', 'undefined'],
     ['meter.nextID', '1'],
   ]);
   t.deepEqual(k.getStaticVats(), [
@@ -348,7 +348,7 @@ test('kernelKeeper device names', async t => {
     ['crankNumber', '0'],
     ['gcActions', '[]'],
     ['runQueue', '[]'],
-    ['boydQueue', '[]'],
+    ['reapQueue', '[]'],
     ['vat.nextID', '1'],
     ['vat.names', '[]'],
     ['vat.dynamicIDs', '[]'],
@@ -360,7 +360,7 @@ test('kernelKeeper device names', async t => {
     ['device.name.devicename5', 'd7'],
     ['device.name.Frank', 'd8'],
     ['kernel.defaultManagerType', 'local'],
-    ['kernel.defaultBoydFrequency', 'undefined'],
+    ['kernel.defaultReapInterval', 'undefined'],
     ['meter.nextID', '1'],
   ]);
   t.deepEqual(k.getDevices(), [
@@ -525,7 +525,7 @@ test('kernelKeeper promises', async t => {
     ['device.names', '[]'],
     ['gcActions', '[]'],
     ['runQueue', JSON.stringify(expectedRunqueue)],
-    ['boydQueue', '[]'],
+    ['reapQueue', '[]'],
     ['kd.nextID', '30'],
     ['ko.nextID', '21'],
     ['kp.nextID', '41'],
@@ -536,7 +536,7 @@ test('kernelKeeper promises', async t => {
     [`${ko}.owner`, 'v1'],
     [`${ko}.refCount`, '1,1'],
     ['kernel.defaultManagerType', 'local'],
-    ['kernel.defaultBoydFrequency', 'undefined'],
+    ['kernel.defaultReapInterval', 'undefined'],
     ['meter.nextID', '1'],
   ]);
 });
@@ -695,7 +695,7 @@ test('crankhash', t => {
   k.commitCrank();
   // the initial state additions happen to hash to this:
   const oldActivityhash =
-    '668ec0ad794255845b124656da85f6e30a4bc32378ceb7bfb610bf2529e3196b';
+    '1bde96fbe196090dc773e8b9d07a22a0a83e2fb3b4295efb2d8f863c9c8831fb';
   t.is(store.kvStore.get('activityhash'), oldActivityhash);
 
   k.kvStore.set('one', '1');
@@ -713,7 +713,7 @@ test('crankhash', t => {
   const expActivityhash = h.digest('hex');
   t.is(
     expActivityhash,
-    '8ba058e647d22eb503790f94212945f5e1085ad6142d168d37ad20b0e16f2df3',
+    'c80eaa61ecad76d48f2a2ab7af42b400505e3ad5bebfb3643a8ff28cc3494e89',
   );
 
   const { crankhash, activityhash } = k.commitCrank();

--- a/packages/SwingSet/test/test-syscall-failure.js
+++ b/packages/SwingSet/test/test-syscall-failure.js
@@ -12,7 +12,7 @@ async function vatSyscallFailure(t, beDynamic) {
         sourceSpec: new URL('vat-syscall-failure.js', import.meta.url).pathname,
       },
     },
-    defaultBoydFrequency: 'never',
+    defaultReapInterval: 'never',
     vats: {
       bootstrap: {
         sourceSpec: new URL('bootstrap-syscall-failure.js', import.meta.url)

--- a/packages/SwingSet/test/test-syscall-failure.js
+++ b/packages/SwingSet/test/test-syscall-failure.js
@@ -12,6 +12,7 @@ async function vatSyscallFailure(t, beDynamic) {
         sourceSpec: new URL('vat-syscall-failure.js', import.meta.url).pathname,
       },
     },
+    defaultBoydFrequency: 'never',
     vats: {
       bootstrap: {
         sourceSpec: new URL('bootstrap-syscall-failure.js', import.meta.url)

--- a/packages/SwingSet/test/util.js
+++ b/packages/SwingSet/test/util.js
@@ -123,6 +123,10 @@ export function makeMessage(target, method, args, result = null) {
   return vatDeliverObject;
 }
 
+export function makeBringOutYourDead() {
+  return harden(['bringOutYourDead']);
+}
+
 export function makeResolutions(resolutions) {
   const vatDeliverObject = harden(['notify', resolutions]);
   return vatDeliverObject;

--- a/packages/SwingSet/test/vat-admin/terminate/swingset-die-cleanly.json
+++ b/packages/SwingSet/test/vat-admin/terminate/swingset-die-cleanly.json
@@ -1,5 +1,6 @@
 {
   "bootstrap": "bootstrap",
+  "defaultManagerType": "xs-worker",
   "bundles": {
     "dude": {
       "sourceSpec": "vat-dude-terminate.js"

--- a/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
+++ b/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
@@ -213,7 +213,7 @@ test('dead vat state removed', async t => {
   const kvStore = hostStorage.kvStore;
   t.is(kvStore.get('vat.dynamicIDs'), '["v6"]');
   t.is(kvStore.get('ko26.owner'), 'v6');
-  t.is(Array.from(kvStore.getKeys('v6.', 'v6/')).length, 9);
+  t.is(Array.from(kvStore.getKeys('v6.', 'v6/')).length, 11);
 
   controller.queueToVatRoot('bootstrap', 'phase2', capargs([]));
   await controller.run();

--- a/packages/SwingSet/test/vat-warehouse/test-reload-snapshot.js
+++ b/packages/SwingSet/test/vat-warehouse/test-reload-snapshot.js
@@ -9,6 +9,7 @@ import { capargs } from '../util.js';
 
 test('vat reload from snapshot', async t => {
   const config = {
+    defaultBoydFrequency: 'never',
     vats: {
       target: {
         sourceSpec: new URL('vat-warehouse-reload.js', import.meta.url)

--- a/packages/SwingSet/test/vat-warehouse/test-reload-snapshot.js
+++ b/packages/SwingSet/test/vat-warehouse/test-reload-snapshot.js
@@ -9,7 +9,7 @@ import { capargs } from '../util.js';
 
 test('vat reload from snapshot', async t => {
   const config = {
-    defaultBoydFrequency: 'never',
+    defaultReapInterval: 'never',
     vats: {
       target: {
         sourceSpec: new URL('vat-warehouse-reload.js', import.meta.url)

--- a/packages/SwingSet/test/virtualObjects/test-representatives.js
+++ b/packages/SwingSet/test/virtualObjects/test-representatives.js
@@ -308,10 +308,10 @@ test.serial('exercise cache', async t => {
   t.deepEqual(log, []);
 
   await make('thing5', false, T5); // evict t2, make t5 - [t5 t4 t3 t1]
-  t.deepEqual(log.shift(), ['get', rcKey(2), undefined]);
-  t.deepEqual(log.shift(), ['get', esKey(2), '1']);
   t.deepEqual(log.shift(), ['set', dataKey(2), thingVal('thing2')]);
   t.deepEqual(log.shift(), ['set', esKey(5), '1']);
+  t.deepEqual(log.shift(), ['get', rcKey(2), undefined]);
+  t.deepEqual(log.shift(), ['get', esKey(2), '1']);
   t.deepEqual(log, []);
 
   await make('thing6', false, T6); // evict t1, make t6 - [t6 t5 t4 t3]
@@ -320,31 +320,31 @@ test.serial('exercise cache', async t => {
   t.deepEqual(log, []);
 
   await make('thing7', false, T7); // evict t3, make t7 - [t7 t6 t5 t4]
-  t.deepEqual(log.shift(), ['get', rcKey(3), undefined]);
-  t.deepEqual(log.shift(), ['get', esKey(3), '1']);
   t.deepEqual(log.shift(), ['set', dataKey(3), thingVal('thing3')]);
   t.deepEqual(log.shift(), ['set', esKey(7), '1']);
+  t.deepEqual(log.shift(), ['get', rcKey(3), undefined]);
+  t.deepEqual(log.shift(), ['get', esKey(3), '1']);
   t.deepEqual(log, []);
 
   await make('thing8', false, T8); // evict t4, make t8 - [t8 t7 t6 t5]
-  t.deepEqual(log.shift(), ['get', rcKey(4), undefined]);
-  t.deepEqual(log.shift(), ['get', esKey(4), '1']);
   t.deepEqual(log.shift(), ['set', dataKey(4), thingVal('thing4')]);
   t.deepEqual(log.shift(), ['set', esKey(8), '1']);
+  t.deepEqual(log.shift(), ['get', rcKey(4), undefined]);
+  t.deepEqual(log.shift(), ['get', esKey(4), '1']);
   t.deepEqual(log, []);
 
   await read(T2, 'thing2'); // reanimate t2, evict t5 - [t2 t8 t7 t6]
   t.deepEqual(log.shift(), ['get', dataKey(2), thingVal('thing2')]);
+  t.deepEqual(log.shift(), ['set', dataKey(5), thingVal('thing5')]);
   t.deepEqual(log.shift(), ['get', rcKey(5), undefined]);
   t.deepEqual(log.shift(), ['get', esKey(5), '1']);
-  t.deepEqual(log.shift(), ['set', dataKey(5), thingVal('thing5')]);
   t.deepEqual(log, []);
 
   await readHeld('thing1'); // reanimate t1, evict t6 - [t1 t2 t8 t7]
   t.deepEqual(log.shift(), ['get', dataKey(1), thingVal('thing1')]);
+  t.deepEqual(log.shift(), ['set', dataKey(6), thingVal('thing6')]);
   t.deepEqual(log.shift(), ['get', rcKey(6), undefined]);
   t.deepEqual(log.shift(), ['get', esKey(6), '1']);
-  t.deepEqual(log.shift(), ['set', dataKey(6), thingVal('thing6')]);
   t.deepEqual(log, []);
 
   await write(T2, 'thing2 updated'); // refresh t2 - [t2 t1 t8 t7]
@@ -356,9 +356,9 @@ test.serial('exercise cache', async t => {
 
   await read(T6, 'thing6'); // reanimate t6, evict t2 - [t6 t7 t8 t1]
   t.deepEqual(log.shift(), ['get', dataKey(6), thingVal('thing6')]);
+  t.deepEqual(log.shift(), ['set', dataKey(2), thingVal('thing2 updated')]);
   t.deepEqual(log.shift(), ['get', rcKey(2), undefined]);
   t.deepEqual(log.shift(), ['get', esKey(2), '1']);
-  t.deepEqual(log.shift(), ['set', dataKey(2), thingVal('thing2 updated')]);
   t.deepEqual(log, []);
 
   await read(T5, 'thing5'); // reanimate t5, evict t1 - [t5 t6 t7 t8]
@@ -373,9 +373,9 @@ test.serial('exercise cache', async t => {
 
   await read(T3, 'thing3'); // reanimate t3, evict t7 - [t3 t4 t5 t6]
   t.deepEqual(log.shift(), ['get', dataKey(3), thingVal('thing3')]);
+  t.deepEqual(log.shift(), ['set', dataKey(7), thingVal('thing7')]);
   t.deepEqual(log.shift(), ['get', rcKey(7), undefined]);
   t.deepEqual(log.shift(), ['get', esKey(7), '1']);
-  t.deepEqual(log.shift(), ['set', dataKey(7), thingVal('thing7')]);
   t.deepEqual(log, []);
 
   await read(T2, 'thing2 updated'); // reanimate t2, evict t6 - [t2 t3 t4 t5]

--- a/packages/SwingSet/test/virtualObjects/test-virtualObjectGC.js
+++ b/packages/SwingSet/test/virtualObjects/test-virtualObjectGC.js
@@ -9,6 +9,7 @@ import {
   makeDropExports,
   makeRetireImports,
   makeRetireExports,
+  makeBringOutYourDead,
 } from '../util.js';
 
 // Legs:
@@ -360,16 +361,20 @@ function setupLifecycleTest(t) {
   async function dispatchMessage(message, args = capargs([])) {
     const rp = nextRP();
     await dispatch(makeMessage(root, message, args, rp));
+    await dispatch(makeBringOutYourDead());
     return rp;
   }
   async function dispatchDropExports(...vrefs) {
     await dispatch(makeDropExports(...vrefs));
+    await dispatch(makeBringOutYourDead());
   }
   async function dispatchRetireImports(...vrefs) {
     await dispatch(makeRetireImports(...vrefs));
+    await dispatch(makeBringOutYourDead());
   }
   async function dispatchRetireExports(...vrefs) {
     await dispatch(makeRetireExports(...vrefs));
+    await dispatch(makeBringOutYourDead());
   }
 
   const v = { t, log };

--- a/packages/swingset-runner/src/runner-debug-entrypoint.js
+++ b/packages/swingset-runner/src/runner-debug-entrypoint.js
@@ -5,8 +5,12 @@
  * as yet not-entirely-ESM-supporting version of NodeJS.
  */
 
-// LMDB bindings need to be imported before lockdown.
+// Initialize trasitive dependencies that run afoul of the property override
+// after SES lockdown hazard.
 import 'node-lmdb';
+// TODO Remove babel-standalone preinitialization
+// https://github.com/endojs/endo/issues/768
+import '@agoric/babel-standalone';
 
 // Now do lockdown.
 import './install-optional-metering-and-ses.js';


### PR DESCRIPTION
These changes implement the machinery described in #3767 to allow the kernel to deterministically control the revelation of the consequences of otherwise non-deterministic garbage collection activity.

As implemented, each vat has a "BOYD frequency", which is the number of deliveries after which the kernel will deliver it a `'bringOutYourDead'` request.  This frequency may be configured on a per-vat basis via the `boydFrequency` vat config  parameter.  If not specified, it defaults to a swingset-global configuration parameter, `defaultBoydFrequency`, which in turn defaults to 1 (i.e., BOYD after each crank, roughly matching the GC behavior prior to this PR).

Alternatively, the BOYD frequency may be specified as `'never'`, in which case `'bringOutYourDead'` is never sent to the vat.  This is useful for tests as well as for `setup` vats that deterministically manage their own GC.  A notable example of the latter is the comms vat, which is thus configured by the changes in this PR.

Other, more sophisticated, BOYD policies are plausible, such as at the end of a block or when some storage usage threshold is met.  Since BOYD is now extrinsic to the vats, such changes may be effected without modification to vat code or liveslots, though of course kernel changes to the control logic would be needed.

Closes #3767