### PR TITLE
fix(pegasus): use dummy ICS20-1 transfer `sender`

### DIFF
--- a/packages/pegasus/src/ics20.js
+++ b/packages/pegasus/src/ics20.js
@@ -8,9 +8,14 @@ import { assert, details as X } from '@agoric/assert';
  * https://github.com/cosmos/ibc/tree/master/spec/app/ics-020-fungible-token-transfer#data-structures
  * @property {string} amount The extent of the amount
  * @property {Denom} denom The denomination of the amount
- * @property {string} [sender] The sender address
+ * @property {string} sender The sender address
  * @property {DepositAddress} receiver The receiver deposit address
  */
+
+// ibc-go as late as v3 requires the `sender` to be nonempty, but doesn't
+// actually use it on the receiving side.  We don't need it on the sending side,
+// either, so we can just omit it.
+export const DUMMY_SENDER_ADDRESS = 'pegasus';
 
 /**
  * @param {string} s
@@ -78,6 +83,7 @@ export const makeICS20TransferPacket = async ({
     amount: stringValue,
     denom: remoteDenom,
     receiver: depositAddress,
+    sender: DUMMY_SENDER_ADDRESS,
   };
 
   return JSON.stringify(ics20);

--- a/packages/pegasus/test/test-peg.js
+++ b/packages/pegasus/test/test-peg.js
@@ -104,6 +104,7 @@ async function testRemotePeg(t) {
                 amount: '100000000000000000001',
                 denom: 'uatom',
                 receiver: 'markaccount',
+                sender: 'pegasus',
               },
               'expected transfer packet',
             );


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #4498

## Description

Implement a static string, `'pegasus'` for the transfer `sender` field, just to satisfy a needless assertion in `ibc-go`.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->
None.

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
Better unit tests would be good, but the types guided this implementation.
