### PR TITLE
WIP: zoe 2.0 design work

### DIFF
--- a/packages/zoe/src/redesign/contractLauncher/createZCFVat.js
+++ b/packages/zoe/src/redesign/contractLauncher/createZCFVat.js
@@ -1,0 +1,32 @@
+import { E } from '@agoric/eventual-send';
+
+import zcfContractBundle from '../../bundles/bundle-contractFacet.js';
+
+/**
+ * Attenuate the power of vatAdminSvc by restricting it such that only
+ * ZCF Vats can be created.
+ *
+ * @param {VatAdminSvc} vatAdminSvc
+ * @param {Computrons} initial
+ * @param {Computrons} threshold
+ * @param {string=} zcfBundleName
+ * @returns {CreateZCFVat}
+ */
+export const setupCreateZCFVat = (
+  vatAdminSvc,
+  initial,
+  threshold,
+  zcfBundleName = undefined,
+) => {
+  /** @type {CreateZCFVat} */
+  const createZCFVat = async () => {
+    const meter = await E(vatAdminSvc).createMeter(initial, threshold);
+    const rootAndAdminNodeP =
+      typeof zcfBundleName === 'string'
+        ? E(vatAdminSvc).createVatByName(zcfBundleName, { meter })
+        : E(vatAdminSvc).createVat(zcfContractBundle, { meter });
+    const rootAndAdminNode = await rootAndAdminNodeP;
+    return harden({ meter, ...rootAndAdminNode });
+  };
+  return createZCFVat;
+};

--- a/packages/zoe/src/redesign/contractLauncher/evalContractCode.js
+++ b/packages/zoe/src/redesign/contractLauncher/evalContractCode.js
@@ -1,0 +1,38 @@
+// @ts-check
+
+/* global makeKind makeVirtualScalarWeakMap */
+
+import { importBundle } from '@agoric/import-bundle';
+import { assert } from '@agoric/assert';
+import { handlePWarning } from '../handleWarning.js';
+
+const evalContractBundle = (bundle, additionalEndowments = {}) => {
+  // Make the console more verbose.
+  const louderConsole = {
+    ...console,
+    log: console.info,
+  };
+
+  const defaultEndowments = {
+    console: louderConsole,
+    assert,
+    makeKind,
+    makeVirtualScalarWeakMap,
+  };
+
+  const fullEndowments = Object.create(null, {
+    ...Object.getOwnPropertyDescriptors(defaultEndowments),
+    ...Object.getOwnPropertyDescriptors(additionalEndowments),
+  });
+
+  // Evaluate the export function, and use the resulting
+  // module namespace as our installation.
+
+  const installation = importBundle(bundle, {
+    endowments: fullEndowments,
+  });
+  handlePWarning(installation);
+  return installation;
+};
+
+export { evalContractBundle };

--- a/packages/zoe/src/redesign/contractLauncher/installationStorage.js
+++ b/packages/zoe/src/redesign/contractLauncher/installationStorage.js
@@ -1,0 +1,45 @@
+// @ts-check
+
+import { assert, details as X } from '@agoric/assert';
+import { Far } from '@agoric/marshal';
+import { E } from '@agoric/eventual-send';
+
+export const makeInstallationStorage = () => {
+  /** @type {WeakSet<Installation>} */
+  const installations = new WeakSet();
+
+  /**
+   * Create an installation by permanently storing the bundle. It will be
+   * evaluated each time it is used to make a new instance of a contract.
+   */
+  /** @type {Install} */
+  const install = async bundle => {
+    assert.typeof(bundle, 'object', X`a bundle must be provided`);
+    /** @type {Installation} */
+    const installation = Far('Installation', {
+      getBundle: () => bundle,
+    });
+    installations.add(installation);
+    return installation;
+  };
+
+  const assertInstallation = installation =>
+    assert(
+      installations.has(installation),
+      X`${installation} was not a valid installation`,
+    );
+
+  /** @type {UnwrapInstallation} */
+  const unwrapInstallation = installationP => {
+    return E.when(installationP, installation => {
+      assertInstallation(installation);
+      const bundle = installation.getBundle();
+      return { bundle, installation };
+    });
+  };
+
+  return harden({
+    install,
+    unwrapInstallation,
+  });
+};

--- a/packages/zoe/src/redesign/contractLauncher/launcher.js
+++ b/packages/zoe/src/redesign/contractLauncher/launcher.js
@@ -1,0 +1,68 @@
+// @ts-check
+
+import { Far, passStyleOf } from '@agoric/marshal';
+import { E } from '@agoric/eventual-send';
+
+import { makeInstallationStorage } from './installationStorage';
+import { makeHandle } from '../makeHandle.js';
+import { createInvitationKit } from './makeInvitation';
+import { setupCreateZCFVat } from './createZCFVat';
+
+const { details: X } = assert;
+
+const makeLauncher = (
+  vatAdminSvc,
+  shutdownZoeVat = () => {},
+  meteringConfig,
+  zcfBundleName,
+) => {
+  const { install, unwrapInstallation } = makeInstallationStorage();
+
+  const { setupMakeInvitation, invitationIssuer } = createInvitationKit(
+    shutdownZoeVat,
+  );
+
+  return Far('launcher', {
+    install,
+    startInstance: async (installationP, terms, privateArgs) => {
+      const { installation, bundle } = await unwrapInstallation(installationP);
+      // AWAIT ///
+
+      if (privateArgs !== undefined) {
+        const passStyle = passStyleOf(privateArgs);
+        assert(
+          passStyle === 'copyRecord',
+          X`privateArgs must be a pass-by-copy record, but instead was a ${q(
+            passStyle,
+          )}: ${privateArgs}`,
+        );
+      }
+
+      const instance = makeHandle('Instance');
+
+      const makeInvitation = setupMakeInvitation(instance, installation);
+
+      // This method contains the power to create a new ZCF Vat, and must
+      // be closely held. vatAdminSvc is even more powerful - any vat can
+      // be created. We severely restrict access to vatAdminSvc for this reason.
+      const createZCFVat = setupCreateZCFVat(
+        vatAdminSvc,
+        meteringConfig.initial,
+        meteringConfig.threshold,
+        zcfBundleName,
+      );
+
+      const { root, adminNode, meter } = await createZCFVat();
+
+      return E(root).executeContract(
+        bundle,
+        makeInvitation,
+        terms,
+        privateArgs,
+      );
+    },
+    getInvitationIssuer: () => invitationIssuer,
+  });
+};
+harden(makeLauncher);
+export { makeLauncher };

--- a/packages/zoe/src/redesign/contractLauncher/makeInvitation.js
+++ b/packages/zoe/src/redesign/contractLauncher/makeInvitation.js
@@ -1,0 +1,63 @@
+// @ts-check
+import { assert, details as X } from '@agoric/assert';
+import { AmountMath, makeIssuerKit, AssetKind } from '@agoric/ertp';
+
+/**
+ * @param {ShutdownWithFailure | undefined} shutdownZoeVat
+ */
+export const createInvitationKit = (shutdownZoeVat = undefined) => {
+  const invitationKit = makeIssuerKit(
+    'Zoe Invitation',
+    AssetKind.SET,
+    undefined,
+    shutdownZoeVat,
+  );
+
+  /**
+   * @param {Instance} instance
+   * @param {Installation} installation
+   * @returns {ZoeInstanceAdminMakeInvitation}
+   */
+  const setupMakeInvitation = (instance, installation) => {
+    assert.typeof(instance, 'object');
+    assert.typeof(installation, 'object');
+
+    /** @type {ZoeInstanceAdminMakeInvitation} */
+    const makeInvitation = async (
+      invitationHandle,
+      description,
+      customProperties,
+    ) => {
+      assert.typeof(invitationHandle, 'object');
+      assert.typeof(
+        description,
+        'string',
+        X`The description ${description} must be a string`,
+      );
+
+      // If the contract-provided customProperties include the
+      // properties 'description', 'handle', 'instance',
+      // 'installation', 'fee', or 'expiry', their corresponding
+      // values will be overwritten with the actual values. For
+      // example, the value for `instance` will always be the actual
+      // instance for the contract, even if customProperties includes
+      // a property called `instance`.
+      const invitationAmount = AmountMath.make(invitationKit.brand, [
+        {
+          ...customProperties,
+          description,
+          handle: invitationHandle,
+          instance,
+          installation,
+        },
+      ]);
+      return invitationKit.mint.mintPayment(invitationAmount);
+    };
+    return makeInvitation;
+  };
+
+  return harden({
+    setupMakeInvitation,
+    invitationIssuer: invitationKit.issuer,
+  });
+};

