### PR TITLE
WIP: Use delta list rather than stagings

### DIFF
--- a/packages/store/src/stores/scalarWeakMapStore.js
+++ b/packages/store/src/stores/scalarWeakMapStore.js
@@ -1,4 +1,5 @@
-import { Far, assertPassable, passStyleOf } from '@endo/marshal';
+import { Far, assertPassable, passStyleOf } from '@agoric/marshal';
+import { getCopyMapEntries, isCopyMap } from '../keys/checkKey.js';
 import { fit, assertPattern } from '../patterns/patternMatchers.js';
 
 const { details: X, quote: q } = assert;
@@ -57,6 +58,9 @@ export const makeWeakMapStoreMethods = (
     },
 
     addAll: entries => {
+      if (isCopyMap(entries)) {
+        entries = getCopyMapEntries(entries);
+      }
       for (const [key, value] of entries) {
         // Don't assert that the key either does or does not exist.
         assertKVOkToAdd(key, value);

--- a/packages/store/src/stores/scalarWeakMapStore.js
+++ b/packages/store/src/stores/scalarWeakMapStore.js
@@ -1,4 +1,4 @@
-import { Far, assertPassable, passStyleOf } from '@agoric/marshal';
+import { Far, assertPassable, passStyleOf } from '@endo/marshal';
 import { getCopyMapEntries, isCopyMap } from '../keys/checkKey.js';
 import { fit, assertPattern } from '../patterns/patternMatchers.js';
 

--- a/packages/store/src/stores/scalarWeakSetStore.js
+++ b/packages/store/src/stores/scalarWeakSetStore.js
@@ -1,4 +1,4 @@
-import { Far, passStyleOf } from '@agoric/marshal';
+import { Far, passStyleOf } from '@endo/marshal';
 import { getCopySetKeys, isCopySet } from '../keys/checkKey.js';
 import { fit, assertPattern } from '../patterns/patternMatchers.js';
 

--- a/packages/store/src/stores/scalarWeakSetStore.js
+++ b/packages/store/src/stores/scalarWeakSetStore.js
@@ -1,4 +1,5 @@
-import { Far, passStyleOf } from '@endo/marshal';
+import { Far, passStyleOf } from '@agoric/marshal';
+import { getCopySetKeys, isCopySet } from '../keys/checkKey.js';
 import { fit, assertPattern } from '../patterns/patternMatchers.js';
 
 const { details: X, quote: q } = assert;
@@ -41,6 +42,9 @@ export const makeWeakSetStoreMethods = (
     },
 
     addAll: keys => {
+      if (isCopySet(keys)) {
+        keys = getCopySetKeys(keys);
+      }
       for (const key of keys) {
         assertKeyOkToAdd(key);
         jsset.add(key);

--- a/packages/store/src/types.js
+++ b/packages/store/src/types.js
@@ -147,7 +147,7 @@
  * allows primitives and remotables.
  * @property {(key: K) => void} delete
  * Remove the key. Throws if not found.
- * @property {(keys: Iterable<K>) => void} addAll
+ * @property {(keys: CopySet<K> | Iterable<K>) => void} addAll
  */
 
 /**
@@ -163,7 +163,7 @@
  * allows primitives and remotables.
  * @property {(key: K) => void} delete
  * Remove the key. Throws if not found.
- * @property {(keys: Iterable<K>) => void} addAll
+ * @property {(keys: CopySet<K> | Iterable<K>) => void} addAll
  * @property {(keyPatt?: Pattern) => Iterable<K>} keys
  * @property {(keyPatt?: Pattern) => Iterable<K>} values
  * @property {(keyPatt?: Pattern) => CopySet<K>} snapshot
@@ -187,7 +187,7 @@
  * Set the key. Throws if not found.
  * @property {(key: K) => void} delete
  * Remove the key. Throws if not found.
- * @property {(entries: Iterable<[K,V]>) => void} addAll
+ * @property {(entries: CopyMap<K,V> | Iterable<[K,V]>) => void} addAll
  */
 
 /**
@@ -206,7 +206,7 @@
  * Set the key. Throws if not found.
  * @property {(key: K) => void} delete
  * Remove the key. Throws if not found.
- * @property {(entries: Iterable<[K,V]>) => void} addAll
+ * @property {(entries: CopyMap<K,V> | Iterable<[K,V]>) => void} addAll
  * @property {(keyPatt?: Pattern, valuePatt?: Pattern) => Iterable<K>} keys
  * @property {(keyPatt?: Pattern, valuePatt?: Pattern) => Iterable<V>} values
  * @property {(

--- a/packages/zoe/src/delta/delta.js
+++ b/packages/zoe/src/delta/delta.js
@@ -1,0 +1,50 @@
+// @ts-check
+
+import { makeScalarMapStore, fit } from '@agoric/store';
+import {
+  addToAllocation,
+  subtractFromAllocation,
+} from '../contractFacet/allocationMath.js';
+import { AllocationDeltasShape } from './typeGuards.js';
+import './types.js';
+
+/**
+ * @template S
+ * @type {ApplyDeltas<S>}
+ */
+export const applyDeltas = (seatMgr, uncleanDeltas) => {
+  const cleanDelta = udelta => {
+    if ('add' in udelta) {
+      const { seat, add } = udelta;
+      return harden({ seat, add: seatMgr.cleanAllocation(add) });
+    }
+    const { seat, subtract } = udelta;
+    return harden({ seat, subtract: seatMgr.cleanAllocation(subtract) });
+  };
+
+  fit(uncleanDeltas, AllocationDeltasShape);
+  const deltas = uncleanDeltas.map(cleanDelta);
+  /** @type {MapStore<S, Allocation>} */
+  const allocationMap = makeScalarMapStore();
+  const getAllocation = seat =>
+    allocationMap.has(seat) ? allocationMap.get(seat) : harden({});
+
+  // Do all the adds before the subtracts, so subtract only fails when
+  // it should.
+  for (const delta of deltas) {
+    if ('add' in delta) {
+      const { seat, add } = delta;
+      allocationMap.set(seat, addToAllocation(getAllocation(seat), add));
+    }
+  }
+  for (const delta of deltas) {
+    if ('subtract' in delta) {
+      const { seat, subtract } = delta;
+      allocationMap.set(
+        seat,
+        subtractFromAllocation(getAllocation(seat), subtract),
+      );
+    }
+  }
+  return allocationMap.snapshot();
+};

--- a/packages/zoe/src/delta/typeGuards.js
+++ b/packages/zoe/src/delta/typeGuards.js
@@ -1,0 +1,21 @@
+// @ts-check
+
+import { M } from '@agoric/store';
+import { AmountKeywordRecordShape } from '../typeGuards';
+
+export const AllocationIncrShape = harden({
+  seat: M.remotable(),
+  add: AmountKeywordRecordShape,
+});
+
+export const AllocationDecrShape = harden({
+  seat: M.remotable(),
+  subtract: AmountKeywordRecordShape,
+});
+
+export const AllocationDeltaShape = M.or(
+  AllocationIncrShape,
+  AllocationDecrShape,
+);
+
+export const AllocationDeltasShape = M.arrayOf(AllocationDeltaShape);

--- a/packages/zoe/src/delta/types.js
+++ b/packages/zoe/src/delta/types.js
@@ -1,0 +1,47 @@
+// @ts-check
+
+/**
+ * @template S
+ * @typedef {Object} AllocationIncr
+ * @property {S} seat
+ * @property {AmountKeywordRecord} add
+ */
+
+/**
+ * @template S
+ * @typedef {Object} AllocationDecr
+ * @property {S} seat
+ * @property {AmountKeywordRecord} subtract
+ */
+
+/**
+ * @template S
+ * @typedef {AllocationIncr<S> | AllocationDecr<S>} AllocationDelta
+ */
+
+/**
+ * @template S
+ * @typedef {AllocationDelta<S>[]} AllocationDeltas
+ */
+
+/**
+ * @template S
+ * @typedef {CopyMap<S, Allocation>} SeatAllocations
+ */
+
+/**
+ * @template S
+ * @typedef {Object} ZoeSeatMgr
+ * @property {(uncleanAllocation: Allocation) => Allocation} cleanAllocation
+ * @property {(seat: S) => boolean} hasExited
+ * @property {(seat: S) => Allocation} getCurrentAllocation
+ * @property {(seat: S, newAllocation: Allocation) => boolean} isOfferSafe
+ */
+
+/**
+ * @template S
+ * @callback ApplyDeltas
+ * @param {ZoeSeatMgr<S>} seatMgr
+ * @param {AllocationDeltas<S>} uncleanDeltas
+ * @returns {SeatAllocations<S>}
+ */

--- a/packages/zoe/src/delta/types.js
+++ b/packages/zoe/src/delta/types.js
@@ -2,14 +2,14 @@
 
 /**
  * @template S
- * @typedef {Object} AllocationIncr
+ * @typedef {object} AllocationIncr
  * @property {S} seat
  * @property {AmountKeywordRecord} add
  */
 
 /**
  * @template S
- * @typedef {Object} AllocationDecr
+ * @typedef {object} AllocationDecr
  * @property {S} seat
  * @property {AmountKeywordRecord} subtract
  */
@@ -31,7 +31,7 @@
 
 /**
  * @template S
- * @typedef {Object} ZoeSeatMgr
+ * @typedef {object} ZoeSeatMgr
  * @property {(uncleanAllocation: Allocation) => Allocation} cleanAllocation
  * @property {(seat: S) => boolean} hasExited
  * @property {(seat: S) => Allocation} getCurrentAllocation


### PR DESCRIPTION
Fixes #3850 borrowing elements from the zoe-2 design.

Revisiting the example from #3850 

```js
brandOutPoolSeat.decrementBy({ Secondary: amountOut });
seat.incrementBy({ Out: amountOut });

brandOutPoolSeat.incrementBy(
  brandInPoolSeat.decrementBy({ Central: reducedCentralAmount }));

seat.decrementBy({ In: reducedAmountIn });
brandInPoolSeat.incrementBy({ Secondary: reducedAmountIn });

zcf.reallocate(brandOutPoolSeat, brandInPoolSeat, seat);
```
we'd like to instead say something like
```js
tranferAssets(zcf, harden([
  { seat: brandOutPoolSeat, subtract: { Secondary: amountOut } },
  { seat, add: { Out: amountOut } },

  { seat: brandInPoolSeat, subtract: { Central: reducedCentralAmount } },
  { seat: brandOutPoolSeat, add: { Central: reducedCentralAmount } },

  { seat, subtract: { In: reducedAmountIn } },
  { seat: brandInPoolSeat, add: { Secondary: reducedAmountIn } },
]));
```
Since the argument is just an array, if we don't have it all up front, we could accumulate it incrementally until we're ready to act on it:
```js
const deltas = [];
// ...
deltas.push({ seat: brandInPoolSeat, subtract: { Central: reducedCentralAmount } });
// ...
transferAssets(zcf, harden(deltas));
```

For another approach, see https://github.com/Agoric/agoric-sdk/pull/6577