### PR TITLE
Consolidate primitive vs object testing

### DIFF
--- a/packages/SwingSet/src/weakref.js
+++ b/packages/SwingSet/src/weakref.js
@@ -1,5 +1,6 @@
 /* global globalThis */
 import { assert, details as X } from '@agoric/assert';
+import { isObject } from '@agoric/marshal';
 
 const { defineProperties } = Object;
 
@@ -33,12 +34,7 @@ const FakeWeakRef = function WeakRef(target) {
     X`WeakRef Constructor requires 'new'`,
     TypeError,
   );
-  assert.equal(
-    Object(target),
-    target,
-    X`WeakRef target must be an object`,
-    TypeError,
-  );
+  assert(isObject(target), X`WeakRef target must be an object`, TypeError);
   weakRefTarget.set(this, target);
 };
 

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -31,7 +31,7 @@
     "@agoric/dapp-svelte-wallet": "^0.11.3",
     "@agoric/import-bundle": "^0.2.29",
     "@agoric/install-ses": "^0.5.26",
-    "@agoric/marshal": "^0.4.25",
+    "@agoric/marshal": "^0.4.26",
     "@agoric/store": "^0.6.4",
     "@agoric/swing-store": "^0.6.0",
     "@agoric/swingset-vat": "^0.22.0",

--- a/packages/cosmic-swingset/package.json
+++ b/packages/cosmic-swingset/package.json
@@ -31,6 +31,7 @@
     "@agoric/dapp-svelte-wallet": "^0.11.3",
     "@agoric/import-bundle": "^0.2.29",
     "@agoric/install-ses": "^0.5.26",
+    "@agoric/marshal": "^0.4.25",
     "@agoric/store": "^0.6.4",
     "@agoric/swing-store": "^0.6.0",
     "@agoric/swingset-vat": "^0.22.0",

--- a/packages/cosmic-swingset/src/block-manager.js
+++ b/packages/cosmic-swingset/src/block-manager.js
@@ -2,7 +2,7 @@
 import anylogger from 'anylogger';
 
 import { assert, details as X } from '@agoric/assert';
-import { isPrimitive } from '@agoric/marshal';
+import { isObject } from '@agoric/marshal';
 
 const console = anylogger('block-manager');
 
@@ -246,7 +246,7 @@ function deepEquals(a, b, already = new WeakSet()) {
   }
 
   // Must both be objects.
