### PR TITLE
fix: represent storage in same order in genesis state

### DIFF
--- a/golang/cosmos/proto/agoric/swingset/genesis.proto
+++ b/golang/cosmos/proto/agoric/swingset/genesis.proto
@@ -10,10 +10,16 @@ option go_package = "github.com/Agoric/agoric-sdk/golang/cosmos/x/swingset/types
 message GenesisState {
     option (gogoproto.equal) = false;
 
-    map<string, string> storage = 1 [
+    repeated StorageEntry storage = 1 [
         (gogoproto.jsontag)    = "storage",
         (gogoproto.moretags)   = "yaml:\"storage\""
     ];
 
     Params params = 2 [(gogoproto.nullable) = false];
+}
+
+// A storage entry.
+message StorageEntry {
+    string key = 1;
+    string value = 2;
 }

--- a/golang/cosmos/x/swingset/genesis.go
+++ b/golang/cosmos/x/swingset/genesis.go
@@ -14,7 +14,7 @@ import (
 
 func NewGenesisState() *types.GenesisState {
 	return &types.GenesisState{
-		Storage: make(map[string]string),
+		Storage: []*types.StorageEntry{},
 	}
 }
 
@@ -31,7 +31,7 @@ func ValidateGenesis(data *types.GenesisState) error {
 func DefaultGenesisState() *types.GenesisState {
 	return &types.GenesisState{
 		Params:  types.DefaultParams(),
-		Storage: make(map[string]string),
+		Storage: []*types.StorageEntry{},
 	}
 }
 
@@ -44,9 +44,8 @@ type bootstrapBlockAction struct {
 func InitGenesis(ctx sdk.Context, keeper Keeper, data *types.GenesisState) []abci.ValidatorUpdate {
 	keeper.SetParams(ctx, data.GetParams())
 
-	// NONDETERMINISM: order of SetStorage is not deterministic
-	for key, value := range data.Storage {
-		keeper.SetStorage(ctx, key, value)
+	for _, entry := range data.Storage {
+		keeper.SetStorage(ctx, entry.Key, entry.Value)
 	}
 
 	// Just run the SwingSet kernel to finish bootstrap and get ready to open for

--- a/golang/cosmos/x/swingset/keeper/keeper.go
+++ b/golang/cosmos/x/swingset/keeper/keeper.go
@@ -125,17 +125,18 @@ func (k Keeper) SetEgress(ctx sdk.Context, egress *types.Egress) error {
 }
 
 // ExportStorage fetches all storage
-func (k Keeper) ExportStorage(ctx sdk.Context) map[string]string {
+func (k Keeper) ExportStorage(ctx sdk.Context) []*types.StorageEntry {
 	store := ctx.KVStore(k.storeKey)
 	dataStore := prefix.NewStore(store, types.DataPrefix)
 
 	iterator := sdk.KVStorePrefixIterator(dataStore, nil)
 
-	exported := make(map[string]string)
+	exported := []*types.StorageEntry{}
 	defer iterator.Close()
 	for ; iterator.Valid(); iterator.Next() {
 		keyStr := keyToString(iterator.Key())
-		exported[keyStr] = string(iterator.Value())
+		entry := types.StorageEntry{Key: keyStr, Value: string(iterator.Value())}
+		exported = append(exported, &entry)
 	}
 	return exported
 }

--- a/golang/cosmos/x/swingset/types/genesis.pb.go
+++ b/golang/cosmos/x/swingset/types/genesis.pb.go
@@ -25,8 +25,8 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // The initial or exported state.
 type GenesisState struct {
-	Storage map[string]string `protobuf:"bytes,1,rep,name=storage,proto3" json:"storage" yaml:"storage" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	Params  Params            `protobuf:"bytes,2,opt,name=params,proto3" json:"params"`
+	Storage []*StorageEntry `protobuf:"bytes,1,rep,name=storage,proto3" json:"storage" yaml:"storage"`
+	Params  Params          `protobuf:"bytes,2,opt,name=params,proto3" json:"params"`
 }
 
 func (m *GenesisState) Reset()         { *m = GenesisState{} }
@@ -62,7 +62,7 @@ func (m *GenesisState) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_GenesisState proto.InternalMessageInfo
 
-func (m *GenesisState) GetStorage() map[string]string {
+func (m *GenesisState) GetStorage() []*StorageEntry {
 	if m != nil {
 		return m.Storage
 	}
@@ -76,35 +76,86 @@ func (m *GenesisState) GetParams() Params {
 	return Params{}
 }
 
+type StorageEntry struct {
+	Key   string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	Value string `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+}
+
+func (m *StorageEntry) Reset()         { *m = StorageEntry{} }
+func (m *StorageEntry) String() string { return proto.CompactTextString(m) }
+func (*StorageEntry) ProtoMessage()    {}
+func (*StorageEntry) Descriptor() ([]byte, []int) {
+	return fileDescriptor_49b057311de9d296, []int{1}
+}
+func (m *StorageEntry) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *StorageEntry) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_StorageEntry.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *StorageEntry) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StorageEntry.Merge(m, src)
+}
+func (m *StorageEntry) XXX_Size() int {
+	return m.Size()
+}
+func (m *StorageEntry) XXX_DiscardUnknown() {
+	xxx_messageInfo_StorageEntry.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_StorageEntry proto.InternalMessageInfo
+
+func (m *StorageEntry) GetKey() string {
+	if m != nil {
+		return m.Key
+	}
+	return ""
+}
+
+func (m *StorageEntry) GetValue() string {
+	if m != nil {
+		return m.Value
+	}
+	return ""
+}
+
 func init() {
 	proto.RegisterType((*GenesisState)(nil), "agoric.swingset.GenesisState")
-	proto.RegisterMapType((map[string]string)(nil), "agoric.swingset.GenesisState.StorageEntry")
+	proto.RegisterType((*StorageEntry)(nil), "agoric.swingset.StorageEntry")
 }
 
 func init() { proto.RegisterFile("agoric/swingset/genesis.proto", fileDescriptor_49b057311de9d296) }
 
 var fileDescriptor_49b057311de9d296 = []byte{
-	// 312 bytes of a gzipped FileDescriptorProto
+	// 304 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x4d, 0x4c, 0xcf, 0x2f,
 	0xca, 0x4c, 0xd6, 0x2f, 0x2e, 0xcf, 0xcc, 0x4b, 0x2f, 0x4e, 0x2d, 0xd1, 0x4f, 0x4f, 0xcd, 0x4b,
 	0x2d, 0xce, 0x2c, 0xd6, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0xe2, 0x87, 0x48, 0xeb, 0xc1, 0xa4,
 	0xa5, 0x44, 0xd2, 0xf3, 0xd3, 0xf3, 0xc1, 0x72, 0xfa, 0x20, 0x16, 0x44, 0x99, 0x94, 0x1c, 0xba,
-	0x29, 0x30, 0x06, 0x44, 0x5e, 0xe9, 0x0d, 0x23, 0x17, 0x8f, 0x3b, 0xc4, 0xe0, 0xe0, 0x92, 0xc4,
-	0x92, 0x54, 0xa1, 0x64, 0x2e, 0xf6, 0xe2, 0x92, 0xfc, 0xa2, 0xc4, 0xf4, 0x54, 0x09, 0x46, 0x05,
-	0x66, 0x0d, 0x6e, 0x23, 0x2d, 0x3d, 0x34, 0x9b, 0xf4, 0x90, 0xd5, 0xeb, 0x05, 0x43, 0x14, 0xbb,
-	0xe6, 0x95, 0x14, 0x55, 0x3a, 0xc9, 0xbe, 0xba, 0x27, 0x0f, 0xd3, 0xfe, 0xe9, 0x9e, 0x3c, 0x5f,
-	0x65, 0x62, 0x6e, 0x8e, 0x95, 0x12, 0x54, 0x40, 0x29, 0x08, 0x26, 0x25, 0x64, 0xca, 0xc5, 0x56,
-	0x90, 0x58, 0x94, 0x98, 0x5b, 0x2c, 0xc1, 0xa4, 0xc0, 0xa8, 0xc1, 0x6d, 0x24, 0x8e, 0x61, 0x47,
-	0x00, 0x58, 0xda, 0x89, 0xe5, 0xc4, 0x3d, 0x79, 0x86, 0x20, 0xa8, 0x62, 0x29, 0x2b, 0x2e, 0x1e,
-	0x64, 0xeb, 0x84, 0x04, 0xb8, 0x98, 0xb3, 0x53, 0x2b, 0x25, 0x18, 0x15, 0x18, 0x35, 0x38, 0x83,
-	0x40, 0x4c, 0x21, 0x11, 0x2e, 0xd6, 0xb2, 0xc4, 0x9c, 0xd2, 0x54, 0xb0, 0xb9, 0x9c, 0x41, 0x10,
-	0x8e, 0x15, 0x93, 0x05, 0xa3, 0x15, 0xcb, 0x8b, 0x05, 0xf2, 0x0c, 0x4e, 0xa1, 0x27, 0x1e, 0xc9,
-	0x31, 0x5e, 0x78, 0x24, 0xc7, 0xf8, 0xe0, 0x91, 0x1c, 0xe3, 0x84, 0xc7, 0x72, 0x0c, 0x17, 0x1e,
-	0xcb, 0x31, 0xdc, 0x78, 0x2c, 0xc7, 0x10, 0x65, 0x9d, 0x9e, 0x59, 0x92, 0x51, 0x9a, 0xa4, 0x97,
-	0x9c, 0x9f, 0xab, 0xef, 0x08, 0x09, 0x33, 0x88, 0x9b, 0x74, 0x8b, 0x53, 0xb2, 0xf5, 0xd3, 0xf3,
-	0x73, 0x12, 0xf3, 0xd2, 0xf5, 0x93, 0xf3, 0x8b, 0x73, 0xf3, 0x8b, 0xf5, 0x2b, 0x10, 0xc1, 0x59,
-	0x52, 0x59, 0x90, 0x5a, 0x9c, 0xc4, 0x06, 0x0e, 0x4c, 0x63, 0x40, 0x00, 0x00, 0x00, 0xff, 0xff,
-	0xee, 0x6b, 0x0c, 0xe2, 0xb4, 0x01, 0x00, 0x00,
+	0x29, 0x30, 0x06, 0x44, 0x5e, 0x69, 0x31, 0x23, 0x17, 0x8f, 0x3b, 0xc4, 0xe0, 0xe0, 0x92, 0xc4,
+	0x92, 0x54, 0xa1, 0x30, 0x2e, 0xf6, 0xe2, 0x92, 0xfc, 0xa2, 0xc4, 0xf4, 0x54, 0x09, 0x46, 0x05,
+	0x66, 0x0d, 0x6e, 0x23, 0x59, 0x3d, 0x34, 0x9b, 0xf4, 0x82, 0x21, 0xf2, 0xae, 0x79, 0x25, 0x45,
+	0x95, 0x4e, 0xb2, 0xaf, 0xee, 0xc9, 0xc3, 0x74, 0x7c, 0xba, 0x27, 0xcf, 0x57, 0x99, 0x98, 0x9b,
+	0x63, 0xa5, 0x04, 0x15, 0x50, 0x0a, 0x82, 0x49, 0x09, 0x99, 0x72, 0xb1, 0x15, 0x24, 0x16, 0x25,
+	0xe6, 0x16, 0x4b, 0x30, 0x29, 0x30, 0x6a, 0x70, 0x1b, 0x89, 0x63, 0x18, 0x1b, 0x00, 0x96, 0x76,
+	0x62, 0x39, 0x71, 0x4f, 0x9e, 0x21, 0x08, 0xaa, 0xd8, 0x8a, 0xe5, 0xc5, 0x02, 0x79, 0x06, 0x25,
+	0x33, 0x2e, 0x1e, 0x64, 0x4b, 0x85, 0x04, 0xb8, 0x98, 0xb3, 0x53, 0x2b, 0x25, 0x18, 0x15, 0x18,
+	0x35, 0x38, 0x83, 0x40, 0x4c, 0x21, 0x11, 0x2e, 0xd6, 0xb2, 0xc4, 0x9c, 0xd2, 0x54, 0xb0, 0xe9,
+	0x9c, 0x41, 0x10, 0x8e, 0x53, 0xe8, 0x89, 0x47, 0x72, 0x8c, 0x17, 0x1e, 0xc9, 0x31, 0x3e, 0x78,
+	0x24, 0xc7, 0x38, 0xe1, 0xb1, 0x1c, 0xc3, 0x85, 0xc7, 0x72, 0x0c, 0x37, 0x1e, 0xcb, 0x31, 0x44,
+	0x59, 0xa7, 0x67, 0x96, 0x64, 0x94, 0x26, 0xe9, 0x25, 0xe7, 0xe7, 0xea, 0x3b, 0x42, 0x82, 0x08,
+	0xe2, 0x1e, 0xdd, 0xe2, 0x94, 0x6c, 0xfd, 0xf4, 0xfc, 0x9c, 0xc4, 0xbc, 0x74, 0xfd, 0xe4, 0xfc,
+	0xe2, 0xdc, 0xfc, 0x62, 0xfd, 0x0a, 0x44, 0xe8, 0x95, 0x54, 0x16, 0xa4, 0x16, 0x27, 0xb1, 0x81,
+	0xc3, 0xce, 0x18, 0x10, 0x00, 0x00, 0xff, 0xff, 0x43, 0x14, 0xc1, 0xd3, 0xa3, 0x01, 0x00, 0x00,
 }
 
 func (m *GenesisState) Marshal() (dAtA []byte, err error) {
@@ -138,23 +189,55 @@ func (m *GenesisState) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i--
 	dAtA[i] = 0x12
 	if len(m.Storage) > 0 {
-		for k := range m.Storage {
-			v := m.Storage[k]
-			baseI := i
-			i -= len(v)
-			copy(dAtA[i:], v)
-			i = encodeVarintGenesis(dAtA, i, uint64(len(v)))
-			i--
-			dAtA[i] = 0x12
-			i -= len(k)
-			copy(dAtA[i:], k)
-			i = encodeVarintGenesis(dAtA, i, uint64(len(k)))
-			i--
-			dAtA[i] = 0xa
-			i = encodeVarintGenesis(dAtA, i, uint64(baseI-i))
+		for iNdEx := len(m.Storage) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Storage[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintGenesis(dAtA, i, uint64(size))
+			}
 			i--
 			dAtA[i] = 0xa
 		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *StorageEntry) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *StorageEntry) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *StorageEntry) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Value) > 0 {
+		i -= len(m.Value)
+		copy(dAtA[i:], m.Value)
+		i = encodeVarintGenesis(dAtA, i, uint64(len(m.Value)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Key) > 0 {
+		i -= len(m.Key)
+		copy(dAtA[i:], m.Key)
+		i = encodeVarintGenesis(dAtA, i, uint64(len(m.Key)))
+		i--
+		dAtA[i] = 0xa
 	}
 	return len(dAtA) - i, nil
 }
@@ -177,15 +260,30 @@ func (m *GenesisState) Size() (n int) {
 	var l int
 	_ = l
 	if len(m.Storage) > 0 {
-		for k, v := range m.Storage {
-			_ = k
-			_ = v
-			mapEntrySize := 1 + len(k) + sovGenesis(uint64(len(k))) + 1 + len(v) + sovGenesis(uint64(len(v)))
-			n += mapEntrySize + 1 + sovGenesis(uint64(mapEntrySize))
+		for _, e := range m.Storage {
+			l = e.Size()
+			n += 1 + l + sovGenesis(uint64(l))
 		}
 	}
 	l = m.Params.Size()
 	n += 1 + l + sovGenesis(uint64(l))
+	return n
+}
+
+func (m *StorageEntry) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Key)
+	if l > 0 {
+		n += 1 + l + sovGenesis(uint64(l))
+	}
+	l = len(m.Value)
+	if l > 0 {
+		n += 1 + l + sovGenesis(uint64(l))
+	}
 	return n
 }
 
@@ -253,103 +351,10 @@ func (m *GenesisState) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Storage == nil {
-				m.Storage = make(map[string]string)
+			m.Storage = append(m.Storage, &StorageEntry{})
+			if err := m.Storage[len(m.Storage)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
 			}
-			var mapkey string
-			var mapvalue string
-			for iNdEx < postIndex {
-				entryPreIndex := iNdEx
-				var wire uint64
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return ErrIntOverflowGenesis
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					wire |= uint64(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				fieldNum := int32(wire >> 3)
-				if fieldNum == 1 {
-					var stringLenmapkey uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowGenesis
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapkey |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapkey := int(stringLenmapkey)
-					if intStringLenmapkey < 0 {
-						return ErrInvalidLengthGenesis
-					}
-					postStringIndexmapkey := iNdEx + intStringLenmapkey
-					if postStringIndexmapkey < 0 {
-						return ErrInvalidLengthGenesis
-					}
-					if postStringIndexmapkey > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
-					iNdEx = postStringIndexmapkey
-				} else if fieldNum == 2 {
-					var stringLenmapvalue uint64
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return ErrIntOverflowGenesis
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						stringLenmapvalue |= uint64(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					intStringLenmapvalue := int(stringLenmapvalue)
-					if intStringLenmapvalue < 0 {
-						return ErrInvalidLengthGenesis
-					}
-					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
-					if postStringIndexmapvalue < 0 {
-						return ErrInvalidLengthGenesis
-					}
-					if postStringIndexmapvalue > l {
-						return io.ErrUnexpectedEOF
-					}
-					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
-					iNdEx = postStringIndexmapvalue
-				} else {
-					iNdEx = entryPreIndex
-					skippy, err := skipGenesis(dAtA[iNdEx:])
-					if err != nil {
-						return err
-					}
-					if (skippy < 0) || (iNdEx+skippy) < 0 {
-						return ErrInvalidLengthGenesis
-					}
-					if (iNdEx + skippy) > postIndex {
-						return io.ErrUnexpectedEOF
-					}
-					iNdEx += skippy
-				}
-			}
-			m.Storage[mapkey] = mapvalue
 			iNdEx = postIndex
 		case 2:
 			if wireType != 2 {
@@ -383,6 +388,120 @@ func (m *GenesisState) Unmarshal(dAtA []byte) error {
 			if err := m.Params.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipGenesis(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *StorageEntry) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowGenesis
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: StorageEntry: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: StorageEntry: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Key", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenesis
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Key = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Value", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenesis
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Value = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/golang/cosmos/x/swingset/types/swingset.pb.go
+++ b/golang/cosmos/x/swingset/types/swingset.pb.go
@@ -35,6 +35,10 @@ type Params struct {
 	//
 	// The structure and interpretation of this map and the units therein is
 	// entirely determined by the JS-level code.
+	//
+	// There is no required order to this list of entries, but all the chain
+	// nodes must all serialize and deserialize the existing order without
+	// permuting it.
 	BeansPerUnit []StringBeans `protobuf:"bytes,1,rep,name=beans_per_unit,json=beansPerUnit,proto3" json:"beans_per_unit"`
 	// The price in Coins per the unit named "fee".  This value is used by
 	// cosmic-swingset JS code to decide how many tokens to charge.
@@ -89,8 +93,11 @@ func (m *Params) GetFeeUnitPrice() github_com_cosmos_cosmos_sdk_types.Coins {
 	return nil
 }
 
+// Map element of a string key to a Nat bean count.
 type StringBeans struct {
-	Key   string                                  `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	// What the beans are for.
+	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	// The actual bean value.
 	Beans github_com_cosmos_cosmos_sdk_types.Uint `protobuf:"bytes,2,opt,name=beans,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Uint" json:"beans"`
 }
 


### PR DESCRIPTION
refs: #4134

## Description

Similar to #4137, make the order of storage entries deterministic in the swingset genesis state.

This has no effect on operation of the chain, but should make it easier to compare different genesis states created by different nodes.

### Security Considerations

None.

### Documentation Considerations

N/A

### Testing Considerations

N/A
