### PR TITLE
Implement flight recorder as the default slog processor

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -115,6 +115,12 @@ Same as SLOGFILE, but for solo instead of chain.
 
 Lifetime: ?
 
+## SOLO_SLOGSENDER
+
+Same as SLOGSENDER, but for solo instead of chain.
+
+Lifetime: ?
+
 ## SOLO_MAX_DEBUG_LENGTH
 
 Affects: solo
@@ -136,6 +142,21 @@ Description: when nonempty, use the value as an absolute path to which SwingSet
 debug logs should be written.
 
 Lifetime: ?
+
+## SLOGSENDER
+
+Affects: cosmic-swingset
+
+Purpose: intercept the SwingSet LOG file in realtime
+
+Description: when nonempty, use the value as a module specifier.  The module
+will be loaded by `@agoric/telemetry/src/make-slog-sender.js`, via
+`import(moduleSpec)`, and then the exported `makeSlogSender` function creates a
+`slogSender`.  Then, every time a SLOG object is written by SwingSet,
+`slogSender(slogObject)` will be called.
+
+The default is `'@agoric/telemetry/src/flight-recorder.js'`, which writes to an
+mmap'ed circular buffer.
 
 ## SWINGSET_WORKER_TYPE
 

--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -7,6 +7,7 @@ import {
 } from '@agoric/swingset-vat/src/devices/mailbox.js';
 
 import { assert, details as X } from '@agoric/assert';
+import { makeSlogSenderFromModule } from '@agoric/telemetry';
 
 import { launch } from './launch-chain.js';
 import makeBlockManager from './block-manager.js';
@@ -249,7 +250,12 @@ export default async function main(progname, args, { env, homedir, agcc }) {
       ),
     ).pathname;
     const { metricsProvider } = getTelemetryProviders({ console, env });
