### PR TITLE
Implement and display zoe offer arguments in the wallet

### DIFF
--- a/packages/wallet/api/test/test-lib-wallet.js
+++ b/packages/wallet/api/test/test-lib-wallet.js
@@ -690,6 +690,7 @@ test('lib-wallet offer methods', async t => {
           },
         },
         exit: { onDemand: null },
+        arguments: { foo: 'bar' },
       },
     });
 
@@ -720,6 +721,7 @@ test('lib-wallet offer methods', async t => {
         proposalTemplate: {
           give: { Contribution: { pursePetname: 'Fun budget', value: 1n } },
           exit: { onDemand: null },
+          arguments: { foo: 'bar' },
         },
         requestContext: { dappOrigin: 'unknown' },
         status: undefined,
@@ -851,6 +853,7 @@ test('lib-wallet offer methods', async t => {
         proposalTemplate: {
           give: { Contribution: { pursePetname: 'Fun budget', value: 1 } },
           exit: { onDemand: null },
+          arguments: { foo: 'bar' },
         },
         requestContext: { dappOrigin: 'unknown' },
         status: 'accept',
@@ -874,6 +877,7 @@ test('lib-wallet offer methods', async t => {
             },
           },
           exit: { onDemand: null },
+          arguments: { foo: 'bar' },
         },
       },
       {
@@ -901,6 +905,7 @@ test('lib-wallet offer methods', async t => {
         proposalTemplate: {
           give: { Contribution: { pursePetname: 'Fun budget', value: 1 } },
           exit: { onDemand: null },
+          arguments: { foo: 'bar' },
         },
         requestContext: { dappOrigin: 'unknown' },
         status: 'decline',
@@ -924,6 +929,7 @@ test('lib-wallet offer methods', async t => {
             },
           },
           exit: { onDemand: null },
+          arguments: { foo: 'bar' },
         },
       },
     ],

--- a/packages/wallet/ui/src/components/Offer.jsx
+++ b/packages/wallet/ui/src/components/Offer.jsx
@@ -60,7 +60,7 @@ const OfferWithoutContext = ({
     instancePetname,
     instanceHandleBoardId,
     requestContext: { date, dappOrigin, origin = 'unknown origin' } = {},
-    proposalForDisplay: { give = {}, want = {} } = {},
+    proposalForDisplay: { give = {}, want = {}, arguments: args } = {},
     invitationDetails: { fee, feePursePetname, expiry } = {},
     id,
   } = offer;
@@ -81,16 +81,16 @@ const OfferWithoutContext = ({
 
   const approve = () => {
     setPendingOffers({ offerId: id, isPending: true });
-    E(offer.actions).accept();
+    E(offer.actions).accept().catch(console.error);
   };
 
   const decline = () => {
     setDeclinedOffers({ offerId: id, isDeclined: true });
-    E(offer.actions).decline();
+    E(offer.actions).decline().catch(console.error);
   };
 
   const exit = () => {
-    E(offer.actions).cancel();
+    E(offer.actions).cancel().catch(console.error);
   };
 
   const close = () => {
@@ -216,6 +216,12 @@ const OfferWithoutContext = ({
         <span className="Blue">{dappOrigin || origin}</span>
       </div>
       <div>
+        {args === undefined || (
+          <div className="OfferArguments">
+            <h6>Arguments</h6>
+            <pre>{JSON.stringify(args, null, 2)}</pre>
+          </div>
+        )}
         {gives.map(Give)}
         {wants.map(Want)}
         {feeEntry}

--- a/packages/wallet/ui/src/components/Offer.jsx
+++ b/packages/wallet/ui/src/components/Offer.jsx
@@ -216,12 +216,6 @@ const OfferWithoutContext = ({
         <span className="Blue">{dappOrigin || origin}</span>
       </div>
       <div>
-        {args === undefined || (
-          <div className="OfferArguments">
-            <h6>Arguments</h6>
-            <pre>{JSON.stringify(args, null, 2)}</pre>
-          </div>
-        )}
         {gives.map(Give)}
         {wants.map(Want)}
         {feeEntry}
@@ -231,6 +225,12 @@ const OfferWithoutContext = ({
             <div className="Expiry text-gray">
               {formatDateNow(parseFloat(expiry) * 1000)}
             </div>
+          </div>
+        )}
+        {args !== undefined && (
+          <div className="OfferEntry">
+            <h6>Arguments</h6>
+            <pre>{JSON.stringify(args, null, 2)}</pre>
           </div>
         )}
       </div>

--- a/packages/wallet/ui/src/components/tests/Offer.test.jsx
+++ b/packages/wallet/ui/src/components/tests/Offer.test.jsx
@@ -12,7 +12,7 @@ jest.mock('@endo/eventual-send', () => ({
     new Proxy(obj, {
       get(target, propKey) {
         const method = target[propKey];
-        return (...args) => method.apply(this, args);
+        return (...args) => Promise.resolve(method.apply(this, args));
       },
     }),
 }));
@@ -66,6 +66,7 @@ const offer = {
     origin: 'unknown origin',
   },
   proposalForDisplay: {
+    arguments: [],
     give: {
       Collateral: {
         amount: {
@@ -127,7 +128,6 @@ test('renders the wants', () => {
   );
   expect(want.text()).toContain('into Zoe fees');
 });
-
 test('renders the fee', () => {
   const component = mount(<Offer offer={offer} />);
 
@@ -151,6 +151,17 @@ test('renders the expiry', () => {
   expect(expiry.text()).toContain('Expiry');
   expect(expiry.text()).toContain(
     formatDateNow(offer.invitationDetails.expiry),
+  );
+});
+
+test('renders the arguments', () => {
+  const component = mount(<Offer offer={offer} />);
+
+  const args = component.find('.OfferEntry').at(4);
+
+  expect(args.text()).toContain('Arguments');
+  expect(args.text()).toContain(
+    JSON.stringify(offer.proposalForDisplay.arguments, null, 2),
   );
 });
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #4860

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

`proposalTemplate.arguments` can be arbitrary passable data (including ocaps), and it will be propagated to the `zoe.offer` call.

<img width="467" alt="image" src="https://user-images.githubusercontent.com/457244/159145815-0fe59085-5b63-4a5f-bd4c-7af90dc25a40.png">

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

The rendering of arguments in the wallet needs to be clear and unambiguous.  Currently, it's just a rehydrated marshal value.

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

Needs tests.