### PR TITLE
fix: separate watch from non-watch testing

### DIFF
--- a/packages/dapp-wallet/ui/package.json
+++ b/packages/dapp-wallet/ui/package.json
@@ -49,7 +49,8 @@
     "build:react": "react-scripts build",
     "lint-check": "eslint '**/*.{js,jsx}'",
     "lint-fix": "eslint --fix '**/*.{js,jsx}'",
-    "test": "react-scripts test",
+    "test": "CI=true react-scripts test",
+    "test:watch": "react-scripts test",
     "test:xs": "exit 0",
     "test:debug": "react-scripts --inspect-brk test --runInBand --no-cache",
     "eject": "react-scripts eject"


### PR DESCRIPTION
After I raised
![image](https://user-images.githubusercontent.com/273868/143249181-9616967c-5a51-41eb-b87b-5ca6ed2ce709.png)
in internal chat, @michaelfig suggested this fix.