### PR TITLE
feat(swingset): support raw devices

### DIFF
--- a/packages/SwingSet/src/deviceTools.js
+++ b/packages/SwingSet/src/deviceTools.js
@@ -1,0 +1,101 @@
+import { assert, details as X } from '@agoric/assert';
+import { makeMarshal, Far } from '@endo/marshal';
+import { parseVatSlot } from './parseVatSlots.js';
+
+// raw devices can use this to build a set of convenience tools for
+// serialization/unserialization
+
+export function buildSerializationTools(syscall, deviceName) {
+  // TODO: prevent our Presence/DeviceNode objects from being accidentally be
+  // marshal-serialized into persistent state
+
+  const presences = new WeakMap();
+  const myDeviceNodes = new WeakMap();
+
+  function slotFromPresence(p) {
+    return presences.get(p);
+  }
+  function presenceForSlot(slot) {
+    const { type, allocatedByVat } = parseVatSlot(slot);
+    assert.equal(type, 'object');
+    assert.equal(allocatedByVat, false);
+    const p = Far('presence', {
+      send(method, args) {
+        assert.typeof(method, 'string');
+        assert(Array.isArray(args), args);
+        // eslint-disable-next-line no-use-before-define
+        const capdata = serialize(args);
+        syscall.sendOnly(slot, method, capdata);
+      },
+    });
+    presences.set(p, slot);
+    return p;
+  }
+
+  function slotFromMyDeviceNode(dn) {
+    return myDeviceNodes.get(dn);
+  }
+  function deviceNodeForSlot(slot) {
+    const { type, allocatedByVat } = parseVatSlot(slot);
+    assert.equal(type, 'device');
+    assert.equal(allocatedByVat, true);
+    const dn = Far('device node', {});
+    myDeviceNodes.set(dn, slot);
+    return dn;
+  }
+
+  function convertSlotToVal(slot) {
+    const { type, allocatedByVat } = parseVatSlot(slot);
+    if (type === 'object') {
+      assert(!allocatedByVat, X`devices cannot yet allocate objects ${slot}`);
+      return presenceForSlot(slot);
+    } else if (type === 'device') {
+      assert(
+        allocatedByVat,
+        X`devices should yet not be given other devices '${slot}'`,
+      );
+      return deviceNodeForSlot(slot);
+    } else if (type === 'promise') {
+      assert.fail(X`devices should not yet be given promises '${slot}'`);
+    } else {
+      assert.fail(X`unrecognized slot type '${type}'`);
+    }
+  }
+
+  function convertValToSlot(val) {
+    const objSlot = slotFromPresence(val);
+    if (objSlot) {
+      return objSlot;
+    }
+    const devnodeSlot = slotFromMyDeviceNode(val);
+    if (devnodeSlot) {
+      return devnodeSlot;
+    }
+    throw Error(X`unable to convert value ${val}`);
+  }
+
+  const m = makeMarshal(convertValToSlot, convertSlotToVal, {
+    marshalName: `device:${deviceName}`,
+    // TODO Temporary hack.
+    // See https://github.com/Agoric/agoric-sdk/issues/2780
+    errorIdNum: 60000,
+  });
+
+  // for invoke(), these will unserialize the arguments, and serialize the
+  // response (into a vatresult with the 'ok' header)
+  const unserialize = capdata => m.unserialize(capdata);
+  const serialize = data => m.serialize(harden(data));
+  const returnFromInvoke = args => harden(['ok', serialize(args)]);
+
+  const tools = {
+    slotFromPresence,
+    presenceForSlot,
+    slotFromMyDeviceNode,
+    deviceNodeForSlot,
+    unserialize,
+    returnFromInvoke,
+  };
+
+  return harden(tools);
+}
+harden(buildSerializationTools);

--- a/packages/SwingSet/test/devices/bootstrap-raw.js
+++ b/packages/SwingSet/test/devices/bootstrap-raw.js
@@ -1,0 +1,66 @@
+import { Far } from '@endo/marshal';
+import { makePromiseKit } from '@agoric/promise-kit';
+
+export function buildRootObject(vatPowers, _vatParameters) {
+  const { D } = vatPowers;
+  let devices;
+  return Far('root', {
+    bootstrap(vats, d0) {
+      devices = d0;
+    },
+
+    step1() {
+      return D(devices.dr).one(harden({ toPush: 'pushed', x: 4 }));
+    },
+
+    async step2() {
+      const pk1 = makePromiseKit();
+      const pk2 = makePromiseKit();
+      const got = [];
+      // give the device an object to return and do sendOnly
+      const target = Far('target', {
+        ping1(hello, p1) {
+          got.push(hello); // should be 'hi ping1'
+          got.push(p1 === target);
+          pk1.resolve();
+        },
+        ping2(hello, p2) {
+          got.push(hello); // should be 'hi ping2'
+          got.push(p2 === target);
+          pk2.resolve();
+        },
+      });
+      const ret = D(devices.dr).two(target); // ['got', target]
+      got.push(ret[0]);
+      got.push(ret[1] === target);
+      await pk1.promise;
+      await pk2.promise;
+      return got; // ['got', true, 'hi ping1', true, 'hi ping2', true]
+    },
+
+    step3() {
+      const { dn1, dn2 } = D(devices.dr).three(); // returns new device nodes
+      const ret1 = D(dn1).threeplus(21, dn1, dn2); // ['dn1', 21, true, true]
+      const ret2 = D(dn2).threeplus(22, dn1, dn2); // ['dn2', 22, true, true]
+      return [ret1, ret2];
+    },
+
+    step4() {
+      const got1 = D(devices.dr).fourGet();
+      D(devices.dr).fourSet('value1');
+      const got2 = D(devices.dr).fourGet();
+      D(devices.dr).fourDelete();
+      const got3 = D(devices.dr).fourGet();
+      return [got1, got2, got3];
+    },
+
+    step5() {
+      try {
+        D(devices.dr).fiveThrow();
+        return false;
+      } catch (e) {
+        return e;
+      }
+    },
+  });
+}

