### PR TITLE
chore(vats): refine bootstrap logging for installations etc. in agoricNames

### DIFF
--- a/packages/vats/src/core/utils.js
+++ b/packages/vats/src/core/utils.js
@@ -215,7 +215,7 @@ harden(extractPowers);
  *
  */
 export const makeAgoricNamesAccess = (
-  log = console.debug,
+  log = () => {}, // console.debug
   reserved = agoricNamesReserved,
 ) => {
   const { nameHub: agoricNames, nameAdmin: agoricNamesAdmin } =
@@ -227,7 +227,8 @@ export const makeAgoricNamesAccess = (
   });
   const spaces = mapEntries(reserved, (key, detail) => {
     const { nameAdmin } = hubs[key];
-    const { produce, consume } = makePromiseSpace(log);
+    const subSpaceLog = (...args) => log(key, ...args);
+    const { produce, consume } = makePromiseSpace(subSpaceLog);
     keys(detail).forEach(k => {
       nameAdmin.reserve(k);
       consume[k].then(v => nameAdmin.update(k, v));


### PR DESCRIPTION
closes: #4713

I think this puts bootstrap logging in the same category as consensus mode, where you have to edit the sources to see them.