--- a/packages/zoe/src/redesign/contractLauncher/useObjService.js
+++ b/packages/zoe/src/redesign/contractLauncher/useObjService.js
@@ -1,0 +1,84 @@
+// @ts-check
+
+import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
+import { makeScalarMap } from '@agoric/store';
+import { makeIssuerKit, AssetKind } from '@agoric/ertp';
+
+const { details: X } = assert;
+
+const makeRevocableWrapper = obj => {
+  // ??
+  // Needs membrane?
+  return wrappedObj;
+};
+
+const revoke = obj => {
+  // ??
+};
+
+// scoped to each contract instance
+const makeService = (instance, installation) => {
+  const wrappedObjToID = makeScalarMap('wrappedObj');
+  const idToDescription = makeScalarMap('id');
+  const descriptions = new Set();
+  const idToOriginal = makeScalarMap('id');
+
+  const issuerKit = makeIssuerKit('invitation', AssetKind.SET);
+  const { mint, issuer } = issuerKit;
+
+  const makePayment = async (original, id, description) => {
+    const info = await E(original).getInfo();
+    const amount = {
+      ...info,
+      id,
+      instance,
+      installation,
+      description,
+    };
+    return mint.mintPayment(amount);
+  };
+
+  const register = description => {
+    const id = makeHandle('nft');
+    assert(
+      !descriptions.has(description),
+      X`Description ${description} is already used`,
+    );
+    descriptions.add(description);
+    idToDescription.init(id, description);
+    return id;
+  };
+
+  const service = Far('service', {
+    registerAndGetObj: async (originalObj, description) => {
+      const id = register(description);
+      const wrappedObj = makeRevocableWrapper(originalObj);
+      wrappedObjToID.init(wrappedObj, id);
+      return wrappedObj;
+    },
+    registerAndGetNFT: async (originalObj, description) => {
+      const id = register(description);
+      return makePayment(originalObj, id, description);
+    },
+    getObj: async payment => {
+      const amount = await issuer.burn(payment);
+      // TODO: Assert only one
+      const [{ id }] = /** @type {SetValue} */ (amount.value);
+      const original = idToOriginal.get(id);
+      const wrappedObj = makeRevocableWrapper(original);
+      wrappedObjToID.set(wrappedObj, id);
+      return wrappedObj;
+    },
+    getPayment: async wrapperObj => {
+      const id = wrappedObjToID.get(wrapperObj);
+      const original = idToOriginal.get(id);
+      revoke(wrapperObj);
+      const description = idToDescription.get(id);
+      return makePayment(original, id, description);
+    },
+  });
+
+  return service;
+};
+harden(makeService);

--- a/packages/zoe/src/redesign/contractLauncher/vatRoot.js
+++ b/packages/zoe/src/redesign/contractLauncher/vatRoot.js
@@ -1,0 +1,26 @@
+// @ts-check
+
+import { Far } from '@agoric/marshal';
+import { E } from '@agoric/eventual-send';
+
+import { evalContractBundle } from './evalContractCode';
+
+/**
+ * @param {VatPowers} powers
+ */
+export function buildRootObject(powers) {
+  const executeContract = (
+    bundle,
+    makeInvitation,
+    terms,
+    privateArgs = undefined,
+  ) => {
+    const contractCode = evalContractBundle(bundle);
+    // TODO pass in power to shutdown the vat
+    return E(contractCode).start(makeInvitation, terms, privateArgs);
+  };
+
+  return Far('executeContract', { executeContract });
+}
+
+harden(buildRootObject);

--- a/packages/zoe/src/redesign/contracts/NFTDropContractBasic.js
+++ b/packages/zoe/src/redesign/contracts/NFTDropContractBasic.js
@@ -1,0 +1,67 @@
+// @ts-check
+
+// `Far` makes objects callable outside the contract code, and even
+// callable off-chain!
+import { Far } from '@agoric/marshal';
+
+// ERTP is the library for dealing with NFTs and fungible tokens
+import { AmountMath, AssetKind, makeIssuerKit } from '@agoric/ertp';
+import { E } from '@agoric/eventual-send';
+import { CLOSING_CONDITIONS } from '../escrow/cleanConditions';
+
+const start = async (escrowService, invitationMaker, terms, privateArgs) => {
+  const { pricePerNFT, nftName } = terms;
+  const { payoutHandler } = privateArgs;
+
+  const issuerKit = makeIssuerKit(nftName, AssetKind.SET);
+  const { brand: NFTBrand } = issuerKit;
+
+  let currentId = 1n;
+
+  const buyNFTs = async buyerAccount => {
+    const [buyerSnapshot] = await E(escrowService).startTransfer([
+      buyerAccount,
+    ]);
+    const {
+      currentAmounts: buyerContributed,
+      seat: buyerSeat,
+      conditions: { wantedAmounts: buyerWanted },
+    } = buyerSnapshot;
+
+    // TODO: perform checks
+
+    const amount = AmountMath.make(NFTBrand, [currentId]);
+    const nft = issuerKit.mint.mintPayment(amount);
+    currentId += 1n;
+
+    const conditions = harden({
+      wantedAmounts: buyerContributed,
+    });
+    const sellerAccount = E(escrowService).openEscrowAccount(
+      nft,
+      conditions,
+      payoutHandler,
+    );
+    await E(escrowService).completeTransfer([
+      {
+        seat: buyerSeat,
+        add: buyerWanted,
+        subtract: buyerContributed,
+      },
+      {
+        account: sellerAccount,
+        add: buyerContributed,
+        subtract: buyerWanted,
+      },
+    ]);
+  };
+
+  const publicFacet = Far('NFT Drop', {
+    makeInvitation: () => E(invitationMaker).registerAndGetNFT({ buyNFTs }),
+  });
+
+  return harden({ publicFacet });
+};
+
+harden(start);
+export { start };

--- a/packages/zoe/src/redesign/contracts/NFTstore.js
+++ b/packages/zoe/src/redesign/contracts/NFTstore.js
@@ -1,0 +1,29 @@
+// @ts-check
+
+import { E } from '@agoric/eventual-send';
+
+const start = escrowService => {
+  // two ways of doing this - a set price per NFT, and an open
+  // marketprice where anything can be offered with specific prices
+  // per NFT
+
+  // is there any need to get exclusive access to trade? There's
+  // very little that needs to be calculated, if the item(s) for sale
+  // are the current amounts wanted
+
+  // Example where there is a set price per NFT, and the buyer just
+  // the next NFT
+
+  E(escrowService).transferAssets([
+    {
+      escrowAccount: sellerEscrowAccount,
+      subtract: [NFTAmount],
+      add: [pricePerNFT],
+    },
+    {
+      escrowAccount: buyerEscrowAccount,
+      subtract: [pricePerNFT],
+      add: [NFTAmount],
+    },
+  ]);
+};

--- a/packages/zoe/src/redesign/contracts/auction.js
+++ b/packages/zoe/src/redesign/contracts/auction.js
@@ -1,0 +1,76 @@
+// @ts-check
+
+import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
+
+// Eventually will be importable from '@agoric/zoe-contract-support'
+import {
+  defaultAcceptanceMsg,
+  assertIssuerKeywords,
+  assertProposalShape,
+} from '../../contractSupport/index.js';
+import { calcWinnerAndClose } from './secondPriceLogic.js';
+import { assertBidSeat } from './assertBidSeat.js';
+
+import '../../../exported.js';
+
+const start = () => {
+  const { timeAuthority, closesAfter } = zcf.getTerms();
+
+  let sellSeat;
+  const bidSeats = [];
+
+  // seller will use 'Asset' and 'Ask'. buyer will use 'Asset' and 'Bid'
+  assertIssuerKeywords(zcf, harden(['Asset', 'Ask']));
+
+  E(timeAuthority)
+    .setWakeup(
+      closesAfter,
+      Far('wakeObj', {
+        wake: () => calcWinnerAndClose(zcf, sellSeat, bidSeats),
+      }),
+    )
+    .catch(err => {
+      console.error(
+        `Could not schedule the close of the auction at the 'closesAfter' deadline ${closesAfter} using this timer ${timeAuthority}`,
+      );
+      console.error(err);
+      throw err;
+    });
+
+  const makeBidInvitation = () => {
+    /** @type {OfferHandler} */
+    const performBid = seat => {
+      assertProposalShape(seat, {
+        give: { Bid: null },
+        want: { Asset: null },
+      });
+      assertBidSeat(zcf, sellSeat, seat);
+      bidSeats.push(seat);
+      return defaultAcceptanceMsg;
+    };
+
+    const customProperties = harden({
+      auctionedAssets: sellSeat.getProposal().give.Asset,
+      minimumBid: sellSeat.getProposal().want.Ask,
+      closesAfter,
+      timeAuthority,
+    });
+
+    return zcf.makeInvitation(performBid, 'bid', customProperties);
+  };
+
+  const sell = escrowAccount => {
+    sellSeat = E(escrowAccount).startTransfer(escrowAccount);
+
+    // The bid invitations can only be sent out after the assets to be
+    // auctioned are escrowed.
+    return Far('offerResult', { makeBidInvitation });
+  };
+
+  const creatorInvitation = zcf.makeInvitation(sell, 'sellAssets');
+
+  return harden({ creatorInvitation });
+};
+
+export { start };

