### PR TITLE
Cosmos and solo controller admission support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Agoric/agoric-sdk
 go 1.15
 
 require (
+	github.com/armon/go-metrics v0.3.9
 	github.com/cosmos/cosmos-sdk v0.44.0
 	github.com/cosmos/ibc-go v1.1.0
 	github.com/gogo/protobuf v1.3.3

--- a/golang/cosmos/app/agoric_ante.go
+++ b/golang/cosmos/app/agoric_ante.go
@@ -1,0 +1,84 @@
+package gaia
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/x/auth/ante"
+
+	"github.com/Agoric/agoric-sdk/golang/cosmos/vm"
+)
+
+// TODO: We don't have a more appropriate error type for this.
+var ErrAdmissionRefused = sdkerrors.ErrMempoolIsFull
+
+// AdmissionDecorator will ask the Controller (such as SwingSet) if it is
+// temporarily rejecting inbound messages.  If CheckAdmissibility passes for all
+// messages, decorator calls next AnteHandler in chain.
+type AdmissionDecorator struct {
+	CallToController func(sdk.Context, string) (string, error)
+}
+
+func NewAdmissionDecorator(callToController func(sdk.Context, string) (string, error)) AdmissionDecorator {
+	return AdmissionDecorator{CallToController: callToController}
+}
+
+// AnteHandle calls CheckAdmissibility for all messages that implement the
+// vm.ControllerAdmissionMsg interface.  If it returns an error, refuse the
+// entire transaction.
+func (ad AdmissionDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	if !simulate {
+		// Ask the controller if we are rejecting messages.
+		for _, msg := range tx.GetMsgs() {
+			if camsg, ok := msg.(vm.ControllerAdmissionMsg); ok {
+				if err := camsg.CheckAdmissibility(ctx, ad.CallToController); err != nil {
+					return ctx, sdkerrors.Wrapf(ErrAdmissionRefused, "controller refused message admission: %s", err.Error())
+				}
+			}
+		}
+	}
+
+	return next(ctx, tx, simulate)
+}
+
+// NewAgoricAnteHandler returns an AnteHandler with the Agoric customisations.
+func NewAgoricAnteHandler(options ante.HandlerOptions, callToController func(sdk.Context, string) (string, error)) (sdk.AnteHandler, error) {
+	if options.AccountKeeper == nil {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "account keeper is required for ante builder")
+	}
+
+	if options.BankKeeper == nil {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "bank keeper is required for ante builder")
+	}
+
+	if options.SignModeHandler == nil {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "sign mode handler is required for ante builder")
+	}
+
+	if callToController == nil {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "call to controller is required for ante builder")
+	}
+
+	var sigGasConsumer = options.SigGasConsumer
+	if sigGasConsumer == nil {
+		sigGasConsumer = ante.DefaultSigVerificationGasConsumer
+	}
+
+	anteDecorators := []sdk.AnteDecorator{
+		ante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
+		ante.NewRejectExtensionOptionsDecorator(),
+		ante.NewMempoolFeeDecorator(),
+		ante.NewValidateBasicDecorator(),
+		ante.NewTxTimeoutHeightDecorator(),
+		ante.NewValidateMemoDecorator(options.AccountKeeper),
+		ante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper),
+		ante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper),
+		ante.NewSetPubKeyDecorator(options.AccountKeeper), // SetPubKeyDecorator must be called before all signature verification decorators
+		ante.NewValidateSigCountDecorator(options.AccountKeeper),
+		ante.NewSigGasConsumeDecorator(options.AccountKeeper, sigGasConsumer),
+		ante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
+		NewAdmissionDecorator(callToController),
+		ante.NewIncrementSequenceDecorator(options.AccountKeeper),
+	}
+
+	return sdk.ChainAnteDecorators(anteDecorators...), nil
+}

--- a/golang/cosmos/vm/controller.go
+++ b/golang/cosmos/vm/controller.go
@@ -13,6 +13,11 @@ type ControllerContext struct {
 	IBCChannelHandlerPort int
 }
 
