### PR TITLE
fix(zoe): assert that amountKeywordRecord is a copyRecord

### DIFF
--- a/packages/governance/test/unitTests/test-shareHolders.js
+++ b/packages/governance/test/unitTests/test-shareHolders.js
@@ -143,9 +143,9 @@ test('shareHolders attestation returned on simpleInvite', async t => {
 
   const { publicFacet: electoratePub } = await E(zoe).startInstance(
     electorateInstall,
-    {
+    harden({
       Attestation: issuer,
-    },
+    }),
   );
 
   const attest1 = AmountMath.make(brand, attest('a', 37n, 5n));
@@ -159,9 +159,10 @@ test('shareHolders attestation returned on simpleInvite', async t => {
 test('shareHolders attestation to vote', async t => {
   const { issuer, brand, mint } = makeIssuerKit('attestations', AssetKind.SET);
   const timer = buildManualTimer(console.log);
-  const { publicFacet, creatorFacet } = await E(
-    zoe,
-  ).startInstance(electorateInstall, { Attestation: issuer });
+  const { publicFacet, creatorFacet } = await E(zoe).startInstance(
+    electorateInstall,
+    harden({ Attestation: issuer }),
+  );
 
   const attest1 = AmountMath.make(brand, attest('a', 37n, 5n));
   const voteSeat = voterFacet(mint, publicFacet, attest1);
@@ -185,9 +186,10 @@ test('shareHolders attestation to vote', async t => {
 test('shareHolders reuse across questions', async t => {
   const { issuer, brand, mint } = makeIssuerKit('attestations', AssetKind.SET);
   const timer = buildManualTimer(console.log);
-  const { publicFacet, creatorFacet } = await E(
-    zoe,
-  ).startInstance(electorateInstall, { Attestation: issuer });
+  const { publicFacet, creatorFacet } = await E(zoe).startInstance(
+    electorateInstall,
+    harden({ Attestation: issuer }),
+  );
 
   const attest1 = AmountMath.make(brand, attest('a', 37n, 5n));
   const voteFacet1 = voterFacet(mint, publicFacet, attest1);
@@ -247,9 +249,10 @@ test('shareHolders reuse across questions', async t => {
 test('shareHolders expiring attestations', async t => {
   const { issuer, brand, mint } = makeIssuerKit('attestations', AssetKind.SET);
   const timer = buildManualTimer(console.log);
-  const { publicFacet, creatorFacet } = await E(
-    zoe,
-  ).startInstance(electorateInstall, { Attestation: issuer });
+  const { publicFacet, creatorFacet } = await E(zoe).startInstance(
+    electorateInstall,
+    harden({ Attestation: issuer }),
+  );
 
   // deadlines:  depose: 2, dividends: 4
   // voter 1 votes won't count; voter 2 can't vote on dividends.
@@ -335,9 +338,10 @@ test('shareHolders expiring attestations', async t => {
 test('shareHolders bundle/split attestations', async t => {
   const { issuer, brand, mint } = makeIssuerKit('attestations', AssetKind.SET);
   const timer = buildManualTimer(console.log);
-  const { publicFacet, creatorFacet } = await E(
-    zoe,
-  ).startInstance(electorateInstall, { Attestation: issuer });
+  const { publicFacet, creatorFacet } = await E(zoe).startInstance(
+    electorateInstall,
+    harden({ Attestation: issuer }),
+  );
 
   // deadline:  depose: 2
   const handleShared = makeHandle('Attestation');

--- a/packages/pegasus/src/pegasus.js
+++ b/packages/pegasus/src/pegasus.js
@@ -421,9 +421,10 @@ const makePegasus = (zcf, board, namesByAddress) => {
         board,
         namesByAddress,
         denomUri,
-        retain: (zcfSeat, amounts) => zcfMint.burnLosses(amounts, zcfSeat),
+        retain: (zcfSeat, amounts) =>
+          zcfMint.burnLosses(harden(amounts), zcfSeat),
         redeem: (zcfSeat, amounts) => {
-          zcfMint.mintGains(amounts, zcfSeat);
+          zcfMint.mintGains(harden(amounts), zcfSeat);
         },
       });
 
@@ -499,8 +500,8 @@ const makePegasus = (zcf, board, namesByAddress) => {
         winner,
       ) => {
         // Transfer the amount to our backing seat.
-        loser.decrementBy({ [loserKeyword]: amount });
-        winner.incrementBy({ [winnerKeyword]: amount });
+        loser.decrementBy(harden({ [loserKeyword]: amount }));
+        winner.incrementBy(harden({ [winnerKeyword]: amount }));
         zcf.reallocate(loser, winner);
       };
 

--- a/packages/treasury/src/burn.js
+++ b/packages/treasury/src/burn.js
@@ -10,7 +10,7 @@ import { E } from '@agoric/eventual-send';
  */
 export async function paymentFromZCFMint(zcf, zcfMint, amount) {
   const { zcfSeat, userSeat } = zcf.makeEmptySeatKit();
-  zcfMint.mintGains({ Temp: amount }, zcfSeat);
+  zcfMint.mintGains(harden({ Temp: amount }), zcfSeat);
   zcfSeat.exit();
   return E(userSeat).getPayout('Temp');
 }

--- a/packages/treasury/src/collectRewardFees.js
+++ b/packages/treasury/src/collectRewardFees.js
@@ -17,12 +17,16 @@ export const makeMakeCollectFeesInvitation = (
     await E.get(offerTo(zcf, invitation, {}, {}, transferSeat)).deposited;
 
     seat.incrementBy(
-      feeSeat.decrementBy({ RUN: feeSeat.getAmountAllocated('RUN', runBrand) }),
+      feeSeat.decrementBy(
+        harden({ RUN: feeSeat.getAmountAllocated('RUN', runBrand) }),
+      ),
     );
     seat.incrementBy(
-      transferSeat.decrementBy({
-        RUN: transferSeat.getAmountAllocated('RUN', runBrand),
-      }),
+      transferSeat.decrementBy(
+        harden({
+          RUN: transferSeat.getAmountAllocated('RUN', runBrand),
+        }),
+      ),
     );
     const totalTransferred = seat.getStagedAllocation().RUN;
 

--- a/packages/treasury/src/collectRewardFees.js
+++ b/packages/treasury/src/collectRewardFees.js
@@ -14,7 +14,8 @@ export const makeMakeCollectFeesInvitation = (
       autoswapCreatorFacet,
     ).makeCollectFeesInvitation();
     const { zcfSeat: transferSeat } = zcf.makeEmptySeatKit();
-    await E.get(offerTo(zcf, invitation, {}, {}, transferSeat)).deposited;
+    await E.get(offerTo(zcf, invitation, harden({}), harden({}), transferSeat))
+      .deposited;
 
     seat.incrementBy(
       feeSeat.decrementBy(

--- a/packages/treasury/src/liquidation.js
+++ b/packages/treasury/src/liquidation.js
@@ -52,7 +52,7 @@ export async function liquidate(
 
   const isUnderwater = !AmountMath.isGTE(runProceedsAmount, runDebt);
   const runToBurn = isUnderwater ? runProceedsAmount : runDebt;
-  burnLosses({ RUN: runToBurn }, liquidationSeat);
+  burnLosses(harden({ RUN: runToBurn }), liquidationSeat);
   vaultKit.liquidated(AmountMath.subtract(runDebt, runToBurn));
 
   // any remaining RUN plus anything else leftover from the sale are refunded

--- a/packages/treasury/src/stablecoinMachine.js
+++ b/packages/treasury/src/stablecoinMachine.js
@@ -121,9 +121,11 @@ export async function start(zcf, privateArgs) {
    */
   function reallocateReward(amount, fromSeat, otherSeat = undefined) {
     rewardPoolSeat.incrementBy(
-      fromSeat.decrementBy({
-        RUN: amount,
-      }),
+      fromSeat.decrementBy(
+        harden({
+          RUN: amount,
+        }),
+      ),
     );
     if (otherSeat !== undefined) {
       zcf.reallocate(rewardPoolSeat, fromSeat, otherSeat);
@@ -205,13 +207,13 @@ export async function start(zcf, privateArgs) {
       // tokens as Liquidity. These governance tokens are held by govSeat
       const { zcfSeat: govSeat } = zcf.makeEmptySeatKit();
       // TODO this should create the seat for us
-      govMint.mintGains({ Governance: govAmount }, govSeat);
+      govMint.mintGains(harden({ Governance: govAmount }), govSeat);
 
       // trade the governance tokens for collateral, putting the
       // collateral on Secondary to be positioned for Autoswap
-      seat.incrementBy(govSeat.decrementBy({ Governance: govAmount }));
-      seat.decrementBy({ Collateral: collateralIn });
-      govSeat.incrementBy({ Secondary: collateralIn });
+      seat.incrementBy(govSeat.decrementBy(harden({ Governance: govAmount })));
+      seat.decrementBy(harden({ Collateral: collateralIn }));
+      govSeat.incrementBy(harden({ Secondary: collateralIn }));
 
       zcf.reallocate(govSeat, seat);
       // the collateral is now on the temporary seat
@@ -221,7 +223,7 @@ export async function start(zcf, privateArgs) {
 
       // mint the new RUN to the Central position on the govSeat
       // so we can setup the autoswap pool
-      runMint.mintGains({ Central: runAmount }, govSeat);
+      runMint.mintGains(harden({ Central: runAmount }), govSeat);
 
       // TODO: check for existing pool, use its price instead of the
       // user-provided 'rate'. Or throw an error if it already exists.
@@ -356,9 +358,9 @@ export async function start(zcf, privateArgs) {
     } = zcf.makeEmptySeatKit();
     const bootstrapAmount = AmountMath.make(runBrand, bootstrapPaymentValue);
     runMint.mintGains(
-      {
+      harden({
         Bootstrap: bootstrapAmount,
-      },
+      }),
       bootstrapZCFSeat,
     );
     bootstrapZCFSeat.exit();

--- a/packages/treasury/src/stablecoinMachine.js
+++ b/packages/treasury/src/stablecoinMachine.js
@@ -180,8 +180,8 @@ export async function start(zcf, privateArgs) {
 
     const { creatorFacet: liquidationFacet } = await E(zoe).startInstance(
       liquidationInstall,
-      { RUN: runIssuer },
-      { autoswap: autoswapAPI },
+      harden({ RUN: runIssuer, [collateralKeyword]: collateralIssuer }),
+      harden({ autoswap: autoswapAPI }),
     );
 
     async function addTypeHook(seat) {

--- a/packages/treasury/src/vaultManager.js
+++ b/packages/treasury/src/vaultManager.js
@@ -205,7 +205,7 @@ export function makeVaultManager(
     );
     sortedVaultKits.updateAllDebts();
     reschedulePriceCheck();
-    runMint.mintGains({ RUN: poolIncrement }, poolIncrementSeat);
+    runMint.mintGains(harden({ RUN: poolIncrement }), poolIncrementSeat);
     reallocateReward(poolIncrement, poolIncrementSeat);
   }
 

--- a/packages/treasury/test/swingsetTests/governance/bootstrap.js
+++ b/packages/treasury/test/swingsetTests/governance/bootstrap.js
@@ -54,14 +54,18 @@ const installContracts = async (zoe, cb) => {
 };
 
 const startElectorate = async (zoe, installations) => {
-  const electorateTerms = {
+  const electorateTerms = harden({
     committeeName: 'TwentyCommittee',
     committeeSize: 5,
-  };
+  });
   const {
     creatorFacet: electorateCreatorFacet,
     instance: electorateInstance,
-  } = await E(zoe).startInstance(installations.electorate, {}, electorateTerms);
+  } = await E(zoe).startInstance(
+    installations.electorate,
+    harden({}),
+    electorateTerms,
+  );
   return { electorateCreatorFacet, electorateInstance };
 };
 

--- a/packages/treasury/test/swingsetTests/governance/vat-owner.js
+++ b/packages/treasury/test/swingsetTests/governance/vat-owner.js
@@ -50,8 +50,8 @@ const build = async (
 
   const governorFacets = await E(zoe).startInstance(
     installations.governor,
-    {},
-    {
+    harden({}),
+    harden({
       timer,
       electorateInstance,
       governedContractInstallation: installations.treasury,
@@ -60,7 +60,7 @@ const build = async (
         issuerKeywordRecord: {},
         privateArgs: privateTreasuryArgs,
       },
-    },
+    }),
     privateArgs,
   );
 

--- a/packages/treasury/test/swingsetTests/treasury/bootstrap.js
+++ b/packages/treasury/test/swingsetTests/treasury/bootstrap.js
@@ -21,14 +21,18 @@ const setupBasicMints = () => {
 };
 
 const startElectorate = async (zoe, installations) => {
-  const electorateTerms = {
+  const electorateTerms = harden({
     committeeName: 'TwentyCommittee',
     committeeSize: 5,
-  };
+  });
   const {
     creatorFacet: committeeCreator,
     instance: electorateInstance,
-  } = await E(zoe).startInstance(installations.electorate, {}, electorateTerms);
+  } = await E(zoe).startInstance(
+    installations.electorate,
+    harden({}),
+    electorateTerms,
+  );
   return { committeeCreator, electorateInstance };
 };
 

--- a/packages/treasury/test/swingsetTests/treasury/vat-owner.js
+++ b/packages/treasury/test/swingsetTests/treasury/vat-owner.js
@@ -49,7 +49,7 @@ const build = async (
 
   const { creatorFacet: governor } = await E(zoe).startInstance(
     installations.governor,
-    {},
+    harden({}),
     {
       timer,
       electorateInstance,
@@ -60,7 +60,7 @@ const build = async (
         privateArgs: privateTreasuryArgs,
       },
     },
-    { electorateCreatorFacet: committeeCreator },
+    harden({ electorateCreatorFacet: committeeCreator }),
   );
 
   const governedInstance = await E(governor).getInstance();

--- a/packages/treasury/test/test-bootstrapPayment.js
+++ b/packages/treasury/test/test-bootstrapPayment.js
@@ -64,7 +64,11 @@ const setupGovernor = async (
   const {
     instance: electorateInstance,
     creatorFacet: electorateCreatorFacet,
-  } = await E(zoe).startInstance(electorateInstall, {}, electorateTerms);
+  } = await E(zoe).startInstance(
+    electorateInstall,
+    harden({}),
+    electorateTerms,
+  );
 
   const governorTerms = {
     electorateInstance,
@@ -74,7 +78,7 @@ const setupGovernor = async (
   };
   return E(zoe).startInstance(
     governanceInstall,
-    {},
+    harden({}),
     governorTerms,
     harden({ electorateCreatorFacet }),
   );

--- a/packages/treasury/test/test-stablecoin.js
+++ b/packages/treasury/test/test-stablecoin.js
@@ -207,7 +207,11 @@ async function setupServices(
   const {
     creatorFacet: committeeCreator,
     instance: electorateInstance,
-  } = await E(zoe).startInstance(installs.electorate, {}, electorateTerms);
+  } = await E(zoe).startInstance(
+    installs.electorate,
+    harden({}),
+    electorateTerms,
+  );
 
   const priceAuthorityPromiseKit = makePromiseKit();
   const priceAuthorityPromise = priceAuthorityPromiseKit.promise;
@@ -234,9 +238,14 @@ async function setupServices(
     instance: governorInstance,
     publicFacet: governorPublicFacet,
     creatorFacet: governorCreatorFacet,
-  } = await E(zoe).startInstance(installs.governor, {}, governorTerms, {
-    electorateCreatorFacet: committeeCreator,
-  });
+  } = await E(zoe).startInstance(
+    installs.governor,
+    harden({}),
+    governorTerms,
+    harden({
+      electorateCreatorFacet: committeeCreator,
+    }),
+  );
 
   const stablecoinMachineP = E(governorCreatorFacet).getCreatorFacet();
   const lenderP = E(governorCreatorFacet).getPublicFacet();
@@ -617,10 +626,10 @@ test('price falls precipitously', async t => {
 
   // Sell some Eth to drive the value down
   const swapInvitation = E(services.autoswapAPI).makeSwapInvitation();
-  const proposal = {
+  const proposal = harden({
     give: { In: AmountMath.make(aethBrand, 200n) },
     want: { Out: AmountMath.makeEmpty(runBrand) },
-  };
+  });
   await E(zoe).offer(
     swapInvitation,
     proposal,
@@ -1265,7 +1274,7 @@ test('overdeposit', async t => {
 
   // overpay debt ///////////////////////////////////// (give RUN)
 
-  const combinedRun = await E(runIssuer).combine([borrowedRun, bobRun]);
+  const combinedRun = await E(runIssuer).combine(harden([borrowedRun, bobRun]));
   const depositRun2 = AmountMath.make(runBrand, 6000n);
 
   const aliceOverpaySeat = await E(zoe).offer(
@@ -1545,15 +1554,15 @@ test('bad chargingPeriod', async t => {
     () =>
       E(zoe).startInstance(
         stablecoinInstall,
-        {},
-        {
+        harden({}),
+        harden({
           autoswapInstall,
           priceAuthority: priceAuthorityPromise,
           loanParams,
           timerService: manualTimer,
           liquidationInstall,
           governedParams: governedParameterTerms,
-        },
+        }),
         harden({ feeMintAccess }),
       ),
     { message: 'chargingPeriod (2) must be a BigInt' },
@@ -1774,7 +1783,7 @@ test('close loan', async t => {
 
   // close loan, using Bob's RUN /////////////////////////////////////
 
-  const runRepayment = await E(runIssuer).combine([bobRun, runLent]);
+  const runRepayment = await E(runIssuer).combine(harden([bobRun, runLent]));
 
   const aliceCloseSeat = await E(zoe).offer(
     E(aliceVault).makeCloseInvitation(),

--- a/packages/treasury/test/vault-contract-wrapper.js
+++ b/packages/treasury/test/vault-contract-wrapper.js
@@ -41,9 +41,11 @@ export async function start(zcf, privateArgs) {
 
   function reallocateReward(amount, fromSeat, otherSeat) {
     stableCoinSeat.incrementBy(
-      fromSeat.decrementBy({
-        RUN: amount,
-      }),
+      fromSeat.decrementBy(
+        harden({
+          RUN: amount,
+        }),
+      ),
     );
     if (otherSeat !== undefined) {
       zcf.reallocate(stableCoinSeat, fromSeat, otherSeat);

--- a/packages/zoe/src/cleanProposal.js
+++ b/packages/zoe/src/cleanProposal.js
@@ -4,6 +4,7 @@ import { assert, details as X, q } from '@agoric/assert';
 import { mustBeComparable } from '@agoric/same-structure';
 import { isNat } from '@agoric/nat';
 import { AmountMath, getAssetKind } from '@agoric/ertp';
+import { assertRecord } from '@agoric/marshal';
 import {
   isOnDemandExitRule,
   isWaivedExitRule,
@@ -61,10 +62,11 @@ const cleanKeys = (allowedKeys, record) => {
 export const getKeywords = keywordRecord =>
   harden(Object.getOwnPropertyNames(keywordRecord));
 
-const coerceAmountKeywordRecord = (
+export const coerceAmountKeywordRecord = (
   allegedAmountKeywordRecord,
   getAssetKindByBrand,
 ) => {
+  assertRecord(allegedAmountKeywordRecord, 'amountKeywordRecord');
   const keywords = getKeywords(allegedAmountKeywordRecord);
   keywords.forEach(assertKeywordName);
 
@@ -84,7 +86,7 @@ const coerceAmountKeywordRecord = (
   });
 
   // Recreate the amountKeywordRecord with coercedAmounts.
-  return arrayToObj(coercedAmounts, keywords);
+  return harden(arrayToObj(coercedAmounts, keywords));
 };
 
 export const cleanKeywords = keywordRecord => {

--- a/packages/zoe/src/contractFacet/zcfSeat.js
+++ b/packages/zoe/src/contractFacet/zcfSeat.js
@@ -9,6 +9,7 @@ import { Far } from '@agoric/marshal';
 import { isOfferSafe } from './offerSafety.js';
 import { assertRightsConserved } from './rightsConservation.js';
 import { addToAllocation, subtractFromAllocation } from './allocationMath.js';
+import { coerceAmountKeywordRecord } from '../cleanProposal.js';
 
 /** @type {CreateSeatManager} */
 export const createSeatManager = (
@@ -303,6 +304,10 @@ export const createSeatManager = (
       },
       incrementBy: amountKeywordRecord => {
         assertActive(zcfSeat);
+        amountKeywordRecord = coerceAmountKeywordRecord(
+          amountKeywordRecord,
+          getAssetKindByBrand,
+        );
         setStagedAllocation(
           zcfSeat,
           addToAllocation(getStagedAllocation(zcfSeat), amountKeywordRecord),
@@ -311,6 +316,10 @@ export const createSeatManager = (
       },
       decrementBy: amountKeywordRecord => {
         assertActive(zcfSeat);
+        amountKeywordRecord = coerceAmountKeywordRecord(
+          amountKeywordRecord,
+          getAssetKindByBrand,
+        );
         setStagedAllocation(
           zcfSeat,
           subtractFromAllocation(

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -7,7 +7,7 @@ import { AssetKind, AmountMath } from '@agoric/ertp';
 import { makeNotifierKit, observeNotifier } from '@agoric/notifier';
 import { makePromiseKit } from '@agoric/promise-kit';
 
-import { cleanProposal } from '../cleanProposal.js';
+import { cleanProposal, coerceAmountKeywordRecord } from '../cleanProposal.js';
 import { evalContractBundle } from './evalContractCode.js';
 import { makeExitObj } from './exit.js';
 import { makeHandle } from '../makeHandle.js';
@@ -113,15 +113,6 @@ export const makeZCFZygote = (
     return { zcfSeat, userSeat: userSeatPromiseKit.promise };
   };
 
-  const assertAmountKeywordRecord = (amountKeywordRecord, name) => {
-    assert.typeof(
-      amountKeywordRecord,
-      'object',
-      X`${name} ${amountKeywordRecord} must be an amountKeywordRecord`,
-    );
-    assert(amountKeywordRecord !== null, X`${name} cannot be null`);
-  };
-
   // A helper for the code shared between MakeZCFMint and RegisterZCFMint
   const doMakeZCFMint = async (keyword, zoeMintP) => {
     const {
@@ -148,7 +139,7 @@ export const makeZCFZygote = (
         return mintyIssuerRecord;
       },
       mintGains: (gains, zcfSeat = undefined) => {
-        assertAmountKeywordRecord(gains, 'gains');
+        gains = coerceAmountKeywordRecord(gains, getAssetKindByBrand);
         if (zcfSeat === undefined) {
           zcfSeat = makeEmptySeatKit().zcfSeat;
         }
@@ -186,7 +177,7 @@ export const makeZCFZygote = (
         return zcfSeat;
       },
       burnLosses: (losses, zcfSeat) => {
-        assertAmountKeywordRecord(losses, 'losses');
+        losses = coerceAmountKeywordRecord(losses, getAssetKindByBrand);
         const totalToBurn = Object.values(losses).reduce(add, empty);
         assert(
           !zcfSeat.hasExited(),

--- a/packages/zoe/src/contractSupport/types.js
+++ b/packages/zoe/src/contractSupport/types.js
@@ -85,7 +85,7 @@
  *   contractB. Note that the pathway to deposit the payout back to
  *   contractA reverses this mapping.
  *
- * @param {Proposal} proposal
+ * @param {Proposal | undefined} proposal
  *   The proposal for the offer to be made to contractB
  *
  * @param {ZCFSeat} fromSeat

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -246,19 +246,23 @@ export async function saveAllIssuers(zcf, issuerKeywordRecord = harden({})) {
 
 /** @type {MapKeywords} */
 export const mapKeywords = (keywordRecord = {}, keywordMapping) => {
-  return Object.fromEntries(
-    Object.entries(keywordRecord).map(([keyword, value]) => {
-      if (keywordMapping[keyword] === undefined) {
-        return [keyword, value];
-      }
-      return [keywordMapping[keyword], value];
-    }),
+  return harden(
+    Object.fromEntries(
+      Object.entries(keywordRecord).map(([keyword, value]) => {
+        if (keywordMapping[keyword] === undefined) {
+          return [keyword, value];
+        }
+        return [keywordMapping[keyword], value];
+      }),
+    ),
   );
 };
 /** @type {Reverse} */
 const reverse = (keywordRecord = {}) => {
-  return Object.fromEntries(
-    Object.entries(keywordRecord).map(([key, value]) => [value, key]),
+  return harden(
+    Object.fromEntries(
+      Object.entries(keywordRecord).map(([key, value]) => [value, key]),
+    ),
   );
 };
 
@@ -276,14 +280,14 @@ export const offerTo = async (
   const zoe = zcf.getZoeService();
   const mappingReversed = reverse(keywordMapping);
 
+  const newKeywords =
+    proposal !== undefined
+      ? mapKeywords(proposal.give, mappingReversed)
+      : harden({});
+
   // the proposal is in the other contract's keywords, but we want to
   // use `proposal.give` to withdraw
-  const payments = await withdrawFromSeat(
-    zcf,
-    fromSeat,
-    // `proposal.give` may be undefined
-    mapKeywords(proposal.give, mappingReversed),
-  );
+  const payments = await withdrawFromSeat(zcf, fromSeat, newKeywords);
 
   // Map to the other contract's keywords
   const paymentsForOtherContract = mapKeywords(payments, keywordMapping);

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -54,11 +54,11 @@ export const satisfies = (zcf, seat, update) => {
 /** @type {Swap} */
 export const swap = (zcf, leftSeat, rightSeat) => {
   try {
-    rightSeat.decrementBy(leftSeat.getProposal().want);
-    leftSeat.incrementBy(leftSeat.getProposal().want);
+    rightSeat.decrementBy(harden(leftSeat.getProposal().want));
+    leftSeat.incrementBy(harden(leftSeat.getProposal().want));
 
-    leftSeat.decrementBy(rightSeat.getProposal().want);
-    rightSeat.incrementBy(rightSeat.getProposal().want);
+    leftSeat.decrementBy(harden(rightSeat.getProposal().want));
+    rightSeat.incrementBy(harden(rightSeat.getProposal().want));
 
     zcf.reallocate(leftSeat, rightSeat);
   } catch (err) {
@@ -75,11 +75,11 @@ export const swap = (zcf, leftSeat, rightSeat) => {
 /** @type {SwapExact} */
 export const swapExact = (zcf, leftSeat, rightSeat) => {
   try {
-    rightSeat.decrementBy(rightSeat.getProposal().give);
-    leftSeat.incrementBy(leftSeat.getProposal().want);
+    rightSeat.decrementBy(harden(rightSeat.getProposal().give));
+    leftSeat.incrementBy(harden(leftSeat.getProposal().want));
 
-    leftSeat.decrementBy(leftSeat.getProposal().give);
-    rightSeat.incrementBy(rightSeat.getProposal().want);
+    leftSeat.decrementBy(harden(leftSeat.getProposal().give));
+    rightSeat.incrementBy(harden(rightSeat.getProposal().want));
 
     zcf.reallocate(leftSeat, rightSeat);
   } catch (err) {
@@ -178,8 +178,8 @@ export async function depositToSeat(zcf, recipientSeat, amounts, payments) {
     // exit the temporary seat. Note that the offerResult is the return value of this
     // function, so this synchronous trade must happen before the
     // offerResult resolves.
-    tempSeat.decrementBy(amounts);
-    recipientSeat.incrementBy(amounts);
+    tempSeat.decrementBy(harden(amounts));
+    recipientSeat.incrementBy(harden(amounts));
     zcf.reallocate(tempSeat, recipientSeat);
     tempSeat.exit();
     return depositToSeatSuccessMsg;
@@ -213,8 +213,8 @@ export async function depositToSeat(zcf, recipientSeat, amounts, payments) {
 export async function withdrawFromSeat(zcf, seat, amounts) {
   assert(!seat.hasExited(), 'The seat cannot have exited.');
   const { zcfSeat: tempSeat, userSeat: tempUserSeatP } = zcf.makeEmptySeatKit();
-  seat.decrementBy(amounts);
-  tempSeat.incrementBy(amounts);
+  seat.decrementBy(harden(amounts));
+  tempSeat.incrementBy(harden(amounts));
   zcf.reallocate(tempSeat, seat);
   tempSeat.exit();
   return E(tempUserSeatP).getPayouts();

--- a/packages/zoe/src/contracts/attestation/expiring/extendExpiration.js
+++ b/packages/zoe/src/contracts/attestation/expiring/extendExpiration.js
@@ -72,8 +72,8 @@ const extendExpiration = (
 
   // commit point within updateLienedAmount
   valueToMint.forEach(updateLienedAmount);
-  zcfMint.burnLosses(seat.getCurrentAllocation(), seat);
-  zcfMint.mintGains({ Attestation: amountToMint }, seat);
+  zcfMint.burnLosses(harden(seat.getCurrentAllocation()), seat);
+  zcfMint.mintGains(harden({ Attestation: amountToMint }), seat);
   seat.exit();
 };
 harden(extendExpiration);

--- a/packages/zoe/src/contracts/attestation/helpers.js
+++ b/packages/zoe/src/contracts/attestation/helpers.js
@@ -31,7 +31,7 @@ harden(validateInputs);
  */
 const mintZCFMintPayment = (zcf, zcfMint, amountToMint) => {
   const { userSeat, zcfSeat } = zcf.makeEmptySeatKit();
-  zcfMint.mintGains({ Attestation: amountToMint }, zcfSeat);
+  zcfMint.mintGains(harden({ Attestation: amountToMint }), zcfSeat);
   zcfSeat.exit();
   return E(userSeat).getPayout('Attestation');
 };

--- a/packages/zoe/src/contracts/attestation/returnable/returnableNFT.js
+++ b/packages/zoe/src/contracts/attestation/returnable/returnableNFT.js
@@ -66,7 +66,7 @@ const setupAttestation = async (attestationTokenName, empty, zcf) => {
     const attestationAmount = checkOfferShape(seat, attestationBrand);
 
     // Burn the escrowed attestation payment and exit the seat
-    zcfMint.burnLosses({ Attestation: attestationAmount }, seat);
+    zcfMint.burnLosses(harden({ Attestation: attestationAmount }), seat);
     seat.exit();
 
     const attestationValue =

--- a/packages/zoe/src/contracts/auction/firstPriceLogic.js
+++ b/packages/zoe/src/contracts/auction/firstPriceLogic.js
@@ -43,11 +43,11 @@ export const calcWinnerAndClose = (zcf, sellSeat, bidSeats) => {
   }
 
   // Everyone else gets a refund so their values remain the same.
-  highestBidSeat.decrementBy({ Bid: highestBid });
-  sellSeat.incrementBy({ Ask: highestBid });
+  highestBidSeat.decrementBy(harden({ Bid: highestBid }));
+  sellSeat.incrementBy(harden({ Ask: highestBid }));
 
-  sellSeat.decrementBy({ Asset: assetAmount });
-  highestBidSeat.incrementBy({ Asset: assetAmount });
+  sellSeat.decrementBy(harden({ Asset: assetAmount }));
+  highestBidSeat.incrementBy(harden({ Asset: assetAmount }));
 
   zcf.reallocate(sellSeat, highestBidSeat);
   sellSeat.exit();

--- a/packages/zoe/src/contracts/auction/secondPriceLogic.js
+++ b/packages/zoe/src/contracts/auction/secondPriceLogic.js
@@ -49,11 +49,11 @@ export const calcWinnerAndClose = (zcf, sellSeat, bidSeats) => {
   }
 
   // Everyone else gets a refund so their values remain the same.
-  highestBidSeat.decrementBy({ Bid: secondHighestBid });
-  sellSeat.incrementBy({ Ask: secondHighestBid });
+  highestBidSeat.decrementBy(harden({ Bid: secondHighestBid }));
+  sellSeat.incrementBy(harden({ Ask: secondHighestBid }));
 
-  sellSeat.decrementBy({ Asset: assetAmount });
-  highestBidSeat.incrementBy({ Asset: assetAmount });
+  sellSeat.decrementBy(harden({ Asset: assetAmount }));
+  highestBidSeat.incrementBy(harden({ Asset: assetAmount }));
 
   zcf.reallocate(sellSeat, highestBidSeat);
   sellSeat.exit();

--- a/packages/zoe/src/contracts/autoswap.js
+++ b/packages/zoe/src/contracts/autoswap.js
@@ -93,15 +93,19 @@ const start = async zcf => {
   };
 
   function consummate(tradeAmountIn, tradeAmountOut, swapSeat) {
-    swapSeat.decrementBy({ In: tradeAmountIn });
-    poolSeat.incrementBy({
-      [getPoolKeyword(tradeAmountIn.brand)]: tradeAmountIn,
-    });
+    swapSeat.decrementBy(harden({ In: tradeAmountIn }));
+    poolSeat.incrementBy(
+      harden({
+        [getPoolKeyword(tradeAmountIn.brand)]: tradeAmountIn,
+      }),
+    );
 
-    poolSeat.decrementBy({
-      [getPoolKeyword(tradeAmountOut.brand)]: tradeAmountOut,
-    });
-    swapSeat.incrementBy({ Out: tradeAmountOut });
+    poolSeat.decrementBy(
+      harden({
+        [getPoolKeyword(tradeAmountOut.brand)]: tradeAmountOut,
+      }),
+    );
+    swapSeat.incrementBy(harden({ Out: tradeAmountOut }));
 
     zcf.reallocate(swapSeat, poolSeat);
 
@@ -191,15 +195,20 @@ const start = async zcf => {
       liquidityBrand,
       liquidityValueOut,
     );
-    liquidityMint.mintGains({ Liquidity: liquidityAmountOut }, poolSeat);
+    liquidityMint.mintGains(
+      harden({ Liquidity: liquidityAmountOut }),
+      poolSeat,
+    );
     liqTokenSupply += liquidityValueOut;
 
     const liquidityDeposited = {
       Central: AmountMath.make(brands.Central, centralIn),
       Secondary: secondaryAmount,
     };
-    poolSeat.incrementBy(seat.decrementBy(liquidityDeposited));
-    seat.incrementBy(poolSeat.decrementBy({ Liquidity: liquidityAmountOut }));
+    poolSeat.incrementBy(seat.decrementBy(harden(liquidityDeposited)));
+    seat.incrementBy(
+      poolSeat.decrementBy(harden({ Liquidity: liquidityAmountOut })),
+    );
 
     zcf.reallocate(poolSeat, seat);
 
@@ -296,10 +305,12 @@ const start = async zcf => {
     };
 
     poolSeat.incrementBy(
-      removeLiqSeat.decrementBy({ Liquidity: userAllocation.Liquidity }),
+      removeLiqSeat.decrementBy(
+        harden({ Liquidity: userAllocation.Liquidity }),
+      ),
     );
 
-    removeLiqSeat.incrementBy(poolSeat.decrementBy(liquidityRemoved));
+    removeLiqSeat.incrementBy(poolSeat.decrementBy(harden(liquidityRemoved)));
 
     zcf.reallocate(poolSeat, removeLiqSeat);
 

--- a/packages/zoe/src/contracts/barterExchange.js
+++ b/packages/zoe/src/contracts/barterExchange.js
@@ -67,11 +67,11 @@ const start = zcf => {
     const matchingTrade = findMatchingTrade(offerDetails, orders);
     if (matchingTrade) {
       // reallocate by giving each side what it wants
-      offerDetails.seat.decrementBy({ In: matchingTrade.amountOut });
-      matchingTrade.seat.incrementBy({ Out: matchingTrade.amountOut });
+      offerDetails.seat.decrementBy(harden({ In: matchingTrade.amountOut }));
+      matchingTrade.seat.incrementBy(harden({ Out: matchingTrade.amountOut }));
 
-      matchingTrade.seat.decrementBy({ In: offerDetails.amountOut });
-      offerDetails.seat.incrementBy({ Out: offerDetails.amountOut });
+      matchingTrade.seat.decrementBy(harden({ In: offerDetails.amountOut }));
+      offerDetails.seat.incrementBy(harden({ Out: offerDetails.amountOut }));
 
       zcf.reallocate(offerDetails.seat, matchingTrade.seat);
       removeFromOrders(matchingTrade);

--- a/packages/zoe/src/contracts/callSpread/fundedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/fundedCallSpread.js
@@ -111,13 +111,15 @@ const start = async zcf => {
         want: { LongOption: null, ShortOption: null },
       });
       collateralSeat.incrementBy(
-        creatorSeat.decrementBy({ Collateral: settlementAmount }),
+        creatorSeat.decrementBy(harden({ Collateral: settlementAmount })),
       );
       creatorSeat.incrementBy(
-        collateralSeat.decrementBy({
-          LongOption: longAmount,
-          ShortOption: shortAmount,
-        }),
+        collateralSeat.decrementBy(
+          harden({
+            LongOption: longAmount,
+            ShortOption: shortAmount,
+          }),
+        ),
       );
       zcf.reallocate(collateralSeat, creatorSeat);
       payoffHandler.schedulePayoffs();

--- a/packages/zoe/src/contracts/callSpread/payoffHandler.js
+++ b/packages/zoe/src/contracts/callSpread/payoffHandler.js
@@ -36,7 +36,9 @@ function makePayoffHandler(zcf, seatPromiseKits, collateralSeat) {
 
   function reallocateToSeat(seatPromise, seatPortion) {
     seatPromise.then(seat => {
-      seat.incrementBy(collateralSeat.decrementBy({ Collateral: seatPortion }));
+      seat.incrementBy(
+        collateralSeat.decrementBy(harden({ Collateral: seatPortion })),
+      );
       zcf.reallocate(seat, collateralSeat);
       seat.exit();
       seatsExited += 1;

--- a/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
+++ b/packages/zoe/src/contracts/callSpread/pricedCallSpread.js
@@ -131,9 +131,9 @@ const start = zcf => {
         X`wanted option not a match`,
       );
 
-      depositSeat.incrementBy(collateralSeat.decrementBy(spreadAmount));
+      depositSeat.incrementBy(collateralSeat.decrementBy(harden(spreadAmount)));
       collateralSeat.incrementBy(
-        depositSeat.decrementBy({ Collateral: newCollateral }),
+        depositSeat.decrementBy(harden({ Collateral: newCollateral })),
       );
 
       zcf.reallocate(collateralSeat, depositSeat);

--- a/packages/zoe/src/contracts/loan/addCollateral.js
+++ b/packages/zoe/src/contracts/loan/addCollateral.js
@@ -21,9 +21,11 @@ export const makeAddCollateralInvitation = (zcf, config) => {
     });
 
     collateralSeat.incrementBy(
-      addCollateralSeat.decrementBy({
-        Collateral: addCollateralSeat.getAmountAllocated('Collateral'),
-      }),
+      addCollateralSeat.decrementBy(
+        harden({
+          Collateral: addCollateralSeat.getAmountAllocated('Collateral'),
+        }),
+      ),
     );
 
     zcf.reallocate(collateralSeat, addCollateralSeat);

--- a/packages/zoe/src/contracts/loan/borrow.js
+++ b/packages/zoe/src/contracts/loan/borrow.js
@@ -80,11 +80,13 @@ export const makeBorrowInvitation = (zcf, config) => {
     const { zcfSeat: collateralSeat } = zcf.makeEmptySeatKit();
 
     // Transfer the wanted Loan amount to the borrower
-    borrowerSeat.incrementBy(lenderSeat.decrementBy({ Loan: loanWanted }));
+    borrowerSeat.incrementBy(
+      lenderSeat.decrementBy(harden({ Loan: loanWanted })),
+    );
 
     // Transfer *all* collateral to the collateral seat.
     collateralSeat.incrementBy(
-      borrowerSeat.decrementBy({ Collateral: collateralGiven }),
+      borrowerSeat.decrementBy(harden({ Collateral: collateralGiven })),
     );
     zcf.reallocate(lenderSeat, borrowerSeat, collateralSeat);
 

--- a/packages/zoe/src/contracts/loan/close.js
+++ b/packages/zoe/src/contracts/loan/close.js
@@ -43,14 +43,16 @@ export const makeCloseLoanInvitation = (zcf, config) => {
     // Transfer the repaid loan amount to the lender
 
     repaySeat.incrementBy(
-      collateralSeat.decrementBy({
-        Collateral: collateralSeat.getAmountAllocated(
-          'Collateral',
-          collateralBrand,
-        ),
-      }),
+      collateralSeat.decrementBy(
+        harden({
+          Collateral: collateralSeat.getAmountAllocated(
+            'Collateral',
+            collateralBrand,
+          ),
+        }),
+      ),
     );
-    lenderSeat.incrementBy(repaySeat.decrementBy({ Loan: debt }));
+    lenderSeat.incrementBy(repaySeat.decrementBy(harden({ Loan: debt })));
 
     zcf.reallocate(repaySeat, collateralSeat, lenderSeat);
 

--- a/packages/zoe/src/contracts/loan/scheduleLiquidation.js
+++ b/packages/zoe/src/contracts/loan/scheduleLiquidation.js
@@ -56,7 +56,7 @@ export const scheduleLiquidation = (zcf, configWithBorrower) => {
       // reallocate the collateral to the lender and shutdown the
       // contract, kicking out any remaining seats.
       lenderSeat.incrementBy(
-        collateralSeat.decrementBy({ Collateral: allCollateral }),
+        collateralSeat.decrementBy(harden({ Collateral: allCollateral })),
       );
       zcf.reallocate(lenderSeat, collateralSeat);
       zcf.shutdownWithFailure(err);

--- a/packages/zoe/src/contracts/mintPayments.js
+++ b/packages/zoe/src/contracts/mintPayments.js
@@ -33,7 +33,7 @@ const start = async zcf => {
   const mintPayment = value => seat => {
     const amount = AmountMath.make(brand, value);
     // Synchronously mint and allocate amount to seat.
-    zcfMint.mintGains({ Token: amount }, seat);
+    zcfMint.mintGains(harden({ Token: amount }), seat);
     // Exit the seat so that the user gets a payout.
     seat.exit();
     // Since the user is getting the payout through Zoe, we can

--- a/packages/zoe/src/contracts/multipoolAutoswap/pool.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/pool.js
@@ -60,18 +60,23 @@ export const makeAddPool = (
         liquidityBrand,
         liquidityValueOut,
       );
-      liquidityZcfMint.mintGains({ Liquidity: liquidityAmountOut }, poolSeat);
+      liquidityZcfMint.mintGains(
+        harden({ Liquidity: liquidityAmountOut }),
+        poolSeat,
+      );
       liqTokenSupply += liquidityValueOut;
 
       poolSeat.incrementBy(
-        zcfSeat.decrementBy({
-          Central: zcfSeat.getCurrentAllocation().Central,
-          Secondary: secondaryAmount,
-        }),
+        zcfSeat.decrementBy(
+          harden({
+            Central: zcfSeat.getCurrentAllocation().Central,
+            Secondary: secondaryAmount,
+          }),
+        ),
       );
 
       zcfSeat.incrementBy(
-        poolSeat.decrementBy({ Liquidity: liquidityAmountOut }),
+        poolSeat.decrementBy(harden({ Liquidity: liquidityAmountOut })),
       );
       zcf.reallocate(poolSeat, zcfSeat);
       zcfSeat.exit();
@@ -249,12 +254,16 @@ export const makeAddPool = (
 
         liqTokenSupply -= liquidityValueIn;
 
-        poolSeat.incrementBy(userSeat.decrementBy({ Liquidity: liquidityIn }));
+        poolSeat.incrementBy(
+          userSeat.decrementBy(harden({ Liquidity: liquidityIn })),
+        );
         userSeat.incrementBy(
-          poolSeat.decrementBy({
-            Central: centralTokenAmountOut,
-            Secondary: tokenKeywordAmountOut,
-          }),
+          poolSeat.decrementBy(
+            harden({
+              Central: centralTokenAmountOut,
+              Secondary: tokenKeywordAmountOut,
+            }),
+          ),
         );
         zcf.reallocate(userSeat, poolSeat);
 

--- a/packages/zoe/src/contracts/multipoolAutoswap/swap.js
+++ b/packages/zoe/src/contracts/multipoolAutoswap/swap.js
@@ -58,11 +58,11 @@ export const makeMakeSwapInvitation = (
 
       const poolSeat = pool.getPoolSeat();
 
-      seat.decrementBy({ In: reducedAmountIn });
-      poolSeat.incrementBy({ Central: reducedAmountIn });
+      seat.decrementBy(harden({ In: reducedAmountIn }));
+      poolSeat.incrementBy(harden({ Central: reducedAmountIn }));
 
-      poolSeat.decrementBy({ Secondary: amountOut });
-      seat.incrementBy({ Out: amountOut });
+      poolSeat.decrementBy(harden({ Secondary: amountOut }));
+      seat.incrementBy(harden({ Out: amountOut }));
 
       zcf.reallocate(poolSeat, seat);
       seat.exit();
@@ -78,11 +78,11 @@ export const makeMakeSwapInvitation = (
       } = pool.getPriceGivenAvailableInput(amountIn, brandOut);
       const poolSeat = pool.getPoolSeat();
 
-      seat.decrementBy({ In: reducedAmountIn });
-      poolSeat.incrementBy({ Secondary: reducedAmountIn });
+      seat.decrementBy(harden({ In: reducedAmountIn }));
+      poolSeat.incrementBy(harden({ Secondary: reducedAmountIn }));
 
-      poolSeat.decrementBy({ Central: amountOut });
-      seat.incrementBy({ Out: amountOut });
+      poolSeat.decrementBy(harden({ Central: amountOut }));
+      seat.incrementBy(harden({ Out: amountOut }));
 
       zcf.reallocate(seat, poolSeat);
 
@@ -101,14 +101,14 @@ export const makeMakeSwapInvitation = (
       const brandInPoolSeat = getPool(brandIn).getPoolSeat();
       const brandOutPoolSeat = getPool(brandOut).getPoolSeat();
 
-      brandOutPoolSeat.decrementBy({ Secondary: amountOut });
-      seat.incrementBy({ Out: amountOut });
+      brandOutPoolSeat.decrementBy(harden({ Secondary: amountOut }));
+      seat.incrementBy(harden({ Out: amountOut }));
 
-      brandInPoolSeat.decrementBy({ Central: reducedCentralAmount });
-      brandOutPoolSeat.incrementBy({ Central: reducedCentralAmount });
+      brandInPoolSeat.decrementBy(harden({ Central: reducedCentralAmount }));
+      brandOutPoolSeat.incrementBy(harden({ Central: reducedCentralAmount }));
 
-      seat.decrementBy({ In: reducedAmountIn });
-      brandInPoolSeat.incrementBy({ Secondary: reducedAmountIn });
+      seat.decrementBy(harden({ In: reducedAmountIn }));
+      brandInPoolSeat.incrementBy(harden({ Secondary: reducedAmountIn }));
 
       zcf.reallocate(brandOutPoolSeat, brandInPoolSeat, seat);
       seat.exit();
@@ -149,11 +149,11 @@ export const makeMakeSwapInvitation = (
         throw seat.fail(Error(reason));
       }
       const poolSeat = pool.getPoolSeat();
-      seat.decrementBy({ In: amountIn });
-      poolSeat.incrementBy({ Secondary: amountIn });
+      seat.decrementBy(harden({ In: amountIn }));
+      poolSeat.incrementBy(harden({ Secondary: amountIn }));
 
-      poolSeat.decrementBy({ Central: improvedAmountOut });
-      seat.incrementBy({ Out: improvedAmountOut });
+      poolSeat.decrementBy(harden({ Central: improvedAmountOut }));
+      seat.incrementBy(harden({ Out: improvedAmountOut }));
 
       zcf.reallocate(seat, poolSeat);
 
@@ -169,11 +169,11 @@ export const makeMakeSwapInvitation = (
 
       const poolSeat = pool.getPoolSeat();
 
-      seat.decrementBy({ In: amountIn });
-      poolSeat.incrementBy({ Central: amountIn });
+      seat.decrementBy(harden({ In: amountIn }));
+      poolSeat.incrementBy(harden({ Central: amountIn }));
 
-      poolSeat.decrementBy({ Secondary: improvedAmountOut });
-      seat.incrementBy({ Out: improvedAmountOut });
+      poolSeat.decrementBy(harden({ Secondary: improvedAmountOut }));
+      seat.incrementBy(harden({ Out: improvedAmountOut }));
 
       zcf.reallocate(poolSeat, seat);
 
@@ -191,14 +191,14 @@ export const makeMakeSwapInvitation = (
       const brandInPoolSeat = getPool(brandIn).getPoolSeat();
       const brandOutPoolSeat = getPool(brandOut).getPoolSeat();
 
-      brandOutPoolSeat.decrementBy({ Secondary: improvedAmountOut });
-      seat.incrementBy({ Out: improvedAmountOut });
+      brandOutPoolSeat.decrementBy(harden({ Secondary: improvedAmountOut }));
+      seat.incrementBy(harden({ Out: improvedAmountOut }));
 
-      brandInPoolSeat.decrementBy({ Central: improvedCentralAmount });
-      brandOutPoolSeat.incrementBy({ Central: improvedCentralAmount });
+      brandInPoolSeat.decrementBy(harden({ Central: improvedCentralAmount }));
+      brandOutPoolSeat.incrementBy(harden({ Central: improvedCentralAmount }));
 
-      seat.decrementBy({ In: amountIn });
-      brandInPoolSeat.incrementBy({ Secondary: amountIn });
+      seat.decrementBy(harden({ In: amountIn }));
+      brandInPoolSeat.incrementBy(harden({ Secondary: amountIn }));
 
       zcf.reallocate(brandInPoolSeat, brandOutPoolSeat, seat);
       seat.exit();

--- a/packages/zoe/src/contracts/newSwap/collectFees.js
+++ b/packages/zoe/src/contracts/newSwap/collectFees.js
@@ -3,7 +3,7 @@
 export const makeMakeCollectFeesInvitation = (zcf, feeSeat, centralBrand) => {
   const collectFees = seat => {
     const amount = feeSeat.getAmountAllocated('RUN', centralBrand);
-    seat.incrementBy(feeSeat.decrementBy({ RUN: amount }));
+    seat.incrementBy(feeSeat.decrementBy(harden({ RUN: amount })));
     zcf.reallocate(seat, feeSeat);
 
     seat.exit();

--- a/packages/zoe/src/contracts/newSwap/swap.js
+++ b/packages/zoe/src/contracts/newSwap/swap.js
@@ -37,20 +37,20 @@ export const makeMakeSwapInvitation = (
     const poolSeat = pool.getPoolSeat();
 
     // Transfer amountIn from the user
-    seat.decrementBy({ In: amountIn });
-    poolSeat.incrementBy({ Central: amountIn });
+    seat.decrementBy(harden({ In: amountIn }));
+    poolSeat.incrementBy(harden({ Central: amountIn }));
 
     // Transfer protocolFee
 
     // TODO: this should be transferred directly from the user such
     // that there's no way to accidentally take more than expected
     // from the pool.
-    poolSeat.decrementBy({ Central: protocolFee });
-    protocolSeat.incrementBy({ RUN: protocolFee });
+    poolSeat.decrementBy(harden({ Central: protocolFee }));
+    protocolSeat.incrementBy(harden({ RUN: protocolFee }));
 
     // Transfer amountOut from the pool
-    poolSeat.decrementBy({ Secondary: amountOut });
-    seat.incrementBy({ Out: amountOut });
+    poolSeat.decrementBy(harden({ Secondary: amountOut }));
+    seat.incrementBy(harden({ Out: amountOut }));
 
     zcf.reallocate(poolSeat, seat, protocolSeat);
     seat.exit();
@@ -67,16 +67,16 @@ export const makeMakeSwapInvitation = (
     const poolSeat = pool.getPoolSeat();
 
     // Transfer amountIn from the user
-    seat.decrementBy({ In: amountIn });
-    poolSeat.incrementBy({ Secondary: amountIn });
+    seat.decrementBy(harden({ In: amountIn }));
+    poolSeat.incrementBy(harden({ Secondary: amountIn }));
 
     // Transfer amountOut from the pool
-    poolSeat.decrementBy({ Central: amountOut });
-    seat.incrementBy({ Out: amountOut });
+    poolSeat.decrementBy(harden({ Central: amountOut }));
+    seat.incrementBy(harden({ Out: amountOut }));
 
     // Transfer protocolFee
-    poolSeat.decrementBy({ Central: protocolFee });
-    protocolSeat.incrementBy({ RUN: protocolFee });
+    poolSeat.decrementBy(harden({ Central: protocolFee }));
+    protocolSeat.incrementBy(harden({ RUN: protocolFee }));
 
     zcf.reallocate(poolSeat, seat, protocolSeat);
     seat.exit();
@@ -97,8 +97,8 @@ export const makeMakeSwapInvitation = (
     const brandOutPoolSeat = brandOutPool.getPoolSeat();
 
     // Transfer amountIn from the user
-    seat.decrementBy({ In: amountIn });
-    brandInPoolSeat.incrementBy({ Secondary: amountIn });
+    seat.decrementBy(harden({ In: amountIn }));
+    brandInPoolSeat.incrementBy(harden({ Secondary: amountIn }));
 
     // Transfer protocolFee from the brandInPool
 
@@ -107,16 +107,16 @@ export const makeMakeSwapInvitation = (
     // from brandInPool directly, and we subtract more value from
     // brandOutPool than we otherwise would, thus taking part of the
     // fee from brandOutPool too.
-    brandInPoolSeat.decrementBy({ Central: protocolFee });
-    protocolSeat.incrementBy({ RUN: protocolFee });
+    brandInPoolSeat.decrementBy(harden({ Central: protocolFee }));
+    protocolSeat.incrementBy(harden({ RUN: protocolFee }));
 
     // Transfer Central between pools
-    brandInPoolSeat.decrementBy({ Central: centralAmount });
-    brandOutPoolSeat.incrementBy({ Central: centralAmount });
+    brandInPoolSeat.decrementBy(harden({ Central: centralAmount }));
+    brandOutPoolSeat.incrementBy(harden({ Central: centralAmount }));
 
     // Transfer amountOut from the pool
-    brandOutPoolSeat.decrementBy({ Secondary: amountOut });
-    seat.incrementBy({ Out: amountOut });
+    brandOutPoolSeat.decrementBy(harden({ Secondary: amountOut }));
+    seat.incrementBy(harden({ Out: amountOut }));
 
     zcf.reallocate(brandInPoolSeat, brandOutPoolSeat, seat, protocolSeat);
     seat.exit();

--- a/packages/zoe/src/contracts/oracle.js
+++ b/packages/zoe/src/contracts/oracle.js
@@ -34,7 +34,7 @@ const start = async zcf => {
           ? feeSeat.getCurrentAllocation()
           : seat.getProposal().want;
 
-        seat.incrementBy(feeSeat.decrementBy(gains));
+        seat.incrementBy(feeSeat.decrementBy(harden(gains)));
         zcf.reallocate(seat, feeSeat);
         seat.exit();
         return 'Successfully withdrawn';
@@ -46,7 +46,9 @@ const start = async zcf => {
     makeShutdownInvitation: () => {
       const shutdown = seat => {
         revoked = true;
-        seat.incrementBy(feeSeat.decrementBy(feeSeat.getCurrentAllocation()));
+        seat.incrementBy(
+          feeSeat.decrementBy(harden(feeSeat.getCurrentAllocation())),
+        );
         zcf.reallocate(seat, feeSeat);
         zcf.shutdown(revokedMsg);
       };
@@ -84,7 +86,9 @@ const start = async zcf => {
           const fee = querySeat.getAmountAllocated('Fee', feeBrand);
           const { requiredFee, reply } = await E(handler).onQuery(query, fee);
           if (requiredFee) {
-            feeSeat.incrementBy(querySeat.decrementBy({ Fee: requiredFee }));
+            feeSeat.incrementBy(
+              querySeat.decrementBy(harden({ Fee: requiredFee })),
+            );
             zcf.reallocate(feeSeat, querySeat);
           }
           querySeat.exit();

--- a/packages/zoe/src/contracts/otcDesk.js
+++ b/packages/zoe/src/contracts/otcDesk.js
@@ -99,7 +99,9 @@ const start = zcf => {
   const addInventory = seat => {
     assertProposalShape(seat, { want: {} });
     // Take everything in this seat and add it to the marketMakerSeat
-    marketMakerSeat.incrementBy(seat.decrementBy(seat.getCurrentAllocation()));
+    marketMakerSeat.incrementBy(
+      seat.decrementBy(harden(seat.getCurrentAllocation())),
+    );
     zcf.reallocate(marketMakerSeat, seat);
     seat.exit();
     return 'Inventory added';
@@ -108,7 +110,7 @@ const start = zcf => {
   const removeInventory = seat => {
     assertProposalShape(seat, { give: {} });
     const { want } = seat.getProposal();
-    seat.incrementBy(marketMakerSeat.decrementBy(want));
+    seat.incrementBy(marketMakerSeat.decrementBy(harden(want)));
     zcf.reallocate(marketMakerSeat, seat);
     seat.exit();
     return 'Inventory removed';

--- a/packages/zoe/src/contracts/sellItems.js
+++ b/packages/zoe/src/contracts/sellItems.js
@@ -108,8 +108,12 @@ const start = zcf => {
     );
 
     // Reallocate.
-    sellerSeat.incrementBy(buyerSeat.decrementBy({ Money: providedMoney }));
-    buyerSeat.incrementBy(sellerSeat.decrementBy({ Items: wantedItems }));
+    sellerSeat.incrementBy(
+      buyerSeat.decrementBy(harden({ Money: providedMoney })),
+    );
+    buyerSeat.incrementBy(
+      sellerSeat.decrementBy(harden({ Items: wantedItems })),
+    );
     zcf.reallocate(buyerSeat, sellerSeat);
 
     // The buyer's offer has been processed.

--- a/packages/zoe/src/contracts/vpool-xyk-amm/doublePool.js
+++ b/packages/zoe/src/contracts/vpool-xyk-amm/doublePool.js
@@ -57,13 +57,13 @@ export const makeDoublePool = (
     const inPoolSeat = collateralInPool.getPoolSeat();
     const outPoolSeat = collateralOutPool.getPoolSeat();
 
-    seat.decrementBy({ In: prices.swapperGives });
-    seat.incrementBy({ Out: prices.swapperGets });
-    feeSeat.incrementBy({ RUN: prices.protocolFee });
-    inPoolSeat.incrementBy({ Secondary: prices.inPoolIncrement });
-    inPoolSeat.decrementBy({ Central: prices.inPoolDecrement });
-    outPoolSeat.incrementBy({ Central: prices.outPoolIncrement });
-    outPoolSeat.decrementBy({ Secondary: prices.outpoolDecrement });
+    seat.decrementBy(harden({ In: prices.swapperGives }));
+    seat.incrementBy(harden({ Out: prices.swapperGets }));
+    feeSeat.incrementBy(harden({ RUN: prices.protocolFee }));
+    inPoolSeat.incrementBy(harden({ Secondary: prices.inPoolIncrement }));
+    inPoolSeat.decrementBy(harden({ Central: prices.inPoolDecrement }));
+    outPoolSeat.incrementBy(harden({ Central: prices.outPoolIncrement }));
+    outPoolSeat.decrementBy(harden({ Secondary: prices.outpoolDecrement }));
 
     zcf.reallocate(outPoolSeat, inPoolSeat, feeSeat, seat);
     seat.exit();

--- a/packages/zoe/src/contracts/vpool-xyk-amm/pool.js
+++ b/packages/zoe/src/contracts/vpool-xyk-amm/pool.js
@@ -73,18 +73,23 @@ export const makeAddPool = (
         liquidityBrand,
         liquidityValueOut,
       );
-      liquidityZcfMint.mintGains({ Liquidity: liquidityAmountOut }, poolSeat);
+      liquidityZcfMint.mintGains(
+        harden({ Liquidity: liquidityAmountOut }),
+        poolSeat,
+      );
       liqTokenSupply += liquidityValueOut;
 
       poolSeat.incrementBy(
-        zcfSeat.decrementBy({
-          Central: zcfSeat.getCurrentAllocation().Central,
-          Secondary: secondaryAmount,
-        }),
+        zcfSeat.decrementBy(
+          harden({
+            Central: zcfSeat.getCurrentAllocation().Central,
+            Secondary: secondaryAmount,
+          }),
+        ),
       );
 
       zcfSeat.incrementBy(
-        poolSeat.decrementBy({ Liquidity: liquidityAmountOut }),
+        poolSeat.decrementBy(harden({ Liquidity: liquidityAmountOut })),
       );
       zcf.reallocate(poolSeat, zcfSeat);
       zcfSeat.exit();
@@ -164,12 +169,16 @@ export const makeAddPool = (
 
         liqTokenSupply -= liquidityValueIn;
 
-        poolSeat.incrementBy(userSeat.decrementBy({ Liquidity: liquidityIn }));
+        poolSeat.incrementBy(
+          userSeat.decrementBy(harden({ Liquidity: liquidityIn })),
+        );
         userSeat.incrementBy(
-          poolSeat.decrementBy({
-            Central: centralTokenAmountOut,
-            Secondary: tokenKeywordAmountOut,
-          }),
+          poolSeat.decrementBy(
+            harden({
+              Central: centralTokenAmountOut,
+              Secondary: tokenKeywordAmountOut,
+            }),
+          ),
         );
         zcf.reallocate(userSeat, poolSeat);
 

--- a/packages/zoe/src/contracts/vpool-xyk-amm/singlePool.js
+++ b/packages/zoe/src/contracts/vpool-xyk-amm/singlePool.js
@@ -35,16 +35,16 @@ export const makeSinglePool = (
 
   const allocateGainsAndLosses = (inBrand, prices, seat) => {
     const poolSeat = pool.getPoolSeat();
-    seat.decrementBy({ In: prices.swapperGives });
-    seat.incrementBy({ Out: prices.swapperGets });
-    feeSeat.incrementBy({ RUN: prices.protocolFee });
+    seat.decrementBy(harden({ In: prices.swapperGives }));
+    seat.incrementBy(harden({ Out: prices.swapperGets }));
+    feeSeat.incrementBy(harden({ RUN: prices.protocolFee }));
 
     if (inBrand === secondaryBrand) {
-      poolSeat.incrementBy({ Secondary: prices.xIncrement });
-      poolSeat.decrementBy({ Central: prices.yDecrement });
+      poolSeat.incrementBy(harden({ Secondary: prices.xIncrement }));
+      poolSeat.decrementBy(harden({ Central: prices.yDecrement }));
     } else {
-      poolSeat.incrementBy({ Central: prices.xIncrement });
-      poolSeat.decrementBy({ Secondary: prices.yDecrement });
+      poolSeat.incrementBy(harden({ Central: prices.xIncrement }));
+      poolSeat.decrementBy(harden({ Secondary: prices.yDecrement }));
     }
 
     zcf.reallocate(poolSeat, seat, feeSeat);

--- a/packages/zoe/test/runMintContract.js
+++ b/packages/zoe/test/runMintContract.js
@@ -13,7 +13,7 @@ const start = async (zcf, privateArgs) => {
   const creatorFacet = Far('creatorFacet', {
     mintRun: () => {
       const { zcfSeat, userSeat } = zcf.makeEmptySeatKit();
-      runMint.mintGains({ RUN: run10 }, zcfSeat);
+      runMint.mintGains(harden({ RUN: run10 }), zcfSeat);
       zcfSeat.exit();
       return E(userSeat).getPayout('RUN');
     },

--- a/packages/zoe/test/unitTests/bounty.js
+++ b/packages/zoe/test/unitTests/bounty.js
@@ -28,9 +28,11 @@ const start = async zcf => {
 
     function payOffBounty(seat) {
       seat.incrementBy(
-        funderSeat.decrementBy({
-          Bounty: funderSeat.getCurrentAllocation().Bounty,
-        }),
+        funderSeat.decrementBy(
+          harden({
+            Bounty: funderSeat.getCurrentAllocation().Bounty,
+          }),
+        ),
       );
 
       zcf.reallocate(funderSeat, seat);
@@ -59,7 +61,9 @@ const start = async zcf => {
       );
 
       // The funder gets the fee regardless of the outcome.
-      funderSeat.incrementBy(bountySeat.decrementBy({ Fee: feeAmount }));
+      funderSeat.incrementBy(
+        bountySeat.decrementBy(harden({ Fee: feeAmount })),
+      );
       zcf.reallocate(funderSeat, bountySeat);
 
       const wakeHandler = Far('wakeHandler', {

--- a/packages/zoe/test/unitTests/contracts/loan/test-liquidate.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-liquidate.js
@@ -47,11 +47,11 @@ test('test doLiquidation with mocked autoswap', async t => {
   const swapHandler = swapSeat => {
     // swapSeat gains 20 loan tokens from fakePoolSeat, loses all collateral
 
-    swapSeat.decrementBy({ In: collateral });
-    fakePoolSeat.incrementBy({ Secondary: collateral });
+    swapSeat.decrementBy(harden({ In: collateral }));
+    fakePoolSeat.incrementBy(harden({ Secondary: collateral }));
 
-    fakePoolSeat.decrementBy({ Central: price });
-    swapSeat.incrementBy({ Out: price });
+    fakePoolSeat.decrementBy(harden({ Central: price }));
+    swapSeat.incrementBy(harden({ Out: price }));
 
     zcf.reallocate(swapSeat, fakePoolSeat);
 

--- a/packages/zoe/test/unitTests/contracts/multipoolAutoswap/test-constantProduct.js
+++ b/packages/zoe/test/unitTests/contracts/multipoolAutoswap/test-constantProduct.js
@@ -23,11 +23,11 @@ test('constantProduct invariant', async t => {
   const secondaryMint = await checkedZCF.makeZCFMint('Secondary');
   const { brand: secondaryBrand } = secondaryMint.getIssuerRecord();
   centralMint.mintGains(
-    { Central: AmountMath.make(centralBrand, 10n ** 6n) },
+    harden({ Central: AmountMath.make(centralBrand, 10n ** 6n) }),
     poolSeat,
   );
   secondaryMint.mintGains(
-    { Secondary: AmountMath.make(secondaryBrand, 10n ** 6n) },
+    harden({ Secondary: AmountMath.make(secondaryBrand, 10n ** 6n) }),
     poolSeat,
   );
 
@@ -46,11 +46,13 @@ test('constantProduct invariant', async t => {
   // nothing, a clear violation of the constant product
   t.throws(
     () => {
-      poolSeat.decrementBy(poolSeatAllocation);
-      swapSeat.incrementBy({
-        In: poolSeatAllocation.Central,
-        Out: poolSeatAllocation.Secondary,
-      });
+      poolSeat.decrementBy(harden(poolSeatAllocation));
+      swapSeat.incrementBy(
+        harden({
+          In: poolSeatAllocation.Central,
+          Out: poolSeatAllocation.Secondary,
+        }),
+      );
       checkedZCF.reallocate(poolSeat, swapSeat);
     },
     {

--- a/packages/zoe/test/unitTests/contracts/vpool-xyk-amm/test-amm-governance.js
+++ b/packages/zoe/test/unitTests/contracts/vpool-xyk-amm/test-amm-governance.js
@@ -125,9 +125,14 @@ const setupServices = async (
     instance: governorInstance,
     publicFacet: governorPublicFacet,
     creatorFacet: governorCreatorFacet,
-  } = await E(zoe).startInstance(installs.governor, {}, governorTerms, {
-    electorateCreatorFacet: committeeCreator,
-  });
+  } = await E(zoe).startInstance(
+    installs.governor,
+    {},
+    governorTerms,
+    harden({
+      electorateCreatorFacet: committeeCreator,
+    }),
+  );
 
   const ammCreatorFacetP = E(governorCreatorFacet).getInternalCreatorFacet();
   const ammPublicP = E(governorCreatorFacet).getPublicFacet();

--- a/packages/zoe/test/unitTests/contracts/vpool-xyk-amm/test-xyk-amm-swap.js
+++ b/packages/zoe/test/unitTests/contracts/vpool-xyk-amm/test-xyk-amm-swap.js
@@ -146,9 +146,14 @@ const setupServices = async (
     instance: governorInstance,
     publicFacet: governorPublicFacet,
     creatorFacet: governorCreatorFacet,
-  } = await E(zoe).startInstance(installs.governor, {}, governorTerms, {
-    electorateCreatorFacet: committeeCreator,
-  });
+  } = await E(zoe).startInstance(
+    installs.governor,
+    {},
+    governorTerms,
+    harden({
+      electorateCreatorFacet: committeeCreator,
+    }),
+  );
 
   const ammCreatorFacetP = E(governorCreatorFacet).getInternalCreatorFacet();
   const ammPublicP = E(governorCreatorFacet).getPublicFacet();

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -413,7 +413,7 @@ test(`zoe.makeFeePurse`, async t => {
   const { zcfSeat, userSeat } = zcf.makeEmptySeatKit();
 
   const fee1000 = AmountMath.make(feeBrand, 1000n);
-  zcfMint.mintGains({ Fee: fee1000 }, zcfSeat);
+  zcfMint.mintGains(harden({ Fee: fee1000 }), zcfSeat);
 
   zcfSeat.exit();
   const payment = await E(userSeat).getPayout('Fee');
@@ -436,8 +436,8 @@ test(`zcf.registerFeeMint twice`, async t => {
   const zcfMint1 = await zcf1.registerFeeMint('RUN', feeMintAccess);
   const zcfMint2 = await zcf2.registerFeeMint('RUN', feeMintAccess);
 
-  const zcfSeat1 = zcfMint1.mintGains({ Fee: fee1000 });
-  const zcfSeat2 = zcfMint2.mintGains({ Fee: fee1000 });
+  const zcfSeat1 = zcfMint1.mintGains(harden({ Fee: fee1000 }));
+  const zcfSeat2 = zcfMint2.mintGains(harden({ Fee: fee1000 }));
 
   t.deepEqual(zcfSeat1.getCurrentAllocation(), {
     Fee: fee1000,

--- a/packages/zoe/test/unitTests/zcf/registerFeeMintContract.js
+++ b/packages/zoe/test/unitTests/zcf/registerFeeMintContract.js
@@ -20,9 +20,9 @@ const start = async (zcf, privateArgs) => {
   const { brand: RUNBrand } = RUNZCFMint.getIssuerRecord();
   const { zcfSeat, userSeat } = zcf.makeEmptySeatKit();
   RUNZCFMint.mintGains(
-    {
+    harden({
       Winnings: AmountMath.make(RUNBrand, 10n),
-    },
+    }),
     zcfSeat,
   );
 

--- a/packages/zoe/test/unitTests/zcf/test-allStagedSeatsUsed.js
+++ b/packages/zoe/test/unitTests/zcf/test-allStagedSeatsUsed.js
@@ -29,7 +29,7 @@ test(`allStagedSeatsUsed should not be asserted`, async t => {
     harden({ B: moolaKit.mint.mintPayment(moola(3n)) }),
   );
 
-  zcfSeat1.incrementBy(zcfSeat2.decrementBy({ B: moola(2n) }));
+  zcfSeat1.incrementBy(zcfSeat2.decrementBy(harden({ B: moola(2n) })));
   // Seats have staged allocations
   t.true(zcfSeat1.hasStagedAllocation());
 
@@ -43,9 +43,11 @@ test(`allStagedSeatsUsed should not be asserted`, async t => {
 
   const { brand: tokenBrand } = zcfMint.getIssuerRecord();
 
-  const zcfSeat3 = zcfMint.mintGains({
-    MyToken: AmountMath.make(tokenBrand, 100n),
-  });
+  const zcfSeat3 = zcfMint.mintGains(
+    harden({
+      MyToken: AmountMath.make(tokenBrand, 100n),
+    }),
+  );
 
   // This test was failing due to this bug: https://github.com/Agoric/agoric-sdk/issues/3613
   t.deepEqual(zcfSeat3.getCurrentAllocation(), {
@@ -80,9 +82,9 @@ test(`allStagedSeatsUsed should be asserted`, async t => {
     harden({ B: moolaKit.mint.mintPayment(moola(3n)) }),
   );
 
-  zcfSeat1.incrementBy(zcfSeat2.decrementBy({ B: moola(2n) }));
+  zcfSeat1.incrementBy(harden(zcfSeat2.decrementBy(harden({ B: moola(2n) }))));
 
-  zcfSeat3.incrementBy({ B: moola(3n) });
+  zcfSeat3.incrementBy(harden({ B: moola(3n) }));
 
   t.true(zcfSeat3.hasStagedAllocation());
 

--- a/packages/zoe/test/unitTests/zcf/test-reallocate-empty.js
+++ b/packages/zoe/test/unitTests/zcf/test-reallocate-empty.js
@@ -20,13 +20,13 @@ test(`zcf.reallocate introducing new empty amount`, async t => {
   const empty = AmountMath.makeEmpty(brand, AssetKind.NAT);
 
   // decrementBy empty does not throw, and does not add a keyword
-  zcfSeat1.decrementBy({ RUN: empty });
+  zcfSeat1.decrementBy(harden({ RUN: empty }));
   t.deepEqual(zcfSeat1.getStagedAllocation(), {});
 
   // Try to incrementBy empty. This succeeds, and the keyword is added
   // with an empty amount.
-  zcfSeat1.incrementBy({ RUN: empty });
-  zcfSeat2.incrementBy({ RUN: empty });
+  zcfSeat1.incrementBy(harden({ RUN: empty }));
+  zcfSeat2.incrementBy(harden({ RUN: empty }));
 
   zcf.reallocate(zcfSeat1, zcfSeat2);
 

--- a/packages/zoe/test/unitTests/zcf/test-reallocateForZCFMint.js
+++ b/packages/zoe/test/unitTests/zcf/test-reallocateForZCFMint.js
@@ -60,16 +60,16 @@ test(`stagedAllocations safely interleave with zcfMint calls`, async t => {
   const { brand: tokenBrand } = zcfMint.getIssuerRecord();
 
   // Decrement zcfSeat2 by non-zcfMintToken
-  zcfSeat2.decrementBy({ B: moola(2n) });
+  zcfSeat2.decrementBy(harden({ B: moola(2n) }));
   t.true(zcfSeat2.hasStagedAllocation());
   t.deepEqual(zcfSeat2.getStagedAllocation(), { B: moola(1n) });
   t.deepEqual(zcfSeat2.getCurrentAllocation(), { B: moola(3n) });
 
   // Mint gains to zcfSeat2
   zcfMint.mintGains(
-    {
+    harden({
       MyToken: AmountMath.make(tokenBrand, 100n),
-    },
+    }),
     zcfSeat2,
   );
   // zcfSeat2's staged allocation and the current allocation should
@@ -88,9 +88,9 @@ test(`stagedAllocations safely interleave with zcfMint calls`, async t => {
 
   // Mint gains to zcfSeat1
   zcfMint.mintGains(
-    {
+    harden({
       OtherTokens: AmountMath.make(tokenBrand, 50n),
-    },
+    }),
     zcfSeat1,
   );
   // zcfSeat1 has no staged allocation, but the current
@@ -102,7 +102,7 @@ test(`stagedAllocations safely interleave with zcfMint calls`, async t => {
   });
 
   // zcfSeat1.incrementBy non-zcfMint token
-  zcfSeat1.incrementBy({ B: moola(2n) });
+  zcfSeat1.incrementBy(harden({ B: moola(2n) }));
   // Both the staged allocation and the current allocation show the OtherTokens
   t.deepEqual(zcfSeat1.getStagedAllocation(), {
     B: moola(5n),
@@ -129,14 +129,16 @@ test(`stagedAllocations safely interleave with zcfMint calls`, async t => {
   // Test burnLosses interleaving
 
   // zcfSeat1 decrementBy both zcfMint token and non-zcfMint token
-  zcfSeat1.decrementBy({
-    OtherTokens: AmountMath.make(tokenBrand, 5n),
-    B: moola(1n),
-  });
+  zcfSeat1.decrementBy(
+    harden({
+      OtherTokens: AmountMath.make(tokenBrand, 5n),
+      B: moola(1n),
+    }),
+  );
 
   // zcfMint.burnLosses on zcfSeat1
   zcfMint.burnLosses(
-    { OtherTokens: AmountMath.make(tokenBrand, 7n) },
+    harden({ OtherTokens: AmountMath.make(tokenBrand, 7n) }),
     zcfSeat1,
   );
   // The zcfMint losses are subtracted from both the currentAllocation and the
@@ -153,9 +155,9 @@ test(`stagedAllocations safely interleave with zcfMint calls`, async t => {
 
   // zcfMint.burnLosses on zcfSeat2
   zcfMint.burnLosses(
-    {
+    harden({
       MyToken: AmountMath.make(tokenBrand, 17n),
-    },
+    }),
     zcfSeat2,
   );
   t.deepEqual(zcfSeat2.getCurrentAllocation(), {
@@ -165,10 +167,12 @@ test(`stagedAllocations safely interleave with zcfMint calls`, async t => {
   t.false(zcfSeat2.hasStagedAllocation());
 
   // zcfSeat2.incrementBy
-  zcfSeat2.incrementBy({
-    OtherTokens: AmountMath.make(tokenBrand, 5n), // let's keep this keyword separate even though we don't have to
-    B: moola(1n),
-  });
+  zcfSeat2.incrementBy(
+    harden({
+      OtherTokens: AmountMath.make(tokenBrand, 5n), // let's keep this keyword separate even though we don't have to
+      B: moola(1n),
+    }),
+  );
   t.deepEqual(zcfSeat2.getCurrentAllocation(), {
     B: moola(1n),
     MyToken: AmountMath.make(tokenBrand, 83n),
@@ -181,9 +185,9 @@ test(`stagedAllocations safely interleave with zcfMint calls`, async t => {
 
   // zcfMint.mintGains on zcfSeat2
   zcfMint.mintGains(
-    {
+    harden({
       AnotherOne: AmountMath.make(tokenBrand, 2n),
-    },
+    }),
     zcfSeat2,
   );
   t.deepEqual(zcfSeat2.getCurrentAllocation(), {

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -438,7 +438,8 @@ test(`zcf.makeZCFMint - mintGains - no args`, async t => {
   const zcfMint = await zcf.makeZCFMint('A', AssetKind.SET);
   // @ts-ignore deliberate invalid arguments for testing
   t.throws(() => zcfMint.mintGains(), {
-    message: '"gains" "[undefined]" must be an amountKeywordRecord',
+    message:
+      '"amountKeywordRecord" "[undefined]" must be a pass-by-copy record, not "undefined"',
   });
 });
 
@@ -446,7 +447,7 @@ test(`zcf.makeZCFMint - mintGains - no seat`, async t => {
   const { zcf } = await setupZCFTest();
   const zcfMint = await zcf.makeZCFMint('A', AssetKind.NAT);
   const { brand } = zcfMint.getIssuerRecord();
-  const zcfSeat = zcfMint.mintGains({ A: AmountMath.make(brand, 4n) });
+  const zcfSeat = zcfMint.mintGains(harden({ A: AmountMath.make(brand, 4n) }));
   t.truthy(zcfSeat);
   assertAmountsEqual(
     t,
@@ -463,7 +464,8 @@ test(`zcf.makeZCFMint - mintGains - no gains`, async t => {
   // https://github.com/Agoric/agoric-sdk/issues/1696
   // @ts-ignore deliberate invalid arguments for testing
   t.throws(() => zcfMint.mintGains(undefined, zcfSeat), {
-    message: '"gains" "[undefined]" must be an amountKeywordRecord',
+    message:
+      '"amountKeywordRecord" "[undefined]" must be a pass-by-copy record, not "undefined"',
   });
 });
 
@@ -472,7 +474,8 @@ test(`zcf.makeZCFMint - burnLosses - no args`, async t => {
   const zcfMint = await zcf.makeZCFMint('A', AssetKind.SET);
   // @ts-ignore deliberate invalid arguments for testing
   t.throws(() => zcfMint.burnLosses(), {
-    message: '"losses" "[undefined]" must be an amountKeywordRecord',
+    message:
+      '"amountKeywordRecord" "[undefined]" must be a pass-by-copy record, not "undefined"',
   });
 });
 
@@ -482,7 +485,8 @@ test(`zcf.makeZCFMint - burnLosses - no losses`, async t => {
   const { zcfSeat } = zcf.makeEmptySeatKit();
   // @ts-ignore deliberate invalid arguments for testing
   t.throws(() => zcfMint.burnLosses(undefined, zcfSeat), {
-    message: '"losses" "[undefined]" must be an amountKeywordRecord',
+    message:
+      '"amountKeywordRecord" "[undefined]" must be a pass-by-copy record, not "undefined"',
   });
 });
 
@@ -492,7 +496,7 @@ test(`zcf.makeZCFMint - mintGains - wrong brand`, async t => {
 
   const zcfMint = await zcf.makeZCFMint('A', AssetKind.SET);
   const { zcfSeat } = zcf.makeEmptySeatKit();
-  t.throws(() => zcfMint.mintGains({ Moola: moola(3n) }, zcfSeat), {
+  t.throws(() => zcfMint.mintGains(harden({ Moola: moola(3n) }), zcfSeat), {
     message: `amount's brand "[Alleged: moola brand]" did not match expected brand "[Alleged: A brand]"`,
   });
 });
@@ -503,7 +507,7 @@ test(`zcf.makeZCFMint - burnLosses - wrong brand`, async t => {
 
   const zcfMint = await zcf.makeZCFMint('A', AssetKind.SET);
   const { zcfSeat } = zcf.makeEmptySeatKit();
-  t.throws(() => zcfMint.burnLosses({ Moola: moola(3n) }, zcfSeat), {
+  t.throws(() => zcfMint.burnLosses(harden({ Moola: moola(3n) }), zcfSeat), {
     message: `amount's brand "[Alleged: moola brand]" did not match expected brand "[Alleged: A brand]"`,
   });
 });
@@ -515,7 +519,7 @@ test(`zcf.makeZCFMint - mintGains - right issuer`, async t => {
   const { brand } = zcfMint.getIssuerRecord();
   const { zcfSeat } = zcf.makeEmptySeatKit();
   const zcfSeat2 = zcfMint.mintGains(
-    { A: AmountMath.make(brand, 4n) },
+    harden({ A: AmountMath.make(brand, 4n) }),
     zcfSeat,
   );
   t.is(zcfSeat2, zcfSeat);
@@ -533,7 +537,7 @@ test(`zcf.makeZCFMint - burnLosses - right issuer`, async t => {
   const { brand } = zcfMint.getIssuerRecord();
   const { zcfSeat } = zcf.makeEmptySeatKit();
   const zcfSeat2 = zcfMint.mintGains(
-    { A: AmountMath.make(brand, 4n) },
+    harden({ A: AmountMath.make(brand, 4n) }),
     zcfSeat,
   );
   t.is(zcfSeat2, zcfSeat);
@@ -544,7 +548,10 @@ test(`zcf.makeZCFMint - burnLosses - right issuer`, async t => {
   );
   // TODO: return a seat?
   // https://github.com/Agoric/agoric-sdk/issues/1709
-  const result = zcfMint.burnLosses({ A: AmountMath.make(brand, 1n) }, zcfSeat);
+  const result = zcfMint.burnLosses(
+    harden({ A: AmountMath.make(brand, 1n) }),
+    zcfSeat,
+  );
   t.is(result, undefined);
   assertAmountsEqual(
     t,
@@ -560,7 +567,7 @@ test(`zcf.makeZCFMint - mintGains - seat exited`, async t => {
   const { zcfSeat } = zcf.makeEmptySeatKit();
   zcfSeat.exit();
   t.throws(
-    () => zcfMint.mintGains({ A: AmountMath.make(brand, 4n) }, zcfSeat),
+    () => zcfMint.mintGains(harden({ A: AmountMath.make(brand, 4n) }), zcfSeat),
     {
       message: `zcfSeat must be active to mint gains for the zcfSeat`,
     },
@@ -573,7 +580,7 @@ test(`zcf.makeZCFMint - burnLosses - seat exited`, async t => {
   const { brand } = zcfMint.getIssuerRecord();
   const { zcfSeat } = zcf.makeEmptySeatKit();
   const zcfSeat2 = zcfMint.mintGains(
-    { A: AmountMath.make(brand, 4n) },
+    harden({ A: AmountMath.make(brand, 4n) }),
     zcfSeat,
   );
   t.is(zcfSeat2, zcfSeat);
@@ -584,7 +591,8 @@ test(`zcf.makeZCFMint - burnLosses - seat exited`, async t => {
   );
   zcfSeat.exit();
   t.throws(
-    () => zcfMint.burnLosses({ A: AmountMath.make(brand, 1n) }, zcfSeat),
+    () =>
+      zcfMint.burnLosses(harden({ A: AmountMath.make(brand, 1n) }), zcfSeat),
     {
       message: `zcfSeat must be active to burn losses from the zcfSeat`,
     },
@@ -739,7 +747,7 @@ const allocateEasy = async (
   const zcfMint = await zcf.makeZCFMint(zcfMintKeyword);
   const { brand } = zcfMint.getIssuerRecord();
   zcfMint.mintGains(
-    { [gainsKeyword]: AmountMath.make(brand, gainsValue) },
+    harden({ [gainsKeyword]: AmountMath.make(brand, gainsValue) }),
     zcfSeat,
   );
   return zcfMint.getIssuerRecord();
@@ -864,8 +872,8 @@ test(`zcfSeat.incrementBy, decrementBy, zcf.reallocate from zcf.makeEmptySeatKit
 
   const issuerRecord1 = await allocateEasy(zcf, 'Stuff', zcfSeat1, 'A', 6n);
   const six = AmountMath.make(issuerRecord1.brand, 6n);
-  zcfSeat1.decrementBy({ A: six });
-  zcfSeat2.incrementBy({ B: six });
+  zcfSeat1.decrementBy(harden({ A: six }));
+  zcfSeat2.incrementBy(harden({ B: six }));
 
   zcf.reallocate(zcfSeat1, zcfSeat2);
 
@@ -1137,12 +1145,12 @@ test(`zcf.reallocate 3 seats, rights conserved`, async t => {
       want: { Whatever: moola(1n) },
     }),
   );
-  zcfSeat1.decrementBy({ B: moola(3n) });
-  zcfSeat3.incrementBy({ Whatever: moola(1n) });
-  zcfSeat2.incrementBy({ Whatever: moola(2n) });
+  zcfSeat1.decrementBy(harden({ B: moola(3n) }));
+  zcfSeat3.incrementBy(harden({ Whatever: moola(1n) }));
+  zcfSeat2.incrementBy(harden({ Whatever: moola(2n) }));
 
-  zcfSeat2.decrementBy({ Whatever2: simoleans(2n) });
-  zcfSeat1.incrementBy({ A: simoleans(2n) });
+  zcfSeat2.decrementBy(harden({ Whatever2: simoleans(2n) }));
+  zcfSeat1.incrementBy(harden({ A: simoleans(2n) }));
 
   zcf.reallocate(zcfSeat1, zcfSeat2, zcfSeat3);
   t.deepEqual(zcfSeat1.getCurrentAllocation(), {
@@ -1191,9 +1199,11 @@ test(`zcf.reallocate 3 seats, some not staged`, async t => {
     }),
   );
 
-  zcfSeat1.incrementBy({
-    A: simoleans(100n),
-  });
+  zcfSeat1.incrementBy(
+    harden({
+      A: simoleans(100n),
+    }),
+  );
 
   t.throws(() => zcf.reallocate(zcfSeat1, zcfSeat2, zcfSeat3), {
     message:
@@ -1242,12 +1252,14 @@ test(`zcf.reallocate 3 seats, rights NOT conserved`, async t => {
     }),
   );
 
-  zcfSeat2.decrementBy({ Whatever2: simoleans(2n) });
+  zcfSeat2.decrementBy(harden({ Whatever2: simoleans(2n) }));
   // This does not conserve rights in the slightest
-  zcfSeat1.incrementBy({
-    A: simoleans(100n),
-  });
-  zcfSeat3.incrementBy({ Whatever: moola(1n) });
+  zcfSeat1.incrementBy(
+    harden({
+      A: simoleans(100n),
+    }),
+  );
+  zcfSeat3.incrementBy(harden({ Whatever: moola(1n) }));
 
   t.throws(() => zcf.reallocate(zcfSeat1, zcfSeat2, zcfSeat3), {
     message: /rights were not conserved for brand .*/,


### PR DESCRIPTION
BREAKING CHANGE: `amountKeywordRecord` must be hardened before passing to `zcfMint` and `zcfSeat` methods

Note: because this is a breaking change, we may want to wait to merge until we have other Zoe input validation complete, so there's only one breaking change to Zoe.

closes: #4061

## Description

This PR changes the code of `zcfMint.burnLosses`, `zcfMint.mintGains`, `zcfSeat.incrementBy`, and `zcfSeat.decrementBy` to assert that the user-defined `amountKeywordRecord` is actually a keyword record and coerce the amounts. This means checking that it is a copyRecord, among other things. The actual function used is `coerceAmountKeywordRecord` from `cleanProposal.js`.

`coerceAmountKeywordRecord` requires a hardened object, thus, this is a breaking change. Any `amountKeywordRecord` not hardened will cause the function to throw.

### Security Considerations

This is part of the input validation that we need to do for Zoe, but not the entirety of it. https://github.com/Agoric/agoric-sdk/issues/4068 is the input validation task covering all of Zoe.

### Documentation Considerations

This is a breaking change that will effect dapps. We should explain the need to `harden` in our documentation.

### Testing Considerations

No additional tests needed.