### PR TITLE
chore: prettier ignore lcov-report, .html, .json and .md

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,7 +3,13 @@ build
 bundles
 compiled
 dist
+lcov-report
 public
+
+# Opt out of these file types for now
+*.html
+*.json
+*.md
 
 # subrepos
 /packages/xsnap/moddable


### PR DESCRIPTION
closes: #4440


## Description

`lcov-reports` are an artifact that is sometimes built.

This also pulls the file extension opt outs from https://github.com/Agoric/agoric-sdk/pull/4330
