### PR TITLE
refactor: Relax internal dependencies

### DIFF
--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -37,7 +37,6 @@
   },
   "devDependencies": {
     "@agoric/install-ses": "^0.5.29",
-    "@agoric/swingset-vat": "^0.24.1",
     "@endo/ses-ava": "^0.2.13",
     "ava": "^3.12.1",
     "c8": "^7.7.2"

--- a/packages/captp/package.json
+++ b/packages/captp/package.json
@@ -43,7 +43,6 @@
     "c8": "^7.7.2"
   },
   "dependencies": {
-    "@agoric/assert": "^0.3.15",
     "@agoric/eventual-send": "^0.14.0",
     "@agoric/marshal": "^0.5.0",
     "@agoric/nat": "^4.1.0",

--- a/packages/captp/src/atomics.js
+++ b/packages/captp/src/atomics.js
@@ -1,7 +1,8 @@
 // @ts-check
 /* global BigUint64Array */
+/// <reference types="ses"/>
 
-import { assert, details as X } from '@agoric/assert';
+const { details: X } = assert;
 
 // This is a pathological minimum, but exercised by the unit test.
 export const MIN_DATA_BUFFER_LENGTH = 1;

--- a/packages/captp/src/captp.js
+++ b/packages/captp/src/captp.js
@@ -1,4 +1,5 @@
 // @ts-check
+/// <reference types="ses"/>
 
 // Your app may need to `import '@agoric/eventual-send/shim'` to get HandledPromise
 
@@ -7,13 +8,14 @@
 import { Remotable, Far, makeMarshal, QCLASS } from '@agoric/marshal';
 import { E, HandledPromise } from '@agoric/eventual-send';
 import { isPromise, makePromiseKit } from '@agoric/promise-kit';
-import { assert, details as X } from '@agoric/assert';
 
 import { makeTrap } from './trap.js';
 
 import './types.js';
 
 export { E };
+
+const { details: X } = assert;
 
 /**
  * @param {any} maybeThenable

--- a/packages/captp/test/traplib.js
+++ b/packages/captp/test/traplib.js
@@ -1,11 +1,13 @@
 // @ts-check
 /* global setTimeout */
+/// <reference types="ses"/>
 
-import { assert, details as X } from '@agoric/assert';
 import { Far } from '@agoric/marshal';
 import { E, makeCapTP } from '../src/captp.js';
 
 import { makeAtomicsTrapGuest, makeAtomicsTrapHost } from '../src/atomics.js';
+
+const { details: X } = assert;
 
 export const createHostBootstrap = makeTrapHandler => {
   // Create a remotable that has a syncable return value.

--- a/packages/captp/test/worker.js
+++ b/packages/captp/test/worker.js
@@ -1,10 +1,12 @@
+/// <reference types="ses"/>
+
 import '@agoric/install-ses/pre-remoting.js';
 import '@agoric/install-ses/debug.js';
 
-import { assert, details as X } from '@agoric/assert';
-
 import { parentPort } from 'worker_threads';
 import { makeGuest, makeHost } from './traplib.js';
+
+const { details: X } = assert;
 
 let dispatch;
 parentPort.addListener('message', obj => {

--- a/packages/eventual-send/package.json
+++ b/packages/eventual-send/package.json
@@ -27,7 +27,6 @@
   },
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "devDependencies": {
-    "@agoric/assert": "^0.3.15",
     "@agoric/lockdown": "^0.1.1",
     "@endo/ses-ava": "^0.2.13",
     "ava": "^3.12.1",

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -24,7 +24,6 @@
   "devDependencies": {
     "@agoric/bundle-source": "^2.0.1",
     "@agoric/install-ses": "^0.5.29",
-    "@agoric/swingset-vat": "^0.24.1",
     "@endo/ses-ava": "^0.2.13",
     "ava": "^3.12.1",
     "c8": "^7.7.2"

--- a/packages/import-bundle/package.json
+++ b/packages/import-bundle/package.json
@@ -18,7 +18,6 @@
     "lint": "eslint '**/*.js'"
   },
   "dependencies": {
-    "@agoric/assert": "^0.3.15",
     "@endo/base64": "^0.2.13",
     "@endo/compartment-mapper": "^0.6.1"
   },

--- a/packages/import-bundle/src/index.js
+++ b/packages/import-bundle/src/index.js
@@ -1,9 +1,11 @@
 /* global globalThis */
+/// <reference types="ses"/>
 
 import { parseArchive } from '@endo/compartment-mapper/import-archive.js';
 import { decodeBase64 } from '@endo/base64';
-import { assert, details as X } from '@agoric/assert';
 import { wrapInescapableCompartment } from './compartment-wrapper.js';
+
+const { details: X } = assert;
 
 // importBundle takes the output of bundle-source, and returns a namespace
 // object (with .default, and maybe other properties for named exports)

--- a/packages/import-bundle/test/test-compartment-wrapper.js
+++ b/packages/import-bundle/test/test-compartment-wrapper.js
@@ -1,7 +1,10 @@
+/// <reference types="ses"/>
+
 import { test } from './prepare-test-env-ava.js';
 // eslint-disable-next-line import/order
-import { assert, details as X } from '@agoric/assert';
 import { wrapInescapableCompartment } from '../src/compartment-wrapper.js';
+
+const { details: X } = assert;
 
 // We build a transform that allows oldSrc to increment the odometer, but not
 // read it. Note, of course, that SES provides a far easier way to accomplish

--- a/packages/marshal/package.json
+++ b/packages/marshal/package.json
@@ -34,7 +34,6 @@
   },
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "dependencies": {
-    "@agoric/assert": "^0.3.15",
     "@agoric/eventual-send": "^0.14.0",
     "@agoric/nat": "^4.1.0",
     "@agoric/promise-kit": "^0.2.29"

--- a/packages/marshal/src/dot-membrane.js
+++ b/packages/marshal/src/dot-membrane.js
@@ -4,7 +4,6 @@
 // eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
-import { assert, details as X } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
 import { isObject } from './helpers/passStyle-helpers.js';
 import { getInterfaceOf } from './helpers/remotable.js';
@@ -14,6 +13,7 @@ import { passStyleOf } from './passStyleOf.js';
 
 const { fromEntries } = Object;
 const { ownKeys } = Reflect;
+const { details: X } = assert;
 
 const makeConverter = (mirrorConverter = undefined) => {
   /** @type {WeakMap<any,any>=} */

--- a/packages/marshal/src/helpers/copyArray.js
+++ b/packages/marshal/src/helpers/copyArray.js
@@ -5,7 +5,6 @@
 
 import '../types.js';
 import './internal-types.js';
-import '@agoric/assert/exported.js';
 import { assertChecker, checkNormalProperty } from './passStyle-helpers.js';
 
 const { details: X } = assert;

--- a/packages/marshal/src/helpers/copyRecord.js
+++ b/packages/marshal/src/helpers/copyRecord.js
@@ -11,7 +11,6 @@ import {
 
 import '../types.js';
 import './internal-types.js';
-import '@agoric/assert/exported.js';
 
 const { details: X } = assert;
 const { ownKeys } = Reflect;

--- a/packages/marshal/src/helpers/error.js
+++ b/packages/marshal/src/helpers/error.js
@@ -5,7 +5,6 @@
 
 import '../types.js';
 import './internal-types.js';
-import '@agoric/assert/exported.js';
 import { assertChecker } from './passStyle-helpers.js';
 
 const { details: X } = assert;

--- a/packages/marshal/src/helpers/passStyle-helpers.js
+++ b/packages/marshal/src/helpers/passStyle-helpers.js
@@ -5,7 +5,6 @@
 
 import '../types.js';
 import './internal-types.js';
-import '@agoric/assert/exported.js';
 
 const { details: X, quote: q } = assert;
 const {

--- a/packages/marshal/src/helpers/remotable.js
+++ b/packages/marshal/src/helpers/remotable.js
@@ -5,7 +5,6 @@
 
 import '../types.js';
 import './internal-types.js';
-import '@agoric/assert/exported.js';
 import {
   assertChecker,
   canBeMethod,

--- a/packages/marshal/src/helpers/tagged.js
+++ b/packages/marshal/src/helpers/tagged.js
@@ -12,7 +12,6 @@ import {
 
 import '../types.js';
 import './internal-types.js';
-import '@agoric/assert/exported.js';
 
 const { details: X } = assert;
 const { ownKeys } = Reflect;

--- a/packages/marshal/src/make-far.js
+++ b/packages/marshal/src/make-far.js
@@ -3,7 +3,6 @@
 // eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
-import { assert, details as X, q } from '@agoric/assert';
 import { assertChecker, PASS_STYLE } from './helpers/passStyle-helpers.js';
 import {
   assertIface,
@@ -11,6 +10,8 @@ import {
   RemotableHelper,
 } from './helpers/remotable.js';
 import { pureCopy } from './pureCopy.js';
+
+const { quote: q, details: X } = assert;
 
 const { prototype: functionPrototype } = Function;
 const {

--- a/packages/marshal/src/makeTagged.js
+++ b/packages/marshal/src/makeTagged.js
@@ -3,11 +3,11 @@
 // eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
-import { assert, details as X } from '@agoric/assert';
 import { PASS_STYLE } from './helpers/passStyle-helpers.js';
 import { assertPassable } from './passStyleOf.js';
 
 const { create, prototype: objectPrototype } = Object;
+const { details: X } = assert;
 
 export const makeTagged = (tag, payload) => {
   assert.typeof(

--- a/packages/marshal/src/marshal-justin.js
+++ b/packages/marshal/src/marshal-justin.js
@@ -4,7 +4,6 @@
 /// <reference types="ses"/>
 
 import { Nat } from '@agoric/nat';
-import { assert, details as X, q } from '@agoric/assert';
 import { QCLASS } from './marshal.js';
 
 import './types.js';
@@ -15,6 +14,7 @@ import { AtAtPrefixPattern, passableSymbolForName } from './helpers/symbol.js';
 const { ownKeys } = Reflect;
 const { isArray } = Array;
 const { stringify: quote } = JSON;
+const { quote: q, details: X } = assert;
 
 /**
  * @typedef {Object} Indenter

--- a/packages/marshal/src/marshal-stringify.js
+++ b/packages/marshal/src/marshal-stringify.js
@@ -1,9 +1,11 @@
 // @ts-check
+/// <reference types="ses"/>
 
-import { assert, details as X } from '@agoric/assert';
 import { makeMarshal } from './marshal.js';
 
 import './types.js';
+
+const { details: X } = assert;
 
 /** @type {ConvertValToSlot<any>} */
 const doNotConvertValToSlot = val =>

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -396,6 +396,10 @@ export function makeMarshal(
               errorId === undefined
                 ? `Remote${EC.name}`
                 : `Remote${EC.name}(${errorId})`;
+            // Due to a defect in the SES type definition, the next line is
+            // fails a type check.
+            // Pending https://github.com/endojs/endo/issues/977
+            // @ts-ignore-next-line
             const error = assert.error(`${message}`, EC, { errorName });
             return error;
           }

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -4,7 +4,6 @@
 /// <reference types="ses"/>
 
 import { Nat } from '@agoric/nat';
-import { assert, details as X, q } from '@agoric/assert';
 import { passStyleOf } from './passStyleOf.js';
 
 import './types.js';
@@ -21,6 +20,7 @@ import {
 const { ownKeys } = Reflect;
 const { isArray } = Array;
 const { getOwnPropertyDescriptors, defineProperties, is, fromEntries } = Object;
+const { details: X, quote: q } = assert;
 
 /**
  * Special property name that indicates an encoding that needs special

--- a/packages/marshal/src/pureCopy.js
+++ b/packages/marshal/src/pureCopy.js
@@ -1,11 +1,11 @@
 // @ts-check
 
-import { assert, details as X, q } from '@agoric/assert';
 import { getTag } from './helpers/passStyle-helpers.js';
 import { makeTagged } from './makeTagged.js';
 import { passStyleOf } from './passStyleOf.js';
 
 const { is } = Object;
+const { details: X, quote: q } = assert;
 
 /**
  * This is the equality comparison used by JavaScript's Map and Set


### PR DESCRIPTION
In preparation for motion to Endo, this change relaxes some dependencies. In order to avoid having to create an `@endo/assert`, one commit refactors existing code to depend on the global instead of the module, and using the SES ambient types. The remaining two commits remove the dependency on swingset-vat from the package.jsons of captp and import-bundle, neither of which ever import swingset-vat. https://github.com/endojs/endo/issues/506