### PR TITLE
fix: virtualize payments, purses, ledger

### DIFF
--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -41,11 +41,11 @@
     "@agoric/nat": "^4.1.0",
     "@agoric/notifier": "^0.3.35",
     "@agoric/store": "^0.6.10",
+    "@agoric/swingset-vat": "^0.25.1",
     "@endo/marshal": "^0.6.3",
     "@endo/promise-kit": "^0.2.37"
   },
   "devDependencies": {
-    "@agoric/swingset-vat": "^0.25.1",
     "@endo/bundle-source": "^2.1.1",
     "ava": "^3.12.1",
     "fast-check": "^2.21.0"

--- a/packages/ERTP/src/payment.js
+++ b/packages/ERTP/src/payment.js
@@ -1,15 +1,21 @@
 // @ts-check
 
-import { Far } from '@endo/marshal';
+import { defineKind } from '@agoric/swingset-vat/src/storeModule.js';
 
 /**
  * @template {AssetKind} K
  * @param {string} allegedName
  * @param {Brand<K>} brand
- * @returns {Payment<K>}
+ * @returns {() => Payment<K>}
  */
-export const makePayment = (allegedName, brand) => {
-  return Far(`${allegedName} payment`, {
-    getAllegedBrand: () => brand,
-  });
+export const makePaymentMaker = (allegedName, brand) => {
+  const makePayment = defineKind(
+    `${allegedName} payment`,
+    () => ({}),
+    () => ({
+      getAllegedBrand: () => brand,
+    }),
+  );
+  return makePayment;
 };
+harden(makePaymentMaker);

--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -4,11 +4,11 @@ import { assert, details as X } from '@agoric/assert';
 import { E } from '@endo/eventual-send';
 import { isPromise } from '@endo/promise-kit';
 import { Far, assertCopyArray } from '@endo/marshal';
-import { makeWeakStore, fit } from '@agoric/store';
-
+import { fit } from '@agoric/store';
+import { makeScalarBigWeakMapStore } from '@agoric/swingset-vat/src/storeModule.js';
 import { AmountMath } from './amountMath.js';
-import { makePayment } from './payment.js';
-import { makePurse } from './purse.js';
+import { makePaymentMaker } from './payment.js';
+import { makePurseMaker } from './purse.js';
 
 import '@agoric/store/exported.js';
 
@@ -31,6 +31,8 @@ export const makePaymentLedger = (
   displayInfo,
   optShutdownWithFailure = undefined,
 ) => {
+  const makePayment = makePaymentMaker(allegedName, brand);
+
   /** @type {ShutdownWithFailure} */
   const shutdownLedgerWithFailure = reason => {
     // TODO This should also destroy ledger state.
@@ -47,7 +49,7 @@ export const makePaymentLedger = (
   };
 
   /** @type {WeakStore<Payment, Amount>} */
-  const paymentLedger = makeWeakStore('payment');
+  const paymentLedger = makeScalarBigWeakMapStore('payment');
 
   /** @type {(left: Amount, right: Amount) => Amount } */
   const add = (left, right) => AmountMath.add(left, right, brand);
@@ -142,7 +144,7 @@ export const makePaymentLedger = (
       payments.forEach(payment => paymentLedger.delete(payment));
 
       newPayments = newPaymentBalances.map(balance => {
-        const newPayment = makePayment(allegedName, brand);
+        const newPayment = makePayment();
         paymentLedger.init(newPayment, balance);
         return newPayment;
       });
@@ -257,7 +259,7 @@ export const makePaymentLedger = (
    */
   const mintPayment = newAmount => {
     newAmount = coerce(newAmount);
-    const payment = makePayment(allegedName, brand);
+    const payment = makePayment();
     paymentLedger.init(payment, newAmount);
     return payment;
   };
@@ -319,7 +321,7 @@ export const makePaymentLedger = (
     );
     const newPurseBalance = subtract(currentBalance, amount);
 
-    const payment = makePayment(allegedName, brand);
+    const payment = makePayment();
     try {
       // COMMIT POINT Move the withdrawn assets from this purse into
       // payment. Total assets must remain conserved.
@@ -337,6 +339,13 @@ export const makePaymentLedger = (
     withdraw,
   };
 
+  const makeEmptyPurse = makePurseMaker(
+    allegedName,
+    assetKind,
+    brand,
+    purseMethods,
+  );
+
   /** @type {Issuer<K>} */
   const issuer = Far(`${allegedName} issuer`, {
     isLive,
@@ -350,8 +359,7 @@ export const makePaymentLedger = (
     getAllegedName: () => allegedName,
     getAssetKind: () => assetKind,
     getDisplayInfo: () => displayInfo,
-    makeEmptyPurse: () =>
-      makePurse(allegedName, assetKind, brand, purseMethods),
+    makeEmptyPurse,
   });
 
   /** @type {Mint<K>} */

--- a/packages/ERTP/src/purse.js
+++ b/packages/ERTP/src/purse.js
@@ -3,6 +3,12 @@ import { defineKind } from '@agoric/swingset-vat/src/storeModule.js';
 import { AmountMath } from './amountMath.js';
 
 export const makePurseMaker = (allegedName, assetKind, brand, purseMethods) => {
+  // - This kind is a pair of purse and depositFacet that have a 1:1
+  //   correspondence.
+  // - They are virtualized together to share a single state record.
+  // - An alternative design considered was to have this return a Purse alone
+  //   that created depositFacet as needed. But this approach ensures a constant
+  //   identity for the facet and exercises the multi-faceted object style.
   const makePurseKit = defineKind(
     allegedName,
     () => {

--- a/packages/ERTP/src/purse.js
+++ b/packages/ERTP/src/purse.js
@@ -1,43 +1,60 @@
 import { makeNotifierKit } from '@agoric/notifier';
-import { Far } from '@endo/marshal';
+import { defineKind } from '@agoric/swingset-vat/src/storeModule.js';
 import { AmountMath } from './amountMath.js';
 
-export const makePurse = (allegedName, assetKind, brand, purseMethods) => {
-  let currentBalance = AmountMath.makeEmpty(brand, assetKind);
+export const makePurseMaker = (allegedName, assetKind, brand, purseMethods) => {
+  const makePurseKit = defineKind(
+    allegedName,
+    () => {
+      const currentBalance = AmountMath.makeEmpty(brand, assetKind);
 
-  /** @type {NotifierRecord<Amount>} */
-  const { notifier: balanceNotifier, updater: balanceUpdater } =
-    makeNotifierKit(currentBalance);
+      /** @type {NotifierRecord<Amount>} */
+      const { notifier: balanceNotifier, updater: balanceUpdater } =
+        makeNotifierKit(currentBalance);
 
-  const updatePurseBalance = newPurseBalance => {
-    currentBalance = newPurseBalance;
-    balanceUpdater.updateState(currentBalance);
-  };
-
-  /** @type {Purse} */
-  const purse = Far(`${allegedName} purse`, {
-    deposit: (srcPayment, optAmountShape = undefined) => {
-      // Note COMMIT POINT within deposit.
-      return purseMethods.deposit(
+      return {
         currentBalance,
-        updatePurseBalance,
-        srcPayment,
-        optAmountShape,
-      );
+        balanceNotifier,
+        balanceUpdater,
+      };
     },
-    withdraw: amount =>
-      // Note COMMIT POINT within withdraw.
-      purseMethods.withdraw(currentBalance, updatePurseBalance, amount),
-    getCurrentAmount: () => currentBalance,
-    getCurrentAmountNotifier: () => balanceNotifier,
-    getAllegedBrand: () => brand,
-    // eslint-disable-next-line no-use-before-define
-    getDepositFacet: () => depositFacet,
-  });
+    state => {
+      const { balanceNotifier, balanceUpdater } = state;
+      const updatePurseBalance = newPurseBalance => {
+        state.currentBalance = newPurseBalance;
+        balanceUpdater.updateState(state.currentBalance);
+      };
 
-  const depositFacet = Far(`${allegedName} depositFacet`, {
-    receive: purse.deposit,
-  });
-
-  return purse;
+      /** @type {Purse} */
+      const purse = {
+        deposit: (srcPayment, optAmountShape = undefined) => {
+          // Note COMMIT POINT within deposit.
+          return purseMethods.deposit(
+            state.currentBalance,
+            updatePurseBalance,
+            srcPayment,
+            optAmountShape,
+          );
+        },
+        withdraw: amount =>
+          // Note COMMIT POINT within withdraw.
+          purseMethods.withdraw(
+            state.currentBalance,
+            updatePurseBalance,
+            amount,
+          ),
+        getCurrentAmount: () => state.currentBalance,
+        getCurrentAmountNotifier: () => balanceNotifier,
+        getAllegedBrand: () => brand,
+        // eslint-disable-next-line no-use-before-define
+        getDepositFacet: () => depositFacet,
+      };
+      const depositFacet = {
+        receive: purse.deposit,
+      };
+      return { purse, depositFacet };
+    },
+  );
+  return () => makePurseKit().purse;
 };
+harden(makePurseMaker);

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -434,7 +434,7 @@ test('issuer.combine bad payments', async t => {
   await t.throwsAsync(
     () => E(issuer).combine(payments),
     {
-      message: /.* "\[Alleged: other fungible payment\]"/,
+      message: /"\[Alleged: other fungible payment\]"/,
     },
     'payment from other mint is not found',
   );

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -434,7 +434,7 @@ test('issuer.combine bad payments', async t => {
   await t.throwsAsync(
     () => E(issuer).combine(payments),
     {
-      message: '"payment" not found: "[Alleged: other fungible payment]"',
+      message: /.* "\[Alleged: other fungible payment\]"/,
     },
     'payment from other mint is not found',
   );

--- a/packages/SwingSet/src/storeModule.js
+++ b/packages/SwingSet/src/storeModule.js
@@ -1,4 +1,39 @@
-/* global VatData */
+/* global VatData globalThis */
+
+import { Far } from '@endo/marshal';
+
+import {
+  M,
+  makeScalarMapStore,
+  makeScalarWeakMapStore,
+  makeScalarSetStore,
+  makeScalarWeakSetStore,
+} from '@agoric/store';
+
+export {
+  M,
+  makeScalarMapStore,
+  makeScalarWeakMapStore,
+  makeScalarSetStore,
+  makeScalarWeakSetStore,
+};
+
+let MyVatData;
+if ('VatData' in globalThis) {
+  MyVatData = VatData;
+} else {
+  console.log('Emulating VatData');
+  MyVatData = {
+    defineKind: () => assert.fail('fake defineKind not yet implemented'),
+    defineDurableKind: () =>
+      assert.fail('fake defineDurableKind not yet implemented'),
+    makeKindHandle: tag => Far(`fake kind handle ${tag}`, {}),
+    makeScalarBigMapStore: makeScalarMapStore,
+    makeScalarBigWeakMapStore: makeScalarWeakMapStore,
+    makeScalarBigSetStore: makeScalarSetStore,
+    makeScalarBigWeakSetStore: makeScalarWeakSetStore,
+  };
+}
 
 export const {
   defineKind,
@@ -8,12 +43,4 @@ export const {
   makeScalarBigWeakMapStore,
   makeScalarBigSetStore,
   makeScalarBigWeakSetStore,
-} = VatData;
-
-export {
-  M,
-  makeScalarMapStore,
-  makeScalarWeakMapStore,
-  makeScalarSetStore,
-  makeScalarWeakSetStore,
-} from '@agoric/store';
+} = MyVatData;

--- a/packages/governance/test/unitTests/test-buildParamManager.js
+++ b/packages/governance/test/unitTests/test-buildParamManager.js
@@ -6,6 +6,7 @@ import { makeRatio } from '@agoric/zoe/src/contractSupport/index.js';
 import { setupZCFTest } from '@agoric/zoe/test/unitTests/zcf/setupZcfTest.js';
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
+import { keyEQ } from '@agoric/store';
 
 import { makeHandle } from '@agoric/zoe/src/makeHandle.js';
 import { ParamTypes, makeParamManagerBuilder } from '../../src/index.js';
@@ -214,6 +215,7 @@ test('Invitation', async t => {
   const invitationActualAmount =
     paramManager.getInvitationAmount('Invite').value;
   t.deepEqual(invitationActualAmount, invitationAmount.value);
+  t.assert(keyEQ(invitationActualAmount, invitationAmount.value));
   // @ts-ignore invitationActualAmount's type is unknown
   t.is(invitationActualAmount[0].description, 'simple');
 

--- a/packages/governance/test/unitTests/test-buildParamManager.js
+++ b/packages/governance/test/unitTests/test-buildParamManager.js
@@ -213,7 +213,7 @@ test('Invitation', async t => {
   t.is(paramManager.getAmount('Amt'), drachmaAmount);
   const invitationActualAmount =
     paramManager.getInvitationAmount('Invite').value;
-  t.is(invitationActualAmount, invitationAmount.value);
+  t.deepEqual(invitationActualAmount, invitationAmount.value);
   // @ts-ignore invitationActualAmount's type is unknown
   t.is(invitationActualAmount[0].description, 'simple');
 

--- a/packages/governance/test/unitTests/test-typedParamManager.js
+++ b/packages/governance/test/unitTests/test-typedParamManager.js
@@ -220,7 +220,7 @@ test('Invitation', async t => {
   t.is(paramManager.getCurrency(), drachmaBrand);
   t.is(paramManager.getAmt(), drachmaAmount);
   const invitationActualAmount = paramManager.getInvite().value;
-  t.is(invitationActualAmount, invitationAmount.value);
+  t.deepEqual(invitationActualAmount, invitationAmount.value);
   t.is(invitationActualAmount[0].description, 'simple');
 
   t.is(await paramManager.getInternalParamValue('Invite'), invitation);


### PR DESCRIPTION
Virtualize payment, paymentLedger, and purse,depositFacet together as a multi-faceted unit.

This does not virtualize everything that will need to be durable to support upgrade.

This does not even virtualize everything of high arity, needed for scaling, as it does not virtualize the per-purse notifier.