### PR TITLE
fix(swingset): startVat(vatParameters) are now capdata

### DIFF
--- a/packages/SwingSet/src/controller/initializeKernel.js
+++ b/packages/SwingSet/src/controller/initializeKernel.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-use-before-define */
 
-import { makeMarshal, Far } from '@endo/marshal';
+import { makeMarshal, Far, stringify } from '@endo/marshal';
 import { assert, details as X } from '@agoric/assert';
 import { createSHA256 } from '../lib-nodejs/hasher.js';
 import { assertKnownOptions } from '../lib/assertOptions.js';
@@ -87,8 +87,9 @@ export function initializeKernel(config, hostStorage, verbose = false) {
       const vatKeeper = kernelKeeper.provideVatKeeper(vatID);
       vatKeeper.setSourceAndOptions({ bundleID }, creationOptions);
       vatKeeper.initializeReapCountdown(creationOptions.reapInterval);
+      const vpCapData = { body: stringify(harden(vatParameters)), slots: [] };
       kernelKeeper.addToAcceptanceQueue(
-        harden({ type: 'startVat', vatID, vatParameters }),
+        harden({ type: 'startVat', vatID, vatParameters: vpCapData }),
       );
       if (name === 'vatAdmin') {
         // Create a kref for the vatAdmin root, so the kernel can tell it

--- a/packages/SwingSet/src/kernel/vatTranslator.js
+++ b/packages/SwingSet/src/kernel/vatTranslator.js
@@ -150,7 +150,7 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
 
   /**
    *
-   * @param {unknown} kernelVP
+   * @param {SwingSetCapData} kernelVP
    * @returns { VatDeliveryStartVat }
    */
   function translateStartVat(kernelVP) {

--- a/packages/SwingSet/src/lib/message.js
+++ b/packages/SwingSet/src/lib/message.js
@@ -66,8 +66,9 @@ export function insistVatDeliveryObject(vdo) {
       break;
     }
     case 'startVat': {
-      const [_vatParameters] = rest;
-      // TODO: insistCapData(vatParameters);
+      assert(rest.length === 1);
+      const [vatParameters] = rest;
+      insistCapData(vatParameters);
       break;
     }
     case 'bringOutYourDead': {

--- a/packages/SwingSet/src/liveslots/liveslots.js
+++ b/packages/SwingSet/src/liveslots/liveslots.js
@@ -1097,7 +1097,8 @@ function build(
     assert(key.match(/^[-\w.+/]+$/), X`invalid vatstore key`);
   }
 
-  async function startVat(vatParameters) {
+  async function startVat(vatParametersCapData) {
+    insistCapData(vatParametersCapData);
     assert(!didStartVat);
     didStartVat = true;
 
@@ -1162,7 +1163,7 @@ function build(
       });
     }
 
-    // TODO: unserialize(vatParameters)
+    const vatParameters = m.unserialize(vatParametersCapData);
 
     // Below this point, user-provided code might crash or overrun a meter, so
     // any prior-to-user-code setup that can be done without reference to the
@@ -1235,8 +1236,8 @@ function build(
         break;
       }
       case 'startVat': {
-        const [vatParameters] = args;
-        result = startVat(vatParameters);
+        const [vpCapData] = args;
+        result = startVat(vpCapData);
         break;
       }
       default:

--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -96,7 +96,7 @@ export {};
  * @typedef { [tag: 'dropExports', vrefs: string[] ]} VatDeliveryDropExports
  * @typedef { [tag: 'retireExports', vrefs: string[] ]} VatDeliveryRetireExports
  * @typedef { [tag: 'retireImports', vrefs: string[] ]} VatDeliveryRetireImports
- * @typedef { [tag: 'startVat', vatParameters: unknown ]} VatDeliveryStartVat
+ * @typedef { [tag: 'startVat', vatParameters: SwingSetCapData ]} VatDeliveryStartVat
  * @typedef { [tag: 'bringOutYourDead' ]} VatDeliveryBringOutYourDead
  * @typedef { VatDeliveryMessage | VatDeliveryNotify | VatDeliveryDropExports
  *            | VatDeliveryRetireExports | VatDeliveryRetireImports
@@ -135,7 +135,7 @@ export {};
  * @typedef { [tag: 'dropExports', krefs: string[] ]} KernelDeliveryDropExports
  * @typedef { [tag: 'retireExports', krefs: string[] ]} KernelDeliveryRetireExports
  * @typedef { [tag: 'retireImports', krefs: string[] ]} KernelDeliveryRetireImports
- * @typedef { [tag: 'startVat', vatParameters: unknown ]} KernelDeliveryStartVat
+ * @typedef { [tag: 'startVat', vatParameters: SwingSetCapData ]} KernelDeliveryStartVat
  * @typedef { [tag: 'bringOutYourDead']} KernelDeliveryBringOutYourDead
  * @typedef { KernelDeliveryMessage | KernelDeliveryNotify | KernelDeliveryDropExports
  *            | KernelDeliveryRetireExports | KernelDeliveryRetireImports

--- a/packages/SwingSet/src/vats/comms/dispatch.js
+++ b/packages/SwingSet/src/vats/comms/dispatch.js
@@ -1,4 +1,5 @@
 import { assert, details as X } from '@agoric/assert';
+import { parse } from '@endo/marshal';
 import { makeVatSlot } from '../../lib/parseVatSlots.js';
 import { insistMessage } from '../../lib/message.js';
 import { makeState } from './state.js';
@@ -45,7 +46,10 @@ export function buildCommsDispatch(syscall, _state, _helpers, _vatPowers) {
   // our root object (o+0) is the Comms Controller
   const controller = makeVatSlot('object', true, 0);
 
-  function doStartVat(vatParameters = {}) {
+  function doStartVat(vatParametersCapData) {
+    insistCapData(vatParametersCapData);
+    assert(vatParametersCapData.slots.length === 0, 'comms got slots');
+    const vatParameters = parse(vatParametersCapData.body) || {};
     const { identifierBase = 0, sendExplicitSeqNums } = vatParameters;
     state.initialize(controller, identifierBase);
     if (sendExplicitSeqNums !== undefined) {

--- a/packages/SwingSet/test/commsVatDriver.js
+++ b/packages/SwingSet/test/commsVatDriver.js
@@ -2,7 +2,7 @@ import { assert, details as X } from '@agoric/assert';
 import buildCommsDispatch from '../src/vats/comms/index.js';
 import { debugState } from '../src/vats/comms/dispatch.js';
 import { flipRemoteSlot } from '../src/vats/comms/parseRemoteSlot.js';
-import { makeMessage, makeResolutions } from './util.js';
+import { capargs, makeMessage, makeResolutions } from './util.js';
 
 // This module provides a power tool for testing the comms vat implementation.
 // It provides support for injecting events into the comms vat and observing
@@ -350,7 +350,7 @@ export function commsVatDriver(t, verbose = false) {
   const log = [];
   const syscall = loggingSyscall(log);
   const dispatch = buildCommsDispatch(syscall, 'fakestate', 'fakehelpers');
-  dispatch(['startVat']);
+  dispatch(['startVat', capargs()]);
   const { state } = debugState.get(dispatch);
 
   const remotes = new Map();

--- a/packages/SwingSet/test/liveslots-helpers.js
+++ b/packages/SwingSet/test/liveslots-helpers.js
@@ -5,6 +5,7 @@ import { waitUntilQuiescent } from '../src/lib-nodejs/waitUntilQuiescent.js';
 import { makeGcAndFinalize } from '../src/lib-nodejs/gc-and-finalize.js';
 import { makeDummyMeterControl } from '../src/kernel/dummyMeterControl.js';
 import { makeLiveSlots } from '../src/liveslots/liveslots.js';
+import { capargs } from './vat-util.js';
 
 export function buildSyscall() {
   const log = [];
@@ -131,7 +132,7 @@ export async function makeDispatch(
       return { buildRootObject: build };
     },
   );
-  await startVat();
+  await startVat(capargs());
   if (returnTestHooks) {
     returnTestHooks[0] = testHooks;
   }

--- a/packages/SwingSet/test/test-comms.js
+++ b/packages/SwingSet/test/test-comms.js
@@ -7,6 +7,7 @@ import { makeState } from '../src/vats/comms/state.js';
 import { makeCListKit } from '../src/vats/comms/clist.js';
 import { debugState } from '../src/vats/comms/dispatch.js';
 import {
+  capargs,
   makeMessage,
   makeDropExports,
   makeRetireExports,
@@ -127,7 +128,7 @@ test('transmit', t => {
   // remote 'bob' on machine B
   const { syscall, sends } = mockSyscall();
   const dispatch = buildCommsDispatch(syscall, 'fakestate', 'fakehelpers');
-  dispatch(['startVat']);
+  dispatch(['startVat', capargs()]);
   const { state, clistKit } = debugState.get(dispatch);
   const {
     provideKernelForLocal,
@@ -202,7 +203,7 @@ test('receive', t => {
   // vat's object 'bob'
   const { syscall, sends, gcs } = mockSyscall();
   const dispatch = buildCommsDispatch(syscall, 'fakestate', 'fakehelpers');
-  dispatch(['startVat']);
+  dispatch(['startVat', capargs()]);
   const { state, clistKit } = debugState.get(dispatch);
   const {
     provideLocalForKernel,
@@ -348,7 +349,7 @@ test('receive', t => {
 test('addEgress', t => {
   const { syscall } = mockSyscall();
   const dispatch = buildCommsDispatch(syscall, 'fakestate', 'fakehelpers');
-  dispatch(['startVat']);
+  dispatch(['startVat', capargs()]);
   const { state, clistKit } = debugState.get(dispatch);
   const { getLocalForKernel, getRemoteForLocal } = clistKit;
   const transmitterID = 'o-1';
@@ -381,7 +382,7 @@ test('addEgress', t => {
 test('addIngress', t => {
   const { syscall, resolves } = mockSyscall();
   const dispatch = buildCommsDispatch(syscall, 'fakestate', 'fakehelpers');
-  dispatch(['startVat']);
+  dispatch(['startVat', capargs()]);
   const { state, clistKit } = debugState.get(dispatch);
   const { getLocalForKernel, getRemoteForLocal } = clistKit;
   const transmitterID = 'o-1';
@@ -415,7 +416,7 @@ test('comms gc', t => {
   // about various objects that are dropped and retired
   const { syscall, sends, gcs } = mockSyscall();
   const dispatch = buildCommsDispatch(syscall, 'fakestate', 'fakehelpers');
-  dispatch(['startVat']);
+  dispatch(['startVat', capargs()]);
   const { state, clistKit: ck } = debugState.get(dispatch);
   const transmitterID = 'o-1'; // vat-tp target for B
   const { remoteID, receiverID } = state.addRemote('B', transmitterID);

--- a/packages/SwingSet/test/test-controller.js
+++ b/packages/SwingSet/test/test-controller.js
@@ -10,11 +10,9 @@ import {
   initializeSwingset,
   makeSwingsetController,
 } from '../src/index.js';
-import { checkKT } from './util.js';
+import { checkKT, capdata, capargs } from './util.js';
 
-function capdata(body, slots = []) {
-  return harden({ body, slots });
-}
+const emptyVP = capargs({});
 
 function removeTriple(arr, a, b, c) {
   for (let i = 0; i < arr.length; i += 1) {
@@ -69,11 +67,11 @@ async function simpleCall(t) {
   controller.queueToVatRoot('vat1', 'foo', capdata('args'));
   t.deepEqual(controller.dump().runQueue, []);
   t.deepEqual(controller.dump().acceptanceQueue, [
-    { type: 'startVat', vatID: 'v1', vatParameters: {} },
-    { type: 'startVat', vatID: 'v2', vatParameters: {} },
-    { type: 'startVat', vatID: 'v3', vatParameters: {} },
-    { type: 'startVat', vatID: 'v4', vatParameters: {} },
-    { type: 'startVat', vatID: 'v5', vatParameters: {} },
+    { type: 'startVat', vatID: 'v1', vatParameters: emptyVP },
+    { type: 'startVat', vatID: 'v2', vatParameters: emptyVP },
+    { type: 'startVat', vatID: 'v3', vatParameters: emptyVP },
+    { type: 'startVat', vatID: 'v4', vatParameters: emptyVP },
+    { type: 'startVat', vatID: 'v5', vatParameters: emptyVP },
     {
       msg: {
         method: 'foo',
@@ -222,13 +220,13 @@ test.serial('bootstrap export', async t => {
 
   t.deepEqual(c.dump().runQueue, []);
   t.deepEqual(c.dump().acceptanceQueue, [
-    { type: 'startVat', vatID: 'v1', vatParameters: {} },
-    { type: 'startVat', vatID: 'v2', vatParameters: {} },
-    { type: 'startVat', vatID: 'v3', vatParameters: { argv: [] } },
-    { type: 'startVat', vatID: 'v4', vatParameters: {} },
-    { type: 'startVat', vatID: 'v5', vatParameters: {} },
-    { type: 'startVat', vatID: 'v6', vatParameters: {} },
-    { type: 'startVat', vatID: 'v7', vatParameters: {} },
+    { type: 'startVat', vatID: 'v1', vatParameters: emptyVP },
+    { type: 'startVat', vatID: 'v2', vatParameters: emptyVP },
+    { type: 'startVat', vatID: 'v3', vatParameters: capargs({ argv: [] }) },
+    { type: 'startVat', vatID: 'v4', vatParameters: emptyVP },
+    { type: 'startVat', vatID: 'v5', vatParameters: emptyVP },
+    { type: 'startVat', vatID: 'v6', vatParameters: emptyVP },
+    { type: 'startVat', vatID: 'v7', vatParameters: emptyVP },
     {
       msg: {
         result: 'kp40',

--- a/packages/SwingSet/test/test-kernel.js
+++ b/packages/SwingSet/test/test-kernel.js
@@ -17,6 +17,7 @@ function capargs(args, slots = []) {
 }
 
 const slot0arg = { '@qclass': 'slot', index: 0 };
+const emptyVP = capargs({});
 
 function oneResolution(promiseID, rejected, data) {
   return [[promiseID, rejected, data]];
@@ -47,7 +48,7 @@ function makeKernel() {
   return buildKernel(endowments, {}, {});
 }
 
-const tsv = [{ d: ['startVat', {}], syscalls: [] }];
+const tsv = [{ d: ['startVat', emptyVP], syscalls: [] }];
 
 test('build kernel', async t => {
   const kernel = makeKernel();

--- a/packages/SwingSet/test/test-liveslots.js
+++ b/packages/SwingSet/test/test-liveslots.js
@@ -957,7 +957,7 @@ test('dropImports', async t => {
     },
   );
   const { dispatch, startVat, possiblyDeadSet } = ls;
-  await startVat();
+  await startVat(capargs());
   const allFRs = gcTools.getAllFRs();
   t.is(allFRs.length, 2);
   const FR = allFRs[0];
@@ -1095,7 +1095,7 @@ test('buildVatNamespace not called until after startVat', async t => {
     () => ({ buildRootObject }),
   );
   t.falsy(buildCalled);
-  await ls.startVat();
+  await ls.startVat(capargs());
   t.truthy(buildCalled);
 });
 

--- a/packages/SwingSet/test/test-xsnap-errors.js
+++ b/packages/SwingSet/test/test-xsnap-errors.js
@@ -66,7 +66,7 @@ test('child termination distinguished from meter exhaustion', async t => {
     schandler,
   );
 
-  await m.deliver(['startVat']);
+  await m.deliver(['startVat', capargs()]);
 
   const msg = { method: 'hang', args: capargs([]) };
   /** @type { VatDeliveryObject } */

--- a/packages/SwingSet/test/vat-util.js
+++ b/packages/SwingSet/test/vat-util.js
@@ -16,15 +16,18 @@ export function capdata(body, slots = []) {
   return harden({ body, slots });
 }
 
-function marshalBigIntReplacer(_, arg) {
+function replacer(_, arg) {
   if (typeof arg === 'bigint') {
     return { [QCLASS]: 'bigint', digits: String(arg) };
+  }
+  if (arg === undefined) {
+    return { [QCLASS]: 'undefined' };
   }
   return arg;
 }
 
 export function capargs(args, slots = []) {
-  return capdata(JSON.stringify(args, marshalBigIntReplacer), slots);
+  return capdata(JSON.stringify(args, replacer), slots);
 }
 
 export function ignore(p) {


### PR DESCRIPTION
The `startVat()` message accepts "vat parameters", but previously these were
arbitrary (inert) data. This changes the argument to contain capdata.
Liveslots will `unserialize` this data into the `vatParameters` argument
given to `buildRootObject()`.

The kernel was updated to populate this field with capdata in all pathways
that create create/start/upgrade-vat events. Parameters passed in through
config (which must be inert data) are serialized into capdata.

Parameters passed through `E(vatAdminService).createVat(bundle, {
vatParameters })` are also treated as inert data and serialized into capdata,
however when we move to "device hooks", this will change, and dynamic vat
creators will be able to pass object references in those parameters.

refs #4381
