### PR TITLE
Sanitise use of Cosmos helper

### DIFF
--- a/packages/agoric-cli/src/helpers.js
+++ b/packages/agoric-cli/src/helpers.js
@@ -61,7 +61,7 @@ export const makePspawn = ({
       return args.join(' ');
     };
 
-    log.log(color('blueBright', cmd, ...cargs));
+    log.warn(color('blueBright', cmd, ...cargs));
     const cp = spawn(cmd, cargs, { stdio, env, ...rest });
     const pr = new Promise((resolve, _reject) => {
       cp.on('exit', resolve);

--- a/packages/agoric-cli/src/start.js
+++ b/packages/agoric-cli/src/start.js
@@ -462,6 +462,25 @@ export default async function startMain(progname, rawArgs, powers, opts) {
         );
     }
 
+    // Initialise the solo directory and key.
+    if (!(await exists(agServer))) {
+      const initArgs = [`--webport=${portNum}`];
+      if (opts.dockerTag) {
+        initArgs.push(`--webhost=0.0.0.0`);
+      }
+      const exitStatus = await soloSpawn(
+        ['init', agServer, ...initArgs],
+        undefined,
+        [`--workdir=/usr/src/dapp`],
+      );
+      if (exitStatus) {
+        return exitStatus;
+      }
+    }
+    if (!opts.restart) {
+      return 0;
+    }
+
     const gciFile = `_agstate/agoric-servers/local-chain-${CHAIN_PORT}/config/genesis.json.sha256`;
     process.stdout.write(`Waiting for local-chain-${CHAIN_PORT} to start...`);
     let hasGci = false;
@@ -486,22 +505,6 @@ export default async function startMain(progname, rawArgs, powers, opts) {
       });
     }
     process.stdout.write('\n');
-
-    // Initialise the solo directory and key.
-    if (!(await exists(agServer))) {
-      const initArgs = [`--webport=${portNum}`];
-      if (opts.dockerTag) {
-        initArgs.push(`--webhost=0.0.0.0`);
-      }
-      const exitStatus = await soloSpawn(
-        ['init', agServer, ...initArgs],
-        undefined,
-        [`--workdir=/usr/src/dapp`],
-      );
-      if (exitStatus) {
-        return exitStatus;
-      }
-    }
 
     const spawnOpts = {};
     if (!popts.dockerTag) {

--- a/packages/agoric-cli/src/start.js
+++ b/packages/agoric-cli/src/start.js
@@ -61,16 +61,16 @@ export default async function startMain(progname, rawArgs, powers, opts) {
     nodeDebugEnv.SWINGSET_WORKER_TYPE = 'local';
   }
 
-  const agServersPrefix = opts.sdk
-    ? undefined
-    : path.resolve(`node_modules/@agoric`);
-  const getBinaries = opts.sdk
-    ? getSDKBinaries
-    : () => getSDKBinaries({ goPfx: agServersPrefix, jsPfx: agServersPrefix });
+  const sdkPrefixes = {};
+  if (!opts.sdk) {
+    const agoricPrefix = path.resolve(`node_modules/@agoric`);
+    sdkPrefixes.goPfx = agoricPrefix;
+    sdkPrefixes.jsPfx = agoricPrefix;
+  }
 
   let keysSpawn;
   if (!opts.dockerTag) {
-    const { cosmosHelper } = getBinaries();
+    const { cosmosHelper } = getSDKBinaries(sdkPrefixes);
     keysSpawn = (args, ...rest) =>
       pspawn(cosmosHelper, [`--home=_agstate/keys`, ...args], ...rest);
   } else {
@@ -141,7 +141,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
   if (opts.dockerTag) {
     agSolo = `ag-solo`;
   } else {
-    ({ agSolo, agSoloBuild } = getBinaries());
+    ({ agSolo, agSoloBuild } = getSDKBinaries(sdkPrefixes));
   }
 
   async function startFakeChain(profileName, _startArgs, popts) {
@@ -215,7 +215,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
       return 1;
     }
 
-    const { cosmosChain, cosmosChainBuild } = getBinaries();
+    const { cosmosChain, cosmosChainBuild } = getSDKBinaries(sdkPrefixes);
     if (popts.pull || popts.rebuild) {
       if (popts.dockerTag) {
         const exitStatus = await pspawn('docker', ['pull', SDK_IMAGE]);
@@ -407,7 +407,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
 
     const agServer = `_agstate/agoric-servers/${profileName}-${portNum}`;
 
-    const { cosmosClientBuild } = getBinaries();
+    const { cosmosClientBuild } = getSDKBinaries(sdkPrefixes);
     if (popts.pull || popts.rebuild) {
       if (popts.dockerTag) {
         const exitStatus = await pspawn('docker', ['pull', SDK_IMAGE]);


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description

A few little changes to make our Cosmos solo handling clearer.  Can be reviewed commit-by-commit.

Notably, `agoric cosmos ...` now works consistently with the `--sdk` and `--docker-tag` flags.  Also, leave behind an `ag-solo-mnemonic` file that will be used by CosmJS support.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

Makes the `ag-solo` ephemeral key recoverable via its mnemonic.  This doesn't really change the security profile, as the mnemonic is not reused elsewhere.

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

We should encourage people to use `agoric cosmos ...` instead of direct use of `agd ...`.

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
