### PR TITLE
test(zoe): switch to E(zoe).installBundleID()

### DIFF
--- a/packages/zoe/test/swingsetTests/brokenContracts/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/brokenContracts/bootstrap.js
@@ -3,9 +3,6 @@
 import { E } from '@agoric/eventual-send';
 import { Far } from '@endo/marshal';
 import { makeIssuerKit, AmountMath } from '@agoric/ertp';
-/* eslint-disable import/extensions, import/no-unresolved */
-import crashingAutoRefund from './bundle-crashingAutoRefund';
-/* eslint-enable import/extensions, import/no-unresolved */
 
 const setupBasicMints = () => {
   const all = [
@@ -40,14 +37,17 @@ const makeVats = (log, vats, zoe, installations, startingValues) => {
 };
 
 export function buildRootObject(vatPowers, vatParameters) {
+  const { D } = vatPowers;
   return Far('root', {
     async bootstrap(vats, devices) {
       const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
         devices.vatAdmin,
       );
       const zoe = await E(vats.zoe).buildZoe(vatAdminSvc);
+      const bcap = await E(vatAdminSvc).getNamedBundleCap('crashingAutoRefund');
+      const id = D(bcap).getBundleID();
       const installations = {
-        crashAutoRefund: await E(zoe).install(crashingAutoRefund.bundle),
+        crashAutoRefund: await E(zoe).installBundleID(id),
       };
 
       const [testName, startingValues] = vatParameters.argv;

--- a/packages/zoe/test/swingsetTests/makeKind/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/makeKind/bootstrap.js
@@ -1,16 +1,20 @@
 import { E } from '@agoric/eventual-send';
 import { Far } from '@endo/marshal';
 
-export function buildRootObject(vatPowers, vatParameters) {
-  const { contractBundles: cb } = vatParameters;
+export function buildRootObject(vatPowers) {
+  const { D } = vatPowers;
   return Far('root', {
     async bootstrap(vats, devices) {
       const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
         devices.vatAdmin,
       );
       const zoe = await E(vats.zoe).buildZoe(vatAdminSvc);
+      const bcap = await E(vatAdminSvc).getNamedBundleCap(
+        'minimalMakeKindContract',
+      );
+      const id = D(bcap).getBundleID();
       const installations = {
-        minimalMakeKind: await E(zoe).install(cb.minimalMakeKindContract),
+        minimalMakeKind: await E(zoe).installBundleID(id),
       };
 
       const aliceP = E(vats.alice).build(zoe, installations);

--- a/packages/zoe/test/swingsetTests/makeKind/test-makeKind.js
+++ b/packages/zoe/test/swingsetTests/makeKind/test-makeKind.js
@@ -33,7 +33,7 @@ test.before(async t => {
       }
       const source = `${dirname}/../../${contractPath}`;
       const bundle = await bundleSource(source);
-      contractBundles[bundleName] = bundle;
+      contractBundles[bundleName] = { bundle };
     }),
   );
   const step3 = Date.now();
@@ -49,10 +49,10 @@ test.before(async t => {
   const bootstrapSource = `${dirname}/bootstrap.js`;
   vats.bootstrap = {
     bundle: await bundleSource(bootstrapSource),
-    parameters: { contractBundles }, // argv will be added to this
+    parameters: {}, // argv will be added to this
   };
   const config = { bootstrap: 'bootstrap', vats };
-  config.bundles = { zcf: { bundle: zcfBundle } };
+  config.bundles = { zcf: { bundle: zcfBundle }, ...contractBundles };
   config.defaultManagerType = 'xs-worker';
 
   const step4 = Date.now();

--- a/packages/zoe/test/swingsetTests/offerArgs/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/offerArgs/bootstrap.js
@@ -1,16 +1,20 @@
 import { E } from '@agoric/eventual-send';
 import { Far } from '@endo/marshal';
 
-export function buildRootObject(vatPowers, vatParameters) {
-  const { contractBundles: cb } = vatParameters;
+export function buildRootObject(vatPowers) {
+  const { D } = vatPowers;
   return Far('root', {
     async bootstrap(vats, devices) {
       const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
         devices.vatAdmin,
       );
       const zoe = await E(vats.zoe).buildZoe(vatAdminSvc);
+      const bcap = await E(vatAdminSvc).getNamedBundleCap(
+        'offerArgsUsageContract',
+      );
+      const id = D(bcap).getBundleID();
       const installations = {
-        offerArgsUsageContract: await E(zoe).install(cb.offerArgsUsageContract),
+        offerArgsUsageContract: await E(zoe).installBundleID(id),
       };
 
       const aliceP = E(vats.alice).build(zoe, installations);

--- a/packages/zoe/test/swingsetTests/offerArgs/test-offerArgs.js
+++ b/packages/zoe/test/swingsetTests/offerArgs/test-offerArgs.js
@@ -33,7 +33,7 @@ test.before(async t => {
       }
       const source = `${dirname}/../../${contractPath}`;
       const bundle = await bundleSource(source);
-      contractBundles[bundleName] = bundle;
+      contractBundles[bundleName] = { bundle };
     }),
   );
   const step3 = Date.now();
@@ -49,10 +49,10 @@ test.before(async t => {
   const bootstrapSource = `${dirname}/bootstrap.js`;
   vats.bootstrap = {
     bundle: await bundleSource(bootstrapSource),
-    parameters: { contractBundles }, // argv will be added to this
+    parameters: {}, // argv will be added to this
   };
   const config = { bootstrap: 'bootstrap', vats };
-  config.bundles = { zcf: { bundle: zcfBundle } };
+  config.bundles = { zcf: { bundle: zcfBundle }, ...contractBundles };
   config.defaultManagerType = 'xs-worker';
 
   const step4 = Date.now();

--- a/packages/zoe/test/swingsetTests/privateArgs/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/privateArgs/bootstrap.js
@@ -1,18 +1,20 @@
 import { E } from '@agoric/eventual-send';
 import { Far } from '@endo/marshal';
 
-export function buildRootObject(vatPowers, vatParameters) {
-  const { contractBundles: cb } = vatParameters;
+export function buildRootObject(vatPowers) {
+  const { D } = vatPowers;
   return Far('root', {
     async bootstrap(vats, devices) {
       const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
         devices.vatAdmin,
       );
       const zoe = await E(vats.zoe).buildZoe(vatAdminSvc);
+      const bcap = await E(vatAdminSvc).getNamedBundleCap(
+        'privateArgsUsageContract',
+      );
+      const id = D(bcap).getBundleID();
       const installations = {
-        privateArgsUsageContract: await E(zoe).install(
-          cb.privateArgsUsageContract,
-        ),
+        privateArgsUsageContract: await E(zoe).installBundleID(id),
       };
 
       const aliceP = E(vats.alice).build(zoe, installations);

--- a/packages/zoe/test/swingsetTests/privateArgs/test-privateArgs.js
+++ b/packages/zoe/test/swingsetTests/privateArgs/test-privateArgs.js
@@ -33,7 +33,7 @@ test.before(async t => {
       }
       const source = `${dirname}/../../${contractPath}`;
       const bundle = await bundleSource(source);
-      contractBundles[bundleName] = bundle;
+      contractBundles[bundleName] = { bundle };
     }),
   );
   const step3 = Date.now();
@@ -49,10 +49,10 @@ test.before(async t => {
   const bootstrapSource = `${dirname}/bootstrap.js`;
   vats.bootstrap = {
     bundle: await bundleSource(bootstrapSource),
-    parameters: { contractBundles }, // argv will be added to this
+    parameters: {}, // argv will be added to this
   };
   const config = { bootstrap: 'bootstrap', vats };
-  config.bundles = { zcf: { bundle: zcfBundle } };
+  config.bundles = { zcf: { bundle: zcfBundle }, ...contractBundles };
   config.defaultManagerType = 'xs-worker';
 
   const step4 = Date.now();

--- a/packages/zoe/test/swingsetTests/runMint/bootstrap.js
+++ b/packages/zoe/test/swingsetTests/runMint/bootstrap.js
@@ -2,17 +2,23 @@ import { E } from '@agoric/eventual-send';
 import { Far } from '@endo/marshal';
 
 export function buildRootObject(vatPowers, vatParameters) {
-  const { contractBundles: cb } = vatParameters;
+  const { D } = vatPowers;
   return Far('root', {
     async bootstrap(vats, devices) {
       const vatAdminSvc = await E(vats.vatAdmin).createVatAdminService(
         devices.vatAdmin,
       );
       const { zoe, feeMintAccess } = await E(vats.zoe).buildZoe(vatAdminSvc);
-      const installations = {
-        runMintContract: await E(zoe).install(cb.runMintContract),
-        offerArgsUsageContract: await E(zoe).install(cb.offerArgsUsageContract),
-      };
+      const installations = {};
+      const installedPs = vatParameters.contractNames.map(name =>
+        E(vatAdminSvc)
+          .getNamedBundleCap(name)
+          .then(bcap => E(zoe).installBundleID(D(bcap).getBundleID()))
+          .then(installation => {
+            installations[name] = installation;
+          }),
+      );
+      await Promise.all(installedPs);
 
       const aliceP = E(vats.alice).build(zoe, installations, feeMintAccess);
       await E(aliceP).runMintTest();

--- a/packages/zoe/test/swingsetTests/runMint/test-runMint.js
+++ b/packages/zoe/test/swingsetTests/runMint/test-runMint.js
@@ -24,6 +24,7 @@ test.before(async t => {
   const kernelBundles = await buildKernelBundles();
   const step2 = Date.now();
   const contractBundles = {};
+  const contractNames = [];
   await Promise.all(
     CONTRACT_FILES.map(async settings => {
       let bundleName;
@@ -36,7 +37,8 @@ test.before(async t => {
       }
       const source = `${dirname}/../../${contractPath}`;
       const bundle = await bundleSource(source);
-      contractBundles[bundleName] = bundle;
+      contractBundles[bundleName] = { bundle };
+      contractNames.push(bundleName);
     }),
   );
   const step3 = Date.now();
@@ -52,10 +54,10 @@ test.before(async t => {
   const bootstrapSource = `${dirname}/bootstrap.js`;
   vats.bootstrap = {
     bundle: await bundleSource(bootstrapSource),
-    parameters: { contractBundles }, // argv will be added to this
+    parameters: { contractNames }, // argv will be added to this
   };
   const config = { bootstrap: 'bootstrap', vats };
-  config.bundles = { zcf: { bundle: zcfBundle } };
+  config.bundles = { zcf: { bundle: zcfBundle }, ...contractBundles };
   config.defaultManagerType = 'xs-worker';
 
   const step4 = Date.now();

--- a/packages/zoe/test/swingsetTests/zoe/test-zoe.js
+++ b/packages/zoe/test/swingsetTests/zoe/test-zoe.js
@@ -35,6 +35,7 @@ test.before(async t => {
   const kernelBundles = await buildKernelBundles();
   const step2 = Date.now();
   const contractBundles = {};
+  const contractNames = [];
   await Promise.all(
     CONTRACT_FILES.map(async settings => {
       let bundleName;
@@ -47,10 +48,11 @@ test.before(async t => {
       }
       const source = `${dirname}/../../../src/contracts/${contractPath}.js`;
       const bundle = await bundleSource(source);
-      contractBundles[bundleName] = bundle;
+      contractBundles[bundleName] = { bundle };
+      contractNames.push(bundleName);
     }),
   );
-  const bundles = { zcf: { bundle: zcfBundle } };
+  const bundles = { zcf: { bundle: zcfBundle }, ...contractBundles };
   const step3 = Date.now();
 
   const vats = {};
@@ -64,7 +66,7 @@ test.before(async t => {
   const bootstrapSource = `${dirname}/bootstrap.js`;
   vats.bootstrap = {
     bundle: await bundleSource(bootstrapSource),
-    parameters: { contractBundles }, // argv will be added to this
+    parameters: { contractNames }, // argv will be added to this
   };
   const config = { bootstrap: 'bootstrap', vats, bundles };
   config.defaultManagerType = 'xs-worker';

--- a/packages/zoe/test/unitTests/contractSupport/test-depositTo.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-depositTo.js
@@ -23,12 +23,15 @@ async function setupContract(moolaIssuer, bucksIssuer) {
   const setJig = jig => {
     testJig = jig;
   };
-  const { zoeService: zoe } = makeZoeKit(makeFakeVatAdmin(setJig).admin);
+  const fakeVatAdmin = makeFakeVatAdmin(setJig);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin.admin);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);
+  fakeVatAdmin.vatAdminState.installBundle('b1-contract', bundle);
+
   // install the contract
-  const installation = await E(zoe).install(bundle);
+  const installation = await E(zoe).installBundleID('b1-contract');
 
   // Alice creates an instance
   const issuerKeywordRecord = harden({

--- a/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-offerTo.js
@@ -27,12 +27,14 @@ const setupContract = async (moolaIssuer, bucksIssuer) => {
   const setJig = jig => {
     instanceToZCF.set(jig.instance, jig.zcf);
   };
-  const { zoeService: zoe } = makeZoeKit(makeFakeVatAdmin(setJig).admin);
+  const fakeVatAdmin = makeFakeVatAdmin(setJig);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin.admin);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);
+  fakeVatAdmin.vatAdminState.installBundle('b1-contract', bundle);
   // install the contract
-  const installation = await E(zoe).install(bundle);
+  const installation = await E(zoe).installBundleID('b1-contract');
 
   // Create TWO instances of the zcfTesterContract which have
   // different keywords

--- a/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-withdrawFrom.js
@@ -27,12 +27,14 @@ async function setupContract(moolaIssuer, bucksIssuer) {
   const setJig = jig => {
     testJig = jig;
   };
-  const { zoeService: zoe } = makeZoeKit(makeFakeVatAdmin(setJig).admin);
+  const fakeVatAdmin = makeFakeVatAdmin(setJig);
+  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin.admin);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);
+  fakeVatAdmin.vatAdminState.installBundle('b1-contract', bundle);
   // install the contract
-  const installation = await E(zoe).install(bundle);
+  const installation = await E(zoe).installBundleID('b1-contract');
 
   // Alice creates an instance
   const issuerKeywordRecord = harden({

--- a/packages/zoe/test/unitTests/contracts/attestation/test-attestation.js
+++ b/packages/zoe/test/unitTests/contracts/attestation/test-attestation.js
@@ -12,7 +12,7 @@ import bundleSource from '@endo/bundle-source';
 import { E } from '@agoric/eventual-send';
 
 import { makeZoeKit } from '../../../../src/zoeService/zoe.js';
-import fakeVatAdmin from '../../../../tools/fakeVatAdmin.js';
+import { makeFakeVatAdmin } from '../../../../tools/fakeVatAdmin.js';
 
 const filename = new URL(import.meta.url).pathname;
 const dirname = path.dirname(filename);
@@ -20,10 +20,12 @@ const dirname = path.dirname(filename);
 const attestationRoot = `${dirname}/../../../../src/contracts/attestation/attestation.js`;
 
 test('attestation contract basic tests', async t => {
+  const { admin: fakeVatAdmin, vatAdminState } = makeFakeVatAdmin();
   const bundle = await bundleSource(attestationRoot);
+  vatAdminState.installBundle('b1-contract', bundle);
 
   const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
-  const installation = await E(zoe).install(bundle);
+  const installation = await E(zoe).installBundleID('b1-contract');
 
   const bldIssuerKit = makeIssuerKit(
     'BLD',

--- a/packages/zoe/test/unitTests/contracts/loan/helpers.js
+++ b/packages/zoe/test/unitTests/contracts/loan/helpers.js
@@ -106,10 +106,8 @@ export const setupLoanUnitTest = async terms => {
     Loan: loanKit.issuer,
   });
 
-  const { zcf, zoe, installation, instance } = await setupZCFTest(
-    issuerKeywordRecord,
-    terms,
-  );
+  const { zcf, zoe, installation, instance, vatAdminState } =
+    await setupZCFTest(issuerKeywordRecord, terms);
 
   return {
     zcf,
@@ -118,6 +116,7 @@ export const setupLoanUnitTest = async terms => {
     loanKit,
     installation,
     instance,
+    vatAdminState,
   };
 };
 
@@ -195,12 +194,14 @@ export const makeAutoswapInstance = async (
   collateralKit,
   loanKit,
   initialLiquidityKeywordRecord,
+  vatAdminState,
 ) => {
   const autoswapRoot = `${dirname}/../../../../src/contracts/autoswap`;
 
   // Create autoswap installation and instance
   const autoswapBundle = await bundleSource(autoswapRoot);
-  const autoswapInstallation = await E(zoe).install(autoswapBundle);
+  vatAdminState.installBundle('b1-autoswap', autoswapBundle);
+  const autoswapInstallation = await E(zoe).installBundleID('b1-autoswap');
 
   const { instance: autoswapInstance, publicFacet } = await E(
     zoe,

--- a/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-borrow.js
@@ -36,7 +36,7 @@ const setupBorrow = async (
   timer = buildManualTimer(console.log),
 ) => {
   const setup = await setupLoanUnitTest();
-  const { zcf, loanKit, collateralKit, zoe } = setup;
+  const { zcf, loanKit, collateralKit, zoe, vatAdminState } = setup;
   // Set up the lender seat
   const maxLoan = AmountMath.make(loanKit.brand, maxLoanValue);
   const { zcfSeat: lenderSeat, userSeat: lenderUserSeat } = await makeSeatKit(
@@ -66,6 +66,7 @@ const setupBorrow = async (
     collateralKit,
     loanKit,
     initialLiquidityKeywordRecord,
+    vatAdminState,
   );
 
   // In the config that the borrow code sees, the periodNotifier has

--- a/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
+++ b/packages/zoe/test/unitTests/contracts/loan/test-loan-e2e.js
@@ -35,13 +35,20 @@ test.todo('loan - lend - wrong exit rule');
 test.todo('loan - lend - must want nothing');
 
 test('loan - lend - exit before borrow', async t => {
-  const { moolaKit: collateralKit, simoleanKit: loanKit, zoe } = setup();
+  const {
+    moolaKit: collateralKit,
+    simoleanKit: loanKit,
+    zoe,
+    vatAdminState,
+  } = setup();
   const bundle = await bundleSource(loanRoot);
-  const installation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-loan', bundle);
+  const installation = await E(zoe).installBundleID('b1-loan');
 
   // Create autoswap installation and instance
   const autoswapBundle = await bundleSource(autoswapRoot);
-  const autoswapInstallation = await E(zoe).install(autoswapBundle);
+  vatAdminState.installBundle('b1-autoswap', autoswapBundle);
+  const autoswapInstallation = await E(zoe).installBundleID('b1-autoswap');
 
   const { instance: autoswapInstance } = await E(zoe).startInstance(
     autoswapInstallation,

--- a/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
+++ b/packages/zoe/test/unitTests/contracts/test-atomicSwap.js
@@ -19,7 +19,8 @@ const atomicSwapRoot = `${dirname}/../../../src/contracts/atomicSwap.js`;
 
 test('zoe - atomicSwap', async t => {
   t.plan(8);
-  const { moolaKit, simoleanKit, moola, simoleans, zoe } = setup();
+  const { moolaKit, simoleanKit, moola, simoleans, zoe, vatAdminState } =
+    setup();
 
   const makeAlice = async moolaPayment => {
     const moolaPurse = await E(moolaKit.issuer).makeEmptyPurse();
@@ -29,7 +30,8 @@ test('zoe - atomicSwap', async t => {
         // pack the contract
         const bundle = await bundleSource(atomicSwapRoot);
         // install the contract
-        const installationP = E(zoe).install(bundle);
+        vatAdminState.installBundle('b1-atomicswap', bundle);
+        const installationP = E(zoe).installBundleID('b1-atomicswap');
         return installationP;
       },
       startInstance: async installation => {
@@ -181,6 +183,7 @@ test('zoe - non-fungible atomicSwap', async t => {
     rpgItems,
     createRpgItem,
     zoe,
+    vatAdminState,
   } = setupNonFungible();
 
   const makeAlice = async aliceCcPayment => {
@@ -191,7 +194,8 @@ test('zoe - non-fungible atomicSwap', async t => {
         // pack the contract
         const bundle = await bundleSource(atomicSwapRoot);
         // install the contract
-        const installationP = E(zoe).install(bundle);
+        vatAdminState.installBundle('b1-atomicswap', bundle);
+        const installationP = E(zoe).installBundleID('b1-atomicswap');
         return installationP;
       },
       startInstance: async installation => {
@@ -339,13 +343,14 @@ test('zoe - non-fungible atomicSwap', async t => {
 // Checking handling of duplicate issuers. I'd have preferred a raffle contract
 test('zoe - atomicSwap like-for-like', async t => {
   t.plan(13);
-  const { moolaIssuer, moolaMint, moola, zoe } = setup();
+  const { moolaIssuer, moolaMint, moola, zoe, vatAdminState } = setup();
   const invitationIssuer = await E(zoe).getInvitationIssuer();
 
   // pack the contract
   const bundle = await bundleSource(atomicSwapRoot);
   // install the contract
-  const installation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-atomicswap', bundle);
+  const installation = await E(zoe).installBundleID('b1-atomicswap');
 
   // Setup Alice
   const aliceMoolaPayment = moolaMint.mintPayment(moola(3n));

--- a/packages/zoe/test/unitTests/contracts/test-auction.js
+++ b/packages/zoe/test/unitTests/contracts/test-auction.js
@@ -9,11 +9,9 @@ import { E } from '@agoric/eventual-send';
 import { Far } from '@endo/marshal';
 import { assert, details as X } from '@agoric/assert';
 
-import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import buildManualTimer from '../../../tools/manualTimer.js';
 import { setup } from '../setupBasicMints.js';
 import { setupMixed } from '../setupMixedMints.js';
-import fakeVatAdmin from '../../../tools/fakeVatAdmin.js';
 
 const filename = new URL(import.meta.url).pathname;
 const dirname = path.dirname(filename);
@@ -22,7 +20,8 @@ const auctionRoot = `${dirname}/../../../src/contracts/auction/index.js`;
 
 test('zoe - secondPriceAuction w/ 3 bids', async t => {
   t.plan(15);
-  const { moolaKit, simoleanKit, moola, simoleans, zoe } = setup();
+  const { moolaKit, simoleanKit, moola, simoleans, zoe, vatAdminState } =
+    setup();
 
   const makeAlice = async (timer, moolaPayment) => {
     const moolaPurse = await E(moolaKit.issuer).makeEmptyPurse();
@@ -32,7 +31,8 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
         // pack the contract
         const bundle = await bundleSource(auctionRoot);
         // install the contract
-        const installationP = E(zoe).install(bundle);
+        vatAdminState.installBundle('b1-auction', bundle);
+        const installationP = E(zoe).installBundleID('b1-auction');
         return installationP;
       },
       startInstance: async installation => {
@@ -247,8 +247,7 @@ test('zoe - secondPriceAuction w/ 3 bids', async t => {
 
 test('zoe - secondPriceAuction - alice tries to exit', async t => {
   t.plan(12);
-  const { moolaR, simoleanR, moola, simoleans } = setup();
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
+  const { moolaR, simoleanR, moola, simoleans, zoe, vatAdminState } = setup();
 
   // Setup Alice
   const aliceMoolaPayment = moolaR.mint.mintPayment(moola(1n));
@@ -268,7 +267,8 @@ test('zoe - secondPriceAuction - alice tries to exit', async t => {
   // Pack the contract.
   const bundle = await bundleSource(auctionRoot);
 
-  const installation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-auction', bundle);
+  const installation = await E(zoe).installBundleID('b1-auction');
   const issuerKeywordRecord = harden({
     Asset: moolaR.issuer,
     Ask: simoleanR.issuer,
@@ -401,8 +401,7 @@ test('zoe - secondPriceAuction - alice tries to exit', async t => {
 
 test('zoe - secondPriceAuction - all bidders try to exit', async t => {
   t.plan(10);
-  const { moolaR, simoleanR, moola, simoleans } = setup();
-  const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
+  const { moolaR, simoleanR, moola, simoleans, zoe, vatAdminState } = setup();
 
   // Setup Alice
   const aliceMoolaPayment = moolaR.mint.mintPayment(moola(1n));
@@ -418,8 +417,8 @@ test('zoe - secondPriceAuction - all bidders try to exit', async t => {
 
   // Pack the contract.
   const bundle = await bundleSource(auctionRoot);
-
-  const installation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-auction', bundle);
+  const installation = await E(zoe).installBundleID('b1-auction');
   const issuerKeywordRecord = harden({
     Asset: moolaR.issuer,
     Ask: simoleanR.issuer,
@@ -526,8 +525,16 @@ test('zoe - secondPriceAuction - all bidders try to exit', async t => {
 // Three bidders with (fungible) moola bid for a CryptoCat
 test('zoe - secondPriceAuction non-fungible asset', async t => {
   t.plan(30);
-  const { ccIssuer, moolaIssuer, ccMint, moolaMint, cryptoCats, moola, zoe } =
-    setupMixed();
+  const {
+    ccIssuer,
+    moolaIssuer,
+    ccMint,
+    moolaMint,
+    cryptoCats,
+    moola,
+    zoe,
+    vatAdminState,
+  } = setupMixed();
   const invitationIssuer = await E(zoe).getInvitationIssuer();
 
   // Setup Alice
@@ -554,8 +561,8 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
 
   // Pack the contract.
   const bundle = await bundleSource(auctionRoot);
-
-  const installation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-auction', bundle);
+  const installation = await E(zoe).installBundleID('b1-auction');
   const issuerKeywordRecord = harden({
     Asset: ccIssuer,
     Ask: moolaIssuer,
@@ -812,7 +819,8 @@ test('zoe - secondPriceAuction non-fungible asset', async t => {
 
 test('zoe - firstPriceAuction w/ 3 bids', async t => {
   t.plan(15);
-  const { moolaKit, simoleanKit, moola, simoleans, zoe } = setup();
+  const { moolaKit, simoleanKit, moola, simoleans, zoe, vatAdminState } =
+    setup();
 
   const makeAlice = async (timer, moolaPayment) => {
     const moolaPurse = await E(moolaKit.issuer).makeEmptyPurse();
@@ -822,7 +830,8 @@ test('zoe - firstPriceAuction w/ 3 bids', async t => {
         // pack the contract
         const bundle = await bundleSource(auctionRoot);
         // install the contract
-        const installationP = E(zoe).install(bundle);
+        vatAdminState.installBundle('b1-auction', bundle);
+        const installationP = E(zoe).installBundleID('b1-auction');
         return installationP;
       },
       startInstance: async installation => {

--- a/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
+++ b/packages/zoe/test/unitTests/contracts/test-automaticRefund.js
@@ -17,10 +17,11 @@ const automaticRefundRoot = `${dirname}/../../../src/contracts/automaticRefund.j
 
 test('zoe - simplest automaticRefund', async t => {
   // Setup zoe and mints
-  const { moolaR, moola, zoe } = setup();
+  const { moolaR, moola, zoe, vatAdminState } = setup();
   // Pack the contract.
   const bundle = await bundleSource(automaticRefundRoot);
-  const installation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-automaticRefund', bundle);
+  const installation = await E(zoe).installBundleID('b1-automaticRefund');
 
   // Setup Alice
   const aliceMoolaPayment = moolaR.mint.mintPayment(moola(3n));
@@ -56,10 +57,11 @@ test('zoe - simplest automaticRefund', async t => {
 
 test('zoe - automaticRefund same issuer', async t => {
   // Setup zoe and mints
-  const { moolaR, moola, zoe } = setup();
+  const { moolaR, moola, zoe, vatAdminState } = setup();
   // Pack the contract.
   const bundle = await bundleSource(automaticRefundRoot);
-  const installation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-automaticRefund', bundle);
+  const installation = await E(zoe).installBundleID('b1-automaticRefund');
 
   // Setup Alice
   const aliceMoolaPayment = moolaR.mint.mintPayment(moola(9n));
@@ -98,7 +100,7 @@ test('zoe - automaticRefund same issuer', async t => {
 test('zoe with automaticRefund', async t => {
   t.plan(11);
   // Setup zoe and mints
-  const { moolaR, simoleanR, moola, simoleans, zoe } = setup();
+  const { moolaR, simoleanR, moola, simoleans, zoe, vatAdminState } = setup();
   const invitationIssuer = await E(zoe).getInvitationIssuer();
 
   // Setup Alice
@@ -115,7 +117,8 @@ test('zoe with automaticRefund', async t => {
   const bundle = await bundleSource(automaticRefundRoot);
 
   // 1: Alice creates an automatic refund instance
-  const installation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-automaticRefund', bundle);
+  const installation = await E(zoe).installBundleID('b1-automaticRefund');
   const issuerKeywordRecord = harden({
     Contribution1: moolaR.issuer,
     Contribution2: simoleanR.issuer,
@@ -229,7 +232,7 @@ test('zoe with automaticRefund', async t => {
 test('multiple instances of automaticRefund for the same Zoe', async t => {
   t.plan(6);
   // Setup zoe and mints
-  const { moolaR, simoleanR, moola, simoleans, zoe } = setup();
+  const { moolaR, simoleanR, moola, simoleans, zoe, vatAdminState } = setup();
 
   // Setup Alice
   const aliceMoolaPayment = moolaR.mint.mintPayment(moola(30n));
@@ -243,7 +246,8 @@ test('multiple instances of automaticRefund for the same Zoe', async t => {
   // Pack the contract.
   const bundle = await bundleSource(automaticRefundRoot);
 
-  const installation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-automaticRefund', bundle);
+  const installation = await E(zoe).installBundleID('b1-automaticRefund');
   const issuerKeywordRecord = harden({
     ContributionA: moolaR.issuer,
     ContributionB: simoleanR.issuer,
@@ -307,7 +311,7 @@ test('multiple instances of automaticRefund for the same Zoe', async t => {
 test('zoe - alice tries to complete after completion has already occurred', async t => {
   t.plan(5);
   // Setup zoe and mints
-  const { moolaR, simoleanR, moola, simoleans, zoe } = setup();
+  const { moolaR, simoleanR, moola, simoleans, zoe, vatAdminState } = setup();
 
   // Setup Alice
   const aliceMoolaPayment = moolaR.mint.mintPayment(moola(3n));
@@ -316,7 +320,8 @@ test('zoe - alice tries to complete after completion has already occurred', asyn
 
   // Pack the contract.
   const bundle = await bundleSource(automaticRefundRoot);
-  const installation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-automaticRefund', bundle);
+  const installation = await E(zoe).installBundleID('b1-automaticRefund');
   const issuerKeywordRecord = harden({
     ContributionA: moolaR.issuer,
     ContributionB: simoleanR.issuer,
@@ -372,11 +377,13 @@ test('zoe - alice tries to complete after completion has already occurred', asyn
 test('zoe - automaticRefund non-fungible', async t => {
   t.plan(1);
   // Setup zoe and mints
-  const { ccIssuer, ccMint, cryptoCats, zoe } = setupNonFungible();
+  const { ccIssuer, ccMint, cryptoCats, zoe, vatAdminState } =
+    setupNonFungible();
 
   // Pack the contract.
   const bundle = await bundleSource(automaticRefundRoot);
-  const installation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-automaticRefund', bundle);
+  const installation = await E(zoe).installBundleID('b1-automaticRefund');
 
   // Setup Alice
   const aliceCcPayment = ccMint.mintPayment(cryptoCats(harden(['tigger'])));

--- a/packages/zoe/test/unitTests/contracts/test-autoswap.js
+++ b/packages/zoe/test/unitTests/contracts/test-autoswap.js
@@ -34,9 +34,14 @@ test('autoSwap API interactions, no jig', async t => {
     moola,
     simoleans,
     zoe,
+    vatAdminState,
   } = setup();
   const invitationIssuer = await E(zoe).getInvitationIssuer();
-  const installation = await installationPFromSource(zoe, autoswap);
+  const installation = await installationPFromSource(
+    zoe,
+    vatAdminState,
+    autoswap,
+  );
 
   // Setup Alice
   const aliceMoolaPayment = moolaMint.mintPayment(moola(10n));
@@ -248,8 +253,13 @@ test('autoSwap - thorough jig test init, add, swap', async t => {
     moola,
     simoleans,
     zoe,
+    vatAdminState,
   } = setup();
-  const installation = await installationPFromSource(zoe, autoswap);
+  const installation = await installationPFromSource(
+    zoe,
+    vatAdminState,
+    autoswap,
+  );
 
   // create an autoswap instance
   const issuerKeywordRecord = harden({
@@ -366,8 +376,13 @@ test('autoSwap jig - add liquidity in exact ratio', async t => {
     moola,
     simoleans,
     zoe,
+    vatAdminState,
   } = setup();
-  const installation = await installationPFromSource(zoe, autoswap);
+  const installation = await installationPFromSource(
+    zoe,
+    vatAdminState,
+    autoswap,
+  );
 
   // create an autoswap instance
   const issuerKeywordRecord = harden({
@@ -453,9 +468,20 @@ test('autoSwap jig - add liquidity in exact ratio', async t => {
 });
 
 test('autoSwap - trade attempt before init, no jig', async t => {
-  const { moolaIssuer, simoleanIssuer, moolaMint, moola, simoleans, zoe } =
-    setup();
-  const installation = await installationPFromSource(zoe, autoswap);
+  const {
+    moolaIssuer,
+    simoleanIssuer,
+    moolaMint,
+    moola,
+    simoleans,
+    zoe,
+    vatAdminState,
+  } = setup();
+  const installation = await installationPFromSource(
+    zoe,
+    vatAdminState,
+    autoswap,
+  );
 
   const issuerKeywordRecord = harden({
     Central: moolaIssuer,
@@ -508,8 +534,13 @@ test('autoSwap jig - swap varying amounts', async t => {
     moola,
     simoleans,
     zoe,
+    vatAdminState,
   } = setup();
-  const installation = await installationPFromSource(zoe, autoswap);
+  const installation = await installationPFromSource(
+    zoe,
+    vatAdminState,
+    autoswap,
+  );
 
   // create an autoswap instance
   const issuerKeywordRecord = harden({
@@ -651,8 +682,13 @@ test('autoSwap price quote for zero', async t => {
     moola,
     simoleans,
     zoe,
+    vatAdminState,
   } = setup();
-  const installation = await installationPFromSource(zoe, autoswap);
+  const installation = await installationPFromSource(
+    zoe,
+    vatAdminState,
+    autoswap,
+  );
 
   // Setup Alice
   const aliceMoolaPayment = moolaMint.mintPayment(moola(10n));

--- a/packages/zoe/test/unitTests/contracts/test-barter.js
+++ b/packages/zoe/test/unitTests/contracts/test-barter.js
@@ -26,9 +26,14 @@ test('barter with valid offers', async t => {
     moola,
     simoleans,
     zoe,
+    vatAdminState,
   } = setup();
   const invitationIssuer = await E(zoe).getInvitationIssuer();
-  const installation = await installationPFromSource(zoe, barter);
+  const installation = await installationPFromSource(
+    zoe,
+    vatAdminState,
+    barter,
+  );
 
   // Setup Alice
   const aliceMoolaPayment = moolaMint.mintPayment(moola(3n));

--- a/packages/zoe/test/unitTests/contracts/test-brokenContract.js
+++ b/packages/zoe/test/unitTests/contracts/test-brokenContract.js
@@ -10,7 +10,7 @@ import { E } from '@agoric/eventual-send';
 
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import { setup } from '../setupBasicMints.js';
-import fakeVatAdmin from '../../../tools/fakeVatAdmin.js';
+import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
 
 const filename = new URL(import.meta.url).pathname;
 const dirname = path.dirname(filename);
@@ -21,10 +21,12 @@ test('zoe - brokenAutomaticRefund', async t => {
   t.plan(1);
   // Setup zoe and mints
   const { moolaR } = setup();
+  const { admin: fakeVatAdmin, vatAdminState } = makeFakeVatAdmin();
   const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
   // Pack the contract.
   const bundle = await bundleSource(automaticRefundRoot);
-  const installation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-brokenAutomaticRefund', bundle);
+  const installation = await E(zoe).installBundleID('b1-brokenAutomaticRefund');
 
   const issuerKeywordRecord = harden({ Contribution: moolaR.issuer });
 

--- a/packages/zoe/test/unitTests/contracts/test-callSpread.js
+++ b/packages/zoe/test/unitTests/contracts/test-callSpread.js
@@ -45,8 +45,13 @@ test('fundedCallSpread below Strike1', async t => {
     bucks,
     zoe,
     brands,
+    vatAdminState,
   } = setup();
-  const installation = await installationPFromSource(zoe, fundedCallSpread);
+  const installation = await installationPFromSource(
+    zoe,
+    vatAdminState,
+    fundedCallSpread,
+  );
 
   // Alice will create and fund a call spread contract, and give the invitations
   // to Bob and Carol. Bob and Carol will promptly schedule collection of funds.
@@ -146,8 +151,13 @@ test('fundedCallSpread above Strike2', async t => {
     bucks,
     zoe,
     brands,
+    vatAdminState,
   } = setup();
-  const installation = await installationPFromSource(zoe, fundedCallSpread);
+  const installation = await installationPFromSource(
+    zoe,
+    vatAdminState,
+    fundedCallSpread,
+  );
 
   // Alice will create and fund a call spread contract, and give the invitations
   // to Bob and Carol. Bob and Carol will promptly schedule collection of funds.
@@ -240,8 +250,13 @@ test('fundedCallSpread, mid-strike', async t => {
     bucks,
     zoe,
     brands,
+    vatAdminState,
   } = setup();
-  const installation = await installationPFromSource(zoe, fundedCallSpread);
+  const installation = await installationPFromSource(
+    zoe,
+    vatAdminState,
+    fundedCallSpread,
+  );
 
   // Alice will create and fund a call spread contract, and give the invitations
   // to Bob and Carol. Bob and Carol will promptly schedule collection of funds.
@@ -333,8 +348,13 @@ test('fundedCallSpread, late exercise', async t => {
     bucks,
     zoe,
     brands,
+    vatAdminState,
   } = setup();
-  const installation = await installationPFromSource(zoe, fundedCallSpread);
+  const installation = await installationPFromSource(
+    zoe,
+    vatAdminState,
+    fundedCallSpread,
+  );
 
   // Alice will create and fund a call spread contract, and give the invitations
   // to Bob and Carol. Bob and Carol will promptly schedule collection of funds.
@@ -426,8 +446,13 @@ test('fundedCallSpread, sell options', async t => {
     bucks,
     zoe,
     brands,
+    vatAdminState,
   } = setup();
-  const installation = await installationPFromSource(zoe, fundedCallSpread);
+  const installation = await installationPFromSource(
+    zoe,
+    vatAdminState,
+    fundedCallSpread,
+  );
   const invitationIssuer = await E(zoe).getInvitationIssuer();
 
   // Alice will create and fund a call spread contract, and sell the invitations
@@ -488,6 +513,7 @@ test('fundedCallSpread, sell options', async t => {
 
   const exchangeInstallation = await installationPFromSource(
     zoe,
+    vatAdminState,
     simpleExchange,
   );
   const { publicFacet: exchangePublic } = await E(zoe).startInstance(
@@ -603,8 +629,13 @@ test('pricedCallSpread, mid-strike', async t => {
     bucks,
     zoe,
     brands,
+    vatAdminState,
   } = setup();
-  const installation = await installationPFromSource(zoe, pricedCallSpread);
+  const installation = await installationPFromSource(
+    zoe,
+    vatAdminState,
+    pricedCallSpread,
+  );
 
   // Alice will create a call spread contract, and give the invitations
   // to Bob and Carol. Bob and Carol will fund and exercise, then promptly

--- a/packages/zoe/test/unitTests/contracts/test-coveredCall-want-pattern.js
+++ b/packages/zoe/test/unitTests/contracts/test-coveredCall-want-pattern.js
@@ -26,14 +26,27 @@ test('zoe - coveredCall with swap for invitation', async t => {
   t.plan(24);
   // Setup the environment
   const timer = buildManualTimer(console.log);
-  const { moolaR, simoleanR, bucksR, moola, simoleans, bucks, zoe } = setup();
+  const {
+    moolaR,
+    simoleanR,
+    bucksR,
+    moola,
+    simoleans,
+    bucks,
+    zoe,
+    vatAdminState,
+  } = setup();
   // Pack the contract.
   const coveredCallBundle = await bundleSource(coveredCallRoot);
 
-  const coveredCallInstallation = await E(zoe).install(coveredCallBundle);
+  vatAdminState.installBundle('b1-coveredcall', coveredCallBundle);
+  const coveredCallInstallation = await E(zoe).installBundleID(
+    'b1-coveredcall',
+  );
   const atomicSwapBundle = await bundleSource(atomicSwapRoot);
 
-  const swapInstallationId = await E(zoe).install(atomicSwapBundle);
+  vatAdminState.installBundle('b1-atomicswap', atomicSwapBundle);
+  const swapInstallationId = await E(zoe).installBundleID('b1-atomicswap');
 
   // Setup Alice
   // Alice starts with 3 moola

--- a/packages/zoe/test/unitTests/contracts/test-coveredCall.js
+++ b/packages/zoe/test/unitTests/contracts/test-coveredCall.js
@@ -23,8 +23,16 @@ const atomicSwapRoot = `${dirname}/../../../src/contracts/atomicSwap.js`;
 
 test('zoe - coveredCall', async t => {
   t.plan(13);
-  const { moolaKit, simoleanKit, bucksKit, moola, simoleans, bucks, zoe } =
-    setup();
+  const {
+    moolaKit,
+    simoleanKit,
+    bucksKit,
+    moola,
+    simoleans,
+    bucks,
+    zoe,
+    vatAdminState,
+  } = setup();
 
   const makeAlice = async (timer, moolaPayment) => {
     const moolaPurse = await E(moolaKit.issuer).makeEmptyPurse();
@@ -35,7 +43,8 @@ test('zoe - coveredCall', async t => {
         // pack the contract
         const bundle = await bundleSource(coveredCallRoot);
         // install the contract
-        const installationP = E(zoe).install(bundle);
+        vatAdminState.installBundle('b1-coveredcall', bundle);
+        const installationP = E(zoe).installBundleID('b1-coveredcall');
         return installationP;
       },
       startInstance: async installation => {
@@ -218,10 +227,13 @@ test('zoe - coveredCall', async t => {
 
 test(`zoe - coveredCall - alice's deadline expires, cancelling alice and bob`, async t => {
   t.plan(13);
-  const { moolaR, simoleanR, moola, simoleans, zoe } = setup();
+  const { moolaR, simoleanR, moola, simoleans, zoe, vatAdminState } = setup();
   // Pack the contract.
   const bundle = await bundleSource(coveredCallRoot);
-  const coveredCallInstallation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-coveredcall', bundle);
+  const coveredCallInstallation = await E(zoe).installBundleID(
+    'b1-coveredcall',
+  );
   const timer = buildManualTimer(console.log);
 
   // Setup Alice
@@ -339,14 +351,27 @@ test('zoe - coveredCall with swap for invitation', async t => {
   t.plan(24);
   // Setup the environment
   const timer = buildManualTimer(console.log);
-  const { moolaR, simoleanR, bucksR, moola, simoleans, bucks, zoe } = setup();
+  const {
+    moolaR,
+    simoleanR,
+    bucksR,
+    moola,
+    simoleans,
+    bucks,
+    zoe,
+    vatAdminState,
+  } = setup();
   // Pack the contract.
   const coveredCallBundle = await bundleSource(coveredCallRoot);
 
-  const coveredCallInstallation = await E(zoe).install(coveredCallBundle);
+  vatAdminState.installBundle('b1-coveredcall', coveredCallBundle);
+  const coveredCallInstallation = await E(zoe).installBundleID(
+    'b1-coveredcall',
+  );
   const atomicSwapBundle = await bundleSource(atomicSwapRoot);
 
-  const swapInstallationId = await E(zoe).install(atomicSwapBundle);
+  vatAdminState.installBundle('b1-atomicswap', atomicSwapBundle);
+  const swapInstallationId = await E(zoe).installBundleID('b1-atomicswap');
 
   // Setup Alice
   // Alice starts with 3 moola
@@ -591,12 +616,24 @@ test('zoe - coveredCall with coveredCall for invitation', async t => {
   t.plan(31);
   // Setup the environment
   const timer = buildManualTimer(console.log);
-  const { moolaR, simoleanR, bucksR, moola, simoleans, bucks, zoe } = setup();
+  const {
+    moolaR,
+    simoleanR,
+    bucksR,
+    moola,
+    simoleans,
+    bucks,
+    zoe,
+    vatAdminState,
+  } = setup();
 
   // Pack the contract.
   const bundle = await bundleSource(coveredCallRoot);
 
-  const coveredCallInstallation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-coveredcall', bundle);
+  const coveredCallInstallation = await E(zoe).installBundleID(
+    'b1-coveredcall',
+  );
 
   // Setup Alice
   // Alice starts with 3 moola
@@ -864,11 +901,16 @@ test('zoe - coveredCall non-fungible', async t => {
     rpgItems,
     createRpgItem,
     zoe,
+    vatAdminState,
   } = setupNonFungible();
 
   // install the contract.
   const bundle = await bundleSource(coveredCallRoot);
-  const coveredCallInstallation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-coveredcall', bundle);
+
+  const coveredCallInstallation = await E(zoe).installBundleID(
+    'b1-coveredcall',
+  );
   const timer = buildManualTimer(console.log);
 
   // Setup Alice

--- a/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
+++ b/packages/zoe/test/unitTests/contracts/test-escrowToVote.js
@@ -10,7 +10,7 @@ import { E } from '@agoric/eventual-send';
 
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import { setup } from '../setupBasicMints.js';
-import fakeVatAdmin from '../../../tools/fakeVatAdmin.js';
+import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
 
 const filename = new URL(import.meta.url).pathname;
 const dirname = path.dirname(filename);
@@ -20,12 +20,14 @@ const contractRoot = `${dirname}/escrowToVote.js`;
 test('zoe - escrowToVote', async t => {
   t.plan(14);
   const { moolaIssuer, moolaMint, moola } = setup();
+  const { admin: fakeVatAdmin, vatAdminState } = makeFakeVatAdmin();
   const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);
   // install the contract
-  const installation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-escrowtovote', bundle);
+  const installation = await E(zoe).installBundleID('b1-escrowtovote');
 
   // Alice creates an instance and acts as the Secretary
   const issuerKeywordRecord = harden({

--- a/packages/zoe/test/unitTests/contracts/test-mintPayments.js
+++ b/packages/zoe/test/unitTests/contracts/test-mintPayments.js
@@ -7,7 +7,7 @@ import path from 'path';
 import bundleSource from '@endo/bundle-source';
 import { E } from '@agoric/eventual-send';
 import { makeIssuerKit, AmountMath } from '@agoric/ertp';
-import fakeVatAdmin from '../../../tools/fakeVatAdmin.js';
+import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
 
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 
@@ -18,6 +18,7 @@ const mintPaymentsRoot = `${dirname}/../../../src/contracts/mintPayments.js`;
 
 test('zoe - mint payments', async t => {
   t.plan(2);
+  const { admin: fakeVatAdmin, vatAdminState } = makeFakeVatAdmin();
   const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   const makeAlice = () => {
@@ -26,7 +27,8 @@ test('zoe - mint payments', async t => {
         // pack the contract
         const bundle = await bundleSource(mintPaymentsRoot);
         // install the contract
-        const installationP = E(zoe).install(bundle);
+        vatAdminState.installBundle('b1-mintpayments', bundle);
+        const installationP = E(zoe).installBundleID('b1-mintpayments');
         return installationP;
       },
       startInstance: async installation => {
@@ -86,6 +88,7 @@ test('zoe - mint payments', async t => {
 
 test('zoe - mint payments with unrelated give and want', async t => {
   t.plan(3);
+  const { admin: fakeVatAdmin, vatAdminState } = makeFakeVatAdmin();
   const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
   const moolaKit = makeIssuerKit('moola');
   const simoleanKit = makeIssuerKit('simolean');
@@ -96,7 +99,8 @@ test('zoe - mint payments with unrelated give and want', async t => {
         // pack the contract
         const bundle = await bundleSource(mintPaymentsRoot);
         // install the contract
-        const installationP = E(zoe).install(bundle);
+        vatAdminState.installBundle('b1-mintpayments', bundle);
+        const installationP = E(zoe).installBundleID('b1-mintpayments');
         return installationP;
       },
       startInstance: async installation => {

--- a/packages/zoe/test/unitTests/contracts/test-oracle.js
+++ b/packages/zoe/test/unitTests/contracts/test-oracle.js
@@ -37,10 +37,12 @@ test.before(
   /** @param {ExecutionContext} ot */ async ot => {
     // Outside of tests, we should use the long-lived Zoe on the
     // testnet. In this test, we must create a new Zoe.
-    const { zoeService: zoe } = makeZoeKit(makeFakeVatAdmin().admin);
+    const { admin, vatAdminState } = makeFakeVatAdmin();
+    const { zoeService: zoe } = makeZoeKit(admin);
 
     // Pack the contract.
     const contractBundle = await bundleSource(contractPath);
+    vatAdminState.installBundle('b1-oracle', contractBundle);
 
     const link = makeIssuerKit('$LINK', AssetKind.NAT);
 
@@ -49,7 +51,7 @@ test.before(
     // of tests, we can also send the installation to someone
     // else, and they can use it to create a new contract instance
     // using the same code.
-    const installation = await E(zoe).install(contractBundle);
+    const installation = await E(zoe).installBundleID('b1-oracle');
 
     const feeAmount = AmountMath.make(link.brand, 1000n);
     /**

--- a/packages/zoe/test/unitTests/contracts/test-otcDesk.js
+++ b/packages/zoe/test/unitTests/contracts/test-otcDesk.js
@@ -18,9 +18,12 @@ const dirname = path.dirname(filename);
 
 const root = `${dirname}/../../../src/contracts/otcDesk.js`;
 
+let vatAdminState;
+
 const installCode = async zoe => {
   const bundle = await bundleSource(root);
-  const installation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-otcdesk', bundle);
+  const installation = await E(zoe).installBundleID('b1-otcdesk');
   return installation;
 };
 
@@ -28,7 +31,8 @@ const installCoveredCall = async zoe => {
   const bundle = await bundleSource(
     `${dirname}/../../../src/contracts/coveredCall`,
   );
-  const installation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-coveredcall', bundle);
+  const installation = await E(zoe).installBundleID('b1-coveredcall');
   return installation;
 };
 
@@ -357,6 +361,8 @@ const makeBob = (
   });
 };
 
+// eslint complains about these shadowing local variables if this is defined
+// too early, but vatAdminState needs to be visible earlier
 const {
   moolaKit,
   simoleanKit,
@@ -368,7 +374,9 @@ const {
   bucksIssuer,
   bucks,
   zoe,
+  vatAdminState: vas0,
 } = setup();
+vatAdminState = vas0;
 
 const issuers = {
   moolaIssuer,

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregator.js
@@ -48,7 +48,8 @@ test.before(
   /** @param {ExecutionContext} ot */ async ot => {
     // Outside of tests, we should use the long-lived Zoe on the
     // testnet. In this test, we must create a new Zoe.
-    const { zoeService: zoe } = makeZoeKit(makeFakeVatAdmin().admin);
+    const { admin, vatAdminState } = makeFakeVatAdmin();
+    const { zoeService: zoe } = makeZoeKit(admin);
 
     // Pack the contracts.
     const oracleBundle = await bundleSource(oraclePath);
@@ -59,8 +60,12 @@ test.before(
     // of tests, we can also send the installation to someone
     // else, and they can use it to create a new contract instance
     // using the same code.
-    const oracleInstallation = await E(zoe).install(oracleBundle);
-    const aggregatorInstallation = await E(zoe).install(aggregatorBundle);
+    vatAdminState.installBundle('b1-oracle', oracleBundle);
+    const oracleInstallation = await E(zoe).installBundleID('b1-oracle');
+    vatAdminState.installBundle('b1-aggregator', aggregatorBundle);
+    const aggregatorInstallation = await E(zoe).installBundleID(
+      'b1-aggregator',
+    );
 
     const link = makeIssuerKit('$LINK', AssetKind.NAT);
     const usd = makeIssuerKit('$USD', AssetKind.NAT);

--- a/packages/zoe/test/unitTests/contracts/test-priceAggregatorChainlink.js
+++ b/packages/zoe/test/unitTests/contracts/test-priceAggregatorChainlink.js
@@ -46,7 +46,8 @@ test.before(
   /** @param {ExecutionContext} ot */ async ot => {
     // Outside of tests, we should use the long-lived Zoe on the
     // testnet. In this test, we must create a new Zoe.
-    const { zoeService: zoe } = makeZoeKit(makeFakeVatAdmin().admin);
+    const { admin, vatAdminState } = makeFakeVatAdmin();
+    const { zoeService: zoe } = makeZoeKit(admin);
 
     // Pack the contracts.
     const oracleBundle = await bundleSource(oraclePath);
@@ -57,8 +58,12 @@ test.before(
     // of tests, we can also send the installation to someone
     // else, and they can use it to create a new contract instance
     // using the same code.
-    const oracleInstallation = await E(zoe).install(oracleBundle);
-    const aggregatorInstallation = await E(zoe).install(aggregatorBundle);
+    vatAdminState.installBundle('b1-oracle', oracleBundle);
+    const oracleInstallation = await E(zoe).installBundleID('b1-oracle');
+    vatAdminState.installBundle('b1-aggregator', aggregatorBundle);
+    const aggregatorInstallation = await E(zoe).installBundleID(
+      'b1-aggregator',
+    );
 
     const link = makeIssuerKit('$LINK', AssetKind.NAT);
     const usd = makeIssuerKit('$USD', AssetKind.NAT);

--- a/packages/zoe/test/unitTests/contracts/test-sellTickets.js
+++ b/packages/zoe/test/unitTests/contracts/test-sellTickets.js
@@ -8,7 +8,7 @@ import { assert } from '@agoric/assert';
 import bundleSource from '@endo/bundle-source';
 import { makeIssuerKit, AmountMath, isSetValue } from '@agoric/ertp';
 import { E } from '@agoric/eventual-send';
-import fakeVatAdmin from '../../../tools/fakeVatAdmin.js';
+import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
 
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import { defaultAcceptanceMsg } from '../../../src/contractSupport/index.js';
@@ -21,13 +21,16 @@ const sellItemsRoot = `${dirname}/../../../src/contracts/sellItems.js`;
 
 test(`mint and sell tickets for multiple shows`, async t => {
   // Setup initial conditions
+  const { admin: fakeVatAdmin, vatAdminState } = makeFakeVatAdmin();
   const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   const mintAndSellNFTBundle = await bundleSource(mintAndSellNFTRoot);
-  const mintAndSellNFTInstallation = await E(zoe).install(mintAndSellNFTBundle);
+  vatAdminState.installBundle('b1-nft', mintAndSellNFTBundle);
+  const mintAndSellNFTInstallation = await E(zoe).installBundleID('b1-nft');
 
   const sellItemsBundle = await bundleSource(sellItemsRoot);
-  const sellItemsInstallation = await E(zoe).install(sellItemsBundle);
+  vatAdminState.installBundle('b1-sell-items', sellItemsBundle);
+  const sellItemsInstallation = await E(zoe).installBundleID('b1-sell-items');
 
   const { issuer: moolaIssuer, brand: moolaBrand } = makeIssuerKit('moola');
 
@@ -145,13 +148,16 @@ test(`mint and sell opera tickets`, async t => {
 
   const moola = value => AmountMath.make(moolaBrand, value);
 
+  const { admin: fakeVatAdmin, vatAdminState } = makeFakeVatAdmin();
   const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   const mintAndSellNFTBundle = await bundleSource(mintAndSellNFTRoot);
-  const mintAndSellNFTInstallation = await E(zoe).install(mintAndSellNFTBundle);
+  vatAdminState.installBundle('b1-nft', mintAndSellNFTBundle);
+  const mintAndSellNFTInstallation = await E(zoe).installBundleID('b1-nft');
 
   const sellItemsBundle = await bundleSource(sellItemsRoot);
-  const sellItemsInstallation = await E(zoe).install(sellItemsBundle);
+  vatAdminState.installBundle('b1-sell-items', sellItemsBundle);
+  const sellItemsInstallation = await E(zoe).installBundleID('b1-sell-items');
 
   // === Initial Opera de Bordeaux part ===
 
@@ -538,13 +544,16 @@ test(`mint and sell opera tickets`, async t => {
 //
 test('Testing publicFacet.getAvailableItemsNotifier()', async t => {
   // Setup initial conditions
+  const { admin: fakeVatAdmin, vatAdminState } = makeFakeVatAdmin();
   const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   const mintAndSellNFTBundle = await bundleSource(mintAndSellNFTRoot);
-  const mintAndSellNFTInstallation = await E(zoe).install(mintAndSellNFTBundle);
+  vatAdminState.installBundle('b1-nft', mintAndSellNFTBundle);
+  const mintAndSellNFTInstallation = await E(zoe).installBundleID('b1-nft');
 
   const sellItemsBundle = await bundleSource(sellItemsRoot);
-  const sellItemsInstallation = await E(zoe).install(sellItemsBundle);
+  vatAdminState.installBundle('b1-sell-items', sellItemsBundle);
+  const sellItemsInstallation = await E(zoe).installBundleID('b1-sell-items');
 
   const { issuer: moolaIssuer, brand: moolaBrand } = makeIssuerKit('moola');
 

--- a/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
+++ b/packages/zoe/test/unitTests/contracts/test-simpleExchange.js
@@ -29,9 +29,14 @@ test('simpleExchange with valid offers', async t => {
     moola,
     simoleans,
     zoe,
+    vatAdminState,
   } = setup();
   const invitationIssuer = await E(zoe).getInvitationIssuer();
-  const installation = await installationPFromSource(zoe, simpleExchange);
+  const installation = await installationPFromSource(
+    zoe,
+    vatAdminState,
+    simpleExchange,
+  );
 
   // Setup Alice
   const aliceMoolaPayment = moolaMint.mintPayment(moola(3n));
@@ -211,9 +216,14 @@ test('simpleExchange with multiple sell offers', async t => {
     moola,
     simoleans,
     zoe,
+    vatAdminState,
   } = setup();
   const invitationIssuer = await E(zoe).getInvitationIssuer();
-  const installation = await installationPFromSource(zoe, simpleExchange);
+  const installation = await installationPFromSource(
+    zoe,
+    vatAdminState,
+    simpleExchange,
+  );
 
   // Setup Alice
   const aliceMoolaPayment = moolaMint.mintPayment(moola(30n));
@@ -314,9 +324,14 @@ test('simpleExchange with non-fungible assets', async t => {
     createRpgItem,
     zoe,
     brands,
+    vatAdminState,
   } = setupNonFungible();
   const invitationIssuer = await E(zoe).getInvitationIssuer();
-  const installation = await installationPFromSource(zoe, simpleExchange);
+  const installation = await installationPFromSource(
+    zoe,
+    vatAdminState,
+    simpleExchange,
+  );
 
   // Setup Alice
   const spell = createRpgItem('Spell of Binding', 'binding');

--- a/packages/zoe/test/unitTests/contracts/test-throwInOfferHandler.js
+++ b/packages/zoe/test/unitTests/contracts/test-throwInOfferHandler.js
@@ -8,7 +8,7 @@ import bundleSource from '@endo/bundle-source';
 
 import { E } from '@agoric/eventual-send';
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
-import fakeVatAdmin from '../../../tools/fakeVatAdmin.js';
+import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
 
 const filename = new URL(import.meta.url).pathname;
 const dirname = path.dirname(filename);
@@ -16,12 +16,14 @@ const dirname = path.dirname(filename);
 const contractRoot = `${dirname}/throwInOfferHandler.js`;
 
 test('throw in offerHandler', async t => {
+  const { admin: fakeVatAdmin, vatAdminState } = makeFakeVatAdmin();
   const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);
   // install the contract
-  const installation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-throw', bundle);
+  const installation = await E(zoe).installBundleID('b1-throw');
 
   const { creatorFacet } = await E(zoe).startInstance(installation);
 

--- a/packages/zoe/test/unitTests/contracts/test-useObj.js
+++ b/packages/zoe/test/unitTests/contracts/test-useObj.js
@@ -9,7 +9,7 @@ import bundleSource from '@endo/bundle-source';
 import { E } from '@agoric/eventual-send';
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
 import { setup } from '../setupBasicMints.js';
-import fakeVatAdmin from '../../../tools/fakeVatAdmin.js';
+import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
 
 const filename = new URL(import.meta.url).pathname;
 const dirname = path.dirname(filename);
@@ -19,12 +19,14 @@ const contractRoot = `${dirname}/useObjExample.js`;
 test('zoe - useObj', async t => {
   t.plan(3);
   const { moolaIssuer, moolaMint, moola } = setup();
+  const { admin: fakeVatAdmin, vatAdminState } = makeFakeVatAdmin();
   const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   // pack the contract
   const bundle = await bundleSource(contractRoot);
   // install the contract
-  const installation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-use-obj', bundle);
+  const installation = await E(zoe).installBundleID('b1-use-obj');
 
   // Setup Alice
   const aliceMoolaPayment = moolaMint.mintPayment(moola(3n));

--- a/packages/zoe/test/unitTests/installFromSource.js
+++ b/packages/zoe/test/unitTests/installFromSource.js
@@ -5,8 +5,13 @@ import { E } from '@agoric/eventual-send';
 
 /**
  * @param {ZoeService} zoe
+ * @param {*} vatAdminState
  * @param {string} path
  * @returns {Promise<Installation>}
  */
-export const installationPFromSource = (zoe, path) =>
-  bundleSource(path).then(b => E(zoe).install(b));
+export const installationPFromSource = async (zoe, vatAdminState, path) => {
+  const bundle = await bundleSource(path);
+  const id = `b1-${path}`;
+  vatAdminState.installBundle(id, bundle);
+  return E(zoe).installBundleID(id);
+};

--- a/packages/zoe/test/unitTests/setupMixedMints.js
+++ b/packages/zoe/test/unitTests/setupMixedMints.js
@@ -2,7 +2,7 @@
 
 import { makeIssuerKit, AmountMath, AssetKind } from '@agoric/ertp';
 import { makeZoeKit } from '../../src/zoeService/zoe.js';
-import fakeVatAdmin from '../../tools/fakeVatAdmin.js';
+import { makeFakeVatAdmin } from '../../tools/fakeVatAdmin.js';
 
 const setupMixed = () => {
   const ccBundle = makeIssuerKit('CryptoCats', AssetKind.SET);
@@ -25,6 +25,7 @@ const setupMixed = () => {
   const cryptoCats = value => AmountMath.make(allBundles.cc.brand, value);
   const moola = value => AmountMath.make(allBundles.moola.brand, value);
 
+  const { admin: fakeVatAdmin, vatAdminState } = makeFakeVatAdmin();
   const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
   return {
     zoe,
@@ -35,6 +36,7 @@ const setupMixed = () => {
     cryptoCats,
     moola,
     brands,
+    vatAdminState,
   };
 };
 harden(setupMixed);

--- a/packages/zoe/test/unitTests/setupNonFungibleMints.js
+++ b/packages/zoe/test/unitTests/setupNonFungibleMints.js
@@ -2,7 +2,7 @@
 
 import { makeIssuerKit, AmountMath, AssetKind } from '@agoric/ertp';
 import { makeZoeKit } from '../../src/zoeService/zoe.js';
-import fakeVatAdmin from '../../tools/fakeVatAdmin.js';
+import { makeFakeVatAdmin } from '../../tools/fakeVatAdmin.js';
 
 const setupNonFungible = () => {
   const ccBundle = makeIssuerKit('CryptoCats', AssetKind.SET);
@@ -24,6 +24,7 @@ const setupNonFungible = () => {
   function createRpgItem(name, power, desc = undefined) {
     return harden([{ name, description: desc || name, power }]);
   }
+  const { admin: fakeVatAdmin, vatAdminState } = makeFakeVatAdmin();
   const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
 
   const ccIssuer = ccBundle.issuer;
@@ -44,6 +45,7 @@ const setupNonFungible = () => {
     brands,
     createRpgItem,
     zoe,
+    vatAdminState,
   };
 };
 harden(setupNonFungible);

--- a/packages/zoe/test/unitTests/test-makeKind.js
+++ b/packages/zoe/test/unitTests/test-makeKind.js
@@ -9,7 +9,7 @@ import bundleSource from '@endo/bundle-source';
 
 import { E } from '@agoric/eventual-send';
 import { makeZoeKit } from '../../src/zoeService/zoe.js';
-import fakeVatAdmin from '../../tools/fakeVatAdmin.js';
+import { makeFakeVatAdmin } from '../../tools/fakeVatAdmin.js';
 
 const filename = new URL(import.meta.url).pathname;
 const dirname = path.dirname(filename);
@@ -18,8 +18,10 @@ const root = `${dirname}/../minimalMakeKindContract.js`;
 
 test('defineKind non-swingset', async t => {
   const bundle = await bundleSource(root);
+  const { admin: fakeVatAdmin, vatAdminState } = makeFakeVatAdmin();
   const { zoeService: zoe } = makeZoeKit(fakeVatAdmin);
-  const installation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-minimal', bundle);
+  const installation = await E(zoe).installBundleID('b1-minimal');
   t.notThrows(() => VatData.defineKind());
   t.notThrows(() => VatData.defineDurableKind());
   t.notThrows(() => VatData.makeScalarBigMapStore());

--- a/packages/zoe/test/unitTests/test-scriptedOracle.js
+++ b/packages/zoe/test/unitTests/test-scriptedOracle.js
@@ -44,15 +44,18 @@ test.before(
   /** @param {ExecutionContext} ot */ async ot => {
     // Outside of tests, we should use the long-lived Zoe on the
     // testnet. In this test, we must create a new Zoe.
-    const { zoeService: zoe } = makeZoeKit(makeFakeVatAdmin().admin);
+    const { admin, vatAdminState } = makeFakeVatAdmin();
+    const { zoeService: zoe } = makeZoeKit(admin);
 
     const oracleContractBundle = await bundleSource(oracleContractPath);
     const bountyContractBundle = await bundleSource(bountyContractPath);
 
     // Install the contracts on Zoe, getting installations. We use these
     // installations to instantiate the contracts.
-    const oracleInstallation = await E(zoe).install(oracleContractBundle);
-    const bountyInstallation = await E(zoe).install(bountyContractBundle);
+    vatAdminState.installBundle('b1-oracle', oracleContractBundle);
+    const oracleInstallation = await E(zoe).installBundleID('b1-oracle');
+    vatAdminState.installBundle('b1-bounty', bountyContractBundle);
+    const bountyInstallation = await E(zoe).installBundleID('b1-bounty');
     const { moolaIssuer, moolaMint, moola } = setup();
 
     ot.context.zoe = zoe;

--- a/packages/zoe/test/unitTests/test-zoe.js
+++ b/packages/zoe/test/unitTests/test-zoe.js
@@ -201,10 +201,11 @@ test(`E(zoe).offer - no invitation`, async t => {
 });
 
 test(`E(zoe).getPublicFacet`, async t => {
-  const { zoe } = setup();
+  const { zoe, vatAdminState } = setup();
   const contractPath = `${dirname}/../../src/contracts/automaticRefund`;
   const bundle = await bundleSource(contractPath);
-  const installation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-refund', bundle);
+  const installation = await E(zoe).installBundleID('b1-refund');
   const { publicFacet, instance } = await E(zoe).startInstance(installation);
   const offersCount = await E(publicFacet).getOffersCount();
   t.is(offersCount, 0n);
@@ -212,10 +213,11 @@ test(`E(zoe).getPublicFacet`, async t => {
 });
 
 test(`E(zoe).getPublicFacet promise for instance`, async t => {
-  const { zoe } = setup();
+  const { zoe, vatAdminState } = setup();
   const contractPath = `${dirname}/../../src/contracts/automaticRefund`;
   const bundle = await bundleSource(contractPath);
-  const installationP = E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-refund', bundle);
+  const installationP = E(zoe).installBundleID('b1-refund');
   // Note that E.get does not currently pipeline
   const { publicFacet: publicFacetP, instance: instanceP } = E.get(
     E(zoe).startInstance(installationP),
@@ -246,10 +248,11 @@ test(`E(zoe).getPublicFacet - no instance`, async t => {
 });
 
 test(`zoe.getIssuers`, async t => {
-  const { zoe, moolaKit } = setup();
+  const { zoe, moolaKit, vatAdminState } = setup();
   const contractPath = `${dirname}/../../src/contracts/automaticRefund`;
   const bundle = await bundleSource(contractPath);
-  const installation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-refund', bundle);
+  const installation = await E(zoe).installBundleID('b1-refund');
   const { instance } = await E(zoe).startInstance(installation, {
     Moola: moolaKit.issuer,
   });
@@ -257,10 +260,11 @@ test(`zoe.getIssuers`, async t => {
 });
 
 test(`zoe.getIssuers - none`, async t => {
-  const { zoe } = setup();
+  const { zoe, vatAdminState } = setup();
   const contractPath = `${dirname}/../../src/contracts/automaticRefund`;
   const bundle = await bundleSource(contractPath);
-  const installation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-refund', bundle);
+  const installation = await E(zoe).installBundleID('b1-refund');
   const { instance } = await E(zoe).startInstance(installation);
   t.deepEqual(await E(zoe).getIssuers(instance), {});
 });
@@ -280,10 +284,11 @@ test(`zoe.getIssuers - no instance`, async t => {
 });
 
 test(`zoe.getBrands`, async t => {
-  const { zoe, moolaKit } = setup();
+  const { zoe, moolaKit, vatAdminState } = setup();
   const contractPath = `${dirname}/../../src/contracts/automaticRefund`;
   const bundle = await bundleSource(contractPath);
-  const installation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-refund', bundle);
+  const installation = await E(zoe).installBundleID('b1-refund');
   const { instance } = await E(zoe).startInstance(installation, {
     Moola: moolaKit.issuer,
   });
@@ -291,10 +296,11 @@ test(`zoe.getBrands`, async t => {
 });
 
 test(`zoe.getBrands - none`, async t => {
-  const { zoe } = setup();
+  const { zoe, vatAdminState } = setup();
   const contractPath = `${dirname}/../../src/contracts/automaticRefund`;
   const bundle = await bundleSource(contractPath);
-  const installation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-refund', bundle);
+  const installation = await E(zoe).installBundleID('b1-refund');
   const { instance } = await E(zoe).startInstance(installation);
   t.deepEqual(await E(zoe).getBrands(instance), {});
 });
@@ -314,10 +320,11 @@ test(`zoe.getBrands - no instance`, async t => {
 });
 
 test(`zoe.getTerms - none`, async t => {
-  const { zoe } = setup();
+  const { zoe, vatAdminState } = setup();
   const contractPath = `${dirname}/../../src/contracts/automaticRefund`;
   const bundle = await bundleSource(contractPath);
-  const installation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-refund', bundle);
+  const installation = await E(zoe).installBundleID('b1-refund');
   const { instance } = await E(zoe).startInstance(installation);
   t.deepEqual(await E(zoe).getTerms(instance), {
     brands: {},
@@ -326,10 +333,11 @@ test(`zoe.getTerms - none`, async t => {
 });
 
 test(`zoe.getTerms`, async t => {
-  const { zoe, moolaKit } = setup();
+  const { zoe, moolaKit, vatAdminState } = setup();
   const contractPath = `${dirname}/../../src/contracts/automaticRefund`;
   const bundle = await bundleSource(contractPath);
-  const installation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-refund', bundle);
+  const installation = await E(zoe).installBundleID('b1-refund');
   const { instance } = await E(zoe).startInstance(
     installation,
     {
@@ -370,10 +378,11 @@ test(`zoe.getTerms - no instance`, async t => {
 });
 
 test(`zoe.getInstallationForInstance`, async t => {
-  const { zoe, moolaKit } = setup();
+  const { zoe, moolaKit, vatAdminState } = setup();
   const contractPath = `${dirname}/../../src/contracts/automaticRefund`;
   const bundle = await bundleSource(contractPath);
-  const installation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-refund', bundle);
+  const installation = await E(zoe).installBundleID('b1-refund');
   const { instance } = await E(zoe).startInstance(
     installation,
     {

--- a/packages/zoe/test/unitTests/zcf/setupZcfTest.js
+++ b/packages/zoe/test/unitTests/zcf/setupZcfTest.js
@@ -35,7 +35,8 @@ export const setupZCFTest = async (issuerKeywordRecord, terms) => {
   const fakeVatAdmin = makeFakeVatAdmin(setZCF);
   const { zoeService: zoe, feeMintAccess } = makeZoeKit(fakeVatAdmin.admin);
   const bundle = await bundleSource(contractRoot);
-  const installation = await E(zoe).install(bundle);
+  fakeVatAdmin.vatAdminState.installBundle('b1-contract', bundle);
+  const installation = await E(zoe).installBundleID('b1-contract');
   const { creatorFacet, instance } = await E(zoe).startInstance(
     installation,
     issuerKeywordRecord,

--- a/packages/zoe/test/unitTests/zcf/test-feeMintAccess.js
+++ b/packages/zoe/test/unitTests/zcf/test-feeMintAccess.js
@@ -11,7 +11,7 @@ import { AmountMath } from '@agoric/ertp';
 import bundleSource from '@endo/bundle-source';
 
 import { makeZoeKit } from '../../../src/zoeService/zoe.js';
-import fakeVatAdmin from '../../../tools/fakeVatAdmin.js';
+import { makeFakeVatAdmin } from '../../../tools/fakeVatAdmin.js';
 
 const filename = new URL(import.meta.url).pathname;
 const dirname = path.dirname(filename);
@@ -19,9 +19,11 @@ const dirname = path.dirname(filename);
 const contractRoot = `${dirname}/registerFeeMintContract.js`;
 
 test(`feeMintAccess`, async t => {
+  const { admin: fakeVatAdmin, vatAdminState } = makeFakeVatAdmin();
   const { zoeService: zoe, feeMintAccess } = makeZoeKit(fakeVatAdmin);
   const bundle = await bundleSource(contractRoot);
-  const installation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-registerfee', bundle);
+  const installation = await E(zoe).installBundleID('b1-registerfee');
   const { creatorFacet } = await E(zoe).startInstance(
     installation,
     undefined,

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat-exit.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat-exit.js
@@ -33,7 +33,8 @@ test(`zoe - wrongly throw zcfSeat.exit()`, async t => {
   // pack the contract
   const bundle = await bundleSource(contractRoot);
   // install the contract
-  const installation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-zcftester', bundle);
+  const installation = await E(zoe).installBundleID('b1-zcftester');
 
   // Alice creates an instance
   const issuerKeywordRecord = harden({

--- a/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
+++ b/packages/zoe/test/unitTests/zcf/test-zcfSeat.js
@@ -30,7 +30,8 @@ test(`zoe - zcfSeat.fail() doesn't throw`, async t => {
   // pack the contract
   const bundle = await bundleSource(contractRoot);
   // install the contract
-  const installation = await E(zoe).install(bundle);
+  vatAdminState.installBundle('b1-zcftester', bundle);
+  const installation = await E(zoe).installBundleID('b1-zcftester');
 
   // Alice creates an instance
   const issuerKeywordRecord = harden({


### PR DESCRIPTION
The new preferred way to install a contract is by its bundleID, using
`E(zoe).installBundleID(id)` instead of `E(zoe).install(bundle)`. The bundle
itself must first be installed/registered with the VatAdmin service. In a
real swingset, this happens out-of-band, via
`controller.validateAndInstallBundle`. In a non-swingset unit test, the
`fakeVatAdmin` has a new `vatAdminState.installBundle(id, bundle)`.

This changes most Zoe unit tests to perform `vatAdminState.installBundle` and
then use Zoe's `installBundleID` method. This requires some mechanical
changes to the way many tests get access to their fakeVatAdmin. I took the
opportunity to switch all tests to importing `makeFakeVatAdmin` and building
their own local copy, rather than relying upon the shared singleton created
and exported by `fakeVatAdmin.js` itself.

This leaves one test in `unitTests/` using the old `E(zoe).install(bundle)`,
to ensure it still works until we decide to remove it entirely. All tests in
`swingsetTests/` still use `install(bundle)`, those will be changed later.

It also updates all swingset-based zoe tests to install contracts by BundleID
instead of a full bundle. In all cases, we add the bundles by name to
`config.bundles`, from which you can obtain the BundleID with:

```js
const bcap = await E(vatAdminService).getNamedBundleCap(name);
const id = D(bcap).getBundleID();
```

In a real chain, the bundles would be installed into the kernel at runtime,
and zoe would be given a BundleID by the (off-chain) user doing the
install (or their deploy script).

refs #4565
