### PR TITLE
Add displayInfo for the liquidity tokens created in the AMM

### DIFF
--- a/packages/zoe/src/contracts/vpool-xyk-amm/pool.js
+++ b/packages/zoe/src/contracts/vpool-xyk-amm/pool.js
@@ -264,7 +264,11 @@ export const makeAddPool = (
     // zcf.assertUniqueKeyword(keyword), which will be checked by saveIssuer()
     // before proceeding), so we can do the work now.
     await zcf.saveIssuer(secondaryIssuer, keyword);
-    const liquidityZCFMint = await zcf.makeZCFMint(liquidityKeyword);
+    const liquidityZCFMint = await zcf.makeZCFMint(
+      liquidityKeyword,
+      AssetKind.NAT,
+      harden({ decimalPlaces: 6 }),
+    );
     const { zcfSeat: poolSeat } = zcf.makeEmptySeatKit();
     const pool = makePool(liquidityZCFMint, poolSeat, secondaryBrand);
     initPool(secondaryBrand, pool);

--- a/packages/zoe/test/unitTests/contracts/vpool-xyk-amm/test-xyk-amm-swap.js
+++ b/packages/zoe/test/unitTests/contracts/vpool-xyk-amm/test-xyk-amm-swap.js
@@ -1158,6 +1158,8 @@ test('amm jig - breaking scenario', async t => {
   );
   const moolaLiquidityBrand = await E(moolaLiquidityIssuer).getBrand();
   const moolaLiquidity = value => AmountMath.make(moolaLiquidityBrand, value);
+  const displayInfo = await E(moolaLiquidityBrand).getDisplayInfo();
+  t.is(displayInfo.decimalPlaces, 6);
 
   const mIssuerKeywordRecord = {
     Secondary: moolaR.issuer,


### PR DESCRIPTION
## Description

Add displayInfo for the liquidity tokens created in the AMM

Set it to 6 rather than doing something dependent on the displayInfo
of the secondary token, since that would take an extra round trip and
not be clearly better.

### Security Considerations

None.

### Documentation Considerations

Nothing required

### Testing Considerations

Added a test to show that the value was set.