### PR TITLE
Fully support `agoric install <dist-tag>`

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -30,8 +30,7 @@ Once tests pass, you can publish to NPM with the following:
 
 ```sh
 # Publish to NPM. NOTE: You may have to repeat this several times if there are failures.
-# Specify the --dist-tag if you're publishing a new beta release.
-yarn lerna publish from-package # --dist-tag=beta
+yarn lerna publish from-package
 ```
 
 Merge the release PR into master.  DO NOT REBASE OR SQUASH OR YOU WILL LOSE
@@ -42,7 +41,15 @@ REFERENCES TO YOUR TAGS.
 ./scripts/get-released-tags git push origin
 ```
 
-To make validators' lives easier, create a tag for the chain-id:
+If you want to update an NPM dist-tag for the current checked-out Agoric SDK's
+packages (to enable `agoric install <TAG>`), use:
+
+```sh
+# Use "beta" for <TAG> for example.
+./scripts/npm-dist-tag.sh lerna add <TAG>
+```
+
+To make validators' lives easier, create a Git tag for the chain-id:
 
 ```sh
 CHAIN_ID=agoricstage-8 # Change this as necessary

--- a/packages/agoric-cli/src/install.js
+++ b/packages/agoric-cli/src/install.js
@@ -1,4 +1,4 @@
-/* global process Buffer */
+/* global process AggregateError Buffer */
 import path from 'path';
 import chalk from 'chalk';
 import { makePspawn } from './helpers.js';
@@ -40,15 +40,164 @@ export default async function installMain(progname, rawArgs, powers, opts) {
   }
 
   let subdirs;
+  const workTrees = ['.'];
   let sdkWorktree;
