### PR TITLE
fix: minor, from purple

### DIFF
--- a/packages/marshal/src/helpers/error.js
+++ b/packages/marshal/src/helpers/error.js
@@ -52,7 +52,7 @@ export const ErrorHelper = harden({
       return check(false, X`Error expected: ${candidate}`);
     }
     const proto = getPrototypeOf(candidate);
-    const { name } = candidate;
+    const { name } = proto;
     const EC = getErrorConstructor(name);
     if (!EC || EC.prototype !== proto) {
       const note = X`Errors must inherit from an error class .prototype ${candidate}`;
@@ -62,6 +62,7 @@ export const ErrorHelper = harden({
     }
 
     const {
+      // Must allow `cause`, `errors`
       message: mDesc,
       // Allow but ignore only extraneous own `stack` property.
       stack: _optStackDesc,

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -77,6 +77,7 @@ export function makeMarshal(
     function serializeSlot(val, iface = undefined) {
       let slotIndex;
       if (slotMap.has(val)) {
+        // TODO assert that it's the same iface as before
         slotIndex = slotMap.get(val);
         assert.typeof(slotIndex, 'number');
         iface = undefined;
@@ -88,6 +89,7 @@ export function makeMarshal(
         slotMap.set(val, slotIndex);
       }
 
+      // TODO explore removing this special case
       if (iface === undefined) {
         return harden({
           [QCLASS]: 'slot',
@@ -122,6 +124,8 @@ export function makeMarshal(
         const errorId = nextErrorId();
         assert.note(err, X`Sent as ${errorId}`);
         marshalSaveError(err);
+        // Must encode `cause`, `errors`.
+        // nested non-passable errors must be ok from here.
         return harden({
           [QCLASS]: 'error',
           errorId,
@@ -278,6 +282,8 @@ export function makeMarshal(
       if (valMap.has(index)) {
         return valMap.get(index);
       }
+      // TODO SECURITY HAZARD: must enfoce that remotable vs promise
+      // is according to the encoded string.
       const slot = slots[Number(Nat(index))];
       const val = convertSlotToVal(slot, iface);
       valMap.set(index, val);
@@ -378,6 +384,7 @@ export function makeMarshal(
           }
 
           case 'error': {
+            // Must decode `cause` and `errors` properties
             const { name, message, errorId } = rawTree;
             assert.typeof(
               name,

--- a/packages/store/src/stores/scalarMapStore.js
+++ b/packages/store/src/stores/scalarMapStore.js
@@ -133,14 +133,14 @@ export const makeMapStoreMethods = (
  */
 export const makeScalarMapStore = (
   keyName = 'key',
-  { keySchema = undefined, valueSchema = undefined } = {},
+  { keyPattern = undefined, valuePattern = undefined } = {},
 ) => {
   const jsmap = new Map();
-  if (keySchema !== undefined) {
-    assertPattern(keySchema);
+  if (keyPattern !== undefined) {
+    assertPattern(keyPattern);
   }
-  if (valueSchema !== undefined) {
-    assertPattern(valueSchema);
+  if (valuePattern !== undefined) {
+    assertPattern(valuePattern);
   }
 
   const assertKVOkToSet = (_key, value) => {
@@ -149,8 +149,8 @@ export const makeScalarMapStore = (
     harden(value);
 
     assertPassable(value);
-    if (valueSchema !== undefined) {
-      fit(value, valueSchema);
+    if (valuePattern !== undefined) {
+      fit(value, valuePattern);
     }
   };
 
@@ -160,8 +160,8 @@ export const makeScalarMapStore = (
     harden(key);
 
     assertScalarKey(key);
-    if (keySchema !== undefined) {
-      fit(key, keySchema);
+    if (keyPattern !== undefined) {
+      fit(key, keyPattern);
     }
     assertKVOkToSet(key, value);
   };

--- a/packages/store/src/stores/scalarSetStore.js
+++ b/packages/store/src/stores/scalarSetStore.js
@@ -89,11 +89,11 @@ export const makeSetStoreMethods = (
  */
 export const makeScalarSetStore = (
   keyName = 'key',
-  { keySchema = undefined } = {},
+  { keyPattern = undefined } = {},
 ) => {
   const jsset = new Set();
-  if (keySchema !== undefined) {
-    assertPattern(keySchema);
+  if (keyPattern !== undefined) {
+    assertPattern(keyPattern);
   }
 
   const assertKeyOkToAdd = key => {
@@ -102,8 +102,8 @@ export const makeScalarSetStore = (
     harden(key);
 
     assertScalarKey(key);
-    if (keySchema !== undefined) {
-      fit(key, keySchema);
+    if (keyPattern !== undefined) {
+      fit(key, keyPattern);
     }
   };
 

--- a/packages/store/src/stores/scalarWeakMapStore.js
+++ b/packages/store/src/stores/scalarWeakMapStore.js
@@ -88,14 +88,14 @@ export const makeWeakMapStoreMethods = (
  */
 export const makeScalarWeakMapStore = (
   keyName = 'key',
-  { longLived = true, keySchema = undefined, valueSchema = undefined } = {},
+  { longLived = true, keyPattern = undefined, valuePattern = undefined } = {},
 ) => {
   const jsmap = new (longLived ? WeakMap : Map)();
-  if (keySchema !== undefined) {
-    assertPattern(keySchema);
+  if (keyPattern !== undefined) {
+    assertPattern(keyPattern);
   }
-  if (valueSchema !== undefined) {
-    assertPattern(valueSchema);
+  if (valuePattern !== undefined) {
+    assertPattern(valuePattern);
   }
 
   const assertKVOkToSet = (_key, value) => {
@@ -104,8 +104,8 @@ export const makeScalarWeakMapStore = (
     harden(value);
 
     assertPassable(value);
-    if (valueSchema !== undefined) {
-      fit(value, valueSchema);
+    if (valuePattern !== undefined) {
+      fit(value, valuePattern);
     }
   };
 
@@ -118,8 +118,8 @@ export const makeScalarWeakMapStore = (
       passStyleOf(key) === 'remotable',
       X`Only remotables can be keys of scalar WeakMapStores: ${key}`,
     );
-    if (keySchema !== undefined) {
-      fit(key, keySchema);
+    if (keyPattern !== undefined) {
+      fit(key, keyPattern);
     }
     assertKVOkToSet(key, value);
   };

--- a/packages/store/src/stores/scalarWeakSetStore.js
+++ b/packages/store/src/stores/scalarWeakSetStore.js
@@ -70,11 +70,11 @@ export const makeWeakSetStoreMethods = (
  */
 export const makeScalarWeakSetStore = (
   keyName = 'key',
-  { longLived = true, keySchema = undefined } = {},
+  { longLived = true, keyPattern = undefined } = {},
 ) => {
   const jsset = new (longLived ? WeakSet : Set)();
-  if (keySchema !== undefined) {
-    assertPattern(keySchema);
+  if (keyPattern !== undefined) {
+    assertPattern(keyPattern);
   }
 
   const assertKeyOkToAdd = key => {
@@ -86,8 +86,8 @@ export const makeScalarWeakSetStore = (
       passStyleOf(key) === 'remotable',
       X`Only remotables can be keys of scalar WeakStores: ${key}`,
     );
-    if (keySchema !== undefined) {
-      fit(key, keySchema);
+    if (keyPattern !== undefined) {
+      fit(key, keyPattern);
     }
   };
 

--- a/packages/store/src/types.js
+++ b/packages/store/src/types.js
@@ -84,8 +84,8 @@
  * case we internally may use a JavaScript `WeakMap`. Otherwise we internally
  * may use a JavaScript `Map`.
  * Defaults to true, so please mark short lived stores explicitly.
- * @property {Pattern=} keySchema
- * @property {Pattern=} valueSchema
+ * @property {Pattern=} keyPattern
+ * @property {Pattern=} valuePattern
  */
 
 /**

--- a/packages/zoe/src/zoeService/escrowStorage.js
+++ b/packages/zoe/src/zoeService/escrowStorage.js
@@ -70,7 +70,7 @@ export const makeEscrowStorage = () => {
    * @param {Amount} amount
    * @returns {Promise<Amount>}
    */
-  const doDepositPayments = (paymentP, amount) => {
+  const doDepositPayment = (paymentP, amount) => {
     const purse = brandToPurse.get(amount.brand);
     return E.when(paymentP, payment => E(purse).deposit(payment, amount));
   };
@@ -88,7 +88,6 @@ export const makeEscrowStorage = () => {
     // keywords. Proposal.give keywords that do not have matching payments will
     // be caught in the deposit step.
     paymentKeywords.forEach(keyword => {
-      assert.typeof(keyword, 'string');
       assert(
         giveKeywords.includes(keyword),
         X`The ${q(
@@ -118,7 +117,7 @@ export const makeEscrowStorage = () => {
             paymentKeywords,
           )}`,
         );
-        return doDepositPayments(payments[keyword], give[keyword]);
+        return doDepositPayment(payments[keyword], give[keyword]);
       }),
     );
 

--- a/packages/zoe/src/zoeService/offer/offer.js
+++ b/packages/zoe/src/zoeService/offer/offer.js
@@ -18,7 +18,7 @@ const { details: X, quote: q } = assert;
  * @param {GetAssetKindByBrand} getAssetKindByBrand
  * @returns {Offer}
  */
-export const makeOffer = (
+export const makeOfferMethod = (
   invitationIssuer,
   getInstanceAdmin,
   depositPayments,

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -177,6 +177,7 @@
 /**
  * @typedef {Object} UserSeat
  * @property {() => Promise<Allocation>} getCurrentAllocation
+ * TODO remove getCurrentAllocation query
  * @property {() => Promise<ProposalRecord>} getProposal
  * @property {() => Promise<PaymentPKeywordRecord>} getPayouts
  * @property {(keyword: Keyword) => Promise<Payment>} getPayout

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -21,7 +21,7 @@ import { makePromiseKit } from '@agoric/promise-kit';
 
 import { makeZoeStorageManager } from './zoeStorageManager.js';
 import { makeStartInstance } from './startInstance.js';
-import { makeOffer } from './offer/offer.js';
+import { makeOfferMethod } from './offer/offer.js';
 import { makeInvitationQueryFns } from './invitationQueries.js';
 import { setupCreateZCFVat } from './createZCFVat.js';
 import { createFeeMint } from './feeMint.js';
@@ -97,7 +97,7 @@ const makeZoeKit = (
   );
 
   // Pass the capabilities necessary to create E(zoe).offer
-  const offer = makeOffer(
+  const offer = makeOfferMethod(
     invitationIssuer,
     getInstanceAdmin,
     depositPayments,


### PR DESCRIPTION
Fixes #4312 
Have recognition of passable Error obtain `name` from prototype, skipping any own `name` property on the error instance.

Note several of the places we need to revisit when we admit `error.cause` and `error.errors`.

Inline TODOs reminding us to revisit issues identified by zestival

Rename `keySchema`,`valueSchema` to `keyPattern`,`valuePattern`. Attn @FUDCo 

Some internal clarifying renamings.