--- a/packages/zoe/src/redesign/contracts/autoswapExperiments.js
+++ b/packages/zoe/src/redesign/contracts/autoswapExperiments.js
@@ -1,0 +1,62 @@
+// const newBrandOutPoolRecord = brandOutPoolRecord.decrementBy(amountOut);
+// const newTraderRecord = traderRecord.incrementBy(amountOut);
+
+// const brandInPoolRecordStage2 = brandInPoolRecord.decrementBy(
+//   reducedCentralAmount,
+// );
+// const brandOutPoolRecordStage3 = newBrandOutPoolRecord.incrementBy(
+//   reducedCentralAmount,
+// );
+
+// const newTraderRecordStage2 = newTraderRecord.decrementBy(reducedAmountIn);
+// const brandInPoolRecordStage3 = brandInPoolRecordStage2.incrementBy(
+//   reducedAmountIn,
+// );
+
+// zcf.reallocate(
+//   newTraderRecordStage2,
+//   brandInPoolRecordStage3,
+//   brandOutPoolRecordStage3,
+// );
+
+///
+// swapIn secondaryToSecondary
+// const swapIn = (escrowAccount, amountIn, brandOut) => {
+//   const [poolIn, poolOut, swapper] = await takeSnapshots([poolInReceipt, poolOutReceipt, swapperReceipt])
+//   const {
+//     amountIn: reducedAmountIn,
+//     amountOut,
+//     centralAmount: reducedCentralAmount,
+//   } = getPriceGivenAvailableInput(amountIn, brandOut);
+
+//   const proposedAllocations = move(poolOut, escrowAccount, amountOut)
+//     .move(poolIn, poolOut, reducedCentralAmount)
+//     .move(escrowAccount, poolIn, reducedAmountIn);
+
+//   E(zoe).reallocate(...proposedAllocations);
+//   swapperReceipt.releaseFunds();
+// };
+
+// swapIn secondaryToSecondary
+
+// snapshot, reallocate, releaseFunds
+const swapIn = (swapperEA, amountIn, brandOut) => {
+  const callback = ([swapperS, poolInS, poolOutS]) => {
+
+    const {
+      amountIn: reducedAmountIn,
+      amountOut,
+      centralAmount: reducedCentralAmount,
+    } = getPriceGivenAvailableInput(amountIn, brandOut);
+  
+    const proposedAllocations = move(poolOutS, swapperS, amountOut)
+      .move(poolInS, poolOutS, reducedCentralAmount)
+      .move(swapperS, poolInS, reducedAmountIn)
+      .end();
+
+    return proposedAllocations;
+  };
+
+  const snapshots = await takeSnapshots([swapperEA, poolInEA, poolOutEA]);
+  const transferCompleteP = E(zoe).completeTransfer(callback(snapshots));
+};

--- a/packages/zoe/src/redesign/contracts/contractHelpers.js
+++ b/packages/zoe/src/redesign/contracts/contractHelpers.js
@@ -1,0 +1,55 @@
+//   const proposedAllocations = move(poolOutS, swapperS, amountOut)
+//   .move(poolInS, poolOutS, reducedCentralAmount)
+//   .move(swapperS, poolInS, reducedAmountIn)
+//   .end();
+
+import { addAmounts } from '../escrow/amountArrayMath';
+
+// return proposedAllocations;
+
+const move = (fromSnapshot, toSnapshot, amountsToMove) => {
+  const allocations = [];
+  const updatedFromSnapshot = {
+    escrowAccount: fromSnapshot.escrowAccount,
+    conditions: fromSnapshot.conditions,
+    amounts: subtractAmounts(fromSnapshot.amounts, amountsToMove),
+  };
+  allocations.push(updatedFromSnapshot);
+  const updatedToSnapshot = {
+    escrowAccount: toSnapshot.escrowAccount,
+    conditions: toSnapshot.conditions,
+    amounts: addAmounts(toSnapshot.amounts, amountsToMove),
+  };
+  allocations.push(updatedToSnapshot);
+
+  // TODO: figure out how to chain these
+  return {
+    move: () => {},
+  };
+};
+
+/**
+ * @param {Array<ERef<EscrowAccount>>} escrowAccounts
+ * @returns {Promise<Array<EASnapshot>>}
+ */
+const takeSnapshots = escrowAccounts =>
+  Promise.all(escrowAccounts.map(ea => E(ea).takeSnapshot()));
+
+/**
+ *
+ * @param {Array<ERef<EscrowAccount>>} escrowAccounts
+ * @param {Promise=} promiseToAwait
+ * @returns {Promise<Array<Array<Amount>>>}
+ */
+const closeAccounts = (escrowAccounts, promiseToAwait) => {
+  return Promise.all(
+    escrowAccounts.map(ea => E(ea).closeAccount(promiseToAwait)),
+  );
+};
+
+// Trade everything with each other
+const swapAll = ([firstSnapshot, secondSnapshot]) => {
+  return move(firstSnapshot, secondSnapshot, firstSnapshot.amounts)
+    .move(secondSnapshot, firstSnapshot, secondSnapshot.amounts)
+    .end();
+};

--- a/packages/zoe/src/redesign/contracts/coveredCall.js
+++ b/packages/zoe/src/redesign/contracts/coveredCall.js
@@ -1,0 +1,67 @@
+// @ts-check
+import { registerPlugin } from '@agoric/babel-standalone';
+import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
+import { CLOSING_CONDITIONS } from '../escrow/cleanConditions';
+
+const { details: X } = assert;
+
+const start = async (escrowService, useObjService, terms, privateArgs) => {
+  const { sellerEA } = privateArgs;
+  const [sellerSnapshot] = await E(escrowService).startTransfer([sellerEA]);
+  const closing = sellerSnapshot.conditions.closing;
+  assert(closing.condition === CLOSING_CONDITIONS.AFTER_DEADLINE);
+  const underlyingAssets = sellerSnapshot.escrowedAmounts;
+  const strikePrice = sellerSnapshot.wantedAmounts;
+
+  // An invitation gives an object which can trigger the trade of
+  // the underlyingAssets for the strikePrice, but only if the option
+  // has not expired
+
+  // if the trade has completed successfully, no NFT can be created.
+  let available = true;
+
+  const exerciseOptionObj = Far('exerciseOption', {
+    exerciseOption: async buyerEA => {
+      // old code had a synchronous check that the seller seat hadn't
+      // exited. It was only helpful for giving a good error message.
+
+      const [buyerSnapshot] = await E(escrowService).startTransfer([buyerEA]);
+
+      await E(escrowService).completeTransfer([
+        {
+          seat: sellerSnapshot.seat,
+          add: strikePrice,
+          subtract: underlyingAssets,
+        },
+        {
+          seat: buyerSnapshot.seat,
+          add: underlyingAssets,
+          subtract: strikePrice,
+        },
+      ]);
+      available = false;
+
+      // zcf.shutdown('Swap completed.');
+    },
+
+    // not the same thing as getState - these are intended to be public
+    getInfo: () => {
+      assert(
+        available,
+        X`The option is not longer available to be transferred. It has expired, or it was exercised.`,
+      );
+      return harden({
+        expirationDate: closing.deadline,
+        timeAuthority: closing.timer,
+        underlyingAssets,
+        strikePrice,
+      });
+    },
+  });
+
+  return E(useObjService).registerGetNFT(exerciseOptionObj);
+};
+
+harden(start);
+export { start };

--- a/packages/zoe/src/redesign/contracts/mintPayments.js
+++ b/packages/zoe/src/redesign/contracts/mintPayments.js
@@ -1,0 +1,54 @@
+// @ts-check
+
+import { Far } from '@agoric/marshal';
+import { AssetKind, makeIssuerKit } from '@agoric/ertp';
+import { E } from '@agoric/eventual-send';
+
+const start = async (escrowService, terms, privateArgs) => {
+  const issuerKit = makeIssuerKit('tokens', AssetKind.NAT);
+  await E(escrowService).addIssuer(issuerKit.issuer);
+  const { payoutHandler } = privateArgs;
+
+  const buyTokens = async buyerAccount => {
+    const [buyerSnapshot] = await E(escrowService).startTransfer([
+      buyerAccount,
+    ]);
+    const {
+      currentAmounts: buyerContributed,
+      seat: buyerSeat,
+      conditions: { wantedAmounts: buyerWanted },
+    } = buyerSnapshot;
+
+    // TODO: check that there is enough money to cover the wanted
+    // tokens, using the wantedAmounts and currentAmounts. Also, leave
+    // any excess contributed.
+
+    const payment = issuerKit.mint.mintPayment(buyerWanted);
+    const conditions = harden({ wantedAmounts: buyerContributed });
+    const sellerAccount = E(escrowService).openEscrowAccount(
+      payment,
+      conditions,
+      payoutHandler,
+    );
+    await E(escrowService).completeTransfer([
+      {
+        seat: buyerSeat,
+        add: buyerWanted,
+        subtract: buyerContributed,
+      },
+      {
+        account: sellerAccount,
+        add: buyerContributed,
+        subtract: buyerWanted,
+      },
+    ]);
+  };
+
+  return Far('API', { buyTokens, getIssuer: issuerKit.issuer });
+
+  // or return an object that allows the holder to create new use obj
+  // <-> invitations if we want the sale to be private
+};
+
+harden(start);
+export { start };

