### PR TITLE
fix: emulate multi-facet support

### DIFF
--- a/packages/ERTP/package.json
+++ b/packages/ERTP/package.json
@@ -41,11 +41,11 @@
     "@agoric/nat": "^4.1.0",
     "@agoric/notifier": "^0.3.35",
     "@agoric/store": "^0.6.10",
+    "@agoric/swingset-vat": "^0.25.1",
     "@endo/marshal": "^0.6.1",
     "@endo/promise-kit": "^0.2.35"
   },
   "devDependencies": {
-    "@agoric/swingset-vat": "^0.25.1",
     "@endo/bundle-source": "^2.0.7",
     "ava": "^3.12.1",
     "fast-check": "^2.21.0"

--- a/packages/ERTP/src/payment.js
+++ b/packages/ERTP/src/payment.js
@@ -1,14 +1,21 @@
 // @ts-check
 
-import { Far } from '@endo/marshal';
+// import { defineHeapKind } from '@agoric/store';
+import { defineKind } from '@agoric/swingset-vat/src/storeModule.js';
 
 /**
  * @param {string} allegedName
  * @param {Brand} brand
- * @returns {Payment}
+ * @returns {() => Payment}
  */
-export const makePayment = (allegedName, brand) => {
-  return Far(`${allegedName} payment`, {
-    getAllegedBrand: () => brand,
-  });
+export const makePaymentMaker = (allegedName, brand) => {
+  const makePayment = defineKind(
+    `${allegedName} payment`,
+    () => ({}),
+    () => ({
+      getAllegedBrand: () => brand,
+    }),
+  );
+  return makePayment;
 };
+harden(makePaymentMaker);

--- a/packages/ERTP/src/purse.js
+++ b/packages/ERTP/src/purse.js
@@ -1,43 +1,60 @@
 import { makeNotifierKit } from '@agoric/notifier';
-import { Far } from '@endo/marshal';
+import { defineHeapKind } from '@agoric/store';
 import { AmountMath } from './amountMath.js';
 
-export const makePurse = (allegedName, assetKind, brand, purseMethods) => {
-  let currentBalance = AmountMath.makeEmpty(brand, assetKind);
+export const makePurseMaker = (allegedName, assetKind, brand, purseMethods) => {
+  const makePurseKit = defineHeapKind(
+    allegedName,
+    () => {
+      const currentBalance = AmountMath.makeEmpty(brand, assetKind);
 
-  /** @type {NotifierRecord<Amount>} */
-  const { notifier: balanceNotifier, updater: balanceUpdater } =
-    makeNotifierKit(currentBalance);
+      /** @type {NotifierRecord<Amount>} */
+      const { notifier: balanceNotifier, updater: balanceUpdater } =
+        makeNotifierKit(currentBalance);
 
-  const updatePurseBalance = newPurseBalance => {
-    currentBalance = newPurseBalance;
-    balanceUpdater.updateState(currentBalance);
-  };
-
-  /** @type {Purse} */
-  const purse = Far(`${allegedName} purse`, {
-    deposit: (srcPayment, optAmountShape = undefined) => {
-      // Note COMMIT POINT within deposit.
-      return purseMethods.deposit(
+      return {
         currentBalance,
-        updatePurseBalance,
-        srcPayment,
-        optAmountShape,
-      );
+        balanceNotifier,
+        balanceUpdater,
+      };
     },
-    withdraw: amount =>
-      // Note COMMIT POINT within withdraw.
-      purseMethods.withdraw(currentBalance, updatePurseBalance, amount),
-    getCurrentAmount: () => currentBalance,
-    getCurrentAmountNotifier: () => balanceNotifier,
-    getAllegedBrand: () => brand,
-    // eslint-disable-next-line no-use-before-define
-    getDepositFacet: () => depositFacet,
-  });
+    state => {
+      const { balanceNotifier, balanceUpdater } = state;
+      const updatePurseBalance = newPurseBalance => {
+        state.currentBalance = newPurseBalance;
+        balanceUpdater.updateState(state.currentBalance);
+      };
 
-  const depositFacet = Far(`${allegedName} depositFacet`, {
-    receive: purse.deposit,
-  });
-
-  return purse;
+      /** @type {Purse} */
+      const purse = {
+        deposit: (srcPayment, optAmountShape = undefined) => {
+          // Note COMMIT POINT within deposit.
+          return purseMethods.deposit(
+            state.currentBalance,
+            updatePurseBalance,
+            srcPayment,
+            optAmountShape,
+          );
+        },
+        withdraw: amount =>
+          // Note COMMIT POINT within withdraw.
+          purseMethods.withdraw(
+            state.currentBalance,
+            updatePurseBalance,
+            amount,
+          ),
+        getCurrentAmount: () => state.currentBalance,
+        getCurrentAmountNotifier: () => balanceNotifier,
+        getAllegedBrand: () => brand,
+        // eslint-disable-next-line no-use-before-define
+        getDepositFacet: () => depositFacet,
+      };
+      const depositFacet = {
+        receive: purse.deposit,
+      };
+      return { purse, depositFacet };
+    },
+  );
+  return () => makePurseKit().purse;
 };
+harden(makePurseMaker);

--- a/packages/ERTP/test/unitTests/test-issuerObj.js
+++ b/packages/ERTP/test/unitTests/test-issuerObj.js
@@ -434,7 +434,7 @@ test('issuer.combine bad payments', async t => {
   await t.throwsAsync(
     () => E(issuer).combine(payments),
     {
-      message: '"payment" not found: "[Alleged: other fungible payment]"',
+      message: /.* "\[Alleged: other fungible payment\]"/,
     },
     'payment from other mint is not found',
   );

--- a/packages/SwingSet/src/storeModule.js
+++ b/packages/SwingSet/src/storeModule.js
@@ -11,6 +11,7 @@ export const {
 
 export {
   M,
+  defineHeapKind,
   makeScalarMapStore,
   makeScalarWeakMapStore,
   makeScalarSetStore,

--- a/packages/governance/test/unitTests/test-buildParamManager.js
+++ b/packages/governance/test/unitTests/test-buildParamManager.js
@@ -238,7 +238,7 @@ test('Invitation', async t => {
   t.is(paramManager.getAmount('Amt'), drachmaAmount);
   const invitationActualAmount =
     paramManager.getInvitationAmount('Invite').value;
-  t.is(invitationActualAmount, invitationAmount.value);
+  t.deepEqual(invitationActualAmount, invitationAmount.value);
   // @ts-ignore invitationActualAmount's type is unknown
   t.is(invitationActualAmount[0].description, 'simple');
 

--- a/packages/store/src/defineHeapKind.js
+++ b/packages/store/src/defineHeapKind.js
@@ -1,0 +1,72 @@
+// @ts-check
+
+import { Far } from '@endo/marshal';
+
+const { ownKeys } = Reflect;
+
+const becomePassable = (tag, thing) => {
+  const names = ownKeys(thing);
+  if (names.length === 0 || typeof thing[names[0]] === 'function') {
+    return Far(tag, thing);
+  }
+  for (const name of names) {
+    assert.typeof(name, 'string');
+    Far(`${tag} ${name}`, thing[name]);
+  }
+  return harden(thing);
+};
+harden(becomePassable);
+
+/**
+ * Ersatz defineKind until virtual objects system is stable.
+ *
+ * @param {string} tag
+ * @param {Function} init
+ * @param {Function} actualize
+ * @param {Function} [finish]
+ */
+export const defineHeapKind = (tag, init, actualize, finish) => {
+  let nextInstanceID = 1;
+  const propertyNames = new Set();
+
+  function makeRepresentative(innerSelf) {
+    const wrappedData = {};
+    for (const prop of propertyNames) {
+      Object.defineProperty(wrappedData, prop, {
+        get: () => {
+          return innerSelf.rawData[prop];
+        },
+        set: value => {
+          innerSelf.rawData[prop] = value;
+        },
+      });
+    }
+    harden(wrappedData);
+
+    const representative = actualize(wrappedData);
+    return [representative, wrappedData];
+  }
+
+  function makeNewInstance(...args) {
+    const objID = `nonvirtual/${nextInstanceID}`;
+    nextInstanceID += 1;
+    const initialData = init ? init(...args) : {};
+    const rawData = {};
+    for (const prop of Object.getOwnPropertyNames(initialData)) {
+      const data = initialData[prop];
+      rawData[prop] = data;
+      propertyNames.add(prop);
+    }
+    const innerSelf = { objID, rawData };
+    const [initialRepresentative, wrappedData] = makeRepresentative(innerSelf);
+    becomePassable(tag, initialRepresentative);
+    if (finish) {
+      finish(wrappedData, initialRepresentative);
+    }
+    return initialRepresentative;
+  }
+
+  return makeNewInstance;
+};
+
+harden(defineHeapKind);

--- a/packages/store/src/index.js
+++ b/packages/store/src/index.js
@@ -71,6 +71,10 @@ export {
   makeScalarMapStore as makeStore, // Deprecated legacy
 } from './stores/scalarMapStore.js';
 
+// /////////////////////// Experimental ////////////////////////////////////////
+
+export { defineHeapKind } from './defineHeapKind.js';
+
 // /////////////////////// Deprecated Legacy ///////////////////////////////////
 
 // export default as well as makeLegacy* only for compatibility


### PR DESCRIPTION
Adapted @turadg 's emulated `defineKind` from #4697 into the `defineHeapKind` seen here, to emulate upcoming multi-facet support.

Use it to virtualize (or pretend to virtualize) purses, payments, ledgers

Compare to #4618 

Suggestion to reviewers: review hiding whitespace differences.