### PR TITLE
fix(eventual-send): correct typing of E and Remote

### DIFF
--- a/packages/eventual-send/src/E.js
+++ b/packages/eventual-send/src/E.js
@@ -23,7 +23,7 @@ const baseFreezableProxyHandler = {
  * A Proxy handler for E(x).
  *
  * @param {*} x Any value passed to E(x)
- * @param {*} HandledPromise
+ * @param {import('./index').HandledPromiseConstructor} HandledPromise
  * @returns {ProxyHandler} the Proxy handler
  */
 function EProxyHandler(x, HandledPromise) {
@@ -53,7 +53,7 @@ function EProxyHandler(x, HandledPromise) {
  * It is a variant on the E(x) Proxy handler.
  *
  * @param {*} x Any value passed to E.sendOnly(x)
- * @param {*} HandledPromise
+ * @param {import('./index').HandledPromiseConstructor} HandledPromise
  * @returns {ProxyHandler} the Proxy handler
  */
 function EsendOnlyProxyHandler(x, HandledPromise) {
@@ -76,6 +76,10 @@ function EsendOnlyProxyHandler(x, HandledPromise) {
   });
 }
 
+/**
+ * @param {import('./index').HandledPromiseConstructor} HandledPromise
+ * @returns {import('./index').EProxy}
+ */
 export default function makeE(HandledPromise) {
   function E(x) {
     const handler = EProxyHandler(x, HandledPromise);

--- a/packages/eventual-send/src/index.d.ts
+++ b/packages/eventual-send/src/index.d.ts
@@ -21,6 +21,20 @@ type Unpromise<T> = T extends ERef<infer U> ? U : T;
 type Parameters<T> = T extends (...args: infer T) => any ? T : any;
 type ReturnType<T> = T extends (...args: any[]) => infer T ? T : any;
 
+type FilteredKeys<T, U> = {
+  [P in keyof T]: T[P] extends U ? P : never;
+}[keyof T];
+
+type DataOnly<T> = Omit<T, FilteredKeys<T, Function>>;
+type FunctionOnly<T> = Pick<T, FilteredKeys<T, Function>> &
+  (T extends Function ? (...args: Parameters<T>) => ReturnType<T> : {});
+
+interface Remotable<T> {
+  __Remote__: T;
+}
+type Remote<Primary, Local = DataOnly<Primary>> = ERef<
+  Local & Remotable<Primary>
+>;
 interface EHandler<T> {
   get?: (p: T, name: Property, returnedP?: Promise<unknown>) => any;
   getSendOnly?: (p: T, name: Property) => void;
@@ -57,7 +71,7 @@ type ResolveWithPresenceOptionsBag<T extends Object> = {
 };
 
 declare interface HandledPromiseStaticMethods {
-  resolve<T>(x: T): Promise<Unpromise<T>>;
+  resolve<T>(x: T): Promise<Awaited<T>>;
   resolve(): Promise<undefined>;
   applyFunction(target: unknown, args: unknown[]): Promise<unknown>;
   applyFunctionSendOnly(target: unknown, args: unknown[]): void;
@@ -93,14 +107,14 @@ declare function makeHandledPromise(): HandledPromiseConstructor;
 type ESingleMethod<T> = {
   readonly [P in keyof T]: (
     ...args: Parameters<T[P]>
-  ) => Promise<Unpromise<ReturnType<T[P]>>>;
+  ) => Promise<Awaited<ReturnType<T[P]>>>;
 };
 type ESingleCall<T> = T extends Function
-  ? ((...args: Parameters<T>) => Promise<Unpromise<ReturnType<T>>>) &
+  ? ((...args: Parameters<T>) => Promise<Awaited<ReturnType<T>>>) &
       ESingleMethod<Required<T>>
   : ESingleMethod<Required<T>>;
 type ESingleGet<T> = {
-  readonly [P in keyof T]: Promise<Unpromise<T[P]>>;
+  readonly [P in keyof T]: Promise<Awaited<T[P]>>;
 };
 
 /* Same types for send-only. */
@@ -115,7 +129,7 @@ type ESingleGetOnly<T> = {
 };
 
 interface ESendOnly {
-  <T>(x: T): ESingleCallOnly<Unpromise<T>>;
+  <T>(x: T): ESingleCallOnly<Awaited<T>>;
 }
 
 interface EProxy {
@@ -128,7 +142,13 @@ interface EProxy {
    * @param {*} x target for method/function call
    * @returns {ESingleCall} method/function call proxy
    */
-  <T>(x: T): ESingleCall<Unpromise<T>>;
+  <T>(x: T): ESingleCall<
+    T extends Remotable<infer U>
+      ? FunctionOnly<U>
+      : Awaited<T> extends Remotable<infer U>
+      ? FunctionOnly<U>
+      : Awaited<T>
+  >;
 
   /**
    * E.get(x) returns a proxy on which you can get arbitrary properties.
@@ -139,13 +159,21 @@ interface EProxy {
    * @param {*} x target for property get
    * @returns {ESingleGet} property get proxy
    */
-  readonly get: <T>(x: T) => ESingleGet<Unpromise<T>>;
+  readonly get: <T>(
+    x: T,
+  ) => ESingleGet<
+    T extends Remotable<infer U>
+      ? DataOnly<U>
+      : Awaited<T> extends Remotable<infer U>
+      ? DataOnly<U>
+      : Awaited<T>
+  >;
 
   /**
    * E.resolve(x) converts x to a handled promise. It is
    * shorthand for HandledPromise.resolve(x)
    */
-  readonly resolve: <T>(x: T) => Promise<Unpromise<T>>;
+  readonly resolve: <T>(x: T) => Promise<Awaited<T>>;
 
   /**
    * E.when(x, res, rej) is equivalent to
@@ -153,7 +181,7 @@ interface EProxy {
    */
   readonly when: <T, U>(
     x: T,
-    onfulfilled?: (value: Unpromise<T>) => ERef<U>,
+    onfulfilled?: (value: Awaited<T>) => ERef<U>,
     onrejected?: (reason: any) => ERef<U>,
   ) => Promise<U>;
 

--- a/packages/eventual-send/src/index.d.ts
+++ b/packages/eventual-send/src/index.d.ts
@@ -16,11 +16,6 @@ export type EOnly<T> = T extends (...args: infer P) => infer R
     }>
   : ERef<T>;
 
-type Unpromise<T> = T extends ERef<infer U> ? U : T;
-
-type Parameters<T> = T extends (...args: infer T) => any ? T : any;
-type ReturnType<T> = T extends (...args: any[]) => infer T ? T : any;
-
 type FilteredKeys<T, U> = {
   [P in keyof T]: T[P] extends U ? P : never;
 }[keyof T];

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -728,4 +728,4 @@ export const makeInnerVault = (
 };
 
 /** @typedef {ReturnType<typeof makeInnerVault>} InnerVault */
-/** @typedef {Unpromise<ReturnType<InnerVault['initVaultKit']>>} VaultKit */
+/** @typedef {Awaited<ReturnType<InnerVault['initVaultKit']>>} VaultKit */

--- a/packages/run-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/run-protocol/src/vaultFactory/vaultFactory.js
@@ -261,4 +261,4 @@ export const start = async (zcf, privateArgs) => {
     publicFacet,
   });
 };
-/** @typedef {Unpromise<ReturnType<typeof start>>['publicFacet']} VaultFactoryPublicFacet */
+/** @typedef {Awaited<ReturnType<typeof start>>['publicFacet']} VaultFactoryPublicFacet */

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -262,7 +262,7 @@
  *     namesByAddressAdmin: Producer<NameAdmin>,
  *   },
  * }} BootstrapSpace
- * @typedef {ReturnType<Unpromise<BankVat>['makeBankManager']>} BankManager
+ * @typedef {ReturnType<Awaited<BankVat>['makeBankManager']>} BankManager
  * @typedef {ERef<ReturnType<import('../vat-bank.js').buildRootObject>>} BankVat
  * @typedef {ERef<ReturnType<import('../vat-provisioning.js').buildRootObject>>} ProvisioningVat
  * @typedef {ERef<ReturnType<import('../vat-mints.js').buildRootObject>>} MintsVat
@@ -286,4 +286,3 @@
  */
 
 /** @template T @typedef  {{vatPowers: { D: DProxy }, devices: T}} BootDevices<T>  */
-/** @template T @typedef {import('@agoric/eventual-send').Unpromise<T>} Unpromise<T> */

--- a/packages/vats/src/vat-network.js
+++ b/packages/vats/src/vat-network.js
@@ -3,5 +3,6 @@ import { E } from '@endo/far';
 import { makeRouterProtocol } from '@agoric/swingset-vat/src/vats/network/router.js';
 
 export function buildRootObject(_vatPowers) {
+  // @ts-expect-error UNTIL Endo updated https://github.com/endojs/endo/pull/1095/
   return makeRouterProtocol(E); // already Far('Router')
 }


### PR DESCRIPTION
_no ticket_

## Description

`Unpromise` came up in https://github.com/Agoric/agoric-sdk/pull/4686#discussion_r815482939. While looking into why we have it I noticed that [TypeScript 4.5 added an Awaited type](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#the-awaited-type-and-promise-improvements) I could have used instead.

I tried replacing `Unpromise` with `Awaited`, but ran into this error:
```
../notifier/src/asyncIterableAdaptor.js:39:3 - error TS2322: Type '{ [Symbol.asyncIterator]: () => { next: () => Promise<{ value: T; done: boolean; }> | undefined; }; }' is not assignable to type 'ConsistentAsyncIterable<T>'.
  The types returned by '[Symbol.asyncIterator]().next(...)' are incompatible between these types.
    Type 'Promise<{ value: T; done: boolean; }> | undefined' is not assignable to type 'Promise<IteratorResult<T, T>>'.
      Type 'undefined' is not assignable to type 'Promise<IteratorResult<T, T>>'.

 39   return Far('asyncIterableFromNotifier', {
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 40     [Symbol.asyncIterator]: () => {
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
...
 86     },
    ~~~~~~
 87   });
    ~~~~~
```

@michaelfig graciously paired to come up with https://github.com/endojs/endo/pull/1095/ . This includes those type changes so that we don't need `Unpromise`. I didn't pull over the tests and documentation because I believe @agoric/eventual-send is on the chopping block, to be replaced by @endo/eventual-send.

### Security Considerations

None.

### Documentation Considerations

Reduces need for documentation (rely more on TypeScript's documentation).

### Testing Considerations

Type checker in CI.