### PR TITLE
Draft: highlight where constant product differs from v1 and find out why

### DIFF
--- a/packages/zoe/src/contracts/constantProduct/core.js
+++ b/packages/zoe/src/contracts/constantProduct/core.js
@@ -142,6 +142,32 @@ const swapOutImproved = ({ x, y, deltaY: wantedAmountOut }) => {
   });
 };
 
+export const swapInNotImprovedNoFees = ({ amountGiven, poolAllocation }) => {
+  const { x, y, deltaX: amountIn } = getXY({
+    amountGiven,
+    poolAllocation,
+  });
+  const amountOut = calcDeltaYSellingX(x, y, amountIn);
+
+  return harden({
+    amountIn,
+    amountOut,
+  });
+};
+
+export const swapOutNotImprovedNoFees = ({ poolAllocation, amountWanted }) => {
+  const { x, y, deltaY: amountOut } = getXY({
+    poolAllocation,
+    amountWanted,
+  });
+  const amountIn = calcDeltaXSellingX(x, y, amountOut);
+
+  return harden({
+    amountIn,
+    amountOut,
+  });
+};
+
 /** @type {NoFeeSwapFn} */
 export const swapInNoFees = ({ amountGiven, poolAllocation }) => {
   const XY = getXY({ amountGiven, poolAllocation });

--- a/packages/zoe/test/unitTests/contracts/constantProduct/test-compareBondingCurves.js
+++ b/packages/zoe/test/unitTests/contracts/constantProduct/test-compareBondingCurves.js
@@ -21,7 +21,7 @@ const prepareSwapInTest = ({ inputReserve, outputReserve, inputValue }) => {
   });
   const amountWanted = bld(0n);
   const protocolFeeRatio = makeRatio(0n, runKit.brand, BASIS_POINTS);
