### PR TITLE
chore: Ignore vim swap files

### DIFF
--- a/golang/cosmos/.gitignore
+++ b/golang/cosmos/.gitignore
@@ -24,8 +24,9 @@ chains
 solo
 solo/
 
-# emacs
+# emacs and vim
 *~
+[._]*.sw[a-p]
 
 # Logs
 logs

--- a/packages/ERTP/.gitignore
+++ b/packages/ERTP/.gitignore
@@ -1,5 +1,6 @@
-# emacs
+# emacs and vim
 *~
+[._]*.sw[a-p]
 
 # Logs
 logs

--- a/packages/SwingSet/.gitignore
+++ b/packages/SwingSet/.gitignore
@@ -1,5 +1,6 @@
-# emacs
+# emacs and vim
 *~
+[._]*.sw[a-p]
 
 # Logs
 logs

--- a/packages/SwingSet/src/controller/initializeSwingset.js
+++ b/packages/SwingSet/src/controller/initializeSwingset.js
@@ -111,16 +111,10 @@ export function loadBasedir(basedir, options = {}) {
   const subs = fs.readdirSync(basedir, { withFileTypes: true });
   subs.sort(byName);
   subs.forEach(dirent => {
-    if (dirent.name.endsWith('~')) {
-      // Special case crap filter to ignore emacs backup files and the like.
-      // Note that the regular filename parsing below will ignore such files
-      // anyway, but this skips logging them so as to reduce log spam.
-      return;
-    }
     if (
       dirent.name.startsWith('vat-') &&
-      dirent.isFile() &&
-      dirent.name.endsWith('.js')
+      dirent.name.endsWith('.js') &&
+      dirent.isFile()
     ) {
       const name = dirent.name.slice('vat-'.length, -'.js'.length);
       const vatSourcePath = path.resolve(basedir, dirent.name);

--- a/packages/agoric-cli/.gitignore
+++ b/packages/agoric-cli/.gitignore
@@ -1,8 +1,9 @@
 .vagrant
 /dapps
 
-# emacs
+# emacs and vim
 *~
+[._]*.sw[a-p]
 
 # Logs
 logs

--- a/packages/cosmic-swingset/.gitignore
+++ b/packages/cosmic-swingset/.gitignore
@@ -25,8 +25,9 @@ chains
 solo
 solo/
 
-# emacs
+# emacs and vim
 *~
+[._]*.sw[a-p]
 
 # Logs
 logs

--- a/packages/deploy-script-support/.gitignore
+++ b/packages/deploy-script-support/.gitignore
@@ -1,5 +1,6 @@
-# emacs
+# emacs and vim
 *~
+[._]*.sw[a-p]
 
 # Logs
 logs

--- a/packages/wallet/api/.gitignore
+++ b/packages/wallet/api/.gitignore
@@ -1,5 +1,6 @@
-# emacs
+# emacs and vim
 *~
+[._]*.sw[a-p]
 
 # Logs
 logs


### PR DESCRIPTION
## Description

Ignore vim swap files (matching existing treatment for emacs backup files).
Implements a simple subset of
https://github.com/github/gitignore/blob/41ec05833ae00be887bab36fceaee63611e86189/Global/Vim.gitignore#L1-L7

### Security Considerations

n/a

### Documentation Considerations

n/a

### Testing Considerations

n/a