### PR TITLE
fix(swingset): use consistent lowercase `bundlecap' in API/docs

### DIFF
--- a/packages/SwingSet/src/devices/bundle.js
+++ b/packages/SwingSet/src/devices/bundle.js
@@ -34,13 +34,13 @@ The kernel will provide this device with three endowments:
 * getNamedBundleID(name) -> bundleID
 
 The root device node offers two methods to callers:
-* D(devices.bundle).getBundleCap(bundleID) -> devnode or undefined
-* D(devices.bundle).getNamedBundleCap(name) -> devnode or undefined
+* D(devices.bundle).getBundlecap(bundleID) -> devnode or undefined
+* D(devices.bundle).getNamedBundlecap(name) -> devnode or undefined
 
-The device node returned by getBundleCap() is called, unsurprisingly, a
+The device node returned by getBundlecap() is called, unsurprisingly, a
 "bundlecap". Most vats interact with bundlecaps, not bundleIDs (although of
-course somebody must call `getBundleCap()` first). Holding a bundlecap
-guarantees that the bundle contents are available, since `getBundleCap()`
+course somebody must call `getBundlecap()` first). Holding a bundlecap
+guarantees that the bundle contents are available, since `getBundlecap()`
 will fail unless the bundle is currently installed. When we implement
 refcounting GC for bundles, the bundlecap will maintain a reference and
 protect the bundle data from collection.
@@ -106,15 +106,15 @@ export function buildDevice(tools, endowments) {
       const args = unserialize(argsCapdata);
 
       if (dnid === ROOT) {
-        // D(devices.bundle).getBundleCap(id) -> bundlecap
-        if (method === 'getBundleCap') {
+        // D(devices.bundle).getBundlecap(id) -> bundlecap
+        if (method === 'getBundlecap') {
           const [bundleID] = args;
           assert.typeof(bundleID, 'string');
           assert(bundleIDRE.test(bundleID), 'not a bundleID');
           return returnCapForBundleID(bundleID);
         }
-        // D(devices.bundle).getNamedBundleCap(name) -> bundlecap
-        if (method === 'getNamedBundleCap') {
+        // D(devices.bundle).getNamedBundlecap(name) -> bundlecap
+        if (method === 'getNamedBundlecap') {
           const [name] = args;
           assert.typeof(name, 'string');
           let bundleID;

--- a/packages/SwingSet/src/initializeSwingset.js
+++ b/packages/SwingSet/src/initializeSwingset.js
@@ -365,7 +365,7 @@ export async function initializeSwingset(
   // The 'bundleName' option points into
   // config.bundles.BUNDLENAME.[bundle|bundleSpec|sourceSpec] , which can
   // also include arbitrary named bundles that will be made available to
-  // D(devices.bundle).getNamedBundleCap(bundleName) ,and temporarily as
+  // D(devices.bundle).getNamedBundlecap(bundleName) ,and temporarily as
   // E(vatAdminService).createVatByName(bundleName)
 
   // The 'kconfig' we pass through to initializeKernel has

--- a/packages/SwingSet/test/bundles/bootstrap-bundles.js
+++ b/packages/SwingSet/test/bundles/bootstrap-bundles.js
@@ -40,8 +40,8 @@ export function buildRootObject(vatPowers) {
       return [hello];
     },
 
-    async vatFromNamedBundleCap(name, method) {
-      const bcap = D(devices.bundle).getNamedBundleCap(name);
+    async vatFromNamedBundlecap(name, method) {
+      const bcap = D(devices.bundle).getNamedBundlecap(name);
       const { root } = await E(vatAdmin).createVat(bcap);
       const hello = await E(root)[method]();
       return [hello];
@@ -55,25 +55,25 @@ export function buildRootObject(vatPowers) {
     },
 
     async vatFromID(id, method) {
-      const bcap = D(devices.bundle).getBundleCap(id);
+      const bcap = D(devices.bundle).getBundlecap(id);
       const { root } = await E(vatAdmin).createVat(bcap);
       const hello = await E(root)[method]();
       return [hello];
     },
 
-    getBundleCap(id) {
+    getBundlecap(id) {
       // bad bundleIDs should throw
-      return D(devices.bundle).getBundleCap(id);
+      return D(devices.bundle).getBundlecap(id);
     },
 
     getBundle(id) {
-      const bcap = D(devices.bundle).getBundleCap(id);
+      const bcap = D(devices.bundle).getBundlecap(id);
       return D(bcap).getBundle();
     },
 
     async checkImportByID(id) {
       function getCap() {
-        const bcap = D(devices.bundle).getBundleCap(id);
+        const bcap = D(devices.bundle).getBundlecap(id);
         assert.equal(D(bcap).getBundleID(), id);
         return bcap;
       }
@@ -82,7 +82,7 @@ export function buildRootObject(vatPowers) {
 
     async checkImportByName(name) {
       function getCap() {
-        return D(devices.bundle).getNamedBundleCap(name);
+        return D(devices.bundle).getNamedBundlecap(name);
       }
       return checkImport(getCap);
     },

--- a/packages/SwingSet/test/bundles/test-bundles.js
+++ b/packages/SwingSet/test/bundles/test-bundles.js
@@ -41,7 +41,7 @@ test('bundles', async t => {
 
   // This one (with 'hi()') provides a named vat bundle, for a static vat,
   // exercising config.vats.NAME.bundleName . We also build dynamic vats to
-  // test D(devices.bundle).getNamedBundleCap and E(vatAdmin).createVatByName
+  // test D(devices.bundle).getNamedBundlecap and E(vatAdmin).createVatByName
   const namedBundleFilename = bfile('vat-named.js');
 
   // We save this vat bundle (with 'disk()') to disk, to exercise
@@ -113,24 +113,24 @@ test('bundles', async t => {
   await check('checkConfiguredVats', [undefined], ['hello']);
 
   // create dynamic vats from a named bundle created at config file
-  await check('vatFromNamedBundleCap', ['named', 'hi'], ['hello']);
+  await check('vatFromNamedBundlecap', ['named', 'hi'], ['hello']);
 
   // pre-made bundles can be loaded from disk, via a named bundle
-  await check('vatFromNamedBundleCap', ['disk', 'disk'], ['otech']);
+  await check('vatFromNamedBundlecap', ['disk', 'disk'], ['otech']);
 
   // vatAdminService~.createVatByName() still works, TODO until we remove it
   await check('vatByName', ['named', 'hi'], ['hello']);
 
-  // D(devices.bundle).getBundleCap(invalidBundleID) should throw
+  // D(devices.bundle).getBundlecap(invalidBundleID) should throw
   await checkRejects(
-    'getBundleCap',
+    'getBundlecap',
     [invalidBundleID],
     Error('syscall.callNow failed: device.invoke failed, see logs for details'),
   );
   // the logs would show "not a bundleID"
 
-  // D(devices.bundle).getBundleCap(missingBundleID) should return undefined
-  await check('getBundleCap', [missingBundleID], undefined);
+  // D(devices.bundle).getBundlecap(missingBundleID) should return undefined
+  await check('getBundlecap', [missingBundleID], undefined);
 
   // install a vat bundle at runtime, make sure we can load it by ID
   const bid1 = await c.validateAndInstallBundle(installableVatBundle);
@@ -145,7 +145,7 @@ test('bundles', async t => {
   await check('checkImportByName', ['importableNonVat'], ['importable', true]);
 
   // check the shape of a bundlecap
-  const [s1, d1] = await run('getBundleCap', [bid2]);
+  const [s1, d1] = await run('getBundlecap', [bid2]);
   t.is(s1, 'fulfilled');
   const res1 = JSON.parse(d1.body);
   const dev1 = { '@qclass': 'slot', iface: 'Alleged: device node', index: 0 };

--- a/packages/SwingSet/test/metering/vat-load-dynamic.js
+++ b/packages/SwingSet/test/metering/vat-load-dynamic.js
@@ -40,7 +40,7 @@ export function buildRootObject(vatPowers) {
     },
 
     async createVat(name, dynamicOptions) {
-      const bundleID = D(bundleDev).getNamedBundleCap(name);
+      const bundleID = D(bundleDev).getNamedBundlecap(name);
       control = await E(service).createVat(bundleID, dynamicOptions);
       const done = E(control.adminNode).done();
       // the caller checks this later, but doesn't wait for it

--- a/packages/SwingSet/test/vat-admin/bootstrap.js
+++ b/packages/SwingSet/test/vat-admin/bootstrap.js
@@ -24,15 +24,15 @@ export function buildRootObject(vatPowers) {
       return n;
     },
 
-    async byNamedBundleCap(name) {
-      const bcap = D(bundleDevice).getNamedBundleCap(name);
+    async byNamedBundlecap(name) {
+      const bcap = D(bundleDevice).getNamedBundlecap(name);
       const { root } = await E(admin).createVat(bcap);
       const n = await E(root).getANumber();
       return n;
     },
 
     async byID(id) {
-      const bcap = D(bundleDevice).getBundleCap(id);
+      const bcap = D(bundleDevice).getBundlecap(id);
       const { root } = await E(admin).createVat(bcap);
       const n = await E(root).getANumber();
       return n;
@@ -52,7 +52,7 @@ export function buildRootObject(vatPowers) {
       return E(admin).createVatByName(bundleName); // should reject
     },
 
-    async nonBundleCap() {
+    async nonBundlecap() {
       return E(admin).createVat(Far('non-bundlecap', {})); // should reject
     },
   });

--- a/packages/SwingSet/test/vat-admin/replay-bootstrap.js
+++ b/packages/SwingSet/test/vat-admin/replay-bootstrap.js
@@ -15,7 +15,7 @@ export function buildRootObject(vatPowers) {
     },
 
     async createVat() {
-      const bcap = D(devices.bundle).getNamedBundleCap('dynamic');
+      const bcap = D(devices.bundle).getNamedBundlecap('dynamic');
       const vc = await E(vatAdminSvc).createVat(bcap);
       root = vc.root;
       const count = await E(root).first();

--- a/packages/SwingSet/test/vat-admin/test-create-vat.js
+++ b/packages/SwingSet/test/vat-admin/test-create-vat.js
@@ -66,7 +66,7 @@ test('createVat by named bundlecap', async t => {
   const { c } = await doTestSetup(t);
   const kpid = c.queueToVatRoot(
     'bootstrap',
-    'byNamedBundleCap',
+    'byNamedBundlecap',
     capargs(['new13']),
   );
   await c.run();
@@ -104,7 +104,7 @@ test('broken vat creation fails', async t => {
 
 test('error creating vat from non-bundle', async t => {
   const { c } = await doTestSetup(t);
-  const kpid = c.queueToVatRoot('bootstrap', 'nonBundleCap', capargs([]));
+  const kpid = c.queueToVatRoot('bootstrap', 'nonBundlecap', capargs([]));
   await c.run();
   t.is(c.kpStatus(kpid), 'rejected');
   t.deepEqual(


### PR DESCRIPTION
Change the following APIs:

* `D(devices.bundle).getBundlecap()`, not `getBundleCap`
* `D(devices.bundle).getNamedBundlecap()`, not `getNamedBundleCap`

I want code to use `bundlecap` in variable names, rather than `bundleCap`,
and this reinforces the pattern.

refs #4372
