### PR TITLE
fix(wallet-api): don't drop unused invitations on the floor

### DIFF
--- a/packages/wallet/api/src/lib-wallet.js
+++ b/packages/wallet/api/src/lib-wallet.js
@@ -1064,11 +1064,12 @@ export function makeWallet({
     return false;
   }
 
-  function declineOffer(id) {
+  async function declineOffer(id) {
     const offer = idToOffer.get(id);
     if (consummated(offer)) {
       return;
     }
+
     // Update status, drop the proposal
     const declinedOffer = addMeta({
       ...offer,
@@ -1076,6 +1077,15 @@ export function makeWallet({
     });
     idToOffer.set(id, declinedOffer);
     updateInboxState(id, declinedOffer);
+
+    // Try to reclaim the invitation.
+    const compiledOfferP = idToCompiledOfferP.get(id);
+    if (!compiledOfferP) {
+      return;
+    }
+
+    // eslint-disable-next-line no-use-before-define
+    await addPayment(E.get(compiledOfferP).inviteP).catch(console.error);
   }
 
   async function cancelOffer(id) {

--- a/packages/wallet/api/test/test-lib-wallet.js
+++ b/packages/wallet/api/test/test-lib-wallet.js
@@ -643,7 +643,7 @@ test('lib-wallet dapp suggests issuer, instance, installation petnames', async t
 });
 
 test('lib-wallet offer methods', async t => {
-  t.plan(7);
+  t.plan(8);
   const {
     moolaBundle,
     wallet,
@@ -753,12 +753,11 @@ test('lib-wallet offer methods', async t => {
   await wallet.deposit('Default Zoe invite purse', invite2);
   // `addOffer` withdraws the invite from the Zoe invite purse.
   await wallet.addOffer(offer2);
-  await wallet.declineOffer(id2);
-  // TODO: test cancelOffer with a contract that holds offers, like
-  // simpleExchange
   const zoeInvitePurse = await E(wallet).getPurse('Default Zoe invite purse');
   const zoePurseAmount = await E(zoeInvitePurse).getCurrentAmount();
   t.deepEqual(zoePurseAmount.value, [], `zoeInvitePurse balance`);
+  // TODO: test cancelOffer with a contract that holds offers, like
+  // simpleExchange
   const lastPurseState = JSON.parse(pursesStateChangeLog.pop());
   const [zoeInvitePurseState, moolaPurseState] = lastPurseState;
   t.deepEqual(
@@ -813,6 +812,16 @@ test('lib-wallet offer methods', async t => {
     },
     `moolaPurseState`,
   );
+
+  // `declineOffer` puts the invitation back.
+  await wallet.declineOffer(id2);
+  const zoePurseAmount2 = await E(zoeInvitePurse).getCurrentAmount();
+  t.deepEqual(
+    zoePurseAmount2.value,
+    [...invitationAmountValue2],
+    `zoeInvitePurse balance`,
+  );
+
   const lastInboxState = JSON.parse(inboxStateChangeLog.pop());
   t.deepEqual(
     lastInboxState,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

<!-- Most PRs should close a specific Issue. All PRs should at least reference one or more Issues. Edit and/or delete the following lines as appropriate (note: you don't need both `refs` and `closes` for the same one): -->

closes: #4875

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

A small but important tweak to `lib-wallet.js`.

### Security Considerations

<!-- Does this change introduce new assumptions or dependencies that, if violated, could introduce security vulnerabilities? How does this PR change the boundaries between mutually-suspicious components? What new authorities are introduced by this change, perhaps by new API calls? 
-->

Improved security for users of valuable invitations.

### Documentation Considerations

<!-- Give our docs folks some hints about what needs to be described to downstream users.

Backwards compatibility: what happens to existing data or deployments when this code is shipped? Do we need to instruct users to do something to upgrade their saved data? If there is no upgrade path possible, how bad will that be for users?

-->

Fully compatible.

### Testing Considerations

<!-- Every PR should of course come with tests of its own functionality. What additional tests are still needed beyond those unit tests? How does this affect CI, other test automation, or the testnet?
-->

None additional needed.
