### PR TITLE
ci: reenable workflows that rely on pushes to `$default-branch`

### DIFF
--- a/.github/workflows/ag-solo-xs.yml.DISABLED
+++ b/.github/workflows/ag-solo-xs.yml.DISABLED
@@ -4,10 +4,10 @@ name: ag-solo on xs
 # default
 
 on:
- push:
-   branches: [$default-branch]
- pull_request:
-   branches: [$default-branch]
+  push:
+    branches: [ master ] # $default-branch
+  pull_request:
+    branches: [ master ] # $default-branch
 
 jobs:
   xs-build:

--- a/.github/workflows/deployment-test.yml
+++ b/.github/workflows/deployment-test.yml
@@ -6,12 +6,7 @@ on:
   workflow_dispatch:
   # Otherwise, run on default branch.
   push:
-    branches:
-      - $default-branch
-  pull_request:
-    types: [closed]
-    branches:
-      - $default-branch
+    branches: [ master ] # $default-branch
 
 jobs:
   deployment-test:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,14 +2,9 @@ name: Build release Docker Images
 
 on:
   push:
-    branches:
-      - $default-branch
+    branches: [ master ] # $default-branch
     tags:
       - "@agoric/sdk@*"
-  pull_request:
-    types: [closed]
-    branches:
-      - $default-branch
 
 jobs:
   docker-deployment:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,9 +1,9 @@
 name: Integration tests
 
 on:
- push:
-   branches: [$default-branch]
- pull_request:
+  push:
+    branches: [ master ] # $default-branch
+  pull_request:
 
 jobs:
   # This job is meant to emulate what developers working with the Agoric platform will experience

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,7 +4,7 @@ name: PR Checks
 # branches)
 
 on:
- pull_request:
+  pull_request:
 
 jobs:
   # Check that commits conform to https://www.conventionalcommits.org/en/v1.0.0/

--- a/.github/workflows/test-all-packages.yml
+++ b/.github/workflows/test-all-packages.yml
@@ -5,11 +5,8 @@ name: Test all Packages
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ master ] # $default-branch
   pull_request:
-    # Include default types, and also `closed`
-    # See https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request
-    types: [opened, reopened, synchronize, closed]
 
 # set ESM_DISABLE_CACHE=true (will be JSON parsed)
 jobs:
@@ -65,7 +62,7 @@ jobs:
       run: yarn lint-check
 
   dev-canary:
-    if: ${{github.event_name == 'push' || github.event.pull_request.merged == 'true'}}
+    if: ${{github.event_name == 'push'}}
     needs: build
     runs-on: ubuntu-latest
     strategy:
@@ -99,7 +96,7 @@ jobs:
       matrix:
         # note: only use one node-version
         node-version: ['14.x']
-    if: ${{github.event_name == 'push' || github.event.pull_request.merged == 'true'}}
+    if: ${{github.event_name == 'push'}}
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/restore-node
@@ -122,7 +119,7 @@ jobs:
       matrix:
         # note: only use one node-version
         node-version: ['14.x']
-    if: ${{github.event_name == 'push' || github.event.pull_request.merged == 'true'}}
+    if: ${{github.event_name == 'push' }}
     steps:
     - uses: actions/checkout@v2
     - uses: ./.github/actions/restore-node
@@ -144,7 +141,7 @@ jobs:
     - uses: nwtgck/actions-netlify@v1.1
       with:
         # Production deployment if a push or merged PR.
-        production-deploy: ${{github.event_name == 'push' || github.event.pull_request.merged == 'true'}}
+        production-deploy: ${{github.event_name == 'push'}}
         publish-dir: coverage/html
         # SECURITY: we don't want to hand out the Github token to this action.
         # github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-dapp-card-store.yml
+++ b/.github/workflows/test-dapp-card-store.yml
@@ -5,7 +5,7 @@ name: Test Dapp Card Store
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ master ] # $default-branch
   pull_request:
 
 jobs:

--- a/.github/workflows/test-dapp-fungible-faucet.yml
+++ b/.github/workflows/test-dapp-fungible-faucet.yml
@@ -5,7 +5,7 @@ name: Test Dapp Fungible Faucet
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ master ] # $default-branch
   pull_request:
 
 jobs:

--- a/.github/workflows/test-dapp-oracle.yml
+++ b/.github/workflows/test-dapp-oracle.yml
@@ -5,7 +5,7 @@ name: Test Dapp Oracle
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ master ] # $default-branch
   pull_request:
 
 jobs:

--- a/.github/workflows/test-dapp-otc.yml
+++ b/.github/workflows/test-dapp-otc.yml
@@ -5,7 +5,7 @@ name: Test Dapp OTC Desk
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ master ] # $default-branch
   pull_request:
 
 jobs:

--- a/.github/workflows/test-dapp-pegasus.yml
+++ b/.github/workflows/test-dapp-pegasus.yml
@@ -5,7 +5,7 @@ name: Test Dapp Pegasus
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ master ] # $default-branch
   pull_request:
 
 jobs:

--- a/.github/workflows/test-dapp-simple-exchange.yml
+++ b/.github/workflows/test-dapp-simple-exchange.yml
@@ -5,7 +5,7 @@ name: Test Dapp Simple Exchange
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ master ] # $default-branch
   pull_request:
 
 jobs:

--- a/.github/workflows/test-dapp-treasury.yml
+++ b/.github/workflows/test-dapp-treasury.yml
@@ -5,7 +5,7 @@ name: Test Dapp Treasury
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ master ] # $default-branch
   pull_request:
 
 jobs:

--- a/.github/workflows/test-documentation.yml
+++ b/.github/workflows/test-documentation.yml
@@ -5,7 +5,7 @@ name: Test Documentation
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ master ] # $default-branch
   pull_request:
 
 jobs:

--- a/.github/workflows/test-golang.yml
+++ b/.github/workflows/test-golang.yml
@@ -4,9 +4,9 @@ name: Test Golang
 # branches)
 
 on:
- push:
-   branches: [ $default-branch ]
- pull_request:
+  push:
+    branches: [ master ] # $default-branch
+  pull_request:
 
 # set ESM_DISABLE_CACHE=true (will be JSON parsed)
 jobs:


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description

The `$default-branch` macro is not expanded in `.github/workflows`, only
`workflow-templates`.  So, unfortunately, we have to hardcode the
`master` branch in the `yml` files to get these to work.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
