### PR TITLE
chore: remove unused dependencies resulting in package cycles

### DIFF
--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -37,7 +37,6 @@
     "@endo/promise-kit": "^0.2.35"
   },
   "devDependencies": {
-    "@agoric/swingset-vat": "^0.25.0",
     "@endo/init": "^0.5.35",
     "@endo/ses-ava": "^0.2.19",
     "ava": "^3.12.1",

--- a/packages/pegasus/package.json
+++ b/packages/pegasus/package.json
@@ -30,7 +30,6 @@
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "dependencies": {
     "@agoric/assert": "^0.3.16",
-    "@agoric/deploy-script-support": "^0.6.2",
     "@agoric/ertp": "^0.13.2",
     "@agoric/eventual-send": "^0.14.1",
     "@agoric/nat": "^4.1.0",

--- a/packages/run-protocol/package.json
+++ b/packages/run-protocol/package.json
@@ -30,7 +30,6 @@
   "homepage": "https://github.com/Agoric/agoric-sdk#readme",
   "dependencies": {
     "@agoric/assert": "^0.3.16",
-    "@agoric/deploy-script-support": "^0.6.2",
     "@agoric/ertp": "^0.13.2",
     "@agoric/eventual-send": "^0.14.1",
     "@agoric/governance": "^0.4.2",

--- a/packages/swing-store/package.json
+++ b/packages/swing-store/package.json
@@ -24,7 +24,6 @@
     "tmp": "^0.2.1"
   },
   "devDependencies": {
-    "@agoric/swing-store": "^0.6.4",
     "@endo/init": "^0.5.35",
     "ava": "^3.12.1",
     "c8": "^7.7.2"

--- a/packages/zoe/package.json
+++ b/packages/zoe/package.json
@@ -43,7 +43,6 @@
     "@agoric/assert": "^0.3.16",
     "@agoric/ertp": "^0.13.2",
     "@agoric/eventual-send": "^0.14.1",
-    "@agoric/governance": "^0.4.2",
     "@agoric/nat": "^4.1.0",
     "@agoric/notifier": "^0.3.34",
     "@agoric/store": "^0.6.9",


### PR DESCRIPTION
## Description

See #4645 . This removes the declared dependencies that were simply unnecessary.

### Before
```
lerna notice cli v3.20.2
lerna WARN ECYCLE Dependency cycles detected, you should fix these!
lerna WARN ECYCLE @agoric/swingset-vat -> @agoric/notifier -> @agoric/swingset-vat
lerna WARN ECYCLE @agoric/deploy-script-support -> @agoric/vats -> @agoric/pegasus -> @agoric/deploy-script-support
lerna WARN ECYCLE @agoric/governance -> @agoric/zoe -> @agoric/governance
lerna WARN ECYCLE @agoric/run-protocol -> (nested cycle: @agoric/deploy-script-support -> @agoric/vats -> @agoric/pegasus -> @agoric/deploy-script-support) -> @agoric/run-protocol
lerna WARN ECYCLE @agoric/store -> (nested cycle: @agoric/swingset-vat -> @agoric/notifier -> @agoric/swingset-vat) -> @agoric/store
lerna WARN ECYCLE @agoric/swing-store -> @agoric/swing-store
lerna WARN ECYCLE @agoric/wallet-backend -> (nested cycle: @agoric/run-protocol -> (nested cycle: @agoric/deploy-script-support -> @agoric/vats -> @agoric/pegasus -> @agoric/deploy-script-support) -> @agoric/run-protocol) -> @agoric/wallet-backend
lerna WARN ECYCLE (nested cycle: @agoric/store -> (nested cycle: @agoric/swingset-vat -> @agoric/notifier -> @agoric/swingset-vat) -> @agoric/store) -> (nested cycle: @agoric/store -> (nested cycle: @agoric/swingset-vat -> @agoric/notifier -> @agoric/swingset-vat) -> @agoric/store)
lerna WARN ECYCLE (nested cycle: @agoric/wallet-backend -> (nested cycle: @agoric/run-protocol -> (nested cycle: @agoric/deploy-script-support -> @agoric/vats -> @agoric/pegasus -> @agoric/deploy-script-support) -> @agoric/run-protocol) -> @agoric/wallet-backend) -> (nested cycle: @agoric/wallet-backend -> (nested cycle: @agoric/run-protocol -> (nested cycle: @agoric/deploy-script-support -> @agoric/vats -> @agoric/pegasus -> @agoric/deploy-script-support) -> @agoric/run-protocol) -> @agoric/wallet-backend)
```

### After
```
lerna WARN ECYCLE Dependency cycles detected, you should fix these!
lerna WARN ECYCLE @agoric/swingset-vat -> @agoric/store -> @agoric/swingset-vat
lerna WARN ECYCLE @agoric/pegasus -> @agoric/vats -> @agoric/pegasus
lerna WARN ECYCLE @agoric/run-protocol -> (nested cycle: @agoric/pegasus -> @agoric/vats -> @agoric/pegasus) -> @agoric/run-protocol
lerna WARN ECYCLE @agoric/wallet-backend -> (nested cycle: @agoric/run-protocol -> (nested cycle: @agoric/pegasus -> @agoric/vats -> @agoric/pegasus) -> @agoric/run-protocol) -> @agoric/wallet-backend
lerna WARN ECYCLE (nested cycle: @agoric/wallet-backend -> (nested cycle: @agoric/run-protocol -> (nested cycle: @agoric/pegasus -> @agoric/vats -> @agoric/pegasus) -> @agoric/run-protocol) -> @agoric/wallet-backend) -> (nested cycle: @agoric/wallet-backend -> (nested cycle: @agoric/run-protocol -> (nested cycle: @agoric/pegasus -> @agoric/vats -> @agoric/pegasus) -> @agoric/run-protocol) -> @agoric/wallet-backend)
```

### Security Considerations

Possible improvement from eliminating unused imports.

### Documentation Considerations

--

### Testing Considerations

--