### PR TITLE
Allocate ID numbers from counters that are kept in persistent storage

### DIFF
--- a/packages/SwingSet/src/liveslots/collectionManager.js
+++ b/packages/SwingSet/src/liveslots/collectionManager.js
@@ -22,6 +22,7 @@ export function makeCollectionManager(
   syscall,
   vrm,
   allocateExportID,
+  allocateCollectionID,
   convertValToSlot,
   convertSlotToVal,
   registerValue,
@@ -546,8 +547,6 @@ export function makeCollectionManager(
     return doMoreGC;
   }
 
-  let nextCollectionID = 1;
-
   function makeCollection(label, kindName, keySchema, valueSchema) {
     assert.typeof(label, 'string');
     assert(storeKindInfo[kindName]);
@@ -557,8 +556,7 @@ export function makeCollectionManager(
       assertPattern(valueSchema);
       schemata.push(valueSchema);
     }
-    const collectionID = nextCollectionID;
-    nextCollectionID += 1;
+    const collectionID = allocateCollectionID();
     const kindID = obtainStoreKindID(kindName);
     const vobjID = `o+${kindID}/${collectionID}`;
 

--- a/packages/SwingSet/test/liveslots-helpers.js
+++ b/packages/SwingSet/test/liveslots-helpers.js
@@ -240,7 +240,11 @@ export function matchVatstoreDelete(key) {
 }
 
 export function matchVatstoreSet(key, value) {
-  return { type: 'vatstoreSet', key, value };
+  if (value !== undefined) {
+    return { type: 'vatstoreSet', key, value };
+  } else {
+    return { type: 'vatstoreSet', key };
+  }
 }
 
 export function matchRetireExports(...slots) {
@@ -256,7 +260,7 @@ export function matchRetireImports(...slots) {
 }
 
 export function validate(v, match) {
-  v.t.deepEqual(v.log.shift(), match);
+  v.t.like(v.log.shift(), match);
 }
 
 export function validateDone(v) {

--- a/packages/SwingSet/test/stores/test-storeGC.js
+++ b/packages/SwingSet/test/stores/test-storeGC.js
@@ -263,6 +263,7 @@ function validateUpdate(v, key, before, after) {
 function validateMakeAndHold(v, rp) {
   validateCreateStore(v, mainHeldIdx);
   validateReturned(v, rp);
+  validate(v, matchVatstoreSet('idCounters'));
   validateDone(v);
 }
 
@@ -442,6 +443,9 @@ function validateImportAndHold(v, rp, idx) {
     validate(v, matchVatstoreGet(`vc.${idx}.|label`, `store #${idx}`));
   }
   validateReturned(v, rp);
+  if (idx === NONE) {
+    validate(v, matchVatstoreSet('idCounters'));
+  }
   validateDone(v);
 }
 
@@ -461,6 +465,7 @@ function validateCreateHolder(v, idx) {
 }
 
 function validateInit(v) {
+  validate(v, matchVatstoreGet('idCounters', NONE));
   validate(v, matchVatstoreGet('baggageID', NONE));
   validate(v, matchVatstoreGet('storeKindIDTable', NONE));
   validate(
@@ -858,6 +863,7 @@ function validatePrepareStore3(
   validate(v, matchVatstoreSet(`vc.${base + 2}.|entryCount`, '1'));
 
   validateReturned(v, rp);
+  validate(v, matchVatstoreSet('idCounters'));
   if (!nonVirtual) {
     validateRefCountCheck(v, contentRef, '3');
     if (checkES) {
@@ -971,6 +977,7 @@ test.serial('store refcount management 3', async t => {
   validate(v, matchVatstoreGet(`vc.${base + 2}.|entryCount`, '0'));
   validate(v, matchVatstoreSet(`vc.${base + 2}.|entryCount`, '1'));
   validateReturned(v, rp);
+  validate(v, matchVatstoreSet('idCounters'));
   validateStatusCheck(v, mapRef(mainHeldIdx), '1', NONE);
   validateStatusCheck(v, mapRef(base), '1', NONE);
   validateStatusCheck(v, mapRef(base + 1), '1', NONE);
@@ -1078,6 +1085,7 @@ test.serial('remotable refcount management 1', async t => {
   let rp = await dispatchMessage('makeAndHoldRemotable');
   validateInit(v);
   validateReturned(v, rp);
+  validate(v, matchVatstoreSet('idCounters'));
   validateDone(v);
 
   rp = await dispatchMessage('prepareStore3');
@@ -1109,6 +1117,7 @@ test.serial('remotable refcount management 2', async t => {
   let rp = await dispatchMessage('makeAndHoldRemotable');
   validateInit(v);
   validateReturned(v, rp);
+  validate(v, matchVatstoreSet('idCounters'));
   validateDone(v);
 
   rp = await dispatchMessage('prepareStore3');
@@ -1163,6 +1172,7 @@ test.serial('verify store weak key GC', async t => {
   validate(v, matchVatstoreGet(`vc.${setID}.|${mapRef(keyID)}`, '1'));
   validate(v, matchVatstoreSet(`vc.${setID}.${ordinalKey}`, nullValString));
   validateReturned(v, rp);
+  validate(v, matchVatstoreSet('idCounters'));
   validateDone(v);
 
   t.is(testHooks.countCollectionsForWeakKey(mapRef(keyID)), 2);
@@ -1246,6 +1256,7 @@ test.serial('verify presence weak key GC', async t => {
   validate(v, matchVatstoreGet(`vc.${setID}.|${presenceRef}`, '1'));
   validate(v, matchVatstoreSet(`vc.${setID}.${ordinalKey}`, nullValString));
   validateReturned(v, rp);
+  validate(v, matchVatstoreSet('idCounters'));
 
   t.is(testHooks.countCollectionsForWeakKey(presenceRef), 2);
   t.is(testHooks.storeSizeInternal(mapRef(mapID)), 1);

--- a/packages/SwingSet/test/test-baggage.js
+++ b/packages/SwingSet/test/test-baggage.js
@@ -46,6 +46,7 @@ function validateCreateBaggage(v, idx) {
 }
 
 function validateSetup(v) {
+  validate(v, matchVatstoreGet('idCounters', NONE));
   validate(v, matchVatstoreGet('baggageID', NONE));
   validate(v, matchVatstoreGet('storeKindIDTable', NONE));
   validate(
@@ -80,5 +81,6 @@ test.serial('exercise baggage', async t => {
   validate(v, matchVatstoreGet('vc.1.|entryCount', '1'));
   validate(v, matchVatstoreSet('vc.1.|entryCount', '2'));
   validateReturned(v, rp);
+  validate(v, matchVatstoreSet('idCounters'));
   validateDone(v);
 });

--- a/packages/SwingSet/test/test-liveslots.js
+++ b/packages/SwingSet/test/test-liveslots.js
@@ -25,6 +25,10 @@ import {
   makeRetireImports,
 } from './util.js';
 
+function matchIDCounterSet(t, log) {
+  t.like(log.shift(), { type: 'vatstoreSet', key: 'idCounters' });
+}
+
 test('calls', async t => {
   const { log, syscall } = buildSyscall();
 
@@ -60,6 +64,7 @@ test('calls', async t => {
       capargs([{ '@qclass': 'slot', index: 0 }], ['p-1']),
     ),
   );
+  matchIDCounterSet(t, log);
   t.deepEqual(log.shift(), { type: 'subscribe', target: 'p-1' });
   t.deepEqual(log.shift(), 'two true');
 
@@ -181,6 +186,7 @@ test('liveslots pipeline/non-pipeline calls', async t => {
   });
   // then it subscribes to the result promise too
   t.deepEqual(log.shift(), { type: 'subscribe', target: 'p+5' });
+  matchIDCounterSet(t, log);
   t.deepEqual(log, []);
 
   // now we tell it the promise has resolved, to object 'o2'
@@ -195,6 +201,7 @@ test('liveslots pipeline/non-pipeline calls', async t => {
   });
   // and nonpipe2() wants a result
   t.deepEqual(log.shift(), { type: 'subscribe', target: 'p+6' });
+  matchIDCounterSet(t, log);
   t.deepEqual(log, []);
 
   // now call two(), which should send nonpipe3 to o2, not p1, since p1 has
@@ -209,6 +216,7 @@ test('liveslots pipeline/non-pipeline calls', async t => {
   });
   // and nonpipe3() wants a result
   t.deepEqual(log.shift(), { type: 'subscribe', target: 'p+7' });
+  matchIDCounterSet(t, log);
   t.deepEqual(log, []);
 });
 
@@ -308,6 +316,7 @@ async function doOutboundPromise(t, mode) {
   // and again it subscribes to the result promise
   t.deepEqual(log.shift(), { type: 'subscribe', target: expectedResultP2 });
 
+  matchIDCounterSet(t, log);
   t.deepEqual(log, []);
 }
 
@@ -427,6 +436,7 @@ async function doResultPromise(t, mode) {
   t.deepEqual(log.shift(), { type: 'subscribe', target: expectedP2 });
 
   // now it should be waiting for p2 to resolve, before it can send two()
+  matchIDCounterSet(t, log);
   t.deepEqual(log, []);
 
   // resolve p1 first. The one() call was already pipelined, so this
@@ -456,6 +466,7 @@ async function doResultPromise(t, mode) {
       resultSlot: expectedP3,
     });
     t.deepEqual(log.shift(), { type: 'subscribe', target: expectedP3 });
+    matchIDCounterSet(t, log);
   } else if (mode === 'to data' || mode === 'reject') {
     // Resolving to a non-target means a locally-generated error, and no
     // send() call
@@ -514,6 +525,7 @@ test('liveslots vs symbols', async t => {
     type: 'resolve',
     resolutions: [[rp1, false, capargs(['ok', 'asyncIterator', 'one'])]],
   });
+  matchIDCounterSet(t, log);
   t.deepEqual(log, []);
 
   // root~.good(target) -> send(methodname=Symbol.asyncIterator)
@@ -532,6 +544,7 @@ test('liveslots vs symbols', async t => {
     resultSlot: 'p+5',
   });
   t.deepEqual(log.shift(), { type: 'subscribe', target: 'p+5' });
+  matchIDCounterSet(t, log);
   t.deepEqual(log, []);
 
   // root~.bad(target) -> error because other Symbols are rejected
@@ -574,6 +587,7 @@ test('disable disavow', async t => {
   // root~.one() // sendOnly
   await dispatch(makeMessage(rootA, 'one', capargs([])));
   t.deepEqual(log.shift(), false);
+  matchIDCounterSet(t, log);
   t.deepEqual(log, []);
 });
 
@@ -660,6 +674,7 @@ test('disavow', async t => {
   });
   t.deepEqual(log.shift(), Error('this Presence has been disavowed'));
   t.deepEqual(log.shift(), 'tried to send to disavowed');
+  matchIDCounterSet(t, log);
   t.deepEqual(log, []);
 });
 
@@ -734,6 +749,11 @@ test('GC syscall.dropImports', async t => {
   t.falsy(wr.deref());
 
   // first it will check that there are no VO's holding onto it
+  t.deepEqual(log.shift(), {
+    type: 'vatstoreSet',
+    key: 'idCounters',
+    value: '{"collectionID":2,"exportID":9}',
+  });
   const l2 = log.shift();
   t.deepEqual(l2, {
     type: 'vatstoreGet',
@@ -784,6 +804,7 @@ test('GC dispatch.retireImports', async t => {
   // dispatch.retireImport into the vat
   await dispatch(makeRetireImports(arg));
   // for now, we only care that it doesn't crash
+  matchIDCounterSet(t, log);
   t.deepEqual(log, []);
 
   // when we implement VOM.vrefIsRecognizable, this test might do more
@@ -814,6 +835,7 @@ test('GC dispatch.retireExports', async t => {
     type: 'resolve',
     resolutions: [[rp1, false, capdataOneSlot(ex1)]],
   });
+  matchIDCounterSet(t, log);
   t.deepEqual(log, []);
 
   // All other vats drop the export, but since the vat holds it strongly, the
@@ -1128,6 +1150,11 @@ test('GC dispatch.dropExports', async t => {
     type: 'resolve',
     resolutions: [[rp1, false, capdataOneSlot(ex1)]],
   });
+  t.deepEqual(log.shift(), {
+    type: 'vatstoreSet',
+    key: 'idCounters',
+    value: '{"collectionID":2,"exportID":10}',
+  });
   t.deepEqual(log, []);
 
   // the exported Remotable should be held in place by exportedRemotables
@@ -1189,6 +1216,11 @@ test('GC dispatch.retireExports inhibits syscall.retireExports', async t => {
   t.deepEqual(l1, {
     type: 'resolve',
     resolutions: [[rp1, false, capdataOneSlot(ex1)]],
+  });
+  t.deepEqual(log.shift(), {
+    type: 'vatstoreSet',
+    key: 'idCounters',
+    value: '{"collectionID":2,"exportID":10}',
   });
   t.deepEqual(log, []);
 
@@ -1260,6 +1292,7 @@ test('simple promise resolution', async t => {
     type: 'resolve',
     resolutions: [[rp1, false, capargs(expectedResult1, [expectedPA])]],
   });
+  matchIDCounterSet(t, log);
   t.deepEqual(log, []);
 
   await dispatch(makeMessage(rootA, 'resolve', capargs([])));
@@ -1327,6 +1360,7 @@ test('promise cycle', async t => {
       [expectedPA2, false, capargs([oneSlot], [expectedPB])],
     ],
   });
+  matchIDCounterSet(t, log);
   t.deepEqual(log, []);
 });
 
@@ -1361,6 +1395,7 @@ test('unserializable promise resolution', async t => {
     type: 'resolve',
     resolutions: [[rp1, false, capargs(expectedResult1, [expectedPA])]],
   });
+  matchIDCounterSet(t, log);
   t.deepEqual(log, []);
 
   console.log('generating deliberate error');
@@ -1421,6 +1456,7 @@ test('unserializable promise rejection', async t => {
     type: 'resolve',
     resolutions: [[rp1, false, capargs(expectedResult1, [expectedPA])]],
   });
+  matchIDCounterSet(t, log);
   t.deepEqual(log, []);
 
   console.log('generating deliberate error');

--- a/packages/SwingSet/test/test-marshal.js
+++ b/packages/SwingSet/test/test-marshal.js
@@ -21,7 +21,10 @@ function makeUnmeteredMarshaller(syscall) {
 }
 
 test('serialize exports', t => {
-  const { m } = makeMarshaller(undefined, gcTools);
+  const syscall = {
+    vatstoreGet: () => undefined,
+  };
+  const { m } = makeMarshaller(syscall, gcTools);
   const ser = m.serialize;
   const o1 = Far('o1', {});
   const o2 = Far('o2', {
@@ -70,7 +73,10 @@ test('deserialize imports', async t => {
 });
 
 test('deserialize exports', t => {
-  const { m, unmeteredUnserialize } = makeUnmeteredMarshaller(undefined);
+  const syscall = {
+    vatstoreGet: () => undefined,
+  };
+  const { m, unmeteredUnserialize } = makeUnmeteredMarshaller(syscall);
   const o1 = Far('o1', {});
   m.serialize(o1); // allocates slot=1
   const a = unmeteredUnserialize({
@@ -98,6 +104,7 @@ test('serialize promise', async t => {
     resolve(resolutions) {
       log.push(resolutions);
     },
+    vatstoreGet: () => undefined,
   };
 
   const { m, unmeteredUnserialize } = makeUnmeteredMarshaller(syscall);

--- a/packages/SwingSet/test/test-vpid-liveslots.js
+++ b/packages/SwingSet/test/test-vpid-liveslots.js
@@ -151,6 +151,10 @@ function resolutionOf(vpid, mode, targets) {
   return resolution;
 }
 
+function matchIDCounterSet(t, log) {
+  t.like(log.shift(), { type: 'vatstoreSet', key: 'idCounters' });
+}
+
 async function doVatResolveCase1(t, mode) {
   // case 1
   const { log, syscall } = buildSyscall();
@@ -216,6 +220,7 @@ async function doVatResolveCase1(t, mode) {
   const targets2 = { target2, localTarget, p1: expectedP3 };
   t.deepEqual(log.shift(), resolutionOf(expectedTwoArg, mode, targets2));
   t.deepEqual(log.shift(), { type: 'subscribe', target: expectedResultOfTwo });
+  matchIDCounterSet(t, log);
   t.deepEqual(log, []);
 }
 
@@ -346,7 +351,13 @@ async function doVatResolveCase23(t, which, mode, stalls) {
   } else {
     assert.fail(X`bad which=${which}`);
   }
+  if (which === 2) {
+    matchIDCounterSet(t, log);
+  }
   t.deepEqual(log.shift(), { type: 'subscribe', target: p1 });
+  if (which === 3) {
+    matchIDCounterSet(t, log);
+  }
   t.deepEqual(log, []);
 
   await dispatch(
@@ -469,6 +480,7 @@ async function doVatResolveCase23(t, which, mode, stalls) {
   t.deepEqual(log.shift(), resolutionOf(expectedP4, mode, targets2));
 
   // that's all the syscalls we should see
+  matchIDCounterSet(t, log);
   t.deepEqual(log, []);
 
   // assert that the vat saw the local promise being resolved too
@@ -557,6 +569,7 @@ async function doVatResolveCase4(t, mode) {
 
   await dispatch(makeMessage(rootA, 'get', capargs([slot0arg], [p1])));
   t.deepEqual(log.shift(), { type: 'subscribe', target: p1 });
+  matchIDCounterSet(t, log);
   t.deepEqual(log, []);
 
   await dispatch(makeMessage(rootA, 'first', capargs([slot0arg], [target1])));
@@ -580,6 +593,7 @@ async function doVatResolveCase4(t, mode) {
     resultSlot: expectedP3,
   });
   t.deepEqual(log.shift(), { type: 'subscribe', target: expectedP3 });
+  matchIDCounterSet(t, log);
   t.deepEqual(log, []);
 
   let r;
@@ -633,6 +647,7 @@ async function doVatResolveCase4(t, mode) {
   t.deepEqual(log.shift(), resolutionOf(expectedP4, mode, targets));
 
   // if p1 rejects or resolves to data, the kernel never hears about four()
+  matchIDCounterSet(t, log);
   t.deepEqual(log, []);
 }
 
@@ -681,6 +696,7 @@ test('inter-vat circular promise references', async t => {
   // const paB = 'p-19';
 
   await dispatchA(makeMessage(rootA, 'genPromise', capargs([], []), paA));
+  matchIDCounterSet(t, log);
   t.deepEqual(log, []);
 
   // await dispatchB(makeMessage(rootB, 'genPromise', capargs([], []), pbB));

--- a/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
+++ b/packages/SwingSet/test/vat-admin/terminate/test-terminate.js
@@ -213,7 +213,7 @@ test('dead vat state removed', async t => {
   const kvStore = hostStorage.kvStore;
   t.is(kvStore.get('vat.dynamicIDs'), '["v6"]');
   t.is(kvStore.get('ko26.owner'), 'v6');
-  t.is(Array.from(kvStore.getKeys('v6.', 'v6/')).length, 18);
+  t.is(Array.from(kvStore.getKeys('v6.', 'v6/')).length, 19);
 
   controller.queueToVatRoot('bootstrap', 'phase2', capargs([]));
   await controller.run();

--- a/packages/SwingSet/test/virtualObjects/test-representatives.js
+++ b/packages/SwingSet/test/virtualObjects/test-representatives.js
@@ -382,6 +382,7 @@ test('virtual object gc', async t => {
   }
   t.deepEqual(remainingVOs, {
     'v1.vs.baggageID': 'o+5/1',
+    'v1.vs.idCounters': '{"collectionID":2,"exportID":10,"promiseID":8}',
     'v1.vs.storeKindIDTable':
       '{"scalarMapStore":1,"scalarWeakMapStore":2,"scalarSetStore":3,"scalarWeakSetStore":4,"scalarDurableMapStore":5,"scalarDurableWeakMapStore":6,"scalarDurableSetStore":7,"scalarDurableWeakSetStore":8}',
     'v1.vs.vc.1.|entryCount': '0',

--- a/packages/SwingSet/test/virtualObjects/test-virtualObjectGC.js
+++ b/packages/SwingSet/test/virtualObjects/test-virtualObjectGC.js
@@ -439,6 +439,7 @@ function validateStatusCheck(v, vref, rc, es, value) {
 }
 
 function validateFauxCacheDisplacerDeletion(v) {
+  validate(v, matchVatstoreSet('idCounters'));
   validate(v, matchVatstoreGet(rcKey(fCacheDisplacerVref), NONE));
   validate(v, matchVatstoreGet(esKey(fCacheDisplacerVref), NONE));
   validate(v, matchVatstoreGet(stateKey(fCacheDisplacerVref), cacheObjValue));
@@ -459,6 +460,7 @@ function validateCreateBaggage(v, idx) {
 }
 
 function validateSetup(v) {
+  validate(v, matchVatstoreGet('idCounters', NONE));
   validate(v, matchVatstoreGet('baggageID', NONE));
   validate(v, matchVatstoreGet('storeKindIDTable', NONE));
   validate(
@@ -1445,6 +1447,7 @@ test.serial('remotable refcount management 1', async t => {
   validate(v, matchVatstoreSet(stateKey(`${holderKindID}/4`), heldThingValue(remotableID)));
   validate(v, matchVatstoreGet(stateKey(cacheDisplacerVref), cacheObjValue));
   validateReturned(v, rp);
+  validate(v, matchVatstoreSet('idCounters'));
   validateDone(v);
 
   rp = await dispatchMessage('finishClearHolders');
@@ -1477,6 +1480,7 @@ test.serial('remotable refcount management 2', async t => {
   validate(v, matchVatstoreSet(stateKey(`${holderKindID}/4`), heldThingValue(remotableID)));
   validate(v, matchVatstoreGet(stateKey(cacheDisplacerVref), cacheObjValue));
   validateReturned(v, rp);
+  validate(v, matchVatstoreSet('idCounters'));
   validateDone(v);
 
   rp = await dispatchMessage('finishDropHolders');
@@ -1576,6 +1580,7 @@ test.serial('VO holding non-VO', async t => {
   // Lerv -> LERv  Export non-VO
   rp = await dispatchMessage('exportHeld');
   validate(v, matchResolveOne(rp, thingSer(remotableID)));
+  validate(v, matchVatstoreSet('idCounters'));
   validateDone(v);
 
   // LERv -> LERV  Store non-VO reference virtually

--- a/packages/SwingSet/tools/fakeCollectionManager.js
+++ b/packages/SwingSet/tools/fakeCollectionManager.js
@@ -10,6 +10,7 @@ export function makeFakeCollectionManager(vrm, fakeStuff, _options = {}) {
     fakeStuff.syscall,
     vrm,
     fakeStuff.allocateExportID,
+    fakeStuff.allocateCollectionID,
     fakeStuff.convertValToSlot,
     fakeStuff.convertSlotToVal,
     fakeStuff.registerEntry,

--- a/packages/SwingSet/tools/fakeVirtualSupport.js
+++ b/packages/SwingSet/tools/fakeVirtualSupport.js
@@ -141,6 +141,13 @@ export function makeFakeLiveSlotsStuff(options = {}) {
     return exportID;
   }
 
+  let nextCollectionID = 1;
+  function allocateCollectionID() {
+    const collectionID = nextCollectionID;
+    nextCollectionID += 1;
+    return collectionID;
+  }
+
   // note: The real liveslots slotToVal() maps slots (vrefs) to a WeakRef,
   // and the WeakRef may or may not contain the target value. Use
   // options={weak:true} to match that behavior, or the default weak:false to
@@ -208,6 +215,7 @@ export function makeFakeLiveSlotsStuff(options = {}) {
   return {
     syscall,
     allocateExportID,
+    allocateCollectionID,
     getSlotForVal,
     getValForSlot,
     setValForSlot,


### PR DESCRIPTION
Promise IDs, export IDs, and collection IDs were previously assigned from counters that were maintained in RAM.  This would not survive vat shutdown and resurrection.

Now they are tracked via a DB record that is used to implement a write through cache that gets flushed to disk as part of the `bringOutYourDead` alongside the flushing of the virtual object cache.

Fixes #4730