### PR TITLE
Restore nameHub behaviour (arrays, not iterators)

### DIFF
--- a/packages/vats/src/nameHub.js
+++ b/packages/vats/src/nameHub.js
@@ -33,19 +33,26 @@ export const makeNameHubKit = () => {
       return E(firstValue).lookup(...remaining);
     },
     entries() {
-      return mapIterable(keyToRecord.entries(), ([key, record]) => [
-        key,
-        record.promise || record.value,
-      ]);
+      return [
+        ...mapIterable(
+          keyToRecord.entries(),
+          ([key, record]) => /** @type {[string, ERef<unknown>]} */ ([
+            key,
+            record.promise || record.value,
+          ]),
+        ),
+      ];
     },
     values() {
-      return mapIterable(
-        keyToRecord.values(),
-        record => record.promise || record.value,
-      );
+      return [
+        ...mapIterable(
+          keyToRecord.values(),
+          record => record.promise || record.value,
+        ),
+      ];
     },
     keys() {
-      return keyToRecord.keys();
+      return [...keyToRecord.keys()];
     },
   });
 

--- a/packages/vats/src/types.js
+++ b/packages/vats/src/types.js
@@ -15,14 +15,19 @@
 
 /**
  * @typedef {Object} NameHub
+ *
+ * NOTE: We need to return arrays, not iterables, because even if marshal could
+ * allow passing a remote iterable, there would be an inordinate number of round
+ * trips for the contents of even the simplest nameHub.
+ *
  * @property {(...path: Array<string>) => Promise<any>} lookup Look up a
  * path of keys starting from the current NameHub.  Wait on any reserved
  * promises.
- * @property {() => Iterable<[string, unknown]>} entries get all the entries
+ * @property {() => [string, unknown][]} entries get all the entries
  * available in the current NameHub
- * @property {() => Iterable<string>} keys get all names available in the
+ * @property {() => string[]} keys get all names available in the
  * current NameHub
- * @property {() => Iterable<unknown>} values get all values available in the
+ * @property {() => unknown[]} values get all values available in the
  * current NameHub
  */
 

