### PR TITLE
ci: disable loadgen integration

### DIFF
--- a/packages/deployment/scripts/integration-test.sh
+++ b/packages/deployment/scripts/integration-test.sh
@@ -28,7 +28,7 @@ DOCKER_VOLUMES="$(cd "$thisdir/../../.." > /dev/null && pwd -P):/usr/src/agoric-
 AG_COSMOS_START_ARGS="--log_level=info --trace-store=.ag-chain-cosmos/data/kvstore.trace" \
   "$thisdir/setup.sh" bootstrap ${1+"$@"}
 
-if [ -d /usr/src/testnet-load-generator ]
+if false && [ -d /usr/src/testnet-load-generator ]
 then
   /usr/src/agoric-sdk/packages/deployment/scripts/setup.sh show-config > "$RESULTSDIR/network-config"
   cp ag-chain-cosmos/data/genesis.json "$RESULTSDIR/genesis.json"


### PR DESCRIPTION
refs: #4634 

## Description

While working on a fix to make the loadgen compatible again with the recent economy changes, disable the loadgen CI to avoid spamming everyone when this test fails on master.