### PR TITLE
Dedeprecate exports from same-structure

### DIFF
--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -45,7 +45,6 @@
     "@agoric/nat": "^4.1.0",
     "@agoric/notifier": "^0.3.33",
     "@agoric/promise-kit": "^0.2.29",
-    "@agoric/same-structure": "^0.1.29",
     "@agoric/store": "^0.6.8"
   },
   "devDependencies": {

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -23,12 +23,12 @@
 
 /**
  * @typedef {NatValue | SetValue} Value
- * Values describe the value of something that can be owned or shared.
- * Fungible values are normally represented by natural numbers. Other
- * values may be represented as strings naming a particular right, or
- * an arbitrary object that sensibly represents the rights at issue.
- *
- * Value must be Comparable. (Would be nice to type this correctly.)
+ * Values describe a set or quantity of something that can be owned or shared.
+ * Fungible values use a non-negative bigint to represent a quantity.
+ * Non-fungible values use an array of `Key`s to represent a set of
+ * whatever each key represents. A `Key` is a passable value that can
+ * be used as an key an element in a set (SetStore or CopySet) or as the
+ * key in a map (MapStore or CopyMap).
  */
 
 /**
@@ -515,7 +515,7 @@
  */
 
 /**
- * @typedef {Comparable} SetValueElem
+ * @typedef {Key} SetValueElem
  */
 
 /**

--- a/packages/ERTP/test/unitTests/mathHelpers/test-setMathHelpers.js
+++ b/packages/ERTP/test/unitTests/mathHelpers/test-setMathHelpers.js
@@ -40,7 +40,7 @@ const runSetMathHelpersTests = (t, [a, b, c], a2 = undefined) => {
   t.deepEqual(
     m.make(mockBrand, harden(['a', 'b'])),
     { brand: mockBrand, value: harden(['b', 'a']) },
-    'anything comparable is a valid element',
+    'any key is a valid element',
   );
   t.throws(
     // @ts-ignore deliberate invalid arguments for testing
@@ -80,7 +80,7 @@ const runSetMathHelpersTests = (t, [a, b, c], a2 = undefined) => {
   t.deepEqual(
     m.coerce(mockBrand, m.make(mockBrand, harden(['a', 'b']))),
     { brand: mockBrand, value: harden(['b', 'a']) },
-    'anything comparable is a valid element',
+    'any key is a valid element',
   );
   t.throws(
     // @ts-ignore deliberate invalid arguments for testing

--- a/packages/deploy-script-support/package.json
+++ b/packages/deploy-script-support/package.json
@@ -46,7 +46,6 @@
     "@agoric/nat": "^4.1.0",
     "@agoric/notifier": "^0.3.33",
     "@agoric/promise-kit": "^0.2.29",
-    "@agoric/same-structure": "^0.1.29",
     "@agoric/store": "^0.6.8",
     "@agoric/vats": "^0.5.1",
     "@agoric/zoe": "^0.21.1"

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -37,7 +37,6 @@
     "@agoric/nat": "^4.1.0",
     "@agoric/notifier": "^0.3.33",
     "@agoric/promise-kit": "^0.2.29",
-    "@agoric/same-structure": "^0.1.29",
     "@agoric/store": "^0.6.8",
     "@agoric/zoe": "^0.21.1"
   },

--- a/packages/governance/src/binaryVoteCounter.js
+++ b/packages/governance/src/binaryVoteCounter.js
@@ -2,8 +2,7 @@
 
 import { Far } from '@agoric/marshal';
 import { makePromiseKit } from '@agoric/promise-kit';
-import { sameStructure } from '@agoric/same-structure';
-import { makeStore } from '@agoric/store';
+import { keyEQ, makeStore } from '@agoric/store';
 
 import {
   ChoiceMethod,
@@ -104,7 +103,7 @@ const makeBinaryVoteCounter = (questionSpec, threshold, instance) => {
     const tally = [0n, 0n];
 
     for (const { chosen, shares } of allBallots.values()) {
-      const choice = positions.findIndex(p => sameStructure(p, chosen));
+      const choice = positions.findIndex(p => keyEQ(p, chosen));
       if (choice < 0) {
         spoiled += shares;
       } else {

--- a/packages/governance/src/contractHelper.js
+++ b/packages/governance/src/contractHelper.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { Far } from '@agoric/marshal';
-import { sameStructure } from '@agoric/same-structure';
+import { keyEQ } from '@agoric/store';
 
 const { details: X, quote: q } = assert;
 
@@ -26,7 +26,7 @@ const handleParamGovernance = (zcf, paramManager) => {
   const { electionManager } = terms;
 
   assert(
-    sameStructure(governedParams, paramManager.getParams()),
+    keyEQ(governedParams, paramManager.getParams()),
     X`Terms must include ${q(paramManager.getParams())}, but were ${q(
       governedParams,
     )}`,

--- a/packages/governance/src/electorateTools.js
+++ b/packages/governance/src/electorateTools.js
@@ -1,8 +1,7 @@
 // @ts-check
 
 import { E } from '@agoric/eventual-send';
-import { allComparable } from '@agoric/same-structure';
-import { Far } from '@agoric/marshal';
+import { deeplyFulfilled, Far } from '@agoric/marshal';
 
 /**
  * Start up a new Counter for a question
@@ -48,7 +47,7 @@ const getOpenQuestions = async questionStore => {
     },
   );
 
-  const isOpenQuestions = await allComparable(harden(isOpenPQuestions));
+  const isOpenQuestions = await deeplyFulfilled(harden(isOpenPQuestions));
   return isOpenQuestions
     .filter(([open, _key]) => open)
     .map(([_open, key]) => key);

--- a/packages/governance/src/paramGovernance/governParam.js
+++ b/packages/governance/src/paramGovernance/governParam.js
@@ -3,7 +3,7 @@
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 import { makePromiseKit } from '@agoric/promise-kit';
-import { sameStructure } from '@agoric/same-structure';
+import { keyEQ } from '@agoric/store';
 
 import {
   ChoiceMethod,
@@ -142,7 +142,7 @@ const setupGovernance = async (
     E(counterPublicFacet)
       .getOutcome()
       .then(outcome => {
-        if (sameStructure(positive, outcome)) {
+        if (keyEQ(positive, outcome)) {
           E(paramMgr)
             [`update${(paramSpec.parameterName)}`](proposedValue)
             .then(newValue => outcomeOfUpdateP.resolve(newValue))

--- a/packages/governance/src/question.js
+++ b/packages/governance/src/question.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { Far, passStyleOf } from '@agoric/marshal';
-import { sameStructure } from '@agoric/same-structure';
+import { keyEQ } from '@agoric/store';
 import { makeHandle } from '@agoric/zoe/src/makeHandle.js';
 import { Nat } from '@agoric/nat';
 
@@ -101,8 +101,7 @@ const looksLikeIssueForType = (electionType, issue) => {
 };
 
 /** @type {PositionIncluded} */
-const positionIncluded = (positions, p) =>
-  positions.some(e => sameStructure(e, p));
+const positionIncluded = (positions, p) => positions.some(e => keyEQ(e, p));
 
 // QuestionSpec contains the subset of QuestionDetails that can be specified before
 /** @type {LooksLikeClosingRule} */

--- a/packages/governance/test/swingsetTests/committeeBinary/vat-voter.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/vat-voter.js
@@ -3,7 +3,7 @@
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 import { observeIteration } from '@agoric/notifier';
-import { sameStructure } from '@agoric/same-structure';
+import { keyEQ } from '@agoric/store';
 
 const { quote: q } = assert;
 
@@ -14,7 +14,7 @@ const verify = async (log, issue, electoratePublicFacet, instances) => {
     return E(question).getDetails();
   });
   const detailsPlural = await Promise.all(detailsP);