+type ControllerAdmissionMsg interface {
+	sdk.Msg
+	CheckAdmissibility(sdk.Context, func(sdk.Context, string) (string, error)) error
+}
+
 var controllerContext ControllerContext
 
 type PortHandler interface {

--- a/golang/cosmos/x/swingset/types/msgs.go
+++ b/golang/cosmos/x/swingset/types/msgs.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"github.com/Agoric/agoric-sdk/golang/cosmos/vm"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
@@ -8,6 +9,7 @@ import (
 const RouterKey = ModuleName // this was defined in your key.go file
 
 var _, _ sdk.Msg = &MsgDeliverInbound{}, &MsgProvision{}
+var _ vm.ControllerAdmissionMsg = &MsgDeliverInbound{}
 
 func NewMsgDeliverInbound(msgs *Messages, submitter sdk.AccAddress) *MsgDeliverInbound {
 	return &MsgDeliverInbound{
@@ -16,6 +18,18 @@ func NewMsgDeliverInbound(msgs *Messages, submitter sdk.AccAddress) *MsgDeliverI
 		Ack:       msgs.Ack,
 		Submitter: submitter,
 	}
+}
+
+func (msg MsgDeliverInbound) CheckAdmissibility(ctx sdk.Context, callToController func(sdk.Context, string) (string, error)) error {
+	// TODO: This is where we would consult the controller for deterministic
+	// advice on whether we are overwhelmed.
+	/*
+		// The nondeterministic torture test.  Mark every third message as not inadmissible.
+		if rand.Intn(3) == 0 {
+			return fmt.Errorf("FIGME: MsgDeliverInbound is randomly not admissible")
+		}
+	*/
+	return nil
 }
 
 // Route should return the name of the module

--- a/packages/agoric-cli/lib/start.js
+++ b/packages/agoric-cli/lib/start.js
@@ -26,6 +26,8 @@ const HOST_PORT = process.env.HOST_PORT || PORT;
 const CHAIN_PORT = process.env.CHAIN_PORT || 26657;
 const DEFAULT_NETCONFIG = 'https://testnet.agoric.net/network-config';
 
+const GAS_ADJUSTMENT = '1.2';
+
 /**
  * Resolve after a delay in milliseconds.
  *
@@ -485,7 +487,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
               '--keyring-backend=test',
               '--from=provision',
               '--gas=auto',
-              '--gas-adjustment=1.2',
+              `--gas-adjustment=${GAS_ADJUSTMENT}`,
               '--broadcast-mode=block',
               '--yes',
               `--chain-id=${CHAIN_ID}`,
@@ -502,7 +504,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
               '-ojson',
               '--keyring-backend=test',
               '--gas=auto',
-              '--gas-adjustment=1.2',
+              `--gas-adjustment=${GAS_ADJUSTMENT}`,
               '--broadcast-mode=block',
               '--yes',
               `--chain-id=${CHAIN_ID}`,

--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -16,6 +16,7 @@ NUM_SOLOS?=1
 BASE_PORT?=8000
 
 OTEL_EXPORTER_PROMETHEUS_PORT = 9461
+GAS_ADJUSTMENT = 1.2
 
 AGC_START_ARGS =
 
@@ -125,10 +126,10 @@ t1-provision-one-with-powers: wait-for-cosmos
 		addr=$$(cat $$addrfile); \
 	  $(AGCH) --home=t1/bootstrap query swingset egress $$addr --chain-id=$(CHAIN_ID) || \
 		{ $(AGCH) --home=t1/bootstrap tx bank send --keyring-backend=test --from=bootstrap \
-		  --gas=auto --gas-adjustment=1.2 --broadcast-mode=block --yes --chain-id=$(CHAIN_ID) \
+		  --gas=auto --gas-adjustment=$(GAS_ADJUSTMENT) --broadcast-mode=block --yes --chain-id=$(CHAIN_ID) \
 			bootstrap $$addr $(SOLO_COINS) && \
 	  $(AGCH) --home=t1/bootstrap tx swingset provision-one --keyring-backend=test --from=bootstrap \
-		  --gas=auto --gas-adjustment=1.2 --broadcast-mode=block --yes --chain-id=$(CHAIN_ID) \
+		  --gas=auto --gas-adjustment=$(GAS_ADJUSTMENT) --broadcast-mode=block --yes --chain-id=$(CHAIN_ID) \
 		  t1/$(BASE_PORT) $$addr $(AGORIC_POWERS) -ojson | tee /dev/stderr | grep -q '"code":0'; }
 	
 
@@ -138,23 +139,23 @@ t1-provision-one: wait-for-cosmos
 		addr=$$(cat $$addrfile); \
 	  $(AGCH) --home=t1/bootstrap query swingset egress $$addr --chain-id=$(CHAIN_ID) || \
 		{ $(AGCH) --home=t1/bootstrap tx bank send --keyring-backend=test --from=bootstrap \
-		  --gas=auto --gas-adjustment=1.2 --broadcast-mode=block --yes --chain-id=$(CHAIN_ID) \
+		  --gas=auto --gas-adjustment=$(GAS_ADJUSTMENT) --broadcast-mode=block --yes --chain-id=$(CHAIN_ID) \
 			bootstrap $$addr $(SOLO_COINS) && \
 	  $(AGCH) --home=t1/bootstrap tx swingset provision-one --keyring-backend=test --from=bootstrap \
-		  --gas=auto --gas-adjustment=1.2 --broadcast-mode=block --yes --chain-id=$(CHAIN_ID) \
+		  --gas=auto --gas-adjustment=$(GAS_ADJUSTMENT) --broadcast-mode=block --yes --chain-id=$(CHAIN_ID) \
 		  t1/$(BASE_PORT) $$addr -ojson | tee /dev/stderr | grep -q '"code":0'; }
 
 t1/$(BASE_PORT)/cosmos-client-account.setup:
 	test ! -f t1/$(BASE_PORT)/cosmos-client-account || \
 	  $(AGCH) --home=t1/$(BASE_PORT)/owner --keyring-backend=test tx authz grant \
-		--gas=auto --gas-adjustment=1.2 --broadcast-mode=block --yes --chain-id=$(CHAIN_ID) --from=owner \
+		--gas=auto --gas-adjustment=$(GAS_ADJUSTMENT) --broadcast-mode=block --yes --chain-id=$(CHAIN_ID) --from=owner \
 		$$(cat t1/$(BASE_PORT)/ag-cosmos-helper-address) generic --msg-type=/agoric.swingset.MsgDeliverInbound
 	date > $@
 
 t1/$(BASE_PORT)/cosmos-fee-account.setup:
 	test ! -f t1/$(BASE_PORT)/cosmos-fee-account || \
 	  $(AGCH) --home=t1/$(BASE_PORT)/owner --keyring-backend=test tx feegrant grant \
-		--gas=auto --gas-adjustment=1.2 --broadcast-mode=block --yes --chain-id=$(CHAIN_ID) --from=owner \
+		--gas=auto --gas-adjustment=$(GAS_ADJUSTMENT) --broadcast-mode=block --yes --chain-id=$(CHAIN_ID) --from=owner \
 		--period=5 --period-limit=200urun $$(cat t1/$(BASE_PORT)/cosmos-fee-account) $$(cat t1/$(BASE_PORT)/ag-cosmos-helper-address)
 	date > $@
 
@@ -163,7 +164,7 @@ t1-start-ag-solo: t1/$(BASE_PORT)/cosmos-client-account.setup t1/$(BASE_PORT)/co
 	addr=$$(cat t1/$(BASE_PORT)/ag-cosmos-helper-address); \
 	$(AGCH) query auth account $$addr >/dev/null 2>&1 || \
 		$(AGCH) --home=t1/bootstrap tx bank send --keyring-backend=test --from=bootstrap \
-		--gas=auto --gas-adjustment=1.2 --broadcast-mode=block --yes --chain-id=$(CHAIN_ID) \
+		--gas=auto --gas-adjustment=$(GAS_ADJUSTMENT) --broadcast-mode=block --yes --chain-id=$(CHAIN_ID) \
 		bootstrap $$addr 1urun
 	cd t1/$(BASE_PORT) && $(AG_SOLO) start
 

--- a/packages/solo/src/chain-cosmos-sdk.js
+++ b/packages/solo/src/chain-cosmos-sdk.js
@@ -29,6 +29,9 @@ export const HELPER = new URL(
 const FAUCET_ADDRESS =
   'the appropriate faucet channel on Discord (https://agoric.com/discord)';
 
+// Transaction simulation should be an accurate measure of gas.
+const GAS_ADJUSTMENT = '1.2';
+
 const adviseEgress = egressAddr =>
   `\
 
@@ -40,7 +43,10 @@ Send:
 to ${FAUCET_ADDRESS}`;
 
 // Retry if our latest message failed.
-const SEND_RETRY_DELAY_MS = 1_000;
+const INITIAL_SEND_RETRY_DELAY_MS = 1_000;
+const MAXIMUM_SEND_RETRY_DELAY_MS = 15_000;
+
+const exponentialBackoff = backoff => backoff * 2;
 
 const MAX_BUFFER_SIZE = 10 * 1024 * 1024;
 
@@ -240,6 +246,14 @@ export async function connectToChain(
   // client + transaction needs.  For now, it's simple enough to notice when
   // blocks happen an just to issue mailbox queries.
 
+  let currentTxHashPK = makePromiseKit();
+  let postponedTxHash;
+  const postponedWaitForTxHash = txHash => {
+    postponedTxHash = txHash;
+    return currentTxHashPK.promise;
+  };
+  let waitForTxHash = postponedWaitForTxHash;
+
   /**
    * Get a notifier that announces every time a block lands.
    *
@@ -271,6 +285,8 @@ export async function connectToChain(
       // We have a new instance of the map and id per connection.
       let lastId = 0;
       const idToCallback = new Map();
+      const clearCallback = id => idToCallback.delete(id);
+      const setCallback = (id, cb) => idToCallback.set(id, cb);
 
       const sendRPC = (method, params) => {
         lastId += 1;
@@ -283,6 +299,50 @@ export async function connectToChain(
         };
         ws.send(JSON.stringify(fullObj));
         return id;
+      };
+
+      const subscribeToTxHash = (txHash, cb) => {
+        const txQuery = `tm.event = 'Tx' and tx.hash = '${txHash}'`;
+
+        const b64Hash = Buffer.from(txHash, 'hex').toString('base64');
+        const txSubscriptionId = sendRPC('subscribe', { query: txQuery });
+        const queryId = sendRPC('tx', { hash: b64Hash });
+        const cleanup = () => {
+          clearCallback(txSubscriptionId);
+          clearCallback(queryId);
+          sendRPC('unsubscribe', { query: txQuery });
+        };
+
+        const handleResult = obj => {
+          // console.log('got', txHash, obj);
+          if (obj.error) {
+            if (obj.error.code === -32603) {
+              // This is the error we expect when the transaction is not found.
+              return;
+            }
+            cleanup();
+            cb(obj.error);
+            return;
+          }
+          if (!obj.result) {
+            return;
+          }
+          let txResult;
+          const { data, tx_result: rawTxResult } = obj.result;
+          if (data) {
+            txResult = data.value.TxResult.result;
+          } else {
+            txResult = rawTxResult;
+          }
+          if (!txResult) {
+            return;
+          }
+          cleanup();
+          cb(null, txResult);
+        };
+        setCallback(txSubscriptionId, handleResult);
+        setCallback(queryId, handleResult);
+        return cleanup;
       };
 
       const subscribeToStorage = (storagePath, cb) => {
@@ -302,9 +362,9 @@ export async function connectToChain(
 
         const cleanup = () => {
           // console.info('Unsubscribing from', blockSubscriptionId);
-          idToCallback.delete(blockSubscriptionId);
-          idToCallback.delete(txSubscriptionId);
-          idToCallback.delete(queryId);
+          clearCallback(blockSubscriptionId);
+          clearCallback(txSubscriptionId);
+          clearCallback(queryId);
           sendRPC('unsubscribe', { query: blockQuery });
           sendRPC('unsubscribe', { query: txQuery });
         };
@@ -318,7 +378,7 @@ export async function connectToChain(
         };
 
         // Query for our initial value.
-        idToCallback.set(queryId, obj => {
+        setCallback(queryId, obj => {
           // console.info(`got ${storagePath} query`, obj);
           if (obj.result && obj.result.response && obj.result.response.value) {
             // Decode the layers up to the actual storage value.
@@ -344,7 +404,7 @@ export async function connectToChain(
             // Unexpected error.
             cb(obj, null);
           }
-          idToCallback.delete(queryId);
+          clearCallback(queryId);
         });
 
         const handleSubscription = obj => {
@@ -401,8 +461,8 @@ export async function connectToChain(
           guardedCb(height, storageValue);
         };
 
-        idToCallback.set(blockSubscriptionId, handleSubscription);
-        idToCallback.set(txSubscriptionId, handleSubscription);
+        setCallback(blockSubscriptionId, handleSubscription);
+        setCallback(txSubscriptionId, handleSubscription);
 
         return cleanup;
       };
@@ -410,6 +470,30 @@ export async function connectToChain(
       const followMailbox = () => {
         // Tell the sender to go.
         updater.updateState(undefined);
+
+        // Initialize the txHash subscription.
+        const subscribeAndWaitForTxHash = txHash => {
+          const thisPK = currentTxHashPK;
+          postponedTxHash = undefined;
+          currentTxHashPK = makePromiseKit();
+          const unsubscribe = subscribeToTxHash(txHash, (err, txResult) => {
+            // console.info('received subscription for', txHash, err, txEvent);
+            unsubscribe();
+            if (err) {
+              thisPK.reject(err);
+            } else {
+              thisPK.resolve(txResult);
+            }
+            postponedTxHash = undefined;
+          });
+          return thisPK.promise;
+        };
+
+        waitForTxHash = subscribeAndWaitForTxHash;
+        if (postponedTxHash) {
+          subscribeAndWaitForTxHash(postponedTxHash);
+        }
+
         subscribeToStorage(`mailbox.${clientAddr}`, (err, storageValue) => {
           if (err) {
             console.error(`Error subscribing to mailbox`, err);
@@ -472,6 +556,7 @@ ${chainID} chain does not yet know of address ${clientAddr}${adviseEgress(
         // The value `undefined` as the resolution of this retry
         // tells the caller to retry again with a different RPC server.
         retryPK.resolve(undefined);
+        waitForTxHash = postponedWaitForTxHash;
       });
       // Return an unresolved promise that resolves to `undefined`
       // when the WebSocket is closed.
@@ -564,7 +649,7 @@ ${chainID} chain does not yet know of address ${clientAddr}${adviseEgress(
       txArgs.push(
         '--keyring-backend=test',
         '--gas=auto',
-        '--gas-adjustment=1.3',
+        `--gas-adjustment=${GAS_ADJUSTMENT}`,
         '--from=ag-solo',
         '--yes',
         '-ojson',
@@ -607,10 +692,23 @@ ${chainID} chain does not yet know of address ${clientAddr}${adviseEgress(
           const out = JSON.parse(stdout);
 
           assert.equal(
-            parseInt(out.code, 10),
+            out.code,
             0,
-            X`Unexpected output: ${stdout.trimRight()}`,
+            X`Unexpected output: ${out.raw_log || stdout.trimRight()}`,
           );
+
+          // Wait for the transaction to be included in a block.
+          const txHash = out.txhash;
+
+          waitForTxHash(txHash).then(txResult => {
+            // The result had an error code (not 0 or undefined for success).
+            if (txResult.code) {
+              // eslint-disable-next-line no-use-before-define
+              failedSend(
+                assert.error(X`Error in tx processing: ${txResult.log}`),
+              );
+            }
+          });
 
           // We submitted the transaction to the mempool successfully.
           // Preemptively increment our sequence number to avoid needing to
@@ -657,7 +755,12 @@ ${chainID} chain does not yet know of address ${clientAddr}${adviseEgress(
 
   // Retry sending, but no more than one pending retry at a time.
   let retryPending;
-  const retrySend = (e = undefined) => {
+  let retryBackoff;
+  const successfulSend = () => {
+    // Reset the backoff period.
+    retryBackoff = randomizeDelay(INITIAL_SEND_RETRY_DELAY_MS);
+  };
+  const failedSend = (e = undefined) => {
     if (e) {
       console.error(`Error sending`, e);
     }
@@ -668,7 +771,12 @@ ${chainID} chain does not yet know of address ${clientAddr}${adviseEgress(
     retryPending = setTimeout(() => {
       retryPending = undefined;
       sendUpdater.updateState(true);
-    }, randomizeDelay(SEND_RETRY_DELAY_MS));
+    }, retryBackoff);
+
+    // This is where we naively implement exponential backoff with a maximum.
+    retryBackoff = randomizeDelay(
+      Math.min(exponentialBackoff(retryBackoff), MAXIMUM_SEND_RETRY_DELAY_MS),
+    );
   };
 
   // This function ensures we only have one outgoing send operation at a time.
@@ -677,7 +785,7 @@ ${chainID} chain does not yet know of address ${clientAddr}${adviseEgress(
     const { updateCount } = await sendNotifier.getUpdateSince(lastSendUpdate);
     assert(updateCount, X`Sending unexpectedly finished!`);
 
-    await sendFromMessagePool().catch(retrySend);
+    await sendFromMessagePool().then(successfulSend, failedSend);
     recurseEachSend(updateCount);
   };
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: #3467 

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
This PR implements opt-in admission control for individual Cosmos messages.  If any one of the messages in a transaction reports that the message was not cleared for landing, then the entire transaction is aborted.  The per-validator admission control happens both when the transaction is (out of consensus) trying to be added to the mempool, and also (within consensus) when the transaction is being added to a block.

Also update the `ag-solo`s to properly handle and retry transactions that were failed in this way.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

This support requires an up-to-date ag-solo, or the ag-solo will probably hang on the first error.

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

I tested the admission support by having 1/3 of all transactions be rejected.  1/3 failed to enter the mempool and 1/3 of those failed to be added to a block.  The ag-solo was happy and kept on ticking through this simulated outage.