--- a/packages/zoe/src/redesign/contracts/swapAll.js
+++ b/packages/zoe/src/redesign/contracts/swapAll.js
@@ -1,0 +1,110 @@
+// @ts-check
+
+import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
+
+import '../../../exported.js';
+
+const { details: X } = assert;
+
+const swapAll = ([firstSnapshot, secondSnapshot]) => {
+  const firstAllocation = harden({
+    escrowAccount: firstSnapshot.escrowAccount,
+    amounts: secondSnapshot.amounts,
+  });
+
+  const secondAllocation = harden({
+    escrowAccount: secondSnapshot.escrowAccount,
+    amounts: firstSnapshot.amounts,
+  });
+
+  return [firstAllocation, secondAllocation];
+};
+
+const performTransfer = async (escrowService, accounts, callback) => {
+  const snapshots = await E(escrowService).startTransfer(...accounts);
+  const newSnapshots = callback(snapshots);
+  return E(escrowService).completeTransfer(...newSnapshots);
+};
+
+const contractHelper = es => {
+  return harden({
+    transfer: async (callback, accounts) => {
+      const newSnapshotsP = E.when(E(es).startTransfer(accounts), callback);
+      return E(es).completeTransfer(newSnapshotsP);
+    },
+  });
+};
+
+// no helpers
+const startNoHelpers = escrow => {
+  let initialEA;
+  const startSwap = initial => {
+    initialEA = initial;
+  };
+  const completeSwap = async matchingEA => {
+    assert(initialEA !== undefined, X`The swap has not yet started`);
+    const [initialS, matchingS] = await E(escrow).startTransfer([
+      initialEA,
+      matchingEA,
+    ]);
+    const completeP = E(escrow).completeTransfer([
+      {
+        seat: initialS.seat,
+        subtract: matchingS.conditions.wantedAmounts,
+        add: initialS.conditions.wantedAmounts,
+      },
+      {
+        seat: matchingS.seat,
+        subtract: initialS.conditions.wantedAmounts,
+        add: matchingS.conditions.wantedAmounts,
+      },
+    ]);
+    completeP
+      .then(() => {
+        const initialClosed = E(initialEA).closeAccount();
+        const matchingClosed = E(matchingEA).closeAccount();
+        return Promise.all([initialClosed, matchingClosed]);
+      })
+      .then(() => {
+        shutdownVat();
+      });
+  };
+  return Far('API', {
+    startSwap,
+    completeSwap,
+  });
+};
+
+/**
+ * All of the escrowed assets are swapped between two escrowAccounts.
+ *
+ * @param {EscrowService} escrowService
+ */
+const start = escrowService => {
+  const h = makeHelper(escrowService);
+  const offerFirst = firstEA => {
+    const offerSecond = async secondEA => {
+      const callback = ([leftSeat, rightSeat]) => {
+        rightSeat.decrementBy(leftSeat.getWanted());
+        leftSeat.incrementBy(leftSeat.getWanted());
+        leftSeat.decrementBy(rightSeat.getWanted());
+        rightSeat.incrementBy(rightSeat.getWanted());
+
+        return [leftSeat, rightSeat];
+      };
+      h.transfer(callback, [firstEA, secondEA]);
+    };
+
+    return Far('secondOffer', {
+      offerSecond,
+    });
+  };
+
+  return Far('firstOffer', {
+    offerFirst,
+  });
+};
+
+harden(start);
+export { start };

--- a/packages/zoe/src/redesign/escrow/amountArrayMath.js
+++ b/packages/zoe/src/redesign/escrow/amountArrayMath.js
@@ -1,0 +1,33 @@
+// @ts-check
+
+import { assert, details as X } from '@agoric/assert';
+import { AmountMath } from '@agoric/ertp';
+import { sumByBrand } from './rightsConservation.js';
+
+/** @type {AddAmounts} */
+const addAmounts = (leftAmounts, rightAmounts) => {
+  return sumByBrand([...leftAmounts, ...rightAmounts]).values();
+};
+harden(addAmounts);
+
+/** @type {SubtractAmounts} */
+const subtractAmounts = (leftAmounts, rightAmounts) => {
+  const leftSums = sumByBrand(leftAmounts);
+  const rightSums = sumByBrand(rightAmounts);
+
+  return rightSums.entries().map(([brand, amountToSubtract]) => {
+    assert(
+      leftSums.has(brand),
+      X`${rightAmounts} could not be subtracted from ${leftAmounts} because the left did not have the brand ${brand}`,
+    );
+    const leftAmount = leftSums.get(brand);
+    assert(
+      AmountMath.isGTE(leftAmount, amountToSubtract),
+      X`${rightAmounts} could not be subtracted from ${leftAmounts} because the amount to be subtracted ${amountToSubtract} was greater than the original amount ${leftAmount}`,
+    );
+    return AmountMath.subtract(leftAmount, amountToSubtract);
+  });
+};
+harden(subtractAmounts);
+
+export { addAmounts, subtractAmounts };

--- a/packages/zoe/src/redesign/escrow/assertAmounts.js
+++ b/packages/zoe/src/redesign/escrow/assertAmounts.js
@@ -1,0 +1,6 @@
+// @ts-check
+
+const assertAmounts = amounts => {};
+harden(assertAmounts);
+
+export { assertAmounts };

--- a/packages/zoe/src/redesign/escrow/assertOfferSafetyForAllocations.js
+++ b/packages/zoe/src/redesign/escrow/assertOfferSafetyForAllocations.js
@@ -1,0 +1,20 @@
+// @ts-check
+
+import { isOfferSafe } from './offerSafety.js';
+
+const { details: X } = assert;
+
+// TODO: add types and move to offerSafety.js
+const assertOfferSafetyForAllocations = allocations => {
+  // Ensure that offer safety holds for each escrowAccount
+  allocations.forEach(({ escrowAccount, amounts: proposedAmounts }) => {
+    const initialAmounts = escrowAccount.getCurrentAmounts();
+    const conditions = escrowAccount.getConditions();
+    assert(
+      isOfferSafe(initialAmounts, conditions.wantedAmounts, proposedAmounts),
+      X`Offer safety was violated. Initial amounts: ${initialAmounts}. Wanted amounts: ${conditions.wantedAmounts}. Proposed amounts: ${proposedAmounts}`,
+    );
+  });
+};
+harden(assertOfferSafetyForAllocations);
+export { assertOfferSafetyForAllocations };

--- a/packages/zoe/src/redesign/escrow/assertPassStyleOf.js
+++ b/packages/zoe/src/redesign/escrow/assertPassStyleOf.js
@@ -1,0 +1,49 @@
+// @ts-check
+
+import { passStyleOf } from '@agoric/marshal';
+
+/**
+ * Assert that the argument is an array, or a "copyArray" in @agoric/marshal terms.
+ *
+ * @param {Array} array
+ * @param {string=} optNameOfArray
+ */
+const assertArray = (array, optNameOfArray = 'Alleged array') => {
+  const passStyle = passStyleOf(array);
+  assert(
+    passStyle === 'copyArray',
+    `${optNameOfArray} ${array} must be an array, not ${passStyle}`,
+  );
+};
+harden(assertArray);
+
+/**
+ * Assert that the argument is a pass-by-copy record, or a
+ * "copyRecord" in @agoric/marshal terms
+ *
+ * @param {Object} record
+ * @param {string=} optNameOfRecord
+ * @returns {void}
+ */
+const assertRecord = (record, optNameOfRecord = 'Alleged record') => {
+  const passStyle = passStyleOf(record);
+  assert(
+    passStyle === 'copyRecord',
+    `${optNameOfRecord} ${record} must be a pass-by-copy record, not ${passStyle}`,
+  );
+};
+harden(assertRecord);
+
+const assertRemotable = (
+  remotable,
+  optNameOfRemotable = 'Alleged remotable',
+) => {
+  const passStyle = passStyleOf(remotable);
+  assert(
+    passStyle === 'remotable',
+    `${optNameOfRemotable} ${remotable} must be a remotable, not ${passStyle}`,
+  );
+};
+harden(assertRemotable);
+
+export { assertRecord, assertArray, assertRemotable };