-    const slogFile = env.SLOGFILE;
+
+    const { SLOGFILE, SLOGSENDER } = env;
+    const slogSender = await makeSlogSenderFromModule(SLOGSENDER, {
+      stateDir: stateDBDir,
+    });
+
     const consensusMode = env.DEBUG === undefined;
     const s = await launch(
       stateDBDir,
@@ -260,7 +266,8 @@ export default async function main(progname, args, { env, homedir, agcc }) {
       argv,
       undefined,
       metricsProvider,
-      slogFile,
+      SLOGFILE,
+      slogSender,
       consensusMode,
     );
     return s;

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -35,7 +35,7 @@ async function buildSwingset(
   hostStorage,
   vatconfig,
   argv,
-  { consensusMode, debugName = undefined, slogCallbacks, slogFile },
+  { consensusMode, debugName = undefined, slogCallbacks, slogFile, slogSender },
 ) {
   const debugPrefix = debugName === undefined ? '' : `${debugName}:`;
   let config = await loadSwingsetConfigFile(vatconfig);
@@ -78,7 +78,12 @@ async function buildSwingset(
   const controller = await makeSwingsetController(
     hostStorage,
     deviceEndowments,
-    { overrideVatManagerOptions: { consensusMode }, slogCallbacks, slogFile },
+    {
+      overrideVatManagerOptions: { consensusMode },
+      slogCallbacks,
+      slogFile,
+      slogSender,
+    },
   );
 
   // We DON'T want to run the kernel yet, only when the application decides
@@ -140,6 +145,7 @@ export async function launch(
   debugName = undefined,
   meterProvider = DEFAULT_METER_PROVIDER,
   slogFile = undefined,
+  slogSender,
   consensusMode = false,
 ) {
   console.info('Launching SwingSet kernel');
@@ -172,6 +178,7 @@ export async function launch(
       debugName,
       slogCallbacks,
       slogFile,
+      slogSender,
       consensusMode,
     },
   );

--- a/packages/cosmic-swingset/src/sim-chain.js
+++ b/packages/cosmic-swingset/src/sim-chain.js
@@ -10,6 +10,8 @@ import {
 
 import anylogger from 'anylogger';
 
+import { makeSlogSenderFromModule } from '@agoric/telemetry';
+
 import { resolve as importMetaResolve } from 'import-meta-resolve';
 import { assert, details as X } from '@agoric/assert';
 import { makeWithQueue } from '@agoric/vats/src/queue.js';
@@ -83,6 +85,12 @@ export async function connectToFakeChain(basedir, GCI, delay, inbound) {
     console,
     env: process.env,
   });
+
+  const { SLOGFILE, SLOGSENDER } = process.env;
+  const slogSender = await makeSlogSenderFromModule(SLOGSENDER, {
+    stateDir: stateDBdir,
+  });
+
   const s = await launch(
     stateDBdir,
     mailboxStorage,
@@ -92,6 +100,8 @@ export async function connectToFakeChain(basedir, GCI, delay, inbound) {
     argv,
     GCI, // debugName
     metricsProvider,
+    SLOGFILE,
+    slogSender,
   );
 
   const { savedHeight, savedActions, savedChainSends } = s;

--- a/packages/deployment/scripts/capture-integration-results.sh
+++ b/packages/deployment/scripts/capture-integration-results.sh
@@ -14,5 +14,6 @@ for node in validator{0,1}; do
   home=/home/ag-chain-cosmos/.ag-chain-cosmos
   "$thisdir/setup.sh" ssh "$node" cat "$home/config/genesis.json" > "$RESULTSDIR/$node-genesis.json" || true
   "$thisdir/setup.sh" ssh "$node" cat "$home/data/chain.slog" > "$RESULTSDIR/$node.slog" || true
+  "$thisdir/setup.sh" ssh "$node" cat "$home/data/ag-cosmos-chain-state/flight-recorder.bin" > "$RESULTSDIR/$node-flight-recorder.bin" || true
   "$thisdir/setup.sh" ssh "$node" cat "$home/data/kvstore.trace" > "$RESULTSDIR/$node-kvstore.trace" || true
 done

--- a/packages/solo/package.json
+++ b/packages/solo/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@agoric/access-token": "^0.4.16",
     "@agoric/assert": "^0.3.15",
+    "@agoric/telemetry": "^0.1.0",
     "@endo/captp": "^1.10.12",
     "@agoric/cosmic-swingset": "^0.34.4",
     "@agoric/eventual-send": "^0.14.0",

--- a/packages/solo/src/start.js
+++ b/packages/solo/src/start.js
@@ -15,6 +15,7 @@ import anylogger from 'anylogger';
 // import djson from 'deterministic-json';
 
 import { assert, details as X } from '@agoric/assert';
+import { makeSlogSenderFromModule } from '@agoric/telemetry';
 import {
   loadSwingsetConfigFile,
   buildCommand,
@@ -156,11 +157,14 @@ const buildSwingset = async (
     }
     await initializeSwingset(config, argv, hostStorage);
   }
-  const slogFile = process.env.SOLO_SLOGFILE;
+  const { SOLO_SLOGFILE: slogFile, SOLO_SLOGSENDER } = process.env;
+  const slogSender = await makeSlogSenderFromModule(SOLO_SLOGSENDER, {
+    stateDir: kernelStateDBDir,
+  });
   const controller = await makeSwingsetController(
     hostStorage,
     deviceEndowments,
-    { slogFile },
+    { slogFile, slogSender },
   );
 
   async function saveState() {

--- a/packages/telemetry/bin/frcat
+++ b/packages/telemetry/bin/frcat
@@ -1,0 +1,1 @@
+../src/frcat-entrypoint.js

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -20,13 +20,16 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@opentelemetry/exporter-prometheus": "^0.16.0",
-    "@opentelemetry/metrics": "^0.16.0"
+    "@opentelemetry/metrics": "^0.16.0",
+    "bufferfromfile": "agoric-labs/BufferFromFile#Agoric-built"
   },
   "devDependencies": {
     "@endo/lockdown": "^0.1.5",
     "@endo/ses-ava": "^0.2.17",
+    "@endo/init": "^0.5.33",
     "ava": "^3.12.1",
-    "c8": "^7.7.2"
+    "c8": "^7.7.2",
+    "tmp": "^0.2.1"
   },
   "eslintConfig": {
     "extends": [

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -15,10 +15,14 @@
     "lint:types": "tsc -p jsconfig.json",
     "lint:eslint": "eslint '**/*.js'"
   },
+  "bin": {
+    "frcat": "./src/frcat-entrypoint.js"
+  },
   "keywords": [],
   "author": "Agoric",
   "license": "Apache-2.0",
   "dependencies": {
+    "@endo/init": "^0.5.33",
     "@opentelemetry/exporter-prometheus": "^0.16.0",
     "@opentelemetry/metrics": "^0.16.0",
     "bufferfromfile": "agoric-labs/BufferFromFile#Agoric-built"
@@ -26,7 +30,6 @@
   "devDependencies": {
     "@endo/lockdown": "^0.1.5",
     "@endo/ses-ava": "^0.2.17",
-    "@endo/init": "^0.5.33",
     "ava": "^3.12.1",
     "c8": "^7.7.2",
     "tmp": "^0.2.1"

--- a/packages/telemetry/src/flight-recorder.js
+++ b/packages/telemetry/src/flight-recorder.js
@@ -1,0 +1,205 @@
+// @ts-check
+/* global BigUint64Array */
+/// <reference types="ses" />
+
+// https://github.com/Agoric/agoric-sdk/issues/3742#issuecomment-1028451575
+// I'd mmap() a 100MB file, reserve a few bytes for offsets, then use the rest
+// as a circular buffer to hold length-prefixed records. The agd process would
+// keep writing new events into the RAM window and updating the start/end
+// pointers, with some sequencing to make sure the record gets written before
+// the pointer is updated. Then, no mattter how abruptly the process is
+// terminated, as long as the host computer itself is still running, the on-disk
+// file would contain the most recent state, and anybody who reads the file will
+// get the most recent state. The host kernel (linux) is under no obligation to
+// flush it to disk any particular time, but knows when reads happen, so there's
+// no coherency problem, and the speed is unaffected by disk write speeds.
+
+import BufferFromFile from 'bufferfromfile';
+import fs from 'fs';
+import path from 'path';
+
+const { details: X } = assert;
+
+export const DEFAULT_CIRCULAR_BUFFER_SIZE = 100 * 1024 * 1024;
+export const DEFAULT_CIRCULAR_BUFFER_FILE = 'flight-recorder.bin';
+export const SLOG_MAGIC = 0x21474f4c532d4741n; // 'AG-SLOG!'
+
+const I_MAGIC = 0;
+const I_ARENA_SIZE = 1;
+const I_CIRC_START = 2;
+const I_CIRC_END = 3;
+const HEADER_LENGTH = 4;
+
+export const makeMemoryMappedCircularBuffer = ({
+  circularBufferSize = DEFAULT_CIRCULAR_BUFFER_SIZE,
+  stateDir = '/tmp',
+  circularBufferFile,
+}) => {
+  const bufferFile =
+    circularBufferFile || `${stateDir}/${DEFAULT_CIRCULAR_BUFFER_FILE}`;
+  // console.log({ circularBufferFile, bufferFile });
+
+  // If the file doesn't exist, or is not large enough, create it.
+  let stbuf;
+  try {
+    stbuf = fs.statSync(bufferFile);
+  } catch (e) {
+    if (e.code !== 'ENOENT') {
+      throw e;
+    }
+  }
+  const arenaSize = BigInt(
+    circularBufferSize - HEADER_LENGTH * BigUint64Array.BYTES_PER_ELEMENT,
+  );
+  if (!stbuf || stbuf.size < BigUint64Array.BYTES_PER_ELEMENT * 3) {
+    // Write the header.
+    const header = new Array(HEADER_LENGTH).fill(0n);
+    header[I_MAGIC] = SLOG_MAGIC;
+    header[I_ARENA_SIZE] = arenaSize;
+    fs.mkdirSync(path.dirname(bufferFile), { recursive: true });
+    fs.writeFileSync(bufferFile, BigUint64Array.from(header));
+  }
+  if (!stbuf || stbuf.size < circularBufferSize) {
+    fs.truncateSync(bufferFile, circularBufferSize);
+  }
+
+  /** @type {Uint8Array} */
+  const fileBuf = BufferFromFile(bufferFile).Uint8Array();
+  const header = new BigUint64Array(fileBuf.buffer, 0, HEADER_LENGTH);
+
+  assert.equal(
+    SLOG_MAGIC,
+    header[I_MAGIC],
+    X`${bufferFile} is not a slog buffer; wanted magic ${SLOG_MAGIC}, got ${header[I_MAGIC]}`,
+  );
+  assert.equal(
+    arenaSize,
+    header[I_ARENA_SIZE],
+    X`${bufferFile} arena size mismatch; wanted ${arenaSize}, got ${header[I_ARENA_SIZE]}`,
+  );
+  const arena = new Uint8Array(
+    fileBuf.buffer,
+    header.byteLength,
+    Number(arenaSize),
+  );
+
+  /**
+   * @param {Uint8Array} data
+   * @param {number} [offset]
+   */
+  const readCircBuf = (data, offset = 0) => {
+    assert(
+      offset + data.byteLength <= arenaSize,
+      X`Reading past end of circular buffer`,
+    );
+
+    // Read the data to the end of the arena.
+    let firstReadLength = data.byteLength;
+    const circStart = Number(header[I_CIRC_START]);
+    const readStart = (circStart + offset) % Number(arenaSize);
+    if (readStart > header[I_CIRC_END]) {
+      // The data is wrapped around the end of the arena, like BBB---AAA
+      firstReadLength = Math.min(
+        firstReadLength,
+        Number(arenaSize) - readStart,
+      );
+    }
+    data.set(arena.subarray(readStart, readStart + firstReadLength));
+    if (firstReadLength < data.byteLength) {
+      data.set(
+        arena.subarray(0, data.byteLength - firstReadLength),
+        firstReadLength,
+      );
+    }
+    return data;
+  };
+
+  /** @param {Uint8Array} data */
+  const writeCircBuf = data => {
+    if (BigUint64Array.BYTES_PER_ELEMENT + data.byteLength > arena.byteLength) {
+      // The data is too big to fit in the arena, so skip it.
+      const tooBigRecord = JSON.stringify({
+        type: 'slog-record-too-big',
+        size: data.byteLength,
+      });
+      data = new TextEncoder().encode(tooBigRecord);
+    }
+
+    const record = new Uint8Array(
+      BigUint64Array.BYTES_PER_ELEMENT + data.byteLength,
+    );
+    const lengthPrefix = new BigUint64Array(record.buffer, 0, 1);
+    lengthPrefix[0] = BigInt(data.byteLength);
+    record.set(data, BigUint64Array.BYTES_PER_ELEMENT);
+
+    // Check if we need to wrap around.
+    /** @type {bigint} */
+    let capacity;
+    if (header[I_CIRC_START] <= header[I_CIRC_END]) {
+      // ---AAAABBBB----
+      capacity =
+        header[I_ARENA_SIZE] - header[I_CIRC_END] + header[I_CIRC_START];
+    } else {
+      // BBB---AAAA
+      capacity = header[I_CIRC_START] - header[I_CIRC_END];
+    }
+
+    let overlap = BigInt(record.byteLength) - capacity;
+    while (overlap > 0n) {
+      // Advance the start pointer.
+      const startRecordLength = new BigUint64Array(1);
+      readCircBuf(new Uint8Array(startRecordLength.buffer));
+
+      const totalRecordLength =
+        BigInt(startRecordLength.byteLength) + // size of the length field
+        startRecordLength[0]; // size of the record
+
+      header[I_CIRC_START] =
+        (header[I_CIRC_START] + totalRecordLength) % header[I_ARENA_SIZE];
+      overlap -= totalRecordLength;
+    }
+
+    // Append the record.
+    let firstWriteLength = record.byteLength;
+    if (header[I_CIRC_START] < header[I_CIRC_END]) {
+      // May need to wrap, it's ---AAAABBBB---
+      firstWriteLength = Math.min(
+        firstWriteLength,
+        Number(header[I_ARENA_SIZE] - header[I_CIRC_END]),
+      );
+    }
+
+    const circEnd = Number(header[I_CIRC_END]);
+    arena.set(record.subarray(0, firstWriteLength), circEnd);
+    if (firstWriteLength < record.byteLength) {
+      // Write to the beginning of the arena.
+      arena.set(record.subarray(firstWriteLength, record.byteLength), 0);
+    }
+    header[I_CIRC_END] =
+      (header[I_CIRC_END] + BigInt(record.byteLength)) % header[I_ARENA_SIZE];
+  };
+
+  const writeJSON = obj => {
+    const text = JSON.stringify(obj, (key, value) => {
+      if (typeof value === 'bigint') {
+        return Number(value);
+      }
+      if (key === 'endoZipBase64') {
+        // Abridge the source bundle, since it's pretty huge.
+        return `[${value.length} characters...]`;
+      }
+      return value;
+    });
+    // Prepend a newline so that the file can be more easily manipulated.
+    const data = new TextEncoder().encode(`\n${text}`);
+    // console.log('have obj', obj);
+    writeCircBuf(data);
+  };
+
+  return { readCircBuf, writeCircBuf, writeJSON };
+};
+
+export const makeSlogSender = opts => {
+  const { writeJSON } = makeMemoryMappedCircularBuffer(opts);
+  return writeJSON;
+};

--- a/packages/telemetry/src/frcat-entrypoint.js
+++ b/packages/telemetry/src/frcat-entrypoint.js
@@ -1,6 +1,7 @@
 #! /usr/bin/env node
 /* global process, BigUint64Array */
 // frcat - print out the contents of a flight recorder
+// NOTE: this only works on inactive recorder files where the writer has terminated
 
 import '@endo/init';
 
@@ -14,7 +15,7 @@ const main = async () => {
 
   for await (const file of files) {
     const { readCircBuf } = await makeMemoryMappedCircularBuffer({
-      circularBufferFile: file,
+      circularBufferFilename: file,
       circularBufferSize: null,
     });
 
@@ -25,7 +26,7 @@ const main = async () => {
       if (done) {
         break;
       }
-      offset += 8;
+      offset += lenBuf.byteLength;
       const dv = new DataView(lenBuf.buffer);
       const len = Number(dv.getBigUint64(0));
 

--- a/packages/telemetry/src/frcat-entrypoint.js
+++ b/packages/telemetry/src/frcat-entrypoint.js
@@ -13,20 +13,21 @@ const main = async () => {
   }
 
   for await (const file of files) {
-    const { readCircBuf } = makeMemoryMappedCircularBuffer({
+    const { readCircBuf } = await makeMemoryMappedCircularBuffer({
       circularBufferFile: file,
       circularBufferSize: null,
     });
 
     let offset = 0;
     for (;;) {
-      const lenBuf = new BigUint64Array(1);
-      const { done } = readCircBuf(new Uint8Array(lenBuf.buffer), offset);
+      const lenBuf = new Uint8Array(BigUint64Array.BYTES_PER_ELEMENT);
+      const { done } = readCircBuf(lenBuf, offset);
       if (done) {
         break;
       }
       offset += 8;
-      const len = Number(lenBuf[0]);
+      const dv = new DataView(lenBuf.buffer);
+      const len = Number(dv.getBigUint64(0));
 
       const { done: done2, value: buf } = readCircBuf(
         new Uint8Array(len),

--- a/packages/telemetry/src/frcat-entrypoint.js
+++ b/packages/telemetry/src/frcat-entrypoint.js
@@ -1,0 +1,60 @@
+#! /usr/bin/env node
+/* global process, BigUint64Array */
+// frcat - print out the contents of a flight recorder
+
+import '@endo/init';
+
+import { makeMemoryMappedCircularBuffer } from './flight-recorder.js';
+
+const main = async () => {
+  const files = process.argv.slice(2);
+  if (files.length === 0) {
+    throw Error('no flight-recorder.bin files specified');
+  }
+
+  for await (const file of files) {
+    const { readCircBuf } = makeMemoryMappedCircularBuffer({
+      circularBufferFile: file,
+      circularBufferSize: null,
+    });
+
+    let offset = 0;
+    for (;;) {
+      const lenBuf = new BigUint64Array(1);
+      const { done } = readCircBuf(new Uint8Array(lenBuf.buffer), offset);
+      if (done) {
+        break;
+      }
+      offset += 8;
+      const len = Number(lenBuf[0]);
+
+      const { done: done2, value: buf } = readCircBuf(
+        new Uint8Array(len),
+        offset,
+      );
+      if (done2) {
+        break;
+      }
+      offset += len;
+      const bufStr = new TextDecoder().decode(buf);
+      if (bufStr[0] === '\n') {
+        process.stdout.write(bufStr.slice(1));
+      } else {
+        process.stdout.write(bufStr);
+      }
+      if (process.stdout.write('\n')) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+
+      // If the buffer is full, wait for stdout to drain.
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise(resolve => process.stdout.once('drain', resolve));
+    }
+  }
+};
+
+main().catch(err => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/packages/telemetry/src/index.js
+++ b/packages/telemetry/src/index.js
@@ -3,6 +3,8 @@
 import { MeterProvider } from '@opentelemetry/metrics';
 import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
 
+export * from './make-slog-sender.js';
+
 /**
  * @typedef {Object} Powers
  * @property {{ warn: Console['warn'] }} console

--- a/packages/telemetry/src/make-slog-sender.js
+++ b/packages/telemetry/src/make-slog-sender.js
@@ -1,0 +1,26 @@
+// @ts-check
+import path from 'path';
+
+export const DEFAULT_SLOG_SENDER_MODULE =
+  '@agoric/telemetry/src/flight-recorder.js';
+
+export const makeSlogSenderFromModule = async (
+  slogSenderModule = DEFAULT_SLOG_SENDER_MODULE,
+  makerOpts = {},
+) => {
+  if (!slogSenderModule) {
+    return undefined;
+  }
+
+  if (slogSenderModule.startsWith('.')) {
+    // Resolve relative to the current working directory.
+    slogSenderModule = path.resolve(slogSenderModule);
+  }
+
+  console.warn(`Loading makeSlogSender from ${slogSenderModule}`);
+  const { makeSlogSender: maker } = await import(slogSenderModule);
+  if (typeof maker !== 'function') {
+    throw Error(`${slogSenderModule} did not export a makeSlogSender function`);
+  }
+  return maker(makerOpts);
+};

--- a/packages/telemetry/test/prepare-test-env-ava.js
+++ b/packages/telemetry/test/prepare-test-env-ava.js
@@ -1,6 +1,5 @@
-/* eslint-disable import/no-extraneous-dependencies */
-import '@endo/init/pre-bundle-source.js';
-import '@endo/lockdown/commit-debug.js';
+// @ts-check
+import '@endo/init';
 
 import { wrapTest } from '@endo/ses-ava';
 import rawTest from 'ava';

--- a/packages/telemetry/test/test-flight-recorder.js
+++ b/packages/telemetry/test/test-flight-recorder.js
@@ -14,14 +14,15 @@ test('flight-recorder sanity', async t => {
     });
   slogSender({ type: 'start' });
 
-  const len0 = new BigUint64Array(1);
-  const { done: done0 } = readCircBuf(new Uint8Array(len0.buffer));
+  const len0 = new Uint8Array(BigUint64Array.BYTES_PER_ELEMENT);
+  const { done: done0 } = readCircBuf(len0);
   t.false(done0, 'readCircBuf should not be done');
-  const buf0 = new Uint8Array(Number(len0[0]));
+  const dv0 = new DataView(len0.buffer);
+  const buf0 = new Uint8Array(Number(dv0.getBigUint64(0)));
   const { done: done0b } = readCircBuf(buf0, len0.byteLength);
   t.false(done0b, 'readCircBuf should not be done');
   const buf0Str = new TextDecoder().decode(buf0);
-  t.is(buf0Str, `\n{"type":"start"}`);
+  t.is(buf0Str, `\n{"type":"start"}`, `start compare failed`);
 
   const last = 500;
   for (let i = 0; i < last; i += 1) {
@@ -29,20 +30,26 @@ test('flight-recorder sanity', async t => {
   }
 
   let offset = 0;
-  const len1 = new BigUint64Array(1);
+  const len1 = new Uint8Array(BigUint64Array.BYTES_PER_ELEMENT);
   for (let i = 490; i < last; i += 1) {
-    const { done: done1 } = readCircBuf(new Uint8Array(len1.buffer), offset);
+    const { done: done1 } = readCircBuf(len1, offset);
     offset += len1.byteLength;
     t.false(done1, `readCircBuf ${i} should not be done`);
-    const buf1 = new Uint8Array(Number(len1[0]));
+    const dv1 = new DataView(len1.buffer);
+    const buf1 = new Uint8Array(Number(dv1.getBigUint64(0)));
     const { done: done1b } = readCircBuf(buf1, offset);
     offset += buf1.byteLength;
     t.false(done1b, `readCircBuf ${i} should not be done`);
     const buf1Str = new TextDecoder().decode(buf1);
-    t.is(buf1Str, `\n{"type":"iteration","iteration":${i}}`);
+    t.is(
+      buf1Str,
+      `\n{"type":"iteration","iteration":${i}}`,
+      `iteration ${i} compare failed`,
+    );
   }
 
-  const { done: done2 } = readCircBuf(new Uint8Array(len1.buffer), offset);
+  const { done: done2 } = readCircBuf(len1, offset);
   t.assert(done2, `readCircBuf ${last} should be done`);
-  removeCallback();
+  console.log({ tmpFile });
+  // removeCallback();
 });

--- a/packages/telemetry/test/test-flight-recorder.js
+++ b/packages/telemetry/test/test-flight-recorder.js
@@ -10,7 +10,7 @@ test('flight-recorder sanity', async t => {
   const { writeJSON: slogSender, readCircBuf } =
     await makeMemoryMappedCircularBuffer({
       circularBufferSize: 512,
-      circularBufferFile: tmpFile,
+      circularBufferFilename: tmpFile,
     });
   slogSender({ type: 'start' });
 
@@ -50,6 +50,6 @@ test('flight-recorder sanity', async t => {
 
   const { done: done2 } = readCircBuf(len1, offset);
   t.assert(done2, `readCircBuf ${last} should be done`);
-  console.log({ tmpFile });
+  // console.log({ tmpFile });
   removeCallback();
 });

--- a/packages/telemetry/test/test-flight-recorder.js
+++ b/packages/telemetry/test/test-flight-recorder.js
@@ -5,14 +5,13 @@ import { test } from './prepare-test-env-ava.js';
 
 import { makeMemoryMappedCircularBuffer } from '../src/flight-recorder.js';
 
-test('flight-recorder sanity', t => {
+test('flight-recorder sanity', async t => {
   const { name: tmpFile, removeCallback } = tmp.fileSync();
-  const { writeJSON: slogSender, readCircBuf } = makeMemoryMappedCircularBuffer(
-    {
+  const { writeJSON: slogSender, readCircBuf } =
+    await makeMemoryMappedCircularBuffer({
       circularBufferSize: 512,
       circularBufferFile: tmpFile,
-    },
-  );
+    });
   slogSender({ type: 'start' });
 
   const len0 = new BigUint64Array(1);

--- a/packages/telemetry/test/test-flight-recorder.js
+++ b/packages/telemetry/test/test-flight-recorder.js
@@ -1,0 +1,32 @@
+// @ts-check
+/* global BigUint64Array */
+import tmp from 'tmp';
+import { test } from './prepare-test-env-ava.js';
+
+import { makeMemoryMappedCircularBuffer } from '../src/flight-recorder.js';
+
+test('flight-recorder sanity', t => {
+  const { name: tmpFile } = tmp.fileSync();
+  console.log(tmpFile);
+  const { writeJSON: slogSender, readCircBuf } = makeMemoryMappedCircularBuffer(
+    {
+      circularBufferSize: 512,
+      circularBufferFile: tmpFile,
+    },
+  );
+  slogSender({ type: 'start' });
+
+  const len0 = new BigUint64Array(readCircBuf(new Uint8Array(8)).buffer);
+  const buf0 = readCircBuf(new Uint8Array(Number(len0[0])), 8);
+  const buf0Str = new TextDecoder().decode(buf0);
+  t.is(buf0Str, `\n{"type":"start"}`);
+
+  for (let i = 0; i < 500; i += 1) {
+    slogSender({ type: 'iteration', iteration: i });
+  }
+
+  const len1 = new BigUint64Array(readCircBuf(new Uint8Array(8)).buffer);
+  const buf1 = readCircBuf(new Uint8Array(Number(len1[0])), 8);
+  const buf1Str = new TextDecoder().decode(buf1);
+  t.is(buf1Str, `\n{"type":"iteration","iteration":490}`);
+});

--- a/packages/telemetry/test/test-flight-recorder.js
+++ b/packages/telemetry/test/test-flight-recorder.js
@@ -51,5 +51,5 @@ test('flight-recorder sanity', async t => {
   const { done: done2 } = readCircBuf(len1, offset);
   t.assert(done2, `readCircBuf ${last} should be done`);
   console.log({ tmpFile });
-  // removeCallback();
+  removeCallback();
 });

--- a/packages/telemetry/test/test-flight-recorder.js
+++ b/packages/telemetry/test/test-flight-recorder.js
@@ -6,8 +6,7 @@ import { test } from './prepare-test-env-ava.js';
 import { makeMemoryMappedCircularBuffer } from '../src/flight-recorder.js';
 
 test('flight-recorder sanity', t => {
-  const { name: tmpFile } = tmp.fileSync();
-  console.log(tmpFile);
+  const { name: tmpFile, removeCallback } = tmp.fileSync();
   const { writeJSON: slogSender, readCircBuf } = makeMemoryMappedCircularBuffer(
     {
       circularBufferSize: 512,
@@ -16,8 +15,12 @@ test('flight-recorder sanity', t => {
   );
   slogSender({ type: 'start' });
 
-  const len0 = new BigUint64Array(readCircBuf(new Uint8Array(8)).buffer);
-  const buf0 = readCircBuf(new Uint8Array(Number(len0[0])), 8);
+  const len0 = new BigUint64Array(1);
+  const { done: done0 } = readCircBuf(new Uint8Array(len0.buffer));
+  t.false(done0, 'readCircBuf should not be done');
+  const buf0 = new Uint8Array(Number(len0[0]));
+  const { done: done0b } = readCircBuf(buf0, len0.byteLength);
+  t.false(done0b, 'readCircBuf should not be done');
   const buf0Str = new TextDecoder().decode(buf0);
   t.is(buf0Str, `\n{"type":"start"}`);
 
@@ -25,8 +28,14 @@ test('flight-recorder sanity', t => {
     slogSender({ type: 'iteration', iteration: i });
   }
 
-  const len1 = new BigUint64Array(readCircBuf(new Uint8Array(8)).buffer);
-  const buf1 = readCircBuf(new Uint8Array(Number(len1[0])), 8);
+  const len1 = new BigUint64Array(1);
+  const { done: done1 } = readCircBuf(new Uint8Array(len1.buffer));
+  t.false(done1, 'readCircBuf should not be done');
+  const buf1 = new Uint8Array(Number(len1[0]));
+  const { done: done1b } = readCircBuf(buf1, len1.byteLength);
+  t.false(done1b, 'readCircBuf should not be done');
   const buf1Str = new TextDecoder().decode(buf1);
   t.is(buf1Str, `\n{"type":"iteration","iteration":490}`);
+
+  removeCallback();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2612,6 +2612,21 @@
   resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-1.0.0-rc.3.tgz#5032f493fbf39781b187a7e2dd5d256537c8760c"
   integrity sha512-Rs2px1keOQUNJUo5B+WExl5v244ZNCiN/iMVNO9evFdJjAdWCIupR/p14zRPkNHsciRBELLTcOZ379cI9O6PDg==
 
+"@mapbox/node-pre-gyp@1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.5.tgz#2a0b32fcb416fb3f2250fd24cb2a81421a4f5950"
+  integrity sha512-4srsKPXWlIxp5Vbqz5uLfBN+du2fJChBoYn/f2h991WLdk7jUvcSk/McVLSv/X+xQIPI8eGD5GjrnygdyHnhPA==
+  dependencies:
+    detect-libc "^1.0.3"
+    https-proxy-agent "^5.0.0"
+    make-dir "^3.1.0"
+    node-fetch "^2.6.1"
+    nopt "^5.0.0"
+    npmlog "^4.1.2"
+    rimraf "^3.0.2"
+    semver "^7.3.4"
+    tar "^6.1.0"
+
 "@material-ui/core@4.11.3":
   version "4.11.3"
   resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.11.3.tgz#f22e41775b0bd075e36a7a093d43951bf7f63850"
@@ -4628,7 +4643,7 @@ agent-base@4, agent-base@^4.3.0:
   dependencies:
     es6-promisify "^5.0.0"
 
-agent-base@6:
+agent-base@6, agent-base@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
   integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
@@ -4647,6 +4662,15 @@ agentkeepalive@^3.4.1:
   resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-3.5.2.tgz#a113924dd3fa24a0bc3b78108c450c2abee00f67"
   integrity sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==
   dependencies:
+    humanize-ms "^1.2.1"
+
+agentkeepalive@^4.1.3:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.2.0.tgz#616ce94ccb41d1a39a45d203d8076fe98713062d"
+  integrity sha512-0PhAp58jZNw13UJv7NVdTGb0ZcghHUb3DrZ046JiiJY/BOaTTpbwdHq2VObPCBV8M2GPh7sgrJ3AQ8Ey468LJw==
+  dependencies:
+    debug "^4.1.0"
+    depd "^1.1.2"
     humanize-ms "^1.2.1"
 
 aggregate-error@^3.0.0:
@@ -5774,6 +5798,14 @@ buffer@^5.2.1, buffer@^5.5.0:
   dependencies:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
+
+bufferfromfile@agoric-labs/BufferFromFile#Agoric-built:
+  version "0.4.360"
+  resolved "https://codeload.github.com/agoric-labs/BufferFromFile/tar.gz/620ad350bfa6789b297ebab937e22d582fbd19ba"
+  dependencies:
+    "@mapbox/node-pre-gyp" "1.0.5"
+    node-gyp "8.1.0"
+    wbasenodejscpp alpha
 
 builtin-modules@^3.1.0:
   version "3.1.0"
@@ -7576,15 +7608,15 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
+depd@^1.1.2, depd@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
+  integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+
 depd@^2.0.0, depd@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
-
-depd@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
-  integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
 dependency-graph@^0.11.0:
   version "0.11.0"
@@ -8015,6 +8047,13 @@ encoding@^0.1.11:
   dependencies:
     iconv-lite "~0.4.13"
 
+encoding@^0.1.12:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
+  integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
+  dependencies:
+    iconv-lite "^0.6.2"
+
 end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
@@ -8131,6 +8170,11 @@ err-code@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/err-code/-/err-code-1.1.2.tgz#06e0116d3028f6aef4806849eb0ea6a748ae6960"
   integrity sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=
+
+err-code@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/err-code/-/err-code-2.0.3.tgz#23c2f3b756ffdfc608d30e27c9a941024807e7f9"
+  integrity sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==
 
 errno@^0.1.3, errno@~0.1.7:
   version "0.1.8"
@@ -9759,6 +9803,11 @@ graceful-fs@^4.2.4:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
 
+graceful-fs@^4.2.6:
+  version "4.2.9"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96"
+  integrity sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
+
 growl@1.10.5:
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
@@ -10090,7 +10139,7 @@ http-cache-semantics@^3.8.1:
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz#39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2"
   integrity sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==
 
-http-cache-semantics@^4.0.0:
+http-cache-semantics@^4.0.0, http-cache-semantics@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
   integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
@@ -10237,6 +10286,13 @@ iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+iconv-lite@^0.6.2:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
 
 icss-utils@^4.0.0, icss-utils@^4.1.1:
   version "4.1.1"
@@ -10772,6 +10828,11 @@ is-interactive@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
   integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
+
+is-lambda@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-lambda/-/is-lambda-1.0.1.tgz#3d9877899e6a53efc0160504cde15f82e6f061d5"
+  integrity sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=
 
 is-module@^1.0.0:
   version "1.0.0"
@@ -12526,7 +12587,7 @@ make-dir@^2.0.0, make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
-make-dir@^3.0.0, make-dir@^3.0.2:
+make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
@@ -12549,6 +12610,27 @@ make-fetch-happen@^5.0.0:
     promise-retry "^1.1.1"
     socks-proxy-agent "^4.0.0"
     ssri "^6.0.0"
+
+make-fetch-happen@^8.0.14:
+  version "8.0.14"
+  resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-8.0.14.tgz#aaba73ae0ab5586ad8eaa68bd83332669393e222"
+  integrity sha512-EsS89h6l4vbfJEtBZnENTOFk8mCRpY5ru36Xe5bcX1KYIli2mkSHqoFsp5O1wMDvTJJzxe/4THpCTtygjeeGWQ==
+  dependencies:
+    agentkeepalive "^4.1.3"
+    cacache "^15.0.5"
+    http-cache-semantics "^4.1.0"
+    http-proxy-agent "^4.0.1"
+    https-proxy-agent "^5.0.0"
+    is-lambda "^1.0.1"
+    lru-cache "^6.0.0"
+    minipass "^3.1.3"
+    minipass-collect "^1.0.2"
+    minipass-fetch "^1.3.2"
+    minipass-flush "^1.0.5"
+    minipass-pipeline "^1.2.4"
+    promise-retry "^2.0.1"
+    socks-proxy-agent "^5.0.0"
+    ssri "^8.0.0"
 
 makeerror@1.0.12:
   version "1.0.12"
@@ -12957,6 +13039,17 @@ minipass-collect@^1.0.2:
   dependencies:
     minipass "^3.0.0"
 
+minipass-fetch@^1.3.2:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/minipass-fetch/-/minipass-fetch-1.4.1.tgz#d75e0091daac1b0ffd7e9d41629faff7d0c1f1b6"
+  integrity sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==
+  dependencies:
+    minipass "^3.1.0"
+    minipass-sized "^1.0.3"
+    minizlib "^2.0.0"
+  optionalDependencies:
+    encoding "^0.1.12"
+
 minipass-flush@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/minipass-flush/-/minipass-flush-1.0.5.tgz#82e7135d7e89a50ffe64610a787953c4c4cbb373"
@@ -12964,10 +13057,17 @@ minipass-flush@^1.0.5:
   dependencies:
     minipass "^3.0.0"
 
-minipass-pipeline@^1.2.2:
+minipass-pipeline@^1.2.2, minipass-pipeline@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz#68472f79711c084657c067c5c6ad93cddea8214c"
   integrity sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==
+  dependencies:
+    minipass "^3.0.0"
+
+minipass-sized@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/minipass-sized/-/minipass-sized-1.0.3.tgz#70ee5a7c5052070afacfbc22977ea79def353b70"
+  integrity sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==
   dependencies:
     minipass "^3.0.0"
 
@@ -12986,6 +13086,13 @@ minipass@^3.0.0, minipass@^3.1.1:
   dependencies:
     yallist "^4.0.0"
 
+minipass@^3.1.0, minipass@^3.1.3:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.6.tgz#3b8150aa688a711a1521af5e8779c1d3bb4f45ee"
+  integrity sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==
+  dependencies:
+    yallist "^4.0.0"
+
 minizlib@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
@@ -12993,7 +13100,7 @@ minizlib@^1.3.3:
   dependencies:
     minipass "^2.9.0"
 
-minizlib@^2.1.1:
+minizlib@^2.0.0, minizlib@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
   integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
@@ -13346,7 +13453,7 @@ node-fetch@2.6.5:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-fetch@^2.3.0, node-fetch@^2.5.0, node-fetch@^2.6.0:
+node-fetch@^2.3.0, node-fetch@^2.5.0, node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
@@ -13362,6 +13469,22 @@ node-gyp-build@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.2.3.tgz#ce6277f853835f718829efb47db20f3e4d9c4739"
   integrity sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==
+
+node-gyp@8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-8.1.0.tgz#81f43283e922d285c886fb0e0f520a7fd431d8c2"
+  integrity sha512-o2elh1qt7YUp3lkMwY3/l4KF3j/A3fI/Qt4NH+CQQgPJdqGE9y7qnP84cjIWN27Q0jJkrSAhCVDg+wBVNBYdBg==
+  dependencies:
+    env-paths "^2.2.0"
+    glob "^7.1.4"
+    graceful-fs "^4.2.6"
+    make-fetch-happen "^8.0.14"
+    nopt "^5.0.0"
+    npmlog "^4.1.2"
+    rimraf "^3.0.2"
+    semver "^7.3.5"
+    tar "^6.1.0"
+    which "^2.0.2"
 
 node-gyp@^5.0.2:
   version "5.1.0"
@@ -15300,6 +15423,14 @@ promise-retry@^1.1.1:
     err-code "^1.0.0"
     retry "^0.10.0"
 
+promise-retry@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/promise-retry/-/promise-retry-2.0.1.tgz#ff747a13620ab57ba688f5fc67855410c370da22"
+  integrity sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==
+  dependencies:
+    err-code "^2.0.2"
+    retry "^0.12.0"
+
 promise@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/promise/-/promise-8.1.0.tgz#697c25c3dfe7435dd79fcd58c38a135888eaf05e"
@@ -16596,7 +16727,7 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -17061,6 +17192,23 @@ socks-proxy-agent@^4.0.0:
     agent-base "~4.2.1"
     socks "~2.3.2"
 
+socks-proxy-agent@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-5.0.1.tgz#032fb583048a29ebffec2e6a73fca0761f48177e"
+  integrity sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==
+  dependencies:
+    agent-base "^6.0.2"
+    debug "4"
+    socks "^2.3.3"
+
+socks@^2.3.3:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.6.1.tgz#989e6534a07cf337deb1b1c94aaa44296520d30e"
+  integrity sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==
+  dependencies:
+    ip "^1.1.5"
+    smart-buffer "^4.1.0"
+
 socks@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/socks/-/socks-2.3.3.tgz#01129f0a5d534d2b897712ed8aceab7ee65d78e3"
@@ -17265,7 +17413,7 @@ ssri@^6.0.0, ssri@^6.0.1:
   dependencies:
     figgy-pudding "^3.5.1"
 
-ssri@^8.0.1:
+ssri@^8.0.0, ssri@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-8.0.1.tgz#638e4e439e2ffbd2cd289776d5ca457c4f51a2af"
   integrity sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==
@@ -18676,6 +18824,11 @@ watchpack@^1.7.4:
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"
+
+wbasenodejscpp@alpha:
+  version "0.3.124"
+  resolved "https://registry.yarnpkg.com/wbasenodejscpp/-/wbasenodejscpp-0.3.124.tgz#0fee456904d9a570b106fe6c7225af3d71e2b960"
+  integrity sha512-5SnpuYtZZbQ7cfJXKk0MEiNgFF3w1GkGnQL8T7JJrf6m8uWdolq9zlHrhpoGTRdf97JVJ1Bh1Q8LoCW+KISanw==
 
 wbuf@^1.1.0, wbuf@^1.7.3:
   version "1.7.3"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #3742

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
The `SLOGSENDER` and `SOLO_SLOGSENDER` environment variables can be an ESM specifier.  If not set, these create a 100MB `flight-recorder.bin` mmap'ed circular buffer file of slog messages in the kernel DB directory.  These messages can be extracted by running `@agoric/telemetry/bin/frcat <filename>` for analysis in the usual slogfile way.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->
We load the `bufferfromfile` NPM module to do cross-platform mmap for us.

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->
Because these files are put in the kernel's DBdir, they should easily be uploaded with other kernel state for us to analyse in the case of failure.

A follow-on PR will show how to enable OpenTelemetry tracing using the same `$SLOGSENDER` environment variable mechanism.

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
`frcat` was manually tested.  It would make sense to load its functionality as a library so the unit tests could exercise it as well.
