### PR TITLE
ci: repeat boilerplate to install node-canvas prerequisites

### DIFF
--- a/.github/workflow-templates/test-dapp.yml
+++ b/.github/workflow-templates/test-dapp.yml
@@ -52,6 +52,11 @@ jobs:
           console.log(branch);
           return branch;
 
+    - name: install node-canvas dependencies
+      run: |
+        set -e
+        sudo apt update -y
+        sudo apt install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
     - name: yarn install
       run: yarn install
     # 'yarn build' loops over all workspaces

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -47,6 +47,11 @@ jobs:
           console.log(branch);
           return branch;
 
+    - name: install node-canvas dependencies
+      run: |
+        set -e
+        sudo apt update -y
+        sudo apt install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
     # 'yarn install' must be done at the top level, to build all the
     # cross-package symlinks
     - run: yarn install

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -74,6 +74,12 @@ jobs:
       with:
         submodules: 'true'
       if: steps.built.outputs.cache-hit != 'true'
+    - name: install node-canvas dependencies
+      run: |
+        set -e
+        sudo apt update -y
+        sudo apt install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
+      if: steps.built.outputs.cache-hit != 'true'
     - name: yarn install
       run: yarn install
       if: steps.built.outputs.cache-hit != 'true'
@@ -107,6 +113,12 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
+      if: steps.built.outputs.cache-hit != 'true'
+    - name: install node-canvas dependencies
+      run: |
+        set -e
+        sudo apt update -y
+        sudo apt install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
       if: steps.built.outputs.cache-hit != 'true'
     - name: yarn install
       run: yarn install
@@ -147,6 +159,12 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
+      if: steps.built.outputs.cache-hit != 'true'
+    - name: install node-canvas dependencies
+      run: |
+        set -e
+        sudo apt update -y
+        sudo apt install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
       if: steps.built.outputs.cache-hit != 'true'
     - name: yarn install
       run: yarn install
@@ -202,6 +220,12 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
+      if: steps.built.outputs.cache-hit != 'true'
+    - name: install node-canvas dependencies
+      run: |
+        set -e
+        sudo apt update -y
+        sudo apt install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
       if: steps.built.outputs.cache-hit != 'true'
     - name: yarn install
       run: yarn install
@@ -328,6 +352,12 @@ jobs:
       with:
         submodules: 'true'
       if: steps.built.outputs.cache-hit != 'true'
+    - name: install node-canvas dependencies
+      run: |
+        set -e
+        sudo apt update -y
+        sudo apt install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
+      if: steps.built.outputs.cache-hit != 'true'
     - name: yarn install
       run: yarn install
       if: steps.built.outputs.cache-hit != 'true'
@@ -394,6 +424,12 @@ jobs:
       with:
         submodules: 'true'
       if: steps.built.outputs.cache-hit != 'true'
+    - name: install node-canvas dependencies
+      run: |
+        set -e
+        sudo apt update -y
+        sudo apt install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
+      if: steps.built.outputs.cache-hit != 'true'
     - name: yarn install
       run: yarn install
       if: steps.built.outputs.cache-hit != 'true'
@@ -431,6 +467,12 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
+      if: steps.built.outputs.cache-hit != 'true'
+    - name: install node-canvas dependencies
+      run: |
+        set -e
+        sudo apt update -y
+        sudo apt install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
       if: steps.built.outputs.cache-hit != 'true'
     - name: yarn install
       run: yarn install
@@ -479,6 +521,12 @@ jobs:
       with:
         submodules: 'true'
       if: steps.built.outputs.cache-hit != 'true'
+    - name: install node-canvas dependencies
+      run: |
+        set -e
+        sudo apt update -y
+        sudo apt install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
+      if: steps.built.outputs.cache-hit != 'true'
     - name: yarn install
       run: yarn install
       if: steps.built.outputs.cache-hit != 'true'
@@ -524,6 +572,12 @@ jobs:
       with:
         submodules: 'true'
       if: steps.built.outputs.cache-hit != 'true'
+    - name: install node-canvas dependencies
+      run: |
+        set -e
+        sudo apt update -y
+        sudo apt install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
+      if: steps.built.outputs.cache-hit != 'true'
     - name: yarn install
       run: yarn install
       if: steps.built.outputs.cache-hit != 'true'
@@ -560,6 +614,12 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
+      if: steps.built.outputs.cache-hit != 'true'
+    - name: install node-canvas dependencies
+      run: |
+        set -e
+        sudo apt update -y
+        sudo apt install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
       if: steps.built.outputs.cache-hit != 'true'
     - name: yarn install
       run: yarn install
@@ -599,6 +659,12 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
+      if: steps.built.outputs.cache-hit != 'true'
+    - name: install node-canvas dependencies
+      run: |
+        set -e
+        sudo apt update -y
+        sudo apt install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
       if: steps.built.outputs.cache-hit != 'true'
     - name: yarn install
       run: yarn install