--- a/packages/zoe/src/redesign/escrow/assertPayments.js
+++ b/packages/zoe/src/redesign/escrow/assertPayments.js
@@ -1,0 +1,34 @@
+// @ts-check
+
+import { passStyleOf } from '@agoric/marshal';
+
+const { details: X } = assert;
+
+/**
+ * This function uses passStyleOf to assert that the argument is a
+ * copyArray, remotable or promise. It returns a standardized form: a
+ * copyArray of remotables or promises for remotables.
+ *
+ * @param {Array<ERef<Payment>> | ERef<Payment>} payments
+ * @returns {Array<ERef<Payment>>}
+ */
+const assertPayments = payments => {
+  const paymentsPassStyle = passStyleOf(payments);
+  assert(
+    paymentsPassStyle === 'copyArray' ||
+      paymentsPassStyle === 'remotable' ||
+      paymentsPassStyle === 'promise',
+    X`Payments ${payments} must be an array of payments, a payment, or a promise for a payment, not ${paymentsPassStyle}`,
+  );
+  /** @type {Array<ERef<Payment>>} */
+  let paymentsArray;
+  if (paymentsPassStyle === 'remotable' || paymentsPassStyle === 'promise') {
+    paymentsArray = [/** @type {ERef<Payment>} */ (payments)];
+  } else {
+    paymentsArray = /** @type {Array<ERef<Payment>>} */ (payments);
+  }
+  return paymentsArray;
+};
+harden(assertPayments);
+
+export { assertPayments };

--- a/packages/zoe/src/redesign/escrow/assertRightsConservedForAllocations.js
+++ b/packages/zoe/src/redesign/escrow/assertRightsConservedForAllocations.js
@@ -1,0 +1,14 @@
+// @ts-check
+
+import { assertRightsConserved } from './rightsConservation.js';
+
+// TODO: type this and move to rightsConservation
+const assertRightsConservedForAllocations = allocations => {
+  const previousAmounts = allocations.flatMap(({ escrowAccount }) =>
+    escrowAccount.getCurrentAmounts(),
+  );
+  const newAmounts = allocations.flatMap(({ amounts }) => amounts);
+  assertRightsConserved(previousAmounts, newAmounts);
+};
+harden(assertRightsConservedForAllocations);
+export { assertRightsConservedForAllocations };

--- a/packages/zoe/src/redesign/escrow/calculateAllocations.js
+++ b/packages/zoe/src/redesign/escrow/calculateAllocations.js
@@ -1,0 +1,24 @@
+// @ts-check
+
+import { addAmounts, subtractAmounts } from './amountArrayMath';
+
+// Deltas have already gone through input validation
+/** @type {CalculateAllocations} */
+const calculateAllocations = deltas => {
+  return harden(
+    deltas.map(({ account, add, subtract }) => {
+      const currentAmounts = account.getCurrentAmounts();
+      // TODO: consider the order of adding and subtracting
+      const proposedAmounts = subtractAmounts(
+        addAmounts(currentAmounts, add),
+        subtract,
+      );
+      return {
+        account,
+        amounts: proposedAmounts,
+      };
+    }),
+  );
+};
+harden(calculateAllocations);
+export { calculateAllocations };

--- a/packages/zoe/src/redesign/escrow/cleanConditions.js
+++ b/packages/zoe/src/redesign/escrow/cleanConditions.js
@@ -1,0 +1,80 @@
+// @ts-check
+
+import { AmountMath } from '@agoric/ertp';
+import { assertStructure } from '@agoric/marshal';
+import { isNat } from '@agoric/nat';
+
+import { assertArray, assertRecord } from './assertPassStyleOf.js';
+
+const { details: X } = assert;
+
+/**
+ * Constants for the kinds of closing conditions we support.
+ *
+ * @type {ClosingConditionChoices}
+ */
+const CLOSING_CONDITIONS = {
+  AFTER_DEADLINE: 'afterDeadline',
+  ON_DEMAND: 'onDemand',
+  OPTIMISTIC: 'optimistic',
+};
+harden(CLOSING_CONDITIONS);
+
+/**
+ * // TODO: define Conditions
+ *
+ * @param {Conditions} conditions
+ * @returns {Conditions}
+ */
+const cleanConditions = conditions => {
+  // This check ensures that there are no promises in the conditions.
+  // TODO: improve error message?
+  assertStructure(conditions);
+  // TODO: is this unnecessary given assertStructure? What should the
+  // order be?
+  assertRecord(conditions, 'conditions');
+  const { wantedAmounts = [], closingConditions } = conditions;
+  assertArray(wantedAmounts, 'wantedAmounts');
+  // TODO: cleanProposal.js had a check that the perceived assetKind
+  // of the value matched the brand's assetKind. Consider alternative
+  // approaches or include that here. It seems like that should be
+  // part of ERTP instead.
+  const cleanedWantedAllocation = wantedAmounts.map(amount =>
+    AmountMath.coerce(amount.brand, amount),
+  );
+
+  let cleanedClosingConditions = harden({
+    condition: CLOSING_CONDITIONS.ON_DEMAND,
+  });
+
+  if (closingConditions) {
+    assertRecord(closingConditions, 'closingConditions');
+    const { condition } = closingConditions;
+    // TODO: clean this up
+    if (condition === CLOSING_CONDITIONS.AFTER_DEADLINE) {
+      assert(closingConditions.timer !== undefined, X`timer must be defined`);
+      assert(
+        typeof closingConditions.deadline === 'bigint' &&
+          isNat(closingConditions.deadline),
+        X`deadline must be a Nat BigInt`,
+      );
+      cleanedClosingConditions = harden({
+        condition: CLOSING_CONDITIONS.AFTER_DEADLINE,
+        timer: closingConditions.timer,
+        deadline: closingConditions.deadline,
+      });
+    } else {
+      assert(
+        condition === CLOSING_CONDITIONS.ON_DEMAND,
+        `Closing conditions can only be AFTER_DEADLINE or ON_DEMAND, not ${condition}`,
+      );
+    }
+    // TODO: add handling for OPTIMISTIC
+  }
+  return harden({
+    wantedAllocation: cleanedWantedAllocation,
+    closingConditions: cleanedClosingConditions,
+  });
+};
+harden(cleanConditions);
+export { cleanConditions, CLOSING_CONDITIONS };

--- a/packages/zoe/src/redesign/escrow/coerceDeltas.js
+++ b/packages/zoe/src/redesign/escrow/coerceDeltas.js
@@ -1,0 +1,51 @@
+// @ts-check
+
+import { fulfillToStructure } from '@agoric/marshal';
+import { assertRecord, assertArray } from './assertPassStyleOf.js';
+import { assertAmounts } from './assertAmounts';
+
+const { details: X } = assert;
+
+/** @type {CoerceDeltas} */
+const coerceDeltas = async (isEscrowAccount, hasSeat, deltas) => {
+  assertArray(deltas, 'deltas');
+  deltas = await fulfillToStructure(deltas);
+
+  // We may want to handle this with static checking instead.
+  // Discussion at: https://github.com/Agoric/agoric-sdk/issues/1017
+  assert(
+    deltas.length >= 2,
+    X`Transfer requires two or more deltas, not ${deltas}`,
+  );
+
+  const coerceDelta = delta => {
+    assertRecord(delta, 'delta');
+    const { account, add, subtract } = delta;
+    assert(
+      isEscrowAccount(account),
+      X`${account} was not a valid escrowAccount`,
+    );
+    assert(
+      !hasSeat(account),
+      X`assets could not be transferred from ${account} because someone else had the exclusive right to transfer`,
+    );
+    // TODO: write this function
+    assertAmounts(add);
+    assertAmounts(subtract);
+    return harden({ account, add, subtract });
+  };
+  deltas = deltas.map(coerceDelta);
+
+  // Keep track of escrowAccounts used, to prevent aliasing.
+  const escrowAccountsSoFar = new Set();
+
+  deltas.forEach(({ account }) => {
+    assert(
+      !escrowAccountsSoFar.has(account),
+      X`escrowAccount (${account} was included twice in the transfer`,
+    );
+    escrowAccountsSoFar.add(account);
+  });
+};
+harden(coerceDeltas);
+export { coerceDeltas };

