### PR TITLE
fix(wallet-backend): next new purse is autodeposit if there was none

### DIFF
--- a/packages/wallet/api/src/lib-wallet.js
+++ b/packages/wallet/api/src/lib-wallet.js
@@ -804,7 +804,7 @@ export function makeWallet({
   const makeEmptyPurse = (
     brandPetname,
     petnameForPurse,
-    defaultAutoDeposit = false,
+    defaultAutoDeposit = true,
   ) =>
     internalUnsafeImportPurse(
       brandPetname,

--- a/packages/wallet/api/test/test-getPursesNotifier.js
+++ b/packages/wallet/api/test/test-getPursesNotifier.js
@@ -61,7 +61,7 @@ test('getPursesNotifier', async t => {
   } = await setup();
   const pursesNotifier = wallet.getPursesNotifier();
   const update = await pursesNotifier.getUpdateSince();
-  t.is(update.updateCount, 7);
+  t.is(update.updateCount, 6);
   // Has the default Zoe invitation purse and a moola purse
   t.is(update.value.length, 2);
   const moolaPurseInfo = update.value[1];
@@ -101,7 +101,7 @@ test('getAttenuatedPursesNotifier', async t => {
   } = await setup();
   const pursesNotifier = wallet.getAttenuatedPursesNotifier();
   const update = await pursesNotifier.getUpdateSince();
-  t.is(update.updateCount, 7);
+  t.is(update.updateCount, 6);
   // Has the default Zoe invitation purse and a moola purse
   t.is(update.value.length, 2);
   const moolaPurseInfo = update.value[1];

--- a/packages/wallet/api/test/test-lib-wallet.js
+++ b/packages/wallet/api/test/test-lib-wallet.js
@@ -197,7 +197,7 @@ test('lib-wallet issuer and purse methods', async t => {
     AmountMath.make(moolaBundle.brand, 100n),
     `deposit successful`,
   );
-  t.is(pursesStateChangeLog.length, 6, `pursesStateChangeLog length`);
+  t.is(pursesStateChangeLog.length, 5, `pursesStateChangeLog length`);
   const purseLog = JSON.parse(
     pursesStateChangeLog[pursesStateChangeLog.length - 1],
   );
@@ -231,6 +231,7 @@ test('lib-wallet issuer and purse methods', async t => {
         brand: purseLog[1].brand,
         brandBoardId: '727995140',
         brandPetname: 'moola',
+        depositBoardId: '604346717',
         displayInfo: {
           assetKind: 'nat',
         },
@@ -814,6 +815,7 @@ test('lib-wallet offer methods', async t => {
         assetKind: 'nat',
       },
       pursePetname: 'Fun budget',
+      depositBoardId: '604346717',
       value: 100,
       currentAmountSlots: {
         body:


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: #4149

## Description

We've been bitten repeatedly by payments getting stuck because there was no "autodeposit" purse in the wallet.  This PR helps by defaulting new purses to be "autodeposit" (unless there already was one).

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

Less needed documentation, since this footgun has been eliminated.

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

Unit tests have been updated.