### PR TITLE
feat(wallet-backend): attach timestamp and sequence metadata

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -44,8 +44,8 @@ REFERENCES TO YOUR TAGS.
 To make validators' lives easier, create a tag for the chain-id:
 
 ```sh
-SDK_VERSION=$(jq -r .version package.json)
 CHAIN_ID=agoricstage-8 # Change this as necessary
+SDK_VERSION=$(jq -r .version package.json)
 git tag -s -m "release $CHAIN_ID" $CHAIN_ID @agoric/sdk@$SDK_VERSION^{}
 git push origin $CHAIN_ID
 ```

--- a/packages/dapp-svelte-wallet/api/deploy.js
+++ b/packages/dapp-svelte-wallet/api/deploy.js
@@ -25,7 +25,7 @@ export default async function deployWallet(
       faucet,
       zoe,
     },
-    local: { http, spawner, wallet: oldWallet, scratch },
+    local: { http, localTimerService, spawner, wallet: oldWallet, scratch },
   } = home;
 
   let walletVat = await E(scratch).get('dapp-svelte-wallet/api');
@@ -43,6 +43,7 @@ export default async function deployWallet(
       myAddressNameAdmin,
       zoe,
       board,
+      localTimerService,
     });
   }
 

--- a/packages/dapp-svelte-wallet/api/src/internal-types.js
+++ b/packages/dapp-svelte-wallet/api/src/internal-types.js
@@ -65,14 +65,15 @@
 
 /**
  * @typedef {Object} PaymentRecord
- * @property {Issuer=} issuer
+ * @property {RecordMetadata} meta
+ * @property {Issuer} [issuer]
  * @property {Payment} payment
  * @property {Brand} brand
- * @property {'pending'|'deposited'|undefined} status
+ * @property {'pending'|'deposited'} [status]
  * @property {PaymentActions} actions
- * @property {Amount=} lastAmount
- * @property {Amount=} depositedAmount
- * @property {string=} issuerBoardId
+ * @property {Amount} [lastAmount]
+ * @property {Amount} [depositedAmount]
+ * @property {string} [issuerBoardId]
  *
  * @typedef {Object} PaymentActions
  * @property {(purseOrPetname?: (Purse | Petname)) => Promise<Value>} deposit

--- a/packages/dapp-svelte-wallet/api/src/issuerTable.js
+++ b/packages/dapp-svelte-wallet/api/src/issuerTable.js
@@ -34,7 +34,7 @@ const makeIssuerTable = () => {
     getByIssuer: issuerToIssuerRecord.get,
     // `issuerP` may be a promise, presence, or local object. If there's
     // already a record, return it. Otherwise, save the record.
-    initIssuer: async (issuerP, now = undefined) => {
+    initIssuer: async (issuerP, addMeta = x => x) => {
       const brandP = E(issuerP).getBrand();
       const brandIssuerMatchP = E(brandP).isMyIssuer(issuerP);
       const displayInfoP = E(brandP).getDisplayInfo();
@@ -54,13 +54,14 @@ const makeIssuerTable = () => {
         brandIssuerMatch,
         `issuer was using a brand which was not its own`,
       );
-      issuerTable.initIssuerByRecord({
-        creationStamp: now,
-        brand,
-        issuer,
-        assetKind: displayInfo.assetKind,
-        displayInfo,
-      });
+      issuerTable.initIssuerByRecord(
+        addMeta({
+          brand,
+          issuer,
+          assetKind: displayInfo.assetKind,
+          displayInfo,
+        }),
+      );
       return issuerTable.getByBrand(brand);
     },
     initIssuerByRecord: issuerRecord => {

--- a/packages/dapp-svelte-wallet/api/src/issuerTable.js
+++ b/packages/dapp-svelte-wallet/api/src/issuerTable.js
@@ -34,7 +34,7 @@ const makeIssuerTable = () => {
     getByIssuer: issuerToIssuerRecord.get,
     // `issuerP` may be a promise, presence, or local object. If there's
     // already a record, return it. Otherwise, save the record.
-    initIssuer: async issuerP => {
+    initIssuer: async (issuerP, now = undefined) => {
       const brandP = E(issuerP).getBrand();
       const brandIssuerMatchP = E(brandP).isMyIssuer(issuerP);
       const displayInfoP = E(brandP).getDisplayInfo();
@@ -55,6 +55,7 @@ const makeIssuerTable = () => {
         `issuer was using a brand which was not its own`,
       );
       issuerTable.initIssuerByRecord({
+        creationStamp: now,
         brand,
         issuer,
         assetKind: displayInfo.assetKind,

--- a/packages/dapp-svelte-wallet/api/src/lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-wallet.js
@@ -662,7 +662,7 @@ export function makeWallet({
     const issuer = await issuerP;
     const recP = brandTable.hasByIssuer(issuer)
       ? brandTable.getByIssuer(issuer)
-      : brandTable.initIssuer(issuer, nowMs);
+      : brandTable.initIssuer(issuer, addMeta);
     const { brand } = await recP;
     await initIssuerToBoardId(issuer);
     const addBrandPetname = () => {

--- a/packages/dapp-svelte-wallet/api/src/lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-wallet.js
@@ -57,6 +57,7 @@ const cmp = (a, b) => {
  * @property {MyAddressNameAdmin} myAddressNameAdmin
  * @property {(state: any) => void} [pursesStateChangeHandler=noActionStateChangeHandler]
  * @property {(state: any) => void} [inboxStateChangeHandler=noActionStateChangeHandler]
+ * @property {ERef<TimerService>} [localTimerService]
  * @param {MakeWalletParams} param0
  */
 export function makeWallet({
@@ -67,7 +68,43 @@ export function makeWallet({
   myAddressNameAdmin,
   pursesStateChangeHandler = noActionStateChangeHandler,
   inboxStateChangeHandler = noActionStateChangeHandler,
+  localTimerService,
 }) {
+  /**
+   * The current timestamp, in milliseconds (if it is known).
+   *
+   * @type {number | undefined}
+   */
+  let nowMs;
+
+  // Subscribe to the timer service to update our stamp.
+  assert(localTimerService, 'localTimerService is required');
+  if (localTimerService) {
+    observeNotifier(E(localTimerService).makeNotifier(0n, 1000n), {
+      updateState(bigStamp) {
+        // We need to convert the bigint to a number (for easy Javascript date math).
+        nowMs = parseInt(`${bigStamp}`, 10);
+      },
+    });
+  }
+
+  let lastSequence = 0;
+  const addMeta = record => {
+    const { meta: oldMeta = {} } = record;
+    let { sequence, creationStamp } = oldMeta;
+    if (!sequence) {
+      // Add a sequence number to the record.
+      lastSequence += 1;
+      sequence = lastSequence;
+    }
+    if (!creationStamp) {
+      // Set the creationStamp to be right now.
+      creationStamp = nowMs;
+    }
+    const meta = { ...oldMeta, sequence, creationStamp, updatedStamp: nowMs };
+    return { ...record, meta };
+  };
+
   // Create the petname maps so we can dehydrate information sent to
   // the frontend.
   const { makeMapping, dehydrate, edgeMapping } = makeDehydrator();
@@ -484,10 +521,10 @@ export function makeWallet({
       idToSeat.delete(id);
 
       const offer = idToOffer.get(id);
-      const completedOffer = {
+      const completedOffer = addMeta({
         ...offer,
         status: 'complete',
-      };
+      });
       idToOffer.set(id, completedOffer);
       updateInboxState(id, completedOffer);
       idToNotifierP.delete(id);
@@ -625,7 +662,7 @@ export function makeWallet({
     const issuer = await issuerP;
     const recP = brandTable.hasByIssuer(issuer)
       ? brandTable.getByIssuer(issuer)
-      : brandTable.initIssuer(issuer);
+      : brandTable.initIssuer(issuer, nowMs);
     const { brand } = await recP;
     await initIssuerToBoardId(issuer);
     const addBrandPetname = () => {
@@ -660,6 +697,11 @@ export function makeWallet({
     [],
   ));
 
+  /**
+   * @param {Petname} petname
+   * @param {ERef<{receive: (payment: Payment) => Promise<void>}>} actions
+   * @param {string} [address]
+   */
   const addContact = async (petname, actions, address = undefined) => {
     const already = await E(board).has(actions);
     let depositFacet;
@@ -684,11 +726,13 @@ export function makeWallet({
       )}`,
     );
 
-    const contact = harden({
-      actions,
-      address,
-      depositBoardId,
-    });
+    const contact = harden(
+      addMeta({
+        actions,
+        address,
+        depositBoardId,
+      }),
+    );
 
     contactMapping.suggestPetname(petname, contact);
     contactsUpdater.updateState([...contactMapping.petnameToVal.entries()]);
@@ -874,7 +918,7 @@ export function makeWallet({
   } = /** @type {NotifierRecord<DappRecord[]>} */ (makeNotifierKit([]));
 
   function updateDapp(dappRecord) {
-    harden(dappRecord);
+    harden(addMeta(dappRecord));
     dappOrigins.set(dappRecord.origin, dappRecord);
     dappsUpdater.updateState([...dappOrigins.values()]);
   }
@@ -892,7 +936,7 @@ export function makeWallet({
       let reject;
       let approvalP;
 
-      dappRecord = {
+      dappRecord = addMeta({
         suggestedPetname,
         petname: suggestedPetname,
         origin,
@@ -908,20 +952,20 @@ export function makeWallet({
             } else {
               petname = edgeMapping.suggestPetname(petname, origin);
             }
-            dappRecord = {
+            dappRecord = addMeta({
               ...dappRecord,
               petname,
-            };
+            });
             updateDapp(dappRecord);
             updateAllState();
             return dappRecord.actions;
           },
           enable() {
             // Enable the dapp with the attached petname.
-            dappRecord = {
+            dappRecord = addMeta({
               ...dappRecord,
               enable: true,
-            };
+            });
             edgeMapping.suggestPetname(dappRecord.petname, origin);
             updateDapp(dappRecord);
 
@@ -936,16 +980,16 @@ export function makeWallet({
             }
             // Create a new, suspended-approval record.
             ({ resolve, reject, promise: approvalP } = makePromiseKit());
-            dappRecord = {
+            dappRecord = addMeta({
               ...dappRecord,
               enable: false,
               approvalP,
-            };
+            });
             updateDapp(dappRecord);
             return dappRecord.actions;
           },
         }),
-      };
+      });
 
       // Prepare the table entry to be updated.
       dappOrigins.init(origin, dappRecord);
@@ -968,13 +1012,15 @@ export function makeWallet({
       requestContext.dappOrigin || requestContext.origin || 'unknown';
     const { id: rawId } = rawOffer;
     const id = makeId(dappOrigin, rawId);
-    const offer = harden({
-      ...rawOffer,
-      rawId,
-      id,
-      requestContext: { ...requestContext, dappOrigin },
-      status: undefined,
-    });
+    const offer = harden(
+      addMeta({
+        ...rawOffer,
+        rawId,
+        id,
+        requestContext: { ...requestContext, dappOrigin },
+        status: undefined,
+      }),
+    );
     idToOffer.init(id, offer);
     idToOfferResultPromiseKit.init(id, makePromiseKit());
     await updateInboxState(id, offer);
@@ -992,12 +1038,14 @@ export function makeWallet({
     }
     idToOffer.set(
       id,
-      harden({
-        ...idToOffer.get(id),
-        installation,
-        instance,
-        invitationDetails,
-      }),
+      harden(
+        addMeta({
+          ...idToOffer.get(id),
+          installation,
+          instance,
+          invitationDetails,
+        }),
+      ),
     );
     await updateInboxState(id, idToOffer.get(id));
     return rawId;
@@ -1019,10 +1067,10 @@ export function makeWallet({
       return;
     }
     // Update status, drop the proposal
-    const declinedOffer = {
+    const declinedOffer = addMeta({
       ...offer,
       status: 'decline',
-    };
+    });
     idToOffer.set(id, declinedOffer);
     updateInboxState(id, declinedOffer);
   }
@@ -1037,10 +1085,10 @@ export function makeWallet({
       .then(_ => {
         idToComplete.delete(id);
         const offer = idToOffer.get(id);
-        const cancelledOffer = {
+        const cancelledOffer = addMeta({
           ...offer,
           status: 'cancel',
-        };
+        });
         idToOffer.set(id, cancelledOffer);
         updateInboxState(id, cancelledOffer);
       })
@@ -1062,20 +1110,20 @@ export function makeWallet({
       if (alreadyResolved) {
         return;
       }
-      const rejectOffer = {
+      const rejectOffer = addMeta({
         ...offer,
         status: 'rejected',
         error: `${e}`,
-      };
+      });
       idToOffer.set(id, rejectOffer);
       updateInboxState(id, rejectOffer);
     };
 
     try {
-      const pendingOffer = {
+      const pendingOffer = addMeta({
         ...offer,
         status: 'pending',
-      };
+      });
       idToOffer.set(id, pendingOffer);
       updateInboxState(id, pendingOffer);
       const compiledOffer = await idToCompiledOfferP.get(id);
@@ -1111,10 +1159,10 @@ export function makeWallet({
           // We got something back, so no longer pending or rejected.
           if (!alreadyResolved) {
             alreadyResolved = true;
-            const acceptedOffer = {
+            const acceptedOffer = addMeta({
               ...pendingOffer,
               status: 'accept',
-            };
+            });
             idToOffer.set(id, acceptedOffer);
             updateInboxState(id, acceptedOffer);
           }
@@ -1141,7 +1189,11 @@ export function makeWallet({
    */
   const updatePaymentRecord = ({ actions, ...preDisplay }) => {
     const displayPayment = fillInSlots(dehydrate(harden(preDisplay)));
-    const paymentRecord = { ...preDisplay, actions, displayPayment };
+    const paymentRecord = addMeta({
+      ...preDisplay,
+      actions,
+      displayPayment,
+    });
     payments.set(paymentRecord.payment, harden(paymentRecord));
     paymentsUpdater.updateState([...payments.values()]);
   };
@@ -1152,23 +1204,14 @@ export function makeWallet({
    */
   const addPayment = async (paymentP, depositTo = undefined) => {
     // We don't even create the record until we resolve the payment.
-    const payment = await paymentP;
-    const brand = await E(payment).getAllegedBrand();
+    const [payment, brand] = await Promise.all([
+      paymentP,
+      E(paymentP).getAllegedBrand(),
+    ]);
     const depositedPK = makePromiseKit();
 
-    /** @type {ERef<boolean>} */
-    let isAliveP = true;
-    if (brandTable.hasByBrand(brand)) {
-      isAliveP = E(brandTable.getByBrand(brand).issuer).isLive(payment);
-    }
-    const isAlive = await isAliveP;
-    if (!isAlive) {
-      // Nothing to do.
-      return;
-    }
-
     /** @type {PaymentRecord} */
-    let paymentRecord = {
+    let paymentRecord = addMeta({
       payment,
       brand,
       issuer: undefined,
@@ -1195,9 +1238,11 @@ export function makeWallet({
           const brandRecord =
             brandTable.hasByBrand(brand) && brandTable.getByBrand(brand);
           paymentRecord = {
-            ...paymentRecord,
             ...brandRecord,
-            status: 'pending',
+            ...addMeta({
+              ...paymentRecord,
+              status: 'pending',
+            }),
           };
           updatePaymentRecord(paymentRecord);
           // Now try depositing.
@@ -1206,10 +1251,12 @@ export function makeWallet({
             .then(
               depositedAmount => {
                 paymentRecord = {
-                  ...paymentRecord,
-                  status: 'deposited',
-                  depositedAmount,
                   ...brandRecord,
+                  ...addMeta({
+                    ...paymentRecord,
+                    status: 'deposited',
+                    depositedAmount,
+                  }),
                 };
                 updatePaymentRecord(paymentRecord);
                 depositedPK.resolve(depositedAmount);
@@ -1223,10 +1270,10 @@ export function makeWallet({
                 if (purseOrPetname === undefined) {
                   // Error in auto-deposit purse, just fail.  They can try
                   // again.
-                  paymentRecord = {
+                  paymentRecord = addMeta({
                     ...paymentRecord,
                     status: undefined,
-                  };
+                  });
                   depositedPK.reject(e);
                 } else {
                   // Error in designated deposit, so retry automatically without
@@ -1246,9 +1293,11 @@ export function makeWallet({
           if (!issuer) {
             const brandRecord = brandTable.getByBrand(brand);
             paymentRecord = {
-              ...paymentRecord,
               ...brandRecord,
-              issuerBoardId: issuerToBoardId.get(brandRecord.issuer),
+              ...addMeta({
+                ...paymentRecord,
+                issuerBoardId: issuerToBoardId.get(brandRecord.issuer),
+              }),
             };
             updatePaymentRecord(paymentRecord);
           }
@@ -1262,17 +1311,16 @@ export function makeWallet({
           // Fetch the current amount of the payment.
           const lastAmount = await E(issuer).getAmountOf(payment);
 
-          paymentRecord = {
+          paymentRecord = addMeta({
             ...paymentRecord,
             lastAmount,
-          };
+          });
           updatePaymentRecord(paymentRecord);
           return true;
         },
       }),
-    };
+    });
 
-    payments.init(payment, harden(paymentRecord));
     const refreshed = await paymentRecord.actions.refresh();
     if (!refreshed) {
       // Only update if the refresh didn't.
@@ -1360,6 +1408,11 @@ export function makeWallet({
       .then(value => acceptFn(petname, value));
   }
 
+  /**
+   * @param {Petname} suggestedPetname
+   * @param {string} issuerBoardId
+   * @param {string} [dappOrigin]
+   */
   async function suggestIssuer(
     suggestedPetname,
     issuerBoardId,
@@ -1377,6 +1430,11 @@ export function makeWallet({
     );
   }
 
+  /**
+   * @param {Petname} suggestedPetname
+   * @param {string} instanceHandleBoardId
+   * @param {string} [dappOrigin]
+   */
   async function suggestInstance(
     suggestedPetname,
     instanceHandleBoardId,
@@ -1394,6 +1452,11 @@ export function makeWallet({
     );
   }
 
+  /**
+   * @param {Petname} suggestedPetname
+   * @param {string} installationHandleBoardId
+   * @param {string} [dappOrigin]
+   */
   async function suggestInstallation(
     suggestedPetname,
     installationHandleBoardId,
@@ -1563,11 +1626,6 @@ export function makeWallet({
     getPurse,
     getPurseIssuer,
     addOffer,
-    async addOfferInvitation(_offer, _invitation, _dappOrigin = undefined) {
-      // Will be part of the Rendezvous system, when landed.
-      // TODO unimplemented
-      assert.fail(X`Adding an invitation to an offer is unimplemented`);
-    },
     declineOffer,
     cancelOffer,
     acceptOffer,

--- a/packages/dapp-svelte-wallet/api/src/types.js
+++ b/packages/dapp-svelte-wallet/api/src/types.js
@@ -132,6 +132,6 @@
  * @property {(brand: Brand) => IssuerRecord} getByBrand
  * @property {(issuer: Issuer) => boolean} hasByIssuer
  * @property {(issuer: Issuer) => IssuerRecord} getByIssuer
- * @property {(issuerP: ERef<Issuer>, timestamp?: number) => Promise<IssuerRecord>} initIssuer
+ * @property {(issuerP: ERef<Issuer>, addMeta = x => x) => Promise<IssuerRecord>} initIssuer
  * @property {(issuerRecord: IssuerRecord) => void } initIssuerByRecord
  */

--- a/packages/dapp-svelte-wallet/api/src/types.js
+++ b/packages/dapp-svelte-wallet/api/src/types.js
@@ -86,6 +86,18 @@
  */
 
 /**
+ * @typedef {Object} RecordMetadata
+ * @property {number} sequence a monotonically increasing number to allow
+ * total ordering between records.
+ * @property {number} [creationStamp] the approximate time at which the record
+ * was created in milliseconds since the epoch; `undefined` if there is no
+ * timer source
+ * @property {number} [updatedStamp] the approximate time at which the record
+ * was last updated in milliseconds since the epoch; `undefined` if there is
+ * no timer source
+ */
+
+/**
  * @typedef {Object} PursesJSONState
  * @property {Brand} brand
  * @property {string} brandBoardId  the board ID for this purse's brand

--- a/packages/dapp-svelte-wallet/api/src/types.js
+++ b/packages/dapp-svelte-wallet/api/src/types.js
@@ -51,8 +51,6 @@
  * wallet.
  *
  * @property {(offer: OfferState) => Promise<string>} addOffer
- * @property {(offer: OfferState, invitation: ERef<Payment>) => Promise<string>}
- * addOfferInvitation add an invitation to the specified offer
  * @property {(brandBoardId: string) => Promise<string>} getDepositFacetId
  * return the board ID to use to receive payments of the specified brand.
  * @property {() => Promise<Notifier<Array<PursesJSONState>>>} getPursesNotifier
@@ -134,6 +132,6 @@
  * @property {(brand: Brand) => IssuerRecord} getByBrand
  * @property {(issuer: Issuer) => boolean} hasByIssuer
  * @property {(issuer: Issuer) => IssuerRecord} getByIssuer
- * @property {(issuerP: ERef<Issuer>) => Promise<IssuerRecord>} initIssuer
+ * @property {(issuerP: ERef<Issuer>, timestamp?: number) => Promise<IssuerRecord>} initIssuer
  * @property {(issuerRecord: IssuerRecord) => void } initIssuerByRecord
  */

--- a/packages/dapp-svelte-wallet/api/src/types.js
+++ b/packages/dapp-svelte-wallet/api/src/types.js
@@ -132,6 +132,6 @@
  * @property {(brand: Brand) => IssuerRecord} getByBrand
  * @property {(issuer: Issuer) => boolean} hasByIssuer
  * @property {(issuer: Issuer) => IssuerRecord} getByIssuer
- * @property {(issuerP: ERef<Issuer>, addMeta = x => x) => Promise<IssuerRecord>} initIssuer
+ * @property {(issuerP: ERef<Issuer>, addMeta?: (x: any) => any) => Promise<IssuerRecord>} initIssuer
  * @property {(issuerRecord: IssuerRecord) => void } initIssuerByRecord
  */

--- a/packages/dapp-svelte-wallet/api/src/wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/wallet.js
@@ -84,6 +84,7 @@ export function buildRootObject(_vatPowers) {
     agoricNames,
     namesByAddress,
     myAddressNameAdmin,
+    localTimerService,
   }) {
     const w = makeWallet({
       agoricNames,
@@ -93,6 +94,7 @@ export function buildRootObject(_vatPowers) {
       board,
       pursesStateChangeHandler: pursesPublish,
       inboxStateChangeHandler: inboxPublish,
+      localTimerService,
     });
     console.error('waiting for wallet to initialize');
     await w.initialized;
@@ -137,10 +139,6 @@ export function buildRootObject(_vatPowers) {
       async addOffer(offer) {
         await approve();
         return walletAdmin.addOffer(offer, { ...meta, dappOrigin });
-      },
-      async addOfferInvitation(offer, invitation) {
-        await approve();
-        return walletAdmin.addOfferInvitation(offer, invitation, dappOrigin);
       },
       async getOffersNotifier(status = null) {
         await approve();
@@ -223,9 +221,6 @@ export function buildRootObject(_vatPowers) {
   const preapprovedBridge = Far('preapprovedBridge', {
     addOffer(offer) {
       return walletAdmin.addOffer(offer);
-    },
-    addOfferInvitation(offer, invitation) {
-      return walletAdmin.addOfferInvitation(offer, invitation);
     },
     getDepositFacetId(brandBoardId) {
       return walletAdmin.getDepositFacetId(brandBoardId);

--- a/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
@@ -7,6 +7,7 @@ import { makeIssuerKit, AmountMath, AssetKind } from '@agoric/ertp';
 
 import { makeZoeKit } from '@agoric/zoe';
 import fakeVatAdmin from '@agoric/zoe/tools/fakeVatAdmin.js';
+import makeManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import { E } from '@agoric/eventual-send';
 
 import { assert } from '@agoric/assert';
@@ -1390,4 +1391,77 @@ test('getZoe, getBoard', async t => {
 
   t.is(await E(wallet).getZoe(), await zoe);
   t.is(await E(wallet).getBoard(), board);
+});
+
+test('stamps from localTimerService', async t => {
+  const { zoeService } = makeZoeKit(fakeVatAdmin);
+  const feePurse = E(zoeService).makeFeePurse();
+  const zoe = E(zoeService).bindDefaultFeePurse(feePurse);
+  const board = makeBoard();
+  const manualTimer = makeManualTimer(t.log, 19199000n, 1000n);
+
+  const { admin: wallet, initialized } = makeWallet({
+    zoe,
+    board,
+    myAddressNameAdmin: makeFakeMyAddressNameAdmin(),
+    localTimerService: manualTimer,
+  });
+  await initialized;
+
+  const {
+    issuer: simoleanIssuer,
+    mint: simoleanMint,
+    brand: simoleanBrand,
+  } = makeIssuerKit('simolean');
+
+  await E(wallet).addIssuer('simolean', simoleanIssuer);
+  await E(wallet).makeEmptyPurse('simolean', 'Tester', true);
+
+  const [pmt1, pmt2, pmt3] = await Promise.all(
+    [30n, 50n, 71n].map(async n =>
+      E(simoleanMint).mintPayment(AmountMath.make(simoleanBrand, n)),
+    ),
+  );
+
+  const clockNotifier = E(wallet).getClockNotifier();
+  const paymentNotifier = E(wallet).getPaymentsNotifier();
+
+  const { updateCount: count0 } = await E(paymentNotifier).getUpdateSince();
+  await E(wallet).addPayment(pmt1);
+  const { updateCount: count1 } = await E(paymentNotifier).getUpdateSince(
+    count0,
+  );
+
+  // Wait for tick to take effect.
+  const { updateCount: clock0, value: clockValue0 } = await E(
+    clockNotifier,
+  ).getUpdateSince();
+  t.is(clockValue0, 19199000);
+  await manualTimer.tick();
+
+  const { value: clockValue1 } = await E(clockNotifier).getUpdateSince(clock0);
+  t.is(clockValue1, 19199000 + 1000);
+
+  await E(wallet).addPayment(pmt2);
+  await E(wallet).addPayment(pmt3);
+  const { value: payments } = await E(paymentNotifier).getUpdateSince(count1);
+
+  const paymentMeta = payments.map(p => p.meta);
+  t.deepEqual(paymentMeta, [
+    {
+      creationStamp: 19199000,
+      updatedStamp: 19199000,
+      sequence: 2,
+    },
+    {
+      creationStamp: 19200000,
+      updatedStamp: 19200000,
+      sequence: 3,
+    },
+    {
+      creationStamp: 19200000,
+      updatedStamp: 19200000,
+      sequence: 4,
+    },
+  ]);
 });

--- a/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
@@ -494,6 +494,9 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
         },
       },
       inviteHandleBoardId: '727995140',
+      meta: {
+        sequence: 3,
+      },
       proposalTemplate: {},
       requestContext: { dappOrigin: 'unknown' },
       instancePetname: 'automaticRefund',
@@ -625,6 +628,9 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
         },
       },
       inviteHandleBoardId: '727995140',
+      meta: {
+        sequence: 3,
+      },
       proposalTemplate: {},
       requestContext: { dappOrigin: 'unknown' },
       instancePetname: 'automaticRefund',
@@ -710,6 +716,9 @@ test('lib-wallet offer methods', async t => {
         inviteHandleBoardId: '727995140',
         instance,
         installation,
+        meta: {
+          sequence: 2,
+        },
         proposalTemplate: {
           give: { Contribution: { pursePetname: 'Fun budget', value: 1 } },
           exit: { onDemand: null },
@@ -824,6 +833,9 @@ test('lib-wallet offer methods', async t => {
           },
         },
         inviteHandleBoardId: '727995140',
+        meta: {
+          sequence: 2,
+        },
         proposalTemplate: {
           give: { Contribution: { pursePetname: 'Fun budget', value: 1 } },
           exit: { onDemand: null },
@@ -859,7 +871,7 @@ test('lib-wallet offer methods', async t => {
           description: 'getRefund',
           handle: {
             kind: 'unnamed',
-            petname: 'unnamed-6',
+            petname: 'unnamed-7',
           },
           installation: {
             kind: 'unnamed',
@@ -871,6 +883,9 @@ test('lib-wallet offer methods', async t => {
           },
         },
         inviteHandleBoardId: '371571443',
+        meta: {
+          sequence: 5,
+        },
         proposalTemplate: {
           give: { Contribution: { pursePetname: 'Fun budget', value: 1 } },
           exit: { onDemand: null },


### PR DESCRIPTION
This provides a unique `meta.sequence` value to help determine the order of events.

After #3841 is landed, this will provide timing information in the `meta` `creationStamp` and `updatedStamp` properties.

Also, a drive-by promise optimisation and doc fix.
