### PR TITLE
Mitigate more ag-solo robustness issues

### DIFF
--- a/packages/agoric-cli/lib/chain-config.js
+++ b/packages/agoric-cli/lib/chain-config.js
@@ -14,6 +14,8 @@ export const DEFAULT_MINIMUM_GAS_PRICES = `0${CENTRAL_DENOM}`;
 //
 // 5 seconds is about as fast as we can go without penalising validators.
 export const BLOCK_CADENCE_S = 5;
+export const RPC_BROADCAST_TIMEOUT_S = 30;
+export const RPC_MAX_BODY_BYTES = 15_000_000;
 
 export const EPOCH_DURATION_S = 60 * 60; // 1 hour
 export const BLOCKS_PER_EPOCH = Math.floor(EPOCH_DURATION_S / BLOCK_CADENCE_S);
@@ -93,7 +95,8 @@ export function finishTendermintConfig({
   config.p2p.unconditional_peer_ids = unconditionalPeerIds;
   config.p2p.seeds = seeds;
   config.rpc.laddr = `tcp://0.0.0.0:${rpcPort}`;
-  config.rpc.max_body_bytes = 15 * 10 ** 6;
+  config.rpc.max_body_bytes = RPC_MAX_BODY_BYTES;
+  config.rpc.timeout_broadcast_tx_commit = `${RPC_BROADCAST_TIMEOUT_S}s`;
 
   if (
     enableCors &&

--- a/packages/agoric-cli/lib/deploy.js
+++ b/packages/agoric-cli/lib/deploy.js
@@ -30,7 +30,7 @@ const RETRY_DELAY_MS = 1000;
 const PATH_SEP_RE = new RegExp(`${path.sep.replace(/\\/g, '\\\\')}`, 'g');
 
 export default async function deployMain(progname, rawArgs, powers, opts) {
-  const { anylogger, fs, makeWebSocket } = powers;
+  const { anylogger, fs, makeWebSocket, now } = powers;
   const console = anylogger('agoric:deploy');
 
   const allowUnsafePlugins = opts.allowUnsafePlugins;
@@ -98,7 +98,7 @@ export default async function deployMain(progname, rawArgs, powers, opts) {
       try {
         console.debug('Connected to CapTP!');
         // Help disambiguate connections.
-        const epoch = Date.now();
+        const epoch = now();
         const { dispatch, getBootstrap } = makeCapTP(
           'bundle',
           obj => sendJSON(ws, obj),

--- a/packages/agoric-cli/lib/deploy.js
+++ b/packages/agoric-cli/lib/deploy.js
@@ -97,8 +97,15 @@ export default async function deployMain(progname, rawArgs, powers, opts) {
       connected = true;
       try {
         console.debug('Connected to CapTP!');
-        const { dispatch, getBootstrap } = makeCapTP('bundle', obj =>
-          sendJSON(ws, obj),
+        // Help disambiguate connections.
+        const epoch = Date.now();
+        const { dispatch, getBootstrap } = makeCapTP(
+          'bundle',
+          obj => sendJSON(ws, obj),
+          undefined,
+          {
+            epoch,
+          },
         );
         ws.on('message', data => {
           try {

--- a/packages/agoric-cli/lib/entrypoint.js
+++ b/packages/agoric-cli/lib/entrypoint.js
@@ -32,6 +32,7 @@ main(progname, rawArgs, {
   stdout,
   makeWebSocket,
   fs,
+  now: Date.now,
   os,
   process,
   spawn,

--- a/packages/solo/src/captp.js
+++ b/packages/solo/src/captp.js
@@ -6,6 +6,7 @@ export const getCapTPHandler = (
   getLocalBootstrap,
   fallback = undefined,
 ) => {
+  let lastEpoch;
   const chans = new Map();
   const doFallback = async (method, ...args) => {
     if (!fallback) {
@@ -16,7 +17,9 @@ export const getCapTPHandler = (
   const handler = Far('capTpHandler', {
     onOpen(obj, meta) {
       const { channelHandle, origin = 'unknown' } = meta || {};
-      console.debug(`Starting CapTP`, meta);
+      lastEpoch += 1;
+      const epoch = lastEpoch;
+      console.debug(`Starting CapTP#${epoch}`, meta);
       const sendObj = o => {
         send(o, [channelHandle]);
       };
@@ -25,6 +28,9 @@ export const getCapTPHandler = (
         sendObj,
         async o => getLocalBootstrap(getRemoteBootstrap(), meta, o),
         {
+          // Disambiguate in case we receive messages from different
+          // connections.
+          epoch,
           onReject(err) {
             // Be quieter for sanity's sake.
             console.log('CapTP', origin, 'exception:', err);

--- a/packages/solo/src/scratch.js
+++ b/packages/solo/src/scratch.js
@@ -2,25 +2,27 @@ import { Far } from '@agoric/marshal';
 
 export default function makeScratchPad() {
   const map = new Map();
-  async function get(idP) {
-    const id = await idP;
-    return map.get(id);
-  }
-  async function set(idP, objP) {
-    const [id, obj] = await Promise.all([idP, objP]);
-    map.set(id, obj);
-    return id;
-  }
-  function list() {
-    const ids = [];
-    for (const id of map.keys()) {
-      ids.push(id);
-    }
-    return harden(ids.sort());
-  }
   return Far('scratchPad', {
-    get,
-    set,
-    list,
+    get: async idP => {
+      const id = await idP;
+      return map.get(id);
+    },
+    set: async (idP, objP) => {
+      const [id, obj] = await Promise.all([idP, objP]);
+      map.set(id, obj);
+      return id;
+    },
+    init: async (idP, objP) => {
+      const [id, obj] = await Promise.all([idP, objP]);
+      if (map.has(id)) {
+        throw Error(`Scratchpad already has id ${id}`);
+      }
+      map.set(id, obj);
+      return id;
+    },
+    list: async () => {
+      const ids = [...map.keys()];
+      return harden(ids.sort());
+    },
   });
 }

--- a/packages/solo/src/scratch.js
+++ b/packages/solo/src/scratch.js
@@ -2,27 +2,38 @@ import { Far } from '@agoric/marshal';
 
 export default function makeScratchPad() {
   const map = new Map();
+
+  const keys = async () => {
+    const keyList = [...map.keys()];
+    return harden(keyList.sort());
+  };
+
   return Far('scratchPad', {
-    get: async idP => {
-      const id = await idP;
-      return map.get(id);
+    delete: async keyP => {
+      const key = await keyP;
+      map.delete(key);
     },
-    set: async (idP, objP) => {
-      const [id, obj] = await Promise.all([idP, objP]);
-      map.set(id, obj);
-      return id;
+    get: async keyP => {
+      const key = await keyP;
+      return map.get(key);
     },
-    init: async (idP, objP) => {
-      const [id, obj] = await Promise.all([idP, objP]);
-      if (map.has(id)) {
-        throw Error(`Scratchpad already has id ${id}`);
+    // Initialize a key only if it doesn't already exist.  Needed for atomicity
+    // between multiple invocations.
+    init: async (keyP, objP) => {
+      const [key, obj] = await Promise.all([keyP, objP]);
+      if (map.has(key)) {
+        throw Error(`Scratchpad already has key ${key}`);
       }
-      map.set(id, obj);
-      return id;
+      map.set(key, obj);
+      return key;
     },
-    list: async () => {
-      const ids = [...map.keys()];
-      return harden(ids.sort());
+    keys,
+    // Legacy alias for `keys`.
+    list: keys,
+    set: async (keyP, objP) => {
+      const [key, obj] = await Promise.all([keyP, objP]);
+      map.set(key, obj);
+      return key;
     },
   });
 }


### PR DESCRIPTION
The three commits are mostly independent and can be read separately.

- use `epoch` to help prevent accidental CapTP crosstalk with multiple `agoric deploy` closes #3289
- make sure the wallet backend deployment is idempotent (only one active wallet backend)
- increase our default HTTP timeout to help prevent EOF error refs Agoric/testnet-notes#30
