### PR TITLE
test: Ensure access to reduced counterexamples from fast-check

### DIFF
--- a/packages/ERTP/test/unitTests/test-amountProperties.js
+++ b/packages/ERTP/test/unitTests/test-amountProperties.js
@@ -4,6 +4,7 @@ import fc from 'fast-check';
 
 import { AmountMath as m, AssetKind } from '../../src/index.js';
 import { mockBrand } from './mathHelpers/mockBrand.js';
+import { assertionPassed } from '../../../store/test/test-store.js';
 
 // Perhaps makeCopyBag should coalesce duplicate labels, but for now, it does
 // not.
@@ -33,11 +34,26 @@ test('isEqual is a (total) equivalence relation', async t => {
     fc.property(
       fc.record({ x: arbAmount, y: arbAmount, z: arbAmount }),
       ({ x, y, z }) => {
-        t.true([true, false].includes(m.isEqual(x, y))); // Total
-        t.true(m.isEqual(x, x)); // Reflexive
-        t.true(implies(m.isEqual(x, y), m.isEqual(y, x))); // Symmetric
-        // Transitive
-        t.true(implies(m.isEqual(x, y) && m.isEqual(y, z), m.isEqual(x, z)));
+        return (
+          // Total
+          assertionPassed(t.true([true, false].includes(m.isEqual(x, y))), () =>
+            [true, false].includes(m.isEqual(x, y)),
+          ) &&
+          // Reflexive
+          assertionPassed(t.true(m.isEqual(x, x)), () => m.isEqual(x, x)) &&
+          // Symmetric
+          assertionPassed(
+            t.true(implies(m.isEqual(x, y), m.isEqual(y, x))),
+            () => implies(m.isEqual(x, y), m.isEqual(y, x)),
+          ) &&
+          // Transitive
+          assertionPassed(
+            t.true(
+              implies(m.isEqual(x, y) && m.isEqual(y, z), m.isEqual(x, z)),
+            ),
+            () => implies(m.isEqual(x, y) && m.isEqual(y, z), m.isEqual(x, z)),
+          )
+        );
       },
     ),
   );
@@ -47,11 +63,20 @@ test('isGTE is a partial order with empty as minimum', async t => {
   const empty = m.makeEmpty(mockBrand, AssetKind.COPY_BAG);
   await fc.assert(
     fc.property(fc.record({ x: arbAmount, y: arbAmount }), ({ x, y }) => {
-      t.true(m.isGTE(x, empty));
-      t.true([true, false].includes(m.isGTE(x, y))); // Total
-      t.true(m.isGTE(x, x)); // Reflexive
-      // Antisymmetric
-      t.true(implies(m.isGTE(x, y) && m.isGTE(y, x), m.isEqual(x, y)));
+      return (
+        assertionPassed(t.true(m.isGTE(x, empty)), () => m.isGTE(x, empty)) &&
+        // Total
+        assertionPassed(t.true([true, false].includes(m.isGTE(x, y))), () =>
+          [true, false].includes(m.isGTE(x, y)),
+        ) &&
+        // Reflexive
+        assertionPassed(t.true(m.isGTE(x, x)), () => m.isGTE(x, x)) &&
+        // Antisymmetric
+        assertionPassed(
+          t.true(implies(m.isGTE(x, y) && m.isGTE(y, x), m.isEqual(x, y))),
+          () => implies(m.isGTE(x, y) && m.isGTE(y, x), m.isEqual(x, y)),
+        )
+      );
     }),
   );
 });
@@ -62,15 +87,37 @@ test('add: closed, commutative, associative, monotonic, with empty identity', as
     fc.property(
       fc.record({ x: arbAmount, y: arbAmount, z: arbAmount }),
       ({ x, y, z }) => {
-        // note: + for SET is not total.
-        t.truthy(m.coerce(mockBrand, m.add(x, y)));
-        t.true(m.isEqual(m.add(x, empty), x)); // Identity (right)
-        t.true(m.isEqual(m.add(empty, x), x)); // Identity (left)
-        t.true(m.isEqual(m.add(x, y), m.add(y, x))); // Commutative
-        // Associative
-        t.true(m.isEqual(m.add(m.add(x, y), z), m.add(x, m.add(y, z))));
-        t.true(m.isGTE(m.add(x, y), x)); // Monotonic (left)
-        t.true(m.isGTE(m.add(x, y), y)); // Monotonic (right)
+        return (
+          // note: + for SET is not total.
+          assertionPassed(t.truthy(m.coerce(mockBrand, m.add(x, y))), () =>
+            m.coerce(mockBrand, m.add(x, y)),
+          ) &&
+          // Identity (right)
+          assertionPassed(t.true(m.isEqual(m.add(x, empty), x)), () =>
+            m.isEqual(m.add(x, empty), x),
+          ) &&
+          // Identity (left)
+          assertionPassed(t.true(m.isEqual(m.add(empty, x), x)), () =>
+            m.isEqual(m.add(empty, x), x),
+          ) &&
+          // Commutative
+          assertionPassed(t.true(m.isEqual(m.add(x, y), m.add(y, x))), () =>
+            m.isEqual(m.add(x, y), m.add(y, x)),
+          ) &&
+          // Associative
+          assertionPassed(
+            t.true(m.isEqual(m.add(m.add(x, y), z), m.add(x, m.add(y, z)))),
+            () => m.isEqual(m.add(m.add(x, y), z), m.add(x, m.add(y, z))),
+          ) &&
+          // Monotonic (left)
+          assertionPassed(t.true(m.isGTE(m.add(x, y), x)), () =>
+            m.isGTE(m.add(x, y), x),
+          ) &&
+          // Monotonic (right)
+          assertionPassed(t.true(m.isGTE(m.add(x, y), y)), () =>
+            m.isGTE(m.add(x, y), y),
+          )
+        );
       },
     ),
   );
@@ -79,8 +126,18 @@ test('add: closed, commutative, associative, monotonic, with empty identity', as
 test('subtract: (x + y) - y = x; (y - x) + x = y if y >= x', async t => {
   await fc.assert(
     fc.property(fc.record({ x: arbAmount, y: arbAmount }), ({ x, y }) => {
-      t.true(m.isEqual(m.subtract(m.add(x, y), y), x));
-      t.true(m.isGTE(y, x) ? m.isEqual(m.add(m.subtract(y, x), x), y) : true);
+      return (
+        assertionPassed(t.true(m.isEqual(m.subtract(m.add(x, y), y), x)), () =>
+          m.isEqual(m.subtract(m.add(x, y), y), x),
+        ) &&
+        assertionPassed(
+          t.true(
+            m.isGTE(y, x) ? m.isEqual(m.add(m.subtract(y, x), x), y) : true,
+          ),
+          () =>
+            m.isGTE(y, x) ? m.isEqual(m.add(m.subtract(y, x), x), y) : true,
+        )
+      );
     }),
   );
 });

--- a/packages/ERTP/test/unitTests/test-amountProperties.js
+++ b/packages/ERTP/test/unitTests/test-amountProperties.js
@@ -28,8 +28,8 @@ const arbAmount = arbBagContents.map(contents =>
 // Note: we write P => Q as !P || Q since JS has no logical => operator
 const implies = (p, q) => !p || q;
 
-test('isEqual is a (total) equivalence relation', t => {
-  fc.assert(
+test('isEqual is a (total) equivalence relation', async t => {
+  await fc.assert(
     fc.property(
       fc.record({ x: arbAmount, y: arbAmount, z: arbAmount }),
       ({ x, y, z }) => {
@@ -43,9 +43,9 @@ test('isEqual is a (total) equivalence relation', t => {
   );
 });
 
-test('isGTE is a partial order with empty as minimum', t => {
+test('isGTE is a partial order with empty as minimum', async t => {
   const empty = m.makeEmpty(mockBrand, AssetKind.COPY_BAG);
-  fc.assert(
+  await fc.assert(
     fc.property(fc.record({ x: arbAmount, y: arbAmount }), ({ x, y }) => {
       t.true(m.isGTE(x, empty));
       t.true([true, false].includes(m.isGTE(x, y))); // Total
@@ -56,9 +56,9 @@ test('isGTE is a partial order with empty as minimum', t => {
   );
 });
 
-test('add: closed, commutative, associative, monotonic, with empty identity', t => {
+test('add: closed, commutative, associative, monotonic, with empty identity', async t => {
   const empty = m.makeEmpty(mockBrand, AssetKind.COPY_BAG);
-  fc.assert(
+  await fc.assert(
     fc.property(
       fc.record({ x: arbAmount, y: arbAmount, z: arbAmount }),
       ({ x, y, z }) => {
@@ -76,8 +76,8 @@ test('add: closed, commutative, associative, monotonic, with empty identity', t 
   );
 });
 
-test('subtract: (x + y) - y = x; (y - x) + x = y if y >= x', t => {
-  fc.assert(
+test('subtract: (x + y) - y = x; (y - x) + x = y if y >= x', async t => {
+  await fc.assert(
     fc.property(fc.record({ x: arbAmount, y: arbAmount }), ({ x, y }) => {
       t.true(m.isEqual(m.subtract(m.add(x, y), y), x));
       t.true(m.isGTE(y, x) ? m.isEqual(m.add(m.subtract(y, x), x), y) : true);

--- a/packages/run-protocol/test/amm/vpool-xyk-amm/test-amm-calc.js
+++ b/packages/run-protocol/test/amm/vpool-xyk-amm/test-amm-calc.js
@@ -56,6 +56,8 @@ test('balancesToReachRatio calculations are to spec', async t => {
             multiply(poolX.value, poolY.value),
           ),
         );
+        let ok = true;
+
         const { targetX, targetY } = balancesToReachRatio(
           poolX,
           poolY,
@@ -71,6 +73,7 @@ test('balancesToReachRatio calculations are to spec', async t => {
           targetWithinRangeOfK,
           `with giveX=${giveX.value} giveY=${giveY.value}, targetX=${targetX.value} and targetY=${targetY.value} should have the same product as poolX=${poolX.value} * poolY=${poolY.value}.`,
         );
+        if (!targetWithinRangeOfK) ok = false;
 
         // target X / targetY approximately equals poolXAfter / poolYAfter
         const ratiosWithinRange = withinEpsilon(
@@ -79,11 +82,13 @@ test('balancesToReachRatio calculations are to spec', async t => {
           // @ts-ignore targetY.value is a Nat
           targetY.value * add(poolX.value, giveX.value),
         );
-
         t.truthy(
           ratiosWithinRange,
           `targetX ${targetX.value} and targetY ${targetY.value} should be in the same ratio as poolX + giveX / poolY + giveY`,
         );
+        if (!ratiosWithinRange) ok = false;
+
+        return ok;
       },
     ),
   );

--- a/packages/run-protocol/test/amm/vpool-xyk-amm/test-amm-calc.js
+++ b/packages/run-protocol/test/amm/vpool-xyk-amm/test-amm-calc.js
@@ -37,8 +37,8 @@ const withinEpsilon = (left, right) =>
   multiply(right, 105) >= multiply(left, 100) &&
   multiply(left, 105) >= multiply(right, 100);
 
-test('balancesToReachRatio calculations are to spec', t => {
-  fc.assert(
+test('balancesToReachRatio calculations are to spec', async t => {
+  await fc.assert(
     fc.property(
       fc.record({
         poolX: arbPoolX,

--- a/packages/store/src/types.js
+++ b/packages/store/src/types.js
@@ -153,6 +153,7 @@
  * Remove the key. Throws if not found.
  * @property {(keys: Iterable<K>) => void} addAll
  * @property {(keyPatt?: Pattern) => Iterable<K>} keys
+ * @property {(keyPatt?: Pattern) => Iterable<K>} values
  * @property {(keyPatt?: Pattern) => CopySet<K>} snapshot
  * @property {(keyPatt?: Pattern) => number} getSize
  * @property {(keyPatt?: Pattern) => void} clear


### PR DESCRIPTION
## Description

Updates use of fast-check assert to conform with its documentation: https://dubzzz.github.io/fast-check/index.html#assert

> WARNING: Has to be awaited
> …
> Returns Promise\<void>

### Security Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

Noted above.
