### PR TITLE
chore(ERTP): additional input validation and clean up

### DIFF
--- a/packages/ERTP/docs/INPUT_VALIDATION.md
+++ b/packages/ERTP/docs/INPUT_VALIDATION.md
@@ -1,0 +1,141 @@
+# Input Validation for ERTP - A Walkthrough
+
+## Requirements
+
+We want ERTP to be robust against malicious code in the same vat, so the ERTP must be robust without the kind of checks that we get for free in intervat communication going through `@agoric/marshal` and `@agoric/swingset-vat`. In other words, the only tools at our disposal are being in a Hardened JS environment, and helpers that we import and call directly, such as `passStyleOf` from `@agoric/marshal`. 
+
+## Malicious Behavior
+
+We identify two personas: the creator of an issuerKit, and a user of the asset type. A user is someone who holds a purse or payment of that brand, or describes something in terms of an amount of that brand. A creator might be vulnerable to an attack by users and vice versa. Users might be vulnerable to other users.
+
+The malicious behavior we would like to prevent is:
+
+1. Users stealing funds from other users
+2. Users minting who do not have access to the mint
+3. The creator of an issuerKit revoking assets from the holders of purses and payments
+
+## Entry points in ERTP
+
+There are three entry points in ERTP:
+1. packages/ERTP/src/amountMath.js
+2. packages/ERTP/src/issuerKit.js
+3. packages/ERTP/src/typeGuards.js
+
+This document will only analyze `AmountMath.coerce`, but the
+methodology for validating inputs remains the same for the ERTP functions.
+
+`AmountMath.coerce` takes a `brand` and an `amount` and returns a new `amount`, but throws if the amount does not match the brand, or if the amount is not a valid amount generally.
+
+For `coerce` to work according to spec, if the user passes in an invalid brand or an invalid amount, we must throw. 
+
+## Valid amounts
+
+A valid amount is an object record with two properties: `brand` and
+`value`. `brand` is a Remotable with a few methods, such as
+`isMyIssuer`, but for the purposes of a valid amount, we allow any
+Remotable and do not call any of these methods (we would have to call
+them asynchronously in order to check them, since the `brand` might be
+a remote object, so we do not check them.)
+
+The value is either a bigint Nat in the case of AssetKind.NAT (we formerly allowed numbers for backwards compatibility, but now only bigints are allowed) or an array of Structures in the case of AssetKind.SET. The array of Structures might include any combination of other Structures, “undefined”, “null”, booleans, symbols, strings, pass-by-copy records, pass-by-copy arrays, numbers, bigints,  Remotables, and errors. Importantly, a Structure cannot contain promises. 
+
+## Invalid Amounts
+
+There are a number of ways in which amounts can be invalid:
+
+### Not an object
+
+* **The danger**: we’ll get unexpected failures later on in our use of the amount rather than failing fast at the start as intended.
+
+### Not a CopyRecord
+
+* **The danger**: an object that isn’t a `copyRecord` can have `getters` that return different values at different times, so checking the value is no guarantee that the value will be the same when accessed later. For example:
+
+```js
+const object1 = {};
+let checked = false;
+Object.defineProperty(object1, 'value', {
+ get() {
+   if (checked) {
+     return 1000000n;
+   } else {
+     checked = true;
+     return 1n;
+   }
+ },
+});
+```
+```sh
+> object1.value
+1n
+> object1.value
+1000000n
+```
+ 
+`Object.freeze(object1)` is not helpful here, as the `getter` is not changing, the value that is being returned is. `harden` also does not prevent `value` from changing. ​​When harden does encounter an accessor property during its traversal, it does not "read" the property, and thereby does not call the getter. Rather, it proceeds to recursively harden the getter and setter themselves. That's because, for an accessor property, its current value isn't, for this purpose, considered part of its API surface, but rather part of the behavior of that API. Thus, we need an additional way to ensure that the value of `checked` cannot change.
+
+`isPassStyleOf` throws on objects with accessor properties like the object defined above.
+
+### Is a CopyRecord and is a proxy
+
+* **The dangers**: 
+  1) A proxy can throw on any property access, but only the first
+     time. Any time it does *not* throw, it *must* return the same
+     value as before. 
+  2) A proxy can mount a reentrancy attack where a proxy handler is running while code is executing, and can reenter the code while the original is still executing. 
+
+Commit points are a good mitigation for #1 - do all of your checks upfront so that any throwing causes you to fail fast, before any state is changed.
+
+Some mitigation for #2 are: 
+1. Create a new object with a spread operator so that the proxy isn't
+   used further. 
+2. Destructure and then never use the original object again. 
+3. Use `pureCopy`. `pureCopy` ensures the object is not a proxy, but `pureCopy` only works for copyRecords that are pure data, meaning no remotables and no promises.
+
+We aim to address proxy-based reentrancy by other, lower-level means, thus making `passStyleOf(amount) === ‘copyRecord’` sufficient protection against proxy-based reentrancy as well, but we should note that proxy-based reentrancy is not a threat across a vat boundary because it requires synchronous access.
+
+## Invalid brands
+
+A brand can be "wrong" if:
+1. It's not a Remotable
+2. Its methods don’t adhere to the expected Brand API
+3. It misbehaves (i.e. answering isMyIssuer with different responses)
+
+In determining whether a brand is "valid", we only check that the brand is a remotable. This means that a brand
+that passes our input validation could still have the wrong API or misbehave.
+
+## Who hardens?
+It is the responsibility of the sender/client (the creator of an
+issuerKit or user of ERTP) to harden. AmountMath does not harden
+inputs.
+
+## The implementation
+
+In `AmountMath.coerce(brand, allegedAmount)`, we do the following:
+1. assert that the `brand` is a remotable
+2. assert that the `allegedAmount` is a `copyRecord`
+3. destructure the `allegedAmount` into `allegedBrand` and
+   `allegedValue`
+4. Assert that the `brand` is identical to the `allegedBrand` 
+5. Call `AmountMath.make(brand, allegedValue)`, which:
+    * Asserts that the `brand` is a remotable, again.
+    * Asserts that the `allegedValue` is a `copyArray` or a `bigint`
+    * Gets the appropriate MathHelpers
+    * Calls `helpers.doCoerce(allegedValue)`, which either asserts
+      that the value is a `Nat bigint` or that the value is a
+      `copyArray` `structure` with no duplicate elements
+11. Return a new `amount`
+
+Thus, we ensure that the `brand` is valid by checking that it is a
+remotable. We ensure that the `allegedAmount` is a copyRecord with
+valid `brand` and `value` properties.
+
+If `allegedAmount` were a proxy, we would either throw in step 3 (the
+destructuring), or we successfully get both the `allegedBrand` and
+`allegedValue` and never touch the proxy again. Currently, we do not
+attempt to prevent proxy-based reentrancy, so this is the full extent
+of our defense.
+
+
+
+

--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -183,7 +183,7 @@ const AmountMath = {
   isEmpty: (amount, brand = undefined) => {
     assertRecord(amount, 'amount');
     const { brand: allegedBrand, value } = amount;
-    assertRemotable(allegedBrand);
+    assertRemotable(allegedBrand, 'brand');
     optionalBrandCheck(allegedBrand, brand);
     const h = assertValueGetHelpers(value);
     // @ts-ignore Needs better typing to express Value to Helpers relationship

--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -1,19 +1,12 @@
 // @ts-check
 
 import { assert, details as X } from '@agoric/assert';
-import { mustBeComparable } from '@agoric/same-structure';
+import { passStyleOf, assertRemotable, assertRecord } from '@agoric/marshal';
 
 import './types.js';
 import natMathHelpers from './mathHelpers/natMathHelpers.js';
 import setMathHelpers from './mathHelpers/setMathHelpers.js';
-import {
-  looksLikeSetValue,
-  looksLikeNatValue,
-  looksLikeValue,
-  looksLikeBrand,
-} from './typeGuards.js';
 
-// We want an enum, but narrowed to the AssetKind type.
 /**
  * Constants for the kinds of assets we support.
  *
@@ -25,6 +18,14 @@ const AssetKind = {
 };
 harden(AssetKind);
 
+/** @type {AssertAssetKind} */
+const assertAssetKind = allegedAK =>
+  assert(
+    Object.values(AssetKind).includes(allegedAK),
+    X`The assetKind ${allegedAK} must be either AssetKind.NAT or AssetKind.SET`,
+  );
+harden(assertAssetKind);
+
 /**
  * Amounts describe digital assets. From an amount, you can learn the
  * brand of digital asset as well as "how much" or "how many". Amounts
@@ -35,14 +36,14 @@ harden(AssetKind);
  * assets. Amounts are pass-by-copy and can be made by and sent to
  * anyone.
  *
- * The issuer has an internal table that maps purses and payments to
- * amounts. The issuer must be able to do things such as add digital
- * assets to a purse and withdraw digital assets from a purse. To do
- * so, it must know how to add and subtract digital assets. Rather
- * than hard-coding a particular solution, we chose to parameterize
- * the issuer with a collection of polymorphic functions, which we
- * call `AmountMath`. These math functions include concepts like
- * addition, subtraction, and greater than or equal to.
+ * The issuer is the authoritative source of the amount in payments
+ * and purses. The issuer must be able to do things such as add
+ * digital assets to a purse and withdraw digital assets from a purse.
+ * To do so, it must know how to add and subtract digital assets.
+ * Rather than hard-coding a particular solution, we chose to
+ * parameterize the issuer with a collection of polymorphic functions,
+ * which we call `AmountMath`. These math functions include concepts
+ * like addition, subtraction, and greater than or equal to.
  *
  * We also want to make sure there is no confusion as to what kind of
  * asset we are using. Thus, AmountMath includes checks of the
@@ -70,88 +71,40 @@ const helpers = {
   set: setMathHelpers,
 };
 
+/** @type {(value: Value) => AssetKind} */
+const assertValueGetAssetKind = value => {
+  const valuePassStyle = passStyleOf(value);
+  if (valuePassStyle === 'copyArray') {
+    return 'set';
+  }
+  if (valuePassStyle === 'bigint') {
+    return 'nat';
+  }
+  assert.fail(
+    X`value ${value} must be a bigint or an array, not ${valuePassStyle}`,
+  );
+};
+
 /**
+ *
+ * Asserts that passStyleOf(value) === 'copyArray' or 'bigint' and
+ * returns the appropriate helpers.
+ *
  * @param {Value} value
  * @returns {NatMathHelpers | SetMathHelpers}
  */
-const getHelpersFromValue = value => {
-  if (looksLikeSetValue(value)) {
-    return setMathHelpers;
-  }
-  if (looksLikeNatValue(value)) {
-    return natMathHelpers;
-  }
-  assert.fail(X`value ${value} must be a bigint or an array`);
-};
+const assertValueGetHelpers = value => helpers[assertValueGetAssetKind(value)];
 
-/** @type {(amount: Amount) => AssetKind} */
-const getAssetKind = amount => {
-  if (looksLikeSetValue(amount.value)) {
-    return 'set';
-  }
-  if (looksLikeNatValue(amount.value)) {
-    return 'nat';
-  }
-  assert.fail(X`value ${amount.value} must be a bigint or an array`);
-};
-
-/**
- * @type {(amount: Amount ) => NatMathHelpers | SetMathHelpers }
- */
-const getHelpersFromAmount = amount => {
-  return getHelpersFromValue(amount.value);
-};
-
-/** @type {(leftAmount: Amount, rightAmount: Amount ) =>
- * NatMathHelpers | SetMathHelpers } */
-const getHelpers = (leftAmount, rightAmount) => {
-  const leftHelpers = getHelpersFromAmount(leftAmount);
-  const rightHelpers = getHelpersFromAmount(rightAmount);
-  assert.equal(leftHelpers, rightHelpers);
-  return leftHelpers;
-};
-
-/** @type {(amount: Amount, brand?: Brand) => void} */
-const optionalBrandCheck = (amount, brand) => {
+/** @type {(allegedBrand: Brand, brand?: Brand) => void} */
+const optionalBrandCheck = (allegedBrand, brand) => {
   if (brand !== undefined) {
-    mustBeComparable(brand);
+    assertRemotable(brand, 'brand');
     assert.equal(
-      amount.brand,
+      allegedBrand,
       brand,
-      X`amount's brand ${amount.brand} did not match expected brand ${brand}`,
+      X`amount's brand ${allegedBrand} did not match expected brand ${brand}`,
     );
   }
-};
-
-/** @type {(value: Value, brand: Brand) => Amount} */
-const noCoerceMake = (value, brand) => {
-  const amount = harden({ brand, value });
-  return amount;
-};
-
-/** @type {(value: Value) => void} */
-const assertLooksLikeValue = value => {
-  assert(looksLikeValue(value), X`value ${value} must be a Nat or an array`);
-};
-
-/** @type {(brand: Brand, msg?: Details) => void} */
-const assertLooksLikeBrand = (
-  brand,
-  msg = X`The brand ${brand} doesn't look like a brand.`,
-) => {
-  assert(looksLikeBrand(brand), msg);
-};
-
-/**
- * Give a better error message by logging the entire amount
- * rather than just the brand
- *
- * @type {(amount: Amount) => void}
- */
-const assertLooksLikeAmount = amount => {
-  const msg = X`The amount ${amount} doesn't look like an amount. Did you pass a value instead?`;
-  assertLooksLikeBrand(amount.brand, msg);
-  assertLooksLikeValue(amount.value);
 };
 
 /**
@@ -161,16 +114,27 @@ const assertLooksLikeAmount = amount => {
  * @returns {NatMathHelpers | SetMathHelpers }
  */
 const checkLRAndGetHelpers = (leftAmount, rightAmount, brand = undefined) => {
-  assertLooksLikeAmount(leftAmount);
-  assertLooksLikeAmount(rightAmount);
-  optionalBrandCheck(leftAmount, brand);
-  optionalBrandCheck(rightAmount, brand);
+  assertRecord(leftAmount, 'leftAmount');
+  assertRecord(rightAmount, 'rightAmount');
+  const { value: leftValue, brand: leftBrand } = leftAmount;
+  const { value: rightValue, brand: rightBrand } = rightAmount;
+  assertRemotable(leftBrand, 'leftBrand');
+  assertRemotable(rightBrand, 'rightBrand');
+  optionalBrandCheck(leftBrand, brand);
+  optionalBrandCheck(rightBrand, brand);
   assert.equal(
-    leftAmount.brand,
-    rightAmount.brand,
-    X`Brands in left ${leftAmount.brand} and right ${rightAmount.brand} should match but do not`,
+    leftBrand,
+    rightBrand,
+    X`Brands in left ${leftBrand} and right ${rightBrand} should match but do not`,
   );
-  return getHelpers(leftAmount, rightAmount);
+  const leftHelpers = assertValueGetHelpers(leftValue);
+  const rightHelpers = assertValueGetHelpers(rightValue);
+  assert.equal(
+    leftHelpers,
+    rightHelpers,
+    X`The left ${leftAmount} and right amount ${rightAmount} had different assetKinds`,
+  );
+  return leftHelpers;
 };
 
 /**
@@ -185,59 +149,45 @@ const coerceLR = (h, leftAmount, rightAmount) => {
 
 /** @type {AmountMath} */
 const AmountMath = {
-  // TODO: remove when the deprecated order is no longer allowed.
-  // https://github.com/Agoric/agoric-sdk/issues/3202
-  // @ts-ignore The brand can be the second argument, but this is deprecated
   make: (brand, allegedValue) => {
-    if (looksLikeBrand(allegedValue)) {
-      // Swap to support deprecated reverse argument order
-      [brand, allegedValue] = [allegedValue, brand];
-    } else {
-      assertLooksLikeBrand(brand);
-    }
-    assertLooksLikeValue(allegedValue);
+    assertRemotable(brand, 'brand');
+    const h = assertValueGetHelpers(allegedValue);
     // @ts-ignore Needs better typing to express Value to Helpers relationship
-    const value = getHelpersFromValue(allegedValue).doCoerce(allegedValue);
+    const value = h.doCoerce(allegedValue);
     return harden({ brand, value });
   },
-  // TODO: remove when the deprecated order is no longer allowed.
-  // https://github.com/Agoric/agoric-sdk/issues/3202
-  // @ts-ignore The brand can be the second argument, but this is deprecated
   coerce: (brand, allegedAmount) => {
-    if (looksLikeBrand(allegedAmount)) {
-      // Swap to support deprecated reverse argument order
-      [brand, allegedAmount] = [allegedAmount, brand];
-    } else {
-      assertLooksLikeBrand(brand);
-    }
-    assertLooksLikeAmount(allegedAmount);
+    assertRemotable(brand, 'brand');
+    assertRecord(allegedAmount, 'amount');
+    const { brand: allegedBrand, value: allegedValue } = allegedAmount;
     assert(
-      brand === allegedAmount.brand,
+      brand === allegedBrand,
       X`The brand in the allegedAmount ${allegedAmount} in 'coerce' didn't match the specified brand ${brand}.`,
     );
     // Will throw on inappropriate value
-    return AmountMath.make(brand, allegedAmount.value);
+    return AmountMath.make(brand, allegedValue);
   },
-  // TODO: remove when the deprecated order is no longer allowed.
-  // https://github.com/Agoric/agoric-sdk/issues/3202
-  // @ts-ignore The brand can be the second argument, but this is deprecated
   getValue: (brand, amount) => AmountMath.coerce(brand, amount).value,
   makeEmpty: (brand, assetKind = AssetKind.NAT) => {
-    assert(
-      helpers[assetKind],
-      X`${assetKind} must be AssetKind.NAT or AssetKind.SET`,
-    );
-    assertLooksLikeBrand(brand);
-    return noCoerceMake(helpers[assetKind].doMakeEmpty(), brand);
+    assertRemotable(brand, 'brand');
+    assertAssetKind(assetKind);
+    const value = helpers[assetKind].doMakeEmpty();
+    return harden({ brand, value });
   },
-  makeEmptyFromAmount: amount =>
-    AmountMath.makeEmpty(amount.brand, getAssetKind(amount)),
+  makeEmptyFromAmount: amount => {
+    assertRecord(amount, 'amount');
+    const { brand, value } = amount;
+    const assetKind = assertValueGetAssetKind(value);
+    return AmountMath.makeEmpty(brand, assetKind);
+  },
   isEmpty: (amount, brand = undefined) => {
-    assertLooksLikeAmount(amount);
-    optionalBrandCheck(amount, brand);
-    const h = getHelpersFromAmount(amount);
+    assertRecord(amount, 'amount');
+    const { brand: allegedBrand, value } = amount;
+    assertRemotable(allegedBrand);
+    optionalBrandCheck(allegedBrand, brand);
+    const h = assertValueGetHelpers(value);
     // @ts-ignore Needs better typing to express Value to Helpers relationship
-    return h.doIsEmpty(h.doCoerce(amount.value));
+    return h.doIsEmpty(h.doCoerce(value));
   },
   isGTE: (leftAmount, rightAmount, brand = undefined) => {
     const h = checkLRAndGetHelpers(leftAmount, rightAmount, brand);
@@ -251,29 +201,24 @@ const AmountMath = {
   },
   add: (leftAmount, rightAmount, brand = undefined) => {
     const h = checkLRAndGetHelpers(leftAmount, rightAmount, brand);
-    return noCoerceMake(
-      // @ts-ignore Needs better typing to express Value to Helpers relationship
-      h.doAdd(...coerceLR(h, leftAmount, rightAmount)),
-      leftAmount.brand,
-    );
+    // @ts-ignore Needs better typing to express Value to Helpers relationship
+    const value = h.doAdd(...coerceLR(h, leftAmount, rightAmount));
+    return harden({ brand: leftAmount.brand, value });
   },
   subtract: (leftAmount, rightAmount, brand = undefined) => {
     const h = checkLRAndGetHelpers(leftAmount, rightAmount, brand);
-    return noCoerceMake(
-      // @ts-ignore Needs better typing to express Value to Helpers relationship
-      h.doSubtract(...coerceLR(h, leftAmount, rightAmount)),
-      leftAmount.brand,
-    );
+    // @ts-ignore Needs better typing to express Value to Helpers relationship
+    const value = h.doSubtract(...coerceLR(h, leftAmount, rightAmount));
+    return harden({ brand: leftAmount.brand, value });
   },
 };
 harden(AmountMath);
 
-/**
- * Usage of lowercase `amountMath` is deprecated. Please import
- * `AmountMath` instead.
- *
- * @deprecated
- */
-const amountMath = AmountMath;
+const getAssetKind = amount => {
+  assertRecord(amount, 'amount');
+  const { value } = amount;
+  return assertValueGetAssetKind(value);
+};
+harden(getAssetKind);
 
-export { amountMath, AmountMath, AssetKind, getAssetKind };
+export { AmountMath, AssetKind, getAssetKind, assertAssetKind };

--- a/packages/ERTP/src/displayInfo.js
+++ b/packages/ERTP/src/displayInfo.js
@@ -37,6 +37,12 @@ export const coerceDisplayInfo = (allegedDisplayInfo, assetKind) => {
   // `pureCopy` works in this case because displayInfo is a copyRecord
   // that is pure data, meaning no remotables and no promises.
   allegedDisplayInfo = pureCopy(allegedDisplayInfo);
+  if (allegedDisplayInfo.assetKind !== undefined) {
+    assert(
+      allegedDisplayInfo.assetKind === assetKind,
+      X`displayInfo.assetKind was present (${allegedDisplayInfo.assetKind}) and did not match the assetKind argument (${assetKind})`,
+    );
+  }
   const displayInfo = harden({ ...allegedDisplayInfo, assetKind });
 
   assertSubset(displayInfoKeys, Object.keys(displayInfo));

--- a/packages/ERTP/src/displayInfo.js
+++ b/packages/ERTP/src/displayInfo.js
@@ -1,11 +1,11 @@
 // @ts-check
 
 import { assert, details as X, q } from '@agoric/assert';
-import { pureCopy, passStyleOf } from '@agoric/marshal';
+import { pureCopy, assertRecord } from '@agoric/marshal';
 
-// TODO: assertSubset and assertKeysAllowed are copied from Zoe. Move
-// this code to a location where it can be used by ERTP and Zoe
-// easily. Perhaps another package.
+// TODO: assertSubset is copied from Zoe. Move this code to a location
+// where it can be used by ERTP and Zoe easily. Perhaps another
+// package.
 
 /**
  * Assert all values from `part` appear in `whole`.
@@ -13,9 +13,8 @@ import { pureCopy, passStyleOf } from '@agoric/marshal';
  * @param {string[]} whole
  * @param {string[]} part
  */
-export const assertSubset = (whole, part) => {
+const assertSubset = (whole, part) => {
   part.forEach(key => {
-    assert.typeof(key, 'string');
     assert(
       whole.includes(key),
       X`key ${q(key)} was not one of the expected keys ${q(whole)}`,
@@ -23,38 +22,7 @@ export const assertSubset = (whole, part) => {
   });
 };
 
-/**
- * Assert that the keys of `record` are all in `allowedKeys`. If a key
- * of `record` is not in `allowedKeys`, throw an error. If a key in
- * `allowedKeys` is not a key of record, we do not throw an error.
- *
- * @param {string[]} allowedKeys
- * @param {Object} record
- */
-export const assertKeysAllowed = (allowedKeys, record) => {
-  const keys = Object.getOwnPropertyNames(record);
-  assertSubset(allowedKeys, keys);
-  // assert that there are no symbol properties.
-  assert(
-    Object.getOwnPropertySymbols(record).length === 0,
-    X`no symbol properties allowed`,
-  );
-};
-
-// eslint-disable-next-line jsdoc/require-returns-check
-/**
- * @param {DisplayInfo} allegedDisplayInfo
- * @returns {asserts allegedDisplayInfo is DisplayInfo}
- */
-function assertDisplayInfo(allegedDisplayInfo) {
-  assert(
-    passStyleOf(allegedDisplayInfo) === 'copyRecord',
-    X`A displayInfo can only be a pass-by-copy record: ${allegedDisplayInfo}`,
-  );
-  const displayInfoKeys = harden(['decimalPlaces', 'assetKind']);
-  assertKeysAllowed(displayInfoKeys, allegedDisplayInfo);
-}
-export { assertDisplayInfo };
+const displayInfoKeys = harden(['decimalPlaces', 'assetKind']);
 
 /**
  * @param {AdditionalDisplayInfo} allegedDisplayInfo
@@ -62,9 +30,18 @@ export { assertDisplayInfo };
  * @returns {DisplayInfo}
  */
 export const coerceDisplayInfo = (allegedDisplayInfo, assetKind) => {
-  const copyDisplayInfo = pureCopy(
-    harden({ ...allegedDisplayInfo, assetKind }),
-  );
-  assertDisplayInfo(copyDisplayInfo);
-  return copyDisplayInfo;
+  // We include this check for a better error message
+  assertRecord(allegedDisplayInfo, 'displayInfo');
+
+  // `pureCopy` ensures the resulting object is not a proxy. Note that
+  // `pureCopy` works in this case because displayInfo is a copyRecord
+  // that is pure data, meaning no remotables and no promises.
+  allegedDisplayInfo = pureCopy(allegedDisplayInfo);
+  const displayInfo = harden({ ...allegedDisplayInfo, assetKind });
+
+  assertSubset(displayInfoKeys, Object.keys(displayInfo));
+  if (displayInfo.decimalPlaces !== undefined) {
+    assert.typeof(displayInfo.decimalPlaces, 'number');
+  }
+  return displayInfo;
 };

--- a/packages/ERTP/src/issuerKit.js
+++ b/packages/ERTP/src/issuerKit.js
@@ -1,9 +1,9 @@
 // @ts-check
 // @jessie-check
 
-import { assert, details as X } from '@agoric/assert';
+import { assert } from '@agoric/assert';
 
-import { AssetKind } from './amountMath.js';
+import { AssetKind, assertAssetKind } from './amountMath.js';
 import { coerceDisplayInfo } from './displayInfo.js';
 import { makeBrand } from './brand.js';
 import { makePaymentLedger } from './paymentLedger.js';
@@ -20,13 +20,13 @@ const makeIssuerKit = (
   optShutdownWithFailure = undefined,
 ) => {
   assert.typeof(allegedName, 'string');
-  assert(
-    Object.values(AssetKind).includes(assetKind),
-    X`The assetKind ${assetKind} must be either AssetKind.NAT or AssetKind.SET`,
-  );
+  assertAssetKind(assetKind);
 
   // Add assetKind to displayInfo, or override if present
   const cleanDisplayInfo = coerceDisplayInfo(displayInfo, assetKind);
+  if (optShutdownWithFailure !== undefined) {
+    assert.typeof(optShutdownWithFailure, 'function');
+  }
 
   /**
    * We can define this function to use the in-scope `issuer` variable

--- a/packages/ERTP/src/mathHelpers/natMathHelpers.js
+++ b/packages/ERTP/src/mathHelpers/natMathHelpers.js
@@ -1,9 +1,10 @@
 // @ts-check
 
-import { Nat } from '@agoric/nat';
+import { Nat, isNat } from '@agoric/nat';
 
 import '../types.js';
 
+const { details: X } = assert;
 const empty = 0n;
 
 /**
@@ -19,7 +20,12 @@ const empty = 0n;
  * @type {NatMathHelpers}
  */
 const natMathHelpers = {
-  doCoerce: Nat,
+  doCoerce: nat => {
+    // TODO: tighten the definition of Nat in @agoric/nat to throw on `number`
+    assert.typeof(nat, 'bigint');
+    assert(isNat(nat), X`value ${nat} must be a natural number`);
+    return Nat(nat);
+  },
   doMakeEmpty: () => empty,
   doIsEmpty: nat => nat === empty,
   doIsGTE: (left, right) => left >= right,

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -3,7 +3,7 @@
 import { assert, details as X } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
 import { isPromise } from '@agoric/promise-kit';
-import { Far } from '@agoric/marshal';
+import { Far, assertArray } from '@agoric/marshal';
 import { makeWeakStore } from '@agoric/store';
 
 import { AmountMath } from './amountMath.js';
@@ -60,6 +60,8 @@ export const makePaymentLedger = (
    * which, if present, is supposed to be equal to the balance of the
    * payment. This helper function does that check.
    *
+   * Note: `amount` is user-supplied with no previous validation.
+   *
    * @param {Amount} paymentBalance
    * @param {Amount | undefined} amount
    * @returns {void}
@@ -80,7 +82,7 @@ export const makePaymentLedger = (
   const assertLivePayment = payment => {
     assert(
       paymentLedger.has(payment),
-      X`payment not found for ${allegedName}; got ${payment}`,
+      X`${payment} was not a live payment for brand ${brand}. It could be a used-up payment, a payment for another brand, or it might not be a payment at all.`,
     );
   };
 
@@ -89,7 +91,7 @@ export const makePaymentLedger = (
    * created and returned, with balances from `newPaymentBalances`.
    * Enforces that total assets are conserved.
    *
-   * Note that this is not the only operation that reallocates assets.
+   * Note that this is not the only operation that moves assets.
    * `purse.deposit` and `purse.withdraw` move assets between a purse and
    * a payment, and so must also enforce conservation there.
    *
@@ -97,9 +99,12 @@ export const makePaymentLedger = (
    * @param {Amount[]} newPaymentBalances
    * @returns {Payment[]}
    */
-  const reallocate = (payments, newPaymentBalances) => {
+  const moveAssets = (payments, newPaymentBalances) => {
+    assertArray(payments, 'payments');
+    assertArray(newPaymentBalances, 'newPaymentBalances');
+
     // There may be zero, one, or many payments as input to
-    // reallocate. We want to protect against someone passing in
+    // moveAssets. We want to protect against someone passing in
     // what appears to be multiple payments that turn out to actually
     // be the same payment (an aliasing issue). The `combine` method
     // legitimately needs to take in multiple payments, but we don't
@@ -109,9 +114,10 @@ export const makePaymentLedger = (
     if (payments.length > 1) {
       const antiAliasingStore = new Set();
       payments.forEach(payment => {
-        if (antiAliasingStore.has(payment)) {
-          throw Error('same payment seen twice');
-        }
+        assert(
+          !antiAliasingStore.has(payment),
+          `same payment ${payment} seen twice`,
+        );
         antiAliasingStore.add(payment);
       });
     }
@@ -181,24 +187,31 @@ export const makePaymentLedger = (
       assertLivePayment(srcPayment);
       const srcPaymentBalance = paymentLedger.get(srcPayment);
       assertAmountConsistent(srcPaymentBalance, optAmount);
-      // Note COMMIT POINT within reallocate.
-      const [payment] = reallocate([srcPayment], [srcPaymentBalance]);
+      // Note COMMIT POINT within moveAssets.
+      const [payment] = moveAssets(
+        harden([srcPayment]),
+        harden([srcPaymentBalance]),
+      );
       return payment;
     });
   };
 
   /** @type {IssuerCombine} */
   const combine = (fromPaymentsPArray, optTotalAmount = undefined) => {
+    assertArray(fromPaymentsPArray, 'fromPaymentsArray');
     // Payments in `fromPaymentsPArray` must be distinct. Alias
-    // checking is delegated to the `reallocate` function.
+    // checking is delegated to the `moveAssets` function.
     return Promise.all(fromPaymentsPArray).then(fromPaymentsArray => {
       fromPaymentsArray.every(assertLivePayment);
       const totalPaymentsBalance = fromPaymentsArray
         .map(paymentLedger.get)
         .reduce(add, emptyAmount);
       assertAmountConsistent(totalPaymentsBalance, optTotalAmount);
-      // Note COMMIT POINT within reallocate.
-      const [payment] = reallocate(fromPaymentsArray, [totalPaymentsBalance]);
+      // Note COMMIT POINT within moveAssets.
+      const [payment] = moveAssets(
+        harden(fromPaymentsArray),
+        harden([totalPaymentsBalance]),
+      );
       return payment;
     });
   };
@@ -211,10 +224,10 @@ export const makePaymentLedger = (
       assertLivePayment(srcPayment);
       const srcPaymentBalance = paymentLedger.get(srcPayment);
       const paymentAmountB = subtract(srcPaymentBalance, paymentAmountA);
-      // Note COMMIT POINT within reallocate.
-      const newPayments = reallocate(
-        [srcPayment],
-        [paymentAmountA, paymentAmountB],
+      // Note COMMIT POINT within moveAssets.
+      const newPayments = moveAssets(
+        harden([srcPayment]),
+        harden([paymentAmountA, paymentAmountB]),
       );
       return newPayments;
     });
@@ -224,9 +237,10 @@ export const makePaymentLedger = (
   const splitMany = (paymentP, amounts) => {
     return E.when(paymentP, srcPayment => {
       assertLivePayment(srcPayment);
+      assertArray(amounts, 'amounts');
       amounts = amounts.map(coerce);
-      // Note COMMIT POINT within reallocate.
-      const newPayments = reallocate([srcPayment], amounts);
+      // Note COMMIT POINT within moveAssets.
+      const newPayments = moveAssets(harden([srcPayment]), harden(amounts));
       return newPayments;
     });
   };
@@ -256,14 +270,13 @@ export const makePaymentLedger = (
     srcPayment,
     optAmount = undefined,
   ) => {
-    if (isPromise(srcPayment)) {
-      throw TypeError(
-        `deposit does not accept promises as first argument. Instead of passing the promise (deposit(paymentPromise)), consider unwrapping the promise first: E.when(paymentPromise, (actualPayment => deposit(actualPayment))`,
-      );
-    }
+    assert(
+      !isPromise(srcPayment),
+      `deposit does not accept promises as first argument. Instead of passing the promise (deposit(paymentPromise)), consider unwrapping the promise first: E.when(paymentPromise, (actualPayment => deposit(actualPayment))`,
+      TypeError,
+    );
     assertLivePayment(srcPayment);
     const srcPaymentBalance = paymentLedger.get(srcPayment);
-    // Note: this does not guarantee that optAmount itself is a valid stable amount
     assertAmountConsistent(srcPaymentBalance, optAmount);
     const newPurseBalance = add(srcPaymentBalance, currentBalance);
     try {
@@ -299,9 +312,8 @@ export const makePaymentLedger = (
 
     const payment = makePayment(allegedName, brand);
     try {
-      // COMMIT POINT
-      // Move the withdrawn assets from this purse into a new payment
-      // which is returned. Total assets must remain conserved.
+      // COMMIT POINT Move the withdrawn assets from this purse into
+      // payment. Total assets must remain conserved.
       updatePurseBalance(newPurseBalance);
       paymentLedger.init(payment, amount);
     } catch (err) {

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -3,7 +3,7 @@
 import { assert, details as X } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
 import { isPromise } from '@agoric/promise-kit';
-import { Far, assertArray } from '@agoric/marshal';
+import { Far, assertCopyArray } from '@agoric/marshal';
 import { makeWeakStore } from '@agoric/store';
 
 import { AmountMath } from './amountMath.js';
@@ -100,8 +100,8 @@ export const makePaymentLedger = (
    * @returns {Payment[]}
    */
   const moveAssets = (payments, newPaymentBalances) => {
-    assertArray(payments, 'payments');
-    assertArray(newPaymentBalances, 'newPaymentBalances');
+    assertCopyArray(payments, 'payments');
+    assertCopyArray(newPaymentBalances, 'newPaymentBalances');
 
     // There may be zero, one, or many payments as input to
     // moveAssets. We want to protect against someone passing in
@@ -198,7 +198,7 @@ export const makePaymentLedger = (
 
   /** @type {IssuerCombine} */
   const combine = (fromPaymentsPArray, optTotalAmount = undefined) => {
-    assertArray(fromPaymentsPArray, 'fromPaymentsArray');
+    assertCopyArray(fromPaymentsPArray, 'fromPaymentsArray');
     // Payments in `fromPaymentsPArray` must be distinct. Alias
     // checking is delegated to the `moveAssets` function.
     return Promise.all(fromPaymentsPArray).then(fromPaymentsArray => {
@@ -237,7 +237,7 @@ export const makePaymentLedger = (
   const splitMany = (paymentP, amounts) => {
     return E.when(paymentP, srcPayment => {
       assertLivePayment(srcPayment);
-      assertArray(amounts, 'amounts');
+      assertCopyArray(amounts, 'amounts');
       amounts = amounts.map(coerce);
       // Note COMMIT POINT within moveAssets.
       const newPayments = moveAssets(harden([srcPayment]), harden(amounts));

--- a/packages/ERTP/src/typeGuards.js
+++ b/packages/ERTP/src/typeGuards.js
@@ -1,64 +1,27 @@
 import { isNat } from '@agoric/nat';
-import { passStyleOf } from '@agoric/marshal';
-
-const { isFrozen } = Object;
-
-// A type guard predicate named `looksLikeFoo` tests that something seems to be
-// a Foo, produces static type info on the truthy path alleging that it is a
-// Foo, but does not validate that it is a well formed Foo. Names like `isFoo`
-// should be reserved for predicates that actually validate objects coming from
-// untrusted callers.
-//
-// The corresponding assertions would be `assertLooksLikeFoo` and `assertFoo`.
-// These produce the same static type info, but on the success path rather than
-// the truthy path.
+import { passStyleOf, isStructure } from '@agoric/marshal';
 
 /**
- * Non-validating type guard for SetValue
+ * Returns true if value is a Nat bigint.
  *
- * Used as a pre-validation check to select which validator
- * (mathHelpers) to use, and also used with assert to satisfy
- * Typescript checking
+ * @param {Value} value
+ * @returns {value is NatValue}
+ */
+const isNatValue = value => {
+  return typeof value === 'bigint' && isNat(value);
+};
+harden(isNatValue);
+
+/**
+ * Returns true if value is a pass by copy array structure. Does not
+ * check for duplicates. To check for duplicates, use setMathHelpers.coerce.
  *
  * @param {Value} value
  * @returns {value is SetValue}
  */
-export const looksLikeSetValue = value => Array.isArray(value);
+const isSetValue = value => {
+  return passStyleOf(value) === 'copyArray' && isStructure(value);
+};
+harden(isSetValue);
 
-/**
- * Non-validating type guard for NatValue.
- *
- * Used as a pre-validation check to select which validator
- * (mathHelpers) to use, and also used with assert to satisfy
- * Typescript checking
- *
- * @param {Value} value
- * @returns {value is NatValue}
- */
-export const looksLikeNatValue = value => isNat(value);
-
-/**
- * Call this for a validated answer (that in this case happens to be the same).
- *
- * @param {Value} value
- * @returns {value is NatValue}
- */
-export const isNatValue = looksLikeNatValue;
-
-/**
- * Non-validating type guard for Value.
- *
- * @param {Value} value
- * @returns {value is Value}
- */
-export const looksLikeValue = value =>
-  looksLikeSetValue(value) || looksLikeNatValue(value);
-
-/**
- * Non-validating type guard for Brand.
- *
- * @param {Brand} brand
- * @returns {brand is Brand}
- */
-export const looksLikeBrand = brand =>
-  isFrozen(brand) && passStyleOf(brand) === 'remotable';
+export { isNatValue, isSetValue };

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -46,27 +46,20 @@
  * This section blindly imitates what Endo's ses/src/error/types.js
  * does to express type overloaded methods.
  *
- * @callback AmountMakeBrandValue
+ * @callback AmountMake
  * @param {Brand} brand
  * @param {Value} allegedValue
  * @returns {Amount}
  *
- * @typedef {AmountMakeBrandValue} AmountMake
- *
- * @callback AmountCoerceBrandAmount
+ * @callback AmountCoerce
  * @param {Brand} brand
  * @param {Amount} allegedAmount
  * @returns {Amount}
  *
- * @typedef {AmountCoerceBrandAmount} AmountCoerce
- *
- * @callback AmountGetValueBrandAmount
+ * @callback AmountGetValue
  * @param {Brand} brand
  * @param {Amount} allegedAmount
  * @returns {Value}
- *
- *
- * @typedef {AmountGetValueBrandAmount} AmountGetValue
  */
 
 /**
@@ -302,7 +295,6 @@
 /**
  * @typedef {Object} AdditionalDisplayInfo
  *
- * Does not include `assetKind`, which is automatically added in MakeIssuerKit
  * @property {number=} decimalPlaces Tells the display software how
  *   many decimal places to move the decimal over to the left, or in
  *   other words, which position corresponds to whole numbers. We
@@ -313,6 +305,7 @@
  *   assets, should not be specified. The decimalPlaces property
  *   should be used for *display purposes only*. Any other use is an
  *   anti-pattern.
+ * @property {AssetKind=} assetKind
  */
 
 /**

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -51,51 +51,22 @@
  * @param {Value} allegedValue
  * @returns {Amount}
  *
- * TODO find out how to get this "deprecated" marking recognized,
- * or remove it.
- * @deprecated Use brand-first overload instead
- * @callback AmountMakeValueBrand
- * Please use the brand-first overload. The value-first overload
- * is deprecated and will go way.
- * @param {Value} brand
- * @param {Brand} allegedValue
- * @returns {Amount}
- *
- * @typedef {AmountMakeBrandValue & AmountMakeValueBrand} AmountMake
+ * @typedef {AmountMakeBrandValue} AmountMake
  *
  * @callback AmountCoerceBrandAmount
  * @param {Brand} brand
  * @param {Amount} allegedAmount
  * @returns {Amount}
  *
- * TODO find out how to get this "deprecated" marking recognized,
- * or remove it.
- * @deprecated Use brand-first overload instead
- * @callback AmountCoerceAmountBrand
- * Please use the brand-first overload. The amount-first overload
- * is deprecated and will go way.
- * @param {Amount} brand
- * @param {Brand} allegedAmount
- * @returns {Amount}
- *
- * @typedef {AmountCoerceBrandAmount & AmountCoerceAmountBrand} AmountCoerce
+ * @typedef {AmountCoerceBrandAmount} AmountCoerce
  *
  * @callback AmountGetValueBrandAmount
  * @param {Brand} brand
  * @param {Amount} allegedAmount
  * @returns {Value}
  *
- * TODO find out how to get this "deprecated" marking recognized,
- * or remove it.
- * @deprecated Use brand-first overload instead
- * @callback AmountGetValueAmountBrand
- * Please use the brand-first overload. The amount-first overload
- * is deprecated and will go way.
- * @param {Amount} brand
- * @param {Brand} allegedAmount
- * @returns {Value}
  *
- * @typedef {AmountGetValueBrandAmount & AmountGetValueAmountBrand} AmountGetValue
+ * @typedef {AmountGetValueBrandAmount} AmountGetValue
  */
 
 /**
@@ -110,19 +81,13 @@
  *
  * @property {AmountMake} make
  * Make an amount from a value by adding the brand.
- * Please use the brand-first overload. The value-first overload
- * is deprecated and will go way.
  *
  * @property {AmountCoerce} coerce
  * Make sure this amount is valid enough, and return a corresponding
  * valid amount if so.
- * Please use the brand-first overload. The amount-first overload
- * is deprecated and will go way.
  *
  * @property {AmountGetValue} getValue
  * Extract and return the value.
- * Please use the brand-first overload. The amount-first overload
- * is deprecated and will go way.
  *
  * @property {MakeEmpty} makeEmpty
  * Return the amount representing an empty amount. This is the
@@ -552,4 +517,10 @@
 
 /**
  * @typedef {MathHelpers<SetValue>} SetMathHelpers
+ */
+
+/**
+ * @callback AssertAssetKind
+ * @param {AssetKind} allegedAK
+ * @returns {void}
  */

--- a/packages/ERTP/test/unitTests/mathHelpers/test-setMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-setMathHelpers.js
@@ -18,39 +18,39 @@ const runSetMathHelpersTests = (t, [a, b, c], a2 = undefined) => {
 
   // make
   t.deepEqual(
-    m.make(mockBrand, [a]),
-    { brand: mockBrand, value: [a] },
+    m.make(mockBrand, harden([a])),
+    { brand: mockBrand, value: harden([a]) },
     `[a] is a valid set`,
   );
   t.deepEqual(
-    m.make(mockBrand, [a, b]),
-    { brand: mockBrand, value: [a, b] },
+    m.make(mockBrand, harden([a, b])),
+    { brand: mockBrand, value: harden([a, b]) },
     `[a, b] is a valid set`,
   );
   t.deepEqual(
-    m.make(mockBrand, []),
-    { brand: mockBrand, value: [] },
+    m.make(mockBrand, harden([])),
+    { brand: mockBrand, value: harden([]) },
     `[] is a valid set`,
   );
   t.throws(
-    () => m.make(mockBrand, [a, a]),
+    () => m.make(mockBrand, harden([a, a])),
     { message: /value has duplicates/ },
     `duplicates in make should throw`,
   );
   t.deepEqual(
-    m.make(mockBrand, ['a', 'b']),
-    { brand: mockBrand, value: ['a', 'b'] },
+    m.make(mockBrand, harden(['a', 'b'])),
+    { brand: mockBrand, value: harden(['a', 'b']) },
     'anything comparable is a valid element',
   );
   t.throws(
     // @ts-ignore deliberate invalid arguments for testing
     () => m.make(mockBrand, 'a'),
-    { message: /value .* must be a Nat or an array/ },
+    { message: 'value "a" must be a bigint or an array, not "string"' },
     'strings are not valid',
   );
   if (a2 !== undefined) {
     t.throws(
-      () => m.make(mockBrand, [a, a2]),
+      () => m.make(mockBrand, harden([a, a2])),
       { message: /value has duplicates/ },
       `data identity throws`,
     );
@@ -58,39 +58,39 @@ const runSetMathHelpersTests = (t, [a, b, c], a2 = undefined) => {
 
   // coerce
   t.deepEqual(
-    m.coerce(mockBrand, { brand: mockBrand, value: [a] }),
-    { brand: mockBrand, value: [a] },
+    m.coerce(mockBrand, harden({ brand: mockBrand, value: harden([a]) })),
+    { brand: mockBrand, value: harden([a]) },
     `[a] is a valid set`,
   );
   t.deepEqual(
-    m.coerce(mockBrand, { brand: mockBrand, value: [a, b] }),
-    { brand: mockBrand, value: [a, b] },
+    m.coerce(mockBrand, harden({ brand: mockBrand, value: harden([a, b]) })),
+    { brand: mockBrand, value: harden([a, b]) },
     `[a, b] is a valid set`,
   );
   t.deepEqual(
-    m.coerce(mockBrand, { brand: mockBrand, value: [] }),
-    { brand: mockBrand, value: [] },
+    m.coerce(mockBrand, harden({ brand: mockBrand, value: harden([]) })),
+    { brand: mockBrand, value: harden([]) },
     `[] is a valid set`,
   );
   t.throws(
-    () => m.coerce(mockBrand, m.make(mockBrand, [a, a])),
+    () => m.coerce(mockBrand, m.make(mockBrand, harden([a, a]))),
     { message: /value has duplicates/ },
     `duplicates in coerce should throw`,
   );
   t.deepEqual(
-    m.coerce(mockBrand, m.make(mockBrand, ['a', 'b'])),
-    { brand: mockBrand, value: ['a', 'b'] },
+    m.coerce(mockBrand, m.make(mockBrand, harden(['a', 'b']))),
+    { brand: mockBrand, value: harden(['a', 'b']) },
     'anything comparable is a valid element',
   );
   t.throws(
     // @ts-ignore deliberate invalid arguments for testing
-    () => m.coerce(mockBrand, { brand: mockBrand, value: 'a' }),
-    { message: /value .* must be a Nat or an array/ },
+    () => m.coerce(mockBrand, harden({ brand: mockBrand, value: 'a' })),
+    { message: 'value "a" must be a bigint or an array, not "string"' },
     'strings are not valid',
   );
   if (a2 !== undefined) {
     t.throws(
-      () => m.coerce(mockBrand, { brand: mockBrand, value: [a, a2] }),
+      () => m.coerce(mockBrand, harden({ brand: mockBrand, value: [a, a2] })),
       { message: /value has duplicates/ },
       `data identity throws`,
     );
@@ -98,7 +98,7 @@ const runSetMathHelpersTests = (t, [a, b, c], a2 = undefined) => {
 
   // m.getValue(
   t.deepEqual(
-    m.getValue(mockBrand, { brand: mockBrand, value: [a] }),
+    m.getValue(mockBrand, harden({ brand: mockBrand, value: [a] })),
     [a],
     `m.getValue( of m.make([a]) is [a]`,
   );
@@ -106,34 +106,40 @@ const runSetMathHelpersTests = (t, [a, b, c], a2 = undefined) => {
   // makeEmpty
   t.deepEqual(
     m.makeEmpty(mockBrand, AssetKind.SET),
-    { brand: mockBrand, value: [] },
+    { brand: mockBrand, value: harden([]) },
     `empty is []`,
   );
 
   // isEmpty
   t.assert(
-    m.isEmpty(m.make(mockBrand, []), mockBrand),
+    m.isEmpty(m.make(mockBrand, harden([])), mockBrand),
     `m.isEmpty([]) is true`,
   );
   t.throws(
     // @ts-ignore deliberate invalid arguments for testing
-    () => m.isEmpty({ brand: mockBrand, value: harden({}) }),
-    { message: /value .* must be a Nat or an array/ },
+    () => m.isEmpty(harden({ brand: mockBrand, value: {} })),
+    { message: 'value {} must be a bigint or an array, not "copyRecord"' },
     `m.isEmpty({}) throws`,
   );
-  t.falsy(m.isEmpty(m.make(mockBrand, ['abc'])), `m.isEmpty(['abc']) is false`);
-  t.falsy(m.isEmpty(m.make(mockBrand, [a])), `m.isEmpty([a]) is false`);
+  t.falsy(
+    m.isEmpty(m.make(mockBrand, harden(['abc']))),
+    `m.isEmpty(['abc']) is false`,
+  );
+  t.falsy(m.isEmpty(m.make(mockBrand, harden([a]))), `m.isEmpty([a]) is false`);
   t.throws(
-    () => m.isEmpty({ brand: mockBrand, value: [a, a] }),
+    () => m.isEmpty(harden({ brand: mockBrand, value: harden([a, a]) })),
     { message: /value has duplicates/ },
     `duplicates in value in isEmpty throw because of coercion`,
   );
-  t.assert(m.isEmpty(m.make(mockBrand, [])), `m.isEmpty([]) is true`);
-  t.falsy(m.isEmpty(m.make(mockBrand, ['abc'])), `m.isEmpty(['abc']) is false`);
-  t.falsy(m.isEmpty(m.make(mockBrand, [a])), `m.isEmpty([a]) is false`);
+  t.assert(m.isEmpty(m.make(mockBrand, harden([]))), `m.isEmpty([]) is true`);
+  t.falsy(
+    m.isEmpty(m.make(mockBrand, harden(['abc']))),
+    `m.isEmpty(['abc']) is false`,
+  );
+  t.falsy(m.isEmpty(m.make(mockBrand, harden([a]))), `m.isEmpty([a]) is false`);
   if (a2 !== undefined) {
     t.throws(
-      () => m.isEmpty({ brand: mockBrand, value: [a, a2] }),
+      () => m.isEmpty(harden({ brand: mockBrand, value: harden([a, a2]) })),
       { message: /value has duplicates/ },
       `data identity throws`,
     );
@@ -143,8 +149,8 @@ const runSetMathHelpersTests = (t, [a, b, c], a2 = undefined) => {
   t.throws(
     () =>
       m.isGTE(
-        { brand: mockBrand, value: [a, a] },
-        { brand: mockBrand, value: [b] },
+        harden({ brand: mockBrand, value: [a, a] }),
+        harden({ brand: mockBrand, value: [b] }),
       ),
     { message: /value has duplicates/ },
     `duplicates in the left of isGTE should throw`,
@@ -152,27 +158,30 @@ const runSetMathHelpersTests = (t, [a, b, c], a2 = undefined) => {
   t.throws(
     () =>
       m.isGTE(
-        { brand: mockBrand, value: [a] },
-        { brand: mockBrand, value: [b, b] },
+        harden({ brand: mockBrand, value: [a] }),
+        harden({ brand: mockBrand, value: [b, b] }),
       ),
     { message: /value has duplicates/ },
     `duplicates in the right of isGTE should throw`,
   );
   t.assert(
-    m.isGTE({ brand: mockBrand, value: [a] }, { brand: mockBrand, value: [a] }),
+    m.isGTE(
+      harden({ brand: mockBrand, value: [a] }),
+      harden({ brand: mockBrand, value: [a] }),
+    ),
     `overlap between left and right of isGTE should not throw`,
   );
   t.assert(
     m.isGTE(
-      { brand: mockBrand, value: [a, b] },
-      { brand: mockBrand, value: [b] },
+      harden({ brand: mockBrand, value: [a, b] }),
+      harden({ brand: mockBrand, value: [b] }),
     ),
     '[a, b] is GTE [b]',
   );
   t.falsy(
     m.isGTE(
-      { brand: mockBrand, value: [b] },
-      { brand: mockBrand, value: [b, a] },
+      harden({ brand: mockBrand, value: [b] }),
+      harden({ brand: mockBrand, value: [b, a] }),
     ),
     '[b] does not include [b, a]',
   );
@@ -180,8 +189,8 @@ const runSetMathHelpersTests = (t, [a, b, c], a2 = undefined) => {
     t.throws(
       () =>
         m.isGTE(
-          { brand: mockBrand, value: [a, a2] },
-          { brand: mockBrand, value: [b] },
+          harden({ brand: mockBrand, value: [a, a2] }),
+          harden({ brand: mockBrand, value: [b] }),
         ),
       { message: /value has duplicates/ },
       `data identity throws`,
@@ -192,8 +201,8 @@ const runSetMathHelpersTests = (t, [a, b, c], a2 = undefined) => {
   t.throws(
     () =>
       m.isEqual(
-        { brand: mockBrand, value: [a, a] },
-        { brand: mockBrand, value: [a] },
+        harden({ brand: mockBrand, value: [a, a] }),
+        harden({ brand: mockBrand, value: [a] }),
       ),
     { message: /value has duplicates/ },
     `duplicates in left of isEqual should throw`,
@@ -201,30 +210,30 @@ const runSetMathHelpersTests = (t, [a, b, c], a2 = undefined) => {
   t.throws(
     () =>
       m.isEqual(
-        { brand: mockBrand, value: [a] },
-        { brand: mockBrand, value: [a, a] },
+        harden({ brand: mockBrand, value: [a] }),
+        harden({ brand: mockBrand, value: [a, a] }),
       ),
     { message: /value has duplicates/ },
     `duplicates in right of isEqual should throw`,
   );
   t.assert(
     m.isEqual(
-      { brand: mockBrand, value: [a] },
-      { brand: mockBrand, value: [a] },
+      harden({ brand: mockBrand, value: [a] }),
+      harden({ brand: mockBrand, value: [a] }),
     ),
     `overlap between left and right of isEqual is ok`,
   );
   t.assert(
     m.isEqual(
-      { brand: mockBrand, value: [b, a, c] },
-      { brand: mockBrand, value: [a, c, b] },
+      harden({ brand: mockBrand, value: [b, a, c] }),
+      harden({ brand: mockBrand, value: [a, c, b] }),
     ),
     `order doesn't matter`,
   );
   t.falsy(
     m.isEqual(
-      { brand: mockBrand, value: [b, c] },
-      { brand: mockBrand, value: [b, a] },
+      harden({ brand: mockBrand, value: [b, c] }),
+      harden({ brand: mockBrand, value: [b, a] }),
     ),
     `not equal`,
   );
@@ -232,8 +241,8 @@ const runSetMathHelpersTests = (t, [a, b, c], a2 = undefined) => {
     t.throws(
       () =>
         m.isEqual(
-          { brand: mockBrand, value: [a, a2] },
-          { brand: mockBrand, value: [a] },
+          harden({ brand: mockBrand, value: [a, a2] }),
+          harden({ brand: mockBrand, value: [a] }),
         ),
       { message: /value has duplicates/ },
       `data identity throws`,
@@ -244,8 +253,8 @@ const runSetMathHelpersTests = (t, [a, b, c], a2 = undefined) => {
   t.throws(
     () =>
       m.add(
-        { brand: mockBrand, value: [a, a] },
-        { brand: mockBrand, value: [b] },
+        harden({ brand: mockBrand, value: [a, a] }),
+        harden({ brand: mockBrand, value: [b] }),
       ),
     { message: /value has duplicates/ },
     `duplicates in left of add should throw`,
@@ -253,25 +262,34 @@ const runSetMathHelpersTests = (t, [a, b, c], a2 = undefined) => {
   t.throws(
     () =>
       m.add(
-        { brand: mockBrand, value: [a] },
-        { brand: mockBrand, value: [b, b] },
+        harden({ brand: mockBrand, value: [a] }),
+        harden({ brand: mockBrand, value: [b, b] }),
       ),
     { message: /value has duplicates/ },
     `duplicates in right of add should throw`,
   );
   t.throws(
     () =>
-      m.add({ brand: mockBrand, value: [a] }, { brand: mockBrand, value: [a] }),
+      m.add(
+        harden({ brand: mockBrand, value: [a] }),
+        harden({ brand: mockBrand, value: [a] }),
+      ),
     { message: /value has duplicates/ },
     `overlap between left and right of add should throw`,
   );
   t.deepEqual(
-    m.add({ brand: mockBrand, value: [] }, { brand: mockBrand, value: [b, c] }),
+    m.add(
+      harden({ brand: mockBrand, value: [] }),
+      harden({ brand: mockBrand, value: [b, c] }),
+    ),
     { brand: mockBrand, value: [b, c] },
     `anything + identity stays same`,
   );
   t.deepEqual(
-    m.add({ brand: mockBrand, value: [b, c] }, { brand: mockBrand, value: [] }),
+    m.add(
+      harden({ brand: mockBrand, value: [b, c] }),
+      harden({ brand: mockBrand, value: [] }),
+    ),
     { brand: mockBrand, value: [b, c] },
     `anything + identity stays same`,
   );
@@ -279,8 +297,8 @@ const runSetMathHelpersTests = (t, [a, b, c], a2 = undefined) => {
     t.throws(
       () =>
         m.add(
-          { brand: mockBrand, value: [a, a2] },
-          { brand: mockBrand, value: [b] },
+          harden({ brand: mockBrand, value: [a, a2] }),
+          harden({ brand: mockBrand, value: [b] }),
         ),
       { message: /value has duplicates/ },
       `data identity throws`,
@@ -291,8 +309,8 @@ const runSetMathHelpersTests = (t, [a, b, c], a2 = undefined) => {
   t.throws(
     () =>
       m.subtract(
-        { brand: mockBrand, value: [a, a] },
-        { brand: mockBrand, value: [b] },
+        harden({ brand: mockBrand, value: [a, a] }),
+        harden({ brand: mockBrand, value: [b] }),
       ),
     { message: /value has duplicates/ },
     `duplicates in left of subtract should throw`,
@@ -300,16 +318,16 @@ const runSetMathHelpersTests = (t, [a, b, c], a2 = undefined) => {
   t.throws(
     () =>
       m.subtract(
-        { brand: mockBrand, value: [a] },
-        { brand: mockBrand, value: [b, b] },
+        harden({ brand: mockBrand, value: [a] }),
+        harden({ brand: mockBrand, value: [b, b] }),
       ),
     { message: /value has duplicates/ },
     `duplicates in right of subtract should throw`,
   );
   t.deepEqual(
     m.subtract(
-      { brand: mockBrand, value: [a] },
-      { brand: mockBrand, value: [a] },
+      harden({ brand: mockBrand, value: [a] }),
+      harden({ brand: mockBrand, value: [a] }),
     ),
     { brand: mockBrand, value: [] },
     `overlap between left and right of subtract should not throw`,
@@ -317,24 +335,24 @@ const runSetMathHelpersTests = (t, [a, b, c], a2 = undefined) => {
   t.throws(
     () =>
       m.subtract(
-        { brand: mockBrand, value: [a, b] },
-        { brand: mockBrand, value: [c] },
+        harden({ brand: mockBrand, value: [a, b] }),
+        harden({ brand: mockBrand, value: [c] }),
       ),
     { message: /was not in left/ },
     `elements in right but not in left of subtract should throw`,
   );
   t.deepEqual(
     m.subtract(
-      { brand: mockBrand, value: [b, c] },
-      { brand: mockBrand, value: [] },
+      harden({ brand: mockBrand, value: [b, c] }),
+      harden({ brand: mockBrand, value: [] }),
     ),
     { brand: mockBrand, value: [b, c] },
     `anything - identity stays same`,
   );
   t.deepEqual(
     m.subtract(
-      { brand: mockBrand, value: [b, c] },
-      { brand: mockBrand, value: [b] },
+      harden({ brand: mockBrand, value: [b, c] }),
+      harden({ brand: mockBrand, value: [b] }),
     ),
     { brand: mockBrand, value: [c] },
     `b, c - b is c`,
@@ -343,8 +361,11 @@ const runSetMathHelpersTests = (t, [a, b, c], a2 = undefined) => {
     t.throws(
       () =>
         m.subtract(
-          { brand: mockBrand, value: [a, a2] },
-          { brand: mockBrand, value: [b] },
+          harden({ brand: mockBrand, value: [a, a2] }),
+          harden({
+            brand: mockBrand,
+            value: [b],
+          }),
         ),
       { message: /value has duplicates/ },
       `data identity throws`,

--- a/packages/ERTP/test/unitTests/mathHelpers/test-strSetMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-strSetMathHelpers.js
@@ -10,19 +10,22 @@ import { mockBrand } from './mockBrand.js';
 // correctly.
 
 test('set with strings make', t => {
-  t.notThrows(() => m.make(mockBrand, ['1']), `['1'] is a valid string array`);
   t.notThrows(
-    () => m.make(mockBrand, [6]),
+    () => m.make(mockBrand, harden(['1'])),
+    `['1'] is a valid string array`,
+  );
+  t.notThrows(
+    () => m.make(mockBrand, harden([6])),
     `[6] is a valid set even though it isn't a string`,
   );
   t.throws(
     // @ts-ignore deliberate invalid arguments for testing
     () => m.make(mockBrand, 'abc'),
-    { message: /value .* must be a Nat or an array/ },
+    { message: 'value "abc" must be a bigint or an array, not "string"' },
     `'abc' is not a valid string array`,
   );
   t.throws(
-    () => m.make(mockBrand, ['a', 'a']),
+    () => m.make(mockBrand, harden(['a', 'a'])),
     { message: /value has duplicates/ },
     `duplicates in make throw`,
   );
@@ -30,46 +33,52 @@ test('set with strings make', t => {
 
 test('set with strings coerce', t => {
   t.deepEqual(
-    m.coerce(mockBrand, { brand: mockBrand, value: ['1'] }),
+    m.coerce(mockBrand, harden({ brand: mockBrand, value: ['1'] })),
     { brand: mockBrand, value: ['1'] },
     `coerce({ brand, value: ['1']}) is a valid amount`,
   );
   t.notThrows(
-    () => m.coerce(mockBrand, { brand: mockBrand, value: [6] }),
+    () => m.coerce(mockBrand, harden({ brand: mockBrand, value: [6] })),
     `[6] is a valid set`,
   );
   t.throws(
     // @ts-ignore deliberate invalid arguments for testing
-    () => m.coerce(mockBrand, { brand: mockBrand, value: '6' }),
-    { message: /value .* must be a Nat or an array/ },
+    () => m.coerce(mockBrand, harden({ brand: mockBrand, value: '6' })),
+    { message: 'value "6" must be a bigint or an array, not "string"' },
     `'6' is not a valid array`,
   );
   t.throws(
-    () => m.coerce(mockBrand, { brand: mockBrand, value: ['a', 'a'] }),
+    () => m.coerce(mockBrand, harden({ brand: mockBrand, value: ['a', 'a'] })),
     { message: /value has duplicates/ },
     `duplicates should throw`,
   );
 });
 
 test('set with strings getValue', t => {
-  t.deepEqual(m.getValue(mockBrand, { brand: mockBrand, value: ['1'] }), ['1']);
-  t.deepEqual(m.getValue(mockBrand, m.make(mockBrand, ['1'])), ['1']);
+  t.deepEqual(
+    m.getValue(mockBrand, harden({ brand: mockBrand, value: ['1'] })),
+    ['1'],
+  );
+  t.deepEqual(m.getValue(mockBrand, m.make(mockBrand, harden(['1']))), ['1']);
 });
 
 test('set with strings makeEmpty', t => {
   t.deepEqual(
     m.makeEmpty(mockBrand, AssetKind.SET),
-    { brand: mockBrand, value: [] },
+    harden({ brand: mockBrand, value: [] }),
     `empty is []`,
   );
 
-  t.assert(m.isEmpty({ brand: mockBrand, value: [] }), `isEmpty([]) is true`);
+  t.assert(
+    m.isEmpty(harden({ brand: mockBrand, value: [] })),
+    `isEmpty([])) is true`,
+  );
   t.falsy(
-    m.isEmpty({ brand: mockBrand, value: ['abc'] }),
+    m.isEmpty(harden({ brand: mockBrand, value: ['abc'] })),
     `isEmpty(['abc']) is false`,
   );
   t.throws(
-    () => m.isEmpty({ brand: mockBrand, value: ['a', 'a'] }),
+    () => m.isEmpty(harden({ brand: mockBrand, value: ['a', 'a'] })),
     { message: /value has duplicates: .* and .*/ },
     `duplicates in isEmpty throw`,
   );
@@ -79,8 +88,8 @@ test('set with strings isGTE', t => {
   t.throws(
     () =>
       m.isGTE(
-        { brand: mockBrand, value: ['a', 'a'] },
-        { brand: mockBrand, value: ['b'] },
+        harden({ brand: mockBrand, value: ['a', 'a'] }),
+        harden({ brand: mockBrand, value: ['b'] }),
       ),
     null,
     `duplicates in the left of isGTE should throw`,
@@ -88,30 +97,30 @@ test('set with strings isGTE', t => {
   t.throws(
     () =>
       m.isGTE(
-        { brand: mockBrand, value: ['a'] },
-        { brand: mockBrand, value: ['b', 'b'] },
+        harden({ brand: mockBrand, value: ['a'] }),
+        harden({ brand: mockBrand, value: ['b', 'b'] }),
       ),
     null,
     `duplicates in the right of isGTE should throw`,
   );
   t.assert(
     m.isGTE(
-      { brand: mockBrand, value: ['a'] },
-      { brand: mockBrand, value: ['a'] },
+      harden({ brand: mockBrand, value: ['a'] }),
+      harden({ brand: mockBrand, value: ['a'] }),
     ),
     `overlap between left and right of isGTE should not throw`,
   );
   t.assert(
     m.isGTE(
-      { brand: mockBrand, value: ['a', 'b'] },
-      { brand: mockBrand, value: ['a'] },
+      harden({ brand: mockBrand, value: ['a', 'b'] }),
+      harden({ brand: mockBrand, value: ['a'] }),
     ),
     `['a', 'b'] is gte to ['a']`,
   );
   t.falsy(
     m.isGTE(
-      { brand: mockBrand, value: ['a'] },
-      { brand: mockBrand, value: ['b'] },
+      harden({ brand: mockBrand, value: ['a'] }),
+      harden({ brand: mockBrand, value: ['b'] }),
     ),
     `['a'] is not gte to ['b']`,
   );
@@ -121,8 +130,8 @@ test('set with strings isEqual', t => {
   t.throws(
     () =>
       m.isEqual(
-        { brand: mockBrand, value: ['a', 'a'] },
-        { brand: mockBrand, value: ['a'] },
+        harden({ brand: mockBrand, value: ['a', 'a'] }),
+        harden({ brand: mockBrand, value: ['a'] }),
       ),
     { message: /value has duplicates/ },
     `duplicates in left of isEqual should throw`,
@@ -130,30 +139,30 @@ test('set with strings isEqual', t => {
   t.throws(
     () =>
       m.isEqual(
-        { brand: mockBrand, value: ['a'] },
-        { brand: mockBrand, value: ['a', 'a'] },
+        harden({ brand: mockBrand, value: ['a'] }),
+        harden({ brand: mockBrand, value: ['a', 'a'] }),
       ),
     { message: /value has duplicates/ },
     `duplicates in right of isEqual should throw`,
   );
   t.assert(
     m.isEqual(
-      { brand: mockBrand, value: ['a'] },
-      { brand: mockBrand, value: ['a'] },
+      harden({ brand: mockBrand, value: ['a'] }),
+      harden({ brand: mockBrand, value: ['a'] }),
     ),
     `overlap between left and right of isEqual is ok`,
   );
   t.assert(
     m.isEqual(
-      { brand: mockBrand, value: ['a', 'b'] },
-      { brand: mockBrand, value: ['b', 'a'] },
+      harden({ brand: mockBrand, value: ['a', 'b'] }),
+      harden({ brand: mockBrand, value: ['b', 'a'] }),
     ),
     `['a', 'b'] equals ['b', 'a']`,
   );
   t.falsy(
     m.isEqual(
-      { brand: mockBrand, value: ['a'] },
-      { brand: mockBrand, value: ['b'] },
+      harden({ brand: mockBrand, value: ['a'] }),
+      harden({ brand: mockBrand, value: ['b'] }),
     ),
     `['a'] does not equal ['b']`,
   );
@@ -163,8 +172,8 @@ test('set with strings add', t => {
   t.throws(
     () =>
       m.add(
-        { brand: mockBrand, value: ['a', 'a'] },
-        { brand: mockBrand, value: ['b'] },
+        harden({ brand: mockBrand, value: ['a', 'a'] }),
+        harden({ brand: mockBrand, value: ['b'] }),
       ),
     { message: /value has duplicates/ },
     `duplicates in left of add should throw`,
@@ -172,8 +181,8 @@ test('set with strings add', t => {
   t.throws(
     () =>
       m.add(
-        { brand: mockBrand, value: ['a'] },
-        { brand: mockBrand, value: ['b', 'b'] },
+        harden({ brand: mockBrand, value: ['a'] }),
+        harden({ brand: mockBrand, value: ['b', 'b'] }),
       ),
     { message: /value has duplicates/ },
     `duplicates in right of add should throw`,
@@ -181,18 +190,18 @@ test('set with strings add', t => {
   t.throws(
     () =>
       m.add(
-        { brand: mockBrand, value: ['a'] },
-        { brand: mockBrand, value: ['a'] },
+        harden({ brand: mockBrand, value: ['a'] }),
+        harden({ brand: mockBrand, value: ['a'] }),
       ),
     { message: /value has duplicates: .* and .*/ },
     `overlap between left and right of add should throw`,
   );
   t.deepEqual(
     m.add(
-      { brand: mockBrand, value: ['a'] },
-      { brand: mockBrand, value: ['b'] },
+      harden({ brand: mockBrand, value: ['a'] }),
+      harden({ brand: mockBrand, value: ['b'] }),
     ),
-    { brand: mockBrand, value: ['a', 'b'] },
+    { brand: mockBrand, value: harden(['a', 'b']) },
     `['a'] + ['b'] = ['a', 'b']`,
   );
 });
@@ -201,8 +210,8 @@ test('set with strings subtract', t => {
   t.throws(
     () =>
       m.subtract(
-        { brand: mockBrand, value: ['a', 'a'] },
-        { brand: mockBrand, value: ['b'] },
+        harden({ brand: mockBrand, value: ['a', 'a'] }),
+        harden({ brand: mockBrand, value: ['b'] }),
       ),
     { message: /value has duplicates/ },
     `duplicates in left of subtract should throw`,
@@ -210,16 +219,16 @@ test('set with strings subtract', t => {
   t.throws(
     () =>
       m.subtract(
-        { brand: mockBrand, value: ['a'] },
-        { brand: mockBrand, value: ['b', 'b'] },
+        harden({ brand: mockBrand, value: ['a'] }),
+        harden({ brand: mockBrand, value: ['b', 'b'] }),
       ),
     { message: /value has duplicates/ },
     `duplicates in right of subtract should throw`,
   );
   t.deepEqual(
     m.subtract(
-      { brand: mockBrand, value: ['a'] },
-      { brand: mockBrand, value: ['a'] },
+      harden({ brand: mockBrand, value: ['a'] }),
+      harden({ brand: mockBrand, value: ['a'] }),
     ),
     { brand: mockBrand, value: [] },
     `overlap between left and right of subtract should not throw`,
@@ -227,16 +236,16 @@ test('set with strings subtract', t => {
   t.throws(
     () =>
       m.subtract(
-        { brand: mockBrand, value: ['a', 'b'] },
-        { brand: mockBrand, value: ['c'] },
+        harden({ brand: mockBrand, value: ['a', 'b'] }),
+        harden({ brand: mockBrand, value: ['c'] }),
       ),
     { message: /right element .* was not in left/ },
     `elements in right but not in left of subtract should throw`,
   );
   t.deepEqual(
     m.subtract(
-      { brand: mockBrand, value: ['a', 'b'] },
-      { brand: mockBrand, value: ['a'] },
+      harden({ brand: mockBrand, value: ['a', 'b'] }),
+      harden({ brand: mockBrand, value: ['a'] }),
     ),
     { brand: mockBrand, value: ['b'] },
     `['a', 'b'] - ['a'] = ['a']`,

--- a/packages/ERTP/test/unitTests/test-inputValidation.js
+++ b/packages/ERTP/test/unitTests/test-inputValidation.js
@@ -34,18 +34,21 @@ test('makeIssuerKit bad displayInfo.decimalPlaces', async t => {
 });
 
 test('makeIssuerKit bad displayInfo.assetKind', async t => {
-  // The bad assetKind gets silently overridden
-  const { issuer } = makeIssuerKit(
-    'myTokens',
-    AssetKind.NAT,
-    // @ts-ignore Intentional wrong type for testing
-    harden({
-      assetKind: 'something',
-    }),
+  t.throws(
+    () =>
+      makeIssuerKit(
+        'myTokens',
+        AssetKind.NAT,
+        // @ts-ignore Intentional wrong type for testing
+        harden({
+          assetKind: 'something',
+        }),
+      ),
+    {
+      message:
+        'displayInfo.assetKind was present ("something") and did not match the assetKind argument ("nat")',
+    },
   );
-  t.deepEqual(issuer.getDisplayInfo(), {
-    assetKind: 'nat',
-  });
 });
 
 test('makeIssuerKit bad displayInfo.whatever', async t => {

--- a/packages/ERTP/test/unitTests/test-inputValidation.js
+++ b/packages/ERTP/test/unitTests/test-inputValidation.js
@@ -1,0 +1,177 @@
+// @ts-check
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+
+import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
+import { AssetKind, makeIssuerKit, AmountMath } from '../../src/index.js';
+
+test('makeIssuerKit bad allegedName', async t => {
+  // @ts-ignore Intentional wrong type for testing
+  t.throws(() => makeIssuerKit({}), { message: `{} must be a string` });
+});
+
+test('makeIssuerKit bad assetKind', async t => {
+  // @ts-ignore Intentional wrong type for testing
+  t.throws(() => makeIssuerKit('myTokens', 'somethingWrong'), {
+    message: `The assetKind "somethingWrong" must be either AssetKind.NAT or AssetKind.SET`,
+  });
+});
+
+test('makeIssuerKit bad displayInfo.decimalPlaces', async t => {
+  t.throws(
+    () =>
+      makeIssuerKit(
+        'myTokens',
+        AssetKind.NAT,
+        // @ts-ignore Intentional wrong type for testing
+        harden({ decimalPlaces: 'hello' }),
+      ),
+    {
+      message: `"hello" must be a number`,
+    },
+  );
+});
+
+test('makeIssuerKit bad displayInfo.assetKind', async t => {
+  // The bad assetKind gets silently overridden
+  const { issuer } = makeIssuerKit(
+    'myTokens',
+    AssetKind.NAT,
+    // @ts-ignore Intentional wrong type for testing
+    harden({
+      assetKind: 'something',
+    }),
+  );
+  t.deepEqual(issuer.getDisplayInfo(), {
+    assetKind: 'nat',
+  });
+});
+
+test('makeIssuerKit bad displayInfo.whatever', async t => {
+  t.throws(
+    () =>
+      makeIssuerKit(
+        'myTokens',
+        AssetKind.NAT,
+        // @ts-ignore Intentional wrong type for testing
+        harden({
+          whatever: 'something',
+        }),
+      ),
+    {
+      message:
+        'key "whatever" was not one of the expected keys ["decimalPlaces","assetKind"]',
+    },
+  );
+});
+
+test('makeIssuerKit malicious displayInfo', async t => {
+  t.throws(
+    () =>
+      makeIssuerKit(
+        'myTokens',
+        AssetKind.NAT,
+        // @ts-ignore Intentional wrong type for testing
+        Far('malicious', { doesSomething: () => {} }),
+      ),
+    {
+      message:
+        '"displayInfo" "[Alleged: malicious]" must be a pass-by-copy record, not "remotable"',
+    },
+  );
+});
+
+// Note: because optShutdownWithFailure should never be able to be
+// reached, we can't easily test that pathway.
+test('makeIssuerKit bad optShutdownWithFailure', async t => {
+  t.throws(
+    // @ts-ignore Intentional wrong type for testing
+    () => makeIssuerKit('myTokens', AssetKind.NAT, undefined, 'not a function'),
+    {
+      message: '"not a function" must be a function',
+    },
+  );
+});
+
+test('brand.isMyIssuer bad issuer', async t => {
+  const { brand } = makeIssuerKit('myTokens');
+  // @ts-ignore Intentional wrong type for testing
+  const result = await brand.isMyIssuer('not an issuer');
+  t.false(result);
+});
+
+// Tested in the context of an issuer.claim call, as assertLivePayment is not exported
+test('assertLivePayment', async t => {
+  const { issuer, mint, brand } = makeIssuerKit('fungible');
+  const { mint: mintB, brand: brandB } = makeIssuerKit('fungibleB');
+
+  const paymentB = E(mintB).mintPayment(AmountMath.make(brandB, 837n));
+
+  // payment is of the wrong brand
+  await t.throwsAsync(() => E(issuer).claim(paymentB), {
+    message:
+      '"[Alleged: fungibleB payment]" was not a live payment for brand "[Alleged: fungible brand]". It could be a used-up payment, a payment for another brand, or it might not be a payment at all.',
+  });
+
+  // payment is used up
+  const payment = E(mint).mintPayment(AmountMath.make(brand, 10n));
+  // use up payment
+  await E(issuer).claim(payment);
+
+  await t.throwsAsync(() => E(issuer).claim(payment), {
+    message:
+      '"[Alleged: fungible payment]" was not a live payment for brand "[Alleged: fungible brand]". It could be a used-up payment, a payment for another brand, or it might not be a payment at all.',
+  });
+});
+
+test('issuer.combine bad payments array', async t => {
+  const { issuer } = makeIssuerKit('fungible');
+  const notAnArray = {
+    length: 2,
+    split: () => {},
+  };
+  // @ts-ignore Intentional wrong type for testing
+  await t.throwsAsync(() => E(issuer).combine(notAnArray), {
+    message:
+      'Cannot pass non-frozen objects like {"length":2,"split":"[Function split]"}. Use harden()',
+  });
+
+  const notAnArray2 = Far('notAnArray2', {
+    length: () => 2,
+    split: () => {},
+  });
+  // @ts-ignore Intentional wrong type for testing
+  await t.throwsAsync(() => E(issuer).combine(notAnArray2), {
+    message:
+      '"fromPaymentsArray" "[Alleged: notAnArray2]" must be a pass-by-copy array, not "remotable"',
+  });
+});
+
+test('amount with accessor properties', async t => {
+  const { brand } = makeIssuerKit('token');
+  const makeAmount = () => {
+    const amount = { brand };
+    let checked = false;
+    // Create an amount where the first time `value` is accessed, 1 is
+    // returned, but afterwards 1 million is returned. Might be a nice
+    // attack to withdraw a lot more than allowed.
+    Object.defineProperty(amount, 'value', {
+      get() {
+        if (checked) {
+          return 1_000_000n;
+        } else {
+          checked = true;
+          return 1n;
+        }
+      },
+    });
+    return harden(amount);
+  };
+
+  const amount = makeAmount();
+
+  t.throws(() => AmountMath.coerce(brand, /** @type {Amount} */ (amount)), {
+    message: /"value" must not be an accessor property/,
+  });
+});

--- a/packages/ERTP/test/unitTests/test-mintObj.js
+++ b/packages/ERTP/test/unitTests/test-mintObj.js
@@ -27,12 +27,12 @@ test('mint.mintPayment default nat AssetKind', async t => {
 
 test('mint.mintPayment set w strings AssetKind', async t => {
   const { mint, issuer, brand } = makeIssuerKit('items', AssetKind.SET);
-  const items1and2and4 = AmountMath.make(brand, ['1', '2', '4']);
+  const items1and2and4 = AmountMath.make(brand, harden(['1', '2', '4']));
   const payment1 = mint.mintPayment(items1and2and4);
   const paymentBalance1 = await issuer.getAmountOf(payment1);
   t.assert(AmountMath.isEqual(paymentBalance1, items1and2and4));
 
-  const items5and6 = AmountMath.make(brand, ['5', '6']);
+  const items5and6 = AmountMath.make(brand, harden(['5', '6']));
   const payment2 = mint.mintPayment(items5and6);
   const paymentBalance2 = await issuer.getAmountOf(payment2);
   t.assert(AmountMath.isEqual(paymentBalance2, items5and6));
@@ -43,12 +43,12 @@ test('mint.mintPayment set AssetKind', async t => {
   const item1handle = Far('iface', {});
   const item2handle = Far('iface', {});
   const item3handle = Far('iface', {});
-  const items1and2 = AmountMath.make(brand, [item1handle, item2handle]);
+  const items1and2 = AmountMath.make(brand, harden([item1handle, item2handle]));
   const payment1 = mint.mintPayment(items1and2);
   const paymentBalance1 = await issuer.getAmountOf(payment1);
   t.assert(AmountMath.isEqual(paymentBalance1, items1and2));
 
-  const item3 = AmountMath.make(brand, [item3handle]);
+  const item3 = AmountMath.make(brand, harden([item3handle]));
   const payment2 = mint.mintPayment(item3);
   const paymentBalance2 = await issuer.getAmountOf(payment2);
   t.assert(AmountMath.isEqual(paymentBalance2, item3));
@@ -75,12 +75,15 @@ test('mint.mintPayment set AssetKind with invites', async t => {
     handle: Far('iface', {}),
     instanceHandle: Far('iface', {}),
   };
-  const invites1and2 = AmountMath.make(brand, [invite1Value, invite2Value]);
+  const invites1and2 = AmountMath.make(
+    brand,
+    harden([invite1Value, invite2Value]),
+  );
   const payment1 = mint.mintPayment(invites1and2);
   const paymentBalance1 = await issuer.getAmountOf(payment1);
   t.assert(AmountMath.isEqual(paymentBalance1, invites1and2));
 
-  const invite3 = AmountMath.make(brand, [invite3Value]);
+  const invite3 = AmountMath.make(brand, harden([invite3Value]));
   const payment2 = mint.mintPayment(invite3);
   const paymentBalance2 = await issuer.getAmountOf(payment2);
   t.assert(AmountMath.isEqual(paymentBalance2, invite3));
@@ -100,16 +103,18 @@ test('non-fungible tokens example', async t => {
 
   const ticketDescriptionObjects = Array(5)
     .fill('')
-    .map((_, i) => ({
-      seat: i + 1,
-      show: 'The Sofa',
-      start: startDateString,
-    }));
+    .map((_, i) =>
+      harden({
+        seat: i + 1,
+        show: 'The Sofa',
+        start: startDateString,
+      }),
+    );
 
   const balletTicketPayments = ticketDescriptionObjects.map(
     ticketDescription => {
       return balletTicketMint.mintPayment(
-        AmountMath.make(brand, [ticketDescription]),
+        AmountMath.make(brand, harden([ticketDescription])),
       );
     },
   );
@@ -117,10 +122,9 @@ test('non-fungible tokens example', async t => {
   // Alice will buy ticket 1
   const paymentForAlice = balletTicketPayments[0];
   // Bob will buy tickets 3 and 4
-  const paymentForBob = balletTicketIssuer.combine([
-    balletTicketPayments[2],
-    balletTicketPayments[3],
-  ]);
+  const paymentForBob = balletTicketIssuer.combine(
+    harden([balletTicketPayments[2], balletTicketPayments[3]]),
+  );
 
   // ALICE SIDE
   // Alice bought ticket 1 and has access to the balletTicketIssuer, because it's public

--- a/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
@@ -699,7 +699,7 @@ test('lib-wallet offer methods', async t => {
           Contribution: {
             // The pursePetname identifies which purse we want to use
             pursePetname: 'Fun budget',
-            value: 1,
+            value: 1n,
           },
         },
         exit: { onDemand: null },
@@ -734,7 +734,7 @@ test('lib-wallet offer methods', async t => {
           id: 6,
         },
         proposalTemplate: {
-          give: { Contribution: { pursePetname: 'Fun budget', value: 1 } },
+          give: { Contribution: { pursePetname: 'Fun budget', value: 1n } },
           exit: { onDemand: null },
         },
         requestContext: { dappOrigin: 'unknown' },
@@ -1025,13 +1025,13 @@ test('lib-wallet addOffer for autoswap swap', async t => {
       give: {
         In: {
           pursePetname: 'Fun budget',
-          value: 30,
+          value: 30n,
         },
       },
       want: {
         Out: {
           pursePetname: 'Nest egg',
-          value: 1,
+          value: 1n,
         },
       },
       exit: {
@@ -1148,13 +1148,13 @@ test('addOffer invitationQuery', async t => {
       give: {
         In: {
           pursePetname: 'Fun budget',
-          value: 30,
+          value: 30n,
         },
       },
       want: {
         Out: {
           pursePetname: 'Nest egg',
-          value: 1,
+          value: 1n,
         },
       },
       exit: {
@@ -1264,13 +1264,13 @@ test('addOffer offer.invitation', async t => {
       give: {
         In: {
           pursePetname: 'Fun budget',
-          value: 30,
+          value: 30n,
         },
       },
       want: {
         Out: {
           pursePetname: 'Nest egg',
-          value: 1,
+          value: 1n,
         },
       },
       exit: {

--- a/packages/deploy-script-support/test/unitTests/test-depositInvitation.js
+++ b/packages/deploy-script-support/test/unitTests/test-depositInvitation.js
@@ -10,7 +10,7 @@ import { makeDepositInvitation } from '../../src/depositInvitation.js';
 test('depositInvitation', async t => {
   const { mint, issuer, brand } = makeIssuerKit('invitations', AssetKind.SET);
   const purse = issuer.makeEmptyPurse();
-  const paymentAmount = AmountMath.make(brand, [{ instance: {} }]);
+  const paymentAmount = AmountMath.make(brand, harden([{ instance: {} }]));
   const payment = mint.mintPayment(paymentAmount);
   const depositInvitation = makeDepositInvitation(purse);
   const result = await depositInvitation(payment);

--- a/packages/deploy-script-support/test/unitTests/test-findInvitationAmount.js
+++ b/packages/deploy-script-support/test/unitTests/test-findInvitationAmount.js
@@ -14,9 +14,10 @@ test('findInvitationAmount', async t => {
   const walletAdmin = {};
   const zoe = {};
 
-  const paymentAmount = AmountMath.make(brand, [
-    { description: 'found', instance: {} },
-  ]);
+  const paymentAmount = AmountMath.make(
+    brand,
+    harden([{ description: 'found', instance: {} }]),
+  );
   const payment = mint.mintPayment(paymentAmount);
   zoeInvitationPurse.deposit(payment);
 

--- a/packages/governance/src/paramManager.js
+++ b/packages/governance/src/paramManager.js
@@ -1,8 +1,8 @@
 // @ts-check
 
+import { isRemotable, Far } from '@agoric/marshal';
 import { assertIsRatio } from '@agoric/zoe/src/contractSupport/index.js';
-import { AmountMath, looksLikeBrand } from '@agoric/ertp';
-import { Far } from '@agoric/marshal';
+import { AmountMath } from '@agoric/ertp';
 import { assertKeywordName } from '@agoric/zoe/src/cleanProposal.js';
 import { Nat } from '@agoric/nat';
 import { makeSubscriptionKit } from '@agoric/notifier';
@@ -47,7 +47,7 @@ const assertType = (type, value, name) => {
     case ParamType.BRAND:
       assert(
         // @ts-ignore value is undifferentiated to this point
-        looksLikeBrand(value),
+        isRemotable(value),
         X`value for ${name} must be a brand, was ${value}`,
       );
       break;

--- a/packages/governance/test/unitTests/test-param-manager.js
+++ b/packages/governance/test/unitTests/test-param-manager.js
@@ -77,7 +77,7 @@ test('params one Amount', async t => {
   t.throws(
     () => updateAmount(18.1),
     {
-      message: 'The brand "[undefined]" doesn\'t look like a brand.',
+      message: '"brand" "[undefined]" must be a remotable, not "undefined"',
     },
     'value should be a amount',
   );
@@ -134,7 +134,7 @@ test('params one ratio', async t => {
   t.throws(
     () => updateRatio(18.1),
     {
-      message: 'Expected "number" is same as "copyRecord"',
+      message: '"ratio" 18.1 must be a pass-by-copy record, not "number"',
     },
     'value should be a ratio',
   );

--- a/packages/marshal/index.js
+++ b/packages/marshal/index.js
@@ -19,9 +19,9 @@ export {
 } from './src/structure.js';
 export {
   assertRecord,
-  assertArray,
+  assertCopyArray,
   assertRemotable,
   isRemotable,
   isRecord,
-  isArray,
+  isCopyArray,
 } from './src/assertPassStyleOf.js';

--- a/packages/marshal/index.js
+++ b/packages/marshal/index.js
@@ -17,3 +17,11 @@ export {
   sameStructure,
   fulfillToStructure,
 } from './src/structure.js';
+export {
+  assertRecord,
+  assertArray,
+  assertRemotable,
+  isRemotable,
+  isRecord,
+  isArray,
+} from './src/assertPassStyleOf.js';

--- a/packages/marshal/src/assertPassStyleOf.js
+++ b/packages/marshal/src/assertPassStyleOf.js
@@ -19,8 +19,8 @@ const { details: X, quote: q } = assert;
  * @param {CopyArray} array
  * @returns {boolean}
  */
-const isArray = array => passStyleOf(array) === 'copyArray';
-harden(isArray);
+const isCopyArray = array => passStyleOf(array) === 'copyArray';
+harden(isCopyArray);
 
 /**
  * Check whether the argument is a pass-by-copy record, AKA a
@@ -49,7 +49,7 @@ harden(isRemotable);
  * @param {string=} optNameOfArray
  * @returns {void}
  */
-const assertArray = (array, optNameOfArray = 'Alleged array') => {
+const assertCopyArray = (array, optNameOfArray = 'Alleged array') => {
   const passStyle = passStyleOf(array);
   assert(
     passStyle === 'copyArray',
@@ -58,7 +58,7 @@ const assertArray = (array, optNameOfArray = 'Alleged array') => {
     )} ${array} must be a pass-by-copy array, not ${passStyle}`,
   );
 };
-harden(assertArray);
+harden(assertCopyArray);
 
 /**
  * Assert that the argument is a pass-by-copy record, or a
@@ -102,9 +102,9 @@ harden(assertRemotable);
 
 export {
   assertRecord,
-  assertArray,
+  assertCopyArray,
   assertRemotable,
   isRemotable,
   isRecord,
-  isArray,
+  isCopyArray,
 };

--- a/packages/marshal/src/assertPassStyleOf.js
+++ b/packages/marshal/src/assertPassStyleOf.js
@@ -1,0 +1,110 @@
+// @ts-check
+
+import { passStyleOf } from './passStyleOf.js';
+
+const { details: X, quote: q } = assert;
+
+/**
+ * @typedef {Array} CopyArray
+ */
+
+/**
+ * @typedef {Record<string, Passable>} CopyRecord
+ */
+
+/**
+ * Check whether the argument is a pass-by-copy array, AKA a "copyArray"
+ * in @agoric/marshal terms
+ *
+ * @param {CopyArray} array
+ * @returns {boolean}
+ */
+const isArray = array => passStyleOf(array) === 'copyArray';
+harden(isArray);
+
+/**
+ * Check whether the argument is a pass-by-copy record, AKA a
+ * "copyRecord" in @agoric/marshal terms
+ *
+ * @param {CopyRecord} record
+ * @returns {boolean}
+ */
+const isRecord = record => passStyleOf(record) === 'copyRecord';
+harden(isRecord);
+
+/**
+ * Check whether the argument is a remotable.
+ *
+ * @param {Remotable} remotable
+ * @returns {boolean}
+ */
+const isRemotable = remotable => passStyleOf(remotable) === 'remotable';
+harden(isRemotable);
+
+/**
+ * Assert that the argument is a pass-by-copy array, AKA a "copyArray"
+ * in @agoric/marshal terms
+ *
+ * @param {CopyArray} array
+ * @param {string=} optNameOfArray
+ * @returns {void}
+ */
+const assertArray = (array, optNameOfArray = 'Alleged array') => {
+  const passStyle = passStyleOf(array);
+  assert(
+    passStyle === 'copyArray',
+    X`${q(
+      optNameOfArray,
+    )} ${array} must be a pass-by-copy array, not ${passStyle}`,
+  );
+};
+harden(assertArray);
+
+/**
+ * Assert that the argument is a pass-by-copy record, or a
+ * "copyRecord" in @agoric/marshal terms
+ *
+ * @param {CopyRecord} record
+ * @param {string=} optNameOfRecord
+ * @returns {void}
+ */
+const assertRecord = (record, optNameOfRecord = 'Alleged record') => {
+  const passStyle = passStyleOf(record);
+  assert(
+    passStyle === 'copyRecord',
+    X`${q(
+      optNameOfRecord,
+    )} ${record} must be a pass-by-copy record, not ${passStyle}`,
+  );
+};
+harden(assertRecord);
+
+/**
+ * Assert that the argument is a remotable.
+ *
+ * @param {Remotable} remotable
+ * @param {string=} optNameOfRemotable
+ * @returns {void}
+ */
+const assertRemotable = (
+  remotable,
+  optNameOfRemotable = 'Alleged remotable',
+) => {
+  const passStyle = passStyleOf(remotable);
+  assert(
+    passStyle === 'remotable',
+    X`${q(
+      optNameOfRemotable,
+    )} ${remotable} must be a remotable, not ${passStyle}`,
+  );
+};
+harden(assertRemotable);
+
+export {
+  assertRecord,
+  assertArray,
+  assertRemotable,
+  isRemotable,
+  isRecord,
+  isArray,
+};

--- a/packages/swingset-runner/demo/zoeTests/vat-alice.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-alice.js
@@ -328,8 +328,8 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     // 10 moola = 5 simoleans at the time of the liquidity adding
     // aka 2 moola = 1 simolean
     const addLiquidityProposal = harden({
-      give: { Central: moola(10), Secondary: simoleans(5) },
-      want: { Liquidity: liquidity(10) },
+      give: { Central: moola(10n), Secondary: simoleans(5n) },
+      want: { Liquidity: liquidity(10n) },
     });
     const paymentKeywordRecord = harden({
       Central: moolaPayment,
@@ -353,12 +353,12 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
     // remove the liquidity
     const aliceRemoveLiquidityProposal = harden({
-      give: { Liquidity: liquidity(10) },
+      give: { Liquidity: liquidity(10n) },
       want: { Central: moola(0n), Secondary: simoleans(0) },
     });
 
     const liquidityTokenPayment = await E(liquidityTokenPurseP).withdraw(
-      liquidity(10),
+      liquidity(10n),
     );
     const removeLiquidityInvitation = E(
       publicFacet,
@@ -401,16 +401,18 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       sellItemsCreatorSeat,
       sellItemsPublicFacet,
       sellItemsCreatorFacet,
-    } = await E(creatorFacet).sellTokens({
-      customValueProperties: {
-        show: 'Steven Universe, the Opera',
-        start: 'Wed, March 25th 2020 at 8pm',
-      },
-      count: 3,
-      moneyIssuer: moolaIssuer,
-      sellItemsInstallation: installations.sellItems,
-      pricePerItem: moola(22),
-    });
+    } = await E(creatorFacet).sellTokens(
+      harden({
+        customValueProperties: {
+          show: 'Steven Universe, the Opera',
+          start: 'Wed, March 25th 2020 at 8pm',
+        },
+        count: 3,
+        moneyIssuer: moolaIssuer,
+        sellItemsInstallation: installations.sellItems,
+        pricePerItem: moola(22),
+      }),
+    );
     const buyerInvitation = E(sellItemsCreatorFacet).makeBuyerInvitation();
     await E(bobP).doBuyTickets(ticketSalesInstance, buyerInvitation);
 
@@ -446,7 +448,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       give: {
         Moola: moola(10000),
         Simolean: simoleans(10000),
-        Buck: bucks(10000),
+        Buck: bucks(10000n),
       },
     });
     const addInventoryPayments = {

--- a/packages/swingset-runner/demo/zoeTests/vat-bob.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-bob.js
@@ -194,7 +194,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       // current invitation from Alice. He wants 1 buck in return.
       const bobProposalSwap = harden({
         give: { Asset: optionAmounts },
-        want: { Price: bucks(1) },
+        want: { Price: bucks(1n) },
       });
 
       const bobSwapPayments = harden({ Asset: exclInvitation });

--- a/packages/swingset-runner/demo/zoeTests/vat-dave.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-dave.js
@@ -105,7 +105,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         X`asset is the option`,
       );
       assert(
-        sameStructure(invitationValue[0].price, bucks(1)),
+        sameStructure(invitationValue[0].price, bucks(1n)),
         X`price is 1 buck`,
       );
       const optionValue = optionAmounts.value;
@@ -133,7 +133,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       // Dave escrows his 1 buck with Zoe and forms his proposal
       const daveSwapProposal = harden({
         want: { Asset: optionAmounts },
-        give: { Price: bucks(1) },
+        give: { Price: bucks(1n) },
       });
       const daveSwapPayments = harden({ Price: bucksPayment });
       const seatP = await E(zoe).offer(

--- a/packages/treasury/src/prioritizedVaults.js
+++ b/packages/treasury/src/prioritizedVaults.js
@@ -32,7 +32,7 @@ function calculateDebtToCollateral(debtAmount, collateralAmount) {
   if (AmountMath.isEmpty(collateralAmount)) {
     return makeRatioFromAmounts(
       debtAmount,
-      AmountMath.make(1n, collateralAmount.brand),
+      AmountMath.make(collateralAmount.brand, 1n),
     );
   }
   return makeRatioFromAmounts(debtAmount, collateralAmount);

--- a/packages/treasury/src/stablecoinMachine.js
+++ b/packages/treasury/src/stablecoinMachine.js
@@ -195,7 +195,7 @@ export async function start(zcf, privateArgs) {
       // initialPrice is in rates, but only used at creation, so not in governor
       const runAmount = ceilMultiplyBy(collateralIn, rates.initialPrice);
       // arbitrarily, give governance tokens equal to RUN tokens
-      const govAmount = AmountMath.make(runAmount.value, govBrand);
+      const govAmount = AmountMath.make(govBrand, runAmount.value);
 
       // Create new governance tokens, trade them with the incoming offer for
       // collateral. The offer uses the keywords Collateral and Governance.

--- a/packages/treasury/src/vaultManager.js
+++ b/packages/treasury/src/vaultManager.js
@@ -98,7 +98,7 @@ export function makeVaultManager(
       const displayInfo = await E(collateralBrand).getDisplayInfo();
       const decimalPlaces = (displayInfo && displayInfo.decimalPlaces) || 0n;
       return E(priceAuthority).quoteGiven(
-        AmountMath.make(10n ** Nat(decimalPlaces), collateralBrand),
+        AmountMath.make(collateralBrand, 10n ** Nat(decimalPlaces)),
         runBrand,
       );
     },

--- a/packages/treasury/test/swingsetTests/governance/bootstrap.js
+++ b/packages/treasury/test/swingsetTests/governance/bootstrap.js
@@ -155,7 +155,7 @@ const makeBootstrap = (argv, cb, vatPowers) => async (vats, devices) => {
   const { mints, issuers, brands } = setupBasicMints();
   const makePayments = values =>
     mints.map((mint, i) =>
-      mint.mintPayment(AmountMath.make(values[i], brands[i])),
+      mint.mintPayment(AmountMath.make(brands[i], BigInt(values[i]))),
     );
   const [aliceValues, ownerValues] = startingValues;
 

--- a/packages/treasury/test/swingsetTests/treasury/bootstrap.js
+++ b/packages/treasury/test/swingsetTests/treasury/bootstrap.js
@@ -44,7 +44,7 @@ const makeVats = async (
   const { mints, issuers, brands } = setupBasicMints();
   const makePayments = values =>
     mints.map((mint, i) =>
-      mint.mintPayment(AmountMath.make(values[i], brands[i])),
+      mint.mintPayment(AmountMath.make(brands[i], BigInt(values[i]))),
     );
   const [aliceValues, ownerValues] = startingValues;
 

--- a/packages/treasury/test/test-bootstrapPayment.js
+++ b/packages/treasury/test/test-bootstrapPayment.js
@@ -260,7 +260,7 @@ test('bootstrap payment - only minted once', async t => {
   ).getBootstrapPayment();
 
   await t.throwsAsync(() => E(issuers.RUN).claim(bootstrapPayment2), {
-    message: /^payment not found for "RUN"/,
+    message: /was not a live payment/,
   });
 });
 

--- a/packages/treasury/test/test-interest.js
+++ b/packages/treasury/test/test-interest.js
@@ -23,7 +23,7 @@ test('too soon', async t => {
     6n,
   );
   const debtStatus = {
-    newDebt: AmountMath.make(1000n, brand),
+    newDebt: AmountMath.make(brand, 1000n),
     latestInterestUpdate: 10n,
     interest: AmountMath.makeEmpty(brand),
   };
@@ -31,7 +31,7 @@ test('too soon', async t => {
   t.deepEqual(calculator.calculate(debtStatus, 12n), {
     latestInterestUpdate: 10n,
     interest: AmountMath.makeEmpty(brand),
-    newDebt: AmountMath.make(1000n, brand),
+    newDebt: AmountMath.make(brand, 1000n),
   });
 });
 
@@ -45,15 +45,15 @@ test('basic charge 1 period', async t => {
     ONE_MONTH,
   );
   const debtStatus = {
-    newDebt: AmountMath.make(HUNDRED_THOUSAND, brand),
+    newDebt: AmountMath.make(brand, HUNDRED_THOUSAND),
     latestInterestUpdate: 0n,
     interest: AmountMath.makeEmpty(brand),
   };
   // 6n is daily interest of 2.5% APR on 100k. Compounding is in the noise.
   t.deepEqual(calculator.calculate(debtStatus, ONE_DAY), {
     latestInterestUpdate: ONE_DAY,
-    interest: AmountMath.make(6n, brand),
-    newDebt: AmountMath.make(100006n, brand),
+    interest: AmountMath.make(brand, 6n),
+    newDebt: AmountMath.make(brand, 100006n),
   });
 });
 
@@ -67,7 +67,7 @@ test('basic 2 charge periods', async t => {
     ONE_MONTH,
   );
   const debtStatus = {
-    newDebt: AmountMath.make(HUNDRED_THOUSAND, brand),
+    newDebt: AmountMath.make(brand, HUNDRED_THOUSAND),
     latestInterestUpdate: ONE_DAY,
     interest: AmountMath.makeEmpty(brand),
   };
@@ -75,8 +75,8 @@ test('basic 2 charge periods', async t => {
   // Compounding is in the noise.
   t.deepEqual(calculator.calculate(debtStatus, ONE_DAY * 3n), {
     latestInterestUpdate: ONE_DAY * 3n,
-    interest: AmountMath.make(12n, brand),
-    newDebt: AmountMath.make(100012n, brand),
+    interest: AmountMath.make(brand, 12n),
+    newDebt: AmountMath.make(brand, 100012n),
   });
 });
 
@@ -90,15 +90,15 @@ test('partial periods', async t => {
     ONE_MONTH,
   );
   const debtStatus = {
-    newDebt: AmountMath.make(HUNDRED_THOUSAND, brand),
+    newDebt: AmountMath.make(brand, HUNDRED_THOUSAND),
     latestInterestUpdate: 10n,
     interest: AmountMath.makeEmpty(brand),
   };
   // just less than three days gets two days of interest (6n/day)
   t.deepEqual(calculator.calculate(debtStatus, ONE_DAY * 3n - 1n), {
     latestInterestUpdate: 10n + ONE_DAY * 2n,
-    interest: AmountMath.make(12n, brand),
-    newDebt: AmountMath.make(100012n, brand),
+    interest: AmountMath.make(brand, 12n),
+    newDebt: AmountMath.make(brand, 100012n),
   });
 });
 
@@ -112,7 +112,7 @@ test('reportingPeriod: partial', async t => {
     ONE_MONTH,
   );
   const debtStatus = {
-    newDebt: AmountMath.make(HUNDRED_THOUSAND, brand),
+    newDebt: AmountMath.make(brand, HUNDRED_THOUSAND),
     latestInterestUpdate: 10n,
     interest: AmountMath.makeEmpty(brand),
   };
@@ -121,15 +121,15 @@ test('reportingPeriod: partial', async t => {
   t.deepEqual(calculator.calculateReportingPeriod(debtStatus, ONE_MONTH), {
     latestInterestUpdate: 10n,
     interest: AmountMath.makeEmpty(brand),
-    newDebt: AmountMath.make(HUNDRED_THOUSAND, brand),
+    newDebt: AmountMath.make(brand, HUNDRED_THOUSAND),
   });
   // charge daily, record monthly. After a month, charge 30 * 6n
   t.deepEqual(
     calculator.calculateReportingPeriod(debtStatus, ONE_DAY + ONE_MONTH),
     {
       latestInterestUpdate: 10n + ONE_MONTH,
-      interest: AmountMath.make(180n, brand),
-      newDebt: AmountMath.make(100180n, brand),
+      interest: AmountMath.make(brand, 180n),
+      newDebt: AmountMath.make(brand, 100180n),
     },
   );
 });
@@ -144,7 +144,7 @@ test('reportingPeriod: longer', async t => {
     ONE_DAY,
   );
   const debtStatus = {
-    newDebt: AmountMath.make(HUNDRED_THOUSAND, brand),
+    newDebt: AmountMath.make(brand, HUNDRED_THOUSAND),
     latestInterestUpdate: 10n,
     interest: AmountMath.makeEmpty(brand),
   };
@@ -154,8 +154,8 @@ test('reportingPeriod: longer', async t => {
     calculator.calculateReportingPeriod(debtStatus, ONE_MONTH + ONE_DAY),
     {
       latestInterestUpdate: ONE_MONTH + 10n,
-      interest: AmountMath.make(203n, brand),
-      newDebt: AmountMath.make(100203n, brand),
+      interest: AmountMath.make(brand, 203n),
+      newDebt: AmountMath.make(brand, 100203n),
     },
   );
 });
@@ -170,7 +170,7 @@ test('start charging later', async t => {
     ONE_MONTH,
   );
   const debtStatus = {
-    newDebt: AmountMath.make(HUNDRED_THOUSAND, brand),
+    newDebt: AmountMath.make(brand, HUNDRED_THOUSAND),
     latestInterestUpdate: 16n,
     interest: AmountMath.makeEmpty(brand),
   };
@@ -179,12 +179,12 @@ test('start charging later', async t => {
   t.deepEqual(calculator.calculate(debtStatus, ONE_DAY), {
     latestInterestUpdate: 16n,
     interest: AmountMath.makeEmpty(brand),
-    newDebt: AmountMath.make(HUNDRED_THOUSAND, brand),
+    newDebt: AmountMath.make(brand, HUNDRED_THOUSAND),
   });
   t.deepEqual(calculator.calculate(debtStatus, ONE_DAY + 16n), {
     latestInterestUpdate: ONE_DAY + 16n,
-    interest: AmountMath.make(6n, brand),
-    newDebt: AmountMath.make(100006n, brand),
+    interest: AmountMath.make(brand, 6n),
+    newDebt: AmountMath.make(brand, 100006n),
   });
 });
 
@@ -198,7 +198,7 @@ test('simple compounding', async t => {
     ONE_MONTH,
   );
   const debtStatus = {
-    newDebt: AmountMath.make(HUNDRED_THOUSAND, brand),
+    newDebt: AmountMath.make(brand, HUNDRED_THOUSAND),
     latestInterestUpdate: 10n,
     interest: AmountMath.makeEmpty(brand),
   };
@@ -208,8 +208,8 @@ test('simple compounding', async t => {
     calculator.calculateReportingPeriod(debtStatus, ONE_MONTH + ONE_DAY),
     {
       latestInterestUpdate: ONE_MONTH + 10n,
-      interest: AmountMath.make(180n, brand),
-      newDebt: AmountMath.make(100180n, brand),
+      interest: AmountMath.make(brand, 180n),
+      newDebt: AmountMath.make(brand, 100180n),
     },
   );
 });
@@ -224,14 +224,14 @@ test('reportingPeriod shorter than charging', async t => {
     ONE_DAY,
   );
   let debtStatus = {
-    newDebt: AmountMath.make(HUNDRED_THOUSAND, brand),
+    newDebt: AmountMath.make(brand, HUNDRED_THOUSAND),
     latestInterestUpdate: 10n,
     interest: AmountMath.makeEmpty(brand),
   };
   const afterOneMonth = {
     latestInterestUpdate: 10n,
     interest: AmountMath.makeEmpty(brand),
-    newDebt: AmountMath.make(HUNDRED_THOUSAND, brand),
+    newDebt: AmountMath.make(brand, HUNDRED_THOUSAND),
   };
   // charging period is 30 days. interest isn't charged until then.
   t.deepEqual(calculator.calculate(debtStatus, ONE_DAY), afterOneMonth);
@@ -241,13 +241,13 @@ test('reportingPeriod shorter than charging', async t => {
   t.deepEqual(calculator.calculate(debtStatus, 29n * ONE_DAY), afterOneMonth);
   t.deepEqual(calculator.calculate(debtStatus, ONE_MONTH + 10n), {
     latestInterestUpdate: ONE_MONTH + 10n,
-    interest: AmountMath.make(203n, brand),
-    newDebt: AmountMath.make(100203n, brand),
+    interest: AmountMath.make(brand, 203n),
+    newDebt: AmountMath.make(brand, 100203n),
   });
 
   debtStatus = {
-    newDebt: AmountMath.make(100203n, brand),
-    interest: AmountMath.make(203n, brand),
+    newDebt: AmountMath.make(brand, 100203n),
+    interest: AmountMath.make(brand, 203n),
     latestInterestUpdate: ONE_MONTH,
   };
   const afterTwoMonths = {
@@ -262,8 +262,8 @@ test('reportingPeriod shorter than charging', async t => {
   t.deepEqual(calculator.calculate(debtStatus, 59n * ONE_DAY), afterTwoMonths);
   t.deepEqual(calculator.calculate(debtStatus, 60n * ONE_DAY), {
     latestInterestUpdate: 2n * ONE_MONTH,
-    interest: AmountMath.make(406n, brand),
-    newDebt: AmountMath.make(100406n, brand),
+    interest: AmountMath.make(brand, 406n),
+    newDebt: AmountMath.make(brand, 100406n),
   });
 });
 
@@ -278,13 +278,13 @@ test('reportingPeriod shorter than charging; start day boundary', async t => {
   );
   const startOneDay = {
     latestInterestUpdate: ONE_DAY,
-    newDebt: AmountMath.make(HUNDRED_THOUSAND, brand),
+    newDebt: AmountMath.make(brand, HUNDRED_THOUSAND),
     interest: AmountMath.makeEmpty(brand),
   };
   const afterOneDay = {
     latestInterestUpdate: ONE_DAY,
     interest: AmountMath.makeEmpty(brand),
-    newDebt: AmountMath.make(HUNDRED_THOUSAND, brand),
+    newDebt: AmountMath.make(brand, HUNDRED_THOUSAND),
   };
   // no interest charged before a month elapses
   t.deepEqual(calculator.calculate(startOneDay, 4n * ONE_DAY), afterOneDay);
@@ -295,8 +295,8 @@ test('reportingPeriod shorter than charging; start day boundary', async t => {
 
   const afterAMonth = {
     latestInterestUpdate: ONE_MONTH + ONE_DAY,
-    interest: AmountMath.make(203n, brand),
-    newDebt: AmountMath.make(100203n, brand),
+    interest: AmountMath.make(brand, 203n),
+    newDebt: AmountMath.make(brand, 100203n),
   };
   // 203n is 2.5% APR charged monthly
   t.deepEqual(
@@ -316,13 +316,13 @@ test('reportingPeriod shorter than charging; start not even days', async t => {
   );
   const startPartialDay = {
     latestInterestUpdate: 20n,
-    newDebt: AmountMath.make(101000n, brand),
+    newDebt: AmountMath.make(brand, 101000n),
     interest: AmountMath.makeEmpty(brand),
   };
   const afterOneMonth = {
     latestInterestUpdate: 20n,
     interest: AmountMath.makeEmpty(brand),
-    newDebt: AmountMath.make(101000n, brand),
+    newDebt: AmountMath.make(brand, 101000n),
   };
   t.deepEqual(calculator.calculate(startPartialDay, ONE_MONTH), afterOneMonth);
   t.deepEqual(
@@ -332,8 +332,8 @@ test('reportingPeriod shorter than charging; start not even days', async t => {
   // interest not charged until ONE_MONTH + 20n
   t.deepEqual(calculator.calculate(startPartialDay, ONE_MONTH + 20n), {
     latestInterestUpdate: 20n + ONE_MONTH,
-    interest: AmountMath.make(205n, brand),
-    newDebt: AmountMath.make(101205n, brand),
+    interest: AmountMath.make(brand, 205n),
+    newDebt: AmountMath.make(brand, 101205n),
   });
 });
 
@@ -351,40 +351,40 @@ test.only('basic charge large numbers, compounding', async t => {
   );
   // TEN_MILLION is enough to observe compounding
   const debtStatus = {
-    newDebt: AmountMath.make(TEN_MILLION, brand),
+    newDebt: AmountMath.make(brand, TEN_MILLION),
     interest: AmountMath.makeEmpty(brand),
     latestInterestUpdate: START_TIME,
   };
   t.deepEqual(calculator.calculate(debtStatus, START_TIME), {
     latestInterestUpdate: START_TIME,
     interest: AmountMath.makeEmpty(brand),
-    newDebt: AmountMath.make(TEN_MILLION, brand),
+    newDebt: AmountMath.make(brand, TEN_MILLION),
   });
   t.deepEqual(calculator.calculate(debtStatus, START_TIME + 1n), {
     latestInterestUpdate: START_TIME,
     interest: AmountMath.makeEmpty(brand),
-    newDebt: AmountMath.make(TEN_MILLION, brand),
+    newDebt: AmountMath.make(brand, TEN_MILLION),
   });
   // 676n is one day's interest on TEN_MILLION at 2.5% APR.
   t.deepEqual(calculator.calculate(debtStatus, START_TIME + ONE_DAY), {
     latestInterestUpdate: START_TIME + ONE_DAY,
-    interest: AmountMath.make(676n, brand),
-    newDebt: AmountMath.make(10000676n, brand),
+    interest: AmountMath.make(brand, 676n),
+    newDebt: AmountMath.make(brand, 10000676n),
   });
   // two days interest. compounding not visible
   t.deepEqual(
     calculator.calculate(debtStatus, START_TIME + ONE_DAY + ONE_DAY),
     {
       latestInterestUpdate: START_TIME + ONE_DAY + ONE_DAY,
-      interest: AmountMath.make(1352n, brand),
-      newDebt: AmountMath.make(10001352n, brand),
+      interest: AmountMath.make(brand, 1352n),
+      newDebt: AmountMath.make(brand, 10001352n),
     },
   );
   // Notice that interest compounds 30 * 676 = 20280
   t.deepEqual(calculator.calculate(debtStatus, START_TIME + ONE_MONTH), {
     latestInterestUpdate: START_TIME + ONE_MONTH,
-    interest: AmountMath.make(20299n, brand),
-    newDebt: AmountMath.make(10020299n, brand),
+    interest: AmountMath.make(brand, 20299n),
+    newDebt: AmountMath.make(brand, 10020299n),
   });
 });
 
@@ -403,7 +403,7 @@ test('basic charge reasonable numbers monthly', async t => {
   );
   // TEN_MILLION is enough to observe compounding
   const debtStatus = {
-    newDebt: AmountMath.make(TEN_MILLION, brand),
+    newDebt: AmountMath.make(brand, TEN_MILLION),
     interest: AmountMath.makeEmpty(brand),
     latestInterestUpdate: START_TIME,
   };
@@ -411,14 +411,14 @@ test('basic charge reasonable numbers monthly', async t => {
   t.deepEqual(calculator.calculateReportingPeriod(debtStatus, START_TIME), {
     latestInterestUpdate: START_TIME,
     interest: AmountMath.makeEmpty(brand),
-    newDebt: AmountMath.make(TEN_MILLION, brand),
+    newDebt: AmountMath.make(brand, TEN_MILLION),
   });
   t.deepEqual(
     calculator.calculateReportingPeriod(debtStatus, START_TIME + 1n),
     {
       latestInterestUpdate: START_TIME,
       interest: AmountMath.makeEmpty(brand),
-      newDebt: AmountMath.make(TEN_MILLION, brand),
+      newDebt: AmountMath.make(brand, TEN_MILLION),
     },
   );
   t.deepEqual(
@@ -426,7 +426,7 @@ test('basic charge reasonable numbers monthly', async t => {
     {
       latestInterestUpdate: START_TIME,
       interest: AmountMath.makeEmpty(brand),
-      newDebt: AmountMath.make(TEN_MILLION, brand),
+      newDebt: AmountMath.make(brand, TEN_MILLION),
     },
   );
   t.deepEqual(
@@ -437,7 +437,7 @@ test('basic charge reasonable numbers monthly', async t => {
     {
       latestInterestUpdate: START_TIME,
       interest: AmountMath.makeEmpty(brand),
-      newDebt: AmountMath.make(TEN_MILLION, brand),
+      newDebt: AmountMath.make(brand, TEN_MILLION),
     },
   );
 
@@ -446,8 +446,8 @@ test('basic charge reasonable numbers monthly', async t => {
     calculator.calculateReportingPeriod(debtStatus, START_TIME + ONE_MONTH),
     {
       latestInterestUpdate: START_TIME + ONE_MONTH,
-      interest: AmountMath.make(20299n, brand),
-      newDebt: AmountMath.make(10020299n, brand),
+      interest: AmountMath.make(brand, 20299n),
+      newDebt: AmountMath.make(brand, 10020299n),
     },
   );
   const HALF_YEAR = 6n * ONE_MONTH;
@@ -457,8 +457,8 @@ test('basic charge reasonable numbers monthly', async t => {
     calculator.calculateReportingPeriod(debtStatus, START_TIME + HALF_YEAR),
     {
       latestInterestUpdate: START_TIME + HALF_YEAR,
-      interest: AmountMath.make(122419n, brand),
-      newDebt: AmountMath.make(10122419n, brand),
+      interest: AmountMath.make(brand, 122419n),
+      newDebt: AmountMath.make(brand, 10122419n),
     },
   );
   // compounding: 360 days * 676 = 243360
@@ -466,8 +466,8 @@ test('basic charge reasonable numbers monthly', async t => {
     calculator.calculateReportingPeriod(debtStatus, START_TIME + ONE_YEAR),
     {
       latestInterestUpdate: START_TIME + ONE_YEAR,
-      interest: AmountMath.make(246338n, brand),
-      newDebt: AmountMath.make(10246338n, brand),
+      interest: AmountMath.make(brand, 246338n),
+      newDebt: AmountMath.make(brand, 10246338n),
     },
   );
 });

--- a/packages/treasury/test/test-prioritizedVaults.js
+++ b/packages/treasury/test/test-prioritizedVaults.js
@@ -138,7 +138,7 @@ test('update changes ratio', async t => {
   const ratio180 = makeRatio(180n, brand, 100n);
   t.deepEqual(vaults.highestRatio(), ratio180);
 
-  fakeVault1.vault.setDebt(AmountMath.make(200n, brand));
+  fakeVault1.vault.setDebt(AmountMath.make(brand, 200n));
   updater1.updateState({ locked: AmountMath.make(brand, 300n) });
   await waitForPromisesToSettle();
   t.deepEqual(vaults.highestRatio(), makeRatio(200n, brand, 100n));

--- a/packages/treasury/test/test-stablecoin.js
+++ b/packages/treasury/test/test-stablecoin.js
@@ -292,7 +292,7 @@ test('first', async t => {
   const services = await setupServices(
     loanParams,
     [500n, 15n],
-    AmountMath.make(900n, aethBrand),
+    AmountMath.make(aethBrand, 900n),
     aethBrand,
     { committeeName: 'TheCabal', committeeSize: 5 },
   );
@@ -302,7 +302,7 @@ test('first', async t => {
   const { stablecoinMachine, lender } = services.stablecoin;
 
   // Add a pool with 900 aeth collateral at a 201 aeth/RUN rate
-  const capitalAmount = AmountMath.make(900n, aethBrand);
+  const capitalAmount = AmountMath.make(aethBrand, 900n);
   const rates = makeRates(runBrand, aethBrand);
   const aethVaultSeat = await E(zoe).offer(
     E(stablecoinMachine).makeAddTypeInvitation(aethIssuer, 'AEth', rates),
@@ -319,8 +319,8 @@ test('first', async t => {
   const aethVaultManager = await E(aethVaultSeat).getOfferResult();
 
   // Create a loan for 470 RUN with 1100 aeth collateral
-  const collateralAmount = AmountMath.make(1100n, aethBrand);
-  const loanAmount = AmountMath.make(470n, runBrand);
+  const collateralAmount = AmountMath.make(aethBrand, 1100n);
+  const loanAmount = AmountMath.make(runBrand, 470n);
   const loanSeat = await E(zoe).offer(
     E(lender).makeLoanInvitation(),
     harden({
@@ -334,7 +334,7 @@ test('first', async t => {
 
   const { vault } = await E(loanSeat).getOfferResult();
   const debtAmount = await E(vault).getDebtAmount();
-  const fee = multiplyBy(AmountMath.make(470n, runBrand), rates.loanFee);
+  const fee = multiplyBy(AmountMath.make(runBrand, 470n), rates.loanFee);
   t.deepEqual(
     debtAmount,
     AmountMath.add(loanAmount, fee),
@@ -348,7 +348,7 @@ test('first', async t => {
   t.deepEqual(lentAmount, loanAmount, 'received 47 RUN');
   t.deepEqual(
     vault.getCollateralAmount(),
-    AmountMath.make(1100n, aethBrand),
+    AmountMath.make(aethBrand, 1100n),
     'vault holds 1100 Collateral',
   );
 
@@ -356,8 +356,8 @@ test('first', async t => {
   // fuzzy feeling.
 
   // partially payback
-  const collateralWanted = AmountMath.make(100n, aethBrand);
-  const paybackAmount = AmountMath.make(200n, runBrand);
+  const collateralWanted = AmountMath.make(aethBrand, 100n);
+  const paybackAmount = AmountMath.make(runBrand, 200n);
   const [paybackPayment, _remainingPayment] = await E(runIssuer).split(
     runLent,
     paybackAmount,
@@ -379,17 +379,17 @@ test('first', async t => {
   const returnedAmount = await aethIssuer.getAmountOf(returnedCollateral);
   t.deepEqual(
     vault.getDebtAmount(),
-    AmountMath.make(293n, runBrand),
+    AmountMath.make(runBrand, 293n),
     'debt reduced to 293 RUN',
   );
   t.deepEqual(
     vault.getCollateralAmount(),
-    AmountMath.make(1000n, aethBrand),
+    AmountMath.make(aethBrand, 1000n),
     'vault holds 1000 Collateral',
   );
   t.deepEqual(
     returnedAmount,
-    AmountMath.make(100n, aethBrand),
+    AmountMath.make(aethBrand, 100n),
     'withdrew 100 collateral',
   );
 
@@ -405,7 +405,7 @@ test('first', async t => {
   t.deepEqual(liquidations.RUN, AmountMath.makeEmpty(runBrand));
 
   t.deepEqual(stablecoinMachine.getRewardAllocation(), {
-    RUN: AmountMath.make(23n, runBrand),
+    RUN: AmountMath.make(runBrand, 23n),
   });
 });
 
@@ -428,7 +428,7 @@ test('price drop', async t => {
   const services = await setupServices(
     loanParams,
     [1000n, 677n, 636n],
-    AmountMath.make(900n, aethBrand),
+    AmountMath.make(aethBrand, 900n),
     aethBrand,
     { committeeName: 'TheCabal', committeeSize: 5 },
     manualTimer,
@@ -439,7 +439,7 @@ test('price drop', async t => {
   const { stablecoinMachine, lender } = services.stablecoin;
 
   // Add a pool with 900 aeth at a 201 RUN/aeth rate
-  const capitalAmount = AmountMath.make(900n, aethBrand);
+  const capitalAmount = AmountMath.make(aethBrand, 900n);
   const rates = makeRates(runBrand, aethBrand);
   const aethVaultSeat = await E(zoe).offer(
     E(stablecoinMachine).makeAddTypeInvitation(aethIssuer, 'AEth', rates),
@@ -455,8 +455,8 @@ test('price drop', async t => {
   await E(aethVaultSeat).getOfferResult();
 
   // Create a loan for 270 RUN with 400 aeth collateral
-  const collateralAmount = AmountMath.make(400n, aethBrand);
-  const loanAmount = AmountMath.make(270n, runBrand);
+  const collateralAmount = AmountMath.make(aethBrand, 400n);
+  const loanAmount = AmountMath.make(runBrand, 270n);
   const loanSeat = await E(zoe).offer(
     E(lender).makeLoanInvitation(),
     harden({
@@ -470,7 +470,7 @@ test('price drop', async t => {
 
   const { vault, uiNotifier } = await E(loanSeat).getOfferResult();
   const debtAmount = await E(vault).getDebtAmount();
-  const fee = multiplyBy(AmountMath.make(270n, runBrand), rates.loanFee);
+  const fee = multiplyBy(AmountMath.make(runBrand, 270n), rates.loanFee);
   t.deepEqual(
     debtAmount,
     AmountMath.add(loanAmount, fee),
@@ -487,7 +487,7 @@ test('price drop', async t => {
   t.truthy(AmountMath.isEqual(lentAmount, loanAmount), 'received 470 RUN');
   t.deepEqual(
     vault.getCollateralAmount(),
-    AmountMath.make(400n, aethBrand),
+    AmountMath.make(aethBrand, 400n),
     'vault holds 11 Collateral',
   );
 
@@ -522,7 +522,7 @@ test('price drop', async t => {
   t.truthy(AmountMath.isEmpty(debtAmountAfter));
 
   t.deepEqual(stablecoinMachine.getRewardAllocation(), {
-    RUN: AmountMath.make(13n, runBrand),
+    RUN: AmountMath.make(runBrand, 13n),
   });
 
   t.is(await vault.getLiquidationPromise(), 'Liquidated');
@@ -556,7 +556,7 @@ test('price falls precipitously', async t => {
   const services = await setupServices(
     loanParams,
     [2200n, 19180n, 1650n, 150n],
-    AmountMath.make(900n, aethBrand),
+    AmountMath.make(aethBrand, 900n),
     aethBrand,
     { committeeName: 'TheCabal', committeeSize: 5 },
     manualTimer,
@@ -567,7 +567,7 @@ test('price falls precipitously', async t => {
   const { stablecoinMachine, lender } = services.stablecoin;
 
   // Add a pool with 900 aeth at a 201 RUN/aeth rate
-  const capitalAmount = AmountMath.make(900n, aethBrand);
+  const capitalAmount = AmountMath.make(aethBrand, 900n);
   const rates = makeRates(runBrand, aethBrand);
   const aethVaultSeat = await E(zoe).offer(
     E(stablecoinMachine).makeAddTypeInvitation(aethIssuer, 'AEth', rates),
@@ -584,8 +584,8 @@ test('price falls precipitously', async t => {
   await E(aethVaultSeat).getOfferResult();
 
   // Create a loan for 370 RUN with 400 aeth collateral
-  const collateralAmount = AmountMath.make(400n, aethBrand);
-  const loanAmount = AmountMath.make(370n, runBrand);
+  const collateralAmount = AmountMath.make(aethBrand, 400n);
+  const loanAmount = AmountMath.make(runBrand, 370n);
   const loanSeat = await E(zoe).offer(
     E(lender).makeLoanInvitation(),
     harden({
@@ -599,7 +599,7 @@ test('price falls precipitously', async t => {
 
   const { vault } = await E(loanSeat).getOfferResult();
   const debtAmount = await E(vault).getDebtAmount();
-  const fee = multiplyBy(AmountMath.make(370n, runBrand), rates.loanFee);
+  const fee = multiplyBy(AmountMath.make(runBrand, 370n), rates.loanFee);
   t.deepEqual(
     debtAmount,
     AmountMath.add(loanAmount, fee),
@@ -611,21 +611,21 @@ test('price falls precipitously', async t => {
   t.deepEqual(lentAmount, loanAmount, 'received 470 RUN');
   t.deepEqual(
     vault.getCollateralAmount(),
-    AmountMath.make(400n, aethBrand),
+    AmountMath.make(aethBrand, 400n),
     'vault holds 400 Collateral',
   );
 
   // Sell some Eth to drive the value down
   const swapInvitation = E(services.autoswapAPI).makeSwapInvitation();
   const proposal = {
-    give: { In: AmountMath.make(200n, aethBrand) },
+    give: { In: AmountMath.make(aethBrand, 200n) },
     want: { Out: AmountMath.makeEmpty(runBrand) },
   };
   await E(zoe).offer(
     swapInvitation,
     proposal,
     harden({
-      In: aethMint.mintPayment(AmountMath.make(200n, aethBrand)),
+      In: aethMint.mintPayment(AmountMath.make(aethBrand, 200n)),
     }),
   );
 
@@ -666,7 +666,7 @@ test('stablecoin display collateral', async t => {
   const services = await setupServices(
     loanParams,
     [500n, 1500n],
-    AmountMath.make(90n, aethBrand),
+    AmountMath.make(aethBrand, 90n),
     aethBrand,
     { committeeName: 'TheCabal', committeeSize: 5 },
   );
@@ -676,7 +676,7 @@ test('stablecoin display collateral', async t => {
   const { stablecoinMachine } = services.stablecoin;
 
   // Add a vaultManager with 900 aeth collateral at a 201 aeth/RUN rate
-  const capitalAmount = AmountMath.make(900n, aethBrand);
+  const capitalAmount = AmountMath.make(aethBrand, 900n);
   const rates = harden({
     initialPrice: makeRatio(201n, runBrand, PERCENT, aethBrand),
     initialMargin: makeRatio(120n, runBrand),
@@ -727,7 +727,7 @@ test('interest on multiple vaults', async t => {
   const services = await setupServices(
     loanParams,
     [500n, 1500n],
-    AmountMath.make(90n, aethBrand),
+    AmountMath.make(aethBrand, 90n),
     aethBrand,
     { committeeName: 'TheCabal', committeeSize: 5 },
     manualTimer,
@@ -739,7 +739,7 @@ test('interest on multiple vaults', async t => {
   const { stablecoinMachine, lender } = services.stablecoin;
 
   // Add a vaultManager with 900 aeth collateral at a 201 aeth/RUN rate
-  const capitalAmount = AmountMath.make(900n, aethBrand);
+  const capitalAmount = AmountMath.make(aethBrand, 900n);
   const interestRate = makeRatio(5n, runBrand);
   const rates = harden({
     initialPrice: makeRatio(201n, runBrand, PERCENT, aethBrand),
@@ -762,8 +762,8 @@ test('interest on multiple vaults', async t => {
   await E(aethVaultManagerSeat).getOfferResult();
 
   // Create a loan for Alice for 4700 RUN with 1100 aeth collateral
-  const collateralAmount = AmountMath.make(1100n, aethBrand);
-  const aliceLoanAmount = AmountMath.make(4700n, runBrand);
+  const collateralAmount = AmountMath.make(aethBrand, 1100n);
+  const aliceLoanAmount = AmountMath.make(runBrand, 4700n);
   const aliceLoanSeat = await E(zoe).offer(
     E(lender).makeLoanInvitation(),
     harden({
@@ -794,13 +794,13 @@ test('interest on multiple vaults', async t => {
   t.truthy(
     AmountMath.isEqual(
       await E(runIssuer).getAmountOf(runLent),
-      AmountMath.make(4700n, runBrand),
+      AmountMath.make(runBrand, 4700n),
     ),
   );
 
   // Create a loan for Bob for 3200 RUN with 800 aeth collateral
-  const bobCollateralAmount = AmountMath.make(800n, aethBrand);
-  const bobLoanAmount = AmountMath.make(3200n, runBrand);
+  const bobCollateralAmount = AmountMath.make(aethBrand, 800n);
+  const bobLoanAmount = AmountMath.make(runBrand, 3200n);
   const bobLoanSeat = await E(zoe).offer(
     E(lender).makeLoanInvitation(),
     harden({
@@ -831,7 +831,7 @@ test('interest on multiple vaults', async t => {
   t.truthy(
     AmountMath.isEqual(
       await E(runIssuer).getAmountOf(bobRunLent),
-      AmountMath.make(3200n, runBrand),
+      AmountMath.make(runBrand, 3200n),
     ),
   );
 
@@ -847,7 +847,7 @@ test('interest on multiple vaults', async t => {
   const bobAddedDebt = 160n + 3n;
   t.deepEqual(
     bobUpdate.value.debt,
-    AmountMath.make(3200n + bobAddedDebt, runBrand),
+    AmountMath.make(runBrand, 3200n + bobAddedDebt),
   );
   t.deepEqual(bobUpdate.value.interestRate, interestRate);
   t.deepEqual(
@@ -864,7 +864,7 @@ test('interest on multiple vaults', async t => {
   const aliceAddedDebt = 235n + 4n;
   t.deepEqual(
     aliceUpdate.value.debt,
-    AmountMath.make(4700n + aliceAddedDebt, runBrand),
+    AmountMath.make(runBrand, 4700n + aliceAddedDebt),
     `should have collected ${aliceAddedDebt}`,
   );
   t.deepEqual(aliceUpdate.value.interestRate, interestRate);
@@ -878,7 +878,7 @@ test('interest on multiple vaults', async t => {
   t.truthy(
     AmountMath.isEqual(
       stablecoinMachine.getRewardAllocation().RUN,
-      AmountMath.make(aliceAddedDebt + bobAddedDebt, runBrand),
+      AmountMath.make(runBrand, aliceAddedDebt + bobAddedDebt),
     ),
     // reward includes 5% fees on two loans plus 1% interest three times on each
     `Should be ${aliceAddedDebt + bobAddedDebt}, was ${
@@ -901,7 +901,7 @@ test('adjust balances', async t => {
   const services = await setupServices(
     loanParams,
     [15n],
-    AmountMath.make(1n, aethBrand),
+    AmountMath.make(aethBrand, 1n),
     aethBrand,
     { committeeName: 'TheCabal', committeeSize: 5 },
   );
@@ -912,7 +912,7 @@ test('adjust balances', async t => {
 
   const priceConversion = makeRatio(15n, runBrand, 1n, aethBrand);
   // Add a vaultManager with 900 aeth collateral at a 201 aeth/RUN rate
-  const capitalAmount = AmountMath.make(900n, aethBrand);
+  const capitalAmount = AmountMath.make(aethBrand, 900n);
   const rates = makeRates(runBrand, aethBrand);
   const aethVaultManagerSeat = await E(zoe).offer(
     E(stablecoinMachine).makeAddTypeInvitation(aethIssuer, 'AEth', rates),
@@ -930,8 +930,8 @@ test('adjust balances', async t => {
   // initial loan /////////////////////////////////////
 
   // Create a loan for Alice for 5000 RUN with 1000 aeth collateral
-  const collateralAmount = AmountMath.make(1000n, aethBrand);
-  const aliceLoanAmount = AmountMath.make(5000n, runBrand);
+  const collateralAmount = AmountMath.make(aethBrand, 1000n);
+  const aliceLoanAmount = AmountMath.make(runBrand, 5000n);
   const aliceLoanSeat = await E(zoe).offer(
     E(lender).makeLoanInvitation(),
     harden({
@@ -949,7 +949,7 @@ test('adjust balances', async t => {
   let debtAmount = await E(aliceVault).getDebtAmount();
   const fee = multiplyBy(aliceLoanAmount, rates.loanFee);
   let runDebtLevel = AmountMath.add(aliceLoanAmount, fee);
-  let collateralLevel = AmountMath.make(1000n, aethBrand);
+  let collateralLevel = AmountMath.make(aethBrand, 1000n);
 
   t.deepEqual(debtAmount, runDebtLevel, 'vault lent 5000 RUN + fees');
   const { RUN: lentAmount } = await E(aliceLoanSeat).getCurrentAllocation();
@@ -960,7 +960,7 @@ test('adjust balances', async t => {
   t.truthy(
     AmountMath.isEqual(
       await E(runIssuer).getAmountOf(runLent),
-      AmountMath.make(5000n, runBrand),
+      AmountMath.make(runBrand, 5000n),
     ),
   );
 
@@ -973,8 +973,8 @@ test('adjust balances', async t => {
   // increase collateral 1 ///////////////////////////////////// (give both)
 
   // Alice increase collateral by 100, paying in 50 RUN against debt
-  const collateralIncrement = AmountMath.make(100n, aethBrand);
-  const depositRunAmount = AmountMath.make(50n, runBrand);
+  const collateralIncrement = AmountMath.make(aethBrand, 100n);
+  const depositRunAmount = AmountMath.make(runBrand, 50n);
   runDebtLevel = AmountMath.subtract(runDebtLevel, depositRunAmount);
   collateralLevel = AmountMath.add(collateralLevel, collateralIncrement);
 
@@ -1024,8 +1024,8 @@ test('adjust balances', async t => {
   // increase collateral 2 ////////////////////////////////// (want:s, give:c)
 
   // Alice increase collateral by 100, withdrawing 50 RUN
-  const collateralIncrement2 = AmountMath.make(100n, aethBrand);
-  const withdrawRunAmount = AmountMath.make(50n, runBrand);
+  const collateralIncrement2 = AmountMath.make(aethBrand, 100n);
+  const withdrawRunAmount = AmountMath.make(runBrand, 50n);
   const withdrawRunAmountWithFees = multiplyBy(
     withdrawRunAmount,
     rates.loanFee,
@@ -1052,7 +1052,7 @@ test('adjust balances', async t => {
     aliceAddCollateralSeat2,
   ).getCurrentAllocation();
   const loanProceeds3 = await E(aliceAddCollateralSeat2).getPayouts();
-  t.deepEqual(lentAmount3, AmountMath.make(50n, runBrand));
+  t.deepEqual(lentAmount3, AmountMath.make(runBrand, 50n));
 
   debtAmount = await E(aliceVault).getDebtAmount();
   t.deepEqual(debtAmount, runDebtLevel);
@@ -1061,7 +1061,7 @@ test('adjust balances', async t => {
   t.truthy(
     AmountMath.isEqual(
       await E(runIssuer).getAmountOf(runLent3),
-      AmountMath.make(50n, runBrand),
+      AmountMath.make(runBrand, 50n),
     ),
   );
 
@@ -1077,8 +1077,8 @@ test('adjust balances', async t => {
   // reduce collateral  ///////////////////////////////////// (want both)
 
   // Alice reduce collateral by 100, withdrawing 50 RUN
-  const collateralDecrement = AmountMath.make(100n, aethBrand);
-  const withdrawRun2 = AmountMath.make(50n, runBrand);
+  const collateralDecrement = AmountMath.make(aethBrand, 100n);
+  const withdrawRun2 = AmountMath.make(runBrand, 50n);
   const withdrawRun2WithFees = multiplyBy(withdrawRun2, rates.loanFee);
   runDebtLevel = AmountMath.add(
     runDebtLevel,
@@ -1102,13 +1102,13 @@ test('adjust balances', async t => {
     aliceReduceCollateralSeat,
   ).getCurrentAllocation();
   const loanProceeds4 = await E(aliceReduceCollateralSeat).getPayouts();
-  t.deepEqual(lentAmount4, AmountMath.make(50n, runBrand));
+  t.deepEqual(lentAmount4, AmountMath.make(runBrand, 50n));
 
   const runBorrowed = await loanProceeds4.RUN;
   t.truthy(
     AmountMath.isEqual(
       await E(runIssuer).getAmountOf(runBorrowed),
-      AmountMath.make(50n, runBrand),
+      AmountMath.make(runBrand, 50n),
     ),
   );
   const collateralWithdrawn = await loanProceeds4.Collateral;
@@ -1131,8 +1131,8 @@ test('adjust balances', async t => {
   // NSF  ///////////////////////////////////// (want too much of both)
 
   // Alice reduce collateral by 100, withdrawing 50 RUN
-  const collateralDecr2 = AmountMath.make(800n, aethBrand);
-  const withdrawRun3 = AmountMath.make(500n, runBrand);
+  const collateralDecr2 = AmountMath.make(aethBrand, 800n);
+  const withdrawRun3 = AmountMath.make(runBrand, 500n);
   const withdrawRun3WithFees = multiplyBy(withdrawRun3, rates.loanFee);
   runDebtLevel = AmountMath.add(
     runDebtLevel,
@@ -1171,7 +1171,7 @@ test('overdeposit', async t => {
   const services = await setupServices(
     loanParams,
     [15n],
-    AmountMath.make(1n, aethBrand),
+    AmountMath.make(aethBrand, 1n),
     aethBrand,
     { committeeName: 'TheCabal', committeeSize: 5 },
   );
@@ -1181,7 +1181,7 @@ test('overdeposit', async t => {
   const { stablecoinMachine, lender } = services.stablecoin;
 
   // Add a vaultManager with 900 aeth collateral at a 201 aeth/RUN rate
-  const capitalAmount = AmountMath.make(900n, aethBrand);
+  const capitalAmount = AmountMath.make(aethBrand, 900n);
   const rates = makeRates(runBrand, aethBrand);
   const aethVaultManagerSeat = await E(zoe).offer(
     E(stablecoinMachine).makeAddTypeInvitation(aethIssuer, 'AEth', rates),
@@ -1199,8 +1199,8 @@ test('overdeposit', async t => {
   // Alice's loan /////////////////////////////////////
 
   // Create a loan for Alice for 5000 RUN with 1000 aeth collateral
-  const collateralAmount = AmountMath.make(1000n, aethBrand);
-  const aliceLoanAmount = AmountMath.make(5000n, runBrand);
+  const collateralAmount = AmountMath.make(aethBrand, 1000n);
+  const aliceLoanAmount = AmountMath.make(runBrand, 5000n);
   const aliceLoanSeat = await E(zoe).offer(
     E(lender).makeLoanInvitation(),
     harden({
@@ -1228,7 +1228,7 @@ test('overdeposit', async t => {
   t.truthy(
     AmountMath.isEqual(
       await E(runIssuer).getAmountOf(borrowedRun),
-      AmountMath.make(5000n, runBrand),
+      AmountMath.make(runBrand, 5000n),
     ),
   );
 
@@ -1241,8 +1241,8 @@ test('overdeposit', async t => {
   // Bob's loan /////////////////////////////////////
 
   // Create a loan for Bob for 1000 RUN with 200 aeth collateral
-  const bobCollateralAmount = AmountMath.make(200n, aethBrand);
-  const bobLoanAmount = AmountMath.make(1000n, runBrand);
+  const bobCollateralAmount = AmountMath.make(aethBrand, 200n);
+  const bobLoanAmount = AmountMath.make(runBrand, 1000n);
   const bobLoanSeat = await E(zoe).offer(
     E(lender).makeLoanInvitation(),
     harden({
@@ -1259,14 +1259,14 @@ test('overdeposit', async t => {
   t.truthy(
     AmountMath.isEqual(
       await E(runIssuer).getAmountOf(bobRun),
-      AmountMath.make(1000n, runBrand),
+      AmountMath.make(runBrand, 1000n),
     ),
   );
 
   // overpay debt ///////////////////////////////////// (give RUN)
 
   const combinedRun = await E(runIssuer).combine([borrowedRun, bobRun]);
-  const depositRun2 = AmountMath.make(6000n, runBrand);
+  const depositRun2 = AmountMath.make(runBrand, 6000n);
 
   const aliceOverpaySeat = await E(zoe).offer(
     E(aliceVault).makeAdjustBalancesInvitation(),
@@ -1282,12 +1282,12 @@ test('overdeposit', async t => {
 
   const { RUN: lentAmount5 } = await E(aliceOverpaySeat).getCurrentAllocation();
   const loanProceeds5 = await E(aliceOverpaySeat).getPayouts();
-  t.deepEqual(lentAmount5, AmountMath.make(750n, runBrand));
+  t.deepEqual(lentAmount5, AmountMath.make(runBrand, 750n));
 
   const runReturned = await loanProceeds5.RUN;
   t.deepEqual(
     await E(runIssuer).getAmountOf(runReturned),
-    AmountMath.make(750n, runBrand),
+    AmountMath.make(runBrand, 750n),
   );
 
   aliceUpdate = await aliceNotifier.getUpdateSince();
@@ -1295,11 +1295,11 @@ test('overdeposit', async t => {
   const aliceCollateralization5 = aliceUpdate.value.collateralizationRatio;
   t.deepEqual(
     aliceCollateralization5.numerator,
-    AmountMath.make(1000n, runBrand),
+    AmountMath.make(runBrand, 1000n),
   );
   t.deepEqual(
     aliceCollateralization5.denominator,
-    AmountMath.make(1n, runBrand),
+    AmountMath.make(runBrand, 1n),
   );
 
   const collectFeesSeat = await E(zoe).offer(
@@ -1335,7 +1335,7 @@ test('mutable liquidity triggers and interest', async t => {
   const services = await setupServices(
     loanParams,
     [10n, 7n],
-    AmountMath.make(1n, aethBrand),
+    AmountMath.make(aethBrand, 1n),
     aethBrand,
     { committeeName: 'TheCabal', committeeSize: 5 },
     manualTimer,
@@ -1347,7 +1347,7 @@ test('mutable liquidity triggers and interest', async t => {
   const { stablecoinMachine, lender } = services.stablecoin;
 
   // Add a vaultManager with 10000 aeth collateral at a 200 aeth/RUN rate
-  const capitalAmount = AmountMath.make(10000n, aethBrand);
+  const capitalAmount = AmountMath.make(aethBrand, 10000n);
   const rates = harden({
     initialPrice: makeRatio(200n, runBrand, PERCENT, aethBrand),
     initialMargin: makeRatio(120n, runBrand),
@@ -1373,8 +1373,8 @@ test('mutable liquidity triggers and interest', async t => {
   // initial loans /////////////////////////////////////
 
   // Create a loan for Alice for 5000 RUN with 1000 aeth collateral
-  const aliceCollateralAmount = AmountMath.make(1000n, aethBrand);
-  const aliceLoanAmount = AmountMath.make(5000n, runBrand);
+  const aliceCollateralAmount = AmountMath.make(aethBrand, 1000n);
+  const aliceLoanAmount = AmountMath.make(runBrand, 5000n);
   const aliceLoanSeat = await E(zoe).offer(
     E(lender).makeLoanInvitation(),
     harden({
@@ -1392,7 +1392,7 @@ test('mutable liquidity triggers and interest', async t => {
   const aliceDebtAmount = await E(aliceVault).getDebtAmount();
   const fee = multiplyBy(aliceLoanAmount, rates.loanFee);
   const aliceRunDebtLevel = AmountMath.add(aliceLoanAmount, fee);
-  let aliceCollateralLevel = AmountMath.make(1000n, aethBrand);
+  let aliceCollateralLevel = AmountMath.make(aethBrand, 1000n);
 
   t.deepEqual(aliceDebtAmount, aliceRunDebtLevel, 'vault lent 5000 RUN + fees');
   const { RUN: aliceLentAmount } = await E(
@@ -1405,7 +1405,7 @@ test('mutable liquidity triggers and interest', async t => {
   t.truthy(
     AmountMath.isEqual(
       await E(runIssuer).getAmountOf(aliceRunLent),
-      AmountMath.make(5000n, runBrand),
+      AmountMath.make(runBrand, 5000n),
     ),
   );
 
@@ -1413,8 +1413,8 @@ test('mutable liquidity triggers and interest', async t => {
   t.deepEqual(aliceUpdate.value.debt, aliceRunDebtLevel);
 
   // Create a loan for Bob for 740 RUN with 100 Aeth collateral
-  const bobCollateralAmount = AmountMath.make(100n, aethBrand);
-  const bobLoanAmount = AmountMath.make(740n, runBrand);
+  const bobCollateralAmount = AmountMath.make(aethBrand, 100n);
+  const bobLoanAmount = AmountMath.make(runBrand, 740n);
   const bobLoanSeat = await E(zoe).offer(
     E(lender).makeLoanInvitation(),
     harden({
@@ -1442,7 +1442,7 @@ test('mutable liquidity triggers and interest', async t => {
   t.truthy(
     AmountMath.isEqual(
       await E(runIssuer).getAmountOf(bobRunLent),
-      AmountMath.make(740n, runBrand),
+      AmountMath.make(runBrand, 740n),
     ),
   );
 
@@ -1453,7 +1453,7 @@ test('mutable liquidity triggers and interest', async t => {
 
   // Alice reduce collateral by 300. That leaves her at 700 * 10 > 1.05 * 5000.
   // Prices will drop from 10 to 7, she'll be liquidated: 700 * 7 < 1.05 * 5000.
-  const collateralDecrement = AmountMath.make(300n, aethBrand);
+  const collateralDecrement = AmountMath.make(aethBrand, 300n);
   aliceCollateralLevel = AmountMath.subtract(
     aliceCollateralLevel,
     collateralDecrement,
@@ -1471,7 +1471,7 @@ test('mutable liquidity triggers and interest', async t => {
     aliceReduceCollateralSeat,
   ).getCurrentAllocation();
   const loanProceeds4 = await E(aliceReduceCollateralSeat).getPayouts();
-  t.deepEqual(aliceWithdrawnAeth, AmountMath.make(300n, aethBrand));
+  t.deepEqual(aliceWithdrawnAeth, AmountMath.make(aethBrand, 300n));
 
   const collateralWithdrawn = await loanProceeds4.Collateral;
   t.truthy(
@@ -1572,7 +1572,7 @@ test('coll fees from loan and AMM', async t => {
     aethKit: { mint: aethMint, issuer: aethIssuer, brand: aethBrand },
   } = setupAssets();
   const priceList = [500n, 15n];
-  const unitAmountIn = AmountMath.make(900n, aethBrand);
+  const unitAmountIn = AmountMath.make(aethBrand, 900n);
   const electorateTerms = { committeeName: 'TheCabal', committeeSize: 5 };
   const manualTimer = buildManualTimer(console.log);
 
@@ -1590,7 +1590,7 @@ test('coll fees from loan and AMM', async t => {
   const { stablecoinMachine, lender } = services.stablecoin;
 
   // Add a pool with 900 aeth collateral at a 201 aeth/RUN rate
-  const capitalAmount = AmountMath.make(900n, aethBrand);
+  const capitalAmount = AmountMath.make(aethBrand, 900n);
   const rates = makeRates(runBrand, aethBrand);
   const aethVaultSeat = await E(zoe).offer(
     E(stablecoinMachine).makeAddTypeInvitation(aethIssuer, 'AEth', rates),
@@ -1606,8 +1606,8 @@ test('coll fees from loan and AMM', async t => {
   await E(aethVaultSeat).getOfferResult();
 
   // Create a loan for 470 RUN with 1100 aeth collateral
-  const collateralAmount = AmountMath.make(1100n, aethBrand);
-  const loanAmount = AmountMath.make(470n, runBrand);
+  const collateralAmount = AmountMath.make(aethBrand, 1100n);
+  const loanAmount = AmountMath.make(runBrand, 470n);
   const loanSeat = await E(zoe).offer(
     E(lender).makeLoanInvitation(),
     harden({
@@ -1621,7 +1621,7 @@ test('coll fees from loan and AMM', async t => {
 
   const { vault } = await E(loanSeat).getOfferResult();
   const debtAmount = await E(vault).getDebtAmount();
-  const fee = multiplyBy(AmountMath.make(470n, runBrand), rates.loanFee);
+  const fee = multiplyBy(AmountMath.make(runBrand, 470n), rates.loanFee);
   t.deepEqual(
     debtAmount,
     AmountMath.add(loanAmount, fee),
@@ -1635,12 +1635,12 @@ test('coll fees from loan and AMM', async t => {
   t.deepEqual(lentAmount, loanAmount, 'received 47 RUN');
   t.deepEqual(
     vault.getCollateralAmount(),
-    AmountMath.make(1100n, aethBrand),
+    AmountMath.make(aethBrand, 1100n),
     'vault holds 1100 Collateral',
   );
 
   t.deepEqual(stablecoinMachine.getRewardAllocation(), {
-    RUN: AmountMath.make(23n, runBrand),
+    RUN: AmountMath.make(runBrand, 23n),
   });
 
   const amm = E(zoe).getPublicFacet(await E(stablecoinMachine).getAMM());
@@ -1682,7 +1682,7 @@ test('close loan', async t => {
   const services = await setupServices(
     loanParams,
     [15n],
-    AmountMath.make(1n, aethBrand),
+    AmountMath.make(aethBrand, 1n),
     aethBrand,
     { committeeName: 'Star Chamber', committeeSize: 5 },
   );
@@ -1692,7 +1692,7 @@ test('close loan', async t => {
   const { stablecoinMachine, lender } = services.stablecoin;
 
   // Add a vaultManager with 900 aeth collateral at a 201 aeth/RUN rate
-  const capitalAmount = AmountMath.make(900n, aethBrand);
+  const capitalAmount = AmountMath.make(aethBrand, 900n);
   const rates = makeRates(runBrand, aethBrand);
   const aethVaultManagerSeat = await E(zoe).offer(
     E(stablecoinMachine).makeAddTypeInvitation(aethIssuer, 'AEth', rates),
@@ -1710,8 +1710,8 @@ test('close loan', async t => {
   // initial loan /////////////////////////////////////
 
   // Create a loan for Alice for 5000 RUN with 1000 aeth collateral
-  const collateralAmount = AmountMath.make(1000n, aethBrand);
-  const aliceLoanAmount = AmountMath.make(5000n, runBrand);
+  const collateralAmount = AmountMath.make(aethBrand, 1000n);
+  const aliceLoanAmount = AmountMath.make(runBrand, 5000n);
   const aliceLoanSeat = await E(zoe).offer(
     E(lender).makeLoanInvitation(),
     harden({
@@ -1739,7 +1739,7 @@ test('close loan', async t => {
   t.truthy(
     AmountMath.isEqual(
       await E(runIssuer).getAmountOf(runLent),
-      AmountMath.make(5000n, runBrand),
+      AmountMath.make(runBrand, 5000n),
     ),
   );
 
@@ -1750,8 +1750,8 @@ test('close loan', async t => {
   t.deepEqual(aliceCollateralization1.denominator.value, runDebtLevel.value);
 
   // Create a loan for Bob for 1000 RUN with 200 aeth collateral
-  const bobCollateralAmount = AmountMath.make(200n, aethBrand);
-  const bobLoanAmount = AmountMath.make(1000n, runBrand);
+  const bobCollateralAmount = AmountMath.make(aethBrand, 200n);
+  const bobLoanAmount = AmountMath.make(runBrand, 1000n);
   const bobLoanSeat = await E(zoe).offer(
     E(lender).makeLoanInvitation(),
     harden({
@@ -1768,7 +1768,7 @@ test('close loan', async t => {
   t.truthy(
     AmountMath.isEqual(
       await E(runIssuer).getAmountOf(bobRun),
-      AmountMath.make(1000n, runBrand),
+      AmountMath.make(runBrand, 1000n),
     ),
   );
 
@@ -1779,7 +1779,7 @@ test('close loan', async t => {
   const aliceCloseSeat = await E(zoe).offer(
     E(aliceVault).makeCloseInvitation(),
     harden({
-      give: { RUN: AmountMath.make(6000n, runBrand) },
+      give: { RUN: AmountMath.make(runBrand, 6000n) },
       want: { Collateral: AmountMath.makeEmpty(aethBrand) },
     }),
     harden({ RUN: runRepayment }),
@@ -1790,15 +1790,15 @@ test('close loan', async t => {
 
   const closeAlloc = await E(aliceCloseSeat).getCurrentAllocation();
   t.deepEqual(closeAlloc, {
-    RUN: AmountMath.make(750n, runBrand),
-    Collateral: AmountMath.make(1000n, aethBrand),
+    RUN: AmountMath.make(runBrand, 750n),
+    Collateral: AmountMath.make(aethBrand, 1000n),
   });
   const closeProceeds = await E(aliceCloseSeat).getPayouts();
   const collProceeds = await aethIssuer.getAmountOf(closeProceeds.Collateral);
   const runProceeds = await E(runIssuer).getAmountOf(closeProceeds.RUN);
 
-  t.deepEqual(runProceeds, AmountMath.make(750n, runBrand));
-  t.deepEqual(collProceeds, AmountMath.make(1000n, aethBrand));
+  t.deepEqual(runProceeds, AmountMath.make(runBrand, 750n));
+  t.deepEqual(collProceeds, AmountMath.make(aethBrand, 1000n));
   t.deepEqual(
     await E(aliceVault).getCollateralAmount(),
     AmountMath.makeEmpty(aethBrand),

--- a/packages/treasury/test/test-vault-interest.js
+++ b/packages/treasury/test/test-vault-interest.js
@@ -74,10 +74,10 @@ async function launch(zoeP, sourceRoot) {
   } = testJig;
   const { brand: runBrand } = runMint.getIssuerRecord();
 
-  const collateral50 = AmountMath.make(50000n, collaterlBrand);
+  const collateral50 = AmountMath.make(collaterlBrand, 50000n);
   const proposal = harden({
     give: { Collateral: collateral50 },
-    want: { RUN: AmountMath.make(70000n, runBrand) },
+    want: { RUN: AmountMath.make(runBrand, 70000n) },
   });
   const payments = harden({
     Collateral: collateralMint.mintPayment(collateral50),
@@ -108,18 +108,18 @@ test('interest', async t => {
   const { brand: runBrand } = runMint.getIssuerRecord();
 
   const { value: v1, updateCount: c1 } = await E(notifier).getUpdateSince();
-  t.deepEqual(v1.debt, AmountMath.make(73500n, runBrand));
-  t.deepEqual(v1.locked, AmountMath.make(50000n, collateralBrand));
+  t.deepEqual(v1.debt, AmountMath.make(runBrand, 73500n));
+  t.deepEqual(v1.locked, AmountMath.make(collateralBrand, 50000n));
   t.is(c1, 2);
 
   t.deepEqual(
     vault.getDebtAmount(),
-    AmountMath.make(73500n, runBrand),
+    AmountMath.make(runBrand, 73500n),
     'borrower owes 73 RUN',
   );
   t.deepEqual(
     vault.getCollateralAmount(),
-    AmountMath.make(50000n, collateralBrand),
+    AmountMath.make(collateralBrand, 50000n),
     'vault holds 50 Collateral',
   );
 
@@ -136,11 +136,11 @@ test('interest', async t => {
     timer.getCurrentTimestamp(),
   );
   t.truthy(
-    AmountMath.isEqual(nextInterest, AmountMath.make(63n, runBrand)),
+    AmountMath.isEqual(nextInterest, AmountMath.make(runBrand, 63n)),
     `interest should be 3, was ${nextInterest.value}`,
   );
   const { value: v2, updateCount: c2 } = await E(notifier).getUpdateSince(c1);
-  t.deepEqual(v2.debt, AmountMath.make(73500n + 63n, runBrand));
+  t.deepEqual(v2.debt, AmountMath.make(runBrand, 73500n + 63n));
   t.deepEqual(v2.interestRate, makeRatio(5n, runBrand, 100n));
   t.deepEqual(v2.liquidationRatio, makeRatio(105n, runBrand));
   const collateralization = v2.collateralizationRatio;

--- a/packages/treasury/test/test-vault.js
+++ b/packages/treasury/test/test-vault.js
@@ -72,10 +72,10 @@ async function launch(zoeP, sourceRoot) {
   } = testJig;
   const { brand: runBrand } = runMint.getIssuerRecord();
 
-  const collateral50 = AmountMath.make(50n, collaterlBrand);
+  const collateral50 = AmountMath.make(collaterlBrand, 50n);
   const proposal = harden({
     give: { Collateral: collateral50 },
-    want: { RUN: AmountMath.make(70n, runBrand) },
+    want: { RUN: AmountMath.make(runBrand, 70n) },
   });
   const payments = harden({
     Collateral: collateralMint.mintPayment(collateral50),
@@ -104,25 +104,25 @@ test('first', async t => {
 
   t.deepEqual(
     vault.getDebtAmount(),
-    AmountMath.make(73n, runBrand),
+    AmountMath.make(runBrand, 73n),
     'borrower owes 73 RUN',
   );
   t.deepEqual(
     vault.getCollateralAmount(),
-    AmountMath.make(50n, cBrand),
+    AmountMath.make(cBrand, 50n),
     'vault holds 50 Collateral',
   );
 
   // Add more collateral to an existing loan. We get nothing back but a warm
   // fuzzy feeling.
 
-  const collateralAmount = AmountMath.make(20n, cBrand);
+  const collateralAmount = AmountMath.make(cBrand, 20n);
   const invite = await E(creatorFacet).makeAdjustBalancesInvitation();
   const giveCollateralSeat = await E(zoe).offer(
     invite,
     harden({
       give: { Collateral: collateralAmount },
-      want: {}, // RUN: AmountMath.make(2n, runBrand) },
+      want: {}, // RUN: AmountMath.make(runBrand, 2n) },
     }),
     harden({
       // TODO
@@ -133,14 +133,14 @@ test('first', async t => {
   await E(giveCollateralSeat).getOfferResult();
   t.deepEqual(
     vault.getCollateralAmount(),
-    AmountMath.make(70n, cBrand),
+    AmountMath.make(cBrand, 70n),
     'vault holds 70 Collateral',
   );
   trace('addCollateral');
 
   // partially payback
-  const collateralWanted = AmountMath.make(1n, cBrand);
-  const paybackAmount = AmountMath.make(3n, runBrand);
+  const collateralWanted = AmountMath.make(cBrand, 1n);
+  const paybackAmount = AmountMath.make(runBrand, 3n);
   const payback = await E(creatorFacet).mintRun(paybackAmount);
   const paybackSeat = E(zoe).offer(
     vault.makeAdjustBalancesInvitation(),
@@ -157,17 +157,17 @@ test('first', async t => {
   const returnedAmount = await cIssuer.getAmountOf(returnedCollateral);
   t.deepEqual(
     vault.getDebtAmount(),
-    AmountMath.make(70n, runBrand),
+    AmountMath.make(runBrand, 70n),
     'debt reduced to 70 RUN',
   );
   t.deepEqual(
     vault.getCollateralAmount(),
-    AmountMath.make(69n, cBrand),
+    AmountMath.make(cBrand, 69n),
     'vault holds 69 Collateral',
   );
   t.deepEqual(
     returnedAmount,
-    AmountMath.make(1n, cBrand),
+    AmountMath.make(cBrand, 1n),
     'withdrew 1 collateral',
   );
   t.is(returnedAmount.value, 1n, 'withdrew 1 collateral');
@@ -187,20 +187,20 @@ test('bad collateral', async t => {
 
   t.deepEqual(
     vault.getCollateralAmount(),
-    AmountMath.make(50n, collateralBrand),
+    AmountMath.make(collateralBrand, 50n),
     'vault should hold 50 Collateral',
   );
   t.deepEqual(
     vault.getDebtAmount(),
-    AmountMath.make(73n, runBrand),
+    AmountMath.make(runBrand, 73n),
     'borrower owes 73 RUN',
   );
 
-  const collateralAmount = AmountMath.make(2n, collateralBrand);
+  const collateralAmount = AmountMath.make(collateralBrand, 2n);
 
   // adding the wrong kind of collateral should be rejected
   const { mint: wrongMint, brand: wrongBrand } = makeIssuerKit('wrong');
-  const wrongAmount = AmountMath.make(2n, wrongBrand);
+  const wrongAmount = AmountMath.make(wrongBrand, 2n);
   const p = E(zoe).offer(
     vault.makeAdjustBalancesInvitation(),
     harden({
@@ -220,5 +220,5 @@ test('bad collateral', async t => {
   // p.then(_ => console.log('oops passed'),
   //       rej => console.log('reg', rej));
   // t.rejects(p, / /, 'addCollateral requires the right kind', {});
-  // t.throws(async () => { await p; }, /payment not found for/);
+  // t.throws(async () => { await p; }, /was not a live payment/);
 });

--- a/packages/treasury/test/vault-contract-wrapper.js
+++ b/packages/treasury/test/vault-contract-wrapper.js
@@ -35,7 +35,7 @@ export async function start(zcf, privateArgs) {
   const autoswapMock = {
     getInputPrice(amountIn, brandOut) {
       assert.equal(brandOut, runBrand);
-      return AmountMath.make(4n * amountIn.value, runBrand);
+      return AmountMath.make(runBrand, 4n * amountIn.value);
     },
   };
 

--- a/packages/vats/src/issuers.js
+++ b/packages/vats/src/issuers.js
@@ -4,12 +4,10 @@ import { Nat } from '@agoric/nat';
 
 export const CENTRAL_ISSUER_NAME = 'RUN';
 
-/** @typedef {number | bigint} Bigish */
-
 /**
  * @typedef {Object} CollateralConfig
  * @property {string} keyword
- * @property {Bigish} collateralValue the initial price of this collateral is
+ * @property {NatValue} collateralValue the initial price of this collateral is
  * provided by tradesGivenCentral[0]
  * @property {bigint} initialMarginPercent
  * @property {bigint} liquidationMarginPercent
@@ -26,14 +24,15 @@ export const CENTRAL_ISSUER_NAME = 'RUN';
  * @property {string} [bankDenom]
  * @property {string} [bankPurse]
  * @property {Payment} [bankPayment]
- * @property {Array<[string, Bigish]>} [defaultPurses]
- * @property {Array<[Bigish, Bigish]>} [tradesGivenCentral]
+ * @property {Array<[string, bigint | number]>} [defaultPurses]
+ * @property {Array<[bigint | number, bigint | number]>} [tradesGivenCentral]
  */
 
 /**
  * @callback Scaler Scale a number from a (potentially fractional) input to a
  * fixed-precision bigint
- * @param {Bigish} n the input number to scale
+ * @param {bigint | number} n the input number to scale, must be a
+ * natural number
  * @param {number} [fromDecimalPlaces=0] number of decimal places to keep from the input
  * @returns {bigint} the scaled integer
  */

--- a/packages/vats/test/test-distributeFees.js
+++ b/packages/vats/test/test-distributeFees.js
@@ -78,7 +78,7 @@ test('fee distribution', async t => {
   await epochTimer.tick();
   await waitForPromisesToSettle();
 
-  await assertPaymentArray(t, getPayments(), 1, 500, issuer, brand);
+  await assertPaymentArray(t, getPayments(), 1, 500n, issuer, brand);
 });
 
 test('fee distribution, leftovers', async t => {
@@ -99,7 +99,7 @@ test('fee distribution, leftovers', async t => {
   await epochTimer.tick();
   await waitForPromisesToSettle();
 
-  assertPaymentArray(t, getPayments(), 1, 12, issuer, brand);
+  assertPaymentArray(t, getPayments(), 1, 12n, issuer, brand);
 
   // Pay them again
   treasury.pushFees(runMint.mintPayment(AmountMath.make(brand, 13n)));
@@ -107,5 +107,5 @@ test('fee distribution, leftovers', async t => {
   await epochTimer.tick();
   await waitForPromisesToSettle();
 
-  await assertPaymentArray(t, getPayments().slice(1), 1, 13, issuer, brand);
+  await assertPaymentArray(t, getPayments().slice(1), 1, 13n, issuer, brand);
 });

--- a/packages/vats/test/test-vat-bank.js
+++ b/packages/vats/test/test-vat-bank.js
@@ -156,9 +156,13 @@ test('communication', async t => {
     ),
   );
 
-  const { mint, ...feeKit } = makeIssuerKit('fee', AssetKind.NAT, {
-    decimalPlaces: 6,
-  });
+  const { mint, ...feeKit } = makeIssuerKit(
+    'fee',
+    AssetKind.NAT,
+    harden({
+      decimalPlaces: 6,
+    }),
+  );
 
   const backingFee = mint.mintPayment(AmountMath.make(feeKit.brand, 20000000n));
   await E(bankMgr).addAsset('ufee', 'FEE', 'ERTP Fees', {

--- a/packages/zoe/jsconfig.json
+++ b/packages/zoe/jsconfig.json
@@ -15,5 +15,7 @@
     "strictNullChecks": true,
     "moduleResolution": "node",
   },
+  // To include tests, change to:
+  //  "include": ["src/**/*.js", "exported.js", "tools/**/*.js", "test/**/*.js"], 
   "include": ["src/**/*.js", "exported.js", "tools/**/*.js"],
 }

--- a/packages/zoe/src/cleanProposal.js
+++ b/packages/zoe/src/cleanProposal.js
@@ -80,7 +80,7 @@ const coerceAmountKeywordRecord = (
       assetKind === brandAssetKind,
       X`The amount ${amount} did not have the assetKind of the brand ${brandAssetKind}`,
     );
-    return AmountMath.coerce(amount, amount.brand);
+    return AmountMath.coerce(amount.brand, amount);
   });
 
   // Recreate the amountKeywordRecord with coercedAmounts.

--- a/packages/zoe/src/contractSupport/bondingCurves.js
+++ b/packages/zoe/src/contractSupport/bondingCurves.js
@@ -108,6 +108,13 @@ export const getOutputPrice = (
 // liquidity multiplied by the ratio of new central tokens to central tokens
 // already held. If the current supply is zero, return the inputValue as the
 // initial liquidity to mint is arbitrary.
+/**
+ *
+ * @param {bigint} liqTokenSupply
+ * @param {bigint} inputValue
+ * @param {bigint} inputReserve
+ * @returns {NatValue}
+ */
 export const calcLiqValueToMint = (
   liqTokenSupply,
   inputValue,

--- a/packages/zoe/src/contractSupport/priceAuthority.js
+++ b/packages/zoe/src/contractSupport/priceAuthority.js
@@ -98,8 +98,8 @@ export function makeOnewayPriceAuthorityKit(opts) {
      * of calcAmountTrigger
      */
     async function quoteWhenOutTrigger(amountIn, amountOutLimit) {
-      AmountMath.coerce(amountIn, actualBrandIn);
-      AmountMath.coerce(amountOutLimit, actualBrandOut);
+      amountIn = AmountMath.coerce(actualBrandIn, amountIn);
+      amountOutLimit = AmountMath.coerce(actualBrandOut, amountOutLimit);
 
       /** @type {PromiseRecord<PriceQuote>} */
       const triggerPK = makePromiseKit();
@@ -147,8 +147,8 @@ export function makeOnewayPriceAuthorityKit(opts) {
 
   const makeMutableQuote = compareAmountsFn =>
     async function mutableQuoteWhenOutTrigger(amountInArg, amountOutLimitArg) {
-      let amountIn = AmountMath.coerce(amountInArg, actualBrandIn);
-      let amountOutLimit = AmountMath.coerce(amountOutLimitArg, actualBrandOut);
+      let amountIn = AmountMath.coerce(actualBrandIn, amountInArg);
+      let amountOutLimit = AmountMath.coerce(actualBrandOut, amountOutLimitArg);
 
       /** @type {PromiseRecord<PriceQuote>} */
       const triggerPK = makePromiseKit();
@@ -156,10 +156,10 @@ export function makeOnewayPriceAuthorityKit(opts) {
       const mutableQuote = Far('MutableQuote', {
         cancel: e => triggerPK.reject(e),
         updateLevel: (newAmountIn, newAmountOutLimit) => {
-          const coercedAmountIn = AmountMath.coerce(newAmountIn, actualBrandIn);
+          const coercedAmountIn = AmountMath.coerce(actualBrandIn, newAmountIn);
           const coercedAmountOutLimit = AmountMath.coerce(
-            newAmountOutLimit,
             actualBrandOut,
+            newAmountOutLimit,
           );
           amountIn = coercedAmountIn;
           amountOutLimit = coercedAmountOutLimit;
@@ -238,7 +238,7 @@ export function makeOnewayPriceAuthorityKit(opts) {
       return timer;
     },
     makeQuoteNotifier(amountIn, brandOut) {
-      AmountMath.coerce(amountIn, actualBrandIn);
+      AmountMath.coerce(actualBrandIn, amountIn);
       assertBrands(amountIn.brand, brandOut);
 
       // Wrap our underlying notifier with specific quotes.
@@ -271,7 +271,7 @@ export function makeOnewayPriceAuthorityKit(opts) {
       return specificNotifier;
     },
     async quoteGiven(amountIn, brandOut) {
-      AmountMath.coerce(amountIn, actualBrandIn);
+      AmountMath.coerce(actualBrandIn, amountIn);
       assertBrands(amountIn.brand, brandOut);
 
       await E(notifier).getUpdateSince();
@@ -283,7 +283,7 @@ export function makeOnewayPriceAuthorityKit(opts) {
       return quote;
     },
     async quoteWanted(brandIn, amountOut) {
-      AmountMath.coerce(amountOut, actualBrandOut);
+      AmountMath.coerce(actualBrandOut, amountOut);
       assertBrands(brandIn, amountOut.brand);
 
       await E(notifier).getUpdateSince();
@@ -303,7 +303,7 @@ export function makeOnewayPriceAuthorityKit(opts) {
     },
     async quoteAtTime(deadline, amountIn, brandOut) {
       assert.typeof(deadline, 'bigint');
-      AmountMath.coerce(amountIn, actualBrandIn);
+      AmountMath.coerce(actualBrandIn, amountIn);
       assertBrands(amountIn.brand, brandOut);
 
       await E(notifier).getUpdateSince();

--- a/packages/zoe/src/contractSupport/ratio.js
+++ b/packages/zoe/src/contractSupport/ratio.js
@@ -3,8 +3,8 @@
 import './types.js';
 import { assert, details as X, q } from '@agoric/assert';
 import { AmountMath } from '@agoric/ertp';
-import natMathHelpers from '@agoric/ertp/src/mathHelpers/natMathHelpers.js';
 import { assertRecord } from '@agoric/marshal';
+import { isNat } from '@agoric/nat';
 
 import { natSafeMath } from './safeMath.js';
 
@@ -49,8 +49,16 @@ export const assertIsRatio = ratio => {
       X`Parameter must be a Ratio record, but ${ratio} has ${q(name)}`,
     );
   }
-  natMathHelpers.doCoerce(ratio.numerator.value);
-  natMathHelpers.doCoerce(ratio.denominator.value);
+  const numeratorValue = ratio.numerator.value;
+  const denominatorValue = ratio.denominator.value;
+  assert(
+    isNat(numeratorValue),
+    X`The numerator value must be a NatValue, not ${numeratorValue}`,
+  );
+  assert(
+    isNat(denominatorValue),
+    X`The denominator value must be a NatValue, not ${denominatorValue}`,
+  );
 };
 
 /** @type {MakeRatio} */

--- a/packages/zoe/src/contractSupport/ratio.js
+++ b/packages/zoe/src/contractSupport/ratio.js
@@ -2,9 +2,9 @@
 
 import './types.js';
 import { assert, details as X, q } from '@agoric/assert';
-import { Nat } from '@agoric/nat';
 import { AmountMath } from '@agoric/ertp';
-import { passStyleOf } from '@agoric/marshal';
+import natMathHelpers from '@agoric/ertp/src/mathHelpers/natMathHelpers.js';
+import { assertRecord } from '@agoric/marshal';
 
 import { natSafeMath } from './safeMath.js';
 
@@ -40,20 +40,17 @@ const PERCENT = 100n;
 const ratioPropertyNames = ['numerator', 'denominator'];
 
 export const assertIsRatio = ratio => {
-  assert.equal(passStyleOf(ratio), 'copyRecord');
-  const propertyNames = Object.getOwnPropertyNames(ratio);
-  assert(
-    propertyNames.length === 2,
-    X`Ratio ${ratio} must be a record with 2 fields.`,
-  );
-  for (const name of propertyNames) {
+  assertRecord(ratio, 'ratio');
+  const keys = Object.keys(ratio);
+  assert(keys.length === 2, X`Ratio ${ratio} must be a record with 2 fields.`);
+  for (const name of keys) {
     assert(
       ratioPropertyNames.includes(name),
       X`Parameter must be a Ratio record, but ${ratio} has ${q(name)}`,
     );
   }
-  Nat(ratio.numerator.value);
-  Nat(ratio.denominator.value);
+  natMathHelpers.doCoerce(ratio.numerator.value);
+  natMathHelpers.doCoerce(ratio.denominator.value);
 };
 
 /** @type {MakeRatio} */
@@ -69,8 +66,8 @@ export const makeRatio = (
   );
 
   return harden({
-    numerator: AmountMath.make(numeratorBrand, Nat(numerator)),
-    denominator: AmountMath.make(denominatorBrand, Nat(denominator)),
+    numerator: AmountMath.make(numeratorBrand, numerator),
+    denominator: AmountMath.make(denominatorBrand, denominator),
   });
 };
 
@@ -79,9 +76,9 @@ export const makeRatioFromAmounts = (numeratorAmount, denominatorAmount) => {
   AmountMath.coerce(numeratorAmount.brand, numeratorAmount);
   AmountMath.coerce(denominatorAmount.brand, denominatorAmount);
   return makeRatio(
-    Nat(/** @type {NatValue} */ (numeratorAmount.value)),
+    /** @type {NatValue} */ (numeratorAmount.value),
     numeratorAmount.brand,
-    Nat(/** @type {NatValue} */ (denominatorAmount.value)),
+    /** @type {NatValue} */ (denominatorAmount.value),
     denominatorAmount.brand,
   );
 };

--- a/packages/zoe/src/contractSupport/safeMath.js
+++ b/packages/zoe/src/contractSupport/safeMath.js
@@ -19,6 +19,5 @@ export const natSafeMath = harden({
     y = Nat(y);
     return Nat(Nat(x) + y - 1n) / y;
   },
-  // Numbers and BigInts already compare magnitudes correctly.
   isGTE: (x, y) => x >= y,
 });

--- a/packages/zoe/src/contractSupport/types.js
+++ b/packages/zoe/src/contractSupport/types.js
@@ -131,7 +131,7 @@
  * @callback MakeRatio
  * @param {bigint} numerator
  * @param {Brand} numeratorBrand
- * @param {bigint=} denominator The default denomiator is 100
+ * @param {bigint=} denominator The default denominator is 100
  * @param {Brand=} denominatorBrand The default is to reuse the numeratorBrand
  * @returns {Ratio}
  */

--- a/packages/zoe/src/contracts/attestation/expiring/expiringNFT.js
+++ b/packages/zoe/src/contracts/attestation/expiring/expiringNFT.js
@@ -69,7 +69,10 @@ const setupAttestation = async (attestationTokenName, empty, zcf) => {
       handle,
     );
 
-    const amountToMint = AmountMath.make(attestationBrand, [attestationElem]);
+    const amountToMint = AmountMath.make(
+      attestationBrand,
+      harden([attestationElem]),
+    );
     addToLiened(lienedAmounts, attestationElem);
 
     return mintZCFMintPayment(zcf, zcfMint, amountToMint);

--- a/packages/zoe/src/contracts/attestation/expiring/extendExpiration.js
+++ b/packages/zoe/src/contracts/attestation/expiring/extendExpiration.js
@@ -68,7 +68,7 @@ const extendExpiration = (
 
   const valueToMint = attestationValue.map(makeNewAttestationElem);
 
-  const amountToMint = AmountMath.make(attestationBrand, valueToMint);
+  const amountToMint = AmountMath.make(attestationBrand, harden(valueToMint));
 
   // commit point within updateLienedAmount
   valueToMint.forEach(updateLienedAmount);

--- a/packages/zoe/src/contracts/attestation/returnable/returnableNFT.js
+++ b/packages/zoe/src/contracts/attestation/returnable/returnableNFT.js
@@ -48,12 +48,15 @@ const setupAttestation = async (attestationTokenName, empty, zcf) => {
     const amountToLien = validateInputs(externalBrand, address, amount);
 
     addToLiened(lienedAmounts, address, amountToLien);
-    const amountToMint = AmountMath.make(attestationBrand, [
-      /** @type {ReturnableAttElem} */ ({
-        address,
-        amountLiened: amountToLien,
-      }),
-    ]);
+    const amountToMint = AmountMath.make(
+      attestationBrand,
+      harden([
+        /** @type {ReturnableAttElem} */ ({
+          address,
+          amountLiened: amountToLien,
+        }),
+      ]),
+    );
 
     return mintZCFMintPayment(zcf, zcfMint, amountToMint);
   };

--- a/packages/zoe/src/contracts/autoswap.js
+++ b/packages/zoe/src/contracts/autoswap.js
@@ -142,7 +142,7 @@ const start = async zcf => {
       getPoolAmount(amountIn.brand).value,
       getPoolAmount(wantedAmountOut.brand).value,
     );
-    const tradeAmountOut = AmountMath.make(outputValue, wantedAmountOut.brand);
+    const tradeAmountOut = AmountMath.make(wantedAmountOut.brand, outputValue);
     return consummate(amountIn, tradeAmountOut, swapSeat);
   };
 
@@ -173,7 +173,7 @@ const start = async zcf => {
       getPoolAmount(wantedAmountOut.brand).value,
     );
     assert(tradePrice <= amountIn.value, 'amountIn insufficient');
-    const tradeAmountIn = AmountMath.make(tradePrice, amountIn.brand);
+    const tradeAmountIn = AmountMath.make(amountIn.brand, tradePrice);
 
     return consummate(tradeAmountIn, wantedAmountOut, swapSeat);
   };
@@ -185,17 +185,17 @@ const start = async zcf => {
     const liquidityValueOut = calcLiqValueToMint(
       liqTokenSupply,
       centralIn,
-      centralPool,
+      /** @type {bigint} */ (centralPool),
     );
     const liquidityAmountOut = AmountMath.make(
-      liquidityValueOut,
       liquidityBrand,
+      liquidityValueOut,
     );
     liquidityMint.mintGains({ Liquidity: liquidityAmountOut }, poolSeat);
     liqTokenSupply += liquidityValueOut;
 
     const liquidityDeposited = {
-      Central: AmountMath.make(centralIn, brands.Central),
+      Central: AmountMath.make(brands.Central, centralIn),
       Secondary: secondaryAmount,
     };
     poolSeat.incrementBy(seat.decrementBy(liquidityDeposited));
@@ -242,13 +242,13 @@ const start = async zcf => {
     // To calculate liquidity, we'll need to calculate alpha from the primary
     // token's value before, and the value that will be added to the pool
     const secondaryOut = AmountMath.make(
+      secondaryIn.brand,
       calcSecondaryRequired(
         userAllocation.Central.value,
         getPoolAmount(brands.Central).value,
         getPoolAmount(brands.Secondary).value,
         secondaryIn.value,
       ),
-      secondaryIn.brand,
     );
 
     // Central was specified precisely so offer must provide enough secondary.
@@ -272,20 +272,20 @@ const start = async zcf => {
     assert(isNatValue(liquidityValueIn));
 
     const newUserCentralAmount = AmountMath.make(
+      brands.Central,
       calcValueToRemove(
         liqTokenSupply,
         getPoolAmount(brands.Central).value,
         liquidityValueIn,
       ),
-      brands.Central,
     );
     const newUserSecondaryAmount = AmountMath.make(
+      brands.Secondary,
       calcValueToRemove(
         liqTokenSupply,
         getPoolAmount(brands.Secondary).value,
         liquidityValueIn,
       ),
-      brands.Secondary,
     );
 
     liqTokenSupply -= liquidityValueIn;
@@ -339,7 +339,7 @@ const start = async zcf => {
       inputReserve,
       outputReserve,
     );
-    return AmountMath.make(outputValue, brandOut);
+    return AmountMath.make(brandOut, outputValue);
   };
 
   /**
@@ -361,7 +361,7 @@ const start = async zcf => {
       inputReserve,
       outputReserve,
     );
-    return AmountMath.make(outputValue, brandIn);
+    return AmountMath.make(brandIn, outputValue);
   };
 
   const getPoolAllocation = poolSeat.getCurrentAllocation;

--- a/packages/zoe/src/contracts/mintAndSellNFT.js
+++ b/packages/zoe/src/contracts/mintAndSellNFT.js
@@ -19,7 +19,7 @@ import { assert } from '@agoric/assert';
  *   count: 3n,
  *   moneyIssuer: moolaIssuer,
  *   sellItemsInstallationHandle,
- *   pricePerItem: AmountMath.make(20n, moolaBrand),
+ *   pricePerItem: AmountMath.make(moolaBrand, 20n),
  * }
  * The payouts are returned as an offerResult in the `outcome`, and an API that
  * allows selling the tickets that were produced. You can reuse the ticket maker
@@ -42,16 +42,18 @@ const start = zcf => {
     pricePerItem,
   }) => {
     const tokenAmount = AmountMath.make(
-      Array(count)
-        .fill(undefined)
-        .map((_, i) => {
-          const tokenNumber = i + 1;
-          return {
-            ...customValueProperties,
-            number: tokenNumber,
-          };
-        }),
       brand,
+      harden(
+        Array(count)
+          .fill(undefined)
+          .map((_, i) => {
+            const tokenNumber = i + 1;
+            return {
+              ...customValueProperties,
+              number: tokenNumber,
+            };
+          }),
+      ),
     );
     const tokenPayment = mint.mintPayment(harden(tokenAmount));
     // Note that the proposal `want` is empty

--- a/packages/zoe/src/contracts/mintPayments.js
+++ b/packages/zoe/src/contracts/mintPayments.js
@@ -31,7 +31,7 @@ const start = async zcf => {
   const { issuer, brand } = zcfMint.getIssuerRecord();
 
   const mintPayment = value => seat => {
-    const amount = AmountMath.make(value, brand);
+    const amount = AmountMath.make(brand, value);
     // Synchronously mint and allocate amount to seat.
     zcfMint.mintGains({ Token: amount }, seat);
     // Exit the seat so that the user gets a payout.
@@ -44,7 +44,7 @@ const start = async zcf => {
   const creatorFacet = Far('creatorFacet', {
     // The creator of the instance can send invitations to anyone
     // they wish to.
-    makeInvitation: (value = 1000) =>
+    makeInvitation: (value = 1000n) =>
       zcf.makeInvitation(mintPayment(value), 'mint a payment'),
     getTokenIssuer: () => issuer,
   });

--- a/packages/zoe/src/contracts/multipoolAutoswap/pool.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/pool.js
@@ -57,8 +57,8 @@ export const makeAddPool = (
       );
 
       const liquidityAmountOut = AmountMath.make(
-        liquidityValueOut,
         liquidityBrand,
+        liquidityValueOut,
       );
       liquidityZcfMint.mintGains({ Liquidity: liquidityAmountOut }, poolSeat);
       liqTokenSupply += liquidityValueOut;
@@ -144,8 +144,8 @@ export const makeAddPool = (
           feeBP,
         );
         return {
-          amountOut: AmountMath.make(valueOut, outputBrand),
-          amountIn: AmountMath.make(valueIn, inputAmount.brand),
+          amountOut: AmountMath.make(outputBrand, valueOut),
+          amountIn: AmountMath.make(inputAmount.brand, valueIn),
         };
       },
 
@@ -183,8 +183,8 @@ export const makeAddPool = (
           feeBP,
         );
         return {
-          amountOut: AmountMath.make(valueOut, outputAmount.brand),
-          amountIn: AmountMath.make(valueIn, inputBrand),
+          amountOut: AmountMath.make(outputAmount.brand, valueOut),
+          amountIn: AmountMath.make(inputBrand, valueIn),
         };
       },
       addLiquidity: zcfSeat => {
@@ -205,13 +205,13 @@ export const makeAddPool = (
         // To calculate liquidity, we'll need to calculate alpha from the primary
         // token's value before, and the value that will be added to the pool
         const secondaryOut = AmountMath.make(
+          secondaryBrand,
           calcSecondaryRequired(
             userAllocation.Central.value,
             centralAmount.value,
             secondaryAmount.value,
             secondaryIn.value,
           ),
-          secondaryBrand,
         );
 
         // Central was specified precisely so offer must provide enough secondary.
@@ -230,21 +230,21 @@ export const makeAddPool = (
         const liquidityValueIn = liquidityIn.value;
         assert(isNatValue(liquidityValueIn));
         const centralTokenAmountOut = AmountMath.make(
+          centralBrand,
           calcValueToRemove(
             liqTokenSupply,
             pool.getCentralAmount().value,
             liquidityValueIn,
           ),
-          centralBrand,
         );
 
         const tokenKeywordAmountOut = AmountMath.make(
+          secondaryBrand,
           calcValueToRemove(
             liqTokenSupply,
             pool.getSecondaryAmount().value,
             liquidityValueIn,
           ),
-          secondaryBrand,
         );
 
         liqTokenSupply -= liquidityValueIn;

--- a/packages/zoe/src/contracts/multipoolAutoswap/priceAuthority.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/priceAuthority.js
@@ -21,7 +21,7 @@ export const makePriceAuthority = (
 
   /** @param {PriceQuoteValue} quote */
   const authenticateQuote = quote => {
-    const quoteAmount = AmountMath.make(quote, brand);
+    const quoteAmount = AmountMath.make(brand, harden(quote));
     const quotePayment = quoteIssuerKit.mint.mintPayment(quoteAmount);
     return harden({ quoteAmount, quotePayment });
   };

--- a/packages/zoe/src/contracts/priceAggregator.js
+++ b/packages/zoe/src/contracts/priceAggregator.js
@@ -28,10 +28,10 @@ const start = async zcf => {
     timer: rawTimer,
     POLL_INTERVAL,
     brands: { In: brandIn, Out: brandOut },
-    unitAmountIn = AmountMath.make(1n, brandIn),
+    unitAmountIn = AmountMath.make(brandIn, 1n),
   } = zcf.getTerms();
 
-  const unitIn = AmountMath.getValue(unitAmountIn, brandIn);
+  const unitIn = AmountMath.getValue(brandIn, unitAmountIn);
 
   /** @type {TimerService} */
   const timer = rawTimer;
@@ -53,7 +53,7 @@ const start = async zcf => {
    * @param {PriceQuoteValue} quote
    */
   const authenticateQuote = async quote => {
-    const quoteAmount = AmountMath.make(quote, quoteKit.brand);
+    const quoteAmount = AmountMath.make(quoteKit.brand, harden(quote));
     const quotePayment = await E(quoteKit.mint).mintPayment(quoteAmount);
     return harden({ quoteAmount, quotePayment });
   };
@@ -119,10 +119,10 @@ const start = async zcf => {
        * @returns {Amount} the amountOut that will be received
        */
       const calcAmountOut = amountIn => {
-        const valueIn = AmountMath.getValue(amountIn, brandIn);
+        const valueIn = AmountMath.getValue(brandIn, amountIn);
         return AmountMath.make(
-          floorDivide(multiply(valueIn, valueOutForUnitIn), unitIn),
           brandOut,
+          floorDivide(multiply(valueIn, valueOutForUnitIn), unitIn),
         );
       };
 
@@ -131,10 +131,10 @@ const start = async zcf => {
        * @returns {Amount} the amountIn needed to give
        */
       const calcAmountIn = amountOut => {
-        const valueOut = AmountMath.getValue(amountOut, brandOut);
+        const valueOut = AmountMath.getValue(brandOut, amountOut);
         return AmountMath.make(
-          ceilDivide(multiply(valueOut, unitIn), valueOutForUnitIn),
           brandIn,
+          ceilDivide(multiply(valueOut, unitIn), valueOutForUnitIn),
         );
       };
 
@@ -149,8 +149,8 @@ const start = async zcf => {
         amountOut,
         timestamp: theirTimestamp = timestamp,
       } = quote;
-      AmountMath.coerce(amountIn, brandIn);
-      AmountMath.coerce(amountOut, brandOut);
+      AmountMath.coerce(brandIn, amountIn);
+      AmountMath.coerce(brandOut, amountOut);
       if (theirTimestamp !== undefined) {
         return authenticateQuote([
           { amountIn, amountOut, timer, timestamp: theirTimestamp },
@@ -178,7 +178,7 @@ const start = async zcf => {
       return;
     }
 
-    const amountOut = AmountMath.make(median, brandOut);
+    const amountOut = AmountMath.make(brandOut, median);
 
     /** @type {PriceDescription} */
     const quote = {

--- a/packages/zoe/src/contracts/priceAggregatorChainlink.js
+++ b/packages/zoe/src/contracts/priceAggregatorChainlink.js
@@ -34,10 +34,10 @@ const start = async zcf => {
     minSubmissionValue,
     maxSubmissionValue,
 
-    unitAmountIn = AmountMath.make(1n, brandIn),
+    unitAmountIn = AmountMath.make(brandIn, 1n),
   } = zcf.getTerms();
 
-  const unitIn = AmountMath.getValue(unitAmountIn, brandIn);
+  const unitIn = AmountMath.getValue(brandIn, unitAmountIn);
 
   /** @type {ERef<TimerService>} */
   const timer = rawTimer;
@@ -140,7 +140,7 @@ const start = async zcf => {
    * @param {PriceQuoteValue} quote
    */
   const authenticateQuote = async quote => {
-    const quoteAmount = AmountMath.make(quote, quoteKit.brand);
+    const quoteAmount = AmountMath.make(quoteKit.brand, harden(quote));
     const quotePayment = await E(quoteKit.mint).mintPayment(quoteAmount);
     return harden({ quoteAmount, quotePayment });
   };
@@ -181,10 +181,10 @@ const start = async zcf => {
        * @param {Amount} amountIn the given amountIn
        */
       const calcAmountOut = amountIn => {
-        const valueIn = AmountMath.getValue(amountIn, brandIn);
+        const valueIn = AmountMath.getValue(brandIn, amountIn);
         return AmountMath.make(
-          floorDivide(multiply(valueIn, valueOutForUnitIn), unitIn),
           brandOut,
+          floorDivide(multiply(valueIn, valueOutForUnitIn), unitIn),
         );
       };
 
@@ -192,10 +192,10 @@ const start = async zcf => {
        * @param {Amount} amountOut the wanted amountOut
        */
       const calcAmountIn = amountOut => {
-        const valueOut = AmountMath.getValue(amountOut, brandOut);
+        const valueOut = AmountMath.getValue(brandOut, amountOut);
         return AmountMath.make(
-          ceilDivide(multiply(valueOut, unitIn), valueOutForUnitIn),
           brandIn,
+          ceilDivide(multiply(valueOut, unitIn), valueOutForUnitIn),
         );
       };
 
@@ -210,8 +210,8 @@ const start = async zcf => {
         amountOut,
         timestamp: theirTimestamp = timestamp,
       } = quote;
-      AmountMath.coerce(amountIn, brandIn);
-      AmountMath.coerce(amountOut, brandOut);
+      AmountMath.coerce(brandIn, amountIn);
+      AmountMath.coerce(brandOut, amountOut);
       if (theirTimestamp !== undefined) {
         return authenticateQuote([
           {

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -97,8 +97,8 @@ const start = zcf => {
 
     // All items are the same price.
     const totalCost = AmountMath.make(
-      pricePerItem.value * Nat(wantedItems.value.length),
       brands.Money,
+      pricePerItem.value * Nat(wantedItems.value.length),
     );
 
     // Check that the money provided to pay for the items is greater than the totalCost.

--- a/packages/zoe/src/contracts/simpleExchange.js
+++ b/packages/zoe/src/contracts/simpleExchange.js
@@ -21,8 +21,8 @@ import {
  * the two keywords symmetrically. New offers can be created and existing offers
  * can be accepted in either direction.
  *
- * { give: { 'Asset', simoleans(5) }, want: { 'Price', quatloos(3) } }
- * { give: { 'Price', quatloos(8) }, want: { 'Asset', simoleans(3) } }
+ * { give: { 'Asset', simoleans(5n) }, want: { 'Price', quatloos(3) } }
+ * { give: { 'Price', quatloos(8) }, want: { 'Asset', simoleans(3n) } }
  *
  * The Asset is treated as an exact amount to be exchanged, while the
  * Price is a limit that may be improved on. This simple exchange does

--- a/packages/zoe/src/contracts/vpool-xyk-amm/pool.js
+++ b/packages/zoe/src/contracts/vpool-xyk-amm/pool.js
@@ -70,8 +70,8 @@ export const makeAddPool = (
       );
 
       const liquidityAmountOut = AmountMath.make(
-        liquidityValueOut,
         liquidityBrand,
+        liquidityValueOut,
       );
       liquidityZcfMint.mintGains({ Liquidity: liquidityAmountOut }, poolSeat);
       liqTokenSupply += liquidityValueOut;
@@ -120,13 +120,13 @@ export const makeAddPool = (
         // To calculate liquidity, we'll need to calculate alpha from the primary
         // token's value before, and the value that will be added to the pool
         const secondaryOut = AmountMath.make(
+          secondaryBrand,
           calcSecondaryRequired(
             userAllocation.Central.value,
             centralAmount.value,
             secondaryAmount.value,
             secondaryIn.value,
           ),
-          secondaryBrand,
         );
 
         // Central was specified precisely so offer must provide enough secondary.
@@ -145,21 +145,21 @@ export const makeAddPool = (
         const liquidityValueIn = liquidityIn.value;
         assert(isNatValue(liquidityValueIn), 'User Liquidity');
         const centralTokenAmountOut = AmountMath.make(
+          centralBrand,
           calcValueToRemove(
             liqTokenSupply,
             pool.getCentralAmount().value,
             liquidityValueIn,
           ),
-          centralBrand,
         );
 
         const tokenKeywordAmountOut = AmountMath.make(
+          secondaryBrand,
           calcValueToRemove(
             liqTokenSupply,
             pool.getSecondaryAmount().value,
             liquidityValueIn,
           ),
-          secondaryBrand,
         );
 
         liqTokenSupply -= liquidityValueIn;

--- a/packages/zoe/src/zoeService/makeInvitation.js
+++ b/packages/zoe/src/zoeService/makeInvitation.js
@@ -60,16 +60,19 @@ export const createInvitationKit = (
       // example, the value for `instance` will always be the actual
       // instance for the contract, even if customProperties includes
       // a property called `instance`.
-      const invitationAmount = AmountMath.make(invitationKit.brand, [
-        {
-          ...customProperties,
-          description,
-          handle: invitationHandle,
-          instance,
-          installation,
-          ...feeInfo, // will override customProperties if they exist
-        },
-      ]);
+      const invitationAmount = AmountMath.make(
+        invitationKit.brand,
+        harden([
+          {
+            ...customProperties,
+            description,
+            handle: invitationHandle,
+            instance,
+            installation,
+            ...feeInfo, // will override customProperties if they exist
+          },
+        ]),
+      );
       return invitationKit.mint.mintPayment(invitationAmount);
     };
     return makeInvitation;

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -283,8 +283,8 @@
  * @typedef {Record<Keyword,Amount>} AmountKeywordRecord
  *
  * The keys are keywords, and the values are amounts. For example:
- * { Asset: AmountMath.make(5n, assetBrand), Price:
- * AmountMath.make(9n, priceBrand) }
+ * { Asset: AmountMath.make(assetBrand, 5n), Price:
+ * AmountMath.make(priceBrand, 9n) }
  */
 
 /**

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -57,7 +57,7 @@ const makeZoeKit = (
   feeIssuerConfig = {
     name: 'RUN',
     assetKind: AssetKind.NAT,
-    displayInfo: { decimalPlaces: 6, assetKind: AssetKind.NAT },
+    displayInfo: harden({ decimalPlaces: 6, assetKind: AssetKind.NAT }),
     initialFunds: 0n,
   },
   zoeFeesConfig = {

--- a/packages/zoe/test/autoswapJig.js
+++ b/packages/zoe/test/autoswapJig.js
@@ -165,8 +165,8 @@ export const makeTrader = async (purses, zoe, publicFacet, centralIssuer) => {
 
       const centralBrand = await E(centralIssuer).getBrand();
       const secondaryBrand = await E(secondaryIssuer).getBrand();
-      const central = value => AmountMath.make(value, centralBrand);
-      const secondary = value => AmountMath.make(value, secondaryBrand);
+      const central = value => AmountMath.make(centralBrand, value);
+      const secondary = value => AmountMath.make(secondaryBrand, value);
 
       const poolPre = await getPoolAllocation(secondaryIssuer);
       t.deepEqual(poolPre.Central, central(cPoolPre), `central before swap`);
@@ -185,8 +185,20 @@ export const makeTrader = async (purses, zoe, publicFacet, centralIssuer) => {
           ? [centralIssuer, central, secondaryIssuer, secondary]
           : [secondaryIssuer, secondary, centralIssuer, central];
       const { In: refund, Out: payout } = await E(seat).getPayouts();
-      assertPayoutAmount(t, outIssuer, payout, out(outExpected), 'trade out');
-      assertPayoutAmount(t, inIssuer, refund, inMath(inExpected), 'trade in');
+      await assertPayoutAmount(
+        t,
+        outIssuer,
+        payout,
+        out(outExpected),
+        'trade out',
+      );
+      await assertPayoutAmount(
+        t,
+        inIssuer,
+        refund,
+        inMath(inExpected),
+        'trade in',
+      );
 
       const poolPost = await getPoolAllocation(secondaryIssuer);
       t.deepEqual(poolPost.Central, central(cPost), `central after swap`);
@@ -212,12 +224,12 @@ export const makeTrader = async (purses, zoe, publicFacet, centralIssuer) => {
       const centralBrand = await E(centralIssuer).getBrand();
       const secondaryBrand = await E(secondaryIssuer).getBrand();
       const liquidityBrand = await E(liquidityIssuer).getBrand();
-      const central = value => AmountMath.make(value, centralBrand);
-      const secondary = value => AmountMath.make(value, secondaryBrand);
-      const liquidity = value => AmountMath.make(value, liquidityBrand);
+      const central = value => AmountMath.make(centralBrand, value);
+      const secondary = value => AmountMath.make(secondaryBrand, value);
+      const liquidity = value => AmountMath.make(liquidityBrand, value);
 
       const { c: cPre, s: sPre, l: lPre, k: kPre } = priorPoolState;
-      const { cAmount, sAmount, lAmount = liquidity(0) } = details;
+      const { cAmount, sAmount, lAmount = liquidity(0n) } = details;
       const {
         c: cPost,
         s: sPost,
@@ -261,9 +273,27 @@ export const makeTrader = async (purses, zoe, publicFacet, centralIssuer) => {
         Secondary: sPayout,
         Liquidity: lPayout,
       } = await seat.getPayouts();
-      assertPayoutAmount(t, centralIssuer, cPayout, central(payoutC), '+c');
-      assertPayoutAmount(t, secondaryIssuer, sPayout, secondary(payoutS), '+s');
-      assertPayoutAmount(t, liquidityIssuer, lPayout, liquidity(payoutL), '+l');
+      await assertPayoutAmount(
+        t,
+        centralIssuer,
+        cPayout,
+        central(payoutC),
+        '+c',
+      );
+      await assertPayoutAmount(
+        t,
+        secondaryIssuer,
+        sPayout,
+        secondary(payoutS),
+        '+s',
+      );
+      await assertPayoutAmount(
+        t,
+        liquidityIssuer,
+        lPayout,
+        liquidity(payoutL),
+        '+l',
+      );
 
       const poolPost = await getPoolAllocation(secondaryIssuer);
       t.deepEqual(poolPost.Central, central(cPost), `central after add liq`);
@@ -295,12 +325,12 @@ export const makeTrader = async (purses, zoe, publicFacet, centralIssuer) => {
       const centralBrand = await E(centralIssuer).getBrand();
       const secondaryBrand = await E(secondaryIssuer).getBrand();
       const liquidityBrand = await E(liquidityIssuer).getBrand();
-      const central = value => AmountMath.make(value, centralBrand);
-      const secondary = value => AmountMath.make(value, secondaryBrand);
-      const liquidity = value => AmountMath.make(value, liquidityBrand);
+      const central = value => AmountMath.make(centralBrand, value);
+      const secondary = value => AmountMath.make(secondaryBrand, value);
+      const liquidity = value => AmountMath.make(liquidityBrand, value);
 
       const { c: cPre, s: sPre, l: lPre, k: kPre } = priorPoolState;
-      const { cAmount, sAmount, lAmount = liquidity(0) } = details;
+      const { cAmount, sAmount, lAmount = liquidity(0n) } = details;
       const {
         c: cPost,
         s: sPost,
@@ -339,8 +369,20 @@ export const makeTrader = async (purses, zoe, publicFacet, centralIssuer) => {
       assertOfferResult(t, seat, 'Liquidity successfully removed.');
 
       const { Central: cPayout, Secondary: sPayout } = await seat.getPayouts();
-      assertPayoutAmount(t, centralIssuer, cPayout, central(payoutC), '+c');
-      assertPayoutAmount(t, secondaryIssuer, sPayout, secondary(payoutS), '+s');
+      await assertPayoutAmount(
+        t,
+        centralIssuer,
+        cPayout,
+        central(payoutC),
+        '+c',
+      );
+      await assertPayoutAmount(
+        t,
+        secondaryIssuer,
+        sPayout,
+        secondary(payoutS),
+        '+s',
+      );
 
       const poolPost = await getPoolAllocation(secondaryIssuer);
       t.deepEqual(poolPost.Central, central(cPost), `central after add liq`);
@@ -366,12 +408,12 @@ export const makeTrader = async (purses, zoe, publicFacet, centralIssuer) => {
       const centralBrand = await E(centralIssuer).getBrand();
       const secondaryBrand = await E(secondaryIssuer).getBrand();
       const liquidityBrand = await E(liquidityIssuer).getBrand();
-      const central = value => AmountMath.make(value, centralBrand);
-      const secondary = value => AmountMath.make(value, secondaryBrand);
-      const liquidity = value => AmountMath.make(value, liquidityBrand);
+      const central = value => AmountMath.make(centralBrand, value);
+      const secondary = value => AmountMath.make(secondaryBrand, value);
+      const liquidity = value => AmountMath.make(liquidityBrand, value);
 
       const { c: cPre, s: sPre, l: lPre, k: kPre } = priorPoolState;
-      const { cAmount, sAmount, lAmount = liquidity(0) } = details;
+      const { cAmount, sAmount, lAmount = liquidity(0n) } = details;
       const {
         c: cPost,
         s: sPost,
@@ -408,11 +450,29 @@ export const makeTrader = async (purses, zoe, publicFacet, centralIssuer) => {
         Secondary: sPayout,
         Liquidity: lPayout,
       } = await E(seat).getPayouts();
-      assertPayoutAmount(t, centralIssuer, cPayout, central(payoutC), 'init c');
+      await assertPayoutAmount(
+        t,
+        centralIssuer,
+        cPayout,
+        central(payoutC),
+        'init c',
+      );
       const secondaryAmt = secondary(payoutS);
-      assertPayoutAmount(t, secondaryIssuer, sPayout, secondaryAmt, 'init s');
+      await assertPayoutAmount(
+        t,
+        secondaryIssuer,
+        sPayout,
+        secondaryAmt,
+        'init s',
+      );
       const liquidityAmt = liquidity(payoutL);
-      assertPayoutAmount(t, liquidityIssuer, lPayout, liquidityAmt, 'init l');
+      await assertPayoutAmount(
+        t,
+        liquidityIssuer,
+        lPayout,
+        liquidityAmt,
+        'init l',
+      );
 
       const poolPost = await getPoolAllocation(secondaryIssuer);
       t.deepEqual(poolPost.Central, central(cPost), `central after init`);

--- a/packages/zoe/test/swingsetTests/brokenContracts/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/bootstrap.js
@@ -28,7 +28,7 @@ const makeVats = (log, vats, zoe, installations, startingValues) => {
   const { mints, issuers, brands } = setupBasicMints();
   const makePayments = values =>
     mints.map((mint, i) => {
-      return mint.mintPayment(AmountMath.make(values[i], brands[i]));
+      return mint.mintPayment(AmountMath.make(brands[i], BigInt(values[i])));
     });
 
   // Setup Alice

--- a/packages/zoe/test/swingsetTests/brokenContracts/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/vat-alice.js
@@ -37,8 +37,8 @@ const build = async (log, zoe, issuers, payments, installations) => {
       issuerKeywordRecord,
     );
     const proposal = harden({
-      give: { Asset: moola(3) },
-      want: { Price: simoleans(7) },
+      give: { Asset: moola(3n) },
+      want: { Price: simoleans(7n) },
       exit: { onDemand: null },
     });
     const alicePayments = { Asset: moolaPayment };
@@ -83,7 +83,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
     const installId = installations.crashAutoRefund;
     const [refundPayment, swapPayment] = await E(moolaIssuer).split(
       moolaPayment,
-      moola(3),
+      moola(3n),
     );
 
     const issuerKeywordRecord = harden({
@@ -97,8 +97,8 @@ const build = async (log, zoe, issuers, payments, installations) => {
     );
 
     const swapProposal = harden({
-      give: { Asset: moola(5) },
-      want: { Price: simoleans(12) },
+      give: { Asset: moola(5n) },
+      want: { Price: simoleans(12n) },
       exit: { onDemand: null },
     });
     const aliceSwapPayments = { Asset: swapPayment };
@@ -134,8 +134,8 @@ const build = async (log, zoe, issuers, payments, installations) => {
     // This invitation throws a metering exception
     const refundInvitation = await E(publicFacet).makeExcessiveInvitation();
     const refundProposal = harden({
-      give: { Asset: moola(3) },
-      want: { Price: simoleans(7) },
+      give: { Asset: moola(3n) },
+      want: { Price: simoleans(7n) },
       exit: { onDemand: null },
     });
     const refundPayments = { Asset: refundPayment };
@@ -201,8 +201,8 @@ const build = async (log, zoe, issuers, payments, installations) => {
       issuerKeywordRecord,
     );
     const proposal = harden({
-      give: { Asset: moola(3) },
-      want: { Price: simoleans(7) },
+      give: { Asset: moola(3n) },
+      want: { Price: simoleans(7n) },
       exit: { onDemand: null },
     });
     const alicePayments = { Asset: moolaPayment };
@@ -235,7 +235,7 @@ const build = async (log, zoe, issuers, payments, installations) => {
     log(`newCounter: ${await E(publicFacet2).getOffersCount()}`);
 
     const newInvitation = await E(publicFacet).makeSafeInvitation();
-    const newMoolaPayment = await E(moolaPurseP).withdraw(moola(3));
+    const newMoolaPayment = await E(moolaPurseP).withdraw(moola(3n));
     const newPayments = { Asset: newMoolaPayment };
 
     const secondSeat = await E(zoe).offer(newInvitation, proposal, newPayments);
@@ -271,8 +271,8 @@ const build = async (log, zoe, issuers, payments, installations) => {
     );
 
     const swapProposal = harden({
-      give: { Asset: moola(5) },
-      want: { Price: simoleans(8) },
+      give: { Asset: moola(5n) },
+      want: { Price: simoleans(8n) },
       exit: { onDemand: null },
     });
     const aliceSwapPayments = { Asset: moolaPayment };
@@ -332,8 +332,8 @@ const build = async (log, zoe, issuers, payments, installations) => {
     log(`newCounter: ${await E(publicFacet2).getOffersCount()}`);
 
     const swapTwoProposal = harden({
-      give: { Price: simoleans(12) },
-      want: { Asset: moola(2) },
+      give: { Price: simoleans(12n) },
+      want: { Asset: moola(2n) },
       exit: { onDemand: null },
     });
     assert(swapInvitationTwo);
@@ -376,8 +376,8 @@ const build = async (log, zoe, issuers, payments, installations) => {
     );
     logCounter(log, publicFacet);
     const proposal = harden({
-      give: { Asset: moola(3) },
-      want: { Price: simoleans(7) },
+      give: { Asset: moola(3n) },
+      want: { Price: simoleans(7n) },
       exit: { onDemand: null },
     });
     const alicePayments = { Asset: moolaPayment };
@@ -520,8 +520,8 @@ const build = async (log, zoe, issuers, payments, installations) => {
 
     // Alice submits an offer. The contract will be terminated before resolution
     const swapProposal = harden({
-      give: { Asset: moola(5) },
-      want: { Price: simoleans(12) },
+      give: { Asset: moola(5n) },
+      want: { Price: simoleans(12n) },
       exit: { onDemand: null },
     });
     const aliceSwapPayments = { Asset: moolaPayment };
@@ -578,8 +578,8 @@ const build = async (log, zoe, issuers, payments, installations) => {
 
     // Alice submits an offer. The contract will be terminated before resolution
     const swapProposal = harden({
-      give: { Asset: moola(5) },
-      want: { Price: simoleans(12) },
+      give: { Asset: moola(5n) },
+      want: { Price: simoleans(12n) },
       exit: { onDemand: null },
     });
     const aliceSwapPayments = { Asset: moolaPayment };

--- a/packages/zoe/test/swingsetTests/helpers.js
+++ b/packages/zoe/test/swingsetTests/helpers.js
@@ -20,9 +20,9 @@ export const setupIssuers = async (zoe, issuers) => {
     issuers.map(issuer => E(issuer).getBrand()),
   );
 
-  const moola = value => AmountMath.make(value, moolaBrand);
-  const simoleans = value => AmountMath.make(value, simoleanBrand);
-  const bucks = value => AmountMath.make(value, bucksBrand);
+  const moola = value => AmountMath.make(moolaBrand, value);
+  const simoleans = value => AmountMath.make(simoleanBrand, value);
+  const bucks = value => AmountMath.make(bucksBrand, value);
 
   return harden({
     issuers: harden([moolaIssuer, simoleanIssuer]),

--- a/packages/zoe/test/swingsetTests/refillMeter/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/refillMeter/bootstrap.js
@@ -16,7 +16,7 @@ export function buildRootObject(vatPowers) {
       const feeIssuerConfig = {
         name: 'RUN',
         assetKind: AssetKind.NAT,
-        displayInfo: { decimalPlaces: 6, assetKind: AssetKind.NAT },
+        displayInfo: harden({ decimalPlaces: 6, assetKind: AssetKind.NAT }),
         initialFunds: 4_470_000n,
       };
       const zoeFeesConfig = {

--- a/packages/zoe/test/swingsetTests/zoe/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/zoe/bootstrap.js
@@ -27,7 +27,7 @@ const makeVats = (log, vats, zoe, installations, startingValues) => {
   const { mints, issuers, brands } = setupBasicMints();
   const makePayments = values =>
     mints.map((mint, i) =>
-      mint.mintPayment(AmountMath.make(values[i], brands[i])),
+      mint.mintPayment(AmountMath.make(brands[i], BigInt(values[i]))),
     );
   const [aliceValues, bobValues, carolValues, daveValues] = startingValues;
 

--- a/packages/zoe/test/swingsetTests/zoe/vat-alice.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-alice.js
@@ -25,8 +25,8 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     ).startInstance(installId, issuerKeywordRecord);
 
     const proposal = harden({
-      give: { Contribution1: moola(3) },
-      want: { Contribution2: simoleans(7) },
+      give: { Contribution1: moola(3n) },
+      want: { Contribution2: simoleans(7n) },
       exit: { onDemand: null },
     });
 
@@ -69,8 +69,8 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       );
 
     const proposal = harden({
-      give: { UnderlyingAsset: moola(3) },
-      want: { StrikePrice: simoleans(7) },
+      give: { UnderlyingAsset: moola(3n) },
+      want: { StrikePrice: simoleans(7n) },
       exit: { afterDeadline: { deadline: 1n, timer } },
     });
 
@@ -103,8 +103,8 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     ).startInstance(installations.coveredCall, issuerKeywordRecord);
 
     const proposal = harden({
-      give: { UnderlyingAsset: moola(3) },
-      want: { StrikePrice: simoleans(7) },
+      give: { UnderlyingAsset: moola(3n) },
+      want: { StrikePrice: simoleans(7n) },
       exit: {
         afterDeadline: {
           deadline: 100n,
@@ -149,8 +149,8 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     );
 
     const proposal = harden({
-      give: { Asset: moola(1) },
-      want: { Ask: simoleans(3) },
+      give: { Asset: moola(1n) },
+      want: { Ask: simoleans(3n) },
       exit: { waived: null },
     });
     const paymentKeywordRecord = { Asset: moolaPayment };
@@ -197,8 +197,8 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     ).startInstance(installations.atomicSwap, issuerKeywordRecord);
 
     const proposal = harden({
-      give: { Asset: moola(3) },
-      want: { Price: simoleans(7) },
+      give: { Asset: moola(3n) },
+      want: { Price: simoleans(7n) },
       exit: { onDemand: null },
     });
     const paymentKeywordRecord = { Asset: moolaPayment };
@@ -234,8 +234,8 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
     const addOrderInvitation = await E(publicFacet).makeInvitation();
     const aliceSellOrderProposal = harden({
-      give: { Asset: moola(3) },
-      want: { Price: simoleans(4) },
+      give: { Asset: moola(3n) },
+      want: { Price: simoleans(4n) },
       exit: { onDemand: null },
     });
     const paymentKeywordRecord = { Asset: moolaPayment };
@@ -281,8 +281,8 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     logStateOnChanges(await E(publicFacet).getNotifier());
 
     const aliceSellOrderProposal = harden({
-      give: { Asset: moola(3) },
-      want: { Price: simoleans(4) },
+      give: { Asset: moola(3n) },
+      want: { Price: simoleans(4n) },
       exit: { onDemand: null },
     });
     const paymentKeywordRecord = { Asset: moolaPayment };
@@ -296,9 +296,9 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     log(await E(addOrderSeatP).getOfferResult());
 
     const bobInvitation1P = E(publicFacet).makeInvitation();
-    await E(bobP).doSimpleExchangeUpdates(bobInvitation1P, 3, 7);
+    await E(bobP).doSimpleExchangeUpdates(bobInvitation1P, 3n, 7n);
     const bobInvitation2P = E(publicFacet).makeInvitation();
-    await E(bobP).doSimpleExchangeUpdates(bobInvitation2P, 8, 2);
+    await E(bobP).doSimpleExchangeUpdates(bobInvitation2P, 8n, 2n);
 
     const moolaPayout = await E(addOrderSeatP).getPayout('Asset');
     const simoleanPayout = await E(addOrderSeatP).getPayout('Price');
@@ -306,9 +306,9 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     await E(moolaPurseP).deposit(moolaPayout);
     await E(simoleanPurseP).deposit(simoleanPayout);
     const bobInvitation3P = E(publicFacet).makeInvitation();
-    await E(bobP).doSimpleExchangeUpdates(bobInvitation3P, 20, 13);
+    await E(bobP).doSimpleExchangeUpdates(bobInvitation3P, 20n, 13n);
     const bobInvitation4P = E(publicFacet).makeInvitation();
-    await E(bobP).doSimpleExchangeUpdates(bobInvitation4P, 5, 2);
+    await E(bobP).doSimpleExchangeUpdates(bobInvitation4P, 5n, 2n);
     await showPurseBalance(moolaPurseP, 'aliceMoolaPurse', log);
     await showPurseBalance(simoleanPurseP, 'aliceSimoleanPurse', log);
   };
@@ -324,14 +324,14 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     );
     const liquidityIssuer = await E(publicFacet).getLiquidityIssuer();
     const liquidityBrand = await E(liquidityIssuer).getBrand();
-    const liquidity = value => AmountMath.make(value, liquidityBrand);
+    const liquidity = value => AmountMath.make(liquidityBrand, value);
 
     // Alice adds liquidity
     // 10 moola = 5 simoleans at the time of the liquidity adding
     // aka 2 moola = 1 simolean
     const addLiquidityProposal = harden({
-      give: { Central: moola(10), Secondary: simoleans(5) },
-      want: { Liquidity: liquidity(10) },
+      give: { Central: moola(10n), Secondary: simoleans(5n) },
+      want: { Liquidity: liquidity(10n) },
     });
     const paymentKeywordRecord = harden({
       Central: moolaPayment,
@@ -355,12 +355,12 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
     // remove the liquidity
     const aliceRemoveLiquidityProposal = harden({
-      give: { Liquidity: liquidity(10) },
-      want: { Central: moola(0n), Secondary: simoleans(0) },
+      give: { Liquidity: liquidity(10n) },
+      want: { Central: moola(0n), Secondary: simoleans(0n) },
     });
 
     const liquidityTokenPayment = await E(liquidityTokenPurseP).withdraw(
-      liquidity(10),
+      liquidity(10n),
     );
     const removeLiquidityInvitation = E(
       publicFacet,
@@ -411,7 +411,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       count: 3,
       moneyIssuer: moolaIssuer,
       sellItemsInstallation: installations.sellItems,
-      pricePerItem: moola(22),
+      pricePerItem: moola(22n),
     });
     const buyerInvitation = E(sellItemsCreatorFacet).makeBuyerInvitation();
     await E(bobP).doBuyTickets(ticketSalesInstance, buyerInvitation);
@@ -446,9 +446,9 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     });
     const addInventoryProposal = harden({
       give: {
-        Moola: moola(10000),
-        Simolean: simoleans(10000),
-        Buck: bucks(10000),
+        Moola: moola(10000n),
+        Simolean: simoleans(10000n),
+        Buck: bucks(10000n),
       },
     });
     const addInventoryPayments = {
@@ -465,8 +465,8 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     const addInventoryOfferResult = await E(addInventorySeat).getOfferResult();
     log(addInventoryOfferResult);
     const bobInvitation = await E(creatorFacet).makeQuote(
-      { Simolean: simoleans(4) },
-      { Moola: moola(3) },
+      { Simolean: simoleans(4n) },
+      { Moola: moola(3n) },
       timer,
       1n,
     );
@@ -479,7 +479,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     ).makeRemoveInventoryInvitation();
     // Intentionally do not remove it all
     const removeInventoryProposal = harden({
-      want: { Simolean: simoleans(2) },
+      want: { Simolean: simoleans(2n) },
     });
     const removeInventorySeat = await E(zoe).offer(
       removeInventoryInvitation,
@@ -506,8 +506,8 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
     ).startInstance(installation, issuerKeywordRecord);
 
     const proposal = harden({
-      give: { UnderlyingAsset: moola(3) },
-      want: { StrikePrice: simoleans(7) },
+      give: { UnderlyingAsset: moola(3n) },
+      want: { StrikePrice: simoleans(7n) },
       exit: {
         afterDeadline: {
           timer: Far('timer', { setWakeup: () => {} }),

--- a/packages/zoe/test/swingsetTests/zoe/vat-bob.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-bob.js
@@ -4,8 +4,7 @@ import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
 import { sameStructure } from '@agoric/same-structure';
-import { AmountMath } from '@agoric/ertp';
-import { looksLikeSetValue } from '@agoric/ertp/src/typeGuards.js';
+import { AmountMath, isSetValue } from '@agoric/ertp';
 
 import { showPurseBalance, setupIssuers } from '../helpers.js';
 
@@ -43,8 +42,8 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
       // 1. Bob escrows his offer
       const bobProposal = harden({
-        want: { Contribution1: moola(15) },
-        give: { Contribution2: simoleans(17) },
+        want: { Contribution1: moola(15n) },
+        give: { Contribution2: simoleans(17n) },
         exit: { onDemand: null },
       });
 
@@ -77,8 +76,8 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const issuerKeywordRecord = await E(zoe).getIssuers(instance);
 
       const bobIntendedProposal = harden({
-        want: { UnderlyingAsset: moola(3) },
-        give: { StrikePrice: simoleans(7) },
+        want: { UnderlyingAsset: moola(3n) },
+        give: { StrikePrice: simoleans(7n) },
       });
 
       // Bob checks that the invitation is for the right covered call
@@ -93,13 +92,13 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       assert(
         AmountMath.isEqual(
           optionValue[0].underlyingAssets.UnderlyingAsset,
-          moola(3),
+          moola(3n),
         ),
       );
       assert(
         AmountMath.isEqual(
           optionValue[0].strikePrice.StrikePrice,
-          simoleans(7),
+          simoleans(7n),
         ),
       );
       assert(optionValue[0].expirationDate === 1n, X`wrong expirationDate`);
@@ -159,14 +158,14 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       assert(
         AmountMath.isEqual(
           optionValue[0].underlyingAssets.UnderlyingAsset,
-          moola(3),
+          moola(3n),
         ),
         X`wrong underlying asset`,
       );
       assert(
         AmountMath.isEqual(
           optionValue[0].strikePrice.StrikePrice,
-          simoleans(7),
+          simoleans(7n),
         ),
         X`wrong strike price`,
       );
@@ -196,7 +195,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       // current invitation from Alice. He wants 1 buck in return.
       const bobProposalSwap = harden({
         give: { Asset: optionAmounts },
-        want: { Price: bucks(1) },
+        want: { Price: bucks(1n) },
       });
 
       const bobSwapPayments = harden({ Asset: exclInvitation });
@@ -241,12 +240,12 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         ),
         X`issuerKeywordRecord was not as expected`,
       );
-      assert(sameStructure(invitationValue[0].minimumBid, simoleans(3)));
-      assert(sameStructure(invitationValue[0].auctionedAssets, moola(1)));
+      assert(sameStructure(invitationValue[0].minimumBid, simoleans(3n)));
+      assert(sameStructure(invitationValue[0].auctionedAssets, moola(1n)));
 
       const proposal = harden({
-        want: { Asset: moola(1) },
-        give: { Bid: simoleans(11) },
+        want: { Asset: moola(1n) },
+        give: { Bid: simoleans(11n) },
       });
       const paymentKeywordRecord = { Bid: simoleanPayment };
 
@@ -286,17 +285,17 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       );
 
       assert(
-        sameStructure(invitationValue[0].asset, moola(3)),
+        sameStructure(invitationValue[0].asset, moola(3n)),
         X`Alice made a different offer than expected`,
       );
       assert(
-        sameStructure(invitationValue[0].price, simoleans(7)),
+        sameStructure(invitationValue[0].price, simoleans(7n)),
         X`Alice made a different offer than expected`,
       );
 
       const proposal = harden({
-        want: { Asset: moola(3) },
-        give: { Price: simoleans(7) },
+        want: { Asset: moola(3n) },
+        give: { Price: simoleans(7n) },
       });
       const paymentKeywordRecord = { Price: simoleanPayment };
 
@@ -338,8 +337,8 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       );
 
       const bobBuyOrderProposal = harden({
-        want: { Asset: moola(3) },
-        give: { Price: simoleans(7) },
+        want: { Asset: moola(3n) },
+        give: { Price: simoleans(7n) },
         exit: { onDemand: null },
       });
       const paymentKeywordRecord = { Price: simoleanPayment };
@@ -384,7 +383,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         give: { Price: simoleans(s) },
         exit: { onDemand: null },
       });
-      if (m === 3 && s === 7) {
+      if (m === 3n && s === 7n) {
         await E(simoleanPurseP).deposit(simoleanPayment);
       }
       const simoleanPayment2 = await E(simoleanPurseP).withdraw(simoleans(s));
@@ -432,14 +431,14 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
       // bob checks how many simoleans he can get for 3 moola
       const simoleanAmounts = await E(publicFacet).getInputPrice(
-        moola(3),
-        simoleans(0).brand,
+        moola(3n),
+        simoleans(0n).brand,
       );
       log(`simoleanAmounts `, simoleanAmounts);
 
       const moolaForSimProposal = harden({
-        give: { In: moola(3) },
-        want: { Out: simoleans(1) },
+        give: { In: moola(3n) },
+        want: { Out: simoleans(1n) },
       });
 
       const moolaForSimPayments = harden({ In: moolaPayment });
@@ -459,24 +458,24 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
       // Bob looks up how much moola he can get for 3 simoleans. It's 5
       const moolaProceeds = await E(publicFacet).getInputPrice(
-        simoleans(3),
+        simoleans(3n),
         moola(0n).brand,
       );
       log(`moola proceeds `, moolaProceeds);
 
       // Bob makes another offer and swaps
-      const bobSimsForMoolaProposa2 = harden({
-        want: { Out: moola(5) },
-        give: { In: simoleans(3) },
+      const bobSimsForMoolaProposal2 = harden({
+        want: { Out: moola(5n) },
+        give: { In: simoleans(3n) },
       });
       await E(simoleanPurseP).deposit(simoleanPayment);
-      const bobSimPayment2 = await E(simoleanPurseP).withdraw(simoleans(3));
+      const bobSimPayment2 = await E(simoleanPurseP).withdraw(simoleans(3n));
       const simsForMoolaPayments2 = harden({ In: bobSimPayment2 });
       const invitation2 = E(publicFacet).makeSwapInInvitation();
 
       const swapSeat2 = await E(zoe).offer(
         invitation2,
-        bobSimsForMoolaProposa2,
+        bobSimsForMoolaProposal2,
         simsForMoolaPayments2,
       );
 
@@ -493,8 +492,8 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
       // Bob looks up how much simoleans he'd have to pay for 3 moola. It's 6
       const simRequired = await E(publicFacet).getOutputPrice(
-        moola(3),
-        simoleans(0).brand,
+        moola(3n),
+        simoleans(0n).brand,
       );
       log(`simoleans required `, simRequired);
     },
@@ -508,12 +507,15 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       const availableTickets = await E(publicFacet).getAvailableItems();
       log('availableTickets: ', availableTickets);
       // find the value corresponding to ticket #1
-      assert(looksLikeSetValue(availableTickets.value));
+      assert(isSetValue(availableTickets.value));
       const ticket1Value = availableTickets.value.find(
         ticket => ticket.number === 1,
       );
       // make the corresponding amount
-      const ticket1Amount = AmountMath.make([ticket1Value], ticketBrand);
+      const ticket1Amount = AmountMath.make(
+        ticketBrand,
+        harden([ticket1Value]),
+      );
       const proposal = harden({
         give: { Money: terms.pricePerItem },
         want: { Items: ticket1Amount },
@@ -539,12 +541,12 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
       // Bob can use whatever keywords he wants
       const proposal = harden({
-        give: { Whatever1: simoleans(4) },
-        want: { Whatever2: moola(3) },
+        give: { Whatever1: simoleans(4n) },
+        want: { Whatever2: moola(3n) },
         exit: { onDemand: null },
       });
       await E(simoleanPurseP).deposit(simoleanPayment);
-      const simoleanPayment1 = await E(simoleanPurseP).withdraw(simoleans(4));
+      const simoleanPayment1 = await E(simoleanPurseP).withdraw(simoleans(4n));
 
       const seat = await E(zoe).offer(invitation, proposal, {
         Whatever1: simoleanPayment1,

--- a/packages/zoe/test/swingsetTests/zoe/vat-carol.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-carol.js
@@ -36,12 +36,12 @@ const build = async (log, zoe, issuers, payments, installations) => {
         ),
         X`issuerKeywordRecord were not as expected`,
       );
-      assert(sameStructure(invitationValue[0].minimumBid, simoleans(3)));
-      assert(sameStructure(invitationValue[0].auctionedAssets, moola(1)));
+      assert(sameStructure(invitationValue[0].minimumBid, simoleans(3n)));
+      assert(sameStructure(invitationValue[0].auctionedAssets, moola(1n)));
 
       const proposal = harden({
-        want: { Asset: moola(1) },
-        give: { Bid: simoleans(7) },
+        want: { Asset: moola(1n) },
+        give: { Bid: simoleans(7n) },
         exit: { onDemand: null },
       });
       const paymentKeywordRecord = { Bid: simoleanPayment };

--- a/packages/zoe/test/swingsetTests/zoe/vat-dave.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-dave.js
@@ -37,12 +37,12 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         ),
         X`issuerKeywordRecord were not as expected`,
       );
-      assert(sameStructure(invitationValue[0].minimumBid, simoleans(3)));
-      assert(sameStructure(invitationValue[0].auctionedAssets, moola(1)));
+      assert(sameStructure(invitationValue[0].minimumBid, simoleans(3n)));
+      assert(sameStructure(invitationValue[0].auctionedAssets, moola(1n)));
 
       const proposal = harden({
-        want: { Asset: moola(1) },
-        give: { Bid: simoleans(5) },
+        want: { Asset: moola(1n) },
+        give: { Bid: simoleans(5n) },
         exit: { onDemand: null },
       });
       const paymentKeywordRecord = { Bid: simoleanPayment };
@@ -98,7 +98,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         X`asset is the option`,
       );
       assert(
-        sameStructure(invitationValue[0].price, bucks(1)),
+        sameStructure(invitationValue[0].price, bucks(1n)),
         X`price is 1 buck`,
       );
       const optionValue = optionAmounts.value;
@@ -109,14 +109,14 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       assert(
         AmountMath.isEqual(
           optionValue[0].underlyingAssets.UnderlyingAsset,
-          moola(3),
+          moola(3n),
         ),
         X`wrong underlying asset`,
       );
       assert(
         AmountMath.isEqual(
           optionValue[0].strikePrice.StrikePrice,
-          simoleans(7),
+          simoleans(7n),
         ),
         X`wrong strike price`,
       );
@@ -126,7 +126,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       // Dave escrows his 1 buck with Zoe and forms his proposal
       const daveSwapProposal = harden({
         want: { Asset: optionAmounts },
-        give: { Price: bucks(1) },
+        give: { Price: bucks(1n) },
       });
       const daveSwapPayments = harden({ Price: bucksPayment });
       const seatP = await E(zoe).offer(
@@ -144,8 +144,8 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       // call. First, he escrows with Zoe.
 
       const daveCoveredCallProposal = harden({
-        want: { UnderlyingAsset: moola(3) },
-        give: { StrikePrice: simoleans(7) },
+        want: { UnderlyingAsset: moola(3n) },
+        give: { StrikePrice: simoleans(7n) },
       });
       const daveCoveredCallPayments = harden({ StrikePrice: simoleanPayment });
       const optionSeatP = await E(zoe).offer(

--- a/packages/zoe/test/unitTests/contractSupport/test-depositTo.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-depositTo.js
@@ -52,11 +52,11 @@ test(`depositToSeat - groundZero`, async t => {
   const { zcfSeat } = await makeOffer(
     zoe,
     zcf,
-    harden({ want: { A: moola(3) }, give: { B: bucks(5) } }),
-    harden({ B: bucksMint.mintPayment(bucks(5)) }),
+    harden({ want: { A: moola(3n) }, give: { B: bucks(5n) } }),
+    harden({ B: bucksMint.mintPayment(bucks(5n)) }),
   );
-  const newBucks = bucksMint.mintPayment(bucks(2));
-  await depositToSeat(zcf, zcfSeat, { B: bucks(2) }, { B: newBucks });
+  const newBucks = bucksMint.mintPayment(bucks(2n));
+  await depositToSeat(zcf, zcfSeat, { B: bucks(2n) }, { B: newBucks });
   t.deepEqual(
     zcfSeat.getCurrentAllocation(),
     { A: moola(0n), B: bucks(7n) },
@@ -71,14 +71,14 @@ test(`depositToSeat - keyword variations`, async t => {
   const { zcfSeat } = await makeOffer(
     zoe,
     zcf,
-    harden({ want: { A: moola(3) }, give: { B: bucks(5) } }),
-    harden({ B: bucksMint.mintPayment(bucks(5)) }),
+    harden({ want: { A: moola(3n) }, give: { B: bucks(5n) } }),
+    harden({ B: bucksMint.mintPayment(bucks(5n)) }),
   );
-  const newBucks = bucksMint.mintPayment(bucks(2));
-  await depositToSeat(zcf, zcfSeat, { C: bucks(2) }, { C: newBucks });
+  const newBucks = bucksMint.mintPayment(bucks(2n));
+  await depositToSeat(zcf, zcfSeat, { C: bucks(2n) }, { C: newBucks });
   t.deepEqual(
     zcfSeat.getCurrentAllocation(),
-    { A: moola(0n), B: bucks(5), C: bucks(2) },
+    { A: moola(0n), B: bucks(5n), C: bucks(2n) },
     'should add deposit',
   );
 });
@@ -90,12 +90,12 @@ test(`depositToSeat - mismatched keywords`, async t => {
   const { zcfSeat } = await makeOffer(
     zoe,
     zcf,
-    harden({ want: { A: moola(3) }, give: { B: bucks(5) } }),
-    harden({ B: bucksMint.mintPayment(bucks(5)) }),
+    harden({ want: { A: moola(3n) }, give: { B: bucks(5n) } }),
+    harden({ B: bucksMint.mintPayment(bucks(5n)) }),
   );
-  const newBucks = bucksMint.mintPayment(bucks(2));
+  const newBucks = bucksMint.mintPayment(bucks(2n));
   await t.throwsAsync(
-    () => depositToSeat(zcf, zcfSeat, { C: bucks(2) }, { D: newBucks }),
+    () => depositToSeat(zcf, zcfSeat, { C: bucks(2n) }, { D: newBucks }),
     {
       message:
         'The "D" keyword in the paymentKeywordRecord was not a keyword in proposal.give, which had keywords: ["C"]',
@@ -104,7 +104,7 @@ test(`depositToSeat - mismatched keywords`, async t => {
   );
   t.deepEqual(
     zcfSeat.getCurrentAllocation(),
-    { A: moola(0n), B: bucks(5) },
+    { A: moola(0n), B: bucks(5n) },
     'should add deposit',
   );
 });

--- a/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
@@ -91,8 +91,8 @@ test(`offerTo - basic usage`, async t => {
   const { zcfSeat: fromSeatContractA } = await makeOffer(
     zoe,
     zcfA,
-    harden({ want: harden({}), give: { TokenK: bucks(5) } }),
-    harden({ TokenK: bucksMint.mintPayment(bucks(5)) }),
+    harden({ want: harden({}), give: { TokenK: bucks(5n) } }),
+    harden({ TokenK: bucksMint.mintPayment(bucks(5n)) }),
   );
 
   // Create a seat in contract instance B to exchange with.
@@ -100,8 +100,8 @@ test(`offerTo - basic usage`, async t => {
   const { zcfSeat: contractBCollateralSeat } = await makeOffer(
     zoe,
     zcfB,
-    harden({ want: { TokenM: bucks(5) }, give: { TokenL: moola(10) } }),
-    harden({ TokenL: moolaMint.mintPayment(moola(10)) }),
+    harden({ want: { TokenM: bucks(5n) }, give: { TokenL: moola(10n) } }),
+    harden({ TokenL: moolaMint.mintPayment(moola(10n)) }),
   );
 
   // create an invitation for contract instance B. This offer will
@@ -138,10 +138,10 @@ test(`offerTo - basic usage`, async t => {
 
   const proposal = harden({
     give: {
-      TokenM: bucks(5),
+      TokenM: bucks(5n),
     },
     want: {
-      TokenL: moola(10),
+      TokenL: moola(10n),
     },
   });
 
@@ -161,8 +161,8 @@ test(`offerTo - basic usage`, async t => {
   // The toSeat successfully got the payout from the offer to Contract
   // Instance B
   t.deepEqual(toSeatContractA.getCurrentAllocation(), {
-    TokenJ: moola(10),
-    TokenK: bucks(0),
+    TokenJ: moola(10n),
+    TokenK: bucks(0n),
   });
 
   // The offerResult is as expected
@@ -189,8 +189,8 @@ test(`offerTo - violates offer safety of fromSeat`, async t => {
     zoe,
     zcfA,
     // Actually enforce offer safety
-    harden({ want: { TokenJ: moola(3) }, give: { TokenK: bucks(5) } }),
-    harden({ TokenK: bucksMint.mintPayment(bucks(5)) }),
+    harden({ want: { TokenJ: moola(3n) }, give: { TokenK: bucks(5n) } }),
+    harden({ TokenK: bucksMint.mintPayment(bucks(5n)) }),
   );
 
   const offerHandler = () => {};
@@ -207,10 +207,10 @@ test(`offerTo - violates offer safety of fromSeat`, async t => {
 
   const proposal = harden({
     give: {
-      TokenM: bucks(5),
+      TokenM: bucks(5n),
     },
     want: {
-      TokenL: moola(10),
+      TokenL: moola(10n),
     },
   });
 
@@ -235,7 +235,7 @@ test(`offerTo - violates offer safety of fromSeat`, async t => {
 
   t.deepEqual(fromSeatContractA.getCurrentAllocation(), {
     TokenJ: moola(0n),
-    TokenK: bucks(5),
+    TokenK: bucks(5n),
   });
   t.falsy(fromSeatContractA.hasExited());
 });

--- a/packages/zoe/test/unitTests/contractSupport/test-percentSupport.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-percentSupport.js
@@ -32,24 +32,24 @@ function amountsEqual(t, a1, a2, brand) {
 
 test('ratio - ALL', t => {
   const { brand } = makeIssuerKit('moe');
-  const moe = value => AmountMath.make(value, brand);
+  const moe = value => AmountMath.make(brand, value);
 
   amountsEqual(
     t,
-    floorMultiplyBy(moe(100000), make100Percent(brand)),
-    moe(100000),
+    floorMultiplyBy(moe(100000n), make100Percent(brand)),
+    moe(100000n),
     brand,
   );
 });
 
 test('ratio - NONE', t => {
   const { brand } = makeIssuerKit('moe');
-  const moe = value => AmountMath.make(value, brand);
+  const moe = value => AmountMath.make(brand, value);
 
   amountsEqual(
     t,
     AmountMath.makeEmpty(brand),
-    floorMultiplyBy(moe(100000), make0Percent(brand)),
+    floorMultiplyBy(moe(100000n), make0Percent(brand)),
     brand,
   );
 });

--- a/packages/zoe/test/unitTests/contractSupport/test-ratio.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-ratio.js
@@ -42,7 +42,7 @@ function amountsEqual(t, a1, a2, brand) {
 test('ratio - basic (floor)', t => {
   const { brand } = makeIssuerKit('moe');
   /** @param {bigint} value */
-  const moe = value => AmountMath.make(value, brand);
+  const moe = value => AmountMath.make(brand, value);
 
   const halfDefault = makeRatio(50n, brand);
   const halfPrecise = makeRatio(5000n, brand, 10000n);
@@ -67,7 +67,7 @@ test('ratio - basic (floor)', t => {
 test('ratio - basic (ceil)', t => {
   const { brand } = makeIssuerKit('moe');
   /** @param {bigint} value */
-  const moe = value => AmountMath.make(value, brand);
+  const moe = value => AmountMath.make(brand, value);
 
   const halfDefault = makeRatio(50n, brand);
   const halfPrecise = makeRatio(5000n, brand, 10000n);
@@ -93,7 +93,7 @@ test('ratio - basic (ceil)', t => {
 test('ratio - basic deprecated', t => {
   const { brand } = makeIssuerKit('moe');
   /** @param {bigint} value */
-  const moe = value => AmountMath.make(value, brand);
+  const moe = value => AmountMath.make(brand, value);
 
   const halfDefault = makeRatio(50n, brand);
   const halfPrecise = makeRatio(5000n, brand, 10000n);
@@ -122,17 +122,21 @@ test('ratio - multiplyBy non Amount', t => {
     value: 3.5,
     brand,
   });
+  // @ts-ignore Incorrect values for testing
   t.throws(() => floorMultiplyBy(badAmount, makeRatio(25n, brand)), {
-    message: 'value 3.5 must be a Nat or an array',
+    message: 'value 3.5 must be a bigint or an array, not "number"',
   });
+  // @ts-ignore Incorrect values for testing
   t.throws(() => ceilMultiplyBy(badAmount, makeRatio(25n, brand)), {
-    message: 'value 3.5 must be a Nat or an array',
+    message: 'value 3.5 must be a bigint or an array, not "number"',
   });
+  // @ts-ignore Incorrect values for testing
   t.throws(() => floorDivideBy(badAmount, makeRatio(25n, brand)), {
-    message: 'value 3.5 must be a Nat or an array',
+    message: 'value 3.5 must be a bigint or an array, not "number"',
   });
+  // @ts-ignore Incorrect values for testing
   t.throws(() => ceilDivideBy(badAmount, makeRatio(25n, brand)), {
-    message: 'value 3.5 must be a Nat or an array',
+    message: 'value 3.5 must be a bigint or an array, not "number"',
   });
 });
 
@@ -145,17 +149,17 @@ test('ratio - multiplyBy non Amount deprecated', t => {
     brand,
   });
   t.throws(() => multiplyBy(badAmount, makeRatio(25n, brand)), {
-    message: 'value 3.5 must be a Nat or an array',
+    message: 'value 3.5 must be a bigint or an array, not "number"',
   });
   t.throws(() => divideBy(badAmount, makeRatio(25n, brand)), {
-    message: 'value 3.5 must be a Nat or an array',
+    message: 'value 3.5 must be a bigint or an array, not "number"',
   });
 });
 
 test('ratio - onethird', t => {
   const { brand } = makeIssuerKit('moe');
   /** @param {bigint} value */
-  const moe = value => AmountMath.make(value, brand);
+  const moe = value => AmountMath.make(brand, value);
 
   const oneThird = makeRatioFromAmounts(moe(1n), moe(3n));
 
@@ -167,7 +171,7 @@ test('ratio - onethird', t => {
 test('ratio - onethird deprecated', t => {
   const { brand } = makeIssuerKit('moe');
   /** @param {bigint} value */
-  const moe = value => AmountMath.make(value, brand);
+  const moe = value => AmountMath.make(brand, value);
 
   const oneThird = makeRatioFromAmounts(moe(1n), moe(3n));
 
@@ -177,14 +181,14 @@ test('ratio - onethird deprecated', t => {
 test('ratio - different brands', t => {
   const { brand } = makeIssuerKit('moe');
   /** @param {bigint} value */
-  const moe = value => AmountMath.make(value, brand);
+  const moe = value => AmountMath.make(brand, value);
   const { brand: astBrand } = makeIssuerKit('ast');
   /** @param {bigint} value */
-  const ast = value => AmountMath.make(value, astBrand);
+  const ast = value => AmountMath.make(astBrand, value);
 
   const convertToMoe = makeRatioFromAmounts(
     moe(1n),
-    AmountMath.make(3n, astBrand),
+    AmountMath.make(astBrand, 3n),
   );
   amountsEqual(
     t,
@@ -199,14 +203,14 @@ test('ratio - different brands', t => {
 test('ratio - different brands deprecated', t => {
   const { brand } = makeIssuerKit('moe');
   /** @param {bigint} value */
-  const moe = value => AmountMath.make(value, brand);
+  const moe = value => AmountMath.make(brand, value);
   const { brand: astBrand } = makeIssuerKit('ast');
   /** @param {bigint} value */
-  const ast = value => AmountMath.make(value, astBrand);
+  const ast = value => AmountMath.make(astBrand, value);
 
   const convertToMoe = makeRatioFromAmounts(
     moe(1n),
-    AmountMath.make(3n, astBrand),
+    AmountMath.make(astBrand, 3n),
   );
   amountsEqual(t, multiplyBy(ast(10000n), convertToMoe), moe(3333n), brand);
 });
@@ -214,14 +218,14 @@ test('ratio - different brands deprecated', t => {
 test('ratio - brand mismatch', t => {
   const { brand } = makeIssuerKit('moe');
   /** @param {bigint} value */
-  const moe = value => AmountMath.make(value, brand);
+  const moe = value => AmountMath.make(brand, value);
   const { brand: astBrand } = makeIssuerKit('ast');
   /** @param {bigint} value */
-  const ast = value => AmountMath.make(value, astBrand);
+  const ast = value => AmountMath.make(astBrand, value);
 
   const convertToMoe = makeRatioFromAmounts(
     moe(1n),
-    AmountMath.make(3n, astBrand),
+    AmountMath.make(astBrand, 3n),
   );
   t.throws(() => floorDivideBy(ast(10000n), convertToMoe), {
     message: /amount's brand .* must match ratio's numerator .*/,
@@ -241,14 +245,14 @@ test('ratio - brand mismatch', t => {
 test('ratio - brand mismatch deprecated', t => {
   const { brand } = makeIssuerKit('moe');
   /** @param {bigint} value */
-  const moe = value => AmountMath.make(value, brand);
+  const moe = value => AmountMath.make(brand, value);
   const { brand: astBrand } = makeIssuerKit('ast');
   /** @param {bigint} value */
-  const ast = value => AmountMath.make(value, astBrand);
+  const ast = value => AmountMath.make(astBrand, value);
 
   const convertToMoe = makeRatioFromAmounts(
     moe(1n),
-    AmountMath.make(3n, astBrand),
+    AmountMath.make(astBrand, 3n),
   );
   t.throws(() => divideBy(ast(10000n), convertToMoe), {
     message: /amount's brand .* must match ratio's numerator .*/,
@@ -261,14 +265,14 @@ test('ratio - brand mismatch deprecated', t => {
 test('ratio - brand mismatch & details', t => {
   const { brand } = makeIssuerKit('moe');
   /** @param {bigint} value */
-  const moe = value => AmountMath.make(value, brand);
+  const moe = value => AmountMath.make(brand, value);
   const { brand: astBrand } = makeIssuerKit('ast');
   /** @param {bigint} value */
-  const ast = value => AmountMath.make(value, astBrand);
+  const ast = value => AmountMath.make(astBrand, value);
 
   const convertToMoe = makeRatioFromAmounts(
     moe(1n),
-    AmountMath.make(3n, astBrand),
+    AmountMath.make(astBrand, 3n),
   );
   t.throws(() => floorDivideBy(ast(10000n), convertToMoe), {
     message: `amount's brand "[Alleged: ast brand]" must match ratio's numerator "[Alleged: moe brand]"`,
@@ -288,14 +292,14 @@ test('ratio - brand mismatch & details', t => {
 test('ratio - brand mismatch & details deprecated', t => {
   const { brand } = makeIssuerKit('moe');
   /** @param {bigint} value */
-  const moe = value => AmountMath.make(value, brand);
+  const moe = value => AmountMath.make(brand, value);
   const { brand: astBrand } = makeIssuerKit('ast');
   /** @param {bigint} value */
-  const ast = value => AmountMath.make(value, astBrand);
+  const ast = value => AmountMath.make(astBrand, value);
 
   const convertToMoe = makeRatioFromAmounts(
     moe(1n),
-    AmountMath.make(3n, astBrand),
+    AmountMath.make(astBrand, 3n),
   );
   t.throws(() => divideBy(ast(10000n), convertToMoe), {
     message: `amount's brand "[Alleged: ast brand]" must match ratio's numerator "[Alleged: moe brand]"`,
@@ -308,7 +312,7 @@ test('ratio - brand mismatch & details deprecated', t => {
 test('ratio - larger than 100%', t => {
   const { brand } = makeIssuerKit('moe');
   /** @param {bigint} value */
-  const moe = value => AmountMath.make(value, brand);
+  const moe = value => AmountMath.make(brand, value);
 
   const fiveThirds = makeRatioFromAmounts(moe(5n), moe(3n));
 
@@ -321,7 +325,7 @@ test('ratio - larger than 100%', t => {
 test('ratio - larger than 100% deprecated', t => {
   const { brand } = makeIssuerKit('moe');
   /** @param {bigint} value */
-  const moe = value => AmountMath.make(value, brand);
+  const moe = value => AmountMath.make(brand, value);
 
   const fiveThirds = makeRatioFromAmounts(moe(5n), moe(3n));
 
@@ -334,14 +338,14 @@ test('ratio - Nats', t => {
 
   // @ts-ignore invalid arguments for testing
   t.throws(() => makeRatio(10.1, brand), {
-    message: '10.1 not a safe integer',
+    message: 'value 10.1 must be a bigint or an array, not "number"',
   });
 });
 
 test('ratio division', t => {
   const { brand } = makeIssuerKit('moe');
   /** @param {bigint} value */
-  const moe = value => AmountMath.make(value, brand);
+  const moe = value => AmountMath.make(brand, value);
 
   const twoFifths = makeRatioFromAmounts(moe(2n), moe(5n));
   amountsEqual(t, floorDivideBy(moe(100n), twoFifths), moe(250n), brand);
@@ -356,7 +360,7 @@ test('ratio division', t => {
 test('ratio division deprecated', t => {
   const { brand } = makeIssuerKit('moe');
   /** @param {bigint} value */
-  const moe = value => AmountMath.make(value, brand);
+  const moe = value => AmountMath.make(brand, value);
 
   const twoFifths = makeRatioFromAmounts(moe(2n), moe(5n));
   amountsEqual(t, divideBy(moe(100n), twoFifths), moe(250n), brand);
@@ -367,7 +371,7 @@ test('ratio division deprecated', t => {
 test('ratio inverse', t => {
   const { brand } = makeIssuerKit('moe');
   /** @param {bigint} value */
-  const moe = value => AmountMath.make(value, brand);
+  const moe = value => AmountMath.make(brand, value);
 
   const twoFifths = makeRatioFromAmounts(moe(2n), moe(5n));
   const fiveHalves = invertRatio(twoFifths);
@@ -382,7 +386,7 @@ test('ratio inverse', t => {
 test('ratio inverse deprecated', t => {
   const { brand } = makeIssuerKit('moe');
   /** @param {bigint} value */
-  const moe = value => AmountMath.make(value, brand);
+  const moe = value => AmountMath.make(brand, value);
 
   const twoFifths = makeRatioFromAmounts(moe(2n), moe(5n));
   const fiveHalves = invertRatio(twoFifths);
@@ -394,29 +398,34 @@ test('ratio inverse deprecated', t => {
 test('ratio bad inputs', t => {
   const { brand } = makeIssuerKit('moe');
   /** @param {bigint} value */
-  const moe = value => AmountMath.make(value, brand);
+  const moe = value => AmountMath.make(brand, value);
   // @ts-ignore invalid arguments for testing
   t.throws(() => makeRatio(-3, brand), {
-    message: '-3 is negative',
+    message: 'value -3 must be a bigint or an array, not "number"',
   });
   // @ts-ignore invalid arguments for testing
   t.throws(() => makeRatio(3n, brand, 100.5), {
-    message: '100.5 not a safe integer',
+    message: 'value 100.5 must be a bigint or an array, not "number"',
   });
+  // @ts-ignore invalid arguments for testing
   t.throws(() => makeRatioFromAmounts(3n, moe(30n)), {
-    message: `The brand "[undefined]" doesn't look like a brand.`,
+    message: '"brand" "[undefined]" must be a remotable, not "undefined"',
   });
+  // @ts-ignore invalid arguments for testing
   t.throws(() => floorMultiplyBy(37, makeRatioFromAmounts(moe(3n), moe(5n))), {
-    message: `The brand "[undefined]" doesn't look like a brand.`,
+    message: '"brand" "[undefined]" must be a remotable, not "undefined"',
   });
+  // @ts-ignore invalid arguments for testing
   t.throws(() => ceilMultiplyBy(37, makeRatioFromAmounts(moe(3n), moe(5n))), {
-    message: `The brand "[undefined]" doesn't look like a brand.`,
+    message: '"brand" "[undefined]" must be a remotable, not "undefined"',
   });
+  // @ts-ignore invalid arguments for testing
   t.throws(() => floorDivideBy(makeRatioFromAmounts(moe(3n), moe(5n)), 37), {
-    message: `The brand "[undefined]" doesn't look like a brand.`,
+    message: '"brand" "[undefined]" must be a remotable, not "undefined"',
   });
+  // @ts-ignore invalid arguments for testing
   t.throws(() => ceilDivideBy(makeRatioFromAmounts(moe(3n), moe(5n)), 37), {
-    message: `The brand "[undefined]" doesn't look like a brand.`,
+    message: '"brand" "[undefined]" must be a remotable, not "undefined"',
   });
   t.throws(() => makeRatio(3n, brand, 0n), {
     message: /No infinite ratios! Denominator was 0/,
@@ -433,20 +442,21 @@ test('ratio bad inputs', t => {
 test('ratio bad inputs deprecated', t => {
   const { brand } = makeIssuerKit('moe');
   /** @param {bigint} value */
-  const moe = value => AmountMath.make(value, brand);
+  const moe = value => AmountMath.make(brand, value);
   // @ts-ignore invalid arguments for testing
   t.throws(() => multiplyBy(37, makeRatioFromAmounts(moe(3n), moe(5n))), {
-    message: `The brand "[undefined]" doesn't look like a brand.`,
+    message: '"brand" "[undefined]" must be a remotable, not "undefined"',
   });
+  // @ts-ignore invalid arguments for testing
   t.throws(() => divideBy(makeRatioFromAmounts(moe(3n), moe(5n)), 37), {
-    message: `The brand "[undefined]" doesn't look like a brand.`,
+    message: '"brand" "[undefined]" must be a remotable, not "undefined"',
   });
 });
 
 test('ratio bad inputs w/brand names', t => {
   const { brand } = makeIssuerKit('moe');
   /** @param {bigint} value */
-  const moe = value => AmountMath.make(value, brand);
+  const moe = value => AmountMath.make(brand, value);
   t.throws(() => makeRatio(3n, brand, 0n), {
     message: 'No infinite ratios! Denominator was 0/"[Alleged: moe brand]"',
   });
@@ -462,7 +472,7 @@ test('multiply ratios', t => {
   const { brand } = makeIssuerKit('moe');
 
   /** @param {bigint} value */
-  const moe = value => AmountMath.make(value, brand);
+  const moe = value => AmountMath.make(brand, value);
 
   const twoFifths = makeRatioFromAmounts(moe(2n), moe(5n));
   const fiveSixths = makeRatioFromAmounts(moe(5n), moe(6n));
@@ -476,7 +486,7 @@ test('add ratios', t => {
   const { brand } = makeIssuerKit('moe');
 
   /** @param {bigint} value */
-  const moe = value => AmountMath.make(value, brand);
+  const moe = value => AmountMath.make(brand, value);
 
   const twoFifths = makeRatioFromAmounts(moe(2n), moe(5n));
   const fiveSixths = makeRatioFromAmounts(moe(5n), moe(6n));
@@ -488,22 +498,23 @@ test('add ratios', t => {
 
 test('ratio - complement', t => {
   const { brand } = makeIssuerKit('moe');
-  const moe = value => AmountMath.make(value, brand);
+  const moe = value => AmountMath.make(brand, value);
 
-  const oneThird = makeRatioFromAmounts(moe(1), moe(3));
+  const oneThird = makeRatioFromAmounts(moe(1n), moe(3n));
   const twoThirds = oneMinus(oneThird);
 
-  t.deepEqual(twoThirds, makeRatio(2, brand, 3));
-  amountsEqual(t, floorMultiplyBy(moe(100000), oneThird), moe(33333), brand);
-  amountsEqual(t, ceilMultiplyBy(moe(100000), oneThird), moe(33334), brand);
-  amountsEqual(t, floorMultiplyBy(moe(100000), twoThirds), moe(66666), brand);
-  amountsEqual(t, ceilMultiplyBy(moe(100000), twoThirds), moe(66667), brand);
+  t.deepEqual(twoThirds, makeRatio(2n, brand, 3n));
+  amountsEqual(t, floorMultiplyBy(moe(100000n), oneThird), moe(33333n), brand);
+  amountsEqual(t, ceilMultiplyBy(moe(100000n), oneThird), moe(33334n), brand);
+  amountsEqual(t, floorMultiplyBy(moe(100000n), twoThirds), moe(66666n), brand);
+  amountsEqual(t, ceilMultiplyBy(moe(100000n), twoThirds), moe(66667n), brand);
 
-  t.throws(() => oneMinus(moe(3)), {
+  // @ts-ignore invalid arguments for testing
+  t.throws(() => oneMinus(moe(3n)), {
     message:
       'Parameter must be a Ratio record, but {"brand":"[Alleged: moe brand]","value":"[3n]"} has "brand"',
   });
-  t.throws(() => oneMinus(makeRatioFromAmounts(moe(30), moe(20))), {
+  t.throws(() => oneMinus(makeRatioFromAmounts(moe(30n), moe(20n))), {
     message: /Parameter must be less than or equal to 1: .*/,
   });
 });
@@ -511,12 +522,12 @@ test('ratio - complement', t => {
 // TODO: (3676) drop when the deprecated multiplyBy is removed
 test('ratio - complement deprecated', t => {
   const { brand } = makeIssuerKit('moe');
-  const moe = value => AmountMath.make(value, brand);
+  const moe = value => AmountMath.make(brand, value);
 
-  const oneThird = makeRatioFromAmounts(moe(1), moe(3));
+  const oneThird = makeRatioFromAmounts(moe(1n), moe(3n));
   const twoThirds = oneMinus(oneThird);
 
-  t.deepEqual(twoThirds, makeRatio(2, brand, 3));
-  amountsEqual(t, multiplyBy(moe(100000), oneThird), moe(33333), brand);
-  amountsEqual(t, multiplyBy(moe(100000), twoThirds), moe(66666), brand);
+  t.deepEqual(twoThirds, makeRatio(2n, brand, 3n));
+  amountsEqual(t, multiplyBy(moe(100000n), oneThird), moe(33333n), brand);
+  amountsEqual(t, multiplyBy(moe(100000n), twoThirds), moe(66666n), brand);
 });

--- a/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
@@ -56,15 +56,15 @@ test(`withdrawFromSeat - groundZero`, async t => {
   const { zcfSeat } = await makeOffer(
     zoe,
     zcf,
-    harden({ want: { A: moola(3) }, give: { B: bucks(5) } }),
-    harden({ B: bucksMint.mintPayment(bucks(5)) }),
+    harden({ want: { A: moola(3n) }, give: { B: bucks(5n) } }),
+    harden({ B: bucksMint.mintPayment(bucks(5n)) }),
   );
 
-  const newBucks = bucksMint.mintPayment(bucks(2));
-  await depositToSeat(zcf, zcfSeat, { C: bucks(2) }, { C: newBucks });
-  const promises = await withdrawFromSeat(zcf, zcfSeat, { C: bucks(2) });
+  const newBucks = bucksMint.mintPayment(bucks(2n));
+  await depositToSeat(zcf, zcfSeat, { C: bucks(2n) }, { C: newBucks });
+  const promises = await withdrawFromSeat(zcf, zcfSeat, { C: bucks(2n) });
 
-  await assertPayoutAmount(t, bucksIssuer, promises.C, bucks(2), 'C is 2');
+  await assertPayoutAmount(t, bucksIssuer, promises.C, bucks(2n), 'C is 2');
 });
 
 test(`withdrawFromSeat - violates offerSafety`, async t => {
@@ -74,19 +74,19 @@ test(`withdrawFromSeat - violates offerSafety`, async t => {
   const { zcfSeat } = await makeOffer(
     zoe,
     zcf,
-    harden({ want: { A: moola(3) }, give: { B: bucks(5) } }),
-    harden({ B: bucksMint.mintPayment(bucks(5)) }),
+    harden({ want: { A: moola(3n) }, give: { B: bucks(5n) } }),
+    harden({ B: bucksMint.mintPayment(bucks(5n)) }),
   );
 
-  const newBucks = bucksMint.mintPayment(bucks(2));
-  await depositToSeat(zcf, zcfSeat, { B: bucks(2) }, { B: newBucks });
+  const newBucks = bucksMint.mintPayment(bucks(2n));
+  await depositToSeat(zcf, zcfSeat, { B: bucks(2n) }, { B: newBucks });
   t.deepEqual(
     zcfSeat.getCurrentAllocation(),
     { A: moola(0n), B: bucks(7n) },
     'should add deposit',
   );
   await t.throwsAsync(
-    withdrawFromSeat(zcf, zcfSeat, { B: bucks(4) }),
+    withdrawFromSeat(zcf, zcfSeat, { B: bucks(4n) }),
     {
       message: /Offer safety was violated by the proposed allocation/,
     },

--- a/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-zoeHelpers.js
@@ -40,13 +40,13 @@ function makeMockTradingZcfBuilder() {
 test('ZoeHelpers satisfies blank proposal', t => {
   const { moola } = setup();
   const fakeZcfSeat = Far('fakeZcfSeat', {
-    getCurrentAllocation: () => harden({ Asset: moola(10) }),
+    getCurrentAllocation: () => harden({ Asset: moola(10n) }),
     getProposal: () => harden({}),
   });
   const mockZCFBuilder = makeMockTradingZcfBuilder();
   const mockZCF = mockZCFBuilder.build();
   t.truthy(
-    satisfies(mockZCF, fakeZcfSeat, { Gift: moola(3) }),
+    satisfies(mockZCF, fakeZcfSeat, { Gift: moola(3n) }),
     `giving anything to a blank proposal is satisifying`,
   );
 });
@@ -54,29 +54,32 @@ test('ZoeHelpers satisfies blank proposal', t => {
 test('ZoeHelpers satisfies simple proposal', t => {
   const { moola, simoleans } = setup();
   const fakeZcfSeat = Far('fakeZcfSeat', {
-    getCurrentAllocation: () => harden({ Asset: moola(10) }),
-    getProposal: () => harden({ want: { Desire: moola(30) } }),
+    getCurrentAllocation: () => harden({ Asset: moola(10n) }),
+    getProposal: () => harden({ want: { Desire: moola(30n) } }),
   });
   const mockZCFBuilder = makeMockTradingZcfBuilder();
   const mockZCF = mockZCFBuilder.build();
   t.falsy(
-    satisfies(mockZCF, fakeZcfSeat, { Desire: moola(3) }),
+    satisfies(mockZCF, fakeZcfSeat, { Desire: moola(3n) }),
     `giving less than specified to a proposal is not satisifying`,
   );
   t.falsy(
-    satisfies(mockZCF, fakeZcfSeat, { Gift: moola(3) }),
+    satisfies(mockZCF, fakeZcfSeat, { Gift: moola(3n) }),
     `giving other than what's specified to a proposal is not satisifying`,
   );
   t.truthy(
-    satisfies(mockZCF, fakeZcfSeat, { Desire: moola(30) }),
+    satisfies(mockZCF, fakeZcfSeat, { Desire: moola(30n) }),
     `giving exactly what's proposed is satisifying`,
   );
   t.truthy(
-    satisfies(mockZCF, fakeZcfSeat, { Desire: moola(30), Gift: simoleans(1) }),
+    satisfies(mockZCF, fakeZcfSeat, {
+      Desire: moola(30n),
+      Gift: simoleans(1n),
+    }),
     `giving extras beyond what's proposed is satisifying`,
   );
   t.truthy(
-    satisfies(mockZCF, fakeZcfSeat, { Desire: moola(40) }),
+    satisfies(mockZCF, fakeZcfSeat, { Desire: moola(40n) }),
     `giving more than what's proposed is satisifying`,
   );
 });
@@ -84,26 +87,26 @@ test('ZoeHelpers satisfies simple proposal', t => {
 test('ZoeHelpers satisfies() with give', t => {
   const { moola, bucks } = setup();
   const fakeZcfSeat = Far('fakeZcfSeat', {
-    getCurrentAllocation: () => harden({ Charge: moola(30) }),
+    getCurrentAllocation: () => harden({ Charge: moola(30n) }),
     getProposal: () =>
-      harden({ give: { Charge: moola(30) }, want: { Desire: bucks(5) } }),
+      harden({ give: { Charge: moola(30n) }, want: { Desire: bucks(5n) } }),
   });
   const mockZCFBuilder = makeMockTradingZcfBuilder();
   const mockZCF = mockZCFBuilder.build();
   t.falsy(
-    satisfies(mockZCF, fakeZcfSeat, { Charge: moola(0n), Desire: bucks(1) }),
+    satisfies(mockZCF, fakeZcfSeat, { Charge: moola(0n), Desire: bucks(1n) }),
     `providing neither give nor want is not satisfying`,
   );
   t.falsy(
-    satisfies(mockZCF, fakeZcfSeat, { Charge: moola(30) }),
+    satisfies(mockZCF, fakeZcfSeat, { Charge: moola(30n) }),
     `providing less than what's wanted is not satisfying`,
   );
   t.truthy(
-    satisfies(mockZCF, fakeZcfSeat, { Charge: moola(0n), Desire: bucks(40) }),
+    satisfies(mockZCF, fakeZcfSeat, { Charge: moola(0n), Desire: bucks(40n) }),
     `providing more than what's wanted is satisfying`,
   );
   t.truthy(
-    satisfies(mockZCF, fakeZcfSeat, { Desire: bucks(40), Charge: moola(3) }),
+    satisfies(mockZCF, fakeZcfSeat, { Desire: bucks(40n), Charge: moola(3n) }),
     `providing what's wanted makes it possible to reduce give`,
   );
 });

--- a/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-extendExpiration.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/expiringNFT/test-extendExpiration.js
@@ -41,11 +41,11 @@ const doTest = (
     currentAllocation = {};
   } else if (moreThanOneElem) {
     currentAllocation = {
-      Attestation: AmountMath.make(attestationBrand, [elem, elem2]),
+      Attestation: AmountMath.make(attestationBrand, harden([elem, elem2])),
     };
   } else {
     currentAllocation = {
-      Attestation: AmountMath.make(attestationBrand, [elem]),
+      Attestation: AmountMath.make(attestationBrand, harden([elem])),
     };
   }
 
@@ -83,11 +83,14 @@ const doTest = (
     mintGains: (gains, seat) => {
       if (moreThanOneElem) {
         t.deepEqual(gains, {
-          Attestation: AmountMath.make(attestationBrand, [newElem, newElem2]),
+          Attestation: AmountMath.make(
+            attestationBrand,
+            harden([newElem, newElem2]),
+          ),
         });
       } else {
         t.deepEqual(gains, {
-          Attestation: AmountMath.make(attestationBrand, [newElem]),
+          Attestation: AmountMath.make(attestationBrand, harden([newElem])),
         });
       }
       t.is(seat, zcfSeat);

--- a/packages/zoe/test/unitTests/contracts/attestation/returnableNFT/test-userFlow.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/returnableNFT/test-userFlow.js
@@ -112,7 +112,7 @@ test(`typical flow`, async t => {
 
   // The attestation should have been deposited and used up
   await t.throwsAsync(() => E(attestationIssuer).getAmountOf(attestation2), {
-    message: /^payment not found for "Token"/,
+    message: /was not a live payment/,
   });
 
   // The amountLiened has been reduced by 50n to 100n

--- a/packages/zoe/test/unitTests/contracts/attestation/test-attestation.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/test-attestation.js
@@ -27,9 +27,13 @@ test('attestation contract basic tests', async t => {
   const zoe = E(zoeService).bindDefaultFeePurse(feePurse);
   const installation = await E(zoe).install(bundle);
 
-  const bldIssuerKit = makeIssuerKit('BLD', AssetKind.NAT, {
-    decimalPlaces: 6,
-  });
+  const bldIssuerKit = makeIssuerKit(
+    'BLD',
+    AssetKind.NAT,
+    harden({
+      decimalPlaces: 6,
+    }),
+  );
   const uBrand = bldIssuerKit.brand;
   const uIssuer = bldIssuerKit.issuer;
 
@@ -103,24 +107,30 @@ test('attestation contract basic tests', async t => {
 
   t.deepEqual(
     await E(issuers.returnable).getAmountOf(returnable1),
-    AmountMath.make(brands.returnable, [
-      {
-        address: 'address1',
-        amountLiened: amount50,
-      },
-    ]),
+    AmountMath.make(
+      brands.returnable,
+      harden([
+        {
+          address: 'address1',
+          amountLiened: amount50,
+        },
+      ]),
+    ),
   );
   const expiring1Amount = await E(issuers.expiring).getAmountOf(expiring1);
   t.deepEqual(
     expiring1Amount,
-    AmountMath.make(brands.expiring, [
-      {
-        address: 'address1',
-        amountLiened: amount50,
-        expiration: shortExpiration,
-        handle: expiring1Amount.value[0].handle,
-      },
-    ]),
+    AmountMath.make(
+      brands.expiring,
+      harden([
+        {
+          address: 'address1',
+          amountLiened: amount50,
+          expiration: shortExpiration,
+          handle: expiring1Amount.value[0].handle,
+        },
+      ]),
+    ),
   );
 
   const liened2 = await E(creatorFacet).getLiened(
@@ -139,24 +149,30 @@ test('attestation contract basic tests', async t => {
 
   t.deepEqual(
     await E(issuers.returnable).getAmountOf(returnable2),
-    AmountMath.make(brands.returnable, [
-      {
-        address: 'address1',
-        amountLiened: amount25,
-      },
-    ]),
+    AmountMath.make(
+      brands.returnable,
+      harden([
+        {
+          address: 'address1',
+          amountLiened: amount25,
+        },
+      ]),
+    ),
   );
   const expiring2Amount = await E(issuers.expiring).getAmountOf(expiring2);
   t.deepEqual(
     expiring2Amount,
-    AmountMath.make(brands.expiring, [
-      {
-        address: 'address1',
-        amountLiened: amount25,
-        expiration: longExpiration,
-        handle: expiring2Amount.value[0].handle,
-      },
-    ]),
+    AmountMath.make(
+      brands.expiring,
+      harden([
+        {
+          address: 'address1',
+          amountLiened: amount25,
+          expiration: longExpiration,
+          handle: expiring2Amount.value[0].handle,
+        },
+      ]),
+    ),
   );
   t.not(expiring1Amount.value[0].handle, expiring2Amount.value[0].handle);
 
@@ -262,14 +278,17 @@ test('attestation contract basic tests', async t => {
   const expiring4Amount = await E(issuers.expiring).getAmountOf(expiring4);
   t.deepEqual(
     expiring4Amount,
-    AmountMath.make(brands.expiring, [
-      {
-        address: 'address1',
-        amountLiened: amount50,
-        expiration: 103n,
-        handle: expiring3Amount.value[0].handle,
-      },
-    ]),
+    AmountMath.make(
+      brands.expiring,
+      harden([
+        {
+          address: 'address1',
+          amountLiened: amount50,
+          expiration: 103n,
+          handle: expiring3Amount.value[0].handle,
+        },
+      ]),
+    ),
   );
 
   await E(creatorFacet).slashed(harden([address1]), currentTime, uBrand);

--- a/packages/zoe/test/unitTests/contracts/attestation/test-exampleVotingUsage.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/test-exampleVotingUsage.js
@@ -28,9 +28,13 @@ test('exampleVotingUsage', async t => {
   const zoe = E(zoeService).bindDefaultFeePurse(feePurse);
   const installation = await E(zoe).install(bundle);
 
-  const bldIssuerKit = makeIssuerKit('BLD', AssetKind.NAT, {
-    decimalPlaces: 6,
-  });
+  const bldIssuerKit = makeIssuerKit(
+    'BLD',
+    AssetKind.NAT,
+    harden({
+      decimalPlaces: 6,
+    }),
+  );
 
   const issuerKit = makeIssuerKit('BldAttGov', AssetKind.SET);
 
@@ -60,24 +64,27 @@ test('exampleVotingUsage', async t => {
   const firstHandle = makeHandle('Attestation');
   const bld40 = AmountMath.make(bldIssuerKit.brand, 40n);
   const elem1 = makeAttestationElem('myaddress', bld40, 5n, firstHandle);
-  await doVote(AmountMath.make(issuerKit.brand, [elem1]), 'Yes');
+  await doVote(AmountMath.make(issuerKit.brand, harden([elem1])), 'Yes');
 
   // Another vote, but which expires at 1n
   const secondHandle = makeHandle('Attestation');
   const bld3 = AmountMath.make(bldIssuerKit.brand, 3n);
   const elem2 = makeAttestationElem('myaddress', bld3, 1n, secondHandle);
-  await doVote(AmountMath.make(issuerKit.brand, [elem2]), 'No');
+  await doVote(AmountMath.make(issuerKit.brand, harden([elem2])), 'No');
 
   // Let's decide to trade that attestation in for one with a longer
   // expiration. Note that the handle and the value are the same.
   const elem3 = makeAttestationElem('myaddress', bld3, 4n, secondHandle);
-  await doVote(AmountMath.make(issuerKit.brand, [elem3]), 'Maybe');
+  await doVote(AmountMath.make(issuerKit.brand, harden([elem3])), 'Maybe');
 
   // This vote should not be counted as it is expired.
   const thirdHandle = makeHandle('Attestation');
   const bld5 = AmountMath.make(bldIssuerKit.brand, 5n);
   const elem4 = makeAttestationElem('myaddress', bld5, 1n, thirdHandle);
-  await doVote(AmountMath.make(issuerKit.brand, [elem4]), 'Should not count');
+  await doVote(
+    AmountMath.make(issuerKit.brand, harden([elem4])),
+    'Should not count',
+  );
 
   const result = await E(creatorFacet).closeVote(3n);
 

--- a/packages/zoe/test/unitTests/contracts/constantProduct/test-calcDeltaX.js
+++ b/packages/zoe/test/unitTests/contracts/constantProduct/test-calcDeltaX.js
@@ -17,43 +17,43 @@ const doTest = (t, x, y, deltaY, expectedDeltaX) => {
 };
 
 test('0, 0, 0, 0', t => {
-  t.throws(() => doTest(t, 0, 0, 0, 0), {
+  t.throws(() => doTest(t, 0n, 0n, 0n, 0n), {
     message: 'No infinite ratios! Denominator was 0/"[Alleged: BLD brand]"',
   });
 });
 
 test('0, 0, 1, 0', t => {
-  t.throws(() => doTest(t, 0, 0, 1, 0), {
+  t.throws(() => doTest(t, 0n, 0n, 1n, 0n), {
     message: '-1 is negative',
   });
 });
 
 test('1, 0, 0, 0', t => {
-  t.throws(() => doTest(t, 1, 0, 0, 0), {
+  t.throws(() => doTest(t, 1n, 0n, 0n, 0n), {
     message: 'No infinite ratios! Denominator was 0/"[Alleged: BLD brand]"',
   });
 });
 
 test('0, 1, 0, 0', t => {
-  doTest(t, 0, 1, 0, 0);
+  doTest(t, 0n, 1n, 0n, 0n);
 });
 
 test('1, 1, 0, 0', t => {
-  doTest(t, 1, 1, 0, 0);
+  doTest(t, 1n, 1n, 0n, 0n);
 });
 
 test('1, 1, 1, 0', t => {
-  t.throws(() => doTest(t, 1, 1, 1, 0), {
+  t.throws(() => doTest(t, 1n, 1n, 1n, 0n), {
     message: 'No infinite ratios! Denominator was 0/"[Alleged: BLD brand]"',
   });
 });
 
 test('1, 2, 1, 1', t => {
-  doTest(t, 1, 2, 1, 1);
+  doTest(t, 1n, 2n, 1n, 1n);
 });
 
 test('2, 3, 1, 1', t => {
-  doTest(t, 2, 3, 1, 1);
+  doTest(t, 2n, 3n, 1n, 1n);
 });
 
 test('928861206, 130870247, 746353662, 158115257', t => {
@@ -61,22 +61,22 @@ test('928861206, 130870247, 746353662, 158115257', t => {
 });
 
 test('9, 17, 3, 2', t => {
-  doTest(t, 9, 17, 3, 2);
+  doTest(t, 9n, 17n, 3n, 2n);
 });
 
 test('10000, 5000, 209, 437', t => {
-  doTest(t, 10000, 5000, 209, 437);
+  doTest(t, 10000n, 5000n, 209n, 437n);
 });
 
 test('1000000, 5000, 209, 1', t => {
-  doTest(t, 1_000_000, 5000, 209, 43624);
+  doTest(t, 1_000_000n, 5000n, 209n, 43624n);
 });
 
 test('5000, 1000000, 209, 2', t => {
-  doTest(t, 5000, 1000000, 209, 2);
+  doTest(t, 5000n, 1000000n, 209n, 2n);
 });
 
 test('500_000, 1000_000, 209 or 210', t => {
-  doTest(t, 500_000, 1000_000, 209, 105);
-  doTest(t, 500_000, 1000_000, 210, 106);
+  doTest(t, 500_000n, 1000_000n, 209n, 105n);
+  doTest(t, 500_000n, 1000_000n, 210n, 106n);
 });

--- a/packages/zoe/test/unitTests/contracts/constantProduct/test-calcDeltaY.js
+++ b/packages/zoe/test/unitTests/contracts/constantProduct/test-calcDeltaY.js
@@ -18,40 +18,40 @@ const doTest = (t, x, y, deltaX, expectedDeltaY) => {
 
 // deltaXPlusX is 0
 test('0, 0, 0, 0', t => {
-  t.throws(() => doTest(t, 0, 0, 0, 0), {
+  t.throws(() => doTest(t, 0n, 0n, 0n, 0n), {
     message: 'No infinite ratios! Denominator was 0/"[Alleged: RUN brand]"',
   });
 });
 
 test('0, 0, 1, 0', t => {
-  doTest(t, 0, 0, 1, 0);
+  doTest(t, 0n, 0n, 1n, 0n);
 });
 
 test('1, 0, 0, 0', t => {
-  doTest(t, 1, 0, 0, 0);
+  doTest(t, 1n, 0n, 0n, 0n);
 });
 
 // deltaXPlusX is 0
 test('0, 1, 0, 0', t => {
-  t.throws(() => doTest(t, 0, 1, 0, 0), {
+  t.throws(() => doTest(t, 0n, 1n, 0n, 0n), {
     message: 'No infinite ratios! Denominator was 0/"[Alleged: RUN brand]"',
   });
 });
 
 test('1, 1, 0, 0', t => {
-  doTest(t, 1, 1, 0, 0);
+  doTest(t, 1n, 1n, 0n, 0n);
 });
 
 test('1, 1, 1, 0', t => {
-  doTest(t, 1, 1, 1, 0);
+  doTest(t, 1n, 1n, 1n, 0n);
 });
 
 test('1, 2, 1, 1', t => {
-  doTest(t, 1, 2, 1, 1);
+  doTest(t, 1n, 2n, 1n, 1n);
 });
 
 test('2, 3, 4, 2', t => {
-  doTest(t, 2, 3, 4, 2);
+  doTest(t, 2n, 3n, 4n, 2n);
 });
 
 test('928861206, 130870247, 746353662, 58306244', t => {
@@ -59,17 +59,17 @@ test('928861206, 130870247, 746353662, 58306244', t => {
 });
 
 test('9, 3, 17, 1', t => {
-  doTest(t, 9, 3, 17, 1);
+  doTest(t, 9n, 3n, 17n, 1n);
 });
 
 test('10000, 5000, 209, 102', t => {
-  doTest(t, 10000, 5000, 209, 102);
+  doTest(t, 10000n, 5000n, 209n, 102n);
 });
 
 test('1000000, 5000, 209, 1', t => {
-  doTest(t, 1000000, 5000, 209, 1);
+  doTest(t, 1000000n, 5000n, 209n, 1n);
 });
 
 test('5000, 1000000, 209, 40122', t => {
-  doTest(t, 5000, 1000000, 209, 40122);
+  doTest(t, 5000n, 1000000n, 209n, 40122n);
 });

--- a/packages/zoe/test/unitTests/contracts/constantProduct/test-checkInvariants.js
+++ b/packages/zoe/test/unitTests/contracts/constantProduct/test-checkInvariants.js
@@ -259,7 +259,7 @@ test('getInputPrice negative', t => {
     outputReserve: 117n,
     inputValue: -7n,
   };
-  const message = 'value "[-7n]" must be a Nat or an array';
+  const message = 'value "[-7n]" must be a natural number';
   testGetInputPriceThrows(t, input, message, true);
   testGetInputPriceThrows(t, input, message, false);
 });

--- a/packages/zoe/test/unitTests/contracts/constantProduct/test-compareBondingCurves.js
+++ b/packages/zoe/test/unitTests/contracts/constantProduct/test-compareBondingCurves.js
@@ -163,7 +163,7 @@ test('getInputPrice negative', t => {
     outputReserve: 117n,
     inputValue: -7n,
   };
-  const message = 'value "[-7n]" must be a Nat or an array';
+  const message = 'value "[-7n]" must be a natural number';
   getInputPriceThrows(t, input, message);
 });
 

--- a/packages/zoe/test/unitTests/contracts/constantProduct/test-getXY.js
+++ b/packages/zoe/test/unitTests/contracts/constantProduct/test-getXY.js
@@ -51,7 +51,7 @@ test('swap Central for Secondary no Give', t => {
 test('swap Central for Secondary no want', t => {
   const { run, bld } = setupMintKits();
 
-  const amountGiven = run(3000);
+  const amountGiven = run(3000n);
   const poolAllocation = {
     Central: run(102902920n),
     Secondary: bld(203838393n),
@@ -119,7 +119,7 @@ test('swap Secondary for Central no give', t => {
     Central: run(102902920n),
     Secondary: bld(203838393n),
   };
-  const amountWanted = run(9342193);
+  const amountWanted = run(9342193n);
   const { x, y, deltaX, deltaY } = getXY({
     amountGiven,
     poolAllocation,

--- a/packages/zoe/test/unitTests/contracts/loan/helpers.js
+++ b/packages/zoe/test/unitTests/contracts/loan/helpers.js
@@ -42,7 +42,7 @@ export const checkPayout = async (
 
 /**
  * @param {import("ava").ExecutionContext<unknown>} t
- * @param {ZoeService} zoe
+ * @param {ERef<ZoeService>} zoe
  * @param {ERef<Invitation>} invitation
  * @param {string} expected
  */
@@ -53,7 +53,7 @@ export const checkDescription = async (t, zoe, invitation, expected) => {
 
 /**
  * @param {import("ava").ExecutionContext<unknown>} t
- * @param {ZoeService} zoe
+ * @param {ERef<ZoeService>} zoe
  * @param {ERef<Invitation>} invitation
  * @param {InvitationDetails} expectedNullHandle expected invitation
  * details with the handle set to 'null'

--- a/packages/zoe/test/unitTests/contracts/loan/test-addCollateral.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-addCollateral.js
@@ -23,7 +23,7 @@ test.todo('makeAddCollateralInvitation - test bad proposal');
 test('makeAddCollateralInvitation', async t => {
   const { zcf, zoe, collateralKit, loanKit } = await setupLoanUnitTest();
 
-  const collateral = AmountMath.make(10n, collateralKit.brand);
+  const collateral = AmountMath.make(collateralKit.brand, 10n);
 
   // Set up the collateral seat
   const { zcfSeat: collateralSeat } = await makeSeatKit(
@@ -46,7 +46,7 @@ test('makeAddCollateralInvitation', async t => {
   });
 
   const autoswapInstance = {};
-  const getDebt = () => AmountMath.make(100n, loanKit.brand);
+  const getDebt = () => AmountMath.make(loanKit.brand, 100n);
 
   const config = {
     collateralSeat,
@@ -59,7 +59,7 @@ test('makeAddCollateralInvitation', async t => {
   };
   const addCollateralInvitation = makeAddCollateralInvitation(zcf, config);
 
-  const addedAmount = AmountMath.make(3n, collateralKit.brand);
+  const addedAmount = AmountMath.make(collateralKit.brand, 3n);
 
   await performAddCollateral(
     t,

--- a/packages/zoe/test/unitTests/contracts/loan/test-close.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-close.js
@@ -26,7 +26,7 @@ test.todo(`repay - request too much collateral`);
 test('makeCloseLoanInvitation repay all', async t => {
   const { zcf, zoe, collateralKit, loanKit } = await setupLoanUnitTest();
 
-  const collateral = AmountMath.make(10n, collateralKit.brand);
+  const collateral = AmountMath.make(collateralKit.brand, 10n);
 
   // Set up the collateral seat
   const { zcfSeat: collateralSeat } = await makeSeatKit(
@@ -43,8 +43,8 @@ test('makeCloseLoanInvitation repay all', async t => {
     userSeat: lenderUserSeatP,
   } = zcf.makeEmptySeatKit();
 
-  const borrowedAmount = AmountMath.make(20n, loanKit.brand);
-  const interest = AmountMath.make(3n, loanKit.brand);
+  const borrowedAmount = AmountMath.make(loanKit.brand, 20n);
+  const interest = AmountMath.make(loanKit.brand, 3n);
   const required = AmountMath.add(borrowedAmount, interest);
   const getDebt = () => required;
 
@@ -60,7 +60,7 @@ test('makeCloseLoanInvitation repay all', async t => {
 
   const proposal = harden({
     give: { Loan: required },
-    want: { Collateral: AmountMath.make(10n, collateralKit.brand) },
+    want: { Collateral: AmountMath.make(collateralKit.brand, 10n) },
   });
 
   const payments = harden({
@@ -80,7 +80,7 @@ test('makeCloseLoanInvitation repay all', async t => {
     { Loan: loanKit, Collateral: collateralKit },
     {
       Loan: AmountMath.makeEmpty(loanKit.brand),
-      Collateral: AmountMath.make(10n, collateralKit.brand),
+      Collateral: AmountMath.make(collateralKit.brand, 10n),
     },
     'repaySeat',
   );

--- a/packages/zoe/test/unitTests/contracts/loan/test-lend.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-lend.js
@@ -21,7 +21,7 @@ test('makeLendInvitation', async t => {
 
   await checkDescription(t, zoe, lendInvitation, 'lend');
 
-  const maxLoan = AmountMath.make(1000n, loanKit.brand);
+  const maxLoan = AmountMath.make(loanKit.brand, 1000n);
 
   const proposal = harden({
     give: { Loan: maxLoan },

--- a/packages/zoe/test/unitTests/contracts/loan/test-liquidate.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-liquidate.js
@@ -23,7 +23,7 @@ test('test doLiquidation with mocked autoswap', async t => {
     harden({}),
   );
 
-  const collateral = AmountMath.make(10n, collateralKit.brand);
+  const collateral = AmountMath.make(collateralKit.brand, 10n);
   const {
     zcfSeat: collateralSeat,
     userSeat: collateralUserSeat,
@@ -33,7 +33,7 @@ test('test doLiquidation with mocked autoswap', async t => {
     { Collateral: collateralKit.mint.mintPayment(collateral) },
   );
 
-  const loan1000 = AmountMath.make(1000n, loanKit.brand);
+  const loan1000 = AmountMath.make(loanKit.brand, 1000n);
 
   // Setup fake autoswap
   const { zcfSeat: fakePoolSeat } = await makeSeatKit(
@@ -42,7 +42,7 @@ test('test doLiquidation with mocked autoswap', async t => {
     { Central: loanKit.mint.mintPayment(loan1000) },
   );
 
-  const price = AmountMath.make(20n, loanKit.brand);
+  const price = AmountMath.make(loanKit.brand, 20n);
 
   const swapHandler = swapSeat => {
     // swapSeat gains 20 loan tokens from fakePoolSeat, loses all collateral
@@ -108,7 +108,7 @@ test('test with malfunctioning autoswap', async t => {
     harden({}),
   );
 
-  const collateral = AmountMath.make(10n, collateralKit.brand);
+  const collateral = AmountMath.make(collateralKit.brand, 10n);
   const {
     zcfSeat: collateralSeat,
     userSeat: collateralUserSeat,

--- a/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
@@ -77,7 +77,7 @@ test('loan - lend - exit before borrow', async t => {
     zoe,
   ).startInstance(installation, issuerKeywordRecord, terms);
 
-  const maxLoan = AmountMath.make(1000n, loanKit.brand);
+  const maxLoan = AmountMath.make(loanKit.brand, 1000n);
 
   // Alice is willing to lend Loan tokens
   const proposal = harden({

--- a/packages/zoe/test/unitTests/contracts/loan/test-updateDebt.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-updateDebt.js
@@ -11,7 +11,7 @@ test('test calculateInterest', async t => {
   const { brands } = setup();
   const brand = brands.get('moola');
   const testCalculateInterest = ([oldDebt, interestRate, expected]) => {
-    const debt = { brand, value: oldDebt };
+    const debt = harden({ brand, value: oldDebt });
     const interestRateRatio = makeRatio(interestRate, brand, 10000n);
     const interest = calculateInterest(debt, interestRateRatio);
     t.is(

--- a/packages/zoe/test/unitTests/contracts/multipoolAutoswap/test-feeCharged.js
+++ b/packages/zoe/test/unitTests/contracts/multipoolAutoswap/test-feeCharged.js
@@ -58,15 +58,15 @@ test('multipoolAutoSwap with valid offers', async t => {
 
   // Set up central token
   const centralR = makeIssuerKit('central');
-  const centralTokens = value => AmountMath.make(value, centralR.brand);
+  const centralTokens = value => AmountMath.make(centralR.brand, value);
 
   // Setup Alice
-  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(100));
+  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(100n));
   // Let's assume that central tokens are worth 2x as much as moola
-  const aliceCentralPayment = centralR.mint.mintPayment(centralTokens(50));
+  const aliceCentralPayment = centralR.mint.mintPayment(centralTokens(50n));
 
   // Setup Bob
-  const bobMoolaPayment = moolaR.mint.mintPayment(moola(17));
+  const bobMoolaPayment = moolaR.mint.mintPayment(moola(17n));
 
   // Alice creates an autoswap instance
 
@@ -90,14 +90,14 @@ test('multipoolAutoSwap with valid offers', async t => {
     'Moola',
   );
   const moolaLiquidityBrand = await E(moolaLiquidityIssuer).getBrand();
-  const moolaLiquidity = value => AmountMath.make(value, moolaLiquidityBrand);
+  const moolaLiquidity = value => AmountMath.make(moolaLiquidityBrand, value);
 
   // Alice adds liquidity
   // 10 moola = 5 central tokens at the time of the liquidity adding
   // aka 2 moola = 1 central token
   const aliceProposal = harden({
-    want: { Liquidity: moolaLiquidity(50) },
-    give: { Secondary: moola(100), Central: centralTokens(50) },
+    want: { Liquidity: moolaLiquidity(50n) },
+    give: { Secondary: moola(100n), Central: centralTokens(50n) },
   });
   const alicePayments = {
     Secondary: aliceMoolaPayment,
@@ -130,8 +130,8 @@ test('multipoolAutoSwap with valid offers', async t => {
   t.deepEqual(bobInvitationValue.zoeTimeAuthority, fakeTimer);
 
   const bobMoolaForCentralProposal = harden({
-    want: { Out: centralTokens(7) },
-    give: { In: moola(17) },
+    want: { Out: centralTokens(7n) },
+    give: { In: moola(17n) },
   });
   const bobMoolaForCentralPayments = harden({ In: bobMoolaPayment });
 

--- a/packages/zoe/test/unitTests/contracts/multipoolAutoswap/test-multipoolPriceAuthority.js
+++ b/packages/zoe/test/unitTests/contracts/multipoolAutoswap/test-multipoolPriceAuthority.js
@@ -23,8 +23,8 @@ test('multipoolAutoSwap PriceAuthority exception path', async t => {
   }
 
   const priceAuthority = makePriceAuthority(
-    () => ersatzQuote(3, 25),
-    () => ersatzQuote(18, 5),
+    () => ersatzQuote(3n, 25n),
+    () => ersatzQuote(18n, 5n),
     moolaR.brand,
     simoleanR.brand,
     timer,
@@ -34,8 +34,8 @@ test('multipoolAutoSwap PriceAuthority exception path', async t => {
   );
 
   const triggerDoesNot = priceAuthority.quoteWhenLT(
-    AmountMath.make(moolaR.brand, 10),
-    AmountMath.make(simoleanR.brand, 20),
+    AmountMath.make(moolaR.brand, 10n),
+    AmountMath.make(simoleanR.brand, 20n),
   );
 
   triggerDoesNot.then(
@@ -44,8 +44,8 @@ test('multipoolAutoSwap PriceAuthority exception path', async t => {
   );
 
   const trigger = priceAuthority.quoteWhenLT(
-    AmountMath.make(moolaR.brand, 10),
-    AmountMath.make(simoleanR.brand, 30),
+    AmountMath.make(moolaR.brand, 10n),
+    AmountMath.make(simoleanR.brand, 30n),
   );
 
   trigger.then(

--- a/packages/zoe/test/unitTests/contracts/newSwap/test-newSwap-swap.js
+++ b/packages/zoe/test/unitTests/contracts/newSwap/test-newSwap-swap.js
@@ -45,16 +45,16 @@ test('newSwap with valid offers', async t => {
 
   // Set up central token
   const centralR = makeIssuerKit('central');
-  const centralTokens = value => AmountMath.make(value, centralR.brand);
+  const centralTokens = value => AmountMath.make(centralR.brand, value);
 
   // Setup Alice
-  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(100000));
+  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(100000n));
   // Let's assume that central tokens are worth 2x as much as moola
-  const aliceCentralPayment = centralR.mint.mintPayment(centralTokens(50000));
-  const aliceSimoleanPayment = simoleanR.mint.mintPayment(simoleans(398));
+  const aliceCentralPayment = centralR.mint.mintPayment(centralTokens(50000n));
+  const aliceSimoleanPayment = simoleanR.mint.mintPayment(simoleans(398n));
 
   // Setup Bob
-  const bobMoolaPayment = moolaR.mint.mintPayment(moola(17000));
+  const bobMoolaPayment = moolaR.mint.mintPayment(moola(17000n));
 
   // Alice creates an autoswap instance
 
@@ -79,7 +79,8 @@ test('newSwap with valid offers', async t => {
   t.deepEqual(
     aliceInvitationAmount,
     AmountMath.make(
-      [
+      invitationBrand,
+      harden([
         {
           description: 'multipool autoswap add liquidity',
           instance,
@@ -89,8 +90,7 @@ test('newSwap with valid offers', async t => {
           expiry: undefined,
           zoeTimeAuthority: undefined,
         },
-      ],
-      invitationBrand,
+      ]),
     ),
     `invitation value is as expected`,
   );
@@ -100,7 +100,7 @@ test('newSwap with valid offers', async t => {
     'Moola',
   );
   const moolaLiquidityBrand = await E(moolaLiquidityIssuer).getBrand();
-  const moolaLiquidity = value => AmountMath.make(value, moolaLiquidityBrand);
+  const moolaLiquidity = value => AmountMath.make(moolaLiquidityBrand, value);
 
   const simoleanLiquidityIssuer = await E(publicFacet).addPool(
     simoleanR.issuer,
@@ -109,7 +109,7 @@ test('newSwap with valid offers', async t => {
 
   const simoleanLiquidityBrand = await E(simoleanLiquidityIssuer).getBrand();
   const simoleanLiquidity = value =>
-    AmountMath.make(value, simoleanLiquidityBrand);
+    AmountMath.make(simoleanLiquidityBrand, value);
 
   const { toCentral: priceAuthority } = await E(
     publicFacet,
@@ -142,8 +142,8 @@ test('newSwap with valid offers', async t => {
   // 10 moola = 5 central tokens at the time of the liquidity adding
   // aka 2 moola = 1 central token
   const aliceProposal = harden({
-    want: { Liquidity: moolaLiquidity(50000) },
-    give: { Secondary: moola(100000), Central: centralTokens(50000) },
+    want: { Liquidity: moolaLiquidity(50000n) },
+    give: { Secondary: moola(100000n), Central: centralTokens(50000n) },
   });
   const alicePayments = {
     Secondary: aliceMoolaPayment,
@@ -166,14 +166,14 @@ test('newSwap with valid offers', async t => {
 
   t.deepEqual(
     await moolaLiquidityIssuer.getAmountOf(liquidityPayout),
-    moolaLiquidity(50000),
+    moolaLiquidity(50000n),
   );
   t.deepEqual(
     await E(publicFacet).getPoolAllocation(moolaR.brand),
     harden({
-      Secondary: moola(100000),
-      Central: centralTokens(50000),
-      Liquidity: moolaLiquidity(0),
+      Secondary: moola(100000n),
+      Central: centralTokens(50000n),
+      Liquidity: moolaLiquidity(0n),
     }),
     `The poolAmounts record should contain the new liquidity`,
   );
@@ -197,13 +197,13 @@ test('newSwap with valid offers', async t => {
   // Bob looks up the price of 17000 moola in central tokens
   const { amountOut: priceInCentrals } = await E(
     bobPublicFacet,
-  ).getPriceGivenAvailableInput(moola(17000), centralR.brand);
+  ).getPriceGivenAvailableInput(moola(17000n), centralR.brand);
 
   t.deepEqual(await E(publicFacet).getProtocolPoolBalance(), {});
 
   const bobMoolaForCentralProposal = harden({
     want: { Out: priceInCentrals },
-    give: { In: moola(17000) },
+    give: { In: moola(17000n) },
   });
   const bobMoolaForCentralPayments = harden({ In: bobMoolaPayment });
 
@@ -214,7 +214,7 @@ test('newSwap with valid offers', async t => {
     bobMoolaForCentralPayments,
   );
 
-  const protocolFeeRatio = makeRatio(6n, centralR.brand, 10000);
+  const protocolFeeRatio = makeRatio(6n, centralR.brand, 10000n);
   /** @type {Amount} */
   let runningFees = multiplyBy(priceInCentrals, protocolFeeRatio);
   t.deepEqual(await E(publicFacet).getProtocolPoolBalance(), {
@@ -222,7 +222,7 @@ test('newSwap with valid offers', async t => {
   });
 
   const quoteGivenBob = await E(priceAuthority).quoteGiven(
-    moola(5000),
+    moola(5000n),
     centralR.brand,
   );
   assertAmountsEqual(
@@ -246,15 +246,15 @@ test('newSwap with valid offers', async t => {
   assertAmountsEqual(
     t,
     await centralR.issuer.getAmountOf(bobCentralPayout1),
-    centralTokens(7246),
+    centralTokens(7246n),
     `bob gets the same price as when he called the getInputPrice method`,
   );
   t.deepEqual(
     await E(bobPublicFacet).getPoolAllocation(moolaR.brand),
     {
-      Secondary: moola(117000),
-      Central: centralTokens(42750),
-      Liquidity: moolaLiquidity(0),
+      Secondary: moola(117000n),
+      Central: centralTokens(42750n),
+      Liquidity: moolaLiquidity(0n),
     },
     `pool allocation added the moola and subtracted the central tokens`,
   );
@@ -264,23 +264,23 @@ test('newSwap with valid offers', async t => {
 
   // Bob looks up the price of 700 central tokens in moola
   const moolaAmounts = await E(bobPublicFacet).getInputPrice(
-    centralTokens(700),
+    centralTokens(700n),
     moolaR.brand,
   );
   t.deepEqual(
     moolaAmounts,
-    moola(1880),
+    moola(1880n),
     `the fee was one moola over the two trades`,
   );
 
   // Bob makes another offer and swaps
   const bobSwapInvitation2 = await E(bobPublicFacet).makeSwapInInvitation();
   const bobCentralForMoolaProposal = harden({
-    want: { Out: moola(1880) },
-    give: { In: centralTokens(700) },
+    want: { Out: moola(1880n) },
+    give: { In: centralTokens(700n) },
   });
   const centralForMoolaPayments = harden({
-    In: await E(bobCentralPurse).withdraw(centralTokens(700)),
+    In: await E(bobCentralPurse).withdraw(centralTokens(700n)),
   });
 
   const bobSeat2 = await E(zoe).offer(
@@ -291,7 +291,7 @@ test('newSwap with valid offers', async t => {
 
   runningFees = AmountMath.add(
     runningFees,
-    multiplyBy(centralTokens(700), protocolFeeRatio),
+    multiplyBy(centralTokens(700n), protocolFeeRatio),
   );
   t.deepEqual(await E(publicFacet).getProtocolPoolBalance(), {
     RUN: runningFees,
@@ -304,7 +304,7 @@ test('newSwap with valid offers', async t => {
   );
 
   const quoteBob2 = await E(priceAuthority).quoteGiven(
-    moola(5000),
+    moola(5000n),
     centralR.brand,
   );
   assertAmountsEqual(
@@ -318,20 +318,20 @@ test('newSwap with valid offers', async t => {
 
   t.deepEqual(
     await moolaR.issuer.getAmountOf(bobMoolaPayout2),
-    moola(1880),
+    moola(1880n),
     `bob gets 1880 moola back`,
   );
   t.deepEqual(
     await centralR.issuer.getAmountOf(bobCentralPayout2),
-    centralTokens(0),
+    centralTokens(0n),
     `bob gets no central tokens back`,
   );
   t.deepEqual(
     await E(bobPublicFacet).getPoolAllocation(moolaR.brand),
     {
-      Secondary: moola(115120),
-      Central: centralTokens(43450),
-      Liquidity: moolaLiquidity(0),
+      Secondary: moola(115120n),
+      Central: centralTokens(43450n),
+      Liquidity: moolaLiquidity(0n),
     },
     `fee added to liquidity pool`,
   );
@@ -344,11 +344,11 @@ test('newSwap with valid offers', async t => {
     publicFacet,
   ).makeAddLiquidityInvitation();
   const aliceSimCentralProposal = harden({
-    want: { Liquidity: simoleanLiquidity(43) },
-    give: { Secondary: simoleans(398), Central: centralTokens(43) },
+    want: { Liquidity: simoleanLiquidity(43n) },
+    give: { Secondary: simoleans(398n), Central: centralTokens(43n) },
   });
   const aliceCentralPayment2 = await centralR.mint.mintPayment(
-    centralTokens(43),
+    centralTokens(43n),
   );
   const aliceSimCentralPayments = {
     Secondary: aliceSimoleanPayment,
@@ -362,7 +362,7 @@ test('newSwap with valid offers', async t => {
   );
 
   const quoteLiquidation2 = await E(priceAuthority).quoteGiven(
-    moola(5000),
+    moola(5000n),
     centralR.brand,
   );
   // a simolean trade had no effect on moola prices
@@ -381,15 +381,15 @@ test('newSwap with valid offers', async t => {
 
   t.deepEqual(
     await simoleanLiquidityIssuer.getAmountOf(simoleanLiquidityPayout),
-    simoleanLiquidity(43),
+    simoleanLiquidity(43n),
     `simoleanLiquidity minted was equal to the amount of central tokens added to pool`,
   );
   t.deepEqual(
     await E(publicFacet).getPoolAllocation(simoleanR.brand),
     harden({
-      Secondary: simoleans(398),
-      Central: centralTokens(43),
-      Liquidity: simoleanLiquidity(0),
+      Secondary: simoleans(398n),
+      Central: centralTokens(43n),
+      Liquidity: simoleanLiquidity(0n),
     }),
     `The poolAmounts record should contain the new liquidity`,
   );
@@ -403,17 +403,17 @@ test('newSwap doubleSwap', async t => {
 
   // Set up central token
   const centralR = makeIssuerKit('central');
-  const centralTokens = value => AmountMath.make(value, centralR.brand);
+  const centralTokens = value => AmountMath.make(centralR.brand, value);
 
   // Setup Alice
-  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(100000));
+  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(100000n));
   // Let's assume that central tokens are worth 2x as much as moola
-  const aliceCentralPayment = centralR.mint.mintPayment(centralTokens(50000));
-  const aliceSimoleanPayment = simoleanR.mint.mintPayment(simoleans(39800));
+  const aliceCentralPayment = centralR.mint.mintPayment(centralTokens(50000n));
+  const aliceSimoleanPayment = simoleanR.mint.mintPayment(simoleans(39800n));
 
   // Setup Bob
-  const bobSimoleanPayment = simoleanR.mint.mintPayment(simoleans(4000));
-  const bobMoolaPayment = moolaR.mint.mintPayment(moola(5000));
+  const bobSimoleanPayment = simoleanR.mint.mintPayment(simoleans(4000n));
+  const bobMoolaPayment = moolaR.mint.mintPayment(moola(5000n));
 
   // Alice creates an autoswap instance
   const bundle = await bundleSource(newSwapRoot);
@@ -439,7 +439,7 @@ test('newSwap doubleSwap', async t => {
     'Moola',
   );
   const moolaLiquidityBrand = await E(moolaLiquidityIssuer).getBrand();
-  const moolaLiquidity = value => AmountMath.make(value, moolaLiquidityBrand);
+  const moolaLiquidity = value => AmountMath.make(moolaLiquidityBrand, value);
 
   const simoleanLiquidityIssuer = await E(publicFacet).addPool(
     simoleanR.issuer,
@@ -448,7 +448,7 @@ test('newSwap doubleSwap', async t => {
 
   const simoleanLiquidityBrand = await E(simoleanLiquidityIssuer).getBrand();
   const simoleanLiquidity = value =>
-    AmountMath.make(value, simoleanLiquidityBrand);
+    AmountMath.make(simoleanLiquidityBrand, value);
 
   const issuerKeywordRecord = await E(zoe).getIssuers(instance);
   t.deepEqual(
@@ -477,8 +477,8 @@ test('newSwap doubleSwap', async t => {
   // 10 moola = 5 central tokens at the time of the liquidity adding
   // aka 2 moola = 1 central token
   const aliceProposal = harden({
-    want: { Liquidity: moolaLiquidity(50000) },
-    give: { Secondary: moola(100000), Central: centralTokens(50000) },
+    want: { Liquidity: moolaLiquidity(50000n) },
+    give: { Secondary: moola(100000n), Central: centralTokens(50000n) },
   });
   const alicePayments = {
     Secondary: aliceMoolaPayment,
@@ -506,11 +506,11 @@ test('newSwap doubleSwap', async t => {
     publicFacet,
   ).makeAddLiquidityInvitation();
   const aliceSimCentralProposal = harden({
-    want: { Liquidity: simoleanLiquidity(430) },
-    give: { Secondary: simoleans(39800), Central: centralTokens(43000) },
+    want: { Liquidity: simoleanLiquidity(430n) },
+    give: { Secondary: simoleans(39800n), Central: centralTokens(43000n) },
   });
   const aliceCentralPayment2 = await centralR.mint.mintPayment(
-    centralTokens(43000),
+    centralTokens(43000n),
   );
   const aliceSimCentralPayments = {
     Secondary: aliceSimoleanPayment,
@@ -534,12 +534,12 @@ test('newSwap doubleSwap', async t => {
   // Bob looks up the value of 4000 simoleans in moola
   const { amountOut: priceInMoola } = await E(
     publicFacet,
-  ).getPriceGivenAvailableInput(simoleans(4000), moolaR.brand);
+  ).getPriceGivenAvailableInput(simoleans(4000n), moolaR.brand);
 
   const bobInvitation = await E(publicFacet).makeSwapInInvitation();
   const bobSimsForMoolaProposal = harden({
     want: { Out: priceInMoola },
-    give: { In: simoleans(4000) },
+    give: { In: simoleans(4000n) },
   });
   const simsForMoolaPayments = harden({
     In: bobSimoleanPayment,
@@ -556,7 +556,7 @@ test('newSwap doubleSwap', async t => {
 
   t.deepEqual(
     await moolaR.issuer.getAmountOf(bobMoolaPayout),
-    moola(7261),
+    moola(7261n),
     `bob gets 7261 moola`,
   );
 
@@ -570,12 +570,12 @@ test('newSwap doubleSwap', async t => {
   // Bob looks up the value of 5000 moola in simoleans
   const { amountOut: priceInSimoleans } = await E(
     publicFacet,
-  ).getPriceGivenAvailableInput(moola(5000), simoleanR.brand);
+  ).getPriceGivenAvailableInput(moola(5000n), simoleanR.brand);
 
   const bobInvitation2 = await E(publicFacet).makeSwapInInvitation();
   const bobMoolaForSimsProposal = harden({
     want: { Out: priceInSimoleans },
-    give: { In: moola(5000) },
+    give: { In: moola(5000n) },
   });
   const moolaForSimsPayments = harden({
     In: bobMoolaPayment,
@@ -590,7 +590,7 @@ test('newSwap doubleSwap', async t => {
 
   t.deepEqual(
     await simoleanR.issuer.getAmountOf(bobSimoleanPayout),
-    simoleans(2880),
+    simoleans(2880n),
     `bob gets 2880 simoleans`,
   );
 
@@ -627,10 +627,10 @@ test('newSwap with some invalid offers', async t => {
 
   // Set up central token
   const centralR = makeIssuerKit('central');
-  const centralTokens = value => AmountMath.make(value, centralR.brand);
+  const centralTokens = value => AmountMath.make(centralR.brand, value);
 
   // Setup Bob
-  const bobMoolaPayment = moolaR.mint.mintPayment(moola(17));
+  const bobMoolaPayment = moolaR.mint.mintPayment(moola(17n));
 
   // Alice creates an autoswap instance
 
@@ -656,15 +656,15 @@ test('newSwap with some invalid offers', async t => {
 
   // Bob tries to look up prices, but the pool isn't initiailzed
   await t.throwsAsync(
-    () => E(bobPublicFacet).getInputPrice(moola(5), centralR.brand),
+    () => E(bobPublicFacet).getInputPrice(moola(5n), centralR.brand),
     { message: 'pool not initialized' },
     'pool not initialized',
   );
 
   // Bob tries to trade anyway.
   const bobMoolaForCentralProposal = harden({
-    want: { Out: centralTokens(7) },
-    give: { In: moola(17) },
+    want: { Out: centralTokens(7n) },
+    give: { In: moola(17n) },
   });
   const bobMoolaForCentralPayments = harden({ In: bobMoolaPayment });
 
@@ -695,16 +695,16 @@ test('newSwap jig - swapOut uneven', async t => {
 
   // Set up central token
   const centralR = makeIssuerKit('central');
-  const centralTokens = value => AmountMath.make(value, centralR.brand);
+  const centralTokens = value => AmountMath.make(centralR.brand, value);
 
   // set up purses
-  const centralPayment = centralR.mint.mintPayment(centralTokens(30000000));
+  const centralPayment = centralR.mint.mintPayment(centralTokens(30000000n));
   const centralPurse = centralR.issuer.makeEmptyPurse();
   await centralPurse.deposit(centralPayment);
   const moolaPurse = moolaR.issuer.makeEmptyPurse();
-  moolaPurse.deposit(moolaR.mint.mintPayment(moola(20000000)));
+  moolaPurse.deposit(moolaR.mint.mintPayment(moola(20000000n)));
   const simoleanPurse = simoleanR.issuer.makeEmptyPurse();
-  simoleanPurse.deposit(simoleanR.mint.mintPayment(simoleans(20000000)));
+  simoleanPurse.deposit(simoleanR.mint.mintPayment(simoleans(20000000n)));
 
   const fakeTimer = buildManualTimer(console.log);
   const startRecord = await E(zoe).startInstance(
@@ -722,7 +722,7 @@ test('newSwap jig - swapOut uneven', async t => {
     'Moola',
   );
   const moolaLiquidityBrand = await E(moolaLiquidityIssuer).getBrand();
-  const moolaLiquidity = value => AmountMath.make(value, moolaLiquidityBrand);
+  const moolaLiquidity = value => AmountMath.make(moolaLiquidityBrand, value);
 
   const simoleanLiquidityIssuer = await E(publicFacet).addPool(
     simoleanR.issuer,
@@ -731,7 +731,7 @@ test('newSwap jig - swapOut uneven', async t => {
 
   const simoleanLiquidityBrand = await E(simoleanLiquidityIssuer).getBrand();
   const simoleanLiquidity = value =>
-    AmountMath.make(value, simoleanLiquidityBrand);
+    AmountMath.make(simoleanLiquidityBrand, value);
   const mIssuerKeywordRecord = {
     Secondary: moolaR.issuer,
     Liquidity: moolaLiquidityIssuer,
@@ -754,12 +754,12 @@ test('newSwap jig - swapOut uneven', async t => {
 
   // this test uses twice as much Central as Moola to make the price difference
   // more visible.
-  const initMoolaLiquidityDetails = {
-    cAmount: centralTokens(10000000),
-    sAmount: moola(5000000),
-    lAmount: moolaLiquidity(10000000),
+  const initmoolaLiquidityDetails = {
+    cAmount: centralTokens(10000000n),
+    sAmount: moola(5000000n),
+    lAmount: moolaLiquidity(10000000n),
   };
-  const initMoolaLiquidityExpected = {
+  const initmoolaLiquidityExpected = {
     c: 10000000n,
     s: 5000000n,
     l: 10000000n,
@@ -771,11 +771,11 @@ test('newSwap jig - swapOut uneven', async t => {
   await alice.initLiquidityAndCheck(
     t,
     mPoolState,
-    initMoolaLiquidityDetails,
-    initMoolaLiquidityExpected,
+    initmoolaLiquidityDetails,
+    initmoolaLiquidityExpected,
     mIssuerKeywordRecord,
   );
-  mPoolState = updatePoolState(mPoolState, initMoolaLiquidityExpected);
+  mPoolState = updatePoolState(mPoolState, initmoolaLiquidityExpected);
 
   let sPoolState = {
     c: 0n,
@@ -783,10 +783,10 @@ test('newSwap jig - swapOut uneven', async t => {
     l: 0n,
     k: 0n,
   };
-  const initSimoleanLiquidityDetails = {
-    cAmount: centralTokens(10000000),
-    sAmount: simoleans(10000000),
-    lAmount: simoleanLiquidity(10000000),
+  const initsimoleanLiquidityDetails = {
+    cAmount: centralTokens(10000000n),
+    sAmount: simoleans(10000000n),
+    lAmount: simoleanLiquidity(10000000n),
   };
   const initSimLiqExpected = {
     c: 10000000n,
@@ -805,7 +805,7 @@ test('newSwap jig - swapOut uneven', async t => {
   await alice.initLiquidityAndCheck(
     t,
     sPoolState,
-    initSimoleanLiquidityDetails,
+    initsimoleanLiquidityDetails,
     initSimLiqExpected,
     sIssuerKeywordRecord,
   );
@@ -934,7 +934,7 @@ test('newSwap jig - breaking scenario', async t => {
 
   // Set up central token
   const centralR = makeIssuerKit('central');
-  const centralTokens = value => AmountMath.make(value, centralR.brand);
+  const centralTokens = value => AmountMath.make(centralR.brand, value);
 
   // set up purses
   const centralPayment = centralR.mint.mintPayment(
@@ -960,7 +960,7 @@ test('newSwap jig - breaking scenario', async t => {
     'Moola',
   );
   const moolaLiquidityBrand = await E(moolaLiquidityIssuer).getBrand();
-  const moolaLiquidity = value => AmountMath.make(value, moolaLiquidityBrand);
+  const moolaLiquidity = value => AmountMath.make(moolaLiquidityBrand, value);
 
   const simoleanLiquidityIssuer = await E(publicFacet).addPool(
     simoleanR.issuer,
@@ -986,12 +986,12 @@ test('newSwap jig - breaking scenario', async t => {
     k: 0n,
   };
 
-  const initMoolaLiquidityDetails = {
+  const initmoolaLiquidityDetails = {
     cAmount: centralTokens(50825056949339n),
     sAmount: moola(2196247730468n),
     lAmount: moolaLiquidity(50825056949339n),
   };
-  const initMoolaLiquidityExpected = {
+  const initmoolaLiquidityExpected = {
     c: 50825056949339n,
     s: 2196247730468n,
     l: 50825056949339n,
@@ -1003,11 +1003,11 @@ test('newSwap jig - breaking scenario', async t => {
   await alice.initLiquidityAndCheck(
     t,
     mPoolState,
-    initMoolaLiquidityDetails,
-    initMoolaLiquidityExpected,
+    initmoolaLiquidityDetails,
+    initmoolaLiquidityExpected,
     mIssuerKeywordRecord,
   );
-  mPoolState = updatePoolState(mPoolState, initMoolaLiquidityExpected);
+  mPoolState = updatePoolState(mPoolState, initmoolaLiquidityExpected);
 
   t.deepEqual(await E(publicFacet).getProtocolPoolBalance(), {});
 

--- a/packages/zoe/test/unitTests/contracts/newSwap/test-newSwapPrice.js
+++ b/packages/zoe/test/unitTests/contracts/newSwap/test-newSwapPrice.js
@@ -44,8 +44,8 @@ function makeFakePool(initCentral, initSecondary) {
         feeBP,
       );
       return {
-        amountOut: AmountMath.make(valueOut, outputBrand),
-        amountIn: AmountMath.make(valueIn, inputAmount.brand),
+        amountOut: AmountMath.make(outputBrand, valueOut),
+        amountIn: AmountMath.make(inputAmount.brand, valueIn),
       };
     },
 
@@ -67,8 +67,8 @@ function makeFakePool(initCentral, initSecondary) {
         feeBP,
       );
       return {
-        amountOut: AmountMath.make(valueOut, outputAmount.brand),
-        amountIn: AmountMath.make(valueIn, inputBrand),
+        amountOut: AmountMath.make(outputAmount.brand, valueOut),
+        amountIn: AmountMath.make(inputBrand, valueIn),
       };
     },
   };

--- a/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
+++ b/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
@@ -42,8 +42,8 @@ test('zoe - atomicSwap', async t => {
       },
       offer: async firstInvitation => {
         const proposal = harden({
-          give: { Asset: moola(3) },
-          want: { Price: simoleans(7) },
+          give: { Asset: moola(3n) },
+          want: { Price: simoleans(7n) },
           exit: { onDemand: null },
         });
         const payments = { Asset: moolaPayment };
@@ -73,7 +73,7 @@ test('zoe - atomicSwap', async t => {
           .then(amountDeposited =>
             t.deepEqual(
               amountDeposited,
-              simoleans(7),
+              simoleans(7n),
               `Alice got exactly what she wanted`,
             ),
           );
@@ -100,18 +100,18 @@ test('zoe - atomicSwap', async t => {
         );
         t.deepEqual(
           invitationValue.asset,
-          moola(3),
+          moola(3n),
           `asset to be traded is 3 moola`,
         );
         t.deepEqual(
           invitationValue.price,
-          simoleans(7),
+          simoleans(7n),
           `price is 7 simoleans, so bob must give that`,
         );
 
         const proposal = harden({
-          give: { Price: simoleans(7) },
-          want: { Asset: moola(3) },
+          give: { Price: simoleans(7n) },
+          want: { Asset: moola(3n) },
           exit: { onDemand: null },
         });
         const payments = { Price: simoleanPayment };
@@ -140,7 +140,7 @@ test('zoe - atomicSwap', async t => {
           .then(amountDeposited =>
             t.deepEqual(
               amountDeposited,
-              simoleans(0),
+              simoleans(0n),
               `Bob didn't get anything back`,
             ),
           );
@@ -150,13 +150,13 @@ test('zoe - atomicSwap', async t => {
     });
   };
 
-  const alice = await makeAlice(await E(moolaKit.mint).mintPayment(moola(3)));
+  const alice = await makeAlice(await E(moolaKit.mint).mintPayment(moola(3n)));
   // Alice makes an instance and makes her offer.
   const installation = await alice.installCode();
 
   const bob = await makeBob(
     installation,
-    await E(simoleanKit.mint).mintPayment(simoleans(7)),
+    await E(simoleanKit.mint).mintPayment(simoleans(7n)),
   );
 
   const { creatorInvitation } = await alice.startInstance(installation);
@@ -348,11 +348,11 @@ test('zoe - atomicSwap like-for-like', async t => {
   const installation = await E(zoe).install(bundle);
 
   // Setup Alice
-  const aliceMoolaPayment = moolaMint.mintPayment(moola(3));
+  const aliceMoolaPayment = moolaMint.mintPayment(moola(3n));
   const aliceMoolaPurse = moolaIssuer.makeEmptyPurse();
 
   // Setup Bob
-  const bobMoolaPayment = moolaMint.mintPayment(moola(7));
+  const bobMoolaPayment = moolaMint.mintPayment(moola(7n));
   const bobMoolaPurse = moolaIssuer.makeEmptyPurse();
 
   // 1: Alice creates an atomicSwap instance
@@ -367,8 +367,8 @@ test('zoe - atomicSwap like-for-like', async t => {
 
   // 2: Alice escrows with zoe
   const aliceProposal = harden({
-    give: { Asset: moola(3) },
-    want: { Price: moola(7) },
+    give: { Asset: moola(3n) },
+    want: { Price: moola(7n) },
     exit: { onDemand: null },
   });
   const alicePayments = { Asset: aliceMoolaPayment };
@@ -396,12 +396,12 @@ test('zoe - atomicSwap like-for-like', async t => {
 
   t.is(bobInvitationValue.installation, installation, 'bobInstallationId');
   t.deepEqual(bobIssuers, { Asset: moolaIssuer, Price: moolaIssuer });
-  t.deepEqual(bobInvitationValue.asset, moola(3));
-  t.deepEqual(bobInvitationValue.price, moola(7));
+  t.deepEqual(bobInvitationValue.asset, moola(3n));
+  t.deepEqual(bobInvitationValue.price, moola(7n));
 
   const bobProposal = harden({
-    give: { Price: moola(7) },
-    want: { Asset: moola(3) },
+    give: { Price: moola(7n) },
+    want: { Asset: moola(3n) },
     exit: { onDemand: null },
   });
   const bobPayments = { Price: bobMoolaPayment };

--- a/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
+++ b/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
@@ -23,7 +23,7 @@ test('zoe - simplest automaticRefund', async t => {
   const installation = await E(zoe).install(bundle);
 
   // Setup Alice
-  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(3));
+  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(3n));
 
   // 1: Alice creates an automatic refund instance
   const issuerKeywordRecord = harden({ Contribution: moolaR.issuer });
@@ -33,7 +33,7 @@ test('zoe - simplest automaticRefund', async t => {
   );
 
   const aliceProposal = harden({
-    give: { Contribution: moola(3) },
+    give: { Contribution: moola(3n) },
     exit: { onDemand: null },
   });
   const alicePayments = { Contribution: aliceMoolaPayment };
@@ -62,7 +62,7 @@ test('zoe - automaticRefund same issuer', async t => {
   const installation = await E(zoe).install(bundle);
 
   // Setup Alice
-  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(9));
+  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(9n));
 
   // 1: Alice creates an automatic refund instance
   const issuerKeywordRecord = harden({
@@ -75,7 +75,7 @@ test('zoe - automaticRefund same issuer', async t => {
   );
 
   const aliceProposal = harden({
-    give: { Contribution2: moola(9) },
+    give: { Contribution2: moola(9n) },
     exit: { onDemand: null },
   });
   const alicePayments = harden({ Contribution2: aliceMoolaPayment });
@@ -102,14 +102,14 @@ test('zoe with automaticRefund', async t => {
   const invitationIssuer = await E(zoe).getInvitationIssuer();
 
   // Setup Alice
-  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(3));
+  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(3n));
   const aliceMoolaPurse = moolaR.issuer.makeEmptyPurse();
   const aliceSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
 
   // Setup Bob
   const bobMoolaPurse = moolaR.issuer.makeEmptyPurse();
   const bobSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
-  const bobSimoleanPayment = simoleanR.mint.mintPayment(simoleans(17));
+  const bobSimoleanPayment = simoleanR.mint.mintPayment(simoleans(17n));
 
   // Pack the contract.
   const bundle = await bundleSource(automaticRefundRoot);
@@ -126,8 +126,8 @@ test('zoe with automaticRefund', async t => {
 
   // 2: Alice escrows with zoe
   const aliceProposal = harden({
-    give: { Contribution1: moola(3) },
-    want: { Contribution2: simoleans(7) },
+    give: { Contribution1: moola(3n) },
+    want: { Contribution2: simoleans(7n) },
     exit: { onDemand: null },
   });
   const alicePayments = { Contribution1: aliceMoolaPayment };
@@ -169,8 +169,8 @@ test('zoe with automaticRefund', async t => {
   // 6: Bob also wants to get an automaticRefund (why? we don't
   // know) so he escrows his offer payments and makes a proposal.
   const bobProposal = harden({
-    give: { Contribution2: simoleans(17) },
-    want: { Contribution1: moola(15) },
+    give: { Contribution2: simoleans(17n) },
+    want: { Contribution1: moola(15n) },
     exit: { onDemand: null },
   });
   const bobPayments = { Contribution2: bobSimoleanPayment };
@@ -206,7 +206,7 @@ test('zoe with automaticRefund', async t => {
   // Alice didn't get any of what she wanted
   t.deepEqual(
     await simoleanR.issuer.getAmountOf(aliceSimoleanPayout),
-    simoleans(0),
+    simoleans(0n),
   );
 
   // 9: Alice deposits her refund to ensure she can
@@ -232,13 +232,12 @@ test('multiple instances of automaticRefund for the same Zoe', async t => {
   const { moolaR, simoleanR, moola, simoleans, zoe } = setup();
 
   // Setup Alice
-  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(30));
-  const moola10 = moola(10);
-  const aliceMoolaPayments = await moolaR.issuer.splitMany(aliceMoolaPayment, [
-    moola10,
-    moola10,
-    moola10,
-  ]);
+  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(30n));
+  const moola10 = moola(10n);
+  const aliceMoolaPayments = await moolaR.issuer.splitMany(
+    aliceMoolaPayment,
+    harden([moola10, moola10, moola10]),
+  );
 
   // Alice creates 3 automatic refund instances
   // Pack the contract.
@@ -265,8 +264,8 @@ test('multiple instances of automaticRefund for the same Zoe', async t => {
   } = await E(zoe).startInstance(installation, issuerKeywordRecord);
 
   const aliceProposal = harden({
-    give: { ContributionA: moola(10) },
-    want: { ContributionB: simoleans(7) },
+    give: { ContributionA: moola(10n) },
+    want: { ContributionB: simoleans(7n) },
   });
 
   const seat1 = await E(zoe).offer(
@@ -317,7 +316,7 @@ test('zoe - alice tries to complete after completion has already occurred', asyn
   const { moolaR, simoleanR, moola, simoleans, zoe } = setup();
 
   // Setup Alice
-  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(3));
+  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(3n));
   const aliceMoolaPurse = moolaR.issuer.makeEmptyPurse();
   const aliceSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
 
@@ -334,8 +333,8 @@ test('zoe - alice tries to complete after completion has already occurred', asyn
   );
 
   const aliceProposal = harden({
-    give: { ContributionA: moola(3) },
-    want: { ContributionB: simoleans(7) },
+    give: { ContributionA: moola(3n) },
+    want: { ContributionB: simoleans(7n) },
   });
   const alicePayments = { ContributionA: aliceMoolaPayment };
 
@@ -361,7 +360,10 @@ test('zoe - alice tries to complete after completion has already occurred', asyn
   );
 
   // Alice didn't get any of what she wanted
-  t.deepEqual(await simoleanR.issuer.getAmountOf(simoleanPayout), simoleans(0));
+  t.deepEqual(
+    await simoleanR.issuer.getAmountOf(simoleanPayout),
+    simoleans(0n),
+  );
 
   // 9: Alice deposits her refund to ensure she can
   await aliceMoolaPurse.deposit(moolaPayout);

--- a/packages/zoe/test/unitTests/contracts/test-autoswapPool.js
+++ b/packages/zoe/test/unitTests/contracts/test-autoswapPool.js
@@ -129,9 +129,9 @@ test('pool getPrice amountIn != available', async t => {
     secondary(valueIn),
     centralBrand,
   );
-  t.deepEqual(amountOut, central(3));
+  t.deepEqual(amountOut, central(3n));
   // 40 would get you 3, but you can get 3 for 32 if that's better.
-  t.deepEqual(amountIn, secondary(32));
+  t.deepEqual(amountIn, secondary(32n));
 });
 
 test('pool getOutputPrice cenToSec', async t => {
@@ -174,10 +174,10 @@ test('pool getOutputPrice amountOut != requested', async t => {
     secondaryBrand,
     central(valueOut),
   );
-  // central(4) requires spending secondary(1), but you can get central(9) for
-  // secondary(1)
-  t.deepEqual(amountOut, central(9));
-  t.deepEqual(amountIn, secondary(1));
+  // central(4n) requires spending secondary(1n), but you can get central(9n) for
+  // secondary(1n)
+  t.deepEqual(amountOut, central(9n));
+  t.deepEqual(amountIn, secondary(1n));
 });
 
 test('pool getOutputPrice secToSec', async t => {

--- a/packages/zoe/test/unitTests/contracts/test-barter.js
+++ b/packages/zoe/test/unitTests/contracts/test-barter.js
@@ -31,10 +31,10 @@ test('barter with valid offers', async t => {
   const installation = await installationPFromSource(zoe, barter);
 
   // Setup Alice
-  const aliceMoolaPayment = moolaMint.mintPayment(moola(3));
+  const aliceMoolaPayment = moolaMint.mintPayment(moola(3n));
 
   // Setup Bob
-  const bobSimoleanPayment = simoleanMint.mintPayment(simoleans(7));
+  const bobSimoleanPayment = simoleanMint.mintPayment(simoleans(7n));
 
   // 1: Simon creates a barter instance and spreads the instance far and
   // wide with instructions on how to use it.
@@ -51,8 +51,8 @@ test('barter with valid offers', async t => {
   // sell 3 moola and wants to receive at least 4 simoleans in
   // return.
   const aliceSellOrderProposal = harden({
-    give: { In: moola(3) },
-    want: { Out: simoleans(4) },
+    give: { In: moola(3n) },
+    want: { Out: simoleans(4n) },
     exit: { onDemand: null },
   });
   const alicePayments = { In: aliceMoolaPayment };
@@ -80,8 +80,8 @@ test('barter with valid offers', async t => {
   // Bob creates a buy order, saying that he wants exactly 3 moola,
   // and is willing to pay up to 7 simoleans.
   const bobBuyOrderProposal = harden({
-    give: { In: simoleans(7) },
-    want: { Out: moola(3) },
+    give: { In: simoleans(7n) },
+    want: { Out: moola(3n) },
     exit: { onDemand: null },
   });
   const bobPayments = { In: bobSimoleanPayment };
@@ -118,11 +118,21 @@ test('barter with valid offers', async t => {
 
   await Promise.all([
     // Alice had 0 moola and 4 simoleans.
-    assertPayoutAmount(t, moolaIssuer, aliceMoolaPayout, moola(0n)),
-    assertPayoutAmount(t, simoleanIssuer, aliceSimoleanPayout, simoleans(4)),
+    await assertPayoutAmount(t, moolaIssuer, aliceMoolaPayout, moola(0n)),
+    await assertPayoutAmount(
+      t,
+      simoleanIssuer,
+      aliceSimoleanPayout,
+      simoleans(4n),
+    ),
 
     // Bob had 3 moola and 3 simoleans.
-    assertPayoutAmount(t, moolaIssuer, bobMoolaPayout, moola(3)),
-    assertPayoutAmount(t, simoleanIssuer, bobSimoleanPayout, simoleans(3)),
+    await assertPayoutAmount(t, moolaIssuer, bobMoolaPayout, moola(3n)),
+    await assertPayoutAmount(
+      t,
+      simoleanIssuer,
+      bobSimoleanPayout,
+      simoleans(3n),
+    ),
   ]);
 });

--- a/packages/zoe/test/unitTests/contracts/test-callSpread-calculation.js
+++ b/packages/zoe/test/unitTests/contracts/test-callSpread-calculation.js
@@ -30,9 +30,9 @@ test('callSpread-calculation, at lower bound', async t => {
   const { moola, bucks, brands } = setup();
   const bucksBrand = brands.get('bucks');
 
-  const strike1 = moola(20);
-  const strike2 = moola(70);
-  const price = moola(20);
+  const strike1 = moola(20n);
+  const strike2 = moola(70n);
+  const price = moola(20n);
   compareShareRatios(
     t,
     calculateShares(bucksBrand, price, strike1, strike2),
@@ -40,7 +40,7 @@ test('callSpread-calculation, at lower bound', async t => {
       longShare: make0Percent(bucksBrand),
       shortShare: make100Percent(bucksBrand),
     },
-    bucks(1000),
+    bucks(1000n),
   );
 });
 
@@ -48,9 +48,9 @@ test('callSpread-calculation, at upper bound', async t => {
   const { moola, bucks, brands } = setup();
   const bucksBrand = brands.get('bucks');
 
-  const strike1 = moola(20);
-  const strike2 = moola(55);
-  const price = moola(55);
+  const strike1 = moola(20n);
+  const strike2 = moola(55n);
+  const price = moola(55n);
   compareShareRatios(
     t,
     calculateShares(bucksBrand, price, strike1, strike2),
@@ -58,7 +58,7 @@ test('callSpread-calculation, at upper bound', async t => {
       longShare: make100Percent(bucksBrand),
       shortShare: make0Percent(bucksBrand),
     },
-    bucks(1000),
+    bucks(1000n),
   );
 });
 
@@ -66,8 +66,8 @@ test('callSpread-calculation, below lower bound', async t => {
   const { moola, bucks, brands } = setup();
   const bucksBrand = brands.get('bucks');
 
-  const strike1 = moola(15);
-  const strike2 = moola(55);
+  const strike1 = moola(15n);
+  const strike2 = moola(55n);
   const price = moola(0n);
   compareShareRatios(
     t,
@@ -76,7 +76,7 @@ test('callSpread-calculation, below lower bound', async t => {
       longShare: make0Percent(bucksBrand),
       shortShare: make100Percent(bucksBrand),
     },
-    bucks(1000),
+    bucks(1000n),
   );
 });
 
@@ -85,9 +85,9 @@ test('callSpread-calculation, above upper bound', async t => {
 
   const bucksBrand = brands.get('bucks');
 
-  const strike1 = moola(15);
-  const strike2 = moola(55);
-  const price = moola(60);
+  const strike1 = moola(15n);
+  const strike2 = moola(55n);
+  const price = moola(60n);
   compareShareRatios(
     t,
     calculateShares(bucksBrand, price, strike1, strike2),
@@ -95,7 +95,7 @@ test('callSpread-calculation, above upper bound', async t => {
       longShare: make100Percent(bucksBrand),
       shortShare: make0Percent(bucksBrand),
     },
-    bucks(1000),
+    bucks(1000n),
   );
 });
 
@@ -103,25 +103,25 @@ test('callSpread-calculation, mid-way', async t => {
   const { moola, bucks, brands } = setup();
   const bucksBrand = brands.get('bucks');
 
-  const strike1 = moola(15);
-  const strike2 = moola(45);
-  const price = moola(40);
+  const strike1 = moola(15n);
+  const strike2 = moola(45n);
+  const price = moola(40n);
   const { longShare, shortShare } = calculateShares(
     bucksBrand,
     price,
     strike1,
     strike2,
   );
-  t.deepEqual(ceilMultiplyBy(bucks(1000), longShare), bucks(834));
-  t.deepEqual(floorMultiplyBy(bucks(1000), shortShare), bucks(166));
+  t.deepEqual(ceilMultiplyBy(bucks(1000n), longShare), bucks(834n));
+  t.deepEqual(floorMultiplyBy(bucks(1000n), shortShare), bucks(166n));
 });
 
 test('callSpread-calculation, zero', async t => {
   const { moola, bucks, brands } = setup();
   const bucksBrand = brands.get('bucks');
 
-  const strike1 = moola(15);
-  const strike2 = moola(45);
+  const strike1 = moola(15n);
+  const strike2 = moola(45n);
   const price = moola(0n);
   compareShareRatios(
     t,
@@ -130,7 +130,7 @@ test('callSpread-calculation, zero', async t => {
       longShare: make0Percent(bucksBrand),
       shortShare: make100Percent(bucksBrand),
     },
-    bucks(1000),
+    bucks(1000n),
   );
 });
 
@@ -138,9 +138,9 @@ test('callSpread-calculation, large', async t => {
   const { moola, bucks, brands } = setup();
   const bucksBrand = brands.get('bucks');
 
-  const strike1 = moola(15);
-  const strike2 = moola(45);
-  const price = moola(10000000000);
+  const strike1 = moola(15n);
+  const strike2 = moola(45n);
+  const price = moola(10000000000n);
   compareShareRatios(
     t,
     calculateShares(bucksBrand, price, strike1, strike2),
@@ -148,6 +148,6 @@ test('callSpread-calculation, large', async t => {
       longShare: make100Percent(bucksBrand),
       shortShare: make0Percent(bucksBrand),
     },
-    bucks(1000),
+    bucks(1000n),
   );
 });

--- a/packages/zoe/test/unitTests/contracts/test-callSpread.js
+++ b/packages/zoe/test/unitTests/contracts/test-callSpread.js
@@ -53,7 +53,7 @@ test('fundedCallSpread below Strike1', async t => {
   // The spread will then mature at a low price, and carol will get paid.
 
   // Setup Alice
-  const aliceBucksPayment = bucksMint.mintPayment(bucks(300));
+  const aliceBucksPayment = bucksMint.mintPayment(bucks(300n));
   // Setup Bob
   const bobBucksPurse = bucksIssuer.makeEmptyPurse();
   // Setup Carol
@@ -68,11 +68,11 @@ test('fundedCallSpread below Strike1', async t => {
   // underlying is 2 Simoleans, strike range is 30-50 (doubled)
   const terms = harden({
     expiration: 3n,
-    underlyingAmount: simoleans(2),
+    underlyingAmount: simoleans(2n),
     priceAuthority,
-    strikePrice1: moola(60),
-    strikePrice2: moola(100),
-    settlementAmount: bucks(300),
+    strikePrice1: moola(60n),
+    strikePrice2: moola(100n),
+    settlementAmount: bucks(300n),
     timer: manualTimer,
   });
 
@@ -98,7 +98,7 @@ test('fundedCallSpread below Strike1', async t => {
 
   const aliceProposal = harden({
     want: { LongOption: longOptionAmount, ShortOption: shortOptionAmount },
-    give: { Collateral: bucks(300) },
+    give: { Collateral: bucks(300n) },
   });
   const alicePayments = { Collateral: aliceBucksPayment };
   const aliceSeat = await E(zoe).offer(
@@ -113,7 +113,12 @@ test('fundedCallSpread below Strike1', async t => {
 
   const bobOptionSeat = await E(zoe).offer(bobLongOption);
   const bobPayout = bobOptionSeat.getPayout('Collateral');
-  const bobDeposit = assertPayoutDeposit(t, bobPayout, bobBucksPurse, bucks(0));
+  const bobDeposit = assertPayoutDeposit(
+    t,
+    bobPayout,
+    bobBucksPurse,
+    bucks(0n),
+  );
 
   const carolOptionSeat = await E(zoe).offer(carolShortOption);
   const carolPayout = carolOptionSeat.getPayout('Collateral');
@@ -121,7 +126,7 @@ test('fundedCallSpread below Strike1', async t => {
     t,
     carolPayout,
     carolBucksPurse,
-    bucks(300),
+    bucks(300n),
   );
 
   await E(manualTimer).tick();
@@ -151,7 +156,7 @@ test('fundedCallSpread above Strike2', async t => {
   // The spread will then mature at a high price, and bob will get paid.
 
   // Setup Alice
-  const aliceBucksPayment = bucksMint.mintPayment(bucks(300));
+  const aliceBucksPayment = bucksMint.mintPayment(bucks(300n));
   // Setup Bob
   const bobBucksPurse = bucksIssuer.makeEmptyPurse();
   // Setup Carol
@@ -162,11 +167,11 @@ test('fundedCallSpread above Strike2', async t => {
   // underlying is 2 Simoleans, strike range is 30-50 (doubled)
   const terms = harden({
     expiration: 3n,
-    underlyingAmount: simoleans(2),
+    underlyingAmount: simoleans(2n),
     priceAuthority,
-    strikePrice1: moola(60),
-    strikePrice2: moola(100),
-    settlementAmount: bucks(300),
+    strikePrice1: moola(60n),
+    strikePrice2: moola(100n),
+    settlementAmount: bucks(300n),
     timer: manualTimer,
   });
 
@@ -189,7 +194,7 @@ test('fundedCallSpread above Strike2', async t => {
 
   const aliceProposal = harden({
     want: { LongOption: longOptionAmount, ShortOption: shortOptionAmount },
-    give: { Collateral: bucks(300) },
+    give: { Collateral: bucks(300n) },
   });
   const alicePayments = { Collateral: aliceBucksPayment };
   const aliceSeat = await E(zoe).offer(
@@ -208,7 +213,7 @@ test('fundedCallSpread above Strike2', async t => {
     t,
     bobPayout,
     bobBucksPurse,
-    bucks(300),
+    bucks(300n),
   );
 
   const carolOptionSeat = await E(zoe).offer(carolShortOption);
@@ -217,7 +222,7 @@ test('fundedCallSpread above Strike2', async t => {
     t,
     carolPayout,
     carolBucksPurse,
-    bucks(0),
+    bucks(0n),
   );
 
   await E(manualTimer).tick();
@@ -247,7 +252,7 @@ test('fundedCallSpread, mid-strike', async t => {
   // The spread will then mature, and both will get paid.
 
   // Setup Alice
-  const aliceBucksPayment = bucksMint.mintPayment(bucks(300));
+  const aliceBucksPayment = bucksMint.mintPayment(bucks(300n));
   // Setup Bob
   const bobBucksPurse = bucksIssuer.makeEmptyPurse();
   // Setup Carol
@@ -258,11 +263,11 @@ test('fundedCallSpread, mid-strike', async t => {
   // underlying is 2 Simoleans, strike range is 30-50 (doubled)
   const terms = harden({
     expiration: 3n,
-    underlyingAmount: simoleans(2),
+    underlyingAmount: simoleans(2n),
     priceAuthority,
-    strikePrice1: moola(60),
-    strikePrice2: moola(100),
-    settlementAmount: bucks(300),
+    strikePrice1: moola(60n),
+    strikePrice2: moola(100n),
+    settlementAmount: bucks(300n),
     timer: manualTimer,
   });
   // Alice creates a fundedCallSpread instance
@@ -284,7 +289,7 @@ test('fundedCallSpread, mid-strike', async t => {
 
   const aliceProposal = harden({
     want: { LongOption: longOptionAmount, ShortOption: shortOptionAmount },
-    give: { Collateral: bucks(300) },
+    give: { Collateral: bucks(300n) },
   });
   const alicePayments = { Collateral: aliceBucksPayment };
   const aliceSeat = await E(zoe).offer(
@@ -303,7 +308,7 @@ test('fundedCallSpread, mid-strike', async t => {
     t,
     bobPayout,
     bobBucksPurse,
-    bucks(225),
+    bucks(225n),
   );
 
   const carolOptionSeat = await E(zoe).offer(carolShortOption);
@@ -312,7 +317,7 @@ test('fundedCallSpread, mid-strike', async t => {
     t,
     carolPayout,
     carolBucksPurse,
-    bucks(75),
+    bucks(75n),
   );
 
   await E(manualTimer).tick();
@@ -342,7 +347,7 @@ test('fundedCallSpread, late exercise', async t => {
   // The spread will then mature, and both will get paid.
 
   // Setup Alice
-  const aliceBucksPayment = bucksMint.mintPayment(bucks(300));
+  const aliceBucksPayment = bucksMint.mintPayment(bucks(300n));
   // Setup Bob
   const bobBucksPurse = bucksIssuer.makeEmptyPurse();
   // Setup Carol
@@ -353,11 +358,11 @@ test('fundedCallSpread, late exercise', async t => {
   // underlying is 2 Simoleans, strike range is 30-50 (doubled)
   const terms = harden({
     expiration: 3n,
-    underlyingAmount: simoleans(2),
+    underlyingAmount: simoleans(2n),
     priceAuthority,
-    strikePrice1: moola(60),
-    strikePrice2: moola(100),
-    settlementAmount: bucks(300),
+    strikePrice1: moola(60n),
+    strikePrice2: moola(100n),
+    settlementAmount: bucks(300n),
     timer: manualTimer,
   });
 
@@ -381,7 +386,7 @@ test('fundedCallSpread, late exercise', async t => {
       LongOption: invitationDetails.longAmount,
       ShortOption: invitationDetails.shortAmount,
     },
-    give: { Collateral: bucks(300) },
+    give: { Collateral: bucks(300n) },
   });
   const alicePayments = { Collateral: aliceBucksPayment };
   const aliceSeat = await E(zoe).offer(
@@ -400,7 +405,7 @@ test('fundedCallSpread, late exercise', async t => {
     t,
     bobPayout,
     bobBucksPurse,
-    bucks(225),
+    bucks(225n),
   );
 
   await E(manualTimer).tick();
@@ -412,7 +417,7 @@ test('fundedCallSpread, late exercise', async t => {
   const carolDepositAmount = await E(carolBucksPurse).deposit(carolPayout);
   await t.deepEqual(
     carolDepositAmount,
-    bucks(75),
+    bucks(75n),
     `payout was ${carolDepositAmount.value}, expected 75`,
   );
   await Promise.all([bobDeposit]);
@@ -438,25 +443,25 @@ test('fundedCallSpread, sell options', async t => {
   // The spread will then mature, and both will get paid.
 
   // Setup Alice
-  const aliceBucksPayment = bucksMint.mintPayment(bucks(300));
+  const aliceBucksPayment = bucksMint.mintPayment(bucks(300n));
   const aliceBucksPurse = bucksIssuer.makeEmptyPurse();
   // Setup Bob
   const bobBucksPurse = bucksIssuer.makeEmptyPurse();
-  const bobBucksPayment = bucksMint.mintPayment(bucks(200));
+  const bobBucksPayment = bucksMint.mintPayment(bucks(200n));
   // Setup Carol
   const carolBucksPurse = bucksIssuer.makeEmptyPurse();
-  const carolBucksPayment = bucksMint.mintPayment(bucks(100));
+  const carolBucksPayment = bucksMint.mintPayment(bucks(100n));
 
   const manualTimer = buildManualTimer(console.log, 0n);
   const priceAuthority = makeTestPriceAuthority(brands, [20, 45], manualTimer);
   // underlying is 2 Simoleans, strike range is 30-50 (doubled)
   const terms = harden({
     expiration: 3n,
-    underlyingAmount: simoleans(2),
+    underlyingAmount: simoleans(2n),
     priceAuthority,
-    strikePrice1: moola(60),
-    strikePrice2: moola(100),
-    settlementAmount: bucks(300),
+    strikePrice1: moola(60n),
+    strikePrice2: moola(100n),
+    settlementAmount: bucks(300n),
     timer: manualTimer,
   });
 
@@ -478,7 +483,7 @@ test('fundedCallSpread, sell options', async t => {
 
   const aliceProposal = harden({
     want: { LongOption: longOptionAmount, ShortOption: shortOptionAmount },
-    give: { Collateral: bucks(300) },
+    give: { Collateral: bucks(300n) },
   });
   const alicePayments = { Collateral: aliceBucksPayment };
   const aliceSeat = await E(zoe).offer(
@@ -507,7 +512,7 @@ test('fundedCallSpread, sell options', async t => {
   const aliceLongInvitation = E(exchangePublic).makeInvitation();
   const proposalLong = harden({
     give: { Asset: longOptionAmount },
-    want: { Price: bucks(200) },
+    want: { Price: bucks(200n) },
   });
   const aliceSellLongSeat = await E(zoe).offer(
     aliceLongInvitation,
@@ -520,14 +525,14 @@ test('fundedCallSpread, sell options', async t => {
     t,
     aliceSellLongSeat.getPayout('Price'),
     aliceBucksPurse,
-    bucks(200),
+    bucks(200n),
   );
 
   // Alice offers to sell the short invitation
   const aliceShortInvitation = E(exchangePublic).makeInvitation();
   const proposalShort = harden({
     give: { Asset: shortOptionAmount },
-    want: { Price: bucks(100) },
+    want: { Price: bucks(100n) },
   });
   const aliceSellShortSeat = await E(zoe).offer(
     aliceShortInvitation,
@@ -538,20 +543,20 @@ test('fundedCallSpread, sell options', async t => {
     t,
     aliceSellShortSeat.getPayout('Price'),
     carolBucksPurse,
-    bucks(100),
+    bucks(100n),
   );
 
   // Bob buys the long invitation
   const bobLongInvitation = E(exchangePublic).makeInvitation();
   const bobProposal = harden({
-    give: { Price: bucks(200) },
+    give: { Price: bucks(200n) },
     want: { Asset: longOptionAmount },
   });
   const bobBuySeat = await E(zoe).offer(bobLongInvitation, bobProposal, {
     Price: bobBucksPayment,
   });
   const longInvitationPayout = await bobBuySeat.getPayout('Asset');
-  assertPayoutAmount(
+  await assertPayoutAmount(
     t,
     invitationIssuer,
     longInvitationPayout,
@@ -563,20 +568,20 @@ test('fundedCallSpread, sell options', async t => {
     t,
     bobPayout,
     bobBucksPurse,
-    bucks(225),
+    bucks(225n),
   );
 
   // Carol buys the Short invitation
   const carolShortInvitation = E(exchangePublic).makeInvitation();
   const carolProposal = harden({
-    give: { Price: bucks(100) },
+    give: { Price: bucks(100n) },
     want: { Asset: shortOptionAmount },
   });
   const carolBuySeat = await E(zoe).offer(carolShortInvitation, carolProposal, {
     Price: carolBucksPayment,
   });
   const ShortInvitationPayout = await carolBuySeat.getPayout('Asset');
-  assertPayoutAmount(
+  await assertPayoutAmount(
     t,
     invitationIssuer,
     ShortInvitationPayout,
@@ -588,7 +593,7 @@ test('fundedCallSpread, sell options', async t => {
     t,
     carolPayout,
     carolBucksPurse,
-    bucks(75),
+    bucks(75n),
   );
 
   await E(manualTimer).tick();
@@ -618,10 +623,10 @@ test('pricedCallSpread, mid-strike', async t => {
 
   // Setup Bob
   const bobBucksPurse = bucksIssuer.makeEmptyPurse();
-  const bobBucksPayment = bucksMint.mintPayment(bucks(225));
+  const bobBucksPayment = bucksMint.mintPayment(bucks(225n));
   // Setup Carol
   const carolBucksPurse = bucksIssuer.makeEmptyPurse();
-  const carolBucksPayment = bucksMint.mintPayment(bucks(75));
+  const carolBucksPayment = bucksMint.mintPayment(bucks(75n));
 
   const manualTimer = buildManualTimer(console.log, 0n);
   const priceAuthority = await makeTestPriceAuthority(
@@ -632,11 +637,11 @@ test('pricedCallSpread, mid-strike', async t => {
   // underlying is 2 Simoleans, strike range is 30-50 (doubled)
   const terms = harden({
     expiration: 3n,
-    underlyingAmount: simoleans(2),
+    underlyingAmount: simoleans(2n),
     priceAuthority,
-    strikePrice1: moola(60),
-    strikePrice2: moola(100),
-    settlementAmount: bucks(300),
+    strikePrice1: moola(60n),
+    strikePrice2: moola(100n),
+    settlementAmount: bucks(300n),
     timer: manualTimer,
   });
   // Alice creates a pricedCallSpread instance
@@ -678,7 +683,7 @@ test('pricedCallSpread, mid-strike', async t => {
     t,
     bobPayout,
     bobBucksPurse,
-    bucks(225),
+    bucks(225n),
   );
 
   const shortOptionValue = shortAmount.value[0];
@@ -706,7 +711,7 @@ test('pricedCallSpread, mid-strike', async t => {
     t,
     carolPayout,
     carolBucksPurse,
-    bucks(75),
+    bucks(75n),
   );
 
   await E(manualTimer).tick();

--- a/packages/zoe/test/unitTests/contracts/test-coveredCall.js
+++ b/packages/zoe/test/unitTests/contracts/test-coveredCall.js
@@ -56,8 +56,8 @@ test('zoe - coveredCall', async t => {
       },
       offer: async createCallOptionInvitation => {
         const proposal = harden({
-          give: { Moola: moola(3) },
-          want: { Simoleans: simoleans(7), Bucks: bucks(2) },
+          give: { Moola: moola(3n) },
+          want: { Simoleans: simoleans(7n), Bucks: bucks(2n) },
           exit: { afterDeadline: { deadline: 1n, timer } },
         });
         const payments = { Moola: moolaPayment };
@@ -92,7 +92,7 @@ test('zoe - coveredCall', async t => {
           .then(amountDeposited =>
             t.deepEqual(
               amountDeposited,
-              simoleans(7),
+              simoleans(7n),
               `Alice got exactly what she wanted`,
             ),
           );
@@ -103,7 +103,7 @@ test('zoe - coveredCall', async t => {
           .then(amountDeposited =>
             t.deepEqual(
               amountDeposited,
-              bucks(2),
+              bucks(2n),
               `Alice got exactly what she wanted`,
             ),
           );
@@ -134,12 +134,12 @@ test('zoe - coveredCall', async t => {
 
         t.deepEqual(
           invitationValue.underlyingAssets,
-          { Moola: moola(3) },
+          { Moola: moola(3n) },
           `underlying assets are 3 moola`,
         );
         t.deepEqual(
           invitationValue.strikePrice,
-          { Simoleans: simoleans(7), Bucks: bucks(2) },
+          { Simoleans: simoleans(7n), Bucks: bucks(2n) },
           `strike price is 7 simoleans and 2 bucks, so bob must give that`,
         );
 
@@ -147,8 +147,8 @@ test('zoe - coveredCall', async t => {
         t.deepEqual(invitationValue.timeAuthority, timer);
 
         const proposal = harden({
-          give: { StrikePrice1: simoleans(7), StrikePrice2: bucks(2) },
-          want: { UnderlyingAsset: moola(3) },
+          give: { StrikePrice1: simoleans(7n), StrikePrice2: bucks(2n) },
+          want: { UnderlyingAsset: moola(3n) },
           exit: { onDemand: null },
         });
         const payments = {
@@ -169,7 +169,7 @@ test('zoe - coveredCall', async t => {
           .getPayout('UnderlyingAsset')
           .then(moolaPurse.deposit)
           .then(amountDeposited =>
-            t.deepEqual(amountDeposited, moola(3), `Bob got what he wanted`),
+            t.deepEqual(amountDeposited, moola(3n), `Bob got what he wanted`),
           );
 
         await E(seat)
@@ -178,7 +178,7 @@ test('zoe - coveredCall', async t => {
           .then(amountDeposited =>
             t.deepEqual(
               amountDeposited,
-              simoleans(0),
+              simoleans(0n),
               `Bob didn't get anything back`,
             ),
           );
@@ -189,7 +189,7 @@ test('zoe - coveredCall', async t => {
           .then(amountDeposited =>
             t.deepEqual(
               amountDeposited,
-              bucks(0),
+              bucks(0n),
               `Bob didn't get anything back`,
             ),
           );
@@ -200,15 +200,15 @@ test('zoe - coveredCall', async t => {
   const timer = buildManualTimer(console.log);
 
   // Setup Alice
-  const aliceMoolaPayment = moolaKit.mint.mintPayment(moola(3));
+  const aliceMoolaPayment = moolaKit.mint.mintPayment(moola(3n));
   const alice = await makeAlice(timer, aliceMoolaPayment);
 
   // Alice makes an instance and makes her offer.
   const installation = await alice.installCode();
 
   // Setup Bob
-  const bobSimoleanPayment = simoleanKit.mint.mintPayment(simoleans(7));
-  const bobBucksPayment = bucksKit.mint.mintPayment(bucks(2));
+  const bobSimoleanPayment = simoleanKit.mint.mintPayment(simoleans(7n));
+  const bobBucksPayment = bucksKit.mint.mintPayment(bucks(2n));
   const bob = makeBob(timer, installation, bobSimoleanPayment, bobBucksPayment);
 
   const { creatorInvitation } = await alice.startInstance(installation);
@@ -232,12 +232,12 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
   const timer = buildManualTimer(console.log);
 
   // Setup Alice
-  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(3));
+  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(3n));
   const aliceMoolaPurse = moolaR.issuer.makeEmptyPurse();
   const aliceSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
 
   // Setup Bob
-  const bobSimoleanPayment = simoleanR.mint.mintPayment(simoleans(7));
+  const bobSimoleanPayment = simoleanR.mint.mintPayment(simoleans(7n));
   const bobMoolaPurse = moolaR.issuer.makeEmptyPurse();
   const bobSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
 
@@ -253,8 +253,8 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
 
   // Alice escrows with Zoe
   const aliceProposal = harden({
-    give: { UnderlyingAsset: moola(3) },
-    want: { StrikePrice: simoleans(7) },
+    give: { UnderlyingAsset: moola(3n) },
+    want: { StrikePrice: simoleans(7n) },
     exit: {
       afterDeadline: {
         deadline: 1n,
@@ -285,8 +285,8 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
   const optionValue = await E(zoe).getInvitationDetails(bobExclOption);
   t.is(optionValue.installation, coveredCallInstallation);
   t.is(optionValue.description, 'exerciseOption');
-  t.deepEqual(optionValue.underlyingAssets, { UnderlyingAsset: moola(3) });
-  t.deepEqual(optionValue.strikePrice, { StrikePrice: simoleans(7) });
+  t.deepEqual(optionValue.underlyingAssets, { UnderlyingAsset: moola(3n) });
+  t.deepEqual(optionValue.strikePrice, { StrikePrice: simoleans(7n) });
   t.is(optionValue.expirationDate, 1n);
   t.deepEqual(optionValue.timeAuthority, timer);
 
@@ -313,12 +313,12 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
   const aliceSimoleanPayout = await E(aliceSeat).getPayout('StrikePrice');
 
   // Alice gets back what she put in
-  t.deepEqual(await moolaR.issuer.getAmountOf(aliceMoolaPayout), moola(3));
+  t.deepEqual(await moolaR.issuer.getAmountOf(aliceMoolaPayout), moola(3n));
 
   // Alice doesn't get what she wanted
   t.deepEqual(
     await simoleanR.issuer.getAmountOf(aliceSimoleanPayout),
-    simoleans(0),
+    simoleans(0n),
   );
 
   // Alice deposits her winnings to ensure she can
@@ -332,10 +332,10 @@ test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, a
   // Assert that the correct outcome was achieved.
   // Alice had 3 moola and 0 simoleans.
   // Bob had 0 moola and 7 simoleans.
-  t.deepEqual(aliceMoolaPurse.getCurrentAmount(), moola(3));
-  t.deepEqual(aliceSimoleanPurse.getCurrentAmount(), simoleans(0));
+  t.deepEqual(aliceMoolaPurse.getCurrentAmount(), moola(3n));
+  t.deepEqual(aliceSimoleanPurse.getCurrentAmount(), simoleans(0n));
   t.deepEqual(bobMoolaPurse.getCurrentAmount(), moola(0n));
-  t.deepEqual(bobSimoleanPurse.getCurrentAmount(), simoleans(7));
+  t.deepEqual(bobSimoleanPurse.getCurrentAmount(), simoleans(7n));
 });
 
 // Alice makes a covered call and escrows. She shares the invitation to
@@ -357,7 +357,7 @@ test('zoe - coveredCall with swap for invitation', async t => {
 
   // Setup Alice
   // Alice starts with 3 moola
-  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(3));
+  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(3n));
   const aliceMoolaPurse = moolaR.issuer.makeEmptyPurse();
   const aliceSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
 
@@ -369,8 +369,8 @@ test('zoe - coveredCall with swap for invitation', async t => {
 
   // Setup Dave
   // Dave starts with 1 buck
-  const daveSimoleanPayment = simoleanR.mint.mintPayment(simoleans(7));
-  const daveBucksPayment = bucksR.mint.mintPayment(bucks(1));
+  const daveSimoleanPayment = simoleanR.mint.mintPayment(simoleans(7n));
+  const daveBucksPayment = bucksR.mint.mintPayment(bucks(1n));
   const daveMoolaPurse = moolaR.issuer.makeEmptyPurse();
   const daveSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
   const daveBucksPurse = bucksR.issuer.makeEmptyPurse();
@@ -393,8 +393,8 @@ test('zoe - coveredCall with swap for invitation', async t => {
   // reached in this test.
 
   const aliceProposal = harden({
-    give: { UnderlyingAsset: moola(3) },
-    want: { StrikePrice: simoleans(7) },
+    give: { UnderlyingAsset: moola(3n) },
+    want: { StrikePrice: simoleans(7n) },
     exit: {
       afterDeadline: {
         deadline: 100n, // we will not reach this
@@ -427,8 +427,8 @@ test('zoe - coveredCall with swap for invitation', async t => {
   const optionDesc = optionAmount.value[0];
   t.is(optionDesc.installation, coveredCallInstallation);
   t.is(optionDesc.description, 'exerciseOption');
-  t.deepEqual(optionDesc.underlyingAssets, { UnderlyingAsset: moola(3) });
-  t.deepEqual(optionDesc.strikePrice, { StrikePrice: simoleans(7) });
+  t.deepEqual(optionDesc.underlyingAssets, { UnderlyingAsset: moola(3n) });
+  t.deepEqual(optionDesc.strikePrice, { StrikePrice: simoleans(7n) });
   t.is(optionDesc.expirationDate, 100n);
   t.deepEqual(optionDesc.timeAuthority, timer);
 
@@ -447,7 +447,7 @@ test('zoe - coveredCall with swap for invitation', async t => {
   // current invitation from Alice. He wants 1 buck in return.
   const bobProposalSwap = harden({
     give: { Asset: await E(invitationIssuer).getAmountOf(bobExclOption) },
-    want: { Price: bucks(1) },
+    want: { Price: bucks(1n) },
   });
 
   const bobPayments = harden({ Asset: bobExclOption });
@@ -498,7 +498,7 @@ test('zoe - coveredCall with swap for invitation', async t => {
   // Dave escrows his 1 buck with Zoe and forms his proposal
   const daveSwapProposal = harden({
     want: { Asset: optionAmount },
-    give: { Price: bucks(1) },
+    give: { Price: bucks(1n) },
   });
 
   const daveSwapPayments = harden({ Price: daveBucksPayment });
@@ -520,8 +520,8 @@ test('zoe - coveredCall with swap for invitation', async t => {
   // call. First, he escrows with Zoe.
 
   const daveCoveredCallProposal = harden({
-    want: { UnderlyingAsset: moola(3) },
-    give: { StrikePrice: simoleans(7) },
+    want: { UnderlyingAsset: moola(3n) },
+    give: { StrikePrice: simoleans(7n) },
   });
   const daveCoveredCallPayments = harden({
     StrikePrice: daveSimoleanPayment,
@@ -548,23 +548,23 @@ test('zoe - coveredCall with swap for invitation', async t => {
   const bobInvitationPayout = await bobSwapSeat.getPayout('Asset');
   const bobBucksPayout = await bobSwapSeat.getPayout('Price');
 
-  t.deepEqual(await moolaR.issuer.getAmountOf(daveMoolaPayout), moola(3));
+  t.deepEqual(await moolaR.issuer.getAmountOf(daveMoolaPayout), moola(3n));
   t.deepEqual(
     await simoleanR.issuer.getAmountOf(daveSimoleanPayout),
-    simoleans(0),
+    simoleans(0n),
   );
 
   t.deepEqual(await moolaR.issuer.getAmountOf(aliceMoolaPayout), moola(0n));
   t.deepEqual(
     await simoleanR.issuer.getAmountOf(aliceSimoleanPayout),
-    simoleans(7),
+    simoleans(7n),
   );
 
   t.deepEqual(
     await E(invitationIssuer).getAmountOf(bobInvitationPayout),
     AmountMath.makeEmpty(invitationBrand, AssetKind.SET),
   );
-  t.deepEqual(await bucksR.issuer.getAmountOf(bobBucksPayout), bucks(1));
+  t.deepEqual(await bucksR.issuer.getAmountOf(bobBucksPayout), bucks(1n));
 
   // Alice deposits her payouts
   await aliceMoolaPurse.deposit(aliceMoolaPayout);
@@ -607,7 +607,7 @@ test('zoe - coveredCall with coveredCall for invitation', async t => {
 
   // Setup Alice
   // Alice starts with 3 moola
-  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(3));
+  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(3n));
   const aliceMoolaPurse = moolaR.issuer.makeEmptyPurse();
   const aliceSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
 
@@ -619,8 +619,8 @@ test('zoe - coveredCall with coveredCall for invitation', async t => {
 
   // Setup Dave
   // Dave starts with 1 buck and 7 simoleans
-  const daveSimoleanPayment = simoleanR.mint.mintPayment(simoleans(7));
-  const daveBucksPayment = bucksR.mint.mintPayment(bucks(1));
+  const daveSimoleanPayment = simoleanR.mint.mintPayment(simoleans(7n));
+  const daveBucksPayment = bucksR.mint.mintPayment(bucks(1n));
   const daveMoolaPurse = moolaR.issuer.makeEmptyPurse();
   const daveSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
   const daveBucksPurse = bucksR.issuer.makeEmptyPurse();
@@ -642,8 +642,8 @@ test('zoe - coveredCall with coveredCall for invitation', async t => {
   // reached in this test.
 
   const aliceProposal = harden({
-    give: { UnderlyingAsset: moola(3) },
-    want: { StrikePrice: simoleans(7) },
+    give: { UnderlyingAsset: moola(3n) },
+    want: { StrikePrice: simoleans(7n) },
     exit: {
       afterDeadline: {
         deadline: 100n, // we will not reach this
@@ -675,8 +675,8 @@ test('zoe - coveredCall with coveredCall for invitation', async t => {
   const optionValue = await E(zoe).getInvitationDetails(bobExclOption);
   t.is(optionValue.installation, coveredCallInstallation);
   t.is(optionValue.description, 'exerciseOption');
-  t.deepEqual(optionValue.underlyingAssets, { UnderlyingAsset: moola(3) });
-  t.deepEqual(optionValue.strikePrice, { StrikePrice: simoleans(7) });
+  t.deepEqual(optionValue.underlyingAssets, { UnderlyingAsset: moola(3n) });
+  t.deepEqual(optionValue.strikePrice, { StrikePrice: simoleans(7n) });
   t.is(optionValue.expirationDate, 100n);
   t.deepEqual(optionValue.timeAuthority, timer);
 
@@ -696,7 +696,7 @@ test('zoe - coveredCall with coveredCall for invitation', async t => {
     give: {
       UnderlyingAsset: await E(invitationIssuer).getAmountOf(bobExclOption),
     },
-    want: { StrikePrice: bucks(1) },
+    want: { StrikePrice: bucks(1n) },
     exit: {
       afterDeadline: {
         deadline: 100n, // we will not reach this
@@ -726,7 +726,7 @@ test('zoe - coveredCall with coveredCall for invitation', async t => {
   const daveOptionValue = await E(zoe).getInvitationDetails(daveExclOption);
   t.is(daveOptionValue.installation, coveredCallInstallation);
   t.is(daveOptionValue.description, 'exerciseOption');
-  assertAmountsEqual(t, daveOptionValue.strikePrice.StrikePrice, bucks(1));
+  assertAmountsEqual(t, daveOptionValue.strikePrice.StrikePrice, bucks(1n));
   t.is(daveOptionValue.expirationDate, 100n);
   t.deepEqual(daveOptionValue.timeAuthority, timer);
 
@@ -743,7 +743,7 @@ test('zoe - coveredCall with coveredCall for invitation', async t => {
     t,
     daveOptionValue.underlyingAssets.UnderlyingAsset.value[0].strikePrice
       .StrikePrice,
-    simoleans(7),
+    simoleans(7n),
   );
   t.deepEqual(
     daveOptionValue.underlyingAssets.UnderlyingAsset.value[0].timeAuthority,
@@ -753,7 +753,7 @@ test('zoe - coveredCall with coveredCall for invitation', async t => {
   // Dave's planned proposal
   const daveProposalCoveredCall = harden({
     want: daveOptionValue.underlyingAssets,
-    give: { StrikePrice: bucks(1) },
+    give: { StrikePrice: bucks(1n) },
   });
 
   // Dave escrows his 1 buck with Zoe and forms his proposal
@@ -781,8 +781,8 @@ test('zoe - coveredCall with coveredCall for invitation', async t => {
   // call. First, he escrows with Zoe.
 
   const daveFirstCoveredCallProposal = harden({
-    want: { UnderlyingAsset: moola(3) },
-    give: { StrikePrice: simoleans(7) },
+    want: { UnderlyingAsset: moola(3n) },
+    give: { StrikePrice: simoleans(7n) },
   });
   const daveFirstCoveredCallPayments = harden({
     StrikePrice: daveSimoleanPayment,
@@ -815,16 +815,16 @@ test('zoe - coveredCall with coveredCall for invitation', async t => {
   const bobInvitationPayout = await bobSeat.getPayout('UnderlyingAsset');
   const bobBucksPayout = await bobSeat.getPayout('StrikePrice');
 
-  t.deepEqual(await moolaR.issuer.getAmountOf(daveMoolaPayout), moola(3));
+  t.deepEqual(await moolaR.issuer.getAmountOf(daveMoolaPayout), moola(3n));
   t.deepEqual(
     await simoleanR.issuer.getAmountOf(daveSimoleanPayout),
-    simoleans(0),
+    simoleans(0n),
   );
 
   t.deepEqual(await moolaR.issuer.getAmountOf(aliceMoolaPayout), moola(0n));
   t.deepEqual(
     await simoleanR.issuer.getAmountOf(aliceSimoleanPayout),
-    simoleans(7),
+    simoleans(7n),
   );
 
   const invitationBrand = await E(invitationIssuer).getBrand();
@@ -832,7 +832,7 @@ test('zoe - coveredCall with coveredCall for invitation', async t => {
     await E(invitationIssuer).getAmountOf(bobInvitationPayout),
     AmountMath.makeEmpty(invitationBrand, AssetKind.SET),
   );
-  t.deepEqual(await bucksR.issuer.getAmountOf(bobBucksPayout), bucks(1));
+  t.deepEqual(await bucksR.issuer.getAmountOf(bobBucksPayout), bucks(1n));
 
   // Alice deposits her payouts
   await aliceMoolaPurse.deposit(aliceMoolaPayout);

--- a/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
@@ -59,10 +59,10 @@ test('zoe - escrowToVote', async t => {
   // Voter 1 votes YES. Vote will be weighted by 3 (3 moola escrowed).
   const voter1Votes = async invitation => {
     const proposal = harden({
-      give: { Assets: moola(3) },
+      give: { Assets: moola(3n) },
     });
     const payments = harden({
-      Assets: moolaMint.mintPayment(moola(3)),
+      Assets: moolaMint.mintPayment(moola(3n)),
     });
     const seat = await E(zoe).offer(invitation, proposal, payments);
 
@@ -77,7 +77,7 @@ test('zoe - escrowToVote', async t => {
     const moolaPayment = await seat.getPayout('Assets');
     t.deepEqual(
       await moolaIssuer.getAmountOf(moolaPayment),
-      moola(3),
+      moola(3n),
       `voter1 gets everything she escrowed back`,
     );
 
@@ -95,10 +95,10 @@ test('zoe - escrowToVote', async t => {
   // vote to NO. Vote will be weighted by 5 (5 moola escrowed).
   const voter2Votes = async invitation => {
     const proposal = harden({
-      give: { Assets: moola(5) },
+      give: { Assets: moola(5n) },
     });
     const payments = harden({
-      Assets: moolaMint.mintPayment(moola(5)),
+      Assets: moolaMint.mintPayment(moola(5n)),
     });
     const seat = await E(zoe).offer(invitation, proposal, payments);
 
@@ -130,7 +130,7 @@ test('zoe - escrowToVote', async t => {
     const moolaPayment = await seat.getPayout('Assets');
     t.deepEqual(
       await moolaIssuer.getAmountOf(moolaPayment),
-      moola(5),
+      moola(5n),
       `voter2 gets everything she escrowed back`,
     );
 
@@ -149,10 +149,10 @@ test('zoe - escrowToVote', async t => {
   // their full moola (1 moola) back as a payout.
   const voter3Votes = async invitation => {
     const proposal = harden({
-      give: { Assets: moola(1) },
+      give: { Assets: moola(1n) },
     });
     const payments = harden({
-      Assets: moolaMint.mintPayment(moola(1)),
+      Assets: moolaMint.mintPayment(moola(1n)),
     });
     const seat = await E(zoe).offer(invitation, proposal, payments);
 
@@ -172,7 +172,7 @@ test('zoe - escrowToVote', async t => {
 
     t.deepEqual(
       await moolaIssuer.getAmountOf(moolaPayment),
-      moola(1),
+      moola(1n),
       `voter3 gets everything she escrowed back`,
     );
 
@@ -189,10 +189,10 @@ test('zoe - escrowToVote', async t => {
   // Voter4 votes YES with a weight of 4
   const voter4Votes = async invitation => {
     const proposal = harden({
-      give: { Assets: moola(4) },
+      give: { Assets: moola(4n) },
     });
     const payments = harden({
-      Assets: moolaMint.mintPayment(moola(4)),
+      Assets: moolaMint.mintPayment(moola(4n)),
     });
     const seat = await E(zoe).offer(invitation, proposal, payments);
 
@@ -208,7 +208,7 @@ test('zoe - escrowToVote', async t => {
     const moolaPayment = seat.getPayout('Assets');
     t.deepEqual(
       await moolaIssuer.getAmountOf(moolaPayment),
-      moola(4),
+      moola(4n),
       `voter4 gets everything she escrowed back`,
     );
   };
@@ -218,7 +218,7 @@ test('zoe - escrowToVote', async t => {
 
   // Secretary closes election and tallies the votes.
   const electionResults = await E(secretary).closeElection();
-  t.deepEqual(electionResults, { YES: moola(7), NO: moola(5) });
+  t.deepEqual(electionResults, { YES: moola(7n), NO: moola(5n) });
 
   // Once the election is closed, the voters get their escrowed funds
   // back and can no longer vote.

--- a/packages/zoe/test/unitTests/contracts/test-mintPayments.js
+++ b/packages/zoe/test/unitTests/contracts/test-mintPayments.js
@@ -67,7 +67,7 @@ test('zoe - mint payments', async t => {
         const tokenIssuer = await E(publicFacet).getTokenIssuer();
         const tokenBrand = await E(tokenIssuer).getBrand();
 
-        const tokens1000 = await AmountMath.make(1000n, tokenBrand);
+        const tokens1000 = await AmountMath.make(tokenBrand, 1000n);
         const tokenPayoutAmount = await E(tokenIssuer).getAmountOf(paymentP);
 
         // Bob got 1000 tokens
@@ -80,7 +80,7 @@ test('zoe - mint payments', async t => {
   const alice = await makeAlice();
   const installation = await alice.installCode();
   const { creatorFacet } = await E(alice).startInstance(installation);
-  const invitation = E(creatorFacet).makeInvitation(1000);
+  const invitation = E(creatorFacet).makeInvitation(1000n);
 
   // Setup Bob
   const bob = makeBob(installation);
@@ -137,8 +137,8 @@ test('zoe - mint payments with unrelated give and want', async t => {
         const { instance } = invitationValue;
 
         const proposal = harden({
-          give: { Asset: AmountMath.make(10n, moolaKit.brand) },
-          want: { Price: AmountMath.make(100n, simoleanKit.brand) },
+          give: { Asset: AmountMath.make(moolaKit.brand, 10n) },
+          want: { Price: AmountMath.make(simoleanKit.brand, 100n) },
         });
         const paymentKeywordRecord = harden({
           Asset: moolaPayment,
@@ -158,7 +158,7 @@ test('zoe - mint payments with unrelated give and want', async t => {
         const tokenIssuer = await E(publicFacet).getTokenIssuer();
         const tokenBrand = await E(tokenIssuer).getBrand();
 
-        const tokens1000 = await AmountMath.make(1000n, tokenBrand);
+        const tokens1000 = await AmountMath.make(tokenBrand, 1000n);
         const tokenPayoutAmount = await E(tokenIssuer).getAmountOf(
           tokenPaymentP,
         );
@@ -169,7 +169,7 @@ test('zoe - mint payments with unrelated give and want', async t => {
         // Got refunded all the moola given
         t.deepEqual(
           await E(moolaKit.issuer).getAmountOf(moolaRefundP),
-          AmountMath.make(10n, moolaKit.brand),
+          AmountMath.make(moolaKit.brand, 10n),
         );
       },
     };
@@ -179,12 +179,12 @@ test('zoe - mint payments with unrelated give and want', async t => {
   const alice = await makeAlice();
   const installation = await alice.installCode();
   const { creatorFacet } = await E(alice).startInstance(installation);
-  const invitation = E(creatorFacet).makeInvitation(1000);
+  const invitation = E(creatorFacet).makeInvitation(1000n);
 
   // Setup Bob
   const bob = makeBob(
     installation,
-    moolaKit.mint.mintPayment(AmountMath.make(10n, moolaKit.brand)),
+    moolaKit.mint.mintPayment(AmountMath.make(moolaKit.brand, 10n)),
   );
   await bob.offer(invitation);
 });

--- a/packages/zoe/test/unitTests/contracts/test-oracle.js
+++ b/packages/zoe/test/unitTests/contracts/test-oracle.js
@@ -53,7 +53,7 @@ test.before(
     // using the same code.
     const installation = await E(zoe).install(contractBundle);
 
-    const feeAmount = AmountMath.make(1000n, link.brand);
+    const feeAmount = AmountMath.make(link.brand, 1000n);
     /**
      * @param {ExecutionContext} _t
      * @returns {Promise<OracleKit>}
@@ -151,7 +151,7 @@ test('single oracle', /** @param {ExecutionContext} t */ async t => {
   // Ensure our oracle handles $LINK.
   const overAmount = AmountMath.add(
     feeAmount,
-    AmountMath.make(799n, link.brand),
+    AmountMath.make(link.brand, 799n),
   );
   const offer3 = E(zoe).offer(
     invitation3,
@@ -183,7 +183,7 @@ test('single oracle', /** @param {ExecutionContext} t */ async t => {
   const offer2 = E(zoe).offer(invitation2);
 
   // Check the underpaid result.
-  const underAmount = AmountMath.make(500n, link.brand);
+  const underAmount = AmountMath.make(link.brand, 500n);
   const offer4 = E(zoe).offer(
     invitation4,
     harden({ give: { Fee: underAmount } }),
@@ -203,7 +203,7 @@ test('single oracle', /** @param {ExecutionContext} t */ async t => {
   const withdrawOffer = E(zoe).offer(
     withdrawSome,
     harden({
-      want: { Fee: AmountMath.make(201n, link.brand) },
+      want: { Fee: AmountMath.make(link.brand, 201n) },
     }),
   );
   t.is(await E(withdrawOffer).getOfferResult(), 'Successfully withdrawn');
@@ -222,7 +222,7 @@ test('single oracle', /** @param {ExecutionContext} t */ async t => {
       ),
     )
     .then(kvals => {
-      t.deepEqual(kvals, [['Fee', AmountMath.make(799n, link.brand)]]);
+      t.deepEqual(kvals, [['Fee', AmountMath.make(link.brand, 799n)]]);
     });
 
   const badInvitation = E(publicFacet).makeQueryInvitation({
@@ -243,6 +243,6 @@ test('single oracle', /** @param {ExecutionContext} t */ async t => {
 
   t.deepEqual(
     await link.issuer.getAmountOf(E(withdrawOffer).getPayout('Fee')),
-    AmountMath.make(201n, link.brand),
+    AmountMath.make(link.brand, 201n),
   );
 });

--- a/packages/zoe/test/unitTests/contracts/test-otcDesk.js
+++ b/packages/zoe/test/unitTests/contracts/test-otcDesk.js
@@ -69,9 +69,9 @@ const makeAlice = async (
       });
       const proposal = harden({
         give: {
-          Moola: moola(10000),
-          Simolean: simoleans(10000),
-          Buck: bucks(10000),
+          Moola: moola(10000n),
+          Simolean: simoleans(10000n),
+          Buck: bucks(10000n),
         },
       });
       const payments = {
@@ -142,22 +142,22 @@ const makeBob = (
       );
       t.deepEqual(
         invitationValue.underlyingAssets,
-        { Moola: moola(3) },
+        { Moola: moola(3n) },
         `bob will get 3 moola`,
       );
       t.deepEqual(
         invitationValue.strikePrice,
-        { Simolean: simoleans(4) },
+        { Simolean: simoleans(4n) },
         `bob must give 4 simoleans`,
       );
 
       // Bob can use whatever keywords he wants
       const proposal = harden({
-        give: { Whatever1: simoleans(4) },
-        want: { Whatever2: moola(3) },
+        give: { Whatever1: simoleans(4n) },
+        want: { Whatever2: moola(3n) },
         exit: { onDemand: null },
       });
-      const simoleanPayment1 = simoleanPurse.withdraw(simoleans(4));
+      const simoleanPayment1 = simoleanPurse.withdraw(simoleans(4n));
       const payments = { Whatever1: simoleanPayment1 };
 
       const seat = await E(zoe).offer(invitation, proposal, payments);
@@ -171,14 +171,14 @@ const makeBob = (
         t,
         moolaIssuer,
         E(seat).getPayout('Whatever2'),
-        moola(3),
+        moola(3n),
         'bob moola',
       );
       await assertPayoutAmount(
         t,
         simoleanIssuer,
         E(seat).getPayout('Whatever1'),
-        simoleans(0),
+        simoleans(0n),
         'bob simolean',
       );
     },
@@ -193,22 +193,22 @@ const makeBob = (
       );
       t.deepEqual(
         invitationValue.underlyingAssets,
-        { Moola: moola(3) },
+        { Moola: moola(3n) },
         `bob will get 3 moola`,
       );
       t.deepEqual(
         invitationValue.strikePrice,
-        { Simolean: simoleans(4) },
+        { Simolean: simoleans(4n) },
         `bob must give 4 simoleans`,
       );
 
       // Bob can use whatever keywords he wants
       const proposal = harden({
-        give: { Whatever1: simoleans(4) },
-        want: { Whatever2: moola(3) },
+        give: { Whatever1: simoleans(4n) },
+        want: { Whatever2: moola(3n) },
         exit: { onDemand: null },
       });
-      const simoleanPayment1 = simoleanPurse.withdraw(simoleans(4));
+      const simoleanPayment1 = simoleanPurse.withdraw(simoleans(4n));
       const payments = { Whatever1: simoleanPayment1 };
 
       const offerExpiredSeat = await E(zoe).offer(
@@ -232,7 +232,7 @@ const makeBob = (
         t,
         simoleanIssuer,
         E(offerExpiredSeat).getPayout('Whatever1'),
-        simoleans(4),
+        simoleans(4n),
         'bob simolean',
       );
     },
@@ -247,23 +247,23 @@ const makeBob = (
       );
       t.deepEqual(
         invitationValue.underlyingAssets,
-        { Simolean: simoleans(15) },
+        { Simolean: simoleans(15n) },
         `bob will get 15 simoleans`,
       );
       t.deepEqual(
         invitationValue.strikePrice,
-        { Buck: bucks(500), Moola: moola(35) },
+        { Buck: bucks(500n), Moola: moola(35n) },
         `bob must give 500 bucks and 35 moola`,
       );
 
       // Bob can use whatever keywords he wants
       const proposal = harden({
-        give: { Whatever1: bucks(500), Whatever2: moola(35) },
-        want: { Whatever3: simoleans(16) },
+        give: { Whatever1: bucks(500n), Whatever2: moola(35n) },
+        want: { Whatever3: simoleans(16n) },
         exit: { onDemand: null },
       });
-      const bucks500Payment = bucksPurse.withdraw(bucks(500));
-      const moola35Payment = moolaPurse.withdraw(moola(35));
+      const bucks500Payment = bucksPurse.withdraw(bucks(500n));
+      const moola35Payment = moolaPurse.withdraw(moola(35n));
       const payments = {
         Whatever1: bucks500Payment,
         Whatever2: moola35Payment,
@@ -280,21 +280,21 @@ const makeBob = (
         t,
         bucksIssuer,
         E(seat).getPayout('Whatever1'),
-        bucks(500),
+        bucks(500n),
         'bob bucks',
       );
       await assertPayoutAmount(
         t,
         moolaIssuer,
         E(seat).getPayout('Whatever2'),
-        moola(35),
+        moola(35n),
         'bob moola',
       );
       await assertPayoutAmount(
         t,
         simoleanIssuer,
         E(seat).getPayout('Whatever3'),
-        simoleans(0),
+        simoleans(0n),
         'bob simolean',
       );
     },
@@ -309,12 +309,12 @@ const makeBob = (
       );
       t.deepEqual(
         invitationValue.underlyingAssets,
-        { Simolean: simoleans(15) },
+        { Simolean: simoleans(15n) },
         `bob will get 15 simoleans`,
       );
       t.deepEqual(
         invitationValue.strikePrice,
-        { Buck: bucks(500), Moola: moola(35) },
+        { Buck: bucks(500n), Moola: moola(35n) },
         `bob must give 500 bucks and 35 moola`,
       );
 
@@ -324,12 +324,12 @@ const makeBob = (
 
       // Bob can use whatever keywords he wants
       const proposal = harden({
-        give: { Whatever1: bucks(500), Whatever2: moola(35) },
-        want: { Whatever3: simoleans(15) },
+        give: { Whatever1: bucks(500n), Whatever2: moola(35n) },
+        want: { Whatever3: simoleans(15n) },
         exit: { onDemand: null },
       });
-      const bucks500Payment = bucksPurse.withdraw(bucks(500));
-      const moola35Payment = moolaPurse.withdraw(moola(35));
+      const bucks500Payment = bucksPurse.withdraw(bucks(500n));
+      const moola35Payment = moolaPurse.withdraw(moola(35n));
       const payments = {
         Whatever1: bucks500Payment,
         Whatever2: moola35Payment,
@@ -348,21 +348,21 @@ const makeBob = (
         t,
         bucksIssuer,
         E(seat).getPayout('Whatever1'),
-        bucks(500),
+        bucks(500n),
         'bob bucks',
       );
       await assertPayoutAmount(
         t,
         moolaIssuer,
         E(seat).getPayout('Whatever2'),
-        moola(35),
+        moola(35n),
         'bob moola',
       );
       await assertPayoutAmount(
         t,
         simoleanIssuer,
         E(seat).getPayout('Whatever3'),
-        simoleans(0),
+        simoleans(0n),
         'bob simolean',
       );
     },
@@ -391,6 +391,13 @@ const issuers = {
   bucks,
 };
 
+/**
+ * @param {Value} moolaValue
+ * @param {Value} simoleanValue
+ * @param {Value} bucksValue
+ * @returns {{ moolaPayment: Payment, simoleanPayment: Payment,
+ * bucksPayment: Payment }}
+ */
 const makeInitialPayments = (moolaValue, simoleanValue, bucksValue) => ({
   moolaPayment: moolaKit.mint.mintPayment(moola(moolaValue)),
   simoleanPayment: simoleanKit.mint.mintPayment(simoleans(simoleanValue)),
@@ -403,7 +410,7 @@ test('zoe - otcDesk - offerOk', async t => {
   const coveredCallInstallation = await installCoveredCall(zoe);
 
   // Make Alice
-  const alicePayments = makeInitialPayments(10000, 10000, 10000);
+  const alicePayments = makeInitialPayments(10000n, 10000n, 10000n);
   const alice = await makeAlice(
     t,
     zoe,
@@ -414,7 +421,7 @@ test('zoe - otcDesk - offerOk', async t => {
   );
 
   // Make Bob
-  const bobPayments = makeInitialPayments(10000, 10000, 10000);
+  const bobPayments = makeInitialPayments(10000n, 10000n, 10000n);
   const bob = await makeBob(
     t,
     zoe,
@@ -436,14 +443,14 @@ test('zoe - otcDesk - offerOk', async t => {
 
   // Alice makes a custom quote for Bob
   const invitation1 = await alice.makeQuoteForBob(
-    { Simolean: simoleans(4) },
-    { Moola: moola(3) },
+    { Simolean: simoleans(4n) },
+    { Moola: moola(3n) },
     timer,
     1n,
   );
 
   await bob.offerOk(invitation1);
-  await alice.removeInventory(simoleans(2));
+  await alice.removeInventory(simoleans(2n));
 });
 
 test('zoe - otcDesk - offerExpired', async t => {
@@ -452,7 +459,7 @@ test('zoe - otcDesk - offerExpired', async t => {
   const coveredCallInstallation = await installCoveredCall(zoe);
 
   // Make Alice
-  const alicePayments = makeInitialPayments(10000, 10000, 10000);
+  const alicePayments = makeInitialPayments(10000n, 10000n, 10000n);
   const alice = await makeAlice(
     t,
     zoe,
@@ -463,7 +470,7 @@ test('zoe - otcDesk - offerExpired', async t => {
   );
 
   // Make Bob
-  const bobPayments = makeInitialPayments(10000, 10000, 10000);
+  const bobPayments = makeInitialPayments(10000n, 10000n, 10000n);
   const bob = await makeBob(
     t,
     zoe,
@@ -485,8 +492,8 @@ test('zoe - otcDesk - offerExpired', async t => {
 
   // Alice makes a custom quote for Bob
   const invitation2 = await alice.makeQuoteForBob(
-    { Simolean: simoleans(4) },
-    { Moola: moola(3) },
+    { Simolean: simoleans(4n) },
+    { Moola: moola(3n) },
     timer,
     1n,
   );
@@ -502,7 +509,7 @@ test('zoe - otcDesk - offerWantTooMuch', async t => {
   const coveredCallInstallation = await installCoveredCall(zoe);
 
   // Make Alice
-  const alicePayments = makeInitialPayments(10000, 10000, 10000);
+  const alicePayments = makeInitialPayments(10000n, 10000n, 10000n);
   const alice = await makeAlice(
     t,
     zoe,
@@ -513,7 +520,7 @@ test('zoe - otcDesk - offerWantTooMuch', async t => {
   );
 
   // Make Bob
-  const bobPayments = makeInitialPayments(10000, 10000, 10000);
+  const bobPayments = makeInitialPayments(10000n, 10000n, 10000n);
   const bob = await makeBob(
     t,
     zoe,
@@ -534,8 +541,8 @@ test('zoe - otcDesk - offerWantTooMuch', async t => {
   await alice.addInventory();
 
   const invitation3 = await alice.makeQuoteForBob(
-    { Buck: bucks(500), Moola: moola(35) },
-    { Simolean: simoleans(15) },
+    { Buck: bucks(500n), Moola: moola(35n) },
+    { Simolean: simoleans(15n) },
     timer,
     100n,
   );

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
@@ -128,7 +128,7 @@ test('median aggregator', /** @param {ExecutionContext} t */ async t => {
     timer: oracleTimer,
     brands: { In: brandIn, Out: brandOut },
     issuers: { Quote: quoteIssuer },
-    unitAmountIn = AmountMath.make(1n, brandIn),
+    unitAmountIn = AmountMath.make(brandIn, 1n),
   } = await E(zoe).getTerms(aggregator.instance);
 
   const price1000 = await makeFakePriceOracle(t, 1000n);
@@ -157,7 +157,7 @@ test('median aggregator', /** @param {ExecutionContext} t */ async t => {
     t.deepEqual(q, lastRec.value.quoteAmount);
     const [{ timestamp, timer, amountIn, amountOut }] = q.value;
     t.is(timer, oracleTimer);
-    const valueOut = AmountMath.getValue(amountOut, brandOut);
+    const valueOut = AmountMath.getValue(brandOut, amountOut);
 
     t.deepEqual(amountIn, unitAmountIn);
 
@@ -267,7 +267,7 @@ test('quoteAtTime', /** @param {ExecutionContext} t */ async t => {
 
   const quoteAtTime = E(pa).quoteAtTime(
     7n,
-    AmountMath.make(41n, brandIn),
+    AmountMath.make(brandIn, 41n),
     usdBrand,
   );
 
@@ -288,7 +288,7 @@ test('quoteAtTime', /** @param {ExecutionContext} t */ async t => {
     Far('wakeHandler', {
       async wake(_timestamp) {
         userQuotePK.resolve(
-          E(pa).quoteGiven(AmountMath.make(23n, brandIn), usdBrand),
+          E(pa).quoteGiven(AmountMath.make(brandIn, 23n), usdBrand),
         );
         await userQuotePK.promise;
       },
@@ -387,8 +387,8 @@ test('quoteWhen', /** @param {ExecutionContext} t */ async t => {
   const pa = E(aggregator.publicFacet).getPriceAuthority();
 
   const quoteWhenGTE = E(pa).quoteWhenGTE(
-    AmountMath.make(37n, brands.In),
-    AmountMath.make(1183n * 37n, brands.Out),
+    AmountMath.make(brands.In, 37n),
+    AmountMath.make(brands.Out, 1183n * 37n),
   );
 
   /** @type {PriceQuote | undefined} */
@@ -402,8 +402,8 @@ test('quoteWhen', /** @param {ExecutionContext} t */ async t => {
   );
 
   const quoteWhenLTE = E(pa).quoteWhenLTE(
-    AmountMath.make(29n, brands.In),
-    AmountMath.make(974n * 29n, brands.Out),
+    AmountMath.make(brands.In, 29n),
+    AmountMath.make(brands.Out, 974n * 29n),
   );
 
   /** @type {PriceQuote | undefined} */
@@ -506,8 +506,8 @@ test('mutableQuoteWhen no replacement', /** @param {ExecutionContext} t */ async
   const pa = E(aggregator.publicFacet).getPriceAuthority();
 
   const mutableQuoteWhenGTE = E(pa).mutableQuoteWhenGTE(
-    AmountMath.make(37n, brands.In),
-    AmountMath.make(1183n * 37n, brands.Out),
+    AmountMath.make(brands.In, 37n),
+    AmountMath.make(brands.Out, 1183n * 37n),
   );
 
   /** @type {PriceQuote | undefined} */
@@ -523,8 +523,8 @@ test('mutableQuoteWhen no replacement', /** @param {ExecutionContext} t */ async
     );
 
   const mutableQuoteWhenLTE = E(pa).mutableQuoteWhenLTE(
-    AmountMath.make(29n, brands.In),
-    AmountMath.make(974n * 29n, brands.Out),
+    AmountMath.make(brands.In, 29n),
+    AmountMath.make(brands.Out, 974n * 29n),
   );
 
   /** @type {PriceQuote | undefined} */
@@ -631,8 +631,8 @@ test('mutableQuoteWhen with update', /** @param {ExecutionContext} t */ async t 
   const pa = E(aggregator.publicFacet).getPriceAuthority();
 
   const mutableQuoteWhenGTE = E(pa).mutableQuoteWhenGTE(
-    AmountMath.make(25n, brands.In),
-    AmountMath.make(1240n * 25n, brands.Out),
+    AmountMath.make(brands.In, 25n),
+    AmountMath.make(brands.Out, 1240n * 25n),
   );
 
   /** @type {PriceQuote | undefined} */
@@ -654,8 +654,8 @@ test('mutableQuoteWhen with update', /** @param {ExecutionContext} t */ async t 
   await E(oracleTimer).tick();
 
   await E(mutableQuoteWhenGTE).updateLevel(
-    AmountMath.make(25n, brands.In),
-    AmountMath.make(1245n * 25n, brands.Out),
+    AmountMath.make(brands.In, 25n),
+    AmountMath.make(brands.Out, 1245n * 25n),
   );
 
   await E(oracleTimer).tick();
@@ -700,8 +700,8 @@ test('cancel mutableQuoteWhen', /** @param {ExecutionContext} t */ async t => {
   const pa = E(aggregator.publicFacet).getPriceAuthority();
 
   const mutableQuoteWhenGTE = E(pa).mutableQuoteWhenGTE(
-    AmountMath.make(25n, brands.In),
-    AmountMath.make(1240n * 25n, brands.Out),
+    AmountMath.make(brands.In, 25n),
+    AmountMath.make(brands.Out, 1240n * 25n),
   );
 
   /** @type {PriceQuote | undefined} */

--- a/packages/zoe/test/unitTests/contracts/test-secondPriceAuction.js
+++ b/packages/zoe/test/unitTests/contracts/test-secondPriceAuction.js
@@ -50,8 +50,8 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
       },
       offer: async sellInvitation => {
         const proposal = harden({
-          give: { Asset: moola(1) },
-          want: { Ask: simoleans(3) },
+          give: { Asset: moola(1n) },
+          want: { Ask: simoleans(3n) },
           exit: { waived: null },
         });
 
@@ -80,7 +80,7 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
           .then(amountDeposited =>
             t.deepEqual(
               amountDeposited,
-              simoleans(7),
+              simoleans(7n),
               `Alice got the second price bid, Carol's bid, even though Bob won`,
             ),
           );
@@ -109,12 +109,12 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
         );
         t.deepEqual(
           invitationValue.auctionedAssets,
-          moola(1),
+          moola(1n),
           `asset to be auctioned is 1 moola`,
         );
         t.deepEqual(
           invitationValue.minimumBid,
-          simoleans(3),
+          simoleans(3n),
           `minimum bid is 3 simoleans`,
         );
 
@@ -125,8 +125,8 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
         );
 
         const proposal = harden({
-          give: { Bid: simoleans(11) },
-          want: { Asset: moola(1) },
+          give: { Bid: simoleans(11n) },
+          want: { Asset: moola(1n) },
         });
         const payments = { Bid: simoleanPayment };
 
@@ -143,7 +143,7 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
           .getPayout('Asset')
           .then(moolaPurse.deposit)
           .then(amountDeposited =>
-            t.deepEqual(amountDeposited, moola(1), `Bob wins the auction`),
+            t.deepEqual(amountDeposited, moola(1n), `Bob wins the auction`),
           );
 
         await E(seat)
@@ -152,7 +152,7 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
           .then(amountDeposited =>
             t.deepEqual(
               amountDeposited,
-              simoleans(4),
+              simoleans(4n),
               `Bob gets the difference between the second-price bid (Carol's 7 simoleans) and his bid back`,
             ),
           );
@@ -170,7 +170,7 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
 
         const proposal = harden({
           give: { Bid: bidAmount },
-          want: { Asset: moola(1) },
+          want: { Asset: moola(1n) },
         });
         const payments = { Bid: simoleanPayment };
 
@@ -202,21 +202,21 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
 
   // Setup Alice
   const timer = buildManualTimer(console.log);
-  const alice = await makeAlice(timer, moolaKit.mint.mintPayment(moola(1)));
+  const alice = await makeAlice(timer, moolaKit.mint.mintPayment(moola(1n)));
   const installation = await alice.installCode();
 
   // Setup Bob, Carol, Dave
   const bob = makeBob(
     installation,
-    await simoleanKit.mint.mintPayment(simoleans(11)),
+    await simoleanKit.mint.mintPayment(simoleans(11n)),
   );
   const carol = makeLosingBidder(
-    simoleans(7),
-    await simoleanKit.mint.mintPayment(simoleans(7)),
+    simoleans(7n),
+    await simoleanKit.mint.mintPayment(simoleans(7n)),
   );
   const dave = makeLosingBidder(
-    simoleans(5),
-    await simoleanKit.mint.mintPayment(simoleans(5)),
+    simoleans(5n),
+    await simoleanKit.mint.mintPayment(simoleans(5n)),
   );
 
   const { creatorInvitation } = await alice.startInstance(installation);
@@ -250,17 +250,17 @@ test('zoe - secondPriceAuction - alice tries to exit', async t => {
   const zoe = E(zoeService).bindDefaultFeePurse(feePurse);
 
   // Setup Alice
-  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(1));
+  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(1n));
   const aliceMoolaPurse = moolaR.issuer.makeEmptyPurse();
   const aliceSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
 
   // Setup Bob
-  const bobSimoleanPayment = simoleanR.mint.mintPayment(simoleans(11));
+  const bobSimoleanPayment = simoleanR.mint.mintPayment(simoleans(11n));
   const bobMoolaPurse = moolaR.issuer.makeEmptyPurse();
   const bobSimoleanPurse = simoleanR.issuer.makeEmptyPurse();
 
   // Setup Carol
-  const carolSimoleanPayment = simoleanR.mint.mintPayment(simoleans(8));
+  const carolSimoleanPayment = simoleanR.mint.mintPayment(simoleans(8n));
 
   // Alice creates a secondPriceAuction instance
 
@@ -282,8 +282,8 @@ test('zoe - secondPriceAuction - alice tries to exit', async t => {
 
   // Alice escrows with zoe
   const aliceProposal = harden({
-    give: { Asset: moola(1) },
-    want: { Ask: simoleans(3) },
+    give: { Asset: moola(1n) },
+    want: { Ask: simoleans(3n) },
     exit: { waived: null },
   });
   const alicePayments = harden({ Asset: aliceMoolaPayment });
@@ -307,8 +307,8 @@ test('zoe - secondPriceAuction - alice tries to exit', async t => {
   // Alice gives Bob the invitation
 
   const bobProposal = harden({
-    want: { Asset: moola(1) },
-    give: { Bid: simoleans(11) },
+    want: { Asset: moola(1n) },
+    give: { Bid: simoleans(11n) },
   });
   const bobPayments = harden({ Bid: bobSimoleanPayment });
 
@@ -329,8 +329,8 @@ test('zoe - secondPriceAuction - alice tries to exit', async t => {
   const carolInvitation = await E(makeInvitationObj).makeBidInvitation();
 
   const carolProposal = harden({
-    want: { Asset: moola(1) },
-    give: { Bid: simoleans(8) },
+    want: { Asset: moola(1n) },
+    give: { Bid: simoleans(8n) },
   });
   const carolPayments = harden({ Bid: carolSimoleanPayment });
 
@@ -360,7 +360,7 @@ test('zoe - secondPriceAuction - alice tries to exit', async t => {
   // Alice got Carol's simoleans
   t.deepEqual(
     await simoleanR.issuer.getAmountOf(aliceSimoleanPayout),
-    simoleans(8),
+    simoleans(8n),
   );
 
   // Alice deposits her payout to ensure she can
@@ -380,10 +380,10 @@ test('zoe - secondPriceAuction - alice tries to exit', async t => {
 
   // Carol gets the assets and all her simoleans are taken to pay
   // Alice
-  t.deepEqual(await moolaR.issuer.getAmountOf(carolMoolaPayout), moola(1));
+  t.deepEqual(await moolaR.issuer.getAmountOf(carolMoolaPayout), moola(1n));
   t.deepEqual(
     await simoleanR.issuer.getAmountOf(carolSimoleanPayout),
-    simoleans(0),
+    simoleans(0n),
   );
 
   // Assert that the correct refunds were received.
@@ -413,17 +413,17 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
   const aliceMoolaPurse = moolaIssuer.makeEmptyPurse();
 
   // Setup Bob
-  const bobMoolaPayment = moolaMint.mintPayment(moola(11));
+  const bobMoolaPayment = moolaMint.mintPayment(moola(11n));
   const bobCcPurse = ccIssuer.makeEmptyPurse();
   const bobMoolaPurse = moolaIssuer.makeEmptyPurse();
 
   // Setup Carol
-  const carolMoolaPayment = moolaMint.mintPayment(moola(7));
+  const carolMoolaPayment = moolaMint.mintPayment(moola(7n));
   const carolCcPurse = ccIssuer.makeEmptyPurse();
   const carolMoolaPurse = moolaIssuer.makeEmptyPurse();
 
   // Setup Dave
-  const daveMoolaPayment = moolaMint.mintPayment(moola(5));
+  const daveMoolaPayment = moolaMint.mintPayment(moola(5n));
   const daveCcPurse = ccIssuer.makeEmptyPurse();
   const daveMoolaPurse = moolaIssuer.makeEmptyPurse();
 
@@ -448,7 +448,7 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
   // Alice escrows with zoe
   const aliceProposal = harden({
     give: { Asset: cryptoCats(harden(['Felix'])) },
-    want: { Ask: moola(3) },
+    want: { Ask: moola(3n) },
     exit: { waived: null },
   });
   const alicePayments = { Asset: aliceCcPayment };
@@ -474,7 +474,7 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
 
   t.is(bobInvitationValue.installation, installation, 'bobInstallationId');
   t.deepEqual(bobIssuers, { Asset: ccIssuer, Ask: moolaIssuer }, 'bobIssuers');
-  t.deepEqual(bobInvitationValue.minimumBid, moola(3), 'minimumBid');
+  t.deepEqual(bobInvitationValue.minimumBid, moola(3n), 'minimumBid');
   t.deepEqual(
     bobInvitationValue.auctionedAssets,
     cryptoCats(harden(['Felix'])),
@@ -482,7 +482,7 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
   );
 
   const bobProposal = harden({
-    give: { Bid: moola(11) },
+    give: { Bid: moola(11n) },
     want: { Asset: cryptoCats(harden(['Felix'])) },
   });
   const bobPayments = { Bid: bobMoolaPayment };
@@ -518,7 +518,7 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
     { Asset: ccIssuer, Ask: moolaIssuer },
     'carolIssuers',
   );
-  t.deepEqual(carolInvitationValue.minimumBid, moola(3), 'carolMinimumBid');
+  t.deepEqual(carolInvitationValue.minimumBid, moola(3n), 'carolMinimumBid');
   t.deepEqual(
     carolInvitationValue.auctionedAssets,
     cryptoCats(harden(['Felix'])),
@@ -526,7 +526,7 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
   );
 
   const carolProposal = harden({
-    give: { Bid: moola(7) },
+    give: { Bid: moola(7n) },
     want: { Asset: cryptoCats(harden(['Felix'])) },
   });
   const carolPayments = { Bid: carolMoolaPayment };
@@ -561,7 +561,7 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
     { Asset: ccIssuer, Ask: moolaIssuer },
     'daveIssuers',
   );
-  t.deepEqual(daveInvitationValue.minimumBid, moola(3), 'daveMinimumBid');
+  t.deepEqual(daveInvitationValue.minimumBid, moola(3n), 'daveMinimumBid');
   t.deepEqual(
     daveInvitationValue.auctionedAssets,
     cryptoCats(harden(['Felix'])),
@@ -569,7 +569,7 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
   );
 
   const daveProposal = harden({
-    give: { Bid: moola(5) },
+    give: { Bid: moola(5n) },
     want: { Asset: cryptoCats(harden(['Felix'])) },
   });
   const davePayments = { Bid: daveMoolaPayment };
@@ -629,7 +629,7 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
   );
   t.deepEqual(
     await moolaIssuer.getAmountOf(bobMoolaPayout),
-    moola(4),
+    moola(4n),
     `bob gets difference back`,
   );
 

--- a/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
+++ b/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
@@ -35,10 +35,10 @@ test('simpleExchange with valid offers', async t => {
   const installation = await installationPFromSource(zoe, simpleExchange);
 
   // Setup Alice
-  const aliceMoolaPayment = moolaMint.mintPayment(moola(3));
+  const aliceMoolaPayment = moolaMint.mintPayment(moola(3n));
 
   // Setup Bob
-  const bobSimoleanPayment = simoleanMint.mintPayment(simoleans(7));
+  const bobSimoleanPayment = simoleanMint.mintPayment(simoleans(7n));
 
   // 1: Alice creates a simpleExchange instance and spreads the publicFacet far
   // and wide with instructions on how to call makeInvitation().
@@ -77,8 +77,8 @@ test('simpleExchange with valid offers', async t => {
   // sell 3 moola and wants to receive at least 4 simoleans in
   // return.
   const aliceSellOrderProposal = harden({
-    give: { Asset: moola(3) },
-    want: { Price: simoleans(4) },
+    give: { Asset: moola(3n) },
+    want: { Price: simoleans(4n) },
     exit: { onDemand: null },
   });
   const alicePayments = { Asset: aliceMoolaPayment };
@@ -135,8 +135,8 @@ test('simpleExchange with valid offers', async t => {
   // Bob creates a buy order, saying that he wants exactly 3 moola,
   // and is willing to pay up to 7 simoleans.
   const bobBuyOrderProposal = harden({
-    give: { Price: simoleans(7) },
-    want: { Asset: moola(3) },
+    give: { Price: simoleans(7n) },
+    want: { Asset: moola(3n) },
     exit: { onDemand: null },
   });
   const bobPayments = { Price: bobSimoleanPayment };
@@ -187,13 +187,23 @@ test('simpleExchange with valid offers', async t => {
     part1,
     // 6: Alice deposits her payout to ensure she can
     // Alice had 0 moola and 4 simoleans.
-    assertPayoutAmount(t, moolaIssuer, aliceMoolaPayout, moola(0n)),
-    assertPayoutAmount(t, simoleanIssuer, aliceSimoleanPayout, simoleans(4)),
+    await assertPayoutAmount(t, moolaIssuer, aliceMoolaPayout, moola(0n)),
+    await assertPayoutAmount(
+      t,
+      simoleanIssuer,
+      aliceSimoleanPayout,
+      simoleans(4n),
+    ),
 
     // 7: Bob deposits his original payments to ensure he can
     // Bob had 3 moola and 3 simoleans.
-    assertPayoutAmount(t, moolaIssuer, bobMoolaPayout, moola(3)),
-    assertPayoutAmount(t, simoleanIssuer, bobSimoleanPayout, simoleans(3)),
+    await assertPayoutAmount(t, moolaIssuer, bobMoolaPayout, moola(3n)),
+    await assertPayoutAmount(
+      t,
+      simoleanIssuer,
+      bobSimoleanPayout,
+      simoleans(3n),
+    ),
   ]);
 });
 
@@ -211,8 +221,8 @@ test('simpleExchange with multiple sell offers', async t => {
   const installation = await installationPFromSource(zoe, simpleExchange);
 
   // Setup Alice
-  const aliceMoolaPayment = moolaMint.mintPayment(moola(30));
-  const aliceSimoleanPayment = simoleanMint.mintPayment(simoleans(30));
+  const aliceMoolaPayment = moolaMint.mintPayment(moola(30n));
+  const aliceSimoleanPayment = simoleanMint.mintPayment(simoleans(30n));
   const aliceMoolaPurse = moolaIssuer.makeEmptyPurse();
   const aliceSimoleanPurse = simoleanIssuer.makeEmptyPurse();
   await aliceMoolaPurse.deposit(aliceMoolaPayment);
@@ -229,12 +239,12 @@ test('simpleExchange with multiple sell offers', async t => {
   // sell 3 moola and wants to receive at least 4 simoleans in
   // return.
   const aliceSale1OrderProposal = harden({
-    give: { Asset: moola(3) },
-    want: { Price: simoleans(4) },
+    give: { Asset: moola(3n) },
+    want: { Price: simoleans(4n) },
     exit: { onDemand: null },
   });
 
-  const alicePayments = { Asset: aliceMoolaPurse.withdraw(moola(3)) };
+  const alicePayments = { Asset: aliceMoolaPurse.withdraw(moola(3n)) };
 
   const aliceInvitation1 = E(publicFacet).makeInvitation();
   // 4: Alice adds her sell order to the exchange
@@ -249,12 +259,12 @@ test('simpleExchange with multiple sell offers', async t => {
     await E(publicFacet).makeInvitation(),
   );
   const aliceSale2OrderProposal = harden({
-    give: { Asset: moola(5) },
-    want: { Price: simoleans(8) },
+    give: { Asset: moola(5n) },
+    want: { Price: simoleans(8n) },
     exit: { onDemand: null },
   });
   const proposal2 = {
-    Asset: aliceMoolaPurse.withdraw(moola(5)),
+    Asset: aliceMoolaPurse.withdraw(moola(5n)),
   };
   const aliceSeat2 = await E(zoe).offer(
     aliceInvitation2,
@@ -267,11 +277,11 @@ test('simpleExchange with multiple sell offers', async t => {
     await E(publicFacet).makeInvitation(),
   );
   const aliceBuyOrderProposal = harden({
-    give: { Price: simoleans(18) },
-    want: { Asset: moola(29) },
+    give: { Price: simoleans(18n) },
+    want: { Asset: moola(29n) },
     exit: { onDemand: null },
   });
-  const proposal3 = { Price: aliceSimoleanPurse.withdraw(simoleans(18)) };
+  const proposal3 = { Price: aliceSimoleanPurse.withdraw(simoleans(18n)) };
   const aliceSeat3 = await E(zoe).offer(
     aliceInvitation3,
     aliceBuyOrderProposal,
@@ -284,10 +294,10 @@ test('simpleExchange with multiple sell offers', async t => {
     aliceSeat3.getOfferResult(),
   ]).then(async () => {
     const expectedBook = {
-      buys: [{ want: { Asset: moola(29) }, give: { Price: simoleans(18) } }],
+      buys: [{ want: { Asset: moola(29n) }, give: { Price: simoleans(18n) } }],
       sells: [
-        { want: { Price: simoleans(4) }, give: { Asset: moola(3) } },
-        { want: { Price: simoleans(8) }, give: { Asset: moola(5) } },
+        { want: { Price: simoleans(4n) }, give: { Asset: moola(3n) } },
+        { want: { Price: simoleans(8n) }, give: { Asset: moola(5n) } },
       ],
     };
     t.deepEqual(

--- a/packages/zoe/test/unitTests/contracts/test-useObj.js
+++ b/packages/zoe/test/unitTests/contracts/test-useObj.js
@@ -30,7 +30,7 @@ test('zoe - useObj', async t => {
   const installation = await E(zoe).install(bundle);
 
   // Setup Alice
-  const aliceMoolaPayment = moolaMint.mintPayment(moola(3));
+  const aliceMoolaPayment = moolaMint.mintPayment(moola(3n));
 
   // Alice creates an instance
   const issuerKeywordRecord = harden({
@@ -45,7 +45,7 @@ test('zoe - useObj', async t => {
 
   // Alice escrows with zoe
   const aliceProposal = harden({
-    give: { Pixels: moola(3) },
+    give: { Pixels: moola(3n) },
   });
   const alicePayments = { Pixels: aliceMoolaPayment };
 
@@ -70,7 +70,7 @@ test('zoe - useObj', async t => {
 
   t.deepEqual(
     await moolaIssuer.getAmountOf(aliceMoolaPayoutPayment),
-    moola(3),
+    moola(3n),
     `alice gets everything she escrowed back`,
   );
 

--- a/packages/zoe/test/unitTests/contracts/throwInOfferHandler.js
+++ b/packages/zoe/test/unitTests/contracts/throwInOfferHandler.js
@@ -19,7 +19,7 @@ const start = zcf => {
 
   const throwInDepositToSeat = async seat => {
     const issuerKit = makeIssuerKit('token');
-    const tokens10 = AmountMath.make(10n, issuerKit.brand);
+    const tokens10 = AmountMath.make(issuerKit.brand, 10n);
     const payment = issuerKit.mint.mintPayment(tokens10);
     const amounts = harden({ Token: tokens10 });
     const payments = harden({ Tokens: payment });

--- a/packages/zoe/test/unitTests/contracts/vpool-xyk-amm/test-amm-governance.js
+++ b/packages/zoe/test/unitTests/contracts/vpool-xyk-amm/test-amm-governance.js
@@ -253,9 +253,9 @@ test('price check after Governance param change', async t => {
   } = await setupServices(electorateTerms, ammTerms, centralR, timer);
 
   // Setup Alice
-  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(100000));
+  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(100000n));
   // Let's assume that central tokens are worth 2x as much as moola
-  const aliceCentralPayment = centralR.mint.mintPayment(centralTokens(50000));
+  const aliceCentralPayment = centralR.mint.mintPayment(centralTokens(50000n));
 
   const aliceAddLiquidityInvitation = E(
     amm.ammPublicFacet,
@@ -269,8 +269,8 @@ test('price check after Governance param change', async t => {
   const moolaLiquidity = value => AmountMath.make(moolaLiquidityBrand, value);
 
   const aliceProposal = harden({
-    want: { Liquidity: moolaLiquidity(50000) },
-    give: { Secondary: moola(100000), Central: centralTokens(50000) },
+    want: { Liquidity: moolaLiquidity(50000n) },
+    give: { Secondary: moola(100000n), Central: centralTokens(50000n) },
   });
   const alicePayments = {
     Secondary: aliceMoolaPayment,
@@ -291,7 +291,7 @@ test('price check after Governance param change', async t => {
 
   // look up the price of 17000 moola in central tokens
   const priceInCentrals = await E(amm.ammPublicFacet).getInputPrice(
-    moola(17000),
+    moola(17000n),
     AmountMath.makeEmpty(centralR.brand),
   );
 
@@ -339,7 +339,7 @@ test('price check after Governance param change', async t => {
   t.deepEqual(paramValue, 20n, 'updated value');
 
   const priceAfter = await E(amm.ammPublicFacet).getInputPrice(
-    moola(17000),
+    moola(17000n),
     AmountMath.makeEmpty(centralR.brand),
   );
 

--- a/packages/zoe/test/unitTests/contracts/vpool-xyk-amm/test-xyk-amm-swap.js
+++ b/packages/zoe/test/unitTests/contracts/vpool-xyk-amm/test-xyk-amm-swap.js
@@ -188,6 +188,7 @@ const ammInitialValues = harden([
 test('amm with valid offers', async t => {
   // Set up central token
   const centralR = makeIssuerKit('central');
+  /** @param {NatValue} value */
   const centralTokens = value => AmountMath.make(centralR.brand, value);
   const moolaR = makeIssuerKit('moola');
   const moola = value => AmountMath.make(moolaR.brand, value);
@@ -216,13 +217,13 @@ test('amm with valid offers', async t => {
   const invitationBrand = await E(invitationIssuer).getBrand();
 
   // Setup Alice
-  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(100000));
+  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(100000n));
   // Let's assume that central tokens are worth 2x as much as moola
-  const aliceCentralPayment = centralR.mint.mintPayment(centralTokens(50000));
-  const aliceSimoleanPayment = simoleanR.mint.mintPayment(simoleans(398));
+  const aliceCentralPayment = centralR.mint.mintPayment(centralTokens(50000n));
+  const aliceSimoleanPayment = simoleanR.mint.mintPayment(simoleans(398n));
 
   // Setup Bob
-  const bobMoolaPayment = moolaR.mint.mintPayment(moola(17000));
+  const bobMoolaPayment = moolaR.mint.mintPayment(moola(17000n));
 
   const aliceAddLiquidityInvitation = E(
     amm.ammPublicFacet,
@@ -256,6 +257,7 @@ test('amm with valid offers', async t => {
     'Moola',
   );
   const moolaLiquidityBrand = await E(moolaLiquidityIssuer).getBrand();
+  /** @param {NatValue} value */
   const moolaLiquidity = value => AmountMath.make(moolaLiquidityBrand, value);
 
   const simoleanLiquidityIssuer = await E(amm.ammPublicFacet).addPool(
@@ -298,8 +300,8 @@ test('amm with valid offers', async t => {
   // 10 moola = 5 central tokens at the time of the liquidity adding
   // aka 2 moola = 1 central token
   const aliceProposal = harden({
-    want: { Liquidity: moolaLiquidity(50000) },
-    give: { Secondary: moola(100000), Central: centralTokens(50000) },
+    want: { Liquidity: moolaLiquidity(50000n) },
+    give: { Secondary: moola(100000n), Central: centralTokens(50000n) },
   });
   const alicePayments = {
     Secondary: aliceMoolaPayment,
@@ -322,14 +324,14 @@ test('amm with valid offers', async t => {
 
   t.deepEqual(
     await E(moolaLiquidityIssuer).getAmountOf(liquidityPayout),
-    moolaLiquidity(50000),
+    moolaLiquidity(50000n),
   );
   t.deepEqual(
     await E(amm.ammPublicFacet).getPoolAllocation(moolaR.brand),
     harden({
-      Secondary: moola(100000),
-      Central: centralTokens(50000),
-      Liquidity: moolaLiquidity(0),
+      Secondary: moola(100000n),
+      Central: centralTokens(50000n),
+      Liquidity: moolaLiquidity(0n),
     }),
     `The poolAmounts record should contain the new liquidity`,
   );
@@ -351,7 +353,7 @@ test('amm with valid offers', async t => {
 
   // Bob looks up the price of 17000 moola in central tokens
   const { amountOut: priceInCentrals } = await E(bobPublicFacet).getInputPrice(
-    moola(17000),
+    moola(17000n),
     AmountMath.makeEmpty(centralR.brand),
   );
 
@@ -359,7 +361,7 @@ test('amm with valid offers', async t => {
 
   const bobMoolaForCentralProposal = harden({
     want: { Out: priceInCentrals },
-    give: { In: moola(17000) },
+    give: { In: moola(17000n) },
   });
   const bobMoolaForCentralPayments = harden({ In: bobMoolaPayment });
 
@@ -377,7 +379,7 @@ test('amm with valid offers', async t => {
   });
 
   const quoteGivenBob = await E(priceAuthority).quoteGiven(
-    moola(5000),
+    moola(5000n),
     centralR.brand,
   );
   assertAmountsEqual(
@@ -401,15 +403,15 @@ test('amm with valid offers', async t => {
   assertAmountsEqual(
     t,
     await E(centralR.issuer).getAmountOf(bobCentralPayout1),
-    centralTokens(7241),
+    centralTokens(7241n),
     `bob gets the same price as when he called the getInputPrice method`,
   );
   t.deepEqual(
     await E(bobPublicFacet).getPoolAllocation(moolaR.brand),
     {
-      Secondary: moola(117000 - 2),
-      Central: centralTokens(42750 + 4),
-      Liquidity: moolaLiquidity(0),
+      Secondary: moola(117000n - 2n),
+      Central: centralTokens(42750n + 4n),
+      Liquidity: moolaLiquidity(0n),
     },
     `pool allocation added the moola and subtracted the central tokens`,
   );
@@ -419,14 +421,14 @@ test('amm with valid offers', async t => {
 
   // Bob looks up the price of 700 central tokens in moola
   const priceFor700 = await E(bobPublicFacet).getInputPrice(
-    centralTokens(700),
+    centralTokens(700n),
     AmountMath.makeEmpty(moolaR.brand),
   );
   t.deepEqual(
     priceFor700,
     {
-      amountOut: moola(1877),
-      amountIn: centralTokens(700),
+      amountOut: moola(1877n),
+      amountIn: centralTokens(700n),
     },
     `the fee was one moola over the two trades`,
   );
@@ -434,11 +436,11 @@ test('amm with valid offers', async t => {
   // Bob makes another offer and swaps
   const bobSwapInvitation2 = await E(bobPublicFacet).makeSwapInInvitation();
   const bobCentralForMoolaProposal = harden({
-    want: { Out: moola(1877) },
-    give: { In: centralTokens(700) },
+    want: { Out: moola(1877n) },
+    give: { In: centralTokens(700n) },
   });
   const centralForMoolaPayments = harden({
-    In: await E(bobCentralPurse).withdraw(centralTokens(700)),
+    In: await E(bobCentralPurse).withdraw(centralTokens(700n)),
   });
 
   const bobSeat2 = await E(zoe).offer(
@@ -449,7 +451,7 @@ test('amm with valid offers', async t => {
 
   runningFees = AmountMath.add(
     runningFees,
-    ceilMultiplyBy(centralTokens(700), protocolFeeRatio),
+    ceilMultiplyBy(centralTokens(700n), protocolFeeRatio),
   );
   t.deepEqual(await E(amm.ammPublicFacet).getProtocolPoolBalance(), {
     RUN: runningFees,
@@ -462,7 +464,7 @@ test('amm with valid offers', async t => {
   );
 
   const quoteBob2 = await E(priceAuthority).quoteGiven(
-    moola(5000),
+    moola(5000n),
     centralR.brand,
   );
   assertAmountsEqual(
@@ -476,20 +478,20 @@ test('amm with valid offers', async t => {
 
   t.deepEqual(
     await E(moolaR.issuer).getAmountOf(bobMoolaPayout2),
-    moola(1877),
+    moola(1877n),
     `bob gets 1877 moola back`,
   );
   t.deepEqual(
     await E(centralR.issuer).getAmountOf(bobCentralPayout2),
-    centralTokens(0),
+    centralTokens(0n),
     `bob gets no central tokens back`,
   );
   t.deepEqual(
     await E(bobPublicFacet).getPoolAllocation(moolaR.brand),
     {
-      Secondary: moola(115121),
-      Central: centralTokens(43453),
-      Liquidity: moolaLiquidity(0),
+      Secondary: moola(115121n),
+      Central: centralTokens(43453n),
+      Liquidity: moolaLiquidity(0n),
     },
     `fee added to liquidity pool`,
   );
@@ -502,11 +504,11 @@ test('amm with valid offers', async t => {
     amm.ammPublicFacet,
   ).makeAddLiquidityInvitation();
   const aliceSimCentralProposal = harden({
-    want: { Liquidity: simoleanLiquidity(43) },
-    give: { Secondary: simoleans(398), Central: centralTokens(43) },
+    want: { Liquidity: simoleanLiquidity(43n) },
+    give: { Secondary: simoleans(398n), Central: centralTokens(43n) },
   });
   const aliceCentralPayment2 = await centralR.mint.mintPayment(
-    centralTokens(43),
+    centralTokens(43n),
   );
   const aliceSimCentralPayments = {
     Secondary: aliceSimoleanPayment,
@@ -520,7 +522,7 @@ test('amm with valid offers', async t => {
   );
 
   const quoteLiquidation2 = await E(priceAuthority).quoteGiven(
-    moola(5000),
+    moola(5000n),
     centralR.brand,
   );
   // a simolean trade had no effect on moola prices
@@ -539,15 +541,15 @@ test('amm with valid offers', async t => {
 
   t.deepEqual(
     await E(simoleanLiquidityIssuer).getAmountOf(simoleanLiquidityPayout),
-    simoleanLiquidity(43),
+    simoleanLiquidity(43n),
     `simoleanLiquidity minted was equal to the amount of central tokens added to pool`,
   );
   t.deepEqual(
     await E(amm.ammPublicFacet).getPoolAllocation(simoleanR.brand),
     harden({
-      Secondary: simoleans(398),
-      Central: centralTokens(43),
-      Liquidity: simoleanLiquidity(0),
+      Secondary: simoleans(398n),
+      Central: centralTokens(43n),
+      Liquidity: simoleanLiquidity(0n),
     }),
     `The poolAmounts record should contain the new liquidity`,
   );
@@ -581,14 +583,14 @@ test('amm doubleSwap', async t => {
   );
 
   // Setup Alice
-  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(100000));
+  const aliceMoolaPayment = moolaR.mint.mintPayment(moola(100000n));
   // Let's assume that central tokens are worth 2x as much as moola
-  const aliceCentralPayment = centralR.mint.mintPayment(centralTokens(50000));
-  const aliceSimoleanPayment = simoleanR.mint.mintPayment(simoleans(39800));
+  const aliceCentralPayment = centralR.mint.mintPayment(centralTokens(50000n));
+  const aliceSimoleanPayment = simoleanR.mint.mintPayment(simoleans(39800n));
 
   // Setup Bob
-  const bobSimoleanPayment = simoleanR.mint.mintPayment(simoleans(4000));
-  const bobMoolaPayment = moolaR.mint.mintPayment(moola(5000));
+  const bobSimoleanPayment = simoleanR.mint.mintPayment(simoleans(4000n));
+  const bobMoolaPayment = moolaR.mint.mintPayment(moola(5000n));
 
   const ammInstance = await amm.instance;
 
@@ -639,8 +641,8 @@ test('amm doubleSwap', async t => {
   // 10 moola = 5 central tokens at the time of the liquidity adding
   // aka 2 moola = 1 central token
   const aliceProposal = harden({
-    want: { Liquidity: moolaLiquidity(50000) },
-    give: { Secondary: moola(100000), Central: centralTokens(50000) },
+    want: { Liquidity: moolaLiquidity(50000n) },
+    give: { Secondary: moola(100000n), Central: centralTokens(50000n) },
   });
   const alicePayments = {
     Secondary: aliceMoolaPayment,
@@ -668,11 +670,11 @@ test('amm doubleSwap', async t => {
     amm.ammPublicFacet,
   ).makeAddLiquidityInvitation();
   const aliceSimCentralProposal = harden({
-    want: { Liquidity: simoleanLiquidity(430) },
-    give: { Secondary: simoleans(39800), Central: centralTokens(43000) },
+    want: { Liquidity: simoleanLiquidity(430n) },
+    give: { Secondary: simoleans(39800n), Central: centralTokens(43000n) },
   });
   const aliceCentralPayment2 = await centralR.mint.mintPayment(
-    centralTokens(43000),
+    centralTokens(43000n),
   );
   const aliceSimCentralPayments = {
     Secondary: aliceSimoleanPayment,
@@ -695,14 +697,14 @@ test('amm doubleSwap', async t => {
 
   // Bob looks up the value of 4000 simoleans in moola
   const { amountOut: priceInMoola } = await E(amm.ammPublicFacet).getInputPrice(
-    simoleans(4000),
+    simoleans(4000n),
     AmountMath.makeEmpty(moolaR.brand),
   );
 
   const bobInvitation = await E(amm.ammPublicFacet).makeSwapInInvitation();
   const bobSimsForMoolaProposal = harden({
     want: { Out: priceInMoola },
-    give: { In: simoleans(4000) },
+    give: { In: simoleans(4000n) },
   });
   const simsForMoolaPayments = harden({
     In: bobSimoleanPayment,
@@ -719,7 +721,7 @@ test('amm doubleSwap', async t => {
 
   t.deepEqual(
     await moolaR.issuer.getAmountOf(bobMoolaPayout),
-    moola(7234),
+    moola(7234n),
     `bob gets 7234 moola`,
   );
 
@@ -733,12 +735,12 @@ test('amm doubleSwap', async t => {
   // Bob looks up the value of 5000 moola in simoleans
   const { amountOut: priceInSimoleans } = await E(
     amm.ammPublicFacet,
-  ).getInputPrice(moola(5000), AmountMath.makeEmpty(simoleanR.brand));
+  ).getInputPrice(moola(5000n), AmountMath.makeEmpty(simoleanR.brand));
 
   const bobInvitation2 = await E(amm.ammPublicFacet).makeSwapInInvitation();
   const bobMoolaForSimsProposal = harden({
     want: { Out: priceInSimoleans },
-    give: { In: moola(5000) },
+    give: { In: moola(5000n) },
   });
   const moolaForSimsPayments = harden({
     In: bobMoolaPayment,
@@ -753,7 +755,7 @@ test('amm doubleSwap', async t => {
 
   t.deepEqual(
     await simoleanR.issuer.getAmountOf(bobSimoleanPayout),
-    simoleans(2868),
+    simoleans(2868n),
     `bob gets 2880 simoleans`,
   );
 
@@ -811,7 +813,7 @@ test('amm with some invalid offers', async t => {
   const invitationIssuer = await E(zoe).getInvitationIssuer();
 
   // Setup Bob
-  const bobMoolaPayment = moolaR.mint.mintPayment(moola(17));
+  const bobMoolaPayment = moolaR.mint.mintPayment(moola(17n));
 
   await E(amm.ammPublicFacet).addPool(moolaR.issuer, 'Moola');
   // Bob creates a swap invitation for himself
@@ -825,7 +827,7 @@ test('amm with some invalid offers', async t => {
   await t.throwsAsync(
     () =>
       E(bobPublicFacet).getInputPrice(
-        moola(5),
+        moola(5n),
         AmountMath.makeEmpty(centralR.brand),
       ),
     {
@@ -837,8 +839,8 @@ test('amm with some invalid offers', async t => {
 
   // Bob tries to trade anyway.
   const bobMoolaForCentralProposal = harden({
-    want: { Out: centralTokens(7) },
-    give: { In: moola(17) },
+    want: { Out: centralTokens(7n) },
+    give: { In: moola(17n) },
   });
   const bobMoolaForCentralPayments = harden({ In: bobMoolaPayment });
 
@@ -888,13 +890,13 @@ test('amm jig - swapOut uneven', async t => {
   );
 
   // set up purses
-  const centralPayment = centralR.mint.mintPayment(centralTokens(30000000));
+  const centralPayment = centralR.mint.mintPayment(centralTokens(30000000n));
   const centralPurse = centralR.issuer.makeEmptyPurse();
   await centralPurse.deposit(centralPayment);
   const moolaPurse = moolaR.issuer.makeEmptyPurse();
-  moolaPurse.deposit(moolaR.mint.mintPayment(moola(20000000)));
+  moolaPurse.deposit(moolaR.mint.mintPayment(moola(20000000n)));
   const simoleanPurse = simoleanR.issuer.makeEmptyPurse();
-  simoleanPurse.deposit(simoleanR.mint.mintPayment(simoleans(20000000)));
+  simoleanPurse.deposit(simoleanR.mint.mintPayment(simoleans(20000000n)));
 
   /** @type {XYKAMMPublicFacet} */
   const publicFacet = amm.ammPublicFacet;
@@ -937,12 +939,12 @@ test('amm jig - swapOut uneven', async t => {
 
   // this test uses twice as much Central as Moola to make the price difference
   // more visible.
-  const initMoolaLiquidityDetails = {
-    cAmount: centralTokens(10000000),
-    sAmount: moola(5000000),
-    lAmount: moolaLiquidity(10000000),
+  const initmoolaLiquidityDetails = {
+    cAmount: centralTokens(10000000n),
+    sAmount: moola(5000000n),
+    lAmount: moolaLiquidity(10000000n),
   };
-  const initMoolaLiquidityExpected = {
+  const initmoolaLiquidityExpected = {
     c: 10000000n,
     s: 5000000n,
     l: 10000000n,
@@ -954,11 +956,11 @@ test('amm jig - swapOut uneven', async t => {
   await alice.initLiquidityAndCheck(
     t,
     mPoolState,
-    initMoolaLiquidityDetails,
-    initMoolaLiquidityExpected,
+    initmoolaLiquidityDetails,
+    initmoolaLiquidityExpected,
     mIssuerKeywordRecord,
   );
-  mPoolState = updatePoolState(mPoolState, initMoolaLiquidityExpected);
+  mPoolState = updatePoolState(mPoolState, initmoolaLiquidityExpected);
 
   let sPoolState = {
     c: 0n,
@@ -966,10 +968,10 @@ test('amm jig - swapOut uneven', async t => {
     l: 0n,
     k: 0n,
   };
-  const initSimoleanLiquidityDetails = {
-    cAmount: centralTokens(10000000),
-    sAmount: simoleans(10000000),
-    lAmount: simoleanLiquidity(10000000),
+  const initsimoleanLiquidityDetails = {
+    cAmount: centralTokens(10000000n),
+    sAmount: simoleans(10000000n),
+    lAmount: simoleanLiquidity(10000000n),
   };
   const initSimLiqExpected = {
     c: 10000000n,
@@ -988,7 +990,7 @@ test('amm jig - swapOut uneven', async t => {
   await alice.initLiquidityAndCheck(
     t,
     sPoolState,
-    initSimoleanLiquidityDetails,
+    initsimoleanLiquidityDetails,
     initSimLiqExpected,
     sIssuerKeywordRecord,
   );
@@ -1170,12 +1172,12 @@ test('amm jig - breaking scenario', async t => {
     k: 0n,
   };
 
-  const initMoolaLiquidityDetails = {
+  const initmoolaLiquidityDetails = {
     cAmount: centralTokens(50825056949339n),
     sAmount: moola(2196247730468n),
     lAmount: moolaLiquidity(50825056949339n),
   };
-  const initMoolaLiquidityExpected = {
+  const initmoolaLiquidityExpected = {
     c: 50825056949339n,
     s: 2196247730468n,
     l: 50825056949339n,
@@ -1187,11 +1189,11 @@ test('amm jig - breaking scenario', async t => {
   await alice.initLiquidityAndCheck(
     t,
     mPoolState,
-    initMoolaLiquidityDetails,
-    initMoolaLiquidityExpected,
+    initmoolaLiquidityDetails,
+    initmoolaLiquidityExpected,
     mIssuerKeywordRecord,
   );
-  mPoolState = updatePoolState(mPoolState, initMoolaLiquidityExpected);
+  mPoolState = updatePoolState(mPoolState, initmoolaLiquidityExpected);
 
   t.deepEqual(await E(publicFacet).getProtocolPoolBalance(), {});
 

--- a/packages/zoe/test/unitTests/makeOffer.js
+++ b/packages/zoe/test/unitTests/makeOffer.js
@@ -4,7 +4,7 @@ import { E } from '@agoric/eventual-send';
 import { assert } from '@agoric/assert';
 
 /**
- * @param {ZoeService} zoe
+ * @param {ERef<ZoeService>} zoe
  * @param {ContractFacet} zcf
  * @param {Proposal=} proposal
  * @param {PaymentPKeywordRecord=} payments

--- a/packages/zoe/test/unitTests/setupBasicMints.js
+++ b/packages/zoe/test/unitTests/setupBasicMints.js
@@ -26,7 +26,8 @@ const setup = () => {
   const feePurse = E(zoeService).makeFeePurse();
   const zoe = E(zoeService).bindDefaultFeePurse(feePurse);
 
-  const makeSimpleMake = brand => value => AmountMath.make(value, brand);
+  /** @type {(brand: Brand) => (value: Value) => Amount} */
+  const makeSimpleMake = brand => value => AmountMath.make(brand, value);
 
   /**
    * @typedef {Object} BasicMints
@@ -43,9 +44,9 @@ const setup = () => {
    * @property {IssuerKit} bucksR
    * @property {IssuerKit} bucksKit
    * @property {Store<string, Brand>} brands
-   * @property {(value: any) => Amount} moola
-   * @property {(value: any) => Amount} simoleans
-   * @property {(value: any) => Amount} bucks
+   * @property {(value: Value) => Amount} moola
+   * @property {(value: Value) => Amount} simoleans
+   * @property {(value: Value) => Amount} bucks
    * @property {ERef<ZoeService>} zoe
    */
 

--- a/packages/zoe/test/unitTests/setupMixedMints.js
+++ b/packages/zoe/test/unitTests/setupMixedMints.js
@@ -23,8 +23,8 @@ const setupMixed = () => {
   const moolaIssuer = issuers.get('moola');
   const ccMint = mints.get('cc');
   const moolaMint = mints.get('moola');
-  const cryptoCats = value => AmountMath.make(value, allBundles.cc.brand);
-  const moola = value => AmountMath.make(value, allBundles.moola.brand);
+  const cryptoCats = value => AmountMath.make(allBundles.cc.brand, value);
+  const moola = value => AmountMath.make(allBundles.moola.brand, value);
 
   const { zoeService } = makeZoeKit(fakeVatAdmin);
   const feePurse = E(zoeService).makeFeePurse();

--- a/packages/zoe/test/unitTests/setupNonFungibleMints.js
+++ b/packages/zoe/test/unitTests/setupNonFungibleMints.js
@@ -9,8 +9,11 @@ const setupNonFungible = () => {
   const ccBundle = makeIssuerKit('CryptoCats', AssetKind.SET);
   const rpgBundle = makeIssuerKit('MMORPG Items', AssetKind.SET);
   const allBundles = { cc: ccBundle, rpg: rpgBundle };
+  /** @type {Map<string, Mint>} */
   const mints = new Map();
+  /** @type {Map<string, Issuer>} */
   const issuers = new Map();
+  /** @type {Map<string, Brand>} */
   const brands = new Map();
 
   for (const k of Object.getOwnPropertyNames(allBundles)) {
@@ -26,12 +29,14 @@ const setupNonFungible = () => {
   const feePurse = E(zoeService).makeFeePurse();
   const zoe = E(zoeService).bindDefaultFeePurse(feePurse);
 
-  const ccIssuer = issuers.get('cc');
-  const rpgIssuer = issuers.get('rpg');
-  const ccMint = mints.get('cc');
-  const rpgMint = mints.get('rpg');
-  const cryptoCats = value => AmountMath.make(value, allBundles.cc.brand);
-  const rpgItems = value => AmountMath.make(value, allBundles.rpg.brand);
+  const ccIssuer = ccBundle.issuer;
+  const rpgIssuer = rpgBundle.issuer;
+  const ccMint = ccBundle.mint;
+  const rpgMint = rpgBundle.mint;
+  /** @param {Value} value */
+  const cryptoCats = value => AmountMath.make(allBundles.cc.brand, value);
+  /** @param {Value} value */
+  const rpgItems = value => AmountMath.make(allBundles.rpg.brand, value);
   return {
     ccIssuer,
     rpgIssuer,

--- a/packages/zoe/test/unitTests/test-cleanProposal.js
+++ b/packages/zoe/test/unitTests/test-cleanProposal.js
@@ -1,4 +1,5 @@
 // @ts-check
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
@@ -11,13 +12,13 @@ test('cleanProposal test', t => {
   const { moola, simoleans } = setup();
 
   const proposal = harden({
-    give: { Asset: simoleans(1) },
-    want: { Price: moola(3) },
+    give: { Asset: simoleans(1n) },
+    want: { Price: moola(3n) },
   });
 
   const expected = harden({
-    give: { Asset: simoleans(1) },
-    want: { Price: moola(3) },
+    give: { Asset: simoleans(1n) },
+    want: { Price: moola(3n) },
     exit: { onDemand: null },
   });
 
@@ -53,16 +54,16 @@ test('cleanProposal - repeated brands', t => {
   const timer = buildManualTimer(console.log);
 
   const proposal = harden({
-    want: { Asset2: simoleans(1) },
-    give: { Price2: moola(3) },
+    want: { Asset2: simoleans(1n) },
+    give: { Price2: moola(3n) },
     exit: { afterDeadline: { timer, deadline: 100n } },
   });
 
   const expected = harden({
     want: {
-      Asset2: simoleans(1),
+      Asset2: simoleans(1n),
     },
-    give: { Price2: moola(3) },
+    give: { Price2: moola(3n) },
     exit: { afterDeadline: { timer, deadline: 100n } },
   });
 
@@ -80,8 +81,8 @@ test('cleanProposal - wrong assetKind', t => {
   const timer = buildManualTimer(console.log);
 
   const proposal = harden({
-    want: { Asset2: simoleans(1) },
-    give: { Price2: moola(3) },
+    want: { Asset2: simoleans(1n) },
+    give: { Price2: moola(3n) },
     exit: { afterDeadline: { timer, deadline: 100n } },
   });
 

--- a/packages/zoe/test/unitTests/test-fakePriceAuthority.js
+++ b/packages/zoe/test/unitTests/test-fakePriceAuthority.js
@@ -36,10 +36,10 @@ test('priceAuthority quoteAtTime', async t => {
   );
 
   const done = E(priceAuthority)
-    .quoteAtTime(3n, moola(5), bucksBrand)
+    .quoteAtTime(3n, moola(5n), bucksBrand)
     .then(async quote => {
-      assertAmountsEqual(t, moola(5), getAmountIn(quote));
-      assertAmountsEqual(t, bucks(55 * 5), getAmountOut(quote));
+      assertAmountsEqual(t, moola(5n), getAmountIn(quote));
+      assertAmountsEqual(t, bucks(55n * 5n), getAmountOut(quote));
       t.is(3n, getTimestamp(quote));
     });
 
@@ -62,10 +62,10 @@ test('priceAuthority quoteGiven', async t => {
   );
 
   await E(manualTimer).tick();
-  const quote = await E(priceAuthority).quoteGiven(moola(37), bucksBrand);
+  const quote = await E(priceAuthority).quoteGiven(moola(37n), bucksBrand);
   const quoteAmount = getQuoteValues(quote);
   t.is(1n, quoteAmount.timestamp);
-  t.deepEqual(bucks(37 * 20), quoteAmount.amountOut);
+  t.deepEqual(bucks(37n * 20n), quoteAmount.amountOut);
 });
 
 test('priceAuthority quoteWanted', async t => {
@@ -80,11 +80,11 @@ test('priceAuthority quoteWanted', async t => {
   );
 
   await E(manualTimer).tick();
-  const quote = await E(priceAuthority).quoteWanted(moolaBrand, bucks(400));
+  const quote = await E(priceAuthority).quoteWanted(moolaBrand, bucks(400n));
   const quoteAmount = quote.quoteAmount.value[0];
   t.is(1n, quoteAmount.timestamp);
-  assertAmountsEqual(t, bucks(400), quoteAmount.amountOut);
-  assertAmountsEqual(t, moola(20), quoteAmount.amountIn);
+  assertAmountsEqual(t, bucks(400n), quoteAmount.amountOut);
+  assertAmountsEqual(t, moola(20n), quoteAmount.amountIn);
 });
 
 test('priceAuthority paired quotes', async t => {
@@ -102,17 +102,17 @@ test('priceAuthority paired quotes', async t => {
 
   await E(manualTimer).tick();
 
-  const quoteOut = await E(priceAuthority).quoteWanted(moolaBrand, bucks(400));
+  const quoteOut = await E(priceAuthority).quoteWanted(moolaBrand, bucks(400n));
   const quoteOutAmount = quoteOut.quoteAmount.value[0];
   t.is(1n, quoteOutAmount.timestamp);
-  assertAmountsEqual(t, bucks(400), quoteOutAmount.amountOut);
-  assertAmountsEqual(t, moola(20), quoteOutAmount.amountIn);
+  assertAmountsEqual(t, bucks(400n), quoteOutAmount.amountOut);
+  assertAmountsEqual(t, moola(20n), quoteOutAmount.amountIn);
 
-  const quoteIn = await E(priceAuthority).quoteGiven(moola(22), bucksBrand);
+  const quoteIn = await E(priceAuthority).quoteGiven(moola(22n), bucksBrand);
   const quoteInAmount = quoteIn.quoteAmount.value[0];
   t.is(1n, quoteInAmount.timestamp);
-  assertAmountsEqual(t, bucks(20 * 22), quoteInAmount.amountOut);
-  assertAmountsEqual(t, moola(22), quoteInAmount.amountIn);
+  assertAmountsEqual(t, bucks(20n * 22n), quoteInAmount.amountOut);
+  assertAmountsEqual(t, moola(22n), quoteInAmount.amountIn);
 });
 
 test('priceAuthority quoteWhenGTE', async t => {
@@ -125,13 +125,13 @@ test('priceAuthority quoteWhenGTE', async t => {
   );
 
   E(priceAuthority)
-    .quoteWhenGTE(moola(1), bucks(40))
+    .quoteWhenGTE(moola(1n), bucks(40n))
     .then(quote => {
       const quoteInAmount = quote.quoteAmount.value[0];
       t.is(4n, manualTimer.getCurrentTimestamp());
       t.is(4n, quoteInAmount.timestamp);
-      assertAmountsEqual(t, bucks(40), quoteInAmount.amountOut);
-      assertAmountsEqual(t, moola(1), quoteInAmount.amountIn);
+      assertAmountsEqual(t, bucks(40n), quoteInAmount.amountOut);
+      assertAmountsEqual(t, moola(1n), quoteInAmount.amountIn);
     });
 
   await E(manualTimer).tick();
@@ -151,13 +151,13 @@ test('priceAuthority quoteWhenLT', async t => {
   );
 
   E(priceAuthority)
-    .quoteWhenLT(moola(1), bucks(30))
+    .quoteWhenLT(moola(1n), bucks(30n))
     .then(quote => {
       const quoteInAmount = quote.quoteAmount.value[0];
       t.is(3n, manualTimer.getCurrentTimestamp());
       t.is(3n, quoteInAmount.timestamp);
-      assertAmountsEqual(t, bucks(29), quoteInAmount.amountOut);
-      assertAmountsEqual(t, moola(1), quoteInAmount.amountIn);
+      assertAmountsEqual(t, bucks(29n), quoteInAmount.amountOut);
+      assertAmountsEqual(t, moola(1n), quoteInAmount.amountIn);
     });
 
   await E(manualTimer).tick();
@@ -176,13 +176,13 @@ test('priceAuthority quoteWhenGT', async t => {
   );
 
   E(priceAuthority)
-    .quoteWhenGT(moola(1), bucks(40))
+    .quoteWhenGT(moola(1n), bucks(40n))
     .then(quote => {
       const quoteInAmount = quote.quoteAmount.value[0];
       t.is(3n, manualTimer.getCurrentTimestamp());
       t.is(3n, quoteInAmount.timestamp);
-      assertAmountsEqual(t, bucks(41), quoteInAmount.amountOut);
-      assertAmountsEqual(t, moola(1), quoteInAmount.amountIn);
+      assertAmountsEqual(t, bucks(41n), quoteInAmount.amountOut);
+      assertAmountsEqual(t, moola(1n), quoteInAmount.amountIn);
     });
 
   await E(manualTimer).tick();
@@ -201,13 +201,13 @@ test('priceAuthority quoteWhenLTE', async t => {
   );
 
   E(priceAuthority)
-    .quoteWhenLTE(moola(1), bucks(25))
+    .quoteWhenLTE(moola(1n), bucks(25n))
     .then(quote => {
       const quoteInAmount = quote.quoteAmount.value[0];
       t.is(4n, quoteInAmount.timestamp);
       t.is(4n, manualTimer.getCurrentTimestamp());
-      assertAmountsEqual(t, bucks(25), quoteInAmount.amountOut);
-      assertAmountsEqual(t, moola(1), quoteInAmount.amountIn);
+      assertAmountsEqual(t, bucks(25n), quoteInAmount.amountOut);
+      assertAmountsEqual(t, moola(1n), quoteInAmount.amountIn);
     });
 
   await E(manualTimer).tick();

--- a/packages/zoe/test/unitTests/test-feesCharged.js
+++ b/packages/zoe/test/unitTests/test-feesCharged.js
@@ -37,7 +37,7 @@ test(`fee charged for install, startInstance, offer, getPublicFacet`, async t =>
   const feeIssuerConfig = {
     name: 'RUN',
     assetKind: AssetKind.NAT,
-    displayInfo: { decimalPlaces: 6, assetKind: AssetKind.NAT },
+    displayInfo: harden({ decimalPlaces: 6, assetKind: AssetKind.NAT }),
     initialFunds: 200n,
   };
 

--- a/packages/zoe/test/unitTests/test-instanceStorage.js
+++ b/packages/zoe/test/unitTests/test-instanceStorage.js
@@ -80,10 +80,14 @@ test('makeAndStoreInstanceRecord', async t => {
   // Add currency again, but call it "money"
   addIssuerToInstanceRecord(
     'Money',
-    makeIssuerRecord(currencyKit.brand, currencyKit.issuer, {
-      assetKind: AssetKind.NAT,
-      decimalPlaces: 18,
-    }),
+    makeIssuerRecord(
+      currencyKit.brand,
+      currencyKit.issuer,
+      harden({
+        assetKind: AssetKind.NAT,
+        decimalPlaces: 18,
+      }),
+    ),
   );
 
   t.deepEqual(getIssuers(), { ...issuers, Money: currencyKit.issuer });
@@ -135,10 +139,14 @@ test('makeInstanceRecordStorage', async t => {
   // Add currency again, but call it "money"
   addIssuerToInstanceRecord(
     'Money',
-    makeIssuerRecord(currencyKit.brand, currencyKit.issuer, {
-      assetKind: AssetKind.NAT,
-      decimalPlaces: 18,
-    }),
+    makeIssuerRecord(
+      currencyKit.brand,
+      currencyKit.issuer,
+      harden({
+        assetKind: AssetKind.NAT,
+        decimalPlaces: 18,
+      }),
+    ),
   );
 
   t.deepEqual(getIssuers(), { ...issuers, Money: currencyKit.issuer });

--- a/packages/zoe/test/unitTests/test-issuerStorage.js
+++ b/packages/zoe/test/unitTests/test-issuerStorage.js
@@ -120,10 +120,14 @@ test(`storeIssuerRecord`, async t => {
   instantiate();
   const { currencyKit } = setupIssuersForTest();
 
-  const issuerRecord = makeIssuerRecord(currencyKit.brand, currencyKit.issuer, {
-    decimalPlaces: 18,
-    assetKind: AssetKind.NAT,
-  });
+  const issuerRecord = makeIssuerRecord(
+    currencyKit.brand,
+    currencyKit.issuer,
+    harden({
+      decimalPlaces: 18,
+      assetKind: AssetKind.NAT,
+    }),
+  );
 
   const returnedIssuerRecord = await storeIssuerRecord(issuerRecord);
 
@@ -141,10 +145,14 @@ test(`storeIssuerRecord twice`, async t => {
   instantiate();
   const { currencyKit } = setupIssuersForTest();
 
-  const issuerRecord = makeIssuerRecord(currencyKit.brand, currencyKit.issuer, {
-    decimalPlaces: 18,
-    assetKind: AssetKind.NAT,
-  });
+  const issuerRecord = makeIssuerRecord(
+    currencyKit.brand,
+    currencyKit.issuer,
+    harden({
+      decimalPlaces: 18,
+      assetKind: AssetKind.NAT,
+    }),
+  );
 
   const returnedIssuerRecord = await storeIssuerRecord(issuerRecord);
 

--- a/packages/zoe/test/unitTests/test-offerSafety.js
+++ b/packages/zoe/test/unitTests/test-offerSafety.js
@@ -1,4 +1,5 @@
 // @ts-check
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
@@ -26,11 +27,11 @@ import { setup } from './setupBasicMints.js';
 test('isOfferSafe - more than want, more than give', t => {
   const { moola, simoleans, bucks } = setup();
   const proposal = harden({
-    give: { A: moola(8) },
-    want: { B: simoleans(6), C: bucks(7n) },
+    give: { A: moola(8n) },
+    want: { B: simoleans(6n), C: bucks(7n) },
     exit: { waived: null },
   });
-  const amounts = harden({ A: moola(10), B: simoleans(7), C: bucks(8) });
+  const amounts = harden({ A: moola(10n), B: simoleans(7n), C: bucks(8n) });
 
   t.truthy(isOfferSafe(proposal, amounts));
 });
@@ -39,11 +40,11 @@ test('isOfferSafe - more than want, more than give', t => {
 test('isOfferSafe - more than want, less than give', t => {
   const { moola, simoleans, bucks } = setup();
   const proposal = harden({
-    give: { A: moola(8) },
-    want: { B: simoleans(6), C: bucks(7n) },
+    give: { A: moola(8n) },
+    want: { B: simoleans(6n), C: bucks(7n) },
     exit: { waived: null },
   });
-  const amounts = harden({ A: moola(1), B: simoleans(7), C: bucks(8) });
+  const amounts = harden({ A: moola(1n), B: simoleans(7n), C: bucks(8n) });
 
   t.truthy(isOfferSafe(proposal, amounts));
 });
@@ -52,11 +53,11 @@ test('isOfferSafe - more than want, less than give', t => {
 test('isOfferSafe - more than want, equal to give', t => {
   const { moola, simoleans, bucks } = setup();
   const proposal = harden({
-    want: { A: moola(8) },
-    give: { B: simoleans(6), C: bucks(7n) },
+    want: { A: moola(8n) },
+    give: { B: simoleans(6n), C: bucks(7n) },
     exit: { waived: null },
   });
-  const amounts = harden({ A: moola(9), B: simoleans(6), C: bucks(7n) });
+  const amounts = harden({ A: moola(9n), B: simoleans(6n), C: bucks(7n) });
 
   t.truthy(isOfferSafe(proposal, amounts));
 });
@@ -65,11 +66,11 @@ test('isOfferSafe - more than want, equal to give', t => {
 test('isOfferSafe - less than want, more than give', t => {
   const { moola, simoleans, bucks } = setup();
   const proposal = harden({
-    want: { A: moola(8) },
-    give: { B: simoleans(6), C: bucks(7n) },
+    want: { A: moola(8n) },
+    give: { B: simoleans(6n), C: bucks(7n) },
     exit: { waived: null },
   });
-  const amounts = harden({ A: moola(7), B: simoleans(9), C: bucks(19) });
+  const amounts = harden({ A: moola(7n), B: simoleans(9n), C: bucks(19n) });
 
   t.truthy(isOfferSafe(proposal, amounts));
 });
@@ -78,11 +79,11 @@ test('isOfferSafe - less than want, more than give', t => {
 test('isOfferSafe - less than want, less than give', t => {
   const { moola, simoleans, bucks } = setup();
   const proposal = harden({
-    want: { A: moola(8) },
-    give: { B: simoleans(6), C: bucks(7n) },
+    want: { A: moola(8n) },
+    give: { B: simoleans(6n), C: bucks(7n) },
     exit: { waived: null },
   });
-  const amounts = harden({ A: moola(7), B: simoleans(5), C: bucks(6) });
+  const amounts = harden({ A: moola(7n), B: simoleans(5n), C: bucks(6n) });
 
   t.falsy(isOfferSafe(proposal, amounts));
 });
@@ -91,11 +92,11 @@ test('isOfferSafe - less than want, less than give', t => {
 test('isOfferSafe - less than want, equal to give', t => {
   const { moola, simoleans, bucks } = setup();
   const proposal = harden({
-    want: { B: simoleans(6) },
-    give: { A: moola(1), C: bucks(7n) },
+    want: { B: simoleans(6n) },
+    give: { A: moola(1n), C: bucks(7n) },
     exit: { waived: null },
   });
-  const amounts = harden({ A: moola(1), B: simoleans(5), C: bucks(7n) });
+  const amounts = harden({ A: moola(1n), B: simoleans(5n), C: bucks(7n) });
 
   t.truthy(isOfferSafe(proposal, amounts));
 });
@@ -104,11 +105,11 @@ test('isOfferSafe - less than want, equal to give', t => {
 test('isOfferSafe - equal to want, more than give', t => {
   const { moola, simoleans, bucks } = setup();
   const proposal = harden({
-    want: { B: simoleans(6) },
-    give: { A: moola(1), C: bucks(7n) },
+    want: { B: simoleans(6n) },
+    give: { A: moola(1n), C: bucks(7n) },
     exit: { waived: null },
   });
-  const amounts = harden({ A: moola(2), B: simoleans(6), C: bucks(8) });
+  const amounts = harden({ A: moola(2n), B: simoleans(6n), C: bucks(8n) });
 
   t.truthy(isOfferSafe(proposal, amounts));
 });
@@ -117,11 +118,11 @@ test('isOfferSafe - equal to want, more than give', t => {
 test('isOfferSafe - equal to want, less than give', t => {
   const { moola, simoleans, bucks } = setup();
   const proposal = harden({
-    want: { B: simoleans(6) },
-    give: { A: moola(1), C: bucks(7n) },
+    want: { B: simoleans(6n) },
+    give: { A: moola(1n), C: bucks(7n) },
     exit: { waived: null },
   });
-  const amounts = harden({ A: moola(0n), B: simoleans(6), C: bucks(0) });
+  const amounts = harden({ A: moola(0n), B: simoleans(6n), C: bucks(0n) });
 
   t.truthy(isOfferSafe(proposal, amounts));
 });
@@ -130,11 +131,11 @@ test('isOfferSafe - equal to want, less than give', t => {
 test('isOfferSafe - equal to want, equal to give', t => {
   const { moola, simoleans, bucks } = setup();
   const proposal = harden({
-    want: { B: simoleans(6) },
-    give: { A: moola(1), C: bucks(7n) },
+    want: { B: simoleans(6n) },
+    give: { A: moola(1n), C: bucks(7n) },
     exit: { waived: null },
   });
-  const amounts = harden({ A: moola(1), B: simoleans(6), C: bucks(7n) });
+  const amounts = harden({ A: moola(1n), B: simoleans(6n), C: bucks(7n) });
 
   t.truthy(isOfferSafe(proposal, amounts));
 });
@@ -142,7 +143,7 @@ test('isOfferSafe - equal to want, equal to give', t => {
 test('isOfferSafe - empty proposal', t => {
   const { moola, simoleans, bucks } = setup();
   const proposal = harden({ give: {}, want: {}, exit: { waived: null } });
-  const amounts = harden({ A: moola(1), B: simoleans(6), C: bucks(7n) });
+  const amounts = harden({ A: moola(1n), B: simoleans(6n), C: bucks(7n) });
 
   t.truthy(isOfferSafe(proposal, amounts));
 });

--- a/packages/zoe/test/unitTests/test-rightsConservation.js
+++ b/packages/zoe/test/unitTests/test-rightsConservation.js
@@ -18,21 +18,21 @@ const setupBrands = () => {
 
 const makeAmountMatrix = (brands, valueMatrix) =>
   valueMatrix.map(row =>
-    row.map((value, i) => AmountMath.make(value, brands[i])),
+    row.map((value, i) => AmountMath.make(brands[i], value)),
   );
 
 // rights are conserved for amount with Nat values
 test(`assertRightsConserved - true for amount with nat values`, t => {
   const brands = setupBrands();
   const previousValues = [
-    [0, 1, 0],
-    [4, 1, 0],
-    [6, 3, 0],
+    [0n, 1n, 0n],
+    [4n, 1n, 0n],
+    [6n, 3n, 0n],
   ];
   const newValues = [
-    [1, 2, 0],
-    [3, 1, 0],
-    [6, 2, 0],
+    [1n, 2n, 0n],
+    [3n, 1n, 0n],
+    [6n, 2n, 0n],
   ];
 
   const previousAmounts = makeAmountMatrix(brands, previousValues).flat();
@@ -45,14 +45,14 @@ test(`assertRightsConserved - true for amount with nat values`, t => {
 test(`assertRightsConserved - false for amount with Nat values`, t => {
   const brands = setupBrands();
   const oldValues = [
-    [0, 1, 4],
-    [4, 1, 0],
-    [6, 3, 0],
+    [0n, 1n, 4n],
+    [4n, 1n, 0n],
+    [6n, 3n, 0n],
   ];
   const newValues = [
-    [1, 2, 0],
-    [3, 1, 0],
-    [6, 2, 0],
+    [1n, 2n, 0n],
+    [3n, 1n, 0n],
+    [6n, 2n, 0n],
   ];
 
   const oldAmounts = makeAmountMatrix(brands, oldValues).flat();

--- a/packages/zoe/test/unitTests/test-scriptedOracle.js
+++ b/packages/zoe/test/unitTests/test-scriptedOracle.js
@@ -192,9 +192,14 @@ test('pay no bounty', async t => {
     }),
   );
   const bountyInvitation = await funderSeat.getOfferResult();
-  assertPayoutAmount(t, moolaIssuer, funderSeat.getPayout('Fee'), moola(50n));
+  const p1 = assertPayoutAmount(
+    t,
+    moolaIssuer,
+    funderSeat.getPayout('Fee'),
+    moola(50n),
+  );
   // Alice gets the funds back.
-  assertPayoutAmount(
+  const p2 = assertPayoutAmount(
     t,
     moolaIssuer,
     funderSeat.getPayout('Bounty'),
@@ -212,12 +217,24 @@ test('pay no bounty', async t => {
       Fee: moolaMint.mintPayment(moola(50n)),
     }),
   );
-  assertPayoutAmount(t, moolaIssuer, bountySeat.getPayout('Fee'), moola(0n));
+  const p3 = assertPayoutAmount(
+    t,
+    moolaIssuer,
+    bountySeat.getPayout('Fee'),
+    moola(0n),
+  );
   // Bob doesn't receive the bounty
-  assertPayoutAmount(t, moolaIssuer, bountySeat.getPayout('Bounty'), moola(0n));
+  const p4 = assertPayoutAmount(
+    t,
+    moolaIssuer,
+    bountySeat.getPayout('Bounty'),
+    moola(0n),
+  );
 
   await E(timer).tick();
   await E(timer).tick();
   await E(timer).tick();
   await E(timer).tick();
+
+  await Promise.all([p1, p2, p3, p4]);
 });

--- a/packages/zoe/test/unitTests/test-testHelpers.js
+++ b/packages/zoe/test/unitTests/test-testHelpers.js
@@ -19,7 +19,7 @@ test('assertAmountsEqual - Nat dup', t => {
   const { moola } = setup();
 
   const fakeT = makeFakeT();
-  assertAmountsEqual(fakeT, moola(0), moola(0));
+  assertAmountsEqual(fakeT, moola(0n), moola(0n));
   t.falsy(fakeT.getError());
 });
 
@@ -30,7 +30,11 @@ test('assertAmountsEqual - Nat manual', t => {
   } = setup();
 
   const fakeT = makeFakeT();
-  assertAmountsEqual(fakeT, moola(0), { value: 0n, brand: moolaBrand });
+  assertAmountsEqual(
+    fakeT,
+    moola(0n),
+    harden({ value: 0n, brand: moolaBrand }),
+  );
   t.falsy(fakeT.getError());
 });
 
@@ -38,7 +42,7 @@ test('assertAmountsEqual - false Nat', t => {
   const { moola } = setup();
   const fakeT = makeFakeT();
 
-  assertAmountsEqual(fakeT, moola(0), moola(1));
+  assertAmountsEqual(fakeT, moola(0n), moola(1n));
   t.is(fakeT.getError(), 'value ("[0n]") expected to equal "[1n]"');
 });
 
@@ -99,7 +103,7 @@ test('assertAmountsEqual - false StrSet', t => {
 test('assertAmountsEqual - brand mismatch', t => {
   const { moola, bucks } = setup();
   const fakeT = makeFakeT();
-  assertAmountsEqual(fakeT, moola(0), bucks(0));
+  assertAmountsEqual(fakeT, moola(0n), bucks(0n));
   t.is(
     fakeT.getError(),
     'brand ([object Alleged: moola brand]) expected to equal [object Alleged: bucks brand]',
@@ -111,7 +115,7 @@ test('assertAmountsEqual - both mismatch', t => {
   const { cryptoCats } = setupNonFungible();
 
   const fakeT = makeFakeT();
-  assertAmountsEqual(fakeT, moola(0), cryptoCats(harden(['Garfield'])));
+  assertAmountsEqual(fakeT, moola(0n), cryptoCats(harden(['Garfield'])));
   t.is(
     fakeT.getError(),
     'Neither brand nor value matched: {"brand":"[Alleged: moola brand]","value":"[0n]"}, {"brand":"[Alleged: CryptoCats brand]","value":["Garfield"]}',

--- a/packages/zoe/test/unitTests/zcf/test-allStagedSeatsUsed.js
+++ b/packages/zoe/test/unitTests/zcf/test-allStagedSeatsUsed.js
@@ -18,24 +18,28 @@ test(`allStagedSeatsUsed should not be asserted`, async t => {
   const { zcfSeat: zcfSeat1 } = await makeOffer(
     zoe,
     zcf,
-    harden({ give: { B: moola(3) } }),
-    harden({ B: moolaKit.mint.mintPayment(moola(3)) }),
+    harden({ give: { B: moola(3n) } }),
+    harden({ B: moolaKit.mint.mintPayment(moola(3n)) }),
   );
 
   const { zcfSeat: zcfSeat2 } = await makeOffer(
     zoe,
     zcf,
-    harden({ give: { B: moola(3) } }),
-    harden({ B: moolaKit.mint.mintPayment(moola(3)) }),
+    harden({ give: { B: moola(3n) } }),
+    harden({ B: moolaKit.mint.mintPayment(moola(3n)) }),
   );
 
-  zcfSeat1.incrementBy(zcfSeat2.decrementBy({ B: moola(2) }));
+  zcfSeat1.incrementBy(zcfSeat2.decrementBy({ B: moola(2n) }));
   // Seats have staged allocations
   t.true(zcfSeat1.hasStagedAllocation());
 
-  const zcfMint = await zcf.makeZCFMint('Token', AssetKind.NAT, {
-    decimalPlaces: 6,
-  });
+  const zcfMint = await zcf.makeZCFMint(
+    'Token',
+    AssetKind.NAT,
+    harden({
+      decimalPlaces: 6,
+    }),
+  );
 
   const { brand: tokenBrand } = zcfMint.getIssuerRecord();
 
@@ -58,27 +62,27 @@ test(`allStagedSeatsUsed should be asserted`, async t => {
   const { zcfSeat: zcfSeat1 } = await makeOffer(
     zoe,
     zcf,
-    harden({ give: { B: moola(3) } }),
-    harden({ B: moolaKit.mint.mintPayment(moola(3)) }),
+    harden({ give: { B: moola(3n) } }),
+    harden({ B: moolaKit.mint.mintPayment(moola(3n)) }),
   );
 
   const { zcfSeat: zcfSeat2 } = await makeOffer(
     zoe,
     zcf,
-    harden({ give: { B: moola(3) } }),
-    harden({ B: moolaKit.mint.mintPayment(moola(3)) }),
+    harden({ give: { B: moola(3n) } }),
+    harden({ B: moolaKit.mint.mintPayment(moola(3n)) }),
   );
 
   const { zcfSeat: zcfSeat3 } = await makeOffer(
     zoe,
     zcf,
-    harden({ give: { B: moola(3) } }),
-    harden({ B: moolaKit.mint.mintPayment(moola(3)) }),
+    harden({ give: { B: moola(3n) } }),
+    harden({ B: moolaKit.mint.mintPayment(moola(3n)) }),
   );
 
-  zcfSeat1.incrementBy(zcfSeat2.decrementBy({ B: moola(2) }));
+  zcfSeat1.incrementBy(zcfSeat2.decrementBy({ B: moola(2n) }));
 
-  zcfSeat3.incrementBy({ B: moola(3) });
+  zcfSeat3.incrementBy({ B: moola(3n) });
 
   t.true(zcfSeat3.hasStagedAllocation());
 

--- a/packages/zoe/test/unitTests/zcf/test-reallocateForZCFMint.js
+++ b/packages/zoe/test/unitTests/zcf/test-reallocateForZCFMint.js
@@ -37,29 +37,33 @@ test(`stagedAllocations safely interleave with zcfMint calls`, async t => {
   const { zcfSeat: zcfSeat1 } = await makeOffer(
     zoe,
     zcf,
-    harden({ give: { B: moola(3) } }),
-    harden({ B: moolaKit.mint.mintPayment(moola(3)) }),
+    harden({ give: { B: moola(3n) } }),
+    harden({ B: moolaKit.mint.mintPayment(moola(3n)) }),
   );
 
   // Make zcfSeat2
   const { zcfSeat: zcfSeat2 } = await makeOffer(
     zoe,
     zcf,
-    harden({ give: { B: moola(3) } }),
-    harden({ B: moolaKit.mint.mintPayment(moola(3)) }),
+    harden({ give: { B: moola(3n) } }),
+    harden({ B: moolaKit.mint.mintPayment(moola(3n)) }),
   );
 
   // Make ZCFMint
-  const zcfMint = await zcf.makeZCFMint('Token', AssetKind.NAT, {
-    decimalPlaces: 6,
-  });
+  const zcfMint = await zcf.makeZCFMint(
+    'Token',
+    AssetKind.NAT,
+    harden({
+      decimalPlaces: 6,
+    }),
+  );
   const { brand: tokenBrand } = zcfMint.getIssuerRecord();
 
   // Decrement zcfSeat2 by non-zcfMintToken
-  zcfSeat2.decrementBy({ B: moola(2) });
+  zcfSeat2.decrementBy({ B: moola(2n) });
   t.true(zcfSeat2.hasStagedAllocation());
-  t.deepEqual(zcfSeat2.getStagedAllocation(), { B: moola(1) });
-  t.deepEqual(zcfSeat2.getCurrentAllocation(), { B: moola(3) });
+  t.deepEqual(zcfSeat2.getStagedAllocation(), { B: moola(1n) });
+  t.deepEqual(zcfSeat2.getCurrentAllocation(), { B: moola(3n) });
 
   // Mint gains to zcfSeat2
   zcfMint.mintGains(
@@ -74,11 +78,11 @@ test(`stagedAllocations safely interleave with zcfMint calls`, async t => {
   // added to the current allocation also gets added to any
   // in-progress staged allocation.
   t.deepEqual(zcfSeat2.getStagedAllocation(), {
-    B: moola(1),
+    B: moola(1n),
     MyToken: AmountMath.make(tokenBrand, 100n),
   });
   t.deepEqual(zcfSeat2.getCurrentAllocation(), {
-    B: moola(3),
+    B: moola(3n),
     MyToken: AmountMath.make(tokenBrand, 100n),
   });
 
@@ -93,19 +97,19 @@ test(`stagedAllocations safely interleave with zcfMint calls`, async t => {
   // allocation should have changed to include the minted tokens
   t.false(zcfSeat1.hasStagedAllocation());
   t.deepEqual(zcfSeat1.getCurrentAllocation(), {
-    B: moola(3),
+    B: moola(3n),
     OtherTokens: AmountMath.make(tokenBrand, 50n),
   });
 
   // zcfSeat1.incrementBy non-zcfMint token
-  zcfSeat1.incrementBy({ B: moola(2) });
+  zcfSeat1.incrementBy({ B: moola(2n) });
   // Both the staged allocation and the current allocation show the OtherTokens
   t.deepEqual(zcfSeat1.getStagedAllocation(), {
-    B: moola(5),
+    B: moola(5n),
     OtherTokens: AmountMath.make(tokenBrand, 50n),
   });
   t.deepEqual(zcfSeat1.getCurrentAllocation(), {
-    B: moola(3),
+    B: moola(3n),
     OtherTokens: AmountMath.make(tokenBrand, 50n),
   });
 
@@ -114,11 +118,11 @@ test(`stagedAllocations safely interleave with zcfMint calls`, async t => {
   t.false(zcfSeat1.hasStagedAllocation());
   t.false(zcfSeat2.hasStagedAllocation());
   t.deepEqual(zcfSeat1.getCurrentAllocation(), {
-    B: moola(5),
+    B: moola(5n),
     OtherTokens: AmountMath.make(tokenBrand, 50n),
   });
   t.deepEqual(zcfSeat2.getCurrentAllocation(), {
-    B: moola(1),
+    B: moola(1n),
     MyToken: AmountMath.make(tokenBrand, 100n),
   });
 
@@ -127,7 +131,7 @@ test(`stagedAllocations safely interleave with zcfMint calls`, async t => {
   // zcfSeat1 decrementBy both zcfMint token and non-zcfMint token
   zcfSeat1.decrementBy({
     OtherTokens: AmountMath.make(tokenBrand, 5n),
-    B: moola(1),
+    B: moola(1n),
   });
 
   // zcfMint.burnLosses on zcfSeat1
@@ -139,11 +143,11 @@ test(`stagedAllocations safely interleave with zcfMint calls`, async t => {
   // stagedAllocation, but currentAllocation does not include the
   // stagedAllocations, and will not until zcf.reallocate is called.
   t.deepEqual(zcfSeat1.getCurrentAllocation(), {
-    B: moola(5), // no change since reallocate
+    B: moola(5n), // no change since reallocate
     OtherTokens: AmountMath.make(tokenBrand, 43n),
   });
   t.deepEqual(zcfSeat1.getStagedAllocation(), {
-    B: moola(4),
+    B: moola(4n),
     OtherTokens: AmountMath.make(tokenBrand, 38n), // includes decrementBy and burnLosses
   });
 
@@ -155,7 +159,7 @@ test(`stagedAllocations safely interleave with zcfMint calls`, async t => {
     zcfSeat2,
   );
   t.deepEqual(zcfSeat2.getCurrentAllocation(), {
-    B: moola(1),
+    B: moola(1n),
     MyToken: AmountMath.make(tokenBrand, 83n),
   });
   t.false(zcfSeat2.hasStagedAllocation());
@@ -163,14 +167,14 @@ test(`stagedAllocations safely interleave with zcfMint calls`, async t => {
   // zcfSeat2.incrementBy
   zcfSeat2.incrementBy({
     OtherTokens: AmountMath.make(tokenBrand, 5n), // let's keep this keyword separate even though we don't have to
-    B: moola(1),
+    B: moola(1n),
   });
   t.deepEqual(zcfSeat2.getCurrentAllocation(), {
-    B: moola(1),
+    B: moola(1n),
     MyToken: AmountMath.make(tokenBrand, 83n),
   });
   t.deepEqual(zcfSeat2.getStagedAllocation(), {
-    B: moola(2),
+    B: moola(2n),
     MyToken: AmountMath.make(tokenBrand, 83n),
     OtherTokens: AmountMath.make(tokenBrand, 5n),
   });
@@ -183,12 +187,12 @@ test(`stagedAllocations safely interleave with zcfMint calls`, async t => {
     zcfSeat2,
   );
   t.deepEqual(zcfSeat2.getCurrentAllocation(), {
-    B: moola(1),
+    B: moola(1n),
     MyToken: AmountMath.make(tokenBrand, 83n),
     AnotherOne: AmountMath.make(tokenBrand, 2n),
   });
   t.deepEqual(zcfSeat2.getStagedAllocation(), {
-    B: moola(2),
+    B: moola(2n),
     MyToken: AmountMath.make(tokenBrand, 83n),
     OtherTokens: AmountMath.make(tokenBrand, 5n),
     AnotherOne: AmountMath.make(tokenBrand, 2n),
@@ -197,13 +201,13 @@ test(`stagedAllocations safely interleave with zcfMint calls`, async t => {
   // One last reallocate
   zcf.reallocate(zcfSeat1, zcfSeat2);
   t.deepEqual(zcfSeat2.getCurrentAllocation(), {
-    B: moola(2),
+    B: moola(2n),
     MyToken: AmountMath.make(tokenBrand, 83n),
     OtherTokens: AmountMath.make(tokenBrand, 5n),
     AnotherOne: AmountMath.make(tokenBrand, 2n),
   });
   t.deepEqual(zcfSeat1.getCurrentAllocation(), {
-    B: moola(4),
+    B: moola(4n),
     OtherTokens: AmountMath.make(tokenBrand, 38n),
   });
   t.false(zcfSeat1.hasStagedAllocation());

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -422,12 +422,12 @@ test(`zcf.makeZCFMint - mintGains - no seat`, async t => {
   const { zcf } = await setupZCFTest();
   const zcfMint = await zcf.makeZCFMint('A', AssetKind.NAT);
   const { brand } = zcfMint.getIssuerRecord();
-  const zcfSeat = zcfMint.mintGains({ A: AmountMath.make(4n, brand) });
+  const zcfSeat = zcfMint.mintGains({ A: AmountMath.make(brand, 4n) });
   t.truthy(zcfSeat);
   assertAmountsEqual(
     t,
     zcfSeat.getAmountAllocated('A', brand),
-    AmountMath.make(4n, brand),
+    AmountMath.make(brand, 4n),
   );
 });
 
@@ -468,7 +468,7 @@ test(`zcf.makeZCFMint - mintGains - wrong brand`, async t => {
 
   const zcfMint = await zcf.makeZCFMint('A', AssetKind.SET);
   const { zcfSeat } = zcf.makeEmptySeatKit();
-  t.throws(() => zcfMint.mintGains({ Moola: moola(3) }, zcfSeat), {
+  t.throws(() => zcfMint.mintGains({ Moola: moola(3n) }, zcfSeat), {
     message: `amount's brand "[Alleged: moola brand]" did not match expected brand "[Alleged: A brand]"`,
   });
 });
@@ -479,7 +479,7 @@ test(`zcf.makeZCFMint - burnLosses - wrong brand`, async t => {
 
   const zcfMint = await zcf.makeZCFMint('A', AssetKind.SET);
   const { zcfSeat } = zcf.makeEmptySeatKit();
-  t.throws(() => zcfMint.burnLosses({ Moola: moola(3) }, zcfSeat), {
+  t.throws(() => zcfMint.burnLosses({ Moola: moola(3n) }, zcfSeat), {
     message: `amount's brand "[Alleged: moola brand]" did not match expected brand "[Alleged: A brand]"`,
   });
 });
@@ -491,14 +491,14 @@ test(`zcf.makeZCFMint - mintGains - right issuer`, async t => {
   const { brand } = zcfMint.getIssuerRecord();
   const { zcfSeat } = zcf.makeEmptySeatKit();
   const zcfSeat2 = zcfMint.mintGains(
-    { A: AmountMath.make(4n, brand) },
+    { A: AmountMath.make(brand, 4n) },
     zcfSeat,
   );
   t.is(zcfSeat2, zcfSeat);
   assertAmountsEqual(
     t,
     zcfSeat.getAmountAllocated('A', brand),
-    AmountMath.make(4n, brand),
+    AmountMath.make(brand, 4n),
   );
 });
 
@@ -509,23 +509,23 @@ test(`zcf.makeZCFMint - burnLosses - right issuer`, async t => {
   const { brand } = zcfMint.getIssuerRecord();
   const { zcfSeat } = zcf.makeEmptySeatKit();
   const zcfSeat2 = zcfMint.mintGains(
-    { A: AmountMath.make(4n, brand) },
+    { A: AmountMath.make(brand, 4n) },
     zcfSeat,
   );
   t.is(zcfSeat2, zcfSeat);
   assertAmountsEqual(
     t,
     zcfSeat.getAmountAllocated('A', brand),
-    AmountMath.make(4n, brand),
+    AmountMath.make(brand, 4n),
   );
   // TODO: return a seat?
   // https://github.com/Agoric/agoric-sdk/issues/1709
-  const result = zcfMint.burnLosses({ A: AmountMath.make(1n, brand) }, zcfSeat);
+  const result = zcfMint.burnLosses({ A: AmountMath.make(brand, 1n) }, zcfSeat);
   t.is(result, undefined);
   assertAmountsEqual(
     t,
     zcfSeat.getAmountAllocated('A', brand),
-    AmountMath.make(3n, brand),
+    AmountMath.make(brand, 3n),
   );
 });
 
@@ -536,7 +536,7 @@ test(`zcf.makeZCFMint - mintGains - seat exited`, async t => {
   const { zcfSeat } = zcf.makeEmptySeatKit();
   zcfSeat.exit();
   t.throws(
-    () => zcfMint.mintGains({ A: AmountMath.make(4n, brand) }, zcfSeat),
+    () => zcfMint.mintGains({ A: AmountMath.make(brand, 4n) }, zcfSeat),
     {
       message: `zcfSeat must be active to mint gains for the zcfSeat`,
     },
@@ -549,18 +549,18 @@ test(`zcf.makeZCFMint - burnLosses - seat exited`, async t => {
   const { brand } = zcfMint.getIssuerRecord();
   const { zcfSeat } = zcf.makeEmptySeatKit();
   const zcfSeat2 = zcfMint.mintGains(
-    { A: AmountMath.make(4n, brand) },
+    { A: AmountMath.make(brand, 4n) },
     zcfSeat,
   );
   t.is(zcfSeat2, zcfSeat);
   assertAmountsEqual(
     t,
     zcfSeat.getAmountAllocated('A', brand),
-    AmountMath.make(4n, brand),
+    AmountMath.make(brand, 4n),
   );
   zcfSeat.exit();
   t.throws(
-    () => zcfMint.burnLosses({ A: AmountMath.make(1n, brand) }, zcfSeat),
+    () => zcfMint.burnLosses({ A: AmountMath.make(brand, 1n) }, zcfSeat),
     {
       message: `zcfSeat must be active to burn losses from the zcfSeat`,
     },
@@ -692,9 +692,18 @@ test(`zcfSeat.isOfferSafe from zcf.makeEmptySeatKit`, async t => {
   // @ts-ignore deliberate invalid arguments for testing
   t.truthy(zcfSeat.isOfferSafe());
   t.truthy(zcfSeat.isOfferSafe({ Moola: moola(0n) }));
-  t.truthy(zcfSeat.isOfferSafe({ Moola: moola(10) }));
+  t.truthy(zcfSeat.isOfferSafe({ Moola: moola(10n) }));
 });
 
+/**
+ *
+ * @param {ContractFacet} zcf
+ * @param {Keyword} zcfMintKeyword
+ * @param {ZCFSeat} zcfSeat
+ * @param {Keyword} gainsKeyword
+ * @param {Value} gainsValue
+ * @returns {Promise<IssuerRecord>}
+ */
 const allocateEasy = async (
   zcf,
   zcfMintKeyword,
@@ -706,7 +715,7 @@ const allocateEasy = async (
   const zcfMint = await zcf.makeZCFMint(zcfMintKeyword);
   const { brand } = zcfMint.getIssuerRecord();
   zcfMint.mintGains(
-    { [gainsKeyword]: AmountMath.make(gainsValue, brand) },
+    { [gainsKeyword]: AmountMath.make(brand, gainsValue) },
     zcfSeat,
   );
   return zcfMint.getIssuerRecord();
@@ -720,7 +729,7 @@ test(`zcfSeat.getNotifier`, async t => {
   t.not(notifier, await E(userSeat).getNotifier());
 
   // Mint some gains to change the allocation.
-  const { brand: brand1 } = await allocateEasy(zcf, 'Stuff', zcfSeat, 'A', 3);
+  const { brand: brand1 } = await allocateEasy(zcf, 'Stuff', zcfSeat, 'A', 3n);
   t.deepEqual(await notifier.getUpdateSince(2), {
     updateCount: 3,
     value: {
@@ -731,7 +740,7 @@ test(`zcfSeat.getNotifier`, async t => {
     },
   });
 
-  const { brand: brand2 } = await allocateEasy(zcf, 'Stuff2', zcfSeat, 'B', 6);
+  const { brand: brand2 } = await allocateEasy(zcf, 'Stuff2', zcfSeat, 'B', 6n);
   t.deepEqual(await notifier.getUpdateSince(3), {
     updateCount: 4,
     value: {
@@ -765,7 +774,7 @@ test(`zcfSeat.getCurrentAllocation from zcf.makeEmptySeatKit`, async t => {
   t.deepEqual(zcfSeat.getCurrentAllocation(), {});
 
   // Mint some gains to change the allocation.
-  const { brand: brand1 } = await allocateEasy(zcf, 'Stuff', zcfSeat, 'A', 3);
+  const { brand: brand1 } = await allocateEasy(zcf, 'Stuff', zcfSeat, 'A', 3n);
 
   t.deepEqual(zcfSeat.getCurrentAllocation(), {
     A: {
@@ -775,7 +784,7 @@ test(`zcfSeat.getCurrentAllocation from zcf.makeEmptySeatKit`, async t => {
   });
 
   // Again, mint some gains to change the allocation.
-  const { brand: brand2 } = await allocateEasy(zcf, 'Stuff2', zcfSeat, 'B', 6);
+  const { brand: brand2 } = await allocateEasy(zcf, 'Stuff2', zcfSeat, 'B', 6n);
 
   t.deepEqual(zcfSeat.getCurrentAllocation(), {
     A: {
@@ -799,7 +808,7 @@ test(`zcfSeat.getAmountAllocated from zcf.makeEmptySeatKit`, async t => {
   const { zcfSeat } = zcf.makeEmptySeatKit();
 
   // Mint some gains to change the allocation.
-  const { brand: brand1 } = await allocateEasy(zcf, 'Stuff', zcfSeat, 'A', 3);
+  const { brand: brand1 } = await allocateEasy(zcf, 'Stuff', zcfSeat, 'A', 3n);
 
   assertAmountsEqual(t, zcfSeat.getAmountAllocated('A', brand1), {
     brand: brand1,
@@ -807,7 +816,7 @@ test(`zcfSeat.getAmountAllocated from zcf.makeEmptySeatKit`, async t => {
   });
 
   // Again, mint some gains to change the allocation.
-  const { brand: brand2 } = await allocateEasy(zcf, 'Stuff2', zcfSeat, 'B', 6);
+  const { brand: brand2 } = await allocateEasy(zcf, 'Stuff2', zcfSeat, 'B', 6n);
 
   assertAmountsEqual(t, zcfSeat.getAmountAllocated('B'), {
     brand: brand2,
@@ -829,18 +838,18 @@ test(`zcfSeat.incrementBy, decrementBy, zcf.reallocate from zcf.makeEmptySeatKit
   const { zcfSeat: zcfSeat1 } = zcf.makeEmptySeatKit();
   const { zcfSeat: zcfSeat2 } = zcf.makeEmptySeatKit();
 
-  const issuerRecord1 = await allocateEasy(zcf, 'Stuff', zcfSeat1, 'A', 6);
-  const six = AmountMath.make(6n, issuerRecord1.brand);
+  const issuerRecord1 = await allocateEasy(zcf, 'Stuff', zcfSeat1, 'A', 6n);
+  const six = AmountMath.make(issuerRecord1.brand, 6n);
   zcfSeat1.decrementBy({ A: six });
   zcfSeat2.incrementBy({ B: six });
 
   zcf.reallocate(zcfSeat1, zcfSeat2);
 
   t.deepEqual(zcfSeat1.getCurrentAllocation(), {
-    A: AmountMath.make(0n, issuerRecord1.brand),
+    A: AmountMath.make(issuerRecord1.brand, 0n),
   });
   t.deepEqual(zcfSeat2.getCurrentAllocation(), {
-    B: AmountMath.make(6n, issuerRecord1.brand),
+    B: AmountMath.make(issuerRecord1.brand, 6n),
   });
 });
 
@@ -929,7 +938,7 @@ test(`userSeat.getCurrentAllocation from zcf.makeEmptySeatKit`, async t => {
   t.deepEqual(await E(userSeat).getCurrentAllocation(), {});
 
   // Mint some gains to change the allocation.
-  const { brand: brand1 } = await allocateEasy(zcf, 'Stuff', zcfSeat, 'A', 3);
+  const { brand: brand1 } = await allocateEasy(zcf, 'Stuff', zcfSeat, 'A', 3n);
 
   t.deepEqual(await E(userSeat).getCurrentAllocation(), {
     A: {
@@ -939,7 +948,7 @@ test(`userSeat.getCurrentAllocation from zcf.makeEmptySeatKit`, async t => {
   });
 
   // Again, mint some gains to change the allocation.
-  const { brand: brand2 } = await allocateEasy(zcf, 'Stuff2', zcfSeat, 'B', 6);
+  const { brand: brand2 } = await allocateEasy(zcf, 'Stuff2', zcfSeat, 'B', 6n);
 
   t.deepEqual(await E(userSeat).getCurrentAllocation(), {
     A: {
@@ -971,7 +980,7 @@ test(`userSeat.getNotifier`, async t => {
   const notifier = await E(userSeat).getNotifier();
 
   // Mint some gains to change the allocation.
-  const { brand: brand1 } = await allocateEasy(zcf, 'Stuff', zcfSeat, 'A', 3);
+  const { brand: brand1 } = await allocateEasy(zcf, 'Stuff', zcfSeat, 'A', 3n);
   t.deepEqual(await notifier.getUpdateSince(), {
     updateCount: 3,
     value: {
@@ -982,7 +991,7 @@ test(`userSeat.getNotifier`, async t => {
     },
   });
 
-  const { brand: brand2 } = await allocateEasy(zcf, 'Stuff2', zcfSeat, 'B', 6);
+  const { brand: brand2 } = await allocateEasy(zcf, 'Stuff2', zcfSeat, 'B', 6n);
   t.deepEqual(await notifier.getUpdateSince(2), {
     updateCount: 4,
     value: {
@@ -1015,7 +1024,7 @@ test(`userSeat.getPayouts, getPayout from zcf.makeEmptySeatKit`, async t => {
     'Stuff',
     zcfSeat,
     'A',
-    3,
+    3n,
   );
 
   // Again, mint some gains to change the allocation.
@@ -1024,7 +1033,7 @@ test(`userSeat.getPayouts, getPayout from zcf.makeEmptySeatKit`, async t => {
     'Stuff2',
     zcfSeat,
     'B',
-    6,
+    6n,
   );
 
   t.deepEqual(await E(userSeat).getCurrentAllocation(), {
@@ -1084,46 +1093,46 @@ test(`zcf.reallocate 3 seats, rights conserved`, async t => {
   const { zcfSeat: zcfSeat1 } = await makeOffer(
     zoe,
     zcf,
-    harden({ want: { A: simoleans(2) }, give: { B: moola(3) } }),
-    harden({ B: moolaKit.mint.mintPayment(moola(3)) }),
+    harden({ want: { A: simoleans(2n) }, give: { B: moola(3n) } }),
+    harden({ B: moolaKit.mint.mintPayment(moola(3n)) }),
   );
   const { zcfSeat: zcfSeat2 } = await makeOffer(
     zoe,
     zcf,
     harden({
-      want: { Whatever: moola(2) },
-      give: { Whatever2: simoleans(2) },
+      want: { Whatever: moola(2n) },
+      give: { Whatever2: simoleans(2n) },
     }),
-    harden({ Whatever2: simoleanKit.mint.mintPayment(simoleans(2)) }),
+    harden({ Whatever2: simoleanKit.mint.mintPayment(simoleans(2n)) }),
   );
 
   const { zcfSeat: zcfSeat3 } = await makeOffer(
     zoe,
     zcf,
     harden({
-      want: { Whatever: moola(1) },
+      want: { Whatever: moola(1n) },
     }),
   );
   zcfSeat1.decrementBy({ B: moola(3n) });
-  zcfSeat3.incrementBy({ Whatever: moola(1) });
-  zcfSeat2.incrementBy({ Whatever: moola(2) });
+  zcfSeat3.incrementBy({ Whatever: moola(1n) });
+  zcfSeat2.incrementBy({ Whatever: moola(2n) });
 
-  zcfSeat2.decrementBy({ Whatever2: simoleans(2) });
-  zcfSeat1.incrementBy({ A: simoleans(2) });
+  zcfSeat2.decrementBy({ Whatever2: simoleans(2n) });
+  zcfSeat1.incrementBy({ A: simoleans(2n) });
 
   zcf.reallocate(zcfSeat1, zcfSeat2, zcfSeat3);
   t.deepEqual(zcfSeat1.getCurrentAllocation(), {
-    A: simoleans(2),
+    A: simoleans(2n),
     B: moola(0n),
   });
 
   t.deepEqual(zcfSeat2.getCurrentAllocation(), {
-    Whatever: moola(2),
-    Whatever2: simoleans(0),
+    Whatever: moola(2n),
+    Whatever2: simoleans(0n),
   });
 
   t.deepEqual(zcfSeat3.getCurrentAllocation(), {
-    Whatever: moola(1),
+    Whatever: moola(1n),
   });
 });
 
@@ -1137,29 +1146,29 @@ test(`zcf.reallocate 3 seats, some not staged`, async t => {
   const { zcfSeat: zcfSeat1 } = await makeOffer(
     zoe,
     zcf,
-    harden({ want: { A: simoleans(2) }, give: { B: moola(3) } }),
-    harden({ B: moolaKit.mint.mintPayment(moola(3)) }),
+    harden({ want: { A: simoleans(2n) }, give: { B: moola(3n) } }),
+    harden({ B: moolaKit.mint.mintPayment(moola(3n)) }),
   );
   const { zcfSeat: zcfSeat2 } = await makeOffer(
     zoe,
     zcf,
     harden({
-      want: { Whatever: moola(2) },
-      give: { Whatever2: simoleans(2) },
+      want: { Whatever: moola(2n) },
+      give: { Whatever2: simoleans(2n) },
     }),
-    harden({ Whatever2: simoleanKit.mint.mintPayment(simoleans(2)) }),
+    harden({ Whatever2: simoleanKit.mint.mintPayment(simoleans(2n)) }),
   );
 
   const { zcfSeat: zcfSeat3 } = await makeOffer(
     zoe,
     zcf,
     harden({
-      want: { Whatever: moola(1) },
+      want: { Whatever: moola(1n) },
     }),
   );
 
   zcfSeat1.incrementBy({
-    A: simoleans(100),
+    A: simoleans(100n),
   });
 
   t.throws(() => zcf.reallocate(zcfSeat1, zcfSeat2, zcfSeat3), {
@@ -1168,12 +1177,12 @@ test(`zcf.reallocate 3 seats, some not staged`, async t => {
   });
 
   t.deepEqual(zcfSeat1.getCurrentAllocation(), {
-    A: simoleans(0),
-    B: moola(3),
+    A: simoleans(0n),
+    B: moola(3n),
   });
   t.deepEqual(zcfSeat2.getCurrentAllocation(), {
     Whatever: moola(0n),
-    Whatever2: simoleans(2),
+    Whatever2: simoleans(2n),
   });
   t.deepEqual(zcfSeat3.getCurrentAllocation(), { Whatever: moola(0n) });
 });
@@ -1188,45 +1197,45 @@ test(`zcf.reallocate 3 seats, rights NOT conserved`, async t => {
   const { zcfSeat: zcfSeat1 } = await makeOffer(
     zoe,
     zcf,
-    harden({ want: { A: simoleans(2) }, give: { B: moola(3) } }),
-    harden({ B: moolaKit.mint.mintPayment(moola(3)) }),
+    harden({ want: { A: simoleans(2n) }, give: { B: moola(3n) } }),
+    harden({ B: moolaKit.mint.mintPayment(moola(3n)) }),
   );
   const { zcfSeat: zcfSeat2 } = await makeOffer(
     zoe,
     zcf,
     harden({
-      want: { Whatever: moola(2) },
-      give: { Whatever2: simoleans(2) },
+      want: { Whatever: moola(2n) },
+      give: { Whatever2: simoleans(2n) },
     }),
-    harden({ Whatever2: simoleanKit.mint.mintPayment(simoleans(2)) }),
+    harden({ Whatever2: simoleanKit.mint.mintPayment(simoleans(2n)) }),
   );
 
   const { zcfSeat: zcfSeat3 } = await makeOffer(
     zoe,
     zcf,
     harden({
-      want: { Whatever: moola(1) },
+      want: { Whatever: moola(1n) },
     }),
   );
 
-  zcfSeat2.decrementBy({ Whatever2: simoleans(2) });
+  zcfSeat2.decrementBy({ Whatever2: simoleans(2n) });
   // This does not conserve rights in the slightest
   zcfSeat1.incrementBy({
-    A: simoleans(100),
+    A: simoleans(100n),
   });
-  zcfSeat3.incrementBy({ Whatever: moola(1) });
+  zcfSeat3.incrementBy({ Whatever: moola(1n) });
 
   t.throws(() => zcf.reallocate(zcfSeat1, zcfSeat2, zcfSeat3), {
     message: /rights were not conserved for brand .*/,
   });
 
   t.deepEqual(zcfSeat1.getCurrentAllocation(), {
-    A: simoleans(0),
-    B: moola(3),
+    A: simoleans(0n),
+    B: moola(3n),
   });
   t.deepEqual(zcfSeat2.getCurrentAllocation(), {
     Whatever: moola(0n),
-    Whatever2: simoleans(2),
+    Whatever2: simoleans(2n),
   });
   t.deepEqual(zcfSeat3.getCurrentAllocation(), { Whatever: moola(0n) });
 });
@@ -1263,11 +1272,11 @@ test(`zcf.shutdown - no further offers accepted`, async t => {
 test(`zcf.shutdownWithFailure - no further offers accepted`, async t => {
   const { zoe, zcf, vatAdminState } = await setupZCFTest();
   const invitation = await zcf.makeInvitation(() => {}, 'seat');
-  zcf.shutdownWithFailure(`And don't come back`);
+  zcf.shutdownWithFailure(Error(`And don't come back`));
   await t.throwsAsync(() => E(zoe).offer(invitation), {
     message: 'No further offers are accepted',
   });
-  t.is(vatAdminState.getExitMessage(), `And don't come back`);
+  t.is(vatAdminState.getExitMessage().message, `And don't come back`);
   t.truthy(vatAdminState.getExitWithFailure());
 });
 

--- a/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
@@ -31,30 +31,35 @@ test(`zoeHelper with zcf - swap`, async t => {
   const { zcfSeat: aZcfSeat, userSeat: aUserSeat } = await makeOffer(
     zoe,
     zcf,
-    harden({ want: { A: moola(3) }, give: { B: simoleans(7) } }),
-    { B: simoleanMint.mintPayment(simoleans(7)) },
+    harden({ want: { A: moola(3n) }, give: { B: simoleans(7n) } }),
+    { B: simoleanMint.mintPayment(simoleans(7n)) },
   );
   const { zcfSeat: bZcfSeat, userSeat: bUserSeat } = await makeOffer(
     zoe,
     zcf,
-    harden({ want: { B: simoleans(3) }, give: { A: moola(5) } }),
-    { A: moolaMint.mintPayment(moola(5)) },
+    harden({ want: { B: simoleans(3n) }, give: { A: moola(5n) } }),
+    { A: moolaMint.mintPayment(moola(5n)) },
   );
   const message = await swap(zcf, aZcfSeat, bZcfSeat);
   t.is(
     message,
     'The offer has been accepted. Once the contract has been completed, please check your payout',
   );
-  assertPayoutAmount(t, moolaIssuer, await aUserSeat.getPayout('A'), moola(3));
+  await assertPayoutAmount(
+    t,
+    moolaIssuer,
+    await aUserSeat.getPayout('A'),
+    moola(3n),
+  );
   const seat1PayoutB = await aUserSeat.getPayout('B');
-  assertPayoutAmount(t, simoleanIssuer, seat1PayoutB, simoleans(4));
+  await assertPayoutAmount(t, simoleanIssuer, seat1PayoutB, simoleans(4n));
   const seat2PayoutB = await bUserSeat.getPayout('B');
-  assertPayoutAmount(t, simoleanIssuer, seat2PayoutB, simoleans(3));
+  await assertPayoutAmount(t, simoleanIssuer, seat2PayoutB, simoleans(3n));
   await assertPayoutAmount(
     t,
     moolaIssuer,
     await bUserSeat.getPayout('A'),
-    moola(2),
+    moola(2n),
   );
 });
 
@@ -73,14 +78,14 @@ test(`zoeHelper with zcf - swap no match`, async t => {
   const { zcfSeat: aZcfSeat, userSeat: aUserSeat } = await makeOffer(
     zoe,
     zcf,
-    harden({ want: { A: moola(20) }, give: { B: simoleans(3) } }),
-    { B: simoleanMint.mintPayment(simoleans(3)) },
+    harden({ want: { A: moola(20n) }, give: { B: simoleans(3n) } }),
+    { B: simoleanMint.mintPayment(simoleans(3n)) },
   );
   const { zcfSeat: bZcfSeat, userSeat: bUserSeat } = await makeOffer(
     zoe,
     zcf,
-    harden({ want: { B: simoleans(43) }, give: { A: moola(5) } }),
-    { A: moolaMint.mintPayment(moola(5)) },
+    harden({ want: { B: simoleans(43n) }, give: { A: moola(5n) } }),
+    { A: moolaMint.mintPayment(moola(5n)) },
   );
   t.throws(
     () => swap(zcf, aZcfSeat, bZcfSeat),
@@ -90,16 +95,21 @@ test(`zoeHelper with zcf - swap no match`, async t => {
     },
     'mismatched offers',
   );
-  assertPayoutAmount(t, moolaIssuer, await aUserSeat.getPayout('A'), moola(0n));
+  await assertPayoutAmount(
+    t,
+    moolaIssuer,
+    await aUserSeat.getPayout('A'),
+    moola(0n),
+  );
   const seat1PayoutB = await aUserSeat.getPayout('B');
-  assertPayoutAmount(t, simoleanIssuer, seat1PayoutB, simoleans(3));
+  await assertPayoutAmount(t, simoleanIssuer, seat1PayoutB, simoleans(3n));
   const seat2PayoutB = await bUserSeat.getPayout('B');
-  assertPayoutAmount(t, simoleanIssuer, seat2PayoutB, simoleans(0));
+  await assertPayoutAmount(t, simoleanIssuer, seat2PayoutB, simoleans(0n));
   await assertPayoutAmount(
     t,
     moolaIssuer,
     await bUserSeat.getPayout('A'),
-    moola(5),
+    moola(5n),
   );
 });
 
@@ -238,8 +248,8 @@ test(`zoeHelper with zcf - assertIssuerKeywords`, async t => {
   await makeOffer(
     zoe,
     zcf,
-    harden({ want: { A: moola(20) }, give: { B: simoleans(3) } }),
-    { B: simoleanMint.mintPayment(simoleans(3)) },
+    harden({ want: { A: moola(20n) }, give: { B: simoleans(3n) } }),
+    { B: simoleanMint.mintPayment(simoleans(3n)) },
   );
 
   t.throws(
@@ -295,8 +305,8 @@ test(`zoeHelper with zcf - assertProposalShape`, async t => {
   const { zcfSeat } = await makeOffer(
     zoe,
     zcf,
-    harden({ want: { A: moola(20) }, give: { B: simoleans(3) } }),
-    { B: simoleanMint.mintPayment(simoleans(3)) },
+    harden({ want: { A: moola(20n) }, give: { B: simoleans(3n) } }),
+    { B: simoleanMint.mintPayment(simoleans(3n)) },
   );
 
   // @ts-ignore invalid arguments for testing
@@ -343,37 +353,42 @@ test(`zoeHelper w/zcf - swapExact`, async t => {
   const { zcfSeat: zcfSeatA, userSeat: userSeatA } = await makeOffer(
     zoe,
     zcf,
-    harden({ want: { A: moola(20) }, give: { B: simoleans(3) } }),
-    { B: simoleanMint.mintPayment(simoleans(3)) },
+    harden({ want: { A: moola(20n) }, give: { B: simoleans(3n) } }),
+    { B: simoleanMint.mintPayment(simoleans(3n)) },
   );
   const { zcfSeat: zcfSeatB, userSeat: userSeatB } = await makeOffer(
     zoe,
     zcf,
-    harden({ want: { C: simoleans(3) }, give: { D: moola(20) } }),
-    { D: moolaMint.mintPayment(moola(20)) },
+    harden({ want: { C: simoleans(3n) }, give: { D: moola(20n) } }),
+    { D: moolaMint.mintPayment(moola(20n)) },
   );
 
   const swapMsg = swapExact(zcf, zcfSeatA, zcfSeatB);
 
   t.truthy(swapMsg, 'swap succeeded');
   t.truthy(zcfSeatA.hasExited(), 'exit right');
-  assertPayoutAmount(t, moolaIssuer, await userSeatA.getPayout('A'), moola(20));
-  assertPayoutAmount(
+  await assertPayoutAmount(
+    t,
+    moolaIssuer,
+    await userSeatA.getPayout('A'),
+    moola(20n),
+  );
+  await assertPayoutAmount(
     t,
     simoleanIssuer,
     await userSeatA.getPayout('B'),
-    simoleans(0),
+    simoleans(0n),
   );
   t.deepEqual(Object.getOwnPropertyNames(await userSeatA.getPayouts()), [
     'B',
     'A',
   ]);
   t.truthy(zcfSeatB.hasExited(), 'exit right');
-  assertPayoutAmount(
+  await assertPayoutAmount(
     t,
     simoleanIssuer,
     await userSeatB.getPayout('C'),
-    simoleans(3),
+    simoleans(3n),
   );
   await assertPayoutAmount(
     t,
@@ -402,39 +417,44 @@ test(`zoeHelper w/zcf - swapExact w/shortage`, async t => {
   const { zcfSeat: zcfSeatA, userSeat: userSeatA } = await makeOffer(
     zoe,
     zcf,
-    harden({ want: { A: moola(20) }, give: { B: simoleans(10) } }),
-    { B: simoleanMint.mintPayment(simoleans(10)) },
+    harden({ want: { A: moola(20n) }, give: { B: simoleans(10n) } }),
+    { B: simoleanMint.mintPayment(simoleans(10n)) },
   );
   const { zcfSeat: zcfSeatB, userSeat: userSeatB } = await makeOffer(
     zoe,
     zcf,
-    harden({ want: { C: simoleans(10) }, give: { D: moola(15) } }),
-    { D: moolaMint.mintPayment(moola(15)) },
+    harden({ want: { C: simoleans(10n) }, give: { D: moola(15n) } }),
+    { D: moolaMint.mintPayment(moola(15n)) },
   );
 
   t.throws(() => swapExact(zcf, zcfSeatA, zcfSeatB), {
     message: 'rights were not conserved for brand "[Alleged: moola brand]"',
   });
   t.truthy(zcfSeatA.hasExited(), 'fail right');
-  assertPayoutAmount(t, moolaIssuer, await userSeatA.getPayout('A'), moola(0n));
-  assertPayoutAmount(
+  await assertPayoutAmount(
+    t,
+    moolaIssuer,
+    await userSeatA.getPayout('A'),
+    moola(0n),
+  );
+  await assertPayoutAmount(
     t,
     simoleanIssuer,
     await userSeatA.getPayout('B'),
-    simoleans(10),
+    simoleans(10n),
   );
   t.truthy(zcfSeatB.hasExited(), 'fail right');
-  assertPayoutAmount(
+  await assertPayoutAmount(
     t,
     simoleanIssuer,
     await userSeatB.getPayout('C'),
-    simoleans(0),
+    simoleans(0n),
   );
   await assertPayoutAmount(
     t,
     moolaIssuer,
     await userSeatB.getPayout('D'),
-    moola(15),
+    moola(15n),
   );
 });
 
@@ -453,39 +473,44 @@ test(`zoeHelper w/zcf - swapExact w/excess`, async t => {
   const { zcfSeat: zcfSeatA, userSeat: userSeatA } = await makeOffer(
     zoe,
     zcf,
-    harden({ want: { A: moola(20) }, give: { B: simoleans(10) } }),
-    { B: simoleanMint.mintPayment(simoleans(10)) },
+    harden({ want: { A: moola(20n) }, give: { B: simoleans(10n) } }),
+    { B: simoleanMint.mintPayment(simoleans(10n)) },
   );
   const { zcfSeat: zcfSeatB, userSeat: userSeatB } = await makeOffer(
     zoe,
     zcf,
-    harden({ want: { C: simoleans(10) }, give: { D: moola(40) } }),
-    { D: moolaMint.mintPayment(moola(40)) },
+    harden({ want: { C: simoleans(10n) }, give: { D: moola(40n) } }),
+    { D: moolaMint.mintPayment(moola(40n)) },
   );
 
   t.throws(() => swapExact(zcf, zcfSeatA, zcfSeatB), {
     message: 'rights were not conserved for brand "[Alleged: moola brand]"',
   });
   t.truthy(zcfSeatA.hasExited(), 'fail right');
-  assertPayoutAmount(t, moolaIssuer, await userSeatA.getPayout('A'), moola(0n));
-  assertPayoutAmount(
+  await assertPayoutAmount(
+    t,
+    moolaIssuer,
+    await userSeatA.getPayout('A'),
+    moola(0n),
+  );
+  await assertPayoutAmount(
     t,
     simoleanIssuer,
     await userSeatA.getPayout('B'),
-    simoleans(10),
+    simoleans(10n),
   );
   t.truthy(zcfSeatB.hasExited(), 'fail right');
-  assertPayoutAmount(
+  await assertPayoutAmount(
     t,
     simoleanIssuer,
     await userSeatB.getPayout('C'),
-    simoleans(0),
+    simoleans(0n),
   );
   await assertPayoutAmount(
     t,
     moolaIssuer,
     await userSeatB.getPayout('D'),
-    moola(40),
+    moola(40n),
   );
 });
 
@@ -504,38 +529,38 @@ test(`zoeHelper w/zcf - swapExact w/extra payments`, async t => {
   const { zcfSeat: zcfSeatA, userSeat: userSeatA } = await makeOffer(
     zoe,
     zcf,
-    harden({ give: { B: simoleans(10) } }),
-    { B: simoleanMint.mintPayment(simoleans(10)) },
+    harden({ give: { B: simoleans(10n) } }),
+    { B: simoleanMint.mintPayment(simoleans(10n)) },
   );
   const { zcfSeat: zcfSeatB, userSeat: userSeatB } = await makeOffer(
     zoe,
     zcf,
-    harden({ want: { C: simoleans(10) }, give: { D: moola(40) } }),
-    { D: moolaMint.mintPayment(moola(40)) },
+    harden({ want: { C: simoleans(10n) }, give: { D: moola(40n) } }),
+    { D: moolaMint.mintPayment(moola(40n)) },
   );
 
   t.throws(() => swapExact(zcf, zcfSeatA, zcfSeatB), {
     message: 'rights were not conserved for brand "[Alleged: moola brand]"',
   });
   t.truthy(zcfSeatA.hasExited(), 'fail right');
-  assertPayoutAmount(
+  await assertPayoutAmount(
     t,
     simoleanIssuer,
     await userSeatA.getPayout('B'),
-    simoleans(10),
+    simoleans(10n),
   );
   t.truthy(zcfSeatB.hasExited(), 'fail right');
-  assertPayoutAmount(
+  await assertPayoutAmount(
     t,
     simoleanIssuer,
     await userSeatB.getPayout('C'),
-    simoleans(0),
+    simoleans(0n),
   );
   await assertPayoutAmount(
     t,
     moolaIssuer,
     await userSeatB.getPayout('D'),
-    moola(40),
+    moola(40n),
   );
 });
 
@@ -553,12 +578,12 @@ test(`zcf/zoeHelper - assertProposalShape w/bad Expected`, async t => {
   const { zcfSeat } = await makeOffer(
     zoe,
     zcf,
-    harden({ want: { A: moola(20) }, give: { B: simoleans(3) } }),
-    { B: simoleanMint.mintPayment(simoleans(3)) },
+    harden({ want: { A: moola(20n) }, give: { B: simoleans(3n) } }),
+    { B: simoleanMint.mintPayment(simoleans(3n)) },
   );
 
   // @ts-ignore invalid arguments for testing
-  t.throws(() => assertProposalShape(zcfSeat, { give: { B: moola(3) } }), {
+  t.throws(() => assertProposalShape(zcfSeat, { give: { B: moola(3n) } }), {
     message: /The value of the expected record must be null but was .*/,
   });
 });

--- a/packages/zoe/test/unitTests/zoe/test-burnInvitation.js
+++ b/packages/zoe/test/unitTests/zoe/test-burnInvitation.js
@@ -15,9 +15,10 @@ test('burnInvitation', async t => {
   const invitationHandle = Far('handle', {});
 
   const invitation = mockInvitationKit.mint.mintPayment(
-    AmountMath.make(mockInvitationKit.brand, [
-      { instance: instanceHandle, handle: invitationHandle },
-    ]),
+    AmountMath.make(
+      mockInvitationKit.brand,
+      harden([{ instance: instanceHandle, handle: invitationHandle }]),
+    ),
   );
 
   t.deepEqual(await burnInvitation(mockInvitationKit.issuer, invitation), {
@@ -45,9 +46,10 @@ test('burnInvitation - invitation already used', async t => {
   const invitationHandle = Far('handle', {});
 
   const invitation = mockInvitationKit.mint.mintPayment(
-    AmountMath.make(mockInvitationKit.brand, [
-      { instance: instanceHandle, handle: invitationHandle },
-    ]),
+    AmountMath.make(
+      mockInvitationKit.brand,
+      harden([{ instance: instanceHandle, handle: invitationHandle }]),
+    ),
   );
 
   t.deepEqual(await burnInvitation(mockInvitationKit.issuer, invitation), {
@@ -74,10 +76,13 @@ test('burnInvitation - multiple invitations', async t => {
   const invitationHandle2 = Far('handle', {});
 
   const invitations = mockInvitationKit.mint.mintPayment(
-    AmountMath.make(mockInvitationKit.brand, [
-      { instance: instanceHandle, handle: invitationHandle1 },
-      { instance: instanceHandle, handle: invitationHandle2 },
-    ]),
+    AmountMath.make(
+      mockInvitationKit.brand,
+      harden([
+        { instance: instanceHandle, handle: invitationHandle1 },
+        { instance: instanceHandle, handle: invitationHandle2 },
+      ]),
+    ),
   );
 
   await t.throwsAsync(

--- a/packages/zoe/test/unitTests/zoe/test-escrowStorage.js
+++ b/packages/zoe/test/unitTests/zoe/test-escrowStorage.js
@@ -32,15 +32,17 @@ test('makeEscrowStorage', async t => {
   // Normally only used for ZCFMint issuers
   makeLocalPurse(ticketKit.issuer, ticketKit.brand);
 
-  const gameTicketAmount = AmountMath.make(ticketKit.brand, [
-    { show: 'superbowl' },
-  ]);
+  const gameTicketAmount = AmountMath.make(
+    ticketKit.brand,
+    harden([{ show: 'superbowl' }]),
+  );
 
   const currencyAmount = AmountMath.make(currencyKit.brand, 5n * 10n ** 18n);
 
-  const wantedConcertTicketAmount = AmountMath.make(ticketKit.brand, [
-    { show: 'my show' },
-  ]);
+  const wantedConcertTicketAmount = AmountMath.make(
+    ticketKit.brand,
+    harden([{ show: 'my show' }]),
+  );
 
   const paymentPKeywordRecord = harden({
     GameTicket: E(ticketKit.mint).mintPayment(gameTicketAmount),
@@ -138,9 +140,10 @@ test('payments without matching give keywords', async t => {
 
   const { ticketKit, currencyKit } = setupPurses(createPurse);
 
-  const gameTicketAmount = AmountMath.make(ticketKit.brand, [
-    { show: 'superbowl' },
-  ]);
+  const gameTicketAmount = AmountMath.make(
+    ticketKit.brand,
+    harden([{ show: 'superbowl' }]),
+  );
 
   const currencyAmount = AmountMath.make(currencyKit.brand, 5n * 10n ** 18n);
 
@@ -172,9 +175,10 @@ test(`give keywords without matching payments`, async t => {
 
   const { ticketKit, currencyKit } = setupPurses(createPurse);
 
-  const gameTicketAmount = AmountMath.make(ticketKit.brand, [
-    { show: 'superbowl' },
-  ]);
+  const gameTicketAmount = AmountMath.make(
+    ticketKit.brand,
+    harden([{ show: 'superbowl' }]),
+  );
 
   const currencyAmount = AmountMath.make(currencyKit.brand, 5n * 10n ** 18n);
 

--- a/packages/zoe/test/unitTests/zoe/test-feePurse.js
+++ b/packages/zoe/test/unitTests/zoe/test-feePurse.js
@@ -8,9 +8,13 @@ import { makeIssuerKit, AssetKind, AmountMath } from '@agoric/ertp';
 import { setupMakeFeePurse } from '../../../src/zoeService/feePurse.js';
 
 const setup = () => {
-  const runIssuerKit = makeIssuerKit('RUN', AssetKind.NAT, {
-    decimalPlaces: 6,
-  });
+  const runIssuerKit = makeIssuerKit(
+    'RUN',
+    AssetKind.NAT,
+    harden({
+      decimalPlaces: 6,
+    }),
+  );
   const { makeFeePurse, chargeZoeFee } = setupMakeFeePurse(runIssuerKit.issuer);
   return { makeFeePurse, chargeZoeFee, runIssuerKit };
 };

--- a/packages/zoe/test/unitTests/zoe/test-installationStorage.js
+++ b/packages/zoe/test/unitTests/zoe/test-installationStorage.js
@@ -7,6 +7,7 @@ import { makeInstallationStorage } from '../../../src/zoeService/installationSto
 
 test('install, unwrap installations', async t => {
   const chargeZoeFee = () => true;
+  // @ts-ignore No amount passed because no fees charged
   const { install, unwrapInstallation } = makeInstallationStorage(chargeZoeFee);
   const fakeBundle = {};
   const feePurse = /** @type {FeePurse} */ ({});
@@ -19,6 +20,7 @@ test('install, unwrap installations', async t => {
 
 test('unwrap promise for installation', async t => {
   const chargeZoeFee = () => true;
+  // @ts-ignore No amount passed because no fees charged
   const { install, unwrapInstallation } = makeInstallationStorage(chargeZoeFee);
   const fakeBundle = {};
   const feePurse = /** @type {FeePurse} */ ({});
@@ -31,6 +33,7 @@ test('unwrap promise for installation', async t => {
 
 test('install several', async t => {
   const chargeZoeFee = () => true;
+  // @ts-ignore No amount passed because no fees charged
   const { install, unwrapInstallation } = makeInstallationStorage(chargeZoeFee);
   const fakeBundle1 = {};
   const fakeBundle2 = {};
@@ -49,6 +52,7 @@ test('install several', async t => {
 
 test('install same twice', async t => {
   const chargeZoeFee = () => true;
+  // @ts-ignore No amount passed because no fees charged
   const { install, unwrapInstallation } = makeInstallationStorage(chargeZoeFee);
   const fakeBundle1 = {};
   const feePurse = /** @type {FeePurse} */ ({});

--- a/packages/zoe/test/unitTests/zoe/test-makeInvitation.js
+++ b/packages/zoe/test/unitTests/zoe/test-makeInvitation.js
@@ -34,18 +34,21 @@ test('createInvitationKit', async t => {
 
   t.deepEqual(
     amount,
-    AmountMath.make(invitationBrand, [
-      {
-        description: 'myInvitation',
-        fruit: 'apple',
-        handle: mockInvitationHandle,
-        installation: mockInstallation,
-        instance: mockInstance,
-        fee: undefined,
-        expiry: undefined,
-        zoeTimeAuthority: undefined,
-      },
-    ]),
+    AmountMath.make(
+      invitationBrand,
+      harden([
+        {
+          description: 'myInvitation',
+          fruit: 'apple',
+          handle: mockInvitationHandle,
+          installation: mockInstallation,
+          instance: mockInstance,
+          fee: undefined,
+          expiry: undefined,
+          zoeTimeAuthority: undefined,
+        },
+      ]),
+    ),
   );
 });
 
@@ -99,16 +102,19 @@ test('customProperties ok to omit', async t => {
 
   t.deepEqual(
     amount,
-    AmountMath.make(invitationBrand, [
-      {
-        description: 'myInvitation',
-        handle: mockInvitationHandle,
-        installation: mockInstallation,
-        instance: mockInstance,
-        fee: undefined,
-        expiry: undefined,
-        zoeTimeAuthority: undefined,
-      },
-    ]),
+    AmountMath.make(
+      invitationBrand,
+      harden([
+        {
+          description: 'myInvitation',
+          handle: mockInvitationHandle,
+          installation: mockInstallation,
+          instance: mockInstance,
+          fee: undefined,
+          expiry: undefined,
+          zoeTimeAuthority: undefined,
+        },
+      ]),
+    ),
   );
 });

--- a/packages/zoe/test/zoeTestHelpers.js
+++ b/packages/zoe/test/zoeTestHelpers.js
@@ -4,15 +4,17 @@ import { E } from '@agoric/eventual-send';
 
 import '../exported.js';
 import setMathHelpers from '@agoric/ertp/src/mathHelpers/setMathHelpers.js';
-import { AmountMath, looksLikeSetValue, isNatValue } from '@agoric/ertp';
+import { AmountMath, isNatValue, isSetValue } from '@agoric/ertp';
 
 import { q } from '@agoric/assert';
 
 export const assertAmountsEqual = (t, amount, expected, label = '') => {
+  harden(amount);
+  harden(expected);
   const brandsEqual = amount.brand === expected.brand;
   const l = label ? `${label} ` : '';
   let valuesEqual;
-  if (looksLikeSetValue(expected.value)) {
+  if (isSetValue(expected.value)) {
     valuesEqual = setMathHelpers.doIsEqual(amount.value, expected.value);
   } else if (isNatValue(expected.value)) {
     valuesEqual = amount.value === expected.value;

--- a/packages/zoe/tools/scriptedPriceAuthority.js
+++ b/packages/zoe/tools/scriptedPriceAuthority.js
@@ -15,7 +15,7 @@ export function makeScriptedPriceAuthority(options) {
     actualBrandOut,
     priceList,
     timer,
-    unitAmountIn = AmountMath.make(1n, actualBrandIn),
+    unitAmountIn = AmountMath.make(actualBrandIn, 1n),
     quoteInterval = 1n,
     quoteIssuerKit = makeIssuerKit('quote', AssetKind.SET),
   } = options;
@@ -24,7 +24,7 @@ export function makeScriptedPriceAuthority(options) {
 
   /** @param {PriceQuoteValue} quote */
   const authenticateQuote = quote => {
-    const quoteAmount = AmountMath.make(quote, brand);
+    const quoteAmount = AmountMath.make(brand, harden(quote));
     const quotePayment = quoteMint.mintPayment(quoteAmount);
     return harden({ quoteAmount, quotePayment });
   };
@@ -33,21 +33,21 @@ export function makeScriptedPriceAuthority(options) {
     AmountMath.coerce(actualBrandIn, amountIn);
 
     return AmountMath.make(
+      actualBrandOut,
       natSafeMath.floorDivide(
         natSafeMath.multiply(currentPrice, amountIn.value),
         unitAmountIn.value,
       ),
-      actualBrandOut,
     );
   };
   const calcAmountIn = amountOut => {
     AmountMath.coerce(actualBrandOut, amountOut);
     return AmountMath.make(
+      actualBrandOut,
       natSafeMath.floorDivide(
         natSafeMath.multiply(unitAmountIn.value, amountOut.value),
         currentPrice,
       ),
-      actualBrandOut,
     );
   };
 


### PR DESCRIPTION
This PR is the result of doing an evaluation of ERTP for missing input validation. I also did some ~~small~~ large clean up to ensure that the input validation was easy to audit. Namely, NatValues now only accept bigints, lower-case `amountMath` is removed, and AmountMath methods always follow the order of: `brand`, `value`. I removed the `looksLike` usage to make it clearer when something was actually trying to validate inputs rather than sniff to see what kind of validation to do.

- `@agoric/same-structure` is deprecated, so I changed to using `@agoric/marshal`
- I removed inconsistent input validation or added comments explaining the difference
- renamed the ERTP `reallocate` function to `moveAssets` for clarity
- renamed `checkForDupes` to `assertNoDuplicates` to fit the standard of using `assert` for a function that throws
- improved error messages for common errors

Closes: #3202 
Closes: #3867 
Closes: #3885 
Closes: #3960
Closes: #3089
Closes: #3045

#documentation-branch: 3885-ertp-input-validation
#dapp-card-store-branch: 3885-ertp-input-validation
#dapp-oracle-branch: 3885-ertp-input-validation
#dapp-otc-branch: 3885-ertp-input-validation