### PR TITLE
add details to rights conservation assertion msg

### DIFF
--- a/packages/zoe/src/contractFacet/rightsConservation.js
+++ b/packages/zoe/src/contractFacet/rightsConservation.js
@@ -79,7 +79,7 @@ const assertEqualPerBrand = (leftSumsByBrand, rightSumsByBrand) => {
     const { leftSum, rightSum } = getSums(brand);
     assert(
       AmountMath.isEqual(leftSum, rightSum),
-      X`rights were not conserved for brand ${brand}`,
+      X`rights were not conserved for brand ${brand} ${leftSum.value} != ${rightSum.value}`,
     );
   });
 };

--- a/packages/zoe/test/unitTests/contracts/test-otcDesk.js
+++ b/packages/zoe/test/unitTests/contracts/test-otcDesk.js
@@ -261,7 +261,7 @@ const makeBob = (
 
       await t.throwsAsync(() => E(seat).getOfferResult(), {
         message:
-          'rights were not conserved for brand "[Alleged: simoleans brand]"',
+          'rights were not conserved for brand "[Alleged: simoleans brand]" "[15n]" != "[16n]"',
       });
 
       await assertPayoutAmount(

--- a/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
+++ b/packages/zoe/test/unitTests/zcf/test-zoeHelpersWZcf.js
@@ -459,7 +459,8 @@ test(`zoeHelper w/zcf - swapExact w/shortage`, async t => {
   );
 
   t.throws(() => swapExact(zcf, zcfSeatA, zcfSeatB), {
-    message: 'rights were not conserved for brand "[Alleged: moola brand]"',
+    message:
+      'rights were not conserved for brand "[Alleged: moola brand]" "[15n]" != "[20n]"',
   });
   t.truthy(zcfSeatA.hasExited(), 'fail right');
   await assertPayoutAmount(
@@ -515,7 +516,8 @@ test(`zoeHelper w/zcf - swapExact w/excess`, async t => {
   );
 
   t.throws(() => swapExact(zcf, zcfSeatA, zcfSeatB), {
-    message: 'rights were not conserved for brand "[Alleged: moola brand]"',
+    message:
+      'rights were not conserved for brand "[Alleged: moola brand]" "[40n]" != "[20n]"',
   });
   t.truthy(zcfSeatA.hasExited(), 'fail right');
   await assertPayoutAmount(
@@ -571,7 +573,8 @@ test(`zoeHelper w/zcf - swapExact w/extra payments`, async t => {
   );
 
   t.throws(() => swapExact(zcf, zcfSeatA, zcfSeatB), {
-    message: 'rights were not conserved for brand "[Alleged: moola brand]"',
+    message:
+      'rights were not conserved for brand "[Alleged: moola brand]" "[40n]" != "[0n]"',
   });
   t.truthy(zcfSeatA.hasExited(), 'fail right');
   await assertPayoutAmount(


### PR DESCRIPTION
for help diagnosing #4407

## Description

Add the leftSum and rightSum to the assertion message to help diagnosing #4407.

### Security Considerations

This adds details about a failing transaction to our logs, but it's very minor, and only when a rights conservation violation occurs, so I don't think it's significant. If someone thinks it is, we should remove the extra detail once the bug is addressed.

### Documentation Considerations

None

### Testing Considerations

Tests updated.