-  const poolFeeRatio = makeRatio(3n, bldKit.brand, BASIS_POINTS);
+  const poolFeeRatio = makeRatio(30n, bldKit.brand, BASIS_POINTS);
 
   const args = [
     amountGiven,

--- a/packages/zoe/test/unitTests/contracts/constantProduct/test-v1.js
+++ b/packages/zoe/test/unitTests/contracts/constantProduct/test-v1.js
@@ -1,0 +1,323 @@
+// @ts-check
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import { BASIS_POINTS } from '../../../../src/contracts/constantProduct/defaults.js';
+import {
+  swapOutNotImprovedNoFees,
+  swapInNotImprovedNoFees,
+} from '../../../../src/contracts/constantProduct/core.js';
+import { setupMintKits } from './setupMints.js';
+import { makeRatio } from '../../../../src/contractSupport/index.js';
+import { swap } from '../../../../src/contracts/constantProduct/swap.js';
+
+const swapIn = (
+  amountGiven,
+  poolAllocation,
+  amountWanted,
+  protocolFeeRatio,
+  poolFeeRatio,
+) => {
+  return swap(
+    amountGiven,
+    poolAllocation,
+    amountWanted,
+    protocolFeeRatio,
+    poolFeeRatio,
+    swapInNotImprovedNoFees,
+  );
+};
+
+export const swapOut = (
+  amountGiven,
+  poolAllocation,
+  amountWanted,
+  protocolFeeRatio,
+  poolFeeRatio,
+) => {
+  return swap(
+    amountGiven,
+    poolAllocation,
+    amountWanted,
+    protocolFeeRatio,
+    poolFeeRatio,
+    swapOutNotImprovedNoFees,
+  );
+};
+
+// This assumes RUN is swapped in. The test should function the same
+// regardless of what brand is the amountIn, because no RUN-specific fee is
+// charged.
+const prepareSwapInTest = ({ inputReserve, outputReserve, inputValue }) => {
+  const { run, bld, runKit, bldKit } = setupMintKits();
+  const amountGiven = run(inputValue);
+  const poolAllocation = harden({
+    Central: run(inputReserve),
+    Secondary: bld(outputReserve),
+  });
+  const amountWanted = bld(3n);
+  // Protocol fee set to 0 to emulate Uniswap V1
+  const protocolFeeRatio = makeRatio(0n, runKit.brand, BASIS_POINTS);
+  const poolFeeRatio = makeRatio(3n, bldKit.brand, BASIS_POINTS);
+
+  const args = [
+    amountGiven,
+    poolAllocation,
+    amountWanted,
+    protocolFeeRatio,
+    poolFeeRatio,
+  ];
+  return harden({
+    args,
+    run,
+    bld,
+  });
+};
+
+const testGetPrice = (t, inputs, expectedOutput) => {
+  const { args, bld } = prepareSwapInTest(inputs);
+  const result = swapIn(...args);
+  t.deepEqual(result.swapperGets, bld(expectedOutput));
+};
+
+const getInputPriceThrows = (t, inputs, message) => {
+  t.throws(
+    _ => {
+      const { args } = prepareSwapInTest(inputs);
+      return swapIn(...args);
+    },
+    {
+      message,
+    },
+  );
+};
+
+// This assumes run is swapped in. The test should function the same
+// regardless of what brand is the amountIn, because no run fee is
+// charged.
+const prepareSwapOutTest = ({ inputReserve, outputReserve, outputValue }) => {
+  const { run, bld, runKit } = setupMintKits();
+  const amountGiven = run(10000n); // hard-coded
+  const poolAllocation = harden({
+    Central: run(inputReserve),
+    Secondary: bld(outputReserve),
+  });
+  const amountWanted = bld(outputValue);
+  const protocolFeeRatio = makeRatio(0n, runKit.brand, BASIS_POINTS);
+  const poolFeeRatio = makeRatio(30n, runKit.brand, BASIS_POINTS);
+
+  const args = [
+    amountGiven,
+    poolAllocation,
+    amountWanted,
+    protocolFeeRatio,
+    poolFeeRatio,
+  ];
+  return harden({
+    args,
+    run,
+    bld,
+  });
+};
+
+const testGetOutputPrice = (t, inputs, expectedInput) => {
+  const { args, run } = prepareSwapOutTest(inputs);
+  const result = swapOut(...args);
+  t.deepEqual(result.swapperGives, run(expectedInput));
+};
+
+const getOutputPriceThrows = (t, inputs, message) => {
+  const { args } = prepareSwapOutTest(inputs);
+  t.throws(_ => swapOut(...args), {
+    message,
+  });
+};
+
+// If these tests of `getInputPrice` fail, it would indicate that we have
+// diverged from the calculation in the Uniswap paper.
+test('getInputPrice no reserves', t => {
+  const input = {
+    inputReserve: 0n,
+    outputReserve: 0n,
+    inputValue: 1n,
+  };
+  const message =
+    '"poolAllocation.Central" must be greater than 0: {"brand":"[Alleged: RUN brand]","value":"[0n]"}';
+  getInputPriceThrows(t, input, message);
+});
+
+test('getInputPrice ok 2', t => {
+  const input = {
+    inputReserve: 5984n,
+    outputReserve: 3028n,
+    inputValue: 1398n,
+  };
+  const expectedOutput = 572n;
+  testGetPrice(t, input, expectedOutput);
+});
+
+test('getInputPrice ok 3', t => {
+  const input = {
+    inputReserve: 8160n,
+    outputReserve: 7743n,
+    inputValue: 6635n,
+  };
+  const expectedOutput = 3466n;
+  testGetPrice(t, input, expectedOutput);
+});
+
+test('getInputPrice ok 4', t => {
+  const input = {
+    inputReserve: 10n,
+    outputReserve: 10n,
+    inputValue: 1000n,
+  };
+  const expectedOutput = 9n;
+  testGetPrice(t, input, expectedOutput);
+});
+
+test('getInputPrice ok 5', t => {
+  const input = {
+    inputReserve: 100n,
+    outputReserve: 50n,
+    inputValue: 17n,
+  };
+  const expectedOutput = 7n;
+  testGetPrice(t, input, expectedOutput);
+});
+
+test('getInputPrice ok 6', t => {
+  const input = {
+    outputReserve: 117n,
+    inputReserve: 43n,
+    inputValue: 7n,
+  };
+  const expectedOutput = 16n;
+  testGetPrice(t, input, expectedOutput);
+});
+
+test('getInputPrice negative', t => {
+  const input = {
+    outputReserve: 117n,
+    inputReserve: 43n,
+    inputValue: -7n,
+  };
+  const message = 'value "[-7n]" must be a Nat or an array';
+  getInputPriceThrows(t, input, message);
+});
+
+test('getInputPrice bad reserve 1', t => {
+  const input = {
+    outputReserve: 0n,
+    inputReserve: 43n,
+    inputValue: 347n,
+  };
+  const message =
+    '"poolAllocation.Secondary" must be greater than 0: {"brand":"[Alleged: BLD brand]","value":"[0n]"}';
+  getInputPriceThrows(t, input, message);
+});
+
+test('getInputPrice bad reserve 2', t => {
+  const input = {
+    outputReserve: 50n,
+    inputReserve: 0n,
+    inputValue: 828n,
+  };
+  const message =
+    '"poolAllocation.Central" must be greater than 0: {"brand":"[Alleged: RUN brand]","value":"[0n]"}';
+  getInputPriceThrows(t, input, message);
+});
+
+test('getInputPrice zero input', t => {
+  const input = {
+    outputReserve: 50n,
+    inputReserve: 320n,
+    inputValue: 0n,
+  };
+  const message =
+    '"allocation.In" was not greater than 0: {"brand":"[Alleged: RUN brand]","value":"[0n]"}';
+  getInputPriceThrows(t, input, message);
+});
+
+test('getInputPrice big product', t => {
+  const input = {
+    outputReserve: 100000000n,
+    inputReserve: 100000000n,
+    inputValue: 1000n,
+  };
+  const expectedOutput = 996n;
+  testGetPrice(t, input, expectedOutput);
+});
+
+test('getOutputPrice ok', t => {
+  const input = {
+    outputReserve: 117n,
+    inputReserve: 43n,
+    outputValue: 37n,
+  };
+  const expectedOutput = 20n;
+  testGetOutputPrice(t, input, expectedOutput);
+});
+
+test('getOutputPrice zero output reserve', t => {
+  const input = {
+    outputReserve: 0n,
+    inputReserve: 43n,
+    outputValue: 37n,
+  };
+  const message =
+    '"poolAllocation.Secondary" must be greater than 0: {"brand":"[Alleged: BLD brand]","value":"[0n]"}';
+  getOutputPriceThrows(t, input, message);
+});
+
+test('getOutputPrice zero input reserve', t => {
+  const input = {
+    outputReserve: 92n,
+    inputReserve: 0n,
+    outputValue: 37n,
+  };
+  const message =
+    '"poolAllocation.Central" must be greater than 0: {"brand":"[Alleged: RUN brand]","value":"[0n]"}';
+  getOutputPriceThrows(t, input, message);
+});
+
+test('getOutputPrice too much output', t => {
+  const input = {
+    outputReserve: 1024n,
+    inputReserve: 1132n,
+    outputValue: 20923n,
+  };
+  const message =
+    'The poolAllocation {"brand":"[Alleged: BLD brand]","value":"[1024n]"} did not have enough to satisfy the wanted amountOut {"brand":"[Alleged: BLD brand]","value":"[20923n]"}';
+  getOutputPriceThrows(t, input, message);
+});
+
+test('getOutputPrice too much output 2', t => {
+  const input = {
+    outputReserve: 345n,
+    inputReserve: 1132n,
+    outputValue: 345n,
+  };
+  const message =
+    'The poolAllocation {"brand":"[Alleged: BLD brand]","value":"[345n]"} did not have enough to satisfy the wanted amountOut {"brand":"[Alleged: BLD brand]","value":"[345n]"}';
+  getOutputPriceThrows(t, input, message);
+});
+
+test('getOutputPrice big product', t => {
+  const input = {
+    outputReserve: 100000000n,
+    inputReserve: 100000000n,
+    outputValue: 1000n,
+  };
+  const expectedOutput = 1004n;
+  testGetOutputPrice(t, input, expectedOutput);
+});
+
+test('getOutputPrice minimum price', t => {
+  const input = {
+    outputReserve: 10n,
+    inputReserve: 1n,
+    outputValue: 1n,
+  };
+  const expectedOutput = 1n;
+  testGetOutputPrice(t, input, expectedOutput);
+});

--- a/packages/zoe/test/unitTests/contracts/constantProduct/test-v1.js
+++ b/packages/zoe/test/unitTests/contracts/constantProduct/test-v1.js
@@ -155,14 +155,27 @@ test('getInputPrice ok 2', t => {
   testGetPrice(t, input, expectedOutput);
 });
 
-test('getInputPrice ok 3', t => {
+test.only('getInputPrice ok 3', t => {
   const input = {
     inputReserve: 8160n,
     outputReserve: 7743n,
     inputValue: 6635n,
   };
   const expectedOutput = 3466n;
-  testGetPrice(t, input, expectedOutput);
+
+  // inputValue = deltaX
+  // outputReserve = y
+  // inputReserve = x
+  // (997 * deltaX * y) / (1000 * x + 997 * deltaX) where / is
+  // floorDivide
+
+  const v1 =
+    (997n * input.inputValue * input.outputReserve) /
+    (1000n * input.inputReserve + 997n * input.inputValue);
+  t.is(v1, expectedOutput, `expected output didn't match v1`);
+
+  // This produces 3470n, not the v1 answer which is 3466n.
+  testGetPrice(t, input, v1);
 });
 
 test('getInputPrice ok 4', t => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1963,17 +1963,17 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.9.2":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.4.tgz#fd17d16bfdf878e6dd02d19753a39fa8a8d9c84a"
+  integrity sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2":
   version "7.15.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.3.tgz#2e1c2880ca118e5b2f9988322bd8a7656a32502b"
   integrity sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.12.5", "@babel/runtime@^7.9.2":
-  version "7.15.4"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.4.tgz#fd17d16bfdf878e6dd02d19753a39fa8a8d9c84a"
-  integrity sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -10973,6 +10973,18 @@ hex-rgb@^4.1.0:
   resolved "https://registry.yarnpkg.com/hex-rgb/-/hex-rgb-4.1.0.tgz#2d5d3a2943bd40e7dc9b0d5b98903d7d17035967"
   integrity sha512-n7xsIfyBkFChITGPh6FLtxNzAt2HxZLcQIY9hYH4gm2gmMQJHMguMH3E+jnmvUbSTF5QrmFnGab5Ippi+D7e/g==
 
+history@^4.9.0:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
+  integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    loose-envify "^1.2.0"
+    resolve-pathname "^3.0.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+    value-equal "^1.0.1"
+
 hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -10982,7 +10994,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -12171,6 +12183,11 @@ is-yarn-global@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/is-yarn-global/-/is-yarn-global-0.3.0.tgz#d502d3382590ea3004893746754c89139973e232"
   integrity sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -13550,7 +13567,7 @@ loglevel@^1.6.8:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.1.tgz#005fde2f5e6e47068f935ff28573e125ef72f197"
   integrity sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==
 
-loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -14003,6 +14020,14 @@ min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
+
+mini-create-react-context@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz#072171561bfdc922da08a60c2197a497cc2d1d5e"
+  integrity sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==
+  dependencies:
+    "@babel/runtime" "^7.12.1"
+    tiny-warning "^1.0.3"
 
 mini-css-extract-plugin@0.11.3:
   version "0.11.3"
@@ -15522,6 +15547,13 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
+
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -17052,7 +17084,7 @@ react-error-overlay@^6.0.9:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
   integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
-react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
+react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -17071,6 +17103,35 @@ react-refresh@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
+
+react-router-dom@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.3.0.tgz#da1bfb535a0e89a712a93b97dd76f47ad1f32363"
+  integrity sha512-ObVBLjUZsphUUMVycibxgMdh5jJ1e3o+KpAZBVeHcNQZ4W+uUGGWsokurzlF4YOldQYRQL4y6yFRWM4m3svmuQ==
+  dependencies:
+    "@babel/runtime" "^7.12.13"
+    history "^4.9.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.6.2"
+    react-router "5.2.1"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+
+react-router@5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.1.tgz#4d2e4e9d5ae9425091845b8dbc6d9d276239774d"
+  integrity sha512-lIboRiOtDLFdg1VTemMwud9vRVuOCZmUIT/7lUoZiSpPODiiH1UQlfXy+vPLC/7IWdFYnhRwAyNqA/+I7wnvKQ==
+  dependencies:
+    "@babel/runtime" "^7.12.13"
+    history "^4.9.0"
+    hoist-non-react-statics "^3.1.0"
+    loose-envify "^1.3.1"
+    mini-create-react-context "^0.4.0"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.6.2"
+    react-is "^16.6.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
 
 react-scripts@4.0.3:
   version "4.0.3"
@@ -17644,6 +17705,11 @@ resolve-path@^1.4.0:
   dependencies:
     http-errors "~1.6.2"
     path-is-absolute "1.0.1"
+
+resolve-pathname@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
+  integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
 
 resolve-url-loader@^3.1.2:
   version "3.1.4"
@@ -19574,7 +19640,12 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
-tiny-warning@^1.0.2:
+tiny-invariant@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
+  integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
+
+tiny-warning@^1.0.0, tiny-warning@^1.0.2, tiny-warning@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
@@ -20255,6 +20326,11 @@ validate-npm-package-name@^3.0.0:
   integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
   dependencies:
     builtins "^1.0.3"
+
+value-equal@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
+  integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
 vary@^1.1.2, vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
refs: #3716 (original constant product code with tests)
refs: #3771 (constant product code that got merged)

## Description

This draft PR is to set up tests so that we can do a direct comparison of the constant product code and Uniswap v1. We're assuming that if the protocolFee is 0 and the price is not being "improved" or "reduced", the results should be the same. I'm getting different results. The file to look at is packages/zoe/test/unitTests/contracts/constantProduct/test-v1.js. I highlighted a particular test with `test.only`, but the other tests are failing too. 