### PR TITLE
feat(wallet): implement offer actions

### DIFF
--- a/packages/dapp-wallet/ui/src/components/Request.jsx
+++ b/packages/dapp-wallet/ui/src/components/Request.jsx
@@ -11,7 +11,7 @@ const Request = ({ close, header, completed, children }) => {
           <h6>{header}</h6>
         </div>
         {completed && (
-          <IconButton click={close} size="medium">
+          <IconButton onClick={close} size="medium">
             <CloseIcon />
           </IconButton>
         )}

--- a/packages/dapp-wallet/ui/src/components/tests/Offer.test.jsx
+++ b/packages/dapp-wallet/ui/src/components/tests/Offer.test.jsx
@@ -1,9 +1,21 @@
 /* eslint-disable import/no-extraneous-dependencies */
+import { act } from '@testing-library/react';
 import { stringifyPurseValue } from '@agoric/ui-components';
 import { mount } from 'enzyme';
 import Chip from '@mui/material/Chip';
 import Offer from '../Offer';
+import Request from '../Request';
 import { formatDateNow } from '../../util/Date';
+
+jest.mock('@agoric/eventual-send', () => ({
+  E: obj =>
+    new Proxy(obj, {
+      get(target, propKey) {
+        const method = target[propKey];
+        return (...args) => method.apply(this, args);
+      },
+    }),
+}));
 
 jest.mock('@agoric/ui-components', () => ({
   stringifyPurseValue: ({ value, displayInfo }) =>
@@ -12,8 +24,39 @@ jest.mock('@agoric/ui-components', () => ({
 
 jest.mock('../../util/Date', () => ({ formatDateNow: stamp => stamp }));
 
+const pendingOffers = new Set();
+const setPendingOffers = jest.fn();
+const declinedOffers = new Set();
+const setDeclinedOffers = jest.fn();
+const setClosedOffers = jest.fn();
+const walletBridge = {
+  acceptOffer: jest.fn(),
+  declineOffer: jest.fn(),
+  cancelOffer: jest.fn(),
+};
+
+const withApplicationContext = (Component, _) => ({ ...props }) => {
+  return (
+    <Component
+      pendingOffers={pendingOffers}
+      setPendingOffers={setPendingOffers}
+      declinedOffers={declinedOffers}
+      setDeclinedOffers={setDeclinedOffers}
+      setClosedOffers={setClosedOffers}
+      walletBridge={walletBridge}
+      {...props}
+    />
+  );
+};
+
+jest.mock('../../contexts/Application', () => {
+  return { withApplicationContext };
+});
+
 const offer = {
   status: 'proposed',
+  id: '123',
+  offerId: 'https://tokenpalace.app#555',
   instancePetname: ['TokenPalace', 'Installation'],
   instanceHandleBoardId: '123',
   requestContext: {
@@ -157,6 +200,39 @@ test('renders the cancel button while pending', () => {
   ).toContain('Cancel');
 });
 
+test('renders the pending state eagerly', () => {
+  const component = mount(
+    <Offer offer={offer} pendingOffers={new Set([offer.id])} />,
+  );
+
+  expect(
+    component
+      .find(Chip)
+      .at(0)
+      .text(),
+  ).toContain('Pending');
+  expect(
+    component
+      .find('.Controls')
+      .find(Chip)
+      .text(),
+  ).toContain('Cancel');
+});
+
+test('renders the declined state eagerly', () => {
+  const component = mount(
+    <Offer offer={offer} declinedOffers={new Set([offer.id])} />,
+  );
+
+  expect(
+    component
+      .find(Chip)
+      .at(0)
+      .text(),
+  ).toContain('Declined');
+  expect(component.find('.Controls').find(Chip)).toHaveLength(0);
+});
+
 test('renders the accepted state', () => {
   const acceptedOffer = { ...offer };
   acceptedOffer.status = 'accept';
@@ -170,6 +246,127 @@ test('renders the accepted state', () => {
       .text(),
   ).toContain('Accepted');
   expect(component.find('.Controls').find(Chip)).toHaveLength(0);
+});
+
+test('renders the declined state', () => {
+  const declinedOffer = { ...offer };
+  declinedOffer.status = 'decline';
+
+  const component = mount(<Offer offer={declinedOffer} />);
+
+  expect(
+    component
+      .find(Chip)
+      .at(0)
+      .text(),
+  ).toContain('Declined');
+  expect(component.find('.Controls').find(Chip)).toHaveLength(0);
+});
+
+test('renders the request as completed when appropriate', () => {
+  let component = mount(<Offer offer={offer} />);
+  expect(component.find(Request).props().completed).toEqual(false);
+
+  const declinedOffer = { ...offer };
+  declinedOffer.status = 'decline';
+  component = mount(<Offer offer={declinedOffer} />);
+  expect(component.find(Request).props().completed).toEqual(true);
+
+  const acceptedOffer = { ...offer };
+  acceptedOffer.status = 'accept';
+  component = mount(<Offer offer={acceptedOffer} />);
+  expect(component.find(Request).props().completed).toEqual(true);
+
+  const completedOffer = { ...offer };
+  completedOffer.status = 'complete';
+  component = mount(<Offer offer={completedOffer} />);
+  expect(component.find(Request).props().completed).toEqual(true);
+
+  const pendingOffer = { ...offer };
+  pendingOffer.status = 'pending';
+  component = mount(<Offer offer={pendingOffer} />);
+  expect(component.find(Request).props().completed).toEqual(false);
+
+  const rejectedOffer = { ...offer };
+  rejectedOffer.status = 'rejected';
+  component = mount(<Offer offer={rejectedOffer} />);
+  expect(component.find(Request).props().completed).toEqual(true);
+});
+
+test('closes the offer', () => {
+  const component = mount(<Offer offer={offer} />);
+
+  act(() =>
+    component
+      .find(Request)
+      .props()
+      .close(),
+  );
+
+  expect(setClosedOffers).toHaveBeenCalledWith({
+    offerId: offer.id,
+    isClosed: true,
+  });
+  expect(setPendingOffers).toHaveBeenCalledWith({
+    offerId: offer.id,
+    isPending: false,
+  });
+  expect(setDeclinedOffers).toHaveBeenCalledWith({
+    offerId: offer.id,
+    isDeclined: false,
+  });
+});
+
+test('accepts the offer', () => {
+  const component = mount(<Offer offer={offer} />);
+
+  act(() =>
+    component
+      .find(Chip)
+      .at(1)
+      .props()
+      .onClick(),
+  );
+
+  expect(setPendingOffers).toHaveBeenCalledWith({
+    offerId: offer.id,
+    isPending: true,
+  });
+  expect(walletBridge.acceptOffer).toHaveBeenCalledWith(offer.offerId);
+});
+
+test('declines the offer', () => {
+  const component = mount(<Offer offer={offer} />);
+
+  act(() =>
+    component
+      .find(Chip)
+      .at(2)
+      .props()
+      .onClick(),
+  );
+
+  expect(setDeclinedOffers).toHaveBeenCalledWith({
+    offerId: offer.id,
+    isDeclined: true,
+  });
+  expect(walletBridge.declineOffer).toHaveBeenCalledWith(offer.offerId);
+});
+
+test('cancels the offer', () => {
+  const pendingOffer = { ...offer };
+  pendingOffer.status = 'pending';
+  const component = mount(<Offer offer={pendingOffer} />);
+
+  act(() =>
+    component
+      .find(Chip)
+      .at(1)
+      .props()
+      .onClick(),
+  );
+
+  expect(walletBridge.cancelOffer).toHaveBeenCalledWith(offer.offerId);
 });
 
 test('renders the dapp origin', () => {

--- a/packages/dapp-wallet/ui/src/components/tests/Requests.test.jsx
+++ b/packages/dapp-wallet/ui/src/components/tests/Requests.test.jsx
@@ -26,7 +26,13 @@ const purses = [
   },
 ];
 
-const offers = [{ id: 3 }];
+const offers = [
+  { id: 3, status: 'accept' },
+  { id: 6, status: 'decline' },
+  { id: 7 },
+  { id: 8 },
+  { id: 9, status: 'accept' },
+];
 
 const dapps = [
   { enable: false, id: 2 },
@@ -38,6 +44,10 @@ const payments = [
   { brand: 'Brouzouf', id: 1 },
 ];
 
+const pendingOffers = new Set([3]);
+const declinedOffers = new Set([6]);
+const closedOffers = new Set([7]);
+
 const withApplicationContext = (Component, _) => ({ ...props }) => {
   return (
     <Component
@@ -45,6 +55,9 @@ const withApplicationContext = (Component, _) => ({ ...props }) => {
       offers={offers}
       dapps={dapps}
       payments={payments}
+      pendingOffers={pendingOffers}
+      declinedOffers={declinedOffers}
+      closedOffers={closedOffers}
       {...props}
     />
   );
@@ -60,10 +73,10 @@ test('renders non-autodeposit payments', () => {
   expect(component.find(Payment).length).toEqual(1);
 });
 
-test('renders offers', () => {
+test('renders fresh offers', () => {
   const component = mount(<Requests />);
 
-  expect(component.find(Offer).length).toEqual(1);
+  expect(component.find(Offer).length).toEqual(3);
 });
 
 test('renders unapproved dapps', () => {

--- a/packages/dapp-wallet/ui/src/contexts/Application.jsx
+++ b/packages/dapp-wallet/ui/src/contexts/Application.jsx
@@ -100,6 +100,27 @@ const pendingTransfersReducer = (pendingTransfers, { purseId, isPending }) => {
   return new Set(pendingTransfers);
 };
 
+const pendingOffersReducer = (pendingOffers, { offerId, isPending }) => {
+  if (isPending) pendingOffers.add(offerId);
+  else pendingOffers.delete(offerId);
+
+  return new Set(pendingOffers);
+};
+
+const declinedOffersReducer = (declinedOffers, { offerId, isDeclined }) => {
+  if (isDeclined) declinedOffers.add(offerId);
+  else declinedOffers.delete(offerId);
+
+  return new Set(declinedOffers);
+};
+
+const closedOffersReducer = (closedOffers, { offerId, isClosed }) => {
+  if (isClosed) closedOffers.add(offerId);
+  else closedOffers.delete(offerId);
+
+  return new Set(closedOffers);
+};
+
 const Provider = ({ children }) => {
   const [connectionState, setConnectionState] = useState('disconnected');
   const [walletBridge, setWalletBridge] = useState(null);
@@ -116,6 +137,25 @@ const Provider = ({ children }) => {
   );
   const [pendingTransfers, setPendingTransfers] = useReducer(
     pendingTransfersReducer,
+    new Set(),
+  );
+
+  // Eager set of pending offer ids.
+  const [pendingOffers, setPendingOffers] = useReducer(
+    pendingOffersReducer,
+    new Set(),
+  );
+
+  // Eager set of declined offer ids.
+  const [declinedOffers, setDeclinedOffers] = useReducer(
+    declinedOffersReducer,
+    new Set(),
+  );
+
+  // Set of closed offers. Allows eagerly declined offers to be closed while
+  // still pending.
+  const [closedOffers, setClosedOffers] = useReducer(
+    closedOffersReducer,
     new Set(),
   );
 
@@ -140,6 +180,12 @@ const Provider = ({ children }) => {
     setWalletBridge,
     pendingTransfers,
     setPendingTransfers,
+    pendingOffers,
+    setPendingOffers,
+    declinedOffers,
+    setDeclinedOffers,
+    closedOffers,
+    setClosedOffers,
   };
 
   useDebugLogging(state, [
@@ -152,6 +198,9 @@ const Provider = ({ children }) => {
     pendingPurseCreations,
     walletBridge,
     pendingTransfers,
+    pendingOffers,
+    declinedOffers,
+    closedOffers,
   ]);
 
   return (


### PR DESCRIPTION
This implements accept, decline, cancel, and the ability to dismiss offers after they're completed. It uses the context, rather than local storage, to track which offers to show and dismiss.