### PR TITLE
move vatParameters to startVat() delivery

### DIFF
--- a/packages/SwingSet/src/controller/initializeKernel.js
+++ b/packages/SwingSet/src/controller/initializeKernel.js
@@ -70,7 +70,6 @@ export function initializeKernel(config, hostStorage, verbose = false) {
         'useTranscript',
         'reapInterval',
       ]);
-      creationOptions.vatParameters = vatParameters;
       creationOptions.description = `static name=${name}`;
       creationOptions.name = name;
       if (creationOptions.useTranscript === undefined) {
@@ -88,7 +87,9 @@ export function initializeKernel(config, hostStorage, verbose = false) {
       const vatKeeper = kernelKeeper.provideVatKeeper(vatID);
       vatKeeper.setSourceAndOptions({ bundleID }, creationOptions);
       vatKeeper.initializeReapCountdown(creationOptions.reapInterval);
-      kernelKeeper.addToAcceptanceQueue(harden({ type: 'startVat', vatID }));
+      kernelKeeper.addToAcceptanceQueue(
+        harden({ type: 'startVat', vatID, vatParameters }),
+      );
       if (name === 'vatAdmin') {
         // Create a kref for the vatAdmin root, so the kernel can tell it
         // about creation/termination of dynamic vats, and the installation

--- a/packages/SwingSet/src/controller/initializeKernel.js
+++ b/packages/SwingSet/src/controller/initializeKernel.js
@@ -157,7 +157,7 @@ export function initializeKernel(config, hostStorage, verbose = false) {
       // non-empty object as vatObj0s, since an empty object would be
       // serialized as pass-by-presence. It wouldn't make much sense for the
       // bootstrap object to call itself, though.
-      const vref = Far('vref', {});
+      const vref = Far('root', {});
       vatObj0s[name] = vref;
       const vatKeeper = kernelKeeper.provideVatKeeper(vatID);
       const kernelSlot = vatKeeper.mapVatSlotToKernelSlot(vatSlot);

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -1217,6 +1217,13 @@ export default function buildKernel(
     vatKeeper.initializeReapCountdown(creationOptions.reapInterval);
 
     await vatWarehouse.loadTestVat(vatID, setup, creationOptions);
+
+    /** @type { RunQueueEventStartVat } */
+    const startVatMessage = { type: 'startVat', vatID };
+    // eslint-disable-next-line no-unused-vars
+    const ds = await processStartVat(startVatMessage);
+    // TODO: do something with DeliveryStatus, maybe just assert it's ok
+
     return vatID;
   }
 

--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -526,13 +526,13 @@ export default function buildKernel(
    * @returns { Promise<DeliveryStatus> }
    */
   async function processStartVat(message) {
-    const { type, vatID } = message;
+    const { vatID, vatParameters } = message;
     // console.log(`-- processStartVat(${vatID})`);
     insistVatID(vatID);
     // eslint-disable-next-line no-use-before-define
     assert(vatWarehouse.lookup(vatID));
     /** @type { KernelDeliveryStartVat } */
-    const kd = harden([type]); // TODO(4381) add vatParameters here
+    const kd = harden(['startVat', vatParameters]); // TODO(4381) add vatParameters here
     // eslint-disable-next-line no-use-before-define
     const vd = vatWarehouse.kernelDeliveryToVatDelivery(vatID, kd);
     // TODO: can we provide a computron count to the run policy?
@@ -547,7 +547,7 @@ export default function buildKernel(
    */
   async function processCreateVat(message) {
     assert(vatAdminRootKref, `initializeKernel did not set vatAdminRootKref`);
-    const { vatID, source, dynamicOptions } = message;
+    const { vatID, source, vatParameters, dynamicOptions } = message;
     kernelKeeper.addDynamicVatID(vatID);
     const vatKeeper = kernelKeeper.provideVatKeeper(vatID);
     const options = { ...dynamicOptions };
@@ -599,7 +599,9 @@ export default function buildKernel(
       vatWarehouse
         .createDynamicVat(vatID)
         // if createDynamicVat fails, go directly to makeErrorResponse
-        .then(_vatinfo => processStartVat({ type: 'startVat', vatID }))
+        .then(_vatinfo =>
+          processStartVat({ type: 'startVat', vatID, vatParameters }),
+        )
         // TODO(4381) add vatParameters here
         // If processStartVat/deliverAndLogToVat observes a worker error, it
         // will return status={ terminate: problem } rather than throw an
@@ -768,11 +770,12 @@ export default function buildKernel(
    * @typedef { { type: 'send', target: string, msg: Message }} RunQueueEventSend
    * @typedef { { type: 'create-vat', vatID: VatID,
    *              source: { bundle: Bundle } | { bundleID: BundleID },
+   *              vatParameters: SwingSetCapData,
    *              dynamicOptions: InternalDynamicVatOptions }
    *          } RunQueueEventCreateVat
    * @typedef { { type: 'upgrade-vat', vatID: VatID, upgradeID: string,
    *              bundleID: BundleID, vatParameters: SwingSetCapData } } RunQueueEventUpgradeVat
-   * @typedef { { type: 'startVat', vatID: VatID } } RunQueueEventStartVat
+   * @typedef { { type: 'startVat', vatID: VatID, vatParameters: unknown } } RunQueueEventStartVat
    * @typedef { { type: 'dropExports', vatID: VatID, krefs: string[] } } RunQueueEventDropExports
    * @typedef { { type: 'retireExports', vatID: VatID, krefs: string[] } } RunQueueEventRetireExports
    * @typedef { { type: 'retireImports', vatID: VatID, krefs: string[] } } RunQueueEventRetireImports
@@ -1205,7 +1208,6 @@ export default function buildKernel(
     ]);
 
     assert(!kernelKeeper.hasVatWithName(name), X`vat ${name} already exists`);
-    creationOptions.vatParameters = vatParameters;
 
     const vatID = kernelKeeper.allocateVatIDForNameIfNeeded(name);
     logStartup(`assigned VatID ${vatID} for test vat ${name}`);
@@ -1219,7 +1221,7 @@ export default function buildKernel(
     await vatWarehouse.loadTestVat(vatID, setup, creationOptions);
 
     /** @type { RunQueueEventStartVat } */
-    const startVatMessage = { type: 'startVat', vatID };
+    const startVatMessage = { type: 'startVat', vatID, vatParameters };
     // eslint-disable-next-line no-unused-vars
     const ds = await processStartVat(startVatMessage);
     // TODO: do something with DeliveryStatus, maybe just assert it's ok
@@ -1245,7 +1247,15 @@ export default function buildKernel(
         // TODO: translate dynamicOptions.vatParameters.slots from dref to kref
         const source = { bundle };
         const vatID = kernelKeeper.allocateUnusedVatID();
-        const event = { type: 'create-vat', vatID, source, dynamicOptions };
+        const { vatParameters, ...rest } = dynamicOptions;
+        dynamicOptions = rest;
+        const event = {
+          type: 'create-vat',
+          vatID,
+          source,
+          vatParameters,
+          dynamicOptions,
+        };
         kernelKeeper.addToAcceptanceQueue(harden(event));
         // the device gets the new vatID immediately, and will be notified
         // later when it is created and a root object is available
@@ -1256,7 +1266,15 @@ export default function buildKernel(
         // TODO: translate dynamicOptions.vatParameters.slots from dref to kref
         const source = { bundleID };
         const vatID = kernelKeeper.allocateUnusedVatID();
-        const event = { type: 'create-vat', vatID, source, dynamicOptions };
+        const { vatParameters, ...rest } = dynamicOptions;
+        dynamicOptions = rest;
+        const event = {
+          type: 'create-vat',
+          vatID,
+          source,
+          vatParameters,
+          dynamicOptions,
+        };
         kernelKeeper.addToAcceptanceQueue(harden(event));
         // the device gets the new vatID immediately, and will be notified
         // later when it is created and a root object is available

--- a/packages/SwingSet/src/kernel/vat-loader/manager-factory.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-factory.js
@@ -62,7 +62,6 @@ export function makeVatManagerFactory({
       'virtualObjectCacheSize',
       'useTranscript',
       'reapInterval',
-      'vatParameters',
       'vatConsole',
       'name',
       'compareSyscalls',

--- a/packages/SwingSet/src/kernel/vat-loader/manager-local.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-local.js
@@ -49,7 +49,7 @@ export function makeLocalVatManagerFactory(tools) {
   function createFromSetup(vatID, setup, managerOptions, vatSyscallHandler) {
     assert.typeof(setup, 'function', 'setup is not an in-realm function');
 
-    const { vatParameters, compareSyscalls, useTranscript } = managerOptions;
+    const { compareSyscalls, useTranscript } = managerOptions;
     const { syscall, finish } = prepare(
       vatID,
       vatSyscallHandler,
@@ -61,7 +61,7 @@ export function makeLocalVatManagerFactory(tools) {
     const state = null; // TODO remove from setup()
     const vatPowers = harden({ ...baseVP, testLog });
 
-    const dispatch = setup(syscall, state, helpers, vatPowers, vatParameters);
+    const dispatch = setup(syscall, state, helpers, vatPowers);
     return finish(dispatch);
   }
 
@@ -75,7 +75,6 @@ export function makeLocalVatManagerFactory(tools) {
       consensusMode,
       enableDisavow = false,
       enableSetup = false,
-      vatParameters = {},
       vatConsole,
       liveSlotsConsole,
       enableVatstore = false,
@@ -94,7 +93,6 @@ export function makeLocalVatManagerFactory(tools) {
 
     const vatPowers = harden({
       ...baseVP,
-      vatParameters,
       testLog: allVatPowers.testLog,
     });
 
@@ -146,14 +144,13 @@ export function makeLocalVatManagerFactory(tools) {
       assert.typeof(setup, 'function');
       const helpers = harden({}); // DEPRECATED, todo remove from setup()
       const state = null; // TODO remove from setup()
-      const dispatch = setup(syscall, state, helpers, vatPowers, vatParameters);
+      const dispatch = setup(syscall, state, helpers, vatPowers);
       return finish(dispatch);
     } else {
       const ls = makeLiveSlots(
         syscall,
         vatID,
         vatPowers,
-        vatParameters,
         virtualObjectCacheSize,
         enableDisavow,
         enableVatstore,

--- a/packages/SwingSet/src/kernel/vat-loader/manager-nodeworker.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-nodeworker.js
@@ -38,7 +38,6 @@ export function makeNodeWorkerVatManagerFactory(tools) {
   function createFromBundle(vatID, bundle, managerOptions, vatSyscallHandler) {
     const {
       consensusMode,
-      vatParameters,
       virtualObjectCacheSize,
       enableDisavow,
       enableVatstore,
@@ -111,7 +110,6 @@ export function makeNodeWorkerVatManagerFactory(tools) {
     sendToWorker([
       'setBundle',
       bundle,
-      vatParameters,
       virtualObjectCacheSize,
       enableDisavow,
       enableVatstore,

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-node.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-node.js
@@ -18,7 +18,6 @@ export function makeNodeSubprocessFactory(tools) {
   function createFromBundle(vatID, bundle, managerOptions, vatSyscallHandler) {
     const {
       consensusMode,
-      vatParameters,
       virtualObjectCacheSize,
       enableDisavow,
       enableVatstore,
@@ -106,7 +105,6 @@ export function makeNodeSubprocessFactory(tools) {
     sendToWorker([
       'setBundle',
       bundle,
-      vatParameters,
       virtualObjectCacheSize,
       enableDisavow,
       enableVatstore,

--- a/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
+++ b/packages/SwingSet/src/kernel/vat-loader/manager-subprocess-xsnap.js
@@ -52,7 +52,6 @@ export function makeXsSubprocessFactory({
     parentLog(vatID, 'createFromBundle', { vatID });
     const {
       consensusMode,
-      vatParameters,
       virtualObjectCacheSize,
       enableDisavow,
       enableVatstore,
@@ -147,7 +146,6 @@ export function makeXsSubprocessFactory({
         'setBundle',
         vatID,
         bundle,
-        vatParameters,
         virtualObjectCacheSize,
         enableDisavow,
         enableVatstore,

--- a/packages/SwingSet/src/kernel/vat-loader/vat-loader.js
+++ b/packages/SwingSet/src/kernel/vat-loader/vat-loader.js
@@ -89,7 +89,6 @@ export function makeVatLoader(stuff) {
     'description',
     'meterID',
     'managerType', // TODO: not sure we want vats to be able to control this
-    'vatParameters',
     'enableSetup',
     'enablePipelining',
     'enableVatstore',
@@ -101,7 +100,6 @@ export function makeVatLoader(stuff) {
   const allowedStaticOptions = [
     'description',
     'name',
-    'vatParameters',
     'managerType',
     'enableDisavow',
     'enableSetup',
@@ -143,10 +141,6 @@ export function makeVatLoader(stuff) {
    *        used by each crank. The meter will eventually underflow unless it
    *        is topped up, at which point the vat is terminated. If undefined,
    *        the vat is unmetered. Static vats cannot be metered.
-   *
-   * @param {Record<string, unknown>} [options.vatParameters] provides
-   *        the contents of the second argument to
-   *        'buildRootObject()'.  Defaults to `{}`.
    *
    * @param {boolean} [options.enableSetup] If true,
    *        permits the vat to construct itself using the
@@ -220,7 +214,6 @@ export function makeVatLoader(stuff) {
     );
     const {
       meterID,
-      vatParameters = {},
       managerType,
       enableSetup = false,
       enableDisavow = false,
@@ -240,7 +233,6 @@ export function makeVatLoader(stuff) {
       name,
       vatSourceBundle,
       managerType,
-      vatParameters,
     );
 
     const managerOptions = {
@@ -252,7 +244,6 @@ export function makeVatLoader(stuff) {
       enablePipelining,
       vatConsole: makeVatConsole('vat', vatID),
       liveSlotsConsole: makeVatConsole('ls', vatID),
-      vatParameters,
       enableVatstore,
       virtualObjectCacheSize,
       useTranscript,

--- a/packages/SwingSet/src/kernel/vatTranslator.js
+++ b/packages/SwingSet/src/kernel/vatTranslator.js
@@ -13,9 +13,6 @@ import {
 /** @type { VatDeliveryBringOutYourDead } */
 const reapMessageVatDelivery = harden(['bringOutYourDead']);
 
-/** @type { VatDeliveryStartVat } */
-const startVatMessageVatDelivery = harden(['startVat']);
-
 export function assertValidVatstoreKey(key) {
   assert.typeof(key, 'string');
 }
@@ -151,8 +148,21 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
     return vatDelivery;
   }
 
-  function translateStartVat() {
-    return startVatMessageVatDelivery;
+  /**
+   *
+   * @param {unknown} kernelVP
+   * @returns { VatDeliveryStartVat }
+   */
+  function translateStartVat(kernelVP) {
+    /** @type { VatDeliveryStartVat } */
+    return harden(['startVat', kernelVP]); // TODO until capdata
+    // const vatVP = {
+    //   ...kernelVP,
+    //   slots: kernelVP.slots.map(slot => mapKernelSlotToVatSlot(slot)),
+    // };
+    // /** @type { VatDeliveryStartVat } */
+    // const startVatMessageVatDelivery = harden(['startVat', vatVP]);
+    // return startVatMessageVatDelivery;
   }
 
   function translateBringOutYourDead() {

--- a/packages/SwingSet/src/lib/message.js
+++ b/packages/SwingSet/src/lib/message.js
@@ -65,7 +65,11 @@ export function insistVatDeliveryObject(vdo) {
       }
       break;
     }
-    case 'startVat':
+    case 'startVat': {
+      const [_vatParameters] = rest;
+      // TODO: insistCapData(vatParameters);
+      break;
+    }
     case 'bringOutYourDead': {
       assert(rest.length === 0);
       break;

--- a/packages/SwingSet/src/supervisors/nodeworker/supervisor-nodeworker.js
+++ b/packages/SwingSet/src/supervisors/nodeworker/supervisor-nodeworker.js
@@ -47,7 +47,6 @@ parentPort.on('message', ([type, ...margs]) => {
   } else if (type === 'setBundle') {
     const [
       bundle,
-      vatParameters,
       virtualObjectCacheSize,
       enableDisavow,
       enableVatstore,
@@ -121,7 +120,6 @@ parentPort.on('message', ([type, ...margs]) => {
       syscall,
       vatID,
       vatPowers,
-      vatParameters,
       virtualObjectCacheSize,
       enableDisavow,
       enableVatstore,

--- a/packages/SwingSet/src/supervisors/subprocess-node/supervisor-subprocess-node.js
+++ b/packages/SwingSet/src/supervisors/subprocess-node/supervisor-subprocess-node.js
@@ -67,7 +67,6 @@ fromParent.on('data', ([type, ...margs]) => {
   } else if (type === 'setBundle') {
     const [
       bundle,
-      vatParameters,
       virtualObjectCacheSize,
       enableDisavow,
       enableVatstore,
@@ -141,7 +140,6 @@ fromParent.on('data', ([type, ...margs]) => {
       syscall,
       vatID,
       vatPowers,
-      vatParameters,
       virtualObjectCacheSize,
       enableDisavow,
       enableVatstore,

--- a/packages/SwingSet/src/supervisors/subprocess-xsnap/supervisor-subprocess-xsnap.js
+++ b/packages/SwingSet/src/supervisors/subprocess-xsnap/supervisor-subprocess-xsnap.js
@@ -186,7 +186,6 @@ function makeWorker(port) {
   /**
    * @param {unknown} vatID
    * @param {unknown} bundle
-   * @param {unknown} vatParameters
    * @param {unknown} virtualObjectCacheSize
    * @param {boolean} enableDisavow
    * @param {boolean} enableVatstore
@@ -197,7 +196,6 @@ function makeWorker(port) {
   async function setBundle(
     vatID,
     bundle,
-    vatParameters,
     virtualObjectCacheSize,
     enableDisavow,
     enableVatstore,
@@ -308,7 +306,6 @@ function makeWorker(port) {
       syscall,
       vatID,
       vatPowers,
-      vatParameters,
       cacheSize,
       enableDisavow,
       enableVatstore,
@@ -329,15 +326,14 @@ function makeWorker(port) {
     switch (tag) {
       case 'setBundle': {
         assert(!dispatch, 'cannot setBundle again');
-        const enableDisavow = !!args[4];
-        const enableVatstore = !!args[5];
-        const consensusMode = !!args[6];
-        const gcEveryCrank = args[7] === undefined ? true : !!args[7];
+        const enableDisavow = !!args[3];
+        const enableVatstore = !!args[4];
+        const consensusMode = !!args[5];
+        const gcEveryCrank = args[6] === undefined ? true : !!args[6];
         return setBundle(
           args[0],
           args[1],
           args[2],
-          args[3],
           enableDisavow,
           enableVatstore,
           consensusMode,

--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -97,7 +97,7 @@ export {};
  * @typedef { [tag: 'dropExports', vrefs: string[] ]} VatDeliveryDropExports
  * @typedef { [tag: 'retireExports', vrefs: string[] ]} VatDeliveryRetireExports
  * @typedef { [tag: 'retireImports', vrefs: string[] ]} VatDeliveryRetireImports
- * @typedef { [tag: 'startVat' ]} VatDeliveryStartVat
+ * @typedef { [tag: 'startVat', vatParameters: unknown ]} VatDeliveryStartVat
  * @typedef { [tag: 'bringOutYourDead' ]} VatDeliveryBringOutYourDead
  * @typedef { VatDeliveryMessage | VatDeliveryNotify | VatDeliveryDropExports
  *            | VatDeliveryRetireExports | VatDeliveryRetireImports
@@ -136,7 +136,7 @@ export {};
  * @typedef { [tag: 'dropExports', krefs: string[] ]} KernelDeliveryDropExports
  * @typedef { [tag: 'retireExports', krefs: string[] ]} KernelDeliveryRetireExports
  * @typedef { [tag: 'retireImports', krefs: string[] ]} KernelDeliveryRetireImports
- * @typedef { [tag: 'startVat']} KernelDeliveryStartVat
+ * @typedef { [tag: 'startVat', vatParameters: unknown ]} KernelDeliveryStartVat
  * @typedef { [tag: 'bringOutYourDead']} KernelDeliveryBringOutYourDead
  * @typedef { KernelDeliveryMessage | KernelDeliveryNotify | KernelDeliveryDropExports
  *            | KernelDeliveryRetireExports | KernelDeliveryRetireImports

--- a/packages/SwingSet/test/devices/test-devices.js
+++ b/packages/SwingSet/test/devices/test-devices.js
@@ -69,11 +69,11 @@ test.serial('d0', async t => {
   // console.log(util.inspect(c.dump(), { depth: null }));
   t.deepEqual(JSON.parse(c.dump().log[0]), [
     {
-      bootstrap: { '@qclass': 'slot', iface: 'Alleged: vref', index: 0 },
-      comms: { '@qclass': 'slot', iface: 'Alleged: vref', index: 1 },
-      timer: { '@qclass': 'slot', iface: 'Alleged: vref', index: 2 },
-      vatAdmin: { '@qclass': 'slot', iface: 'Alleged: vref', index: 3 },
-      vattp: { '@qclass': 'slot', iface: 'Alleged: vref', index: 4 },
+      bootstrap: { '@qclass': 'slot', iface: 'Alleged: root', index: 0 },
+      comms: { '@qclass': 'slot', iface: 'Alleged: root', index: 1 },
+      timer: { '@qclass': 'slot', iface: 'Alleged: root', index: 2 },
+      vatAdmin: { '@qclass': 'slot', iface: 'Alleged: root', index: 3 },
+      vattp: { '@qclass': 'slot', iface: 'Alleged: root', index: 4 },
     },
     {
       d0: { '@qclass': 'slot', iface: 'Alleged: device', index: 5 },

--- a/packages/SwingSet/test/liveslots-helpers.js
+++ b/packages/SwingSet/test/liveslots-helpers.js
@@ -122,7 +122,6 @@ export async function makeDispatch(
     syscall,
     vatID,
     {},
-    {},
     cacheSize,
     enableDisavow,
     false,

--- a/packages/SwingSet/test/test-comms.js
+++ b/packages/SwingSet/test/test-comms.js
@@ -15,8 +15,8 @@ import {
 import { commsVatDriver } from './commsVatDriver.js';
 
 test('translation', t => {
-  const s = makeState(null, 0);
-  s.maybeInitialize();
+  const s = makeState(null);
+  s.initialize(null, 0);
   const fakeSyscall = {};
   const clistKit = makeCListKit(s, fakeSyscall);
   const { provideRemoteForLocal, provideLocalForRemote } = clistKit;

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -69,11 +69,11 @@ async function simpleCall(t) {
   controller.queueToVatRoot('vat1', 'foo', capdata('args'));
   t.deepEqual(controller.dump().runQueue, []);
   t.deepEqual(controller.dump().acceptanceQueue, [
-    { type: 'startVat', vatID: 'v1' },
-    { type: 'startVat', vatID: 'v2' },
-    { type: 'startVat', vatID: 'v3' },
-    { type: 'startVat', vatID: 'v4' },
-    { type: 'startVat', vatID: 'v5' },
+    { type: 'startVat', vatID: 'v1', vatParameters: {} },
+    { type: 'startVat', vatID: 'v2', vatParameters: {} },
+    { type: 'startVat', vatID: 'v3', vatParameters: {} },
+    { type: 'startVat', vatID: 'v4', vatParameters: {} },
+    { type: 'startVat', vatID: 'v5', vatParameters: {} },
     {
       msg: {
         method: 'foo',
@@ -222,13 +222,13 @@ test.serial('bootstrap export', async t => {
 
   t.deepEqual(c.dump().runQueue, []);
   t.deepEqual(c.dump().acceptanceQueue, [
-    { type: 'startVat', vatID: 'v1' },
-    { type: 'startVat', vatID: 'v2' },
-    { type: 'startVat', vatID: 'v3' },
-    { type: 'startVat', vatID: 'v4' },
-    { type: 'startVat', vatID: 'v5' },
-    { type: 'startVat', vatID: 'v6' },
-    { type: 'startVat', vatID: 'v7' },
+    { type: 'startVat', vatID: 'v1', vatParameters: {} },
+    { type: 'startVat', vatID: 'v2', vatParameters: {} },
+    { type: 'startVat', vatID: 'v3', vatParameters: { argv: [] } },
+    { type: 'startVat', vatID: 'v4', vatParameters: {} },
+    { type: 'startVat', vatID: 'v5', vatParameters: {} },
+    { type: 'startVat', vatID: 'v6', vatParameters: {} },
+    { type: 'startVat', vatID: 'v7', vatParameters: {} },
     {
       msg: {
         result: 'kp40',

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -234,7 +234,7 @@ test.serial('bootstrap export', async t => {
         result: 'kp40',
         method: 'bootstrap',
         args: {
-          body: '[{"bootstrap":{"@qclass":"slot","iface":"Alleged: vref","index":0},"comms":{"@qclass":"slot","iface":"Alleged: vref","index":1},"left":{"@qclass":"slot","iface":"Alleged: vref","index":2},"right":{"@qclass":"slot","iface":"Alleged: vref","index":3},"timer":{"@qclass":"slot","iface":"Alleged: vref","index":4},"vatAdmin":{"@qclass":"slot","iface":"Alleged: vref","index":5},"vattp":{"@qclass":"slot","iface":"Alleged: vref","index":6}},{"vatAdmin":{"@qclass":"slot","iface":"Alleged: device","index":7}}]',
+          body: '[{"bootstrap":{"@qclass":"slot","iface":"Alleged: root","index":0},"comms":{"@qclass":"slot","iface":"Alleged: root","index":1},"left":{"@qclass":"slot","iface":"Alleged: root","index":2},"right":{"@qclass":"slot","iface":"Alleged: root","index":3},"timer":{"@qclass":"slot","iface":"Alleged: root","index":4},"vatAdmin":{"@qclass":"slot","iface":"Alleged: root","index":5},"vattp":{"@qclass":"slot","iface":"Alleged: root","index":6}},{"vatAdmin":{"@qclass":"slot","iface":"Alleged: device","index":7}}]',
           slots: [
             boot0,
             comms0,
@@ -299,7 +299,7 @@ test.serial('bootstrap export', async t => {
       msg: {
         method: 'foo',
         args: {
-          body: '[1,{"@qclass":"slot","iface":"Alleged: vref","index":0}]',
+          body: '[1,{"@qclass":"slot","iface":"Alleged: root","index":0}]',
           slots: [right0],
         },
         result: fooP,
@@ -323,7 +323,7 @@ test.serial('bootstrap export', async t => {
       msg: {
         method: 'bar',
         args: {
-          body: '[2,{"@qclass":"slot","iface":"Alleged: vref","index":0}]',
+          body: '[2,{"@qclass":"slot","iface":"Alleged: root","index":0}]',
           slots: [right0],
         },
         result: barP,

--- a/packages/SwingSet/test/test-gc-kernel.js
+++ b/packages/SwingSet/test/test-gc-kernel.js
@@ -125,6 +125,9 @@ async function prep(t, options = {}) {
   const logA = [];
   function setupA(syscall, _state, _helpers, _vatPowers) {
     function dispatch(vd) {
+      if (vd[0] === 'startVat') {
+        return; // skip startVat
+      }
       // console.log(`dispatchA`, vd);
       logA.push(vd);
       if (vd[0] === 'message' && vd[2].method === 'one-alice') {
@@ -176,6 +179,9 @@ async function prep(t, options = {}) {
   const logB = [];
   function setupB(syscall, _state, _helpers, _vatPowers) {
     function dispatch(vd) {
+      if (vd[0] === 'startVat') {
+        return; // skip startVat
+      }
       logB.push(vd);
       // console.log(`dispatchB`, vd);
       if (vd[0] === 'message' && vd[2].method === 'two') {
@@ -249,6 +255,9 @@ async function prep(t, options = {}) {
   const logC = [];
   function setupC(syscall, _state, _helpers, _vatPowers) {
     function dispatch(vd) {
+      if (vd[0] === 'startVat') {
+        return; // skip startVat
+      }
       logC.push(vd);
       if (vd[0] === 'message' && vd[2].method === 'two') {
         vrefs.amyForCarol = vd[2].args.slots[0];

--- a/packages/SwingSet/test/test-kernel.js
+++ b/packages/SwingSet/test/test-kernel.js
@@ -47,7 +47,7 @@ function makeKernel() {
   return buildKernel(endowments, {}, {});
 }
 
-const tsv = [{ d: ['startVat'], syscalls: [] }];
+const tsv = [{ d: ['startVat', {}], syscalls: [] }];
 
 test('build kernel', async t => {
   const kernel = makeKernel();

--- a/packages/SwingSet/test/test-kernel.js
+++ b/packages/SwingSet/test/test-kernel.js
@@ -47,6 +47,8 @@ function makeKernel() {
   return buildKernel(endowments, {}, {});
 }
 
+const tsv = [{ d: ['startVat'], syscalls: [] }];
+
 test('build kernel', async t => {
   const kernel = makeKernel();
   await kernel.start(); // empty queue
@@ -62,6 +64,9 @@ test('simple call', async t => {
   function setup1(syscall, state, _helpers, vatPowers) {
     function dispatch(vatDeliverObject) {
       // TODO: just push the vatDeliverObject
+      if (vatDeliverObject[0] === 'startVat') {
+        return; // skip startVat
+      }
       const { facetID, method, args } = extractMessage(vatDeliverObject);
       log.push([facetID, method, args]);
       vatPowers.testLog(JSON.stringify({ facetID, method, args }));
@@ -71,7 +76,7 @@ test('simple call', async t => {
   await kernel.createTestVat('vat1', setup1);
   const vat1 = kernel.vatNameToID('vat1');
   let data = kernel.dump();
-  t.deepEqual(data.vatTables, [{ vatID: vat1, state: { transcript: [] } }]);
+  t.deepEqual(data.vatTables, [{ vatID: vat1, state: { transcript: tsv } }]);
   t.deepEqual(data.kernelTable, []);
   t.deepEqual(data.log, []);
   t.deepEqual(log, []);
@@ -108,6 +113,9 @@ test('vat store', async t => {
   const log = [];
   function setup(syscall, _state, _helpers, _vatPowers) {
     function dispatch(vatDeliverObject) {
+      if (vatDeliverObject[0] === 'startVat') {
+        return; // skip startVat
+      }
       const { method, args } = extractMessage(vatDeliverObject);
       switch (method) {
         case 'get': {
@@ -161,6 +169,9 @@ test('map inbound', async t => {
   const log = [];
   function setup1(_syscall) {
     function dispatch(vatDeliverObject) {
+      if (vatDeliverObject[0] === 'startVat') {
+        return; // skip startVat
+      }
       const { facetID, method, args } = extractMessage(vatDeliverObject);
       log.push([facetID, method, args]);
     }
@@ -172,8 +183,8 @@ test('map inbound', async t => {
   const vat2 = kernel.vatNameToID('vat2');
   const data = kernel.dump();
   t.deepEqual(data.vatTables, [
-    { vatID: vat1, state: { transcript: [] } },
-    { vatID: vat2, state: { transcript: [] } },
+    { vatID: vat1, state: { transcript: tsv } },
+    { vatID: vat2, state: { transcript: tsv } },
   ]);
   t.deepEqual(data.kernelTable, []);
   t.deepEqual(log, []);
@@ -240,6 +251,9 @@ test('outbound call', async t => {
       return makeVatSlot('promise', true, index);
     }
     function dispatch(vatDeliverObject) {
+      if (vatDeliverObject[0] === 'startVat') {
+        return; // skip startVat
+      }
       const { facetID, method, args } = extractMessage(vatDeliverObject);
       // console.log(`d1/${facetID} called`);
       log.push(['d1', facetID, method, args]);
@@ -257,6 +271,9 @@ test('outbound call', async t => {
 
   function setup2(_syscall) {
     function dispatch(vatDeliverObject) {
+      if (vatDeliverObject[0] === 'startVat') {
+        return; // skip startVat
+      }
       const { facetID, method, args } = extractMessage(vatDeliverObject);
       // console.log(`d2/${facetID} called`);
       log.push(['d2', facetID, method, args]);
@@ -275,8 +292,8 @@ test('outbound call', async t => {
 
   const data = kernel.dump();
   t.deepEqual(data.vatTables, [
-    { vatID: vat1, state: { transcript: [] } },
-    { vatID: vat2, state: { transcript: [] } },
+    { vatID: vat1, state: { transcript: tsv } },
+    { vatID: vat2, state: { transcript: tsv } },
   ]);
 
   const kt = [
@@ -469,6 +486,9 @@ test('three-party', async t => {
       return makeVatSlot('promise', true, index);
     }
     function dispatch(vatDeliverObject) {
+      if (vatDeliverObject[0] === 'startVat') {
+        return; // skip startVat
+      }
       const { facetID, method, args } = extractMessage(vatDeliverObject);
       // console.log(`vatA/${facetID} called`);
       log.push(['vatA', facetID, method, args]);
@@ -482,6 +502,9 @@ test('three-party', async t => {
 
   function setupB(_syscall) {
     function dispatch(vatDeliverObject) {
+      if (vatDeliverObject[0] === 'startVat') {
+        return; // skip startVat
+      }
       const { facetID, method, args } = extractMessage(vatDeliverObject);
       // console.log(`vatB/${facetID} called`);
       log.push(['vatB', facetID, method, args]);
@@ -492,6 +515,9 @@ test('three-party', async t => {
 
   function setupC(_syscall) {
     function dispatch(vatDeliverObject) {
+      if (vatDeliverObject[0] === 'startVat') {
+        return; // skip startVat
+      }
       const { facetID, method, args } = extractMessage(vatDeliverObject);
       log.push(['vatC', facetID, method, args]);
     }
@@ -516,9 +542,9 @@ test('three-party', async t => {
 
   const data = kernel.dump();
   t.deepEqual(data.vatTables, [
-    { vatID: vatA, state: { transcript: [] } },
-    { vatID: vatB, state: { transcript: [] } },
-    { vatID: vatC, state: { transcript: [] } },
+    { vatID: vatA, state: { transcript: tsv } },
+    { vatID: vatB, state: { transcript: tsv } },
+    { vatID: vatC, state: { transcript: tsv } },
   ]);
   const kt = [
     [alice, vatA, 'o+4'],
@@ -603,6 +629,9 @@ test('transfer promise', async t => {
   function setupA(syscall) {
     syscallA = syscall;
     function dispatch(vatDeliverObject) {
+      if (vatDeliverObject[0] === 'startVat') {
+        return; // skip startVat
+      }
       const { facetID, method, args } = extractMessage(vatDeliverObject);
       logA.push([facetID, method, args]);
     }
@@ -615,6 +644,9 @@ test('transfer promise', async t => {
   function setupB(syscall) {
     syscallB = syscall;
     function dispatch(vatDeliverObject) {
+      if (vatDeliverObject[0] === 'startVat') {
+        return; // skip startVat
+      }
       const { facetID, method, args } = extractMessage(vatDeliverObject);
       logB.push([facetID, method, args]);
     }
@@ -708,6 +740,9 @@ test('subscribe to promise', async t => {
   function setup(s) {
     syscall = s;
     function dispatch(vatDeliverObject) {
+      if (vatDeliverObject[0] === 'startVat') {
+        return; // skip startVat
+      }
       const { facetID, method, args } = extractMessage(vatDeliverObject);
       log.push(['deliver', facetID, method, args]);
     }
@@ -752,6 +787,9 @@ test('promise resolveToData', async t => {
   function setupA(s) {
     syscallA = s;
     function dispatch(vatDeliverObject) {
+      if (vatDeliverObject[0] === 'startVat') {
+        return; // skip startVat
+      }
       log.push(vatDeliverObject);
     }
     return dispatch;
@@ -806,6 +844,7 @@ test('promise resolveToData', async t => {
   await kernel.step();
   // Deliver the notify
   await kernel.step();
+
   // the kernelPromiseID gets mapped back to the vat PromiseID
   t.deepEqual(log.shift(), [
     'notify',
@@ -824,6 +863,9 @@ test('promise resolveToPresence', async t => {
   function setupA(s) {
     syscallA = s;
     function dispatch(vatDeliverObject) {
+      if (vatDeliverObject[0] === 'startVat') {
+        return; // skip startVat
+      }
       log.push(vatDeliverObject);
     }
     return dispatch;
@@ -904,6 +946,9 @@ test('promise reject', async t => {
   function setupA(s) {
     syscallA = s;
     function dispatch(vatDeliverObject) {
+      if (vatDeliverObject[0] === 'startVat') {
+        return; // skip startVat
+      }
       log.push(vatDeliverObject);
     }
     return dispatch;
@@ -975,6 +1020,9 @@ test('transcript', async t => {
 
   function setup(syscall, _state) {
     function dispatch(vatDeliverObject) {
+      if (vatDeliverObject[0] === 'startVat') {
+        return; // skip startVat
+      }
       const { facetID, args } = extractMessage(vatDeliverObject);
       if (facetID === aliceForAlice) {
         syscall.send(args.slots[1], 'foo', capdata('fooarg'), 'p+5');
@@ -1000,8 +1048,9 @@ test('transcript', async t => {
   // the transcript records vat-specific import/export slots
 
   const tr = kernel.dump().vatTables[0].state.transcript;
-  t.is(tr.length, 1);
-  t.deepEqual(tr[0], {
+  t.is(tr.length, 2);
+  t.deepEqual(tr[0], tsv[0]);
+  t.deepEqual(tr[1], {
     d: [
       'message',
       aliceForAlice,
@@ -1043,6 +1092,9 @@ test('non-pipelined promise queueing', async t => {
 
   function setupB(_s) {
     function dispatch(vatDeliverObject) {
+      if (vatDeliverObject[0] === 'startVat') {
+        return; // skip startVat
+      }
       const { facetID, method, args, result } =
         extractMessage(vatDeliverObject);
       log.push([facetID, method, args, result]);
@@ -1167,6 +1219,9 @@ test('pipelined promise queueing', async t => {
 
   function setupB(_s) {
     function dispatch(vatDeliverObject) {
+      if (vatDeliverObject[0] === 'startVat') {
+        return; // skip startVat
+      }
       const { facetID, method, args, result } =
         extractMessage(vatDeliverObject);
       log.push([facetID, method, args, result]);
@@ -1281,6 +1336,9 @@ async function reapTest(t, freq) {
   const log = [];
   function setup() {
     function dispatch(vatDeliverObject) {
+      if (vatDeliverObject[0] === 'startVat') {
+        return; // skip startVat
+      }
       log.push(vatDeliverObject);
     }
     return dispatch;

--- a/packages/SwingSet/test/test-liveslots.js
+++ b/packages/SwingSet/test/test-liveslots.js
@@ -947,7 +947,6 @@ test('dropImports', async t => {
     syscall,
     'vatA',
     {},
-    {},
     undefined,
     false,
     false,
@@ -1087,7 +1086,6 @@ test('buildVatNamespace not called until after startVat', async t => {
   const ls = makeLiveSlots(
     syscall,
     'vatA',
-    {},
     {},
     undefined,
     false,

--- a/packages/SwingSet/test/util.js
+++ b/packages/SwingSet/test/util.js
@@ -69,6 +69,8 @@ export function buildDispatch(onDispatchCallback = undefined) {
       if (onDispatchCallback) {
         onDispatchCallback(d);
       }
+    } else if (type === 'startVat') {
+      // ignore
     } else {
       throw Error(`unknown vatDeliverObject type ${type}`);
     }


### PR DESCRIPTION
fix(swingset): deliver vatParameters in startVat()

Previously, `vatParameters` arrived at a vat worker in the `setBundle`
message to the supervisor (the same one that provided the vat's source
bundle). This changes the code to deliver them inside the
`dispatch.startVat()` invocation instead.

Liveslots-based vats see no change: both cases hand vatParameters in via the
`buildRootObject()` call. `setup()`-based vats must change: the `setup()`
call no longer contains a `vatParameters` argument, and vatParameters are
available temporally later than before.

As a result, the comms vat must wait for `startVat()` to learn its two
configuration settings: `identifierBase` and `sendExplicitSeqNums`. Comms now
uses both to initialize its state DB, and reads `sendExplicitSeqNums` from
the DB for each `transit()` call.

This paves the way for `vatParameters` to contain slots, not just inert data.
The VatTranslator that converts `startVat` KernelDeliveryObjects into
VatDeliveryObjects does not yet perform slot translation, nor does liveslots
treat `vatParameters` as capdata, but they are now in the right place to
perform those tasks.

refs #4381
closes #4766
