### PR TITLE
feat(swingset): add "device hooks"

### DIFF
--- a/packages/SwingSet/src/controller/controller.js
+++ b/packages/SwingSet/src/controller/controller.js
@@ -382,14 +382,19 @@ export async function makeSwingsetController(
       return kernel.getActivityhash();
     },
 
+    // everything beyond here is for tests, and everything should be migrated
+    // to be on this 'debug' object to make that clear
+
+    debug: {
+      addDeviceHook: kernel.addDeviceHook,
+    },
+
     pinVatRoot(vatName) {
       const vatID = kernel.vatNameToID(vatName);
       const kref = kernel.getRootObject(vatID);
       kernel.pinObject(kref);
       return kref;
     },
-
-    // these are for tests
 
     kpStatus(kpid) {
       return kernel.kpStatus(kpid);

--- a/packages/SwingSet/src/controller/initializeSwingset.js
+++ b/packages/SwingSet/src/controller/initializeSwingset.js
@@ -240,11 +240,17 @@ export function swingsetIsInitialized(hostStorage) {
   return !!hostStorage.kvStore.get('initialized');
 }
 
+/** @typedef {{ kernelBundles?: Record<string, string>, verbose?: boolean,
+ *              addVatAdmin?: boolean, addComms?: boolean, addVattp?: boolean,
+ *              addTimer?: boolean,
+ *            }} InitializationOptions
+ */
+
 /**
  * @param {SwingSetConfig} config
  * @param {string[]} argv
  * @param {HostStore} hostStorage
- * @param {{ kernelBundles?: Record<string, string>, verbose?: boolean }} initializationOptions
+ * @param {InitializationOptions} initializationOptions
  * @param {{ env?: Record<string, string | undefined > }} runtimeOptions
  */
 export async function initializeSwingset(
@@ -300,6 +306,10 @@ export async function initializeSwingset(
       bundleFormat: config.bundleFormat,
     }),
     verbose,
+    addVatAdmin = true,
+    addComms = true,
+    addVattp = true,
+    addTimer = true,
   } = initializationOptions;
 
   kvStore.set('kernelBundle', JSON.stringify(kernelBundles.kernel));
@@ -316,42 +326,50 @@ export async function initializeSwingset(
     }
   }
 
-  // vatAdmin and bundle devices are given endowments by the kernel itself
-  config.vats.vatAdmin = {
-    bundle: kernelBundles.adminVat,
-  };
-  config.devices.vatAdmin = {
-    bundle: kernelBundles.adminDevice,
-  };
+  if (addVatAdmin) {
+    // vatAdmin and bundle devices are given endowments by the kernel itself
+    config.vats.vatAdmin = {
+      bundle: kernelBundles.adminVat,
+    };
+    config.devices.vatAdmin = {
+      bundle: kernelBundles.adminDevice,
+    };
+  }
 
-  // comms vat is added automatically, but TODO: bootstraps must still
-  // connect it to vat-tp. TODO: test-message-patterns builds two comms and
-  // two vattps, must handle somehow.
-  config.vats.comms = {
-    bundle: kernelBundles.comms,
-    creationOptions: {
-      enablePipelining: true,
-      // The use of setup rather than buildRootObject requires
-      // a local worker. We have no plans to support setup on
-      // non-local workers any time soon.
-      enableSetup: true,
-      managerType: 'local',
-      useTranscript: false,
-      reapInterval: 'never',
-    },
-  };
+  if (addComms) {
+    // comms vat is added automatically, but TODO: bootstraps must still
+    // connect it to vat-tp. TODO: test-message-patterns builds two comms and
+    // two vattps, must handle somehow.
+    config.vats.comms = {
+      bundle: kernelBundles.comms,
+      creationOptions: {
+        enablePipelining: true,
+        // The use of setup rather than buildRootObject requires
+        // a local worker. We have no plans to support setup on
+        // non-local workers any time soon.
+        enableSetup: true,
+        managerType: 'local',
+        useTranscript: false,
+        reapInterval: 'never',
+      },
+    };
+  }
 
-  // vat-tp is added automatically, but TODO: bootstraps must still connect
-  // it to comms
-  config.vats.vattp = {
-    bundle: kernelBundles.vattp,
-  };
+  if (addVattp) {
+    // vat-tp is added automatically, but TODO: bootstraps must still connect
+    // it to comms
+    config.vats.vattp = {
+      bundle: kernelBundles.vattp,
+    };
+  }
 
