### PR TITLE
refactor(run-protocol): remove unused InitialMargin param

### DIFF
--- a/packages/run-protocol/bundles/install-on-chain.js
+++ b/packages/run-protocol/bundles/install-on-chain.js
@@ -229,7 +229,6 @@ export async function installOnChain({
 
   // declare governed params for the vaultFactory; addVaultType() sets actual rates
   const rates = {
-    initialMargin: makeRatio(120n, centralBrand),
     liquidationMargin: makeRatio(105n, centralBrand),
     interestRate: makeRatio(250n, centralBrand, BASIS_POINTS),
     loanFee: makeRatio(200n, centralBrand, BASIS_POINTS),

--- a/packages/run-protocol/src/econ-behaviors.js
+++ b/packages/run-protocol/src/econ-behaviors.js
@@ -240,7 +240,6 @@ export const startVaultFactory = async (
 
   // declare governed params for the vaultFactory; addVaultType() sets actual rates
   const rates = {
-    initialMargin: makeRatio(120n, centralBrand),
     liquidationMargin: makeRatio(105n, centralBrand),
     interestRate: makeRatio(250n, centralBrand, BASIS_POINTS),
     loanFee: makeRatio(200n, centralBrand, BASIS_POINTS),

--- a/packages/run-protocol/src/vaultFactory/params.js
+++ b/packages/run-protocol/src/vaultFactory/params.js
@@ -13,7 +13,6 @@ import {
 export const CHARGING_PERIOD_KEY = 'ChargingPeriod';
 export const RECORDING_PERIOD_KEY = 'RecordingPeriod';
 
-export const INITIAL_MARGIN_KEY = 'InitialMargin';
 export const LIQUIDATION_MARGIN_KEY = 'LiquidationMargin';
 export const INTEREST_RATE_KEY = 'InterestRate';
 export const LOAN_FEE_KEY = 'LoanFee';
@@ -35,7 +34,6 @@ const makeLoanParams = (loanTiming, rates) => {
   return harden({
     [CHARGING_PERIOD_KEY]: makeGovernedNat(loanTiming.chargingPeriod),
     [RECORDING_PERIOD_KEY]: makeGovernedNat(loanTiming.recordingPeriod),
-    [INITIAL_MARGIN_KEY]: makeGovernedRatio(rates.initialMargin),
     [LIQUIDATION_MARGIN_KEY]: makeGovernedRatio(rates.liquidationMargin),
     [INTEREST_RATE_KEY]: makeGovernedRatio(rates.interestRate),
     [LOAN_FEE_KEY]: makeGovernedRatio(rates.loanFee),
@@ -64,7 +62,6 @@ const makeLoanTimingManager = initialValues => {
 const makeVaultParamManager = rates => {
   // @ts-expect-error until makeParamManagerBuilder can be generic */
   return makeParamManagerBuilder()
-    .addBrandedRatio(INITIAL_MARGIN_KEY, rates.initialMargin)
     .addBrandedRatio(LIQUIDATION_MARGIN_KEY, rates.liquidationMargin)
     .addBrandedRatio(INTEREST_RATE_KEY, rates.interestRate)
     .addBrandedRatio(LOAN_FEE_KEY, rates.loanFee)

--- a/packages/run-protocol/src/vaultFactory/types.js
+++ b/packages/run-protocol/src/vaultFactory/types.js
@@ -8,7 +8,6 @@
 
 /**
  * @typedef {Object} Collateral
- * @property {Ratio} initialMargin
  * @property {Ratio} liquidationMargin
  * @property {Ratio} stabilityFee
  * @property {Ratio} marketPrice
@@ -18,8 +17,6 @@
 
 /**
  * @typedef {Object} Rates
- * @property {Ratio} initialMargin - minimum over-collateralization
- * required to open a loan
  * @property {Ratio} liquidationMargin - margin below which collateral will be
  * liquidated to satisfy the debt.
  * @property {Ratio} interestRate - annual interest rate charged on loans
@@ -90,7 +87,6 @@
  * @property {() => Ratio} getLiquidationMargin
  * @property {() => Ratio} getLoanFee
  * @property {() => Promise<PriceQuote>} getCollateralQuote
- * @property {() => Ratio} getInitialMargin
  * @property {() => Ratio} getInterestRate - The annual interest rate on a loan
  * @property {() => RelativeTime} getChargingPeriod - The period (in seconds) at
  *   which interest is charged to the loan.
@@ -222,14 +218,12 @@
 /**
  * @typedef {Object} VaultParamManager
  * @property {() => Record<Keyword, ParamShortDescription> & {
- *  'InitialMargin': ParamRecord<'ratio'> & { value: Ratio },
  *  'InterestRate': ParamRecord<'ratio'> & { value: Ratio },
  *  'LiquidationMargin': ParamRecord<'ratio'> & { value: Ratio },
  *  'LoanFee': ParamRecord<'ratio'> & { value: Ratio },
  * }} getParams
  * @property {(name: string) => bigint} getNat
  * @property {(name: string) => Ratio} getRatio
- * @property {(margin: Ratio) => void} updateInitialMargin
  * @property {(margin: Ratio) => void} updateLiquidationMargin
  * @property {(ratio: Ratio) => void} updateInterestRate
  * @property {(ratio: Ratio) => void} updateLoanFee
@@ -238,7 +232,6 @@
 /**
  * @callback GetGovernedVaultParams
  * @returns {{
- *  InitialMargin: ParamRecord<'ratio'> & { value: Ratio },
  *  InterestRate: ParamRecord<'ratio'> & { value: Ratio },
  *  LiquidationMargin: ParamRecord<'ratio'> & { value: Ratio },
  *  LoanFee: ParamRecord<'ratio'> & { value: Ratio },

--- a/packages/run-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/run-protocol/src/vaultFactory/vaultFactory.js
@@ -176,7 +176,6 @@ export const start = async (zcf, privateArgs) => {
             brand,
             interestRate: vm.getInterestRate(),
             liquidationMargin: vm.getLiquidationMargin(),
-            initialMargin: vm.getInitialMargin(),
             stabilityFee: vm.getLoanFee(),
             marketPrice: makeRatioFromAmounts(
               getAmountOut(priceQuote),

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -22,7 +22,6 @@ import { makeTracer } from '../makeTracer.js';
 import {
   RECORDING_PERIOD_KEY,
   LIQUIDATION_MARGIN_KEY,
-  INITIAL_MARGIN_KEY,
   LOAN_FEE_KEY,
   INTEREST_RATE_KEY,
   CHARGING_PERIOD_KEY,
@@ -70,7 +69,6 @@ export const makeVaultManager = (
     // loans below this margin may be liquidated
     getLiquidationMargin: () => getLoanParams()[LIQUIDATION_MARGIN_KEY].value,
     // loans must initially have at least 1.2x collateralization
-    getInitialMargin: () => getLoanParams()[INITIAL_MARGIN_KEY].value,
     getLoanFee: () => getLoanParams()[LOAN_FEE_KEY].value,
     getInterestRate: () => getLoanParams()[INTEREST_RATE_KEY].value,
     getChargingPeriod: () => timingParams[CHARGING_PERIOD_KEY].value,

--- a/packages/run-protocol/test/vaultFactory/swingsetTests/setup.js
+++ b/packages/run-protocol/test/vaultFactory/swingsetTests/setup.js
@@ -49,7 +49,6 @@ const installContracts = async (zoe, cb) => {
 
 const makeRates = runBrand => {
   return {
-    initialMargin: makeRatio(120n, runBrand),
     liquidationMargin: makeRatio(105n, runBrand),
     interestRate: makeRatio(250n, runBrand, BASIS_POINTS),
     loanFee: makeRatio(200n, runBrand, BASIS_POINTS),

--- a/packages/run-protocol/test/vaultFactory/test-bootstrapPayment.js
+++ b/packages/run-protocol/test/vaultFactory/test-bootstrapPayment.js
@@ -72,7 +72,6 @@ const setUpZoeForTest = async setJig => {
 
 const makeRates = runBrand =>
   harden({
-    initialMargin: makeRatio(120n, runBrand),
     liquidationMargin: makeRatio(105n, runBrand),
     interestRate: makeRatio(100n, runBrand, BASIS_POINTS),
     loanFee: makeRatio(500n, runBrand, BASIS_POINTS),

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -79,8 +79,6 @@ async function waitForPromisesToSettle() {
 
 function makeRates(runBrand) {
   return harden({
-    // margin required to open a loan
-    initialMargin: makeRatio(120n, runBrand),
     // margin required to maintain a loan
     liquidationMargin: makeRatio(105n, runBrand),
     // periodic interest rate (per charging period)
@@ -714,7 +712,6 @@ test('vaultFactory display collateral', async t => {
   const { vaultFactory } = services.vaultFactory;
 
   const rates = harden({
-    initialMargin: makeRatio(120n, runBrand),
     liquidationMargin: makeRatio(105n, runBrand),
     interestRate: makeRatio(100n, runBrand, BASIS_POINTS),
     loanFee: makeRatio(530n, runBrand, BASIS_POINTS),
@@ -727,7 +724,6 @@ test('vaultFactory display collateral', async t => {
   t.deepEqual(collaterals[0], {
     brand: aethBrand,
     liquidationMargin: makeRatio(105n, runBrand),
-    initialMargin: makeRatio(120n, runBrand),
     stabilityFee: makeRatio(530n, runBrand, BASIS_POINTS),
     marketPrice: makeRatio(5n, runBrand, 1n, aethBrand),
     interestRate: makeRatio(100n, runBrand, 10000n, runBrand),
@@ -773,7 +769,6 @@ test('interest on multiple vaults', async t => {
 
   const interestRate = makeRatio(5n, runBrand);
   const rates = harden({
-    initialMargin: makeRatio(120n, runBrand),
     liquidationMargin: makeRatio(105n, runBrand),
     interestRate,
     loanFee: makeRatio(500n, runBrand, BASIS_POINTS),
@@ -1372,7 +1367,6 @@ test('mutable liquidity triggers and interest', async t => {
 
   // Add a vaultManager with 10000 aeth collateral at a 200 aeth/RUN rate
   const rates = harden({
-    initialMargin: makeRatio(120n, runBrand),
     liquidationMargin: makeRatio(105n, runBrand),
     // charge 5% interest
     interestRate: makeRatio(5n, runBrand),
@@ -1894,7 +1888,6 @@ test('mutable liquidity triggers and interest sensitivity', async t => {
 
   // Add a vaultManager with 10000 aeth collateral at a 200 aeth/RUN rate
   const rates = harden({
-    initialMargin: makeRatio(120n, runBrand),
     liquidationMargin: makeRatio(105n, runBrand),
     // charge 5% interest
     interestRate: makeRatio(5n, runBrand),

--- a/packages/run-protocol/test/vaultFactory/vault-contract-wrapper.js
+++ b/packages/run-protocol/test/vaultFactory/vault-contract-wrapper.js
@@ -50,9 +50,6 @@ export async function start(zcf, privateArgs) {
     getLiquidationMargin() {
       return makeRatio(105n, runBrand);
     },
-    getInitialMargin() {
-      return makeRatio(150n, runBrand);
-    },
     getLoanFee() {
       return makeRatio(500n, runBrand, BASIS_POINTS);
     },


### PR DESCRIPTION
refs: #4176 (don't close until [docs](https://github.com/Agoric/documentation/blob/main/main/zoe/guide/contracts/treasury.md#interest-and-liquidation) are updated)

## Description

[#4163](https://github.com/Agoric/agoric-sdk/issues/4163) removed the one use of InitialMargin. (LiquidationMargin suffices.) Since it's no longer used remove it entirely.

### Security Considerations

None.

### Documentation Considerations

Need to update [`main/zoe/guide/contracts/treasury.md` in ](https://github.com/Agoric/documentation/blob/main/main/zoe/guide/contracts/treasury.md#interest-and-liquidation)

### Testing Considerations

Tests updated.