### PR TITLE
feat: NonNullish checked cast

### DIFF
--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -9,13 +9,17 @@
   },
   "scripts": {
     "build": "exit 0",
-    "test": "exit 0",
+    "test": "ava",
     "test:nyc": "exit 0",
     "test:xs": "exit 0",
     "lint-fix": "yarn lint:eslint --fix",
     "lint": "run-s --continue-on-error lint:*",
     "lint:eslint": "eslint .",
     "lint:types": "tsc -p jsconfig.json"
+  },
+  "devDependencies": {
+    "@endo/init": "^0.5.43",
+    "ava": "^4.3.1"
   },
   "repository": {
     "type": "git",
@@ -35,14 +39,6 @@
     "src/",
     "exported.js",
     "NEWS.md"
-  ],
-  "eslintConfig": {
-    "extends": [
-      "@agoric"
-    ]
-  },
-  "eslintIgnore": [
-    "bundle-*.js"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -58,6 +58,21 @@ export { quote as q };
 export { makeAssert };
 
 /**
+ * @template T
+ * @param {T | null | undefined} val
+ * @param {string} [optDetails]
+ * @returns {T}
+ */
+export const NonNullish = (val, optDetails = `unexpected ${quote(val)}`) => {
+  if (val != null) {
+    // This `!= null` idiom checks that `val` is neither `null` nor `undefined`.
+    return val;
+  }
+  assert.fail(optDetails);
+};
+harden(NonNullish);
+
+/**
  * Prepend the correct indefinite article onto a noun, typically a typeof result
  * e.g., "an Object" vs. "a Number"
  *

--- a/packages/assert/test/test-assert.js
+++ b/packages/assert/test/test-assert.js
@@ -1,0 +1,15 @@
+import '@endo/init';
+// eslint-disable-next-line import/no-unresolved -- lint error not worth solving; test passes
+import test from 'ava';
+
+import { NonNullish } from '../src/assert.js';
+
+test('NonNullish', t => {
+  assert.equal(NonNullish('defined'), 'defined');
+  t.throws(() => NonNullish(null), {
+    message: 'unexpected null',
+  });
+  t.throws(() => NonNullish(undefined), {
+    message: 'unexpected "[undefined]"',
+  });
+});


### PR DESCRIPTION
## Description

Sometimes you or the type checker doesn't know that a value will be defined at runtime. This adds a utility that casts to a non-nullish version of the value, with a check that the cast is valid.

### Security Considerations

This function may be used in many places.

### Documentation Considerations

No action needed.

### Testing Considerations

- [x] needs tests