### PR TITLE
fix(liveSlots): reflect return value marshalling failures

### DIFF
--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -1328,10 +1328,10 @@ export function makeLiveSlots(
 }
 
 // for tests
-export function makeMarshaller(syscall, gcTools) {
+export function makeMarshaller(syscall, gcTools, vatID = 'forVatID') {
   const { m } = build(
     syscall,
-    'forVatID',
+    vatID,
     DEFAULT_VIRTUAL_OBJECT_CACHE_SIZE,
     false,
     false,

--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -673,7 +673,14 @@ function build(
     function collect(promiseID, rejected, value) {
       doneResolutions.add(promiseID);
       meterControl.assertIsMetered(); // else userspace getters could escape
-      const valueSer = m.serialize(value);
+      let valueSer;
+      try {
+        valueSer = m.serialize(value);
+      } catch (e) {
+        // Serialization failure.
+        valueSer = m.serialize(e);
+        rejected = true;
+      }
       valueSer.slots.map(retainExportedVref);
       resolutions.push([promiseID, rejected, valueSer]);
       scanSlots(valueSer.slots);

--- a/packages/SwingSet/test/message-patterns.js
+++ b/packages/SwingSet/test/message-patterns.js
@@ -44,8 +44,8 @@ import { ignore } from './util.js';
 function NonError(message) {
   // marshal emits a warning (with stack trace) to the console each time it
   // serializes an Error, which makes it look like tests are failing. We have
-  // tests which test 'raise' and Promise rejection to make sure they are
-  // signalled correctly. We previously used 'raise Error()' for this, but
+  // tests which test 'throw' and Promise rejection to make sure they are
+  // signalled correctly. We previously used 'throw Error()' for this, but
   // that provokes the scary-looking warning. Since we aren't trying to
   // exercise *Error* serialization here, merely Promise rejection, we can
   // use a non-Error instead, which avoids the warning.

--- a/packages/SwingSet/test/test-liveslots.js
+++ b/packages/SwingSet/test/test-liveslots.js
@@ -1360,3 +1360,63 @@ test('unserializable promise resolution', async t => {
 
   t.deepEqual(l2.resolutions[0], [expectedPA, true, expectedError]);
 });
+
+test('unserializable promise rejection', async t => {
+  // method-bearing objects must be marked as Far, else they cannot be
+  // serialized
+  const unserializable = harden({ deliberate: () => {} });
+  const { log, syscall } = buildSyscall();
+  function build(_vatPowers) {
+    const pkA = makePromiseKit();
+    const root = Far('root', {
+      export() {
+        return harden({ p: pkA.promise });
+      },
+      resolve() {
+        pkA.reject(unserializable); // causes serialization error
+      },
+    });
+    return root;
+  }
+  const dispatch = makeDispatch(syscall, build, 'vatA', true);
+  t.deepEqual(log, []);
+  const rootA = 'o+0';
+
+  const rp1 = 'p-1';
+  await dispatch(makeMessage(rootA, 'export', capargs([]), rp1));
+  const l1 = log.shift();
+  t.is(l1.type, 'resolve');
+  const expectedPA = 'p+5';
+  const expectedResult1 = { p: oneSlot };
+  t.deepEqual(l1, {
+    type: 'resolve',
+    resolutions: [[rp1, false, capargs(expectedResult1, [expectedPA])]],
+  });
+  t.deepEqual(log, []);
+
+  console.log('generating deliberate error');
+  await dispatch(makeMessage(rootA, 'resolve', capargs([])));
+  // This should reject pkA.promise, because the promise's resolution cannot
+  // be serialized. If liveSlots doesn't catch serialization errors, the
+  // promise won't get resolved, and the vat won't have made any syscalls
+  t.truthy(log.length, 'vat failed to resolve promise');
+
+  const l2 = log.shift();
+  t.is(l2.type, 'resolve');
+  t.is(l2.resolutions[0][0], expectedPA);
+
+  // one-off marshaller to find out what an Error should look like
+  const { m } = makeMarshaller(null, makeMockGC(), 'vatA');
+  let expectedError;
+  try {
+    m.serialize(unserializable);
+  } catch (e) {
+    expectedError = m.serialize(e);
+  }
+  const ebody = JSON.parse(expectedError.body);
+  t.is(ebody['@qclass'], 'error');
+  t.is(ebody.name, 'Error');
+  t.regex(ebody.message, /Remotables must be explicitly declared/);
+
+  t.deepEqual(l2.resolutions[0], [expectedPA, true, expectedError]);
+});

--- a/packages/SwingSet/test/test-liveslots.js
+++ b/packages/SwingSet/test/test-liveslots.js
@@ -10,7 +10,7 @@ import engineGC from '../src/engine-gc.js';
 import { waitUntilQuiescent } from '../src/waitUntilQuiescent.js';
 import { makeGcAndFinalize } from '../src/gc-and-finalize.js';
 import { makeDummyMeterControl } from '../src/kernel/dummyMeterControl.js';
-import { makeLiveSlots } from '../src/kernel/liveSlots.js';
+import { makeLiveSlots, makeMarshaller } from '../src/kernel/liveSlots.js';
 import { buildSyscall, makeDispatch } from './liveslots-helpers.js';
 import {
   capargs,
@@ -1197,4 +1197,166 @@ test('GC dispatch.retireExports inhibits syscall.retireExports', async t => {
   // the vat should *not* emit `syscall.retireExport`, because it already
   // received a dispatch.retireExport
   t.deepEqual(log, []);
+});
+
+const oneSlot = { '@qclass': 'slot', index: 0 };
+
+// todo: test that ancillary promises cause syscall.resolve, also test
+// unserializable resolutions
+test('simple promise resolution', async t => {
+  const { log, syscall } = buildSyscall();
+  function build(_vatPowers) {
+    const pkA = makePromiseKit();
+    const root = Far('root', {
+      export() {
+        return harden({ p: pkA.promise });
+      },
+      resolve() {
+        pkA.resolve('data');
+      },
+    });
+    return root;
+  }
+  const dispatch = makeDispatch(syscall, build, 'vatA', true);
+  t.deepEqual(log, []);
+  const rootA = 'o+0';
+
+  const rp1 = 'p-1';
+  await dispatch(makeMessage(rootA, 'export', capargs([]), rp1));
+  const l1 = log.shift();
+  t.is(l1.type, 'resolve');
+  const expectedPA = 'p+5';
+  const expectedResult1 = { p: oneSlot };
+  t.deepEqual(l1, {
+    type: 'resolve',
+    resolutions: [[rp1, false, capargs(expectedResult1, [expectedPA])]],
+  });
+  t.deepEqual(log, []);
+
+  await dispatch(makeMessage(rootA, 'resolve', capargs([])));
+  // this should resolve pkA.promise
+  const l2 = log.shift();
+  t.is(l2.type, 'resolve');
+  t.is(l2.resolutions[0][0], expectedPA);
+  t.deepEqual(l2.resolutions[0][2], capargs('data'));
+});
+
+test('promise cycle', async t => {
+  const { log, syscall } = buildSyscall();
+  function build(_vatPowers) {
+    const pkA = makePromiseKit();
+    const pkB = makePromiseKit();
+    pkA.resolve([pkB.promise]);
+    pkB.resolve([pkA.promise]);
+    const root = Far('root', {
+      export() {
+        return harden({ p: pkA.promise });
+      },
+      resolve() {
+        pkA.resolve('data');
+      },
+    });
+    return root;
+  }
+  const dispatch = makeDispatch(syscall, build, 'vatA', true);
+  t.deepEqual(log, []);
+  const rootA = 'o+0';
+
+  const rp1 = 'p-1';
+  await dispatch(makeMessage(rootA, 'export', capargs([]), rp1));
+  const l1 = log.shift();
+  t.is(l1.type, 'resolve');
+  const expectedPA1 = 'p+5'; // pkA.promise first export
+  t.deepEqual(l1, {
+    type: 'resolve',
+    resolutions: [[rp1, false, capargs({ p: oneSlot }, [expectedPA1])]],
+  });
+  // liveslots will see pkA.promise resolve on the second-ish turn of the
+  // first delivery (of root~.export), to an array. When it serializes that
+  // array, it notices pkB.promise, and attaches a .then() to watch it. The
+  // first resolution syscall will announce the resolution of pkA, and will
+  // mention pkB in the resolution data.
+  const expectedPB = 'p+6'; // pkB.promise first export
+  const l2 = log.shift();
+  t.deepEqual(l2, {
+    type: 'resolve',
+    resolutions: [[expectedPA1, false, capargs([oneSlot], [expectedPB])]],
+  });
+
+  // When liveslots sees pkB resolve, the resolution will be to an array that
+  // includes pkA. Liveslots knows pkA is already resolved, so the
+  // syscall.resolve will include pkA as an "ancillary promise": it will be a
+  // batch that resolves both pkB and a new identifier for pkA, so the cycle
+  // is entirely contained within a single syscall.
+  const expectedPA2 = 'p+7'; // pkA.promise second export
+  const l3 = log.shift();
+
+  t.deepEqual(l3, {
+    type: 'resolve',
+    resolutions: [
+      [expectedPB, false, capargs([oneSlot], [expectedPA2])],
+      [expectedPA2, false, capargs([oneSlot], [expectedPB])],
+    ],
+  });
+  t.deepEqual(log, []);
+});
+
+test('unserializable promise resolution', async t => {
+  // method-bearing objects must be marked as Far, else they cannot be
+  // serialized
+  const unserializable = harden({ deliberate: () => {} });
+  const { log, syscall } = buildSyscall();
+  function build(_vatPowers) {
+    const pkA = makePromiseKit();
+    const root = Far('root', {
+      export() {
+        return harden({ p: pkA.promise });
+      },
+      resolve() {
+        pkA.resolve(unserializable); // causes serialization error
+      },
+    });
+    return root;
+  }
+  const dispatch = makeDispatch(syscall, build, 'vatA', true);
+  t.deepEqual(log, []);
+  const rootA = 'o+0';
+
+  const rp1 = 'p-1';
+  await dispatch(makeMessage(rootA, 'export', capargs([]), rp1));
+  const l1 = log.shift();
+  t.is(l1.type, 'resolve');
+  const expectedPA = 'p+5';
+  const expectedResult1 = { p: oneSlot };
+  t.deepEqual(l1, {
+    type: 'resolve',
+    resolutions: [[rp1, false, capargs(expectedResult1, [expectedPA])]],
+  });
+  t.deepEqual(log, []);
+
+  console.log('generating deliberate error');
+  await dispatch(makeMessage(rootA, 'resolve', capargs([])));
+  // This should reject pkA.promise, because the promise's resolution cannot
+  // be serialized. If liveSlots doesn't catch serialization errors, the
+  // promise won't get resolved, and the vat won't have made any syscalls
+  t.truthy(log.length, 'vat failed to resolve promise');
+
+  const l2 = log.shift();
+  t.is(l2.type, 'resolve');
+  t.is(l2.resolutions[0][0], expectedPA);
+
+  // one-off marshaller to find out what an Error should look like
+  const { m } = makeMarshaller(null, makeMockGC(), 'vatA');
+  let expectedError;
+  try {
+    m.serialize(unserializable);
+  } catch (e) {
+    expectedError = m.serialize(e);
+  }
+  const ebody = JSON.parse(expectedError.body);
+  t.is(ebody['@qclass'], 'error');
+  t.is(ebody.name, 'Error');
+  t.regex(ebody.message, /Remotables must be explicitly declared/);
+
+  t.deepEqual(l2.resolutions[0], [expectedPA, true, expectedError]);
 });

--- a/packages/spawner/test/swingsetTests/contractHost/bootstrap.js
+++ b/packages/spawner/test/swingsetTests/contractHost/bootstrap.js
@@ -42,6 +42,25 @@ export function buildRootObject(vatPowers, vatParameters) {
       );
   }
 
+  async function farFailureContractTest(spawner, trivialBundle) {
+    log('starting farFailureContractTest');
+    const installationP = E(spawner).install(trivialBundle);
+    const trivial = await E(installationP).spawn('terms are provided');
+    await E(trivial)
+      .getTerms(harden({ failureArg() {} }))
+      .then(
+        () => log(`wrong: far failure arg resolves`),
+        err => log(`send non-Far: ${err}`),
+      );
+    await E(trivial)
+      .failureToFar()
+      .then(
+        () => log(`wrong: far failure return resolves`),
+        err => log(`far failure: ${err}`),
+      );
+    log(`++ DONE`);
+  }
+
   return Far('root', {
     async bootstrap(vats, devices) {
       const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
@@ -55,6 +74,9 @@ export function buildRootObject(vatPowers, vatParameters) {
         }
         case 'exhaust': {
           return exhaustedContractTest(spawner, trivialBundle);
+        }
+        case 'farFailure': {
+          return farFailureContractTest(spawner, trivialBundle);
         }
         default: {
           assert.fail(X`unrecognized argument value ${mode}`);

--- a/packages/spawner/test/swingsetTests/contractHost/test-contractHost.js
+++ b/packages/spawner/test/swingsetTests/contractHost/test-contractHost.js
@@ -51,3 +51,15 @@ test('exhaustion', async t => {
   const dump = await main(t, 'exhaust');
   t.deepEqual(dump.log, contractExhaustedGolden);
 });
+
+const farFailureGolden = [
+  'starting farFailureContractTest',
+  'send non-Far: Error: Remotables must be explicitly declared: {"failureArg":"[Function failureArg]"}',
+  'far failure: Error: Remotables must be explicitly declared: {"failureReturn":"[Function failureReturn]"}',
+  '++ DONE',
+];
+
+test('farFailure', async t => {
+  const dump = await main(t, 'farFailure');
+  t.deepEqual(dump.log, farFailureGolden);
+});

--- a/packages/spawner/test/swingsetTests/contractHost/trivial.js
+++ b/packages/spawner/test/swingsetTests/contractHost/trivial.js
@@ -23,5 +23,10 @@ export default function start(terms) {
     areYouOk() {
       return 'yes';
     },
+    failureToFar() {
+      return harden({
+        failureReturn() {},
+      });
+    },
   });
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: #4180

## Description

Liveslots needs to be sensitive to the fact that `marshal.serialize` can throw.  Sometimes in liveSlots we are in a context where such failures are silent (i.e. result in a permanently unresolved promise... deadlock) unless they are explicitly reflected to the other side.

This PR is a strawman, not intended to merge as it is just a sketch of the bare minimum of what is needed in one particular circumstance.

@warner, I think this is your bailiwick.  Please use this PR as inspiration for writing some comprehensive marshal failure handling in liveSlots, and some tests that exercise it.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
