### PR TITLE
fix(cosmosswingset): check negativity before castnig to uint

### DIFF
--- a/golang/cosmos/x/swingset/types/types.go
+++ b/golang/cosmos/x/swingset/types/types.go
@@ -34,14 +34,15 @@ func NewKeys() *Keys {
 
 // FIXME: Should have @agoric/nat
 func Nat(num float64) (uint64, error) {
+	if num < 0 {
+		return 0, errors.New("Not a natural")
+	}
+
 	nat := uint64(num)
 	if float64(nat) != num {
 		return 0, errors.New("Not a precise integer")
 	}
 
-	if nat < 0 {
-		return 0, errors.New("Not a natural")
-	}
 	return nat, nil
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #4792

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Moves the negativity check against the input float instead of the casted uint64, which can't be negative

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

This should fail quicker given a negative number, instead of coalescing it into a uint64

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