--- a/packages/vats/test/test-name-hub.js
+++ b/packages/vats/test/test-name-hub.js
@@ -7,15 +7,15 @@ test('makeNameHubKit - lookup paths', async t => {
   const { nameAdmin: na2, nameHub: nh2 } = makeNameHubKit();
   const { nameAdmin: na3, nameHub: nh3 } = makeNameHubKit();
 
-  t.deepEqual([...nh1.keys()], []);
-  t.deepEqual([...nh1.values()], []);
-  t.deepEqual([...nh1.entries()], []);
-  t.deepEqual([...nh2.keys()], []);
-  t.deepEqual([...nh2.values()], []);
-  t.deepEqual([...nh2.entries()], []);
-  t.deepEqual([...nh3.keys()], []);
-  t.deepEqual([...nh3.values()], []);
-  t.deepEqual([...nh3.entries()], []);
+  t.deepEqual(nh1.keys(), []);
+  t.deepEqual(nh1.values(), []);
+  t.deepEqual(nh1.entries(), []);
+  t.deepEqual(nh2.keys(), []);
+  t.deepEqual(nh2.values(), []);
+  t.deepEqual(nh2.entries(), []);
+  t.deepEqual(nh3.keys(), []);
+  t.deepEqual(nh3.values(), []);
+  t.deepEqual(nh3.entries(), []);
 
   na1.update('path1', nh2);
   t.is(await nh1.lookup('path1'), nh2);
@@ -24,15 +24,15 @@ test('makeNameHubKit - lookup paths', async t => {
   na3.update('path3', 'finish');
   t.is(await nh3.lookup('path3'), 'finish');
 
-  t.deepEqual([...nh1.keys()], ['path1']);
-  t.deepEqual([...nh1.values()], [nh2]);
-  t.deepEqual([...nh1.entries()], [['path1', nh2]]);
-  t.deepEqual([...nh2.keys()], ['path2']);
-  t.deepEqual([...nh2.values()], [nh3]);
-  t.deepEqual([...nh2.entries()], [['path2', nh3]]);
-  t.deepEqual([...nh3.keys()], ['path3']);
-  t.deepEqual([...nh3.values()], ['finish']);
-  t.deepEqual([...nh3.entries()], [['path3', 'finish']]);
+  t.deepEqual(nh1.keys(), ['path1']);
+  t.deepEqual(nh1.values(), [nh2]);
+  t.deepEqual(nh1.entries(), [['path1', nh2]]);
+  t.deepEqual(nh2.keys(), ['path2']);
+  t.deepEqual(nh2.values(), [nh3]);
+  t.deepEqual(nh2.entries(), [['path2', nh3]]);
+  t.deepEqual(nh3.keys(), ['path3']);
+  t.deepEqual(nh3.values(), ['finish']);
+  t.deepEqual(nh3.entries(), [['path3', 'finish']]);
 
   t.is(await nh1.lookup(), nh1);
   t.is(await nh1.lookup('path1'), nh2);
@@ -50,9 +50,9 @@ test('makeNameHubKit - reserve and update', async t => {
     message: /"nameKey" not found: .*/,
   });
 
-  t.deepEqual([...nameHub.keys()], []);
-  t.deepEqual([...nameHub.values()], []);
-  t.deepEqual([...nameHub.entries()], []);
+  t.deepEqual(nameHub.keys(), []);
+  t.deepEqual(nameHub.values(), []);
+  t.deepEqual(nameHub.entries(), []);
 
   // Try reserving and looking up.
   nameAdmin.reserve('hello');
@@ -61,16 +61,16 @@ test('makeNameHubKit - reserve and update', async t => {
   const lookupHelloP = nameHub
     .lookup('hello')
     .finally(() => (lookedUpHello = true));
-  t.deepEqual([...nameHub.keys()], ['hello']);
-  const helloP = [...nameHub.values()][0];
+  t.deepEqual(nameHub.keys(), ['hello']);
+  const helloP = nameHub.values()[0];
   t.assert(helloP instanceof Promise);
-  t.deepEqual([...nameHub.entries()], [['hello', helloP]]);
+  t.deepEqual(nameHub.entries(), [['hello', helloP]]);
 
   t.falsy(lookedUpHello);
   nameAdmin.update('hello', 'foo');
-  t.deepEqual([...nameHub.keys()], ['hello']);
-  t.deepEqual([...nameHub.values()], ['foo']);
-  t.deepEqual([...nameHub.entries()], [['hello', 'foo']]);
+  t.deepEqual(nameHub.keys(), ['hello']);
+  t.deepEqual(nameHub.values(), ['foo']);
+  t.deepEqual(nameHub.entries(), [['hello', 'foo']]);
   t.is(await lookupHelloP, 'foo');
   t.truthy(lookedUpHello);
 
@@ -85,9 +85,9 @@ test('makeNameHubKit - reserve and delete', async t => {
     message: /"nameKey" not found: .*/,
   });
 
-  t.deepEqual([...nameHub.keys()], []);
-  t.deepEqual([...nameHub.values()], []);
-  t.deepEqual([...nameHub.entries()], []);
+  t.deepEqual(nameHub.keys(), []);
+  t.deepEqual(nameHub.values(), []);
+  t.deepEqual(nameHub.entries(), []);
 
   nameAdmin.reserve('goodbye');
   let lookedUpGoodbye = false;
@@ -96,15 +96,15 @@ test('makeNameHubKit - reserve and delete', async t => {
     .finally(() => (lookedUpGoodbye = true));
 
   t.falsy(lookedUpGoodbye);
-  t.deepEqual([...nameHub.keys()], ['goodbye']);
-  const goodbyeP = [...nameHub.values()][0];
+  t.deepEqual(nameHub.keys(), ['goodbye']);
+  const goodbyeP = nameHub.values()[0];
   t.assert(goodbyeP instanceof Promise);
-  t.deepEqual([...nameHub.entries()], [['goodbye', goodbyeP]]);
+  t.deepEqual(nameHub.entries(), [['goodbye', goodbyeP]]);
 
   nameAdmin.delete('goodbye');
-  t.deepEqual([...nameHub.keys()], []);
-  t.deepEqual([...nameHub.values()], []);
-  t.deepEqual([...nameHub.entries()], []);
+  t.deepEqual(nameHub.keys(), []);
+  t.deepEqual(nameHub.values(), []);
+  t.deepEqual(nameHub.entries(), []);
   await t.throwsAsync(lookupGoodbyeP, {
     message: /"nameKey" not found: .*/,
   });


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: #4191

## Description

`packages/vats/test/test-name-hub.js` was updated to tolerate iterators in #4191, but it was actually testing a client-facing NameHub API that must not change without careful thought and proper deprecation.  An iterator, even if it were possible across remote Far objects, would incur a terrible number of round trips, so it is not appropriate in this case.

I reviewed the changes made by #4191, and no other tests changed semantics, so I don't think there're any other negative consequences.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

Restores backwards compat.

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

Tested by reverting the changed test and running CI.
