### PR TITLE
SwingSet: Consolidate kernel run queue syscalls

### DIFF
--- a/packages/SwingSet/src/kernel/initializeKernel.js
+++ b/packages/SwingSet/src/kernel/initializeKernel.js
@@ -8,7 +8,8 @@ import { insistVatID } from './id.js';
 import { makeVatSlot } from '../parseVatSlots.js';
 import { insistStorageAPI } from '../storageAPI.js';
 import makeKernelKeeper from './state/kernelKeeper.js';
-import { exportRootObject, doQueueToKref } from './kernel.js';
+import { exportRootObject } from './kernel.js';
+import { makeKernelQueueHandler } from './kernelQueue.js';
 
 function makeVatRootObjectSlot() {
   return makeVatSlot('object', true, 0);
@@ -182,6 +183,8 @@ export function initializeKernel(config, hostStorage, verbose = false) {
       throw Error('bootstrap got unexpected pass-by-presence');
     }
 
+    const { queueToKref } = makeKernelQueueHandler({ kernelKeeper });
+
     const m = makeMarshal(convertValToSlot, undefined, {
       marshalName: 'kernel:bootstrap',
       // TODO Temporary hack.
@@ -191,8 +194,7 @@ export function initializeKernel(config, hostStorage, verbose = false) {
     const args = harden([vatObj0s, deviceObj0s]);
     // doQueueToKref() takes kernel-refs (ko+NN, kd+NN) in s.slots
     const rootKref = exportRootObject(kernelKeeper, bootstrapVatID);
-    const resultKpid = doQueueToKref(
-      kernelKeeper,
+    const resultKpid = queueToKref(
       rootKref,
       'bootstrap',
       m.serialize(args),

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -14,7 +14,8 @@ import { parseVatSlot } from '../parseVatSlots.js';
 import { insistCapData } from '../capdata.js';
 import { insistMessage, insistVatDeliveryResult } from '../message.js';
 import { insistDeviceID, insistVatID } from './id.js';
-import { makeKernelSyscallHandler, doSend } from './kernelSyscall.js';
+import { makeKernelQueueHandler } from './kernelQueue.js';
+import { makeKernelSyscallHandler } from './kernelSyscall.js';
 import { makeSlogger, makeDummySlogger } from './slogger.js';
 import { makeDummyMeterControl } from './dummyMeterControl.js';
 import { getKpidsToRetire } from './cleanup.js';
@@ -70,42 +71,6 @@ export function doAddExport(kernelKeeper, fromVatID, vref) {
   // it's an import) so it will actually increment the count
   kernelKeeper.incrementRefCount(kref, 'doAddExport', { isExport: false });
   return kref;
-}
-
-/**
- * Enqueue a message to some kernel object, as if the message had been sent
- * by some other vat. This requires a kref as a target.
- *
- * @param {*} kernelKeeper  Kernel keeper managing persistent kernel state
- * @param {string} kref  Target of the message
- * @param {string} method  The message verb
- * @param {*} args  The message arguments
- * @param {string} policy How the kernel should handle an eventual resolution
- *    or rejection of the message's result promise. Should be one of
- *    'sendOnly' (don't even create a result promise), 'ignore' (do nothing),
- *    'logAlways' (log the resolution or rejection), 'logFailure' (log only
- *    rejections), or 'panic' (panic the kernel upon a rejection).
- *
- * @returns {string?} the kpid of the sent message's result promise
- */
-export function doQueueToKref(
-  kernelKeeper,
-  kref,
-  method,
-  args,
-  policy = 'ignore',
-) {
-  // queue a message on the end of the queue, with 'absolute' krefs.
-  // Use 'step' or 'run' to execute it
-  insistCapData(args);
-  args.slots.forEach(s => parseKernelSlot(s));
-  let resultKPID;
-  if (policy !== 'none') {
-    resultKPID = kernelKeeper.addKernelPromise(policy);
-  }
-  const msg = harden({ method, args, result: resultKPID });
-  doSend(kernelKeeper, kref, msg);
-  return resultKPID;
 }
 
 export default function buildKernel(
@@ -248,17 +213,6 @@ export default function buildKernel(
     return doAddExport(kernelKeeper, fromVatID, vatSlot);
   }
 
-  const kernelSyscallHandler = makeKernelSyscallHandler({
-    kernelKeeper,
-    ephemeral,
-    // eslint-disable-next-line no-use-before-define
-    notify,
-    // eslint-disable-next-line no-use-before-define
-    doResolve,
-    // eslint-disable-next-line no-use-before-define
-    setTerminationTrigger,
-  });
-
   // If `kernelPanic` is set to non-null, vat execution code will throw it as an
   // error at the first opportunity
   let kernelPanic = null;
@@ -269,61 +223,8 @@ export default function buildKernel(
     kernelPanic = err || new Error(`kernel panic ${problem}`);
   }
 
-  /**
-   * Enqueue a message to some kernel object, as if the message had been sent
-   * by some other vat.
-   *
-   * @param {string} kref  Target of the message
-   * @param {string} method  The message verb
-   * @param {*} args  The message arguments
-   * @param {ResolutionPolicy=} policy How the kernel should handle an eventual
-   *    resolution or rejection of the message's result promise. Should be
-   *    one of 'sendOnly' (don't even create a result promise), 'ignore' (do
-   *    nothing), 'logAlways' (log the resolution or rejection), 'logFailure'
-   *    (log only rejections), or 'panic' (panic the kernel upon a
-   *    rejection).
-   * @returns {string?} the kpid of the sent message's result promise, if any
-   */
-  function queueToKref(kref, method, args, policy = 'ignore') {
-    return doQueueToKref(kernelKeeper, kref, method, args, policy);
-  }
-
-  function notify(vatID, kpid) {
-    const m = harden({ type: 'notify', vatID, kpid });
-    kernelKeeper.incrementRefCount(kpid, `enq|notify`);
-    kernelKeeper.addToRunQueue(m);
-  }
-
-  function doResolve(vatID, resolutions) {
-    if (vatID) {
-      insistVatID(vatID);
-    }
-    for (const resolution of resolutions) {
-      const [kpid, rejected, data] = resolution;
-      insistKernelType('promise', kpid);
-      insistCapData(data);
-      const p = kernelKeeper.getResolveablePromise(kpid, vatID);
-      const { subscribers } = p;
-      for (const subscriber of subscribers) {
-        if (subscriber !== vatID) {
-          notify(subscriber, kpid);
-        }
-      }
-      kernelKeeper.resolveKernelPromise(kpid, rejected, data);
-      const tag = rejected ? 'rejected' : 'fulfilled';
-      if (p.policy === 'logAlways' || (rejected && p.policy === 'logFailure')) {
-        console.log(
-          `${kpid}.policy ${p.policy}: ${tag} ${JSON.stringify(data)}`,
-        );
-      } else if (rejected && p.policy === 'panic') {
-        panic(`${kpid}.policy panic: ${tag} ${JSON.stringify(data)}`);
-      }
-    }
-  }
-
-  function resolveToError(kpid, errorData, expectedDecider) {
-    doResolve(expectedDecider, [[kpid, true, errorData]]);
-  }
+  const { doSend, doSubscribe, doResolve, resolveToError, queueToKref } =
+    makeKernelQueueHandler({ kernelKeeper, panic });
 
   /**
    * Terminate a vat; that is: delete vat DB state,
@@ -412,6 +313,15 @@ export default function buildKernel(
       terminationTrigger = { vatID, shouldAbortCrank, shouldReject, info };
     }
   }
+
+  const kernelSyscallHandler = makeKernelSyscallHandler({
+    kernelKeeper,
+    ephemeral,
+    doSend,
+    doSubscribe,
+    doResolve,
+    setTerminationTrigger,
+  });
 
   /**
    * Perform one delivery to a vat.

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -918,7 +918,7 @@ export default function buildKernel(
       if (ksc) {
         try {
           // this can throw if kernel is buggy
-          kres = kernelSyscallHandler.doKernelSyscall(ksc);
+          kres = kernelSyscallHandler(ksc);
 
           // kres is a KernelResult: ['ok', value] or ['error', problem],
           // where 'error' means we want the calling vat's syscall() to
@@ -1094,7 +1094,7 @@ export default function buildKernel(
         function deviceSyscallHandler(deviceSyscallObject) {
           const ksc =
             translators.deviceSyscallToKernelSyscall(deviceSyscallObject);
-          const kres = kernelSyscallHandler.doKernelSyscall(ksc);
+          const kres = kernelSyscallHandler(ksc);
           const dres = translators.kernelResultToDeviceResult(ksc[0], kres);
           assert.equal(dres[0], 'ok');
           return dres[1];

--- a/packages/SwingSet/src/kernel/kernelQueue.js
+++ b/packages/SwingSet/src/kernel/kernelQueue.js
@@ -1,0 +1,124 @@
+// @ts-check
+import { insistKernelType, parseKernelSlot } from './parseKernelSlots.js';
+import { insistCapData } from '../capdata.js';
+import { insistMessage } from '../message.js';
+import { insistVatID } from './id.js';
+
+/**
+ * @param {Object} tools
+ * @param {*} tools.kernelKeeper  Kernel keeper managing persistent kernel state
+ * @param {(problem: unknown, err?: Error) => void } [tools.panic]
+ */
+export function makeKernelQueueHandler(tools) {
+  const {
+    kernelKeeper,
+    panic = (problem, err) => {
+      throw err || new Error(`kernel panic ${problem}`);
+    },
+  } = tools;
+
+  function notify(vatID, kpid) {
+    const m = harden({ type: 'notify', vatID, kpid });
+    kernelKeeper.incrementRefCount(kpid, `enq|notify`);
+    kernelKeeper.addToRunQueue(m);
+  }
+
+  function doSubscribe(vatID, kpid) {
+    insistVatID(vatID);
+    const p = kernelKeeper.getKernelPromise(kpid);
+    if (p.state === 'unresolved') {
+      kernelKeeper.addSubscriberToPromise(kpid, vatID);
+    } else {
+      // otherwise it's already resolved, you probably want to know how
+      notify(vatID, kpid);
+    }
+  }
+
+  function doResolve(vatID, resolutions) {
+    if (vatID) {
+      insistVatID(vatID);
+    }
+    for (const resolution of resolutions) {
+      const [kpid, rejected, data] = resolution;
+      insistKernelType('promise', kpid);
+      insistCapData(data);
+      const p = kernelKeeper.getResolveablePromise(kpid, vatID);
+      const { subscribers } = p;
+      for (const subscriber of subscribers) {
+        if (subscriber !== vatID) {
+          notify(subscriber, kpid);
+        }
+      }
+      kernelKeeper.resolveKernelPromise(kpid, rejected, data);
+      const tag = rejected ? 'rejected' : 'fulfilled';
+      if (p.policy === 'logAlways' || (rejected && p.policy === 'logFailure')) {
+        console.log(
+          `${kpid}.policy ${p.policy}: ${tag} ${JSON.stringify(data)}`,
+        );
+      } else if (rejected && p.policy === 'panic') {
+        panic(`${kpid}.policy panic: ${tag} ${JSON.stringify(data)}`);
+      }
+    }
+  }
+
+  function resolveToError(kpid, errorData, expectedDecider) {
+    doResolve(expectedDecider, [[kpid, true, errorData]]);
+  }
+
+  function doSend(target, msg) {
+    parseKernelSlot(target);
+    insistMessage(msg);
+    const m = harden({ type: 'send', target, msg });
+    kernelKeeper.incrementRefCount(target, `enq|msg|t`);
+    if (msg.result) {
+      kernelKeeper.incrementRefCount(msg.result, `enq|msg|r`);
+    }
+    let idx = 0;
+    for (const argSlot of msg.args.slots) {
+      kernelKeeper.incrementRefCount(argSlot, `enq|msg|s${idx}`);
+      idx += 1;
+    }
+    kernelKeeper.addToRunQueue(m);
+  }
+
+  /**
+   * Enqueue a message to some kernel object, as if the message had been sent
+   * by some other vat. This requires a kref as a target.
+   *
+   * @param {string} kref  Target of the message
+   * @param {string} method  The message verb
+   * @param {*} args  The message arguments
+   * @param {ResolutionPolicy=} policy How the kernel should handle an eventual
+   *    resolution or rejection of the message's result promise. Should be
+   *    one of 'sendOnly' (don't even create a result promise), 'ignore' (do
+   *    nothing), 'logAlways' (log the resolution or rejection), 'logFailure'
+   *    (log only rejections), or 'panic' (panic the kernel upon a
+   *    rejection).
+   * @returns {string?} the kpid of the sent message's result promise, if any
+   */
+  function queueToKref(kref, method, args, policy = 'ignore') {
+    // queue a message on the end of the queue, with 'absolute' krefs.
+    // Use 'step' or 'run' to execute it
+    insistCapData(args);
+    args.slots.forEach(s => parseKernelSlot(s));
+    let resultKPID;
+    if (policy !== 'none') {
+      resultKPID = kernelKeeper.addKernelPromise(policy);
+    }
+    // Should we actually increment these stats in this case?
+    kernelKeeper.incStat('syscalls');
+    kernelKeeper.incStat('syscallSend');
+    const msg = harden({ method, args, result: resultKPID });
+    doSend(kref, msg);
+    return resultKPID;
+  }
+
+  return harden({
+    doSend,
+    doSubscribe,
+    doResolve,
+    notify,
+    resolveToError,
+    queueToKref,
+  });
+}

--- a/packages/SwingSet/src/kernel/kernelQueue.js
+++ b/packages/SwingSet/src/kernel/kernelQueue.js
@@ -90,7 +90,7 @@ export function makeKernelQueueHandler(tools) {
    * @param {*} args  The message arguments
    * @param {ResolutionPolicy=} policy How the kernel should handle an eventual
    *    resolution or rejection of the message's result promise. Should be
-   *    one of 'sendOnly' (don't even create a result promise), 'ignore' (do
+   *    one of 'none' (don't even create a result promise), 'ignore' (do
    *    nothing), 'logAlways' (log the resolution or rejection), 'logFailure'
    *    (log only rejections), or 'panic' (panic the kernel upon a
    *    rejection).

--- a/packages/SwingSet/src/kernel/kernelSyscall.js
+++ b/packages/SwingSet/src/kernel/kernelSyscall.js
@@ -320,7 +320,7 @@ export function makeKernelSyscallHandler(tools) {
    * @param { KernelSyscallObject } ksc
    * @returns {  KernelSyscallResult }
    */
-  function doKernelSyscall(ksc) {
+  function kernelSyscallHandler(ksc) {
     // this repeated pattern is necessary to get the typechecker to refine 'ksc' and 'args' properly
     switch (ksc[0]) {
       case 'send': {
@@ -376,9 +376,5 @@ export function makeKernelSyscallHandler(tools) {
     }
   }
 
-  const kernelSyscallHandler = harden({
-    send, // TODO remove these individual ones
-    doKernelSyscall,
-  });
-  return kernelSyscallHandler;
+  return harden(kernelSyscallHandler);
 }

--- a/packages/SwingSet/src/kernel/kernelSyscall.js
+++ b/packages/SwingSet/src/kernel/kernelSyscall.js
@@ -1,41 +1,30 @@
 // @ts-check
 
 import { assert, details as X } from '@agoric/assert';
-import { insistKernelType, parseKernelSlot } from './parseKernelSlots.js';
-import { insistMessage } from '../message.js';
+import { insistKernelType } from './parseKernelSlots.js';
 import { insistCapData } from '../capdata.js';
 import { insistDeviceID, insistVatID } from './id.js';
 
 /** @type { KernelSyscallResult } */
 const OKNULL = harden(['ok', null]);
 
-export function doSend(kernelKeeper, target, msg) {
-  parseKernelSlot(target);
-  insistMessage(msg);
-  const m = harden({ type: 'send', target, msg });
-  kernelKeeper.incrementRefCount(target, `enq|msg|t`);
-  if (msg.result) {
-    kernelKeeper.incrementRefCount(msg.result, `enq|msg|r`);
-  }
-  kernelKeeper.incStat('syscalls');
-  kernelKeeper.incStat('syscallSend');
-  let idx = 0;
-  for (const argSlot of msg.args.slots) {
-    kernelKeeper.incrementRefCount(argSlot, `enq|msg|s${idx}`);
-    idx += 1;
-  }
-  kernelKeeper.addToRunQueue(m);
-  return OKNULL;
-}
-
 export function makeKernelSyscallHandler(tools) {
-  const { kernelKeeper, ephemeral, notify, doResolve, setTerminationTrigger } =
-    tools;
+  const {
+    kernelKeeper,
+    ephemeral,
+    doSend,
+    doSubscribe,
+    doResolve,
+    setTerminationTrigger,
+  } = tools;
 
   const { kvStore } = kernelKeeper;
 
   function send(target, msg) {
-    return doSend(kernelKeeper, target, msg);
+    kernelKeeper.incStat('syscalls');
+    kernelKeeper.incStat('syscallSend');
+    doSend(target, msg);
+    return OKNULL;
   }
 
   function exit(vatID, isFailure, info) {
@@ -268,16 +257,9 @@ export function makeKernelSyscallHandler(tools) {
   }
 
   function subscribe(vatID, kpid) {
-    insistVatID(vatID);
     kernelKeeper.incStat('syscalls');
     kernelKeeper.incStat('syscallSubscribe');
-    const p = kernelKeeper.getKernelPromise(kpid);
-    if (p.state === 'unresolved') {
-      kernelKeeper.addSubscriberToPromise(kpid, vatID);
-    } else {
-      // otherwise it's already resolved, you probably want to know how
-      notify(vatID, kpid);
-    }
+    doSubscribe(vatID, kpid);
     return OKNULL;
   }
 

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -603,7 +603,6 @@ export default function makeKernelKeeper(
     kvStore.delete(`${kpid}.policy`);
     kvStore.deletePrefixedKeys(`${kpid}.queue.`);
     kvStore.delete(`${kpid}.queue.nextID`);
-    kvStore.delete(`${kpid}.slot`);
     kvStore.delete(`${kpid}.data.body`);
     kvStore.delete(`${kpid}.data.slots`);
   }

--- a/packages/SwingSet/src/types.js
+++ b/packages/SwingSet/src/types.js
@@ -87,7 +87,7 @@
  * result: string | undefined | null,
  * }} Message
  *
- * @typedef { 'sendOnly' | 'ignore' | 'logAlways' | 'logFailure' | 'panic' } ResolutionPolicy
+ * @typedef { 'none' | 'ignore' | 'logAlways' | 'logFailure' | 'panic' } ResolutionPolicy
  *
  * @typedef { [tag: 'message', target: string, msg: Message]} VatDeliveryMessage
  * @typedef { [vpid: string, isReject: boolean, data: SwingSetCapData ] } VatOneResolution


### PR DESCRIPTION
## Description

This change is preliminary refactor before #4542 and #3465, and just moves some code around. The goal is to consolidate the implementation of syscalls that impact the run queue into a single place. After this I believe all operations that result in a message to be added to the run queue transit through one of the methods of `kernelQueue.js`, except for the `create-vat` message.

### Security Considerations

None

### Documentation Considerations

N/A

### Testing Considerations

Since this only moves code, no tests are added or removed, and all tests pass.
