### PR TITLE
Harden args in`E(x)[method](...args)` to match SwingSet better

### DIFF
--- a/packages/ERTP/test/unitTests/test-inputValidation.js
+++ b/packages/ERTP/test/unitTests/test-inputValidation.js
@@ -135,10 +135,10 @@ test('issuer.combine bad payments array', async t => {
     length: 2,
     split: () => {},
   };
-  // @ts-ignore Intentional wrong type for testing
+  // @ts-expect-error Intentional wrong type for testing
   await t.throwsAsync(() => E(issuer).combine(notAnArray), {
     message:
-      'Cannot pass non-frozen objects like {"length":2,"split":"[Function split]"}. Use harden()',
+      'cannot serialize Remotables with non-methods like "length" in {"length":2,"split":"[Function split]"}',
   });
 
   const notAnArray2 = Far('notAnArray2', {

--- a/packages/eventual-send/src/E.js
+++ b/packages/eventual-send/src/E.js
@@ -35,10 +35,11 @@ function EProxyHandler(x, HandledPromise) {
       // allow the handler to synchronously influence the promise returned
       // by the handled methods, so we must freeze it from the outside. See
       // #95 for details.
-      return (...args) => harden(HandledPromise.applyMethod(x, p, args));
+      return (...args) =>
+        harden(HandledPromise.applyMethod(x, p, harden(args)));
     },
     apply(_target, _thisArg, argArray = []) {
-      return harden(HandledPromise.applyFunction(x, argArray));
+      return harden(HandledPromise.applyFunction(x, harden(argArray)));
     },
     has(_target, _p) {
       // We just pretend everything exists.
@@ -60,12 +61,12 @@ function EsendOnlyProxyHandler(x, HandledPromise) {
     ...baseFreezableProxyHandler,
     get(_target, p, _receiver) {
       return (...args) => {
-        HandledPromise.applyMethodSendOnly(x, p, args);
+        HandledPromise.applyMethodSendOnly(x, p, harden(args));
         return undefined;
       };
     },
     apply(_target, _thisArg, argsArray = []) {
-      HandledPromise.applyFunctionSendOnly(x, argsArray);
+      HandledPromise.applyFunctionSendOnly(x, harden(argsArray));
       return undefined;
     },
     has(_target, _p) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

## Description

There is a discrepancy between unit tests that use `E(x)[method](...args)` and its actual use under SwingSet.  To maximise convenient defensiveness, SwingSet's liveSlots hardens arguments before marshalling them.

This PR makes that behaviour consistent so that unit tests don't fail when the same code would work in production.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

Makes unit tests consistent with in-SwingSet behaviour.
