### PR TITLE
feat(vats): attenuate access to zoe.install, zoe.startInstance

### DIFF
--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -47,7 +47,7 @@ export const buildZoe = async ({
   consume: { agoricNames, vatAdminSvc, loadVat, client, nameAdmins },
   produce: { zoe, feeMintAccess },
 }) => {
-  const { zoeService, feeMintAccess: fma } = await E(
+  const { zoeService, zoe1, feeMintAccess: fma } = await E(
     E(loadVat)('zoe'),
   ).buildZoe(vatAdminSvc, feeIssuerConfig);
 
@@ -65,7 +65,7 @@ export const buildZoe = async ({
   return Promise.all([
     E(issuerAdmin).update('RUN', runIssuer),
     E(brandAdmin).update('RUN', runBrand),
-    E(client).assignBundle({ zoe: _addr => zoeService }),
+    E(client).assignBundle({ zoe1: _addr => zoe1 }),
   ]);
 };
 harden(buildZoe);

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -45,13 +45,14 @@ harden(makeVatsFromBundles);
  */
 export const buildZoe = async ({
   consume: { agoricNames, vatAdminSvc, loadVat, client, nameAdmins },
-  produce: { zoe, feeMintAccess },
+  produce: { zoe, zoeAdmin: produceZoeAdmin, feeMintAccess },
 }) => {
-  const { zoeService, zoe1, feeMintAccess: fma } = await E(
+  const { zoeService, zoeAdmin, feeMintAccess: fma } = await E(
     E(loadVat)('zoe'),
   ).buildZoe(vatAdminSvc, feeIssuerConfig);
 
   zoe.resolve(zoeService);
+  produceZoeAdmin.resolve(zoeAdmin);
 
   const runIssuer = await E(zoeService).getFeeIssuer();
   const runBrand = await E(runIssuer).getBrand();
@@ -65,7 +66,7 @@ export const buildZoe = async ({
   return Promise.all([
     E(issuerAdmin).update('RUN', runIssuer),
     E(brandAdmin).update('RUN', runBrand),
-    E(client).assignBundle({ zoe1: _addr => zoe1 }),
+    E(client).assignBundle({ zoe: _addr => E(zoeAdmin).getUserZoe() }),
   ]);
 };
 harden(buildZoe);

--- a/packages/vats/src/core/manifest.js
+++ b/packages/vats/src/core/manifest.js
@@ -152,15 +152,4 @@ export const GOVERNANCE_ACTIONS_MANIFEST = harden({
       nameAdmins: true,
     },
   },
-  startGetRun: {
-    consume: {
-      zoe: true,
-      feeMintAccess: true,
-      agoricNames: true,
-      chainTimerService: true,
-      nameAdmins: true,
-      bridgeManager: true,
-      client: true,
-    },
-  },
 });

--- a/packages/vats/src/core/manifest.js
+++ b/packages/vats/src/core/manifest.js
@@ -22,6 +22,7 @@ export const CHAIN_BOOTSTRAP_MANIFEST = harden({
     },
     produce: {
       zoe: true,
+      zoeAdmin: true,
       feeMintAccess: true,
     },
   },

--- a/packages/vats/src/core/manifest.js
+++ b/packages/vats/src/core/manifest.js
@@ -145,11 +145,4 @@ export const GOVERNANCE_ACTIONS_MANIFEST = harden({
       priceAuthorityAdmin: true,
     },
   },
-  installEconomicGovernance: {
-    consume: {
-      zoe: true,
-      agoricNames: true,
-      nameAdmins: true,
-    },
-  },
 });

--- a/packages/vats/src/core/manifest.js
+++ b/packages/vats/src/core/manifest.js
@@ -126,6 +126,7 @@ export const SIM_CHAIN_BOOTSTRAP_MANIFEST = harden({
     runBehaviors: true,
     consume: { client: true },
   },
+  grantUnrestrictedZoe: { consume: { client: true, zoe: true } },
 });
 
 export const GOVERNANCE_ACTIONS_MANIFEST = harden({

--- a/packages/vats/src/core/sim-behaviors.js
+++ b/packages/vats/src/core/sim-behaviors.js
@@ -66,3 +66,11 @@ export const grantRunBehaviors = async ({
   });
 };
 harden(grantRunBehaviors);
+
+/** @param {BootstrapPowers} powers */
+export const grantUnrestrictedZoe = async ({ consume: { client, zoe } }) => {
+  return E(client).assignBundle({
+    zoe: _address => zoe,
+  });
+};
+harden(grantRunBehaviors);

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -116,6 +116,7 @@
  *     provisioning: ProvisioningVat,
  *     vatAdminSvc: ERef<VatAdminSvc>,
  *     zoe: ERef<ZoeService>,
+ *     zoeAdmin: ERef<unknown>,
  *   },
  *   produce: {
  *     agoricNames: Producer<NameHub>,
@@ -133,6 +134,7 @@
  *     provisioning: Producer<unknown>,
  *     vatAdminSvc: Producer<ERef<VatAdminSvc>>,
  *     zoe: Producer<ZoeService>,
+ *     zoeAdmin: Producer<unknown>,
  *   },
  * }} BootstrapPowers
  * @typedef {*} BankManager // TODO

--- a/packages/vats/src/vat-zoe.js
+++ b/packages/vats/src/vat-zoe.js
@@ -11,7 +11,16 @@ export function buildRootObject(vatPowers, vatParameters) {
         feeIssuerConfig,
         vatParameters.zcfBundleName,
       );
+
+      const zoe1 = Far('zoe without install/startInstance', {
+        ...zoeService,
+        install: (..._args) => assert.fail('contract installation prohibited'),
+        startInstance: (..._args) =>
+          assert.fail('contract instantiation prohibited'),
+      });
+
       return harden({
+        zoe1,
         zoeService,
         feeMintAccess,
       });


### PR DESCRIPTION
This is sort of a simple idea that falls out of the updated bootstrap structure.

refs #4395, #3725

Is there a nicer idiom for overriding selected methods and forwarding the rest?

### Security Considerations

home.zoe1 wraps zoe so that install and startInstance always throw.
full home.zoe is only granted in the sim chain.
