### PR TITLE
fix(swingset): deliver startVat to setup() vats

### DIFF
--- a/packages/SwingSet/src/controller/initializeKernel.js
+++ b/packages/SwingSet/src/controller/initializeKernel.js
@@ -88,9 +88,7 @@ export function initializeKernel(config, hostStorage, verbose = false) {
       const vatKeeper = kernelKeeper.provideVatKeeper(vatID);
       vatKeeper.setSourceAndOptions({ bundleID }, creationOptions);
       vatKeeper.initializeReapCountdown(creationOptions.reapInterval);
-      if (!creationOptions.enableSetup) {
-        kernelKeeper.addToAcceptanceQueue(harden({ type: 'startVat', vatID }));
-      }
+      kernelKeeper.addToAcceptanceQueue(harden({ type: 'startVat', vatID }));
       if (name === 'vatAdmin') {
         // Create a kref for the vatAdmin root, so the kernel can tell it
         // about creation/termination of dynamic vats, and the installation

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -559,7 +559,6 @@ export default function buildKernel(
     }
     vatKeeper.setSourceAndOptions(source, options);
     vatKeeper.initializeReapCountdown(options.reapInterval);
-    const { enableSetup } = options;
 
     function sendNewVatCallback(args) {
       // @ts-ignore see assert(...) above
@@ -600,9 +599,8 @@ export default function buildKernel(
       vatWarehouse
         .createDynamicVat(vatID)
         // if createDynamicVat fails, go directly to makeErrorResponse
-        .then(_vatinfo =>
-          enableSetup ? null : processStartVat({ type: 'startVat', vatID }),
-        ) // TODO(4381) add vatParameters here
+        .then(_vatinfo => processStartVat({ type: 'startVat', vatID }))
+        // TODO(4381) add vatParameters here
         // If processStartVat/deliverAndLogToVat observes a worker error, it
         // will return status={ terminate: problem } rather than throw an
         // error, so makeSuccessResponse will sendNewVatCallback. But the

--- a/packages/SwingSet/src/vats/comms/dispatch.js
+++ b/packages/SwingSet/src/vats/comms/dispatch.js
@@ -155,6 +155,9 @@ export function buildCommsDispatch(
   function doDispatch(vatDeliveryObject) {
     const [type, ...args] = vatDeliveryObject;
     switch (type) {
+      case 'startVat': {
+        break;
+      }
       case 'message': {
         const [targetSlot, msg] = args;
         insistMessage(msg);

--- a/packages/SwingSet/src/vats/comms/dispatch.js
+++ b/packages/SwingSet/src/vats/comms/dispatch.js
@@ -51,12 +51,11 @@ export function buildCommsDispatch(
   // our root object (o+0) is the Comms Controller
   const controller = makeVatSlot('object', true, 0);
 
-  function maybeInitializeState() {
+  function doStartVat() {
     state.maybeInitialize(controller);
   }
 
   function doDeliver(target, method, args, result) {
-    maybeInitializeState();
     // console.debug(`comms.deliver ${target} r=${result}`);
     insistCapData(args);
 
@@ -156,6 +155,7 @@ export function buildCommsDispatch(
     const [type, ...args] = vatDeliveryObject;
     switch (type) {
       case 'startVat': {
+        doStartVat();
         break;
       }
       case 'message': {

--- a/packages/SwingSet/src/vats/comms/remote.js
+++ b/packages/SwingSet/src/vats/comms/remote.js
@@ -34,7 +34,6 @@ export function initializeRemoteState(
 
 export function makeRemote(state, store, remoteID) {
   insistRemoteID(remoteID);
-  assert(store.get(`${remoteID}.initialized`), X`missing ${remoteID}`);
 
   function name() {
     return store.get(`${remoteID}.name`);

--- a/packages/SwingSet/test/commsVatDriver.js
+++ b/packages/SwingSet/test/commsVatDriver.js
@@ -350,6 +350,7 @@ export function commsVatDriver(t, verbose = false) {
   const log = [];
   const syscall = loggingSyscall(log);
   const dispatch = buildCommsDispatch(syscall, 'fakestate', 'fakehelpers');
+  dispatch(['startVat']);
   const { state } = debugState.get(dispatch);
 
   const remotes = new Map();

--- a/packages/SwingSet/test/devices/bootstrap-2.js
+++ b/packages/SwingSet/test/devices/bootstrap-2.js
@@ -1,79 +1,88 @@
 import { E } from '@agoric/eventual-send';
 import { Far } from '@endo/marshal';
-import { assert, details as X } from '@agoric/assert';
 
-export function buildRootObject(vatPowers, vatParameters) {
+export function buildRootObject(vatPowers) {
   const { D, testLog: log } = vatPowers;
+  let devices;
+  let vats;
   return Far('root', {
-    async bootstrap(vats, devices) {
-      const { argv } = vatParameters;
-      if (argv[0] === '1') {
-        log(`calling d2.method1`);
-        const ret = D(devices.d2).method1('hello');
-        log(ret);
-      } else if (argv[0] === '2') {
-        log(`calling d2.method2`);
-        const [d2, d3] = D(devices.d2).method2(); // [d2,d3]
-        const ret2 = D(d3).method3(d2);
-        log(ret2.key);
-      } else if (argv[0] === '3') {
-        log(`calling d2.method3`);
-        // devices can't yet do sendOnly on pass-by-presence objects, but
-        // they should still be able to accept and return them
-        const o = Far('iface', {});
-        const ret = D(devices.d2).method3(o);
-        log(`ret ${ret === o}`);
-      } else if (argv[0] === '4') {
-        log(`calling d2.method4`);
-        // now exercise sendOnly on pass-by-presence objects
-        const o = Far('o', {
-          foo(obj) {
-            log(`d2.m4 foo`);
-            D(obj).bar('hello');
-            log(`d2.m4 did bar`);
-          },
-        });
-        const ret = D(devices.d2).method4(o);
-        log(`ret ${ret}`);
-      } else if (argv[0] === '5') {
-        log(`calling v2.method5`);
-        const p = E(vats.left).left5(devices.d2);
-        log(`called`);
-        const ret = await p;
-        log(`ret ${ret}`);
-      } else if (argv[0] === 'state1') {
-        log(`calling setState`);
-        D(devices.d2).setState('state2');
-        log(`called`);
-      } else if (argv[0] === 'state2') {
-        log(`calling getState`);
-        const s = D(devices.d2).getState();
-        log(`got ${s}`);
-      } else if (argv[0] === 'command1') {
-        D(devices.command).sendBroadcast({ hello: 'everybody' });
-      } else if (argv[0] === 'command2') {
-        const handler = Far('handler', {
-          inbound(count, body) {
-            log(`handle-${count}-${body.piece}`);
-            D(devices.command).sendResponse(count, body.doReject, {
-              response: 'body',
-            });
-          },
-        });
-        D(devices.command).registerInboundHandler(handler);
-      } else if (argv[0] === 'promise1') {
-        const p = Promise.resolve();
-        log('sending Promise');
-        try {
-          // this will be rejected by liveslots before the device is involved
-          D(devices.d0).send({ p });
-          // shouldn't get here
-          log('oops: survived sending Promise');
-        } catch (e) {
-          log('good: callNow failed');
-        }
-      } else {
-        assert.fail(X`unknown argv mode '${argv[0]}'`);
+    async bootstrap(v, devs) {
+      vats = v;
+      devices = devs;
+    },
+    async do1() {
+      log(`calling d2.method1`);
+      const ret = D(devices.d2).method1('hello');
+      log(ret);
+    },
+    async do2() {
+      log(`calling d2.method2`);
+      const [d2, d3] = D(devices.d2).method2(); // [d2,d3]
+      const ret2 = D(d3).method3(d2);
+      log(ret2.key);
+    },
+    async do3() {
+      log(`calling d2.method3`);
+      // devices can't yet do sendOnly on pass-by-presence objects, but
+      // they should still be able to accept and return them
+      const o = Far('iface', {});
+      const ret = D(devices.d2).method3(o);
+      log(`ret ${ret === o}`);
+    },
+    async do4() {
+      log(`calling d2.method4`);
+      // now exercise sendOnly on pass-by-presence objects
+      const o = Far('o', {
+        foo(obj) {
+          log(`d2.m4 foo`);
+          D(obj).bar('hello');
+          log(`d2.m4 did bar`);
+        },
+      });
+      const ret = D(devices.d2).method4(o);
+      log(`ret ${ret}`);
+    },
+    async do5() {
+      log(`calling v2.method5`);
+      const p = E(vats.left).left5(devices.d2);
+      log(`called`);
+      const ret = await p;
+      log(`ret ${ret}`);
+    },
+    async doState1() {
+      log(`calling setState`);
+      D(devices.d2).setState('state2');
+      log(`called`);
+    },
+    async doState2() {
+      log(`calling getState`);
+      const s = D(devices.d2).getState();
+      log(`got ${s}`);
+    },
+    async doCommand1() {
+      D(devices.command).sendBroadcast({ hello: 'everybody' });
+    },
+    async doCommand2() {
+      const handler = Far('handler', {
+        inbound(count, body) {
+          log(`handle-${count}-${body.piece}`);
+          D(devices.command).sendResponse(count, body.doReject, {
+            response: 'body',
+          });
+        },
+      });
+      D(devices.command).registerInboundHandler(handler);
+    },
+    async doPromise1() {
+      const p = Promise.resolve();
+      log('sending Promise');
+      try {
+        // this will be rejected by liveslots before the device is involved
+        D(devices.d0).send({ p });
+        // shouldn't get here
+        log('oops: survived sending Promise');
+      } catch (e) {
+        log('good: callNow failed');
       }
     },
     ping() {

--- a/packages/SwingSet/test/devices/bootstrap-4.js
+++ b/packages/SwingSet/test/devices/bootstrap-4.js
@@ -18,17 +18,21 @@ function capargs(args, slots = []) {
 export default function setup(syscall, state, _helpers, vatPowers) {
   const { callNow } = syscall;
   const { testLog } = vatPowers;
+  let slot;
   function dispatch(vatDeliverObject) {
     if (vatDeliverObject[0] === 'message') {
-      const { method, args } = extractMessage(vatDeliverObject);
+      const { method, args, result } = extractMessage(vatDeliverObject);
       if (method === 'bootstrap') {
-        // find the device slot
+        // find and stash the device slot
         const [_vats, devices] = JSON.parse(args.body);
         const qnode = devices.d0;
         assert.equal(qnode[QCLASS], 'slot');
-        const slot = args.slots[qnode.index];
+        slot = args.slots[qnode.index];
         insistVatType('device', slot);
-
+        // resolve the bootstrap() promise now, so it won't be rejected later
+        // when we're terminated
+        syscall.resolve([[result, false, capargs(0, [])]]);
+      } else if (method === 'doBadCallNow') {
         const vpid = 'p+1'; // pretend we're exporting a promise
         const pnode = { [QCLASS]: 'slot', index: 0 };
         const callNowArgs = capargs([pnode], [vpid]);

--- a/packages/SwingSet/test/devices/test-devices.js
+++ b/packages/SwingSet/test/devices/test-devices.js
@@ -117,11 +117,11 @@ test.serial('d1', async t => {
   const hostStorage = provideHostStorage();
   await initializeSwingset(config, [], hostStorage, t.context.data);
   const c = await makeSwingsetController(hostStorage, deviceEndowments);
+  c.pinVatRoot('bootstrap');
   await c.run();
 
   c.queueToVatRoot('bootstrap', 'step1', capargs([]));
-  await c.step(); // acceptance
-  await c.step(); // deliver
+  await c.run();
   t.deepEqual(c.dump().log, [
     'callNow',
     'invoke 1 2',
@@ -150,20 +150,22 @@ async function test2(t, mode) {
     },
   };
   const hostStorage = provideHostStorage();
-  await initializeSwingset(config, [mode], hostStorage, t.context.data);
+  await initializeSwingset(config, [], hostStorage, t.context.data);
   const c = await makeSwingsetController(hostStorage, {});
-  for (let i = 0; i < 5; i += 1) {
-    // eslint-disable-next-line no-await-in-loop
-    await c.step(); // vat start acceptance
-    // eslint-disable-next-line no-await-in-loop
-    await c.step(); // vat start deliver
-  }
   c.pinVatRoot('bootstrap');
-  await c.step(); // acceptance
-  await c.step(); // deliver
+  await c.run(); // startup
+
+  function qv(method) {
+    c.queueToVatRoot('bootstrap', method, capargs([]), 'panic');
+  }
+
   if (mode === '1') {
+    qv('do1');
+    await c.run();
     t.deepEqual(c.dump().log, ['calling d2.method1', 'method1 hello', 'done']);
   } else if (mode === '2') {
+    qv('do2');
+    await c.run();
     t.deepEqual(c.dump().log, [
       'calling d2.method2',
       'method2',
@@ -171,13 +173,11 @@ async function test2(t, mode) {
       'value',
     ]);
   } else if (mode === '3') {
+    qv('do3');
+    await c.run();
     t.deepEqual(c.dump().log, ['calling d2.method3', 'method3', 'ret true']);
   } else if (mode === '4') {
-    t.deepEqual(c.dump().log, [
-      'calling d2.method4',
-      'method4',
-      'ret method4 done',
-    ]);
+    qv('do4');
     await c.run();
     t.deepEqual(c.dump().log, [
       'calling d2.method4',
@@ -188,18 +188,8 @@ async function test2(t, mode) {
       'd2.m4 did bar',
     ]);
   } else if (mode === '5') {
-    t.deepEqual(c.dump().log, ['calling v2.method5', 'called']);
-    await c.step(); // acceptance
-    await c.step(); // deliver
-    t.deepEqual(c.dump().log, [
-      'calling v2.method5',
-      'called',
-      'left5',
-      'method5 hello',
-      'left5 did d2.method5, got ok',
-    ]);
-    await c.step(); // acceptance
-    await c.step(); // deliver
+    qv('do5');
+    await c.run();
     t.deepEqual(c.dump().log, [
       'calling v2.method5',
       'called',
@@ -281,8 +271,10 @@ test.serial('command broadcast', async t => {
   };
 
   const hostStorage = provideHostStorage();
-  await initializeSwingset(config, ['command1'], hostStorage, t.context.data);
+  await initializeSwingset(config, [], hostStorage, t.context.data);
   const c = await makeSwingsetController(hostStorage, deviceEndowments);
+  c.pinVatRoot('bootstrap');
+  c.queueToVatRoot('bootstrap', 'doCommand1', capargs([]), 'panic');
   await c.run();
   t.deepEqual(broadcasts, [{ hello: 'everybody' }]);
 });
@@ -307,8 +299,10 @@ test.serial('command deliver', async t => {
   };
 
   const hostStorage = provideHostStorage();
-  await initializeSwingset(config, ['command2'], hostStorage, t.context.data);
+  await initializeSwingset(config, [], hostStorage, t.context.data);
   const c = await makeSwingsetController(hostStorage, deviceEndowments);
+  c.pinVatRoot('bootstrap');
+  c.queueToVatRoot('bootstrap', 'doCommand2', capargs([]), 'panic');
   await c.run();
 
   t.deepEqual(c.dump().log.length, 0);
@@ -329,6 +323,7 @@ test.serial('command deliver', async t => {
   t.deepEqual(rejection, { response: 'body' });
 });
 
+// warner HERE
 test.serial('liveslots throws when D() gets promise', async t => {
   const config = {
     bootstrap: 'bootstrap',
@@ -345,21 +340,14 @@ test.serial('liveslots throws when D() gets promise', async t => {
     },
   };
   const hostStorage = provideHostStorage();
-  await initializeSwingset(config, ['promise1'], hostStorage, t.context.data);
+  await initializeSwingset(config, [], hostStorage, t.context.data);
   const c = await makeSwingsetController(hostStorage, {});
+  c.pinVatRoot('bootstrap');
 
-  for (let i = 0; i < 4; i += 1) {
-    // eslint-disable-next-line no-await-in-loop
-    await c.step(); // vat start acceptance
-    // eslint-disable-next-line no-await-in-loop
-    await c.step(); // vat start deliver
-    // eslint-disable-next-line no-await-in-loop
-    await c.step(); // bring out your dead
-  }
-  await c.step(); // acceptance
-  await c.step(); // deliver
   // When liveslots catches an attempt to send a promise into D(), it throws
   // a regular error, which the vat can catch.
+  c.queueToVatRoot('bootstrap', 'doPromise1', capargs([]), 'panic');
+  await c.run();
   t.deepEqual(c.dump().log, ['sending Promise', 'good: callNow failed']);
 
   // If that isn't working as expected, and the promise makes it to
@@ -370,8 +358,7 @@ test.serial('liveslots throws when D() gets promise', async t => {
   await c.run();
 
   // If the translator doesn't catch the promise and it makes it to the device,
-  // the kernel will panic, and the c.step() above will reject, so the
-  // 'await c.step()' will throw.
+  // the kernel will panic, and the c.run()s would throw
 });
 
 test.serial('syscall.callNow(promise) is vat-fatal', async t => {
@@ -393,18 +380,15 @@ test.serial('syscall.callNow(promise) is vat-fatal', async t => {
   const hostStorage = provideHostStorage();
   await initializeSwingset(config, [], hostStorage, t.context.data);
   const c = await makeSwingsetController(hostStorage, {});
-  for (let i = 0; i < 3; i += 1) {
-    // eslint-disable-next-line no-await-in-loop
-    await c.step(); // vat start acceptance
-    // eslint-disable-next-line no-await-in-loop
-    await c.step(); // vat start deliver
-    // eslint-disable-next-line no-await-in-loop
-    await c.step(); // bring out your dead
-  }
-  await c.step(); // acceptance
-  await c.step(); // deliver bootstrap, which will fail
-  // if the kernel paniced, that c.step() will reject, and the await will throw
+  c.pinVatRoot('bootstrap');
+  await c.run();
+
+  // deliver doBadCallNow, which will fail, which kills vat-bootstrap, which
+  // emits "DANGER: static vat v1 terminated", but does not panic the kernel
+  c.queueToVatRoot('bootstrap', 'doBadCallNow', capargs([]), 'ignore');
+  await c.run();
   t.deepEqual(c.dump().log, ['sending Promise', 'good: callNow failed']);
+
   // now check that the vat was terminated: this should throw an exception
   // because the entire bootstrap vat was deleted
   t.throws(() => c.queueToVatRoot('bootstrap', 'ping', capargs([])), {

--- a/packages/SwingSet/test/test-comms.js
+++ b/packages/SwingSet/test/test-comms.js
@@ -127,8 +127,8 @@ test('transmit', t => {
   // remote 'bob' on machine B
   const { syscall, sends } = mockSyscall();
   const dispatch = buildCommsDispatch(syscall, 'fakestate', 'fakehelpers');
+  dispatch(['startVat']);
   const { state, clistKit } = debugState.get(dispatch);
-  state.maybeInitialize();
   const {
     provideKernelForLocal,
     provideLocalForKernel,
@@ -202,8 +202,8 @@ test('receive', t => {
   // vat's object 'bob'
   const { syscall, sends, gcs } = mockSyscall();
   const dispatch = buildCommsDispatch(syscall, 'fakestate', 'fakehelpers');
+  dispatch(['startVat']);
   const { state, clistKit } = debugState.get(dispatch);
-  state.maybeInitialize();
   const {
     provideLocalForKernel,
     getKernelForLocal,
@@ -348,8 +348,8 @@ test('receive', t => {
 test('addEgress', t => {
   const { syscall } = mockSyscall();
   const dispatch = buildCommsDispatch(syscall, 'fakestate', 'fakehelpers');
+  dispatch(['startVat']);
   const { state, clistKit } = debugState.get(dispatch);
-  state.maybeInitialize();
   const { getLocalForKernel, getRemoteForLocal } = clistKit;
   const transmitterID = 'o-1';
   const remoteName = 'remote1';
@@ -381,8 +381,8 @@ test('addEgress', t => {
 test('addIngress', t => {
   const { syscall, resolves } = mockSyscall();
   const dispatch = buildCommsDispatch(syscall, 'fakestate', 'fakehelpers');
+  dispatch(['startVat']);
   const { state, clistKit } = debugState.get(dispatch);
-  state.maybeInitialize();
   const { getLocalForKernel, getRemoteForLocal } = clistKit;
   const transmitterID = 'o-1';
   const remoteName = 'remote1';
@@ -415,8 +415,8 @@ test('comms gc', t => {
   // about various objects that are dropped and retired
   const { syscall, sends, gcs } = mockSyscall();
   const dispatch = buildCommsDispatch(syscall, 'fakestate', 'fakehelpers');
+  dispatch(['startVat']);
   const { state, clistKit: ck } = debugState.get(dispatch);
-  state.maybeInitialize();
   const transmitterID = 'o-1'; // vat-tp target for B
   const { remoteID, receiverID } = state.addRemote('B', transmitterID);
   function didTx(exp) {

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -69,7 +69,9 @@ async function simpleCall(t) {
   controller.queueToVatRoot('vat1', 'foo', capdata('args'));
   t.deepEqual(controller.dump().runQueue, []);
   t.deepEqual(controller.dump().acceptanceQueue, [
+    { type: 'startVat', vatID: 'v1' },
     { type: 'startVat', vatID: 'v2' },
+    { type: 'startVat', vatID: 'v3' },
     { type: 'startVat', vatID: 'v4' },
     { type: 'startVat', vatID: 'v5' },
     {
@@ -224,6 +226,7 @@ test.serial('bootstrap export', async t => {
     { type: 'startVat', vatID: 'v2' },
     { type: 'startVat', vatID: 'v3' },
     { type: 'startVat', vatID: 'v4' },
+    { type: 'startVat', vatID: 'v5' },
     { type: 'startVat', vatID: 'v6' },
     { type: 'startVat', vatID: 'v7' },
     {
@@ -269,7 +272,7 @@ test.serial('bootstrap export', async t => {
   }
 
   t.deepEqual(c.dump().log, []);
-  for (let i = 0; i < 6; i += 1) {
+  for (let i = 0; i < 7; i += 1) {
     // eslint-disable-next-line no-await-in-loop
     await stepGC(); // vat starts
   }

--- a/packages/SwingSet/test/vat-syscall-failure.js
+++ b/packages/SwingSet/test/vat-syscall-failure.js
@@ -10,6 +10,9 @@ function capargs(args, slots = []) {
 
 export default function setup(syscall, _state, _helpers, vatPowers) {
   function dispatch(vatDeliverObject) {
+    if (vatDeliverObject[0] !== 'message') {
+      return;
+    }
     const { method, args } = extractMessage(vatDeliverObject);
     vatPowers.testLog(`${method}`);
     const thing = method === 'begood' ? args.slots[0] : 'o-3414159';

--- a/packages/SwingSet/test/virtualObjects/test-representatives.js
+++ b/packages/SwingSet/test/virtualObjects/test-representatives.js
@@ -40,10 +40,14 @@ test.serial('exercise cache', async t => {
 
   const log = [];
 
+  const expectedVatID = 'v1';
   const hostStorage = provideHostStorage();
   const kvStore = hostStorage.kvStore;
   function vsKey(key) {
-    return key.match(/^\w+\.vs\./);
+    // ignore everything except vatStores on the one vat under test
+    // (especially ignore comms, which performs vatstore operations during
+    // startup)
+    return key.startsWith(`${expectedVatID}.`) && key.match(/^\w+\.vs\./);
   }
   const loggingKVStore = {
     has: key => kvStore.has(key),
@@ -160,6 +164,10 @@ test.serial('exercise cache', async t => {
   const T6 = 'ko30';
   const T7 = 'ko31';
   const T8 = 'ko32';
+
+  // these tests are hard-coded to expect our vat-under-test to be 'v1', so
+  // double-check here
+  t.is(c.vatNameToID('bootstrap'), expectedVatID);
 
   await c.run();
   t.deepEqual(c.kpResolution(bootstrapResult), capargs('bootstrap done'));


### PR DESCRIPTION
For normal vats (both static and dynamic), `dispatch.startVat()` is the
signal to evaluate the userspace code bundle and invoke `buildRootObject`.
Liveslots has access to `syscall` earlier, but it must not use it until
`startVat()` indicates the kernel is ready (prepared to record the syscalls
in a transcript). However, `setup()`-based "raw vats" did not receive
`startVat`.

This changes the kernel to send `startVat` to `setup()`-based vats too. The
only real `setup()`-based vat we use is comms, which now ignores `startVat`,
but in the future will be able to use it to avoid constant vatstore
initialization queries.

Several unit tests create `setup()`-based vats: these were changed to ignore
`startVat` too. The test which counted message deliveries were updated to
accomodate the extra deliveries.

refs #4637
but doesn't close it until comms is improved too