--- a/packages/zoe/src/redesign/escrow/deleteSeatDeltas.js
+++ b/packages/zoe/src/redesign/escrow/deleteSeatDeltas.js
@@ -1,0 +1,19 @@
+// @ts-check
+
+import { assertArray, assertRecord } from './assertPassStyleOf';
+
+const deleteSeatDeltas = (deleteSeat, seatDeltas) => {
+  assertArray(seatDeltas, 'seatDeltas');
+  return seatDeltas.map(seatDelta => {
+    assertRecord(seatDelta, 'seatDelta');
+    const { seat, add, subtract } = seatDelta;
+    const account = deleteSeat(seat);
+    return harden({
+      account,
+      add,
+      subtract,
+    });
+  });
+};
+harden(deleteSeatDeltas);
+export { deleteSeatDeltas };

--- a/packages/zoe/src/redesign/escrow/escrow.js
+++ b/packages/zoe/src/redesign/escrow/escrow.js
@@ -1,0 +1,223 @@
+// @ts-check
+
+/**
+ * The Escrow Service
+ *
+ * Users can deposit payments in escrow accounts, with clear
+ * conditions for how the account can be closed and how funds can
+ * moved between accounts. Funds can only be moved between escrow
+ * accounts after the conditions for moving (offer safety) and total
+ * conservation of funds (rights conservation) have been confirmed.
+ */
+
+import { E } from '@agoric/eventual-send';
+import { Far } from '@agoric/marshal';
+import { makeScalarMap } from '@agoric/store';
+
+import { areAmountsGTE } from './offerSafety';
+import { assertRightsConservedForAllocations } from './assertRightsConservedForAllocations.js';
+import { assertOfferSafetyForAllocations } from './assertOfferSafetyForAllocations.js';
+import { holdEscrowPurses } from './purses.js';
+import { assertPayments } from './assertPayments.js';
+import { cleanConditions, CLOSING_CONDITIONS } from './cleanConditions.js';
+import { assertRemotable } from './assertPassStyleOf.js';
+import { coerceDeltas } from './coerceDeltas.js';
+import { addAmounts, subtractAmounts } from './amountArrayMath.js';
+import { calculateAllocations } from './calculateAllocations';
+import { assertAmounts } from './assertAmounts';
+import { makeHandle } from '../makeHandle';
+import { deleteSeatDeltas } from './deleteSeatDeltas';
+
+const { details: X } = assert;
+
+const makeZoeEscrowService = (shutdownWithFailure = _err => {}) => {
+  const { depositPayments, withdrawPayments, addIssuer } = holdEscrowPurses();
+
+  // The amounts that will be paid out if the escrowAccount were to
+  // close now
+  /** @type {Store<EscrowAccount, Array<Amount>>} */
+  const escrowAccountToCurrentAmounts = makeScalarMap('escrowAccount');
+
+  // The amounts that the user has deposited (minus those withdrawn)
+  // Used for offerSafety
+  /** @type {Store<EscrowAccount, Array<Amount>>} */
+  const escrowAccountToEscrowedAmounts = makeScalarMap('escrowAccount');
+
+  // Seats are the exclusive right to transfer assets to and from an
+  // escrowAccount
+  /** @type {Store<EscrowAccount, Seat>} */
+  const escrowAccountToSeat = makeScalarMap('escrowAccount');
+  /** @type {Store<Seat, EscrowAccount>} */
+  const seatToEscrowAccount = makeScalarMap('seat');
+
+  /** @type {TransferAssets} */
+  const transferAssets = async deltas => {
+    const isEscrowAccount = escrowAccountToCurrentAmounts.has;
+    const hasSeat = escrowAccountToSeat.has;
+    const localDeltas = await coerceDeltas(isEscrowAccount, hasSeat, deltas);
+    const allocations = calculateAllocations(localDeltas);
+    assertRightsConservedForAllocations(allocations);
+    assertOfferSafetyForAllocations(allocations);
+
+    try {
+      // No side effects above. All conditions checked which could have
+      // caused us to reject this reallocation.
+      // COMMIT POINT
+      allocations.forEach(({ account, amounts }) => {
+        escrowAccountToCurrentAmounts.set(account, amounts);
+      });
+    } catch (err) {
+      shutdownWithFailure(err);
+      throw err;
+    }
+
+    // Close the escrow account if the wantedAmounts are achieved and
+    // the closingConditions allow it
+
+    allocations.forEach(({ account }) => {
+      const { closing, wantedAmounts } = account.getConditions();
+      if (closing.condition === CLOSING_CONDITIONS.OPTIMISTIC) {
+        if (areAmountsGTE(account.getCurrentAmounts(), wantedAmounts)) {
+          account.closeAccount();
+        }
+      }
+    });
+  };
+
+  /** @type {StartTransfer} */
+  const startExclTransfer = async accounts => {
+    const localAccounts = await Promise.all(accounts);
+    return localAccounts.map(account => account.startTransfer());
+  };
+
+  // TODO: figure out if this needs to allow for ERef<Seat>
+  /** @type {CompleteTransfer} */
+  const completeExclTransfer = async seatDeltas => {
+    const deleteSeat = seat => {
+      const ea = seatToEscrowAccount.get(seat);
+      seatToEscrowAccount.delete(seat);
+      escrowAccountToSeat.delete(ea);
+      return ea;
+    };
+    const deltas = deleteSeatDeltas(deleteSeat, seatDeltas);
+    return transferAssets(deltas);
+  };
+
+  // The `escrowAccount` object has the ability to release funds from
+  // escrow, which triggers payments being sent to the pre-registered
+  // payoutHandler.
+
+  // "releasing funds from escrow" = "payout"
+  const openEscrowAccount = async (payments, conditions, payoutHandler) => {
+    // Validate the inputs
+    const paymentsArray = assertPayments(payments);
+    conditions = cleanConditions(conditions);
+    assertRemotable(payoutHandler, `payoutHandler`);
+
+    let paymentsAmounts;
+    try {
+      paymentsAmounts = await depositPayments(paymentsArray);
+    } catch (err) {
+      // TODO: handle case of partially deposited
+      // const payouts = withdrawPayments(alreadyDepositedAmounts);
+      E(payoutHandler).handle(paymentsArray);
+      throw err;
+    }
+
+    const assertOpen = ea => {
+      assert(
+        escrowAccountToCurrentAmounts.has(ea),
+        `The escrow account ${ea} has been closed, or is not actually an escrow account`,
+      );
+    };
+
+    // TODO: handle afterDeadline closing, and prevent closing (from both
+    // contract and user's side) if that is the case.
+
+    /** @type {EscrowAccount} */
+    const escrowAccount = Far('escrowAccount', {
+      getConditions: () => conditions,
+      getCurrentAmounts: () => escrowAccountToCurrentAmounts.get(escrowAccount),
+      closeAccount: async (promiseToWait = Promise.resolve()) => {
+        await promiseToWait;
+        assertOpen(escrowAccount);
+        const closingAmounts = escrowAccountToCurrentAmounts.get(escrowAccount);
+        escrowAccountToCurrentAmounts.delete(escrowAccount);
+        escrowAccountToEscrowedAmounts.delete(escrowAccount);
+        const payouts = withdrawPayments(closingAmounts);
+        E(payoutHandler).handle(payouts);
+        return closingAmounts;
+      },
+      deposit: async additionalPayments => {
+        // TODO: are deposits allowed even with an outstanding seat?
+        assert(
+          !escrowAccountToSeat.has(escrowAccount),
+          X`Deposit failed because there is an outstanding exclusive right to transfer assets to and from this escrowAccount`,
+        );
+        const additionalPaymentsArray = assertPayments(additionalPayments);
+        const additionalAmounts = await depositPayments(
+          additionalPaymentsArray,
+        );
+        const currentAmounts = escrowAccountToCurrentAmounts.get(escrowAccount);
+        const escrowedAmounts = escrowAccountToEscrowedAmounts.get(
+          escrowAccount,
+        );
+        const combinedCurrent = addAmounts(currentAmounts, additionalAmounts);
+        const combinedEscrowed = addAmounts(escrowedAmounts, additionalAmounts);
+
+        // COMMIT POINT
+        escrowAccountToCurrentAmounts.set(escrowAccount, combinedCurrent);
+        escrowAccountToEscrowedAmounts.set(escrowAccount, combinedEscrowed);
+        return additionalAmounts;
+      },
+      withdraw: amountsToWithdraw => {
+        assert(
+          !escrowAccountToSeat.has(escrowAccount),
+          X`Deposit failed because there is an outstanding exclusive right to transfer assets to and from this escrowAccount`,
+        );
+        assertAmounts(amountsToWithdraw);
+        const currentAmounts = escrowAccountToCurrentAmounts.get(escrowAccount);
+        const escrowedAmounts = escrowAccountToEscrowedAmounts.get(
+          escrowAccount,
+        );
+        const remainingCurrent = subtractAmounts(
+          currentAmounts,
+          amountsToWithdraw,
+        );
+        const remainingEscrowed = subtractAmounts(
+          escrowedAmounts,
+          amountsToWithdraw,
+        );
+
+        // COMMIT POINT
+        escrowAccountToCurrentAmounts.set(escrowAccount, remainingCurrent);
+        escrowAccountToEscrowedAmounts.set(escrowAccount, remainingEscrowed);
+        const newPayments = withdrawPayments(amountsToWithdraw);
+        E(payoutHandler).handle(newPayments);
+      },
+      startTransfer: () => {
+        const seat = makeHandle('Seat');
+        escrowAccountToSeat.init(escrowAccount, seat);
+        seatToEscrowAccount.init(seat, escrowAccount);
+        return harden({
+          seat, // To be renamed
+          conditions,
+          currentAmounts: escrowAccountToCurrentAmounts.get(escrowAccount),
+          escrowedAmounts: escrowAccountToEscrowedAmounts.get(escrowAccount),
+        });
+      },
+    });
+    escrowAccountToCurrentAmounts.init(escrowAccount, paymentsAmounts);
+    return escrowAccount;
+  };
+
+  return harden({
+    addIssuer,
+    openEscrowAccount,
+    transferAssets,
+    startExclTransfer,
+    completeExclTransfer,
+  });
+};
+harden(makeZoeEscrowService);
+export { makeZoeEscrowService };

