### PR TITLE
Sort preserving order for composite keys! Woohoo!

### DIFF
--- a/packages/store/src/keys/compareKeys.js
+++ b/packages/store/src/keys/compareKeys.js
@@ -3,13 +3,12 @@
 /// <reference types="ses"/>
 
 import { passStyleOf, getTag } from '@endo/marshal';
-import { compareRank } from '../patterns/rankOrder.js';
+import { compareRank, recordParts } from '../patterns/rankOrder.js';
 import { assertKey } from './checkKey.js';
 import { bagCompare } from './merge-bag-operators.js';
 import { setCompare } from './merge-set-operators.js';
 
 const { details: X, quote: q } = assert;
-const { ownKeys } = Reflect;
 
 /** @type {KeyCompare} */
 export const compareKeys = (left, right) => {
@@ -71,8 +70,9 @@ export const compareKeys = (left, right) => {
     }
     case 'copyRecord': {
       // Pareto partial order comparison.
-      const leftNames = harden(ownKeys(left).sort());
-      const rightNames = harden(ownKeys(right).sort());
+      const [leftNames, leftValues] = recordParts(left);
+      const [rightNames, rightValues] = recordParts(right);
+
       // eslint-disable-next-line no-use-before-define
       if (!keyEQ(leftNames, rightNames)) {
         // If they do not have exactly the same properties,
@@ -85,8 +85,8 @@ export const compareKeys = (left, right) => {
       // Presume that both copyRecords have the same key order
       // until encountering a property disproving that hypothesis.
       let result = 0;
-      for (const name of leftNames) {
-        const comp = compareKeys(left[name], right[name]);
+      for (let i = 0; i < leftValues.length; i += 1) {
+        const comp = compareKeys(leftValues[i], rightValues[i]);
         if (Number.isNaN(comp)) {
           return NaN;
         }

--- a/packages/store/src/patterns/patternMatchers.js
+++ b/packages/store/src/patterns/patternMatchers.js
@@ -9,10 +9,10 @@ import {
   hasOwnPropertyOf,
 } from '@endo/marshal';
 import {
-  compareAntiRank,
   compareRank,
   getPassStyleCover,
   intersectRankCovers,
+  recordParts,
   unionRankCovers,
 } from './rankOrder.js';
 import { keyEQ, keyGT, keyGTE, keyLT, keyLTE } from '../keys/compareKeys.js';
@@ -30,8 +30,6 @@ import {
 
 /// <reference types="ses"/>
 
-// const { entries, fromEntries } = Object; // XXX TEMP
-const { ownKeys } = Reflect;
 const { quote: q, details: X } = assert;
 
 /** @type WeakSet<Pattern> */
@@ -293,16 +291,14 @@ const makePatternKit = () => {
             X`${specimen} - Must be a copyRecord to match a copyRecord pattern: ${patt}`,
           );
         }
-        const specNames = harden(ownKeys(specimen).sort(compareAntiRank));
-        const pattNames = harden(ownKeys(patt).sort(compareAntiRank));
+        const [specNames, specValues] = recordParts(specimen);
+        const [pattNames, pattValues] = recordParts(patt);
         if (!keyEQ(specNames, pattNames)) {
           return check(
             false,
             X`Record ${specimen} - Must have same property names as record pattern: ${patt}`,
           );
         }
-        const specValues = harden(specNames.map(name => specimen[name]));
-        const pattValues = harden(pattNames.map(name => patt[name]));
         return checkMatches(specValues, pattValues, check);
       }
       case 'tagged': {

--- a/packages/store/test/test-encodeKey.js
+++ b/packages/store/test/test-encodeKey.js
@@ -3,7 +3,7 @@
 /* eslint-disable no-bitwise */
 
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
-import { isKey, isScalarKey } from '../src/keys/checkKey.js';
+import { isKey } from '../src/keys/checkKey.js';
 import { compareKeys, keyEQ } from '../src/keys/compareKeys.js';
 import { makeEncodeKey, makeDecodeKey } from '../src/patterns/encodeKey.js';
 import { compareRank, makeComparatorKit } from '../src/patterns/rankOrder.js';
@@ -97,18 +97,14 @@ const orderInvariants = (t, x, y) => {
       t.is(keyComp, fullComp);
       t.is(keyComp, rankComp);
     }
-    if (isScalarKey(x) && isScalarKey(y)) {
-      // TODO We're working towards making all keys encodable, but
-      // currently only scalars are.
-      const ex = encodeKey(x);
-      const ey = encodeKey(y);
-      const encComp = compareRank(ex, ey);
-      t.is(encComp, fullComp);
-      const dx = decodeKey(ex);
-      const dy = decodeKey(ey);
-      t.assert(keyEQ(x, dx));
-      t.assert(keyEQ(y, dy));
-    }
+    const ex = encodeKey(x);
+    const ey = encodeKey(y);
+    const encComp = compareRank(ex, ey);
+    const dx = decodeKey(ex);
+    const dy = decodeKey(ey);
+    t.assert(keyEQ(x, dx));
+    t.assert(keyEQ(y, dy));
+    t.is(encComp, fullComp);
   }
 };
 

--- a/packages/store/test/test-rankOrder.js
+++ b/packages/store/test/test-rankOrder.js
@@ -120,23 +120,6 @@ const sortedSample = harden([
   // Lexicographic arrays. Shorter beats longer.
   // Lexicographic records by reverse sorted property name, then by values
   // in that order.
-
-  // XXX The arrays in the sample data sort as follows, but this is not the sort
-  // order that appeared in the original version of this test as it existed
-  // prior to merging with Mark's (@erights) earlier POC implementation of
-  // stores.  A key difference between that version and this one is the switch
-  // from using values themselves as covers directly to using the key-string
-  // encoding of those values.  However, that formulation currently only works
-  // for scalar keys and the code that deals with non-scalars was not touched by
-  // these changes, so the rank sort order of non-scalar values ought not to be
-  // different -- but it is.  In f2f discussion we concluded that it's possible
-  // other work he did in the meantime caused this change and the divergence in
-  // behavior simply went undetected because this test had been disabled at time
-  // on account of it not yet having been updated for the new rank order
-  // encoding (which it now has been).  This comment is here as a flag and
-  // reminder for Mark, so that when he gets to it he can investigage how
-  // non-scalars are now being rank sorted and possibly debug or possibly
-  // pronounce the current order correct.
   [],
   [5],
   [5, { bar: 5 }],


### PR DESCRIPTION
`encodeKey` now works for composite keys (copyArray, copyRecord, tagged) and therefore for all key types (copySet, copyBag, copyMap). It produces strings that are sort order preserving. See `orderInvariants` for a number of invariants between these orders that are passing, at least on the current test data.