### PR TITLE
Skip refill meter test

### DIFF
--- a/packages/zoe/test/swingsetTests/refillMeter/test-refillMeter.js
+++ b/packages/zoe/test/swingsetTests/refillMeter/test-refillMeter.js
@@ -46,7 +46,11 @@ const refillMeterLog = [
   'error: Error: vat terminated',
 ];
 
-test('zoe - metering - refill meter', async t => {
+// See https://github.com/Agoric/agoric-sdk/issues/3804
+// TODO make this test more robust, or replace with something more
+// robust. This test is currently too sensitive to minor variations in
+// compute.
+test.skip('zoe - metering - refill meter', async t => {
   // If this assertion fails, please update this test with the new
   // computron values. This test aims to be resilient to changes in
   // computron values for particular actions but a significant change


### PR DESCRIPTION
See https://github.com/Agoric/agoric-sdk/issues/3804

This test is currently too sensitive to minor variations in compute, making errors like https://github.com/Agoric/agoric-sdk/pull/3736/checks?check_run_id=3637497640 repeatedly happen or stop happening.
