### PR TITLE
chore(swingset): factor some test utilities out of util.js

### DIFF
--- a/packages/SwingSet/test/devices/bootstrap-0.js
+++ b/packages/SwingSet/test/devices/bootstrap-0.js
@@ -1,4 +1,4 @@
-import { extractMessage } from '../util.js';
+import { extractMessage } from '../vat-util.js';
 
 export default function setup(syscall, state, _helpers, vatPowers) {
   function dispatch(vatDeliverObject) {

--- a/packages/SwingSet/test/devices/bootstrap-1.js
+++ b/packages/SwingSet/test/devices/bootstrap-1.js
@@ -1,5 +1,5 @@
 import { assert, details as X } from '@agoric/assert';
-import { extractMessage } from '../util.js';
+import { extractMessage } from '../vat-util.js';
 
 export default function setup(syscall, state, _helpers, vatPowers) {
   const { testLog } = vatPowers;

--- a/packages/SwingSet/test/devices/bootstrap-4.js
+++ b/packages/SwingSet/test/devices/bootstrap-4.js
@@ -1,7 +1,7 @@
 import { assert } from '@agoric/assert';
 import { QCLASS } from '@endo/marshal';
 import { insistVatType } from '../../src/parseVatSlots.js';
-import { extractMessage } from '../util.js';
+import { extractMessage } from '../vat-util.js';
 
 // to exercise the error we get when syscall.callNow() is given a promise
 // identifier, we must bypass liveslots, which would otherwise protect us

--- a/packages/SwingSet/test/message-patterns.js
+++ b/packages/SwingSet/test/message-patterns.js
@@ -7,7 +7,7 @@ import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
 import { quote as q } from '@agoric/assert';
 import { Far } from '@endo/marshal';
-import { ignore } from './util.js';
+import { ignore } from './vat-util.js';
 
 // Exercise a set of increasingly complex object-capability message patterns,
 // for testing.

--- a/packages/SwingSet/test/util.js
+++ b/packages/SwingSet/test/util.js
@@ -1,5 +1,12 @@
-import { assert } from '@agoric/assert';
-import { QCLASS } from '@endo/marshal';
+import anylogger from 'anylogger';
+
+import { waitUntilQuiescent } from '../src/waitUntilQuiescent.js';
+import { provideHostStorage } from '../src/hostStorage.js';
+import { WeakRef, FinalizationRegistry } from '../src/weakref.js';
+import { createSHA256 } from '../src/hasher.js';
+import { extractMessage, capdata, capargs, ignore } from './vat-util.js';
+
+export { extractMessage, capdata, capargs, ignore };
 
 function compareArraysOfStrings(a, b) {
   a = a.join(' ');
@@ -70,36 +77,6 @@ export function buildDispatch(onDispatchCallback = undefined) {
   return { log, dispatch };
 }
 
-export function ignore(p) {
-  p.then(
-    () => 0,
-    () => 0,
-  );
-}
-
-export function extractMessage(vatDeliverObject) {
-  const [type, ...vdoargs] = vatDeliverObject;
-  assert.equal(type, 'message', `util.js .extractMessage`);
-  const [facetID, msg] = vdoargs;
-  const { method, args, result } = msg;
-  return { facetID, method, args, result };
-}
-
-export function capdata(body, slots = []) {
-  return harden({ body, slots });
-}
-
-function marshalBigIntReplacer(_, arg) {
-  if (typeof arg === 'bigint') {
-    return { [QCLASS]: 'bigint', digits: String(arg) };
-  }
-  return arg;
-}
-
-export function capargs(args, slots = []) {
-  return capdata(JSON.stringify(args, marshalBigIntReplacer), slots);
-}
-
 export function capSlot(index) {
   return { '@qclass': 'slot', iface: 'Alleged: export', index };
 }
@@ -156,4 +133,25 @@ export function makeRetireExports(...vrefs) {
 export function makeRetireImports(...vrefs) {
   const vatDeliverObject = harden(['retireImports', vrefs]);
   return vatDeliverObject;
+}
+
+function makeConsole(tag) {
+  const log = anylogger(tag);
+  const cons = {};
+  for (const level of ['debug', 'log', 'info', 'warn', 'error']) {
+    cons[level] = log[level];
+  }
+  return harden(cons);
+}
+
+export function makeKernelEndowments() {
+  return {
+    waitUntilQuiescent,
+    hostStorage: provideHostStorage(),
+    runEndOfCrank: () => {},
+    makeConsole,
+    WeakRef,
+    FinalizationRegistry,
+    createSHA256,
+  };
 }

--- a/packages/SwingSet/test/vat-controller-1.js
+++ b/packages/SwingSet/test/vat-controller-1.js
@@ -1,5 +1,5 @@
 // -*- js -*-
-import { extractMessage } from './util';
+import { extractMessage } from './vat-util';
 
 export default function setup(syscall, _state, _helpers, vatPowers) {
   function dispatch(vatDeliverObject) {

--- a/packages/SwingSet/test/vat-syscall-failure.js
+++ b/packages/SwingSet/test/vat-syscall-failure.js
@@ -1,4 +1,4 @@
-import { extractMessage } from './util.js';
+import { extractMessage } from './vat-util.js';
 
 function capdata(body, slots = []) {
   return harden({ body, slots });

--- a/packages/SwingSet/test/vat-util.js
+++ b/packages/SwingSet/test/vat-util.js
@@ -1,0 +1,35 @@
+// this file is imported by some test vats, so don't import any non-pure
+// modules
+
+import { assert } from '@agoric/assert';
+import { QCLASS } from '@endo/marshal';
+
+export function extractMessage(vatDeliverObject) {
+  const [type, ...vdoargs] = vatDeliverObject;
+  assert.equal(type, 'message', `util.js .extractMessage`);
+  const [facetID, msg] = vdoargs;
+  const { method, args, result } = msg;
+  return { facetID, method, args, result };
+}
+
+export function capdata(body, slots = []) {
+  return harden({ body, slots });
+}
+
+function marshalBigIntReplacer(_, arg) {
+  if (typeof arg === 'bigint') {
+    return { [QCLASS]: 'bigint', digits: String(arg) };
+  }
+  return arg;
+}
+
+export function capargs(args, slots = []) {
+  return capdata(JSON.stringify(args, marshalBigIntReplacer), slots);
+}
+
+export function ignore(p) {
+  p.then(
+    () => 0,
+    () => 0,
+  );
+}


### PR DESCRIPTION
test/util.js has a variety of utilities for unit tests, but was imported by
both start-compartment test programs, and vat code. The additional imports
from other packages cause a problem when bundling code for a vat.

This moves the handful of utilities we want for vat code into a separate
vat-util.js, which is then imported+rexported by util.js for the
start-compartment code.

It also moves some utilities from test-kernel.js into util.js for the benefit
of future unit tests.
