### PR TITLE
fix: "yarn lint" should not fix

### DIFF
--- a/packages/wallet-connection/package.json
+++ b/packages/wallet-connection/package.json
@@ -18,7 +18,7 @@
     "lint-check": "yarn lint",
     "lint": "yarn lint:types && yarn lint:eslint",
     "lint:types": "tsc -p jsconfig.json",
-    "lint:eslint": "eslint --ext .js,.html . --fix --ignore-path .gitignore",
+    "lint:eslint": "eslint --ext .js,.html . --ignore-path .gitignore",
     "analyze": "cem analyze --litelement",
     "start": "web-dev-server --port 8100"
   },


### PR DESCRIPTION
In wallet-connection, a plain `yarn lint` was accidentally doing a `--fix`