--- a/packages/SwingSet/test/devices/device-raw-0.js
+++ b/packages/SwingSet/test/devices/device-raw-0.js
@@ -1,0 +1,103 @@
+import { assert } from '@agoric/assert';
+import { buildSerializationTools } from '../../src/deviceTools.js';
+
+export function buildDevice(tools, endowments) {
+  const { syscall } = tools;
+  const dtools = buildSerializationTools(syscall, 'dr0');
+  const { unserialize, returnFromInvoke } = dtools;
+  const { slotFromPresence, presenceForSlot } = dtools;
+  const { deviceNodeForSlot, slotFromMyDeviceNode } = dtools;
+
+  const ROOT = 'd+0';
+  const DN1SLOT = 'd+1';
+  const DN2SLOT = 'd+2';
+
+  // invoke() should use unserialize() and returnFromInvoke
+  // throwing errors or returning undefined will crash the kernel
+
+  const dispatch = {
+    invoke: (dnid, method, argsCapdata) => {
+      const args = unserialize(argsCapdata);
+
+      if (dnid === ROOT) {
+        if (method === 'one') {
+          // exercise basic invocation, args, return value
+          endowments.shared.push(args[0].toPush);
+          // need iserialize to make ['ok', capdata]
+          return returnFromInvoke({ a: args[0].x, b: [5, 6] });
+        }
+        if (method === 'two') {
+          // exercise Presences, send
+          const pres1 = args[0];
+          const slot1 = slotFromPresence(pres1); // should be o-1
+          pres1.send('ping1', ['hi ping1', pres1]);
+          const pres2 = presenceForSlot(slot1);
+          pres2.send('ping2', ['hi ping2', pres2]);
+          return returnFromInvoke(['got', pres1]);
+        }
+        if (method === 'three') {
+          // create new device nodes
+          const dn1 = deviceNodeForSlot(DN1SLOT);
+          const dn2 = deviceNodeForSlot(DN2SLOT);
+          return returnFromInvoke({ dn1, dn2 });
+        }
+
+        // manage state through vatStore
+        if (method === 'fourGet') {
+          return returnFromInvoke([
+            syscall.vatstoreGet('key1'),
+            syscall.vatstoreGet('key2'),
+          ]);
+        }
+        if (method === 'fourSet') {
+          assert.typeof(args[0], 'string');
+          syscall.vatstoreSet('key1', args[0]);
+          return returnFromInvoke();
+        }
+        if (method === 'fourDelete') {
+          syscall.vatstoreDelete('key1');
+          return returnFromInvoke();
+        }
+
+        if (method === 'fiveThrow') {
+          throw Error('intentional device error');
+        }
+
+        throw TypeError(`target[${method}] does not exist`);
+      }
+
+      if (dnid === DN1SLOT) {
+        // exercise new device nodes
+        if (method === 'threeplus') {
+          const [num, dn1b, dn2b] = args;
+          const ret = [
+            'dn1',
+            num,
+            slotFromMyDeviceNode(dn1b) === DN1SLOT,
+            slotFromMyDeviceNode(dn2b) === DN2SLOT,
+          ];
+          return returnFromInvoke(ret);
+        }
+        throw TypeError(`dn1[${method}] does not exist`);
+      }
+
+      if (dnid === DN2SLOT) {
+        // exercise new device nodes
+        if (method === 'threeplus') {
+          const [num, dn1b, dn2b] = args;
+          const ret = [
+            'dn2',
+            num,
+            slotFromMyDeviceNode(dn1b) === DN1SLOT,
+            slotFromMyDeviceNode(dn2b) === DN2SLOT,
+          ];
+          return returnFromInvoke(ret);
+        }
+        throw TypeError(`dn2[${method}] does not exist`);
+      }
+
+      throw TypeError(`target does not exist`);
+    },
+  };
+  return dispatch;
+}

