### PR TITLE
Add --wide option to kerneldump utility

### DIFF
--- a/packages/swingset-runner/src/dumpstore.js
+++ b/packages/swingset-runner/src/dumpstore.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import process from 'process';
 
 /* eslint-disable no-use-before-define */
-export function dumpStore(swingStore, outfile, rawMode) {
+export function dumpStore(swingStore, outfile, rawMode, truncate = true) {
   const streamStore = swingStore.streamStore;
   let out;
   if (outfile) {
@@ -283,7 +283,7 @@ export function dumpStore(swingStore, outfile, rawMode) {
   }
 
   function pkvBig(tag, key, value, maxWidth = 50) {
-    if (value.length > maxWidth) {
+    if (value.length > maxWidth && truncate) {
       pkv(key, `<<${tag} ${value.length}>>`);
     } else {
       pkv(key, value);

--- a/packages/swingset-runner/src/kerneldump.js
+++ b/packages/swingset-runner/src/kerneldump.js
@@ -22,6 +22,7 @@ FLAGS may be:
   --help      - print this helpful usage information
   --out PATH  - output dump to PATH ("-" indicates stdout, the default)
   --stats     - just print summary stats and exit
+  --wide      - don't truncate unreadably long values
 
 TARGET is one of: the base directory where a swingset's vats live, a swingset
 data store directory, or the path to a swingset database file.  If omitted, it
@@ -58,12 +59,16 @@ export function main() {
   let justStats = false;
   let doDump = true;
   let refDump = false;
+  let wideMode = false;
   let outfile;
   while (argv[0] && argv[0].startsWith('-')) {
     const flag = argv.shift();
     switch (flag) {
       case '--raw':
         rawMode = true;
+        break;
+      case '--wide':
+        wideMode = true;
         break;
       case '--refcounts':
       case '--refCounts':
@@ -121,7 +126,7 @@ export function main() {
     printMainStats(organizeMainStats(rawStats, cranks));
   } else {
     if (doDump) {
-      dumpStore(swingStore, outfile, rawMode);
+      dumpStore(swingStore, outfile, rawMode, !wideMode);
     }
     if (refCounts) {
       auditRefCounts(swingStore.kvStore, refDump, doDump);


### PR DESCRIPTION
Simple enhancement to the `kerneldump` utility to add a new command line parameter, `--wide`, that enables dumps to still be pretty but without truncating large values, for rare case when you actually need to look at the precise value of one of those keys whose value is very long and thus would otherwise be abbreviated for legibility.