### PR TITLE
Allow addLiquidity contributions in arbitrary proportions

### DIFF
--- a/packages/zoe/src/contracts/vpool-xyk-amm/addLiquidity.js
+++ b/packages/zoe/src/contracts/vpool-xyk-amm/addLiquidity.js
@@ -1,8 +1,68 @@
 // @ts-check
 
-import { assertProposalShape } from '../../contractSupport/index.js';
+import { Nat } from '@agoric/nat';
+import {
+  assertProposalShape,
+  natSafeMath,
+} from '../../contractSupport/index.js';
 
 import '../../../exported.js';
+
+const { subtract, multiply, floorDivide } = natSafeMath;
+const { details: X } = assert;
+
+/**
+ * Calculate the Liquidity Tokens to return in exchange for the indicated
+ * increments to a liquidity pool. This implementation doesn't place any
+ * restrictions on the ratio of central to secondary. The standard design
+ * requires that the contributions be in the same ratio as the existing pool.
+ *
+ * The Formal Spec paper for UniSwap V1 says
+ * KPrime / K = (LPrime / L)^2,   and   DeltaL = LPrime - L
+ * so LPrime = sqrt(KPrime * L^2 / K) and DeltaL = sqrt(l^2 * KPrime/K) - 1).
+ *
+ * K is the product of the balances of the two assets in the pool before the
+ * investment, and KPrime is the product after. L is the liquidity token supply
+ * before, and LPrime is the token supply after, so the new investor gets
+ * DeltaL = LPrime - L.  The paper uses operations that round down when
+ * calculating liquidity, so we'll use floorDivide.
+ *
+ * This approach produces the same result as first trading with the pool to move
+ * its ratio to what would result from adding the new liquidity to the pool, and
+ * then adding liquidity using the original formulas. The trading step keeps
+ * K the same, and leaves the investor with assets in the correct proportion for
+ * the second step.
+ *
+ * @param {bigint} liqTokenSupply - outstanding liquidity tokens
+ * @param {bigint} centralPool
+ * @param {bigint} secondaryPool
+ * @param {bigint} centralIn
+ * @param {bigint} secondaryIn
+ * @returns {bigint}
+ */
+export const calcLiqValueAnyRatio = (
+  liqTokenSupply,
+  centralPool,
+  secondaryPool,
+  centralIn,
+  secondaryIn,
+) => {
+  const l = Nat(liqTokenSupply);
+  if (liqTokenSupply === 0n) {
+    return centralIn;
+  }
+
+  assert(centralPool > 0, X`Pool must already be initialized.`);
+  assert(secondaryPool > 0, X`Pool must already be initialized.`);
+
+  const kPrime = (centralIn + centralPool) * (secondaryIn + secondaryPool);
+  const k = centralPool * secondaryPool;
+  const lSquared = multiply(l, l);
+  const lPrime = Math.trunc(
+    Math.sqrt(Number(floorDivide(multiply(lSquared, kPrime), k))),
+  );
+  return subtract(lPrime, l);
+};
 
 /**
  * @param {ContractFacet} zcf

--- a/packages/zoe/test/unitTests/contracts/vpool-xyk-amm/test-addLiquidity.js
+++ b/packages/zoe/test/unitTests/contracts/vpool-xyk-amm/test-addLiquidity.js
@@ -1,0 +1,39 @@
+// @ts-check
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import { calcLiqValueAnyRatio } from '../../../../src/contracts/vpool-xyk-amm/addLiquidity.js';
+
+test('pool initialized', t => {
+  t.throws(() => calcLiqValueAnyRatio(20n, 0n, 20n, 11n, 15n), {
+    message: 'Pool must already be initialized.',
+  });
+  t.throws(() => calcLiqValueAnyRatio(20n, 30n, 0n, 11n, 15n), {
+    message: 'Pool must already be initialized.',
+  });
+});
+
+test('double the liquidity', t => {
+  t.is(calcLiqValueAnyRatio(20n, 30n, 20n, 30n, 20n), 20n);
+  t.is(calcLiqValueAnyRatio(1000n, 3000n, 2000n, 3000n, 2000n), 1000n);
+});
+
+test('change the ratio', t => {
+  // sqrt(3000^2 * 53k * 24K / (3k * 4k)) - 3000
+  t.is(calcLiqValueAnyRatio(3000n, 3000n, 4000n, 50000n, 20000n), 27886n);
+  // sqrt(3000^2 * 400k * 300k / (3k * 4k))  - 3000
+  t.is(
+    calcLiqValueAnyRatio(3000n, 3000n, 4000n, 397_000n, 296_000n),
+    300000n - 3000n,
+  );
+
+  // same thing in reverse order
+  t.is(calcLiqValueAnyRatio(397_000n, 397_000n, 296_000n, 3000n, 4000n), 4180n);
+});
+
+test('add just one currency', t => {
+  // sqrt(3000^2 * 3k * 24K / (3k * 4k)) - 3000
+  t.is(calcLiqValueAnyRatio(3000n, 3000n, 4000n, 0n, 20000n), 4348n);
+  // sqrt(3000^2 * 400k * 4k / (3k * 4k)) - 3000
+  t.is(calcLiqValueAnyRatio(3000n, 3000n, 4000n, 397_000n, 0n), 31641n);
+});


### PR DESCRIPTION
closes: #4200

## Description

The standard version of addLiquidity requires that new assets be added
in the same proportion as the existing pool. If the investor has a
ratio they want to reach, this causes a race. In order that the
runProtocol can fund pools and not be concerned about the race, this
change relaxes that requirement.

The liquidity tokens received by the investor will be the same as if
they had atomically traded (without fees) to change the pool's ratio,
and then added the remainder of their contribution as liquidity.

### Security Considerations

No security impact.

### Documentation Considerations

This approach to adding liquidity isn't the same as what's supported in UniSwap, (though I think some other constant product AMMs do allow it), so it's worth at least a mention in documentation.

### Testing Considerations

Added unit tests for the liquidity calculation.
Inserted adding incremental liquidity in an existing test.