### PR TITLE
fix: if `makeEmptyPurse` fails, then `startInstance` and `saveIssuer` should fail

### DIFF
--- a/packages/zoe/src/zoeService/escrowStorage.js
+++ b/packages/zoe/src/zoeService/escrowStorage.js
@@ -29,6 +29,7 @@ export const makeEscrowStorage = () => {
       purseP = await E(issuer).makeEmptyPurse();
     } catch (err) {
       const cannotCreateError = Error(
+        // @ts-ignore Types should allow for a DetailsToken
         X`A purse could not be created for brand ${brand}`,
       );
       assert.note(cannotCreateError, X`Caused by: ${err}`);

--- a/packages/zoe/src/zoeService/escrowStorage.js
+++ b/packages/zoe/src/zoeService/escrowStorage.js
@@ -20,9 +20,23 @@ export const makeEscrowStorage = () => {
   const brandToPurse = makeWeakStore('brand');
 
   /** @type {CreatePurse} */
-  const createPurse = (issuer, brand) => {
+  const createPurse = async (issuer, brand) => {
+    if (brandToPurse.has(brand)) {
+      return;
+    }
+    let purseP;
+    try {
+      purseP = await E(issuer).makeEmptyPurse();
+    } catch (err) {
+      const cannotCreateError = Error(
+        X`A purse could not be created for brand ${brand}`,
+      );
+      assert.note(cannotCreateError, X`Caused by: ${err}`);
+      throw cannotCreateError;
+    }
+    // Check again after the `await`
     if (!brandToPurse.has(brand)) {
-      brandToPurse.init(brand, E(issuer).makeEmptyPurse());
+      brandToPurse.init(brand, purseP);
     }
   };
 

--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -6,7 +6,7 @@
  * @callback CreatePurse
  * @param {Issuer} issuer
  * @param {Brand} brand
- * @returns {Promise<void>}
+ * @returns {ERef<void>}
  */
 
 /**

--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -6,7 +6,7 @@
  * @callback CreatePurse
  * @param {Issuer} issuer
  * @param {Brand} brand
- * @returns {void}
+ * @returns {Promise<void>}
  */
 
 /**

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -122,8 +122,10 @@ export const makeZoeStorageManager = (
     );
 
     // Create purses for the issuers if they do not already exist
-    Object.entries(issuers).forEach(([keyword, issuer]) =>
-      escrowStorage.createPurse(issuer, brands[keyword]),
+    await Promise.all(
+      Object.entries(issuers).map(([keyword, issuer]) =>
+        escrowStorage.createPurse(issuer, brands[keyword]),
+      ),
     );
 
     // The instanceRecord is what the contract code is parameterized
@@ -143,7 +145,7 @@ export const makeZoeStorageManager = (
     /** @type {SaveIssuer} */
     const saveIssuer = async (issuerP, keyword) => {
       const issuerRecord = await issuerStorage.storeIssuer(issuerP);
-      escrowStorage.createPurse(issuerRecord.issuer, issuerRecord.brand);
+      await escrowStorage.createPurse(issuerRecord.issuer, issuerRecord.brand);
       instanceRecordManager.addIssuerToInstanceRecord(keyword, issuerRecord);
       return issuerRecord;
     };

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -158,7 +158,8 @@ test(`E(zoe).startInstance - bad issuer, makeEmptyPurse throws`, async t => {
     // @ts-ignore deliberate invalid arguments for testing
     () => E(zoe).startInstance(installation, { Money: badIssuer }),
     {
-      message: 'A purse could not be created for brand "[Alleged: brand]"',
+      message:
+        'A purse could not be created for brand "[Alleged: brand]" because: "[Error: bad issuer]"',
     },
   );
 });

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -4,10 +4,10 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import path from 'path';
 
-import { AmountMath } from '@agoric/ertp';
+import { AmountMath, AssetKind } from '@agoric/ertp';
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
-import { passStyleOf } from '@agoric/marshal';
+import { passStyleOf, Far } from '@agoric/marshal';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import bundleSource from '@agoric/bundle-source';
@@ -137,6 +137,28 @@ test(`E(zoe).startInstance - terms, issuerKeywordRecord switched`, async t => {
         //
         // /keyword "something" must be ascii and must start with a capital letter./
         /keyword .* must be ascii and must start with a capital letter./,
+    },
+  );
+});
+
+test(`E(zoe).startInstance - bad issuer, makeEmptyPurse throws`, async t => {
+  const { zoe, installation } = await setupZCFTest();
+  const brand = Far('brand', {
+    // eslint-disable-next-line no-use-before-define
+    isMyIssuer: i => i === badIssuer,
+    getDisplayInfo: () => ({ decimalPlaces: 6, assetKind: AssetKind.NAT }),
+  });
+  const badIssuer = Far('issuer', {
+    makeEmptyPurse: async () => {
+      throw Error('bad issuer');
+    },
+    getBrand: () => brand,
+  });
+  await t.throwsAsync(
+    // @ts-ignore deliberate invalid arguments for testing
+    () => E(zoe).startInstance(installation, { Money: badIssuer }),
+    {
+      message: 'A purse could not be created for brand "[Alleged: brand]"',
     },
   );
 });

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -2,6 +2,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
+import { Far } from '@agoric/marshal';
 import { AssetKind, AmountMath } from '@agoric/ertp';
 import { E } from '@agoric/eventual-send';
 import { details as X } from '@agoric/assert';
