### PR TITLE
style: loosen some eslint rules

### DIFF
--- a/packages/SwingSet/src/vats/network/bytes.js
+++ b/packages/SwingSet/src/vats/network/bytes.js
@@ -3,7 +3,6 @@
 import './types.js';
 import { encodeBase64, decodeBase64 } from '@endo/base64';
 
-/* eslint-disable no-bitwise */
 /**
  * Convert some data to bytes.
  *

--- a/packages/SwingSet/test/test-vat-env.js
+++ b/packages/SwingSet/test/test-vat-env.js
@@ -23,7 +23,6 @@ function makeThingInnards(_state) {
 }
 
 test('kind makers are in the test environment', t => {
-  // eslint-disable-next-line no-undef
   const makeVThing = VatData.makeKind(makeThingInnards);
   const vthing = makeVThing('vthing');
   t.is(vthing.ping(), 4);
@@ -35,7 +34,6 @@ test('kind makers are in the test environment', t => {
 
 test('store makers are in the test environment', t => {
   // TODO: configure eslint to know that VatData is a global
-  // eslint-disable-next-line no-undef
   const o = harden({ size: 10, color: 'blue' });
 
   const m = VatData.makeScalarBigMapStore();

--- a/packages/SwingSet/test/vat-admin/broken-vat.js
+++ b/packages/SwingSet/test/vat-admin/broken-vat.js
@@ -1,4 +1,4 @@
+/* global missing */
 export function buildRootObject(_vatPowers) {
-  // eslint-disable-next-line no-undef
   return missing({});
 }

--- a/packages/eslint-config/eslint-config.json
+++ b/packages/eslint-config/eslint-config.json
@@ -25,6 +25,7 @@
       }
     ],
     "no-bitwise": "off", // type checker will catch these errors
+    "no-plusplus": "off", // we have consistent whitespace
     "prettier/prettier": "warn" // @jessie.js/recommended errors. This repo checks format separately but keeps warn to maintain that "eslint --fix" prettifies
   },
   "settings": {

--- a/packages/eslint-config/eslint-config.json
+++ b/packages/eslint-config/eslint-config.json
@@ -26,6 +26,7 @@
     ],
     "no-bitwise": "off", // type checker will catch these errors
     "no-plusplus": "off", // we have consistent whitespace
+    "no-underscore-dangle": "off", // we use them
     "no-use-before-define": "warn", // readability consideration, needn't fail CI
     "prettier/prettier": "warn" // @jessie.js/recommended errors. This repo checks format separately but keeps warn to maintain that "eslint --fix" prettifies
   },

--- a/packages/eslint-config/eslint-config.json
+++ b/packages/eslint-config/eslint-config.json
@@ -26,6 +26,7 @@
     ],
     "no-bitwise": "off", // type checker will catch these errors
     "no-plusplus": "off", // we have consistent whitespace
+    "no-use-before-define": "warn", // readability consideration, needn't fail CI
     "prettier/prettier": "warn" // @jessie.js/recommended errors. This repo checks format separately but keeps warn to maintain that "eslint --fix" prettifies
   },
   "settings": {

--- a/packages/eslint-config/eslint-config.json
+++ b/packages/eslint-config/eslint-config.json
@@ -24,6 +24,7 @@
         ]
       }
     ],
