### PR TITLE
fix(zoe): update zoe+tests to provide zcfBundle, stop passing bundle through userspace

### DIFF
--- a/packages/governance/test/swingsetTests/committeeBinary/test-committee.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/test-committee.js
@@ -10,6 +10,7 @@ import '@endo/init';
 import test from 'ava';
 import { buildVatController, buildKernelBundles } from '@agoric/swingset-vat';
 import bundleSource from '@endo/bundle-source';
+import zcfBundle from '@agoric/zoe/bundles/bundle-contractFacet.js';
 import path from 'path';
 
 const CONTRACT_FILES = ['committee', 'binaryVoteCounter'];
@@ -47,6 +48,7 @@ test.before(async t => {
     parameters: { contractBundles }, // argv will be added to this
   };
   const config = { bootstrap: 'bootstrap', vats };
+  config.bundles = { zcf: { bundle: zcfBundle } };
   config.defaultManagerType = 'xs-worker';
 
   const step4 = Date.now();

--- a/packages/governance/test/swingsetTests/contractGovernor/test-governor.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/test-governor.js
@@ -12,6 +12,7 @@ import path from 'path';
 
 import { buildVatController, buildKernelBundles } from '@agoric/swingset-vat';
 import bundleSource from '@endo/bundle-source';
+import zcfBundle from '@agoric/zoe/bundles/bundle-contractFacet.js';
 
 const CONTRACT_FILES = [
   'committee',
@@ -62,6 +63,7 @@ test.before(async t => {
     parameters: { contractBundles }, // argv will be added to this
   };
   const config = { bootstrap: 'bootstrap', vats };
+  config.bundles = { zcf: { bundle: zcfBundle } };
   config.defaultManagerType = 'xs-worker';
 
   const step4 = Date.now();

--- a/packages/run-protocol/test/vaultFactory/swingsetTests/governance/test-governance.js
+++ b/packages/run-protocol/test/vaultFactory/swingsetTests/governance/test-governance.js
@@ -11,6 +11,7 @@ import { buildVatController, buildKernelBundles } from '@agoric/swingset-vat';
 import bundleSource from '@endo/bundle-source';
 import { E } from '@agoric/eventual-send';
 import path from 'path';
+import zcfBundle from '@agoric/zoe/bundles/bundle-contractFacet.js';
 import {
   governanceBundles,
   economyBundles,
@@ -53,6 +54,7 @@ test.before(async t => {
   vats.bootstrap.parameters = { contractBundles };
 
   const config = { bootstrap: 'bootstrap', vats };
+  config.bundles = { zcf: { bundle: zcfBundle } };
   config.defaultManagerType = 'xs-worker';
 
   t.context.data = { kernelBundles, config };

--- a/packages/run-protocol/test/vaultFactory/swingsetTests/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/swingsetTests/vaultFactory/test-vaultFactory.js
@@ -11,6 +11,7 @@ import path from 'path';
 import { buildVatController, buildKernelBundles } from '@agoric/swingset-vat';
 import bundleSource from '@endo/bundle-source';
 import { E } from '@agoric/eventual-send';
+import zcfBundle from '@agoric/zoe/bundles/bundle-contractFacet.js';
 
 import liquidateMinimumBundle from '../../../../bundles/bundle-liquidateMinimum.js';
 import ammBundle from '../../../../bundles/bundle-amm.js';
@@ -51,6 +52,7 @@ export const buildSwingSetConfig = async (contractBundles, vatNames) => {
   vats.bootstrap.parameters = { contractBundles };
 
   const config = { bootstrap: 'bootstrap', vats };
+  config.bundles = { zcf: { bundle: zcfBundle } };
   config.defaultManagerType = 'xs-worker';
   return config;
 };

--- a/packages/zoe/src/zoeService/createZCFVat.js
+++ b/packages/zoe/src/zoeService/createZCFVat.js
@@ -1,7 +1,5 @@
 import { E } from '@agoric/eventual-send';
 
-import zcfContractBundle from '../../bundles/bundle-contractFacet.js';
-
 /**
  * Attenuate the power of vatAdminSvc by restricting it such that only
  * ZCF Vats can be created.
@@ -10,13 +8,11 @@ import zcfContractBundle from '../../bundles/bundle-contractFacet.js';
  * @param {string=} zcfBundleName
  * @returns {CreateZCFVat}
  */
-export const setupCreateZCFVat = (vatAdminSvc, zcfBundleName = undefined) => {
+export const setupCreateZCFVat = (vatAdminSvc, zcfBundleName = 'zcf') => {
   /** @type {CreateZCFVat} */
   const createZCFVat = async () => {
-    const rootAndAdminNodeP =
-      typeof zcfBundleName === 'string'
-        ? E(vatAdminSvc).createVatByName(zcfBundleName)
-        : E(vatAdminSvc).createVat(zcfContractBundle);
+    assert.typeof(zcfBundleName, 'string');
+    const rootAndAdminNodeP = E(vatAdminSvc).createVatByName(zcfBundleName);
     const rootAndAdminNode = await rootAndAdminNodeP;
     return rootAndAdminNode;
   };

--- a/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/test-crashingContract.js
@@ -11,8 +11,8 @@ import path from 'path';
 
 import { loadBasedir, buildVatController } from '@agoric/swingset-vat';
 import bundleSource from '@endo/bundle-source';
-
 import fs from 'fs';
+import zcfBundle from '../../../bundles/bundle-contractFacet.js';
 
 const filename = new URL(import.meta.url).pathname;
 const dirname = path.dirname(filename);
@@ -32,6 +32,7 @@ const generateBundlesP = Promise.all(
 async function main(argv) {
   const config = await loadBasedir(dirname);
   config.defaultManagerType = 'xs-worker';
+  config.bundles = { zcf: { bundle: zcfBundle } };
   await generateBundlesP;
   const controller = await buildVatController(config, argv);
   await controller.run();

--- a/packages/zoe/test/swingsetTests/makeKind/test-makeKind.js
+++ b/packages/zoe/test/swingsetTests/makeKind/test-makeKind.js
@@ -9,6 +9,7 @@ import path from 'path';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { buildVatController, buildKernelBundles } from '@agoric/swingset-vat';
 import bundleSource from '@endo/bundle-source';
+import zcfBundle from '../../../bundles/bundle-contractFacet.js';
 
 const CONTRACT_FILES = ['minimalMakeKindContract'];
 
@@ -51,6 +52,7 @@ test.before(async t => {
     parameters: { contractBundles }, // argv will be added to this
   };
   const config = { bootstrap: 'bootstrap', vats };
+  config.bundles = { zcf: { bundle: zcfBundle } };
   config.defaultManagerType = 'xs-worker';
 
   const step4 = Date.now();

--- a/packages/zoe/test/swingsetTests/offerArgs/test-offerArgs.js
+++ b/packages/zoe/test/swingsetTests/offerArgs/test-offerArgs.js
@@ -9,6 +9,7 @@ import path from 'path';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { buildVatController, buildKernelBundles } from '@agoric/swingset-vat';
 import bundleSource from '@endo/bundle-source';
+import zcfBundle from '../../../bundles/bundle-contractFacet.js';
 
 const CONTRACT_FILES = ['offerArgsUsageContract'];
 
@@ -51,6 +52,7 @@ test.before(async t => {
     parameters: { contractBundles }, // argv will be added to this
   };
   const config = { bootstrap: 'bootstrap', vats };
+  config.bundles = { zcf: { bundle: zcfBundle } };
   config.defaultManagerType = 'xs-worker';
 
   const step4 = Date.now();

--- a/packages/zoe/test/swingsetTests/privateArgs/test-privateArgs.js
+++ b/packages/zoe/test/swingsetTests/privateArgs/test-privateArgs.js
@@ -9,6 +9,7 @@ import path from 'path';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { buildVatController, buildKernelBundles } from '@agoric/swingset-vat';
 import bundleSource from '@endo/bundle-source';
+import zcfBundle from '../../../bundles/bundle-contractFacet.js';
 
 const CONTRACT_FILES = ['privateArgsUsageContract'];
 
@@ -51,6 +52,7 @@ test.before(async t => {
     parameters: { contractBundles }, // argv will be added to this
   };
   const config = { bootstrap: 'bootstrap', vats };
+  config.bundles = { zcf: { bundle: zcfBundle } };
   config.defaultManagerType = 'xs-worker';
 
   const step4 = Date.now();

--- a/packages/zoe/test/swingsetTests/runMint/test-runMint.js
+++ b/packages/zoe/test/swingsetTests/runMint/test-runMint.js
@@ -9,6 +9,7 @@ import path from 'path';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { buildVatController, buildKernelBundles } from '@agoric/swingset-vat';
 import bundleSource from '@endo/bundle-source';
+import zcfBundle from '../../../bundles/bundle-contractFacet.js';
 
 // offerArgsUsageContract is just used as a generic contract for the
 // purpose of registering a feeBrand before any zcfMint for the
@@ -54,6 +55,7 @@ test.before(async t => {
     parameters: { contractBundles }, // argv will be added to this
   };
   const config = { bootstrap: 'bootstrap', vats };
+  config.bundles = { zcf: { bundle: zcfBundle } };
   config.defaultManagerType = 'xs-worker';
 
   const step4 = Date.now();

--- a/packages/zoe/test/swingsetTests/zoe/test-zoe.js
+++ b/packages/zoe/test/swingsetTests/zoe/test-zoe.js
@@ -10,6 +10,7 @@ import test from 'ava';
 import path from 'path';
 import { buildVatController, buildKernelBundles } from '@agoric/swingset-vat';
 import bundleSource from '@endo/bundle-source';
+import zcfBundle from '../../../bundles/bundle-contractFacet.js';
 
 const filename = new URL(import.meta.url).pathname;
 const dirname = path.dirname(filename);
@@ -49,6 +50,7 @@ test.before(async t => {
       contractBundles[bundleName] = bundle;
     }),
   );
+  const bundles = { zcf: { bundle: zcfBundle } };
   const step3 = Date.now();
 
   const vats = {};
@@ -64,7 +66,7 @@ test.before(async t => {
     bundle: await bundleSource(bootstrapSource),
     parameters: { contractBundles }, // argv will be added to this
   };
-  const config = { bootstrap: 'bootstrap', vats };
+  const config = { bootstrap: 'bootstrap', vats, bundles };
   config.defaultManagerType = 'xs-worker';
 
   const step4 = Date.now();

--- a/packages/zoe/tools/fakeVatAdmin.js
+++ b/packages/zoe/tools/fakeVatAdmin.js
@@ -4,9 +4,10 @@ import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
 import { Far } from '@endo/marshal';
 
-import { assert, details as X } from '@agoric/assert';
+import { assert } from '@agoric/assert';
 import { evalContractBundle } from '../src/contractFacet/evalContractCode.js';
 import { handlePKitWarning } from '../src/handleWarning.js';
+import zcfContractBundle from '../bundles/bundle-contractFacet.js';
 
 /**
  * @param { (...args) => unknown } [testContextSetter]
@@ -54,8 +55,9 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
         }),
       });
     },
-    createVatByName: _name => {
-      assert.fail(X`createVatByName not supported in fake mode`);
+    createVatByName: name => {
+      assert.equal(name, 'zcf', `only name='zcf' accepted, not ${name}`);
+      return admin.createVat(zcfContractBundle);
     },
   });
   const vatAdminState = {


### PR DESCRIPTION
Teach zoe's `fakeVatAdmin` to do `createVatByName(zcf)`, and change
zoe-based unit tests to provide the bundle to swingset kernel config.

Zoe needs a way to create a new ZCF vat. Inside swingset, zoe uses
`vatAdminService`, and this is used from unit tests (zoe and other
packages that use zoe) when they are willing to take the time to run a
full swingset environment.

Unit tests that use zoe, but not swingset, use `tools/fakeVatAdmin.js`
as a replacement, which implements `createVat(bundle)` but not
`createVatByName(name)`. This is used to evaluate the ZCF bundle in a
new Compartment (using `importBundle` and `evalContractBundle`).

The primary export of `@agoric/zoe` is `makeZoeKit()`, which is called
with `vatAdminService` and an optional `zcfBundleName`. This function
runs `setupCreateZCFVat(vatAdminService)` to attenuate the vat-making
power into one that can only create ZCF vats. Previously,
`setupCreateZCFVat` closed over a copy of the ZCF bundle, and passed it
to `vatAdminService~.createVat(zcfBundle)`. This hides the existence of
the ZCF bundle from other packages that just want to use Zoe.

However, to remove these large code bundles from userspace messages, we
need the ZCF bundle to be installed "off to the side", by the code that
prepares the swingset environment (usually as `config.bundles.zcf=`).

This commit changes `fakeVatAdmin.js` to implement
`createVatByName('zcf')`, and to move the copy of the zcfBundle out of
`makeZoeKit()` and into `fakeVatAdmin.js` . In addition, it changes
`createZCFVat.js` to provide a default bundle name of 'zcf'. Any unit
test that uses `fakeVatAdmin.js` can continue to do so without changes,
and the fake service will magically know how to create Zoe's ZCF vat
without any additional configuration.

This also updates unit tests in (zoe, governance, run-protocol),
specifically those which use a swingset environment, to fetch the ZCF
contract bundle from the Zoe package, and install it into the kernel
config they build. This is necessary now that Zoe's `setupCreateZCFVat`
no longer includes a copy. Any new tests which follow this pattern will
need to do the same, with something like:

```
import zcfBundle from `@agoric/zoe/bundles/bundle-contractFacet.js`;
...
config.bundles.zcf = { bundle: zcfBundle };
```

Note: if we used `{ sourceSpec: '@agoric/zoe/contractFacet.js' }`, then we
would not depend upon a recent `cd packages/zoe && yarn build`, and each
kernel instance would bundle its own copy. This would be slower, but perhaps
less prone to stale-bundle surprises, and might be a nicer export
commitment).

refs #4487
