### PR TITLE
fix(wallet): automatically convert number values to bigints

### DIFF
--- a/packages/dapp-svelte-wallet/api/package.json
+++ b/packages/dapp-svelte-wallet/api/package.json
@@ -25,6 +25,7 @@
     "@agoric/ertp": "^0.12.2",
     "@agoric/eventual-send": "^0.13.30",
     "@agoric/marshal": "^0.4.28",
+    "@agoric/nat": "^4.1.0",
     "@agoric/notifier": "^0.3.31",
     "@agoric/promise-kit": "^0.2.28",
     "@agoric/store": "^0.6.6",

--- a/packages/dapp-svelte-wallet/api/src/lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-wallet.js
@@ -859,6 +859,10 @@ export function makeWallet({
         Object.fromEntries(
           Object.entries(amountKeywordRecord).map(
             ([keyword, { pursePetname, value }]) => {
+              // Automatically convert numbers to BigInts.
+              if (typeof value === 'number') {
+                value = BigInt(value);
+              }
               const purse = getPurse(pursePetname);
               purseKeywordRecord[keyword] = purse;
               const brand = purseToBrand.get(purse);
@@ -1203,7 +1207,7 @@ export function makeWallet({
   const makePaymentActionsForId = id =>
     makePaymentActions({
       getRecord: () => idToPaymentRecord.get(id),
-      updateRecord: (record, withoutMeta = undefined) => {
+      updateRecord: (record, withoutMeta = {}) => {
         // This order is important, so that the `withoutMeta.meta` gets
         // overridden by `record.meta`.
         updatePaymentRecord({ ...withoutMeta, ...addMeta(record) });

--- a/packages/dapp-svelte-wallet/api/src/lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/src/lib-wallet.js
@@ -17,6 +17,7 @@ import { AmountMath } from '@agoric/ertp';
 import { E } from '@agoric/eventual-send';
 
 import { makeMarshal, passStyleOf, Far } from '@agoric/marshal';
+import { Nat } from '@agoric/nat';
 import {
   makeNotifierKit,
   observeIteration,
@@ -859,9 +860,9 @@ export function makeWallet({
         Object.fromEntries(
           Object.entries(amountKeywordRecord).map(
             ([keyword, { pursePetname, value }]) => {
-              // Automatically convert numbers to BigInts.
+              // Automatically convert numbers to Nats.
               if (typeof value === 'number') {
-                value = BigInt(value);
+                value = Nat(value);
               }
               const purse = getPurse(pursePetname);
               purseKeywordRecord[keyword] = purse;

--- a/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
@@ -1025,7 +1025,7 @@ test('lib-wallet addOffer for autoswap swap', async t => {
       give: {
         In: {
           pursePetname: 'Fun budget',
-          // Test automatic BigInt conversion.
+          // Test automatic Nat conversion.
           value: 30,
         },
       },

--- a/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
+++ b/packages/dapp-svelte-wallet/api/test/test-lib-wallet.js
@@ -1025,7 +1025,8 @@ test('lib-wallet addOffer for autoswap swap', async t => {
       give: {
         In: {
           pursePetname: 'Fun budget',
-          value: 30n,
+          // Test automatic BigInt conversion.
+          value: 30,
         },
       },
       want: {


### PR DESCRIPTION
ref: https://github.com/Agoric/agoric-sdk/issues/4027

Some of our dapps are using the old websocket API to connect to the wallet backend, which does not support BigInts. The latest ERTP changes now require BigInts in offer proposals, so we can convert numbers to BigInts on the wallet backend itself.

Tested with dapp-fungible-faucet to confirm the fix.