### PR TITLE
fix(zoe): get ZCF bundlecap from vatAdminService

### DIFF
--- a/packages/swingset-runner/demo/exchangeBenchmark/vat-zoe.js
+++ b/packages/swingset-runner/demo/exchangeBenchmark/vat-zoe.js
@@ -8,11 +8,9 @@ export function buildRootObject(vatPowers, vatParameters) {
   return Far('root', {
     buildZoe: vatAdminSvc => {
       const shutdownZoeVat = vatPowers.exitVatWithFailure;
-      const { zoeService: zoe } = makeZoeKit(
-        vatAdminSvc,
-        shutdownZoeVat,
-        vatParameters.zcfBundleName,
-      );
+      const { zoeService: zoe } = makeZoeKit(vatAdminSvc, shutdownZoeVat, {
+        name: vatParameters.zcfBundleName,
+      });
       return zoe;
     },
   });

--- a/packages/swingset-runner/demo/swapBenchmark/vat-zoe.js
+++ b/packages/swingset-runner/demo/swapBenchmark/vat-zoe.js
@@ -8,11 +8,9 @@ export function buildRootObject(vatPowers, vatParameters) {
   return Far('root', {
     buildZoe: vatAdminSvc => {
       const shutdownZoeVat = vatPowers.exitVatWithFailure;
-      const { zoeService: zoe } = makeZoeKit(
-        vatAdminSvc,
-        shutdownZoeVat,
-        vatParameters.zcfBundleName,
-      );
+      const { zoeService: zoe } = makeZoeKit(vatAdminSvc, shutdownZoeVat, {
+        name: vatParameters.zcfBundleName,
+      });
       return zoe;
     },
   });

--- a/packages/swingset-runner/demo/zoeTests/vat-zoe.js
+++ b/packages/swingset-runner/demo/zoeTests/vat-zoe.js
@@ -8,11 +8,9 @@ export function buildRootObject(vatPowers, vatParameters) {
   return Far('root', {
     buildZoe: vatAdminSvc => {
       const shutdownZoeVat = vatPowers.exitVatWithFailure;
-      const { zoeService: zoe } = makeZoeKit(
-        vatAdminSvc,
-        shutdownZoeVat,
-        vatParameters.zcfBundleName,
-      );
+      const { zoeService: zoe } = makeZoeKit(vatAdminSvc, shutdownZoeVat, {
+        name: vatParameters.zcfBundleName,
+      });
       return zoe;
     },
   });

--- a/packages/vats/decentral-core-config.json
+++ b/packages/vats/decentral-core-config.json
@@ -40,10 +40,7 @@
       "sourceSpec": "./src/vat-walletManager.js"
     },
     "zoe": {
-      "sourceSpec": "./src/vat-zoe.js",
-      "parameters": {
-        "zcfBundleName": "zcf"
-      }
+      "sourceSpec": "./src/vat-zoe.js"
     }
   },
   "defaultManagerType": "xs-worker"

--- a/packages/vats/decentral-demo-config.json
+++ b/packages/vats/decentral-demo-config.json
@@ -43,10 +43,7 @@
       "sourceSpec": "./src/vat-walletManager.js"
     },
     "zoe": {
-      "sourceSpec": "./src/vat-zoe.js",
-      "parameters": {
-        "zcfBundleName": "zcf"
-      }
+      "sourceSpec": "./src/vat-zoe.js"
     }
   },
   "defaultManagerType": "xs-worker"

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -84,9 +84,10 @@ export const buildZoe = async ({
   consume: { vatAdminSvc, loadVat, client },
   produce: { zoe, feeMintAccess },
 }) => {
+  const zcfBundleName = 'zcf'; // should match config.bundles.zcf=
   const { zoeService, feeMintAccess: fma } = await E(
     E(loadVat)('zoe'),
-  ).buildZoe(vatAdminSvc, feeIssuerConfig);
+  ).buildZoe(vatAdminSvc, feeIssuerConfig, zcfBundleName);
 
   zoe.resolve(zoeService);
 