-  // timer wrapper vat is added automatically, but TODO: bootstraps must
-  // still provide a timer device, and connect it to the wrapper vat
-  config.vats.timer = {
-    bundle: kernelBundles.timer,
-  };
+  if (addTimer) {
+    // timer wrapper vat is added automatically, but TODO: bootstraps must
+    // still provide a timer device, and connect it to the wrapper vat
+    config.vats.timer = {
+      bundle: kernelBundles.timer,
+    };
+  }
 
   // The host application gives us
   // config.[vats|devices].NAME.[bundle|bundleSpec|sourceSpec|bundleName] .

--- a/packages/SwingSet/src/kernel/deviceManager.js
+++ b/packages/SwingSet/src/kernel/deviceManager.js
@@ -52,6 +52,12 @@ export default function makeDeviceManager(
       const dso = harden(['vatstoreDelete', key]);
       deviceSyscallHandler(dso);
     },
+    callKernelHook: (name, args) => {
+      const dso = harden(['callKernelHook', name, args]);
+      const result = deviceSyscallHandler(dso);
+      insistCapData(result);
+      return result;
+    },
   });
 
   let dispatch;

--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -154,11 +154,12 @@ export {};
  * @typedef { [tag: 'dropImports', krefs: string[] ]} KernelSyscallDropImports
  * @typedef { [tag: 'retireImports', krefs: string[] ]} KernelSyscallRetireImports
  * @typedef { [tag: 'retireExports', krefs: string[] ]} KernelSyscallRetireExports
+ * @typedef { [tag: 'callKernelHook', hookName: string, args: SwingSetCapData]} KernelSyscallCallKernelHook
  *
  * @typedef { KernelSyscallSend | KernelSyscallInvoke | KernelSyscallSubscribe
  *    | KernelSyscallResolve | KernelSyscallExit | KernelSyscallVatstoreGet | KernelSyscallVatstoreGetAfter
  *    | KernelSyscallVatstoreSet | KernelSyscallVatstoreDelete | KernelSyscallDropImports
- *    | KernelSyscallRetireImports | KernelSyscallRetireExports
+ *    | KernelSyscallRetireImports | KernelSyscallRetireExports | KernelSyscallCallKernelHook
  * } KernelSyscallObject
  * @typedef { [tag: 'ok', data: SwingSetCapData | string | string[] | undefined[] | null ]} KernelSyscallResultOk
  * @typedef { [tag: 'error', err: string ] } KernelSyscallResultError

--- a/packages/SwingSet/test/device-hooks/bootstrap-device-hook.js
+++ b/packages/SwingSet/test/device-hooks/bootstrap-device-hook.js
@@ -1,0 +1,71 @@
+import { Far } from '@endo/marshal';
+
+export function buildRootObject(vatPowers) {
+  const { D } = vatPowers;
+  const o1 = Far('obj', {});
+  const o2 = Far('obj', {});
+  let hookdev;
+  let devnode;
+
+  const root = Far('root', {
+    async bootstrap(_vats, devices) {
+      hookdev = devices.hookdev;
+    },
+
+    async doCapdata(hookinput) {
+      return D(hookdev).returnCapdata(hookinput);
+    },
+    async doActual(hookinput) {
+      return D(hookdev).returnActual(hookinput);
+    },
+
+    async returnObjects() {
+      return [root, o1, o2];
+    },
+
+    async doObjects() {
+      return D(hookdev).returnCapdata(root, o1, o2);
+    },
+    async actualObjects() {
+      return D(hookdev).returnActual(root, o1, o2);
+    },
+    async checkObjects1(data) {
+      const rroot = D(hookdev).returnActual(data);
+      return { match: rroot === root, rroot };
+    },
+    async checkObjects2(data) {
+      const r2 = D(hookdev).returnActual(data);
+      return { match: r2 === o2, r2 };
+    },
+    async checkObjects3(data) {
+      const rextra2 = D(hookdev).returnActual(data);
+      return { rextra2 };
+    },
+    async checkDevNodeIn(data) {
+      devnode = D(hookdev).returnDevnode(data);
+      D(hookdev).returnActual(devnode);
+      return devnode;
+    },
+    async checkDevNodeOut(data) {
+      const d2 = D(hookdev).returnActual(data);
+      return { match: d2 === devnode, d2 };
+    },
+    async throwError(data) {
+      try {
+        const ret = D(hookdev).throwError(data); // will throw
+        return { worked: true, ret };
+      } catch (err) {
+        return { worked: false, err };
+      }
+    },
+    async missingHook(data) {
+      try {
+        const ret = D(hookdev).missingHook(data); // will throw
+        return { worked: true, ret };
+      } catch (err) {
+        return { worked: false, err };
+      }
+    },
+  });
+  return root;
+}

