### PR TITLE
Implement durable kind API

### DIFF
--- a/packages/ERTP/globals.d.ts
+++ b/packages/ERTP/globals.d.ts
@@ -1,6 +1,7 @@
 interface VatData {
   defineKind: function;
   defineDurableKind: function;
+  makeKindHandle: function;
   makeScalarBigMapStore: function;
   makeScalarBigWeakMapStore: function;
   makeScalarBigSetStore: function;

--- a/packages/SwingSet/docs/virtual-objects.md
+++ b/packages/SwingSet/docs/virtual-objects.md
@@ -1,39 +1,49 @@
-# TODO (update to include new stores and durable objects stuff)
+# TODO (update to include new stores stuff)
 
 # Vat Secondary Storage
 
 The kernel currently provides two secondary storage mechanisms for the use of (application) code running in a vat:
 
-- Virtual objects
+- Virtual and durable objects
 - Persistent stores
 
-Each of these is accessed via a global made available to vat code.
+These are accessed via properties of the `VatData` global made available to vat code, or more stylishly by importing from `@agoric/swingset-vat/src/storeModule.js` (that's a working placeholder module which we will be replacing it with a more ergonomic package name once we figure out what that should be).
 
-## Virtual Objects
+The APIs described here all have to do with storing data on disk.  However, you should understand an important distinction made in these APIs between the labels "virtual" and "durable".  In our usage here, things that are "virtual" will automatically swap their state to disk storage and thus don't eat up RAM space in the running vat process even if they grow large in number.  In contrast, things that are "durable" are not only stored on disk but survive the lifetime of the vat process holding them and may be retrieved later in a future version of the vat.
 
-A virtual object is an object with a durable identity whose state is automatically and transparently backed up in secondary storage.  This means that when a given virtual object is not in active use, it need not occupy any memory within the executing vat.  Thus a vat can manage an arbitrarily large number of such objects without concern about running out of memory.
+## Virtual and Durable Objects
 
-A virtual object has a "kind", which defines what sort of behavior and state it will possess.  A kind is not exactly a data type, since it comes with a concrete implementation, but it indicates a family of objects that share a set of common behaviors and a common state template.
+A virtual or durable object (which we'll abbreviate VDO to save breath) is an object whose state is automatically and transparently backed up in secondary storage.  This means that when a given VDO is not in active use, it need not occupy any memory within the executing vat.  Thus a vat can manage an arbitrarily large number of such objects without concern about running out of memory.
 
-A vat can define new kinds of virtual object by calling the `defineKind` function provided as a vat global:
+A VDO has a "kind", which defines what sort of behavior and state it will possess.  A kind is not exactly a data type, since it comes with a concrete implementation, but it indicates a family of objects that share a set of common behaviors and a common state template.
 
-  `defineKind(descriptionTag, init, actualize, finish)`
+A vat can define new kinds of VDOs by calling the `defineKind` or `defineDurableKind` functions:
 
-The return value from `defineKind` is a maker function which the vat can use to create instances of the newly defined object kind.
+  `maker = defineKind(descriptionTag, init, actualize, finish)`
+or
+  `maker = defineDurableKind(kindHandle, init, actual, finish)`
 
-The `descriptionTag` parameter is a short description string for the kind.  This is the same kind of tag string you would use in a call to `Far`.  It will appear on `.toString()` representations of corresponding `Presence` objects that are exported to remote vats.
+The return value from `defineKind` or `defineDurableKind` is a maker function which the vat can use to create instances of the newly defined VDO kind.
 
-The `init` parameter is a function that will be called when new instances are first created. It is expected to return a simple JavaScript object that represents the initialized state for the new virtual object instance.  Any parameters passed to the maker function returned by `defineKind` are passed directly to the `init` function.
+The `descriptionTag` parameter is a short description string for the kind.  This is the same kind of tag string you would use in a call to `Far`.  It will appear on `.toString()` representations of corresponding `Presence` objects that are exported to remote vats.  Note that this string should only be used for diagnostics and debugging, as it is not safe from substitution by adversarial intermediaries.
 
-The `actualize` parameter is a function that binds an in-memory instance (the "Representative") of the virtual object with the virtual object's state, associating such instances with the virtual object's behavior.  It is passed the virtual object's state as a parameter and is expected to return either:
+A `kindHandle` is a type of durable object that can be used to identify the kind in a later incarnation of the vat.  The usage of a kind handle rather than a simple tag string is the main thing that distinguished the two kind definition functions.  You obtain a kind handle for use in `defineDurableKind` by calling
+
+  `kindHandle = makeKindHandle(descriptionTag)`
+
+where `descriptionTag` is exactly the same as the same named parameter of `defineKind`.  The difference is that a kind handle is itself that a durable object that may be stored for later retrieval, and used in a future call to `defineDurableKind` to associate new behavior with the kind in question.
+
+The `init` parameter is a function that will be called when new instances are first created. It is expected to return a simple JavaScript object that represents the initialized state for the new VDO instance.  Any parameters passed to the maker function returned by `defineKind`/`defineDurableKind` are passed directly to the `init` function.
+
+The `actualize` parameter is a function that binds an in-memory instance (the "Representative") of the VDO with the VDO's state, associating such instances with the VDO's behavior.  It is passed the VDO's state as a parameter and is expected to return either:
 
 1. A new JavaScript object with methods that close over the given state.  This returned object will become the body of the new instance.  This object can be empty; in such a case it can serve as a powerless but unforgeable "marker" handle.
 
 2. A new JavaScript object populated with objects as described in (1).  These will become facets of the new instance.  The returned object will be an object mapping to the facets by name.
 
-The `actualize` function is called whenever a new virtual object instance is created, whenever such an instance is swapped in from secondary storage, and whenever a reference to a virtual object is received as a parameter of a message and deserialized.  The `actualize` function for a given VDO kind must always return the same shape of result: if it returns a single instance body, it must always return a single instance body; if it returns a object full of facets, it must always return an object with the exact same facet names.
+The `actualize` function is called whenever a new VDO instance is created, whenever such an instance is swapped in from secondary storage, and whenever a reference to a VDO is received as a parameter of a message and deserialized.  Note that for any given VDO kind, the shape of the value returned by the `actualize` function may not vary over successive calls.  That is, if it's a single facet, it must always be a single facet, and if it's multiple facets it must always be the same set of multiple facets.
 
-The `finish` parameter will, if present (it is optional), be called exactly once as part of instance initialization.  It will be invoked immediately after the `actualize` function is called for the first time.  In other words, it will be called after the instance per se exists but before that instance is returned from the maker function and thus becomes available to whoever requested its creation.  `finish` is passed two parameters: the virtual object's state (exactly as passed to the `actualize` function) and the virtual object itself. The `finish` function can modify the object's state in the context of knowing the object's identity, and thus can be used in cases where a validly initialized instance requires it to participate in some kind of cyclical object graph with other virtual objects.  It can also be used, for example, to register the object with outside tracking data structures, or do whatever other post-creation setup is needed for the object to do its job.  In particular, if one or more of the object's methods need to refer to the object itself (for example, so it can pass itself to other objects), the `finish` function provides a way to capture that identity as part of the object's state.
+The `finish` parameter is optional. It is a function that, if present, will be called exactly once as part of instance initialization.  It will be invoked _immediately_ after the `actualize` function for that instance is called for the very first time.  In other words, it will be called after the instance per se exists but before that instance is returned from the maker function to whoever requested its creation.  `finish` is passed two parameters: the VDO's state (exactly as passed to the `actualize` function) and the VDO itself. The `finish` function can modify the object's state in the context of knowing the object's identity, and thus can be used in cases where a validly initialized instance requires it to participate in some kind of cyclical object graph with other VDOs.  It can also be used, for example, to register the object with outside tracking data structures, or do whatever other post-creation setup is needed for the object to do its job.  In particular, if one or more of the object's methods need to refer to the object itself (for example, so it can pass itself to other objects), the `finish` function provides a way to capture that identity as part of the object's state.
 
 For example:
 
@@ -64,7 +74,7 @@ For example:
   const makeCounter = defineKind('counter', initCounter, actualizeCounter, finishCounter);
 ```
 
-This defines a simple counter object with two properties in its state, a count and a name.  You'd use it like this:
+This defines a simple virtual counter object with two properties in its state, a count and a name.  You'd use it like this:
 
 ```javascript
   const fooCounter = makeCounter('foo');
@@ -78,7 +88,7 @@ This defines a simple counter object with two properties in its state, a count a
   console.log(`${barCounter.getName()} count is ${barCounter.getCount()`); // "new bar count is 1"
 ```
 
-Suppose you instead wanted to provide the the increment and decrement capabilities as independent facets.  A simplified version of the above (without the name property, counter registry, and `reset` method) might look like:
+Suppose you instead wanted to provide a version with the increment and decrement capabilities made available as independent facets.  A simplified version of the above (without the name property, counter registry, and `reset` method) might look like:
 
 ```javascript
   const initFacetedCounter = () => ({ counter: 0 });
@@ -104,7 +114,15 @@ Suppose you instead wanted to provide the the increment and decrement capabiliti
   const makeFacetedCounter = defineKind('counter', initCounter, actualizeCounter);
 ```
 
-Which you'd use like:
+If you wanted to also make this durable, instead of the last line you'd generate
+the kind with something more like:
+
+```javascript
+  const facetedCounterKind = makeKindHandle('durable counter');
+  const makeFacetedCounter = defineDurableKind(facetedCounterKind, initCounter, actualizeCounter);
+```
+
+In either case you'd use it like:
 
 ```javascript
   const { incr, decr } = makeFacetedCounter('foo');
@@ -154,6 +172,6 @@ Additional important details:
 
   `state.zot.push(4);`
 
-- A virtual object can be passed as a parameter in messages to other vats.  It will be passed by presence, just like any other non-data object you might send in a message parameter.
+- A VDO can be passed as a parameter in messages to other vats.  It will be passed by presence, just like any other non-data object you might send in a message parameter.
 
-- A virtual object's state may include references to other virtual objects. The latter objects will be persisted separately and only deserialized as needed, so "swapping in" a virtual object that references other virtual objects does not entail swapping in the entire associated object graph.
+- A VDO's state may include references to other VDOs. The latter objects will be persisted separately and only deserialized as needed, so "swapping in" a VDO that references other VDOs does not entail swapping in the entire associated object graph.

--- a/packages/SwingSet/src/liveslots/liveslots.js
+++ b/packages/SwingSet/src/liveslots/liveslots.js
@@ -1073,6 +1073,7 @@ function build(
     VatData: {
       defineKind: vom.defineKind,
       defineDurableKind: vom.defineDurableKind,
+      makeKindHandle: vom.makeKindHandle,
       makeScalarBigMapStore: collectionManager.makeScalarBigMapStore,
       makeScalarBigWeakMapStore: collectionManager.makeScalarBigWeakMapStore,
       makeScalarBigSetStore: collectionManager.makeScalarBigSetStore,

--- a/packages/SwingSet/src/storeModule.js
+++ b/packages/SwingSet/src/storeModule.js
@@ -3,6 +3,7 @@
 export const {
   defineKind,
   defineDurableKind,
+  makeKindHandle,
   makeScalarBigMapStore,
   makeScalarBigWeakMapStore,
   makeScalarBigSetStore,

--- a/packages/SwingSet/test/stores/test-durabilityChecks.js
+++ b/packages/SwingSet/test/stores/test-durabilityChecks.js
@@ -8,7 +8,9 @@ const { vom, cm } = makeFakeVirtualStuff({ cacheSize: 3 });
 
 const { makeScalarBigMapStore, makeScalarBigSetStore } = cm;
 
-const { defineKind, defineDurableKind } = vom;
+const { defineKind, defineDurableKind, makeKindHandle } = vom;
+
+const durableHolderKind = makeKindHandle('holder');
 
 const initHolder = (held = null) => ({ held });
 const actualizeHolder = state => ({
@@ -19,7 +21,7 @@ const actualizeHolder = state => ({
 
 const makeVirtualHolder = defineKind('holder', initHolder, actualizeHolder);
 const makeDurableHolder = defineDurableKind(
-  'holder',
+  durableHolderKind,
   initHolder,
   actualizeHolder,
 );
@@ -42,11 +44,13 @@ const anObjectFullOfVirtualStuff = harden({
   aRemotableObject,
   aVirtualStore,
   aDurableStore,
+  durableHolderKind,
 });
 const anObjectFullOfDurableStuff = harden({
   aString,
   aDurableObject,
   aDurableStore,
+  durableHolderKind,
 });
 const anArrayFullOfVirtualStuff = harden([
   aString,
@@ -55,11 +59,13 @@ const anArrayFullOfVirtualStuff = harden([
   aRemotableObject,
   aVirtualStore,
   aDurableStore,
+  durableHolderKind,
 ]);
 const anArrayFullOfDurableStuff = harden([
   aString,
   aDurableObject,
   aDurableStore,
+  durableHolderKind,
 ]);
 
 function m(s) {
@@ -90,6 +96,8 @@ test('durability checks', t => {
   passKey(() => virtualMap.set(aVirtualStore, 'revise virtual store key'));
   passKey(() => virtualMap.init(aDurableStore, 'durable store as key'));
   passKey(() => virtualMap.set(aDurableStore, 'revise durable store key'));
+  passKey(() => virtualMap.init(durableHolderKind, 'durable kind as key'));
+  passKey(() => virtualMap.set(durableHolderKind, 'revise durable kind key'));
 
   passKey(() => virtualMap.init('simple string value', aString));
   passKey(() => virtualMap.init('virtual object value', aVirtualObject));
@@ -101,6 +109,7 @@ test('durability checks', t => {
   passKey(() => virtualMap.init('array full of virtual stuff', anArrayFullOfVirtualStuff));
   passKey(() => virtualMap.init('object full of durable stuff', anObjectFullOfDurableStuff));
   passKey(() => virtualMap.init('array full of durable stuff', anArrayFullOfDurableStuff));
+  passKey(() => virtualMap.init('durable kind', durableHolderKind));
 
   passKey(() => virtualMap.init('changeme', 47));
   passKey(() => virtualMap.set('changeme', aString));
@@ -113,6 +122,7 @@ test('durability checks', t => {
   passKey(() => virtualMap.set('changeme', anArrayFullOfVirtualStuff));
   passKey(() => virtualMap.set('changeme', anObjectFullOfDurableStuff));
   passKey(() => virtualMap.set('changeme', anArrayFullOfDurableStuff));
+  passKey(() => virtualMap.set('changeme', durableHolderKind));
 
   passKey(() => durableMap.init(aString, 'simple string key'));
   passKey(() => durableMap.set(aString, 'revise string key'));
@@ -123,6 +133,8 @@ test('durability checks', t => {
   failKey(() => durableMap.init(aVirtualStore, 'virtual store as key'));
   passKey(() => durableMap.init(aDurableStore, 'durable store as key'));
   passKey(() => durableMap.set(aDurableStore, 'revise durable store key'));
+  passKey(() => durableMap.init(durableHolderKind, 'durable kind as key'));
+  passKey(() => durableMap.set(durableHolderKind, 'revise durable kind key'));
 
   passVal(() => durableMap.init('simple string value', aString));
   failVal(() => durableMap.init('virtual object value', aVirtualObject));
@@ -134,6 +146,7 @@ test('durability checks', t => {
   failVal(() => durableMap.init('array full of virtual stuff', anArrayFullOfVirtualStuff));
   passVal(() => durableMap.init('object full of durable stuff', anObjectFullOfDurableStuff));
   passVal(() => durableMap.init('array full of durable stuff', anArrayFullOfDurableStuff));
+  passVal(() => durableMap.init('durable kind', durableHolderKind));
 
   passVal(() => durableMap.init('changeme', 47));
   passVal(() => durableMap.set('changeme', aString));
@@ -146,6 +159,7 @@ test('durability checks', t => {
   failVal(() => durableMap.set('changeme', anArrayFullOfVirtualStuff));
   passVal(() => durableMap.set('changeme', anObjectFullOfDurableStuff));
   passVal(() => durableMap.set('changeme', anArrayFullOfDurableStuff));
+  passVal(() => durableMap.set('changeme', durableHolderKind));
 
   const virtualSet = makeScalarBigSetStore('vset');
   const durableSet = makeScalarBigSetStore('dset', { durable: true });
@@ -156,6 +170,7 @@ test('durability checks', t => {
   passKey(() => virtualSet.add(aRemotableObject));
   passKey(() => virtualSet.add(aVirtualStore));
   passKey(() => virtualSet.add(aDurableStore));
+  passKey(() => virtualSet.add(durableHolderKind));
 
   passKey(() => durableSet.add(aString));
   failKey(() => durableSet.add(aVirtualObject));
@@ -163,6 +178,7 @@ test('durability checks', t => {
   failKey(() => durableSet.add(aRemotableObject));
   failKey(() => durableSet.add(aVirtualStore));
   passKey(() => durableSet.add(aDurableStore));
+  passKey(() => durableSet.add(durableHolderKind));
 
   const virtualHolder = makeVirtualHolder();
 
@@ -176,6 +192,7 @@ test('durability checks', t => {
   passHold(() => makeVirtualHolder(anArrayFullOfVirtualStuff));
   passHold(() => makeVirtualHolder(anObjectFullOfDurableStuff));
   passHold(() => makeVirtualHolder(anArrayFullOfDurableStuff));
+  passHold(() => makeVirtualHolder(durableHolderKind));
 
   passHold(() => virtualHolder.hold(aString));
   passHold(() => virtualHolder.hold(aVirtualObject));
@@ -187,6 +204,7 @@ test('durability checks', t => {
   passHold(() => virtualHolder.hold(anArrayFullOfVirtualStuff));
   passHold(() => virtualHolder.hold(anObjectFullOfDurableStuff));
   passHold(() => virtualHolder.hold(anArrayFullOfDurableStuff));
+  passHold(() => virtualHolder.hold(durableHolderKind));
 
   const durableHolder = makeDurableHolder();
 
@@ -200,6 +218,7 @@ test('durability checks', t => {
   failHold(() => makeDurableHolder(anArrayFullOfVirtualStuff));
   passHold(() => makeDurableHolder(anObjectFullOfDurableStuff));
   passHold(() => makeDurableHolder(anArrayFullOfDurableStuff));
+  passHold(() => makeDurableHolder(durableHolderKind));
 
   passHold(() => durableHolder.hold(aString));
   failHold(() => durableHolder.hold(aVirtualObject));
@@ -211,4 +230,5 @@ test('durability checks', t => {
   failHold(() => durableHolder.hold(anArrayFullOfVirtualStuff));
   passHold(() => durableHolder.hold(anObjectFullOfDurableStuff));
   passHold(() => durableHolder.hold(anArrayFullOfDurableStuff));
+  passHold(() => durableHolder.hold(durableHolderKind));
 });

--- a/packages/SwingSet/test/test-vat-env.js
+++ b/packages/SwingSet/test/test-vat-env.js
@@ -14,19 +14,17 @@ const actualizeThing = _state => ({
 });
 
 test('kind makers are in the test environment', t => {
-  // eslint-disable-next-line no-undef
   const makeVThing = VatData.defineKind('thing', null, actualizeThing);
   const vthing = makeVThing('vthing');
   t.is(vthing.ping(), 4);
 
-  const makeDThing = VatData.defineDurableKind('thing', null, actualizeThing);
+  const kind = VatData.makeKindHandle('thing');
+  const makeDThing = VatData.defineDurableKind(kind, null, actualizeThing);
   const dthing = makeDThing('dthing');
   t.is(dthing.ping(), 4);
 });
 
 test('store makers are in the test environment', t => {
-  // TODO: configure eslint to know that VatData is a global
-  // eslint-disable-next-line no-undef
   const o = harden({ size: 10, color: 'blue' });
 
   const m = VatData.makeScalarBigMapStore();
@@ -67,6 +65,7 @@ async function testForExpectedGlobals(t, workerType) {
     'VatData: object',
     'VatData.defineKind: function',
     'VatData.defineDurableKind: function',
+    'VatData.makeKindHandle: function',
     'VatData.makeScalarBigMapStore: function',
     'VatData.makeScalarBigWeakMapStore: function',
     'VatData.makeScalarBigSetStore: function',

--- a/packages/SwingSet/tools/fakeVirtualObjectManager.js
+++ b/packages/SwingSet/tools/fakeVirtualObjectManager.js
@@ -17,6 +17,7 @@ export function makeFakeVirtualObjectManager(vrm, fakeStuff, options = {}) {
   const {
     defineKind,
     defineDurableKind,
+    makeKindHandle,
     VirtualObjectAwareWeakMap,
     VirtualObjectAwareWeakSet,
     flushCache,
@@ -34,6 +35,7 @@ export function makeFakeVirtualObjectManager(vrm, fakeStuff, options = {}) {
   const normalVOM = {
     defineKind,
     defineDurableKind,
+    makeKindHandle,
     VirtualObjectAwareWeakMap,
     VirtualObjectAwareWeakSet,
   };

--- a/packages/SwingSet/tools/prepare-test-env.js
+++ b/packages/SwingSet/tools/prepare-test-env.js
@@ -13,7 +13,7 @@ import { makeFakeVirtualStuff } from './fakeVirtualSupport.js';
 
 const { vom, cm } = makeFakeVirtualStuff({ cacheSize: 3 });
 
-const { defineKind, defineDurableKind } = vom;
+const { defineKind, defineDurableKind, makeKindHandle } = vom;
 
 const {
   makeScalarBigMapStore,
@@ -25,6 +25,7 @@ const {
 const VatData = harden({
   defineKind,
   defineDurableKind,
+  makeKindHandle,
   makeScalarBigMapStore,
   makeScalarBigWeakMapStore,
   makeScalarBigSetStore,

--- a/packages/deploy-script-support/globals.d.ts
+++ b/packages/deploy-script-support/globals.d.ts
@@ -1,6 +1,7 @@
 interface VatData {
   defineKind: function;
   defineDurableKind: function;
+  makeKindHandle: function;
   makeScalarBigMapStore: function;
   makeScalarBigWeakMapStore: function;
   makeScalarBigSetStore: function;

--- a/packages/pegasus/globals.d.ts
+++ b/packages/pegasus/globals.d.ts
@@ -1,6 +1,7 @@
 interface VatData {
   defineKind: function;
   defineDurableKind: function;
+  makeKindHandle: function;
   makeScalarBigMapStore: function;
   makeScalarBigWeakMapStore: function;
   makeScalarBigSetStore: function;

--- a/packages/run-protocol/globals.d.ts
+++ b/packages/run-protocol/globals.d.ts
@@ -1,6 +1,7 @@
 interface VatData {
   defineKind: function;
   defineDurableKind: function;
+  makeKindHandle: function;
   makeScalarBigMapStore: function;
   makeScalarBigWeakMapStore: function;
   makeScalarBigSetStore: function;

--- a/packages/vats/globals.d.ts
+++ b/packages/vats/globals.d.ts
@@ -1,6 +1,7 @@
 interface VatData {
   defineKind: function;
   defineDurableKind: function;
+  makeKindHandle: function;
   makeScalarBigMapStore: function;
   makeScalarBigWeakMapStore: function;
   makeScalarBigSetStore: function;

--- a/packages/xsnap/src/globals.d.ts
+++ b/packages/xsnap/src/globals.d.ts
@@ -7,6 +7,7 @@ namespace global {
 interface VatData {
   defineKind: function;
   defineDurableKind: function;
+  makeKindHandle: function;
   makeScalarBigMapStore: function;
   makeScalarBigWeakMapStore: function;
   makeScalarBigSetStore: function;

--- a/packages/zoe/test/minimalMakeKindContract.js
+++ b/packages/zoe/test/minimalMakeKindContract.js
@@ -2,7 +2,8 @@
 
 const start = _zcf => {
   VatData.defineKind();
-  VatData.defineDurableKind();
+  const kh = VatData.makeKindHandle();
+  VatData.defineDurableKind(kh);
   VatData.makeScalarBigMapStore();
   VatData.makeScalarBigWeakMapStore();
   VatData.makeScalarBigSetStore();

--- a/packages/zoe/test/unitTests/test-makeKind.js
+++ b/packages/zoe/test/unitTests/test-makeKind.js
@@ -23,7 +23,9 @@ test('defineKind non-swingset', async t => {
   vatAdminState.installBundle('b1-minimal', bundle);
   const installation = await E(zoe).installBundleID('b1-minimal');
   t.notThrows(() => VatData.defineKind());
-  t.notThrows(() => VatData.defineDurableKind());
+  t.notThrows(() => VatData.makeKindHandle());
+  const kh = VatData.makeKindHandle();
+  t.notThrows(() => VatData.defineDurableKind(kh));
   t.notThrows(() => VatData.makeScalarBigMapStore());
   t.notThrows(() => VatData.makeScalarBigWeakMapStore());
   t.notThrows(() => VatData.makeScalarBigSetStore());

--- a/packages/zoe/test/unitTests/test-zoe-env.js
+++ b/packages/zoe/test/unitTests/test-zoe-env.js
@@ -12,7 +12,8 @@ test('harden from SES is in the zoe contract environment', t => {
 test('(mock) kind makers from SwingSet are in the zoe contract environment', t => {
   // @ts-ignore testing existence of function only
   VatData.defineKind();
-  VatData.defineDurableKind();
+  const kh = VatData.makeKindHandle();
+  VatData.defineDurableKind(kh);
   t.pass();
 });
 


### PR DESCRIPTION
This implements the durable kind API (though not the rest of the baggage machinery) per #4495 

In particular, we provide the new `VatData` function `makeKindHandle` to produce durable (and storable) handles that may be used to associate durable kinds with their implementations.  At least, that is what it is called until we change the name again.

Closes #4495 