--- a/packages/vats/src/vat-zoe.js
+++ b/packages/vats/src/vat-zoe.js
@@ -1,15 +1,16 @@
 import { Far } from '@endo/far';
 import { makeZoeKit } from '@agoric/zoe';
 
-export function buildRootObject(vatPowers, vatParameters) {
+export function buildRootObject(vatPowers) {
   return Far('root', {
-    buildZoe: async (adminVat, feeIssuerConfig) => {
+    buildZoe: async (adminVat, feeIssuerConfig, zcfBundleName) => {
       const shutdownZoeVat = vatPowers.exitVatWithFailure;
+      assert(zcfBundleName, `vat-zoe requires zcfBundleName`);
       const { zoeService, feeMintAccess } = makeZoeKit(
         adminVat,
         shutdownZoeVat,
         feeIssuerConfig,
-        vatParameters.zcfBundleName,
+        { name: zcfBundleName },
       );
       return harden({
         zoeService,

--- a/packages/zoe/src/zoeService/createZCFVat.js
+++ b/packages/zoe/src/zoeService/createZCFVat.js
@@ -5,14 +5,28 @@ import { E } from '@agoric/eventual-send';
  * ZCF Vats can be created.
  *
  * @param {VatAdminSvc} vatAdminSvc
- * @param {string=} zcfBundleName
+ * @param {ZCFSpec} zcfSpec
  * @returns {CreateZCFVat}
  */
-export const setupCreateZCFVat = (vatAdminSvc, zcfBundleName = 'zcf') => {
+export const setupCreateZCFVat = (vatAdminSvc, zcfSpec) => {
   /** @type {CreateZCFVat} */
   const createZCFVat = async () => {
-    assert.typeof(zcfBundleName, 'string');
-    const rootAndAdminNodeP = E(vatAdminSvc).createVatByName(zcfBundleName);
+    /** @type {ERef<BundleCap>} */
+    let bundleCapP;
+    if (zcfSpec.bundleCap) {
+      bundleCapP = zcfSpec.bundleCap;
+    } else if (zcfSpec.name) {
+      bundleCapP = E(vatAdminSvc).getNamedBundleCap(zcfSpec.name);
+    } else if (zcfSpec.id) {
+      bundleCapP = E(vatAdminSvc).getBundleCap(zcfSpec.id);
+    } else {
+      const keys = Object.keys(zcfSpec).join(',');
+      assert.fail(`setupCreateZCFVat: bad zcfSpec, has keys '${keys}'`);
+    }
+    /** @type {BundleCap} */
+    const bundleCap = await bundleCapP;
+    assert(bundleCap, `setupCreateZCFVat did not get bundleCap`);
+    const rootAndAdminNodeP = E(vatAdminSvc).createVat(bundleCap);
     const rootAndAdminNode = await rootAndAdminNodeP;
     return rootAndAdminNode;
   };

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -268,8 +268,13 @@
 
 /**
  * @typedef {Object} VatAdminSvc
- * @property {(bundle: SourceBundle) => RootAndAdminNode} createVat
- * @property {(BundleName: string) => RootAndAdminNode} createVatByName
+ * @property {(BundleID: id) => BundleCap} getBundleCap
+ * @property {(name: string) => BundleCap} getNamedBundleCap
+ * @property {(bundleCap: BundleCap) => RootAndAdminNode} createVat
+ */
+
+/**
+ * @typedef {{bundleCap: BundleCap } | {name: string} | {id: BundleID}} ZCFSpec
  */
 
 /**

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -35,7 +35,7 @@ import { createFeeMint } from './feeMint.js';
  * shutdown the Zoe Vat. This function needs to use the vatPowers
  * available to a vat.
  * @param {FeeIssuerConfig} feeIssuerConfig
- * @param {string} [zcfBundleName] - The name of the contract facet bundle.
+ * @param {ZCFSpec} [zcfSpec] - Pointer to the contract facet bundle.
  * @returns {{
  *   zoeService: ZoeService,
  *   feeMintAccess: FeeMintAccess,
@@ -49,7 +49,7 @@ const makeZoeKit = (
     assetKind: AssetKind.NAT,
     displayInfo: harden({ decimalPlaces: 6, assetKind: AssetKind.NAT }),
   },
-  zcfBundleName = undefined,
+  zcfSpec = { name: 'zcf' },
 ) => {
   // We must pass the ZoeService to `makeStartInstance` before it is
   // defined. See below where the promise is resolved.
@@ -64,7 +64,7 @@ const makeZoeKit = (
   // This method contains the power to create a new ZCF Vat, and must
   // be closely held. vatAdminSvc is even more powerful - any vat can
   // be created. We severely restrict access to vatAdminSvc for this reason.
-  const createZCFVat = setupCreateZCFVat(vatAdminSvc, zcfBundleName);
+  const createZCFVat = setupCreateZCFVat(vatAdminSvc, zcfSpec);
 
   // The ZoeStorageManager composes and consolidates capabilities
   // needed by Zoe according to POLA.

--- a/packages/zoe/test/unitTests/zoe/test-createZCFVat.js
+++ b/packages/zoe/test/unitTests/zoe/test-createZCFVat.js
@@ -11,22 +11,21 @@ test('setupCreateZCFVat', async t => {
   // This is difficult to unit test, since the real functionality
   // creates a new vat
 
+  const zcfBundleCap = Far('zcfBundleCap', {});
   const fakeVatAdminSvc = Far('fakeVatAdminSvc', {
-    createVatByName: _name => {
-      return harden({ adminNode: undefined, root: undefined });
+    getNamedBundleCap: name => {
+      assert.equal(name, 'zcf');
+      return zcfBundleCap;
     },
-    createVat: _bundle => {
+    createVat: bundleCap => {
+      assert.equal(bundleCap, zcfBundleCap);
       return harden({ adminNode: undefined, root: undefined });
     },
   });
 
   // @ts-ignore fakeVatAdminSvc is mocked
-  t.deepEqual(await setupCreateZCFVat(fakeVatAdminSvc, undefined)(), {
-    adminNode: undefined,
-    root: undefined,
-  });
-  // @ts-ignore fakeVatAdminSvc is mocked
-  t.deepEqual(await setupCreateZCFVat(fakeVatAdminSvc, 'myVat')(), {
+  t.deepEqual(await setupCreateZCFVat(fakeVatAdminSvc, { name: 'zcf' })(), {
+    // @ts-ignore fakeVatAdminSvc is mocked
     adminNode: undefined,
     root: undefined,
   });


### PR DESCRIPTION
Zoe needs access to the vatAdminSvc, to create a new ZCF vat to host each
contract. `makeZoeKit()` provides an optional argument to control which
bundle is used for this purpose. This 4th argument was a string, defaulting
to 'zcf', and relied upon `E(vatAdminSvc).createVatByName` (which is going
away).

To move everything closer to bundlecaps, the `makeZoeKit()` optional argument
now takes `{ name }` or `{ id }` or `{ bundlecap }`, instead of only a name.
Zoe uses the new `E(vatAdminSvc).getNamedBundleCap()` to convert a name into
a bundlecap, but in the future I expect our chain-side bootstrap() to call
`makeZoeKit()` with a specific bundlecap. In the long run, I'm trying to make
room for Zoe to accomodate multiple versions of ZCF, each indexed by its
bundlecap.

Non-swingset-based zoe-using unit tests generally use `fakeVatAdmin.js` to
build a mock `vatAdminSvc`. This commit changes `fakeVatAdmin.js` to include
an additional `zcfBundlecap` export, which is an empty marker object that
serves as a stand-in for the bundlecap. The fake `vatAdminSvc` can accept
this fake `zcfBundlecap`, and will evaluate the ZCF code appropriately.
However the fake `vatAdminSvc` also knows how to convert the default `'zcf'`
name into that bundlecap, so downstream code should not need to change.

refs #4487
