### PR TITLE
feat(swingset): allow object refs in create/upgrade/terminate vat

### DIFF
--- a/packages/SwingSet/src/kernel/state/kernelKeeper.js
+++ b/packages/SwingSet/src/kernel/state/kernelKeeper.js
@@ -1300,10 +1300,12 @@ export default function makeKernelKeeper(
     return harden(vatIDs);
   }
 
+  /*
+   * @returns { DeviceID | undefined }
+   */
   function getDeviceIDForName(name) {
     assert.typeof(name, 'string');
     const k = `device.name.${name}`;
-    assert(kvStore.has(k), X`device name ${name} must exist, but doesn't`);
     return kvStore.get(k);
   }
 

--- a/packages/SwingSet/src/kernel/state/vatKeeper.js
+++ b/packages/SwingSet/src/kernel/state/vatKeeper.js
@@ -123,6 +123,12 @@ export function makeVatKeeper(
   }
 
   function initializeReapCountdown(count) {
+    assert(
+      typeof count === 'number' ||
+        typeof count === 'bigint' ||
+        count === 'never',
+      `bad reapCountdown ${count}`,
+    );
     kvStore.set(`${vatID}.reapInterval`, `${count}`);
     kvStore.set(`${vatID}.reapCountdown`, `${count}`);
   }

--- a/packages/SwingSet/src/kernel/vat-admin-hooks.js
+++ b/packages/SwingSet/src/kernel/vat-admin-hooks.js
@@ -1,0 +1,114 @@
+import { assert } from '@agoric/assert';
+import { stringify, parse } from '@endo/marshal';
+import { insistVatID } from '../lib/id.js';
+
+export function makeVatAdminHooks(tools) {
+  const { kernelKeeper, terminateVat } = tools;
+  return {
+    createByBundle(argsCapData) {
+      // first, split off vatParameters
+      const argsJSON = JSON.parse(argsCapData.body);
+      const [bundle, { vatParameters: vpJSON, ...dynamicOptionsJSON }] =
+        argsJSON;
+      // assemble the vatParameters capdata
+      const vatParameters = {
+        body: JSON.stringify(vpJSON),
+        slots: argsCapData.slots,
+      };
+      // then re-parse the rest with marshal
+      const dynamicOptions = parse(JSON.stringify(dynamicOptionsJSON));
+      // incref slots while create-vat is on run-queue
+      for (const kref of vatParameters.slots) {
+        kernelKeeper.incrementRefCount(kref, 'create-vat-event');
+      }
+      const source = { bundle };
+      const vatID = kernelKeeper.allocateUnusedVatID();
+      const event = {
+        type: 'create-vat',
+        vatID,
+        source,
+        vatParameters,
+        dynamicOptions,
+      };
+      kernelKeeper.addToAcceptanceQueue(harden(event));
+      // the device gets the new vatID immediately, and will be notified
+      // later when it is created and a root object is available
+      const vatIDCapData = { body: JSON.stringify(vatID), slots: [] };
+      return harden(vatIDCapData);
+    },
+
+    createByID(argsCapData) {
+      // argsCapData is marshal([bundleID, options]), and options is {
+      // vatParameters, ...rest }, and 'rest' is JSON-serializable (no
+      // slots or bigints or undefined). We get the intermediate marshal
+      // representation (with @qclass nodes), carve off vatParameters,
+      // then reassemble the rest. All slots will be associated with
+      // vatParameters.
+
+      // first, split off vatParameters
+      const argsJSON = JSON.parse(argsCapData.body);
+      const [bundleID, { vatParameters: vpJSON, ...dynamicOptionsJSON }] =
+        argsJSON;
+      assert(kernelKeeper.hasBundle(bundleID), bundleID);
+      // assemble the vatParameters capdata
+      const vatParameters = {
+        body: JSON.stringify(vpJSON),
+        slots: argsCapData.slots,
+      };
+      // then re-parse the rest with marshal
+      const dynamicOptions = parse(JSON.stringify(dynamicOptionsJSON));
+      // incref slots while create-vat is on run-queue
+      for (const kref of vatParameters.slots) {
+        kernelKeeper.incrementRefCount(kref, 'create-vat-event');
+      }
+      const source = { bundleID };
+      const vatID = kernelKeeper.allocateUnusedVatID();
+      const event = {
+        type: 'create-vat',
+        vatID,
+        source,
+        vatParameters,
+        dynamicOptions,
+      };
+      kernelKeeper.addToAcceptanceQueue(harden(event));
+      // the device gets the new vatID immediately, and will be notified
+      // later when it is created and a root object is available
+      const vatIDCapData = { body: JSON.stringify(vatID), slots: [] };
+      return harden(vatIDCapData);
+    },
+
+    upgrade(argsCapData) {
+      // marshal([bundleID, vatParameters]) -> upgradeID
+      const argsJSON = JSON.parse(argsCapData.body);
+      const [bundleID, vpJSON] = argsJSON;
+      assert.typeof(bundleID, 'string');
+      const vpCD = { body: JSON.stringify(vpJSON), slots: argsCapData.slots };
+      for (const kref of vpCD.slots) {
+        kernelKeeper.incrementRefCount(kref, 'upgrade-vat-event');
+      }
+      const upgradeID = kernelKeeper.allocateUpgradeID();
+      const ev = {
+        type: 'upgrade-vat',
+        upgradeID,
+        bundleID,
+        vatParameters: vpCD,
+      };
+      kernelKeeper.addToAcceptanceQueue(harden(ev));
+      const upgradeIDCD = { body: JSON.stringify(upgradeID), slots: [] };
+      return harden(upgradeIDCD);
+    },
+
+    terminate(argsCD) {
+      // marshal([vatID, reason]) -> null
+      const argsJSON = JSON.parse(argsCD.body);
+      const [vatID, reasonJSON] = argsJSON;
+      insistVatID(vatID);
+      const reasonCD = { ...argsCD, body: JSON.stringify(reasonJSON) };
+      // we don't need to incrementRefCount because if terminateVat sends
+      // 'reason' to vat-admin, it uses notifyTermination / queueToKref /
+      // doSend, and doSend() does its own incref
+      terminateVat(vatID, true, reasonCD);
+      return harden({ body: stringify(undefined), slots: [] });
+    },
+  };
+}