-  if (isPrimitive(a) || isPrimitive(b)) {
+  if (!isObject(a) || !isObject(b)) {
     return false;
   }
 

--- a/packages/cosmic-swingset/src/block-manager.js
+++ b/packages/cosmic-swingset/src/block-manager.js
@@ -2,6 +2,7 @@
 import anylogger from 'anylogger';
 
 import { assert, details as X } from '@agoric/assert';
+import { isPrimitive } from '@agoric/marshal';
 
 const console = anylogger('block-manager');
 
@@ -245,7 +246,7 @@ function deepEquals(a, b, already = new WeakSet()) {
   }
 
   // Must both be objects.
-  if (Object(a) !== a || Object(b) !== b) {
+  if (isPrimitive(a) || isPrimitive(b)) {
     return false;
   }
 

--- a/packages/deployment/package.json
+++ b/packages/deployment/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@agoric/assert": "^0.3.12",
     "@agoric/install-ses": "^0.5.26",
-    "@agoric/marshal": "^0.4.25",
+    "@agoric/marshal": "^0.4.26",
     "chalk": "^2.4.2",
     "deterministic-json": "^1.0.5",
     "inquirer": "^6.3.1",

--- a/packages/deployment/package.json
+++ b/packages/deployment/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@agoric/assert": "^0.3.12",
     "@agoric/install-ses": "^0.5.26",
+    "@agoric/marshal": "^0.4.25",
     "chalk": "^2.4.2",
     "deterministic-json": "^1.0.5",
     "inquirer": "^6.3.1",

--- a/packages/deployment/src/init.js
+++ b/packages/deployment/src/init.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import { assert, details as X } from '@agoric/assert';
+import { isObject } from '@agoric/marshal';
 import { PLAYBOOK_WRAPPER, SSH_TYPE } from './setup.js';
 import { shellEscape } from './run.js';
 
@@ -32,7 +33,7 @@ const tfStringify = obj => {
       sep = ',';
     }
     ret += ']';
-  } else if (Object(obj) === obj) {
+  } else if (isObject(obj)) {
     ret += '{';
     let sep = '';
     for (const key of Object.keys(obj).sort()) {

--- a/packages/marshal/index.js
+++ b/packages/marshal/index.js
@@ -1,8 +1,4 @@
-export {
-  PASS_STYLE,
-  isPrimitive,
-  isObject,
-} from './src/helpers/passStyleHelpers.js';
+export { PASS_STYLE, isObject } from './src/helpers/passStyleHelpers.js';
 export { getErrorConstructor } from './src/helpers/error.js';
 export {
   getInterfaceOf,

--- a/packages/marshal/index.js
+++ b/packages/marshal/index.js
@@ -1,4 +1,8 @@
-export { PASS_STYLE } from './src/helpers/passStyleHelpers.js';
+export {
+  PASS_STYLE,
+  isPrimitive,
+  isObject,
+} from './src/helpers/passStyleHelpers.js';
 export { getErrorConstructor } from './src/helpers/error.js';
 export {
   getInterfaceOf,

--- a/packages/marshal/src/helpers/passStyleHelpers.js
+++ b/packages/marshal/src/helpers/passStyleHelpers.js
@@ -24,9 +24,7 @@ export const hasOwnPropertyOf = (obj, prop) =>
   apply(objectHasOwnProperty, obj, [prop]);
 harden(hasOwnPropertyOf);
 
-export const isPrimitive = val => Object(val) !== val;
 export const isObject = val => Object(val) === val;
-harden(isPrimitive);
 harden(isObject);
 
 export const PASS_STYLE = Symbol.for('passStyle');

--- a/packages/marshal/src/helpers/passStyleHelpers.js
+++ b/packages/marshal/src/helpers/passStyleHelpers.js
@@ -25,7 +25,9 @@ export const hasOwnPropertyOf = (obj, prop) =>
 harden(hasOwnPropertyOf);
 
 export const isPrimitive = val => Object(val) !== val;
+export const isObject = val => Object(val) === val;
 harden(isPrimitive);
+harden(isObject);
 
 export const PASS_STYLE = Symbol.for('passStyle');
 

--- a/packages/marshal/src/helpers/remotable.js
+++ b/packages/marshal/src/helpers/remotable.js
@@ -18,6 +18,7 @@ import {
   hasOwnPropertyOf,
   PASS_STYLE,
   checkTagRecord,
+  isObject,
 } from './passStyleHelpers.js';
 import { getEnvironmentOption } from './environment-options.js';
 
@@ -202,7 +203,7 @@ export const RemotableHelper = harden({
     if (
       !(
         check(
-          typeof candidate === 'object' || typeof candidate === 'function',
+          isObject(candidate),
           X`cannot serialize non-objects like ${candidate}`,
         ) &&
         check(!isArray(candidate), X`Arrays cannot be pass-by-remote`) &&

--- a/packages/marshal/src/helpers/remotable.js
+++ b/packages/marshal/src/helpers/remotable.js
@@ -205,9 +205,7 @@ export const RemotableHelper = harden({
         check(
           isObject(candidate),
           X`cannot serialize non-objects like ${candidate}`,
-        ) &&
-        check(!isArray(candidate), X`Arrays cannot be pass-by-remote`) &&
-        check(candidate !== null, X`null cannot be pass-by-remote`)
+        ) && check(!isArray(candidate), X`Arrays cannot be pass-by-remote`)
       )
     ) {
       return false;

--- a/packages/marshal/src/marshal-justin.js
+++ b/packages/marshal/src/marshal-justin.js
@@ -9,6 +9,7 @@ import { QCLASS } from './marshal.js';
 
 import './types.js';
 import { getErrorConstructor } from './helpers/error.js';
+import { isPrimitive } from './helpers/passStyleHelpers.js';
 
 const { ownKeys } = Reflect;
 const { isArray } = Array;
@@ -131,7 +132,7 @@ const decodeToJustin = (encoding, shouldIndent = false) => {
    * @returns {void}
    */
   const prepare = rawTree => {
-    if (Object(rawTree) !== rawTree) {
+    if (isPrimitive(rawTree)) {
       return;
     }
     // Assertions of the above to narrow the type.
@@ -286,7 +287,7 @@ const decodeToJustin = (encoding, shouldIndent = false) => {
    * @returns {number}
    */
   const recur = rawTree => {
-    if (Object(rawTree) !== rawTree) {
+    if (isPrimitive(rawTree)) {
       // primitives get quoted
       return out.next(quote(rawTree));
     }

--- a/packages/marshal/src/marshal-justin.js
+++ b/packages/marshal/src/marshal-justin.js
@@ -9,7 +9,7 @@ import { QCLASS } from './marshal.js';
 
 import './types.js';
 import { getErrorConstructor } from './helpers/error.js';
-import { isPrimitive } from './helpers/passStyleHelpers.js';
+import { isObject } from './helpers/passStyleHelpers.js';
 
 const { ownKeys } = Reflect;
 const { isArray } = Array;
@@ -132,7 +132,7 @@ const decodeToJustin = (encoding, shouldIndent = false) => {
    * @returns {void}
    */
   const prepare = rawTree => {
-    if (isPrimitive(rawTree)) {
+    if (!isObject(rawTree)) {
       return;
     }
     // Assertions of the above to narrow the type.
@@ -287,7 +287,7 @@ const decodeToJustin = (encoding, shouldIndent = false) => {
    * @returns {number}
    */
   const recur = rawTree => {
-    if (isPrimitive(rawTree)) {
+    if (!isObject(rawTree)) {
       // primitives get quoted
       return out.next(quote(rawTree));
     }

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -403,7 +403,10 @@ export function makeMarshal(
 
           default: {
             assert(
-              // @ts-expect-error This value indeed violates the current types.
+              // @ts-ignore Should be at-ts-expect-error, but see
+              // https://github.com/Agoric/agoric-sdk/issues/3840
+              //
+              // This value indeed violates the current types.
               // We test for it to give a more informative diagnostic if we
               // receive it from a counterparty using an older version of the
               // protocol.

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -10,7 +10,7 @@ import { passStyleOf } from './passStyleOf.js';
 import './types.js';
 import { getInterfaceOf } from './helpers/remotable.js';
 import { ErrorHelper, getErrorConstructor } from './helpers/error.js';
-import { isPrimitive } from './helpers/passStyleHelpers.js';
+import { isObject } from './helpers/passStyleHelpers.js';
 
 const { ownKeys } = Reflect;
 const { isArray } = Array;
@@ -302,7 +302,7 @@ export function makeMarshal(
      * @param {Encoding} rawTree must be hardened
      */
     function fullRevive(rawTree) {
-      if (isPrimitive(rawTree)) {
+      if (!isObject(rawTree)) {
         // primitives pass through
         return rawTree;
       }
@@ -403,6 +403,10 @@ export function makeMarshal(
 
           default: {
             assert(
+              // @ts-ignore This value indeed violates the current types. We
+              // test for it to give a more informative diagnostic if we
+              // receive it from a counterparty using an older version of the
+              // protocol.
               qclass !== 'ibid',
               X`The protocol no longer supports ibid encoding: ${rawTree}.`,
             );

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -403,8 +403,8 @@ export function makeMarshal(
 
           default: {
             assert(
-              // @ts-ignore This value indeed violates the current types. We
-              // test for it to give a more informative diagnostic if we
+              // @ts-expect-error This value indeed violates the current types.
+              // We test for it to give a more informative diagnostic if we
               // receive it from a counterparty using an older version of the
               // protocol.
               qclass !== 'ibid',

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -10,6 +10,7 @@ import { passStyleOf } from './passStyleOf.js';
 import './types.js';
 import { getInterfaceOf } from './helpers/remotable.js';
 import { ErrorHelper, getErrorConstructor } from './helpers/error.js';
+import { isPrimitive } from './helpers/passStyleHelpers.js';
 
 const { ownKeys } = Reflect;
 const { isArray } = Array;
@@ -301,7 +302,7 @@ export function makeMarshal(
      * @param {Encoding} rawTree must be hardened
      */
     function fullRevive(rawTree) {
-      if (Object(rawTree) !== rawTree) {
+      if (isPrimitive(rawTree)) {
         // primitives pass through
         return rawTree;
       }

--- a/packages/marshal/src/passStyleOf.js
+++ b/packages/marshal/src/passStyleOf.js
@@ -4,7 +4,7 @@
 /// <reference types="ses"/>
 
 import { isPromise } from '@agoric/promise-kit';
-import { isPrimitive, PASS_STYLE } from './helpers/passStyleHelpers.js';
+import { isObject, PASS_STYLE } from './helpers/passStyleHelpers.js';
 
 import { CopyArrayHelper } from './helpers/copyArray.js';
 import { CopyRecordHelper } from './helpers/copyRecord.js';
@@ -84,8 +84,8 @@ const makePassStyleOfKit = passStyleHelper => {
      * @type {PassStyleOf}
      */
     const passStyleOfRecur = inner => {
-      const isObject = !isPrimitive(inner);
-      if (isObject) {
+      const innerIsObject = isObject(inner);
+      if (innerIsObject) {
         if (passStyleOfCache.has(inner)) {
           // @ts-ignore TypeScript doesn't know that `get` after `has` is safe
           return passStyleOfCache.get(inner);
@@ -98,7 +98,7 @@ const makePassStyleOfKit = passStyleHelper => {
       }
       // eslint-disable-next-line no-use-before-define
       const passStyle = passStyleOfInternal(inner);
-      if (isObject) {
+      if (innerIsObject) {
         passStyleOfCache.set(inner, passStyle);
         inProgress.delete(inner);
       }

--- a/packages/marshal/src/structure.js
+++ b/packages/marshal/src/structure.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { assert, details as X, q } from '@agoric/assert';
-import { isPrimitive } from './helpers/passStyleHelpers.js';
+import { isObject } from './helpers/passStyleHelpers.js';
 import { passStyleOf, everyPassableChild } from './passStyleOf.js';
 
 const { is, fromEntries, getOwnPropertyNames } = Object;
@@ -71,14 +71,14 @@ const structureCache = new WeakMap();
  * @returns {boolean}
  */
 export const isStructure = passable => {
-  const isObject = !isPrimitive(passable);
-  if (isObject) {
+  const passableIsObject = isObject(passable);
+  if (passableIsObject) {
     if (structureCache.has(passable)) {
       return structureCache.get(passable);
     }
   }
   const result = isStructureInternal(passable);
-  if (isObject) {
+  if (passableIsObject) {
     structureCache.set(passable, result);
   }
   return result;

--- a/packages/vats/src/repl.js
+++ b/packages/vats/src/repl.js
@@ -1,6 +1,6 @@
 import { isPromise } from '@agoric/promise-kit';
 import { E } from '@agoric/eventual-send';
-import { getInterfaceOf, Remotable, Far } from '@agoric/marshal';
+import { getInterfaceOf, Remotable, Far, isPrimitive } from '@agoric/marshal';
 
 import { Nat } from '@agoric/nat';
 import makeUIAgentMakers from './ui-agent.js';
@@ -19,7 +19,7 @@ export const dump = (value, spaces = '') =>
   dump0(value, spaces, new WeakSet(), 0);
 
 function dump0(value, spaces, inProgress, depth) {
-  if (Object(value) !== value) {
+  if (isPrimitive(value)) {
     if (typeof value === 'bigint') {
       return `${value}n`;
     }

--- a/packages/vats/src/repl.js
+++ b/packages/vats/src/repl.js
@@ -1,6 +1,6 @@
 import { isPromise } from '@agoric/promise-kit';
 import { E } from '@agoric/eventual-send';
-import { getInterfaceOf, Remotable, Far, isPrimitive } from '@agoric/marshal';
+import { getInterfaceOf, Remotable, Far, isObject } from '@agoric/marshal';
 
 import { Nat } from '@agoric/nat';
 import makeUIAgentMakers from './ui-agent.js';
@@ -19,7 +19,7 @@ export const dump = (value, spaces = '') =>
   dump0(value, spaces, new WeakSet(), 0);
 
 function dump0(value, spaces, inProgress, depth) {
-  if (isPrimitive(value)) {
+  if (!isObject(value)) {
     if (typeof value === 'bigint') {
       return `${value}n`;
     }

--- a/packages/zoe/test/swingsetTests/refillMeter/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/refillMeter/bootstrap.js
@@ -86,7 +86,7 @@ export function buildRootObject(vatPowers) {
       await E(publicFacet).smallComputation();
 
       const postSmallComputation2 = await E(feePurse).getCurrentAmount();
-      // No refill
+      expected -= meteringConfig.incrementBy;
 
       log(
         'post-smallComputation2 equals expected: ',
@@ -97,7 +97,7 @@ export function buildRootObject(vatPowers) {
       await E(publicFacet).smallComputation();
 
       const postSmallComputation3 = await E(feePurse).getCurrentAmount();
-      expected -= meteringConfig.incrementBy;
+      // no refill
 
       log(
         'post-smallComputation3 equals expected: ',

--- a/packages/zoe/test/swingsetTests/refillMeter/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/refillMeter/bootstrap.js
@@ -86,7 +86,7 @@ export function buildRootObject(vatPowers) {
       await E(publicFacet).smallComputation();
 
       const postSmallComputation2 = await E(feePurse).getCurrentAmount();
-      expected -= meteringConfig.incrementBy;
+      // No refill
 
       log(
         'post-smallComputation2 equals expected: ',
@@ -97,7 +97,7 @@ export function buildRootObject(vatPowers) {
       await E(publicFacet).smallComputation();
 
       const postSmallComputation3 = await E(feePurse).getCurrentAmount();
-      // no refill
+      expected -= meteringConfig.incrementBy;
 
       log(
         'post-smallComputation3 equals expected: ',

--- a/packages/zoe/test/swingsetTests/refillMeter/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/refillMeter/bootstrap.js
@@ -86,7 +86,7 @@ export function buildRootObject(vatPowers) {
       await E(publicFacet).smallComputation();
 
       const postSmallComputation2 = await E(feePurse).getCurrentAmount();
-      // No refill
+      expected -= meteringConfig.incrementBy;
 
       log(
         'post-smallComputation2 equals expected: ',
@@ -97,7 +97,7 @@ export function buildRootObject(vatPowers) {
       await E(publicFacet).smallComputation();
 
       const postSmallComputation3 = await E(feePurse).getCurrentAmount();
-      expected -= meteringConfig.incrementBy;
+      // No refill
 
       log(
         'post-smallComputation3 equals expected: ',


### PR DESCRIPTION
agoric-sdk had only `isPrimitive`. endo had only `isObject`.Now both use only `isObject`. Consolidate ad hoc primitive testing by other means to use only `isObject` instead.

See https://github.com/endojs/endo/pull/888

See https://gist.github.com/nicolo-ribaudo/2f9c50e73b434601063a49d2e50be674#gistcomment-3891584