### PR TITLE
Local SwingSet worker debugging

### DIFF
--- a/packages/SwingSet/misc-tools/replay-transcript.js
+++ b/packages/SwingSet/misc-tools/replay-transcript.js
@@ -1,5 +1,4 @@
 /* global WeakRef FinalizationRegistry */
-import { performance } from 'perf_hooks';
 import fs from 'fs';
 // import '@agoric/install-ses';
 import '../tools/install-ses-debug.js';
@@ -68,7 +67,7 @@ async function replay(transcriptFile) {
     FinalizationRegistry,
     waitUntilQuiescent,
     gcAndFinalize: makeGcAndFinalize(gcEveryCrank ? engineGC : false),
-    meterControl: makeDummyMeterControl(),
+    meterControl,
   });
   const allVatPowers = { testLog };
 

--- a/packages/SwingSet/src/controller.js
+++ b/packages/SwingSet/src/controller.js
@@ -391,6 +391,7 @@ export async function makeSwingsetController(
  * @param {string[]} argv
  * @param {{
  *   hostStorage?: HostStore,
+ *   env?: Record<string, string>,
  *   verbose?: boolean,
  *   kernelBundles?: Record<string, string>,
  *   debugPrefix?: string,
@@ -409,6 +410,7 @@ export async function buildVatController(
 ) {
   const {
     hostStorage = provideHostStorage(),
+    env,
     verbose,
     kernelBundles,
     debugPrefix,
@@ -417,6 +419,7 @@ export async function buildVatController(
     slogFile,
   } = runtimeOptions;
   const actualRuntimeOptions = {
+    env,
     verbose,
     debugPrefix,
     slogCallbacks,
@@ -431,6 +434,7 @@ export async function buildVatController(
       argv,
       hostStorage,
       initializationOptions,
+      runtimeOptions,
     );
   }
   const controller = await makeSwingsetController(

--- a/packages/SwingSet/src/initializeSwingset.js
+++ b/packages/SwingSet/src/initializeSwingset.js
@@ -278,7 +278,10 @@ export async function initializeSwingset(
 
   // Use ambient process.env only if caller did not specify.
   const { env: { SWINGSET_WORKER_TYPE } = process.env } = runtimeOptions;
-  const defaultManagerType = config.defaultManagerType || SWINGSET_WORKER_TYPE;
+
+  // Override the worker type if specified by the caller, to avoid having to
+  // edit the config just to run everything under a different manager.
+  const defaultManagerType = SWINGSET_WORKER_TYPE || config.defaultManagerType;
   switch (defaultManagerType) {
     case 'local':
     case 'nodeWorker':

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -453,9 +453,9 @@ export default function buildKernel(
           used = BigInt(consumed);
           policyInput = ['crank', { computrons: used }];
         }
-        if (useMeter && meterID) {
-          // if we have a Meter, the result must include metering
-          assert(metering);
+        if (useMeter && metering !== null && meterID) {
+          // If we have a Meter, and the manager reported a non-null value, use it.
+          assert(used !== undefined);
           const underflow = deductMeter(meterID, used, true);
           if (underflow) {
             console.log(`meter ${meterID} underflow, terminating vat ${vatID}`);

--- a/packages/SwingSet/src/kernel/vatManager/manager-helper.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-helper.js
@@ -103,6 +103,8 @@ import { makeTranscriptManager } from './transcript.js';
  * @param { KernelSlog } kernelSlog
  * @param { (vso: VatSyscallObject) => VatSyscallResult } vatSyscallHandler
  * @param { boolean } workerCanBlock
+ * @param { (vatID: any, originalSyscall: any, newSyscall: any) => Error | undefined } [compareSyscalls]
+ * @param { boolean } [useTranscript]
  * @returns { ManagerKit }
  */
 

--- a/packages/SwingSet/src/kernel/vatManager/manager-local.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-local.js
@@ -52,7 +52,6 @@ export function makeLocalVatManagerFactory(tools) {
   }
 
   function createFromSetup(vatID, setup, managerOptions, vatSyscallHandler) {
-    assert(!managerOptions.metered, `metering unsupported on 'local' workers`);
     assert.typeof(setup, 'function', 'setup is not an in-realm function');
 
     const { vatParameters, compareSyscalls, useTranscript } = managerOptions;
@@ -77,7 +76,6 @@ export function makeLocalVatManagerFactory(tools) {
     managerOptions,
     vatSyscallHandler,
   ) {
-    assert(!managerOptions.metered, `metering unsupported on 'local' workers`);
     const {
       consensusMode,
       enableDisavow = false,

--- a/packages/SwingSet/src/kernel/vatManager/manager-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-nodeworker.js
@@ -45,7 +45,6 @@ export function makeNodeWorkerVatManagerFactory(tools) {
       compareSyscalls,
       useTranscript,
     } = managerOptions;
-    assert(!managerOptions.metered, 'not supported yet');
     assert(!managerOptions.enableSetup, 'not supported at all');
 
     // We use workerCanBlock=false because we get syscalls via an async

--- a/packages/SwingSet/src/kernel/vatManager/manager-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vatManager/manager-subprocess-node.js
@@ -25,7 +25,6 @@ export function makeNodeSubprocessFactory(tools) {
       compareSyscalls,
       useTranscript,
     } = managerOptions;
-    assert(!managerOptions.metered, 'not supported yet');
     assert(!managerOptions.enableSetup, 'not supported at all');
 
     const mk = makeManagerKit(

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -165,7 +165,9 @@ test('validate config.defaultManagerType', async t => {
     new URL('basedir-controller-2', import.meta.url).pathname,
   );
   config.defaultManagerType = 'XYZ';
-  await t.throwsAsync(buildVatController(config), { message: /XYZ/ });
+  await t.throwsAsync(buildVatController(config, undefined, { env: {} }), {
+    message: /XYZ/,
+  });
 });
 
 test.serial('bootstrap export', async t => {

--- a/packages/SwingSet/test/test-device-bridge.js
+++ b/packages/SwingSet/test/test-device-bridge.js
@@ -126,11 +126,11 @@ test('bridge device can return undefined', async t => {
   const hostStorage = provideHostStorage();
   const config = {
     bootstrap: 'bootstrap',
-    defaultManagerType: 'local',
     vats: {
       bootstrap: {
         sourceSpec: new URL('./device-bridge-bootstrap.js', import.meta.url)
           .pathname,
+        creationOptions: { managerType: 'local' },
       },
     },
     devices: {

--- a/packages/SwingSet/test/virtualObjects/test-weakcollections.js
+++ b/packages/SwingSet/test/virtualObjects/test-weakcollections.js
@@ -18,7 +18,6 @@ function capargs(args, slots = []) {
 test('weakMap in vat', async t => {
   const config = {
     bootstrap: 'bootstrap',
-    defaultManagerType: 'local',
     vats: {
       bootstrap: {
         sourceSpec: new URL('vat-weakcollections-bootstrap.js', import.meta.url)
@@ -27,6 +26,7 @@ test('weakMap in vat', async t => {
       alice: {
         sourceSpec: new URL('vat-weakcollections-alice.js', import.meta.url)
           .pathname,
+        creationOptions: { managerType: 'local' },
       },
     },
   };

--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -1,3 +1,8 @@
+# This Makefile is designed to be used with `NODE_OPTIONS=--inspect-brk` to
+# debug the main program you're running.  It clears `$NODE_OPTIONS` while
+# running incidental Node.js programs to avoid starting debuggers you probably
+# don't want.
+
 REPOSITORY = agoric/cosmic-swingset
 CHAIN_ID = agoric
 INITIAL_HEIGHT = 17
@@ -54,7 +59,7 @@ scenario2-setup-nobuild:
 	$(AGCH) --home=t1/n0 init scenario2-chain --chain-id=$(CHAIN_ID)
 	# Init all the ag-solos.
 	set -e; for port in `seq $(BASE_PORT) $$(($(BASE_PORT) + $(NUM_SOLOS) - 1))`; do \
-		$(AG_SOLO) init t1/$$port --webport=$$port; \
+		NODE_OPTIONS= $(AG_SOLO) init t1/$$port --webport=$$port; \
 	done
 	# Create the bootstrap account.
 	$(AGCH) --home=t1/bootstrap keys add bootstrap --keyring-backend=test
@@ -64,7 +69,7 @@ scenario2-setup-nobuild:
 	$(AGCH) --home=t1/n0 --keyring-dir=t1/bootstrap gentx --keyring-backend=test bootstrap 73000000ubld --chain-id=$(CHAIN_ID)
 	$(AGCH) --home=t1/n0 collect-gentxs
 	$(AGCH) --home=t1/n0 validate-genesis
-	../agoric-cli/bin/agoric set-defaults --export-metrics ag-chain-cosmos t1/n0/config
+	NODE_OPTIONS= ../agoric-cli/bin/agoric set-defaults --export-metrics ag-chain-cosmos t1/n0/config
 	# Set the chain address in all the ag-solos.
 	jq '. + { genesis_time: "$(GENESIS_TIME)", initial_height: "$(INITIAL_HEIGHT)" }' t1/n0/config/genesis.json > t1/n0/config/genesis2.json
 	mv t1/n0/config/genesis2.json t1/n0/config/genesis.json
@@ -179,7 +184,7 @@ t1-start-ag-solo: t1/$(BASE_PORT)/cosmos-client-account.setup t1/$(BASE_PORT)/co
 VATWORKER=local
 scenario3-setup:
 	rm -rf t3
-	$(AG_SOLO) init t3 --egresses=fake --webport=$(BASE_PORT) --defaultManagerType=$(VATWORKER)
+	NODE_OPTIONS= $(AG_SOLO) init t3 --egresses=fake --webport=$(BASE_PORT) --defaultManagerType=$(VATWORKER)
 	@echo 'Execute `make scenario3-run` to run the client and simulated chain'
 
 # This runs both the client and the fake chain.
@@ -187,7 +192,7 @@ scenario3-run-client: scenario3-run
 # Set the fake chain here in case the delay has changed.
 scenario3-run:
 	cd t3 && \
-			$(AG_SOLO) set-fake-chain --delay=$(FAKE_CHAIN_DELAY) mySimGCI
+		NODE_OPTIONS= $(AG_SOLO) set-fake-chain --delay=$(FAKE_CHAIN_DELAY) mySimGCI
 	cd t3 && \
 		OTEL_EXPORTER_PROMETHEUS_PORT=$(OTEL_EXPORTER_PROMETHEUS_PORT) \
 		$(AG_SOLO) start
@@ -230,5 +235,5 @@ set-local-gci-ingress:
 	rpcport=`./calc-rpcport.js t1/n0/config/config.toml`; \
 	set -e; for port in `seq $(BASE_PORT) $$(($(BASE_PORT) + $(NUM_SOLOS) - 1))`; do \
 		(cd t1/$$port && \
-			$(AG_SOLO) set-gci-ingress --chainID=$(CHAIN_ID) $$gci $$rpcport); \
+			NODE_OPTIONS= $(AG_SOLO) set-gci-ingress --chainID=$(CHAIN_ID) $$gci $$rpcport); \
 	done


### PR DESCRIPTION
These changes are to adjust some incompatibilities introduced in SwingSet that prevented debugging the sim-chain under Node.js.

- allow `$SWINGSET_WORKER_TYPE` to override SwingSet's config file default instead of providing a too-soft-to-be-useful default
- use a fake meter value instead of crashing when `SWINGSET_WORKER_TYPE=local`.

@kriskowal and I are discussing trying to support such debugging modes, starting with:

```
cd packages/cosmic-swingset
NODE_OPTIONS=--inspect-brk SWINGSET_WORKER_TYPE=local make scenario3-setup scenario3-run
```

There is still more to do to make this work nicely, but it's a start.

Next:

- propagate filenames through Endo bundles as `//#sourceURL=...` when debugging
- don't strip URL prefixes during SES stack filtering when debugging
- provide a convenient way to run in this mode using the `agoric` CLI
