### PR TITLE
feat(eventual-send)!: harden return values from `E`

### DIFF
--- a/packages/eventual-send/test/test-e.js
+++ b/packages/eventual-send/test/test-e.js
@@ -43,10 +43,16 @@ test('E method calls', async t => {
     double(n) {
       return 2 * n;
     },
+    frozenTest(input) {
+      t.assert(Object.isFrozen(input), 'input is frozen');
+      return { input, ret: 456 };
+    },
   };
   const d = E(x).double(6);
   t.is(typeof d.then, 'function', 'return is a thenable');
   t.is(await d, 12, 'method call works');
+  const output = await E(x).frozenTest({ arg: 123 });
+  t.assert(Object.isFrozen(output), 'output is frozen');
 });
 
 test('E sendOnly method calls', async t => {
@@ -62,11 +68,15 @@ test('E sendOnly method calls', async t => {
       testIncrDoneResolve(); // only here for the test.
       return count;
     },
+    frozenTest(input) {
+      t.assert(Object.isFrozen(input), 'input is frozen');
+    },
   };
   const result = E.sendOnly(counter).incr(42);
   t.is(typeof result, 'undefined', 'return is undefined as expected');
   await testIncrDone;
   t.is(count, 42, 'sendOnly method call variant works');
+  await E(counter).frozenTest({ arg: 123 });
 });
 
 test('E call missing method', async t => {
@@ -145,6 +155,11 @@ test('E.get', async t => {
   const x = {
     name: 'buddy',
     val: 123,
+    testFrozen: input => {
+      t.assert(Object.isFrozen(input), 'input is frozen');
+      return { input, ret: 456 };
+    },
+    output: { ret: 456 },
     y: Object.freeze({
       val2: 456,
       name2: 'holly',
@@ -154,6 +169,11 @@ test('E.get', async t => {
       return `${greeting}, ${this.name}!`;
     },
   };
+  t.assert(Object.isFrozen(await E.get(x).output), 'get output is frozen');
+  t.assert(
+    Object.isFrozen(await E(E.get(x).testFrozen)({ arg: 123 })),
+    'function apply output is frozen',
+  );
   t.is(
     await E(await E.get(await E.get(x).y).fn)(4),
     8,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

refs: #4362

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This is a continuation of #4353 to its logical conclusion (E's return values and fulfillments from eventual sends/gets, should be hardened), based on the rationale in #4362.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

Agoric SDK tests pass without modification.