### PR TITLE
fix(zoe)!: makeZoeKit() now requires a zcfBundlecap

### DIFF
--- a/packages/SwingSet/src/types.js
+++ b/packages/SwingSet/src/types.js
@@ -5,6 +5,7 @@
 /**
  * @typedef {'getExport' | 'nestedEvaluate' | 'endoZipBase64'} BundleFormat
  * @typedef { string } BundleID
+ * @typedef { {} } BundleCap
  */
 
 /**

--- a/packages/deploy-script-support/test/unitTests/test-install.js
+++ b/packages/deploy-script-support/test/unitTests/test-install.js
@@ -2,7 +2,7 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { makeZoeKit } from '@agoric/zoe';
-import fakeVatAdmin from '@agoric/zoe/tools/fakeVatAdmin.js';
+import { fakeVatAdmin, zcfBundlecap } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import { makeBoard } from '@agoric/vats/src/lib-board.js';
 import bundleSource from '@endo/bundle-source';
 import { resolve as importMetaResolve } from 'import-meta-resolve';
@@ -12,7 +12,7 @@ import '../../exported.js';
 import { makeInstall } from '../../src/install.js';
 
 test('install', async t => {
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin, zcfBundlecap);
 
   let addedInstallation;
 

--- a/packages/deploy-script-support/test/unitTests/test-offer.js
+++ b/packages/deploy-script-support/test/unitTests/test-offer.js
@@ -2,7 +2,7 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { makeZoeKit } from '@agoric/zoe';
-import fakeVatAdmin from '@agoric/zoe/tools/fakeVatAdmin.js';
+import { fakeVatAdmin, zcfBundlecap } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import bundleSource from '@endo/bundle-source';
 import { makeIssuerKit, AmountMath } from '@agoric/ertp';
 import { resolve as importMetaResolve } from 'import-meta-resolve';
@@ -37,7 +37,7 @@ test('offer', async t => {
     },
     saveOfferResult: () => {},
   };
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin, zcfBundlecap);
 
   const bundleUrl = await importMetaResolve(
     '@agoric/zoe/src/contracts/automaticRefund.js',

--- a/packages/deploy-script-support/test/unitTests/test-startInstance.js
+++ b/packages/deploy-script-support/test/unitTests/test-startInstance.js
@@ -2,7 +2,7 @@
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { makeZoeKit } from '@agoric/zoe';
-import fakeVatAdmin from '@agoric/zoe/tools/fakeVatAdmin.js';
+import { fakeVatAdmin, zcfBundlecap } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import bundleSource from '@endo/bundle-source';
 import { makeIssuerKit } from '@agoric/ertp';
 import { resolve as importMetaResolve } from 'import-meta-resolve';
@@ -19,7 +19,7 @@ test('startInstance', async t => {
   const moolaKit = makeIssuerKit('moola');
   const usdKit = makeIssuerKit('usd');
 
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin, zcfBundlecap);
 
   const bundleUrl = new URL(
     await importMetaResolve(

--- a/packages/governance/test/swingsetTests/committeeBinary/bootstrap.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/bootstrap.js
@@ -212,8 +212,9 @@ const makeBootstrap = (argv, cb, vatPowers) => async (vats, devices) => {
   const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
     devices.vatAdmin,
   );
+  const zcfBundlecap = vatPowers.D(devices.bundle).getNamedBundleCap('zcf');
   /** @type { ERef<ZoeService> } */
