### PR TITLE
ci: Re-enable loadgen integration test

### DIFF
--- a/packages/deployment/ansible/roles/cosmos-genesis/files/faucet-helper.sh
+++ b/packages/deployment/ansible/roles/cosmos-genesis/files/faucet-helper.sh
@@ -66,7 +66,7 @@ while [[ ${#rpcAddrs[@]} -gt 0 ]]; do
       txfile="/tmp/faucet.$$.json"
       trap 'rm -f "$txfile"' EXIT
       echo "$body0" | jq ".body.messages += $msg1" > "$txfile"
-      $TX sign "$txfile" | $TX broadcast "$BROADCAST_FLAGS" - | tee /dev/stderr | grep -q '^code: 0'
+      $TX sign "$txfile" | $TX broadcast --broadcast-mode=block - | tee /dev/stderr | grep -q '^code: 0'
       exit $? 
       ;;
     gift)

--- a/packages/deployment/scripts/integration-test.sh
+++ b/packages/deployment/scripts/integration-test.sh
@@ -17,6 +17,15 @@ cd "$NETWORK_NAME/setup"
 
 export AG_SETUP_COSMOS_HOME=${AG_SETUP_COSMOS_HOME-$PWD}
 
+if [ -d /usr/src/testnet-load-generator ]
+then
+  $thisdir/../../solo/bin/ag-solo init \
+    /usr/src/testnet-load-generator/_agstate/agoric-servers/testnet-8000 \
+    --webport=8000
+  SOLO_ADDR=$(cat /usr/src/testnet-load-generator/_agstate/agoric-servers/testnet-8000/ag-cosmos-helper-address)
+  VAT_CONFIG="@agoric/vats/decentral-loadgen-config.json"
+fi
+
 # Speed up the docker deployment by pre-mounting /usr/src/agoric-sdk.
 DOCKER_VOLUMES="$(cd "$thisdir/../../.." > /dev/null && pwd -P):/usr/src/agoric-sdk" \
   "$thisdir/docker-deployment.cjs" > deployment.json
@@ -26,24 +35,22 @@ DOCKER_VOLUMES="$(cd "$thisdir/../../.." > /dev/null && pwd -P):/usr/src/agoric-
 
 # Go ahead and bootstrap with detailed debug logging.
 AG_COSMOS_START_ARGS="--log_level=info --trace-store=.ag-chain-cosmos/data/kvstore.trace" \
+VAULT_FACTORY_CONTROLLER_ADDR="$SOLO_ADDR" \
+CHAIN_BOOTSTRAP_VAT_CONFIG="$VAT_CONFIG" \
   "$thisdir/setup.sh" bootstrap ${1+"$@"}
 
-if false && [ -d /usr/src/testnet-load-generator ]
+if [ -d /usr/src/testnet-load-generator ]
 then
   /usr/src/agoric-sdk/packages/deployment/scripts/setup.sh show-config > "$RESULTSDIR/network-config"
   cp ag-chain-cosmos/data/genesis.json "$RESULTSDIR/genesis.json"
   cp "$AG_SETUP_COSMOS_HOME/ag-chain-cosmos/data/genesis.json" "$RESULTSDIR/genesis.json"
   cd /usr/src/testnet-load-generator
-  $thisdir/../../solo/bin/ag-solo init \
-    _agstate/agoric-servers/testnet-8000 \
-    --webport=8000 \
-    --netconfig="$RESULTSDIR/network-config"
-  $AG_SETUP_COSMOS_HOME/faucet-helper.sh add-egress \
-    loadgen $(cat _agstate/agoric-servers/testnet-8000/ag-cosmos-helper-address)
+  SOLO_COINS=40000000000urun \
+    "$AG_SETUP_COSMOS_HOME/faucet-helper.sh" add-egress loadgen "$SOLO_ADDR"
   SDK_BUILD=0 SDK_SRC=/usr/src/agoric-sdk OUTPUT_DIR="$RESULTSDIR" ./start.sh \
     --no-stage.save-storage --stages=3 --stage.duration=4 \
     --stage.loadgen.vault.interval=12 --stage.loadgen.vault.limit=2 \
     --stage.loadgen.amm.interval=12 --stage.loadgen.amm.wait=6 --stage.loadgen.amm.limit=2 \
     --profile=testnet "--testnet-origin=file://$RESULTSDIR" \
-    --no-reset
+    --no-reset --custom-bootstrap
 fi

--- a/packages/deployment/scripts/integration-test.sh
+++ b/packages/deployment/scripts/integration-test.sh
@@ -48,7 +48,7 @@ then
   SOLO_COINS=40000000000urun \
     "$AG_SETUP_COSMOS_HOME/faucet-helper.sh" add-egress loadgen "$SOLO_ADDR"
   SDK_BUILD=0 SDK_SRC=/usr/src/agoric-sdk OUTPUT_DIR="$RESULTSDIR" ./start.sh \
-    --no-stage.save-storage --stages=3 --stage.duration=4 \
+    --no-stage.save-storage --stages=1 --stage.duration=11 \
     --stage.loadgen.vault.interval=12 --stage.loadgen.vault.limit=2 \
     --stage.loadgen.amm.interval=12 --stage.loadgen.amm.wait=6 --stage.loadgen.amm.limit=2 \
     --profile=testnet "--testnet-origin=file://$RESULTSDIR" \

--- a/packages/deployment/src/main.js
+++ b/packages/deployment/src/main.js
@@ -458,14 +458,25 @@ show-config      display the client connection parameters
       if (await rd.exists(`prometheus-tendermint.txt`)) {
         SWINGSET_PROMETHEUS_PORT = DEFAULT_SWINGSET_PROMETHEUS_PORT;
       }
-      const serviceLines = `Environment=SLOGFILE=.ag-chain-cosmos/data/chain.slog\n`;
-      const agChainCosmosEnvironment = SWINGSET_PROMETHEUS_PORT
-        ? [
-            `-eserviceLines=${shellEscape(
-              `${serviceLines}Environment="OTEL_EXPORTER_PROMETHEUS_PORT=${SWINGSET_PROMETHEUS_PORT}"`,
-            )}`,
-          ]
-        : [`-eserviceLines=${shellEscape(serviceLines)}`];
+      const serviceLines = [
+        `Environment=SLOGFILE=.ag-chain-cosmos/data/chain.slog`,
+      ];
+      if (SWINGSET_PROMETHEUS_PORT) {
+        serviceLines.push(
+          `Environment="OTEL_EXPORTER_PROMETHEUS_PORT=${SWINGSET_PROMETHEUS_PORT}"`,
+        );
+      }
+      for (const envName of [
+        'VAULT_FACTORY_CONTROLLER_ADDR',
+        'CHAIN_BOOTSTRAP_VAT_CONFIG',
+      ]) {
+        if (env[envName]) {
+          serviceLines.push(`Environment="${envName}=${env[envName]}"`);
+        }
+      }
+      const agChainCosmosEnvironment = [
+        `-eserviceLines=${shellEscape(serviceLines.join('\n'))}`,
+      ];
       await guardFile(`${COSMOS_DIR}/service.stamp`, () =>
         needReMain([
           'play',


### PR DESCRIPTION
refs: #4634 ##4661

## Description

Re-enable the loadgen part of the deployment CI job that was disabled in #4661

### Security Considerations

2 new environment variables are passed through to the chain process for the ansible based deployment script. They allow changing the bootstrap config and grant vault powers to a given address. These environments variables were introduced in https://github.com/Agoric/agoric-sdk/pull/4641

### Testing Considerations

To temporarily deal with #4911, I've included a change to the loadgen config to run the loadgen without restart.