### PR TITLE
chore: Document configure-vscode.sh and update it to run from anywhere

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for getting involved!
 
 ## Platforms, Dev Tools and Testing
 
-We support MacOS, linux, and Windows Subsystem for Linux (wsl).
+We support MacOS, Linux, and Windows Subsystem for Linux (WSL).
 
 For many of the packages here, JavaScript development tools suffice:
 
@@ -29,6 +29,9 @@ yarn build
 yarn test
 yarn lint
 ```
+
+A standard Visual Studio Code configuration can be initialized or updated by
+running [`scripts/configure-vscode.sh`](scripts/configure-vscode.sh).
 
 See also notes on [Coding
 style](https://github.com/Agoric/agoric-sdk/wiki/Coding-Style),

--- a/scripts/configure-vscode.sh
+++ b/scripts/configure-vscode.sh
@@ -7,8 +7,8 @@ die() {
 	exit 1
 }
 
-# NB: script assumes it runs one level below repo root
-cd "$(dirname "$0")"/.. ||
+# Run at the top level of the repository
+cd "$(git rev-parse --show-toplevel)" ||
 	die "Could not cd to top-level directory"
 
 mkdir -p .vscode ||


### PR DESCRIPTION
## Description

I didn't know about `configure-vscode.sh` until seeing it updated by #4825. This adds a mention from CONTRIBUTING.md, and also improves it to run from anywhere in the repository rather than assuming its containing directory.

### Security Considerations

n/a

### Documentation Considerations

I'm open to ideas about what else should be mentioned in CONTRIBUTING.md

### Testing Considerations

n/a