-  const zoe = E(vats.zoe).buildZoe(vatAdminSvc);
+  const zoe = E(vats.zoe).buildZoe(vatAdminSvc, zcfBundlecap);
 
   const [committee, binaryVoteCounter] = await Promise.all([
     E(zoe).install(cb.committee),

--- a/packages/governance/test/swingsetTests/committeeBinary/vat-zoe.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/vat-zoe.js
@@ -6,9 +6,13 @@ import { makeZoeKit } from '@agoric/zoe';
 
 export function buildRootObject(vatPowers) {
   return Far('root', {
-    buildZoe: vatAdminSvc => {
+    buildZoe: (vatAdminSvc, zcfBundlecap) => {
       const shutdownZoeVat = vatPowers.exitVatWithFailure;
-      const { zoeService: zoe } = makeZoeKit(vatAdminSvc, shutdownZoeVat);
+      const { zoeService: zoe } = makeZoeKit(
+        vatAdminSvc,
+        zcfBundlecap,
+        shutdownZoeVat,
+      );
       return zoe;
     },
   });

--- a/packages/governance/test/swingsetTests/contractGovernor/bootstrap.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/bootstrap.js
@@ -188,8 +188,9 @@ const makeBootstrap = (argv, cb, vatPowers) => async (vats, devices) => {
   const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
     devices.vatAdmin,
   );
+  const zcfBundlecap = vatPowers.D(devices.bundle).getNamedBundleCap('zcf');
   /** @type { ERef<ZoeService> } */
-  const zoe = E(vats.zoe).buildZoe(vatAdminSvc);
+  const zoe = E(vats.zoe).buildZoe(vatAdminSvc, zcfBundlecap);
   const installations = await installContracts(zoe, cb);
   const timer = buildManualTimer(log);
   const voterCreator = E(vats.voter).build(zoe);

--- a/packages/governance/test/swingsetTests/contractGovernor/vat-zoe.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/vat-zoe.js
@@ -6,9 +6,13 @@ import { makeZoeKit } from '@agoric/zoe';
 
 export function buildRootObject(vatPowers) {
   return Far('root', {
-    buildZoe: vatAdminSvc => {
+    buildZoe: (vatAdminSvc, zcfBundlecap) => {
       const shutdownZoeVat = vatPowers.exitVatWithFailure;
-      const { zoeService: zoe } = makeZoeKit(vatAdminSvc, shutdownZoeVat);
+      const { zoeService: zoe } = makeZoeKit(
+        vatAdminSvc,
+        zcfBundlecap,
+        shutdownZoeVat,
+      );
       return zoe;
     },
   });

--- a/packages/governance/test/unitTests/test-committee.js
+++ b/packages/governance/test/unitTests/test-committee.js
@@ -7,7 +7,7 @@ import '@agoric/zoe/exported.js';
 import path from 'path';
 import { E } from '@agoric/eventual-send';
 import { makeZoeKit } from '@agoric/zoe';
-import fakeVatAdmin from '@agoric/zoe/tools/fakeVatAdmin.js';
+import { fakeVatAdmin, zcfBundlecap } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import bundleSource from '@endo/bundle-source';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 
@@ -25,7 +25,7 @@ const electorateRoot = `${dirname}/../../src/committee.js`;
 const counterRoot = `${dirname}/../../src/binaryVoteCounter.js`;
 
 const setupContract = async () => {
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin, zcfBundlecap);
 
   // pack the contract
   const [electorateBundle, counterBundle] = await Promise.all([

--- a/packages/governance/test/unitTests/test-paramGovernance.js
+++ b/packages/governance/test/unitTests/test-paramGovernance.js
@@ -6,7 +6,10 @@ import '@agoric/zoe/exported.js';
 import { makeZoeKit } from '@agoric/zoe';
 import bundleSource from '@endo/bundle-source';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
-import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
+import {
+  makeFakeVatAdmin,
+  zcfBundlecap,
+} from '@agoric/zoe/tools/fakeVatAdmin.js';
 import { E } from '@agoric/eventual-send';
 import { makeLoopback } from '@endo/captp';
 
@@ -50,6 +53,7 @@ const setUpZoeForTest = async setJig => {
 
   const { zoeService, feeMintAccess: nonFarFeeMintAccess } = makeZoeKit(
     makeFakeVatAdmin(setJig, o => makeFar(o)).admin,
+    zcfBundlecap,
   );
   /** @type {ERef<ZoeService>} */
   const zoe = makeFar(zoeService);

--- a/packages/pegasus/test/test-peg.js
+++ b/packages/pegasus/test/test-peg.js
@@ -11,7 +11,7 @@ import bundleSource from '@endo/bundle-source';
 import { AmountMath } from '@agoric/ertp';
 import { makeZoeKit } from '@agoric/zoe';
 
-import fakeVatAdmin from '@agoric/zoe/tools/fakeVatAdmin.js';
+import { fakeVatAdmin, zcfBundlecap } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import { Far } from '@endo/marshal';
 import { makeSubscription } from '@agoric/notifier';
 
@@ -62,7 +62,7 @@ async function testRemotePeg(t) {
     },
   });
 
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin, zcfBundlecap);
 
   // Pack the contract.
   const contractBundle = await bundleSource(contractPath);

--- a/packages/run-protocol/test/amm/vpool-xyk-amm/setup.js
+++ b/packages/run-protocol/test/amm/vpool-xyk-amm/setup.js
@@ -5,7 +5,7 @@ import { E } from '@agoric/eventual-send';
 import { makeLoopback } from '@endo/captp';
 
 import { resolve as importMetaResolve } from 'import-meta-resolve';
-import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
+import { makeFakeVatAdmin, zcfBundlecap } from '@agoric/zoe/tools/fakeVatAdmin.js';
 
 import { makeZoeKit } from '@agoric/zoe';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
@@ -44,7 +44,7 @@ export const setUpZoeForTest = async () => {
   const { makeFar } = makeLoopback('zoeTest');
 
   const { zoeService, feeMintAccess: nonFarFeeMintAccess } = makeZoeKit(
-    makeFakeVatAdmin(() => {}).admin,
+    makeFakeVatAdmin(() => {}).admin, zcfBundlecap,
   );
   /** @type {ERef<ZoeService>} */
   const zoe = makeFar(zoeService);

--- a/packages/run-protocol/test/vaultFactory/swingsetTests/governance/bootstrap.js
+++ b/packages/run-protocol/test/vaultFactory/swingsetTests/governance/bootstrap.js
@@ -81,7 +81,8 @@ const makeBootstrap = (argv, cb, vatPowers) => async (vats, devices) => {
   const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
     devices.vatAdmin,
   );
-  const { zoe, feeMintAccess } = await E(vats.zoe).buildZoe(vatAdminSvc);
+  const zcfBundlecap = vatPowers.D(devices.bundle).getNamedBundleCap('zcf');
+  const { zoe, feeMintAccess } = await E(vats.zoe).buildZoe(vatAdminSvc, zcfBundlecap);
 
   const installations = await installContracts(zoe, cb);
   const voterCreator = E(vats.voter).build(zoe);

--- a/packages/run-protocol/test/vaultFactory/swingsetTests/governance/vat-zoe.js
+++ b/packages/run-protocol/test/vaultFactory/swingsetTests/governance/vat-zoe.js
@@ -7,10 +7,11 @@ import { makeZoeKit } from '@agoric/zoe';
 /** @type {BuildRootObjectForTestVat} */
 export function buildRootObject(vatPowers) {
   return Far('root', {
-    buildZoe: vatAdminSvc => {
+    buildZoe: (vatAdminSvc, zcfBundlecap) => {
       const shutdownZoeVat = vatPowers.exitVatWithFailure;
       const { zoeService: zoe, feeMintAccess } = makeZoeKit(
         vatAdminSvc,
+        zcfBundlecap,
         shutdownZoeVat,
       );
 

--- a/packages/run-protocol/test/vaultFactory/swingsetTests/vaultFactory/bootstrap.js
+++ b/packages/run-protocol/test/vaultFactory/swingsetTests/vaultFactory/bootstrap.js
@@ -9,7 +9,8 @@ function makeBootstrap(argv, cb, vatPowers) {
     const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
       devices.vatAdmin,
     );
-    const { zoe, feeMintAccess } = await E(vats.zoe).buildZoe(vatAdminSvc);
+    const zcfBundlecap = vatPowers.D(devices.bundle).getNamedBundleCap('zcf');
+    const { zoe, feeMintAccess } = await E(vats.zoe).buildZoe(vatAdminSvc, zcfBundlecap);
 
     const installations = await installContracts(zoe, cb);
 

--- a/packages/run-protocol/test/vaultFactory/swingsetTests/vaultFactory/vat-zoe.js
+++ b/packages/run-protocol/test/vaultFactory/swingsetTests/vaultFactory/vat-zoe.js
@@ -7,10 +7,11 @@ import { makeZoeKit } from '@agoric/zoe';
 /** @type {BuildRootObjectForTestVat} */
 export function buildRootObject(vatPowers) {
   return Far('root', {
-    buildZoe: vatAdminSvc => {
+    buildZoe: (vatAdminSvc, zcfBundlecap) => {
       const shutdownZoeVat = vatPowers.exitVatWithFailure;
       const { zoeService: zoe, feeMintAccess } = makeZoeKit(
         vatAdminSvc,
+        zcfBundlecap,
         shutdownZoeVat,
       );
       return { zoe, feeMintAccess };

--- a/packages/run-protocol/test/vaultFactory/test-bootstrapPayment.js
+++ b/packages/run-protocol/test/vaultFactory/test-bootstrapPayment.js
@@ -8,7 +8,7 @@ import '../../src/vaultFactory/types.js';
 import path from 'path';
 import { E } from '@agoric/eventual-send';
 import bundleSource from '@endo/bundle-source';
-import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
+import { makeFakeVatAdmin, zcfBundlecap } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import { makeZoeKit } from '@agoric/zoe';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import { AmountMath } from '@agoric/ertp';
@@ -59,7 +59,7 @@ const installBundle = (zoe, contractBundle) => E(zoe).install(contractBundle);
 const setUpZoeForTest = async setJig => {
   const { makeFar } = makeLoopback('zoeTest');
   const { zoeService, feeMintAccess: nonFarFeeMintAccess } = makeZoeKit(
-    makeFakeVatAdmin(setJig).admin,
+    makeFakeVatAdmin(setJig).admin, zcfBundlecap
   );
   /** @type {ERef<ZoeService>} */
   const zoe = makeFar(zoeService);

--- a/packages/run-protocol/test/vaultFactory/test-vault-interest.js
+++ b/packages/run-protocol/test/vaultFactory/test-vault-interest.js
@@ -3,7 +3,7 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import '@agoric/zoe/exported.js';
 
 import { E } from '@agoric/eventual-send';
-import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
+import { makeFakeVatAdmin, zcfBundlecap } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import { makeLoopback } from '@endo/captp';
 import { makeZoeKit } from '@agoric/zoe';
 import bundleSource from '@endo/bundle-source';
@@ -40,7 +40,7 @@ const setJig = jig => {
 const { makeFar, makeNear: makeRemote } = makeLoopback('zoeTest');
 
 const { zoeService, feeMintAccess: nonFarFeeMintAccess } = makeZoeKit(
-  makeFakeVatAdmin(setJig, makeRemote).admin,
+  makeFakeVatAdmin(setJig, makeRemote).admin, zcfBundlecap
 );
 /** @type {ERef<ZoeService>} */
 const zoe = makeFar(zoeService);

--- a/packages/run-protocol/test/vaultFactory/test-vault.js
+++ b/packages/run-protocol/test/vaultFactory/test-vault.js
@@ -4,7 +4,7 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 import '@agoric/zoe/exported.js';
 
 import { E } from '@agoric/eventual-send';
-import { makeFakeVatAdmin } from '@agoric/zoe/tools/fakeVatAdmin.js';
+import { makeFakeVatAdmin, zcfBundlecap } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import { makeLoopback } from '@endo/captp';
 import { makeZoeKit } from '@agoric/zoe';
 import bundleSource from '@endo/bundle-source';
@@ -38,7 +38,7 @@ const setJig = jig => {
 const { makeFar, makeNear: makeRemote } = makeLoopback('zoeTest');
 
 const { zoeService, feeMintAccess: nonFarFeeMintAccess } = makeZoeKit(
-  makeFakeVatAdmin(setJig, makeRemote).admin,
+  makeFakeVatAdmin(setJig, makeRemote).admin, zcfBundlecap
 );
 /** @type {ERef<ZoeService>} */
 const zoe = makeFar(zoeService);

--- a/packages/vats/decentral-config.json
+++ b/packages/vats/decentral-config.json
@@ -38,10 +38,7 @@
       "sourceSpec": "./src/vat-walletManager.js"
     },
     "zoe": {
-      "sourceSpec": "./src/vat-zoe.js",
-      "parameters": {
-        "zcfBundleName": "zcf"
-      }
+      "sourceSpec": "./src/vat-zoe.js"
     },
     "bootstrap": {
       "sourceSpec": "./src/bootstrap.js"

--- a/packages/vats/decentral-core-config.json
+++ b/packages/vats/decentral-core-config.json
@@ -40,10 +40,7 @@
       "sourceSpec": "./src/vat-walletManager.js"
     },
     "zoe": {
-      "sourceSpec": "./src/vat-zoe.js",
-      "parameters": {
-        "zcfBundleName": "zcf"
-      }
+      "sourceSpec": "./src/vat-zoe.js"
     }
   },
   "defaultManagerType": "xs-worker"

--- a/packages/vats/decentral-demo-config.json
+++ b/packages/vats/decentral-demo-config.json
@@ -43,10 +43,7 @@
       "sourceSpec": "./src/vat-walletManager.js"
     },
     "zoe": {
-      "sourceSpec": "./src/vat-zoe.js",
-      "parameters": {
-        "zcfBundleName": "zcf"
-      }
+      "sourceSpec": "./src/vat-zoe.js"
     }
   },
   "defaultManagerType": "xs-worker"

--- a/packages/vats/src/bootstrap.js
+++ b/packages/vats/src/bootstrap.js
@@ -66,6 +66,7 @@ export function buildRootObject(vatPowers, vatParameters) {
     vats,
     bridgeManager,
     timerDevice,
+    bundleDevice,
     vatAdminSvc,
     noFakeCurrencies,
   ) {
@@ -79,6 +80,9 @@ export function buildRootObject(vatPowers, vatParameters) {
     const dibcBridgeManager = bridgeManager;
 
     const chainTimerServiceP = E(vats.timer).createTimerService(timerDevice);
+
+    // vatParameters.zcfBundleName,
+    const zcfBundlecap = D(bundleDevice).getNamedBundleCap('zcf');
 
     // Create singleton instances.
     const [
@@ -96,7 +100,7 @@ export function buildRootObject(vatPowers, vatParameters) {
       chainTimerServiceP,
       /** @type {Promise<{ zoeService: ZoeService, feeMintAccess:
        * FeeMintAccess }>} */ (
-        E(vats.zoe).buildZoe(vatAdminSvc, feeIssuerConfig)
+        E(vats.zoe).buildZoe(vatAdminSvc, zcfBundlecap, feeIssuerConfig)
       ),
       E(vats.priceAuthority).makePriceAuthority(),
       E(vats.walletManager).buildWalletManager(vatAdminSvc),
@@ -986,6 +990,7 @@ export function buildRootObject(vatPowers, vatParameters) {
             vats,
             bridgeManager,
             devices.timer,
+            devices.bundle,
             vatAdminSvc,
             noFakeCurrencies,
           );
@@ -1045,6 +1050,7 @@ export function buildRootObject(vatPowers, vatParameters) {
             vats,
             bridgeManager,
             devices.timer,
+            devices.bundle,
             vatAdminSvc,
             noFakeCurrencies,
           );

--- a/packages/vats/src/vat-zoe.js
+++ b/packages/vats/src/vat-zoe.js
@@ -3,13 +3,13 @@ import { makeZoeKit } from '@agoric/zoe';
 
 export function buildRootObject(vatPowers, vatParameters) {
   return Far('root', {
-    buildZoe: async (adminVat, feeIssuerConfig) => {
+    buildZoe: async (adminVat, zcfBundlecap, feeIssuerConfig) => {
       const shutdownZoeVat = vatPowers.exitVatWithFailure;
       const { zoeService, feeMintAccess } = makeZoeKit(
         adminVat,
+        zcfBundlecap,
         shutdownZoeVat,
         feeIssuerConfig,
-        vatParameters.zcfBundleName,
       );
       return harden({
         zoeService,

--- a/packages/wallet/api/test/test-getPursesNotifier.js
+++ b/packages/wallet/api/test/test-getPursesNotifier.js
@@ -3,7 +3,7 @@ import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
 import { makeIssuerKit } from '@agoric/ertp';
 import { makeZoeKit } from '@agoric/zoe';
-import fakeVatAdmin from '@agoric/zoe/tools/fakeVatAdmin.js';
+import { fakeVatAdmin, zcfBundlecap} from '@agoric/zoe/tools/fakeVatAdmin.js';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { makeBoard } from '@agoric/vats/src/lib-board.js';
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -24,7 +24,7 @@ function makeFakeMyAddressNameAdmin() {
 }
 
 const setup = async () => {
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin, zcfBundlecap);
   const board = makeBoard();
 
   const pursesStateChangeHandler = _data => {};

--- a/packages/wallet/api/test/test-lib-wallet.js
+++ b/packages/wallet/api/test/test-lib-wallet.js
@@ -6,7 +6,7 @@ import bundleSource from '@endo/bundle-source';
 import { makeIssuerKit, AmountMath, AssetKind } from '@agoric/ertp';
 
 import { makeZoeKit } from '@agoric/zoe';
-import fakeVatAdmin from '@agoric/zoe/tools/fakeVatAdmin.js';
+import { fakeVatAdmin, zcfBundlecap } from '@agoric/zoe/tools/fakeVatAdmin.js';
 import { E } from '@agoric/eventual-send';
 
 import { assert } from '@agoric/assert';
@@ -45,7 +45,7 @@ async function setupTest() {
   const moolaBundle = makeIssuerKit('moola');
   const simoleanBundle = makeIssuerKit('simolean');
   const rpgBundle = makeIssuerKit('rpg', AssetKind.SET);
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin, zcfBundlecap);
   const board = makeBoard();
 
   // Create AutomaticRefund instance
@@ -1289,7 +1289,7 @@ test('addOffer offer.invitation', async t => {
 });
 
 test('addOffer makeContinuingInvitation', async t => {
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin, zcfBundlecap);
   const board = makeBoard();
 
   // Create ContinuingInvitationExample instance
@@ -1373,7 +1373,7 @@ test('addOffer makeContinuingInvitation', async t => {
 });
 
 test('getZoe, getBoard', async t => {
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin, zcfBundlecap);
   const board = makeBoard();
 
   const pursesStateChangeHandler = _data => {};
@@ -1393,7 +1393,7 @@ test('getZoe, getBoard', async t => {
 });
 
 test('stamps from dateNow', async t => {
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin, zcfBundlecap);
   const board = makeBoard();
 
   const startDateMS = new Date(2020, 0, 1).valueOf();

--- a/packages/zoe/src/zoeService/createZCFVat.js
+++ b/packages/zoe/src/zoeService/createZCFVat.js
@@ -1,18 +1,20 @@
 import { E } from '@agoric/eventual-send';
+import { passStyleOf } from '@endo/marshal';
 
 /**
  * Attenuate the power of vatAdminSvc by restricting it such that only
  * ZCF Vats can be created.
  *
  * @param {VatAdminSvc} vatAdminSvc
- * @param {string=} zcfBundleName
+ * @param {BundleCap} zcfBundlecap
  * @returns {CreateZCFVat}
  */
-export const setupCreateZCFVat = (vatAdminSvc, zcfBundleName = 'zcf') => {
+export const setupCreateZCFVat = (vatAdminSvc, zcfBundlecap) => {
   /** @type {CreateZCFVat} */
   const createZCFVat = async () => {
-    assert.typeof(zcfBundleName, 'string');
-    const rootAndAdminNodeP = E(vatAdminSvc).createVatByName(zcfBundleName);
+    assert.typeof(zcfBundlecap, 'object');
+    assert.equal(passStyleOf(zcfBundlecap), 'remotable');
+    const rootAndAdminNodeP = E(vatAdminSvc).createVat(zcfBundlecap);
     const rootAndAdminNode = await rootAndAdminNodeP;
     return rootAndAdminNode;
   };

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -268,8 +268,7 @@
 
 /**
  * @typedef {Object} VatAdminSvc
- * @property {(bundle: SourceBundle) => RootAndAdminNode} createVat
- * @property {(BundleName: string) => RootAndAdminNode} createVatByName
+ * @property {(bundlecap: bundlecap) => RootAndAdminNode} createVat
  */
 
 /**

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -31,11 +31,11 @@ import { createFeeMint } from './feeMint.js';
  *
  * @param {VatAdminSvc} vatAdminSvc - The vatAdmin Service, which carries the power
  * to create a new vat.
+ * @param {BundleCap} zcfBundlecap - handle to the ZCF source bundle
  * @param {ShutdownWithFailure} shutdownZoeVat - a function to
  * shutdown the Zoe Vat. This function needs to use the vatPowers
  * available to a vat.
  * @param {FeeIssuerConfig} feeIssuerConfig
- * @param {string} [zcfBundleName] - The name of the contract facet bundle.
  * @returns {{
  *   zoeService: ZoeService,
  *   feeMintAccess: FeeMintAccess,
@@ -43,13 +43,13 @@ import { createFeeMint } from './feeMint.js';
  */
 const makeZoeKit = (
   vatAdminSvc,
+  zcfBundlecap,
   shutdownZoeVat = () => {},
   feeIssuerConfig = {
     name: 'RUN',
     assetKind: AssetKind.NAT,
     displayInfo: harden({ decimalPlaces: 6, assetKind: AssetKind.NAT }),
   },
-  zcfBundleName = undefined,
 ) => {
   // We must pass the ZoeService to `makeStartInstance` before it is
   // defined. See below where the promise is resolved.
@@ -64,7 +64,7 @@ const makeZoeKit = (
   // This method contains the power to create a new ZCF Vat, and must
   // be closely held. vatAdminSvc is even more powerful - any vat can
   // be created. We severely restrict access to vatAdminSvc for this reason.
-  const createZCFVat = setupCreateZCFVat(vatAdminSvc, zcfBundleName);
+  const createZCFVat = setupCreateZCFVat(vatAdminSvc, zcfBundlecap);
 
   // The ZoeStorageManager composes and consolidates capabilities
   // needed by Zoe according to POLA.

--- a/packages/zoe/test/swingsetTests/brokenContracts/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/bootstrap.js
@@ -40,12 +40,14 @@ const makeVats = (log, vats, zoe, installations, startingValues) => {
 };
 
 export function buildRootObject(vatPowers, vatParameters) {
+  const { D } = vatPowers;
   return Far('root', {
     async bootstrap(vats, devices) {
       const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
         devices.vatAdmin,
       );
-      const zoe = await E(vats.zoe).buildZoe(vatAdminSvc);
+      const zcfBundlecap = D(devices.bundle).getNamedBundleCap('zcf');
+      const zoe = await E(vats.zoe).buildZoe(vatAdminSvc, zcfBundlecap);
       const installations = {
         crashAutoRefund: await E(zoe).install(crashingAutoRefund.bundle),
       };

--- a/packages/zoe/test/swingsetTests/brokenContracts/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/vat-zoe.js
@@ -6,9 +6,13 @@ import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 
 export function buildRootObject(vatPowers) {
   return Far('root', {
-    buildZoe: vatAdminSvc => {
+    buildZoe: (vatAdminSvc, zcfBundlecap) => {
       const shutdownZoeVat = vatPowers.exitVatWithFailure;
-      const { zoeService: zoe } = makeZoeKit(vatAdminSvc, shutdownZoeVat);
+      const { zoeService: zoe } = makeZoeKit(
+        vatAdminSvc,
+        zcfBundlecap,
+        shutdownZoeVat,
+      );
       return zoe;
     },
   });

--- a/packages/zoe/test/swingsetTests/makeKind/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/makeKind/bootstrap.js
@@ -2,13 +2,15 @@ import { E } from '@agoric/eventual-send';
 import { Far } from '@endo/marshal';
 
 export function buildRootObject(vatPowers, vatParameters) {
+  const { D } = vatPowers;
   const { contractBundles: cb } = vatParameters;
   return Far('root', {
     async bootstrap(vats, devices) {
       const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
         devices.vatAdmin,
       );
-      const zoe = await E(vats.zoe).buildZoe(vatAdminSvc);
+      const zcfBundlecap = D(devices.bundle).getNamedBundleCap('zcf');
+      const zoe = await E(vats.zoe).buildZoe(vatAdminSvc, zcfBundlecap);
       const installations = {
         minimalMakeKind: await E(zoe).install(cb.minimalMakeKindContract),
       };

--- a/packages/zoe/test/swingsetTests/makeKind/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/makeKind/vat-zoe.js
@@ -6,9 +6,13 @@ import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 
 export function buildRootObject(vatPowers) {
   return Far('root', {
-    buildZoe: vatAdminSvc => {
+    buildZoe: (vatAdminSvc, zcfBundlecap) => {
       const shutdownZoeVat = vatPowers.exitVatWithFailure;
-      const { zoeService: zoe } = makeZoeKit(vatAdminSvc, shutdownZoeVat);
+      const { zoeService: zoe } = makeZoeKit(
+        vatAdminSvc,
+        zcfBundlecap,
+        shutdownZoeVat,
+      );
       return zoe;
     },
   });

--- a/packages/zoe/test/swingsetTests/offerArgs/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/offerArgs/bootstrap.js
@@ -2,13 +2,15 @@ import { E } from '@agoric/eventual-send';
 import { Far } from '@endo/marshal';
 
 export function buildRootObject(vatPowers, vatParameters) {
+  const { D } = vatPowers;
   const { contractBundles: cb } = vatParameters;
   return Far('root', {
     async bootstrap(vats, devices) {
       const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
         devices.vatAdmin,
       );
-      const zoe = await E(vats.zoe).buildZoe(vatAdminSvc);
+      const zcfBundlecap = D(devices.bundle).getNamedBundleCap('zcf');
+      const zoe = await E(vats.zoe).buildZoe(vatAdminSvc, zcfBundlecap);
       const installations = {
         offerArgsUsageContract: await E(zoe).install(cb.offerArgsUsageContract),
       };

--- a/packages/zoe/test/swingsetTests/offerArgs/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/offerArgs/vat-zoe.js
@@ -6,9 +6,13 @@ import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 
 export function buildRootObject(vatPowers) {
   return Far('root', {
-    buildZoe: vatAdminSvc => {
+    buildZoe: (vatAdminSvc, zcfBundlecap) => {
       const shutdownZoeVat = vatPowers.exitVatWithFailure;
-      const { zoeService: zoe } = makeZoeKit(vatAdminSvc, shutdownZoeVat);
+      const { zoeService: zoe } = makeZoeKit(
+        vatAdminSvc,
+        zcfBundlecap,
+        shutdownZoeVat,
+      );
       return zoe;
     },
   });

--- a/packages/zoe/test/swingsetTests/privateArgs/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/privateArgs/bootstrap.js
@@ -2,13 +2,15 @@ import { E } from '@agoric/eventual-send';
 import { Far } from '@endo/marshal';
 
 export function buildRootObject(vatPowers, vatParameters) {
+  const { D } = vatPowers;
   const { contractBundles: cb } = vatParameters;
   return Far('root', {
     async bootstrap(vats, devices) {
       const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
         devices.vatAdmin,
       );
-      const zoe = await E(vats.zoe).buildZoe(vatAdminSvc);
+      const zcfBundlecap = D(devices.bundle).getNamedBundleCap('zcf');
+      const zoe = await E(vats.zoe).buildZoe(vatAdminSvc, zcfBundlecap);
       const installations = {
         privateArgsUsageContract: await E(zoe).install(
           cb.privateArgsUsageContract,

--- a/packages/zoe/test/swingsetTests/privateArgs/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/privateArgs/vat-zoe.js
@@ -6,9 +6,13 @@ import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 
 export function buildRootObject(vatPowers) {
   return Far('root', {
-    buildZoe: vatAdminSvc => {
+    buildZoe: (vatAdminSvc, zcfBundlecap) => {
       const shutdownZoeVat = vatPowers.exitVatWithFailure;
-      const { zoeService: zoe } = makeZoeKit(vatAdminSvc, shutdownZoeVat);
+      const { zoeService: zoe } = makeZoeKit(
+        vatAdminSvc,
+        zcfBundlecap,
+        shutdownZoeVat,
+      );
       return zoe;
     },
   });

--- a/packages/zoe/test/swingsetTests/runMint/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/runMint/bootstrap.js
@@ -2,13 +2,18 @@ import { E } from '@agoric/eventual-send';
 import { Far } from '@endo/marshal';
 
 export function buildRootObject(vatPowers, vatParameters) {
+  const { D } = vatPowers;
   const { contractBundles: cb } = vatParameters;
   return Far('root', {
     async bootstrap(vats, devices) {
       const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
         devices.vatAdmin,
       );
-      const { zoe, feeMintAccess } = await E(vats.zoe).buildZoe(vatAdminSvc);
+      const zcfBundlecap = D(devices.bundle).getNamedBundleCap('zcf');
+      const { zoe, feeMintAccess } = await E(vats.zoe).buildZoe(
+        vatAdminSvc,
+        zcfBundlecap,
+      );
       const installations = {
         runMintContract: await E(zoe).install(cb.runMintContract),
         offerArgsUsageContract: await E(zoe).install(cb.offerArgsUsageContract),

--- a/packages/zoe/test/swingsetTests/runMint/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/runMint/vat-zoe.js
@@ -6,10 +6,11 @@ import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 
 export function buildRootObject(vatPowers) {
   return Far('root', {
-    buildZoe: async vatAdminSvc => {
+    buildZoe: async (vatAdminSvc, zcfBundlecap) => {
       const shutdownZoeVat = vatPowers.exitVatWithFailure;
       const { zoeService: zoe, feeMintAccess } = makeZoeKit(
         vatAdminSvc,
+        zcfBundlecap,
         shutdownZoeVat,
       );
       return harden({ zoe, feeMintAccess });

--- a/packages/zoe/test/swingsetTests/zoe/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/zoe/bootstrap.js
@@ -81,13 +81,15 @@ const makeVats = (log, vats, zoe, installations, startingValues) => {
 };
 
 export function buildRootObject(vatPowers, vatParameters) {
+  const { D } = vatPowers;
   const { argv, contractBundles: cb } = vatParameters;
   return Far('root', {
     async bootstrap(vats, devices) {
       const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
         devices.vatAdmin,
       );
-      const zoe = await E(vats.zoe).buildZoe(vatAdminSvc);
+      const zcfBundlecap = D(devices.bundle).getNamedBundleCap('zcf');
+      const zoe = await E(vats.zoe).buildZoe(vatAdminSvc, zcfBundlecap);
       const installations = {
         automaticRefund: await E(zoe).install(cb.automaticRefund),
         coveredCall: await E(zoe).install(cb.coveredCall),

--- a/packages/zoe/test/swingsetTests/zoe/vat-zoe.js
+++ b/packages/zoe/test/swingsetTests/zoe/vat-zoe.js
@@ -6,9 +6,13 @@ import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 
 export function buildRootObject(vatPowers) {
   return Far('root', {
-    buildZoe: vatAdminSvc => {
+    buildZoe: (vatAdminSvc, zcfBundlecap) => {
       const shutdownZoeVat = vatPowers.exitVatWithFailure;
-      const { zoeService: zoe } = makeZoeKit(vatAdminSvc, shutdownZoeVat);
+      const { zoeService: zoe } = makeZoeKit(
+        vatAdminSvc,
+        zcfBundlecap,
+        shutdownZoeVat,
+      );
       return zoe;
     },
   });

--- a/packages/zoe/test/unitTests/contractSupport/test-depositTo.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-depositTo.js
@@ -9,7 +9,7 @@ import bundleSource from '@endo/bundle-source';
 
 import { setup } from '../setupBasicMints.js';
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
-import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
+import { makeFakeVatAdmin, zcfBundlecap } from '../../../tools/fakeVatAdmin.js';
 import { depositToSeat } from '../../../src/contractSupport/zoeHelpers.js';
 import { makeOffer } from '../makeOffer.js';
 
@@ -23,7 +23,10 @@ async function setupContract(moolaIssuer, bucksIssuer) {
   const setJig = jig => {
     testJig = jig;
   };
-  const { zoeService: zoe } = makeZoeKit(makeFakeVatAdmin(setJig).admin);
+  const { zoeService: zoe } = makeZoeKit(
+    makeFakeVatAdmin(setJig).admin,
+    zcfBundlecap,
+  );
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
@@ -9,7 +9,7 @@ import bundleSource from '@endo/bundle-source';
 
 import { setup } from '../setupBasicMints.js';
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
-import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
+import { makeFakeVatAdmin, zcfBundlecap } from '../../../tools/fakeVatAdmin.js';
 import {
   offerTo,
   assertProposalShape,
@@ -27,7 +27,10 @@ const setupContract = async (moolaIssuer, bucksIssuer) => {
   const setJig = jig => {
     instanceToZCF.set(jig.instance, jig.zcf);
   };
-  const { zoeService: zoe } = makeZoeKit(makeFakeVatAdmin(setJig).admin);
+  const { zoeService: zoe } = makeZoeKit(
+    makeFakeVatAdmin(setJig).admin,
+    zcfBundlecap,
+  );
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
@@ -9,7 +9,7 @@ import bundleSource from '@endo/bundle-source';
 
 import { setup } from '../setupBasicMints.js';
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
-import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
+import { makeFakeVatAdmin, zcfBundlecap } from '../../../tools/fakeVatAdmin.js';
 import {
   depositToSeat,
   withdrawFromSeat,
@@ -27,7 +27,10 @@ async function setupContract(moolaIssuer, bucksIssuer) {
   const setJig = jig => {
     testJig = jig;
   };
-  const { zoeService: zoe } = makeZoeKit(makeFakeVatAdmin(setJig).admin);
+  const { zoeService: zoe } = makeZoeKit(
+    makeFakeVatAdmin(setJig).admin,
+    zcfBundlecap,
+  );
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/contracts/attestation/test-attestation.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/test-attestation.js
@@ -12,7 +12,7 @@ import bundleSource from '@endo/bundle-source';
 import { E } from '@agoric/eventual-send';
 
 import { makeZoeKit } from '../../../../src/zoeService/zoe.js';
-import fakeVatAdmin from '../../../../tools/fakeVatAdmin.js';
+import { fakeVatAdmin, zcfBundlecap } from '../../../../tools/fakeVatAdmin.js';
 
 const filename = new URL(import.meta.url).pathname;
 const dirname = path.dirname(filename);
@@ -22,7 +22,7 @@ const attestationRoot = `${dirname}/../../../../src/contracts/attestation/attest
 test('attestation contract basic tests', async t => {
   const bundle = await bundleSource(attestationRoot);
 
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin, zcfBundlecap);
   const installation = await E(zoe).install(bundle);
 
   const bldIssuerKit = makeIssuerKit(

--- a/packages/zoe/test/unitTests/contracts/test-auction.js
+++ b/packages/zoe/test/unitTests/contracts/test-auction.js
@@ -13,7 +13,7 @@ import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import buildManualTimer from '../../../tools/manualTimer.js';
 import { setup } from '../setupBasicMints.js';
 import { setupMixed } from '../setupMixedMints.js';
-import fakeVatAdmin from '../../../tools/fakeVatAdmin.js';
+import { fakeVatAdmin, zcfBundlecap } from '../../../tools/fakeVatAdmin.js';
 
 const filename = new URL(import.meta.url).pathname;
 const dirname = path.dirname(filename);
@@ -248,7 +248,7 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
 test('zoe - secondPriceAuction - alice tries to exit', async t => {
   t.plan(12);
   const { moolaR, simoleanR, moola, simoleans } = setup();
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin, zcfBundlecap);
 
   // Setup Alice
   const aliceMoolaPayment = moolaR.mint.mintPayment(moola(1n));
@@ -402,7 +402,7 @@ test('zoe - secondPriceAuction - alice tries to exit', async t => {
 test('zoe - secondPriceAuction - all bidders try to exit', async t => {
   t.plan(10);
   const { moolaR, simoleanR, moola, simoleans } = setup();
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin, zcfBundlecap);
 
   // Setup Alice
   const aliceMoolaPayment = moolaR.mint.mintPayment(moola(1n));

--- a/packages/zoe/test/unitTests/contracts/test-brokenContract.js
+++ b/packages/zoe/test/unitTests/contracts/test-brokenContract.js
@@ -10,7 +10,7 @@ import { E } from '@agoric/eventual-send';
 
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import { setup } from '../setupBasicMints.js';
-import fakeVatAdmin from '../../../tools/fakeVatAdmin.js';
+import { fakeVatAdmin, zcfBundlecap } from '../../../tools/fakeVatAdmin.js';
 
 const filename = new URL(import.meta.url).pathname;
 const dirname = path.dirname(filename);
@@ -21,7 +21,7 @@ test('zoe - brokenAutomaticRefund', async t => {
   t.plan(1);
   // Setup zoe and mints
   const { moolaR } = setup();
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin, zcfBundlecap);
   // Pack the contract.
   const bundle = await bundleSource(automaticRefundRoot);
   const installation = await E(zoe).install(bundle);

--- a/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
@@ -10,7 +10,7 @@ import { E } from '@agoric/eventual-send';
 
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import { setup } from '../setupBasicMints.js';
-import fakeVatAdmin from '../../../tools/fakeVatAdmin.js';
+import { fakeVatAdmin, zcfBundlecap } from '../../../tools/fakeVatAdmin.js';
 
 const filename = new URL(import.meta.url).pathname;
 const dirname = path.dirname(filename);
@@ -20,7 +20,7 @@ const contractRoot = `${dirname}/escrowToVote.js`;
 test('zoe - escrowToVote', async t => {
   t.plan(14);
   const { moolaIssuer, moolaMint, moola } = setup();
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin, zcfBundlecap);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/contracts/test-mintPayments.js
+++ b/packages/zoe/test/unitTests/contracts/test-mintPayments.js
@@ -7,7 +7,7 @@ import path from 'path';
 import bundleSource from '@endo/bundle-source';
 import { E } from '@agoric/eventual-send';
 import { makeIssuerKit, AmountMath } from '@agoric/ertp';
-import fakeVatAdmin from '../../../tools/fakeVatAdmin.js';
+import { fakeVatAdmin, zcfBundlecap } from '../../../tools/fakeVatAdmin.js';
 
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 
@@ -18,7 +18,7 @@ const mintPaymentsRoot = `${dirname}/../../../src/contracts/mintPayments.js`;
 
 test('zoe - mint payments', async t => {
   t.plan(2);
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin, zcfBundlecap);
 
   const makeAlice = () => {
     return {
@@ -86,7 +86,7 @@ test('zoe - mint payments', async t => {
 
 test('zoe - mint payments with unrelated give and want', async t => {
   t.plan(3);
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin, zcfBundlecap);
   const moolaKit = makeIssuerKit('moola');
   const simoleanKit = makeIssuerKit('simolean');
 

--- a/packages/zoe/test/unitTests/contracts/test-oracle.js
+++ b/packages/zoe/test/unitTests/contracts/test-oracle.js
@@ -11,7 +11,7 @@ import { Far } from '@endo/marshal';
 import { assert, details as X } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
 
-import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
+import { makeFakeVatAdmin, zcfBundlecap } from '../../../tools/fakeVatAdmin.js';
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 
 import '../../../exported.js';
@@ -37,7 +37,10 @@ test.before(
   /** @param {ExecutionContext} ot */ async ot => {
     // Outside of tests, we should use the long-lived Zoe on the
     // testnet. In this test, we must create a new Zoe.
-    const { zoeService: zoe } = makeZoeKit(makeFakeVatAdmin().admin);
+    const { zoeService: zoe } = makeZoeKit(
+      makeFakeVatAdmin().admin,
+      zcfBundlecap,
+    );
 
     // Pack the contract.
     const contractBundle = await bundleSource(contractPath);

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
@@ -12,7 +12,7 @@ import { makeIssuerKit, AssetKind, AmountMath } from '@agoric/ertp';
 import { makePromiseKit } from '@agoric/promise-kit';
 
 import { assert } from '@agoric/assert';
-import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
+import { makeFakeVatAdmin, zcfBundlecap } from '../../../tools/fakeVatAdmin.js';
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import buildManualTimer from '../../../tools/manualTimer.js';
 
@@ -48,7 +48,10 @@ test.before(
   /** @param {ExecutionContext} ot */ async ot => {
     // Outside of tests, we should use the long-lived Zoe on the
     // testnet. In this test, we must create a new Zoe.
-    const { zoeService: zoe } = makeZoeKit(makeFakeVatAdmin().admin);
+    const { zoeService: zoe } = makeZoeKit(
+      makeFakeVatAdmin().admin,
+      zcfBundlecap,
+    );
 
     // Pack the contracts.
     const oracleBundle = await bundleSource(oraclePath);

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregatorChainlink.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregatorChainlink.js
@@ -10,7 +10,7 @@ import { E } from '@agoric/eventual-send';
 import { Far } from '@endo/marshal';
 import { makeIssuerKit, AssetKind, AmountMath } from '@agoric/ertp';
 
-import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
+import { makeFakeVatAdmin, zcfBundlecap } from '../../../tools/fakeVatAdmin.js';
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import buildManualTimer from '../../../tools/manualTimer.js';
 
@@ -46,7 +46,10 @@ test.before(
   /** @param {ExecutionContext} ot */ async ot => {
     // Outside of tests, we should use the long-lived Zoe on the
     // testnet. In this test, we must create a new Zoe.
-    const { zoeService: zoe } = makeZoeKit(makeFakeVatAdmin().admin);
+    const { zoeService: zoe } = makeZoeKit(
+      makeFakeVatAdmin().admin,
+      zcfBundlecap,
+    );
 
     // Pack the contracts.
     const oracleBundle = await bundleSource(oraclePath);

--- a/packages/zoe/test/unitTests/contracts/test-sellTickets.js
+++ b/packages/zoe/test/unitTests/contracts/test-sellTickets.js
@@ -8,7 +8,7 @@ import { assert } from '@agoric/assert';
 import bundleSource from '@endo/bundle-source';
 import { makeIssuerKit, AmountMath, isSetValue } from '@agoric/ertp';
 import { E } from '@agoric/eventual-send';
-import fakeVatAdmin from '../../../tools/fakeVatAdmin.js';
+import { fakeVatAdmin, zcfBundlecap } from '../../../tools/fakeVatAdmin.js';
 
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import { defaultAcceptanceMsg } from '../../../src/contractSupport/index.js';
@@ -21,7 +21,7 @@ const sellItemsRoot = `${dirname}/../../../src/contracts/sellItems.js`;
 
 test(`mint and sell tickets for multiple shows`, async t => {
   // Setup initial conditions
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin, zcfBundlecap);
 
   const mintAndSellNFTBundle = await bundleSource(mintAndSellNFTRoot);
   const mintAndSellNFTInstallation = await E(zoe).install(mintAndSellNFTBundle);
@@ -145,7 +145,7 @@ test(`mint and sell opera tickets`, async t => {
 
   const moola = value => AmountMath.make(moolaBrand, value);
 
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin, zcfBundlecap);
 
   const mintAndSellNFTBundle = await bundleSource(mintAndSellNFTRoot);
   const mintAndSellNFTInstallation = await E(zoe).install(mintAndSellNFTBundle);
@@ -538,7 +538,7 @@ test(`mint and sell opera tickets`, async t => {
 //
 test('Testing publicFacet.getAvailableItemsNotifier()', async t => {
   // Setup initial conditions
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin, zcfBundlecap);
 
   const mintAndSellNFTBundle = await bundleSource(mintAndSellNFTRoot);
   const mintAndSellNFTInstallation = await E(zoe).install(mintAndSellNFTBundle);

--- a/packages/zoe/test/unitTests/contracts/test-throwInOfferHandler.js
+++ b/packages/zoe/test/unitTests/contracts/test-throwInOfferHandler.js
@@ -8,7 +8,7 @@ import bundleSource from '@endo/bundle-source';
 
 import { E } from '@agoric/eventual-send';
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
-import fakeVatAdmin from '../../../tools/fakeVatAdmin.js';
+import { fakeVatAdmin, zcfBundlecap } from '../../../tools/fakeVatAdmin.js';
 
 const filename = new URL(import.meta.url).pathname;
 const dirname = path.dirname(filename);
@@ -16,7 +16,7 @@ const dirname = path.dirname(filename);
 const contractRoot = `${dirname}/throwInOfferHandler.js`;
 
 test('throw in offerHandler', async t => {
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin, zcfBundlecap);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/contracts/test-useObj.js
+++ b/packages/zoe/test/unitTests/contracts/test-useObj.js
@@ -9,7 +9,7 @@ import bundleSource from '@endo/bundle-source';
 import { E } from '@agoric/eventual-send';
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import { setup } from '../setupBasicMints.js';
-import fakeVatAdmin from '../../../tools/fakeVatAdmin.js';
+import { fakeVatAdmin, zcfBundlecap } from '../../../tools/fakeVatAdmin.js';
 
 const filename = new URL(import.meta.url).pathname;
 const dirname = path.dirname(filename);
@@ -19,7 +19,7 @@ const contractRoot = `${dirname}/useObjExample.js`;
 test('zoe - useObj', async t => {
   t.plan(3);
   const { moolaIssuer, moolaMint, moola } = setup();
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin, zcfBundlecap);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/setupBasicMints.js
+++ b/packages/zoe/test/unitTests/setupBasicMints.js
@@ -3,7 +3,7 @@
 import { makeIssuerKit, AmountMath } from '@agoric/ertp';
 import { makeStore } from '@agoric/store';
 import { makeZoeKit } from '../../src/zoeService/zoe.js';
-import fakeVatAdmin from '../../tools/fakeVatAdmin.js';
+import { fakeVatAdmin, zcfBundlecap } from '../../tools/fakeVatAdmin.js';
 
 const setup = () => {
   const moolaBundle = makeIssuerKit('moola');
@@ -21,7 +21,7 @@ const setup = () => {
     brands.init(k, allBundles[k].brand);
   }
 
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin, zcfBundlecap);
 
   /** @type {(brand: Brand) => (value: AmountValue) => Amount} */
   const makeSimpleMake = brand => value => AmountMath.make(brand, value);

--- a/packages/zoe/test/unitTests/setupMixedMints.js
+++ b/packages/zoe/test/unitTests/setupMixedMints.js
@@ -2,7 +2,7 @@
 
 import { makeIssuerKit, AmountMath, AssetKind } from '@agoric/ertp';
 import { makeZoeKit } from '../../src/zoeService/zoe.js';
-import fakeVatAdmin from '../../tools/fakeVatAdmin.js';
+import { fakeVatAdmin, zcfBundlecap } from '../../tools/fakeVatAdmin.js';
 
 const setupMixed = () => {
   const ccBundle = makeIssuerKit('CryptoCats', AssetKind.SET);
@@ -25,7 +25,7 @@ const setupMixed = () => {
   const cryptoCats = value => AmountMath.make(allBundles.cc.brand, value);
   const moola = value => AmountMath.make(allBundles.moola.brand, value);
 
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin, zcfBundlecap);
   return {
     zoe,
     ccIssuer,

--- a/packages/zoe/test/unitTests/setupNonFungibleMints.js
+++ b/packages/zoe/test/unitTests/setupNonFungibleMints.js
@@ -2,7 +2,7 @@
 
 import { makeIssuerKit, AmountMath, AssetKind } from '@agoric/ertp';
 import { makeZoeKit } from '../../src/zoeService/zoe.js';
-import fakeVatAdmin from '../../tools/fakeVatAdmin.js';
+import { fakeVatAdmin, zcfBundlecap } from '../../tools/fakeVatAdmin.js';
 
 const setupNonFungible = () => {
   const ccBundle = makeIssuerKit('CryptoCats', AssetKind.SET);
@@ -24,7 +24,7 @@ const setupNonFungible = () => {
   function createRpgItem(name, power, desc = undefined) {
     return harden([{ name, description: desc || name, power }]);
   }
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin, zcfBundlecap);
 
   const ccIssuer = ccBundle.issuer;
   const rpgIssuer = rpgBundle.issuer;

--- a/packages/zoe/test/unitTests/test-makeKind.js
+++ b/packages/zoe/test/unitTests/test-makeKind.js
@@ -9,7 +9,7 @@ import bundleSource from '@endo/bundle-source';
 
 import { E } from '@agoric/eventual-send';
 import { makeZoeKit } from '../../src/zoeService/zoe.js';
-import fakeVatAdmin from '../../tools/fakeVatAdmin.js';
+import { fakeVatAdmin, zcfBundlecap } from '../../tools/fakeVatAdmin.js';
 
 const filename = new URL(import.meta.url).pathname;
 const dirname = path.dirname(filename);
@@ -18,7 +18,7 @@ const root = `${dirname}/../minimalMakeKindContract.js`;
 
 test('makeKind non-swingset', async t => {
   const bundle = await bundleSource(root);
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin, zcfBundlecap);
   const installation = await E(zoe).install(bundle);
   t.notThrows(() => VatData.makeKind());
   t.notThrows(() => VatData.makeDurableKind());

--- a/packages/zoe/test/unitTests/test-scriptedOracle.js
+++ b/packages/zoe/test/unitTests/test-scriptedOracle.js
@@ -9,7 +9,7 @@ import bundleSource from '@endo/bundle-source';
 import { E } from '@agoric/eventual-send';
 
 import { assert } from '@agoric/assert';
-import { makeFakeVatAdmin } from '../../tools/fakeVatAdmin.js';
+import { makeFakeVatAdmin, zcfBundlecap } from '../../tools/fakeVatAdmin.js';
 import { makeZoeKit } from '../../src/zoeService/zoe.js';
 
 import '../../exported.js';
@@ -44,7 +44,10 @@ test.before(
   /** @param {ExecutionContext} ot */ async ot => {
     // Outside of tests, we should use the long-lived Zoe on the
     // testnet. In this test, we must create a new Zoe.
-    const { zoeService: zoe } = makeZoeKit(makeFakeVatAdmin().admin);
+    const { zoeService: zoe } = makeZoeKit(
+      makeFakeVatAdmin().admin,
+      zcfBundlecap,
+    );
 
     const oracleContractBundle = await bundleSource(oracleContractPath);
     const bountyContractBundle = await bundleSource(bountyContractPath);

--- a/packages/zoe/test/unitTests/zcf/setupZcfTest.js
+++ b/packages/zoe/test/unitTests/zcf/setupZcfTest.js
@@ -7,7 +7,7 @@ import { assert } from '@agoric/assert';
 import path from 'path';
 
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
-import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
+import { makeFakeVatAdmin, zcfBundlecap } from '../../../tools/fakeVatAdmin.js';
 
 const filename = new URL(import.meta.url).pathname;
 const dirname = path.dirname(filename);
@@ -33,7 +33,10 @@ export const setupZCFTest = async (issuerKeywordRecord, terms) => {
   };
   // The contract provides the `zcf` via `setTestJig` upon `start`.
   const fakeVatAdmin = makeFakeVatAdmin(setZCF);
-  const { zoeService: zoe, feeMintAccess } = makeZoeKit(fakeVatAdmin.admin);
+  const { zoeService: zoe, feeMintAccess } = makeZoeKit(
+    fakeVatAdmin.admin,
+    zcfBundlecap,
+  );
   const bundle = await bundleSource(contractRoot);
   const installation = await E(zoe).install(bundle);
   const { creatorFacet, instance } = await E(zoe).startInstance(

--- a/packages/zoe/test/unitTests/zcf/test-feeMintAccess.js
+++ b/packages/zoe/test/unitTests/zcf/test-feeMintAccess.js
@@ -11,7 +11,7 @@ import { AmountMath } from '@agoric/ertp';
 import bundleSource from '@endo/bundle-source';
 
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
-import fakeVatAdmin from '../../../tools/fakeVatAdmin.js';
+import { fakeVatAdmin, zcfBundlecap } from '../../../tools/fakeVatAdmin.js';
 
 const filename = new URL(import.meta.url).pathname;
 const dirname = path.dirname(filename);
@@ -19,7 +19,10 @@ const dirname = path.dirname(filename);
 const contractRoot = `${dirname}/registerFeeMintContract.js`;
 
 test(`feeMintAccess`, async t => {
-  const { zoeService: zoe, feeMintAccess } = makeZoeKit(fakeVatAdmin);
+  const { zoeService: zoe, feeMintAccess } = makeZoeKit(
+    fakeVatAdmin,
+    zcfBundlecap,
+  );
   const bundle = await bundleSource(contractRoot);
   const installation = await E(zoe).install(bundle);
   const { creatorFacet } = await E(zoe).startInstance(

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat-exit.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat-exit.js
@@ -9,7 +9,7 @@ import bundleSource from '@endo/bundle-source';
 
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import { setup } from '../setupBasicMints.js';
-import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
+import { makeFakeVatAdmin, zcfBundlecap } from '../../../tools/fakeVatAdmin.js';
 
 import '../../../exported.js';
 
@@ -28,7 +28,7 @@ test(`zoe - wrongly throw zcfSeat.exit()`, async t => {
     testJig = jig;
   };
   const { admin: fakeVatAdminSvc, vatAdminState } = makeFakeVatAdmin(setJig);
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdminSvc);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdminSvc, zcfBundlecap);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
@@ -9,7 +9,7 @@ import bundleSource from '@endo/bundle-source';
 
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import { setup } from '../setupBasicMints.js';
-import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
+import { makeFakeVatAdmin, zcfBundlecap } from '../../../tools/fakeVatAdmin.js';
 
 import '../../../exported.js';
 
@@ -25,7 +25,7 @@ test(`zoe - zcfSeat.fail() doesn't throw`, async t => {
     testJig = jig;
   };
   const { admin: fakeVatAdminSvc, vatAdminState } = makeFakeVatAdmin(setJig);
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdminSvc);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdminSvc, zcfBundlecap);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);

--- a/packages/zoe/test/unitTests/zoe/test-createZCFVat.js
+++ b/packages/zoe/test/unitTests/zoe/test-createZCFVat.js
@@ -11,22 +11,16 @@ test('setupCreateZCFVat', async t => {
   // This is difficult to unit test, since the real functionality
   // creates a new vat
 
+  const zcfBundlecap = Far('zcfBundlecap', {});
   const fakeVatAdminSvc = Far('fakeVatAdminSvc', {
-    createVatByName: _name => {
-      return harden({ adminNode: undefined, root: undefined });
-    },
-    createVat: _bundle => {
+    createVat: bundlecap => {
+      assert.equal(bundlecap, zcfBundlecap);
       return harden({ adminNode: undefined, root: undefined });
     },
   });
 
   // @ts-ignore fakeVatAdminSvc is mocked
-  t.deepEqual(await setupCreateZCFVat(fakeVatAdminSvc, undefined)(), {
-    adminNode: undefined,
-    root: undefined,
-  });
-  // @ts-ignore fakeVatAdminSvc is mocked
-  t.deepEqual(await setupCreateZCFVat(fakeVatAdminSvc, 'myVat')(), {
+  t.deepEqual(await setupCreateZCFVat(fakeVatAdminSvc, zcfBundlecap)(), {
     adminNode: undefined,
     root: undefined,
   });

--- a/packages/zoe/tools/fakeVatAdmin.js
+++ b/packages/zoe/tools/fakeVatAdmin.js
@@ -9,6 +9,9 @@ import { evalContractBundle } from '../src/contractFacet/evalContractCode.js';
 import { handlePKitWarning } from '../src/handleWarning.js';
 import zcfContractBundle from '../bundles/bundle-contractFacet.js';
 
+// this simulates a bundlecap, which is normally a swingset "device node"
+export const zcfBundlecap = Far('zcfBundlecap', {});
+
 /**
  * @param { (...args) => unknown } [testContextSetter]
  * @param { (x: unknown) => unknown } [makeRemote]
@@ -36,7 +39,9 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
   // test-only state can be provided from contracts
   // to their tests.
   const admin = Far('vatAdmin', {
-    createVat: bundle => {
+    createVat: bundlecap => {
+      assert.equal(bundlecap, zcfBundlecap, 'fakeVatAdmin only creates ZCF');
+      const bundle = zcfContractBundle;
       return harden({
         root: makeRemote(
           E(evalContractBundle(bundle)).buildRootObject(
@@ -55,10 +60,6 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
         }),
       });
     },
-    createVatByName: name => {
-      assert.equal(name, 'zcf', `only name='zcf' accepted, not ${name}`);
-      return admin.createVat(zcfContractBundle);
-    },
   });
   const vatAdminState = {
     getExitMessage: () => exitMessage,
@@ -71,4 +72,4 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
 const fakeVatAdmin = makeFakeVatAdmin().admin;
 
 export default fakeVatAdmin;
-export { makeFakeVatAdmin };
+export { makeFakeVatAdmin, fakeVatAdmin };


### PR DESCRIPTION
fix(zoe)!: makeZoeKit() now requires a zcfBundlecap

Zoe needs access to the vatAdminSvc, to create a new ZCF vat to host each
contract. Previously, Zoe did E(vatAdminSvc).createVatByName('zcf'), and
assumed that vatAdminSvc had access to a vat source bundle by that name. Now,
whoever calls makeZoeKit() is obligated to provide Zoe with the right
bundlecap, and Zoe does E(vatAdminSvc).createVat(zcfBundlecap). This makes
things more explicit.

This changes the signature of `makeZoeKit()` in a non-backwards-compatible
way: the `zcfBundlecap` argument is now mandatory, and thus appears second,
replacing the old optional fourth-position `zcfBundleName`.

Swingset-based unit tests that use Zoe generally follow a pattern where
`vat-zoe.js` holds the `makeZoeKit()` call, and `bootstrap.js` sends vat-zoe
a `buildZoe(vatAdminSvc)` message. Those need to change: bootstrap should use
`D(devices.bundle).getNamedBundleCap('zcf')` to get the `zcfBundlecap`, and
send it through `buildZoe()`. vat-zoe should be changed to pass
`zcfBundlecap` into `makeZoeKit()`.

A similar pattern should be used in actual deployments.

Non-swingset-based zoe-using unit tests generally use `fakeVatAdmin.js` to
build a mock `vatAdminSvc`. This commit changes `fakeVatAdmin.js` to include
an additional `zcfBundlecap` export, which is an empty marker object that
serves as a stand-in for the bundlecap. The fake `vatAdminSvc` can accept
this fake `zcfBundlecap`, and will evaluate the ZCF code appropriately.

Downstream module owners should grep their source code for `makeZoeKit` and
`fakeVatAdmin` to find the calls that need updating.

refs #4487