### PR TITLE
chore: configure VSCode to autofix eslint

### DIFF
--- a/scripts/configure-vscode.sh
+++ b/scripts/configure-vscode.sh
@@ -92,7 +92,7 @@ for file in .vscode/launch.json .vscode/settings.json; do
 		else
 			printf "The file %s.new has these changes:\n\n" $file
 			git --no-pager diff --no-index $file $file.new
-			printf "\n\nTo overwrite yours:\n\n  mv %s.new %s\n\n" $file
+			printf "\n\nTo overwrite yours:\n\n  mv %s.new %s\n\n" $file $file
 		fi
 	else
 		mv $file.new $file

--- a/scripts/configure-vscode.sh
+++ b/scripts/configure-vscode.sh
@@ -18,9 +18,27 @@ mkdir -p .vscode ||
 
 cat >.vscode/settings.json.new <<\EOF ||
 {
+  // Automatically format with Prettier on save
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "typescript.preferences.importModuleSpecifierEnding": "js"
+
+  "typescript.preferences.importModuleSpecifierEnding": "js",
+
+  // ESLint config
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  "eslint.rules.customizations": [
+    // Leave this to Prettier itself
+    { "rule": "prettier/*", "severity": "off" },
+    // Error in CI but a common state while coding in IDE
+    { "rule": "no-unused-vars", "severity": "warn" },
+    // Imports are auto-fixed on save
+    { "rule": "import/newline-after-import", "severity": "off" },
+    { "rule": "import/order", "severity": "off" },
+  ],
+  "eslint.useESLintClass": true,
+  "eslint.packageManager": "yarn"
 }
 EOF
 	die "Could not write settings.json"
@@ -48,7 +66,7 @@ cat > .vscode/launch.json.new <<\EOF ||
         {
             "type": "pwa-node",
             "request": "launch",
-            "name": "Debug AVA match",
+            "name": "Debug AVA matches",
             "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/ava",
             "runtimeArgs": [
               "${file}",
@@ -60,22 +78,21 @@ cat > .vscode/launch.json.new <<\EOF ||
                 "<node_internals>/**"
             ],
         }
-
     ]
 }
 EOF
 	die "Could not write launch.json"
 
 for file in .vscode/launch.json .vscode/settings.json; do
-	echo "\nComparing $file"
+	printf "\nComparing %s\n" $file
 	if test -f $file; then
 		if git diff --no-index --quiet --exit-code $file $file.new; then
 			echo "Your existing configuration matches the recommendations."
 			rm $file.new
 		else
-			printf "The file $file.new has these changes:\n\n"
+			printf "The file %s.new has these changes:\n\n" $file
 			git --no-pager diff --no-index $file $file.new
-			printf "\n\nTo overwrite yours:\n\n  mv $file.new $file\n\n"
+			printf "\n\nTo overwrite yours:\n\n  mv %s.new %s\n\n" $file
 		fi
 	else
 		mv $file.new $file


### PR DESCRIPTION
no ticket, came up in chat

## Description

With lint-while-type enabled (the default) there are lots of _problems_ displayed that aren't important to the developer because they can be automatically fixed by the tooling. This configures VSCode to automatically fix such problems on save and to downgrade their severity while coding. It also downgrades "no-unused-vars" because, while it can't be fixed automatically, it's a common interim state while typing and doesn't need attention.

This uses the new script from https://github.com/Agoric/agoric-sdk/pull/4418/ to make adopting these settings a pull operation and developers can see what would be changed. 

The ESLint configuration settings are described in https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint

### Security Considerations

--
### Documentation Considerations

--

### Testing Considerations

--
