### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,28 +1,28 @@
+# Linear queue for the main branch.
+queue_rules:
+  - name: main
+    conditions:
+      - base=master
+
 pull_request_rules:
   - name: automerge to master with label automerge:merge and branch protection passing
     conditions:
-      - base=master
       - label=automerge:merge
     actions:
-      merge:
+      queue:
+        name: main
         method: merge
-        strict: true
-        commit_message: title+body
   - name: automerge to master with label automerge:rebase and branch protection passing
     conditions:
-      - base=master
       - label=automerge:rebase
     actions:
-      merge:
+      queue:
+        name: main
         method: rebase
-        strict: true
-        commit_message: title+body
   - name: automerge to master with label automerge:squash and branch protection passing
     conditions:
-      - base=master
       - label=automerge:squash
     actions:
-      merge:
+      queue:
+        name: main
         method: squash
-        strict: true
-        commit_message: title+body


### PR DESCRIPTION
Use an explicit queue to avoid deprecated `strict: true` Mergify config.

Also, for now, use default GitHub-generated commit message for merge and squash.

This change has been made by @michaelfig from https://mergify.io config editor.
