### PR TITLE
style(governance): lint for Jessie dialect (WIP)

### DIFF
--- a/packages/governance/src/binaryVoteCounter.js
+++ b/packages/governance/src/binaryVoteCounter.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { Far } from '@agoric/marshal';
 import { makePromiseKit } from '@agoric/promise-kit';
@@ -108,7 +109,7 @@ const makeBinaryVoteCounter = (questionSpec, threshold, instance) => {
       if (choice < 0) {
         spoiled += shares;
       } else {
-        tally[choice] += shares;
+        tally[+choice] += shares;
       }
     });
 

--- a/packages/governance/src/closingRule.js
+++ b/packages/governance/src/closingRule.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 // Standard closing rule is a deadline and Timer. An alternative might allow for
 // emergency votes that can close as soon as a quorum or other threshold is

--- a/packages/governance/src/committee.js
+++ b/packages/governance/src/committee.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';

--- a/packages/governance/src/contractGovernor.js
+++ b/packages/governance/src/contractGovernor.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';

--- a/packages/governance/src/electorateTools.js
+++ b/packages/governance/src/electorateTools.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { E } from '@agoric/eventual-send';
 import { allComparable } from '@agoric/same-structure';

--- a/packages/governance/src/governParam.js
+++ b/packages/governance/src/governParam.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';

--- a/packages/governance/src/index.js
+++ b/packages/governance/src/index.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import './types.js';
 

--- a/packages/governance/src/question.js
+++ b/packages/governance/src/question.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { Far, passStyleOf } from '@agoric/marshal';
 import { sameStructure } from '@agoric/same-structure';

--- a/packages/governance/src/validators.js
+++ b/packages/governance/src/validators.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { E } from '@agoric/eventual-send';
 


### PR DESCRIPTION
I got surprisingly few lint errors when I added `@jessie-check` to the governance sources. The code is already remarkably close to Jessie. The biggest issue I see is:

 - [ ] dynamic property names in paramManager

For code such as...

```js
typesAndValues[name] = { type, value };
```

Is that just irreconcilable with Jessie? Or is there some `Object.defineProperty(...)` idiom that we prefer in such cases?

The other issue is relatively minor:

 - [ ] use of `new` in `new WeakMap()` (1 occurrence)

I'd be tempted to put

```js
export const makeWeakMap = () => new WeakMap();
```

in the same directory, named `tablemaker.js` or `jessielib.js` or some such and import from there. I lean against adding a new package dependency for a 1-liner (plus, I'm not sure how stable our jessie stdlib package is).