### PR TITLE
feat(solo): make client objects appear earlier, parallelise chain

### DIFF
--- a/packages/agoric-cli/lib/main.js
+++ b/packages/agoric-cli/lib/main.js
@@ -177,7 +177,7 @@ const main = async (progname, rawArgs, powers) => {
     .option(
       '--need <subsystems>',
       'comma-separated names of subsystems to wait for',
-      'agoric,wallet',
+      'local,agoric,wallet',
     )
     .option(
       '--provide <subsystems>',

--- a/packages/solo/src/start.js
+++ b/packages/solo/src/start.js
@@ -323,6 +323,10 @@ export default async function start(basedir, argv) {
     resetOutdatedState,
   } = d;
 
+  // Start timer here!
+  startTimer(800);
+  resetOutdatedState();
+
   // Remove wallet traces.
   await unlink('html/wallet').catch(_ => {});
 
@@ -390,10 +394,6 @@ export default async function start(basedir, argv) {
       }
     }),
   );
-
-  // Start timer here!
-  startTimer(1200);
-  resetOutdatedState();
 
   log.info(`swingset running`);
   swingSetRunning = true;

--- a/packages/solo/src/vat-http.js
+++ b/packages/solo/src/vat-http.js
@@ -105,15 +105,15 @@ export function buildRootObject(vatPowers) {
     },
 
     setPresences(
-      privateObjects,
+      privateObjects = undefined,
       decentralObjects = undefined,
-      handyObjects = undefined,
+      deprecatedObjects = undefined,
     ) {
       exportedToCapTP = {
         ...exportedToCapTP,
         ...decentralObjects, // TODO: Remove; replaced by .agoric
         ...privateObjects, // TODO: Remove; replaced by .local
-        ...handyObjects,
+        ...deprecatedObjects,
         agoric: { ...decentralObjects },
         local: { ...privateObjects },
       };
@@ -129,15 +129,13 @@ export function buildRootObject(vatPowers) {
         doneLoading(['agoric']);
       }
 
-      // TODO: Remove; home object is deprecated.
-      if (decentralObjects) {
-        Object.assign(
-          replObjects.home,
-          decentralObjects,
-          privateObjects,
-          handyObjects,
-        );
-      }
+      // TODO: Maybe remove sometime; home object is deprecated.
+      Object.assign(
+        replObjects.home,
+        decentralObjects,
+        privateObjects,
+        deprecatedObjects,
+      );
     },
 
     // devices.command invokes our inbound() because we passed to

--- a/packages/vats/src/vat-provisioning.js
+++ b/packages/vats/src/vat-provisioning.js
@@ -18,7 +18,7 @@ export function buildRootObject(_vatPowers) {
   async function pleaseProvision(nickname, address, powerFlags) {
     let chainBundle;
     const fetch = Far('fetch', {
-      getDemoBundle() {
+      getChainBundle() {
         return chainBundle;
       },
     });


### PR DESCRIPTION
This PR makes it possible to work with the REPL and local objects as soon as SwingSet boots, regardless of the external connections (such as `agoric` and `sim-chain`).
