### PR TITLE
Begin codifying the use of NPM dist-tags

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -30,7 +30,8 @@ Once tests pass, you can publish to NPM with the following:
 
 ```sh
 # Publish to NPM. NOTE: You may have to repeat this several times if there are failures.
-yarn lerna publish from-package
+# Specify the --dist-tag if you're publishing a new beta release.
+yarn lerna publish from-package # --dist-tag=beta
 ```
 
 Merge the release PR into master.  DO NOT REBASE OR SQUASH OR YOU WILL LOSE

--- a/docs/env.md
+++ b/docs/env.md
@@ -34,6 +34,17 @@ declarations.
 Lifetime: until all sources (including dapps) conform to using `Far`
 declarations for all remote objects
 
+## CXXFLAGS
+
+Affects: yarn, agoric install
+
+Purpose: add compilation flags to Node.js C++ addons
+
+Description: defaults to `-std=c++14` if not set (empty string doesn't default)
+
+Lifetime: probably forever (until all supported Node versions work with
+`CXXFLAGS=''`)
+
 ## DEBUG
 
 Affects: agoric (CLI), ag-chain-cosmos, ag-solo

--- a/packages/agoric-cli/src/install.js
+++ b/packages/agoric-cli/src/install.js
@@ -13,6 +13,11 @@ export default async function installMain(progname, rawArgs, powers, opts) {
   // Notify the preinstall guard that we are running.
   process.env.AGORIC_INSTALL = 'true';
 
+  // Node 16 requires this to be set for C++ addons to compile.
+  if (process.env.CXXFLAGS === undefined) {
+    process.env.CXXFLAGS = '-std=c++14';
+  }
+
   const pspawn = makePspawn({ log, spawn, chalk });
 
   const rimraf = file => pspawn('rm', ['-rf', file]);
@@ -33,13 +38,15 @@ export default async function installMain(progname, rawArgs, powers, opts) {
   }
 
   let subdirs;
+  let sdkWorktree;
   const dappPackageJSON = await fs
     .readFile(`package.json`, 'utf-8')
     .then(data => JSON.parse(data))
     .catch(err => log('error reading', `package.json`, err));
   if (dappPackageJSON.useWorkspaces) {
-    subdirs = await workspaceDirectories();
-    subdirs.unshift('.');
+    const workdirs = await workspaceDirectories();
+    sdkWorktree = workdirs.find(subd => subd === 'agoric-sdk');
+    subdirs = ['.', ...workdirs.filter(subd => subd !== 'agoric-sdk')];
   } else {
     const existingSubdirs = await Promise.all(
       ['.', '_agstate/agoric-servers', 'contract', 'api', 'ui']
@@ -91,6 +98,14 @@ export default async function installMain(progname, rawArgs, powers, opts) {
       }),
     );
 
+    const sdkVersion = sdkWorktree ? 'workspace:^' : 'latest';
+
+    // Link the SDK.
+    if (sdkWorktree) {
+      await fs.unlink(sdkWorktree).catch(_ => {});
+      await fs.symlink(sdkRoot, sdkWorktree);
+    }
+
     await Promise.all(
       subdirs.map(async subdir => {
         const nm = `${subdir}/node_modules`;
@@ -120,7 +135,7 @@ export default async function installMain(progname, rawArgs, powers, opts) {
           if (deps) {
             for (const pkg of Object.keys(deps)) {
               if (versions.has(pkg)) {
-                deps[pkg] = `*`;
+                deps[pkg] = sdkVersion;
               }
             }
           }
@@ -149,6 +164,10 @@ export default async function installMain(progname, rawArgs, powers, opts) {
   if (yarnInstallUi) {
     log.error('Cannot yarn install in ui directory');
     return 1;
+  }
+
+  if (sdkWorktree) {
+    return 0;
   }
 
   if (opts.sdk) {

--- a/packages/agoric-cli/src/main.js
+++ b/packages/agoric-cli/src/main.js
@@ -156,12 +156,12 @@ const main = async (progname, rawArgs, powers) => {
     });
 
   program
-    .command('install')
+    .command('install [force-sdk-version]')
     .description('install Dapp dependencies')
-    .action(async cmd => {
+    .action(async (forceSdkVersion, cmd) => {
       await isNotBasedir();
       const opts = { ...program.opts(), ...cmd.opts() };
-      return subMain(installMain, ['install'], opts);
+      return subMain(installMain, ['install', forceSdkVersion], opts);
     });
 
   program

--- a/packages/dapp-svelte-wallet/api/package.json
+++ b/packages/dapp-svelte-wallet/api/package.json
@@ -57,5 +57,8 @@
       "test/**/test-*.js"
     ],
     "timeout": "2m"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: #3857

## Description

Begin distinguishing between `latest`, `dev` (and hopefully soon `beta`) tags that users can `agoric install latest` in order to keep their dapp dependencies up-to-date.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This will make dapp dependency management more like typical Yarn.  We also add a CI `dev-canary` publish on push to master, so that `agoric install dev` will get the freshest code.

Drive-by: try incorporating the Node 16 `CXXFLAGS` support discovered by @robert-zaremba.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
