### PR TITLE
refactor(run-protocol)!: compound interest from assetNofifier instead of vault

### DIFF
--- a/docs/threat_models/vaultFactory/vaultFactory.puml
+++ b/docs/threat_models/vaultFactory/vaultFactory.puml
@@ -38,7 +38,7 @@ node "Vat" {
         circle makeAdjustBalancesInvitation
         makeAdjustBalancesInvitation -u-> AdjustBalancesInvitation
         circle getCollateralAmount
-        circle getDebtAmount
+        circle getCurrentDebt
         circle getLiquidationSeat
         getLiquidationSeat -u-> LiquidationSeat
     }
@@ -51,7 +51,7 @@ Borrower -d-> LiquidationPromise: did loan get liquidated?
 Borrower -> AdjustBalancesInvitation: add or remove collateral or \nincrease or decrease the loan balance
 Borrower -l-> CloseVaultInvitation: close loan and withdraw \nany remaining collateral
 vfc -d-> makeAddTypeInvitation
-Borrower -d-> getDebtAmount: how much do I owe
+Borrower -d-> getCurrentDebt: how much do I owe
 Borrower -d-> getCollateralAmount: how much did I \ndeposit as collateral
 
 @enduml

--- a/packages/run-protocol/src/vaultFactory/liquidation.js
+++ b/packages/run-protocol/src/vaultFactory/liquidation.js
@@ -26,7 +26,7 @@ const trace = makeTracer('LIQ');
  */
 const liquidate = async (zcf, vault, burnLosses, strategy, collateralBrand) => {
   vault.liquidating();
-  const runDebt = vault.getDebtAmount();
+  const runDebt = vault.getCurrentDebt();
   const { brand: runBrand } = runDebt;
   const liquidationSeat = vault.getInnerLiquidationSeat();
   const vaultSeat = vault.getVaultSeat();

--- a/packages/run-protocol/src/vaultFactory/orderedVaultStore.js
+++ b/packages/run-protocol/src/vaultFactory/orderedVaultStore.js
@@ -27,7 +27,7 @@ export const makeOrderedVaultStore = () => {
    * @param {InnerVault} vault
    */
   const addVault = (vaultId, vault) => {
-    const debt = vault.getDebtAmount();
+    const debt = vault.getCurrentDebt();
     const collateral = vault.getCollateralAmount();
     const key = toVaultKey(debt, collateral, vaultId);
     store.init(key, vault);

--- a/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
+++ b/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
@@ -30,7 +30,10 @@ const calculateDebtToCollateral = (debtAmount, collateralAmount) => {
  * @returns {Ratio}
  */
 export const currentDebtToCollateral = vault =>
-  calculateDebtToCollateral(vault.getDebtAmount(), vault.getCollateralAmount());
+  calculateDebtToCollateral(
+    vault.getCurrentDebt(),
+    vault.getCollateralAmount(),
+  );
 
 /** @typedef {{debtToCollateral: Ratio, vault: InnerVault}} VaultRecord */
 
@@ -84,7 +87,7 @@ export const makePrioritizedVaults = reschedulePriceCheck => {
       // Would be an infinite ratio
       return undefined;
     }
-    const actualDebtAmount = vault.getDebtAmount();
+    const actualDebtAmount = vault.getCurrentDebt();
     return makeRatioFromAmounts(actualDebtAmount, vault.getCollateralAmount());
   };
 

--- a/packages/run-protocol/src/vaultFactory/types.js
+++ b/packages/run-protocol/src/vaultFactory/types.js
@@ -37,8 +37,8 @@
 
 /**
  * @typedef  {Object} VaultFactoryPublicFacet - the public facet
- * @property {() => Promise<Invitation>} makeLoanInvitation
- * @property {() => Promise<Invitation>} makeVaultInvitation
+ * @property {() => Promise<Invitation<VaultKit>>} makeLoanInvitation
+ * @property {() => Promise<Invitation<VaultKit>>} makeVaultInvitation
  * @property {() => Promise<Array<Collateral>>} getCollaterals
  * @property {() => Issuer} getRunIssuer
  * @property {(paramDescription: ParamDescription) => bigint} getNatParamState
@@ -105,7 +105,7 @@
  * @typedef {BaseVault & VaultMixin} Vault
  * @typedef {Object} VaultMixin
  * @property {() => Promise<Invitation>} makeAdjustBalancesInvitation
- * @property {() => Promise<Invitation>} makeCloseInvitation
+ * @property {() => Promise<Invitation<string>>} makeCloseInvitation
  * @property {() => Promise<Invitation>} makeTransferInvitation
  * @property {() => ERef<UserSeat>} getLiquidationSeat
  * @property {() => Notifier<VaultUIState>} getNotifier

--- a/packages/run-protocol/src/vaultFactory/types.js
+++ b/packages/run-protocol/src/vaultFactory/types.js
@@ -110,7 +110,7 @@
 /**
  * @typedef {Object} BaseVault
  * @property {() => Amount<NatValue>} getCollateralAmount
- * @property {() => Amount<NatValue>} getDebtAmount
+ * @property {() => Amount<NatValue>} getCurrentDebt
  * @property {() => Amount<NatValue>} getNormalizedDebt
  *
  * @typedef {BaseVault & VaultMixin} Vault

--- a/packages/run-protocol/src/vaultFactory/types.js
+++ b/packages/run-protocol/src/vaultFactory/types.js
@@ -36,19 +36,6 @@
  */
 
 /**
- * @typedef  {Object} VaultFactoryPublicFacet - the public facet
- * @property {() => Promise<Invitation<VaultKit>>} makeLoanInvitation
- * @property {() => Promise<Invitation<VaultKit>>} makeVaultInvitation
- * @property {() => Promise<Array<Collateral>>} getCollaterals
- * @property {() => Issuer} getRunIssuer
- * @property {(paramDescription: ParamDescription) => bigint} getNatParamState
- * @property {(paramDescription: ParamDescription) => Ratio} getRatioParamState
- * @property {() => Record<Keyword, ParamShortDescription>} getGovernedParams
- * @property {() => Promise<GovernorPublic>} getContractGovernor
- * @property {(name: string) => Amount} getInvitationAmount
- */
-
-/**
  * @typedef  {Object} VaultFactory - the creator facet
  * @property {AddVaultType} addVaultType
  * @property {() => Promise<Array<Collateral>>} getCollaterals

--- a/packages/run-protocol/src/vaultFactory/types.js
+++ b/packages/run-protocol/src/vaultFactory/types.js
@@ -1,5 +1,8 @@
 // @ts-check
 
+/** @typedef {import('./vault').VaultUIState} VaultUIState */
+/** @typedef {import('./vault').VaultKit} VaultKit */
+
 /**
  * @typedef  {Object} AutoswapLocal
  * @property {(amount: Amount, brand: Brand) => Amount} getInputPrice
@@ -55,20 +58,6 @@
  */
 
 /**
- * @typedef {Object} BaseUIState
- * @property {Amount<NatValue>} locked Amount of Collateral locked
- * @property {Amount<NatValue>} debt Amount of Loan (including accrued interest)
- */
-
-/**
- * @typedef {BaseUIState & LiquidationUIMixin} VaultUIState
- * @typedef {Object} LiquidationUIMixin
- * @property {Ratio} interestRate Annual interest rate charge
- * @property {Ratio} liquidationRatio
- * @property {'active' | 'liquidating' | 'liquidated' | 'closed' | 'transfer'} vaultState
- */
-
-/**
  * @callback ReallocateReward
  *
  * Transfer the indicated amount to the vaultFactory's reward
@@ -120,22 +109,6 @@
  * @property {() => Promise<Invitation>} makeTransferInvitation
  * @property {() => ERef<UserSeat>} getLiquidationSeat
  * @property {() => Notifier<VaultUIState>} getNotifier
- */
-
-/**
- * @typedef {Object} LineOfCreditKit
- * @property {Notifier<BaseUIState>} uiNotifier
- * @property {BaseVault} vault
- * @property {{
- *    AdjustBalances: () => Promise<Invitation>,
- *    CloseVault: () => Promise<Invitation>,
- *  }} invitationMakers
- */
-
-/**
- * @typedef {Object} VaultKit
- * @property {Vault} vault
- * @property {Notifier<VaultUIState>} vaultNotifier
  */
 
 /**

--- a/packages/run-protocol/src/vaultFactory/types.js
+++ b/packages/run-protocol/src/vaultFactory/types.js
@@ -135,7 +135,7 @@
 /**
  * @typedef {Object} VaultKit
  * @property {Vault} vault
- * @property {Notifier<VaultUIState>} uiNotifier
+ * @property {Notifier<VaultUIState>} vaultNotifier
  */
 
 /**

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -640,7 +640,7 @@ export const makeInnerVault = (
     outerUpdater = updater;
     updateUiState();
     return harden({
-      uiNotifier: vault.getNotifier(),
+      vaultNotifier: vault.getNotifier(),
       invitationMakers: Far('invitation makers', {
         AdjustBalances: vault.makeAdjustBalancesInvitation,
         CloseVault: vault.makeCloseInvitation,
@@ -650,7 +650,10 @@ export const makeInnerVault = (
     });
   };
 
-  /** @type {OfferHandler} */
+  /**
+   * @param {ZCFSeat} seat
+   * @param {InnerVault} innerVault
+   */
   const initVaultKit = async (seat, innerVault) => {
     assert(
       AmountMath.isEmpty(debtSnapshot.run),

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -83,7 +83,7 @@ const makeOuterKit = inner => {
     },
     // for status/debugging
     getCollateralAmount: () => assertActive(vault).getCollateralAmount(),
-    getDebtAmount: () => assertActive(vault).getDebtAmount(),
+    getCurrentDebt: () => assertActive(vault).getCurrentDebt(),
     getNormalizedDebt: () => assertActive(vault).getNormalizedDebt(),
     getLiquidationSeat: () => assertActive(vault).getLiquidationSeat(),
   });
@@ -205,8 +205,7 @@ export const makeInnerVault = (
    * @see getNormalizedDebt
    * @returns {Amount<NatValue>}
    */
-  // TODO rename to getActualDebtAmount throughout codebase https://github.com/Agoric/agoric-sdk/issues/4540
-  const getDebtAmount = () => {
+  const getCurrentDebt = () => {
     // divide compounded interest by the snapshot
     const interestSinceSnapshot = multiplyRatios(
       manager.getCompoundedInterest(),
@@ -287,7 +286,7 @@ export const makeInnerVault = (
       liquidationRatio: manager.getLiquidationMargin(),
       debtSnapshot,
       locked: getCollateralAmount(),
-      debt: getDebtAmount(),
+      debt: getCurrentDebt(),
       // newPhase param is so that makeTransferInvitation can finish without setting the vault's phase
       // TODO refactor https://github.com/Agoric/agoric-sdk/issues/4415
       vaultState: newPhase,
@@ -366,7 +365,7 @@ export const makeInnerVault = (
 
     // you must pay off the entire remainder but if you offer too much, we won't
     // take more than you owe
-    const currentDebt = getDebtAmount();
+    const currentDebt = getCurrentDebt();
     assert(
       AmountMath.isGTE(runReturned, currentDebt),
       X`You must pay off the entire debt ${runReturned} > ${currentDebt}`,
@@ -482,7 +481,7 @@ export const makeInnerVault = (
     } else if (proposal.give.RUN) {
       // We don't allow runDebt to be negative, so we'll refund overpayments
       // TODO this is the same as in `transferRun`
-      const currentDebt = getDebtAmount();
+      const currentDebt = getCurrentDebt();
       const acceptedRun = AmountMath.isGTE(proposal.give.RUN, currentDebt)
         ? currentDebt
         : proposal.give.RUN;
@@ -507,7 +506,7 @@ export const makeInnerVault = (
       );
     } else if (proposal.give.RUN) {
       // We don't allow runDebt to be negative, so we'll refund overpayments
-      const currentDebt = getDebtAmount();
+      const currentDebt = getCurrentDebt();
       const acceptedRun = AmountMath.isGTE(proposal.give.RUN, currentDebt)
         ? currentDebt
         : proposal.give.RUN;
@@ -524,7 +523,7 @@ export const makeInnerVault = (
    */
   const loanFee = (proposal, runAfter) => {
     let newDebt;
-    const currentDebt = getDebtAmount();
+    const currentDebt = getCurrentDebt();
     let toMint = AmountMath.makeEmpty(runBrand);
     let fee = AmountMath.makeEmpty(runBrand);
     if (proposal.want.RUN) {
@@ -549,7 +548,7 @@ export const makeInnerVault = (
     // the updater will change if we start a transfer
     const oldUpdater = outerUpdater;
     const proposal = clientSeat.getProposal();
-    const oldDebt = getDebtAmount();
+    const oldDebt = getCurrentDebt();
     const oldCollateral = getCollateralAmount();
 
     assertOnlyKeys(proposal, ['Collateral', 'RUN']);
@@ -657,7 +656,7 @@ export const makeInnerVault = (
       AmountMath.isEmpty(debtSnapshot.run),
       X`vault must be empty initially`,
     );
-    const oldDebt = getDebtAmount();
+    const oldDebt = getCurrentDebt();
     const oldCollateral = getCollateralAmount();
     trace('initVaultKit start: collateral', { oldDebt, oldCollateral });
 
@@ -721,7 +720,7 @@ export const makeInnerVault = (
 
     // for status/debugging
     getCollateralAmount,
-    getDebtAmount,
+    getCurrentDebt,
     getNormalizedDebt,
     getLiquidationSeat: () => liquidationSeat,
   });

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -233,7 +233,6 @@ export const makeInnerVault = (
    * @see getActualDebAmount
    * @returns {Amount<NatValue>} as if the vault was open at the launch of this manager, before any interest accrued
    */
-  // Not in use until https://github.com/Agoric/agoric-sdk/issues/4540
   const getNormalizedDebt = () => {
     assert(debtSnapshot);
     return reverseInterest(debtSnapshot.run, debtSnapshot.interest);
@@ -292,7 +291,6 @@ export const makeInnerVault = (
       liquidationRatio: manager.getLiquidationMargin(),
       debtSnapshot,
       locked: getCollateralAmount(),
-      debt: getCurrentDebt(),
       // newPhase param is so that makeTransferInvitation can finish without setting the vault's phase
       // TODO refactor https://github.com/Agoric/agoric-sdk/issues/4415
       vaultState: newPhase,

--- a/packages/run-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/run-protocol/src/vaultFactory/vaultFactory.js
@@ -38,7 +38,10 @@ import { makeVaultParamManager, makeElectorateParamManager } from './params.js';
 
 const { details: X } = assert;
 
-/** @type {ContractStartFn} */
+/**
+ * @param {ContractFacet} zcf
+ * @param {{feeMintAccess: FeeMintAccess, initialPoserInvitation: Invitation}} privateArgs
+ */
 export const start = async (zcf, privateArgs) => {
   const {
     ammPublicFacet,
@@ -208,9 +211,9 @@ export const start = async (zcf, privateArgs) => {
     return vaultParamManagers.get(paramDesc.collateralBrand).getParams();
   };
 
-  /** @type {VaultFactoryPublicFacet} */
   const publicFacet = Far('vaultFactory public facet', {
-    makeLoanInvitation: makeVaultInvitation, // deprecated
+    /** @deprecated use makeVaultInvitation instead */
+    makeLoanInvitation: makeVaultInvitation,
     makeVaultInvitation,
     getCollaterals,
     getRunIssuer: () => runIssuer,
@@ -258,3 +261,4 @@ export const start = async (zcf, privateArgs) => {
     publicFacet,
   });
 };
+/** @typedef {Unpromise<ReturnType<typeof start>>['publicFacet']} VaultFactoryPublicFacet */

--- a/packages/run-protocol/test/supports.js
+++ b/packages/run-protocol/test/supports.js
@@ -18,7 +18,7 @@ export function makeFakeInnerVault(
   const vault = Far('Vault', {
     getCollateralAmount: () => collateral,
     getNormalizedDebt: () => debt,
-    getDebtAmount: () => debt,
+    getCurrentDebt: () => debt,
     setDebt: newDebt => (debt = newDebt),
     setCollateral: newCollateral => (collateral = newCollateral),
     getIdInManager: () => vaultId,

--- a/packages/run-protocol/test/vaultFactory/swingsetTests/governance/test-governance.js
+++ b/packages/run-protocol/test/vaultFactory/swingsetTests/governance/test-governance.js
@@ -86,8 +86,8 @@ const expectedVaultFactoryLog = [
   'after vote on (InterestRate), InterestRate numerator is 4321',
   'at 3 days: vote closed',
   'at 3 days: Alice owes {"brand":"[Alleged: RUN brand]","value":"[510105n]"}',
-  'at 3 days: 1 day after votes cast, vaultNotifier update #5 has interestRate.numerator 250',
-  'at 4 days: 2 days after votes cast, vaultNotifier update #6 has interestRate.numerator 4321',
+  'at 3 days: 1 day after votes cast, assetNotifier update #5 has interestRate.numerator 250',
+  'at 4 days: 2 days after votes cast, assetNotifier update #6 has interestRate.numerator 4321',
   'at 4 days: Alice owes {"brand":"[Alleged: RUN brand]","value":"[510608n]"}',
 ];
 

--- a/packages/run-protocol/test/vaultFactory/swingsetTests/governance/test-governance.js
+++ b/packages/run-protocol/test/vaultFactory/swingsetTests/governance/test-governance.js
@@ -86,8 +86,8 @@ const expectedVaultFactoryLog = [
   'after vote on (InterestRate), InterestRate numerator is 4321',
   'at 3 days: vote closed',
   'at 3 days: Alice owes {"brand":"[Alleged: RUN brand]","value":"[510105n]"}',
-  'at 3 days: 1 day after votes cast, uiNotifier update #5 has interestRate.numerator 250',
-  'at 4 days: 2 days after votes cast, uiNotifier update #6 has interestRate.numerator 4321',
+  'at 3 days: 1 day after votes cast, vaultNotifier update #5 has interestRate.numerator 250',
+  'at 4 days: 2 days after votes cast, vaultNotifier update #6 has interestRate.numerator 4321',
   'at 4 days: Alice owes {"brand":"[Alleged: RUN brand]","value":"[510608n]"}',
 ];
 

--- a/packages/run-protocol/test/vaultFactory/swingsetTests/governance/vat-alice.js
+++ b/packages/run-protocol/test/vaultFactory/swingsetTests/governance/vat-alice.js
@@ -42,7 +42,7 @@ const build = async (log, zoe, brands, payments, timer) => {
     );
 
     /** @type {VaultKit} */
-    const { vault, uiNotifier } = await E(loanSeat).getOfferResult();
+    const { vault, vaultNotifier } = await E(loanSeat).getOfferResult();
 
     const timeLog = async msg =>
       log(
@@ -65,8 +65,8 @@ const build = async (log, zoe, brands, payments, timer) => {
     timeLog(`Alice owes ${q(await E(vault).getCurrentDebt())}`);
 
     const uiDescription = async () => {
-      const current = await E(uiNotifier).getUpdateSince();
-      return `uiNotifier update #${current.updateCount} has interestRate.numerator ${current.value.interestRate.numerator.value}`;
+      const current = await E(vaultNotifier).getUpdateSince();
+      return `vaultNotifier update #${current.updateCount} has interestRate.numerator ${current.value.interestRate.numerator.value}`;
     };
 
     timeLog(`1 day after votes cast, ${await uiDescription()}`);

--- a/packages/run-protocol/test/vaultFactory/swingsetTests/governance/vat-alice.js
+++ b/packages/run-protocol/test/vaultFactory/swingsetTests/governance/vat-alice.js
@@ -49,20 +49,20 @@ const build = async (log, zoe, brands, payments, timer) => {
         `at ${(await E(timer).getCurrentTimestamp()) / ONE_DAY} days: ${msg}`,
       );
 
-    timeLog(`Alice owes ${q(await E(vault).getDebtAmount())}`);
+    timeLog(`Alice owes ${q(await E(vault).getCurrentDebt())}`);
 
     // accrue one day of interest at initial rate
     await E(timer).tick();
-    timeLog(`Alice owes ${q(await E(vault).getDebtAmount())}`);
+    timeLog(`Alice owes ${q(await E(vault).getCurrentDebt())}`);
 
     // advance time enough that governance updates the interest rate
     await Promise.all(new Array(daysForVoting).fill(E(timer).tick()));
     timeLog('vote ready to close');
-    timeLog(`Alice owes ${q(await E(vault).getDebtAmount())}`);
+    timeLog(`Alice owes ${q(await E(vault).getCurrentDebt())}`);
 
     await E(timer).tick();
     timeLog('vote closed');
-    timeLog(`Alice owes ${q(await E(vault).getDebtAmount())}`);
+    timeLog(`Alice owes ${q(await E(vault).getCurrentDebt())}`);
 
     const uiDescription = async () => {
       const current = await E(uiNotifier).getUpdateSince();
@@ -72,7 +72,7 @@ const build = async (log, zoe, brands, payments, timer) => {
     timeLog(`1 day after votes cast, ${await uiDescription()}`);
     await E(timer).tick();
     timeLog(`2 days after votes cast, ${await uiDescription()}`);
-    timeLog(`Alice owes ${q(await E(vault).getDebtAmount())}`);
+    timeLog(`Alice owes ${q(await E(vault).getCurrentDebt())}`);
   };
 
   return Far('build', {

--- a/packages/run-protocol/test/vaultFactory/swingsetTests/governance/vat-alice.js
+++ b/packages/run-protocol/test/vaultFactory/swingsetTests/governance/vat-alice.js
@@ -22,7 +22,7 @@ const build = async (log, zoe, brands, payments, timer) => {
   const [moolaPayment] = payments;
 
   /**
-   * @param {VaultFactoryPublicFacet} vaultFactory
+   * @param {import('../../test-vaultFactory').VaultFactoryPublicFacet} vaultFactory
    */
   const oneLoanWithInterest = async vaultFactory => {
     log(`=> alice.oneLoanWithInterest called`);
@@ -30,6 +30,7 @@ const build = async (log, zoe, brands, payments, timer) => {
     const runIssuer = await E(vaultFactory).getRunIssuer();
     const runBrand = await E(runIssuer).getBrand();
 
+    /** @type {UserSeat<VaultKit>} */
     const loanSeat = await E(zoe).offer(
       E(vaultFactory).makeLoanInvitation(),
       harden({
@@ -77,7 +78,7 @@ const build = async (log, zoe, brands, payments, timer) => {
   return Far('build', {
     /**
      * @param {string} testName
-     * @param {VaultFactoryPublicFacet} vaultFactory
+     * @param {import('../../test-vaultFactory').VaultFactoryPublicFacet} vaultFactory
      * @returns {Promise<void>}
      */
     startTest: async (testName, vaultFactory) => {

--- a/packages/run-protocol/test/vaultFactory/swingsetTests/governance/vat-alice.js
+++ b/packages/run-protocol/test/vaultFactory/swingsetTests/governance/vat-alice.js
@@ -41,8 +41,7 @@ const build = async (log, zoe, brands, payments, timer) => {
       }),
     );
 
-    /** @type {VaultKit} */
-    const { vault, vaultNotifier } = await E(loanSeat).getOfferResult();
+    const { assetNotifier, vault } = await E(loanSeat).getOfferResult();
 
     const timeLog = async msg =>
       log(
@@ -65,8 +64,8 @@ const build = async (log, zoe, brands, payments, timer) => {
     timeLog(`Alice owes ${q(await E(vault).getCurrentDebt())}`);
 
     const uiDescription = async () => {
-      const current = await E(vaultNotifier).getUpdateSince();
-      return `vaultNotifier update #${current.updateCount} has interestRate.numerator ${current.value.interestRate.numerator.value}`;
+      const current = await E(assetNotifier).getUpdateSince();
+      return `assetNotifier update #${current.updateCount} has interestRate.numerator ${current.value.interestRate.numerator.value}`;
     };
 
     timeLog(`1 day after votes cast, ${await uiDescription()}`);

--- a/packages/run-protocol/test/vaultFactory/swingsetTests/vaultFactory/vat-alice.js
+++ b/packages/run-protocol/test/vaultFactory/swingsetTests/vaultFactory/vat-alice.js
@@ -36,9 +36,9 @@ const build = async (log, zoe, brands, payments, timer) => {
     );
 
     const { vault } = await E(loanSeat).getOfferResult();
-    log(`Alice owes ${q(await E(vault).getDebtAmount())} after borrowing`);
+    log(`Alice owes ${q(await E(vault).getCurrentDebt())} after borrowing`);
     await E(timer).tick();
-    log(`Alice owes ${q(await E(vault).getDebtAmount())} after interest`);
+    log(`Alice owes ${q(await E(vault).getCurrentDebt())} after interest`);
   };
 
   return Far('build', {

--- a/packages/run-protocol/test/vaultFactory/test-orderedVaultStore.js
+++ b/packages/run-protocol/test/vaultFactory/test-orderedVaultStore.js
@@ -14,7 +14,7 @@ const mockVault = (runCount, collateralCount) => {
   const collateralAmount = AmountMath.make(brand, collateralCount);
 
   return Far('vault', {
-    getDebtAmount: () => debtAmount,
+    getCurrentDebt: () => debtAmount,
     getCollateralAmount: () => collateralAmount,
   });
 };

--- a/packages/run-protocol/test/vaultFactory/test-prioritizedVaults.js
+++ b/packages/run-protocol/test/vaultFactory/test-prioritizedVaults.js
@@ -240,13 +240,13 @@ test('highestRatio', async t => {
   const debtsOverThreshold = [];
   Array.from(vaults.entriesPrioritizedGTE(percent(45))).map(([_key, vault]) =>
     debtsOverThreshold.push([
-      vault.getDebtAmount(),
+      vault.getCurrentDebt(),
       vault.getCollateralAmount(),
     ]),
   );
 
   t.deepEqual(debtsOverThreshold, [
-    [fakeVault6.getDebtAmount(), fakeVault6.getCollateralAmount()],
+    [fakeVault6.getCurrentDebt(), fakeVault6.getCollateralAmount()],
   ]);
   t.deepEqual(vaults.highestRatio(), percent(50), 'expected 50% to be highest');
 });

--- a/packages/run-protocol/test/vaultFactory/test-vault-interest.js
+++ b/packages/run-protocol/test/vaultFactory/test-vault-interest.js
@@ -98,7 +98,7 @@ test('charges', async t => {
 
   const startingDebt = 74n;
   t.deepEqual(
-    vault.getDebtAmount(),
+    vault.getCurrentDebt(),
     AmountMath.make(runBrand, startingDebt),
     'borrower owes 74 RUN',
   );
@@ -114,7 +114,7 @@ test('charges', async t => {
     testJig.advanceRecordingPeriod();
     interest += charge;
     t.is(
-      vault.getDebtAmount().value,
+      vault.getCurrentDebt().value,
       startingDebt + interest,
       `interest charge ${i} should have been ${charge}`,
     );
@@ -136,7 +136,7 @@ test('charges', async t => {
   );
   await E(paybackSeat).getOfferResult();
   t.deepEqual(
-    vault.getDebtAmount(),
+    vault.getCurrentDebt(),
     AmountMath.make(runBrand, startingDebt + interest - paybackValue),
   );
   const normalizedPaybackValue = paybackValue + 1n;
@@ -151,7 +151,7 @@ test('charges', async t => {
     testJig.advanceRecordingPeriod();
     interest += charge;
     t.is(
-      vault.getDebtAmount().value,
+      vault.getCurrentDebt().value,
       startingDebt + interest - paybackValue,
       `interest charge ${i} should have been ${charge}`,
     );

--- a/packages/run-protocol/test/vaultFactory/test-vault.js
+++ b/packages/run-protocol/test/vaultFactory/test-vault.js
@@ -100,7 +100,7 @@ test('first', async t => {
   const { issuer: cIssuer, mint: cMint, brand: cBrand } = collateralKit;
 
   t.deepEqual(
-    vault.getDebtAmount(),
+    vault.getCurrentDebt(),
     AmountMath.make(runBrand, 74n),
     'borrower owes 74 RUN',
   );
@@ -153,7 +153,7 @@ test('first', async t => {
   trace('returnedCollateral', returnedCollateral, cIssuer);
   const returnedAmount = await cIssuer.getAmountOf(returnedCollateral);
   t.deepEqual(
-    vault.getDebtAmount(),
+    vault.getCurrentDebt(),
     AmountMath.make(runBrand, 71n),
     'debt reduced to 71 RUN',
   );
@@ -188,7 +188,7 @@ test('bad collateral', async t => {
     'vault should hold 50 Collateral',
   );
   t.deepEqual(
-    vault.getDebtAmount(),
+    vault.getCurrentDebt(),
     AmountMath.make(runBrand, 74n),
     'borrower owes 74 RUN',
   );

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -502,7 +502,7 @@ test('price drop', async t => {
   );
   trace('loan made', loanAmount);
 
-  const { vault, uiNotifier } = await E(loanSeat).getOfferResult();
+  const { vault, vaultNotifier } = await E(loanSeat).getOfferResult();
   trace('offer result', vault);
   const debtAmount = await E(vault).getCurrentDebt();
   const fee = ceilMultiplyBy(loanAmount, rates.loanFee);
@@ -513,7 +513,7 @@ test('price drop', async t => {
   );
 
   /** @type {UpdateRecord<VaultUIState>} */
-  let notification = await E(uiNotifier).getUpdateSince();
+  let notification = await E(vaultNotifier).getUpdateSince();
   trace('got notificaation', notification);
 
   t.is(notification.value.vaultState, Phase.ACTIVE);
@@ -526,21 +526,25 @@ test('price drop', async t => {
     'vault holds 11 Collateral',
   );
   await manualTimer.tick();
-  notification = await E(uiNotifier).getUpdateSince();
+  notification = await E(vaultNotifier).getUpdateSince();
   t.is(notification.value.vaultState, Phase.ACTIVE);
 
   await manualTimer.tick();
-  notification = await E(uiNotifier).getUpdateSince(notification.updateCount);
+  notification = await E(vaultNotifier).getUpdateSince(
+    notification.updateCount,
+  );
   trace('price changed to liquidate', notification.value.vaultState);
   t.is(notification.value.vaultState, Phase.LIQUIDATING);
 
   await manualTimer.tick();
-  notification = await E(uiNotifier).getUpdateSince(notification.updateCount);
+  notification = await E(vaultNotifier).getUpdateSince(
+    notification.updateCount,
+  );
   t.falsy(notification.updateCount);
   t.is(notification.value.vaultState, Phase.LIQUIDATED);
 
   const debtAmountAfter = await E(vault).getCurrentDebt();
-  const finalNotification = await E(uiNotifier).getUpdateSince();
+  const finalNotification = await E(vaultNotifier).getUpdateSince();
   t.is(finalNotification.value.vaultState, Phase.LIQUIDATED);
   t.truthy(AmountMath.isEmpty(debtAmountAfter));
 
@@ -796,7 +800,7 @@ test('interest on multiple vaults', async t => {
       Collateral: aethMint.mintPayment(collateralAmount),
     }),
   );
-  const { vault: aliceVault, uiNotifier: aliceNotifier } = await E(
+  const { vault: aliceVault, vaultNotifier: aliceNotifier } = await E(
     aliceLoanSeat,
   ).getOfferResult();
 
@@ -833,7 +837,7 @@ test('interest on multiple vaults', async t => {
       Collateral: aethMint.mintPayment(bobCollateralAmount),
     }),
   );
-  const { vault: bobVault, uiNotifier: bobNotifier } = await E(
+  const { vault: bobVault, vaultNotifier: bobNotifier } = await E(
     bobLoanSeat,
   ).getOfferResult();
 
@@ -935,8 +939,8 @@ test('interest on multiple vaults', async t => {
       Collateral: aethMint.mintPayment(AmountMath.make(aethBrand, 2_000n)),
     }),
   );
-  /** @type {{vault: Vault, uiNotifier: Notifier<*>}} */
-  const { vault: danVault, uiNotifier: danNotifier } = await E(
+  /** @type {{vault: Vault, vaultNotifier: Notifier<*>}} */
+  const { vault: danVault, vaultNotifier: danNotifier } = await E(
     danLoanSeat,
   ).getOfferResult();
   const danActualDebt = wantedRun + 50n; // includes fees
@@ -1004,7 +1008,7 @@ test('adjust balances', async t => {
       Collateral: aethMint.mintPayment(collateralAmount),
     }),
   );
-  const { vault: aliceVault, uiNotifier: aliceNotifier } = await E(
+  const { vault: aliceVault, vaultNotifier: aliceNotifier } = await E(
     aliceLoanSeat,
   ).getOfferResult();
 
@@ -1256,7 +1260,7 @@ test('transfer vault', async t => {
       Collateral: aethMint.mintPayment(collateralAmount),
     }),
   );
-  const { vault: aliceVault, uiNotifier: aliceNotifier } = await E(
+  const { vault: aliceVault, vaultNotifier: aliceNotifier } = await E(
     aliceLoanSeat,
   ).getOfferResult();
 
@@ -1265,7 +1269,7 @@ test('transfer vault', async t => {
   // TODO this should not need `await`
   const transferInvite = await E(aliceVault).makeTransferInvitation();
   const transferSeat = await E(zoe).offer(transferInvite);
-  const { vault: transferVault, uiNotifier: transferNotifier } = await E(
+  const { vault: transferVault, vaultNotifier: transferNotifier } = await E(
     transferSeat,
   ).getOfferResult();
   t.throwsAsync(() => E(aliceVault).getCurrentDebt());
@@ -1315,7 +1319,7 @@ test('transfer vault', async t => {
   );
   const t2Invite = await E(transferVault).makeTransferInvitation();
   const t2Seat = await E(zoe).offer(t2Invite);
-  const { vault: t2Vault, uiNotifier: t2Notifier } = await E(
+  const { vault: t2Vault, vaultNotifier: t2Notifier } = await E(
     t2Seat,
   ).getOfferResult();
   t.throwsAsync(async () => E(adjustPromise).getOfferResult());
@@ -1394,7 +1398,7 @@ test('overdeposit', async t => {
       Collateral: aethMint.mintPayment(collateralAmount),
     }),
   );
-  const { vault: aliceVault, uiNotifier: aliceNotifier } = await E(
+  const { vault: aliceVault, vaultNotifier: aliceNotifier } = await E(
     aliceLoanSeat,
   ).getOfferResult();
 
@@ -1554,7 +1558,7 @@ test('mutable liquidity triggers and interest', async t => {
       Collateral: aethMint.mintPayment(aliceCollateralAmount),
     }),
   );
-  const { vault: aliceVault, uiNotifier: aliceNotifier } = await E(
+  const { vault: aliceVault, vaultNotifier: aliceNotifier } = await E(
     aliceLoanSeat,
   ).getOfferResult();
 
@@ -1593,7 +1597,7 @@ test('mutable liquidity triggers and interest', async t => {
       Collateral: aethMint.mintPayment(bobCollateralAmount),
     }),
   );
-  const { vault: bobVault, uiNotifier: bobNotifier } = await E(
+  const { vault: bobVault, vaultNotifier: bobNotifier } = await E(
     bobLoanSeat,
   ).getOfferResult();
 
@@ -1846,7 +1850,7 @@ test('close loan', async t => {
       Collateral: aethMint.mintPayment(collateralAmount),
     }),
   );
-  const { vault: aliceVault, uiNotifier: aliceNotifier } = await E(
+  const { vault: aliceVault, vaultNotifier: aliceNotifier } = await E(
     aliceLoanSeat,
   ).getOfferResult();
 
@@ -2058,7 +2062,7 @@ test('mutable liquidity triggers and interest sensitivity', async t => {
       Collateral: aethMint.mintPayment(aliceCollateralAmount),
     }),
   );
-  const { vault: aliceVault, uiNotifier: aliceNotifier } = await E(
+  const { vault: aliceVault, vaultNotifier: aliceNotifier } = await E(
     aliceLoanSeat,
   ).getOfferResult();
 
@@ -2097,7 +2101,7 @@ test('mutable liquidity triggers and interest sensitivity', async t => {
       Collateral: aethMint.mintPayment(bobCollateralAmount),
     }),
   );
-  const { vault: bobVault, uiNotifier: bobNotifier } = await E(
+  const { vault: bobVault, vaultNotifier: bobNotifier } = await E(
     bobLoanSeat,
   ).getOfferResult();
 

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -2183,20 +2183,13 @@ test('mutable liquidity triggers and interest sensitivity', async t => {
   // Bob's loan is now 777 RUN (including interest) on 100 Aeth, with the price
   // at 7. 100 * 7 > 1.05 * 777. When interest is charged again, Bob should get
   // liquidated.
-
+  // Advance time to trigger interest collection.
   for (let i = 0; i < 8; i += 1) {
     manualTimer.tick();
   }
   await waitForPromisesToSettle();
-  aliceUpdate = await E(aliceNotifier).getUpdateSince(aliceUpdate.updateCount);
+  aliceUpdate = await E(aliceNotifier).getUpdateSince();
   bobUpdate = await E(bobNotifier).getUpdateSince();
   t.is(aliceUpdate.value.vaultState, Phase.ACTIVE);
-
-  for (let i = 0; i < 5; i += 1) {
-    manualTimer.tick();
-  }
-  await waitForPromisesToSettle();
-  bobUpdate = await E(bobNotifier).getUpdateSince();
-
   t.is(bobUpdate.value.vaultState, Phase.LIQUIDATED);
 });

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -359,7 +359,7 @@ test('first', async t => {
   );
 
   const { vault } = await E(loanSeat).getOfferResult();
-  const debtAmount = await E(vault).getDebtAmount();
+  const debtAmount = await E(vault).getCurrentDebt();
   const fee = ceilMultiplyBy(AmountMath.make(runBrand, 470n), rates.loanFee);
   t.deepEqual(
     debtAmount,
@@ -403,7 +403,7 @@ test('first', async t => {
   const payouts = E(seat).getPayouts();
   const { Collateral: returnedCollateral, RUN: returnedRun } = await payouts;
   t.deepEqual(
-    await E(vault).getDebtAmount(),
+    await E(vault).getCurrentDebt(),
     AmountMath.make(runBrand, 294n),
     'debt reduced to 294 RUN',
   );
@@ -425,7 +425,7 @@ test('first', async t => {
 
   await E(aethVaultManager).liquidateAll();
   t.truthy(
-    AmountMath.isEmpty(await E(vault).getDebtAmount()),
+    AmountMath.isEmpty(await E(vault).getCurrentDebt()),
     'debt is paid off',
   );
   t.truthy(
@@ -504,7 +504,7 @@ test('price drop', async t => {
 
   const { vault, uiNotifier } = await E(loanSeat).getOfferResult();
   trace('offer result', vault);
-  const debtAmount = await E(vault).getDebtAmount();
+  const debtAmount = await E(vault).getCurrentDebt();
   const fee = ceilMultiplyBy(loanAmount, rates.loanFee);
   t.deepEqual(
     debtAmount,
@@ -539,7 +539,7 @@ test('price drop', async t => {
   t.falsy(notification.updateCount);
   t.is(notification.value.vaultState, Phase.LIQUIDATED);
 
-  const debtAmountAfter = await E(vault).getDebtAmount();
+  const debtAmountAfter = await E(vault).getCurrentDebt();
   const finalNotification = await E(uiNotifier).getUpdateSince();
   t.is(finalNotification.value.vaultState, Phase.LIQUIDATED);
   t.truthy(AmountMath.isEmpty(debtAmountAfter));
@@ -616,7 +616,7 @@ test('price falls precipitously', async t => {
 
   /** @type {{vault: Vault}} */
   const { vault } = await E(loanSeat).getOfferResult();
-  const debtAmount = await E(vault).getDebtAmount();
+  const debtAmount = await E(vault).getCurrentDebt();
   const fee = ceilMultiplyBy(AmountMath.make(runBrand, 370n), rates.loanFee);
   t.deepEqual(
     debtAmount,
@@ -650,7 +650,7 @@ test('price falls precipitously', async t => {
   );
 
   async function assertDebtIs(value) {
-    const debt = await E(vault).getDebtAmount();
+    const debt = await E(vault).getCurrentDebt();
     t.is(
       debt.value,
       BigInt(value),
@@ -670,7 +670,7 @@ test('price falls precipitously', async t => {
   await manualTimer.tick();
   await waitForPromisesToSettle();
   // An emergency liquidation got less than full value
-  const newDebtAmount = await E(vault).getDebtAmount();
+  const newDebtAmount = await E(vault).getCurrentDebt();
   t.truthy(
     AmountMath.isGTE(AmountMath.make(runBrand, 70n), newDebtAmount),
     `Expected ${newDebtAmount.value} to be less than 70`,
@@ -800,7 +800,7 @@ test('interest on multiple vaults', async t => {
     aliceLoanSeat,
   ).getOfferResult();
 
-  const debtAmount = await E(aliceVault).getDebtAmount();
+  const debtAmount = await E(aliceVault).getCurrentDebt();
   const fee = ceilMultiplyBy(aliceLoanAmount, rates.loanFee);
   t.deepEqual(
     debtAmount,
@@ -837,7 +837,7 @@ test('interest on multiple vaults', async t => {
     bobLoanSeat,
   ).getOfferResult();
 
-  const bobDebtAmount = await E(bobVault).getDebtAmount();
+  const bobDebtAmount = await E(bobVault).getCurrentDebt();
   const bobFee = ceilMultiplyBy(bobLoanAmount, rates.loanFee);
   t.deepEqual(
     bobDebtAmount,
@@ -940,7 +940,7 @@ test('interest on multiple vaults', async t => {
     danLoanSeat,
   ).getOfferResult();
   const danActualDebt = wantedRun + 50n; // includes fees
-  t.is((await E(danVault).getDebtAmount()).value, danActualDebt);
+  t.is((await E(danVault).getCurrentDebt()).value, danActualDebt);
   const normalizedDebt = (await E(danVault).getNormalizedDebt()).value;
   t.true(
     normalizedDebt < danActualDebt,
@@ -1008,7 +1008,7 @@ test('adjust balances', async t => {
     aliceLoanSeat,
   ).getOfferResult();
 
-  let debtAmount = await E(aliceVault).getDebtAmount();
+  let debtAmount = await E(aliceVault).getCurrentDebt();
   const fee = ceilMultiplyBy(aliceLoanAmount, rates.loanFee);
   let runDebtLevel = AmountMath.add(aliceLoanAmount, fee);
   let collateralLevel = AmountMath.make(aethBrand, 1000n);
@@ -1058,7 +1058,7 @@ test('adjust balances', async t => {
   );
 
   await E(aliceAddCollateralSeat1).getOfferResult();
-  debtAmount = await E(aliceVault).getDebtAmount();
+  debtAmount = await E(aliceVault).getCurrentDebt();
   t.deepEqual(debtAmount, runDebtLevel);
 
   const { RUN: lentAmount2 } = await E(
@@ -1111,7 +1111,7 @@ test('adjust balances', async t => {
   const loanProceeds3 = await E(aliceAddCollateralSeat2).getPayouts();
   t.deepEqual(lentAmount3, AmountMath.make(runBrand, 50n));
 
-  debtAmount = await E(aliceVault).getDebtAmount();
+  debtAmount = await E(aliceVault).getCurrentDebt();
   t.deepEqual(debtAmount, runDebtLevel);
 
   const runLent3 = await loanProceeds3.RUN;
@@ -1150,7 +1150,7 @@ test('adjust balances', async t => {
 
   await E(aliceReduceCollateralSeat).getOfferResult();
 
-  debtAmount = await E(aliceVault).getDebtAmount();
+  debtAmount = await E(aliceVault).getCurrentDebt();
   t.deepEqual(debtAmount, runDebtLevel);
   t.deepEqual(collateralLevel, await E(aliceVault).getCollateralAmount());
 
@@ -1260,7 +1260,7 @@ test('transfer vault', async t => {
     aliceLoanSeat,
   ).getOfferResult();
 
-  const debtAmount = await E(aliceVault).getDebtAmount();
+  const debtAmount = await E(aliceVault).getCurrentDebt();
 
   // TODO this should not need `await`
   const transferInvite = await E(aliceVault).makeTransferInvitation();
@@ -1268,8 +1268,8 @@ test('transfer vault', async t => {
   const { vault: transferVault, uiNotifier: transferNotifier } = await E(
     transferSeat,
   ).getOfferResult();
-  t.throwsAsync(() => E(aliceVault).getDebtAmount());
-  const debtAfter = await E(transferVault).getDebtAmount();
+  t.throwsAsync(() => E(aliceVault).getCurrentDebt());
+  const debtAfter = await E(transferVault).getCurrentDebt();
   t.deepEqual(debtAmount, debtAfter, 'vault lent 5000 RUN + fees');
   const collateralAfter = await E(transferVault).getCollateralAmount();
   t.deepEqual(collateralAmount, collateralAfter, 'vault has 1000n aEth');
@@ -1319,8 +1319,8 @@ test('transfer vault', async t => {
     t2Seat,
   ).getOfferResult();
   t.throwsAsync(async () => E(adjustPromise).getOfferResult());
-  t.throwsAsync(() => E(transferVault).getDebtAmount());
-  const debtAfter2 = await E(t2Vault).getDebtAmount();
+  t.throwsAsync(() => E(transferVault).getCurrentDebt());
+  const debtAfter2 = await E(t2Vault).getCurrentDebt();
   t.deepEqual(debtAmount, debtAfter2, 'vault lent 5000 RUN + fees');
 
   const collateralAfter2 = await E(t2Vault).getCollateralAmount();
@@ -1398,7 +1398,7 @@ test('overdeposit', async t => {
     aliceLoanSeat,
   ).getOfferResult();
 
-  let debtAmount = await E(aliceVault).getDebtAmount();
+  let debtAmount = await E(aliceVault).getCurrentDebt();
   const fee = ceilMultiplyBy(aliceLoanAmount, rates.loanFee);
   const runDebt = AmountMath.add(aliceLoanAmount, fee);
 
@@ -1458,7 +1458,7 @@ test('overdeposit', async t => {
   );
 
   await E(aliceOverpaySeat).getOfferResult();
-  debtAmount = await E(aliceVault).getDebtAmount();
+  debtAmount = await E(aliceVault).getCurrentDebt();
   t.deepEqual(debtAmount, AmountMath.makeEmpty(runBrand));
 
   const { RUN: lentAmount5 } = await E(aliceOverpaySeat).getCurrentAllocation();
@@ -1558,7 +1558,7 @@ test('mutable liquidity triggers and interest', async t => {
     aliceLoanSeat,
   ).getOfferResult();
 
-  const aliceDebtAmount = await E(aliceVault).getDebtAmount();
+  const aliceDebtAmount = await E(aliceVault).getCurrentDebt();
   const fee = ceilMultiplyBy(aliceLoanAmount, rates.loanFee);
   const aliceRunDebtLevel = AmountMath.add(aliceLoanAmount, fee);
 
@@ -1597,7 +1597,7 @@ test('mutable liquidity triggers and interest', async t => {
     bobLoanSeat,
   ).getOfferResult();
 
-  const bobDebtAmount = await E(bobVault).getDebtAmount();
+  const bobDebtAmount = await E(bobVault).getCurrentDebt();
   const bobFee = ceilMultiplyBy(bobLoanAmount, rates.loanFee);
   const bobRunDebtLevel = AmountMath.add(bobLoanAmount, bobFee);
 
@@ -1749,7 +1749,7 @@ test('collect fees from loan and AMM', async t => {
   );
 
   const { vault } = await E(loanSeat).getOfferResult();
-  const debtAmount = await E(vault).getDebtAmount();
+  const debtAmount = await E(vault).getCurrentDebt();
   const fee = ceilMultiplyBy(AmountMath.make(runBrand, 470n), rates.loanFee);
   t.deepEqual(debtAmount, AmountMath.add(loanAmount, fee), 'vault loaned RUN');
   trace('correct debt', debtAmount);
@@ -1850,7 +1850,7 @@ test('close loan', async t => {
     aliceLoanSeat,
   ).getOfferResult();
 
-  const debtAmount = await E(aliceVault).getDebtAmount();
+  const debtAmount = await E(aliceVault).getCurrentDebt();
   const fee = ceilMultiplyBy(aliceLoanAmount, rates.loanFee);
   const runDebtLevel = AmountMath.add(aliceLoanAmount, fee);
 
@@ -2062,7 +2062,7 @@ test('mutable liquidity triggers and interest sensitivity', async t => {
     aliceLoanSeat,
   ).getOfferResult();
 
-  const aliceDebtAmount = await E(aliceVault).getDebtAmount();
+  const aliceDebtAmount = await E(aliceVault).getCurrentDebt();
   const fee = ceilMultiplyBy(aliceLoanAmount, rates.loanFee);
   const aliceRunDebtLevel = AmountMath.add(aliceLoanAmount, fee);
 
@@ -2101,7 +2101,7 @@ test('mutable liquidity triggers and interest sensitivity', async t => {
     bobLoanSeat,
   ).getOfferResult();
 
-  const bobDebtAmount = await E(bobVault).getDebtAmount();
+  const bobDebtAmount = await E(bobVault).getCurrentDebt();
   const bobFee = ceilMultiplyBy(bobLoanAmount, rates.loanFee);
   const bobRunDebtLevel = AmountMath.add(bobLoanAmount, bobFee);
 

--- a/packages/run-protocol/test/vaultFactory/vault-contract-wrapper.js
+++ b/packages/run-protocol/test/vaultFactory/vault-contract-wrapper.js
@@ -146,10 +146,10 @@ export async function start(zcf, privateArgs) {
       collateralKit,
       actions: Far('vault actions', {
         add() {
-          return vaultKit.makeAdjustBalancesInvitation();
+          return vaultKit.invitationMakers.AdjustBalances();
         },
       }),
-      notifier: vaultKit.uiNotifier,
+      notifier: vaultKit.vaultNotifier,
     };
   }
 

--- a/packages/zoe/src/contractFacet/types.js
+++ b/packages/zoe/src/contractFacet/types.js
@@ -82,6 +82,7 @@
  */
 
 /**
+ * @template {object} [OR=any] OR is OfferResult
  * @callback MakeInvitation
  *
  * Make a credible Zoe invitation for a particular smart contract
@@ -93,11 +94,11 @@
  * getting in the `customProperties`. `customProperties` will be
  * placed in the details of the invitation.
  *
- * @param {OfferHandler=} offerHandler - a contract specific function
+ * @param {OfferHandler<OR>} offerHandler - a contract specific function
  * that handles the offer, such as saving it or performing a trade
  * @param {string} description
  * @param {Object=} customProperties
- * @returns {Promise<Invitation>}
+ * @returns {Promise<Invitation<OR>>}
  */
 
 /**
@@ -209,10 +210,11 @@
  */
 
 /**
+ * @template {Object} [OR=any]
  * @callback OfferHandler
  * @param {ZCFSeat} seat
  * @param {Object=} offerArgs
- * @returns {any}
+ * @returns {OR}
  */
 
 /**

--- a/packages/zoe/src/contractSupport/index.js
+++ b/packages/zoe/src/contractSupport/index.js
@@ -21,6 +21,7 @@ export { natSafeMath } from './safeMath.js';
 
 export { makeStateMachine } from './stateMachine.js';
 
+export * from './interest.js';
 export * from './statistics.js';
 
 export {

--- a/packages/zoe/src/contractSupport/interest.js
+++ b/packages/zoe/src/contractSupport/interest.js
@@ -1,0 +1,60 @@
+// @ts-check
+
+import {
+  floorDivideBy,
+  floorMultiplyBy,
+  invertRatio,
+  multiplyRatios,
+  ratiosSame,
+} from './ratio.js';
+
+/**
+ *
+ * @param {Ratio} currentCompoundedInterest as coefficient
+ * @param {Ratio} previousCompoundedInterest as coefficient
+ * @returns {Ratio} additional compounding since the previous
+ */
+const calculateRelativeCompounding = (
+  currentCompoundedInterest,
+  previousCompoundedInterest,
+) => {
+  // divide compounded interest by the snapshot
+  return multiplyRatios(
+    currentCompoundedInterest,
+    invertRatio(previousCompoundedInterest),
+  );
+};
+
+/**
+ *
+ * @param {Amount<NatValue>} debtSnapshot
+ * @param {Ratio} interestSnapshot as coefficient
+ * @param {Ratio} currentCompoundedInterest as coefficient
+ * @returns {Amount<NatValue>}
+ */
+export const calculateCurrentDebt = (
+  debtSnapshot,
+  interestSnapshot,
+  currentCompoundedInterest,
+) => {
+  if (ratiosSame(interestSnapshot, currentCompoundedInterest)) {
+    return debtSnapshot;
+  }
+
+  const interestSinceSnapshot = calculateRelativeCompounding(
+    currentCompoundedInterest,
+    interestSnapshot,
+  );
+
+  return floorMultiplyBy(debtSnapshot, interestSinceSnapshot);
+};
+
+/**
+ *
+ * @param {Amount<NatValue>} debt
+ * @param {Ratio} interestApplied
+ * @returns {Amount<NatValue>}
+ */
+export const reverseInterest = (debt, interestApplied) => {
+  return floorDivideBy(debt, interestApplied);
+};

--- a/packages/zoe/src/contractSupport/ratio.js
+++ b/packages/zoe/src/contractSupport/ratio.js
@@ -269,6 +269,20 @@ export const ratioGTE = (left, right) => {
 };
 
 /**
+ * True iff the ratios are the same values (equal or equivalant may return false)
+ *
+ * @param {Ratio} left
+ * @param {Ratio} right
+ * @returns {boolean}
+ */
+export const ratiosSame = (left, right) => {
+  return (
+    AmountMath.isEqual(left.numerator, right.numerator) &&
+    AmountMath.isEqual(left.denominator, right.denominator)
+  );
+};
+
+/**
  * Make an equivalant ratio with a new denominator
  *
  * @param {Ratio} ratio

--- a/packages/zoe/src/internal-types.js
+++ b/packages/zoe/src/internal-types.js
@@ -30,7 +30,7 @@
  * @param {ProposalRecord} proposal
  * @param {WithdrawPayments} withdrawPayments
  * @param {ERef<ExitObj>} exitObj
- * @param {ERef<OfferResult>=} offerResult
+ * @param {ERef<unknown>} [offerResult]
  * @returns {ZoeSeatAdminKit}
  */
 

--- a/packages/zoe/src/types.js
+++ b/packages/zoe/src/types.js
@@ -42,5 +42,8 @@
  */
 
 /**
+ * XXX offer() return value at runtime is implied by the invitation but it's not typed
+ *
+ * @template {object} [OR=unknown]
  * @typedef {Payment} Invitation
  */

--- a/packages/zoe/src/zoeService/types.js
+++ b/packages/zoe/src/zoeService/types.js
@@ -172,6 +172,7 @@
  */
 
 /**
+ * @template {object} [OR=any]
  * @callback Offer
  *
  * To redeem an invitation, the user normally provides a proposal (their
@@ -188,28 +189,25 @@
  * values are the actual payments to be escrowed. A payment is
  * expected for every rule under `give`.
  *
- * @param {ERef<Invitation>} invitation
+ * @param {ERef<Invitation<OR>>} invitation
  * @param {Proposal=} proposal
  * @param {PaymentPKeywordRecord=} paymentKeywordRecord
  * @param {Object=} offerArgs
- * @returns {Promise<UserSeat>} seat
+ * @returns {Promise<UserSeat<OR>>} seat
  */
 
 /**
+ * @template {Object} [OR=any]
  * @typedef {Object} UserSeat
  * @property {() => Promise<Allocation>} getCurrentAllocation
  * TODO remove getCurrentAllocation query
  * @property {() => Promise<ProposalRecord>} getProposal
  * @property {() => Promise<PaymentPKeywordRecord>} getPayouts
  * @property {(keyword: Keyword) => Promise<Payment>} getPayout
- * @property {() => Promise<OfferResult>} getOfferResult
+ * @property {() => Promise<OR>} getOfferResult
  * @property {() => void=} tryExit
  * @property {() => Promise<boolean>} hasExited
  * @property {() => Promise<Notifier<Allocation>>} getNotifier
- */
-
-/**
- * @typedef {any} OfferResult
  */
 
 /**

--- a/packages/zoe/test/unitTests/contractSupport/test-interest.js
+++ b/packages/zoe/test/unitTests/contractSupport/test-interest.js
@@ -1,0 +1,77 @@
+// @ts-check
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { test } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+
+import { makeIssuerKit, AmountMath } from '@agoric/ertp';
+import {
+  calculateCurrentDebt,
+  reverseInterest,
+} from '../../../src/contractSupport/interest.js';
+import { makeRatio } from '../../../src/contractSupport/ratio.js';
+
+const runBrand = makeIssuerKit('run').brand;
+
+/**
+ * @param {*} t
+ * @param {readonly [bigint, bigint, bigint]} input
+ * @param {bigint} result
+ */
+function checkDebt(t, input, result) {
+  /** @type {Amount<NatValue>} */
+  const debtSnapshot = AmountMath.make(runBrand, input[0]);
+  const interestSnapshot = makeRatio(100n + input[1], runBrand);
+  const currentCompoundedInterest = makeRatio(100n + input[2], runBrand);
+  t.is(
+    calculateCurrentDebt(
+      debtSnapshot,
+      interestSnapshot,
+      currentCompoundedInterest,
+    ).value,
+    result,
+  );
+}
+
+for (const [input, result] of /** @type {const} */ ([
+  // no debt
+  [[0n, 0n, 0n], 0n],
+  [[0n, 0n, 250n], 0n],
+
+  // some debt
+  [[1_000_000n, 0n, 0n], 1_000_000n],
+  [[1_000_000n, 0n, 2n], 1_020_000n],
+
+  // some debt and previous interest
+  [[1_000_000n, 2n, 0n], 980_392n], // negative interest since snapshot
+  [[1_000_000n, 2n, 2n], 1_000_000n],
+  [[1_000_000n, 2n, 4n], 1_019_607n],
+])) {
+  test(
+    `calculateCurrentDebt ${input} returns ${result}`,
+    checkDebt,
+    input,
+    result,
+  );
+}
+
+function checkReverse(t, input, result) {
+  /** @type {Amount<NatValue>} */
+  const debt = AmountMath.make(runBrand, input[0]);
+  const interestApplied = makeRatio(100n + input[1], runBrand);
+  t.deepEqual(reverseInterest(debt, interestApplied).value, result);
+}
+
+for (const [input, result] of /** @type {const} */ ([
+  [[0n, 0n], 0n],
+  [[0n, 1n], 0n],
+
+  [[1_000_000n, 0n], 1_000_000n],
+  [[1_000_000n, 2n], 980_392n],
+  [[1_000_000n, 100n], 500_000n],
+])) {
+  test(
+    `reverseInterest ${input} returns ${result}`,
+    checkReverse,
+    input,
+    result,
+  );
+}


### PR DESCRIPTION
closes: #4540

## Description

See #4540 for motivation. Recommended to review commit-by-commit. Fixup commits will be autosquashed before merging to master.

### Security Considerations

This introduces new requirements on the consuming dapp for determining what the current debt is. The vault itself will only report its snapshot of the debt and interest. The consumer has to:
- maintain the association of the  `assetNotifier` with the `vaultNotifier` and `vault` (received together from the vault kit)
- listen to the assetNotifier for changes to compounded interest (daily per current parameters)
- use new contractSupport functions to put those two values together to get the current debt with accrued interest

These introduces risks into calculating the debt _apparent to the dapp_ but not the real debt calculations in the system.

### Documentation Considerations

There are two breaking changes contained in this PR, denoted in the commit titles:
[refactor(run-protocol)!: rename uiNotifier to vaultNotifier](https://github.com/Agoric/agoric-sdk/pull/4686/commits/fad520a32b04c30046bd32345e33af7835779022)
[refactor(run-protocol)!: return assetNotifier instead of notifying on…](https://github.com/Agoric/agoric-sdk/pull/4686/commits/290eaf0e41f3ff798b52fa86d89f3e1000d85097)


### Testing Considerations

Covered in integration test updates and new unit tests.