### PR TITLE
refactor(marshal): test isObject without allocation

### DIFF
--- a/packages/marshal/src/helpers/passStyle-helpers.js
+++ b/packages/marshal/src/helpers/passStyle-helpers.js
@@ -17,7 +17,8 @@ export const hasOwnPropertyOf = (obj, prop) =>
   apply(objectHasOwnProperty, obj, [prop]);
 harden(hasOwnPropertyOf);
 
-export const isObject = val => Object(val) === val;
+export const isObject = val =>
+  val !== null && (typeof val === 'object' || typeof val === 'function');
 harden(isObject);
 
 export const PASS_STYLE = Symbol.for('passStyle');


### PR DESCRIPTION
closes: #4287
though I didn't address the "should" around `isPrimitive`. It's not clear to me where that should be used.

@kriskowal marshal is moving to endo, right? I suppose you'll re-sync when you remove stuff from agoric-sdk?