### PR TITLE
Extract AMM from Vaults (ex-Treasury)

### DIFF
--- a/packages/treasury/bundles/install-on-chain.js
+++ b/packages/treasury/bundles/install-on-chain.js
@@ -172,9 +172,6 @@ export async function installOnChain({
     protocolFee,
   )
 
-  // todo(hibbert): set up an initial AMM pool with RUN and BLD
-  // const liqSeat = createLiquidityPool(...);
-
   const loanParams = {
     chargingPeriod: SECONDS_PER_HOUR,
     recordingPeriod: SECONDS_PER_DAY,

--- a/packages/treasury/scripts/build-bundles.js
+++ b/packages/treasury/scripts/build-bundles.js
@@ -39,8 +39,8 @@ async function main() {
       `${bundlesDir}/bundle-liquidateMinimum.js`,
     ],
     [
-      `@agoric/zoe/src/contracts/multipoolAutoswap/multipoolAutoswap.js`,
-      `${dirname}/../bundles/bundle-multipoolAutoswap.js`,
+      `@agoric/zoe/src/contracts/vpool-xyk-amm/multipoolMarketMaker.js`,
+      `${dirname}/../bundles/bundle-amm.js`,
     ],
     [
       '@agoric/governance/src/contractGovernor.js',

--- a/packages/treasury/src/collectRewardFees.js
+++ b/packages/treasury/src/collectRewardFees.js
@@ -3,7 +3,9 @@
 export const makeMakeCollectFeesInvitation = (zcf, feeSeat, runBrand) => {
   const collectFees = async seat => {
     seat.incrementBy(
-      feeSeat.decrementBy({ RUN: feeSeat.getAmountAllocated('RUN', runBrand) }),
+      feeSeat.decrementBy(
+        harden({ RUN: feeSeat.getAmountAllocated('RUN', runBrand) }),
+      ),
     );
     const totalTransferred = seat.getStagedAllocation().RUN;
 

--- a/packages/treasury/src/collectRewardFees.js
+++ b/packages/treasury/src/collectRewardFees.js
@@ -1,39 +1,14 @@
 // @ts-check
 
-import { offerTo } from '@agoric/zoe/src/contractSupport/index.js';
-import { E } from '@agoric/eventual-send';
-
-export const makeMakeCollectFeesInvitation = (
-  zcf,
-  feeSeat,
-  autoswapCreatorFacet,
-  runBrand,
-) => {
+export const makeMakeCollectFeesInvitation = (zcf, feeSeat, runBrand) => {
   const collectFees = async seat => {
-    const invitation = await E(
-      autoswapCreatorFacet,
-    ).makeCollectFeesInvitation();
-    const { zcfSeat: transferSeat } = zcf.makeEmptySeatKit();
-    await E.get(offerTo(zcf, invitation, harden({}), harden({}), transferSeat))
-      .deposited;
-
     seat.incrementBy(
-      feeSeat.decrementBy(
-        harden({ RUN: feeSeat.getAmountAllocated('RUN', runBrand) }),
-      ),
-    );
-    seat.incrementBy(
-      transferSeat.decrementBy(
-        harden({
-          RUN: transferSeat.getAmountAllocated('RUN', runBrand),
-        }),
-      ),
+      feeSeat.decrementBy({ RUN: feeSeat.getAmountAllocated('RUN', runBrand) }),
     );
     const totalTransferred = seat.getStagedAllocation().RUN;
 
-    zcf.reallocate(transferSeat, feeSeat, seat);
+    zcf.reallocate(feeSeat, seat);
     seat.exit();
-    transferSeat.exit();
 
     return `paid out ${totalTransferred.value}`;
   };

--- a/packages/treasury/src/interest.js
+++ b/packages/treasury/src/interest.js
@@ -4,7 +4,7 @@ import '@agoric/zoe/exported.js';
 import '@agoric/zoe/src/contracts/callSpread/types.js';
 import './types.js';
 import {
-  multiplyBy,
+  ceilMultiplyBy,
   makeRatio,
 } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { AmountMath } from '@agoric/ertp';
@@ -48,7 +48,7 @@ export function makeInterestCalculator(
     let growingDebt = newDebt;
     while (newRecent + chargingPeriod <= currentTime) {
       newRecent += chargingPeriod;
-      const newInterest = multiplyBy(growingDebt, ratePerChargingPeriod);
+      const newInterest = ceilMultiplyBy(growingDebt, ratePerChargingPeriod);
       growingInterest = AmountMath.add(growingInterest, newInterest);
       growingDebt = AmountMath.add(growingDebt, newInterest, brand);
     }

--- a/packages/treasury/src/liquidateMinimum.js
+++ b/packages/treasury/src/liquidateMinimum.js
@@ -12,10 +12,10 @@ const trace = makeTracer('LM');
 
 /**
  * This contract liquidates the minimum amount of vault's collateral necessary
- * to satisfy the debt. It uses AutoSwap's swapOut, which sells no more than
+ * to satisfy the debt. It uses the AMM's swapOut, which sells no more than
  * necessary. Because it has offer safety, it can refuse the trade. When that
  * happens, we fall back to selling using the default strategy, which currently
- * uses AutoSwap's swapIn instead.
+ * uses the AMM's swapIn instead.
  */
 
 /** @type {ContractStartFn} */

--- a/packages/treasury/src/liquidation.js
+++ b/packages/treasury/src/liquidation.js
@@ -7,19 +7,17 @@ import { makeTracer } from './makeTracer.js';
 
 const trace = makeTracer('LIQ');
 
-// Liquidates a Vault, using the strategy to parameterize the particular
-// contract being used. The strategy provides a KeywordMapping and proposal
-// suitable for `offerTo()`, and an invitation.
-//
-// Once collateral has been sold using the contract, we burn the amount
-// necessary to cover the debt and return the remainder.
-export async function liquidate(
-  zcf,
-  vaultKit,
-  burnLosses,
-  strategy,
-  collateralBrand,
-) {
+/**
+ * Liquidates a Vault, using the strategy to parameterize the particular
+ * contract being used. The strategy provides a KeywordMapping and proposal
+ * suitable for `offerTo()`, and an invitation.
+ *
+ * Once collateral has been sold using the contract, we burn the amount
+ * necessary to cover the debt and return the remainder.
+ *
+ * @type {TreasuryLiquidate}
+ */
+async function liquidate(zcf, vaultKit, burnLosses, strategy, collateralBrand) {
   vaultKit.liquidating();
   const runDebt = vaultKit.vault.getDebtAmount();
   const { brand: runBrand } = runDebt;
@@ -37,7 +35,7 @@ export async function liquidate(
     vaultSeat,
     liquidationSeat,
   );
-  trace(` offeredTo`, runDebt);
+  trace(` offeredTo`, collateralToSell, runDebt);
 
   // await deposited, but we don't need the value.
   await Promise.all([deposited, E(liqSeat).getOfferResult()]);
@@ -61,9 +59,13 @@ export async function liquidate(
   vaultKit.liquidationPromiseKit.resolve('Liquidated');
 }
 
-// The default strategy converts of all the collateral to RUN using autoswap,
-// and refunds any excess RUN.
-export function makeDefaultLiquidationStrategy(autoswap) {
+/**
+ * The default strategy converts of all the collateral to RUN using autoswap,
+ * and refunds any excess RUN.
+ *
+ * @type {(XYKAMMPublicFacet) => LiquidationStrategy}
+ */
+function makeDefaultLiquidationStrategy(amm) {
   function keywordMapping() {
     return harden({
       Collateral: 'In',
@@ -81,8 +83,13 @@ export function makeDefaultLiquidationStrategy(autoswap) {
   trace(`return from makeDefault`);
 
   return {
-    makeInvitation: () => E(autoswap).makeSwapInInvitation(),
+    makeInvitation: () => E(amm).makeSwapInInvitation(),
     keywordMapping,
     makeProposal,
   };
 }
+
+harden(makeDefaultLiquidationStrategy);
+harden(liquidate);
+
+export { makeDefaultLiquidationStrategy, liquidate };

--- a/packages/treasury/src/params.js
+++ b/packages/treasury/src/params.js
@@ -4,9 +4,6 @@ import './types.js';
 
 import { buildParamManager, ParamType } from '@agoric/governance';
 
-export const POOL_FEE_KEY = 'PoolFee';
-export const PROTOCOL_FEE_KEY = 'ProtocolFee';
-
 export const CHARGING_PERIOD_KEY = 'ChargingPeriod';
 export const RECORDING_PERIOD_KEY = 'RecordingPeriod';
 
@@ -16,8 +13,7 @@ export const INTEREST_RATE_KEY = 'InterestRate';
 export const LOAN_FEE_KEY = 'LoanFee';
 
 export const governedParameterTerms = {
-  loanParams: [POOL_FEE_KEY, PROTOCOL_FEE_KEY],
-  poolParams: [
+  vaultParams: [
     CHARGING_PERIOD_KEY,
     RECORDING_PERIOD_KEY,
     INITIAL_MARGIN_KEY,
@@ -27,31 +23,8 @@ export const governedParameterTerms = {
   ],
 };
 
-/** @type {{ FEE: 'fee', POOL: 'pool' }} */
-export const ParamKey = {
-  FEE: 'fee',
-  POOL: 'pool',
-};
-
-/** @type {MakeFeeParamManager} */
-export const makeFeeParamManager = ammFees => {
-  // @ts-ignore buildParamManager doesn't describe all the update methods
-  return buildParamManager([
-    {
-      name: POOL_FEE_KEY,
-      value: ammFees.poolFee,
-      type: ParamType.NAT,
-    },
-    {
-      name: PROTOCOL_FEE_KEY,
-      value: ammFees.protocolFee,
-      type: ParamType.NAT,
-    },
-  ]);
-};
-
-/** @type {MakePoolParamManager} */
-export const makePoolParamManager = (loanParams, rates) => {
+/** @type {MakeVaultParamManager} */
+export const makeVaultParamManager = (loanParams, rates) => {
   // @ts-ignore buildParamManager doesn't describe all the update methods
   return buildParamManager([
     {

--- a/packages/treasury/src/stablecoinMachine.js
+++ b/packages/treasury/src/stablecoinMachine.js
@@ -121,7 +121,7 @@ export async function start(zcf, privateArgs) {
 
     const { creatorFacet: liquidationFacet } = await E(zoe).startInstance(
       liquidationInstall,
-      harden({ RUN: runIssuer }),
+      harden({ RUN: runIssuer, Collateral: collateralIssuer }),
       harden({ amm: ammPublicFacet }),
     );
     const liquidationStrategy = makeLiquidationStrategy(liquidationFacet);

--- a/packages/treasury/src/stablecoinMachine.js
+++ b/packages/treasury/src/stablecoinMachine.js
@@ -4,18 +4,14 @@ import '@agoric/zoe/exported.js';
 import '@agoric/zoe/src/contracts/exported.js';
 
 // The StableCoinMachine owns a number of VaultManagers, and a mint for the
-// "RUN" stablecoin. This overarching SCM will hold ownershipTokens in the
-// individual per-type vaultManagers.
+// "RUN" stablecoin.
 //
-// makeAddTypeInvitation is a closely held method that adds a brand new
-// collateral type. It specifies the initial exchange rate for that type.
-//
-// a second closely held method (not implemented yet) would add collateral of a
-// type for which there is an existing pool. It gets the current price from the
-// pool.
-//
-// ownershipTokens for vaultManagers entitle holders to distributions, but you
-// can't redeem them outright, that would drain the utility from the economy.
+// addVaultType is a closely held method that adds a brand new collateral type.
+// It specifies the initial exchange rate for that type. It depends on a
+// separately specified AMM to provide the ability to liquidate loans that are
+// in arrears. We could check that the AMM has sufficient liquidity, but for the
+// moment leave that to those participating in the governance process for adding
+// new collateral type to ascertain.
 
 import { E } from '@agoric/eventual-send';
 import '@agoric/governance/src/exported';
@@ -23,55 +19,30 @@ import '@agoric/governance/src/exported';
 import { makeScalarMap } from '@agoric/store';
 import {
   assertProposalShape,
-  offerTo,
   getAmountOut,
   getAmountIn,
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { HIGH_FEE, LONG_EXP } from '@agoric/zoe/src/constants.js';
-import {
-  ceilMultiplyBy,
-  makeRatioFromAmounts,
-} from '@agoric/zoe/src/contractSupport/ratio.js';
+import { makeRatioFromAmounts } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { AmountMath } from '@agoric/ertp';
 import { sameStructure } from '@agoric/same-structure';
 import { Far } from '@agoric/marshal';
 
-import { makeTracer } from './makeTracer.js';
 import { makeVaultManager } from './vaultManager.js';
 import { makeLiquidationStrategy } from './liquidateMinimum.js';
 import { makeMakeCollectFeesInvitation } from './collectRewardFees.js';
 import {
-  makePoolParamManager,
-  makeFeeParamManager,
-  PROTOCOL_FEE_KEY,
-  POOL_FEE_KEY,
+  makeVaultParamManager,
   governedParameterTerms as governedParameterLocal,
-  ParamKey,
 } from './params.js';
 
 const { quote: q, details: X } = assert;
-
-const trace = makeTracer('ST');
-
-// The StableCoinMachine owns a number of VaultManagers, and a mint for the
-// "RUN" stablecoin. This overarching SCM will hold ownershipTokens in the
-// individual per-type vaultManagers.
-//
-// makeAddTypeInvitation is a closely held method that adds a brand new
-// collateral type. It specifies the initial exchange rate for that type.
-//
-// a second closely held method (not implemented yet) would add collateral of a
-// type for which there is an existing pool. It gets the current price from the
-// pool.
-//
-// ownershipTokens for vaultManagers entitle holders to distributions, but you
-// can't redeem them outright; that would drain the utility from the economy.
 
 /** @type {ContractStartFn} */
 export async function start(zcf, privateArgs) {
   // loanParams has time limits for charging interest
   const {
-    autoswapInstall,
+    ammPublicFacet,
     priceAuthority,
     loanParams,
     timerService,
@@ -83,6 +54,11 @@ export async function start(zcf, privateArgs) {
   const governorPublic = E(zcf.getZoeService()).getPublicFacet(electionManager);
 
   const { feeMintAccess } = privateArgs;
+  const runMint = await zcf.registerFeeMint('RUN', feeMintAccess);
+  const { issuer: runIssuer, brand: runBrand } = runMint.getIssuerRecord();
+  zcf.setTestJig(() => ({
+    runIssuerRecord: runMint.getIssuerRecord(),
+  }));
 
   assert.typeof(
     loanParams.chargingPeriod,
@@ -97,24 +73,13 @@ export async function start(zcf, privateArgs) {
 
   assert(
     sameStructure(governedParams, harden(governedParameterLocal)),
-    X`Terms must match ${governedParameterLocal}`,
+    X`Terms ${governedParams} must match ${governedParameterLocal}`,
   );
-  const feeParams = makeFeeParamManager(loanParams);
 
-  const [runMint, govMint] = await Promise.all([
-    zcf.registerFeeMint('RUN', feeMintAccess),
-    zcf.makeZCFMint('Governance', undefined, harden({ decimalPlaces: 6 })),
-  ]);
-  const { issuer: runIssuer, brand: runBrand } = runMint.getIssuerRecord();
-
-  const { brand: govBrand } = govMint.getIssuerRecord();
-
-  // This is a stand-in for a reward pool. For now, it's a place to squirrel
-  // away fees so the tests show that the funds have been removed.
   const { zcfSeat: rewardPoolSeat } = zcf.makeEmptySeatKit();
 
   /**
-   * We provide an easy way for the vaultManager and vaults to add rewards to
+   * We provide an easy way for the vaultManager to add rewards to
    * the rewardPoolSeat, without directly exposing the rewardPoolSeat to them.
    *
    * @type {ReallocateReward}
@@ -135,161 +100,49 @@ export async function start(zcf, privateArgs) {
   }
 
   /** @type {Store<Brand,VaultManager>} */
-  const collateralTypes = makeScalarMap('brand'); // Brand -> vaultManager
+  const collateralTypes = makeScalarMap('brand');
 
   const zoe = zcf.getZoeService();
 
-  // we assume the multipool-autoswap is public, so folks can buy/sell
-  // through it without our involvement
-  // Should it use creatorFacet, creatorInvitation, instance?
-  /** @type {{ publicFacet: MultipoolAutoswapPublicFacet, instance: Instance,
-   *  creatorFacet: MultipoolAutoswapCreatorFacet }} */
-  const {
-    publicFacet: autoswapAPI,
-    instance: autoswapInstance,
-    creatorFacet: autoswapCreatorFacet,
-  } = await E(zoe).startInstance(
-    autoswapInstall,
-    { Central: runIssuer },
-    {
-      timer: timerService,
-      // TODO(#3862): make the AMM use a paramManager. For now, the values
-      //  are fixed after creation of an autoswap instance.
-      poolFee: feeParams.getParam(POOL_FEE_KEY).value,
-      protocolFee: feeParams.getParam(PROTOCOL_FEE_KEY).value,
-    },
-  );
+  /** @type { Store<Brand, VaultParamManager> } */
+  const vaultParamManagers = makeScalarMap('brand');
 
-  /** @type { Store<Brand, PoolParamManager> } */
-  const poolParamManagers = makeScalarMap('brand');
-
-  // We process only one offer per collateralType. They must tell us the
-  // dollar value of their collateral, and we create that many RUN.
-  // collateralKeyword = 'aEth'
-  async function makeAddTypeInvitation(
-    collateralIssuer,
-    collateralKeyword,
-    rates,
-  ) {
+  async function addVaultType(collateralIssuer, collateralKeyword, rates) {
     await zcf.saveIssuer(collateralIssuer, collateralKeyword);
     const collateralBrand = zcf.getBrandForIssuer(collateralIssuer);
-    assert(!collateralTypes.has(collateralBrand));
+    // We create only one vault per collateralType.
+    assert(
+      !collateralTypes.has(collateralBrand),
+      `Collateral brand ${collateralBrand} has already been added`,
+    );
 
-    const poolParamManager = makePoolParamManager(loanParams, rates);
-    poolParamManagers.init(collateralBrand, poolParamManager);
+    const vaultParamManager = makeVaultParamManager(loanParams, rates);
+    vaultParamManagers.init(collateralBrand, vaultParamManager);
 
     const { creatorFacet: liquidationFacet } = await E(zoe).startInstance(
       liquidationInstall,
-      harden({ RUN: runIssuer, [collateralKeyword]: collateralIssuer }),
-      harden({ autoswap: autoswapAPI }),
+      harden({ RUN: runIssuer }),
+      harden({ amm: ammPublicFacet }),
     );
+    const liquidationStrategy = makeLiquidationStrategy(liquidationFacet);
 
-    async function addTypeHook(seat) {
-      assertProposalShape(seat, {
-        give: { Collateral: null },
-        want: { Governance: null },
-      });
-      const {
-        give: { Collateral: collateralIn },
-        want: { Governance: _govOut }, // ownership of the whole stablecoin machine
-      } = seat.getProposal();
-      assert(!collateralTypes.has(collateralBrand));
-      // initialPrice is in rates, but only used at creation, so not in governor
-      const runAmount = ceilMultiplyBy(collateralIn, rates.initialPrice);
-      // arbitrarily, give governance tokens equal to RUN tokens
-      const govAmount = AmountMath.make(govBrand, runAmount.value);
-
-      // Create new governance tokens, trade them with the incoming offer for
-      // collateral. The offer uses the keywords Collateral and Governance.
-      // govSeat stores the collateral as Secondary. We then mint new RUN for
-      // govSeat and store them as Central. govSeat then creates a liquidity
-      // pool for autoswap, trading in Central and Secondary for governance
-      // tokens as Liquidity. These governance tokens are held by govSeat
-      const { zcfSeat: govSeat } = zcf.makeEmptySeatKit();
-      // TODO this should create the seat for us
-      govMint.mintGains(harden({ Governance: govAmount }), govSeat);
-
-      // trade the governance tokens for collateral, putting the
-      // collateral on Secondary to be positioned for Autoswap
-      seat.incrementBy(govSeat.decrementBy(harden({ Governance: govAmount })));
-      seat.decrementBy(harden({ Collateral: collateralIn }));
-      govSeat.incrementBy(harden({ Secondary: collateralIn }));
-
-      zcf.reallocate(govSeat, seat);
-      // the collateral is now on the temporary seat
-
-      // once we've done that, we can put both the collateral and the minted
-      // RUN into the autoswap, giving us liquidity tokens, which we store
-
-      // mint the new RUN to the Central position on the govSeat
-      // so we can setup the autoswap pool
-      runMint.mintGains(harden({ Central: runAmount }), govSeat);
-
-      // TODO: check for existing pool, use its price instead of the
-      // user-provided 'rate'. Or throw an error if it already exists.
-      // `addPool` should combine initial liquidity with pool setup
-
-      const liquidityIssuer = await E(autoswapAPI).addPool(
-        collateralIssuer,
-        collateralKeyword,
-      );
-      const { brand: liquidityBrand } = await zcf.saveIssuer(
-        liquidityIssuer,
-        `${collateralKeyword}Liquidity`,
-      );
-
-      // inject both the collateral and the RUN into the new autoswap, to
-      // provide the initial liquidity pool
-      const liqProposal = harden({
-        give: {
-          Secondary: collateralIn,
-          Central: runAmount,
-        },
-        want: { Liquidity: AmountMath.makeEmpty(liquidityBrand) },
-      });
-      const liqInvitation = E(autoswapAPI).makeAddLiquidityInvitation();
-
-      const { deposited } = await offerTo(
-        zcf,
-        liqInvitation,
-        undefined,
-        liqProposal,
-        govSeat,
-      );
-
-      const depositValue = await deposited;
-
-      // TODO(hibbert): make use of these assets (Liquidity: 19899 Aeth)
-      trace('depositValue', depositValue);
-
-      const liquidationStrategy = makeLiquidationStrategy(liquidationFacet);
-
-      // do something with the liquidity we just bought
-      const vm = makeVaultManager(
-        zcf,
-        autoswapAPI,
-        runMint,
-        collateralBrand,
-        priceAuthority,
-        poolParamManager.getParams,
-        reallocateReward,
-        timerService,
-        liquidationStrategy,
-      );
-      collateralTypes.init(collateralBrand, vm);
-      return vm;
-    }
-
-    return zcf.makeInvitation(addTypeHook, 'AddCollateralType');
+    const vm = makeVaultManager(
+      zcf,
+      runMint,
+      collateralBrand,
+      priceAuthority,
+      vaultParamManager.getParams,
+      reallocateReward,
+      timerService,
+      liquidationStrategy,
+    );
+    collateralTypes.init(collateralBrand, vm);
+    return vm;
   }
 
-  /**
-   * Make a loan in the vaultManager based on the collateral type.
-   */
+  /** Make a loan in the vaultManager based on the collateral type. */
   function makeLoanInvitation() {
-    /**
-     * @param {ZCFSeat} seat
-     */
+    /** @param {ZCFSeat} seat */
     async function makeLoanHook(seat) {
       assertProposalShape(seat, {
         give: { Collateral: null },
@@ -316,12 +169,6 @@ export async function start(zcf, privateArgs) {
       LONG_EXP,
     );
   }
-
-  zcf.setTestJig(() => ({
-    runIssuerRecord: runMint.getIssuerRecord(),
-    govIssuerRecord: govMint.getIssuerRecord(),
-    autoswap: autoswapAPI,
-  }));
 
   async function getCollaterals() {
     // should be collateralTypes.map((vm, brand) => ({
@@ -351,6 +198,7 @@ export async function start(zcf, privateArgs) {
     return rewardPoolSeat.getCurrentAllocation();
   }
 
+  // TODO(#4021) remove this method
   function mintBootstrapPayment() {
     const {
       zcfSeat: bootstrapZCFSeat,
@@ -383,33 +231,16 @@ export async function start(zcf, privateArgs) {
   }
 
   const getParams = paramDesc => {
-    switch (paramDesc.key) {
-      case ParamKey.FEE:
-        return feeParams.getParams();
-      case ParamKey.POOL:
-        return poolParamManagers.get(paramDesc.collateralBrand).getParams();
-      default:
-        throw Error(`Unrecognized param key for Params '${paramDesc.key}'`);
-    }
+    return vaultParamManagers.get(paramDesc.collateralBrand).getParams();
   };
 
   const getParamState = paramDesc => {
-    switch (paramDesc.keyl) {
-      case ParamKey.FEE:
-        return feeParams.getParam(paramDesc.parameterName);
-      case ParamKey.POOL:
-        return poolParamManagers
-          .get(paramDesc.collateralBrand)
-          .getParam(paramDesc.parameterName);
-      default:
-        throw Error(`Unrecognized param key for State '${paramDesc.key}'`);
-    }
+    return vaultParamManagers
+      .get(paramDesc.collateralBrand)
+      .getParam(paramDesc.parameterName);
   };
 
   const publicFacet = Far('stablecoin public facet', {
-    getAMM() {
-      return autoswapInstance;
-    },
     makeLoanInvitation,
     getCollaterals,
     // TODO this is in the terms, so could be retrieved from there.
@@ -425,32 +256,19 @@ export async function start(zcf, privateArgs) {
   const { makeCollectFeesInvitation } = makeMakeCollectFeesInvitation(
     zcf,
     rewardPoolSeat,
-    autoswapCreatorFacet,
     runBrand,
   );
 
   const getParamMgrRetriever = () =>
     Far('paramManagerAccessor', {
       get: paramDesc => {
-        switch (paramDesc.key) {
-          case ParamKey.FEE:
-            return feeParams;
-          case ParamKey.POOL:
-            return poolParamManagers.get(paramDesc.collateralBrand);
-          default:
-            throw Error(
-              `Unrecognized param key for accessor '${paramDesc.key}'`,
-            );
-        }
+        return vaultParamManagers.get(paramDesc.collateralBrand);
       },
     });
 
   /** @type {StablecoinMachine} */
   const stablecoinMachine = Far('stablecoin machine', {
-    makeAddTypeInvitation,
-    getAMM() {
-      return autoswapInstance;
-    },
+    addVaultType,
     getCollaterals,
     getRewardAllocation,
     getBootstrapPayment: mintBootstrapPayment(),
@@ -466,6 +284,5 @@ export async function start(zcf, privateArgs) {
   return harden({
     creatorFacet: stablecoinMachineWrapper,
     publicFacet,
-    ParamKey,
   });
 }

--- a/packages/treasury/src/types.js
+++ b/packages/treasury/src/types.js
@@ -131,7 +131,7 @@
  * @property {PromiseRecord<string>} liquidationPromiseKit
  * @property {ZCFSeat} liquidationZcfSeat
  * @property {() => void} liquidating
- * @property {(Amount) => void} liquidated
+ * @property {(newDebt: Amount) => void} liquidated
  */
 
 /**

--- a/packages/treasury/src/types.js
+++ b/packages/treasury/src/types.js
@@ -17,20 +17,26 @@
 
 /**
  * @typedef {Object} Rates
- * @property {Ratio} initialMargin minimum required over-collateralization
+ * @property {Ratio} initialMargin - minimum over-collateralization
  * required to open a loan
- * @property {Ratio} liquidationMargin margin below which collateral will be
+ * @property {Ratio} liquidationMargin - margin below which collateral will be
  * liquidated to satisfy the debt.
- * @property {Ratio} initialPrice price ratio of collateral to RUN
  * @property {Ratio} interestRate - annual interest rate charged on loans
- * @property {Ratio} loanFee The fee (in BasisPoints) charged when opening
+ * @property {Ratio} loanFee - The fee (in BasisPoints) charged when opening
  * or increasing a loan.
  */
 
 /**
+ * @callback AddVaultType
+ * @param {Issuer} collateralIssuer
+ * @param {Keyword} collateralKeyword
+ * @param {Rates} rates
+ * @returns {Promise<VaultManager>}
+ */
+
+/**
  * @typedef  {Object} StablecoinMachine
- * @property {(collateralIssuer: Issuer, collateralKeyword: Keyword, rates: Rates) => Promise<Invitation>} makeAddTypeInvitation
- * @property {() => Instance} getAMM
+ * @property {AddVaultType} addVaultType
  * @property {() => Promise<Array<Collateral>>} getCollaterals
  * @property {() => Allocation} getRewardAllocation,
  * @property {() => ERef<Payment>} getBootstrapPayment
@@ -124,6 +130,8 @@
  * @property {ZCFSeat} vaultSeat
  * @property {PromiseRecord<string>} liquidationPromiseKit
  * @property {ZCFSeat} liquidationZcfSeat
+ * @property {() => void} liquidating
+ * @property {(Amount) => void} liquidated
  */
 
 /**
@@ -141,14 +149,24 @@
 /**
  * @typedef {Object} LiquidationStrategy
  * @property {() => KeywordKeywordRecord} keywordMapping
- * @property {(collateral: Amount, RUN: Amount) => Proposal} makeProposal
- * @property {() => Promise<Invitation>} makeInvitation
+ * @property {(collateral: Amount, run: Amount) => Proposal} makeProposal
+ * @property {(runDebt: Amount) => Promise<Invitation>} makeInvitation
+ */
+
+/**
+ * @typedef {Object} liquidationCreatorFacet
+ * @property {(runDebt: Amount) => Promise<Invitation>} makeDebtorInvitation
+ */
+
+/**
+ * @callback MakeLiquidationStrategy
+ * @param {liquidationCreatorFacet} creatorFacet
+ * @returns {LiquidationStrategy}
  */
 
 /**
  * @callback MakeVaultManager
  * @param {ContractFacet} zcf
- * @param {ERef<MultipoolAutoswapPublicFacet>} autoswap
  * @param {ZCFMint} runMint
  * @param {Brand} collateralBrand
  * @param {ERef<PriceAuthority>} priceAuthority
@@ -164,7 +182,6 @@
  * @param {ContractFacet} zcf
  * @param {InnerVaultManager} manager
  * @param {ZCFMint} runMint
- * @param {ERef<MultipoolAutoswapPublicFacet>} autoswap
  * @param {ERef<PriceAuthority>} priceAuthority
  * @param {GetParams} paramManager
  * @param {Timestamp} startTimeStamp
@@ -213,27 +230,37 @@
  */
 
 /**
- * @typedef {Object} PoolParamManager
+ * @typedef {Object} VaultParamManager
  * @property {GetParams} getParams
  * @property {GetParam} getParam
  * @property {(period: bigint) => void} updateChargingPeriod
  * @property {(period: bigint) => void} updateRecordingPeriod
  * @property {(margin: Ratio) => void} updateInitialMargin
  * @property {(margin: Ratio) => void} updateLiquidationMargin
- * @property {(price: Ratio) => void} updateInitialPrice
  * @property {(ratio: Ratio) => void} updateInterestRate
  * @property {(ratio: Ratio) => void} updateLoanFee
  */
 
 /**
- * @callback MakePoolParamManager
+ * @callback MakeVaultParamManager
  * @param {LoanParams} loanParams
  * @param {Rates} rates
- * @returns {PoolParamManager}
+ * @returns {VaultParamManager}
  */
 
 /**
  * @callback MakeFeeParamManager
  * @param {AMMFees} ammFees
  * @returns {FeeParamManager}
+ */
+
+/**
+ * @callback TreasuryLiquidate
+ * @param {ContractFacet} zcf,
+ * @param {VaultKit} vaultKit,
+ * @param {(losses: AmountKeywordRecord,
+ *             zcfSeat: ZCFSeat,
+ *            ) => void} burnLosses,
+ * @param {LiquidationStrategy} strategy,
+ * @param {Brand} collateralBrand,
  */

--- a/packages/treasury/src/vaultManager.js
+++ b/packages/treasury/src/vaultManager.js
@@ -8,8 +8,8 @@ import {
   makeRatioFromAmounts,
   getAmountOut,
   getAmountIn,
-  divideBy,
-  multiplyBy,
+  ceilMultiplyBy,
+  ceilDivideBy,
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { observeNotifier } from '@agoric/notifier';
 import { AmountMath } from '@agoric/ertp';
@@ -40,7 +40,6 @@ const trace = makeTracer(' VM ');
 /** @type {MakeVaultManager} */
 export function makeVaultManager(
   zcf,
-  autoswap,
   runMint,
   collateralBrand,
   priceAuthority,
@@ -131,7 +130,7 @@ export function makeVaultManager(
     // ask to be alerted when the price level falls enough that the vault
     // with the highest debt to collateral ratio will no longer be valued at the
     // liquidationMargin above its debt.
-    const triggerPoint = multiplyBy(
+    const triggerPoint = ceilMultiplyBy(
       highestDebtRatio.numerator,
       liquidationMargin,
     );
@@ -160,9 +159,10 @@ export function makeVaultManager(
     const quote = await E(outstandingQuote).getPromise();
     // When we receive a quote, we liquidate all the vaults that don't have
     // sufficient collateral, (even if the trigger was set for a different
-    // level) because we use the actual price ratio plus margin here.
+    // level) because we use the actual price ratio plus margin here. Use
+    // ceilDivide to round up because ratios above this will be liquidated.
     const quoteRatioPlusMargin = makeRatioFromAmounts(
-      divideBy(getAmountOut(quote), liquidationMargin),
+      ceilDivideBy(getAmountOut(quote), liquidationMargin),
       getAmountIn(quote),
     );
 
@@ -251,7 +251,6 @@ export function makeVaultManager(
       zcf,
       innerFacet,
       runMint,
-      autoswap,
       priceAuthority,
       getLoanParams,
       startTimeStamp,

--- a/packages/treasury/test/faucet.js
+++ b/packages/treasury/test/faucet.js
@@ -1,0 +1,39 @@
+// @ts-check
+
+import { Far } from '@agoric/marshal';
+import { assertProposalShape } from '@agoric/zoe/src/contractSupport';
+import { LOW_FEE, SHORT_EXP } from '@agoric/zoe/src/constants';
+
+// A Faucet providing RUN so we can provide initial liquidity to the AMM so the
+// Treasury can reliably liquidate.
+
+/** @type {ContractStartFn} */
+export async function start(zcf, privateArgs) {
+  const { feeMintAccess } = privateArgs;
+  const runMint = await zcf.registerFeeMint('RUN', feeMintAccess);
+
+  function makeFaucetInvitation() {
+    /** @param {ZCFSeat} seat */
+    async function faucetHook(seat) {
+      assertProposalShape(seat, { want: { RUN: null } });
+
+      const {
+        want: { RUN: runAmount },
+      } = seat.getProposal();
+      runMint.mintGains({ RUN: runAmount }, seat);
+      seat.exit();
+      return `success ${runAmount.value}`;
+    }
+
+    return zcf.makeInvitation(
+      faucetHook,
+      'provide RUN',
+      undefined,
+      LOW_FEE,
+      SHORT_EXP,
+    );
+  }
+
+  const creatorFacet = Far('faucetInvitationMaker', { makeFaucetInvitation });
+  return harden({ creatorFacet });
+}

--- a/packages/treasury/test/faucet.js
+++ b/packages/treasury/test/faucet.js
@@ -20,7 +20,7 @@ export async function start(zcf, privateArgs) {
       const {
         want: { RUN: runAmount },
       } = seat.getProposal();
-      runMint.mintGains({ RUN: runAmount }, seat);
+      runMint.mintGains(harden({ RUN: runAmount }), seat);
       seat.exit();
       return `success ${runAmount.value}`;
     }

--- a/packages/treasury/test/mockAmm.js
+++ b/packages/treasury/test/mockAmm.js
@@ -1,0 +1,9 @@
+// @ts-check
+
+import { Far } from '@agoric/marshal';
+
+export const ammMock = Far('mock AMM', {
+  getInputPrice(amountIn, amountOut) {
+    return { amountIn, amountOut };
+  },
+});

--- a/packages/treasury/test/swingsetTests/governance/bootstrap.js
+++ b/packages/treasury/test/swingsetTests/governance/bootstrap.js
@@ -4,11 +4,11 @@ import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 import { makeIssuerKit, AmountMath } from '@agoric/ertp';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer';
-import { q } from '@agoric/assert';
 import { makeRatio } from '@agoric/zoe/src/contractSupport';
 
-import { POOL_FEE_KEY, ParamKey, INTEREST_RATE_KEY } from '../../../src/params';
+import { INTEREST_RATE_KEY } from '../../../src/params';
 
+const { quote: q } = assert;
 const ONE_DAY = 24n * 60n * 60n;
 const BASIS_POINTS = 10000n;
 
@@ -28,14 +28,12 @@ const setupBasicMints = () => {
 const installContracts = async (zoe, cb) => {
   const [
     liquidateMinimum,
-    autoswap,
     treasury,
     electorate,
     counter,
     governor,
   ] = await Promise.all([
     E(zoe).install(cb.liquidateMinimum),
-    E(zoe).install(cb.autoswap),
     E(zoe).install(cb.treasury),
     E(zoe).install(cb.committee),
     E(zoe).install(cb.binaryVoteCounter),
@@ -44,7 +42,6 @@ const installContracts = async (zoe, cb) => {
 
   const installations = {
     liquidateMinimum,
-    autoswap,
     treasury,
     electorate,
     counter,
@@ -195,42 +192,32 @@ const makeBootstrap = (argv, cb, vatPowers) => async (vats, devices) => {
   log(`=> alice and the treasury are set up`);
 
   const feeParamsStateAnte = await E(treasury.publicFacet).getParams({
-    key: ParamKey.FEE,
+    collateralBrand: brands[0],
   });
   log(`param values before ${q(feeParamsStateAnte)}`);
 
   const contracts = { treasury, installations, electorateInstance, governor };
   const votes = [0, 1, 1, 0, 0];
 
-  const fees = {
-    key: ParamKey.FEE,
-    parameterName: POOL_FEE_KEY,
-  };
-
-  const counter = await setUpVote(
-    37n,
-    3n * ONE_DAY,
-    votersP,
-    votes,
-    fees,
-    contracts,
-  );
-
-  const poolParams = {
-    key: ParamKey.POOL,
+  const interestRateParam = {
     parameterName: INTEREST_RATE_KEY,
     collateralBrand: brands[0],
   };
-  const newRate = makeRatio(500n, runBrand, BASIS_POINTS);
-
-  await setUpVote(newRate, 3n * ONE_DAY, votersP, votes, poolParams, contracts);
+  const counter = await setUpVote(
+    makeRatio(500n, runBrand, BASIS_POINTS),
+    3n * ONE_DAY,
+    votersP,
+    votes,
+    interestRateParam,
+    contracts,
+  );
 
   E(E(zoe).getPublicFacet(counter))
     .getOutcome()
     .then(async outcome => {
-      const feeParamsStatePost = await E(treasury.publicFacet).getParams({
-        key: ParamKey.FEE,
-      });
+      const feeParamsStatePost = await E(treasury.publicFacet).getParams(
+        interestRateParam,
+      );
       log(
         `param values after vote on (${outcome.changeParam.parameterName}) ${q(
           feeParamsStatePost,

--- a/packages/treasury/test/swingsetTests/governance/test-governance.js
+++ b/packages/treasury/test/swingsetTests/governance/test-governance.js
@@ -13,7 +13,7 @@ import { E } from '@agoric/eventual-send';
 import path from 'path';
 
 import liquidateBundle from '../../../bundles/bundle-liquidateMinimum.js';
-import autoswapBundle from '../../../bundles/bundle-multipoolAutoswap.js';
+import ammBundle from '../../../bundles/bundle-amm.js';
 import stablecoinBundle from '../../../bundles/bundle-stablecoinMachine.js';
 import contractGovernorBundle from '../../../bundles/bundle-contractGovernor.js';
 import committeeBundle from '../../../bundles/bundle-committee.js';
@@ -30,7 +30,7 @@ test.before(async t => {
 
   const nameToBundle = [
     ['liquidateMinimum', liquidateBundle],
-    ['autoswap', autoswapBundle],
+    ['amm', ammBundle],
     ['treasury', stablecoinBundle],
     ['committee', committeeBundle],
     ['contractGovernor', contractGovernorBundle],
@@ -75,25 +75,18 @@ async function main(t, argv) {
 const expectedTreasuryLog = [
   '=> voter and electorate vats are set up',
   '=> alice and the treasury are set up',
-  'param values before {"PoolFee":{"name":"PoolFee","type":"nat","value":"[24n]"},"ProtocolFee":{"name":"ProtocolFee","type":"nat","value":"[6n]"}}',
-  'Voter Bob cast a ballot for {"changeParam":{"key":"fee","parameterName":"PoolFee"},"proposedValue":"[37n]"}',
-  'Voter Carol cast a ballot for {"noChange":{"key":"fee","parameterName":"PoolFee"}}',
-  'Voter Dave cast a ballot for {"noChange":{"key":"fee","parameterName":"PoolFee"}}',
-  'Voter Emma cast a ballot for {"changeParam":{"key":"fee","parameterName":"PoolFee"},"proposedValue":"[37n]"}',
-  'Voter Flora cast a ballot for {"changeParam":{"key":"fee","parameterName":"PoolFee"},"proposedValue":"[37n]"}',
-  'governor from governed matches governor instance',
-  'Param "PoolFee" is in the question',
-  'Voter Bob cast a ballot for {"changeParam":{"collateralBrand":"[Alleged: moola brand]","key":"pool","parameterName":"InterestRate"},"proposedValue":{"denominator":{"brand":"[Alleged: RUN brand]","value":"[10000n]"},"numerator":{"brand":"[Seen]","value":"[500n]"}}}',
-  'Voter Carol cast a ballot for {"noChange":{"collateralBrand":"[Alleged: moola brand]","key":"pool","parameterName":"InterestRate"}}',
-  'Voter Dave cast a ballot for {"noChange":{"collateralBrand":"[Alleged: moola brand]","key":"pool","parameterName":"InterestRate"}}',
-  'Voter Emma cast a ballot for {"changeParam":{"collateralBrand":"[Alleged: moola brand]","key":"pool","parameterName":"InterestRate"},"proposedValue":{"denominator":{"brand":"[Alleged: RUN brand]","value":"[10000n]"},"numerator":{"brand":"[Seen]","value":"[500n]"}}}',
-  'Voter Flora cast a ballot for {"changeParam":{"collateralBrand":"[Alleged: moola brand]","key":"pool","parameterName":"InterestRate"},"proposedValue":{"denominator":{"brand":"[Alleged: RUN brand]","value":"[10000n]"},"numerator":{"brand":"[Seen]","value":"[500n]"}}}',
+  'param values before {"ChargingPeriod":{"name":"ChargingPeriod","type":"nat","value":"[86400n]"},"InitialMargin":{"name":"InitialMargin","type":"ratio","value":{"denominator":{"brand":"[Alleged: RUN brand]","value":"[100n]"},"numerator":{"brand":"[Seen]","value":"[120n]"}}},"InterestRate":{"name":"InterestRate","type":"ratio","value":{"denominator":{"brand":"[Seen]","value":"[10000n]"},"numerator":{"brand":"[Seen]","value":"[250n]"}}},"LiquidationMargin":{"name":"LiquidationMargin","type":"ratio","value":{"denominator":{"brand":"[Seen]","value":"[100n]"},"numerator":{"brand":"[Seen]","value":"[105n]"}}},"LoanFee":{"name":"LoanFee","type":"ratio","value":{"denominator":{"brand":"[Seen]","value":"[10000n]"},"numerator":{"brand":"[Seen]","value":"[200n]"}}},"RecordingPeriod":{"name":"RecordingPeriod","type":"nat","value":"[86400n]"}}',
+  'Voter Bob cast a ballot for {"changeParam":{"collateralBrand":"[Alleged: moola brand]","parameterName":"InterestRate"},"proposedValue":{"denominator":{"brand":"[Alleged: RUN brand]","value":"[10000n]"},"numerator":{"brand":"[Seen]","value":"[500n]"}}}',
+  'Voter Carol cast a ballot for {"noChange":{"collateralBrand":"[Alleged: moola brand]","parameterName":"InterestRate"}}',
+  'Voter Dave cast a ballot for {"noChange":{"collateralBrand":"[Alleged: moola brand]","parameterName":"InterestRate"}}',
+  'Voter Emma cast a ballot for {"changeParam":{"collateralBrand":"[Alleged: moola brand]","parameterName":"InterestRate"},"proposedValue":{"denominator":{"brand":"[Alleged: RUN brand]","value":"[10000n]"},"numerator":{"brand":"[Seen]","value":"[500n]"}}}',
+  'Voter Flora cast a ballot for {"changeParam":{"collateralBrand":"[Alleged: moola brand]","parameterName":"InterestRate"},"proposedValue":{"denominator":{"brand":"[Alleged: RUN brand]","value":"[10000n]"},"numerator":{"brand":"[Seen]","value":"[500n]"}}}',
   '=> alice.oneLoanWithInterest called',
-  'param values after vote on (PoolFee) {"PoolFee":{"name":"PoolFee","type":"nat","value":"[37n]"},"ProtocolFee":{"name":"ProtocolFee","type":"nat","value":"[6n]"}}',
+  'param values after vote on (InterestRate) {"ChargingPeriod":{"name":"ChargingPeriod","type":"nat","value":"[86400n]"},"InitialMargin":{"name":"InitialMargin","type":"ratio","value":{"denominator":{"brand":"[Alleged: RUN brand]","value":"[100n]"},"numerator":{"brand":"[Seen]","value":"[120n]"}}},"InterestRate":{"name":"InterestRate","type":"ratio","value":{"denominator":{"brand":"[Seen]","value":"[10000n]"},"numerator":{"brand":"[Seen]","value":"[500n]"}}},"LiquidationMargin":{"name":"LiquidationMargin","type":"ratio","value":{"denominator":{"brand":"[Seen]","value":"[100n]"},"numerator":{"brand":"[Seen]","value":"[105n]"}}},"LoanFee":{"name":"LoanFee","type":"ratio","value":{"denominator":{"brand":"[Seen]","value":"[10000n]"},"numerator":{"brand":"[Seen]","value":"[200n]"}}},"RecordingPeriod":{"name":"RecordingPeriod","type":"nat","value":"[86400n]"}}',
   'governor from governed matches governor instance',
   'Param "InterestRate" is in the question',
   'Alice owes {"brand":"[Alleged: RUN brand]","value":"[510000n]"} after borrowing',
-  'Alice owes {"brand":"[Alleged: RUN brand]","value":"[510068n]"} after interest',
+  'Alice owes {"brand":"[Alleged: RUN brand]","value":"[510069n]"} after interest',
 ];
 
 test.serial('treasury', async t => {

--- a/packages/treasury/test/swingsetTests/governance/vat-owner.js
+++ b/packages/treasury/test/swingsetTests/governance/vat-owner.js
@@ -3,8 +3,8 @@
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 import { makeRatio } from '@agoric/zoe/src/contractSupport';
-import { AmountMath } from '@agoric/ertp';
 import { governedParameterTerms } from '../../../src/params';
+import { ammMock } from '../../mockAmm.js';
 
 const SECONDS_PER_HOUR = 60n * 60n;
 const SECONDS_PER_DAY = 24n * SECONDS_PER_HOUR;
@@ -26,24 +26,21 @@ const build = async (
   electorateCreatorFacet,
 ) => {
   const [moolaBrand] = brands;
-  const [moolaPayment] = payments;
   const [moolaIssuer] = issuers;
 
   const loanParams = {
     chargingPeriod: SECONDS_PER_DAY,
     recordingPeriod: SECONDS_PER_DAY,
-    poolFee: 24n,
-    protocolFee: 6n,
   };
 
   const priceAuthorityKit = await E(priceAuthorityVat).makePriceAuthority();
   const terms = harden({
-    autoswapInstall: installations.autoswap,
     priceAuthority: priceAuthorityKit.priceAuthority,
     loanParams,
     liquidationInstall: installations.liquidateMinimum,
     timerService: timer,
     governedParams: governedParameterTerms,
+    ammPublicFacet: ammMock,
   });
   const privateArgs = harden({ electorateCreatorFacet });
   const privateTreasuryArgs = { feeMintAccess };
@@ -69,34 +66,21 @@ const build = async (
 
   const {
     issuers: { RUN: runIssuer },
-    brands: { Governance: govBrand, RUN: runBrand },
+    brands: { RUN: runBrand },
   } = await E(zoe).getTerms(governedInstance);
 
   const rates = {
-    initialPrice: makeRatio(10000n, runBrand, 5n, moolaBrand),
     initialMargin: makeRatio(120n, runBrand),
     liquidationMargin: makeRatio(105n, runBrand),
     interestRate: makeRatio(250n, runBrand, BASIS_POINTS),
     loanFee: makeRatio(200n, runBrand, BASIS_POINTS),
   };
 
-  const addTypeInvitation = await E(
-    // get the governed creatorFacet from the governor
-    E(governorFacets.creatorFacet).getCreatorFacet(),
-  ).makeAddTypeInvitation(moolaIssuer, 'Moola', rates);
-  const proposal = harden({
-    give: {
-      Collateral: AmountMath.make(moolaBrand, 1000n),
-    },
-    want: { Governance: AmountMath.makeEmpty(govBrand) },
-  });
-
-  const seat = await E(zoe).offer(
-    addTypeInvitation,
-    proposal,
-    harden({ Collateral: moolaPayment }),
+  await E(E(governorFacets.creatorFacet).getCreatorFacet()).addVaultType(
+    moolaIssuer,
+    'Moola',
+    rates,
   );
-  await E(seat).getOfferResult();
 
   const QUOTE_INTERVAL = 24n * 60n * 60n;
   const moolaPriceAuthority = await E(priceAuthorityVat).makeFakePriceAuthority(

--- a/packages/treasury/test/swingsetTests/treasury/bootstrap.js
+++ b/packages/treasury/test/swingsetTests/treasury/bootstrap.js
@@ -93,14 +93,12 @@ function makeBootstrap(argv, cb, vatPowers) {
     const { zoe, feeMintAccess } = await E(vats.zoe).buildZoe(vatAdminSvc);
     const [
       liquidateMinimum,
-      autoswap,
       treasury,
       electorate,
       counter,
       governor,
     ] = await Promise.all([
       E(zoe).install(cb.liquidateMinimum),
-      E(zoe).install(cb.autoswap),
       E(zoe).install(cb.treasury),
       E(zoe).install(cb.committee),
       E(zoe).install(cb.binaryVoteCounter),
@@ -109,7 +107,6 @@ function makeBootstrap(argv, cb, vatPowers) {
 
     const installations = {
       liquidateMinimum,
-      autoswap,
       treasury,
       electorate,
       counter,

--- a/packages/treasury/test/swingsetTests/treasury/test-treasury.js
+++ b/packages/treasury/test/swingsetTests/treasury/test-treasury.js
@@ -13,7 +13,7 @@ import bundleSource from '@agoric/bundle-source';
 import { E } from '@agoric/eventual-send';
 
 import liquidateBundle from '../../../bundles/bundle-liquidateMinimum.js';
-import autoswapBundle from '../../../bundles/bundle-multipoolAutoswap.js';
+import ammBundle from '../../../bundles/bundle-amm.js';
 import stablecoinBundle from '../../../bundles/bundle-stablecoinMachine.js';
 import committeeBundle from '../../../bundles/bundle-committee.js';
 import contractGovernorBundle from '../../../bundles/bundle-contractGovernor.js';
@@ -30,7 +30,7 @@ test.before(async t => {
 
   const nameToBundle = [
     ['liquidateMinimum', liquidateBundle],
-    ['autoswap', autoswapBundle],
+    ['amm', ammBundle],
     ['treasury', stablecoinBundle],
     ['committee', committeeBundle],
     ['contractGovernor', contractGovernorBundle],
@@ -76,7 +76,7 @@ const expectedTreasuryLog = [
   '=> alice and the treasury are set up',
   '=> alice.oneLoanWithInterest called',
   'Alice owes {"brand":"[Alleged: RUN brand]","value":"[510000n]"} after borrowing',
-  'Alice owes {"brand":"[Alleged: RUN brand]","value":"[510034n]"} after interest',
+  'Alice owes {"brand":"[Alleged: RUN brand]","value":"[510035n]"} after interest',
 ];
 
 test.serial('treasury', async t => {

--- a/packages/treasury/test/test-bootstrapPayment.js
+++ b/packages/treasury/test/test-bootstrapPayment.js
@@ -22,7 +22,7 @@ const dirname = path.dirname(filename);
 const stablecoinRoot = `${dirname}/../src/stablecoinMachine.js`;
 const liquidationRoot = `${dirname}/../src/liquidateMinimum.js`;
 const autoswapRoot =
-  '@agoric/zoe/src/contracts/multipoolAutoswap/multipoolAutoswap.js';
+  '@agoric/zoe/src/contracts/vpool-xyk-amm/multipoolMarketMaker.js';
 const governanceRoot = '@agoric/governance/src/contractGovernor.js';
 const electorateRoot = '@agoric/governance/src/committee.js';
 
@@ -101,7 +101,7 @@ const setUpZoeForTest = async setJig => {
    * @property {ContractFacet} zcf
    * @property {IssuerRecord} runIssuerRecord
    * @property {IssuerRecord} govIssuerRecord
-   * @property {ERef<MultipoolAutoswapPublicFacet>} autoswap
+   * @property {ERef<XYKAMMPublicFacet>} amm
    */
 
   const {

--- a/packages/treasury/test/test-interest.js
+++ b/packages/treasury/test/test-interest.js
@@ -49,11 +49,11 @@ test('basic charge 1 period', async t => {
     latestInterestUpdate: 0n,
     interest: AmountMath.makeEmpty(brand),
   };
-  // 6n is daily interest of 2.5% APR on 100k. Compounding is in the noise.
+  // 7n is daily interest of 2.5% APR on 100k. Compounding is in the noise.
   t.deepEqual(calculator.calculate(debtStatus, ONE_DAY), {
     latestInterestUpdate: ONE_DAY,
-    interest: AmountMath.make(brand, 6n),
-    newDebt: AmountMath.make(brand, 100006n),
+    interest: AmountMath.make(brand, 7n),
+    newDebt: AmountMath.make(brand, 100007n),
   });
 });
 
@@ -71,12 +71,12 @@ test('basic 2 charge periods', async t => {
     latestInterestUpdate: ONE_DAY,
     interest: AmountMath.makeEmpty(brand),
   };
-  // 12n is 2x daily (from day 1 to day 3) interest of 2.5% APR on 100k.
+  // 14n is 2x daily (from day 1 to day 3) interest of 2.5% APR on 100k.
   // Compounding is in the noise.
   t.deepEqual(calculator.calculate(debtStatus, ONE_DAY * 3n), {
     latestInterestUpdate: ONE_DAY * 3n,
-    interest: AmountMath.make(brand, 12n),
-    newDebt: AmountMath.make(brand, 100012n),
+    interest: AmountMath.make(brand, 14n),
+    newDebt: AmountMath.make(brand, 100014n),
   });
 });
 
@@ -94,11 +94,11 @@ test('partial periods', async t => {
     latestInterestUpdate: 10n,
     interest: AmountMath.makeEmpty(brand),
   };
-  // just less than three days gets two days of interest (6n/day)
+  // just less than three days gets two days of interest (7n/day)
   t.deepEqual(calculator.calculate(debtStatus, ONE_DAY * 3n - 1n), {
     latestInterestUpdate: 10n + ONE_DAY * 2n,
-    interest: AmountMath.make(brand, 12n),
-    newDebt: AmountMath.make(brand, 100012n),
+    interest: AmountMath.make(brand, 14n),
+    newDebt: AmountMath.make(brand, 100014n),
   });
 });
 
@@ -123,13 +123,13 @@ test('reportingPeriod: partial', async t => {
     interest: AmountMath.makeEmpty(brand),
     newDebt: AmountMath.make(brand, HUNDRED_THOUSAND),
   });
-  // charge daily, record monthly. After a month, charge 30 * 6n
+  // charge daily, record monthly. After a month, charge 30 * 7n
   t.deepEqual(
     calculator.calculateReportingPeriod(debtStatus, ONE_DAY + ONE_MONTH),
     {
       latestInterestUpdate: 10n + ONE_MONTH,
-      interest: AmountMath.make(brand, 180n),
-      newDebt: AmountMath.make(brand, 100180n),
+      interest: AmountMath.make(brand, 210n),
+      newDebt: AmountMath.make(brand, 100210n),
     },
   );
 });
@@ -148,14 +148,14 @@ test('reportingPeriod: longer', async t => {
     latestInterestUpdate: 10n,
     interest: AmountMath.makeEmpty(brand),
   };
-  // charge monthly, record daily. 2.5% APR compounded monthly rate is 203 BP.
+  // charge monthly, record daily. 2.5% APR compounded monthly rate is 204 BP.
   // charge at reporting period intervals
   t.deepEqual(
     calculator.calculateReportingPeriod(debtStatus, ONE_MONTH + ONE_DAY),
     {
       latestInterestUpdate: ONE_MONTH + 10n,
-      interest: AmountMath.make(brand, 203n),
-      newDebt: AmountMath.make(brand, 100203n),
+      interest: AmountMath.make(brand, 204n),
+      newDebt: AmountMath.make(brand, 100204n),
     },
   );
 });
@@ -183,8 +183,8 @@ test('start charging later', async t => {
   });
   t.deepEqual(calculator.calculate(debtStatus, ONE_DAY + 16n), {
     latestInterestUpdate: ONE_DAY + 16n,
-    interest: AmountMath.make(brand, 6n),
-    newDebt: AmountMath.make(brand, 100006n),
+    interest: AmountMath.make(brand, 7n),
+    newDebt: AmountMath.make(brand, 100007n),
   });
 });
 
@@ -202,14 +202,14 @@ test('simple compounding', async t => {
     latestInterestUpdate: 10n,
     interest: AmountMath.makeEmpty(brand),
   };
-  // 30 days of 6n interest per day. Compounding is in the noise.
+  // 30 days of 7n interest per day. Compounding is in the noise.
   // charge at reporting period intervals
   t.deepEqual(
     calculator.calculateReportingPeriod(debtStatus, ONE_MONTH + ONE_DAY),
     {
       latestInterestUpdate: ONE_MONTH + 10n,
-      interest: AmountMath.make(brand, 180n),
-      newDebt: AmountMath.make(brand, 100180n),
+      interest: AmountMath.make(brand, 210n),
+      newDebt: AmountMath.make(brand, 100210n),
     },
   );
 });
@@ -241,19 +241,19 @@ test('reportingPeriod shorter than charging', async t => {
   t.deepEqual(calculator.calculate(debtStatus, 29n * ONE_DAY), afterOneMonth);
   t.deepEqual(calculator.calculate(debtStatus, ONE_MONTH + 10n), {
     latestInterestUpdate: ONE_MONTH + 10n,
-    interest: AmountMath.make(brand, 203n),
-    newDebt: AmountMath.make(brand, 100203n),
+    interest: AmountMath.make(brand, 204n),
+    newDebt: AmountMath.make(brand, 100204n),
   });
 
   debtStatus = {
-    newDebt: AmountMath.make(brand, 100203n),
-    interest: AmountMath.make(brand, 203n),
+    newDebt: AmountMath.make(brand, 100204n),
+    interest: AmountMath.make(brand, 204n),
     latestInterestUpdate: ONE_MONTH,
   };
   const afterTwoMonths = {
     latestInterestUpdate: ONE_MONTH,
-    interest: AmountMath.make(brand, 203n),
-    newDebt: AmountMath.make(brand, 100203n),
+    interest: AmountMath.make(brand, 204n),
+    newDebt: AmountMath.make(brand, 100204n),
   };
   // charging period is 30 days. 2nd interest isn't charged until 60 days.
   t.deepEqual(calculator.calculate(debtStatus, 32n * ONE_DAY), afterTwoMonths);
@@ -262,8 +262,8 @@ test('reportingPeriod shorter than charging', async t => {
   t.deepEqual(calculator.calculate(debtStatus, 59n * ONE_DAY), afterTwoMonths);
   t.deepEqual(calculator.calculate(debtStatus, 60n * ONE_DAY), {
     latestInterestUpdate: 2n * ONE_MONTH,
-    interest: AmountMath.make(brand, 406n),
-    newDebt: AmountMath.make(brand, 100406n),
+    interest: AmountMath.make(brand, 408n),
+    newDebt: AmountMath.make(brand, 100408n),
   });
 });
 
@@ -295,10 +295,10 @@ test('reportingPeriod shorter than charging; start day boundary', async t => {
 
   const afterAMonth = {
     latestInterestUpdate: ONE_MONTH + ONE_DAY,
-    interest: AmountMath.make(brand, 203n),
-    newDebt: AmountMath.make(brand, 100203n),
+    interest: AmountMath.make(brand, 204n),
+    newDebt: AmountMath.make(brand, 100204n),
   };
-  // 203n is 2.5% APR charged monthly
+  // 204n is 2.5% APR charged monthly
   t.deepEqual(
     calculator.calculate(startOneDay, ONE_DAY + ONE_MONTH),
     afterAMonth,
@@ -332,13 +332,13 @@ test('reportingPeriod shorter than charging; start not even days', async t => {
   // interest not charged until ONE_MONTH + 20n
   t.deepEqual(calculator.calculate(startPartialDay, ONE_MONTH + 20n), {
     latestInterestUpdate: 20n + ONE_MONTH,
-    interest: AmountMath.make(brand, 205n),
-    newDebt: AmountMath.make(brand, 101205n),
+    interest: AmountMath.make(brand, 206n),
+    newDebt: AmountMath.make(brand, 101206n),
   });
 });
 
 // 2.5 % APR charged daily, large enough loan to display compounding
-test.only('basic charge large numbers, compounding', async t => {
+test('basic charge large numbers, compounding', async t => {
   const { brand } = makeIssuerKit('ducats');
   const annualRate = makeRatio(250n, brand, BASIS_POINTS);
   // Unix epoch time:  Tuesday April 6th 2021 at 11:45am PT
@@ -365,26 +365,26 @@ test.only('basic charge large numbers, compounding', async t => {
     interest: AmountMath.makeEmpty(brand),
     newDebt: AmountMath.make(brand, TEN_MILLION),
   });
-  // 676n is one day's interest on TEN_MILLION at 2.5% APR.
+  // 677n is one day's interest on TEN_MILLION at 2.5% APR, rounded up.
   t.deepEqual(calculator.calculate(debtStatus, START_TIME + ONE_DAY), {
     latestInterestUpdate: START_TIME + ONE_DAY,
-    interest: AmountMath.make(brand, 676n),
-    newDebt: AmountMath.make(brand, 10000676n),
+    interest: AmountMath.make(brand, 677n),
+    newDebt: AmountMath.make(brand, 10000677n),
   });
   // two days interest. compounding not visible
   t.deepEqual(
     calculator.calculate(debtStatus, START_TIME + ONE_DAY + ONE_DAY),
     {
       latestInterestUpdate: START_TIME + ONE_DAY + ONE_DAY,
-      interest: AmountMath.make(brand, 1352n),
-      newDebt: AmountMath.make(brand, 10001352n),
+      interest: AmountMath.make(brand, 1354n),
+      newDebt: AmountMath.make(brand, 10001354n),
     },
   );
-  // Notice that interest compounds 30 * 676 = 20280
+  // Notice that interest compounds 30 days * 677 = 20310 < 20329
   t.deepEqual(calculator.calculate(debtStatus, START_TIME + ONE_MONTH), {
     latestInterestUpdate: START_TIME + ONE_MONTH,
-    interest: AmountMath.make(brand, 20299n),
-    newDebt: AmountMath.make(brand, 10020299n),
+    interest: AmountMath.make(brand, 20329n),
+    newDebt: AmountMath.make(brand, 10020329n),
   });
 });
 
@@ -441,33 +441,33 @@ test('basic charge reasonable numbers monthly', async t => {
     },
   );
 
-  // a month has elapsed. interest compounds: 30 * 676 = 20280
+  // a month has elapsed. interest compounds: 30 days @ 677 => 20329
   t.deepEqual(
     calculator.calculateReportingPeriod(debtStatus, START_TIME + ONE_MONTH),
     {
       latestInterestUpdate: START_TIME + ONE_MONTH,
-      interest: AmountMath.make(brand, 20299n),
-      newDebt: AmountMath.make(brand, 10020299n),
+      interest: AmountMath.make(brand, 20329n),
+      newDebt: AmountMath.make(brand, 10020329n),
     },
   );
   const HALF_YEAR = 6n * ONE_MONTH;
 
-  // compounding: 180 days * 676 = 121680
+  // compounding: 180 days * 677 = 121860 < 122601
   t.deepEqual(
     calculator.calculateReportingPeriod(debtStatus, START_TIME + HALF_YEAR),
     {
       latestInterestUpdate: START_TIME + HALF_YEAR,
-      interest: AmountMath.make(brand, 122419n),
-      newDebt: AmountMath.make(brand, 10122419n),
+      interest: AmountMath.make(brand, 122601n),
+      newDebt: AmountMath.make(brand, 10122601n),
     },
   );
-  // compounding: 360 days * 676 = 243360
+  // compounding: 360 days * 677 = 243720 < 246705
   t.deepEqual(
     calculator.calculateReportingPeriod(debtStatus, START_TIME + ONE_YEAR),
     {
       latestInterestUpdate: START_TIME + ONE_YEAR,
-      interest: AmountMath.make(brand, 246338n),
-      newDebt: AmountMath.make(brand, 10246338n),
+      interest: AmountMath.make(brand, 246705n),
+      newDebt: AmountMath.make(brand, 10246705n),
     },
   );
 });

--- a/packages/treasury/test/test-stablecoin.js
+++ b/packages/treasury/test/test-stablecoin.js
@@ -18,21 +18,26 @@ import { makeIssuerKit, AssetKind, AmountMath } from '@agoric/ertp';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import {
   makeRatio,
-  multiplyBy,
+  ceilMultiplyBy,
 } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { makePromiseKit } from '@agoric/promise-kit';
 
 import { makeScriptedPriceAuthority } from '@agoric/zoe/tools/scriptedPriceAuthority.js';
 import { assertAmountsEqual } from '@agoric/zoe/test/zoeTestHelpers.js';
+import { makeInitialValues } from '@agoric/zoe/src/contracts/vpool-xyk-amm/params.js';
+
 import { makeTracer } from '../src/makeTracer.js';
 import { SECONDS_PER_YEAR } from '../src/interest.js';
 import { VaultState } from '../src/vault.js';
-
 import { governedParameterTerms } from '../src/params.js';
+
+const ammRoot =
+  '@agoric/zoe/src/contracts/vpool-xyk-amm/multipoolMarketMaker.js';
 
 const stablecoinRoot = '../src/stablecoinMachine.js';
 const liquidationRoot = '../src/liquidateMinimum.js';
-const autoswapRoot = '@agoric/zoe/src/contracts/newSwap/multipoolAutoswap.js';
+
+const faucetRoot = './faucet.js';
 
 const contractGovernorRoot = '@agoric/governance/src/contractGovernor.js';
 const committeeRoot = '@agoric/governance/src/committee.js';
@@ -41,7 +46,6 @@ const voteCounterRoot = '@agoric/governance/src/binaryVoteCounter.js';
 const trace = makeTracer('TestST');
 
 const BASIS_POINTS = 10000n;
-const PERCENT = 100n;
 
 async function makeBundle(sourceRoot) {
   const url = await importMetaResolve(sourceRoot, import.meta.url);
@@ -52,31 +56,16 @@ async function makeBundle(sourceRoot) {
 }
 
 // makeBundle is a slow step, so we do it once for all the tests.
-const [
-  autoswapBundle,
-  stablecoinBundle,
-  liquidationBundle,
-  contractGovernorBundle,
-  committeeBundle,
-  voteCounterBundle,
-] = await Promise.all([
-  makeBundle(autoswapRoot),
-  makeBundle(stablecoinRoot),
-  makeBundle(liquidationRoot),
-  makeBundle(contractGovernorRoot),
-  makeBundle(committeeRoot),
-  makeBundle(voteCounterRoot),
-]);
+const stablecoinBundleP = makeBundle(stablecoinRoot);
+const liquidationBundleP = makeBundle(liquidationRoot);
+const contractGovernorBundleP = makeBundle(contractGovernorRoot);
+const committeeBundleP = makeBundle(committeeRoot);
+const voteCounterBundleP = makeBundle(voteCounterRoot);
+const ammBundleP = makeBundle(ammRoot);
+const faucetBundleP = makeBundle(faucetRoot);
 
 const setUpZoeForTest = async setJig => {
-  const { makeFar, makeNear } = makeLoopback('zoeTest');
-  let isFirst = true;
-  function makeRemote(arg) {
-    const result = isFirst ? makeNear(arg) : arg;
-    // this seems fragile. It relies on one contract being created first by Zoe
-    isFirst = !isFirst;
-    return result;
-  }
+  const { makeFar } = makeLoopback('zoeTest');
 
   /**
    * These properties will be assigned by `setJig` in the contract.
@@ -85,18 +74,16 @@ const setUpZoeForTest = async setJig => {
    * @property {ContractFacet} zcf
    * @property {IssuerRecord} runIssuerRecord
    * @property {IssuerRecord} govIssuerRecord
-   * @property {ERef<MultipoolAutoswapPublicFacet>} autoswap
    */
 
   const {
     zoeService: nonFarZoeService,
     feeMintAccess: nonFarFeeMintAccess,
-  } = makeZoeKit(makeFakeVatAdmin(setJig, makeRemote).admin);
+  } = makeZoeKit(makeFakeVatAdmin(setJig, o => makeFar(o)).admin);
   const feePurse = E(nonFarZoeService).makeFeePurse();
   const zoeService = await E(nonFarZoeService).bindDefaultFeePurse(feePurse);
   /** @type {ERef<ZoeService>} */
   const zoe = makeFar(zoeService);
-  trace('makeZoe');
   const feeMintAccess = await makeFar(nonFarFeeMintAccess);
   return {
     zoe,
@@ -112,7 +99,6 @@ function setupAssets() {
   // setup collateral assets
   const aethKit = makeIssuerKit('aEth');
 
-  trace('setup assets');
   return harden({
     aethKit,
   });
@@ -148,10 +134,8 @@ const makePriceAuthority = (
   return makeScriptedPriceAuthority(options);
 };
 
-function makeRates(runBrand, aethBrand) {
+function makeRates(runBrand) {
   return harden({
-    // exchange rate
-    initialPrice: makeRatio(201n, runBrand, PERCENT, aethBrand),
     // margin required to open a loan
     initialMargin: makeRatio(120n, runBrand),
     // margin required to maintain a loan
@@ -163,89 +147,97 @@ function makeRates(runBrand, aethBrand) {
   });
 }
 
-// called separately by each test so AMM/zoe/priceAuthority don't interfere
-async function setupServices(
-  loanParams,
-  priceList,
-  unitAmountIn,
-  aethBrand,
-  electorateTerms,
-  timer = buildManualTimer(console.log),
-  quoteInterval,
+const PROTOCOL_FEE_BP = 6n;
+const POOL_FEE_BP = 24n;
+
+async function setupAmm(
+  timer,
+  electorateInstance,
+  installs,
+  zoe,
+  committeeCreator,
+  aethLiquidity,
+  runLiquidity,
+  aethIssuer,
 ) {
-  let testJig;
-  const setJig = jig => {
-    testJig = jig;
-  };
-  const { zoe, feeMintAccess } = await setUpZoeForTest(setJig);
-
-  const [
-    autoswap,
-    stablecoin,
-    liquidation,
-    governor,
-    electorate,
-    counter,
-  ] = await Promise.all([
-    installBundle(zoe, autoswapBundle),
-    installBundle(zoe, stablecoinBundle),
-    installBundle(zoe, liquidationBundle),
-    installBundle(zoe, contractGovernorBundle),
-    installBundle(zoe, committeeBundle),
-    installBundle(zoe, voteCounterBundle),
-  ]);
-
-  const installs = {
-    autoswap,
-    stablecoin,
-    liquidation,
-    governor,
-    electorate,
-    counter,
+  const ammTerms = {
+    timer,
+    poolFeeBP: POOL_FEE_BP,
+    protocolFeeBP: PROTOCOL_FEE_BP,
+    main: makeInitialValues(POOL_FEE_BP, PROTOCOL_FEE_BP),
   };
 
-  const {
-    creatorFacet: committeeCreator,
-    instance: electorateInstance,
-  } = await E(zoe).startInstance(
-    installs.electorate,
-    harden({}),
-    electorateTerms,
-  );
-
-  const priceAuthorityPromiseKit = makePromiseKit();
-  const priceAuthorityPromise = priceAuthorityPromiseKit.promise;
-  const treasuryTerms = {
-    autoswapInstall: installs.autoswap,
-    priceAuthority: priceAuthorityPromise,
-    loanParams,
-    liquidationInstall: installs.liquidation,
-    timerService: timer,
-    governedParams: governedParameterTerms,
-  };
-  const governorTerms = {
+  const ammGovernorTerms = {
     timer,
     electorateInstance,
-    governedContractInstallation: installs.stablecoin,
+    governedContractInstallation: installs.amm,
     governed: {
-      terms: treasuryTerms,
-      issuerKeywordRecord: {},
-      privateArgs: { feeMintAccess },
+      terms: ammTerms,
+      issuerKeywordRecord: { Central: E(zoe).getFeeIssuer() },
+      privateArgs: {},
     },
   };
+  const {
+    instance: ammGovernorInstance,
+    publicFacet: ammGovernorPublicFacet,
+    creatorFacet: ammGovernorCreatorFacet,
+  } = await E(zoe).startInstance(installs.governor, {}, ammGovernorTerms, {
+    electorateCreatorFacet: committeeCreator,
+  });
 
+  const ammCreatorFacetP = E(ammGovernorCreatorFacet).getInternalCreatorFacet();
+  const ammPublicP = E(ammGovernorCreatorFacet).getPublicFacet();
+
+  const [ammCreatorFacet, ammPublicFacet] = await Promise.all([
+    ammCreatorFacetP,
+    ammPublicP,
+  ]);
+
+  const liquidityIssuer = E(ammPublicFacet).addPool(aethIssuer, 'Aeth');
+  const liquidityBrand = await E(liquidityIssuer).getBrand();
+
+  const liqProposal = harden({
+    give: {
+      Secondary: aethLiquidity.proposal,
+      Central: runLiquidity.proposal,
+    },
+    want: { Liquidity: AmountMath.makeEmpty(liquidityBrand) },
+  });
+  const liqInvitation = E(ammPublicFacet).makeAddLiquidityInvitation();
+
+  const ammLiquiditySeat = await E(zoe).offer(liqInvitation, liqProposal, {
+    Secondary: aethLiquidity.payment,
+    Central: runLiquidity.payment,
+  });
+
+  const g = {
+    ammGovernorInstance,
+    ammGovernorPublicFacet,
+    ammGovernorCreatorFacet,
+  };
+  const governedInstance = E(ammGovernorPublicFacet).getGovernedContract();
+
+  const amm = {
+    ammCreatorFacet,
+    ammPublicFacet,
+    instance: governedInstance,
+    ammLiquidity: E(ammLiquiditySeat).getPayout('Liquidity'),
+  };
+
+  return {
+    governor: g,
+    amm,
+  };
+}
+
+async function setupTreasury(governorTerms, installs, zoe, committeeCreator) {
   const {
     instance: governorInstance,
     publicFacet: governorPublicFacet,
     creatorFacet: governorCreatorFacet,
-  } = await E(zoe).startInstance(
-    installs.governor,
-    harden({}),
-    governorTerms,
-    harden({
-      electorateCreatorFacet: committeeCreator,
-    }),
-  );
+  } = await E(zoe).startInstance(installs.governor, {}, governorTerms, {
+    electorateCreatorFacet: committeeCreator,
+  });
 
   const stablecoinMachineP = E(governorCreatorFacet).getCreatorFacet();
   const lenderP = E(governorCreatorFacet).getPublicFacet();
@@ -258,8 +250,144 @@ async function setupServices(
   const g = { governorInstance, governorPublicFacet, governorCreatorFacet };
 
   const s = { stablecoinMachine, lender };
-  const { runIssuerRecord, govIssuerRecord, autoswap: autoswapAPI } = testJig;
-  const issuers = { run: runIssuerRecord, gov: govIssuerRecord };
+  return { g, s };
+}
+
+// called separately by each test so AMM/zoe/priceAuthority don't interfere
+async function setupServices(
+  loanParams,
+  priceList,
+  unitAmountIn,
+  aethBrand,
+  electorateTerms,
+  timer = buildManualTimer(console.log),
+  quoteInterval,
+  aethLiquidity,
+  runInitialLiquidity,
+  aethIssuer,
+) {
+  const { zoe, feeMintAccess } = await setUpZoeForTest(() => {});
+  const [
+    stablecoinBundle,
+    liquidationBundle,
+    contractGovernorBundle,
+    committeeBundle,
+    voteCounterBundle,
+    ammBundle,
+    faucetBundle,
+  ] = await Promise.all([
+    stablecoinBundleP,
+    liquidationBundleP,
+    contractGovernorBundleP,
+    committeeBundleP,
+    voteCounterBundleP,
+    ammBundleP,
+    faucetBundleP,
+  ]);
+
+  const [
+    stablecoin,
+    liquidation,
+    governor,
+    electorate,
+    counter,
+    amm,
+    faucet,
+  ] = await Promise.all([
+    installBundle(zoe, stablecoinBundle),
+    installBundle(zoe, liquidationBundle),
+    installBundle(zoe, contractGovernorBundle),
+    installBundle(zoe, committeeBundle),
+    installBundle(zoe, voteCounterBundle),
+    installBundle(zoe, ammBundle),
+    installBundle(zoe, faucetBundle),
+  ]);
+
+  const installs = {
+    stablecoin,
+    liquidation,
+    governor,
+    electorate,
+    counter,
+    amm,
+    faucet,
+  };
+  const runIssuer = E(zoe).getFeeIssuer();
+  const runBrand = await E(runIssuer).getBrand();
+
+  // On-chain, there will be pre-existing RUN. The faucet replicates that
+  const { creatorFacet: faucetCreator } = await E(zoe).startInstance(
+    installs.faucet,
+    {},
+    {},
+    harden({ feeMintAccess }),
+  );
+  const faucetSeat = E(zoe).offer(
+    E(faucetCreator).makeFaucetInvitation(),
+    harden({
+      give: {},
+      want: { RUN: AmountMath.make(runBrand, runInitialLiquidity) },
+    }),
+    {},
+    { feeMintAccess },
+  );
+  // const result = await E(faucetSeat).getOfferResult();
+
+  const {
+    creatorFacet: committeeCreator,
+    instance: electorateInstance,
+  } = await E(zoe).startInstance(
+    installs.electorate,
+    harden({}),
+    electorateTerms,
+  );
+
+  const runPayment = await E(faucetSeat).getPayout('RUN');
+
+  const runLiquidity = {
+    proposal: AmountMath.make(runBrand, runInitialLiquidity),
+    payment: runPayment,
+  };
+
+  const { governor: _ammGovernorFacets, amm: ammFacets } = await setupAmm(
+    timer,
+    electorateInstance,
+    installs,
+    zoe,
+    committeeCreator,
+    aethLiquidity,
+    runLiquidity,
+    aethIssuer,
+  );
+
+  const priceAuthorityPromiseKit = makePromiseKit();
+  const priceAuthorityPromise = priceAuthorityPromiseKit.promise;
+
+  const treasuryTerms = {
+    priceAuthority: priceAuthorityPromise,
+    loanParams,
+    liquidationInstall: installs.liquidation,
+    timerService: timer,
+    governedParams: governedParameterTerms,
+    ammPublicFacet: ammFacets.ammPublicFacet,
+  };
+  const governorTerms = {
+    timer,
+    electorateInstance,
+    governedContractInstallation: installs.stablecoin,
+    governed: {
+      terms: treasuryTerms,
+      issuerKeywordRecord: {},
+      privateArgs: { feeMintAccess },
+    },
+  };
+
+  const { g, s } = await setupTreasury(
+    governorTerms,
+    installs,
+    zoe,
+    committeeCreator,
+  );
 
   const quoteMint = makeIssuerKit('quote', AssetKind.SET).mint;
 
@@ -267,7 +395,7 @@ async function setupServices(
   // stablecoinMachine has been built, so resolve priceAuthorityPromiseKit here
   const priceAuthority = makePriceAuthority(
     aethBrand,
-    runIssuerRecord.brand,
+    runBrand,
     priceList,
     timer,
     quoteMint,
@@ -282,9 +410,9 @@ async function setupServices(
     electorate,
     governor: g,
     stablecoin: s,
-    issuers,
+    ammFacets,
+    runKit: { issuer: runIssuer, brand: runBrand },
     priceAuthority,
-    autoswapAPI,
   };
 }
 
@@ -295,37 +423,40 @@ test('first', async t => {
   const loanParams = {
     chargingPeriod: 2n,
     recordingPeriod: 10n,
-    poolFee: 24n,
-    protocolFee: 6n,
   };
+
+  const aethInitialLiquidity = AmountMath.make(aethBrand, 300n);
+  const aethLiquidity = {
+    proposal: aethInitialLiquidity,
+    payment: aethMint.mintPayment(aethInitialLiquidity),
+  };
+
   const services = await setupServices(
     loanParams,
     [500n, 15n],
     AmountMath.make(aethBrand, 900n),
     aethBrand,
     { committeeName: 'TheCabal', committeeSize: 5 },
+    buildManualTimer(console.log),
+    undefined,
+    aethLiquidity,
+    500n,
+    aethIssuer,
   );
-  const { issuer: runIssuer, brand: runBrand } = services.issuers.run;
-  const { brand: govBrand } = services.issuers.gov;
-  const zoe = services.zoe;
+  const {
+    zoe,
+    runKit: { issuer: runIssuer, brand: runBrand },
+  } = services;
   const { stablecoinMachine, lender } = services.stablecoin;
 
-  // Add a pool with 900 aeth collateral at a 201 aeth/RUN rate
-  const capitalAmount = AmountMath.make(aethBrand, 900n);
-  const rates = makeRates(runBrand, aethBrand);
-  const aethVaultSeat = await E(zoe).offer(
-    E(stablecoinMachine).makeAddTypeInvitation(aethIssuer, 'AEth', rates),
-    harden({
-      give: { Collateral: capitalAmount },
-      want: { Governance: AmountMath.makeEmpty(govBrand) },
-    }),
-    harden({
-      Collateral: aethMint.mintPayment(capitalAmount),
-    }),
-  );
-
+  // Add a vault that will lend on aeth collateral
+  const rates = makeRates(runBrand);
   /** @type {VaultManager} */
-  const aethVaultManager = await E(aethVaultSeat).getOfferResult();
+  const aethVaultManager = await E(stablecoinMachine).addVaultType(
+    aethIssuer,
+    'AEth',
+    rates,
+  );
 
   // Create a loan for 470 RUN with 1100 aeth collateral
   const collateralAmount = AmountMath.make(aethBrand, 1100n);
@@ -343,7 +474,7 @@ test('first', async t => {
 
   const { vault } = await E(loanSeat).getOfferResult();
   const debtAmount = await E(vault).getDebtAmount();
-  const fee = multiplyBy(AmountMath.make(runBrand, 470n), rates.loanFee);
+  const fee = ceilMultiplyBy(AmountMath.make(runBrand, 470n), rates.loanFee);
   t.deepEqual(
     debtAmount,
     AmountMath.add(loanAmount, fee),
@@ -356,7 +487,7 @@ test('first', async t => {
   const runLent = await loanProceeds.RUN;
   t.deepEqual(lentAmount, loanAmount, 'received 47 RUN');
   t.deepEqual(
-    vault.getCollateralAmount(),
+    await E(vault).getCollateralAmount(),
     AmountMath.make(aethBrand, 1100n),
     'vault holds 1100 Collateral',
   );
@@ -373,7 +504,7 @@ test('first', async t => {
   );
 
   const seat = await E(zoe).offer(
-    vault.makeAdjustBalancesInvitation(),
+    await E(vault).makeAdjustBalancesInvitation(),
     harden({
       give: { RUN: paybackAmount },
       want: { Collateral: collateralWanted },
@@ -382,39 +513,49 @@ test('first', async t => {
       RUN: paybackPayment,
     }),
   );
-  await E(seat).getOfferResult();
 
-  const { Collateral: returnedCollateral } = await E(seat).getPayouts();
-  const returnedAmount = await aethIssuer.getAmountOf(returnedCollateral);
+  const payouts = E(seat).getPayouts();
+  const { Collateral: returnedCollateral, RUN: returnedRun } = await payouts;
   t.deepEqual(
-    vault.getDebtAmount(),
-    AmountMath.make(runBrand, 293n),
-    'debt reduced to 293 RUN',
+    await E(vault).getDebtAmount(),
+    AmountMath.make(runBrand, 294n),
+    'debt reduced to 294 RUN',
   );
   t.deepEqual(
-    vault.getCollateralAmount(),
+    await E(vault).getCollateralAmount(),
     AmountMath.make(aethBrand, 1000n),
     'vault holds 1000 Collateral',
   );
   t.deepEqual(
-    returnedAmount,
+    await aethIssuer.getAmountOf(returnedCollateral),
     AmountMath.make(aethBrand, 100n),
     'withdrew 100 collateral',
   );
+  t.deepEqual(
+    await E(runIssuer).getAmountOf(returnedRun),
+    AmountMath.makeEmpty(runBrand),
+    'received no run',
+  );
 
   await E(aethVaultManager).liquidateAll();
-  t.truthy(AmountMath.isEmpty(vault.getDebtAmount()), 'debt is paid off');
-  t.truthy(AmountMath.isEmpty(vault.getCollateralAmount()), 'vault is cleared');
+  t.truthy(
+    AmountMath.isEmpty(await E(vault).getDebtAmount()),
+    'debt is paid off',
+  );
+  t.truthy(
+    AmountMath.isEmpty(await E(vault).getCollateralAmount()),
+    'vault is cleared',
+  );
 
-  t.is(await vault.getLiquidationPromise(), 'Liquidated');
+  t.is(await E(vault).getLiquidationPromise(), 'Liquidated');
   const liquidations = await E(
-    vault.getLiquidationSeat(),
+    E(vault).getLiquidationSeat(),
   ).getCurrentAllocation();
-  t.deepEqual(liquidations.Collateral, AmountMath.make(aethBrand, 825n));
+  t.deepEqual(liquidations.Collateral, AmountMath.make(aethBrand, 566n));
   t.deepEqual(liquidations.RUN, AmountMath.makeEmpty(runBrand));
 
-  t.deepEqual(stablecoinMachine.getRewardAllocation(), {
-    RUN: AmountMath.make(runBrand, 23n),
+  t.deepEqual(await E(stablecoinMachine).getRewardAllocation(), {
+    RUN: AmountMath.make(runBrand, 24n),
   });
 });
 
@@ -430,8 +571,11 @@ test('price drop', async t => {
   const loanParams = {
     chargingPeriod: 2n,
     recordingPeriod: 10n,
-    poolFee: 24n,
-    protocolFee: 6n,
+  };
+  const aethInitialLiquidity = AmountMath.make(aethBrand, 300n);
+  const aethLiquidity = {
+    proposal: aethInitialLiquidity,
+    payment: aethMint.mintPayment(aethInitialLiquidity),
   };
 
   const services = await setupServices(
@@ -441,27 +585,21 @@ test('price drop', async t => {
     aethBrand,
     { committeeName: 'TheCabal', committeeSize: 5 },
     manualTimer,
+    undefined,
+    aethLiquidity,
+    500n,
+    aethIssuer,
   );
-  const { brand: runBrand } = services.issuers.run;
-  const { brand: govBrand } = services.issuers.gov;
-  const zoe = services.zoe;
+
+  const {
+    zoe,
+    runKit: { brand: runBrand },
+  } = services;
   const { stablecoinMachine, lender } = services.stablecoin;
 
-  // Add a pool with 900 aeth at a 201 RUN/aeth rate
-  const capitalAmount = AmountMath.make(aethBrand, 900n);
-  const rates = makeRates(runBrand, aethBrand);
-  const aethVaultSeat = await E(zoe).offer(
-    E(stablecoinMachine).makeAddTypeInvitation(aethIssuer, 'AEth', rates),
-    harden({
-      give: { Collateral: capitalAmount },
-      want: { Governance: AmountMath.makeEmpty(govBrand) },
-    }),
-    harden({
-      Collateral: aethMint.mintPayment(capitalAmount),
-    }),
-  );
-
-  await E(aethVaultSeat).getOfferResult();
+  // Add a vault that will lend on aeth collateral
+  const rates = makeRates(runBrand);
+  await E(stablecoinMachine).addVaultType(aethIssuer, 'AEth', rates);
 
   // Create a loan for 270 RUN with 400 aeth collateral
   const collateralAmount = AmountMath.make(aethBrand, 400n);
@@ -479,50 +617,50 @@ test('price drop', async t => {
 
   const { vault, uiNotifier } = await E(loanSeat).getOfferResult();
   const debtAmount = await E(vault).getDebtAmount();
-  const fee = multiplyBy(AmountMath.make(runBrand, 270n), rates.loanFee);
+  const fee = ceilMultiplyBy(AmountMath.make(runBrand, 270n), rates.loanFee);
   t.deepEqual(
     debtAmount,
     AmountMath.add(loanAmount, fee),
-    'borrower owes 283 RUN',
+    'borrower RUN amount does not match',
   );
 
-  const notification1 = await uiNotifier.getUpdateSince();
+  const notification1 = await E(uiNotifier).getUpdateSince();
   t.falsy(notification1.value.liquidated);
   t.deepEqual(
     await notification1.value.collateralizationRatio,
-    makeRatio(444n, runBrand, 283n),
+    makeRatio(444n, runBrand, 284n),
   );
   const { RUN: lentAmount } = await E(loanSeat).getCurrentAllocation();
   t.truthy(AmountMath.isEqual(lentAmount, loanAmount), 'received 470 RUN');
   t.deepEqual(
-    vault.getCollateralAmount(),
+    await E(vault).getCollateralAmount(),
     AmountMath.make(aethBrand, 400n),
     'vault holds 11 Collateral',
   );
 
   await manualTimer.tick();
-  const notification2 = await uiNotifier.getUpdateSince();
+  const notification2 = await E(uiNotifier).getUpdateSince();
   t.is(notification2.updateCount, 2);
   t.falsy(notification2.value.liquidated);
 
   await manualTimer.tick();
-  const notification3 = await uiNotifier.getUpdateSince();
+  const notification3 = await E(uiNotifier).getUpdateSince();
   t.is(notification3.updateCount, 2);
   t.falsy(notification3.value.liquidated);
 
   await manualTimer.tick();
-  const notification4 = await uiNotifier.getUpdateSince(2);
+  const notification4 = await E(uiNotifier).getUpdateSince(2);
   t.falsy(notification4.value.liquidated);
   t.is(notification4.value.vaultState, VaultState.LIQUIDATING);
 
   await manualTimer.tick();
-  const notification5 = await uiNotifier.getUpdateSince(3);
+  const notification5 = await E(uiNotifier).getUpdateSince(3);
 
   t.falsy(notification5.updateCount);
   t.truthy(notification5.value.liquidated);
 
   const debtAmountAfter = await E(vault).getDebtAmount();
-  const finalNotification = await uiNotifier.getUpdateSince();
+  const finalNotification = await E(uiNotifier).getUpdateSince();
   t.truthy(finalNotification.value.liquidated);
   t.deepEqual(
     await finalNotification.value.collateralizationRatio,
@@ -530,15 +668,15 @@ test('price drop', async t => {
   );
   t.truthy(AmountMath.isEmpty(debtAmountAfter));
 
-  t.deepEqual(stablecoinMachine.getRewardAllocation(), {
-    RUN: AmountMath.make(runBrand, 13n),
+  t.deepEqual(await E(stablecoinMachine).getRewardAllocation(), {
+    RUN: AmountMath.make(runBrand, 14n),
   });
 
-  t.is(await vault.getLiquidationPromise(), 'Liquidated');
+  t.is(await E(vault).getLiquidationPromise(), 'Liquidated');
   const liquidations = await E(
-    vault.getLiquidationSeat(),
+    E(vault).getLiquidationSeat(),
   ).getCurrentAllocation();
-  t.deepEqual(liquidations.Collateral, AmountMath.make(aethBrand, 232n));
+  t.deepEqual(liquidations.Collateral, AmountMath.make(aethBrand, 1n));
   t.deepEqual(liquidations.RUN, AmountMath.makeEmpty(runBrand));
 });
 
@@ -549,8 +687,6 @@ test('price falls precipitously', async t => {
   const loanParams = {
     chargingPeriod: 2n,
     recordingPeriod: 10n,
-    poolFee: 24n,
-    protocolFee: 6n,
   };
 
   // The borrower will deposit 4 Aeth, and ask to borrow 470 RUN. The
@@ -562,6 +698,11 @@ test('price falls precipitously', async t => {
   // gets 41 back
 
   const manualTimer = buildManualTimer(console.log);
+  const aethInitialLiquidity = AmountMath.make(aethBrand, 900n);
+  const aethLiquidity = {
+    proposal: aethInitialLiquidity,
+    payment: aethMint.mintPayment(aethInitialLiquidity),
+  };
   const services = await setupServices(
     loanParams,
     [2200n, 19180n, 1650n, 150n],
@@ -569,28 +710,20 @@ test('price falls precipitously', async t => {
     aethBrand,
     { committeeName: 'TheCabal', committeeSize: 5 },
     manualTimer,
+    undefined,
+    aethLiquidity,
+    1500n,
+    aethIssuer,
   );
-  const { brand: runBrand } = services.issuers.run;
-  const { brand: govBrand } = services.issuers.gov;
-  const zoe = services.zoe;
+  const {
+    zoe,
+    runKit: { brand: runBrand },
+  } = services;
   const { stablecoinMachine, lender } = services.stablecoin;
 
-  // Add a pool with 900 aeth at a 201 RUN/aeth rate
-  const capitalAmount = AmountMath.make(aethBrand, 900n);
-  const rates = makeRates(runBrand, aethBrand);
-  const aethVaultSeat = await E(zoe).offer(
-    E(stablecoinMachine).makeAddTypeInvitation(aethIssuer, 'AEth', rates),
-    harden({
-      give: { Collateral: capitalAmount },
-      want: { Governance: AmountMath.makeEmpty(govBrand) },
-    }),
-    harden({
-      Collateral: aethMint.mintPayment(capitalAmount),
-    }),
-  );
-
-  /** @type {VaultManager} */
-  await E(aethVaultSeat).getOfferResult();
+  // Add a vault that will lend on aeth collateral
+  const rates = makeRates(runBrand);
+  await E(stablecoinMachine).addVaultType(aethIssuer, 'AEth', rates);
 
   // Create a loan for 370 RUN with 400 aeth collateral
   const collateralAmount = AmountMath.make(aethBrand, 400n);
@@ -608,7 +741,7 @@ test('price falls precipitously', async t => {
 
   const { vault } = await E(loanSeat).getOfferResult();
   const debtAmount = await E(vault).getDebtAmount();
-  const fee = multiplyBy(AmountMath.make(runBrand, 370n), rates.loanFee);
+  const fee = ceilMultiplyBy(AmountMath.make(runBrand, 370n), rates.loanFee);
   t.deepEqual(
     debtAmount,
     AmountMath.add(loanAmount, fee),
@@ -619,19 +752,21 @@ test('price falls precipitously', async t => {
   const { RUN: lentAmount } = await E(loanSeat).getCurrentAllocation();
   t.deepEqual(lentAmount, loanAmount, 'received 470 RUN');
   t.deepEqual(
-    vault.getCollateralAmount(),
+    await E(vault).getCollateralAmount(),
     AmountMath.make(aethBrand, 400n),
     'vault holds 400 Collateral',
   );
 
   // Sell some Eth to drive the value down
-  const swapInvitation = E(services.autoswapAPI).makeSwapInvitation();
+  const swapInvitation = E(
+    services.ammFacets.ammPublicFacet,
+  ).makeSwapInvitation();
   const proposal = harden({
     give: { In: AmountMath.make(aethBrand, 200n) },
     want: { Out: AmountMath.makeEmpty(runBrand) },
   });
   await E(zoe).offer(
-    swapInvitation,
+    await swapInvitation,
     proposal,
     harden({
       In: aethMint.mintPayment(AmountMath.make(aethBrand, 200n)),
@@ -646,18 +781,21 @@ test('price falls precipitously', async t => {
   t.falsy(AmountMath.isEmpty(await E(vault).getDebtAmount()));
   await manualTimer.tick();
 
-  t.is(await vault.getLiquidationPromise(), 'Liquidated');
+  t.is(await E(vault).getLiquidationPromise(), 'Liquidated');
 
-  t.truthy(AmountMath.isEmpty(await E(vault).getDebtAmount()));
+  // An emergency liquidation got less than full value
+  const newDebtAmount = await E(vault).getDebtAmount();
 
-  t.deepEqual(stablecoinMachine.getRewardAllocation(), {
-    RUN: AmountMath.make(runBrand, 18n),
+  t.truthy(AmountMath.isGTE(AmountMath.make(runBrand, 70n), newDebtAmount));
+
+  t.deepEqual(await E(stablecoinMachine).getRewardAllocation(), {
+    RUN: AmountMath.make(runBrand, 19n),
   });
 
   const liquidations = await E(
-    vault.getLiquidationSeat(),
+    E(vault).getLiquidationSeat(),
   ).getCurrentAllocation();
-  t.deepEqual(liquidations.Collateral, AmountMath.make(aethBrand, 8n));
+  t.deepEqual(liquidations.Collateral, AmountMath.make(aethBrand, 1n));
   t.deepEqual(liquidations.RUN, AmountMath.makeEmpty(runBrand));
 });
 
@@ -665,12 +803,15 @@ test('stablecoin display collateral', async t => {
   const loanParams = {
     chargingPeriod: 2n,
     recordingPeriod: 6n,
-    poolFee: 24n,
-    protocolFee: 6n,
   };
   const {
     aethKit: { mint: aethMint, issuer: aethIssuer, brand: aethBrand },
   } = setupAssets();
+  const aethInitialLiquidity = AmountMath.make(aethBrand, 900n);
+  const aethLiquidity = {
+    proposal: aethInitialLiquidity,
+    payment: aethMint.mintPayment(aethInitialLiquidity),
+  };
 
   const services = await setupServices(
     loanParams,
@@ -678,33 +819,26 @@ test('stablecoin display collateral', async t => {
     AmountMath.make(aethBrand, 90n),
     aethBrand,
     { committeeName: 'TheCabal', committeeSize: 5 },
+    buildManualTimer(console.log),
+    undefined,
+    aethLiquidity,
+    500n,
+    aethIssuer,
   );
-  const { brand: runBrand } = services.issuers.run;
-  const { brand: govBrand } = services.issuers.gov;
-  const zoe = services.zoe;
+
+  const {
+    runKit: { brand: runBrand },
+  } = services;
   const { stablecoinMachine } = services.stablecoin;
 
-  // Add a vaultManager with 900 aeth collateral at a 201 aeth/RUN rate
-  const capitalAmount = AmountMath.make(aethBrand, 900n);
   const rates = harden({
-    initialPrice: makeRatio(201n, runBrand, PERCENT, aethBrand),
     initialMargin: makeRatio(120n, runBrand),
     liquidationMargin: makeRatio(105n, runBrand),
     interestRate: makeRatio(100n, runBrand, BASIS_POINTS),
     loanFee: makeRatio(530n, runBrand, BASIS_POINTS),
   });
-  const aethVaultManagerSeat = await E(zoe).offer(
-    E(stablecoinMachine).makeAddTypeInvitation(aethIssuer, 'AEth', rates),
-    harden({
-      give: { Collateral: capitalAmount },
-      want: { Governance: AmountMath.makeEmpty(govBrand) },
-    }),
-    harden({
-      Collateral: aethMint.mintPayment(capitalAmount),
-    }),
-  );
 
-  await E(aethVaultManagerSeat).getOfferResult();
+  await E(stablecoinMachine).addVaultType(aethIssuer, 'AEth', rates);
 
   const collaterals = await E(stablecoinMachine).getCollaterals();
 
@@ -720,19 +854,23 @@ test('stablecoin display collateral', async t => {
 
 // charging period is 1 week. Clock ticks by days
 test('interest on multiple vaults', async t => {
+  const {
+    aethKit: { mint: aethMint, issuer: aethIssuer, brand: aethBrand },
+  } = setupAssets();
   const secondsPerDay = SECONDS_PER_YEAR / 365n;
   const loanParams = {
     chargingPeriod: secondsPerDay * 7n,
     recordingPeriod: secondsPerDay * 7n,
-    poolFee: 24n,
-    protocolFee: 6n,
   };
   // Clock ticks by days
   const manualTimer = buildManualTimer(console.log, 0n, secondsPerDay);
 
-  const {
-    aethKit: { mint: aethMint, issuer: aethIssuer, brand: aethBrand },
-  } = setupAssets();
+  const aethInitialLiquidity = AmountMath.make(aethBrand, 300n);
+  const aethLiquidity = {
+    proposal: aethInitialLiquidity,
+    payment: aethMint.mintPayment(aethInitialLiquidity),
+  };
+
   const services = await setupServices(
     loanParams,
     [500n, 1500n],
@@ -741,34 +879,24 @@ test('interest on multiple vaults', async t => {
     { committeeName: 'TheCabal', committeeSize: 5 },
     manualTimer,
     secondsPerDay,
+    aethLiquidity,
+    500n,
+    aethIssuer,
   );
-  const { issuer: runIssuer, brand: runBrand } = services.issuers.run;
-  const { brand: govBrand } = services.issuers.gov;
-  const zoe = services.zoe;
+  const {
+    zoe,
+    runKit: { issuer: runIssuer, brand: runBrand },
+  } = services;
   const { stablecoinMachine, lender } = services.stablecoin;
 
-  // Add a vaultManager with 900 aeth collateral at a 201 aeth/RUN rate
-  const capitalAmount = AmountMath.make(aethBrand, 900n);
   const interestRate = makeRatio(5n, runBrand);
   const rates = harden({
-    initialPrice: makeRatio(201n, runBrand, PERCENT, aethBrand),
     initialMargin: makeRatio(120n, runBrand),
     liquidationMargin: makeRatio(105n, runBrand),
     interestRate,
     loanFee: makeRatio(500n, runBrand, BASIS_POINTS),
   });
-  const aethVaultManagerSeat = await E(zoe).offer(
-    E(stablecoinMachine).makeAddTypeInvitation(aethIssuer, 'AEth', rates),
-    harden({
-      give: { Collateral: capitalAmount },
-      want: { Governance: AmountMath.makeEmpty(govBrand) },
-    }),
-    harden({
-      Collateral: aethMint.mintPayment(capitalAmount),
-    }),
-  );
-
-  await E(aethVaultManagerSeat).getOfferResult();
+  await E(stablecoinMachine).addVaultType(aethIssuer, 'AEth', rates);
 
   // Create a loan for Alice for 4700 RUN with 1100 aeth collateral
   const collateralAmount = AmountMath.make(aethBrand, 1100n);
@@ -788,7 +916,7 @@ test('interest on multiple vaults', async t => {
   ).getOfferResult();
 
   const debtAmount = await E(aliceVault).getDebtAmount();
-  const fee = multiplyBy(aliceLoanAmount, rates.loanFee);
+  const fee = ceilMultiplyBy(aliceLoanAmount, rates.loanFee);
   t.deepEqual(
     debtAmount,
     AmountMath.add(aliceLoanAmount, fee),
@@ -825,7 +953,7 @@ test('interest on multiple vaults', async t => {
   ).getOfferResult();
 
   const bobDebtAmount = await E(bobVault).getDebtAmount();
-  const bobFee = multiplyBy(bobLoanAmount, rates.loanFee);
+  const bobFee = ceilMultiplyBy(bobLoanAmount, rates.loanFee);
   t.deepEqual(
     bobDebtAmount,
     AmountMath.add(bobLoanAmount, bobFee),
@@ -850,10 +978,10 @@ test('interest on multiple vaults', async t => {
   }
   await waitForPromisesToSettle();
 
-  const aliceUpdate = await aliceNotifier.getUpdateSince();
-  const bobUpdate = await bobNotifier.getUpdateSince();
+  const aliceUpdate = await E(aliceNotifier).getUpdateSince();
+  const bobUpdate = await E(bobNotifier).getUpdateSince();
   // 160 is initial fee. interest is 3n/week. compounding is in the noise.
-  const bobAddedDebt = 160n + 3n;
+  const bobAddedDebt = 160n + 4n;
   t.deepEqual(
     bobUpdate.value.debt,
     AmountMath.make(runBrand, 3200n + bobAddedDebt),
@@ -869,8 +997,8 @@ test('interest on multiple vaults', async t => {
       bobCollateralization.denominator.value,
   );
 
-  // 235 is the initial fee. Interest is 4n/week
-  const aliceAddedDebt = 235n + 4n;
+  // 236 is the initial fee. Interest is 4n/week
+  const aliceAddedDebt = 236n + 4n;
   t.deepEqual(
     aliceUpdate.value.debt,
     AmountMath.make(runBrand, 4700n + aliceAddedDebt),
@@ -884,15 +1012,14 @@ test('interest on multiple vaults', async t => {
       aliceCollateralization.denominator.value,
   );
 
+  const rewardAllocation = await E(stablecoinMachine).getRewardAllocation();
   t.truthy(
     AmountMath.isEqual(
-      stablecoinMachine.getRewardAllocation().RUN,
+      rewardAllocation.RUN,
       AmountMath.make(runBrand, aliceAddedDebt + bobAddedDebt),
     ),
     // reward includes 5% fees on two loans plus 1% interest three times on each
-    `Should be ${aliceAddedDebt + bobAddedDebt}, was ${
-      stablecoinMachine.getRewardAllocation().value
-    }`,
+    `Should be ${aliceAddedDebt + bobAddedDebt}, was ${rewardAllocation.RUN}`,
   );
 });
 
@@ -900,41 +1027,38 @@ test('adjust balances', async t => {
   const loanParams = {
     chargingPeriod: 2n,
     recordingPeriod: 6n,
-    poolFee: 24n,
-    protocolFee: 6n,
   };
 
   const {
     aethKit: { mint: aethMint, issuer: aethIssuer, brand: aethBrand },
   } = setupAssets();
+  const aethInitialLiquidity = AmountMath.make(aethBrand, 300n);
+  const aethLiquidity = {
+    proposal: aethInitialLiquidity,
+    payment: aethMint.mintPayment(aethInitialLiquidity),
+  };
+
   const services = await setupServices(
     loanParams,
     [15n],
     AmountMath.make(aethBrand, 1n),
     aethBrand,
     { committeeName: 'TheCabal', committeeSize: 5 },
+    buildManualTimer(console.log),
+    undefined,
+    aethLiquidity,
+    500n,
+    aethIssuer,
   );
-  const { issuer: runIssuer, brand: runBrand } = services.issuers.run;
-  const { brand: govBrand } = services.issuers.gov;
-  const zoe = services.zoe;
+  const {
+    zoe,
+    runKit: { issuer: runIssuer, brand: runBrand },
+  } = services;
   const { stablecoinMachine, lender } = services.stablecoin;
 
   const priceConversion = makeRatio(15n, runBrand, 1n, aethBrand);
-  // Add a vaultManager with 900 aeth collateral at a 201 aeth/RUN rate
-  const capitalAmount = AmountMath.make(aethBrand, 900n);
-  const rates = makeRates(runBrand, aethBrand);
-  const aethVaultManagerSeat = await E(zoe).offer(
-    E(stablecoinMachine).makeAddTypeInvitation(aethIssuer, 'AEth', rates),
-    harden({
-      give: { Collateral: capitalAmount },
-      want: { Governance: AmountMath.makeEmpty(govBrand) },
-    }),
-    harden({
-      Collateral: aethMint.mintPayment(capitalAmount),
-    }),
-  );
-
-  await E(aethVaultManagerSeat).getOfferResult();
+  const rates = makeRates(runBrand);
+  await E(stablecoinMachine).addVaultType(aethIssuer, 'AEth', rates);
 
   // initial loan /////////////////////////////////////
 
@@ -956,7 +1080,7 @@ test('adjust balances', async t => {
   ).getOfferResult();
 
   let debtAmount = await E(aliceVault).getDebtAmount();
-  const fee = multiplyBy(aliceLoanAmount, rates.loanFee);
+  const fee = ceilMultiplyBy(aliceLoanAmount, rates.loanFee);
   let runDebtLevel = AmountMath.add(aliceLoanAmount, fee);
   let collateralLevel = AmountMath.make(aethBrand, 1000n);
 
@@ -973,7 +1097,7 @@ test('adjust balances', async t => {
     ),
   );
 
-  let aliceUpdate = await aliceNotifier.getUpdateSince();
+  let aliceUpdate = await E(aliceNotifier).getUpdateSince();
   t.deepEqual(aliceUpdate.value.debt, runDebtLevel);
   const aliceCollateralization1 = aliceUpdate.value.collateralizationRatio;
   t.deepEqual(aliceCollateralization1.numerator.value, 15000n);
@@ -1021,12 +1145,12 @@ test('adjust balances', async t => {
     ),
   );
 
-  aliceUpdate = await aliceNotifier.getUpdateSince();
+  aliceUpdate = await E(aliceNotifier).getUpdateSince();
   t.deepEqual(aliceUpdate.value.debt, runDebtLevel);
   const aliceCollateralization2 = aliceUpdate.value.collateralizationRatio;
   t.deepEqual(
     aliceCollateralization2.numerator,
-    multiplyBy(collateralLevel, priceConversion),
+    ceilMultiplyBy(collateralLevel, priceConversion),
   );
   t.deepEqual(aliceCollateralization2.denominator, runDebtLevel);
 
@@ -1035,7 +1159,7 @@ test('adjust balances', async t => {
   // Alice increase collateral by 100, withdrawing 50 RUN
   const collateralIncrement2 = AmountMath.make(aethBrand, 100n);
   const withdrawRunAmount = AmountMath.make(runBrand, 50n);
-  const withdrawRunAmountWithFees = multiplyBy(
+  const withdrawRunAmountWithFees = ceilMultiplyBy(
     withdrawRunAmount,
     rates.loanFee,
   );
@@ -1074,12 +1198,12 @@ test('adjust balances', async t => {
     ),
   );
 
-  aliceUpdate = await aliceNotifier.getUpdateSince();
+  aliceUpdate = await E(aliceNotifier).getUpdateSince();
   t.deepEqual(aliceUpdate.value.debt, runDebtLevel);
   const aliceCollateralization3 = aliceUpdate.value.collateralizationRatio;
   t.deepEqual(
     aliceCollateralization3.numerator,
-    multiplyBy(collateralLevel, priceConversion),
+    ceilMultiplyBy(collateralLevel, priceConversion),
   );
   t.deepEqual(aliceCollateralization3.denominator, runDebtLevel);
 
@@ -1088,7 +1212,7 @@ test('adjust balances', async t => {
   // Alice reduce collateral by 100, withdrawing 50 RUN
   const collateralDecrement = AmountMath.make(aethBrand, 100n);
   const withdrawRun2 = AmountMath.make(runBrand, 50n);
-  const withdrawRun2WithFees = multiplyBy(withdrawRun2, rates.loanFee);
+  const withdrawRun2WithFees = ceilMultiplyBy(withdrawRun2, rates.loanFee);
   runDebtLevel = AmountMath.add(
     runDebtLevel,
     AmountMath.add(withdrawRunAmount, withdrawRun2WithFees),
@@ -1128,12 +1252,12 @@ test('adjust balances', async t => {
     ),
   );
 
-  aliceUpdate = await aliceNotifier.getUpdateSince();
+  aliceUpdate = await E(aliceNotifier).getUpdateSince();
   t.deepEqual(aliceUpdate.value.debt, runDebtLevel);
   const aliceCollateralization4 = aliceUpdate.value.collateralizationRatio;
   t.deepEqual(
     aliceCollateralization4.numerator,
-    multiplyBy(collateralLevel, priceConversion),
+    ceilMultiplyBy(collateralLevel, priceConversion),
   );
   t.deepEqual(aliceCollateralization4.denominator, runDebtLevel);
 
@@ -1142,7 +1266,7 @@ test('adjust balances', async t => {
   // Alice reduce collateral by 100, withdrawing 50 RUN
   const collateralDecr2 = AmountMath.make(aethBrand, 800n);
   const withdrawRun3 = AmountMath.make(runBrand, 500n);
-  const withdrawRun3WithFees = multiplyBy(withdrawRun3, rates.loanFee);
+  const withdrawRun3WithFees = ceilMultiplyBy(withdrawRun3, rates.loanFee);
   runDebtLevel = AmountMath.add(
     runDebtLevel,
     AmountMath.add(withdrawRunAmount, withdrawRun3WithFees),
@@ -1160,7 +1284,8 @@ test('adjust balances', async t => {
     // wildcards were:
     // "brand":"[Alleged: RUN brand]","value":"[5829n]"
     // "value":"[3750n]","brand":"[Alleged: RUN brand]"
-    message: /The requested debt {.*} is more than the collateralization ratio allows: {.*}/,
+    message: / is more than the collateralization ratio allows:/,
+    // message: /The requested debt {.*} is more than the collateralization ratio allows: {.*}/,
   });
 });
 
@@ -1170,40 +1295,37 @@ test('overdeposit', async t => {
   const loanParams = {
     chargingPeriod: 2n,
     recordingPeriod: 6n,
-    poolFee: 24n,
-    protocolFee: 6n,
   };
 
   const {
     aethKit: { mint: aethMint, issuer: aethIssuer, brand: aethBrand },
   } = setupAssets();
+  const aethInitialLiquidity = AmountMath.make(aethBrand, 300n);
+  const aethLiquidity = {
+    proposal: aethInitialLiquidity,
+    payment: aethMint.mintPayment(aethInitialLiquidity),
+  };
+
   const services = await setupServices(
     loanParams,
     [15n],
     AmountMath.make(aethBrand, 1n),
     aethBrand,
     { committeeName: 'TheCabal', committeeSize: 5 },
+    buildManualTimer(console.log),
+    undefined,
+    aethLiquidity,
+    500n,
+    aethIssuer,
   );
-  const { issuer: runIssuer, brand: runBrand } = services.issuers.run;
-  const { brand: govBrand } = services.issuers.gov;
-  const zoe = services.zoe;
+  const {
+    zoe,
+    runKit: { issuer: runIssuer, brand: runBrand },
+  } = services;
   const { stablecoinMachine, lender } = services.stablecoin;
 
-  // Add a vaultManager with 900 aeth collateral at a 201 aeth/RUN rate
-  const capitalAmount = AmountMath.make(aethBrand, 900n);
-  const rates = makeRates(runBrand, aethBrand);
-  const aethVaultManagerSeat = await E(zoe).offer(
-    E(stablecoinMachine).makeAddTypeInvitation(aethIssuer, 'AEth', rates),
-    harden({
-      give: { Collateral: capitalAmount },
-      want: { Governance: AmountMath.makeEmpty(govBrand) },
-    }),
-    harden({
-      Collateral: aethMint.mintPayment(capitalAmount),
-    }),
-  );
-
-  await E(aethVaultManagerSeat).getOfferResult();
+  const rates = makeRates(runBrand);
+  await E(stablecoinMachine).addVaultType(aethIssuer, 'AEth', rates);
 
   // Alice's loan /////////////////////////////////////
 
@@ -1225,7 +1347,7 @@ test('overdeposit', async t => {
   ).getOfferResult();
 
   let debtAmount = await E(aliceVault).getDebtAmount();
-  const fee = multiplyBy(aliceLoanAmount, rates.loanFee);
+  const fee = ceilMultiplyBy(aliceLoanAmount, rates.loanFee);
   const runDebt = AmountMath.add(aliceLoanAmount, fee);
 
   t.deepEqual(debtAmount, runDebt, 'vault lent 5000 RUN + fees');
@@ -1241,7 +1363,7 @@ test('overdeposit', async t => {
     ),
   );
 
-  let aliceUpdate = await aliceNotifier.getUpdateSince();
+  let aliceUpdate = await E(aliceNotifier).getUpdateSince();
   t.deepEqual(aliceUpdate.value.debt, runDebt);
   const aliceCollateralization1 = aliceUpdate.value.collateralizationRatio;
   t.deepEqual(aliceCollateralization1.numerator.value, 15000n);
@@ -1299,7 +1421,7 @@ test('overdeposit', async t => {
     AmountMath.make(runBrand, 750n),
   );
 
-  aliceUpdate = await aliceNotifier.getUpdateSince();
+  aliceUpdate = await E(aliceNotifier).getUpdateSince();
   t.deepEqual(aliceUpdate.value.debt, AmountMath.makeEmpty(runBrand));
   const aliceCollateralization5 = aliceUpdate.value.collateralizationRatio;
   t.deepEqual(
@@ -1331,13 +1453,16 @@ test('mutable liquidity triggers and interest', async t => {
   const {
     aethKit: { mint: aethMint, issuer: aethIssuer, brand: aethBrand },
   } = setupAssets();
+  const aethInitialLiquidity = AmountMath.make(aethBrand, 300n);
+  const aethLiquidity = {
+    proposal: aethInitialLiquidity,
+    payment: aethMint.mintPayment(aethInitialLiquidity),
+  };
 
   const secondsPerDay = SECONDS_PER_YEAR / 365n;
   const loanParams = {
     chargingPeriod: secondsPerDay * 7n,
     recordingPeriod: secondsPerDay * 7n,
-    poolFee: 24n,
-    protocolFee: 6n,
   };
   // charge interest on every tick
   const manualTimer = buildManualTimer(console.log, 0n, secondsPerDay * 7n);
@@ -1346,19 +1471,25 @@ test('mutable liquidity triggers and interest', async t => {
     [10n, 7n],
     AmountMath.make(aethBrand, 1n),
     aethBrand,
-    { committeeName: 'TheCabal', committeeSize: 5 },
+    {
+      committeeName: 'TheCabal',
+      committeeSize: 5,
+    },
     manualTimer,
     secondsPerDay * 7n,
+    aethLiquidity,
+    500n,
+    aethIssuer,
   );
-  const { issuer: runIssuer, brand: runBrand } = services.issuers.run;
-  const { brand: govBrand } = services.issuers.gov;
-  const zoe = services.zoe;
+
+  const {
+    zoe,
+    runKit: { issuer: runIssuer, brand: runBrand },
+  } = services;
   const { stablecoinMachine, lender } = services.stablecoin;
 
   // Add a vaultManager with 10000 aeth collateral at a 200 aeth/RUN rate
-  const capitalAmount = AmountMath.make(aethBrand, 10000n);
   const rates = harden({
-    initialPrice: makeRatio(200n, runBrand, PERCENT, aethBrand),
     initialMargin: makeRatio(120n, runBrand),
     liquidationMargin: makeRatio(105n, runBrand),
     // charge 5% interest
@@ -1366,18 +1497,7 @@ test('mutable liquidity triggers and interest', async t => {
     loanFee: makeRatio(500n, runBrand, BASIS_POINTS),
   });
 
-  const aethVaultManagerSeat = await E(zoe).offer(
-    E(stablecoinMachine).makeAddTypeInvitation(aethIssuer, 'AEth', rates),
-    harden({
-      give: { Collateral: capitalAmount },
-      want: { Governance: AmountMath.makeEmpty(govBrand) },
-    }),
-    harden({
-      Collateral: aethMint.mintPayment(capitalAmount),
-    }),
-  );
-
-  await E(aethVaultManagerSeat).getOfferResult();
+  await E(stablecoinMachine).addVaultType(aethIssuer, 'AEth', rates);
 
   // initial loans /////////////////////////////////////
 
@@ -1399,7 +1519,7 @@ test('mutable liquidity triggers and interest', async t => {
   ).getOfferResult();
 
   const aliceDebtAmount = await E(aliceVault).getDebtAmount();
-  const fee = multiplyBy(aliceLoanAmount, rates.loanFee);
+  const fee = ceilMultiplyBy(aliceLoanAmount, rates.loanFee);
   const aliceRunDebtLevel = AmountMath.add(aliceLoanAmount, fee);
   let aliceCollateralLevel = AmountMath.make(aethBrand, 1000n);
 
@@ -1418,7 +1538,7 @@ test('mutable liquidity triggers and interest', async t => {
     ),
   );
 
-  let aliceUpdate = await aliceNotifier.getUpdateSince();
+  let aliceUpdate = await E(aliceNotifier).getUpdateSince();
   t.deepEqual(aliceUpdate.value.debt, aliceRunDebtLevel);
 
   // Create a loan for Bob for 740 RUN with 100 Aeth collateral
@@ -1439,7 +1559,7 @@ test('mutable liquidity triggers and interest', async t => {
   ).getOfferResult();
 
   const bobDebtAmount = await E(bobVault).getDebtAmount();
-  const bobFee = multiplyBy(bobLoanAmount, rates.loanFee);
+  const bobFee = ceilMultiplyBy(bobLoanAmount, rates.loanFee);
   const bobRunDebtLevel = AmountMath.add(bobLoanAmount, bobFee);
 
   t.deepEqual(bobDebtAmount, bobRunDebtLevel, 'vault lent 5000 RUN + fees');
@@ -1455,7 +1575,7 @@ test('mutable liquidity triggers and interest', async t => {
     ),
   );
 
-  let bobUpdate = await bobNotifier.getUpdateSince();
+  let bobUpdate = await E(bobNotifier).getUpdateSince();
   t.deepEqual(bobUpdate.value.debt, bobRunDebtLevel);
 
   // reduce collateral  /////////////////////////////////////
@@ -1490,12 +1610,15 @@ test('mutable liquidity triggers and interest', async t => {
     ),
   );
 
-  aliceUpdate = await aliceNotifier.getUpdateSince();
+  aliceUpdate = await E(aliceNotifier).getUpdateSince();
   t.deepEqual(aliceUpdate.value.debt, aliceRunDebtLevel);
   const aliceCollateralization4 = aliceUpdate.value.collateralizationRatio;
   t.deepEqual(
     aliceCollateralization4.numerator,
-    multiplyBy(aliceCollateralLevel, makeRatio(10n, runBrand, 1n, aethBrand)),
+    ceilMultiplyBy(
+      aliceCollateralLevel,
+      makeRatio(10n, runBrand, 1n, aethBrand),
+    ),
   );
   t.deepEqual(aliceCollateralization4.denominator, aliceRunDebtLevel);
 
@@ -1503,7 +1626,7 @@ test('mutable liquidity triggers and interest', async t => {
   // price levels changed and interest was charged.
 
   // expect Alice to be liquidated because her collateral is too low.
-  aliceUpdate = await aliceNotifier.getUpdateSince();
+  aliceUpdate = await E(aliceNotifier).getUpdateSince();
 
   // Bob's loan is now 777 RUN (including interest) on 100 Aeth, with the price
   // at 7. 100 * 7 > 1.05 * 777. When interest is charged again, Bob should get
@@ -1513,15 +1636,15 @@ test('mutable liquidity triggers and interest', async t => {
     manualTimer.tick();
   }
   await waitForPromisesToSettle();
-  aliceUpdate = await aliceNotifier.getUpdateSince(aliceUpdate.updateCount);
-  bobUpdate = await bobNotifier.getUpdateSince();
+  aliceUpdate = await E(aliceNotifier).getUpdateSince(aliceUpdate.updateCount);
+  bobUpdate = await E(bobNotifier).getUpdateSince();
   t.truthy(aliceUpdate.value.liquidated);
 
   for (let i = 0; i < 5; i += 1) {
     manualTimer.tick();
   }
   await waitForPromisesToSettle();
-  bobUpdate = await bobNotifier.getUpdateSince();
+  bobUpdate = await E(bobNotifier).getUpdateSince();
 
   t.truthy(bobUpdate.value.liquidated);
 });
@@ -1530,12 +1653,12 @@ test('bad chargingPeriod', async t => {
   const setJig = () => {};
   const { zoe, feeMintAccess } = await setUpZoeForTest(setJig);
 
-  const [
-    autoswapInstall,
-    stablecoinInstall,
-    liquidationInstall,
-  ] = await Promise.all([
-    installBundle(zoe, autoswapBundle),
+  const [stablecoinBundle, liquidationBundle] = await Promise.all([
+    stablecoinBundleP,
+    liquidationBundleP,
+  ]);
+
+  const [stablecoinInstall, liquidationInstall] = await Promise.all([
     installBundle(zoe, stablecoinBundle),
     installBundle(zoe, liquidationBundle),
   ]);
@@ -1545,8 +1668,6 @@ test('bad chargingPeriod', async t => {
   const loanParams = {
     chargingPeriod: 2,
     recordingPeriod: 10n,
-    poolFee: 24n,
-    protocolFee: 6n,
   };
   const manualTimer = buildManualTimer(console.log);
 
@@ -1556,7 +1677,6 @@ test('bad chargingPeriod', async t => {
         stablecoinInstall,
         harden({}),
         harden({
-          autoswapInstall,
           priceAuthority: priceAuthorityPromise,
           loanParams,
           timerService: manualTimer,
@@ -1569,12 +1689,10 @@ test('bad chargingPeriod', async t => {
   );
 });
 
-test('coll fees from loan and AMM', async t => {
+test('collect fees from loan and AMM', async t => {
   const loanParams = {
     chargingPeriod: 2n,
     recordingPeriod: 10n,
-    poolFee: 24n,
-    protocolFee: 6n,
   };
 
   const {
@@ -1584,6 +1702,11 @@ test('coll fees from loan and AMM', async t => {
   const unitAmountIn = AmountMath.make(aethBrand, 900n);
   const electorateTerms = { committeeName: 'TheCabal', committeeSize: 5 };
   const manualTimer = buildManualTimer(console.log);
+  const aethInitialLiquidity = AmountMath.make(aethBrand, 300n);
+  const aethLiquidity = {
+    proposal: aethInitialLiquidity,
+    payment: aethMint.mintPayment(aethInitialLiquidity),
+  };
 
   const services = await setupServices(
     loanParams,
@@ -1592,27 +1715,21 @@ test('coll fees from loan and AMM', async t => {
     aethBrand,
     electorateTerms,
     manualTimer,
+    undefined,
+    aethLiquidity,
+    500n,
+    aethIssuer,
   );
-  const { brand: runBrand } = services.issuers.run;
-  const { brand: govBrand } = services.issuers.gov;
-  const zoe = services.zoe;
+  const {
+    zoe,
+    runKit: { brand: runBrand },
+  } = services;
   const { stablecoinMachine, lender } = services.stablecoin;
 
   // Add a pool with 900 aeth collateral at a 201 aeth/RUN rate
-  const capitalAmount = AmountMath.make(aethBrand, 900n);
-  const rates = makeRates(runBrand, aethBrand);
-  const aethVaultSeat = await E(zoe).offer(
-    E(stablecoinMachine).makeAddTypeInvitation(aethIssuer, 'AEth', rates),
-    harden({
-      give: { Collateral: capitalAmount },
-      want: { Governance: AmountMath.makeEmpty(govBrand) },
-    }),
-    harden({
-      Collateral: aethMint.mintPayment(capitalAmount),
-    }),
-  );
+  const rates = makeRates(runBrand);
 
-  await E(aethVaultSeat).getOfferResult();
+  await E(stablecoinMachine).addVaultType(aethIssuer, 'AEth', rates);
 
   // Create a loan for 470 RUN with 1100 aeth collateral
   const collateralAmount = AmountMath.make(aethBrand, 1100n);
@@ -1630,12 +1747,8 @@ test('coll fees from loan and AMM', async t => {
 
   const { vault } = await E(loanSeat).getOfferResult();
   const debtAmount = await E(vault).getDebtAmount();
-  const fee = multiplyBy(AmountMath.make(runBrand, 470n), rates.loanFee);
-  t.deepEqual(
-    debtAmount,
-    AmountMath.add(loanAmount, fee),
-    'vault lent 470 RUN',
-  );
+  const fee = ceilMultiplyBy(AmountMath.make(runBrand, 470n), rates.loanFee);
+  t.deepEqual(debtAmount, AmountMath.add(loanAmount, fee), 'vault loaned RUN');
   trace('correct debt', debtAmount);
 
   const { RUN: lentAmount } = await E(loanSeat).getCurrentAllocation();
@@ -1643,16 +1756,16 @@ test('coll fees from loan and AMM', async t => {
   await loanProceeds.RUN;
   t.deepEqual(lentAmount, loanAmount, 'received 47 RUN');
   t.deepEqual(
-    vault.getCollateralAmount(),
+    await E(vault).getCollateralAmount(),
     AmountMath.make(aethBrand, 1100n),
     'vault holds 1100 Collateral',
   );
 
-  t.deepEqual(stablecoinMachine.getRewardAllocation(), {
-    RUN: AmountMath.make(runBrand, 23n),
+  t.deepEqual(await E(stablecoinMachine).getRewardAllocation(), {
+    RUN: AmountMath.make(runBrand, 24n),
   });
 
-  const amm = E(zoe).getPublicFacet(await E(stablecoinMachine).getAMM());
+  const amm = services.ammFacets.ammPublicFacet;
   const swapAmount = AmountMath.make(aethBrand, 60000n);
   const swapSeat = await E(zoe).offer(
     E(amm).makeSwapInInvitation(),
@@ -1682,39 +1795,38 @@ test('close loan', async t => {
   const {
     aethKit: { mint: aethMint, issuer: aethIssuer, brand: aethBrand },
   } = setupAssets();
+  const aethInitialLiquidity = AmountMath.make(aethBrand, 300n);
+  const aethLiquidity = {
+    proposal: aethInitialLiquidity,
+    payment: aethMint.mintPayment(aethInitialLiquidity),
+  };
   const loanParams = {
     chargingPeriod: 2n,
     recordingPeriod: 6n,
-    poolFee: 24n,
-    protocolFee: 6n,
   };
   const services = await setupServices(
     loanParams,
     [15n],
     AmountMath.make(aethBrand, 1n),
     aethBrand,
-    { committeeName: 'Star Chamber', committeeSize: 5 },
+    {
+      committeeName: 'Star Chamber',
+      committeeSize: 5,
+    },
+    buildManualTimer(console.log),
+    undefined,
+    aethLiquidity,
+    500n,
+    aethIssuer,
   );
-  const { issuer: runIssuer, brand: runBrand } = services.issuers.run;
-  const { brand: govBrand } = services.issuers.gov;
-  const zoe = services.zoe;
+  const {
+    zoe,
+    runKit: { issuer: runIssuer, brand: runBrand },
+  } = services;
   const { stablecoinMachine, lender } = services.stablecoin;
 
-  // Add a vaultManager with 900 aeth collateral at a 201 aeth/RUN rate
-  const capitalAmount = AmountMath.make(aethBrand, 900n);
-  const rates = makeRates(runBrand, aethBrand);
-  const aethVaultManagerSeat = await E(zoe).offer(
-    E(stablecoinMachine).makeAddTypeInvitation(aethIssuer, 'AEth', rates),
-    harden({
-      give: { Collateral: capitalAmount },
-      want: { Governance: AmountMath.makeEmpty(govBrand) },
-    }),
-    harden({
-      Collateral: aethMint.mintPayment(capitalAmount),
-    }),
-  );
-
-  await E(aethVaultManagerSeat).getOfferResult();
+  const rates = makeRates(runBrand);
+  await E(stablecoinMachine).addVaultType(aethIssuer, 'AEth', rates);
 
   // initial loan /////////////////////////////////////
 
@@ -1736,7 +1848,7 @@ test('close loan', async t => {
   ).getOfferResult();
 
   const debtAmount = await E(aliceVault).getDebtAmount();
-  const fee = multiplyBy(aliceLoanAmount, rates.loanFee);
+  const fee = ceilMultiplyBy(aliceLoanAmount, rates.loanFee);
   const runDebtLevel = AmountMath.add(aliceLoanAmount, fee);
 
   t.deepEqual(debtAmount, runDebtLevel, 'vault lent 5000 RUN + fees');
@@ -1752,7 +1864,7 @@ test('close loan', async t => {
     ),
   );
 
-  const aliceUpdate = await aliceNotifier.getUpdateSince();
+  const aliceUpdate = await E(aliceNotifier).getUpdateSince();
   t.deepEqual(aliceUpdate.value.debt, runDebtLevel);
   const aliceCollateralization1 = aliceUpdate.value.collateralizationRatio;
   t.deepEqual(aliceCollateralization1.numerator.value, 15000n);
@@ -1813,9 +1925,64 @@ test('close loan', async t => {
     AmountMath.makeEmpty(aethBrand),
   );
 
-  t.is(await aliceVault.getLiquidationPromise(), 'Closed');
+  t.is(await E(aliceVault).getLiquidationPromise(), 'Closed');
   t.deepEqual(
-    await E(aliceVault.getLiquidationSeat()).getCurrentAllocation(),
+    await E(E(aliceVault).getLiquidationSeat()).getCurrentAllocation(),
     {},
   );
+});
+
+test('excessive loan', async t => {
+  const {
+    aethKit: { mint: aethMint, issuer: aethIssuer, brand: aethBrand },
+  } = setupAssets();
+  const aethInitialLiquidity = AmountMath.make(aethBrand, 300n);
+  const aethLiquidity = {
+    proposal: aethInitialLiquidity,
+    payment: aethMint.mintPayment(aethInitialLiquidity),
+  };
+  const loanParams = {
+    chargingPeriod: 2n,
+    recordingPeriod: 6n,
+  };
+  const services = await setupServices(
+    loanParams,
+    [15n],
+    AmountMath.make(aethBrand, 1n),
+    aethBrand,
+    {
+      committeeName: 'Star Chamber',
+      committeeSize: 5,
+    },
+    buildManualTimer(console.log),
+    undefined,
+    aethLiquidity,
+    500n,
+    aethIssuer,
+  );
+  const {
+    zoe,
+    runKit: { brand: runBrand },
+  } = services;
+  const { stablecoinMachine, lender } = services.stablecoin;
+
+  const rates = makeRates(runBrand);
+  await E(stablecoinMachine).addVaultType(aethIssuer, 'AEth', rates);
+
+  // Try to Create a loan for Alice for 5000 RUN with 100 aeth collateral
+  const collateralAmount = AmountMath.make(aethBrand, 100n);
+  const aliceLoanAmount = AmountMath.make(runBrand, 5000n);
+  const aliceLoanSeat = await E(zoe).offer(
+    E(lender).makeLoanInvitation(),
+    harden({
+      give: { Collateral: collateralAmount },
+      want: { RUN: aliceLoanAmount },
+    }),
+    harden({
+      Collateral: aethMint.mintPayment(collateralAmount),
+    }),
+  );
+  await t.throwsAsync(() => E(aliceLoanSeat).getOfferResult(), {
+    message: /exceeds max/,
+  });
 });

--- a/packages/treasury/test/test-stablecoin.js
+++ b/packages/treasury/test/test-stablecoin.js
@@ -205,10 +205,14 @@ async function setupAmm(
   });
   const liqInvitation = E(ammPublicFacet).makeAddLiquidityInvitation();
 
-  const ammLiquiditySeat = await E(zoe).offer(liqInvitation, liqProposal, {
-    Secondary: aethLiquidity.payment,
-    Central: runLiquidity.payment,
-  });
+  const ammLiquiditySeat = await E(zoe).offer(
+    liqInvitation,
+    liqProposal,
+    harden({
+      Secondary: aethLiquidity.payment,
+      Central: runLiquidity.payment,
+    }),
+  );
 
   const g = {
     ammGovernorInstance,
@@ -328,10 +332,9 @@ async function setupServices(
       give: {},
       want: { RUN: AmountMath.make(runBrand, runInitialLiquidity) },
     }),
-    {},
+    harden({}),
     { feeMintAccess },
   );
-  // const result = await E(faucetSeat).getOfferResult();
 
   const {
     creatorFacet: committeeCreator,
@@ -345,7 +348,7 @@ async function setupServices(
   const runPayment = await E(faucetSeat).getPayout('RUN');
 
   const runLiquidity = {
-    proposal: AmountMath.make(runBrand, runInitialLiquidity),
+    proposal: harden(AmountMath.make(runBrand, runInitialLiquidity)),
     payment: runPayment,
   };
 
@@ -1994,7 +1997,7 @@ test('excessive loan', async t => {
 // prices drop. Bob will be charged interest (twice), which will trigger
 // liquidation. Alice's withdrawal is precisely gauged so the difference between
 // a floorDivideBy and a ceilingDivideBy will leave her unliquidated.
-test('mutable liquidity triggers and interest (sensitivity', async t => {
+test('mutable liquidity triggers and interest sensitivity', async t => {
   const {
     aethKit: { mint: aethMint, issuer: aethIssuer, brand: aethBrand },
   } = setupAssets();

--- a/packages/treasury/test/test-vault-interest.js
+++ b/packages/treasury/test/test-vault-interest.js
@@ -96,8 +96,8 @@ test('interest', async t => {
   const { creatorSeat } = await helperContract;
 
   // Our wrapper gives us a Vault which holds 50 Collateral, has lent out 70
-  // RUN (charging 3 RUN fee), which uses an autoswap that presents a
-  // fixed price of 4 RUN per Collateral.
+  // RUN (charging 3 RUN fee), which uses an automatic market maker that
+  // presents a fixed price of 4 RUN per Collateral.
   const { notifier, actions } = await E(creatorSeat).getOfferResult();
   const {
     runMint,
@@ -114,13 +114,13 @@ test('interest', async t => {
 
   t.deepEqual(
     vault.getDebtAmount(),
-    AmountMath.make(runBrand, 73500n),
-    'borrower owes 73 RUN',
+    AmountMath.make(runBrand, 73_500n),
+    'borrower owes 73,500 RUN',
   );
   t.deepEqual(
     vault.getCollateralAmount(),
-    AmountMath.make(collateralBrand, 50000n),
-    'vault holds 50 Collateral',
+    AmountMath.make(collateralBrand, 50_000n),
+    'vault holds 50,000 Collateral',
   );
 
   timer.tick();
@@ -136,11 +136,11 @@ test('interest', async t => {
     timer.getCurrentTimestamp(),
   );
   t.truthy(
-    AmountMath.isEqual(nextInterest, AmountMath.make(runBrand, 63n)),
-    `interest should be 3, was ${nextInterest.value}`,
+    AmountMath.isEqual(nextInterest, AmountMath.make(runBrand, 70n)),
+    `interest should be 70, was ${nextInterest.value}`,
   );
   const { value: v2, updateCount: c2 } = await E(notifier).getUpdateSince(c1);
-  t.deepEqual(v2.debt, AmountMath.make(runBrand, 73500n + 63n));
+  t.deepEqual(v2.debt, AmountMath.make(runBrand, 73500n + 70n));
   t.deepEqual(v2.interestRate, makeRatio(5n, runBrand, 100n));
   t.deepEqual(v2.liquidationRatio, makeRatio(105n, runBrand));
   const collateralization = v2.collateralizationRatio;

--- a/packages/treasury/test/test-vault.js
+++ b/packages/treasury/test/test-vault.js
@@ -94,8 +94,8 @@ test('first', async t => {
   const { creatorSeat, creatorFacet } = await helperContract;
 
   // Our wrapper gives us a Vault which holds 50 Collateral, has lent out 70
-  // RUN (charging 3 RUN fee), which uses an autoswap that presents a
-  // fixed price of 4 RUN per Collateral.
+  // RUN (charging 3 RUN fee), which uses an automatic market maker that
+  // presents a fixed price of 4 RUN per Collateral.
   await E(creatorSeat).getOfferResult();
   const { runMint, collateralKit, vault } = testJig;
   const { brand: runBrand } = runMint.getIssuerRecord();
@@ -104,8 +104,8 @@ test('first', async t => {
 
   t.deepEqual(
     vault.getDebtAmount(),
-    AmountMath.make(runBrand, 73n),
-    'borrower owes 73 RUN',
+    AmountMath.make(runBrand, 74n),
+    'borrower owes 74 RUN',
   );
   t.deepEqual(
     vault.getCollateralAmount(),
@@ -157,8 +157,8 @@ test('first', async t => {
   const returnedAmount = await cIssuer.getAmountOf(returnedCollateral);
   t.deepEqual(
     vault.getDebtAmount(),
-    AmountMath.make(runBrand, 70n),
-    'debt reduced to 70 RUN',
+    AmountMath.make(runBrand, 71n),
+    'debt reduced to 71 RUN',
   );
   t.deepEqual(
     vault.getCollateralAmount(),
@@ -179,8 +179,8 @@ test('bad collateral', async t => {
   const { runMint, collateralKit, vault } = testJig;
 
   // Our wrapper gives us a Vault which holds 50 Collateral, has lent out 70
-  // RUN (charging 3 RUN fee), which uses an autoswap that presents a
-  // fixed price of 4 RUN per Collateral.
+  // RUN (charging 3 RUN fee), which uses an automatic market maker that
+  // presents a fixed price of 4 RUN per Collateral.
   await E(offerKit).getOfferResult();
   const { brand: collateralBrand } = collateralKit;
   const { brand: runBrand } = runMint.getIssuerRecord();
@@ -192,8 +192,8 @@ test('bad collateral', async t => {
   );
   t.deepEqual(
     vault.getDebtAmount(),
-    AmountMath.make(runBrand, 73n),
-    'borrower owes 73 RUN',
+    AmountMath.make(runBrand, 74n),
+    'borrower owes 74 RUN',
   );
 
   const collateralAmount = AmountMath.make(collateralBrand, 2n);

--- a/packages/treasury/test/vault-contract-wrapper.js
+++ b/packages/treasury/test/vault-contract-wrapper.js
@@ -2,7 +2,7 @@
 
 import '@agoric/zoe/src/types.js';
 
-import { makeIssuerKit, AssetKind, AmountMath } from '@agoric/ertp';
+import { makeIssuerKit, AssetKind } from '@agoric/ertp';
 
 import { assert } from '@agoric/assert';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
@@ -30,14 +30,6 @@ export async function start(zcf, privateArgs) {
   const { brand: runBrand } = runMint.getIssuerRecord();
 
   const { zcfSeat: stableCoinSeat } = zcf.makeEmptySeatKit();
-
-  /** @type {MultipoolAutoswapPublicFacet} */
-  const autoswapMock = {
-    getInputPrice(amountIn, brandOut) {
-      assert.equal(brandOut, runBrand);
-      return AmountMath.make(runBrand, 4n * amountIn.value);
-    },
-  };
 
   function reallocateReward(amount, fromSeat, otherSeat) {
     stableCoinSeat.incrementBy(
@@ -97,7 +89,6 @@ export async function start(zcf, privateArgs) {
     zcf,
     managerMock,
     runMint,
-    autoswapMock,
     priceAuthority,
     publicFacet,
     timer.getCurrentTimestamp(),

--- a/packages/vats/src/bootstrap.js
+++ b/packages/vats/src/bootstrap.js
@@ -22,6 +22,7 @@ import {
   CENTRAL_ISSUER_NAME,
   demoIssuerEntries,
   fromCosmosIssuerEntries,
+  BLD_ISSUER_ENTRY,
 } from './issuers';
 
 const NUM_IBC_PORTS = 3;
@@ -157,7 +158,7 @@ export function buildRootObject(vatPowers, vatParameters) {
       );
 
       // Install the economy, giving the components access to the name admins we made.
-      const [treasuryCreator] = await Promise.all([
+      const [treasuryInstallResults] = await Promise.all([
         installTreasuryOnChain({
           agoricNames,
           board,
@@ -177,8 +178,46 @@ export function buildRootObject(vatPowers, vatParameters) {
           zoeWPurse: zoeWUnlimitedPurse,
         }),
       ]);
-      return treasuryCreator;
+      return treasuryInstallResults;
     }
+
+    const demoIssuers = demoIssuerEntries(noFakeCurrencies);
+    // all the non=RUN issuers. RUN can't be initialized until we have the
+    // bootstrap payment, but we need to know pool sizes to ask for that.
+    const demoAndBldIssuers = [...demoIssuers, BLD_ISSUER_ENTRY];
+
+    // Calculate how much RUN we need to fund the AMM pools
+    function ammPoolRunDeposits(issuers) {
+      let ammTotal = 0n;
+      const ammPoolIssuers = [];
+      const ammPoolBalances = [];
+      issuers.forEach(entry => {
+        const [issuerName, record] = entry;
+        if (!record.collateralConfig) {
+          // skip RUN and fake issuers
+          return;
+        }
+        assert(record.tradesGivenCentral);
+        /** @type {bigint} */
+        const initialRunPrice = record.tradesGivenCentral[0][0];
+        const poolBalance =
+          initialRunPrice * record.collateralConfig.collateralValue;
+        ammTotal += poolBalance;
+        ammPoolIssuers.push(issuerName);
+        ammPoolBalances.push(poolBalance);
+      });
+      return {
+        ammTotal,
+        ammPoolBalances,
+        ammPoolIssuers,
+      };
+    }
+
+    const {
+      ammTotal: ammDepositValue,
+      ammPoolBalances,
+      ammPoolIssuers,
+    } = ammPoolRunDeposits(demoAndBldIssuers);
 
     // We'll usually have something like:
     // {
@@ -202,10 +241,12 @@ export function buildRootObject(vatPowers, vatParameters) {
     ) || { amount: '0' };
 
     // Now we can bootstrap the economy!
-    const bootstrapPaymentValue = Nat(BigInt(centralBootstrapSupply.amount));
+    const bankBootstrapSupply = Nat(BigInt(centralBootstrapSupply.amount));
+    // Ask the treasury for enough RUN to fund both AMM and bank.
+    const bootstrapPaymentValue = bankBootstrapSupply + ammDepositValue;
     // NOTE: no use of the voteCreator. We'll need it to initiate votes on
     // changing Treasury parameters.
-    const { treasuryCreator, _voteCreator } = await installEconomy(
+    const { treasuryCreator, _voteCreator, ammFacets } = await installEconomy(
       bootstrapPaymentValue,
     );
 
@@ -217,7 +258,7 @@ export function buildRootObject(vatPowers, vatParameters) {
     ] = await Promise.all([
       E(agoricNames).lookup('issuer', CENTRAL_ISSUER_NAME),
       E(agoricNames).lookup('brand', CENTRAL_ISSUER_NAME),
-      E(agoricNames).lookup('instance', 'autoswap'),
+      E(agoricNames).lookup('instance', 'amm'),
       E(agoricNames).lookup('instance', 'Pegasus'),
     ]);
 
@@ -239,10 +280,10 @@ export function buildRootObject(vatPowers, vatParameters) {
       // Only distribute fees if there is a collector.
       E(vats.distributeFees)
         .buildDistributor(
-          E(vats.distributeFees).makeTreasuryFeeCollector(
-            zoeWUnlimitedPurse,
+          E(vats.distributeFees).makeFeeCollector(zoeWUnlimitedPurse, [
             treasuryCreator,
-          ),
+            ammFacets.creatorFacet,
+          ]),
           feeCollectorDepositFacet,
           epochTimerService,
           harden(distributorParams),
@@ -251,8 +292,8 @@ export function buildRootObject(vatPowers, vatParameters) {
     }
 
     /**
-     * @type {Store<Brand, Payment>} The store of payments that aren't actually
-     * used by the bank.
+     * @type {Store<Brand, Payment>} A store containing payments that weren't
+     * used by the bank and can be used for other purposes.
      */
     const unusedBankPayments = makeStore('brand');
 
@@ -261,8 +302,16 @@ export function buildRootObject(vatPowers, vatParameters) {
       treasuryCreator,
     ).getBootstrapPayment(AmountMath.make(centralBrand, bootstrapPaymentValue));
 
+    const [ammBootstrapPayment, bankBootstrapPayment] = await E(
+      centralIssuer,
+    ).split(
+      centralBootstrapPayment,
+      AmountMath.make(centralBrand, ammDepositValue),
+    );
+
+    // If there's no bankBridgeManager, we'll find other uses for these funds.
     if (!bankBridgeManager) {
-      unusedBankPayments.init(centralBrand, centralBootstrapPayment);
+      unusedBankPayments.init(centralBrand, bankBootstrapPayment);
     }
 
     /** @type {Array<[string, import('./issuers').IssuerInitializationRecord]>} */
@@ -271,11 +320,11 @@ export function buildRootObject(vatPowers, vatParameters) {
         issuer: centralIssuer,
         brand: centralBrand,
         bankDenom: CENTRAL_DENOM_NAME,
-        bankPayment: centralBootstrapPayment,
+        bankPayment: bankBootstrapPayment,
       }),
       // We still create demo currencies, but not obviously fake ones unless
       // $FAKE_CURRENCIES is given.
-      ...demoIssuerEntries(noFakeCurrencies),
+      ...demoIssuers,
     ];
 
     const issuerEntries = await Promise.all(
@@ -336,10 +385,29 @@ export function buildRootObject(vatPowers, vatParameters) {
     );
 
     async function addAllCollateral() {
-      const govBrand = await E(agoricNames).lookup(
-        'brand',
-        'TreasuryGovernance',
-      );
+      async function splitAllCentralPayments() {
+        const ammPoolAmounts = ammPoolBalances.map(b =>
+          AmountMath.make(centralBrand, b),
+        );
+
+        const allPayments = await E(centralIssuer).splitMany(
+          ammBootstrapPayment,
+          ammPoolAmounts,
+        );
+
+        const issuerMap = {};
+        for (let i = 0; i < ammPoolBalances.length; i += 1) {
+          const issuerName = ammPoolIssuers[i];
+          issuerMap[issuerName] = {
+            payment: allPayments[i],
+            amount: ammPoolAmounts[i],
+          };
+        }
+        return issuerMap;
+      }
+
+      const issuerMap = await splitAllCentralPayments();
+
       return Promise.all(
         issuerEntries.map(async entry => {
           const [issuerName, record] = entry;
@@ -350,9 +418,10 @@ export function buildRootObject(vatPowers, vatParameters) {
           assert(record.tradesGivenCentral);
           const initialPrice = record.tradesGivenCentral[0];
           assert(initialPrice);
+          const initialPriceNumerator = /** @type {bigint} */ (initialPrice[0]);
           const rates = {
             initialPrice: makeRatio(
-              /** @type {bigint} */ (initialPrice[0]),
+              initialPriceNumerator,
               centralBrand,
               /** @type {bigint} */ (initialPrice[1]),
               record.brand,
@@ -374,39 +443,41 @@ export function buildRootObject(vatPowers, vatParameters) {
             ),
           };
 
-          const addTypeInvitation = E(treasuryCreator).makeAddTypeInvitation(
+          const collateralPayments = E(vats.mints).mintInitialPayments(
+            [issuerName],
+            [config.collateralValue],
+          );
+          const secondaryPayment = E.get(collateralPayments)[0];
+
+          assert(record.issuer, `No issuer for ${issuerName}`);
+          const liquidityIssuer = E(ammFacets.ammPublicFacet).addPool(
+            record.issuer,
+            config.keyword,
+          );
+          const [secondaryAmount, liquidityBrand] = await Promise.all([
+            E(record.issuer).getAmountOf(secondaryPayment),
+            E(liquidityIssuer).getBrand(),
+          ]);
+          const centralAmount = issuerMap[issuerName].amount;
+          const proposal = harden({
+            want: { Liquidity: AmountMath.makeEmpty(liquidityBrand) },
+            give: { Secondary: secondaryAmount, Central: centralAmount },
+          });
+
+          E(zoeWUnlimitedPurse).offer(
+            E(ammFacets.ammPublicFacet).makeAddLiquidityInvitation(),
+            proposal,
+            harden({
+              Secondary: secondaryPayment,
+              Central: issuerMap[issuerName].payment,
+            }),
+          );
+
+          return E(treasuryCreator).addVaultType(
             record.issuer,
             config.keyword,
             rates,
           );
-
-          const payments = E(vats.mints).mintInitialPayments(
-            [issuerName],
-            [config.collateralValue],
-          );
-          const payment = E.get(payments)[0];
-
-          assert(record.issuer);
-          const amount = await E(record.issuer).getAmountOf(payment);
-          const proposal = harden({
-            give: {
-              Collateral: amount,
-            },
-            want: {
-              // We just throw away our governance tokens.
-              Governance: AmountMath.makeEmpty(govBrand, AssetKind.NAT),
-            },
-          });
-          const paymentKeywords = harden({
-            Collateral: payment,
-          });
-          const seat = E(zoeWUnlimitedPurse).offer(
-            addTypeInvitation,
-            proposal,
-            paymentKeywords,
-          );
-          const vaultManager = E(seat).getOfferResult();
-          return vaultManager;
         }),
       );
     }
@@ -577,6 +648,8 @@ export function buildRootObject(vatPowers, vatParameters) {
                   }
                   // We have an unusedPayment, so we can split off a payment.
                   const amount = AmountMath.make(brand, Nat(value));
+                  // TODO: what happens if unusedBankPayment doesn't have enough
+                  // remaining?
                   const [fragment, remaining] = await E(issuer).split(
                     unusedBankPayments.get(brand),
                     amount,

--- a/packages/vats/src/issuers.js
+++ b/packages/vats/src/issuers.js
@@ -7,7 +7,7 @@ export const CENTRAL_ISSUER_NAME = 'RUN';
 /**
  * @typedef {Object} CollateralConfig
  * @property {string} keyword
- * @property {NatValue} collateralValue the initial price of this collateral is
+ * @property {bigint} collateralValue the initial price of this collateral is
  * provided by tradesGivenCentral[0]
  * @property {bigint} initialMarginPercent
  * @property {bigint} liquidationMarginPercent
@@ -24,8 +24,8 @@ export const CENTRAL_ISSUER_NAME = 'RUN';
  * @property {string} [bankDenom]
  * @property {string} [bankPurse]
  * @property {Payment} [bankPayment]
- * @property {Array<[string, bigint | number]>} [defaultPurses]
- * @property {Array<[bigint | number, bigint | number]>} [tradesGivenCentral]
+ * @property {Array<[string, bigint]>} [defaultPurses]
+ * @property {Array<[bigint, bigint]>} [tradesGivenCentral]
  */
 
 /**
@@ -66,6 +66,32 @@ export const scaleMicro = makeScaler(6);
 export const scaleEth = makeScaler(18);
 export const scaleCentral = scaleMicro;
 
+/** @type {[string, IssuerInitializationRecord]} */
+const BLD_ISSUER_ENTRY = [
+  'BLD',
+  {
+    issuerArgs: [undefined, { decimalPlaces: 6 }],
+    defaultPurses: [['Agoric staking token', scaleMicro(62)]],
+    bankDenom: 'ubld',
+    bankPurse: 'Agoric staking token',
+    collateralConfig: {
+      keyword: 'BLD',
+      collateralValue: scaleMicro(20_000_000n),
+      initialMarginPercent: 150n,
+      liquidationMarginPercent: 125n,
+      interestRateBasis: 250n,
+      loanFeeBasis: 1n,
+    },
+    tradesGivenCentral: [
+      [scaleCentral(27.9, 1), scaleMicro(1)],
+      [scaleCentral(25.7, 1), scaleMicro(1)],
+      [scaleCentral(26.8, 1), scaleMicro(1)],
+    ],
+  },
+];
+harden(BLD_ISSUER_ENTRY);
+export { BLD_ISSUER_ENTRY };
+
 /** @type {(centralRecord: Partial<IssuerInitializationRecord>) => Array<[string, IssuerInitializationRecord]>} */
 const fromCosmosIssuerEntries = centralRecord => [
   [
@@ -74,32 +100,11 @@ const fromCosmosIssuerEntries = centralRecord => [
       issuerArgs: [undefined, { decimalPlaces: 6 }],
       defaultPurses: [['Agoric RUN currency', scaleMicro(53)]],
       bankPurse: 'Agoric RUN currency',
-      tradesGivenCentral: [[1, 1]],
+      tradesGivenCentral: [[1n, 1n]],
       ...centralRecord,
     },
   ],
-  [
-    'BLD',
-    {
-      issuerArgs: [undefined, { decimalPlaces: 6 }],
-      defaultPurses: [['Agoric staking token', scaleMicro(62)]],
-      bankDenom: 'ubld',
-      bankPurse: 'Agoric staking token',
-      collateralConfig: {
-        keyword: 'BLD',
-        collateralValue: scaleMicro(20_000_000n),
-        initialMarginPercent: 150n,
-        liquidationMarginPercent: 125n,
-        interestRateBasis: 250n,
-        loanFeeBasis: 1n,
-      },
-      tradesGivenCentral: [
-        [scaleCentral(27.9, 1), scaleMicro(1)],
-        [scaleCentral(25.7, 1), scaleMicro(1)],
-        [scaleCentral(26.8, 1), scaleMicro(1)],
-      ],
-    },
-  ],
+  BLD_ISSUER_ENTRY,
 ];
 
 harden(fromCosmosIssuerEntries);
@@ -195,24 +200,24 @@ export const demoIssuerEntries = noObviouslyFakeCurrencies => {
     [
       'moola',
       {
-        defaultPurses: doFakePurses && [['Fun budget', 1900]],
+        defaultPurses: doFakePurses && [['Fun budget', 1900n]],
         tradesGivenCentral: [
-          [scaleCentral(1), 1],
-          [scaleCentral(1.3, 1), 1],
-          [scaleCentral(1.2, 1), 1],
-          [scaleCentral(1.8, 1), 1],
-          [scaleCentral(1.5, 1), 1],
+          [scaleCentral(1), 1n],
+          [scaleCentral(1.3, 1), 1n],
+          [scaleCentral(1.2, 1), 1n],
+          [scaleCentral(1.8, 1), 1n],
+          [scaleCentral(1.5, 1), 1n],
         ],
       },
     ],
     [
       'simolean',
       {
-        defaultPurses: doFakePurses && [['Nest egg', 970]],
+        defaultPurses: doFakePurses && [['Nest egg', 970n]],
         tradesGivenCentral: [
-          [scaleCentral(21.35, 2), 1],
-          [scaleCentral(21.72, 2), 1],
-          [scaleCentral(21.24, 2), 1],
+          [scaleCentral(21.35, 2), 1n],
+          [scaleCentral(21.72, 2), 1n],
+          [scaleCentral(21.24, 2), 1n],
         ],
       },
     ],

--- a/packages/vats/src/types.js
+++ b/packages/vats/src/types.js
@@ -65,9 +65,9 @@
 /**
  * @callback BuildFeeDistributor
  *
- * @param {ERef<FeeCollector>} treasuryCollector - an object with a
- *  collectFees() method, which will return a payment. can be populated with
- *  makeTreasuryFeeCollector(zoe, treasuryCreatorFacet)
+ * @param {ERef<FeeCollector>[]} collectors - an array of objects with
+ *   collectFees() methods, each of which will return a payment. Can
+ *   be populated with the results of makeFeeCollector(zoe, creatorFacet)
  * @param {EOnly<DepositFacet>} feeDepositFacet - object with receive()
  * @param {ERef<TimerService>} epochTimer - timer that notifies at the end of
  *  each Epoch. The epochInterval parameter controls the interval.

--- a/packages/vats/src/vat-distributeFees.js
+++ b/packages/vats/src/vat-distributeFees.js
@@ -1,9 +1,9 @@
 import { Far } from '@agoric/marshal';
-import {
-  buildDistributor,
-  makeTreasuryFeeCollector,
-} from './distributeFees.js';
+import { buildDistributor, makeFeeCollector } from './distributeFees.js';
 
 export function buildRootObject(_vatPowers) {
-  return Far('feeDistributor', { buildDistributor, makeTreasuryFeeCollector });
+  return Far('feeDistributor', {
+    buildDistributor,
+    makeFeeCollector,
+  });
 }

--- a/packages/vats/test/test-distributeFees.js
+++ b/packages/vats/test/test-distributeFees.js
@@ -37,7 +37,7 @@ function makeFakeFeeDepositFacet(feeIssuer) {
   return { feeDepositFacet, getPayments: _ => depositPayments };
 }
 
-function makeFakeTreasury() {
+function makeFakeFeeProducer() {
   const feePayments = [];
   return {
     collectFees: () => feePayments.pop(),
@@ -62,8 +62,8 @@ test('fee distribution', async t => {
   const { brands, moolaIssuer: issuer, moolaMint: runMint } = setup();
   const brand = brands.get('moola');
   const { feeDepositFacet, getPayments } = makeFakeFeeDepositFacet(issuer);
-  const treasury = makeFakeTreasury();
-  const amm = makeFakeTreasury();
+  const treasury = makeFakeFeeProducer();
+  const amm = makeFakeFeeProducer();
   const epochTimer = buildManualTimer(console.log);
   const distributorParams = {
     epochInterval: 1n,
@@ -92,8 +92,8 @@ test('fee distribution, leftovers', async t => {
   const { brands, moolaIssuer: issuer, moolaMint: runMint } = setup();
   const brand = brands.get('moola');
   const { feeDepositFacet, getPayments } = makeFakeFeeDepositFacet(issuer);
-  const treasury = makeFakeTreasury();
-  const amm = makeFakeTreasury();
+  const treasury = makeFakeFeeProducer();
+  const amm = makeFakeFeeProducer();
   const epochTimer = buildManualTimer(console.log);
   const distributorParams = {
     epochInterval: 1n,

--- a/packages/vats/test/test-distributeFees.js
+++ b/packages/vats/test/test-distributeFees.js
@@ -47,9 +47,14 @@ function makeFakeTreasury() {
   };
 }
 
-function assertPaymentArray(t, payments, count, value, issuer, brand) {
+function assertPaymentArray(t, payments, count, values, issuer, brand) {
   for (let i = 0; i < count; i += 1) {
-    assertPayoutAmount(t, issuer, payments[i], AmountMath.make(brand, value));
+    assertPayoutAmount(
+      t,
+      issuer,
+      payments[i],
+      AmountMath.make(brand, values[i]),
+    );
   }
 }
 
@@ -58,12 +63,13 @@ test('fee distribution', async t => {
   const brand = brands.get('moola');
   const { feeDepositFacet, getPayments } = makeFakeFeeDepositFacet(issuer);
   const treasury = makeFakeTreasury();
+  const amm = makeFakeTreasury();
   const epochTimer = buildManualTimer(console.log);
   const distributorParams = {
     epochInterval: 1n,
   };
   buildDistributor(
-    treasury,
+    [treasury, amm],
     feeDepositFacet,
     epochTimer,
     distributorParams,
@@ -72,13 +78,14 @@ test('fee distribution', async t => {
   });
 
   treasury.pushFees(runMint.mintPayment(AmountMath.make(brand, 500n)));
+  amm.pushFees(runMint.mintPayment(AmountMath.make(brand, 270n)));
 
   t.deepEqual(getPayments(), []);
 
   await epochTimer.tick();
   await waitForPromisesToSettle();
 
-  await assertPaymentArray(t, getPayments(), 1, 500n, issuer, brand);
+  await assertPaymentArray(t, getPayments(), 2, [500n, 270n], issuer, brand);
 });
 
 test('fee distribution, leftovers', async t => {
@@ -86,26 +93,41 @@ test('fee distribution, leftovers', async t => {
   const brand = brands.get('moola');
   const { feeDepositFacet, getPayments } = makeFakeFeeDepositFacet(issuer);
   const treasury = makeFakeTreasury();
+  const amm = makeFakeTreasury();
   const epochTimer = buildManualTimer(console.log);
   const distributorParams = {
     epochInterval: 1n,
   };
-  buildDistributor(treasury, feeDepositFacet, epochTimer, distributorParams);
+  buildDistributor(
+    [treasury, amm],
+    feeDepositFacet,
+    epochTimer,
+    distributorParams,
+  );
 
   treasury.pushFees(runMint.mintPayment(AmountMath.make(brand, 12n)));
+  amm.pushFees(runMint.mintPayment(AmountMath.make(brand, 8n)));
 
   t.deepEqual(getPayments(), []);
 
   await epochTimer.tick();
   await waitForPromisesToSettle();
 
-  assertPaymentArray(t, getPayments(), 1, 12n, issuer, brand);
+  assertPaymentArray(t, getPayments(), 2, [12n, 8n], issuer, brand);
 
   // Pay them again
   treasury.pushFees(runMint.mintPayment(AmountMath.make(brand, 13n)));
+  amm.pushFees(runMint.mintPayment(AmountMath.make(brand, 7n)));
 
   await epochTimer.tick();
   await waitForPromisesToSettle();
 
-  await assertPaymentArray(t, getPayments().slice(1), 1, 13n, issuer, brand);
+  await assertPaymentArray(
+    t,
+    getPayments().slice(2),
+    2,
+    [13n, 7n],
+    issuer,
+    brand,
+  );
 });

--- a/packages/zoe/src/contracts/exported.js
+++ b/packages/zoe/src/contracts/exported.js
@@ -4,3 +4,4 @@ import './multipoolAutoswap/types.js';
 import './priceAggregatorTypes.js';
 import './callSpread/types.js';
 import './attestation/types.js';
+import './vpool-xyk-amm/types.js';

--- a/packages/zoe/src/contracts/vpool-xyk-amm/addLiquidity.js
+++ b/packages/zoe/src/contracts/vpool-xyk-amm/addLiquidity.js
@@ -24,7 +24,7 @@ export const makeMakeAddLiquidityInvitation = (zcf, getPool) => {
   };
 
   const makeAddLiquidityInvitation = () =>
-    zcf.makeInvitation(addLiquidity, 'multipool autoswap add liquidity');
+    zcf.makeInvitation(addLiquidity, 'multipool amm add liquidity');
 
   return makeAddLiquidityInvitation;
 };

--- a/packages/zoe/test/unitTests/contracts/vpool-xyk-amm/test-xyk-amm-swap.js
+++ b/packages/zoe/test/unitTests/contracts/vpool-xyk-amm/test-xyk-amm-swap.js
@@ -59,7 +59,7 @@ const makeBundle = async sourceRoot => {
 };
 
 // makeBundle is a slow step, so we do it once for all the tests.
-const autoswapBundleP = makeBundle(ammRoot);
+const ammBundleP = makeBundle(ammRoot);
 const contractGovernorBundleP = makeBundle(contractGovernorRoot);
 const committeeBundleP = makeBundle(committeeRoot);
 const voteCounterBundleP = makeBundle(voteCounterRoot);
@@ -103,25 +103,25 @@ const setupServices = async (
 
   // XS doesn't like top-level await, so do it here. this should be quick
   const [
-    autoswapBundle,
+    ammBundle,
     contractGovernorBundle,
     committeeBundle,
     voteCounterBundle,
   ] = await Promise.all([
-    autoswapBundleP,
+    ammBundleP,
     contractGovernorBundleP,
     committeeBundleP,
     voteCounterBundleP,
   ]);
 
-  const [autoswap, governor, electorate, counter] = await Promise.all([
-    installBundle(zoe, autoswapBundle),
+  const [constProductAmm, governor, electorate, counter] = await Promise.all([
+    installBundle(zoe, ammBundle),
     installBundle(zoe, contractGovernorBundle),
     installBundle(zoe, committeeBundle),
     installBundle(zoe, voteCounterBundle),
   ]);
   const installs = {
-    autoswap,
+    amm: constProductAmm,
     governor,
     electorate,
     counter,
@@ -135,7 +135,7 @@ const setupServices = async (
   const governorTerms = {
     timer,
     electorateInstance,
-    governedContractInstallation: installs.autoswap,
+    governedContractInstallation: installs.amm,
     governed: {
       terms: ammTerms,
       issuerKeywordRecord: { Central: centralR.issuer },
@@ -244,9 +244,9 @@ test('amm with valid offers', async t => {
       invitationBrand,
       harden([
         {
-          description: 'multipool autoswap add liquidity',
+          description: 'multipool amm add liquidity',
           instance: ammInstance,
-          installation: installs.autoswap,
+          installation: installs.amm,
           handle: aliceInvitationAmount.value[0].handle,
           fee: undefined,
           expiry: undefined,
@@ -352,7 +352,7 @@ test('amm with valid offers', async t => {
 
   t.is(
     bobInvitationValue.installation,
-    installs.autoswap,
+    installs.amm,
     `installation is as expected`,
   );
 


### PR DESCRIPTION
closes: #3861 
closes: #3019
closes: #4032
closes: #2877

## Description

Vaults switch to using constantProduct AMM
Rewards are no longer collected from the AMM in the Vaults
Vaults consistently specify rounding mode with Ratios
Vaults is unaware of AMM governed params
Vaults uses feeMintAccess for access to RUN mint
governance tokens in Vaults are no longer supported
fix up install-on-chain

### Security Considerations

The normal for a core part of our economy

### Documentation Considerations

Documentation for the constantProduct AMM is in [566](https://github.com/Agoric/documentation/pull/566)
An update to [Treasury docs](https://github.com/Agoric/documentation/pull/570) has been prepared.

### Testing Considerations

tests are included and updated.