### PR TITLE
refactor(run-protocol): simpler vault UI notifications

### DIFF
--- a/packages/run-protocol/src/vaultFactory/types.js
+++ b/packages/run-protocol/src/vaultFactory/types.js
@@ -58,7 +58,6 @@
  * @typedef {Object} BaseUIState
  * @property {Amount<NatValue>} locked Amount of Collateral locked
  * @property {Amount<NatValue>} debt Amount of Loan (including accrued interest)
- * @property {Ratio} collateralizationRatio
  */
 
 /**

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -14,7 +14,6 @@ import { makeNotifierKit, observeNotifier } from '@agoric/notifier';
 
 import {
   invertRatio,
-  makeRatio,
   multiplyRatios,
 } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { AmountMath } from '@agoric/ertp';
@@ -240,7 +239,7 @@ export const makeInnerVault = (
       : getCollateralAllocated(vaultSeat);
   };
 
-  const snapshotState = (vstate) => {
+  const snapshotState = vstate => {
     /** @type {VaultUIState} */
     return harden({
       // TODO move manager state to a separate notifer https://github.com/Agoric/agoric-sdk/issues/4540
@@ -256,7 +255,7 @@ export const makeInnerVault = (
   };
 
   // call this whenever anything changes!
-  const updateUiState = async () => {
+  const updateUiState = () => {
     if (!outerUpdater) {
       return;
     }

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -240,25 +240,7 @@ export const makeInnerVault = (
       : getCollateralAllocated(vaultSeat);
   };
 
-  /**
-   * @returns {Promise<Ratio>} Collateral over actual debt
-   */
-  const getCollateralizationRatio = async () => {
-    const collateralAmount = getCollateralAmount();
-    const quoteAmount = await E(priceAuthority).quoteGiven(
-      collateralAmount,
-      runBrand,
-    );
-
-    // TODO: allow Ratios to represent X/0.
-    if (AmountMath.isEmpty(debtSnapshot.run)) {
-      return makeRatio(collateralAmount.value, runBrand, 1n);
-    }
-    const collateralValueInRun = getAmountOut(quoteAmount);
-    return makeRatioFromAmounts(collateralValueInRun, getDebtAmount());
-  };
-
-  const snapshotState = (vstate, collateralizationRatio) => {
+  const snapshotState = (vstate) => {
     /** @type {VaultUIState} */
     return harden({
       // TODO move manager state to a separate notifer https://github.com/Agoric/agoric-sdk/issues/4540
@@ -267,7 +249,6 @@ export const makeInnerVault = (
       debtSnapshot,
       locked: getCollateralAmount(),
       debt: getDebtAmount(),
-      collateralizationRatio,
       // TODO state distinct from CLOSED https://github.com/Agoric/agoric-sdk/issues/4539
       liquidated: vaultState === VaultState.CLOSED,
       vaultState: vstate,
@@ -279,13 +260,8 @@ export const makeInnerVault = (
     if (!outerUpdater) {
       return;
     }
-    // TODO(123): track down all calls and ensure that they all update a
-    // lastKnownCollateralizationRatio (since they all know) so we don't have to
-    // await quoteGiven() here
-    // [https://github.com/Agoric/dapp-token-economy/issues/123]
-    const collateralizationRatio = await getCollateralizationRatio();
     /** @type {VaultUIState} */
-    const uiState = snapshotState(vaultState, collateralizationRatio);
+    const uiState = snapshotState(vaultState);
     trace('updateUiState', uiState);
 
     switch (vaultState) {

--- a/packages/run-protocol/test/vaultFactory/swingsetTests/governance/test-governance.js
+++ b/packages/run-protocol/test/vaultFactory/swingsetTests/governance/test-governance.js
@@ -86,8 +86,8 @@ const expectedVaultFactoryLog = [
   'after vote on (InterestRate), InterestRate numerator is 4321',
   'at 3 days: vote closed',
   'at 3 days: Alice owes {"brand":"[Alleged: RUN brand]","value":"[510105n]"}',
-  'at 3 days: 1 day after votes cast, uiNotifier update #4 has interestRate.numerator 250',
-  'at 4 days: 2 days after votes cast, uiNotifier update #5 has interestRate.numerator 4321',
+  'at 3 days: 1 day after votes cast, uiNotifier update #5 has interestRate.numerator 250',
+  'at 4 days: 2 days after votes cast, uiNotifier update #6 has interestRate.numerator 4321',
   'at 4 days: Alice owes {"brand":"[Alleged: RUN brand]","value":"[510608n]"}',
 ];
 

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -979,7 +979,6 @@ test('adjust balances', async t => {
   } = services;
   const { vaultFactory, lender } = services.vaultFactory;
 
-  const priceConversion = makeRatio(15n, runBrand, 1n, aethBrand);
   const rates = makeRates(runBrand);
   await E(vaultFactory).addVaultType(aethIssuer, 'AEth', rates);
 
@@ -1146,6 +1145,7 @@ test('adjust balances', async t => {
 
   debtAmount = await E(aliceVault).getDebtAmount();
   t.deepEqual(debtAmount, runDebtLevel);
+  t.deepEqual(collateralLevel, await E(aliceVault).getCollateralAmount());
 
   const { RUN: lentAmount4 } = await E(
     aliceReduceCollateralSeat,
@@ -1181,7 +1181,6 @@ test('adjust balances', async t => {
     runDebtLevel,
     AmountMath.add(withdrawRunAmount, withdrawRun3WithFees),
   );
-  collateralLevel = AmountMath.subtract(collateralLevel, collateralDecr2);
   const aliceReduceCollateralSeat2 = await E(zoe).offer(
     E(aliceVault).makeAdjustBalancesInvitation(),
     harden({
@@ -1555,7 +1554,6 @@ test('mutable liquidity triggers and interest', async t => {
   const aliceDebtAmount = await E(aliceVault).getDebtAmount();
   const fee = ceilMultiplyBy(aliceLoanAmount, rates.loanFee);
   const aliceRunDebtLevel = AmountMath.add(aliceLoanAmount, fee);
-  let aliceCollateralLevel = AmountMath.make(aethBrand, 1000n);
 
   t.deepEqual(aliceDebtAmount, aliceRunDebtLevel, 'vault lent 5000 RUN + fees');
   const { RUN: aliceLentAmount } = await E(
@@ -1617,10 +1615,6 @@ test('mutable liquidity triggers and interest', async t => {
   // Alice reduce collateral by 300. That leaves her at 700 * 10 > 1.05 * 5000.
   // Prices will drop from 10 to 7, she'll be liquidated: 700 * 7 < 1.05 * 5000.
   const collateralDecrement = AmountMath.make(aethBrand, 300n);
-  aliceCollateralLevel = AmountMath.subtract(
-    aliceCollateralLevel,
-    collateralDecrement,
-  );
   const aliceReduceCollateralSeat = await E(zoe).offer(
     E(aliceVault).makeAdjustBalancesInvitation(),
     harden({
@@ -2064,7 +2058,6 @@ test('mutable liquidity triggers and interest sensitivity', async t => {
   const aliceDebtAmount = await E(aliceVault).getDebtAmount();
   const fee = ceilMultiplyBy(aliceLoanAmount, rates.loanFee);
   const aliceRunDebtLevel = AmountMath.add(aliceLoanAmount, fee);
-  let aliceCollateralLevel = AmountMath.make(aethBrand, 1000n);
 
   t.deepEqual(aliceDebtAmount, aliceRunDebtLevel, 'vault lent 5000 RUN + fees');
   const { RUN: aliceLentAmount } = await E(
@@ -2126,10 +2119,6 @@ test('mutable liquidity triggers and interest sensitivity', async t => {
   // Alice reduce collateral by 300. That leaves her at 700 * 10 > 1.05 * 5000.
   // Prices will drop from 10 to 7, she'll be liquidated: 700 * 7 < 1.05 * 5000.
   const collateralDecrement = AmountMath.make(aethBrand, 211n);
-  aliceCollateralLevel = AmountMath.subtract(
-    aliceCollateralLevel,
-    collateralDecrement,
-  );
   const aliceReduceCollateralSeat = await E(zoe).offer(
     E(aliceVault).makeAdjustBalancesInvitation(),
     harden({
@@ -2152,7 +2141,7 @@ test('mutable liquidity triggers and interest sensitivity', async t => {
   );
 
   aliceUpdate = await E(aliceNotifier).getUpdateSince();
-  t.deepEqual(aliceUpdate.value.debt, aliceRunDebtLevel);;
+  t.deepEqual(aliceUpdate.value.debt, aliceRunDebtLevel);
 
   await manualTimer.tick();
   // price levels changed and interest was charged.


### PR DESCRIPTION
closes: #4602

## Description

Delete the function to compute `collateralizationRatio`, remove from the state that gets notified, and fix up tests.

### Security Considerations
None

### Documentation Considerations

Update the record definition if it's in the docs.

Vault UI may need to be updated to compute the property.

### Testing Considerations

Deleted most test, and in a few cases checked the notification's debt to confirm that the action in the test had been taken.
