### PR TITLE
fix(swingset): silently ignore attempts to kill a dead vat

### DIFF
--- a/packages/SwingSet/src/kernel/kernel.js
+++ b/packages/SwingSet/src/kernel/kernel.js
@@ -259,20 +259,21 @@ export default function buildKernel(
       // ISSUE: terminate stuff in its own crank like creation?
       // eslint-disable-next-line no-use-before-define
       vatWarehouse.vatWasTerminated(vatID);
-    }
-    if (vatAdminRootKref) {
-      // static vat termination can happen before vat admin vat exists
-      notifyTermination(
-        vatID,
-        vatAdminRootKref,
-        shouldReject,
-        info,
-        queueToKref,
-      );
-    } else {
-      console.log(
-        `warning: vat ${vatID} terminated without a vatAdmin to report to`,
-      );
+
+      if (vatAdminRootKref) {
+        // static vat termination can happen before vat admin vat exists
+        notifyTermination(
+          vatID,
+          vatAdminRootKref,
+          shouldReject,
+          info,
+          queueToKref,
+        );
+      } else {
+        console.log(
+          `warning: vat ${vatID} terminated without a vatAdmin to report to`,
+        );
+      }
     }
   }
 

--- a/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
+++ b/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
@@ -83,9 +83,14 @@ export function buildRootObject(vatPowers) {
     running.set(vatID, doneRR);
     doneP.catch(() => {}); // shut up false whine about unhandled rejection
 
+    let terminated = false;
+
     const adminNode = Far('adminNode', {
       terminateWithFailure(reason) {
-        D(vatAdminNode).terminateWithFailure(vatID, reason);
+        if (!terminated) {
+          D(vatAdminNode).terminateWithFailure(vatID, reason);
+        }
+        terminated = true;
       },
       done() {
         return doneP;


### PR DESCRIPTION
Userspace can do `E(adminNode).terminateWithFailure()` multiple times on the
same vat. Previously, the kernel sent multiple `vatTerminated` messages to
vat-vat-admin, and since the first one removed vat-vat-admin's memory of the
dead vat, the second one made vat-vat-admin think that a static vat had died,
and it emitted a scary warning message.

The kernel was already catching duplicate termination attempts (and not
trying to clean up the already-deleted state), but the `notifyTermination()`
call was outside the check. This moves the call inside the check, so the
kernel won't emit the multiple calls.

It also changes vat-vat-admin's per-vat admin node to remember that
`terminateWithFailure` was called once already, and ignore subsequent calls.

closes #4866
