### PR TITLE
add no-op dispatch.stopVat

### DIFF
--- a/packages/SwingSet/src/devices/vat-admin/device-vat-admin.js
+++ b/packages/SwingSet/src/devices/vat-admin/device-vat-admin.js
@@ -2,6 +2,7 @@
 import { Nat } from '@agoric/nat';
 import { assert } from '@agoric/assert';
 import { buildSerializationTools } from '../lib/deviceTools.js';
+import { insistVatID } from '../../lib/id.js';
 
 /*
 
@@ -205,12 +206,13 @@ export function buildDevice(tools, endowments) {
           return returnFromInvoke(vatID);
         }
 
-        // D(devices.vatAdmin).upgradeVat(bundleID, vatParameters) -> upgradeID
+        // D(devices.vatAdmin).upgradeVat(vatID, bundleID, vatParameters) -> upgradeID
         if (method === 'upgradeVat') {
           const args = JSON.parse(argsCapdata.body);
           assert(Array.isArray(args), 'upgradeVat() args array');
-          assert.equal(args.length, 2, `upgradeVat() args length`);
-          const [bundleID, _vatParameters] = args;
+          assert.equal(args.length, 3, `upgradeVat() args length`);
+          const [vatID, bundleID, _vatParameters] = args;
+          insistVatID(vatID);
           assert.typeof(bundleID, 'string', `upgradeVat() bundleID`);
 
           const res = syscall.callKernelHook('upgrade', argsCapdata);

--- a/packages/SwingSet/src/kernel/vat-admin-hooks.js
+++ b/packages/SwingSet/src/kernel/vat-admin-hooks.js
@@ -78,9 +78,10 @@ export function makeVatAdminHooks(tools) {
     },
 
     upgrade(argsCapData) {
-      // marshal([bundleID, vatParameters]) -> upgradeID
+      // marshal([vatID, bundleID, vatParameters]) -> upgradeID
       const argsJSON = JSON.parse(argsCapData.body);
-      const [bundleID, vpJSON] = argsJSON;
+      const [vatID, bundleID, vpJSON] = argsJSON;
+      insistVatID(vatID);
       assert.typeof(bundleID, 'string');
       const vpCD = { body: JSON.stringify(vpJSON), slots: argsCapData.slots };
       for (const kref of vpCD.slots) {
@@ -89,6 +90,7 @@ export function makeVatAdminHooks(tools) {
       const upgradeID = kernelKeeper.allocateUpgradeID();
       const ev = {
         type: 'upgrade-vat',
+        vatID,
         upgradeID,
         bundleID,
         vatParameters: vpCD,

--- a/packages/SwingSet/src/kernel/vatTranslator.js
+++ b/packages/SwingSet/src/kernel/vatTranslator.js
@@ -10,9 +10,6 @@ import {
   legibilizeValue,
 } from '../lib/kdebug.js';
 
-/** @type { VatDeliveryBringOutYourDead } */
-const reapMessageVatDelivery = harden(['bringOutYourDead']);
-
 export function assertValidVatstoreKey(key) {
   assert.typeof(key, 'string');
 }
@@ -161,6 +158,16 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
     return startVatMessageVatDelivery;
   }
 
+  /** @type { import('../types-external.js').VatDeliveryStopVat } */
+  const stopVatMessage = harden(['stopVat']);
+
+  function translateStopVat() {
+    return stopVatMessage;
+  }
+
+  /** @type { VatDeliveryBringOutYourDead } */
+  const reapMessageVatDelivery = harden(['bringOutYourDead']);
+
   function translateBringOutYourDead() {
     return reapMessageVatDelivery;
   }
@@ -196,6 +203,10 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
         const [_, ...args] = kd;
         return translateStartVat(...args);
       }