@@ -197,6 +198,28 @@ test(`zcf.saveIssuer - bad issuer`, async t => {
     message:
       'target has no method "getBrand", has ["getAllegedName","getDisplayInfo","isMyIssuer"]',
   });
+});
+
+test(`zcf.saveIssuer - bad issuer, makeEmptyPurse throws`, async t => {
+  const { zcf } = await setupZCFTest();
+  const brand = Far('brand', {
+    // eslint-disable-next-line no-use-before-define
+    isMyIssuer: i => i === badIssuer,
+    getDisplayInfo: () => ({ decimalPlaces: 6, assetKind: AssetKind.NAT }),
+  });
+  const badIssuer = Far('issuer', {
+    makeEmptyPurse: async () => {
+      throw Error('bad issuer');
+    },
+    getBrand: () => brand,
+  });
+  await t.throwsAsync(
+    // @ts-ignore deliberate invalid arguments for testing
+    () => zcf.saveIssuer(badIssuer, 'A'),
+    {
+      message: 'A purse could not be created for brand "[Alleged: brand]"',
+    },
+  );
 });
 
 test(`zcf.saveIssuer - bad keyword`, async t => {

--- a/packages/zoe/test/unitTests/zcf/test-zcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcf.js
@@ -217,7 +217,8 @@ test(`zcf.saveIssuer - bad issuer, makeEmptyPurse throws`, async t => {
     // @ts-ignore deliberate invalid arguments for testing
     () => zcf.saveIssuer(badIssuer, 'A'),
     {
-      message: 'A purse could not be created for brand "[Alleged: brand]"',
+      message:
+        'A purse could not be created for brand "[Alleged: brand]" because: "[Error: bad issuer]"',
     },
   );
 });

--- a/packages/zoe/test/unitTests/zoe/test-escrowStorage.js
+++ b/packages/zoe/test/unitTests/zoe/test-escrowStorage.js
@@ -27,7 +27,7 @@ test('makeEscrowStorage', async t => {
 
   const ticketKit = makeIssuerKit('tickets', AssetKind.SET);
 
-  createPurse(currencyKit.issuer, currencyKit.brand);
+  await createPurse(currencyKit.issuer, currencyKit.brand);
 
   // Normally only used for ZCFMint issuers
   makeLocalPurse(ticketKit.issuer, ticketKit.brand);
@@ -109,7 +109,7 @@ test('makeEscrowStorage', async t => {
   });
 });
 
-const setupPurses = createPurse => {
+const setupPurses = async createPurse => {
   const currencyKit = makeIssuerKit(
     'currency',
     AssetKind.NAT,
@@ -130,15 +130,15 @@ const setupPurses = createPurse => {
     assetKind: AssetKind.SET,
     brand: ticketKit.brand,
   };
-  createPurse(currencyIssuerRecord.issuer, currencyIssuerRecord.brand);
-  createPurse(ticketIssuerRecord.issuer, ticketIssuerRecord.brand);
+  await createPurse(currencyIssuerRecord.issuer, currencyIssuerRecord.brand);
+  await createPurse(ticketIssuerRecord.issuer, ticketIssuerRecord.brand);
   return harden({ ticketKit, currencyKit });
 };
 
 test('payments without matching give keywords', async t => {
   const { createPurse, depositPayments } = makeEscrowStorage();
 
-  const { ticketKit, currencyKit } = setupPurses(createPurse);
+  const { ticketKit, currencyKit } = await setupPurses(createPurse);
 
   const gameTicketAmount = AmountMath.make(
     ticketKit.brand,
@@ -173,7 +173,7 @@ test('payments without matching give keywords', async t => {
 test(`give keywords without matching payments`, async t => {
   const { createPurse, depositPayments } = makeEscrowStorage();
 
-  const { ticketKit, currencyKit } = setupPurses(createPurse);
+  const { ticketKit, currencyKit } = await setupPurses(createPurse);
 
   const gameTicketAmount = AmountMath.make(
     ticketKit.brand,


### PR DESCRIPTION
closes: #4062 

## Description

This PR fixes a bug in Zoe. Previously, when `startInstance` or `saveIssuer` was called, Zoe would try to create a new empty escrow purse for any new issuer. Rather than `await` the promise for the purse, Zoe put the promise for the purse directly in a map. This created problems, because if the promise later rejected, the original call would have already succeeded, and moreover, any further use of the "purse" would fail because only a rejected promise was stored. The fix is to `await` the promise for the purse, and thus make sure that the calling function (`startInstance` or `saveIssuer`) throws if `makeEmptyPurse` throws. Only when `makeEmptyPurse` succeeds and resolves to a purse do we store the purse in the map. 

### Security Considerations

If `makeEmptyPurse` throws during `startInstance`, a contract instance is not created, which is a security improvement.

### Documentation Considerations

Probably nothing to add to documentation.

### Testing Considerations

I added tests to confirm that `startInstance` and `saveIssuer` throw appropriately.
