### PR TITLE
fix(vault): make vault transfer invitation legible

### DIFF
--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -690,12 +690,28 @@ export const makeInnerVault = (
     makeAdjustBalancesInvitation,
     makeCloseInvitation,
     makeTransferInvitation: () => {
-      const { outerUpdater } = state;
+      // Bring the debt snapshot current for the final report before transfer
+      updateDebtSnapshot(getCurrentDebt());
+      const {
+        outerUpdater,
+        debtSnapshot: debt,
+        interestSnapshot: interest,
+        phase,
+      } = state;
       if (outerUpdater) {
         outerUpdater.finish(snapshotState(VaultPhase.TRANSFER));
         state.outerUpdater = null;
       }
-      return zcf.makeInvitation(makeTransferInvitationHook, 'TransferVault');
+      const transferState = {
+        debtSnapshot: { debt, interest },
+        locked: getCollateralAmount(),
+        vaultState: phase,
+      };
+      return zcf.makeInvitation(
+        makeTransferInvitationHook,
+        'TransferVault',
+        transferState,
+      );
     },
 
     // for status/debugging

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -1367,7 +1367,7 @@ test('transfer vault', async t => {
   ).getOfferResult();
   t.throwsAsync(() => E(aliceVault).getCurrentDebt());
   const debtAfter = await E(transferVault).getCurrentDebt();
-  t.deepEqual(debtAmount, debtAfter, 'vault lent 5000 RUN + fees');
+  t.deepEqual(debtAfter, debtAmount, 'vault lent 5000 RUN + fees');
   const collateralAfter = await E(transferVault).getCollateralAmount();
   t.deepEqual(collateralAmount, collateralAfter, 'vault has 1000n aEth');
 
@@ -1378,20 +1378,16 @@ test('transfer vault', async t => {
     'transfer closed old notifier',
   );
 
-  t.deepEqual(
-    {
-      // simplify test by including any properties not mentioned below
-      ...inviteProps,
-      debtSnapshot: {
-        debt: debtAmount,
-        interest: aliceFinish.value.debtSnapshot.interest,
-      },
-      description: 'TransferVault',
-      locked: collateralAmount,
-      vaultState: 'active',
+  t.like(inviteProps, {
+    // simplify test by including any properties not mentioned below
+    debtSnapshot: {
+      debt: debtAmount,
+      interest: aliceFinish.value.debtSnapshot.interest,
     },
-    inviteProps,
-  );
+    description: 'TransferVault',
+    locked: collateralAmount,
+    vaultState: 'active',
+  });
 
   const transferStatus = await E(transferNotifier).getUpdateSince();
   t.deepEqual(

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -1379,7 +1379,6 @@ test('transfer vault', async t => {
   );
 
   t.like(inviteProps, {
-    // simplify test by including any properties not mentioned below
     debtSnapshot: {
       debt: debtAmount,
       interest: aliceFinish.value.debtSnapshot.interest,


### PR DESCRIPTION
closes: #4820

## Description

make vault transfer invitation legible by adding custom properties to the requested invitation for the vault state at the time of the `makeTransferInvitation`

* add debt, interestSnapshot, collateral, and state to invitation custom properties
* add test to check for the custom properties
* bring the debt snapshot to current before transferring

### Security Considerations

Support the ability of a third party to automatically confirm that they received a transfer invitation for a vault in a specific state.

### Documentation Considerations

Properties should be described in `makeTransferInvitation` documentation.

### Testing Considerations

Added a test to verify the expected values.