### PR TITLE
chore: fix mintPayment type

### DIFF
--- a/packages/ERTP/src/paymentLedger.js
+++ b/packages/ERTP/src/paymentLedger.js
@@ -253,7 +253,7 @@ export const makePaymentLedger = (
    * Creates a new Payment containing newly minted amount.
    *
    * @param {Amount<K>} newAmount
-   * @returns {Payment}
+   * @returns {Payment<K>}
    */
   const mintPayment = newAmount => {
     newAmount = coerce(newAmount);
@@ -365,3 +365,5 @@ export const makePaymentLedger = (
     mint,
   });
 };
+
+/** @typedef {ReturnType<makePaymentLedger>} PaymentLedger */

--- a/packages/ERTP/src/types.js
+++ b/packages/ERTP/src/types.js
@@ -292,7 +292,7 @@
  * assets all have the same kind, which is called a Brand.
  *
  * @property {() => Issuer<K>} getIssuer Gets the Issuer for this mint.
- * @property {MintPayment<K>} mintPayment
+ * @property {(newAmount: Amount<K>) => Payment<K>} mintPayment
  */
 
 /**


### PR DESCRIPTION
## Description

The removal of `MintPayment` type wasn't complete. (h/t @mhofman https://github.com/Agoric/agoric-sdk/pull/4736/files#r830781495) I wonder what it would take for the type system to have noted this problem. I suppose tsc is permissive with type annotations in JSdoc because they could be for another type specification system. 

I didn't restore the callback because it's not a callback/interface. It's a function that exists only on `Mint` objects so I corrected the type inline. 

(While iterating on approaches I defined the `PaymentLedger` type and it's left in here)

### Security Considerations

--

### Documentation Considerations

--

### Testing Considerations

--
