### PR TITLE
fix(cosmic-swingset): enforce consensusMode, not by sniffing `$DEBUG`

### DIFF
--- a/packages/cosmic-swingset/src/chain-main.js
+++ b/packages/cosmic-swingset/src/chain-main.js
@@ -256,7 +256,9 @@ export default async function main(progname, args, { env, homedir, agcc }) {
       stateDir: stateDBDir,
     });
 
-    const consensusMode = env.DEBUG === undefined;
+    // We want to make it hard for a validator to accidentally disable
+    // consensusMode.
+    const consensusMode = true;
     const s = await launch(
       stateDBDir,
       mailboxStorage,

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -146,7 +146,7 @@ export async function launch(
   meterProvider = DEFAULT_METER_PROVIDER,
   slogFile = undefined,
   slogSender,
-  consensusMode = false,
+  consensusMode = true,
 ) {
   console.info('Launching SwingSet kernel');
 

--- a/packages/cosmic-swingset/src/sim-chain.js
+++ b/packages/cosmic-swingset/src/sim-chain.js
@@ -91,6 +91,8 @@ export async function connectToFakeChain(basedir, GCI, delay, inbound) {
     stateDir: stateDBdir,
   });
 
+  // We don't want to force a sim chain to use consensus mode.
+  const consensusMode = false;
   const s = await launch(
     stateDBdir,
     mailboxStorage,
@@ -102,6 +104,7 @@ export async function connectToFakeChain(basedir, GCI, delay, inbound) {
     metricsProvider,
     SLOGFILE,
     slogSender,
+    consensusMode,
   );
 
   const { savedHeight, savedActions, savedChainSends } = s;


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #4506
refs: #4510

## Description

Decouple consensus mode from the `$DEBUG` variable.  Instead, always enable for actual chain, and always disable for sim-chain.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->
Better protection of our validator community.

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
