### PR TITLE
Add acceptance queue

### DIFF
--- a/packages/SwingSet/misc-tools/measure-metering/measure.js
+++ b/packages/SwingSet/misc-tools/measure-metering/measure.js
@@ -29,6 +29,9 @@ function countingPolicy() {
     crankFailed() {
       return true;
     },
+    emptyCrank() {
+      return true;
+    },
 
     counted() {
       return computrons;

--- a/packages/SwingSet/src/kernel/initializeKernel.js
+++ b/packages/SwingSet/src/kernel/initializeKernel.js
@@ -89,7 +89,7 @@ export function initializeKernel(config, hostStorage, verbose = false) {
       vatKeeper.setSourceAndOptions({ bundleID }, creationOptions);
       vatKeeper.initializeReapCountdown(creationOptions.reapInterval);
       if (!creationOptions.enableSetup) {
-        kernelKeeper.addToRunQueue(harden({ type: 'startVat', vatID }));
+        kernelKeeper.addToAcceptanceQueue(harden({ type: 'startVat', vatID }));
       }
       if (name === 'vatAdmin') {
         // Create a kref for the vatAdmin root, so the kernel can tell it

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -1192,6 +1192,7 @@ export default function buildKernel(
           policyOutput = policy.crankFailed(policyInput[1]);
           break;
         case 'none':
+          policyOutput = policy.emptyCrank();
           break;
         default:
           assert.fail(`unknown policyInput type in ${policyInput}`);

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -150,9 +150,10 @@ export default function buildKernel(
     return kernelSlog.vatConsole(vatID, origConsole);
   }
 
-  // runQueue entries are {type, vatID, more..}. 'more' depends on type:
-  // * deliver: target, msg
-  // * notify: kernelPromiseID
+  // runQueue and acceptanceQueue entries are {type, more..}. 'more' depends on type:
+  // * send: target, msg
+  // * notify: vatID, kpid
+  // * create-vat: vatID, source, dynamicOptions
 
   // in the kernel table, promises and resolvers are both indexed by the same
   // value. kernelPromises[promiseID] = { decider, subscribers }
@@ -1113,7 +1114,7 @@ export default function buildKernel(
     }
 
     if (!kernelKeeper.isRunQueueEmpty()) {
-      return kernelKeeper.getNextMsg();
+      return kernelKeeper.getNextRunQueueMsg();
     }
     return undefined;
   }

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -783,7 +783,6 @@ export default function buildKernel(
       } else {
         assert.fail(X`unable to process message.type ${message.type}`);
       }
-      processAcceptanceQueue();
       let didAbort = false;
       if (terminationTrigger) {
         // the vat is doomed, either voluntarily or from meter/syscall fault
@@ -811,7 +810,6 @@ export default function buildKernel(
         // state changes reflecting the termination must also survive, so
         // these happen after a possible abortCrank()
         terminateVat(vatID, shouldReject, info);
-        processAcceptanceQueue();
         kernelSlog.terminateVat(vatID, shouldReject, info);
         kdebug(`vat terminated: ${JSON.stringify(info)}`);
       }
@@ -1167,9 +1165,9 @@ export default function buildKernel(
     if (!started) {
       throw new Error('must do kernel.start() before run()');
     }
-    processAcceptanceQueue();
     let count = 0;
     for (;;) {
+      processAcceptanceQueue();
       const message = getNextMessage();
       if (!message) {
         break;

--- a/packages/SwingSet/src/kernel/kernelQueue.js
+++ b/packages/SwingSet/src/kernel/kernelQueue.js
@@ -20,7 +20,7 @@ export function makeKernelQueueHandler(tools) {
   function notify(vatID, kpid) {
     const m = harden({ type: 'notify', vatID, kpid });
     kernelKeeper.incrementRefCount(kpid, `enq|notify`);
-    kernelKeeper.addToRunQueue(m);
+    kernelKeeper.addToAcceptanceQueue(m);
   }
 
   function doSubscribe(vatID, kpid) {
@@ -78,7 +78,7 @@ export function makeKernelQueueHandler(tools) {
       kernelKeeper.incrementRefCount(argSlot, `enq|msg|s${idx}`);
       idx += 1;
     }
-    kernelKeeper.addToRunQueue(m);
+    kernelKeeper.addToAcceptanceQueue(m);
   }
 
   /**

--- a/packages/SwingSet/src/kernel/kernelQueue.js
+++ b/packages/SwingSet/src/kernel/kernelQueue.js
@@ -6,7 +6,7 @@ import { insistVatID } from './id.js';
 
 /**
  * @param {Object} tools
- * @param {*} tools.kernelKeeper  Kernel keeper managing persistent kernel state
+ * @param {KernelKeeper} tools.kernelKeeper  Kernel keeper managing persistent kernel state
  * @param {(problem: unknown, err?: Error) => void } [tools.panic]
  */
 export function makeKernelQueueHandler(tools) {
@@ -94,7 +94,7 @@ export function makeKernelQueueHandler(tools) {
    *    nothing), 'logAlways' (log the resolution or rejection), 'logFailure'
    *    (log only rejections), or 'panic' (panic the kernel upon a
    *    rejection).
-   * @returns {string?} the kpid of the sent message's result promise, if any
+   * @returns {string | undefined} the kpid of the sent message's result promise, if any
    */
   function queueToKref(kref, method, args, policy = 'ignore') {
     // queue a message on the end of the queue, with 'absolute' krefs.

--- a/packages/SwingSet/src/kernel/metrics.js
+++ b/packages/SwingSet/src/kernel/metrics.js
@@ -109,6 +109,11 @@ export const KERNEL_STATS_UPDOWN_METRICS = [
     description: 'Length of the kernel run queue',
   },
   {
+    key: 'acceptanceQueueLength',
+    name: 'swingset_acceptance_queue_length',
+    description: 'Length of the kernel acceptance queue',
+  },
+  {
     key: 'clistEntries',
     name: 'swingset_clist_entries',
     description: 'Number of entries in the kernel c-list',

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -648,13 +648,13 @@ export default function makeKernelKeeper(
     // up the resolution *now* and set the correct target early. Doing that
     // might make it easier to remove the Promise Table entry earlier.
     const p = getKernelPromise(kernelSlot);
-    const runQueue = JSON.parse(getRequired('runQueue'));
+    const acceptanceQueue = JSON.parse(getRequired('acceptanceQueue'));
     for (const msg of p.queue) {
       const entry = harden({ type: 'send', target: kernelSlot, msg });
-      runQueue.push(entry);
+      acceptanceQueue.push(entry);
     }
-    kvStore.set('runQueue', JSON.stringify(runQueue));
-    incStat('runQueueLength', p.queue.length);
+    kvStore.set('acceptanceQueue', JSON.stringify(acceptanceQueue));
+    incStat('acceptanceQueueLength', p.queue.length);
 
     deleteKernelPromiseState(kernelSlot);
     decStat('kpUnresolved');

--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -87,6 +87,7 @@ const enableKernelGC = true;
 
 // crankNumber = $NN
 // runQueue = JSON(runQueue)
+// acceptanceQueue = JSON(acceptanceQueue)
 // gcActions = JSON(gcActions)
 // reapQueue = JSON([vatIDs...])
 // pinnedObjects = ko$NN[,ko$NN..]
@@ -292,6 +293,7 @@ export default function makeKernelKeeper(
     kvStore.set('gcActions', '[]');
     kvStore.set('reapQueue', '[]');
     kvStore.set('runQueue', JSON.stringify([]));
+    kvStore.set('acceptanceQueue', JSON.stringify([]));
     kvStore.set('crankNumber', `${FIRST_CRANK_NUMBER}`);
     kvStore.set('kernel.defaultManagerType', defaultManagerType);
     kvStore.set('kernel.defaultReapInterval', `${defaultReapInterval}`);
@@ -838,7 +840,8 @@ export default function makeKernelKeeper(
   }
 
   function addToRunQueue(msg) {
-    // the runqueue is usually empty between blocks, so we can afford a
+    // TODO: May not be true
+    // the run-queue is usually empty between blocks, so we can afford a
     // non-delta-friendly format
     const queue = JSON.parse(getRequired('runQueue'));
     queue.push(msg);
@@ -856,11 +859,39 @@ export default function makeKernelKeeper(
     return queue.length;
   }
 
-  function getNextMsg() {
+  function getNextRunQueueMsg() {
     const queue = JSON.parse(getRequired('runQueue'));
     const msg = queue.shift();
     kvStore.set('runQueue', JSON.stringify(queue));
     decStat('runQueueLength');
+    return msg;
+  }
+
+  function addToAcceptanceQueue(msg) {
+    // TODO: May not be true
+    // the acceptance-queue is usually empty between blocks, so we can afford a
+    // non-delta-friendly format
+    const queue = JSON.parse(getRequired('acceptanceQueue'));
+    queue.push(msg);
+    kvStore.set('acceptanceQueue', JSON.stringify(queue));
+    incStat('acceptanceQueueLength');
+  }
+
+  function isAcceptanceQueueEmpty() {
+    const queue = JSON.parse(getRequired('acceptanceQueue'));
+    return queue.length <= 0;
+  }
+
+  function getAcceptanceQueueLength() {
+    const queue = JSON.parse(getRequired('acceptanceQueue'));
+    return queue.length;
+  }
+
+  function getNextAcceptanceQueueMsg() {
+    const queue = JSON.parse(getRequired('acceptanceQueue'));
+    const msg = queue.shift();
+    kvStore.set('acceptanceQueue', JSON.stringify(queue));
+    decStat('acceptanceQueueLength');
     return msg;
   }
 
@@ -1382,6 +1413,8 @@ export default function makeKernelKeeper(
 
     const runQueue = JSON.parse(getRequired('runQueue'));
 
+    const acceptanceQueue = JSON.parse(getRequired('acceptanceQueue'));
+
     return harden({
       vatTables,
       kernelTable,
@@ -1390,6 +1423,7 @@ export default function makeKernelKeeper(
       gcActions,
       reapQueue,
       runQueue,
+      acceptanceQueue,
     });
   }
 
@@ -1448,7 +1482,12 @@ export default function makeKernelKeeper(
     addToRunQueue,
     isRunQueueEmpty,
     getRunQueueLength,
-    getNextMsg,
+    getNextRunQueueMsg,
+
+    addToAcceptanceQueue,
+    isAcceptanceQueueEmpty,
+    getAcceptanceQueueLength,
+    getNextAcceptanceQueueMsg,
 
     allocateMeter,
     addMeterRemaining,

--- a/packages/SwingSet/src/runPolicies.js
+++ b/packages/SwingSet/src/runPolicies.js
@@ -14,10 +14,17 @@ export function foreverPolicy() {
     crankFailed(_details) {
       return true;
     },
+    emptyCrank() {
+      return true;
+    },
   });
 }
 
-export function crankCounter(maxCranks, maxCreateVats) {
+export function crankCounter(
+  maxCranks,
+  maxCreateVats,
+  includeEmptyCranks = false,
+) {
   let cranks = 0;
   let vats = 0;
   /** @type { RunPolicy } */
@@ -32,6 +39,10 @@ export function crankCounter(maxCranks, maxCreateVats) {
     },
     crankFailed() {
       cranks += 1;
+      return cranks < maxCranks;
+    },
+    emptyCrank() {
+      cranks += includeEmptyCranks ? 1 : 0;
       return cranks < maxCranks;
     },
   });
@@ -59,6 +70,9 @@ export function computronCounter(limit) {
       total += 1000000n; // who knows, 1M is as good as anything
       return total < limit;
     },
+    emptyCrank() {
+      return true;
+    },
   });
   return policy;
 }
@@ -70,6 +84,7 @@ export function wallClockWaiter(seconds) {
     vatCreated: () => Date.now() < timeout,
     crankComplete: () => Date.now() < timeout,
     crankFailed: () => Date.now() < timeout,
+    emptyCrank: () => Date.now() < timeout,
   });
   return policy;
 }

--- a/packages/SwingSet/src/types.js
+++ b/packages/SwingSet/src/types.js
@@ -297,6 +297,7 @@
  * @typedef { { vatCreated: (details: {}) => PolicyOutput,
  *              crankComplete: (details: { computrons?: bigint }) => PolicyOutput,
  *              crankFailed: (details: {}) => PolicyOutput,
+ *              emptyCrank: () => PolicyOutput,
  *             } } RunPolicy
  */
 

--- a/packages/SwingSet/test/devices/test-devices.js
+++ b/packages/SwingSet/test/devices/test-devices.js
@@ -120,7 +120,8 @@ test.serial('d1', async t => {
   await c.run();
 
   c.queueToVatRoot('bootstrap', 'step1', capargs([]));
-  await c.step();
+  await c.step(); // acceptance
+  await c.step(); // deliver
   t.deepEqual(c.dump().log, [
     'callNow',
     'invoke 1 2',
@@ -153,10 +154,13 @@ async function test2(t, mode) {
   const c = await makeSwingsetController(hostStorage, {});
   for (let i = 0; i < 5; i += 1) {
     // eslint-disable-next-line no-await-in-loop
-    await c.step(); // vat start
+    await c.step(); // vat start acceptance
+    // eslint-disable-next-line no-await-in-loop
+    await c.step(); // vat start deliver
   }
   c.pinVatRoot('bootstrap');
-  await c.step();
+  await c.step(); // acceptance
+  await c.step(); // deliver
   if (mode === '1') {
     t.deepEqual(c.dump().log, ['calling d2.method1', 'method1 hello', 'done']);
   } else if (mode === '2') {
@@ -185,7 +189,8 @@ async function test2(t, mode) {
     ]);
   } else if (mode === '5') {
     t.deepEqual(c.dump().log, ['calling v2.method5', 'called']);
-    await c.step();
+    await c.step(); // acceptance
+    await c.step(); // deliver
     t.deepEqual(c.dump().log, [
       'calling v2.method5',
       'called',
@@ -193,7 +198,8 @@ async function test2(t, mode) {
       'method5 hello',
       'left5 did d2.method5, got ok',
     ]);
-    await c.step();
+    await c.step(); // acceptance
+    await c.step(); // deliver
     t.deepEqual(c.dump().log, [
       'calling v2.method5',
       'called',
@@ -344,11 +350,14 @@ test.serial('liveslots throws when D() gets promise', async t => {
 
   for (let i = 0; i < 4; i += 1) {
     // eslint-disable-next-line no-await-in-loop
-    await c.step(); // vat start
+    await c.step(); // vat start acceptance
+    // eslint-disable-next-line no-await-in-loop
+    await c.step(); // vat start deliver
     // eslint-disable-next-line no-await-in-loop
     await c.step(); // bring out your dead
   }
-  await c.step();
+  await c.step(); // acceptance
+  await c.step(); // deliver
   // When liveslots catches an attempt to send a promise into D(), it throws
   // a regular error, which the vat can catch.
   t.deepEqual(c.dump().log, ['sending Promise', 'good: callNow failed']);
@@ -386,11 +395,14 @@ test.serial('syscall.callNow(promise) is vat-fatal', async t => {
   const c = await makeSwingsetController(hostStorage, {});
   for (let i = 0; i < 3; i += 1) {
     // eslint-disable-next-line no-await-in-loop
-    await c.step(); // vat start
+    await c.step(); // vat start acceptance
+    // eslint-disable-next-line no-await-in-loop
+    await c.step(); // vat start deliver
     // eslint-disable-next-line no-await-in-loop
     await c.step(); // bring out your dead
   }
-  await c.step(); // bootstrap, which will fail
+  await c.step(); // acceptance
+  await c.step(); // deliver bootstrap, which will fail
   // if the kernel paniced, that c.step() will reject, and the await will throw
   t.deepEqual(c.dump().log, ['sending Promise', 'good: callNow failed']);
   // now check that the vat was terminated: this should throw an exception

--- a/packages/SwingSet/test/gc/test-gc-vat.js
+++ b/packages/SwingSet/test/gc/test-gc-vat.js
@@ -52,9 +52,11 @@ async function dropPresence(t, dropExport) {
   c.queueToVatRoot('bootstrap', 'one', capargs([]));
   if (dropExport) {
     c.queueToVatRoot('bootstrap', 'drop', capargs([]));
+    await c.step(); // acceptance
     await c.step(); // message
     await c.step(); // reap
   }
+  await c.step(); // acceptance
   await c.step(); // message
   await c.step(); // reap
 

--- a/packages/SwingSet/test/run-policy/test-run-policy.js
+++ b/packages/SwingSet/test/run-policy/test-run-policy.js
@@ -67,15 +67,15 @@ async function testCranks(t, mode) {
   let more;
 
   if (mode === 'messages' || mode === 'resolutions') {
-    more = await c.run(crankCounter(7, 0));
+    more = await c.run(crankCounter(7, 0, true));
     t.truthy(more, 'vat was supposed to run forever');
     t.is(elapsedCranks(), 7);
 
-    more = await c.run(crankCounter(1, 0));
+    more = await c.run(crankCounter(1, 0, true));
     t.truthy(more, 'vat was supposed to run forever');
     t.is(elapsedCranks(), 1);
 
-    more = await c.run(crankCounter(8, 0));
+    more = await c.run(crankCounter(8, 0, true));
     t.truthy(more, 'vat was supposed to run forever');
     t.is(elapsedCranks(), 8);
   } else if (mode === 'computrons') {

--- a/packages/SwingSet/test/run-policy/test-run-policy.js
+++ b/packages/SwingSet/test/run-policy/test-run-policy.js
@@ -67,17 +67,17 @@ async function testCranks(t, mode) {
   let more;
 
   if (mode === 'messages' || mode === 'resolutions') {
-    more = await c.run(crankCounter(7, 0, true));
+    more = await c.run(crankCounter(15, 0, true));
     t.truthy(more, 'vat was supposed to run forever');
-    t.is(elapsedCranks(), 7);
+    t.is(elapsedCranks(), 15);
 
-    more = await c.run(crankCounter(1, 0, true));
+    more = await c.run(crankCounter(2, 0, true));
     t.truthy(more, 'vat was supposed to run forever');
-    t.is(elapsedCranks(), 1);
+    t.is(elapsedCranks(), 2);
 
-    more = await c.run(crankCounter(8, 0, true));
+    more = await c.run(crankCounter(16, 0, true));
     t.truthy(more, 'vat was supposed to run forever');
-    t.is(elapsedCranks(), 8);
+    t.is(elapsedCranks(), 16);
   } else if (mode === 'computrons') {
     // the doMessage cycle has four steps:
     // 1: normal delivery (122k-134k computrons)
@@ -91,7 +91,7 @@ async function testCranks(t, mode) {
     // setting a threshold of 4M, we should finish c.run() just after that
     // extra-compute step.
     await c.run(computronCounter(4_000_000n));
-    t.is(elapsedCranks(), 17);
+    t.is(elapsedCranks(), 35);
     const ckey = `${rightID}.vs.vvs.seqnum`;
     const seqnum = parseInt(hostStorage.kvStore.get(ckey), 10);
     t.is(seqnum, 5);

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -296,7 +296,8 @@ test.serial('bootstrap export', async t => {
   kt.push([adminDev, bootstrapVatID, 'd-70']);
   // checkKT(t, c, kt); // disabled due to cross-engine GC variation
 
-  t.deepEqual(c.dump().runQueue, [
+  t.deepEqual(c.dump().runQueue, []);
+  t.deepEqual(c.dump().acceptanceQueue, [
     {
       type: 'send',
       target: left0,
@@ -319,7 +320,8 @@ test.serial('bootstrap export', async t => {
   kt.push([barP, leftVatID, 'p+5']);
   // checkKT(t, c, kt); // disabled due to cross-engine GC variation
 
-  t.deepEqual(c.dump().runQueue, [
+  t.deepEqual(c.dump().runQueue, []);
+  t.deepEqual(c.dump().acceptanceQueue, [
     {
       type: 'send',
       target: right0,
@@ -347,6 +349,8 @@ test.serial('bootstrap export', async t => {
 
   t.deepEqual(c.dump().runQueue, [
     { type: 'notify', vatID: bootstrapVatID, kpid: fooP },
+  ]);
+  t.deepEqual(c.dump().acceptanceQueue, [
     { type: 'notify', vatID: leftVatID, kpid: barP },
   ]);
 
@@ -371,6 +375,7 @@ test.serial('bootstrap export', async t => {
   t.deepEqual(c.dump().runQueue, [
     { type: 'notify', vatID: leftVatID, kpid: barP },
   ]);
+  t.deepEqual(c.dump().acceptanceQueue, []);
 
   await stepGC(); // notify
 

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -275,7 +275,7 @@ test.serial('bootstrap export', async t => {
   }
 
   t.deepEqual(c.dump().log, []);
-  for (let i = 0; i < 7; i += 1) {
+  for (let i = 0; i < 6; i += 1) {
     // eslint-disable-next-line no-await-in-loop
     await stepGC(); // vat starts
   }
@@ -309,6 +309,7 @@ test.serial('bootstrap export', async t => {
     },
   ]);
 
+  await stepGC(); // dropExports
   await stepGC(); // message foo
   const barP = 'kp42';
   t.deepEqual(c.dump().log, ['bootstrap.obj0.bootstrap()', 'left.foo 1']);

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -67,7 +67,8 @@ async function simpleCall(t) {
 
   // vat1:o+0 will map to ko21
   controller.queueToVatRoot('vat1', 'foo', capdata('args'));
-  t.deepEqual(controller.dump().runQueue, [
+  t.deepEqual(controller.dump().runQueue, []);
+  t.deepEqual(controller.dump().acceptanceQueue, [
     { type: 'startVat', vatID: 'v2' },
     { type: 'startVat', vatID: 'v4' },
     { type: 'startVat', vatID: 'v5' },
@@ -229,7 +230,8 @@ test.serial('bootstrap export', async t => {
   ];
   checkKT(t, c, kt);
 
-  t.deepEqual(c.dump().runQueue, [
+  t.deepEqual(c.dump().runQueue, []);
+  t.deepEqual(c.dump().acceptanceQueue, [
     { type: 'startVat', vatID: 'v1' },
     { type: 'startVat', vatID: 'v2' },
     { type: 'startVat', vatID: 'v3' },

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -119,7 +119,9 @@ test('bootstrap', async t => {
   const c = await buildVatController(config);
   for (let i = 0; i < 5; i += 1) {
     // eslint-disable-next-line no-await-in-loop
-    await c.step(); // vat starts
+    await c.step(); // vat start acceptance
+    // eslint-disable-next-line no-await-in-loop
+    await c.step(); // vat start deliver
   }
   t.deepEqual(c.dump().log, ['bootstrap called']);
 });
@@ -133,7 +135,9 @@ test('XS bootstrap', async t => {
   const c = await buildVatController(config, [], { hostStorage });
   for (let i = 0; i < 5; i += 1) {
     // eslint-disable-next-line no-await-in-loop
-    await c.step(); // vat starts
+    await c.step(); // vat start acceptance
+    // eslint-disable-next-line no-await-in-loop
+    await c.step(); // vat start deliver
   }
   t.deepEqual(c.dump().log, ['bootstrap called']);
   t.is(
@@ -170,7 +174,9 @@ test('static vats are unmetered on XS', async t => {
   );
   for (let i = 0; i < 5; i += 1) {
     // eslint-disable-next-line no-await-in-loop
-    await c.step(); // vat starts
+    await c.step(); // vat start acceptance
+    // eslint-disable-next-line no-await-in-loop
+    await c.step(); // vat start deliver
   }
   t.deepEqual(c.dump().log, ['bootstrap called']);
   t.deepEqual(limited, [false, false, false, false]);
@@ -261,15 +267,19 @@ test.serial('bootstrap export', async t => {
     },
   ]);
 
-  // this test was designed before GC, and wants to single-step the kernel,
-  // but doesn't care about the GC action steps, so we use this helper
-  // function
+  // this test was designed before GC and acceptance queues, and wants to
+  // single-step the kernel, but doesn't care about the GC action steps,
+  // or the temporary acceptance queue, so we use this helper function
   async function stepGC() {
     while (c.dump().gcActions.length) {
       // eslint-disable-next-line no-await-in-loop
       await c.step();
     }
     while (c.dump().reapQueue.length) {
+      // eslint-disable-next-line no-await-in-loop
+      await c.step();
+    }
+    while (c.dump().acceptanceQueue.length) {
       // eslint-disable-next-line no-await-in-loop
       await c.step();
     }

--- a/packages/SwingSet/test/test-gc-kernel.js
+++ b/packages/SwingSet/test/test-gc-kernel.js
@@ -324,7 +324,8 @@ async function prep(t, options = {}) {
 
   if (sendToSelf) {
     kernel.queueToKref(alice, 'one-alice', capdataOneSlot(alice), 'none');
-    await kernel.step();
+    await kernel.step(); // acceptance
+    await kernel.step(); // deliver
   }
 
   // look up amy's kref
@@ -424,7 +425,8 @@ async function testDropAndRetire(t, mode) {
   const { amy, bob, vatA, vrefs } = p;
   // tell bob to both drop and retire amy
   p.kernel.queueToKref(bob, 'drop and retire', capargs([]), 'none');
-  await p.kernel.step();
+  await p.kernel.step(); // acceptance
+  await p.kernel.step(); // deliver
   t.true(p.aliceClistPresent());
   t.false(p.bobClistPresent());
   t.false(p.amyRetired());
@@ -476,7 +478,8 @@ async function testDrop(t, mode) {
 
   // tell bob to drop amy, but not retire
   p.kernel.queueToKref(bob, 'drop', capargs([]), 'none');
-  await p.kernel.step();
+  await p.kernel.step(); // acceptance
+  await p.kernel.step(); // deliver
   t.true(p.aliceClistPresent());
   t.true(p.bobClistPresent());
   t.false(p.amyRetired());
@@ -505,7 +508,8 @@ async function testDrop(t, mode) {
     if (mode === '24A') {
       // 24A: alice emits retire first
       p.kernel.queueToKref(alice, 'retire', capargs([]), 'none');
-      await p.kernel.step();
+      await p.kernel.step(); // acceptance
+      await p.kernel.step(); // deliver
       // that deletes the kobj and queues a retire to the importers (bob)
       t.false(p.aliceClistPresent());
       t.true(p.bobClistPresent());
@@ -515,7 +519,8 @@ async function testDrop(t, mode) {
       // 24B: bob emits retire first
       // console.log(`++ telling bob to retire first`);
       p.kernel.queueToKref(bob, 'retire', capargs([]), 'none');
-      await p.kernel.step();
+      await p.kernel.step(); // acceptance
+      await p.kernel.step(); // deliver
       // that was the last importer: queue a retire to the exporter
       t.true(p.aliceClistPresent());
       t.false(p.bobClistPresent());
@@ -621,7 +626,8 @@ test('two importers both drop+retire', async t => {
   const { amy, bob, carol, vatA, vrefs } = p;
   // tell bob to drop+retire amy
   p.kernel.queueToKref(bob, 'drop and retire', capargs([]), 'none');
-  await p.kernel.step();
+  await p.kernel.step(); // acceptance
+  await p.kernel.step(); // deliver
   t.deepEqual(
     p.logB.shift(),
     makeMessage(vrefs.bobForBob, 'drop and retire', capargs([])),
@@ -654,7 +660,8 @@ test('two importers both drop but not retire', async t => {
   const { amy, bob, carol, vatA, vatB, vatC, vrefs } = p;
   // tell bob to drop amy, but not retire
   p.kernel.queueToKref(bob, 'drop', capargs([]), 'none');
-  await p.kernel.step();
+  await p.kernel.step(); // acceptance
+  await p.kernel.step(); // deliver
   t.deepEqual(
     p.logB.shift(),
     makeMessage(vrefs.bobForBob, 'drop', capargs([])),
@@ -667,7 +674,8 @@ test('two importers both drop but not retire', async t => {
   p.gcActionsAre([]);
   // carol drops amy too
   p.kernel.queueToKref(carol, 'drop', capargs([]), 'none');
-  await p.kernel.step();
+  await p.kernel.step(); // acceptance
+  await p.kernel.step(); // deliver
   t.deepEqual(
     p.logC.shift(),
     makeMessage(vrefs.carolForCarol, 'drop', capargs([])),
@@ -714,7 +722,8 @@ test('two importers: drop+retire, cross-import, drop+retire', async t => {
 
   // tell carol to drop+retire amy
   p.kernel.queueToKref(carol, 'drop and retire', capargs([]), 'none');
-  await p.kernel.step();
+  await p.kernel.step(); // acceptance
+  await p.kernel.step(); // deliver
   t.deepEqual(
     p.logC.shift(),
     makeMessage(vrefs.carolForCarol, 'drop and retire', capargs([])),
@@ -747,7 +756,8 @@ test('two importers: drop+retire, cross-import, drop+retire', async t => {
 
   // bob drops+retires
   p.kernel.queueToKref(bob, 'drop and retire', capargs([]), 'none');
-  await p.kernel.step();
+  await p.kernel.step(); // acceptance
+  await p.kernel.step(); // deliver
   t.deepEqual(
     p.logB.shift(),
     makeMessage(vrefs.bobForBob, 'drop and retire', capargs([])),
@@ -791,7 +801,8 @@ test('promise resolution holds the only reference', async t => {
   // step far enough to retire the GC actions
 
   // there should be a notify(carol) on the queue, and no GC actions
-  await p.kernel.step();
+  await p.kernel.step(); // acceptance
+  await p.kernel.step(); // deliver
 
   // amy should now be held alive by only the resolved promise data
   t.true(p.aliceClistPresent());
@@ -809,7 +820,8 @@ test('promise resolution holds the only reference', async t => {
 
   // when the notify(carol) runs, carol should acquire a reference, and the
   // resolved promise goes away, so the refcount should be back to 1
-  await p.kernel.step();
+  await p.kernel.step(); // acceptance
+  await p.kernel.step(); // deliver
   t.true(p.aliceClistPresent());
   t.false(p.bobClistPresent());
   t.true(p.carolClistPresent());
@@ -872,7 +884,8 @@ test('promise queue holds the only reference, resolved', async t => {
   // tell carol to resolve the promise (to herself), transferring
   // 'queued-message()' from the promise queue to the regular run-queue
   p.kernel.queueToKref(carol, 'resolve-result', capargs([]), 'none');
-  await p.kernel.step();
+  await p.kernel.step(); // acceptance
+  await p.kernel.step(); // deliver
   t.deepEqual(
     p.logC.shift(),
     makeMessage(vrefs.carolForCarol, 'resolve-result', capargs([])),
@@ -984,7 +997,8 @@ test('message to self', async t => {
   p.gcActionsAre([]);
 
   // deliver the message-to-self, which should drop the refcount to 0
-  await p.kernel.step();
+  await p.kernel.step(); // acceptance
+  await p.kernel.step(); // deliver
   t.true(p.aliceClistPresent());
   t.false(p.amyRetired());
   t.deepEqual(dumpObjects(p.kernel)[amy], [vatA, 0, 0]);

--- a/packages/SwingSet/test/test-kernel.js
+++ b/packages/SwingSet/test/test-kernel.js
@@ -309,7 +309,8 @@ test('outbound call', async t => {
   t.deepEqual(log.shift(), ['d1', 'o+1', 'foo', capdata('args')]);
   t.deepEqual(log, []);
 
-  t.deepEqual(kernel.dump().runQueue, [
+  t.deepEqual(kernel.dump().runQueue, []);
+  t.deepEqual(kernel.dump().acceptanceQueue, [
     {
       type: 'send',
       target: vat2Obj5,
@@ -519,7 +520,8 @@ test('three-party', async t => {
   t.deepEqual(log.shift(), ['vatA', 'promiseID', 'p+5']);
   t.deepEqual(log, []);
 
-  t.deepEqual(kernel.dump().runQueue, [
+  t.deepEqual(kernel.dump().runQueue, []);
+  t.deepEqual(kernel.dump().acceptanceQueue, [
     {
       type: 'send',
       target: bob,

--- a/packages/SwingSet/test/test-kernel.js
+++ b/packages/SwingSet/test/test-kernel.js
@@ -78,7 +78,7 @@ test('simple call', async t => {
 
   const o1 = kernel.addExport(vat1, 'o+1');
   kernel.queueToKref(o1, 'foo', capdata('args'));
-  t.deepEqual(kernel.dump().runQueue, [
+  t.deepEqual(kernel.dump().acceptanceQueue, [
     {
       type: 'send',
       target: 'ko20',
@@ -182,7 +182,7 @@ test('map inbound', async t => {
   const koFor5 = kernel.addExport(vat1, 'o+5');
   const koFor6 = kernel.addExport(vat2, 'o+6');
   kernel.queueToKref(o1, 'foo', capdata('args', [koFor5, koFor6]));
-  t.deepEqual(kernel.dump().runQueue, [
+  t.deepEqual(kernel.dump().acceptanceQueue, [
     {
       type: 'send',
       target: o1,
@@ -291,7 +291,7 @@ test('outbound call', async t => {
   const o1 = kernel.addExport(vat1, 'o+1');
   kernel.queueToKref(o1, 'foo', capdata('args'));
   t.deepEqual(log, []);
-  t.deepEqual(kernel.dump().runQueue, [
+  t.deepEqual(kernel.dump().acceptanceQueue, [
     {
       type: 'send',
       target: t1,
@@ -621,7 +621,7 @@ test('transfer promise', async t => {
 
   // sending a promise should arrive as a promise
   syscallA.send(B, 'foo1', capdata('args', [pr1]));
-  t.deepEqual(kernel.dump().runQueue, [
+  t.deepEqual(kernel.dump().acceptanceQueue, [
     {
       type: 'send',
       target: bob,
@@ -769,7 +769,7 @@ test('promise resolveToData', async t => {
   syscallB.resolve([[pForB, false, capdata('"args"', [aliceForA])]]);
   // this causes a notify message to be queued
   t.deepEqual(log, []); // no other dispatch calls
-  t.deepEqual(kernel.dump().runQueue, [
+  t.deepEqual(kernel.dump().acceptanceQueue, [
     {
       type: 'notify',
       vatID: vatA,
@@ -843,7 +843,7 @@ test('promise resolveToPresence', async t => {
 
   syscallB.resolve([[pForB, false, capargs(slot0arg, [bobForB])]]);
   t.deepEqual(log, []); // no other dispatch calls
-  t.deepEqual(kernel.dump().runQueue, [
+  t.deepEqual(kernel.dump().acceptanceQueue, [
     {
       type: 'notify',
       vatID: vatA,
@@ -861,6 +861,7 @@ test('promise resolveToPresence', async t => {
   ]);
   t.deepEqual(log, []); // no other dispatch calls
   t.deepEqual(kernel.dump().runQueue, []);
+  t.deepEqual(kernel.dump().acceptanceQueue, []);
 });
 
 test('promise reject', async t => {
@@ -914,7 +915,7 @@ test('promise reject', async t => {
   syscallB.resolve([[pForB, true, capdata('"args"', [aliceForA])]]);
   // this causes a notify message to be queued
   t.deepEqual(log, []); // no other dispatch calls
-  t.deepEqual(kernel.dump().runQueue, [
+  t.deepEqual(kernel.dump().acceptanceQueue, [
     {
       type: 'notify',
       vatID: vatA,
@@ -930,6 +931,7 @@ test('promise reject', async t => {
   ]);
   t.deepEqual(log, []); // no other dispatch calls
   t.deepEqual(kernel.dump().runQueue, []);
+  t.deepEqual(kernel.dump().acceptanceQueue, []);
 });
 
 test('transcript', async t => {

--- a/packages/SwingSet/test/test-state.js
+++ b/packages/SwingSet/test/test-state.js
@@ -265,6 +265,7 @@ test('kernel state', async t => {
     ['initialized', 'true'],
     ['gcActions', '[]'],
     ['runQueue', '[]'],
+    ['acceptanceQueue', '[]'],
     ['reapQueue', '[]'],
     ['vat.nextID', '1'],
     ['vat.names', '[]'],
@@ -296,6 +297,7 @@ test('kernelKeeper vat names', async t => {
     ['crankNumber', '0'],
     ['gcActions', '[]'],
     ['runQueue', '[]'],
+    ['acceptanceQueue', '[]'],
     ['reapQueue', '[]'],
     ['vat.nextID', '3'],
     ['vat.names', JSON.stringify(['vatname5', 'Frank'])],
@@ -343,6 +345,7 @@ test('kernelKeeper device names', async t => {
     ['crankNumber', '0'],
     ['gcActions', '[]'],
     ['runQueue', '[]'],
+    ['acceptanceQueue', '[]'],
     ['reapQueue', '[]'],
     ['vat.nextID', '1'],
     ['vat.names', '[]'],
@@ -394,19 +397,25 @@ test('kernelKeeper runQueue', async t => {
   k.commitCrank();
   const k2 = duplicateKeeper(getState);
 
-  t.deepEqual(k.getNextMsg(), { type: 'send', stuff: 'awesome' });
+  t.deepEqual(k.getNextRunQueueMsg(), { type: 'send', stuff: 'awesome' });
   t.falsy(k.isRunQueueEmpty());
   t.is(k.getRunQueueLength(), 1);
 
-  t.deepEqual(k.getNextMsg(), { type: 'notify', stuff: 'notifawesome' });
+  t.deepEqual(k.getNextRunQueueMsg(), {
+    type: 'notify',
+    stuff: 'notifawesome',
+  });
   t.truthy(k.isRunQueueEmpty());
   t.is(k.getRunQueueLength(), 0);
 
-  t.deepEqual(k2.getNextMsg(), { type: 'send', stuff: 'awesome' });
+  t.deepEqual(k2.getNextRunQueueMsg(), { type: 'send', stuff: 'awesome' });
   t.falsy(k2.isRunQueueEmpty());
   t.is(k2.getRunQueueLength(), 1);
 
-  t.deepEqual(k2.getNextMsg(), { type: 'notify', stuff: 'notifawesome' });
+  t.deepEqual(k2.getNextRunQueueMsg(), {
+    type: 'notify',
+    stuff: 'notifawesome',
+  });
   t.truthy(k2.isRunQueueEmpty());
   t.is(k2.getRunQueueLength(), 0);
 });
@@ -520,6 +529,7 @@ test('kernelKeeper promises', async t => {
     ['device.names', '[]'],
     ['gcActions', '[]'],
     ['runQueue', JSON.stringify(expectedRunqueue)],
+    ['acceptanceQueue', '[]'],
     ['reapQueue', '[]'],
     ['kd.nextID', '30'],
     ['ko.nextID', '21'],
@@ -692,7 +702,7 @@ test('crankhash', t => {
   k.commitCrank();
   // the initial state additions happen to hash to this:
   const oldActivityhash =
-    '1bde96fbe196090dc773e8b9d07a22a0a83e2fb3b4295efb2d8f863c9c8831fb';
+    'f4aa6b9a21148ce1bbb233224f3812a52f88e72ea097fc48bed2a04d0e60925d';
   t.is(store.kvStore.get('activityhash'), oldActivityhash);
 
   k.kvStore.set('one', '1');
@@ -710,7 +720,7 @@ test('crankhash', t => {
   const expActivityhash = h.digest('hex');
   t.is(
     expActivityhash,
-    'c80eaa61ecad76d48f2a2ab7af42b400505e3ad5bebfb3643a8ff28cc3494e89',
+    '98ca436fbb912599ef9a6e26fc20a3c228dd2d2ccdcb2a622e8bf0071a139f10',
   );
 
   const { crankhash, activityhash } = k.commitCrank();

--- a/packages/SwingSet/test/test-state.js
+++ b/packages/SwingSet/test/test-state.js
@@ -487,17 +487,17 @@ test('kernelKeeper promises', async t => {
   k.addSubscriberToPromise(p1, 'v3');
   t.deepEqual(k.getKernelPromise(p1).subscribers, ['v3', 'v5']);
 
-  const expectedRunqueue = [];
+  const expectedAcceptanceQueue = [];
   const m1 = { method: 'm1', args: { body: '', slots: [] } };
   k.addMessageToPromiseQueue(p1, m1);
   t.deepEqual(k.getKernelPromise(p1).refCount, 1);
-  expectedRunqueue.push({ type: 'send', target: 'kp40', msg: m1 });
+  expectedAcceptanceQueue.push({ type: 'send', target: 'kp40', msg: m1 });
 
   const m2 = { method: 'm2', args: { body: '', slots: [] } };
   k.addMessageToPromiseQueue(p1, m2);
   t.deepEqual(k.getKernelPromise(p1).queue, [m1, m2]);
   t.deepEqual(k.getKernelPromise(p1).refCount, 2);
-  expectedRunqueue.push({ type: 'send', target: 'kp40', msg: m2 });
+  expectedAcceptanceQueue.push({ type: 'send', target: 'kp40', msg: m2 });
 
   k.commitCrank();
   k2 = duplicateKeeper(getState);
@@ -528,8 +528,8 @@ test('kernelKeeper promises', async t => {
     ['vat.dynamicIDs', '[]'],
     ['device.names', '[]'],
     ['gcActions', '[]'],
-    ['runQueue', JSON.stringify(expectedRunqueue)],
-    ['acceptanceQueue', '[]'],
+    ['runQueue', '[]'],
+    ['acceptanceQueue', JSON.stringify(expectedAcceptanceQueue)],
     ['reapQueue', '[]'],
     ['kd.nextID', '30'],
     ['ko.nextID', '21'],

--- a/packages/SwingSet/test/test-transcript-light.js
+++ b/packages/SwingSet/test/test-transcript-light.js
@@ -14,7 +14,8 @@ test('transcript-light load', async t => {
   const c = await buildVatController(config, ['one'], { hostStorage });
   const state0 = getAllState(hostStorage);
   t.is(state0.kvStuff.initialized, 'true');
-  t.not(state0.kvStuff.runQueue, '[]');
+  t.is(state0.kvStuff.runQueue, '[]');
+  t.not(state0.kvStuff.acceptanceQueue, '[]');
 
   await c.step();
   const state1 = getAllState(hostStorage);

--- a/packages/SwingSet/tools/vat.js
+++ b/packages/SwingSet/tools/vat.js
@@ -45,6 +45,8 @@ async function main() {
       deepLog(d.promises);
       console.log('Run Queue:');
       deepLog(d.runQueue);
+      console.log('Acceptance Queue:');
+      deepLog(d.acceptanceQueue);
     };
     r.context.dump2 = () => controller.dump();
     r.context.run = () => {

--- a/packages/cosmic-swingset/src/launch-chain.js
+++ b/packages/cosmic-swingset/src/launch-chain.js
@@ -123,6 +123,9 @@ function computronCounter({
       totalBeans += failedComputrons * xsnapComputron;
       return totalBeans < blockComputeLimit;
     },
+    emptyCrank() {
+      return true;
+    },
   });
   return policy;
 }
@@ -132,6 +135,7 @@ function neverStop() {
     vatCreated: () => true,
     crankComplete: () => true,
     crankFailed: () => true,
+    emptyCrank: () => true,
   });
 }
 


### PR DESCRIPTION
refs: #3465

Best reviewed commit by commit

## Description

This is a preliminary refactor splitting the run-queue in 2 before #3465. All `send`, `resolve` and `subscribe` syscalls, as well as kernel initiated deliveries are first enqueued to an "acceptance" queue, which is drained into the usual "run" queue in its own cranks.

The next step (follow-up PR) is to change the handling of the `resolve` and `subscribe` syscalls so that they are enqueued onto the acceptance queue first instead of mutating promise state immediately (except for reference counting). Processing those and `send` events from the acceptance queue would then be as follow:
- message `send` onto promises are enqueued onto the promise queue or run-queue, depending on the state of the promise, instead of going through the run-queue as-is (see #4542). `send` onto objects are simply moved to the run-queue
- `resolve` would queue notifications on the run-queue for subscribers, and move `send` from the promise queue to the run-queue
- `subscribe` would either add the vat to the promise subscriber list, or enqueue a notify back to the vat, depending on the promise state

The goal is to only have messages with a known destination vat pending on the run-queue, so that the run (aka delivery) and acceptance queues can be split per vat according to https://github.com/Agoric/agoric-sdk/issues/3465#issuecomment-1041052494

The `maybeProcessNextMessage` is awkward and a bit of a temporary hack. I'll rethink handling of messages once processing the acceptance queue does more than simply re-queueing the message.

This change also introduces an `emptyCrank` call to the run-policy. It was already possible to have empty cranks (that did no delivery before), e.g. in the case of a send queued on an unresolved promise. With acceptance queue processing this is now much more common.

This PR does not change anything to vat termination, which will still be processed at the end of the current crank. Currently the delivery to vat-admin informing of the vat termination is enqueued, like every other delivery generated from the kernel, onto the acceptance queue, thus after any pending syscall events generated by the exited vat. In the future with queues per vat, we can imagine that kernel initiated deliveries use their own acceptance queue, or are queued directly onto the target's queue.

This PR also contains a fix for a test inconsistency described in https://github.com/Agoric/agoric-sdk/pull/4575/files#r809781876

### Security Considerations

None

### Documentation Considerations

This change should only impact the number of cranks necessary to process messages, but nothing else.

### Testing Considerations

Tests updated to account for different amount of cranks, and the new state of the queue, but no specific tests were added since the existing tests seem to cover the updated code already.
