### PR TITLE
Convert functions to arrow functions in Treasury

### DIFF
--- a/packages/treasury/src/burn.js
+++ b/packages/treasury/src/burn.js
@@ -8,9 +8,9 @@ import { E } from '@agoric/eventual-send';
  * @param {ZCFMint} zcfMint
  * @param {Amount} amount
  */
-export async function paymentFromZCFMint(zcf, zcfMint, amount) {
+export const paymentFromZCFMint = async (zcf, zcfMint, amount) => {
   const { zcfSeat, userSeat } = zcf.makeEmptySeatKit();
   zcfMint.mintGains(harden({ Temp: amount }), zcfSeat);
   zcfSeat.exit();
   return E(userSeat).getPayout('Temp');
-}
+};

--- a/packages/treasury/src/interest.js
+++ b/packages/treasury/src/interest.js
@@ -9,9 +9,11 @@ import {
 } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { AmountMath } from '@agoric/ertp';
 
-function makeResult(latestInterestUpdate, interest, newDebt) {
-  return { latestInterestUpdate, interest, newDebt };
-}
+const makeResult = (latestInterestUpdate, interest, newDebt) => ({
+  latestInterestUpdate,
+  interest,
+  newDebt,
+});
 
 export const SECONDS_PER_YEAR = 60n * 60n * 24n * 365n;
 const BASIS_POINTS = 10000;
@@ -19,12 +21,12 @@ const BASIS_POINTS = 10000;
 const LARGE_DENOMINATOR = BASIS_POINTS * BASIS_POINTS;
 
 /** @type {MakeInterestCalculator} */
