### PR TITLE
Simplify Pegasus for POLA

### DIFF
--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -457,16 +457,17 @@ export default function buildKernel(
           assert.typeof(consumed, 'number');
           used = BigInt(consumed);
           policyInput = ['crank', { computrons: used }];
-        }
-        if (useMeter && metering !== null && meterID) {
-          // If we have a Meter, and the manager reported a non-null value, use it.
-          assert(used !== undefined);
-          const underflow = deductMeter(meterID, used, true);
-          if (underflow) {
-            console.log(`meter ${meterID} underflow, terminating vat ${vatID}`);
-            const err = makeError('meter underflow, vat terminated');
-            setTerminationTrigger(vatID, true, true, err);
-            return harden(['crank-failed', {}]);
+          if (useMeter && meterID) {
+            // If we have a Meter and we want to use it, do so.
+            const underflow = deductMeter(meterID, used, true);
+            if (underflow) {
+              console.log(
+                `meter ${meterID} underflow, terminating vat ${vatID}`,
+              );
+              const err = makeError('meter underflow, vat terminated');
+              setTerminationTrigger(vatID, true, true, err);
+              return harden(['crank-failed', {}]);
+            }
           }
         }
       }

--- a/packages/notifier/src/notifier.js
+++ b/packages/notifier/src/notifier.js
@@ -85,7 +85,7 @@ export const makeNotifierKit = (...args) => {
     ...baseNotifier,
   });
 
