### PR TITLE
fix: avoid eslint escaping agoric-sdk package root

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,9 @@
   "engines": {
     "node": ">=14.15.0"
   },
+  "eslintConfig": {
+    "root": true
+  },
   "scripts": {
     "OFF-clean": "yarn workspaces run clean",
     "check-dependencies": "node ./scripts/check-mismatched-dependencies.js",


### PR DESCRIPTION
We were seeing trouble when agoric-sdk was checked
out as a child of documentation, dapps.