--- a/packages/SwingSet/test/devices/test-raw-device.js
+++ b/packages/SwingSet/test/devices/test-raw-device.js
@@ -1,0 +1,98 @@
+// eslint-disable-next-line import/order
+import { test } from '../../tools/prepare-test-env-ava.js';
+
+// eslint-disable-next-line import/order
+import bundleSource from '@endo/bundle-source';
+import { parse } from '@endo/marshal';
+import { provideHostStorage } from '../../src/hostStorage.js';
+
+import {
+  initializeSwingset,
+  makeSwingsetController,
+  buildKernelBundles,
+} from '../../src/index.js';
+import { capargs } from '../util.js';
+
+function dfile(name) {
+  return new URL(`./${name}`, import.meta.url).pathname;
+}
+
+test.before(async t => {
+  const kernelBundles = await buildKernelBundles();
+  const bootstrapRaw = await bundleSource(dfile('bootstrap-raw.js'));
+  t.context.data = {
+    kernelBundles,
+    bootstrapRaw,
+  };
+});
+
+test('d1', async t => {
+  const sharedArray = [];
+  const config = {
+    bootstrap: 'bootstrap',
+    defaultReapInterval: 'never',
+    vats: {
+      bootstrap: {
+        bundle: t.context.data.bootstrapRaw,
+      },
+    },
+    devices: {
+      dr: {
+        sourceSpec: dfile('device-raw-0'),
+      },
+    },
+  };
+  const deviceEndowments = {
+    dr: {
+      shared: sharedArray,
+    },
+  };
+
+  const hostStorage = provideHostStorage();
+  await initializeSwingset(config, [], hostStorage, t.context.data);
+  const c = await makeSwingsetController(hostStorage, deviceEndowments);
+  c.pinVatRoot('bootstrap');
+  await c.run();
+
+  // first, exercise plain arguments and return values
+  const r1 = c.queueToVatRoot('bootstrap', 'step1', capargs([]));
+  await c.run();
+  t.deepEqual(JSON.parse(c.kpResolution(r1).body), { a: 4, b: [5, 6] });
+  t.deepEqual(sharedArray, ['pushed']);
+  sharedArray.length = 0;
+
+  // exercise giving objects to devices, getting them back, and the device's
+  // ability to do sendOnly to those objects
+  const r2 = c.queueToVatRoot('bootstrap', 'step2', capargs([]));
+  await c.run();
+  const expected2 = ['got', true, 'hi ping1', true, 'hi ping2', true];
+  t.deepEqual(JSON.parse(c.kpResolution(r2).body), expected2);
+
+  // create and pass around new device nodes
+  const r3 = c.queueToVatRoot('bootstrap', 'step3', capargs([]));
+  await c.run();
+  const expected3 = [
+    ['dn1', 21, true, true],
+    ['dn2', 22, true, true],
+  ];
+  t.deepEqual(JSON.parse(c.kpResolution(r3).body), expected3);
+
+  // check that devices can manage state through vatstore
+  const r4 = c.queueToVatRoot('bootstrap', 'step4', capargs([]));
+  await c.run();
+  const expected4 = [
+    [undefined, undefined],
+    ['value1', undefined],
+    [undefined, undefined],
+  ];
+  t.deepEqual(parse(c.kpResolution(r4).body), expected4);
+
+  // check that device exceptions do not kill the device, calling vat, or kernel
+  const r5 = c.queueToVatRoot('bootstrap', 'step5', capargs([]));
+  await c.run();
+  // body: '{"@qclass":"error","errorId":"error:liveSlots:v1#70001","message":"syscall.callNow failed: device.invoke failed, see logs for details","name":"Error"}',
+  const expected5 = Error(
+    'syscall.callNow failed: device.invoke failed, see logs for details',
+  );
+  t.deepEqual(parse(c.kpResolution(r5).body), expected5);
+});


### PR DESCRIPTION
"Raw devices" bypass the deviceSlots layer and allow device code direct
access to `syscall`, and the arguments arriving through the `dispatch` object
it must produce. This makes some patterns much easier to implement, such as
producing new device nodes as part of the device's API (e.g. one device node
per code bundle).

It also provides vatstoreGet/Set/Delete, so the device code can manage one
piece of state at a time, instead of doing an expensive read-modify-write
cycle on a single large aggregate state object.

A helper library named deviceTools.js was added to make it slightly easier to
write a raw device.

In the longer run (see #1346), we'd like these devices to support Promises
and plain object references. This change doesn't go that far. The remaining
limitations are:

* the deviceTools.js library refuses to handle exported objects, imported
foreign device nodes, or promises of any sort
* the outbound translator (deviceKeeper.js `mapDeviceSlotToKernelSlot`)
refuses to handle exported objects and exported promises
* the vat outbound translator (vatTranslator.js `translateCallNow`) refuses
to handle promises
* liveslots rejects promises in `D()` arguments

refs #1346
