### PR TITLE
Update comment in installationStorage.js

### DIFF
--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -332,7 +332,17 @@ export const makeZCFZygote = (
 
   let contractCode;
 
-  /** @type {ZCFZygote} */
+  /**
+   * A zygote is a pre-image of a vat that can quickly be instantiated because
+   * the code has already been evaluated. SwingSet doesn't support zygotes yet.
+   * Once it does the code will be evaluated once when creating the zcfZygote,
+   * then the start() function will be called each time an instance is started.
+   *
+   * Currently, Zoe's buildRootObject calls makeZCFZygote, evaluateContract, and
+   * startContract every time a contract instance is created.
+   *
+   * @type {ZCFZygote}
+   * */
   const zcfZygote = {
     evaluateContract: bundle => {
       contractCode = evalContractBundle(bundle);

--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -12,9 +12,11 @@ export const makeInstallationStorage = () => {
   const installations = new WeakSet();
 
   /**
-   * Create an installation by permanently storing the bundle. The code will be
-   * evaluated once when creating a zcfZygote, then the start() function will be
-   * called each time an instance is started.
+   * Create an installation by permanently storing the bundle. The code is
+   * currently evaluated each time it is used to make a new instance of a
+   * contract. When SwingSet supports zygotes, the code will be evaluated once
+   * when creating a zcfZygote, then the start() function will be called each
+   * time an instance is started.
    */
   /** @type {Install} */
   const install = async bundle => {

--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -12,8 +12,9 @@ export const makeInstallationStorage = () => {
   const installations = new WeakSet();
 
   /**
-   * Create an installation by permanently storing the bundle. It will be
-   * evaluated each time it is used to make a new instance of a contract.
+   * Create an installation by permanently storing the bundle. The code will be
+   * evaluated once when creating a zcfZygote, then the start() function will be
+   * called each time an instance is started.
    */
   /** @type {Install} */
   const install = async bundle => {


### PR DESCRIPTION
ref: #4223

## Description

While reading code for the Zoe Attacker's Guide, I found this out-of-date comment

### Security Considerations

Just internal doc.

### Documentation Considerations

Catching the internal comments up with changes made a while ago. No further implications. The documentation site doesn't say anything that needs to be updated.

### Testing Considerations

none.