+    "no-bitwise": "off", // type checker will catch these errors
     "prettier/prettier": "warn" // @jessie.js/recommended errors. This repo checks format separately but keeps warn to maintain that "eslint --fix" prettifies
   },
   "settings": {

--- a/packages/eventual-send/test/test-eventual-send.js
+++ b/packages/eventual-send/test/test-eventual-send.js
@@ -1,4 +1,4 @@
-/* global setTimeout */
+/* global setTimeout, window */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from './prepare-test-env-ava.js';
 
@@ -9,7 +9,6 @@ const { details: X } = assert;
 
 if (typeof window !== 'undefined') {
   // Let the browser detect when the tests are done.
-  /* eslint-disable-next-line no-undef */
   window.testDonePromise = new Promise(resolve => {
     test.onFinish(() => {
       // Allow the summary to be printed.

--- a/packages/notifier/src/subscriber.js
+++ b/packages/notifier/src/subscriber.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle */
 // @ts-check
 /// <reference types="ses"/>
 

--- a/packages/solo/src/web.js
+++ b/packages/solo/src/web.js
@@ -54,7 +54,6 @@ const verifyToken = (actual, expected) => {
   // The bitwise operations here and fixed loop length are necessary to
   // guarantee constant time.
   for (let i = 0; i < expectedLength; i += 1) {
-    // eslint-disable-next-line no-bitwise
     failed |= stringToCompare.charCodeAt(i) ^ expected.charCodeAt(i);
   }
 

--- a/packages/solo/src/web.js
+++ b/packages/solo/src/web.js
@@ -295,7 +295,6 @@ export async function makeHTTPListener(
         obj = JSON.parse(message);
         const res = await inboundCommand(obj, meta, id);
 
-        // eslint-disable-next-line no-use-before-define
         sendJSON({ ...res, meta });
       } catch (error) {
         inboundCommand(

--- a/packages/sparse-ints/src/sparseInts.js
+++ b/packages/sparse-ints/src/sparseInts.js
@@ -14,7 +14,6 @@ function* generateSparseInts(seed) {
   // Thus, it is totally deterministic, but at least looks a little random
   // and so can be used for e.g., colors in a game or the gallery
 
-  /* eslint-disable no-bitwise */
   const mask = 0xffffffff;
   const startState = Math.floor(seed * mask) ^ 0xdeadbeef;
   let lfsr = startState;
@@ -25,7 +24,6 @@ function* generateSparseInts(seed) {
     const rand = (Math.floor(lfsr) % 0x800000) + 0x7fffff;
     yield rand;
   }
-  /* eslint-enable no-bitwise */
 }
 harden(generateSparseInts);
 export { generateSparseInts };

--- a/packages/store/src/patterns/encodeKey.js
+++ b/packages/store/src/patterns/encodeKey.js
@@ -58,11 +58,8 @@ const numberToDBEntryKey = n => {
   asNumber[0] = n;
   let bits = asBits[0];
   if (n < 0) {
-    // XXX Why is the no-bitwise lint rule even a thing??
-    // eslint-disable-next-line no-bitwise
     bits ^= 0xffffffffffffffffn;
   } else {
-    // eslint-disable-next-line no-bitwise
     bits ^= 0x8000000000000000n;
   }
   return `f${zeroPad(bits.toString(16), 16)}`;
@@ -71,10 +68,8 @@ const numberToDBEntryKey = n => {
 const dbEntryKeyToNumber = k => {
   let bits = BigInt(`0x${k.substring(1)}`);
   if (k[1] < '8') {
-    // eslint-disable-next-line no-bitwise
     bits ^= 0xffffffffffffffffn;
   } else {
-    // eslint-disable-next-line no-bitwise
     bits ^= 0x8000000000000000n;
   }
   asBits[0] = bits;

--- a/packages/store/test/test-encodeKey.js
+++ b/packages/store/test/test-encodeKey.js
@@ -1,6 +1,5 @@
 // @ts-check
 /* global BigUint64Array */
-/* eslint-disable no-bitwise */
 
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 import { isKey } from '../src/keys/checkKey.js';

--- a/packages/vats/src/crc.js
+++ b/packages/vats/src/crc.js
@@ -7,7 +7,6 @@
  * down to a version that assumes TypedArrays are universal.
  */
 // @ts-check
-/* eslint-disable no-bitwise */
 
 /**
  * @typedef {string | number | Uint8Array | ArrayBuffer} Data

--- a/packages/vats/test/test-distributeFees.js
+++ b/packages/vats/test/test-distributeFees.js
@@ -1,5 +1,5 @@
 // @ts-check
-
+/* global setImmediate */
 import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
 
 import { AmountMath } from '@agoric/ertp';
@@ -16,7 +16,6 @@ import { buildDistributor } from '../src/distributeFees.js';
 // have all their callbacks run
 async function waitForPromisesToSettle() {
   const pk = makePromiseKit();
-  // eslint-disable-next-line no-undef
   setImmediate(pk.resolve);
   return pk.promise;
 }

--- a/packages/xsnap/src/avaHandler.js
+++ b/packages/xsnap/src/avaHandler.js
@@ -73,8 +73,6 @@ function handler(rawMessage) {
     case 'loadScript': {
       const { source } = msg;
       const virtualObjectGlobals =
-        // @ts-ignore
-        // eslint-disable-next-line no-undef
         typeof VatData !== 'undefined' ? { VatData } : {};
       // @ts-ignore How do I get ses types in scope?!?!?!
       const c = new Compartment({

--- a/packages/xsnap/test/test-gc.js
+++ b/packages/xsnap/test/test-gc.js
@@ -27,7 +27,6 @@ function makeVictim() {
 }
 
 async function provokeGC(myGC) {
-  // eslint-disable-next-line no-undef
   const gcAndFinalize = makeGcAndFinalize(myGC);
   // the transition from REACHABLE to UNREACHABLE happens as soon as makeVictim()
   // finishes, and the local 'victim' binding goes out of scope

--- a/packages/xsnap/test/test-xs-perf.js
+++ b/packages/xsnap/test/test-xs-perf.js
@@ -183,7 +183,6 @@ test('metering switch - start compartment only', async t => {
 
 /** @param {number} logn */
 function dataStructurePerformance(logn) {
-  // eslint-disable-next-line no-bitwise
   const n = 1 << logn;
   // @ts-ignore
   // eslint-disable-next-line no-undef

--- a/packages/xsnap/test/test-xs-perf.js
+++ b/packages/xsnap/test/test-xs-perf.js
@@ -1,4 +1,4 @@
-/* global performance */
+/* global performance, issueCommand */
 // @ts-check
 
 import '@endo/init';
@@ -185,7 +185,6 @@ test('metering switch - start compartment only', async t => {
 function dataStructurePerformance(logn) {
   const n = 1 << logn;
   // @ts-ignore
-  // eslint-disable-next-line no-undef
   const send = it => issueCommand(ArrayBuffer.fromString(JSON.stringify(it)));
   const t0 = performance.now();
   for (let i = 0; i < 256; i += 1) {


### PR DESCRIPTION
## Description

Some of the eslint rules imported this codebase doesn't really follow. See commits for examples. Having inline lint disabling works against the point of having lint rules. The ones we don't consider errors we shouldn't check for.

This disables:
- no-bitwise
- no-plusplus
- no-underscore-dangle

Sometimes it's worth drawing attention not worth failing the build. For that, a warning instead of error:
- no-use-before-define

Note that `packages/web-components` doesn't use the shared eslint config.

### Security Considerations

--

### Documentation Considerations

--

### Testing Considerations

--