### PR TITLE
fix: quick "fix" of a red squiggle problem

### DIFF
--- a/packages/store/src/keys/checkKey.js
+++ b/packages/store/src/keys/checkKey.js
@@ -1,5 +1,7 @@
 // @ts-check
 
+import '@endo/marshal/exported.js';
+
 /// <reference types="ses"/>
 
 import {


### PR DESCRIPTION
Applies suggestion from https://github.com/Agoric/agoric-sdk/issues/4444#issuecomment-1029409934 at a place that seems to make more red squiggles to away.

If I apply the quick "fix" to store/src/types.js itself, then checkKey.js has lots of red squiggles that don't disappear, either with or without the same quick fix applied there. However, if I apply the quick fix only there, the red squiggles go away both places.

I also searched for `/// <reference types="ses"/>` and visually verified that vscode doesn't show any red squiggles on the 20 matching files after this change.

If a principled change is about to arrive soon that fixes this correctly, then by all means let's not merge this PR in the meantime. What PR is that?