--- a/packages/SwingSet/src/kernel/vatTranslator.js
+++ b/packages/SwingSet/src/kernel/vatTranslator.js
@@ -154,15 +154,11 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
    * @returns { VatDeliveryStartVat }
    */
   function translateStartVat(kernelVP) {
+    const slots = kernelVP.slots.map(slot => mapKernelSlotToVatSlot(slot));
+    const vatVP = { ...kernelVP, slots };
     /** @type { VatDeliveryStartVat } */
-    return harden(['startVat', kernelVP]); // TODO until capdata
-    // const vatVP = {
-    //   ...kernelVP,
-    //   slots: kernelVP.slots.map(slot => mapKernelSlotToVatSlot(slot)),
-    // };
-    // /** @type { VatDeliveryStartVat } */
-    // const startVatMessageVatDelivery = harden(['startVat', vatVP]);
-    // return startVatMessageVatDelivery;
+    const startVatMessageVatDelivery = harden(['startVat', vatVP]);
+    return startVatMessageVatDelivery;
   }
 
   function translateBringOutYourDead() {

--- a/packages/SwingSet/test/upgrade/bootstrap-upgrade.js
+++ b/packages/SwingSet/test/upgrade/bootstrap-upgrade.js
@@ -5,16 +5,21 @@ export function buildRootObject() {
   let vatAdmin;
   let ulrikRoot;
   let ulrikAdmin;
+  const marker = Far('marker', {});
 
   return Far('root', {
     async bootstrap(vats, devices) {
       vatAdmin = await E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
     },
 
+    getMarker() {
+      return marker;
+    },
+
     async buildV1() {
       // build Ulrik, the upgrading vat
       const bcap = await E(vatAdmin).getNamedBundleCap('ulrik1');
-      const vatParameters = { youAre: 'v1' };
+      const vatParameters = { youAre: 'v1', marker };
       const options = { vatParameters };
       const res = await E(vatAdmin).createVat(bcap, options);
       ulrikRoot = res.root;
@@ -26,7 +31,7 @@ export function buildRootObject() {
 
     async upgradeV2() {
       const bcap = await E(vatAdmin).getNamedBundleCap('ulrik2');
-      const vatParameters = { youAre: 'v2' };
+      const vatParameters = { youAre: 'v2', marker };
       await E(ulrikAdmin).upgrade(bcap, vatParameters);
       const version = await E(ulrikRoot).getVersion();
       const parameters = await E(ulrikRoot).getParameters();

--- a/packages/SwingSet/test/vat-admin/new-vat-13.js
+++ b/packages/SwingSet/test/vat-admin/new-vat-13.js
@@ -1,7 +1,8 @@
 import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 
-export function buildRootObject(_vatPowers) {
+export function buildRootObject(_vatPowers, vatParameters) {
+  const { adder } = vatParameters;
   function rcvrMaker(seed) {
     let count = 0;
     let sum = seed;
@@ -10,6 +11,9 @@ export function buildRootObject(_vatPowers) {
         sum += val;
         count += 1;
         return sum;
+      },
+      add2(val) {
+        return E(adder).add1(val + 1);
       },
       ticker() {
         return count;

--- a/packages/SwingSet/test/vat-admin/new-vat-44.js
+++ b/packages/SwingSet/test/vat-admin/new-vat-44.js
@@ -1,9 +1,11 @@
+import { E } from '@endo/eventual-send';
 import { Far } from '@endo/marshal';
 
-export function buildRootObject(_vatPowers) {
+export function buildRootObject(_vatPowers, vatParameters) {
+  const { adder } = vatParameters;
   return Far('root', {
     getANumber() {
-      return 44;
+      return E(adder).add1(43);
     },
   });
 }

--- a/packages/SwingSet/test/vat-admin/new-vat-refcount.js
+++ b/packages/SwingSet/test/vat-admin/new-vat-refcount.js
@@ -1,0 +1,8 @@
+import { Far } from '@endo/marshal';
+
+export function buildRootObject(_vatPowers, vatParameters) {
+  const { held } = vatParameters;
+  return Far('root', {
+    foo: () => held, // hold until root goes away
+  });
+}

--- a/packages/SwingSet/test/vat-admin/terminate/bootstrap-terminate-with-presence.js
+++ b/packages/SwingSet/test/vat-admin/terminate/bootstrap-terminate-with-presence.js
@@ -1,0 +1,38 @@
+import { E } from '@endo/eventual-send';
+import { Far } from '@endo/marshal';
+
+export function buildRootObject(vatPowers) {
+  const { testLog } = vatPowers;
+  const marker = Far('marker', {});
+
+  const self = Far('root', {
+    async bootstrap(vats, devices) {
+      const vatMaker = E(vats.vatAdmin).createVatAdminService(devices.vatAdmin);
+
+      const dude = await E(vatMaker).createVatByName('dude');
+      const count1 = await E(dude.root).foo(1);
+      testLog(`vat ready ${count1}`);
+
+      const doneP = E(dude.adminNode).done();
+      doneP.then(
+        answer => testLog(`doneP.then ${answer}`),
+        err => testLog(`doneP.catch ${err.why} ${err.marker === marker}`),
+      );
+      const foreverP = E(dude.root).never();
+      foreverP.then(
+        answer => testLog(`foreverP.then ${answer}`),
+        err => testLog(`foreverP.catch ${err}`),
+      );
+
+      const why = 'because';
+      const reason = harden({ why, marker });
+      const termP = E(dude.adminNode).terminateWithFailure(reason);
+      termP.then(
+        answer => testLog(`termP.then ${answer}`),
+        err => testLog(`termP.err ${err}`),
+      );
+      return 'bootstrap done';
+    },
+  });
+  return self;
+}

--- a/packages/SwingSet/test/vat-admin/terminate/swingset-terminate-with-presence.json
+++ b/packages/SwingSet/test/vat-admin/terminate/swingset-terminate-with-presence.json
@@ -1,0 +1,13 @@
+{
+  "bootstrap": "bootstrap",
+  "bundles": {
+    "dude": {
+      "sourceSpec": "vat-dude-terminate.js"
+    }
+  },
+  "vats": {
+    "bootstrap": {
+      "sourceSpec": "bootstrap-terminate-with-presence.js"
+    }
+  }
+}

--- a/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
+++ b/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
@@ -221,3 +221,20 @@ test('dead vat state removed', async t => {
   t.is(kvStore.get('ko26.owner'), undefined);
   t.is(Array.from(kvStore.getKeys('v6.', 'v6/')).length, 0);
 });
+
+test('terminate with presence', async t => {
+  const configPath = new URL(
+    'swingset-terminate-with-presence.json',
+    import.meta.url,
+  ).pathname;
+  const config = await loadSwingsetConfigFile(configPath);
+  const controller = await buildVatController(config, [], t.context.data);
+  await controller.run();
+  t.deepEqual(controller.dump().log, [
+    'FOO 1',
+    'vat ready FOO SAYS 1',
+    'foreverP.catch Error: vat terminated',
+    'termP.then undefined',
+    'doneP.catch because true',
+  ]);
+});

--- a/packages/SwingSet/test/vat-admin/test-create-vat.js
+++ b/packages/SwingSet/test/vat-admin/test-create-vat.js
@@ -3,12 +3,14 @@ import { test } from '../../tools/prepare-test-env-ava.js';
 // eslint-disable-next-line import/order
 import bundleSource from '@endo/bundle-source';
 import { parse } from '@endo/marshal';
+import { provideHostStorage } from '../../src/controller/hostStorage.js';
 import {
   buildKernelBundles,
-  buildVatController,
+  initializeSwingset,
+  makeSwingsetController,
   loadBasedir,
 } from '../../src/index.js';
-import { capargs } from '../util.js';
+import { capargs, capSlot } from '../util.js';
 
 function nonBundleFunction(_E) {
   return {};
@@ -28,30 +30,54 @@ test.before(async t => {
   const brokenRootVatBundle = await bundleSource(
     new URL('broken-root-vat.js', import.meta.url).pathname,
   );
+  const vatRefcountBundle = await bundleSource(
+    new URL('new-vat-refcount.js', import.meta.url).pathname,
+  );
   const nonBundle = `${nonBundleFunction}`;
   const bundles = {
     vat13Bundle,
     vat44Bundle,
     brokenModuleVatBundle,
     brokenRootVatBundle,
+    vatRefcountBundle,
     nonBundle,
   };
   t.context.data = { kernelBundles, bundles };
 });
 
-async function doTestSetup(t) {
+async function doTestSetup(t, enableSlog = false) {
   const { bundles, kernelBundles } = t.context.data;
   const config = await loadBasedir(new URL('./', import.meta.url).pathname);
+  config.defaultManagerType = 'xs-worker';
   config.bundles = {
     new13: { bundle: bundles.vat13Bundle },
     brokenModule: { bundle: bundles.brokenModuleVatBundle },
     brokenRoot: { bundle: bundles.brokenRootVatBundle },
   };
-  const c = await buildVatController(config, [], { kernelBundles });
+  const hostStorage = provideHostStorage();
+  await initializeSwingset(config, [], hostStorage, { kernelBundles });
+  let doSlog = false;
+  function slogSender(_, s) {
+    if (!doSlog) return;
+    const o = JSON.parse(s);
+    delete o.time;
+    delete o.replay;
+    delete o.crankNum;
+    delete o.deliveryNum;
+    if (['crank-start', 'deliver', 'syscall'].includes(o.type)) {
+      console.log(JSON.stringify(o));
+    }
+  }
+  const c = await makeSwingsetController(hostStorage, {}, { slogSender });
   const id44 = await c.validateAndInstallBundle(bundles.vat44Bundle);
+  const idRC = await c.validateAndInstallBundle(bundles.vatRefcountBundle);
   c.pinVatRoot('bootstrap');
   await c.run();
-  return { c, id44, vat13Bundle: bundles.vat13Bundle };
+  if (enableSlog) {
+    // for debugging, set enableSlog=true to start tracing after setup
+    doSlog = true;
+  }
+  return { c, id44, idRC, vat13Bundle: bundles.vat13Bundle, hostStorage };
 }
 
 test('createVatByBundle', async t => {
@@ -94,7 +120,7 @@ test('counter test', async t => {
   const { c } = await doTestSetup(t);
   const kpid = c.queueToVatRoot('bootstrap', 'counters', capargs(['new13']));
   await c.run();
-  t.deepEqual(JSON.parse(c.kpResolution(kpid).body), [4, 9, 2]);
+  t.deepEqual(JSON.parse(c.kpResolution(kpid).body), [4, 9, 2, 8]);
 });
 
 async function brokenVatTest(t, bundleName) {
@@ -130,4 +156,193 @@ test('error creating vat from non-bundle', async t => {
     parse(c.kpResolution(kpid).body),
     Error('Vat Creation Error: createVat() requires a bundlecap'),
   );
+});
+
+function findRefs(kvStore, koid) {
+  const refs = [];
+  const nextVatID = Number(kvStore.get('vat.nextID'));
+  for (let vn = 1; vn < nextVatID; vn += 1) {
+    const vatID = `v${vn}`;
+    const r = kvStore.get(`${vatID}.c.${koid}`);
+    if (r) {
+      refs.push(`${vatID}: ${r}`);
+    }
+  }
+  const nextDeviceID = Number(kvStore.get('device.nextID'));
+  for (let dn = 1; dn < nextDeviceID; dn += 1) {
+    const deviceID = `d${dn}`;
+    const r = kvStore.get(`${deviceID}.c.${koid}`);
+    if (r) {
+      refs.push(`${deviceID}: ${r}`);
+    }
+  }
+  const refcountString = kvStore.get(`${koid}.refCount`) || '0,0';
+  const refcount = refcountString.split(',').map(Number);
+  return { refs, refcount };
+}
+
+test('createVat holds refcount', async t => {
+  const printSlog = false; // set true to debug this test
+  const { c, idRC, hostStorage } = await doTestSetup(t, printSlog);
+  const { kvStore } = hostStorage;
+
+  // The bootstrap vat starts by fetching 'held' from vat-export-held, during
+  // doTestSetup(), and retains it throughout the entire test. When we send
+  // it refcount(), it will send VatAdminService.getBundleCap(), wait for the
+  // response, then send VatAdminService.createVat(held). VAS will tell
+  // device-vat-admin to push a create-vat event (including 'held') on the
+  // run-queue. Some time later, the create-vat event reaches the front, and
+  // the new vat is created, receiving 'held' in vatParametesr.
+
+  // We want to check the refcounts during this sequence, to confirm that the
+  // create-vat event holds a reference. Otherwise, 'held' might get GCed
+  // after VAS has pushed the event but before the kernel has created the new
+  // vat. (Currently, this is accidentally prevented by the fact that
+  // deviceKeeper.mapKernelSlotToDeviceSlot does an incrementRefCount but
+  // nothing ever decrements it: devices hold eternal refcounts on their
+  // c-list entries, and nothing ever removes a device c-list entry. But some
+  // day when we fix that, we'll rely upon the create-vat event's refcount to
+  // keep these things alive.
+
+  // We happen to know that 'held' will be allocated ko27, but we use
+  // `getHeld()` to obtain the real value in case e.g. a new built-in vat is
+  // added and some other koid is allocated. To remind us to review this test
+  // if/when things like that change, this test also asserts ko27, but that
+  // can be updated in a single place.
+
+  // 'held' is exported by v1, which shows up in the c-lists but doesn't
+  // count towards the refcount
+  let expectedRefcount = 0;
+  let expectedCLists = 1; // v1-export-held
+
+  // bootstrap() imports 'held', adding it to the v2-bootstrap c-list and
+  // incrementing the refcount.
+  expectedRefcount += 1; // v2-bootstrap
+  expectedCLists += 1; // v2-bootstrap
+
+  // calling getHeld doesn't immediately increment the refcount
+  const kpid1 = c.queueToVatRoot('bootstrap', 'getHeld', capargs([]));
+  await c.run();
+  const h1 = c.kpResolution(kpid1);
+  t.deepEqual(JSON.parse(h1.body), capSlot(0, 'held'));
+  const held = h1.slots[0];
+  t.is(held, 'ko27'); // gleaned from the logs, unstable, update as needed
+
+  // but `kpResolution()` does an incref on the results, making the refcount
+  // now 2,2: imported by v2-bootstrap and pinned by kpResolution.
+  expectedRefcount += 1; // kpResolution pin
+  const { refcount, refs } = findRefs(kvStore, held);
+  t.deepEqual(refcount, [expectedRefcount, expectedRefcount]);
+  t.is(refs.length, expectedCLists);
+
+  // console.log(`---`);
+
+  async function stepUntil(predicate) {
+    for (;;) {
+      // eslint-disable-next-line no-await-in-loop
+      const more = await c.step();
+      // const { refcount, refs } = findRefs(kvStore, held);
+      // const rc = kvStore.get(`${held}.refCount`);
+      // console.log(`rc(${held}): ${refcount}  ${refs.join(' , ')}`);
+      if (!more || predicate()) {
+        return;
+      }
+    }
+  }
+
+  // now start refcount() and step until we see the `send(createVat)` on
+  // the run-queue
+  const kpid = c.queueToVatRoot('bootstrap', 'refcount', capargs([idRC]));
+  function seeDeliverCreateVat() {
+    // console.log('rq:', JSON.stringify(c.dump().runQueue));
+    return c
+      .dump()
+      .runQueue.filter(q => q.type === 'send' && q.msg.method === 'createVat')
+      .length;
+  }
+  await stepUntil(seeDeliverCreateVat);
+
+  // now we should see 3,3: v2-bootstrap, the kpResolution pin, and the
+  // send(createVat) arguments. Two of these are c-lists.
+  expectedRefcount += 1; // send(createVat) arguments
+  const r1 = findRefs(kvStore, held);
+  t.deepEqual(r1.refcount, [expectedRefcount, expectedRefcount]);
+  t.is(r1.refs.length, expectedCLists);
+  // console.log(`---`);
+
+  // allow that to be delivered to vat-admin and step until we see the
+  // 'create-vat' event on the run-queue, which means vat-admin has just
+  // finished executing the createVat() message. We stop stepping before
+  // delivering bringOutYourDead to vat-admin, so it should still be holding
+  // the arguments.
+  function seeCreateVat() {
+    // console.log('rq:', JSON.stringify(c.dump().runQueue));
+    return c.dump().runQueue.filter(q => q.type === 'create-vat').length;
+  }
+  await stepUntil(seeCreateVat);
+  // console.log(`---`);
+
+  // We should see 5,5: v2-bootstrap, the kpResolution pin, vat-vat-admin,
+  // device-vat-admin, and the create-vat run-queue event. Three of these are
+  // c-lists.
+  expectedRefcount += 1; // vat-vat-admin c-list
+  expectedCLists += 1; // vat-vat-admin c-list
+  expectedRefcount += 1; // device-vat-admin c-list
+  expectedCLists += 1; // device-vat-admin c-list
+
+  const r2 = findRefs(kvStore, held);
+  // console.log(`r2:`, JSON.stringify(r2));
+  t.deepEqual(r2.refcount, [expectedRefcount, expectedRefcount]);
+  t.is(r2.refs.length, expectedCLists);
+
+  // Allow the vat-admin bringOutYourDead to be delivered, which *ought* to
+  // allow it to drop its reference to 'held'. NOTE: for some reason,
+  // `createVat()` does not drop that reference right away. I *think* it
+  // holds onto them until the result promise resolves, which doesn't happen
+  // until `newVatCallback()` is delivered. So this -=1 is commented out
+  // until we figure out how to fix that.. maybe a HandledPromise thing.
+
+  // expectedRefcount -= 1; // vat-vat-admin retires
+  // expectedCLists -= 1; // vat-vat-admin retires
+
+  // In addition, device-vat-admin does not yet participate in GC, and holds
+  // its references forever. So this -=1 remains commented out until we
+  // implement that functionality.
+
+  // expectedRefcount -= 1; // device-vat-admin retires
+  // expectedCLists -= 1; // device-vat-admin retires
+
+  t.deepEqual(c.dump().reapQueue, ['v3']);
+  await c.step();
+  t.deepEqual(c.dump().reapQueue, []);
+  // console.log(`---`);
+
+  // At this point we expected to see 5,5: v2-bootstrap, kpResolution pin,
+  // vat-vat-admin (because of the non-dropping bug), device-vat-admin
+  // (because of unimplemented GC), and the create-vat run-queue event. Two
+  // are c-lists.
+
+  const r3 = findRefs(kvStore, held);
+  // console.log(`r3:`, JSON.stringify(r3));
+  t.deepEqual(r3.refcount, [expectedRefcount, expectedRefcount]);
+  t.is(r3.refs.length, expectedCLists);
+
+  // Allow create-vat to be processed, removing the create-vat reference and
+  // adding a reference from the new vat's c-list
+  await c.step();
+  expectedRefcount -= 1; // remove send(createVat) argument
+  expectedRefcount += 1; // new-vat c-list
+  expectedCLists += 1; // new-vat c-list
+  // console.log(`---`);
+
+  // v2-bootstrap, kpResolution pin, device-vat-admin, new-vat
+  const r4 = findRefs(kvStore, held);
+  // console.log(`r4:`, JSON.stringify(r4));
+  t.deepEqual(r4.refcount, [expectedRefcount, expectedRefcount]);
+  t.is(r4.refs.length, expectedCLists);
+
+  // now let everything finish
+  // await c.run();
+  await stepUntil(() => false);
+  t.deepEqual(JSON.parse(c.kpResolution(kpid).body), 0);
 });

--- a/packages/SwingSet/test/vat-admin/vat-export-held.js
+++ b/packages/SwingSet/test/vat-admin/vat-export-held.js
@@ -1,0 +1,7 @@
+import { Far } from '@endo/marshal';
+
+export function buildRootObject() {
+  return Far('root', {
+    createHeld: () => Far('held', {}),
+  });
+}


### PR DESCRIPTION
This allows `E(vatAdminService).createVat(bundleID, { vatParameters })` to
include object references in `vatParameters`, which are then delivered
through the `dispatch.startVat()` delivery and made available to
`buildRootObject(vatPowers, vatParameters)`.

In vat-vat-admin, the CreateVatOptions validation was rewritten to
ensure that any existing slots are only in vatParameters.

From within a vat, `vatPowers.exitVat(completion)` and
`.exitVatWithFailure(reason)` can include object references, and they will be
delivered to the parent caller's `done` promise.

From outside the vat, `E(adminNode).terminateWithFailure(reason)` can take
object refs in `reason` and they will be delivered to the parent caller's
`done` promise. `E(adminNode).upgrade(bundleID, vatParameters)` can take
object refs in `vatParameters` just like `createVat` (although `upgrade`
itself is still non-functional).

The kernel will maintain a refcount on each object passed through this
mechanism, to keep it from being collected while in transit.

This is implemented with the new "kernel device hooks" feature, which allows
a device to call into the kernel and have its drefs translated into
krefs.

This will help with ZCF/contract vat upgrade, to pass the new contract
bundlecap into the new ZCF vat via vatParameters.

closes #4588
closes #4381
refs #1848
