### PR TITLE
feat(pegasus): implement correct result and denom trace handling

### DIFF
--- a/packages/pegasus/src/courier.js
+++ b/packages/pegasus/src/courier.js
@@ -33,7 +33,7 @@ export const getCourierPK = (key, keyToCourierPK) => {
  * @property {ContractFacet} zcf
  * @property {ERef<BoardDepositFacet>} board
  * @property {ERef<NameHub>} namesByAddress
- * @property {Denom} remoteDenom
+ * @property {Denom} sendDenom
  * @property {Brand} localBrand
  * @property {(zcfSeat: ZCFSeat, amounts: AmountKeywordRecord) => void} retain
  * @property {(zcfSeat: ZCFSeat, amounts: AmountKeywordRecord) => void} redeem
@@ -47,7 +47,7 @@ export const makeCourierMaker =
     zcf,
     board,
     namesByAddress,
-    remoteDenom,
+    sendDenom,
     localBrand,
     retain,
     redeem,
@@ -59,7 +59,7 @@ export const makeCourierMaker =
         const amount = zcfSeat.getAmountAllocated('Transfer', localBrand);
         const transferPacket = await E(transferProtocol).makeTransferPacket({
           value: amount.value,
-          remoteDenom,
+          remoteDenom: sendDenom,
           depositAddress,
         });
 

--- a/packages/pegasus/src/ibc-trace.js
+++ b/packages/pegasus/src/ibc-trace.js
@@ -1,0 +1,44 @@
+// @ts-check
+import { Far } from '@endo/marshal';
+import { assert, details as X } from '@agoric/assert';
+
+import { parse } from '@agoric/swingset-vat/src/vats/network/multiaddr.js';
+
+/**
+ * Return a source-prefixed version of the denomination, as specified in
+ * ICS20-1.
+ *
+ * @param {Address} addr
+ * @param {Denom} denom
+ */
+const sourcePrefixedDenom = (addr, denom) => {
+  const ma = parse(addr);
+
+  const ibcPort = ma.find(([protocol]) => protocol === 'ibc-port');
+  assert(ibcPort, X`${addr} does not contain an IBC port`);
+  const ibcChannel = ma.find(([protocol]) => protocol === 'ibc-channel');
+  assert(ibcChannel, X`${addr} does not contain an IBC channel`);
+
+  return `${ibcPort[1]}/${ibcChannel[1]}/${denom}`;
+};
+
+/** @type {DenomTransformer} */
+const transformer = {
+  getDenomsForLocalPeg: async (denom, _localAddress, remoteAddress) => {
+    return {
+      sendDenom: denom,
+      receiveDenom: sourcePrefixedDenom(remoteAddress, denom),
+    };
+  },
+  getDenomsForRemotePeg: async (denom, localAddress, _remoteAddress) => {
+    return {
+      sendDenom: sourcePrefixedDenom(localAddress, denom),
+      receiveDenom: denom,
+    };
+  },
+};
+
+export const IBCSourceTraceDenomTransformer = Far(
+  'IBC source trace denom transformer',
+  transformer,
+);

--- a/packages/pegasus/src/types.js
+++ b/packages/pegasus/src/types.js
@@ -55,7 +55,7 @@
  */
 
 /**
- * @callback RejectStuckTransfers
+ * @callback RejectTransfersWaitingForPegRemote
  * Abort any in-progress receiveDenom transfers if there has not yet been a
  * pegRemote or pegLocal corresponding to it.
  *
@@ -93,7 +93,7 @@
  * @typedef {Object} PegasusConnectionActions
  * @property {PegLocal} pegLocal
  * @property {PegRemote} pegRemote
- * @property {RejectStuckTransfers} rejectStuckTransfers
+ * @property {RejectTransfersWaitingForPegRemote} rejectTransfersWaitingForPegRemote
  * @property {(reason?: any) => void} abort
  */
 

--- a/packages/pegasus/src/types.js
+++ b/packages/pegasus/src/types.js
@@ -23,10 +23,21 @@
  */
 
 /**
+ * @typedef {Object} DenomTransformer
+ * @property {(remoteDenom: Denom, localAddr: Address, remoteAddr: Address)
+ *   => Promise<{ sendDenom: Denom, receiveDenom: Denom }>
+ * } getDenomsForLocalPeg
+ * @property {(remoteDenom: Denom, localAddr: Address, remoteAddr: Address)
+ *   => Promise<{ sendDenom: Denom, receiveDenom: Denom }>
+ * } getDenomsForRemotePeg
+ */
+
+/**
  * @typedef {Object} Peg
  * @property {() => string} getAllegedName get the debug name
  * @property {() => Brand} getLocalBrand get the brand associated with the peg
- * @property {() => Denom} getRemoteDenom get the denomination identifier
+ * @property {() => Denom} getReceiveDenom get the remote denomination identifier we receive
+ * @property {() => Denom} getSendDenom get the remote denomination identifier we send
  */
 
 /**
@@ -45,15 +56,15 @@
 
 /**
  * @callback RejectStuckTransfers
- * Abort any in-progress remoteDenom transfers if there has not yet been a
- * pegRemote or pegLocal for it.
+ * Abort any in-progress receiveDenom transfers if there has not yet been a
+ * pegRemote or pegLocal corresponding to it.
  *
  * This races against any attempts to obtain metadata and establish a given
  * peg.
  *
  * It's alright to expose to the holder of the connection.
  *
- * @param {Denom} remoteDenom
+ * @param {Denom} receiveDenom
  * @returns {Promise<void>}
  */
 

--- a/packages/pegasus/test/test-peg.js
+++ b/packages/pegasus/test/test-peg.js
@@ -92,7 +92,7 @@ async function testRemotePeg(t) {
   E(portP).addListener(
     Far('acceptor', {
       async onAccept(_p, _localAddr, _remoteAddr) {
-        return harden({
+        return Far('handler', {
           async onOpen(c) {
             gaiaConnection = c;
           },
@@ -102,13 +102,13 @@ async function testRemotePeg(t) {
               packet,
               {
                 amount: '100000000000000000001',
-                denom: 'uatom',
+                denom: 'portdef/chanabc/uatom',
                 receiver: 'markaccount',
                 sender: 'pegasus',
               },
               'expected transfer packet',
             );
-            return JSON.stringify({ success: true });
+            return JSON.stringify({ result: 'AQ==' });
           },
         });
       },
@@ -167,8 +167,8 @@ async function testRemotePeg(t) {
 
   const sendAckData = await sendAckDataP;
   const sendAck = JSON.parse(sendAckData);
-  t.deepEqual(sendAck, { success: true }, 'Gaia sent the atoms');
-  if (!sendAck.success) {
+  t.deepEqual(sendAck, { result: 'AQ==' }, 'Gaia sent the atoms');
+  if (!sendAck.result) {
     console.log(sendAckData, sendAck.error);
   }
 
@@ -190,8 +190,8 @@ async function testRemotePeg(t) {
     JSON.stringify(sendPacket2),
   );
   const sendAck2 = JSON.parse(sendAckData2);
-  t.deepEqual(sendAck2, { success: true }, 'Gaia sent more atoms');
-  if (!sendAck2.success) {
+  t.deepEqual(sendAck2, { result: 'AQ==' }, 'Gaia sent more atoms');
+  if (!sendAck2.result) {
     console.log(sendAckData2, sendAck2.error);
   }
 
@@ -218,7 +218,7 @@ async function testRemotePeg(t) {
   const sendAck3 = JSON.parse(sendAckData3);
   t.deepEqual(
     sendAck3,
-    { success: false, error: 'Error: "umuon" is temporarily unavailable' },
+    { error: 'Error: "umuon" is temporarily unavailable' },
     'rejecting transfers works',
   );
 
@@ -232,10 +232,10 @@ async function testRemotePeg(t) {
   );
   const seat = await E(zoe).offer(
     transferInvitation,
-    harden({
+    {
       give: { Transfer: localAtomsAmount },
-    }),
-    harden({ Transfer: localAtoms }),
+    },
+    { Transfer: localAtoms },
   );
   const outcome = await seat.getOfferResult();
   t.is(outcome, undefined, 'transfer is successful');

--- a/packages/pegasus/test/test-peg.js
+++ b/packages/pegasus/test/test-peg.js
@@ -212,7 +212,7 @@ async function testRemotePeg(t) {
 
   // Wait for the packet to go through.
   t.deepEqual(await remoteDenomAit.next(), { done: false, value: 'umuon' });
-  E(pegConnActions).rejectStuckTransfers('umuon');
+  E(pegConnActions).rejectTransfersWaitingForPegRemote('umuon');
 
   const sendAckData3 = await sendAckData3P;
   const sendAck3 = JSON.parse(sendAckData3);


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #4614
refs: cosmos/ibc#661

## Description

Implement IBC denom trace transforms for Pegasus, as well as use the acknowledgement packet's actual `result` and `error` properties instead of `success`.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

The incorrect parsing of acknowledgement packets caused refunds to be given even though the transfer went through.  This led to a practically infinite supply of tokens on Pegasus connections to other chains. 

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
