### PR TITLE
don't panic the kernel upon a device error

### DIFF
--- a/packages/SwingSet/src/kernel/deviceSlots.js
+++ b/packages/SwingSet/src/kernel/deviceSlots.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { Remotable, passStyleOf, makeMarshal } from '@agoric/marshal';
 import { assert, details as X } from '@agoric/assert';
 import { insistVatType, makeVatSlot, parseVatSlot } from '../parseVatSlots.js';
@@ -181,6 +182,13 @@ export function makeDeviceSlots(
 
   // this function throws an exception if anything goes wrong, or if the
   // device node itself throws an exception during invocation
+  /**
+   *
+   * @param { string } deviceID
+   * @param { string } method
+   * @param { SwingSetCapData } args
+   * @returns { DeviceInvocationResult }
+   */
   function invoke(deviceID, method, args) {
     insistVatType('device', deviceID);
     insistCapData(args);
@@ -206,9 +214,11 @@ export function makeDeviceSlots(
       );
     }
     const res = fn.apply(t, m.unserialize(args));
-    const vres = harden(['ok', m.serialize(res)]);
+    const vres = m.serialize(res);
+    /** @type { DeviceInvocationResultOk } */
+    const ires = harden(['ok', vres]);
     lsdebug(` results ${vres.body} ${JSON.stringify(vres.slots)}`);
-    return vres;
+    return ires;
   }
 
   return harden({ invoke });

--- a/packages/SwingSet/src/kernel/state/deviceKeeper.js
+++ b/packages/SwingSet/src/kernel/state/deviceKeeper.js
@@ -8,7 +8,9 @@ import { parseKernelSlot } from '../parseKernelSlots.js';
 import { makeVatSlot, parseVatSlot } from '../../parseVatSlots.js';
 import { insistDeviceID } from '../id.js';
 
