### PR TITLE
fix: freeze globalThis in coreEval to enforce OCap discipline

### DIFF
--- a/packages/vats/src/core/chain-behaviors.js
+++ b/packages/vats/src/core/chain-behaviors.js
@@ -80,7 +80,9 @@ export const bridgeCoreEval = async allPowers => {
                 });
 
                 // Evaluate the code in the context of the globals.
-                const behavior = new Compartment(globals).evaluate(code);
+                const compartment = new Compartment(globals);
+                harden(compartment.globalThis);
+                const behavior = compartment.evaluate(code);
                 return behavior(powers);
               }),
             ),


### PR DESCRIPTION
refs: #4642, #4352

I pointed out to @erights the other day that in `coreEval`, rather than make powers ambient globals in the compartment, we evaluate a function in a powerless environment and then pass powers to it, in order to allow the evaluated code to take advantage of OCap discipline.

@erights pointed out that `globalThis` isn't frozen in that compartment. Oops.