--- a/packages/SwingSet/test/device-hooks/device-use-hook.js
+++ b/packages/SwingSet/test/device-hooks/device-use-hook.js
@@ -1,0 +1,48 @@
+import { buildSerializationTools } from '../../src/devices/lib/deviceTools.js';
+
+export function buildDevice(tools, _endowments) {
+  const { syscall } = tools;
+  const dtools = buildSerializationTools(syscall, 'device-use-hook');
+  const { deviceNodeForSlot, returnFromInvoke } = dtools;
+
+  const ROOT = 'd+0';
+  const DEVNODE_DREF = 'd+1';
+  const devnode = deviceNodeForSlot(DEVNODE_DREF);
+
+  // invoke() should use unserialize() and returnFromInvoke
+  // throwing errors or returning undefined will crash the kernel
+
+  const dispatch = {
+    invoke: (dnid, method, argsCapdata) => {
+      if (dnid === ROOT) {
+        if (method === 'returnCapdata') {
+          // exercise basic invocation, args, return value
+          const hookResultCapdata = syscall.callKernelHook(
+            'hook1',
+            argsCapdata,
+          );
+          return returnFromInvoke({ hookResultCapdata });
+        }
+        if (method === 'returnActual') {
+          const hookResultCapdata = syscall.callKernelHook(
+            'hook1',
+            argsCapdata,
+          );
+          return harden(['ok', hookResultCapdata]);
+        }
+        if (method === 'returnDevnode') {
+          return returnFromInvoke(devnode);
+        }
+        if (method === 'throwError') {
+          syscall.callKernelHook('throwError', argsCapdata); // throws
+        }
+        if (method === 'missingHook') {
+          syscall.callKernelHook('missingHook', argsCapdata); // throws
+        }
+      }
+
+      throw TypeError(`target does not exist`);
+    },
+  };
+  return dispatch;
+}

