### PR TITLE
Spruce up dIBC implementation

### DIFF
--- a/golang/cosmos/x/vibc/keeper/keeper.go
+++ b/golang/cosmos/x/vibc/keeper/keeper.go
@@ -85,7 +85,19 @@ func (k Keeper) ChanOpenInit(ctx sdk.Context, order channeltypes.Order, connecti
 		return err
 	}
 	chanCapName := host.ChannelCapabilityPath(portID, channelID)
-	return k.ClaimCapability(ctx, chanCap, chanCapName)
+	err = k.ClaimCapability(ctx, chanCap, chanCapName)
+	if err != nil {
+		return err
+	}
+
+	// We need to emit a channel event to notify the relayer.
+	ctx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			sdk.EventTypeMessage,
+			sdk.NewAttribute(sdk.AttributeKeyModule, channeltypes.AttributeValueCategory),
+		),
+	})
+	return nil
 }
 
 // SendPacket defines a wrapper function for the channel Keeper's function
@@ -122,7 +134,19 @@ func (k Keeper) ChanCloseInit(ctx sdk.Context, portID, channelID string) error {
 	if !ok {
 		return sdkerrors.Wrapf(channeltypes.ErrChannelCapabilityNotFound, "could not retrieve channel capability at: %s", capName)
 	}
-	return k.channelKeeper.ChanCloseInit(ctx, portID, channelID, chanCap)
+	err := k.channelKeeper.ChanCloseInit(ctx, portID, channelID, chanCap)
+	if err != nil {
+		return err
+	}
+
+	// We need to emit a channel event to notify the relayer.
+	ctx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			sdk.EventTypeMessage,
+			sdk.NewAttribute(sdk.AttributeKeyModule, channeltypes.AttributeValueCategory),
+		),
+	})
+	return nil
 }
 
 // BindPort defines a wrapper function for the port Keeper's function in

