### PR TITLE
Cold notifiers -- if a cat mews but nobody hears it, does it make a sound?

### DIFF
--- a/packages/notifier/src/types.js
+++ b/packages/notifier/src/types.js
@@ -33,6 +33,20 @@
  */
 
 /**
+ * @callback OnObservedCallback
+ * @param {UpdateCount} observedUpdateCount which future update is being
+ * observed
+ * @returns {void}
+ */
+
+/**
+ * @callback RegisterOnObserved Register `onObserved` to be called when at least one
+ * client is actually waiting for a state update.
+ * @param {OnObservedCallback} onObserved the callback to register
+ * @returns {() => void} a function to call to unregister the callback
+ */
+
+/**
  * @template T
  * @typedef {Object} UpdateRecord<T>
  * @property {T} value is whatever state the service wants to publish
@@ -89,6 +103,9 @@
  * @template T
  * @typedef {Object} NotifierRecord<T> the produced notifier/updater pair
  * @property {IterationObserver<T>} updater the (closely-held) notifier producer
+ * @property {RegisterOnObserved} registerOnObserved (closely-held) call a
+ * function when the notifier is being asked for a new state that hasn't been
+ * updated yet
  * @property {Notifier<T>} notifier the (widely-held) notifier consumer
  */
 


### PR DESCRIPTION
# Context

Notifiers are great because they don't make sounds unless somebody is waiting to hear them.  However, "hot" notifiers think furiously to themselves until somebody explicitly stops them (if ever).  "Cold" notifiers only think immediately before they make a sound, and peacefully cease to exist when they are forgotten.

In the Observable literature, this is the difference between a "hot" observable (which is always active, regardless of whether it has observers), and a "cold" observable which is only active when it is being observed.

Our existing notifier mechanism is useful, but only supports "hot" notifiers.  We can solve this without needing to lean on big hammers like WeakRefs.

# The Cold Notifier implementation

This PR introduces a capability as part of the NotifierKit that allows updater code to register an "onObserved" callback.  By doing so, the updater can be quiescent until somebody calls `E(notifier).getUpdateSince(nextStateCount)`, when `onObserved(nextStateCount)` will be called.

A "cold" notifier can be built by only subscribing to resource events when a call to `onObserved` callback implies that somebody is watching.  This way, garbage collection is still not observable by the updater, but it can, when nobody is listening, be garbage-collected without any resource leaks.

The difference to the caller is that the `updateCount` is only incremented once in a while, instead of every `interval`.  As soon as the notifier is not asked for updates, the timer updater quiesces.  If a timer notifier has no external references, once the updater has also quiesced, the entire reference graph for the notifier and updater and `onObserved` callback can be garbage-collected without leaving behind any eternal subscriptions.

# Use cases

As a motivating example in this PR, the TimerService `E(timerService).makeNotifier(delay, interval)` currently returns a "hot" notifier that holds onto an eternal subscription to the timer device, causing both inefficiency and a resource leak.  This PR reimplements that API with a "cold" notifier which only subscribes to individual timer wake-ups when their presence is required by actual observations.

In a future PR to solve #3629, we'd like to use a cold notifier for the "bank purse" balance notifiers.  That way, the Golang side of the bank purses won't actually need to publish balance changes unless there is somebody is waiting on the corresponding JS balance notifiers.  This will usefully reduce the amount of messages to SwingSet when transfers are made on the Cosmos side.
