### PR TITLE
Use possibly separate brands for oracle prices; convert units within the vault factory

### DIFF
--- a/packages/run-protocol/src/econ-behaviors.js
+++ b/packages/run-protocol/src/econ-behaviors.js
@@ -2,7 +2,10 @@
 
 import { E, Far } from '@endo/far';
 import { makeRatio } from '@agoric/zoe/src/contractSupport/index.js';
-import { CENTRAL_ISSUER_NAME } from '@agoric/vats/src/core/utils.js';
+import {
+  CENTRAL_ISSUER_NAME,
+  ORACLE_PRICE_BRAND_NAME,
+} from '@agoric/vats/src/core/utils.js';
 import '@agoric/governance/exported.js';
 import '@agoric/vats/exported.js';
 import '@agoric/vats/src/core/types.js';
@@ -236,6 +239,9 @@ export const startVaultFactory = async (
     produce, // {  vaultFactoryCreator }
     brand: {
       consume: { [CENTRAL_ISSUER_NAME]: centralBrandP },
+    },
+    oracleBrand: {
+      consume: { [ORACLE_PRICE_BRAND_NAME]: oraclePriceBrandP },
     },
     instance,
     installation,

--- a/packages/run-protocol/src/vaultFactory/params.js
+++ b/packages/run-protocol/src/vaultFactory/params.js
@@ -58,6 +58,7 @@ const makeElectorateParamManager = async (zoe, electorateInvitation) => {
 
 /**
  * @param {ERef<PriceAuthority>} priceAuthority
+ * @param {Ratio} debtToPrice
  * @param {LoanTiming} loanTiming
  * @param {Installation} liquidationInstall
  * @param {ERef<TimerService>} timerService
@@ -68,6 +69,7 @@ const makeElectorateParamManager = async (zoe, electorateInvitation) => {
  */
 const makeGovernedTerms = (
   priceAuthority,
+  debtToPrice,
   loanTiming,
   liquidationInstall,
   timerService,
@@ -86,6 +88,7 @@ const makeGovernedTerms = (
   return harden({
     ammPublicFacet,
     priceAuthority,
+    debtToPrice,
     loanParams: vmParamMgr.getParams(),
     loanTimingParams: timingParamMgr.getParams(),
     timerService,

--- a/packages/run-protocol/src/vaultFactory/types.js
+++ b/packages/run-protocol/src/vaultFactory/types.js
@@ -37,6 +37,7 @@
  * @param {Issuer} collateralIssuer
  * @param {Keyword} collateralKeyword
  * @param {VaultManagerParamValues} params
+ * @param {Brand} [collateralPriceBrand]
  * @returns {Promise<VaultManager>}
  */
 

--- a/packages/vats/src/core/basic-behaviors.js
+++ b/packages/vats/src/core/basic-behaviors.js
@@ -5,7 +5,7 @@ import { AssetKind, makeIssuerKit } from '@agoric/ertp';
 import { Nat } from '@agoric/nat';
 import { makeNameHubKit } from '../nameHub.js';
 
-import { feeIssuerConfig } from './utils.js';
+import { ORACLE_BRAND_PRICE_NAME, feeIssuerConfig } from './utils.js';
 
 // TODO/TECHDEBT: move to run-protocol?
 const Tokens = harden({
@@ -129,11 +129,11 @@ export const makeOracleBrands = async ({
   oracleBrand: { produce: oracleBrandProduce },
 }) => {
   const { brand } = makeIssuerKit(
-    'USD',
+    ORACLE_BRAND_PRICE_NAME,
     AssetKind.NAT,
     harden({ decimalPlaces: 6 }),
   );
-  oracleBrandProduce.USD.resolve(brand);
+  oracleBrandProduce[ORACLE_BRAND_PRICE_NAME].resolve(brand);
 };
 harden(makeOracleBrands);
 

--- a/packages/vats/src/core/manifest.js
+++ b/packages/vats/src/core/manifest.js
@@ -1,10 +1,11 @@
 // @ts-check
+import { ORACLE_BRAND_PRICE_NAME } from './utils.js';
 
 const SHARED_BOOTSTRAP_MANIFEST = harden({
   makeOracleBrands: {
     oracleBrand: {
       produce: {
-        USD: true,
+        [ORACLE_BRAND_PRICE_NAME]: true,
       },
     },
   },
@@ -317,7 +318,7 @@ const SHARED_POST_BOOT_MANIFEST = harden({
       vaultFactoryVoteCreator: 'VaultFactory',
     },
     brand: { consume: { RUN: 'zoe' } },
-    oracleBrand: { consume: { USD: true } },
+    oracleBrand: { consume: { [ORACLE_BRAND_PRICE_NAME]: true } },
     installation: {
       consume: { contractGovernor: 'zoe' },
       produce: { VaultFactory: 'zoe', liquidate: 'zoe' },

--- a/packages/vats/src/core/types.js
+++ b/packages/vats/src/core/types.js
@@ -141,8 +141,8 @@
  *     'amm' | 'ammGovernor' | 'VaultFactory' | 'VaultFactoryGovernor' | 'liquidate' |
  *     'runStake' | 'runStakeGovernor' |
  *     'Treasury' | 'reserve' | 'reserveGovernor' | 'Pegasus',
- *   oracleBrand:
- *     'USD',
+ *   oracleBrand: |
+ *     import('./utils').ORACLE_BRAND_PRICE_NAME,
  *   uiConfig: |
  *     'VaultFactory' |
  *     'Treasury' // compat.

--- a/packages/vats/src/core/utils.js
+++ b/packages/vats/src/core/utils.js
@@ -13,6 +13,7 @@ const mapEntries = (obj, f) =>
   fromEntries(entries(obj).map(([p, v]) => f(p, v)));
 
 export const CENTRAL_ISSUER_NAME = 'RUN';
+export const ORACLE_BRAND_PRICE_NAME = 'USD';
 
 /**
  * We reserve these keys in name hubs.

--- a/packages/zoe/tools/fakePriceAuthority.js
+++ b/packages/zoe/tools/fakePriceAuthority.js
@@ -14,12 +14,14 @@ import { natSafeMath } from '../src/contractSupport/index.js';
 import './types.js';
 import '../exported.js';
 
+/** @typedef {number | bigint} Numeric */
+
 /**
  * @typedef {Object} FakePriceAuthorityOptions
  * @property {Brand} actualBrandIn
  * @property {Brand} actualBrandOut
- * @property {Array<number>} [priceList]
- * @property {Array<[number, number]>} [tradeList]
+ * @property {Array<Numeric>} [priceList]
+ * @property {Array<[Numeric, Numeric]>} [tradeList]
  * @property {ERef<TimerService>} timer
  * @property {RelativeTime} [quoteInterval]
  * @property {ERef<Mint>} [quoteMint]


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #4714

## Description

As part of ongoing oracle work, this PR decouples the units quoted by the priceAuthority (USD) from the debt units (RUN).    It does the same for the priceAuthority asset vs. the vault collateral brand.

It also makes it possible to bootstrap the oracle network using price quotes in terms of `E(home.agoricNames).lookup('oracleBrand', 'USD')` even before RUN is enabled.  That well-known USD brand is inert; there is no corresponding mint or issuer.  Even if someday we were able to print money on chain, all we'd need to do is update the agoricNames entry.  @dckc can you please review the bootstrap stuff?

The main work to plumb this through the vaultFactory was to create `debtToPrice`, which is something like 1 RUN (debt) : 1 USD (price).  Each of the brands in this ratio has independent decimalPlaces, and the ratio is used to scale values when translating between the two brands.  I would argue that the ratio should not be configurable for the life of the vault factory.  I'll tag @turadg for review of the run-protocol stuff, and leave it up to you to involve other folks if you need.

Note that this also introduces `collateralToPrice` as an optional argument to `addVaultType`.  This is so that the `priceAuthority` could be initialised with a different brand for the asset, and the collateral amounts are scaled accordingly.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

The inertness of the new USD brand was done in order to avoid increasing the attack surface when just a brand with a few methods was needed.

Economic security, allowing drawing the lines between USD and RUN in a different, better, way.

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

The main observable change is that now, `getCollateralQuote` values will be in terms of USD.  This is a good thing, but may need UI work to put `$` on any displayed price quotes.  @samsiegart, can you confirm if this needs doing?

Another change (which is less observable) is that the vault's priceAuthorities need to quote in terms of USD.  This affects oracles, but not many other folk.

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->
