### PR TITLE
ci: eslint warn import/no-default-export

### DIFF
--- a/packages/eslint-config/eslint-config.json
+++ b/packages/eslint-config/eslint-config.json
@@ -1,3 +1,4 @@
+// If you have questions about the settings of any rule, discussion may be found in the PR that made the change.
 {
   "extends": [
     "@endo",
@@ -12,6 +13,7 @@
     // "jsdoc/valid-types": 1,
     // "jsdoc/no-undefined-types": [1, {"definedTypes": ["never", "unknown"]}],
     "jsdoc/tag-lines": "off",
+    "import/no-default-export": "warn",
     "import/no-extraneous-dependencies": [
       "error",
       {

--- a/packages/wallet/ui/package.json
+++ b/packages/wallet/ui/package.json
@@ -78,6 +78,7 @@
     "rules": {
       "react/prop-types": "off",
       "react/react-in-jsx-scope": "off",
+      "import/no-default-export": "off",
       "import/no-extraneous-dependencies": "off",
       "react/display-name": "off"
     },


### PR DESCRIPTION
## Description

As yet undocumented coding style is to not use default exports. This documents it in the linter.

Not erroring yet because there are so many. Sample:
https://github.com/Agoric/agoric-sdk/blob/master/packages/deployment/src/main.js
https://github.com/Agoric/agoric-sdk/blob/master/packages/agoric-cli/src/start.js#L47
https://github.com/Agoric/agoric-sdk/blob/master/packages/cosmic-swingset/src/json-stable-stringify.js#L29
https://github.com/Agoric/agoric-sdk/blob/master/packages/solo/src/add-chain.js#L87
https://github.com/Agoric/agoric-sdk/blob/master/packages/SwingSet/src/kernel/deviceManager.js#L29

very common pattern in React components:
https://github.com/Agoric/agoric-sdk/blob/master/packages/wallet/ui/src/App.jsx#L62
(and 25 other components)

recommendation in our documentation:
https://github.com/Agoric/agoric-sdk/blob/f3744012338f7362516098d72bfb7191acb2f3a7/packages/SwingSet/docs/static-vats.md?plain=1#L50-L55


### Security Considerations

--

### Documentation Considerations

We could document this in the wiki, but it's better to have one source of truth. 

### Testing Considerations

--