### PR TITLE
chore(dockerignore): clean up handling of Terraform secrets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,8 @@ packages/cosmic-swingset/lib/lib*.h
 packages/cosmic-swingset/lib/lib*.so
 packages/swingset-runner
 packages/stat-logger
+**/deployment.json
+**/vars.tf
 **/*.log
 **/dist
 **/build

--- a/packages/deployment/.dockerignore
+++ b/packages/deployment/.dockerignore
@@ -1,4 +1,6 @@
 node_modules
+**/vars.tf
+**/deployment.json
 *.log
 dist
 build/


### PR DESCRIPTION
Ignore generated Terraform `vars.tf` and `deployment.json` files in Docker builds.
