### PR TITLE
refactor(run-protocol): improve navigation with types

### DIFF
--- a/packages/run-protocol/src/vaultFactory/types.js
+++ b/packages/run-protocol/src/vaultFactory/types.js
@@ -31,7 +31,7 @@
  * @param {Issuer} collateralIssuer
  * @param {Keyword} collateralKeyword
  * @param {Rates} rates
- * @returns {Promise<VaultManager>}
+ * @returns {Promise<import('./vaultManager').VaultManager>}
  */
 
 /**
@@ -106,10 +106,6 @@
  * @typedef {Object} VaultManagerBase
  * @property {(seat: ZCFSeat) => Promise<LoanKit>} makeLoanKit
  * @property {() => void} liquidateAll
- */
-
-/**
- * @typedef {ReturnType<import("./vaultManager").makeVaultManager>} VaultManager
  */
 
 /**

--- a/packages/run-protocol/src/vaultFactory/types.js
+++ b/packages/run-protocol/src/vaultFactory/types.js
@@ -104,12 +104,12 @@
 
 /**
  * @typedef {Object} VaultManagerBase
- * @property {(seat: ZCFSeat) => Promise<LoanKit>}  makeLoanKit
+ * @property {(seat: ZCFSeat) => Promise<LoanKit>} makeLoanKit
  * @property {() => void} liquidateAll
  */
 
 /**
- * @typedef {VaultManagerBase & GetVaultParams} VaultManager
+ * @typedef {ReturnType<import("./vaultManager").makeVaultManager>} VaultManager
  */
 
 /**
@@ -174,19 +174,6 @@
  * @callback MakeLiquidationStrategy
  * @param {LiquidationCreatorFacet} creatorFacet
  * @returns {LiquidationStrategy}
- */
-
-/**
- * @callback MakeVaultManager
- * @param {ContractFacet} zcf
- * @param {ZCFMint} runMint
- * @param {Brand} collateralBrand
- * @param {ERef<PriceAuthority>} priceAuthority
- * @param {GetParams} getLoanParams
- * @param {ReallocateReward} reallocateReward
- * @param {ERef<TimerService>} timerService
- * @param {LiquidationStrategy} liquidationStrategy
- * @returns {VaultManager}
  */
 
 /**

--- a/packages/run-protocol/src/vaultFactory/types.js
+++ b/packages/run-protocol/src/vaultFactory/types.js
@@ -80,35 +80,6 @@
  */
 
 /**
- * @typedef {Object} GetVaultParams
- * @property {() => Ratio} getLiquidationMargin
- * @property {() => Ratio} getLoanFee
- * @property {() => Promise<PriceQuote>} getCollateralQuote
- * @property {() => Ratio} getInitialMargin
- * @property {() => Ratio} getInterestRate - The annual interest rate on a loan
- * @property {() => RelativeTime} getChargingPeriod - The period (in seconds) at
- *   which interest is charged to the loan.
- * @property {() => RelativeTime} getRecordingPeriod - The period (in seconds)
- *   at which interest is recorded to the loan.
- */
-
-/**
- * @typedef {Object} InnerVaultManagerBase
- * @property {() => Brand} getCollateralBrand
- * @property {ReallocateReward} reallocateReward
- */
-
-/**
- * @typedef {InnerVaultManagerBase & GetVaultParams} InnerVaultManager
- */
-
-/**
- * @typedef {Object} VaultManagerBase
- * @property {(seat: ZCFSeat) => Promise<LoanKit>} makeLoanKit
- * @property {() => void} liquidateAll
- */
-
-/**
  * @typedef {Object} OpenLoanKit
  * @property {Notifier<UIState>} notifier
  * @property {Promise<PaymentPKeywordRecord>} collateralPayoutP
@@ -170,16 +141,6 @@
  * @callback MakeLiquidationStrategy
  * @param {LiquidationCreatorFacet} creatorFacet
  * @returns {LiquidationStrategy}
- */
-
-/**
- * @callback MakeVaultKit
- * @param {ContractFacet} zcf
- * @param {InnerVaultManager} manager
- * @param {ZCFMint} runMint
- * @param {ERef<PriceAuthority>} priceAuthority
- * @param {Timestamp} startTimeStamp
- * @returns {VaultKit}
  */
 
 /**

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -36,7 +36,22 @@ export const VaultState = {
   CLOSED: 'closed',
 };
 
-/** @type {MakeVaultKit} */
+/**
+ * @param {ContractFacet} zcf
+ * @param {{reallocateReward: ReallocateReward;
+    getCollateralBrand: () => Brand;
+    getLiquidationMargin(): Ratio;
+    getInitialMargin(): Ratio;
+    getLoanFee(): Ratio;
+    getInterestRate(): Ratio;
+    getChargingPeriod(): bigint;
+    getRecordingPeriod(): bigint;
+    getCollateralQuote(): Promise<PriceQuote>}} manager
+ * @param {ZCFMint} runMint
+ * @param {ERef<PriceAuthority>} priceAuthority
+ * @param {Timestamp} startTimeStamp
+ * @returns {VaultKit}
+ */
 export const makeVaultKit = (
   zcf,
   manager,

--- a/packages/run-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/run-protocol/src/vaultFactory/vaultFactory.js
@@ -167,7 +167,6 @@ export const start = async (zcf, privateArgs) => {
         collateralTypes.has(brandIn),
         X`Not a supported collateral type ${brandIn}`,
       );
-      /** @type {VaultManager} */
       const mgr = collateralTypes.get(brandIn);
       return mgr.makeLoanKit(seat);
     };

