### PR TITLE
4602 simpler vault uinotify

### DIFF
--- a/packages/ERTP/src/amountMath.js
+++ b/packages/ERTP/src/amountMath.js
@@ -252,10 +252,12 @@ const AmountMath = {
    *
    * @template {AssetKind} K
    * @param {Brand} brand
-   * @param {AssetKind=} assetKind
+   * @param {K=} [assetKind='nat']
    * @returns {Amount<K extends 'nat' ? NatValue: K extends 'set' ? SetValue: K extends 'copySet' ? CopySetValue: K extends 'copyBag' ? CopyBagValue : never>}
    */
-  makeEmpty: (brand, assetKind = AssetKind.NAT) => {
+  // @ts-expect-error TS/jsdoc things 'nat' can't be assigned to K subclassing AssetKind
+  // If we were using TypeScript we'd simply overload the function definition for each case.
+  makeEmpty: (brand, assetKind = 'nat') => {
     assertRemotable(brand, 'brand');
     assertAssetKind(assetKind);
     const value = helpers[assetKind].doMakeEmpty();

--- a/packages/run-protocol/src/vaultFactory/liquidation.js
+++ b/packages/run-protocol/src/vaultFactory/liquidation.js
@@ -22,7 +22,7 @@ const trace = makeTracer('LIQ');
  *            ) => void} burnLosses
  * @param {LiquidationStrategy} strategy
  * @param {Brand} collateralBrand
- * @returns {Promise<Vault>}
+ * @returns {Promise<InnerVault>}
  */
 const liquidate = async (zcf, vault, burnLosses, strategy, collateralBrand) => {
   vault.liquidating();

--- a/packages/run-protocol/src/vaultFactory/orderedVaultStore.js
+++ b/packages/run-protocol/src/vaultFactory/orderedVaultStore.js
@@ -13,7 +13,7 @@ import { fromVaultKey, toVaultKey } from './storeUtils.js';
  * first.)
  */
 
-/** @typedef {import('./vault').VaultKit} VaultKit */
+/** @typedef {import('./vault').InnerVault} VaultKit */
 /** @typedef {import('./storeUtils').CompositeKey} CompositeKey */
 
 export const makeOrderedVaultStore = () => {

--- a/packages/run-protocol/src/vaultFactory/orderedVaultStore.js
+++ b/packages/run-protocol/src/vaultFactory/orderedVaultStore.js
@@ -13,39 +13,38 @@ import { fromVaultKey, toVaultKey } from './storeUtils.js';
  * first.)
  */
 
-/** @typedef {import('./vault').InnerVault} VaultKit */
+/** @typedef {import('./vault').InnerVault} InnerVault */
 /** @typedef {import('./storeUtils').CompositeKey} CompositeKey */
 
 export const makeOrderedVaultStore = () => {
   // TODO make it work durably https://github.com/Agoric/agoric-sdk/issues/4550
-  /** @type {MapStore<string, VaultKit>} */
+  /** @type {MapStore<string, InnerVault>} */
   const store = makeScalarBigMapStore('orderedVaultStore', { durable: false });
 
   /**
    *
    * @param {string} vaultId
-   * @param {VaultKit} vaultKit
+   * @param {InnerVault} vault
    */
-  const addVaultKit = (vaultId, vaultKit) => {
-    const { vault } = vaultKit;
+  const addVault = (vaultId, vault) => {
     const debt = vault.getDebtAmount();
     const collateral = vault.getCollateralAmount();
     const key = toVaultKey(debt, collateral, vaultId);
-    store.init(key, vaultKit);
+    store.init(key, vault);
     return key;
   };
 
   /**
    *
    * @param {string} key
-   * @returns {VaultKit}
+   * @returns {InnerVault}
    */
   const removeByKey = key => {
     try {
-      const vaultKit = store.get(key);
-      assert(vaultKit);
+      const vault = store.get(key);
+      assert(vault);
       store.delete(key);
-      return vaultKit;
+      return vault;
     } catch (e) {
       const keys = Array.from(store.keys());
       console.error(
@@ -61,7 +60,7 @@ export const makeOrderedVaultStore = () => {
   };
 
   return harden({
-    addVaultKit,
+    addVault,
     removeByKey,
     keys: store.keys,
     entries: store.entries,

--- a/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
+++ b/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
@@ -6,7 +6,7 @@ import { ratioGTE } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { makeOrderedVaultStore } from './orderedVaultStore.js';
 import { toVaultKey } from './storeUtils.js';
 
-/** @typedef {import('./vault').InnerVault} VaultKit */
+/** @typedef {import('./vault').InnerVault} InnerVault */
 
 /**
  *
@@ -26,16 +26,16 @@ const calculateDebtToCollateral = (debtAmount, collateralAmount) => {
 
 /**
  *
- * @param {Vault} vault
+ * @param {InnerVault} vault
  * @returns {Ratio}
  */
 export const currentDebtToCollateral = vault =>
   calculateDebtToCollateral(vault.getDebtAmount(), vault.getCollateralAmount());
 
-/** @typedef {{debtToCollateral: Ratio, vaultKit: VaultKit}} VaultKitRecord */
+/** @typedef {{debtToCollateral: Ratio, vault: InnerVault}} VaultRecord */
 
 /**
- * Really a prioritization of vault *kits*.
+ * Really a prioritization of vault *kits.
  *
  * @param {() => void} reschedulePriceCheck called when there is a new
  * least-collateralized vault
@@ -46,7 +46,7 @@ export const makePrioritizedVaults = reschedulePriceCheck => {
   // To deal with fluctuating prices and varying collateralization, we schedule a
   // new request to the priceAuthority when some vault's debtToCollateral ratio
   // surpasses the current high-water mark. When the request that is at the
-  // current high-water mark fires, we reschedule at the new highest ratio
+  // current high-water mark fires, we reschedule
   // (which should be lower, as we will have liquidated any that were at least
   // as high.)
   // Without this we'd be calling reschedulePriceCheck() unnecessarily
@@ -78,8 +78,8 @@ export const makePrioritizedVaults = reschedulePriceCheck => {
       return undefined;
     }
 
-    const [[_, vaultKit]] = vaults.entries();
-    const { vault } = vaultKit;
+    // TODO isn't this just `values`?
+    const [[_, vault]] = vaults.entries();
     const collateralAmount = vault.getCollateralAmount();
     if (AmountMath.isEmpty(collateralAmount)) {
       // Would be an infinite ratio
@@ -91,11 +91,11 @@ export const makePrioritizedVaults = reschedulePriceCheck => {
 
   /**
    * @param {string} key
-   * @returns {VaultKit}
+   * @returns {InnerVault}
    */
   const removeVault = key => {
-    const vk = vaults.removeByKey(key);
-    const debtToCollateral = currentDebtToCollateral(vk.vault);
+    const vault = vaults.removeByKey(key);
+    const debtToCollateral = currentDebtToCollateral(vault);
     if (
       !oracleQueryThreshold ||
       ratioGTE(debtToCollateral, oracleQueryThreshold)
@@ -104,7 +104,7 @@ export const makePrioritizedVaults = reschedulePriceCheck => {
       // This could be expensive if we delete individual entries in order. Will know once we have perf data.
       oracleQueryThreshold = firstDebtRatio();
     }
-    return vk;
+    return vault;
   };
 
   /**
@@ -121,12 +121,12 @@ export const makePrioritizedVaults = reschedulePriceCheck => {
   /**
    *
    * @param {VaultId} vaultId
-   * @param {VaultKit} vaultKit
+   * @param {InnerVault} vault
    */
-  const addVaultKit = (vaultId, vaultKit) => {
-    const key = vaults.addVaultKit(vaultId, vaultKit);
+  const addVault = (vaultId, vault) => {
+    const key = vaults.addVault(vaultId, vault);
 
-    const debtToCollateral = currentDebtToCollateral(vaultKit.vault);
+    const debtToCollateral = currentDebtToCollateral(vault);
     rescheduleIfHighest(debtToCollateral);
     return key;
   };
@@ -139,16 +139,16 @@ export const makePrioritizedVaults = reschedulePriceCheck => {
    * Redundant tags until https://github.com/Microsoft/TypeScript/issues/23857
    *
    * @param {Ratio} ratio
-   * @yields {[string, VaultKit]}
-   * @returns {IterableIterator<[string, VaultKit]>}
+   * @yields {[string, InnerVault]>}
+   * @returns {IterableIterator<[string, InnerVault]>}
    */
   // eslint-disable-next-line func-names
   function* entriesPrioritizedGTE(ratio) {
     // TODO use a Pattern to limit the query https://github.com/Agoric/agoric-sdk/issues/4550
-    for (const [key, vk] of vaults.entries()) {
-      const debtToCollateral = currentDebtToCollateral(vk.vault);
+    for (const [key, vault] of vaults.entries()) {
+      const debtToCollateral = currentDebtToCollateral(vault);
       if (ratioGTE(debtToCollateral, ratio)) {
-        yield [key, vk];
+        yield [key, vault];
       } else {
         // stop once we are below the target ratio
         break;
@@ -162,12 +162,12 @@ export const makePrioritizedVaults = reschedulePriceCheck => {
    * @param {string} vaultId
    */
   const refreshVaultPriority = (oldDebt, oldCollateral, vaultId) => {
-    const vaultKit = removeVaultByAttributes(oldDebt, oldCollateral, vaultId);
-    addVaultKit(vaultId, vaultKit);
+    const vault = removeVaultByAttributes(oldDebt, oldCollateral, vaultId);
+    addVault(vaultId, vault);
   };
 
   return harden({
-    addVaultKit,
+    addVault,
     entries: vaults.entries,
     entriesPrioritizedGTE,
     highestRatio: () => oracleQueryThreshold,

--- a/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
+++ b/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
@@ -6,7 +6,7 @@ import { ratioGTE } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { makeOrderedVaultStore } from './orderedVaultStore.js';
 import { toVaultKey } from './storeUtils.js';
 
-/** @typedef {import('./vault').VaultKit} VaultKit */
+/** @typedef {import('./vault').InnerVault} VaultKit */
 
 /**
  *

--- a/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
+++ b/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
@@ -47,9 +47,8 @@ export const makePrioritizedVaults = reschedulePriceCheck => {
   // To deal with fluctuating prices and varying collateralization, we schedule a
   // new request to the priceAuthority when some vault's debtToCollateral ratio
   // surpasses the current high-water mark. When the request that is at the
-  // current high-water mark fires, we reschedule
-  // (which should be lower, as we will have liquidated any that were at least
-  // as high.)
+  // current high-water mark fires, we reschedule at the new (presumably
+  // lower) rate.
   // Without this we'd be calling reschedulePriceCheck() unnecessarily
   /** @type {Ratio=} */
   let oracleQueryThreshold;

--- a/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
+++ b/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
@@ -79,8 +79,7 @@ export const makePrioritizedVaults = reschedulePriceCheck => {
       return undefined;
     }
 
-    // TODO isn't this just `values`?
-    const [[_, vault]] = vaults.entries();
+    const [vault] = vaults.values();
     const collateralAmount = vault.getCollateralAmount();
     if (AmountMath.isEmpty(collateralAmount)) {
       // Would be an infinite ratio

--- a/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
+++ b/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
@@ -35,7 +35,8 @@ export const currentDebtToCollateral = vault =>
 /** @typedef {{debtToCollateral: Ratio, vault: InnerVault}} VaultRecord */
 
 /**
- * Really a prioritization of vault *kits.
+ * InnerVaults, ordered by their liquidation ratio so that all the
+ * vaults below a threshold can be quickly found and liquidated.
  *
  * @param {() => void} reschedulePriceCheck called when there is a new
  * least-collateralized vault

--- a/packages/run-protocol/src/vaultFactory/types.js
+++ b/packages/run-protocol/src/vaultFactory/types.js
@@ -35,6 +35,7 @@
 /**
  * @typedef  {Object} VaultFactoryPublicFacet - the public facet
  * @property {() => Promise<Invitation>} makeLoanInvitation
+ * @property {() => Promise<Invitation>} makeVaultInvitation
  * @property {() => Promise<Array<Collateral>>} getCollaterals
  * @property {() => Issuer} getRunIssuer
  * @property {(paramDescription: ParamDescription) => bigint} getNatParamState

--- a/packages/run-protocol/src/vaultFactory/types.js
+++ b/packages/run-protocol/src/vaultFactory/types.js
@@ -221,4 +221,4 @@
  * }}
  */
 
-/** @typedef {import('./vault').VaultKit} VaultKit */
+/** @typedef {import('./vault').InnerVault} InnerVault */

--- a/packages/run-protocol/src/vaultFactory/types.js
+++ b/packages/run-protocol/src/vaultFactory/types.js
@@ -126,6 +126,7 @@
  * @typedef {Object} VaultMixin
  * @property {() => Promise<Invitation>} makeAdjustBalancesInvitation
  * @property {() => Promise<Invitation>} makeCloseInvitation
+ * @property {() => Promise<Invitation>} makeTransferInvitation
  * @property {() => ERef<UserSeat>} getLiquidationSeat
  * @property {() => Notifier<VaultUIState>} getNotifier
  */

--- a/packages/run-protocol/src/vaultFactory/types.js
+++ b/packages/run-protocol/src/vaultFactory/types.js
@@ -102,18 +102,12 @@
 
 /**
  * @typedef {Object} VaultManagerBase
- * @property {(seat: ZCFSeat) => Promise<LoanKit>}  makeVaultKit
+ * @property {(seat: ZCFSeat) => Promise<VaultKit>}  makeVaultKit
  * @property {() => void} liquidateAll
  */
 
 /**
  * @typedef {VaultManagerBase & GetVaultParams} VaultManager
- */
-
-/**
- * @typedef {Object} OpenLoanKit
- * @property {Notifier<VaultUIState>} notifier
- * @property {Promise<PaymentPKeywordRecord>} collateralPayoutP
  */
 
 /**
@@ -142,7 +136,7 @@
  */
 
 /**
- * @typedef {Object} LoanKit
+ * @typedef {Object} VaultKit
  * @property {Vault} vault
  * @property {Notifier<VaultUIState>} uiNotifier
  */

--- a/packages/run-protocol/src/vaultFactory/types.js
+++ b/packages/run-protocol/src/vaultFactory/types.js
@@ -101,7 +101,7 @@
 
 /**
  * @typedef {Object} VaultManagerBase
- * @property {(seat: ZCFSeat) => Promise<LoanKit>}  makeLoanKit
+ * @property {(seat: ZCFSeat) => Promise<LoanKit>}  makeVaultKit
  * @property {() => void} liquidateAll
  */
 

--- a/packages/run-protocol/src/vaultFactory/types.js
+++ b/packages/run-protocol/src/vaultFactory/types.js
@@ -59,7 +59,6 @@
  * @typedef {Object} BaseUIState
  * @property {Amount<NatValue>} locked Amount of Collateral locked
  * @property {Amount<NatValue>} debt Amount of Loan (including accrued interest)
- * @property {Ratio} collateralizationRatio
  */
 
 /**

--- a/packages/run-protocol/src/vaultFactory/types.js
+++ b/packages/run-protocol/src/vaultFactory/types.js
@@ -127,6 +127,7 @@
  * @property {() => Promise<Invitation>} makeAdjustBalancesInvitation
  * @property {() => Promise<Invitation>} makeCloseInvitation
  * @property {() => ERef<UserSeat>} getLiquidationSeat
+ * @property {() => Notifier<VaultUIState>} getNotifier
  */
 
 /**

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -541,6 +541,7 @@ export const makeInnerVault = (
    */
   const adjustBalancesHook = async clientSeat => {
     assertVaultIsOpen();
+    const caller = outerVault;
     const proposal = clientSeat.getProposal();
     const oldDebt = getDebtAmount();
     const oldCollateral = getCollateralAmount();
@@ -550,6 +551,7 @@ export const makeInnerVault = (
     const targetCollateralAmount = targetCollateralLevels(clientSeat).vault;
     // max debt supported by current Collateral as modified by proposal
     const maxDebtForOriginalTarget = await maxDebtFor(targetCollateralAmount);
+    assertActiveOuter(caller);
     assertVaultIsOpen();
 
     const priceOfCollateralInRun = makeRatioFromAmounts(

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -108,27 +108,7 @@ export const makeInnerVault = (
     assert(vaultState === VaultState.ACTIVE, X`vault must still be active`);
   };
 
-  /** @type {Vault} */
-  let outerVault;
-  const assertActiveOuter = outer => {
-    assert(outerVault === outer, X`Using ${outer} after transfer`);
-    // assert(vaultState === VaultState.ACTIVE, X`vault must still be active (is ${vaultState})`);
-  };
-
-  let uiUpdater;
-<<<<<<< HEAD
-  const updateOuter = inner => {
-    // ({ vault: outerVault, uiUpdater }) = makeOuterKit(inner);
-    if (uiUpdater) {
-      uiUpdater.finish(snapshotState(VaultState.TRANSFER));
-    }
-    const { vault, uiUpdater: updater } = makeOuterKit(inner);
-    outerVault = vault;
-    uiUpdater = updater;
-    updateUiState();
-  };
-=======
->>>>>>> d05c3899d (feat: stronger revocation)
+  let outerUpdater;
 
   // vaultSeat will hold the collateral until the loan is retired. The
   // payout from it will be handed to the user: if the vault dies early
@@ -147,24 +127,6 @@ export const makeInnerVault = (
     interest: manager.getCompoundedInterest(),
   };
 
-<<<<<<< HEAD
-  const snapshotState = (vstate, collateralizationRatio) => {
-    /** @type {VaultUIState} */
-    return harden({
-      // TODO move manager state to a separate notifer https://github.com/Agoric/agoric-sdk/issues/4540
-      interestRate: manager.getInterestRate(),
-      liquidationRatio: manager.getLiquidationMargin(),
-      debtSnapshot,
-      locked: getCollateralAmount(),
-      debt: getDebtAmount(),
-      collateralizationRatio,
-      // TODO state distinct from CLOSED https://github.com/Agoric/agoric-sdk/issues/4539
-      liquidated: vaultState === VaultState.CLOSED,
-      vaultState,
-    });
-  };
-=======
->>>>>>> d05c3899d (feat: stronger revocation)
   /**
    * Called whenever the debt is paid or created through a transaction,
    * but not for interest accrual.
@@ -312,7 +274,7 @@ export const makeInnerVault = (
 
   // call this whenever anything changes!
   const updateUiState = async () => {
-    if (!uiUpdater) {
+    if (!outerUpdater) {
       return;
     }
     // TODO(123): track down all calls and ensure that they all update a
@@ -327,10 +289,10 @@ export const makeInnerVault = (
     switch (vaultState) {
       case VaultState.ACTIVE:
       case VaultState.LIQUIDATING:
-        uiUpdater.updateState(uiState);
+        outerUpdater.updateState(uiState);
         break;
       case VaultState.CLOSED:
-        uiUpdater.finish(uiState);
+        outerUpdater.finish(uiState);
         break;
       default:
         throw Error(`unreachable vaultState: ${vaultState}`);
@@ -564,7 +526,8 @@ export const makeInnerVault = (
    */
   const adjustBalancesHook = async clientSeat => {
     assertVaultIsOpen();
-    const caller = outerVault;
+    // the updater will change if we start a transfer
+    const oldUpdater = outerUpdater;
     const proposal = clientSeat.getProposal();
     const oldDebt = getDebtAmount();
     const oldCollateral = getCollateralAmount();
@@ -574,7 +537,7 @@ export const makeInnerVault = (
     const targetCollateralAmount = targetCollateralLevels(clientSeat).vault;
     // max debt supported by current Collateral as modified by proposal
     const maxDebtForOriginalTarget = await maxDebtFor(targetCollateralAmount);
-    assertActiveOuter(caller);
+    assert(oldUpdater === outerUpdater, X`Transfer during vault adjustment`);
     assertVaultIsOpen();
 
     const priceOfCollateralInRun = makeRatioFromAmounts(
@@ -653,27 +616,30 @@ export const makeInnerVault = (
     return zcf.makeInvitation(adjustBalancesHook, 'AdjustBalances');
   };
 
-  const updateOuter = inner => {
-    if (uiUpdater) {
-      uiUpdater.finish(snapshotState(VaultState.TRANSFER));
-    }
-    // This syntax is supposed to work, but is rejected:
-    // ({ vault: outerVault, uiUpdater }) = makeOuterKit(inner);
+  const setupOuter = inner => {
     const { vault, uiUpdater: updater } = makeOuterKit(inner);
-    outerVault = vault;
-    uiUpdater = updater;
+    outerUpdater = updater;
     updateUiState();
+    return harden({
+      uiNotifier: vault.getNotifier(),
+      invitationMakers: Far('invitation makers', {
+        AdjustBalances: vault.makeAdjustBalancesInvitation,
+        CloseVault: vault.makeCloseInvitation,
+        // TransferVault: vault.makeTransferVaultInvitation,
+      }),
+      vault,
+    });
   };
 
   /** @type {OfferHandler} */
-  const initVault = async (seat, innerVault) => {
+  const initVaultKit = async (seat, innerVault) => {
     assert(
       AmountMath.isEmpty(debtSnapshot.run),
       X`vault must be empty initially`,
     );
     const oldDebt = getDebtAmount();
     const oldCollateral = getCollateralAmount();
-    trace('initVault start: collateral', { oldDebt, oldCollateral });
+    trace('initVaultKit start: collateral', { oldDebt, oldCollateral });
 
     // get the payout to provide access to the collateral if the
     // contract abandons
@@ -705,40 +671,31 @@ export const makeInnerVault = (
 
     refreshLoanTracking(oldDebt, oldCollateral, stagedDebt);
 
-    // TODO why isn't this complaining about use-before-define
-    updateOuter(innerVault);
-    return outerVault;
+    return setupOuter(innerVault);
   };
 
   const makeTransferInvitationHook = seat => {
     assertVaultIsOpen();
-<<<<<<< HEAD
-    throw 'TODO unimplemented';
-  };
-
-  const makeTransferInvitation = () => {
-    updateOuter(innerVault);
-    return zcf.makeInvitation(makeTransferInvitationHook, 'TransferVault');
-=======
     seat.exit();
-    return outerVault;
->>>>>>> d05c3899d (feat: stronger revocation)
+    // eslint-disable-next-line no-use-before-define
+    return setupOuter(innerVault);
   };
 
   const innerVault = Far('innerVault', {
     getInnerLiquidationSeat: () => liquidationZcfSeat,
     getVaultSeat: () => vaultSeat,
-    assertActiveOuter,
 
-    //
-    initVault: seat => initVault(seat, innerVault),
+    initVaultKit: seat => initVaultKit(seat, innerVault),
     liquidating,
     liquidated,
 
     makeAdjustBalancesInvitation,
     makeCloseInvitation,
     makeTransferInvitation: () => {
-      updateOuter(innerVault);
+      if (outerUpdater) {
+        outerUpdater.finish(snapshotState(VaultState.TRANSFER));
+        outerUpdater = null;
+      }
       return zcf.makeInvitation(makeTransferInvitationHook, 'TransferVault');
     },
 

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -31,14 +31,15 @@ const trace = makeTracer('Vault');
 /**
  * Constants for vault state.
  *
- * @typedef {'active' | 'liquidating' | 'closed'} VAULT_STATE
+ * @typedef {'active' | 'liquidating' | 'closed' | 'transfer'} VAULT_STATE
  *
- * @type {{ ACTIVE: 'active', LIQUIDATING: 'liquidating', CLOSED: 'closed' }}
+ * @type {{ ACTIVE: 'active', LIQUIDATING: 'liquidating', CLOSED: 'closed', TRANSFER: 'transfer' }}
  */
 export const VaultState = {
   ACTIVE: 'active',
   LIQUIDATING: 'liquidating',
   CLOSED: 'closed',
+  TRANSFER: 'transfer',
 };
 
 const makeOuterKit = inner => {
@@ -109,13 +110,16 @@ export const makeInnerVault = (
   /** @type {Vault} */
   let outerVault;
   const assertActiveOuter = outer => {
-    assert(outerVault === outer, X`Using ${outer} after transfer/close`);
+    assert(outerVault === outer, X`Using ${outer} after transfer`);
     // assert(vaultState === VaultState.ACTIVE, X`vault must still be active (is ${vaultState})`);
   };
 
   let uiUpdater;
   const updateOuter = inner => {
     // ({ vault: outerVault, uiUpdater }) = makeOuterKit(inner);
+    if (uiUpdater) {
+      uiUpdater.finish(snapshotState(VaultState.TRANSFER));
+    }
     const { vault, uiUpdater: updater } = makeOuterKit(inner);
     outerVault = vault;
     uiUpdater = updater;
@@ -139,6 +143,21 @@ export const makeInnerVault = (
     interest: manager.getCompoundedInterest(),
   };
 
+  const snapshotState = (vstate, collateralizationRatio) => {
+    /** @type {VaultUIState} */
+    return harden({
+      // TODO move manager state to a separate notifer https://github.com/Agoric/agoric-sdk/issues/4540
+      interestRate: manager.getInterestRate(),
+      liquidationRatio: manager.getLiquidationMargin(),
+      debtSnapshot,
+      locked: getCollateralAmount(),
+      debt: getDebtAmount(),
+      collateralizationRatio,
+      // TODO state distinct from CLOSED https://github.com/Agoric/agoric-sdk/issues/4539
+      liquidated: vaultState === VaultState.CLOSED,
+      vaultState,
+    });
+  };
   /**
    * Called whenever the debt is paid or created through a transaction,
    * but not for interest accrual.
@@ -148,7 +167,6 @@ export const makeInnerVault = (
   const updateDebtSnapshot = newDebt => {
     // update local state
     debtSnapshot = { run: newDebt, interest: manager.getCompoundedInterest() };
-
     trace(`${idInManager} updateDebtSnapshot`, newDebt.value, debtSnapshot);
   };
 
@@ -280,18 +298,8 @@ export const makeInnerVault = (
     // [https://github.com/Agoric/dapp-token-economy/issues/123]
     const collateralizationRatio = await getCollateralizationRatio();
     /** @type {VaultUIState} */
-    const uiState = harden({
-      // TODO move manager state to a separate notifer https://github.com/Agoric/agoric-sdk/issues/4540
-      interestRate: manager.getInterestRate(),
-      liquidationRatio: manager.getLiquidationMargin(),
-      debtSnapshot,
-      locked: getCollateralAmount(),
-      debt: getDebtAmount(),
-      collateralizationRatio,
-      // TODO state distinct from CLOSED https://github.com/Agoric/agoric-sdk/issues/4539
-      liquidated: vaultState === VaultState.CLOSED,
-      vaultState,
-    });
+    const uiState = snapshotState(vaultState, collateralizationRatio);
+    trace('updateUiState', uiState);
 
     switch (vaultState) {
       case VaultState.ACTIVE:

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -14,7 +14,6 @@ import { makeNotifierKit, observeNotifier } from '@agoric/notifier';
 
 import {
   invertRatio,
-  makeRatio,
   multiplyRatios,
 } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { AmountMath } from '@agoric/ertp';
@@ -240,7 +239,7 @@ export const makeInnerVault = (
       : getCollateralAllocated(vaultSeat);
   };
 
-  const snapshotState = (vstate) => {
+  const snapshotState = vstate => {
     /** @type {VaultUIState} */
     return harden({
       // TODO move manager state to a separate notifer https://github.com/Agoric/agoric-sdk/issues/4540
@@ -256,7 +255,7 @@ export const makeInnerVault = (
   };
 
   // call this whenever anything changes!
-  const updateUiState = async () => {
+  const updateUiState = () => {
     if (!outerUpdater) {
       return;
     }

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -240,25 +240,7 @@ export const makeInnerVault = (
       : getCollateralAllocated(vaultSeat);
   };
 
-  /**
-   * @returns {Promise<Ratio>} Collateral over actual debt
-   */
-  const getCollateralizationRatio = async () => {
-    const collateralAmount = getCollateralAmount();
-    const quoteAmount = await E(priceAuthority).quoteGiven(
-      collateralAmount,
-      runBrand,
-    );
-
-    // TODO: allow Ratios to represent X/0.
-    if (AmountMath.isEmpty(debtSnapshot.run)) {
-      return makeRatio(collateralAmount.value, runBrand, 1n);
-    }
-    const collateralValueInRun = getAmountOut(quoteAmount);
-    return makeRatioFromAmounts(collateralValueInRun, getDebtAmount());
-  };
-
-  const snapshotState = (vstate, collateralizationRatio) => {
+  const snapshotState = (vstate) => {
     /** @type {VaultUIState} */
     return harden({
       // TODO move manager state to a separate notifer https://github.com/Agoric/agoric-sdk/issues/4540
@@ -267,7 +249,6 @@ export const makeInnerVault = (
       debtSnapshot,
       locked: getCollateralAmount(),
       debt: getDebtAmount(),
-      collateralizationRatio,
       // TODO state distinct from CLOSED https://github.com/Agoric/agoric-sdk/issues/4539
       liquidated: vaultState === VaultState.CLOSED,
       vaultState: vstate,
@@ -279,13 +260,8 @@ export const makeInnerVault = (
     if (!outerUpdater) {
       return;
     }
-    // TODO(123): track down all calls and ensure that they all update a
-    // lastKnownCollateralizationRatio (since they all know) so we don't have to
-    // await quoteGiven() here
-    // [https://github.com/Agoric/dapp-token-economy/issues/123]
-    const collateralizationRatio = await getCollateralizationRatio();
     /** @type {VaultUIState} */
-    const uiState = snapshotState(vaultState, collateralizationRatio);
+    const uiState = snapshotState(vaultState);
     trace('updateUiState', uiState);
 
     switch (vaultState) {

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -46,6 +46,7 @@ const makeOuterKit = inner => {
   const { updater: uiUpdater, notifier } = makeNotifierKit();
 
   const assertActive = v => {
+    // console.log('OUTER', v, 'INNER', inner);
     assert(inner, X`Using ${v} after transfer`);
     return inner;
   };
@@ -56,8 +57,9 @@ const makeOuterKit = inner => {
       assertActive(vault).makeAdjustBalancesInvitation(),
     makeCloseInvitation: () => assertActive(vault).makeCloseInvitation(),
     makeTransferInvitation: () => {
+      const tmpInner = assertActive(vault);
       inner = null;
-      return assertActive(vault).makeTransferInvitation();
+      return tmpInner.makeTransferInvitation();
     },
     // for status/debugging
     getCollateralAmount: () => assertActive(vault).getCollateralAmount(),
@@ -625,7 +627,7 @@ export const makeInnerVault = (
       invitationMakers: Far('invitation makers', {
         AdjustBalances: vault.makeAdjustBalancesInvitation,
         CloseVault: vault.makeCloseInvitation,
-        // TransferVault: vault.makeTransferVaultInvitation,
+        TransferVault: vault.makeTransferInvitation,
       }),
       vault,
     });

--- a/packages/run-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/run-protocol/src/vaultFactory/vaultFactory.js
@@ -146,7 +146,7 @@ export const start = async (zcf, privateArgs) => {
   };
 
   /** Make a loan in the vaultManager based on the collateral type. */
-  const makeLoanInvitation = () => {
+  const makeVaultInvitation = () => {
     /** @param {ZCFSeat} seat */
     const makeLoanHook = async seat => {
       assertProposalShape(seat, {
@@ -163,7 +163,7 @@ export const start = async (zcf, privateArgs) => {
       );
       /** @type {VaultManager} */
       const mgr = collateralTypes.get(brandIn);
-      return mgr.makeLoanKit(seat);
+      return mgr.makeVaultKit(seat);
     };
 
     return zcf.makeInvitation(makeLoanHook, 'MakeLoan');
@@ -242,7 +242,8 @@ export const start = async (zcf, privateArgs) => {
 
   /** @type {VaultFactoryPublicFacet} */
   const publicFacet = Far('vaultFactory public facet', {
-    makeLoanInvitation,
+    makeLoanInvitation: makeVaultInvitation, //deprecated
+    makeVaultInvitation,
     getCollaterals,
     getRunIssuer: () => runIssuer,
     getNatParamState,

--- a/packages/run-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/run-protocol/src/vaultFactory/vaultFactory.js
@@ -242,7 +242,7 @@ export const start = async (zcf, privateArgs) => {
 
   /** @type {VaultFactoryPublicFacet} */
   const publicFacet = Far('vaultFactory public facet', {
-    makeLoanInvitation: makeVaultInvitation, //deprecated
+    makeLoanInvitation: makeVaultInvitation, // deprecated
     makeVaultInvitation,
     getCollaterals,
     getRunIssuer: () => runIssuer,

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -371,8 +371,7 @@ export const makeVaultManager = (
       priceAuthority,
     );
 
-    // Don't record the vault until it gets opened
-    // TODO
+    // TODO Don't record the vault until it gets opened
     assert(prioritizedVaults);
     const addedVaultKey = prioritizedVaults.addVault(vaultId, innerVault);
 

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -103,7 +103,7 @@ export const makeVaultManager = (
   /** @type {MutableQuote=} */
   let outstandingQuote;
   /** @type {Amount<NatValue>} */
-  let totalDebt = AmountMath.make(runBrand, 0n);
+  let totalDebt = AmountMath.makeEmpty(runBrand, 'nat');
   /** @type {Ratio}} */
   let compoundedInterest = makeRatio(100n, runBrand); // starts at 1.0, no interest
 

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -377,19 +377,9 @@ export const makeVaultManager = (
     const addedVaultKey = prioritizedVaults.addVault(vaultId, innerVault);
 
     try {
-      const vault = await innerVault.initVault(seat);
-
+      const vaultKit = await innerVault.initVaultKit(seat);
       seat.exit();
-
-      return harden({
-        uiNotifier: vault.getNotifier(),
-        invitationMakers: Far('invitation makers', {
-          AdjustBalances: vault.makeAdjustBalancesInvitation,
-          CloseVault: vault.makeCloseInvitation,
-          // TransferVault: vault.makeTransferVaultInvitation,
-        }),
-        vault,
-      });
+      return vaultKit;
     } catch (err) {
       // remove it from prioritizedVaults
       // XXX openLoan shouldn't assume it's already in the prioritizedVaults

--- a/packages/run-protocol/test/supports.js
+++ b/packages/run-protocol/test/supports.js
@@ -6,7 +6,7 @@ import { Far } from '@endo/marshal';
  * @param {VaultId} vaultId
  * @param {Amount} initDebt
  * @param {Amount} initCollateral
- * @returns {InnerVault & {vault: {setDebt: (Amount) => void}}}
+ * @returns {InnerVault & {setDebt: (Amount) => void}}
  */
 export function makeFakeInnerVault(
   vaultId,

--- a/packages/run-protocol/test/supports.js
+++ b/packages/run-protocol/test/supports.js
@@ -6,9 +6,9 @@ import { Far } from '@endo/marshal';
  * @param {VaultId} vaultId
  * @param {Amount} initDebt
  * @param {Amount} initCollateral
- * @returns {VaultKit & {vault: {setDebt: (Amount) => void}}}
+ * @returns {InnerVault & {vault: {setDebt: (Amount) => void}}}
  */
-export function makeFakeVaultKit(
+export function makeFakeInnerVault(
   vaultId,
   initDebt,
   initCollateral = AmountMath.make(initDebt.brand, 100n),
@@ -21,14 +21,9 @@ export function makeFakeVaultKit(
     getDebtAmount: () => debt,
     setDebt: newDebt => (debt = newDebt),
     setCollateral: newCollateral => (collateral = newCollateral),
-  });
-  const admin = Far('vaultAdmin', {
     getIdInManager: () => vaultId,
     liquidate: () => {},
   });
   // @ts-expect-error pretend this is compatible with VaultKit
-  return harden({
-    vault,
-    admin,
-  });
+  return vault;
 }

--- a/packages/run-protocol/test/vaultFactory/swingsetTests/governance/test-governance.js
+++ b/packages/run-protocol/test/vaultFactory/swingsetTests/governance/test-governance.js
@@ -86,8 +86,8 @@ const expectedVaultFactoryLog = [
   'after vote on (InterestRate), InterestRate numerator is 4321',
   'at 3 days: vote closed',
   'at 3 days: Alice owes {"brand":"[Alleged: RUN brand]","value":"[510105n]"}',
-  'at 3 days: 1 day after votes cast, uiNotifier update #5 has interestRate.numerator 250',
-  'at 4 days: 2 days after votes cast, uiNotifier update #6 has interestRate.numerator 4321',
+  'at 3 days: 1 day after votes cast, uiNotifier update #4 has interestRate.numerator 250',
+  'at 4 days: 2 days after votes cast, uiNotifier update #5 has interestRate.numerator 4321',
   'at 4 days: Alice owes {"brand":"[Alleged: RUN brand]","value":"[510608n]"}',
 ];
 

--- a/packages/run-protocol/test/vaultFactory/swingsetTests/governance/vat-alice.js
+++ b/packages/run-protocol/test/vaultFactory/swingsetTests/governance/vat-alice.js
@@ -41,7 +41,7 @@ const build = async (log, zoe, brands, payments, timer) => {
       }),
     );
 
-    /** @type {LoanKit} */
+    /** @type {VaultKit} */
     const { vault, uiNotifier } = await E(loanSeat).getOfferResult();
 
     const timeLog = async msg =>

--- a/packages/run-protocol/test/vaultFactory/test-orderedVaultStore.js
+++ b/packages/run-protocol/test/vaultFactory/test-orderedVaultStore.js
@@ -44,11 +44,9 @@ test('ordering', t => {
   const vaults = makeOrderedVaultStore();
 
   for (const [vaultId, runCount, collateralCount] of fixture) {
-    const mockVaultKit = harden({
-      vault: mockVault(runCount, collateralCount),
-    });
+    const vault = mockVault(runCount, collateralCount);
     // @ts-expect-error mock
-    vaults.addVaultKit(vaultId, mockVaultKit);
+    vaults.addVault(vaultId, vault);
   }
   const contents = Array.from(vaults.entries());
   const vaultIds = contents.map(([k, _v]) => fromVaultKey(k)[1]);
@@ -60,11 +58,9 @@ test('uniqueness', t => {
   const vaults = makeOrderedVaultStore();
 
   for (const [vaultId, runCount, collateralCount] of fixture) {
-    const mockVaultKit = harden({
-      vault: mockVault(runCount, collateralCount),
-    });
+    const vault = mockVault(runCount, collateralCount);
     // @ts-expect-error mock
-    vaults.addVaultKit(vaultId, mockVaultKit);
+    vaults.addVault(vaultId, vault);
   }
   const numberParts = Array.from(vaults.entries()).map(
     ([k, _v]) => k.split(':')[0],

--- a/packages/run-protocol/test/vaultFactory/test-prioritizedVaults.js
+++ b/packages/run-protocol/test/vaultFactory/test-prioritizedVaults.js
@@ -12,9 +12,9 @@ import {
   currentDebtToCollateral,
   makePrioritizedVaults,
 } from '../../src/vaultFactory/prioritizedVaults.js';
-import { makeFakeVaultKit } from '../supports.js';
+import { makeFakeInnerVault } from '../supports.js';
 
-/** @typedef {import('../../src/vaultFactory/vault.js').VaultKit} VaultKit */
+/** @typedef {import('../../src/vaultFactory/vault.js').InnerVault} InnerVault */
 
 // Some notifier updates aren't propogating sufficiently quickly for the tests.
 // This invocation (thanks to Warner) waits for all promises that can fire to
@@ -31,10 +31,10 @@ function makeCollector() {
 
   /**
    *
-   * @param {[string, VaultKit]} record
+   * @param {[string, InnerVault]} record
    */
-  function lookForRatio([_, vaultKit]) {
-    ratios.push(currentDebtToCollateral(vaultKit.vault));
+  function lookForRatio([_, vault]) {
+    ratios.push(currentDebtToCollateral(vault));
   }
 
   return {
@@ -64,9 +64,9 @@ const percent = n => makeRatio(BigInt(n), brand);
 test('add to vault', async t => {
   const rescheduler = makeRescheduler();
   const vaults = makePrioritizedVaults(rescheduler.fakeReschedule);
-  vaults.addVaultKit(
+  vaults.addVault(
     'id-fakeVaultKit',
-    makeFakeVaultKit('id-fakeVaultKit', AmountMath.make(brand, 130n)),
+    makeFakeInnerVault('id-fakeVaultKit', AmountMath.make(brand, 130n)),
   );
   const collector = makeCollector();
   // ??? why doesn't this work?
@@ -86,14 +86,14 @@ test('updates', async t => {
   const rescheduler = makeRescheduler();
   const vaults = makePrioritizedVaults(rescheduler.fakeReschedule);
 
-  vaults.addVaultKit(
+  vaults.addVault(
     'id-fakeVault1',
-    makeFakeVaultKit('id-fakeVault1', AmountMath.make(brand, 20n)),
+    makeFakeInnerVault('id-fakeVault1', AmountMath.make(brand, 20n)),
   );
 
-  vaults.addVaultKit(
+  vaults.addVault(
     'id-fakeVault2',
-    makeFakeVaultKit('id-fakeVault2', AmountMath.make(brand, 80n)),
+    makeFakeInnerVault('id-fakeVault2', AmountMath.make(brand, 80n)),
   );
 
   await waitForPromisesToSettle();
@@ -111,15 +111,15 @@ test('update changes ratio', async t => {
   const rescheduler = makeRescheduler();
   const vaults = makePrioritizedVaults(rescheduler.fakeReschedule);
 
-  const fakeVault1 = makeFakeVaultKit(
+  const fakeVault1 = makeFakeInnerVault(
     'id-fakeVault1',
     AmountMath.make(brand, 20n),
   );
-  vaults.addVaultKit('id-fakeVault1', fakeVault1);
+  vaults.addVault('id-fakeVault1', fakeVault1);
 
-  vaults.addVaultKit(
+  vaults.addVault(
     'id-fakeVault2',
-    makeFakeVaultKit('id-fakeVault2', AmountMath.make(brand, 80n)),
+    makeFakeInnerVault('id-fakeVault2', AmountMath.make(brand, 80n)),
   );
 
   await waitForPromisesToSettle();
@@ -132,7 +132,7 @@ test('update changes ratio', async t => {
   t.deepEqual(vaults.highestRatio(), percent(80));
 
   // update the fake debt of the vault and then refresh priority queue
-  fakeVault1.vault.setDebt(AmountMath.make(brand, 95n));
+  fakeVault1.setDebt(AmountMath.make(brand, 95n));
   vaults.refreshVaultPriority(
     AmountMath.make(brand, 20n),
     AmountMath.make(brand, 100n), // default collateral of makeFakeVaultKit
@@ -161,17 +161,17 @@ test('removals', async t => {
   const vaults = makePrioritizedVaults(rescheduler.fakeReschedule);
 
   // Add fakes 1,2,3
-  vaults.addVaultKit(
+  vaults.addVault(
     'id-fakeVault1',
-    makeFakeVaultKit('id-fakeVault1', AmountMath.make(brand, 150n)),
+    makeFakeInnerVault('id-fakeVault1', AmountMath.make(brand, 150n)),
   );
-  vaults.addVaultKit(
+  vaults.addVault(
     'id-fakeVault2',
-    makeFakeVaultKit('id-fakeVault2', AmountMath.make(brand, 130n)),
+    makeFakeInnerVault('id-fakeVault2', AmountMath.make(brand, 130n)),
   );
-  vaults.addVaultKit(
+  vaults.addVault(
     'id-fakeVault3',
-    makeFakeVaultKit('id-fakeVault3', AmountMath.make(brand, 140n)),
+    makeFakeInnerVault('id-fakeVault3', AmountMath.make(brand, 140n)),
   );
 
   // remove fake 3
@@ -207,24 +207,24 @@ test('highestRatio', async t => {
   const reschedulePriceCheck = makeRescheduler();
   const vaults = makePrioritizedVaults(reschedulePriceCheck.fakeReschedule);
 
-  vaults.addVaultKit(
+  vaults.addVault(
     'id-fakeVault1',
-    makeFakeVaultKit('id-fakeVault1', AmountMath.make(brand, 30n)),
+    makeFakeInnerVault('id-fakeVault1', AmountMath.make(brand, 30n)),
   );
   const cr1 = percent(30);
   t.deepEqual(vaults.highestRatio(), cr1);
 
-  const fakeVault6 = makeFakeVaultKit(
+  const fakeVault6 = makeFakeInnerVault(
     'id-fakeVault6',
     AmountMath.make(brand, 50n),
   );
-  vaults.addVaultKit('id-fakeVault6', fakeVault6);
+  vaults.addVault('id-fakeVault6', fakeVault6);
   const cr6 = percent(50);
   t.deepEqual(vaults.highestRatio(), cr6);
 
-  vaults.addVaultKit(
+  vaults.addVault(
     'id-fakeVault3',
-    makeFakeVaultKit('id-fakeVault3', AmountMath.make(brand, 40n)),
+    makeFakeInnerVault('id-fakeVault3', AmountMath.make(brand, 40n)),
   );
 
   // sanity check ordering
@@ -238,15 +238,15 @@ test('highestRatio', async t => {
   );
 
   const debtsOverThreshold = [];
-  Array.from(vaults.entriesPrioritizedGTE(percent(45))).map(([_key, vk]) =>
+  Array.from(vaults.entriesPrioritizedGTE(percent(45))).map(([_key, vault]) =>
     debtsOverThreshold.push([
-      vk.vault.getDebtAmount(),
-      vk.vault.getCollateralAmount(),
+      vault.getDebtAmount(),
+      vault.getCollateralAmount(),
     ]),
   );
 
   t.deepEqual(debtsOverThreshold, [
-    [fakeVault6.vault.getDebtAmount(), fakeVault6.vault.getCollateralAmount()],
+    [fakeVault6.getDebtAmount(), fakeVault6.getCollateralAmount()],
   ]);
   t.deepEqual(vaults.highestRatio(), percent(50), 'expected 50% to be highest');
 });

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -469,6 +469,7 @@ test('price drop', async t => {
     500n,
     aethIssuer,
   );
+  trace('setup');
 
   const {
     zoe,
@@ -493,8 +494,10 @@ test('price drop', async t => {
       Collateral: aethMint.mintPayment(collateralAmount),
     }),
   );
+  trace('loan made', loanAmount);
 
   const { vault, uiNotifier } = await E(loanSeat).getOfferResult();
+  trace('offer result', vault);
   const debtAmount = await E(vault).getDebtAmount();
   const fee = ceilMultiplyBy(AmountMath.make(runBrand, 270n), rates.loanFee);
   t.deepEqual(
@@ -505,6 +508,7 @@ test('price drop', async t => {
 
   /** @type {UpdateRecord<VaultUIState>} */
   let notification = await E(uiNotifier).getUpdateSince();
+  trace('got notificaation', notification);
 
   t.falsy(notification.value.liquidated);
   t.deepEqual(
@@ -518,13 +522,13 @@ test('price drop', async t => {
     AmountMath.make(aethBrand, 400n),
     'vault holds 11 Collateral',
   );
-
   await manualTimer.tick();
   notification = await E(uiNotifier).getUpdateSince();
   t.falsy(notification.value.liquidated);
 
   await manualTimer.tick();
   notification = await E(uiNotifier).getUpdateSince(notification.updateCount);
+  trace('price changed to liquidate', notification.value.vaultState);
   t.falsy(notification.value.liquidated);
   t.is(notification.value.vaultState, VaultState.LIQUIDATING);
 

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -981,7 +981,6 @@ test('adjust balances', async t => {
   } = services;
   const { vaultFactory, lender } = services.vaultFactory;
 
-  const priceConversion = makeRatio(15n, runBrand, 1n, aethBrand);
   const rates = makeRates(runBrand);
   await E(vaultFactory).addVaultType(aethIssuer, 'AEth', rates);
 
@@ -1148,6 +1147,7 @@ test('adjust balances', async t => {
 
   debtAmount = await E(aliceVault).getDebtAmount();
   t.deepEqual(debtAmount, runDebtLevel);
+  t.deepEqual(collateralLevel, await E(aliceVault).getCollateralAmount());
 
   const { RUN: lentAmount4 } = await E(
     aliceReduceCollateralSeat,
@@ -1183,7 +1183,6 @@ test('adjust balances', async t => {
     runDebtLevel,
     AmountMath.add(withdrawRunAmount, withdrawRun3WithFees),
   );
-  collateralLevel = AmountMath.subtract(collateralLevel, collateralDecr2);
   const aliceReduceCollateralSeat2 = await E(zoe).offer(
     E(aliceVault).makeAdjustBalancesInvitation(),
     harden({
@@ -1557,7 +1556,6 @@ test('mutable liquidity triggers and interest', async t => {
   const aliceDebtAmount = await E(aliceVault).getDebtAmount();
   const fee = ceilMultiplyBy(aliceLoanAmount, rates.loanFee);
   const aliceRunDebtLevel = AmountMath.add(aliceLoanAmount, fee);
-  let aliceCollateralLevel = AmountMath.make(aethBrand, 1000n);
 
   t.deepEqual(aliceDebtAmount, aliceRunDebtLevel, 'vault lent 5000 RUN + fees');
   const { RUN: aliceLentAmount } = await E(
@@ -1619,10 +1617,6 @@ test('mutable liquidity triggers and interest', async t => {
   // Alice reduce collateral by 300. That leaves her at 700 * 10 > 1.05 * 5000.
   // Prices will drop from 10 to 7, she'll be liquidated: 700 * 7 < 1.05 * 5000.
   const collateralDecrement = AmountMath.make(aethBrand, 300n);
-  aliceCollateralLevel = AmountMath.subtract(
-    aliceCollateralLevel,
-    collateralDecrement,
-  );
   const aliceReduceCollateralSeat = await E(zoe).offer(
     E(aliceVault).makeAdjustBalancesInvitation(),
     harden({
@@ -2066,7 +2060,6 @@ test('mutable liquidity triggers and interest sensitivity', async t => {
   const aliceDebtAmount = await E(aliceVault).getDebtAmount();
   const fee = ceilMultiplyBy(aliceLoanAmount, rates.loanFee);
   const aliceRunDebtLevel = AmountMath.add(aliceLoanAmount, fee);
-  let aliceCollateralLevel = AmountMath.make(aethBrand, 1000n);
 
   t.deepEqual(aliceDebtAmount, aliceRunDebtLevel, 'vault lent 5000 RUN + fees');
   const { RUN: aliceLentAmount } = await E(
@@ -2128,10 +2121,6 @@ test('mutable liquidity triggers and interest sensitivity', async t => {
   // Alice reduce collateral by 300. That leaves her at 700 * 10 > 1.05 * 5000.
   // Prices will drop from 10 to 7, she'll be liquidated: 700 * 7 < 1.05 * 5000.
   const collateralDecrement = AmountMath.make(aethBrand, 211n);
-  aliceCollateralLevel = AmountMath.subtract(
-    aliceCollateralLevel,
-    collateralDecrement,
-  );
   const aliceReduceCollateralSeat = await E(zoe).offer(
     E(aliceVault).makeAdjustBalancesInvitation(),
     harden({
@@ -2154,7 +2143,7 @@ test('mutable liquidity triggers and interest sensitivity', async t => {
   );
 
   aliceUpdate = await E(aliceNotifier).getUpdateSince();
-  t.deepEqual(aliceUpdate.value.debt, aliceRunDebtLevel);;
+  t.deepEqual(aliceUpdate.value.debt, aliceRunDebtLevel);
 
   await manualTimer.tick();
   // price levels changed and interest was charged.

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -1244,6 +1244,142 @@ test('adjust balances', async t => {
   });
 });
 
+test('transfer vault', async t => {
+  const loanTiming = {
+    chargingPeriod: 2n,
+    recordingPeriod: 6n,
+  };
+
+  const {
+    aethKit: { mint: aethMint, issuer: aethIssuer, brand: aethBrand },
+  } = setupAssets();
+  const aethInitialLiquidity = AmountMath.make(aethBrand, 300n);
+  const aethLiquidity = {
+    proposal: aethInitialLiquidity,
+    payment: aethMint.mintPayment(aethInitialLiquidity),
+  };
+
+  const services = await setupServices(
+    loanTiming,
+    [15n],
+    AmountMath.make(aethBrand, 1n),
+    aethBrand,
+    { committeeName: 'TheCabal', committeeSize: 5 },
+    buildManualTimer(console.log),
+    undefined,
+    aethLiquidity,
+    500n,
+    aethIssuer,
+  );
+  const {
+    zoe,
+    runKit: { issuer: runIssuer, brand: runBrand },
+  } = services;
+  const { vaultFactory, lender } = services.vaultFactory;
+
+  const rates = makeRates(runBrand);
+  await E(vaultFactory).addVaultType(aethIssuer, 'AEth', rates);
+
+  // initial loan /////////////////////////////////////
+
+  // Create a loan for Alice for 5000 RUN with 1000 aeth collateral
+  const collateralAmount = AmountMath.make(aethBrand, 1000n);
+  const aliceLoanAmount = AmountMath.make(runBrand, 5000n);
+  const aliceLoanSeat = await E(zoe).offer(
+    E(lender).makeLoanInvitation(),
+    harden({
+      give: { Collateral: collateralAmount },
+      want: { RUN: aliceLoanAmount },
+    }),
+    harden({
+      Collateral: aethMint.mintPayment(collateralAmount),
+    }),
+  );
+  const { vault: aliceVault, uiNotifier: aliceNotifier } = await E(
+    aliceLoanSeat,
+  ).getOfferResult();
+
+  const debtAmount = await E(aliceVault).getDebtAmount();
+
+  // TODO this should not need `await`
+  const transferInvite = await E(aliceVault).makeTransferInvitation();
+  const transferSeat = await E(zoe).offer(transferInvite);
+  const { vault: transferVault, uiNotifier: transferNotifier } = await E(
+    transferSeat,
+  ).getOfferResult();
+  t.throwsAsync(() => E(aliceVault).getDebtAmount());
+  const debtAfter = await E(transferVault).getDebtAmount();
+  t.deepEqual(debtAmount, debtAfter, 'vault lent 5000 RUN + fees');
+  const collateralAfter = await E(transferVault).getCollateralAmount();
+  t.deepEqual(collateralAmount, collateralAfter, 'vault has 1000n aEth');
+
+  const aliceFinish = await E(aliceNotifier).getUpdateSince();
+  t.deepEqual(
+    aliceFinish.value.vaultState,
+    VaultState.TRANSFER,
+    'transfer closed old notifier',
+  );
+
+  const transferStatus = await E(transferNotifier).getUpdateSince();
+  t.deepEqual(
+    transferStatus.value.vaultState,
+    VaultState.ACTIVE,
+    'new notifier is active',
+  );
+
+  // Interleave with `adjustVault`
+  // make the invitation first so that we can arrange the interleaving
+  // of adjust and tranfer
+  // TODO this should not need `await`
+  const adjustInvitation = await E(
+    transferVault,
+  ).makeAdjustBalancesInvitation();
+  const { RUN: lentAmount } = await E(aliceLoanSeat).getCurrentAllocation();
+  const aliceProceeds = await E(aliceLoanSeat).getPayouts();
+  t.deepEqual(lentAmount, aliceLoanAmount, 'received 5000 RUN');
+  const borrowedRun = await aliceProceeds.RUN;
+  const payoffRun2 = AmountMath.make(runBrand, 600n);
+  const [paybackPayment, _remainingPayment] = await E(runIssuer).split(
+    borrowedRun,
+    payoffRun2,
+  );
+
+  // Adjust is multi-turn. Confirm that an interleaved transfer prevents it
+  const adjustPromise = E(zoe).offer(
+    adjustInvitation,
+    harden({
+      give: { RUN: payoffRun2 },
+    }),
+    harden({ RUN: paybackPayment }),
+  );
+  const t2Invite = await E(transferVault).makeTransferInvitation();
+  const t2Seat = await E(zoe).offer(t2Invite);
+  const { vault: t2Vault, uiNotifier: t2Notifier } = await E(
+    t2Seat,
+  ).getOfferResult();
+  t.throwsAsync(async () => E(adjustPromise).getOfferResult());
+  t.throwsAsync(() => E(transferVault).getDebtAmount());
+  const debtAfter2 = await E(t2Vault).getDebtAmount();
+  t.deepEqual(debtAmount, debtAfter2, 'vault lent 5000 RUN + fees');
+
+  const collateralAfter2 = await E(t2Vault).getCollateralAmount();
+  t.deepEqual(collateralAmount, collateralAfter2, 'vault has 1000n aEth');
+
+  const transferFinish = await E(transferNotifier).getUpdateSince();
+  t.deepEqual(
+    transferFinish.value.vaultState,
+    VaultState.TRANSFER,
+    't2 closed old notifier',
+  );
+
+  const t2Status = await E(t2Notifier).getUpdateSince();
+  t.deepEqual(
+    t2Status.value.vaultState,
+    VaultState.ACTIVE,
+    'new notifier is active',
+  );
+});
+
 // Alice will over repay her borrowed RUN. In order to make that possible,
 // Bob will also take out a loan and will give her the proceeds.
 test('overdeposit', async t => {

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -499,7 +499,7 @@ test('price drop', async t => {
   const { vault, uiNotifier } = await E(loanSeat).getOfferResult();
   trace('offer result', vault);
   const debtAmount = await E(vault).getDebtAmount();
-  const fee = ceilMultiplyBy(AmountMath.make(runBrand, 270n), rates.loanFee);
+  const fee = ceilMultiplyBy(loanAmount, rates.loanFee);
   t.deepEqual(
     debtAmount,
     AmountMath.add(loanAmount, fee),
@@ -511,10 +511,7 @@ test('price drop', async t => {
   trace('got notificaation', notification);
 
   t.falsy(notification.value.liquidated);
-  t.deepEqual(
-    await notification.value.collateralizationRatio,
-    makeRatio(444n, runBrand, 284n),
-  );
+  t.deepEqual(await notification.value.debt, AmountMath.add(loanAmount, fee));
   const { RUN: lentAmount } = await E(loanSeat).getCurrentAllocation();
   t.truthy(AmountMath.isEqual(lentAmount, loanAmount), 'received 470 RUN');
   t.deepEqual(
@@ -540,10 +537,6 @@ test('price drop', async t => {
   const debtAmountAfter = await E(vault).getDebtAmount();
   const finalNotification = await E(uiNotifier).getUpdateSince();
   t.truthy(finalNotification.value.liquidated);
-  t.deepEqual(
-    await finalNotification.value.collateralizationRatio,
-    makeRatio(0n, runBrand, 1n),
-  );
   t.truthy(AmountMath.isEmpty(debtAmountAfter));
 
   t.deepEqual(await E(vaultFactory).getRewardAllocation(), {
@@ -879,11 +872,6 @@ test('interest on multiple vaults', async t => {
     bobUpdate.value.liquidationRatio,
     makeRatio(105n, runBrand, 100n),
   );
-  const bobCollateralization = bobUpdate.value.collateralizationRatio;
-  t.truthy(
-    bobCollateralization.numerator.value >
-      bobCollateralization.denominator.value,
-  );
 
   // 236 is the initial fee. Interest is ~3n/week
   const aliceAddedDebt = 236n + 3n;
@@ -899,16 +887,6 @@ test('interest on multiple vaults', async t => {
   });
   t.deepEqual(aliceUpdate.value.interestRate, interestRate);
   t.deepEqual(aliceUpdate.value.liquidationRatio, makeRatio(105n, runBrand));
-  const aliceCollateralization = aliceUpdate.value.collateralizationRatio;
-  t.truthy(
-    aliceCollateralization.numerator.value >
-      aliceCollateralization.denominator.value,
-  );
-  t.is(
-    aliceCollateralization.denominator.value,
-    aliceUpdate.value.debt.value,
-    `Debt in collateralizationRatio should match actual debt`,
-  );
 
   const rewardAllocation = await E(vaultFactory).getRewardAllocation();
   const rewardRunCount = aliceAddedDebt + bobAddedDebt + 1n; // +1 due to rounding
@@ -1046,9 +1024,6 @@ test('adjust balances', async t => {
 
   let aliceUpdate = await E(aliceNotifier).getUpdateSince();
   t.deepEqual(aliceUpdate.value.debt, runDebtLevel);
-  const aliceCollateralization1 = aliceUpdate.value.collateralizationRatio;
-  t.deepEqual(aliceCollateralization1.numerator.value, 15000n);
-  t.deepEqual(aliceCollateralization1.denominator.value, runDebtLevel.value);
   t.deepEqual(aliceUpdate.value.debtSnapshot, {
     run: AmountMath.make(runBrand, 5250n),
     interest: makeRatio(100n, runBrand),
@@ -1098,12 +1073,6 @@ test('adjust balances', async t => {
 
   aliceUpdate = await E(aliceNotifier).getUpdateSince();
   t.deepEqual(aliceUpdate.value.debt, runDebtLevel);
-  const aliceCollateralization2 = aliceUpdate.value.collateralizationRatio;
-  t.deepEqual(
-    aliceCollateralization2.numerator,
-    ceilMultiplyBy(collateralLevel, priceConversion),
-  );
-  t.deepEqual(aliceCollateralization2.denominator, runDebtLevel);
 
   // increase collateral 2 ////////////////////////////////// (want:s, give:c)
 
@@ -1151,12 +1120,6 @@ test('adjust balances', async t => {
 
   aliceUpdate = await E(aliceNotifier).getUpdateSince();
   t.deepEqual(aliceUpdate.value.debt, runDebtLevel);
-  const aliceCollateralization3 = aliceUpdate.value.collateralizationRatio;
-  t.deepEqual(
-    aliceCollateralization3.numerator,
-    ceilMultiplyBy(collateralLevel, priceConversion),
-  );
-  t.deepEqual(aliceCollateralization3.denominator, runDebtLevel);
   t.deepEqual(aliceUpdate.value.debtSnapshot, {
     run: AmountMath.make(runBrand, 5253n),
     interest: makeRatio(100n, runBrand),
@@ -1209,12 +1172,6 @@ test('adjust balances', async t => {
 
   aliceUpdate = await E(aliceNotifier).getUpdateSince();
   t.deepEqual(aliceUpdate.value.debt, runDebtLevel);
-  const aliceCollateralization4 = aliceUpdate.value.collateralizationRatio;
-  t.deepEqual(
-    aliceCollateralization4.numerator,
-    ceilMultiplyBy(collateralLevel, priceConversion),
-  );
-  t.deepEqual(aliceCollateralization4.denominator, runDebtLevel);
 
   // NSF  ///////////////////////////////////// (want too much of both)
 
@@ -1456,9 +1413,7 @@ test('overdeposit', async t => {
 
   let aliceUpdate = await E(aliceNotifier).getUpdateSince();
   t.deepEqual(aliceUpdate.value.debt, runDebt);
-  const aliceCollateralization1 = aliceUpdate.value.collateralizationRatio;
-  t.deepEqual(aliceCollateralization1.numerator.value, 15000n);
-  t.deepEqual(aliceCollateralization1.denominator.value, runDebt.value);
+  t.deepEqual(aliceUpdate.value.locked, collateralAmount);
 
   // Bob's loan /////////////////////////////////////
 
@@ -1514,15 +1469,6 @@ test('overdeposit', async t => {
 
   aliceUpdate = await E(aliceNotifier).getUpdateSince();
   t.deepEqual(aliceUpdate.value.debt, AmountMath.makeEmpty(runBrand));
-  const aliceCollateralization5 = aliceUpdate.value.collateralizationRatio;
-  t.deepEqual(
-    aliceCollateralization5.numerator,
-    AmountMath.make(runBrand, 1000n),
-  );
-  t.deepEqual(
-    aliceCollateralization5.denominator,
-    AmountMath.make(runBrand, 1n),
-  );
 
   const collectFeesSeat = await E(zoe).offer(
     E(vaultFactory).makeCollectFeesInvitation(),
@@ -1702,15 +1648,6 @@ test('mutable liquidity triggers and interest', async t => {
 
   aliceUpdate = await E(aliceNotifier).getUpdateSince();
   t.deepEqual(aliceUpdate.value.debt, aliceRunDebtLevel);
-  const aliceCollateralization4 = aliceUpdate.value.collateralizationRatio;
-  t.deepEqual(
-    aliceCollateralization4.numerator,
-    ceilMultiplyBy(
-      aliceCollateralLevel,
-      makeRatio(10n, runBrand, 1n, aethBrand),
-    ),
-  );
-  t.deepEqual(aliceCollateralization4.denominator, aliceRunDebtLevel);
 
   await manualTimer.tick();
   // price levels changed and interest was charged.
@@ -1933,9 +1870,7 @@ test('close loan', async t => {
 
   const aliceUpdate = await E(aliceNotifier).getUpdateSince();
   t.deepEqual(aliceUpdate.value.debt, runDebtLevel);
-  const aliceCollateralization1 = aliceUpdate.value.collateralizationRatio;
-  t.deepEqual(aliceCollateralization1.numerator.value, 15000n);
-  t.deepEqual(aliceCollateralization1.denominator.value, runDebtLevel.value);
+  t.deepEqual(aliceUpdate.value.locked, collateralAmount);
 
   // Create a loan for Bob for 1000 RUN with 200 aeth collateral
   const bobCollateralAmount = AmountMath.make(aethBrand, 200n);
@@ -2219,16 +2154,7 @@ test('mutable liquidity triggers and interest sensitivity', async t => {
   );
 
   aliceUpdate = await E(aliceNotifier).getUpdateSince();
-  t.deepEqual(aliceUpdate.value.debt, aliceRunDebtLevel);
-  const aliceCollateralization4 = aliceUpdate.value.collateralizationRatio;
-  t.deepEqual(
-    aliceCollateralization4.numerator,
-    ceilMultiplyBy(
-      aliceCollateralLevel,
-      makeRatio(10n, runBrand, 1n, aethBrand),
-    ),
-  );
-  t.deepEqual(aliceCollateralization4.denominator, aliceRunDebtLevel);
+  t.deepEqual(aliceUpdate.value.debt, aliceRunDebtLevel);;
 
   await manualTimer.tick();
   // price levels changed and interest was charged.

--- a/packages/run-protocol/test/vaultFactory/vault-contract-wrapper.js
+++ b/packages/run-protocol/test/vaultFactory/vault-contract-wrapper.js
@@ -14,7 +14,7 @@ import {
 import { Far } from '@endo/marshal';
 
 import { makeNotifierKit } from '@agoric/notifier';
-import { makeVaultKit } from '../../src/vaultFactory/vault.js';
+import { makeInnerVaultKit } from '../../src/vaultFactory/vault.js';
 import { paymentFromZCFMint } from '../../src/vaultFactory/burn.js';
 
 const BASIS_POINTS = 10000n;
@@ -55,7 +55,7 @@ export async function start(zcf, privateArgs) {
     }
   }
 
-  /** @type {Parameters<typeof makeVaultKit>[1]} */
+  /** @type {Parameters<typeof makeInnerVaultKit>[1]} */
   const managerMock = Far('vault manager mock', {
     getLiquidationMargin() {
       return makeRatio(105n, runBrand);
@@ -104,8 +104,8 @@ export async function start(zcf, privateArgs) {
 
   const {
     vault,
-    actions: { openLoan },
-  } = await makeVaultKit(
+    actions: { initVault },
+  } = await makeInnerVaultKit(
     zcf,
     managerMock,
     managerNotifier,
@@ -142,7 +142,7 @@ export async function start(zcf, privateArgs) {
   }));
 
   async function makeHook(seat) {
-    const { notifier } = await openLoan(seat);
+    const { notifier } = await initVault(seat);
 
     return {
       vault,

--- a/packages/run-protocol/test/vaultFactory/vault-contract-wrapper.js
+++ b/packages/run-protocol/test/vaultFactory/vault-contract-wrapper.js
@@ -14,7 +14,7 @@ import {
 import { Far } from '@endo/marshal';
 
 import { makeNotifierKit } from '@agoric/notifier';
-import { makeInnerVaultKit } from '../../src/vaultFactory/vault.js';
+import { makeInnerVault } from '../../src/vaultFactory/vault.js';
 import { paymentFromZCFMint } from '../../src/vaultFactory/burn.js';
 
 const BASIS_POINTS = 10000n;
@@ -55,7 +55,7 @@ export async function start(zcf, privateArgs) {
     }
   }
 
-  /** @type {Parameters<typeof makeInnerVaultKit>[1]} */
+  /** @type {Parameters<typeof makeInnerVault>[1]} */
   const managerMock = Far('vault manager mock', {
     getLiquidationMargin() {
       return makeRatio(105n, runBrand);
@@ -102,10 +102,7 @@ export async function start(zcf, privateArgs) {
 
   const { notifier: managerNotifier } = makeNotifierKit();
 
-  const {
-    vault,
-    actions: { initVault },
-  } = await makeInnerVaultKit(
+  const innerVault = await makeInnerVault(
     zcf,
     managerMock,
     managerNotifier,
@@ -138,22 +135,21 @@ export async function start(zcf, privateArgs) {
     collateralKit,
     runMint,
     setInterestRate,
-    vault,
+    vault: innerVault,
   }));
 
   async function makeHook(seat) {
-    const { notifier } = await initVault(seat);
-
+    const vault = await innerVault.initVault(seat);
     return {
-      vault,
+      vault: innerVault,
       runMint,
       collateralKit,
       actions: Far('vault actions', {
         add() {
-          return vault.makeAdjustBalancesInvitation();
+          return innerVault.makeAdjustBalancesInvitation();
         },
       }),
-      notifier,
+      notifier: vault.getNotifier(),
     };
   }
 
@@ -161,7 +157,7 @@ export async function start(zcf, privateArgs) {
 
   const vaultAPI = Far('vaultAPI', {
     makeAdjustBalancesInvitation() {
-      return vault.makeAdjustBalancesInvitation();
+      return innerVault.makeAdjustBalancesInvitation();
     },
     mintRun(amount) {
       return paymentFromZCFMint(zcf, runMint, amount);

--- a/packages/run-protocol/test/vaultFactory/vault-contract-wrapper.js
+++ b/packages/run-protocol/test/vaultFactory/vault-contract-wrapper.js
@@ -139,17 +139,17 @@ export async function start(zcf, privateArgs) {
   }));
 
   async function makeHook(seat) {
-    const vault = await innerVault.initVault(seat);
+    const vaultKit = await innerVault.initVaultKit(seat);
     return {
       vault: innerVault,
       runMint,
       collateralKit,
       actions: Far('vault actions', {
         add() {
-          return innerVault.makeAdjustBalancesInvitation();
+          return vaultKit.makeAdjustBalancesInvitation();
         },
       }),
-      notifier: vault.getNotifier(),
+      notifier: vaultKit.uiNotifier,
     };
   }
 


### PR DESCRIPTION
closes: #4602
refs: #XXXX

## Description

Delete the function to compute `collateralizationRatio`, remove from the state that gets notified, and fix up tests.

### Security Considerations
None

### Documentation Considerations

Update the record definition if it's in the docs.

Vault UI may need to be updated to compute the property.

### Testing Considerations

Deleted most test, and in a few cases checked the notification's debt to confirm that the action in the test had been taken.