+  const versions = new Map();
+  const linkFolder = path.resolve(`_agstate/yarn-links`);
+  const linkFlags = [];
+  if (opts.sdk) {
+    linkFlags.push(`--link-folder=${linkFolder}`);
+  }
+
+  const yarnInstallEachWorktree = async (phase, ...flags) => {
+    for (const workTree of workTrees) {
+      log.info(`yarn install ${phase} in ${workTree}`);
+      // eslint-disable-next-line no-await-in-loop
+      const yarnInstall = await pspawn(
+        'yarn',
+        [...linkFlags, 'install', ...flags],
+        {
+          stdio: 'inherit',
+          cwd: workTree,
+        },
+      );
+      if (yarnInstall) {
+        throw Error(`yarn install ${phase} failed in ${workTree}`);
+      }
+    }
+  };
+
+  const updateSdkVersion = async forceVersion => {
+    // Prune the old version (removing potentially stale on-disk and yarn.lock
+    // packages), and update on-disk and yarn.lock packages to the new version.
+    // This is the most efficient way to fetch `forceVersion` fresh from the NPM
+    // registry, in case it has changed (dist-tags are wont to point to
+    // different packages over time).
+    const addPackagesTodo = [];
+    const prunePackagesTodo = [];
+
+    await Promise.all(
+      subdirs.map(async subdir => {
+        // Prune, then update all the SDK package versions.
+        const pjson = `${subdir}/package.json`;
+        const packageJSON = await fs
+          .readFile(pjson, 'utf-8')
+          .catch(_ => undefined);
+        if (!packageJSON) {
+          return;
+        }
+        const updatedPackageDescriptor = JSON.parse(packageJSON);
+        const prunedPackageDescriptor = { ...updatedPackageDescriptor };
+        let needsPruning = false;
+        for (const depSection of ['dependencies', 'devDependencies']) {
+          const updatedDeps = updatedPackageDescriptor[depSection];
+          if (updatedDeps) {
+            const prunedDeps = { ...updatedDeps };
+            prunedPackageDescriptor[depSection] = prunedDeps;
+            for (const pkg of Object.keys(updatedDeps)) {
+              if (versions.has(pkg)) {
+                if (updatedDeps[pkg] === forceVersion) {
+                  // We need to remove the old package and `yarn install` to
+                  // prune the old dependencies both from disk and also the
+                  // `yarn.lock`.  Only after that can we write the new deps and
+                  // run `yarn install` again to update disk and `yarn.lock`.
+                  delete prunedDeps[pkg];
+                  needsPruning = true;
+                }
+                updatedDeps[pkg] = forceVersion;
+              }
+            }
+          }
+        }
+        // Ensure we update the package.json before exiting.
+        const updatePackageJson = async () => {
+          // Don't update on exit anymore.
+          // eslint-disable-next-line no-use-before-define
+          process.off('beforeExit', updatePackageJsonOnExit);
+          log.info(`updating ${pjson}`);
+          await fs.writeFile(
+            pjson,
+            `${JSON.stringify(updatedPackageDescriptor, null, 2)}\n`,
+          );
+        };
+        const updatePackageJsonOnExit = () => {
+          // Prevent unhandled rejections.
+          updatePackageJson().catch(e =>
+            log.error(`Cannot update ${pjson}:`, e),
+          );
+        };
+        addPackagesTodo.push(updatePackageJson);
+        if (needsPruning) {
+          prunePackagesTodo.push(async () => {
+            // Update on exit, in case we are interrupted.
+            process.on('beforeExit', updatePackageJsonOnExit);
+            // Remove the old packages.
+            log.info(`pruning ${pjson}`);
+            await fs.writeFile(
+              pjson,
+              `${JSON.stringify(prunedPackageDescriptor, null, 2)}\n`,
+            );
+          });
+        }
+      }),
+    );
+
+    let prunedP;
+    if (prunePackagesTodo.length) {
+      // Run all the package+yarn.lock removal tasks in parallel.
+      prunedP = Promise.allSettled(
+        prunePackagesTodo.map(async prune => prune()),
+      )
+        .then(results => {
+          // After all have settled, throw any errors.
+          const failures = results.filter(
+            ({ status }) => status !== 'fulfilled',
+          );
+          if (failures.length) {
+            if (typeof AggregateError !== 'function') {
+              throw failures[0].reason;
+            }
+            throw AggregateError(
+              failures.map(({ reason }) => reason),
+              'Failed to prune',
+            );
+          }
+        })
+        .then(async () =>
+          yarnInstallEachWorktree('pruning', '--ignore-scripts'),
+        );
+    } else {
+      // Nothing to prune, so just skip this step.
+      prunedP = Promise.resolve();
+    }
+
+    // Ensure we do all the package.json+yarn.lock additions after any necessary
+    // pruning, even if there are failures.
+    await prunedP.finally(() =>
+      // Ensure the package.jsons are installed with the fresh version information.
+      Promise.allSettled(addPackagesTodo.map(async update => update())),
+    );
+  };
+
   const dappPackageJSON = await fs
     .readFile(`package.json`, 'utf-8')
     .then(data => JSON.parse(data))
