### PR TITLE
fix(swingset): make vatAdmin provide getBundlecap/getNamedBundlecap

### DIFF
--- a/packages/SwingSet/docs/bundles.md
+++ b/packages/SwingSet/docs/bundles.md
@@ -10,7 +10,7 @@ In a given workspace (e.g. a Git checkout / working tree), you will have a hiera
 
 If you point at a single "entry point" module, and chase down all the `import` statements, you'll find some other set of module files. Following the transitive `import` statements leads to a collection of modules and a linkage map which remembers how they are wired together.
 
-A "code bundle" is a data structure that captures the contents of these modules and the linkage map (called a "compartment map"). Bundles are JSON-serializable objects, with one mandatory string property named `moduleFormat`, and other properties that depend on the format. Typically there is exactly one other property, and its value is a very large string (1-2 MB is common). Our bundles use a format that Endo defines, named "EndoZipBase64", in which the "very large string" is a base64-encoded Zip file, which contains one component for the compartment map, plus components for each of the modules it includes.
+A "code bundle" is a data structure that captures the contents of these modules and the linkage map (called a "compartment map"). Bundles are JSON-serializable objects, with one mandatory string property named `moduleFormat`, and other properties that depend on the format. Typically there is exactly one other property, and its value is a very large string (1-2 MB is common). Our bundles use a format defined by [Endo](https://github.com/endojs/endo/), named "EndoZipBase64", in which the "very large string" is a base64-encoded Zip file, which contains one component for the compartment map, plus components for each of the modules it includes.
 
 The `bundleSource()` function takes a filename of the entry point module and returns (a promise for) the code bundle object. It generally needs disk access to find all the imports.
 
@@ -22,70 +22,89 @@ Bundles are interesting because they can be serialized and sent to a remote syst
 
 We define the "bundle ID" as a hash of the bundle's compartment map file, specifically the fixed string `b1-` followed by the lowercase hex encoding of the SHA512 hash of the compartment map file. The compartment map includes hashes of all the modules included in the bundle, and the validation process ensures that the bundle contains exactly the expected set of modules. So the bundle ID is a strong identifier of the contents of the bundle, which is not sensitive to the order of the zipfile contents.
 
-A bundle might be assembled piecemeal. If I want to give you a bundle, and you already have a number of similar bundles, we can compare the modules in each and figure out the ones my bundle needs but you don't have yet. Then I can send you just the compartment map and the missing modules, and you can reassemble a functionally identical bundle. The bundleID will be the same, the imported behavior will be the same, but the zipfile itself might be slightly different. This lets us minimize the amount of data transmitted and stored.
+A bundle might be assembled piecemeal. If I want to give you a bundle, and you already have a number of similar bundles, we can compare the modules in each and figure out the ones my bundle needs but you don't have yet. Then I can send you just the compartment map and the missing modules, and you can reassemble a functionally identical bundle. The bundle ID will be the same, the imported behavior will be the same, but the zipfile itself might be slightly different. This lets us minimize the amount of data transmitted and stored.
+
+## Bundlecaps
+
+A "bundlecap" is an object (specifically a swingset "device node") which identifies a specific installed bundle. Bundlecaps only exist within swingset vats. Each bundlecap knows the bundle ID to which it refers. There is at most one bundlecap per bundle ID. It is not possible to make a bundlecap for a bundle that is not yet installed into the enclosing kernel, and holding a bundlecap guarantees that the bundle will be available (bundles may be GCed, but the bundlecap holds a reference that inhibits collection).
 
 ## How Swingset Uses Bundles
 
-The swingset kernel maintains a "bundle table" in the kernel database. Bundles can be installed here, indexed by their bundleID, and retrieved for various purposes:
+The swingset kernel maintains a "bundle table" in the kernel database. Bundles can be installed here, indexed by their bundle ID, and retrieved for various purposes:
 
 * all swingset vats, both static and dynamic, start from a bundle
   * in these bundles, the entry point module exports a function named `buildRootObject`
-* through a special `devices.bundle`, vat code can exchange a bundleID for a "bundlecap", which is an ocap-friendly way to refer to a bundle
+* through a special `devices.bundle`, vat code can exchange a bundle ID for a bundlecap
 * the bundlecap can be used with `vatAdminService~.createVat()` to make a new dynamic vat
-* userspace can use `D(bundlecap).getBundle()` to fetch the bundle itself, for use with `importBundle()` that does not create an entire new vat
+* userspace can use `D(bundlecap).getBundle()` to fetch the bundle itself, for use with an `importBundle()` that does not create an entire new vat
   * the Zoe "ZCF" facet uses this to load contract code within an existing vat
   * this could also be used as part of an in-vat upgrade process, to load new behavior
 * each vat also has a "liveslots" layer, defined by a bundle
-  * the liveslots bundleID is recorded separately for each vat, so liveslots can be upgraded (for new vats) without affecting the behavior of existing ones
+  * the liveslots bundle ID is recorded separately for each vat, so liveslots can be upgraded (for new vats) without affecting the behavior of existing ones
 * swingset devices are defined by bundles that are stored in the bundle table
 * the kernel source code itself is stored in a bundle, to make it easier to switch from one version of the kernel to another at a pre-determined time
 
+For convenience, the `vatAdminService` exposes both `getBundlecap(bundleID)` and `getNamedBundle(name)`, so user vats don't need to interact with `devices.bundle`.
+
 ## Bundle Installation Through Config
 
-When defining a static vat in the Swingset `config.vats` object, the filename provided as `sourceSpec` is turned into a bundle, the bundle is installed into the bundle table, and resulting bundleID is stored in the vat's database record. When the static vat is launched, the DB record provides the bundleID, and the bundle is loaded and evaluated in a new vat worker.
+When defining a static vat in the Swingset `config.vats` object, the filename provided as `sourceSpec` is turned into a bundle, the bundle is installed into the bundle table, and resulting bundle ID is stored in the vat's database record. When the static vat is launched, the DB record provides the bundle ID, and the bundle is loaded and evaluated in a new vat worker.
 
-The `config.bundles` object maps names to a bundle specification. These bundles are installed as above, and then a special "named bundles" table is updated with the name-to-bundleID mapping. These names are available to `D(devices.bundle).getNamedBundleCap(name) -> bundlecap`. For example, the chain's "core bootstrap" code will use this to define bundles for the core vats (Zoe, etc), and create dynamic vats at bootstrap time from them. It will also provide Zoe with the bundlecap for ZCF this way, so Zoe can later create dynamic ZCF vats. `E(vatAdminService).createVatByName(bundleName)` will continue to be supported until core-bootstrap is updated to retrieve bundlecaps, after which vat-admin will drop `createVatByName` and only support `createVat(bundlecap)`.
+The `config.bundles` object maps names to a bundle specification. These bundles are installed as above, and then a special "named bundles" table is updated with the name-to-bundle-ID mapping. These names are available to `D(devices.bundle).getNamedBundlecap(name) -> bundlecap` (or `E(vatAdminService).getNamedBundlecap`). For example, the chain's "core bootstrap" code will use this to define bundles for the core vats (Zoe, etc), and create dynamic vats at bootstrap time from them. It will also provide Zoe with the bundlecap for ZCF this way, so Zoe can later create dynamic ZCF vats. `E(vatAdminService).createVatByName(name)` will continue to be supported until core-bootstrap is updated to retrieve bundlecaps, after which vat-admin will drop `createVatByName` and only support `createVat(bundlecap)`.
 
-The `initializeSwingset()` function, called when the host application is first configured, creates bundles for built-in vats and devices (timer, vatAdmin, mailbox), as well as liveslots and the kernel, and installs them into the table as well. Internally, the kernel remembers the bundleID of each one for later use.
+The `initializeSwingset()` function, called when the host application is first configured, creates bundles for built-in vats and devices (timer, vatAdmin, mailbox), as well as liveslots and the kernel, and installs them into the table as well. Internally, the kernel remembers the bundle ID of each one for later use.
 
 ## Bundle Installation at Runtime
 
-Once the kernel is up and running, new bundles can be installed with the `controller.validateAndInstallBundle()` interface. This accepts a bundle and an optional alleged bundleID. It performs validity checks: if the ID is provided but does not match the compartment map, or if (TODO) the bundle contents do not match the compartment map, or if (TODO) the contents do not parse as JavaScript modules, then it will throw. If everything looks good, it will install the bundle into the table and return the computed bundleID.
+Once the kernel is up and running, new bundles can be installed with the `controller.validateAndInstallBundle()` interface. This accepts a bundle and an optional alleged bundle ID. It performs validity checks: if the ID is provided but does not match the compartment map, or if (TODO) the bundle contents do not match the compartment map, or if (TODO) the contents do not parse as JavaScript modules, then it will throw. If everything looks good, it will install the bundle into the table and return the computed bundle ID.
 
-Once the bundle is installed, the external caller can send a vat-level message with the bundleID to some vat within the kernel. The receiving vat can then do `D(devices.bundle).getBundleCap(bundleID) -> bundlecap` to get a handle from which vats can be created.
+Once the bundle is installed, the external caller can send a vat-level message with the bundle ID to some vat within the kernel. The receiving vat can then do `E(vatAdminService).getBundlecap(bundleID) -> bundlecap` to get a handle from which vats can be created.
 
 A future version of this interface will expose enough information to install individual modules first, and then "install" a bundle from just the compartment map contents (after checking that all the required modules are already present).
 
 By moving bundle installation into a separate external interface, vat-level messages can remain small. Currently the only place the full bundle will appear is in a vat transcript, in the results of the syscall that implements `D(bundlecap).getBundle()`, when userspace needs to do an `importBundle()` directly, and we hope to remove even that copy in the future.
 
-## Bundlecaps
+## Using Bundlecaps
 
-As suggested above, userspace works with a "bundlecap", which is a passable object (actually a device node) that represents the bundle. This can be passed through eventual-sends from one vat to another and stored in collections (and virtual objects). Internally, it wraps the bundleID.
+Userspace works with bundlecaps, which can be passed through eventual-sends from one vat to another and stored in collections (and virtual objects). Internally, each bundlecap wraps a bundle ID.
 
-The full set of things you can do with a bundlecap are:
+Bundlecaps can be obtained directly from the root device-node of the bundle device (aka `devices.bundle`). This `getBundlecap()` returns `undefined` (immediately) if the bundle ID was not installed at the moment of invocation.
 
-* `D(bundlecap).getBundleID() -> string`: to get the bundleID
+* `D(devices.bundle).getBundlecap(bundleID) -> bundlecap` (or `undefined` if not installed)
+* `D(devices.bundle).getNamedBundlecap(name) -> bundlecap` (throws if not registered)
+
+These methods are also exposed on `vatAdminService`, which (as a vat) always returns a Promise. The `getBundlecap()` method will wait (possibly forever) for the bundle ID to be installed before resolving its Promise, so the Promise will never resolve to `undefined`.
+
+* `E(vatAdminService).getBundlecap(bundleID) -> Promise<bundlecap>` (waits until installed)
+* `E(vatAdminService).getNamedBundlecap(name) -> Promise<bundlecap>` (rejects if not registered)
+
+Once you have a bundlecap, the full set of things you can do with it are:
+
+* `D(bundlecap).getBundleID() -> string`: to get the bundle ID
 * `D(bundlecap).getBundle() -> bundle object`: if you really need the full bundle, i.e. for `importBundle()`
 * `E(vatAdminService).createVat(bundlecap)`: create a new dynamic vat from the bundle
 
 ## Kernel Internals
 
-The kvStore has a subset of the key space reserved for holding bundles (mapping bundleID to the JSON-encoded bundle). Another keyspace holds mapping from bundle name to bundleID for the named bundles. These are accessed through `kernelKeeper` methods.
+The kvStore has a subset of the key space reserved for holding bundles (mapping bundle ID to the JSON-encoded bundle). Another keyspace holds mapping from bundle name to bundle ID for the named bundles. These are accessed through `kernelKeeper` methods.
 
-The "bundle device" (aka `devices.bundle`) has a root device node with an API to create bundlecaps:
-* `D(devices.bundle).getBundleCap(bundleID) -> bundlecap`
-* `D(devices.bundle).getNamedBundleCap(bundleName) -> bundlecap`
+Bundlecaps are new device nodes created by the bundle device. Internally, this device remembers the mapping from bundle ID to the device node ID (`dref`), and vice versa, in a pair of vatstore state entries. This mapping is not held in RAM: the state entries are looked up on each call to `getBundleID`/etc. The device can also access the kernelKeeper APIs to convert bundle IDs into full bundles, if requested.
 
-Bundlecaps are new device nodes created by the bundle device. Internally, this device remembers the mapping from bundleID to the device node ID (`dref`), and vice versa, in a pair of vatstore state entries. This mapping is not held in RAM: the state entries are looked up on each call to `getBundleID`/etc. The device can also access the kernelKeeper APIs to convert bundleIDs into full bundles, if requested.
+The vatAdmin vat's `createVat` method accepts bundlecaps (or full bundles, for now). The vatAdmin device (which is wrapped tightly by vatAdminVat and not exposed to anyone else) accepts bundle IDs. VatAdminDevice translates bundlecaps into bundle IDs before talking to the device.
 
-The vatAdmin vat's `createVat` method accepts bundlecaps (or full bundles, for now). The vatAdmin device (which is wrapped tightly by vatAdminVat and not exposed to anyone else) accepts bundleIDs. VatAdminDevice translates bundlecaps into bundleIDs before talking to the device.
+`controller.validateAndInstallBundle(bundle, optionalAllegedBundleID)` performs validity checks, installs the bundle, and returns the computed bundle ID. It uses `kernel.installBundle(bundleID, bundle)` internally, which uses uses `kernelKeeper` to store the bundle, and does not perform validation.
 
-`controller.validateAndInstallBundle(bundle, optionalAllegedBundleID)` performs validity checks, installs the bundle, and returns the computed bundleID. It uses `kernel.installBundle(bundleID, bundle)` internally, which uses uses `kernelKeeper` to store the bundle, and does not perform validation.
+## Initialization
 
+To support `getBundlecap`/`getNamedBundlecap`, the `vatAdminService` must be given access to `device.bundles` during initialization. The application-specific bootstrap vat needs a clause like:
 
+```js
+  const vatAdminService = await E(vats.vatAdmin).createVatAdminService(
+    devices.vatAdmin, devices.bundle);
+```
 
 ## Determinism
 
-Bundle installation is a transactional event: it must happen, and be committed, before the bundle is available. `D(devices.bundle).getBundleCap(bundleID)` will fail (consistently) if the bundle was not already installed. Host applications (like a chain) should perform `validateAndInstallBundle()` from within a transaction, so all validators maintain consensus about whether the bundle is installed or not.
+Bundle installation is a transactional event: it must happen, and be committed, before the bundle is available. `D(devices.bundle).getBundlecap(bundleID)` will fail (consistently) if the bundle was not already installed. Host applications (like a chain) should perform `validateAndInstallBundle()` from within a transaction, so all validators maintain consensus about whether the bundle is installed or not.
 
 But once a bundlecap is obtained, the corresponding bundle is guaranteed to be available. We do not yet have GC for bundles, but once we do, each copy of the bundlecap will establish a reference count. As long as any bundlecap is still held, the bundle will be held too. Bundles will be deleted at some point after the last bundlecap is gone. (We need a story for what keeps the bundle alive between the external `controller.validateAndInstallBundle()` and some vat getting a bundlecap, but that interval is not expected to be very long, so we might just use explicit GC actions that we don't run very often).

--- a/packages/SwingSet/src/devices/bundle.js
+++ b/packages/SwingSet/src/devices/bundle.js
@@ -34,13 +34,13 @@ The kernel will provide this device with three endowments:
 * getNamedBundleID(name) -> bundleID
 
 The root device node offers two methods to callers:
-* D(devices.bundle).getBundleCap(bundleID) -> devnode or undefined
-* D(devices.bundle).getNamedBundleCap(name) -> devnode or undefined
+* D(devices.bundle).getBundlecap(bundleID) -> devnode or undefined
+* D(devices.bundle).getNamedBundlecap(name) -> devnode or undefined
 
-The device node returned by getBundleCap() is called, unsurprisingly, a
+The device node returned by getBundlecap() is called, unsurprisingly, a
 "bundlecap". Most vats interact with bundlecaps, not bundleIDs (although of
-course somebody must call `getBundleCap()` first). Holding a bundlecap
-guarantees that the bundle contents are available, since `getBundleCap()`
+course somebody must call `getBundlecap()` first). Holding a bundlecap
+guarantees that the bundle contents are available, since `getBundlecap()`
 will fail unless the bundle is currently installed. When we implement
 refcounting GC for bundles, the bundlecap will maintain a reference and
 protect the bundle data from collection.
@@ -106,15 +106,15 @@ export function buildDevice(tools, endowments) {
       const args = unserialize(argsCapdata);
 
       if (dnid === ROOT) {
-        // D(devices.bundle).getBundleCap(id) -> bundlecap
-        if (method === 'getBundleCap') {
+        // D(devices.bundle).getBundlecap(id) -> bundlecap
+        if (method === 'getBundlecap') {
           const [bundleID] = args;
           assert.typeof(bundleID, 'string');
           assert(bundleIDRE.test(bundleID), 'not a bundleID');
           return returnCapForBundleID(bundleID);
         }
-        // D(devices.bundle).getNamedBundleCap(name) -> bundlecap
-        if (method === 'getNamedBundleCap') {
+        // D(devices.bundle).getNamedBundlecap(name) -> bundlecap
+        if (method === 'getNamedBundlecap') {
           const [name] = args;
           assert.typeof(name, 'string');
           let bundleID;

--- a/packages/SwingSet/src/initializeSwingset.js
+++ b/packages/SwingSet/src/initializeSwingset.js
@@ -365,7 +365,7 @@ export async function initializeSwingset(
   // The 'bundleName' option points into
   // config.bundles.BUNDLENAME.[bundle|bundleSpec|sourceSpec] , which can
   // also include arbitrary named bundles that will be made available to
-  // D(devices.bundle).getNamedBundleCap(bundleName) ,and temporarily as
+  // D(devices.bundle).getNamedBundlecap(bundleName) ,and temporarily as
   // E(vatAdminService).createVatByName(bundleName)
 
   // The 'kconfig' we pass through to initializeKernel has

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -1050,10 +1050,6 @@ export default function buildKernel(
         // later when it is created and a root object is available
         return vatID;
       },
-      getBundleIDByName(bundleName) {
-        // this throws if the name is unknown
-        return kernelKeeper.getNamedBundleID(bundleName);
-      },
       terminate: (vatID, reason) => terminateVat(vatID, true, reason),
       meterCreate: (remaining, threshold) =>
         kernelKeeper.allocateMeter(remaining, threshold),

--- a/packages/SwingSet/src/kernel/vatAdmin/vatAdmin-src.js
+++ b/packages/SwingSet/src/kernel/vatAdmin/vatAdmin-src.js
@@ -25,7 +25,6 @@ export function buildRootDeviceNode({ endowments, serialize }) {
   const {
     pushCreateVatBundleEvent,
     pushCreateVatIDEvent,
-    getBundleIDByName,
     terminate: kernelTerminateVatFn,
     meterCreate,
     meterAddRemaining,
@@ -60,17 +59,6 @@ export function buildRootDeviceNode({ endowments, serialize }) {
     },
     createByBundleID(bundleID, options = {}) {
       assert.typeof(bundleID, 'string');
-      const vatID = pushCreateVatIDEvent(bundleID, options);
-      return vatID;
-    },
-    createByName(bundleName, options = {}) {
-      assert.typeof(bundleName, 'string');
-      let bundleID;
-      try {
-        bundleID = getBundleIDByName(bundleName);
-      } catch (e) {
-        throw Error(`unregistered bundle name '${bundleName}'`);
-      }
       const vatID = pushCreateVatIDEvent(bundleID, options);
       return vatID;
     },

--- a/packages/SwingSet/test/bootstrap-syscall-failure.js
+++ b/packages/SwingSet/test/bootstrap-syscall-failure.js
@@ -16,6 +16,7 @@ export function buildRootObject(vatPowers, vatParameters) {
       if (vatParameters.beDynamic) {
         const vatMaker = E(vats.vatAdmin).createVatAdminService(
           devices.vatAdmin,
+          devices.bundle,
         );
         const vat = await E(vatMaker).createVatByName('badvat', {
           enableSetup: true,

--- a/packages/SwingSet/test/bundles/bootstrap-bundles.js
+++ b/packages/SwingSet/test/bundles/bootstrap-bundles.js
@@ -32,7 +32,10 @@ export function buildRootObject(vatPowers) {
       devices = d0;
       // we exercise a little bit of vatAdmin, but this test is mostly about
       // bundles
-      vatAdmin = await E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
+      vatAdmin = await E(vats.vatAdmin).createVatAdminService(
+        devices.vatAdmin,
+        devices.bundle,
+      );
     },
 
     async checkConfiguredVats() {

--- a/packages/SwingSet/test/bundles/bootstrap-bundles.js
+++ b/packages/SwingSet/test/bundles/bootstrap-bundles.js
@@ -40,8 +40,8 @@ export function buildRootObject(vatPowers) {
       return [hello];
     },
 
-    async vatFromNamedBundleCap(name, method) {
-      const bcap = D(devices.bundle).getNamedBundleCap(name);
+    async vatFromNamedBundlecap(name, method) {
+      const bcap = D(devices.bundle).getNamedBundlecap(name);
       const { root } = await E(vatAdmin).createVat(bcap);
       const hello = await E(root)[method]();
       return [hello];
@@ -55,25 +55,25 @@ export function buildRootObject(vatPowers) {
     },
 
     async vatFromID(id, method) {
-      const bcap = D(devices.bundle).getBundleCap(id);
+      const bcap = D(devices.bundle).getBundlecap(id);
       const { root } = await E(vatAdmin).createVat(bcap);
       const hello = await E(root)[method]();
       return [hello];
     },
 
-    getBundleCap(id) {
+    getBundlecap(id) {
       // bad bundleIDs should throw
-      return D(devices.bundle).getBundleCap(id);
+      return D(devices.bundle).getBundlecap(id);
     },
 
     getBundle(id) {
-      const bcap = D(devices.bundle).getBundleCap(id);
+      const bcap = D(devices.bundle).getBundlecap(id);
       return D(bcap).getBundle();
     },
 
     async checkImportByID(id) {
       function getCap() {
-        const bcap = D(devices.bundle).getBundleCap(id);
+        const bcap = D(devices.bundle).getBundlecap(id);
         assert.equal(D(bcap).getBundleID(), id);
         return bcap;
       }
@@ -82,7 +82,7 @@ export function buildRootObject(vatPowers) {
 
     async checkImportByName(name) {
       function getCap() {
-        return D(devices.bundle).getNamedBundleCap(name);
+        return D(devices.bundle).getNamedBundlecap(name);
       }
       return checkImport(getCap);
     },

--- a/packages/SwingSet/test/bundles/test-bundles.js
+++ b/packages/SwingSet/test/bundles/test-bundles.js
@@ -41,7 +41,7 @@ test('bundles', async t => {
 
   // This one (with 'hi()') provides a named vat bundle, for a static vat,
   // exercising config.vats.NAME.bundleName . We also build dynamic vats to
-  // test D(devices.bundle).getNamedBundleCap and E(vatAdmin).createVatByName
+  // test D(devices.bundle).getNamedBundlecap and E(vatAdmin).createVatByName
   const namedBundleFilename = bfile('vat-named.js');
 
   // We save this vat bundle (with 'disk()') to disk, to exercise
@@ -113,24 +113,24 @@ test('bundles', async t => {
   await check('checkConfiguredVats', [undefined], ['hello']);
 
   // create dynamic vats from a named bundle created at config file
-  await check('vatFromNamedBundleCap', ['named', 'hi'], ['hello']);
+  await check('vatFromNamedBundlecap', ['named', 'hi'], ['hello']);
 
   // pre-made bundles can be loaded from disk, via a named bundle
-  await check('vatFromNamedBundleCap', ['disk', 'disk'], ['otech']);
+  await check('vatFromNamedBundlecap', ['disk', 'disk'], ['otech']);
 
   // vatAdminService~.createVatByName() still works, TODO until we remove it
   await check('vatByName', ['named', 'hi'], ['hello']);
 
-  // D(devices.bundle).getBundleCap(invalidBundleID) should throw
+  // D(devices.bundle).getBundlecap(invalidBundleID) should throw
   await checkRejects(
-    'getBundleCap',
+    'getBundlecap',
     [invalidBundleID],
     Error('syscall.callNow failed: device.invoke failed, see logs for details'),
   );
   // the logs would show "not a bundleID"
 
-  // D(devices.bundle).getBundleCap(missingBundleID) should return undefined
-  await check('getBundleCap', [missingBundleID], undefined);
+  // D(devices.bundle).getBundlecap(missingBundleID) should return undefined
+  await check('getBundlecap', [missingBundleID], undefined);
 
   // install a vat bundle at runtime, make sure we can load it by ID
   const bid1 = await c.validateAndInstallBundle(installableVatBundle);
@@ -145,7 +145,7 @@ test('bundles', async t => {
   await check('checkImportByName', ['importableNonVat'], ['importable', true]);
 
   // check the shape of a bundlecap
-  const [s1, d1] = await run('getBundleCap', [bid2]);
+  const [s1, d1] = await run('getBundlecap', [bid2]);
   t.is(s1, 'fulfilled');
   const res1 = JSON.parse(d1.body);
   const dev1 = { '@qclass': 'slot', iface: 'Alleged: device node', index: 0 };

--- a/packages/SwingSet/test/gc-dead-vat/bootstrap.js
+++ b/packages/SwingSet/test/gc-dead-vat/bootstrap.js
@@ -14,7 +14,10 @@ export function buildRootObject() {
   const pk1 = makePromiseKit();
   return Far('root', {
     async bootstrap(vats, devices) {
-      const vatMaker = E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
+      const vatMaker = E(vats.vatAdmin).createVatAdminService(
+        devices.vatAdmin,
+        devices.bundle,
+      );
       vat = await E(vatMaker).createVatByName('doomed');
       doomedRoot = vat.root;
       await sendExport(doomedRoot);

--- a/packages/SwingSet/test/metering/vat-load-dynamic.js
+++ b/packages/SwingSet/test/metering/vat-load-dynamic.js
@@ -9,7 +9,10 @@ export function buildRootObject(vatPowers) {
 
   return Far('root', {
     async bootstrap(vats, devices) {
-      service = await E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
+      service = await E(vats.vatAdmin).createVatAdminService(
+        devices.vatAdmin,
+        devices.bundle,
+      );
       bundleDev = devices.bundle;
     },
 

--- a/packages/SwingSet/test/metering/vat-load-dynamic.js
+++ b/packages/SwingSet/test/metering/vat-load-dynamic.js
@@ -40,7 +40,7 @@ export function buildRootObject(vatPowers) {
     },
 
     async createVat(name, dynamicOptions) {
-      const bundleID = D(bundleDev).getNamedBundleCap(name);
+      const bundleID = D(bundleDev).getNamedBundlecap(name);
       control = await E(service).createVat(bundleID, dynamicOptions);
       const done = E(control.adminNode).done();
       // the caller checks this later, but doesn't wait for it

--- a/packages/SwingSet/test/vat-admin/bootstrap.js
+++ b/packages/SwingSet/test/vat-admin/bootstrap.js
@@ -24,15 +24,15 @@ export function buildRootObject(vatPowers) {
       return n;
     },
 
-    async byNamedBundleCap(name) {
-      const bcap = D(bundleDevice).getNamedBundleCap(name);
+    async byNamedBundlecap(name) {
+      const bcap = D(bundleDevice).getNamedBundlecap(name);
       const { root } = await E(admin).createVat(bcap);
       const n = await E(root).getANumber();
       return n;
     },
 
     async byID(id) {
-      const bcap = D(bundleDevice).getBundleCap(id);
+      const bcap = D(bundleDevice).getBundlecap(id);
       const { root } = await E(admin).createVat(bcap);
       const n = await E(root).getANumber();
       return n;
@@ -52,7 +52,7 @@ export function buildRootObject(vatPowers) {
       return E(admin).createVatByName(bundleName); // should reject
     },
 
-    async nonBundleCap() {
+    async nonBundlecap() {
       return E(admin).createVat(Far('non-bundlecap', {})); // should reject
     },
   });

--- a/packages/SwingSet/test/vat-admin/bootstrap.js
+++ b/packages/SwingSet/test/vat-admin/bootstrap.js
@@ -8,7 +8,10 @@ export function buildRootObject(vatPowers) {
 
   return Far('root', {
     async bootstrap(vats, devices) {
-      admin = await E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
+      admin = await E(vats.vatAdmin).createVatAdminService(
+        devices.vatAdmin,
+        devices.bundle,
+      );
       bundleDevice = devices.bundle;
     },
 

--- a/packages/SwingSet/test/vat-admin/replay-bootstrap.js
+++ b/packages/SwingSet/test/vat-admin/replay-bootstrap.js
@@ -11,7 +11,12 @@ export function buildRootObject(vatPowers) {
   return Far('root', {
     async bootstrap(vats, devs) {
       devices = devs;
-      gotVatAdminSvc(E(vats.vatAdmin).createVatAdminService(devices.vatAdmin));
+      gotVatAdminSvc(
+        E(vats.vatAdmin).createVatAdminService(
+          devices.vatAdmin,
+          devices.bundle,
+        ),
+      );
     },
 
     async createVat() {

--- a/packages/SwingSet/test/vat-admin/replay-bootstrap.js
+++ b/packages/SwingSet/test/vat-admin/replay-bootstrap.js
@@ -15,7 +15,7 @@ export function buildRootObject(vatPowers) {
     },
 
     async createVat() {
-      const bcap = D(devices.bundle).getNamedBundleCap('dynamic');
+      const bcap = D(devices.bundle).getNamedBundlecap('dynamic');
       const vc = await E(vatAdminSvc).createVat(bcap);
       root = vc.root;
       const count = await E(root).first();

--- a/packages/SwingSet/test/vat-admin/terminate/bootstrap-die-cleanly.js
+++ b/packages/SwingSet/test/vat-admin/terminate/bootstrap-die-cleanly.js
@@ -6,7 +6,10 @@ export function buildRootObject() {
 
   const self = Far('root', {
     async bootstrap(vats, devices) {
-      const vatMaker = E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
+      const vatMaker = E(vats.vatAdmin).createVatAdminService(
+        devices.vatAdmin,
+        devices.bundle,
+      );
 
       // create a dynamic vat, send it a message and let it respond, to make
       // sure everything is working

--- a/packages/SwingSet/test/vat-admin/terminate/bootstrap-die-with-presence.js
+++ b/packages/SwingSet/test/vat-admin/terminate/bootstrap-die-with-presence.js
@@ -7,7 +7,10 @@ export function buildRootObject(vatPowers) {
   const self = Far('root', {
     async bootstrap(vats, devices) {
       testLog('preparing dynamic vat');
-      const vatMaker = E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
+      const vatMaker = E(vats.vatAdmin).createVatAdminService(
+        devices.vatAdmin,
+        devices.bundle,
+      );
       const dude = await E(vatMaker).createVatByName('dude');
       E(dude.root).dieReturningAPresence(self);
       const doneP = E(dude.adminNode).done();

--- a/packages/SwingSet/test/vat-admin/terminate/bootstrap-no-zombies.js
+++ b/packages/SwingSet/test/vat-admin/terminate/bootstrap-no-zombies.js
@@ -4,7 +4,10 @@ import { Far } from '@endo/marshal';
 export function buildRootObject() {
   const self = Far('root', {
     async bootstrap(vats, devices) {
-      const vatMaker = E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
+      const vatMaker = E(vats.vatAdmin).createVatAdminService(
+        devices.vatAdmin,
+        devices.bundle,
+      );
 
       // create a dynamic vat, send it a message and let it respond, to make
       // sure everything is working

--- a/packages/SwingSet/test/vat-admin/terminate/bootstrap-speak-to-dead.js
+++ b/packages/SwingSet/test/vat-admin/terminate/bootstrap-speak-to-dead.js
@@ -10,7 +10,10 @@ export function buildRootObject(vatPowers) {
 
   const self = Far('root', {
     async bootstrap(vats, devices) {
-      const vatMaker = E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
+      const vatMaker = E(vats.vatAdmin).createVatAdminService(
+        devices.vatAdmin,
+        devices.bundle,
+      );
       mediumRoot = vats.medium;
 
       // create a dynamic vat, then kill it, then try to send it a message

--- a/packages/SwingSet/test/vat-admin/terminate/bootstrap-terminate.js
+++ b/packages/SwingSet/test/vat-admin/terminate/bootstrap-terminate.js
@@ -7,7 +7,10 @@ export function buildRootObject(vatPowers, vatParameters) {
 
   const self = Far('root', {
     async bootstrap(vats, devices) {
-      const vatMaker = E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
+      const vatMaker = E(vats.vatAdmin).createVatAdminService(
+        devices.vatAdmin,
+        devices.bundle,
+      );
 
       // create a dynamic vat, send it a message and let it respond, to make
       // sure everything is working

--- a/packages/SwingSet/test/vat-admin/test-create-vat.js
+++ b/packages/SwingSet/test/vat-admin/test-create-vat.js
@@ -66,7 +66,7 @@ test('createVat by named bundlecap', async t => {
   const { c } = await doTestSetup(t);
   const kpid = c.queueToVatRoot(
     'bootstrap',
-    'byNamedBundleCap',
+    'byNamedBundlecap',
     capargs(['new13']),
   );
   await c.run();
@@ -104,7 +104,7 @@ test('broken vat creation fails', async t => {
 
 test('error creating vat from non-bundle', async t => {
   const { c } = await doTestSetup(t);
-  const kpid = c.queueToVatRoot('bootstrap', 'nonBundleCap', capargs([]));
+  const kpid = c.queueToVatRoot('bootstrap', 'nonBundlecap', capargs([]));
   await c.run();
   t.is(c.kpStatus(kpid), 'rejected');
   t.deepEqual(

--- a/packages/governance/test/swingsetTests/committeeBinary/bootstrap.js
+++ b/packages/governance/test/swingsetTests/committeeBinary/bootstrap.js
@@ -211,6 +211,7 @@ const makeBootstrap = (argv, cb, vatPowers) => async (vats, devices) => {
   const log = vatPowers.testLog;
   const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
     devices.vatAdmin,
+    devices.bundle,
   );
   /** @type { ERef<ZoeService> } */
   const zoe = E(vats.zoe).buildZoe(vatAdminSvc);

--- a/packages/governance/test/swingsetTests/contractGovernor/bootstrap.js
+++ b/packages/governance/test/swingsetTests/contractGovernor/bootstrap.js
@@ -187,6 +187,7 @@ const makeBootstrap = (argv, cb, vatPowers) => async (vats, devices) => {
   const log = vatPowers.testLog;
   const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
     devices.vatAdmin,
+    devices.bundle,
   );
   /** @type { ERef<ZoeService> } */
   const zoe = E(vats.zoe).buildZoe(vatAdminSvc);

--- a/packages/run-protocol/test/vaultFactory/swingsetTests/governance/bootstrap.js
+++ b/packages/run-protocol/test/vaultFactory/swingsetTests/governance/bootstrap.js
@@ -80,6 +80,7 @@ const makeBootstrap = (argv, cb, vatPowers) => async (vats, devices) => {
   const log = vatPowers.testLog;
   const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
     devices.vatAdmin,
+    devices.bundle,
   );
   const { zoe, feeMintAccess } = await E(vats.zoe).buildZoe(vatAdminSvc);
 

--- a/packages/run-protocol/test/vaultFactory/swingsetTests/vaultFactory/bootstrap.js
+++ b/packages/run-protocol/test/vaultFactory/swingsetTests/vaultFactory/bootstrap.js
@@ -8,6 +8,7 @@ function makeBootstrap(argv, cb, vatPowers) {
   return async (vats, devices) => {
     const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
       devices.vatAdmin,
+      devices.bundle,
     );
     const { zoe, feeMintAccess } = await E(vats.zoe).buildZoe(vatAdminSvc);
 

--- a/packages/spawner/test/swingsetTests/contractHost/bootstrap.js
+++ b/packages/spawner/test/swingsetTests/contractHost/bootstrap.js
@@ -65,6 +65,7 @@ export function buildRootObject(vatPowers, vatParameters) {
     async bootstrap(vats, devices) {
       const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
         devices.vatAdmin,
+        devices.bundle,
       );
       const spawner = await E(vats.spawner).buildSpawner(vatAdminSvc);
       const [mode, trivialBundle] = vatParameters.argv;

--- a/packages/swingset-runner/src/vat-launcher.js
+++ b/packages/swingset-runner/src/vat-launcher.js
@@ -26,7 +26,10 @@ export function buildRootObject(_vatPowers, vatParameters) {
 
   return Far('root', {
     async bootstrap(vats, devices) {
-      const vatMaker = E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
+      const vatMaker = E(vats.vatAdmin).createVatAdminService(
+        devices.vatAdmin,
+        devices.bundle,
+      );
       const vatRoots = {};
       for (const vatName of Object.keys(vatParameters.config.vats)) {
         const vatDesc = vatParameters.config.vats[vatName];

--- a/packages/vats/src/bootstrap.js
+++ b/packages/vats/src/bootstrap.js
@@ -970,6 +970,7 @@ export function buildRootObject(vatPowers, vatParameters) {
 
       const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
         devices.vatAdmin,
+        devices.bundle,
       );
 
       console.debug(`${ROLE} bootstrap starting`);

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -18,7 +18,10 @@ export const makeVatsFromBundles = ({
   devices,
   produce: { vatAdminSvc, loadVat },
 }) => {
-  const svc = E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
+  const svc = E(vats.vatAdmin).createVatAdminService(
+    devices.vatAdmin,
+    devices.bundle,
+  );
   vatAdminSvc.resolve(svc);
   // TODO: getVat? do we need to memoize this by name?
   // TODO: rename loadVat to createVatByName?

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -135,6 +135,7 @@
  *      timer: unknown,
  *      bridge: Device<import('../bridge.js').BridgeDevice>,
  *      vatAdmin: unknown,
+ *      bundle: unknown,
  *   },
  *   vats: {
  *     comms: CommsVatRoot,

--- a/packages/zoe/test/swingsetTests/brokenContracts/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/bootstrap.js
@@ -44,6 +44,7 @@ export function buildRootObject(vatPowers, vatParameters) {
     async bootstrap(vats, devices) {
       const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
         devices.vatAdmin,
+        devices.bundle,
       );
       const zoe = await E(vats.zoe).buildZoe(vatAdminSvc);
       const installations = {

--- a/packages/zoe/test/swingsetTests/makeKind/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/makeKind/bootstrap.js
@@ -7,6 +7,7 @@ export function buildRootObject(vatPowers, vatParameters) {
     async bootstrap(vats, devices) {
       const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
         devices.vatAdmin,
+        devices.bundle,
       );
       const zoe = await E(vats.zoe).buildZoe(vatAdminSvc);
       const installations = {

--- a/packages/zoe/test/swingsetTests/offerArgs/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/offerArgs/bootstrap.js
@@ -7,6 +7,7 @@ export function buildRootObject(vatPowers, vatParameters) {
     async bootstrap(vats, devices) {
       const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
         devices.vatAdmin,
+        devices.bundle,
       );
       const zoe = await E(vats.zoe).buildZoe(vatAdminSvc);
       const installations = {

--- a/packages/zoe/test/swingsetTests/privateArgs/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/privateArgs/bootstrap.js
@@ -7,6 +7,7 @@ export function buildRootObject(vatPowers, vatParameters) {
     async bootstrap(vats, devices) {
       const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
         devices.vatAdmin,
+        devices.bundle,
       );
       const zoe = await E(vats.zoe).buildZoe(vatAdminSvc);
       const installations = {

--- a/packages/zoe/test/swingsetTests/runMint/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/runMint/bootstrap.js
@@ -7,6 +7,7 @@ export function buildRootObject(vatPowers, vatParameters) {
     async bootstrap(vats, devices) {
       const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
         devices.vatAdmin,
+        devices.bundle,
       );
       const { zoe, feeMintAccess } = await E(vats.zoe).buildZoe(vatAdminSvc);
       const installations = {

--- a/packages/zoe/test/swingsetTests/zoe/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/zoe/bootstrap.js
@@ -86,6 +86,7 @@ export function buildRootObject(vatPowers, vatParameters) {
     async bootstrap(vats, devices) {
       const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
         devices.vatAdmin,
+        devices.bundle,
       );
       const zoe = await E(vats.zoe).buildZoe(vatAdminSvc);
       const installations = {

--- a/packages/zoe/test/unitTests/zoe/test-createZCFVat.js
+++ b/packages/zoe/test/unitTests/zoe/test-createZCFVat.js
@@ -22,11 +22,13 @@ test('setupCreateZCFVat', async t => {
 
   // @ts-ignore fakeVatAdminSvc is mocked
   t.deepEqual(await setupCreateZCFVat(fakeVatAdminSvc, undefined)(), {
+    // @ts-ignore fakeVatAdminSvc is mocked
     adminNode: undefined,
     root: undefined,
   });
   // @ts-ignore fakeVatAdminSvc is mocked
   t.deepEqual(await setupCreateZCFVat(fakeVatAdminSvc, 'myVat')(), {
+    // @ts-ignore fakeVatAdminSvc is mocked
     adminNode: undefined,
     root: undefined,
   });


### PR DESCRIPTION
fix(swingset): make vatAdmin provide getBundlecap/getNamedBundlecap

This changes `vatAdminService` to expose/re-export the `getBundlecap()` and
`getNamedBundlecap()` functionality from `devices.bundle`. Since vats can
return Promises, the new vatAdmin.getBundlecap lets you wait for the given
bundle to be installed, which should simplify some contract install flows.

As a result, `createVatAdminService` changes: you must connect it to
`devices.bundle`. This requires a change to the bootstrap function all
tests (and production uses of swingset) from:

```js
const vatAdminService = await E(vats.vatAdmin).createVatAdminService(
  devices.vatAdmin);
```

to:

```js
const vatAdminService = await E(vats.vatAdmin).createVatAdminService(
  devices.vatAdmin, devices.bundle);
```

This commit updates all swingset tests to call createVatAdminService the new
way. The next commit will update all other packages in the tree. External
dapps don't usually perform full-swingset tests, so they are unlikely to be
affected.

closes #4521