### PR TITLE
fix(agoric-cli): Docker support corrections

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - "@agoric/sdk@*"
+  schedule:
+    # Build daily images.
+    cron: "0 0 * * *"
 
 jobs:
   docker-sdk:
@@ -19,6 +22,9 @@ jobs:
     - name: Save commit hash, url of submodules to environment
       run: |
         node packages/xsnap/src/build.js --show-env >> $GITHUB_ENV
+    - name: Save Docker tag
+      run: echo "DOCKER_TAG=,$SDK_VERSION" >> $GITHUB_ENV
+      if: ${{ github.event_name == 'push' }}
     - name: Build SDK image
       uses: elgohr/Publish-Docker-Github-Action@3.04
       with:
@@ -30,7 +36,7 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         snapshot: true
-        tags: "latest,${{ env.SDK_VERSION }}"
+        tags: "latest${{ env.DOCKER_TAG }}"
 
   # This is currently needed for the relayer integration test framework.
   # It just runs agoric/agoric-sdk with a "single-node" argument.
@@ -49,7 +55,7 @@ jobs:
         context: packages/deployment/docker
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        tags: "ibc-alpha,${{ env.SDK_VERSION }}"
+        tags: "ibc-alpha"
 
   docker-solo:
     needs: docker-sdk
@@ -58,6 +64,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: Save SDK_VERSION
       run: echo "SDK_VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
+    - name: Save Docker tag
+      run: echo "DOCKER_TAG=,$SDK_VERSION" >> $GITHUB_ENV
+      if: ${{ github.event_name == 'push' }}
     - name: Build ag-solo image
       uses: elgohr/Publish-Docker-Github-Action@3.04
       with:
@@ -67,7 +76,7 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         snapshot: true
-        tags: "latest,${{ env.SDK_VERSION }}"
+        tags: "latest${{ env.DOCKER_TAG }}"
 
   docker-setup:
     needs: docker-sdk
@@ -76,6 +85,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: Save SDK_VERSION
       run: echo "SDK_VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
+    - name: Save Docker tag
+      run: echo "DOCKER_TAG=,$SDK_VERSION" >> $GITHUB_ENV
+      if: ${{ github.event_name == 'push' }}
     - name: Build setup image
       uses: elgohr/Publish-Docker-Github-Action@3.04
       with:
@@ -85,7 +97,7 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         snapshot: true
-        tags: "latest,${{ env.SDK_VERSION }}"
+        tags: "latest${{ env.DOCKER_TAG }}"
 
   docker-deployment:
     runs-on: ubuntu-latest
@@ -93,6 +105,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: Save SDK_VERSION
       run: echo "SDK_VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
+    - name: Save Docker tag
+      run: echo "DOCKER_TAG=,$SDK_VERSION" >> $GITHUB_ENV
+      if: ${{ github.event_name == 'push' }}
     - name: Build setup image
       uses: elgohr/Publish-Docker-Github-Action@3.04
       with:
@@ -102,4 +117,4 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         snapshot: true
-        tags: "latest,${{ env.SDK_VERSION }}"
+        tags: "latest${{ env.DOCKER_TAG }}"

--- a/packages/agoric-cli/src/main.js
+++ b/packages/agoric-cli/src/main.js
@@ -51,7 +51,12 @@ const main = async (progname, rawArgs, powers) => {
 
   program
     .option('--sdk', 'use the Agoric SDK containing this program')
-    .option('--docker-tag <tag>', 'image tag to use for Docker containers')
+    .option('--no-sdk', 'do not use the Agoric SDK containing this program')
+    .option(
+      '--docker-tag <tag>',
+      'image tag to use for Docker containers',
+      'latest',
+    )
     .option(
       '-v, --verbose',
       'verbosity that can be increased',

--- a/packages/agoric-cli/src/start.js
+++ b/packages/agoric-cli/src/start.js
@@ -12,6 +12,13 @@ import {
 
 import { makePspawn, getSDKBinaries } from './helpers.js';
 
+const terminalOnlyFlags = (...flags) => {
+  if (process.stdout.isTTY && process.stdin.isTTY) {
+    return flags;
+  }
+  return [];
+};
+
 const PROVISION_COINS = `100000000${STAKING_DENOM},500000000000000${CENTRAL_DENOM},100provisionpass,100sendpacketpass`;
 const DELEGATE0_COINS = `50000000${STAKING_DENOM}`;
 const SOLO_COINS = `13000000${STAKING_DENOM},50000000${CENTRAL_DENOM}`;
@@ -66,7 +73,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
           'run',
           `--volume=${process.cwd()}:/usr/src/dapp`,
           `--rm`,
-          // `-it`,
+          ...terminalOnlyFlags(`-it`),
           `--entrypoint=agd`,
           SDK_IMAGE,
           `--home=/usr/src/dapp/_agstate/keys`,
@@ -222,7 +229,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
             `--volume=${process.cwd()}:/usr/src/dapp`,
             `--rm`,
             ...dockerArgs,
-            // `-it`,
+            ...terminalOnlyFlags(`-it`),
             SDK_IMAGE,
             ...args,
             `--home=/usr/src/dapp/${agServer}`,
@@ -402,7 +409,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
             `--volume=${process.env.HOME}/.agoric:/root/.agoric`,
             `-eAG_SOLO_BASEDIR=/usr/src/dapp/${agServer}`,
             `--rm`,
-            // `-it`,
+            ...terminalOnlyFlags(`-it`),
             `--entrypoint=ag-solo`,
             ...dockerArgs,
             SOLO_IMAGE,
@@ -595,7 +602,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
         `--volume=${process.cwd()}:/usr/src/dapp`,
         `-eAG_SOLO_BASEDIR=/usr/src/dapp/${agServer}`,
         `--rm`,
-        `-it`,
+        ...terminalOnlyFlags(`-it`),
         SOLO_IMAGE,
         `--webport=${port}`,
         `--webhost=0.0.0.0`,

--- a/packages/deployment/Dockerfile.sdk
+++ b/packages/deployment/Dockerfile.sdk
@@ -32,7 +32,7 @@ COPY --from=cosmos-go /usr/src/agoric-sdk/golang/cosmos/build golang/cosmos/buil
 RUN cd golang/cosmos && yarn build:gyp
 
 # Install the entry points in GOBIN.
-RUN cd packages/cosmic-swingset && make install install-helper install-agd
+RUN cd packages/cosmic-swingset && make install-local install-helper install-agd
 
 # Check out the specified submodule versions.
 # When changing/adding entries here, make sure to search the whole project for


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

Changes need to build and use Docker images.

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

`agoric --no-sdk` is a way to override an earlier `--sdk` flag.  This is needed to force the use of Docker, for example.  Also add default of `latest` for `--docker-tag`.

Also, publish nightly images to the `latest` Docker tag.

Drive-by correction of the Docker build that was broken by #4098.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
