### PR TITLE
chore: allow multiple zcfMints for RUN to be registered

### DIFF
--- a/packages/zoe/src/zoeService/escrowStorage.js
+++ b/packages/zoe/src/zoeService/escrowStorage.js
@@ -30,9 +30,13 @@ export const makeEscrowStorage = () => {
    * @type {MakeLocalPurse}
    */
   const makeLocalPurse = (issuer, brand) => {
-    const localPurse = issuer.makeEmptyPurse();
-    brandToPurse.init(brand, localPurse);
-    return localPurse;
+    if (brandToPurse.has(brand)) {
+      return /** @type {Purse} */ (brandToPurse.get(brand));
+    } else {
+      const localPurse = issuer.makeEmptyPurse();
+      brandToPurse.init(brand, localPurse);
+      return localPurse;
+    }
   };
 
   /** @type {WithdrawPayments} */

--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -12,6 +12,10 @@
 /**
  * Create a purse for a new, local issuer. Used only for ZCFMint issuers.
  *
+ * Note: in the case of the feeMint, it may have been registered
+ * before with `feeMintAccess`. In that case, we do not create a new
+ * purse, but reuse the existing purse.
+ *
  * @callback MakeLocalPurse
  * @param {Issuer} issuer
  * @param {Brand} brand

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -403,6 +403,27 @@ test(`zoe.makeFeePurse`, async t => {
   t.true(AmountMath.isEmpty(await E(feePurse).getCurrentAmount()));
 });
 
+test(`zcf.registerFeeMint twice`, async t => {
+  const { zoe, zcf: zcf1, zcf2, feeMintAccess } = await setupZCFTest();
+  const feeIssuer = E(zoe).getFeeIssuer();
+  const feeBrand = await E(feeIssuer).getBrand();
+
+  const fee1000 = AmountMath.make(feeBrand, 1000n);
+
+  const zcfMint1 = await zcf1.registerFeeMint('RUN', feeMintAccess);
+  const zcfMint2 = await zcf2.registerFeeMint('RUN', feeMintAccess);
+
+  const zcfSeat1 = zcfMint1.mintGains({ Fee: fee1000 });
+  const zcfSeat2 = zcfMint2.mintGains({ Fee: fee1000 });
+
+  t.deepEqual(zcfSeat1.getCurrentAllocation(), {
+    Fee: fee1000,
+  });
+  t.deepEqual(zcfSeat2.getCurrentAllocation(), {
+    Fee: fee1000,
+  });
+});
+
 test(`zoe.getConfiguration`, async t => {
   const { zoe } = await setupZCFTest();
   const config = await E(zoe).getConfiguration();

--- a/packages/zoe/test/unitTests/zcf/setupZcfTest.js
+++ b/packages/zoe/test/unitTests/zcf/setupZcfTest.js
@@ -18,8 +18,14 @@ const contractRoot = `${dirname}/zcfTesterContract.js`;
 export const setupZCFTest = async (issuerKeywordRecord, terms) => {
   /** @type {ContractFacet} */
   let zcf;
+  /** @type {ContractFacet} */
+  let zcf2;
   const setZCF = jig => {
-    zcf = jig.zcf;
+    if (zcf === undefined) {
+      zcf = jig.zcf;
+    } else {
+      zcf2 = jig.zcf;
+    }
   };
   // The contract provides the `zcf` via `setTestJig` upon `start`.
   const fakeVatAdmin = makeFakeVatAdmin(setZCF);
@@ -33,6 +39,10 @@ export const setupZCFTest = async (issuerKeywordRecord, terms) => {
     issuerKeywordRecord,
     terms,
   );
+  // In case a second zcf is needed
+  const { creatorFacet: creatorFacet2, instance: instance2 } = await E(
+    zoe,
+  ).startInstance(installation, issuerKeywordRecord, terms);
   const { vatAdminState } = fakeVatAdmin;
   // @ts-ignore fix types to understand that zcf is always defined
   assert(zcf !== undefined);
@@ -44,5 +54,10 @@ export const setupZCFTest = async (issuerKeywordRecord, terms) => {
     creatorFacet,
     vatAdminState,
     feeMintAccess,
+
+    // Additional ZCF
+    zcf2,
+    creatorFacet2,
+    instance2,
   };
 };

--- a/packages/zoe/test/unitTests/zcf/setupZcfTest.js
+++ b/packages/zoe/test/unitTests/zcf/setupZcfTest.js
@@ -20,6 +20,11 @@ export const setupZCFTest = async (issuerKeywordRecord, terms) => {
   let zcf;
   /** @type {ContractFacet} */
   let zcf2;
+
+  // We would like to start two contract instances in order to get two
+  // different `zcfs`. However, we only pass in one `setTestJig`, so
+  // here, we set the first `zcf` if it has not been set before, and
+  // if it has, we set the second `zcf`.
   const setZCF = jig => {
     if (zcf === undefined) {
       zcf = jig.zcf;


### PR DESCRIPTION
closes: #4011 

## Description

Generally, we don't allow multiple zcfMints in different contracts to have the same brand. So, the Zoe code was written with the expectation that the creation of a zcfMint was always registering a new <brand, purse>. However, in the case of the RUN mint, we require that any contract with access to `feeMintAccess` can register a zcfMint for RUN. 

Because of time constraints, this part wasn't fully tested.

So, this PR changes the underlying infrastructure to allow for multiple registrations of the same RUN brand, and adds a test to confirm the functionality.

### Security Considerations

A zcfMint for the same brand could be registered if the internal function is reached. We don't check specifically for the RUN brand. This isn't necessarily bad, and might be desirable in the future. Currently, the ZCF API does not allow a zcfMint for the same brand to be registered, but we could choose to allow that in the future, which would use this code path.

### Documentation Considerations

Fee/Metering documentation is up. Since we might go in a different direction, I don't think we should spend much time on additional documentation. 

### Testing Considerations

Fully tested.