### PR TITLE
fix: fix bug which breaks rights conservation and offer safety guarantees

### DIFF
--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -113,7 +113,7 @@ export const createSeatManager = (
    * and so can be used internally for reallocations that violate
    * conservation.
    *
-   * @type {reallocateForZCFMint}
+   * @type {ReallocateForZCFMint}
    */
   const reallocateForZCFMint = (zcfSeat, newAllocation) => {
     try {

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -135,9 +135,6 @@ export const createSeatManager = (
           allocation: newAllocation,
         },
       ];
-        const seatHandle = zcfSeatToSeatHandle.get(seat);
-        return { seatHandle, allocation: newAllocation };
-      });
 
       E(zoeInstanceAdmin).replaceAllocations(seatHandleAllocations);
     } catch (err) {

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -129,7 +129,12 @@ export const createSeatManager = (
 
       activeZCFSeats.set(zcfSeat, newAllocation);
 
-      const seatHandleAllocations = [zcfSeat].map(seat => {
+      const seatHandleAllocations = [
+        {
+          seatHandle: zcfSeatToSeatHandle.get(zcfSeat),
+          allocation: newAllocation,
+        },
+      ];
         const seatHandle = zcfSeatToSeatHandle.get(seat);
         return { seatHandle, allocation: newAllocation };
       });

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -168,7 +168,10 @@ export const makeZCFZygote = (
           zcfSeat.incrementBy(gains);
         }
 
-        // verifies offer safety
+        // Offer safety should never be able to be violated here, as
+        // we are adding assets. However, we keep this check so that
+        // all reallocations are covered by offer safety checks, and
+        // that any bug within Zoe that may affect this is caught.
         assert(
           zcfSeat.isOfferSafe(allocationPlusGains),
           `The allocation after minting gains ${allocationPlusGains} for the zcfSeat was not offer safe`,

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -278,8 +278,9 @@
  */
 
 /**
- * @callback ReallocateInternal
- * @param {ZCFSeat[]} seats
+ * @callback ReallocateForZCFMint
+ * @param {ZCFSeat} zcfSeat
+ * @param {Allocation} newAllocation
  * @returns {void}
  */
 
@@ -295,7 +296,7 @@
  * @param {ShutdownWithFailure} shutdownWithFailure
  * @returns {{ makeZCFSeat: MakeZCFSeat,
     reallocate: Reallocate,
-    reallocateInternal: ReallocateInternal,
+    reallocateForZCFMint: ReallocateForZCFMint,
     dropAllReferences: DropAllReferences }}
  */
 

--- a/packages/zoe/test/unitTests/zcf/test-reallocateForZCFMint.js
+++ b/packages/zoe/test/unitTests/zcf/test-reallocateForZCFMint.js
@@ -1,0 +1,211 @@
+// @ts-check
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+
+import { AssetKind, AmountMath } from '@agoric/ertp';
+import { makeOffer } from '../makeOffer.js';
+
+import { setup } from '../setupBasicMints.js';
+
+import { setupZCFTest } from './setupZcfTest.js';
+
+// Test that `zcfSeat.incrementBy()` and `zcfSeat.decrementBy()` can
+// be interleaved at any point with `zcfMint.mintGains()` and
+// `zcfMint.burnLosses()` with no problems. This test only performs a
+// subset of all possible interleavings, but it should cover a fair amount
+//
+// Order of calls:
+// 1. zcfSeat2.decrementBy with non-zcfMint token
+// 2. zcfMint.mintGains on zcfSeat2
+// 3. zcfMint.mintGains on zcfSeat1
+// 4. zcfSeat1.incrementBy non-zcfMint token
+// 5. reallocate(zcfSeat1, zcfSeat2)
+// 6. zcfSeat1.decrementBy zcfMint token and non-zcfMint token
+// 7. zcfMint.burnLosses on zcfSeat1
+// 8. zcfMint.burnLosses on zcfSeat2
+// 9. zcfSeat2.incrementBy zcfMint token and non-zcfMint token
+// 10. zcfMint.mintGains on zcfSeat2
+// 11 reallocate(zcfSeat1, zcfSeat2)
+
+test(`stagedAllocations safely interleave with zcfMint calls`, async t => {
+  const { moolaKit, moola } = setup();
+  const { zoe, zcf } = await setupZCFTest({
+    Moola: moolaKit.issuer,
+  });
+
+  // Make zcfSeat1
+  const { zcfSeat: zcfSeat1 } = await makeOffer(
+    zoe,
+    zcf,
+    harden({ give: { B: moola(3) } }),
+    harden({ B: moolaKit.mint.mintPayment(moola(3)) }),
+  );
+
+  // Make zcfSeat2
+  const { zcfSeat: zcfSeat2 } = await makeOffer(
+    zoe,
+    zcf,
+    harden({ give: { B: moola(3) } }),
+    harden({ B: moolaKit.mint.mintPayment(moola(3)) }),
+  );
+
+  // Make ZCFMint
+  const zcfMint = await zcf.makeZCFMint('Token', AssetKind.NAT, {
+    decimalPlaces: 6,
+  });
+  const { brand: tokenBrand } = zcfMint.getIssuerRecord();
+
+  // Decrement zcfSeat2 by non-zcfMintToken
+  zcfSeat2.decrementBy({ B: moola(2) });
+  t.true(zcfSeat2.hasStagedAllocation());
+  t.deepEqual(zcfSeat2.getStagedAllocation(), { B: moola(1) });
+  t.deepEqual(zcfSeat2.getCurrentAllocation(), { B: moola(3) });
+
+  // Mint gains to zcfSeat2
+  zcfMint.mintGains(
+    {
+      MyToken: AmountMath.make(tokenBrand, 100n),
+    },
+    zcfSeat2,
+  );
+  // zcfSeat2's staged allocation and the current allocation should
+  // include the newly minted tokens. Staged allocations completely
+  // replace the old allocations, so it is important that anything
+  // added to the current allocation also gets added to any
+  // in-progress staged allocation.
+  t.deepEqual(zcfSeat2.getStagedAllocation(), {
+    B: moola(1),
+    MyToken: AmountMath.make(tokenBrand, 100n),
+  });
+  t.deepEqual(zcfSeat2.getCurrentAllocation(), {
+    B: moola(3),
+    MyToken: AmountMath.make(tokenBrand, 100n),
+  });
+
+  // Mint gains to zcfSeat1
+  zcfMint.mintGains(
+    {
+      OtherTokens: AmountMath.make(tokenBrand, 50n),
+    },
+    zcfSeat1,
+  );
+  // zcfSeat1 has no staged allocation, but the current
+  // allocation should have changed to include the minted tokens
+  t.false(zcfSeat1.hasStagedAllocation());
+  t.deepEqual(zcfSeat1.getCurrentAllocation(), {
+    B: moola(3),
+    OtherTokens: AmountMath.make(tokenBrand, 50n),
+  });
+
+  // zcfSeat1.incrementBy non-zcfMint token
+  zcfSeat1.incrementBy({ B: moola(2) });
+  // Both the staged allocation and the current allocation show the OtherTokens
+  t.deepEqual(zcfSeat1.getStagedAllocation(), {
+    B: moola(5),
+    OtherTokens: AmountMath.make(tokenBrand, 50n),
+  });
+  t.deepEqual(zcfSeat1.getCurrentAllocation(), {
+    B: moola(3),
+    OtherTokens: AmountMath.make(tokenBrand, 50n),
+  });
+
+  // Reallocate
+  zcf.reallocate(zcfSeat1, zcfSeat2);
+  t.false(zcfSeat1.hasStagedAllocation());
+  t.false(zcfSeat2.hasStagedAllocation());
+  t.deepEqual(zcfSeat1.getCurrentAllocation(), {
+    B: moola(5),
+    OtherTokens: AmountMath.make(tokenBrand, 50n),
+  });
+  t.deepEqual(zcfSeat2.getCurrentAllocation(), {
+    B: moola(1),
+    MyToken: AmountMath.make(tokenBrand, 100n),
+  });
+
+  // Test burnLosses interleaving
+
+  // zcfSeat1 decrementBy both zcfMint token and non-zcfMint token
+  zcfSeat1.decrementBy({
+    OtherTokens: AmountMath.make(tokenBrand, 5n),
+    B: moola(1),
+  });
+
+  // zcfMint.burnLosses on zcfSeat1
+  zcfMint.burnLosses(
+    { OtherTokens: AmountMath.make(tokenBrand, 7n) },
+    zcfSeat1,
+  );
+  // The zcfMint losses are subtracted from both the currentAllocation and the
+  // stagedAllocation, but currentAllocation does not include the
+  // stagedAllocations, and will not until zcf.reallocate is called.
+  t.deepEqual(zcfSeat1.getCurrentAllocation(), {
+    B: moola(5), // no change since reallocate
+    OtherTokens: AmountMath.make(tokenBrand, 43n),
+  });
+  t.deepEqual(zcfSeat1.getStagedAllocation(), {
+    B: moola(4),
+    OtherTokens: AmountMath.make(tokenBrand, 38n), // includes decrementBy and burnLosses
+  });
+
+  // zcfMint.burnLosses on zcfSeat2
+  zcfMint.burnLosses(
+    {
+      MyToken: AmountMath.make(tokenBrand, 17n),
+    },
+    zcfSeat2,
+  );
+  t.deepEqual(zcfSeat2.getCurrentAllocation(), {
+    B: moola(1),
+    MyToken: AmountMath.make(tokenBrand, 83n),
+  });
+  t.false(zcfSeat2.hasStagedAllocation());
+
+  // zcfSeat2.incrementBy
+  zcfSeat2.incrementBy({
+    OtherTokens: AmountMath.make(tokenBrand, 5n), // let's keep this keyword separate even though we don't have to
+    B: moola(1),
+  });
+  t.deepEqual(zcfSeat2.getCurrentAllocation(), {
+    B: moola(1),
+    MyToken: AmountMath.make(tokenBrand, 83n),
+  });
+  t.deepEqual(zcfSeat2.getStagedAllocation(), {
+    B: moola(2),
+    MyToken: AmountMath.make(tokenBrand, 83n),
+    OtherTokens: AmountMath.make(tokenBrand, 5n),
+  });
+
+  // zcfMint.mintGains on zcfSeat2
+  zcfMint.mintGains(
+    {
+      AnotherOne: AmountMath.make(tokenBrand, 2n),
+    },
+    zcfSeat2,
+  );
+  t.deepEqual(zcfSeat2.getCurrentAllocation(), {
+    B: moola(1),
+    MyToken: AmountMath.make(tokenBrand, 83n),
+    AnotherOne: AmountMath.make(tokenBrand, 2n),
+  });
+  t.deepEqual(zcfSeat2.getStagedAllocation(), {
+    B: moola(2),
+    MyToken: AmountMath.make(tokenBrand, 83n),
+    OtherTokens: AmountMath.make(tokenBrand, 5n),
+    AnotherOne: AmountMath.make(tokenBrand, 2n),
+  });
+
+  // One last reallocate
+  zcf.reallocate(zcfSeat1, zcfSeat2);
+  t.deepEqual(zcfSeat2.getCurrentAllocation(), {
+    B: moola(2),
+    MyToken: AmountMath.make(tokenBrand, 83n),
+    OtherTokens: AmountMath.make(tokenBrand, 5n),
+    AnotherOne: AmountMath.make(tokenBrand, 2n),
+  });
+  t.deepEqual(zcfSeat1.getCurrentAllocation(), {
+    B: moola(4),
+    OtherTokens: AmountMath.make(tokenBrand, 38n),
+  });
+  t.false(zcfSeat1.hasStagedAllocation());
+  t.false(zcfSeat2.hasStagedAllocation());
+});

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -538,7 +538,7 @@ test(`zcf.makeZCFMint - mintGains - seat exited`, async t => {
   t.throws(
     () => zcfMint.mintGains({ A: AmountMath.make(4n, brand) }, zcfSeat),
     {
-      message: `seat has been exited`,
+      message: `zcfSeat must be active to mint gains for the zcfSeat`,
     },
   );
 });
@@ -562,7 +562,7 @@ test(`zcf.makeZCFMint - burnLosses - seat exited`, async t => {
   t.throws(
     () => zcfMint.burnLosses({ A: AmountMath.make(1n, brand) }, zcfSeat),
     {
-      message: `seat has been exited`,
+      message: `zcfSeat must be active to burn losses from the zcfSeat`,
     },
   );
 });


### PR DESCRIPTION
This PR rewrites `zcfMint.mintGains` and `zcfMint.burnLosses` so that neither use staged allocations and neither use the typical `reallocate` path. Instead, the code is simplified such that the updated allocations are calculated, then a special reallocate only for zcfMint methods (`reallocateForZCFMint`) is called. `reallocateInternal` is deleted and its contents moved into `reallocate` proper.

Closes #3848