--- a/.github/workflows/test-dapp-autoswap.yml
+++ b/.github/workflows/test-dapp-autoswap.yml
@@ -52,6 +52,11 @@ jobs:
           console.log(branch);
           return branch;
 
+    - name: install node-canvas dependencies
+      run: |
+        set -e
+        sudo apt update -y
+        sudo apt install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
     - name: yarn install
       run: yarn install
     # 'yarn build' loops over all workspaces

--- a/.github/workflows/test-dapp-card-store.yml
+++ b/.github/workflows/test-dapp-card-store.yml
@@ -52,6 +52,11 @@ jobs:
           console.log(branch);
           return branch;
 
+    - name: install node-canvas dependencies
+      run: |
+        set -e
+        sudo apt update -y
+        sudo apt install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
     - name: yarn install
       run: yarn install
     # 'yarn build' loops over all workspaces

--- a/.github/workflows/test-dapp-fungible-faucet.yml
+++ b/.github/workflows/test-dapp-fungible-faucet.yml
@@ -52,6 +52,11 @@ jobs:
           console.log(branch);
           return branch;
 
+    - name: install node-canvas dependencies
+      run: |
+        set -e
+        sudo apt update -y
+        sudo apt install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
     - name: yarn install
       run: yarn install
     # 'yarn build' loops over all workspaces

--- a/.github/workflows/test-dapp-oracle.yml
+++ b/.github/workflows/test-dapp-oracle.yml
@@ -52,6 +52,11 @@ jobs:
           console.log(branch);
           return branch;
 
+    - name: install node-canvas dependencies
+      run: |
+        set -e
+        sudo apt update -y
+        sudo apt install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
     - name: yarn install
       run: yarn install
     # 'yarn build' loops over all workspaces

--- a/.github/workflows/test-dapp-otc.yml
+++ b/.github/workflows/test-dapp-otc.yml
@@ -52,6 +52,11 @@ jobs:
           console.log(branch);
           return branch;
 
+    - name: install node-canvas dependencies
+      run: |
+        set -e
+        sudo apt update -y
+        sudo apt install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
     - name: yarn install
       run: yarn install
     # 'yarn build' loops over all workspaces

--- a/.github/workflows/test-dapp-pegasus.yml
+++ b/.github/workflows/test-dapp-pegasus.yml
@@ -52,6 +52,11 @@ jobs:
           console.log(branch);
           return branch;
 
+    - name: install node-canvas dependencies
+      run: |
+        set -e
+        sudo apt update -y
+        sudo apt install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
     - name: yarn install
       run: yarn install
     # 'yarn build' loops over all workspaces

--- a/.github/workflows/test-dapp-simple-exchange.yml
+++ b/.github/workflows/test-dapp-simple-exchange.yml
@@ -52,6 +52,11 @@ jobs:
           console.log(branch);
           return branch;
 
+    - name: install node-canvas dependencies
+      run: |
+        set -e
+        sudo apt update -y
+        sudo apt install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
     - name: yarn install
       run: yarn install
     # 'yarn build' loops over all workspaces

--- a/.github/workflows/test-dapp-treasury.yml
+++ b/.github/workflows/test-dapp-treasury.yml
@@ -52,6 +52,11 @@ jobs:
           console.log(branch);
           return branch;
 
+    - name: install node-canvas dependencies
+      run: |
+        set -e
+        sudo apt update -y
+        sudo apt install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
     - name: yarn install
       run: yarn install
     # 'yarn build' loops over all workspaces


### PR DESCRIPTION
We need this because prebuilt `node-canvas` binaries are not always available, and if our build cache fails to download, a `yarn install` will try to rebuild them.

Here is the symptom, when trying to run `test-all-packages / test-cosmic-swingset (16.x)`:

```
[5/5] Building fresh packages...
error /home/runner/work/agoric-sdk/agoric-sdk/node_modules/canvas: Command failed.
[...]
Package pangocairo was not found in the pkg-config search path.
Perhaps you should add the directory containing `pangocairo.pc'
to the PKG_CONFIG_PATH environment variable
No package 'pangocairo' found
gyp: Call to 'pkg-config pangocairo --libs' returned exit status 1 while in binding.gyp. while trying to load binding.gyp
[...]
node-pre-gyp ERR! not ok 
Failed to execute '/opt/hostedtoolcache/node/16.9.0/x64/bin/node /home/runner/work/agoric-sdk/agoric-sdk/node_modules/node-gyp/bin/node-gyp.js configure --fallback-to-build --module=/home/runner/work/agoric-sdk/agoric-sdk/node_modules/canvas/build/Release/canvas.node --module_name=canvas --module_path=/home/runner/work/agoric-sdk/agoric-sdk/node_modules/canvas/build/Release --napi_version=8 --node_abi_napi=napi --napi_build_version=0 --node_napi_label=node-v93' (1)
```
