### PR TITLE
Increase initial meter cause we got too close

### DIFF
--- a/packages/vats/src/bootstrap.js
+++ b/packages/vats/src/bootstrap.js
@@ -97,7 +97,7 @@ export function buildRootObject(vatPowers, vatParameters) {
     };
     const meteringConfig = {
       incrementBy: 25_000_000n,
-      initial: 50_000_000n,
+      initial: 103_000_000n,
       threshold: 25_000_000n,
       price: {
         feeNumerator: 1n,


### PR DESCRIPTION
While @warner and I were jointly debugging a #4217 failure (both CI and locally for both of us) we determined that the $50M initial meter budget was only just barely big enough, giving us little room to maneuver. #4217 was failing because it went just over the line. There seems to be little downside in making this much larger, so this PR doubles it (with a little extra to make it appear more unique), giving us back our needed headroom.

Fixes #4219 