### PR TITLE
Notifier API updates

### DIFF
--- a/packages/notifier/src/asyncIterableAdaptor.js
+++ b/packages/notifier/src/asyncIterableAdaptor.js
@@ -34,7 +34,7 @@ import './types.js';
  *
  * @template T
  * @param {ERef<BaseNotifier<T>>} notifierP
- * @returns {AsyncIterable<T>}
+ * @returns {ConsistentAsyncIterable<T>}
  */
 export const makeAsyncIterableFromNotifier = notifierP => {
   return Far('asyncIterableFromNotifier', {

--- a/packages/notifier/src/types.js
+++ b/packages/notifier/src/types.js
@@ -12,6 +12,14 @@
 
 /**
  * @template T
+ * @typedef {{
+ *   [Symbol.asyncIterator]: () => AsyncIterator<T, T>
+ * }} ConsistentAsyncIterable
+ * An AsyncIterable that returns the same type as it yields.
+ */
+
+/**
+ * @template T
  * @typedef {Object} IterationObserver<T>
  * A valid sequence of calls to the methods of an `IterationObserver`
  * represents an iteration. A valid sequence consists of any number of calls
@@ -61,20 +69,24 @@
  */
 
 /**
- * @typedef {any} NotifierInternals Purposely opaque. Will be shared between
- * machines, so it must be safe to expose. But other software should avoid
- * depending on its internal structure.
+ * @template T
+ * @typedef {BaseNotifier<T>} NotifierInternals Will be shared between machines,
+ * so it must be safe to expose. But other software should avoid depending on
+ * its internal structure.
  */
 
 /**
  * @template T
- * @typedef {BaseNotifier<T> & AsyncIterable<T> & SharableNotifier} Notifier<T> an object that can
- * be used to get the current state or updates
+ * @typedef {BaseNotifier<T> &
+ *   ConsistentAsyncIterable<T> &
+ *   SharableNotifier<T>
+ * } Notifier<T> an object that can be used to get the current state or updates
  */
 
 /**
+ * @template T
  * @typedef {Object} SharableNotifier
- * @property {() => NotifierInternals} getSharableNotifierInternals
+ * @property {() => ERef<NotifierInternals<T>>} getSharableNotifierInternals
  * Used to replicate the multicast values at other sites. To manually create a
  * local representative of a Notification, do
  * ```js
@@ -101,20 +113,26 @@
  */
 
 /**
- * @typedef {any} SubscriptionInternals Purposely opaque. Will be shared between
- * machines, so it must be safe to expose. But other software should avoid
- * depending on its internal structure.
+ * @template T
+ * @typedef {Object} SubscriptionInternals
+ * Will be shared between machines, so it must be safe to expose. But other
+ * software should avoid depending on its internal structure.
+ * @property {ERef<IteratorResult<T, T>>} head internal only
+ * @property {Promise<SubscriptionInternals<T>>} tail internal onli
  */
 
 /**
  * @template T
- * @typedef {BaseSubscription<T> & AsyncIterable<T> & SharableSubscription} Subscription<T>
+ * @typedef {BaseSubscription<T> &
+ *   ConsistentAsyncIterable<T> &
+ *   SharableSubscription<T>} Subscription<T>
  * A form of AsyncIterable supporting distributed and multicast usage.
  */
 
 /**
+ * @template T
  * @typedef {Object} SharableSubscription
- * @property {() => SubscriptionInternals} getSharableSubscriptionInternals
+ * @property {() => ERef<SubscriptionInternals<T>>} getSharableSubscriptionInternals
  * Used to replicate the multicast values at other sites. To manually create a
  * local representative of a Subscription, do
  * ```js
@@ -127,7 +145,7 @@
 
 /**
  * @template T
- * @typedef {AsyncIterator<T> & AsyncIterable<T>} SubscriptionIterator<T>
+ * @typedef {AsyncIterator<T, T> & ConsistentAsyncIterable<T>} SubscriptionIterator<T>
  * an AsyncIterator supporting distributed and multicast usage.
  *
  * @property {() => Subscription<T>} subscribe

--- a/packages/notifier/test/iterable-testing-tools.js
+++ b/packages/notifier/test/iterable-testing-tools.js
@@ -6,6 +6,8 @@ import { observeIteration, observeIterator } from '../src/index.js';
 import '@agoric/marshal/exported.js';
 import '../src/types.js';
 
+/** @typedef {import('ava').Assertions} Assertions */
+
 const obj = harden({});
 const unresP = new Promise(_ => {});
 const rejP = Promise.reject(new Error('foo'));
@@ -73,7 +75,7 @@ export const explodingStream = makeTestIterable(true);
  * this promise to succeed with the canonical `refResult` successful
  * completion, or to fail with the canonical `refReason` reason for failure.
  *
- * @param {any} t TODO What's the correct type for Ava's `t`?
+ * @param {Assertions} t
  * @param {ERef<Passable>} p
  * @param {boolean} fails
  */
@@ -119,7 +121,7 @@ const skip = (i, value, lossy) => {
  * non-final values are from a sampliing subset of the canonical test
  * iteration. Otherwise it checks for exact conformance.
  *
- * @param {any} t TODO What's the correct type for Ava's `t`?
+ * @param {Assertions} t
  * @param {AsyncIterable<Passable>} iterable
  * @param {boolean} lossy
  * @returns {Promise<Passable>}
@@ -157,7 +159,7 @@ export const testManualConsumer = (t, iterable, lossy = false) => {
  * case, `testAutoConsumer` fulfills the returned promise with the canonical
  * `refResult` completion value, which is what `testEnding` expects.
  *
- * @param {any} t TODO What's the correct type for Ava's `t`?
+ * @param {Assertions} t
  * @param {AsyncIterable<Passable>} iterable
  * @param {boolean} lossy
  * @returns {Promise<Passable>}
@@ -182,7 +184,7 @@ export const testAutoConsumer = async (t, iterable, lossy = false) => {
  * Makes an IterationObserver which will test iteration reported to it against
  * the canonical test iteration.
  *
- * @param {any} t TODO What's the correct type for Ava's `t`?
+ * @param {Assertions} t
  * @param {boolean} lossy Are we checking every non-final value or only a
  * sampling subset?
  * @param {boolean} fails Do we expect termination with the canonical successful


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description

Improve typing (convey the type of a Notifier/Subscription via its SharableInternals) and tolerate remote AsyncIterables.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->
None.

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

Only changes as reflected in the public types.

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

Passes existing tests.
