### PR TITLE
feat(zoe): implement E(zoe).install(bundleOrBundleID)

### DIFF
--- a/packages/zoe/src/contractFacet/internal-types.js
+++ b/packages/zoe/src/contractFacet/internal-types.js
@@ -16,7 +16,7 @@
 
 /**
  * @typedef ZCFZygote
- * @property {(bundle: SourceBundle) => void} evaluateContract
+ * @property {(bundleOrBundlecap: SourceBundle | Bundlecap) => void} evaluateContract
  * @property {(instanceAdminFromZoe: ERef<ZoeInstanceAdmin>,
  *     instanceRecordFromZoe: InstanceRecord,
  *     issuerStorageFromZoe: IssuerRecords,

--- a/packages/zoe/src/contractFacet/vatRoot.js
+++ b/packages/zoe/src/contractFacet/vatRoot.js
@@ -29,7 +29,7 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
 
   /** @type {ExecuteContract} */
   const executeContract = (
-    bundle,
+    bundleOrBundlecap,
     zoeService,
     invitationIssuer,
     zoeInstanceAdmin,
@@ -44,7 +44,7 @@ export function buildRootObject(powers, _params, testJigSetter = undefined) {
       invitationIssuer,
       testJigSetter,
     );
-    zcfZygote.evaluateContract(bundle);
+    zcfZygote.evaluateContract(bundleOrBundlecap);
     return zcfZygote.startContract(
       zoeInstanceAdmin,
       instanceRecordFromZoe,

--- a/packages/zoe/src/contractFacet/zcfZygote.js
+++ b/packages/zoe/src/contractFacet/zcfZygote.js
@@ -2,7 +2,7 @@
 
 import { assert, details as X, makeAssert } from '@agoric/assert';
 import { E } from '@agoric/eventual-send';
-import { Far, Remotable } from '@endo/marshal';
+import { Far, Remotable, passStyleOf } from '@endo/marshal';
 import { AssetKind, AmountMath } from '@agoric/ertp';
 import { makeNotifierKit, observeNotifier } from '@agoric/notifier';
 import { makePromiseKit } from '@agoric/promise-kit';
@@ -340,7 +340,15 @@ export const makeZCFZygote = (
    * @type {ZCFZygote}
    * */
   const zcfZygote = {
-    evaluateContract: bundle => {
+    evaluateContract: bundleOrBundlecap => {
+      let bundle;
+      if (passStyleOf(bundleOrBundlecap) === 'remotable') {
+        const bundlecap = bundleOrBundlecap;
+        // @ts-ignore powers is not typed correctly: https://github.com/Agoric/agoric-sdk/issues/3239s
+        bundle = powers.D(bundlecap).getBundle();
+      } else {
+        bundle = bundleOrBundlecap;
+      }
       contractCode = evalContractBundle(bundle);
       handlePWarning(contractCode);
     },

--- a/packages/zoe/src/zoeService/installationStorage.js
+++ b/packages/zoe/src/zoeService/installationStorage.js
@@ -3,44 +3,74 @@
 import { assert, details as X } from '@agoric/assert';
 import { Far } from '@endo/marshal';
 import { E } from '@agoric/eventual-send';
+import { makeWeakStore } from '@agoric/store';
 
 /**
- *
+ * @param {GetBundlecapFromID} getBundlecapFromID
  */
-export const makeInstallationStorage = () => {
-  /** @type {WeakSet<Installation>} */
-  const installations = new WeakSet();
+export const makeInstallationStorage = getBundlecapFromID => {
+  /** @type {WeakStore<Installation, Bundlecap>} */
+  const installationsBundlecap = makeWeakStore('installationsBundlecap');
+  /** @type {WeakStore<Installation, SourceBundle>} */
+  const installationsBundle = makeWeakStore('installationsBundle');
 
   /**
-   * Create an installation by permanently storing the bundle. The code is
-   * currently evaluated each time it is used to make a new instance of a
-   * contract. When SwingSet supports zygotes, the code will be evaluated once
-   * when creating a zcfZygote, then the start() function will be called each
-   * time an instance is started.
+   * Create an installation from a bundle ID or a full bundle. If we are
+   * given a bundle ID, wait for the corresponding code bundle to be received
+   * by the swingset kernel, then store its bundlecap. The code is currently
+   * evaluated each time it is used to make a new instance of a contract.
+   * When SwingSet supports zygotes, the code will be evaluated once when
+   * creating a zcfZygote, then the start() function will be called each time
+   * an instance is started.
    */
   /** @type {Install} */
-  const install = async bundle => {
-    assert.typeof(bundle, 'object', X`a bundle must be provided`);
+  const install = async bundleOrID => {
     /** @type {Installation} */
-    const installation = Far('Installation', {
-      getBundle: () => bundle,
+    let installation;
+    if (typeof bundleOrID === 'object') {
+      /** @type {SourceBundle} */
+      const bundle = bundleOrID;
+      installation = Far('Installation', {
+        getBundle: () => bundle,
+        getBundleID: () => {
+          throw Error('installation used a bundle, not ID');
+        },
+      });
+      installationsBundle.init(installation, bundle);
+      return installation;
+    }
+    assert.typeof(bundleOrID, 'string', `needs bundle or bundle ID`);
+    /** @type {BundleID} */
+    const bundleID = bundleOrID;
+    // this waits until someone tells the host application to store the
+    // bundle into the kernel, with controller.validateAndInstallBundle()
+    const bundlecap = await getBundlecapFromID(bundleID);
+    installation = Far('Installation', {
+      getBundle: () => {
+        throw Error('installation used a bundleID, not bundle');
+      },
+      getBundleID: () => bundleID,
     });
-    installations.add(installation);
+    installationsBundlecap.init(installation, bundlecap);
     return installation;
   };
-
-  const assertInstallation = installation =>
-    assert(
-      installations.has(installation),
-      X`${installation} was not a valid installation`,
-    );
 
   /** @type {UnwrapInstallation} */
   const unwrapInstallation = installationP => {
     return E.when(installationP, installation => {
-      assertInstallation(installation);
-      const bundle = installation.getBundle();
-      return { bundle, installation };
+      if (installationsBundlecap.has(installation)) {
+        return {
+          bundleOrBundlecap: installationsBundlecap.get(installation),
+          installation,
+        };
+      } else if (installationsBundle.has(installation)) {
+        return {
+          bundleOrBundlecap: installationsBundle.get(installation),
+          installation,
+        };
+      } else {
+        assert.fail(X`${installation} was not a valid installation`);
+      }
     });
   };
 

--- a/packages/zoe/src/zoeService/internal-types.js
+++ b/packages/zoe/src/zoeService/internal-types.js
@@ -54,14 +54,18 @@
  */
 
 /**
+ * @typedef { SourceBundle | Bundlecap } BundleOrBundlecap
+ */
+
+/**
  * @callback UnwrapInstallation
  *
- * Assert the installation is known, and return the bundle and
+ * Assert the installation is known, and return the bundle/bundlecap and
  * installation
  *
  * @param {ERef<Installation>} installationP
  * @returns {Promise<{
- *   bundle: SourceBundle,
+ *   bundleOrBundlecap: BundleOrBundlecap,
  *   installation:Installation
  * }>}
  */
@@ -103,6 +107,12 @@
  * @param {IssuerKeywordRecord} uncleanIssuerKeywordRecord
  * @param {Instance} instance
  * @returns {ZoeInstanceStorageManager}
+ */
+
+/**
+ * @callback GetBundlecapFromID
+ * @param {BundleID} id
+ * @returns {Promise<Bundlecap>}
  */
 
 /**

--- a/packages/zoe/src/zoeService/startInstance.js
+++ b/packages/zoe/src/zoeService/startInstance.js
@@ -31,7 +31,9 @@ export const makeStartInstance = (
     /** @type {WeakStore<SeatHandle, ZoeSeatAdmin>} */
     const seatHandleToZoeSeatAdmin = makeWeakStore('seatHandle');
 
-    const { installation, bundle } = await unwrapInstallation(installationP);
+    const { installation, bundleOrBundlecap } = await unwrapInstallation(
+      installationP,
+    );
     // AWAIT ///
 
     if (privateArgs !== undefined) {
@@ -204,7 +206,7 @@ export const makeStartInstance = (
       creatorInvitation: creatorInvitationP,
       handleOfferObj,
     } = await E(zcfRoot).executeContract(
-      bundle,
+      bundleOrBundlecap,
       zoeServicePromise,
       zoeInstanceStorageManager.invitationIssuer,
       zoeInstanceAdminForZcf,

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -113,12 +113,16 @@
  */
 
 /**
+ * @typedef { SourceBundle | BundleID } BundleOrBundleID
+ */
+
+/**
  * @callback Install
  *
  * Create an installation by safely evaluating the code and
  * registering it with Zoe. Returns an installation.
  *
- * @param {SourceBundle} bundle
+ * @param {BundleOrBundleID} bundleOrBundleID
  * @returns {Promise<Installation>}
  */
 
@@ -272,9 +276,9 @@
 
 /**
  * @typedef {Object} VatAdminSvc
- * @property {(BundleID: id) => Bundlecap} getBundlecap
- * @property {(name: string) => Bundlecap} getNamedBundlecap
- * @property {(bundlecap: Bundlecap) => RootAndAdminNode} createVat
+ * @property {(BundleID: id) => Promise<Bundlecap>} getBundlecap
+ * @property {(name: string) => Promise<Bundlecap>} getNamedBundlecap
+ * @property {(bundlecap: Bundlecap) => Promise<RootAndAdminNode>} createVat
  */
 
 /**
@@ -306,6 +310,7 @@
 /**
  * @typedef {Object} Installation
  * @property {() => SourceBundle} getBundle
+ * @property {() => BundleID} getBundleID
  */
 
 /**

--- a/packages/zoe/src/zoeService/zoe.js
+++ b/packages/zoe/src/zoeService/zoe.js
@@ -17,6 +17,7 @@ import '../internal-types.js';
 
 import { AssetKind } from '@agoric/ertp';
 import { Far } from '@endo/marshal';
+import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
 
 import { makeZoeStorageManager } from './zoeStorageManager.js';
@@ -61,6 +62,8 @@ const makeZoeKit = (
     shutdownZoeVat,
   );
 
+  const getBundlecapFromID = bundleID => E(vatAdminSvc).getBundlecap(bundleID);
+
   // This method contains the power to create a new ZCF Vat, and must
   // be closely held. vatAdminSvc is even more powerful - any vat can
   // be created. We severely restrict access to vatAdminSvc for this reason.
@@ -83,6 +86,7 @@ const makeZoeKit = (
     invitationIssuer,
   } = makeZoeStorageManager(
     createZCFVat,
+    getBundlecapFromID,
     getFeeIssuerKit,
     shutdownZoeVat,
     feeIssuer,

--- a/packages/zoe/src/zoeService/zoeStorageManager.js
+++ b/packages/zoe/src/zoeService/zoeStorageManager.js
@@ -26,6 +26,7 @@ import { makeInstallationStorage } from './installationStorage.js';
  *
  * @param {CreateZCFVat} createZCFVat - the ability to create a new
  * ZCF Vat
+ * @param {GetBundlecapFromID} getBundlecapFromID
  * @param {GetFeeIssuerKit} getFeeIssuerKit
  * @param {ShutdownWithFailure} shutdownZoeVat
  * @param {Issuer} feeIssuer
@@ -34,6 +35,7 @@ import { makeInstallationStorage } from './installationStorage.js';
  */
 export const makeZoeStorageManager = (
   createZCFVat,
+  getBundlecapFromID,
   getFeeIssuerKit,
   shutdownZoeVat,
   feeIssuer,
@@ -82,7 +84,8 @@ export const makeZoeStorageManager = (
   // Zoe stores "installations" - identifiable bundles of contract
   // code that can be reused again and again to create new contract
   // instances
-  const { install, unwrapInstallation } = makeInstallationStorage();
+  const { install, unwrapInstallation } =
+    makeInstallationStorage(getBundlecapFromID);
 
   /** @type {MakeZoeInstanceStorageManager} */
   const makeZoeInstanceStorageManager = async (

--- a/packages/zoe/test/unitTests/setupBasicMints.js
+++ b/packages/zoe/test/unitTests/setupBasicMints.js
@@ -3,7 +3,7 @@
 import { makeIssuerKit, AmountMath } from '@agoric/ertp';
 import { makeStore } from '@agoric/store';
 import { makeZoeKit } from '../../src/zoeService/zoe.js';
-import fakeVatAdmin from '../../tools/fakeVatAdmin.js';
+import { makeFakeVatAdmin } from '../../tools/fakeVatAdmin.js';
 
 const setup = () => {
   const moolaBundle = makeIssuerKit('moola');
@@ -21,6 +21,7 @@ const setup = () => {
     brands.init(k, allBundles[k].brand);
   }
 
+  const { admin: fakeVatAdmin, vatAdminState } = makeFakeVatAdmin();
   const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   /** @type {(brand: Brand) => (value: AmountValue) => Amount} */
@@ -66,6 +67,7 @@ const setup = () => {
     simoleans: makeSimpleMake(simoleanBundle.brand),
     bucks: makeSimpleMake(bucksBundle.brand),
     zoe,
+    vatAdminState,
   };
   harden(result);
   return result;

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -37,11 +37,11 @@ test(`E(zoe).install bad bundle`, async t => {
   const { zoe } = setup();
   // @ts-ignore deliberate invalid arguments for testing
   await t.throwsAsync(() => E(zoe).install(), {
-    message: 'a bundle must be provided',
+    message: 'a bundle or bundle ID must be provided',
   });
 });
 
-test(`E(zoe).install`, async t => {
+test(`E(zoe).install(bundle)`, async t => {
   const { zoe } = setup();
   const contractPath = `${dirname}/../../src/contracts/atomicSwap`;
   const bundle = await bundleSource(contractPath);
@@ -51,6 +51,20 @@ test(`E(zoe).install`, async t => {
   // const hash = await E(installation).getHash();
   // assert.is(hash, 'XXX');
   t.is(await E(installation).getBundle(), bundle);
+});
+
+test(`E(zoe).install(bundleID)`, async t => {
+  const { zoe, vatAdminState } = setup();
+  const contractPath = `${dirname}/../../src/contracts/atomicSwap`;
+  const bundle = await bundleSource(contractPath);
+  vatAdminState.installBundle('b1-atomic', bundle);
+  const installation = await E(zoe).install('b1-atomic');
+  // TODO Check the integrity of the installation by its hash.
+  // https://github.com/Agoric/agoric-sdk/issues/3859
+  // const hash = await E(installation).getHash();
+  // assert.is(hash, 'XXX');
+  // NOTE: the bundle ID is now tha hash
+  t.is(await E(installation).getBundleID(), 'b1-atomic');
 });
 
 test(`E(zoe).startInstance bad installation`, async t => {

--- a/packages/zoe/test/unitTests/zoe/test-installationStorage.js
+++ b/packages/zoe/test/unitTests/zoe/test-installationStorage.js
@@ -3,6 +3,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
 
+import { makeHandle } from '../../../src/makeHandle.js';
 import { makeInstallationStorage } from '../../../src/zoeService/installationStorage.js';
 
 test('install, unwrap installations', async t => {
@@ -12,7 +13,21 @@ test('install, unwrap installations', async t => {
   const installation = await install(fakeBundle);
   const unwrapped = await unwrapInstallation(installation);
   t.is(unwrapped.installation, installation);
-  t.is(unwrapped.bundle, fakeBundle);
+  t.is(unwrapped.bundleOrBundlecap, fakeBundle);
+});
+
+test('install, unwrap installation of bundlecap', async t => {
+  const bundlecaps = { id: makeHandle('Bundlecap') };
+  const getBundlecapFromID = id => bundlecaps[id];
+
+  const { install, unwrapInstallation } =
+    makeInstallationStorage(getBundlecapFromID);
+
+  const installation = await install('id');
+  const unwrapped = await unwrapInstallation(installation);
+  t.is(unwrapped.installation, installation);
+  t.is(unwrapped.bundleOrBundlecap, bundlecaps.id);
+  t.is(installation.getBundleID(), 'id');
 });
 
 test('unwrap promise for installation', async t => {
@@ -22,7 +37,7 @@ test('unwrap promise for installation', async t => {
   const installation = await install(fakeBundle);
   const unwrapped = await unwrapInstallation(Promise.resolve(installation));
   t.is(unwrapped.installation, installation);
-  t.is(unwrapped.bundle, fakeBundle);
+  t.is(unwrapped.bundleOrBundlecap, fakeBundle);
 });
 
 test('install several', async t => {
@@ -33,22 +48,25 @@ test('install several', async t => {
   const installation1 = await install(fakeBundle1);
   const unwrapped1 = await unwrapInstallation(installation1);
   t.is(unwrapped1.installation, installation1);
-  t.is(unwrapped1.bundle, fakeBundle1);
+  t.is(unwrapped1.bundleOrBundlecap, fakeBundle1);
 
   const installation2 = await install(fakeBundle2);
   const unwrapped2 = await unwrapInstallation(installation2);
   t.is(unwrapped2.installation, installation2);
-  t.is(unwrapped2.bundle, fakeBundle2);
+  t.is(unwrapped2.bundleOrBundlecap, fakeBundle2);
 });
 
 test('install same twice', async t => {
-  const { install, unwrapInstallation } = makeInstallationStorage();
+  const bundlecaps = { id: makeHandle('Bundlecap') };
+  const getBundlecapFromID = id => bundlecaps[id];
+  const { install, unwrapInstallation } =
+    makeInstallationStorage(getBundlecapFromID);
   const fakeBundle1 = {};
 
   const installation1 = await install(fakeBundle1);
   const unwrapped1 = await unwrapInstallation(installation1);
   t.is(unwrapped1.installation, installation1);
-  t.is(unwrapped1.bundle, fakeBundle1);
+  t.is(unwrapped1.bundleOrBundlecap, fakeBundle1);
 
   // If the same bundle is installed twice, the bundle is the same,
   // but the installation is different. Zoe does not currently care about
@@ -57,5 +75,18 @@ test('install same twice', async t => {
   const unwrapped2 = await unwrapInstallation(installation2);
   t.is(unwrapped2.installation, installation2);
   t.not(installation2, installation1);
-  t.is(unwrapped2.bundle, fakeBundle1);
+  t.is(unwrapped2.bundleOrBundlecap, fakeBundle1);
+
+  const installation3 = await install('id');
+  const installation4 = await install('id');
+  t.not(installation3, installation4);
+  const unwrapped3 = await unwrapInstallation(installation3);
+  t.is(unwrapped3.installation, installation3);
+  t.is(unwrapped3.bundleOrBundlecap, bundlecaps.id);
+  const unwrapped4 = await unwrapInstallation(installation4);
+  t.is(unwrapped4.installation, installation4);
+  t.is(unwrapped4.bundleOrBundlecap, bundlecaps.id);
+
+  t.is(installation3.getBundleID(), 'id');
+  t.is(installation4.getBundleID(), 'id');
 });

--- a/packages/zoe/tools/fakeVatAdmin.js
+++ b/packages/zoe/tools/fakeVatAdmin.js
@@ -3,6 +3,7 @@
 import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@agoric/promise-kit';
 import { Far } from '@endo/marshal';
+import { makeStore } from '@agoric/store';
 
 import { assert } from '@agoric/assert';
 import { evalContractBundle } from '../src/contractFacet/evalContractCode.js';
@@ -24,6 +25,10 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
   let exitMessage;
   let hasExited = false;
   let exitWithFailure;
+  /** @type {Store<BundleID, Bundlecap>} */
+  const idToBundlecap = makeStore('idToBundlecap');
+  /** @type {Store<Bundlecap, EndoZipBase64Bundle>} */
+  const bundlecapToBundle = makeStore('bundlecapToBundle');
   const fakeVatPowers = {
     exitVat: completion => {
       exitMessage = completion;
@@ -35,48 +40,73 @@ function makeFakeVatAdmin(testContextSetter = undefined, makeRemote = x => x) {
       hasExited = true;
       exitWithFailure = true;
     },
+    D: bundlecap => ({
+      getBundle: () => bundlecapToBundle.get(bundlecap),
+    }),
   };
 
   // This is explicitly intended to be mutable so that
   // test-only state can be provided from contracts
   // to their tests.
   const admin = Far('vatAdmin', {
-    getBundlecap: _bundleID => {
-      assert.fail(`fakeVatAdmin.getBundlecap() not yet implemented`);
+    getBundlecap: bundleID => {
+      if (!idToBundlecap.has(bundleID)) {
+        idToBundlecap.init(bundleID, makeHandle('Bundlecap'));
+      }
+      return Promise.resolve(idToBundlecap.get(bundleID));
     },
     getNamedBundlecap: name => {
       assert.equal(name, 'zcf', 'fakeVatAdmin only knows ZCF');
-      return zcfBundlecap;
+      return Promise.resolve(zcfBundlecap);
     },
     createVat: bundlecap => {
       assert.equal(bundlecap, zcfBundlecap, 'fakeVatAdmin only knows ZCF');
       const bundle = zcfContractBundle;
-      return harden({
-        root: makeRemote(
-          E(evalContractBundle(bundle)).buildRootObject(
-            fakeVatPowers,
-            undefined,
-            testContextSetter,
+      return Promise.resolve(
+        harden({
+          root: makeRemote(
+            E(evalContractBundle(bundle)).buildRootObject(
+              fakeVatPowers,
+              undefined,
+              testContextSetter,
+            ),
           ),
-        ),
-        adminNode: Far('adminNode', {
-          done: () => {
-            const kit = makePromiseKit();
-            handlePKitWarning(kit);
-            return kit.promise;
-          },
-          terminateWithFailure: () => {},
+          adminNode: Far('adminNode', {
+            done: () => {
+              const kit = makePromiseKit();
+              handlePKitWarning(kit);
+              return kit.promise;
+            },
+            terminateWithFailure: () => {},
+          }),
         }),
-      });
+      );
     },
   });
   const vatAdminState = {
     getExitMessage: () => exitMessage,
     getHasExited: () => hasExited,
     getExitWithFailure: () => exitWithFailure,
+    installBundle: (id, bundle) => {
+      if (idToBundlecap.has(id)) {
+        assert.equal(
+          bundle.endoZipBase64,
+          bundlecapToBundle.get(idToBundlecap.get(id)).endoZipBase64,
+        );
+        return;
+      }
+      const bundlecap = makeHandle('Bundlecap');
+      idToBundlecap.init(id, bundlecap);
+      bundlecapToBundle.init(bundlecap, bundle);
+    },
   };
   return { admin, vatAdminState };
 }
+
+// Tests which use this global/shared fakeVatAdmin should really import
+// makeFakeVatAdmin() instead, and build their own private instance. This
+// will be forced when #4565 requires them to use
+// vatAdminState.installBundle().
 
 const fakeVatAdmin = makeFakeVatAdmin().admin;
 


### PR DESCRIPTION
Previously, `E(zoe).install()` accepted a source bundle. Now it accepts
either a source bundle, or a "bundle ID". The ID is a hash-based identifier
string that refers to a bundle installed into the kernel via
`controller.validateAndInstallBundle()`, and is retrievable from
vatAdminService. Zoe exchanges the ID for a bundlecap, and retains the
bundlecap for future use (including passing to the new ZCF vat, which
converts it into a source bundle for evaluation at the last possible moment).

The kernel install step can happen either before or after `E(zoe).install`,
because the id-to-bundlecap conversion waits until the kernel install is
complete.

This begins the process of making Zoe work exclusively with (small)
bundlecaps, and not (large) source bundles. The next step is to modify all
unit tests and external callers (including deploy scripts, #4564) to
kernel-install their bundle and use a bundleID for the Zoe install()
invocation. After that is complete, #4565 will remove support for full
bundles, and `E(zoe).install(bundleID)` will be the only choice.

closes #4563
