### PR TITLE
Fix bitrot in mock VOM implementation

### DIFF
--- a/packages/SwingSet/src/kernel/virtualObjectManager.js
+++ b/packages/SwingSet/src/kernel/virtualObjectManager.js
@@ -168,12 +168,6 @@ export function makeCache(size, fetch, store) {
  *    instances, writing any changed state to the persistent store.  This
  *    provided for testing; it otherwise has little use.
  *
- * - `makeVirtualObjectRepresentative` will provide a useeable, in-memory
- *    version of a virtual object, given its vat slot ID.  This is used when
- *    deserializing a reference to an object that has been received in a message
- *    or is part of the persistent state of another virtual object that is being
- *    swapped in from storage.
- *
  * `makeKind` and `makeDurableKind` are made available to user vat code in the
  * `VatData` global.  The other two methods are for internal use by liveslots.
  */

--- a/packages/SwingSet/tools/fakeVirtualObjectManager.js
+++ b/packages/SwingSet/tools/fakeVirtualObjectManager.js
@@ -19,7 +19,6 @@ export function makeFakeVirtualObjectManager(vrm, fakeStuff, options = {}) {
     makeDurableKind,
     VirtualObjectAwareWeakMap,
     VirtualObjectAwareWeakSet,
-    makeVirtualObjectRepresentative,
     flushCache,
   } = makeVirtualObjectManager(
     fakeStuff.syscall,
@@ -37,7 +36,6 @@ export function makeFakeVirtualObjectManager(vrm, fakeStuff, options = {}) {
     makeDurableKind,
     VirtualObjectAwareWeakMap,
     VirtualObjectAwareWeakSet,
-    makeVirtualObjectRepresentative,
   };
 
   const debugTools = {

--- a/packages/SwingSet/tools/fakeVirtualSupport.js
+++ b/packages/SwingSet/tools/fakeVirtualSupport.js
@@ -19,10 +19,10 @@ class FakeFinalizationRegistry {
 }
 
 export function makeFakeLiveSlotsStuff(options = {}) {
-  let vom;
-  function setVom(vomToUse) {
-    assert(!vom, 'vom already configured');
-    vom = vomToUse;
+  let vrm;
+  function setVrm(vrmToUse) {
+    assert(!vrm, 'vrm already configured');
+    vrm = vrmToUse;
   }
 
   const {
@@ -174,10 +174,10 @@ export function makeFakeLiveSlotsStuff(options = {}) {
     const { type, virtual } = parseVatSlot(slot);
     assert.equal(type, 'object');
     if (virtual) {
-      if (vom) {
-        return vom.makeVirtualObjectRepresentative(slot);
+      if (vrm) {
+        return vrm.reanimate(slot, false);
       } else {
-        assert.fail('fake liveSlots stuff configured without vom');
+        assert.fail('fake liveSlots stuff configured without vrm');
       }
     } else {
       return getValForSlot(slot);
@@ -216,7 +216,7 @@ export function makeFakeLiveSlotsStuff(options = {}) {
     addToPossiblyDeadSet,
     addToPossiblyRetiredSet,
     dumpStore,
-    setVom,
+    setVrm,
   };
 }
 
@@ -235,7 +235,7 @@ export function makeFakeVirtualStuff(options = {}) {
   const fakeStuff = makeFakeLiveSlotsStuff(options);
   const vrm = makeFakeVirtualReferenceManager(fakeStuff);
   const vom = makeFakeVirtualObjectManager(vrm, fakeStuff, options);
-  fakeStuff.setVom(vom);
+  fakeStuff.setVrm(vrm);
   const cm = makeFakeCollectionManager(vrm, fakeStuff, options);
   return { fakeStuff, vrm, vom, cm };
 }
@@ -244,7 +244,7 @@ export function makeStandaloneFakeVirtualObjectManager(options = {}) {
   const fakeStuff = makeFakeLiveSlotsStuff(options);
   const vrm = makeFakeVirtualReferenceManager(fakeStuff);
   const vom = makeFakeVirtualObjectManager(vrm, fakeStuff, options);
-  fakeStuff.setVom(vom);
+  fakeStuff.setVrm(vrm);
   return vom;
 }
 


### PR DESCRIPTION
Somehow, a needed update to the fake virtual object tools got missed in the last round of reworking for collections.  This corrects that.

Closes #4591
