### PR TITLE
fix(wallet): allow wallet app deep linking

### DIFF
--- a/packages/solo/src/web.js
+++ b/packages/solo/src/web.js
@@ -102,6 +102,7 @@ export async function makeHTTPListener(basedir, port, host, rawInboundCommand) {
   };
 
   const app = express();
+
   // HTTP logging.
   app.use(
     morgan(`:method :url :status :res[content-length] - :response-time ms`, {
@@ -120,6 +121,10 @@ export async function makeHTTPListener(basedir, port, host, rawInboundCommand) {
   log(`Serving static files from ${htmldir}`);
   app.use(express.static(htmldir));
   app.use(express.static(new URL('../public', import.meta.url).pathname));
+
+  app.get('/wallet/*', (_, res) =>
+    res.sendFile(path.resolve('html', 'wallet', 'index.html')),
+  );
 
   // The rules for validation:
   //


### PR DESCRIPTION
If you navigated to a route e.g. /wallet/dapps and tried to refresh the page then you'd get a 400 error. This is because client-side navigation is intercepted by react routing, but the server only recognized the base url "/wallet/"