### PR TITLE
merge bundle/vat-admin devices, add waitForBundlecap()

### DIFF
--- a/packages/SwingSet/docs/bundles.md
+++ b/packages/SwingSet/docs/bundles.md
@@ -10,7 +10,7 @@ In a given workspace (e.g. a Git checkout / working tree), you will have a hiera
 
 If you point at a single "entry point" module, and chase down all the `import` statements, you'll find some other set of module files. Following the transitive `import` statements leads to a collection of modules and a linkage map which remembers how they are wired together.
 
-A "code bundle" is a data structure that captures the contents of these modules and the linkage map (called a "compartment map"). Bundles are JSON-serializable objects, with one mandatory string property named `moduleFormat`, and other properties that depend on the format. Typically there is exactly one other property, and its value is a very large string (1-2 MB is common). Our bundles use a format that Endo defines, named "EndoZipBase64", in which the "very large string" is a base64-encoded Zip file, which contains one component for the compartment map, plus components for each of the modules it includes.
+A "code bundle" is a data structure that captures the contents of these modules and the linkage map (called a "compartment map"). Bundles are JSON-serializable objects, with one mandatory string property named `moduleFormat`, and other properties that depend on the format. Typically there is exactly one other property, and its value is a very large string (1-2 MB is common). Our bundles use a format defined by [Endo](https://github.com/endojs/endo/), named "EndoZipBase64", in which the "very large string" is a base64-encoded Zip file, which contains one component for the compartment map, plus components for each of the modules it includes.
 
 The `bundleSource()` function takes a filename of the entry point module and returns (a promise for) the code bundle object. It generally needs disk access to find all the imports.
 
@@ -22,70 +22,76 @@ Bundles are interesting because they can be serialized and sent to a remote syst
 
 We define the "bundle ID" as a hash of the bundle's compartment map file, specifically the fixed string `b1-` followed by the lowercase hex encoding of the SHA512 hash of the compartment map file. The compartment map includes hashes of all the modules included in the bundle, and the validation process ensures that the bundle contains exactly the expected set of modules. So the bundle ID is a strong identifier of the contents of the bundle, which is not sensitive to the order of the zipfile contents.
 
-A bundle might be assembled piecemeal. If I want to give you a bundle, and you already have a number of similar bundles, we can compare the modules in each and figure out the ones my bundle needs but you don't have yet. Then I can send you just the compartment map and the missing modules, and you can reassemble a functionally identical bundle. The bundleID will be the same, the imported behavior will be the same, but the zipfile itself might be slightly different. This lets us minimize the amount of data transmitted and stored.
+A bundle might be assembled piecemeal. If I want to give you a bundle, and you already have a number of similar bundles, we can compare the modules in each and figure out the ones my bundle needs but you don't have yet. Then I can send you just the compartment map and the missing modules, and you can reassemble a functionally identical bundle. The bundle ID will be the same, the imported behavior will be the same, but the zipfile itself might be slightly different. This lets us minimize the amount of data transmitted and stored.
+
+## Bundlecaps
+
+A "bundlecap" is an object (specifically a swingset "device node") which identifies a specific installed bundle. Bundlecaps only exist within swingset vats. Each bundlecap knows the bundle ID to which it refers. There is at most one bundlecap per bundle ID. It is not possible to make a bundlecap for a bundle that is not yet installed into the enclosing kernel, and holding a bundlecap guarantees that the bundle will be available (bundles may be GCed, but the bundlecap holds a reference that inhibits collection).
 
 ## How Swingset Uses Bundles
 
-The swingset kernel maintains a "bundle table" in the kernel database. Bundles can be installed here, indexed by their bundleID, and retrieved for various purposes:
+The swingset kernel maintains a "bundle table" in the kernel database. Bundles can be installed here, indexed by their bundle ID, and retrieved for various purposes:
 
 * all swingset vats, both static and dynamic, start from a bundle
   * in these bundles, the entry point module exports a function named `buildRootObject`
-* through a special `devices.bundle`, vat code can exchange a bundleID for a "bundlecap", which is an ocap-friendly way to refer to a bundle
+* through `vatAdminService~.getBundleCap()`, vat code can exchange a bundle ID for a bundlecap
 * the bundlecap can be used with `vatAdminService~.createVat()` to make a new dynamic vat
-* userspace can use `D(bundlecap).getBundle()` to fetch the bundle itself, for use with `importBundle()` that does not create an entire new vat
+* userspace can use `D(bundleCap).getBundle()` to fetch the bundle itself, for use with an `importBundle()` that does not create an entire new vat
   * the Zoe "ZCF" facet uses this to load contract code within an existing vat
   * this could also be used as part of an in-vat upgrade process, to load new behavior
 * each vat also has a "liveslots" layer, defined by a bundle
-  * the liveslots bundleID is recorded separately for each vat, so liveslots can be upgraded (for new vats) without affecting the behavior of existing ones
+  * the liveslots bundle ID is recorded separately for each vat, so liveslots can be upgraded (for new vats) without affecting the behavior of existing ones
 * swingset devices are defined by bundles that are stored in the bundle table
 * the kernel source code itself is stored in a bundle, to make it easier to switch from one version of the kernel to another at a pre-determined time
 
 ## Bundle Installation Through Config
 
-When defining a static vat in the Swingset `config.vats` object, the filename provided as `sourceSpec` is turned into a bundle, the bundle is installed into the bundle table, and resulting bundleID is stored in the vat's database record. When the static vat is launched, the DB record provides the bundleID, and the bundle is loaded and evaluated in a new vat worker.
+When defining a static vat in the Swingset `config.vats` object, the filename provided as `sourceSpec` is turned into a bundle, the bundle is installed into the bundle table, and resulting bundle ID is stored in the vat's database record. When the static vat is launched, the DB record provides the bundle ID, and the bundle is loaded and evaluated in a new vat worker.
 
-The `config.bundles` object maps names to a bundle specification. These bundles are installed as above, and then a special "named bundles" table is updated with the name-to-bundleID mapping. These names are available to `D(devices.bundle).getNamedBundleCap(name) -> bundlecap`. For example, the chain's "core bootstrap" code will use this to define bundles for the core vats (Zoe, etc), and create dynamic vats at bootstrap time from them. It will also provide Zoe with the bundlecap for ZCF this way, so Zoe can later create dynamic ZCF vats. `E(vatAdminService).createVatByName(bundleName)` will continue to be supported until core-bootstrap is updated to retrieve bundlecaps, after which vat-admin will drop `createVatByName` and only support `createVat(bundlecap)`.
+The `config.bundles` object maps names to a bundle specification. These bundles are installed as above, and then a special "named bundles" table is updated with the name-to-bundle-ID mapping. These names are available to `E(vatAdminService).getNamedBundleCap(name) -> bundleCap`. For example, the chain's "core bootstrap" code will use this to define bundles for the core vats (Zoe, etc), and create dynamic vats at bootstrap time from them. It will also provide Zoe with the bundlecap for ZCF this way, so Zoe can later create dynamic ZCF vats. `E(vatAdminService).createVatByName(name)` will continue to be supported until core-bootstrap is updated to retrieve bundlecaps, after which vat-admin will drop `createVatByName` and only support `createVat(bundleCap)`.
 
-The `initializeSwingset()` function, called when the host application is first configured, creates bundles for built-in vats and devices (timer, vatAdmin, mailbox), as well as liveslots and the kernel, and installs them into the table as well. Internally, the kernel remembers the bundleID of each one for later use.
+The `initializeSwingset()` function, called when the host application is first configured, creates bundles for built-in vats and devices (timer, vatAdmin, mailbox), as well as liveslots and the kernel, and installs them into the table as well. Internally, the kernel remembers the bundle ID of each one for later use.
 
 ## Bundle Installation at Runtime
 
-Once the kernel is up and running, new bundles can be installed with the `controller.validateAndInstallBundle()` interface. This accepts a bundle and an optional alleged bundleID. It performs validity checks: if the ID is provided but does not match the compartment map, or if (TODO) the bundle contents do not match the compartment map, or if (TODO) the contents do not parse as JavaScript modules, then it will throw. If everything looks good, it will install the bundle into the table and return the computed bundleID.
+Once the kernel is up and running, new bundles can be installed with the `controller.validateAndInstallBundle()` interface. This accepts a bundle and an optional alleged bundle ID. It performs validity checks: if the ID is provided but does not match the compartment map, or if (TODO) the bundle contents do not match the compartment map, or if (TODO) the contents do not parse as JavaScript modules, then it will throw. If everything looks good, it will install the bundle into the table and return the computed bundle ID.
 
-Once the bundle is installed, the external caller can send a vat-level message with the bundleID to some vat within the kernel. The receiving vat can then do `D(devices.bundle).getBundleCap(bundleID) -> bundlecap` to get a handle from which vats can be created.
+Once the bundle is installed, the external caller can send a vat-level message with the bundle ID to some vat within the kernel. The receiving vat can then do `E(vatAdminService).getBundleCap(bundleID) -> bundleCap` to get a handle from which vats can be created.
 
 A future version of this interface will expose enough information to install individual modules first, and then "install" a bundle from just the compartment map contents (after checking that all the required modules are already present).
 
-By moving bundle installation into a separate external interface, vat-level messages can remain small. Currently the only place the full bundle will appear is in a vat transcript, in the results of the syscall that implements `D(bundlecap).getBundle()`, when userspace needs to do an `importBundle()` directly, and we hope to remove even that copy in the future.
+By moving bundle installation into a separate external interface, vat-level messages can remain small. Currently the only place the full bundle will appear is in a vat transcript, in the results of the syscall that implements `D(bundleCap).getBundle()`, when userspace needs to do an `importBundle()` directly, and we hope to remove even that copy in the future.
 
-## Bundlecaps
+## Using Bundlecaps
 
-As suggested above, userspace works with a "bundlecap", which is a passable object (actually a device node) that represents the bundle. This can be passed through eventual-sends from one vat to another and stored in collections (and virtual objects). Internally, it wraps the bundleID.
+Userspace works with bundlecaps, which can be passed through eventual-sends from one vat to another and stored in collections (and virtual objects). Internally, each bundlecap wraps a bundle ID.
 
-The full set of things you can do with a bundlecap are:
+Bundlecaps can be obtained from several methods of `vatAdminService`, which (as a vat) always returns a Promise.
 
-* `D(bundlecap).getBundleID() -> string`: to get the bundleID
-* `D(bundlecap).getBundle() -> bundle object`: if you really need the full bundle, i.e. for `importBundle()`
-* `E(vatAdminService).createVat(bundlecap)`: create a new dynamic vat from the bundle
+* `E(vatAdminService).getBundleCap(bundleID) -> Promise<BundleCap>` (rejects if not installed yet)
+* `E(vatAdminService).waitForBundleCap(bundleID) -> Promise<BundleCap>` (waits until installed)
+* `E(vatAdminService).getNamedBundleCap(name) -> Promise<BundleCap>` (rejects if not registered)
+
+Note that the `waitForBundleCap()` method will wait (possibly forever) for the bundle ID to be installed before resolving its Promise, so the Promise will never resolve to `undefined`.
+
+Once you have a bundlecap, the full set of things you can do with it are:
+
+* `D(bundleCap).getBundleID() -> string`: to get the bundle ID
+* `D(bundleCap).getBundle() -> bundle object`: if you really need the full bundle, i.e. for `importBundle()`
+* `E(vatAdminService).createVat(bundleCap)`: create a new dynamic vat from the bundle
 
 ## Kernel Internals
 
-The kvStore has a subset of the key space reserved for holding bundles (mapping bundleID to the JSON-encoded bundle). Another keyspace holds mapping from bundle name to bundleID for the named bundles. These are accessed through `kernelKeeper` methods.
+The kvStore has a subset of the key space reserved for holding bundles (mapping bundle ID to the JSON-encoded bundle). Another keyspace holds mapping from bundle name to bundle ID for the named bundles. These are accessed through `kernelKeeper` methods.
 
-The "bundle device" (aka `devices.bundle`) has a root device node with an API to create bundlecaps:
-* `D(devices.bundle).getBundleCap(bundleID) -> bundlecap`
-* `D(devices.bundle).getNamedBundleCap(bundleName) -> bundlecap`
+Bundlecaps are new device nodes created by the vatAdmin device. Internally, this device remembers the mapping from bundle ID to the device node ID (`dref`), and vice versa, in a pair of vatstore state entries. This mapping is not held in RAM: the state entries are looked up on each call to `getBundleID`/etc. The device can also access the kernelKeeper APIs to convert bundle IDs into full bundles, if requested.
 
-Bundlecaps are new device nodes created by the bundle device. Internally, this device remembers the mapping from bundleID to the device node ID (`dref`), and vice versa, in a pair of vatstore state entries. This mapping is not held in RAM: the state entries are looked up on each call to `getBundleID`/etc. The device can also access the kernelKeeper APIs to convert bundleIDs into full bundles, if requested.
+The vatAdmin vat's `createVat` method accepts bundlecaps (or full bundles, for now). The vatAdmin device (which is wrapped tightly by vatAdminVat and not exposed to anyone else) accepts bundle IDs. VatAdminDevice translates bundlecaps into bundle IDs before talking to the device.
 
-The vatAdmin vat's `createVat` method accepts bundlecaps (or full bundles, for now). The vatAdmin device (which is wrapped tightly by vatAdminVat and not exposed to anyone else) accepts bundleIDs. VatAdminDevice translates bundlecaps into bundleIDs before talking to the device.
-
-`controller.validateAndInstallBundle(bundle, optionalAllegedBundleID)` performs validity checks, installs the bundle, and returns the computed bundleID. It uses `kernel.installBundle(bundleID, bundle)` internally, which uses uses `kernelKeeper` to store the bundle, and does not perform validation.
-
-
+`controller.validateAndInstallBundle(bundle, optionalAllegedBundleID)` performs validity checks, installs the bundle, and returns the computed bundle ID. It uses `kernel.installBundle(bundleID, bundle)` internally, which uses uses `kernelKeeper` to store the bundle, and does not perform validation.
 
 ## Determinism
 
-Bundle installation is a transactional event: it must happen, and be committed, before the bundle is available. `D(devices.bundle).getBundleCap(bundleID)` will fail (consistently) if the bundle was not already installed. Host applications (like a chain) should perform `validateAndInstallBundle()` from within a transaction, so all validators maintain consensus about whether the bundle is installed or not.
+Bundle installation is a transactional event: it must happen, and be committed, before the bundle is available. `E(vatAdminService).getBundleCap(bundleID)` will fail (consistently) if the bundle was not already installed. Host applications (like a chain) should perform `validateAndInstallBundle()` from within a transaction, so all validators maintain consensus about whether the bundle is installed or not.
 
 But once a bundlecap is obtained, the corresponding bundle is guaranteed to be available. We do not yet have GC for bundles, but once we do, each copy of the bundlecap will establish a reference count. As long as any bundlecap is still held, the bundle will be held too. Bundles will be deleted at some point after the last bundlecap is gone. (We need a story for what keeps the bundle alive between the external `controller.validateAndInstallBundle()` and some vat getting a bundlecap, but that interval is not expected to be very long, so we might just use explicit GC actions that we don't run very often).

--- a/packages/SwingSet/src/index.js
+++ b/packages/SwingSet/src/index.js
@@ -12,3 +12,6 @@ export { buildTimer } from './devices/timer.js';
 export { buildBridge } from './devices/bridge.js';
 export { default as buildCommand } from './devices/command.js';
 export { buildPlugin } from './devices/plugin.js';
+
+// eslint-disable-next-line import/export
+export * from './types-exported.js';

--- a/packages/SwingSet/src/initializeSwingset.js
+++ b/packages/SwingSet/src/initializeSwingset.js
@@ -53,7 +53,6 @@ export async function buildKernelBundles(options = {}) {
     kernel: src('./kernel/kernel.js'),
     adminDevice: src('./kernel/vatAdmin/vatAdmin-src'),
     adminVat: src('./kernel/vatAdmin/vatAdminWrapper'),
-    bundleDevice: src('./devices/bundle'),
     comms: src('./vats/comms'),
     vattp: src('./vats/vat-tp'),
     timer: src('./vats/vat-timerWrapper'),
@@ -327,9 +326,6 @@ export async function initializeSwingset(
   config.devices.vatAdmin = {
     bundle: kernelBundles.adminDevice,
   };
-  config.devices.bundle = {
-    bundle: kernelBundles.bundleDevice,
-  };
 
   // comms vat is added automatically, but TODO: bootstraps must still
   // connect it to vat-tp. TODO: test-message-patterns builds two comms and
@@ -365,7 +361,7 @@ export async function initializeSwingset(
   // The 'bundleName' option points into
   // config.bundles.BUNDLENAME.[bundle|bundleSpec|sourceSpec] , which can
   // also include arbitrary named bundles that will be made available to
-  // D(devices.bundle).getNamedBundlecap(bundleName) ,and temporarily as
+  // E(vatAdminService).getNamedBundleCap(bundleName) ,and temporarily as
   // E(vatAdminService).createVatByName(bundleName)
 
   // The 'kconfig' we pass through to initializeKernel has

--- a/packages/SwingSet/src/kernel/initializeKernel.js
+++ b/packages/SwingSet/src/kernel/initializeKernel.js
@@ -93,7 +93,8 @@ export function initializeKernel(config, hostStorage, verbose = false) {
       }
       if (name === 'vatAdmin') {
         // Create a kref for the vatAdmin root, so the kernel can tell it
-        // about creation/termination of dynamic vats.
+        // about creation/termination of dynamic vats, and the installation
+        // of bundles
         const kref = exportRootObject(kernelKeeper, vatID);
         // Pin, to prevent it being GC'd when only the kvStore points to it
         kernelKeeper.pinObject(kref);

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -1009,6 +1009,9 @@ export default function buildKernel(
 
     // the admin device is endowed directly by the kernel
     deviceEndowments.vatAdmin = {
+      hasBundle: kernelKeeper.hasBundle,
+      getBundle: kernelKeeper.getBundle,
+      getNamedBundleID: kernelKeeper.getNamedBundleID,
       pushCreateVatBundleEvent(bundle, dynamicOptions) {
         const source = { bundle };
         const vatID = kernelKeeper.allocateUnusedVatID();
@@ -1028,10 +1031,6 @@ export default function buildKernel(
         // later when it is created and a root object is available
         return vatID;
       },
-      getBundleIDByName(bundleName) {
-        // this throws if the name is unknown
-        return kernelKeeper.getNamedBundleID(bundleName);
-      },
       terminate: (vatID, reason) => terminateVat(vatID, true, reason),
       meterCreate: (remaining, threshold) =>
         kernelKeeper.allocateMeter(remaining, threshold),
@@ -1040,13 +1039,6 @@ export default function buildKernel(
       meterSetThreshold: (meterID, threshold) =>
         kernelKeeper.setMeterThreshold(meterID, threshold),
       meterGet: meterID => kernelKeeper.getMeter(meterID),
-    };
-
-    // same for bundle device
-    deviceEndowments.bundle = {
-      hasBundle: kernelKeeper.hasBundle,
-      getBundle: kernelKeeper.getBundle,
-      getNamedBundleID: kernelKeeper.getNamedBundleID,
     };
 
     // instantiate all devices
@@ -1217,6 +1209,15 @@ export default function buildKernel(
     // bundleID is b1-HASH
     if (!kernelKeeper.hasBundle(bundleID)) {
       kernelKeeper.addBundle(bundleID, bundle);
+      const args = harden({ body: JSON.stringify([bundleID]), slots: [] });
+      if (vatAdminRootKref) {
+        // TODO: consider 'panic' instead of 'logFailure'
+        queueToKref(vatAdminRootKref, 'bundleInstalled', args, 'logFailure');
+      } else {
+        // this should only happen during unit tests that are too lazy to
+        // build a complete kernel: test/bundles/test-bundles-kernel.js
+        console.log(`installBundle cannot notify, missing vatAdminRootKref`);
+      }
       kernelKeeper.commitCrank();
     }
   }

--- a/packages/SwingSet/src/kernel/vatAdmin/vatAdmin-src.js
+++ b/packages/SwingSet/src/kernel/vatAdmin/vatAdmin-src.js
@@ -1,81 +1,282 @@
-/**
- * A Vat management device that provides a capability that can be used to
- * create new vats. create(adminId, code) creates a new vat running code, and
- * returns the root object.
- *
- * This code runs in the inner part of the device vat. The only device object
- * exposed to vats is the vat creator. The root objects for the new vats are
- * returned as javascript objects.
- *
- * buildRootDeviceNode() is called with { SO, getDeviceState, setDeviceState,
- * endowments }. We don't currently need to use SO, or to maintain state. All
- * functionality is provided by calling kernel functions and passing in the
- * VatID. The wrapper vat sends the VatID on every call.
- *
- * @param {Object} param0
- * @param {Record<string, any>} param0.endowments
- * @param {*} param0.serialize
- */
-
-import { Far } from '@endo/marshal';
+// @ts-check
 import { Nat } from '@agoric/nat';
 import { assert } from '@agoric/assert';
+import { buildSerializationTools } from '../../deviceTools.js';
 
-export function buildRootDeviceNode({ endowments, serialize }) {
-  const {
-    pushCreateVatBundleEvent,
-    pushCreateVatIDEvent,
-    getBundleIDByName,
-    terminate: kernelTerminateVatFn,
-    meterCreate,
-    meterAddRemaining,
-    meterSetThreshold,
-    meterGet,
-  } = endowments;
+/*
 
-  // The Root Device Node.
-  return Far('root', {
-    createMeter(remaining, threshold) {
-      return meterCreate(Nat(remaining), Nat(threshold));
-    },
-    createUnlimitedMeter() {
-      return meterCreate('unlimited', 0n);
-    },
-    addMeterRemaining(meterID, delta) {
-      meterAddRemaining(meterID, Nat(delta));
-    },
-    setMeterThreshold(meterID, threshold) {
-      meterSetThreshold(meterID, Nat(threshold));
-    },
-    getMeter(meterID) {
-      return meterGet(meterID);
-    },
+The "vatAdmin device" manages code bundles, meters, and the creation /
+maintenance of dynamic vats.
 
-    // Called by the wrapper vat to create a new vat. Gets a new ID from the
-    // kernel's vat creator fn. Remember that the root object will arrive
-    // separately. Clean up the outgoing and incoming arguments.
-    createByBundle(bundle, options = {}) {
-      const vatID = pushCreateVatBundleEvent(bundle, options);
-      return vatID;
-    },
-    createByBundleID(bundleID, options = {}) {
-      assert.typeof(bundleID, 'string');
-      const vatID = pushCreateVatIDEvent(bundleID, options);
-      return vatID;
-    },
-    createByName(bundleName, options = {}) {
-      assert.typeof(bundleName, 'string');
-      let bundleID;
-      try {
-        bundleID = getBundleIDByName(bundleName);
-      } catch (e) {
-        throw Error(`unregistered bundle name '${bundleName}'`);
+Code bundles can be used to define a new dynamic vat
+(vatAdminSvc~.createVat), or can be imported/evaluated from within a vat
+(importBundle).
+
+Bundles are 'endoZipBase64' archives, which are basically a string-encoded
+ZIP file containing a bunch of importable modules and a single "compartment
+map". Each bundle has a unique "bundleID" string, which is the SHA512 hash of
+the compartment map file, aka the manifest. This manifest contains hashes of
+all the component modules, as well as information about how they link
+together, so the bundle's behavior is completely specified by the bundleID
+(plus the runtime behavior of the module loader, which includes global
+endowments, and potentially "holes" in the module map which will be filled in
+by the loader with locally-provided module namespace objects). The order of
+the modules in a zip file does not affect the bundleID.
+
+Any two bundles are likely to have a lot of modules in common (shared support
+libraries, etc). Modules are individual source files, so they tend to be
+small (1-50kB), but bundles tend to be several MB in size.
+
+The goals are:
+* install bundles "out of band", through controller.validateAndInstallBundle()
+* keep large (multi-MB) bundles out of vat messages and transcripts
+* reduce communication bandwidth by uploading shared modules only once
+* reduce storage costs by storing shared modules only once
+
+The kernel will provide this device with three endowments:
+* hasBundle(bundleID) -> boolean
+* getBundle(bundleID) -> string
+* getNamedBundleID(name) -> bundleID
+
+The root device node offers two methods to callers:
+* D(devices.bundle).getBundleCap(bundleID) -> devnode or undefined
+* D(devices.bundle).getNamedBundleCap(name) -> devnode or undefined
+
+The device node returned by getBundleCap() is called, unsurprisingly, a
+"bundlecap". Most vats interact with bundlecaps, not bundleIDs (although of
+course somebody must call `getBundleCap()` first). Holding a bundlecap
+guarantees that the bundle contents are available, since `getBundleCap()`
+will fail unless the bundle is currently installed. When we implement
+refcounting GC for bundles, the bundlecap will maintain a reference and
+protect the bundle data from collection.
+
+The bundlecap device node provides two device-invocation methods to callers:
+
+* D(bundleCap).getBundleID() -> string (bundleID)
+* D(bundleCap).getBundle() -> string (the bundle contents)
+
+For now, the only way to give a bundle to `importBundle()` is to obtain its
+string contents first, but eventually we hope to implement more direct
+support and keep the large string out of syscall results and userspace
+entirely.
+
+Meters are defined by the wrapper vat, who talks to us with a meterID
+instead.
+
+Dynamic vats are created with either a bundlecap (which we convert into a
+bundleID before submitting to the kernel), or (temporarily) a full bundle.
+
+*/
+
+/**
+ * if you're into types, this might loosely describe devices.vatAdmin
+ *
+ * @typedef { import('../../types-exported.js').BundleID } BundleID
+ *
+ * @typedef { string } MeterID
+ * @typedef { string } VatID
+ * @typedef {{
+ *  createMeter: (remaining: bigint, threshold: bigint) => MeterID
+ *  createUnlimitedMeter: () => MeterID
+ *  addMeterRemaining: (meterID: MeterID, delta: bigint) => void
+ *  setMeterThreshold: (meterID: MeterID, threshold: bigint) => void
+ *  getMeter: (meterID: MeterID) => { remaining: bigint, threshold: bigint }
+ *  createByBundle: (bundle: Bundle, options: {}) => VatID
+ *  createByBundleID: (bundleID: BundleID, options: {}) => VatID
+ *  terminateWithFailure: (vatID: VatID, reason: {}) => void
+ *  getBundleCap: (bundleID: BundleID) => BundleCap
+ *  getNamedBundleCap: (name: string) => BundleCap
+ * }} VatAdminRootDeviceNode
+ */
+
+export function buildDevice(tools, endowments) {
+  const { hasBundle, getBundle, getNamedBundleID } = endowments;
+  const { pushCreateVatBundleEvent, pushCreateVatIDEvent } = endowments;
+  const { terminate } = endowments;
+  const { meterCreate, meterAddRemaining, meterSetThreshold, meterGet } =
+    endowments;
+
+  const { syscall } = tools;
+  const dtools = buildSerializationTools(syscall, 'bundle');
+  const { unserialize, returnFromInvoke, deviceNodeForSlot } = dtools;
+
+  const ROOT = 'd+0';
+  const bundleIDRE = new RegExp('^b1-[0-9a-f]{128}$');
+  const nextDeviceNodeIDKey = 'nextDev';
+
+  // reminder: you may not perform vatstore writes during buildDevice(),
+  // because it runs on each kernel reboot, which is not consistent among
+  // members of a consensus kernel
+
+  function allocateDeviceNode() {
+    let s = syscall.vatstoreGet(nextDeviceNodeIDKey);
+    if (!s) {
+      s = '1';
+    }
+    const id = BigInt(s);
+    syscall.vatstoreSet(nextDeviceNodeIDKey, `${id + 1n}`);
+    return `d+${id}`;
+  }
+
+  function returnCapForBundleID(bundleID) {
+    assert(bundleID, 'returnCapForBundleID needs bundleID');
+    const idToBundleKey = `id.${bundleID}`;
+    let cap;
+    cap = syscall.vatstoreGet(idToBundleKey);
+    if (!cap) {
+      if (!hasBundle(bundleID)) {
+        return returnFromInvoke(undefined);
       }
-      const vatID = pushCreateVatIDEvent(bundleID, options);
-      return vatID;
+      cap = allocateDeviceNode();
+      syscall.vatstoreSet(idToBundleKey, cap);
+      const capToIDKey = `slot.${cap}`;
+      syscall.vatstoreSet(capToIDKey, bundleID);
+    }
+    return returnFromInvoke(deviceNodeForSlot(cap));
+  }
+
+  // invoke() should use unserialize() and returnFromInvoke. Throwing an
+  // error will cause the calling vat's D() to throw.
+
+  const dispatch = {
+    invoke: (dnid, method, argsCapdata) => {
+      if (dnid === ROOT) {
+        // Meters
+
+        // D(devices.vatAdmin).createMeter(remaining, threshold) -> meterID
+        if (method === 'createMeter') {
+          const args = unserialize(argsCapdata);
+          const [remaining, threshold] = args;
+          assert.typeof(remaining, 'bigint', `createMeter() remaining`);
+          assert.typeof(threshold, 'bigint', `createMeter() threshold`);
+          const meterID = meterCreate(Nat(remaining), Nat(threshold));
+          return returnFromInvoke(meterID);
+        }
+
+        // D(devices.vatAdmin).createUnlimitedMeter() -> meterID
+        if (method === 'createUnlimitedMeter') {
+          const meterID = meterCreate('unlimited', 0n);
+          return returnFromInvoke(meterID);
+        }
+
+        // D(devices.vatAdmin).addMeterRemaining(meterID, delta)
+        if (method === 'addMeterRemaining') {
+          const args = unserialize(argsCapdata);
+          const [meterID, delta] = args;
+          assert.typeof(meterID, 'string', `addMeterRemaining() meterID`);
+          assert.typeof(delta, 'bigint', `addMeterRemaining() delta`);
+          meterAddRemaining(meterID, Nat(delta));
+          return returnFromInvoke(undefined);
+        }
+
+        // D(devices.vatAdmin).setMeterThreshold(meterID, threshold)
+        if (method === 'setMeterThreshold') {
+          const args = unserialize(argsCapdata);
+          const [meterID, threshold] = args;
+          assert.typeof(meterID, 'string', `setMeterThreshold() meterID`);
+          assert.typeof(threshold, 'bigint', `setMeterThreshold() threshold`);
+          meterSetThreshold(meterID, Nat(threshold));
+          return returnFromInvoke(undefined);
+        }
+
+        // D(devices.vatAdmin).getMeter(meterID) -> { remaining, threshold }
+        if (method === 'getMeter') {
+          const args = unserialize(argsCapdata);
+          const [meterID] = args;
+          assert.typeof(meterID, 'string', `getMeter() meterID`);
+          return returnFromInvoke(meterGet(meterID));
+        }
+
+        // Vat Creation
+
+        // D(devices.vatAdmin).createByBundle(bundle, options) -> vatID
+        if (method === 'createByBundle') {
+          // see #4588
+          assert.equal(argsCapdata.slots.length, 0, 'cannot handle refs');
+          const args = unserialize(argsCapdata);
+          const [bundle, options] = args;
+          // options cannot hold caps yet, but I expect #4486 will remove
+          // this case before #4381 needs them here
+          const vatID = pushCreateVatBundleEvent(bundle, options);
+          return returnFromInvoke(vatID);
+        }
+
+        // D(devices.vatAdmin).createByBundleID(bundleID, options) -> vatID
+        if (method === 'createByBundleID') {
+          // see #4588
+          assert.equal(argsCapdata.slots.length, 0, 'cannot handle refs');
+          const args = unserialize(argsCapdata);
+          const [bundleID, options] = args;
+          assert.typeof(bundleID, 'string', `createByBundleID() bundleID`);
+          // TODO: options cannot hold caps yet, #4381 will want them in
+          // vatParameters, follow the pattern in terminateWithFailure
+          const vatID = pushCreateVatIDEvent(bundleID, options);
+          return returnFromInvoke(vatID);
+        }
+
+        // D(devices.vatAdmin).terminateWithFailure(vatID, reason)
+        if (method === 'terminateWithFailure') {
+          // 'args' is capdata([vatID, reason]), and comes from vatAdmin (but
+          // 'reason' comes from user code). We want to extract vatID and get
+          // capdata(reason) to send into terminate(). Don't use the
+          // deviceTools serialize(), it isn't a complete marshal and we just
+          // want to passthrough anyways.
+          const { body, slots } = argsCapdata;
+          // TODO: these slots are drefs, and the kernel terminate()
+          // endowment needs krefs, so we forbid them entirely for now
+          // see #4588
+          assert.equal(slots.length, 0, 'cannot handle refs in terminate');
+          const args = JSON.parse(body);
+          assert(Array.isArray(args), 'terminateWithFailure() args array');
+          const [vatID, reason] = args;
+          assert.typeof(vatID, 'string', `terminateWithFailure() vatID`);
+          const reasonCapdata = { body: JSON.stringify(reason), slots };
+          terminate(vatID, reasonCapdata);
+          return returnFromInvoke(undefined);
+        }
+
+        // Bundlecaps
+
+        // D(devices.bundle).getBundleCap(id) -> bundlecap
+        if (method === 'getBundleCap') {
+          const args = unserialize(argsCapdata);
+          const [bundleID] = args;
+          assert.typeof(bundleID, 'string', `getBundleCap() bundleID`);
+          assert(bundleIDRE.test(bundleID), 'getBundleCap() not a bundleID');
+          return returnCapForBundleID(bundleID);
+        }
+        // D(devices.bundle).getNamedBundleCap(name) -> bundlecap
+        if (method === 'getNamedBundleCap') {
+          const args = unserialize(argsCapdata);
+          const [name] = args;
+          assert.typeof(name, 'string', `getNamedBundleCap() name`);
+          let bundleID;
+          try {
+            // this throws on a bad name, so make a better error
+            bundleID = getNamedBundleID(name);
+          } catch (e) {
+            throw Error(`unregistered bundle name '${name}'`);
+          }
+          return returnCapForBundleID(bundleID);
+        }
+        throw TypeError(`target[${method}] does not exist`);
+      }
+
+      const capToIDKey = `slot.${dnid}`;
+      const bundleID = syscall.vatstoreGet(capToIDKey);
+      if (bundleID) {
+        // D(bundleCap).getBundleID() -> id
+        if (method === 'getBundleID') {
+          return returnFromInvoke(bundleID);
+        }
+        // D(bundleCap).getBundle() -> bundle
+        if (method === 'getBundle') {
+          return returnFromInvoke(getBundle(bundleID));
+        }
+        throw TypeError(`bundlecap[${method}] does not exist`);
+      }
+      throw TypeError(`unknown device node ${dnid}, shouldn't happen`);
     },
-    terminateWithFailure(vatID, reason) {
-      kernelTerminateVatFn(vatID, serialize(reason));
-    },
-  });
+  };
+  return dispatch;
 }

--- a/packages/SwingSet/src/types-exported.js
+++ b/packages/SwingSet/src/types-exported.js
@@ -1,0 +1,14 @@
+import './types.js';
+
+export {};
+
+/* This file defines types that part of the external API of swingset. That
+ * includes standard services which user-provided vat code might interact
+ * with, like VatAdminService. */
+
+/**
+ *
+ * @typedef { string } BundleID
+ * @typedef {*} BundleCap
+ * @typedef { { moduleFormat: 'endoZipBase64', endoZipBase64: string } } EndoZipBase64Bundle
+ */

--- a/packages/SwingSet/src/types.js
+++ b/packages/SwingSet/src/types.js
@@ -4,15 +4,17 @@
 
 /**
  * @typedef {'getExport' | 'nestedEvaluate' | 'endoZipBase64'} BundleFormat
- * @typedef { string } BundleID
  */
 
 /**
  * @typedef {import('@endo/marshal').CapData<string>} SwingSetCapData
  */
 
+/** @typedef { import('./types-exported.js').BundleID } BundleID */
+/** @typedef { import('./types-exported.js').BundleCap } BundleCap */
+/** @typedef { import('./types-exported.js').EndoZipBase64Bundle } EndoZipBase64Bundle */
+
 /**
- * @typedef { { moduleFormat: 'endoZipBase64', endoZipBase64: string } } EndoZipBase64Bundle
  * @typedef { { moduleFormat: 'getExport', source: string, sourceMap: string? } } GetExportBundle
  * @typedef { { moduleFormat: 'nestedEvaluate', source: string, sourceMap: string? } } NestedEvaluateBundle
  * @typedef { EndoZipBase64Bundle | GetExportBundle | NestedEvaluateBundle } Bundle

--- a/packages/SwingSet/test/bundles/test-bundles.js
+++ b/packages/SwingSet/test/bundles/test-bundles.js
@@ -8,6 +8,7 @@ import { assert } from '@agoric/assert';
 import { parse } from '@endo/marshal';
 import { provideHostStorage } from '../../src/hostStorage.js';
 import { initializeSwingset, makeSwingsetController } from '../../src/index.js';
+import { computeBundleID } from '../../src/validate-archive.js';
 import { capargs } from '../util.js';
 
 function bfile(name) {
@@ -41,7 +42,7 @@ test('bundles', async t => {
 
   // This one (with 'hi()') provides a named vat bundle, for a static vat,
   // exercising config.vats.NAME.bundleName . We also build dynamic vats to
-  // test D(devices.bundle).getNamedBundlecap and E(vatAdmin).createVatByName
+  // test D(devices.bundle).getNamedBundleCap and E(vatAdmin).createVatByName
   const namedBundleFilename = bfile('vat-named.js');
 
   // We save this vat bundle (with 'disk()') to disk, to exercise
@@ -113,28 +114,67 @@ test('bundles', async t => {
   await check('checkConfiguredVats', [undefined], ['hello']);
 
   // create dynamic vats from a named bundle created at config file
-  await check('vatFromNamedBundlecap', ['named', 'hi'], ['hello']);
+  await check('vatFromNamedBundleCap', ['named', 'hi'], ['hello']);
 
   // pre-made bundles can be loaded from disk, via a named bundle
-  await check('vatFromNamedBundlecap', ['disk', 'disk'], ['otech']);
+  await check('vatFromNamedBundleCap', ['disk', 'disk'], ['otech']);
 
   // vatAdminService~.createVatByName() still works, TODO until we remove it
   await check('vatByName', ['named', 'hi'], ['hello']);
 
-  // D(devices.bundle).getBundlecap(invalidBundleID) should throw
+  // vatAdminService~.getBundleCap(invalidBundleID) should reject
   await checkRejects(
-    'getBundlecap',
+    'getBundleCap',
     [invalidBundleID],
     Error('syscall.callNow failed: device.invoke failed, see logs for details'),
   );
   // the logs would show "not a bundleID"
 
-  // D(devices.bundle).getBundlecap(missingBundleID) should return undefined
-  await check('getBundlecap', [missingBundleID], undefined);
+  // vatAdminService~.getBundleCap(missingBundleID) should reject
+  await checkRejects(
+    'getBundleCap',
+    [missingBundleID],
+    Error(`bundleID not yet installed: ${missingBundleID}`),
+  );
 
-  // install a vat bundle at runtime, make sure we can load it by ID
-  const bid1 = await c.validateAndInstallBundle(installableVatBundle);
+  const bid1 = await computeBundleID(installableVatBundle);
+
+  // vatAdminService~.getBundleCap(bid1) should reject: not installed yet
+  await checkRejects(
+    'getBundleCap',
+    [bid1],
+    Error(`bundleID not yet installed: ${bid1}`),
+  );
+
+  // vatAdminService~.waitForBundleCap(bid1) should hang until installed
+  const waitKPID = c.queueToVatRoot(
+    'bootstrap',
+    'waitForBundleCap',
+    capargs([bid1]),
+  );
+  await c.run();
+  t.is(c.kpStatus(waitKPID), 'unresolved');
+
+  // install a vat bundle at runtime
+  const bid1a = await c.validateAndInstallBundle(installableVatBundle);
+  t.is(bid1a, bid1);
   t.regex(bid1, bundleIDRE);
+  await c.run();
+
+  // so now the waitForBundleCap should be done
+  t.is(c.kpStatus(waitKPID), 'fulfilled');
+
+  // check the shape of the waitForBundleCap bundlecap
+  const d1 = c.kpResolution(waitKPID);
+  const res1 = JSON.parse(d1.body);
+  const dev1 = { '@qclass': 'slot', iface: 'Alleged: device node', index: 0 };
+  t.deepEqual(res1, dev1);
+  const slots1 = d1.slots;
+  const dev1slot = slots1[0];
+  t.regex(dev1slot, /^kd\d+$/);
+  t.is(slots1[0], dev1slot);
+
+  // and make sure we can load it by ID
   await check('vatFromID', [bid1, 'runtime'], ['installed']);
 
   // test importing a non-vat bundle, by ID
@@ -144,24 +184,24 @@ test('bundles', async t => {
   // test importing a named non-vat bundle
   await check('checkImportByName', ['importableNonVat'], ['importable', true]);
 
-  // check the shape of a bundlecap
-  const [s1, d1] = await run('getBundlecap', [bid2]);
-  t.is(s1, 'fulfilled');
-  const res1 = JSON.parse(d1.body);
-  const dev1 = { '@qclass': 'slot', iface: 'Alleged: device node', index: 0 };
-  t.deepEqual(res1, dev1);
-  const slots1 = d1.slots;
-  const dev1slot = slots1[0];
-  t.regex(dev1slot, /^kd\d+$/);
-  t.is(slots1[0], dev1slot);
+  // check the shape of the getBundleCap bundlecap
+  const [s2, d2] = await run('getBundleCap', [bid2]);
+  t.is(s2, 'fulfilled');
+  const res2 = JSON.parse(d2.body);
+  const dev2 = { '@qclass': 'slot', iface: 'Alleged: device node', index: 0 };
+  t.deepEqual(res2, dev2);
+  const slots2 = d2.slots;
+  const dev2slot = slots2[0];
+  t.regex(dev2slot, /^kd\d+$/);
+  t.is(slots2[0], dev2slot);
 
   // and the shape of the bundle
-  const [s2, d2] = await run('getBundle', [bid2]);
+  const [s3, d3] = await run('getBundle', [bid2]);
   // TODO: I want to treat the bundle as a string (really bytes, eventually),
   // but importBundle() requires an object, with moduleFormat: and
   // endoZipBase64:
-  t.is(s2, 'fulfilled');
-  const res2 = parse(d2.body);
-  t.is(res2.moduleFormat, 'endoZipBase64');
-  t.is(typeof res2.endoZipBase64, 'string');
+  t.is(s3, 'fulfilled');
+  const res3 = parse(d3.body);
+  t.is(res3.moduleFormat, 'endoZipBase64');
+  t.is(typeof res3.endoZipBase64, 'string');
 });

--- a/packages/SwingSet/test/devices/bootstrap-1.js
+++ b/packages/SwingSet/test/devices/bootstrap-1.js
@@ -11,7 +11,7 @@ export default function setup(syscall, state, _helpers, vatPowers) {
         const argb = JSON.parse(args.body);
         const deviceIndex = argb[1].d1.index;
         deviceRef = args.slots[deviceIndex];
-        assert(deviceRef === 'd-71', X`bad deviceRef ${deviceRef}`);
+        assert(deviceRef === 'd-70', X`bad deviceRef ${deviceRef}`);
       } else if (method === 'step1') {
         testLog(`callNow`);
         const setArgs = harden({ body: JSON.stringify([1, 2]), slots: [] });

--- a/packages/SwingSet/test/devices/test-devices.js
+++ b/packages/SwingSet/test/devices/test-devices.js
@@ -76,9 +76,8 @@ test.serial('d0', async t => {
       vattp: { '@qclass': 'slot', iface: 'Alleged: vref', index: 4 },
     },
     {
-      bundle: { '@qclass': 'slot', iface: 'Alleged: device', index: 5 },
-      d0: { '@qclass': 'slot', iface: 'Alleged: device', index: 6 },
-      vatAdmin: { '@qclass': 'slot', iface: 'Alleged: device', index: 7 },
+      d0: { '@qclass': 'slot', iface: 'Alleged: device', index: 5 },
+      vatAdmin: { '@qclass': 'slot', iface: 'Alleged: device', index: 6 },
     },
   ]);
   t.deepEqual(JSON.parse(c.dump().log[1]), [
@@ -89,7 +88,6 @@ test.serial('d0', async t => {
     'o-53',
     'd-70',
     'd-71',
-    'd-72',
   ]);
 });
 

--- a/packages/SwingSet/test/metering/vat-load-dynamic.js
+++ b/packages/SwingSet/test/metering/vat-load-dynamic.js
@@ -2,15 +2,13 @@ import { E } from '@agoric/eventual-send';
 import { Far } from '@endo/marshal';
 
 export function buildRootObject(vatPowers) {
-  const { D, testLog: log } = vatPowers;
-  let bundleDev;
+  const { testLog: log } = vatPowers;
   let service;
   let control;
 
   return Far('root', {
     async bootstrap(vats, devices) {
       service = await E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
-      bundleDev = devices.bundle;
     },
 
     createMeter(remaining, notifyThreshold) {
@@ -40,8 +38,8 @@ export function buildRootObject(vatPowers) {
     },
 
     async createVat(name, dynamicOptions) {
-      const bundleID = D(bundleDev).getNamedBundlecap(name);
-      control = await E(service).createVat(bundleID, dynamicOptions);
+      const bundlecap = await E(service).getNamedBundleCap(name);
+      control = await E(service).createVat(bundlecap, dynamicOptions);
       const done = E(control.adminNode).done();
       // the caller checks this later, but doesn't wait for it
       return ['created', done];

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -194,7 +194,6 @@ test.serial('bootstrap export', async t => {
   c.pinVatRoot('bootstrap');
   const vatAdminVatID = c.vatNameToID('vatAdmin');
   const vatAdminDevID = c.deviceNameToID('vatAdmin');
-  const bundleDevID = c.deviceNameToID('bundle');
   const commsVatID = c.vatNameToID('comms');
   const vatTPVatID = c.vatNameToID('vattp');
   const timerVatID = c.vatNameToID('timer');
@@ -217,10 +216,8 @@ test.serial('bootstrap export', async t => {
   const right0 = 'ko24';
   const timer0 = 'ko25';
   const vattp0 = 'ko26';
-  const bundleDev = 'kd30';
-  const adminDev = 'kd31';
+  const adminDev = 'kd30';
   const kt = [
-    [bundleDev, bundleDevID, 'd+0'],
     [adminDev, vatAdminDevID, 'd+0'],
     [boot0, bootstrapVatID, 'o+0'],
     [left0, leftVatID, 'o+0'],
@@ -244,7 +241,7 @@ test.serial('bootstrap export', async t => {
         result: 'kp40',
         method: 'bootstrap',
         args: {
-          body: '[{"bootstrap":{"@qclass":"slot","iface":"Alleged: vref","index":0},"comms":{"@qclass":"slot","iface":"Alleged: vref","index":1},"left":{"@qclass":"slot","iface":"Alleged: vref","index":2},"right":{"@qclass":"slot","iface":"Alleged: vref","index":3},"timer":{"@qclass":"slot","iface":"Alleged: vref","index":4},"vatAdmin":{"@qclass":"slot","iface":"Alleged: vref","index":5},"vattp":{"@qclass":"slot","iface":"Alleged: vref","index":6}},{"bundle":{"@qclass":"slot","iface":"Alleged: device","index":7},"vatAdmin":{"@qclass":"slot","iface":"Alleged: device","index":8}}]',
+          body: '[{"bootstrap":{"@qclass":"slot","iface":"Alleged: vref","index":0},"comms":{"@qclass":"slot","iface":"Alleged: vref","index":1},"left":{"@qclass":"slot","iface":"Alleged: vref","index":2},"right":{"@qclass":"slot","iface":"Alleged: vref","index":3},"timer":{"@qclass":"slot","iface":"Alleged: vref","index":4},"vatAdmin":{"@qclass":"slot","iface":"Alleged: vref","index":5},"vattp":{"@qclass":"slot","iface":"Alleged: vref","index":6}},{"vatAdmin":{"@qclass":"slot","iface":"Alleged: device","index":7}}]',
           slots: [
             boot0,
             comms0,
@@ -253,7 +250,6 @@ test.serial('bootstrap export', async t => {
             timer0,
             vatAdminSvc,
             vattp0,
-            bundleDev,
             adminDev,
           ],
         },
@@ -295,8 +291,7 @@ test.serial('bootstrap export', async t => {
   kt.push([vatAdminSvc, bootstrapVatID, 'o-54']);
   kt.push([vattp0, bootstrapVatID, 'o-55']);
   kt.push([fooP, bootstrapVatID, 'p+5']);
-  kt.push([bundleDev, bootstrapVatID, 'd-70']);
-  kt.push([adminDev, bootstrapVatID, 'd-71']);
+  kt.push([adminDev, bootstrapVatID, 'd-70']);
   // checkKT(t, c, kt); // disabled due to cross-engine GC variation
 
   t.deepEqual(c.dump().runQueue, [

--- a/packages/SwingSet/test/vat-admin/bootstrap.js
+++ b/packages/SwingSet/test/vat-admin/bootstrap.js
@@ -1,15 +1,12 @@
 import { E } from '@agoric/eventual-send';
 import { Far } from '@endo/marshal';
 
-export function buildRootObject(vatPowers) {
-  const { D } = vatPowers;
+export function buildRootObject() {
   let admin;
-  let bundleDevice;
 
   return Far('root', {
     async bootstrap(vats, devices) {
       admin = await E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
-      bundleDevice = devices.bundle;
     },
 
     async byBundle(bundle) {
@@ -24,15 +21,15 @@ export function buildRootObject(vatPowers) {
       return n;
     },
 
-    async byNamedBundlecap(name) {
-      const bcap = D(bundleDevice).getNamedBundlecap(name);
+    async byNamedBundleCap(name) {
+      const bcap = await E(admin).getNamedBundleCap(name);
       const { root } = await E(admin).createVat(bcap);
       const n = await E(root).getANumber();
       return n;
     },
 
     async byID(id) {
-      const bcap = D(bundleDevice).getBundlecap(id);
+      const bcap = await E(admin).getBundleCap(id);
       const { root } = await E(admin).createVat(bcap);
       const n = await E(root).getANumber();
       return n;
@@ -52,7 +49,7 @@ export function buildRootObject(vatPowers) {
       return E(admin).createVatByName(bundleName); // should reject
     },
 
-    async nonBundlecap() {
+    async nonBundleCap() {
       return E(admin).createVat(Far('non-bundlecap', {})); // should reject
     },
   });

--- a/packages/SwingSet/test/vat-admin/replay-bootstrap.js
+++ b/packages/SwingSet/test/vat-admin/replay-bootstrap.js
@@ -2,20 +2,19 @@ import { E } from '@agoric/eventual-send';
 import { makePromiseKit } from '@endo/promise-kit';
 import { Far } from '@endo/marshal';
 
-export function buildRootObject(vatPowers) {
-  const { D } = vatPowers;
+export function buildRootObject() {
   const { promise: vatAdminSvc, resolve: gotVatAdminSvc } = makePromiseKit();
   let root;
-  let devices;
+  let vats;
 
   return Far('root', {
-    async bootstrap(vats, devs) {
-      devices = devs;
+    async bootstrap(vats0, devices) {
+      vats = vats0;
       gotVatAdminSvc(E(vats.vatAdmin).createVatAdminService(devices.vatAdmin));
     },
 
     async createVat() {
-      const bcap = D(devices.bundle).getNamedBundlecap('dynamic');
+      const bcap = await E(vatAdminSvc).getNamedBundleCap('dynamic');
       const vc = await E(vatAdminSvc).createVat(bcap);
       root = vc.root;
       const count = await E(root).first();

--- a/packages/SwingSet/test/vat-admin/test-create-vat.js
+++ b/packages/SwingSet/test/vat-admin/test-create-vat.js
@@ -76,7 +76,7 @@ test('createVat by named bundlecap', async t => {
   const { c } = await doTestSetup(t);
   const kpid = c.queueToVatRoot(
     'bootstrap',
-    'byNamedBundlecap',
+    'byNamedBundleCap',
     capargs(['new13']),
   );
   await c.run();
@@ -123,7 +123,7 @@ test('broken vat creation fails (bad buildRootObject)', async t => {
 
 test('error creating vat from non-bundle', async t => {
   const { c } = await doTestSetup(t);
-  const kpid = c.queueToVatRoot('bootstrap', 'nonBundlecap', capargs([]));
+  const kpid = c.queueToVatRoot('bootstrap', 'nonBundleCap', capargs([]));
   await c.run();
   t.is(c.kpStatus(kpid), 'rejected');
   t.deepEqual(

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -23,8 +23,8 @@
  * @typedef { import('@agoric/swingset-vat/src/vats/plugin-manager.js').PluginDevice } PluginDevice
  * @typedef { Device<ReturnType<typeof
  *   import('@agoric/swingset-vat/src/devices/timer-src.js').buildRootDeviceNode>> } TimerDevice
- * @typedef { Device<ReturnType<typeof
- *   import('@agoric/swingset-vat/src/kernel/vatAdmin/vatAdmin-src.js').buildRootDeviceNode>> } VatAdminDevice
+ * @typedef { Device<
+ *   import('@agoric/swingset-vat/src/kernel/vatAdmin/vatAdmin-src.js').VatAdminRootDeviceNode> } VatAdminDevice
  *
  * @typedef { ERef<ReturnType<typeof
  *   import('@agoric/swingset-vat/src/vats/vat-tp.js').buildRootObject>> } VattpVat


### PR DESCRIPTION
fix(swingset): merge bundle/vat-admin devices, add waitForBundlecap()

Simplify the user experience by removing `devices.bundle` and merging its
functionality into vat-admin.

* bootstrap() can go back to doing `vatAdminService =
E(vats.vatAdmin).createVatAdminService(devices.vatAdmin)` ,
instead of `createVatAdminService(devices.vatAdmin, devices.bundle)`
* you can get bundlecaps from `E(vatAdminService).getBundlecap` or
`.getNamedBundlecap`, you no longer need `D(devices.bundle)` for those
* `E(vatAdminService).waitForBundlecap(bundleID)` gives you a Promise that
fires when (and if) the bundle has been installed, so you can e.g. begin a
`zoe.install()` before the bundle is installed (closes #4521)

closes #4566
