### PR TITLE
experiment: refactor vault to API of virtual objects

### DIFF
--- a/packages/SwingSet/src/liveslots/virtualObjectManager.js
+++ b/packages/SwingSet/src/liveslots/virtualObjectManager.js
@@ -454,6 +454,10 @@ export function makeVirtualObjectManager(
           cache.refresh(innerSelf);
         } else {
           innerSelf = cache.lookup(innerSelf.vobjID, true);
+          assert(
+            innerSelf.rawData,
+            `Missing rawData for innerSelf '${innerSelf.vobjID}'`,
+          );
         }
       }
 

--- a/packages/run-protocol/src/vaultFactory/liquidation.js
+++ b/packages/run-protocol/src/vaultFactory/liquidation.js
@@ -50,6 +50,8 @@ const liquidate = async (zcf, vault, burnLosses, strategy, collateralBrand) => {
   await Promise.all([deposited, E(liqSeat).getOfferResult()]);
 
   // Now we need to know how much was sold so we can pay off the debt
+  /** @type {Amount<NatValue>} */
+  // @ts-expect-error liquidationSeat not generic (RUN implies NatValue)
   const runProceedsAmount = liquidationSeat.getAmountAllocated('RUN', runBrand);
 
   trace('RUN PROCEEDS', runProceedsAmount);

--- a/packages/run-protocol/src/vaultFactory/nonvirtualStore.js
+++ b/packages/run-protocol/src/vaultFactory/nonvirtualStore.js
@@ -1,0 +1,53 @@
+/**
+ * Ersatz defineKind until virtual objects system is stable.
+ *
+ * @param {string} tag
+ * @param {Function} init
+ * @param {Function} actualize
+ * @param {Function} [finish]
+ */
+const defineKind = (tag, init, actualize, finish) => {
+  let nextInstanceID = 1;
+  const propertyNames = new Set();
+
+  function makeRepresentative(innerSelf) {
+    const wrappedData = {};
+    for (const prop of propertyNames) {
+      Object.defineProperty(wrappedData, prop, {
+        get: () => {
+          return innerSelf.rawData[prop];
+        },
+        set: value => {
+          innerSelf.rawData[prop] = value;
+        },
+      });
+    }
+    harden(wrappedData);
+
+    const representative = actualize(wrappedData);
+    return [representative, wrappedData];
+  }
+
+  function makeNewInstance(...args) {
+    const objID = `nonvirtual/${nextInstanceID}`;
+    nextInstanceID += 1;
+    const initialData = init ? init(...args) : {};
+    const rawData = {};
+    for (const prop of Object.getOwnPropertyNames(initialData)) {
+      const data = initialData[prop];
+      rawData[prop] = data;
+      propertyNames.add(prop);
+    }
+    const innerSelf = { objID, rawData };
+    const [initialRepresentative, wrappedData] = makeRepresentative(innerSelf);
+    if (finish) {
+      finish(wrappedData, initialRepresentative);
+    }
+    return initialRepresentative;
+  }
+
+  return makeNewInstance;
+};
+
+harden(defineKind);
+export { defineKind };

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -11,16 +11,13 @@ import {
   floorDivideBy,
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { observeNotifier } from '@agoric/notifier';
-
-// XXX avoid deep imports https://github.com/Agoric/agoric-sdk/issues/4255#issuecomment-1032117527
-import { defineKind } from '@agoric/swingset-vat/src/storeModule.js';
-
 import {
   invertRatio,
   multiplyRatios,
 } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { AmountMath } from '@agoric/ertp';
 import { Far } from '@endo/marshal';
+import { defineKind } from './nonvirtualStore.js';
 import { makeTracer } from '../makeTracer.js';
 import { setupOuter } from './vaultKit.js';
 

--- a/packages/run-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/run-protocol/src/vaultFactory/vaultKit.js
@@ -54,6 +54,4 @@ export const setupOuter = inner => {
   return harden({ transferInvitationHook, updater });
 };
 
-/**
- * @typedef {(ReturnType<typeof setupOuter>)['transferInvitationHook']} TransferInvitationHook
- */
+/** @typedef {(ReturnType<typeof setupOuter>)['transferInvitationHook']} TransferInvitationHook */

--- a/packages/run-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/run-protocol/src/vaultFactory/vaultKit.js
@@ -55,5 +55,5 @@ export const setupOuter = inner => {
 };
 
 /**
- * @typedef {ReturnType<typeof setupOuter>['transferInvitationHook']} TransferInvitationHook
+ * @typedef {(ReturnType<typeof setupOuter>)['transferInvitationHook']} TransferInvitationHook
  */

--- a/packages/run-protocol/src/vaultFactory/vaultKit.js
+++ b/packages/run-protocol/src/vaultFactory/vaultKit.js
@@ -1,0 +1,59 @@
+// @ts-check
+import { makeNotifierKit } from '@agoric/notifier';
+import '@agoric/zoe/exported.js';
+import { Far } from '@endo/marshal';
+
+const { details: X } = assert;
+
+/**
+ *
+ * @param {InnerVault | null} inner
+ */
+const makeOuterKit = inner => {
+  const { updater: uiUpdater, notifier } = makeNotifierKit();
+
+  const assertActive = v => {
+    assert(inner, X`Using ${v} after transfer`);
+    return inner;
+  };
+  /** @type {Vault} */
+  const vault = Far('vault', {
+    getNotifier: () => notifier,
+    makeAdjustBalancesInvitation: () =>
+      assertActive(vault).makeAdjustBalancesInvitation(),
+    makeCloseInvitation: () => assertActive(vault).makeCloseInvitation(),
+    makeTransferInvitation: () => {
+      const tmpInner = assertActive(vault);
+      inner = null;
+      return tmpInner.makeTransferInvitation();
+    },
+    // for status/debugging
+    getCollateralAmount: () => assertActive(vault).getCollateralAmount(),
+    getDebtAmount: () => assertActive(vault).getDebtAmount(),
+    getNormalizedDebt: () => assertActive(vault).getNormalizedDebt(),
+    getLiquidationSeat: () => assertActive(vault).getLiquidationSeat(),
+  });
+  return { vault, uiUpdater };
+};
+
+/**
+ *
+ * @param {InnerVault} inner
+ */
+export const setupOuter = inner => {
+  const { vault, uiUpdater: updater } = makeOuterKit(inner);
+  const transferInvitationHook = {
+    uiNotifier: vault.getNotifier(),
+    invitationMakers: Far('invitation makers', {
+      AdjustBalances: vault.makeAdjustBalancesInvitation,
+      CloseVault: vault.makeCloseInvitation,
+      TransferVault: vault.makeTransferInvitation,
+    }),
+    vault,
+  };
+  return harden({ transferInvitationHook, updater });
+};
+
+/**
+ * @typedef {ReturnType<typeof setupOuter>['transferInvitationHook']} TransferInvitationHook
+ */

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -342,8 +342,9 @@ export const makeVaultManager = (
 
   observeNotifier(periodNotifier, timeObserver);
 
+  // FIXME define type
   /** @type {Parameters<typeof makeInnerVault>[1]} */
-  const managerFacet = harden({
+  const managerFacet = Far('vaultManager', {
     ...shared,
     applyDebtDelta,
     reallocateReward,


### PR DESCRIPTION
_no ticket_

## Description

For consideration of doing before Restival until we can fully virtualized the run-protocol objects. This introduces a `nonvirtualStore` that has a `defineKind` that matches the same API but without the virtualization abiltiies.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
