### PR TITLE
test(run-protocol):  balancesToReachRatio calculations are to spec (WIP)

### DIFF
--- a/packages/run-protocol/package.json
+++ b/packages/run-protocol/package.json
@@ -51,6 +51,7 @@
     "@endo/init": "^0.5.33",
     "ava": "^3.12.1",
     "c8": "^7.7.2",
+    "fast-check": "^2.21.0",
     "import-meta-resolve": "^1.1.1"
   },
   "files": [

--- a/packages/run-protocol/src/vpool-xyk-amm/addLiquidity.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/addLiquidity.js
@@ -1,9 +1,15 @@
 // @ts-check
 
-import { assertProposalShape } from '@agoric/zoe/src/contractSupport/index.js';
+import {
+  assertProposalShape,
+  calcSecondaryRequired,
+  natSafeMath,
+} from '@agoric/zoe/src/contractSupport/index.js';
+import { AmountMath } from '@agoric/ertp';
 
 import '@agoric/zoe/exported.js';
 
+const { add, multiply } = natSafeMath;
 /**
  * @param {ContractFacet} zcf
  * @param {(brand: Brand) => XYKPool} getPool
@@ -25,6 +31,146 @@ export const makeMakeAddLiquidityInvitation = (zcf, getPool) => {
 
   const makeAddLiquidityInvitation = () =>
     zcf.makeInvitation(addLiquidity, 'multipool amm add liquidity');
+
+  return makeAddLiquidityInvitation;
+};
+
+/**
+ * The pool has poolX and poolY currently. The user wants to add liquidity of
+ * giveX and giveY, but the ratios are probably not the same. We want to adjust
+ * the pool to have the ratio (poolX + giveX) / (poolY + giveY), without
+ * changing K, the product of the two sides.
+ *
+ * Calculate targetX and targetY, which multiply to the same product as
+ * poolX * poolY, but are in the ratio we'll end at. From this we can produce
+ * a proposed trade that maintains K, but changes the ratio, so we can add
+ * liquidity at the desired ratio.
+ *
+ * endX = poolX + giveX;   endY = poolY + giveY
+ * desiredRatio = endX / endY
+ * targetY = sqrt(startK / desiredRatio)
+ * targetX = desiredRatio * targetY
+ *   so targetK equals startK because we square targetY
+ * targetK = targetX * targetY = desiredRatio * (startK / desiredRatio)
+ *
+ * Since startK/endK is less than one, and we have to worry about early loss of
+ * precision, we round and convert to bigint as the last step
+ *
+ * @param {Amount} poolX
+ * @param {Amount} poolY
+ * @param {Amount} giveX
+ * @param {Amount} giveY
+ * @returns {{newX: Amount, newY: Amount }}
+ */
+export const balancesToReachRatio = (poolX, poolY, giveX, giveY) => {
+  const startK = multiply(poolX.value, poolY.value);
+  const endX = add(poolX.value, giveX.value);
+  const endY = add(poolY.value, giveY.value);
+  const desiredRatio = Number(endX) / Number(endY);
+  const targetY = Math.sqrt(Number(startK) / desiredRatio);
+  const targetX = targetY * desiredRatio;
+
+  return {
+    newX: AmountMath.make(poolX.brand, BigInt(Math.trunc(targetX))),
+    newY: AmountMath.make(poolY.brand, BigInt(Math.trunc(targetY))),
+  };
+};
+
+export const makeMakeAddLiquidityAtRateInvitation = (
+  zcf,
+  getPool,
+  provideVPool,
+  feeSeat,
+) => {
+  const addLiquidityAtRate = seat => {
+    assertProposalShape(seat, {
+      give: {
+        Central: null,
+        Secondary: null,
+      },
+      want: { Liquidity: null },
+    });
+
+    const giveAlloc = seat.getProposal().give;
+    const secondaryAmount = giveAlloc.Secondary;
+    const secondaryBrand = secondaryAmount.brand;
+    const centralBrand = giveAlloc.Central.brand;
+    const pool = getPool(secondaryBrand);
+    // Step 1: trade to adjust the pool's price
+    //   A  figure out the ratio of the inputs
+    //   B  figure out how X*Y changes to reach that ratio (ignoring fees)
+    const centralPoolAmount = pool.getCentralAmount();
+    const secondaryPoolAmount = pool.getSecondaryAmount();
+
+    if (
+      AmountMath.isEmpty(centralPoolAmount) &&
+      AmountMath.isEmpty(secondaryPoolAmount)
+    ) {
+      return pool.addLiquidity(seat);
+    }
+
+    const { newX: newCentral, newY: newSecondary } = balancesToReachRatio(
+      centralPoolAmount,
+      secondaryPoolAmount,
+      giveAlloc.Central,
+      giveAlloc.Secondary,
+    );
+
+    const vPool = provideVPool(secondaryBrand).internalFacet;
+    const poolSeat = pool.getPoolSeat();
+    function transferForTrade(prices, incrementKey, decrementKey) {
+      seat.decrementBy(harden({ [incrementKey]: prices.swapperGives }));
+      seat.incrementBy(harden({ [decrementKey]: prices.swapperGets }));
+      feeSeat.incrementBy(harden({ RUN: prices.protocolFee }));
+      poolSeat.incrementBy(harden({ [incrementKey]: prices.xIncrement }));
+      poolSeat.decrementBy(harden({ [decrementKey]: prices.yDecrement }));
+    }
+
+    //   1C  Stage the changes for the trade
+    if (AmountMath.isGTE(newCentral, centralPoolAmount)) {
+      const prices = vPool.getPriceForOutput(
+        AmountMath.makeEmpty(centralBrand),
+        AmountMath.subtract(secondaryPoolAmount, newSecondary),
+      );
+      transferForTrade(prices, 'Central', 'Secondary');
+    } else {
+      const prices = vPool.getPriceForInput(
+        AmountMath.subtract(newSecondary, secondaryPoolAmount),
+        AmountMath.makeEmpty(centralBrand),
+      );
+      transferForTrade(prices, 'Secondary', 'Central');
+    }
+
+    // Step 2: add remaining liquidity
+    const stagedAllocation = poolSeat.getStagedAllocation();
+    const centralPoolAfterTrade = stagedAllocation.Central;
+    const secondaryPoolAfterTrade = stagedAllocation.Secondary;
+    const userAllocation = seat.getStagedAllocation();
+
+    const secondaryRequired = AmountMath.make(
+      secondaryBrand,
+      calcSecondaryRequired(
+        userAllocation.Central.value,
+        centralPoolAfterTrade.value,
+        secondaryPoolAfterTrade.value,
+        userAllocation.Secondary.value,
+      ),
+    );
+
+    return vPool.addLiquidityActual(
+      pool,
+      seat,
+      secondaryRequired,
+      poolSeat.getStagedAllocation().Central,
+      feeSeat,
+    );
+  };
+
+  const makeAddLiquidityInvitation = () =>
+    zcf.makeInvitation(
+      addLiquidityAtRate,
+      'multipool amm add liquidity at rate',
+    );
 
   return makeAddLiquidityInvitation;
 };

--- a/packages/run-protocol/src/vpool-xyk-amm/doublePool.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/doublePool.js
@@ -27,7 +27,7 @@ const publicPrices = prices => {
  * @param {() => bigint} getProtocolFeeBP - retrieve governed protocol fee value
  * @param {() => bigint} getPoolFeeBP - retrieve governed pool fee value
  * @param {ZCFSeat} feeSeat
- * @returns {VPool}
+ * @returns {VPoolWrapper<VPoolInternalFacet>}
  */
 export const makeDoublePool = (
   zcf,
@@ -63,7 +63,7 @@ export const makeDoublePool = (
     inPoolSeat.incrementBy(harden({ Secondary: prices.inPoolIncrement }));
     inPoolSeat.decrementBy(harden({ Central: prices.inPoolDecrement }));
     outPoolSeat.incrementBy(harden({ Central: prices.outPoolIncrement }));
-    outPoolSeat.decrementBy(harden({ Secondary: prices.outpoolDecrement }));
+    outPoolSeat.decrementBy(harden({ Secondary: prices.outPoolDecrement }));
 
     zcf.reallocate(outPoolSeat, inPoolSeat, feeSeat, seat);
     seat.exit();
@@ -115,7 +115,7 @@ export const makeDoublePool = (
       inPoolIncrement: finalInPoolPrices.xIncrement,
       inPoolDecrement: finalInPoolPrices.yDecrement,
       outPoolIncrement: outPoolPrices.xIncrement,
-      outpoolDecrement: outPoolPrices.yDecrement,
+      outPoolDecrement: outPoolPrices.yDecrement,
       protocolFee: AmountMath.add(
         finalInPoolPrices.protocolFee,
         outPoolPrices.protocolFee,
@@ -176,7 +176,7 @@ export const makeDoublePool = (
       inPoolIncrement: inpoolPrices.xIncrement,
       inPoolDecrement: inpoolPrices.yDecrement,
       outPoolIncrement: finalOutpoolPrices.xIncrement,
-      outpoolDecrement: finalOutpoolPrices.yDecrement,
+      outPoolDecrement: finalOutpoolPrices.yDecrement,
       protocolFee: AmountMath.add(
         finalOutpoolPrices.protocolFee,
         inpoolPrices.protocolFee,
@@ -192,10 +192,17 @@ export const makeDoublePool = (
     return allocateGainsAndLosses(seat, prices);
   };
 
-  return Far('double pool', {
+  const externalFacet = Far('double pool', {
     getInputPrice,
     getOutputPrice,
     swapIn,
     swapOut,
   });
+
+  const internalFacet = Far('single pool', {
+    getPriceForInput,
+    getPriceForOutput,
+  });
+
+  return { externalFacet, internalFacet };
 };

--- a/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/multipoolMarketMaker.js
@@ -8,7 +8,10 @@ import { CONTRACT_ELECTORATE, handleParamGovernance } from '@agoric/governance';
 
 import { assertIssuerKeywords } from '@agoric/zoe/src/contractSupport/index.js';
 import { makeAddPool } from './pool.js';
-import { makeMakeAddLiquidityInvitation } from './addLiquidity.js';
+import {
+  makeMakeAddLiquidityInvitation,
+  makeMakeAddLiquidityAtRateInvitation,
+} from './addLiquidity.js';
 import { makeMakeRemoveLiquidityInvitation } from './removeLiquidity.js';
 
 import '@agoric/zoe/exported.js';
@@ -176,7 +179,7 @@ const start = async (zcf, privateArgs) => {
   /**
    * @param {Brand} brandIn
    * @param {Brand} brandOut
-   * @returns {VPool}
+   * @returns {VPoolWrapper<unknown>}
    */
   const provideVPool = (brandIn, brandOut) => {
     if (isSecondary(brandIn) && isSecondary(brandOut)) {
@@ -195,11 +198,11 @@ const start = async (zcf, privateArgs) => {
   };
 
   const getInputPrice = (amountIn, amountOut) => {
-    const pool = provideVPool(amountIn.brand, amountOut.brand);
+    const pool = provideVPool(amountIn.brand, amountOut.brand).externalFacet;
     return pool.getInputPrice(amountIn, amountOut);
   };
   const getOutputPrice = (amountIn, amountOut) => {
-    const pool = provideVPool(amountIn.brand, amountOut.brand);
+    const pool = provideVPool(amountIn.brand, amountOut.brand).externalFacet;
     return pool.getOutputPrice(amountIn, amountOut);
   };
 
@@ -208,6 +211,12 @@ const start = async (zcf, privateArgs) => {
   const makeAddLiquidityInvitation = makeMakeAddLiquidityInvitation(
     zcf,
     getPool,
+  );
+  const makeAddLiquidityAtRateInvitation = makeMakeAddLiquidityAtRateInvitation(
+    zcf,
+    getPool,
+    provideVPool,
+    protocolSeat,
   );
 
   const makeRemoveLiquidityInvitation = makeMakeRemoveLiquidityInvitation(
@@ -235,6 +244,7 @@ const start = async (zcf, privateArgs) => {
       makeSwapInInvitation,
       makeSwapOutInvitation,
       makeAddLiquidityInvitation,
+      makeAddLiquidityAtRateInvitation,
       makeRemoveLiquidityInvitation,
       getQuoteIssuer: () => quoteIssuerKit.issuer,
       getPriceAuthorities,

--- a/packages/run-protocol/src/vpool-xyk-amm/pool.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/pool.js
@@ -57,14 +57,20 @@ export const makeAddPool = (
         secondary: pool.getSecondaryAmount(),
       });
 
-    const addLiquidityActual = (pool, zcfSeat, secondaryAmount) => {
+    const addLiquidityActual = (
+      pool,
+      zcfSeat,
+      secondaryAmount,
+      poolCentralAmount,
+      feeSeat,
+    ) => {
       // addLiquidity can't be called until the pool has been created. We verify
       // that the asset is NAT before creating a pool.
 
       const liquidityValueOut = calcLiqValueToMint(
         liqTokenSupply,
-        zcfSeat.getAmountAllocated('Central').value,
-        pool.getCentralAmount().value,
+        zcfSeat.getStagedAllocation().Central.value,
+        poolCentralAmount.value,
       );
 
       const liquidityAmountOut = AmountMath.make(
@@ -80,7 +86,7 @@ export const makeAddPool = (
       poolSeat.incrementBy(
         zcfSeat.decrementBy(
           harden({
-            Central: zcfSeat.getCurrentAllocation().Central,
+            Central: zcfSeat.getStagedAllocation().Central,
             Secondary: secondaryAmount,
           }),
         ),
@@ -89,7 +95,11 @@ export const makeAddPool = (
       zcfSeat.incrementBy(
         poolSeat.decrementBy(harden({ Liquidity: liquidityAmountOut })),
       );
-      zcf.reallocate(poolSeat, zcfSeat);
+      if (feeSeat) {
+        zcf.reallocate(poolSeat, zcfSeat, feeSeat);
+      } else {
+        zcf.reallocate(poolSeat, zcfSeat);
+      }
       zcfSeat.exit();
       updateState(pool);
       return 'Added liquidity.';
@@ -106,39 +116,39 @@ export const makeAddPool = (
         poolSeat.getAmountAllocated('Secondary', secondaryBrand),
 
       addLiquidity: zcfSeat => {
+        const centralIn = zcfSeat.getStagedAllocation().Central;
+        assert(isNatValue(centralIn.value), 'User Central');
+        const secondaryIn = zcfSeat.getStagedAllocation().Secondary;
+        assert(isNatValue(secondaryIn.value), 'User Secondary');
+
         if (liqTokenSupply === 0n) {
-          const userAllocation = zcfSeat.getCurrentAllocation();
-          return addLiquidityActual(pool, zcfSeat, userAllocation.Secondary);
+          return addLiquidityActual(pool, zcfSeat, secondaryIn, centralIn);
         }
 
-        const userAllocation = zcfSeat.getCurrentAllocation();
-        const secondaryIn = userAllocation.Secondary;
-        const centralAmount = pool.getCentralAmount();
-        const secondaryAmount = pool.getSecondaryAmount();
-        assert(isNatValue(userAllocation.Central.value), 'User Central');
-        assert(isNatValue(centralAmount.value), 'Pool Central');
-        assert(isNatValue(secondaryAmount.value), 'Pool Secondary');
-        assert(isNatValue(secondaryIn.value), 'User Secondary');
+        const centralPoolAmount = pool.getCentralAmount();
+        const secondaryPoolAmount = pool.getSecondaryAmount();
+        assert(isNatValue(centralPoolAmount.value), 'Pool Central');
+        assert(isNatValue(secondaryPoolAmount.value), 'Pool Secondary');
 
         // To calculate liquidity, we'll need to calculate alpha from the primary
         // token's value before, and the value that will be added to the pool
-        const secondaryOut = AmountMath.make(
+        const secondaryRequired = AmountMath.make(
           secondaryBrand,
           calcSecondaryRequired(
-            userAllocation.Central.value,
-            centralAmount.value,
-            secondaryAmount.value,
+            centralIn.value,
+            centralPoolAmount.value,
+            secondaryPoolAmount.value,
             secondaryIn.value,
           ),
         );
 
         // Central was specified precisely so offer must provide enough secondary.
         assert(
-          AmountMath.isGTE(secondaryIn, secondaryOut),
+          AmountMath.isGTE(secondaryIn, secondaryRequired),
           'insufficient Secondary deposited',
         );
 
-        return addLiquidityActual(pool, zcfSeat, secondaryOut);
+        return addLiquidityActual(pool, zcfSeat, secondaryRequired, centralIn);
       },
       removeLiquidity: userSeat => {
         const liquidityIn = userSeat.getAmountAllocated(
@@ -200,12 +210,19 @@ export const makeAddPool = (
       getProtocolFeeBP,
       getPoolFeeBP,
       protocolSeat,
+      addLiquidityActual,
     );
 
     const getInputPriceForPA = (amountIn, brandOut) =>
-      vPool.getInputPrice(amountIn, AmountMath.makeEmpty(brandOut));
+      vPool.externalFacet.getInputPrice(
+        amountIn,
+        AmountMath.makeEmpty(brandOut),
+      );
     const getOutputPriceForPA = (brandIn, amountout) =>
-      vPool.getInputPrice(AmountMath.makeEmpty(brandIn), amountout);
+      vPool.externalFacet.getInputPrice(
+        AmountMath.makeEmpty(brandIn),
+        amountout,
+      );
 
     const toCentralPriceAuthority = makePriceAuthority(
       getInputPriceForPA,

--- a/packages/run-protocol/src/vpool-xyk-amm/singlePool.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/singlePool.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { Far } from '@endo/marshal';
-import { makeFeeRatio } from './constantProduct/calcFees';
+import { makeFeeRatio } from './constantProduct/calcFees.js';
 import {
   pricesForStatedInput,
   pricesForStatedOutput,
@@ -13,7 +13,8 @@ import {
  * @param {() => bigint} getProtocolFeeBP - retrieve governed protocol fee value
  * @param {() => bigint} getPoolFeeBP - retrieve governed pool fee value
  * @param {ZCFSeat} feeSeat
- * @returns {VPool}
+ * @param {AddLiquidityActual} addLiquidityActual
+ * @returns {VPoolWrapper<SinglePoolInternalFacet>}
  */
 export const makeSinglePool = (
   zcf,
@@ -21,6 +22,7 @@ export const makeSinglePool = (
   getProtocolFeeBP,
   getPoolFeeBP,
   feeSeat,
+  addLiquidityActual,
 ) => {
   const secondaryBrand = pool.getSecondaryAmount().brand;
   const centralBrand = pool.getCentralAmount().brand;
@@ -83,7 +85,7 @@ export const makeSinglePool = (
   };
 
   /** @type {VPool} */
-  return Far('single pool', {
+  const externalFacet = Far('single pool', {
     getInputPrice: (amountIn, amountOut) =>
       publicPrices(getPriceForInput(amountIn, amountOut)),
     getOutputPrice: (amountIn, amountOut) =>
@@ -91,4 +93,12 @@ export const makeSinglePool = (
     swapIn,
     swapOut,
   });
+
+  const internalFacet = Far('single pool', {
+    getPriceForInput,
+    getPriceForOutput,
+    addLiquidityActual,
+  });
+
+  return { externalFacet, internalFacet };
 };

--- a/packages/run-protocol/src/vpool-xyk-amm/swap.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/swap.js
@@ -6,7 +6,7 @@ import '@agoric/zoe/exported.js';
 
 /**
  * @param {ContractFacet} zcf
- * @param {(brandIn: Brand, brandOut: Brand) => VPool} provideVPool
+ * @param {(brandIn: Brand, brandOut: Brand) => VPoolWrapper<unknown>} provideVPool
  */
 export const makeMakeSwapInvitation = (zcf, provideVPool) => {
   // trade with a stated amountIn.
@@ -19,7 +19,7 @@ export const makeMakeSwapInvitation = (zcf, provideVPool) => {
       give: { In: amountIn },
       want: { Out: amountOut },
     } = seat.getProposal();
-    const pool = provideVPool(amountIn.brand, amountOut.brand);
+    const pool = provideVPool(amountIn.brand, amountOut.brand).externalFacet;
     return pool.swapIn(seat, amountIn, amountOut);
   };
 
@@ -34,7 +34,7 @@ export const makeMakeSwapInvitation = (zcf, provideVPool) => {
       give: { In: amountIn },
       want: { Out: amountOut },
     } = seat.getProposal();
-    const pool = provideVPool(amountIn.brand, amountOut.brand);
+    const pool = provideVPool(amountIn.brand, amountOut.brand).externalFacet;
     return pool.swapOut(seat, amountIn, amountOut);
   };
 

--- a/packages/run-protocol/src/vpool-xyk-amm/types.js
+++ b/packages/run-protocol/src/vpool-xyk-amm/types.js
@@ -15,6 +15,61 @@
  */
 
 /**
+ * @typedef {Object} DoublePoolSwapResult
+ * @property {Amount} swapperGives
+ * @property {Amount} swapperGets
+ * @property {Amount} inPoolIncrement
+ * @property {Amount} inPoolDecrement
+ * @property {Amount} outPoolIncrement
+ * @property {Amount} outPoolDecrement
+ * @property {Amount} protocolFee
+ */
+
+/**
+ * @callback GetDoublePoolSwapQuote
+ * @param {Amount} amountIn
+ * @param {Amount} amountOut
+ * @returns {DoublePoolSwapResult}
+ */
+
+/**
+ * @callback GetSinglePoolSwapQuote
+ * @param {Amount} amountIn
+ * @param {Amount} amountOut
+ * @returns {SwapResult}
+ */
+
+/**
+ * @typedef {Object} VPoolInternalFacet - virtual pool for price quotes and trading
+ * @property {GetDoublePoolSwapQuote} getPriceForInput
+ * @property {GetDoublePoolSwapQuote} getPriceForOutput
+ */
+
+/**
+ * @callback AddLiquidityActual
+ * @param {XYKPool} pool
+ * @param {ZCFSeat} zcfSeat
+ * @param {Amount} secondaryAmount
+ * @param {Amount} poolCentralAmount
+ * @param {ZCFSeat} feeSeat
+ * @returns {string}
+ */
+
+/**
+ * @typedef {Object} SinglePoolInternalFacet
+ * @property {GetSinglePoolSwapQuote} getPriceForInput
+ * @property {GetSinglePoolSwapQuote} getPriceForOutput
+ * @property {AddLiquidityActual} addLiquidityActual
+ */
+
+/**
+ * @template T
+ * @typedef {Object} VPoolWrapper - wrapper holding external and internal facets
+ * @property {VPool} externalFacet
+ * @property {T} internalFacet
+ */
+
+/**
  * @typedef {Object} XYKPool
  * @property {() => bigint} getLiquiditySupply
  * @property {() => Issuer} getLiquidityIssuer
@@ -27,7 +82,7 @@
  * @property {() => void} updateState
  * @property {() => PriceAuthority} getToCentralPriceAuthority
  * @property {() => PriceAuthority} getFromCentralPriceAuthority
- * @property {() => VPool} getVPool
+ * @property {() => VPoolWrapper<unknown>} getVPool
  */
 
 /**

--- a/packages/run-protocol/test/amm/vpool-xyk-amm/test-addLiquidity.js
+++ b/packages/run-protocol/test/amm/vpool-xyk-amm/test-addLiquidity.js
@@ -1,0 +1,30 @@
+// @ts-check
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+
+import { balancesToReachRatio } from '../../../src/vpool-xyk-amm/addLiquidity.js';
+import { setupMintKits } from '../constantProduct/setupMints.js';
+
+// The pool starts at 3000 and 4000. We want to add 400K and 300K to the pool,
+// so the ratio will be close to 4:3
+test('calcBalances', t => {
+  const { run, bld } = setupMintKits();
+  t.deepEqual(
+    balancesToReachRatio(run(3000n), bld(4000n), run(400_000n), bld(300_000n)),
+    {
+      newX: run(3988n),
+      newY: bld(3008n),
+    },
+  );
+});
+
+// pool starts at 4 and 9. We want it to end with a ratio of 12 to 3. This
+// calculation doesn't pay attention to fees.
+test('calcBalances 2', t => {
+  const { run, bld } = setupMintKits();
+  t.deepEqual(balancesToReachRatio(run(4n), bld(9n), run(1196n), bld(291n)), {
+    newX: run(12n),
+    newY: bld(3n),
+  });
+});

--- a/packages/run-protocol/test/amm/vpool-xyk-amm/test-amm-calc.js
+++ b/packages/run-protocol/test/amm/vpool-xyk-amm/test-amm-calc.js
@@ -1,0 +1,40 @@
+// @ts-check
+import { test } from '@agoric/swingset-vat/tools/prepare-test-env-ava.js';
+import { AmountMath as m, makeIssuerKit } from '@agoric/ertp';
+import { natSafeMath } from '@agoric/zoe/src/contractSupport/index.js';
+import fc from 'fast-check';
+import { balancesToReachRatio } from '../../../src/vpool-xyk-amm/addLiquidity.js';
+
+const { add, multiply } = natSafeMath;
+
+const { brand: brandX } = makeIssuerKit('X');
+const { brand: brandY } = makeIssuerKit('Y');
+
+const arbX = fc.bigUint().map(value => m.make(brandX, value));
+const arbY = fc.bigUint().map(value => m.make(brandY, value));
+
+test('balancesToReachRatio calculations are to spec', t => {
+  const sameRatio = ([x1, y1], [x2, y2], label) =>
+    t.deepEqual(multiply(x1, y2), multiply(x2, y1), label);
+
+  fc.assert(
+    fc.property(
+      fc.record({ poolX: arbX, poolY: arbY, giveX: arbX, giveY: arbY }),
+      ({ poolX, poolY, giveX, giveY }) => {
+        const { newX, newY } = balancesToReachRatio(poolX, poolY, giveX, giveY);
+
+        t.deepEqual(
+          multiply(newX.value, newY.value),
+          multiply(poolX.value, poolY.value),
+          `with giveX=${giveX.value} giveY=${giveY.value}, targetX=${newX.value} and targetY=${newY.value} multiply to the same product as poolX=${poolX.value} * poolY=${poolY.value}.`,
+        );
+
+        sameRatio(
+          [newX.value, newY.value],
+          [add(poolX.value, giveX.value), add(poolY.value, giveY.value)],
+          `targetX ${newX.value} and targetY ${newY.value} are in the ratio as poolX + giveX / poolY + giveY`,
+        );
+      },
+    ),
+  );
+});

--- a/packages/run-protocol/test/amm/vpool-xyk-amm/test-amm-calc.js
+++ b/packages/run-protocol/test/amm/vpool-xyk-amm/test-amm-calc.js
@@ -10,8 +10,11 @@ const { add, multiply } = natSafeMath;
 const { brand: brandX } = makeIssuerKit('X');
 const { brand: brandY } = makeIssuerKit('Y');
 
-const arbX = fc.bigUint().map(value => m.make(brandX, value));
-const arbY = fc.bigUint().map(value => m.make(brandY, value));
+const oneB = 1_000_000_000n;
+// const dec18 = 1_000_000_000_000_000_000n; // 18 decimals as used in ETH
+
+const arbX = fc.bigUint({ max: oneB }).map(value => m.make(brandX, value));
+const arbY = fc.bigUint({ max: oneB }).map(value => m.make(brandY, value));
 
 test('balancesToReachRatio calculations are to spec', t => {
   const sameRatio = ([x1, y1], [x2, y2], label) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,12 +33,12 @@
     "@nicolo-ribaudo/chokidar-2" "2.1.8-no-fsevents.3"
     chokidar "^3.4.0"
 
-"@babel/code-frame@7.10.4", "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.11", "@babel/code-frame@^7.16.7", "@babel/code-frame@^7.5.5":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
-  integrity sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
+"@babel/code-frame@7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
+  integrity sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==
   dependencies:
-    "@babel/highlight" "^7.16.7"
+    "@babel/highlight" "^7.10.4"
 
 "@babel/code-frame@7.12.11":
   version "7.12.11"
@@ -47,12 +47,41 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.11", "@babel/code-frame@^7.16.7", "@babel/code-frame@^7.5.5":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
+  integrity sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
+  dependencies:
+    "@babel/highlight" "^7.16.7"
+
 "@babel/compat-data@^7.13.11", "@babel/compat-data@^7.16.4", "@babel/compat-data@^7.16.8":
   version "7.16.8"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.16.8.tgz#31560f9f29fdf1868de8cb55049538a1b9732a60"
   integrity sha512-m7OkX0IdKLKPpBlJtF561YJal5y/jyI5fNfWbPxh2D/nbzzGI4qRyrD8xO2jB24u7l+5I2a43scCG2IrfjC50Q==
 
-"@babel/core@7.12.3", "@babel/core@^7.1.0", "@babel/core@^7.12.13", "@babel/core@^7.12.3", "@babel/core@^7.16.0", "@babel/core@^7.7.5", "@babel/core@^7.8.4":
+"@babel/core@7.12.3":
+  version "7.12.3"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.3.tgz#1b436884e1e3bff6fb1328dc02b208759de92ad8"
+  integrity sha512-0qXcZYKZp3/6N2jKYVxZv0aNCsxTSVCiK72DTiTYZAu7sjg73W0/aynWjMbiGd87EQL4WyA8reiJVh92AVla9g==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.12.1"
+    "@babel/helper-module-transforms" "^7.12.1"
+    "@babel/helpers" "^7.12.1"
+    "@babel/parser" "^7.12.3"
+    "@babel/template" "^7.10.4"
+    "@babel/traverse" "^7.12.1"
+    "@babel/types" "^7.12.1"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.1"
+    json5 "^2.1.2"
+    lodash "^4.17.19"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
+"@babel/core@^7.1.0", "@babel/core@^7.12.13", "@babel/core@^7.12.3", "@babel/core@^7.16.0", "@babel/core@^7.7.5", "@babel/core@^7.8.4":
   version "7.16.12"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.16.12.tgz#5edc53c1b71e54881315923ae2aedea2522bb784"
   integrity sha512-dK5PtG1uiN2ikk++5OzSYsitZKny4wOCD0nrO4TqnW4BVBTQ2NGS3NgilvT/TEyxTST7LNyWV/T4tXDoD3fOgg==
@@ -81,6 +110,15 @@
     eslint-scope "^5.1.1"
     eslint-visitor-keys "^2.1.0"
     semver "^6.3.0"
+
+"@babel/generator@^7.12.1", "@babel/generator@^7.17.0":
+  version "7.17.0"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.17.0.tgz#7bd890ba706cd86d3e2f727322346ffdbf98f65e"
+  integrity sha512-I3Omiv6FGOC29dtlZhkfXO6pgkmukJSlT26QjVvS1DGZe/NzSVCPG41X0tS21oZkJYlovfj9qDWgKP+Cn4bXxw==
+  dependencies:
+    "@babel/types" "^7.17.0"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
 
 "@babel/generator@^7.14.2", "@babel/generator@^7.16.8":
   version "7.16.8"
@@ -202,7 +240,7 @@
   dependencies:
     "@babel/types" "^7.16.7"
 
-"@babel/helper-module-transforms@^7.16.7":
+"@babel/helper-module-transforms@^7.12.1", "@babel/helper-module-transforms@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.16.7.tgz#7665faeb721a01ca5327ddc6bba15a5cb34b6a41"
   integrity sha512-gaqtLDxJEFCeQbYp9aLAefjhkKdjKcdh6DB7jniIGU3Pz52WAmP268zK0VgPz9hUNkMSYeH976K2/Y6yPadpng==
@@ -289,6 +327,15 @@
     "@babel/traverse" "^7.16.8"
     "@babel/types" "^7.16.8"
 
+"@babel/helpers@^7.12.1":
+  version "7.17.2"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.17.2.tgz#23f0a0746c8e287773ccd27c14be428891f63417"
+  integrity sha512-0Qu7RLR1dILozr/6M0xgj+DFPmi6Bnulgm9M8BVa9ZCWxDqlSnqt3cf8IDPB5m45sVXUZ0kuQAgUrdSFFH79fQ==
+  dependencies:
+    "@babel/template" "^7.16.7"
+    "@babel/traverse" "^7.17.0"
+    "@babel/types" "^7.17.0"
+
 "@babel/helpers@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.16.7.tgz#7e3504d708d50344112767c3542fc5e357fffefc"
@@ -311,6 +358,11 @@
   version "7.16.12"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.12.tgz#9474794f9a650cf5e2f892444227f98e28cdf8b6"
   integrity sha512-VfaV15po8RiZssrkPweyvbGVSe4x2y+aciFCgn0n0/SJMR22cwofRV1mtnJQYcSB1wUTaA/X1LnA3es66MCO5A==
+
+"@babel/parser@^7.12.3", "@babel/parser@^7.17.0":
+  version "7.17.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.0.tgz#f0ac33eddbe214e4105363bb17c3341c5ffcc43c"
+  integrity sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.16.7":
   version "7.16.7"
@@ -1051,7 +1103,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/template@^7.16.7", "@babel/template@^7.3.3":
+"@babel/template@^7.10.4", "@babel/template@^7.16.7", "@babel/template@^7.3.3":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
   integrity sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==
@@ -1076,10 +1128,34 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.12.1", "@babel/traverse@^7.17.0":
+  version "7.17.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.17.0.tgz#3143e5066796408ccc880a33ecd3184f3e75cd30"
+  integrity sha512-fpFIXvqD6kC7c7PUNnZ0Z8cQXlarCLtCUpt2S1Dx7PjoRtCFffvOkHHSom+m5HIxMZn5bIBVb71lhabcmjEsqg==
+  dependencies:
+    "@babel/code-frame" "^7.16.7"
+    "@babel/generator" "^7.17.0"
+    "@babel/helper-environment-visitor" "^7.16.7"
+    "@babel/helper-function-name" "^7.16.7"
+    "@babel/helper-hoist-variables" "^7.16.7"
+    "@babel/helper-split-export-declaration" "^7.16.7"
+    "@babel/parser" "^7.17.0"
+    "@babel/types" "^7.17.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/types@^7.0.0", "@babel/types@^7.12.6", "@babel/types@^7.16.0", "@babel/types@^7.16.7", "@babel/types@^7.16.8", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
   version "7.16.8"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.16.8.tgz#0ba5da91dd71e0a4e7781a30f22770831062e3c1"
   integrity sha512-smN2DQc5s4M7fntyjGtyIPbRJv6wW4rU/94fmYJ7PKQuZkC0qGMHXJbg6sNGt12JmVr4k5YaptI/XtiLJBnmIg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.16.7"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.12.1", "@babel/types@^7.17.0":
+  version "7.17.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.17.0.tgz#a826e368bccb6b3d84acd76acad5c0d87342390b"
+  integrity sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==
   dependencies:
     "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
@@ -3700,7 +3776,7 @@
     jest-diff "^27.0.0"
     pretty-format "^27.0.0"
 
-"@types/json-schema@*", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
+"@types/json-schema@*", "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
@@ -4013,7 +4089,21 @@
   dependencies:
     "@types/node" "*"
 
-"@typescript-eslint/eslint-plugin@^4.5.0", "@typescript-eslint/eslint-plugin@^5.10.2", "@typescript-eslint/eslint-plugin@^5.5.0":
+"@typescript-eslint/eslint-plugin@^4.5.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz#c24dc7c8069c7706bc40d99f6fa87edcb2005276"
+  integrity sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "4.33.0"
+    "@typescript-eslint/scope-manager" "4.33.0"
+    debug "^4.3.1"
+    functional-red-black-tree "^1.0.1"
+    ignore "^5.1.8"
+    regexpp "^3.1.0"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/eslint-plugin@^5.10.2", "@typescript-eslint/eslint-plugin@^5.5.0":
   version "5.10.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.2.tgz#f8c1d59fc37bd6d9d11c97267fdfe722c4777152"
   integrity sha512-4W/9lLuE+v27O/oe7hXJKjNtBLnZE8tQAFpapdxwSVHqtmIoPB1gph3+ahNwVuNL37BX7YQHyGF9Xv6XCnIX2Q==
@@ -4028,7 +4118,47 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/parser@^4.5.0", "@typescript-eslint/parser@^5.10.2", "@typescript-eslint/parser@^5.5.0":
+"@typescript-eslint/experimental-utils@4.33.0", "@typescript-eslint/experimental-utils@^4.0.1":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz#6f2a786a4209fa2222989e9380b5331b2810f7fd"
+  integrity sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==
+  dependencies:
+    "@types/json-schema" "^7.0.7"
+    "@typescript-eslint/scope-manager" "4.33.0"
+    "@typescript-eslint/types" "4.33.0"
+    "@typescript-eslint/typescript-estree" "4.33.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+
+"@typescript-eslint/experimental-utils@^3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.10.1.tgz#e179ffc81a80ebcae2ea04e0332f8b251345a686"
+  integrity sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/types" "3.10.1"
+    "@typescript-eslint/typescript-estree" "3.10.1"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
+
+"@typescript-eslint/experimental-utils@^5.0.0":
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.11.0.tgz#e7b2bfd57ddda47c3f658faad57655ed9e01fea0"
+  integrity sha512-EPvC/bU2n1LKtzKWP1AjGWkp7r8tJ8giVlZHIODo6q7SAd6J+/9vjtEKHK2G/Qp+D2IGPsQge+oadDR3CZcFtQ==
+  dependencies:
+    "@typescript-eslint/utils" "5.11.0"
+
+"@typescript-eslint/parser@^4.5.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.33.0.tgz#dfe797570d9694e560528d18eecad86c8c744899"
+  integrity sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==
+  dependencies:
+    "@typescript-eslint/scope-manager" "4.33.0"
+    "@typescript-eslint/types" "4.33.0"
+    "@typescript-eslint/typescript-estree" "4.33.0"
+    debug "^4.3.1"
+
+"@typescript-eslint/parser@^5.10.2", "@typescript-eslint/parser@^5.5.0":
   version "5.10.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.10.2.tgz#b6076d27cc5499ce3f2c625f5ccde946ecb7db9a"
   integrity sha512-JaNYGkaQVhP6HNF+lkdOr2cAs2wdSZBoalE22uYWq8IEv/OVH0RksSGydk+sW8cLoSeYmC+OHvRyv2i4AQ7Czg==
@@ -4038,6 +4168,14 @@
     "@typescript-eslint/typescript-estree" "5.10.2"
     debug "^4.3.2"
 
+"@typescript-eslint/scope-manager@4.33.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz#d38e49280d983e8772e29121cf8c6e9221f280a3"
+  integrity sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==
+  dependencies:
+    "@typescript-eslint/types" "4.33.0"
+    "@typescript-eslint/visitor-keys" "4.33.0"
+
 "@typescript-eslint/scope-manager@5.10.2":
   version "5.10.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.10.2.tgz#92c0bc935ec00f3d8638cdffb3d0e70c9b879639"
@@ -4045,6 +4183,14 @@
   dependencies:
     "@typescript-eslint/types" "5.10.2"
     "@typescript-eslint/visitor-keys" "5.10.2"
+
+"@typescript-eslint/scope-manager@5.11.0":
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.11.0.tgz#f5aef83ff253f457ecbee5f46f762298f0101e4b"
+  integrity sha512-z+K4LlahDFVMww20t/0zcA7gq/NgOawaLuxgqGRVKS0PiZlCTIUtX0EJbC0BK1JtR4CelmkPK67zuCgpdlF4EA==
+  dependencies:
+    "@typescript-eslint/types" "5.11.0"
+    "@typescript-eslint/visitor-keys" "5.11.0"
 
 "@typescript-eslint/type-utils@5.10.2":
   version "5.10.2"
@@ -4055,10 +4201,52 @@
     debug "^4.3.2"
     tsutils "^3.21.0"
 
+"@typescript-eslint/types@3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-3.10.1.tgz#1d7463fa7c32d8a23ab508a803ca2fe26e758727"
+  integrity sha512-+3+FCUJIahE9q0lDi1WleYzjCwJs5hIsbugIgnbB+dSCYUxl8L6PwmsyOPFZde2hc1DlTo/xnkOgiTLSyAbHiQ==
+
+"@typescript-eslint/types@4.33.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.33.0.tgz#a1e59036a3b53ae8430ceebf2a919dc7f9af6d72"
+  integrity sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==
+
 "@typescript-eslint/types@5.10.2":
   version "5.10.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.10.2.tgz#604d15d795c4601fffba6ecb4587ff9fdec68ce8"
   integrity sha512-Qfp0qk/5j2Rz3p3/WhWgu4S1JtMcPgFLnmAKAW061uXxKSa7VWKZsDXVaMXh2N60CX9h6YLaBoy9PJAfCOjk3w==
+
+"@typescript-eslint/types@5.11.0":
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.11.0.tgz#ba345818a2540fdf2755c804dc2158517ab61188"
+  integrity sha512-cxgBFGSRCoBEhvSVLkKw39+kMzUKHlJGVwwMbPcTZX3qEhuXhrjwaZXWMxVfxDgyMm+b5Q5b29Llo2yow8Y7xQ==
+
+"@typescript-eslint/typescript-estree@3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-3.10.1.tgz#fd0061cc38add4fad45136d654408569f365b853"
+  integrity sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==
+  dependencies:
+    "@typescript-eslint/types" "3.10.1"
+    "@typescript-eslint/visitor-keys" "3.10.1"
+    debug "^4.1.1"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/typescript-estree@4.33.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz#0dfb51c2908f68c5c08d82aefeaf166a17c24609"
+  integrity sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==
+  dependencies:
+    "@typescript-eslint/types" "4.33.0"
+    "@typescript-eslint/visitor-keys" "4.33.0"
+    debug "^4.3.1"
+    globby "^11.0.3"
+    is-glob "^4.0.1"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
 
 "@typescript-eslint/typescript-estree@5.10.2":
   version "5.10.2"
@@ -4067,6 +4255,19 @@
   dependencies:
     "@typescript-eslint/types" "5.10.2"
     "@typescript-eslint/visitor-keys" "5.10.2"
+    debug "^4.3.2"
+    globby "^11.0.4"
+    is-glob "^4.0.3"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/typescript-estree@5.11.0":
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.11.0.tgz#53f9e09b88368191e52020af77c312a4777ffa43"
+  integrity sha512-yVH9hKIv3ZN3lw8m/Jy5I4oXO4ZBMqijcXCdA4mY8ull6TPTAoQnKKrcZ0HDXg7Bsl0Unwwx7jcXMuNZc0m4lg==
+  dependencies:
+    "@typescript-eslint/types" "5.11.0"
+    "@typescript-eslint/visitor-keys" "5.11.0"
     debug "^4.3.2"
     globby "^11.0.4"
     is-glob "^4.0.3"
@@ -4085,12 +4286,47 @@
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
+"@typescript-eslint/utils@5.11.0":
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.11.0.tgz#d91548ef180d74c95d417950336d9260fdbe1dc5"
+  integrity sha512-g2I480tFE1iYRDyMhxPAtLQ9HAn0jjBtipgTCZmd9I9s11OV8CTsG+YfFciuNDcHqm4csbAgC2aVZCHzLxMSUw==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.11.0"
+    "@typescript-eslint/types" "5.11.0"
+    "@typescript-eslint/typescript-estree" "5.11.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+
+"@typescript-eslint/visitor-keys@3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-3.10.1.tgz#cd4274773e3eb63b2e870ac602274487ecd1e931"
+  integrity sha512-9JgC82AaQeglebjZMgYR5wgmfUdUc+EitGUUMW8u2nDckaeimzW+VsoLV6FoimPv2id3VQzfjwBxEMVz08ameQ==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
+
+"@typescript-eslint/visitor-keys@4.33.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz#2a22f77a41604289b7a186586e9ec48ca92ef1dd"
+  integrity sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==
+  dependencies:
+    "@typescript-eslint/types" "4.33.0"
+    eslint-visitor-keys "^2.0.0"
+
 "@typescript-eslint/visitor-keys@5.10.2":
   version "5.10.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.2.tgz#fdbf272d8e61c045d865bd6c8b41bea73d222f3d"
   integrity sha512-zHIhYGGGrFJvvyfwHk5M08C5B5K4bewkm+rrvNTKk1/S15YHR+SA/QUF8ZWscXSfEaB8Nn2puZj+iHcoxVOD/Q==
   dependencies:
     "@typescript-eslint/types" "5.10.2"
+    eslint-visitor-keys "^3.0.0"
+
+"@typescript-eslint/visitor-keys@5.11.0":
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.11.0.tgz#888542381f1a2ac745b06d110c83c0b261487ebb"
+  integrity sha512-E8w/vJReMGuloGxJDkpPlGwhxocxOpSVgSvjiLO5IxZPmxZF30weOeJYyPSEACwM+X4NziYS9q+WkN/2DHYQwA==
+  dependencies:
+    "@typescript-eslint/types" "5.11.0"
     eslint-visitor-keys "^3.0.0"
 
 "@web/browser-logs@^0.2.1":
@@ -8304,7 +8540,14 @@ eslint-config-prettier@^6.15.0:
   dependencies:
     get-stdin "^6.0.0"
 
-eslint-config-react-app@^6.0.0, eslint-config-react-app@^7.0.0:
+eslint-config-react-app@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-6.0.0.tgz#ccff9fc8e36b322902844cbd79197982be355a0e"
+  integrity sha512-bpoAAC+YRfzq0dsTk+6v9aHm/uqnDwayNAXleMypGl6CpxI9oXXscVHo4fk3eJPIn+rsbtNetB4r/ZIidFIE8A==
+  dependencies:
+    confusing-browser-globals "^1.0.10"
+
+eslint-config-react-app@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-7.0.0.tgz#0fa96d5ec1dfb99c029b1554362ab3fa1c3757df"
   integrity sha512-xyymoxtIt1EOsSaGag+/jmcywRuieQoA2JbPCjnw9HukFj9/97aGPoZVFioaotzk1K5Qt9sHO5EutZbkrAXS0g==
@@ -8390,7 +8633,21 @@ eslint-plugin-import@^2.18.2, eslint-plugin-import@^2.22.1, eslint-plugin-import
     resolve "^1.20.0"
     tsconfig-paths "^3.12.0"
 
-eslint-plugin-jest@^24.1.0, eslint-plugin-jest@^25.3.0, eslint-plugin-jest@^26.0.0:
+eslint-plugin-jest@^24.1.0:
+  version "24.7.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-24.7.0.tgz#206ac0833841e59e375170b15f8d0955219c4889"
+  integrity sha512-wUxdF2bAZiYSKBclsUMrYHH6WxiBreNjyDxbRv345TIvPeoCEgPNEn3Sa+ZrSqsf1Dl9SqqSREXMHExlMMu1DA==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "^4.0.1"
+
+eslint-plugin-jest@^25.3.0:
+  version "25.7.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-25.7.0.tgz#ff4ac97520b53a96187bad9c9814e7d00de09a6a"
+  integrity sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "^5.0.0"
+
+eslint-plugin-jest@^26.0.0:
   version "26.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-26.0.0.tgz#f83a25a23ab90ce5b375b1d44389b8c391be5ce8"
   integrity sha512-Fvs0YgJ/nw9FTrnqTuMGVrkozkd07jkQzWm0ajqyHlfcsdkxGfAuv30fgfWHOnHiCr9+1YQ365CcDX7vrNhqQg==
@@ -8493,7 +8750,14 @@ eslint-plugin-react@^7.21.5, eslint-plugin-react@^7.27.1, eslint-plugin-react@^7
     semver "^6.3.0"
     string.prototype.matchall "^4.0.6"
 
-eslint-plugin-testing-library@^3.9.2, eslint-plugin-testing-library@^5.0.1:
+eslint-plugin-testing-library@^3.9.2:
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-3.10.2.tgz#609ec2b0369da7cf2e6d9edff5da153cc31d87bd"
+  integrity sha512-WAmOCt7EbF1XM8XfbCKAEzAPnShkNSwcIsAD2jHdsMUT9mZJPjLCG7pMzbcC8kK366NOuGip8HKLDC+Xk4yIdA==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "^3.10.1"
+
+eslint-plugin-testing-library@^5.0.1:
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.0.5.tgz#5757961ec20a6ca8b0992d2c5487db1b51612d8d"
   integrity sha512-0j355vJpJCE/2g+aayIgJRUB6jBVqpD5ztMLGcadR1PgrgGPnPxN1HJuOAsAAwiMo27GwRnpJB8KOQzyNuNZrw==
@@ -8521,7 +8785,7 @@ eslint-scope@^4.0.3:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-scope@^5.1.1:
+eslint-scope@^5.0.0, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
   integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
@@ -8529,7 +8793,7 @@ eslint-scope@^5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-eslint-utils@^2.1.0:
+eslint-utils@^2.0.0, eslint-utils@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
   integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
@@ -8935,6 +9199,17 @@ fast-glob@^3.1.1:
     merge2 "^1.3.0"
     micromatch "^4.0.2"
     picomatch "^2.2.1"
+
+fast-glob@^3.2.9:
+  version "3.2.11"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
+  integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
@@ -9381,7 +9656,7 @@ genfun@^5.0.0:
   resolved "https://registry.yarnpkg.com/genfun/-/genfun-5.0.0.tgz#9dd9710a06900a5c4a5bf57aca5da4e52fe76537"
   integrity sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==
 
-gensync@^1.0.0-beta.2:
+gensync@^1.0.0-beta.1, gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
@@ -9560,7 +9835,7 @@ glob-parent@^5.1.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob-parent@~5.1.2:
+glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -9691,6 +9966,18 @@ globby@^11.0.1, globby@^11.0.4:
     fast-glob "^3.1.1"
     ignore "^5.1.4"
     merge2 "^1.3.0"
+    slash "^3.0.0"
+
+globby@^11.0.3:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
+  integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.2.9"
+    ignore "^5.2.0"
+    merge2 "^1.4.1"
     slash "^3.0.0"
 
 globby@^6.1.0:
@@ -10288,6 +10575,11 @@ ignore@^5.1.4:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
+
+ignore@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
+  integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
 immer@8.0.1:
   version "8.0.1"
@@ -12401,7 +12693,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.7.0, lodash@~4.17.10:
+"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.7.0, lodash@~4.17.10:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -12742,7 +13034,7 @@ merge2@^1.2.3:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81"
   integrity sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==
 
-merge2@^1.3.0:
+merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
@@ -16355,7 +16647,7 @@ resolve@1.18.1:
     is-core-module "^2.0.0"
     path-parse "^1.0.6"
 
-resolve@^1.10.0, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.19.0, resolve@^1.20.0:
+resolve@^1.10.0, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.3.2:
   version "1.22.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.0.tgz#5e0b8c67c15df57a89bdbabe603a002f21731198"
   integrity sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==
@@ -18161,7 +18453,7 @@ tsscmp@1.0.6:
   resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.6.tgz#85b99583ac3589ec4bfef825b5000aa911d605eb"
   integrity sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==
 
-tsutils@^3.21.0:
+tsutils@^3.17.1, tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==


### PR DESCRIPTION
property testing for `balancesToReachRatio` calculations. Maybe I don't understand how this is supposed to work, but note that these **do not pass**:

```
~/projects/agoric/agoric-sdk/packages/run-protocol
10:12 connolly@jambox$ yarn test test/amm/vpool-xyk-amm/test-amm-calc.js 
yarn run v1.22.15
$ ava test/amm/vpool-xyk-amm/test-amm-calc.js

  balancesToReachRatio calculations are to spec

  with giveX=8 giveY=834594958, targetX=259870149 and targetY=766756489 multiply to the same product as poolX=437294554 * poolY=455658826.

  Difference:

  - 199257123043146861n
  + 199257123091833604n
```

another example:

```
  with giveX=5 giveY=990668278, targetX=0 and targetY=35689 multiply to the same product as poolX=9 * poolY=2.

  Difference:

  - 0n
  + 18n
```

and another:

```
  with giveX=5 giveY=999999996, targetX=3 and targetY=587666676 multiply to the same product as poolX=5 * poolY=469899091.

  Difference:

  - 1763000028n
  + 2349495455n
```