-const FIRST_DEVICE_STATE_ID = 10n;
+const FIRST_DEVICE_IMPORTED_OBJECT_ID = 10n;
+const FIRST_DEVICE_IMPORTED_DEVICE_ID = 20n;
+const FIRST_DEVICE_IMPORTED_PROMISE_ID = 30n;
 
 /**
  * Establish a device's state.
@@ -19,7 +21,9 @@ const FIRST_DEVICE_STATE_ID = 10n;
  * TODO move into makeDeviceKeeper?
  */
 export function initializeDeviceState(kvStore, deviceID) {
-  kvStore.set(`${deviceID}.o.nextID`, `${FIRST_DEVICE_STATE_ID}`);
+  kvStore.set(`${deviceID}.o.nextID`, `${FIRST_DEVICE_IMPORTED_OBJECT_ID}`);
+  kvStore.set(`${deviceID}.d.nextID`, `${FIRST_DEVICE_IMPORTED_DEVICE_ID}`);
+  kvStore.set(`${deviceID}.p.nextID`, `${FIRST_DEVICE_IMPORTED_PROMISE_ID}`);
 }
 
 /**
@@ -121,9 +125,11 @@ export function makeDeviceKeeper(kvStore, deviceID, tools) {
         id = Nat(BigInt(kvStore.get(`${deviceID}.o.nextID`)));
         kvStore.set(`${deviceID}.o.nextID`, `${id + 1n}`);
       } else if (type === 'device') {
-        throw new Error('devices cannot import other device nodes');
+        id = Nat(BigInt(kvStore.get(`${deviceID}.d.nextID`)));
+        kvStore.set(`${deviceID}.d.nextID`, `${id + 1n}`);
       } else if (type === 'promise') {
-        throw new Error('devices cannot import Promises');
+        id = Nat(BigInt(kvStore.get(`${deviceID}.p.nextID`)));
+        kvStore.set(`${deviceID}.p.nextID`, `${id + 1n}`);
       } else {
         assert.fail(X`unknown type ${type}`);
       }

--- a/packages/SwingSet/src/kernel/vatManager/supervisor-helper.js
+++ b/packages/SwingSet/src/kernel/vatManager/supervisor-helper.js
@@ -88,7 +88,7 @@ function makeSupervisorSyscall(syscallToManager, workerCanBlock) {
       }
       case 'error': {
         const [err] = rest;
-        throw Error(`syscall.${fields[0]} failed, prepare to die: ${err}`);
+        throw Error(`syscall.${fields[0]} failed: ${err}`);
       }
       default:
         throw Error(`unknown result type ${type}`);

--- a/packages/SwingSet/src/types.js
+++ b/packages/SwingSet/src/types.js
@@ -130,26 +130,36 @@
  *            | KernelDeliveryRetireExports | KernelDeliveryRetireImports
  *          } KernelDeliveryObject
  * @typedef { [tag: 'send', target: string, msg: Message] } KernelSyscallSend
- * @typedef { [tag: 'callNow', target: string, method: string, args: SwingSetCapData]} KernelSyscallCallNow
+ * @typedef { [tag: 'invoke', target: string, method: string, args: SwingSetCapData]} KernelSyscallInvoke
  * @typedef { [tag: 'subscribe', kpid: string ]} KernelSyscallSubscribe
  * @typedef { [ kpid: string, rejected: boolean, data: SwingSetCapData ]} KernelResolutions
  * @typedef { [tag: 'resolve', resolutions: KernelResolutions ]} KernelSyscallResolve
- * @typedef { [tag: 'vatstoreGet', key: string ]} KernelSyscallVatstoreGet
- * @typedef { [tag: 'vatstoreGetAfter', priorKey: string, lowerBound: string, upperBound: string | undefined ]} KernelSyscallVatstoreGetAfter
- * @typedef { [tag: 'vatstoreSet', key: string, data: string ]} KernelSyscallVatstoreSet
- * @typedef { [tag: 'vatstoreDelete', key: string ]} KernelSyscallVatstoreDelete
+ * @typedef { [tag: 'exit', vatID: string, isFailure: boolean, info: SwingSetCapData ]} KernelSyscallExit
+ * @typedef { [tag: 'vatstoreGet', vatID: string, key: string ]} KernelSyscallVatstoreGet
+ * @typedef { [tag: 'vatstoreGetAfter', vatID: string, priorKey: string, lowerBound: string, upperBound: string | undefined ]} KernelSyscallVatstoreGetAfter
+ * @typedef { [tag: 'vatstoreSet', vatID: string, key: string, data: string ]} KernelSyscallVatstoreSet
+ * @typedef { [tag: 'vatstoreDelete', vatID: string, key: string ]} KernelSyscallVatstoreDelete
  * @typedef { [tag: 'dropImports', krefs: string[] ]} KernelSyscallDropImports
  * @typedef { [tag: 'retireImports', krefs: string[] ]} KernelSyscallRetireImports
  * @typedef { [tag: 'retireExports', krefs: string[] ]} KernelSyscallRetireExports
  *
- * @typedef { KernelSyscallSend | KernelSyscallCallNow | KernelSyscallSubscribe
- *    | KernelSyscallResolve | KernelSyscallVatstoreGet | KernelSyscallVatstoreGetAfter
+ * @typedef { KernelSyscallSend | KernelSyscallInvoke | KernelSyscallSubscribe
+ *    | KernelSyscallResolve | KernelSyscallExit | KernelSyscallVatstoreGet | KernelSyscallVatstoreGetAfter
  *    | KernelSyscallVatstoreSet | KernelSyscallVatstoreDelete | KernelSyscallDropImports
  *    | KernelSyscallRetireImports | KernelSyscallRetireExports
  * } KernelSyscallObject
- * @typedef { [tag: 'ok', data: SwingSetCapData | string | null ]} KernelSyscallResultOk
+ * @typedef { [tag: 'ok', data: SwingSetCapData | string | string[] | null ]} KernelSyscallResultOk
  * @typedef { [tag: 'error', err: string ] } KernelSyscallResultError
  * @typedef { KernelSyscallResultOk | KernelSyscallResultError } KernelSyscallResult
+ *
+ * @typedef {[string, string, SwingSetCapData]} DeviceInvocation
+ * @property {string} 0 Kernel slot designating the device node that is the target of
+ * the invocation
+ * @property {string} 1 A string naming the method to be invoked
+ * @property {CapData} 2 A capdata object containing the arguments to the invocation
+ * @typedef {[tag: 'ok', data: SwingSetCapData]} DeviceInvocationResultOk
+ * @typedef {[tag: 'error', problem: string]} DeviceInvocationResultError
+ * @typedef { DeviceInvocationResultOk | DeviceInvocationResultError } DeviceInvocationResult
  *
  * @typedef { { d: VatDeliveryObject, syscalls: VatSyscallObject[] } } TranscriptEntry
  * @typedef { { transcriptCount: number } } VatStats

--- a/packages/SwingSet/test/devices/bootstrap-5.js
+++ b/packages/SwingSet/test/devices/bootstrap-5.js
@@ -1,0 +1,17 @@
+import { Far } from '@agoric/marshal';
+
+export function buildRootObject(vatPowers, _vatParameters) {
+  const { D } = vatPowers;
+  return Far('root', {
+    async bootstrap(vats, devices) {
+      let got;
+      try {
+        D(devices.d5).pleaseThrow('with message');
+        got = 'oops, did not throw';
+      } catch (e) {
+        got = e;
+      }
+      return harden(['got', got]);
+    },
+  });
+}

--- a/packages/SwingSet/test/devices/bootstrap-6.js
+++ b/packages/SwingSet/test/devices/bootstrap-6.js
@@ -1,0 +1,22 @@
+import { Far } from '@agoric/marshal';
+
+export function buildRootObject(vatPowers, _vatParameters) {
+  const { D } = vatPowers;
+  return Far('root', {
+    async bootstrap(vats, devices) {
+      let got;
+      try {
+        // ideally, device nodes can round-trip through unrelated devices
+        const second = D(devices.d6first).pleaseReturn(devices.d6second);
+        got = second === devices.d6second;
+      } catch (e) {
+        // but deviceSlots.js cannot handle foreign device nodes yet, so we
+        // expect a catchable device error. If/when deviceSlots is enhanced
+        // to handle this, or if the target is raw device, this can start to
+        // work.
+        got = e;
+      }
+      return harden(['got', got]);
+    },
+  });
+}

--- a/packages/SwingSet/test/devices/device-5.js
+++ b/packages/SwingSet/test/devices/device-5.js
@@ -1,0 +1,9 @@
+import { Far } from '@agoric/marshal';
+
+export function buildRootDeviceNode() {
+  return Far('root', {
+    pleaseThrow(msg) {
+      throw Error(`intentional: ${msg}`);
+    },
+  });
+}

--- a/packages/SwingSet/test/devices/device-6.js
+++ b/packages/SwingSet/test/devices/device-6.js
@@ -1,0 +1,9 @@
+import { Far } from '@agoric/marshal';
+
+export function buildRootDeviceNode() {
+  return Far('root', {
+    pleaseReturn(obj) {
+      return obj;
+    },
+  });
+}

--- a/packages/SwingSet/test/test-gc-kernel.js
+++ b/packages/SwingSet/test/test-gc-kernel.js
@@ -607,7 +607,7 @@ test('retire before drop is error', async t => {
   t.is(syscallError.name, 'Error');
   t.is(
     syscallError.message,
-    'syscall.retireImports failed, prepare to die: syscall translation error: prepare to die',
+    'syscall.retireImports failed: syscall translation error: prepare to die',
   );
 
   // vat should be terminated


### PR DESCRIPTION
fix(swingset): don't kernel panic upon device error

Previously, any error thrown by a device invocation would set the kernel to
the "panic" state, mark the calling vat as scheduled for termination, then
return an error indication to the calling vat, which makes the
`syscall.callNow()` throw an exception. From the calling vat's perspective,
their `D()` invocation throw a "you killed my kernel, prepare to die" error,
the delivery would complete, then the entire kernel would shut down.
`controller.run()` rejects its return promise, causing the host application
to halt without committing state.

This was fail-stop safe against surprises in the device code, but is too
difficult to use in practice. Devices could not use assert() to validate
caller arguments without giving the calling vat the power to shut down the
entire kernel.

With this change, errors during device invocation cause the calling vat to
get an error, as before, but the error is neither vat-fatal nor kernel-fatal.

It is still vat-fatal to pass promises in arguments to devices, where the
mistake is caught by the vat's outbound translator, rather than the device's
inbound translator. We'll probably relax this restriction later.

The device inbound translator used to throw an error if it got a foreign
device node, or a promise that somehow got past the guard above. In both
cases, the translator error caused a kernel panic. This commit changes the
inbound translator to handle both foreign device nodes and promises, which
ought to prevent vats from triggering kernel panics via this route.
Deviceslots will still reject both, but since that error occurs in the
device *invocation*, the calling vat should get a (catchable) error, and the
kernel will not panic.

GC handling is still really sketchy around devices: do not expect objects
passed to a device to ever be dropped.

closes #4326
