### PR TITLE
Deployment fixes

### DIFF
--- a/packages/deployment/ansible/roles/cosmos-validators/tasks/main.yml
+++ b/packages/deployment/ansible/roles/cosmos-validators/tasks/main.yml
@@ -30,9 +30,21 @@
     staker: "{{ STAKER }}-{{ inventory_hostname }}"
   when: inventory_hostname != STAKER_NODE
 
+- name: "Find staking_denom from {{ STAKER_SELF_DELEGATION }}"
+  set_fact:
+    staking_denom: "{{ STAKER_SELF_DELEGATION | regex_search('^[0-9]*(.*)', '\\1') | first }}"
+
 - name: "Specially set JSON valconspub"
   set_fact:
     valconspub: "{{ lookup('file', data + '/' + inventory_hostname + '/pubkey') | string }}"
+
+- name: "Wait for transfer of {{ staking_denom }} to arrive at {{ inventory_hostname }}"
+  shell: "\
+    ag-cosmos-helper query bank balances {{ staker_address.stdout }}"
+  register: staker_balance
+  until: staker_balance.stdout.find(staking_denom) != -1
+  delay: 10
+  retries: 60
 
 - name: "Create validators for {{ STAKER }}-*"
   become_user: "{{ service }}"


### PR DESCRIPTION
A few updates to the deployment template to ensure it configures a new chain properly.

I've tested these in a "smoke" network, on which I couldn't reproduce the apphash failures yet.  Tomorrow it would be good if @mhofman could set up some loadgens.  Here is the `network-config.json`:

```json
{
  "chainName": "smoke-3",
  "gci": "4acae2fad46f746f85318799f79328af2c186f9fd2e5d18d9b57536e92cd980b",
  "peers": [
    "7e72fd2a319ba4856fbd87d657c6e707fe37e854@137.184.12.84:26656",
    "7072cebde937556874227fb14abd31a73dcc258e@137.184.4.169:26656",
    "d7745a6163f82a43439a3151499889e28d7d3927@137.184.4.78:26656",
    "f7fe097d1fe58f30e4ff886153bdec1dd3107686@137.184.4.71:26656"
  ],
  "rpcAddrs": [
    "137.184.12.84:26657",
    "137.184.4.169:26657",
    "137.184.4.78:26657",
    "137.184.4.71:26657"
  ],
  "seeds": [
    ""
  ]
}
```
