### PR TITLE
chore(swingset): re-enable all message-patterns tests

### DIFF
--- a/packages/SwingSet/test/message-patterns.js
+++ b/packages/SwingSet/test/message-patterns.js
@@ -308,7 +308,6 @@ export function buildPatterns(log) {
       return b.bert;
     };
   }
-  // TODO https://github.com/Agoric/agoric-sdk/issues/1631
   out.a51 = ['a51 done, got [object Alleged: bert], match true true'];
   test('a51');
 

--- a/packages/SwingSet/test/test-message-patterns.js
+++ b/packages/SwingSet/test/test-message-patterns.js
@@ -123,11 +123,6 @@ async function testLocalPattern(t, name) {
 }
 testLocalPattern.title = (_, name) => `test pattern ${name} local`;
 for (const name of Array.from(bp.patterns.keys()).sort()) {
-  if (name === 'a51') {
-    // TODO https://github.com/Agoric/agoric-sdk/issues/1631
-    // eslint-disable-next-line no-continue
-    continue;
-  }
   test.serial('local patterns', testLocalPattern, name);
 }
 
@@ -173,6 +168,5 @@ async function testCommsPattern(t, name) {
 }
 testCommsPattern.title = (_, name) => `test pattern ${name} comms`;
 for (const name of Array.from(bp.patterns.keys()).sort()) {
-  // TODO https://github.com/Agoric/agoric-sdk/issues/1631
   test.serial('comms patterns', testCommsPattern, name);
 }


### PR DESCRIPTION
One test was disabled a while ago while implementing the `iface:` Presence
stringification code. I don't know what the core issue was, but it seems to
be working ok now, so I've reenabled it.

closes #1631
