### PR TITLE
Restival vault improvements

### DIFF
--- a/packages/run-protocol/src/collect.js
+++ b/packages/run-protocol/src/collect.js
@@ -7,8 +7,10 @@ export const mapValues = (obj, f) =>
   harden(fromEntries(entries(obj).map(([p, v]) => [p, f(v)])));
 
 /** @type { <X, Y>(xs: X[], ys: Y[]) => [X, Y][]} */
-export const zip = (xs, ys) => harden(xs.map((x, i) => [x, ys[i]]));
+export const zip = (xs, ys) => harden(xs.map((x, i) => [x, ys[+i]]));
 
 /** @type { <V>(obj: Record<string, ERef<V>>) => Promise<Record<string, V>> } */
-export const allValues = async obj =>
-  harden(fromEntries(zip(keys(obj), await Promise.all(values(obj)))));
+export const allValues = async obj => {
+  const resolved = await Promise.all(values(obj));
+  return harden(fromEntries(zip(keys(obj), resolved)));
+};

--- a/packages/run-protocol/src/econ-behaviors.js
+++ b/packages/run-protocol/src/econ-behaviors.js
@@ -143,7 +143,7 @@ export const setupAmm = async ({
 
   if (!ammPublicFacet) {
     // ISSUE: what is this test for?!
-    throw new Error(`ammPublicFacet broken  ${ammPublicFacet}`);
+    throw Error(`ammPublicFacet broken  ${ammPublicFacet}`);
   }
 
   ammInstanceProducer.resolve(instance);

--- a/packages/run-protocol/src/econ-behaviors.js
+++ b/packages/run-protocol/src/econ-behaviors.js
@@ -20,6 +20,7 @@ import { PROTOCOL_FEE_KEY, POOL_FEE_KEY } from './vpool-xyk-amm/params.js';
 
 import * as Collect from './collect.js';
 
+const { details: X } = assert;
 const { entries } = Object;
 
 const SECONDS_PER_HOUR = 60n * 60n;
@@ -141,10 +142,8 @@ export const setupAmm = async ({
   ammGovernorCreatorFacet.resolve(g.creatorFacet);
   ammCreatorFacet.resolve(creatorFacet);
 
-  if (!ammPublicFacet) {
-    // ISSUE: what is this test for?!
-    throw Error(`ammPublicFacet broken  ${ammPublicFacet}`);
-  }
+  // Confirm that the amm was indeed setup
+  assert(ammPublicFacet, X`ammPublicFacet broken  ${ammPublicFacet}`);
 
   ammInstanceProducer.resolve(instance);
   ammGovernor.resolve(g.instance);

--- a/packages/run-protocol/src/interest.js
+++ b/packages/run-protocol/src/interest.js
@@ -7,7 +7,6 @@ import {
   multiplyRatios,
   quantize,
 } from '@agoric/zoe/src/contractSupport/ratio.js';
-import { E } from '@endo/far';
 import { assert, details as X } from '@agoric/assert';
 
 export const SECONDS_PER_YEAR = 60n * 60n * 24n * 365n;

--- a/packages/run-protocol/src/interest.js
+++ b/packages/run-protocol/src/interest.js
@@ -118,9 +118,9 @@ export const calculateCompoundedInterest = (
  * @param {ZCFMint} mint
  * @param {Amount} debt
  */
-const validatedBrand = async (mint, debt) => {
+const validatedBrand = (mint, debt) => {
   const { brand: debtBrand } = debt;
-  const { brand: issuerBrand } = await E(mint).getIssuerRecord();
+  const { brand: issuerBrand } = mint.getIssuerRecord();
   assert(
     debtBrand === issuerBrand,
     X`Debt and issuer brands differ: ${debtBrand} != ${issuerBrand}`,
@@ -145,10 +145,10 @@ const validatedBrand = async (mint, debt) => {
  *  compoundedInterest: Ratio,
  *  totalDebt: Amount<'nat'>}} prior
  * @param {bigint} accruedUntil
- * @returns {Promise<{compoundedInterest: Ratio, latestInterestUpdate: bigint, totalDebt: Amount<'nat'> }>}
+ * @returns {{compoundedInterest: Ratio, latestInterestUpdate: bigint, totalDebt: Amount<'nat'> }}
  */
-export const chargeInterest = async (powers, params, prior, accruedUntil) => {
-  const brand = await validatedBrand(powers.mint, prior.totalDebt);
+export const chargeInterest = (powers, params, prior, accruedUntil) => {
+  const brand = validatedBrand(powers.mint, prior.totalDebt);
 
   const interestCalculator = makeInterestCalculator(
     params.interestRate,

--- a/packages/run-protocol/src/vaultFactory/liquidation.js
+++ b/packages/run-protocol/src/vaultFactory/liquidation.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { E } from '@agoric/eventual-send';
 import { AmountMath } from '@agoric/ertp';
@@ -57,9 +58,9 @@ const liquidate = async (
   // We can use this because only liquidation adds RUN to the vaultSeat.
   const proceeds = vaultZcfSeat.getAmountAllocated('RUN', runBrand);
 
-  const isUnderwater = !AmountMath.isGTE(proceeds, debt);
-  const runToBurn = isUnderwater ? proceeds : debt;
-  trace({ debt, isUnderwater, runToBurn });
+  const isShortfall = !AmountMath.isGTE(proceeds, debt);
+  const runToBurn = isShortfall ? proceeds : debt;
+  trace({ debt, isShortfall, runToBurn });
   burnLosses(harden({ RUN: runToBurn }), vaultZcfSeat);
   innerVault.liquidated(AmountMath.subtract(debt, runToBurn));
 

--- a/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
+++ b/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
@@ -1,4 +1,5 @@
 // @ts-check
+// @jessie-check
 
 import { makeRatioFromAmounts } from '@agoric/zoe/src/contractSupport/index.js';
 import { AmountMath } from '@agoric/ertp';
@@ -80,7 +81,7 @@ export const makePrioritizedVaults = reschedulePriceCheck => {
     if (vaults.getSize() === 0) {
       return undefined;
     }
-
+    // Get the first vault.
     const [vault] = vaults.values();
     const collateralAmount = vault.getCollateralAmount();
     if (AmountMath.isEmpty(collateralAmount)) {
@@ -144,7 +145,9 @@ export const makePrioritizedVaults = reschedulePriceCheck => {
    * @yields {[string, InnerVault]>}
    * @returns {IterableIterator<[string, InnerVault]>}
    */
+  // Allow generator function
   // eslint-disable-next-line func-names
+  // eslint-disable-next-line no-restricted-syntax
   function* entriesPrioritizedGTE(ratio) {
     // TODO use a Pattern to limit the query https://github.com/Agoric/agoric-sdk/issues/4550
     for (const [key, vault] of vaults.entries()) {
@@ -168,6 +171,7 @@ export const makePrioritizedVaults = reschedulePriceCheck => {
     addVault(vaultId, vault);
   };
 
+  // TODO make Far
   return harden({
     addVault,
     entries: vaults.entries,

--- a/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
+++ b/packages/run-protocol/src/vaultFactory/prioritizedVaults.js
@@ -4,6 +4,7 @@
 import { makeRatioFromAmounts } from '@agoric/zoe/src/contractSupport/index.js';
 import { AmountMath } from '@agoric/ertp';
 import { ratioGTE } from '@agoric/zoe/src/contractSupport/ratio.js';
+import { Far } from '@endo/marshal';
 import { makeOrderedVaultStore } from './orderedVaultStore.js';
 import { toVaultKey } from './storeUtils.js';
 
@@ -171,8 +172,7 @@ export const makePrioritizedVaults = reschedulePriceCheck => {
     addVault(vaultId, vault);
   };
 
-  // TODO make Far
-  return harden({
+  return Far('PrioritizedVaults', {
     addVault,
     entries: vaults.entries,
     entriesPrioritizedGTE,

--- a/packages/run-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/run-protocol/src/vaultFactory/vaultFactory.js
@@ -146,27 +146,28 @@ export const start = async (zcf, privateArgs) => {
     return vm;
   };
 
+  const makeLoanHook = async seat => {
+    assertProposalShape(seat, {
+      give: { Collateral: null },
+      want: { RUN: null },
+    });
+    const {
+      give: { Collateral: collateralAmount },
+    } = seat.getProposal();
+    const { brand: brandIn } = collateralAmount;
+    assert(
+      collateralTypes.has(brandIn),
+      X`Not a supported collateral type ${brandIn}`,
+    );
+    /** @type {VaultManager} */
+    const mgr = collateralTypes.get(brandIn);
+    return mgr.makeVaultKit(seat);
+  };
+
+  // TODO add a `collateralBrand` argument to makeVaultInvitation`
   /** Make a loan in the vaultManager based on the collateral type. */
   const makeVaultInvitation = () => {
     /** @param {ZCFSeat} seat */
-    const makeLoanHook = async seat => {
-      assertProposalShape(seat, {
-        give: { Collateral: null },
-        want: { RUN: null },
-      });
-      const {
-        give: { Collateral: collateralAmount },
-      } = seat.getProposal();
-      const { brand: brandIn } = collateralAmount;
-      assert(
-        collateralTypes.has(brandIn),
-        X`Not a supported collateral type ${brandIn}`,
-      );
-      /** @type {VaultManager} */
-      const mgr = collateralTypes.get(brandIn);
-      return mgr.makeVaultKit(seat);
-    };
-
     return zcf.makeInvitation(makeLoanHook, 'MakeLoan');
   };
 

--- a/packages/run-protocol/src/vaultFactory/vaultFactory.js
+++ b/packages/run-protocol/src/vaultFactory/vaultFactory.js
@@ -146,7 +146,8 @@ export const start = async (zcf, privateArgs) => {
     return vm;
   };
 
-  const makeLoanHook = async seat => {
+  /** @param {ZCFSeat} seat */
+  const makeVaultHook = async seat => {
     assertProposalShape(seat, {
       give: { Collateral: null },
       want: { RUN: null },
@@ -167,8 +168,7 @@ export const start = async (zcf, privateArgs) => {
   // TODO add a `collateralBrand` argument to makeVaultInvitation`
   /** Make a loan in the vaultManager based on the collateral type. */
   const makeVaultInvitation = () => {
-    /** @param {ZCFSeat} seat */
-    return zcf.makeInvitation(makeLoanHook, 'MakeLoan');
+    return zcf.makeInvitation(makeVaultHook, 'MakeVault');
   };
 
   const getCollaterals = async () => {

--- a/packages/run-protocol/test/test-interest.js
+++ b/packages/run-protocol/test/test-interest.js
@@ -509,7 +509,7 @@ test('chargeInterest when no time elapsed', async t => {
     /** @type {Amount<'nat'>} */
     totalDebt: AmountMath.make(brand, 10_000n),
   };
-  const results = await chargeInterest(powers, params, prior, now);
+  const results = chargeInterest(powers, params, prior, now);
   t.deepEqual(results.compoundedInterest, prior.compoundedInterest);
   t.is(results.latestInterestUpdate, now);
   t.deepEqual(results.totalDebt, prior.totalDebt);


### PR DESCRIPTION
closes: #XXXX
refs: #XXXX

## Description

* make vault interest computation non async
* fix misplaced `await` usages
* fix `jessie` errors (e.g., delete `new` from Errors)
* minor naming improvements

### Security Considerations

Interleavings were possible with async interest computation. No exploit determined but eliminated the vulnerability and removed the complexity.

### Documentation Considerations

N/A

### Testing Considerations

Doc or pure refactor, so covered by existing tests.