### PR TITLE
chore(deployment): Use latest Node 14 in docker images

### DIFF
--- a/packages/deployment/Dockerfile.sdk
+++ b/packages/deployment/Dockerfile.sdk
@@ -13,7 +13,7 @@ RUN make GIT_COMMIT="$GIT_COMMIT" MOD_READONLY= compile-go
 
 ###############################
 # The js build container
-FROM node:14.15-buster AS build-js
+FROM node:14-buster AS build-js
 
 # When changing/adding entries here, make sure to search the whole project for
 # `@@AGORIC_DOCKER_SUBMODULES@@`
@@ -51,7 +51,7 @@ RUN rm -rf packages/xsnap/moddable
 
 ###############################
 # The install container.
-FROM node:14.15-buster AS install
+FROM node:14-buster AS install
 
 # Install some conveniences.
 RUN apt-get --allow-releaseinfo-change update && apt-get install -y vim jq less && apt-get clean -y


### PR DESCRIPTION
refs: #4459

## Description

#4420 requires a more recent node version, and the `deployment` package was hard coding `14.15`. Switch to the latest 14 instead.
