### PR TITLE
style: remove extraneous eslint-disable of spaced-comment

### DIFF
--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 /**

--- a/packages/assert/src/types.js
+++ b/packages/assert/src/types.js
@@ -1,5 +1,4 @@
 // @ts-check
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 // Based on

--- a/packages/captp/src/ts-types.d.ts
+++ b/packages/captp/src/ts-types.d.ts
@@ -1,5 +1,4 @@
 /* eslint-disable */
-// eslint-disable-next-line spaced-comment
 
 import type { Unpromise } from '@agoric/eventual-send';
 

--- a/packages/eventual-send/src/E.js
+++ b/packages/eventual-send/src/E.js
@@ -1,7 +1,6 @@
 // @ts-check
 import { trackTurns } from './track-turns.js';
 
-// eslint-disable-next-line spaced-comment
 /// <reference path="index.d.ts" />
 
 /** @type {ProxyHandler<any>} */

--- a/packages/marshal/src/deeplyFulfilled.js
+++ b/packages/marshal/src/deeplyFulfilled.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 import { E } from '@agoric/eventual-send';

--- a/packages/marshal/src/dot-membrane.js
+++ b/packages/marshal/src/dot-membrane.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-use-before-define */
 // @ts-check
 
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 import { E } from '@agoric/eventual-send';

--- a/packages/marshal/src/helpers/copyArray.js
+++ b/packages/marshal/src/helpers/copyArray.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 import '../types.js';

--- a/packages/marshal/src/helpers/copyRecord.js
+++ b/packages/marshal/src/helpers/copyRecord.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 import {

--- a/packages/marshal/src/helpers/error.js
+++ b/packages/marshal/src/helpers/error.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 import '../types.js';

--- a/packages/marshal/src/helpers/internal-types.js
+++ b/packages/marshal/src/helpers/internal-types.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-// eslint-disable-next-line spaced-comment
 /// <reference path="../extra-types.d.ts" />
 
 /**

--- a/packages/marshal/src/helpers/passStyle-helpers.js
+++ b/packages/marshal/src/helpers/passStyle-helpers.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 import '../types.js';

--- a/packages/marshal/src/helpers/remotable.js
+++ b/packages/marshal/src/helpers/remotable.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 import '../types.js';

--- a/packages/marshal/src/helpers/tagged.js
+++ b/packages/marshal/src/helpers/tagged.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 import {

--- a/packages/marshal/src/make-far.js
+++ b/packages/marshal/src/make-far.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 import { assertChecker, PASS_STYLE } from './helpers/passStyle-helpers.js';

--- a/packages/marshal/src/makeTagged.js
+++ b/packages/marshal/src/makeTagged.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 import { PASS_STYLE } from './helpers/passStyle-helpers.js';

--- a/packages/marshal/src/marshal-justin.js
+++ b/packages/marshal/src/marshal-justin.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 import { Nat } from '@agoric/nat';

--- a/packages/marshal/src/marshal.js
+++ b/packages/marshal/src/marshal.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 import { Nat } from '@agoric/nat';

--- a/packages/marshal/src/passStyleOf.js
+++ b/packages/marshal/src/passStyleOf.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 import { isPromise } from '@agoric/promise-kit';

--- a/packages/marshal/src/types.js
+++ b/packages/marshal/src/types.js
@@ -1,7 +1,6 @@
 // @ts-nocheck TODO Fix the recursive types to it checks. Will this
 // require a .d.ts file? I don't know.
 
-// eslint-disable-next-line spaced-comment
 /// <reference path="extra-types.d.ts" />
 
 /**

--- a/packages/notifier/src/asyncIterableAdaptor.js
+++ b/packages/notifier/src/asyncIterableAdaptor.js
@@ -1,5 +1,4 @@
 // @ts-check
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 import { E } from '@agoric/eventual-send';

--- a/packages/notifier/src/notifier.js
+++ b/packages/notifier/src/notifier.js
@@ -1,5 +1,4 @@
 // @ts-check
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 import { assert } from '@agoric/assert';

--- a/packages/notifier/src/subscriber.js
+++ b/packages/notifier/src/subscriber.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-underscore-dangle */
 // @ts-check
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 import { HandledPromise, E } from '@agoric/eventual-send';

--- a/packages/pegasus/src/types.js
+++ b/packages/pegasus/src/types.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 /**

--- a/packages/promise-kit/src/promiseKit.js
+++ b/packages/promise-kit/src/promiseKit.js
@@ -1,7 +1,6 @@
 /* global globalThis */
 // @ts-check
 
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 /** @type {PromiseConstructor} */

--- a/packages/store/src/keys/checkKey.js
+++ b/packages/store/src/keys/checkKey.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 import {

--- a/packages/store/src/keys/compareKeys.js
+++ b/packages/store/src/keys/compareKeys.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 import { passStyleOf, getTag } from '@agoric/marshal';

--- a/packages/store/src/keys/copyMap.js
+++ b/packages/store/src/keys/copyMap.js
@@ -10,7 +10,6 @@ import {
 import { compareAntiRank, sortByRank } from '../patterns/rankOrder.js';
 import { checkCopySetKeys } from './copySet.js';
 
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 const { details: X } = assert;

--- a/packages/store/src/keys/copySet.js
+++ b/packages/store/src/keys/copySet.js
@@ -13,7 +13,6 @@ import {
   sortByRank,
 } from '../patterns/rankOrder.js';
 
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 const { details: X } = assert;

--- a/packages/store/src/patterns/internal-types.js
+++ b/packages/store/src/patterns/internal-types.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 // TODO

--- a/packages/store/src/patterns/patternMatchers.js
+++ b/packages/store/src/patterns/patternMatchers.js
@@ -26,7 +26,6 @@ import {
 import { checkCopySet /* , makeCopySet XXX TEMP */ } from '../keys/copySet.js';
 import { checkCopyMap, copyMapKeySet } from '../keys/copyMap.js';
 
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 // const { entries, fromEntries } = Object; // XXX TEMP

--- a/packages/store/src/types.js
+++ b/packages/store/src/types.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 /**

--- a/packages/xsnap/src/avaHandler.js
+++ b/packages/xsnap/src/avaHandler.js
@@ -10,9 +10,7 @@ HandledPromise is defined by eventual send shim.
 */
 /* global __dirname, __filename, HandledPromise, issueCommand, test */
 // @ts-check
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses" />
-// eslint-disable-next-line spaced-comment
 /// <reference types="@agoric/eventual-send" />
 
 const encoder = new TextEncoder();

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 /**

--- a/packages/zoe/src/contractSupport/types.js
+++ b/packages/zoe/src/contractSupport/types.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 /**

--- a/packages/zoe/src/types.js
+++ b/packages/zoe/src/types.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 /**

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line spaced-comment
 /// <reference types="ses"/>
 
 /**


### PR DESCRIPTION
## Description

The disabling of [spaced-comment rule](https://eslint.org/docs/rules/spaced-comment) was unnecessary.

### Security Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

n/a
