### PR TITLE
Agoric add cli command

### DIFF
--- a/packages/agoric-cli/src/add.js
+++ b/packages/agoric-cli/src/add.js
@@ -1,0 +1,35 @@
+import fs from 'fs';
+import installMain from './install.js';
+
+function subMain(fn, args, options, powers, progname) {
+  return fn(progname, args, powers, options).then(
+    // This seems to be the only way to propagate the exit code.
+    code => process.exit(code || 0),
+  );
+}
+
+export default async function addMain(progname, rawArgs, powers, opts) {
+  const command = rawArgs[0];
+  const workspace = rawArgs[1][0];
+  if (rawArgs[1].length < 2) {
+    console.error(
+      'Invalid format\nUse : agoric add workspace packagesname@version',
+    );
+    return;
+  }
+  if (command === 'add') {
+    const packages = rawArgs[1].slice(1)[0];
+    let path = powers.process.env.PWD + '/' + workspace + '/package.json';
+    let packageJson = fs.readFileSync(path, 'utf-8');
+    packageJson = JSON.parse(packageJson);
+
+    let package_version = packages.split('@');
+    let packageName = package_version[0];
+    const version = package_version[1];
+    packageJson.dependencies[packageName.toString()] = version
+      ? '^' + version
+      : '*';
+    packageJson = JSON.stringify(packageJson);
+    fs.writeFileSync(path, packageJson, 'utf-8');
+  }
+}

--- a/packages/agoric-cli/src/main.js
+++ b/packages/agoric-cli/src/main.js
@@ -9,6 +9,7 @@ import installMain from './install.js';
 import setDefaultsMain from './set-defaults.js';
 import startMain from './start.js';
 import walletMain from './open.js';
+import addMain from './add.js';
 
 const DEFAULT_DAPP_TEMPLATE = 'dapp-fungible-faucet';
 const DEFAULT_DAPP_URL_BASE = 'https://github.com/Agoric/';
@@ -41,6 +42,9 @@ const main = async (progname, rawArgs, powers) => {
       // This seems to be the only way to propagate the exit code.
       code => process.exit(code || 0),
     );
+  }
+  function subMainNoExit(fn, args, options) {
+    return fn(progname, args, powers, options);
   }
 
   program.storeOptionsAsProperties(false);
@@ -150,7 +154,20 @@ const main = async (progname, rawArgs, powers) => {
       const opts = { ...program.opts(), ...cmd.opts() };
       return subMain(setDefaultsMain, ['set-defaults', prog, configDir], opts);
     });
-
+  program
+    .command('add [script-args...]')
+    .description('add a new dependency to the directory')
+    .action(async (scriptArgs, cmd) => {
+      await isNotBasedir();
+      const opts = { ...program.opts(), ...cmd.opts() };
+      subMainNoExit(addMain, ['add', scriptArgs], opts);
+      await isNotBasedir();
+      console.log(scriptArgs);
+      if (scriptArgs.length < 2) {
+        return;
+      }
+      return subMain(installMain, ['install', undefined], opts);
+    });
   program
     .command('install [force-sdk-version]')
     .description('install Dapp dependencies')


### PR DESCRIPTION
### Use case of the command:
- Previously, If we needed to install an `npm package` to the ui directory.
- We had to manually add the package name to the `package.json` file in the `ui` directory.
- And then by running `agoric install` from the main directory installed that package.
- The `agoric add cli` command just `automates` this process.
- For example if we need to add `react-toastify` package to our ui npm module.
- Using this command we just have to run `agoric add ui react-toastify`.
- For a specific version `agoric add ui react-toastify@1.2.4`