--- a/packages/zoe/src/redesign/escrow/offerSafety.js
+++ b/packages/zoe/src/redesign/escrow/offerSafety.js
@@ -1,0 +1,66 @@
+// @ts-check
+
+import { AmountMath } from '@agoric/ertp';
+
+import { sumByBrand } from './rightsConservation';
+
+// TODO: add types
+// TODO add unit tests
+
+/**
+ *
+ * @param {Array<Amount>} left - an array of amounts, of various brands
+ * @param {Array<Amount>} right - an array of amounts, of various brands
+ * @returns {boolean}
+ */
+const areAmountsGTE = (left, right) => {
+  // Sum the amounts by brand to get a mapping of brands to the total sums
+  const sumsLeft = sumByBrand(left);
+  const sumsRight = sumByBrand(right);
+
+  const checkBrands = () => {
+    // if right has any brands not in left, left is not GTE to right
+    const brandsInLeft = new Set(sumsLeft.keys());
+    const everyRightBrandAlsoInLeft = sumsRight
+      .keys()
+      .every(brandInRight => brandsInLeft.has(brandInRight));
+    return everyRightBrandAlsoInLeft;
+  };
+
+  const checkAmountsGTE = () => {
+    return sumsRight.entries().every(([brand, amountInRight]) => {
+      const amountInLeft = sumsLeft.get(brand);
+      return AmountMath.isGTE(amountInLeft, amountInRight);
+    });
+  };
+
+  return checkBrands() && checkAmountsGTE();
+};
+
+harden(areAmountsGTE);
+
+/**
+ * `isOfferSafe` checks whether proposed amounts fulfill offer safety
+ * for a single escrow account .
+ *
+ * Note: This implementation checks whether the proposed amounts are
+ * GTE to the initial amounts and whether the proposed allocation is
+ * GTE to the wanted amounts. Both can be true. Only one has to be
+ * true for offer safety to be satisfied.
+ *
+ * @param {Array<Amount>} initialAmounts - the initial amounts in the
+ * escrow account
+ * @param {Array<Amount>} wantedAmounts - the user wants these
+ * amounts in return, if the escrowed amounts are taken. In other
+ * words, offer safety ensures that the escrowed amounts can only be
+ * taken if these amounts or more are given.
+ * @param {Array<Amount>} proposedAmounts - the amounts we are
+ * checking for offer safety, which will become the currentAmounts if
+ * all checks pass
+ * @returns {boolean}
+ */
+const isOfferSafe = (initialAmounts, wantedAmounts, proposedAmounts) =>
+  areAmountsGTE(proposedAmounts, initialAmounts) ||
+  areAmountsGTE(proposedAmounts, wantedAmounts);
+
+export { isOfferSafe, areAmountsGTE };

--- a/packages/zoe/src/redesign/escrow/purses.js
+++ b/packages/zoe/src/redesign/escrow/purses.js
@@ -1,0 +1,73 @@
+// @ts-check
+import { E } from '@agoric/eventual-send';
+import { makeScalarWeakMap } from '@agoric/store';
+
+// Note: input validation done elsewhere.
+
+const { details: X } = assert;
+
+const holdEscrowPurses = () => {
+  /** @type {WeakStore<Brand, ERef<Purse>>} */
+  const brandToPurse = makeScalarWeakMap('brand');
+
+  /**
+   * Add issuer so that assets of this brand can be escrowed. Creates
+   * a purse so that payments of this brand can be deposited. Note
+   * that all funds of the same brand are intermingled in the same purse.
+   *
+   * @param {ERef<Issuer>} issuer
+   * @returns {Promise<void>}
+   */
+  const addIssuer = async issuer => {
+    const brandP = E(issuer).getBrand();
+    const issuerMatchesP = E(brandP).isMyIssuer(issuer);
+    const purseP = E(issuer).makeEmptyPurse();
+
+    const [brand, issuerMatches, purse] = await Promise.all([
+      brandP,
+      issuerMatchesP,
+      purseP,
+    ]);
+    assert(issuerMatches, X`issuer ${issuer} did not match ${brand}`);
+    brandToPurse.init(brand, purse);
+  };
+
+  /**
+   * TODO: think about whether the promises are optimized
+   *
+   * @param {Array<ERef<Payment>>} payments
+   * @returns {Promise<Array<Amount>>}
+   */
+  const depositPayments = async payments => {
+    const allegedBrands = await Promise.all(
+      payments.map(payment => E(payment).getAllegedBrand()),
+    );
+    return Promise.all(
+      payments.map((paymentP, i) => {
+        const allegedBrand = allegedBrands[i];
+        const purse = brandToPurse.get(allegedBrand);
+        return E.when(paymentP, payment => E(purse).deposit(payment));
+      }),
+    );
+  };
+
+  /**
+   *
+   * TODO: validate amounts or confirm validated elsewhere
+   *
+   * @param {Array<Amount>} amounts
+   * @returns {Array<Promise<Payment>>}
+   */
+  const withdrawPayments = amounts => {
+    const paymentPs = amounts.map(amount => {
+      const purse = brandToPurse.get(amount.brand);
+      return E(purse).withdraw(amount);
+    });
+    harden(paymentPs);
+    return paymentPs;
+  };
+
+  return harden({ depositPayments, withdrawPayments, addIssuer });
+};
+harden(holdEscrowPurses);
+export { holdEscrowPurses };

--- a/packages/zoe/src/redesign/escrow/rightsConservation.js
+++ b/packages/zoe/src/redesign/escrow/rightsConservation.js
@@ -1,22 +1,24 @@
 // @ts-check
 
-import { makeStore } from '@agoric/store';
+import { makeScalarMap } from '@agoric/store';
 import { assert, details as X } from '@agoric/assert';
 import { AmountMath } from '@agoric/ertp';
 