--- a/packages/SwingSet/test/device-hooks/test-device-hooks.js
+++ b/packages/SwingSet/test/device-hooks/test-device-hooks.js
@@ -1,0 +1,289 @@
+/* eslint-disable no-lone-blocks */
+// eslint-disable-next-line import/order
+import { test } from '../../tools/prepare-test-env-ava.js';
+
+// eslint-disable-next-line import/order
+import bundleSource from '@endo/bundle-source';
+import { parse } from '@endo/marshal';
+import { provideHostStorage } from '../../src/controller/hostStorage.js';
+
+import {
+  initializeSwingset,
+  makeSwingsetController,
+  buildKernelBundles,
+} from '../../src/index.js';
+import { capargs, capSlot, capdataOneSlot } from '../util.js';
+
+function dfile(name) {
+  return new URL(`./${name}`, import.meta.url).pathname;
+}
+
+test.before(async t => {
+  const kernelBundles = await buildKernelBundles();
+  const bootstrapBundle = await bundleSource(dfile('bootstrap-device-hook.js'));
+  const deviceBundle = await bundleSource(dfile('device-use-hook.js'));
+  t.context.data = {
+    kernelBundles,
+    bootstrapBundle,
+    deviceBundle,
+  };
+});
+
+test('add hook', async t => {
+  const config = {
+    bootstrap: 'bootstrap',
+    defaultReapInterval: 'never',
+    vats: {
+      bootstrap: {
+        bundle: t.context.data.bootstrapBundle,
+      },
+      extra1: {
+        bundle: t.context.data.bootstrapBundle,
+      },
+      extra2: {
+        bundle: t.context.data.bootstrapBundle,
+      },
+    },
+    devices: {
+      hookdev: {
+        bundle: t.context.data.deviceBundle,
+        creationOptions: { unendowed: true },
+      },
+    },
+  };
+
+  const hostStorage = provideHostStorage();
+  const initOpts = {
+    ...t.context.data,
+    addComms: false,
+    addVattp: false,
+    addTimer: false,
+  };
+  await initializeSwingset(config, [], hostStorage, initOpts);
+  const c = await makeSwingsetController(hostStorage, {});
+
+  let hookreturn;
+  function setHookReturn(args, slots = []) {
+    hookreturn = capargs(args, slots);
+  }
+  const hooklog = [];
+
+  function hook1(args) {
+    hooklog.push(args);
+    return hookreturn; // must be capdata
+  }
+  c.debug.addDeviceHook('hookdev', 'hook1', hook1);
+  function throwError() {
+    throw Error('deliberate hook error');
+  }
+  c.debug.addDeviceHook('hookdev', 'throwError', throwError);
+
+  const bootkref = c.pinVatRoot('bootstrap');
+  const extra1kref = c.pinVatRoot('extra1');
+  const extra2kref = c.pinVatRoot('extra2');
+  await c.run();
+  t.deepEqual(hooklog, []);
+
+  // When we queueToVatRoot() to doCapdata(), the 'hookinput' we provide will
+  // appear as the first argument do doCapdata(), which passes it into
+  // D(hookdev).returnCapdata(hookinput). The raw device therefore receives a
+  // dispatch.invoke where `argsCapdata` is capdata([hookinput]) with drefs.
+  // It passes that to `syscall.callKernelHook`, which translate it, and our
+  // hook receives capdata([hookinput]) with krefs. We record this in hooklog
+  // for comparison.
+  //
+  // Our hook returns 'hookreturn' (capdata with krefs). The syscall
+  // translates it back and returns it to the raw device as
+  // `hookResultCapdata`. For doCapdata/returnCapdata, the device wraps this
+  // as `{ hookResultCapdata }` so we can see the details without the
+  // D(hookdev) modifying it further. The vat's doCapdata() call receives
+  // this wrapped data and uses it to resolve the result promise, so our
+  // `kpResolution` gets back `capdata({hookResultCapdata})`.
+
+  function expCD(hret) {
+    return capargs({ hookResultCapdata: capargs(hret) });
+  }
+
+  // Doing a queueToVatRoot() to doActual() does the same thing with
+  // 'hookinput', but does not wrap `hookResultCapdata'. Whatever
+  // kref-capdata we provide as 'hookreturn' is thus translated from kref to
+  // dref to vref to kref, and `kpResolution` gets back the translated form
+  // of `hookreturn`.
+
+  // basic test: callKernelHook() with static data, returns capdata(static)
+  {
+    setHookReturn({ y: 2 });
+    const kp = c.queueToVatRoot('bootstrap', 'doCapdata', capargs([{ x: 1 }]));
+    await c.run();
+    t.deepEqual(hooklog.shift(), capargs([{ x: 1 }]));
+    t.deepEqual(hooklog, []);
+    t.deepEqual(c.kpResolution(kp), expCD({ y: 2 }));
+  }
+
+  // same, but we ask the hook to return the actual capdata, not capdata
+  // which serializes the capdata
+  {
+    setHookReturn({ y: 4 });
+    const kp = c.queueToVatRoot('bootstrap', 'doActual', capargs([{ x: 3 }]));
+    await c.run();
+    t.deepEqual(hooklog.shift(), capargs([{ x: 3 }]));
+    t.deepEqual(hooklog, []);
+    t.deepEqual(c.kpResolution(kp), capargs({ y: 4 }));
+  }
+
+  // tell the vat to share several objects with us, so we can learn their krefs
+  let o1kref;
+  let o2kref;
+  {
+    const kp = c.queueToVatRoot('bootstrap', 'returnObjects', capargs([]));
+    await c.run();
+    const res3 = c.kpResolution(kp);
+    t.is(res3.slots.length, 3);
+    t.is(res3.slots[0], bootkref);
+    o1kref = res3.slots[1];
+    o2kref = res3.slots[2];
+    // these happen to be the current values
+    t.is(o1kref, 'ko24');
+    t.is(o2kref, 'ko25');
+  }
+
+  // now tell the vat to pass those objects to the hook, we should see their
+  // capdata emerge in the hooklog as krefs, not drefs
+  {
+    setHookReturn(0); // 'undefined' isn't handled by our lazy JSON marshaller
+    const kp = c.queueToVatRoot('bootstrap', 'doObjects', capargs([]));
+    await c.run();
+    const exp = [capSlot(0, 'root'), capSlot(1, 'obj'), capSlot(2, 'obj')];
+    t.deepEqual(hooklog.shift(), {
+      body: JSON.stringify(exp),
+      slots: [bootkref, o1kref, o2kref], // note: krefs
+    });
+    t.deepEqual(hooklog, []);
+    t.deepEqual(c.kpResolution(kp), expCD(0));
+  }
+
+  // do it again, to make sure they get serialized the same way twice
+  {
+    const kp = c.queueToVatRoot('bootstrap', 'doObjects', capargs([]));
+    await c.run();
+    const exp = [capSlot(0, 'root'), capSlot(1, 'obj'), capSlot(2, 'obj')];
+    t.deepEqual(hooklog.shift(), {
+      body: JSON.stringify(exp),
+      slots: [bootkref, o1kref, o2kref], // note: krefs
+    });
+    t.deepEqual(hooklog, []);
+    t.deepEqual(c.kpResolution(kp), expCD(0));
+  }
+
+  // now have the hook return some objects, and introduce a new one (the
+  // vat-extra1 root object) to test the kref->dref return pathway
+  {
+    // return [root, o1, extra1]
+    const cargs = [capSlot(0, 'root'), capSlot(1, 'obj'), capSlot(2, 'root')];
+    const kslots = [bootkref, o1kref, extra1kref];
+    setHookReturn(cargs, kslots);
+    const kp = c.queueToVatRoot('bootstrap', 'doCapdata', capargs([0]));
+    await c.run();
+    t.deepEqual(hooklog.shift(), capargs([0]));
+    t.deepEqual(hooklog, []);
+    // the device sees these drefs
+    const dslots = ['o-10', 'o-11', 'o-13'];
+    const exp = capargs({ hookResultCapdata: capargs(cargs, dslots) });
+    t.deepEqual(c.kpResolution(kp), exp);
+  }
+
+  // same, but ask the hook to return actual capdata, not wrapped. Our vat
+  // helper methods compares these objects against local copies to make sure
+  // they are unserialized by D() within the vat correctly. We make three
+  // separate calls to examine three separate objects, which makes matching
+  // against the serialized data easier (no concern about ordering of slots)
+
+  {
+    // return root
+    setHookReturn(capSlot(0, 'root'), [bootkref]);
+    const kp = c.queueToVatRoot('bootstrap', 'checkObjects1', capargs([0]));
+    await c.run();
+    t.deepEqual(hooklog.shift(), capargs([0]));
+    t.deepEqual(hooklog, []);
+    const exp = capargs({ match: true, rroot: capSlot(0, 'root') }, [bootkref]);
+    t.deepEqual(c.kpResolution(kp), exp);
+  }
+
+  {
+    // return r2
+    setHookReturn(capSlot(0, 'obj'), [o2kref]);
+    const kp = c.queueToVatRoot('bootstrap', 'checkObjects2', capargs([0]));
+    await c.run();
+    t.deepEqual(hooklog.shift(), capargs([0]));
+    t.deepEqual(hooklog, []);
+    const exp = capargs({ match: true, r2: capSlot(0, 'obj') }, [o2kref]);
+    t.deepEqual(c.kpResolution(kp), exp);
+  }
+
+  {
+    // return extra2
+    setHookReturn(capSlot(0, 'root'), [extra2kref]);
+    const kp = c.queueToVatRoot('bootstrap', 'checkObjects3', capargs([0]));
+    await c.run();
+    t.deepEqual(hooklog.shift(), capargs([0]));
+    t.deepEqual(hooklog, []);
+    const exp = capargs({ rextra2: capSlot(0, 'root') }, [extra2kref]);
+    t.deepEqual(c.kpResolution(kp), exp);
+  }
+
+  let deviceKref;
+  {
+    // exercise passing device nodes into the hook
+    setHookReturn(0);
+    const kp = c.queueToVatRoot('bootstrap', 'checkDevNodeIn', capargs([0]));
+    await c.run();
+    // hooklog should get kref for devnode d+1
+    const got = hooklog.shift();
+    t.deepEqual(JSON.parse(got.body), [capSlot(0, 'device node')]);
+    deviceKref = got.slots[0];
+    t.is(deviceKref, 'kd32'); // current value
+    t.deepEqual(hooklog, []);
+    // same as what the vat returned
+    const exp = capdataOneSlot(deviceKref, 'device node');
+    t.deepEqual(c.kpResolution(kp), exp);
+  }
+
+  {
+    // exercise returning device nodes from the hook
+    setHookReturn(capSlot(0, 'device node'), [deviceKref]);
+    const kp = c.queueToVatRoot('bootstrap', 'checkDevNodeOut', capargs([0]));
+    await c.run();
+    t.deepEqual(hooklog.shift(), capargs([0]));
+    t.deepEqual(hooklog, []);
+    const exp = capargs({ d2: capSlot(0, 'device node'), match: true }, [
+      deviceKref,
+    ]);
+    t.deepEqual(c.kpResolution(kp), exp);
+  }
+
+  const err = Error(
+    'syscall.callNow failed: device.invoke failed, see logs for details',
+  );
+
+  {
+    // test error within hook
+    setHookReturn(0);
+    // writes "dm.invoke failed, informing calling vat" and "deliberate hook
+    // error" to logs
+    const kp = c.queueToVatRoot('bootstrap', 'throwError', capargs([0]));
+    await c.run();
+    const exp = { worked: false, err };
+    t.deepEqual(parse(c.kpResolution(kp).body), exp);
+  }
+
+  {
+    // test missing hook name
+    setHookReturn(0);
+    // writes "dm.invoke failed, informing calling vat" and "device d7 has no
+    // hook named missingHook" to logs
+    const kp = c.queueToVatRoot('bootstrap', 'missingHook', capargs([0]));
+    await c.run();
+    const exp = { worked: false, err };
+    t.deepEqual(parse(c.kpResolution(kp).body), exp);
+  }
+});