-  const details = detailsPlural.find(d => sameStructure(d.issue, issue));
+  const details = detailsPlural.find(d => keyEQ(d.issue, issue));
 
   const { positions, method, issue: iss, maxChoices } = details;
   log(`verify question from instance: ${q(issue)}, ${q(positions)}, ${method}`);

--- a/packages/governance/test/swingsetTests/contractGovernor/governedContract.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/governedContract.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { sameStructure } from '@agoric/same-structure';
+import { keyEQ } from '@agoric/store';
 
 import { handleParamGovernance } from '../../../src/contractHelper.js';
 import { makeParamManagerBuilder } from '../../../src/paramGovernance/paramManager.js';
@@ -51,7 +51,7 @@ const start = async (zcf, privateArgs) => {
 
   const invitationAmount = getInvitationAmount(CONTRACT_ELECTORATE);
   assert(
-    sameStructure(invitationAmount, electorateParam.value),
+    keyEQ(invitationAmount, electorateParam.value),
     X`electorate amount ${electorateParam.amount} didn't match ${invitationAmount}`,
   );
 

--- a/packages/run-protocol/package.json
+++ b/packages/run-protocol/package.json
@@ -42,7 +42,6 @@
     "@agoric/nat": "^4.1.0",
     "@agoric/notifier": "^0.3.33",
     "@agoric/promise-kit": "^0.2.29",
-    "@agoric/same-structure": "^0.1.29",
     "@agoric/store": "^0.6.8",
     "@agoric/swingset-vat": "^0.24.1",
     "@agoric/zoe": "^0.21.1"

--- a/packages/run-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/run-protocol/src/vaultFactory/vaultFactory.js
@@ -21,7 +21,7 @@ import '@agoric/zoe/src/contracts/exported.js';
 import { E } from '@agoric/eventual-send';
 import '@agoric/governance/src/exported';
 
-import { makeScalarMap } from '@agoric/store';
+import { makeScalarMap, keyEQ } from '@agoric/store';
 import {
   assertProposalShape,
   getAmountOut,
@@ -29,7 +29,6 @@ import {
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { makeRatioFromAmounts } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { AmountMath } from '@agoric/ertp';
-import { sameStructure } from '@agoric/same-structure';
 import { Far } from '@agoric/marshal';
 import { CONTRACT_ELECTORATE } from '@agoric/governance';
 
@@ -79,7 +78,7 @@ export const start = async (zcf, privateArgs) => {
     CONTRACT_ELECTORATE,
   );
   assert(
-    sameStructure(electorateInvAmt, electorateParam.value),
+    keyEQ(electorateInvAmt, electorateParam.value),
     X`electorate amount (${electorateParam.value} didn't match ${electorateInvAmt}`,
   );
 

--- a/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
@@ -1,8 +1,7 @@
 // @ts-check
 
-import { makeWeakStore } from '@agoric/store';
+import { makeWeakStore, keyEQ } from '@agoric/store';
 import { Far } from '@agoric/marshal';
-import { sameStructure } from '@agoric/same-structure';
 
 import { AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { CONTRACT_ELECTORATE, handleParamGovernance } from '@agoric/governance';
@@ -133,7 +132,7 @@ const start = async (zcf, privateArgs) => {
 
   const electorateInvAmt = getInvitationAmount(CONTRACT_ELECTORATE);
   assert(
-    sameStructure(electorateInvAmt, electorateParam.value),
+    keyEQ(electorateInvAmt, electorateParam.value),
     X`electorate amount (${electorateParam.value} didn't match ${electorateInvAmt}`,
   );
 

--- a/packages/run-protocol/test/vaultFactory/swingsetTests/governance/vat-voter.js
+++ b/packages/run-protocol/test/vaultFactory/swingsetTests/governance/vat-voter.js
@@ -3,7 +3,7 @@
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 import { q } from '@agoric/assert';
-import { sameStructure } from '@agoric/same-structure';
+import { keyEQ } from '@agoric/store';
 import {
   validateQuestionFromCounter,
   assertContractElectorate,
@@ -55,7 +55,7 @@ const build = async (log, zoe) => {
             } governor instance`,
           );
 
-          const included = sameStructure(
+          const included = keyEQ(
             ballotDetails.issue.paramSpec,
             issue.paramSpec,
           );

--- a/packages/same-structure/package.json
+++ b/packages/same-structure/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@agoric/assert": "^0.3.15",
     "@agoric/marshal": "^0.5.0",
-    "@agoric/store": "^0.6.7"
+    "@agoric/store": "^0.6.8"
   },
   "devDependencies": {
     "ava": "^3.12.1"

--- a/packages/swingset-runner/demo/zoeTests/vat-bob.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-bob.js
@@ -1,6 +1,6 @@
 import { E } from '@agoric/eventual-send';
 import { assert, details as X } from '@agoric/assert';
-import { sameStructure } from '@agoric/same-structure';
+import { keyEQ } from '@agoric/store';
 import { AmountMath } from '@agoric/ertp';
 import { Far } from '@agoric/marshal';
 import { showPurseBalance, setupIssuers } from './helpers.js';
@@ -233,14 +233,14 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         X`wrong installation`,
       );
       assert(
-        sameStructure(
+        keyEQ(
           harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),
           issuerKeywordRecord,
         ),
         X`issuerKeywordRecord was not as expected`,
       );
-      assert(sameStructure(invitationValue[0].minimumBid, simoleans(3)));
-      assert(sameStructure(invitationValue[0].auctionedAssets, moola(1)));
+      assert(keyEQ(invitationValue[0].minimumBid, simoleans(3)));
+      assert(keyEQ(invitationValue[0].auctionedAssets, moola(1)));
 
       const proposal = harden({
         want: { Asset: moola(1) },
@@ -276,7 +276,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
       assert(installation === installations.atomicSwap, X`wrong installation`);
       assert(
-        sameStructure(
+        keyEQ(
           harden({ Asset: moolaIssuer, Price: simoleanIssuer }),
           issuerKeywordRecord,
         ),
@@ -284,11 +284,11 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       );
 
       assert(
-        sameStructure(invitationValue[0].asset, moola(3)),
+        keyEQ(invitationValue[0].asset, moola(3)),
         X`Alice made a different offer than expected`,
       );
       assert(
-        sameStructure(invitationValue[0].price, simoleans(7)),
+        keyEQ(invitationValue[0].price, simoleans(7)),
         X`Alice made a different offer than expected`,
       );
 
@@ -417,7 +417,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       assert(installation === installations.autoswap, X`wrong installation`);
       const liquidityIssuer = await E(publicFacet).getLiquidityIssuer();
       assert(
-        sameStructure(
+        keyEQ(
           harden({
             Central: moolaIssuer,
             Secondary: simoleanIssuer,

--- a/packages/swingset-runner/demo/zoeTests/vat-carol.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-carol.js
@@ -1,6 +1,6 @@
 import { E } from '@agoric/eventual-send';
 import { assert, details as X } from '@agoric/assert';
-import { sameStructure } from '@agoric/same-structure';
+import { keyEQ } from '@agoric/store';
 import { Far } from '@agoric/marshal';
 import { showPurseBalance, setupIssuers } from './helpers.js';
 
@@ -30,14 +30,14 @@ const build = async (log, zoe, issuers, payments, installations) => {
         X`wrong installation`,
       );
       assert(
-        sameStructure(
+        keyEQ(
           harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),
           issuerKeywordRecord,
         ),
         X`issuerKeywordRecord were not as expected`,
       );
-      assert(sameStructure(invitationValue[0].minimumBid, simoleans(3)));
-      assert(sameStructure(invitationValue[0].auctionedAssets, moola(1)));
+      assert(keyEQ(invitationValue[0].minimumBid, simoleans(3)));
+      assert(keyEQ(invitationValue[0].auctionedAssets, moola(1)));
 
       const proposal = harden({
         want: { Asset: moola(1) },

--- a/packages/swingset-runner/demo/zoeTests/vat-dave.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-dave.js
@@ -1,6 +1,6 @@
 import { E } from '@agoric/eventual-send';
 import { assert, details as X } from '@agoric/assert';
-import { sameStructure } from '@agoric/same-structure';
+import { keyEQ } from '@agoric/store';
 import { AmountMath } from '@agoric/ertp';
 import { Far } from '@agoric/marshal';
 import { showPurseBalance, setupIssuers } from './helpers.js';
@@ -31,14 +31,14 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         X`wrong installation`,
       );
       assert(
-        sameStructure(
+        keyEQ(
           harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),
           issuerKeywordRecord,
         ),
         X`issuerKeywordRecord were not as expected`,
       );
-      assert(sameStructure(invitationValue[0].minimumBid, simoleans(3)));
-      assert(sameStructure(invitationValue[0].auctionedAssets, moola(1)));
+      assert(keyEQ(invitationValue[0].minimumBid, simoleans(3)));
+      assert(keyEQ(invitationValue[0].auctionedAssets, moola(1)));
 
       const proposal = harden({
         want: { Asset: moola(1) },
@@ -91,7 +91,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       );
       assert(installation === installations.atomicSwap, X`wrong installation`);
       assert(
-        sameStructure(
+        keyEQ(
           harden({ Asset: invitationIssuer, Price: bucksIssuer }),
           issuerKeywordRecord,
         ),
@@ -101,13 +101,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       // Dave expects that Bob has already made an offer in the swap
       // with the following rules:
       assert(
-        sameStructure(invitationValue[0].asset, optionAmounts),
+        keyEQ(invitationValue[0].asset, optionAmounts),
         X`asset is the option`,
       );
-      assert(
-        sameStructure(invitationValue[0].price, bucks(1n)),
-        X`price is 1 buck`,
-      );
+      assert(keyEQ(invitationValue[0].price, bucks(1n)), X`price is 1 buck`);
       const optionValue = optionAmounts.value;
       assert(
         optionValue[0].description === 'exerciseOption',

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -26,7 +26,7 @@
     "@agoric/install-ses": "^0.5.29",
     "@agoric/marshal": "^0.5.0",
     "@agoric/nat": "^4.1.0",
-    "@agoric/same-structure": "^0.1.29",
+    "@agoric/store": "^0.6.8",
     "@agoric/stat-logger": "^0.4.24",
     "@agoric/swing-store": "^0.6.3",
     "@agoric/swingset-vat": "^0.24.1",

--- a/packages/vats/package.json
+++ b/packages/vats/package.json
@@ -32,7 +32,6 @@
     "@agoric/notifier": "^0.3.33",
     "@agoric/pegasus": "^0.5.1",
     "@agoric/promise-kit": "^0.2.29",
-    "@agoric/same-structure": "^0.1.29",
     "@agoric/sharing-service": "^0.1.33",
     "@agoric/sparse-ints": "^0.1.24",
     "@agoric/store": "^0.6.8",

--- a/packages/vats/src/bootstrap.js
+++ b/packages/vats/src/bootstrap.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { allComparable } from '@agoric/same-structure';
+import { deeplyFulfilled } from '@agoric/marshal';
 import {
   makeLoopbackProtocolHandler,
   makeEchoConnectionHandler,
@@ -959,7 +959,7 @@ export function buildRootObject(vatPowers, vatParameters) {
       },
     });
 
-    return allComparable(
+    return deeplyFulfilled(
       harden({
         ...(plugin ? { plugin } : {}),
         scratch,

--- a/packages/web-components/test/agoric-wallet-connection.test.js
+++ b/packages/web-components/test/agoric-wallet-connection.test.js
@@ -148,43 +148,43 @@ describe('AgoricWalletConnection', () => {
 
       // Connecting happens instantly with the mock socket,
       // just need to let the event loop run once.
-      await new Promise(resolve => setTimeout(resolve, 10));
+      await new Promise(resolve => setTimeout(resolve, 30));
       expect(el.state).to.equal('bridged');
     });
 
     it('lets the websocket dispatch messages through capTP', async () => {
       iframeOnMessage('http://localhost:8000');
-      await new Promise(resolve => setTimeout(resolve, 10));
+      await new Promise(resolve => setTimeout(resolve, 30));
 
       socket.send(JSON.stringify({ foo: 'bar' }));
-      await new Promise(resolve => setTimeout(resolve, 10));
+      await new Promise(resolve => setTimeout(resolve, 30));
 
       expect(captpInnards.lastDispatched).to.deep.equal({ foo: 'bar' });
     });
 
     it('lets capTP send messages through the websocket', async () => {
       iframeOnMessage('http://localhost:8000');
-      await new Promise(resolve => setTimeout(resolve, 10));
+      await new Promise(resolve => setTimeout(resolve, 30));
 
       captpInnards.send({ foo: 'bar2' });
-      await new Promise(resolve => setTimeout(resolve, 10));
+      await new Promise(resolve => setTimeout(resolve, 30));
 
       expect(lastMessage).to.equal(JSON.stringify({ foo: 'bar2' }));
     });
 
     it('aborts capTP when the socket disconnects', async () => {
       iframeOnMessage('http://localhost:8000');
-      await new Promise(resolve => setTimeout(resolve, 10));
+      await new Promise(resolve => setTimeout(resolve, 30));
 
       socket.close();
 
-      await new Promise(resolve => setTimeout(resolve, 10));
+      await new Promise(resolve => setTimeout(resolve, 30));
       expect(captpInnards.isAborted).to.equal(true);
     });
 
     it('returns the admin bootstrap', async () => {
       iframeOnMessage('http://localhost:8000');
-      await new Promise(resolve => setTimeout(resolve, 10));
+      await new Promise(resolve => setTimeout(resolve, 30));
 
       expect(await adminBootstrap).to.deep.equal({ isAdmin: true });
     });

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -52,7 +52,6 @@
     "@agoric/nat": "^4.1.0",
     "@agoric/notifier": "^0.3.33",
     "@agoric/promise-kit": "^0.2.29",
-    "@agoric/same-structure": "^0.1.29",
     "@agoric/store": "^0.6.8",
     "@agoric/swingset-vat": "^0.24.1"
   },

--- a/packages/zoe/src/contractSupport/zoeHelpers.js
+++ b/packages/zoe/src/contractSupport/zoeHelpers.js
@@ -2,10 +2,9 @@
 import '../../exported.js';
 
 import { assert, details as X } from '@agoric/assert';
-import { sameStructure } from '@agoric/same-structure';
+import { keyEQ, fit } from '@agoric/store';
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
-import { fit } from '@agoric/store';
 import { AssetKind } from '@agoric/ertp';
 import { satisfiesWant } from '../contractFacet/offerSafety.js';
 
@@ -20,7 +19,7 @@ export const assertIssuerKeywords = (zcf, expected) => {
   expected = [...expected]; // in case hardened
   expected.sort();
   assert(
-    sameStructure(actual, harden(expected)),
+    keyEQ(actual, harden(expected)),
     X`keywords: ${actual} were not as expected: ${expected}`,
   );
 };
@@ -148,7 +147,7 @@ export const assertProposalShape = (seat, expected) => {
   const assertKeys = (a, e) => {
     if (e !== undefined) {
       assert(
-        sameStructure(getKeysSorted(a), getKeysSorted(e)),
+        keyEQ(getKeysSorted(a), getKeysSorted(e)),
         X`actual ${a} did not match expected ${e}`,
       );
     }

--- a/packages/zoe/test/swingsetTests/zoe/vat-bob.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-bob.js
@@ -3,7 +3,7 @@
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
-import { sameStructure } from '@agoric/same-structure';
+import { keyEQ } from '@agoric/store';
 import { AmountMath, isSetValue } from '@agoric/ertp';
 
 import { showPurseBalance, setupIssuers } from '../helpers.js';
@@ -234,14 +234,14 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         X`wrong installation`,
       );
       assert(
-        sameStructure(
+        keyEQ(
           harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),
           issuerKeywordRecord,
         ),
         X`issuerKeywordRecord was not as expected`,
       );
-      assert(sameStructure(invitationValue[0].minimumBid, simoleans(3n)));
-      assert(sameStructure(invitationValue[0].auctionedAssets, moola(1n)));
+      assert(keyEQ(invitationValue[0].minimumBid, simoleans(3n)));
+      assert(keyEQ(invitationValue[0].auctionedAssets, moola(1n)));
 
       const proposal = harden({
         want: { Asset: moola(1n) },
@@ -277,7 +277,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
       assert(installation === installations.atomicSwap, X`wrong installation`);
       assert(
-        sameStructure(
+        keyEQ(
           harden({ Asset: moolaIssuer, Price: simoleanIssuer }),
           issuerKeywordRecord,
         ),
@@ -285,11 +285,11 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       );
 
       assert(
-        sameStructure(invitationValue[0].asset, moola(3n)),
+        keyEQ(invitationValue[0].asset, moola(3n)),
         X`Alice made a different offer than expected`,
       );
       assert(
-        sameStructure(invitationValue[0].price, simoleans(7n)),
+        keyEQ(invitationValue[0].price, simoleans(7n)),
         X`Alice made a different offer than expected`,
       );
 
@@ -418,7 +418,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       assert(installation === installations.autoswap, X`wrong installation`);
       const liquidityIssuer = await E(publicFacet).getLiquidityIssuer();
       assert(
-        sameStructure(
+        keyEQ(
           harden({
             Central: moolaIssuer,
             Secondary: simoleanIssuer,

--- a/packages/zoe/test/swingsetTests/zoe/vat-carol.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-carol.js
@@ -3,7 +3,7 @@
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
-import { sameStructure } from '@agoric/same-structure';
+import { keyEQ } from '@agoric/store';
 import { showPurseBalance, setupIssuers } from '../helpers.js';
 
 const build = async (log, zoe, issuers, payments, installations) => {
@@ -30,14 +30,14 @@ const build = async (log, zoe, issuers, payments, installations) => {
         X`wrong installation`,
       );
       assert(
-        sameStructure(
+        keyEQ(
           harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),
           issuerKeywordRecord,
         ),
         X`issuerKeywordRecord were not as expected`,
       );
-      assert(sameStructure(invitationValue[0].minimumBid, simoleans(3n)));
-      assert(sameStructure(invitationValue[0].auctionedAssets, moola(1n)));
+      assert(keyEQ(invitationValue[0].minimumBid, simoleans(3n)));
+      assert(keyEQ(invitationValue[0].auctionedAssets, moola(1n)));
 
       const proposal = harden({
         want: { Asset: moola(1n) },

--- a/packages/zoe/test/swingsetTests/zoe/vat-dave.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-dave.js
@@ -3,7 +3,7 @@
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
-import { sameStructure } from '@agoric/same-structure';
+import { keyEQ } from '@agoric/store';
 import { AmountMath } from '@agoric/ertp';
 import { showPurseBalance, setupIssuers } from '../helpers.js';
 
@@ -31,14 +31,14 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
         X`wrong installation`,
       );
       assert(
-        sameStructure(
+        keyEQ(
           harden({ Asset: moolaIssuer, Ask: simoleanIssuer }),
           issuerKeywordRecord,
         ),
         X`issuerKeywordRecord were not as expected`,
       );
-      assert(sameStructure(invitationValue[0].minimumBid, simoleans(3n)));
-      assert(sameStructure(invitationValue[0].auctionedAssets, moola(1n)));
+      assert(keyEQ(invitationValue[0].minimumBid, simoleans(3n)));
+      assert(keyEQ(invitationValue[0].auctionedAssets, moola(1n)));
 
       const proposal = harden({
         want: { Asset: moola(1n) },
@@ -84,7 +84,7 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
 
       assert(installation === installations.atomicSwap, X`wrong installation`);
       assert(
-        sameStructure(
+        keyEQ(
           harden({ Asset: invitationIssuer, Price: bucksIssuer }),
           issuerKeywordRecord,
         ),
@@ -94,13 +94,10 @@ const build = async (log, zoe, issuers, payments, installations, timer) => {
       // Dave expects that Bob has already made an offer in the swap
       // with the following rules:
       assert(
-        sameStructure(invitationValue[0].asset, optionAmounts),
+        keyEQ(invitationValue[0].asset, optionAmounts),
         X`asset is the option`,
       );
-      assert(
-        sameStructure(invitationValue[0].price, bucks(1n)),
-        X`price is 1 buck`,
-      );
+      assert(keyEQ(invitationValue[0].price, bucks(1n)), X`price is 1 buck`);
       const optionValue = optionAmounts.value;
       assert(
         optionValue[0].description === 'exerciseOption',

--- a/packages/zoe/test/unitTests/contracts/test-coveredCall-want-pattern.js
+++ b/packages/zoe/test/unitTests/contracts/test-coveredCall-want-pattern.js
@@ -6,9 +6,8 @@ import path from 'path';
 
 import bundleSource from '@agoric/bundle-source';
 import { E } from '@agoric/eventual-send';
-import { M, fit } from '@agoric/store';
+import { M, fit, keyEQ } from '@agoric/store';
 import { AmountMath, AssetKind } from '@agoric/ertp';
-import { sameStructure } from '@agoric/same-structure';
 
 import buildManualTimer from '../../../tools/manualTimer.js';
 import { setup } from '../setupBasicMints.js';
@@ -161,7 +160,7 @@ test('zoe - coveredCall with swap for invitation', async t => {
 
   // Is this swap for the correct issuers and has no other terms? Yes
   t.truthy(
-    sameStructure(
+    keyEQ(
       daveSwapIssuers,
       harden({
         Asset: invitationIssuer,

--- a/packages/zoe/test/unitTests/contracts/test-coveredCall.js
+++ b/packages/zoe/test/unitTests/contracts/test-coveredCall.js
@@ -8,7 +8,7 @@ import bundleSource from '@agoric/bundle-source';
 import { E } from '@agoric/eventual-send';
 import { Far } from '@agoric/marshal';
 import { AmountMath, AssetKind } from '@agoric/ertp';
-import { sameStructure } from '@agoric/same-structure';
+import { keyEQ } from '@agoric/store';
 
 import buildManualTimer from '../../../tools/manualTimer.js';
 import { setup } from '../setupBasicMints.js';
@@ -480,7 +480,7 @@ test('zoe - coveredCall with swap for invitation', async t => {
 
   // Is this swap for the correct issuers and has no other terms? Yes
   t.truthy(
-    sameStructure(
+    keyEQ(
       daveSwapIssuers,
       harden({
         Asset: invitationIssuer,


### PR DESCRIPTION
The same-structure package is now vestigial and all its exports are now deprecated. Fix all uses in agoric-sdk to the recommended binding instead, and remove same-structure from those package's dependencies.