-  const updater = harden({
+  const updater = Far('updater', {
     updateState(state) {
       if (final()) {
         throw new Error('Cannot update state after termination.');
@@ -155,7 +155,6 @@ export const makeNotifierKit = (...args) => {
  * @returns {Notifier<T>}
  */
 export const makeNotifierFromAsyncIterable = asyncIterableP => {
-  /** @type {ERef<AsyncIterator<T>>} */
   const iteratorP = E(asyncIterableP)[Symbol.asyncIterator]();
 
   /** @type {Promise<UpdateRecord<T>>|undefined} */

--- a/packages/pegasus/demo.md
+++ b/packages/pegasus/demo.md
@@ -3,8 +3,12 @@ In agoric-sdk, start the chain:
 ```
 yarn build
 cd packages/cosmic-swingset
-make scenario2-setup-nobuild scenario2-run-chain
-# In another terminal:
+make scenario2-setup-nobuild
+# Look for the bootstrap key mnemonic in the command output marked with **Important**
+make scenario2-run-chain
+# In another terminal, restore that mnemonic (using the below Hermes config):
+hermes keys restore agoric -p "m/44'/564'/0'/0/0" -m 'under cake there slam...'
+# Run the client
 make scenario2-run-client
 ```
 
@@ -23,13 +27,13 @@ host = '127.0.0.1'
 port = 3001
 
 [[chains]]                                                               
-id = 'agoricstage-15'
-rpc_addr = 'http://143.198.36.204:26657'
-grpc_addr = 'http://143.198.36.204:9090'
-websocket_addr = 'ws://143.198.36.204:26657/websocket'
+id = 'agoric'
+rpc_addr = 'http://127.0.0.1:26657'
+grpc_addr = 'http://127.0.0.1:9090'
+websocket_addr = 'ws://127.0.0.1:26657/websocket'
 rpc_timeout = '10s'
 account_prefix = 'agoric'
-key_name = 'stagekey'
+key_name = 'localkey'
 store_prefix = 'ibc'
 max_gas = 3000000
 gas_price = { price = 0.001, denom = 'urun' }
@@ -134,27 +138,27 @@ When Golang relayer says "no packets to relay", or when Hermes started, go to Ag
 command[0]
 E(home.pegasusConnections).entries()
 history[0]
-[["/ibc-port/transfer/unordered/ics20-1/ibc-channel/channel-0",[Alleged: Connection]{}]]
+[["/ibc-port/transfer/unordered/ics20-1/ibc-channel/channel-0",{"actions":[Object Alleged: pegasusConnectionActions]{},"localAddr":"/ibc-port/transfer/unordered/ics20-1/ibc-channel/channel-0","remoteAddr":"/ibc-hop/connection-0/ibc-port/transfer/unordered/ics20-1/ibc-channel/channel-270","remoteDenomSubscription":[Object Alleged: Subscription]{}}]]
 command[1]
-E(home.agoricNames).lookup('instance', 'Pegasus')
+E(history[0][0][1].actions).pegRemote('Muon', 'umuon', 'nat', { decimalPlaces: 6 })
 history[1]
-[Alleged: InstanceHandle]{}
+[Object Alleged: Muon peg]{}
 command[2]
-E(home.zoe).getPublicFacet(history[1])
+E(home.agoricNames).lookup('instance', 'Pegasus')
 history[2]
-[Alleged: presence o-61]{}
+[Object Alleged: InstanceHandle]{}
 command[3]
-E(history[2]).pegRemote('Muon', history[0][0][1], 'umuon', 'nat', { decimalPlaces: 6 })
+E(home.zoe).getPublicFacet(history[2])
 history[3]
-[Alleged: presence o-158]{}
+[Object Alleged: pegasus]{}
 command[4]
-E(history[3]).getLocalBrand()
+E(history[1]).getLocalBrand()
 history[4]
-[Alleged: Local1 Brand ...]
+[Object Alleged: Local1 brand]{}
 command[5]
-E(history[2]).getLocalIssuer(history[4])
+E(history[3]).getLocalIssuer(history[4])
 history[5]
-[issuer]
+[Object Alleged: Local1 issuer]{}
 command[6]
 E(home.board).getId(history[5])
 ```

--- a/packages/pegasus/src/courier.js
+++ b/packages/pegasus/src/courier.js
@@ -1,0 +1,124 @@
+import { details as X } from '@agoric/assert';
+
+import { AmountMath } from '@agoric/ertp';
+import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
+import { makeOncePromiseKit } from './once-promise-kit.js';
+
+/**
+ * Create or return an existing courier promise kit.
+ *
+ * @template K
+ * @param {K} key
+ * @param {Store<K, PromiseRecord<Courier>>} keyToCourierPK
+ */
+export const getCourierPK = (key, keyToCourierPK) => {
+  if (keyToCourierPK.has(key)) {
+    return keyToCourierPK.get(key);
+  }
+
+  // This is the first packet for this denomination.
+  // Create a new Courier promise kit for it.
+  const courierPK = makeOncePromiseKit(() => X`${key} already pegged`);
+
+  keyToCourierPK.init(key, courierPK);
+  return courierPK;
+};
+
+/**
+ * Create the [send, receive] pair.
+ *
+ * @typedef {Object} CourierArgs
+ * @property {ContractFacet} zcf
+ * @property {ERef<BoardDepositFacet>} board
+ * @property {ERef<NameHub>} namesByAddress
+ * @property {Denom} remoteDenom
+ * @property {Brand} localBrand
+ * @property {(zcfSeat: ZCFSeat, amounts: AmountKeywordRecord) => void} retain
+ * @property {(zcfSeat: ZCFSeat, amounts: AmountKeywordRecord) => void} redeem
+ * @property {ERef<TransferProtocol>} transferProtocol
+ * @param {ERef<Connection>} connection
+ * @returns {(args: CourierArgs) => Courier}
+ */
+export const makeCourierMaker = connection => ({
+  zcf,
+  board,
+  namesByAddress,
+  remoteDenom,
+  localBrand,
+  retain,
+  redeem,
+  transferProtocol,
+}) => {
+  /** @type {Sender} */
+  const send = async (zcfSeat, depositAddress) => {
+    const tryToSend = async () => {
+      const amount = zcfSeat.getAmountAllocated('Transfer', localBrand);
+      const transferPacket = await E(transferProtocol).makeTransferPacket({
+        value: amount.value,
+        remoteDenom,
+        depositAddress,
+      });
+
+      // Retain the payment.  We must not proceed on failure.
+      retain(zcfSeat, { Transfer: amount });
+
+      // The payment is already escrowed, and proposed to retain, so try sending.
+      return E(connection)
+        .send(transferPacket)
+        .then(ack => E(transferProtocol).assertTransferPacketAck(ack))
+        .then(
+          _ => zcfSeat.exit(),
+          reason => {
+            // Return the payment to the seat, if possible.
+            redeem(zcfSeat, { Transfer: amount });
+            throw reason;
+          },
+        );
+    };
+
+    // Reflect any error back to the seat.
+    return tryToSend().catch(reason => {
+      zcfSeat.fail(reason);
+    });
+  };
+
+  /** @type {Receiver} */
+  const receive = async ({ value, depositAddress }) => {
+    const localAmount = AmountMath.make(localBrand, value);
+
+    // Look up the deposit facet for this board address, if there is one.
+    /** @type {DepositFacet} */
+    const depositFacet = await E(board)
+      .getValue(depositAddress)
+      .catch(_ => E(namesByAddress).lookup(depositAddress, 'depositFacet'));
+
+    const { userSeat, zcfSeat } = zcf.makeEmptySeatKit();
+
+    // Redeem the backing payment.
+    try {
+      redeem(zcfSeat, { Transfer: localAmount });
+      zcfSeat.exit();
+    } catch (e) {
+      zcfSeat.fail(e);
+      throw e;
+    }
+
+    // Once we've gotten to this point, their payment is committed and
+    // won't be refunded on a failed receive.
+    const payout = await E(userSeat).getPayout('Transfer');
+
+    // Send the payout promise to the deposit facet.
+    //
+    // We don't want to wait for the depositFacet to return, so that
+    // it can't hang up (i.e. DoS) an ordered channel, which relies on
+    // us returning promptly.
+    E(depositFacet)
+      .receive(payout)
+      .catch(_ => {});
+
+    return E(transferProtocol).makeTransferPacketAck(true);
+  };
+
+  return Far('courier', { send, receive });
+};

--- a/packages/pegasus/src/courier.js
+++ b/packages/pegasus/src/courier.js
@@ -41,85 +41,87 @@ export const getCourierPK = (key, keyToCourierPK) => {
  * @param {ERef<Connection>} connection
  * @returns {(args: CourierArgs) => Courier}
  */
-export const makeCourierMaker = connection => ({
-  zcf,
-  board,
-  namesByAddress,
-  remoteDenom,
-  localBrand,
-  retain,
-  redeem,
-  transferProtocol,
-}) => {
-  /** @type {Sender} */
-  const send = async (zcfSeat, depositAddress) => {
-    const tryToSend = async () => {
-      const amount = zcfSeat.getAmountAllocated('Transfer', localBrand);
-      const transferPacket = await E(transferProtocol).makeTransferPacket({
-        value: amount.value,
-        remoteDenom,
-        depositAddress,
+export const makeCourierMaker =
+  connection =>
+  ({
+    zcf,
+    board,
+    namesByAddress,
+    remoteDenom,
+    localBrand,
+    retain,
+    redeem,
+    transferProtocol,
+  }) => {
+    /** @type {Sender} */
+    const send = async (zcfSeat, depositAddress) => {
+      const tryToSend = async () => {
+        const amount = zcfSeat.getAmountAllocated('Transfer', localBrand);
+        const transferPacket = await E(transferProtocol).makeTransferPacket({
+          value: amount.value,
+          remoteDenom,
+          depositAddress,
+        });
+
+        // Retain the payment.  We must not proceed on failure.
+        retain(zcfSeat, { Transfer: amount });
+
+        // The payment is already escrowed, and proposed to retain, so try sending.
+        return E(connection)
+          .send(transferPacket)
+          .then(ack => E(transferProtocol).assertTransferPacketAck(ack))
+          .then(
+            _ => zcfSeat.exit(),
+            reason => {
+              // Return the payment to the seat, if possible.
+              redeem(zcfSeat, { Transfer: amount });
+              throw reason;
+            },
+          );
+      };
+
+      // Reflect any error back to the seat.
+      return tryToSend().catch(reason => {
+        zcfSeat.fail(reason);
       });
-
-      // Retain the payment.  We must not proceed on failure.
-      retain(zcfSeat, { Transfer: amount });
-
-      // The payment is already escrowed, and proposed to retain, so try sending.
-      return E(connection)
-        .send(transferPacket)
-        .then(ack => E(transferProtocol).assertTransferPacketAck(ack))
-        .then(
-          _ => zcfSeat.exit(),
-          reason => {
-            // Return the payment to the seat, if possible.
-            redeem(zcfSeat, { Transfer: amount });
-            throw reason;
-          },
-        );
     };
 
-    // Reflect any error back to the seat.
-    return tryToSend().catch(reason => {
-      zcfSeat.fail(reason);
-    });
+    /** @type {Receiver} */
+    const receive = async ({ value, depositAddress }) => {
+      const localAmount = AmountMath.make(localBrand, value);
+
+      // Look up the deposit facet for this board address, if there is one.
+      /** @type {DepositFacet} */
+      const depositFacet = await E(board)
+        .getValue(depositAddress)
+        .catch(_ => E(namesByAddress).lookup(depositAddress, 'depositFacet'));
+
+      const { userSeat, zcfSeat } = zcf.makeEmptySeatKit();
+
+      // Redeem the backing payment.
+      try {
+        redeem(zcfSeat, { Transfer: localAmount });
+        zcfSeat.exit();
+      } catch (e) {
+        zcfSeat.fail(e);
+        throw e;
+      }
+
+      // Once we've gotten to this point, their payment is committed and
+      // won't be refunded on a failed receive.
+      const payout = await E(userSeat).getPayout('Transfer');
+
+      // Send the payout promise to the deposit facet.
+      //
+      // We don't want to wait for the depositFacet to return, so that
+      // it can't hang up (i.e. DoS) an ordered channel, which relies on
+      // us returning promptly.
+      E(depositFacet)
+        .receive(payout)
+        .catch(_ => {});
+
+      return E(transferProtocol).makeTransferPacketAck(true);
+    };
+
+    return Far('courier', { send, receive });
   };
-
-  /** @type {Receiver} */
-  const receive = async ({ value, depositAddress }) => {
-    const localAmount = AmountMath.make(localBrand, value);
-
-    // Look up the deposit facet for this board address, if there is one.
-    /** @type {DepositFacet} */
-    const depositFacet = await E(board)
-      .getValue(depositAddress)
-      .catch(_ => E(namesByAddress).lookup(depositAddress, 'depositFacet'));
-
-    const { userSeat, zcfSeat } = zcf.makeEmptySeatKit();
-
-    // Redeem the backing payment.
-    try {
-      redeem(zcfSeat, { Transfer: localAmount });
-      zcfSeat.exit();
-    } catch (e) {
-      zcfSeat.fail(e);
-      throw e;
-    }
-
-    // Once we've gotten to this point, their payment is committed and
-    // won't be refunded on a failed receive.
-    const payout = await E(userSeat).getPayout('Transfer');
-
-    // Send the payout promise to the deposit facet.
-    //
-    // We don't want to wait for the depositFacet to return, so that
-    // it can't hang up (i.e. DoS) an ordered channel, which relies on
-    // us returning promptly.
-    E(depositFacet)
-      .receive(payout)
-      .catch(_ => {});
-
-    return E(transferProtocol).makeTransferPacketAck(true);
-  };
-
-  return Far('courier', { send, receive });
-};

--- a/packages/pegasus/src/courier.js
+++ b/packages/pegasus/src/courier.js
@@ -1,8 +1,9 @@
+// @ts-check
 import { details as X } from '@agoric/assert';
 
 import { AmountMath } from '@agoric/ertp';
 import { E } from '@agoric/eventual-send';
-import { Far } from '@agoric/marshal';
+import { Far } from '@endo/marshal';
 import { makeOncePromiseKit } from './once-promise-kit.js';
 
 /**
@@ -10,7 +11,7 @@ import { makeOncePromiseKit } from './once-promise-kit.js';
  *
  * @template K
  * @param {K} key
- * @param {Store<K, PromiseRecord<Courier>>} keyToCourierPK
+ * @param {LegacyMap<K, PromiseRecord<Courier>>} keyToCourierPK
  */
 export const getCourierPK = (key, keyToCourierPK) => {
   if (keyToCourierPK.has(key)) {
@@ -19,7 +20,7 @@ export const getCourierPK = (key, keyToCourierPK) => {
 
   // This is the first packet for this denomination.
   // Create a new Courier promise kit for it.
-  const courierPK = makeOncePromiseKit(() => X`${key} already pegged`);
+  const courierPK = makeOncePromiseKit(X`${key} already pegged`);
 
   keyToCourierPK.init(key, courierPK);
   return courierPK;

--- a/packages/pegasus/src/ics20.js
+++ b/packages/pegasus/src/ics20.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { Nat } from '@agoric/nat';
 import { Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';

--- a/packages/pegasus/src/ics20.js
+++ b/packages/pegasus/src/ics20.js
@@ -1,0 +1,101 @@
+import { Nat } from '@agoric/nat';
+import { Far } from '@agoric/marshal';
+import { assert, details as X } from '@agoric/assert';
+
+/**
+ * @typedef {Object} ICS20TransferPacket
+ * @property {string} amount The extent of the amount
+ * @property {Denom} denom The denomination of the amount
+ * @property {string} [sender] The sender address
+ * @property {DepositAddress} receiver The receiver deposit address
+ */
+
+/**
+ * Convert an inbound packet to a local amount.
+ *
+ * @param {Bytes} packet
+ * @returns {Promise<PacketParts>}
+ */
+export const parseICS20TransferPacket = async packet => {
+  /** @type {ICS20TransferPacket} */
+  const ics20Packet = JSON.parse(packet);
+  const { amount, denom, receiver } = ics20Packet;
+
+  assert.typeof(denom, 'string', X`Denom ${denom} must be a string`);
+  assert.typeof(receiver, 'string', X`Receiver ${receiver} must be a string`);
+
+  // amount is a string in JSON.
+  assert.typeof(amount, 'string', X`Amount ${amount} must be a string`);
+  const bigValue = BigInt(amount);
+
+  // If we overflow, or don't have a non-negative integer, throw an exception!
+  const value = Nat(bigValue);
+
+  return harden({
+    depositAddress: receiver,
+    remoteDenom: denom,
+    value,
+  });
+};
+
+/**
+ * Convert the amount to a packet to send.
+ *
+ * @param {PacketParts} param0
+ * @returns {Promise<Bytes>}
+ */
+export const makeICS20TransferPacket = async ({
+  value,
+  remoteDenom,
+  depositAddress,
+}) => {
+  // We're using Nat as a dynamic check in a way that tsc doesn't grok.
+  // Should Nat's parameter type be `unknown`?
+  // @ts-ignore
+  const stringValue = String(Nat(value));
+
+  // Generate the ics20-1 packet.
+  /** @type {ICS20TransferPacket} */
+  const ics20 = {
+    amount: stringValue,
+    denom: remoteDenom,
+    receiver: depositAddress,
+  };
+
+  return JSON.stringify(ics20);
+};
+
+/**
+ * Check the results of the transfer.
+ *
+ * @param {Bytes} ack
+ * @returns {Promise<void>}
+ */
+export const assertICS20TransferPacketAck = async ack => {
+  const { success, error } = JSON.parse(ack);
+  assert(success, X`ICS20 transfer error ${error}`);
+};
+
+/**
+ * Create results of the transfer.
+ *
+ * @param {boolean} success
+ * @param {any} error
+ * @returns {Promise<Bytes>}
+ */
+export const makeICS20TransferPacketAck = async (success, error) => {
+  if (success) {
+    const ack = { success: true };
+    return JSON.stringify(ack);
+  }
+  const nack = { success: false, error: `${error}` };
+  return JSON.stringify(nack);
+};
+
+/** @type {TransferProtocol} */
+export const ICS20TransferProtocol = Far('ics20-1 transfer protocol', {
+  makeTransferPacket: makeICS20TransferPacket,
+  assertTransferPacketAck: assertICS20TransferPacketAck,
+  parseTransferPacket: parseICS20TransferPacket,
+  makeTransferPacketAck: makeICS20TransferPacketAck,
+});

--- a/packages/pegasus/src/ics20.js
+++ b/packages/pegasus/src/ics20.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { Nat } from '@agoric/nat';
-import { Far } from '@agoric/marshal';
+import { Far } from '@endo/marshal';
 import { assert, details as X } from '@agoric/assert';
 
 /**

--- a/packages/pegasus/src/once-promise-kit.js
+++ b/packages/pegasus/src/once-promise-kit.js
@@ -1,0 +1,33 @@
+import { assert } from '@agoric/assert';
+import { makePromiseKit } from '@agoric/promise-kit';
+
+/**
+ * Create a promise kit that will throw an exception if it is resolved or
+ * rejected more than once.
+ *
+ * @param {() => Details} makeReinitDetails
+ */
+export const makeOncePromiseKit = makeReinitDetails => {
+  const { promise, resolve, reject } = makePromiseKit();
+
+  let initialized = false;
+  /**
+   * @template {any[]} A
+   * @template R
+   * @param {(...args: A) => R} fn
+   * @returns {(...args: A) => R}
+   */
+  const onceOnly = fn => (...args) => {
+    assert(!initialized, makeReinitDetails());
+    initialized = true;
+    return fn(...args);
+  };
+
+  /** @type {PromiseRecord<any>} */
+  const oncePK = harden({
+    promise,
+    resolve: onceOnly(resolve),
+    reject: onceOnly(reject),
+  });
+  return oncePK;
+};

--- a/packages/pegasus/src/once-promise-kit.js
+++ b/packages/pegasus/src/once-promise-kit.js
@@ -18,11 +18,13 @@ export const makeOncePromiseKit = reinitDetails => {
    * @param {(...args: A) => R} fn
    * @returns {(...args: A) => R}
    */
-  const onceOnly = fn => (...args) => {
-    assert(!resolved, reinitDetails);
-    resolved = true;
-    return fn(...args);
-  };
+  const onceOnly =
+    fn =>
+    (...args) => {
+      assert(!resolved, reinitDetails);
+      resolved = true;
+      return fn(...args);
+    };
 
   /** @type {PromiseRecord<any>} */
   const oncePK = harden({

--- a/packages/pegasus/src/once-promise-kit.js
+++ b/packages/pegasus/src/once-promise-kit.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { assert } from '@agoric/assert';
 import { makePromiseKit } from '@agoric/promise-kit';
 
@@ -5,12 +6,12 @@ import { makePromiseKit } from '@agoric/promise-kit';
  * Create a promise kit that will throw an exception if it is resolved or
  * rejected more than once.
  *
- * @param {() => Details} makeReinitDetails
+ * @param {DetailsToken} reinitDetails
  */
-export const makeOncePromiseKit = makeReinitDetails => {
+export const makeOncePromiseKit = reinitDetails => {
   const { promise, resolve, reject } = makePromiseKit();
 
-  let initialized = false;
+  let resolved = false;
   /**
    * @template {any[]} A
    * @template R
@@ -18,8 +19,8 @@ export const makeOncePromiseKit = makeReinitDetails => {
    * @returns {(...args: A) => R}
    */
   const onceOnly = fn => (...args) => {
-    assert(!initialized, makeReinitDetails());
-    initialized = true;
+    assert(!resolved, reinitDetails);
+    resolved = true;
     return fn(...args);
   };
 

--- a/packages/pegasus/src/pegasus.js
+++ b/packages/pegasus/src/pegasus.js
@@ -72,7 +72,7 @@ const makePegasus = (zcf, board, namesByAddress) => {
    */
   const makePeg = (state, desc) => {
     /** @type {Peg} */
-    const peg = Far('peg', {
+    const peg = Far(`${desc.allegedName} peg`, {
       getAllegedName() {
         return desc.allegedName;
       },

--- a/packages/pegasus/src/pegasus.js
+++ b/packages/pegasus/src/pegasus.js
@@ -1,7 +1,7 @@
 // @ts-check
 
-import { assert, details as X, q } from '@agoric/assert';
-import { makeLegacyWeakMap, makeStore, makeLegacyMap } from '@agoric/store';
+import { assert, details as X } from '@agoric/assert';
+import { makeLegacyWeakMap, makeLegacyMap } from '@agoric/store';
 import { E } from '@agoric/eventual-send';
 import { assertProposalShape } from '@agoric/zoe/src/contractSupport/index.js';
 import { Far } from '@endo/marshal';
@@ -12,168 +12,15 @@ import '@agoric/swingset-vat/src/vats/network/types.js';
 import '@agoric/zoe/exported.js';
 
 import '../exported.js';
-import { makePromiseKit } from '@agoric/promise-kit';
-import { AmountMath } from '@agoric/ertp';
 import { ICS20TransferProtocol } from './ics20.js';
+import { makeCourierMaker, getCourierPK } from './courier.js';
 
 const DEFAULT_TRANSFER_PROTOCOL = ICS20TransferProtocol;
-
-const DEFAULT_AMOUNT_MATH_KIND = 'nat';
 
 const TRANSFER_PROPOSAL_SHAPE = {
   give: {
     Transfer: null,
   },
-};
-
-/**
- * Create a promise kit that will throw an exception if it is resolved or
- * rejected more than once.
- *
- * @param {() => Details} makeReinitDetails
- */
-const makeOncePromiseKit = makeReinitDetails => {
-  const { promise, resolve, reject } = makePromiseKit();
-
-  let initialized = false;
-  /**
-   * @template {any[]} A
-   * @template R
-   * @param {(...args: A) => R} fn
-   * @returns {(...args: A) => R}
-   */
-  const onceOnly = fn => (...args) => {
-    assert(!initialized, makeReinitDetails());
-    initialized = true;
-    return fn(...args);
-  };
-
-  /** @type {PromiseRecord<any>} */
-  const oncePK = harden({
-    promise,
-    resolve: onceOnly(resolve),
-    reject: onceOnly(reject),
-  });
-  return oncePK;
-};
-
-/**
- * Create or return an existing courier promise kit.
- *
- * @param {Denom} remoteDenom
- * @param {Store<Denom, PromiseRecord<Courier>>} remoteDenomToCourierPK
- */
-const getCourierPK = (remoteDenom, remoteDenomToCourierPK) => {
-  if (remoteDenomToCourierPK.has(remoteDenom)) {
-    return remoteDenomToCourierPK.get(remoteDenom);
-  }
-
-  // This is the first packet for this denomination.
-  // Create a new Courier promise kit for it.
-  const courierPK = makeOncePromiseKit(() => X`${remoteDenom} already pegged`);
-
-  remoteDenomToCourierPK.init(remoteDenom, courierPK);
-  return courierPK;
-};
-
-/**
- * Create the [send, receive] pair.
- *
- * @typedef {Object} CourierArgs
- * @property {ContractFacet} zcf
- * @property {ERef<Connection>} connection
- * @property {ERef<BoardDepositFacet>} board
- * @property {ERef<NameHub>} namesByAddress
- * @property {Denom} remoteDenom
- * @property {Brand} localBrand
- * @property {(zcfSeat: ZCFSeat, amounts: AmountKeywordRecord) => void} retain
- * @property {(zcfSeat: ZCFSeat, amounts: AmountKeywordRecord) => void} redeem
- * @property {ERef<TransferProtocol>} transferProtocol
- * @param {CourierArgs} arg0
- * @returns {Courier}
- */
-const makeCourier = ({
-  zcf,
-  connection,
-  board,
-  namesByAddress,
-  remoteDenom,
-  localBrand,
-  retain,
-  redeem,
-  transferProtocol,
-}) => {
-  /** @type {Sender} */
-  const send = async (zcfSeat, depositAddress) => {
-    const tryToSend = async () => {
-      const amount = zcfSeat.getAmountAllocated('Transfer', localBrand);
-      const transferPacket = await E(transferProtocol).makeTransferPacket({
-        value: amount.value,
-        remoteDenom,
-        depositAddress,
-      });
-
-      // Retain the payment.  We must not proceed on failure.
-      retain(zcfSeat, { Transfer: amount });
-
-      // The payment is already escrowed, and proposed to retain, so try sending.
-      return E(connection)
-        .send(transferPacket)
-        .then(ack => E(transferProtocol).assertTransferPacketAck(ack))
-        .then(
-          _ => zcfSeat.exit(),
-          reason => {
-            // Return the payment to the seat, if possible.
-            redeem(zcfSeat, { Transfer: amount });
-            throw reason;
-          },
-        );
-    };
-
-    // Reflect any error back to the seat.
-    return tryToSend().catch(reason => {
-      zcfSeat.fail(reason);
-    });
-  };
-
-  /** @type {Receiver} */
-  const receive = async ({ value, depositAddress }) => {
-    const localAmount = AmountMath.make(localBrand, value);
-
-    // Look up the deposit facet for this board address, if there is one.
-    /** @type {DepositFacet} */
-    const depositFacet = await E(board)
-      .getValue(depositAddress)
-      .catch(_ => E(namesByAddress).lookup(depositAddress, 'depositFacet'));
-
-    const { userSeat, zcfSeat } = zcf.makeEmptySeatKit();
-
-    // Redeem the backing payment.
-    try {
-      redeem(zcfSeat, { Transfer: localAmount });
-      zcfSeat.exit();
-    } catch (e) {
-      zcfSeat.fail(e);
-      throw e;
-    }
-
-    // Once we've gotten to this point, their payment is committed and
-    // won't be refunded on a failed receive.
-    const payout = await E(userSeat).getPayout('Transfer');
-
-    // Send the payout promise to the deposit facet.
-    //
-    // We don't want to wait for the depositFacet to return, so that
-    // it can't hang up (i.e. DoS) an ordered channel, which relies on
-    // us returning promptly.
-    E(depositFacet)
-      .receive(payout)
-      .catch(_ => {});
-
-    return E(transferProtocol).makeTransferPacketAck(true);
-  };
-
-  return Far('courier', { send, receive });
 };
 
 /**
@@ -187,16 +34,10 @@ const makePegasus = (zcf, board, namesByAddress) => {
   /**
    * @typedef {Object} LocalDenomState
    * @property {Store<Denom, PromiseRecord<Courier>>} remoteDenomToCourierPK
+   * @property {IterationObserver<Denom>} remoteDenomPublication
    * @property {Subscription<Denom>} remoteDenomSubscription
    * @property {number} lastDenomNonce
-   * @property {ERef<TransferProtocol>} transferProtocol
    */
-
-  /**
-   * @type {LegacyWeakMap<Connection, LocalDenomState>}
-   */
-  // Legacy because the value contains a JS Set
-  const connectionToLocalDenomState = makeLegacyWeakMap('Connection');
 
   let lastLocalIssuerNonce = 0;
   /**
@@ -210,23 +51,23 @@ const makePegasus = (zcf, board, namesByAddress) => {
   };
 
   /**
-   * @type {Store<Peg, Connection>}
+   * @type {LegacyWeakMap<Peg, LocalDenomState>}
    */
-  const pegToConnection = makeStore('Peg');
+  const pegToDenomState = makeLegacyWeakMap('Peg');
 
   /**
    * Create a fresh Peg associated with a descriptor.
    *
-   * @typedef {Object} PegDescriptor
+   * @typedef {Object} PegasusDescriptor
    * @property {Brand} localBrand
    * @property {Denom} remoteDenom
    * @property {string} allegedName
    *
-   * @param {Connection} c
-   * @param {PegDescriptor} desc
+   * @param {LocalDenomState} state
+   * @param {PegasusDescriptor} desc
    * @returns {Peg}
    */
-  const makePeg = (c, desc) => {
+  const makePeg = (state, desc) => {
     /** @type {Peg} */
     const peg = Far('peg', {
       getAllegedName() {
@@ -240,8 +81,152 @@ const makePegasus = (zcf, board, namesByAddress) => {
       },
     });
 
-    pegToConnection.init(peg, c);
+    pegToDenomState.init(peg, state);
     return peg;
+  };
+
+  /**
+   * @param {Object} param0
+   * @param {ReturnType<typeof makeCourierMaker>} param0.makeCourier
+   * @param {LocalDenomState} param0.localDenomState
+   * @param {ERef<TransferProtocol>} param0.transferProtocol
+   * @returns {PegasusConnectionActions}
+   */
+  const makePegasusConnectionActions = ({
+    makeCourier,
+    localDenomState,
+    transferProtocol,
+  }) => {
+    /** @type {PegasusConnectionActions} */
+    const pegasusConnectionActions = {
+      async rejectStuckTransfers(remoteDenom) {
+        const { remoteDenomToCourierPK } = localDenomState;
+
+        const { reject, promise } = remoteDenomToCourierPK.get(remoteDenom);
+        promise.catch(() => {});
+        reject(assert.error(X`${remoteDenom} is temporarily unavailable`));
+
+        // Allow new transfers to be initiated.
+        remoteDenomToCourierPK.delete(remoteDenom);
+      },
+      async pegRemote(
+        allegedName,
+        remoteDenom,
+        assetKind = undefined,
+        displayInfo = undefined,
+      ) {
+        const { remoteDenomToCourierPK } = localDenomState;
+
+        // Create the issuer for the local erights corresponding to the remote values.
+        const localKeyword = createLocalIssuerKeyword();
+        const zcfMint = await zcf.makeZCFMint(
+          localKeyword,
+          assetKind,
+          displayInfo,
+        );
+        const { brand: localBrand } = zcfMint.getIssuerRecord();
+
+        // Describe how to retain/redeem pegged shadow erights.
+        const courier = makeCourier({
+          zcf,
+          localBrand,
+          board,
+          namesByAddress,
+          remoteDenom,
+          retain: (zcfSeat, amounts) =>
+            zcfMint.burnLosses(harden(amounts), zcfSeat),
+          redeem: (zcfSeat, amounts) => {
+            zcfMint.mintGains(harden(amounts), zcfSeat);
+          },
+          transferProtocol,
+        });
+
+        const courierPK = getCourierPK(remoteDenom, remoteDenomToCourierPK);
+        courierPK.resolve(courier);
+
+        return makePeg(localDenomState, {
+          localBrand,
+          remoteDenom,
+          allegedName,
+        });
+      },
+
+      async pegLocal(allegedName, localIssuer) {
+        // We need the last nonce for our denom name.
+        localDenomState.lastDenomNonce += 1;
+        const remoteDenom = `pegasus${localDenomState.lastDenomNonce}`;
+
+        // Create a seat in which to keep our denomination.
+        const { zcfSeat: poolSeat } = zcf.makeEmptySeatKit();
+
+        // Ensure the issuer can be used in Zoe offers.
+        const localKeyword = createLocalIssuerKeyword();
+        const { brand: localBrand } = await zcf.saveIssuer(
+          localIssuer,
+          localKeyword,
+        );
+
+        /**
+         * Transfer amount (of localBrand) from loser to winner seats.
+         *
+         * @param {Amount} amount amount to transfer
+         * @param {Keyword} loserKeyword the keyword to take from the loser
+         * @param {ZCFSeat} loser seat to transfer from
+         * @param {Keyword} winnerKeyword the keyword to give to the winner
+         * @param {ZCFSeat} winner seat to transfer to
+         */
+        const transferAmountFrom = (
+          amount,
+          loserKeyword,
+          loser,
+          winnerKeyword,
+          winner,
+        ) => {
+          // Transfer the amount to our backing seat.
+          loser.decrementBy(harden({ [loserKeyword]: amount }));
+          winner.incrementBy(harden({ [winnerKeyword]: amount }));
+          zcf.reallocate(loser, winner);
+        };
+
+        // Describe how to retain/redeem real local erights.
+        const courier = makeCourier({
+          zcf,
+          board,
+          namesByAddress,
+          remoteDenom,
+          localBrand,
+          retain: (transferSeat, amounts) =>
+            transferAmountFrom(
+              amounts.Transfer,
+              'Transfer',
+              transferSeat,
+              'Pool',
+              poolSeat,
+            ),
+          redeem: (transferSeat, amounts) =>
+            transferAmountFrom(
+              amounts.Transfer,
+              'Pool',
+              poolSeat,
+              'Transfer',
+              transferSeat,
+            ),
+          transferProtocol,
+        });
+
+        const { remoteDenomToCourierPK } = localDenomState;
+
+        const courierPK = getCourierPK(remoteDenom, remoteDenomToCourierPK);
+        courierPK.resolve(courier);
+
+        return makePeg(localDenomState, {
+          localBrand,
+          remoteDenom,
+          allegedName,
+        });
+      },
+    };
+    return Far('pegasusConnectionActions', pegasusConnectionActions);
   };
 
   return Far('pegasus', {
@@ -249,33 +234,61 @@ const makePegasus = (zcf, board, namesByAddress) => {
      * Return a handler that can be used with the Network API.
      *
      * @param {ERef<TransferProtocol>} [transferProtocol=DEFAULT_TRANSFER_PROTOCOL]
-     * @returns {ConnectionHandler}
+     * @returns {PegasusConnectionKit}
      */
-    makePegConnectionHandler(transferProtocol = DEFAULT_TRANSFER_PROTOCOL) {
+    makePegasusConnectionKit(transferProtocol = DEFAULT_TRANSFER_PROTOCOL) {
       /**
-       * @type {Store<Denom, PromiseRecord<Courier>>}
+       * @type {WeakStore<Connection, LocalDenomState>}
        */
-      const remoteDenomToCourierPK = makeLegacyMap('Denomination');
+      // Legacy because the value contains a JS Set
+      const connectionToLocalDenomState = makeLegacyWeakMap('Connection');
 
       /**
-       * @type {SubscriptionRecord<Denom>}
+       * @type {SubscriptionRecord<PegasusConnectionSubscription>}
        */
       const {
-        subscription: remoteDenomSubscription,
-        publication: remoteDenomPublication,
+        subscription: connectionSubscription,
+        publication: connectionPublication,
       } = makeSubscriptionKit();
 
-      return Far('pegConnectionHandler', {
-        async onOpen(c) {
+      /** @type {ConnectionHandler} */
+      const handler = {
+        async onOpen(c, localAddr, remoteAddr) {
           // Register C with the table of Peg receivers.
-          connectionToLocalDenomState.init(c, {
+          const {
+            subscription: remoteDenomSubscription,
+            publication: remoteDenomPublication,
+          } = makeSubscriptionKit();
+          const remoteDenomToCourierPK = makeLegacyMap('Denomination');
+
+          /** @type {LocalDenomState} */
+          const localDenomState = {
             remoteDenomToCourierPK,
             lastDenomNonce: 0,
+            remoteDenomPublication,
+            remoteDenomSubscription,
+          };
+
+          // The courier is the only thing that we use to send messages to C.
+          const makeCourier = makeCourierMaker(c);
+          const actions = makePegasusConnectionActions({
+            localDenomState,
+            makeCourier,
             transferProtocol,
+          });
+
+          connectionToLocalDenomState.init(c, localDenomState);
+
+          /** @type {PegasusConnectionSubscription} */
+          const subData = harden({
+            localAddr,
+            remoteAddr,
+            actions,
             remoteDenomSubscription,
           });
+          connectionPublication.updateState(subData);
         },
-        async onReceive(_c, packetBytes) {
+        async onReceive(c, packetBytes) {
           const doReceive = async () => {
             // Dispatch the packet to the appropriate Peg for this connection.
             const parts = await E(transferProtocol).parseTransferPacket(
@@ -284,6 +297,11 @@ const makePegasus = (zcf, board, namesByAddress) => {
 
             const { remoteDenom } = parts;
             assert.typeof(remoteDenom, 'string');
+
+            const {
+              remoteDenomToCourierPK,
+              remoteDenomPublication,
+            } = connectionToLocalDenomState.get(c);
 
             if (!remoteDenomToCourierPK.has(remoteDenom)) {
               // This is the first time we've heard of this denomination.
@@ -302,216 +320,21 @@ const makePegasus = (zcf, board, namesByAddress) => {
         },
         async onClose(c) {
           // Unregister C.  Pending transfers will be rejected by the Network API.
+          const { remoteDenomPublication } = connectionToLocalDenomState.get(c);
           connectionToLocalDenomState.delete(c);
           remoteDenomPublication.fail(
-            assert.error(X`pegConnectionHandler closed`),
+            assert.error(X`pegasusConnectionHandler closed`),
           );
         },
-      });
-    },
-
-    /**
-     * Get a subscription for remote denoms added on a connection.
-     *
-     * @param {ERef<Connection>} connectionP
-     */
-    async getRemoteDenomSubscription(connectionP) {
-      const connection = await connectionP;
-      const { remoteDenomSubscription } = connectionToLocalDenomState.get(
-        connection,
-      );
-      return remoteDenomSubscription;
-    },
-
-    /**
-     * Abort any in-progress remoteDenom transfers if there has not yet been a
-     * pegRemote or pegLocal for it.
-     *
-     * This races against any attempts to obtain metadata and establish a given
-     * peg.
-     *
-     * It's alright to expose to the holder of the connection.
-     *
-     * @param {ERef<Connection>} connectionP
-     * @param {string} remoteDenom
-     */
-    async rejectStuckTransfers(connectionP, remoteDenom) {
-      const connection = await connectionP;
-      const { remoteDenomToCourierPK } = connectionToLocalDenomState.get(
-        connection,
-      );
-
-      const { reject, promise } = remoteDenomToCourierPK.get(remoteDenom);
-      promise.catch(() => {});
-      reject(assert.error(X`${remoteDenom} is temporarily unavailable`));
-
-      // Allow new transfers to be initiated.
-      remoteDenomToCourierPK.delete(remoteDenom);
-    },
-
-    /**
-     * Peg a remote asset over a network connection.
-     *
-     * @param {string} allegedName
-     * @param {ERef<Connection>} connectionP The network connection (such as IBC
-     * channel) to communicate over
-     * @param {Denom} remoteDenom Remote denomination
-     * @param {string} [assetKind=DEFAULT_AMOUNT_MATH_KIND] The kind of
-     * amount math for the pegged values
-     * @param {DisplayInfo} [displayInfo]
-     * @returns {Promise<Peg>}
-     */
-    async pegRemote(
-      allegedName,
-      connectionP,
-      remoteDenom,
-      assetKind = DEFAULT_AMOUNT_MATH_KIND,
-      displayInfo = undefined,
-    ) {
-      // Assertions
-      assert(
-        assetKind === 'nat',
-        X`Unimplemented assetKind ${q(assetKind)}; need "nat"`,
-      );
-
-      const c = await connectionP;
-      assert(
-        connectionToLocalDenomState.has(c),
-        X`The connection must use .makePegConnectionHandler()`,
-      );
-
-      const { transferProtocol } = connectionToLocalDenomState.get(c);
-
-      // Create the issuer for the local erights corresponding to the remote values.
-      const localKeyword = createLocalIssuerKeyword();
-      const zcfMint = await zcf.makeZCFMint(
-        localKeyword,
-        assetKind,
-        displayInfo,
-      );
-      const { brand: localBrand } = zcfMint.getIssuerRecord();
-
-      // Describe how to retain/redeem pegged shadow erights.
-      const courier = makeCourier({
-        zcf,
-        connection: c,
-        localBrand,
-        board,
-        namesByAddress,
-        remoteDenom,
-        retain: (zcfSeat, amounts) =>
-          zcfMint.burnLosses(harden(amounts), zcfSeat),
-        redeem: (zcfSeat, amounts) => {
-          zcfMint.mintGains(harden(amounts), zcfSeat);
-        },
-        transferProtocol,
-      });
-
-      const { remoteDenomToCourierPK } = connectionToLocalDenomState.get(c);
-
-      const courierPK = getCourierPK(remoteDenom, remoteDenomToCourierPK);
-      courierPK.resolve(courier);
-
-      return makePeg(c, { localBrand, remoteDenom, allegedName });
-    },
-
-    /**
-     * Peg a local asset over a network connection.
-     *
-     * @param {string} allegedName
-     * @param {ERef<Connection>} connectionP The network connection (such as IBC
-     * channel) to communicate over
-     * @param {Issuer} localIssuer Local ERTP issuer whose assets should be
-     * pegged to the connection
-     * @returns {Promise<Peg>}
-     */
-    async pegLocal(allegedName, connectionP, localIssuer) {
-      const c = await connectionP;
-      assert(
-        connectionToLocalDenomState.has(c),
-        X`The connection must use .makePegConnectionHandler()`,
-      );
-
-      // We need the last nonce for our denom name.
-      const localDenomState = connectionToLocalDenomState.get(c);
-      const { transferProtocol } = localDenomState;
-      localDenomState.lastDenomNonce += 1;
-      const remoteDenom = `pegasus${localDenomState.lastDenomNonce}`;
-
-      // Create a seat in which to keep our denomination.
-      const { zcfSeat: poolSeat } = zcf.makeEmptySeatKit();
-
-      // Ensure the issuer can be used in Zoe offers.
-      const localKeyword = createLocalIssuerKeyword();
-      const { brand: localBrand } = await zcf.saveIssuer(
-        localIssuer,
-        localKeyword,
-      );
-
-      /**
-       * Transfer amount (of localBrand) from loser to winner seats.
-       *
-       * @param {Amount} amount amount to transfer
-       * @param {Keyword} loserKeyword the keyword to take from the loser
-       * @param {ZCFSeat} loser seat to transfer from
-       * @param {Keyword} winnerKeyword the keyword to give to the winner
-       * @param {ZCFSeat} winner seat to transfer to
-       */
-      const transferAmountFrom = (
-        amount,
-        loserKeyword,
-        loser,
-        winnerKeyword,
-        winner,
-      ) => {
-        // Transfer the amount to our backing seat.
-        loser.decrementBy(harden({ [loserKeyword]: amount }));
-        winner.incrementBy(harden({ [winnerKeyword]: amount }));
-        zcf.reallocate(loser, winner);
       };
 
-      // Describe how to retain/redeem real local erights.
-      const courier = makeCourier({
-        zcf,
-        connection: c,
-        board,
-        namesByAddress,
-        remoteDenom,
-        localBrand,
-        retain: (transferSeat, amounts) =>
-          transferAmountFrom(
-            amounts.Transfer,
-            'Transfer',
-            transferSeat,
-            'Pool',
-            poolSeat,
-          ),
-        redeem: (transferSeat, amounts) =>
-          transferAmountFrom(
-            amounts.Transfer,
-            'Pool',
-            poolSeat,
-            'Transfer',
-            transferSeat,
-          ),
-        transferProtocol,
+      return harden({
+        handler: Far('pegasusConnectionHandler', handler),
+        subscription: connectionSubscription,
       });
-
-      const { remoteDenomToCourierPK } = localDenomState;
-
-      const courierPK = getCourierPK(remoteDenom, remoteDenomToCourierPK);
-      courierPK.resolve(courier);
-
-      return makePeg(c, { localBrand, remoteDenom, allegedName });
     },
 
-    /**
-     * Find one of our registered issuers.
-     *
-     * @param {Brand} localBrand
-     * @returns {Promise<Issuer>}
-     */
-    async getLocalIssuer(localBrand) {
+    getLocalIssuer(localBrand) {
       return zcf.getIssuerForBrand(localBrand);
     },
 
@@ -525,11 +348,11 @@ const makePegasus = (zcf, board, namesByAddress) => {
     async makeInvitationToTransfer(pegP, depositAddress) {
       // Verify the peg.
       const peg = await pegP;
-      const c = pegToConnection.get(peg);
+      const denomState = pegToDenomState.get(peg);
 
       // Get details from the peg.
       const remoteDenom = await E(peg).getRemoteDenom();
-      const { remoteDenomToCourierPK } = connectionToLocalDenomState.get(c);
+      const { remoteDenomToCourierPK } = denomState;
 
       const courierPK = getCourierPK(remoteDenom, remoteDenomToCourierPK);
       const { send } = await courierPK.promise;

--- a/packages/pegasus/src/types.js
+++ b/packages/pegasus/src/types.js
@@ -9,7 +9,7 @@
 
 /**
  * @typedef {Object} PacketParts
- * @property {Value} value
+ * @property {AmountValue} value
  * @property {Denom} remoteDenom
  * @property {DepositAddress} depositAddress
  */

--- a/packages/pegasus/src/types.js
+++ b/packages/pegasus/src/types.js
@@ -81,18 +81,19 @@
  * @property {PegLocal} pegLocal
  * @property {PegRemote} pegRemote
  * @property {RejectStuckTransfers} rejectStuckTransfers
+ * @property {(reason?: any) => void} abort
  */
 
 /**
- * @typedef {Object} PegasusConnectionSubscription
- * @property {PegasusConnectionActions} actions
+ * @typedef {Object} PegasusConnectionState
+ * @property {PegasusConnectionActions} [actions]
  * @property {Address} localAddr
  * @property {Address} remoteAddr
- * @property {Subscription<Denom>} remoteDenomSubscription
+ * @property {Subscription<Denom>} [remoteDenomSubscription]
  */
 
 /**
  * @typedef {Object} PegasusConnectionKit
  * @property {ConnectionHandler} handler
- * @property {Subscription<PegasusConnectionSubscription>} subscription
+ * @property {Subscription<PegasusConnectionState>} subscription
  */

--- a/packages/pegasus/src/types.js
+++ b/packages/pegasus/src/types.js
@@ -1,15 +1,30 @@
 /// <reference types="ses"/>
 
 /**
- * @typedef {string} DenomUri
  * @typedef {string} Denom
  * @typedef {string} DepositAddress
- * @typedef {string} TransferProtocol
- *
+ */
+
+/**
+ * @typedef {Object} PacketParts
+ * @property {Value} value
+ * @property {Denom} remoteDenom
+ * @property {DepositAddress} depositAddress
+ */
+
+/**
+ * @typedef {Object} TransferProtocol
+ * @property {(parts: PacketParts) => Promise<Bytes>} makeTransferPacket
+ * @property {(packet: Bytes) => Promise<PacketParts>} parseTransferPacket
+ * @property {(success: boolean, error?: any) => Promise<Bytes>} makeTransferPacketAck
+ * @property {(ack: Bytes) => Promise<void>} assertTransferPacketAck
+ */
+
+/**
  * @typedef {Object} Peg
  * @property {() => string} getAllegedName get the debug name
  * @property {() => Brand} getLocalBrand get the brand associated with the peg
- * @property {() => DenomUri} getDenomUri get the denomination identifier
+ * @property {() => Denom} getRemoteDenom get the denomination identifier
  */
 
 /**
@@ -18,17 +33,9 @@
  */
 
 /**
- * @typedef {Object} FungibleTransferPacket
- * @property {string} amount The extent of the amount
- * @property {Denom} denom The denomination of the amount
- * @property {string} [sender] The sender address
- * @property {DepositAddress} receiver The receiver deposit address
- */
-
-/**
  * @typedef {(zcfSeat: ZCFSeat, depositAddress: DepositAddress) => Promise<void>} Sender
  * Successive transfers are not guaranteed to be processed in the order in which they were sent.
- * @typedef {(packet: FungibleTransferPacket) => Promise<void>} Receiver
+ * @typedef {(parts: PacketParts) => Promise<Bytes>} Receiver
  * @typedef {Object} Courier
  * @property {Sender} send
  * @property {Receiver} receive

--- a/packages/pegasus/src/types.js
+++ b/packages/pegasus/src/types.js
@@ -1,3 +1,5 @@
+// @ts-check
+// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 /**
@@ -85,7 +87,7 @@
  */
 
 /**
- * @typedef {Object} PegasusConnectionState
+ * @typedef {Object} PegasusConnection
  * @property {PegasusConnectionActions} [actions]
  * @property {Address} localAddr
  * @property {Address} remoteAddr
@@ -95,5 +97,5 @@
 /**
  * @typedef {Object} PegasusConnectionKit
  * @property {ConnectionHandler} handler
- * @property {Subscription<PegasusConnectionState>} subscription
+ * @property {Subscription<PegasusConnection>} subscription
  */

--- a/packages/pegasus/src/types.js
+++ b/packages/pegasus/src/types.js
@@ -40,3 +40,59 @@
  * @property {Sender} send
  * @property {Receiver} receive
  */
+
+/**
+ * @callback RejectStuckTransfers
+ * Abort any in-progress remoteDenom transfers if there has not yet been a
+ * pegRemote or pegLocal for it.
+ *
+ * This races against any attempts to obtain metadata and establish a given
+ * peg.
+ *
+ * It's alright to expose to the holder of the connection.
+ *
+ * @param {Denom} remoteDenom
+ * @returns {Promise<void>}
+ */
+
+/**
+ * @callback PegRemote
+ * Peg a remote asset over a network connection.
+ *
+ * @param {string} allegedName
+ * @param {Denom} remoteDenom
+ * @param {AssetKind} [assetKind] The kind of the pegged values
+ * @param {DisplayInfo} [displayInfo]
+ * @returns {Promise<Peg>}
+ */
+
+/**
+ * @callback PegLocal
+ * Peg a local asset over a network connection.
+ *
+ * @param {string} allegedName
+ * @param {Issuer} localIssuer Local ERTP issuer whose assets should be
+ * pegged to the connection
+ * @returns {Promise<Peg>}
+ */
+
+/**
+ * @typedef {Object} PegasusConnectionActions
+ * @property {PegLocal} pegLocal
+ * @property {PegRemote} pegRemote
+ * @property {RejectStuckTransfers} rejectStuckTransfers
+ */
+
+/**
+ * @typedef {Object} PegasusConnectionSubscription
+ * @property {PegasusConnectionActions} actions
+ * @property {Address} localAddr
+ * @property {Address} remoteAddr
+ * @property {Subscription<Denom>} remoteDenomSubscription
+ */
+
+/**
+ * @typedef {Object} PegasusConnectionKit
+ * @property {ConnectionHandler} handler
+ * @property {Subscription<PegasusConnectionSubscription>} subscription
+ */

--- a/packages/pegasus/test/test-peg.js
+++ b/packages/pegasus/test/test-peg.js
@@ -42,10 +42,8 @@ async function testRemotePeg(t) {
   /**
    * @type {PromiseRecord<import('@agoric/ertp').DepositFacet>}
    */
-  const {
-    promise: localDepositFacet,
-    resolve: resolveLocalDepositFacet,
-  } = makePromiseKit();
+  const { promise: localDepositFacet, resolve: resolveLocalDepositFacet } =
+    makePromiseKit();
   const fakeBoard = Far('fakeBoard', {
     getValue(id) {
       if (id === '0x1234') {

--- a/packages/pegasus/test/test-peg.js
+++ b/packages/pegasus/test/test-peg.js
@@ -183,5 +183,4 @@ async function testRemotePeg(t) {
   t.assert(!stillIsLive, 'payment is consumed');
 }
 
-test('remote peg', t =>
-  testRemotePeg(t).catch(err => t.not(err, err, 'unexpected exception')));
+test('remote peg', t => testRemotePeg(t));

--- a/packages/promise-kit/src/promiseKit.js
+++ b/packages/promise-kit/src/promiseKit.js
@@ -10,7 +10,7 @@ const BestPipelinablePromise = globalThis.HandledPromise || Promise;
  * @template T
  * @typedef {Object} PromiseKit A reified Promise
  * @property {(value: ERef<T>) => void} resolve
- * @property {(reason: any) => void} reject
+ * @property {(reason?: any) => void} reject
  * @property {Promise<T>} promise
  */
 

--- a/packages/vats/src/bootstrap.js
+++ b/packages/vats/src/bootstrap.js
@@ -18,6 +18,7 @@ import {
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { AmountMath } from '@agoric/ertp';
 import { Nat } from '@agoric/nat';
+import { observeIteration } from '@agoric/notifier';
 import { makeBridgeManager } from './bridge.js';
 import { makeNameHubKit } from './nameHub.js';
 import {
@@ -94,19 +95,26 @@ export function buildRootObject(vatPowers, vatParameters) {
       E(vats.board).getBoard(),
       chainTimerServiceP,
       /** @type {Promise<{ zoeService: ZoeService, feeMintAccess:
-       * FeeMintAccess }>} */ (
-        E(vats.zoe).buildZoe(vatAdminSvc, feeIssuerConfig)
-      ),
+       * FeeMintAccess }>} */ (E(vats.zoe).buildZoe(
+        vatAdminSvc,
+        feeIssuerConfig,
+      )),
       E(vats.priceAuthority).makePriceAuthority(),
       E(vats.walletManager).buildWalletManager(vatAdminSvc),
     ]);
 
-    const { nameHub: agoricNames, nameAdmin: agoricNamesAdmin } =
-      makeNameHubKit();
-    const { nameHub: namesByAddress, nameAdmin: namesByAddressAdmin } =
-      makeNameHubKit();
-    const { nameHub: pegasusConnections, nameAdmin: pegasusConnectionsAdmin } =
-      makeNameHubKit();
+    const {
+      nameHub: agoricNames,
+      nameAdmin: agoricNamesAdmin,
+    } = makeNameHubKit();
+    const {
+      nameHub: namesByAddress,
+      nameAdmin: namesByAddressAdmin,
+    } = makeNameHubKit();
+    const {
+      nameHub: pegasusConnections,
+      nameAdmin: pegasusConnectionsAdmin,
+    } = makeNameHubKit();
 
     async function installEconomy(bootstrapPaymentValue) {
       // Create a mapping from all the nameHubs we create to their corresponding
@@ -222,16 +230,23 @@ export function buildRootObject(vatPowers, vatParameters) {
     const bootstrapPaymentValue = bankBootstrapSupply + ammDepositValue;
     // NOTE: no use of the voteCreator. We'll need it to initiate votes on
     // changing VaultFactory parameters.
-    const { vaultFactoryCreator, _voteCreator, ammFacets } =
-      await installEconomy(bootstrapPaymentValue);
+    const {
+      vaultFactoryCreator,
+      _voteCreator,
+      ammFacets,
+    } = await installEconomy(bootstrapPaymentValue);
 
-    const [centralIssuer, centralBrand, ammInstance, pegasusInstance] =
-      await Promise.all([
-        E(agoricNames).lookup('issuer', CENTRAL_ISSUER_NAME),
-        E(agoricNames).lookup('brand', CENTRAL_ISSUER_NAME),
-        E(agoricNames).lookup('instance', 'amm'),
-        E(agoricNames).lookup('instance', 'Pegasus'),
-      ]);
+    const [
+      centralIssuer,
+      centralBrand,
+      ammInstance,
+      pegasusInstance,
+    ] = await Promise.all([
+      E(agoricNames).lookup('issuer', CENTRAL_ISSUER_NAME),
+      E(agoricNames).lookup('brand', CENTRAL_ISSUER_NAME),
+      E(agoricNames).lookup('instance', 'amm'),
+      E(agoricNames).lookup('instance', 'Pegasus'),
+    ]);
 
     // Start the reward distributor.
     const epochTimerService = chainTimerService;
@@ -579,11 +594,10 @@ export function buildRootObject(vatPowers, vatParameters) {
       async createUserBundle(_nickname, address, powerFlags = []) {
         // Bind to some fresh ports (unspecified name) on the IBC implementation
         // and provide them for the user to have.
-        const ibcport = [];
+        const ibcportP = [];
         for (let i = 0; i < NUM_IBC_PORTS; i += 1) {
-          // eslint-disable-next-line no-await-in-loop
-          const port = await E(network).bind('/ibc-port/');
-          ibcport.push(port);
+          const port = E(network).bind('/ibc-port/');
+          ibcportP.push(port);
         }
 
         /** @type {{ issuerName: string, purseName: string, issuer: Issuer,
@@ -656,14 +670,23 @@ export function buildRootObject(vatPowers, vatParameters) {
           }),
         );
 
-        const bank = await E(bankManager).getBankForAddress(address);
+        const [bank, ibcport] = await Promise.all([
+          E(bankManager).getBankForAddress(address),
+          Promise.all(ibcportP),
+        ]);
 
         // Separate out the purse-creating payments from the bank payments.
         const faucetPaymentInfo = [];
         await Promise.all(
           userPaymentRecords.map(async precord => {
-            const { payToBank, issuer, issuerName, payment, brand, purseName } =
-              precord;
+            const {
+              payToBank,
+              issuer,
+              issuerName,
+              payment,
+              brand,
+              purseName,
+            } = precord;
             if (!payToBank) {
               // Just a faucet payment to be claimed by a wallet.
               faucetPaymentInfo.push({
@@ -696,8 +719,10 @@ export function buildRootObject(vatPowers, vatParameters) {
         });
 
         // Create a name hub for this address.
-        const { nameHub: myAddressNameHub, nameAdmin: rawMyAddressNameAdmin } =
-          makeNameHubKit();
+        const {
+          nameHub: myAddressNameHub,
+          nameAdmin: rawMyAddressNameAdmin,
+        } = makeNameHubKit();
         // Register it with the namesByAddress hub.
         namesByAddressAdmin.update(address, myAddressNameHub);
 
@@ -826,37 +851,26 @@ export function buildRootObject(vatPowers, vatParameters) {
     if (pegasus) {
       // Add the Pegasus transfer port.
       const port = await E(network).bind('/ibc-port/pegasus');
+
+      const { handler, subscription } = await E(
+        pegasus,
+      ).makePegasusConnectionKit();
+      observeIteration(subscription, {
+        updateState(connectionState) {
+          const { localAddr, actions } = connectionState;
+          if (actions) {
+            // We're open and ready for business.
+            pegasusConnectionsAdmin.update(localAddr, connectionState);
+          } else {
+            // We're closed.
+            pegasusConnectionsAdmin.delete(localAddr);
+          }
+        },
+      });
       E(port).addListener(
         Far('listener', {
           async onAccept(_port, _localAddr, _remoteAddr, _listenHandler) {
-            const chandlerP = E(pegasus).makePegConnectionHandler();
-            const proxyMethod =
-              name =>
-              (...args) =>
-                E(chandlerP)[name](...args);
-            const onOpen = proxyMethod('onOpen');
-            const onClose = proxyMethod('onClose');
-
-            let localAddr;
-            return Far('pegasusConnectionHandler', {
-              onOpen(c, actualLocalAddr, ...args) {
-                localAddr = actualLocalAddr;
-                if (pegasusConnectionsAdmin) {
-                  pegasusConnectionsAdmin.update(localAddr, c);
-                }
-                return onOpen(c, ...args);
-              },
-              onReceive: proxyMethod('onReceive'),
-              onClose(c, ...args) {
-                try {
-                  return onClose(c, ...args);
-                } finally {
-                  if (pegasusConnectionsAdmin) {
-                    pegasusConnectionsAdmin.delete(localAddr, c);
-                  }
-                }
-              },
-            });
+            return handler;
           },
           async onListen(p, _listenHandler) {
             console.debug(`Listening on Pegasus transfer port: ${p}`);

--- a/packages/vats/src/bootstrap.js
+++ b/packages/vats/src/bootstrap.js
@@ -95,26 +95,19 @@ export function buildRootObject(vatPowers, vatParameters) {
       E(vats.board).getBoard(),
       chainTimerServiceP,
       /** @type {Promise<{ zoeService: ZoeService, feeMintAccess:
-       * FeeMintAccess }>} */ (E(vats.zoe).buildZoe(
-        vatAdminSvc,
-        feeIssuerConfig,
-      )),
+       * FeeMintAccess }>} */ (
+        E(vats.zoe).buildZoe(vatAdminSvc, feeIssuerConfig)
+      ),
       E(vats.priceAuthority).makePriceAuthority(),
       E(vats.walletManager).buildWalletManager(vatAdminSvc),
     ]);
 
-    const {
-      nameHub: agoricNames,
-      nameAdmin: agoricNamesAdmin,
-    } = makeNameHubKit();
-    const {
-      nameHub: namesByAddress,
-      nameAdmin: namesByAddressAdmin,
-    } = makeNameHubKit();
-    const {
-      nameHub: pegasusConnections,
-      nameAdmin: pegasusConnectionsAdmin,
-    } = makeNameHubKit();
+    const { nameHub: agoricNames, nameAdmin: agoricNamesAdmin } =
+      makeNameHubKit();
+    const { nameHub: namesByAddress, nameAdmin: namesByAddressAdmin } =
+      makeNameHubKit();
+    const { nameHub: pegasusConnections, nameAdmin: pegasusConnectionsAdmin } =
+      makeNameHubKit();
 
     async function installEconomy(bootstrapPaymentValue) {
       // Create a mapping from all the nameHubs we create to their corresponding
@@ -230,23 +223,16 @@ export function buildRootObject(vatPowers, vatParameters) {
     const bootstrapPaymentValue = bankBootstrapSupply + ammDepositValue;
     // NOTE: no use of the voteCreator. We'll need it to initiate votes on
     // changing VaultFactory parameters.
-    const {
-      vaultFactoryCreator,
-      _voteCreator,
-      ammFacets,
-    } = await installEconomy(bootstrapPaymentValue);
+    const { vaultFactoryCreator, _voteCreator, ammFacets } =
+      await installEconomy(bootstrapPaymentValue);
 
-    const [
-      centralIssuer,
-      centralBrand,
-      ammInstance,
-      pegasusInstance,
-    ] = await Promise.all([
-      E(agoricNames).lookup('issuer', CENTRAL_ISSUER_NAME),
-      E(agoricNames).lookup('brand', CENTRAL_ISSUER_NAME),
-      E(agoricNames).lookup('instance', 'amm'),
-      E(agoricNames).lookup('instance', 'Pegasus'),
-    ]);
+    const [centralIssuer, centralBrand, ammInstance, pegasusInstance] =
+      await Promise.all([
+        E(agoricNames).lookup('issuer', CENTRAL_ISSUER_NAME),
+        E(agoricNames).lookup('brand', CENTRAL_ISSUER_NAME),
+        E(agoricNames).lookup('instance', 'amm'),
+        E(agoricNames).lookup('instance', 'Pegasus'),
+      ]);
 
     // Start the reward distributor.
     const epochTimerService = chainTimerService;
@@ -679,14 +665,8 @@ export function buildRootObject(vatPowers, vatParameters) {
         const faucetPaymentInfo = [];
         await Promise.all(
           userPaymentRecords.map(async precord => {
-            const {
-              payToBank,
-              issuer,
-              issuerName,
-              payment,
-              brand,
-              purseName,
-            } = precord;
+            const { payToBank, issuer, issuerName, payment, brand, purseName } =
+              precord;
             if (!payToBank) {
               // Just a faucet payment to be claimed by a wallet.
               faucetPaymentInfo.push({
@@ -719,10 +699,8 @@ export function buildRootObject(vatPowers, vatParameters) {
         });
 
         // Create a name hub for this address.
-        const {
-          nameHub: myAddressNameHub,
-          nameAdmin: rawMyAddressNameAdmin,
-        } = makeNameHubKit();
+        const { nameHub: myAddressNameHub, nameAdmin: rawMyAddressNameAdmin } =
+          makeNameHubKit();
         // Register it with the namesByAddress hub.
         namesByAddressAdmin.update(address, myAddressNameHub);
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description

Rather than exposing publicFacet information about the current pegs, use local `actions` objects to get things done.  These are exposed to the connection owner, and return information about the connection via Subscriptions.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

Should improve auditability via POLA.

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

The bootstrap Pegasus now puts its powerful authorities in `agoricNames.lookup('pegasusConnections')`, which is only given out to powerful provisioned solos.

Nobody was relying on this information before, so there should be no loss of functionality.

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

More tests are done in `packages/pegasus`.
