### PR TITLE
chore: add assert.note

### DIFF
--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -35,7 +35,12 @@ export const makePaymentLedger = (
     // TODO This should also destroy ledger state.
     // See https://github.com/Agoric/agoric-sdk/issues/3434
     if (optShutdownWithFailure !== undefined) {
-      optShutdownWithFailure(reason);
+      try {
+        optShutdownWithFailure(reason);
+      } catch (errInShutdown) {
+        assert.note(errInShutdown, X`Caused by: ${reason}`);
+        throw errInShutdown;
+      }
     }
     throw reason;
   };


### PR DESCRIPTION
closes: #4058 

## Description

This PR adds an `assert.note` so that in the case in which ERTP has a catastrophic, unforeseen failure (the kind which should never happen), and `optShutdownWithFailure` is defined, an additional error thrown when calling `optShutdownWithFailure` does not shadow the original failure. 

Note: we have a choice of which error gets thrown in case in which `optShutdownWithFailure` also throws. I chose to throw the error thrown in `optShutdownWithFailure`, with the original reason added as a note. But we could easily reverse these roles if we want to. 

### Security Considerations

This aids security/visibility by ensuring that the error is not shadowed, but it does introduce a call to `assert.note` in an important pathway. 

### Documentation Considerations

No new documentation needed for this change.

### Testing Considerations

This is not something that can be easily tested in place because the issue only arises in the case of catastrophic, unforeseen error - the kind of thing that we cannot reproduce at will in tests.

We could export the `shutdownLedgerWithFailure` function and try to unit test that separately, though, if we want to. It would require a `make` function to pass in `optShutdownWithFailure`, however, which is a little messy.
