### PR TITLE
Implement the overhauled virtual object API

### DIFF
--- a/packages/ERTP/globals.d.ts
+++ b/packages/ERTP/globals.d.ts
@@ -1,6 +1,6 @@
 interface VatData {
-  makeKind: function;
-  makeDurableKind: function;
+  defineKind: function;
+  defineDurableKind: function;
   makeScalarBigMapStore: function;
   makeScalarBigWeakMapStore: function;
   makeScalarBigSetStore: function;

--- a/packages/SwingSet/docs/virtual-objects.md
+++ b/packages/SwingSet/docs/virtual-objects.md
@@ -15,62 +15,62 @@ A virtual object is an object with a durable identity whose state is automatical
 
 A virtual object has a "kind", which defines what sort of behavior and state it will possess.  A kind is not exactly a data type, since it comes with a concrete implementation, but it indicates a family of objects that share a set of common behaviors and a common state template.
 
-A vat can define new kinds of virtual object by calling the `makeKind` function provided as a vat global:
+A vat can define new kinds of virtual object by calling the `defineKind` function provided as a vat global:
 
-  `makeKind(instanceKitMaker)`
+  `defineKind(descriptionTag, init, actualize, finish)`
 
-The return value from `makeKind` is a maker function which the vat can use to create instances of the newly defined object kind.
+The return value from `defineKind` is a maker function which the vat can use to create instances of the newly defined object kind.
 
-The `instanceKitMaker` parameter is a user provided function that binds an in-memory instance of the virtual object with the virtual object's state, associating such instances with the virtual object's behavior.  It is called whenever a new virtual object instance is created, whenever such an instance is swapped in from secondary storage, and whenever a reference to a virtual object is received as a parameter of a message and deserialized.
+The `descriptionTag` parameter is a short description string for the kind.  This is the same kind of tag string you would use in a call to `Far`.  It will appear on `.toString()` representations of corresponding `Presence` objects that are exported to remote vats.
 
-The `instanceKitMaker` function is passed the virtual object's state as a parameter, and is expected to return a kit object with two properties: `init`, an initialization function; and `self`, a new Javascript object with methods that close over the given state, that will become the body of the new instance.
+The `init` parameter is a function that will be called when new instances are first created. It is expected to return a simple JavaScript object that represents the initialized state for the new virtual object instance.  Any parameters passed to the maker function returned by `defineKind` are passed directly to the `init` function.
 
-The `init` function is called when new instances are first created, and is expected to initialize the state object.  Any parameters passed to the maker function returned by `makeKind` are passed directly to the `init` function.
+The `actualize` parameter is a function that binds an in-memory instance (the "Representation) of the virtual object with the virtual object's state, associating such instances with the virtual object's behavior.  It is passed the virtual object's state as a parameter and is expected to return a new Javascript object with methods that close over the given state.  This returned object will become the body of the new instance.  It is called whenever a new virtual object instance is created, whenever such an instance is swapped in from secondary storage, and whenever a reference to a virtual object is received as a parameter of a message and deserialized.
+
+The `finish` parameter will, if present (it is optional), be called exactly once as part of instance initialization.  It will be invoked immediately after the `actualize` function is called for the first time.  In other words, it will be called after the instance per se exists but before that instance is returned from the maker function and thus becomes available to whoever requested its creation.  `finish` is passed two parameters: the virtual object's state (exactly as passed to the `actualize` function) and the virtual object itself. The `finish` function can modify the object's state in the context of knowing the object's identity, and thus can be used in cases where a validly initialized instance requires it to participate in some kind of cyclical object graph with other virtual objects.  It can also be used, for example, to register the object with outside tracking data structures, or do whatever other post-creation setup is needed for the object to do its job.  In particular, if one or more of the object's methods need to refer to the object itself (for example, so it can pass itself to other objects), the `finish` function provides a way to capture that identity as part of the object's state.
 
 For example:
 
 ```javascript
-  function counterKitMaker(state) {
+  function initCounter(name) {
     return {
-      init(name = 'thing') {
-        state.counter = 0;
-        state.name = name;
-      },
-      self: Far('counter', {
-        inc() {
-          state.counter += 1;
-        },
-        dec() {
-          state.counter -= 1;
-        },
-        reset() {
-          state.counter = 0;
-        },
-        rename(newName) {
-          state.name = newName;
-        },
-        getCount() {
-          return state.counter;
-        },
-        getName() {
-          return state.name;
-        },
-      }),
+      counter: 0,
+      name,
     };
   }
+  function actualizeCounter(state) {
+    return {
+      inc() {
+        state.counter += 1;
+      },
+      dec() {
+        state.counter -= 1;
+      },
+      reset() {
+        state.counter = 0;
+      },
+      rename(newName) {
+        state.name = newName;
+      },
+      getCount() {
+        return state.counter;
+      },
+      getName() {
+        return state.name;
+      },
+    };
+  }
+  function finishCounter(state, counter) {
+    addToCounterRegistry(counter, state.name);
+  }
+  const makeCounter = defineKind('counter', initCounter, actualizeCounter, finishCounter);
 ```
 
-This function defines a simple counter object with two properties in its state, a count and a name.
-
-You'd define the corresponding virtual object kind with:
-
-  `const counterMaker = makeKind(counterKitMaker);`
-
-and then use it like this:
+This defines a simple counter object with two properties in its state, a count and a name.  You'd use it like this:
 
 ```javascript
-  const fooCounter = counterMaker('foo');
-  const barCounter = counterMaker('bar');
+  const fooCounter = makeCounter('foo');
+  const barCounter = makeCounter('bar');
 
   fooCounter.inc();
   fooCounter.inc();
@@ -80,9 +80,11 @@ and then use it like this:
   console.log(`${barCounter.getName()} count is ${barCounter.getCount()`); // "new bar count is 1"
 ```
 
+Note that the `init`, `actualize`, and `finish` functions are defined explicitly here for clarity of exposition, but in practice you'd usually declare them inline as arrow functions in the parameters of the `defineKind` call.
+
 Additional important details:
 
-- The set of state properties is determined by the `init` function.  The properties that exist when `init` returns _are_ the properties of the object.  State properties cannot thereafter be added or removed.
+- The set of state properties is fully determined by the `init` function.  That is, the set of properties that exist on `state` is completely determined by the enumerable properties of the object that `init` returns.  State properties cannot thereafter be added or removed.
 
 - The values a state property may take are limited to things that are serializable and which may be hardened (and, in fact, _are_ hardened and serialized the moment they are assigned).  That is, you can replace what value a state property _has_, but you cannot modify a state property's value in situ.  In other words, you can do things like:
 
@@ -95,23 +97,3 @@ Additional important details:
 - A virtual object can be passed as a parameter in messages to other vats.  It will be passed by presence, just like any other non-data object you might send in a message parameter.
 
 - A virtual object's state may include references to other virtual objects. The latter objects will be persisted separately and only deserialized as needed, so "swapping in" a virtual object that references other virtual objects does not entail swapping in the entire associated object graph.
-
-- The `self` object returned by the `instanceKitMaker` function _is_ the in-memory representation of the virtual object, so you can capture it inside any of the body methods (as well as the `init` function) in order to pass the virtual object to somebody else.  So you can write things like the following:
-
-```javascript
-  function thingKitMaker(state) {
-    const self = Far('thing', {
-      sendMeTo(somebodyElse) {
-        somebodyElse.hereIAm(self);
-      },
-      ... // and so on
-    });
-    function init(someParam) {
-      otherObject.doSomethingWithMe(self, someParam);
-      state.foo = 47;
-    },
-    return { init, self };
-  }
-```
-
-- As illustrated above, the `self` object must be made `Far`, since it will be subject to serialization.

--- a/packages/SwingSet/src/kernel/liveSlots.js
+++ b/packages/SwingSet/src/kernel/liveSlots.js
@@ -1073,8 +1073,8 @@ function build(
 
   const vatGlobals = harden({
     VatData: {
-      makeKind: vom.makeKind,
-      makeDurableKind: vom.makeDurableKind,
+      defineKind: vom.defineKind,
+      defineDurableKind: vom.defineDurableKind,
       makeScalarBigMapStore: collectionManager.makeScalarBigMapStore,
       makeScalarBigWeakMapStore: collectionManager.makeScalarBigWeakMapStore,
       makeScalarBigSetStore: collectionManager.makeScalarBigSetStore,

--- a/packages/SwingSet/src/storeModule.js
+++ b/packages/SwingSet/src/storeModule.js
@@ -1,8 +1,8 @@
 /* global VatData */
 
 export const {
-  makeKind,
-  makeDurableKind,
+  defineKind,
+  defineDurableKind,
   makeScalarBigMapStore,
   makeScalarBigWeakMapStore,
   makeScalarBigSetStore,

--- a/packages/SwingSet/test/stores/test-durabilityChecks.js
+++ b/packages/SwingSet/test/stores/test-durabilityChecks.js
@@ -8,23 +8,21 @@ const { vom, cm } = makeFakeVirtualStuff({ cacheSize: 3 });
 
 const { makeScalarBigMapStore, makeScalarBigSetStore } = cm;
 
-const { makeKind, makeDurableKind } = vom;
+const { defineKind, defineDurableKind } = vom;
 
-function makeHolderInnards(state) {
-  return {
-    init(value = null) {
-      state.held = value;
-    },
-    self: Far('holder', {
-      hold(value) {
-        state.held = value;
-      },
-    }),
-  };
-}
+const initHolder = (held = null) => ({ held });
+const actualizeHolder = state => ({
+  hold: value => {
+    state.held = value;
+  },
+});
 
-const makeVirtualHolder = makeKind(makeHolderInnards);
-const makeDurableHolder = makeDurableKind(makeHolderInnards);
+const makeVirtualHolder = defineKind('holder', initHolder, actualizeHolder);
+const makeDurableHolder = defineDurableKind(
+  'holder',
+  initHolder,
+  actualizeHolder,
+);
 
 const aString = 'zorch!';
 const aVirtualObject = makeVirtualHolder();

--- a/packages/SwingSet/test/test-vat-env.js
+++ b/packages/SwingSet/test/test-vat-env.js
@@ -1,9 +1,6 @@
 /* global VatData */
 import { test } from '../tools/prepare-test-env-ava.js';
 
-// eslint-disable-next-line import/order
-import { Far } from '@endo/marshal';
-
 import { provideHostStorage } from '../src/hostStorage.js';
 import { buildVatController } from '../src/index.js';
 
@@ -12,23 +9,17 @@ test('harden from SES is in the test environment', t => {
   t.pass();
 });
 
-function makeThingInnards(_state) {
-  return {
-    self: Far('thing', {
-      ping() {
-        return 4;
-      },
-    }),
-  };
-}
+const actualizeThing = _state => ({
+  ping: () => 4,
+});
 
 test('kind makers are in the test environment', t => {
   // eslint-disable-next-line no-undef
-  const makeVThing = VatData.makeKind(makeThingInnards);
+  const makeVThing = VatData.defineKind('thing', null, actualizeThing);
   const vthing = makeVThing('vthing');
   t.is(vthing.ping(), 4);
 
-  const makeDThing = VatData.makeDurableKind(makeThingInnards);
+  const makeDThing = VatData.defineDurableKind('thing', null, actualizeThing);
   const dthing = makeDThing('dthing');
   t.is(dthing.ping(), 4);
 });
@@ -74,8 +65,8 @@ async function testForExpectedGlobals(t, workerType) {
     'control sample: undefined',
     'harden: function',
     'VatData: object',
-    'VatData.makeKind: function',
-    'VatData.makeDurableKind: function',
+    'VatData.defineKind: function',
+    'VatData.defineDurableKind: function',
     'VatData.makeScalarBigMapStore: function',
     'VatData.makeScalarBigWeakMapStore: function',
     'VatData.makeScalarBigSetStore: function',

--- a/packages/SwingSet/test/virtualObjects/test-reachable-vrefs.js
+++ b/packages/SwingSet/test/virtualObjects/test-reachable-vrefs.js
@@ -1,43 +1,34 @@
 import { test } from '../../tools/prepare-test-env-ava.js';
 
 // eslint-disable-next-line import/order
-import { Far, Remotable } from '@endo/marshal';
+import { Remotable } from '@endo/marshal';
 
 import { makeVatSlot } from '../../src/parseVatSlots.js';
 import { makeFakeVirtualStuff } from '../../tools/fakeVirtualSupport.js';
 
-// empty object, used as weap map store key
-function makeKeyInnards(_state) {
-  return {
-    init() {},
-    self: Far('key'),
-  };
-}
-
-function makeHolderInnards(state) {
-  return {
-    init(held) {
-      state.held = held;
-    },
-    self: Far('holder', {
-      setHeld(held) {
-        state.held = held;
-      },
-      getHeld() {
-        return state.held;
-      },
-    }),
-  };
-}
-
 test('VOM tracks reachable vrefs', async t => {
   const vomOptions = { cacheSize: 3 };
   const { vom, vrm, cm } = makeFakeVirtualStuff(vomOptions);
-  const { makeKind } = vom;
+  const { defineKind } = vom;
   const { makeScalarBigWeakMapStore } = cm;
   const weakStore = makeScalarBigWeakMapStore('test');
-  const makeKey = makeKind(makeKeyInnards);
-  const makeHolder = makeKind(makeHolderInnards);
+
+  // empty object, used as weap map store key
+  const makeKey = defineKind(
+    'key',
+    () => ({}),
+    _state => ({}),
+  );
+  const makeHolder = defineKind(
+    'holder',
+    held => ({ held }),
+    state => ({
+      setHeld: held => {
+        state.held = held;
+      },
+      getHeld: () => state.held,
+    }),
+  );
 
   let count = 1001;
   function makePresence() {

--- a/packages/SwingSet/test/virtualObjects/test-representatives.js
+++ b/packages/SwingSet/test/virtualObjects/test-representatives.js
@@ -24,132 +24,6 @@ function slot0(iface, kid) {
   };
 }
 
-test('virtual object representatives', async t => {
-  const config = {
-    bootstrap: 'bootstrap',
-    vats: {
-      bootstrap: {
-        sourceSpec: new URL('vat-representative-bootstrap.js', import.meta.url)
-          .pathname,
-        creationOptions: {
-          virtualObjectCacheSize: 3,
-        },
-      },
-    },
-  };
-
-  const c = await buildVatController(config, []);
-  c.pinVatRoot('bootstrap');
-  const nextLog = makeNextLog(c);
-
-  await c.run();
-  t.deepEqual(c.kpResolution(c.bootstrapResult), capargs('bootstrap done'));
-
-  async function doTestA(mode, result) {
-    const r = c.queueToVatRoot(
-      'bootstrap',
-      'testA',
-      capargs([`thing${mode}`, mode]),
-    );
-    await c.run();
-    t.is(c.kpStatus(r), 'fulfilled');
-    t.deepEqual(nextLog(), []);
-    t.deepEqual(c.kpResolution(r), slot0('thing', result));
-  }
-  await doTestA(1, 'ko25');
-  await doTestA(2, 'ko26');
-
-  async function doTestB(mode, result) {
-    const r = c.queueToVatRoot(
-      'bootstrap',
-      'testB',
-      capargs([`thing${mode}`, mode]),
-    );
-    await c.run();
-    t.is(c.kpStatus(r), 'fulfilled');
-    t.deepEqual(nextLog(), [
-      `test${mode} thing.name before rename "thing${mode}"`,
-      `test${mode} initialSelf.name before rename "thing${mode}"`,
-      `test${mode} thing.name after rename "thing${mode} modified"`,
-      `test${mode} initialSelf.name after rename "thing${mode} modified"`,
-    ]);
-    t.deepEqual(c.kpResolution(r), slot0('thing', result));
-  }
-  await doTestB(3, 'ko27');
-  await doTestB(4, 'ko28');
-  await doTestB(5, 'ko29');
-  await doTestB(6, 'ko30');
-
-  async function doTestC(mode) {
-    const r = c.queueToVatRoot(
-      'bootstrap',
-      'testC',
-      capargs([`thing${mode}`, mode]),
-    );
-    await c.run();
-    t.is(c.kpStatus(r), 'fulfilled');
-    t.deepEqual(nextLog(), [`test${mode} result is "47"`]);
-  }
-  await doTestC(7);
-  await doTestC(8);
-  await doTestC(9);
-  await doTestC(10);
-
-  async function doTestD(mode) {
-    const r = c.queueToVatRoot(
-      'bootstrap',
-      'testD',
-      capargs([`thing${mode}`, mode]),
-    );
-    await c.run();
-    t.is(c.kpStatus(r), 'fulfilled');
-    t.deepEqual(nextLog(), [`test${mode} result is "thing${mode}"`]);
-  }
-  await doTestD(11);
-  await doTestD(12);
-
-  async function doTestE(mode) {
-    const r = c.queueToVatRoot(
-      'bootstrap',
-      'testE',
-      capargs([`thing${mode}`, mode]),
-    );
-    await c.run();
-    t.is(c.kpStatus(r), 'fulfilled');
-    t.deepEqual(nextLog(), [`test${mode} result is "thing${mode} modified"`]);
-  }
-  await doTestE(13);
-  await doTestE(14);
-  await doTestE(15);
-  await doTestE(16);
-  await doTestE(17);
-  await doTestE(18);
-  await doTestE(19);
-  await doTestE(20);
-
-  const rz1 = c.queueToVatRoot(
-    'bootstrap',
-    'testCacheOverflow',
-    capargs([`zot1`, false]),
-  );
-  await c.run();
-  t.is(c.kpStatus(rz1), 'fulfilled');
-  t.deepEqual(nextLog(), []);
-  t.deepEqual(c.kpResolution(rz1), slot0('zot', 'ko31'));
-
-  const rz2 = c.queueToVatRoot(
-    'bootstrap',
-    'testCacheOverflow',
-    capargs([`zot2`, true]),
-  );
-  await c.run();
-  t.is(c.kpStatus(rz2), 'fulfilled');
-  t.deepEqual(nextLog(), [
-    'testCacheOverflow catches Error: cache overflowed with objects being initialized',
-  ]);
-  t.deepEqual(c.kpResolution(rz2), capdata('"overflow"'));
-});
-
 test.serial('exercise cache', async t => {
   const config = {
     bootstrap: 'bootstrap',
@@ -208,9 +82,6 @@ test.serial('exercise cache', async t => {
   c.pinVatRoot('bootstrap');
 
   const nextLog = makeNextLog(c);
-
-  await c.run();
-  t.deepEqual(c.kpResolution(bootstrapResult), capargs('bootstrap done'));
 
   async function doSimple(method, what, ...args) {
     let sendArgs;
@@ -290,25 +161,16 @@ test.serial('exercise cache', async t => {
   const T7 = 'ko31';
   const T8 = 'ko32';
 
-  // init cache - []
-  await make('thing1', true, T1); // make t1 - [t1]
-  ck('get', 'v1.vs.storeKindIDTable', undefined);
-  ck(
-    'set',
-    'v1.vs.storeKindIDTable',
-    '{"scalarMapStore":3,"scalarWeakMapStore":4,"scalarSetStore":5,"scalarWeakSetStore":6,"scalarDurableMapStore":7,"scalarDurableWeakMapStore":8,"scalarDurableSetStore":9,"scalarDurableWeakSetStore":10}',
-  );
-  ck('set', 'v1.vs.vc.1.|nextOrdinal', '1');
-  ck(
-    'set',
-    'v1.vs.vc.1.|schemata',
-    '{"body":"[{\\"@qclass\\":\\"tagged\\",\\"tag\\":\\"match:scalar\\",\\"payload\\":{\\"@qclass\\":\\"undefined\\"}}]","slots":[]}',
-  );
-  ck('set', 'v1.vs.vc.1.|label', 'weakMap');
+  await c.run();
+  t.deepEqual(c.kpResolution(bootstrapResult), capargs('bootstrap done'));
   ck('get', 'v1.vs.vom.rc.o-50', undefined);
   ck('get', 'v1.vs.vom.rc.o-51', undefined);
   ck('get', 'v1.vs.vom.rc.o-52', undefined);
   ck('get', 'v1.vs.vom.rc.o-53', undefined);
+
+  // init cache - []
+
+  await make('thing1', true, T1); // make t1 - [t1]
   ck('set', esKey(1), '1');
   ck('set', dataKey(1), thingVal('thing1'));
   done();
@@ -371,12 +233,13 @@ test.serial('exercise cache', async t => {
   done();
 
   await write(T2, 'thing2 updated'); // refresh t2 - [t2 t1 t8 t7]
+  ck('set', dataKey(2), thingVal('thing2 updated'));
+
   await writeHeld('thing1 updated'); // refresh t1 - [t1 t2 t8 t7]
+  ck('set', dataKey(1), thingVal('thing1 updated'));
 
   await read(T8, 'thing8'); // refresh t8 - [t8 t1 t2 t7]
   await read(T7, 'thing7'); // refresh t7 - [t7 t8 t1 t2]
-  ck('set', dataKey(2), thingVal('thing2 updated'));
-  ck('set', dataKey(1), thingVal('thing1 updated'));
   done();
 
   await read(T6, 'thing6'); // reanimate t6, evict t2 - [t6 t7 t8 t1]
@@ -391,6 +254,8 @@ test.serial('exercise cache', async t => {
 
   await read(T4, 'thing4'); // reanimate t4, evict t8 - [t4 t5 t6 t7]
   ck('get', dataKey(4), thingVal('thing4'));
+  ck('get', rcKey(8), undefined);
+  ck('get', esKey(8), '1');
   done();
 
   await read(T3, 'thing3'); // reanimate t3, evict t7 - [t3 t4 t5 t6]

--- a/packages/SwingSet/test/virtualObjects/test-virtualObjectGC.js
+++ b/packages/SwingSet/test/virtualObjects/test-virtualObjectGC.js
@@ -138,40 +138,26 @@ let aWeakSet;
 function buildRootObject(vatPowers) {
   const { VatData, WeakMap, WeakSet } = vatPowers;
 
-  const { makeKind } = VatData;
+  const { defineKind } = VatData;
 
-  function makeThingInnards(state) {
-    return {
-      init(label) {
-        state.label = label;
-      },
-      self: Far('thing', {
-        getLabel() {
-          return state.label;
-        },
-      }),
-    };
-  }
-
-  function makeVirtualHolderInnards(state) {
-    return {
-      init(value = null) {
+  const makeThing = defineKind(
+    'thing',
+    label => ({ label }),
+    state => ({
+      getLabel: () => state.label,
+    }),
+  );
+  const cacheDisplacer = makeThing('cacheDisplacer');
+  const makeVirtualHolder = defineKind(
+    'holder',
+    (held = null) => ({ held }),
+    state => ({
+      setValue: value => {
         state.held = value;
       },
-      self: Far('holder', {
-        setValue(value) {
-          state.held = value;
-        },
-        getValue() {
-          return state.held;
-        },
-      }),
-    };
-  }
-
-  const makeThing = makeKind(makeThingInnards);
-  const cacheDisplacer = makeThing('cacheDisplacer');
-  const makeVirtualHolder = makeKind(makeVirtualHolderInnards);
+      getValue: () => state.held,
+    }),
+  );
   const virtualHolder = makeVirtualHolder();
   let nextThingNumber = 0;
   let heldThing = null;
@@ -831,12 +817,12 @@ test.serial('VO lifecycle 8', async t => {
 function validatePrepareStore3(v, rp) {
   validate(v, matchVatstoreGet('vom.rc.o+1/2'));
   validate(v, matchVatstoreSet('vom.rc.o+1/2', '1'));
-  validate(v, matchVatstoreSet('vom.o+2/2', heldThingValue('o+1/2')));
   validate(v, matchVatstoreGet('vom.rc.o+1/2', '1'));
   validate(v, matchVatstoreSet('vom.rc.o+1/2', '2'));
-  validate(v, matchVatstoreSet('vom.o+2/3', heldThingValue('o+1/2')));
+  validate(v, matchVatstoreSet('vom.o+2/2', heldThingValue('o+1/2')));
   validate(v, matchVatstoreGet('vom.rc.o+1/2', '2'));
   validate(v, matchVatstoreSet('vom.rc.o+1/2', '3'));
+  validate(v, matchVatstoreSet('vom.o+2/3', heldThingValue('o+1/2')));
   validate(v, matchVatstoreSet('vom.o+2/4', heldThingValue('o+1/2')));
   validate(v, matchVatstoreGet('vom.o+1/1', cacheObjValue));
   validateReturned(v, rp);
@@ -917,12 +903,12 @@ test.serial('VO refcount management 3', async t => {
   rp = await dispatchMessage('prepareStoreLinked');
   validate(v, matchVatstoreGet('vom.rc.o+1/2'));
   validate(v, matchVatstoreSet('vom.rc.o+1/2', '1'));
-  validate(v, matchVatstoreSet('vom.o+2/2', heldThingValue('o+1/2')));
   validate(v, matchVatstoreGet('vom.rc.o+2/2'));
   validate(v, matchVatstoreSet('vom.rc.o+2/2', '1'));
-  validate(v, matchVatstoreSet('vom.o+2/3', heldHolderValue('o+2/2')));
+  validate(v, matchVatstoreSet('vom.o+2/2', heldThingValue('o+1/2')));
   validate(v, matchVatstoreGet('vom.rc.o+2/3'));
   validate(v, matchVatstoreSet('vom.rc.o+2/3', '1'));
+  validate(v, matchVatstoreSet('vom.o+2/3', heldHolderValue('o+2/2')));
   validate(v, matchVatstoreSet('vom.o+2/4', heldHolderValue('o+2/3')));
   validate(v, matchVatstoreGet('vom.o+1/1', cacheObjValue));
   validateReturned(v, rp);
@@ -971,12 +957,12 @@ test.serial('presence refcount management 1', async t => {
   rp = await dispatchMessage('prepareStore3');
   validate(v, matchVatstoreGet('vom.rc.o-5'));
   validate(v, matchVatstoreSet('vom.rc.o-5', '1'));
-  validate(v, matchVatstoreSet('vom.o+2/2', heldThingValue('o-5')));
   validate(v, matchVatstoreGet('vom.rc.o-5', '1'));
   validate(v, matchVatstoreSet('vom.rc.o-5', '2'));
-  validate(v, matchVatstoreSet('vom.o+2/3', heldThingValue('o-5')));
+  validate(v, matchVatstoreSet('vom.o+2/2', heldThingValue('o-5')));
   validate(v, matchVatstoreGet('vom.rc.o-5', '2'));
   validate(v, matchVatstoreSet('vom.rc.o-5', '3'));
+  validate(v, matchVatstoreSet('vom.o+2/3', heldThingValue('o-5')));
   validate(v, matchVatstoreSet('vom.o+2/4', heldThingValue('o-5')));
   validate(v, matchVatstoreGet('vom.o+1/1', cacheObjValue));
   validateReturned(v, rp);
@@ -1018,12 +1004,12 @@ test.serial('presence refcount management 2', async t => {
   rp = await dispatchMessage('prepareStore3');
   validate(v, matchVatstoreGet('vom.rc.o-5'));
   validate(v, matchVatstoreSet('vom.rc.o-5', '1'));
-  validate(v, matchVatstoreSet('vom.o+2/2', heldThingValue('o-5')));
   validate(v, matchVatstoreGet('vom.rc.o-5', '1'));
   validate(v, matchVatstoreSet('vom.rc.o-5', '2'));
-  validate(v, matchVatstoreSet('vom.o+2/3', heldThingValue('o-5')));
+  validate(v, matchVatstoreSet('vom.o+2/2', heldThingValue('o-5')));
   validate(v, matchVatstoreGet('vom.rc.o-5', '2'));
   validate(v, matchVatstoreSet('vom.rc.o-5', '3'));
+  validate(v, matchVatstoreSet('vom.o+2/3', heldThingValue('o-5')));
   validate(v, matchVatstoreSet('vom.o+2/4', heldThingValue('o-5')));
   validate(v, matchVatstoreGet('vom.o+1/1', cacheObjValue));
   validateReturned(v, rp);

--- a/packages/SwingSet/test/virtualObjects/test-virtualObjectManager.js
+++ b/packages/SwingSet/test/virtualObjects/test-virtualObjectManager.js
@@ -1,7 +1,5 @@
 import { test } from '../../tools/prepare-test-env-ava.js';
 
-// eslint-disable-next-line import/order
-import { Far } from '@endo/marshal';
 import {
   makeFakeVirtualObjectManager,
   makeFakeVirtualStuff,
@@ -11,33 +9,29 @@ function capdata(body, slots = []) {
   return harden({ body, slots });
 }
 
-function makeThingInnards(state) {
+function initThing(label = 'thing', counter = 0) {
+  return { counter, label, resetCounter: 0 };
+}
+function actualizeThing(state) {
   return {
-    init(label = 'thing', counter = 0) {
-      state.counter = counter;
-      state.label = label;
-      state.resetCounter = 0;
+    inc() {
+      state.counter += 1;
+      return state.counter;
     },
-    self: Far('thing', {
-      inc() {
-        state.counter += 1;
-        return state.counter;
-      },
-      reset(newStart) {
-        state.counter = newStart;
-        state.resetCounter += 1;
-        return state.resetCounter;
-      },
-      relabel(newLabel) {
-        state.label = newLabel;
-      },
-      get() {
-        return state.counter;
-      },
-      describe() {
-        return `${state.label} counter has been reset ${state.resetCounter} times and is now ${state.counter}`;
-      },
-    }),
+    reset(newStart) {
+      state.counter = newStart;
+      state.resetCounter += 1;
+      return state.resetCounter;
+    },
+    relabel(newLabel) {
+      state.label = newLabel;
+    },
+    get() {
+      return state.counter;
+    },
+    describe() {
+      return `${state.label} counter has been reset ${state.resetCounter} times and is now ${state.counter}`;
+    },
   };
 }
 
@@ -53,42 +47,24 @@ function minThing(label) {
   return thingVal(0, label, 0);
 }
 
-function makeRefInnards(state) {
-  return {
-    init(value) {
-      state.value = value;
-    },
-    self: Far('ref', {
-      setVal(value) {
-        state.value = value;
-      },
-    }),
-  };
+function initZot(arbitrary = 47, name = 'Bob', tag = 'say what?') {
+  return { arbitrary, name, tag, count: 0 };
 }
-
-function makeZotInnards(state) {
+function actualizeZot(state) {
   return {
-    init(arbitrary = 47, name = 'Bob', tag = 'say what?') {
-      state.arbitrary = arbitrary;
-      state.name = name;
-      state.tag = tag;
-      state.count = 0;
+    sayHello(msg) {
+      state.count += 1;
+      return `${msg} ${state.name}`;
     },
-    self: Far('zot', {
-      sayHello(msg) {
-        state.count += 1;
-        return `${msg} ${state.name}`;
-      },
-      rename(newName) {
-        state.name = newName;
-        state.count += 1;
-        return state.name;
-      },
-      getInfo() {
-        state.count += 1;
-        return `zot ${state.name} tag=${state.tag} count=${state.count} arbitrary=${state.arbitrary}`;
-      },
-    }),
+    rename(newName) {
+      state.name = newName;
+      state.count += 1;
+      return state.name;
+    },
+    getInfo() {
+      state.count += 1;
+      return `zot ${state.name} tag=${state.tag} count=${state.count} arbitrary=${state.arbitrary}`;
+    },
   };
 }
 
@@ -104,10 +80,10 @@ function zotVal(arbitrary, name, tag, count) {
 // prettier-ignore
 test('virtual object operations', t => {
   const log = [];
-  const { makeKind, flushCache, dumpStore } = makeFakeVirtualObjectManager({ cacheSize: 3, log });
+  const { defineKind, flushCache, dumpStore } = makeFakeVirtualObjectManager({ cacheSize: 3, log });
 
-  const makeThing = makeKind(makeThingInnards);
-  const makeZot = makeKind(makeZotInnards);
+  const makeThing = defineKind('thing', initThing, actualizeThing);
+  const makeZot = defineKind('zot', initZot, actualizeZot);
 
   // phase 0: start
   t.deepEqual(dumpStore(), []);
@@ -317,15 +293,56 @@ test('virtual object operations', t => {
   ]);
 });
 
+test('virtual object cycles using the finish function', t => {
+  const { vom } = makeFakeVirtualStuff();
+  const { defineKind } = vom;
+
+  const makeOtherThing = defineKind(
+    'otherThing',
+    (name, firstThing) => ({ name, firstThing }),
+    state => ({
+      getName: () => state.name,
+      getFirstThing: () => state.firstThing,
+    }),
+  );
+  const makeFirstThing = defineKind(
+    'firstThing',
+    name => ({
+      name,
+      otherThing: undefined,
+    }),
+    state => ({
+      getName: () => state.name,
+      getOtherThing: () => state.otherThing,
+    }),
+    (state, self) => {
+      state.otherThing = makeOtherThing(`${state.name}'s other thing`, self);
+    },
+  );
+
+  const thing = makeFirstThing('foo');
+  t.is(thing.getName(), 'foo');
+  t.is(thing.getOtherThing().getName(), `foo's other thing`);
+  t.is(thing.getOtherThing().getFirstThing(), thing);
+});
+
 test('virtual object gc', t => {
   const log = [];
   const { vom, vrm, fakeStuff } = makeFakeVirtualStuff({ cacheSize: 3, log });
-  const { makeKind } = vom;
+  const { defineKind } = vom;
   const { setExportStatus, possibleVirtualObjectDeath } = vrm;
   const { deleteEntry, dumpStore } = fakeStuff;
 
-  const makeThing = makeKind(makeThingInnards);
-  const makeRef = makeKind(makeRefInnards);
+  const makeThing = defineKind('thing', initThing, actualizeThing);
+  const makeRef = defineKind(
+    'ref',
+    value => ({ value }),
+    state => ({
+      setVal: value => {
+        state.value = value;
+      },
+    }),
+  );
 
   // make a bunch of things which we'll use
   // all virtual objects are born locally ref'd
@@ -442,9 +459,9 @@ test('virtual object gc', t => {
   // ref virtually
   // eslint-disable-next-line no-unused-vars
   const ref1 = makeRef(things[3]);
-  t.is(log.shift(), `set vom.o+1/6 ${minThing('thing #6')}`);
   t.is(log.shift(), `get vom.rc.o+1/4 => undefined`);
   t.is(log.shift(), `set vom.rc.o+1/4 1`);
+  t.is(log.shift(), `set vom.o+1/6 ${minThing('thing #6')}`);
   t.deepEqual(log, []);
   t.deepEqual(dumpStore(), [
     ['vom.o+1/4', minThing('thing #4')],
@@ -475,9 +492,9 @@ test('virtual object gc', t => {
   // ref virtually
   // eslint-disable-next-line no-unused-vars
   const ref2 = makeRef(things[4]);
-  t.is(log.shift(), `set vom.o+1/7 ${minThing('thing #7')}`);
   t.is(log.shift(), `get vom.rc.o+1/5 => undefined`);
   t.is(log.shift(), `set vom.rc.o+1/5 1`);
+  t.is(log.shift(), `set vom.o+1/7 ${minThing('thing #7')}`);
   t.deepEqual(log, []);
   t.deepEqual(dumpStore(), [
     ['vom.es.o+1/4', '0'],
@@ -504,9 +521,9 @@ test('virtual object gc', t => {
   // ref virtually
   // eslint-disable-next-line no-unused-vars
   const ref3 = makeRef(things[5]);
-  t.is(log.shift(), `set vom.o+1/8 ${minThing('thing #8')}`);
   t.is(log.shift(), `get vom.rc.o+1/6 => undefined`);
   t.is(log.shift(), `set vom.rc.o+1/6 1`);
+  t.is(log.shift(), `set vom.o+1/8 ${minThing('thing #8')}`);
   t.deepEqual(log, []);
   t.deepEqual(dumpStore(), [
     ['vom.es.o+1/4', '0'],
@@ -539,31 +556,13 @@ test('virtual object gc', t => {
   ]);
 });
 
-function makeDefectivelyNonFarThingInnards(state) {
-  return {
-    init(label = 'thing') {
-      state.label = label;
-    },
-    self: {
-      noop() {},
-    },
-  };
-}
-
-test('demand farhood', t => {
-  const { makeKind } = makeFakeVirtualObjectManager({ cacheSize: 3 });
-
-  const makeThing = makeKind(makeDefectivelyNonFarThingInnards);
-  t.throws(() => makeThing('thing'), { message: 'self must be declared Far' });
-});
-
 test('weak store operations', t => {
   const { vom, cm } = makeFakeVirtualStuff({ cacheSize: 3 });
-  const { makeKind } = vom;
+  const { defineKind } = vom;
   const { makeScalarBigWeakMapStore } = cm;
 
-  const makeThing = makeKind(makeThingInnards);
-  const makeZot = makeKind(makeZotInnards);
+  const makeThing = defineKind('thing', initThing, actualizeThing);
+  const makeZot = defineKind('zot', initZot, actualizeZot);
 
   const thing1 = makeThing('t1');
   const thing2 = makeThing('t2');
@@ -604,11 +603,11 @@ test('virtualized weak collection operations', t => {
   // TODO: don't yet have a way to test the weakness of the virtualized weak
   // collections
 
-  const { VirtualObjectAwareWeakMap, VirtualObjectAwareWeakSet, makeKind } =
+  const { VirtualObjectAwareWeakMap, VirtualObjectAwareWeakSet, defineKind } =
     makeFakeVirtualObjectManager({ cacheSize: 3 });
 
-  const makeThing = makeKind(makeThingInnards);
-  const makeZot = makeKind(makeZotInnards);
+  const makeThing = defineKind('thing', initThing, actualizeThing);
+  const makeZot = defineKind('zot', initZot, actualizeZot);
 
   const thing1 = makeThing('t1');
   const thing2 = makeThing('t2');

--- a/packages/SwingSet/test/virtualObjects/vat-representative-bootstrap.js
+++ b/packages/SwingSet/test/virtualObjects/vat-representative-bootstrap.js
@@ -1,64 +1,24 @@
 import { Far } from '@endo/marshal';
-import { makeKind, makeScalarBigWeakMapStore } from '../../src/storeModule.js';
+import { defineKind } from '../../src/storeModule.js';
 
-let stuff;
-
-let initialSelf;
-
-function makeThingInnards(state) {
-  function init(name) {
-    state.name = name;
-    // eslint-disable-next-line no-use-before-define
-    initialSelf = self;
-  }
-  const self = Far('thing', {
-    getName() {
-      return state.name;
-    },
-    rename(newName) {
+const makeThing = defineKind(
+  'thing',
+  name => {
+    return { name };
+  },
+  state => ({
+    getName: () => state.name,
+    rename: newName => {
       state.name = newName;
     },
-    getSelf() {
-      return self;
-    },
-  });
-  return { init, self };
-}
+  }),
+);
 
-const makeThing = makeKind(makeThingInnards);
-
-function makeZotInnards(state) {
-  function init(name, forceOverflow) {
-    state.name = name;
-    // enough instances to push me out of the cache
-    for (let i = 0; i < 5; i += 1) {
-      stuff.init(makeThing(`${name}-subthing${i}`, 29));
-    }
-    if (forceOverflow) {
-      // eslint-disable-next-line no-use-before-define
-      makeZot('recur', true);
-    }
-  }
-  const self = Far('zot', {
-    getName() {
-      return state.name;
-    },
-    rename(newName) {
-      state.name = newName;
-    },
-  });
-  return { init, self };
-}
-
-const makeZot = makeKind(makeZotInnards);
-
-export function buildRootObject(vatPowers) {
-  const { testLog } = vatPowers;
+export function buildRootObject() {
   let heldThing;
 
   return Far('root', {
     bootstrap() {
-      stuff = makeScalarBigWeakMapStore();
       return 'bootstrap done';
     },
     makeThing(name, hold) {
@@ -93,172 +53,6 @@ export function buildRootObject(vatPowers) {
     },
     forgetHeldThing() {
       heldThing = null;
-    },
-
-    testA(name, mode) {
-      // mode 1: make thing, return thing
-      // mode 2: make thing, return initial self
-      const thing = makeThing(name);
-      switch (mode) {
-        case 1:
-          return thing;
-        case 2:
-          return initialSelf;
-        default:
-          return `this can't happen`;
-      }
-    },
-    testB(name, mode) {
-      // mode 3: make thing, rename thing, return thing
-      // mode 4: make thing, rename initial self, return thing
-      // mode 5: make thing, rename thing, return initial self
-      // mode 6: make thing, rename initial self, return initial self
-      const thing = makeThing(name);
-      testLog(`test${mode} thing.name before rename "${thing.getName()}"`);
-      // prettier-ignore
-      testLog(`test${mode} initialSelf.name before rename "${initialSelf.getName()}"`);
-      switch (mode) {
-        case 3:
-        case 5:
-          thing.rename(`${name} modified`);
-          break;
-        case 4:
-        case 6:
-          initialSelf.rename(`${name} modified`);
-          break;
-        default:
-          break;
-      }
-      testLog(`test${mode} thing.name after rename "${thing.getName()}"`);
-      // prettier-ignore
-      testLog(`test${mode} initialSelf.name after rename "${initialSelf.getName()}"`);
-      switch (mode) {
-        case 3:
-        case 4:
-          return thing;
-        case 5:
-        case 6:
-          return initialSelf;
-        default:
-          return `this can't happen`;
-      }
-    },
-    testC(name, mode) {
-      // mode 7: make thing, use thing as key in weakstore, lookup value keyed to thing in weakstore
-      // mode 8: make thing, use initial self as key in weakstore, lookup value keyed to thing in weakstore
-      // mode 9: make thing, use thing as key in weakstore, lookup value keyed to initial self in weakstore
-      // mode 10: make thing, use initial self as key in weakstore, lookup value keyed to initial self in weakstore
-      const thing = makeThing(name);
-      switch (mode) {
-        case 7:
-        case 9:
-          stuff.init(thing, 47);
-          break;
-        case 8:
-        case 10:
-          stuff.init(initialSelf, 47);
-          break;
-        default:
-          break;
-      }
-      let result;
-      switch (mode) {
-        case 7:
-        case 8:
-          result = stuff.get(thing);
-          break;
-        case 9:
-        case 10:
-          result = stuff.get(initialSelf);
-          break;
-        default:
-          break;
-      }
-      testLog(`test${mode} result is "${result}"`);
-      return result;
-    },
-    testD(name, mode) {
-      // mode 11: make thing, store thing as value in weakstore, lookup value and return name of value
-      // mode 12: make thing, store initial self as value in weakstore, lookup value and return name of value
-      const thing = makeThing(name);
-      const keyish = `key for mode ${mode}`;
-      switch (mode) {
-        case 11:
-          stuff.init(keyish, thing);
-          break;
-        case 12:
-          stuff.init(keyish, initialSelf);
-          break;
-        default:
-          break;
-      }
-      const result = stuff.get(keyish).getName();
-      testLog(`test${mode} result is "${result}"`);
-      return result;
-    },
-    testE(name, mode) {
-      // mode 13: make thing, rename thing, store thing as value in weakstore, lookup and return name of value
-      // mode 14: make thing, rename thing, store initial self as value in weakstore, lookup and return name of value
-      // mode 15: make thing, rename initial self, store thing as value in weakstore, lookup and return name of value
-      // mode 16: make thing, rename initial self, store initial self as value in weakstore, lookup and return name of value
-      // mode 17: make thing, store thing as value in weakstore, rename thing, lookup and return name of value
-      // mode 18: make thing, store initial self as value in weakstore, rename thing, lookup and return name of value
-      // mode 19: make thing, store thing as value in weakstore, rename initial self, lookup and return name of value
-      // mode 20: make thing, store initial self as value in weakstore, rename initial self, lookup and return name of value
-
-      const thing = makeThing(name);
-      switch (mode) {
-        case 13:
-        case 14:
-          thing.rename(`${name} modified`);
-          break;
-        case 15:
-        case 16:
-          initialSelf.rename(`${name} modified`);
-          break;
-        default:
-          break;
-      }
-      const keyish = `key for mode ${mode}`;
-      switch (mode) {
-        case 13:
-        case 15:
-        case 17:
-        case 19:
-          stuff.init(keyish, thing);
-          break;
-        case 14:
-        case 16:
-        case 18:
-        case 20:
-          stuff.init(keyish, initialSelf);
-          break;
-        default:
-          break;
-      }
-      switch (mode) {
-        case 17:
-        case 18:
-          thing.rename(`${name} modified`);
-          break;
-        case 19:
-        case 20:
-          initialSelf.rename(`${name} modified`);
-          break;
-        default:
-          break;
-      }
-      const result = stuff.get(keyish).getName();
-      testLog(`test${mode} result is "${result}"`);
-      return result;
-    },
-    testCacheOverflow(name, forceOverflow) {
-      try {
-        return makeZot(name, forceOverflow);
-      } catch (e) {
-        testLog(`testCacheOverflow catches ${e}`);
-        return 'overflow';
-      }
     },
   });
 }

--- a/packages/SwingSet/test/virtualObjects/vat-vom-gc-bob.js
+++ b/packages/SwingSet/test/virtualObjects/vat-vom-gc-bob.js
@@ -1,24 +1,17 @@
 import { E } from '@agoric/eventual-send';
 import { Far } from '@endo/marshal';
-import { makeKind } from '../../src/storeModule.js';
+import { defineKind } from '../../src/storeModule.js';
 
 const things = [];
 
 export function buildRootObject(_vatPowers) {
-  function makeThingInnards(state) {
-    return {
-      init(label) {
-        state.label = label;
-      },
-      self: Far('thing', {
-        getLabel() {
-          return state.label;
-        },
-      }),
-    };
-  }
-
-  const makeThing = makeKind(makeThingInnards);
+  const makeThing = defineKind(
+    'thing',
+    label => ({ label }),
+    state => ({
+      getLabel: () => state.label,
+    }),
+  );
   let nextThingNumber = 0;
 
   return Far('root', {

--- a/packages/SwingSet/test/virtualObjects/vat-weakcollections-alice.js
+++ b/packages/SwingSet/test/virtualObjects/vat-weakcollections-alice.js
@@ -1,22 +1,16 @@
 import { Far } from '@endo/marshal';
-import { makeKind } from '../../src/storeModule.js';
+import { defineKind } from '../../src/storeModule.js';
 
-function makeHolderInnards(state) {
-  function init(value) {
-    state.value = value;
-  }
-  const self = Far('holder-vo', {
-    getValue() {
-      return state.value;
-    },
-    setValue(newValue) {
+const makeHolder = defineKind(
+  'holder-vo',
+  value => ({ value }),
+  state => ({
+    getValue: () => state.value,
+    setValue: newValue => {
       state.value = newValue;
     },
-  });
-  return { init, self };
-}
-
-const makeHolder = makeKind(makeHolderInnards);
+  }),
+);
 
 export function buildRootObject() {
   const testWeakMap = new WeakMap();

--- a/packages/SwingSet/tools/fakeVirtualObjectManager.js
+++ b/packages/SwingSet/tools/fakeVirtualObjectManager.js
@@ -15,8 +15,8 @@ export function makeFakeVirtualObjectManager(vrm, fakeStuff, options = {}) {
   const { cacheSize = 100 } = options;
 
   const {
-    makeKind,
-    makeDurableKind,
+    defineKind,
+    defineDurableKind,
     VirtualObjectAwareWeakMap,
     VirtualObjectAwareWeakSet,
     flushCache,
@@ -32,8 +32,8 @@ export function makeFakeVirtualObjectManager(vrm, fakeStuff, options = {}) {
   );
 
   const normalVOM = {
-    makeKind,
-    makeDurableKind,
+    defineKind,
+    defineDurableKind,
     VirtualObjectAwareWeakMap,
     VirtualObjectAwareWeakSet,
   };

--- a/packages/SwingSet/tools/fakeVirtualSupport.js
+++ b/packages/SwingSet/tools/fakeVirtualSupport.js
@@ -173,15 +173,21 @@ export function makeFakeLiveSlotsStuff(options = {}) {
   function convertSlotToVal(slot) {
     const { type, virtual } = parseVatSlot(slot);
     assert.equal(type, 'object');
+    let val = getValForSlot(slot);
+    if (val) {
+      if (virtual) {
+        vrm.reanimate(slot, true);
+      }
+      return val;
+    }
     if (virtual) {
       if (vrm) {
-        return vrm.reanimate(slot, false);
+        val = vrm.reanimate(slot, false);
       } else {
         assert.fail('fake liveSlots stuff configured without vrm');
       }
-    } else {
-      return getValForSlot(slot);
     }
+    return val;
   }
 
   const marshal = makeMarshal(convertValToSlot, convertSlotToVal);

--- a/packages/SwingSet/tools/prepare-test-env.js
+++ b/packages/SwingSet/tools/prepare-test-env.js
@@ -13,7 +13,7 @@ import { makeFakeVirtualStuff } from './fakeVirtualSupport.js';
 
 const { vom, cm } = makeFakeVirtualStuff({ cacheSize: 3 });
 
-const { makeKind, makeDurableKind } = vom;
+const { defineKind, defineDurableKind } = vom;
 
 const {
   makeScalarBigMapStore,
@@ -23,8 +23,8 @@ const {
 } = cm;
 
 const VatData = harden({
-  makeKind,
-  makeDurableKind,
+  defineKind,
+  defineDurableKind,
   makeScalarBigMapStore,
   makeScalarBigWeakMapStore,
   makeScalarBigSetStore,

--- a/packages/deploy-script-support/globals.d.ts
+++ b/packages/deploy-script-support/globals.d.ts
@@ -1,6 +1,6 @@
 interface VatData {
-  makeKind: function;
-  makeDurableKind: function;
+  defineKind: function;
+  defineDurableKind: function;
   makeScalarBigMapStore: function;
   makeScalarBigWeakMapStore: function;
   makeScalarBigSetStore: function;

--- a/packages/pegasus/globals.d.ts
+++ b/packages/pegasus/globals.d.ts
@@ -1,6 +1,6 @@
 interface VatData {
-  makeKind: function;
-  makeDurableKind: function;
+  defineKind: function;
+  defineDurableKind: function;
   makeScalarBigMapStore: function;
   makeScalarBigWeakMapStore: function;
   makeScalarBigSetStore: function;

--- a/packages/run-protocol/globals.d.ts
+++ b/packages/run-protocol/globals.d.ts
@@ -1,6 +1,6 @@
 interface VatData {
-  makeKind: function;
-  makeDurableKind: function;
+  defineKind: function;
+  defineDurableKind: function;
   makeScalarBigMapStore: function;
   makeScalarBigWeakMapStore: function;
   makeScalarBigSetStore: function;

--- a/packages/swingset-runner/demo/vatStore1/vat-bob.js
+++ b/packages/swingset-runner/demo/vatStore1/vat-bob.js
@@ -1,73 +1,62 @@
 import { Far } from '@endo/marshal';
-import { makeKind } from '@agoric/swingset-vat/src/storeModule.js';
+import { defineKind } from '@agoric/swingset-vat/src/storeModule.js';
 
 const p = console.log;
 
-function makeThingInnards(state) {
-  return {
-    init(label = 'thing', counter = 0) {
-      p(`@@@ thing.initialize(${label}, ${counter})`);
-      state.counter = counter;
-      state.label = label;
-      state.resetCounter = 0;
+const makeThing = defineKind(
+  'thing',
+  (label = 'thing', counter = 0) => {
+    p(`@@@ thing.initialize(${label}, ${counter})`);
+    return { counter, label, resetCounter: 0 };
+  },
+  state => ({
+    inc() {
+      state.counter += 1;
+      p(`#thing# ${state.label} inc() counter now ${state.counter}`);
     },
-    self: Far('thing', {
-      inc() {
-        state.counter += 1;
-        p(`#thing# ${state.label} inc() counter now ${state.counter}`);
-      },
-      reset(newStart) {
-        p(`#thing# ${state.label} reset(${newStart})`);
-        state.counter = newStart;
-        state.resetCounter += 1;
-      },
-      relabel(newLabel) {
-        p(`#thing# ${state.label} relabel(${newLabel})`);
-        state.label = newLabel;
-      },
-      get() {
-        p(`#thing# ${state.label} get()=>${state.counter}`);
-        return state.counter;
-      },
-      describe() {
-        p(`#thing# ${state.label} describe()`);
-        return `${state.label} counter has been reset ${state.resetCounter} times and is now ${state.counter}`;
-      },
-    }),
-  };
-}
-
-const makeThing = makeKind(makeThingInnards);
-
-function makeZotInstance(state) {
-  return {
-    init(arbitrary = 47, name = 'Bob', tag = 'say what?') {
-      p(`@@@ zot.initialize(${arbitrary}, ${name}, ${tag})`);
-      state.arbitrary = arbitrary;
-      state.name = name;
-      state.tag = tag;
-      state.count = 0;
+    reset(newStart) {
+      p(`#thing# ${state.label} reset(${newStart})`);
+      state.counter = newStart;
+      state.resetCounter += 1;
     },
-    self: Far('zot', {
-      sayHello(msg) {
-        p(`#zot# ${msg} ${state.name}`);
-        state.count += 1;
-      },
-      rename(newName) {
-        p(`#zot# ${state.name} rename(${newName})`);
-        state.name = newName;
-        state.count += 1;
-      },
-      printInfo() {
-        // prettier-ignore
-        p(`#zot# ${state.name} tag=${state.tag} count=${state.count} arbitrary=${state.arbitrary}`);
-        state.count += 1;
-      },
-    }),
-  };
-}
+    relabel(newLabel) {
+      p(`#thing# ${state.label} relabel(${newLabel})`);
+      state.label = newLabel;
+    },
+    get() {
+      p(`#thing# ${state.label} get()=>${state.counter}`);
+      return state.counter;
+    },
+    describe() {
+      p(`#thing# ${state.label} describe()`);
+      return `${state.label} counter has been reset ${state.resetCounter} times and is now ${state.counter}`;
+    },
+  }),
+);
 
-const makeZot = makeKind(makeZotInstance);
+const makeZot = defineKind(
+  'zot',
+  (arbitrary = 47, name = 'Bob', tag = 'say what?') => {
+    p(`@@@ zot.initialize(${arbitrary}, ${name}, ${tag})`);
+    return { arbitrary, name, tag, count: 0 };
+  },
+  state => ({
+    sayHello(msg) {
+      p(`#zot# ${msg} ${state.name}`);
+      state.count += 1;
+    },
+    rename(newName) {
+      p(`#zot# ${state.name} rename(${newName})`);
+      state.name = newName;
+      state.count += 1;
+    },
+    printInfo() {
+      // prettier-ignore
+      p(`#zot# ${state.name} tag=${state.tag} count=${state.count} arbitrary=${state.arbitrary}`);
+      state.count += 1;
+    },
+  }),
+);
 
 export function buildRootObject(_vatPowers) {
   let thing1;

--- a/packages/swingset-runner/demo/vatStore2/thingHolder.js
+++ b/packages/swingset-runner/demo/vatStore2/thingHolder.js
@@ -1,48 +1,42 @@
 import { E } from '@agoric/eventual-send';
 import { Far } from '@endo/marshal';
 import {
-  makeKind,
+  defineKind,
   makeScalarBigWeakMapStore,
 } from '@agoric/swingset-vat/src/storeModule.js';
 
 const p = console.log;
 
 function build(name) {
-  function makeThingInnards(state) {
-    return {
-      init(label, companion, companionName) {
-        p(`${name}'s thing ${label}: initialize ${companionName}`);
-        state.label = label;
-        state.companion = companion;
-        state.companionName = companionName;
-        state.count = 0;
+  const makeThing = defineKind(
+    'thing',
+    (label, companion, companionName) => {
+      p(`${name}'s thing ${label}: initialize ${companionName}`);
+      return { label, companion, companionName, count: 0 };
+    },
+    state => ({
+      echo(message) {
+        state.count += 1;
+        E(state.companion).say(message);
       },
-      self: Far('thing', {
-        echo(message) {
-          state.count += 1;
-          E(state.companion).say(message);
-        },
-        async changePartner(newCompanion) {
-          state.count += 1;
-          state.companion = newCompanion;
-          const companionName = await E(newCompanion).getName();
-          state.companionName = companionName;
-          p(`${name}'s thing ${state.label}: changePartner ${companionName}`);
-        },
-        getLabel() {
-          const label = state.label;
-          p(`${name}'s thing ${label}: getLabel`);
-          state.count += 1;
-          return label;
-        },
-        report() {
-          p(`${name}'s thing ${state.label} invoked ${state.count} times`);
-        },
-      }),
-    };
-  }
-
-  const makeThing = makeKind(makeThingInnards);
+      async changePartner(newCompanion) {
+        state.count += 1;
+        state.companion = newCompanion;
+        const companionName = await E(newCompanion).getName();
+        state.companionName = companionName;
+        p(`${name}'s thing ${state.label}: changePartner ${companionName}`);
+      },
+      getLabel() {
+        const label = state.label;
+        p(`${name}'s thing ${label}: getLabel`);
+        state.count += 1;
+        return label;
+      },
+      report() {
+        p(`${name}'s thing ${state.label} invoked ${state.count} times`);
+      },
+    }),
+  );
   let nextThingNumber = 0;
 
   let myThings;

--- a/packages/swingset-runner/demo/vatStore3/vat-bob.js
+++ b/packages/swingset-runner/demo/vatStore3/vat-bob.js
@@ -1,24 +1,18 @@
 import { E } from '@agoric/eventual-send';
 import { Far } from '@endo/marshal';
-import { makeKind } from '@agoric/swingset-vat/src/storeModule.js';
+import { defineKind } from '@agoric/swingset-vat/src/storeModule.js';
 
 const things = [];
 
 export function buildRootObject(_vatPowers) {
-  function makeThingInnards(state) {
-    return {
-      init(label) {
-        state.label = label;
-      },
-      self: Far('thing', {
-        getLabel() {
-          return state.label;
-        },
-      }),
-    };
-  }
+  const makeThing = defineKind(
+    'thing',
+    label => ({ label }),
+    state => ({
+      getLabel: () => state.label,
+    }),
+  );
 
-  const makeThing = makeKind(makeThingInnards);
   let nextThingNumber = 0;
 
   return Far('root', {

--- a/packages/swingset-runner/demo/virtualObjectGC/vat-bob.js
+++ b/packages/swingset-runner/demo/virtualObjectGC/vat-bob.js
@@ -1,36 +1,24 @@
 import { E } from '@agoric/eventual-send';
 import { Far } from '@endo/marshal';
-import { makeKind } from '@agoric/swingset-vat/src/storeModule.js';
+import { defineKind } from '@agoric/swingset-vat/src/storeModule.js';
 
 export function buildRootObject(_vatPowers) {
-  function makeThingInnards(state) {
-    return {
-      init(label) {
-        state.label = label;
-      },
-      self: Far('thing', {
-        getLabel() {
-          return state.label;
-        },
-      }),
-    };
-  }
+  const makeThing = defineKind(
+    'thing',
+    label => ({ label }),
+    state => ({
+      getLabel: () => state.label,
+    }),
+  );
 
-  function makeVirtualHolderInnards(state) {
-    return {
-      init(value) {
-        state.value = value;
-      },
-      self: Far('holder', {
-        getValue() {
-          return state.value;
-        },
-      }),
-    };
-  }
+  const makeVirtualHolder = defineKind(
+    'holder',
+    value => ({ value }),
+    state => ({
+      getValue: () => state.value,
+    }),
+  );
 
-  const makeThing = makeKind(makeThingInnards);
-  const makeVirtualHolder = makeKind(makeVirtualHolderInnards);
   const cacheDisplacer = makeThing('cacheDisplacer');
   let nextThingNumber = 0;
   let heldThing = null;

--- a/packages/vats/globals.d.ts
+++ b/packages/vats/globals.d.ts
@@ -1,6 +1,6 @@
 interface VatData {
-  makeKind: function;
-  makeDurableKind: function;
+  defineKind: function;
+  defineDurableKind: function;
   makeScalarBigMapStore: function;
   makeScalarBigWeakMapStore: function;
   makeScalarBigSetStore: function;

--- a/packages/xsnap/src/globals.d.ts
+++ b/packages/xsnap/src/globals.d.ts
@@ -5,8 +5,8 @@ namespace global {
 }
 
 interface VatData {
-  makeKind: function;
-  makeDurableKind: function;
+  defineKind: function;
+  defineDurableKind: function;
   makeScalarBigMapStore: function;
   makeScalarBigWeakMapStore: function;
   makeScalarBigSetStore: function;

--- a/packages/zoe/test/minimalMakeKindContract.js
+++ b/packages/zoe/test/minimalMakeKindContract.js
@@ -1,8 +1,8 @@
 /* global VatData */
 
 const start = _zcf => {
-  VatData.makeKind();
-  VatData.makeDurableKind();
+  VatData.defineKind();
+  VatData.defineDurableKind();
   VatData.makeScalarBigMapStore();
   VatData.makeScalarBigWeakMapStore();
   VatData.makeScalarBigSetStore();

--- a/packages/zoe/test/swingsetTests/makeKind/test-makeKind.js
+++ b/packages/zoe/test/swingsetTests/makeKind/test-makeKind.js
@@ -76,7 +76,7 @@ const expected = [
   '{"adminFacet":{},"creatorFacet":{},"instance":{},"publicFacet":{}}',
 ];
 
-test.serial('makeKind swingset', async t => {
+test.serial('defineKind swingset', async t => {
   const dump = await main(t);
   t.deepEqual(dump.log, expected);
 });

--- a/packages/zoe/test/unitTests/test-makeKind.js
+++ b/packages/zoe/test/unitTests/test-makeKind.js
@@ -16,12 +16,12 @@ const dirname = path.dirname(filename);
 
 const root = `${dirname}/../minimalMakeKindContract.js`;
 
-test('makeKind non-swingset', async t => {
+test('defineKind non-swingset', async t => {
   const bundle = await bundleSource(root);
   const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
   const installation = await E(zoe).install(bundle);
-  t.notThrows(() => VatData.makeKind());
-  t.notThrows(() => VatData.makeDurableKind());
+  t.notThrows(() => VatData.defineKind());
+  t.notThrows(() => VatData.defineDurableKind());
   t.notThrows(() => VatData.makeScalarBigMapStore());
   t.notThrows(() => VatData.makeScalarBigWeakMapStore());
   t.notThrows(() => VatData.makeScalarBigSetStore());

--- a/packages/zoe/test/unitTests/test-zoe-env.js
+++ b/packages/zoe/test/unitTests/test-zoe-env.js
@@ -11,8 +11,8 @@ test('harden from SES is in the zoe contract environment', t => {
 
 test('(mock) kind makers from SwingSet are in the zoe contract environment', t => {
   // @ts-ignore testing existence of function only
-  VatData.makeKind();
-  VatData.makeDurableKind();
+  VatData.defineKind();
+  VatData.defineDurableKind();
   t.pass();
 });
 


### PR DESCRIPTION
This implements the revised virtual object API design as described in #4606

I'm very happy with the code simplifications this enabled.  In particular, an entire large and complicated test went away completely because the largish set of weird edge cases that it checked to ensure were handled correctly are no longer even expressible.

Closes #4606
