### PR TITLE
fix(cosmic-swingset): have `make install` do what you expect

### DIFF
--- a/packages/cosmic-swingset/Makefile
+++ b/packages/cosmic-swingset/Makefile
@@ -27,9 +27,15 @@ AGC_START_ARGS =
 
 BIN := $(shell echo $${GOBIN-$${GOPATH-$$HOME/go}/bin})
 
-all: build-chain install install-agd install-helper
+# This probably shouldn't install, but that's what published instructions
+# expect.
+all: build-chain install-nobuild
 
-client: build-helper install install-agd install-helper
+client: build-helper install-nobuild
+
+install-nobuild: install-local install-agd install-helper
+
+install: all install-nobuild
 
 scenario0-setup:
 	mkdir -p t9
@@ -217,7 +223,7 @@ install-agd:
 install-helper:
 	install -c $(GOSRC)/build/ag-cosmos-helper "$(BIN)/ag-cosmos-helper"
 
-install:
+install-local:
 	mkdir -p "$(BIN)"
 	ln -sf "$$PWD/bin/ag-chain-cosmos" "$$PWD/bin/ag-nchainz" "$(BIN)/"
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This makes `cd packages/cosmic-swingset && make install` an alias for `make all` to prevent confusion with conventional use of `all` and `install` rules.

We may someday want to relax `all` to just doing compilation and not installation, but our docs currently rely on the existing behaviour.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
