### PR TITLE
fix!: improve error message when a purse is overdrawn

### DIFF
--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -291,7 +291,22 @@ export const makePaymentLedger = (
    */
   const withdraw = (currentBalance, updatePurseBalance, amount) => {
     amount = coerce(amount);
-    const newPurseBalance = subtract(currentBalance, amount);
+    let newPurseBalance;
+    try {
+      newPurseBalance = subtract(currentBalance, amount);
+    } catch (err) {
+      if (err instanceof RangeError) {
+        const withdrawalError = Error(
+          // @ts-ignore `X` (aka `details`) lazily constructs a
+          // string, but the types do not reflect that
+          X`Withdrawal of ${amount} failed because the purse only contained ${currentBalance}`,
+        );
+        assert.note(withdrawalError, X`Caused by: ${err}`);
+        throw withdrawalError;
+      }
+      throw err;
+    }
+
     const payment = makePayment(allegedName, brand);
     try {
       // COMMIT POINT

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -291,21 +291,11 @@ export const makePaymentLedger = (
    */
   const withdraw = (currentBalance, updatePurseBalance, amount) => {
     amount = coerce(amount);
-    let newPurseBalance;
-    try {
-      newPurseBalance = subtract(currentBalance, amount);
-    } catch (err) {
-      if (err instanceof RangeError) {
-        const withdrawalError = Error(
-          // @ts-ignore `X` (aka `details`) lazily constructs a
-          // string, but the types do not reflect that
-          X`Withdrawal of ${amount} failed because the purse only contained ${currentBalance}`,
-        );
-        assert.note(withdrawalError, X`Caused by: ${err}`);
-        throw withdrawalError;
-      }
-      throw err;
-    }
+    assert(
+      AmountMath.isGTE(currentBalance, amount),
+      X`Withdrawal of ${amount} failed because the purse only contained ${currentBalance}`,
+    );
+    const newPurseBalance = subtract(currentBalance, amount);
 
     const payment = makePayment(allegedName, brand);
     try {

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -129,6 +129,22 @@ test('issuer.makeEmptyPurse', async t => {
     .then(checkWithdrawal);
 });
 
+test('purse.withdraw overdrawn', async t => {
+  t.plan(1);
+  const { issuer, mint, brand } = makeIssuerKit('fungible');
+  const purse = issuer.makeEmptyPurse();
+  const purseBalance = AmountMath.make(brand, 103980n);
+  const payment = mint.mintPayment(purseBalance);
+  purse.deposit(payment);
+
+  const tooMuch = AmountMath.make(brand, 103981n);
+
+  t.throws(() => purse.withdraw(tooMuch), {
+    message:
+      'Withdrawal of {"brand":"[Alleged: fungible brand]","value":"[103981n]"} failed because the purse only contained {"brand":"[Alleged: fungible brand]","value":"[103980n]"}',
+  });
+});
+
 test('purse.deposit', async t => {
   t.plan(7);
   const { issuer, mint, brand } = makeIssuerKit('fungible');


### PR DESCRIPTION
This PR adds a new error message for the case in which a purse is overdrawn (a `withdraw` fails because the amount to be withdrawn was greater than the amount in the purse). 

Without the PR, the error message is the raw error message from the Nat package. `-65000 is negative`. This is not a good error message.

Refs https://github.com/Agoric/agoric-sdk/issues/3780
(We will be making changes to how fees are charged that may improve this further, so I don't want to close it yet).