### PR TITLE
refactor(SwingSet): remove a couple inline type annotations

### DIFF
--- a/packages/SwingSet/src/kernel/virtualReferences.js
+++ b/packages/SwingSet/src/kernel/virtualReferences.js
@@ -262,13 +262,8 @@ export function makeVirtualReferenceManager(
         } else {
           // exported non-virtual object: Remotable
           const remotable = requiredValForSlot(vref);
-          if (remotableRefCounts.has(remotable)) {
-            /** @type {number} */
-            const oldRefCount = (remotableRefCounts.get(remotable));
-            remotableRefCounts.set(remotable, oldRefCount + 1);
-          } else {
-            remotableRefCounts.set(remotable, 1);
-          }
+          const oldRefCount = remotableRefCounts.get(remotable) || 0;
+          remotableRefCounts.set(remotable, oldRefCount + 1);
         }
       } else {
         // We refcount imports, to preserve their vrefs against
@@ -288,9 +283,11 @@ export function makeVirtualReferenceManager(
         } else {
           // exported non-virtual object: Remotable
           const remotable = requiredValForSlot(vref);
-          /** @type {number} */
-          const oldRefCount = (remotableRefCounts.get(remotable));
-          assert(oldRefCount > 0, `attempt to decref ${vref} below 0`);
+          const oldRefCount = remotableRefCounts.get(remotable);
+          assert(
+            oldRefCount !== undefined && oldRefCount > 0,
+            `attempt to decref ${vref} below 0`,
+          );
           if (oldRefCount === 1) {
             remotableRefCounts.delete(remotable);
             droppedMemoryReference = true;


### PR DESCRIPTION
## Description

With #4136 a couple PRs have conflicts around changes they had to make to play well with type annotations:
https://github.com/Agoric/agoric-sdk/pull/4330
https://github.com/Agoric/agoric-sdk/pull/4420

Those are tooling PRs so ideally they have no changes to application logic. This pulls out some changes they need for green.

### Security Considerations

--

### Documentation Considerations

--

### Testing Considerations

--