### PR TITLE
Fix IBC (`x/capability`) nondeterminism after node restart

### DIFF
--- a/golang/cosmos/app/app.go
+++ b/golang/cosmos/app/app.go
@@ -469,10 +469,23 @@ func NewAgoricApp(
 	// CanWithdrawInvariant invariant.
 	// NOTE: staking module is required if HistoricalEntries param > 0
 	app.mm.SetOrderBeginBlockers(
-		upgradetypes.ModuleName, minttypes.ModuleName, distrtypes.ModuleName, slashingtypes.ModuleName,
-		evidencetypes.ModuleName, stakingtypes.ModuleName, ibchost.ModuleName, swingset.ModuleName,
+		upgradetypes.ModuleName,
+		capabilitytypes.ModuleName,
+		minttypes.ModuleName,
+		distrtypes.ModuleName,
+		slashingtypes.ModuleName,
+		evidencetypes.ModuleName,
+		stakingtypes.ModuleName,
+		ibchost.ModuleName,
+		swingset.ModuleName,
 	)
-	app.mm.SetOrderEndBlockers(vbank.ModuleName, swingset.ModuleName, crisistypes.ModuleName, govtypes.ModuleName, stakingtypes.ModuleName)
+	app.mm.SetOrderEndBlockers(
+		vbank.ModuleName,
+		swingset.ModuleName,
+		crisistypes.ModuleName,
+		govtypes.ModuleName,
+		stakingtypes.ModuleName,
+	)
 
 	// NOTE: The genutils module must occur after staking so that pools are
 	// properly initialized with tokens from genesis accounts.

--- a/packages/agoric-cli/src/chain-config.js
+++ b/packages/agoric-cli/src/chain-config.js
@@ -5,6 +5,13 @@ export const CENTRAL_DENOM = 'urun';
 export const MINT_DENOM = 'ubld';
 export const STAKING_DENOM = 'ubld';
 export const STAKING_MAX_VALIDATORS = 150;
+// Required for IBC connections not to time out.
+export const STAKING_MIN_HISTORICAL_ENTRIES = 10000;
+
+// We reserve the default `transfer` IBC port for Pegasus (JS-level ERTP
+// assets).  The `cosmos-transfer` IBC port is used for ibc-go (Cosmos-level
+// prefixed string token denominations).
+export const COSMOS_TRANSFER_PORT_ID = 'cosmos-transfer';
 
 export const DENOM_METADATA = [
   {
@@ -178,6 +185,15 @@ export function finishCosmosGenesis({ genesisJson, exportedGenesisJson }) {
 
   genesis.app_state.staking.params.bond_denom = STAKING_DENOM;
   genesis.app_state.staking.params.max_validators = STAKING_MAX_VALIDATORS;
+  const {
+    historical_entries: existingHistoricalEntries = 0,
+  } = genesis.app_state.staking.params;
+  genesis.app_state.staking.params.historical_entries = Math.max(
+    existingHistoricalEntries,
+    STAKING_MIN_HISTORICAL_ENTRIES,
+  );
+
+  genesis.app_state.transfer.port_id = COSMOS_TRANSFER_PORT_ID;
 
   // We scale this parameter according to our own block cadence, so
   // that we tolerate the same downtime as the old genesis.

--- a/packages/deployment/src/init.js
+++ b/packages/deployment/src/init.js
@@ -108,18 +108,27 @@ const genericAskDatacenter = ({ inquirer }) => async (
 
 const DOCKER_DATACENTER = 'default';
 
-const makeProviders = ({ env, inquirer, wr, setup, fetch }) => ({
+const makeProviders = ({ env, inquirer, wr, setup, fetch, needBacktick }) => ({
   docker: {
     name: 'Docker instances',
     value: 'docker',
     askDetails: async (_provider, _myDetails) => {
-      let vspec = '/sys/fs/cgroup:/sys/fs/cgroup';
+      let vspec = '';
+
+      const dockerInfo = await needBacktick(`docker info`);
+      const cgroupMatch = dockerInfo.match(/^\s*Cgroup\sVersion:\s*(\d+)/im);
+      if (!cgroupMatch || Number(cgroupMatch[1]) < 2) {
+        // Older cgroup version, we need to mount `/sys/fs/cgroup` explicitly
+        // for our Agoric deployment Docker containers' systemd.
+        vspec += ',/sys/fs/cgroup:/sys/fs/cgroup';
+      }
       if (env.DOCKER_VOLUMES) {
         vspec += `,${env.DOCKER_VOLUMES}`;
       }
       return {
         VOLUMES: vspec
           .split(',')
+          .filter(vol => vol.trim())
           .map(vol => vol.split(':'))
           // eslint-disable-next-line camelcase
           .map(([host_path, container_path]) => ({
@@ -276,8 +285,15 @@ const doInit = ({
   fetch,
   parseArgs,
 }) => async (progname, args) => {
-  const { needDoRun, cwd, chdir } = running;
-  const PROVIDERS = makeProviders({ env, inquirer, wr, setup, fetch });
+  const { needDoRun, needBacktick, cwd, chdir } = running;
+  const PROVIDERS = makeProviders({
+    env,
+    inquirer,
+    wr,
+    setup,
+    fetch,
+    needBacktick,
+  });
 
   const { _: parsedArgs, noninteractive } = parseArgs(args.slice(1), {
     boolean: ['noninteractive'],


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #4159

## Description

Fixes nondeterminism caused by missing `x/capability` in the Cosmos `SetOrderBeginBlockers` call (found by narrowing down to a `x/capability` problem, then studying occurrences of `capability` in Cosmos SDK v0.44.4 `cosmos-sdk/simapp/app.go`).

Simplifies the `golang/cosmos/app/app.go` to set less `genesis.json` overrides, instead doing it explicitly in `agoric set-defaults`.  This makes things a little less magical.

Also updates `packages/deployment` to work with newer Docker installations where the `/sys/fs/cgroup` must not be mounted.  I needed this to do local testing.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

We really need multinode IBC testing along with the other loadgen tests.  Maybe for the New Year?