--- a/packages/SwingSet/src/devices/bridge.js
+++ b/packages/SwingSet/src/devices/bridge.js
@@ -86,7 +86,12 @@ function sanitize(data) {
   if (data instanceof Error) {
     data = data.stack;
   }
-  return JSON.parse(JSON.stringify(data));
+  // Golang likes to have its bigints as strings.
+  return JSON.parse(
+    JSON.stringify(data, (key, value) =>
+      typeof value === 'bigint' ? value.toString() : value,
+    ),
+  );
 }
 
 export function buildBridge(outboundCallback) {

--- a/packages/SwingSet/src/vats/network/network.js
+++ b/packages/SwingSet/src/vats/network/network.js
@@ -25,7 +25,7 @@ export const rethrowUnlessMissing = err => {
   ) {
     throw err;
   }
-  return false;
+  return undefined;
 };
 
 /**
@@ -149,14 +149,10 @@ export function crossoverConnection(
         if (closed) {
           throw closed;
         }
-        const ack =
-          /** @type {Bytes} */
-          (
-            await E(handlers[r])
-              .onReceive(conns[r], toBytes(packetBytes), handlers[r])
-              .catch(rethrowUnlessMissing)
-          );
-        return toBytes(ack);
+        const ack = await E(handlers[r])
+          .onReceive(conns[r], toBytes(packetBytes), handlers[r])
+          .catch(rethrowUnlessMissing);
+        return toBytes(ack || '');
       },
       async close() {
         if (closed) {
@@ -419,7 +415,11 @@ export function makeNetworkProtocol(protocolHandler) {
               .onReject(port, localAddr, remoteAddr, listener)
               .catch(rethrowUnlessMissing);
           },
-          async accept(rchandler) {
+          async accept({
+            localAddress = localAddr,
+            remoteAddress = remoteAddr,
+            handler: rchandler,
+          }) {
             if (consummated) {
               throw consummated;
             }
@@ -435,9 +435,9 @@ export function makeNetworkProtocol(protocolHandler) {
 
             return crossoverConnection(
               lchandler,
-              localAddr,
+              localAddress,
               rchandler,
-              remoteAddr,
+              remoteAddress,
               current,
             )[1];
           },
@@ -453,31 +453,38 @@ export function makeNetworkProtocol(protocolHandler) {
         (await E(port).getLocalAddress());
 
       // Allocate a local address.
-      const localInstance = await E(protocolHandler)
+      const initialLocalInstance = await E(protocolHandler)
         .onInstantiate(port, localAddr, remoteAddr, protocolHandler)
         .catch(rethrowUnlessMissing);
-      const la = localInstance ? `${localAddr}/${localInstance}` : localAddr;
+      const initialLocalAddr = initialLocalInstance
+        ? `${localAddr}/${initialLocalInstance}`
+        : localAddr;
 
       let lastFailure;
       try {
         // Attempt the loopback connection.
-        const attempt = await protocolImpl.inbound(remoteAddr, la);
-        return attempt.accept(lchandler);
+        const attempt = await protocolImpl.inbound(
+          remoteAddr,
+          initialLocalAddr,
+        );
+        return attempt.accept({ handler: lchandler });
       } catch (e) {
         lastFailure = e;
       }
 
-      const [connectedAddress, rchandler] =
-        /** @type {[Endpoint, ConnectionHandler]} */
-        (
-          await E(protocolHandler).onConnect(
-            port,
-            la,
-            remoteAddr,
-            lchandler,
-            protocolHandler,
-          )
-        );
+      const {
+        remoteAddress = remoteAddr,
+        handler: rchandler,
+        localAddress = localAddr,
+      } =
+        /** @type {Partial<AttemptDescription>} */
+        (await E(protocolHandler).onConnect(
+          port,
+          initialLocalAddr,
+          remoteAddr,
+          lchandler,
+          protocolHandler,
+        ));
 
       if (!rchandler) {
         throw lastFailure;
@@ -486,9 +493,9 @@ export function makeNetworkProtocol(protocolHandler) {
       const current = currentConnections.get(port);
       return crossoverConnection(
         lchandler,
-        la,
+        localAddress,
         rchandler,
-        connectedAddress,
+        remoteAddress,
         current,
       )[0];
     },
@@ -571,10 +578,10 @@ export function makeLoopbackProtocolHandler(
       const remoteInstance = await E(protocolHandler)
         .onInstantiate(lport, remoteAddr, localAddr, protocolHandler)
         .catch(rethrowUnlessMissing);
-      const ra = remoteInstance
-        ? `${remoteAddr}/${remoteInstance}`
-        : remoteAddr;
-      return [ra, rchandler];
+      return {
+        remoteInstance,
+        handler: rchandler,
+      };
     },
     onInstantiate,
     async onListen(port, localAddr, listenHandler, _protocolHandler) {

--- a/packages/SwingSet/src/vats/network/network.js
+++ b/packages/SwingSet/src/vats/network/network.js
@@ -72,7 +72,7 @@ export const makeConnection = (
         .onClose(connection, undefined, handler)
         .catch(rethrowUnlessMissing);
     },
-    async send(data) {
+    async send(data, opts) {
       // console.log('send', data, local === srcHandler);
       if (closed) {
         throw closed;
@@ -81,7 +81,7 @@ export const makeConnection = (
       const ackDeferred = makePromiseKit();
       pendingAcks.add(ackDeferred);
       E(handler)
-        .onReceive(connection, bytes, handler)
+        .onReceive(connection, bytes, handler, opts)
         .catch(err => {
           rethrowUnlessMissing(err);
           return '';

--- a/packages/SwingSet/src/vats/network/network.js
+++ b/packages/SwingSet/src/vats/network/network.js
@@ -478,13 +478,15 @@ export function makeNetworkProtocol(protocolHandler) {
         localAddress = localAddr,
       } =
         /** @type {Partial<AttemptDescription>} */
-        (await E(protocolHandler).onConnect(
-          port,
-          initialLocalAddr,
-          remoteAddr,
-          lchandler,
-          protocolHandler,
-        ));
+        (
+          await E(protocolHandler).onConnect(
+            port,
+            initialLocalAddr,
+            remoteAddr,
+            lchandler,
+            protocolHandler,
+          )
+        );
 
       if (!rchandler) {
         throw lastFailure;

--- a/packages/SwingSet/src/vats/network/types.js
+++ b/packages/SwingSet/src/vats/network/types.js
@@ -56,6 +56,13 @@
  */
 
 /**
+ * @typedef {Object} AttemptDescription
+ * @property {ConnectionHandler} handler
+ * @property {Endpoint} [remoteAddress]
+ * @property {Endpoint} [localAddress]
+ */
+
+/**
  * @typedef {Object} ProtocolHandler A handler for things the protocol implementation will invoke
  * @property {(protocol: ProtocolImpl, p: ProtocolHandler) => Promise<void>} onCreate This protocol is created
  * @property {(localAddr: Endpoint, p: ProtocolHandler) => Promise<string>} generatePortID Create a fresh port identifier for this protocol
@@ -64,11 +71,11 @@
  * @property {(port: Port, localAddr: Endpoint, listenHandler: ListenHandler, p: ProtocolHandler) => Promise<void>} onListenRemove A port listener has been reset
  * @property {(port: Port, localAddr: Endpoint, remote: Endpoint, p: ProtocolHandler) => Promise<Endpoint>} [onInstantiate] Return unique suffix for
  * local address
- * @property {(port: Port, localAddr: Endpoint, remote: Endpoint, c: ConnectionHandler, p: ProtocolHandler) => Promise<[Endpoint, ConnectionHandler]>} onConnect A port initiates an outbound connection
+ * @property {(port: Port, localAddr: Endpoint, remote: Endpoint, c: ConnectionHandler, p: ProtocolHandler) => Promise<AttemptDescription>} onConnect A port initiates an outbound connection
  * @property {(port: Port, localAddr: Endpoint, p: ProtocolHandler) => Promise<void>} onRevoke The port is being completely destroyed
  *
  * @typedef {Object} InboundAttempt An inbound connection attempt
- * @property {(connectionHandler: ConnectionHandler) => Promise<Connection>} accept Establish the connection
+ * @property {(desc: AttemptDescription) => Promise<Connection>} accept Establish the connection
  * @property {() => Endpoint} getLocalAddress Return the local address for this attempt
  * @property {() => Endpoint} getRemoteAddress Return the remote address for this attempt
  * @property {() => Promise<void>} close Abort the attempt

--- a/packages/SwingSet/src/vats/network/types.js
+++ b/packages/SwingSet/src/vats/network/types.js
@@ -40,7 +40,7 @@
 
 /**
  * @typedef {Object} Connection
- * @property {(packetBytes: Data) => Promise<Bytes>} send Send a packet on the connection
+ * @property {(packetBytes: Data, opts?: Record<string, any>) => Promise<Bytes>} send Send a packet on the connection
  * @property {() => Promise<void>} close Close both ends of the connection
  * @property {() => Endpoint} getLocalAddress Get the locally bound name of this connection
  * @property {() => Endpoint} getRemoteAddress Get the name of the counterparty
@@ -49,7 +49,7 @@
 /**
  * @typedef {Object} ConnectionHandler A handler for a given Connection
  * @property {(connection: Connection, localAddr: Endpoint, remoteAddr: Endpoint, c: ConnectionHandler) => void} [onOpen] The connection has been opened
- * @property {(connection: Connection, packetBytes: Bytes, c: ConnectionHandler) => Promise<Data>} [onReceive] The connection received a packet
+ * @property {(connection: Connection, packetBytes: Bytes, c: ConnectionHandler, opts?: Record<string, any>) => Promise<Data>} [onReceive] The connection received a packet
  * @property {(connection: Connection, reason?: CloseReason, c?: ConnectionHandler) => Promise<void>} [onClose] The connection has been closed
  *
  * @typedef {any?} CloseReason The reason a connection was closed

--- a/packages/SwingSet/test/test-network.js
+++ b/packages/SwingSet/test/test-network.js
@@ -48,7 +48,7 @@ const makeProtocolHandler = t => {
           .onAccept(lp, localAddr, remoteAddr, l)
           .then(ch => [localAddr, ch]);
       }
-      return [remoteAddr, makeEchoConnectionHandler()];
+      return { handler: makeEchoConnectionHandler() };
     },
     async onListen(port, localAddr, listenHandler) {
       t.assert(port, `port is tracked in onListen`);

--- a/packages/agoric-cli/src/chain-config.js
+++ b/packages/agoric-cli/src/chain-config.js
@@ -8,11 +8,6 @@ export const STAKING_MAX_VALIDATORS = 150;
 // Required for IBC connections not to time out.
 export const STAKING_MIN_HISTORICAL_ENTRIES = 10000;
 
-// We reserve the default `transfer` IBC port for Pegasus (JS-level ERTP
-// assets).  The `cosmos-transfer` IBC port is used for ibc-go (Cosmos-level
-// prefixed string token denominations).
-export const COSMOS_TRANSFER_PORT_ID = 'cosmos-transfer';
-
 export const DENOM_METADATA = [
   {
     name: 'Agoric Staking Token',
@@ -191,8 +186,6 @@ export function finishCosmosGenesis({ genesisJson, exportedGenesisJson }) {
     existingHistoricalEntries,
     STAKING_MIN_HISTORICAL_ENTRIES,
   );
-
-  genesis.app_state.transfer.port_id = COSMOS_TRANSFER_PORT_ID;
 
   // We scale this parameter according to our own block cadence, so
   // that we tolerate the same downtime as the old genesis.

--- a/packages/vats/src/bootstrap.js
+++ b/packages/vats/src/bootstrap.js
@@ -825,7 +825,7 @@ export function buildRootObject(vatPowers, vatParameters) {
 
     if (pegasus) {
       // Add the Pegasus transfer port.
-      const port = await E(network).bind('/ibc-port/transfer');
+      const port = await E(network).bind('/ibc-port/pegasus');
       E(port).addListener(
         Far('listener', {
           async onAccept(_port, _localAddr, _remoteAddr, _listenHandler) {

--- a/packages/vats/src/ibc.js
+++ b/packages/vats/src/ibc.js
@@ -1,7 +1,6 @@
 // @ts-check
 
 import {
-  rethrowUnlessMissing,
   dataToBase64,
   base64ToBytes,
 } from '@agoric/swingset-vat/src/vats/network/index.js';
@@ -14,8 +13,6 @@ import '@agoric/store/exported.js';
 import '@agoric/swingset-vat/src/vats/network/types.js';
 
 import { makeWithQueue } from './queue.js';
-
-const DEFAULT_PACKET_TIMEOUT = 1000;
 
 // CAVEAT: IBC acks cannot be empty, as the Cosmos IAVL tree cannot represent
 // empty acknowledgements as distinct from unacknowledged packets.
@@ -74,14 +71,18 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
    * @property {Counterparty} counterparty
    * @property {string} version
    *
-   * @typedef {PromiseRecord<[Endpoint, ConnectionHandler]>} OnConnectP
-   * @typedef {ConnectingInfo & { onConnectP: OnConnectP }} Outbound
+   * @typedef {PromiseRecord<AttemptDescription>} OnConnectP
+   * @typedef {Omit<ConnectingInfo, 'counterparty' | 'channelID'> & {
+   *   localAddr: Endpoint, onConnectP: OnConnectP
+   *   counterparty: { port_id: string },
+   * }} Outbound
    */
 
   /**
-   * @type {Store<string, Array<Outbound>>}
+   * @type {LegacyMap<string, Array<Outbound>>}
    */
-  const srcPortToOutbounds = makeStore('SRC-PORT');
+  // Legacy because it holds a mutable Javascript Array
+  const srcPortToOutbounds = makeLegacyMap('SRC-PORT');
 
   /**
    * @type {Store<string, ConnectingInfo>}
@@ -89,31 +90,26 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
   const channelKeyToInfo = makeStore('CHANNEL:PORT');
 
   /**
-   * @type {Store<string, OnConnectP>}
-   */
-  const channelKeyToOnConnectP = makeStore('CHANNEL:PORT');
-
-  /**
    * @type {Store<string, Promise<InboundAttempt>>}
    */
   const channelKeyToAttemptP = makeStore('CHANNEL:PORT');
 
   /**
-   * @type {Store<string, Store<number, PromiseRecord<Bytes>>>}
+   * @type {LegacyMap<string, LegacyMap<number, PromiseRecord<Bytes>>>}
    */
-  const channelKeyToSeqAck = makeStore('CHANNEL:PORT');
+  // Legacy because it holds a LegacyMap
+  const channelKeyToSeqAck = makeLegacyMap('CHANNEL:PORT');
 
   /**
    * Send a packet out via the IBC device.
    *
    * @param {IBCPacket} packet
-   * @param {Store<number, PromiseRecord<Bytes>>} seqToAck
+   * @param {LegacyMap<number, PromiseRecord<Bytes>>} seqToAck
    */
   async function ibcSendPacket(packet, seqToAck) {
     // Make a kernel call to do the send.
     const fullPacket = await callIBCDevice('sendPacket', {
       packet,
-      relativeTimeout: DEFAULT_PACKET_TIMEOUT,
     });
 
     // Extract the actual sequence number from the return.
@@ -145,7 +141,8 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
     order,
   ) {
     const channelKey = `${channelID}:${portID}`;
-    const seqToAck = makeStore('SEQUENCE');
+    // Legacy because it holds a PromiseRecord
+    const seqToAck = makeLegacyMap('SEQUENCE');
     channelKeyToSeqAck.init(channelKey, seqToAck);
 
     /**
@@ -190,7 +187,7 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
           source_port: portID,
           source_channel: channelID,
         };
-        await callIBCDevice('channelCloseInit', { packet });
+        await callIBCDevice('startChannelCloseInit', { packet });
         const rejectReason = Error('Connection closed');
         for (const ackDeferred of seqToAck.values()) {
           ackDeferred.reject(rejectReason);
@@ -228,26 +225,22 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
    */
 
   /**
-   * @type {Store<Port, OutboundCircuitRecord[]>}
-   */
-  const portToCircuits = makeStore('Port');
-
-  /**
    * @type {LegacyMap<Port, Set<PromiseRecord<ConnectionHandler>>>}
    */
   // Legacy because it holds a raw JavaScript Set
   const portToPendingConns = makeLegacyMap('Port');
 
-  /** @type {Store<Endpoint, Endpoint>} */
-  const remoteAddrToLocalSuffix = makeStore('endpoint');
-
   /**
    * @type {ProtocolHandler}
    */
-  const protocol = Far('ProtocolHandler', {
+  const protocol = Far('IBCProtocolHandler', {
     async onCreate(impl, _protocolHandler) {
       console.debug('IBC onCreate');
       protocolImpl = impl;
+    },
+    async onInstantiate() {
+      // The IBC channel is not known until after handshake.
+      return '';
     },
     async generatePortID(_localAddr, _protocolHandler) {
       lastPortID += 1;
@@ -255,19 +248,13 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
     },
     async onBind(port, localAddr, _protocolHandler) {
       const portID = localAddrToPortID(localAddr);
-      portToCircuits.init(port, []);
       portToPendingConns.init(port, new Set());
       const packet = {
         source_port: portID,
       };
       return callIBCDevice('bindPort', { packet });
     },
-    async onInstantiate(_port, _localAddr, remoteAddr, _protocolHandler) {
-      // we can take advantage of the fact that remoteAddrs are unique (they
-      // have their own channelID).
-      return remoteAddrToLocalSuffix.get(remoteAddr);
-    },
-    async onConnect(port, localAddr, remoteAddr, chandler, _protocolHandler) {
+    async onConnect(port, localAddr, remoteAddr, _chandler, _protocolHandler) {
       console.debug('IBC onConnect', localAddr, remoteAddr);
       const portID = localAddrToPortID(localAddr);
       const pendingConns = portToPendingConns.get(port);
@@ -302,9 +289,10 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
       const onConnectP = makePromiseKit();
 
       pendingConns.add(onConnectP);
+      /** @type {Outbound[]} */
       let outbounds;
       if (srcPortToOutbounds.has(portID)) {
-        outbounds = srcPortToOutbounds.get(portID);
+        outbounds = [...srcPortToOutbounds.get(portID)];
       } else {
         outbounds = [];
         srcPortToOutbounds.init(portID, outbounds);
@@ -316,9 +304,10 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
         order,
         version,
         onConnectP,
+        localAddr,
       });
 
-      // Get any passive relayers to flow.
+      // Initialise the channel, which automatic relayers should pick up.
       const packet = {
         source_port: portID,
         destination_port: rPortID,
@@ -331,38 +320,6 @@ export function makeIBCProtocolHandler(E, rawCallIBCDevice) {
         version,
       });
 
-      if (!chandler) {
-        // Nothing to explain to the user, so return now.
-        return onConnectP.promise;
-      }
-
-      // We explain to the user how to configure a naive relayer.
-      const q = JSON.stringify;
-      E(
-        /** @type {ConnectionHandler&{infoMessage?: (...args: any[]) => void}} */
-        (chandler),
-      )
-        .infoMessage(
-          `\
-# Set up the relayer for this path:
-ag-nchainz start-relayer <<'EOF'
-{
-  "src": {
-    "connection-id": ${q(hops[0])},
-    "port-id": ${q(portID)},
-    "order": ${q(order)},
-    "version": ${q(version)}
-  },
-  "dst": {
-    "port-id": ${q(rPortID)},
-    "order": ${q(order)}
-  }
-}
-EOF
-# then your connection will try to proceed.
-`,
-        )
-        .catch(rethrowUnlessMissing);
       return onConnectP.promise;
     },
     async onListen(_port, localAddr, _listenHandler) {
@@ -375,7 +332,6 @@ EOF
       console.debug('IBC onRevoke', localAddr);
       const pendingConns = portToPendingConns.get(port);
       portToPendingConns.delete(port);
-      portToCircuits.delete(port);
       const revoked = Error(`Port ${localAddr} revoked`);
       for (const onConnectP of pendingConns.values()) {
         onConnectP.reject(revoked);
@@ -388,50 +344,6 @@ EOF
     async fromBridge(srcID, obj) {
       console.info('IBC fromBridge', srcID, obj);
       switch (obj.event) {
-        case 'channelOpenInit': {
-          // This event is sent by a naive relayer that wants to initiate
-          // a connection.  It is only honoured if we already have autonomously
-          // attempted a connection.
-          const {
-            portID,
-            counterparty: { port_id: rPortID },
-            connectionHops: rHops,
-          } = obj;
-
-          const outbounds = srcPortToOutbounds.has(portID)
-            ? srcPortToOutbounds.get(portID)
-            : [];
-          const oidx = outbounds.findIndex(
-            ({ counterparty: { port_id: iPortID }, connectionHops: iHops }) => {
-              if (iPortID !== rPortID) {
-                return false;
-              }
-              for (let i = 0; i < rHops.length; i += 1) {
-                if (iHops[i] !== rHops[i]) {
-                  return false;
-                }
-              }
-              return true;
-            },
-          );
-
-          assert(oidx >= 0, X`${portID}: did not expect channelOpenInit`);
-
-          // Continue the handshake by extracting the outbound information.
-          const { onConnectP, ...chanInfo } = outbounds[oidx];
-          outbounds.splice(oidx, 1);
-          if (outbounds.length === 0) {
-            srcPortToOutbounds.delete(portID);
-          }
-
-          // We have more specific information for the outbound connection.
-          const channelKey = `${obj.channelID}:${portID}`;
-          channelKeyToInfo.init(channelKey, { ...chanInfo, ...obj });
-          channelKeyToOnConnectP.init(channelKey, onConnectP);
-          break;
-        }
-
-        case 'attemptChannelOpenTry':
         case 'channelOpenTry': {
           // They're (more or less politely) asking if we are listening, so make an attempt.
           const {
@@ -444,33 +356,22 @@ EOF
             counterpartyVersion: rVersion,
           } = obj;
 
-          const channelKey = `${channelID}:${portID}`;
-          if (channelKeyToAttemptP.has(channelKey)) {
-            // We have a pending attempt, so continue the handshake.
-            break;
-          }
-
-          const versionSuffix = version ? `/${version}` : '';
-          const localAddr = `/ibc-port/${portID}/${order.toLowerCase()}${versionSuffix}`;
+          const localAddr = `/ibc-port/${portID}/${order.toLowerCase()}/${version}`;
           const ibcHops = hops.map(hop => `/ibc-hop/${hop}`).join('/');
           const remoteAddr = `${ibcHops}/ibc-port/${rPortID}/${order.toLowerCase()}/${rVersion}/ibc-channel/${rChannelID}`;
 
           // See if we allow an inbound attempt for this address pair (without
           // rejecting).
-          remoteAddrToLocalSuffix.init(remoteAddr, `ibc-channel/${channelID}`);
           const attemptP = E(protocolImpl).inbound(localAddr, remoteAddr);
 
           // Tell what version string we negotiated.
-          const attemptedLocal = await E(attemptP)
-            .getLocalAddress()
-            .finally(() => {
-              // No matter what, delete the temporary mapping.
-              remoteAddrToLocalSuffix.delete(remoteAddr);
-            });
+          const attemptedLocal = await E(attemptP).getLocalAddress();
           const match = attemptedLocal.match(
             // Match:  ... /ORDER/VERSION ...
             new RegExp('^(/[^/]+/[^/]+)*/(ordered|unordered)/([^/]+)(/|$)'),
           );
+
+          const channelKey = `${channelID}:${portID}`;
           if (!match) {
             throw Error(
               `${channelKey}: cannot determine version from attempted local address ${attemptedLocal}`,
@@ -482,23 +383,7 @@ EOF
           channelKeyToInfo.init(channelKey, obj);
 
           try {
-            if (obj.type === 'attemptChannelOpenTry') {
-              // We can try to open with the version we wanted.
-              const packet = {
-                source_channel: channelID,
-                source_port: portID,
-                destination_channel: rChannelID,
-                destination_port: rPortID,
-              };
-
-              await callIBCDevice('continueChannelOpenTry', {
-                packet,
-                order,
-                hops,
-                version: negotiatedVersion,
-                counterpartyVersion: rVersion,
-              });
-            } else if (negotiatedVersion !== version) {
+            if (negotiatedVersion !== version) {
               // Too late; the relayer gave us a version we didn't like.
               throw Error(
                 `${channelKey}: negotiated version was ${negotiatedVersion}; rejecting ${version}`,
@@ -521,30 +406,51 @@ EOF
             channelID,
             counterparty: { port_id: rPortID, channel_id: rChannelID },
             counterpartyVersion: rVersion,
+            connectionHops: rHops,
           } = obj;
-          const channelKey = `${channelID}:${portID}`;
-          assert(
-            channelKeyToOnConnectP.has(channelKey),
-            X`${channelKey}: did not expect channelOpenAck`,
+          const outbounds = srcPortToOutbounds.has(portID)
+            ? srcPortToOutbounds.get(portID)
+            : [];
+          const oidx = outbounds.findIndex(
+            ({ counterparty: { port_id: iPortID }, connectionHops: iHops }) => {
+              if (iPortID !== rPortID) {
+                return false;
+              }
+              if (iHops.length !== rHops.length) {
+                return false;
+              }
+              for (let i = 0; i < iHops.length; i += 1) {
+                if (iHops[i] !== rHops[i]) {
+                  return false;
+                }
+              }
+              return true;
+            },
           );
-          const onConnectP = channelKeyToOnConnectP.get(channelKey);
-          channelKeyToOnConnectP.delete(channelKey);
 
-          const { order, connectionHops: rHops } =
-            channelKeyToInfo.get(channelKey);
-          channelKeyToInfo.delete(channelKey);
+          assert(oidx >= 0, X`${portID}: did not expect channelOpenAck`);
+          const { onConnectP, localAddr, ...chanInfo } = outbounds[oidx];
+          outbounds.splice(oidx, 1);
+          if (outbounds.length === 0) {
+            srcPortToOutbounds.delete(portID);
+          }
 
           // Finish the outbound connection.
           const ibcHops = rHops.map(hop => `/ibc-hop/${hop}`).join('/');
-          const remoteAddr = `${ibcHops}/ibc-port/${rPortID}/${order.toLowerCase()}/${rVersion}`;
+          const remoteAddress = `${ibcHops}/ibc-port/${rPortID}/${chanInfo.order.toLowerCase()}/${rVersion}/ibc-channel/${rChannelID}`;
+          const localAddress = `${localAddr}/ibc-channel/${channelID}`;
           const rchandler = makeIBCConnectionHandler(
             channelID,
             portID,
             rChannelID,
             rPortID,
-            order,
+            chanInfo.order,
           );
-          onConnectP.resolve([remoteAddr, rchandler]);
+          onConnectP.resolve({
+            localAddress,
+            remoteAddress,
+            handler: rchandler,
+          });
           break;
         }
 
@@ -573,7 +479,11 @@ EOF
             rPortID,
             order,
           );
-          E(attemptP).accept(rchandler);
+          const localAddr = await E(attemptP).getLocalAddress();
+          E(attemptP).accept({
+            localAddress: `${localAddr}/ibc-channel/${channelID}`,
+            handler: rchandler,
+          });
           break;
         }
 

--- a/packages/vats/test/test-network.js
+++ b/packages/vats/test/test-network.js
@@ -3,20 +3,26 @@
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import { E, Far } from '@endo/far';
+import { makeSubscriptionKit } from '@agoric/notifier';
 
 import { buildRootObject as ibcBuildRootObject } from '../src/vat-ibc.js';
 import { buildRootObject as networkBuildRootObject } from '../src/vat-network.js';
 
 test('network - ibc', async t => {
-  t.plan(2);
-
   const networkVat = E(networkBuildRootObject)();
   const ibcVat = E(ibcBuildRootObject)();
 
+  const { subscription, publication } = makeSubscriptionKit();
+
+  const events = subscription[Symbol.asyncIterator]();
   const callbacks = Far('ibcCallbacks', {
     downcall: (method, params) => {
-      t.is(method, 'bindPort');
-      t.deepEqual(params, { packet: { source_port: 'port-1' } });
+      publication.updateState([method, params]);
+      if (method === 'sendPacket') {
+        const { packet } = params;
+        return { ...packet, sequence: '39' };
+      }
+      return undefined;
     },
   });
 
@@ -28,5 +34,183 @@ test('network - ibc', async t => {
 
   // Actually test the ibc port binding.
   // TODO: Do more tests on the returned Port object.
-  await E(networkVat).bind('/ibc-port/');
+  const p = E(networkVat).bind('/ibc-port/');
+  await p;
+  const ev1 = await events.next();
+  t.assert(!ev1.done);
+  t.deepEqual(ev1.value, ['bindPort', { packet: { source_port: 'port-1' } }]);
+
+  const testEcho = async () => {
+    await E(p).addListener(
+      Far('ibcListener', {
+        async onAccept(_port, _localAddr, _remoteAddr, _listenHandler) {
+          /** @type {ConnectionHandler} */
+          const handler = Far('plusOne', {
+            async onReceive(_c, packetBytes) {
+              return `${packetBytes}1`;
+            },
+            async onOpen(_c, localAddr, remoteAddr, _connectionHandler) {
+              publication.updateState([
+                'plusOne-open',
+                { localAddr, remoteAddr },
+              ]);
+            },
+          });
+          return handler;
+        },
+        async onListen(port, _listenHandler) {
+          console.debug(`listening on echo port: ${port}`);
+        },
+      }),
+    );
+
+    const c = E(p).connect('/ibc-port/port-1/unordered/foo');
+
+    const ack = await E(c).send('hello198');
+    t.is(ack, 'hello1981', 'expected echo');
+    await c;
+
+    await E(c).close();
+  };
+
+  await testEcho();
+
+  const testIBCOutbound = async () => {
+    const c = E(p).connect(
+      '/ibc-hop/connection-11/ibc-port/port-98/unordered/bar',
+    );
+
+    const evopen = await events.next();
+    t.assert(!evopen.done);
+    t.deepEqual(evopen.value, [
+      'plusOne-open',
+      {
+        localAddr: '/ibc-port/port-1/unordered/foo',
+        remoteAddr: '/ibc-port/port-1',
+      },
+    ]);
+
+    const ev2 = await events.next();
+    t.assert(!ev2.done);
+    t.deepEqual(ev2.value, [
+      'startChannelOpenInit',
+      {
+        packet: { source_port: 'port-1', destination_port: 'port-98' },
+        order: 'UNORDERED',
+        hops: ['connection-11'],
+        version: 'bar',
+      },
+    ]);
+
+    await E(ibcHandler).fromBridge('dontcare', {
+      event: 'channelOpenAck',
+      portID: 'port-1',
+      channelID: 'channel-1',
+      counterparty: { port_id: 'port-98', channel_id: 'channel-22' },
+      counterpartyVersion: 'bar',
+      connectionHops: ['connection-11'],
+    });
+
+    await c;
+    const ack = E(c).send('some-transfer-message');
+
+    const ev3 = await events.next();
+    t.assert(!ev3.done);
+    t.deepEqual(ev3.value, [
+      'sendPacket',
+      {
+        packet: {
+          data: 'c29tZS10cmFuc2Zlci1tZXNzYWdl',
+          destination_channel: 'channel-22',
+          destination_port: 'port-98',
+          source_channel: 'channel-1',
+          source_port: 'port-1',
+        },
+      },
+    ]);
+
+    await E(ibcHandler).fromBridge('stilldontcare', {
+      event: 'acknowledgementPacket',
+      packet: {
+        data: 'c29tZS10cmFuc2Zlci1tZXNzYWdl',
+        destination_channel: 'channel-22',
+        destination_port: 'port-98',
+        source_channel: 'channel-1',
+        source_port: 'port-1',
+        sequence: '39',
+      },
+      acknowledgement: 'YS10cmFuc2Zlci1yZXBseQ==',
+    });
+
+    t.is(await ack, 'a-transfer-reply');
+
+    await E(c).close();
+  };
+
+  await testIBCOutbound();
+
+  const testIBCInbound = async () => {
+    await E(ibcHandler).fromBridge('reallydontcare', {
+      event: 'channelOpenTry',
+      channelID: 'channel-2',
+      portID: 'port-1',
+      counterparty: { port_id: 'port-99', channel_id: 'channel-23' },
+      connectionHops: ['connection-12'],
+      order: 'ORDERED',
+      version: 'bazi',
+      counterpartyVersion: 'bazo',
+    });
+
+    await E(ibcHandler).fromBridge('stillreallydontcare', {
+      event: 'channelOpenConfirm',
+      portID: 'port-1',
+      channelID: 'channel-2',
+    });
+
+    const evopen = await events.next();
+    t.assert(!evopen.done);
+    t.deepEqual(evopen.value, [
+      'plusOne-open',
+      {
+        localAddr: '/ibc-port/port-1/ordered/bazi/ibc-channel/channel-2',
+        remoteAddr:
+          '/ibc-hop/connection-12/ibc-port/port-99/ordered/bazo/ibc-channel/channel-23',
+      },
+    ]);
+
+    await E(ibcHandler).fromBridge('notevenyet', {
+      event: 'receivePacket',
+      packet: {
+        data: 'aW5ib3VuZC1tc2c=',
+        destination_port: 'port-1',
+        destination_channel: 'channel-2',
+        source_channel: 'channel-23',
+        source_port: 'port-99',
+      },
+    });
+
+    const ev4 = await events.next();
+    t.assert(!ev4.done);
+    t.deepEqual(ev4.value, [
+      'receiveExecuted',
+      {
+        ack: 'aW5ib3VuZC1tc2cx',
+        packet: {
+          data: 'aW5ib3VuZC1tc2c=',
+          destination_channel: 'channel-2',
+          destination_port: 'port-1',
+          source_channel: 'channel-23',
+          source_port: 'port-99',
+        },
+      },
+    ]);
+  };
+
+  await testIBCInbound();
+
+  // Verify that we consumed all the published events.
+  publication.finish([]);
+  const evend = await events.next();
+  t.assert(evend.done);
+  t.deepEqual(evend.value, []);
 });

--- a/packages/vats/test/test-network.js
+++ b/packages/vats/test/test-network.js
@@ -126,6 +126,7 @@ test('network - ibc', async t => {
           source_channel: 'channel-1',
           source_port: 'port-1',
         },
+        relativeTimeoutNs: 600_000_000_000n, // 10 minutes in nanoseconds.
       },
     ]);
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: #4306 
closes: #4153

## Description

Modify the chain configuration so that the Pegasus implementation is moved from the `transfer` IBC port to the `pegasus` port.  Then move the `ibc-go` `transfer` implementation from the `cosmos-transfer` IBC port to the `transfer` port.

While testing this, I found there were several problems with dIBC.  This needed a dramatic overhaul and some new unit tests.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

Still need to prevent Pegasus from accepting transfers to or from `vbank` assets, as is explained in #4306.

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

Will improve the usability of IBC transfer on the Agoric chain (works as expected by Cosmos ecosystem), so that Pegasus use is opt-in.

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

Testing that `transfer` port on a local chain allows both sends and receives to another chain via standard (Hermes) tooling.