### PR TITLE
ci(dev-canary): publish a `dev` NPM dist tag on every push

### DIFF
--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -61,6 +61,34 @@ jobs:
     - name: lint check
       run: yarn lint-check
 
+  dev-canary:
+    if: ${{github.event_name == 'push'}}
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # note: only use one node-version
+        node-version: ['14.x']
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./.github/actions/restore-node
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    # Adapted from https://johnny.sh/notes/publish-canary-lerna-cicd/
+    - name: configure NPM token
+      run: |
+        echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+      env:
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - name: check credentials
+      run: npm whoami
+    - name: publish to NPM dev tag
+      run: |
+        yarn lerna publish --conventional-prerelease --canary --exact \
+          --dist-tag=dev --preid=dev-$(git rev-parse --short=7 HEAD) \
+          --no-push --no-verify-access --yes
+
   benchmark:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -4,9 +4,12 @@ name: Test all Packages
 # branches)
 
 on:
- push:
-   branches: [ $default-branch ]
- pull_request:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    # Include default types, and also `closed`
+    # See https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request
+    types: [opened, reopened, synchronize, closed]
 
 # set ESM_DISABLE_CACHE=true (will be JSON parsed)
 jobs:
@@ -62,7 +65,7 @@ jobs:
       run: yarn lint-check
 
   dev-canary:
-    if: ${{github.event_name == 'push'}}
+    if: ${{github.event_name == 'push' || github.event.pull_request.merged == 'true'}}
     needs: build
     runs-on: ubuntu-latest
     strategy:
@@ -96,7 +99,7 @@ jobs:
       matrix:
         # note: only use one node-version
         node-version: ['14.x']
-    if: ${{github.event_name == 'push'}}
+    if: ${{github.event_name == 'push' || github.event.pull_request.merged == 'true'}}
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/restore-node
@@ -119,7 +122,7 @@ jobs:
       matrix:
         # note: only use one node-version
         node-version: ['14.x']
-    if: ${{github.event_name == 'push'}}
+    if: ${{github.event_name == 'push' || github.event.pull_request.merged == 'true'}}
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/restore-node
@@ -140,8 +143,8 @@ jobs:
 
     - uses: nwtgck/actions-netlify@v1.1
       with:
-        # Production deployment if a push.
-        production-deploy: ${{github.event_name == 'push'}}
+        # Production deployment if a push or merged PR.
+        production-deploy: ${{github.event_name == 'push' || github.event.pull_request.merged == 'true'}}
         publish-dir: coverage/html
         # SECURITY: we don't want to hand out the Github token to this action.
         # github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: #4117, #3857

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Add a `dev-canary` CI job to publish dev snapshots to NPM for changes merged to `master`.

The benefit is that our SDK will be published on Github (freshest), NPM (master only), and Docker Hub (nightly only).

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

Consider the risk/benefit of publishing to NPM:

From the Agoric side, we're only using the `NPM_TOKEN` to publish as constrained by the Github Actions present on `master`.  This ensures the packages are marked as prerelease (version is `dev-${commitHash}.N`) and never match the `latest` or `beta` tags, only `dev`.

From the NPM side, the NPM `agoricbot` account should be added to the `agoric` organization, so that that Github secret `NPM_TOKEN` for that bot doesn't have access to publish to other NPM organizations outside `agoric`.  I'm counting on @warner to enable that if he approves.

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
