### PR TITLE
Add loadgen to deployment integration test

### DIFF
--- a/.github/workflows/deployment-test.yml
+++ b/.github/workflows/deployment-test.yml
@@ -1,7 +1,7 @@
 name: Chain deployment test
 
 on:
-  # Use the following to explicitly start thit workflow.
+  # Use the following to explicitly start this workflow.
   # packages/deployment/scripts/start-deployment-test.sh <BRANCH-OR-TAG>
   workflow_dispatch:
   # Otherwise, run on default branch.
@@ -21,12 +21,48 @@ jobs:
       - uses: ./.github/actions/restore-node
         with:
           node-version: 14.x
+
+      # Select a branch on loadgen to test against by adding text to the body of the
+      # pull request. For example: #loadgen-branch: user-123-update-foo
+      # The default is 'main'
+      - name: Get the appropriate loadgen branch
+        id: get-loadgen-branch
+        uses: actions/github-script@0.9.0
+        with:
+          result-encoding: string
+          script: |
+            let branch = 'main';
+            if (context.payload.pull_request) {
+              const { body } = context.payload.pull_request;
+              const regex = /.*\#loadgen-branch:\s+(\S+)/;
+              const result = regex.exec(body);
+              if (result) {
+                branch = result[1];
+              }
+            }
+            console.log(branch);
+            return branch;
+
+      - name: Check out loadgen
+        uses: actions/checkout@v2
+        with:
+          repository: Agoric/testnet-load-generator
+          path: testnet-load-generator
+          ref: ${{steps.get-loadgen-branch.outputs.result}}
+
+      - name: Move repos under /usr/src where scripts expect them
+        run: |
+          set -e
+          sudo mv "$GITHUB_WORKSPACE/testnet-load-generator" /usr/src/testnet-load-generator
+          sudo mv "$GITHUB_WORKSPACE" /usr/src/agoric-sdk
+          ln -s /usr/src/agoric-sdk/packages/deployment/bin/ag-setup-cosmos /usr/local/bin/ag-setup-cosmos
+          ln -s /usr/src/agoric-sdk "$GITHUB_WORKSPACE"
+        working-directory: /
+
       - name: Build cosmic-swingset dependencies
         run: |
           # Some of our build relies on /usr/src/agoric-sdk
           set -e
-          sudo mv "$GITHUB_WORKSPACE" /usr/src/agoric-sdk
-          ln -s /usr/src/agoric-sdk "$GITHUB_WORKSPACE"
           cd /usr/src/agoric-sdk/packages/cosmic-swingset
           make install
         working-directory: /

--- a/packages/deployment/scripts/integration-test.sh
+++ b/packages/deployment/scripts/integration-test.sh
@@ -6,6 +6,12 @@ thisdir=$(cd "$(dirname -- "$real0")" > /dev/null && pwd -P)
 
 export NETWORK_NAME=${NETWORK_NAME-localtest}
 
+RESULTSDIR=${RESULTSDIR-"$NETWORK_NAME/results"}
+mkdir -p "$RESULTSDIR"
+pushd "$RESULTSDIR"
+RESULTSDIR="$PWD"
+popd
+
 mkdir -p "$NETWORK_NAME/setup"
 cd "$NETWORK_NAME/setup"
 
@@ -21,3 +27,21 @@ DOCKER_VOLUMES="$(cd "$thisdir/../../.." > /dev/null && pwd -P):/usr/src/agoric-
 # Go ahead and bootstrap with detailed debug logging.
 AG_COSMOS_START_ARGS="--log_level=info --trace-store=.ag-chain-cosmos/data/kvstore.trace" \
   "$thisdir/setup.sh" bootstrap ${1+"$@"}
+
+if [ -d /usr/src/testnet-load-generator ]
+then
+  /usr/src/agoric-sdk/packages/deployment/scripts/setup.sh show-config > "$RESULTSDIR/network-config"
+  cp ag-chain-cosmos/data/genesis.json "$RESULTSDIR/genesis.json"
+  cp "$AG_SETUP_COSMOS_HOME/ag-chain-cosmos/data/genesis.json" "$RESULTSDIR/genesis.json"
+  cd /usr/src/testnet-load-generator
+  $thisdir/../../solo/bin/ag-solo init \
+    _agstate/agoric-servers/testnet-8000 \
+    --webport=8000 \
+    --netconfig="$RESULTSDIR/network-config"
+  $AG_SETUP_COSMOS_HOME/faucet-helper.sh add-egress \
+    loadgen $(cat _agstate/agoric-servers/testnet-8000/ag-cosmos-helper-address)
+  SDK_BUILD=0 SDK_SRC=/usr/src/agoric-sdk OUTPUT_DIR="$RESULTSDIR" ./start.sh \
+    --no-stage.save-storage --stages=3 --stage.duration=4 \
+    --profile=testnet "--testnet-origin=file://$RESULTSDIR" \
+    --no-reset
+fi

--- a/packages/deployment/scripts/integration-test.sh
+++ b/packages/deployment/scripts/integration-test.sh
@@ -42,6 +42,8 @@ then
     loadgen $(cat _agstate/agoric-servers/testnet-8000/ag-cosmos-helper-address)
   SDK_BUILD=0 SDK_SRC=/usr/src/agoric-sdk OUTPUT_DIR="$RESULTSDIR" ./start.sh \
     --no-stage.save-storage --stages=3 --stage.duration=4 \
+    --stage.loadgen.vault.interval=12 --stage.loadgen.vault.limit=2 \
+    --stage.loadgen.amm.interval=12 --stage.loadgen.amm.wait=6 --stage.loadgen.amm.limit=2 \
     --profile=testnet "--testnet-origin=file://$RESULTSDIR" \
     --no-reset
 fi


### PR DESCRIPTION
refs: #3444 

## Description

This change leverages the loadgen work, and stacks it on top of https://github.com/Agoric/agoric-sdk/pull/4133 to run a short loadgen cycle against the 2 node testnet started by the integration test.

Unlike #3107, the goal is not to generate perf data (even though some very basic deploy times might be useful), but to make sure changes to `agoric-sdk` do not break the loadgen which is a simple representative of dapps.

It should also help catch some non-determinism source (see #3444), but only if caused by different SwingSet executions. It would probably not catch restart related non-determinism.

### Security Considerations

This should not have any impact on security, and is modeled against the dapp integration test which also checks out another Agoric owned repository.

### Testing Considerations

In general SDK breaking changes should be accommodated in the loadgen in a backwards compatible manner, so that the loadgen can run against both old and new versions of the SDK. That usually means merging a loadgen fix first, then running the integration test in the SDK's PR. If necessary, an SDK PR can target a specific loadgen branch using the following PR notation: ` #loadgen-branch: main ` (replace `main` with the branch name).