### PR TITLE
chore(swingset): fix funky use of test.log in test-promises.js

### DIFF
--- a/packages/SwingSet/test/basedir-promises/bootstrap.js
+++ b/packages/SwingSet/test/basedir-promises/bootstrap.js
@@ -10,8 +10,8 @@ export function buildRootObject(vatPowers, vatParameters) {
     bootstrap(vats) {
       const mode = vatParameters.argv[0];
       if (mode === 'flush') {
-        Promise.resolve().then(log('then1'));
-        Promise.resolve().then(log('then2'));
+        Promise.resolve('then1').then(log);
+        Promise.resolve('then2').then(log);
       } else if (mode === 'e-then') {
         E(vats.left)
           .callRight(1, vats.right)


### PR DESCRIPTION
This test was just meant to assert that all promptly-runnable Promise
callbacks happen before the crank ends, but I did something obviously wrong
with the log calls. This fixes the log calls.

closes #1779
