### PR TITLE
chore: add caret

### DIFF
--- a/packages/dapp-wallet/ui/package.json
+++ b/packages/dapp-wallet/ui/package.json
@@ -38,7 +38,7 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
     "react-router-dom": "^5.3.0",
-    "react-scripts": "4.0.3",
+    "react-scripts": "^4.0.3",
     "rimraf": "^3.0.2",
     "ses": "^0.14.3"
   },


### PR DESCRIPTION
@JimLarson and I noticed during dependabotany that this package (which has a dependency of a dependency which has a [vulnerability](https://github.com/facebook/create-react-app/issues/11660)) was pinned at a particular version rather than using ^.