### PR TITLE
fix: Encode Passables, not just keys

### DIFF
--- a/packages/SwingSet/src/liveslots/collectionManager.js
+++ b/packages/SwingSet/src/liveslots/collectionManager.js
@@ -8,8 +8,8 @@ import {
   compareRank,
   M,
   zeroPad,
-  makeEncodeKey,
-  makeDecodeKey,
+  makeEncodePassable,
+  makeDecodePassable,
 } from '@agoric/store';
 import { Far, passStyleOf } from '@endo/marshal';
 import { parseVatSlot } from '../lib/parseVatSlots.js';
@@ -152,12 +152,12 @@ export function makeCollectionManager(
       return `r${ordinalTag}:${convertValToSlot(remotable)}`;
     };
 
-    const encodeKey = makeEncodeKey(encodeRemotable);
+    const encodePassable = makeEncodePassable({ encodeRemotable });
 
     const decodeRemotable = encodedKey =>
       convertSlotToVal(encodedKey.substring(BIGINT_TAG_LEN + 2));
 
-    const decodeKey = makeDecodeKey(decodeRemotable);
+    const decodePassable = makeDecodePassable({ decodeRemotable });
 
     function generateOrdinal(remotable) {
       const nextOrdinal = Number.parseInt(
@@ -180,12 +180,12 @@ export function makeCollectionManager(
     }
 
     function keyToDBKey(key) {
-      return prefix(encodeKey(key));
+      return prefix(encodePassable(key));
     }
 
     function dbKeyToKey(dbKey) {
       const dbEntryKey = dbKey.substring(dbKeyPrefix.length);
-      return decodeKey(dbEntryKey);
+      return decodePassable(dbEntryKey);
     }
 
     function has(key) {
@@ -330,7 +330,7 @@ export function makeCollectionManager(
       assert(needKeys || needValues);
       assertKeyPattern(keyPatt);
       assertPattern(valuePatt);
-      const [coverStart, coverEnd] = getRankCover(keyPatt, encodeKey);
+      const [coverStart, coverEnd] = getRankCover(keyPatt, encodePassable);
       let priorDBKey = '';
       const start = prefix(coverStart);
       const end = prefix(coverEnd);

--- a/packages/SwingSet/src/liveslots/collectionManager.js
+++ b/packages/SwingSet/src/liveslots/collectionManager.js
@@ -152,12 +152,22 @@ export function makeCollectionManager(
       return `r${ordinalTag}:${convertValToSlot(remotable)}`;
     };
 
-    const encodePassable = makeEncodePassable({ encodeRemotable });
+    // `makeEncodePassable` has three named options:
+    // `encodeRemotable`, `encodeError`, and `encodePromise`.
+    // Those which are omitted default to a function that always throws.
+    // So by omitting `encodeError` and `encodePromise`, we know that
+    // the resulting function will encode only `Key` arguments.
+    const encodeKey = makeEncodePassable({ encodeRemotable });
 
     const decodeRemotable = encodedKey =>
       convertSlotToVal(encodedKey.substring(BIGINT_TAG_LEN + 2));
 
-    const decodePassable = makeDecodePassable({ decodeRemotable });
+    // `makeDecodePassable` has three named options:
+    // `decodeRemotable`, `decodeError`, and `decodePromise`.
+    // Those which are omitted default to a function that always throws.
+    // So by omitting `decodeError` and `decodePromise`, we know that
+    // the resulting function will decode only to `Key` results.
+    const decodeKey = makeDecodePassable({ decodeRemotable });
 
     function generateOrdinal(remotable) {
       const nextOrdinal = Number.parseInt(
@@ -180,12 +190,12 @@ export function makeCollectionManager(
     }
 
     function keyToDBKey(key) {
-      return prefix(encodePassable(key));
+      return prefix(encodeKey(key));
     }
 
     function dbKeyToKey(dbKey) {
       const dbEntryKey = dbKey.substring(dbKeyPrefix.length);
-      return decodePassable(dbEntryKey);
+      return decodeKey(dbEntryKey);
     }
 
     function has(key) {
@@ -330,7 +340,7 @@ export function makeCollectionManager(
       assert(needKeys || needValues);
       assertKeyPattern(keyPatt);
       assertPattern(valuePatt);
-      const [coverStart, coverEnd] = getRankCover(keyPatt, encodePassable);
+      const [coverStart, coverEnd] = getRankCover(keyPatt, encodeKey);
       let priorDBKey = '';
       const start = prefix(coverStart);
       const end = prefix(coverEnd);

--- a/packages/run-protocol/src/vaultFactory/storeUtils.js
+++ b/packages/run-protocol/src/vaultFactory/storeUtils.js
@@ -6,15 +6,15 @@
 
 // XXX importing these that are declared to be used only for testing
 // until @agoric/store supports composite keys
-import { makeDecodeKey, makeEncodeKey } from '@agoric/store';
+import { makeDecodePassable, makeEncodePassable } from '@agoric/store';
 
 /** @typedef {[normalizedCollateralization: number, vaultId: VaultId]} CompositeKey */
 
 /**
  * @param {number} n
  */
-const numberToDBEntryKey = makeEncodeKey(/** @type {any} */ (null));
-const dbEntryKeyToNumber = makeDecodeKey(/** @type {any} */ (null));
+const numberToDBEntryKey = makeEncodePassable();
+const dbEntryKeyToNumber = makeDecodePassable();
 
 /**
  * Overcollateralized are greater than one.

--- a/packages/store/src/index.js
+++ b/packages/store/src/index.js
@@ -56,7 +56,11 @@ export {
   fit,
 } from './patterns/patternMatchers.js';
 export { compareRank, isRankSorted, sortByRank } from './patterns/rankOrder.js';
-export { makeDecodeKey, makeEncodeKey, zeroPad } from './patterns/encodeKey.js';
+export {
+  makeDecodePassable,
+  makeEncodePassable,
+  zeroPad,
+} from './patterns/encodePassable.js';
 
 export { makeScalarWeakSetStore } from './stores/scalarWeakSetStore.js';
 export { makeScalarSetStore } from './stores/scalarSetStore.js';

--- a/packages/store/src/patterns/patternMatchers.js
+++ b/packages/store/src/patterns/patternMatchers.js
@@ -383,9 +383,9 @@ const makePatternKit = () => {
   // /////////////////////// getRankCover //////////////////////////////////////
 
   /** @type {GetRankCover} */
-  const getRankCover = (patt, encodeKey) => {
+  const getRankCover = (patt, encodePassable) => {
     if (isKey(patt)) {
-      const encoded = encodeKey(patt);
+      const encoded = encodePassable(patt);
       if (encoded !== undefined) {
         return [encoded, `${encoded}~`];
       }
@@ -397,7 +397,7 @@ const makePatternKit = () => {
         // strings. In the meantime, fall through to the default which
         // returns a cover that covers all copyArrays.
         //
-        // const rankCovers = patt.map(p => getRankCover(p, encodeKey));
+        // const rankCovers = patt.map(p => getRankCover(p, encodePassable));
         // return harden([
         //   rankCovers.map(([left, _right]) => left),
         //   rankCovers.map(([_left, right]) => right),
@@ -425,7 +425,7 @@ const makePatternKit = () => {
         if (matchHelper) {
           // Buried here is the important case, where we process
           // the various patternNodes
-          return matchHelper.getRankCover(patt.payload, encodeKey);
+          return matchHelper.getRankCover(patt.payload, encodePassable);
         }
         switch (tag) {
           case 'copySet': {
@@ -471,7 +471,7 @@ const makePatternKit = () => {
             // // this bug.
             // const [leftPayloadLimit, rightPayloadLimit] = getRankCover(
             //   patt.payload,
-            //   encodeKey,
+            //   encodePassable,
             // );
             // return harden([
             //   makeTagged('copyMap', leftPayloadLimit),
@@ -504,7 +504,7 @@ const makePatternKit = () => {
         X`Payload must be undefined: ${matcherPayload}`,
       ),
 
-    getRankCover: (_matchPayload, _encodeKey) => ['', '{'],
+    getRankCover: (_matchPayload, _encodePassable) => ['', '{'],
 
     checkKeyPattern: (_matcherPayload, _check = x => x) => true,
   });
@@ -525,10 +525,10 @@ const makePatternKit = () => {
       );
     },
 
-    getRankCover: (patts, encodeKey) =>
+    getRankCover: (patts, encodePassable) =>
       intersectRankCovers(
         compareRank,
-        patts.map(p => getRankCover(p, encodeKey)),
+        patts.map(p => getRankCover(p, encodePassable)),
       ),
 
     checkKeyPattern: (patts, check = x => x) => {
@@ -554,10 +554,10 @@ const makePatternKit = () => {
 
     checkIsMatcherPayload: matchAndHelper.checkIsMatcherPayload,
 
-    getRankCover: (patts, encodeKey) =>
+    getRankCover: (patts, encodePassable) =>
       unionRankCovers(
         compareRank,
-        patts.map(p => getRankCover(p, encodeKey)),
+        patts.map(p => getRankCover(p, encodePassable)),
       ),
 
     checkKeyPattern: (patts, check = x => x) => {
@@ -580,7 +580,7 @@ const makePatternKit = () => {
 
     checkIsMatcherPayload: checkPattern,
 
-    getRankCover: (_patt, _encodeKey) => ['', '{'],
+    getRankCover: (_patt, _encodePassable) => ['', '{'],
 
     checkKeyPattern: (patt, check = x => x) => checkKeyPattern(patt, check),
   });
@@ -592,7 +592,7 @@ const makePatternKit = () => {
 
     checkIsMatcherPayload: matchAnyHelper.checkIsMatcherPayload,
 
-    getRankCover: (_matchPayload, _encodeKey) => ['a', 'z~'],
+    getRankCover: (_matchPayload, _encodePassable) => ['a', 'z~'],
 
     checkKeyPattern: (_matcherPayload, _check = x => x) => true,
   });
@@ -604,7 +604,7 @@ const makePatternKit = () => {
 
     checkIsMatcherPayload: matchAnyHelper.checkIsMatcherPayload,
 
-    getRankCover: (_matchPayload, _encodeKey) => ['a', 'z~'],
+    getRankCover: (_matchPayload, _encodePassable) => ['a', 'z~'],
 
     checkKeyPattern: (_matcherPayload, _check = x => x) => true,
   });
@@ -616,7 +616,7 @@ const makePatternKit = () => {
 
     checkIsMatcherPayload: matchAnyHelper.checkIsMatcherPayload,
 
-    getRankCover: (_matchPayload, _encodeKey) => ['a', 'z~'],
+    getRankCover: (_matchPayload, _encodePassable) => ['a', 'z~'],
 
     checkKeyPattern: (_matcherPayload, _check = x => x) => true,
   });
@@ -641,7 +641,7 @@ const makePatternKit = () => {
         X`A kind name must be a string: ${allegedKeyKind}`,
       ),
 
-    getRankCover: (kind, _encodeKey) => {
+    getRankCover: (kind, _encodePassable) => {
       let style;
       switch (kind) {
         case 'copySet':
@@ -683,13 +683,13 @@ const makePatternKit = () => {
 
     checkIsMatcherPayload: checkKey,
 
-    getRankCover: (rightOperand, encodeKey) => {
+    getRankCover: (rightOperand, encodePassable) => {
       const passStyle = passStyleOf(rightOperand);
       // The prefer-const makes no sense when some of the variables need
       // to be `let`
       // eslint-disable-next-line prefer-const
       let [leftBound, rightBound] = getPassStyleCover(passStyle);
-      const newRightBound = `${encodeKey(rightOperand)}~`;
+      const newRightBound = `${encodePassable(rightOperand)}~`;
       if (newRightBound !== undefined) {
         rightBound = newRightBound;
       }
@@ -726,13 +726,13 @@ const makePatternKit = () => {
 
     checkIsMatcherPayload: checkKey,
 
-    getRankCover: (rightOperand, encodeKey) => {
+    getRankCover: (rightOperand, encodePassable) => {
       const passStyle = passStyleOf(rightOperand);
       // The prefer-const makes no sense when some of the variables need
       // to be `let`
       // eslint-disable-next-line prefer-const
       let [leftBound, rightBound] = getPassStyleCover(passStyle);
-      const newLeftBound = encodeKey(rightOperand);
+      const newLeftBound = encodePassable(rightOperand);
       if (newLeftBound !== undefined) {
         leftBound = newLeftBound;
       }

--- a/packages/store/src/types.js
+++ b/packages/store/src/types.js
@@ -446,7 +446,7 @@
  * @callback KeyToDBKey
  * If this key can be encoded as a DBKey string which sorts correctly,
  * return that string. Else return `undefined`. For example, a scalar-only
- * encodeKey would return `undefined` for all non-scalar keys.
+ * encodePassable would return `undefined` for all non-scalar keys.
  * @param {Passable} key
  * @returns {string=}
  */
@@ -454,7 +454,7 @@
 /**
  * @callback GetRankCover
  * @param {Pattern} pattern
- * @param {KeyToDBKey} encodeKey
+ * @param {KeyToDBKey} encodePassable
  * @returns {RankCover}
  */
 
@@ -587,7 +587,7 @@
  *
  * @property {(
  *   payload: Passable,
- *   encodeKey: KeyToDBKey
+ *   encodePassable: KeyToDBKey
  * ) => RankCover} getRankCover
  * Assumes this is the payload of a CopyTagged with the corresponding
  * matchTag. Return a RankCover to bound from below and above,

--- a/packages/store/test/test-encodePassable.js
+++ b/packages/store/test/test-encodePassable.js
@@ -38,9 +38,9 @@ const decodeRemotable = e => {
 const compareRemotables = (x, y) =>
   compareRank(encodeRemotable(x), encodeRemotable(y));
 
-const encodePassable = makeEncodePassable({ encodeRemotable });
+const encodeKey = makeEncodePassable({ encodeRemotable });
 
-const decodePassable = makeDecodePassable({ decodeRemotable });
+const decodeKey = makeDecodePassable({ decodeRemotable });
 
 const { comparator: compareFull } = makeComparatorKit(compareRemotables);
 
@@ -81,12 +81,12 @@ const goldenPairs = harden([
 
 test('golden round trips', t => {
   for (const [k, e] of goldenPairs) {
-    t.is(encodePassable(k), e, 'does k encode as expected');
-    t.is(decodePassable(e), k, 'does the key round trip through the encoding');
+    t.is(encodeKey(k), e, 'does k encode as expected');
+    t.is(decodeKey(e), k, 'does the key round trip through the encoding');
   }
   // Not round trips
-  t.is(encodePassable(-0), 'f8000000000000000');
-  t.is(decodePassable('f0000000000000000'), NaN);
+  t.is(encodeKey(-0), 'f8000000000000000');
+  t.is(decodeKey('f0000000000000000'), NaN);
 });
 
 const orderInvariants = (t, x, y) => {
@@ -110,11 +110,11 @@ const orderInvariants = (t, x, y) => {
       t.is(keyComp, fullComp);
       t.is(keyComp, rankComp);
     }
-    const ex = encodePassable(x);
-    const ey = encodePassable(y);
+    const ex = encodeKey(x);
+    const ey = encodeKey(y);
     const encComp = compareRank(ex, ey);
-    const dx = decodePassable(ex);
-    const dy = decodePassable(ey);
+    const dx = decodeKey(ex);
+    const dy = decodeKey(ey);
     t.assert(keyEQ(x, dx));
     t.assert(keyEQ(y, dy));
     t.is(encComp, fullComp);
@@ -132,7 +132,7 @@ test('order invariants', t => {
 test('BigInt values round-trip', async t => {
   await fc.assert(
     fc.property(fc.bigInt(), n => {
-      const rt = decodePassable(encodePassable(n));
+      const rt = decodeKey(encodeKey(n));
       return assertionPassed(t.is(rt, n), () => rt === n);
     }),
   );
@@ -141,8 +141,8 @@ test('BigInt values round-trip', async t => {
 test('BigInt encoding comparison corresponds with numeric comparison', async t => {
   await fc.assert(
     fc.property(fc.bigInt(), fc.bigInt(), (a, b) => {
-      const ea = encodePassable(a);
-      const eb = encodePassable(b);
+      const ea = encodeKey(a);
+      const eb = encodeKey(b);
       return (
         assertionPassed(t.is(a < b, ea < eb), () => a < b === ea < eb) &&
         assertionPassed(t.is(a > b, ea > eb), () => a > b === ea > eb)

--- a/packages/store/test/test-encodePassable.js
+++ b/packages/store/test/test-encodePassable.js
@@ -5,7 +5,10 @@ import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import fc from 'fast-check';
 import { isKey } from '../src/keys/checkKey.js';
 import { compareKeys, keyEQ } from '../src/keys/compareKeys.js';
-import { makeEncodeKey, makeDecodeKey } from '../src/patterns/encodeKey.js';
+import {
+  makeEncodePassable,
+  makeDecodePassable,
+} from '../src/patterns/encodePassable.js';
 import { compareRank, makeComparatorKit } from '../src/patterns/rankOrder.js';
 import { assertionPassed } from './test-store.js';
 import { sample } from './test-rankOrder.js';
@@ -35,9 +38,9 @@ const decodeRemotable = e => {
 const compareRemotables = (x, y) =>
   compareRank(encodeRemotable(x), encodeRemotable(y));
 
-const encodeKey = makeEncodeKey(encodeRemotable);
+const encodePassable = makeEncodePassable({ encodeRemotable });
 
-const decodeKey = makeDecodeKey(decodeRemotable);
+const decodePassable = makeDecodePassable({ decodeRemotable });
 
 const { comparator: compareFull } = makeComparatorKit(compareRemotables);
 
@@ -55,6 +58,7 @@ const getNaN = (hexEncoding = '0008000000000000') => {
 
 const NegativeNaN = getNaN('ffffffffffffffff');
 
+/** @type {[Key, string][]} */
 const goldenPairs = harden([
   [1, 'fbff0000000000000'],
   [-1, 'f400fffffffffffff'],
@@ -77,12 +81,12 @@ const goldenPairs = harden([
 
 test('golden round trips', t => {
   for (const [k, e] of goldenPairs) {
-    t.is(encodeKey(k), e, 'does k encode as expected');
-    t.is(decodeKey(e), k, 'does the key round trip through the encoding');
+    t.is(encodePassable(k), e, 'does k encode as expected');
+    t.is(decodePassable(e), k, 'does the key round trip through the encoding');
   }
   // Not round trips
-  t.is(encodeKey(-0), 'f8000000000000000');
-  t.is(decodeKey('f0000000000000000'), NaN);
+  t.is(encodePassable(-0), 'f8000000000000000');
+  t.is(decodePassable('f0000000000000000'), NaN);
 });
 
 const orderInvariants = (t, x, y) => {
@@ -106,11 +110,11 @@ const orderInvariants = (t, x, y) => {
       t.is(keyComp, fullComp);
       t.is(keyComp, rankComp);
     }
-    const ex = encodeKey(x);
-    const ey = encodeKey(y);
+    const ex = encodePassable(x);
+    const ey = encodePassable(y);
     const encComp = compareRank(ex, ey);
-    const dx = decodeKey(ex);
-    const dy = decodeKey(ey);
+    const dx = decodePassable(ex);
+    const dy = decodePassable(ey);
     t.assert(keyEQ(x, dx));
     t.assert(keyEQ(y, dy));
     t.is(encComp, fullComp);
@@ -128,7 +132,7 @@ test('order invariants', t => {
 test('BigInt values round-trip', async t => {
   await fc.assert(
     fc.property(fc.bigInt(), n => {
-      const rt = decodeKey(encodeKey(n));
+      const rt = decodePassable(encodePassable(n));
       return assertionPassed(t.is(rt, n), () => rt === n);
     }),
   );
@@ -137,8 +141,8 @@ test('BigInt values round-trip', async t => {
 test('BigInt encoding comparison corresponds with numeric comparison', async t => {
   await fc.assert(
     fc.property(fc.bigInt(), fc.bigInt(), (a, b) => {
-      const ea = encodeKey(a);
-      const eb = encodeKey(b);
+      const ea = encodePassable(a);
+      const eb = encodePassable(b);
       return (
         assertionPassed(t.is(a < b, ea < eb), () => a < b === ea < eb) &&
         assertionPassed(t.is(a > b, ea > eb), () => a > b === ea > eb)


### PR DESCRIPTION
Generalize encodeKey to encodePassable, so we can apply this encoding to any passable.  We've talked about replacing marshal's JSON-based encoding with a compact binary one, such as syrup. The advantage of this encoding is it preserves sort order. Aside from that, seems comparable to things like syrup.