### PR TITLE
test(swingset): use test.serial on GC-sensitive test

### DIFF
--- a/packages/SwingSet/test/test-activityhash-vs-start.js
+++ b/packages/SwingSet/test/test-activityhash-vs-start.js
@@ -11,7 +11,12 @@ import { buildTimer } from '../src/devices/timer.js';
 const TimerSrc = new URL('../src/devices/timer-src.js', import.meta.url)
   .pathname;
 
-test('restarting kernel does not change activityhash', async t => {
+// all tests that are sensitive to GC timing (which means anything that
+// exercises transcript replay or looks at activityHash) need to use
+// test.serial or config.defaultManagerType='xsnap', until we figure out why
+// gcAndFinalize sometimes doesn't work (details in #3240 and #4617)
+
+test.serial('restarting kernel does not change activityhash', async t => {
   const sourceSpec = new URL('vat-empty-setup.js', import.meta.url).pathname;
   const config = {
     bootstrap: 'bootstrap',
@@ -87,7 +92,7 @@ test('restarting kernel does not change activityhash', async t => {
   t.is(c1ah, c2ah);
 });
 
-test('comms initialize is deterministic', async t => {
+test.serial('comms initialize is deterministic', async t => {
   // bug #3726: comms was calling vatstoreGet('initialize') and
   // vatstoreSet('meta.o+0') during the first message after process restart,
   // which makes it a nondeterministic function of the input events.


### PR DESCRIPTION
We don't understand the root cause, but our `gcAndFinalize()` doesn't always
work when 1: run on Node.js (not xsnap) and 2: AVA allows tests to run in
parallel. The problem happens somewhat more frequently on 14.x, at least in
CI.

These two tests exercise transcript replay (which needs GC to happen the same
way for both the original delivery and the replay), and compare the
activityHash (which, of course, is sensitive to all syscalls made, including
GC syscalls). They sometimes failed in CI.

We don't fully understand why gcAndFinalize doesn't work, but serializing the
tests (with test.serial) seems to address the problem.

refs #3240
closes #4617