-    .catch(err => log('error reading', `package.json`, err));
+    .catch(err => {
+      log('error reading', `package.json`, err);
+      throw err;
+    });
   if (dappPackageJSON.useWorkspaces) {
     const workdirs = await workspaceDirectories();
     sdkWorktree = workdirs.find(subd => subd === 'agoric-sdk');
     subdirs = ['.', ...workdirs.filter(subd => subd !== 'agoric-sdk')];
+
+    // Add 'ui' directory by default, if it exists.
+    if (!subdirs.find(subd => subd === 'ui')) {
+      if (await fs.stat(`ui/package.json`).catch(_ => false)) {
+        subdirs.push('ui');
+        workTrees.push('ui');
+      }
+    }
   } else {
     const existingSubdirs = await Promise.all(
       ['.', '_agstate/agoric-servers', 'contract', 'api', 'ui']
@@ -63,42 +212,38 @@ export default async function installMain(progname, rawArgs, powers, opts) {
     subdirs = existingSubdirs.filter(subd => subd);
   }
 
-  const linkFolder = path.resolve(`_agstate/yarn-links`);
-  const linkFlags = [`--link-folder=${linkFolder}`];
-
+  /** @type {Map<string, string>} */
   const packages = new Map();
-  const versions = new Map();
-  const dirPackages = [];
+
+  const sdkRoot = path.resolve(dirname, `../../..`);
+  const sdkDirs = await workspaceDirectories(sdkRoot);
+  await Promise.all(
+    sdkDirs.map(async location => {
+      const dir = `${sdkRoot}/${location}`;
+      const packageJSON = await fs
+        .readFile(`${dir}/package.json`, 'utf-8')
+        .catch(err => log('error reading', `${dir}/package.json`, err));
+      if (!packageJSON) {
+        return;
+      }
+
+      const pj = JSON.parse(packageJSON);
+      if (pj.private) {
+        log('not linking private package', pj.name);
+        return;
+      }
+
+      // Save our metadata.
+      packages.set(dir, pj.name);
+      versions.set(pj.name, pj.version);
+    }),
+  );
+
   if (opts.sdk) {
     // We remove all the links to prevent `yarn install` below from corrupting
     // them.
     log('removing', linkFolder);
     await rimraf(linkFolder);
-
-    const sdkRoot = path.resolve(dirname, `../../..`);
-    const sdkDirs = await workspaceDirectories(sdkRoot);
-    await Promise.all(
-      sdkDirs.map(async location => {
-        const dir = `${sdkRoot}/${location}`;
-        const packageJSON = await fs
-          .readFile(`${dir}/package.json`, 'utf-8')
-          .catch(err => log('error reading', `${dir}/package.json`, err));
-        if (!packageJSON) {
-          return;
-        }
-
-        const pj = JSON.parse(packageJSON);
-        if (pj.private) {
-          log('not linking private package', pj.name);
-          return;
-        }
-
-        // Save our metadata.
-        dirPackages.push([dir, pj.name]);
-        packages.set(dir, pj.name);
-        versions.set(pj.name, pj.version);
-      }),
-    );
 
     // Link the SDK.
     if (sdkWorktree) {
@@ -106,8 +251,6 @@ export default async function installMain(progname, rawArgs, powers, opts) {
       await fs.symlink(sdkRoot, sdkWorktree);
     }
 
-    const updatesTodo = [];
-    const removesTodo = [];
     await Promise.all(
       subdirs.map(async subdir => {
         const nm = `${subdir}/node_modules`;
@@ -118,148 +261,48 @@ export default async function installMain(progname, rawArgs, powers, opts) {
         // This is needed to prevent yarn errors when installing new versions of
         // linked modules (like `@agoric/zoe`).
         await Promise.all(
-          dirPackages.map(async ([_dir, pjName]) =>
+          [...packages.values()].map(async pjName =>
             fs.unlink(`${nm}/${pjName}`).catch(_ => {}),
           ),
         );
-
-        if (forceSdkVersion === undefined) {
-          // No need to change package.json.
-          return;
-        }
-
-        // Modify all the SDK package versions.
-        const pjson = `${subdir}/package.json`;
-        const packageJSON = await fs
-          .readFile(pjson, 'utf-8')
-          .catch(_ => undefined);
-        if (!packageJSON) {
-          return;
-        }
-        const obsolete = new Set();
-        const pj = JSON.parse(packageJSON);
-        for (const section of ['dependencies', 'devDependencies']) {
-          const deps = pj[section];
-          if (deps) {
-            for (const pkg of Object.keys(deps)) {
-              if (versions.has(pkg)) {
-                if (deps[pkg] === forceSdkVersion) {
-                  // We need to remove the old package, or the install will not
-                  // pick up the newly-published one.
-                  obsolete.add(pkg);
-                }
-                deps[pkg] = forceSdkVersion;
-              }
-            }
-          }
-        }
-        // Ensure we update the package.json before exiting.
-        const updatePackageJson = async () => {
-          process.off('beforeExit', updatePackageJson);
-          log.info(`updating ${pjson}`);
-          await fs.writeFile(pjson, `${JSON.stringify(pj, null, 2)}\n`);
-        };
-        updatesTodo.push(updatePackageJson);
-        removesTodo.push(async () => {
-          process.on('beforeExit', updatePackageJson);
-          // Remove the old packages.
-          const removePkgs = [...obsolete.keys()];
-          if (!removePkgs.length) {
-            // No packages to remove.
-            return;
-          }
-          const yarnRemove = await pspawn(
-            'yarn',
-            [
-              ...linkFlags,
-              'remove',
-              '--ignore-workspace-root-check', // This may be a root dependency.
-              '--mutex=network', // Don't race with other removals.
-              '--ignore-scripts', // We install later, so no need to run scripts.
-              ...removePkgs,
-            ],
-            { stdio: 'inherit', cwd: subdir },
-          );
-          if (yarnRemove) {
-            throw Error(`yarn remove obsolete packages failed in ${subdir}`);
-          }
-        });
       }),
     );
-
-    // Ensure we do all the updates after the removes, whether there were
-    // failures or not.
-    await Promise.allSettled(removesTodo.map(async remove => remove()))
-      .then(results => {
-        // After all have settled, try throwing the first rejection.
-        const firstFailure = results.find(
-          ({ status }) => status !== 'fulfilled',
-        );
-        if (firstFailure) {
-          throw firstFailure.reason;
-        }
-      })
-      .finally(() =>
-        Promise.allSettled(updatesTodo.map(async update => update())),
-      );
   }
 
-  const yarnInstall = await pspawn('yarn', [...linkFlags, 'install'], {
-    stdio: 'inherit',
-  });
-  if (yarnInstall) {
-    // Try to install via Yarn.
-    log.error('Cannot yarn install');
-    return 1;
+  if (forceSdkVersion !== undefined) {
+    // We need to update the SDK version in the package.jsons and `yarn.lock`.
+    await updateSdkVersion(forceSdkVersion);
   }
 
-  // Try to install via Yarn.
-  const yarnInstallUi = await (subdirs.includes('ui') &&
-    pspawn('yarn', [...linkFlags, 'install'], {
-      stdio: 'inherit',
-      cwd: 'ui',
-    }));
-  if (yarnInstallUi) {
-    log.error('Cannot yarn install in ui directory');
-    return 1;
-  }
+  await yarnInstallEachWorktree('updates');
 
-  if (sdkWorktree) {
+  if (sdkWorktree || !opts.sdk) {
+    log.info(chalk.bold.green('Done installing without SDK links'));
     return 0;
   }
 
-  if (opts.sdk) {
-    await Promise.all(
-      dirPackages.map(async ([dir, pjName]) => {
-        const SUBOPTIMAL = false;
-        if (SUBOPTIMAL) {
-          // This use of yarn is noisy and slow.
-          await pspawn('yarn', [...linkFlags, 'unlink', pjName]);
-          return pspawn('yarn', [...linkFlags, 'link'], {
-            stdio: 'inherit',
-            cwd: dir,
-          });
-        }
+  // Create symlinks to the SDK packages.
+  await Promise.all(
+    [...packages.entries()].map(async ([dir, pjName]) => {
+      const SUBOPTIMAL = false;
+      if (SUBOPTIMAL) {
+        // This use of yarn is noisy and slow.
+        await pspawn('yarn', [...linkFlags, 'unlink', pjName]);
+        return pspawn('yarn', [...linkFlags, 'link'], {
+          stdio: 'inherit',
+          cwd: dir,
+        });
+      }
 
-        // This open-coding of the above yarn command is quiet and fast.
-        const linkName = `${linkFolder}/${pjName}`;
-        const linkDir = path.dirname(linkName);
-        log('linking', linkName);
-        return fs
-          .mkdir(linkDir, { recursive: true })
-          .then(_ => fs.symlink(path.relative(linkDir, dir), linkName));
-      }),
-    );
-  } else {
-    // Delete all old node_modules.
-    await Promise.all(
-      subdirs.map(subdir => {
-        const nm = `${subdir}/node_modules`;
-        log(chalk.bold.green(`removing ${nm}`));
-        return rimraf(nm);
-      }),
-    );
-  }
+      // This open-coding of the above yarn command is quiet and fast.
+      const linkName = `${linkFolder}/${pjName}`;
+      const linkDir = path.dirname(linkName);
+      log('linking', linkName);
+      return fs
+        .mkdir(linkDir, { recursive: true })
+        .then(_ => fs.symlink(path.relative(linkDir, dir), linkName));
+    }),
+  );
 
   const sdkPackages = [...packages.values()].sort();
   for (const subdir of subdirs) {
@@ -278,6 +321,6 @@ export default async function installMain(progname, rawArgs, powers, opts) {
     }
   }
 
-  log.info(chalk.bold.green('Done installing'));
+  log.info(chalk.bold.green('Done installing with SDK links'));
   return 0;
 }

--- a/scripts/npm-dist-tag.sh
+++ b/scripts/npm-dist-tag.sh
@@ -1,0 +1,67 @@
+#! /bin/bash
+# npm-dist-tag.sh - add/remove/list dist-tags for NPM registry packages 
+# Try: `npm-dist-tag.sh` for usage.
+
+# Exit on any errors.
+set -ueo pipefail
+
+# Check the first argument.
+OP=$1
+case $OP in
+lerna)
+  # npm-dist-tag.sh lerna [args]...
+  # Run `npm-dist-tag.sh [args]...` in every package directory.
+
+  # Find the absolute path to this script.
+  thisdir=$(cd "$(dirname -- "${BASH_SOURCE[0]}")" > /dev/null && pwd -P)
+  thisprog=$(basename -- "${BASH_SOURCE[0]}")
+
+  # Strip the first argument (`lerna`), so that `$@` gives us remaining args.
+  shift
+  exec npm run -- lerna exec --stream --no-bail "$thisdir/$thisprog" ${1+"$@"}
+  ;;
+esac
+
+# If the package.json says it's private, we don't have a published version whose
+# tags we can manipulate.
+priv=$(jq -r .private package.json)
+case "$priv" in
+true)
+  echo 1>&2 "Private package, skipping npm-dist-tag.sh"
+  exit 0
+  ;;
+esac
+
+# Find the package name and version from the package.json.
+pkg=$(jq -r .name package.json)
+version=$(jq -r .version package.json)
+# echo "$OP $pkg@$version"
+
+# Get the second argument, if any.
+TAG=$2
+case $OP in
+add)
+  # Add <tag> to the current-directory package's dist-tags.
+  npm dist-tag add "$pkg@$version" "$TAG"
+  ;;
+remove | rm)
+  # npm-dist-tag.sh remove <tag>
+  # Remove <tag> from the current-directory package's dist-tags.
+  npm dist-tag rm "$pkg" "$TAG"
+  ;;
+list | ls)
+  # npm-dist-tag.sh list [<tag>]
+  # List the current-directory package's dist-tags.
+  # If <tag> is given, list only that tag.
+  if test -n "$TAG"; then
+    npm dist-tag ls "$pkg" | sed -ne "s/^$TAG: //p"
+  else
+    npm dist-tag ls "$pkg"
+  fi
+  ;;
+*)
+  # Usage instructions.
+  echo 1>&2 "Usage: $0 [lerna] <add|remove|list> [<tag>]"
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #3857

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

If a dist-tag is specified with `agoric install <dist-tag>`, ensure we refresh the dapp's `yarn.lock` dependencies.

This makes it possible to build and develop a published dapp without needing the `agoric install` command (just `yarn install` suffices).  Indeed, `npm install -g agoric` or `yarn global add agoric` should be able to produce a working `agoric` command that can do everything that `yarn link-cli ~/bin/agoric` does, once this PR's version of `agoric-cli` has been published to NPM.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

`agoric install beta` will update the workspace's `yarn.lock` with the beta dependencies.  From that point on, installing the dapp only needs `yarn install` (though `agoric install` will work, too).

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

Tested manually on `dapp-oracle`.