--- a/packages/run-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/run-protocol/src/vaultFactory/vaultFactory.js
@@ -105,7 +105,7 @@ export const start = async (zcf, privateArgs) => {
     }
   };
 
-  /** @type {Store<Brand,VaultManager>} */
+  /** @type {Store<Brand,import('./vaultManager').VaultManager>} */
   const collateralTypes = makeScalarMap('brand');
 
   const zoe = zcf.getZoeService();

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -61,7 +61,6 @@ export const makeVaultManager = (
 
   const getLoanParamValue = key => getLoanParams()[key].value;
 
-  /** @type {GetVaultParams} */
   const shared = {
     // loans below this margin may be liquidated
     getLiquidationMargin() {
@@ -83,18 +82,21 @@ export const makeVaultManager = (
         (getLoanParamValue(LOAN_FEE_KEY))
       );
     },
+    /** The annual interest rate on a loan */
     getInterestRate() {
       return (
         /** @type {Ratio} */
         (getLoanParamValue(INTEREST_RATE_KEY))
       );
     },
+    /** The period (in seconds) at which interest is charged to the loan. */
     getChargingPeriod() {
       return (
         /** @type {RelativeTime} */
         (getLoanParamValue(CHARGING_PERIOD_KEY))
       );
     },
+    /** The period (in seconds) at which interest is recorded to the loan. */
     getRecordingPeriod() {
       return (
         /** @type {RelativeTime} */
@@ -244,7 +246,6 @@ export const makeVaultManager = (
 
   observeNotifier(periodNotifier, timeObserver);
 
-  /** @type {InnerVaultManager} */
   const innerFacet = harden({
     ...shared,
     reallocateReward,

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -37,7 +37,16 @@ const trace = makeTracer(' VM ');
 // some number of outstanding loans, each called a Vault, for which the
 // collateral is provided in exchange for borrowed RUN.
 
-/** @type {MakeVaultManager} */
+/**
+ * @param {ContractFacet} zcf
+ * @param {ZCFMint} runMint
+ * @param {Brand} collateralBrand
+ * @param {ERef<PriceAuthority>} priceAuthority
+ * @param {GetParams} getLoanParams
+ * @param {ReallocateReward} reallocateReward
+ * @param {ERef<TimerService>} timerService
+ * @param {LiquidationStrategy} liquidationStrategy
+ */
 export const makeVaultManager = (
   zcf,
   runMint,
@@ -274,7 +283,6 @@ export const makeVaultManager = (
     });
   };
 
-  /** @type {VaultManager} */
   return Far('vault manager', {
     ...shared,
     makeLoanKit,

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -289,3 +289,7 @@ export const makeVaultManager = (
     liquidateAll,
   });
 };
+
+/**
+ * @typedef {ReturnType<makeVaultManager>} VaultManager
+ */

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -426,7 +426,6 @@ test('first', async t => {
 
   // Add a vault that will lend on aeth collateral
   const rates = makeRates(runBrand);
-  /** @type {VaultManager} */
   const aethVaultManager = await E(vaultFactory).addVaultType(
     aethIssuer,
     'AEth',

--- a/packages/run-protocol/test/vaultFactory/vault-contract-wrapper.js
+++ b/packages/run-protocol/test/vaultFactory/vault-contract-wrapper.js
@@ -45,7 +45,6 @@ export async function start(zcf, privateArgs) {
     }
   }
 
-  /** @type {InnerVaultManager} */
   const managerMock = Far('vault manager mock', {
     getLiquidationMargin() {
       return makeRatio(105n, runBrand);


### PR DESCRIPTION
## Description

Exploring the vaultFactory code @dtribble noticed that we couldn't navigate from, for example, `mgr.makeLoanKit`. Here's what VS Code shows when you try "Go to implementations":
<img width="449" alt="Screen Shot 2022-01-27 at 3 40 13 PM" src="https://user-images.githubusercontent.com/21505/151461496-b855e8a8-c958-4f2a-b9da-eb6fdff1c118.png">

After this change, "Go to definition" shows the source of the function:
<img width="970" alt="Screen Shot 2022-01-27 at 3 35 35 PM" src="https://user-images.githubusercontent.com/21505/151461603-17d154ce-7af3-4687-b53a-26a28ce069f0.png">

And "Go to implementations" takes you straight to the logic.

### Security Considerations

None.

### Documentation Considerations

If we agree on using the `types.js` less, that should be documented.

### Testing Considerations

None.