### PR TITLE
test(vats): fix test-extract to not depend on lockdown env

### DIFF
--- a/packages/vats/test/test-extract.js
+++ b/packages/vats/test/test-extract.js
@@ -1,5 +1,6 @@
-import '@endo/init';
-import test from 'ava';
+// @ts-check
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import { extract } from '../src/core/utils.js';
 
@@ -8,10 +9,10 @@ test('extract picks from specimen based on template', t => {
   const template = { b: { c: true } };
   const actual = extract(template, specimen);
   t.throws(() => actual.nonexistent, {
-    message: '(a string) not permitted, only (an object)',
+    message: '"nonexistent" not permitted, only ["b"]',
   });
   t.is(actual.b.c, 2);
   t.throws(() => actual.b.other, {
-    message: '(a string) not permitted, only (an object)',
+    message: '"other" not permitted, only ["c"]',
   });
 });


### PR DESCRIPTION
using bare `import 'ava'` meant this test was sensitive to lockdown env.