-import '../../exported.js';
-import '../internal-types.js';
+import '../../../exported.js';
+import '../../internal-types.js';
 
 /**
  * Iterate over the amounts and sum, storing the sums in a
  * map by brand.
+ *
+ * Amounts are validated elsewhere.
  *
  * @param  {Amount[]} amounts - an array of amounts
  * @returns {Store<Brand, Amount>} sumsByBrand - a map of Brand keys and
  * Amount values. The amounts are the sums.
  */
 const sumByBrand = amounts => {
-  const sumsByBrand = makeStore('brand');
+  const sumsByBrand = makeScalarMap('brand');
   amounts.forEach(amount => {
     const { brand } = amount;
     if (!sumsByBrand.has(brand)) {
@@ -28,6 +30,7 @@ const sumByBrand = amounts => {
   });
   return sumsByBrand;
 };
+harden(sumByBrand);
 
 /**
  * Assert that the left sums by brand equal the right sums by brand
@@ -83,6 +86,7 @@ const assertEqualPerBrand = (leftSumsByBrand, rightSumsByBrand) => {
     );
   });
 };
+harden(assertEqualPerBrand);
 
 /**
  * `assertRightsConserved` checks that the total amount per brand is

--- a/packages/zoe/src/redesign/escrow/types.js
+++ b/packages/zoe/src/redesign/escrow/types.js
@@ -1,0 +1,126 @@
+// @ts-check
+
+/**
+ * @callback CloseAccount
+ *
+ * Waits on the promiseToWait, if not undefined, then closes the
+ * account, returning the closing amounts
+ *
+ * @param {Promise=} promiseToWait
+ * @returns {Promise<Array<Amount>>}
+ */
+
+/**
+ * @typedef {{ AFTER_DEADLINE: 'afterDeadline', ON_DEMAND: 'onDemand',
+ * OPTIMISTIC: 'optimistic' }} ClosingConditionChoices
+ */
+
+/**
+ * @typedef {Object} Conditions
+ * @property {Array<Amount>} wantedAmounts
+ * @property {{ condition: ClosingConditionChoices["AFTER_DEADLINE"] |
+ * ClosingConditionChoices["ON_DEMAND"] | ClosingConditionChoices["OPTIMISTIC"], timer: Timer,
+ * deadline:Deadline}} closing
+ */
+
+/**
+ * @typedef {Object} EscrowAccount
+ * @property {() => Conditions} getConditions
+ * @property {() => Array<Amount>} getCurrentAmounts
+ * @property {CloseAccount} closeAccount
+ * @property {(additionalPayments: Array<ERef<Payment>>) => Promise<Array<Amount>>} deposit
+ * @property {(amountsToWithdraw: Array<Amount>) => void} withdraw
+ * @property {() => AccountSnapshot} startTransfer
+ */
+
+/**
+ * @typedef {Object} AccountSnapshot
+ * @property {Seat} seat
+ * @property {Conditions} conditions
+ * @property {Array<Amount>} currentAmounts
+ * @property {Array<Amount>} escrowedAmounts
+ */
+
+/**
+ * @typedef {Object} ERefDelta
+ * @property {ERef<EscrowAccount>} account
+ * @property {Array<Amount>} add
+ * @property {Array<Amount>} subtract
+ */
+
+/**
+ * @typedef {Object} Delta
+ * @property {EscrowAccount} account
+ * @property {Array<Amount>} add
+ * @property {Array<Amount>} subtract
+ */
+
+/**
+ * @typedef {Object} SeatDelta
+ * @property {Seat} account
+ * @property {Array<Amount>} add
+ * @property {Array<Amount>} subtract
+ */
+
+/**
+ * @typedef {Object} ExclusiveDelta
+ * @property {ERef<Seat>} seat
+ * @property {Array<Amount>} add
+ * @property {Array<Amount>} subtract
+ */
+
+/**
+ * @callback TransferAssets
+ * @param {Array<ERefDelta>} deltas
+ * @returns {void}
+ */
+
+/**
+ * @callback CoerceDeltas
+ * @param {(escrowAccount: EscrowAccount) => boolean} isEscrowAccount
+ * @param {(escrowAccount: EscrowAccount) => boolean} hasSeat
+ * @param {Array<ERefDelta>} deltas
+ * @returns {Array<Delta>}
+ */
+
+/**
+ * @typedef {Object} ProposedAllocation
+ * @property {EscrowAccount} account
+ * @property {Array<Amount>} amounts
+ */
+
+/**
+ * @callback CalculateAllocations
+ * @param {Array<Delta>} deltas
+ * @returns {Array<ProposedAllocation>}
+ */
+
+/**
+ * @callback AddAmounts
+ * @param {Array<Amount>} leftAmounts
+ * @param {Array<Amount>} rightAmounts
+ * @returns {Array<Amount>}
+ */
+
+/**
+ * @callback SubtractAmounts
+ * @param {Array<Amount>} leftAmounts
+ * @param {Array<Amount>} rightAmounts
+ * @returns {Array<Amount>}
+ */
+
+/**
+ * @callback StartTransfer
+ * @param {Array<ERef<EscrowAccount>>} accounts
+ * @returns {Promise<Array<AccountSnapshot>>}
+ */
+
+/**
+ * @callback CompleteTransfer
+ * @param {Array<SeatDelta>} seatDeltas
+ * @returns {void}
+ */
+
+/**
+ * @typedef {Handle<'Seat'>} Seat
+ */

--- a/packages/zoe/src/redesign/makeHandle.js
+++ b/packages/zoe/src/redesign/makeHandle.js
@@ -1,0 +1,18 @@
+// @ts-check
+
+import { assert } from '@agoric/assert';
+import { Far } from '@agoric/marshal';
+
+/**
+ * Create an opaque handle object.
+ *
+ * @template {string} H
+ * @param {H} handleType the string literal type of the handle
+ * @returns {Handle<H>}
+ */
+export const makeHandle = handleType => {
+  // This assert ensures that handleType is referenced.
+  assert.typeof(handleType, 'string', 'handleType must be a string');
+  // Return the intersection type (really just an empty object).
+  return /** @type {Handle<H>} */ (Far(`${handleType}Handle`));
+};


### PR DESCRIPTION
# Zoe 2.0

Note: code has not been tested and almost certainly does not run - this is still highly experimental!

Zoe 2.0 has three parts: the escrow service, the contract launcher, and the "use object" service (better name needed!). 

## The Escrow Service

Users can open an escrow account and deposit payments into the account. For example, a user (or a user's wallet) would do:

```js
const escrowAccountP = E(escrowService).openEscrowAccount(payments, conditions, payoutHandler);
```

Where the arguments are:
* `payments`: a single payment, or an array of payments.
* `conditions`: closing conditions (conditions under which an account can be closed) and transfer conditions (conditions under which assets can be transferred between escrow accounts)
* `payoutHandler`: an object with a `handle` method that can accept payments when the account closes

`conditions` example:

```js
{ 
  wantedAmounts: [run100, atom3],
  closingConditions: {
        condition: CLOSING_CONDITIONS.ON_DEMAND, 
  },
}
```
`payoutHandler` example:

```js
const payoutHandler = Far('payoutHandler', {
  handle: payments => depositInWallet(payments);
});
```

Once an escrow account has been made, the assets in the escrow account can be transferred, as long as the conditions hold. Specifically, at any point in time, the escrow account must have at least what was deposited, or it must have satisfied the `wantedAmounts`:

```js
E(escrowService).transferAssets([
    {
      escrowAccount: sellerEscrowAccount,
      subtract: [NFTAmount],
      add: [pricePerNFT],
    },
    {
      escrowAccount: buyerEscrowAccount,
      subtract: [pricePerNFT],
      add: [NFTAmount],
    },
  ]);
```

Closing an escrow account is easy, and the payout is sent to previously registered `payoutHandler`:

```js
const amountsAtClose = await E(escrowAccount).closeAccount();
```

### Comparison of the Escrow Service with Zoe 1.0

* Easier to understand: Focusing on the escrow functionality creates a simpler and more intuitive experience. The average person has experience with escrow as a concept, so we can meet users where they are.
* Entirely disconnected from contracts: This is beneficial both on a technical and product level. Technically, this means that this code is completely separate from launching contracts and interacting contracts. Isolated and loosely coupled code is better! On a product level, the user does not need to have an invitation to a contract to be able to escrow. The user does not even need to know what kind of contract they intend to join.
* Can potentially implement off-chain matching and transfers: Transfers between escrow accounts can be done by anyone who has access to the escrow accounts. (Like any ocap, only the creator of the escrow account has access, unless they give access to someone else.) Users can send their escrow account into an on-chain contract if they wish, but they can also just send it as an ocap to someone else - this could be an off-chain DEX, or just someone who can trade with them. What makes this (relatively) safe is that payouts cannot be gotten from an escrow account directly - payouts are sent to the handler that was registered at creation. The worst a malicious actor might do is close the escrow account, giving the user their payments.
* "Offer safety" and "exit rules" don't need to be introduced as completely new concepts: they're just conditions on the escrow account
* Many fewer lines of code: The Escrow Service is less than 1000 lines (potentially even less with clean up and removing some experimental features)
* No keywords!: Throw the whole idea out, you don't need it. 
* Forwarding an offer to another contract is easy: just send them the escrow account. No special mechanisms necessary.
* Transferring assets is an asynchronous request and might race with another request, if the escrow account has been shared widely.  (this might be a pro or a con, in that as a user, you might want to have people racing to fulfill your wanted amounts, but as someone trying to match and make trades, someone might get there ahead of you.)

## Use Object Service

This allows users to trade in their NFT for a ocap, or vice versa, if the NFT has been registered. The key insight here was that invitations are effectively a specialized version of this, so why not just make the generalized version? 

The API is roughly:
```js
{
  registerAndGetObj: (originalObj, description) => Promise<wrappedObj>
  registerAndGetNFT: (originalObj, description) => Promise<payment>
  getObj: payment => Promise<wrappedObj>
  getPayment: wrapperObj => Promise<payment>
}
```

There's a lot that still needs to be figured out here. For instance, what happens when you build something on top of the wrapped object, then want to turn it back into the payment - is everything that you built destroyed? Or is there some way to include the rights to those objects too in the payment?

## Contract Launcher 

This particular API had less work done, because it's basically everything that is left: Take contract code (in the form of an installation now, but later on, a hash), create a new vat, and run the contract code. 