-export function makeInterestCalculator(
+export const makeInterestCalculator = (
   brand,
   annualRate,
   chargingPeriod,
   recordingPeriod,
-) {
+) => {
   // see https://en.wikipedia.org/wiki/Compound_interest#Compounding_basis
   const numeratorValue = Number(annualRate.numerator.value);
   const denominatorValue = Number(annualRate.denominator.value);
@@ -41,7 +43,7 @@ export function makeInterestCalculator(
 
   // Calculate new debt for charging periods up to the present.
   /** @type {Calculate} */
-  function calculate(debtStatus, currentTime) {
+  const calculate = (debtStatus, currentTime) => {
     const { newDebt, latestInterestUpdate } = debtStatus;
     let newRecent = latestInterestUpdate;
     let growingInterest = debtStatus.interest;
@@ -53,21 +55,21 @@ export function makeInterestCalculator(
       growingDebt = AmountMath.add(growingDebt, newInterest, brand);
     }
     return makeResult(newRecent, growingInterest, growingDebt);
-  }
+  };
 
   // Calculate new debt for reporting periods up to the present. If some
   // charging periods have elapsed that don't constitute whole reporting
   // periods, the time is not updated past them and interest is not accumulated
   // for them.
   /** @type {Calculate} */
-  function calculateReportingPeriod(debtStatus, currentTime) {
+  const calculateReportingPeriod = (debtStatus, currentTime) => {
     const { latestInterestUpdate } = debtStatus;
     const overshoot = (currentTime - latestInterestUpdate) % recordingPeriod;
     return calculate(debtStatus, currentTime - overshoot);
-  }
+  };
 
   return harden({
     calculate,
     calculateReportingPeriod,
   });
-}
+};

--- a/packages/treasury/src/liquidation.js
+++ b/packages/treasury/src/liquidation.js
@@ -17,7 +17,13 @@ const trace = makeTracer('LIQ');
  *
  * @type {TreasuryLiquidate}
  */
-async function liquidate(zcf, vaultKit, burnLosses, strategy, collateralBrand) {
+const liquidate = async (
+  zcf,
+  vaultKit,
+  burnLosses,
+  strategy,
+  collateralBrand,
+) => {
   vaultKit.liquidating();
   const runDebt = vaultKit.vault.getDebtAmount();
   const { brand: runBrand } = runDebt;
@@ -57,7 +63,7 @@ async function liquidate(zcf, vaultKit, burnLosses, strategy, collateralBrand) {
   vaultSeat.exit();
   liquidationSeat.exit();
   vaultKit.liquidationPromiseKit.resolve('Liquidated');
-}
+};
 
 /**
  * The default strategy converts of all the collateral to RUN using autoswap,
@@ -65,20 +71,18 @@ async function liquidate(zcf, vaultKit, burnLosses, strategy, collateralBrand) {
  *
  * @type {(XYKAMMPublicFacet) => LiquidationStrategy}
  */
-function makeDefaultLiquidationStrategy(amm) {
-  function keywordMapping() {
-    return harden({
+const makeDefaultLiquidationStrategy = amm => {
+  const keywordMapping = () =>
+    harden({
       Collateral: 'In',
       RUN: 'Out',
     });
-  }
 
-  function makeProposal(collateral, run) {
-    return harden({
+  const makeProposal = (collateral, run) =>
+    harden({
       give: { In: collateral },
       want: { Out: AmountMath.makeEmptyFromAmount(run) },
     });
-  }
 
   trace(`return from makeDefault`);
 
@@ -87,7 +91,7 @@ function makeDefaultLiquidationStrategy(amm) {
     keywordMapping,
     makeProposal,
   };
-}
+};
 
 harden(makeDefaultLiquidationStrategy);
 harden(liquidate);

--- a/packages/treasury/src/makeTracer.js
+++ b/packages/treasury/src/makeTracer.js
@@ -1,13 +1,13 @@
 let debugInstance = 1;
 
-function makeTracer(name) {
+const makeTracer = name => {
   debugInstance += 1;
   let debugCount = 1;
   const key = `----- ${name}.${debugInstance} `;
-  function debugTick(...args) {
+  const debugTick = (...args) => {
     console.log(key, (debugCount += 1), ...args);
-  }
+  };
   return debugTick;
-}
+};
 
 export { makeTracer };

--- a/packages/treasury/src/stablecoinMachine.js
+++ b/packages/treasury/src/stablecoinMachine.js
@@ -48,7 +48,7 @@ import {
 const { details: X } = assert;
 
 /** @type {ContractStartFn} */
-export async function start(zcf, privateArgs) {
+export const start = async (zcf, privateArgs) => {
   // loanParams has time limits for charging interest
   const {
     ammPublicFacet,
@@ -93,7 +93,7 @@ export async function start(zcf, privateArgs) {
    *
    * @type {ReallocateReward}
    */
-  function reallocateReward(amount, fromSeat, otherSeat = undefined) {
+  const reallocateReward = (amount, fromSeat, otherSeat = undefined) => {
     rewardPoolSeat.incrementBy(
       fromSeat.decrementBy(
         harden({
@@ -106,7 +106,7 @@ export async function start(zcf, privateArgs) {
     } else {
       zcf.reallocate(rewardPoolSeat, fromSeat);
     }
-  }
+  };
 
   /** @type {Store<Brand,VaultManager>} */
   const collateralTypes = makeScalarMap('brand');
@@ -116,7 +116,7 @@ export async function start(zcf, privateArgs) {
   /** @type { Store<Brand, VaultParamManager> } */
   const vaultParamManagers = makeScalarMap('brand');
 
-  async function addVaultType(collateralIssuer, collateralKeyword, rates) {
+  const addVaultType = async (collateralIssuer, collateralKeyword, rates) => {
     await zcf.saveIssuer(collateralIssuer, collateralKeyword);
     const collateralBrand = zcf.getBrandForIssuer(collateralIssuer);
     // We create only one vault per collateralType.
@@ -152,12 +152,12 @@ export async function start(zcf, privateArgs) {
     );
     collateralTypes.init(collateralBrand, vm);
     return vm;
-  }
+  };
 
   /** Make a loan in the vaultManager based on the collateral type. */
-  function makeLoanInvitation() {
+  const makeLoanInvitation = () => {
     /** @param {ZCFSeat} seat */
-    async function makeLoanHook(seat) {
+    const makeLoanHook = async seat => {
       assertProposalShape(seat, {
         give: { Collateral: null },
         want: { RUN: null },
@@ -173,7 +173,7 @@ export async function start(zcf, privateArgs) {
       /** @type {VaultManager} */
       const mgr = collateralTypes.get(brandIn);
       return mgr.makeLoanKit(seat);
-    }
+    };
 
     return zcf.makeInvitation(
       makeLoanHook,
@@ -182,9 +182,9 @@ export async function start(zcf, privateArgs) {
       HIGH_FEE,
       LONG_EXP,
     );
-  }
+  };
 
-  async function getCollaterals() {
+  const getCollaterals = async () => {
     // should be collateralTypes.map((vm, brand) => ({
     return harden(
       Promise.all(
@@ -204,16 +204,14 @@ export async function start(zcf, privateArgs) {
         }),
       ),
     );
-  }
+  };
 
   // Eventually the reward pool will live elsewhere. For now it's here for
   // bookkeeping. It's needed in tests.
-  function getRewardAllocation() {
-    return rewardPoolSeat.getCurrentAllocation();
-  }
+  const getRewardAllocation = () => rewardPoolSeat.getCurrentAllocation();
 
   // TODO(#4021) remove this method
-  function mintBootstrapPayment() {
+  const mintBootstrapPayment = () => {
     const {
       zcfSeat: bootstrapZCFSeat,
       userSeat: bootstrapUserSeat,
@@ -232,7 +230,7 @@ export async function start(zcf, privateArgs) {
      * @param {Amount=} expectedAmount - if provided, assert that the bootstrap
      * payment is at least the expected amount
      */
-    function getBootstrapPayment(expectedAmount) {
+    const getBootstrapPayment = expectedAmount => {
       if (expectedAmount) {
         assert(
           AmountMath.isGTE(bootstrapAmount, expectedAmount),
@@ -240,9 +238,9 @@ export async function start(zcf, privateArgs) {
         );
       }
       return bootstrapPayment;
-    }
+    };
     return getBootstrapPayment;
-  }
+  };
 
   const getRatioParamState = paramDesc => {
     return vaultParamManagers
@@ -309,4 +307,4 @@ export async function start(zcf, privateArgs) {
     creatorFacet: stablecoinMachineWrapper,
     publicFacet,
   });
-}
+};


### PR DESCRIPTION
## Description

Replace function in Treasury with arrow function.

There was one change in vaultManager.js that was non-trivial. The old code was able to  pass a function as a parameter before it was defined. The new code had to defer the reference by delaying initialization of a variable that should have been const.

### Security Considerations

Should be no consequences.

### Documentation Considerations

None.

### Testing Considerations

None
