### PR TITLE
refactor: unify TypeScript project

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "lint-fix": "yarn lerna run --no-bail lint-fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:packages": "yarn lerna run --no-bail lint",
+    "lint:all-types": "yarn tsc --project tsconfig.build.json",
     "test": "yarn lerna run --no-bail test",
     "test:c8-all": "rm -rf coverage/tmp && C8_OPTIONS=\"--clean=false --temp-directory=$PWD/coverage/tmp\" lerna run test:c8",
     "test:xs": "yarn workspaces run test:xs",

--- a/packages/SwingSet/package.json
+++ b/packages/SwingSet/package.json
@@ -21,7 +21,6 @@
     "lint:eslint": "eslint ."
   },
   "devDependencies": {
-    "@types/better-sqlite3": "^7.5.0",
     "@types/microtime": "^2.1.0",
     "@types/tmp": "^0.2.0",
     "@types/yargs-parser": "^21.0.0"
@@ -56,7 +55,7 @@
     "@endo/zip": "^0.2.34",
     "ansi-styles": "^6.2.1",
     "anylogger": "^0.21.0",
-    "better-sqlite3": "^8.2.0",
+    "better-sqlite3": "^9.1.1",
     "import-meta-resolve": "^2.2.1",
     "microtime": "^3.1.0",
     "semver": "^6.3.0",

--- a/packages/agoric-cli/src/anylogger-agoric.js
+++ b/packages/agoric-cli/src/anylogger-agoric.js
@@ -1,3 +1,4 @@
+// @ts-check
 /* global process */
 import anylogger from 'anylogger';
 import chalk from 'chalk';
@@ -13,8 +14,9 @@ if (DEBUG === undefined) {
 const defaultLevel = anylogger.levels[selectedLevel];
 
 const oldExt = anylogger.ext;
-anylogger.ext = (l, o) => {
-  l = oldExt(l, o);
+/** @type {typeof anylogger.ext} */
+anylogger.ext = l => {
+  l = oldExt(l);
   l.enabledFor = lvl => defaultLevel >= anylogger.levels[lvl];
 
   const prefix = l.name.replace(/:/g, ': ');

--- a/packages/agoric-cli/src/chain-config.js
+++ b/packages/agoric-cli/src/chain-config.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import djson from 'deterministic-json';
 import TOML from '@iarna/toml';
 import * as Tokens from '@agoric/internal/src/tokens.js';
@@ -189,7 +190,11 @@ export function finishTendermintConfig({
   return TOML.stringify(config);
 }
 
-// Rewrite/import the genesis.json.
+/**
+ * Rewrite/import the genesis.json
+ *
+ * @param {genesisJson: string, exportedGenesisJson?: string} genesisjsons
+ */
 export function finishCosmosGenesis({ genesisJson, exportedGenesisJson }) {
   const genesis = JSON.parse(genesisJson);
   const exported = exportedGenesisJson ? JSON.parse(exportedGenesisJson) : {};

--- a/packages/agoric-cli/src/cosmos.js
+++ b/packages/agoric-cli/src/cosmos.js
@@ -1,3 +1,4 @@
+// @ts-check
 import chalk from 'chalk';
 import path from 'path';
 import { makePspawn, getSDKBinaries } from './helpers.js';
@@ -50,6 +51,7 @@ export default async function cosmosMain(progname, rawArgs, powers, opts) {
                 },
               );
               // Ensure the build doesn't mess up stdout.
+              assert(ps.childProcess.stdout);
               ps.childProcess.stdout.pipe(process.stderr);
               return ps;
             }

--- a/packages/agoric-cli/src/helpers.js
+++ b/packages/agoric-cli/src/helpers.js
@@ -27,7 +27,7 @@ export const getSDKBinaries = ({
  * @param {Record<string, string | undefined>} [param0.env] the default environment
  * @param {*} [param0.chalk] a colorizer
  * @param {Console} [param0.log] a console object
- * @param {(cmd: string, cargs: Array<string>, opts: any) => ChildProcess}param0.spawn the spawn function
+ * @param {import('child_process').spawn} param0.spawn the spawn function
  */
 export const makePspawn = ({
   env: defaultEnv = process.env,
@@ -38,13 +38,9 @@ export const makePspawn = ({
   /**
    * Promisified spawn.
    *
-   * @param {string} cmd command name to run
-   * @param {Array<string>} cargs arguments to the command
-   * @param {object} param2
-   * @param {string} [param2.cwd]
-   * @param {string | [string, string, string]} [param2.stdio] standard IO
-   * specification
-   * @param {Record<string, string | undefined>} [param2.env] environment
+   * @param {Parameters<import('child_process').spawn>[0]} cmd command name to run
+   * @param {Parameters<import('child_process').spawn>[1]} cargs arguments to the command
+   * @param {Parameters<import('child_process').spawn>[2]} options
    * @returns {Promise<number> & { childProcess: ChildProcess }}} promise for
    * exit status. The return result has a `childProcess` property to obtain
    * control over the running process

--- a/packages/agoric-cli/src/install.js
+++ b/packages/agoric-cli/src/install.js
@@ -1,3 +1,4 @@
+// @ts-check
 /* global process AggregateError Buffer */
 import path from 'path';
 import chalk from 'chalk';
@@ -38,6 +39,7 @@ export default async function installMain(progname, rawArgs, powers, opts) {
       stdio: ['inherit', 'pipe', 'inherit'],
     });
     const stdout = [];
+    assert(p.childProcess.stdout);
     p.childProcess.stdout.on('data', out => stdout.push(out));
     await p;
     const d = JSON.parse(Buffer.concat(stdout).toString('utf-8'));
@@ -175,9 +177,11 @@ export default async function installMain(progname, rawArgs, powers, opts) {
           );
           if (failures.length) {
             if (typeof AggregateError !== 'function') {
+              // @ts-expect-error Property 'reason' does not exist on type 'PromiseSettledResult'
               throw failures[0].reason;
             }
             throw AggregateError(
+              // @ts-expect-error Property 'reason' does not exist on type 'PromiseSettledResult'
               failures.map(({ reason }) => reason),
               'Failed to prune',
             );
@@ -268,6 +272,7 @@ export default async function installMain(progname, rawArgs, powers, opts) {
     };
     await Promise.all(subdirs.map(removeNodeModulesSymlinks));
   } else {
+    // @ts-expect-error sdkPackageToPath is Map<string, string>
     DEFAULT_SDK_PACKAGE_NAMES.forEach(name => sdkPackageToPath.set(name, null));
   }
 

--- a/packages/agoric-cli/src/run.js
+++ b/packages/agoric-cli/src/run.js
@@ -1,3 +1,4 @@
+// @ts-check
 import makeScratchPad from '@agoric/internal/src/scratch.js';
 import { makeScriptLoader } from './scripts.js';
 

--- a/packages/agoric-cli/src/scripts.js
+++ b/packages/agoric-cli/src/scripts.js
@@ -56,7 +56,7 @@ export const makeLookup =
 
 /**
  * @param {string[]} scripts
- * @param {{ allowUnsafePlugins: boolean, progname: string, rawArgs: string[], endowments?: Record<string, any> }} opts
+ * @param {{ allowUnsafePlugins?: boolean, progname: string, rawArgs: string[], endowments?: Record<string, any> }} opts
  * @param {{ fs: import('fs/promises'), console: Console }} powers
  */
 export const makeScriptLoader =

--- a/packages/agoric-cli/src/start.js
+++ b/packages/agoric-cli/src/start.js
@@ -1,3 +1,4 @@
+// @ts-check
 /* eslint @typescript-eslint/no-floating-promises: "warn" */
 /* global process setTimeout */
 import chalk from 'chalk';
@@ -279,11 +280,11 @@ export default async function startMain(progname, rawArgs, powers, opts) {
 
     let chainSpawn;
     if (!popts.dockerTag) {
-      chainSpawn = (args, spawnOpts = undefined) => {
+      chainSpawn = (args, spawnOpts) => {
         return pspawn(cosmosChain, [...args, `--home=${serverDir}`], spawnOpts);
       };
     } else {
-      chainSpawn = (args, spawnOpts = undefined, dockerArgs = []) =>
+      chainSpawn = (args, spawnOpts, dockerArgs = []) =>
         pspawn(
           'docker',
           [
@@ -398,10 +399,12 @@ export default async function startMain(progname, rawArgs, powers, opts) {
     const newGenesisJson = finishCosmosGenesis({
       genesisJson,
     });
+    // @ts-expect-error typedef lacking optionality
     const newConfigToml = finishTendermintConfig({
       configToml,
       portNum,
     });
+    // @ts-expect-error typedef lacking optionality
     const newAppToml = finishCosmosApp({
       appToml,
       portNum,
@@ -486,10 +489,9 @@ export default async function startMain(progname, rawArgs, powers, opts) {
 
     let soloSpawn;
     if (!popts.dockerTag) {
-      soloSpawn = (args, spawnOpts = undefined) =>
-        pspawn(agSolo, args, spawnOpts);
+      soloSpawn = (args, spawnOpts) => pspawn(agSolo, args, spawnOpts);
     } else {
-      soloSpawn = (args, spawnOpts = undefined, dockerArgs = []) =>
+      soloSpawn = (args, spawnOpts, dockerArgs = []) =>
         pspawn(
           'docker',
           [

--- a/packages/agoric-cli/src/start.js
+++ b/packages/agoric-cli/src/start.js
@@ -184,7 +184,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
 
     await null;
     if (popts.reset) {
-      rmVerbose(serverDir);
+      void rmVerbose(serverDir);
     }
 
     if (!opts.dockerTag) {
@@ -274,7 +274,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
 
     const serverDir = `${SERVERS_ROOT_DIR}/${profileName}-${portNum}`;
     if (popts.reset) {
-      rmVerbose(serverDir);
+      void rmVerbose(serverDir);
     }
 
     let chainSpawn;
@@ -481,7 +481,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
     }
 
     if (popts.reset) {
-      rmVerbose(serverDir);
+      void rmVerbose(serverDir);
     }
 
     let soloSpawn;
@@ -704,7 +704,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
     const serverDir = `${SERVERS_ROOT_DIR}/${profileName}-${port}`;
 
     if (popts.reset) {
-      rmVerbose(serverDir);
+      void rmVerbose(serverDir);
     }
 
     const setupRun = (...bonusArgs) =>
@@ -731,7 +731,7 @@ export default async function startMain(progname, rawArgs, powers, opts) {
 
     await null;
     if (popts.reset) {
-      rmVerbose(serverDir);
+      void rmVerbose(serverDir);
     }
 
     const setupRun = (...bonusArgs) =>

--- a/packages/agoric-cli/test/test-main.js
+++ b/packages/agoric-cli/test/test-main.js
@@ -20,6 +20,7 @@ test('sanity', async t => {
   const myMain = args => {
     const oldConsole = console;
     try {
+      // @ts-expect-error
       globalThis.console = stubAnylogger();
       return main('foo', args, {
         anylogger: stubAnylogger,

--- a/packages/agoric-cli/test/upgrade-contract/init-proposal.js
+++ b/packages/agoric-cli/test/upgrade-contract/init-proposal.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { E } from '@endo/far';
 
 /**

--- a/packages/agoric-cli/test/upgrade-contract/propose-buggy-contract.js
+++ b/packages/agoric-cli/test/upgrade-contract/propose-buggy-contract.js
@@ -14,6 +14,7 @@ export const defaultProposalBuilder = async ({ publishRef, install }) =>
     ],
   });
 
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').DeployScriptFunction} */
 export default async (homeP, endowments) => {
   const helperEndowments = {
     ...endowments,

--- a/packages/agoric-cli/test/upgrade-contract/propose-upgrade-contract.js
+++ b/packages/agoric-cli/test/upgrade-contract/propose-upgrade-contract.js
@@ -14,6 +14,7 @@ export const defaultProposalBuilder = async ({ publishRef, install }) =>
     ],
   });
 
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').DeployScriptFunction} */
 export default async (homeP, endowments) => {
   const helperEndowments = {
     ...endowments,

--- a/packages/agoric-cli/tools/getting-started.js
+++ b/packages/agoric-cli/tools/getting-started.js
@@ -1,5 +1,5 @@
 /* global process setTimeout clearTimeout setInterval clearInterval */
-
+// @ts-check
 import fs from 'fs';
 import path from 'path';
 import tmp from 'tmp';
@@ -41,8 +41,10 @@ export const gettingStartedWorkflowTest = async (t, options = {}) => {
   // Kill an entire process group.
   const pkill = (cp, signal = 'SIGINT') => process.kill(-cp.pid, signal);
 
+  /** @type {typeof pspawn} */
   function pspawnStdout(...args) {
     const ps = pspawn(...args);
+    assert(ps.childProcess.stdout);
     ps.childProcess.stdout.on('data', chunk => {
       process.stdout.write(chunk);
     });
@@ -170,6 +172,7 @@ export const gettingStartedWorkflowTest = async (t, options = {}) => {
 
       if (opts.stdin) {
         // Write the input to stdin.
+        assert(deployP.childProcess.stdin);
         deployP.childProcess.stdin.write(opts.stdin);
         deployP.childProcess.stdin.end();
       }
@@ -200,6 +203,7 @@ export const gettingStartedWorkflowTest = async (t, options = {}) => {
       urlReq.setTimeout(2000);
       urlReq.on('error', err => urlResolve(`Cannot connect to ${url}: ${err}`));
       urlReq.end();
+      // @ts-expect-error urlResolve could be undefined
       const urlTimeout = setTimeout(urlResolve, 3000, 'timeout');
       const urlDone = await urlP;
       clearTimeout(urlTimeout);
@@ -235,7 +239,7 @@ export const gettingStartedWorkflowTest = async (t, options = {}) => {
         });
         req.setTimeout(2000);
         req.on('error', err => {
-          if (err.code !== 'ECONNREFUSED') {
+          if ('code' in err && err.code !== 'ECONNREFUSED') {
             resolve(`Cannot connect to UI server: ${err}`);
           }
         });

--- a/packages/builders/scripts/inter-protocol/add-STARS.js
+++ b/packages/builders/scripts/inter-protocol/add-STARS.js
@@ -36,6 +36,7 @@ export const starsOraclesProposalBuilder = async powers => {
   });
 };
 
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').DeployScriptFunction} */
 export default async (homeP, endowments) => {
   const { writeCoreProposal } = await makeHelpers(homeP, endowments);
   await writeCoreProposal('add-STARS', starsVaultProposalBuilder);

--- a/packages/builders/scripts/inter-protocol/add-collateral-core.js
+++ b/packages/builders/scripts/inter-protocol/add-collateral-core.js
@@ -1,3 +1,4 @@
+// @ts-check
 /* global process */
 import { makeHelpers } from '@agoric/deploy-script-support';
 
@@ -103,6 +104,7 @@ export const psmProposalBuilder = async (
   });
 };
 
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').DeployScriptFunction} */
 export default async (homeP, endowments) => {
   const { writeCoreProposal } = await makeHelpers(homeP, endowments);
 
@@ -112,6 +114,7 @@ export default async (homeP, endowments) => {
 
   await writeCoreProposal('gov-add-collateral', defaultProposalBuilder);
   await writeCoreProposal('gov-start-psm', opts =>
+    // @ts-expect-error xxx wrapInstall generics
     psmProposalBuilder({ ...opts, wrapInstall: tool.wrapInstall }),
   );
 };

--- a/packages/builders/scripts/inter-protocol/deploy-contracts.js
+++ b/packages/builders/scripts/inter-protocol/deploy-contracts.js
@@ -29,7 +29,7 @@ const provideWhen = async (store, key, make) => {
   await E(store).set(key, value);
   return value;
 };
-
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').DeployScriptFunction} */
 export default async (homeP, endowments) => {
   const home = await homeP;
   const { zoe, scratch, board } = home;

--- a/packages/builders/scripts/inter-protocol/init-core.js
+++ b/packages/builders/scripts/inter-protocol/init-core.js
@@ -1,3 +1,4 @@
+// @ts-check
 /* global process */
 /**
  * @file can be run with `agoric deploy` after a chain is running (depends on
@@ -183,7 +184,7 @@ export const defaultProposalBuilder = async (
     ],
   });
 };
-
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').DeployScriptFunction} */
 export default async (homeP, endowments) => {
   const { writeCoreProposal } = await makeHelpers(homeP, endowments);
 
@@ -192,9 +193,11 @@ export default async (homeP, endowments) => {
   });
   await Promise.all([
     writeCoreProposal('gov-econ-committee', opts =>
+      // @ts-expect-error xxx InstallBundle/wrapInstall types
       committeeProposalBuilder({ ...opts, wrapInstall: tool.wrapInstall }),
     ),
     writeCoreProposal('gov-amm-vaults-etc', opts =>
+      // @ts-expect-error xxx InstallBundle/wrapInstall types
       mainProposalBuilder({ ...opts, wrapInstall: tool.wrapInstall }),
     ),
   ]);

--- a/packages/builders/scripts/inter-protocol/invite-committee-core.js
+++ b/packages/builders/scripts/inter-protocol/invite-committee-core.js
@@ -35,7 +35,7 @@ export const defaultProposalBuilder = async (
     ],
   });
 };
-
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').DeployScriptFunction} */
 export default async (homeP, endowments) => {
   const { writeCoreProposal } = await makeHelpers(homeP, endowments);
   await writeCoreProposal('gov-invite-committee', defaultProposalBuilder);

--- a/packages/builders/scripts/pegasus/init-core.js
+++ b/packages/builders/scripts/pegasus/init-core.js
@@ -16,7 +16,7 @@ export const defaultProposalBuilder = async ({ publishRef, install }) =>
       },
     ],
   });
-
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').DeployScriptFunction} */
 export default async (homeP, endowments) => {
   const { writeCoreProposal } = await makeHelpers(homeP, endowments);
   await writeCoreProposal('gov-pegasus', defaultProposalBuilder);

--- a/packages/builders/scripts/smart-wallet/build-game1-start.js
+++ b/packages/builders/scripts/smart-wallet/build-game1-start.js
@@ -27,7 +27,7 @@ export const game1ProposalBuilder = async ({ publishRef, install }) => {
   });
 };
 
-/** @type {DeployScriptFunction} */
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').DeployScriptFunction} */
 export default async (homeP, endowments) => {
   const { writeCoreProposal } = await makeHelpers(homeP, endowments);
   await writeCoreProposal('start-game1', game1ProposalBuilder);

--- a/packages/builders/scripts/smart-wallet/build-walletFactory-upgrade.js
+++ b/packages/builders/scripts/smart-wallet/build-walletFactory-upgrade.js
@@ -27,8 +27,7 @@ export const defaultProposalBuilder = async ({ publishRef, install }) => {
     ],
   });
 };
-
-/** @type {DeployScriptFunction} */
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').DeployScriptFunction} */
 export default async (homeP, endowments) => {
   const { writeCoreProposal } = await makeHelpers(homeP, endowments);
   await writeCoreProposal('upgrade-walletFactory', defaultProposalBuilder);

--- a/packages/builders/scripts/vats/init-core.js
+++ b/packages/builders/scripts/vats/init-core.js
@@ -24,7 +24,7 @@ export const defaultProposalBuilder = async ({ publishRef, install }) =>
       },
     ],
   });
-
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').DeployScriptFunction} */
 export default async (homeP, endowments) => {
   const { writeCoreProposal } = await makeHelpers(homeP, endowments);
   await writeCoreProposal('gov-vats', defaultProposalBuilder);

--- a/packages/builders/scripts/vats/init-network.js
+++ b/packages/builders/scripts/vats/init-network.js
@@ -12,7 +12,7 @@ export const defaultProposalBuilder = async ({ publishRef, install }) =>
       },
     ],
   });
-
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').DeployScriptFunction} */
 export default async (homeP, endowments) => {
   const { writeCoreProposal } = await makeHelpers(homeP, endowments);
   await writeCoreProposal('gov-network', defaultProposalBuilder);

--- a/packages/builders/scripts/vats/replace-zoe.js
+++ b/packages/builders/scripts/vats/replace-zoe.js
@@ -12,7 +12,7 @@ export const defaultProposalBuilder = async ({ publishRef, install }) =>
       },
     ],
   });
-
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').DeployScriptFunction} */
 export default async (homeP, endowments) => {
   const { writeCoreProposal } = await makeHelpers(homeP, endowments);
   await writeCoreProposal('replace-zcf', defaultProposalBuilder);

--- a/packages/builders/scripts/vats/restart-vats.js
+++ b/packages/builders/scripts/vats/restart-vats.js
@@ -16,7 +16,7 @@ export const defaultProposalBuilder = async () => {
     getManifestCall: ['getManifestForRestart', harden({ skip })],
   });
 };
-
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').DeployScriptFunction} */
 export default async (homeP, endowments) => {
   const { writeCoreProposal } = await makeHelpers(homeP, endowments);
   await writeCoreProposal('restart-vats', defaultProposalBuilder);

--- a/packages/builders/scripts/vats/set-core-proposal-env.js
+++ b/packages/builders/scripts/vats/set-core-proposal-env.js
@@ -10,7 +10,7 @@ if (!spec) {
 }
 
 const vatConfigFile = require.resolve(spec);
-const configJson = fs.readFileSync(vatConfigFile);
+const configJson = fs.readFileSync(vatConfigFile, 'utf8');
 const config = JSON.parse(configJson);
 
 const envs = new Map();

--- a/packages/builders/scripts/vats/upgrade-zoe.js
+++ b/packages/builders/scripts/vats/upgrade-zoe.js
@@ -11,7 +11,7 @@ export const defaultProposalBuilder = async ({ publishRef, install }) =>
       },
     ],
   });
-
+/** @type {import('@agoric/deploy-script-support/src/externalTypes.js').DeployScriptFunction} */
 export default async (homeP, endowments) => {
   const { writeCoreProposal } = await makeHelpers(homeP, endowments);
   await writeCoreProposal('null-upgrade-zoe', defaultProposalBuilder);

--- a/packages/cosmic-swingset/src/anylogger-agoric.js
+++ b/packages/cosmic-swingset/src/anylogger-agoric.js
@@ -1,3 +1,4 @@
+// @ts-check
 /* global process */
 import anylogger from 'anylogger';
 
@@ -29,8 +30,9 @@ if (process.env.DEBUG === undefined) {
 const defaultLevel = anylogger.levels[debugging];
 
 const oldExt = anylogger.ext;
-anylogger.ext = (l, o) => {
-  l = oldExt(l, o);
+/** @type {typeof anylogger.ext} */
+anylogger.ext = l => {
+  l = oldExt(l);
   l.enabledFor = lvl => defaultLevel >= anylogger.levels[lvl];
 
   const prefix = l.name.replace(/:/g, ': ');

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -122,6 +122,11 @@ const makePrefixedBridgeStorage = (
   });
 };
 
+/**
+ * @param {string} progname
+ * @param {string[]} args
+ * @param {{env: typeof process.env, homedir: string, agcc: any}} opts
+ */
 export default async function main(progname, args, { env, homedir, agcc }) {
   const portNums = {};
 
@@ -378,7 +383,7 @@ export default async function main(progname, args, { env, homedir, agcc }) {
       serviceName: TELEMETRY_SERVICE_NAME,
     });
 
-    const { XSNAP_KEEP_SNAPSHOTS, NODE_HEAP_SNAPSHOTS = -1 } = env;
+    const { XSNAP_KEEP_SNAPSHOTS, NODE_HEAP_SNAPSHOTS = '-1' } = env;
     const slogSender = await makeSlogSender({
       stateDir: stateDBDir,
       env,

--- a/packages/cosmic-swingset/src/entrypoint.js
+++ b/packages/cosmic-swingset/src/entrypoint.js
@@ -1,4 +1,5 @@
 #! /usr/bin/env node
+// @ts-check
 // @jessie-check
 
 import '@endo/init/pre.js';
@@ -8,7 +9,6 @@ import agcc from '@agoric/cosmos';
 import '@endo/init/unsafe-fast.js';
 
 import os from 'os';
-import path from 'path';
 import process from 'process';
 
 import './anylogger-agoric.js';
@@ -18,7 +18,6 @@ import main from './chain-main.js';
 const log = anylogger('ag-chain-cosmos');
 
 main(process.argv[1], process.argv.splice(2), {
-  path,
   homedir: os.homedir(),
   env: process.env,
   agcc,

--- a/packages/cosmic-swingset/src/helpers/json-stable-stringify.js
+++ b/packages/cosmic-swingset/src/helpers/json-stable-stringify.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /* eslint-disable */
 
 // https://github.com/substack/json-stable-stringify/

--- a/packages/cosmic-swingset/src/sim-chain.js
+++ b/packages/cosmic-swingset/src/sim-chain.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /* global process setTimeout clearTimeout */
 import path from 'path';
 import fs from 'fs';

--- a/packages/cosmic-swingset/test/gov-code.js
+++ b/packages/cosmic-swingset/test/gov-code.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /* global E */
 /**
  * This file, along with the companion `gov-permit.json`, are used to test "big

--- a/packages/cosmic-swingset/test/test-clean-core-eval.js
+++ b/packages/cosmic-swingset/test/test-clean-core-eval.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import test from 'ava';
 import {
   defangEvaluableCode,

--- a/packages/cosmic-swingset/test/test-provision-smartwallet.js
+++ b/packages/cosmic-swingset/test/test-provision-smartwallet.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /* global setTimeout */
 import test from 'ava';
 

--- a/packages/deploy-script-support/src/externalTypes.js
+++ b/packages/deploy-script-support/src/externalTypes.js
@@ -28,7 +28,7 @@ export {};
 /**
  * @callback InstallBundle
  * @param {string} srcSpec
- * @param {string} bundlePath
+ * @param {string} [bundlePath]
  * @param {any} [opts]
  * @returns {Promise<ManifestBundleRef>}
  */
@@ -38,8 +38,46 @@ export {};
  * @param {{
  *   publishRef: PublishBundleRef,
  *   install: InstallBundle,
- *   wrapInstall?: <T>(f: T) => T }
+ *   wrapInstall?: <T extends InstallBundle>(f: T) => T }
  * } powers
  * @param {...any} args
  * @returns {Promise<ProposalResult>}
+ */
+
+/**
+ * @typedef {{
+ *  bundleSource: typeof import('@endo/bundle-source').default,
+ *  now: () => number,
+ *  lookup: (...path: string[]) => unknown,
+ *  publishBundle: PublishBundleRef,
+ *  pathResolve: (...path: string[]) => string,
+ *  cacheDir: string,
+ * }} DeployScriptEndownments
+ */
+
+/**
+ * @typedef {{
+ * agoricNames: ERef<import('@agoric/vats').NameHub>,
+ * bank: ERef<import("@agoric/vats/src/vat-bank.js").Bank>,
+ * board: ERef<import("@agoric/vats").Board>,
+ * faucet: unknown,
+ * myAddressNameAdmin: ERef<import("@agoric/vats").NameAdmin>,
+ * namesByAddress: ERef<import('@agoric/vats').NameHub>,
+ * scratch: ERef<import('@agoric/internal/src/scratch.js').ScratchPad>,
+ * zoe: ERef<ZoeService>,
+ * }} CanonicalHome
+ */
+
+// TODO wallet as import('@agoric/wallet-backend/src/types').WalletAdmin once it's a module
+/**
+ * @typedef {CanonicalHome & {
+ * wallet?: any,
+ * }} AgSoloHome
+ */
+
+/**
+ * @callback DeployScriptFunction
+ * @param {Promise<CanonicalHome>} homeP
+ * @param {DeployScriptEndownments} endowments
+ * @returns {Promise<void>}
  */

--- a/packages/deployment/package.json
+++ b/packages/deployment/package.json
@@ -22,7 +22,7 @@
     "@agoric/assert": "^0.6.0",
     "@endo/init": "^0.5.59",
     "@endo/marshal": "^0.8.8",
-    "better-sqlite3": "^8.2.0",
+    "better-sqlite3": "^9.1.1",
     "chalk": "^5.2.0",
     "deterministic-json": "^1.0.5",
     "inquirer": "^8.2.2",

--- a/packages/deployment/src/entrypoint.js
+++ b/packages/deployment/src/entrypoint.js
@@ -22,7 +22,7 @@ deploy(process.argv[1], process.argv.splice(2), {
   rd: files.reading(fs, path),
   wr: files.writing(fs, path, temp),
   setup: setup({ resolve: path.resolve, env: process.env, setInterval }),
-  running: running(process, { exec, process, spawn }),
+  running: running(process, { exec, spawn }),
   inquirer,
   fetch,
 }).then(

--- a/packages/deployment/src/init.js
+++ b/packages/deployment/src/init.js
@@ -277,14 +277,13 @@ const askProvider =
 const doInit =
   ({ env, rd, wr, running, setup, inquirer, fetch, parseArgs }) =>
   async (progname, args) => {
-    const { needDoRun, needBacktick, cwd, chdir } = running;
+    const { needDoRun, cwd, chdir } = running;
     const PROVIDERS = makeProviders({
       env,
       inquirer,
       wr,
       setup,
       fetch,
-      needBacktick,
     });
 
     const { _: parsedArgs, noninteractive } = parseArgs(args.slice(1), {

--- a/packages/deployment/src/main.js
+++ b/packages/deployment/src/main.js
@@ -1,4 +1,4 @@
-/* eslint-disable @jessie.js/safe-await-separator */
+/* eslint-disable @jessie.js/safe-await-separator, @typescript-eslint/prefer-ts-expect-error */
 import djson from 'deterministic-json';
 import { createHash } from 'crypto';
 import chalk from 'chalk';
@@ -259,11 +259,12 @@ show-config      display the client connection parameters
       const subArgs = args.slice(1);
       const versionFile = `chain-version.txt`;
 
-      let epoch = '0';
+      let epoch = 0;
       if (await rd.exists(versionFile)) {
         const vstr = await trimReadFile(versionFile);
         const match = vstr.match(/^(\d+)/);
-        epoch = match[1] || '0';
+        assert(match);
+        epoch = Number(match[1]) || 0;
       }
 
       let versionKind = subArgs[0];
@@ -777,6 +778,7 @@ ${chalk.yellow.bold(`ag-setup-solo --netconfig='${dwebHost}/network-config'`)}
       }
 
       for (const CLUSTER of Object.keys(prov.public_ips.value)) {
+        assert(selector);
         if (!selector(CLUSTER)) {
           continue;
         }
@@ -904,16 +906,16 @@ ${name}:
       };
 
       const addAll = makeGroup('all');
-      const addChainCosmos = makeGroup('ag-chain-cosmos', 4);
-      const addDweb = makeGroup('dweb', 4);
+      const addChainCosmos = makeGroup('ag-chain-cosmos');
+      const addDweb = makeGroup('dweb');
       const addRole = {};
       for (const provider of Object.keys(prov.public_ips.value).sort()) {
-        const addProvider = makeGroup(provider, 4);
+        const addProvider = makeGroup(provider);
         const ips = prov.public_ips.value[provider];
         const offset = Number(prov.offsets.value[provider]);
         const role = prov.roles.value[provider];
         if (!addRole[role]) {
-          addRole[role] = makeGroup(role, 4);
+          addRole[role] = makeGroup(role);
         }
         const keyFile = rd.resolve(
           rd.dirname(SSH_PRIVATE_KEY_FILE),
@@ -986,6 +988,7 @@ ${node}:${roleParams}
         }
       } else {
         // Need to escape each argument individually.
+        // @ts-ignore Property 'map' does not exist on type '"run"'
         const escapedArgs = cmd.map(shellEscape);
         runArg = `sh -c ${shellEscape(escapedArgs.join(' '))}`;
       }

--- a/packages/deployment/src/run.js
+++ b/packages/deployment/src/run.js
@@ -16,12 +16,16 @@ export const running = (process, { exec, spawn }) => {
     },
     exec: cmd => {
       const cp = exec(cmd);
-      const promise = new Promise((resolve, reject) => {
-        cp.addListener('error', reject);
-        cp.addListener('exit', code => {
-          resolve(code);
-        });
-      });
+
+      const promise =
+        /** @type {Promise<number> & {process: import('child_process').ChildProcess}} */ (
+          new Promise((resolve, reject) => {
+            cp.addListener('error', reject);
+            cp.addListener('exit', code => {
+              resolve(code);
+            });
+          })
+        );
       promise.process = cp;
       return promise;
     },
@@ -36,6 +40,8 @@ export const running = (process, { exec, spawn }) => {
           callback();
         },
       });
+      assert(cp.process.stdout);
+      assert(cp.process.stderr);
       cp.process.stdout.pipe(stdout);
       cp.process.stderr.pipe(process.stderr);
 
@@ -61,7 +67,7 @@ export const running = (process, { exec, spawn }) => {
       }
       return new Promise(resolve => {
         process.chdir(path);
-        resolve();
+        resolve(undefined);
       });
     },
 

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-12/zoe-full-upgrade/run-prober-script.js
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-12/zoe-full-upgrade/run-prober-script.js
@@ -1,4 +1,4 @@
-// @ts-no-check
+// @ts-nocheck
 /* global E */
 
 // to turn on ts-check:

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-12/zoe-full-upgrade/zcf-upgrade-script.js
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/agoric-upgrade-12/zoe-full-upgrade/zcf-upgrade-script.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // to turn on ts-check:
 /* global E */
 

--- a/packages/deployment/upgrade-test/upgrade-test-scripts/package.json
+++ b/packages/deployment/upgrade-test/upgrade-test-scripts/package.json
@@ -3,7 +3,7 @@
   "devDependencies": {},
   "dependencies": {
     "ava": "^5.3.1",
-    "better-sqlite3": "^8.5.1",
+    "better-sqlite3": "^9.1.1",
     "execa": "^7.2.0"
   },
   "scripts": {

--- a/packages/import-manager/src/importManager.js
+++ b/packages/import-manager/src/importManager.js
@@ -1,5 +1,7 @@
 // Copyright (C) 2019 Agoric, under Apache License 2.0
 
+/// <reference types="ses" />
+
 /**
  * ImportManager allows a package to make some code available that can be run
  * locally by a calling vat without requiring a remote round trip to the hosting
@@ -36,6 +38,7 @@ function importManager() {
       for (const name of Object.getOwnPropertyNames(obj)) {
         entries[name] = obj[name];
       }
+      // @ts-expect-error entries can contain properties absent in T
       return harden(entries);
     },
   });

--- a/packages/inter-protocol/src/proposals/utils.js
+++ b/packages/inter-protocol/src/proposals/utils.js
@@ -98,9 +98,9 @@ const provideWhen = async (store, key, make) => {
 };
 
 /**
- * @param {{
+ * @param {Promise<{
  *   scratch: ERef<import('@agoric/internal/src/scratch.js').ScratchPad>;
- * }} homeP
+ * }>} homeP
  * @param {object} opts
  * @param {(specifier: string) => Promise<{ default: Bundle }>} opts.loadBundle
  * @param {string} [opts.installCacheKey]

--- a/packages/network/test/test-network-misc.js
+++ b/packages/network/test/test-network-misc.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // eslint-disable-next-line import/order
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 

--- a/packages/pegasus/test/test-peg.js
+++ b/packages/pegasus/test/test-peg.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 

--- a/packages/solo/public/main.js
+++ b/packages/solo/public/main.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /* global setTimeout */
 /* eslint @typescript-eslint/no-floating-promises: "warn" */
 // NOTE: Runs outside SES

--- a/packages/solo/src/add-chain.js
+++ b/packages/solo/src/add-chain.js
@@ -1,3 +1,4 @@
+// @ts-check
 /* global process */
 import fetch from 'node-fetch';
 import crypto from 'crypto';
@@ -64,7 +65,7 @@ async function addChain(basedir, chainConfig, force = false) {
   netconf.gci || Fail`${url.href} does not contain a "gci" entry`;
 
   const connFile = path.join(basedir, 'connections.json');
-  const conns = JSON.parse(fs.readFileSync(connFile));
+  const conns = JSON.parse(fs.readFileSync(connFile, 'utf-8'));
   for (const conn of conns) {
     if (conn.GCI === netconf.gci) {
       if (!force) {

--- a/packages/solo/src/chain-cosmos-sdk.js
+++ b/packages/solo/src/chain-cosmos-sdk.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /* global clearTimeout setTimeout Buffer */
 /* eslint @typescript-eslint/no-floating-promises: "warn" */
 import path from 'path';

--- a/packages/solo/src/main.js
+++ b/packages/solo/src/main.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import fs from 'fs';
 import path from 'path';
 import parseArgs from 'minimist';

--- a/packages/solo/src/outbound.js
+++ b/packages/solo/src/outbound.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /* global process */
 import anylogger from 'anylogger';
 

--- a/packages/solo/src/set-fake-chain.js
+++ b/packages/solo/src/set-fake-chain.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import fs from 'fs';
 import path from 'path';
 

--- a/packages/solo/src/set-gci-ingress.js
+++ b/packages/solo/src/set-gci-ingress.js
@@ -1,3 +1,4 @@
+// @ts-check
 import fs from 'fs';
 import path from 'path';
 
@@ -58,7 +59,7 @@ export default function setGCIIngress(basedir, GCI, rpcAddresses, chainID) {
     }
   };
 
-  JSON.parse(fs.readFileSync(fn)).forEach(add);
+  JSON.parse(fs.readFileSync(fn, 'utf-8')).forEach(add);
   const newconn = {
     type: 'chain-cosmos-sdk',
     chainID,

--- a/packages/solo/src/web.js
+++ b/packages/solo/src/web.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /* global setTimeout clearTimeout setInterval clearInterval process */
 // Start a network service
 import path from 'path';

--- a/packages/solo/test/captp-fixture.js
+++ b/packages/solo/test/captp-fixture.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /* global process setTimeout */
 /* eslint @typescript-eslint/no-floating-promises: "warn" */
 import { spawn } from 'child_process';

--- a/packages/solo/test/test-home.js
+++ b/packages/solo/test/test-home.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /* global process */
 
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';

--- a/packages/spawner/test/swingsetTests/contractHost/test-contractHost.js
+++ b/packages/spawner/test/swingsetTests/contractHost/test-contractHost.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // eslint-disable-next-line import/order
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 // eslint-disable-next-line import/order

--- a/packages/stat-logger/src/statGraph.js
+++ b/packages/stat-logger/src/statGraph.js
@@ -1,7 +1,10 @@
+// @ts-check
 /* global process */
 import fs from 'fs';
 import path from 'path';
 
+// eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+// @ts-ignore cannot find name 'assert'
 const { Fail } = assert;
 
 function scanMax(filePath, fields) {
@@ -28,8 +31,9 @@ function scanMax(filePath, fields) {
   for (let row = 1; row < lines.length; row += 1) {
     const line = lines[row].split('\t');
     for (let col = 0; col < headerMap.length; col += 1) {
-      if (headerMap[col] && line[col] > maxValue) {
-        maxValue = line[col];
+      const colNum = Number(line[col]);
+      if (headerMap[col] && colNum > maxValue) {
+        maxValue = colNum;
         maxField = headerMap[col];
       }
     }
@@ -163,6 +167,7 @@ export async function renderGraph(spec, outputPath, type = 'png') {
     Fail`invalid output type ${type}, valid types are png or pdf`;
 
   let loadDir = '.';
+  /** @type {Pick<NodeJS.Socket, 'write'>} */
   let out = process.stdout;
   if (outputPath) {
     loadDir = path.dirname(outputPath);
@@ -175,6 +180,7 @@ export async function renderGraph(spec, outputPath, type = 'png') {
   // NOTE: If this import expression fails, you need to install the
   // peerDependencies.
   // Dynamic version of `import * as vega from 'vega';`
+  // @ts-expect-error
   // eslint-disable-next-line import/no-unresolved
   const vega = await import('vega');
 

--- a/packages/stat-logger/tsconfig.json
+++ b/packages/stat-logger/tsconfig.json
@@ -1,6 +1,9 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true
+  },
   "include": [
     "src/**/*.js",
     "test/**/*.js"

--- a/packages/swing-store/package.json
+++ b/packages/swing-store/package.json
@@ -27,11 +27,10 @@
     "@endo/bundle-source": "^2.7.0",
     "@endo/check-bundle": "^0.2.21",
     "@endo/nat": "^4.1.30",
-    "better-sqlite3": "^8.2.0"
+    "better-sqlite3": "^9.1.1"
   },
   "devDependencies": {
     "@endo/init": "^0.5.59",
-    "@types/better-sqlite3": "^7.5.0",
     "ava": "^5.3.0",
     "c8": "^7.13.0",
     "tmp": "^0.2.1"

--- a/packages/swingset-liveslots/src/virtualReferences.js
+++ b/packages/swingset-liveslots/src/virtualReferences.js
@@ -15,7 +15,7 @@ import {
  *   IDs
  * @param {(slot: string) => object} requiredValForSlot  A function that
  *   converts an object ID (vref) to an object.
- * @param {*} FinalizationRegistry  Powerful JavaScript intrinsic normally denied
+ * @param {FinalizationRegistryConstructor} FinalizationRegistry  Powerful JavaScript intrinsic normally denied
  *   by SES
  * @param {*} WeakRef  Powerful JavaScript intrinsic normally denied
  *   by SES
@@ -48,6 +48,7 @@ export function makeVirtualReferenceManager(
 
   function registerDroppedCollection(target, descriptor) {
     const wr = new WeakRef(target);
+    // @ts-expect-error the weakref is ignored
     droppedCollectionRegistry.register(target, { descriptor, wr });
   }
 

--- a/packages/swingset-liveslots/test/mock-gc.js
+++ b/packages/swingset-liveslots/test/mock-gc.js
@@ -98,6 +98,7 @@ export function makeMockGC() {
 
   return harden({
     WeakRef: mockWeakRef,
+    /** @type {FinalizationRegistryConstructor} */
     FinalizationRegistry: mockFinalizationRegistry,
     kill,
     weakRefFor,

--- a/packages/swingset-runner/demo/exchangeBenchmark/bootstrap.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/bootstrap.js
@@ -2,7 +2,8 @@ import { makeIssuerKit, AmountMath } from '@agoric/ertp';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 
-/* eslint-disable-next-line import/no-unresolved, import/extensions */
+// @ts-expect-error missing file
+// eslint-disable-next-line import/no-unresolved, import/extensions
 import exchangeBundle from './bundle-simpleExchange.js';
 
 export function buildRootObject(_vatPowers, vatParameters) {

--- a/packages/swingset-runner/demo/resolveCase1/bootstrap.js
+++ b/packages/swingset-runner/demo/resolveCase1/bootstrap.js
@@ -1,5 +1,6 @@
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
+import { makePromiseKit } from '@endo/promise-kit';
 
 const log = console.log;
 
@@ -11,14 +12,11 @@ export function buildRootObject() {
     bootstrap(vats) {
       log('=> Alice: bootstrap() called');
 
-      let resolver;
-      const param = new Promise((theResolver, _theRejector) => {
-        resolver = theResolver;
-      });
+      const { promise, resolve } = makePromiseKit();
       log('Alice: sending the promise to Bob');
-      const response = E(vats.bob).thisIsYourPromise(param);
+      const response = E(vats.bob).thisIsYourPromise(promise);
       log('Alice: resolving the promise that was sent to Bob');
-      resolver('Alice says hi!');
+      resolve('Alice says hi!');
       log(`Alice: awaiting Bob's response`);
       // prettier-ignore
       response.then(

--- a/packages/swingset-runner/demo/resolveCase2/bootstrap.js
+++ b/packages/swingset-runner/demo/resolveCase2/bootstrap.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 

--- a/packages/swingset-runner/demo/resolveInArrayCase1/bootstrap.js
+++ b/packages/swingset-runner/demo/resolveInArrayCase1/bootstrap.js
@@ -1,5 +1,6 @@
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
+import { makePromiseKit } from '@endo/promise-kit';
 
 const log = console.log;
 
@@ -11,14 +12,12 @@ export function buildRootObject() {
     bootstrap(vats) {
       log('=> Alice: bootstrap() called');
 
-      let resolver;
-      const param = new Promise((theResolver, _theRejector) => {
-        resolver = theResolver;
-      });
+      const { promise, resolve } = makePromiseKit();
+
       log('Alice: sending the promise to Bob');
-      const response = E(vats.bob).thisIsYourPromise([param]);
+      const response = E(vats.bob).thisIsYourPromise([promise]);
       log('Alice: resolving the promise that was sent to Bob');
-      resolver('Alice says hi!');
+      resolve('Alice says hi!');
       log(`Alice: awaiting Bob's response`);
       // prettier-ignore
       response.then(

--- a/packages/swingset-runner/demo/simplePromisePass/vat-alice.js
+++ b/packages/swingset-runner/demo/simplePromisePass/vat-alice.js
@@ -1,5 +1,6 @@
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
+import { makePromiseKit } from '@endo/promise-kit';
 
 const log = console.log;
 
@@ -7,12 +8,9 @@ export function buildRootObject() {
   return Far('root', {
     sendPromiseTo(other) {
       log('=> Alice: sendPromiseTo() begins');
-      let resolver;
-      const param = new Promise((theResolver, _theRejector) => {
-        resolver = theResolver;
-      });
-      const response = E(other).thisIsYourPromise(param);
-      resolver('Alice says hi!');
+      const { promise, resolve } = makePromiseKit();
+      const response = E(other).thisIsYourPromise(promise);
+      resolve('Alice says hi!');
       response.then(
         r => log(`=> Alice: response to thisIsYourPromise resolved to '${r}'`),
         e => log(`=> Alice: response to thisIsYourPromise rejected as '${e}'`),

--- a/packages/swingset-runner/demo/swapBenchmark/bootstrap.js
+++ b/packages/swingset-runner/demo/swapBenchmark/bootstrap.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { makeIssuerKit, AmountMath } from '@agoric/ertp';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';

--- a/packages/swingset-runner/demo/vatResolveTest/vat-bob.js
+++ b/packages/swingset-runner/demo/vatResolveTest/vat-bob.js
@@ -1,15 +1,8 @@
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
+import { makePromiseKit } from '@endo/promise-kit';
 
 const log = console.log;
-
-function makePR() {
-  let r;
-  const p = new Promise((resolve, _reject) => {
-    r = resolve;
-  });
-  return [p, r];
-}
 
 function hush(p) {
   p.then(
@@ -20,7 +13,7 @@ function hush(p) {
 
 export function buildRootObject() {
   let p1;
-  const [p0, r0] = makePR();
+  const { promise: p0, resolve: r0 } = makePromiseKit();
   return Far('root', {
     promise(p) {
       p1 = p;

--- a/packages/swingset-runner/demo/vatResolveTestSimple/vat-bob.js
+++ b/packages/swingset-runner/demo/vatResolveTestSimple/vat-bob.js
@@ -1,15 +1,8 @@
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
+import { makePromiseKit } from '@endo/promise-kit';
 
 const log = console.log;
-
-function makePR() {
-  let r;
-  const p = new Promise((resolve, _reject) => {
-    r = resolve;
-  });
-  return [p, r];
-}
 
 function hush(p) {
   p.then(
@@ -20,7 +13,7 @@ function hush(p) {
 
 export function buildRootObject() {
   let p1;
-  const [p0, r0] = makePR();
+  const { promise: p0, resolve: r0 } = makePromiseKit();
   return Far('root', {
     promise(p) {
       p1 = p;

--- a/packages/swingset-runner/demo/vatStore2/xorshift128.js
+++ b/packages/swingset-runner/demo/vatStore2/xorshift128.js
@@ -160,6 +160,7 @@ export const makeXorShift128 = (seed = defaultSeed) => {
     }
   };
 
+  // @ts-expect-error Argument of type 'Uint32Array' is not assignable to parameter of type 'number[]'.
   const fork = () => makeXorShift128(state);
 
   return {

--- a/packages/swingset-runner/demo/zoeTests/bootstrap.js
+++ b/packages/swingset-runner/demo/zoeTests/bootstrap.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 import { makeIssuerKit, AmountMath } from '@agoric/ertp';

--- a/packages/swingset-runner/package.json
+++ b/packages/swingset-runner/package.json
@@ -37,6 +37,7 @@
     "@endo/init": "^0.5.59",
     "@endo/marshal": "^0.8.8",
     "@endo/nat": "^4.1.30",
+    "@endo/promise-kit": "^0.2.59",
     "expose-gc": "^1.0.0",
     "n-readlines": "^1.0.1",
     "yargs": "^16.1.0"

--- a/packages/swingset-runner/src/dataGraphApp.js
+++ b/packages/swingset-runner/src/dataGraphApp.js
@@ -62,6 +62,7 @@ function fail(message, printUsage, showFields) {
 
 export async function dataGraphApp(xField, xLabel, yField, yLabel, fields) {
   const argv = process.argv.slice(2);
+  assert(argv);
 
   let outfile = null;
   const datafiles = [];
@@ -71,6 +72,7 @@ export async function dataGraphApp(xField, xLabel, yField, yLabel, fields) {
   const expectFields = !fields;
   while (argv[0]) {
     const arg = argv.shift();
+    assert(arg);
     if (arg.startsWith('-')) {
       switch (arg) {
         case '--output':
@@ -91,7 +93,7 @@ export async function dataGraphApp(xField, xLabel, yField, yLabel, fields) {
         case '--fields':
         case '-f':
           if (expectFields) {
-            fields = argv.shift().split(',');
+            fields = argv.shift()?.split(',');
             break;
           }
         // note fall through to error

--- a/packages/swingset-runner/src/kerneldump-entrypoint.js
+++ b/packages/swingset-runner/src/kerneldump-entrypoint.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-/* eslint-env node */
 
 /**
  * Simple boilerplate program providing linkage to launch an application written
@@ -11,12 +10,4 @@
 import '@endo/init';
 import { main } from './kerneldump.js';
 
-process.exitCode = 1;
-main().then(
-  () => {
-    process.exitCode = 0;
-  },
-  error => {
-    console.error(error);
-  },
-);
+main();

--- a/packages/swingset-runner/src/kerneldump.js
+++ b/packages/swingset-runner/src/kerneldump.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import fs from 'fs';
 import path from 'path';
 import process from 'process';
@@ -52,6 +53,7 @@ function dirContains(dirpath, suffix) {
   }
 }
 
+/** @type {() => void} */
 export function main() {
   const argv = process.argv.slice(2);
   let rawMode = false;
@@ -104,6 +106,7 @@ export function main() {
   }
 
   const target = argv.shift();
+  assert(target);
   let kernelStateDBDir;
   const dbSuffix = '.mdb';
   if (target.endsWith(dbSuffix)) {

--- a/packages/swingset-runner/src/main.js
+++ b/packages/swingset-runner/src/main.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import path from 'path';
 import fs from 'fs';
 import process from 'process';

--- a/packages/swingset-runner/src/push-metrics.js
+++ b/packages/swingset-runner/src/push-metrics.js
@@ -34,7 +34,14 @@ if (!benchStatsFile) {
   process.exit(1);
 }
 
-function promHeader(name, metricType, help = undefined) {
+/**
+ * Generates a header for a Prometheus metric.
+ *
+ * @param {string} name
+ * @param {string} metricType
+ * @param {string} [help]
+ */
+function promHeader(name, metricType, help) {
   let hdr = '';
   if (help !== undefined) {
     hdr += `\
@@ -86,7 +93,10 @@ function gatherMetrics(kind, data, labels, specs) {
     specs.map(([prop, name]) => [prop, name]),
   );
   const propMetrics = Object.fromEntries(
-    specs.map(([prop, name, ...args]) => [prop, promHeader(name, ...args)]),
+    specs.map(([prop, name, metricType, help]) => [
+      prop,
+      promHeader(name, metricType, help),
+    ]),
   );
 
   const todo = new Set(Object.keys(data));
@@ -114,7 +124,7 @@ function gatherMetrics(kind, data, labels, specs) {
   return Object.values(propMetrics).join('');
 }
 
-function generateMetricsFromPrimeData(data, labels = undefined) {
+function generateMetricsFromPrimeData(data, labels) {
   return gatherMetrics('prime', data, labels, [
     ['up', 'stat_up', 'counter', `Number of increments`],
     ['down', 'stat_down', 'counter', `Number of decrements`],
@@ -124,7 +134,7 @@ function generateMetricsFromPrimeData(data, labels = undefined) {
   ]);
 }
 
-function generateMetricsFromBenchmarkData(data, labels = undefined) {
+function generateMetricsFromBenchmarkData(data, labels) {
   return gatherMetrics('benchmark', data, labels, [
     ['delta', 'stat_delta', 'gauge', `Autobench benchmark delta`],
     [
@@ -202,4 +212,5 @@ const curlCp = spawnSync(
   },
 );
 
+// @ts-expect-error status is number|null, but exit() takes number|undefined
 process.exit(curlCp.status);

--- a/packages/swingset-runner/src/slogulator-entrypoint.js
+++ b/packages/swingset-runner/src/slogulator-entrypoint.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-/* eslint-env node */
 
 /**
  * Simple boilerplate program providing linkage to launch an application written using modules within the
@@ -8,12 +7,4 @@
 import '@endo/init';
 import { main } from './slogulator.js';
 
-process.exitCode = 1;
-main().then(
-  () => {
-    process.exitCode = 0;
-  },
-  error => {
-    console.error(error);
-  },
-);
+main();

--- a/packages/swingset-runner/src/slogulator.js
+++ b/packages/swingset-runner/src/slogulator.js
@@ -19,6 +19,7 @@ function fail(message, printUsage) {
   process.exit(1);
 }
 
+/** @type {() => void} */
 export function main() {
   const argv = yargs(process.argv.slice(2))
     .string('out')
@@ -116,7 +117,7 @@ export function main() {
   try {
     lines = new Readlines(slogFile);
   } catch (e) {
-    fail(`unable to open slog file ${slogFile}`);
+    throw new Error(`unable to open slog file ${slogFile}`);
   }
 
   const summary = {};
@@ -149,7 +150,7 @@ export function main() {
   if (argv.annotations) {
     let annotations;
     try {
-      annotations = JSON.parse(fs.readFileSync(argv.annotations));
+      annotations = JSON.parse(fs.readFileSync(argv.annotations, 'utf-8'));
     } catch (e) {
       fail(`unable to read annotations file ${argv.annotations}: ${e.message}`);
     }
@@ -198,7 +199,7 @@ export function main() {
     lineNumber += 1;
     let entry;
     try {
-      entry = JSON.parse(line);
+      entry = JSON.parse(line.toString());
     } catch (err) {
       p(`// JSON.parse error on line ${lineNumber}`);
       throw err;

--- a/packages/swingset-runner/test/test-demo.js
+++ b/packages/swingset-runner/test/test-demo.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import test from 'ava';
 import { spawn } from 'child_process';
 import fs from 'fs';

--- a/packages/swingset-runner/tsconfig.json
+++ b/packages/swingset-runner/tsconfig.json
@@ -1,6 +1,9 @@
 // This file can contain .js-specific Typescript compiler config.
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true
+  },
   "include": [
     "*.js",
     "demo/**/*.js",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -36,7 +36,7 @@
     "@opentelemetry/sdk-trace-base": "~1.9.0",
     "@opentelemetry/semantic-conventions": "~1.9.0",
     "anylogger": "^0.21.0",
-    "better-sqlite3": "^8.2.0",
+    "better-sqlite3": "^9.1.1",
     "bufferfromfile": "agoric-labs/BufferFromFile#Agoric-built",
     "tmp": "^0.2.1"
   },

--- a/packages/vat-data/test/test-scalar-only-keys.js
+++ b/packages/vat-data/test/test-scalar-only-keys.js
@@ -1,3 +1,4 @@
+// @ts-check
 // From https://github.com/Agoric/agoric-sdk/pull/6903#discussion_r1098067133
 
 import { test } from './prepare-test-env-ava.js';
@@ -16,7 +17,7 @@ test('scalar maps should reject non-scalar keys', t => {
 
 test('scalar big maps should reject non-scalar keys', t => {
   const bigMap = makeScalarBigMapStore('dummy', { keyShape: M.key() });
-  t.throws(() => bigMap.init(harden({ label: 'not a scalar' })), {
+  t.throws(() => bigMap.init(harden({ label: 'not a scalar' }), 'val'), {
     message:
       /A "copyRecord" cannot be a scalar key: \{"label":"not a scalar"\}/,
   });

--- a/packages/vats/src/proposals/null-upgrade-zoe-proposal.js
+++ b/packages/vats/src/proposals/null-upgrade-zoe-proposal.js
@@ -1,10 +1,14 @@
+// @ts-check
 import { E } from '@endo/far';
 
 /**
  * @param {BootstrapPowers & {
  *   consume: {
  *     vatAdminSvc: VatAdminSvc;
- *     vatStore: MapStore<string, CreateVatResults>;
+ *     vatStore: MapStore<
+ *       string,
+ *       import('@agoric/swingset-vat').CreateVatResults
+ *     >;
  *   };
  * }} powers
  * @param {object} options
@@ -16,6 +20,7 @@ export const nullUpgradeZoe = async (
 ) => {
   const { zoeRef } = options.options;
 
+  assert(zoeRef.bundleID);
   const zoeBundleCap = await E(vatAdminSvc).getBundleCap(zoeRef.bundleID);
   console.log(`ZOE BUNDLE ID: `, zoeRef.bundleID);
 

--- a/packages/vats/src/proposals/zcf-proposal.js
+++ b/packages/vats/src/proposals/zcf-proposal.js
@@ -1,10 +1,14 @@
+// @ts-check
 import { E } from '@endo/far';
 
 /**
  * @param {BootstrapPowers & {
  *   consume: {
  *     vatAdminSvc: VatAdminSvc;
- *     vatStore: MapStore<string, CreateVatResults>;
+ *     vatStore: MapStore<
+ *       string,
+ *       import('@agoric/swingset-vat').CreateVatResults
+ *     >;
  *   };
  * }} powers
  * @param {object} options
@@ -16,6 +20,7 @@ export const upgradeZcf = async (
 ) => {
   const { zoeRef, zcfRef } = options.options;
 
+  assert(zoeRef.bundleID);
   const zoeBundleCap = await E(vatAdminSvc).getBundleCap(zoeRef.bundleID);
   console.log(`ZOE BUNDLE ID: `, zoeRef.bundleID);
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -12,7 +12,6 @@
     "exclude": [
         "packages/xsnap/moddable",
         "packages/xsnap/xsnap-native",
-        "packages/xsnap-lockdown",
         "**/build",
         "**/dist",
         "**/docs",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -9,7 +9,6 @@
         "outDir": "./build"
     },
     "exclude": [
-        "packages/agoric-cli",
         "packages/benchmark",
         "packages/cosmic-swingset",
         "packages/deployment",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -16,7 +16,6 @@
         "**/dist",
         "**/docs",
         "**/*.umd.js",
-        "**/test"
     ],
     "include": [
         "./**/*.ts",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -10,7 +10,6 @@
         "outDir": "./build"
     },
     "exclude": [
-        "packages/cosmic-swingset",
         "packages/deployment",
         "packages/import-manager",
         "packages/solo",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -16,7 +16,6 @@
         "**/dist",
         "**/docs",
         "**/*.umd.js",
-        "**/proposals",
         "**/scripts",
         "**/test"
     ],

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -11,7 +11,6 @@
     },
     "exclude": [
         "packages/swingset-runner",
-        "packages/telemetry",
         "packages/xsnap/moddable",
         "packages/xsnap/xsnap-native",
         "packages/xsnap-lockdown",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -10,7 +10,6 @@
         "outDir": "./build"
     },
     "exclude": [
-        "packages/deployment",
         "packages/swingset-runner",
         "packages/telemetry",
         "packages/xsnap/moddable",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -12,7 +12,6 @@
     "exclude": [
         "packages/deployment",
         "packages/import-manager",
-        "packages/stat-logger",
         "packages/swingset-runner",
         "packages/telemetry",
         "packages/xsnap/moddable",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -16,7 +16,6 @@
         "**/dist",
         "**/docs",
         "**/*.umd.js",
-        "**/scripts",
         "**/test"
     ],
     "include": [

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -11,7 +11,6 @@
     },
     "exclude": [
         "packages/deployment",
-        "packages/import-manager",
         "packages/swingset-runner",
         "packages/telemetry",
         "packages/xsnap/moddable",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -10,7 +10,6 @@
         "outDir": "./build"
     },
     "exclude": [
-        "packages/swingset-runner",
         "packages/xsnap/moddable",
         "packages/xsnap/xsnap-native",
         "packages/xsnap-lockdown",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -12,7 +12,6 @@
     "exclude": [
         "packages/deployment",
         "packages/import-manager",
-        "packages/solo",
         "packages/stat-logger",
         "packages/swingset-runner",
         "packages/telemetry",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
-/* Visit Visit https://www.typescriptlang.org/tsconfig to read more about this file */
+/* Visit https://www.typescriptlang.org/tsconfig to read more about this file */
 {
     "extends": [
         "./tsconfig.json",
@@ -6,10 +6,10 @@
     ],
     "compilerOptions": {
         "allowSyntheticDefaultImports": true,
+        "allowImportingTsExtensions": true,
         "outDir": "./build"
     },
     "exclude": [
-        "packages/benchmark",
         "packages/cosmic-swingset",
         "packages/deployment",
         "packages/import-manager",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2154,13 +2154,6 @@
   resolved "https://registry.yarnpkg.com/@tsd/typescript/-/typescript-5.0.4.tgz#18aa4eb2c35c6bf9aab3199c289be319bedb7e9c"
   integrity sha512-YQi2lvZSI+xidKeUjlbv6b6Zw7qB3aXHw5oGJLs5OOGAEqKIOvz5UIAkWyg0bJbkSUWPBEtaOHpVxU4EYBO1Jg==
 
-"@types/better-sqlite3@^7.5.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@types/better-sqlite3/-/better-sqlite3-7.6.0.tgz#603d1c7a72527dd946e2bf641ed4c0b74a547423"
-  integrity sha512-rnSP9vY+fVsF3iJja5yRGBJV63PNBiezJlYrCkqUmQWFoB16cxAHwOkjsAYEu317miOfKaJpa65cbp0P4XJ/jw==
-  dependencies:
-    "@types/node" "*"
-
 "@types/body-parser@*":
   version "1.19.2"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.2.tgz#aea2059e28b7658639081347ac4fab3de166e6f0"
@@ -2955,13 +2948,13 @@ before-after-hook@^2.2.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.3.tgz#c51e809c81a4e354084422b9b26bad88249c517c"
   integrity sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==
 
-better-sqlite3@^8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-8.2.0.tgz#4ef6185b88992723de7e00cfa67585ac59f320bd"
-  integrity sha512-8eTzxGk9535SB3oSNu0tQ6I4ZffjVCBUjKHN9QeeIFtphBX0sEd0NxAuglBNR9TO5ThnxBB7GqzfcYo9kjadJQ==
+better-sqlite3@^9.1.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-9.1.1.tgz#f139b180a08ed396e660a0601a46ceefd78b832c"
+  integrity sha512-FhW7bS7cXwkB2SFnPJrSGPmQerVSCzwBgmQ1cIRcYKxLsyiKjljzCbyEqqhYXo5TTBqt5BISiBj2YE2Sy2ynaA==
   dependencies:
     bindings "^1.5.0"
-    prebuild-install "^7.1.0"
+    prebuild-install "^7.1.1"
 
 big-integer@^1.6.44:
   version "1.6.51"
@@ -8046,7 +8039,7 @@ pprof-format@^2.0.7:
   resolved "https://registry.yarnpkg.com/pprof-format/-/pprof-format-2.0.7.tgz#526e4361f8b37d16b2ec4bb0696b5292de5046a4"
   integrity sha512-1qWaGAzwMpaXJP9opRa23nPnt2Egi7RMNoNBptEE/XwHbcn4fC2b/4U4bKc5arkGkIh2ZabpF2bEb+c5GNHEKA==
 
-prebuild-install@^7.1.0:
+prebuild-install@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.1.tgz#de97d5b34a70a0c81334fd24641f2a1702352e45"
   integrity sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==


### PR DESCRIPTION
## Description

I was trying to create a type coverage report and along the way it was easiest to unify the type checking into one TypeScript project. With this the checker can be more comprehensive and it turns out there are over a thousand type errors that were masked by the earlier config.

EDIT: having a single TypeScript project will solve OOM in eslint `https://github.com/typescript-eslint/typescript-eslint/issues/1192#issuecomment-1153418862`

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
