### PR TITLE
test(swingset): temporarily tolerate new endo bundle hashes

### DIFF
--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -305,6 +305,13 @@ export async function makeSwingsetController(
   async function validateAndInstallBundle(bundle, allegedBundleID) {
     // TODO: validation: unpack, parse sources, check hashes
 
+    // during the transition to endo's new format, preemptively ignore the
+    // hash it provides
+    bundle = {
+      moduleFormat: bundle.moduleFormat,
+      endoZipBase64: bundle.endoZipBase64,
+    };
+
     // this only computes the hash of the compartment map, it does not check
     // that the rest of the bundle matches
     const bundleID = await computeBundleID(bundle);

--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -307,10 +307,10 @@ export async function makeSwingsetController(
 
     // during the transition to endo's new format, preemptively ignore the
     // hash it provides
-    bundle = {
+    bundle = harden({
       moduleFormat: bundle.moduleFormat,
       endoZipBase64: bundle.endoZipBase64,
-    };
+    });
 
     // this only computes the hash of the compartment map, it does not check
     // that the rest of the bundle matches

--- a/packages/SwingSet/test/bundles/test-bundles-kernel.js
+++ b/packages/SwingSet/test/bundles/test-bundles-kernel.js
@@ -22,10 +22,10 @@ test('install bundle', async t => {
   // during the transition to endo's new format, preemptively ignore the
   // hash it provides
   let bundle = await bundleSource(bundleFile);
-  bundle = {
+  bundle = harden({
     moduleFormat: bundle.moduleFormat,
     endoZipBase64: bundle.endoZipBase64,
-  };
+  });
 
   // my code to compute the bundleID
   const bundleID = await computeBundleID(bundle);

--- a/packages/SwingSet/test/bundles/test-bundles-kernel.js
+++ b/packages/SwingSet/test/bundles/test-bundles-kernel.js
@@ -19,7 +19,13 @@ test('install bundle', async t => {
 
   const bundleFile = new URL('./bootstrap-bundles.js', import.meta.url)
     .pathname;
-  const bundle = await bundleSource(bundleFile);
+  // during the transition to endo's new format, preemptively ignore the
+  // hash it provides
+  let bundle = await bundleSource(bundleFile);
+  bundle = {
+    moduleFormat: bundle.moduleFormat,
+    endoZipBase64: bundle.endoZipBase64,
+  };
 
   // my code to compute the bundleID
   const bundleID = await computeBundleID(bundle);


### PR DESCRIPTION
Endo is adding an `.endoZipBase64Sha512` property to the output of
`bundleSource`. Swingset's tests aren't quite ready for this. Temporarily
delete this property until we're ready to use it properly.

refs #4719
