### PR TITLE
Update docker-compose instructions

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -2,10 +2,32 @@
 
 ## Quick Start (Overview)
 
- 1. Start the `ag-solo` service: `docker-compose up -d`
- 2. Watch the logs for registration details: `docker-compose logs -f --tail=50`
- 3. Issue an unguessable URL to the wallet: `docker-compose exec ag-solo agoric open --repl`
+1. Download the `docker-compose.yml` pre-configured for the chain, e.g. [`devnet`](https://devnet.agoric.net/docker-compose.yml), and start the `ag-solo` service:
+
+   ```sh
+   docker-compose up -d
+   ```
+
+1. Alternatively use the generic `docker-compose.yml` in this repository and configure it with the right SDK version and network config URL:
+
+   - Figure out which version tag to use. Usually the version tag is the same as the name of the chain. You can find the chain name either in the explorer (https://devnet.explorer.agoric.net/) or in the [`network-config` file](https://devnet.agoric.net/network-config).
+   - Start the `ag-solo` service on `devnet`:
+     ```sh
+     SDK_TAG=agoricdev-5.2 NETCONFIG_URL=https://devnet.agoric.net/network-config docker-compose up -d
+     ```
+
+1. Watch the logs for registration details:
+
+   ```sh
+   docker-compose logs -f --tail=50
+   ```
+
+1. Issue an unguessable URL to the wallet:
+
+   ```sh
+   docker-compose exec ag-solo agoric open --repl
+   ```
 
 ## Detailed Instructions
 
-See [Setting up an Agoric Dapp Client with docker compose](https://github.com/Agoric/agoric-sdk/wiki/Setting-up-an-Agoric-Dapp-Client-with-docker-compose) in the [agoric\-sdk wiki](https://github.com/Agoric/agoric-sdk).
+See [Setting up an Agoric Dapp Client with docker compose](https://github.com/Agoric/agoric-sdk/wiki/Setting-up-an-Agoric-Dapp-Client-with-docker-compose) in the [agoric\-sdk wiki](https://github.com/Agoric/agoric-sdk/wiki).

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2.2"
 services:
   ag-solo:
     # This tag needs to be the SDK used by the $NETCONFIG_URL
-    image: agoric/cosmic-swingset-solo:${SDK_TAG:-2.14.0}
+    image: agoric/cosmic-swingset-solo:${SDK_TAG:-latest}
     # ISSUE: 127.0.0.1? not a docker network?
     ports:
       - "${HOST_PORT:-8000}:${PORT:-8000}"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,8 +1,11 @@
 version: "2.2"
 services:
   ag-solo:
+    # NOTE: Use an environment variable like:
+    #   SDK_TAG=agoricdev-5.2
     # This tag needs to be the SDK used by the $NETCONFIG_URL
-    image: agoric/cosmic-swingset-solo:${SDK_TAG:-latest}
+    # Usually it's the same as the chain name
+    image: agoric/cosmic-swingset-solo:${SDK_TAG}
     # ISSUE: 127.0.0.1? not a docker network?
     ports:
       - "${HOST_PORT:-8000}:${PORT:-8000}"
@@ -16,6 +19,8 @@ services:
       - setup
       - --webhost=0.0.0.0
       - --webport=${PORT:-8000}
-      - --netconfig=${NETCONFIG_URL:-https://devnet.agoric.net/network-config}
+      # NOTE: Use an environment variable like:
+      #   NETCONFIG_URL=https://devnet.agoric.net/network-config
+      - --netconfig=${NETCONFIG_URL}
 volumes:
   ag-solo-state:


### PR DESCRIPTION
refs: #4072 

## Description

The `docker-compose.yml` file was stuck in time and no longer matched the [instructions](https://github.com/Agoric/agoric-sdk/wiki/Setting-up-an-Agoric-Dapp-Client-with-docker-compose).

We probably could have a script to update the default version to a specific tag when publishing devnet, but in the meantime, require user to be explicit. The netconfig is also made explicit.

I did not update the `AG_SOLO_BASEDIR` environment, not sure if that's necessary, but it doesn't match the published https://beta.agoric.net/docker-compose.yml

### Security Considerations

N/A

### Documentation Considerations

None.

### Testing Considerations

This is not part of CI, and I'm not sure how it could be. The change is pretty trivial however.