--- a/packages/SwingSet/test/devices/bootstrap-raw.js
+++ b/packages/SwingSet/test/devices/bootstrap-raw.js
@@ -62,5 +62,14 @@ export function buildRootObject(vatPowers, _vatParameters) {
         return e;
       }
     },
+
+    step6() {
+      try {
+        D(devices.dr).sixError();
+        return false;
+      } catch (e) {
+        return e;
+      }
+    },
   });
 }

--- a/packages/SwingSet/test/devices/device-raw-0.js
+++ b/packages/SwingSet/test/devices/device-raw-0.js
@@ -63,6 +63,10 @@ export function buildDevice(tools, endowments) {
           throw Error('intentional device error');
         }
 
+        if (method === 'sixError') {
+          return harden(['error', 'deliberate raw-device result error']);
+        }
+
         throw TypeError(`target[${method}] does not exist`);
       }
 

--- a/packages/SwingSet/test/devices/test-raw-device.js
+++ b/packages/SwingSet/test/devices/test-raw-device.js
@@ -95,4 +95,13 @@ test('d1', async t => {
     'syscall.callNow failed: device.invoke failed, see logs for details',
   );
   t.deepEqual(parse(c.kpResolution(r5).body), expected5);
+
+  // and raw devices can return an error result
+  const r6 = c.queueToVatRoot('bootstrap', 'step6', capargs([]));
+  await c.run();
+  // body: '{"@qclass":"error","errorId":"error:liveSlots:v1#70001","message":"syscall.callNow failed: device.invoke failed, see logs for details","name":"Error"}',
+  const expected6 = Error(
+    'syscall.callNow failed: deliberate raw-device result error',
+  );
+  t.deepEqual(parse(c.kpResolution(r6).body), expected6);
 });

