### PR TITLE
feat(vault): move minting out of vault

### DIFF
--- a/packages/run-protocol/src/interest.js
+++ b/packages/run-protocol/src/interest.js
@@ -198,7 +198,11 @@ export const chargeInterest = (powers, params, prior, accruedUntil) => {
     harden({ [powers.seatAllocationKeyword]: rewarded }),
     powers.poolIncrementSeat,
   );
-  powers.reallocateWithFee(rewarded, powers.poolIncrementSeat);
+  powers.reallocateWithFee(
+    rewarded,
+    AmountMath.makeEmpty(brand),
+    powers.poolIncrementSeat,
+  );
 
   return {
     compoundedInterest,

--- a/packages/run-protocol/src/interest.js
+++ b/packages/run-protocol/src/interest.js
@@ -132,7 +132,7 @@ const validatedBrand = (mint, debt) => {
  *
  * @param {{
  *  mint: ZCFMint,
- *  reallocateWithFee: ReallocateWithFee,
+ *  mintAndReallocateWithFee: MintAndReallocate,
  *  poolIncrementSeat: ZCFSeat,
  *  seatAllocationKeyword: Keyword }} powers
  * @param {{
@@ -194,15 +194,7 @@ export const chargeInterest = (powers, params, prior, accruedUntil) => {
 
   // mint that much of brand for the reward pool
   const rewarded = AmountMath.make(brand, interestAccrued);
-  powers.mint.mintGains(
-    harden({ [powers.seatAllocationKeyword]: rewarded }),
-    powers.poolIncrementSeat,
-  );
-  powers.reallocateWithFee(
-    rewarded,
-    AmountMath.makeEmpty(brand),
-    powers.poolIncrementSeat,
-  );
+  powers.mintAndReallocateWithFee(rewarded, rewarded, powers.poolIncrementSeat);
 
   return {
     compoundedInterest,

--- a/packages/run-protocol/src/vaultFactory/types.js
+++ b/packages/run-protocol/src/vaultFactory/types.js
@@ -46,16 +46,29 @@
  */
 
 /**
- * @callback ReallocateWithFee
+ * @callback MintAndReallocate
  *
- * Transfer the indicated amount to the vaultFactory's reward
- * pool, taken from the `fromSeat`. Then reallocate over all the seat
- * arguments and the rewardPoolSeat.
+ * Mint new debt, and transfer a `fee` part of that to the vaultFactory's reward
+ * pool. Then reallocate over all the seat arguments and the rewardPoolSeat. Update
+ * the `totalDebt` if the reallocate succeeds.
  *
+ * TODO check limits.
+ *
+ * @param {Amount} toMint
  * @param {Amount} fee
- * @param {Amount} wanted
  * @param {ZCFSeat} fromSeat
  * @param {...ZCFSeat} otherSeats
+ * @returns {void}
+ */
+
+/**
+ * @callback BurnDebt
+ *
+ * Burn debt tokens off a seat and update
+ * the `totalDebt` if the reallocate succeeds.
+ *
+ * @param {Amount} toBurn
+ * @param {ZCFSeat} fromSeat
  * @returns {void}
  */
 

--- a/packages/run-protocol/src/vaultFactory/types.js
+++ b/packages/run-protocol/src/vaultFactory/types.js
@@ -52,9 +52,10 @@
  * pool, taken from the `fromSeat`. Then reallocate over all the seat
  * arguments and the rewardPoolSeat.
  *
- * @param {Amount} amount
+ * @param {Amount} fee
+ * @param {Amount} wanted
  * @param {ZCFSeat} fromSeat
- * @param {ZCFSeat=} otherSeat
+ * @param {...ZCFSeat} otherSeats
  * @returns {void}
  */
 
@@ -78,6 +79,7 @@
  * @typedef {Object} VaultManagerBase
  * @property {(seat: ZCFSeat) => Promise<VaultKit>}  makeVaultKit
  * @property {() => void} liquidateAll
+ * @property {() => CollateralManager} getPublicFacet
  */
 
 /**

--- a/packages/run-protocol/src/vaultFactory/types.js
+++ b/packages/run-protocol/src/vaultFactory/types.js
@@ -3,6 +3,8 @@
 /** @typedef {import('./vault').VaultUIState} VaultUIState */
 /** @typedef {import('./vaultKit').VaultKit} VaultKit */
 /** @typedef {VaultKit['vault']} Vault */
+/** @typedef {import('./vaultManager').VaultManager} VaultManager */
+/** @typedef {import('./vaultManager').CollateralManager} CollateralManager */
 
 /**
  * @typedef  {Object} AutoswapLocal
@@ -86,17 +88,6 @@
 
 /**
  * @typedef {string} VaultId
- */
-
-/**
- * @typedef {Object} VaultManagerBase
- * @property {(seat: ZCFSeat) => Promise<VaultKit>}  makeVaultKit
- * @property {() => void} liquidateAll
- * @property {() => CollateralManager} getPublicFacet
- */
-
-/**
- * @typedef {VaultManagerBase & GetVaultParams} VaultManager
  */
 
 /**

--- a/packages/run-protocol/src/vaultFactory/types.js
+++ b/packages/run-protocol/src/vaultFactory/types.js
@@ -48,7 +48,7 @@
 /**
  * @callback MintAndReallocate
  *
- * Mint new debt, and transfer a `fee` part of that to the vaultFactory's reward
+ * Mint new debt `toMint` and transfer the `fee` portion to the vaultFactory's reward
  * pool. Then reallocate over all the seat arguments and the rewardPoolSeat. Update
  * the `totalDebt` if the reallocate succeeds.
  *

--- a/packages/run-protocol/src/vaultFactory/vault.js
+++ b/packages/run-protocol/src/vaultFactory/vault.js
@@ -343,14 +343,14 @@ const constructFromState = state => {
       // you're paying off the debt, you get everything back.
       const debt = getCurrentDebt();
       const {
-        give: { RUN: runOffered },
+        give: { RUN: given },
       } = seat.getProposal();
 
       // you must pay off the entire remainder but if you offer too much, we won't
       // take more than you owe
       assert(
-        AmountMath.isGTE(runOffered, debt),
-        X`Offer ${runOffered} is not sufficient to pay off debt ${debt}`,
+        AmountMath.isGTE(given, debt),
+        X`Offer ${given} is not sufficient to pay off debt ${debt}`,
       );
 
       // Return any overpayment
@@ -473,12 +473,12 @@ const constructFromState = state => {
       // unchanging) or super-linear (also called "convex"). Super-linear is from
       // AMMs: selling less collateral would mean an even smaller price impact, so
       // this is a conservative choice.
-      const runPerCollateral = makeRatioFromAmounts(
+      const debtPerCollateral = makeRatioFromAmounts(
         maxDebtPre,
         newCollateralPre,
       );
       // `floorMultiply` because the debt ceiling should be tight
-      const maxDebtAfter = floorMultiplyBy(newCollateral, runPerCollateral);
+      const maxDebtAfter = floorMultiplyBy(newCollateral, debtPerCollateral);
       assert(
         AmountMath.isGTE(maxDebtAfter, newDebt),
         X`The requested debt ${q(

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -392,7 +392,7 @@ export const makeVaultManager = (
     }
   };
 
-  const publicFacet = harden({
+  const publicFacet = Far('collateral manager', {
     makeVaultInvitation: () => zcf.makeInvitation(makeVaultKit, 'MakeVault'),
     getNotifier: () => assetNotifer,
     getCompoundedInterest: () => compoundedInterest,

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -389,10 +389,19 @@ export const makeVaultManager = (
     }
   };
 
+  const publicFacet = harden({
+    makeVaultInvitation: () => zcf.makeInvitation(makeVaultKit, 'MakeVault'),
+    getNotifier: () => assetNotifer,
+    getCompoundedInterest: () => compoundedInterest,
+  });
+
   /** @type {VaultManager} */
   return Far('vault manager', {
     ...shared,
     makeVaultKit,
     liquidateAll,
+    getPublicFacet: () => publicFacet,
   });
 };
+
+/** @typedef {Awaited<ReturnType<typeof makeVaultManager>>['getPublicFacet']} CollateralManager */

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -12,6 +12,7 @@ import {
   ceilMultiplyBy,
   ceilDivideBy,
   makeRatio,
+  floorDivideBy,
 } from '@agoric/zoe/src/contractSupport/index.js';
 import { makeNotifierKit, observeNotifier } from '@agoric/notifier';
 import { AmountMath } from '@agoric/ertp';
@@ -56,7 +57,8 @@ const trace = makeTracer('VM');
  *  getLiquidationMargin: () => Ratio,
  *  getLoanFee: () => Ratio,
  * }} loanParamGetters
- * @param {ReallocateWithFee} reallocateWithFee
+ * @param {MintAndReallocate} mintAndReallocateWithFee
+ * @param {BurnDebt}  burnDebt
  * @param {ERef<TimerService>} timerService
  * @param {LiquidationStrategy} liquidationStrategy
  * @param {Timestamp} startTimeStamp
@@ -69,7 +71,8 @@ export const makeVaultManager = (
   priceAuthority,
   timingParams,
   loanParamGetters,
-  reallocateWithFee,
+  mintAndReallocateWithFee,
+  burnDebt,
   timerService,
   liquidationStrategy,
   startTimeStamp,
@@ -259,7 +262,7 @@ export const makeVaultManager = (
     ({ compoundedInterest, latestInterestUpdate, totalDebt } = chargeInterest(
       {
         mint: debtMint,
-        reallocateWithFee,
+        mintAndReallocateWithFee,
         poolIncrementSeat,
         seatAllocationKeyword: 'RUN',
       },
@@ -286,24 +289,16 @@ export const makeVaultManager = (
     reschedulePriceCheck();
   };
 
-  /**
-   * Update total debt of this manager given the change in debt on a vault
-   *
-   * @param {Amount<'nat'>} oldDebtOnVault
-   * @param {Amount<'nat'>} newDebtOnVault
-   */
-  // TODO https://github.com/Agoric/agoric-sdk/issues/4599
-  const applyDebtDelta = (oldDebtOnVault, newDebtOnVault) => {
-    // This does not use AmountMath because it could be validly negative
-    const delta = newDebtOnVault.value - oldDebtOnVault.value;
-    trace(`updating total debt ${totalDebt} by ${delta}`);
-    if (delta === 0n) {
-      // nothing to do
-      return;
-    }
-
-    // totalDebt += delta (Amount type ensures natural value)
-    totalDebt = AmountMath.make(debtBrand, totalDebt.value + delta);
+  const maxDebtFor = async collateralAmount => {
+    const quoteAmount = await E(priceAuthority).quoteGiven(
+      collateralAmount,
+      debtBrand,
+    );
+    // floorDivide because we want the debt ceiling lower
+    return floorDivideBy(
+      getAmountOut(quoteAmount),
+      shared.getLiquidationMargin(),
+    );
   };
 
   /**
@@ -342,12 +337,27 @@ export const makeVaultManager = (
 
   observeNotifier(periodNotifier, timeObserver);
 
+  const mintAndReallocate = (toMint, fee, seat, ...otherSeats) => {
+    mintAndReallocateWithFee(toMint, fee, seat, ...otherSeats);
+    totalDebt = AmountMath.add(totalDebt, toMint);
+    // TODO signal updater?
+  };
+
+  const burnAndRecord = (toBurn, seat) => {
+    burnDebt(toBurn, seat);
+    totalDebt = AmountMath.subtract(totalDebt, toBurn);
+    // TODO signal updater?
+  };
+
   /** @type {Parameters<typeof makeInnerVault>[1]} */
   const managerFacet = Far('managerFacet', {
     ...shared,
-    applyDebtDelta,
-    reallocateWithFee,
+    maxDebtFor,
+    mintAndReallocate,
+    burnAndRecord,
+    getNotifier: () => assetNotifer,
     getCollateralBrand: () => collateralBrand,
+    getDebtBrand: () => debtBrand,
     getCompoundedInterest: () => compoundedInterest,
     updateVaultPriority,
   });
@@ -362,14 +372,7 @@ export const makeVaultManager = (
     vaultCounter += 1;
     const vaultId = String(vaultCounter);
 
-    const innerVault = makeInnerVault(
-      zcf,
-      managerFacet,
-      assetNotifer,
-      vaultId,
-      debtMint,
-      priceAuthority,
-    );
+    const innerVault = makeInnerVault(zcf, managerFacet, vaultId);
 
     // TODO Don't record the vault until it gets opened
     assert(prioritizedVaults);

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -62,7 +62,6 @@ const trace = makeTracer('VM');
  * @param {ERef<TimerService>} timerService
  * @param {LiquidationStrategy} liquidationStrategy
  * @param {Timestamp} startTimeStamp
- * @returns {VaultManager}
  */
 export const makeVaultManager = (
   zcf,
@@ -397,7 +396,6 @@ export const makeVaultManager = (
     getCompoundedInterest: () => compoundedInterest,
   });
 
-  /** @type {VaultManager} */
   return Far('vault manager', {
     ...shared,
     makeVaultKit,
@@ -406,4 +404,5 @@ export const makeVaultManager = (
   });
 };
 
-/** @typedef {Awaited<ReturnType<typeof makeVaultManager>>['getPublicFacet']} CollateralManager */
+/** @typedef {ReturnType<typeof makeVaultManager>} VaultManager */
+/** @typedef {ReturnType<VaultManager['getPublicFacet']>} CollateralManager */

--- a/packages/run-protocol/src/vaultFactory/vaultManager.js
+++ b/packages/run-protocol/src/vaultFactory/vaultManager.js
@@ -340,7 +340,6 @@ export const makeVaultManager = (
   const mintAndReallocate = (toMint, fee, seat, ...otherSeats) => {
     mintAndReallocateWithFee(toMint, fee, seat, ...otherSeats);
     totalDebt = AmountMath.add(totalDebt, toMint);
-    // TODO signal updater?
   };
 
   const burnAndRecord = (toBurn, seat) => {

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -527,7 +527,7 @@ test('price drop', async t => {
 
   t.is(notification.value.vaultState, Phase.ACTIVE);
   t.deepEqual((await notification.value).debtSnapshot, {
-    run: AmountMath.add(loanAmount, fee),
+    debt: AmountMath.add(loanAmount, fee),
     interest: makeRatio(100n, runBrand),
   });
   const { RUN: lentAmount } = await E(vaultSeat).getCurrentAllocation();
@@ -951,7 +951,7 @@ test('interest on multiple vaults', async t => {
   const bobAddedDebt = 160n + 3n;
   t.deepEqual(
     calculateCurrentDebt(
-      bobUpdate.value.debtSnapshot.run,
+      bobUpdate.value.debtSnapshot.debt,
       bobUpdate.value.debtSnapshot.interest,
       assetUpdate.value.compoundedInterest,
     ),
@@ -967,7 +967,7 @@ test('interest on multiple vaults', async t => {
   const aliceAddedDebt = 236n + 3n;
   t.deepEqual(
     calculateCurrentDebt(
-      aliceUpdate.value.debtSnapshot.run,
+      aliceUpdate.value.debtSnapshot.debt,
       aliceUpdate.value.debtSnapshot.interest,
       assetUpdate.value.compoundedInterest,
     ),
@@ -976,7 +976,7 @@ test('interest on multiple vaults', async t => {
   );
   // but no change to the snapshot
   t.deepEqual(aliceUpdate.value.debtSnapshot, {
-    run: AmountMath.make(runBrand, 4935n),
+    debt: AmountMath.make(runBrand, 4935n),
     interest: makeRatio(100n, runBrand, 100n),
   });
   t.deepEqual(aliceUpdate.value.interestRate, interestRate);
@@ -1040,7 +1040,7 @@ test('interest on multiple vaults', async t => {
   const danUpdate = await E(danNotifier).getUpdateSince();
   // snapshot should equal actual since no additional time has elapsed
   const { debtSnapshot: danSnap } = danUpdate.value;
-  t.is(danSnap.run.value, danActualDebt);
+  t.is(danSnap.debt.value, danActualDebt);
 });
 
 test('adjust balances', async t => {
@@ -1118,9 +1118,9 @@ test('adjust balances', async t => {
   );
 
   let aliceUpdate = await E(aliceNotifier).getUpdateSince();
-  t.deepEqual(aliceUpdate.value.debtSnapshot.run, runDebtLevel);
+  t.deepEqual(aliceUpdate.value.debtSnapshot.debt, runDebtLevel);
   t.deepEqual(aliceUpdate.value.debtSnapshot, {
-    run: AmountMath.make(runBrand, 5250n),
+    debt: AmountMath.make(runBrand, 5250n),
     interest: makeRatio(100n, runBrand),
   });
 
@@ -1167,7 +1167,7 @@ test('adjust balances', async t => {
   );
 
   aliceUpdate = await E(aliceNotifier).getUpdateSince();
-  t.deepEqual(aliceUpdate.value.debtSnapshot.run, runDebtLevel);
+  t.deepEqual(aliceUpdate.value.debtSnapshot.debt, runDebtLevel);
 
   // increase collateral 2 ////////////////////////////////// (want:s, give:c)
 
@@ -1214,9 +1214,9 @@ test('adjust balances', async t => {
   );
 
   aliceUpdate = await E(aliceNotifier).getUpdateSince();
-  t.deepEqual(aliceUpdate.value.debtSnapshot.run, runDebtLevel);
+  t.deepEqual(aliceUpdate.value.debtSnapshot.debt, runDebtLevel);
   t.deepEqual(aliceUpdate.value.debtSnapshot, {
-    run: AmountMath.make(runBrand, 5253n),
+    debt: AmountMath.make(runBrand, 5253n),
     interest: makeRatio(100n, runBrand),
   });
 
@@ -1267,7 +1267,7 @@ test('adjust balances', async t => {
   );
 
   aliceUpdate = await E(aliceNotifier).getUpdateSince();
-  t.deepEqual(aliceUpdate.value.debtSnapshot.run, runDebtLevel);
+  t.deepEqual(aliceUpdate.value.debtSnapshot.debt, runDebtLevel);
 
   // NSF  ///////////////////////////////////// (want too much of both)
 
@@ -1535,7 +1535,7 @@ test('overdeposit', async t => {
   );
 
   let aliceUpdate = await E(aliceNotifier).getUpdateSince();
-  t.deepEqual(aliceUpdate.value.debtSnapshot.run, runDebt);
+  t.deepEqual(aliceUpdate.value.debtSnapshot.debt, runDebt);
   t.deepEqual(aliceUpdate.value.locked, collateralAmount);
 
   // Bob's loan /////////////////////////////////////
@@ -1593,7 +1593,7 @@ test('overdeposit', async t => {
 
   aliceUpdate = await E(aliceNotifier).getUpdateSince();
   t.deepEqual(
-    aliceUpdate.value.debtSnapshot.run,
+    aliceUpdate.value.debtSnapshot.debt,
     AmountMath.makeEmpty(runBrand),
   );
 
@@ -1702,7 +1702,7 @@ test('mutable liquidity triggers and interest', async t => {
   );
 
   let aliceUpdate = await E(aliceNotifier).getUpdateSince();
-  t.deepEqual(aliceUpdate.value.debtSnapshot.run, aliceRunDebtLevel);
+  t.deepEqual(aliceUpdate.value.debtSnapshot.debt, aliceRunDebtLevel);
 
   // Create a loan for Bob for 740 RUN with 100 Aeth collateral
   const bobCollateralAmount = AmountMath.make(aethBrand, 100n);
@@ -1740,7 +1740,7 @@ test('mutable liquidity triggers and interest', async t => {
   );
 
   let bobUpdate = await E(bobNotifier).getUpdateSince();
-  t.deepEqual(bobUpdate.value.debtSnapshot.run, bobRunDebtLevel);
+  t.deepEqual(bobUpdate.value.debtSnapshot.debt, bobRunDebtLevel);
 
   // reduce collateral  /////////////////////////////////////
 
@@ -1771,7 +1771,7 @@ test('mutable liquidity triggers and interest', async t => {
   );
 
   aliceUpdate = await E(aliceNotifier).getUpdateSince();
-  t.deepEqual(aliceUpdate.value.debtSnapshot.run, aliceRunDebtLevel);
+  t.deepEqual(aliceUpdate.value.debtSnapshot.debt, aliceRunDebtLevel);
 
   await manualTimer.tick();
   // price levels changed and interest was charged.
@@ -1995,7 +1995,7 @@ test('close loan', async t => {
   );
 
   const aliceUpdate = await E(aliceNotifier).getUpdateSince();
-  t.deepEqual(aliceUpdate.value.debtSnapshot.run, runDebtLevel);
+  t.deepEqual(aliceUpdate.value.debtSnapshot.debt, runDebtLevel);
   t.deepEqual(aliceUpdate.value.locked, collateralAmount);
 
   // Create a loan for Bob for 1000 RUN with 200 aeth collateral
@@ -2208,7 +2208,7 @@ test('mutable liquidity triggers and interest sensitivity', async t => {
   );
 
   let aliceUpdate = await E(aliceNotifier).getUpdateSince();
-  t.deepEqual(aliceUpdate.value.debtSnapshot.run, aliceRunDebtLevel);
+  t.deepEqual(aliceUpdate.value.debtSnapshot.debt, aliceRunDebtLevel);
 
   // Create a loan for Bob for 740 RUN with 100 Aeth collateral
   const bobCollateralAmount = AmountMath.make(aethBrand, 100n);
@@ -2246,7 +2246,7 @@ test('mutable liquidity triggers and interest sensitivity', async t => {
   );
 
   let bobUpdate = await E(bobNotifier).getUpdateSince();
-  t.deepEqual(bobUpdate.value.debtSnapshot.run, bobRunDebtLevel);
+  t.deepEqual(bobUpdate.value.debtSnapshot.debt, bobRunDebtLevel);
 
   // reduce collateral  /////////////////////////////////////
 
@@ -2275,7 +2275,7 @@ test('mutable liquidity triggers and interest sensitivity', async t => {
   );
 
   aliceUpdate = await E(aliceNotifier).getUpdateSince();
-  t.deepEqual(aliceUpdate.value.debtSnapshot.run, aliceRunDebtLevel);
+  t.deepEqual(aliceUpdate.value.debtSnapshot.debt, aliceRunDebtLevel);
 
   await manualTimer.tick();
   // price levels changed and interest was charged.

--- a/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
+++ b/packages/run-protocol/test/vaultFactory/test-vaultFactory.js
@@ -947,7 +947,7 @@ test('interest on multiple vaults', async t => {
   const aliceUpdate = await E(aliceNotifier).getUpdateSince();
   const bobUpdate = await E(bobNotifier).getUpdateSince();
 
-  // 160 is initial fee. interest is 3n/week. compounding is in the noise.
+  // 160n is initial fee. interest is 3n/week. compounding is in the noise.
   const bobAddedDebt = 160n + 3n;
   t.deepEqual(
     calculateCurrentDebt(

--- a/packages/run-protocol/test/vaultFactory/vault-contract-wrapper.js
+++ b/packages/run-protocol/test/vaultFactory/vault-contract-wrapper.js
@@ -8,12 +8,15 @@ import { assert } from '@agoric/assert';
 import buildManualTimer from '@agoric/zoe/tools/manualTimer.js';
 import { makeFakePriceAuthority } from '@agoric/zoe/tools/fakePriceAuthority.js';
 import {
+  floorDivideBy,
   makeRatio,
   multiplyRatios,
 } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { Far } from '@endo/marshal';
 
 import { makeNotifierKit } from '@agoric/notifier';
+import { getAmountOut } from '@agoric/zoe/src/contractSupport';
+import { E } from '@endo/eventual-send';
 import { makeInnerVault } from '../../src/vaultFactory/vault.js';
 import { paymentFromZCFMint } from '../../src/vaultFactory/burn.js';
 
@@ -36,6 +39,8 @@ export async function start(zcf, privateArgs) {
   const runMint = await zcf.registerFeeMint('RUN', privateArgs.feeMintAccess);
   const { brand: runBrand } = runMint.getIssuerRecord();
 
+  const LIQUIDATION_MARGIN = makeRatio(105n, runBrand);
+
   const { zcfSeat: vaultFactorySeat } = zcf.makeEmptySeatKit();
 
   let vaultCounter = 0;
@@ -44,6 +49,27 @@ export async function start(zcf, privateArgs) {
   let compoundedInterest = makeRatio(100n, runBrand); // starts at 1.0, no interest
 
   const { zcfSeat: stage } = zcf.makeEmptySeatKit();
+
+  const { notifier: managerNotifier } = makeNotifierKit();
+
+  const timer = buildManualTimer(console.log, 0n, DAY);
+  const options = {
+    actualBrandIn: collateralBrand,
+    actualBrandOut: runBrand,
+    priceList: [80],
+    tradeList: undefined,
+    timer,
+    quoteMint: makeIssuerKit('quote', AssetKind.SET).mint,
+  };
+  const priceAuthority = makeFakePriceAuthority(options);
+  const maxDebtFor = async collateralAmount => {
+    const quoteAmount = await E(priceAuthority).quoteGiven(
+      collateralAmount,
+      runBrand,
+    );
+    // floorDivide because we want the debt ceiling lower
+    return floorDivideBy(getAmountOut(quoteAmount), LIQUIDATION_MARGIN);
+  };
 
   const reallocateWithFee = (fee, wanted, seat, ...otherSeats) => {
     const toMint = AmountMath.add(wanted, fee);
@@ -65,10 +91,19 @@ export async function start(zcf, privateArgs) {
     }
   };
 
+  const mintAndReallocate = (toMint, fee, seat, ...otherSeats) => {
+    const wanted = AmountMath.subtract(toMint, fee);
+    reallocateWithFee(fee, wanted, seat, ...otherSeats);
+  };
+
+  const burnAndRecord = (toBurn, seat) => {
+    runMint.burnLosses(harden({ RUN: toBurn }), seat);
+  };
+
   /** @type {Parameters<typeof makeInnerVault>[1]} */
   const managerMock = Far('vault manager mock', {
     getLiquidationMargin() {
-      return makeRatio(105n, runBrand);
+      return LIQUIDATION_MARGIN;
     },
     getLoanFee() {
       return makeRatio(500n, runBrand, BASIS_POINTS);
@@ -79,14 +114,18 @@ export async function start(zcf, privateArgs) {
     getCollateralBrand() {
       return collateralBrand;
     },
+    getDebtBrand: () => runBrand,
+
     getChargingPeriod() {
       return DAY;
     },
     getRecordingPeriod() {
       return DAY;
     },
-    reallocateWithFee,
-    applyDebtDelta() {},
+    getNotifier: () => managerNotifier,
+    maxDebtFor,
+    mintAndReallocate,
+    burnAndRecord,
     getCollateralQuote() {
       return Promise.resolve({
         quoteAmount: AmountMath.make(runBrand, 0n),
@@ -102,27 +141,11 @@ export async function start(zcf, privateArgs) {
     },
   });
 
-  const timer = buildManualTimer(console.log, 0n, DAY);
-  const options = {
-    actualBrandIn: collateralBrand,
-    actualBrandOut: runBrand,
-    priceList: [80],
-    tradeList: undefined,
-    timer,
-    quoteMint: makeIssuerKit('quote', AssetKind.SET).mint,
-  };
-  const priceAuthority = makeFakePriceAuthority(options);
-
-  const { notifier: managerNotifier } = makeNotifierKit();
-
   const innerVault = await makeInnerVault(
     zcf,
     managerMock,
-    managerNotifier,
     // eslint-disable-next-line no-plusplus
     String(vaultCounter++),
-    runMint,
-    priceAuthority,
   );
 
   const advanceRecordingPeriod = () => {


### PR DESCRIPTION
close: #4838 

## Description

This does several refactoring cleanups. The core and most important is moving direct mint access out of the vaults. This makes it much easier to do per-collateral limit checking and accounting.

* Expose a per-collateral facet to support collateral-specific notifiers (like compounded interest) and enable future segregation into per-collateral contracts
* Consolidate mint access into base contract for POLA in `vault`
* Setup to further refactor so that mint/burn is combined with limit checking and bookkeeping

TODO
* [x] move `burn` into manager
* [x] move `mint` function into manager so it can track per-collateral limits
* [x] integrate bookkeeping with mint/burn
* [x] fix types

### Security Considerations

These changes support better mint POLA, collateral and vault segregation, and simplify bookkeeping 

### Documentation Considerations

The addition of a per-collateral facet should appear in the documentation

### Testing Considerations

This is a refactoring, so all the paths fall under existing tests. With the abstraction of functionality, testing could generally be simplified.

TODO future: the new internal operation should get unit test
* [ ] Add unit tests for new internal operations
* [ ] Add unit test variant to create vaults via the collateral manager