### PR TITLE
Refresh parameter test on amm liquidity

### DIFF
--- a/packages/run-protocol/test/amm/vpool-xyk-amm/test-amm-calc.js
+++ b/packages/run-protocol/test/amm/vpool-xyk-amm/test-amm-calc.js
@@ -13,10 +13,17 @@ const { add, multiply } = natSafeMath;
 const { brand: brandX } = makeIssuerKit('X');
 const { brand: brandY } = makeIssuerKit('Y');
 
-const arbPoolX = fc.bigUint().map(value => m.make(brandX, 100n + value));
-const arbPoolY = fc.bigUint().map(value => m.make(brandY, 100n + value));
-const arbGiveX = fc.bigUint().map(value => m.make(brandX, value));
-const arbGiveY = fc.bigUint().map(value => m.make(brandY, value));
+const oneB = 1_000_000_000n;
+// const dec18 = 1_000_000_000_000_000_000n; // 18 decimals as used in ETH
+
+const arbPoolX = fc
+  .bigUint({ max: oneB })
+  .map(value => m.make(brandX, 100n + value));
+const arbPoolY = fc
+  .bigUint({ max: oneB })
+  .map(value => m.make(brandY, 100n + value));
+const arbGiveX = fc.bigUint({ max: oneB }).map(value => m.make(brandX, value));
+const arbGiveY = fc.bigUint({ max: oneB }).map(value => m.make(brandY, value));
 
 // left and right are within 5% of each other.
 const withinEpsilon = (left, right) =>

--- a/packages/run-protocol/test/amm/vpool-xyk-amm/test-amm-calc.js
+++ b/packages/run-protocol/test/amm/vpool-xyk-amm/test-amm-calc.js
@@ -47,24 +47,15 @@ test('balancesToReachRatio calculations are to spec', t => {
         giveY: arbGiveY,
       }),
       ({ poolX, poolY, giveX, giveY }) => {
-        const kBefore = Number(multiply(poolX.value, poolY.value));
-        const poolRatioAfter = Math.max(
-          Number(giveX.value + poolX.value) / Number(giveY.value + poolY.value),
-          Number(giveY.value + poolY.value) / Number(giveX.value + poolX.value),
-        );
         // skip cases where the target ratio is more than K at the start
-        fc.pre(poolRatioAfter < kBefore);
-        if (
-          imbalancedRequest(
+        fc.pre(
+          !imbalancedRequest(
             // use floats so we don't convert all fractions less than 1 to 0.
             Number(m.add(poolX, giveX).value) /
               Number(m.add(poolY, giveY).value),
             multiply(poolX.value, poolY.value),
-          )
-        ) {
-          t.pass();
-          return;
-        }
+          ),
+        );
         const { targetX, targetY } = balancesToReachRatio(
           poolX,
           poolY,


### PR DESCRIPTION
closes: #4601
 
## Description

#4519  added a test with some failures. #4600 temporarily repaired it. This is a better fix that increases the range of cases we test, with a narrow exclusion for ill-behaved parameters.

### Security Considerations

No actual security issues. The economic security issue is that someone might use the new ability to add liquidity to the AMM in an infelicitous circumstance (the pools have a small amount of collateral to start) and end up giving more money to the arbitrageurs than they intended.

### Documentation Considerations

When we explain `makeAddLiquidityAtRateInvitation`, we need to explain where the edge cases are.

### Testing Considerations

This PR repairs a property-based test that by its nature doesn't run with the same values every time, so it can give different results on different runs. The exclusions mentioned above are intended to skip over values with problematic results.