+      case 'stopVat': {
+        const [_, ...args] = kd;
+        return translateStopVat(...args);
+      }
       case 'bringOutYourDead': {
         const [_, ...args] = kd;
         return translateBringOutYourDead(...args);
@@ -210,6 +221,7 @@ function makeTranslateKernelDeliveryToVatDelivery(vatID, kernelKeeper) {
     //  ['retireExports', vrefs]
     //  ['retireImports', vrefs]
     //  ['startVat']
+    //  ['stopVat']
     //  ['bringOutYourDead']
   }
 

--- a/packages/SwingSet/src/lib/message.js
+++ b/packages/SwingSet/src/lib/message.js
@@ -71,6 +71,10 @@ export function insistVatDeliveryObject(vdo) {
       insistCapData(vatParameters);
       break;
     }
+    case 'stopVat': {
+      assert(rest.length === 0);
+      break;
+    }
     case 'bringOutYourDead': {
       assert(rest.length === 0);
       break;

--- a/packages/SwingSet/src/liveslots/liveslots.js
+++ b/packages/SwingSet/src/liveslots/liveslots.js
@@ -61,6 +61,7 @@ function build(
   }
 
   let didStartVat = false;
+  let didStopVat = false;
 
   const outstandingProxies = new WeakSet();
 
@@ -893,6 +894,7 @@ function build(
 
   function deliver(target, method, argsdata, result) {
     assert(didStartVat);
+    assert(!didStopVat);
     insistCapData(argsdata);
     lsdebug(
       `ls[${forVatID}].dispatch.deliver ${target}.${method} -> ${result}`,
@@ -1019,6 +1021,7 @@ function build(
 
   function notify(resolutions) {
     assert(didStartVat);
+    assert(!didStopVat);
     beginCollectingPromiseImports();
     for (const resolution of resolutions) {
       const [vpid, rejected, data] = resolution;
@@ -1149,6 +1152,7 @@ function build(
     insistCapData(vatParametersCapData);
     assert(!didStartVat);
     didStartVat = true;
+    assert(!didStopVat);
 
     // Build the `vatPowers` provided to `buildRootObject`. We include
     // vatGlobals and inescapableGlobalProperties to make it easier to write
@@ -1256,6 +1260,16 @@ function build(
   }
 
   /**
+   * @returns { Promise<void> }
+   */
+  async function stopVat() {
+    assert(didStartVat);
+    assert(!didStopVat);
+    didStopVat = true;
+    // empty for now
+  }
+
+  /**
    * @param { VatDeliveryObject } delivery
    * @returns { void | Promise<void> }
    */
@@ -1292,6 +1306,10 @@ function build(
       case 'startVat': {
         const [vpCapData] = args;
         result = startVat(vpCapData);
+        break;
+      }
+      case 'stopVat': {
+        result = stopVat();
         break;
       }
       default:

--- a/packages/SwingSet/src/types-external.js
+++ b/packages/SwingSet/src/types-external.js
@@ -97,10 +97,11 @@ export {};
  * @typedef { [tag: 'retireExports', vrefs: string[] ]} VatDeliveryRetireExports
  * @typedef { [tag: 'retireImports', vrefs: string[] ]} VatDeliveryRetireImports
  * @typedef { [tag: 'startVat', vatParameters: SwingSetCapData ]} VatDeliveryStartVat
+ * @typedef { [tag: 'stopVat' ]} VatDeliveryStopVat
  * @typedef { [tag: 'bringOutYourDead' ]} VatDeliveryBringOutYourDead
  * @typedef { VatDeliveryMessage | VatDeliveryNotify | VatDeliveryDropExports
  *            | VatDeliveryRetireExports | VatDeliveryRetireImports
- *            | VatDeliveryStartVat | VatDeliveryBringOutYourDead
+ *            | VatDeliveryStartVat | VatDeliveryStopVat | VatDeliveryBringOutYourDead
  *          } VatDeliveryObject
  * @typedef { [tag: 'ok', message: null, usage: { compute: number } | null] |
  *            [tag: 'error', message: string, usage: unknown | null] } VatDeliveryResult
@@ -136,10 +137,11 @@ export {};
  * @typedef { [tag: 'retireExports', krefs: string[] ]} KernelDeliveryRetireExports
  * @typedef { [tag: 'retireImports', krefs: string[] ]} KernelDeliveryRetireImports
  * @typedef { [tag: 'startVat', vatParameters: SwingSetCapData ]} KernelDeliveryStartVat
+ * @typedef { [tag: 'stopVat' ]} KernelDeliveryStopVat
  * @typedef { [tag: 'bringOutYourDead']} KernelDeliveryBringOutYourDead
  * @typedef { KernelDeliveryMessage | KernelDeliveryNotify | KernelDeliveryDropExports
  *            | KernelDeliveryRetireExports | KernelDeliveryRetireImports
- *            | KernelDeliveryStartVat | KernelDeliveryBringOutYourDead
+ *            | KernelDeliveryStartVat | KernelDeliveryStopVat | KernelDeliveryBringOutYourDead
  *          } KernelDeliveryObject
  * @typedef { [tag: 'send', target: string, msg: Message] } KernelSyscallSend
  * @typedef { [tag: 'invoke', target: string, method: string, args: SwingSetCapData]} KernelSyscallInvoke

--- a/packages/SwingSet/src/vats/comms/dispatch.js
+++ b/packages/SwingSet/src/vats/comms/dispatch.js
@@ -194,6 +194,10 @@ export function buildCommsDispatch(syscall, _state, _helpers, _vatPowers) {
         // nothing to see here, move along
         break;
       }
+      case 'stopVat': {
+        // should never be called, but no-op implemented for completeness
+        break;
+      }
       default:
         assert.fail(X`unknown delivery type ${type}`);
     }

--- a/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
+++ b/packages/SwingSet/src/vats/vat-admin/vat-vat-admin.js
@@ -106,7 +106,11 @@ export function buildRootObject(vatPowers) {
           // 'bundlecap' probably wasn't a bundlecap
           throw Error('vat adminNode.upgrade() requires a bundlecap');
         }
-        const upgradeID = D(vatAdminNode).upgradeVat(bundleID, vatParameters);
+        const upgradeID = D(vatAdminNode).upgradeVat(
+          vatID,
+          bundleID,
+          vatParameters,
+        );
         const [upgradeCompleteP, upgradeRR] = producePRR();
         pendingUpgrades.set(upgradeID, upgradeRR);
         return upgradeCompleteP;


### PR DESCRIPTION
This adds a no-op `dispatch.stopVat()` call to liveslots, and calls it as the first part of vat upgrade (the rest of which is still unimplemented). `stopVat` will be used to delete the vat's non-durable state, and decrement all refcounts properly.

refs #1848