--- a/packages/SwingSet/test/util.js
+++ b/packages/SwingSet/test/util.js
@@ -79,21 +79,19 @@ export function buildDispatch(onDispatchCallback = undefined) {
   return { log, dispatch };
 }
 
-export function capSlot(index) {
-  return { '@qclass': 'slot', iface: 'Alleged: export', index };
+export function capSlot(index, iface = 'export') {
+  iface = iface ? `Alleged: ${iface}` : undefined;
+  return { '@qclass': 'slot', iface, index };
 }
 
-export function capdataOneSlot(slot) {
-  return capargs({ '@qclass': 'slot', iface: 'Alleged: export', index: 0 }, [
-    slot,
-  ]);
+export function capdataOneSlot(slot, iface = 'export') {
+  iface = iface ? `Alleged: ${iface}` : undefined;
+  return capargs({ '@qclass': 'slot', iface, index: 0 }, [slot]);
 }
 
-export function capargsOneSlot(slot) {
-  return capargs(
-    [{ '@qclass': 'slot', iface: 'Alleged: export', index: 0 }],
-    [slot],
-  );
+export function capargsOneSlot(slot, iface = 'export') {
+  iface = iface ? `Alleged: ${iface}` : undefined;
+  return capargs([{ '@qclass': 'slot', iface, index: 0 }], [slot]);
 }
 
 export function makeMessage(target, method, args, result = null) {


### PR DESCRIPTION
feat(swingset): add "device hooks"

Raw devices can use this feature to call kernel functions through a "hook"
that translates device-side slots ("drefs") into kernel-side slots ("krefs").
This will make it possible for devices to submit capdata to kernel endowments
like `pushCreateVatIDEvent`, so vatParameters can carry slots.

closes #4726